### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h
@@ -19,27 +19,27 @@
 #include <boost/dynamic_bitset.hpp>
 
 class CSCALCTHeader {
- public:
-  explicit CSCALCTHeader(int chamberType); ///for packing
+public:
+  explicit CSCALCTHeader(int chamberType);  ///for packing
 
-  explicit CSCALCTHeader(const unsigned short * buf);
+  explicit CSCALCTHeader(const unsigned short *buf);
 
-  CSCALCTHeader(const CSCALCTStatusDigi & digi);/// to access data by via status digis
+  CSCALCTHeader(const CSCALCTStatusDigi &digi);  /// to access data by via status digis
 
-  /// turns on the debug flag for this class 
-  static void setDebug(bool value){debug = value;};
+  /// turns on the debug flag for this class
+  static void setDebug(bool value) { debug = value; };
 
-  void setEventInformation(const CSCDMBHeader &);///for packing
-  unsigned short int nLCTChipRead()   const;
-  
+  void setEventInformation(const CSCDMBHeader &);  ///for packing
+  unsigned short int nLCTChipRead() const;
+
   std::vector<CSCALCTDigi> ALCTDigis() const;
-  
+
   ///some accessors here are only applicable to 2006 header
   ///some to both 2006 and 2007
 
-  enum FIFO_MODE {NO_DUMP, FULL_DUMP, LOCAL_DUMP};
-  unsigned short int FIFOMode()       const {return header2006.fifoMode;} 
-  unsigned short int NTBins()         const {
+  enum FIFO_MODE { NO_DUMP, FULL_DUMP, LOCAL_DUMP };
+  unsigned short int FIFOMode() const { return header2006.fifoMode; }
+  unsigned short int NTBins() const {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
@@ -50,15 +50,15 @@ class CSCALCTHeader {
       case 2007:
         return header2007.rawBins;
       default:
-	edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"trying to access NTBINs: ALCT firmware version is bad/not defined!";
+        edm::LogError("CSCALCTHeader|CSCRawToDigi")
+            << "trying to access NTBINs: ALCT firmware version is bad/not defined!";
         return 0;
-      }
+    }
   }
-  unsigned short int BoardID()        const {return header2006.boardID;}
-  unsigned short int ExtTrig()        const {return header2006.extTrig;}
-  unsigned short int CSCID()          const {return header2006.cscID;}
-  unsigned short int BXNCount()       const {
+  unsigned short int BoardID() const { return header2006.boardID; }
+  unsigned short int ExtTrig() const { return header2006.extTrig; }
+  unsigned short int CSCID() const { return header2006.cscID; }
+  unsigned short int BXNCount() const {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
@@ -69,13 +69,13 @@ class CSCALCTHeader {
       case 2007:
         return header2007.bxnCount;
       default:
-	edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"trying to access BXNcount: ALCT firmware version is bad/not defined!";
+        edm::LogError("CSCALCTHeader|CSCRawToDigi")
+            << "trying to access BXNcount: ALCT firmware version is bad/not defined!";
         return 0;
-      }
+    }
   }
 
-  void setBXNCount(unsigned int bxn)       {
+  void setBXNCount(unsigned int bxn) {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
@@ -83,19 +83,18 @@ class CSCALCTHeader {
 #endif
       case 2006:
         header2006.bxnCount = bxn % 0xFFF;
-	break;
+        break;
       case 2007:
         header2007.bxnCount = bxn % 0xFFF;
-	break;
+        break;
       default:
         edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"trying to set BXNcount: ALCT firmware version is bad/not defined!";
-	break;
-      }
+            << "trying to set BXNcount: ALCT firmware version is bad/not defined!";
+        break;
+    }
   }
 
-
-  unsigned short int L1Acc()          const {
+  unsigned short int L1Acc() const {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
@@ -106,13 +105,13 @@ class CSCALCTHeader {
       case 2007:
         return header2007.l1aCounter;
       default:
-	edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"trying to access L1Acc: ALCT firmware version is bad/not defined!";
+        edm::LogError("CSCALCTHeader|CSCRawToDigi")
+            << "trying to access L1Acc: ALCT firmware version is bad/not defined!";
         return 0;
-      }
+    }
   }
 
-  void setL1Acc(unsigned int l1a)       {
+  void setL1Acc(unsigned int l1a) {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
@@ -125,28 +124,27 @@ class CSCALCTHeader {
         header2007.l1aCounter = l1a % 0xFFF;
         break;
       default:
-        edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"trying to set L1Acc: ALCT firmware version is bad/not defined!";
+        edm::LogError("CSCALCTHeader|CSCRawToDigi") << "trying to set L1Acc: ALCT firmware version is bad/not defined!";
         break;
-      }
+    }
   }
 
-  unsigned short int L1AMatch()        const {return header2006.l1aMatch;}
-  unsigned short int ActiveFEBs()      const {return header2006.activeFEBs;}
-  unsigned short int Promote1()        const {return header2006.promote1;}
-  unsigned short int Promote2()        const {return header2006.promote2;}
-  unsigned short int LCTChipRead()     const {return header2006.lctChipRead;}
-  unsigned short int alctFirmwareVersion() const {return firmwareVersion;}
+  unsigned short int L1AMatch() const { return header2006.l1aMatch; }
+  unsigned short int ActiveFEBs() const { return header2006.activeFEBs; }
+  unsigned short int Promote1() const { return header2006.promote1; }
+  unsigned short int Promote2() const { return header2006.promote2; }
+  unsigned short int LCTChipRead() const { return header2006.lctChipRead; }
+  unsigned short int alctFirmwareVersion() const { return firmwareVersion; }
   void setDAVForChannel(int wireGroup) {
-     if(firmwareVersion == 2006) {
-       header2006.setDAV((wireGroup-1)/16);
-     }
+    if (firmwareVersion == 2006) {
+      header2006.setDAV((wireGroup - 1) / 16);
+    }
   }
-  CSCALCTHeader2007 alctHeader2007()   const {return header2007;}
-  CSCALCTHeader2006 alctHeader2006()   const {return header2006;}
+  CSCALCTHeader2007 alctHeader2007() const { return header2007; }
+  CSCALCTHeader2006 alctHeader2006() const { return header2006; }
 
-  unsigned short int * data() {return theOriginalBuffer;}
- 
+  unsigned short int *data() { return theOriginalBuffer; }
+
   /// in 16-bit words
   int sizeInWords() {
 #ifdef LOCAL_UNPACK
@@ -159,12 +157,11 @@ class CSCALCTHeader {
       case 2007:
         return sizeInWords2007_;
       default:
-	edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"SizeInWords(): ALCT firmware version is bad/not defined!";
+        edm::LogError("CSCALCTHeader|CSCRawToDigi") << "SizeInWords(): ALCT firmware version is bad/not defined!";
         return 0;
-      }
+    }
   }
-  
+
   bool check() const {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
@@ -172,41 +169,40 @@ class CSCALCTHeader {
     switch (firmwareVersion.load()) {
 #endif
       case 2006:
-	return header2006.flag_0 == 0xC;
+        return header2006.flag_0 == 0xC;
       case 2007:
         return header2007.flag1 == 0xDB0A;
       default:
-	edm::LogError("CSCALCTHeader|CSCRawToDigi")
-          <<"check(): ALCT firmware version is bad/not defined!";
+        edm::LogError("CSCALCTHeader|CSCRawToDigi") << "check(): ALCT firmware version is bad/not defined!";
         return false;
-      }
+    }
   }
- 
-  void add(const std::vector<CSCALCTDigi> & digis);
+
+  void add(const std::vector<CSCALCTDigi> &digis);
 
   boost::dynamic_bitset<> pack();
 
   /// tests that we unpack what we packed
-  static void selfTest(int firmware);  
+  static void selfTest(int firmware);
 
- private:
+private:
   CSCALCTHeader2006 header2006;
   CSCALCTHeader2007 header2007;
-  std::vector<CSCALCT> theALCTs;   
+  std::vector<CSCALCT> theALCTs;
   CSCALCTs2006 alcts2006;
   CSCVirtexID virtexID;
   CSCConfigurationRegister configRegister;
   std::vector<CSCCollisionMask> collisionMasks;
   std::vector<CSCHotChannelMask> hotChannelMasks;
-  
+
   //raw data also stored in this buffer
   //maximum header size is 116 words
   unsigned short int theOriginalBuffer[116];
- 
+
 #ifdef LOCAL_UNPACK
- static bool debug;
- static unsigned short int firmwareVersion;  
-#else 
+  static bool debug;
+  static unsigned short int firmwareVersion;
+#else
   static std::atomic<bool> debug;
   static std::atomic<unsigned short int> firmwareVersion;
 #endif
@@ -215,7 +211,6 @@ class CSCALCTHeader {
   unsigned short int sizeInWords2007_, bxn0, bxn1;
 };
 
-std::ostream & operator<<(std::ostream & os, const CSCALCTHeader & header);
+std::ostream &operator<<(std::ostream &os, const CSCALCTHeader &header);
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2006.h
@@ -8,39 +8,35 @@
 class CSCDMBHeader;
 
 ///ALCT Header consists of several modular units that are defined as structs below
-struct CSCALCTHeader2006 { ///this struct contains all 2006 ALCT Header words except ALCTs
-  CSCALCTHeader2006()  {
-    init();
-  }
+struct CSCALCTHeader2006 {  ///this struct contains all 2006 ALCT Header words except ALCTs
+  CSCALCTHeader2006() { init(); }
 
   explicit CSCALCTHeader2006(int chamberType);
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
   void init() {
-     bzero(this,  sizeInWords()*2); ///size of header w/o LCTs = 8 bytes
+    bzero(this, sizeInWords() * 2);  ///size of header w/o LCTs = 8 bytes
   }
 
-  short unsigned int sizeInWords() const { ///size of ALCT Header
+  short unsigned int sizeInWords() const {  ///size of ALCT Header
     return 4;
   }
 
-  unsigned short int BXNCount() const { return bxnCount;}
+  unsigned short int BXNCount() const { return bxnCount; }
 
   unsigned short nLCTChipRead() const;
 
-  void setEventInformation(const CSCDMBHeader &);///for packing
+  void setEventInformation(const CSCDMBHeader&);  ///for packing
 
-  void setDAV(int afebBoard) {activeFEBs |= 1 << afebBoard;}
+  void setDAV(int afebBoard) { activeFEBs |= 1 << afebBoard; }
 
   /// l1 accept counter
-  unsigned l1Acc         : 4;
+  unsigned l1Acc : 4;
   /// chamber ID number
-  unsigned cscID         : 4;
+  unsigned cscID : 4;
   /// ALCT2000 board ID
-  unsigned boardID       : 3;
+  unsigned boardID : 3;
   /// should be '01100', so it'll be a 6xxx in the ASCII dump
   unsigned flag_0 : 5;
 
@@ -74,62 +70,54 @@ struct CSCALCTHeader2006 { ///this struct contains all 2006 ALCT Header words ex
   unsigned activeFEBs : 7;
   ///  DDU+LCT special word flags
   unsigned flag_3 : 2;
-
 };
-
 
 struct CSCALCTs2006 {
   CSCALCTs2006() {
-    bzero(this, 8); ///size of ALCT = 2bytes
+    bzero(this, 8);  ///size of ALCT = 2bytes
   }
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  short unsigned int sizeInWords() const { ///size of ALCT
+  short unsigned int sizeInWords() const {  ///size of ALCT
     return 4;
   }
 
   std::vector<CSCALCTDigi> ALCTDigis() const;
 
   /// should try to sort, but doesn't for now
-  void add(const std::vector<CSCALCTDigi> & digis);
-  void addALCT0(const CSCALCTDigi & digi);
-  void addALCT1(const CSCALCTDigi & digi);
+  void add(const std::vector<CSCALCTDigi>& digis);
+  void addALCT0(const CSCALCTDigi& digi);
+  void addALCT1(const CSCALCTDigi& digi);
 
   /// 1st LCT lower 15 bits
   /// http://www.phys.ufl.edu/cms/emu/dqm/data_formats/ALCT_data_format_notes.pdf
-  unsigned alct0_valid   : 1;
+  unsigned alct0_valid : 1;
   unsigned alct0_quality : 2;
-  unsigned alct0_accel   : 1;
+  unsigned alct0_accel : 1;
   unsigned alct0_pattern : 1;
-  unsigned alct0_key_wire: 7;
+  unsigned alct0_key_wire : 7;
   unsigned alct0_bxn_low : 3;
   ///  DDU+LCT special word flags
   unsigned flag_4 : 1;
 
-  unsigned alct0_bxn_high :2;
-  unsigned alct0_reserved :13;
+  unsigned alct0_bxn_high : 2;
+  unsigned alct0_reserved : 13;
   ///  DDU+LCT special word flags
   unsigned flag_5 : 1;
 
   /// 2nd LCT lower 15 bits
-  unsigned alct1_valid   : 1;
+  unsigned alct1_valid : 1;
   unsigned alct1_quality : 2;
-  unsigned alct1_accel   : 1;
+  unsigned alct1_accel : 1;
   unsigned alct1_pattern : 1;
-  unsigned alct1_key_wire: 7;
+  unsigned alct1_key_wire : 7;
   unsigned alct1_bxn_low : 3;
   unsigned flag_6 : 1;
 
-  unsigned alct1_bxn_high :2;
-  unsigned alct1_reserved :13;
+  unsigned alct1_bxn_high : 2;
+  unsigned alct1_reserved : 13;
   unsigned flag_7 : 1;
 };
-
-
-
-
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h
@@ -16,164 +16,144 @@ class CSCDMBHeader;
 
 struct CSCALCT {
   CSCALCT();
-  CSCALCT(const CSCALCTDigi & alctDigi);
+  CSCALCT(const CSCALCTDigi& alctDigi);
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  static short unsigned int sizeInWords() {return 1; }
+  static short unsigned int sizeInWords() { return 1; }
 
-  unsigned valid   : 1;
+  unsigned valid : 1;
   unsigned quality : 2;
-  unsigned accel   : 1;
+  unsigned accel : 1;
   unsigned pattern : 1;
   unsigned keyWire : 7;
-  unsigned reserved: 4;
+  unsigned reserved : 4;
 };
-
 
 struct CSCALCTHeader2007 {
   CSCALCTHeader2007();
   explicit CSCALCTHeader2007(int chamberType);
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  void setEventInformation(const CSCDMBHeader &);///for packing
+  void setEventInformation(const CSCDMBHeader&);  ///for packing
 
-  short unsigned int sizeInWords() const { ///size of ALCT2007 Header
+  short unsigned int sizeInWords() const {  ///size of ALCT2007 Header
     return 8;
   }
 
-  unsigned flag1                : 16;///=0xDB0A
+  unsigned flag1 : 16;  ///=0xDB0A
 
-  unsigned bxnL1A               : 12;
-  unsigned reserved1            : 4;
+  unsigned bxnL1A : 12;
+  unsigned reserved1 : 4;
 
-  unsigned l1aCounter           : 12;
-  unsigned reserved2            : 4;
+  unsigned l1aCounter : 12;
+  unsigned reserved2 : 4;
 
-  unsigned readoutCounter       : 12;
-  unsigned reserved3            : 4;
+  unsigned readoutCounter : 12;
+  unsigned reserved3 : 4;
 
-  unsigned bxnCount             : 12;
-  unsigned rawOverflow          : 1;
-  unsigned lctOverflow          : 1;
-  unsigned configPresent        : 1;
-  unsigned flag3                : 1;
+  unsigned bxnCount : 12;
+  unsigned rawOverflow : 1;
+  unsigned lctOverflow : 1;
+  unsigned configPresent : 1;
+  unsigned flag3 : 1;
 
-  unsigned bxnBeforeReset       : 12;
-  unsigned flag2                : 4;
+  unsigned bxnBeforeReset : 12;
+  unsigned flag2 : 4;
 
-  unsigned boardType            : 3;
-  unsigned backwardForward      : 1;
-  unsigned negativePositive     : 1;
-  unsigned mirrored             : 1;
-  unsigned qualityCancell       : 1;
-  unsigned latencyClocks        : 1;
-  unsigned patternB             : 1;
-  unsigned widePattern          : 1;
-  unsigned reserved0            : 2;
-  unsigned flag0                : 4;  
-   
-  unsigned rawBins              : 5;
-  unsigned lctBins              : 4;
-  unsigned firmwareVersion      : 6;
-  unsigned flag4                : 1;
+  unsigned boardType : 3;
+  unsigned backwardForward : 1;
+  unsigned negativePositive : 1;
+  unsigned mirrored : 1;
+  unsigned qualityCancell : 1;
+  unsigned latencyClocks : 1;
+  unsigned patternB : 1;
+  unsigned widePattern : 1;
+  unsigned reserved0 : 2;
+  unsigned flag0 : 4;
+
+  unsigned rawBins : 5;
+  unsigned lctBins : 4;
+  unsigned firmwareVersion : 6;
+  unsigned flag4 : 1;
 };
 
 struct CSCVirtexID {
   CSCVirtexID() {
-    bzero(this,  sizeInWords()*2); ///size of virtex ID bits = 6 bytes
+    bzero(this, sizeInWords() * 2);  ///size of virtex ID bits = 6 bytes
   }
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  short unsigned int sizeInWords() const { ///size of VirtexID
+  short unsigned int sizeInWords() const {  ///size of VirtexID
     return 3;
   }
 
-  unsigned virtexIDLow  : 15;
-  unsigned flag0        : 1; ///==0
-  
-  unsigned virtexIDMed  : 15;
-  unsigned flag1        : 1; ///==0
+  unsigned virtexIDLow : 15;
+  unsigned flag0 : 1;  ///==0
 
-  unsigned virtexIDHigh : 10; 
-  unsigned trReg        : 3;
-  unsigned reserved     : 2;
-  unsigned flag2        : 1; ///==0
+  unsigned virtexIDMed : 15;
+  unsigned flag1 : 1;  ///==0
+
+  unsigned virtexIDHigh : 10;
+  unsigned trReg : 3;
+  unsigned reserved : 2;
+  unsigned flag2 : 1;  ///==0
 };
 
 struct CSCConfigurationRegister {
-  CSCConfigurationRegister()  {
-    bzero(this, sizeInWords()*2); 
-  }
+  CSCConfigurationRegister() { bzero(this, sizeInWords() * 2); }
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  short unsigned int sizeInWords() const { ///size of ConfigReg
+  short unsigned int sizeInWords() const {  ///size of ConfigReg
     return 5;
   }
 
+  unsigned configRegister0 : 15;
+  unsigned flag0 : 1;  ///==0
 
-  unsigned configRegister0  : 15;
-  unsigned flag0            : 1; ///==0
+  unsigned configRegister1 : 15;
+  unsigned flag1 : 1;  ///==0
 
-  unsigned configRegister1  : 15;
-  unsigned flag1            : 1; ///==0
+  unsigned configRegister2 : 15;
+  unsigned flag2 : 1;  ///==0
 
-  unsigned configRegister2  : 15;
-  unsigned flag2            : 1; ///==0
+  unsigned configRegister3 : 15;
+  unsigned flag3 : 1;  ///==0
 
-  unsigned configRegister3  : 15;
-  unsigned flag3            : 1; ///==0
-
-  unsigned configRegister4  : 9;
-  unsigned reserved         : 6;
-  unsigned flag4            : 1; ///==0
+  unsigned configRegister4 : 9;
+  unsigned reserved : 6;
+  unsigned flag4 : 1;  ///==0
 };
 
 struct CSCCollisionMask {
-  CSCCollisionMask()  {
-    bzero(this, sizeInWords()*2);
-  }
+  CSCCollisionMask() { bzero(this, sizeInWords() * 2); }
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  short unsigned int sizeInWords() const { ///size of one CollMask word
+  short unsigned int sizeInWords() const {  ///size of one CollMask word
     return 1;
   }
 
-  unsigned collisionMaskRegister  : 14;
-  unsigned reserved               : 1;
-  unsigned flag                   : 1; ///==0
+  unsigned collisionMaskRegister : 14;
+  unsigned reserved : 1;
+  unsigned flag : 1;  ///==0
 };
 
 struct CSCHotChannelMask {
-  CSCHotChannelMask()  {
-    bzero(this, sizeInWords()*2);
-  }
+  CSCHotChannelMask() { bzero(this, sizeInWords() * 2); }
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  short unsigned int sizeInWords() const { ///size of one HotChannMask word
+  short unsigned int sizeInWords() const {  ///size of one HotChannMask word
     return 1;
   }
 
-  unsigned hotChannelMask  : 12;
-  unsigned reserved        : 3;
-  unsigned flag            : 1; ///==0
+  unsigned hotChannelMask : 12;
+  unsigned reserved : 3;
+  unsigned flag : 1;  ///==0
 };
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
@@ -5,7 +5,7 @@
   http://www.phys.ufl.edu/~madorsky/alctv/alct2000_spec.PDF
 */
 
-#include <cstring> // memcpy
+#include <cstring>  // memcpy
 #ifndef LOCAL_UNPACK
 #include <atomic>
 #endif
@@ -15,110 +15,104 @@
 struct CSCALCTTrailer2006 {
   CSCALCTTrailer2006();
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  void setSize(int size) {frameCount = size;}
-  void setCRC(unsigned int crc) {crc0 = crc&0x7FF; crc1 = (crc >> 11) & 0x7FF;}
-  short unsigned int sizeInWords() const { ///size of ALCT Header
+  void setSize(int size) { frameCount = size; }
+  void setCRC(unsigned int crc) {
+    crc0 = crc & 0x7FF;
+    crc1 = (crc >> 11) & 0x7FF;
+  }
+  short unsigned int sizeInWords() const {  ///size of ALCT Header
     return 4;
   }
-  unsigned crc0:11, zero_0:1, d_0:4;
-  unsigned crc1:11, zero_1:1, d_1:4;
-  unsigned e0dLine:16;
-  unsigned frameCount:11, reserved_3:1, d_3:4;
+  unsigned crc0 : 11, zero_0 : 1, d_0 : 4;
+  unsigned crc1 : 11, zero_1 : 1, d_1 : 4;
+  unsigned e0dLine : 16;
+  unsigned frameCount : 11, reserved_3 : 1, d_3 : 4;
 };
 
 struct CSCALCTTrailer2007 {
   CSCALCTTrailer2007();
 
-  void setFromBuffer(unsigned short const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(unsigned short const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  void setSize(int size) {frameCount = size;}
-  void setCRC(unsigned int crc) {crc0 = crc&0x7FF; crc1 = (crc >> 11) & 0x7FF;}
-  short unsigned int sizeInWords() const { ///size of ALCT Header
+  void setSize(int size) { frameCount = size; }
+  void setCRC(unsigned int crc) {
+    crc0 = crc & 0x7FF;
+    crc1 = (crc >> 11) & 0x7FF;
+  }
+  short unsigned int sizeInWords() const {  ///size of ALCT Header
     return 4;
   }
-  unsigned e0dLine:16;
-  unsigned crc0:11, zero_0:1, reserved_0:4;
-  unsigned crc1:11, zero_1:1, reserved_1:4;
-  unsigned frameCount:11, reserved_3:1, reserved_4:4;
+  unsigned e0dLine : 16;
+  unsigned crc0 : 11, zero_0 : 1, reserved_0 : 4;
+  unsigned crc1 : 11, zero_1 : 1, reserved_1 : 4;
+  unsigned frameCount : 11, reserved_3 : 1, reserved_4 : 4;
 };
 
-
-
-class CSCALCTTrailer
-{
+class CSCALCTTrailer {
 public:
   ///needed for packing
   CSCALCTTrailer(int size, int firmVersion);
-  CSCALCTTrailer(const unsigned short * buf);
-  CSCALCTTrailer(const CSCALCTStatusDigi & digi) {
-    CSCALCTTrailer(digi.trailer());
-  }
+  CSCALCTTrailer(const unsigned short* buf);
+  CSCALCTTrailer(const CSCALCTStatusDigi& digi) { CSCALCTTrailer(digi.trailer()); }
 
-  static void setDebug(bool debugValue) {debug = debugValue;}
+  static void setDebug(bool debugValue) { debug = debugValue; }
 
-  unsigned short * data() {
+  unsigned short* data() {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
     switch (firmwareVersion.load()) {
 #endif
-    case 2006:
-      memcpy(theOriginalBuffer, &trailer2006, trailer2006.sizeInWords()*2);
-      break;
-    case 2007:
-      memcpy(theOriginalBuffer, &trailer2007, trailer2007.sizeInWords()*2);
-      break;
-    default:
-      edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-        <<"couldn't access data: ALCT firmware version is bad/not defined!";
-      break;
+      case 2006:
+        memcpy(theOriginalBuffer, &trailer2006, trailer2006.sizeInWords() * 2);
+        break;
+      case 2007:
+        memcpy(theOriginalBuffer, &trailer2007, trailer2007.sizeInWords() * 2);
+        break;
+      default:
+        edm::LogError("CSCALCTTrailer|CSCRawToDigi")
+            << "couldn't access data: ALCT firmware version is bad/not defined!";
+        break;
     }
     return theOriginalBuffer;
   }
 
   /// in 16-bit frames
-  static int sizeInWords() {return 4;}
+  static int sizeInWords() { return 4; }
 
-  void setCRC(unsigned int crc){
+  void setCRC(unsigned int crc) {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
     switch (firmwareVersion.load()) {
 #endif
-    case 2006:
-      trailer2006.setCRC(crc);
-      break;
-    case 2007:
-      trailer2007.setCRC(crc);
-      break;
-    default:
-      edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-        <<"couldn't setCRC: ALCT firmware version is bad/not defined!";
-      break;
+      case 2006:
+        trailer2006.setCRC(crc);
+        break;
+      case 2007:
+        trailer2007.setCRC(crc);
+        break;
+      default:
+        edm::LogError("CSCALCTTrailer|CSCRawToDigi") << "couldn't setCRC: ALCT firmware version is bad/not defined!";
+        break;
     }
   }
-   
-    
-  int getCRC() { 
+
+  int getCRC() {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
     switch (firmwareVersion.load()) {
 #endif
-    case 2006:
-      return ((trailer2006.crc1&0x7ff)<<11) | (trailer2006.crc0&0x7ff);
-    case 2007:
-      return ((trailer2007.crc1&0x7ff)<<11) | (trailer2007.crc0&0x7ff);
-    default:
-      edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-        <<"couldn't getCRC: ALCT firmware version is bad/not defined!";
-      return 0;
+      case 2006:
+        return ((trailer2006.crc1 & 0x7ff) << 11) | (trailer2006.crc0 & 0x7ff);
+      case 2007:
+        return ((trailer2007.crc1 & 0x7ff) << 11) | (trailer2007.crc0 & 0x7ff);
+      default:
+        edm::LogError("CSCALCTTrailer|CSCRawToDigi") << "couldn't getCRC: ALCT firmware version is bad/not defined!";
+        return 0;
     }
   }
 
@@ -128,58 +122,54 @@ public:
 #else
     switch (firmwareVersion.load()) {
 #endif
-    case 2006:
-      return (trailer2006.e0dLine & 0xfff) == 0xe0d;
-    case 2007:
-      return (trailer2007.e0dLine & 0xffff) == 0xde0d;
-    default:
-      edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-	<<"couldn't check: ALCT firmware version is bad/not defined!";
-      return false;
+      case 2006:
+        return (trailer2006.e0dLine & 0xfff) == 0xe0d;
+      case 2007:
+        return (trailer2007.e0dLine & 0xffff) == 0xde0d;
+      default:
+        edm::LogError("CSCALCTTrailer|CSCRawToDigi") << "couldn't check: ALCT firmware version is bad/not defined!";
+        return false;
     }
   }
-  
+
   int wordCount() const {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
     switch (firmwareVersion.load()) {
 #endif
-    case 2006:
-      return trailer2006.frameCount;
-    case 2007:
-      return trailer2007.frameCount;
-    default:
-      edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-	<<"couldn't wordCount: ALCT firmware version is bad/not defined!";
-      return 0;
+      case 2006:
+        return trailer2006.frameCount;
+      case 2007:
+        return trailer2007.frameCount;
+      default:
+        edm::LogError("CSCALCTTrailer|CSCRawToDigi") << "couldn't wordCount: ALCT firmware version is bad/not defined!";
+        return 0;
     }
   }
-  
-  unsigned alctCRCCheck() const { 
+
+  unsigned alctCRCCheck() const {
 #ifdef LOCAL_UNPACK
     switch (firmwareVersion) {
 #else
     switch (firmwareVersion.load()) {
 #endif
-    case 2006:
-      return trailer2006.reserved_3;
-    case 2007:
-      return trailer2007.reserved_3;  
-    default:
-      edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-	<<"couldn't CRCcheck: ALCT firmware version is bad/not defined!";
-      return 0;
+      case 2006:
+        return trailer2006.reserved_3;
+      case 2007:
+        return trailer2007.reserved_3;
+      default:
+        edm::LogError("CSCALCTTrailer|CSCRawToDigi") << "couldn't CRCcheck: ALCT firmware version is bad/not defined!";
+        return 0;
     }
   }
-  
+
   unsigned FrameCount() const { return wordCount(); }
 
-  CSCALCTTrailer2006 alctTrailer2006() {return trailer2006;}
-  CSCALCTTrailer2007 alctTrailer2007() {return trailer2007;}
+  CSCALCTTrailer2006 alctTrailer2006() { return trailer2006; }
+  CSCALCTTrailer2007 alctTrailer2007() { return trailer2007; }
 
 private:
-
 #ifdef LOCAL_UNPACK
   static bool debug;
   static unsigned short int firmwareVersion;
@@ -191,8 +181,6 @@ private:
   CSCALCTTrailer2006 trailer2006;
   CSCALCTTrailer2007 trailer2007;
   unsigned short int theOriginalBuffer[4];
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData.h
@@ -7,24 +7,22 @@
 
 class CSCALCTHeader;
 
-
 class CSCAnodeData {
-
 public:
   /// a blank one, for Monte Carlo
   CSCAnodeData(const CSCALCTHeader &);
   /// fill from a real datastream
   CSCAnodeData(const CSCALCTHeader &, const unsigned short *buf);
 
-  unsigned short * data() {return theData->data();}
+  unsigned short *data() { return theData->data(); }
   /// the amount of the input binary buffer read, in 16-bit words
-  unsigned short int sizeInWords() const {return theData->sizeInWords();}
+  unsigned short int sizeInWords() const { return theData->sizeInWords(); }
 
   /// input layer is from 1 to 6
-  std::vector<CSCWireDigi> wireDigis(int layer) const {return theData->wireDigis(layer);}
+  std::vector<CSCWireDigi> wireDigis(int layer) const { return theData->wireDigis(layer); }
   std::vector<std::vector<CSCWireDigi> > wireDigis() const;
 
-  void add(const CSCWireDigi & wireDigi, int layer) {theData->add(wireDigi, layer);}
+  void add(const CSCWireDigi &wireDigi, int layer) { theData->add(wireDigi, layer); }
 
   static bool selfTest();
 
@@ -34,5 +32,3 @@ private:
 };
 
 #endif
-
-

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h
@@ -8,28 +8,25 @@ class CSCALCTHeader;
 class CSCAnodeDataFrame2006 {
 public:
   CSCAnodeDataFrame2006() {}
-  CSCAnodeDataFrame2006(unsigned short frame):
-    theFrame(frame) {}
+  CSCAnodeDataFrame2006(unsigned short frame) : theFrame(frame) {}
   CSCAnodeDataFrame2006(unsigned chip, unsigned tbin, unsigned data);
 
   /// given a wiregroup between 0 and 7, it tells whether this bit was on
   bool isHit(unsigned wireGroup) const {
     assert(wireGroup < 8);
-    return ( (theFrame>>wireGroup) & 0x1 );
+    return ((theFrame >> wireGroup) & 0x1);
   }
 
   /// sets a bit, from 0 to 7
-  void addHit(unsigned wireBit) {
-    theFrame |= (1 << wireBit);
-  }
+  void addHit(unsigned wireBit) { theFrame |= (1 << wireBit); }
 
   /// time bin
-  unsigned tbin() const {return (theFrame >> 8) & 0x1F;}
+  unsigned tbin() const { return (theFrame >> 8) & 0x1F; }
   /// kind of the chip ID.  But it's only 2-bit, and we really need
   /// three, so it's the lowest bit, plus the OR of the next two.
-  unsigned chip() const {return (theFrame >>13) & 0x3;}
-  unsigned short data() const {return theFrame & 0xFF;}
-  unsigned short frame() const {return theFrame;}
+  unsigned chip() const { return (theFrame >> 13) & 0x3; }
+  unsigned short data() const { return theFrame & 0xFF; }
+  unsigned short frame() const { return theFrame; }
 
 private:
   unsigned short theFrame;
@@ -39,26 +36,23 @@ private:
   //unsigned short ddu_code_ : 1;
 };
 
-
-
-class CSCAnodeData2006 : public CSCAnodeDataFormat 
-{
+class CSCAnodeData2006 : public CSCAnodeDataFormat {
 public:
   /// a blank one, for Monte Carlo
   CSCAnodeData2006(const CSCALCTHeader &);
   /// fill from a real datastream
   CSCAnodeData2006(const CSCALCTHeader &, const unsigned short *buf);
 
-  unsigned short * data() override {return theDataFrames;}
+  unsigned short *data() override { return theDataFrames; }
   /// the amount of the input binary buffer read, in 16-bit words
-  unsigned short int sizeInWords() const override {return nAFEBs_ * nTimeBins_ * 6 * 2;}
+  unsigned short int sizeInWords() const override { return nAFEBs_ * nTimeBins_ * 6 * 2; }
 
   /// input layer is from 1 to 6
   std::vector<CSCWireDigi> wireDigis(int layer) const override;
 
   void add(const CSCWireDigi &, int layer) override;
 
-  static  void selfTest();
+  static void selfTest();
 
 private:
   void init();
@@ -75,9 +69,7 @@ private:
   /// in 2007 format the max number of frames is 1860
   int nAFEBs_;
   int nTimeBins_;
-  unsigned int alctBX_; /// To account BX in wire digis
+  unsigned int alctBX_;  /// To account BX in wire digis
 };
 
 #endif
-
-

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h
@@ -7,45 +7,40 @@
 class CSCALCTHeader;
 
 class CSCAnodeDataFrame2007 {
- public:
-  explicit CSCAnodeDataFrame2007(unsigned short data) {data_ = data;}
+public:
+  explicit CSCAnodeDataFrame2007(unsigned short data) { data_ = data; }
   CSCAnodeDataFrame2007() {}
 
   /// given a wiregroup between 0 and 11, it tells whether this bit was on
   bool isHit(unsigned wireGroup) const {
     assert(wireGroup < 12);
-    return ( (data_>>wireGroup) & 0x1 );
+    return ((data_ >> wireGroup) & 0x1);
   }
 
-  void addHit(unsigned wireGroup)
-  {
-    data_ |= (1 << wireGroup);
-  }
+  void addHit(unsigned wireGroup) { data_ |= (1 << wireGroup); }
 
-  unsigned short data() const {return data_;}
-  
- private:
-  unsigned short data_     : 12;
+  unsigned short data() const { return data_; }
+
+private:
+  unsigned short data_ : 12;
   unsigned short reserved_ : 3;
-  unsigned short flag_     : 1;
+  unsigned short flag_ : 1;
 };
 
-
 class CSCAnodeData2007 : public CSCAnodeDataFormat {
-
 public:
   /// a blank one, for Monte Carlo
   explicit CSCAnodeData2007(const CSCALCTHeader &);
   /// fill from a real datastream
   CSCAnodeData2007(const CSCALCTHeader &, const unsigned short *buf);
 
-  unsigned short * data() override {return theDataFrames;}
+  unsigned short *data() override { return theDataFrames; }
   /// the amount of the input binary buffer read, in 16-bit words
-  unsigned short int sizeInWords() const override {return sizeInWords2007_;}
+  unsigned short int sizeInWords() const override { return sizeInWords2007_; }
 
   /// input layer is from 1 to 6
   std::vector<CSCWireDigi> wireDigis(int layer) const override;
-  
+
   void add(const CSCWireDigi &, int layer) override;
 
   static void selfTest();
@@ -56,17 +51,15 @@ private:
   CSCAnodeDataFrame2007 findFrame(int tbin, int layer, int layerPart) const;
 
   /// we don't know the size at first.  Max should be 7 boards * 32 bins * 6 layers * 2
-  enum {MAXFRAMES=2700};
+  enum { MAXFRAMES = 2700 };
   unsigned short theDataFrames[MAXFRAMES];
   unsigned short int sizeInWords2007_;
   unsigned short int nAFEBs_;
-  unsigned short int  nTimeBins_;
+  unsigned short int nTimeBins_;
 
-  unsigned short int layerParts_;///number of layer parts in the ALCT
-  unsigned short int maxWireGroups_;///number of wiregroups in the ALCT
-  unsigned int alctBX_; /// To account BX in wire digis
+  unsigned short int layerParts_;     ///number of layer parts in the ALCT
+  unsigned short int maxWireGroups_;  ///number of wiregroups in the ALCT
+  unsigned int alctBX_;               /// To account BX in wire digis
 };
 
 #endif
-
-

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeDataFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeDataFormat.h
@@ -3,20 +3,16 @@
 #include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
 #include <vector>
 class CSCAnodeDataFormat {
-
 public:
   virtual ~CSCAnodeDataFormat() {}
-  virtual unsigned short * data() = 0;
+  virtual unsigned short* data() = 0;
   /// the amount of the input binary buffer read, in 16-bit words
   virtual unsigned short int sizeInWords() const = 0;
 
   /// input layer is from 1 to 6
   virtual std::vector<CSCWireDigi> wireDigis(int layer) const = 0;
 
-  virtual void add(const CSCWireDigi & wireDigi, int layer) = 0;
-
+  virtual void add(const CSCWireDigi& wireDigi, int layer) = 0;
 };
 
 #endif
-
-

--- a/EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h
@@ -2,21 +2,19 @@
 #define CSCBadCFEBTimeSlice_h
 
 #include "EventFilter/CSCRawToDigi/interface/CSCBadCFEBWord.h"
-#include<iosfwd>
+#include <iosfwd>
 
 /**
  * When a time slice is bad, it only has four words, and they all start with "B"
  */
 
-
 class CSCBadCFEBTimeSlice {
 public:
-  unsigned sizeInWords() const {return 4;}
+  unsigned sizeInWords() const { return 4; }
   /// count from zero
-  const CSCBadCFEBWord & word(int i) const;
+  const CSCBadCFEBWord& word(int i) const;
 
   bool check() const;
-
 
 private:
   CSCBadCFEBWord theWords[4];

--- a/EventFilter/CSCRawToDigi/interface/CSCBadCFEBWord.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCBadCFEBWord.h
@@ -4,22 +4,22 @@
 /**
  * When a time slice is bad, it only has four words, and they all start with "B"
  */
-#include<iosfwd>
+#include <iosfwd>
 
 class CSCBadCFEBWord {
 public:
   /// make sure it really does start with a "B"
-  bool check() const {return b_==0xb;}
-  bool isBad() const {return true;}
-  friend std::ostream & operator<<(std::ostream & os, const CSCBadCFEBWord &);
-  unsigned data() const {return (word1_ + (word2_<<4) + (code_<<9) + (b_<<12) );}
-private:
-  unsigned short word1_:4;
-  unsigned short word2_:4;
-  unsigned short zero_:1;
-  unsigned short code_:3;
-  unsigned short b_:4;
-};
+  bool check() const { return b_ == 0xb; }
+  bool isBad() const { return true; }
+  friend std::ostream &operator<<(std::ostream &os, const CSCBadCFEBWord &);
+  unsigned data() const { return (word1_ + (word2_ << 4) + (code_ << 9) + (b_ << 12)); }
 
+private:
+  unsigned short word1_ : 4;
+  unsigned short word2_ : 4;
+  unsigned short zero_ : 1;
+  unsigned short code_ : 3;
+  unsigned short b_ : 4;
+};
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
@@ -5,67 +5,65 @@ class CSCCFEBTimeSlice;
 class CSCStripDigi;
 class CSCCFEBStatusDigi;
 
-#include<vector>
-#include<iosfwd>
-#include<iostream>
+#include <vector>
+#include <iosfwd>
+#include <iostream>
 //#include <boost/cstdint.hpp>
 
-
 class CSCCFEBData {
- public:
- /// read from an existing data stream. 
-  CSCCFEBData(unsigned boardNumber, const uint16_t * buf, uint16_t theFormatVersion = 2005, bool fDCFEB = false);
-  /// create, 
+public:
+  /// read from an existing data stream.
+  CSCCFEBData(unsigned boardNumber, const uint16_t *buf, uint16_t theFormatVersion = 2005, bool fDCFEB = false);
+  /// create,
   CSCCFEBData(unsigned boardNumber, bool sixteenSamples, uint16_t theFormatVersion = 2005, bool fDCFEB = false);
-  
-  unsigned nTimeSamples() const { return theNumberOfSamples;}
+
+  unsigned nTimeSamples() const { return theNumberOfSamples; }
 
   /// count from 0.  User should check if it's a bad slice
-  const CSCCFEBTimeSlice * timeSlice(unsigned i) const;
+  const CSCCFEBTimeSlice *timeSlice(unsigned i) const;
 
   unsigned adcCounts(unsigned layer, unsigned channel, unsigned timeBin) const;
   unsigned adcOverflow(unsigned layer, unsigned channel, unsigned timeBin) const;
   unsigned controllerData(unsigned uglay, unsigned ugchan, unsigned timeBin) const;
   unsigned overlappedSampleFlag(unsigned layer, unsigned channel, unsigned timeBin) const;
   unsigned errorstat(unsigned layer, unsigned channel, unsigned timeBin) const;
-  
+
   void add(const CSCStripDigi &, int layer);
   /// Fill strip digis for layer with raw detid = idlayer
   /// WARNING: these digis have no comparator information.
 
   ///faster way to get to digis
-  void digis(uint32_t idlayer,  std::vector<CSCStripDigi> & result) const;
+  void digis(uint32_t idlayer, std::vector<CSCStripDigi> &result) const;
 
   std::vector<CSCStripDigi> digis(unsigned idlayer) const;
   /// deprecated.  Use the above method.
   std::vector<std::vector<CSCStripDigi> > stripDigis();
- 
+
   /// returns one status digi per cfeb
   CSCCFEBStatusDigi statusDigi() const;
 
-  uint16_t * data() {return theData;}
-  unsigned sizeInWords() const {return theSize;} 
-  unsigned boardNumber() const {return boardNumber_;}
-  void setBoardNumber(int cfeb) {boardNumber_=cfeb;}
+  uint16_t *data() { return theData; }
+  unsigned sizeInWords() const { return theSize; }
+  unsigned boardNumber() const { return boardNumber_; }
+  void setBoardNumber(int cfeb) { boardNumber_ = cfeb; }
   void setL1A(unsigned l1a);
   void setL1A(unsigned sample, unsigned l1a);
-  
-  friend std::ostream & operator<<(std::ostream & os, const CSCCFEBData &);
+
+  friend std::ostream &operator<<(std::ostream &os, const CSCCFEBData &);
   static void selfTest();
 
   /// makes sure each time slice has a trailer
   bool check() const;
 
-  bool isDCFEB() const {return fDCFEB;}
- 
- 
- private:
-  CSCCFEBTimeSlice * timeSlice(unsigned i);
+  bool isDCFEB() const { return fDCFEB; }
+
+private:
+  CSCCFEBTimeSlice *timeSlice(unsigned i);
 
   uint16_t theData[1600];
-  /// Shows where in theData the words start.  A bad slice will 
+  /// Shows where in theData the words start.  A bad slice will
   /// be tagged with a false
-  std::vector<std::pair<int,bool> > theSliceStarts;
+  std::vector<std::pair<int, bool> > theSliceStarts;
   /// in words
   int theSize;
   unsigned boardNumber_;

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h
@@ -1,7 +1,6 @@
 #ifndef CSCCFEBTimeSlice_h
 #define CSCCFEBTimeSlice_h
 
-
 /**
  CFEB Data Stream 
 The ordering of the words in the data stream from a single CFEB is described by the following nested loops: 
@@ -19,7 +18,7 @@ do (N_ts  time samples){
 */
 
 struct CSCCFEBDataWord {
-  unsigned short adcCounts   : 12;
+  unsigned short adcCounts : 12;
   unsigned short adcOverflow : 1;
   /// combined from all 16 strips to make a word
   unsigned short controllerData : 1;
@@ -32,7 +31,7 @@ struct CSCCFEBDataWord {
 };
 
 #include <iostream>
-#include <cstring> //for bzero
+#include <cstring>  //for bzero
 
 struct CSCCFEBSCAControllerWord {
   /**
@@ -40,75 +39,72 @@ TRIG_TIME indicates which of the eight time samples in the 400ns SCA block (lowe
 
   */
   explicit CSCCFEBSCAControllerWord(unsigned short frame);
-  CSCCFEBSCAControllerWord() {bzero(this, 2);}
+  CSCCFEBSCAControllerWord() { bzero(this, 2); }
 
   unsigned short trig_time : 8;
-  unsigned short sca_blk   : 4;
+  unsigned short sca_blk : 4;
   unsigned short l1a_phase : 1;
   unsigned short lct_phase : 1;
-  unsigned short sca_full  : 1;
-  unsigned short ts_flag   : 1;
+  unsigned short sca_full : 1;
+  unsigned short ts_flag : 1;
 };
 
-
-
-
 class CSCCFEBTimeSlice {
- public:
+public:
   CSCCFEBTimeSlice();
 
   /// input from 0 to 95
-  CSCCFEBDataWord * timeSample(int index) const {
-    return (CSCCFEBDataWord *)(theSamples+index);
-  }
+  CSCCFEBDataWord *timeSample(int index) const { return (CSCCFEBDataWord *)(theSamples + index); }
 
   /// layer and element count from one
   // CSCCFEBDataWord * timeSample(int layer, int channel) const;
 
   /// !!! Important change. Use isDCFEB flag in user code to distinguish between CFEB and DCFEB
   /// !!! Use CSCCFEBData::isDCFEB() function to get this flag from CSCCFEBData object
-  CSCCFEBDataWord * timeSample(int layer, int channel, bool isDCFEB=false) const;
+  CSCCFEBDataWord *timeSample(int layer, int channel, bool isDCFEB = false) const;
 
   /// whether we keep 8 or 16 time samples
-  bool sixteenSamples() const {/*return scaControllerWord(1).ts_flag;i*/
-    return timeSample(95)->controllerData;}
-  unsigned sizeInWords() const {return 100;}
-
+  bool sixteenSamples() const { /*return scaControllerWord(1).ts_flag;i*/
+    return timeSample(95)->controllerData;
+  }
+  unsigned sizeInWords() const { return 100; }
 
   /// unpacked from the controller words for each channel in the layer
-  CSCCFEBSCAControllerWord scaControllerWord(int layer) const ;
-  
-  void setControllerWord(const CSCCFEBSCAControllerWord & controllerWord);
+  CSCCFEBSCAControllerWord scaControllerWord(int layer) const;
+
+  void setControllerWord(const CSCCFEBSCAControllerWord &controllerWord);
 
   /// Old CFEB format: dummy word 100 should be 0x7FFF
   /// New CFEB format: the sum of word 97 and 100 should be 0x7FFF (word 100 is inverted word 97)
-  bool check() const {return ((dummy == 0x7FFF)||((dummy+crc)== 0x7FFF));}
+  bool check() const { return ((dummy == 0x7FFF) || ((dummy + crc) == 0x7FFF)); }
 
-  bool checkCRC() const {return crc==calcCRC();}
-  
+  bool checkCRC() const { return crc == calcCRC(); }
+
   unsigned calcCRC() const;
 
   /// =VB= Set calculated CRC value for simulated CFEB Time Slice data
-  void setCRC() { crc=calcCRC(); dummy=0x7FFF-crc;}
+  void setCRC() {
+    crc = calcCRC();
+    dummy = 0x7FFF - crc;
+  }
 
-  friend std::ostream & operator<<(std::ostream & os, const CSCCFEBTimeSlice &);
-
+  friend std::ostream &operator<<(std::ostream &os, const CSCCFEBTimeSlice &);
 
   ///accessors for words 97, 98 and 99
-  unsigned  get_crc()               const {return crc;}
-  unsigned  get_n_free_sca_blocks() const {return n_free_sca_blocks;}
-  unsigned  get_lctpipe_count()     const {return lctpipe_count;}
-  unsigned  get_lctpipe_full()      const {return lctpipe_full;}
-  unsigned  get_l1pipe_full()       const {return l1pipe_full;}
-  unsigned  get_lctpipe_empty()     const {return lctpipe_empty;}
-  unsigned  get_l1pipe_empty()      const {return l1pipe_empty;}
-  unsigned  get_buffer_warning()    const {return buffer_warning;}
-  unsigned  get_buffer_count()      const {return buffer_count;}
-  unsigned  get_L1A_number()        const {return L1A_number;}
+  unsigned get_crc() const { return crc; }
+  unsigned get_n_free_sca_blocks() const { return n_free_sca_blocks; }
+  unsigned get_lctpipe_count() const { return lctpipe_count; }
+  unsigned get_lctpipe_full() const { return lctpipe_full; }
+  unsigned get_l1pipe_full() const { return l1pipe_full; }
+  unsigned get_lctpipe_empty() const { return lctpipe_empty; }
+  unsigned get_l1pipe_empty() const { return l1pipe_empty; }
+  unsigned get_buffer_warning() const { return buffer_warning; }
+  unsigned get_buffer_count() const { return buffer_count; }
+  unsigned get_L1A_number() const { return L1A_number; }
 
-  void 	    set_L1Anumber(unsigned l1a) {L1A_number = l1a & 0x3F;}
+  void set_L1Anumber(unsigned l1a) { L1A_number = l1a & 0x3F; }
 
- private:
+private:
   unsigned short theSamples[96];
 
   /// WORD 97
@@ -117,18 +113,17 @@ class CSCCFEBTimeSlice {
   /// WORD 98
   unsigned n_free_sca_blocks : 4;
   unsigned lctpipe_count : 4;
-  unsigned lctpipe_full  : 1;
-  unsigned l1pipe_full   : 1;
+  unsigned lctpipe_full : 1;
+  unsigned l1pipe_full : 1;
   unsigned lctpipe_empty : 1;
-  unsigned l1pipe_empty  : 1;
+  unsigned l1pipe_empty : 1;
   unsigned blank_space_1 : 4;
-
 
   /// WORD 99
   unsigned buffer_warning : 1;
   unsigned buffer_count : 5;
-  unsigned L1A_number :6;
-  unsigned blank_space_3 : 4; 
+  unsigned L1A_number : 6;
+  unsigned blank_space_3 : 4;
 
   /// WORD 100
   unsigned dummy : 16;

--- a/EventFilter/CSCRawToDigi/interface/CSCCLCTData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCLCTData.h
@@ -9,13 +9,11 @@
 #include <atomic>
 #endif
 
-
 struct CSCCLCTDataWord {
-  CSCCLCTDataWord(unsigned cfeb, unsigned tbin, unsigned data)
-  : data_(data), tbin_(tbin), cfeb_(cfeb) {}
-  bool value(int distrip) {return (data_ >> distrip) & 0x1;}
+  CSCCLCTDataWord(unsigned cfeb, unsigned tbin, unsigned data) : data_(data), tbin_(tbin), cfeb_(cfeb) {}
+  bool value(int distrip) { return (data_ >> distrip) & 0x1; }
   ///@@ not right! doesn't set zero
-  void set(int distrip, bool value) {data_ |= (value << distrip);}
+  void set(int distrip, bool value) { data_ |= (value << distrip); }
   unsigned short data_ : 8;
   unsigned short tbin_ : 4;
   unsigned short cfeb_ : 4;
@@ -24,15 +22,13 @@ struct CSCCLCTDataWord {
 class CSCTMBHeader;
 
 class CSCCLCTData {
-
 public:
-
-  explicit CSCCLCTData(const CSCTMBHeader * tmbHeader);
+  explicit CSCCLCTData(const CSCTMBHeader *tmbHeader);
   CSCCLCTData(int ncfebs, int ntbins, int firmware_version = 2007);
   CSCCLCTData(int ncfebs, int ntbins, const unsigned short *e0bbuf, int firmware_version = 2007);
 
   /** turns on/off debug flag for this class */
-  static void setDebug(const bool value) {debug = value;};
+  static void setDebug(const bool value) { debug = value; };
 
   /// layers count from one
   std::vector<CSCComparatorDigi> comparatorDigis(int layer);
@@ -40,34 +36,34 @@ public:
   /// layers count from one
   std::vector<CSCComparatorDigi> comparatorDigis(uint32_t idlayer, unsigned icfeb);
 
-
-  unsigned short * data() {return theData;}
+  unsigned short *data() { return theData; }
   /// in 16-bit words
-  int sizeInWords() const { return size_;}
-  int nlines() const { return ncfebs_*ntbins_*6; }
+  int sizeInWords() const { return size_; }
+  int nlines() const { return ncfebs_ * ntbins_ * 6; }
 
   ///TODO for packing.  Doesn't do flipping yet
-  void add(const CSCComparatorDigi & digi, int layer);
-   ///TODO for packing.  Doesn't do flipping yet
-  void add(const CSCComparatorDigi & digi,  const CSCDetId & id);
+  void add(const CSCComparatorDigi &digi, int layer);
+  ///TODO for packing.  Doesn't do flipping yet
+  void add(const CSCComparatorDigi &digi, const CSCDetId &id);
 
-  CSCCLCTDataWord & dataWord(int iline) const {
+  CSCCLCTDataWord &dataWord(int iline) const {
 #ifdef ASSERTS
     assert(iline < nlines());
 #endif
-    union dataPtr { const unsigned short * s; CSCCLCTDataWord * d; } mptr;
-    mptr.s = theData+iline;
+    union dataPtr {
+      const unsigned short *s;
+      CSCCLCTDataWord *d;
+    } mptr;
+    mptr.s = theData + iline;
     return *(mptr.d);
   }
 
-  CSCCLCTDataWord & dataWord(int cfeb, int tbin, int layer) const {
-    int iline = (layer-1) + tbin*6 + cfeb*6*ntbins_;
+  CSCCLCTDataWord &dataWord(int cfeb, int tbin, int layer) const {
+    int iline = (layer - 1) + tbin * 6 + cfeb * 6 * ntbins_;
     return dataWord(iline);
   }
 
-  bool bitValue(int cfeb, int tbin, int layer, int distrip) {
-    return dataWord(cfeb, tbin, layer).value(distrip);
-  }
+  bool bitValue(int cfeb, int tbin, int layer, int distrip) { return dataWord(cfeb, tbin, layer).value(distrip); }
 
   // checks that the CFEB number and time bins are correct
   bool check() const;
@@ -78,9 +74,7 @@ public:
   // checks packing and unpacking
   static void selfTest();
 
-
- private:
-
+private:
   // helper for constructors
   void zero();
 
@@ -93,7 +87,7 @@ public:
   int ncfebs_;
   int ntbins_;
   int size_;
-  unsigned short theData[7*6*32];
+  unsigned short theData[7 * 6 * 32];
   int theFirmwareVersion;
 };
 

--- a/EventFilter/CSCRawToDigi/interface/CSCChamberDataItr.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCChamberDataItr.h
@@ -10,18 +10,18 @@
 class CSCDCCEventData;
 class CSCDDUEventData;
 class CSCEventData;
-#include<vector>
+#include <vector>
 
 class CSCChamberDataItr {
 public:
   /// construct from data buffer.  Will figure out whether it's
   /// DCC or DDU
-  CSCChamberDataItr(const char * buf);
+  CSCChamberDataItr(const char *buf);
   ~CSCChamberDataItr();
 
   bool next();
 
-  const CSCEventData & operator*();
+  const CSCEventData &operator*();
 
 private:
   /// for DCC data.
@@ -36,11 +36,10 @@ private:
   /// own theDCCData, in which case the DDUs points inside it,
   //  or if there's no DCC, it will
   /// make a new vector of DDUs (length 1).
-  const CSCDCCEventData * theDCCData;
-  CSCDDUDataItr * theDDUItr;
+  const CSCDCCEventData *theDCCData;
+  CSCDDUDataItr *theDDUItr;
   unsigned theCurrentDDU;
   unsigned theNumberOfDDUs;
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h
@@ -15,49 +15,47 @@ public:
   CSCDCCEventData(int sourceId, int nDDUs, int bx, int l1a);
   /// buf may need to stay pinned in memory as long
   /// as this data is used.  Not sure
-  explicit CSCDCCEventData(const uint16_t *buf, CSCDCCExaminer* examiner=nullptr);
+  explicit CSCDCCEventData(const uint16_t* buf, CSCDCCExaminer* examiner = nullptr);
 
   ~CSCDCCEventData();
 
-  static void setDebug(bool value) {debug = value;} 
- 
+  static void setDebug(bool value) { debug = value; }
+
   /// accessor to dduData
-  const std::vector<CSCDDUEventData> & dduData() const {return theDDUData;}
-  std::vector<CSCDDUEventData> & dduData() {return theDDUData;}
+  const std::vector<CSCDDUEventData>& dduData() const { return theDDUData; }
+  std::vector<CSCDDUEventData>& dduData() { return theDDUData; }
 
-  CSCDCCHeader dccHeader() const {return theDCCHeader;}
-  CSCDCCTrailer dccTrailer() const {return theDCCTrailer;}
-
+  CSCDCCHeader dccHeader() const { return theDCCHeader; }
+  CSCDCCTrailer dccTrailer() const { return theDCCTrailer; }
 
   /// for making events.  Sets the bxnum and lvl1num inside the chamber event
   //void add(CSCEventData &);
 
   bool check() const;
 
-  /// prints out the error associated with this status 
+  /// prints out the error associated with this status
   /// from the header or trailer
-  int sizeInWords() const {return theSizeInWords;}
+  int sizeInWords() const { return theSizeInWords; }
 
-  void addChamber(CSCEventData & chamber, int dduID, int dduSlot, int dduInput, int dmbID, uint16_t format_version = 2005);
+  void addChamber(
+      CSCEventData& chamber, int dduID, int dduSlot, int dduInput, int dmbID, uint16_t format_version = 2005);
 
   ///packs data into bits
-  boost::dynamic_bitset<> pack();  
+  boost::dynamic_bitset<> pack();
 
 #ifdef LOCAL_UNPACK
   static bool debug;
 #else
-  static std::atomic<bool> debug;  
+  static std::atomic<bool> debug;
 #endif
 
-
 protected:
-  void unpack_data(const uint16_t * buf, CSCDCCExaminer* examiner=nullptr);
+  void unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner = nullptr);
   CSCDCCHeader theDCCHeader;
   // DDUData is unpacked and stored in this vector
   std::vector<CSCDDUEventData> theDDUData;
   CSCDCCTrailer theDCCTrailer;
   int theSizeInWords;
-  
 };
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCExaminer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCExaminer.h
@@ -14,245 +14,316 @@
 
 class CSCDCCExaminer {
 public:
-	const uint16_t nERRORS, nWARNINGS, nPAYLOADS, nSTATUSES;
+  const uint16_t nERRORS, nWARNINGS, nPAYLOADS, nSTATUSES;
 
 private:
-	std::vector<const char*> sERROR,  sWARNING, sERROR_,  sWARNING_, sDMBExpectedPayload, sDMBEventStaus;
-	ExaminerStatusType bERROR,  bWARNING;
-        ExaminerStatusType bSUM_ERROR,  bSUM_WARNING;	// Summary flags for errors and warnings
-	bool               fERROR  [29];//[nERRORS];
-	bool               fWARNING[5]; //[nWARNINGS];
-        bool               fSUM_ERROR  [29];//[nERRORS];
-        bool               fSUM_WARNING[5]; //[nWARNINGS];
+  std::vector<const char*> sERROR, sWARNING, sERROR_, sWARNING_, sDMBExpectedPayload, sDMBEventStaus;
+  ExaminerStatusType bERROR, bWARNING;
+  ExaminerStatusType bSUM_ERROR, bSUM_WARNING;  // Summary flags for errors and warnings
+  bool fERROR[29];                              //[nERRORS];
+  bool fWARNING[5];                             //[nWARNINGS];
+  bool fSUM_ERROR[29];                          //[nERRORS];
+  bool fSUM_WARNING[5];                         //[nWARNINGS];
 
-	std::set<CSCIdType>      fCHAMB_ERR[29]; // Set of chambers which contain particular error
-	std::set<CSCIdType>      fCHAMB_WRN[5];  // Set of chambers which contain particular warning
-	std::map<CSCIdType,ExaminerStatusType> bCHAMB_ERR;     // chamber <=> errors in bits
-	std::map<CSCIdType,ExaminerStatusType> bCHAMB_WRN;     // chamber <=> errors in bits
-	std::map<CSCIdType,ExaminerStatusType> bCHAMB_PAYLOAD; //
-	std::map<CSCIdType,ExaminerStatusType> bCHAMB_STATUS;  //
-	std::map<DDUIdType,ExaminerStatusType> bDDU_ERR;       // ddu     <-> errors in bits
-	std::map<DDUIdType,ExaminerStatusType> bDDU_WRN;       // ddu     <-> errors in bits
+  std::set<CSCIdType> fCHAMB_ERR[29];                      // Set of chambers which contain particular error
+  std::set<CSCIdType> fCHAMB_WRN[5];                       // Set of chambers which contain particular warning
+  std::map<CSCIdType, ExaminerStatusType> bCHAMB_ERR;      // chamber <=> errors in bits
+  std::map<CSCIdType, ExaminerStatusType> bCHAMB_WRN;      // chamber <=> errors in bits
+  std::map<CSCIdType, ExaminerStatusType> bCHAMB_PAYLOAD;  //
+  std::map<CSCIdType, ExaminerStatusType> bCHAMB_STATUS;   //
+  std::map<DDUIdType, ExaminerStatusType> bDDU_ERR;        // ddu     <-> errors in bits
+  std::map<DDUIdType, ExaminerStatusType> bDDU_WRN;        // ddu     <-> errors in bits
 
 #ifdef LOCAL_UNPACK
-	class OStream : public std::ostream {
-	private:
-		class buffer : public std::streambuf{};
-		buffer     buff;
-		std::streambuf *stream;
-		std::streambuf *null;
-		std::string     name;
+  class OStream : public std::ostream {
+  private:
+    class buffer : public std::streambuf {};
+    buffer buff;
+    std::streambuf* stream;
+    std::streambuf* null;
+    std::string name;
 
-	public:
-		void show(void){ rdbuf(stream); }
-		void hide(void){ rdbuf(null);   }
-		void sign(std::string nm)     { name=nm; }
-		void sign(const char *nm){ name=nm; }
+  public:
+    void show(void) { rdbuf(stream); }
+    void hide(void) { rdbuf(null); }
+    void sign(std::string nm) { name = nm; }
+    void sign(const char* nm) { name = nm; }
 
-		void redirect(std::ostream &str){
-			stream = str.rdbuf(); tie(&str);
-			if( rdbuf() != null ) rdbuf(stream);
-		}
+    void redirect(std::ostream& str) {
+      stream = str.rdbuf();
+      tie(&str);
+      if (rdbuf() != null)
+        rdbuf(stream);
+    }
 
-		template<class T> std::ostream& operator<<(const T& val){
-			return (*(std::ostream*)this)<<name<<val;
-		}
+    template <class T>
+    std::ostream& operator<<(const T& val) {
+      return (*(std::ostream*)this) << name << val;
+    }
 
-		OStream(void):std::ostream(std::cout.rdbuf()),buff(),stream(std::cout.rdbuf()),null(&buff),name(""){}
-		OStream(std::ostream &str):std::ostream(str.rdbuf()),buff(),stream(str.rdbuf()),null(&buff),name(""){}
-	};
+    OStream(void) : std::ostream(std::cout.rdbuf()), buff(), stream(std::cout.rdbuf()), null(&buff), name("") {}
+    OStream(std::ostream& str) : std::ostream(str.rdbuf()), buff(), stream(str.rdbuf()), null(&buff), name("") {}
+  };
 
-	OStream COUT, CERR;
+  OStream COUT, CERR;
 #endif
 
-	CSCIdType currentChamber;       // ( (CrateNumber<<4) + DMBslot ) specifies chamber
+  CSCIdType currentChamber;  // ( (CrateNumber<<4) + DMBslot ) specifies chamber
 
-	const uint16_t *buf_2, *buf_1, *buf0, *buf1, *buf2;
-		  uint16_t tmpbuf[16];
+  const uint16_t *buf_2, *buf_1, *buf0, *buf1, *buf2;
+  uint16_t tmpbuf[16];
 
-	bool fDCC_Header;
-	bool fDCC_Trailer;
-	bool fDDU_Header;
-	bool fDDU_Trailer;
-	bool fDMB_Header;
-	bool fDMB_Trailer;
-	bool fALCT_Header;
-	bool fTMB_Header;
-	bool fTMB_Format2007;
-	bool fALCT_Format2007;
-        bool fFormat2013;
+  bool fDCC_Header;
+  bool fDCC_Trailer;
+  bool fDDU_Header;
+  bool fDDU_Trailer;
+  bool fDMB_Header;
+  bool fDMB_Trailer;
+  bool fALCT_Header;
+  bool fTMB_Header;
+  bool fTMB_Format2007;
+  bool fALCT_Format2007;
+  bool fFormat2013;
 
-	bool uniqueALCT, uniqueTMB; // Do not merge two DMBs if Trailer of the first and Header of the second are lost
+  bool uniqueALCT, uniqueTMB;  // Do not merge two DMBs if Trailer of the first and Header of the second are lost
 
-	bool DAV_ALCT; // ...
-	bool DAV_TMB;  // Check if DAV bits lie
-	int  DAV_CFEB; // ...
-	int  DAV_DMB;  // ...
-	int  DMB_Active, nDMBs;  // ...
+  bool DAV_ALCT;          // ...
+  bool DAV_TMB;           // Check if DAV bits lie
+  int DAV_CFEB;           // ...
+  int DAV_DMB;            // ...
+  int DMB_Active, nDMBs;  // ...
 
 public:
-	uint32_t cntDDU_Headers;
-	uint32_t cntDDU_Trailers;
-	std::map<CSCIdType,uint32_t> cntCHAMB_Headers;
-	std::map<CSCIdType,uint32_t> cntCHAMB_Trailers;
+  uint32_t cntDDU_Headers;
+  uint32_t cntDDU_Trailers;
+  std::map<CSCIdType, uint32_t> cntCHAMB_Headers;
+  std::map<CSCIdType, uint32_t> cntCHAMB_Trailers;
 
 private:
-        void clear();
-        void zeroCounts();
-        void sync_stats();
-        /// checks DAV_ALCT, DAV_TMB, and DAV_CFEB
-        void checkDAVs();
-        void checkTriggerHeadersAndTrailers();
+  void clear();
+  void zeroCounts();
+  void sync_stats();
+  /// checks DAV_ALCT, DAV_TMB, and DAV_CFEB
+  void checkDAVs();
+  void checkTriggerHeadersAndTrailers();
 
-        inline int scanbuf(const uint16_t* &buf, int32_t length, uint16_t sig, uint16_t mask=0xFFFF);
+  inline int scanbuf(const uint16_t*& buf, int32_t length, uint16_t sig, uint16_t mask = 0xFFFF);
 
-	uint32_t DDU_WordsSinceLastHeader;
-	uint32_t DDU_WordCount;
-	uint32_t DDU_WordMismatch_Occurrences;
-	uint32_t DDU_WordsSinceLastTrailer;
-        
-	uint32_t ALCT_WordsSinceLastHeader;
-        uint32_t ALCT_WordsSinceLastHeaderZeroSuppressed; 
-	uint32_t ALCT_WordCount;
-	uint32_t ALCT_WordsExpected;
-        uint32_t ALCT_ZSE;       /// check zero suppression mode
-        uint32_t nWG_round_up;   /// to decode if zero suppression enabled
+  uint32_t DDU_WordsSinceLastHeader;
+  uint32_t DDU_WordCount;
+  uint32_t DDU_WordMismatch_Occurrences;
+  uint32_t DDU_WordsSinceLastTrailer;
 
-	uint32_t TMB_WordsSinceLastHeader;
-	uint32_t TMB_WordCount;
-	uint32_t TMB_WordsExpected;
-	uint32_t TMB_Tbins;
-	uint32_t TMB_WordsRPC;
-	uint32_t TMB_Firmware_Revision;
-  	uint32_t DDU_Firmware_Revision;
+  uint32_t ALCT_WordsSinceLastHeader;
+  uint32_t ALCT_WordsSinceLastHeaderZeroSuppressed;
+  uint32_t ALCT_WordCount;
+  uint32_t ALCT_WordsExpected;
+  uint32_t ALCT_ZSE;      /// check zero suppression mode
+  uint32_t nWG_round_up;  /// to decode if zero suppression enabled
 
-	uint32_t CFEB_SampleWordCount;
-	uint32_t CFEB_SampleCount;
-	uint32_t CFEB_BSampleCount;
+  uint32_t TMB_WordsSinceLastHeader;
+  uint32_t TMB_WordCount;
+  uint32_t TMB_WordsExpected;
+  uint32_t TMB_Tbins;
+  uint32_t TMB_WordsRPC;
+  uint32_t TMB_Firmware_Revision;
+  uint32_t DDU_Firmware_Revision;
 
-	bool checkCrcALCT;
-	uint32_t ALCT_CRC;
-	bool checkCrcTMB;
-	uint32_t TMB_CRC;
-	bool checkCrcCFEB;
-	uint32_t CFEB_CRC;
+  uint32_t CFEB_SampleWordCount;
+  uint32_t CFEB_SampleCount;
+  uint32_t CFEB_BSampleCount;
 
-	bool  modeDDUonly;
-	DDUIdType sourceID;
-	ExaminerMaskType examinerMask;
+  bool checkCrcALCT;
+  uint32_t ALCT_CRC;
+  bool checkCrcTMB;
+  uint32_t TMB_CRC;
+  bool checkCrcCFEB;
+  uint32_t CFEB_CRC;
 
-	//int headerDAV_Active; // Obsolete since 16.09.05
+  bool modeDDUonly;
+  DDUIdType sourceID;
+  ExaminerMaskType examinerMask;
 
-	// data blocks:
-	std::map<DDUIdType,const uint16_t*>                  dduBuffers; // < DDUsourceID, pointer >
-	std::map<DDUIdType,std::map<CSCIdType,const uint16_t*> > dmbBuffers; // < DDUsourceID, < DMBid, pointer > >
-	std::map<DDUIdType,uint32_t>                  dduOffsets; // < DDUsourceID, pointer_offset >
-	std::map<DDUIdType,std::map<CSCIdType,uint32_t> > dmbOffsets; // < DDUsourceID, < DMBid, pointer_offset > >
-	std::map<DDUIdType,uint32_t>                  dduSize; // < DDUsourceID, block_size >
-	std::map<DDUIdType,std::map<CSCIdType,uint32_t> > dmbSize; // < DDUsourceID, < DMBid, block_size > >
-	const uint16_t *buffer_start;
+  //int headerDAV_Active; // Obsolete since 16.09.05
+
+  // data blocks:
+  std::map<DDUIdType, const uint16_t*> dduBuffers;                        // < DDUsourceID, pointer >
+  std::map<DDUIdType, std::map<CSCIdType, const uint16_t*> > dmbBuffers;  // < DDUsourceID, < DMBid, pointer > >
+  std::map<DDUIdType, uint32_t> dduOffsets;                               // < DDUsourceID, pointer_offset >
+  std::map<DDUIdType, std::map<CSCIdType, uint32_t> > dmbOffsets;         // < DDUsourceID, < DMBid, pointer_offset > >
+  std::map<DDUIdType, uint32_t> dduSize;                                  // < DDUsourceID, block_size >
+  std::map<DDUIdType, std::map<CSCIdType, uint32_t> > dmbSize;            // < DDUsourceID, < DMBid, block_size > >
+  const uint16_t* buffer_start;
 
 public:
-
 #ifdef LOCAL_UNPACK
-	OStream& output1(void){ return COUT; }
-	OStream& output2(void){ return CERR; }
+  OStream& output1(void) { return COUT; }
+  OStream& output2(void) { return CERR; }
 #endif
 
-	int32_t check(const uint16_t* &buffer, int32_t length);
+  int32_t check(const uint16_t*& buffer, int32_t length);
 
-	void setMask(ExaminerMaskType mask) {examinerMask=mask;}
-        ExaminerMaskType getMask() const {return examinerMask;}
+  void setMask(ExaminerMaskType mask) { examinerMask = mask; }
+  ExaminerMaskType getMask() const { return examinerMask; }
 
-	ExaminerStatusType errors  (void) const { return bSUM_ERROR;   }
-	ExaminerStatusType warnings(void) const { return bSUM_WARNING; }
+  ExaminerStatusType errors(void) const { return bSUM_ERROR; }
+  ExaminerStatusType warnings(void) const { return bSUM_WARNING; }
 
-	const char* errName(int num) const { if(num>=0&&num<nERRORS)   return sERROR[num];   else return ""; }
-	const char* wrnName(int num) const { if(num>=0&&num<nWARNINGS) return sWARNING[num]; else return ""; }
+  const char* errName(int num) const {
+    if (num >= 0 && num < nERRORS)
+      return sERROR[num];
+    else
+      return "";
+  }
+  const char* wrnName(int num) const {
+    if (num >= 0 && num < nWARNINGS)
+      return sWARNING[num];
+    else
+      return "";
+  }
 
-	const char* errorName  (int num) const { if(num>=0&&num<nERRORS)   return sERROR_[num];   else return ""; }
-	const char* warningName(int num) const { if(num>=0&&num<nWARNINGS) return sWARNING_[num]; else return ""; }
+  const char* errorName(int num) const {
+    if (num >= 0 && num < nERRORS)
+      return sERROR_[num];
+    else
+      return "";
+  }
+  const char* warningName(int num) const {
+    if (num >= 0 && num < nWARNINGS)
+      return sWARNING_[num];
+    else
+      return "";
+  }
 
-	const char* payloadName(int num) const { if(num>=0&&num<nPAYLOADS) return sDMBExpectedPayload[num]; else return ""; }
-	const char* statusName (int num) const { if(num>=0&&num<nSTATUSES) return sDMBEventStaus     [num]; else return ""; }
+  const char* payloadName(int num) const {
+    if (num >= 0 && num < nPAYLOADS)
+      return sDMBExpectedPayload[num];
+    else
+      return "";
+  }
+  const char* statusName(int num) const {
+    if (num >= 0 && num < nSTATUSES)
+      return sDMBEventStaus[num];
+    else
+      return "";
+  }
 
-	bool error  (int num) const { if(num>=0&&num<nERRORS)   return fSUM_ERROR  [num]; else return false; }
-	bool warning(int num) const { if(num>=0&&num<nWARNINGS) return fSUM_WARNING[num]; else return false; }
+  bool error(int num) const {
+    if (num >= 0 && num < nERRORS)
+      return fSUM_ERROR[num];
+    else
+      return false;
+  }
+  bool warning(int num) const {
+    if (num >= 0 && num < nWARNINGS)
+      return fSUM_WARNING[num];
+    else
+      return false;
+  }
 
-	std::set<CSCIdType> chambersWithError  (int num) const { if(num>=0&&num<nERRORS)   return fCHAMB_ERR[num]; else return std::set<int>(); }
-	std::set<CSCIdType> chambersWithWarning(int num) const { if(num>=0&&num<nWARNINGS) return fCHAMB_WRN[num]; else return std::set<int>(); }
+  std::set<CSCIdType> chambersWithError(int num) const {
+    if (num >= 0 && num < nERRORS)
+      return fCHAMB_ERR[num];
+    else
+      return std::set<int>();
+  }
+  std::set<CSCIdType> chambersWithWarning(int num) const {
+    if (num >= 0 && num < nWARNINGS)
+      return fCHAMB_WRN[num];
+    else
+      return std::set<int>();
+  }
 
-	ExaminerStatusType payloadForChamber(CSCIdType chamber) const {
-		std::map<CSCIdType,ExaminerStatusType>::const_iterator item = bCHAMB_PAYLOAD.find(chamber);
-		if( item != bCHAMB_PAYLOAD.end() ) return item->second; else return 0;
-	}
+  ExaminerStatusType payloadForChamber(CSCIdType chamber) const {
+    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = bCHAMB_PAYLOAD.find(chamber);
+    if (item != bCHAMB_PAYLOAD.end())
+      return item->second;
+    else
+      return 0;
+  }
 
-	ExaminerStatusType statusForChamber(CSCIdType chamber) const {
-		std::map<CSCIdType,ExaminerStatusType>::const_iterator item = bCHAMB_STATUS.find(chamber);
-		if( item != bCHAMB_STATUS.end() ) return item->second; else return 0;
-	}
+  ExaminerStatusType statusForChamber(CSCIdType chamber) const {
+    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = bCHAMB_STATUS.find(chamber);
+    if (item != bCHAMB_STATUS.end())
+      return item->second;
+    else
+      return 0;
+  }
 
-	ExaminerStatusType errorsForChamber(CSCIdType chamber) const {
-		std::map<CSCIdType,ExaminerStatusType>::const_iterator item = bCHAMB_ERR.find(chamber);
-                /// Print (for debugging, to be removed)
-                
-                // for(item =bCHAMB_ERR.begin() ; item !=bCHAMB_ERR.end() ; item++)
-                //std::cout << " Ex-errors: " << std::hex << (*item).second << std::dec << std::endl;
+  ExaminerStatusType errorsForChamber(CSCIdType chamber) const {
+    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = bCHAMB_ERR.find(chamber);
+    /// Print (for debugging, to be removed)
 
-                item = bCHAMB_ERR.find(chamber);
-                if( item != bCHAMB_ERR.end() ) return item->second; else return 0;
-	}
+    // for(item =bCHAMB_ERR.begin() ; item !=bCHAMB_ERR.end() ; item++)
+    //std::cout << " Ex-errors: " << std::hex << (*item).second << std::dec << std::endl;
 
-	ExaminerStatusType warningsForChamber(CSCIdType chamber) const {
-		std::map<CSCIdType,ExaminerStatusType>::const_iterator item = bCHAMB_WRN.find(chamber);
-		if( item != bCHAMB_WRN.end() ) return item->second; else return 0;
-	}
+    item = bCHAMB_ERR.find(chamber);
+    if (item != bCHAMB_ERR.end())
+      return item->second;
+    else
+      return 0;
+  }
 
-	ExaminerStatusType errorsForDDU(DDUIdType dduSourceID) const {
-		std::map<DDUIdType,ExaminerStatusType>::const_iterator item = bDDU_ERR.find(dduSourceID);
-		if( item != bDDU_ERR.end() ) return item->second; else return 0;
-	}
-	ExaminerStatusType warningsForDDU(DDUIdType dduSourceID) const {
-		std::map<DDUIdType,ExaminerStatusType>::const_iterator item = bDDU_WRN.find(dduSourceID);
-		if( item != bDDU_WRN.end() ) return item->second; else return 0;
-	}
-	std::vector<DDUIdType> listOfDDUs(void) const {
-		std::vector<DDUIdType> DDUs;
-		std::map<DDUIdType,ExaminerStatusType>::const_iterator item = bDDU_ERR.begin();
-		while( item != bDDU_ERR.end() ){ DDUs.push_back(item->first); item++; }
-		return DDUs;
-	}
+  ExaminerStatusType warningsForChamber(CSCIdType chamber) const {
+    std::map<CSCIdType, ExaminerStatusType>::const_iterator item = bCHAMB_WRN.find(chamber);
+    if (item != bCHAMB_WRN.end())
+      return item->second;
+    else
+      return 0;
+  }
 
-	std::map<DDUIdType,ExaminerStatusType> errorsDetailedDDU  (void) const { return bDDU_ERR; }
+  ExaminerStatusType errorsForDDU(DDUIdType dduSourceID) const {
+    std::map<DDUIdType, ExaminerStatusType>::const_iterator item = bDDU_ERR.find(dduSourceID);
+    if (item != bDDU_ERR.end())
+      return item->second;
+    else
+      return 0;
+  }
+  ExaminerStatusType warningsForDDU(DDUIdType dduSourceID) const {
+    std::map<DDUIdType, ExaminerStatusType>::const_iterator item = bDDU_WRN.find(dduSourceID);
+    if (item != bDDU_WRN.end())
+      return item->second;
+    else
+      return 0;
+  }
+  std::vector<DDUIdType> listOfDDUs(void) const {
+    std::vector<DDUIdType> DDUs;
+    std::map<DDUIdType, ExaminerStatusType>::const_iterator item = bDDU_ERR.begin();
+    while (item != bDDU_ERR.end()) {
+      DDUs.push_back(item->first);
+      item++;
+    }
+    return DDUs;
+  }
 
-	std::map<CSCIdType,ExaminerStatusType> errorsDetailed  (void) const { return bCHAMB_ERR; }
-	std::map<CSCIdType,ExaminerStatusType> warningsDetailed(void) const { return bCHAMB_WRN; }
-	std::map<CSCIdType,ExaminerStatusType> payloadDetailed (void) const { return bCHAMB_PAYLOAD; }
-	std::map<CSCIdType,ExaminerStatusType> statusDetailed  (void) const { return bCHAMB_STATUS; }
+  std::map<DDUIdType, ExaminerStatusType> errorsDetailedDDU(void) const { return bDDU_ERR; }
 
-	
+  std::map<CSCIdType, ExaminerStatusType> errorsDetailed(void) const { return bCHAMB_ERR; }
+  std::map<CSCIdType, ExaminerStatusType> warningsDetailed(void) const { return bCHAMB_WRN; }
+  std::map<CSCIdType, ExaminerStatusType> payloadDetailed(void) const { return bCHAMB_PAYLOAD; }
+  std::map<CSCIdType, ExaminerStatusType> statusDetailed(void) const { return bCHAMB_STATUS; }
 
-	void crcALCT(bool enable);
-	void crcTMB (bool enable);
-	void crcCFEB(bool enable);
+  void crcALCT(bool enable);
+  void crcTMB(bool enable);
+  void crcCFEB(bool enable);
 
-	void modeDDU(bool enable);
+  void modeDDU(bool enable);
 
-        bool isDDUmode() {return modeDDUonly;};
+  bool isDDUmode() { return modeDDUonly; };
 
-	DDUIdType dduSourceID(void){ return sourceID; }
+  DDUIdType dduSourceID(void) { return sourceID; }
 
-	std::map<DDUIdType,const uint16_t*>                  DDU_block(void) const { return dduBuffers; }
-	std::map<DDUIdType,std::map<CSCIdType,const uint16_t*> > DMB_block(void) const { return dmbBuffers; }
+  std::map<DDUIdType, const uint16_t*> DDU_block(void) const { return dduBuffers; }
+  std::map<DDUIdType, std::map<CSCIdType, const uint16_t*> > DMB_block(void) const { return dmbBuffers; }
 
-	std::map<DDUIdType,uint32_t>                  DDU_ptrOffsets(void) const { return dduOffsets; }
-	std::map<DDUIdType,std::map<CSCIdType,uint32_t> > DMB_ptrOffsets(void) const { return dmbOffsets; }
+  std::map<DDUIdType, uint32_t> DDU_ptrOffsets(void) const { return dduOffsets; }
+  std::map<DDUIdType, std::map<CSCIdType, uint32_t> > DMB_ptrOffsets(void) const { return dmbOffsets; }
 
-	std::map<DDUIdType,uint32_t>                  DDU_size(void) const { return dduSize; }
-	std::map<DDUIdType,std::map<CSCIdType,uint32_t> > DMB_size(void) const { return dmbSize; }
+  std::map<DDUIdType, uint32_t> DDU_size(void) const { return dduSize; }
+  std::map<DDUIdType, std::map<CSCIdType, uint32_t> > DMB_size(void) const { return dmbSize; }
 
-	CSCDCCExaminer(ExaminerMaskType mask=0x1); 
-	~CSCDCCExaminer(void){}
+  CSCDCCExaminer(ExaminerMaskType mask = 0x1);
+  ~CSCDCCExaminer(void) {}
 };
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCHeader.h
@@ -7,36 +7,33 @@
 
 #include <cstdint>
 #include <cstring>
-#include <string> //for bzero
+#include <string>  //for bzero
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
 
 class CSCDCCHeader {
-
- public:
-  CSCDCCHeader(int bx, int l1a, int sourceId, int version=0);
+public:
+  CSCDCCHeader(int bx, int l1a, int sourceId, int version = 0);
   CSCDCCHeader();
-  CSCDCCHeader(const CSCDCCStatusDigi & digi);
+  CSCDCCHeader(const CSCDCCStatusDigi& digi);
 
-  void setFromBuffer(uint16_t const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(uint16_t const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  int getCDFEventNumber() const; 
-  int getCDFSourceId() const; 
+  int getCDFEventNumber() const;
+  int getCDFSourceId() const;
   int getCDFFOV() const;
   int getCDFEventType() const;
-  int getCDFBunchCounter() const; 
+  int getCDFBunchCounter() const;
   void setDAV(int dduSlot);
-  bool check() const { return true/*dcc_code1==0xD9 && dcc_code2==0x97*/;}
-  unsigned short * data() {return (short unsigned *)word;}
-  static unsigned sizeInWords() {return 8;}
+  bool check() const { return true /*dcc_code1==0xD9 && dcc_code2==0x97*/; }
+  unsigned short* data() { return (short unsigned*)word; }
+  static unsigned sizeInWords() { return 8; }
 
   // gets some data filled by the event data
   friend class CSCDDUEventData;
 
- private:
+private:
   unsigned long long word[2];
-  
+
   /*
   //first line of DCC header definded by CDF (common data format)
   ///http://cmsdoc.cern.ch/cms/TRIDAS/horizontal/
@@ -58,6 +55,5 @@ class CSCDCCHeader {
   unsigned dcc_code2     : 8;
   
   */
-
 };
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCTrailer.h
@@ -5,55 +5,47 @@
 
 #include <iostream>
 #include <cstdint>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
-
 
 /** documented at  http://www.physics.ohio-state.edu/~cms/ddu/ddu2.html
  */
 
 struct CSCDCCTrailer {
-  CSCDCCTrailer() 
-  {
-    bzero(this, sizeInWords()*2);
+  CSCDCCTrailer() {
+    bzero(this, sizeInWords() * 2);
     dcc_trail1 = 0xEF;
     EOE_1 = 0XA;
-    XXXX_1 = 0X0; //@@ Actually a reserved bit. We should not test on it.
-  }
-  
-  CSCDCCTrailer(const CSCDCCStatusDigi & digi)
-  {
-    memcpy(this, digi.trailer(), sizeInWords()*2);
+    XXXX_1 = 0X0;  //@@ Actually a reserved bit. We should not test on it.
   }
 
-  void setFromBuffer(uint16_t const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  CSCDCCTrailer(const CSCDCCStatusDigi& digi) { memcpy(this, digi.trailer(), sizeInWords() * 2); }
+
+  void setFromBuffer(uint16_t const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
   /// for reference www.physics.ohio-state.edu/%7Ecms/dcc/outdatafmt.html
   /// dcc_trail1 should be EF
-  unsigned fifo_status      : 8;
+  unsigned fifo_status : 8;
   unsigned ddu_data_status2 : 24;
   unsigned ddu_data_status1 : 16;
-  unsigned readout_time     : 8;
-  unsigned dcc_trail1       : 8;
+  unsigned readout_time : 8;
+  unsigned dcc_trail1 : 8;
 
-  /// this line defined by CMS CDF 
+  /// this line defined by CMS CDF
   /// http://cmsdoc.cern.ch/cms/TRIDAS/horizontal/
   unsigned dollardollar : 1;
-  unsigned Tx           : 3;
-  unsigned TTS          : 4;
-  unsigned Evt_stat     : 4;
-  unsigned XXXX_2       : 4;
-  unsigned CRC          : 16;
-  unsigned Evt_lgth     : 24;
-  unsigned XXXX_1       : 4;
-  unsigned EOE_1        : 4;
+  unsigned Tx : 3;
+  unsigned TTS : 4;
+  unsigned Evt_stat : 4;
+  unsigned XXXX_2 : 4;
+  unsigned CRC : 16;
+  unsigned Evt_lgth : 24;
+  unsigned XXXX_1 : 4;
+  unsigned EOE_1 : 4;
 
-  static unsigned sizeInWords() {return 8;}
+  static unsigned sizeInWords() { return 8; }
   //@@ The XXXX_1 is a reserved bit in CMS format - we really should not be testing it
-  bool check() const {return (dcc_trail1 == 0xEF) && (EOE_1 == 0XA) && (XXXX_1 == 0X0);}
-  unsigned short * data() {return (unsigned short *) this;}
-
+  bool check() const { return (dcc_trail1 == 0xEF) && (EOE_1 == 0XA) && (XXXX_1 == 0X0); }
+  unsigned short* data() { return (unsigned short*)this; }
 };
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCUnpacker.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCUnpacker.h
@@ -14,41 +14,38 @@
 
 class CSCMonitorInterface;
 
-class CSCDCCUnpacker: public edm::stream::EDProducer<> {
- public:
+class CSCDCCUnpacker : public edm::stream::EDProducer<> {
+public:
   /// Constructor
-  CSCDCCUnpacker(const edm::ParameterSet & pset);
-  
+  CSCDCCUnpacker(const edm::ParameterSet& pset);
+
   /// Destructor
   ~CSCDCCUnpacker() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
-  /// Produce digis out of raw data
-  void produce(edm::Event & e, const edm::EventSetup& c) override;
-  
-  /// Visualization of raw data in FED-less events (Robert Harr and Alexander Sakharov)
-  void visual_raw(int hl,int id, int run, int event, bool fedshort, bool fDump, short unsigned int* buf) const; 
-  
- private:
 
+  /// Produce digis out of raw data
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+
+  /// Visualization of raw data in FED-less events (Robert Harr and Alexander Sakharov)
+  void visual_raw(int hl, int id, int run, int event, bool fedshort, bool fDump, short unsigned int* buf) const;
+
+private:
   bool debug, printEventNumber, goodEvent, useExaminer, unpackStatusDigis;
   bool useSelectiveUnpacking, useFormatStatus;
-  
+
   /// Visualization of raw data
-  bool  visualFEDInspect, visualFEDShort, formatedEventDump;
+  bool visualFEDInspect, visualFEDShort, formatedEventDump;
   /// Suppress zeros LCTs
   bool SuppressZeroLCT;
-  
+
   int numOfEvents;
   unsigned int errorMask, examinerMask;
   bool instantiateDQM;
-  CSCMonitorInterface * monitor;
+  CSCMonitorInterface* monitor;
 
   /// Token for consumes interface & access to data
   edm::EDGetTokenT<FEDRawDataCollection> i_token;
-
-
 };
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUDataItr.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUDataItr.h
@@ -8,7 +8,7 @@
 
 class CSCDDUEventData;
 class CSCEventData;
-#include<vector>
+#include <vector>
 
 class CSCDDUDataItr {
 public:
@@ -16,10 +16,10 @@ public:
   CSCDDUDataItr();
 
   /// construct from data buffer. so makes a new DDUEventData
-  CSCDDUDataItr(const char * buf);
+  CSCDDUDataItr(const char *buf);
 
   /// uses someone else's data, so doesn't delete
-  CSCDDUDataItr(const CSCDDUEventData * dduData);
+  CSCDDUDataItr(const CSCDDUEventData *dduData);
 
   ~CSCDDUDataItr();
 
@@ -29,15 +29,13 @@ public:
 
   bool next();
 
-  const CSCEventData & operator*();
+  const CSCEventData &operator*();
 
 private:
-
-  const CSCDDUEventData * theDDUData;
+  const CSCDDUEventData *theDDUData;
   int theCurrentCSC;
   int theNumberOfCSCs;
   bool theDataIsOwnedByMe;
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
@@ -18,43 +18,41 @@
 
 class CSCDDUEventData {
 public:
-
   explicit CSCDDUEventData(const CSCDDUHeader &);
 
   // buf may need to stay pinned in memory as long
   // as this data is used.  Not sure
-  explicit CSCDDUEventData(const uint16_t *buf, CSCDCCExaminer* examiner=nullptr);
+  explicit CSCDDUEventData(const uint16_t *buf, CSCDCCExaminer *examiner = nullptr);
 
   ~CSCDDUEventData();
 
-  static void setDebug(bool value) {debug = value;} 
-  static void setErrorMask(unsigned int value) {errMask = value;} 
+  static void setDebug(bool value) { debug = value; }
+  static void setErrorMask(unsigned int value) { errMask = value; }
 
   /// accessor to data
-  const std::vector<CSCEventData> & cscData() const {return theData;}
+  const std::vector<CSCEventData> &cscData() const { return theData; }
 
-  CSCDDUHeader header() const {return theDDUHeader;}
-  CSCDDUTrailer trailer() const {return theDDUTrailer;}
-  uint16_t trailer0() const {return theDDUTrailer0;}
+  CSCDDUHeader header() const { return theDDUHeader; }
+  CSCDDUTrailer trailer() const { return theDDUTrailer; }
+  uint16_t trailer0() const { return theDDUTrailer0; }
 
-  CSCDCCHeader dccHeader() const {return theDCCHeader;}
-  CSCDCCTrailer dccTrailer() const {return theDCCTrailer;}
-
+  CSCDCCHeader dccHeader() const { return theDCCHeader; }
+  CSCDCCTrailer dccTrailer() const { return theDCCTrailer; }
 
   /// for making events.  Sets the bxnum and lvl1num inside the chamber event
-    void add(CSCEventData &, int dmbId, int dduInput, unsigned int format_version = 2005);
+  void add(CSCEventData &, int dmbId, int dduInput, unsigned int format_version = 2005);
 
   /// trailer info
   long unsigned int errorstat;
 
   bool check() const;
 
-  /// prints out the error associated with this status 
+  /// prints out the error associated with this status
   /// from the header or trailer
   void decodeStatus(int status) const;
   void decodeStatus() const;
-  int sizeInWords() const {return theSizeInWords;}
-  int size() const {return theSizeInWords*16;} ///Alex check this 16 or 64
+  int sizeInWords() const { return theSizeInWords; }
+  int size() const { return theSizeInWords * 16; }  ///Alex check this 16 or 64
 
   /// returns packed event data
   boost::dynamic_bitset<> pack();
@@ -69,7 +67,7 @@ public:
 
   /// a good test routine would be to unpack data, then pack it again.
 protected:
-  void unpack_data(const uint16_t * buf, CSCDCCExaminer* examiner=nullptr);
+  void unpack_data(const uint16_t *buf, CSCDCCExaminer *examiner = nullptr);
   CSCDCCHeader theDCCHeader;
   CSCDDUHeader theDDUHeader;
   // CSCData is unpacked and stored in this vector

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUHeader.h
@@ -9,76 +9,69 @@
 #include <cstdint>
 
 class CSCDDUHeader {
-
- public:
+public:
   CSCDDUHeader();
   CSCDDUHeader(unsigned bx, unsigned l1num, unsigned sourceId, unsigned fmt_version = 0x6);
-  CSCDDUHeader(const CSCDDUStatusDigi & digi)
-    {
-      memcpy(this, digi.header(), sizeInWords()*2);
-    }
+  CSCDDUHeader(const CSCDDUStatusDigi& digi) { memcpy(this, digi.header(), sizeInWords() * 2); }
 
-  void setFromBuffer(uint16_t const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
-  }
+  void setFromBuffer(uint16_t const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
   // Getters
-  int s_link_status() const { return s_link_status_;}
-  int format_version() const { return format_version_;}
-  int source_id() const { return source_id_;}
-  int bxnum() const { return bxnum_;}
-  int lvl1num() const { return lvl1num_;}
-  int event_type() const { return event_type_;}
-  int ncsc() const { return ncsc_;}
-  int dmb_dav() const { return dmb_dav_;}
-  int dmb_full() const { return dmb_full_;}
-  int live_cscs() const {return live_cscs_;}
-  int output_path_status() const {return output_path_;}
-  static unsigned sizeInWords() {return 12;}
+  int s_link_status() const { return s_link_status_; }
+  int format_version() const { return format_version_; }
+  int source_id() const { return source_id_; }
+  int bxnum() const { return bxnum_; }
+  int lvl1num() const { return lvl1num_; }
+  int event_type() const { return event_type_; }
+  int ncsc() const { return ncsc_; }
+  int dmb_dav() const { return dmb_dav_; }
+  int dmb_full() const { return dmb_full_; }
+  int live_cscs() const { return live_cscs_; }
+  int output_path_status() const { return output_path_; }
+  static unsigned sizeInWords() { return 12; }
 
   // Setters
   void setDMBDAV(int dduInput);
-  void setSourceId(unsigned sourceId) {source_id_ = sourceId;}
-  void setFormatVersion(unsigned version) {format_version_ = version & 0xF;}
-  void setBXN(unsigned bxn) {bxnum_ = bxn & 0xFFF;}
-  void setL1A(unsigned l1a) {lvl1num_ = l1a & 0xFFFFFF;}
-  void setEventType(unsigned evt_type) {event_type_ = evt_type & 0xF;}
-  void setTTSStatus(unsigned status) {tts_status_ = status & 0xF;}
-  void setBOEStatus(unsigned status) {boe_status_ = status & 0x7F;}
-  void setOutputPathStatus(unsigned status) {output_path_ = status & 0xFF;}
+  void setSourceId(unsigned sourceId) { source_id_ = sourceId; }
+  void setFormatVersion(unsigned version) { format_version_ = version & 0xF; }
+  void setBXN(unsigned bxn) { bxnum_ = bxn & 0xFFF; }
+  void setL1A(unsigned l1a) { lvl1num_ = l1a & 0xFFFFFF; }
+  void setEventType(unsigned evt_type) { event_type_ = evt_type & 0xF; }
+  void setTTSStatus(unsigned status) { tts_status_ = status & 0xF; }
+  void setBOEStatus(unsigned status) { boe_status_ = status & 0x7F; }
+  void setOutputPathStatus(unsigned status) { output_path_ = status & 0xFF; }
 
-  unsigned short * data() {return (unsigned short *) this;}
+  unsigned short* data() { return (unsigned short*)this; }
   bool check() const;
 
   // gets some data filled by the event data
   friend class CSCDDUEventData;
- private:
+
+private:
   /// initializes constants
   void init();
-   
-  unsigned s_link_status_  : 4;
-  unsigned format_version_ : 4;
-  unsigned source_id_      : 12;
-  unsigned bxnum_          : 12;
 
-  unsigned lvl1num_        : 24;
-  unsigned event_type_     : 4;
+  unsigned s_link_status_ : 4;
+  unsigned format_version_ : 4;
+  unsigned source_id_ : 12;
+  unsigned bxnum_ : 12;
+
+  unsigned lvl1num_ : 24;
+  unsigned event_type_ : 4;
   /// should always be 5
-  unsigned bit64_          : 4;
+  unsigned bit64_ : 4;
 
   /// should be 8000/0001/8000
-  unsigned dmb_full_  : 16;
+  unsigned dmb_full_ : 16;
   unsigned header2_1_ : 16;
   unsigned header2_2_ : 16;
   unsigned header2_3_ : 16;
- 
 
-  unsigned ncsc_        : 4; 
-  unsigned tts_status_  : 4;
-  unsigned boe_status_  : 8;
-  unsigned dmb_dav_     : 16;
+  unsigned ncsc_ : 4;
+  unsigned tts_status_ : 4;
+  unsigned boe_status_ : 8;
+  unsigned dmb_dav_ : 16;
   unsigned output_path_ : 16;
-  unsigned live_cscs_   : 16;
-
+  unsigned live_cscs_ : 16;
 };
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUTrailer.h
@@ -3,59 +3,46 @@
 
 #include <iostream>
 #include <cstdint>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include "DataFormats/CSCDigi/interface/CSCDDUStatusDigi.h"
 
 /** documented at  http://www.physics.ohio-state.edu/~cms/ddu/ddu2.html
  */
 
-
-
 class CSCDDUTrailer {
+public:
+  CSCDDUTrailer() {
+    bzero(this, sizeInWords() * 2);
+    trailer2_1 = trailer2_2 = trailer2_4 = 0x8000;
+    trailer2_3 = 0xFFFF;
+  }
+  CSCDDUTrailer(const CSCDDUStatusDigi& digi) { memcpy(this, digi.trailer(), sizeInWords() * 2); }
 
- public:
+  void setFromBuffer(uint16_t const* buf) { memcpy(this, buf, sizeInWords() * 2); }
 
-  CSCDDUTrailer() 
-    {
-      bzero(this, sizeInWords()*2);
-      trailer2_1 = trailer2_2 = trailer2_4 = 0x8000;
-      trailer2_3 = 0xFFFF;
-    }
-  CSCDDUTrailer(const CSCDDUStatusDigi & digi)
-    {
-      memcpy(this, digi.trailer(), sizeInWords()*2);
-    }
-  
-  void setFromBuffer(uint16_t const* buf) {
-    memcpy(this, buf, sizeInWords()*2);
+  static unsigned sizeInWords() { return 12; }
+
+  bool check() const {
+    //std::cout << std:: hex << "DDUTRAILER CHECK " << trailer2_1 << " "
+    //      << trailer2_2  << " " << trailer2_3 << " "
+    //      << trailer2_4 << std:: dec << std::endl;
+    return trailer2_1 == 0x8000 && trailer2_2 == 0x8000 && trailer2_3 == 0xFFFF && trailer2_4 == 0x8000;
   }
 
-  static unsigned sizeInWords() {return 12;}
-  
-  bool check() const {
-    //std::cout << std:: hex << "DDUTRAILER CHECK " << trailer2_1 << " " 
-    //      << trailer2_2  << " " << trailer2_3 << " " 
-    //      << trailer2_4 << std:: dec << std::endl;
-    return trailer2_1 == 0x8000 && trailer2_2 == 0x8000
-                   && trailer2_3 == 0xFFFF && trailer2_4 == 0x8000;}
+  unsigned short* data() { return (unsigned short*)this; }
 
-  unsigned short * data() {return (unsigned short *) this;}
-  
-  //These are accessors to use for calling private members    
-  
+  //These are accessors to use for calling private members
+
   unsigned errorstat() const { return errorstat_; }
-  unsigned wordcount() const { return word_count_; }  
-  void setWordCount(unsigned wordcount) {word_count_ = wordcount;}
+  unsigned wordcount() const { return word_count_; }
+  void setWordCount(unsigned wordcount) { word_count_ = wordcount; }
   //@@ Tim: This seems wrong to me so just pull it
   //@@  void setDMBDAV(int dmbId) {dmb_full_ |= (1 << dmbId);}
-  unsigned dmb_warn() const { return dmb_warn_; }  
+  unsigned dmb_warn() const { return dmb_warn_; }
   unsigned dmb_full() const { return dmb_full_; }
-  unsigned reserved() const { return whatever; } 
+  unsigned reserved() const { return whatever; }
 
-  
-  
- private:
-  
+private:
   /// should be 8000/8000/FFFF/8000
   unsigned trailer2_1 : 16;
   unsigned trailer2_2 : 16;
@@ -63,9 +50,9 @@ class CSCDDUTrailer {
   unsigned trailer2_4 : 16;
 
   /// Active DMB Count (4 bits)
-  unsigned dmb_warn_   : 16;
-  unsigned dmb_full_   : 16;
-  unsigned errorstat_  : 32;
+  unsigned dmb_warn_ : 16;
+  unsigned dmb_full_ : 16;
+  unsigned errorstat_ : 32;
 
   // DDU2004
   //  unsigned reserved_bits     : 4;
@@ -92,13 +79,11 @@ class CSCDDUTrailer {
   unsigned word7 : 4;
   unsigned word8 : 4;
 
-
   /// in 64-bit words
   /// DDU_WC = (6 + 25*N_ts*nCFEB + 3*nDMB)
-  unsigned word_count_        : 24;
-  unsigned whatever           : 4;
+  unsigned word_count_ : 24;
+  unsigned whatever : 4;
   ///constant, should be 1010
-  unsigned cms_directive_0xA  : 4;
-
+  unsigned cms_directive_0xA : 4;
 };
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include <memory>
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
@@ -12,21 +12,16 @@
 struct CSCDMBHeader2005;
 struct CSCDMBHeader2013;
 
-class CSCDMBHeader  {
+class CSCDMBHeader {
 public:
-  
   CSCDMBHeader(uint16_t firmware_version = 2005);
-  
-  CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version = 2005);
 
+  CSCDMBHeader(const uint16_t* buf, uint16_t firmware_version = 2005);
 
-
-  bool cfebAvailable(unsigned icfeb) { 
-	return (theHeaderFormat->cfebAvailable() >> icfeb) & 1;
-    }
+  bool cfebAvailable(unsigned icfeb) { return (theHeaderFormat->cfebAvailable() >> icfeb) & 1; }
 
   void addCFEB(int icfeb) { theHeaderFormat->addCFEB(icfeb); }
-  void addNCLCT() { theHeaderFormat->addNCLCT();};  
+  void addNCLCT() { theHeaderFormat->addNCLCT(); };
 
   void addNALCT() { theHeaderFormat->addNALCT(); };
   void setBXN(int bxn) { theHeaderFormat->setBXN(bxn); };
@@ -36,7 +31,7 @@ public:
   void setdmbID(int newDMBID) { theHeaderFormat->setdmbID(newDMBID); };
   void setdmbVersion(unsigned int version) { theHeaderFormat->setdmbVersion(version); };
 
-  unsigned cfebActive() const { return theHeaderFormat->cfebActive(); }; 
+  unsigned cfebActive() const { return theHeaderFormat->cfebActive(); };
   unsigned crateID() const { return theHeaderFormat->crateID(); };
   unsigned dmbID() const { return theHeaderFormat->dmbID(); };
   unsigned bxn() const { return theHeaderFormat->bxn(); };
@@ -52,27 +47,21 @@ public:
 
   unsigned sizeInWords() const { return theHeaderFormat->sizeInWords(); };
   unsigned format_version() const { return theHeaderFormat->format_version(); };
- 
+
   bool check() const { return theHeaderFormat->check(); };
 
-  unsigned short * data() {return theHeaderFormat->data(); };
-  unsigned short * data() const {return theHeaderFormat->data(); };
-
+  unsigned short* data() { return theHeaderFormat->data(); };
+  unsigned short* data() const { return theHeaderFormat->data(); };
 
   //ostream & operator<<(ostream &, const CSCDMBHeader &);
-  
+
   /// will throw if the cast fails
-  CSCDMBHeader2005 dmbHeader2005()   const;
-  CSCDMBHeader2013 dmbHeader2013()   const;
+  CSCDMBHeader2005 dmbHeader2005() const;
+  CSCDMBHeader2013 dmbHeader2013() const;
 
-
- private:
-
+private:
   std::shared_ptr<CSCVDMBHeaderFormat> theHeaderFormat;
   int theFirmwareVersion;
-
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h
@@ -3,17 +3,17 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"
 
-struct CSCDMBHeader2005: public CSCVDMBHeaderFormat  {
-// public:
-  
+struct CSCDMBHeader2005 : public CSCVDMBHeaderFormat {
+  // public:
+
   CSCDMBHeader2005();
-  
-  CSCDMBHeader2005(const uint16_t * buf);
-/*
+
+  CSCDMBHeader2005(const uint16_t *buf);
+  /*
   CSCDMBHeader2005(const CSCDMBStatusDigi & digi)
     {
       memcpy(this, digi.header(), sizeInWords()*2);
@@ -22,16 +22,16 @@ struct CSCDMBHeader2005: public CSCVDMBHeaderFormat  {
   bool cfebAvailable(unsigned icfeb) override;
 
   void addCFEB(int icfeb) override;
-  void addNCLCT() override;  
+  void addNCLCT() override;
   void addNALCT() override;
   void setBXN(int bxn) override;
   void setL1A(int l1a) override;
   void setL1A24(int l1a) override;
   void setCrateAddress(int crate, int dmbId) override;
-  void setdmbID(int newDMBID) override {bits.dmb_id = newDMBID;}
+  void setdmbID(int newDMBID) override { bits.dmb_id = newDMBID; }
   void setdmbVersion(unsigned int version) override {}
 
-  unsigned cfebActive() const override {return bits.cfeb_active;} 
+  unsigned cfebActive() const override { return bits.cfeb_active; }
   unsigned crateID() const override;
   unsigned dmbID() const override;
   unsigned bxn() const override;
@@ -47,78 +47,72 @@ struct CSCDMBHeader2005: public CSCVDMBHeaderFormat  {
   unsigned format_version() const override;
 
   unsigned sizeInWords() const override;
- 
+
   bool check() const override;
 
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  unsigned short * data() const override {return (unsigned short *)(&bits);}
-
+  unsigned short *data() override { return (unsigned short *)(&bits); }
+  unsigned short *data() const override { return (unsigned short *)(&bits); }
 
   //ostream & operator<<(ostream &, const CSCDMBHeader2005 &);
 
-// private:
+  // private:
 
   struct {
+    /// 1st Header word
+    unsigned dmb_l1a_lowo : 12;
+    /// constant, should be 1001
+    unsigned newddu_code_1 : 4;
 
-  /// 1st Header word
-  unsigned dmb_l1a_lowo : 12;
-  /// constant, should be 1001
-  unsigned newddu_code_1 : 4;
+    /// 2nd Header word
+    unsigned dmb_l1a_hiwo : 12;
+    /// constant, should be 1001
+    unsigned newddu_code_2 : 4;
 
-  /// 2nd Header word
-  unsigned dmb_l1a_hiwo : 12;
-  /// constant, should be 1001
-  unsigned newddu_code_2 : 4;
+    /// 3rd Header word
+    unsigned cfeb_dav_1 : 5;
+    unsigned cfeb_active : 5;
+    unsigned alct_dav_4 : 1;
+    unsigned tmb_dav_4 : 1;
+    /// constant, should be 1001
+    unsigned newddu_code_3 : 4;
 
-  /// 3rd Header word
-  unsigned cfeb_dav_1    : 5;
-  unsigned cfeb_active   : 5;
-  unsigned alct_dav_4    : 1;
-  unsigned tmb_dav_4     : 1;
-  /// constant, should be 1001
-  unsigned newddu_code_3 : 4;
+    /// 4th Header word
+    unsigned dmb_bxn1 : 12;
+    /// constant, should be 1001
+    unsigned newddu_code_4 : 4;
 
+    /// 5th Header word
+    unsigned cfeb_dav : 5;             //5
+    unsigned alct_dav_1 : 1;           // start 1
+    unsigned active_dav_mismatch : 1;  // new
+    unsigned tmb_dav_1 : 1;
+    unsigned active_dav_mismatch_2 : 1;  // new
+    unsigned alct_dav_2 : 1;
+    unsigned active_dav_mismatch_3 : 1;  // new
+    unsigned tmb_dav_2 : 1;
+    /// constant, should be '1010'
+    unsigned ddu_code_1 : 4;
 
-  /// 4th Header word
-  unsigned dmb_bxn1      : 12;
-  /// constant, should be 1001
-  unsigned newddu_code_4 : 4;
+    /// 6th Header word
+    unsigned dmb_id : 4;
+    unsigned dmb_crate : 8;
+    /// constant, should be '1010'
+    unsigned ddu_code_2 : 4;
 
-  /// 5th Header word
-  unsigned cfeb_dav   : 5;   //5
-  unsigned alct_dav_1 : 1;   // start 1
-  unsigned active_dav_mismatch : 1;  // new
-  unsigned tmb_dav_1  : 1;
-  unsigned active_dav_mismatch_2 : 1;  // new
-  unsigned alct_dav_2 : 1;
-  unsigned active_dav_mismatch_3 : 1;  // new
-  unsigned tmb_dav_2  : 1;
-  /// constant, should be '1010'
-  unsigned ddu_code_1 : 4;
+    /// 7th Header word
+    unsigned dmb_bxn : 7;
+    /// the time sample for this event has multiple overlaps
+    /// with samples from previous events
+    unsigned cfeb_movlp : 5;
+    /// constant, should be '1010'
+    unsigned ddu_code_3 : 4;
 
-  /// 6th Header word
-  unsigned dmb_id    : 4;
-  unsigned dmb_crate : 8;
-  /// constant, should be '1010'
-  unsigned ddu_code_2: 4;
-
-  /// 7th Header word
-  unsigned dmb_bxn    : 7;
-  /// the time sample for this event has multiple overlaps
-  /// with samples from previous events
-  unsigned cfeb_movlp : 5;
-  /// constant, should be '1010'
-  unsigned ddu_code_3 : 4;
-
-  /// 8th Header word
-  unsigned dmb_l1a       : 8;
-  unsigned dmb_cfeb_sync : 4;
-  /// constant, should be '1010'
-  unsigned ddu_code_4    : 4;
+    /// 8th Header word
+    unsigned dmb_l1a : 8;
+    unsigned dmb_cfeb_sync : 4;
+    /// constant, should be '1010'
+    unsigned ddu_code_4 : 4;
   } bits;
-
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h
@@ -34,20 +34,19 @@
     DMB_CRC:    each DMB generates a 22-bit CRC that encompasses all CSC data from the first 9-code to the last F-code in the event
  */
 
-
 #include <cassert>
 #include <iosfwd>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"
 
-struct CSCDMBHeader2013: public CSCVDMBHeaderFormat  {
-// public:
-  
+struct CSCDMBHeader2013 : public CSCVDMBHeaderFormat {
+  // public:
+
   CSCDMBHeader2013();
-  
-  CSCDMBHeader2013(const uint16_t * buf);
-/*
+
+  CSCDMBHeader2013(const uint16_t *buf);
+  /*
   CSCDMBHeader2013(const CSCDMBStatusDigi & digi)
     {
       memcpy(this, digi.header(), sizeInWords()*2);
@@ -56,16 +55,16 @@ struct CSCDMBHeader2013: public CSCVDMBHeaderFormat  {
   bool cfebAvailable(unsigned icfeb) override;
 
   void addCFEB(int icfeb) override;
-  void addNCLCT() override;  
+  void addNCLCT() override;
   void addNALCT() override;
   void setBXN(int bxn) override;
   void setL1A(int l1a) override;
   void setL1A24(int l1a) override;
   void setCrateAddress(int crate, int dmbId) override;
   void setdmbID(int newDMBID) override { bits.dmb_id = newDMBID; }
-  void setdmbVersion(unsigned int version) override {bits.fmt_version = (version<4) ? version: 0;}
+  void setdmbVersion(unsigned int version) override { bits.fmt_version = (version < 4) ? version : 0; }
 
-  unsigned cfebActive() const override { return bits.cfeb_clct_sent; } 
+  unsigned cfebActive() const override { return bits.cfeb_clct_sent; }
   unsigned crateID() const override;
   unsigned dmbID() const override;
   unsigned bxn() const override;
@@ -81,71 +80,66 @@ struct CSCDMBHeader2013: public CSCVDMBHeaderFormat  {
   unsigned format_version() const override;
 
   unsigned sizeInWords() const override;
- 
+
   bool check() const override;
 
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  unsigned short * data() const override { return (unsigned short *)(&bits);}
-
+  unsigned short *data() override { return (unsigned short *)(&bits); }
+  unsigned short *data() const override { return (unsigned short *)(&bits); }
 
   //ostream & operator<<(ostream &, const CSCDMBHeader &);
 
-// private:
+  // private:
 
   struct {
-  /// 1st Header word
-  unsigned dmb_l1a_lowo : 12; /// DMB_L1A[11:0]   
-  unsigned newddu_code_1 : 4; /// constant, should be 1001
+    /// 1st Header word
+    unsigned dmb_l1a_lowo : 12;  /// DMB_L1A[11:0]
+    unsigned newddu_code_1 : 4;  /// constant, should be 1001
 
-  /// 2nd Header word
-  unsigned dmb_l1a_hiwo : 12; /// DMB_L1A[23:12]
-  unsigned newddu_code_2 : 4; /// constant, should be 1001
+    /// 2nd Header word
+    unsigned dmb_l1a_hiwo : 12;  /// DMB_L1A[23:12]
+    unsigned newddu_code_2 : 4;  /// constant, should be 1001
 
-  /// 3rd Header word
-  unsigned cfeb_clct_sent : 7; 	  /// CFEB_CLCT_SENT(7:1)   
-  unsigned clct_dav_mismatch : 1; /// CLCT-DAV-Mismatch(1)
-  unsigned fmt_version	 : 2;	  /// Fmt_Vers(1:0)
-  unsigned tmb_dav       : 1;     /// TMB_DAV(1)
-  unsigned alct_dav	 : 1;	  /// ALCT_DAV(1) 
-  unsigned newddu_code_3 : 4; /// constant, should be 1001
+    /// 3rd Header word
+    unsigned cfeb_clct_sent : 7;     /// CFEB_CLCT_SENT(7:1)
+    unsigned clct_dav_mismatch : 1;  /// CLCT-DAV-Mismatch(1)
+    unsigned fmt_version : 2;        /// Fmt_Vers(1:0)
+    unsigned tmb_dav : 1;            /// TMB_DAV(1)
+    unsigned alct_dav : 1;           /// ALCT_DAV(1)
+    unsigned newddu_code_3 : 4;      /// constant, should be 1001
 
-  /// 4th Header word
-  unsigned dmb_bxn1     : 12; /// DMB_BXN[11:0] 
-  unsigned newddu_code_4 : 4; /// constant, should be 1001
+    /// 4th Header word
+    unsigned dmb_bxn1 : 12;      /// DMB_BXN[11:0]
+    unsigned newddu_code_4 : 4;  /// constant, should be 1001
 
-  /// 5th Header word 
-  unsigned cfeb_dav   : 7;    	       /// CFEB_DAV(7:1)
-  unsigned clct_dav_mismatch_copy : 1; /// CLCT-DAV-Mismatch(1)
-  unsigned fmt_version_copy   : 2;     /// Fmt_Vers(1:0)
-  unsigned tmb_dav_copy       : 1;     /// TMB_DAV(1)
-  unsigned alct_dav_copy      : 1;     /// ALCT_DAV(1) 
-  unsigned ddu_code_1 : 4;   /// constant, should be '1010'
+    /// 5th Header word
+    unsigned cfeb_dav : 7;                /// CFEB_DAV(7:1)
+    unsigned clct_dav_mismatch_copy : 1;  /// CLCT-DAV-Mismatch(1)
+    unsigned fmt_version_copy : 2;        /// Fmt_Vers(1:0)
+    unsigned tmb_dav_copy : 1;            /// TMB_DAV(1)
+    unsigned alct_dav_copy : 1;           /// ALCT_DAV(1)
+    unsigned ddu_code_1 : 4;              /// constant, should be '1010'
 
-  /// 6th Header word
-  unsigned dmb_id    : 4;    /// DMB_ID(4)		
-  unsigned dmb_crate : 8;    /// DMB_CRATE(8)
-  unsigned ddu_code_2: 4;    /// constant, should be '1010'
+    /// 6th Header word
+    unsigned dmb_id : 4;      /// DMB_ID(4)
+    unsigned dmb_crate : 8;   /// DMB_CRATE(8)
+    unsigned ddu_code_2 : 4;  /// constant, should be '1010'
 
+    /// 7th Header word
+    unsigned dmb_bxn : 5;         /// DMB_BXN[4:0]
+                                  /// the time sample for this event has multiple overlaps
+                                  /// with samples from previous events
+    unsigned cfeb_movlp : 5;      /// CFEB_MOVLP(5:1)
+    unsigned tmb_dav_copy2 : 1;   /// TMB_DAV(1)
+    unsigned alct_dav_copy2 : 1;  /// ALCT_DAV(1)
+    unsigned ddu_code_3 : 4;      /// constant, should be '1010'
 
-  /// 7th Header word
-  unsigned dmb_bxn    : 5;          /// DMB_BXN[4:0]
-		  /// the time sample for this event has multiple overlaps
-		  /// with samples from previous events
-  unsigned cfeb_movlp : 5;   	    /// CFEB_MOVLP(5:1)
-  unsigned tmb_dav_copy2   : 1;     /// TMB_DAV(1)
-  unsigned alct_dav_copy2  : 1;     /// ALCT_DAV(1) 
-  unsigned ddu_code_3 : 4; /// constant, should be '1010'
-
-  /// 8th Header word
-  unsigned dmb_l1a       : 5;		/// DMB_L1A[4:0]
-  unsigned clct_dav_mismatch_copy2 : 1; /// CLCT-DAV-Mismatch(1)
-  unsigned fmt_version_copy2   : 2;     /// Fmt_Vers(1:0)
-  unsigned dmb_cfeb_sync : 4;		/// DMB-CFEB-Sync[3:0]
-  unsigned ddu_code_4    : 4; /// constant, should be '1010'
+    /// 8th Header word
+    unsigned dmb_l1a : 5;                  /// DMB_L1A[4:0]
+    unsigned clct_dav_mismatch_copy2 : 1;  /// CLCT-DAV-Mismatch(1)
+    unsigned fmt_version_copy2 : 2;        /// Fmt_Vers(1:0)
+    unsigned dmb_cfeb_sync : 4;            /// DMB-CFEB-Sync[3:0]
+    unsigned ddu_code_4 : 4;               /// constant, should be '1010'
   } bits;
-
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
@@ -3,27 +3,24 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include <memory>
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 
-
 struct CSCDMBTrailer2005;
 struct CSCDMBTrailer2013;
 
 class CSCDMBTrailer {
 public:
-
   CSCDMBTrailer(uint16_t firmware_version = 2005);
 
-  CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version = 2005);
-
+  CSCDMBTrailer(const uint16_t* buf, uint16_t firmware_version = 2005);
 
   ///@@ NEEDS TO BE DONE
-  void setEventInformation(const CSCDMBHeader & header) { return theTrailerFormat->setEventInformation(header); };
+  void setEventInformation(const CSCDMBHeader& header) { return theTrailerFormat->setEventInformation(header); };
 
   unsigned crateID() const { return theTrailerFormat->crateID(); };
   unsigned dmbID() const { return theTrailerFormat->dmbID(); };
@@ -51,15 +48,15 @@ public:
   unsigned cfeb_half() const { return theTrailerFormat->cfeb_half(); };
 
   unsigned alct_full() const { return theTrailerFormat->alct_full(); };
-  unsigned tmb_full() const {return theTrailerFormat->tmb_full(); };
+  unsigned tmb_full() const { return theTrailerFormat->tmb_full(); };
   unsigned cfeb_full() const { return theTrailerFormat->cfeb_full(); };
-  
+
   unsigned crc22() const { return theTrailerFormat->crc22(); };
   unsigned crc_lo_parity() const { return theTrailerFormat->crc_lo_parity(); };
   unsigned crc_hi_parity() const { return theTrailerFormat->crc_hi_parity(); };
- 
-  unsigned short * data() { return theTrailerFormat->data(); };
-  unsigned short * data() const { return theTrailerFormat->data(); };
+
+  unsigned short* data() { return theTrailerFormat->data(); };
+  unsigned short* data() const { return theTrailerFormat->data(); };
 
   unsigned sizeInWords() const { return theTrailerFormat->sizeInWords(); };
 
@@ -67,15 +64,11 @@ public:
 
   /// will throw if the cast fails
   CSCDMBTrailer2005 dmbTrailer2005() const;
-  CSCDMBTrailer2013 dmbTrailer2013() const;  
+  CSCDMBTrailer2013 dmbTrailer2013() const;
 
-
- private:
-  
+private:
   std::shared_ptr<CSCVDMBTrailerFormat> theTrailerFormat;
   int theFirmwareVersion;
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
@@ -5,33 +5,28 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"
 
-struct CSCDMBTrailer2005: public CSCVDMBTrailerFormat {
-// public:
-  CSCDMBTrailer2005()
-    {
-      bzero(data(), sizeInWords()*2);
-      bits.ddu_code_1 = bits.ddu_code_2 = bits.ddu_code_3 = bits.ddu_code_4 = 0xF;
-      bits.ddu_code_5 = bits.ddu_code_6 = bits.ddu_code_7 = bits.ddu_code_8 = 0xE;
-    }
+struct CSCDMBTrailer2005 : public CSCVDMBTrailerFormat {
+  // public:
+  CSCDMBTrailer2005() {
+    bzero(data(), sizeInWords() * 2);
+    bits.ddu_code_1 = bits.ddu_code_2 = bits.ddu_code_3 = bits.ddu_code_4 = 0xF;
+    bits.ddu_code_5 = bits.ddu_code_6 = bits.ddu_code_7 = bits.ddu_code_8 = 0xE;
+  }
 
-  CSCDMBTrailer2005(const uint16_t * buf)
-    {
-      memcpy(data(), buf, sizeInWords()*2);
-    };
-/*
+  CSCDMBTrailer2005(const uint16_t *buf) { memcpy(data(), buf, sizeInWords() * 2); };
+  /*
   CSCDMBTrailer2005(const CSCDMBStatusDigi & digi) 
     {
       memcpy(this, digi.trailer(), sizeInWords()*2);
     }
 */
   ///@@ NEEDS TO BE DONE
-  void setEventInformation(const CSCDMBHeader & dmbHeader) override 
-   {
-      bits.dmb_id = dmbHeader.dmbID();
-      bits.crate_id = dmbHeader.crateID();
-      bits.dmb_l1a = dmbHeader.l1a();
-      bits.dmb_bxn = dmbHeader.bxn();
-   };
+  void setEventInformation(const CSCDMBHeader &dmbHeader) override {
+    bits.dmb_id = dmbHeader.dmbID();
+    bits.crate_id = dmbHeader.crateID();
+    bits.dmb_l1a = dmbHeader.l1a();
+    bits.dmb_bxn = dmbHeader.bxn();
+  };
 
   unsigned crateID() const override { return bits.crate_id; };
   unsigned dmbID() const override { return bits.dmb_id; };
@@ -51,77 +46,73 @@ struct CSCDMBTrailer2005: public CSCVDMBTrailerFormat {
   unsigned dmb_l1pipe() const override { return bits.dmb_l1pipe; };
 
   unsigned alct_empty() const override { return bits.alct_empty; };
-  unsigned tmb_empty() const override {return bits.tmb_empty; };
+  unsigned tmb_empty() const override { return bits.tmb_empty; };
   unsigned cfeb_empty() const override { return bits.cfeb_empty; };
 
   unsigned alct_half() const override { return bits.alct_half; };
-  unsigned tmb_half() const override {return bits.tmb_half; };
+  unsigned tmb_half() const override { return bits.tmb_half; };
   unsigned cfeb_half() const override { return bits.cfeb_half; };
 
   unsigned alct_full() const override { return bits.alct_full; };
-  unsigned tmb_full() const override {return bits.tmb_full; };
+  unsigned tmb_full() const override { return bits.tmb_full; };
   unsigned cfeb_full() const override { return bits.cfeb_full; };
 
   unsigned crc22() const override { return (bits.dmb_crc_1 | (bits.dmb_crc_2 << 11)); };
   unsigned crc_lo_parity() const override { return bits.dmb_parity_1; };
   unsigned crc_hi_parity() const override { return bits.dmb_parity_2; };
 
+  unsigned short *data() override { return (unsigned short *)(&bits); }
+  unsigned short *data() const override { return (unsigned short *)(&bits); }
 
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  unsigned short * data() const override {return (unsigned short *)(&bits);}
+  bool check() const override {
+    return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF && bits.ddu_code_3 == 0xF && bits.ddu_code_4 == 0xF &&
+           bits.ddu_code_5 == 0xE && bits.ddu_code_6 == 0xE && bits.ddu_code_7 == 0xE && bits.ddu_code_8 == 0xE;
+  }
 
-  bool check() const override {return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF
-                          && bits.ddu_code_3 == 0xF && bits.ddu_code_4 == 0xF
-                          && bits.ddu_code_5 == 0xE && bits.ddu_code_6 == 0xE
-                          && bits.ddu_code_7 == 0xE && bits.ddu_code_8 == 0xE;}
-
-  unsigned sizeInWords() const override {return 8;}
+  unsigned sizeInWords() const override { return 8; }
 
   struct {
-  unsigned dmb_l1a       : 8;
-  unsigned dmb_bxn       : 4;  
-  unsigned ddu_code_1    : 4;
+    unsigned dmb_l1a : 8;
+    unsigned dmb_bxn : 4;
+    unsigned ddu_code_1 : 4;
 
-  unsigned cfeb_half     : 5;
-  unsigned tmb_half      : 1;
-  unsigned alct_half     : 1;
-  unsigned cfeb_movlp    : 5;
-  unsigned ddu_code_2    : 4;
+    unsigned cfeb_half : 5;
+    unsigned tmb_half : 1;
+    unsigned alct_half : 1;
+    unsigned cfeb_movlp : 5;
+    unsigned ddu_code_2 : 4;
 
-  unsigned tmb_starttimeout   : 1;
-  unsigned alct_starttimeout  : 1;
-  unsigned tmb_empty     : 1;
-  unsigned alct_empty    : 1;
-  unsigned dmb_l1pipe    : 8;
-  unsigned ddu_code_3    : 4;
+    unsigned tmb_starttimeout : 1;
+    unsigned alct_starttimeout : 1;
+    unsigned tmb_empty : 1;
+    unsigned alct_empty : 1;
+    unsigned dmb_l1pipe : 8;
+    unsigned ddu_code_3 : 4;
 
-  unsigned cfeb_starttimeout : 5;
-  unsigned tmb_endtimeout    : 1;
-  unsigned alct_endtimeout   : 1; 
-  unsigned cfeb_endtimeout   : 5;
-  unsigned ddu_code_4        : 4;
+    unsigned cfeb_starttimeout : 5;
+    unsigned tmb_endtimeout : 1;
+    unsigned alct_endtimeout : 1;
+    unsigned cfeb_endtimeout : 5;
+    unsigned ddu_code_4 : 4;
 
+    unsigned cfeb_empty : 5;
+    unsigned cfeb_full : 5;
+    unsigned tmb_full : 1;
+    unsigned alct_full : 1;
+    unsigned ddu_code_5 : 4;
 
-  unsigned cfeb_empty    : 5;
-  unsigned cfeb_full     : 5;
-  unsigned tmb_full      : 1;
-  unsigned alct_full     : 1;
-  unsigned ddu_code_5    : 4;
+    unsigned dmb_id : 4;
+    unsigned crate_id : 8;
+    unsigned ddu_code_6 : 4;
 
-  unsigned dmb_id        : 4; 
-  unsigned crate_id      : 8;
-  unsigned ddu_code_6    : 4;
+    unsigned dmb_crc_1 : 11;
+    unsigned dmb_parity_1 : 1;
+    unsigned ddu_code_7 : 4;
 
-  unsigned dmb_crc_1     : 11;
-  unsigned dmb_parity_1  : 1;
-  unsigned ddu_code_7    : 4;
-
-  unsigned dmb_crc_2     : 11;
-  unsigned dmb_parity_2  : 1;
-  unsigned ddu_code_8    : 4;
+    unsigned dmb_crc_2 : 11;
+    unsigned dmb_parity_2 : 1;
+    unsigned ddu_code_8 : 4;
   } bits;
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
@@ -39,21 +39,17 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"
 
-struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
-// public:
-  CSCDMBTrailer2013()
-    {
-      bzero(data(), sizeInWords()*2);
-      bits.ddu_code_1 = bits.ddu_code_2 = bits.ddu_code_3 = bits.ddu_code_4 = 0xF;
-      bits.ddu_code_5 = bits.ddu_code_6 = bits.ddu_code_7 = bits.ddu_code_8 = 0xE;
-    }
- 
-  CSCDMBTrailer2013(const uint16_t * buf)
-    {
-      memcpy(data(), buf, sizeInWords()*2);
-    }
-  
-/*  
+struct CSCDMBTrailer2013 : public CSCVDMBTrailerFormat {
+  // public:
+  CSCDMBTrailer2013() {
+    bzero(data(), sizeInWords() * 2);
+    bits.ddu_code_1 = bits.ddu_code_2 = bits.ddu_code_3 = bits.ddu_code_4 = 0xF;
+    bits.ddu_code_5 = bits.ddu_code_6 = bits.ddu_code_7 = bits.ddu_code_8 = 0xE;
+  }
+
+  CSCDMBTrailer2013(const uint16_t *buf) { memcpy(data(), buf, sizeInWords() * 2); }
+
+  /*  
   CSCDMBTrailer2013(const CSCDMBStatusDigi & digi) 
     {
       memcpy(this, digi.trailer(), sizeInWords()*2);
@@ -61,13 +57,12 @@ struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
 */
 
   ///@@ NEEDS TO BE DONE
-  void setEventInformation(const CSCDMBHeader & dmbHeader) override 
-    {
-	bits.dmb_id = dmbHeader.dmbID();
-        bits.crate_id = dmbHeader.crateID();
-        bits.dmb_l1a = dmbHeader.l1a();
-        bits.dmb_bxn = dmbHeader.bxn();
-    };
+  void setEventInformation(const CSCDMBHeader &dmbHeader) override {
+    bits.dmb_id = dmbHeader.dmbID();
+    bits.crate_id = dmbHeader.crateID();
+    bits.dmb_l1a = dmbHeader.l1a();
+    bits.dmb_bxn = dmbHeader.bxn();
+  };
 
   unsigned crateID() const override { return bits.crate_id; };
   unsigned dmbID() const override { return bits.dmb_id; };
@@ -88,9 +83,8 @@ struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
 
   /// Empty bits don't exists in new format
   unsigned alct_empty() const override { return 0; };
-  unsigned tmb_empty() const override { return 0 ; };
+  unsigned tmb_empty() const override { return 0; };
   unsigned cfeb_empty() const override { return 0; };
-
 
   unsigned alct_half() const override { return bits.alct_half; };
   unsigned tmb_half() const override { return bits.tmb_half; };
@@ -99,71 +93,69 @@ struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
   unsigned alct_full() const override { return bits.alct_full; };
   unsigned tmb_full() const override { return bits.tmb_full; };
   unsigned cfeb_full() const override { return (bits.cfeb_full_lowo | (bits.cfeb_full_hiwo << 3)); };
-  
+
   unsigned crc22() const override { return (bits.dmb_crc_1 | (bits.dmb_crc_2 << 11)); };
   unsigned crc_lo_parity() const override { return bits.dmb_parity_1; };
   unsigned crc_hi_parity() const override { return bits.dmb_parity_2; };
- 
-  unsigned short * data() override { return (unsigned short *)(&bits); }
-  unsigned short * data() const override { return (unsigned short *)(&bits); }
 
-  bool check() const override {return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF
-                          && bits.ddu_code_3 == 0xF && bits.ddu_code_4 == 0xF
-                          && bits.ddu_code_5 == 0xE && bits.ddu_code_6 == 0xE
-                          && bits.ddu_code_7 == 0xE && bits.ddu_code_8 == 0xE;}
+  unsigned short *data() override { return (unsigned short *)(&bits); }
+  unsigned short *data() const override { return (unsigned short *)(&bits); }
+
+  bool check() const override {
+    return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF && bits.ddu_code_3 == 0xF && bits.ddu_code_4 == 0xF &&
+           bits.ddu_code_5 == 0xE && bits.ddu_code_6 == 0xE && bits.ddu_code_7 == 0xE && bits.ddu_code_8 == 0xE;
+  }
 
   unsigned sizeInWords() const override { return 8; }
 
   struct {
-  /// 1st Trailer word
-  unsigned dmb_l1a   	 : 6;  	  /// DMB_L1A[5:0]
-  unsigned dmb_bxn       : 5;     /// DMB_BXN[4:0]
-  unsigned alct_endtimeout : 1;   /// ALCT_End_Timeout(1) 
-  unsigned ddu_code_1    : 4;     /// constant, should be '1111'
+    /// 1st Trailer word
+    unsigned dmb_l1a : 6;          /// DMB_L1A[5:0]
+    unsigned dmb_bxn : 5;          /// DMB_BXN[4:0]
+    unsigned alct_endtimeout : 1;  /// ALCT_End_Timeout(1)
+    unsigned ddu_code_1 : 4;       /// constant, should be '1111'
 
-  /// 2nd Trailer word
-  unsigned cfeb_endtimeout : 7;   /// CFEB_End_Timeout(7:1)
-  unsigned cfeb_movlp    : 5;     /// CFEB_MOVLP(5:1)
-  unsigned ddu_code_2    : 4;     /// constant, should be '1111'
+    /// 2nd Trailer word
+    unsigned cfeb_endtimeout : 7;  /// CFEB_End_Timeout(7:1)
+    unsigned cfeb_movlp : 5;       /// CFEB_MOVLP(5:1)
+    unsigned ddu_code_2 : 4;       /// constant, should be '1111'
 
-  /// 3rd Trailer word
-  unsigned dmb_l1pipe    : 8;     /// DMB_L1PIPE(8)
-  unsigned tmb_starttimeout : 1;  /// TMB_Start_Timeout(1)
-  unsigned cfeb_full_lowo : 3;    /// CFEB_FULL(3:1)
-  unsigned ddu_code_3    : 4;     /// constant, should be '1111'
+    /// 3rd Trailer word
+    unsigned dmb_l1pipe : 8;        /// DMB_L1PIPE(8)
+    unsigned tmb_starttimeout : 1;  /// TMB_Start_Timeout(1)
+    unsigned cfeb_full_lowo : 3;    /// CFEB_FULL(3:1)
+    unsigned ddu_code_3 : 4;        /// constant, should be '1111'
 
-  /// 4th Trailer word
-  unsigned cfeb_full_hiwo    : 4; /// CFEB_FULL(7:4)
-  unsigned cfeb_starttimeout : 7; /// CFEB_Start_Timeout(7:1)
-  unsigned alct_starttimeout : 1; /// ALCT_Start_Timeout(1) 
-  unsigned ddu_code_4        : 4; /// constant, should be '1111'
+    /// 4th Trailer word
+    unsigned cfeb_full_hiwo : 4;     /// CFEB_FULL(7:4)
+    unsigned cfeb_starttimeout : 7;  /// CFEB_Start_Timeout(7:1)
+    unsigned alct_starttimeout : 1;  /// ALCT_Start_Timeout(1)
+    unsigned ddu_code_4 : 4;         /// constant, should be '1111'
 
-  /// 5th Trailer word
-  unsigned cfeb_half     : 7;   /// CFEB_HALF(7:1)
-  unsigned tmb_endtimeout : 1;  /// TMB_End_Timeout(1)
-  unsigned tmb_half 	 : 1;   /// TMB_HALF(1) 
-  unsigned alct_half	 : 1;   /// ALCT_HALF(1)
-  unsigned tmb_full      : 1;   /// TMB_FULL(1)
-  unsigned alct_full     : 1;   /// ALCT_FULL(1)
-  unsigned ddu_code_5    : 4;   /// constant, should be '1110'
+    /// 5th Trailer word
+    unsigned cfeb_half : 7;       /// CFEB_HALF(7:1)
+    unsigned tmb_endtimeout : 1;  /// TMB_End_Timeout(1)
+    unsigned tmb_half : 1;        /// TMB_HALF(1)
+    unsigned alct_half : 1;       /// ALCT_HALF(1)
+    unsigned tmb_full : 1;        /// TMB_FULL(1)
+    unsigned alct_full : 1;       /// ALCT_FULL(1)
+    unsigned ddu_code_5 : 4;      /// constant, should be '1110'
 
-  /// 6th Trailer word
-  unsigned dmb_id        : 4;   /// DMB_ID(4)
-  unsigned crate_id      : 8;   /// DMB_CRATE(8)
-  unsigned ddu_code_6    : 4;   /// constant, should be '1110'
+    /// 6th Trailer word
+    unsigned dmb_id : 4;      /// DMB_ID(4)
+    unsigned crate_id : 8;    /// DMB_CRATE(8)
+    unsigned ddu_code_6 : 4;  /// constant, should be '1110'
 
-  /// 7th Trailer word
-  unsigned dmb_crc_1     : 11;	/// DMB_CRC[10:0]
-  unsigned dmb_parity_1  : 1;   /// DMB_CRC_LowParity(1)
-  unsigned ddu_code_7    : 4;   /// constant, should be '1110'
+    /// 7th Trailer word
+    unsigned dmb_crc_1 : 11;    /// DMB_CRC[10:0]
+    unsigned dmb_parity_1 : 1;  /// DMB_CRC_LowParity(1)
+    unsigned ddu_code_7 : 4;    /// constant, should be '1110'
 
-  /// 8th Trailer word
-  unsigned dmb_crc_2     : 11;	/// DMB_CRC[21:11]
-  unsigned dmb_parity_2  : 1;   /// DMB_CRC_HighParity(1)
-  unsigned ddu_code_8    : 4;   /// constant, should be '1110'
+    /// 8th Trailer word
+    unsigned dmb_crc_2 : 11;    /// DMB_CRC[21:11]
+    unsigned dmb_parity_2 : 1;  /// DMB_CRC_HighParity(1)
+    unsigned ddu_code_8 : 4;    /// constant, should be '1110'
   } bits;
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCDigiValidator.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDigiValidator.h
@@ -33,57 +33,53 @@ class CSCDetId;
 class CSCChamberMap;
 
 class CSCDigiValidator : public edm::EDFilter {
-   public:
-      explicit CSCDigiValidator(const edm::ParameterSet&);
-      ~CSCDigiValidator() override;
+public:
+  explicit CSCDigiValidator(const edm::ParameterSet&);
+  ~CSCDigiValidator() override;
 
-   private:
-      void beginJob() override ;
-      bool filter(edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      
-      std::vector<CSCWireDigi> 
-	sanitizeWireDigis(std::vector<CSCWireDigi>::const_iterator,
-			  std::vector<CSCWireDigi>::const_iterator);
-      std::vector<CSCStripDigi>
-	relabelStripDigis(const CSCChamberMap*,CSCDetId,
-			  std::vector<CSCStripDigi>::const_iterator,
-			  std::vector<CSCStripDigi>::const_iterator);
-      std::vector<CSCStripDigi>
-	sanitizeStripDigis(std::vector<CSCStripDigi>::const_iterator,
-			   std::vector<CSCStripDigi>::const_iterator);
-      std::vector<CSCStripDigi>
-	zeroSupStripDigis(std::vector<CSCStripDigi>::const_iterator,
-			  std::vector<CSCStripDigi>::const_iterator);
-      std::vector<CSCComparatorDigi> 
-	relabelCompDigis(const CSCChamberMap* m, CSCDetId _id,
-			 std::vector<CSCComparatorDigi>::const_iterator b,
-			 std::vector<CSCComparatorDigi>::const_iterator e);
-      std::vector<CSCComparatorDigi>
-	zeroSupCompDigis(std::vector<CSCComparatorDigi>::const_iterator,
-			 std::vector<CSCComparatorDigi>::const_iterator);
+private:
+  void beginJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-      // ----------member data ---------------------------
-      edm::InputTag wire1,strip1,comp1,clct1,alct1,lct1,csctf1,csctfstubs1;
-      edm::InputTag wire2,strip2,comp2,clct2,alct2,lct2,csctf2,csctfstubs2;
+  std::vector<CSCWireDigi> sanitizeWireDigis(std::vector<CSCWireDigi>::const_iterator,
+                                             std::vector<CSCWireDigi>::const_iterator);
+  std::vector<CSCStripDigi> relabelStripDigis(const CSCChamberMap*,
+                                              CSCDetId,
+                                              std::vector<CSCStripDigi>::const_iterator,
+                                              std::vector<CSCStripDigi>::const_iterator);
+  std::vector<CSCStripDigi> sanitizeStripDigis(std::vector<CSCStripDigi>::const_iterator,
+                                               std::vector<CSCStripDigi>::const_iterator);
+  std::vector<CSCStripDigi> zeroSupStripDigis(std::vector<CSCStripDigi>::const_iterator,
+                                              std::vector<CSCStripDigi>::const_iterator);
+  std::vector<CSCComparatorDigi> relabelCompDigis(const CSCChamberMap* m,
+                                                  CSCDetId _id,
+                                                  std::vector<CSCComparatorDigi>::const_iterator b,
+                                                  std::vector<CSCComparatorDigi>::const_iterator e);
+  std::vector<CSCComparatorDigi> zeroSupCompDigis(std::vector<CSCComparatorDigi>::const_iterator,
+                                                  std::vector<CSCComparatorDigi>::const_iterator);
 
-      bool reorderStrips;
+  // ----------member data ---------------------------
+  edm::InputTag wire1, strip1, comp1, clct1, alct1, lct1, csctf1, csctfstubs1;
+  edm::InputTag wire2, strip2, comp2, clct2, alct2, lct2, csctf2, csctfstubs2;
 
-      edm::EDGetTokenT<CSCWireDigiCollection>                   wd1_token;
-      edm::EDGetTokenT<CSCStripDigiCollection>                  sd1_token;
-      edm::EDGetTokenT<CSCComparatorDigiCollection>             cd1_token;
-      edm::EDGetTokenT<CSCALCTDigiCollection>                   al1_token;
-      edm::EDGetTokenT<CSCCLCTDigiCollection>                   cl1_token;
-      edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>          co1_token;
-      edm::EDGetTokenT<L1CSCTrackCollection>                    tr1_token;
-      edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> >  ts1_token;
+  bool reorderStrips;
 
-      edm::EDGetTokenT<CSCWireDigiCollection>                   wd2_token;
-      edm::EDGetTokenT<CSCStripDigiCollection>                  sd2_token;
-      edm::EDGetTokenT<CSCComparatorDigiCollection>             cd2_token;
-      edm::EDGetTokenT<CSCALCTDigiCollection>                   al2_token;
-      edm::EDGetTokenT<CSCCLCTDigiCollection>                   cl2_token;
-      edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>          co2_token;
-      edm::EDGetTokenT<L1CSCTrackCollection>                    tr2_token;
-      edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> >  ts2_token;
+  edm::EDGetTokenT<CSCWireDigiCollection> wd1_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd1_token;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> cd1_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al1_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl1_token;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co1_token;
+  edm::EDGetTokenT<L1CSCTrackCollection> tr1_token;
+  edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> > ts1_token;
+
+  edm::EDGetTokenT<CSCWireDigiCollection> wd2_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd2_token;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> cd2_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al2_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl2_token;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co2_token;
+  edm::EDGetTokenT<L1CSCTrackCollection> tr2_token;
+  edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> > ts2_token;
 };

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -26,82 +26,75 @@ class CSCStripDigi;
 #define MAX_CFEB 7
 
 class CSCEventData {
- public:
+public:
   explicit CSCEventData(int chamberType, uint16_t format_version = 2005);
   /// should make const input soon
-  CSCEventData(const uint16_t * buf, uint16_t format_version = 2005);
-  CSCEventData(){}
+  CSCEventData(const uint16_t *buf, uint16_t format_version = 2005);
+  CSCEventData() {}
   /// since we need deep copies, need the Big Three
   /// (destructor, copy ctor, op=)
   ~CSCEventData();
-  CSCEventData(const CSCEventData & data);
-  CSCEventData operator=(const CSCEventData & data);
+  CSCEventData(const CSCEventData &data);
+  CSCEventData operator=(const CSCEventData &data);
 
   /// size of the data buffer used, in bytes
-  unsigned short size() const {return size_;}
+  unsigned short size() const { return size_; }
 
   /** turns on/off debug flag for this class */
-  static void setDebug(const bool value) {debug = value;}
-
+  static void setDebug(const bool value) { debug = value; }
 
   ///if dealing with ALCT data
-  bool isALCT(const uint16_t * buf);
+  bool isALCT(const uint16_t *buf);
 
   ///if dealing with TMB data
-  bool isTMB(const uint16_t * buf);
-
-
-  
+  bool isTMB(const uint16_t *buf);
 
   /// unpacked in long mode: has overflow and error bits decoded
-  const CSCCFEBData * cfebData(unsigned icfeb) const;
+  const CSCCFEBData *cfebData(unsigned icfeb) const;
 
   /// returns all the strip digis in the chamber, with the comparator information.
-  std::vector<CSCStripDigi> stripDigis(const CSCDetId & idlayer) const;
+  std::vector<CSCStripDigi> stripDigis(const CSCDetId &idlayer) const;
 
   /// returns all the strip digis in the chamber's cfeb
   std::vector<CSCStripDigi> stripDigis(unsigned idlayer, unsigned icfeb) const;
 
-
   /// deprecated.  Use the above methods instead
-  std::vector< std::vector<CSCStripDigi> > stripDigis() const;
-  
+  std::vector<std::vector<CSCStripDigi> > stripDigis() const;
 
   std::vector<CSCWireDigi> wireDigis(unsigned ilayer) const;
   /// deprecated.  Use the above method instead.
-  std::vector< std::vector<CSCWireDigi> > wireDigis() const;
-
+  std::vector<std::vector<CSCWireDigi> > wireDigis() const;
 
   /// the flag for existence of ALCT data
-  int nalct() const {return theDMBHeader.nalct();}
+  int nalct() const { return theDMBHeader.nalct(); }
 
   /// the number of CLCTs
-  int nclct() const {return theDMBHeader.nclct();}
+  int nclct() const { return theDMBHeader.nclct(); }
 
   /// the DAQ motherboard header.  A good place for event and chamber info
-  const CSCDMBHeader * dmbHeader() const {return &theDMBHeader;}
-  CSCDMBHeader * dmbHeader()  {return &theDMBHeader;}
-  
-  /// user must check if nalct > 0
-  CSCALCTHeader * alctHeader() const;
+  const CSCDMBHeader *dmbHeader() const { return &theDMBHeader; }
+  CSCDMBHeader *dmbHeader() { return &theDMBHeader; }
 
   /// user must check if nalct > 0
-  CSCALCTTrailer * alctTrailer() const;
+  CSCALCTHeader *alctHeader() const;
 
   /// user must check if nalct > 0
-  CSCAnodeData * alctData() const;
+  CSCALCTTrailer *alctTrailer() const;
+
+  /// user must check if nalct > 0
+  CSCAnodeData *alctData() const;
 
   ///user must check in nclct > 0
-  CSCTMBData * tmbData() const;
+  CSCTMBData *tmbData() const;
 
   /// user must check if nclct > 0
-  CSCTMBHeader * tmbHeader() const;
+  CSCTMBHeader *tmbHeader() const;
 
   /// user must check if nclct > 0
-  CSCCLCTData * clctData() const;
+  CSCCLCTData *clctData() const;
 
   /// DMB trailer
-  const CSCDMBTrailer * dmbTrailer() const {return &theDMBTrailer;}
+  const CSCDMBTrailer *dmbTrailer() const { return &theDMBTrailer; }
   /// routines to add digis to the data
   void add(const CSCStripDigi &, int layer);
   void add(const CSCWireDigi &, int layer);
@@ -112,24 +105,22 @@ class CSCEventData {
   void add(const std::vector<CSCCLCTDigi> &);
   void add(const std::vector<CSCCorrelatedLCTDigi> &);
 
-  
   /// this will fill the DMB header, and change all related fields in
   /// the DMBTrailer, ALCTHeader, and TMBHeader
   void setEventInformation(int bxnum, int lvl1num);
 
-  /// returns the packed event data. 
+  /// returns the packed event data.
   boost::dynamic_bitset<> pack();
 
   /// adds an empty ALCTHeader, trailer, and anode data
   void addALCTStructures();
 
   /// might not be set in real data
-  int chamberType() const {return theChamberType;}
+  int chamberType() const { return theChamberType; }
 
   uint16_t getFormatVersion() const { return theFormatVersion; }
 
-  unsigned int calcALCTcrc(std::vector< std::pair<unsigned int, unsigned short*> > &vec);
-
+  unsigned int calcALCTcrc(std::vector<std::pair<unsigned int, unsigned short *> > &vec);
 
 #ifdef LOCAL_UNPACK
   static bool debug;
@@ -143,7 +134,7 @@ private:
   /// helpers for ctors, dtor, and op=
   /// zeroes all pointers
   void init();
-  void unpack_data(const uint16_t * buf);
+  void unpack_data(const uint16_t *buf);
   void copy(const CSCEventData &);
   void destroy();
 
@@ -153,20 +144,20 @@ private:
   void checkTMBClasses();
 
   /// adds the comparators to the strip digis
-  void addComparatorInformation(std::vector<CSCStripDigi>&, int layer) const;
+  void addComparatorInformation(std::vector<CSCStripDigi> &, int layer) const;
 
   CSCDMBHeader theDMBHeader;
   //these are empty data objects unless filled in CSCEventData.cc
   /// these may or may not be present.  I decided to make them
   /// dynamic because most CSC chambers don't have LCTs,
   /// therefore don't have data, except for DMB headers and trailers.
-  CSCALCTHeader * theALCTHeader;
-  CSCAnodeData  * theAnodeData;
-  CSCALCTTrailer * theALCTTrailer;
-  CSCTMBData    * theTMBData;
+  CSCALCTHeader *theALCTHeader;
+  CSCAnodeData *theAnodeData;
+  CSCALCTTrailer *theALCTTrailer;
+  CSCTMBData *theTMBData;
 
   /// for up to MAX_CFEB CFEB boards
-  CSCCFEBData * theCFEBData[MAX_CFEB];
+  CSCCFEBData *theCFEBData[MAX_CFEB];
 
   CSCDMBTrailer theDMBTrailer;
 
@@ -174,14 +165,14 @@ private:
   /// this won't be filled when real data is read it.  It's only used when packing
   /// simulated data, so we know how many wire and strip channels to make.
   int theChamberType;
-  
-  /// Auxiliary bufer to recove the ALCT raw payload from zero suppression 
-  unsigned short * alctZSErecovered;
-  int zseEnable; 
+
+  /// Auxiliary bufer to recove the ALCT raw payload from zero suppression
+  unsigned short *alctZSErecovered;
+  int zseEnable;
 
   /// Output Format Version (2005, 2013)
   uint16_t theFormatVersion;
 };
 
-std::ostream & operator<<(std::ostream & os, const CSCEventData & evt);
+std::ostream &operator<<(std::ostream &os, const CSCEventData &evt);
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCMonitorInterface.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCMonitorInterface.h
@@ -10,22 +10,17 @@
  *
  */
 
-
 class CSCDCCEventData;
 class CSCDCCExaminer;
 
-class CSCMonitorInterface{
-
+class CSCMonitorInterface {
 public:
-
-    CSCMonitorInterface(){}
-    virtual ~CSCMonitorInterface(){}
-    // virtual void process(CSCDCCEventData & dccData)=0;
-    virtual void process(CSCDCCExaminer * examiner, CSCDCCEventData * dccData)=0;      
+  CSCMonitorInterface() {}
+  virtual ~CSCMonitorInterface() {}
+  // virtual void process(CSCDCCEventData & dccData)=0;
+  virtual void process(CSCDCCExaminer* examiner, CSCDCCEventData* dccData) = 0;
 
 private:
-
-
 };
 
 #endif

--- a/EventFilter/CSCRawToDigi/interface/CSCRPCData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCRPCData.h
@@ -8,24 +8,23 @@
 
 class CSCRPCDigi;
 
-
 class CSCRPCData {
 public:
   /// default constructor
-  CSCRPCData(int ntbins=7);
+  CSCRPCData(int ntbins = 7);
   // length is in 16-bit words
-  CSCRPCData(const unsigned short *b04buf , int length);
+  CSCRPCData(const unsigned short *b04buf, int length);
 
   std::vector<int> BXN() const;
   std::vector<CSCRPCDigi> digis() const;
   void add(const CSCRPCDigi &);
-  int sizeInWords() {return size_;}
-  int nTbins() {return ntbins_;}
+  int sizeInWords() { return size_; }
+  int nTbins() { return ntbins_; }
   void Print() const;
-  bool check() const {return theData[0]==0x6b04 && theData[size_-1] == 0x6e04;}
+  bool check() const { return theData[0] == 0x6b04 && theData[size_ - 1] == 0x6e04; }
 
-  static void setDebug(bool debugValue) {debug = debugValue;}
-  
+  static void setDebug(bool debugValue) { debug = debugValue; }
+
 private:
 #ifdef LOCAL_UNPACK
   static bool debug;
@@ -34,8 +33,7 @@ private:
 #endif
   int ntbins_;
   int size_;
-  unsigned short theData[2*4*32+2];
+  unsigned short theData[2 * 4 * 32 + 2];
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h
@@ -1,7 +1,7 @@
 //_______________________________________
 //
-//  Class for TMB Logic Analyzer Data  
-//  CSCTMBBlockedCFEB   July 2010 Alexander Sakharov (Wayne State University) 
+//  Class for TMB Logic Analyzer Data
+//  CSCTMBBlockedCFEB   July 2010 Alexander Sakharov (Wayne State University)
 //_______________________________________
 //
 
@@ -11,25 +11,20 @@
 #include <cstdint>
 
 class CSCTMBBlockedCFEB {
-
 public:
-
-  CSCTMBBlockedCFEB() {size_ = 0;}  //default constructor
-  CSCTMBBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB);
-  int getSize() const {return size_;}
-  std::vector<int> getData() const {return BlockedCFEBdata;}
-  std::vector< std::vector<int> > getSingleCFEBList(int CFEBn) const;
+  CSCTMBBlockedCFEB() { size_ = 0; }  //default constructor
+  CSCTMBBlockedCFEB(const uint16_t *buf, int Line6BCB, int Line6ECB);
+  int getSize() const { return size_; }
+  std::vector<int> getData() const { return BlockedCFEBdata; }
+  std::vector<std::vector<int> > getSingleCFEBList(int CFEBn) const;
 
   void print() const;
-  
+
 private:
+  int UnpackBlockedCFEB(const uint16_t *buf, int Line6BCB, int Line6ECB);
 
-  int UnpackBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB);
-
-  std::vector<int> BlockedCFEBdata;     /// stores all mini scope data
+  std::vector<int> BlockedCFEBdata;  /// stores all mini scope data
   unsigned size_;
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBData.h
@@ -1,7 +1,7 @@
 //_______________________________________
 //
-//  Class to group TMB data  
-//  CSCTMBData 9/18/03  B.Mohr           
+//  Class to group TMB data
+//  CSCTMBData 9/18/03  B.Mohr
 //_______________________________________
 //
 
@@ -21,58 +21,53 @@
 #include <atomic>
 #endif
 
-
 class CSCTMBData {
-
- public:
-
+public:
   CSCTMBData();
-  CSCTMBData(int firmwareVersion, int firmwareRevision, int ncfebs=5);
+  CSCTMBData(int firmwareVersion, int firmwareRevision, int ncfebs = 5);
   ~CSCTMBData();
-  CSCTMBData(const uint16_t *buf);
+  CSCTMBData(const uint16_t* buf);
   CSCTMBData(const CSCTMBData& data);
-  int UnpackTMB(const uint16_t *buf);
+  int UnpackTMB(const uint16_t* buf);
   /// sees if the size adds up to the word count
   bool checkSize() const;
-  static void setDebug(const bool value) {debug = value;}
-  short unsigned int   CWordCnt()   const {return cWordCnt;}
-  int getCRC() const {return theTMBTrailer.crc22();}
-  const unsigned short size()       const {return size_;}
+  static void setDebug(const bool value) { debug = value; }
+  short unsigned int CWordCnt() const { return cWordCnt; }
+  int getCRC() const { return theTMBTrailer.crc22(); }
+  const unsigned short size() const { return size_; }
 
-  CSCTMBHeader * tmbHeader()   {return &theTMBHeader;}
-  CSCCLCTData * clctData()     {return &theCLCTData;}
+  CSCTMBHeader* tmbHeader() { return &theTMBHeader; }
+  CSCCLCTData* clctData() { return &theCLCTData; }
   /// check this before using TMB Scope
-  bool hasTMBScope() const { return theTMBScopeIsPresent;}
-  CSCTMBScope & tmbScope() const;
+  bool hasTMBScope() const { return theTMBScopeIsPresent; }
+  CSCTMBScope& tmbScope() const;
   /// check this before using TMB mini scope
   bool hasTMBMiniScope() const { return theTMBMiniScopeIsPresent; }
-  CSCTMBMiniScope & tmbMiniScope() const;
+  CSCTMBMiniScope& tmbMiniScope() const;
   /// check this before TMB Block CFEB
   bool hasTMBBlockedCFEB() const { return theBlockedCFEBIsPresent; }
-  CSCTMBBlockedCFEB & tmbBlockedCFEB() const;
-  CSCTMBTrailer * tmbTrailer() {return &theTMBTrailer;}
+  CSCTMBBlockedCFEB& tmbBlockedCFEB() const;
+  CSCTMBTrailer* tmbTrailer() { return &theTMBTrailer; }
   /// check this before using RPC
-  bool hasRPC() const {return theRPCDataIsPresent;}
-  CSCRPCData * rpcData()       {return &theRPCData;}
+  bool hasRPC() const { return theRPCDataIsPresent; }
+  CSCRPCData* rpcData() { return &theRPCData; }
 
   /// not const because it sets size int TMBTrailer
 
   /// this method is for digi2raw
   boost::dynamic_bitset<> pack();
 
-
-  std::bitset<22> calCRC22(const std::vector< std::bitset<16> >& datain);
+  std::bitset<22> calCRC22(const std::vector<std::bitset<16> >& datain);
   std::bitset<22> nextCRC22_D16(const std::bitset<16>& D, const std::bitset<22>& C);
   int TMBCRCcalc();
-  
+
   /// tests packing
   static void selfTest();
 
- private:
-
+private:
   ///@@ not sure what this means for simulation.  I keep this
   /// around so we can calculate CRCs
-  const uint16_t * theOriginalBuffer;
+  const uint16_t* theOriginalBuffer;
   /// CRC calc needs to know where 0x6B0C and 0x6E0F lines were
   /// we want to put off CRC calc until needed
   unsigned theB0CLine;
@@ -83,15 +78,15 @@ class CSCTMBData {
   CSCRPCData theRPCData;
   /// The TMB scope is not present in most of data hence its dynamic
   bool theTMBScopeIsPresent;
-  CSCTMBScope * theTMBScope;
+  CSCTMBScope* theTMBScope;
 
   /// The TMB MiniScope must presen in every event, hovewer make it dynamic
   /// as for the main scope
   bool theTMBMiniScopeIsPresent;
-  CSCTMBMiniScope * theTMBMiniScope;
+  CSCTMBMiniScope* theTMBMiniScope;
 
   bool theBlockedCFEBIsPresent;
-  CSCTMBBlockedCFEB * theTMBBlockedCFEB;
+  CSCTMBBlockedCFEB* theTMBBlockedCFEB;
 
   CSCTMBTrailer theTMBTrailer;
 #ifdef LOCAL_UNPACK

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -21,137 +21,89 @@ struct CSCTMBHeader2007;
 struct CSCTMBHeader2007_rev0x50c3;
 struct CSCTMBHeader2013;
 
-
 class CSCTMBHeader {
-
- public:
+public:
   CSCTMBHeader(int firmwareVersion, int firmwareRevision);
-  CSCTMBHeader(const CSCTMBStatusDigi & digi);
-  CSCTMBHeader(const unsigned short * buf);
+  CSCTMBHeader(const CSCTMBStatusDigi& digi);
+  CSCTMBHeader(const unsigned short* buf);
 
   /// fills fields like bxn and l1a
-  void setEventInformation(const CSCDMBHeader & dmbHeader)
-  {
-    theHeaderFormat->setEventInformation(dmbHeader);
-  }
+  void setEventInformation(const CSCDMBHeader& dmbHeader) { theHeaderFormat->setEventInformation(dmbHeader); }
 
-  int FirmwareVersion() const {return theFirmwareVersion;}
-  int FirmwareRevision() const {return theHeaderFormat->firmwareRevision();}
-  
+  int FirmwareVersion() const { return theFirmwareVersion; }
+  int FirmwareRevision() const { return theHeaderFormat->firmwareRevision(); }
 
-  uint16_t BXNCount() const {
-    return theHeaderFormat->BXNCount();
-  }
-  uint16_t ALCTMatchTime() const {
-    return theHeaderFormat->ALCTMatchTime();
-  }
-  uint16_t CLCTOnly() const {
-    return theHeaderFormat->CLCTOnly();
-  }
-  uint16_t ALCTOnly() const {
-    return theHeaderFormat->ALCTOnly();
-  }
-  uint16_t TMBMatch() const {
-    return theHeaderFormat->TMBMatch();
-  }
+  uint16_t BXNCount() const { return theHeaderFormat->BXNCount(); }
+  uint16_t ALCTMatchTime() const { return theHeaderFormat->ALCTMatchTime(); }
+  uint16_t CLCTOnly() const { return theHeaderFormat->CLCTOnly(); }
+  uint16_t ALCTOnly() const { return theHeaderFormat->ALCTOnly(); }
+  uint16_t TMBMatch() const { return theHeaderFormat->TMBMatch(); }
 
-  uint16_t Bxn0Diff() const {
-    return theHeaderFormat->Bxn0Diff();
-  }
-  uint16_t Bxn1Diff() const {
-    return theHeaderFormat->Bxn1Diff();
-  }
+  uint16_t Bxn0Diff() const { return theHeaderFormat->Bxn0Diff(); }
+  uint16_t Bxn1Diff() const { return theHeaderFormat->Bxn1Diff(); }
 
-  uint16_t L1ANumber() const {
-    return theHeaderFormat->L1ANumber();
-  }
+  uint16_t L1ANumber() const { return theHeaderFormat->L1ANumber(); }
 
-  uint16_t sizeInBytes() const {
-    return theHeaderFormat->sizeInWords()*2;
-  }
+  uint16_t sizeInBytes() const { return theHeaderFormat->sizeInWords() * 2; }
 
   /// will throw if the cast fails
-  CSCTMBHeader2007 tmbHeader2007()   const;
+  CSCTMBHeader2007 tmbHeader2007() const;
   CSCTMBHeader2007_rev0x50c3 tmbHeader2007_rev0x50c3() const;
-  CSCTMBHeader2006 tmbHeader2006()   const;
-  CSCTMBHeader2013 tmbHeader2013()   const;
+  CSCTMBHeader2006 tmbHeader2006() const;
+  CSCTMBHeader2013 tmbHeader2013() const;
 
-  uint16_t NTBins() const {
-    return theHeaderFormat->NTBins();
-  }
-  uint16_t NCFEBs() const {
-    return theHeaderFormat->NCFEBs();
-  }
+  uint16_t NTBins() const { return theHeaderFormat->NTBins(); }
+  uint16_t NCFEBs() const { return theHeaderFormat->NCFEBs(); }
 
-  uint16_t syncError() const { return theHeaderFormat->syncError();}
-  uint16_t syncErrorCLCT() const { return theHeaderFormat->syncErrorCLCT();}
-  uint16_t syncErrorMPC0() const { return theHeaderFormat->syncErrorMPC0();}
-  uint16_t syncErrorMPC1() const { return theHeaderFormat->syncErrorMPC1();}
+  uint16_t syncError() const { return theHeaderFormat->syncError(); }
+  uint16_t syncErrorCLCT() const { return theHeaderFormat->syncErrorCLCT(); }
+  uint16_t syncErrorMPC0() const { return theHeaderFormat->syncErrorMPC0(); }
+  uint16_t syncErrorMPC1() const { return theHeaderFormat->syncErrorMPC1(); }
 
-
-  void setNCFEBs(uint16_t ncfebs) {
-	theHeaderFormat->setNCFEBs(ncfebs);
-  }
-
+  void setNCFEBs(uint16_t ncfebs) { theHeaderFormat->setNCFEBs(ncfebs); }
 
   ///returns CLCT digis
-  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer)
-  {
-    return theHeaderFormat->CLCTDigis(idlayer);
-  }
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) { return theHeaderFormat->CLCTDigis(idlayer); }
 
   ///returns CorrelatedLCT digis
-  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const
-  {
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const {
     return theHeaderFormat->CorrelatedLCTDigis(idlayer);
   }
-  
+
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const     {return theHeaderFormat->sizeInWords();}
+  unsigned short int sizeInWords() const { return theHeaderFormat->sizeInWords(); }
 
-  unsigned short int NHeaderFrames() const {
-    return theHeaderFormat->NHeaderFrames();
-  }
-  
-  unsigned short * data() {
-    return theHeaderFormat->data();
-  }
-  
+  unsigned short int NHeaderFrames() const { return theHeaderFormat->NHeaderFrames(); }
+
+  unsigned short* data() { return theHeaderFormat->data(); }
+
   /** turns on/off debug flag for this class */
-  static void setDebug(const bool value) {debug = value;}
-  
-  bool check() const {
-     return theHeaderFormat->check();
-  }
+  static void setDebug(const bool value) { debug = value; }
+
+  bool check() const { return theHeaderFormat->check(); }
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  void addCLCT0(const CSCCLCTDigi & digi) {theHeaderFormat->addCLCT0(digi);}
-  void addCLCT1(const CSCCLCTDigi & digi) {theHeaderFormat->addCLCT1(digi);}
-  void addALCT0(const CSCALCTDigi & digi) {theHeaderFormat->addALCT0(digi);}
-  void addALCT1(const CSCALCTDigi & digi) {theHeaderFormat->addALCT1(digi);}
-  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) {
-    theHeaderFormat->addCorrelatedLCT0(digi);
-  }
-  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) {
-    theHeaderFormat->addCorrelatedLCT1(digi);
-  }
+  void addCLCT0(const CSCCLCTDigi& digi) { theHeaderFormat->addCLCT0(digi); }
+  void addCLCT1(const CSCCLCTDigi& digi) { theHeaderFormat->addCLCT1(digi); }
+  void addALCT0(const CSCALCTDigi& digi) { theHeaderFormat->addALCT0(digi); }
+  void addALCT1(const CSCALCTDigi& digi) { theHeaderFormat->addALCT1(digi); }
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) { theHeaderFormat->addCorrelatedLCT0(digi); }
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) { theHeaderFormat->addCorrelatedLCT1(digi); }
 
   /// these methods need more brains to figure which one goes first
-  void add(const std::vector<CSCCLCTDigi> & digis);
-  void add(const std::vector<CSCCorrelatedLCTDigi> & digis);
-
+  void add(const std::vector<CSCCLCTDigi>& digis);
+  void add(const std::vector<CSCCorrelatedLCTDigi>& digis);
 
   /// tests that packing and unpacking give same results
   static void selfTest();
-  
-  friend std::ostream & operator<<(std::ostream & os, const CSCTMBHeader & hdr);
+
+  friend std::ostream& operator<<(std::ostream& os, const CSCTMBHeader& hdr);
 
 private:
-
   //void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
 #ifdef LOCAL_UNPACK
@@ -162,8 +114,6 @@ private:
 
   boost::shared_ptr<CSCVTMBHeaderFormat> theHeaderFormat;
   int theFirmwareVersion;
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
@@ -3,155 +3,154 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
 struct CSCTMBHeader2006 : public CSCVTMBHeaderFormat {
-  enum {NWORDS=27};
+  enum { NWORDS = 27 };
   CSCTMBHeader2006();
-  explicit CSCTMBHeader2006(const unsigned short * buf);
-  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
+  explicit CSCTMBHeader2006(const unsigned short* buf);
+  void setEventInformation(const CSCDMBHeader& dmbHeader) override;
 
-  uint16_t BXNCount() const override {return bits.bxnCount;}
-  uint16_t ALCTMatchTime() const override {return bits.alctMatchTime;}
-  uint16_t CLCTOnly() const override {return bits.clctOnly;}
-  uint16_t ALCTOnly() const override {return bits.alctOnly;}
-  uint16_t TMBMatch() const override {return bits.tmbMatch;}
-  uint16_t Bxn0Diff() const override {return bits.bxn0Diff;}
-  uint16_t Bxn1Diff() const override {return bits.bxn1Diff;}
-  uint16_t L1ANumber() const override {return bits.l1aNumber;}
-  uint16_t NTBins() const override {return bits.nTBins;}
-  uint16_t NCFEBs() const override {return bits.nCFEBs;}
-  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x1F;}
-  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
-  uint16_t syncError() const override {return bits.syncError;}
-  uint16_t syncErrorCLCT() const override {return (bits.clct0_sync_err | bits.clct1_sync_err);}
-  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
-  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t BXNCount() const override { return bits.bxnCount; }
+  uint16_t ALCTMatchTime() const override { return bits.alctMatchTime; }
+  uint16_t CLCTOnly() const override { return bits.clctOnly; }
+  uint16_t ALCTOnly() const override { return bits.alctOnly; }
+  uint16_t TMBMatch() const override { return bits.tmbMatch; }
+  uint16_t Bxn0Diff() const override { return bits.bxn0Diff; }
+  uint16_t Bxn1Diff() const override { return bits.bxn1Diff; }
+  uint16_t L1ANumber() const override { return bits.l1aNumber; }
+  uint16_t NTBins() const override { return bits.nTBins; }
+  uint16_t NCFEBs() const override { return bits.nCFEBs; }
+  void setNCFEBs(uint16_t ncfebs) override { bits.nCFEBs = ncfebs & 0x1F; }
+  uint16_t firmwareRevision() const override { return bits.firmRevCode; }
+  uint16_t syncError() const override { return bits.syncError; }
+  uint16_t syncErrorCLCT() const override { return (bits.clct0_sync_err | bits.clct1_sync_err); }
+  uint16_t syncErrorMPC0() const override { return bits.MPC_Muon0_SyncErr_; }
+  uint16_t syncErrorMPC1() const override { return bits.MPC_Muon1_SyncErr_; }
 
   ///returns CLCT digis
   std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
   std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
- 
+
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const override {return NWORDS;}
+  unsigned short int sizeInWords() const override { return NWORDS; }
 
-  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override { return bits.nHeaderFrames; }
   /// returns the first data word
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  bool check() const override {return bits.e0bline==0x6e0b && NHeaderFrames()+1 == NWORDS;}
+  unsigned short* data() override { return (unsigned short*)(&bits); }
+  bool check() const override { return bits.e0bline == 0x6e0b && NHeaderFrames() + 1 == NWORDS; }
 
   /// for data packing
-  void addCLCT0(const CSCCLCTDigi & digi) override;
-  void addCLCT1(const CSCCLCTDigi & digi) override;
-  void addALCT0(const CSCALCTDigi & digi) override;
-  void addALCT1(const CSCALCTDigi & digi) override;
-  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
-  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
+  void addCLCT0(const CSCCLCTDigi& digi) override;
+  void addCLCT1(const CSCCLCTDigi& digi) override;
+  void addALCT0(const CSCALCTDigi& digi) override;
+  void addALCT1(const CSCALCTDigi& digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  void print(std::ostream & os) const override;
-    struct {
-      unsigned b0cline:16;
-      unsigned nTBins:5, dumpCFEBs:7, fifoMode:3, reserved_1:1;
-      unsigned l1aNumber:4, cscID:4, boardID:5, l1atype:2, reserved_2:1 ;
-      unsigned bxnCount:12, r_type:2, reserved_3:2;
-      unsigned nHeaderFrames:5, nCFEBs:3, hasBuf:1, preTrigTBins:5, reserved_4:2;
-      unsigned l1aTxCounter:4, trigSourceVect:8, hasPreTrig:4;
-      unsigned activeCFEBs:5, CFEBsInstantiated:5, runID:4, reserved_6:2;
-      unsigned bxnPreTrigger:12, syncError:1, reserved_7:3;
+  void print(std::ostream& os) const override;
+  struct {
+    unsigned b0cline : 16;
+    unsigned nTBins : 5, dumpCFEBs : 7, fifoMode : 3, reserved_1 : 1;
+    unsigned l1aNumber : 4, cscID : 4, boardID : 5, l1atype : 2, reserved_2 : 1;
+    unsigned bxnCount : 12, r_type : 2, reserved_3 : 2;
+    unsigned nHeaderFrames : 5, nCFEBs : 3, hasBuf : 1, preTrigTBins : 5, reserved_4 : 2;
+    unsigned l1aTxCounter : 4, trigSourceVect : 8, hasPreTrig : 4;
+    unsigned activeCFEBs : 5, CFEBsInstantiated : 5, runID : 4, reserved_6 : 2;
+    unsigned bxnPreTrigger : 12, syncError : 1, reserved_7 : 3;
 
-      unsigned clct0_valid      :1;
-      unsigned clct0_quality    :3;
-      unsigned clct0_shape      :3;
-      unsigned clct0_strip_type :1;
-      unsigned clct0_bend       :1;
-      unsigned clct0_key        :5;
-      unsigned clct0_cfeb_low   :1;
-      unsigned reserved_8       :1;
+    unsigned clct0_valid : 1;
+    unsigned clct0_quality : 3;
+    unsigned clct0_shape : 3;
+    unsigned clct0_strip_type : 1;
+    unsigned clct0_bend : 1;
+    unsigned clct0_key : 5;
+    unsigned clct0_cfeb_low : 1;
+    unsigned reserved_8 : 1;
 
-      unsigned clct1_valid      :1;
-      unsigned clct1_quality    :3;
-      unsigned clct1_shape      :3;
-      unsigned clct1_strip_type :1;
-      unsigned clct1_bend       :1;
-      unsigned clct1_key        :5;
-      unsigned clct1_cfeb_low   :1;
-      unsigned reserved_9       :1;
+    unsigned clct1_valid : 1;
+    unsigned clct1_quality : 3;
+    unsigned clct1_shape : 3;
+    unsigned clct1_strip_type : 1;
+    unsigned clct1_bend : 1;
+    unsigned clct1_key : 5;
+    unsigned clct1_cfeb_low : 1;
+    unsigned reserved_9 : 1;
 
-      unsigned clct0_cfeb_high  :2;
-      unsigned clct0_bxn        :2;
-      unsigned clct0_sync_err   :1;
-      unsigned clct0_bx0_local  :1;
-      unsigned clct1_cfeb_high  :2;
-      unsigned clct1_bxn        :2;
-      unsigned clct1_sync_err   :1;
-      unsigned clct1_bx0_local  :1;
-      unsigned invalidPattern   :1;
-      unsigned reserved_10      :3;
+    unsigned clct0_cfeb_high : 2;
+    unsigned clct0_bxn : 2;
+    unsigned clct0_sync_err : 1;
+    unsigned clct0_bx0_local : 1;
+    unsigned clct1_cfeb_high : 2;
+    unsigned clct1_bxn : 2;
+    unsigned clct1_sync_err : 1;
+    unsigned clct1_bx0_local : 1;
+    unsigned invalidPattern : 1;
+    unsigned reserved_10 : 3;
 
-      unsigned tmbMatch:1, alctOnly:1, clctOnly:1, bxn0Diff:2, bxn1Diff:2,
-               alctMatchTime:4, reserved_11:5;
+    unsigned tmbMatch : 1, alctOnly : 1, clctOnly : 1, bxn0Diff : 2, bxn1Diff : 2, alctMatchTime : 4, reserved_11 : 5;
 
-      unsigned MPC_Muon0_wire_         : 7;
-      unsigned MPC_Muon0_clct_pattern_ : 4;
-      unsigned MPC_Muon0_quality_      : 4;
-      unsigned reserved_12:1;
+    unsigned MPC_Muon0_wire_ : 7;
+    unsigned MPC_Muon0_clct_pattern_ : 4;
+    unsigned MPC_Muon0_quality_ : 4;
+    unsigned reserved_12 : 1;
 
-      unsigned MPC_Muon0_halfstrip_clct_pattern : 8;
-      unsigned MPC_Muon0_bend_                  : 1;
-      unsigned MPC_Muon0_SyncErr_               : 1;
-      unsigned MPC_Muon0_bx_                    : 1;
-      unsigned MPC_Muon0_bc0_                   : 1;
-      unsigned MPC_Muon0_cscid_low              : 3;
-      unsigned reserved_13:1;
+    unsigned MPC_Muon0_halfstrip_clct_pattern : 8;
+    unsigned MPC_Muon0_bend_ : 1;
+    unsigned MPC_Muon0_SyncErr_ : 1;
+    unsigned MPC_Muon0_bx_ : 1;
+    unsigned MPC_Muon0_bc0_ : 1;
+    unsigned MPC_Muon0_cscid_low : 3;
+    unsigned reserved_13 : 1;
 
-      unsigned MPC_Muon1_wire_         : 7;
-      unsigned MPC_Muon1_clct_pattern_ : 4;
-      unsigned MPC_Muon1_quality_      : 4;
-      unsigned reserved_14:1;
+    unsigned MPC_Muon1_wire_ : 7;
+    unsigned MPC_Muon1_clct_pattern_ : 4;
+    unsigned MPC_Muon1_quality_ : 4;
+    unsigned reserved_14 : 1;
 
-      unsigned MPC_Muon1_halfstrip_clct_pattern : 8;
-      unsigned MPC_Muon1_bend_                  : 1;
-      unsigned MPC_Muon1_SyncErr_               : 1;
-      unsigned MPC_Muon1_bx_                    : 1;
-      unsigned MPC_Muon1_bc0_                   : 1;
-      unsigned MPC_Muon1_cscid_low              : 3;
-      unsigned reserved_15:1;
+    unsigned MPC_Muon1_halfstrip_clct_pattern : 8;
+    unsigned MPC_Muon1_bend_ : 1;
+    unsigned MPC_Muon1_SyncErr_ : 1;
+    unsigned MPC_Muon1_bx_ : 1;
+    unsigned MPC_Muon1_bc0_ : 1;
+    unsigned MPC_Muon1_cscid_low : 3;
+    unsigned reserved_15 : 1;
 
-      unsigned MPC_Muon0_vpf_        : 1;
-      unsigned MPC_Muon0_cscid_bit4  : 1;
-      unsigned MPC_Muon1_vpf_        : 1;
-      unsigned MPC_Muon1_cscid_bit4  : 1;
-      unsigned mpcAcceptLCT0         : 1;
-      unsigned mpcAcceptLCT1         : 1;
-      unsigned reserved_16_1         : 2;
-      unsigned hs_thresh             : 3;
-      unsigned ds_thresh             : 3;
-      unsigned reserved_16_2:2;
+    unsigned MPC_Muon0_vpf_ : 1;
+    unsigned MPC_Muon0_cscid_bit4 : 1;
+    unsigned MPC_Muon1_vpf_ : 1;
+    unsigned MPC_Muon1_cscid_bit4 : 1;
+    unsigned mpcAcceptLCT0 : 1;
+    unsigned mpcAcceptLCT1 : 1;
+    unsigned reserved_16_1 : 2;
+    unsigned hs_thresh : 3;
+    unsigned ds_thresh : 3;
+    unsigned reserved_16_2 : 2;
 
-      unsigned buffer_info_0:16;
-      unsigned r_buf_nbusy:4; unsigned buffer_info_1:12;
-      unsigned buffer_info_2:16;
-      unsigned buffer_info_3:16;
-      unsigned alct_delay:4,clct_width:4,mpc_tx_delay:4,reserved_21:4;
+    unsigned buffer_info_0 : 16;
+    unsigned r_buf_nbusy : 4;
+    unsigned buffer_info_1 : 12;
+    unsigned buffer_info_2 : 16;
+    unsigned buffer_info_3 : 16;
+    unsigned alct_delay : 4, clct_width : 4, mpc_tx_delay : 4, reserved_21 : 4;
 
-      unsigned rpc_exists:2;
-      unsigned rd_rpc_list:2;
-      unsigned rd_nrpcs:2;
-      unsigned rpc_read_enable:1;
-      unsigned r_nlayers_hit_vec:3;
-      unsigned pop_l1a_match_win:4;
-      unsigned reserved_22:2;
+    unsigned rpc_exists : 2;
+    unsigned rd_rpc_list : 2;
+    unsigned rd_nrpcs : 2;
+    unsigned rpc_read_enable : 1;
+    unsigned r_nlayers_hit_vec : 3;
+    unsigned pop_l1a_match_win : 4;
+    unsigned reserved_22 : 2;
 
-      unsigned bd_status :14;  unsigned reserved_23:2;
-      unsigned uptime :14;  unsigned reserved_24:2;
-      unsigned firmRevCode:14, reserved_25:2;
-      unsigned e0bline:16;
-    } bits;
-
+    unsigned bd_status : 14;
+    unsigned reserved_23 : 2;
+    unsigned uptime : 14;
+    unsigned reserved_24 : 2;
+    unsigned firmRevCode : 14, reserved_25 : 2;
+    unsigned e0bline : 16;
+  } bits;
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
@@ -3,108 +3,113 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
 struct CSCTMBHeader2007 : public CSCVTMBHeaderFormat {
-  enum {NWORDS = 43};
+  enum { NWORDS = 43 };
   CSCTMBHeader2007();
-  CSCTMBHeader2007(const unsigned short * buf);
-  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
+  CSCTMBHeader2007(const unsigned short* buf);
+  void setEventInformation(const CSCDMBHeader& dmbHeader) override;
 
-  uint16_t BXNCount() const override {return bits.bxnCount;}
-  uint16_t ALCTMatchTime() const override {return bits.matchWin;}
-  uint16_t CLCTOnly() const override {return bits.clctOnly;}
-  uint16_t ALCTOnly() const override {return bits.alctOnly;}
-  uint16_t TMBMatch() const override {return bits.tmbMatch;}
-  uint16_t Bxn0Diff() const override {return 0;}
-  uint16_t Bxn1Diff() const override {return 0;}
-  uint16_t L1ANumber() const override {return bits.l1aNumber;}
-  uint16_t NTBins() const override {return bits.nTBins;}
-  uint16_t NCFEBs() const override {return bits.nCFEBs;}
-  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x1F;}
-  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
-  uint16_t syncError() const override {return bits.syncError;}
-  uint16_t syncErrorCLCT() const override {return (bits.clct0_sync_err | bits.clct1_sync_err);}
-  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
-  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t BXNCount() const override { return bits.bxnCount; }
+  uint16_t ALCTMatchTime() const override { return bits.matchWin; }
+  uint16_t CLCTOnly() const override { return bits.clctOnly; }
+  uint16_t ALCTOnly() const override { return bits.alctOnly; }
+  uint16_t TMBMatch() const override { return bits.tmbMatch; }
+  uint16_t Bxn0Diff() const override { return 0; }
+  uint16_t Bxn1Diff() const override { return 0; }
+  uint16_t L1ANumber() const override { return bits.l1aNumber; }
+  uint16_t NTBins() const override { return bits.nTBins; }
+  uint16_t NCFEBs() const override { return bits.nCFEBs; }
+  void setNCFEBs(uint16_t ncfebs) override { bits.nCFEBs = ncfebs & 0x1F; }
+  uint16_t firmwareRevision() const override { return bits.firmRevCode; }
+  uint16_t syncError() const override { return bits.syncError; }
+  uint16_t syncErrorCLCT() const override { return (bits.clct0_sync_err | bits.clct1_sync_err); }
+  uint16_t syncErrorMPC0() const override { return bits.MPC_Muon0_SyncErr_; }
+  uint16_t syncErrorMPC1() const override { return bits.MPC_Muon1_SyncErr_; }
 
   ///returns CLCT digis
   std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
   std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
- 
-  
+
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const override     {return NWORDS;}
+  unsigned short int sizeInWords() const override { return NWORDS; }
 
-  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override { return bits.nHeaderFrames; }
   /// returns the first data word
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  bool check() const override {return bits.e0bline==0x6e0b;}
+  unsigned short* data() override { return (unsigned short*)(&bits); }
+  bool check() const override { return bits.e0bline == 0x6e0b; }
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  void addCLCT0(const CSCCLCTDigi & digi) override;
-  void addCLCT1(const CSCCLCTDigi & digi) override;
-  void addALCT0(const CSCALCTDigi & digi) override;
-  void addALCT1(const CSCALCTDigi & digi) override;
-  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
-  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
+  void addCLCT0(const CSCCLCTDigi& digi) override;
+  void addCLCT1(const CSCCLCTDigi& digi) override;
+  void addALCT0(const CSCALCTDigi& digi) override;
+  void addALCT1(const CSCALCTDigi& digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  void print(std::ostream & os) const override;
+  void print(std::ostream& os) const override;
 
   struct {
-    unsigned b0cline:16;
-    unsigned bxnCount:12, dduCode1:3, flag1:1;
-    unsigned l1aNumber:12, dduCode2:3, flag2:1;
-    unsigned readoutCounter:12, dduCode3:3, flag3:1;
-    unsigned boardID:5, cscID:4, runID:4, stackOvf:1, syncError:1, flag4:1;
-    unsigned nHeaderFrames:6, fifoMode:3, r_type:2, l1atype:2, hasBuf:1, bufFull:1, flag5:1;
-    unsigned bd_status:15, flag6:1;
-    unsigned firmRevCode:15, flag7:1;
-    unsigned bxnPreTrigger:12, reserved:3, flag8:1;
-    unsigned preTrigCounterLow:15, flag9:1;
-    unsigned preTrigCounterHigh:15, flag10:1;
-    unsigned clctCounterLow:15, flag11:1;
-    unsigned clctCounterHigh:15, flag12:1;
-    unsigned trigCounterLow:15, flag13:1;
-    unsigned trigCounterHigh:15, flag14:1;
-    unsigned alctCounterLow:15, flag15:1;
-    unsigned alctCounterHigh:15, flag16:1;
-    unsigned uptimeCounterLow:15, flag17:1;
-    unsigned uptimeCounterHigh:15, flag18:1;
-    unsigned nCFEBs:3, nTBins:5, fifoPretrig:5, scopeExists:1, vmeExists:1, flag19:1;
-    unsigned hitThresh:3, pidThresh:4, nphThresh:3, lyrThresh:3, layerTrigEnabled:1, staggerCSC:1, flag20:1;
-    unsigned triadPersist:4, dmbThresh:3, alct_delay:4, clct_width:4, flag21:1;
-    unsigned trigSourceVect:9, r_nlayers_hit_vec:6, flag22:1;
-    unsigned activeCFEBs:5, readCFEBs:5, pop_l1a_match_win:4, layerTriggered:1, flag23:1;
-    unsigned tmbMatch:1, alctOnly:1, clctOnly:1, matchWin:4, noTMBTrig:1, noMPCFrame:1, noMPCResponse:1, reserved1:5, flag24:1;
-    unsigned clct0_valid:1, clct0_quality:3, clct0_shape:4, clct0_bend:1, clct0_key:5, clct0_cfeb_low:1, flag25:1;
-    unsigned clct1_valid:1, clct1_quality:3, clct1_shape:4, clct1_bend:1, clct1_key:5, clct1_cfeb_low:1, flag26:1;
-    unsigned clct0_cfeb_high:2, clct0_bxn:2, clct0_sync_err:1, clct0_bx0_local:1, clct1_cfeb_high:2, clct1_bxn:2, clct1_sync_err:1, clct1_bx0_local:1, clct0Invalid:1, clct1Invalid:1, clct1Busy:1, flag27:1;
-    unsigned alct0Valid:1, alct0Quality:2, alct0Amu:1, alct0Key:7, reserved2:4, flag28:1;
-    unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, reserved3:4, flag29:1;
-    unsigned alctBXN:5, alctSeqStatus:2, alctSEUStatus:2, alctReserved:4, alctCfg:1, reserved4:1, flag30:1;
-    unsigned MPC_Muon0_wire_:7, MPC_Muon0_clct_pattern_:4, MPC_Muon0_quality_:4, flag31:1;
-    unsigned MPC_Muon0_halfstrip_clct_pattern:8, MPC_Muon0_bend_:1, MPC_Muon0_SyncErr_:1, MPC_Muon0_bx_:1, MPC_Muon0_bc0_:1, MPC_Muon0_cscid_low:3, flag32:1;
-    unsigned MPC_Muon1_wire_: 7, MPC_Muon1_clct_pattern_:4, MPC_Muon1_quality_:4, flag33:1;
-    unsigned MPC_Muon1_halfstrip_clct_pattern:8, MPC_Muon1_bend_:1, MPC_Muon1_SyncErr_:1, MPC_Muon1_bx_:1, MPC_Muon1_bc0_:1, MPC_Muon1_cscid_low:3, flag34:1;
-    unsigned MPC_Muon0_vpf_:1, MPC_Muon0_cscid_bit4:1, MPC_Muon1_vpf_:1, MPC_Muon1_cscid_bit4:1, MPCDelay:4, MPCAccept:2, CFEBsEnabled:5, flag35:1;
-    unsigned RPCExists:2, RPCList:2, NRPCs:2, RPCEnable:1, RPCMatch:8, flag36:1;
-    unsigned addrPretrig:12, bufReady:1, reserved5:2, flag37:1;
-    unsigned addrL1a:12, reserved6:3, flag38:1;
-    unsigned reserved7:15, flag39:1;
-    unsigned reserved8:15, flag40:1;
-    unsigned reserved9:15, flag41:1;
-    unsigned e0bline:16;
+    unsigned b0cline : 16;
+    unsigned bxnCount : 12, dduCode1 : 3, flag1 : 1;
+    unsigned l1aNumber : 12, dduCode2 : 3, flag2 : 1;
+    unsigned readoutCounter : 12, dduCode3 : 3, flag3 : 1;
+    unsigned boardID : 5, cscID : 4, runID : 4, stackOvf : 1, syncError : 1, flag4 : 1;
+    unsigned nHeaderFrames : 6, fifoMode : 3, r_type : 2, l1atype : 2, hasBuf : 1, bufFull : 1, flag5 : 1;
+    unsigned bd_status : 15, flag6 : 1;
+    unsigned firmRevCode : 15, flag7 : 1;
+    unsigned bxnPreTrigger : 12, reserved : 3, flag8 : 1;
+    unsigned preTrigCounterLow : 15, flag9 : 1;
+    unsigned preTrigCounterHigh : 15, flag10 : 1;
+    unsigned clctCounterLow : 15, flag11 : 1;
+    unsigned clctCounterHigh : 15, flag12 : 1;
+    unsigned trigCounterLow : 15, flag13 : 1;
+    unsigned trigCounterHigh : 15, flag14 : 1;
+    unsigned alctCounterLow : 15, flag15 : 1;
+    unsigned alctCounterHigh : 15, flag16 : 1;
+    unsigned uptimeCounterLow : 15, flag17 : 1;
+    unsigned uptimeCounterHigh : 15, flag18 : 1;
+    unsigned nCFEBs : 3, nTBins : 5, fifoPretrig : 5, scopeExists : 1, vmeExists : 1, flag19 : 1;
+    unsigned hitThresh : 3, pidThresh : 4, nphThresh : 3, lyrThresh : 3, layerTrigEnabled : 1, staggerCSC : 1,
+        flag20 : 1;
+    unsigned triadPersist : 4, dmbThresh : 3, alct_delay : 4, clct_width : 4, flag21 : 1;
+    unsigned trigSourceVect : 9, r_nlayers_hit_vec : 6, flag22 : 1;
+    unsigned activeCFEBs : 5, readCFEBs : 5, pop_l1a_match_win : 4, layerTriggered : 1, flag23 : 1;
+    unsigned tmbMatch : 1, alctOnly : 1, clctOnly : 1, matchWin : 4, noTMBTrig : 1, noMPCFrame : 1, noMPCResponse : 1,
+        reserved1 : 5, flag24 : 1;
+    unsigned clct0_valid : 1, clct0_quality : 3, clct0_shape : 4, clct0_bend : 1, clct0_key : 5, clct0_cfeb_low : 1,
+        flag25 : 1;
+    unsigned clct1_valid : 1, clct1_quality : 3, clct1_shape : 4, clct1_bend : 1, clct1_key : 5, clct1_cfeb_low : 1,
+        flag26 : 1;
+    unsigned clct0_cfeb_high : 2, clct0_bxn : 2, clct0_sync_err : 1, clct0_bx0_local : 1, clct1_cfeb_high : 2,
+        clct1_bxn : 2, clct1_sync_err : 1, clct1_bx0_local : 1, clct0Invalid : 1, clct1Invalid : 1, clct1Busy : 1,
+        flag27 : 1;
+    unsigned alct0Valid : 1, alct0Quality : 2, alct0Amu : 1, alct0Key : 7, reserved2 : 4, flag28 : 1;
+    unsigned alct1Valid : 1, alct1Quality : 2, alct1Amu : 1, alct1Key : 7, reserved3 : 4, flag29 : 1;
+    unsigned alctBXN : 5, alctSeqStatus : 2, alctSEUStatus : 2, alctReserved : 4, alctCfg : 1, reserved4 : 1,
+        flag30 : 1;
+    unsigned MPC_Muon0_wire_ : 7, MPC_Muon0_clct_pattern_ : 4, MPC_Muon0_quality_ : 4, flag31 : 1;
+    unsigned MPC_Muon0_halfstrip_clct_pattern : 8, MPC_Muon0_bend_ : 1, MPC_Muon0_SyncErr_ : 1, MPC_Muon0_bx_ : 1,
+        MPC_Muon0_bc0_ : 1, MPC_Muon0_cscid_low : 3, flag32 : 1;
+    unsigned MPC_Muon1_wire_ : 7, MPC_Muon1_clct_pattern_ : 4, MPC_Muon1_quality_ : 4, flag33 : 1;
+    unsigned MPC_Muon1_halfstrip_clct_pattern : 8, MPC_Muon1_bend_ : 1, MPC_Muon1_SyncErr_ : 1, MPC_Muon1_bx_ : 1,
+        MPC_Muon1_bc0_ : 1, MPC_Muon1_cscid_low : 3, flag34 : 1;
+    unsigned MPC_Muon0_vpf_ : 1, MPC_Muon0_cscid_bit4 : 1, MPC_Muon1_vpf_ : 1, MPC_Muon1_cscid_bit4 : 1, MPCDelay : 4,
+        MPCAccept : 2, CFEBsEnabled : 5, flag35 : 1;
+    unsigned RPCExists : 2, RPCList : 2, NRPCs : 2, RPCEnable : 1, RPCMatch : 8, flag36 : 1;
+    unsigned addrPretrig : 12, bufReady : 1, reserved5 : 2, flag37 : 1;
+    unsigned addrL1a : 12, reserved6 : 3, flag38 : 1;
+    unsigned reserved7 : 15, flag39 : 1;
+    unsigned reserved8 : 15, flag40 : 1;
+    unsigned reserved9 : 15, flag41 : 1;
+    unsigned e0bline : 16;
   } bits;
-
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
@@ -3,119 +3,125 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
 struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
-  enum {NWORDS = 43};
+  enum { NWORDS = 43 };
   CSCTMBHeader2007_rev0x50c3();
-  CSCTMBHeader2007_rev0x50c3(const unsigned short * buf);
-  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
+  CSCTMBHeader2007_rev0x50c3(const unsigned short* buf);
+  void setEventInformation(const CSCDMBHeader& dmbHeader) override;
 
-  uint16_t BXNCount() const override {return bits.bxnCount;}
-  uint16_t ALCTMatchTime() const override {return bits.matchWin;}
-  uint16_t CLCTOnly() const override {return bits.clctOnly;}
-  uint16_t ALCTOnly() const override {return bits.alctOnly;}
-  uint16_t TMBMatch() const override {return bits.tmbMatch;}
-  uint16_t Bxn0Diff() const override {return 0;}
-  uint16_t Bxn1Diff() const override {return 0;}
-  uint16_t L1ANumber() const override {return bits.l1aNumber;}
-  uint16_t NTBins() const override {return bits.nTBins;}
-  uint16_t NCFEBs() const override {return bits.nCFEBs;}
-  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x1F;}
-  uint16_t syncError() const override {return bits.syncError;}
-  uint16_t syncErrorCLCT() const override {return bits.clct_sync_err;}
-  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
-  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
-  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
+  uint16_t BXNCount() const override { return bits.bxnCount; }
+  uint16_t ALCTMatchTime() const override { return bits.matchWin; }
+  uint16_t CLCTOnly() const override { return bits.clctOnly; }
+  uint16_t ALCTOnly() const override { return bits.alctOnly; }
+  uint16_t TMBMatch() const override { return bits.tmbMatch; }
+  uint16_t Bxn0Diff() const override { return 0; }
+  uint16_t Bxn1Diff() const override { return 0; }
+  uint16_t L1ANumber() const override { return bits.l1aNumber; }
+  uint16_t NTBins() const override { return bits.nTBins; }
+  uint16_t NCFEBs() const override { return bits.nCFEBs; }
+  void setNCFEBs(uint16_t ncfebs) override { bits.nCFEBs = ncfebs & 0x1F; }
+  uint16_t syncError() const override { return bits.syncError; }
+  uint16_t syncErrorCLCT() const override { return bits.clct_sync_err; }
+  uint16_t syncErrorMPC0() const override { return bits.MPC_Muon0_SyncErr_; }
+  uint16_t syncErrorMPC1() const override { return bits.MPC_Muon1_SyncErr_; }
+  uint16_t firmwareRevision() const override { return bits.firmRevCode; }
 
   ///returns CLCT digis
   std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
   std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
- 
-  
+
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const override     {return NWORDS;}
+  unsigned short int sizeInWords() const override { return NWORDS; }
 
-  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override { return bits.nHeaderFrames; }
   /// returns the first data word
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  bool check() const override {return bits.e0bline==0x6e0b;}
+  unsigned short* data() override { return (unsigned short*)(&bits); }
+  bool check() const override { return bits.e0bline == 0x6e0b; }
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  void addCLCT0(const CSCCLCTDigi & digi) override;
-  void addCLCT1(const CSCCLCTDigi & digi) override;
-  void addALCT0(const CSCALCTDigi & digi) override;
-  void addALCT1(const CSCALCTDigi & digi) override;
-  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
-  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
+  void addCLCT0(const CSCCLCTDigi& digi) override;
+  void addCLCT1(const CSCCLCTDigi& digi) override;
+  void addALCT0(const CSCALCTDigi& digi) override;
+  void addALCT1(const CSCALCTDigi& digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  void print(std::ostream & os) const override;
+  void print(std::ostream& os) const override;
 
   struct {
-  // 0
-  unsigned b0cline:16; 
-  unsigned bxnCount:12, dduCode1:3, flag1:1;
-  unsigned l1aNumber:12, dduCode2:3, flag2:1;
-  unsigned readoutCounter:12, dduCode3:3, flag3:1;
-  // 4
-  unsigned boardID:5, cscID:4, runID:4, stackOvf:1, syncError:1, flag4:1;
-  unsigned nHeaderFrames:6, fifoMode:3, r_type:2, l1atype:2, hasBuf:1, bufFull:1, flag5:1;
-  unsigned bd_status:15, flag6:1;
-  unsigned firmRevCode:15, flag7:1;
-  // 8
-  unsigned bxnPreTrigger:12, tmb_clct0_discard:1, tmb_clct1_discard:1, lock_lost:1, flag8:1; 
-  unsigned preTrigCounterLow:15, flag9:1;
-  unsigned preTrigCounterHigh:15, flag10:1;
-  unsigned clctCounterLow:15, flag11:1;
-  // 12
-  unsigned clctCounterHigh:15, flag12:1;
-  unsigned trigCounterLow:15, flag13:1;
-  unsigned trigCounterHigh:15, flag14:1;
-  unsigned alctCounterLow:15, flag15:1;
-  // 16
-  unsigned alctCounterHigh:15, flag16:1;
-  unsigned uptimeCounterLow:15, flag17:1;
-  unsigned uptimeCounterHigh:15, flag18:1;
-  unsigned nCFEBs:3, nTBins:5, fifoPretrig:5, scopeExists:1, vmeExists:1, flag19:1;
-  // 20
-  unsigned hitThresh:3, pidThresh:4, nphThresh:3, pid_thresh_postdrift:4, staggerCSC:1, flag20:1;
-  unsigned triadPersist:4, dmbThresh:3, alct_delay:4, clct_width:4, flag21:1;
-  unsigned trigSourceVect:9, r_nlayers_hit_vec:6, flag22:1;
-  unsigned activeCFEBs:5, readCFEBs:5, pop_l1a_match_win:4, aff_source:1, flag23:1;
-  // 24
-  unsigned tmbMatch:1, alctOnly:1, clctOnly:1, matchWin:4, noALCT:1, oneALCT:1, oneCLCT:1, twoALCT:1, twoCLCT:1, dupeALCT:1, dupeCLCT:1, lctRankErr:1, flag24:1;
-  unsigned clct0_valid:1, clct0_quality:3, clct0_shape:4, clct0_key_low:7, flag25:1;
-  unsigned clct1_valid:1, clct1_quality:3, clct1_shape:4, clct1_key_low:7, flag26:1;
-  unsigned clct0_key_high:1, clct1_key_high:1, clct_bxn:2, clct_sync_err:1,  clct0Invalid:1, clct1Invalid:1, clct1Busy:1, parity_err_cfeb_ram:5, parity_err_rpc:1, parity_err_summary:1, flag27:1;
-  // 28
-  unsigned alct0Valid:1, alct0Quality:2, alct0Amu:1, alct0Key:7, alct_pretrig_win:4, flag28:1;
-  unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, drift_delay:2, bcb_read_enable:1, layerTriggered:1, flag29:1;
-  unsigned alctBXN:5, alct_ecc_err:2, cfeb_badbits_found:5, cfeb_badbits_blocked:1, alct_cfg_done:1, bx0_match:1, flag30:1;
-  unsigned MPC_Muon0_wire_:7, MPC_Muon0_clct_pattern_:4, MPC_Muon0_quality_:4, flag31:1;
-  // 32
-  unsigned MPC_Muon0_halfstrip_clct_pattern:8, MPC_Muon0_bend_:1, MPC_Muon0_SyncErr_:1, MPC_Muon0_bx_:1, MPC_Muon0_bc0_:1, MPC_Muon0_cscid_low:3, flag32:1;
-  unsigned MPC_Muon1_wire_:7, MPC_Muon1_clct_pattern_:4, MPC_Muon1_quality_:4, flag33:1;
-  unsigned MPC_Muon1_halfstrip_clct_pattern:8, MPC_Muon1_bend_:1, MPC_Muon1_SyncErr_:1, MPC_Muon1_bx_:1, MPC_Muon1_bc0_:1, MPC_Muon1_cscid_low:3, flag34:1;
-  unsigned MPC_Muon0_vpf_:1, MPC_Muon0_cscid_bit4:1, MPC_Muon1_vpf_:1, MPC_Muon1_cscid_bit4:1, MPCDelay:4, MPCAccept:2, CFEBsEnabled:5, flag35:1;
-  // 36
-  unsigned RPCList:2, NRPCs:2, RPCEnable:1, fifo_tbins_rpc:5, fifo_pretrig_rpc:5, flag36:1;
-  unsigned r_wr_buf_adr:11, r_wr_buf_ready:1, wr_buf_ready:1, buf_q_full:1, buf_q_empty:1, flag37:1;
-  unsigned r_buf_fence_dist:11, buf_q_ovf_err:1, buf_q_udf_err:1, buf_q_adr_err:1, buf_stalled:1, flag38:1;
-  unsigned buf_fence_cnt:12, reverse_hs_csc:1, reverse_hs_me1a:1, reverse_hs_me1b:1, flag39:1;
-  // 40
-  unsigned buf_fence_cnt_peak:12, trig_source_vect:2, tmb_trig_pulse:1, flag40:1;
-  unsigned tmb_allow_alct:1, tmb_allow_clct:1, tmb_allow_match:1, tmb_allow_alct_ro:1, tmb_allow_clct_ro:1, tmb_allow_match_ro:1, tmb_alct_only_ro:1, tmb_clct_only_ro:1, tmb_match_ro:1, tmb_trig_keep:1, tmb_non_trig_keep:1, lyr_thresh_pretrig:3, layer_trig_en:1, flag41:1;
-  unsigned e0bline:16;
+    // 0
+    unsigned b0cline : 16;
+    unsigned bxnCount : 12, dduCode1 : 3, flag1 : 1;
+    unsigned l1aNumber : 12, dduCode2 : 3, flag2 : 1;
+    unsigned readoutCounter : 12, dduCode3 : 3, flag3 : 1;
+    // 4
+    unsigned boardID : 5, cscID : 4, runID : 4, stackOvf : 1, syncError : 1, flag4 : 1;
+    unsigned nHeaderFrames : 6, fifoMode : 3, r_type : 2, l1atype : 2, hasBuf : 1, bufFull : 1, flag5 : 1;
+    unsigned bd_status : 15, flag6 : 1;
+    unsigned firmRevCode : 15, flag7 : 1;
+    // 8
+    unsigned bxnPreTrigger : 12, tmb_clct0_discard : 1, tmb_clct1_discard : 1, lock_lost : 1, flag8 : 1;
+    unsigned preTrigCounterLow : 15, flag9 : 1;
+    unsigned preTrigCounterHigh : 15, flag10 : 1;
+    unsigned clctCounterLow : 15, flag11 : 1;
+    // 12
+    unsigned clctCounterHigh : 15, flag12 : 1;
+    unsigned trigCounterLow : 15, flag13 : 1;
+    unsigned trigCounterHigh : 15, flag14 : 1;
+    unsigned alctCounterLow : 15, flag15 : 1;
+    // 16
+    unsigned alctCounterHigh : 15, flag16 : 1;
+    unsigned uptimeCounterLow : 15, flag17 : 1;
+    unsigned uptimeCounterHigh : 15, flag18 : 1;
+    unsigned nCFEBs : 3, nTBins : 5, fifoPretrig : 5, scopeExists : 1, vmeExists : 1, flag19 : 1;
+    // 20
+    unsigned hitThresh : 3, pidThresh : 4, nphThresh : 3, pid_thresh_postdrift : 4, staggerCSC : 1, flag20 : 1;
+    unsigned triadPersist : 4, dmbThresh : 3, alct_delay : 4, clct_width : 4, flag21 : 1;
+    unsigned trigSourceVect : 9, r_nlayers_hit_vec : 6, flag22 : 1;
+    unsigned activeCFEBs : 5, readCFEBs : 5, pop_l1a_match_win : 4, aff_source : 1, flag23 : 1;
+    // 24
+    unsigned tmbMatch : 1, alctOnly : 1, clctOnly : 1, matchWin : 4, noALCT : 1, oneALCT : 1, oneCLCT : 1, twoALCT : 1,
+        twoCLCT : 1, dupeALCT : 1, dupeCLCT : 1, lctRankErr : 1, flag24 : 1;
+    unsigned clct0_valid : 1, clct0_quality : 3, clct0_shape : 4, clct0_key_low : 7, flag25 : 1;
+    unsigned clct1_valid : 1, clct1_quality : 3, clct1_shape : 4, clct1_key_low : 7, flag26 : 1;
+    unsigned clct0_key_high : 1, clct1_key_high : 1, clct_bxn : 2, clct_sync_err : 1, clct0Invalid : 1,
+        clct1Invalid : 1, clct1Busy : 1, parity_err_cfeb_ram : 5, parity_err_rpc : 1, parity_err_summary : 1,
+        flag27 : 1;
+    // 28
+    unsigned alct0Valid : 1, alct0Quality : 2, alct0Amu : 1, alct0Key : 7, alct_pretrig_win : 4, flag28 : 1;
+    unsigned alct1Valid : 1, alct1Quality : 2, alct1Amu : 1, alct1Key : 7, drift_delay : 2, bcb_read_enable : 1,
+        layerTriggered : 1, flag29 : 1;
+    unsigned alctBXN : 5, alct_ecc_err : 2, cfeb_badbits_found : 5, cfeb_badbits_blocked : 1, alct_cfg_done : 1,
+        bx0_match : 1, flag30 : 1;
+    unsigned MPC_Muon0_wire_ : 7, MPC_Muon0_clct_pattern_ : 4, MPC_Muon0_quality_ : 4, flag31 : 1;
+    // 32
+    unsigned MPC_Muon0_halfstrip_clct_pattern : 8, MPC_Muon0_bend_ : 1, MPC_Muon0_SyncErr_ : 1, MPC_Muon0_bx_ : 1,
+        MPC_Muon0_bc0_ : 1, MPC_Muon0_cscid_low : 3, flag32 : 1;
+    unsigned MPC_Muon1_wire_ : 7, MPC_Muon1_clct_pattern_ : 4, MPC_Muon1_quality_ : 4, flag33 : 1;
+    unsigned MPC_Muon1_halfstrip_clct_pattern : 8, MPC_Muon1_bend_ : 1, MPC_Muon1_SyncErr_ : 1, MPC_Muon1_bx_ : 1,
+        MPC_Muon1_bc0_ : 1, MPC_Muon1_cscid_low : 3, flag34 : 1;
+    unsigned MPC_Muon0_vpf_ : 1, MPC_Muon0_cscid_bit4 : 1, MPC_Muon1_vpf_ : 1, MPC_Muon1_cscid_bit4 : 1, MPCDelay : 4,
+        MPCAccept : 2, CFEBsEnabled : 5, flag35 : 1;
+    // 36
+    unsigned RPCList : 2, NRPCs : 2, RPCEnable : 1, fifo_tbins_rpc : 5, fifo_pretrig_rpc : 5, flag36 : 1;
+    unsigned r_wr_buf_adr : 11, r_wr_buf_ready : 1, wr_buf_ready : 1, buf_q_full : 1, buf_q_empty : 1, flag37 : 1;
+    unsigned r_buf_fence_dist : 11, buf_q_ovf_err : 1, buf_q_udf_err : 1, buf_q_adr_err : 1, buf_stalled : 1,
+        flag38 : 1;
+    unsigned buf_fence_cnt : 12, reverse_hs_csc : 1, reverse_hs_me1a : 1, reverse_hs_me1b : 1, flag39 : 1;
+    // 40
+    unsigned buf_fence_cnt_peak : 12, trig_source_vect : 2, tmb_trig_pulse : 1, flag40 : 1;
+    unsigned tmb_allow_alct : 1, tmb_allow_clct : 1, tmb_allow_match : 1, tmb_allow_alct_ro : 1, tmb_allow_clct_ro : 1,
+        tmb_allow_match_ro : 1, tmb_alct_only_ro : 1, tmb_clct_only_ro : 1, tmb_match_ro : 1, tmb_trig_keep : 1,
+        tmb_non_trig_keep : 1, lyr_thresh_pretrig : 3, layer_trig_en : 1, flag41 : 1;
+    unsigned e0bline : 16;
   } bits;
-
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
@@ -3,120 +3,127 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
 struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
-  enum {NWORDS = 43};
+  enum { NWORDS = 43 };
   CSCTMBHeader2013();
-  CSCTMBHeader2013(const unsigned short * buf);
-  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
+  CSCTMBHeader2013(const unsigned short* buf);
+  void setEventInformation(const CSCDMBHeader& dmbHeader) override;
 
-  uint16_t BXNCount() const override {return bits.bxnCount;}
-  uint16_t ALCTMatchTime() const override {return bits.matchWin;}
-  uint16_t CLCTOnly() const override {return bits.clctOnly;}
-  uint16_t ALCTOnly() const override {return bits.alctOnly;}
-  uint16_t TMBMatch() const override {return bits.tmbMatch;}
-  uint16_t Bxn0Diff() const override {return 0;}
-  uint16_t Bxn1Diff() const override {return 0;}
-  uint16_t L1ANumber() const override {return bits.l1aNumber;}
-  uint16_t NTBins() const override {return bits.nTBins;}
-  uint16_t NCFEBs() const override {return bits.nCFEBs;}
-  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x7F;}
-  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
-  uint16_t syncError() const override {return bits.syncError;}
-  uint16_t syncErrorCLCT() const override {return bits.clct_sync_err;}
-  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
-  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t BXNCount() const override { return bits.bxnCount; }
+  uint16_t ALCTMatchTime() const override { return bits.matchWin; }
+  uint16_t CLCTOnly() const override { return bits.clctOnly; }
+  uint16_t ALCTOnly() const override { return bits.alctOnly; }
+  uint16_t TMBMatch() const override { return bits.tmbMatch; }
+  uint16_t Bxn0Diff() const override { return 0; }
+  uint16_t Bxn1Diff() const override { return 0; }
+  uint16_t L1ANumber() const override { return bits.l1aNumber; }
+  uint16_t NTBins() const override { return bits.nTBins; }
+  uint16_t NCFEBs() const override { return bits.nCFEBs; }
+  void setNCFEBs(uint16_t ncfebs) override { bits.nCFEBs = ncfebs & 0x7F; }
+  uint16_t firmwareRevision() const override { return bits.firmRevCode; }
+  uint16_t syncError() const override { return bits.syncError; }
+  uint16_t syncErrorCLCT() const override { return bits.clct_sync_err; }
+  uint16_t syncErrorMPC0() const override { return bits.MPC_Muon0_SyncErr_; }
+  uint16_t syncErrorMPC1() const override { return bits.MPC_Muon1_SyncErr_; }
 
   ///returns CLCT digis
   std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
   std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
- 
-  
+
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const override     {return NWORDS;}
+  unsigned short int sizeInWords() const override { return NWORDS; }
 
-  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override { return bits.nHeaderFrames; }
   /// returns the first data word
-  unsigned short * data() override {return (unsigned short *)(&bits);}
-  bool check() const override {return bits.e0bline==0x6e0b;}
+  unsigned short* data() override { return (unsigned short*)(&bits); }
+  bool check() const override { return bits.e0bline == 0x6e0b; }
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  void addCLCT0(const CSCCLCTDigi & digi) override;
-  void addCLCT1(const CSCCLCTDigi & digi) override;
-  void addALCT0(const CSCALCTDigi & digi) override;
-  void addALCT1(const CSCALCTDigi & digi) override;
-  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
-  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
+  void addCLCT0(const CSCCLCTDigi& digi) override;
+  void addCLCT1(const CSCCLCTDigi& digi) override;
+  void addALCT0(const CSCALCTDigi& digi) override;
+  void addALCT1(const CSCALCTDigi& digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  void print(std::ostream & os) const override;
+  void print(std::ostream& os) const override;
 
   struct {
-  // 0
-  unsigned b0cline:16; 
-  unsigned bxnCount:12, dduCode1:3, flag1:1;
-  unsigned l1aNumber:12, dduCode2:3, flag2:1;
-  unsigned readoutCounter:12, dduCode3:3, flag3:1;
-  // 4
-  unsigned boardID:5, cscID:4, runID:4, stackOvf:1, syncError:1, flag4:1;
-  unsigned nHeaderFrames:6, fifoMode:3, r_type:2, l1atype:2, hasBuf:1, bufFull:1, flag5:1;
-  unsigned bd_status:15, flag6:1;
-  unsigned firmRevCode:15, flag7:1;
-  // 8
-  unsigned bxnPreTrigger:12, tmb_clct0_discard:1, tmb_clct1_discard:1, clock_lock_lost:1, flag8:1; 
-  unsigned preTrigCounterLow:15, flag9:1;
-  unsigned preTrigCounterHigh:15, flag10:1;
-  unsigned clctCounterLow:15, flag11:1;
-  // 12
-  unsigned clctCounterHigh:15, flag12:1;
-  unsigned trigCounterLow:15, flag13:1;
-  unsigned trigCounterHigh:15, flag14:1;
-  unsigned alctCounterLow:15, flag15:1;
-  // 16
-  unsigned alctCounterHigh:15, flag16:1;
-  unsigned uptimeCounterLow:15, flag17:1;
-  unsigned uptimeCounterHigh:15, flag18:1;
-  unsigned nCFEBs:3, nTBins:5, fifoPretrig:5, scopeExists:1, vmeExists:1, flag19:1;
-  // 20
-  unsigned hitThresh:3, pidThresh:4, nphThresh:3, pid_thresh_postdrift:4, staggerCSC:1, flag20:1;
-  unsigned triadPersist:4, dmbThresh:3, alct_delay:4, clct_width:4, flag21:1;
-  unsigned trigSourceVect:9, r_nlayers_hit_vec:6, flag22:1;
-  unsigned activeCFEBs:5, readCFEBs:5, pop_l1a_match_win:4, aff_source:1, flag23:1;
-  // 24
-  unsigned tmbMatch:1, alctOnly:1, clctOnly:1, matchWin:4, noALCT:1, oneALCT:1, oneCLCT:1, twoALCT:1, twoCLCT:1, dupeALCT:1, dupeCLCT:1, lctRankErr:1, flag24:1;
-  unsigned clct0_valid:1, clct0_quality:3, clct0_shape:4, clct0_key_low:7, flag25:1;
-  unsigned clct1_valid:1, clct1_quality:3, clct1_shape:4, clct1_key_low:7, flag26:1;
-  unsigned clct0_key_high:1, clct1_key_high:1, clct_bxn:2, clct_sync_err:1,  clct0Invalid:1, clct1Invalid:1, clct1Busy:1, parity_err_cfeb_ram:5, parity_err_rpc:1, parity_err_summary:1, flag27:1;
-  // 28
-  unsigned alct0Valid:1, alct0Quality:2, alct0Amu:1, alct0Key:7, alct_pretrig_win:4, flag28:1;
-  unsigned alct1Valid:1, alct1Quality:2, alct1Amu:1, alct1Key:7, drift_delay:2, bcb_read_enable:1, hs_layer_trig:1, flag29:1;
-  unsigned alctBXN:5, alct_ecc_err:2, cfeb_badbits_found:5, cfeb_badbits_blocked:1, alctCfg:1, bx0_match:1, flag30:1;
-  unsigned MPC_Muon0_wire_:7, MPC_Muon0_clct_pattern_:4, MPC_Muon0_quality_:4, flag31:1;
-  // 32
-  unsigned MPC_Muon0_halfstrip_clct_pattern:8, MPC_Muon0_bend_:1, MPC_Muon0_SyncErr_:1, MPC_Muon0_bx_:1, MPC_Muon0_bc0_:1, MPC_Muon0_cscid_low:3, flag32:1;
-  unsigned MPC_Muon1_wire_:7, MPC_Muon1_clct_pattern_:4, MPC_Muon1_quality_:4, flag33:1;
-  unsigned MPC_Muon1_halfstrip_clct_pattern:8, MPC_Muon1_bend_:1, MPC_Muon1_SyncErr_:1, MPC_Muon1_bx_:1, MPC_Muon1_bc0_:1, MPC_Muon1_cscid_low:3, flag34:1;
-  unsigned MPC_Muon0_vpf_:1, MPC_Muon0_cscid_bit4:1, MPC_Muon1_vpf_:1, MPC_Muon1_cscid_bit4:1, MPCDelay:4, MPCAccept:2, CFEBsEnabled:5, flag35:1;
-  // 36
-  unsigned RPCList:2, NRPCs:2, RPCEnable:1, fifo_tbins_rpc:5, fifo_pretrig_rpc:5, flag36:1;
-  unsigned r_wr_buf_adr:11, r_wr_buf_ready:1, wr_buf_ready:1, buf_q_full:1, buf_q_empty:1, flag37:1;
-  unsigned r_buf_fence_dist:11, buf_q_ovf_err:1, buf_q_udf_err:1, buf_q_adr_err:1, buf_stalled:1, flag38:1;
-  unsigned buf_fence_cnt:12, reverse_hs_csc:1, reverse_hs_me1a:1, reverse_hs_me1b:1, flag39:1;
-  // 40
-  // unsigned buf_fence_cnt_peak:12, reserved8:3, flag40:1;
-  unsigned activeCFEBs_2:2, readCFEBs_2:2, cfeb_badbits_found_2:2, parity_err_cfeb_ram_2:2, CFEBsEnabled_2:2, buf_fence_cnt_is_peak:1, mxcfeb:1, trig_source_vec:2, tmb_trig_pulse:1, flag40:1;
-  unsigned tmb_allow_alct:1, tmb_allow_clct:1, tmb_allow_match:1, tmb_allow_alct_ro:1, tmb_allow_clct_ro:1, tmb_allow_match_ro:1, tmb_alct_only_ro:1, tmb_clct_only_ro:1, tmb_match_ro:1, tmb_trig_keep:1, tmb_non_trig_keep:1, lyr_thresh_pretrig:3, layer_trig_en:1, flag41:1;
-  unsigned e0bline:16;
+    // 0
+    unsigned b0cline : 16;
+    unsigned bxnCount : 12, dduCode1 : 3, flag1 : 1;
+    unsigned l1aNumber : 12, dduCode2 : 3, flag2 : 1;
+    unsigned readoutCounter : 12, dduCode3 : 3, flag3 : 1;
+    // 4
+    unsigned boardID : 5, cscID : 4, runID : 4, stackOvf : 1, syncError : 1, flag4 : 1;
+    unsigned nHeaderFrames : 6, fifoMode : 3, r_type : 2, l1atype : 2, hasBuf : 1, bufFull : 1, flag5 : 1;
+    unsigned bd_status : 15, flag6 : 1;
+    unsigned firmRevCode : 15, flag7 : 1;
+    // 8
+    unsigned bxnPreTrigger : 12, tmb_clct0_discard : 1, tmb_clct1_discard : 1, clock_lock_lost : 1, flag8 : 1;
+    unsigned preTrigCounterLow : 15, flag9 : 1;
+    unsigned preTrigCounterHigh : 15, flag10 : 1;
+    unsigned clctCounterLow : 15, flag11 : 1;
+    // 12
+    unsigned clctCounterHigh : 15, flag12 : 1;
+    unsigned trigCounterLow : 15, flag13 : 1;
+    unsigned trigCounterHigh : 15, flag14 : 1;
+    unsigned alctCounterLow : 15, flag15 : 1;
+    // 16
+    unsigned alctCounterHigh : 15, flag16 : 1;
+    unsigned uptimeCounterLow : 15, flag17 : 1;
+    unsigned uptimeCounterHigh : 15, flag18 : 1;
+    unsigned nCFEBs : 3, nTBins : 5, fifoPretrig : 5, scopeExists : 1, vmeExists : 1, flag19 : 1;
+    // 20
+    unsigned hitThresh : 3, pidThresh : 4, nphThresh : 3, pid_thresh_postdrift : 4, staggerCSC : 1, flag20 : 1;
+    unsigned triadPersist : 4, dmbThresh : 3, alct_delay : 4, clct_width : 4, flag21 : 1;
+    unsigned trigSourceVect : 9, r_nlayers_hit_vec : 6, flag22 : 1;
+    unsigned activeCFEBs : 5, readCFEBs : 5, pop_l1a_match_win : 4, aff_source : 1, flag23 : 1;
+    // 24
+    unsigned tmbMatch : 1, alctOnly : 1, clctOnly : 1, matchWin : 4, noALCT : 1, oneALCT : 1, oneCLCT : 1, twoALCT : 1,
+        twoCLCT : 1, dupeALCT : 1, dupeCLCT : 1, lctRankErr : 1, flag24 : 1;
+    unsigned clct0_valid : 1, clct0_quality : 3, clct0_shape : 4, clct0_key_low : 7, flag25 : 1;
+    unsigned clct1_valid : 1, clct1_quality : 3, clct1_shape : 4, clct1_key_low : 7, flag26 : 1;
+    unsigned clct0_key_high : 1, clct1_key_high : 1, clct_bxn : 2, clct_sync_err : 1, clct0Invalid : 1,
+        clct1Invalid : 1, clct1Busy : 1, parity_err_cfeb_ram : 5, parity_err_rpc : 1, parity_err_summary : 1,
+        flag27 : 1;
+    // 28
+    unsigned alct0Valid : 1, alct0Quality : 2, alct0Amu : 1, alct0Key : 7, alct_pretrig_win : 4, flag28 : 1;
+    unsigned alct1Valid : 1, alct1Quality : 2, alct1Amu : 1, alct1Key : 7, drift_delay : 2, bcb_read_enable : 1,
+        hs_layer_trig : 1, flag29 : 1;
+    unsigned alctBXN : 5, alct_ecc_err : 2, cfeb_badbits_found : 5, cfeb_badbits_blocked : 1, alctCfg : 1,
+        bx0_match : 1, flag30 : 1;
+    unsigned MPC_Muon0_wire_ : 7, MPC_Muon0_clct_pattern_ : 4, MPC_Muon0_quality_ : 4, flag31 : 1;
+    // 32
+    unsigned MPC_Muon0_halfstrip_clct_pattern : 8, MPC_Muon0_bend_ : 1, MPC_Muon0_SyncErr_ : 1, MPC_Muon0_bx_ : 1,
+        MPC_Muon0_bc0_ : 1, MPC_Muon0_cscid_low : 3, flag32 : 1;
+    unsigned MPC_Muon1_wire_ : 7, MPC_Muon1_clct_pattern_ : 4, MPC_Muon1_quality_ : 4, flag33 : 1;
+    unsigned MPC_Muon1_halfstrip_clct_pattern : 8, MPC_Muon1_bend_ : 1, MPC_Muon1_SyncErr_ : 1, MPC_Muon1_bx_ : 1,
+        MPC_Muon1_bc0_ : 1, MPC_Muon1_cscid_low : 3, flag34 : 1;
+    unsigned MPC_Muon0_vpf_ : 1, MPC_Muon0_cscid_bit4 : 1, MPC_Muon1_vpf_ : 1, MPC_Muon1_cscid_bit4 : 1, MPCDelay : 4,
+        MPCAccept : 2, CFEBsEnabled : 5, flag35 : 1;
+    // 36
+    unsigned RPCList : 2, NRPCs : 2, RPCEnable : 1, fifo_tbins_rpc : 5, fifo_pretrig_rpc : 5, flag36 : 1;
+    unsigned r_wr_buf_adr : 11, r_wr_buf_ready : 1, wr_buf_ready : 1, buf_q_full : 1, buf_q_empty : 1, flag37 : 1;
+    unsigned r_buf_fence_dist : 11, buf_q_ovf_err : 1, buf_q_udf_err : 1, buf_q_adr_err : 1, buf_stalled : 1,
+        flag38 : 1;
+    unsigned buf_fence_cnt : 12, reverse_hs_csc : 1, reverse_hs_me1a : 1, reverse_hs_me1b : 1, flag39 : 1;
+    // 40
+    // unsigned buf_fence_cnt_peak:12, reserved8:3, flag40:1;
+    unsigned activeCFEBs_2 : 2, readCFEBs_2 : 2, cfeb_badbits_found_2 : 2, parity_err_cfeb_ram_2 : 2,
+        CFEBsEnabled_2 : 2, buf_fence_cnt_is_peak : 1, mxcfeb : 1, trig_source_vec : 2, tmb_trig_pulse : 1, flag40 : 1;
+    unsigned tmb_allow_alct : 1, tmb_allow_clct : 1, tmb_allow_match : 1, tmb_allow_alct_ro : 1, tmb_allow_clct_ro : 1,
+        tmb_allow_match_ro : 1, tmb_alct_only_ro : 1, tmb_clct_only_ro : 1, tmb_match_ro : 1, tmb_trig_keep : 1,
+        tmb_non_trig_keep : 1, lyr_thresh_pretrig : 3, layer_trig_en : 1, flag41 : 1;
+    unsigned e0bline : 16;
   } bits;
-
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h
@@ -1,7 +1,7 @@
 //_______________________________________
 //
-//  Class for TMB Logic Analyzer Data  
-//  CSCTMBMiniScope   July 2010 Alexander Sakharov (Wayne State University) 
+//  Class for TMB Logic Analyzer Data
+//  CSCTMBMiniScope   July 2010 Alexander Sakharov (Wayne State University)
 //_______________________________________
 //
 
@@ -11,31 +11,26 @@
 #include <map>
 
 class CSCTMBMiniScope {
-
 public:
-
-  CSCTMBMiniScope() {size_ = 0;}  //default constructor
-  CSCTMBMiniScope(const uint16_t *buf,int Line6b07,int Line6E07);
-  int getSize() const {return size_;}
-  int getTbinCount() const {return miniScopeTbinCount;}
-  int getTbinPreTrigger() const {return miniScopeTbinPreTrigger;}
-  std::vector<int> getAdr() const {return miniScopeAdress;}
-  std::vector<int> getData() const {return miniScopeData;}
+  CSCTMBMiniScope() { size_ = 0; }  //default constructor
+  CSCTMBMiniScope(const uint16_t *buf, int Line6b07, int Line6E07);
+  int getSize() const { return size_; }
+  int getTbinCount() const { return miniScopeTbinCount; }
+  int getTbinPreTrigger() const { return miniScopeTbinPreTrigger; }
+  std::vector<int> getAdr() const { return miniScopeAdress; }
+  std::vector<int> getData() const { return miniScopeData; }
   std::vector<int> getChannelsInTbin(int data) const;
 
-  void print() const; /// Print the maped content of the miniscope
-  
+  void print() const;  /// Print the maped content of the miniscope
+
 private:
+  int UnpackMiniScope(const uint16_t *buf, int Line6b07, int Line6E07);
 
-  int UnpackMiniScope(const uint16_t *buf,int Line6b07,int Line6E07);
-
-  std::vector <int> miniScopeAdress;                /// stores all mini scope adresses
-  std::vector <int> miniScopeData;                  /// stores all mini scope data
+  std::vector<int> miniScopeAdress;  /// stores all mini scope adresses
+  std::vector<int> miniScopeData;    /// stores all mini scope data
   int miniScopeTbinCount;
   int miniScopeTbinPreTrigger;
   unsigned size_;
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBScope.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBScope.h
@@ -1,7 +1,7 @@
 //_______________________________________
 //
-//  Class for TMB Logic Analyzer Data  
-//  CSCTMBScope 9/11/03  B.Mohr           
+//  Class for TMB Logic Analyzer Data
+//  CSCTMBScope 9/11/03  B.Mohr
 //_______________________________________
 //
 
@@ -13,30 +13,25 @@
 #endif
 
 class CSCTMBScope {
-
 public:
+  CSCTMBScope() { size_ = 0; }  //default constructor
+  CSCTMBScope(const uint16_t *buf, int b05Line, int e05Line);
+  static unsigned short sizeInWords() { return 1538; }
+  static void setDebug(const bool value) { debug = value; };
 
-  CSCTMBScope() {size_ = 0;}  //default constructor
-  CSCTMBScope(const uint16_t *buf,int b05Line,int e05Line);
-  static unsigned short sizeInWords() {return 1538;}
-  static void setDebug(const bool value) {debug = value;};
-
-  unsigned int data[52];            //scope data for ntuple
-                                    //public for now -- better way?
+  unsigned int data[52];  //scope data for ntuple
+                          //public for now -- better way?
 private:
-
-  int UnpackScope(const uint16_t *buf,int b05Line,int e05Line);
+  int UnpackScope(const uint16_t *buf, int b05Line, int e05Line);
   int GetPretrig(int ich);
 
-  unsigned int scope_ram[256][6];   //stores all scope data
+  unsigned int scope_ram[256][6];  //stores all scope data
   unsigned short size_;
 #ifdef LOCAL_UNPACK
   static bool debug;
 #else
   static std::atomic<bool> debug;
 #endif
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBTrailer.h
@@ -1,7 +1,7 @@
 #ifndef CSCTMBTrailer_h
 #define CSCTMBTrailer_h
 
-#include <cstring> // bzero
+#include <cstring>  // bzero
 #include "DataFormats/CSCDigi/interface/CSCTMBStatusDigi.h"
 #include <cstdint>
 
@@ -25,33 +25,29 @@ D8+CRC22(10)
 D8+WordCount
 */
 
-
-
 class CSCTMBTrailer {
 public:
   /// don't forget to pass in the size of the tmb header + clct data
   CSCTMBTrailer(int wordCount, int firmwareVersion);
 
-  CSCTMBTrailer(const uint16_t * buf, unsigned short int firmwareVersion);
+  CSCTMBTrailer(const uint16_t* buf, unsigned short int firmwareVersion);
 
-  CSCTMBTrailer(const CSCTMBStatusDigi & digi)
-    {
-      memcpy(this, digi.trailer(), sizeInBytes());
-    }
+  CSCTMBTrailer(const CSCTMBStatusDigi& digi) { memcpy(this, digi.trailer(), sizeInBytes()); }
 
-  uint16_t sizeInBytes() const {return 16;}
+  uint16_t sizeInBytes() const { return 16; }
   unsigned int crc22() const;
   void setCRC(int crc);
-  bool check() const {return theData[0]==0x6e0c;}
+  bool check() const { return theData[0] == 0x6e0c; }
   /// in 16-bit frames
-  int sizeInWords() const {return 5+thePadding;}
-  unsigned short * data() {return theData;}
+  int sizeInWords() const { return 5 + thePadding; }
+  unsigned short* data() { return theData; }
 
   int wordCount() const;
   static void selfTest();
+
 private:
-  int crcOffset() const  {return (theFirmwareVersion == 2006 ? 1 : 2) + thePadding;}
-  int de0fOffset() const {return (theFirmwareVersion == 2006 ? 3 : 1) + thePadding;}
+  int crcOffset() const { return (theFirmwareVersion == 2006 ? 1 : 2) + thePadding; }
+  int de0fOffset() const { return (theFirmwareVersion == 2006 ? 3 : 1) + thePadding; }
 
   unsigned short theData[7];
   int thePadding;
@@ -59,4 +55,3 @@ private:
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h
@@ -3,22 +3,21 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 
-class CSCVDMBHeaderFormat  {
+class CSCVDMBHeaderFormat {
 public:
-
-  virtual ~CSCVDMBHeaderFormat() {};
-/*
+  virtual ~CSCVDMBHeaderFormat(){};
+  /*
   void init() {
     bzero(this, sizeInWords()*2);
   }
 */
-  
+
   virtual bool cfebAvailable(unsigned icfeb) = 0;
 
   virtual void addCFEB(int icfeb) = 0;
-  virtual void addNCLCT() = 0;  
+  virtual void addNCLCT() = 0;
   virtual void addNALCT() = 0;
   virtual void setBXN(int bxn) = 0;
   virtual void setL1A(int l1a) = 0;
@@ -43,15 +42,13 @@ public:
   virtual unsigned format_version() const = 0;
 
   virtual unsigned sizeInWords() const = 0;
- 
+
   virtual bool check() const = 0;
 
-  virtual unsigned short * data() = 0;
-  virtual unsigned short * data() const = 0;
+  virtual unsigned short* data() = 0;
+  virtual unsigned short* data() const = 0;
 
   //ostream & operator<<(ostream &, const CSCVDMBHeaderFormat &);
-
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h
@@ -3,15 +3,14 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <cstring> // bzero
+#include <cstring>  // bzero
 
 class CSCDMBHeader;
 
-class CSCVDMBTrailerFormat  {
+class CSCVDMBTrailerFormat {
 public:
-
-  virtual ~CSCVDMBTrailerFormat() {};
-/*
+  virtual ~CSCVDMBTrailerFormat(){};
+  /*
   void init() {
     bzero(this, sizeInWords()*2);
   }
@@ -51,17 +50,14 @@ public:
   virtual unsigned crc_lo_parity() const = 0;
   virtual unsigned crc_hi_parity() const = 0;
 
-
-  virtual unsigned short * data() = 0;
-  virtual unsigned short * data() const = 0;
+  virtual unsigned short *data() = 0;
+  virtual unsigned short *data() const = 0;
 
   virtual bool check() const = 0;
 
   virtual unsigned sizeInWords() const = 0;
-  
-  //ostream & operator<<(ostream &, const CSCVDMBTrailerFormat &);
 
+  //ostream & operator<<(ostream &, const CSCVDMBTrailerFormat &);
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
@@ -10,12 +10,11 @@
 #include <strings.h>
 class CSCDMBHeader;
 
-
 class CSCVTMBHeaderFormat {
 public:
   virtual ~CSCVTMBHeaderFormat() {}
-  
-  virtual void setEventInformation(const CSCDMBHeader &) = 0;
+
+  virtual void setEventInformation(const CSCDMBHeader&) = 0;
   virtual uint16_t BXNCount() const = 0;
   virtual uint16_t ALCTMatchTime() const = 0;
   virtual uint16_t CLCTOnly() const = 0;
@@ -28,9 +27,7 @@ public:
   virtual uint16_t syncErrorCLCT() const = 0;
   virtual uint16_t syncErrorMPC0() const = 0;
   virtual uint16_t syncErrorMPC1() const = 0;
-  uint16_t sizeInBytes() const {
-    return sizeInWords()*2;
-  }
+  uint16_t sizeInBytes() const { return sizeInWords() * 2; }
   virtual uint16_t NTBins() const = 0;
   virtual uint16_t NCFEBs() const = 0;
   virtual void setNCFEBs(uint16_t ncfebs) = 0;
@@ -39,33 +36,30 @@ public:
   virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) = 0;
   ///returns CorrelatedLCT digis
   virtual std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const = 0;
- 
-  
+
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
   virtual unsigned short int sizeInWords() const = 0;
 
   virtual unsigned short int NHeaderFrames() const = 0;
-  virtual unsigned short * data() = 0;
+  virtual unsigned short* data() = 0;
   virtual bool check() const = 0;
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  virtual void addCLCT0(const CSCCLCTDigi & digi) = 0;
-  virtual void addCLCT1(const CSCCLCTDigi & digi) = 0;
-  virtual void addALCT0(const CSCALCTDigi & digi) = 0;
-  virtual void addALCT1(const CSCALCTDigi & digi) = 0;
-  virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) = 0;
-  virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) = 0;
+  virtual void addCLCT0(const CSCCLCTDigi& digi) = 0;
+  virtual void addCLCT1(const CSCCLCTDigi& digi) = 0;
+  virtual void addALCT0(const CSCALCTDigi& digi) = 0;
+  virtual void addALCT1(const CSCALCTDigi& digi) = 0;
+  virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) = 0;
+  virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) = 0;
 
+  virtual void print(std::ostream& os) const = 0;
 
-  virtual void print(std::ostream & os) const = 0;
 protected:
-
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/CSCViewDigi.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCViewDigi.h
@@ -32,34 +32,29 @@ Location: EventFilter/CSCRawToDigi/interface/CSCViewDigi.h
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigiCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 class CSCViewDigi : public edm::EDAnalyzer {
-   public:
-      explicit CSCViewDigi(const edm::ParameterSet&);
-      ~CSCViewDigi() override;
+public:
+  explicit CSCViewDigi(const edm::ParameterSet&);
+  ~CSCViewDigi() override;
 
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-   private:
+  bool WiresDigiDump, AlctDigiDump, ClctDigiDump, CorrClctDigiDump;
+  bool StripDigiDump, ComparatorDigiDump, RpcDigiDump, StatusDigiDump;
+  bool DDUStatusDigiDump, DCCStatusDigiDump;
 
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-
-      bool WiresDigiDump, AlctDigiDump, ClctDigiDump, CorrClctDigiDump;
-      bool StripDigiDump, ComparatorDigiDump, RpcDigiDump, StatusDigiDump;
-      bool DDUStatusDigiDump, DCCStatusDigiDump;
-
-      edm::EDGetTokenT<CSCWireDigiCollection>             wd_token;
-      edm::EDGetTokenT<CSCStripDigiCollection>            sd_token;
-      edm::EDGetTokenT<CSCComparatorDigiCollection>       cd_token;
-      edm::EDGetTokenT<CSCRPCDigiCollection>              rd_token;
-      edm::EDGetTokenT<CSCALCTDigiCollection>             al_token;
-      edm::EDGetTokenT<CSCCLCTDigiCollection>             cl_token;
-      edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>    co_token;
-      edm::EDGetTokenT<CSCDCCFormatStatusDigiCollection>  st_token;
-      edm::EDGetTokenT<CSCDDUStatusDigiCollection>        dd_token;
-      edm::EDGetTokenT<CSCDCCStatusDigiCollection>        dc_token;
-
+  edm::EDGetTokenT<CSCWireDigiCollection> wd_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd_token;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> cd_token;
+  edm::EDGetTokenT<CSCRPCDigiCollection> rd_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl_token;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co_token;
+  edm::EDGetTokenT<CSCDCCFormatStatusDigiCollection> st_token;
+  edm::EDGetTokenT<CSCDDUStatusDigiCollection> dd_token;
+  edm::EDGetTokenT<CSCDCCStatusDigiCollection> dc_token;
 };
 
 #endif
-

--- a/EventFilter/CSCRawToDigi/interface/DigiAnalyzer.h
+++ b/EventFilter/CSCRawToDigi/interface/DigiAnalyzer.h
@@ -30,20 +30,15 @@ public:
   void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
 
 private:
-
   int eventNumber;
 
-  edm::EDGetTokenT<CSCWireDigiCollection>             wd_token;
-  edm::EDGetTokenT<CSCStripDigiCollection>            sd_token;
-  edm::EDGetTokenT<CSCComparatorDigiCollection>       cd_token;
-  edm::EDGetTokenT<CSCALCTDigiCollection>             al_token;
-  edm::EDGetTokenT<CSCCLCTDigiCollection>             cl_token;
-  edm::EDGetTokenT<CSCRPCDigiCollection>              rd_token;
-  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>    co_token;
-  edm::EDGetTokenT<CSCDDUStatusDigiCollection>        dd_token;
-  edm::EDGetTokenT<CSCDCCFormatStatusDigiCollection>  dc_token;
-
+  edm::EDGetTokenT<CSCWireDigiCollection> wd_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd_token;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> cd_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl_token;
+  edm::EDGetTokenT<CSCRPCDigiCollection> rd_token;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co_token;
+  edm::EDGetTokenT<CSCDDUStatusDigiCollection> dd_token;
+  edm::EDGetTokenT<CSCDCCFormatStatusDigiCollection> dc_token;
 };
-
-
-

--- a/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
@@ -72,42 +72,36 @@
 #include <iomanip>
 #include <cstdio>
 
-CSCDCCUnpacker::CSCDCCUnpacker(const edm::ParameterSet & pset) :
-    numOfEvents(0)
-{
-
+CSCDCCUnpacker::CSCDCCUnpacker(const edm::ParameterSet& pset) : numOfEvents(0) {
   // Tracked
-  i_token = consumes<FEDRawDataCollection>( pset.getParameter<edm::InputTag>("InputObjects") );
+  i_token = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("InputObjects"));
 
-  useExaminer           = pset.getParameter<bool>("UseExaminer");
-  examinerMask          = pset.getParameter<unsigned int>("ExaminerMask");
+  useExaminer = pset.getParameter<bool>("UseExaminer");
+  examinerMask = pset.getParameter<unsigned int>("ExaminerMask");
   /// Selective unpacking mode will skip only troublesome CSC blocks and not whole DCC/DDU block
   useSelectiveUnpacking = pset.getParameter<bool>("UseSelectiveUnpacking");
-  errorMask             = pset.getParameter<unsigned int>("ErrorMask");
-  unpackStatusDigis     = pset.getParameter<bool>("UnpackStatusDigis");
+  errorMask = pset.getParameter<unsigned int>("ErrorMask");
+  unpackStatusDigis = pset.getParameter<bool>("UnpackStatusDigis");
   /// Enable Format Status Digis
-  useFormatStatus       = pset.getParameter<bool>("UseFormatStatus");
+  useFormatStatus = pset.getParameter<bool>("UseFormatStatus");
 
   // Untracked
 
-  printEventNumber      = pset.getUntrackedParameter<bool>("PrintEventNumber", true);
-  debug                 = pset.getUntrackedParameter<bool>("Debug", false);
-  instantiateDQM        = pset.getUntrackedParameter<bool>("runDQM", false);
+  printEventNumber = pset.getUntrackedParameter<bool>("PrintEventNumber", true);
+  debug = pset.getUntrackedParameter<bool>("Debug", false);
+  instantiateDQM = pset.getUntrackedParameter<bool>("runDQM", false);
 
   /// Visualization of raw data
-  visualFEDInspect      = pset.getUntrackedParameter<bool>("VisualFEDInspect", false);
-  visualFEDShort        = pset.getUntrackedParameter<bool>("VisualFEDShort", false);
-  formatedEventDump     = pset.getUntrackedParameter<bool>("FormatedEventDump", false);
+  visualFEDInspect = pset.getUntrackedParameter<bool>("VisualFEDInspect", false);
+  visualFEDShort = pset.getUntrackedParameter<bool>("VisualFEDShort", false);
+  formatedEventDump = pset.getUntrackedParameter<bool>("FormatedEventDump", false);
 
   /// Suppress zeros LCTs
-  SuppressZeroLCT       = pset.getUntrackedParameter<bool>("SuppressZeroLCT", true);
+  SuppressZeroLCT = pset.getUntrackedParameter<bool>("SuppressZeroLCT", true);
 
-
-
-  if (instantiateDQM)
-    {
-      monitor = edm::Service<CSCMonitorInterface>().operator->();
-    }
+  if (instantiateDQM) {
+    monitor = edm::Service<CSCMonitorInterface>().operator->();
+  }
 
   produces<CSCWireDigiCollection>("MuonCSCWireDigi");
   produces<CSCStripDigiCollection>("MuonCSCStripDigi");
@@ -117,20 +111,18 @@ CSCDCCUnpacker::CSCDCCUnpacker(const edm::ParameterSet & pset) :
   produces<CSCRPCDigiCollection>("MuonCSCRPCDigi");
   produces<CSCCorrelatedLCTDigiCollection>("MuonCSCCorrelatedLCTDigi");
 
-  if (unpackStatusDigis)
-    {
-      produces<CSCCFEBStatusDigiCollection>("MuonCSCCFEBStatusDigi");
-      produces<CSCTMBStatusDigiCollection>("MuonCSCTMBStatusDigi");
-      produces<CSCDMBStatusDigiCollection>("MuonCSCDMBStatusDigi");
-      produces<CSCALCTStatusDigiCollection>("MuonCSCALCTStatusDigi");
-      produces<CSCDDUStatusDigiCollection>("MuonCSCDDUStatusDigi");
-      produces<CSCDCCStatusDigiCollection>("MuonCSCDCCStatusDigi");
-    }
+  if (unpackStatusDigis) {
+    produces<CSCCFEBStatusDigiCollection>("MuonCSCCFEBStatusDigi");
+    produces<CSCTMBStatusDigiCollection>("MuonCSCTMBStatusDigi");
+    produces<CSCDMBStatusDigiCollection>("MuonCSCDMBStatusDigi");
+    produces<CSCALCTStatusDigiCollection>("MuonCSCALCTStatusDigi");
+    produces<CSCDDUStatusDigiCollection>("MuonCSCDDUStatusDigi");
+    produces<CSCDCCStatusDigiCollection>("MuonCSCDCCStatusDigi");
+  }
 
-  if (useFormatStatus)
-    {
-      produces<CSCDCCFormatStatusDigiCollection>("MuonCSCDCCFormatStatusDigi");
-    }
+  if (useFormatStatus) {
+    produces<CSCDCCFormatStatusDigiCollection>("MuonCSCDCCFormatStatusDigi");
+  }
   //CSCAnodeData::setDebug(debug);
   CSCALCTHeader::setDebug(debug);
   CSCCLCTData::setDebug(debug);
@@ -141,37 +133,36 @@ CSCDCCUnpacker::CSCDCCUnpacker(const edm::ParameterSet & pset) :
   CSCTMBHeader::setDebug(debug);
   CSCRPCData::setDebug(debug);
   CSCDDUEventData::setErrorMask(errorMask);
-
 }
 
-CSCDCCUnpacker::~CSCDCCUnpacker()
-{
+CSCDCCUnpacker::~CSCDCCUnpacker() {
   //fill destructor here
 }
 
 void CSCDCCUnpacker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("InputObjects",edm::InputTag("rawDataCollector"))->setComment("# Define input to the unpacker");
-  desc.add<bool>("UseExaminer",true)->setComment("# Use CSC examiner to check for corrupt or semi-corrupt data & avoid unpacker crashes");
-  desc.add<unsigned int>("ExaminerMask",535557110)->setComment("# This mask is needed by the examiner");
-  desc.add<bool>("UseSelectiveUnpacking",true)->setComment("# Use Examiner to unpack good chambers and skip only bad ones");
-  desc.add<unsigned int>("ErrorMask",0)->setComment("# This mask simply reduces error reporting");
-  desc.add<bool>("UnpackStatusDigis",false)->setComment("# Unpack general status digis?");
-  desc.add<bool>("UseFormatStatus",true)->setComment("# Unpack FormatStatus digi?");
-  desc.addUntracked<bool>("Debug",false)->setComment("# Turn on lots of output");
-  desc.addUntracked<bool>("PrintEventNumber",false);
-  desc.addUntracked<bool>("runDQM",false);
-  desc.addUntracked<bool>("VisualFEDInspect",false)->setComment("# Visualization of raw data in corrupted events");
-  desc.addUntracked<bool>("VisualFEDShort",false)->setComment("# Visualization of raw data in corrupted events");
-  desc.addUntracked<bool>("FormatedEventDump",false);
-  desc.addUntracked<bool>("SuppressZeroLCT",true);
-  descriptions.add("muonCSCDCCUnpacker",desc);
+  desc.add<edm::InputTag>("InputObjects", edm::InputTag("rawDataCollector"))
+      ->setComment("# Define input to the unpacker");
+  desc.add<bool>("UseExaminer", true)
+      ->setComment("# Use CSC examiner to check for corrupt or semi-corrupt data & avoid unpacker crashes");
+  desc.add<unsigned int>("ExaminerMask", 535557110)->setComment("# This mask is needed by the examiner");
+  desc.add<bool>("UseSelectiveUnpacking", true)
+      ->setComment("# Use Examiner to unpack good chambers and skip only bad ones");
+  desc.add<unsigned int>("ErrorMask", 0)->setComment("# This mask simply reduces error reporting");
+  desc.add<bool>("UnpackStatusDigis", false)->setComment("# Unpack general status digis?");
+  desc.add<bool>("UseFormatStatus", true)->setComment("# Unpack FormatStatus digi?");
+  desc.addUntracked<bool>("Debug", false)->setComment("# Turn on lots of output");
+  desc.addUntracked<bool>("PrintEventNumber", false);
+  desc.addUntracked<bool>("runDQM", false);
+  desc.addUntracked<bool>("VisualFEDInspect", false)->setComment("# Visualization of raw data in corrupted events");
+  desc.addUntracked<bool>("VisualFEDShort", false)->setComment("# Visualization of raw data in corrupted events");
+  desc.addUntracked<bool>("FormatedEventDump", false);
+  desc.addUntracked<bool>("SuppressZeroLCT", true);
+  descriptions.add("muonCSCDCCUnpacker", desc);
   descriptions.setComment(" This is the generic cfi file for CSC unpacking");
 }
 
-void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
-{
-
+void CSCDCCUnpacker::produce(edm::Event& e, const edm::EventSetup& c) {
   ///access database for mapping
   // Do we really have to do this every event???
   // ... Yes, because framework is more efficient than you are at caching :)
@@ -180,16 +171,17 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
   c.get<CSCCrateMapRcd>().get(hcrate);
   const CSCCrateMap* pcrate = hcrate.product();
 
-  // Need access to CSCChamberMap for chamber<->FED/DDU mapping consistency checks 
+  // Need access to CSCChamberMap for chamber<->FED/DDU mapping consistency checks
   edm::ESHandle<CSCChamberMap> cscmap;
   c.get<CSCChamberMapRcd>().get(cscmap);
   const CSCChamberMap* cscmapping = cscmap.product();
 
-  if (printEventNumber) ++numOfEvents;
+  if (printEventNumber)
+    ++numOfEvents;
 
   /// Get a handle to the FED data collection
   edm::Handle<FEDRawDataCollection> rawdata;
-  e.getByToken( i_token, rawdata);
+  e.getByToken(i_token, rawdata);
 
   /// create the collections of CSC digis
   auto wireProduct = std::make_unique<CSCWireDigiCollection>();
@@ -208,72 +200,68 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
 
   auto formatStatusProduct = std::make_unique<CSCDCCFormatStatusDigiCollection>();
 
-
   // If set selective unpacking mode
   // hardcoded examiner mask below to check for DCC and DDU level errors will be used first
   // then examinerMask for CSC level errors will be used during unpacking of each CSC block
   unsigned long dccBinCheckMask = 0x06080016;
 
-  // Post-LS1 FED/DDU ID mapping fix 
-  const unsigned postLS1_map [] =  { 841, 842, 843, 844, 845, 846, 847, 848, 849,
-                                     831, 832, 833, 834, 835, 836, 837, 838, 839,
-                                     861, 862, 863, 864, 865, 866, 867, 868, 869,
-                                     851, 852, 853, 854, 855, 856, 857, 858, 859 };
-
+  // Post-LS1 FED/DDU ID mapping fix
+  const unsigned postLS1_map[] = {841, 842, 843, 844, 845, 846, 847, 848, 849, 831, 832, 833,
+                                  834, 835, 836, 837, 838, 839, 861, 862, 863, 864, 865, 866,
+                                  867, 868, 869, 851, 852, 853, 854, 855, 856, 857, 858, 859};
 
   // For new CSC readout layout, which wont include DCCs need to loop over DDU FED IDs. DCC IDs are included for backward compatibility with old data
   std::vector<unsigned int> cscFEDids;
 
-  for (unsigned int id=FEDNumbering::MINCSCFEDID;
-       id<=FEDNumbering::MAXCSCFEDID; ++id)   // loop over DCCs
+  for (unsigned int id = FEDNumbering::MINCSCFEDID; id <= FEDNumbering::MAXCSCFEDID; ++id)  // loop over DCCs
+  {
+    cscFEDids.push_back(id);
+  }
+
+  for (unsigned int id = FEDNumbering::MINCSCDDUFEDID; id <= FEDNumbering::MAXCSCDDUFEDID; ++id)  // loop over DDUs
+  {
+    cscFEDids.push_back(id);
+  }
+
+  for (unsigned int i = 0; i < cscFEDids.size(); i++)  // loop over all CSC FEDs (DCCs and DDUs)
+  {
+    unsigned int id = cscFEDids[i];
+    bool isDDU_FED = ((id >= FEDNumbering::MINCSCDDUFEDID) && (id <= FEDNumbering::MAXCSCDDUFEDID)) ? true : false;
+
+    /// uncomment this for regional unpacking
+    /// if (id!=SOME_ID) continue;
+
+    /// Take a reference to this FED's data
+    const FEDRawData& fedData = rawdata->FEDData(id);
+    unsigned long length = fedData.size();
+
+    if (length >= 32)  ///if fed has data then unpack it
     {
-      cscFEDids.push_back(id);
-    }
+      CSCDCCExaminer* examiner = nullptr;
+      goodEvent = true;
+      if (useExaminer)  ///examine event for integrity
+      {
+        // CSCDCCExaminer examiner;
+        examiner = new CSCDCCExaminer();
+        if (examinerMask & 0x40000)
+          examiner->crcCFEB(true);
+        if (examinerMask & 0x8000)
+          examiner->crcTMB(true);
+        if (examinerMask & 0x0400)
+          examiner->crcALCT(true);
+        examiner->setMask(examinerMask);
 
-  for (unsigned int id=FEDNumbering::MINCSCDDUFEDID;
-       id<=FEDNumbering::MAXCSCDDUFEDID; ++id)   // loop over DDUs
-    {
-      cscFEDids.push_back(id);
-    }
+        /// If we have DCC or only DDU FED by checking FED ID set examiner to uswe DCC or DDU mode
+        if (isDDU_FED) {
+          if (examiner != nullptr)
+            examiner->modeDDU(true);
+        }
 
-  for (unsigned int i=0; i<cscFEDids.size(); i++)   // loop over all CSC FEDs (DCCs and DDUs)
-    {
-      unsigned int id = cscFEDids[i];
-      bool isDDU_FED = ((id >= FEDNumbering::MINCSCDDUFEDID) && (id <= FEDNumbering::MAXCSCDDUFEDID))?true:false;
+        const short unsigned int* data = (short unsigned int*)fedData.data();
 
-
-      /// uncomment this for regional unpacking
-      /// if (id!=SOME_ID) continue;
-
-      /// Take a reference to this FED's data
-      const FEDRawData& fedData = rawdata->FEDData(id);
-      unsigned long length =  fedData.size();
-
-
-      if (length>=32)  ///if fed has data then unpack it
-        {
-          CSCDCCExaminer* examiner = nullptr;
-          goodEvent = true;
-          if (useExaminer)  ///examine event for integrity
-            {
-              // CSCDCCExaminer examiner;
-              examiner = new CSCDCCExaminer();
-              if ( examinerMask&0x40000 ) examiner->crcCFEB(true);
-              if ( examinerMask&0x8000  ) examiner->crcTMB (true);
-              if ( examinerMask&0x0400  ) examiner->crcALCT(true);
-              examiner->setMask(examinerMask);
-
-              /// If we have DCC or only DDU FED by checking FED ID set examiner to uswe DCC or DDU mode
-              if ( isDDU_FED )
-                {
-                  if (examiner != nullptr) examiner->modeDDU(true);
-                }
-
-              const short unsigned int *data = (short unsigned int *)fedData.data();
-
-              LogTrace("badData") << "Length: "<<  length/2;
-              // Event data hex dump
-              /*
+        LogTrace("badData") << "Length: " << length / 2;
+        // Event data hex dump
+        /*
               short unsigned * buf = (short unsigned int *)fedData.data();
                 std::cout <<std::endl<<length/2<<" words of data:"<<std::endl;
                 for (short unsigned int i=0;i<length/2;i++) {
@@ -282,543 +270,471 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
                 }
                       */
 
-              int res = examiner->check(data,long(fedData.size()/2));
-              if ( res < 0 )
-                {
-                  goodEvent=false;
-                }
-              else
-                {
-                  if (useSelectiveUnpacking)  goodEvent=!(examiner->errors()&dccBinCheckMask);
-                  else goodEvent=!(examiner->errors()&examinerMask);
-                }
+        int res = examiner->check(data, long(fedData.size() / 2));
+        if (res < 0) {
+          goodEvent = false;
+        } else {
+          if (useSelectiveUnpacking)
+            goodEvent = !(examiner->errors() & dccBinCheckMask);
+          else
+            goodEvent = !(examiner->errors() & examinerMask);
+        }
 
-              /*
+        /*
                    std::cout << "FED" << id << " " << fedData.size() << " " << goodEvent << " "
               << std::hex << examiner->errors() << std::dec << " " << status << std::endl;
               */
 
-              // Fill Format status digis per FED
-              // Remove examiner->errors() != 0 check if we need to put status digis for every event
-              if (useFormatStatus && (examiner->errors() !=0))
-                // formatStatusProduct->insertDigi(CSCDetId(1,1,1,1,1), CSCDCCFormatStatusDigi(id,examiner,dccBinCheckMask));
-                formatStatusProduct->insertDigi(CSCDetId(1,1,1,1,1),
-                                                CSCDCCFormatStatusDigi(id,dccBinCheckMask,
-                                                                       examiner->getMask(),
-                                                                       examiner->errors(),
-                                                                       examiner->errorsDetailedDDU(),
-                                                                       examiner->errorsDetailed(),
-                                                                       examiner->payloadDetailed(),
-                                                                       examiner->statusDetailed()));
+        // Fill Format status digis per FED
+        // Remove examiner->errors() != 0 check if we need to put status digis for every event
+        if (useFormatStatus && (examiner->errors() != 0))
+          // formatStatusProduct->insertDigi(CSCDetId(1,1,1,1,1), CSCDCCFormatStatusDigi(id,examiner,dccBinCheckMask));
+          formatStatusProduct->insertDigi(CSCDetId(1, 1, 1, 1, 1),
+                                          CSCDCCFormatStatusDigi(id,
+                                                                 dccBinCheckMask,
+                                                                 examiner->getMask(),
+                                                                 examiner->errors(),
+                                                                 examiner->errorsDetailedDDU(),
+                                                                 examiner->errorsDetailed(),
+                                                                 examiner->payloadDetailed(),
+                                                                 examiner->statusDetailed()));
+      }
+
+      /// Visualization of raw data
+      if (visualFEDInspect || formatedEventDump) {
+        if (!goodEvent || formatedEventDump) {
+          short unsigned* buf = (short unsigned int*)fedData.data();
+          visual_raw(length / 2, id, (int)e.id().run(), (int)e.id().event(), visualFEDShort, formatedEventDump, buf);
+        }
+      }
+
+      if (goodEvent) {
+        ///get a pointer to data and pass it to constructor for unpacking
+
+        CSCDCCExaminer* ptrExaminer = examiner;
+        if (!useSelectiveUnpacking)
+          ptrExaminer = nullptr;
+
+        std::vector<CSCDDUEventData> fed_Data;
+        std::vector<CSCDDUEventData>* ptr_fedData = &fed_Data;
+
+        /// set default detid to that for E=+z, S=1, R=1, C=1, L=1
+        CSCDetId layer(1, 1, 1, 1, 1);
+
+        if (isDDU_FED)  // Use new DDU FED readout mode
+        {
+          CSCDDUEventData single_dduData((short unsigned int*)fedData.data(), ptrExaminer);
+          fed_Data.push_back(single_dduData);
+
+          // if(instantiateDQM) monitor->process(examiner, &single_dduData);
+
+        } else  // Use old DCC FED readout mode
+        {
+          CSCDCCEventData dccData((short unsigned int*)fedData.data(), ptrExaminer);
+
+          //std::cout << " DCC Size [UNPK] " << dccData.sizeInWords() << std::endl;
+
+          if (instantiateDQM)
+            monitor->process(examiner, &dccData);
+
+          ///get a reference to dduData
+          // const std::vector<CSCDDUEventData> & dduData = dccData.dduData();
+          // ptr_fedData = &(dccData.dduData());
+          fed_Data = dccData.dduData();
+
+          if (unpackStatusDigis) {
+            /// DCC Trailer 2 added to dcc status product (to access TTS from DCC)
+            short unsigned* bufForDcc = (short unsigned int*)fedData.data();
+
+            //std::cout << "FED Length: " << std::dec << length/2 <<
+            //" Trailer 2: " << std::hex << bufForDcc[length/2-4] << std::endl;
+
+            dccStatusProduct->insertDigi(layer,
+                                         CSCDCCStatusDigi(dccData.dccHeader().data(),
+                                                          dccData.dccTrailer().data(),
+                                                          examiner->errors(),
+                                                          bufForDcc[length / 2 - 4]));
+          }
+        }
+
+        const std::vector<CSCDDUEventData>& dduData = *ptr_fedData;
+
+        for (unsigned int iDDU = 0; iDDU < dduData.size(); ++iDDU)  // loop over DDUs
+        {
+          /// skip the DDU if its data has serious errors
+          /// define a mask for serious errors
+          if (dduData[iDDU].trailer().errorstat() & errorMask) {
+            LogTrace("CSCDCCUnpacker|CSCRawToDigi")
+                << "FED ID" << id << " DDU# " << iDDU << " has serious error - no digis unpacked! " << std::hex
+                << dduData[iDDU].trailer().errorstat();
+            continue;  // to next iteration of DDU loop
+          }
+
+          if (unpackStatusDigis)
+            dduStatusProduct->insertDigi(
+                layer,
+                CSCDDUStatusDigi(dduData[iDDU].header().data(),
+                                 dduData[iDDU].trailer().data(),
+                                 /// DDU Trailer 0 added to ddu status product (to access TTS from DDU)
+                                 dduData[iDDU].trailer0()));
+
+          ///get a reference to chamber data
+          const std::vector<CSCEventData>& cscData = dduData[iDDU].cscData();
+
+          // if (cscData.size() != 0) std::cout << "FED" << id << " DDU Source ID: " << dduData[iDDU].header().source_id() << " firmware version: " << dduData[iDDU].header().format_version() << std::endl;
+
+          for (unsigned int iCSC = 0; iCSC < cscData.size(); ++iCSC)  // loop over CSCs
+          {
+            ///first process chamber-wide digis such as LCT
+            int vmecrate = cscData[iCSC].dmbHeader()->crateID();
+            int dmb = cscData[iCSC].dmbHeader()->dmbID();
+
+            int icfeb = 0;   /// default value for all digis not related to cfebs
+            int ilayer = 0;  /// layer=0 flags entire chamber
+
+            if (debug)
+              LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "crate = " << vmecrate << "; dmb = " << dmb;
+
+            if ((vmecrate >= 1) && (vmecrate <= 60) && (dmb >= 1) && (dmb <= 10) && (dmb != 6)) {
+              layer = pcrate->detId(vmecrate, dmb, icfeb, ilayer);
+            } else {
+              LogTrace("CSCDCCUnpacker|CSCRawToDigi") << " detID input out of range!!! ";
+              LogTrace("CSCDCCUnpacker|CSCRawToDigi") << " skipping chamber vme= " << vmecrate << " dmb= " << dmb;
+              continue;  // to next iteration of iCSC loop
             }
 
-          /// Visualization of raw data
-          if (visualFEDInspect || formatedEventDump)
-            {
-              if (!goodEvent || formatedEventDump)
-                {
-                  short unsigned * buf = (short unsigned int *)fedData.data();
-                  visual_raw(length/2, id,(int)e.id().run(),(int)e.id().event(),
-                             visualFEDShort, formatedEventDump, buf);
-                }
+            /// For Post-LS1 readout only. Check Chamber->FED/DDU mapping consistency.
+            /// Skip chambers (special case of data corruption), which report wrong ID and pose as different chamber
+            if (isDDU_FED) {
+              unsigned int dduid = cscmapping->ddu(layer);
+              if ((dduid >= 1) && (dduid <= 36))
+                dduid = postLS1_map[dduid - 1];  // Fix for Post-LS1 FED/DDU IDs mappings
+              // std::cout << "CSC " << layer << " -> " << id << ":" << dduid << ":" << vmecrate << ":" << dmb ;
+              if (id != dduid) {
+                LogTrace("CSCDDUUnpacker|CSCRawToDigi") << " CSC->FED/DDU mapping inconsistency!!! ";
+                LogTrace("CSCDCCUnpacker|CSCRawToDigi")
+                    << "readout FED/DDU ID=" << id << " expected ID=" << dduid << ", skipping chamber " << layer
+                    << " vme= " << vmecrate << " dmb= " << dmb;
+                continue;
+              }
             }
 
-          if (goodEvent)
-            {
-              ///get a pointer to data and pass it to constructor for unpacking
-
-
-              CSCDCCExaminer * ptrExaminer = examiner;
-              if (!useSelectiveUnpacking) ptrExaminer = nullptr;
-
-
-
-              std::vector<CSCDDUEventData> fed_Data;
-              std::vector<CSCDDUEventData>* ptr_fedData = &fed_Data;
-
-              /// set default detid to that for E=+z, S=1, R=1, C=1, L=1
-              CSCDetId layer(1, 1, 1, 1, 1);
-
-              if (isDDU_FED) // Use new DDU FED readout mode
-                {
-
-                  CSCDDUEventData single_dduData((short unsigned int *) fedData.data(), ptrExaminer);
-                  fed_Data.push_back(single_dduData);
-
-
-                  // if(instantiateDQM) monitor->process(examiner, &single_dduData);
-
-
-                }
-              else  // Use old DCC FED readout mode
-                {
-
-                  CSCDCCEventData dccData((short unsigned int *) fedData.data(), ptrExaminer);
-
-                  //std::cout << " DCC Size [UNPK] " << dccData.sizeInWords() << std::endl;
-
-                  if (instantiateDQM) monitor->process(examiner, &dccData);
-
-                  ///get a reference to dduData
-                  // const std::vector<CSCDDUEventData> & dduData = dccData.dduData();
-                  // ptr_fedData = &(dccData.dduData());
-                  fed_Data = dccData.dduData();
-
-
-                  if (unpackStatusDigis)
-                    {
-
-                      /// DCC Trailer 2 added to dcc status product (to access TTS from DCC)
-                      short unsigned * bufForDcc = (short unsigned int *)fedData.data();
-
-                      //std::cout << "FED Length: " << std::dec << length/2 <<
-                      //" Trailer 2: " << std::hex << bufForDcc[length/2-4] << std::endl;
-
-                      dccStatusProduct->insertDigi(layer, CSCDCCStatusDigi(dccData.dccHeader().data(),
-                                                   dccData.dccTrailer().data(),
-                                                   examiner->errors(),
-                                                   bufForDcc[length/2-4]));
-
-                    }
-                }
-
-              const std::vector<CSCDDUEventData> & dduData = *ptr_fedData;
-
-
-              for (unsigned int iDDU=0; iDDU<dduData.size(); ++iDDU)    // loop over DDUs
-                {
-
-
-                  /// skip the DDU if its data has serious errors
-                  /// define a mask for serious errors
-                  if (dduData[iDDU].trailer().errorstat()&errorMask)
-                    {
-                      LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "FED ID" << id << " DDU# " << iDDU << " has serious error - no digis unpacked! " <<
-                      std::hex << dduData[iDDU].trailer().errorstat();
-                      continue; // to next iteration of DDU loop
-                    }
-
-                  if (unpackStatusDigis) dduStatusProduct->
-                    insertDigi(layer, CSCDDUStatusDigi(dduData[iDDU].header().data(),
-                                                       dduData[iDDU].trailer().data(),
-                                                       /// DDU Trailer 0 added to ddu status product (to access TTS from DDU)
-                                                       dduData[iDDU].trailer0()));
-
-                  ///get a reference to chamber data
-                  const std::vector<CSCEventData> & cscData = dduData[iDDU].cscData();
-
-		  // if (cscData.size() != 0) std::cout << "FED" << id << " DDU Source ID: " << dduData[iDDU].header().source_id() << " firmware version: " << dduData[iDDU].header().format_version() << std::endl;
-
-
-                  for (unsigned int iCSC=0; iCSC<cscData.size(); ++iCSC)   // loop over CSCs
-                    {
-
-                      ///first process chamber-wide digis such as LCT
-                      int vmecrate = cscData[iCSC].dmbHeader()->crateID();
-                      int dmb = cscData[iCSC].dmbHeader()->dmbID();
-
-                      int icfeb = 0;  /// default value for all digis not related to cfebs
-                      int ilayer = 0; /// layer=0 flags entire chamber
-
-                      if (debug)
-                        LogTrace ("CSCDCCUnpacker|CSCRawToDigi") << "crate = " << vmecrate << "; dmb = " << dmb;
-
-
-
-                      if ((vmecrate>=1)&&(vmecrate<=60) && (dmb>=1)&&(dmb<=10)&&(dmb!=6))
-                        {
-                          layer = pcrate->detId(vmecrate, dmb,icfeb,ilayer );
-                        }
-                      else
-                        {
-                          LogTrace ("CSCDCCUnpacker|CSCRawToDigi") << " detID input out of range!!! ";
-                          LogTrace ("CSCDCCUnpacker|CSCRawToDigi")
-                          << " skipping chamber vme= " << vmecrate << " dmb= " << dmb;
-                          continue; // to next iteration of iCSC loop
-                        }
-
-                      
-                      /// For Post-LS1 readout only. Check Chamber->FED/DDU mapping consistency.
-                      /// Skip chambers (special case of data corruption), which report wrong ID and pose as different chamber 
-                      if (isDDU_FED)
-                        {
-                          unsigned int dduid = cscmapping->ddu(layer);
-                          if ((dduid>=1) && (dduid <= 36)) dduid = postLS1_map[dduid-1]; // Fix for Post-LS1 FED/DDU IDs mappings
-                          // std::cout << "CSC " << layer << " -> " << id << ":" << dduid << ":" << vmecrate << ":" << dmb ;
-                          if (id != dduid )
-                            {
-                              LogTrace ("CSCDDUUnpacker|CSCRawToDigi") << " CSC->FED/DDU mapping inconsistency!!! ";
-                              LogTrace ("CSCDCCUnpacker|CSCRawToDigi")
-                                << "readout FED/DDU ID=" << id << " expected ID=" << dduid
-                                << ", skipping chamber " << layer << " vme= " << vmecrate << " dmb= " << dmb;
-                              continue;
-                            }
-                        } 
-
-                      /// check alct data integrity
-                      int nalct = cscData[iCSC].dmbHeader()->nalct();
-                      bool goodALCT=false;
-                      //if (nalct&&(cscData[iCSC].dataPresent>>6&0x1)==1) {
-                      if (nalct&&cscData[iCSC].alctHeader())
-                        {
-                          if (cscData[iCSC].alctHeader()->check())
-                            {
-                              goodALCT=true;
-                            }
-                          else
-                            {
-                              LogTrace ("CSCDCCUnpacker|CSCRawToDigi") <<
-                              "not storing ALCT digis; alct is bad or not present";
-                            }
-                        }
-                      else
-                        {
-                          if (debug) LogTrace ("CSCDCCUnpacker|CSCRawToDigi") << "nALCT==0 !!!";
-                        }
-
-                      /// fill alct digi
-                      if (goodALCT)
-                        {
-                          std::vector <CSCALCTDigi>  alctDigis =
-                            cscData[iCSC].alctHeader()->ALCTDigis();
-                          if (SuppressZeroLCT)
-                            {
-                              std::vector<CSCALCTDigi> alctDigis_0;
-                              for (int unsigned i=0; i<alctDigis.size(); ++i)
-                                {
-                                  if (alctDigis[i].isValid())
-                                    alctDigis_0.push_back(alctDigis[i]);
-                                }
-                              alctProduct->move(std::make_pair(alctDigis_0.begin(), alctDigis_0.end()),layer);
-                            }
-                          else
-                            alctProduct->move(std::make_pair(alctDigis.begin(), alctDigis.end()),layer);
-                        }
-
-
-                      ///check tmb data integrity
-                      int nclct = cscData[iCSC].dmbHeader()->nclct();
-                      bool goodTMB=false;
-                      //	    if (nclct&&(cscData[iCSC].dataPresent>>5&0x1)==1) {
-                      if (nclct&&cscData[iCSC].tmbData())
-                        {
-                          if (cscData[iCSC].tmbHeader()->check())
-                            {
-                              if (cscData[iCSC].clctData()->check()) goodTMB=true;
-                            }
-                          else
-                            {
-                              LogTrace ("CSCDCCUnpacker|CSCRawToDigi") <<
-                              "one of TMB checks failed! not storing TMB digis ";
-                            }
-                        }
-                      else
-                        {
-                          if (debug) LogTrace ("CSCDCCUnpacker|CSCRawToDigi") << "nCLCT==0 !!!";
-                        }
-
-                      /// fill correlatedlct and clct digis
-                      if (goodTMB)
-                        {
-                          std::vector <CSCCorrelatedLCTDigi>  correlatedlctDigis =
-                            cscData[iCSC].tmbHeader()->CorrelatedLCTDigis(layer.rawId());
-                          if (SuppressZeroLCT)
-                            {
-                              std::vector<CSCCorrelatedLCTDigi> correlatedlctDigis_0;
-                              for (int unsigned i=0; i<correlatedlctDigis.size(); ++i)
-                                {
-                                  if (correlatedlctDigis[i].isValid())
-                                    correlatedlctDigis_0.push_back(correlatedlctDigis[i]);
-                                }
-                              corrlctProduct->move(std::make_pair(correlatedlctDigis_0.begin(),
-                                                                  correlatedlctDigis_0.end()),layer);
-                            }
-                          else
-                            corrlctProduct->move(std::make_pair(correlatedlctDigis.begin(),
-                                                                correlatedlctDigis.end()),layer);
-
-                          std::vector <CSCCLCTDigi>  clctDigis =
-                            cscData[iCSC].tmbHeader()->CLCTDigis(layer.rawId());
-                          if (SuppressZeroLCT)
-                            {
-                              std::vector<CSCCLCTDigi> clctDigis_0;
-                              for (int unsigned i=0; i<clctDigis.size(); ++i)
-                                {
-                                  if (clctDigis[i].isValid())
-                                    clctDigis_0.push_back(clctDigis[i]);
-                                }
-                              clctProduct->move(std::make_pair(clctDigis_0.begin(), clctDigis_0.end()),layer);
-                            }
-                          else
-                            clctProduct->move(std::make_pair(clctDigis.begin(), clctDigis.end()),layer);
-
-                          /// fill cscrpc digi
-                          if (cscData[iCSC].tmbData()->checkSize())
-                            {
-                              if (cscData[iCSC].tmbData()->hasRPC())
-                                {
-                                  std::vector <CSCRPCDigi>  rpcDigis =
-                                    cscData[iCSC].tmbData()->rpcData()->digis();
-                                  rpcProduct->move(std::make_pair(rpcDigis.begin(), rpcDigis.end()),layer);
-                                }
-                            }
-                          else LogTrace("CSCDCCUnpacker|CSCRawToDigi") <<" TMBData check size failed!";
-                        }
-
-
-                      /// fill cfeb status digi
-                      if (unpackStatusDigis)
-                        {
-                          for ( icfeb = 0; icfeb < 7; ++icfeb )  ///loop over status digis
-                            {
-                              if ( cscData[iCSC].cfebData(icfeb) != nullptr )
-                                cfebStatusProduct->
-                                insertDigi(layer, cscData[iCSC].cfebData(icfeb)->statusDigi());
-                            }
-                          /// fill dmb status digi
-                          dmbStatusProduct->insertDigi(layer, CSCDMBStatusDigi(cscData[iCSC].dmbHeader()->data(),
-                                                       cscData[iCSC].dmbTrailer()->data()));
-                          if (goodTMB)  tmbStatusProduct->
-                            insertDigi(layer, CSCTMBStatusDigi(cscData[iCSC].tmbHeader()->data(),
-                                                               cscData[iCSC].tmbData()->tmbTrailer()->data()));
-                          if (goodALCT) alctStatusProduct->
-                            insertDigi(layer, CSCALCTStatusDigi(cscData[iCSC].alctHeader()->data(),
-                                                                cscData[iCSC].alctTrailer()->data()));
-                        }
-
-
-                      /// fill wire, strip and comparator digis...
-                      for (int ilayer = 1; ilayer <= 6; ++ilayer)
-                        {
-                          /// set layer, dmb and vme are valid because already checked in line 240
-                          // (You have to be kidding. Line 240 in whose universe?)
-
-                          // Allocate all ME1/1 wire digis to ring 1
-                          layer = pcrate->detId( vmecrate, dmb, 0, ilayer );
-                          {
-                            std::vector <CSCWireDigi> wireDigis =  cscData[iCSC].wireDigis(ilayer);
-                            wireProduct->move(std::make_pair(wireDigis.begin(), wireDigis.end()),layer);
-                          }
-
-                          for ( icfeb = 0; icfeb < 7; ++icfeb )
-                            {
-                              layer = pcrate->detId( vmecrate, dmb, icfeb,ilayer );
-                              if (cscData[iCSC].cfebData(icfeb) && cscData[iCSC].cfebData(icfeb)->check())
-                                {
-                                  std::vector<CSCStripDigi> stripDigis;
-                                  cscData[iCSC].cfebData(icfeb)->digis(layer.rawId(),stripDigis);
-                                  stripProduct->move(std::make_pair(stripDigis.begin(),
-                                                                    stripDigis.end()),layer);
-                                }
-                            }
-
-
-                          if (goodTMB && (cscData[iCSC].tmbHeader() != nullptr))
-                            {
-                              int nCFEBs = cscData[iCSC].tmbHeader()->NCFEBs();
-                              for ( icfeb = 0; icfeb < nCFEBs; ++icfeb )
-                                {
-				  layer = pcrate->detId( vmecrate, dmb, icfeb,ilayer );
-                                  std::vector <CSCComparatorDigi>  comparatorDigis =
-                                    cscData[iCSC].clctData()->comparatorDigis(layer.rawId(), icfeb);
-                                  // Set cfeb=0, so that ME1/a and ME1/b comparators go to
-                                  // ring 1.
-                                  layer = pcrate->detId( vmecrate, dmb, 0, ilayer );
-                                  comparatorProduct->move(std::make_pair(comparatorDigis.begin(),
-                                                                         comparatorDigis.end()),layer);
-                                }
-                            } // end of loop over cfebs
-                        } // end of loop over layers
-                    } // end of loop over chambers
-                } // endof loop over DDUs
-            } // end of good event
-          else
-            {
-              LogTrace("CSCDCCUnpacker|CSCRawToDigi") <<
-              "ERROR! Examiner rejected FED #" << id;
-              if (examiner)
-                {
-                  for (int i=0; i<examiner->nERRORS; ++i)
-                    {
-                      if (((examinerMask&examiner->errors())>>i)&0x1)
-                        LogTrace("CSCDCCUnpacker|CSCRawToDigi")<<examiner->errName(i);
-                    }
-                  if (debug)
-                    {
-                      LogTrace("CSCDCCUnpacker|CSCRawToDigi")
-                      << " Examiner errors:0x" << std::hex << examiner->errors()
-                      << " & 0x" << examinerMask
-                      << " = " << (examiner->errors()&examinerMask);
-                    }
-                }
-
-              // dccStatusProduct->insertDigi(CSCDetId(1,1,1,1,1), CSCDCCStatusDigi(examiner->errors()));
-              // if(instantiateDQM)  monitor->process(examiner, NULL);
+            /// check alct data integrity
+            int nalct = cscData[iCSC].dmbHeader()->nalct();
+            bool goodALCT = false;
+            //if (nalct&&(cscData[iCSC].dataPresent>>6&0x1)==1) {
+            if (nalct && cscData[iCSC].alctHeader()) {
+              if (cscData[iCSC].alctHeader()->check()) {
+                goodALCT = true;
+              } else {
+                LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "not storing ALCT digis; alct is bad or not present";
+              }
+            } else {
+              if (debug)
+                LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "nALCT==0 !!!";
             }
-          if (examiner!=nullptr) delete examiner;
-        } // end of if fed has data
-    } // end of loop over DCCs
+
+            /// fill alct digi
+            if (goodALCT) {
+              std::vector<CSCALCTDigi> alctDigis = cscData[iCSC].alctHeader()->ALCTDigis();
+              if (SuppressZeroLCT) {
+                std::vector<CSCALCTDigi> alctDigis_0;
+                for (int unsigned i = 0; i < alctDigis.size(); ++i) {
+                  if (alctDigis[i].isValid())
+                    alctDigis_0.push_back(alctDigis[i]);
+                }
+                alctProduct->move(std::make_pair(alctDigis_0.begin(), alctDigis_0.end()), layer);
+              } else
+                alctProduct->move(std::make_pair(alctDigis.begin(), alctDigis.end()), layer);
+            }
+
+            ///check tmb data integrity
+            int nclct = cscData[iCSC].dmbHeader()->nclct();
+            bool goodTMB = false;
+            //	    if (nclct&&(cscData[iCSC].dataPresent>>5&0x1)==1) {
+            if (nclct && cscData[iCSC].tmbData()) {
+              if (cscData[iCSC].tmbHeader()->check()) {
+                if (cscData[iCSC].clctData()->check())
+                  goodTMB = true;
+              } else {
+                LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "one of TMB checks failed! not storing TMB digis ";
+              }
+            } else {
+              if (debug)
+                LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "nCLCT==0 !!!";
+            }
+
+            /// fill correlatedlct and clct digis
+            if (goodTMB) {
+              std::vector<CSCCorrelatedLCTDigi> correlatedlctDigis =
+                  cscData[iCSC].tmbHeader()->CorrelatedLCTDigis(layer.rawId());
+              if (SuppressZeroLCT) {
+                std::vector<CSCCorrelatedLCTDigi> correlatedlctDigis_0;
+                for (int unsigned i = 0; i < correlatedlctDigis.size(); ++i) {
+                  if (correlatedlctDigis[i].isValid())
+                    correlatedlctDigis_0.push_back(correlatedlctDigis[i]);
+                }
+                corrlctProduct->move(std::make_pair(correlatedlctDigis_0.begin(), correlatedlctDigis_0.end()), layer);
+              } else
+                corrlctProduct->move(std::make_pair(correlatedlctDigis.begin(), correlatedlctDigis.end()), layer);
+
+              std::vector<CSCCLCTDigi> clctDigis = cscData[iCSC].tmbHeader()->CLCTDigis(layer.rawId());
+              if (SuppressZeroLCT) {
+                std::vector<CSCCLCTDigi> clctDigis_0;
+                for (int unsigned i = 0; i < clctDigis.size(); ++i) {
+                  if (clctDigis[i].isValid())
+                    clctDigis_0.push_back(clctDigis[i]);
+                }
+                clctProduct->move(std::make_pair(clctDigis_0.begin(), clctDigis_0.end()), layer);
+              } else
+                clctProduct->move(std::make_pair(clctDigis.begin(), clctDigis.end()), layer);
+
+              /// fill cscrpc digi
+              if (cscData[iCSC].tmbData()->checkSize()) {
+                if (cscData[iCSC].tmbData()->hasRPC()) {
+                  std::vector<CSCRPCDigi> rpcDigis = cscData[iCSC].tmbData()->rpcData()->digis();
+                  rpcProduct->move(std::make_pair(rpcDigis.begin(), rpcDigis.end()), layer);
+                }
+              } else
+                LogTrace("CSCDCCUnpacker|CSCRawToDigi") << " TMBData check size failed!";
+            }
+
+            /// fill cfeb status digi
+            if (unpackStatusDigis) {
+              for (icfeb = 0; icfeb < 7; ++icfeb)  ///loop over status digis
+              {
+                if (cscData[iCSC].cfebData(icfeb) != nullptr)
+                  cfebStatusProduct->insertDigi(layer, cscData[iCSC].cfebData(icfeb)->statusDigi());
+              }
+              /// fill dmb status digi
+              dmbStatusProduct->insertDigi(
+                  layer, CSCDMBStatusDigi(cscData[iCSC].dmbHeader()->data(), cscData[iCSC].dmbTrailer()->data()));
+              if (goodTMB)
+                tmbStatusProduct->insertDigi(
+                    layer,
+                    CSCTMBStatusDigi(cscData[iCSC].tmbHeader()->data(), cscData[iCSC].tmbData()->tmbTrailer()->data()));
+              if (goodALCT)
+                alctStatusProduct->insertDigi(
+                    layer, CSCALCTStatusDigi(cscData[iCSC].alctHeader()->data(), cscData[iCSC].alctTrailer()->data()));
+            }
+
+            /// fill wire, strip and comparator digis...
+            for (int ilayer = 1; ilayer <= 6; ++ilayer) {
+              /// set layer, dmb and vme are valid because already checked in line 240
+              // (You have to be kidding. Line 240 in whose universe?)
+
+              // Allocate all ME1/1 wire digis to ring 1
+              layer = pcrate->detId(vmecrate, dmb, 0, ilayer);
+              {
+                std::vector<CSCWireDigi> wireDigis = cscData[iCSC].wireDigis(ilayer);
+                wireProduct->move(std::make_pair(wireDigis.begin(), wireDigis.end()), layer);
+              }
+
+              for (icfeb = 0; icfeb < 7; ++icfeb) {
+                layer = pcrate->detId(vmecrate, dmb, icfeb, ilayer);
+                if (cscData[iCSC].cfebData(icfeb) && cscData[iCSC].cfebData(icfeb)->check()) {
+                  std::vector<CSCStripDigi> stripDigis;
+                  cscData[iCSC].cfebData(icfeb)->digis(layer.rawId(), stripDigis);
+                  stripProduct->move(std::make_pair(stripDigis.begin(), stripDigis.end()), layer);
+                }
+              }
+
+              if (goodTMB && (cscData[iCSC].tmbHeader() != nullptr)) {
+                int nCFEBs = cscData[iCSC].tmbHeader()->NCFEBs();
+                for (icfeb = 0; icfeb < nCFEBs; ++icfeb) {
+                  layer = pcrate->detId(vmecrate, dmb, icfeb, ilayer);
+                  std::vector<CSCComparatorDigi> comparatorDigis =
+                      cscData[iCSC].clctData()->comparatorDigis(layer.rawId(), icfeb);
+                  // Set cfeb=0, so that ME1/a and ME1/b comparators go to
+                  // ring 1.
+                  layer = pcrate->detId(vmecrate, dmb, 0, ilayer);
+                  comparatorProduct->move(std::make_pair(comparatorDigis.begin(), comparatorDigis.end()), layer);
+                }
+              }  // end of loop over cfebs
+            }    // end of loop over layers
+          }      // end of loop over chambers
+        }        // endof loop over DDUs
+      }          // end of good event
+      else {
+        LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "ERROR! Examiner rejected FED #" << id;
+        if (examiner) {
+          for (int i = 0; i < examiner->nERRORS; ++i) {
+            if (((examinerMask & examiner->errors()) >> i) & 0x1)
+              LogTrace("CSCDCCUnpacker|CSCRawToDigi") << examiner->errName(i);
+          }
+          if (debug) {
+            LogTrace("CSCDCCUnpacker|CSCRawToDigi")
+                << " Examiner errors:0x" << std::hex << examiner->errors() << " & 0x" << examinerMask << " = "
+                << (examiner->errors() & examinerMask);
+          }
+        }
+
+        // dccStatusProduct->insertDigi(CSCDetId(1,1,1,1,1), CSCDCCStatusDigi(examiner->errors()));
+        // if(instantiateDQM)  monitor->process(examiner, NULL);
+      }
+      if (examiner != nullptr)
+        delete examiner;
+    }  // end of if fed has data
+  }    // end of loop over DCCs
   // put into the event
-  e.put(std::move(wireProduct),          "MuonCSCWireDigi");
-  e.put(std::move(stripProduct),         "MuonCSCStripDigi");
-  e.put(std::move(alctProduct),          "MuonCSCALCTDigi");
-  e.put(std::move(clctProduct),          "MuonCSCCLCTDigi");
-  e.put(std::move(comparatorProduct),    "MuonCSCComparatorDigi");
-  e.put(std::move(rpcProduct),           "MuonCSCRPCDigi");
-  e.put(std::move(corrlctProduct),       "MuonCSCCorrelatedLCTDigi");
+  e.put(std::move(wireProduct), "MuonCSCWireDigi");
+  e.put(std::move(stripProduct), "MuonCSCStripDigi");
+  e.put(std::move(alctProduct), "MuonCSCALCTDigi");
+  e.put(std::move(clctProduct), "MuonCSCCLCTDigi");
+  e.put(std::move(comparatorProduct), "MuonCSCComparatorDigi");
+  e.put(std::move(rpcProduct), "MuonCSCRPCDigi");
+  e.put(std::move(corrlctProduct), "MuonCSCCorrelatedLCTDigi");
 
-  if (useFormatStatus)  e.put(std::move(formatStatusProduct),    "MuonCSCDCCFormatStatusDigi");
+  if (useFormatStatus)
+    e.put(std::move(formatStatusProduct), "MuonCSCDCCFormatStatusDigi");
 
-  if (unpackStatusDigis)
-    {
-      e.put(std::move(cfebStatusProduct),    "MuonCSCCFEBStatusDigi");
-      e.put(std::move(dmbStatusProduct),     "MuonCSCDMBStatusDigi");
-      e.put(std::move(tmbStatusProduct),     "MuonCSCTMBStatusDigi");
-      e.put(std::move(dduStatusProduct),     "MuonCSCDDUStatusDigi");
-      e.put(std::move(dccStatusProduct),     "MuonCSCDCCStatusDigi");
-      e.put(std::move(alctStatusProduct),    "MuonCSCALCTStatusDigi");
-    }
-  if (printEventNumber) LogTrace("CSCDCCUnpacker|CSCRawToDigi")
-    <<"[CSCDCCUnpacker]: " << numOfEvents << " events processed ";
+  if (unpackStatusDigis) {
+    e.put(std::move(cfebStatusProduct), "MuonCSCCFEBStatusDigi");
+    e.put(std::move(dmbStatusProduct), "MuonCSCDMBStatusDigi");
+    e.put(std::move(tmbStatusProduct), "MuonCSCTMBStatusDigi");
+    e.put(std::move(dduStatusProduct), "MuonCSCDDUStatusDigi");
+    e.put(std::move(dccStatusProduct), "MuonCSCDCCStatusDigi");
+    e.put(std::move(alctStatusProduct), "MuonCSCALCTStatusDigi");
+  }
+  if (printEventNumber)
+    LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "[CSCDCCUnpacker]: " << numOfEvents << " events processed ";
 }
-
 
 /// Visualization of raw data
 
-void CSCDCCUnpacker::visual_raw(int hl,int id, int run, int event,bool fedshort,
-                                bool fDump, short unsigned int *buf) const
-{
-
+void CSCDCCUnpacker::visual_raw(
+    int hl, int id, int run, int event, bool fedshort, bool fDump, short unsigned int* buf) const {
   std::cout << std::endl << std::endl << std::endl;
-  std::cout << "Run: "<< run << " Event: " << event << std::endl;
+  std::cout << "Run: " << run << " Event: " << event << std::endl;
   std::cout << std::endl << std::endl;
   if (formatedEventDump)
-    std::cout << "FED-" << id << "  " << "(scroll down to see summary)" << std::endl;
+    std::cout << "FED-" << id << "  "
+              << "(scroll down to see summary)" << std::endl;
   else
-    std::cout << "Problem seems in FED-" << id << "  " << "(scroll down to see summary)" << std::endl;
-  std::cout <<"********************************************************************************" << std::endl;
-  std::cout << hl <<" words of data:" << std::endl;
+    std::cout << "Problem seems in FED-" << id << "  "
+              << "(scroll down to see summary)" << std::endl;
+  std::cout << "********************************************************************************" << std::endl;
+  std::cout << hl << " words of data:" << std::endl;
 
   //================================================
   // FED codes in DCC
   std::vector<int> dcc_id;
-  int dcc_h1_id=0;
+  int dcc_h1_id = 0;
   // Current codes
-  for (int i=750; i<758; i++)
+  for (int i = 750; i < 758; i++)
     dcc_id.push_back(i);
   // Codes for upgrade
-  for (int i=830; i<838; i++)
+  for (int i = 830; i < 838; i++)
     dcc_id.push_back(i);
 
-  char dcc_common[]="DCC-";
+  char dcc_common[] = "DCC-";
 
   //================================================
   // DDU codes per FED
   std::vector<int> ddu_id;
-  int ddu_h1_12_13=0;
-  for (int i=1; i<37; i++)
+  int ddu_h1_12_13 = 0;
+  for (int i = 1; i < 37; i++)
     ddu_id.push_back(i);
   // For DDU Headers and tarailers
-  char ddu_common[]="DDU-";
-  char ddu_header1[]="Header 1";
-  char ddu_header2[]="Header 2";
-  char ddu_header3[]="Header 3";
-  char ddu_trail1[]="Trailer 1", ddu_trail2[]="Trailer 2", ddu_trail3[]="Trailer 3";
+  char ddu_common[] = "DDU-";
+  char ddu_header1[] = "Header 1";
+  char ddu_header2[] = "Header 2";
+  char ddu_header3[] = "Header 3";
+  char ddu_trail1[] = "Trailer 1", ddu_trail2[] = "Trailer 2", ddu_trail3[] = "Trailer 3";
   // For Header 2
-  char ddu_trailer1_bit[]= {'8','0','0','0','f','f','f','f','8','0','0','0','8','0','0','0'};
-  char ddu_trailer3_bit[]= {'a'};
+  char ddu_trailer1_bit[] = {'8', '0', '0', '0', 'f', 'f', 'f', 'f', '8', '0', '0', '0', '8', '0', '0', '0'};
+  char ddu_trailer3_bit[] = {'a'};
   // Corrupted Trailers
-  char ddu_tr1_err_common[]="Incomplet";
+  char ddu_tr1_err_common[] = "Incomplet";
   //====================================================
 
   //DMB
-  char dmb_common[]="DMB", dmb_header1[]="Header 1", dmb_header2[]="Header 2";
-  char dmb_common_crate[]="crate:", dmb_common_slot[]="slot:";
-  char dmb_common_l1a[]="L1A:";
-  char dmb_header1_bit[]= {'9','9','9','9'};
-  char dmb_header2_bit[]= {'a','a','a','a'};
-  char dmb_tr1[]="Trailer 1", dmb_tr2[]="Trailer 2";
-  char dmb_tr1_bit[]= {'f','f','f','f'}, dmb_tr2_bit[]= {'e','e','e','e'};
-
+  char dmb_common[] = "DMB", dmb_header1[] = "Header 1", dmb_header2[] = "Header 2";
+  char dmb_common_crate[] = "crate:", dmb_common_slot[] = "slot:";
+  char dmb_common_l1a[] = "L1A:";
+  char dmb_header1_bit[] = {'9', '9', '9', '9'};
+  char dmb_header2_bit[] = {'a', 'a', 'a', 'a'};
+  char dmb_tr1[] = "Trailer 1", dmb_tr2[] = "Trailer 2";
+  char dmb_tr1_bit[] = {'f', 'f', 'f', 'f'}, dmb_tr2_bit[] = {'e', 'e', 'e', 'e'};
 
   //=====================================================
 
   // ALCT
-  char alct_common[]="ALCT", alct_header1[]="Header 1", alct_header2[]="Header 2";
-  char alct_common_bxn[]="BXN:";
-  char alct_common_wcnt2[]="| Actual word count:";
-  char alct_common_wcnt1[]="Expected word count:";
-  char alct_header1_bit[]= {'d','d','d','d','b','0','a'};
-  char alct_header2_bit[]= {'0','0','0','0'};
-  char alct_tr1[]="Trailer 1";
+  char alct_common[] = "ALCT", alct_header1[] = "Header 1", alct_header2[] = "Header 2";
+  char alct_common_bxn[] = "BXN:";
+  char alct_common_wcnt2[] = "| Actual word count:";
+  char alct_common_wcnt1[] = "Expected word count:";
+  char alct_header1_bit[] = {'d', 'd', 'd', 'd', 'b', '0', 'a'};
+  char alct_header2_bit[] = {'0', '0', '0', '0'};
+  char alct_tr1[] = "Trailer 1";
 
   //======================================================
 
   //TMB
-  char tmb_common[]="TMB", tmb_header1[]="Header", tmb_tr1[]="Trailer";
-  char tmb_header1_bit[]= {'d','d','d','d','b','0','c'};
-  char tmb_tr1_bit[]= {'d','d','d','d','e','0','f'};
+  char tmb_common[] = "TMB", tmb_header1[] = "Header", tmb_tr1[] = "Trailer";
+  char tmb_header1_bit[] = {'d', 'd', 'd', 'd', 'b', '0', 'c'};
+  char tmb_tr1_bit[] = {'d', 'd', 'd', 'd', 'e', '0', 'f'};
 
   //======================================================
 
   //CFEB
-  char cfeb_common[]="CFEB", cfeb_tr1[]="Trailer", cfeb_b[]="B-word";
-  char cfeb_common_sample[]="sample:";
+  char cfeb_common[] = "CFEB", cfeb_tr1[] = "Trailer", cfeb_b[] = "B-word";
+  char cfeb_common_sample[] = "sample:";
 
   //======================================================
 
   //Auxiliary variables
 
   // Bufers
-  int word_lines=hl/4;
+  int word_lines = hl / 4;
   char tempbuf[80];
   char tempbuf1[130];
   char tempbuf_short[17];
-  char sign1[]="  --->| ";
+  char sign1[] = "  --->| ";
 
   // Counters
-  int word_numbering=0;
-  int ddu_inst_i=0, ddu_inst_n=0, ddu_inst_l1a=0;
-  int ddu_inst_bxn=0;
-  int dmb_inst_crate=0, dmb_inst_slot=0, dmb_inst_l1a=0;
-  int cfeb_sample=0;
-  int alct_inst_l1a=0;
-  int alct_inst_bxn=0;
-  int alct_inst_wcnt1=0;
-  int alct_inst_wcnt2=0;
-  int alct_start=0;
-  int alct_stop=0;
-  int tmb_inst_l1a=0;
-  int tmb_inst_wcnt1=0;
-  int tmb_inst_wcnt2=0;
-  int tmb_start=0;
-  int tmb_stop=0;
-  int dcc_h1_check=0;
+  int word_numbering = 0;
+  int ddu_inst_i = 0, ddu_inst_n = 0, ddu_inst_l1a = 0;
+  int ddu_inst_bxn = 0;
+  int dmb_inst_crate = 0, dmb_inst_slot = 0, dmb_inst_l1a = 0;
+  int cfeb_sample = 0;
+  int alct_inst_l1a = 0;
+  int alct_inst_bxn = 0;
+  int alct_inst_wcnt1 = 0;
+  int alct_inst_wcnt2 = 0;
+  int alct_start = 0;
+  int alct_stop = 0;
+  int tmb_inst_l1a = 0;
+  int tmb_inst_wcnt1 = 0;
+  int tmb_inst_wcnt2 = 0;
+  int tmb_start = 0;
+  int tmb_stop = 0;
+  int dcc_h1_check = 0;
 
   //Flags
-  int ddu_h2_found=0;  //DDU Header 2 found
-  int w=0;
+  int ddu_h2_found = 0;  //DDU Header 2 found
+  int w = 0;
 
   //Logic variables
-  const int sz1=5;
-  bool dcc_check=false;
-  bool ddu_h2_check[sz1]= {false};
-  bool ddu_h1_check=false;
-  bool dmb_h1_check[sz1]= {false};
-  bool dmb_h2_check[sz1]= {false};
-  bool ddu_h2_h1=false;
-  bool ddu_tr1_check[sz1]= {false};
-  bool alct_h1_check[sz1]= {false};
-  bool alct_h2_check[sz1]= {false};
-  bool alct_tr1_check[sz1]= {false};
-  bool dmb_tr1_check[sz1]= {false};
-  bool dmb_tr2_check[sz1]= {false};
-  bool tmb_h1_check[sz1]= {false};
-  bool tmb_tr1_check[sz1]= {false};
-  bool cfeb_tr1_check[sz1]= {false};
-  bool cfeb_b_check[sz1]= {false};
-  bool ddu_tr1_bad_check[sz1]= {false};
-  bool extraction=fedshort;
+  const int sz1 = 5;
+  bool dcc_check = false;
+  bool ddu_h2_check[sz1] = {false};
+  bool ddu_h1_check = false;
+  bool dmb_h1_check[sz1] = {false};
+  bool dmb_h2_check[sz1] = {false};
+  bool ddu_h2_h1 = false;
+  bool ddu_tr1_check[sz1] = {false};
+  bool alct_h1_check[sz1] = {false};
+  bool alct_h2_check[sz1] = {false};
+  bool alct_tr1_check[sz1] = {false};
+  bool dmb_tr1_check[sz1] = {false};
+  bool dmb_tr2_check[sz1] = {false};
+  bool tmb_h1_check[sz1] = {false};
+  bool tmb_tr1_check[sz1] = {false};
+  bool cfeb_tr1_check[sz1] = {false};
+  bool cfeb_b_check[sz1] = {false};
+  bool ddu_tr1_bad_check[sz1] = {false};
+  bool extraction = fedshort;
 
   //Summary vectors
   //DDU
@@ -860,632 +776,810 @@ void CSCDCCUnpacker::visual_raw(int hl,int id, int run, int event,bool fedshort,
   //========================================================
 
   // DCC Header and Ttrailer information
-  char dcc_header1[]="DCC Header 1";
-  char dcc_header2[]="DCC Header 2";
-  char dcc_trail1[]="DCC Trailer 1", dcc_trail1_bit[]= {'e'};
-  char dcc_trail2[]="DCC Trailer 2", dcc_trail2_bit[]= {'a'};
+  char dcc_header1[] = "DCC Header 1";
+  char dcc_header2[] = "DCC Header 2";
+  char dcc_trail1[] = "DCC Trailer 1", dcc_trail1_bit[] = {'e'};
+  char dcc_trail2[] = "DCC Trailer 2", dcc_trail2_bit[] = {'a'};
   //=========================================================
 
-  for (int i=0; i < hl; i++)
-    {
-      ++word_numbering;
-      for (int j=-1; j<4; j++)
-        {
+  for (int i = 0; i < hl; i++) {
+    ++word_numbering;
+    for (int j = -1; j < 4; j++) {
+      sprintf(tempbuf_short,
+              "%04x%04x%04x%04x",
+              buf[i + 4 * (j - 1) + 3],
+              buf[i + 4 * (j - 1) + 2],
+              buf[i + 4 * (j - 1) + 1],
+              buf[i + 4 * (j - 1)]);
 
-          sprintf(tempbuf_short,"%04x%04x%04x%04x",buf[i+4*(j-1)+3],buf[i+4*(j-1)+2],buf[i+4*(j-1)+1],buf[i+4*(j-1)]);
+      // WARNING in 5_0_X for time being
+      ddu_h2_found++;
+      ddu_h2_found--;
 
-          // WARNING in 5_0_X for time being
-          ddu_h2_found++;
-          ddu_h2_found--;
+      ddu_h2_check[j] = ((buf[i + 4 * (j - 1) + 1] == 0x8000) && (buf[i + 4 * (j - 1) + 2] == 0x0001) &&
+                         (buf[i + 4 * (j - 1) + 3] == 0x8000));
 
-          ddu_h2_check[j]=((buf[i+4*(j-1)+1]==0x8000)&&
-                           (buf[i+4*(j-1)+2]==0x0001)&&(buf[i+4*(j-1)+3]==0x8000));
+      ddu_tr1_check[j] = ((tempbuf_short[0] == ddu_trailer1_bit[0]) && (tempbuf_short[1] == ddu_trailer1_bit[1]) &&
+                          (tempbuf_short[2] == ddu_trailer1_bit[2]) && (tempbuf_short[3] == ddu_trailer1_bit[3]) &&
+                          (tempbuf_short[4] == ddu_trailer1_bit[4]) && (tempbuf_short[5] == ddu_trailer1_bit[5]) &&
+                          (tempbuf_short[6] == ddu_trailer1_bit[6]) && (tempbuf_short[7] == ddu_trailer1_bit[7]) &&
+                          (tempbuf_short[8] == ddu_trailer1_bit[8]) && (tempbuf_short[9] == ddu_trailer1_bit[9]) &&
+                          (tempbuf_short[10] == ddu_trailer1_bit[10]) && (tempbuf_short[11] == ddu_trailer1_bit[11]) &&
+                          (tempbuf_short[12] == ddu_trailer1_bit[12]) && (tempbuf_short[13] == ddu_trailer1_bit[13]) &&
+                          (tempbuf_short[14] == ddu_trailer1_bit[14]) && (tempbuf_short[15] == ddu_trailer1_bit[15]));
 
-          ddu_tr1_check[j]=((tempbuf_short[0]==ddu_trailer1_bit[0])&&(tempbuf_short[1]==ddu_trailer1_bit[1])&&
-                            (tempbuf_short[2]==ddu_trailer1_bit[2])&&(tempbuf_short[3]==ddu_trailer1_bit[3])&&
-                            (tempbuf_short[4]==ddu_trailer1_bit[4])&&(tempbuf_short[5]==ddu_trailer1_bit[5])&&
-                            (tempbuf_short[6]==ddu_trailer1_bit[6])&&(tempbuf_short[7]==ddu_trailer1_bit[7])&&
-                            (tempbuf_short[8]==ddu_trailer1_bit[8])&&(tempbuf_short[9]==ddu_trailer1_bit[9])&&
-                            (tempbuf_short[10]==ddu_trailer1_bit[10])&&(tempbuf_short[11]==ddu_trailer1_bit[11])&&
-                            (tempbuf_short[12]==ddu_trailer1_bit[12])&&(tempbuf_short[13]==ddu_trailer1_bit[13])&&
-                            (tempbuf_short[14]==ddu_trailer1_bit[14])&&(tempbuf_short[15]==ddu_trailer1_bit[15]));
+      dmb_h1_check[j] = ((tempbuf_short[0] == dmb_header1_bit[0]) && (tempbuf_short[4] == dmb_header1_bit[1]) &&
+                         (tempbuf_short[8] == dmb_header1_bit[2]) && (tempbuf_short[12] == dmb_header1_bit[3]));
 
-          dmb_h1_check[j]=((tempbuf_short[0]==dmb_header1_bit[0])&&(tempbuf_short[4]==dmb_header1_bit[1])&&
-                           (tempbuf_short[8]==dmb_header1_bit[2])&&(tempbuf_short[12]==dmb_header1_bit[3]));
-
-          dmb_h2_check[j]=((tempbuf_short[0]==dmb_header2_bit[0])&&(tempbuf_short[4]==dmb_header2_bit[1])&&
-                           (tempbuf_short[8]==dmb_header2_bit[2])&&(tempbuf_short[12]==dmb_header2_bit[3]));
-          alct_h1_check[j]=((tempbuf_short[0]==alct_header1_bit[0])&&(tempbuf_short[4]==alct_header1_bit[1])&&
-                            (tempbuf_short[8]==alct_header1_bit[2])&&(tempbuf_short[12]==alct_header1_bit[3])&&
-                            (tempbuf_short[13]==alct_header1_bit[4])&&(tempbuf_short[14]==alct_header1_bit[5])&&
-                            (tempbuf_short[15]==alct_header1_bit[6]));
-          alct_h2_check[j]=(((tempbuf_short[0]==alct_header2_bit[0])&&(tempbuf_short[1]==alct_header2_bit[1])&&
-                             (tempbuf_short[2]==alct_header2_bit[2])&&(tempbuf_short[3]==alct_header2_bit[3]))||
-                            ((tempbuf_short[4]==alct_header2_bit[0])&&(tempbuf_short[5]==alct_header2_bit[1])&&
-                             (tempbuf_short[6]==alct_header2_bit[2])&&(tempbuf_short[7]==alct_header2_bit[3]))||
-                            ((tempbuf_short[8]==alct_header2_bit[0])&&(tempbuf_short[9]==alct_header2_bit[1])&&
-                             (tempbuf_short[10]==alct_header2_bit[2])&&(tempbuf_short[11]==alct_header2_bit[3]))||
-                            ((tempbuf_short[12]==alct_header2_bit[0])&&(tempbuf_short[13]==alct_header2_bit[1])&&
-                             (tempbuf_short[14]==alct_header2_bit[2])&&(tempbuf_short[15]==alct_header2_bit[3]))
-                            //(tempbuf_short[4]==alct_header2_bit[4])&&(tempbuf_short[5]==alct_header2_bit[5])
-                           );
-          // ALCT Trailers
-          alct_tr1_check[j]=(((buf[i+4*(j-1)]&0xFFFF)==0xDE0D)&&((buf[i+4*(j-1)+1]&0xF800)==0xD000)&&
-                             ((buf[i+4*(j-1)+2]&0xF800)==0xD000)&&((buf[i+4*(j-1)+3]&0xF000)==0xD000));
-          // DMB Trailers
-          dmb_tr1_check[j]=((tempbuf_short[0]==dmb_tr1_bit[0])&&(tempbuf_short[4]==dmb_tr1_bit[1])&&
-                            (tempbuf_short[8]==dmb_tr1_bit[2])&&(tempbuf_short[12]==dmb_tr1_bit[3]));
-          dmb_tr2_check[j]=((tempbuf_short[0]==dmb_tr2_bit[0])&&(tempbuf_short[4]==dmb_tr2_bit[1])&&
-                            (tempbuf_short[8]==dmb_tr2_bit[2])&&(tempbuf_short[12]==dmb_tr2_bit[3]));
-          // TMB
-          tmb_h1_check[j]=((tempbuf_short[0]==tmb_header1_bit[0])&&(tempbuf_short[4]==tmb_header1_bit[1])&&
-                           (tempbuf_short[8]==tmb_header1_bit[2])&&(tempbuf_short[12]==tmb_header1_bit[3])&&
-                           (tempbuf_short[13]==tmb_header1_bit[4])&&(tempbuf_short[14]==tmb_header1_bit[5])&&
-                           (tempbuf_short[15]==tmb_header1_bit[6]));
-          tmb_tr1_check[j]=((tempbuf_short[0]==tmb_tr1_bit[0])&&(tempbuf_short[4]==tmb_tr1_bit[1])&&
-                            (tempbuf_short[8]==tmb_tr1_bit[2])&&(tempbuf_short[12]==tmb_tr1_bit[3])&&
-                            (tempbuf_short[13]==tmb_tr1_bit[4])&&(tempbuf_short[14]==tmb_tr1_bit[5])&&
-                            (tempbuf_short[15]==tmb_tr1_bit[6]));
-          // CFEB
-          cfeb_tr1_check[j]=(((buf[i+4*(j-1)+1]&0xF000)==0x7000) &&
-                             ((buf[i+4*(j-1)+2]&0xF000)==0x7000) &&
-                             (( buf[i+4*(j-1)+1]!= 0x7FFF) || (buf[i+4*(j-1)+2] != 0x7FFF)) &&
-                             ((buf[i+4*(j-1)+3] == 0x7FFF) ||
-                              ((buf[i+4*(j-1)+3]&buf[i+4*(j-1)]) == 0x0&&(buf[i+4*(j-1)+3] + buf[i+4*(j-1)] == 0x7FFF ))) );
-          cfeb_b_check[j]=(((buf[i+4*(j-1)+3]&0xF000)==0xB000)&&((buf[i+4*(j-1)+2]&0xF000)==0xB000) &&
-                           ((buf[i+4*(j-1)+1]&0xF000)==0xB000)&&((buf[i+4*(j-1)]=3&0xF000)==0xB000) );
-          // DDU Trailers with errors
-          ddu_tr1_bad_check[j]=((tempbuf_short[0]!=ddu_trailer1_bit[0])&&
-                                //(tempbuf_short[1]!=ddu_trailer1_bit[1])&&(tempbuf_short[2]!=ddu_trailer1_bit[2])&&
-                                //(tempbuf_short[3]==ddu_trailer1_bit[3])&&
-                                (tempbuf_short[4]!=ddu_trailer1_bit[4])&&
-                                //(tempbuf_short[5]==ddu_trailer1_bit[5])&&
-                                //(tempbuf_short[6]==ddu_trailer1_bit[6])&&(tempbuf_short[7]==ddu_trailer1_bit[7])&&
-                                (tempbuf_short[8]==ddu_trailer1_bit[8])&&(tempbuf_short[9]==ddu_trailer1_bit[9])&&
-                                (tempbuf_short[10]==ddu_trailer1_bit[10])&&(tempbuf_short[11]==ddu_trailer1_bit[11])&&
-                                (tempbuf_short[12]==ddu_trailer1_bit[12])&&(tempbuf_short[13]==ddu_trailer1_bit[13])&&
-                                (tempbuf_short[14]==ddu_trailer1_bit[14])&&(tempbuf_short[15]==ddu_trailer1_bit[15]));
-        }
-
-      // DDU Header 2 next to Header 1
-      ddu_h2_h1=ddu_h2_check[2];
-
-      sprintf(tempbuf_short,"%04x%04x%04x%04x",buf[i+3],buf[i+2],buf[i+1],buf[i]);
-
-      // Looking for DDU Header 1
-      ddu_h1_12_13=(buf[i]>>8);
-      for (int kk=0; kk<36; kk++)
-        {
-          if (((buf[i+3]&0xF000)==0x5000)&&(ddu_h1_12_13==ddu_id[kk])&&ddu_h2_h1)
-            {
-              ddu_h1_coll.push_back(word_numbering);
-              ddu_h1_n_coll.push_back(ddu_id[kk]);
-              ddu_inst_l1a=((buf[i+2]&0xFFFF)+((buf[i+3]&0x00FF)<<16));
-              ddu_l1a_coll.push_back(ddu_inst_l1a);
-              ddu_inst_bxn=(buf[i+1]&0xFFF0)>>4;
-              ddu_bxn_coll.push_back(ddu_inst_bxn);
-              sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s%s %s %i %s %i",
-                      word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                      sign1,ddu_common,ddu_id[kk],ddu_header1,sign1,dmb_common_l1a,ddu_inst_l1a,alct_common_bxn,ddu_inst_bxn);
-              std::cout << tempbuf1 << std::endl;
-              w=0;
-              ddu_h1_check=true;
-              cfeb_sample=0;
-            }
-        }
-
-
-
-      // Looking for DCC Header 1
-      dcc_h1_id=(((buf[i+1]<<12)&0xF000)>>4)+(buf[i]>>8);
-      for (int dcci=0; dcci<16; dcci++)
-        {
-          if ((dcc_id[dcci]==dcc_h1_id)&&(((buf[i+3]&0xF000)==0x5000)&&(!ddu_h1_check)))
-            {
-              sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s",word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                      sign1,dcc_common,dcc_h1_id,dcc_header1);
-              dcc_h1_check=word_numbering;
-              w=0;
-              dcc_check=true;
-              std::cout << tempbuf1 << std::endl;
-            }
-        }
-
-      // Looking for DCC Header 2 and trailers
-      if (((word_numbering-1)==dcc_h1_check)&&((buf[i+3]&0xFF00)==0xD900))
-        {
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s",word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,dcc_header2);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-      else if ((word_numbering==word_lines-1)&&(tempbuf_short[0]==dcc_trail1_bit[0]))
-        {
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s",word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,dcc_trail1);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-      else if ((word_numbering==word_lines)&&(tempbuf_short[0]==dcc_trail2_bit[0]))
-        {
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s",word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,dcc_trail2);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      // DDU Header 2
-      else if (ddu_h2_check[1])
-        {
-          ddu_inst_i = ddu_h1_n_coll.size(); //ddu_inst_n=ddu_h1_n_coll[0];
-          if (ddu_inst_i>0)
-            {
-              ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-            }
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,ddu_common,
-                  ddu_inst_n, ddu_header2);
-          ddu_h2_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          ddu_h2_found=1;
-        }
-
-      // DDU Header 3 (either between DDU Header 2 DMB Header or DDU Header 2 DDU Trailer1)
-      else if ((ddu_h2_check[0]&&dmb_h1_check[2])||(ddu_h2_check[0]&&ddu_tr1_check[2]))
-        {
-          ddu_inst_i = ddu_h1_n_coll.size();
-          if (ddu_inst_i>0)
-            {
-              ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-            }
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s",word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,ddu_common,ddu_inst_n,ddu_header3);
-          ddu_h3_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          ddu_h2_found=0;
-        }
-
-      // DMB Header 1,2
-
-      else if (dmb_h1_check[1])
-        {
-          dmb_inst_crate=0;
-          dmb_inst_slot=0;
-          dmb_inst_l1a=((buf[i]&0x0FFF)+((buf[i+1]&0xFFF)<<12));
-          dmb_l1a_coll.push_back(dmb_inst_l1a);
-          if (dmb_h2_check[2])
-            {
-              dmb_inst_crate=((buf[i+4+1]>>4)&0xFF);
-              dmb_inst_slot=(buf[i+4+1]&0xF);
-              dmb_crate_coll.push_back(dmb_inst_crate);
-              dmb_slot_coll.push_back(dmb_inst_slot);
-            }
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i %s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,dmb_common,dmb_header1,sign1,dmb_common_crate,dmb_inst_crate,
-                  dmb_common_slot,dmb_inst_slot,dmb_common_l1a,dmb_inst_l1a);
-          dmb_h1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          ddu_h2_found=1;
-        }
-
-      else if (dmb_h2_check[1])
-        {
-          dmb_inst_crate=((buf[i+1]>>4)&0xFF);
-          dmb_inst_slot=(buf[i+1]&0xF);
-          dmb_h2_coll.push_back(word_numbering);
-          if (dmb_h1_check[0])
-            dmb_inst_l1a=((buf[i-4]&0x0FFF)+((buf[i-4+1]&0xFFF)<<12));
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i %s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,dmb_common,dmb_header2,sign1,dmb_common_crate,dmb_inst_crate,
-                  dmb_common_slot,dmb_inst_slot,dmb_common_l1a,dmb_inst_l1a);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          ddu_h2_found=1;
-        }
-
-      //DDU Trailer 1
-
-      else if (ddu_tr1_check[1])
-        {
-          ddu_inst_i = ddu_h1_n_coll.size();
-          if (ddu_inst_i>0)
-            {
-              ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-            }
-          //ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,ddu_common,ddu_inst_n,ddu_trail1);
-          ddu_t1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      ///ALCT Header 1,2
-      else if (alct_h1_check[1])
-        {
-          alct_start=word_numbering;
-          alct_inst_l1a=(buf[i+2]&0x0FFF);
-          alct_l1a_coll.push_back(alct_inst_l1a);
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s %s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,alct_common,alct_header1,sign1,dmb_common_l1a,alct_inst_l1a);
-          alct_h1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      else if ((alct_h1_check[0])&&(alct_h2_check[2]))
-        {
-          alct_inst_bxn=(buf[i]&0x0FFF);
-          alct_bxn_coll.push_back(alct_inst_bxn);
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s%s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,alct_common,alct_header2,sign1,alct_common_bxn,alct_inst_bxn);
-          alct_h2_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      //ALCT Trailer 1
-      else if (alct_tr1_check[1])
-        {
-          alct_stop=word_numbering;
-          if ((alct_start!=0)&&(alct_stop!=0)&&(alct_stop>alct_start))
-            {
-              alct_inst_wcnt2=4*(alct_stop-alct_start+1);
-              alct_wcnt2_coll.push_back(alct_inst_wcnt2);
-              alct_wcnt2_id_coll.push_back(alct_start);
-            }
-          alct_inst_wcnt1=(buf[i+3]&0x7FF);
-          alct_wcnt1_coll.push_back(alct_inst_wcnt1);
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,alct_common,alct_tr1,sign1,alct_common_wcnt1,alct_inst_wcnt1,
-                  alct_common_wcnt2,alct_inst_wcnt2);
-          alct_t1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          alct_inst_wcnt2=0;
-        }
-
-      //DDU Trailer 3
-
-//      else if ((ddu_tr1_check[-1])&&(tempbuf_short[0]==ddu_trailer3_bit[0])) { // !!! TO FIX: negative index 
-      else if((ddu_h2_h1)&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
-          //&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
-          ddu_inst_i = ddu_h1_n_coll.size();
-          if (ddu_inst_i>0)
-            {
-              ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-            }
-          //ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,ddu_common,ddu_inst_n,ddu_trail3);
-          ddu_t3_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-      //DDU Trailer 2
-      else if ((ddu_tr1_check[0])&&(tempbuf_short[0]!=ddu_trailer3_bit[0]))
-        {
-          //&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
-          ddu_inst_i = ddu_h1_n_coll.size();
-          if (ddu_inst_i>0)
-            {
-              ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-            }
-          //ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,ddu_common,ddu_inst_n,ddu_trail2);
-          ddu_t2_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      //DMB Trailer 1,2
-      else if (dmb_tr1_check[1])
-        {
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,dmb_common,dmb_tr1);
-          dmb_t1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          cfeb_sample=0;
-        }
-
-      else if (dmb_tr2_check[1])
-        {
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,dmb_common,dmb_tr2);
-          dmb_t2_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
+      dmb_h2_check[j] = ((tempbuf_short[0] == dmb_header2_bit[0]) && (tempbuf_short[4] == dmb_header2_bit[1]) &&
+                         (tempbuf_short[8] == dmb_header2_bit[2]) && (tempbuf_short[12] == dmb_header2_bit[3]));
+      alct_h1_check[j] = ((tempbuf_short[0] == alct_header1_bit[0]) && (tempbuf_short[4] == alct_header1_bit[1]) &&
+                          (tempbuf_short[8] == alct_header1_bit[2]) && (tempbuf_short[12] == alct_header1_bit[3]) &&
+                          (tempbuf_short[13] == alct_header1_bit[4]) && (tempbuf_short[14] == alct_header1_bit[5]) &&
+                          (tempbuf_short[15] == alct_header1_bit[6]));
+      alct_h2_check[j] = (((tempbuf_short[0] == alct_header2_bit[0]) && (tempbuf_short[1] == alct_header2_bit[1]) &&
+                           (tempbuf_short[2] == alct_header2_bit[2]) && (tempbuf_short[3] == alct_header2_bit[3])) ||
+                          ((tempbuf_short[4] == alct_header2_bit[0]) && (tempbuf_short[5] == alct_header2_bit[1]) &&
+                           (tempbuf_short[6] == alct_header2_bit[2]) && (tempbuf_short[7] == alct_header2_bit[3])) ||
+                          ((tempbuf_short[8] == alct_header2_bit[0]) && (tempbuf_short[9] == alct_header2_bit[1]) &&
+                           (tempbuf_short[10] == alct_header2_bit[2]) && (tempbuf_short[11] == alct_header2_bit[3])) ||
+                          ((tempbuf_short[12] == alct_header2_bit[0]) && (tempbuf_short[13] == alct_header2_bit[1]) &&
+                           (tempbuf_short[14] == alct_header2_bit[2]) && (tempbuf_short[15] == alct_header2_bit[3]))
+                          //(tempbuf_short[4]==alct_header2_bit[4])&&(tempbuf_short[5]==alct_header2_bit[5])
+      );
+      // ALCT Trailers
+      alct_tr1_check[j] =
+          (((buf[i + 4 * (j - 1)] & 0xFFFF) == 0xDE0D) && ((buf[i + 4 * (j - 1) + 1] & 0xF800) == 0xD000) &&
+           ((buf[i + 4 * (j - 1) + 2] & 0xF800) == 0xD000) && ((buf[i + 4 * (j - 1) + 3] & 0xF000) == 0xD000));
+      // DMB Trailers
+      dmb_tr1_check[j] = ((tempbuf_short[0] == dmb_tr1_bit[0]) && (tempbuf_short[4] == dmb_tr1_bit[1]) &&
+                          (tempbuf_short[8] == dmb_tr1_bit[2]) && (tempbuf_short[12] == dmb_tr1_bit[3]));
+      dmb_tr2_check[j] = ((tempbuf_short[0] == dmb_tr2_bit[0]) && (tempbuf_short[4] == dmb_tr2_bit[1]) &&
+                          (tempbuf_short[8] == dmb_tr2_bit[2]) && (tempbuf_short[12] == dmb_tr2_bit[3]));
       // TMB
-      else if (tmb_h1_check[1])
-        {
-          tmb_start=word_numbering;
-          tmb_inst_l1a=(buf[i+2]&0x000F);
-          tmb_l1a_coll.push_back(tmb_inst_l1a);
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s%s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,tmb_common,tmb_header1,
-                  sign1,dmb_common_l1a,tmb_inst_l1a);
-          tmb_h1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-      else if (tmb_tr1_check[1])
-        {
-          tmb_stop=word_numbering;
-          if ((tmb_start!=0)&&(tmb_stop!=0)&&(tmb_stop>tmb_start))
-            {
-              tmb_inst_wcnt2=4*(tmb_stop-tmb_start+1);
-              tmb_wcnt2_coll.push_back(tmb_inst_wcnt2);
-            }
-          tmb_inst_wcnt1=(buf[i+3]&0x7FF);
-          tmb_wcnt1_coll.push_back(tmb_inst_wcnt1);
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,tmb_common,tmb_tr1,sign1,alct_common_wcnt1,tmb_inst_wcnt1,
-                  alct_common_wcnt2,tmb_inst_wcnt2);
-          tmb_t1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-          tmb_inst_wcnt2=0;
-        }
+      tmb_h1_check[j] = ((tempbuf_short[0] == tmb_header1_bit[0]) && (tempbuf_short[4] == tmb_header1_bit[1]) &&
+                         (tempbuf_short[8] == tmb_header1_bit[2]) && (tempbuf_short[12] == tmb_header1_bit[3]) &&
+                         (tempbuf_short[13] == tmb_header1_bit[4]) && (tempbuf_short[14] == tmb_header1_bit[5]) &&
+                         (tempbuf_short[15] == tmb_header1_bit[6]));
+      tmb_tr1_check[j] = ((tempbuf_short[0] == tmb_tr1_bit[0]) && (tempbuf_short[4] == tmb_tr1_bit[1]) &&
+                          (tempbuf_short[8] == tmb_tr1_bit[2]) && (tempbuf_short[12] == tmb_tr1_bit[3]) &&
+                          (tempbuf_short[13] == tmb_tr1_bit[4]) && (tempbuf_short[14] == tmb_tr1_bit[5]) &&
+                          (tempbuf_short[15] == tmb_tr1_bit[6]));
       // CFEB
-      else if (cfeb_tr1_check[1])
-        {
-          ++cfeb_sample;
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s%s %s %i",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],
-                  sign1,cfeb_common,cfeb_tr1,sign1,cfeb_common_sample,cfeb_sample);
-          cfeb_t1_coll.push_back(word_numbering);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-      else if (cfeb_b_check[1])
-        {
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,cfeb_common,cfeb_b);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      //ERRORS ddu_tr1_bad_check
-
-      else if (ddu_tr1_bad_check[1])
-        {
-          ddu_inst_i = ddu_h1_n_coll.size();
-          ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
-          sprintf(tempbuf1,"%6i    %04x %04x %04x %04x%s%s%i %s %s",
-                  word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i],sign1,ddu_common,ddu_inst_n,
-                  ddu_trail1,ddu_tr1_err_common);
-          std::cout << tempbuf1 << std::endl;
-          w=0;
-        }
-
-      else if (extraction&&(!ddu_h1_check)&&(!dcc_check))
-        {
-          if (w<3)
-            {
-              sprintf(tempbuf,"%6i    %04x %04x %04x %04x",
-                      word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i]);
-              std::cout << tempbuf << std::endl;
-              w++;
-            }
-          if (w==3)
-            {
-              std::cout << "..................................................." << std::endl;
-              w++;
-            }
-        }
-
-      else if ((!ddu_h1_check)&&(!dcc_check))
-        {
-          sprintf(tempbuf,"%6i    %04x %04x %04x %04x",word_numbering,buf[i+3],buf[i+2],buf[i+1],buf[i]);
-          std::cout << tempbuf << std::endl;
-        }
-
-      i+=3;
-      ddu_h1_check=false;
-      dcc_check=false;
+      cfeb_tr1_check[j] =
+          (((buf[i + 4 * (j - 1) + 1] & 0xF000) == 0x7000) && ((buf[i + 4 * (j - 1) + 2] & 0xF000) == 0x7000) &&
+           ((buf[i + 4 * (j - 1) + 1] != 0x7FFF) || (buf[i + 4 * (j - 1) + 2] != 0x7FFF)) &&
+           ((buf[i + 4 * (j - 1) + 3] == 0x7FFF) || ((buf[i + 4 * (j - 1) + 3] & buf[i + 4 * (j - 1)]) == 0x0 &&
+                                                     (buf[i + 4 * (j - 1) + 3] + buf[i + 4 * (j - 1)] == 0x7FFF))));
+      cfeb_b_check[j] =
+          (((buf[i + 4 * (j - 1) + 3] & 0xF000) == 0xB000) && ((buf[i + 4 * (j - 1) + 2] & 0xF000) == 0xB000) &&
+           ((buf[i + 4 * (j - 1) + 1] & 0xF000) == 0xB000) && ((buf[i + 4 * (j - 1)] = 3 & 0xF000) == 0xB000));
+      // DDU Trailers with errors
+      ddu_tr1_bad_check[j] =
+          ((tempbuf_short[0] != ddu_trailer1_bit[0]) &&
+           //(tempbuf_short[1]!=ddu_trailer1_bit[1])&&(tempbuf_short[2]!=ddu_trailer1_bit[2])&&
+           //(tempbuf_short[3]==ddu_trailer1_bit[3])&&
+           (tempbuf_short[4] != ddu_trailer1_bit[4]) &&
+           //(tempbuf_short[5]==ddu_trailer1_bit[5])&&
+           //(tempbuf_short[6]==ddu_trailer1_bit[6])&&(tempbuf_short[7]==ddu_trailer1_bit[7])&&
+           (tempbuf_short[8] == ddu_trailer1_bit[8]) && (tempbuf_short[9] == ddu_trailer1_bit[9]) &&
+           (tempbuf_short[10] == ddu_trailer1_bit[10]) && (tempbuf_short[11] == ddu_trailer1_bit[11]) &&
+           (tempbuf_short[12] == ddu_trailer1_bit[12]) && (tempbuf_short[13] == ddu_trailer1_bit[13]) &&
+           (tempbuf_short[14] == ddu_trailer1_bit[14]) && (tempbuf_short[15] == ddu_trailer1_bit[15]));
     }
+
+    // DDU Header 2 next to Header 1
+    ddu_h2_h1 = ddu_h2_check[2];
+
+    sprintf(tempbuf_short, "%04x%04x%04x%04x", buf[i + 3], buf[i + 2], buf[i + 1], buf[i]);
+
+    // Looking for DDU Header 1
+    ddu_h1_12_13 = (buf[i] >> 8);
+    for (int kk = 0; kk < 36; kk++) {
+      if (((buf[i + 3] & 0xF000) == 0x5000) && (ddu_h1_12_13 == ddu_id[kk]) && ddu_h2_h1) {
+        ddu_h1_coll.push_back(word_numbering);
+        ddu_h1_n_coll.push_back(ddu_id[kk]);
+        ddu_inst_l1a = ((buf[i + 2] & 0xFFFF) + ((buf[i + 3] & 0x00FF) << 16));
+        ddu_l1a_coll.push_back(ddu_inst_l1a);
+        ddu_inst_bxn = (buf[i + 1] & 0xFFF0) >> 4;
+        ddu_bxn_coll.push_back(ddu_inst_bxn);
+        sprintf(tempbuf1,
+                "%6i    %04x %04x %04x %04x%s%s%i %s%s %s %i %s %i",
+                word_numbering,
+                buf[i + 3],
+                buf[i + 2],
+                buf[i + 1],
+                buf[i],
+                sign1,
+                ddu_common,
+                ddu_id[kk],
+                ddu_header1,
+                sign1,
+                dmb_common_l1a,
+                ddu_inst_l1a,
+                alct_common_bxn,
+                ddu_inst_bxn);
+        std::cout << tempbuf1 << std::endl;
+        w = 0;
+        ddu_h1_check = true;
+        cfeb_sample = 0;
+      }
+    }
+
+    // Looking for DCC Header 1
+    dcc_h1_id = (((buf[i + 1] << 12) & 0xF000) >> 4) + (buf[i] >> 8);
+    for (int dcci = 0; dcci < 16; dcci++) {
+      if ((dcc_id[dcci] == dcc_h1_id) && (((buf[i + 3] & 0xF000) == 0x5000) && (!ddu_h1_check))) {
+        sprintf(tempbuf1,
+                "%6i    %04x %04x %04x %04x%s%s%i %s",
+                word_numbering,
+                buf[i + 3],
+                buf[i + 2],
+                buf[i + 1],
+                buf[i],
+                sign1,
+                dcc_common,
+                dcc_h1_id,
+                dcc_header1);
+        dcc_h1_check = word_numbering;
+        w = 0;
+        dcc_check = true;
+        std::cout << tempbuf1 << std::endl;
+      }
+    }
+
+    // Looking for DCC Header 2 and trailers
+    if (((word_numbering - 1) == dcc_h1_check) && ((buf[i + 3] & 0xFF00) == 0xD900)) {
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dcc_header2);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    } else if ((word_numbering == word_lines - 1) && (tempbuf_short[0] == dcc_trail1_bit[0])) {
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dcc_trail1);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    } else if ((word_numbering == word_lines) && (tempbuf_short[0] == dcc_trail2_bit[0])) {
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dcc_trail2);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    // DDU Header 2
+    else if (ddu_h2_check[1]) {
+      ddu_inst_i = ddu_h1_n_coll.size();  //ddu_inst_n=ddu_h1_n_coll[0];
+      if (ddu_inst_i > 0) {
+        ddu_inst_n = ddu_h1_n_coll[ddu_inst_i - 1];
+      }
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s%i %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              ddu_common,
+              ddu_inst_n,
+              ddu_header2);
+      ddu_h2_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      ddu_h2_found = 1;
+    }
+
+    // DDU Header 3 (either between DDU Header 2 DMB Header or DDU Header 2 DDU Trailer1)
+    else if ((ddu_h2_check[0] && dmb_h1_check[2]) || (ddu_h2_check[0] && ddu_tr1_check[2])) {
+      ddu_inst_i = ddu_h1_n_coll.size();
+      if (ddu_inst_i > 0) {
+        ddu_inst_n = ddu_h1_n_coll[ddu_inst_i - 1];
+      }
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s%i %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              ddu_common,
+              ddu_inst_n,
+              ddu_header3);
+      ddu_h3_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      ddu_h2_found = 0;
+    }
+
+    // DMB Header 1,2
+
+    else if (dmb_h1_check[1]) {
+      dmb_inst_crate = 0;
+      dmb_inst_slot = 0;
+      dmb_inst_l1a = ((buf[i] & 0x0FFF) + ((buf[i + 1] & 0xFFF) << 12));
+      dmb_l1a_coll.push_back(dmb_inst_l1a);
+      if (dmb_h2_check[2]) {
+        dmb_inst_crate = ((buf[i + 4 + 1] >> 4) & 0xFF);
+        dmb_inst_slot = (buf[i + 4 + 1] & 0xF);
+        dmb_crate_coll.push_back(dmb_inst_crate);
+        dmb_slot_coll.push_back(dmb_inst_slot);
+      }
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i %s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dmb_common,
+              dmb_header1,
+              sign1,
+              dmb_common_crate,
+              dmb_inst_crate,
+              dmb_common_slot,
+              dmb_inst_slot,
+              dmb_common_l1a,
+              dmb_inst_l1a);
+      dmb_h1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      ddu_h2_found = 1;
+    }
+
+    else if (dmb_h2_check[1]) {
+      dmb_inst_crate = ((buf[i + 1] >> 4) & 0xFF);
+      dmb_inst_slot = (buf[i + 1] & 0xF);
+      dmb_h2_coll.push_back(word_numbering);
+      if (dmb_h1_check[0])
+        dmb_inst_l1a = ((buf[i - 4] & 0x0FFF) + ((buf[i - 4 + 1] & 0xFFF) << 12));
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i %s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dmb_common,
+              dmb_header2,
+              sign1,
+              dmb_common_crate,
+              dmb_inst_crate,
+              dmb_common_slot,
+              dmb_inst_slot,
+              dmb_common_l1a,
+              dmb_inst_l1a);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      ddu_h2_found = 1;
+    }
+
+    //DDU Trailer 1
+
+    else if (ddu_tr1_check[1]) {
+      ddu_inst_i = ddu_h1_n_coll.size();
+      if (ddu_inst_i > 0) {
+        ddu_inst_n = ddu_h1_n_coll[ddu_inst_i - 1];
+      }
+      //ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s%i %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              ddu_common,
+              ddu_inst_n,
+              ddu_trail1);
+      ddu_t1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    ///ALCT Header 1,2
+    else if (alct_h1_check[1]) {
+      alct_start = word_numbering;
+      alct_inst_l1a = (buf[i + 2] & 0x0FFF);
+      alct_l1a_coll.push_back(alct_inst_l1a);
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s %s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              alct_common,
+              alct_header1,
+              sign1,
+              dmb_common_l1a,
+              alct_inst_l1a);
+      alct_h1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    else if ((alct_h1_check[0]) && (alct_h2_check[2])) {
+      alct_inst_bxn = (buf[i] & 0x0FFF);
+      alct_bxn_coll.push_back(alct_inst_bxn);
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s%s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              alct_common,
+              alct_header2,
+              sign1,
+              alct_common_bxn,
+              alct_inst_bxn);
+      alct_h2_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    //ALCT Trailer 1
+    else if (alct_tr1_check[1]) {
+      alct_stop = word_numbering;
+      if ((alct_start != 0) && (alct_stop != 0) && (alct_stop > alct_start)) {
+        alct_inst_wcnt2 = 4 * (alct_stop - alct_start + 1);
+        alct_wcnt2_coll.push_back(alct_inst_wcnt2);
+        alct_wcnt2_id_coll.push_back(alct_start);
+      }
+      alct_inst_wcnt1 = (buf[i + 3] & 0x7FF);
+      alct_wcnt1_coll.push_back(alct_inst_wcnt1);
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              alct_common,
+              alct_tr1,
+              sign1,
+              alct_common_wcnt1,
+              alct_inst_wcnt1,
+              alct_common_wcnt2,
+              alct_inst_wcnt2);
+      alct_t1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      alct_inst_wcnt2 = 0;
+    }
+
+    //DDU Trailer 3
+
+    //      else if ((ddu_tr1_check[-1])&&(tempbuf_short[0]==ddu_trailer3_bit[0])) { // !!! TO FIX: negative index
+    else if ((ddu_h2_h1) && (tempbuf_short[0] == ddu_trailer3_bit[0])) {
+      //&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
+      ddu_inst_i = ddu_h1_n_coll.size();
+      if (ddu_inst_i > 0) {
+        ddu_inst_n = ddu_h1_n_coll[ddu_inst_i - 1];
+      }
+      //ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s%i %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              ddu_common,
+              ddu_inst_n,
+              ddu_trail3);
+      ddu_t3_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+    //DDU Trailer 2
+    else if ((ddu_tr1_check[0]) && (tempbuf_short[0] != ddu_trailer3_bit[0])) {
+      //&&(tempbuf_short[0]==ddu_trailer3_bit[0])){
+      ddu_inst_i = ddu_h1_n_coll.size();
+      if (ddu_inst_i > 0) {
+        ddu_inst_n = ddu_h1_n_coll[ddu_inst_i - 1];
+      }
+      //ddu_inst_n=ddu_h1_n_coll[ddu_inst_i-1];
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s%i %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              ddu_common,
+              ddu_inst_n,
+              ddu_trail2);
+      ddu_t2_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    //DMB Trailer 1,2
+    else if (dmb_tr1_check[1]) {
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dmb_common,
+              dmb_tr1);
+      dmb_t1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      cfeb_sample = 0;
+    }
+
+    else if (dmb_tr2_check[1]) {
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              dmb_common,
+              dmb_tr2);
+      dmb_t2_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+    // TMB
+    else if (tmb_h1_check[1]) {
+      tmb_start = word_numbering;
+      tmb_inst_l1a = (buf[i + 2] & 0x000F);
+      tmb_l1a_coll.push_back(tmb_inst_l1a);
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s%s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              tmb_common,
+              tmb_header1,
+              sign1,
+              dmb_common_l1a,
+              tmb_inst_l1a);
+      tmb_h1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    } else if (tmb_tr1_check[1]) {
+      tmb_stop = word_numbering;
+      if ((tmb_start != 0) && (tmb_stop != 0) && (tmb_stop > tmb_start)) {
+        tmb_inst_wcnt2 = 4 * (tmb_stop - tmb_start + 1);
+        tmb_wcnt2_coll.push_back(tmb_inst_wcnt2);
+      }
+      tmb_inst_wcnt1 = (buf[i + 3] & 0x7FF);
+      tmb_wcnt1_coll.push_back(tmb_inst_wcnt1);
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s%s %i %s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              tmb_common,
+              tmb_tr1,
+              sign1,
+              alct_common_wcnt1,
+              tmb_inst_wcnt1,
+              alct_common_wcnt2,
+              tmb_inst_wcnt2);
+      tmb_t1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+      tmb_inst_wcnt2 = 0;
+    }
+    // CFEB
+    else if (cfeb_tr1_check[1]) {
+      ++cfeb_sample;
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s%s %s %i",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              cfeb_common,
+              cfeb_tr1,
+              sign1,
+              cfeb_common_sample,
+              cfeb_sample);
+      cfeb_t1_coll.push_back(word_numbering);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    } else if (cfeb_b_check[1]) {
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              cfeb_common,
+              cfeb_b);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    //ERRORS ddu_tr1_bad_check
+
+    else if (ddu_tr1_bad_check[1]) {
+      ddu_inst_i = ddu_h1_n_coll.size();
+      ddu_inst_n = ddu_h1_n_coll[ddu_inst_i - 1];
+      sprintf(tempbuf1,
+              "%6i    %04x %04x %04x %04x%s%s%i %s %s",
+              word_numbering,
+              buf[i + 3],
+              buf[i + 2],
+              buf[i + 1],
+              buf[i],
+              sign1,
+              ddu_common,
+              ddu_inst_n,
+              ddu_trail1,
+              ddu_tr1_err_common);
+      std::cout << tempbuf1 << std::endl;
+      w = 0;
+    }
+
+    else if (extraction && (!ddu_h1_check) && (!dcc_check)) {
+      if (w < 3) {
+        sprintf(tempbuf, "%6i    %04x %04x %04x %04x", word_numbering, buf[i + 3], buf[i + 2], buf[i + 1], buf[i]);
+        std::cout << tempbuf << std::endl;
+        w++;
+      }
+      if (w == 3) {
+        std::cout << "..................................................." << std::endl;
+        w++;
+      }
+    }
+
+    else if ((!ddu_h1_check) && (!dcc_check)) {
+      sprintf(tempbuf, "%6i    %04x %04x %04x %04x", word_numbering, buf[i + 3], buf[i + 2], buf[i + 1], buf[i]);
+      std::cout << tempbuf << std::endl;
+    }
+
+    i += 3;
+    ddu_h1_check = false;
+    dcc_check = false;
+  }
   //char sign[30]; //WARNING 5_0_X
-  std::cout <<"********************************************************************************" <<
-            std::endl << std::endl;
+  std::cout << "********************************************************************************" << std::endl
+            << std::endl;
   if (fedshort)
     std::cout << "For complete output turn off VisualFEDShort in muonCSCDigis configuration file." << std::endl;
-  std::cout <<"********************************************************************************" <<
-            std::endl << std::endl;
+  std::cout << "********************************************************************************" << std::endl
+            << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout <<"            Summary                " << std::endl;
+  std::cout << "            Summary                " << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << ddu_h1_coll.size() <<"  "<< ddu_common << "  "<<ddu_header1 << "  "<< "found" << std::endl;
+  std::cout << ddu_h1_coll.size() << "  " << ddu_common << "  " << ddu_header1 << "  "
+            << "found" << std::endl;
   /*
   std::cout << ddu_h1_coll.size() << " " << ddu_h1_n_coll.size() << " " << ddu_l1a_coll.size() <<
   " " << ddu_bxn_coll.size() << std::endl;
   */
-  for (unsigned int k=0; k<ddu_h1_coll.size(); ++k)
-    {
-      /*
+  for (unsigned int k = 0; k < ddu_h1_coll.size(); ++k) {
+    /*
       sprintf(sign,"%s%6i%5s %s%i %s %i %s %i","Line: ",
       ddu_h1_coll[k],sign1,ddu_common,ddu_h1_n_coll[k],dmb_common_l1a,ddu_l1a_coll[k],
       alct_common_bxn,ddu_bxn_coll[k]);
       */
-      std::cout << "Line: " << "    " << ddu_h1_coll[k] << " " << sign1 << " " <<
-                ddu_common << " " << ddu_h1_n_coll[k] << " " << dmb_common_l1a << " " << ddu_l1a_coll[k] << " " <<
-                alct_common_bxn << " " << ddu_bxn_coll[k] << std::endl;
-    }
-
+    std::cout << "Line: "
+              << "    " << ddu_h1_coll[k] << " " << sign1 << " " << ddu_common << " " << ddu_h1_n_coll[k] << " "
+              << dmb_common_l1a << " " << ddu_l1a_coll[k] << " " << alct_common_bxn << " " << ddu_bxn_coll[k]
+              << std::endl;
+  }
 
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << ddu_h2_coll.size() <<"  "<< ddu_common << "  "<<ddu_header2 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<ddu_h2_coll.size(); ++k)
+  std::cout << ddu_h2_coll.size() << "  " << ddu_common << "  " << ddu_header2 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < ddu_h2_coll.size(); ++k)
     std::cout << "Line:  " << ddu_h2_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << ddu_h3_coll.size() <<"  "<< ddu_common << "  "<<ddu_header3 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<ddu_h3_coll.size(); ++k)
+  std::cout << ddu_h3_coll.size() << "  " << ddu_common << "  " << ddu_header3 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < ddu_h3_coll.size(); ++k)
     std::cout << "Line:  " << ddu_h3_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << ddu_t1_coll.size() <<"  "<< ddu_common << "  "<<ddu_trail1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<ddu_t1_coll.size(); ++k)
+  std::cout << ddu_t1_coll.size() << "  " << ddu_common << "  " << ddu_trail1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < ddu_t1_coll.size(); ++k)
     std::cout << "Line:  " << ddu_t1_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << ddu_t2_coll.size() <<"  "<< ddu_common << "  "<<ddu_trail2 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<ddu_t2_coll.size(); ++k)
+  std::cout << ddu_t2_coll.size() << "  " << ddu_common << "  " << ddu_trail2 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < ddu_t2_coll.size(); ++k)
     std::cout << "Line:  " << ddu_t2_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << ddu_t3_coll.size() <<"  "<< ddu_common << "  "<<ddu_trail3 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<ddu_t3_coll.size(); ++k)
+  std::cout << ddu_t3_coll.size() << "  " << ddu_common << "  " << ddu_trail3 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < ddu_t3_coll.size(); ++k)
     std::cout << "Line:  " << ddu_t3_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << dmb_h1_coll.size() <<"  "<< dmb_common << "  "<<dmb_header1 << "  "<< "found" << std::endl;
+  std::cout << dmb_h1_coll.size() << "  " << dmb_common << "  " << dmb_header1 << "  "
+            << "found" << std::endl;
 
-  for (unsigned int k=0; k<dmb_h1_coll.size(); ++k)
-    {
-      /*
+  for (unsigned int k = 0; k < dmb_h1_coll.size(); ++k) {
+    /*
       sprintf(sign,"%s%6i%5s %s %s %i %s %i %s %i","Line: ",
       dmb_h1_coll[k],sign1,dmb_common,dmb_common_crate,dmb_crate_coll[k],dmb_common_slot,
       dmb_slot_coll[k],dmb_common_l1a,dmb_l1a_coll[k]);
       */
-      std::cout << "Line: " << "    " << dmb_h1_coll[k] << " " << sign1 << dmb_common
-                << " " << dmb_common_crate << " " << dmb_crate_coll[k] << " " << dmb_common_slot << " " <<
-                dmb_slot_coll[k] << " " << dmb_common_l1a << " " << dmb_l1a_coll[k] << std::endl;
-    }
+    std::cout << "Line: "
+              << "    " << dmb_h1_coll[k] << " " << sign1 << dmb_common << " " << dmb_common_crate << " "
+              << dmb_crate_coll[k] << " " << dmb_common_slot << " " << dmb_slot_coll[k] << " " << dmb_common_l1a << " "
+              << dmb_l1a_coll[k] << std::endl;
+  }
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << dmb_h2_coll.size() <<"  "<< dmb_common << "  "<<dmb_header2 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<dmb_h2_coll.size(); ++k)
+  std::cout << dmb_h2_coll.size() << "  " << dmb_common << "  " << dmb_header2 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < dmb_h2_coll.size(); ++k)
     std::cout << "Line:  " << dmb_h2_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << dmb_t1_coll.size() <<"  "<< dmb_common << "  "<<dmb_tr1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<dmb_t1_coll.size(); ++k)
+  std::cout << dmb_t1_coll.size() << "  " << dmb_common << "  " << dmb_tr1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < dmb_t1_coll.size(); ++k)
     std::cout << "Line:  " << dmb_t1_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << dmb_t2_coll.size() <<"  "<< dmb_common << "  "<<dmb_tr2 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<dmb_t2_coll.size(); ++k)
+  std::cout << dmb_t2_coll.size() << "  " << dmb_common << "  " << dmb_tr2 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < dmb_t2_coll.size(); ++k)
     std::cout << "Line:  " << dmb_t2_coll[k] << std::endl;
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << alct_h1_coll.size() <<"  "<< alct_common << "  "<<alct_header1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<alct_h1_coll.size(); ++k)
-    {
-      /*
+  std::cout << alct_h1_coll.size() << "  " << alct_common << "  " << alct_header1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < alct_h1_coll.size(); ++k) {
+    /*
       sprintf(sign,"%s%6i%5s %s %s %i","Line: ",
       alct_h1_coll[k],sign1,alct_common,
       dmb_common_l1a,alct_l1a_coll[k]);
       std::cout << sign << std::endl;
       */
-      std::cout << "Line: " << "    " <<
-                alct_h1_coll[k] << " " << sign1 << " " << alct_common << " " <<
-                dmb_common_l1a << " " << alct_l1a_coll[k] << std::endl;
-    }
+    std::cout << "Line: "
+              << "    " << alct_h1_coll[k] << " " << sign1 << " " << alct_common << " " << dmb_common_l1a << " "
+              << alct_l1a_coll[k] << std::endl;
+  }
 
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << alct_h2_coll.size() <<"  "<< alct_common << "  "<<alct_header2 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<alct_h2_coll.size(); ++k)
-    {
-      /*
+  std::cout << alct_h2_coll.size() << "  " << alct_common << "  " << alct_header2 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < alct_h2_coll.size(); ++k) {
+    /*
       sprintf(sign,"%s%6i%5s %s %s %i","Line: ",
       alct_h1_coll[k],sign1,alct_common,
       alct_common_bxn,alct_bxn_coll[k]);
       std::cout << sign << std::endl;
       */
-      std::cout << "Line: " << "    " <<
-                alct_h1_coll[k] << " " << sign1 << " " << alct_common << " " <<
-                alct_common_bxn << " " << alct_bxn_coll[k] << std::endl;
-    }
+    std::cout << "Line: "
+              << "    " << alct_h1_coll[k] << " " << sign1 << " " << alct_common << " " << alct_common_bxn << " "
+              << alct_bxn_coll[k] << std::endl;
+  }
 
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << alct_t1_coll.size() <<"  "<< alct_common << "  "<<alct_tr1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<alct_t1_coll.size(); ++k)
-    {
-      /*
+  std::cout << alct_t1_coll.size() << "  " << alct_common << "  " << alct_tr1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < alct_t1_coll.size(); ++k) {
+    /*
          sprintf(sign,"%s%6i%5s %s %s %i %s %i","Line: ",
          alct_t1_coll[k],sign1,alct_common,
          alct_common_wcnt1,alct_wcnt1_coll[k],alct_common_wcnt2,alct_wcnt2_coll[k]);
          std::cout << sign << std::endl;
        */
-      std::cout << "Line: " << "    " << alct_t1_coll[k] << " " << sign1 << " " << alct_common << " " <<
-                alct_common_wcnt1 << " " << alct_wcnt1_coll[k] << " " << alct_common_wcnt2 << " ";
-      if (!alct_wcnt2_coll.empty())
-        {
-          std::cout << alct_wcnt2_coll[k] << std::endl;
-        }
-      else
-        {
-          std::cout << "Undefined (ALCT Header is not found) " << std::endl;
-        }
+    std::cout << "Line: "
+              << "    " << alct_t1_coll[k] << " " << sign1 << " " << alct_common << " " << alct_common_wcnt1 << " "
+              << alct_wcnt1_coll[k] << " " << alct_common_wcnt2 << " ";
+    if (!alct_wcnt2_coll.empty()) {
+      std::cout << alct_wcnt2_coll[k] << std::endl;
+    } else {
+      std::cout << "Undefined (ALCT Header is not found) " << std::endl;
     }
+  }
 
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << tmb_h1_coll.size() <<"  "<< tmb_common << "  "<<tmb_header1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<tmb_h1_coll.size(); ++k)
-    {
-      /*
+  std::cout << tmb_h1_coll.size() << "  " << tmb_common << "  " << tmb_header1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < tmb_h1_coll.size(); ++k) {
+    /*
       sprintf(sign,"%s%6i%5s %s %s %i","Line: ",
       tmb_h1_coll[k],sign1,tmb_common,
       dmb_common_l1a,tmb_l1a_coll[k]);
       std::cout << sign << std::endl;
       */
-      std::cout << "Line: " << "    " << tmb_h1_coll[k] << " " << sign1 << " " << tmb_common << " " <<
-                dmb_common_l1a << " " << tmb_l1a_coll[k] << std::endl;
-    }
+    std::cout << "Line: "
+              << "    " << tmb_h1_coll[k] << " " << sign1 << " " << tmb_common << " " << dmb_common_l1a << " "
+              << tmb_l1a_coll[k] << std::endl;
+  }
 
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << tmb_t1_coll.size() <<"  "<< tmb_common << "  "<<tmb_tr1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<tmb_t1_coll.size(); ++k)
-    {
-      /*
+  std::cout << tmb_t1_coll.size() << "  " << tmb_common << "  " << tmb_tr1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < tmb_t1_coll.size(); ++k) {
+    /*
       sprintf(sign,"%s%6i%5s %s %s %i %s %i","Line: ",
       tmb_t1_coll[k],sign1,tmb_common,
       alct_common_wcnt1,tmb_wcnt1_coll[k],alct_common_wcnt2,tmb_wcnt2_coll[k]);
       std::cout << sign << std::endl;
       */
-      std::cout << "Line: " << "    " << tmb_t1_coll[k] << " " << sign1 << " " << tmb_common << " " <<
-                alct_common_wcnt1 << " " << tmb_wcnt1_coll[k] << " " << alct_common_wcnt2 << " " << tmb_wcnt2_coll[k]
-                << std::endl;
-    }
-
+    std::cout << "Line: "
+              << "    " << tmb_t1_coll[k] << " " << sign1 << " " << tmb_common << " " << alct_common_wcnt1 << " "
+              << tmb_wcnt1_coll[k] << " " << alct_common_wcnt2 << " " << tmb_wcnt2_coll[k] << std::endl;
+  }
 
   std::cout << std::endl << std::endl;
   std::cout << "||||||||||||||||||||" << std::endl;
   std::cout << std::endl << std::endl;
-  std::cout << cfeb_t1_coll.size() <<"  "<< cfeb_common << "  "<<cfeb_tr1 << "  "<< "found" << std::endl;
-  for (unsigned int k=0; k<cfeb_t1_coll.size(); ++k)
+  std::cout << cfeb_t1_coll.size() << "  " << cfeb_common << "  " << cfeb_tr1 << "  "
+            << "found" << std::endl;
+  for (unsigned int k = 0; k < cfeb_t1_coll.size(); ++k)
     std::cout << "Line:  " << cfeb_t1_coll[k] << std::endl;
-  std::cout <<"********************************************************************************" << std::endl;
-
+  std::cout << "********************************************************************************" << std::endl;
 }

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiToPattern.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiToPattern.cc
@@ -4,47 +4,38 @@
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
 CSCDigiToPattern::CSCDigiToPattern(edm::ParameterSet const& conf) {
-
-  d_token = consumes<CSCCorrelatedLCTDigiCollection>( conf.getParameter<edm::InputTag>("corrlctDigiTag") );
-
+  d_token = consumes<CSCCorrelatedLCTDigiCollection>(conf.getParameter<edm::InputTag>("corrlctDigiTag"));
 }
 
 void CSCDigiToPattern::analyze(edm::Event const& e, edm::EventSetup const& iSetup) {
-
   // These declarations create handles to the types of records that you want
   // to retrieve from event "e".
   //
   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts;
-  e.getByToken( d_token, correlatedlcts);
+  e.getByToken(d_token, correlatedlcts);
 
-  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j=correlatedlcts->begin(); j!=correlatedlcts->end(); j++) { 
-    CSCDetId id=(*j).first;
-    std::cout<<id<<std::endl;
+  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j = correlatedlcts->begin(); j != correlatedlcts->end(); j++) {
+    CSCDetId id = (*j).first;
+    std::cout << id << std::endl;
     std::vector<CSCCorrelatedLCTDigi>::const_iterator digiIt = (*j).second.first;
     std::vector<CSCCorrelatedLCTDigi>::const_iterator last = (*j).second.second;
-    for( ; digiIt != last; ++digiIt) {
-      uint16_t wire       = digiIt->getKeyWG();    // 7 bits
-      uint16_t pattern    = digiIt->getPattern();  // 4 bits
-      uint16_t quality    = digiIt->getQuality();  // 4 bits
-      uint16_t valid      = digiIt->isValid();     // 1 bit
-      uint16_t strip      = digiIt->getStrip();    // 8 bits
-      uint16_t bend       = digiIt->getBend();     // 1 bit
-      uint16_t syncErr    = digiIt->getSyncErr();  // 1 bit
-      uint16_t bx         = digiIt->getBX();       // 1 bit
-      uint16_t bx0        = digiIt->getBX0();      // 1 bit
-      uint16_t cscId      = digiIt->getCSCID();    // 4 bits
+    for (; digiIt != last; ++digiIt) {
+      uint16_t wire = digiIt->getKeyWG();       // 7 bits
+      uint16_t pattern = digiIt->getPattern();  // 4 bits
+      uint16_t quality = digiIt->getQuality();  // 4 bits
+      uint16_t valid = digiIt->isValid();       // 1 bit
+      uint16_t strip = digiIt->getStrip();      // 8 bits
+      uint16_t bend = digiIt->getBend();        // 1 bit
+      uint16_t syncErr = digiIt->getSyncErr();  // 1 bit
+      uint16_t bx = digiIt->getBX();            // 1 bit
+      uint16_t bx0 = digiIt->getBX0();          // 1 bit
+      uint16_t cscId = digiIt->getCSCID();      // 4 bits
       //                                             __
       //                                             32 bits in total
-      long unsigned int mpc =
-	((cscId&0xF)<<28) | ((bx0&0x1)<<27) | ((bx&0x1)<<26) |
-	((syncErr&0x1)<<25) | ((bend&0x1)<<24) | ((strip&0xFF)<<16) |
-	((valid&0x1)<<15) | ((quality&0xF)<<11) | ((pattern&0xF)<<7) |
-	(wire&0x7F);
-      std::cout <<"MPC"<<digiIt->getTrknmb()<< " " << std::hex << mpc <<std::dec <<std::endl;
+      long unsigned int mpc = ((cscId & 0xF) << 28) | ((bx0 & 0x1) << 27) | ((bx & 0x1) << 26) |
+                              ((syncErr & 0x1) << 25) | ((bend & 0x1) << 24) | ((strip & 0xFF) << 16) |
+                              ((valid & 0x1) << 15) | ((quality & 0xF) << 11) | ((pattern & 0xF) << 7) | (wire & 0x7F);
+      std::cout << "MPC" << digiIt->getTrknmb() << " " << std::hex << mpc << std::dec << std::endl;
     }
   }
 }
-
-
-
-

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiToRawModule.cc
@@ -30,69 +30,63 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 
 namespace edm {
-   class ConfigurationDescriptions;
+  class ConfigurationDescriptions;
 }
 
 class CSCDigiToRaw;
 
 class CSCDigiToRawModule : public edm::global::EDProducer<> {
- public:
+public:
   /// Constructor
-  CSCDigiToRawModule(const edm::ParameterSet & pset);
+  CSCDigiToRawModule(const edm::ParameterSet& pset);
 
   // Operations
-  void produce( edm::StreamID, edm::Event&, const edm::EventSetup& ) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // Fill parameters descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
-
-  unsigned int 	theFormatVersion; // Select which version of data format to use Pre-LS1: 2005, Post-LS1: 2013
-  bool		usePreTriggers;   // Select if to use Pre-Triigers CLCT digis
-  bool		packEverything_;   // bypass all cuts and (pre)trigger requirements
+private:
+  unsigned int theFormatVersion;  // Select which version of data format to use Pre-LS1: 2005, Post-LS1: 2013
+  bool usePreTriggers;            // Select if to use Pre-Triigers CLCT digis
+  bool packEverything_;           // bypass all cuts and (pre)trigger requirements
 
   std::unique_ptr<const CSCDigiToRaw> packer_;
 
-  edm::EDGetTokenT<CSCWireDigiCollection>             wd_token;
-  edm::EDGetTokenT<CSCStripDigiCollection>            sd_token;
-  edm::EDGetTokenT<CSCComparatorDigiCollection>       cd_token;
-  edm::EDGetTokenT<CSCALCTDigiCollection>             al_token;
-  edm::EDGetTokenT<CSCCLCTDigiCollection>             cl_token;
-  edm::EDGetTokenT<CSCCLCTPreTriggerCollection>       pr_token;
-  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>    co_token;
+  edm::EDGetTokenT<CSCWireDigiCollection> wd_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd_token;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> cd_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl_token;
+  edm::EDGetTokenT<CSCCLCTPreTriggerCollection> pr_token;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co_token;
 
-  edm::EDPutTokenT<FEDRawDataCollection>              put_token_;
+  edm::EDPutTokenT<FEDRawDataCollection> put_token_;
 };
 
-
-CSCDigiToRawModule::CSCDigiToRawModule(const edm::ParameterSet & pset): 
-  packer_( std::make_unique<CSCDigiToRaw>(pset))
-{
+CSCDigiToRawModule::CSCDigiToRawModule(const edm::ParameterSet& pset) : packer_(std::make_unique<CSCDigiToRaw>(pset)) {
   //theStrip = pset.getUntrackedParameter<string>("DigiCreator", "cscunpacker");
-  
-  theFormatVersion =  pset.getParameter<unsigned int>("useFormatVersion"); 	// pre-LS1 - '2005'. post-LS1 - '2013'
-  usePreTriggers = pset.getParameter<bool>("usePreTriggers"); 			// disable checking CLCT PreTriggers digis
-  packEverything_ = pset.getParameter<bool>("packEverything");                  // don't check for consistency with trig primitives
-                                                                                // overrides usePreTriggers
 
-  wd_token = consumes<CSCWireDigiCollection>( pset.getParameter<edm::InputTag>("wireDigiTag") );
-  sd_token = consumes<CSCStripDigiCollection>( pset.getParameter<edm::InputTag>("stripDigiTag") );
-  cd_token = consumes<CSCComparatorDigiCollection>( pset.getParameter<edm::InputTag>("comparatorDigiTag") );
-  if(usePreTriggers) {
-    pr_token = consumes<CSCCLCTPreTriggerCollection>( pset.getParameter<edm::InputTag>("preTriggerTag") );
+  theFormatVersion = pset.getParameter<unsigned int>("useFormatVersion");  // pre-LS1 - '2005'. post-LS1 - '2013'
+  usePreTriggers = pset.getParameter<bool>("usePreTriggers");              // disable checking CLCT PreTriggers digis
+  packEverything_ = pset.getParameter<bool>("packEverything");  // don't check for consistency with trig primitives
+                                                                // overrides usePreTriggers
+
+  wd_token = consumes<CSCWireDigiCollection>(pset.getParameter<edm::InputTag>("wireDigiTag"));
+  sd_token = consumes<CSCStripDigiCollection>(pset.getParameter<edm::InputTag>("stripDigiTag"));
+  cd_token = consumes<CSCComparatorDigiCollection>(pset.getParameter<edm::InputTag>("comparatorDigiTag"));
+  if (usePreTriggers) {
+    pr_token = consumes<CSCCLCTPreTriggerCollection>(pset.getParameter<edm::InputTag>("preTriggerTag"));
   }
-  al_token = consumes<CSCALCTDigiCollection>( pset.getParameter<edm::InputTag>("alctDigiTag") );
-  cl_token = consumes<CSCCLCTDigiCollection>( pset.getParameter<edm::InputTag>("clctDigiTag") );
-  co_token = consumes<CSCCorrelatedLCTDigiCollection>( pset.getParameter<edm::InputTag>("correlatedLCTDigiTag") );
+  al_token = consumes<CSCALCTDigiCollection>(pset.getParameter<edm::InputTag>("alctDigiTag"));
+  cl_token = consumes<CSCCLCTDigiCollection>(pset.getParameter<edm::InputTag>("clctDigiTag"));
+  co_token = consumes<CSCCorrelatedLCTDigiCollection>(pset.getParameter<edm::InputTag>("correlatedLCTDigiTag"));
 
-  put_token_ = produces<FEDRawDataCollection>("CSCRawData"); 
-
+  put_token_ = produces<FEDRawDataCollection>("CSCRawData");
 }
 
-
-void CSCDigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-/*** From python/cscPacker_cfi.py
+void CSCDigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  /*** From python/cscPacker_cfi.py
     wireDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCWireDigi"),
     stripDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCStripDigi"),
     comparatorDigiTag = cms.InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"),
@@ -111,39 +105,34 @@ void CSCDigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions & descr
 
   edm::ParameterSetDescription desc;
 
-  desc.add<unsigned int>("useFormatVersion",2005)->
-  setComment("Set to 2005 for pre-LS1 CSC data format, 2013 - new post-LS1 CSC data format");
-  desc.add<bool>("usePreTriggers", true)->
-  setComment("Set to false if CSCCLCTPreTrigger digis are not available");
-  desc.add<bool>("packEverything", false)->
-  setComment("Set to true to disable trigger-related constraints on readout data");
+  desc.add<unsigned int>("useFormatVersion", 2005)
+      ->setComment("Set to 2005 for pre-LS1 CSC data format, 2013 - new post-LS1 CSC data format");
+  desc.add<bool>("usePreTriggers", true)->setComment("Set to false if CSCCLCTPreTrigger digis are not available");
+  desc.add<bool>("packEverything", false)
+      ->setComment("Set to true to disable trigger-related constraints on readout data");
 
-  desc.add<edm::InputTag>("wireDigiTag", edm::InputTag("simMuonCSCDigis","MuonCSCWireDigi"));
-  desc.add<edm::InputTag>("stripDigiTag",edm::InputTag("simMuonCSCDigis","MuonCSCStripDigi"));
-  desc.add<edm::InputTag>("comparatorDigiTag", edm::InputTag("simMuonCSCDigis","MuonCSCComparatorDigi"));
-  desc.add<edm::InputTag>("alctDigiTag",edm::InputTag("simCscTriggerPrimitiveDigis"));
-  desc.add<edm::InputTag>("clctDigiTag",edm::InputTag("simCscTriggerPrimitiveDigis"));
+  desc.add<edm::InputTag>("wireDigiTag", edm::InputTag("simMuonCSCDigis", "MuonCSCWireDigi"));
+  desc.add<edm::InputTag>("stripDigiTag", edm::InputTag("simMuonCSCDigis", "MuonCSCStripDigi"));
+  desc.add<edm::InputTag>("comparatorDigiTag", edm::InputTag("simMuonCSCDigis", "MuonCSCComparatorDigi"));
+  desc.add<edm::InputTag>("alctDigiTag", edm::InputTag("simCscTriggerPrimitiveDigis"));
+  desc.add<edm::InputTag>("clctDigiTag", edm::InputTag("simCscTriggerPrimitiveDigis"));
   desc.add<edm::InputTag>("preTriggerTag", edm::InputTag("simCscTriggerPrimitiveDigis"));
-  desc.add<edm::InputTag>("correlatedLCTDigiTag",edm::InputTag("simCscTriggerPrimitiveDigis", "MPCSORTED"));
+  desc.add<edm::InputTag>("correlatedLCTDigiTag", edm::InputTag("simCscTriggerPrimitiveDigis", "MPCSORTED"));
 
-  desc.add<int32_t>("alctWindowMin", -3)->
-  setComment("If min parameter = -999 always accept");
-  desc.add<int32_t>("alctWindowMax",  3);
-  desc.add<int32_t>("clctWindowMin", -3)->
-  setComment("If min parameter = -999 always accept");
-  desc.add<int32_t>("clctWindowMax",  3);
-  desc.add<int32_t>("preTriggerWindowMin", -3)->
-  setComment("If min parameter = -999 always accept");
-  desc.add<int32_t>("preTriggerWindowMax",  1);
+  desc.add<int32_t>("alctWindowMin", -3)->setComment("If min parameter = -999 always accept");
+  desc.add<int32_t>("alctWindowMax", 3);
+  desc.add<int32_t>("clctWindowMin", -3)->setComment("If min parameter = -999 always accept");
+  desc.add<int32_t>("clctWindowMax", 3);
+  desc.add<int32_t>("preTriggerWindowMin", -3)->setComment("If min parameter = -999 always accept");
+  desc.add<int32_t>("preTriggerWindowMax", 1);
 
   descriptions.add("cscPacker", desc);
 }
 
-
-void CSCDigiToRawModule::produce( edm::StreamID, edm::Event & e, const edm::EventSetup& c ) const {
+void CSCDigiToRawModule::produce(edm::StreamID, edm::Event& e, const edm::EventSetup& c) const {
   ///reverse mapping for packer
   edm::ESHandle<CSCChamberMap> hcham;
-  c.get<CSCChamberMapRcd>().get(hcham); 
+  c.get<CSCChamberMapRcd>().get(hcham);
   const CSCChamberMap* theMapping = hcham.product();
 
   FEDRawDataCollection fed_buffers;
@@ -157,24 +146,32 @@ void CSCDigiToRawModule::produce( edm::StreamID, edm::Event & e, const edm::Even
   edm::Handle<CSCCLCTPreTriggerCollection> preTriggers;
   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedLCTDigis;
 
-  e.getByToken( wd_token, wireDigis );
-  e.getByToken( sd_token, stripDigis );
-  e.getByToken( cd_token, comparatorDigis );
-  e.getByToken( al_token, alctDigis );
-  e.getByToken( cl_token, clctDigis );
+  e.getByToken(wd_token, wireDigis);
+  e.getByToken(sd_token, stripDigis);
+  e.getByToken(cd_token, comparatorDigis);
+  e.getByToken(al_token, alctDigis);
+  e.getByToken(cl_token, clctDigis);
   if (usePreTriggers)
-     e.getByToken( pr_token, preTriggers );
-  e.getByToken( co_token, correlatedLCTDigis );
+    e.getByToken(pr_token, preTriggers);
+  e.getByToken(co_token, correlatedLCTDigis);
 
   // Create the packed data
-  packer_->createFedBuffers(*stripDigis, *wireDigis, *comparatorDigis, 
-                            *alctDigis, *clctDigis, *preTriggers, *correlatedLCTDigis,
-                            fed_buffers, theMapping, e, theFormatVersion, usePreTriggers,
+  packer_->createFedBuffers(*stripDigis,
+                            *wireDigis,
+                            *comparatorDigis,
+                            *alctDigis,
+                            *clctDigis,
+                            *preTriggers,
+                            *correlatedLCTDigis,
+                            fed_buffers,
+                            theMapping,
+                            e,
+                            theFormatVersion,
+                            usePreTriggers,
                             packEverything_);
-  
+
   // put the raw data to the event
   e.emplace(put_token_, std::move(fed_buffers));
 }
-
 
 DEFINE_FWK_MODULE(CSCDigiToRawModule);

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
@@ -22,974 +22,784 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
-CSCDigiValidator::CSCDigiValidator(const edm::ParameterSet& iConfig) 
-{
-  wd1_token = consumes<CSCWireDigiCollection>( iConfig.getParameter<edm::InputTag>("inputWire") );
-  wd2_token = consumes<CSCWireDigiCollection>( iConfig.getParameter<edm::InputTag>("repackWire") );
-  sd1_token = consumes<CSCStripDigiCollection>( iConfig.getParameter<edm::InputTag>("inputStrip") );
-  sd2_token = consumes<CSCStripDigiCollection>( iConfig.getParameter<edm::InputTag>("inputStrip") );
-  cd1_token = consumes<CSCComparatorDigiCollection>( iConfig.getParameter<edm::InputTag>("inputComp") );
-  cd2_token = consumes<CSCComparatorDigiCollection>( iConfig.getParameter<edm::InputTag>("RepackComp") );
-  al1_token = consumes<CSCALCTDigiCollection>( iConfig.getParameter<edm::InputTag>("inputALCT") );
-  al2_token = consumes<CSCALCTDigiCollection>( iConfig.getParameter<edm::InputTag>("repackALCT") );
-  cl1_token = consumes<CSCCLCTDigiCollection>( iConfig.getParameter<edm::InputTag>("inputCLCT") );
-  cl2_token = consumes<CSCCLCTDigiCollection>( iConfig.getParameter<edm::InputTag>("repackCLCT") );
-  co1_token = consumes<CSCCorrelatedLCTDigiCollection>( iConfig.getParameter<edm::InputTag>("inputCorrLCT") );
-  co2_token = consumes<CSCCorrelatedLCTDigiCollection>( iConfig.getParameter<edm::InputTag>("repackCorrLCT") );
-  tr1_token = consumes<L1CSCTrackCollection>( iConfig.getParameter<edm::InputTag>("inputCSCTF") );
-  tr2_token = consumes<L1CSCTrackCollection>( iConfig.getParameter<edm::InputTag>("repackCSCTF") );
-  ts1_token = consumes<CSCTriggerContainer<csctf::TrackStub> >( iConfig.getParameter<edm::InputTag>("inputCSCTFStubs") );
-  ts2_token = consumes<CSCTriggerContainer<csctf::TrackStub> >( iConfig.getParameter<edm::InputTag>("repackCSCTFStubs") );
+CSCDigiValidator::CSCDigiValidator(const edm::ParameterSet& iConfig) {
+  wd1_token = consumes<CSCWireDigiCollection>(iConfig.getParameter<edm::InputTag>("inputWire"));
+  wd2_token = consumes<CSCWireDigiCollection>(iConfig.getParameter<edm::InputTag>("repackWire"));
+  sd1_token = consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("inputStrip"));
+  sd2_token = consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("inputStrip"));
+  cd1_token = consumes<CSCComparatorDigiCollection>(iConfig.getParameter<edm::InputTag>("inputComp"));
+  cd2_token = consumes<CSCComparatorDigiCollection>(iConfig.getParameter<edm::InputTag>("RepackComp"));
+  al1_token = consumes<CSCALCTDigiCollection>(iConfig.getParameter<edm::InputTag>("inputALCT"));
+  al2_token = consumes<CSCALCTDigiCollection>(iConfig.getParameter<edm::InputTag>("repackALCT"));
+  cl1_token = consumes<CSCCLCTDigiCollection>(iConfig.getParameter<edm::InputTag>("inputCLCT"));
+  cl2_token = consumes<CSCCLCTDigiCollection>(iConfig.getParameter<edm::InputTag>("repackCLCT"));
+  co1_token = consumes<CSCCorrelatedLCTDigiCollection>(iConfig.getParameter<edm::InputTag>("inputCorrLCT"));
+  co2_token = consumes<CSCCorrelatedLCTDigiCollection>(iConfig.getParameter<edm::InputTag>("repackCorrLCT"));
+  tr1_token = consumes<L1CSCTrackCollection>(iConfig.getParameter<edm::InputTag>("inputCSCTF"));
+  tr2_token = consumes<L1CSCTrackCollection>(iConfig.getParameter<edm::InputTag>("repackCSCTF"));
+  ts1_token = consumes<CSCTriggerContainer<csctf::TrackStub> >(iConfig.getParameter<edm::InputTag>("inputCSCTFStubs"));
+  ts2_token = consumes<CSCTriggerContainer<csctf::TrackStub> >(iConfig.getParameter<edm::InputTag>("repackCSCTFStubs"));
 
   //  reorderStrips(iConfig.getUntrackedParameter<bool>("applyStripReordering",true))
-
 }
 
-CSCDigiValidator::~CSCDigiValidator()
-{
-}
+CSCDigiValidator::~CSCDigiValidator() {}
 
-bool
-CSCDigiValidator::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+bool CSCDigiValidator::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   bool _err = false;
   using namespace edm;
 
-  typedef std::map<CSCDetId,
-    std::pair<std::vector<CSCWireDigi>,std::vector<CSCWireDigi> > > 
-    matchingDetWireCollection;
-  typedef std::map<CSCDetId,
-    std::pair<std::vector<CSCStripDigi>,std::vector<CSCStripDigi> > > 
-    matchingDetStripCollection;
-  typedef std::map<CSCDetId,
-    std::pair<std::vector<CSCComparatorDigi>,std::vector<CSCComparatorDigi> > > 
-    matchingDetComparatorCollection;
-  typedef std::map<CSCDetId,
-    std::pair<std::vector<CSCCLCTDigi>,std::vector<CSCCLCTDigi> > > 
-    matchingDetCLCTCollection;
-  typedef std::map<CSCDetId,
-    std::pair<std::vector<CSCALCTDigi>,std::vector<CSCALCTDigi> > > 
-    matchingDetALCTCollection;
-  typedef std::map<CSCDetId,
-    std::pair<std::vector<CSCCorrelatedLCTDigi>,std::vector<CSCCorrelatedLCTDigi> > > 
-    matchingDetLCTCollection;
+  typedef std::map<CSCDetId, std::pair<std::vector<CSCWireDigi>, std::vector<CSCWireDigi> > > matchingDetWireCollection;
+  typedef std::map<CSCDetId, std::pair<std::vector<CSCStripDigi>, std::vector<CSCStripDigi> > >
+      matchingDetStripCollection;
+  typedef std::map<CSCDetId, std::pair<std::vector<CSCComparatorDigi>, std::vector<CSCComparatorDigi> > >
+      matchingDetComparatorCollection;
+  typedef std::map<CSCDetId, std::pair<std::vector<CSCCLCTDigi>, std::vector<CSCCLCTDigi> > > matchingDetCLCTCollection;
+  typedef std::map<CSCDetId, std::pair<std::vector<CSCALCTDigi>, std::vector<CSCALCTDigi> > > matchingDetALCTCollection;
+  typedef std::map<CSCDetId, std::pair<std::vector<CSCCorrelatedLCTDigi>, std::vector<CSCCorrelatedLCTDigi> > >
+      matchingDetLCTCollection;
 
   edm::ESHandle<CSCChamberMap> hcham;
-  iSetup.get<CSCChamberMapRcd>().get(hcham); 
+  iSetup.get<CSCChamberMapRcd>().get(hcham);
   const CSCChamberMap* theMapping = hcham.product();
-    
-  Handle<CSCWireDigiCollection> _wi,_swi;
-  Handle<CSCStripDigiCollection> _st,_sst;
-  Handle<CSCComparatorDigiCollection> _cmp,_scmp;
+
+  Handle<CSCWireDigiCollection> _wi, _swi;
+  Handle<CSCStripDigiCollection> _st, _sst;
+  Handle<CSCComparatorDigiCollection> _cmp, _scmp;
   Handle<CSCCLCTDigiCollection> _clct, _sclct;
   Handle<CSCALCTDigiCollection> _alct, _salct;
   Handle<CSCCorrelatedLCTDigiCollection> _lct, _slct;
   Handle<L1CSCTrackCollection> _trk, _strk;
   Handle<CSCTriggerContainer<csctf::TrackStub> > _dt, _sdt;
 
-   // get wire digis before and after unpacking
-   iEvent.getByToken( wd1_token, _swi );
-   iEvent.getByToken( wd2_token, _wi );
+  // get wire digis before and after unpacking
+  iEvent.getByToken(wd1_token, _swi);
+  iEvent.getByToken(wd2_token, _wi);
 
-   //get strip digis before and after unpacking
-   iEvent.getByToken( sd1_token, _sst );
-   iEvent.getByToken( sd2_token, _st );
+  //get strip digis before and after unpacking
+  iEvent.getByToken(sd1_token, _sst);
+  iEvent.getByToken(sd2_token, _st);
 
-   //get comparator digis before and after unpacking
-   iEvent.getByToken( co1_token, _scmp );
-   iEvent.getByToken( co2_token, _cmp );
+  //get comparator digis before and after unpacking
+  iEvent.getByToken(co1_token, _scmp);
+  iEvent.getByToken(co2_token, _cmp);
 
-   //get clcts
-   iEvent.getByToken( cl1_token, _sclct );
-   iEvent.getByToken( cl2_token, _clct );
+  //get clcts
+  iEvent.getByToken(cl1_token, _sclct);
+  iEvent.getByToken(cl2_token, _clct);
 
-   //get alcts
-   iEvent.getByToken( al1_token, _salct );
-   iEvent.getByToken( al2_token, _alct );
+  //get alcts
+  iEvent.getByToken(al1_token, _salct);
+  iEvent.getByToken(al2_token, _alct);
 
-   //get corr lcts
-   iEvent.getByToken( co1_token, _slct );
-   iEvent.getByToken( co2_token, _lct );
+  //get corr lcts
+  iEvent.getByToken(co1_token, _slct);
+  iEvent.getByToken(co2_token, _lct);
 
-   //get l1 tracks
-   iEvent.getByToken( tr1_token, _strk );
-   iEvent.getByToken( tr2_token, _trk );
+  //get l1 tracks
+  iEvent.getByToken(tr1_token, _strk);
+  iEvent.getByToken(tr2_token, _trk);
 
-   //get DT stubs for L1 Tracks
-   iEvent.getByToken( ts1_token, _sdt );
-   iEvent.getByToken( ts2_token, _dt );
+  //get DT stubs for L1 Tracks
+  iEvent.getByToken(ts1_token, _sdt);
+  iEvent.getByToken(ts2_token, _dt);
 
+  CSCWireDigiCollection::DigiRangeIterator wi = _wi->begin(), swi = _swi->begin();
+  CSCStripDigiCollection::DigiRangeIterator st = _st->begin(), sst = _sst->begin();
+  CSCComparatorDigiCollection::DigiRangeIterator cmp = _cmp->begin(), scmp = _scmp->begin();
+  CSCCLCTDigiCollection::DigiRangeIterator clct = _clct->begin(), sclct = _sclct->begin();
+  CSCALCTDigiCollection::DigiRangeIterator alct = _alct->begin(), salct = _salct->begin();
+  CSCCorrelatedLCTDigiCollection::DigiRangeIterator lct = _lct->begin(), slct = _slct->begin();
+  L1CSCTrackCollection::const_iterator trk = _trk->begin(), strk = _strk->begin();
+  std::vector<csctf::TrackStub>::const_iterator dt = _dt->get().begin(), sdt = _sdt->get().begin();
+  // WARNING 5_0_X
+  dt++;
+  dt--;
+  sdt++;
+  sdt--;
 
-   CSCWireDigiCollection::DigiRangeIterator 
-     wi = _wi->begin(), swi= _swi->begin();
-   CSCStripDigiCollection::DigiRangeIterator 
-     st = _st->begin(), sst = _sst->begin();
-   CSCComparatorDigiCollection::DigiRangeIterator 
-     cmp = _cmp->begin(), scmp = _scmp->begin();
-   CSCCLCTDigiCollection::DigiRangeIterator
-     clct = _clct->begin(), sclct = _sclct->begin();
-   CSCALCTDigiCollection::DigiRangeIterator
-     alct = _alct->begin(), salct = _salct->begin();
-   CSCCorrelatedLCTDigiCollection::DigiRangeIterator
-     lct = _lct->begin(), slct = _slct->begin();
-   L1CSCTrackCollection::const_iterator 
-     trk = _trk->begin(), strk = _strk->begin();
-   std::vector<csctf::TrackStub>::const_iterator
-     dt = _dt->get().begin(), sdt = _sdt->get().begin();
-     // WARNING 5_0_X
-     dt++; dt--; sdt++; sdt--;
+  //per detID, create lists of various digi types
+  matchingDetWireCollection wires;
+  matchingDetStripCollection strips;
+  matchingDetComparatorCollection comps;
+  matchingDetCLCTCollection clcts;
+  matchingDetALCTCollection alcts;
+  matchingDetLCTCollection lcts, trackstubs;
+  CSCTriggerContainer<csc::L1Track> tracks, simtracks;
 
-   //per detID, create lists of various digi types
-   matchingDetWireCollection wires;
-   matchingDetStripCollection strips;
-   matchingDetComparatorCollection comps;
-   matchingDetCLCTCollection clcts;
-   matchingDetALCTCollection alcts;
-   matchingDetLCTCollection lcts,trackstubs;
-   CSCTriggerContainer<csc::L1Track> tracks, simtracks;
-   
-   //wires
-   for(;wi != _wi->end();++wi)
-     {
-       CSCWireDigiCollection::const_iterator 
-	 b=(*wi).second.first,e=(*wi).second.second;
-       std::vector<CSCWireDigi>::iterator 
-	 beg=wires[(*wi).first].first.end();
-       wires[(*wi).first].first.insert(beg,b,e);
-     }
-   for(;swi != _swi->end();++swi)
-     {
-       CSCWireDigiCollection::const_iterator 
-	 b=(*swi).second.first,e=(*swi).second.second;
-       //convert sim ring 4(ME1/a) to ring 1
-       CSCDetId _id = (*swi).first;
-       if((*swi).first.ring() == 4)
-	 _id = CSCDetId((*swi).first.endcap(),(*swi).first.station(),
-			1, (*swi).first.chamber(),(*swi).first.layer());
+  //wires
+  for (; wi != _wi->end(); ++wi) {
+    CSCWireDigiCollection::const_iterator b = (*wi).second.first, e = (*wi).second.second;
+    std::vector<CSCWireDigi>::iterator beg = wires[(*wi).first].first.end();
+    wires[(*wi).first].first.insert(beg, b, e);
+  }
+  for (; swi != _swi->end(); ++swi) {
+    CSCWireDigiCollection::const_iterator b = (*swi).second.first, e = (*swi).second.second;
+    //convert sim ring 4(ME1/a) to ring 1
+    CSCDetId _id = (*swi).first;
+    if ((*swi).first.ring() == 4)
+      _id = CSCDetId((*swi).first.endcap(), (*swi).first.station(), 1, (*swi).first.chamber(), (*swi).first.layer());
 
-       std::vector<CSCWireDigi>::iterator 
-	 beg=wires[_id].second.end();
-       
-       wires[_id].second.insert(beg,b,e);
-       // automatically combine wire digis after each insertion
-       wires[_id].second = sanitizeWireDigis(wires[_id].second.begin(),
-					     wires[_id].second.end());
-     }
-   
-   //strips
-   for(;st != _st->end();++st)
-     {
-       CSCStripDigiCollection::const_iterator 
-	 b=(*st).second.first,e=(*st).second.second;
-       std::vector<CSCStripDigi>::iterator 
-	 beg=strips[(*st).first].first.end();
-              
-       //need to remove strips with no active ADCs
-       std::vector<CSCStripDigi> zs = zeroSupStripDigis(b,e);
+    std::vector<CSCWireDigi>::iterator beg = wires[_id].second.end();
 
-       strips[(*st).first].first.insert(beg,zs.begin(),zs.end());
-     }
-   for(;sst != _sst->end();++sst)
-     {
-       CSCStripDigiCollection::const_iterator 
-	 b=(*sst).second.first,e=(*sst).second.second;
-       // conversion of ring 4->1 not necessary here
-       CSCDetId _id = (*sst).first;
-       //if((*sst).first.ring() == 4)	 
-       //	 _id = CSCDetId((*sst).first.endcap(),(*sst).first.station(),
-       //		1, (*sst).first.chamber(),(*sst).first.layer());
+    wires[_id].second.insert(beg, b, e);
+    // automatically combine wire digis after each insertion
+    wires[_id].second = sanitizeWireDigis(wires[_id].second.begin(), wires[_id].second.end());
+  }
 
-       std::vector<CSCStripDigi>::iterator 
-	 beg=strips[_id].second.end();       
-       
-       std::vector<CSCStripDigi> relab = relabelStripDigis(theMapping,(*sst).first,b,e);
-        
-       strips[_id].second.insert(beg,relab.begin(),relab.end());              
-       //strips[_id].second.insert(beg,b,e);  
-     }
-   
-   //comparators
-   for(;cmp != _cmp->end();++cmp)
-     {
-       CSCComparatorDigiCollection::const_iterator 
-	 b=(*cmp).second.first,e=(*cmp).second.second;
-       std::vector<CSCComparatorDigi>::iterator 
-	 beg=comps[(*cmp).first].first.end();
+  //strips
+  for (; st != _st->end(); ++st) {
+    CSCStripDigiCollection::const_iterator b = (*st).second.first, e = (*st).second.second;
+    std::vector<CSCStripDigi>::iterator beg = strips[(*st).first].first.end();
 
-       comps[(*cmp).first].first.insert(beg,b,e);
-     }
-   for(;scmp != _scmp->end();++scmp)
-     {
-       CSCComparatorDigiCollection::const_iterator 
-	 b=(*scmp).second.first,e=(*scmp).second.second;
-       // convert sim ring 4 (ME1/a) to ring 1
-       CSCDetId _id = (*scmp).first;
-       if((*scmp).first.ring() == 4)
-         _id = CSCDetId((*scmp).first.endcap(),(*scmp).first.station(),
-			1, (*scmp).first.chamber(),(*scmp).first.layer());
-       
-       std::vector<CSCComparatorDigi>::iterator 
-	 beg=comps[_id].second.begin();
+    //need to remove strips with no active ADCs
+    std::vector<CSCStripDigi> zs = zeroSupStripDigis(b, e);
 
-       if((*scmp).first.ring()==4)
-	 beg=comps[_id].second.end();
+    strips[(*st).first].first.insert(beg, zs.begin(), zs.end());
+  }
+  for (; sst != _sst->end(); ++sst) {
+    CSCStripDigiCollection::const_iterator b = (*sst).second.first, e = (*sst).second.second;
+    // conversion of ring 4->1 not necessary here
+    CSCDetId _id = (*sst).first;
+    //if((*sst).first.ring() == 4)
+    //	 _id = CSCDetId((*sst).first.endcap(),(*sst).first.station(),
+    //		1, (*sst).first.chamber(),(*sst).first.layer());
 
-       std::vector<CSCComparatorDigi> zs = 
-	 zeroSupCompDigis(b,e);			  
+    std::vector<CSCStripDigi>::iterator beg = strips[_id].second.end();
 
-       std::vector<CSCComparatorDigi> relab = 
-	 relabelCompDigis(theMapping,(*scmp).first,
-			  zs.begin(),
-			  zs.end());
+    std::vector<CSCStripDigi> relab = relabelStripDigis(theMapping, (*sst).first, b, e);
 
-       comps[_id].second.insert(beg,relab.begin(),relab.end());
-     }
+    strips[_id].second.insert(beg, relab.begin(), relab.end());
+    //strips[_id].second.insert(beg,b,e);
+  }
 
-   //CLCTs
-   for(;clct != _clct->end();++clct)
-     {
-       CSCCLCTDigiCollection::const_iterator 
-	 b=(*clct).second.first,e=(*clct).second.second;
-       std::vector<CSCCLCTDigi>::iterator 
-	 beg=clcts[(*clct).first].first.end();
+  //comparators
+  for (; cmp != _cmp->end(); ++cmp) {
+    CSCComparatorDigiCollection::const_iterator b = (*cmp).second.first, e = (*cmp).second.second;
+    std::vector<CSCComparatorDigi>::iterator beg = comps[(*cmp).first].first.end();
 
-       clcts[(*clct).first].first.insert(beg,b,e);
-     }
-   for(;sclct != _sclct->end();++sclct)
-     {
-       CSCCLCTDigiCollection::const_iterator 
-	 b=(*sclct).second.first,e=(*sclct).second.second;
-       // convert sim ring 4 (ME1/a) to ring 1
-       CSCDetId _id = (*sclct).first;
-       if((*sclct).first.ring() == 4)
-         _id = CSCDetId((*sclct).first.endcap(),(*sclct).first.station(),
-			1, (*sclct).first.chamber(),(*sclct).first.layer());
-       
-       std::vector<CSCCLCTDigi>::iterator 
-	 beg=clcts[_id].second.begin();
+    comps[(*cmp).first].first.insert(beg, b, e);
+  }
+  for (; scmp != _scmp->end(); ++scmp) {
+    CSCComparatorDigiCollection::const_iterator b = (*scmp).second.first, e = (*scmp).second.second;
+    // convert sim ring 4 (ME1/a) to ring 1
+    CSCDetId _id = (*scmp).first;
+    if ((*scmp).first.ring() == 4)
+      _id =
+          CSCDetId((*scmp).first.endcap(), (*scmp).first.station(), 1, (*scmp).first.chamber(), (*scmp).first.layer());
 
-       if((*sclct).first.ring()==4)
-	 beg=clcts[_id].second.end();
-       
-       clcts[_id].second.insert(beg,b,e);
-     }
+    std::vector<CSCComparatorDigi>::iterator beg = comps[_id].second.begin();
 
-   //ALCTs
-   for(;alct != _alct->end();++alct)
-     {
-       CSCALCTDigiCollection::const_iterator 
-	 b=(*alct).second.first,e=(*alct).second.second;
-       std::vector<CSCALCTDigi>::iterator 
-	 beg=alcts[(*alct).first].first.end();
+    if ((*scmp).first.ring() == 4)
+      beg = comps[_id].second.end();
 
-       alcts[(*alct).first].first.insert(beg,b,e);
-     }
-   for(;salct != _salct->end();++salct)
-     {
-       CSCALCTDigiCollection::const_iterator 
-	 b=(*salct).second.first,e=(*salct).second.second;
-       // convert sim ring 4 (ME1/a) to ring 1
-       CSCDetId _id = (*salct).first;
-       if((*salct).first.ring() == 4)
-         _id = CSCDetId((*salct).first.endcap(),(*salct).first.station(),
-			1, (*salct).first.chamber(),(*salct).first.layer());
-       
-       std::vector<CSCALCTDigi>::iterator 
-	 beg=alcts[_id].second.begin();
+    std::vector<CSCComparatorDigi> zs = zeroSupCompDigis(b, e);
 
-       if((*salct).first.ring()==4)
-	 beg=alcts[_id].second.end();
-       
-       alcts[_id].second.insert(beg,b,e);
-     }
+    std::vector<CSCComparatorDigi> relab = relabelCompDigis(theMapping, (*scmp).first, zs.begin(), zs.end());
 
-   // Correlated LCTs
-   for(;lct != _lct->end();++lct)
-     {
-       CSCCorrelatedLCTDigiCollection::const_iterator 
-	 b=(*lct).second.first,e=(*lct).second.second;
-       std::vector<CSCCorrelatedLCTDigi>::iterator 
-	 beg=lcts[(*lct).first].first.end();
+    comps[_id].second.insert(beg, relab.begin(), relab.end());
+  }
 
-       lcts[(*lct).first].first.insert(beg,b,e);
-     }
-   for(;slct != _slct->end();++slct)
-     {
-       CSCCorrelatedLCTDigiCollection::const_iterator 
-	 b=(*slct).second.first,e=(*slct).second.second;
-       // convert sim ring 4 (ME1/a) to ring 1
-       CSCDetId _id = (*slct).first;
-       if((*slct).first.ring() == 4)
-         _id = CSCDetId((*slct).first.endcap(),(*slct).first.station(),
-			1, (*slct).first.chamber(),(*slct).first.layer());
-       
-       std::vector<CSCCorrelatedLCTDigi>::iterator 
-	 beg=lcts[_id].second.begin();
+  //CLCTs
+  for (; clct != _clct->end(); ++clct) {
+    CSCCLCTDigiCollection::const_iterator b = (*clct).second.first, e = (*clct).second.second;
+    std::vector<CSCCLCTDigi>::iterator beg = clcts[(*clct).first].first.end();
 
-       if((*slct).first.ring()==4)
-	 beg=lcts[_id].second.end();
-       
-       lcts[_id].second.insert(beg,b,e);
-     }
-   // remove attached LCT digis from tracks, should be put into their own collection and checked separately
-   for(; trk != _trk->end(); ++trk)
-     {
-       tracks.push_back(trk->first);
-       
-     }
-   for(;strk != _strk->end(); ++strk)
-     {
-       simtracks.push_back(strk->first);
-     }
+    clcts[(*clct).first].first.insert(beg, b, e);
+  }
+  for (; sclct != _sclct->end(); ++sclct) {
+    CSCCLCTDigiCollection::const_iterator b = (*sclct).second.first, e = (*sclct).second.second;
+    // convert sim ring 4 (ME1/a) to ring 1
+    CSCDetId _id = (*sclct).first;
+    if ((*sclct).first.ring() == 4)
+      _id = CSCDetId(
+          (*sclct).first.endcap(), (*sclct).first.station(), 1, (*sclct).first.chamber(), (*sclct).first.layer());
 
-   //now loop through each set and process if there are differences!
-   matchingDetWireCollection::const_iterator w;
-   matchingDetStripCollection::const_iterator s;
-   matchingDetComparatorCollection::const_iterator c;
-   matchingDetCLCTCollection::const_iterator cl;
-   matchingDetALCTCollection::const_iterator al;
-   matchingDetLCTCollection::const_iterator lc;
-   
-   for(w = wires.begin(); w != wires.end(); ++w)
-     {
-       if(w->second.first.size() != w->second.second.size())
-	 {
-	   std::cout << "Major error! # of wire digis in detID: " << w->first 
-		     << " is not equal between sim and unpacked!" << std::endl;
-	   //eventually do more in this case!
+    std::vector<CSCCLCTDigi>::iterator beg = clcts[_id].second.begin();
 
-	   std::vector<CSCWireDigi> a = w->second.second;
-	   std::vector<CSCWireDigi> b = w->second.first;
-	   std::cout << "SIM OUTPUT:" << std::endl;
-	   for(std::vector<CSCWireDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
-	     i->print();
-	   std::cout << "UNPACKER OUTPUT:" << std::endl;
-	   for(std::vector<CSCWireDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
-	     i->print();
-	     
-	 }
-       int max = std::min(w->second.first.size(),w->second.second.size());
-       std::vector<CSCWireDigi> cv = w->second.first;
-       std::vector<CSCWireDigi> sv = w->second.second;
-       for(int i = 0; i < max; ++i)
-	 {
-	   if(sv[i].getWireGroup() != cv[i].getWireGroup())
-	     {
-	       std::cout << "In detId: " << w->first << std::endl;
-	       std::cout << "Wire Groups do not match: " << sv[i].getWireGroup() 
-			 << " != " << cv[i].getWireGroup() << std::endl;	       
-	     }
-	   if(sv[i].getTimeBin() != cv[i].getTimeBin())
-	     {
-	       std::cout << "In detId: " << w->first << std::endl;
-	       std::cout << "First Time Bins do not match: " << sv[i].getTimeBin()
-			 << " != " << cv[i].getTimeBin() << std::endl;	       
-	     }	   
-	   if(sv[i].getTimeBinWord() != cv[i].getTimeBinWord())
-	     {
-	       std::cout << "In detId: " << w->first << std::endl;
-	       std::cout << "Time Bin Words do not match: " << sv[i].getTimeBinWord()
-			 << " != " << cv[i].getTimeBinWord() << std::endl;
-	     }	   
-	 }
-     }
-   for(s = strips.begin(); s != strips.end(); ++s)
-     {
-       if(s->second.first.size() != s->second.second.size())
-	 {
-	   std::cout << "Major error! # of strip digis in detID: " << s->first 
-		     << " is not equal between sim and unpacked!" << std::endl;
-	   //eventually do more in this case!
+    if ((*sclct).first.ring() == 4)
+      beg = clcts[_id].second.end();
 
-	   std::vector<CSCStripDigi> a = s->second.second;
-	   std::vector<CSCStripDigi> b = s->second.first;
-	   std::cout << "SIM OUTPUT:" << std::endl;
-	   for(std::vector<CSCStripDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
-	     i->print();
-	   std::cout << "UNPACKER OUTPUT:" << std::endl;
-	   for(std::vector<CSCStripDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
-	     i->print();	     
-	 }
-       int max = std::min(s->second.first.size(),s->second.second.size());
-       std::vector<CSCStripDigi> cv = s->second.first;
-       std::vector<CSCStripDigi> sv = s->second.second;
-       for(int i = 0; i < max; ++i)
-	 {
-	   bool me1a = s->first.station()==1 && s->first.ring()==4;
-	   bool me1b = s->first.station()==1 && s->first.ring()==1;
-	   bool zplus = s->first.endcap()==1;
-	   int k=i;
-	   
-	   if(me1a && zplus) k=max-i-1;
-	   if(me1b && !zplus) k=max-i-1;
+    clcts[_id].second.insert(beg, b, e);
+  }
 
-	   if(sv[k].getStrip() != cv[i].getStrip())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "Strips do not match: " << sv[k].getStrip() 
-			 << " != " << cv[i].getStrip() << std::endl;	       
-	     }
-	   if(sv[k].getADCCounts().size() != cv[i].getADCCounts().size())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "ADC Readouts not of equal size!" << std::endl;
-	       std::cout << sv[k].getADCCounts().size() << ' ' 
-			 << cv[i].getADCCounts().size() << std::endl;
-	     }
-	   else
-	     {
-	       std::vector<int> sADC = sv[k].getADCCounts();
-	       std::vector<int> uADC = cv[i].getADCCounts();
+  //ALCTs
+  for (; alct != _alct->end(); ++alct) {
+    CSCALCTDigiCollection::const_iterator b = (*alct).second.first, e = (*alct).second.second;
+    std::vector<CSCALCTDigi>::iterator beg = alcts[(*alct).first].first.end();
 
-	       for(unsigned iadc = 0; iadc < sADC.size(); ++iadc)
-		 if(sADC[iadc] != uADC[iadc])
-		   {
-		     std::cout << "In detId: " << s->first << std::endl;
-		     std::cout << "ADC counts not equal at index: " << iadc << std::endl
-			       << std::hex <<sADC[iadc] << " != " << uADC[iadc] << std::dec
-			       << std::endl;	
-		   }	 
-	     }
-	   if(sv[k].getADCOverflow().size() != cv[i].getADCOverflow().size())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "ADC Overflows not of equal size!" << std::endl;
-	       std::cout << sv[k].getADCOverflow().size() << ' ' 
-			 << cv[i].getADCOverflow().size() << std::endl;
-	     }
-	   else
-	     {
-	       std::vector<uint16_t> sADC = sv[k].getADCOverflow();
-	       std::vector<uint16_t> uADC = cv[i].getADCOverflow();
+    alcts[(*alct).first].first.insert(beg, b, e);
+  }
+  for (; salct != _salct->end(); ++salct) {
+    CSCALCTDigiCollection::const_iterator b = (*salct).second.first, e = (*salct).second.second;
+    // convert sim ring 4 (ME1/a) to ring 1
+    CSCDetId _id = (*salct).first;
+    if ((*salct).first.ring() == 4)
+      _id = CSCDetId(
+          (*salct).first.endcap(), (*salct).first.station(), 1, (*salct).first.chamber(), (*salct).first.layer());
 
-	       for(unsigned iadc = 0; iadc < sADC.size(); ++iadc)
-		 if(sADC[iadc] != uADC[iadc])
-		   {
-		     std::cout << "In detId: " << s->first << std::endl;
-		     std::cout << "ADC overflows not equal at index: " << iadc << std::endl
-			       << std::hex <<sADC[iadc] << " != " << uADC[iadc] << std::dec
-			       << std::endl;		 
-		   }
-	     }
-	   if(sv[k].getOverlappedSample().size() != cv[i].getOverlappedSample().size())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "Overlapped Samples not of equal size!" << std::endl;
-	       std::cout << sv[k].getOverlappedSample().size() << ' ' 
-			 << cv[i].getOverlappedSample().size() << std::endl;
-	     }
-	   else
-	     {
-	       std::vector<uint16_t> sADC = sv[k].getOverlappedSample();
-	       std::vector<uint16_t> uADC = cv[i].getOverlappedSample();
+    std::vector<CSCALCTDigi>::iterator beg = alcts[_id].second.begin();
 
-	       for(unsigned iadc = 0; iadc < sADC.size(); ++iadc)
-		 if(sADC[iadc] != uADC[iadc])
-		   {
-		     std::cout << "In detId: " << s->first << std::endl;
-		     std::cout << "Overlapped Samples not equal at index: " << iadc << std::endl
-			       << std::hex <<sADC[iadc] << " != " << uADC[iadc] << std::dec
-			       << std::endl;		 
-		   }
-	     }
-	   if(sv[k].getErrorstat().size() != cv[i].getErrorstat().size())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "Errorstat not of equal size!" << std::endl;
-	       std::cout << sv[k].getErrorstat().size() << ' ' 
-			 << cv[i].getErrorstat().size() << std::endl;
-	     }
-	   else
-	     {
-	       std::vector<uint16_t> sADC = sv[k].getErrorstat();
-	       std::vector<uint16_t> uADC = cv[i].getErrorstat();
+    if ((*salct).first.ring() == 4)
+      beg = alcts[_id].second.end();
 
-	       for(unsigned iadc = 0; iadc < sADC.size(); ++iadc)
-		 if(sADC[iadc] != uADC[iadc])
-		   {
-		     std::cout << "In detId: " << s->first << std::endl;
-		     std::cout << "Errorstat not equal at index: " << iadc << std::endl
-			       << std::hex <<sADC[iadc] << " != " << uADC[iadc] << std::dec
-			       << std::endl;		 
-		   }
-	     }
-	   if(sv[k].pedestal() != cv[i].pedestal())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "Pedestals not equal: " << sv[k].pedestal() << " != " 
-			 << cv[i].pedestal() << std::endl;
-	     }
-	   if(sv[k].amplitude() != cv[i].amplitude())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "Amplitudes not equal: " << sv[k].amplitude() << " != " 
-			 << cv[i].amplitude() << std::endl;
-	     }
-	 }
-     }
-   for(c = comps.begin(); c != comps.end(); ++c)
-     {
-       if(c->second.first.size() != c->second.second.size())
-	 {
-	   std::cout << "Major error! # of comparator digis in detID: " << c->first
-		     << " is not equal between sim and unpacked!" << std::endl;
-	   //eventually do more in this case!
+    alcts[_id].second.insert(beg, b, e);
+  }
 
-	   std::vector<CSCComparatorDigi> a = c->second.second;
-	   std::vector<CSCComparatorDigi> b = c->second.first;
-	   std::cout << "SIM OUTPUT:" << std::endl;
-	   for(std::vector<CSCComparatorDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
-	     i->print();
-	   std::cout << "UNPACKER OUTPUT:" << std::endl;
-	   for(std::vector<CSCComparatorDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
-	     i->print();	     
-	 }
-       int max = std::min(c->second.first.size(),c->second.second.size());
-       std::vector<CSCComparatorDigi> cv = c->second.first;
-       std::vector<CSCComparatorDigi> sv = c->second.second;
-       for(int i = 0; i < max; ++i)
-	 {	   
-	   if(sv[i].getStrip() != cv[i].getStrip())
-	     {
-	       std::cout << "In detId: " << s->first << std::endl;
-	       std::cout << "Comparator strips do not match: " << sv[i].getStrip() 
-			 << " != " << cv[i].getStrip() << std::endl;
-	     }
-	   if(sv[i].getComparator() != cv[i].getComparator())
-	     {	       
-	       std::cout << "In detId: " << c->first << std::endl;
-	       std::cout << "Comparators do not match: " << sv[i].getComparator()
-			 << " != " << cv[i].getComparator() << std::endl;	      
-	     }
-	   if(sv[i].getTimeBinWord() != cv[i].getTimeBinWord())
-	     {
-	       std::cout << "In detId: " << c->first << std::endl;
-	       std::cout << "Comparator time bins words do not match: " << sv[i].getTimeBinWord()
-			 << " != " << cv[i].getTimeBinWord() << std::endl;
-	     }
-	 }
-     }
-   for(cl = clcts.begin(); cl != clcts.end(); ++cl)
-     {
-       if(cl->second.first.size() != cl->second.second.size())
-	 {
-	   std::cout << "Major error! # of CLCT digis in detID: " << cl->first
-		     << " is not equal between sim and unpacked!" << std::endl;
-	   //eventually do more in this case!
+  // Correlated LCTs
+  for (; lct != _lct->end(); ++lct) {
+    CSCCorrelatedLCTDigiCollection::const_iterator b = (*lct).second.first, e = (*lct).second.second;
+    std::vector<CSCCorrelatedLCTDigi>::iterator beg = lcts[(*lct).first].first.end();
 
-	   std::vector<CSCCLCTDigi> a = cl->second.second;
-	   std::vector<CSCCLCTDigi> b = cl->second.first;
-	   std::cout << "SIM OUTPUT:" << std::endl;
-	   for(std::vector<CSCCLCTDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
-	     i->print();
-	   std::cout << "UNPACKER OUTPUT:" << std::endl;
-	   for(std::vector<CSCCLCTDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
-	     i->print();	     
-	 }
-       int max = std::min(cl->second.first.size(),cl->second.second.size());
-       std::vector<CSCCLCTDigi> cv = cl->second.first;
-       std::vector<CSCCLCTDigi> sv = cl->second.second;
-       for(int i = 0; i < max; ++i)
-	 {
-	   if(cv[i].getKeyStrip() != sv[i].getKeyStrip())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT key strips do not match: " << sv[i].getKeyStrip()
-			 << " != " << cv[i].getKeyStrip() << std::endl;
-	     }
-	   if(cv[i].getStrip() != sv[i].getStrip())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT strips do not match: " << sv[i].getStrip()
-			 << " != " << cv[i].getStrip() << std::endl;
-	     }	   
-	   if(cv[i].isValid() != sv[i].isValid())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT Valid bits do not match: " << sv[i].isValid() 
-			 << " != " << cv[i].isValid() << std::endl;
-	     }
-	   if(cv[i].getQuality() != sv[i].getQuality())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT qualities do not match: " << sv[i].getQuality()
-			 << " != " << cv[i].getQuality() << std::endl;
-	     }
-	   if(cv[i].getPattern() != sv[i].getPattern())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT patterns do not match: " << sv[i].getPattern()
-			 << " != " << cv[i].getPattern() << std::endl;
-	     }
-	   if(cv[i].getStripType() != sv[i].getStripType())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT strip types do not match: " << sv[i].getStripType()
-			 << " != " << cv[i].getStripType() << std::endl;
-	     }
-	   if(cv[i].getBend() != sv[i].getBend())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT bends do not match: " << sv[i].getBend()
-			 << " != " << cv[i].getBend() << std::endl;
-	     }
-	   if(cv[i].getCFEB() != sv[i].getCFEB())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT CFEBs do not match: " << sv[i].getCFEB()
-			 << " != " << cv[i].getCFEB() << std::endl;
-	     }
-	   if(((short)cv[i].getBX()) != ((short)sv[i].getBX()) - 4)
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT BX do not match: " << sv[i].getBX() - 4
-			 << " != " << cv[i].getBX() << std::endl;
-	     }
-	   if(cv[i].getFullBX() != sv[i].getFullBX())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT Full BX do not match: " << sv[i].getFullBX()
-			 << " != " << cv[i].getFullBX() << std::endl;
-	     }
-	   if(cv[i].getTrknmb() != sv[i].getTrknmb())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "CLCT Track numbers do not match: " << sv[i].getTrknmb()
-			 << " != " << cv[i].getTrknmb() << std::endl;
-	     }	   
-	 }
-     }
-   for(al = alcts.begin(); al != alcts.end(); ++al)
-     {
-       if(al->second.first.size() != al->second.second.size())
-	 {
-	   std::cout << "Major error! # of ALCT digis in detID: " << al->first
-		     << " is not equal between sim and unpacked!" << std::endl;
-	   //eventually do more in this case!
+    lcts[(*lct).first].first.insert(beg, b, e);
+  }
+  for (; slct != _slct->end(); ++slct) {
+    CSCCorrelatedLCTDigiCollection::const_iterator b = (*slct).second.first, e = (*slct).second.second;
+    // convert sim ring 4 (ME1/a) to ring 1
+    CSCDetId _id = (*slct).first;
+    if ((*slct).first.ring() == 4)
+      _id =
+          CSCDetId((*slct).first.endcap(), (*slct).first.station(), 1, (*slct).first.chamber(), (*slct).first.layer());
 
-	   std::vector<CSCALCTDigi> a = al->second.second;
-	   std::vector<CSCALCTDigi> b = al->second.first;
-	   std::cout << "SIM OUTPUT:" << std::endl;
-	   for(std::vector<CSCALCTDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
-	     i->print();
-	   std::cout << "UNPACKER OUTPUT:" << std::endl;
-	   for(std::vector<CSCALCTDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
-	     i->print();	     
-	 }
-       int max = std::min(al->second.first.size(),al->second.second.size());
-       std::vector<CSCALCTDigi> cv = al->second.first;
-       std::vector<CSCALCTDigi> sv = al->second.second;
-       for(int i = 0; i < max; ++i)
-	 {
-	   if(cv[i].getKeyWG() != sv[i].getKeyWG())
-	     {
-	       std::cout << "In detId: " << al->first << std::endl;
-	       std::cout << "ALCT key wire groups do not match: " << sv[i].getKeyWG()
-			 << " != " << cv[i].getKeyWG() << std::endl;
-	     }
-	   if(cv[i].isValid() != sv[i].isValid())
-	     {
-	       std::cout << "In detId: " << al->first << std::endl;
-	       std::cout << "ALCT Valid bits do not match: " << sv[i].isValid() 
-			 << " != " << cv[i].isValid() << std::endl;
-	     }
-	   if(cv[i].getQuality() != sv[i].getQuality())
-	     {
-	       std::cout << "In detId: " << al->first << std::endl;
-	       std::cout << "ALCT qualities do not match: " << sv[i].getQuality()
-			 << " != " << cv[i].getQuality() << std::endl;
-	     }
-	   if(cv[i].getAccelerator() != sv[i].getAccelerator())
-	     {
-	       std::cout << "In detId: " << al->first << std::endl;
-	       std::cout << "ALCT accelerator bits do not match: " << sv[i].getAccelerator()
-			 << " != " << cv[i].getAccelerator() << std::endl;
-	     }
-	   if(cv[i].getCollisionB() != sv[i].getCollisionB())
-	     {
-	       std::cout << "In detId: " << al->first << std::endl;
-	       std::cout << "ALCT CollisionB flags do not match: " << sv[i].getCollisionB()
-			 << " != " << cv[i].getCollisionB() << std::endl;
-	     }
-	   if((cv[i].getBX()) != (sv[i].getBX()))
-	     {
-	       std::cout << "In detId: " << al->first << std::endl;
-	       std::cout << "ALCT BX do not match: " << sv[i].getBX()
-			 << " != " << cv[i].getBX() << std::endl;
-	     }
-	   if(cv[i].getFullBX() != sv[i].getFullBX())
-	     {
-	       std::cout << "In detId: " << cl->first << std::endl;
-	       std::cout << "ALCT Full BX do not match: " << sv[i].getFullBX()
-			 << " != " << cv[i].getFullBX() << std::endl;
-	     }
-	 }
-     }
-   for(lc = lcts.begin(); lc != lcts.end(); ++lc)
-     {
-       if(lc->second.first.size() != lc->second.second.size())
-	 {
-	   std::cout << "Major error! # of Correlated LCT digis in detID: " << lc->first
-		     << " is not equal between sim and unpacked!" << std::endl;
-	   //eventually do more in this case!
+    std::vector<CSCCorrelatedLCTDigi>::iterator beg = lcts[_id].second.begin();
 
-	   std::vector<CSCCorrelatedLCTDigi> a = lc->second.second;
-	   std::vector<CSCCorrelatedLCTDigi> b = lc->second.first;
-	   std::cout << "SIM OUTPUT:" << std::endl;
-	   for(std::vector<CSCCorrelatedLCTDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
-	     i->print();
-	   std::cout << "UNPACKER OUTPUT:" << std::endl;
-	   for(std::vector<CSCCorrelatedLCTDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
-	     i->print();	     
-	 }
-       int max = std::min(lc->second.first.size(),lc->second.second.size());
-       std::vector<CSCCorrelatedLCTDigi> cv = lc->second.first;
-       std::vector<CSCCorrelatedLCTDigi> sv = lc->second.second;
-       for(int i = 0; i < max; ++i)
-	 {
-	   if(cv[i].getStrip() != sv[i].getStrip())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT strips do not match: " << sv[i].getStrip()
-			 << " != " << cv[i].getStrip() << std::endl;
-	     }	 
-	   if(cv[i].getKeyWG() != sv[i].getKeyWG())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT key wire groups do not match: " << sv[i].getKeyWG()
-			 << " != " << cv[i].getKeyWG() << std::endl;
-	     }
-	   if(cv[i].isValid() != sv[i].isValid())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT Valid bits do not match: " << sv[i].isValid() 
-			 << " != " << cv[i].isValid() << std::endl;
-	     }
-	   if(cv[i].getQuality() != sv[i].getQuality())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT qualities do not match: " << sv[i].getQuality()
-			 << " != " << cv[i].getQuality() << std::endl;
-	     }
-	   if(cv[i].getPattern() != sv[i].getPattern())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT ALCT patterns do not match: " << sv[i].getPattern()
-			 << " != " << cv[i].getPattern() << std::endl;
-	     }
-	   if(cv[i].getCLCTPattern() != sv[i].getCLCTPattern())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT CLCT patterns do not match: " << sv[i].getCLCTPattern()
-			 << " != " << cv[i].getCLCTPattern() << std::endl;
-	     }
-	   if(cv[i].getStripType() != sv[i].getStripType())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT strip types do not match: " << sv[i].getStripType()
-			 << " != " << cv[i].getStripType() << std::endl;
-	     }
-	   if(cv[i].getBend() != sv[i].getBend())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT bends do not match: " << sv[i].getBend()
-			 << " != " << cv[i].getBend() << std::endl;
-	     }
-	   if(cv[i].getMPCLink() != sv[i].getMPCLink())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT MPC Links do not match: " << sv[i].getMPCLink()
-			 << " != " << cv[i].getMPCLink() << std::endl;
-	     }
-	   if((cv[i].getBX()) != (sv[i].getBX()-6))
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT BX do not match: " << sv[i].getBX()-6
-			 << " != " << cv[i].getBX() << std::endl;
-	     }
-	   if(cv[i].getCSCID() != sv[i].getCSCID())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT CSCIDs do not match: " << sv[i].getCSCID()
-			 << " != " << cv[i].getCSCID() << std::endl;
-	     }
-	   if(cv[i].getBX0() != sv[i].getBX0())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT BX0s do not match: " << sv[i].getBX0()
-			 << " != " << cv[i].getBX0() << std::endl;
-	     }
-	   if(cv[i].getSyncErr() != sv[i].getSyncErr())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT SyncErrs do not match: " << sv[i].getSyncErr()
-			 << " != " << cv[i].getSyncErr() << std::endl;
-	     }
-	   if(cv[i].getTrknmb() != sv[i].getTrknmb())
-	     {
-	       std::cout << "In detId: " << lc->first << std::endl;
-	       std::cout << "Correlated LCT Track numbers do not match: " << sv[i].getTrknmb()
-			 << " != " << cv[i].getTrknmb() << std::endl;
-	     }	   
-	 }
-     }
-   if(tracks.get().size() != simtracks.get().size())
-     {
-       std::cout << "Major error! # of L1 Tracks is not equal between sim and unpacked!" << std::endl;
-       std::vector<csc::L1Track> a = simtracks.get();
-       std::vector<csc::L1Track> b = tracks.get();
-       std::cout << "SIM OUTPUT:" << std::endl;
-       for(std::vector<csc::L1Track>::const_iterator i = a.begin(); i != a.end(); ++i)
-	 i->print();
-       std::cout << "UNPACKER OUTPUT:" << std::endl;
-       for(std::vector<csc::L1Track>::const_iterator i = b.begin(); i != b.end(); ++i)
-	 i->print();
-     }
-   
+    if ((*slct).first.ring() == 4)
+      beg = lcts[_id].second.end();
 
-   return _err;
+    lcts[_id].second.insert(beg, b, e);
+  }
+  // remove attached LCT digis from tracks, should be put into their own collection and checked separately
+  for (; trk != _trk->end(); ++trk) {
+    tracks.push_back(trk->first);
+  }
+  for (; strk != _strk->end(); ++strk) {
+    simtracks.push_back(strk->first);
+  }
+
+  //now loop through each set and process if there are differences!
+  matchingDetWireCollection::const_iterator w;
+  matchingDetStripCollection::const_iterator s;
+  matchingDetComparatorCollection::const_iterator c;
+  matchingDetCLCTCollection::const_iterator cl;
+  matchingDetALCTCollection::const_iterator al;
+  matchingDetLCTCollection::const_iterator lc;
+
+  for (w = wires.begin(); w != wires.end(); ++w) {
+    if (w->second.first.size() != w->second.second.size()) {
+      std::cout << "Major error! # of wire digis in detID: " << w->first << " is not equal between sim and unpacked!"
+                << std::endl;
+      //eventually do more in this case!
+
+      std::vector<CSCWireDigi> a = w->second.second;
+      std::vector<CSCWireDigi> b = w->second.first;
+      std::cout << "SIM OUTPUT:" << std::endl;
+      for (std::vector<CSCWireDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
+        i->print();
+      std::cout << "UNPACKER OUTPUT:" << std::endl;
+      for (std::vector<CSCWireDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
+        i->print();
+    }
+    int max = std::min(w->second.first.size(), w->second.second.size());
+    std::vector<CSCWireDigi> cv = w->second.first;
+    std::vector<CSCWireDigi> sv = w->second.second;
+    for (int i = 0; i < max; ++i) {
+      if (sv[i].getWireGroup() != cv[i].getWireGroup()) {
+        std::cout << "In detId: " << w->first << std::endl;
+        std::cout << "Wire Groups do not match: " << sv[i].getWireGroup() << " != " << cv[i].getWireGroup()
+                  << std::endl;
+      }
+      if (sv[i].getTimeBin() != cv[i].getTimeBin()) {
+        std::cout << "In detId: " << w->first << std::endl;
+        std::cout << "First Time Bins do not match: " << sv[i].getTimeBin() << " != " << cv[i].getTimeBin()
+                  << std::endl;
+      }
+      if (sv[i].getTimeBinWord() != cv[i].getTimeBinWord()) {
+        std::cout << "In detId: " << w->first << std::endl;
+        std::cout << "Time Bin Words do not match: " << sv[i].getTimeBinWord() << " != " << cv[i].getTimeBinWord()
+                  << std::endl;
+      }
+    }
+  }
+  for (s = strips.begin(); s != strips.end(); ++s) {
+    if (s->second.first.size() != s->second.second.size()) {
+      std::cout << "Major error! # of strip digis in detID: " << s->first << " is not equal between sim and unpacked!"
+                << std::endl;
+      //eventually do more in this case!
+
+      std::vector<CSCStripDigi> a = s->second.second;
+      std::vector<CSCStripDigi> b = s->second.first;
+      std::cout << "SIM OUTPUT:" << std::endl;
+      for (std::vector<CSCStripDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
+        i->print();
+      std::cout << "UNPACKER OUTPUT:" << std::endl;
+      for (std::vector<CSCStripDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
+        i->print();
+    }
+    int max = std::min(s->second.first.size(), s->second.second.size());
+    std::vector<CSCStripDigi> cv = s->second.first;
+    std::vector<CSCStripDigi> sv = s->second.second;
+    for (int i = 0; i < max; ++i) {
+      bool me1a = s->first.station() == 1 && s->first.ring() == 4;
+      bool me1b = s->first.station() == 1 && s->first.ring() == 1;
+      bool zplus = s->first.endcap() == 1;
+      int k = i;
+
+      if (me1a && zplus)
+        k = max - i - 1;
+      if (me1b && !zplus)
+        k = max - i - 1;
+
+      if (sv[k].getStrip() != cv[i].getStrip()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "Strips do not match: " << sv[k].getStrip() << " != " << cv[i].getStrip() << std::endl;
+      }
+      if (sv[k].getADCCounts().size() != cv[i].getADCCounts().size()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "ADC Readouts not of equal size!" << std::endl;
+        std::cout << sv[k].getADCCounts().size() << ' ' << cv[i].getADCCounts().size() << std::endl;
+      } else {
+        std::vector<int> sADC = sv[k].getADCCounts();
+        std::vector<int> uADC = cv[i].getADCCounts();
+
+        for (unsigned iadc = 0; iadc < sADC.size(); ++iadc)
+          if (sADC[iadc] != uADC[iadc]) {
+            std::cout << "In detId: " << s->first << std::endl;
+            std::cout << "ADC counts not equal at index: " << iadc << std::endl
+                      << std::hex << sADC[iadc] << " != " << uADC[iadc] << std::dec << std::endl;
+          }
+      }
+      if (sv[k].getADCOverflow().size() != cv[i].getADCOverflow().size()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "ADC Overflows not of equal size!" << std::endl;
+        std::cout << sv[k].getADCOverflow().size() << ' ' << cv[i].getADCOverflow().size() << std::endl;
+      } else {
+        std::vector<uint16_t> sADC = sv[k].getADCOverflow();
+        std::vector<uint16_t> uADC = cv[i].getADCOverflow();
+
+        for (unsigned iadc = 0; iadc < sADC.size(); ++iadc)
+          if (sADC[iadc] != uADC[iadc]) {
+            std::cout << "In detId: " << s->first << std::endl;
+            std::cout << "ADC overflows not equal at index: " << iadc << std::endl
+                      << std::hex << sADC[iadc] << " != " << uADC[iadc] << std::dec << std::endl;
+          }
+      }
+      if (sv[k].getOverlappedSample().size() != cv[i].getOverlappedSample().size()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "Overlapped Samples not of equal size!" << std::endl;
+        std::cout << sv[k].getOverlappedSample().size() << ' ' << cv[i].getOverlappedSample().size() << std::endl;
+      } else {
+        std::vector<uint16_t> sADC = sv[k].getOverlappedSample();
+        std::vector<uint16_t> uADC = cv[i].getOverlappedSample();
+
+        for (unsigned iadc = 0; iadc < sADC.size(); ++iadc)
+          if (sADC[iadc] != uADC[iadc]) {
+            std::cout << "In detId: " << s->first << std::endl;
+            std::cout << "Overlapped Samples not equal at index: " << iadc << std::endl
+                      << std::hex << sADC[iadc] << " != " << uADC[iadc] << std::dec << std::endl;
+          }
+      }
+      if (sv[k].getErrorstat().size() != cv[i].getErrorstat().size()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "Errorstat not of equal size!" << std::endl;
+        std::cout << sv[k].getErrorstat().size() << ' ' << cv[i].getErrorstat().size() << std::endl;
+      } else {
+        std::vector<uint16_t> sADC = sv[k].getErrorstat();
+        std::vector<uint16_t> uADC = cv[i].getErrorstat();
+
+        for (unsigned iadc = 0; iadc < sADC.size(); ++iadc)
+          if (sADC[iadc] != uADC[iadc]) {
+            std::cout << "In detId: " << s->first << std::endl;
+            std::cout << "Errorstat not equal at index: " << iadc << std::endl
+                      << std::hex << sADC[iadc] << " != " << uADC[iadc] << std::dec << std::endl;
+          }
+      }
+      if (sv[k].pedestal() != cv[i].pedestal()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "Pedestals not equal: " << sv[k].pedestal() << " != " << cv[i].pedestal() << std::endl;
+      }
+      if (sv[k].amplitude() != cv[i].amplitude()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "Amplitudes not equal: " << sv[k].amplitude() << " != " << cv[i].amplitude() << std::endl;
+      }
+    }
+  }
+  for (c = comps.begin(); c != comps.end(); ++c) {
+    if (c->second.first.size() != c->second.second.size()) {
+      std::cout << "Major error! # of comparator digis in detID: " << c->first
+                << " is not equal between sim and unpacked!" << std::endl;
+      //eventually do more in this case!
+
+      std::vector<CSCComparatorDigi> a = c->second.second;
+      std::vector<CSCComparatorDigi> b = c->second.first;
+      std::cout << "SIM OUTPUT:" << std::endl;
+      for (std::vector<CSCComparatorDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
+        i->print();
+      std::cout << "UNPACKER OUTPUT:" << std::endl;
+      for (std::vector<CSCComparatorDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
+        i->print();
+    }
+    int max = std::min(c->second.first.size(), c->second.second.size());
+    std::vector<CSCComparatorDigi> cv = c->second.first;
+    std::vector<CSCComparatorDigi> sv = c->second.second;
+    for (int i = 0; i < max; ++i) {
+      if (sv[i].getStrip() != cv[i].getStrip()) {
+        std::cout << "In detId: " << s->first << std::endl;
+        std::cout << "Comparator strips do not match: " << sv[i].getStrip() << " != " << cv[i].getStrip() << std::endl;
+      }
+      if (sv[i].getComparator() != cv[i].getComparator()) {
+        std::cout << "In detId: " << c->first << std::endl;
+        std::cout << "Comparators do not match: " << sv[i].getComparator() << " != " << cv[i].getComparator()
+                  << std::endl;
+      }
+      if (sv[i].getTimeBinWord() != cv[i].getTimeBinWord()) {
+        std::cout << "In detId: " << c->first << std::endl;
+        std::cout << "Comparator time bins words do not match: " << sv[i].getTimeBinWord()
+                  << " != " << cv[i].getTimeBinWord() << std::endl;
+      }
+    }
+  }
+  for (cl = clcts.begin(); cl != clcts.end(); ++cl) {
+    if (cl->second.first.size() != cl->second.second.size()) {
+      std::cout << "Major error! # of CLCT digis in detID: " << cl->first << " is not equal between sim and unpacked!"
+                << std::endl;
+      //eventually do more in this case!
+
+      std::vector<CSCCLCTDigi> a = cl->second.second;
+      std::vector<CSCCLCTDigi> b = cl->second.first;
+      std::cout << "SIM OUTPUT:" << std::endl;
+      for (std::vector<CSCCLCTDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
+        i->print();
+      std::cout << "UNPACKER OUTPUT:" << std::endl;
+      for (std::vector<CSCCLCTDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
+        i->print();
+    }
+    int max = std::min(cl->second.first.size(), cl->second.second.size());
+    std::vector<CSCCLCTDigi> cv = cl->second.first;
+    std::vector<CSCCLCTDigi> sv = cl->second.second;
+    for (int i = 0; i < max; ++i) {
+      if (cv[i].getKeyStrip() != sv[i].getKeyStrip()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT key strips do not match: " << sv[i].getKeyStrip() << " != " << cv[i].getKeyStrip()
+                  << std::endl;
+      }
+      if (cv[i].getStrip() != sv[i].getStrip()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT strips do not match: " << sv[i].getStrip() << " != " << cv[i].getStrip() << std::endl;
+      }
+      if (cv[i].isValid() != sv[i].isValid()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT Valid bits do not match: " << sv[i].isValid() << " != " << cv[i].isValid() << std::endl;
+      }
+      if (cv[i].getQuality() != sv[i].getQuality()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT qualities do not match: " << sv[i].getQuality() << " != " << cv[i].getQuality() << std::endl;
+      }
+      if (cv[i].getPattern() != sv[i].getPattern()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT patterns do not match: " << sv[i].getPattern() << " != " << cv[i].getPattern() << std::endl;
+      }
+      if (cv[i].getStripType() != sv[i].getStripType()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT strip types do not match: " << sv[i].getStripType() << " != " << cv[i].getStripType()
+                  << std::endl;
+      }
+      if (cv[i].getBend() != sv[i].getBend()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT bends do not match: " << sv[i].getBend() << " != " << cv[i].getBend() << std::endl;
+      }
+      if (cv[i].getCFEB() != sv[i].getCFEB()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT CFEBs do not match: " << sv[i].getCFEB() << " != " << cv[i].getCFEB() << std::endl;
+      }
+      if (((short)cv[i].getBX()) != ((short)sv[i].getBX()) - 4) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT BX do not match: " << sv[i].getBX() - 4 << " != " << cv[i].getBX() << std::endl;
+      }
+      if (cv[i].getFullBX() != sv[i].getFullBX()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT Full BX do not match: " << sv[i].getFullBX() << " != " << cv[i].getFullBX() << std::endl;
+      }
+      if (cv[i].getTrknmb() != sv[i].getTrknmb()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "CLCT Track numbers do not match: " << sv[i].getTrknmb() << " != " << cv[i].getTrknmb()
+                  << std::endl;
+      }
+    }
+  }
+  for (al = alcts.begin(); al != alcts.end(); ++al) {
+    if (al->second.first.size() != al->second.second.size()) {
+      std::cout << "Major error! # of ALCT digis in detID: " << al->first << " is not equal between sim and unpacked!"
+                << std::endl;
+      //eventually do more in this case!
+
+      std::vector<CSCALCTDigi> a = al->second.second;
+      std::vector<CSCALCTDigi> b = al->second.first;
+      std::cout << "SIM OUTPUT:" << std::endl;
+      for (std::vector<CSCALCTDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
+        i->print();
+      std::cout << "UNPACKER OUTPUT:" << std::endl;
+      for (std::vector<CSCALCTDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
+        i->print();
+    }
+    int max = std::min(al->second.first.size(), al->second.second.size());
+    std::vector<CSCALCTDigi> cv = al->second.first;
+    std::vector<CSCALCTDigi> sv = al->second.second;
+    for (int i = 0; i < max; ++i) {
+      if (cv[i].getKeyWG() != sv[i].getKeyWG()) {
+        std::cout << "In detId: " << al->first << std::endl;
+        std::cout << "ALCT key wire groups do not match: " << sv[i].getKeyWG() << " != " << cv[i].getKeyWG()
+                  << std::endl;
+      }
+      if (cv[i].isValid() != sv[i].isValid()) {
+        std::cout << "In detId: " << al->first << std::endl;
+        std::cout << "ALCT Valid bits do not match: " << sv[i].isValid() << " != " << cv[i].isValid() << std::endl;
+      }
+      if (cv[i].getQuality() != sv[i].getQuality()) {
+        std::cout << "In detId: " << al->first << std::endl;
+        std::cout << "ALCT qualities do not match: " << sv[i].getQuality() << " != " << cv[i].getQuality() << std::endl;
+      }
+      if (cv[i].getAccelerator() != sv[i].getAccelerator()) {
+        std::cout << "In detId: " << al->first << std::endl;
+        std::cout << "ALCT accelerator bits do not match: " << sv[i].getAccelerator()
+                  << " != " << cv[i].getAccelerator() << std::endl;
+      }
+      if (cv[i].getCollisionB() != sv[i].getCollisionB()) {
+        std::cout << "In detId: " << al->first << std::endl;
+        std::cout << "ALCT CollisionB flags do not match: " << sv[i].getCollisionB() << " != " << cv[i].getCollisionB()
+                  << std::endl;
+      }
+      if ((cv[i].getBX()) != (sv[i].getBX())) {
+        std::cout << "In detId: " << al->first << std::endl;
+        std::cout << "ALCT BX do not match: " << sv[i].getBX() << " != " << cv[i].getBX() << std::endl;
+      }
+      if (cv[i].getFullBX() != sv[i].getFullBX()) {
+        std::cout << "In detId: " << cl->first << std::endl;
+        std::cout << "ALCT Full BX do not match: " << sv[i].getFullBX() << " != " << cv[i].getFullBX() << std::endl;
+      }
+    }
+  }
+  for (lc = lcts.begin(); lc != lcts.end(); ++lc) {
+    if (lc->second.first.size() != lc->second.second.size()) {
+      std::cout << "Major error! # of Correlated LCT digis in detID: " << lc->first
+                << " is not equal between sim and unpacked!" << std::endl;
+      //eventually do more in this case!
+
+      std::vector<CSCCorrelatedLCTDigi> a = lc->second.second;
+      std::vector<CSCCorrelatedLCTDigi> b = lc->second.first;
+      std::cout << "SIM OUTPUT:" << std::endl;
+      for (std::vector<CSCCorrelatedLCTDigi>::const_iterator i = a.begin(); i != a.end(); ++i)
+        i->print();
+      std::cout << "UNPACKER OUTPUT:" << std::endl;
+      for (std::vector<CSCCorrelatedLCTDigi>::const_iterator i = b.begin(); i != b.end(); ++i)
+        i->print();
+    }
+    int max = std::min(lc->second.first.size(), lc->second.second.size());
+    std::vector<CSCCorrelatedLCTDigi> cv = lc->second.first;
+    std::vector<CSCCorrelatedLCTDigi> sv = lc->second.second;
+    for (int i = 0; i < max; ++i) {
+      if (cv[i].getStrip() != sv[i].getStrip()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT strips do not match: " << sv[i].getStrip() << " != " << cv[i].getStrip()
+                  << std::endl;
+      }
+      if (cv[i].getKeyWG() != sv[i].getKeyWG()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT key wire groups do not match: " << sv[i].getKeyWG() << " != " << cv[i].getKeyWG()
+                  << std::endl;
+      }
+      if (cv[i].isValid() != sv[i].isValid()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT Valid bits do not match: " << sv[i].isValid() << " != " << cv[i].isValid()
+                  << std::endl;
+      }
+      if (cv[i].getQuality() != sv[i].getQuality()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT qualities do not match: " << sv[i].getQuality() << " != " << cv[i].getQuality()
+                  << std::endl;
+      }
+      if (cv[i].getPattern() != sv[i].getPattern()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT ALCT patterns do not match: " << sv[i].getPattern() << " != " << cv[i].getPattern()
+                  << std::endl;
+      }
+      if (cv[i].getCLCTPattern() != sv[i].getCLCTPattern()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT CLCT patterns do not match: " << sv[i].getCLCTPattern()
+                  << " != " << cv[i].getCLCTPattern() << std::endl;
+      }
+      if (cv[i].getStripType() != sv[i].getStripType()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT strip types do not match: " << sv[i].getStripType()
+                  << " != " << cv[i].getStripType() << std::endl;
+      }
+      if (cv[i].getBend() != sv[i].getBend()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT bends do not match: " << sv[i].getBend() << " != " << cv[i].getBend() << std::endl;
+      }
+      if (cv[i].getMPCLink() != sv[i].getMPCLink()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT MPC Links do not match: " << sv[i].getMPCLink() << " != " << cv[i].getMPCLink()
+                  << std::endl;
+      }
+      if ((cv[i].getBX()) != (sv[i].getBX() - 6)) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT BX do not match: " << sv[i].getBX() - 6 << " != " << cv[i].getBX() << std::endl;
+      }
+      if (cv[i].getCSCID() != sv[i].getCSCID()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT CSCIDs do not match: " << sv[i].getCSCID() << " != " << cv[i].getCSCID()
+                  << std::endl;
+      }
+      if (cv[i].getBX0() != sv[i].getBX0()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT BX0s do not match: " << sv[i].getBX0() << " != " << cv[i].getBX0() << std::endl;
+      }
+      if (cv[i].getSyncErr() != sv[i].getSyncErr()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT SyncErrs do not match: " << sv[i].getSyncErr() << " != " << cv[i].getSyncErr()
+                  << std::endl;
+      }
+      if (cv[i].getTrknmb() != sv[i].getTrknmb()) {
+        std::cout << "In detId: " << lc->first << std::endl;
+        std::cout << "Correlated LCT Track numbers do not match: " << sv[i].getTrknmb() << " != " << cv[i].getTrknmb()
+                  << std::endl;
+      }
+    }
+  }
+  if (tracks.get().size() != simtracks.get().size()) {
+    std::cout << "Major error! # of L1 Tracks is not equal between sim and unpacked!" << std::endl;
+    std::vector<csc::L1Track> a = simtracks.get();
+    std::vector<csc::L1Track> b = tracks.get();
+    std::cout << "SIM OUTPUT:" << std::endl;
+    for (std::vector<csc::L1Track>::const_iterator i = a.begin(); i != a.end(); ++i)
+      i->print();
+    std::cout << "UNPACKER OUTPUT:" << std::endl;
+    for (std::vector<csc::L1Track>::const_iterator i = b.begin(); i != b.end(); ++i)
+      i->print();
+  }
+
+  return _err;
 }
 
 // this function takes the sim wire digis and combines wire digis from the same wire
 // into one wire digi, as in the data.
 // returns a vector of the combined wire digis
-std::vector<CSCWireDigi> 
-CSCDigiValidator::sanitizeWireDigis(std::vector<CSCWireDigi>::const_iterator b,
-				    std::vector<CSCWireDigi>::const_iterator e)
-{
-  typedef std::map<int,std::vector<CSCWireDigi> > wire2digi;
+std::vector<CSCWireDigi> CSCDigiValidator::sanitizeWireDigis(std::vector<CSCWireDigi>::const_iterator b,
+                                                             std::vector<CSCWireDigi>::const_iterator e) {
+  typedef std::map<int, std::vector<CSCWireDigi> > wire2digi;
 
-  std::vector<CSCWireDigi> _r; // the resulting vector of wire digis
-  wire2digi _wr2digis; // map of wires to a set of digis
+  std::vector<CSCWireDigi> _r;  // the resulting vector of wire digis
+  wire2digi _wr2digis;          // map of wires to a set of digis
 
-  for(std::vector<CSCWireDigi>::const_iterator i = b; i != e; ++i)
+  for (std::vector<CSCWireDigi>::const_iterator i = b; i != e; ++i)
     _wr2digis[i->getWireGroup()].push_back(*i);
 
-  for(wire2digi::const_iterator i = _wr2digis.begin(); i != _wr2digis.end(); ++i)
-    {
-      int wire = i->first;
-      unsigned tbin = 0x0;
+  for (wire2digi::const_iterator i = _wr2digis.begin(); i != _wr2digis.end(); ++i) {
+    int wire = i->first;
+    unsigned tbin = 0x0;
 
-      for(std::vector<CSCWireDigi>::const_iterator d = i->second.begin();
-	  d != i->second.end(); ++d)
-	{
-	  std::vector<int> binson = d->getTimeBinsOn();
-	  for(std::vector<int>::const_iterator t = binson.begin(); 
-	      t != binson.end(); ++t)
-	    tbin |= 1<<(*t);
-	}
-      
-      _r.push_back(CSCWireDigi(wire,tbin));
+    for (std::vector<CSCWireDigi>::const_iterator d = i->second.begin(); d != i->second.end(); ++d) {
+      std::vector<int> binson = d->getTimeBinsOn();
+      for (std::vector<int>::const_iterator t = binson.begin(); t != binson.end(); ++t)
+        tbin |= 1 << (*t);
     }
+
+    _r.push_back(CSCWireDigi(wire, tbin));
+  }
 
   return _r;
 }
 
-std::vector<CSCStripDigi> 
-CSCDigiValidator::relabelStripDigis(const CSCChamberMap* m, CSCDetId _id,
-				    std::vector<CSCStripDigi>::const_iterator b,
-				    std::vector<CSCStripDigi>::const_iterator e)
-{
-  std::vector<CSCStripDigi> _r; // the vector of strip digis with appropriate strip #'s
+std::vector<CSCStripDigi> CSCDigiValidator::relabelStripDigis(const CSCChamberMap* m,
+                                                              CSCDetId _id,
+                                                              std::vector<CSCStripDigi>::const_iterator b,
+                                                              std::vector<CSCStripDigi>::const_iterator e) {
+  std::vector<CSCStripDigi> _r;  // the vector of strip digis with appropriate strip #'s
 
   //bool me1a = _id.station()==1 && _id.ring()==4;
   //bool zplus = _id.endcap()==1;
   //bool me1b = _id.station()==1 && _id.ring()==1;
 
-  for(std::vector<CSCStripDigi>::const_iterator i = b; i != e; ++i)
-  {
-    int strip=i->getStrip();
-    
+  for (std::vector<CSCStripDigi>::const_iterator i = b; i != e; ++i) {
+    int strip = i->getStrip();
+
     //if(me1a&&zplus) strip=17-strip;
     //if(me1b&&!zplus) strip=(65-strip-1)%(m->dmb(_id)*16) + 1;
     //if(me1a) strip+=64;
-    
-    _r.push_back(CSCStripDigi(strip,i->getADCCounts(),i->getADCOverflow(),
-			     i->getOverlappedSample(),i->getErrorstat()));
+
+    _r.push_back(
+        CSCStripDigi(strip, i->getADCCounts(), i->getADCOverflow(), i->getOverlappedSample(), i->getErrorstat()));
   }
   return _r;
 }
 
-std::vector<CSCComparatorDigi> 
-CSCDigiValidator::relabelCompDigis(const CSCChamberMap* m, CSCDetId _id,
-				    std::vector<CSCComparatorDigi>::const_iterator b,
-				    std::vector<CSCComparatorDigi>::const_iterator e)
-{
-  std::vector<CSCComparatorDigi> _r; // the vector of comp digis with appropriate strip #'s
+std::vector<CSCComparatorDigi> CSCDigiValidator::relabelCompDigis(const CSCChamberMap* m,
+                                                                  CSCDetId _id,
+                                                                  std::vector<CSCComparatorDigi>::const_iterator b,
+                                                                  std::vector<CSCComparatorDigi>::const_iterator e) {
+  std::vector<CSCComparatorDigi> _r;  // the vector of comp digis with appropriate strip #'s
 
-  bool me1a = _id.station()==1 && _id.ring()==4;
+  bool me1a = _id.station() == 1 && _id.ring() == 4;
   //bool zplus = _id.endcap()==1;
   //bool me1b = _id.station()==1 && _id.ring()==1;
 
-  for(std::vector<CSCComparatorDigi>::const_iterator i = b; i != e; ++i)
-  {
-    int strip=i->getStrip();
-    
+  for (std::vector<CSCComparatorDigi>::const_iterator i = b; i != e; ++i) {
+    int strip = i->getStrip();
+
     //    if(me1a&&zplus) strip=17-strip;
     //    if(me1b&&!zplus) strip=65-strip;
-    if(me1a) strip+=64;
-    
-    _r.push_back(CSCComparatorDigi(strip,i->getComparator(),
-				   i->getTimeBinWord()));
+    if (me1a)
+      strip += 64;
+
+    _r.push_back(CSCComparatorDigi(strip, i->getComparator(), i->getTimeBinWord()));
   }
   return _r;
 }
 
-std::vector<CSCStripDigi> 
-CSCDigiValidator::sanitizeStripDigis(std::vector<CSCStripDigi>::const_iterator b,
-				     std::vector<CSCStripDigi>::const_iterator e)
-{
-  std::vector<CSCStripDigi> _r; // vector of digis in proper order
+std::vector<CSCStripDigi> CSCDigiValidator::sanitizeStripDigis(std::vector<CSCStripDigi>::const_iterator b,
+                                                               std::vector<CSCStripDigi>::const_iterator e) {
+  std::vector<CSCStripDigi> _r;  // vector of digis in proper order
 
   return _r;
 }
 
-std::vector<CSCStripDigi>
-CSCDigiValidator::zeroSupStripDigis(std::vector<CSCStripDigi>::const_iterator b,
-				    std::vector<CSCStripDigi>::const_iterator e)
-{
-  std::vector<CSCStripDigi> _r; // zero-suppressed strip digis
+std::vector<CSCStripDigi> CSCDigiValidator::zeroSupStripDigis(std::vector<CSCStripDigi>::const_iterator b,
+                                                              std::vector<CSCStripDigi>::const_iterator e) {
+  std::vector<CSCStripDigi> _r;  // zero-suppressed strip digis
   std::vector<int> counts;
 
-  for(std::vector<CSCStripDigi>::const_iterator i = b; i != e; ++i)
-    {
-      bool nonzero=false;
-      counts = i->getADCCounts();
-      for(std::vector<int>::const_iterator a = counts.begin(); a != counts.end(); ++a)
-	if((*a) != 0) nonzero = true;
+  for (std::vector<CSCStripDigi>::const_iterator i = b; i != e; ++i) {
+    bool nonzero = false;
+    counts = i->getADCCounts();
+    for (std::vector<int>::const_iterator a = counts.begin(); a != counts.end(); ++a)
+      if ((*a) != 0)
+        nonzero = true;
 
-      if(nonzero) _r.push_back(*i);
-    }
+    if (nonzero)
+      _r.push_back(*i);
+  }
 
   return _r;
 }
 
 // remove comparator digis on or after the 10th time bin, for now, will be configurable later.
-std::vector<CSCComparatorDigi>
-CSCDigiValidator::zeroSupCompDigis(std::vector<CSCComparatorDigi>::const_iterator b,
-				   std::vector<CSCComparatorDigi>::const_iterator e)
-{
+std::vector<CSCComparatorDigi> CSCDigiValidator::zeroSupCompDigis(std::vector<CSCComparatorDigi>::const_iterator b,
+                                                                  std::vector<CSCComparatorDigi>::const_iterator e) {
   std::vector<CSCComparatorDigi> _r;
 
-  for(std::vector<CSCComparatorDigi>::const_iterator i = b; i != e; ++i)
-    {
-      bool present = false;
+  for (std::vector<CSCComparatorDigi>::const_iterator i = b; i != e; ++i) {
+    bool present = false;
 
-      if(i->getTimeBin() < 10) present=true;
+    if (i->getTimeBin() < 10)
+      present = true;
 
-      if(present) _r.push_back(*i);
-    }
+    if (present)
+      _r.push_back(*i);
+  }
 
   return _r;
 }
 
-void 
-CSCDigiValidator::beginJob()
-{
-}
+void CSCDigiValidator::beginJob() {}
 
-void 
-CSCDigiValidator::endJob() 
-{
-}
+void CSCDigiValidator::endJob() {}

--- a/EventFilter/CSCRawToDigi/plugins/CSCViewDigi.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCViewDigi.cc
@@ -9,230 +9,221 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCViewDigi.h"
 #include <iostream>
 
-CSCViewDigi::CSCViewDigi(const edm::ParameterSet& conf)
-{
+CSCViewDigi::CSCViewDigi(const edm::ParameterSet& conf) {
+  wd_token = consumes<CSCWireDigiCollection>(conf.getParameter<edm::InputTag>("wireDigiTag"));
+  sd_token = consumes<CSCStripDigiCollection>(conf.getParameter<edm::InputTag>("stripDigiTag"));
+  cd_token = consumes<CSCComparatorDigiCollection>(conf.getParameter<edm::InputTag>("comparatorDigiTag"));
+  rd_token = consumes<CSCRPCDigiCollection>(conf.getParameter<edm::InputTag>("rpcDigiTag"));
+  al_token = consumes<CSCALCTDigiCollection>(conf.getParameter<edm::InputTag>("alctDigiTag"));
+  cl_token = consumes<CSCCLCTDigiCollection>(conf.getParameter<edm::InputTag>("clctDigiTag"));
+  co_token = consumes<CSCCorrelatedLCTDigiCollection>(conf.getParameter<edm::InputTag>("corrclctDigiTag"));
+  st_token = consumes<CSCDCCFormatStatusDigiCollection>(conf.getParameter<edm::InputTag>("statusDigiTag"));
+  dd_token = consumes<CSCDDUStatusDigiCollection>(conf.getParameter<edm::InputTag>("DDUstatusDigiTag"));
+  dc_token = consumes<CSCDCCStatusDigiCollection>(conf.getParameter<edm::InputTag>("DCCstatusDigiTag"));
 
-  wd_token = consumes<CSCWireDigiCollection>( conf.getParameter<edm::InputTag>("wireDigiTag") );
-  sd_token = consumes<CSCStripDigiCollection>( conf.getParameter<edm::InputTag>("stripDigiTag") );
-  cd_token = consumes<CSCComparatorDigiCollection>( conf.getParameter<edm::InputTag>("comparatorDigiTag") );
-  rd_token = consumes<CSCRPCDigiCollection>( conf.getParameter<edm::InputTag>("rpcDigiTag") );
-  al_token = consumes<CSCALCTDigiCollection>( conf.getParameter<edm::InputTag>("alctDigiTag") );
-  cl_token = consumes<CSCCLCTDigiCollection>( conf.getParameter<edm::InputTag>("clctDigiTag") );
-  co_token = consumes<CSCCorrelatedLCTDigiCollection>( conf.getParameter<edm::InputTag>("corrclctDigiTag") );
-  st_token = consumes<CSCDCCFormatStatusDigiCollection>( conf.getParameter<edm::InputTag>("statusDigiTag") );
-  dd_token = consumes<CSCDDUStatusDigiCollection>( conf.getParameter<edm::InputTag>("DDUstatusDigiTag") );
-  dc_token = consumes<CSCDCCStatusDigiCollection>( conf.getParameter<edm::InputTag>("DCCstatusDigiTag") );
-
-  WiresDigiDump=conf.getUntrackedParameter<bool>("WiresDigiDump", false);
-  StripDigiDump=conf.getUntrackedParameter<bool>("StripDigiDump", false);
-  ComparatorDigiDump=conf.getUntrackedParameter<bool>("ComparatorDigiDump", false);
-  RpcDigiDump=conf.getUntrackedParameter<bool>("RpcDigiDump", false);
-  AlctDigiDump=conf.getUntrackedParameter<bool>("AlctDigiDump", false);
-  ClctDigiDump=conf.getUntrackedParameter<bool>("ClctDigiDump", false);
-  CorrClctDigiDump=conf.getUntrackedParameter<bool>("CorrClctDigiDump", false);
-  StatusDigiDump=conf.getUntrackedParameter<bool>("StatusDigiDump", false);
-  DDUStatusDigiDump=conf.getUntrackedParameter<bool>("DDUStatus",false);
-  DCCStatusDigiDump=conf.getUntrackedParameter<bool>("DCCStatus",false);
+  WiresDigiDump = conf.getUntrackedParameter<bool>("WiresDigiDump", false);
+  StripDigiDump = conf.getUntrackedParameter<bool>("StripDigiDump", false);
+  ComparatorDigiDump = conf.getUntrackedParameter<bool>("ComparatorDigiDump", false);
+  RpcDigiDump = conf.getUntrackedParameter<bool>("RpcDigiDump", false);
+  AlctDigiDump = conf.getUntrackedParameter<bool>("AlctDigiDump", false);
+  ClctDigiDump = conf.getUntrackedParameter<bool>("ClctDigiDump", false);
+  CorrClctDigiDump = conf.getUntrackedParameter<bool>("CorrClctDigiDump", false);
+  StatusDigiDump = conf.getUntrackedParameter<bool>("StatusDigiDump", false);
+  DDUStatusDigiDump = conf.getUntrackedParameter<bool>("DDUStatus", false);
+  DCCStatusDigiDump = conf.getUntrackedParameter<bool>("DCCStatus", false);
 }
 
+CSCViewDigi::~CSCViewDigi() {}
 
-CSCViewDigi::~CSCViewDigi()
-{
-}
+void CSCViewDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-void
-CSCViewDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+  edm::Handle<CSCWireDigiCollection> wires;
+  edm::Handle<CSCStripDigiCollection> strips;
+  edm::Handle<CSCComparatorDigiCollection> comparators;
+  edm::Handle<CSCRPCDigiCollection> rpcs;
+  edm::Handle<CSCALCTDigiCollection> alcts;
+  edm::Handle<CSCCLCTDigiCollection> clcts;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts;
+  edm::Handle<CSCDCCFormatStatusDigiCollection> statusdigis;
+  edm::Handle<CSCDDUStatusDigiCollection> DDUstatusdigi;
+  edm::Handle<CSCDCCStatusDigiCollection> DCCstatusdigi;
 
-   edm::Handle<CSCWireDigiCollection> wires;
-   edm::Handle<CSCStripDigiCollection> strips;
-   edm::Handle<CSCComparatorDigiCollection> comparators;
-   edm::Handle<CSCRPCDigiCollection> rpcs;
-   edm::Handle<CSCALCTDigiCollection> alcts;
-   edm::Handle<CSCCLCTDigiCollection> clcts;
-   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts;
-   edm::Handle<CSCDCCFormatStatusDigiCollection> statusdigis;
-   edm::Handle<CSCDDUStatusDigiCollection> DDUstatusdigi;
-   edm::Handle<CSCDCCStatusDigiCollection> DCCstatusdigi;
+  iEvent.getByToken(wd_token, wires);
+  iEvent.getByToken(sd_token, strips);
+  iEvent.getByToken(cd_token, comparators);
+  iEvent.getByToken(rd_token, rpcs);
+  iEvent.getByToken(al_token, alcts);
+  iEvent.getByToken(cl_token, clcts);
+  iEvent.getByToken(co_token, correlatedlcts);
 
-   iEvent.getByToken( wd_token, wires );
-   iEvent.getByToken( sd_token, strips );
-   iEvent.getByToken( cd_token, comparators );
-   iEvent.getByToken( rd_token, rpcs );
-   iEvent.getByToken( al_token, alcts );
-   iEvent.getByToken( cl_token, clcts );
-   iEvent.getByToken( co_token, correlatedlcts );
+  if (StatusDigiDump)
+    iEvent.getByToken(st_token, statusdigis);
 
-   if(StatusDigiDump)
-     iEvent.getByToken( st_token, statusdigis );
-     
-   if(DDUStatusDigiDump)
-     iEvent.getByToken( dd_token, DDUstatusdigi );
-  
-   if(DCCStatusDigiDump)
-     iEvent.getByToken( dc_token, DCCstatusdigi );
-    
-   if(WiresDigiDump){ 
-     std::cout << std::endl;
-     std::cout << "Event " << iEvent.id() << std::endl;
-     std::cout << std::endl;
-     std::cout << "********WIRES Digis********" << std::endl;
-     for (CSCWireDigiCollection::DigiRangeIterator j=wires->begin(); j!=wires->end(); j++) {
-         std::cout << "Wire digis from "<< CSCDetId((*j).first) << std::endl;
-         std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
-         std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
-         for( ; digiItr != last; ++digiItr) {
-         digiItr->print();
-         }
+  if (DDUStatusDigiDump)
+    iEvent.getByToken(dd_token, DDUstatusdigi);
+
+  if (DCCStatusDigiDump)
+    iEvent.getByToken(dc_token, DCCstatusdigi);
+
+  if (WiresDigiDump) {
+    std::cout << std::endl;
+    std::cout << "Event " << iEvent.id() << std::endl;
+    std::cout << std::endl;
+    std::cout << "********WIRES Digis********" << std::endl;
+    for (CSCWireDigiCollection::DigiRangeIterator j = wires->begin(); j != wires->end(); j++) {
+      std::cout << "Wire digis from " << CSCDetId((*j).first) << std::endl;
+      std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
+        digiItr->print();
       }
-   }
-   
-   if(StripDigiDump){ 
+    }
+  }
+
+  if (StripDigiDump) {
     std::cout << std::endl;
     std::cout << "Event " << iEvent.id() << std::endl;
     std::cout << std::endl;
     std::cout << "********STRIPS Digis********" << std::endl;
-     for (CSCStripDigiCollection::DigiRangeIterator j=strips->begin(); j!=strips->end(); j++) {
-         std::cout << "Strip digis from "<< CSCDetId((*j).first) << std::endl;
-         std::vector<CSCStripDigi>::const_iterator digiItr = (*j).second.first;
-         std::vector<CSCStripDigi>::const_iterator last = (*j).second.second;
-         for( ; digiItr != last; ++digiItr) {
-         digiItr->print();
-         }
+    for (CSCStripDigiCollection::DigiRangeIterator j = strips->begin(); j != strips->end(); j++) {
+      std::cout << "Strip digis from " << CSCDetId((*j).first) << std::endl;
+      std::vector<CSCStripDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCStripDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
+        digiItr->print();
       }
-   }
-   
-   if(ComparatorDigiDump){
+    }
+  }
+
+  if (ComparatorDigiDump) {
     std::cout << std::endl;
     std::cout << "Event " << iEvent.id() << std::endl;
     std::cout << std::endl;
     std::cout << "********COMPARATOR Digis********" << std::endl;
-     for (CSCComparatorDigiCollection::DigiRangeIterator j=comparators->begin(); j!=comparators->end(); j++) {
-         std::cout << "Comparator digis from "<< CSCDetId((*j).first) << std::endl;
-         std::vector<CSCComparatorDigi>::const_iterator digiItr = (*j).second.first;
-         std::vector<CSCComparatorDigi>::const_iterator last = (*j).second.second;
-         for( ; digiItr != last; ++digiItr) {
-         digiItr->print();
-         }
+    for (CSCComparatorDigiCollection::DigiRangeIterator j = comparators->begin(); j != comparators->end(); j++) {
+      std::cout << "Comparator digis from " << CSCDetId((*j).first) << std::endl;
+      std::vector<CSCComparatorDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCComparatorDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
+        digiItr->print();
       }
-   }
-   
-   if(RpcDigiDump){ 
+    }
+  }
+
+  if (RpcDigiDump) {
     std::cout << std::endl;
     std::cout << "Event " << iEvent.id() << std::endl;
     std::cout << std::endl;
     std::cout << "********RPC Digis********" << std::endl;
-     for (CSCRPCDigiCollection::DigiRangeIterator j=rpcs->begin(); j!=rpcs->end(); j++) {
-         std::cout << "RPC digis from "<< CSCDetId((*j).first) << std::endl;
-         std::vector<CSCRPCDigi>::const_iterator digiItr = (*j).second.first;
-         std::vector<CSCRPCDigi>::const_iterator last = (*j).second.second;
-         for( ; digiItr != last; ++digiItr) {
-         digiItr->print();
-         }
-      }
-   }
- 
-  if(AlctDigiDump){
-   std::cout << std::endl;
-   std::cout << "Event " << iEvent.id() << std::endl;
-   std::cout << std::endl;
-   std::cout << "********ALCT Digis********" << std::endl;
-    for (CSCALCTDigiCollection::DigiRangeIterator j=alcts->begin(); j!=alcts->end(); j++) {
-        std::vector<CSCALCTDigi>::const_iterator digiItr = (*j).second.first;
-        std::vector<CSCALCTDigi>::const_iterator last = (*j).second.second;
-        for( ; digiItr != last; ++digiItr) {
+    for (CSCRPCDigiCollection::DigiRangeIterator j = rpcs->begin(); j != rpcs->end(); j++) {
+      std::cout << "RPC digis from " << CSCDetId((*j).first) << std::endl;
+      std::vector<CSCRPCDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCRPCDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
         digiItr->print();
-        }
-     }
-   }
-   
-   if(ClctDigiDump){
+      }
+    }
+  }
+
+  if (AlctDigiDump) {
+    std::cout << std::endl;
+    std::cout << "Event " << iEvent.id() << std::endl;
+    std::cout << std::endl;
+    std::cout << "********ALCT Digis********" << std::endl;
+    for (CSCALCTDigiCollection::DigiRangeIterator j = alcts->begin(); j != alcts->end(); j++) {
+      std::vector<CSCALCTDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCALCTDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
+        digiItr->print();
+      }
+    }
+  }
+
+  if (ClctDigiDump) {
     std::cout << std::endl;
     std::cout << "Event " << iEvent.id() << std::endl;
     std::cout << std::endl;
     std::cout << "********CLCT Digis********" << std::endl;
-    for (CSCCLCTDigiCollection::DigiRangeIterator j=clcts->begin(); j!=clcts->end(); j++) {
-        std::vector<CSCCLCTDigi>::const_iterator digiItr = (*j).second.first;
-        std::vector<CSCCLCTDigi>::const_iterator last = (*j).second.second;
-        for( ; digiItr != last; ++digiItr) {
+    for (CSCCLCTDigiCollection::DigiRangeIterator j = clcts->begin(); j != clcts->end(); j++) {
+      std::vector<CSCCLCTDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCCLCTDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
         digiItr->print();
-        }
-     }
-   }
-   
-   if(CorrClctDigiDump){
+      }
+    }
+  }
+
+  if (CorrClctDigiDump) {
     std::cout << std::endl;
     std::cout << "Event " << iEvent.id() << std::endl;
     std::cout << std::endl;
     std::cout << "********CorrelatedLCT Digis********" << std::endl;
-    for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j=correlatedlcts->begin(); j!=correlatedlcts->end(); j++) {
-        std::vector<CSCCorrelatedLCTDigi>::const_iterator digiItr = (*j).second.first;
-        std::vector<CSCCorrelatedLCTDigi>::const_iterator last = (*j).second.second;
-        for( ; digiItr != last; ++digiItr) {
+    for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j = correlatedlcts->begin(); j != correlatedlcts->end();
+         j++) {
+      std::vector<CSCCorrelatedLCTDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCCorrelatedLCTDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
         digiItr->print();
-        }
-     }
-   }
-   
-   if(StatusDigiDump){
+      }
+    }
+  }
+
+  if (StatusDigiDump) {
     std::cout << std::endl;
     std::cout << "Event " << iEvent.id() << std::endl;
     std::cout << std::endl;
     std::cout << "********STATUS Digis********" << std::endl;
-    for (CSCDCCFormatStatusDigiCollection::DigiRangeIterator j=statusdigis->begin(); j!=statusdigis->end(); j++) {
-        std::vector<CSCDCCFormatStatusDigi>::const_iterator digiItr = (*j).second.first;
-        std::vector<CSCDCCFormatStatusDigi>::const_iterator last = (*j).second.second;
-        for( ; digiItr != last; ++digiItr) {
+    for (CSCDCCFormatStatusDigiCollection::DigiRangeIterator j = statusdigis->begin(); j != statusdigis->end(); j++) {
+      std::vector<CSCDCCFormatStatusDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCDCCFormatStatusDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
         digiItr->print();
-        }
-     }
-   }
+      }
+    }
+  }
 
-   if(DDUStatusDigiDump){
-     std::cout << std::endl;
-     std::cout << "Event " << iEvent.id() << std::endl;
-     std::cout << std::endl;
-     std::cout << "********DDU STATUS Digis********" << std::endl;
-     for (CSCDDUStatusDigiCollection::DigiRangeIterator j=DDUstatusdigi->begin(); j!=DDUstatusdigi->end(); j++){
-        std::vector<CSCDDUStatusDigi>::const_iterator digiItr = (*j).second.first;
-        std::vector<CSCDDUStatusDigi>::const_iterator last = (*j).second.second;
-        for( ; digiItr != last; ++digiItr) {
+  if (DDUStatusDigiDump) {
+    std::cout << std::endl;
+    std::cout << "Event " << iEvent.id() << std::endl;
+    std::cout << std::endl;
+    std::cout << "********DDU STATUS Digis********" << std::endl;
+    for (CSCDDUStatusDigiCollection::DigiRangeIterator j = DDUstatusdigi->begin(); j != DDUstatusdigi->end(); j++) {
+      std::vector<CSCDDUStatusDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCDDUStatusDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
         digiItr->print();
-        }
-     }
-   }
+      }
+    }
+  }
 
-   if(DCCStatusDigiDump){
-     std::cout << std::endl;
-     std::cout << "Event " << iEvent.id() << std::endl;
-     std::cout << std::endl;
-     std::cout << "********DCC STATUS Digis********" << std::endl;
-     for (CSCDCCStatusDigiCollection::DigiRangeIterator j=DCCstatusdigi->begin(); j!=DCCstatusdigi->end(); j++){
-        std::vector<CSCDCCStatusDigi>::const_iterator digiItr = (*j).second.first;
-        std::vector<CSCDCCStatusDigi>::const_iterator last = (*j).second.second;
-        for( ; digiItr != last; ++digiItr) {
+  if (DCCStatusDigiDump) {
+    std::cout << std::endl;
+    std::cout << "Event " << iEvent.id() << std::endl;
+    std::cout << std::endl;
+    std::cout << "********DCC STATUS Digis********" << std::endl;
+    for (CSCDCCStatusDigiCollection::DigiRangeIterator j = DCCstatusdigi->begin(); j != DCCstatusdigi->end(); j++) {
+      std::vector<CSCDCCStatusDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCDCCStatusDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
         digiItr->print();
-        }
-     }
-   }
-   
+      }
+    }
+  }
+
 #ifdef THIS_IS_AN_EVENT_EXAMPLE
-   Handle<ExampleData> pIn;
-   iEvent.getByLabel("example",pIn);
+  Handle<ExampleData> pIn;
+  iEvent.getByLabel("example", pIn);
 #endif
-   
+
 #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
-   ESHandle<SetupData> pSetup;
-   iSetup.get<SetupRecord>().get(pSetup);
+  ESHandle<SetupData> pSetup;
+  iSetup.get<SetupRecord>().get(pSetup);
 #endif
 }
-
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-CSCViewDigi::endJob() {
-}
+void CSCViewDigi::endJob() {}
 
 //define this as a plug-in
 //DEFINE_FWK_MODULE(CSCViewDigi);

--- a/EventFilter/CSCRawToDigi/plugins/DigiAnalyzer.cc
+++ b/EventFilter/CSCRawToDigi/plugins/DigiAnalyzer.cc
@@ -13,23 +13,20 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 DigiAnalyzer::DigiAnalyzer(edm::ParameterSet const& conf) {
-
   eventNumber = 0;
 
-  wd_token = consumes<CSCWireDigiCollection>( conf.getParameter<edm::InputTag>("wireDigiTag") );
-  sd_token = consumes<CSCStripDigiCollection>( conf.getParameter<edm::InputTag>("stripDigiTag") );
-  cd_token = consumes<CSCComparatorDigiCollection>( conf.getParameter<edm::InputTag>("compDigiTag") );
-  al_token = consumes<CSCALCTDigiCollection>( conf.getParameter<edm::InputTag>("alctDigiTag") );
-  cl_token = consumes<CSCCLCTDigiCollection>( conf.getParameter<edm::InputTag>("clctDigiTag") );
-  rd_token = consumes<CSCRPCDigiCollection>( conf.getParameter<edm::InputTag>("rpcDigiTag") );
-  co_token = consumes<CSCCorrelatedLCTDigiCollection>( conf.getParameter<edm::InputTag>("corrlctDigiTag") );
-  dd_token = consumes<CSCDDUStatusDigiCollection>( conf.getParameter<edm::InputTag>("ddusDigiTag") );
-  dc_token = consumes<CSCDCCFormatStatusDigiCollection>( conf.getParameter<edm::InputTag>("dccfDigiTag") );
-
+  wd_token = consumes<CSCWireDigiCollection>(conf.getParameter<edm::InputTag>("wireDigiTag"));
+  sd_token = consumes<CSCStripDigiCollection>(conf.getParameter<edm::InputTag>("stripDigiTag"));
+  cd_token = consumes<CSCComparatorDigiCollection>(conf.getParameter<edm::InputTag>("compDigiTag"));
+  al_token = consumes<CSCALCTDigiCollection>(conf.getParameter<edm::InputTag>("alctDigiTag"));
+  cl_token = consumes<CSCCLCTDigiCollection>(conf.getParameter<edm::InputTag>("clctDigiTag"));
+  rd_token = consumes<CSCRPCDigiCollection>(conf.getParameter<edm::InputTag>("rpcDigiTag"));
+  co_token = consumes<CSCCorrelatedLCTDigiCollection>(conf.getParameter<edm::InputTag>("corrlctDigiTag"));
+  dd_token = consumes<CSCDDUStatusDigiCollection>(conf.getParameter<edm::InputTag>("ddusDigiTag"));
+  dc_token = consumes<CSCDCCFormatStatusDigiCollection>(conf.getParameter<edm::InputTag>("dccfDigiTag"));
 }
 
 void DigiAnalyzer::analyze(edm::Event const& e, edm::EventSetup const& iSetup) {
-
   edm::Handle<CSCWireDigiCollection> wires;
   edm::Handle<CSCStripDigiCollection> strips;
   edm::Handle<CSCComparatorDigiCollection> comparators;
@@ -40,106 +37,95 @@ void DigiAnalyzer::analyze(edm::Event const& e, edm::EventSetup const& iSetup) {
   edm::Handle<CSCDDUStatusDigiCollection> dduStatusDigi;
   edm::Handle<CSCDCCFormatStatusDigiCollection> formatStatusDigi;
 
-  e.getByToken( dd_token, dduStatusDigi );
-  e.getByToken( wd_token, wires );
-  e.getByToken( sd_token, strips );
-  e.getByToken( cd_token, comparators );
-  e.getByToken( al_token, alcts );
-  e.getByToken( cl_token, clcts );
-  e.getByToken( rd_token, rpcs );
-  e.getByToken( co_token, correlatedlcts );
-  e.getByToken( dc_token, formatStatusDigi );
+  e.getByToken(dd_token, dduStatusDigi);
+  e.getByToken(wd_token, wires);
+  e.getByToken(sd_token, strips);
+  e.getByToken(cd_token, comparators);
+  e.getByToken(al_token, alcts);
+  e.getByToken(cl_token, clcts);
+  e.getByToken(rd_token, rpcs);
+  e.getByToken(co_token, correlatedlcts);
+  e.getByToken(dc_token, formatStatusDigi);
 
-  for (CSCDCCFormatStatusDigiCollection::DigiRangeIterator j=formatStatusDigi->begin(); j!=formatStatusDigi->end(); j++) {
+  for (CSCDCCFormatStatusDigiCollection::DigiRangeIterator j = formatStatusDigi->begin(); j != formatStatusDigi->end();
+       j++) {
     std::vector<CSCDCCFormatStatusDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCDCCFormatStatusDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
-	digiItr->print();
+    for (; digiItr != last; ++digiItr) {
+      digiItr->print();
     }
   }
 
-
-  for (CSCDDUStatusDigiCollection::DigiRangeIterator j=dduStatusDigi->begin(); j!=dduStatusDigi->end(); j++) {
+  for (CSCDDUStatusDigiCollection::DigiRangeIterator j = dduStatusDigi->begin(); j != dduStatusDigi->end(); j++) {
     std::vector<CSCDDUStatusDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCDDUStatusDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       CSCDDUHeader header(*digiItr);
-      std::cout <<"L1 number = " << header.lvl1num() << std::endl; 
-      std::cout <<"DDU number = " << header.source_id() << std::endl;
+      std::cout << "L1 number = " << header.lvl1num() << std::endl;
+      std::cout << "DDU number = " << header.source_id() << std::endl;
     }
   }
 
-  for (CSCStripDigiCollection::DigiRangeIterator j=strips->begin(); j!=strips->end(); j++) {
+  for (CSCStripDigiCollection::DigiRangeIterator j = strips->begin(); j != strips->end(); j++) {
     std::vector<CSCStripDigi>::const_iterator digiItr = (*j).second.first;
-    CSCDetId const cscDetId=(*j).first;
-    std::cout<<cscDetId<<std::endl;
+    CSCDetId const cscDetId = (*j).first;
+    std::cout << cscDetId << std::endl;
     std::vector<CSCStripDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
-  for (CSCWireDigiCollection::DigiRangeIterator j=wires->begin(); j!=wires->end(); j++) {
-    CSCDetId const cscDetId=(*j).first;
-    std::cout<<cscDetId<<std::endl;
+  for (CSCWireDigiCollection::DigiRangeIterator j = wires->begin(); j != wires->end(); j++) {
+    CSCDetId const cscDetId = (*j).first;
+    std::cout << cscDetId << std::endl;
     std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
-  for (CSCComparatorDigiCollection::DigiRangeIterator j=comparators->begin(); j!=comparators->end(); j++) {
- 
+  for (CSCComparatorDigiCollection::DigiRangeIterator j = comparators->begin(); j != comparators->end(); j++) {
     std::vector<CSCComparatorDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCComparatorDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
-  for (CSCALCTDigiCollection::DigiRangeIterator j=alcts->begin(); j!=alcts->end(); j++) {
- 
+  for (CSCALCTDigiCollection::DigiRangeIterator j = alcts->begin(); j != alcts->end(); j++) {
     std::vector<CSCALCTDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCALCTDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
-  for (CSCCLCTDigiCollection::DigiRangeIterator j=clcts->begin(); j!=clcts->end(); j++) {
- 
+  for (CSCCLCTDigiCollection::DigiRangeIterator j = clcts->begin(); j != clcts->end(); j++) {
     std::vector<CSCCLCTDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCCLCTDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
-  for (CSCRPCDigiCollection::DigiRangeIterator j=rpcs->begin(); j!=rpcs->end(); j++) {
- 
+  for (CSCRPCDigiCollection::DigiRangeIterator j = rpcs->begin(); j != rpcs->end(); j++) {
     std::vector<CSCRPCDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCRPCDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
-  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j=correlatedlcts->begin(); j!=correlatedlcts->end(); j++) {
- 
+  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j = correlatedlcts->begin(); j != correlatedlcts->end(); j++) {
     std::vector<CSCCorrelatedLCTDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCCorrelatedLCTDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
+    for (; digiItr != last; ++digiItr) {
       digiItr->print();
     }
   }
 
   eventNumber++;
-  edm::LogInfo ("DigiAnalyzer")  << "end of event number " << eventNumber;
-
+  edm::LogInfo("DigiAnalyzer") << "end of event number " << eventNumber;
 }
-
-
-
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCALCTHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTHeader.cc
@@ -7,57 +7,47 @@
 
 #ifdef LOCAL_UNPACK
 
-bool CSCALCTHeader::debug=false;
-short unsigned int CSCALCTHeader::firmwareVersion=2007;
+bool CSCALCTHeader::debug = false;
+short unsigned int CSCALCTHeader::firmwareVersion = 2007;
 
 #else
 
 #include <atomic>
 
 std::atomic<bool> CSCALCTHeader::debug{false};
-std::atomic<short unsigned int> CSCALCTHeader::firmwareVersion{2007}; 
+std::atomic<short unsigned int> CSCALCTHeader::firmwareVersion{2007};
 
 #endif
 
 CSCALCTHeader::CSCALCTHeader(int chamberType)
-: header2006(chamberType),
-  header2007(chamberType)
-{ //constructor for digi->raw packing based on header2006 
-  if (firmwareVersion==2006)
-  {
-    memcpy(theOriginalBuffer, &header2006, header2006.sizeInWords()*2);
-  }
-  else if(firmwareVersion==2007)
-  {
-    memcpy(theOriginalBuffer, &header2007, header2007.sizeInWords()*2);
+    : header2006(chamberType), header2007(chamberType) {  //constructor for digi->raw packing based on header2006
+  if (firmwareVersion == 2006) {
+    memcpy(theOriginalBuffer, &header2006, header2006.sizeInWords() * 2);
+  } else if (firmwareVersion == 2007) {
+    memcpy(theOriginalBuffer, &header2007, header2007.sizeInWords() * 2);
     // assume no virtex or masks or registers
-    sizeInWords2007_ = header2007.sizeInWords() + header2007.lctBins*CSCALCT::sizeInWords()*2;
-    theALCTs.resize(header2007.lctBins*2);
-  }
-  else
-  {
+    sizeInWords2007_ = header2007.sizeInWords() + header2007.lctBins * CSCALCT::sizeInWords() * 2;
+    theALCTs.resize(header2007.lctBins * 2);
+  } else {
     edm::LogError("CSCALCTHeader|CSCRawToDigi")
-      <<"Cannot construct ALCT header: ALCT firmware version is bad/not defined!" << firmwareVersion;
+        << "Cannot construct ALCT header: ALCT firmware version is bad/not defined!" << firmwareVersion;
   }
-
 }
 
-CSCALCTHeader::CSCALCTHeader(const unsigned short * buf) {
+CSCALCTHeader::CSCALCTHeader(const unsigned short *buf) {
   ///collision and hot channel masks are variable sized
   ///the sizes vary depending on type of the ALCT board
   ///                                        number of words for various
   ///                                        alct board types:  1  2  3     5  6
-  constexpr unsigned short int collisionMaskWordcount[7]    = { 8, 8,12,16,16,24,28};
-  constexpr unsigned short int hotChannelMaskWordcount[7]   = {18,18,24,36,36,48,60};
+  constexpr unsigned short int collisionMaskWordcount[7] = {8, 8, 12, 16, 16, 24, 28};
+  constexpr unsigned short int hotChannelMaskWordcount[7] = {18, 18, 24, 36, 36, 48, 60};
 
-  ///first determine the correct format  
-  if (buf[0]==0xDB0A) {
-    firmwareVersion=2007;
-  }
-  else if ( (buf[0]&0xF800)==0x6000 ) {
-    firmwareVersion=2006;
-  }
-  else {
+  ///first determine the correct format
+  if (buf[0] == 0xDB0A) {
+    firmwareVersion = 2007;
+  } else if ((buf[0] & 0xF800) == 0x6000) {
+    firmwareVersion = 2006;
+  } else {
     edm::LogError("CSCALCTHeader|CSCRawToDigi") << "failed to determine ALCT firmware version!!";
   }
 
@@ -68,98 +58,89 @@ CSCALCTHeader::CSCALCTHeader(const unsigned short * buf) {
   switch (firmwareVersion) {
 #else
   switch (firmwareVersion.load()) {
-#endif 
-  case 2006:
-    header2006.setFromBuffer(buf);///the header part
-    buf +=header2006.sizeInWords();
-    alcts2006.setFromBuffer(buf);///the alct0 and alct1
-    buf +=alcts2006.sizeInWords();
-    break;
+#endif
+    case 2006:
+      header2006.setFromBuffer(buf);  ///the header part
+      buf += header2006.sizeInWords();
+      alcts2006.setFromBuffer(buf);  ///the alct0 and alct1
+      buf += alcts2006.sizeInWords();
+      break;
 
-  case 2007:
-    header2007.setFromBuffer(buf); ///the fixed sized header part
-    buf +=header2007.sizeInWords();
-    sizeInWords2007_ = header2007.sizeInWords();
-    ///now come the variable parts
-    if (header2007.configPresent==1) {
-      virtexID.setFromBuffer(buf);
-      buf +=virtexID.sizeInWords();
-      sizeInWords2007_ = virtexID.sizeInWords();
-      configRegister.setFromBuffer(buf);
-      buf +=configRegister.sizeInWords();
-      sizeInWords2007_ += configRegister.sizeInWords();
+    case 2007:
+      header2007.setFromBuffer(buf);  ///the fixed sized header part
+      buf += header2007.sizeInWords();
+      sizeInWords2007_ = header2007.sizeInWords();
+      ///now come the variable parts
+      if (header2007.configPresent == 1) {
+        virtexID.setFromBuffer(buf);
+        buf += virtexID.sizeInWords();
+        sizeInWords2007_ = virtexID.sizeInWords();
+        configRegister.setFromBuffer(buf);
+        buf += configRegister.sizeInWords();
+        sizeInWords2007_ += configRegister.sizeInWords();
 
-      collisionMasks.resize(collisionMaskWordcount[header2007.boardType]);
-      for (unsigned int i=0; i<collisionMaskWordcount[header2007.boardType]; ++i){
-	collisionMasks[i].setFromBuffer(buf);
-	buf += collisionMasks[i].sizeInWords();
-	sizeInWords2007_ += collisionMasks[i].sizeInWords();
+        collisionMasks.resize(collisionMaskWordcount[header2007.boardType]);
+        for (unsigned int i = 0; i < collisionMaskWordcount[header2007.boardType]; ++i) {
+          collisionMasks[i].setFromBuffer(buf);
+          buf += collisionMasks[i].sizeInWords();
+          sizeInWords2007_ += collisionMasks[i].sizeInWords();
+        }
+
+        hotChannelMasks.resize(hotChannelMaskWordcount[header2007.boardType]);
+        for (unsigned int i = 0; i < hotChannelMaskWordcount[header2007.boardType]; ++i) {
+          hotChannelMasks[i].setFromBuffer(buf);
+          buf += hotChannelMasks[i].sizeInWords();
+          sizeInWords2007_ += hotChannelMasks[i].sizeInWords();
+        }
       }
 
-      hotChannelMasks.resize(hotChannelMaskWordcount[header2007.boardType]);
-      for (unsigned int i=0; i<hotChannelMaskWordcount[header2007.boardType]; ++i) {
-	hotChannelMasks[i].setFromBuffer(buf);
-	buf += hotChannelMasks[i].sizeInWords();
-	sizeInWords2007_ += hotChannelMasks[i].sizeInWords();
+      theALCTs.resize(header2007.lctBins * 2);  ///2007 has LCTbins * 2 alct words
+      for (int i = 0; i < header2007.lctBins * 2; ++i) {
+        theALCTs[i].setFromBuffer(buf);
+        buf += theALCTs[i].sizeInWords();
+        sizeInWords2007_ += theALCTs[i].sizeInWords();
       }
-    }
 
-    theALCTs.resize(header2007.lctBins*2); ///2007 has LCTbins * 2 alct words
-    for (int i=0; i<header2007.lctBins*2; ++i) {
-      theALCTs[i].setFromBuffer(buf);
-      buf += theALCTs[i].sizeInWords(); 
-      sizeInWords2007_ += theALCTs[i].sizeInWords();
-    }
+      ALCTDigis();
+      break;
 
-    ALCTDigis();
-    break;
-
-  default:
-    edm::LogError("CSCALCTHeader|CSCRawToDigi")
-      <<"couldn't construct: ALCT firmware version is bad/not defined!";
-    break;
+    default:
+      edm::LogError("CSCALCTHeader|CSCRawToDigi") << "couldn't construct: ALCT firmware version is bad/not defined!";
+      break;
   }
 
   ///also store raw data buffer too; it is later returned by data() method
-  if ((firmwareVersion==2006)||(firmwareVersion==2007))
-    memcpy(theOriginalBuffer, buf-sizeInWords(), sizeInWords()*2);
-  
+  if ((firmwareVersion == 2006) || (firmwareVersion == 2007))
+    memcpy(theOriginalBuffer, buf - sizeInWords(), sizeInWords() * 2);
 }
 
+CSCALCTHeader::CSCALCTHeader(const CSCALCTStatusDigi &digi) { CSCALCTHeader(digi.header()); }
 
-CSCALCTHeader::CSCALCTHeader(const CSCALCTStatusDigi & digi){
-  CSCALCTHeader(digi.header());
-}
-
-void CSCALCTHeader::setEventInformation(const CSCDMBHeader & dmb) {
+void CSCALCTHeader::setEventInformation(const CSCDMBHeader &dmb) {
 #ifdef LOCAL_UNPACK
- switch (firmwareVersion) {
+  switch (firmwareVersion) {
 #else
- switch (firmwareVersion.load()) {
+  switch (firmwareVersion.load()) {
 #endif
- case 2006:
-    {
-	header2006.setEventInformation(dmb);
-	break;
+    case 2006: {
+      header2006.setEventInformation(dmb);
+      break;
     }
-  case 2007:
-    {
-	header2007.setEventInformation(dmb);
-        break;
+    case 2007: {
+      header2007.setEventInformation(dmb);
+      break;
     }
-  default:
-    edm::LogError("CSCALCTHeader|CSCRawToDigi")
-      <<"setEventInformation: ALCT firmware version is bad/not defined!" << firmwareVersion;
-    break;
+    default:
+      edm::LogError("CSCALCTHeader|CSCRawToDigi")
+          << "setEventInformation: ALCT firmware version is bad/not defined!" << firmwareVersion;
+      break;
   }
 }
 
-
-unsigned short CSCALCTHeader::nLCTChipRead() const {///header2006 method
-  if(firmwareVersion == 2006) {
+unsigned short CSCALCTHeader::nLCTChipRead() const {  ///header2006 method
+  if (firmwareVersion == 2006) {
     return header2006.nLCTChipRead();
-  }
-  else {
+  } else {
     // nLCTChip obsolete in ALCT2007 format (email Andrey K. & Victor B., 20.10.2008)
     // and we don't think anyone makes uses of this call.
     //    edm::LogError("CSCALCTHeader|CSCRawToDigi")
@@ -168,9 +149,7 @@ unsigned short CSCALCTHeader::nLCTChipRead() const {///header2006 method
   return 0;
 }
 
-
-std::vector<CSCALCTDigi> CSCALCTHeader::ALCTDigis() const 
-{ 
+std::vector<CSCALCTDigi> CSCALCTHeader::ALCTDigis() const {
   std::vector<CSCALCTDigi> result;
 
 #ifdef LOCAL_UNPACK
@@ -178,152 +157,125 @@ std::vector<CSCALCTDigi> CSCALCTHeader::ALCTDigis() const
 #else
   switch (firmwareVersion.load()) {
 #endif
-  case 2006:
-    {
+    case 2006: {
       result = alcts2006.ALCTDigis();
       break;
     }
-  case 2007:
-    {
+    case 2007: {
       result.reserve(theALCTs.size());
-      for (unsigned int i=0; i<theALCTs.size(); ++i) {///loop over all alct words
-	CSCALCTDigi digi(theALCTs[i].valid, theALCTs[i].quality, theALCTs[i].accel, theALCTs[i].pattern,
-			 theALCTs[i].keyWire, (int)i/2, i%2+1);
-	result.push_back(digi);
+      for (unsigned int i = 0; i < theALCTs.size(); ++i) {  ///loop over all alct words
+        CSCALCTDigi digi(theALCTs[i].valid,
+                         theALCTs[i].quality,
+                         theALCTs[i].accel,
+                         theALCTs[i].pattern,
+                         theALCTs[i].keyWire,
+                         (int)i / 2,
+                         i % 2 + 1);
+        result.push_back(digi);
       }
       break;
     }
-  default:
-    edm::LogError("CSCALCTHeader|CSCRawToDigi")
-      <<"Empty Digis: ALCT firmware version is bad/not defined!" << firmwareVersion; 
-    break;
+    default:
+      edm::LogError("CSCALCTHeader|CSCRawToDigi")
+          << "Empty Digis: ALCT firmware version is bad/not defined!" << firmwareVersion;
+      break;
   }
-  for(unsigned i = 0; i < result.size(); ++i) {result[i].setFullBX(BXNCount());}
+  for (unsigned i = 0; i < result.size(); ++i) {
+    result[i].setFullBX(BXNCount());
+  }
   return result;
-
 }
 
-
-void CSCALCTHeader::add(const std::vector<CSCALCTDigi> & digis)
-{
-  if(firmwareVersion == 2006) {
-      alcts2006.add(digis);
-  }
-  else if(firmwareVersion == 2007) {
-    if(theALCTs.empty())
-    {
-      theALCTs.resize(header2007.lctBins*2);
+void CSCALCTHeader::add(const std::vector<CSCALCTDigi> &digis) {
+  if (firmwareVersion == 2006) {
+    alcts2006.add(digis);
+  } else if (firmwareVersion == 2007) {
+    if (theALCTs.empty()) {
+      theALCTs.resize(header2007.lctBins * 2);
     }
-    for(std::vector<CSCALCTDigi>::const_iterator digi = digis.begin();
-        digi != digis.end(); ++digi)
-    {
+    for (std::vector<CSCALCTDigi>::const_iterator digi = digis.begin(); digi != digis.end(); ++digi) {
       int bx = digi->getBX();
-      if(bx < (int)header2007.lctBins) 
-      {
+      if (bx < (int)header2007.lctBins) {
         // 2 ALCTs per bx
-        int i = bx*2;
+        int i = bx * 2;
         int q1 = theALCTs[i].quality;
-        int q2 = theALCTs[i+1].quality;
+        int q2 = theALCTs[i + 1].quality;
         // see if it's non=blank
-        if(!theALCTs[i].valid)
-        {
+        if (!theALCTs[i].valid) {
           theALCTs[i] = CSCALCT(*digi);
         }
         // new best LCT
-        else if(digi->getQuality() > q1)
-        {
-          theALCTs[i+1] = theALCTs[i];
+        else if (digi->getQuality() > q1) {
+          theALCTs[i + 1] = theALCTs[i];
           theALCTs[i] = CSCALCT(*digi);
         }
         // new second best
-        else if(!theALCTs[i+1].valid || (digi->getQuality() > q2))
-        {
-          theALCTs[i+1] = CSCALCT(*digi);
+        else if (!theALCTs[i + 1].valid || (digi->getQuality() > q2)) {
+          theALCTs[i + 1] = CSCALCT(*digi);
         }
       }
     }
   }
 }
 
-
-boost::dynamic_bitset<> CSCALCTHeader::pack()
-{
+boost::dynamic_bitset<> CSCALCTHeader::pack() {
   boost::dynamic_bitset<> result;
-  if(firmwareVersion == 2006)
-  {
-     boost::dynamic_bitset<> header
-       = bitset_utilities::ushortToBitset(header2006.sizeInWords()*16,
-                                          (unsigned short *) &header2006);
-     boost::dynamic_bitset<> alcts 
-       = bitset_utilities::ushortToBitset(alcts2006.sizeInWords()*16,
-                                          (unsigned short *) &alcts2006);
-     result = bitset_utilities::append(header, alcts);
+  if (firmwareVersion == 2006) {
+    boost::dynamic_bitset<> header =
+        bitset_utilities::ushortToBitset(header2006.sizeInWords() * 16, (unsigned short *)&header2006);
+    boost::dynamic_bitset<> alcts =
+        bitset_utilities::ushortToBitset(alcts2006.sizeInWords() * 16, (unsigned short *)&alcts2006);
+    result = bitset_utilities::append(header, alcts);
 
-     bitset_utilities::bitsetToChar(result, (unsigned char *) data());
+    bitset_utilities::bitsetToChar(result, (unsigned char *)data());
   }
 
-  else if(firmwareVersion == 2007)
-  {
-    result = bitset_utilities::ushortToBitset(header2007.sizeInWords()*16,
-                                          (unsigned short *) &header2007);
+  else if (firmwareVersion == 2007) {
+    result = bitset_utilities::ushortToBitset(header2007.sizeInWords() * 16, (unsigned short *)&header2007);
 
-    for (unsigned i = 0; i < theALCTs.size(); ++i)
-    {
-       boost::dynamic_bitset<> alct
-         = bitset_utilities::ushortToBitset(theALCTs[i].sizeInWords()*16,
-                                          (unsigned short *) &theALCTs[i]);
-       result = bitset_utilities::append(result, alct);
+    for (unsigned i = 0; i < theALCTs.size(); ++i) {
+      boost::dynamic_bitset<> alct =
+          bitset_utilities::ushortToBitset(theALCTs[i].sizeInWords() * 16, (unsigned short *)&theALCTs[i]);
+      result = bitset_utilities::append(result, alct);
     }
 
-    bitset_utilities::bitsetToChar(result, (unsigned char *) data());
-
+    bitset_utilities::bitsetToChar(result, (unsigned char *)data());
   }
   return result;
 }
-    
 
-
-void CSCALCTHeader::selfTest(int firmware)
-{
+void CSCALCTHeader::selfTest(int firmware) {
   firmwareVersion = firmware;
   CSCALCTDigi alct0(true, 1, 1, 1, 10, 6, 1);
   CSCALCTDigi alct1(true, 1, 1, 0, 11, 6, 2);
 
-    // tests packing and unpacking
-    for(int station = 1; station <= 4; ++station)
-    {
-      CSCDetId detId(1, station, 1, 1, 0);
+  // tests packing and unpacking
+  for (int station = 1; station <= 4; ++station) {
+    CSCDetId detId(1, station, 1, 1, 0);
 
-      std::vector<CSCALCTDigi> oldAlcts;
-      oldAlcts.push_back(alct0);
-      oldAlcts.push_back(alct1);
-      CSCALCTHeader alctHeader(detId.iChamberType());
+    std::vector<CSCALCTDigi> oldAlcts;
+    oldAlcts.push_back(alct0);
+    oldAlcts.push_back(alct1);
+    CSCALCTHeader alctHeader(detId.iChamberType());
 
-      alctHeader.add(oldAlcts);
+    alctHeader.add(oldAlcts);
 
-      std::vector<CSCALCTDigi> alcts = alctHeader.ALCTDigis();
-      // pick out the valid ones
-      std::vector<CSCALCTDigi> validALCTs;
-      for(std::vector<CSCALCTDigi>::const_iterator alctItr = alcts.begin();
-          alctItr != alcts.end(); ++ alctItr)
-      {
-        if(alctItr->isValid())
-        {
-          validALCTs.push_back(*alctItr);
-        }
+    std::vector<CSCALCTDigi> alcts = alctHeader.ALCTDigis();
+    // pick out the valid ones
+    std::vector<CSCALCTDigi> validALCTs;
+    for (std::vector<CSCALCTDigi>::const_iterator alctItr = alcts.begin(); alctItr != alcts.end(); ++alctItr) {
+      if (alctItr->isValid()) {
+        validALCTs.push_back(*alctItr);
       }
-      assert(validALCTs[0] == alct0);
-      assert(validALCTs[1] == alct1);
-      //cscClassPackerCompare(alctHeader);
     }
+    assert(validALCTs[0] == alct0);
+    assert(validALCTs[1] == alct1);
+    //cscClassPackerCompare(alctHeader);
+  }
 }
 
-std::ostream & operator<<(std::ostream & os, const CSCALCTHeader & header) 
-{
-  os << "ALCT HEADER CSCID " << header.CSCID()
-     << "  L1ACC " << header.L1Acc() << std::endl;
+std::ostream &operator<<(std::ostream &os, const CSCALCTHeader &header) {
+  os << "ALCT HEADER CSCID " << header.CSCID() << "  L1ACC " << header.L1Acc() << std::endl;
   os << " time samples " << header.NTBins() << std::endl;
   return os;
 }
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCALCTHeader2006.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTHeader2006.cc
@@ -2,16 +2,14 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 
 #ifdef LOCAL_UNPACK
-static int activeFEBsForChamberType[11] = {0,7,7,0xf,7,0x7f, 0xf,0x3f,0xf,0x3f,0xf};
-static int nTBinsForChamberType[11] = {7,7,7,7,7,7,7,7,7,7,7};
+static int activeFEBsForChamberType[11] = {0, 7, 7, 0xf, 7, 0x7f, 0xf, 0x3f, 0xf, 0x3f, 0xf};
+static int nTBinsForChamberType[11] = {7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
 #else
-constexpr int activeFEBsForChamberType[11] = {0,7,7,0xf,7,0x7f, 0xf,0x3f,0xf,0x3f,0xf};
-constexpr int nTBinsForChamberType[11] = {7,7,7,7,7,7,7,7,7,7,7};
+constexpr int activeFEBsForChamberType[11] = {0, 7, 7, 0xf, 7, 0x7f, 0xf, 0x3f, 0xf, 0x3f, 0xf};
+constexpr int nTBinsForChamberType[11] = {7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
 #endif
 
-
-
-CSCALCTHeader2006::CSCALCTHeader2006(int chamberType) { //constructor for digi->raw packing based on header2006
+CSCALCTHeader2006::CSCALCTHeader2006(int chamberType) {  //constructor for digi->raw packing based on header2006
   // we count from 1 to 10, ME11, ME12, ME13, ME1A, ME21, ME22, ....
   init();
   flag_0 = 0xC;
@@ -25,54 +23,46 @@ CSCALCTHeader2006::CSCALCTHeader2006(int chamberType) { //constructor for digi->
   nTBins = nTBinsForChamberType[chamberType];
   ///in order to be able to return header via data()
   //memcpy(theOriginalBuffer, &header2006, header2006.sizeForPacking());
-
 }
 
-
-void CSCALCTHeader2006::setEventInformation(const CSCDMBHeader & dmb)
-{
- l1Acc = dmb.l1a();
- cscID = dmb.dmbID();
- nTBins = 16;
- bxnCount = dmb.bxn();
+void CSCALCTHeader2006::setEventInformation(const CSCDMBHeader& dmb) {
+  l1Acc = dmb.l1a();
+  cscID = dmb.dmbID();
+  nTBins = 16;
+  bxnCount = dmb.bxn();
 }
 
-
-unsigned short CSCALCTHeader2006::nLCTChipRead() const {///header2006 method
+unsigned short CSCALCTHeader2006::nLCTChipRead() const {  ///header2006 method
   int count = 0;
-  for(int i=0; i<7; ++i) {
-    if( (lctChipRead>>i) & 1) ++count;
+  for (int i = 0; i < 7; ++i) {
+    if ((lctChipRead >> i) & 1)
+      ++count;
   }
   return count;
 }
 
-
-
-std::vector<CSCALCTDigi> CSCALCTs2006::ALCTDigis() const
-{
+std::vector<CSCALCTDigi> CSCALCTs2006::ALCTDigis() const {
   std::vector<CSCALCTDigi> result;
   result.reserve(2);
 
-  CSCALCTDigi digi0(alct0_valid, alct0_quality, alct0_accel,
-                    alct0_pattern, alct0_key_wire,
-                    alct0_bxn_low|(alct0_bxn_high<<3),1);
-  CSCALCTDigi digi1(alct1_valid, alct1_quality, alct1_accel,
-                    alct1_pattern, alct1_key_wire,
-                    alct1_bxn_low|(alct1_bxn_high<<3),2);
-  result.push_back(digi0); result.push_back(digi1);
+  CSCALCTDigi digi0(
+      alct0_valid, alct0_quality, alct0_accel, alct0_pattern, alct0_key_wire, alct0_bxn_low | (alct0_bxn_high << 3), 1);
+  CSCALCTDigi digi1(
+      alct1_valid, alct1_quality, alct1_accel, alct1_pattern, alct1_key_wire, alct1_bxn_low | (alct1_bxn_high << 3), 2);
+  result.push_back(digi0);
+  result.push_back(digi1);
   return result;
 }
 
-
-void CSCALCTs2006::add(const std::vector<CSCALCTDigi> & digis)
-{
+void CSCALCTs2006::add(const std::vector<CSCALCTDigi>& digis) {
   //FIXME doesn't do any sorting
-  if(!digis.empty()) addALCT0(digis[0]);
-  if(digis.size() > 1) addALCT1(digis[1]);
+  if (!digis.empty())
+    addALCT0(digis[0]);
+  if (digis.size() > 1)
+    addALCT1(digis[1]);
 }
 
-void CSCALCTs2006::addALCT0(const CSCALCTDigi & digi)
-{
+void CSCALCTs2006::addALCT0(const CSCALCTDigi& digi) {
   alct0_valid = digi.isValid();
   alct0_quality = digi.getQuality();
   alct0_accel = digi.getAccelerator();
@@ -82,9 +72,7 @@ void CSCALCTs2006::addALCT0(const CSCALCTDigi & digi)
   alct0_bxn_low = digi.getBX();
 }
 
-
-void CSCALCTs2006::addALCT1(const CSCALCTDigi & digi)
-{
+void CSCALCTs2006::addALCT1(const CSCALCTDigi& digi) {
   alct1_valid = digi.isValid();
   alct1_quality = digi.getQuality();
   alct1_accel = digi.getAccelerator();
@@ -93,4 +81,3 @@ void CSCALCTs2006::addALCT1(const CSCALCTDigi & digi)
   // probably not right
   alct1_bxn_low = digi.getBX();
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCALCTHeader2007.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTHeader2007.cc
@@ -1,33 +1,29 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 
-CSCALCT::CSCALCT()  {
-  bzero(this, 2); ///size of ALCT = 2bytes
+CSCALCT::CSCALCT() {
+  bzero(this, 2);  ///size of ALCT = 2bytes
 }
 
-
-CSCALCT::CSCALCT(const CSCALCTDigi & alctDigi):
-    valid(alctDigi.isValid()),
-    quality(alctDigi.getQuality()),
-    accel(alctDigi.getAccelerator()),
-    pattern(alctDigi.getCollisionB()),
-    keyWire(alctDigi.getKeyWG()),
-    reserved(0)
-{
-}
+CSCALCT::CSCALCT(const CSCALCTDigi& alctDigi)
+    : valid(alctDigi.isValid()),
+      quality(alctDigi.getQuality()),
+      accel(alctDigi.getAccelerator()),
+      pattern(alctDigi.getCollisionB()),
+      keyWire(alctDigi.getKeyWG()),
+      reserved(0) {}
 
 #include <iostream>
-CSCALCTHeader2007::CSCALCTHeader2007()
-{
-  bzero(this,  sizeInWords()*2); ///size of 2007 header w/o variable parts = 16 bytes
+CSCALCTHeader2007::CSCALCTHeader2007() {
+  bzero(this, sizeInWords() * 2);  ///size of 2007 header w/o variable parts = 16 bytes
   flag1 = 0xDB0A;
   reserved1 = reserved2 = reserved3 = 0xD;
   rawBins = 16;
   lctBins = 8;
 }
 
-CSCALCTHeader2007::CSCALCTHeader2007(int chamberType)  {
-  bzero(this,  sizeInWords()*2); ///size of 2007 header w/o variable parts = 16 bytes
+CSCALCTHeader2007::CSCALCTHeader2007(int chamberType) {
+  bzero(this, sizeInWords() * 2);  ///size of 2007 header w/o variable parts = 16 bytes
   // things that depend on chamber type
   int boardTypes[11] = {0, 2, 2, 3, 1, 6, 3, 5, 3, 5, 3};
   flag1 = 0xDB0A;
@@ -39,9 +35,7 @@ CSCALCTHeader2007::CSCALCTHeader2007(int chamberType)  {
   lctBins = 8;
 }
 
-void CSCALCTHeader2007::setEventInformation(const CSCDMBHeader & dmb)
-{
- l1aCounter = dmb.l1a24() & 0xFFF;
- bxnCount = dmb.bxn12();
+void CSCALCTHeader2007::setEventInformation(const CSCDMBHeader& dmb) {
+  l1aCounter = dmb.l1a24() & 0xFFF;
+  bxnCount = dmb.bxn12();
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCALCTTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTTrailer.cc
@@ -4,33 +4,31 @@
 
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h"
 
-
 #ifdef LOCAL_UNPACK
 
-bool CSCALCTTrailer::debug=false;
-short unsigned int CSCALCTTrailer::firmwareVersion=2006; 
+bool CSCALCTTrailer::debug = false;
+short unsigned int CSCALCTTrailer::firmwareVersion = 2006;
 
 #else
 
 std::atomic<bool> CSCALCTTrailer::debug{false};
-std::atomic<short unsigned int> CSCALCTTrailer::firmwareVersion{2006}; 
+std::atomic<short unsigned int> CSCALCTTrailer::firmwareVersion{2006};
 
 #endif
 
 CSCALCTTrailer2006::CSCALCTTrailer2006() {
-  bzero(this,  sizeInWords()*2); ///size of the trailer
+  bzero(this, sizeInWords() * 2);  ///size of the trailer
   e0dLine = 0xDE0D;
-  d_0=0xD;
-  d_1=0xD;
+  d_0 = 0xD;
+  d_1 = 0xD;
   zero_0 = 0;
   zero_1 = 0;
   d_3 = 0xD;
   reserved_3 = 1;
 }
 
-
 CSCALCTTrailer2007::CSCALCTTrailer2007() {
-  bzero(this,  sizeInWords()*2); ///size of the trailer
+  bzero(this, sizeInWords() * 2);  ///size of the trailer
   e0dLine = 0xDE0D;
   reserved_0 = 0xD;
   reserved_1 = 0xD;
@@ -38,53 +36,44 @@ CSCALCTTrailer2007::CSCALCTTrailer2007() {
   reserved_4 = 0xD;
 }
 
-
-
-CSCALCTTrailer::CSCALCTTrailer(int size, int firmVersion) 
-{ ///needed for packing
-  if(firmVersion == 2006)
-  {
-     trailer2006.setSize(size);
-     firmwareVersion = 2006;
+CSCALCTTrailer::CSCALCTTrailer(int size, int firmVersion) {  ///needed for packing
+  if (firmVersion == 2006) {
+    trailer2006.setSize(size);
+    firmwareVersion = 2006;
+  } else if (firmVersion == 2007) {
+    trailer2007.setSize(size);
+    firmwareVersion = 2007;
+  } else {
+    edm::LogError("CSCALCTTrailer|CSCRawToDigi")
+        << "failed to construct: undetermined ALCT firmware version!!" << firmVersion;
   }
-  else if (firmVersion == 2007)
-  {
-     trailer2007.setSize(size);
-     firmwareVersion = 2007;
-  }
-  else {
-    edm::LogError("CSCALCTTrailer|CSCRawToDigi") <<"failed to construct: undetermined ALCT firmware version!!" << firmVersion;
-  }
-
 }
 
-CSCALCTTrailer::CSCALCTTrailer(const unsigned short * buf){
+CSCALCTTrailer::CSCALCTTrailer(const unsigned short* buf) {
   ///determine the version first
-  if ((buf[0]==0xDE0D)&&((buf[1]&0xF000)==0xD000)) {
-    firmwareVersion=2007;
-  }
-  else if ( (buf[2]&0xFFF)==0xE0D ) {
-    firmwareVersion=2006;
-  }
-  else {
-    edm::LogError("CSCALCTTrailer|CSCRawToDigi") <<"failed to construct: undetermined ALCT firmware version!!" << firmwareVersion;
+  if ((buf[0] == 0xDE0D) && ((buf[1] & 0xF000) == 0xD000)) {
+    firmwareVersion = 2007;
+  } else if ((buf[2] & 0xFFF) == 0xE0D) {
+    firmwareVersion = 2006;
+  } else {
+    edm::LogError("CSCALCTTrailer|CSCRawToDigi")
+        << "failed to construct: undetermined ALCT firmware version!!" << firmwareVersion;
   }
 
-  ///Now fill data 
+  ///Now fill data
 #ifdef LOCAL_UNPACK
   switch (firmwareVersion) {
 #else
   switch (firmwareVersion.load()) {
 #endif
-  case 2006:
-    trailer2006.setFromBuffer(buf);
-    break;
-  case 2007:
-    trailer2007.setFromBuffer(buf);
-    break;
-  default:
-    edm::LogError("CSCALCTTrailer|CSCRawToDigi")
-      <<"couldn't construct: ALCT firmware version is bad/not defined!";
-    break;
+    case 2006:
+      trailer2006.setFromBuffer(buf);
+      break;
+    case 2007:
+      trailer2007.setFromBuffer(buf);
+      break;
+    default:
+      edm::LogError("CSCALCTTrailer|CSCRawToDigi") << "couldn't construct: ALCT firmware version is bad/not defined!";
+      break;
   }
 }

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData.cc
@@ -3,41 +3,31 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <cstring> // for bzero
+#include <cstring>  // for bzero
 
-
-
-
-CSCAnodeData::CSCAnodeData(const CSCALCTHeader & header) ///for digi->raw packing
-:  firmwareVersion(header.alctFirmwareVersion())
-{
-  if(firmwareVersion == 2006) {
+CSCAnodeData::CSCAnodeData(const CSCALCTHeader &header)  ///for digi->raw packing
+    : firmwareVersion(header.alctFirmwareVersion()) {
+  if (firmwareVersion == 2006) {
     theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2006(header));
   } else {
     theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2007(header));
   }
 }
 
-
 // initialize
-CSCAnodeData::CSCAnodeData(const CSCALCTHeader & header ,
-                               const unsigned short *buf) 
-:  firmwareVersion(header.alctFirmwareVersion())
-{
-  if(firmwareVersion == 2006) {
+CSCAnodeData::CSCAnodeData(const CSCALCTHeader &header, const unsigned short *buf)
+    : firmwareVersion(header.alctFirmwareVersion()) {
+  if (firmwareVersion == 2006) {
     theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2006(header, buf));
   } else {
     theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2007(header, buf));
   }
 }
 
-std::vector < std::vector<CSCWireDigi> > CSCAnodeData::wireDigis() const 
-{
-  std::vector < std::vector<CSCWireDigi> > result;
-  for (int layer = 1; layer <= 6; ++layer) 
-    {
-      result.push_back(wireDigis(layer));
-    }
+std::vector<std::vector<CSCWireDigi> > CSCAnodeData::wireDigis() const {
+  std::vector<std::vector<CSCWireDigi> > result;
+  for (int layer = 1; layer <= 6; ++layer) {
+    result.push_back(wireDigis(layer));
+  }
   return result;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData2006.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData2006.cc
@@ -1,147 +1,123 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <cstring> // for bzero
+#include <cstring>  // for bzero
 #include <iostream>
 
-CSCAnodeDataFrame2006::CSCAnodeDataFrame2006(unsigned chip, unsigned tbin, unsigned data)
-: theFrame(0)
-{
-   // lowest bit, plus the OR of the next two.
-   unsigned packedChip = ( (chip&1) + 2*(chip>1) );
-   theFrame = data + ((tbin&0x1F) << 8) + (packedChip<<13);
+CSCAnodeDataFrame2006::CSCAnodeDataFrame2006(unsigned chip, unsigned tbin, unsigned data) : theFrame(0) {
+  // lowest bit, plus the OR of the next two.
+  unsigned packedChip = ((chip & 1) + 2 * (chip > 1));
+  theFrame = data + ((tbin & 0x1F) << 8) + (packedChip << 13);
 }
 
-
-CSCAnodeData2006::CSCAnodeData2006(const CSCALCTHeader & header) ///for digi->raw packing
-  : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins()) 
-{
-  LogTrace ("CSCAnodeData|CSCRawToDigi") << "Making Anode data " 
-			      << sizeInWords() << " AFEB " << nAFEBs_ 
-			      << " TBINS " << nTimeBins_;
-  bzero(theDataFrames, sizeInWords()*2);
-  for(int afeb = 0; afeb < nAFEBs_; ++afeb) {
-    for(int tbin = 0; tbin < nTimeBins_; ++tbin) {
-      for(int layer = 1; layer <= 6; ++layer) {
-	for(int halfLayer = 0; halfLayer < 2; ++halfLayer) {
-	  theDataFrames[index(afeb, tbin, layer)+halfLayer] = CSCAnodeDataFrame2006(afeb, tbin, 0).frame();
-	}
+CSCAnodeData2006::CSCAnodeData2006(const CSCALCTHeader &header)  ///for digi->raw packing
+    : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins()) {
+  LogTrace("CSCAnodeData|CSCRawToDigi") << "Making Anode data " << sizeInWords() << " AFEB " << nAFEBs_ << " TBINS "
+                                        << nTimeBins_;
+  bzero(theDataFrames, sizeInWords() * 2);
+  for (int afeb = 0; afeb < nAFEBs_; ++afeb) {
+    for (int tbin = 0; tbin < nTimeBins_; ++tbin) {
+      for (int layer = 1; layer <= 6; ++layer) {
+        for (int halfLayer = 0; halfLayer < 2; ++halfLayer) {
+          theDataFrames[index(afeb, tbin, layer) + halfLayer] = CSCAnodeDataFrame2006(afeb, tbin, 0).frame();
+        }
       }
     }
   }
-    /// To get BX from ALCT digis
-    alctBX_= header.BXNCount();
+  /// To get BX from ALCT digis
+  alctBX_ = header.BXNCount();
 }
 
 // initialize
-CSCAnodeData2006::CSCAnodeData2006(const CSCALCTHeader & header ,
-                               const unsigned short *buf) 
-  : nAFEBs_(header.nLCTChipRead()), 
-    nTimeBins_(header.NTBins())
-{
-
+CSCAnodeData2006::CSCAnodeData2006(const CSCALCTHeader &header, const unsigned short *buf)
+    : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins()) {
   ///the sizes of raw words vary depending on type of the ALCT board
   ///                         number of layer parts for various
   ///                         alct board types:     1  2  3     5  6
-  LogTrace ("CSCAnodeData|CSCRawToDigi") << "nAFEBs = " << nAFEBs_ << "  nTimeBins = " 
-				<< nTimeBins_ << " nFrames = " << sizeInWords();  
-  LogTrace ("CSCAnodeData|CSCRawToDigi") << header << " HEADER CHECK " << header.check();
+  LogTrace("CSCAnodeData|CSCRawToDigi") << "nAFEBs = " << nAFEBs_ << "  nTimeBins = " << nTimeBins_
+                                        << " nFrames = " << sizeInWords();
+  LogTrace("CSCAnodeData|CSCRawToDigi") << header << " HEADER CHECK " << header.check();
 
-  memcpy(theDataFrames, buf, sizeInWords()*2);///dont memcpy if not 2006 or 2007
+  memcpy(theDataFrames, buf, sizeInWords() * 2);  ///dont memcpy if not 2006 or 2007
 }
-
 
 std::vector<CSCWireDigi> CSCAnodeData2006::wireDigis(int layer) const {
   std::vector<CSCWireDigi> digis;
-  uint32_t tbinbits=0;
-  uint16_t wireGroup=0;
-    for(int afeb = 0; afeb < nAFEBs_; ++afeb) {
-      for(int halfLayer = 0; halfLayer <2; ++halfLayer) {
-	for (int j=0;j<8;++j) {
-	  for(int tbin = 0; tbin < nTimeBins_; ++tbin) {
-	    CSCAnodeDataFrame2006 frame(rawHit(afeb,tbin,layer, halfLayer));
-	    // see if there's anything in 1st 8 bits.  Usually zero
-	    if(frame.data() != 0) {
-	      if(frame.isHit(j)) {
-		tbinbits=tbinbits + (1<<tbin);      
-	      }
-	    }
-	  }//end of tbin loop
-	  if (tbinbits !=0 ) {
-	    wireGroup = (afeb*16+halfLayer*8+j)+1;
-            uint32_t wireGroupBX=alctBX_;
-            wireGroup = wireGroup | (wireGroupBX << 16);
-	    CSCWireDigi digi(wireGroup, tbinbits);
-	    LogTrace ("CSCAnodeData|CSCRawToDigi") << "Layer " << layer << " " << digi;
-	    digis.push_back(digi);
-	    tbinbits=0;
-	  }
-	}
+  uint32_t tbinbits = 0;
+  uint16_t wireGroup = 0;
+  for (int afeb = 0; afeb < nAFEBs_; ++afeb) {
+    for (int halfLayer = 0; halfLayer < 2; ++halfLayer) {
+      for (int j = 0; j < 8; ++j) {
+        for (int tbin = 0; tbin < nTimeBins_; ++tbin) {
+          CSCAnodeDataFrame2006 frame(rawHit(afeb, tbin, layer, halfLayer));
+          // see if there's anything in 1st 8 bits.  Usually zero
+          if (frame.data() != 0) {
+            if (frame.isHit(j)) {
+              tbinbits = tbinbits + (1 << tbin);
+            }
+          }
+        }  //end of tbin loop
+        if (tbinbits != 0) {
+          wireGroup = (afeb * 16 + halfLayer * 8 + j) + 1;
+          uint32_t wireGroupBX = alctBX_;
+          wireGroup = wireGroup | (wireGroupBX << 16);
+          CSCWireDigi digi(wireGroup, tbinbits);
+          LogTrace("CSCAnodeData|CSCRawToDigi") << "Layer " << layer << " " << digi;
+          digis.push_back(digi);
+          tbinbits = 0;
+        }
       }
     }
-    
+  }
+
   return digis;
 }
 
-
-void CSCAnodeData2006::add(const CSCWireDigi & digi, int layer) 
-{
-
+void CSCAnodeData2006::add(const CSCWireDigi &digi, int layer) {
   int wireGroup = digi.getWireGroup();
-  int bxn=digi.getBeamCrossingTag(); 
-  int alctBoard  = (wireGroup-1) / 16;
-  int localGroup = (wireGroup-1) % 16;
+  int bxn = digi.getBeamCrossingTag();
+  int alctBoard = (wireGroup - 1) / 16;
+  int localGroup = (wireGroup - 1) % 16;
 
   // crash if there's a bad wire number, but don't freak out
-  // if a time bin is out of range 
+  // if a time bin is out of range
   //  assert(alctBoard < nAFEBs_);
-  if(alctBoard > nAFEBs_)
-    {
-      edm::LogError("CSCAnodeData|CSCRawToDigi") << "Bad Wire Number for this digi.";
-      return;
-    }
-  if(bxn >= 0 && bxn < nTimeBins_) 
-    {
-      // 12 16-bit words per time bin, two per layer
-      // wiregroups 0-7 go on the first line, 8-15 go on the 2nd.
-      unsigned halfLayer = (localGroup > 7);
-      unsigned bitNumber = localGroup % 8;
-      // and pack it in the 8 bits allocated
-      addHit(alctBoard, bxn, layer, halfLayer, bitNumber);
-    } 
-  else 
-    {
-      LogTrace("CSCAnodeData|CSCRawToDigi")<< "warning: not saving anode data in bx " << bxn 
-			      << ": out of range ";
-    }
+  if (alctBoard > nAFEBs_) {
+    edm::LogError("CSCAnodeData|CSCRawToDigi") << "Bad Wire Number for this digi.";
+    return;
+  }
+  if (bxn >= 0 && bxn < nTimeBins_) {
+    // 12 16-bit words per time bin, two per layer
+    // wiregroups 0-7 go on the first line, 8-15 go on the 2nd.
+    unsigned halfLayer = (localGroup > 7);
+    unsigned bitNumber = localGroup % 8;
+    // and pack it in the 8 bits allocated
+    addHit(alctBoard, bxn, layer, halfLayer, bitNumber);
+  } else {
+    LogTrace("CSCAnodeData|CSCRawToDigi") << "warning: not saving anode data in bx " << bxn << ": out of range ";
+  }
 }
 
-
-void CSCAnodeData2006::addHit(int afeb, int tbin, int layer, int halfLayer, unsigned wireBit)
-{
-  int i = index(afeb,tbin,layer) + halfLayer;
+void CSCAnodeData2006::addHit(int afeb, int tbin, int layer, int halfLayer, unsigned wireBit) {
+  int i = index(afeb, tbin, layer) + halfLayer;
   CSCAnodeDataFrame2006 frame(theDataFrames[i]);
   frame.addHit(wireBit);
-  theDataFrames[i] = frame.frame(); 
+  theDataFrames[i] = frame.frame();
 }
 
-
-CSCAnodeDataFrame2006 CSCAnodeData2006::rawHit(int afeb, int tbin, int layer, int halfLayer) const
-{
-  return CSCAnodeDataFrame2006(theDataFrames[index(afeb, tbin, layer)+halfLayer]);
+CSCAnodeDataFrame2006 CSCAnodeData2006::rawHit(int afeb, int tbin, int layer, int halfLayer) const {
+  return CSCAnodeDataFrame2006(theDataFrames[index(afeb, tbin, layer) + halfLayer]);
 }
-
 
 int CSCAnodeData2006::index(int afeb, int tbin, int layer) const {
-  int result = (layer-1)*2 + 12*tbin + afeb*12*nTimeBins_;
+  int result = (layer - 1) * 2 + 12 * tbin + afeb * 12 * nTimeBins_;
   assert(result < sizeInWords());
   return result;
 }
 
 #include <iostream>
-void CSCAnodeData2006::selfTest()
-{
-  CSCAnodeDataFrame2006 frame(2, 15, 32); 
+void CSCAnodeData2006::selfTest() {
+  CSCAnodeDataFrame2006 frame(2, 15, 32);
   assert(frame.chip() == 2);
   assert(frame.tbin() == 15);
   assert(frame.data() == 32);
@@ -164,5 +140,3 @@ void CSCAnodeData2006::selfTest()
   assert(wires1[0].getWireGroup() == 10);
   assert(wires6[0].getWireGroup() == 10);
 }
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData2007.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData2007.cc
@@ -1,132 +1,114 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <cstring> // for bzero
-#include<iostream>
+#include <cstring>  // for bzero
+#include <iostream>
 
-CSCAnodeData2007::CSCAnodeData2007(const CSCALCTHeader & header)
-  : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins())
-{
+CSCAnodeData2007::CSCAnodeData2007(const CSCALCTHeader &header)
+    : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins()) {
   init(header);
-  bzero(theDataFrames, sizeInWords()*2);
+  bzero(theDataFrames, sizeInWords() * 2);
   /// To get BX from ALCT digis
-  alctBX_= header.BXNCount();
+  alctBX_ = header.BXNCount();
 }
 
-
-CSCAnodeData2007::CSCAnodeData2007(const CSCALCTHeader & header ,
-                                   const unsigned short *buf) 
-  : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins())
-{
-    init(header);
-    memcpy(theDataFrames, buf, sizeInWords()*2);///dont memcpy if not 2006 or 2007
-    /// To get BX from ALCT digis
-   alctBX_= header.BXNCount();
+CSCAnodeData2007::CSCAnodeData2007(const CSCALCTHeader &header, const unsigned short *buf)
+    : nAFEBs_(header.nLCTChipRead()), nTimeBins_(header.NTBins()) {
+  init(header);
+  memcpy(theDataFrames, buf, sizeInWords() * 2);  ///dont memcpy if not 2006 or 2007
+                                                  /// To get BX from ALCT digis
+  alctBX_ = header.BXNCount();
 }
 
-
-void CSCAnodeData2007::init(const CSCALCTHeader & header) {
+void CSCAnodeData2007::init(const CSCALCTHeader &header) {
   ///the sizes of raw words vary depending on type of the ALCT board
   ///                         number of layer parts for various
   ///                         alct board types:     1  2  3     5  6
-  static const unsigned short int layerParts[7]    = { 3, 3, 4, 6, 6, 8,10};
-  static const unsigned short int wireGroups[7]    = {32,32,48,64,64,96,112};
+  static const unsigned short int layerParts[7] = {3, 3, 4, 6, 6, 8, 10};
+  static const unsigned short int wireGroups[7] = {32, 32, 48, 64, 64, 96, 112};
   //header.ALCTDigis();
-  sizeInWords2007_=(1-header.alctHeader2007().rawOverflow)*6*
-  header.alctHeader2007().rawBins*layerParts[header.alctHeader2007().boardType];
+  sizeInWords2007_ = (1 - header.alctHeader2007().rawOverflow) * 6 * header.alctHeader2007().rawBins *
+                     layerParts[header.alctHeader2007().boardType];
   layerParts_ = layerParts[header.alctHeader2007().boardType];
   maxWireGroups_ = wireGroups[header.alctHeader2007().boardType];
 }
 
-
 std::vector<CSCWireDigi> CSCAnodeData2007::wireDigis(int layer) const {
   std::vector<CSCWireDigi> digis;
-  uint32_t tbinbits=0;
-  uint32_t wireGroup=0;
+  uint32_t tbinbits = 0;
+  uint32_t wireGroup = 0;
   /// BX from ACT (first component)
-  for(int layerPart = 0; layerPart <layerParts_; ++layerPart) {
-    ///we know how many layer parts are there from ALCT header 
-    for (int j=0; (j<12)&&((layerPart*12+j)<maxWireGroups_) ;++j) {
-      ///loop over 12 bits in each word (each bit is one wiregroup) 
+  for (int layerPart = 0; layerPart < layerParts_; ++layerPart) {
+    ///we know how many layer parts are there from ALCT header
+    for (int j = 0; (j < 12) && ((layerPart * 12 + j) < maxWireGroups_); ++j) {
+      ///loop over 12 bits in each word (each bit is one wiregroup)
       ///we want to stop if we reached the maxWireGroups
-      for(int tbin = 0; tbin < nTimeBins_; ++tbin) { ///loop over tbins
-	CSCAnodeDataFrame2007 frame = findFrame(tbin, layer, layerPart);
-	if(frame.data() != 0) {
-	  if(frame.isHit(j)) {
-	    tbinbits=tbinbits + (1<<tbin);
-	  }
-	}
-      }//end of tbin loop
-      if (tbinbits !=0 ) {
-	wireGroup = (layerPart*12+j)+1;
-	/// BX from ALCT encoded in wireGroup
-	uint32_t wireGroupBX=alctBX_;
-	wireGroup = wireGroup | (wireGroupBX << 16);
-	CSCWireDigi digi(wireGroup, tbinbits);
-	LogTrace ("CSCAnodeData|CSCRawToDigi") << "Layer " << layer << " " << digi;
-	digis.push_back(digi);
-	tbinbits=0;
+      for (int tbin = 0; tbin < nTimeBins_; ++tbin) {  ///loop over tbins
+        CSCAnodeDataFrame2007 frame = findFrame(tbin, layer, layerPart);
+        if (frame.data() != 0) {
+          if (frame.isHit(j)) {
+            tbinbits = tbinbits + (1 << tbin);
+          }
+        }
+      }  //end of tbin loop
+      if (tbinbits != 0) {
+        wireGroup = (layerPart * 12 + j) + 1;
+        /// BX from ALCT encoded in wireGroup
+        uint32_t wireGroupBX = alctBX_;
+        wireGroup = wireGroup | (wireGroupBX << 16);
+        CSCWireDigi digi(wireGroup, tbinbits);
+        LogTrace("CSCAnodeData|CSCRawToDigi") << "Layer " << layer << " " << digi;
+        digis.push_back(digi);
+        tbinbits = 0;
       }
-    }///end of the loop over bits in the data frame
-  }///end of the loop over layer parts
-  
+    }  ///end of the loop over bits in the data frame
+  }    ///end of the loop over layer parts
+
   return digis;
 }
-
 
 CSCAnodeDataFrame2007 CSCAnodeData2007::findFrame(int tbin, int layer, int layerPart) const {
   return CSCAnodeDataFrame2007(theDataFrames[index(tbin, layer, layerPart)]);
 }
 
-
-int CSCAnodeData2007::index(int tbin, int layer, int layerPart) const 
-{
-  assert(tbin<nTimeBins_);
-  assert(layer<=6);
-  assert(layerPart<layerParts_);
-  int result = tbin*6*layerParts_+(layer-1)*layerParts_+layerPart;
+int CSCAnodeData2007::index(int tbin, int layer, int layerPart) const {
+  assert(tbin < nTimeBins_);
+  assert(layer <= 6);
+  assert(layerPart < layerParts_);
+  int result = tbin * 6 * layerParts_ + (layer - 1) * layerParts_ + layerPart;
   assert(result < MAXFRAMES);
   return result;
 }
 
-
-void CSCAnodeData2007::add(const CSCWireDigi & digi, int layer) 
-{
+void CSCAnodeData2007::add(const CSCWireDigi &digi, int layer) {
   int wireGroup = digi.getWireGroup();
   //           wireGroup = (layerPart*12+j)+1;
-  unsigned layerPart = (wireGroup-1) / 12;
-  unsigned wireInPart = (wireGroup-1) % 12; 
+  unsigned layerPart = (wireGroup - 1) / 12;
+  unsigned wireInPart = (wireGroup - 1) % 12;
 
   std::vector<int> timeBinsOn = digi.getTimeBinsOn();
-  for(std::vector<int>::const_iterator timeBinOn = timeBinsOn.begin();
-      timeBinOn != timeBinsOn.end(); ++timeBinOn)
-  {
+  for (std::vector<int>::const_iterator timeBinOn = timeBinsOn.begin(); timeBinOn != timeBinsOn.end(); ++timeBinOn) {
     // crash if there's a bad wire number, but don't freak out
-    // if a time bin is out of range 
+    // if a time bin is out of range
     //  assert(alctBoard < nAFEBs_);
-    if(layerPart >= layerParts_)
-      {
-        edm::LogError("CSCAnodeData|CSCRawToDigi") << "Bad Wire Number for this digi.";
-        return;
-      }
+    if (layerPart >= layerParts_) {
+      edm::LogError("CSCAnodeData|CSCRawToDigi") << "Bad Wire Number for this digi.";
+      return;
+    }
 
-    if((*timeBinOn) >= 0 && (*timeBinOn) < nTimeBins_) 
-      {
-        CSCAnodeDataFrame2007 frame = findFrame(*timeBinOn, layer, layerPart);
-        frame.addHit(wireInPart);
-        // FIXME doesn't carry over the (currently 0) leading bits
-        theDataFrames[index(*timeBinOn, layer, layerPart)]  = frame.data();
-      } 
-    else 
-      {
-        LogTrace("CSCAnodeData|CSCRawToDigi")<< "warning: not saving anode data in bx " << *timeBinOn 
-  			      << ": out of range ";
-      }
+    if ((*timeBinOn) >= 0 && (*timeBinOn) < nTimeBins_) {
+      CSCAnodeDataFrame2007 frame = findFrame(*timeBinOn, layer, layerPart);
+      frame.addHit(wireInPart);
+      // FIXME doesn't carry over the (currently 0) leading bits
+      theDataFrames[index(*timeBinOn, layer, layerPart)] = frame.data();
+    } else {
+      LogTrace("CSCAnodeData|CSCRawToDigi")
+          << "warning: not saving anode data in bx " << *timeBinOn << ": out of range ";
+    }
   }
 }
 
-void CSCAnodeData2007::selfTest()
-{
+void CSCAnodeData2007::selfTest() {
   int wireGroup = 12;
   int timeBin = 6;
   CSCWireDigi wireDigi(wireGroup, (1 << timeBin));
@@ -144,6 +126,4 @@ void CSCAnodeData2007::selfTest()
   assert(wires6[0].getWireGroup() == wireGroup);
   assert(wires1[0].getTimeBin() == timeBin);
   assert(wires6[0].getTimeBin() == timeBin);
-
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCBadCFEBTimeSlice.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCBadCFEBTimeSlice.cc
@@ -1,20 +1,16 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h"
-#include<cassert>
+#include <cassert>
 
-const CSCBadCFEBWord & CSCBadCFEBTimeSlice::word(int i) const
-{
-  assert(i>=0 && i<4);
+const CSCBadCFEBWord& CSCBadCFEBTimeSlice::word(int i) const {
+  assert(i >= 0 && i < 4);
   return theWords[i];
 }
 
-bool CSCBadCFEBTimeSlice::check() const
-{
+bool CSCBadCFEBTimeSlice::check() const {
   // demand all four words check out
   bool result = true;
-  for(int i = 0; i < 4; ++i) 
-    {
-      result &= theWords[i].check();
-    }
+  for (int i = 0; i < 4; ++i) {
+    result &= theWords[i].check();
+  }
   return result;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCBadCFEBWord.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCBadCFEBWord.cc
@@ -1,33 +1,29 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCBadCFEBWord.h"
-#include<iostream>
+#include <iostream>
 
-std::ostream & operator<<(std::ostream & os, const CSCBadCFEBWord & word) 
-{
-  if(!word.check()) os << "Even the Bad CFEB word is bad!  Sheesh!" << std::endl;
-  else 
-    {
-      switch(word.code_)
-	{
-	case 1:
-	  os << "CFEB: SCA Capacitors Full  block " << word.word2_ 
-	     << " FIFO1 count (4-bit) " << word.word1_ << std::endl;
-	  break;
-	case 2:
-	  os << "CFEB: FPGA FIFO Full  FIFO3 count (4-bit) " << word.word2_ 
-	     << " FIFO1 count (4-bit) " << word.word1_ << std::endl;
-	  break;
-	case 5:
-	  os << "CFEB: DMB FIFO Full " << std::endl;
-	  break;
-	case 6:
-	  os << "CFEB: DMB FPGA FIFO Full GFIFO count (4-bit)" << word.word2_ 
-	     << " LFIFO count (4-bit) " << word.word1_ << std::endl;
-	  break;
-	default:
-	  os << "Undefined CFEB error" << std::endl;
-	  break;
-	}
+std::ostream& operator<<(std::ostream& os, const CSCBadCFEBWord& word) {
+  if (!word.check())
+    os << "Even the Bad CFEB word is bad!  Sheesh!" << std::endl;
+  else {
+    switch (word.code_) {
+      case 1:
+        os << "CFEB: SCA Capacitors Full  block " << word.word2_ << " FIFO1 count (4-bit) " << word.word1_ << std::endl;
+        break;
+      case 2:
+        os << "CFEB: FPGA FIFO Full  FIFO3 count (4-bit) " << word.word2_ << " FIFO1 count (4-bit) " << word.word1_
+           << std::endl;
+        break;
+      case 5:
+        os << "CFEB: DMB FIFO Full " << std::endl;
+        break;
+      case 6:
+        os << "CFEB: DMB FPGA FIFO Full GFIFO count (4-bit)" << word.word2_ << " LFIFO count (4-bit) " << word.word1_
+           << std::endl;
+        break;
+      default:
+        os << "Undefined CFEB error" << std::endl;
+        break;
     }
+  }
   return os;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -8,61 +8,59 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cassert>
 
-CSCCFEBData::CSCCFEBData(unsigned number, const uint16_t * buf, uint16_t format_version, bool f_dcfeb) 
-  : theSize(0), boardNumber_(number), theNumberOfSamples(0), theFormatVersion(format_version), fDCFEB(f_dcfeb) {
+CSCCFEBData::CSCCFEBData(unsigned number, const uint16_t *buf, uint16_t format_version, bool f_dcfeb)
+    : theSize(0), boardNumber_(number), theNumberOfSamples(0), theFormatVersion(format_version), fDCFEB(f_dcfeb) {
   // I may be grabbing too many words, but that's OK
   // parse for time slices
   unsigned pos = 0;
   // to be set later
   unsigned maxSamples = 8;
   theSliceStarts.reserve(8);
-  while(theNumberOfSamples < maxSamples) {
+  while (theNumberOfSamples < maxSamples) {
     // first see if it's a bad slice
-    const CSCBadCFEBTimeSlice * badSlice
-      = reinterpret_cast<const CSCBadCFEBTimeSlice *>(buf+pos);
-    if(badSlice->check()) {
+    const CSCBadCFEBTimeSlice *badSlice = reinterpret_cast<const CSCBadCFEBTimeSlice *>(buf + pos);
+    if (badSlice->check()) {
       //show that a bad slice starts here
       theSliceStarts.push_back(std::pair<int, bool>(pos, false));
       pos += badSlice->sizeInWords();
       //store bad word for status digis
-      bWords.push_back(badSlice->word(1).data()); //all 4 words are assumed identical so saving #1 only  
-    } 
-    else {
+      bWords.push_back(badSlice->word(1).data());  //all 4 words are assumed identical so saving #1 only
+    } else {
       // OK.  Maybe it's good.
-      const CSCCFEBTimeSlice * goodSlice 
-	= reinterpret_cast<const CSCCFEBTimeSlice *>(buf+pos);
-      if(goodSlice->check()) {
-	// show that a good slice starts here
-	theSliceStarts.push_back(std::pair<int, bool>(pos, true));
-	// it will just be an array of CSCCFEBTimeSlices, so we'll
-	// grab the number of time slices from the first good one
-	// !!! VB - Limit maximum number of CFEB samples to 8. 
-	// !!!      In Run2 rare CFEB data corruptions were causing RECO problems with mistakenly setting 16 samples flags
-	// !!!      Will need another fix in case of CSC switch to 16 samples readout
-	// maxSamples =   goodSlice->sixteenSamples() ? 16 : 8;
-	if (goodSlice->sixteenSamples()) LogTrace ("CSCCFEBData|CSCRawToDigi")
-          << "CFEB DATA slice " << theNumberOfSamples << " 16 samples flag is detected";
-	pos += goodSlice->sizeInWords();
-      } 
-      else {
-	LogTrace ("CSCCFEBData|CSCRawToDigi") 
-	  << "CORRUPT CFEB DATA slice " << theNumberOfSamples << std::hex << " " 
-	  << *(buf+pos+3) << " " << *(buf+pos+2) << " "  << *(buf+pos+1) << " "<< *(buf+pos);
-	//ok slice is bad but try another one at 100 words after it
+      const CSCCFEBTimeSlice *goodSlice = reinterpret_cast<const CSCCFEBTimeSlice *>(buf + pos);
+      if (goodSlice->check()) {
+        // show that a good slice starts here
+        theSliceStarts.push_back(std::pair<int, bool>(pos, true));
+        // it will just be an array of CSCCFEBTimeSlices, so we'll
+        // grab the number of time slices from the first good one
+        // !!! VB - Limit maximum number of CFEB samples to 8.
+        // !!!      In Run2 rare CFEB data corruptions were causing RECO problems with mistakenly setting 16 samples flags
+        // !!!      Will need another fix in case of CSC switch to 16 samples readout
+        // maxSamples =   goodSlice->sixteenSamples() ? 16 : 8;
+        if (goodSlice->sixteenSamples())
+          LogTrace("CSCCFEBData|CSCRawToDigi")
+              << "CFEB DATA slice " << theNumberOfSamples << " 16 samples flag is detected";
+        pos += goodSlice->sizeInWords();
+      } else {
+        LogTrace("CSCCFEBData|CSCRawToDigi")
+            << "CORRUPT CFEB DATA slice " << theNumberOfSamples << std::hex << " " << *(buf + pos + 3) << " "
+            << *(buf + pos + 2) << " " << *(buf + pos + 1) << " " << *(buf + pos);
+        //ok slice is bad but try another one at 100 words after it
         theSliceStarts.push_back(std::pair<int, bool>(pos, false));
-	pos += 100;
+        pos += 100;
       }
     }
     ++theNumberOfSamples;
   }
   theSize = pos;
-  memcpy(theData, buf, theSize*2);
+  memcpy(theData, buf, theSize * 2);
 }
 
-
-CSCCFEBData::CSCCFEBData(unsigned number, bool sixteenSamples, uint16_t format_version, bool f_dcfeb) 
-: boardNumber_(number), theNumberOfSamples(sixteenSamples ? 16 : 8), theFormatVersion(format_version), fDCFEB(f_dcfeb)
-{
+CSCCFEBData::CSCCFEBData(unsigned number, bool sixteenSamples, uint16_t format_version, bool f_dcfeb)
+    : boardNumber_(number),
+      theNumberOfSamples(sixteenSamples ? 16 : 8),
+      theFormatVersion(format_version),
+      fDCFEB(f_dcfeb) {
   theSliceStarts.reserve(theNumberOfSamples);
 
   // fill the SCA controller words
@@ -73,160 +71,141 @@ CSCCFEBData::CSCCFEBData(unsigned number, bool sixteenSamples, uint16_t format_v
   CSCCFEBTimeSlice slice;
   slice.setControllerWord(scaWord);
 
-  for(unsigned i = 0; i < theNumberOfSamples; ++i) 
-    {
-      unsigned short * pos = theData+i*100;
-      memcpy(pos, &slice, 200);
-      theSliceStarts.push_back(std::pair<int,bool>(i*100, true));
-    }
-  theSize = theNumberOfSamples*100;
+  for (unsigned i = 0; i < theNumberOfSamples; ++i) {
+    unsigned short *pos = theData + i * 100;
+    memcpy(pos, &slice, 200);
+    theSliceStarts.push_back(std::pair<int, bool>(i * 100, true));
+  }
+  theSize = theNumberOfSamples * 100;
 }
 
-void CSCCFEBData::add(const CSCStripDigi & digi, int layer)
-{
-  std::vector<int> scaCounts =  digi.getADCCounts();
-  for(unsigned itime = 0; itime < theNumberOfSamples; ++itime) 
-    {
-      unsigned channel = (digi.getStrip()-1) % 16 + 1;
-      unsigned value = scaCounts[itime] & 0xFFF; // 12-bit
-      // assume it's good, since we're working with simulation
-      CSCCFEBTimeSlice * slice = timeSlice(itime);
-      assert(slice != nullptr);
-      slice->timeSample(layer, channel,fDCFEB)->adcCounts = value;
-      /// =VB= Set CRC value for simulated data
-      slice->setCRC();
-    }
+void CSCCFEBData::add(const CSCStripDigi &digi, int layer) {
+  std::vector<int> scaCounts = digi.getADCCounts();
+  for (unsigned itime = 0; itime < theNumberOfSamples; ++itime) {
+    unsigned channel = (digi.getStrip() - 1) % 16 + 1;
+    unsigned value = scaCounts[itime] & 0xFFF;  // 12-bit
+    // assume it's good, since we're working with simulation
+    CSCCFEBTimeSlice *slice = timeSlice(itime);
+    assert(slice != nullptr);
+    slice->timeSample(layer, channel, fDCFEB)->adcCounts = value;
+    /// =VB= Set CRC value for simulated data
+    slice->setCRC();
+  }
 }
 
-const CSCCFEBTimeSlice * CSCCFEBData::timeSlice(unsigned i) const 
-{
+const CSCCFEBTimeSlice *CSCCFEBData::timeSlice(unsigned i) const {
   assert(i < theNumberOfSamples);
-  std::pair<int,bool> start = theSliceStarts[i];
+  std::pair<int, bool> start = theSliceStarts[i];
   // give a NULL pointer if this is a bad slice
-  return start.second ? reinterpret_cast<const CSCCFEBTimeSlice *>(theData+start.first) : nullptr;
+  return start.second ? reinterpret_cast<const CSCCFEBTimeSlice *>(theData + start.first) : nullptr;
 }
 
-CSCCFEBTimeSlice * CSCCFEBData::timeSlice(unsigned i)
-{
+CSCCFEBTimeSlice *CSCCFEBData::timeSlice(unsigned i) {
   assert(i < theNumberOfSamples);
-  std::pair<int,bool> start = theSliceStarts[i];
+  std::pair<int, bool> start = theSliceStarts[i];
   // give a NULL pointer if this is a bad slice
-  return start.second ? reinterpret_cast<CSCCFEBTimeSlice *>(theData+start.first) : nullptr;
+  return start.second ? reinterpret_cast<CSCCFEBTimeSlice *>(theData + start.first) : nullptr;
 }
 
-unsigned CSCCFEBData::adcCounts(unsigned layer, unsigned channel, unsigned timeBin) const 
-{
+unsigned CSCCFEBData::adcCounts(unsigned layer, unsigned channel, unsigned timeBin) const {
   unsigned result = 0;
-  const CSCCFEBTimeSlice * slice = timeSlice(timeBin);
+  const CSCCFEBTimeSlice *slice = timeSlice(timeBin);
   // zero is returned for bad slices
-  if(slice) result = slice->timeSample(layer, channel,fDCFEB)->adcCounts;
+  if (slice)
+    result = slice->timeSample(layer, channel, fDCFEB)->adcCounts;
   return result;
 }
-unsigned CSCCFEBData::adcOverflow(unsigned layer, unsigned channel, unsigned timeBin) const 
-{
+unsigned CSCCFEBData::adcOverflow(unsigned layer, unsigned channel, unsigned timeBin) const {
   unsigned result = 0;
-  const CSCCFEBTimeSlice * slice = timeSlice(timeBin);
+  const CSCCFEBTimeSlice *slice = timeSlice(timeBin);
   // zero is returned for bad slices
-  if(slice) result = slice->timeSample(layer, channel,fDCFEB)->adcOverflow;
-  return result;
-}
-
-unsigned CSCCFEBData::controllerData(unsigned uglay, unsigned ugchan, unsigned timeBin) const 
-{
-
-// The argument notation is
-// uglay = un-Gray Coded layer index 1-6
-// ugchan = un-Gray Coded channel index 1-16
-// The point being that the SCAC is serially encoded directly in the data stream (without Gray Coding)
-// so the layer and channel indexes here are just the direct ordering into the data stream.
-
-  unsigned result = 0;
-  const CSCCFEBTimeSlice * slice = timeSlice(timeBin);
-  // zero is returned for bad slices
-  if(slice) result = slice->timeSample( (ugchan-1)*6+uglay-1 )->controllerData;
+  if (slice)
+    result = slice->timeSample(layer, channel, fDCFEB)->adcOverflow;
   return result;
 }
 
-unsigned CSCCFEBData::overlappedSampleFlag(unsigned layer, unsigned channel, unsigned timeBin) const 
-{
+unsigned CSCCFEBData::controllerData(unsigned uglay, unsigned ugchan, unsigned timeBin) const {
+  // The argument notation is
+  // uglay = un-Gray Coded layer index 1-6
+  // ugchan = un-Gray Coded channel index 1-16
+  // The point being that the SCAC is serially encoded directly in the data stream (without Gray Coding)
+  // so the layer and channel indexes here are just the direct ordering into the data stream.
+
   unsigned result = 0;
-  const CSCCFEBTimeSlice * slice = timeSlice(timeBin);
+  const CSCCFEBTimeSlice *slice = timeSlice(timeBin);
   // zero is returned for bad slices
-  if(slice) result = slice->timeSample(layer, channel,fDCFEB)->overlappedSampleFlag;
+  if (slice)
+    result = slice->timeSample((ugchan - 1) * 6 + uglay - 1)->controllerData;
   return result;
 }
-unsigned CSCCFEBData::errorstat(unsigned layer, unsigned channel, unsigned timeBin) const 
-{
+
+unsigned CSCCFEBData::overlappedSampleFlag(unsigned layer, unsigned channel, unsigned timeBin) const {
   unsigned result = 0;
-  const CSCCFEBTimeSlice * slice = timeSlice(timeBin);
+  const CSCCFEBTimeSlice *slice = timeSlice(timeBin);
   // zero is returned for bad slices
-  if(slice) result = slice->timeSample(layer, channel,fDCFEB)->errorstat;
+  if (slice)
+    result = slice->timeSample(layer, channel, fDCFEB)->overlappedSampleFlag;
+  return result;
+}
+unsigned CSCCFEBData::errorstat(unsigned layer, unsigned channel, unsigned timeBin) const {
+  unsigned result = 0;
+  const CSCCFEBTimeSlice *slice = timeSlice(timeBin);
+  // zero is returned for bad slices
+  if (slice)
+    result = slice->timeSample(layer, channel, fDCFEB)->errorstat;
   return result;
 }
 
-
-void CSCCFEBData::setL1A(unsigned l1a)
-{
-  for (unsigned i=0; i < theNumberOfSamples; i++) setL1A(i, l1a); 
+void CSCCFEBData::setL1A(unsigned l1a) {
+  for (unsigned i = 0; i < theNumberOfSamples; i++)
+    setL1A(i, l1a);
 }
 
-void CSCCFEBData::setL1A(unsigned i, unsigned l1a)
-{
+void CSCCFEBData::setL1A(unsigned i, unsigned l1a) {
   assert(i < theNumberOfSamples);
-  std::pair<int,bool> start = theSliceStarts[i];
+  std::pair<int, bool> start = theSliceStarts[i];
   // give a NULL pointer if this is a bad slice
-  if(start.second)
-    {
-      (reinterpret_cast<CSCCFEBTimeSlice *>(theData+start.first))->set_L1Anumber(l1a);
-    }
+  if (start.second) {
+    (reinterpret_cast<CSCCFEBTimeSlice *>(theData + start.first))->set_L1Anumber(l1a);
+  }
 }
 
-CSCCFEBStatusDigi CSCCFEBData::statusDigi() const 
-{
-  ///returns one status digi per cfeb 
-  ///contains bWord if slice is bad 
+CSCCFEBStatusDigi CSCCFEBData::statusDigi() const {
+  ///returns one status digi per cfeb
+  ///contains bWord if slice is bad
   ///also contains crc word and controller word
 
   std::vector<uint16_t> crcWords(nTimeSamples());
   std::vector<uint16_t> contrWords(nTimeSamples());
 
-  if (nTimeSamples()==0) 
-    {
-      LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples is zero - CFEB data corrupt?";
-    }
-  else
-    {
-      for(unsigned itime = 0; itime < nTimeSamples(); ++itime) {
-	const CSCCFEBTimeSlice * slice = timeSlice(itime);
-	// zero is returned for bad slices
-	if (slice) crcWords[itime] = slice->get_crc();
-	if (slice) 
-	  {	
-	    int layer=1; ///here layer=1 bec this word repeats 6 times for each layer
-	    for(unsigned i = 0; i < 16; ++i)
-	      {
-		contrWords[itime] |= slice->timeSample(i*6+layer-1)->controllerData << i;
-	      }
-	  }
-
+  if (nTimeSamples() == 0) {
+    LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples is zero - CFEB data corrupt?";
+  } else {
+    for (unsigned itime = 0; itime < nTimeSamples(); ++itime) {
+      const CSCCFEBTimeSlice *slice = timeSlice(itime);
+      // zero is returned for bad slices
+      if (slice)
+        crcWords[itime] = slice->get_crc();
+      if (slice) {
+        int layer = 1;  ///here layer=1 bec this word repeats 6 times for each layer
+        for (unsigned i = 0; i < 16; ++i) {
+          contrWords[itime] |= slice->timeSample(i * 6 + layer - 1)->controllerData << i;
+        }
       }
     }
+  }
 
-  CSCCFEBStatusDigi result(boardNumber_+1, crcWords, contrWords, bWords);
+  CSCCFEBStatusDigi result(boardNumber_ + 1, crcWords, contrWords, bWords);
   return result;
 }
 
-
-
-void CSCCFEBData::digis(uint32_t idlayer, std::vector<CSCStripDigi> & result ) const
-{
-  
+void CSCCFEBData::digis(uint32_t idlayer, std::vector<CSCStripDigi> &result) const {
   // assert(layer>0 && layer <= 6);
 
   LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples in CSCCFEBData::digis = " << nTimeSamples();
-  if (nTimeSamples()==0) {
-     LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples is zero - CFEB data corrupt?";
-     return;
+  if (nTimeSamples() == 0) {
+    LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples is zero - CFEB data corrupt?";
+    return;
   }
 
   result.reserve(16);
@@ -236,123 +215,118 @@ void CSCCFEBData::digis(uint32_t idlayer, std::vector<CSCStripDigi> & result ) c
   std::vector<uint16_t> overlap(nTimeSamples());
   std::vector<uint16_t> errorfl(nTimeSamples());
 
-  bool me1a = (CSCDetId::station(idlayer)==1) && (CSCDetId::ring(idlayer)==4);
-  bool zplus = (CSCDetId::endcap(idlayer) == 1); 
-  bool me1b = (CSCDetId::station(idlayer)==1) && (CSCDetId::ring(idlayer)==1);
-  
+  bool me1a = (CSCDetId::station(idlayer) == 1) && (CSCDetId::ring(idlayer) == 4);
+  bool zplus = (CSCDetId::endcap(idlayer) == 1);
+  bool me1b = (CSCDetId::station(idlayer) == 1) && (CSCDetId::ring(idlayer) == 1);
+
   unsigned layer = CSCDetId::layer(idlayer);
 
   std::vector<uint16_t> l1a_phase(nTimeSamples());
-  for(unsigned itime = 0; itime < nTimeSamples(); ++itime) {
-    l1a_phase[itime] = controllerData(layer, 13, itime); // will be zero if timeslice bad
-    LogTrace("CSCCFEBData|CSCRawToDigi") << CSCDetId(idlayer) << " time sample " << itime+1 << " l1a_phase = " << controllerData(layer, 13, itime);
-    LogTrace("CSCCFEBData|CSCRawToDigi") << CSCDetId(idlayer) << " time sample " << itime+1 << " lct_phase = " << controllerData(layer, 14, itime);
-    LogTrace("CSCCFEBData|CSCRawToDigi") << CSCDetId(idlayer) << " time sample " << itime+1 << " # samples = " << controllerData(layer, 16, itime);
+  for (unsigned itime = 0; itime < nTimeSamples(); ++itime) {
+    l1a_phase[itime] = controllerData(layer, 13, itime);  // will be zero if timeslice bad
+    LogTrace("CSCCFEBData|CSCRawToDigi") << CSCDetId(idlayer) << " time sample " << itime + 1
+                                         << " l1a_phase = " << controllerData(layer, 13, itime);
+    LogTrace("CSCCFEBData|CSCRawToDigi") << CSCDetId(idlayer) << " time sample " << itime + 1
+                                         << " lct_phase = " << controllerData(layer, 14, itime);
+    LogTrace("CSCCFEBData|CSCRawToDigi") << CSCDetId(idlayer) << " time sample " << itime + 1
+                                         << " # samples = " << controllerData(layer, 16, itime);
   };
 
-  for(unsigned ichannel = 1; ichannel <= 16; ++ichannel)
-    {
-      // What is the point of testing here? Move it outside this loop
-      //      if (nTimeSamples()==0)
-      //	{
-      //	  LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples is zero - CFEB data corrupt?";
-      //	  break;
-      //	}
-      
-      for(unsigned itime = 0; itime < nTimeSamples(); ++itime)
-	{
-	  const CSCCFEBTimeSlice * slice = timeSlice(itime);
-	  if (slice)
-	    {
-	      CSCCFEBDataWord * word;
-	      word = slice->timeSample(layer, ichannel,fDCFEB);
-	      if (word)
-		{  ///for bad or missing data word will be zero
-		  sca[itime] = word->adcCounts;
-		  overflow[itime] = word->adcOverflow;
-		  overlap[itime] = word->overlappedSampleFlag;
-		  errorfl[itime] = word->errorstat;
+  for (unsigned ichannel = 1; ichannel <= 16; ++ichannel) {
+    // What is the point of testing here? Move it outside this loop
+    //      if (nTimeSamples()==0)
+    //	{
+    //	  LogTrace("CSCCFEBData|CSCRawToDigi") << "nTimeSamples is zero - CFEB data corrupt?";
+    //	  break;
+    //	}
 
-		  // Stick the l1a_phase bit into 'overlap' too (so we can store it in CSCStripDigi
-		  // without changing CSCStripDigi format). 
-		  // Put it in the 9th bit of the overlap word which is only 1-bit anyway.
-                  overlap[itime] = (( l1a_phase[itime] & 0x1 ) << 8 ) | ( word->overlappedSampleFlag & 0x1 );
-		}
-	    }
-	}
-      if (sca.empty())
-	{
-	  LogTrace("CSCCFEBData|CSCRawToDigi") << "ADC counts empty - CFEB data corrupt?";
-	  break;
-	}
-      int strip = ichannel + 16*boardNumber_;
+    for (unsigned itime = 0; itime < nTimeSamples(); ++itime) {
+      const CSCCFEBTimeSlice *slice = timeSlice(itime);
+      if (slice) {
+        CSCCFEBDataWord *word;
+        word = slice->timeSample(layer, ichannel, fDCFEB);
+        if (word) {  ///for bad or missing data word will be zero
+          sca[itime] = word->adcCounts;
+          overflow[itime] = word->adcOverflow;
+          overlap[itime] = word->overlappedSampleFlag;
+          errorfl[itime] = word->errorstat;
 
-      if (theFormatVersion == 2013) { /// Handle 2013 Format 
-
-         if ( me1a ) strip = strip%64; // reset 65-112/ to 1-48 digi
-         if ( me1a && zplus ) { strip = 49 - strip; } // 1-48 -> 48-1 
-         if ( me1b && !zplus) { strip = 65 - strip;} // 1-64 -> 64-1 ...
-
-      } else { // Handle original 2005 format
-     
-         if ( me1a ) strip = strip%64; // reset 65-80 to 1-16 digi
-         if ( me1a && zplus ) { strip = 17 - strip; } // 1-16 -> 16-1 
-         if ( me1b && !zplus) { strip = 65 - strip;} // 1-64 -> 64-1 ...
+          // Stick the l1a_phase bit into 'overlap' too (so we can store it in CSCStripDigi
+          // without changing CSCStripDigi format).
+          // Put it in the 9th bit of the overlap word which is only 1-bit anyway.
+          overlap[itime] = ((l1a_phase[itime] & 0x1) << 8) | (word->overlappedSampleFlag & 0x1);
+        }
       }
-      result.push_back(CSCStripDigi(strip, sca, overflow, overlap, errorfl));
-    } 
+    }
+    if (sca.empty()) {
+      LogTrace("CSCCFEBData|CSCRawToDigi") << "ADC counts empty - CFEB data corrupt?";
+      break;
+    }
+    int strip = ichannel + 16 * boardNumber_;
+
+    if (theFormatVersion == 2013) {  /// Handle 2013 Format
+
+      if (me1a)
+        strip = strip % 64;  // reset 65-112/ to 1-48 digi
+      if (me1a && zplus) {
+        strip = 49 - strip;
+      }  // 1-48 -> 48-1
+      if (me1b && !zplus) {
+        strip = 65 - strip;
+      }  // 1-64 -> 64-1 ...
+
+    } else {  // Handle original 2005 format
+
+      if (me1a)
+        strip = strip % 64;  // reset 65-80 to 1-16 digi
+      if (me1a && zplus) {
+        strip = 17 - strip;
+      }  // 1-16 -> 16-1
+      if (me1b && !zplus) {
+        strip = 65 - strip;
+      }  // 1-64 -> 64-1 ...
+    }
+    result.push_back(CSCStripDigi(strip, sca, overflow, overlap, errorfl));
+  }
 }
 
-
-
-std::vector<CSCStripDigi> CSCCFEBData::digis(unsigned idlayer) const
-{
+std::vector<CSCStripDigi> CSCCFEBData::digis(unsigned idlayer) const {
   //assert(layer>0 && layer <= 6);
   std::vector<CSCStripDigi> result;
-  uint32_t layer= idlayer;
+  uint32_t layer = idlayer;
   digis(layer, result);
   return result;
 }
 
-
-
-bool CSCCFEBData::check() const 
-{
+bool CSCCFEBData::check() const {
   bool result = true;
-  for(unsigned i = 0; i < theNumberOfSamples; ++i) 
-    {
-      const CSCCFEBTimeSlice * slice = timeSlice(i);
-      if(slice==nullptr || !timeSlice(i)->check()) result = false;
-    }
+  for (unsigned i = 0; i < theNumberOfSamples; ++i) {
+    const CSCCFEBTimeSlice *slice = timeSlice(i);
+    if (slice == nullptr || !timeSlice(i)->check())
+      result = false;
+  }
   return result;
 }
 
-std::ostream & operator<<(std::ostream & os, const CSCCFEBData & data) 
-{
+std::ostream &operator<<(std::ostream &os, const CSCCFEBData &data) {
   os << "printing CFEB data sample by sample " << std::endl;
-  for(unsigned ilayer = 1; ilayer <= 6; ++ilayer) 
-    {
-      for(unsigned channel = 1; channel <= 16; ++channel) 
-	{
-	  unsigned strip = channel + data.boardNumber_*16;
-	  os << "Strip " << strip << " ";
-	  for(unsigned timeBin = 0; timeBin < data.nTimeSamples(); ++timeBin)
-	    {
-	      os << data.adcCounts(ilayer, channel, timeBin) << " " ;
-	    }
-	  os << std::endl;
-	}
+  for (unsigned ilayer = 1; ilayer <= 6; ++ilayer) {
+    for (unsigned channel = 1; channel <= 16; ++channel) {
+      unsigned strip = channel + data.boardNumber_ * 16;
+      os << "Strip " << strip << " ";
+      for (unsigned timeBin = 0; timeBin < data.nTimeSamples(); ++timeBin) {
+        os << data.adcCounts(ilayer, channel, timeBin) << " ";
+      }
+      os << std::endl;
     }
+  }
   return os;
 }
 
-std::vector < std::vector<CSCStripDigi> > CSCCFEBData::stripDigis()
-{
-  std::vector < std::vector<CSCStripDigi> > result;
-  for (int layer = 1; layer <= 6; ++layer) 
-    {
-      result.push_back(digis(layer));
-    }
+std::vector<std::vector<CSCStripDigi> > CSCCFEBData::stripDigis() {
+  std::vector<std::vector<CSCStripDigi> > result;
+  for (int layer = 1; layer <= 6; ++layer) {
+    result.push_back(digis(layer));
+  }
   return result;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBTimeSlice.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBTimeSlice.cc
@@ -6,18 +6,16 @@
 // a Gray code is An ordering of 2n binary numbers such that
 // only one bit changes from one entry to the next
 // const unsigned layerGrayCode[] = {3,1,5,6,4,2};
-const unsigned layerInverseGrayCode[] = {1,5,0,4,2,3};
+const unsigned layerInverseGrayCode[] = {1, 5, 0, 4, 2, 3};
 // const unsigned channelGrayCode[] = {0,1,3,2, 6,7,5,4, 12,13,15,14, 10,11,9,8};
-const unsigned channelInverseGrayCode[] = {0,1,3,2, 7,6,4,5, 15,14,12,13, 8,9,11,10};
+const unsigned channelInverseGrayCode[] = {0, 1, 3, 2, 7, 6, 4, 5, 15, 14, 12, 13, 8, 9, 11, 10};
 
-CSCCFEBTimeSlice::CSCCFEBTimeSlice() 
-{
-    bzero(this, 99*2);
+CSCCFEBTimeSlice::CSCCFEBTimeSlice() {
+  bzero(this, 99 * 2);
   dummy = 0x7FFF;
   blank_space_1 = 0x7;
   blank_space_3 = 0x7;
 }
-
 
 CSCCFEBSCAControllerWord::CSCCFEBSCAControllerWord(unsigned short frame)
 // trig_time( frame & 0xFF ),
@@ -30,67 +28,53 @@ CSCCFEBSCAControllerWord::CSCCFEBSCAControllerWord(unsigned short frame)
   memcpy(this, &frame, 2);
 }
 
-
-CSCCFEBDataWord * CSCCFEBTimeSlice::timeSample(int layer, int channel, bool isDCFEB) const 
-{
+CSCCFEBDataWord *CSCCFEBTimeSlice::timeSample(int layer, int channel, bool isDCFEB) const {
   assert(layer >= 1 && layer <= 6);
-  assert(channel >=1 && channel <= 16);
-  int layerIndex = layerInverseGrayCode[layer-1];
+  assert(channel >= 1 && channel <= 16);
+  int layerIndex = layerInverseGrayCode[layer - 1];
 
-  unsigned channelIndex = channelInverseGrayCode[channel-1];
-  if (isDCFEB) channelIndex = channel-1; //!!! New DCFEBs don't use gray coding for channels
-  unsigned scaBin = channelIndex*6 + layerIndex;
-  assert(scaBin < 96U); // scaBin >= 0, since scaBin is unsigned
+  unsigned channelIndex = channelInverseGrayCode[channel - 1];
+  if (isDCFEB)
+    channelIndex = channel - 1;  //!!! New DCFEBs don't use gray coding for channels
+  unsigned scaBin = channelIndex * 6 + layerIndex;
+  assert(scaBin < 96U);  // scaBin >= 0, since scaBin is unsigned
   return timeSample(scaBin);
 }
 
-
-CSCCFEBSCAControllerWord CSCCFEBTimeSlice::scaControllerWord(int layer) const 
-{
-  unsigned int result=0;
-  for(unsigned i = 0; i < 16; ++i) {
-     result |= timeSample(i*6+layer-1)->controllerData << i;
+CSCCFEBSCAControllerWord CSCCFEBTimeSlice::scaControllerWord(int layer) const {
+  unsigned int result = 0;
+  for (unsigned i = 0; i < 16; ++i) {
+    result |= timeSample(i * 6 + layer - 1)->controllerData << i;
   }
   return CSCCFEBSCAControllerWord(result);
 }
 
-
-void CSCCFEBTimeSlice::setControllerWord(const CSCCFEBSCAControllerWord & controllerWord) 
-{
-  for(int layer = 1; layer <= 6; ++layer)
-    {
-      for(int channel = 1; channel <= 16; ++channel)
-	{
-	  const unsigned short * shortWord = reinterpret_cast<const unsigned short *>(&controllerWord);
-	  timeSample(layer, channel)->controllerData
-	    = ( *shortWord >> (channel-1)) & 1;
-	}
+void CSCCFEBTimeSlice::setControllerWord(const CSCCFEBSCAControllerWord &controllerWord) {
+  for (int layer = 1; layer <= 6; ++layer) {
+    for (int channel = 1; channel <= 16; ++channel) {
+      const unsigned short *shortWord = reinterpret_cast<const unsigned short *>(&controllerWord);
+      timeSample(layer, channel)->controllerData = (*shortWord >> (channel - 1)) & 1;
     }
+  }
 }
 
-
-unsigned CSCCFEBTimeSlice::calcCRC() const
-{
-        unsigned CRC=0;
-        for(uint16_t pos=0; pos<96; ++pos)
-        CRC=(theSamples[pos]&0x1fff)^((theSamples[pos]&0x1fff)<<1)^(((CRC&0x7ffc)>>2)|((0x0003&CRC)<<13))^((CRC&0x7ffc)>>1);
-        return CRC;
+unsigned CSCCFEBTimeSlice::calcCRC() const {
+  unsigned CRC = 0;
+  for (uint16_t pos = 0; pos < 96; ++pos)
+    CRC = (theSamples[pos] & 0x1fff) ^ ((theSamples[pos] & 0x1fff) << 1) ^
+          (((CRC & 0x7ffc) >> 2) | ((0x0003 & CRC) << 13)) ^ ((CRC & 0x7ffc) >> 1);
+  return CRC;
 }
 
-
-std::ostream & operator<<(std::ostream & os, const CSCCFEBTimeSlice & slice) 
-{
-  for(int ichannel = 1; ichannel <= 16; ++ichannel) 
-    {
-      for(int ilayer = 1; ilayer <= 6; ++ilayer)
-	{
-	  //unsigned index = (ilayer-1) + (ichannel-1)*6;
-	  //int value = (slice.timeSample(index))->adcCounts - 560;
-	  int value = (slice.timeSample(ilayer, ichannel))->adcCounts - 560; 
-	  os << " " << std::setw(5) << std::dec << value;
-	}
-      os << std::endl;
+std::ostream &operator<<(std::ostream &os, const CSCCFEBTimeSlice &slice) {
+  for (int ichannel = 1; ichannel <= 16; ++ichannel) {
+    for (int ilayer = 1; ilayer <= 6; ++ilayer) {
+      //unsigned index = (ilayer-1) + (ichannel-1)*6;
+      //int value = (slice.timeSample(index))->adcCounts - 560;
+      int value = (slice.timeSample(ilayer, ichannel))->adcCounts - 560;
+      os << " " << std::setw(5) << std::dec << value;
     }
+    os << std::endl;
+  }
   return os;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCCLCTData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCLCTData.cc
@@ -10,98 +10,77 @@
 bool CSCCLCTData::debug = false;
 #else
 #include <atomic>
-std::atomic<bool> CSCCLCTData::debug {false};
+std::atomic<bool> CSCCLCTData::debug{false};
 #endif
 
-
-CSCCLCTData::CSCCLCTData(const CSCTMBHeader * tmbHeader)
-    : ncfebs_(tmbHeader->NCFEBs()), ntbins_(tmbHeader->NTBins())
-{
-  if (tmbHeader != nullptr)  theFirmwareVersion = tmbHeader->FirmwareVersion();
-  else theFirmwareVersion = 2007;
+CSCCLCTData::CSCCLCTData(const CSCTMBHeader* tmbHeader) : ncfebs_(tmbHeader->NCFEBs()), ntbins_(tmbHeader->NTBins()) {
+  if (tmbHeader != nullptr)
+    theFirmwareVersion = tmbHeader->FirmwareVersion();
+  else
+    theFirmwareVersion = 2007;
   size_ = nlines();
   zero();
 }
-
 
 CSCCLCTData::CSCCLCTData(int ncfebs, int ntbins, int firmware_version)
-    : ncfebs_(ncfebs), ntbins_(ntbins), theFirmwareVersion(firmware_version)
-{
+    : ncfebs_(ncfebs), ntbins_(ntbins), theFirmwareVersion(firmware_version) {
   size_ = nlines();
   zero();
 }
 
-
-
-
-CSCCLCTData::CSCCLCTData(int ncfebs, int ntbins, const unsigned short * buf, int firmware_version)
-    : ncfebs_(ncfebs), ntbins_(ntbins), theFirmwareVersion(firmware_version)
-{
+CSCCLCTData::CSCCLCTData(int ncfebs, int ntbins, const unsigned short* buf, int firmware_version)
+    : ncfebs_(ncfebs), ntbins_(ntbins), theFirmwareVersion(firmware_version) {
   // add two more for odd ntbins, plus one for the e0c
   // Oct 2004 Rick: e0c line belongs to CSCTMBTrailer
-  size_ = (nlines()%2==1)? nlines()+2 : nlines();
+  size_ = (nlines() % 2 == 1) ? nlines() + 2 : nlines();
 
-  memcpy(theData, buf, size_*2);
-
+  memcpy(theData, buf, size_ * 2);
 }
 
-
-void CSCCLCTData::zero()
-{
-  for (int ifeb = 0; ifeb < ncfebs_; ++ifeb)
-    {
-      for (int tbin = 0; tbin < ntbins_; ++tbin)
-        {
-          for (int layer = 1; layer <= 6; ++layer)
-            {
-              dataWord(ifeb, tbin, layer) = CSCCLCTDataWord(ifeb, tbin, 0);
-            }
-        }
+void CSCCLCTData::zero() {
+  for (int ifeb = 0; ifeb < ncfebs_; ++ifeb) {
+    for (int tbin = 0; tbin < ntbins_; ++tbin) {
+      for (int layer = 1; layer <= 6; ++layer) {
+        dataWord(ifeb, tbin, layer) = CSCCLCTDataWord(ifeb, tbin, 0);
+      }
     }
-
+  }
 }
 
-
-std::vector<CSCComparatorDigi>  CSCCLCTData::comparatorDigis(uint32_t idlayer, unsigned cfeb)
-{
+std::vector<CSCComparatorDigi> CSCCLCTData::comparatorDigis(uint32_t idlayer, unsigned cfeb) {
   static const bool doStripSwapping = true;
-  bool me1a = (CSCDetId::station(idlayer)==1) && (CSCDetId::ring(idlayer)==4);
+  bool me1a = (CSCDetId::station(idlayer) == 1) && (CSCDetId::ring(idlayer) == 4);
   bool zplus = (CSCDetId::endcap(idlayer) == 1);
-  bool me1b = (CSCDetId::station(idlayer)==1) && (CSCDetId::ring(idlayer)==1);
-//  bool me11 = (CSCDetId::station(idlayer)==1) && ((CSCDetId::ring(idlayer)==1) || (CSCDetId::ring(idlayer)==4));
+  bool me1b = (CSCDetId::station(idlayer) == 1) && (CSCDetId::ring(idlayer) == 1);
+  //  bool me11 = (CSCDetId::station(idlayer)==1) && ((CSCDetId::ring(idlayer)==1) || (CSCDetId::ring(idlayer)==4));
   unsigned layer = CSCDetId::layer(idlayer);
-
-
 
   //looking for comp output on layer
   std::vector<CSCComparatorDigi> result;
-  assert(layer>0 && layer<= 6);
+  assert(layer > 0 && layer <= 6);
   // this is pretty sparse data, so I wish we could check the
   // data word by word, not bit by bit, but I don't see how to
   // do the time sequencing that way.
-  for (int distrip = 0; distrip < 8; ++distrip)
-    {
-      uint16_t tbinbitsS0HS0=0;
-      uint16_t tbinbitsS0HS1=0;
-      uint16_t tbinbitsS1HS0=0;
-      uint16_t tbinbitsS1HS1=0;
-      for (int tbin = 0; tbin < ntbins_-2; ++tbin)
-        {
-          if (bitValue(cfeb, tbin, layer, distrip))
-            {
-              /// first do some checks
-              CSCCLCTDataWord word = dataWord(cfeb, tbin, layer);
-              assert(word.tbin_ == tbin);
-              assert(word.cfeb_ == cfeb);
-              // we have a hit.  The next two time samples
-              // are the other two bits in the triad
-              int bit2 = bitValue(cfeb, tbin+1, layer, distrip);
-              int bit3 = bitValue(cfeb, tbin+2, layer, distrip);
-              // should count from zero
-              int chamberDistrip = distrip + cfeb*8;
-              int HalfStrip = 4*chamberDistrip + bit2*2 + bit3;
-              int output = 4 + bit2*2 + bit3;
-              /*
+  for (int distrip = 0; distrip < 8; ++distrip) {
+    uint16_t tbinbitsS0HS0 = 0;
+    uint16_t tbinbitsS0HS1 = 0;
+    uint16_t tbinbitsS1HS0 = 0;
+    uint16_t tbinbitsS1HS1 = 0;
+    for (int tbin = 0; tbin < ntbins_ - 2; ++tbin) {
+      if (bitValue(cfeb, tbin, layer, distrip)) {
+        /// first do some checks
+        CSCCLCTDataWord word = dataWord(cfeb, tbin, layer);
+        assert(word.tbin_ == tbin);
+        assert(word.cfeb_ == cfeb);
+        // we have a hit.  The next two time samples
+        // are the other two bits in the triad
+        int bit2 = bitValue(cfeb, tbin + 1, layer, distrip);
+        int bit3 = bitValue(cfeb, tbin + 2, layer, distrip);
+        // should count from zero
+        int chamberDistrip = distrip + cfeb * 8;
+        int HalfStrip = 4 * chamberDistrip + bit2 * 2 + bit3;
+        int output = 4 + bit2 * 2 + bit3;
+        /*
                * Handles distrip logic; comparator output is for pairs of strips:
                * hit  bin  dec
                * x--- 100   4
@@ -111,171 +90,150 @@ std::vector<CSCComparatorDigi>  CSCCLCTData::comparatorDigis(uint32_t idlayer, u
                *
                */
 
-              if (debug)
-                LogTrace ("CSCCLCTData|CSCRawToDigi")
-                << "fillComparatorOutputs: layer = "
-                << layer << " timebin = " << tbin
-                << " cfeb = " << cfeb << " distrip = " << chamberDistrip
-                << " HalfStrip = " << HalfStrip
-                << " Output " << output << std::endl;
-              ///what is actually stored in comparator digis are 0/1 for left/right halfstrip for each strip
+        if (debug)
+          LogTrace("CSCCLCTData|CSCRawToDigi")
+              << "fillComparatorOutputs: layer = " << layer << " timebin = " << tbin << " cfeb = " << cfeb
+              << " distrip = " << chamberDistrip << " HalfStrip = " << HalfStrip << " Output " << output << std::endl;
+        ///what is actually stored in comparator digis are 0/1 for left/right halfstrip for each strip
 
-              ///constructing four bitted words for tbits on
-              if (output==4) tbinbitsS0HS0=tbinbitsS0HS0+(1<<tbin);
-              if (output==5) tbinbitsS0HS1=tbinbitsS0HS1+(1<<tbin);
-              if (output==6) tbinbitsS1HS0=tbinbitsS1HS0+(1<<tbin);
-              if (output==7) tbinbitsS1HS1=tbinbitsS1HS1+(1<<tbin);
+        ///constructing four bitted words for tbits on
+        if (output == 4)
+          tbinbitsS0HS0 = tbinbitsS0HS0 + (1 << tbin);
+        if (output == 5)
+          tbinbitsS0HS1 = tbinbitsS0HS1 + (1 << tbin);
+        if (output == 6)
+          tbinbitsS1HS0 = tbinbitsS1HS0 + (1 << tbin);
+        if (output == 7)
+          tbinbitsS1HS1 = tbinbitsS1HS1 + (1 << tbin);
 
-              tbin += 2;
-            }
-        }//end of loop over time bins
-      //we do not have to check over the last couple of time bins if there are no hits since
-      //comparators take 3 time bins
+        tbin += 2;
+      }
+    }  //end of loop over time bins
+    //we do not have to check over the last couple of time bins if there are no hits since
+    //comparators take 3 time bins
 
-      // Store digis each of possible four halfstrips for given distrip:
-      if (tbinbitsS0HS0 || tbinbitsS0HS1 || tbinbitsS1HS0 || tbinbitsS1HS1)
-        {
-          unsigned int cfeb_corr    = cfeb;
-          unsigned int distrip_corr = distrip;
+    // Store digis each of possible four halfstrips for given distrip:
+    if (tbinbitsS0HS0 || tbinbitsS0HS1 || tbinbitsS1HS0 || tbinbitsS1HS1) {
+      unsigned int cfeb_corr = cfeb;
+      unsigned int distrip_corr = distrip;
 
-          if (doStripSwapping)
-            {
-              // Fix ordering of strips and CFEBs in ME1/1.
-              // SV, 27/05/08: keep CFEB=4 for ME1/a until CLCT trigger logic
-              // stops combining it with the info from the other 4 CFEBs (ME1/b).
-              //
-              if (theFirmwareVersion >= 2013)
-                {
-                  if ( me1a &&  zplus )
-                    {
-                      distrip_corr = 7-distrip;  // 0-7 -> 7-0
-                      cfeb_corr = 10-cfeb;
-                    }
-                  if ( me1b && !zplus )
-                    {
-                      distrip_corr = 7-distrip;
-                      cfeb_corr = 3-cfeb;
-                    }
-                }
-              else
-                {
-                  // if ( me1a )           { cfeb_corr = 0; } // reset 4 to 0
-                  if ( me1a &&  zplus )
-                    {
-                      distrip_corr = 7-distrip; // 0-7 -> 7-0
-                    }
-                  if ( me1b && !zplus )
-                    {
-                      distrip_corr = 7-distrip;
-                      cfeb_corr = 3-cfeb;
-                    }
-                }
-            }
-
-
-          int strip = 16*cfeb_corr + 2*distrip_corr + 1;
-
-          if (debug)
-            LogTrace ("CSCCLCTData|CSCRawToDigi")
-            << "fillComparatorOutputs: cfeb_corr = " << cfeb_corr
-            << " distrip_corr = " << distrip_corr << " strip = " << strip;
-
-          if (doStripSwapping && (( me1a && zplus ) || ( me1b && !zplus )))
-            {
-              // Half-strips need to be flipped too.
-              if (tbinbitsS1HS1) result.push_back(CSCComparatorDigi(strip, 0, tbinbitsS1HS1));
-              if (tbinbitsS1HS0) result.push_back(CSCComparatorDigi(strip, 1, tbinbitsS1HS0));
-              if (tbinbitsS0HS1) result.push_back(CSCComparatorDigi(strip+1, 0, tbinbitsS0HS1));
-              if (tbinbitsS0HS0) result.push_back(CSCComparatorDigi(strip+1, 1, tbinbitsS0HS0));
-            }
-          else
-            {
-              if (tbinbitsS0HS0) result.push_back(CSCComparatorDigi(strip, 0, tbinbitsS0HS0));
-              if (tbinbitsS0HS1) result.push_back(CSCComparatorDigi(strip, 1, tbinbitsS0HS1));
-              if (tbinbitsS1HS0) result.push_back(CSCComparatorDigi(strip+1, 0, tbinbitsS1HS0));
-              if (tbinbitsS1HS1) result.push_back(CSCComparatorDigi(strip+1, 1, tbinbitsS1HS1));
-            }
-          //uh oh ugly ugly ugly!
+      if (doStripSwapping) {
+        // Fix ordering of strips and CFEBs in ME1/1.
+        // SV, 27/05/08: keep CFEB=4 for ME1/a until CLCT trigger logic
+        // stops combining it with the info from the other 4 CFEBs (ME1/b).
+        //
+        if (theFirmwareVersion >= 2013) {
+          if (me1a && zplus) {
+            distrip_corr = 7 - distrip;  // 0-7 -> 7-0
+            cfeb_corr = 10 - cfeb;
+          }
+          if (me1b && !zplus) {
+            distrip_corr = 7 - distrip;
+            cfeb_corr = 3 - cfeb;
+          }
+        } else {
+          // if ( me1a )           { cfeb_corr = 0; } // reset 4 to 0
+          if (me1a && zplus) {
+            distrip_corr = 7 - distrip;  // 0-7 -> 7-0
+          }
+          if (me1b && !zplus) {
+            distrip_corr = 7 - distrip;
+            cfeb_corr = 3 - cfeb;
+          }
         }
-    }//end of loop over distrips
+      }
+
+      int strip = 16 * cfeb_corr + 2 * distrip_corr + 1;
+
+      if (debug)
+        LogTrace("CSCCLCTData|CSCRawToDigi") << "fillComparatorOutputs: cfeb_corr = " << cfeb_corr
+                                             << " distrip_corr = " << distrip_corr << " strip = " << strip;
+
+      if (doStripSwapping && ((me1a && zplus) || (me1b && !zplus))) {
+        // Half-strips need to be flipped too.
+        if (tbinbitsS1HS1)
+          result.push_back(CSCComparatorDigi(strip, 0, tbinbitsS1HS1));
+        if (tbinbitsS1HS0)
+          result.push_back(CSCComparatorDigi(strip, 1, tbinbitsS1HS0));
+        if (tbinbitsS0HS1)
+          result.push_back(CSCComparatorDigi(strip + 1, 0, tbinbitsS0HS1));
+        if (tbinbitsS0HS0)
+          result.push_back(CSCComparatorDigi(strip + 1, 1, tbinbitsS0HS0));
+      } else {
+        if (tbinbitsS0HS0)
+          result.push_back(CSCComparatorDigi(strip, 0, tbinbitsS0HS0));
+        if (tbinbitsS0HS1)
+          result.push_back(CSCComparatorDigi(strip, 1, tbinbitsS0HS1));
+        if (tbinbitsS1HS0)
+          result.push_back(CSCComparatorDigi(strip + 1, 0, tbinbitsS1HS0));
+        if (tbinbitsS1HS1)
+          result.push_back(CSCComparatorDigi(strip + 1, 1, tbinbitsS1HS1));
+      }
+      //uh oh ugly ugly ugly!
+    }
+  }  //end of loop over distrips
   return result;
 }
 
-
-
-std::vector<CSCComparatorDigi>  CSCCLCTData::comparatorDigis(int layer)
-{
+std::vector<CSCComparatorDigi> CSCCLCTData::comparatorDigis(int layer) {
   //returns comparators for one layer for all cfebs
   std::vector<CSCComparatorDigi> result;
-  assert(layer>0 && layer<= 6);
+  assert(layer > 0 && layer <= 6);
 
-  for (int cfeb = 0; cfeb < ncfebs_; ++cfeb)
-    {
-      std::vector<CSCComparatorDigi> oneCfebDigi = comparatorDigis(layer,cfeb);
-      result.insert(result.end(), oneCfebDigi.begin(), oneCfebDigi.end());
-    }
+  for (int cfeb = 0; cfeb < ncfebs_; ++cfeb) {
+    std::vector<CSCComparatorDigi> oneCfebDigi = comparatorDigis(layer, cfeb);
+    result.insert(result.end(), oneCfebDigi.begin(), oneCfebDigi.end());
+  }
 
   return result;
 }
 
-
-void CSCCLCTData::add(const CSCComparatorDigi & digi, int layer)
-{
+void CSCCLCTData::add(const CSCComparatorDigi& digi, int layer) {
   //FIXME do flipping
   int strip = digi.getStrip();
-  int halfStrip = (strip-1)*2 + digi.getComparator();
-  int cfeb = (strip-1)/16;
-  int distrip = ((strip-1)%16) / 2;
-
+  int halfStrip = (strip - 1) * 2 + digi.getComparator();
+  int cfeb = (strip - 1) / 16;
+  int distrip = ((strip - 1) % 16) / 2;
 
   // assert(distrip < 8 && cfeb < 6 && halfStrip < 161);
   ///!!! Do we need to introduce format version here to accomodate 7 CFEBs
   assert(distrip < 8 && cfeb < 8 && halfStrip < 225);
 
   std::vector<int> timeBinsOn = digi.getTimeBinsOn();
-  for (std::vector<int>::const_iterator tbinItr = timeBinsOn.begin();
-       tbinItr != timeBinsOn.end(); ++tbinItr)
-    {
-      int tbin = *tbinItr;
-      if (tbin >= 0 && tbin < ntbins_-2)
-        {
-          // First triad bit indicates the presence of the hit
-          dataWord(cfeb, tbin, layer).set(distrip, true);
-          // Second bit indicates which of the two strips contains the hit
-          if (strip%2 == 0)
-            dataWord(cfeb, tbin+1, layer).set(distrip, true);
-          // Third bit indicates whether the hit is located on the left or on the
-          // right side of the strip.
-          if (digi.getComparator())
-            dataWord(cfeb, tbin+2, layer).set(distrip, true);
-
-        }
+  for (std::vector<int>::const_iterator tbinItr = timeBinsOn.begin(); tbinItr != timeBinsOn.end(); ++tbinItr) {
+    int tbin = *tbinItr;
+    if (tbin >= 0 && tbin < ntbins_ - 2) {
+      // First triad bit indicates the presence of the hit
+      dataWord(cfeb, tbin, layer).set(distrip, true);
+      // Second bit indicates which of the two strips contains the hit
+      if (strip % 2 == 0)
+        dataWord(cfeb, tbin + 1, layer).set(distrip, true);
+      // Third bit indicates whether the hit is located on the left or on the
+      // right side of the strip.
+      if (digi.getComparator())
+        dataWord(cfeb, tbin + 2, layer).set(distrip, true);
     }
+  }
 }
 
 /*** 
  * Comparator packing version with ME11 strips swapping
  ***/
-void CSCCLCTData::add(const CSCComparatorDigi & digi, const CSCDetId & cid)
-{
-
+void CSCCLCTData::add(const CSCComparatorDigi& digi, const CSCDetId& cid) {
   static const bool doStripSwapping = true;
-  bool me1a = (cid.station()==1) && (cid.ring()==4);
+  bool me1a = (cid.station() == 1) && (cid.ring() == 4);
   bool zplus = (cid.endcap() == 1);
-  bool me1b = (cid.station()==1) && (cid.ring()==1);
-//  bool me11 = (cid.station()==1) && ((cid.ring()==1) || (cid.ring()==4));
+  bool me1b = (cid.station() == 1) && (cid.ring() == 1);
+  //  bool me11 = (cid.station()==1) && ((cid.ring()==1) || (cid.ring()==4));
 
   unsigned layer = cid.layer();
 
-
   int strip = digi.getStrip();
-  int halfstrip = (strip-1)*2 + digi.getComparator();
-  int cfeb = (strip-1)/16;
-  int distrip = ((strip-1)%16) / 2;
-  int bit2 = (strip-1)%2;
+  int halfstrip = (strip - 1) * 2 + digi.getComparator();
+  int cfeb = (strip - 1) / 16;
+  int distrip = ((strip - 1) % 16) / 2;
+  int bit2 = (strip - 1) % 2;
   int bit3 = digi.getComparator();
-
-
 
   // assert(distrip < 8 && cfeb < 6 && halfStrip < 161);
   ///!!! Do we need to introduce format version here to accomodate 7 CFEBs
@@ -286,116 +244,85 @@ void CSCCLCTData::add(const CSCComparatorDigi & digi, const CSCDetId & cid)
   }
 
   // Lets try to do ME11 strip flipping
-  if (doStripSwapping)
-    {
-
-      if (theFirmwareVersion >= 2013)
-        {
-          if ( (me1a || (me1b && (cfeb > 3))) &&  zplus )
-            {
-              distrip = 7-distrip;  // 0-7 -> 7-0
-              cfeb = 10 - cfeb;
-              bit2 = ((31-(halfstrip%32))%4)/2;
-              bit3 = ((31-(halfstrip%32))%4)%2;
-
-            }
-          if ( me1b && !zplus && (cfeb<4))
-            {
-              distrip = 7-distrip;
-              cfeb = 3 - cfeb;
-              bit2 = ((31-(halfstrip%32))%4)/2;
-              bit3 = ((31-(halfstrip%32))%4)%2;
-
-
-            }
-        }
-      else
-        {
-          // if ( me1a )           { cfeb_corr = 0; } // reset 4 to 0
-          if ( (me1a || (me1b && (cfeb > 3))) &&  zplus )
-            {
-              distrip = 7-distrip; // 0-7 -> 7-0
-              bit2 = ((31-(halfstrip%32))%4)/2;
-              bit3 = ((31-(halfstrip%32))%4)%2;
-            }
-          if ( me1b && !zplus && (cfeb<4))
-            {
-              distrip = 7-distrip;
-              cfeb = 3 - cfeb;
-              bit2 = ((31-(halfstrip%32))%4)/2;
-              bit3 = ((31-(halfstrip%32))%4)%2;
-
-
-            }
-        }
+  if (doStripSwapping) {
+    if (theFirmwareVersion >= 2013) {
+      if ((me1a || (me1b && (cfeb > 3))) && zplus) {
+        distrip = 7 - distrip;  // 0-7 -> 7-0
+        cfeb = 10 - cfeb;
+        bit2 = ((31 - (halfstrip % 32)) % 4) / 2;
+        bit3 = ((31 - (halfstrip % 32)) % 4) % 2;
+      }
+      if (me1b && !zplus && (cfeb < 4)) {
+        distrip = 7 - distrip;
+        cfeb = 3 - cfeb;
+        bit2 = ((31 - (halfstrip % 32)) % 4) / 2;
+        bit3 = ((31 - (halfstrip % 32)) % 4) % 2;
+      }
+    } else {
+      // if ( me1a )           { cfeb_corr = 0; } // reset 4 to 0
+      if ((me1a || (me1b && (cfeb > 3))) && zplus) {
+        distrip = 7 - distrip;  // 0-7 -> 7-0
+        bit2 = ((31 - (halfstrip % 32)) % 4) / 2;
+        bit3 = ((31 - (halfstrip % 32)) % 4) % 2;
+      }
+      if (me1b && !zplus && (cfeb < 4)) {
+        distrip = 7 - distrip;
+        cfeb = 3 - cfeb;
+        bit2 = ((31 - (halfstrip % 32)) % 4) / 2;
+        bit3 = ((31 - (halfstrip % 32)) % 4) % 2;
+      }
     }
-
+  }
 
   std::vector<int> timeBinsOn = digi.getTimeBinsOn();
-  for (std::vector<int>::const_iterator tbinItr = timeBinsOn.begin();
-       tbinItr != timeBinsOn.end();
-       ++tbinItr)
-    {
-      int tbin = *tbinItr;
-      if (tbin >= 0 && tbin < ntbins_-2)
-        {
-          // First triad bit indicates the presence of the hit
-          dataWord(cfeb, tbin, layer).set(distrip, true);
-          // Second bit indicates which of the two strips contains the hit
-          // if (strip%2 == 0)
-          if (bit2)
-            dataWord(cfeb, tbin+1, layer).set(distrip, true);
-          // Third bit indicates whether the hit is located on the left or on the
-          // right side of the strip.
-          // if (digi.getComparator())
-          if (bit3)
-            dataWord(cfeb, tbin+2, layer).set(distrip, true);
-
-        }
+  for (std::vector<int>::const_iterator tbinItr = timeBinsOn.begin(); tbinItr != timeBinsOn.end(); ++tbinItr) {
+    int tbin = *tbinItr;
+    if (tbin >= 0 && tbin < ntbins_ - 2) {
+      // First triad bit indicates the presence of the hit
+      dataWord(cfeb, tbin, layer).set(distrip, true);
+      // Second bit indicates which of the two strips contains the hit
+      // if (strip%2 == 0)
+      if (bit2)
+        dataWord(cfeb, tbin + 1, layer).set(distrip, true);
+      // Third bit indicates whether the hit is located on the left or on the
+      // right side of the strip.
+      // if (digi.getComparator())
+      if (bit3)
+        dataWord(cfeb, tbin + 2, layer).set(distrip, true);
     }
+  }
 }
 
-
-bool CSCCLCTData::check() const
-{
+bool CSCCLCTData::check() const {
   bool result = true;
-  for (int cfeb = 0; cfeb < ncfebs_; ++cfeb)
-    {
-      for (int tbin = 0; tbin < ntbins_; ++tbin)
-        {
-          for (int layer = 1; layer <= 6; ++layer)
-            {
-              /// first do some checks
-              const CSCCLCTDataWord & word = dataWord(cfeb, tbin, layer);
-              bool wordIsGood = (word.tbin_ == tbin) && (word.cfeb_ == cfeb);
-              result = result && wordIsGood;
-              if (!wordIsGood && debug)
-                {
-                  LogTrace("CSCCLCTData|CSCRawToDigi") << "Bad CLCT data  in layer " << layer
-                  << " expect CFEB " << cfeb << " tbin " << tbin;
-                  LogTrace("CSCCLCTData|CSCRawToDigi") << " See " << word.cfeb_ << " "
-                  << word.tbin_;
-                }
-            }
+  for (int cfeb = 0; cfeb < ncfebs_; ++cfeb) {
+    for (int tbin = 0; tbin < ntbins_; ++tbin) {
+      for (int layer = 1; layer <= 6; ++layer) {
+        /// first do some checks
+        const CSCCLCTDataWord& word = dataWord(cfeb, tbin, layer);
+        bool wordIsGood = (word.tbin_ == tbin) && (word.cfeb_ == cfeb);
+        result = result && wordIsGood;
+        if (!wordIsGood && debug) {
+          LogTrace("CSCCLCTData|CSCRawToDigi")
+              << "Bad CLCT data  in layer " << layer << " expect CFEB " << cfeb << " tbin " << tbin;
+          LogTrace("CSCCLCTData|CSCRawToDigi") << " See " << word.cfeb_ << " " << word.tbin_;
         }
+      }
     }
-  if (!result) LogTrace("CSCCLCTData|CSCRawToDigi") << "++ Bad CLCT Data ++ ";
+  }
+  if (!result)
+    LogTrace("CSCCLCTData|CSCRawToDigi") << "++ Bad CLCT Data ++ ";
   return result;
 }
 
-
-void CSCCLCTData::dump() const
-{
-  for (int i=0; i<size_; i++)
-    {
-      printf("%04x %04x %04x %04x\n", theData[i+3], theData[i+2], theData[i+1], theData[i]);
-      i+=3;
-    }
+void CSCCLCTData::dump() const {
+  for (int i = 0; i < size_; i++) {
+    printf("%04x %04x %04x %04x\n", theData[i + 3], theData[i + 2], theData[i + 1], theData[i]);
+    i += 3;
+  }
 }
 
-
-void CSCCLCTData::selfTest()
-{
+void CSCCLCTData::selfTest() {
   CSCCLCTData clctData(5, 16);
   // aim for output 4 in 5th time bin, = 0000000000010000
   CSCComparatorDigi comparatorDigi1(1, 0, 0x10);
@@ -404,13 +331,13 @@ void CSCCLCTData::selfTest()
   // aim for output 7 in 7th time bin, = 000 0000 0100 0000
   CSCComparatorDigi comparatorDigi3(80, 1, 0x40);
 
-  clctData.add(comparatorDigi1,1);
-  clctData.add(comparatorDigi2,4);
-  clctData.add(comparatorDigi3,6);
+  clctData.add(comparatorDigi1, 1);
+  clctData.add(comparatorDigi2, 4);
+  clctData.add(comparatorDigi3, 6);
 
-  CSCDetId layer1(1,4,1,2,1);
-  CSCDetId layer4(1,4,1,2,4);
-  CSCDetId layer6(1,4,1,2,6);
+  CSCDetId layer1(1, 4, 1, 2, 1);
+  CSCDetId layer4(1, 4, 1, 2, 4);
+  CSCDetId layer6(1, 4, 1, 2, 6);
 
   std::vector<CSCComparatorDigi> digis1 = clctData.comparatorDigis(1);
   std::vector<CSCComparatorDigi> digis2 = clctData.comparatorDigis(4);
@@ -432,4 +359,3 @@ void CSCCLCTData::selfTest()
   assert(digis3[0].getComparator() == 1);
   assert(digis3[0].getTimeBin() == 6);
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCChamberDataItr.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCChamberDataItr.cc
@@ -1,59 +1,38 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCChamberDataItr.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h"
 
-CSCChamberDataItr::CSCChamberDataItr(const char * buf) :
-  theDCCData(nullptr),
-  theCurrentDDU(0)
-{
+CSCChamberDataItr::CSCChamberDataItr(const char *buf) : theDCCData(nullptr), theCurrentDDU(0) {
   // first try if it's DCC data.
-  const CSCDCCHeader * dccHeader 
-    = reinterpret_cast<const CSCDCCHeader *>(buf);
-  if(dccHeader->check())
-    {
-      theDCCData = new CSCDCCEventData((const uint16_t *)buf);
-      theNumberOfDDUs = theDCCData->dduData().size();
-      theDDUItr = new CSCDDUDataItr( &(theDCCData->dduData()[theCurrentDDU]) );
-    }
-  else 
-    {
-      // it's DDU data, with only one DDU
-      theDDUItr = new CSCDDUDataItr(buf);
-      theNumberOfDDUs = 1;
-    }
-}
-  
-
-CSCChamberDataItr::~CSCChamberDataItr() 
-{
-   // safe, even if it's zero
-   delete theDCCData;
+  const CSCDCCHeader *dccHeader = reinterpret_cast<const CSCDCCHeader *>(buf);
+  if (dccHeader->check()) {
+    theDCCData = new CSCDCCEventData((const uint16_t *)buf);
+    theNumberOfDDUs = theDCCData->dduData().size();
+    theDDUItr = new CSCDDUDataItr(&(theDCCData->dduData()[theCurrentDDU]));
+  } else {
+    // it's DDU data, with only one DDU
+    theDDUItr = new CSCDDUDataItr(buf);
+    theNumberOfDDUs = 1;
+  }
 }
 
+CSCChamberDataItr::~CSCChamberDataItr() {
+  // safe, even if it's zero
+  delete theDCCData;
+}
 
-bool CSCChamberDataItr::next() 
-{
+bool CSCChamberDataItr::next() {
   bool result = true;
-  if(!theDDUItr->next()) 
-    {
-      if(++theCurrentDDU >= theNumberOfDDUs)
-	{
-	  result = false;
-	}
-      else
-	{
-	  // the next DDU exists, so initialize an itr
-	  assert(theDCCData != nullptr);
-	  delete theDDUItr;
-	  theDDUItr = new CSCDDUDataItr( &(theDCCData->dduData()[theCurrentDDU]) );
-	}
+  if (!theDDUItr->next()) {
+    if (++theCurrentDDU >= theNumberOfDDUs) {
+      result = false;
+    } else {
+      // the next DDU exists, so initialize an itr
+      assert(theDCCData != nullptr);
+      delete theDDUItr;
+      theDDUItr = new CSCDDUDataItr(&(theDCCData->dduData()[theCurrentDDU]));
     }
+  }
   return result;
 }
 
-
-const CSCEventData &  CSCChamberDataItr::operator*() 
-{
-  return **theDDUItr;
-}
-
- 
+const CSCEventData &CSCChamberDataItr::operator*() { return **theDDUItr; }

--- a/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
@@ -19,26 +19,16 @@ bool CSCDCCEventData::debug = false;
 std::atomic<bool> CSCDCCEventData::debug{false};
 #endif
 
-CSCDCCEventData::CSCDCCEventData(int sourceId, int nDDUs, int bx, int l1a) 
-: theDCCHeader(bx, l1a, sourceId) 
-{
+CSCDCCEventData::CSCDCCEventData(int sourceId, int nDDUs, int bx, int l1a) : theDCCHeader(bx, l1a, sourceId) {
   theDDUData.reserve(nDDUs);
-} 
-
-CSCDCCEventData::CSCDCCEventData(const uint16_t *buf, CSCDCCExaminer* examiner)
-{
-  unpack_data(buf, examiner);
 }
 
-CSCDCCEventData::~CSCDCCEventData() 
-{
-}
+CSCDCCEventData::CSCDCCEventData(const uint16_t* buf, CSCDCCExaminer* examiner) { unpack_data(buf, examiner); }
 
+CSCDCCEventData::~CSCDCCEventData() {}
 
-void CSCDCCEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner) 
-{
- 
-/*
+void CSCDCCEventData::unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner) {
+  /*
   for (int i=0;i<20;i++) {
     printf("%04x %04x %04x %04x\n",buf[i+3],buf[i+2],buf[i+1],buf[i]); 
     i+=3;
@@ -46,126 +36,115 @@ void CSCDCCEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
 */
 
   theDDUData.clear();
-  if (debug) 
-    LogTrace ("CSCDCCEventData|CSCRawToDigi") << "CSCDCCEventData::unpack_data() is called";
+  if (debug)
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << "CSCDCCEventData::unpack_data() is called";
 
   // decode DCC header (128 bits)
-  if (debug) 
-    LogTrace ("CSCDCCEventData|CSCRawToDigi") << "unpacking dcc header...";
+  if (debug)
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << "unpacking dcc header...";
   theDCCHeader.setFromBuffer(buf);
   //theDCCHeader = CSCDCCHeader(buf); // direct unpacking instead of bitfields
   buf += theDCCHeader.sizeInWords();
 
   //std::cout <<"Sandrik DCC Id = " << theDCCHeader.getCDFSourceId()  << std::endl;
- 
-  ///loop over DDUEventDatas
-  while ( (buf[7]==0x8000)&&(buf[6]==0x0001)&&(buf[5]==0x8000))
-    {
-       CSCDDUEventData dduEventData(buf, examiner);
-//	CSCDDUEventData dduEventData(buf);
 
-      if (debug) LogTrace ("CSCDCCEventData|CSCRawToDigi") << " checking ddu data integrity ";
-      if (dduEventData.check()) 
-	{
-	  theDDUData.push_back(dduEventData);
-	  buf += dduEventData.sizeInWords();
-	} 
-      else
-	{
-	  if (debug) LogTrace("CSCDCCEventData|CSCRawToDigi") <<"DDU Data Check failed!  ";
-	  break;
-	}
-      
+  ///loop over DDUEventDatas
+  while ((buf[7] == 0x8000) && (buf[6] == 0x0001) && (buf[5] == 0x8000)) {
+    CSCDDUEventData dduEventData(buf, examiner);
+    //	CSCDDUEventData dduEventData(buf);
+
+    if (debug)
+      LogTrace("CSCDCCEventData|CSCRawToDigi") << " checking ddu data integrity ";
+    if (dduEventData.check()) {
+      theDDUData.push_back(dduEventData);
+      buf += dduEventData.sizeInWords();
+    } else {
+      if (debug)
+        LogTrace("CSCDCCEventData|CSCRawToDigi") << "DDU Data Check failed!  ";
+      break;
     }
-  
-  if (debug)
-    {
-      LogTrace ("CSCDCCEventData|CSCRawToDigi") << "unpacking dcc trailer ";
-      LogTrace ("CSCDCCEventData|CSCRawToDigi") << std::hex << buf[3] <<" "
-				       << buf[2]<<" " << buf[1]<<" " << buf[0];
-    }
-	    
+  }
+
+  if (debug) {
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << "unpacking dcc trailer ";
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << std::hex << buf[3] << " " << buf[2] << " " << buf[1] << " " << buf[0];
+  }
+
   //decode dcc trailer (128 bits)
-  if (debug) LogTrace ("CSCDCCEventData|CSCRawToDigi") <<"decoding DCC trailer";
+  if (debug)
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << "decoding DCC trailer";
   theDCCTrailer.setFromBuffer(buf);
-  if (debug) LogTrace("CSCDCCEventData|CSCRawToDigi") << "checking DDU Trailer" << theDCCTrailer.check(); 
- 
-  // buf += theDCCTrailer.sizeInWords(); /* =VB= Commented out to please static analyzer */ 
+  if (debug)
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << "checking DDU Trailer" << theDCCTrailer.check();
+
+  // buf += theDCCTrailer.sizeInWords(); /* =VB= Commented out to please static analyzer */
 
   //std::cout << " DCC Size: " << std::dec << theSizeInWords << std::endl;
   //std::cout << "LastBuf: "  << std::hex << inputBuf[theSizeInWords-4] << std::endl;
 }
-	  
 
-bool CSCDCCEventData::check() const 
-{
+bool CSCDCCEventData::check() const {
   // the trailer counts in 64-bit words
-  if (debug) 
-    {
-      LogTrace ("CSCDCCEventData|CSCRawToDigi") << "size in Words () = " << std::dec << sizeInWords();
-    }
+  if (debug) {
+    LogTrace("CSCDCCEventData|CSCRawToDigi") << "size in Words () = " << std::dec << sizeInWords();
+  }
 
-  return  theDCCHeader.check() && theDCCTrailer.check();
+  return theDCCHeader.check() && theDCCTrailer.check();
 }
 
-
-void CSCDCCEventData::addChamber(CSCEventData & chamber, int dduID, int dduSlot, int dduInput, int dmbID, uint16_t format_version)
-{
+void CSCDCCEventData::addChamber(
+    CSCEventData& chamber, int dduID, int dduSlot, int dduInput, int dmbID, uint16_t format_version) {
   // first, find this DDU
   int dduIndex = -1;
   int nDDUs = theDDUData.size();
-  for(int i = 0; dduIndex == -1 && i < nDDUs; ++i)
-  {
-    if(theDDUData[i].header().source_id() == dduID) dduIndex = i;
+  for (int i = 0; dduIndex == -1 && i < nDDUs; ++i) {
+    if (theDDUData[i].header().source_id() == dduID)
+      dduIndex = i;
   }
-  
+
   /// Set DDU format_version field in header depending on desired format version
-  unsigned ddu_fmt_version = 0x6; // 2005 Format
-  if (format_version == 2013) ddu_fmt_version = 0x7; /// 2013 Format
-  
-  if(dduIndex == -1)
-  {
+  unsigned ddu_fmt_version = 0x6;  // 2005 Format
+  if (format_version == 2013)
+    ddu_fmt_version = 0x7;  /// 2013 Format
+
+  if (dduIndex == -1) {
     // make a new one
-    CSCDDUHeader newDDUHeader(dccHeader().getCDFBunchCounter(), 
-                              dccHeader().getCDFEventNumber(), dduID, ddu_fmt_version);
+    CSCDDUHeader newDDUHeader(
+        dccHeader().getCDFBunchCounter(), dccHeader().getCDFEventNumber(), dduID, ddu_fmt_version);
     theDDUData.push_back(CSCDDUEventData(newDDUHeader));
     dduIndex = nDDUs;
     dccHeader().setDAV(dduSlot);
   }
-  theDDUData[dduIndex].add( chamber, dmbID, dduInput, format_version);
+  theDDUData[dduIndex].add(chamber, dmbID, dduInput, format_version);
 }
- 
 
-boost::dynamic_bitset<> CSCDCCEventData::pack() 
-{
-  boost::dynamic_bitset<> result( theDCCHeader.sizeInWords()*16);
-  result = bitset_utilities::ushortToBitset(theDCCHeader.sizeInWords()*16, theDCCHeader.data());
-  //std::cout <<"SANDRIK DCC size of header  in words"<< theDCCHeader.sizeInWords()*16 <<std::endl;  
+boost::dynamic_bitset<> CSCDCCEventData::pack() {
+  boost::dynamic_bitset<> result(theDCCHeader.sizeInWords() * 16);
+  result = bitset_utilities::ushortToBitset(theDCCHeader.sizeInWords() * 16, theDCCHeader.data());
+  //std::cout <<"SANDRIK DCC size of header  in words"<< theDCCHeader.sizeInWords()*16 <<std::endl;
   //std::cout <<"SANDRIK DCC size of header in bits"<< result.size()<<std::endl;
   //for(size_t i = 0; i < result.size(); ++i) {
   //  std::cout<<result[i];
   //  if (((i+1)%32)==0) std::cout<<std::endl;
   //}
-  
-  for(size_t i = 0; i < theDDUData.size(); ++i) 
-    {
-      result = bitset_utilities::append(result,theDDUData[i].pack());
-      //std::cout <<"SANDRIK here is ddu data check ";
-      //theDDUData[i].header().check();
-      //std::cout <<std::endl;
-      //bitset_utilities::printWords(result);
-    }
-  
+
+  for (size_t i = 0; i < theDDUData.size(); ++i) {
+    result = bitset_utilities::append(result, theDDUData[i].pack());
+    //std::cout <<"SANDRIK here is ddu data check ";
+    //theDDUData[i].header().check();
+    //std::cout <<std::endl;
+    //bitset_utilities::printWords(result);
+  }
+
   //std::cout <<"SANDRIK packed dcc size is "<<result.size()<<std::endl;
   //for(size_t i = 0; i < result.size(); ++i) {
   //  std::cout<<result[i];
   //  if (((i+1)%32)==0) std::cout<<std::endl;
   //}
 
-  boost::dynamic_bitset<> dccTrailer = bitset_utilities::ushortToBitset(theDCCTrailer.sizeInWords()*16,
-									theDCCTrailer.data());
-  result = bitset_utilities::append(result,dccTrailer);
+  boost::dynamic_bitset<> dccTrailer =
+      bitset_utilities::ushortToBitset(theDCCTrailer.sizeInWords() * 16, theDCCTrailer.data());
+  result = bitset_utilities::append(result, dccTrailer);
   //  bitset_utilities::printWords(result);
   return result;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
@@ -26,54 +26,53 @@
 #include <iomanip>
 using namespace std;
 
-void CSCDCCExaminer::crcALCT(bool enable)
-{
+void CSCDCCExaminer::crcALCT(bool enable) {
   checkCrcALCT = enable;
-  if( checkCrcALCT )
+  if (checkCrcALCT)
     sERROR[10] = "ALCT CRC Error                                   ";
   else
     sERROR[10] = "ALCT CRC Error ( disabled )                      ";
 }
 
-void CSCDCCExaminer::crcTMB(bool enable)
-{
+void CSCDCCExaminer::crcTMB(bool enable) {
   checkCrcTMB = enable;
-  if( checkCrcTMB )
+  if (checkCrcTMB)
     sERROR[15] = "TMB CRC Error                                    ";
   else
     sERROR[15] = "TMB CRC Error ( disabled )                       ";
 }
 
-void CSCDCCExaminer::crcCFEB(bool enable)
-{
+void CSCDCCExaminer::crcCFEB(bool enable) {
   checkCrcCFEB = enable;
-  if( checkCrcCFEB )
+  if (checkCrcCFEB)
     sERROR[18] = "CFEB CRC Error                                   ";
   else
     sERROR[18] = "CFEB CRC Error ( disabled )                      ";
 }
 
-void CSCDCCExaminer::modeDDU(bool enable)
-{
+void CSCDCCExaminer::modeDDU(bool enable) {
   modeDDUonly = enable;
-  if( modeDDUonly)
-    {
-      sERROR[25] = "DCC Trailer Missing                              ";
-      sERROR[26] = "DCC Header Missing                               ";
-    }
-  else
-    {
-      sERROR[25] = "DCC Trailer Missing (disabled)                   ";
-      sERROR[26] = "DCC Header Missing (disabled)                    ";
-    }
-
+  if (modeDDUonly) {
+    sERROR[25] = "DCC Trailer Missing                              ";
+    sERROR[26] = "DCC Header Missing                               ";
+  } else {
+    sERROR[25] = "DCC Trailer Missing (disabled)                   ";
+    sERROR[26] = "DCC Header Missing (disabled)                    ";
+  }
 }
 
-
 CSCDCCExaminer::CSCDCCExaminer(ExaminerMaskType mask)
-  :nERRORS(29),nWARNINGS(5),nPAYLOADS(16),nSTATUSES(29),sERROR(nERRORS),sWARNING(nWARNINGS),sERROR_(nERRORS),sWARNING_(nWARNINGS),sDMBExpectedPayload(nPAYLOADS),sDMBEventStaus(nSTATUSES),examinerMask(mask)
-{
-
+    : nERRORS(29),
+      nWARNINGS(5),
+      nPAYLOADS(16),
+      nSTATUSES(29),
+      sERROR(nERRORS),
+      sWARNING(nWARNINGS),
+      sERROR_(nERRORS),
+      sWARNING_(nWARNINGS),
+      sDMBExpectedPayload(nPAYLOADS),
+      sDMBEventStaus(nSTATUSES),
+      examinerMask(mask) {
 #ifdef LOCAL_UNPACK
   COUT.redirect(std::cout);
   CERR.redirect(std::cerr);
@@ -122,35 +121,34 @@ CSCDCCExaminer::CSCDCCExaminer(ExaminerMaskType mask)
   sWARNING[0] = " Extra words between DDU Trailer and DDU Header ";
   sWARNING[1] = " DDU Header Incomplete                          ";
 
-  sDMBExpectedPayload[0]  = "CFEB1_ACTIVE";
-  sDMBExpectedPayload[1]  = "CFEB2_ACTIVE";
-  sDMBExpectedPayload[2]  = "CFEB3_ACTIVE";
-  sDMBExpectedPayload[3]  = "CFEB4_ACTIVE";
-  sDMBExpectedPayload[4]  = "CFEB5_ACTIVE";
-  sDMBExpectedPayload[5]  = "ALCT_DAV";
-  sDMBExpectedPayload[6]  = "TMB_DAV";
-  sDMBExpectedPayload[7]  = "CFEB1_DAV";
-  sDMBExpectedPayload[8]  = "CFEB2_DAV";
-  sDMBExpectedPayload[9]  = "CFEB3_DAV";
+  sDMBExpectedPayload[0] = "CFEB1_ACTIVE";
+  sDMBExpectedPayload[1] = "CFEB2_ACTIVE";
+  sDMBExpectedPayload[2] = "CFEB3_ACTIVE";
+  sDMBExpectedPayload[3] = "CFEB4_ACTIVE";
+  sDMBExpectedPayload[4] = "CFEB5_ACTIVE";
+  sDMBExpectedPayload[5] = "ALCT_DAV";
+  sDMBExpectedPayload[6] = "TMB_DAV";
+  sDMBExpectedPayload[7] = "CFEB1_DAV";
+  sDMBExpectedPayload[8] = "CFEB2_DAV";
+  sDMBExpectedPayload[9] = "CFEB3_DAV";
   sDMBExpectedPayload[10] = "CFEB4_DAV";
   sDMBExpectedPayload[11] = "CFEB5_DAV";
   /// 2013 Format additions
   sDMBExpectedPayload[12] = "CFEB6_DAV";
   sDMBExpectedPayload[13] = "CFEB7_DAV";
-  sDMBExpectedPayload[14]  = "CFEB6_ACTIVE";
-  sDMBExpectedPayload[15]  = "CFEB7_ACTIVE";
+  sDMBExpectedPayload[14] = "CFEB6_ACTIVE";
+  sDMBExpectedPayload[15] = "CFEB7_ACTIVE";
 
-
-  sDMBEventStaus[0]  = "ALCT_FIFO_FULL";
-  sDMBEventStaus[1]  = "TMB_FIFO_FULL";
-  sDMBEventStaus[2]  = "CFEB1_FIFO_FULL";
-  sDMBEventStaus[3]  = "CFEB2_FIFO_FULL";
-  sDMBEventStaus[4]  = "CFEB3_FIFO_FULL";
-  sDMBEventStaus[5]  = "CFEB4_FIFO_FULL";
-  sDMBEventStaus[6]  = "CFEB5_FIFO_FULL";
-  sDMBEventStaus[7]  = "ALCT_START_TIMEOUT";
-  sDMBEventStaus[8]  = "TMB_START_TIMEOUT";
-  sDMBEventStaus[9]  = "CFEB1_START_TIMEOUT";
+  sDMBEventStaus[0] = "ALCT_FIFO_FULL";
+  sDMBEventStaus[1] = "TMB_FIFO_FULL";
+  sDMBEventStaus[2] = "CFEB1_FIFO_FULL";
+  sDMBEventStaus[3] = "CFEB2_FIFO_FULL";
+  sDMBEventStaus[4] = "CFEB3_FIFO_FULL";
+  sDMBEventStaus[5] = "CFEB4_FIFO_FULL";
+  sDMBEventStaus[6] = "CFEB5_FIFO_FULL";
+  sDMBEventStaus[7] = "ALCT_START_TIMEOUT";
+  sDMBEventStaus[8] = "TMB_START_TIMEOUT";
+  sDMBEventStaus[9] = "CFEB1_START_TIMEOUT";
   sDMBEventStaus[10] = "CFEB2_START_TIMEOUT";
   sDMBEventStaus[11] = "CFEB3_START_TIMEOUT";
   sDMBEventStaus[12] = "CFEB4_START_TIMEOUT";
@@ -171,8 +169,6 @@ CSCDCCExaminer::CSCDCCExaminer(ExaminerMaskType mask)
   sDMBEventStaus[26] = "CFEB7_START_TIMEOUT";
   sDMBEventStaus[27] = "CFEB6_END_TIMEOUT";
   sDMBEventStaus[28] = "CFEB7_END_TIMEOUT";
-
-
 
   sERROR_[0] = " Any errors: 00";
   sERROR_[1] = " DDU Trailer Missing: 01";
@@ -208,69 +204,68 @@ CSCDCCExaminer::CSCDCCExaminer(ExaminerMaskType mask)
   sWARNING_[0] = " Extra words between DDU Trailer and DDU Header: 00";
   sWARNING_[1] = " DDU Header Incomplete: 02";
 
-  fDCC_Header  = false;
+  fDCC_Header = false;
   fDCC_Trailer = false;
-  fDDU_Header  = false;
+  fDDU_Header = false;
   fDDU_Trailer = false;
-  fDMB_Header  = false;
+  fDMB_Header = false;
   fDMB_Trailer = false;
   fALCT_Header = false;
-  fTMB_Header  = false;
+  fTMB_Header = false;
   fALCT_Format2007 = true;
-  fTMB_Format2007  = true;
+  fTMB_Format2007 = true;
   fFormat2013 = false;
 
-  cntDDU_Headers  = 0;
+  cntDDU_Headers = 0;
   cntDDU_Trailers = 0;
   cntCHAMB_Headers.clear();
   cntCHAMB_Trailers.clear();
 
   DAV_ALCT = false;
-  DAV_TMB  = false;
+  DAV_TMB = false;
   DAV_CFEB = 0;
-  DMB_Active  = 0;
+  DMB_Active = 0;
   nDMBs = 0;
-  DDU_WordsSinceLastHeader     = 0;
-  DDU_WordCount                = 0;
+  DDU_WordsSinceLastHeader = 0;
+  DDU_WordCount = 0;
   DDU_WordMismatch_Occurrences = 0;
-  DDU_WordsSinceLastTrailer    = 0;
-  ALCT_ZSE                     = 0;
-  nWG_round_up                 = 0;
+  DDU_WordsSinceLastTrailer = 0;
+  ALCT_ZSE = 0;
+  nWG_round_up = 0;
 
-  TMB_WordsRPC  = 0;
+  TMB_WordsRPC = 0;
   TMB_Firmware_Revision = 0;
   DDU_Firmware_Revision = 0;
   zeroCounts();
 
   checkCrcALCT = false;
-  ALCT_CRC=0;
-  checkCrcTMB  = false;
-  TMB_CRC=0;
+  ALCT_CRC = 0;
+  checkCrcTMB = false;
+  TMB_CRC = 0;
   checkCrcCFEB = false;
-  CFEB_CRC=0;
+  CFEB_CRC = 0;
 
   modeDDUonly = false;
-  sourceID    = 0xFFF;
+  sourceID = 0xFFF;
   currentChamber = -1;
 
   //headerDAV_Active = -1; // Trailer vs. Header check // Obsolete since 16.09.05
 
   clear();
   buf_1 = &(tmpbuf[0]);
-  buf0  = &(tmpbuf[4]);
-  buf1  = &(tmpbuf[8]);
-  buf2  = &(tmpbuf[12]);
+  buf0 = &(tmpbuf[4]);
+  buf1 = &(tmpbuf[8]);
+  buf2 = &(tmpbuf[12]);
 
-  bzero(tmpbuf, sizeof(uint16_t)*16);
+  bzero(tmpbuf, sizeof(uint16_t) * 16);
 }
 
-int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
-{
-  if( length<=0 ) return -1;
+int32_t CSCDCCExaminer::check(const uint16_t*& buffer, int32_t length) {
+  if (length <= 0)
+    return -1;
 
   /// 'buffer' is a sliding pointer; keep track of the true buffer
   buffer_start = buffer;
-
 
   /// Check for presence of data blocks inside TMB data
   bool fTMB_MiniScope_Start = false;
@@ -281,470 +276,458 @@ int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
   bool fTMB_RPC = false;
   bool fTMB_BlockedCFEBs = false;
 
-  while( length>0 )
-    {
-      // == Store last 4 read buffers in pipeline-like memory (note that memcpy works quite slower!)
-      buf_2 = buf_1;         //  This bufer was not needed so far
-      buf_1 = buf0;
-      buf0  = buf1;
-      buf1  = buf2;
-      buf2  = buffer;
+  while (length > 0) {
+    // == Store last 4 read buffers in pipeline-like memory (note that memcpy works quite slower!)
+    buf_2 = buf_1;  //  This bufer was not needed so far
+    buf_1 = buf0;
+    buf0 = buf1;
+    buf1 = buf2;
+    buf2 = buffer;
 
-      // check for too long event
-      if(!fERROR[19] && DDU_WordsSinceLastHeader>100000 )
-        {
-          fERROR[19] = true;
-          bERROR    |= 0x80000;
+    // check for too long event
+    if (!fERROR[19] && DDU_WordsSinceLastHeader > 100000) {
+      fERROR[19] = true;
+      bERROR |= 0x80000;
+    }
+
+    // increment counter of 64-bit words since last DDU Header
+    // this counter is reset if DDU Header is found
+    if (fDDU_Header) {
+      ++DDU_WordsSinceLastHeader;
+    }
+
+    // increment counter of 64-bit words since last DDU Trailer
+    // this counter is reset if DDU Trailer is found
+    if (fDDU_Trailer) {
+      ++DDU_WordsSinceLastTrailer;
+    }
+
+    /// increment counter of 16-bit words since last DMB*ALCT Header match
+    /// this counter is reset if ALCT Header is found right after DMB Header
+    if (fALCT_Header) {
+      /// decode the actual counting if zero suppression enabled
+      if (ALCT_ZSE) {
+        for (int g = 0; g < 4; g++) {
+          if (buf0[g] == 0x1000) {
+            ALCT_WordsSinceLastHeader = ALCT_WordsSinceLastHeader + nWG_round_up;
+          } else if (buf0[g] != 0x3000)
+            ALCT_WordsSinceLastHeader = ALCT_WordsSinceLastHeader + 1;
         }
+      } else
+        ALCT_WordsSinceLastHeader = ALCT_WordsSinceLastHeader + 4;
+      /// increment counter of 16-bit words without zero suppression decoding
+      ALCT_WordsSinceLastHeaderZeroSuppressed = ALCT_WordsSinceLastHeaderZeroSuppressed + 4;
+    }
 
-      // increment counter of 64-bit words since last DDU Header
-      // this counter is reset if DDU Header is found
-      if ( fDDU_Header )
-        {
-          ++DDU_WordsSinceLastHeader;
-        }
+    // increment counter of 16-bit words since last DMB*TMB Header match
+    // this counter is reset if TMB Header is found right after DMB Header or ALCT Trailer
+    if (fTMB_Header) {
+      TMB_WordsSinceLastHeader = TMB_WordsSinceLastHeader + 4;
+    }
 
-      // increment counter of 64-bit words since last DDU Trailer
-      // this counter is reset if DDU Trailer is found
-      if ( fDDU_Trailer )
-        {
-          ++DDU_WordsSinceLastTrailer;
-        }
+    // increment counter of 16-bit words since last of DMB Header, ALCT Trailer, TMB Trailer,
+    // CFEB Sample Trailer, CFEB B-word; this counter is reset by all these conditions
+    if (fDMB_Header) {
+      CFEB_SampleWordCount = CFEB_SampleWordCount + 4;
+    }
 
-      /// increment counter of 16-bit words since last DMB*ALCT Header match
-      /// this counter is reset if ALCT Header is found right after DMB Header
-      if ( fALCT_Header )
-        {
-          /// decode the actual counting if zero suppression enabled
-          if(ALCT_ZSE)
-            {
-              for(int g=0; g<4; g++)
-                {
-                  if(buf0[g]==0x1000)
-                    {
-                      ALCT_WordsSinceLastHeader = ALCT_WordsSinceLastHeader + nWG_round_up;
-                    }
-                  else if(buf0[g]!=0x3000) ALCT_WordsSinceLastHeader = ALCT_WordsSinceLastHeader + 1;
-                }
-            }
-          else ALCT_WordsSinceLastHeader = ALCT_WordsSinceLastHeader + 4;
-          /// increment counter of 16-bit words without zero suppression decoding
-          ALCT_WordsSinceLastHeaderZeroSuppressed = ALCT_WordsSinceLastHeaderZeroSuppressed + 4;
-        }
+    // If DDU header is missing we set unphysical 0xFFF value for DDU id
+    if (!fDDU_Header) {
+      sourceID = 0xFFF;
+    }
 
-      // increment counter of 16-bit words since last DMB*TMB Header match
-      // this counter is reset if TMB Header is found right after DMB Header or ALCT Trailer
-      if ( fTMB_Header )
-        {
-          TMB_WordsSinceLastHeader = TMB_WordsSinceLastHeader + 4;
-        }
-
-      // increment counter of 16-bit words since last of DMB Header, ALCT Trailer, TMB Trailer,
-      // CFEB Sample Trailer, CFEB B-word; this counter is reset by all these conditions
-      if ( fDMB_Header )
-        {
-          CFEB_SampleWordCount = CFEB_SampleWordCount + 4;
-        }
-
-      // If DDU header is missing we set unphysical 0xFFF value for DDU id
-      if( !fDDU_Header )
-        {
-          sourceID=0xFFF;
-        }
-
-
-      if (!modeDDUonly)
-        {
-          // DCC Header 1 && DCC Header 2
-          // =VB= Added support for Sep. 2008 CMS DAQ DCC format
-          if ( ( ( (buf0[3]&0xF000) == 0x5000 && (buf0[0]&0x00FF) == 0x005F )
-                 ||
-                 ( (buf0[3]&0xF000) == 0x5000 && (buf0[0]&0x000F) == 0x0008 ) )
-               &&
-               // =VB= Why 0xD900 signature word if only 0xD part is constant???
-               // (buf1[3]&0xFF00) == 0xD900 )
-               (buf1[3]&0xF000) == 0xD000 )
-            {
-              if( fDCC_Header )
-                {
-                  // == Another DCC Header before encountering DCC Trailer!
-                  fERROR[25]=true;
-                  bERROR|=0x2000000;
-                  fERROR[0]=true;
-                  bERROR|=0x1;
+    if (!modeDDUonly) {
+      // DCC Header 1 && DCC Header 2
+      // =VB= Added support for Sep. 2008 CMS DAQ DCC format
+      if ((((buf0[3] & 0xF000) == 0x5000 && (buf0[0] & 0x00FF) == 0x005F) ||
+           ((buf0[3] & 0xF000) == 0x5000 && (buf0[0] & 0x000F) == 0x0008)) &&
+          // =VB= Why 0xD900 signature word if only 0xD part is constant???
+          // (buf1[3]&0xFF00) == 0xD900 )
+          (buf1[3] & 0xF000) == 0xD000) {
+        if (fDCC_Header) {
+          // == Another DCC Header before encountering DCC Trailer!
+          fERROR[25] = true;
+          bERROR |= 0x2000000;
+          fERROR[0] = true;
+          bERROR |= 0x1;
 #ifdef LOCAL_UNPACK
-                  CERR<<"\n\nDCC Header Occurrence ";
-                  CERR<<"  ERROR 25    "<<sERROR[25]<<endl;
+          CERR << "\n\nDCC Header Occurrence ";
+          CERR << "  ERROR 25    " << sERROR[25] << endl;
 #endif
-                  fDDU_Header = false;
+          fDDU_Header = false;
 
-                  // go backward for 3 DDU words ( buf2, buf1, and buf0 )
-                  buffer-=12;
-                  buf_1 = &(tmpbuf[0]);  // Just for safety
-                  buf0  = &(tmpbuf[4]);  // Just for safety
-                  buf1  = &(tmpbuf[8]);  // Just for safety
-                  buf2  = &(tmpbuf[12]); // Just for safety
-                  bzero(tmpbuf,sizeof(uint16_t)*16);
-                  sync_stats();
-                  return length+12;
-                }
-
-              fDCC_Header  = true;
-              clear();
-            }
-        }
-      // == Check for Format Control Words, set proper flags, perform self-consistency checks
-
-      // C-words anywhere besides DDU Header
-      if( fDDU_Header && ( (buf0[0]&0xF000)==0xC000 || (buf0[1]&0xF000)==0xC000 || (buf0[2]&0xF000)==0xC000 || (buf0[3]&0xF000)==0xC000 ) &&
-          ( /*buf_1[0]!=0x8000 ||*/ buf_1[1]!=0x8000 || buf_1[2]!=0x0001 || buf_1[3]!=0x8000 ) )
-        {
-          fERROR[0]  = true;
-          bERROR    |= 0x1;
-          fERROR[20] = true;
-          bERROR    |= 0x100000;
-          // fCHAMB_ERR[20].insert(currentChamber);
-          // bCHAMB_ERR[currentChamber] |= 0x100000;
-#ifdef LOCAL_UNPACK
-          CERR<<"\nDDU Header Occurrence = "<<cntDDU_Headers;
-          CERR<<"  ERROR 20 "<<sERROR[20]<<endl;
-#endif
+          // go backward for 3 DDU words ( buf2, buf1, and buf0 )
+          buffer -= 12;
+          buf_1 = &(tmpbuf[0]);  // Just for safety
+          buf0 = &(tmpbuf[4]);   // Just for safety
+          buf1 = &(tmpbuf[8]);   // Just for safety
+          buf2 = &(tmpbuf[12]);  // Just for safety
+          bzero(tmpbuf, sizeof(uint16_t) * 16);
+          sync_stats();
+          return length + 12;
         }
 
-      // == DDU Header found
-      if( /*buf0[0]==0x8000 &&*/ buf0[1]==0x8000 && buf0[2]==0x0001 && buf0[3]==0x8000 )
-        {
-          // headerDAV_Active = (buf1[1]<<16) | buf1[0]; // Obsolete since 16.09.05
-/////////////////////////////////////////////////////////
-          checkDAVs();
-          checkTriggerHeadersAndTrailers();
-/////////////////////////////////////////////////////////
+        fDCC_Header = true;
+        clear();
+      }
+    }
+    // == Check for Format Control Words, set proper flags, perform self-consistency checks
 
-          if( fDDU_Header )
-            {
-              // == Another DDU Header before encountering DDU Trailer!
-              fERROR[1]=true;
-              bERROR|=0x2;
-              fERROR[0] = true;
-              bERROR|=0x1;
+    // C-words anywhere besides DDU Header
+    if (fDDU_Header &&
+        ((buf0[0] & 0xF000) == 0xC000 || (buf0[1] & 0xF000) == 0xC000 || (buf0[2] & 0xF000) == 0xC000 ||
+         (buf0[3] & 0xF000) == 0xC000) &&
+        (/*buf_1[0]!=0x8000 ||*/ buf_1[1] != 0x8000 || buf_1[2] != 0x0001 || buf_1[3] != 0x8000)) {
+      fERROR[0] = true;
+      bERROR |= 0x1;
+      fERROR[20] = true;
+      bERROR |= 0x100000;
+      // fCHAMB_ERR[20].insert(currentChamber);
+      // bCHAMB_ERR[currentChamber] |= 0x100000;
 #ifdef LOCAL_UNPACK
-              CERR<<"\n\nDDU Header Occurrence = "<<cntDDU_Headers;
-              CERR<<"  ERROR 1    "<<sERROR[1]<<endl;
+      CERR << "\nDDU Header Occurrence = " << cntDDU_Headers;
+      CERR << "  ERROR 20 " << sERROR[20] << endl;
 #endif
-              fDDU_Header = false;
+    }
 
-              // Part of work for chambers that hasn't been done in absent trailer
-              if( fDMB_Header || fDMB_Trailer )
-                {
-                  fERROR[5] = true;
-                  bERROR   |= 0x20;
-                  // Since here there are no chances to know what this chamber was, force it to be -2
-                  if( currentChamber == -1 ) currentChamber = -2;
-                  fCHAMB_ERR[5].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x20;
-                  fCHAMB_ERR[0].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x1;
+    // == DDU Header found
+    if (/*buf0[0]==0x8000 &&*/ buf0[1] == 0x8000 && buf0[2] == 0x0001 && buf0[3] == 0x8000) {
+      // headerDAV_Active = (buf1[1]<<16) | buf1[0]; // Obsolete since 16.09.05
+      /////////////////////////////////////////////////////////
+      checkDAVs();
+      checkTriggerHeadersAndTrailers();
+      /////////////////////////////////////////////////////////
+
+      if (fDDU_Header) {
+        // == Another DDU Header before encountering DDU Trailer!
+        fERROR[1] = true;
+        bERROR |= 0x2;
+        fERROR[0] = true;
+        bERROR |= 0x1;
 #ifdef LOCAL_UNPACK
-                  CERR<<"\n\nDDU Header Occurrence = "<<cntDDU_Headers;
-                  CERR<<"  ERROR 5    "<<sERROR[5]<<endl;
+        CERR << "\n\nDDU Header Occurrence = " << cntDDU_Headers;
+        CERR << "  ERROR 1    " << sERROR[1] << endl;
 #endif
-                }	// One of DMB Trailers is missing ( or both )
-              fDMB_Header  = false;
-              fDMB_Trailer = false;
+        fDDU_Header = false;
 
-              if( DMB_Active!=nDMBs )
-                {
-                  fERROR[24] = true;
-                  bERROR    |= 0x1000000;
-                }
-              DMB_Active = 0;
-              nDMBs = 0;
-
-              // Unknown chamber denoted as -2
-              // If it still remains in any of errors - put it in error 0
-              for(int err=1; err<nERRORS; ++err)
-                if( fCHAMB_ERR[err].find(-2) != fCHAMB_ERR[err].end() )
-                  {
-                    fCHAMB_ERR[0].insert(-2);
-                    bCHAMB_ERR[-2] |= 0x1;
-                  }
-
-              bDDU_ERR[sourceID] |= bERROR;
-              bDDU_WRN[sourceID] |= bWARNING;
-
-              // go backward for 3 DDU words ( buf2, buf1, and buf0 )
-              buffer-=12;
-              buf_1 = &(tmpbuf[0]);  // Just for safety
-              buf0  = &(tmpbuf[4]);  // Just for safety
-              buf1  = &(tmpbuf[8]);  // Just for safety
-              buf2  = &(tmpbuf[12]); // Just for safety
-              bzero(tmpbuf,sizeof(uint16_t)*16);
-              sync_stats();
-              return length+12;
-            }
-
-
-          currentChamber = -1; // Unknown yet
-
-          if( fDDU_Trailer && DDU_WordsSinceLastTrailer != 4 )
-            {
-              // == Counted extraneous words between last DDU Trailer and this DDU Header
-              fWARNING[0]=true;
-              bWARNING|=0x1;
+        // Part of work for chambers that hasn't been done in absent trailer
+        if (fDMB_Header || fDMB_Trailer) {
+          fERROR[5] = true;
+          bERROR |= 0x20;
+          // Since here there are no chances to know what this chamber was, force it to be -2
+          if (currentChamber == -1)
+            currentChamber = -2;
+          fCHAMB_ERR[5].insert(currentChamber);
+          bCHAMB_ERR[currentChamber] |= 0x20;
+          fCHAMB_ERR[0].insert(currentChamber);
+          bCHAMB_ERR[currentChamber] |= 0x1;
 #ifdef LOCAL_UNPACK
-              CERR<<"\nDDU Header Occurrence = "<<cntDDU_Headers;
-              CERR<<"  WARNING 0 "<<sWARNING[0]<<" "<<DDU_WordsSinceLastTrailer<<" extra 64-bit words"<<endl;
+          CERR << "\n\nDDU Header Occurrence = " << cntDDU_Headers;
+          CERR << "  ERROR 5    " << sERROR[5] << endl;
 #endif
-            }
+        }  // One of DMB Trailers is missing ( or both )
+        fDMB_Header = false;
+        fDMB_Trailer = false;
 
-          sourceID      = ((buf_1[1]&0xF)<<8) | ((buf_1[0]&0xFF00)>>8);
-
-          ///* 2013 Data format version check
-          DDU_Firmware_Revision    = (buf_1[0] >> 4) & 0xF;
-          if (DDU_Firmware_Revision > 6)
-            {
-              fFormat2013 = true;
-              modeDDUonly = true; // =VB= Force to use DDU only mode (no DCC Data)
-            }
-
-          fDDU_Header   = true;
-          fDDU_Trailer  = false;
-          DDU_WordCount = 0;
-          fDMB_Header   = false;
-          fDMB_Trailer  = false;
-          fALCT_Header  = false;
-          fALCT_Format2007= true;
-          fTMB_Header   = false;
-          fTMB_Format2007= true;
-          uniqueALCT    = true;
-          uniqueTMB     = true;
-          zeroCounts();
-
-          if (modeDDUonly)
-            {
-              fDCC_Header  = true;
-              clear();
-            }
-
-          dduBuffers[sourceID] = buf_1;
-          dduOffsets[sourceID] = buf_1-buffer_start;
-          dduSize   [sourceID] = 0;
-          dmbBuffers[sourceID].clear();
-          dmbOffsets[sourceID].clear();
-          dmbSize   [sourceID].clear();
-
-          // Reset all Error and Warning flags to be false
-          bDDU_ERR[sourceID] = 0;
-          bDDU_WRN[sourceID] = 0;
-          bERROR             = 0;
-          bWARNING           = 0;
-          bzero(fERROR,   sizeof(bool)*nERRORS);
-          bzero(fWARNING, sizeof(bool)*nWARNINGS);
-
-          nDMBs      = 0;
-          DMB_Active = buf1[0]&0xF;
-          DAV_DMB    = buf1[1]&0x7FFF;
-
-          int nDAV_DMBs=0;
-          for(int bit=0; bit<15; bit++) if( DAV_DMB&(1<<bit) ) nDAV_DMBs++;
-          if(DMB_Active!=nDAV_DMBs)
-            {
-              fERROR[27] = true;
-              bERROR    |= 0x8000000;
-            }
-
-          if( (buf_1[3]&0xF000)!=0x5000 )
-            {
-              fWARNING[1]=true;
-              bWARNING|=0x2;
-#ifdef LOCAL_UNPACK
-              CERR<<"\nDDU Header Occurrence = "<<cntDDU_Headers;
-              CERR<<"  WARNING 1 "<<sWARNING[1]<<". What must have been Header 1: 0x"<<std::hex<<buf_1[0]<<" 0x"<<buf_1[1]<<" 0x"<<buf_1[2]<<" 0x"<<buf_1[3]<<std::dec<<endl;
-#endif
-            }
-
-          ++cntDDU_Headers;
-          DDU_WordsSinceLastHeader=0; // Reset counter of DDU Words since last DDU Header
-#ifdef LOCAL_UNPACK
-          COUT<<"\n----------------------------------------------------------"<<endl;
-          COUT<<"DDU  Header Occurrence "<<cntDDU_Headers<< " L1A = " << ( ((buf_1[2]&0xFFFF) + ((buf_1[3]&0x00FF) << 16)) ) <<endl;
-#endif
-
+        if (DMB_Active != nDMBs) {
+          fERROR[24] = true;
+          bERROR |= 0x1000000;
         }
+        DMB_Active = 0;
+        nDMBs = 0;
 
-      // == DMB Header found
-      if( (buf0[0]&0xF000)==0xA000 && (buf0[1]&0xF000)==0xA000 && (buf0[2]&0xF000)==0xA000 && (buf0[3]&0xF000)==0xA000 )
-        {
-/////////////////////////////////////////////////////////
-          checkDAVs();
-          checkTriggerHeadersAndTrailers();
-/////////////////////////////////////////////////////////
+        // Unknown chamber denoted as -2
+        // If it still remains in any of errors - put it in error 0
+        for (int err = 1; err < nERRORS; ++err)
+          if (fCHAMB_ERR[err].find(-2) != fCHAMB_ERR[err].end()) {
+            fCHAMB_ERR[0].insert(-2);
+            bCHAMB_ERR[-2] |= 0x1;
+          }
 
-          if( DDU_WordsSinceLastHeader>3 && !fDMB_Header && !fDMB_Trailer && !nDMBs )
-            {
-              fERROR[28]=true;
-              bERROR|=0x10000000;;
-            }
+        bDDU_ERR[sourceID] |= bERROR;
+        bDDU_WRN[sourceID] |= bWARNING;
 
-          if( fDMB_Header || fDMB_Trailer )  // F or E  DMB Trailer is missed
-            {
-              fERROR[5]=true;
-              bERROR|=0x20;
-              fCHAMB_ERR[5].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x20;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-            }
-          fDMB_Header  = true;
-          fDMB_Trailer = false;
+        // go backward for 3 DDU words ( buf2, buf1, and buf0 )
+        buffer -= 12;
+        buf_1 = &(tmpbuf[0]);  // Just for safety
+        buf0 = &(tmpbuf[4]);   // Just for safety
+        buf1 = &(tmpbuf[8]);   // Just for safety
+        buf2 = &(tmpbuf[12]);  // Just for safety
+        bzero(tmpbuf, sizeof(uint16_t) * 16);
+        sync_stats();
+        return length + 12;
+      }
 
-          // If previous DMB record was not assigned to any chamber ( it still has -1 indentificator )
-          // let's free -1 identificator for current use and call undefined chamber from previous record -2
-          // ( -2 may already exists in this sets but we have nothing to do with it )
-          for(int err=0; err<nERRORS; ++err)
-            if( fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end() )
-              {
-                fCHAMB_ERR[err].erase(-1);
-                fCHAMB_ERR[err].insert(-2);
-              }
-// Two lines below are commented out because payloads never get filled if 0xA header is missing
-//      bCHAMB_PAYLOAD[-2] |= bCHAMB_PAYLOAD[-1];
-//      fCHAMB_PAYLOAD[-1] = 0;
-          bCHAMB_STATUS[-2] |= bCHAMB_STATUS[-1];
-          bCHAMB_STATUS[-1] = 0;
-          bCHAMB_ERR[-2] |= bCHAMB_ERR[-1];
-          bCHAMB_ERR[-1] = 0;
-          bCHAMB_WRN[-2] |= bCHAMB_WRN[-1];
-          bCHAMB_WRN[-1] = 0;
+      currentChamber = -1;  // Unknown yet
 
-          // Chamber id ( DMB_ID + (DMB_CRATE<<4) ) from header
-          currentChamber = buf0[1]&0x0FFF;
-          ++cntCHAMB_Headers[currentChamber];
-          bCHAMB_ERR[currentChamber] |= 0; //Victor's line
+      if (fDDU_Trailer && DDU_WordsSinceLastTrailer != 4) {
+        // == Counted extraneous words between last DDU Trailer and this DDU Header
+        fWARNING[0] = true;
+        bWARNING |= 0x1;
+#ifdef LOCAL_UNPACK
+        CERR << "\nDDU Header Occurrence = " << cntDDU_Headers;
+        CERR << "  WARNING 0 " << sWARNING[0] << " " << DDU_WordsSinceLastTrailer << " extra 64-bit words" << endl;
+#endif
+      }
 
-          fALCT_Header = false;
-          fALCT_Format2007= true;
-          fTMB_Header  = false;
-          fTMB_Format2007= true;
-          uniqueALCT   = true;
-          uniqueTMB    = true;
+      sourceID = ((buf_1[1] & 0xF) << 8) | ((buf_1[0] & 0xFF00) >> 8);
 
-          fTMB_MiniScope_Start = false;
-          fTMB_RPC_Start = false;
-          fTMB_BlockedCFEBs_Start = false;
+      ///* 2013 Data format version check
+      DDU_Firmware_Revision = (buf_1[0] >> 4) & 0xF;
+      if (DDU_Firmware_Revision > 6) {
+        fFormat2013 = true;
+        modeDDUonly = true;  // =VB= Force to use DDU only mode (no DCC Data)
+      }
 
-          fTMB_MiniScope = false;
-          fTMB_RPC = false;
-          fTMB_BlockedCFEBs = false;
+      fDDU_Header = true;
+      fDDU_Trailer = false;
+      DDU_WordCount = 0;
+      fDMB_Header = false;
+      fDMB_Trailer = false;
+      fALCT_Header = false;
+      fALCT_Format2007 = true;
+      fTMB_Header = false;
+      fTMB_Format2007 = true;
+      uniqueALCT = true;
+      uniqueTMB = true;
+      zeroCounts();
 
+      if (modeDDUonly) {
+        fDCC_Header = true;
+        clear();
+      }
 
-          zeroCounts();
-          CFEB_CRC                  = 0;
+      dduBuffers[sourceID] = buf_1;
+      dduOffsets[sourceID] = buf_1 - buffer_start;
+      dduSize[sourceID] = 0;
+      dmbBuffers[sourceID].clear();
+      dmbOffsets[sourceID].clear();
+      dmbSize[sourceID].clear();
 
-          nDMBs++;
+      // Reset all Error and Warning flags to be false
+      bDDU_ERR[sourceID] = 0;
+      bDDU_WRN[sourceID] = 0;
+      bERROR = 0;
+      bWARNING = 0;
+      bzero(fERROR, sizeof(bool) * nERRORS);
+      bzero(fWARNING, sizeof(bool) * nWARNINGS);
 
-          dmbBuffers[sourceID][currentChamber] = buf0-4;
-          dmbOffsets[sourceID][currentChamber] = buf0-4-buffer_start;
-          dmbSize   [sourceID][currentChamber] = 4;
+      nDMBs = 0;
+      DMB_Active = buf1[0] & 0xF;
+      DAV_DMB = buf1[1] & 0x7FFF;
+
+      int nDAV_DMBs = 0;
+      for (int bit = 0; bit < 15; bit++)
+        if (DAV_DMB & (1 << bit))
+          nDAV_DMBs++;
+      if (DMB_Active != nDAV_DMBs) {
+        fERROR[27] = true;
+        bERROR |= 0x8000000;
+      }
+
+      if ((buf_1[3] & 0xF000) != 0x5000) {
+        fWARNING[1] = true;
+        bWARNING |= 0x2;
+#ifdef LOCAL_UNPACK
+        CERR << "\nDDU Header Occurrence = " << cntDDU_Headers;
+        CERR << "  WARNING 1 " << sWARNING[1] << ". What must have been Header 1: 0x" << std::hex << buf_1[0] << " 0x"
+             << buf_1[1] << " 0x" << buf_1[2] << " 0x" << buf_1[3] << std::dec << endl;
+#endif
+      }
+
+      ++cntDDU_Headers;
+      DDU_WordsSinceLastHeader = 0;  // Reset counter of DDU Words since last DDU Header
+#ifdef LOCAL_UNPACK
+      COUT << "\n----------------------------------------------------------" << endl;
+      COUT << "DDU  Header Occurrence " << cntDDU_Headers
+           << " L1A = " << (((buf_1[2] & 0xFFFF) + ((buf_1[3] & 0x00FF) << 16))) << endl;
+#endif
+    }
+
+    // == DMB Header found
+    if ((buf0[0] & 0xF000) == 0xA000 && (buf0[1] & 0xF000) == 0xA000 && (buf0[2] & 0xF000) == 0xA000 &&
+        (buf0[3] & 0xF000) == 0xA000) {
+      /////////////////////////////////////////////////////////
+      checkDAVs();
+      checkTriggerHeadersAndTrailers();
+      /////////////////////////////////////////////////////////
+
+      if (DDU_WordsSinceLastHeader > 3 && !fDMB_Header && !fDMB_Trailer && !nDMBs) {
+        fERROR[28] = true;
+        bERROR |= 0x10000000;
+        ;
+      }
+
+      if (fDMB_Header || fDMB_Trailer)  // F or E  DMB Trailer is missed
+      {
+        fERROR[5] = true;
+        bERROR |= 0x20;
+        fCHAMB_ERR[5].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x20;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+      }
+      fDMB_Header = true;
+      fDMB_Trailer = false;
+
+      // If previous DMB record was not assigned to any chamber ( it still has -1 indentificator )
+      // let's free -1 identificator for current use and call undefined chamber from previous record -2
+      // ( -2 may already exists in this sets but we have nothing to do with it )
+      for (int err = 0; err < nERRORS; ++err)
+        if (fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end()) {
+          fCHAMB_ERR[err].erase(-1);
+          fCHAMB_ERR[err].insert(-2);
+        }
+      // Two lines below are commented out because payloads never get filled if 0xA header is missing
+      //      bCHAMB_PAYLOAD[-2] |= bCHAMB_PAYLOAD[-1];
+      //      fCHAMB_PAYLOAD[-1] = 0;
+      bCHAMB_STATUS[-2] |= bCHAMB_STATUS[-1];
+      bCHAMB_STATUS[-1] = 0;
+      bCHAMB_ERR[-2] |= bCHAMB_ERR[-1];
+      bCHAMB_ERR[-1] = 0;
+      bCHAMB_WRN[-2] |= bCHAMB_WRN[-1];
+      bCHAMB_WRN[-1] = 0;
+
+      // Chamber id ( DMB_ID + (DMB_CRATE<<4) ) from header
+      currentChamber = buf0[1] & 0x0FFF;
+      ++cntCHAMB_Headers[currentChamber];
+      bCHAMB_ERR[currentChamber] |= 0;  //Victor's line
+
+      fALCT_Header = false;
+      fALCT_Format2007 = true;
+      fTMB_Header = false;
+      fTMB_Format2007 = true;
+      uniqueALCT = true;
+      uniqueTMB = true;
+
+      fTMB_MiniScope_Start = false;
+      fTMB_RPC_Start = false;
+      fTMB_BlockedCFEBs_Start = false;
+
+      fTMB_MiniScope = false;
+      fTMB_RPC = false;
+      fTMB_BlockedCFEBs = false;
+
+      zeroCounts();
+      CFEB_CRC = 0;
+
+      nDMBs++;
+
+      dmbBuffers[sourceID][currentChamber] = buf0 - 4;
+      dmbOffsets[sourceID][currentChamber] = buf0 - 4 - buffer_start;
+      dmbSize[sourceID][currentChamber] = 4;
 
 #ifdef LOCAL_UNPACK
-          // Print DMB_ID from DMB Header
-          COUT<< "Crate=" << setw(3) << setfill('0') << ((buf0[1]>>4)&0x00FF) << " DMB="<<setw(2)<<setfill('0')<<(buf0[1]&0x000F)<<" ";
-          // Print ALCT_DAV and TMB_DAV from DMB Header
-          //COUT<<setw(1)<<((buf0[0]&0x0020)>>5)<<" "<<((buf0[0]&0x0040)>>6)<<" ";
-          COUT<<setw(1)<<((buf0[0]&0x0200)>>9)<<" "<<((buf0[0]&0x0800)>>11)<<" "; //change of format 16.09.05
-          // Print CFEB_DAV from DMB Header
-          COUT<<setw(1)<<((buf0[0]&0x0010)>>4)<<((buf0[0]&0x0008)>>3)<<((buf0[0]&0x0004)>>2)<<((buf0[0]&0x0002)>>1)<<(buf0[0]&0x0001);
-          // Print DMB Header Tag
-          COUT << " {";
+      // Print DMB_ID from DMB Header
+      COUT << "Crate=" << setw(3) << setfill('0') << ((buf0[1] >> 4) & 0x00FF) << " DMB=" << setw(2) << setfill('0')
+           << (buf0[1] & 0x000F) << " ";
+      // Print ALCT_DAV and TMB_DAV from DMB Header
+      //COUT<<setw(1)<<((buf0[0]&0x0020)>>5)<<" "<<((buf0[0]&0x0040)>>6)<<" ";
+      COUT << setw(1) << ((buf0[0] & 0x0200) >> 9) << " " << ((buf0[0] & 0x0800) >> 11)
+           << " ";  //change of format 16.09.05
+      // Print CFEB_DAV from DMB Header
+      COUT << setw(1) << ((buf0[0] & 0x0010) >> 4) << ((buf0[0] & 0x0008) >> 3) << ((buf0[0] & 0x0004) >> 2)
+           << ((buf0[0] & 0x0002) >> 1) << (buf0[0] & 0x0001);
+      // Print DMB Header Tag
+      COUT << " {";
 #endif
 
-          if (fFormat2013) /// 2013 Data format
-            {
+      if (fFormat2013)  /// 2013 Data format
+      {
+        // Set variables if we are waiting ALCT, TMB and CFEB records to be present in event
+        DAV_ALCT = (buf0[0] & 0x0800) >> 11;
+        DAV_TMB = (buf0[0] & 0x0400) >> 10;
+        DAV_CFEB = 0;
+        if (buf0[0] & 0x0001)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0002)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0004)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0008)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0010)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0020)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0040)
+          ++DAV_CFEB;
+        if (DAV_ALCT)
+          bCHAMB_PAYLOAD[currentChamber] |= 0x20;
+        if (DAV_TMB)
+          bCHAMB_PAYLOAD[currentChamber] |= 0x40;
 
-              // Set variables if we are waiting ALCT, TMB and CFEB records to be present in event
-              DAV_ALCT = (buf0[0]&0x0800)>>11;
-              DAV_TMB  = (buf0[0]&0x0400)>>10;
-              DAV_CFEB = 0;
-              if( buf0[0]&0x0001 ) ++DAV_CFEB;
-              if( buf0[0]&0x0002 ) ++DAV_CFEB;
-              if( buf0[0]&0x0004 ) ++DAV_CFEB;
-              if( buf0[0]&0x0008 ) ++DAV_CFEB;
-              if( buf0[0]&0x0010 ) ++DAV_CFEB;
-              if( buf0[0]&0x0020 ) ++DAV_CFEB;
-              if( buf0[0]&0x0040 ) ++DAV_CFEB;
-              if( DAV_ALCT ) bCHAMB_PAYLOAD[currentChamber] |= 0x20;
-              if( DAV_TMB  ) bCHAMB_PAYLOAD[currentChamber] |= 0x40;
+        /// Moved around 7 CFEBs Active and CFEB DAV payload bits to be compatible with 5 CFEBs version
+        bCHAMB_PAYLOAD[currentChamber] |= (buf0[0] & 0x007f) << 7;           /// CFEBs DAV
+        bCHAMB_PAYLOAD[currentChamber] |= (buf_1[2] & 0x001f);               /// CFEBs Active 5
+        bCHAMB_PAYLOAD[currentChamber] |= ((buf_1[2] >> 5) & 0x0003) << 14;  /// CFEBs Active 6,7
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0080) << 15;           /// CLCT-DAV-Mismatch
 
-              /// Moved around 7 CFEBs Active and CFEB DAV payload bits to be compatible with 5 CFEBs version
-              bCHAMB_PAYLOAD[currentChamber] |= (buf0[0]&0x007f)<<7; 		/// CFEBs DAV
-              bCHAMB_PAYLOAD[currentChamber] |= (buf_1[2]&0x001f); 		/// CFEBs Active 5
-              bCHAMB_PAYLOAD[currentChamber] |= ((buf_1[2]>>5)&0x0003)<<14;   /// CFEBs Active 6,7
-              bCHAMB_STATUS [currentChamber] |= (buf0[0]&0x0080)<<15;		/// CLCT-DAV-Mismatch
+      } else  /// Pre-2013 DMB Format
+      {
+        // Set variables if we are waiting ALCT, TMB and CFEB records to be present in event
+        DAV_ALCT = (buf0[0] & 0x0200) >> 9;
+        DAV_TMB = (buf0[0] & 0x0800) >> 11;
+        DAV_CFEB = 0;
+        if (buf0[0] & 0x0001)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0002)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0004)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0008)
+          ++DAV_CFEB;
+        if (buf0[0] & 0x0010)
+          ++DAV_CFEB;
+        if (DAV_ALCT)
+          bCHAMB_PAYLOAD[currentChamber] |= 0x20;
+        if (DAV_TMB)
+          bCHAMB_PAYLOAD[currentChamber] |= 0x40;
+        bCHAMB_PAYLOAD[currentChamber] |= (buf0[0] & 0x001f) << 7;
+        bCHAMB_PAYLOAD[currentChamber] |= ((buf_1[2] >> 5) & 0x001f);
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0040) << 15;
+      }
+    }
 
-            }
-          else     /// Pre-2013 DMB Format
-            {
+    // New ALCT data format:
+    if ((buf0[0] == 0xDB0A && (buf0[1] & 0xF000) == 0xD000 && (buf0[2] & 0xF000) == 0xD000 &&
+         (buf0[3] & 0xF000) == 0xD000) &&
+        ((buf_1[0] & 0xF000) == 0xA000 && (buf_1[1] & 0xF000) == 0xA000 && (buf_1[2] & 0xF000) == 0xA000 &&
+         (buf_1[3] & 0xF000) == 0xA000)) {
+      fALCT_Header = true;
+      fALCT_Format2007 = true;
+      ALCT_CRC = 0;
+      ALCT_WordsSinceLastHeader = 4;
+      ALCT_WordsSinceLastHeaderZeroSuppressed = 4;
 
-              // Set variables if we are waiting ALCT, TMB and CFEB records to be present in event
-              DAV_ALCT = (buf0[0]&0x0200)>>9;
-              DAV_TMB  = (buf0[0]&0x0800)>>11;
-              DAV_CFEB = 0;
-              if( buf0[0]&0x0001 ) ++DAV_CFEB;
-              if( buf0[0]&0x0002 ) ++DAV_CFEB;
-              if( buf0[0]&0x0004 ) ++DAV_CFEB;
-              if( buf0[0]&0x0008 ) ++DAV_CFEB;
-              if( buf0[0]&0x0010 ) ++DAV_CFEB;
-              if( DAV_ALCT ) bCHAMB_PAYLOAD[currentChamber] |= 0x20;
-              if( DAV_TMB  ) bCHAMB_PAYLOAD[currentChamber] |= 0x40;
-              bCHAMB_PAYLOAD[currentChamber] |= (buf0[0]&0x001f)<<7;
-              bCHAMB_PAYLOAD[currentChamber] |=((buf_1[2]>>5)&0x001f);
-              bCHAMB_STATUS [currentChamber] |= (buf0[0]&0x0040)<<15;
-            }
+      // Calculate expected number of ALCT words
+      ALCT_WordsExpected = 12;  // header and trailer always exists
 
+      //  Aauxilary variables
+      //   number of wire groups per layer:
+      int nWGs_per_layer = ((buf1[2] & 0x0007) + 1) * 16;
+      // words in the layer
+      nWG_round_up = int(nWGs_per_layer / 12) + (nWGs_per_layer % 3 ? 1 : 0);
+      //   configuration present:
+      bool config_present = buf1[0] & 0x4000;
+      //   lct overflow:
+      bool lct_overflow = buf1[0] & 0x2000;
+      //   raw overflow:
+      bool raw_overflow = buf1[0] & 0x1000;
+      //   l1a_window:
+      int lct_tbins = (buf1[3] & 0x01E0) >> 5;
+      //   fifo_tbins:
+      int raw_tbins = (buf1[3] & 0x001F);
+
+      ///   Check if ALCT zero suppression enable:
+      ALCT_ZSE = (buf1[1] & 0x1000) >> 12;
+
+      if (ALCT_ZSE) {
+        for (int g = 0; g < 4; g++) {
+          if (buf1[g] == 0x1000)
+            ALCT_WordsSinceLastHeader -= (nWG_round_up - 1);
         }
-
-
-      // New ALCT data format:
-      if( ( buf0[0]==0xDB0A && (buf0[1]&0xF000)==0xD000 && (buf0[2]&0xF000)==0xD000 && (buf0[3]&0xF000)==0xD000)
-          &&
-          ( (buf_1[0]&0xF000)==0xA000 && (buf_1[1]&0xF000)==0xA000 && (buf_1[2]&0xF000)==0xA000 && (buf_1[3]&0xF000)==0xA000 ) )
-        {
-          fALCT_Header              = true;
-          fALCT_Format2007          = true;
-          ALCT_CRC                  = 0;
-          ALCT_WordsSinceLastHeader = 4;
-          ALCT_WordsSinceLastHeaderZeroSuppressed = 4;
-
-          // Calculate expected number of ALCT words
-          ALCT_WordsExpected = 12; // header and trailer always exists
-
-          //  Aauxilary variables
-          //   number of wire groups per layer:
-          int  nWGs_per_layer = ( (buf1[2]&0x0007) + 1 ) * 16 ;
-          // words in the layer
-          nWG_round_up   = int(nWGs_per_layer/12)+(nWGs_per_layer%3?1:0);
-          //   configuration present:
-          bool config_present =  buf1[0]&0x4000;
-          //   lct overflow:
-          bool lct_overflow   =  buf1[0]&0x2000;
-          //   raw overflow:
-          bool raw_overflow   =  buf1[0]&0x1000;
-          //   l1a_window:
-          int  lct_tbins      = (buf1[3]&0x01E0)>>5;
-          //   fifo_tbins:
-          int  raw_tbins      = (buf1[3]&0x001F);
-
-          ///   Check if ALCT zero suppression enable:
-          ALCT_ZSE            = (buf1[1]&0x1000)>>12;
-
-          if (ALCT_ZSE)
-            {
-              for (int g=0; g<4; g++)
-                {
-                  if (buf1[g]==0x1000) ALCT_WordsSinceLastHeader -= (nWG_round_up - 1);
-                }
-            }
+      }
 #ifdef LOCAL_UNPACK
 //        COUT << " Number of Wire Groups: " << nWG_round_up << std::endl;
 ///       COUT << " ALCT_ZSE: " << ALCT_ZSE << std::endl;
@@ -752,699 +735,632 @@ int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
 //        COUT << " LCT Tbins: " << lct_tbins << std::endl;
 #endif
 
-          //  Data block sizes:
-          //   3 words of Vertex ID register + 5 words of config. register bits:
-          int config_size    = ( config_present ? 3 + 5 : 0 );
-          //   collision mask register:
-          int colreg_size    = ( config_present ? nWGs_per_layer/4 : 0 );
-          //   hot channel mask:
-          int hot_ch_size    = ( config_present ? nWG_round_up*6 : 0 );
-          //   ALCT0,1 (best tracks):
-          int alct_0_1_size  = ( !lct_overflow ? 2*lct_tbins : 0 );
-          //   raw hit dump size:
-          int raw_hit_dump_size=(!raw_overflow ? nWG_round_up*6*raw_tbins : 0 );
+      //  Data block sizes:
+      //   3 words of Vertex ID register + 5 words of config. register bits:
+      int config_size = (config_present ? 3 + 5 : 0);
+      //   collision mask register:
+      int colreg_size = (config_present ? nWGs_per_layer / 4 : 0);
+      //   hot channel mask:
+      int hot_ch_size = (config_present ? nWG_round_up * 6 : 0);
+      //   ALCT0,1 (best tracks):
+      int alct_0_1_size = (!lct_overflow ? 2 * lct_tbins : 0);
+      //   raw hit dump size:
+      int raw_hit_dump_size = (!raw_overflow ? nWG_round_up * 6 * raw_tbins : 0);
 
 #ifdef LOCAL_UNPACK
-          // COUT << " Raw Hit Dump: " << std::dec << raw_hit_dump_size << std::endl;
+      // COUT << " Raw Hit Dump: " << std::dec << raw_hit_dump_size << std::endl;
 #endif
 
-          ALCT_WordsExpected += config_size + colreg_size + hot_ch_size + alct_0_1_size + raw_hit_dump_size;
+      ALCT_WordsExpected += config_size + colreg_size + hot_ch_size + alct_0_1_size + raw_hit_dump_size;
 
 #ifdef LOCAL_UNPACK
-          COUT<<" <A";
+      COUT << " <A";
 #endif
 
+    } else {
+      // Old ALCT data format
+
+      // == ALCT Header found right after DMB Header
+      //   (check for all currently reserved/fixed bits in ALCT first 4 words)
+      // if( ( (buf0 [0]&0xF800)==0x6000 && (buf0 [1]&0xFF80)==0x0080 && (buf0 [2]&0xF000)==0x0000 && (buf0 [3]&0xc000)==0x0000 )
+      if (((buf0[0] & 0xF800) == 0x6000 && (buf0[1] & 0x8F80) == 0x0080 && (buf0[2] & 0x8000) == 0x0000 &&
+           (buf0[3] & 0xc000) == 0x0000) &&
+          ((buf_1[0] & 0xF000) == 0xA000 && (buf_1[1] & 0xF000) == 0xA000 && (buf_1[2] & 0xF000) == 0xA000 &&
+           (buf_1[3] & 0xF000) == 0xA000)) {
+        fALCT_Header = true;
+        fALCT_Format2007 = false;
+        ALCT_CRC = 0;
+        ALCT_WordsSinceLastHeader = 4;
+
+        // Calculate expected number of ALCT words
+        if ((buf0[3] & 0x0003) == 0) {
+          ALCT_WordsExpected = 12;  // Short Readout
         }
-      else
+
+        if ((buf0[1] & 0x0003) == 1)  // Full Readout
         {
-          // Old ALCT data format
-
-          // == ALCT Header found right after DMB Header
-          //   (check for all currently reserved/fixed bits in ALCT first 4 words)
-          // if( ( (buf0 [0]&0xF800)==0x6000 && (buf0 [1]&0xFF80)==0x0080 && (buf0 [2]&0xF000)==0x0000 && (buf0 [3]&0xc000)==0x0000 )
-          if( ( (buf0 [0]&0xF800)==0x6000 && (buf0 [1]&0x8F80)==0x0080 && (buf0 [2]&0x8000)==0x0000 && (buf0 [3]&0xc000)==0x0000 )
-              &&
-              ( (buf_1[0]&0xF000)==0xA000 && (buf_1[1]&0xF000)==0xA000 && (buf_1[2]&0xF000)==0xA000 && (buf_1[3]&0xF000)==0xA000 ) )
-            {
-              fALCT_Header              = true;
-              fALCT_Format2007          = false;
-              ALCT_CRC                  = 0;
-              ALCT_WordsSinceLastHeader = 4;
-
-              // Calculate expected number of ALCT words
-              if( (buf0[3]&0x0003)==0 )
-                {
-                  ALCT_WordsExpected = 12;  // Short Readout
-                }
-
-              if( (buf0[1]&0x0003)==1 )  					// Full Readout
-                {
-                  ALCT_WordsExpected = ((buf0[1]&0x007c) >> 2) *
-                                       ( ((buf0[3]&0x0001)   )+((buf0[3]&0x0002)>>1)+
-                                         ((buf0[3]&0x0004)>>2)+((buf0[3]&0x0008)>>3)+
-                                         ((buf0[3]&0x0010)>>4)+((buf0[3]&0x0020)>>5)+
-                                         ((buf0[3]&0x0040)>>6) ) * 12 + 12;
-                }
-#ifdef LOCAL_UNPACK
-              COUT<<" <A";
-#endif
-            }
+          ALCT_WordsExpected = ((buf0[1] & 0x007c) >> 2) *
+                                   (((buf0[3] & 0x0001)) + ((buf0[3] & 0x0002) >> 1) + ((buf0[3] & 0x0004) >> 2) +
+                                    ((buf0[3] & 0x0008) >> 3) + ((buf0[3] & 0x0010) >> 4) + ((buf0[3] & 0x0020) >> 5) +
+                                    ((buf0[3] & 0x0040) >> 6)) *
+                                   12 +
+                               12;
         }
 #ifdef LOCAL_UNPACK
-      //COUT << " ALCT Word Expected: " << ALCT_WordsExpected << std::endl;
+        COUT << " <A";
+#endif
+      }
+    }
+#ifdef LOCAL_UNPACK
+    //COUT << " ALCT Word Expected: " << ALCT_WordsExpected << std::endl;
 #endif
 
-      if( (buf0[0]&0xFFFF)==0xDB0C )
-        {
+    if ((buf0[0] & 0xFFFF) == 0xDB0C) {
+      // =VB= Handles one of the OTMB corrupted data cases.
+      //      Double TMB data block with 2nd TMB Header is found.
+      //      Set missing TMB Trailer error.
+      if (fTMB_Header) {
+        fERROR[12] = true;  // TMB Trailer is missing
+        bERROR |= 0x1000;
+        fCHAMB_ERR[12].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1000;
+      }
 
-	  // =VB= Handles one of the OTMB corrupted data cases.
-	  //      Double TMB data block with 2nd TMB Header is found. 
-	  //      Set missing TMB Trailer error.
-	  if (fTMB_Header) {
-             fERROR[12]=true;        // TMB Trailer is missing
-             bERROR   |= 0x1000;
-             fCHAMB_ERR[12].insert(currentChamber);
-             bCHAMB_ERR[currentChamber] |= 0x1000;
-          }
+      fTMB_Header = true;
+      fTMB_Format2007 = true;
+      TMB_CRC = 0;
+      TMB_WordsSinceLastHeader = 4;
+      TMB_WordsExpected = 0;
 
-          fTMB_Header              = true;
-          fTMB_Format2007          = true;
-          TMB_CRC                  = 0;
-          TMB_WordsSinceLastHeader = 4;
-          TMB_WordsExpected = 0;
-
-          // Calculate expected number of TMB words (whether RPC included will be known later)
-          if ( (buf1[1]&0x3000) == 0x3000)
-            {
-              TMB_WordsExpected = 12;  // Short Header Only
-            }
-          if ( (buf1[1]&0x3000) == 0x0000)
-            {
-              TMB_WordsExpected = 48;  // Long Header Only
-            }
+      // Calculate expected number of TMB words (whether RPC included will be known later)
+      if ((buf1[1] & 0x3000) == 0x3000) {
+        TMB_WordsExpected = 12;  // Short Header Only
+      }
+      if ((buf1[1] & 0x3000) == 0x0000) {
+        TMB_WordsExpected = 48;  // Long Header Only
+      }
 
 #ifdef LOCAL_UNPACK
-          COUT << " <T";
+      COUT << " <T";
 #endif
+    } else {
+      // == TMB Header found right after DMB Header or right after ALCT Trailer
+      if ((buf0[0] & 0xFFFF) == 0x6B0C && (((buf_1[0] & 0xF000) == 0xA000 && (buf_1[1] & 0xF000) == 0xA000 &&
+                                            (buf_1[2] & 0xF000) == 0xA000 && (buf_1[3] & 0xF000) == 0xA000) ||
+                                           ((buf_1[0] & 0x0800) == 0x0000 && (buf_1[1] & 0xF800) == 0xD000 &&
+                                            (buf_1[2] & 0xFFFF) == 0xDE0D && (buf_1[3] & 0xF000) == 0xD000)
+                                           // should've been (buf_1[0]&0xF800)==0xD000 - see comments for sERROR[11]
+                                           )) {
+        //if( (buf_1[2]&0xFFFF)==0xDE0D && (buf_1[3]&0xFC00)!=0xD000 && summer2004 ) ???
+
+        fTMB_Header = true;
+        fTMB_Format2007 = false;
+        TMB_CRC = 0;
+        TMB_WordsSinceLastHeader = 4;
+
+        // Calculate expected number of TMB words (whether RPC included will be known later)
+        if ((buf0[1] & 0x3000) == 0x3000) {
+          TMB_WordsExpected = 8;  // Short Header Only
         }
-      else
-        {
-          // == TMB Header found right after DMB Header or right after ALCT Trailer
-          if(   (buf0 [0]&0xFFFF)==0x6B0C && (
-                  ( (buf_1[0]&0xF000)==0xA000 && (buf_1[1]&0xF000)==0xA000 && (buf_1[2]&0xF000)==0xA000 && (buf_1[3]&0xF000)==0xA000 )
-                  ||
-                  ( (buf_1[0]&0x0800)==0x0000 && (buf_1[1]&0xF800)==0xD000 && (buf_1[2]&0xFFFF)==0xDE0D && (buf_1[3]&0xF000)==0xD000 )
-                  // should've been (buf_1[0]&0xF800)==0xD000 - see comments for sERROR[11]
-                ) )
-            {
-              //if( (buf_1[2]&0xFFFF)==0xDE0D && (buf_1[3]&0xFC00)!=0xD000 && summer2004 ) ???
+        if ((buf0[1] & 0x3000) == 0x0000) {
+          TMB_WordsExpected = 32;  // Long Header Only
+        }
 
-              fTMB_Header              = true;
-              fTMB_Format2007          = false;
-              TMB_CRC                  = 0;
-              TMB_WordsSinceLastHeader = 4;
-
-              // Calculate expected number of TMB words (whether RPC included will be known later)
-              if ( (buf0[1]&0x3000) == 0x3000)
-                {
-                  TMB_WordsExpected = 8;  // Short Header Only
-                }
-              if ( (buf0[1]&0x3000) == 0x0000)
-                {
-                  TMB_WordsExpected = 32;  // Long Header Only
-                }
-
-              if ( (buf0[1]&0x3000) == 0x1000)
-                {
-                  // Full Readout   = 28 + (#Tbins * #CFEBs * 6)
-                  TMB_Tbins=(buf0[1]&0x001F);
-                  TMB_WordsExpected = 28 + TMB_Tbins * ((buf1[0]&0x00E0)>>5) * 6;
-                }
+        if ((buf0[1] & 0x3000) == 0x1000) {
+          // Full Readout   = 28 + (#Tbins * #CFEBs * 6)
+          TMB_Tbins = (buf0[1] & 0x001F);
+          TMB_WordsExpected = 28 + TMB_Tbins * ((buf1[0] & 0x00E0) >> 5) * 6;
+        }
 #ifdef LOCAL_UNPACK
-              COUT << " <T";
+        COUT << " <T";
 #endif
-            }
-        }
-      // New TMB format => very long header Find Firmware revision
-      if ( fTMB_Header && fTMB_Format2007 && TMB_WordsSinceLastHeader==8 )
-        {
-          TMB_Firmware_Revision = buf0[3];
-        }
+      }
+    }
+    // New TMB format => very long header Find Firmware revision
+    if (fTMB_Header && fTMB_Format2007 && TMB_WordsSinceLastHeader == 8) {
+      TMB_Firmware_Revision = buf0[3];
+    }
 
-      // New TMB format => very long header
-      if ( fTMB_Header && fTMB_Format2007 && TMB_WordsSinceLastHeader==20 )
-        {
-          // Full Readout   = 44 + (#Tbins * #CFEBs * 6)
-          TMB_Tbins=(buf0[3]&0x00F8)>>3;
-          TMB_WordsExpected = 44 + TMB_Tbins * (buf0[3]&0x0007) * 6;
-        }
+    // New TMB format => very long header
+    if (fTMB_Header && fTMB_Format2007 && TMB_WordsSinceLastHeader == 20) {
+      // Full Readout   = 44 + (#Tbins * #CFEBs * 6)
+      TMB_Tbins = (buf0[3] & 0x00F8) >> 3;
+      TMB_WordsExpected = 44 + TMB_Tbins * (buf0[3] & 0x0007) * 6;
+    }
 
-      // == ALCT Trailer found
-      if(
+    // == ALCT Trailer found
+    if (
         // New ALCT data format:
-        ( buf0[0]==0xDE0D && (buf0[1]&0xF800)==0xD000 && (buf0[2]&0xF800)==0xD000 && (buf0[3]&0xF000)==0xD000 && fALCT_Format2007 ) ||
+        (buf0[0] == 0xDE0D && (buf0[1] & 0xF800) == 0xD000 && (buf0[2] & 0xF800) == 0xD000 &&
+         (buf0[3] & 0xF000) == 0xD000 && fALCT_Format2007) ||
         // Old ALCT data format; last check is added to avoid confusion with new TMB header (may not be needed):
-        ( (buf0[0]&0x0800)==0x0000 && (buf0[1]&0xF800)==0xD000 && (buf0[2]&0xFFFF)==0xDE0D && (buf0[3]&0xF000)==0xD000 && !fALCT_Format2007 && !(fTMB_Header&&fTMB_Format2007) )
-      )
-        {
-          // should've been (buf0[0]&0xF800)==0xD000 - see comments for sERROR[11]
+        ((buf0[0] & 0x0800) == 0x0000 && (buf0[1] & 0xF800) == 0xD000 && (buf0[2] & 0xFFFF) == 0xDE0D &&
+         (buf0[3] & 0xF000) == 0xD000 && !fALCT_Format2007 && !(fTMB_Header && fTMB_Format2007))) {
+      // should've been (buf0[0]&0xF800)==0xD000 - see comments for sERROR[11]
 
-          // Second ALCT -> Lost both previous DMB Trailer and current DMB Header
-          if( !uniqueALCT ) currentChamber = -1;
-          // Check if this ALCT record have to exist according to DMB Header
-          if(   DAV_ALCT  ) DAV_ALCT = false;
-          else DAV_ALCT = true;
+      // Second ALCT -> Lost both previous DMB Trailer and current DMB Header
+      if (!uniqueALCT)
+        currentChamber = -1;
+      // Check if this ALCT record have to exist according to DMB Header
+      if (DAV_ALCT)
+        DAV_ALCT = false;
+      else
+        DAV_ALCT = true;
 
-          if( !fALCT_Header )
-            {
-              fERROR[8] = true;
-              bERROR   |= 0x100;
-              fCHAMB_ERR[8].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x100;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-            } // ALCT Header is missing
+      if (!fALCT_Header) {
+        fERROR[8] = true;
+        bERROR |= 0x100;
+        fCHAMB_ERR[8].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x100;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+      }  // ALCT Header is missing
 
-          if( !fALCT_Format2007 && (buf0[0]&0xF800)!=0xD000 )
-            {
-              fERROR[11] = true;
-              bERROR    |= 0x800;
-              fCHAMB_ERR[11].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x800;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-            } // some bits in 1st D-Trailer are lost
+      if (!fALCT_Format2007 && (buf0[0] & 0xF800) != 0xD000) {
+        fERROR[11] = true;
+        bERROR |= 0x800;
+        fCHAMB_ERR[11].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x800;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+      }  // some bits in 1st D-Trailer are lost
 
 #ifdef LOCAL_UNPACK
-          /// Print Out ALCT word counting
-          /*
+      /// Print Out ALCT word counting
+      /*
                 COUT << " ALCT Word Since Last Header: " << ALCT_WordsSinceLastHeader << std::endl;
                 COUT << " ALCT Word Expected: " << ALCT_WordsExpected << std::endl;
                 COUT << " ALCT Word Since Last Header Zero Supressed: " << ALCT_WordsSinceLastHeaderZeroSuppressed << std::endl;
           */
 #endif
-          /// Check calculated CRC sum against reported
-          if( checkCrcALCT )
-            {
-              uint32_t crc = ( fALCT_Format2007 ? buf0[1] : buf0[0] ) & 0x7ff;
-              crc |= ((uint32_t)( ( fALCT_Format2007 ? buf0[2] : buf0[1] ) & 0x7ff)) << 11;
-              if( ALCT_CRC != crc )
-                {
-                  fERROR[10] = true;
-                  bERROR   |= 0x400;
-                  fCHAMB_ERR[10].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x400;
-                  fCHAMB_ERR[0].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x1;
-                }
-            }
+      /// Check calculated CRC sum against reported
+      if (checkCrcALCT) {
+        uint32_t crc = (fALCT_Format2007 ? buf0[1] : buf0[0]) & 0x7ff;
+        crc |= ((uint32_t)((fALCT_Format2007 ? buf0[2] : buf0[1]) & 0x7ff)) << 11;
+        if (ALCT_CRC != crc) {
+          fERROR[10] = true;
+          bERROR |= 0x400;
+          fCHAMB_ERR[10].insert(currentChamber);
+          bCHAMB_ERR[currentChamber] |= 0x400;
+          fCHAMB_ERR[0].insert(currentChamber);
+          bCHAMB_ERR[currentChamber] |= 0x1;
+        }
+      }
 
-          fALCT_Header = false;
-          uniqueALCT   = false;
-          CFEB_CRC     = 0;
-          //ALCT_WordCount = (buf0[3]&0x03FF);
-          ALCT_WordCount = (buf0[3]&0x07FF);
-          //ALCT_WordCount = (buf0[3]&0x0FFF);
-          CFEB_SampleWordCount = 0;
+      fALCT_Header = false;
+      uniqueALCT = false;
+      CFEB_CRC = 0;
+      //ALCT_WordCount = (buf0[3]&0x03FF);
+      ALCT_WordCount = (buf0[3] & 0x07FF);
+      //ALCT_WordCount = (buf0[3]&0x0FFF);
+      CFEB_SampleWordCount = 0;
 #ifdef LOCAL_UNPACK
-          COUT << "A> ";
+      COUT << "A> ";
 #endif
-        }
+    }
 
-      // Calculation of CRC sum ( algorithm is written by Madorsky )
-      if( fALCT_Header && checkCrcALCT )
-        {
-          for(uint16_t j=0, w=0; j<4; ++j)
-            {
-              ///w = buf0[j] & 0x7fff;
-              w = buf0[j] & (fALCT_Format2007 ? 0xffff : 0x7fff);
-              for(uint32_t i=15, t=0, ncrc=0; i<16; i--)
-                {
-                  t = ((w >> i) & 1) ^ ((ALCT_CRC >> 21) & 1);
-                  ncrc = (ALCT_CRC << 1) & 0x3ffffc;
-                  ncrc |= (t ^ (ALCT_CRC & 1)) << 1;
-                  ncrc |= t;
-                  ALCT_CRC = ncrc;
-                }
-            }
+    // Calculation of CRC sum ( algorithm is written by Madorsky )
+    if (fALCT_Header && checkCrcALCT) {
+      for (uint16_t j = 0, w = 0; j < 4; ++j) {
+        ///w = buf0[j] & 0x7fff;
+        w = buf0[j] & (fALCT_Format2007 ? 0xffff : 0x7fff);
+        for (uint32_t i = 15, t = 0, ncrc = 0; i < 16; i--) {
+          t = ((w >> i) & 1) ^ ((ALCT_CRC >> 21) & 1);
+          ncrc = (ALCT_CRC << 1) & 0x3ffffc;
+          ncrc |= (t ^ (ALCT_CRC & 1)) << 1;
+          ncrc |= t;
+          ALCT_CRC = ncrc;
         }
+      }
+    }
 
-      // == Find Correction for TMB_WordsExpected due to RPC raw hits,
-      //    should it turn out to be the new RPC-aware format
-      if( fTMB_Header && ((buf0[2]&0xFFFF)==0x6E0B) )
-        {
-          if (fTMB_Format2007)
-            {
-	      /* Checks for TMB2007 firmware revisions ranges to detect data format
+    // == Find Correction for TMB_WordsExpected due to RPC raw hits,
+    //    should it turn out to be the new RPC-aware format
+    if (fTMB_Header && ((buf0[2] & 0xFFFF) == 0x6E0B)) {
+      if (fTMB_Format2007) {
+        /* Checks for TMB2007 firmware revisions ranges to detect data format
                * rev.0x50c3 - first revision with changed format 
                * rev.0x42D5 - oldest known from 06/21/2007
                * There is 4-bits year value rollover in revision number (0 in 2016)
                */
-              if ((TMB_Firmware_Revision >= 0x50c3) || (TMB_Firmware_Revision < 0x42D5))  
-                {
-                  // On/off * nRPCs * nTimebins * 2 words/RPC/bin
-                  TMB_WordsRPC = ((buf_1[0]&0x0010)>>4) * ((buf_1[0]&0x000c)>>2) * ((buf_1[0]>>5) & 0x1F) * 2;
-                }
-              else   // original TMB2007 data format (may not work since TMB_Tbins != RPC_Tbins)
-                {
-                  TMB_WordsRPC = ((buf_1[0]&0x0040)>>6) * ((buf_1[0]&0x0030)>>4) * TMB_Tbins * 2;
-                }
-            }
-          else   // Old format 2006
-            {
-              TMB_WordsRPC   = ((buf_1[2]&0x0040)>>6) * ((buf_1[2]&0x0030)>>4) * TMB_Tbins * 2;
-            }
-          TMB_WordsRPC += 2; // add header/trailer for block of RPC raw hits
-        }
-
-
-
-      // Check for RPC data
-      if ( fTMB_Header && (scanbuf(buf0,4, 0x6B04)>=0) )
+        if ((TMB_Firmware_Revision >= 0x50c3) || (TMB_Firmware_Revision < 0x42D5)) {
+          // On/off * nRPCs * nTimebins * 2 words/RPC/bin
+          TMB_WordsRPC = ((buf_1[0] & 0x0010) >> 4) * ((buf_1[0] & 0x000c) >> 2) * ((buf_1[0] >> 5) & 0x1F) * 2;
+        } else  // original TMB2007 data format (may not work since TMB_Tbins != RPC_Tbins)
         {
-          fTMB_RPC_Start = true;
+          TMB_WordsRPC = ((buf_1[0] & 0x0040) >> 6) * ((buf_1[0] & 0x0030) >> 4) * TMB_Tbins * 2;
         }
+      } else  // Old format 2006
+      {
+        TMB_WordsRPC = ((buf_1[2] & 0x0040) >> 6) * ((buf_1[2] & 0x0030) >> 4) * TMB_Tbins * 2;
+      }
+      TMB_WordsRPC += 2;  // add header/trailer for block of RPC raw hits
+    }
 
-      // Check for Mini-Scope data
-      if ( fTMB_Header && (scanbuf(buf0,4, 0x6B07)>=0) )
-        {
-          fTMB_MiniScope_Start = true;
-        }
+    // Check for RPC data
+    if (fTMB_Header && (scanbuf(buf0, 4, 0x6B04) >= 0)) {
+      fTMB_RPC_Start = true;
+    }
 
-      // Check for Blocked CFEBs data
-      if ( fTMB_Header && (scanbuf(buf0,4, 0x6BCB)>=0) )
-        {
-          fTMB_BlockedCFEBs_Start = true;
-        }
+    // Check for Mini-Scope data
+    if (fTMB_Header && (scanbuf(buf0, 4, 0x6B07) >= 0)) {
+      fTMB_MiniScope_Start = true;
+    }
 
+    // Check for Blocked CFEBs data
+    if (fTMB_Header && (scanbuf(buf0, 4, 0x6BCB) >= 0)) {
+      fTMB_BlockedCFEBs_Start = true;
+    }
 
-      // Check for end of RPC data
-      if ( fTMB_Header && fTMB_RPC_Start
-           && (scanbuf(buf0,4, 0x6E04)>=0) )
-        {
-          fTMB_RPC = true;
-        }
+    // Check for end of RPC data
+    if (fTMB_Header && fTMB_RPC_Start && (scanbuf(buf0, 4, 0x6E04) >= 0)) {
+      fTMB_RPC = true;
+    }
 
-      // Check for end of Mini-Scope data
-      if ( fTMB_Header && fTMB_MiniScope_Start
-           && (scanbuf(buf0,4, 0x6E07)>=0) )
-        {
-          fTMB_MiniScope = true;
-        }
+    // Check for end of Mini-Scope data
+    if (fTMB_Header && fTMB_MiniScope_Start && (scanbuf(buf0, 4, 0x6E07) >= 0)) {
+      fTMB_MiniScope = true;
+    }
 
-      // Check for end of Blocked CFEBs data
-      if ( fTMB_Header && fTMB_BlockedCFEBs_Start
-           && (scanbuf(buf0,4, 0x6ECB)>=0) )
-        {
-          fTMB_BlockedCFEBs = true;
-        }
+    // Check for end of Blocked CFEBs data
+    if (fTMB_Header && fTMB_BlockedCFEBs_Start && (scanbuf(buf0, 4, 0x6ECB) >= 0)) {
+      fTMB_BlockedCFEBs = true;
+    }
 
-      /*
+    /*
          if ( fTMB_Header && (scanbuf(buf0,4, 0x6E04)>=0) ) {
                TMB_WordsExpected += TMB_WordsRPC;
            }
       */
 
-      // == TMB Trailer found
-      if(
+    // == TMB Trailer found
+    if (
         // Old TMB data format; last condition in needed not to confuse if with new ALCT data header
-        ((buf0[0]&0xF000)==0xD000 && (buf0[1]&0xF000)==0xD000 && (buf0[2]&0xFFFF)==0xDE0F && (buf0[3]&0xF000)==0xD000 && !fTMB_Format2007 && !(fALCT_Header&&fALCT_Format2007)) ||
+        ((buf0[0] & 0xF000) == 0xD000 && (buf0[1] & 0xF000) == 0xD000 && (buf0[2] & 0xFFFF) == 0xDE0F &&
+         (buf0[3] & 0xF000) == 0xD000 && !fTMB_Format2007 && !(fALCT_Header && fALCT_Format2007)) ||
         // New TMB data format
-        ( buf0[0]==        0xDE0F && (buf0[1]&0xF000)==0xD000 && (buf0[2]&0xF000)==0xD000 && (buf0[3]&0xF000)==0xD000 &&  fTMB_Format2007 )
-      )
-        {
+        (buf0[0] == 0xDE0F && (buf0[1] & 0xF000) == 0xD000 && (buf0[2] & 0xF000) == 0xD000 &&
+         (buf0[3] & 0xF000) == 0xD000 && fTMB_Format2007)) {
+      // Second TMB -> Lost both previous DMB Trailer and current DMB Header
+      if (!uniqueTMB)
+        currentChamber = -1;
+      // Check if this TMB record have to exist according to DMB Header
+      if (DAV_TMB)
+        DAV_TMB = false;
+      else
+        DAV_TMB = true;
 
-          // Second TMB -> Lost both previous DMB Trailer and current DMB Header
-          if( !uniqueTMB ) currentChamber = -1;
-          // Check if this TMB record have to exist according to DMB Header
-          if(   DAV_TMB  ) DAV_TMB = false;
-          else DAV_TMB = true;
+      if (!fTMB_Header) {
+        fERROR[13] = true;
+        bERROR |= 0x2000;
+        fCHAMB_ERR[13].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x2000;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+      }  // TMB Header is missing
 
-          if(!fTMB_Header)
-            {
-              fERROR[13] = true;
-              bERROR    |= 0x2000;
-              fCHAMB_ERR[13].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x2000;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-            }  // TMB Header is missing
-
-          // Check calculated CRC sum against reported
-          if( checkCrcTMB )
-            {
-              uint32_t crc = ( fTMB_Format2007 ? buf0[1]&0x7ff : buf0[0]&0x7ff );
-              crc |= ((uint32_t)( ( fTMB_Format2007 ? buf0[2]&0x7ff : buf0[1] & 0x7ff ) )) << 11;
-              if( TMB_CRC != crc )
-                {
-                  fERROR[15] = true;
-                  bERROR    |= 0x8000;
-                  fCHAMB_ERR[15].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x8000;
-                  fCHAMB_ERR[0].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x1;
-                }
-            }
-
-          fTMB_Header = false;
-          uniqueTMB   = false;
-          CFEB_CRC     = 0;
-          TMB_WordCount = (buf0[3]&0x07FF);
-
-          // == Correct TMB_WordsExpected
-          //	1) for 2 optional 0x2AAA and 0x5555 Words in the Trailer
-          //    	2) for extra 4 frames in the new TMB trailer and
-          //         for RPC raw hit data, if present
-          //
-          // If the scope data was enabled in readout, scope data markers (0x6B05
-          // and 0x6E05) appear before 0x6E0C, and the optional 0x2AAA and 0x5555
-          // trailer words are suppressed.  So far, we only have data with the
-          // empty scope content, so more corrections will be needed once
-          // non-empty scope data is available. -SV, 5 Nov 2008.
-          //
-          // If word count is not multiple of 4, add 2 optional words and
-          // 4 trailer words.
-
-          int pos = scanbuf(buf_1,4,0x6E0C);
-          if (pos==1)
-            {
-              TMB_WordsExpected += 6;
-            }
-          // If word count is multiple of 4, add 4 trailer words.
-          else if (pos==3)
-            {
-              TMB_WordsExpected += 4;
-            }
-
-          // Correct expected wordcount by RPC data size
-          if (fTMB_RPC)
-            TMB_WordsExpected += TMB_WordsRPC;
-
-          // Correct expected wordcount by MiniScope data size (22 words + 2 signature words)
-          if (fTMB_MiniScope)
-            TMB_WordsExpected += 24;
-
-          // Correct expected wordcount by BlockedCFEBs data size (20 words + 2 signature words)
-          if (fTMB_BlockedCFEBs)
-            TMB_WordsExpected += 22;
-
-          CFEB_SampleWordCount = 0;
-#ifdef LOCAL_UNPACK
-          COUT << "T> ";
-#endif
+      // Check calculated CRC sum against reported
+      if (checkCrcTMB) {
+        uint32_t crc = (fTMB_Format2007 ? buf0[1] & 0x7ff : buf0[0] & 0x7ff);
+        crc |= ((uint32_t)((fTMB_Format2007 ? buf0[2] & 0x7ff : buf0[1] & 0x7ff))) << 11;
+        if (TMB_CRC != crc) {
+          fERROR[15] = true;
+          bERROR |= 0x8000;
+          fCHAMB_ERR[15].insert(currentChamber);
+          bCHAMB_ERR[currentChamber] |= 0x8000;
+          fCHAMB_ERR[0].insert(currentChamber);
+          bCHAMB_ERR[currentChamber] |= 0x1;
         }
+      }
 
-      if( fTMB_Header && checkCrcTMB )
-        {
-          for(uint16_t j=0, w=0; j<4; ++j)
-            {
-              ///w = buf0[j] & 0x7fff;
-              w = buf0[j] & (fTMB_Format2007 ? 0xffff : 0x7fff);
-              for(uint32_t i=15, t=0, ncrc=0; i<16; i--)
-                {
-                  t = ((w >> i) & 1) ^ ((TMB_CRC >> 21) & 1);
-                  ncrc = (TMB_CRC << 1) & 0x3ffffc;
-                  ncrc |= (t ^ (TMB_CRC & 1)) << 1;
-                  ncrc |= t;
-                  TMB_CRC = ncrc;
-                }
-            }
+      fTMB_Header = false;
+      uniqueTMB = false;
+      CFEB_CRC = 0;
+      TMB_WordCount = (buf0[3] & 0x07FF);
+
+      // == Correct TMB_WordsExpected
+      //	1) for 2 optional 0x2AAA and 0x5555 Words in the Trailer
+      //    	2) for extra 4 frames in the new TMB trailer and
+      //         for RPC raw hit data, if present
+      //
+      // If the scope data was enabled in readout, scope data markers (0x6B05
+      // and 0x6E05) appear before 0x6E0C, and the optional 0x2AAA and 0x5555
+      // trailer words are suppressed.  So far, we only have data with the
+      // empty scope content, so more corrections will be needed once
+      // non-empty scope data is available. -SV, 5 Nov 2008.
+      //
+      // If word count is not multiple of 4, add 2 optional words and
+      // 4 trailer words.
+
+      int pos = scanbuf(buf_1, 4, 0x6E0C);
+      if (pos == 1) {
+        TMB_WordsExpected += 6;
+      }
+      // If word count is multiple of 4, add 4 trailer words.
+      else if (pos == 3) {
+        TMB_WordsExpected += 4;
+      }
+
+      // Correct expected wordcount by RPC data size
+      if (fTMB_RPC)
+        TMB_WordsExpected += TMB_WordsRPC;
+
+      // Correct expected wordcount by MiniScope data size (22 words + 2 signature words)
+      if (fTMB_MiniScope)
+        TMB_WordsExpected += 24;
+
+      // Correct expected wordcount by BlockedCFEBs data size (20 words + 2 signature words)
+      if (fTMB_BlockedCFEBs)
+        TMB_WordsExpected += 22;
+
+      CFEB_SampleWordCount = 0;
+#ifdef LOCAL_UNPACK
+      COUT << "T> ";
+#endif
+    }
+
+    if (fTMB_Header && checkCrcTMB) {
+      for (uint16_t j = 0, w = 0; j < 4; ++j) {
+        ///w = buf0[j] & 0x7fff;
+        w = buf0[j] & (fTMB_Format2007 ? 0xffff : 0x7fff);
+        for (uint32_t i = 15, t = 0, ncrc = 0; i < 16; i--) {
+          t = ((w >> i) & 1) ^ ((TMB_CRC >> 21) & 1);
+          ncrc = (TMB_CRC << 1) & 0x3ffffc;
+          ncrc |= (t ^ (TMB_CRC & 1)) << 1;
+          ncrc |= t;
+          TMB_CRC = ncrc;
         }
+      }
+    }
 
+    // == CFEB Sample Trailer found
 
-      // == CFEB Sample Trailer found
-
-      if( ((buf0[1]&0xF000)==0x7000) &&
-          ((buf0[2]&0xF000)==0x7000) &&
-          ((buf0[1]!=0x7FFF) || (buf0[2]!=0x7FFF)) &&
-          ( ((buf0[3]&0xFFFF)==0x7FFF) ||   // old format
-            ( (buf0[3]&buf0[0])==0x0000 && (buf0[3]+buf0[0])==0x7FFF ) // 2007 format
-          ) )
-        {
+    if (((buf0[1] & 0xF000) == 0x7000) && ((buf0[2] & 0xF000) == 0x7000) &&
+        ((buf0[1] != 0x7FFF) || (buf0[2] != 0x7FFF)) &&
+        (((buf0[3] & 0xFFFF) == 0x7FFF) ||                                 // old format
+         ((buf0[3] & buf0[0]) == 0x0000 && (buf0[3] + buf0[0]) == 0x7FFF)  // 2007 format
+         )) {
 #ifdef LOCAL_UNPACK
-          if((CFEB_SampleCount%8)  == 0   )
-            {
-              COUT<<" <";
-            }
-          if( CFEB_SampleWordCount == 100 )
-            {
-              COUT<<"+";
-            }
+      if ((CFEB_SampleCount % 8) == 0) {
+        COUT << " <";
+      }
+      if (CFEB_SampleWordCount == 100) {
+        COUT << "+";
+      }
 #endif
-          if( CFEB_SampleWordCount != 100 )
-            {
+      if (CFEB_SampleWordCount != 100) {
 #ifdef LOCAL_UNPACK
-              COUT<<"-";
+        COUT << "-";
 #endif
 
-              fERROR[16] = true;
-              bERROR    |= 0x10000;
-              fCHAMB_ERR[16].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x10000;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-            }
+        fERROR[16] = true;
+        bERROR |= 0x10000;
+        fCHAMB_ERR[16].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x10000;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+      }
 
-          ++CFEB_SampleCount;
+      ++CFEB_SampleCount;
 
-          if( (CFEB_SampleCount%8)==0 )
-            {
+      if ((CFEB_SampleCount % 8) == 0) {
 #ifdef LOCAL_UNPACK
-              COUT<<">";
+        COUT << ">";
 #endif
-              CFEB_BSampleCount=0;
-              // Count CFEBs
-              DAV_CFEB--;
-            }
+        CFEB_BSampleCount = 0;
+        // Count CFEBs
+        DAV_CFEB--;
+      }
 
-          // Check calculated CRC sum against reported
-          if( checkCrcCFEB && CFEB_CRC!=buf0[0] )
-            {
-              fERROR[18] = true;
-              bERROR    |= 0x40000;
-              fCHAMB_ERR[18].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x40000;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-            }
+      // Check calculated CRC sum against reported
+      if (checkCrcCFEB && CFEB_CRC != buf0[0]) {
+        fERROR[18] = true;
+        bERROR |= 0x40000;
+        fCHAMB_ERR[18].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x40000;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+      }
 
-          CFEB_CRC = 0;
-          CFEB_SampleWordCount=0;
-        }
+      CFEB_CRC = 0;
+      CFEB_SampleWordCount = 0;
+    }
 
-
-      // == CFEB B-word found
-      if( (buf0[0]&0xF000)==0xB000 && (buf0[1]&0xF000)==0xB000 && (buf0[2]&0xF000)==0xB000 && (buf0[3]&0xF000)==0xB000 )
-        {
-          bCHAMB_STATUS[currentChamber] |= 0x400000;
+    // == CFEB B-word found
+    if ((buf0[0] & 0xF000) == 0xB000 && (buf0[1] & 0xF000) == 0xB000 && (buf0[2] & 0xF000) == 0xB000 &&
+        (buf0[3] & 0xF000) == 0xB000) {
+      bCHAMB_STATUS[currentChamber] |= 0x400000;
 
 #ifdef LOCAL_UNPACK
-          if( (CFEB_SampleCount%8)==0 )
-            {
-              COUT<<" <";
-            }
-          COUT<<"B";
+      if ((CFEB_SampleCount % 8) == 0) {
+        COUT << " <";
+      }
+      COUT << "B";
 #endif
 
-          ++CFEB_SampleCount;
-          ++CFEB_BSampleCount;
+      ++CFEB_SampleCount;
+      ++CFEB_BSampleCount;
 
-          if( (CFEB_SampleCount%8)==0 )
-            {
+      if ((CFEB_SampleCount % 8) == 0) {
 #ifdef LOCAL_UNPACK
-              COUT << ">";
+        COUT << ">";
 #endif
-              CFEB_BSampleCount=0;
-              DAV_CFEB--;
-            }
+        CFEB_BSampleCount = 0;
+        DAV_CFEB--;
+      }
 
-          CFEB_SampleWordCount=0;
-        }
+      CFEB_SampleWordCount = 0;
+    }
 
-      // == If it is neither ALCT record nor TMB - probably it is CFEB record and we try to count CRC sum.
-      // It very few words of CFEB occasionaly will be misinterpreted as ALCT or TMB header the result
-      // for the CRC sum will be wrong, but other errors of Trailers counting will appear as well
-      if( checkCrcCFEB && fDMB_Header && !fTMB_Header && !fALCT_Header && CFEB_SampleWordCount )
-        for(int pos=0; pos<4; ++pos)
-          CFEB_CRC=(buf0[pos]&0x1fff)^((buf0[pos]&0x1fff)<<1)^(((CFEB_CRC&0x7ffc)>>2)|((0x0003&CFEB_CRC)<<13))^((CFEB_CRC&0x7ffc)>>1);
+    // == If it is neither ALCT record nor TMB - probably it is CFEB record and we try to count CRC sum.
+    // It very few words of CFEB occasionaly will be misinterpreted as ALCT or TMB header the result
+    // for the CRC sum will be wrong, but other errors of Trailers counting will appear as well
+    if (checkCrcCFEB && fDMB_Header && !fTMB_Header && !fALCT_Header && CFEB_SampleWordCount)
+      for (int pos = 0; pos < 4; ++pos)
+        CFEB_CRC = (buf0[pos] & 0x1fff) ^ ((buf0[pos] & 0x1fff) << 1) ^
+                   (((CFEB_CRC & 0x7ffc) >> 2) | ((0x0003 & CFEB_CRC) << 13)) ^ ((CFEB_CRC & 0x7ffc) >> 1);
 
+    // == DMB F-Trailer found
+    if ((buf0[0] & 0xF000) == 0xF000 && (buf0[1] & 0xF000) == 0xF000 && (buf0[2] & 0xF000) == 0xF000 &&
+        (buf0[3] & 0xF000) == 0xF000) {
+      if (!fDMB_Header) {
+        currentChamber = buf0[3] & 0x0FFF;
+        fERROR[6] = true;
+        bERROR |= 0x40;
+        fCHAMB_ERR[6].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x40;
+        nDMBs++;
+        // Set variables if we are waiting ALCT, TMB and CFEB records to be present in event
+        if (buf0[0] & 0x0400)
+          bCHAMB_PAYLOAD[currentChamber] |= 0x20;
+        if (buf0[0] & 0x0800)
+          bCHAMB_PAYLOAD[currentChamber] |= 0x40;
+        bCHAMB_PAYLOAD[currentChamber] |= (buf0[0] & 0x001f) << 7;
+        bCHAMB_PAYLOAD[currentChamber] |= ((buf0[0] >> 5) & 0x1f);
 
-      // == DMB F-Trailer found
-      if( (buf0[0]&0xF000)==0xF000 && (buf0[1]&0xF000)==0xF000 && (buf0[2]&0xF000)==0xF000 && (buf0[3]&0xF000)==0xF000 )
-        {
-          if(!fDMB_Header)
-            {
-              currentChamber = buf0[3]&0x0FFF;
-              fERROR[6] = true;
-              bERROR   |= 0x40;
-              fCHAMB_ERR[6].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x40;
-              nDMBs++;
-              // Set variables if we are waiting ALCT, TMB and CFEB records to be present in event
-              if( buf0[0]&0x0400 ) bCHAMB_PAYLOAD[currentChamber] |= 0x20;
-              if( buf0[0]&0x0800 ) bCHAMB_PAYLOAD[currentChamber] |= 0x40;
-              bCHAMB_PAYLOAD[currentChamber] |= (buf0[0]&0x001f)<<7;
-              bCHAMB_PAYLOAD[currentChamber] |=((buf0[0]>>5)&0x1f);
+      }  // DMB Header is missing
+      fDMB_Header = false;
+      fDMB_Trailer = true;
+      uniqueALCT = true;
+      uniqueTMB = true;
 
-            } // DMB Header is missing
-          fDMB_Header  = false;
-          fDMB_Trailer = true;
-          uniqueALCT   = true;
-          uniqueTMB    = true;
+      dmbSize[sourceID][currentChamber] = buf0 - dmbBuffers[sourceID][currentChamber];
 
-          dmbSize[sourceID][currentChamber] = buf0 - dmbBuffers[sourceID][currentChamber];
+      // Finally check if DAVs were correct
+      checkDAVs();
 
-          // Finally check if DAVs were correct
-          checkDAVs();
-
-          // If F-Trailer is lost then do necessary work here
-          if( (buf1[0]&0xF000)!=0xE000 || (buf1[1]&0xF000)!=0xE000 || (buf1[2]&0xF000)!=0xE000 || (buf1[3]&0xF000)!=0xE000 )
-            {
-              for(int err=1; err<nERRORS; ++err)
-                if( fCHAMB_ERR[err].find(currentChamber) != fCHAMB_ERR[err].end() )
-                  {
-                    fCHAMB_ERR[0].insert(currentChamber);
-                    bCHAMB_ERR[currentChamber] |= 0x1;
-                  }
-              // Reset chamber id
-              currentChamber=-1;
-              /*
+      // If F-Trailer is lost then do necessary work here
+      if ((buf1[0] & 0xF000) != 0xE000 || (buf1[1] & 0xF000) != 0xE000 || (buf1[2] & 0xF000) != 0xE000 ||
+          (buf1[3] & 0xF000) != 0xE000) {
+        for (int err = 1; err < nERRORS; ++err)
+          if (fCHAMB_ERR[err].find(currentChamber) != fCHAMB_ERR[err].end()) {
+            fCHAMB_ERR[0].insert(currentChamber);
+            bCHAMB_ERR[currentChamber] |= 0x1;
+          }
+        // Reset chamber id
+        currentChamber = -1;
+        /*
                 for(int err=0; err<nERRORS; err++)
                 if( fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end() )
                 fCHAMB_ERR[err].erase(-1);
                 bCHAMB_ERR[-1] = 0;
                 bCHAMB_WRN[-1] = 0;
               */
-            }
+      }
 #ifdef LOCAL_UNPACK
-          // Print DMB F-Trailer marker
-          COUT << " }";
+      // Print DMB F-Trailer marker
+      COUT << " }";
 #endif
+    }
+
+    // == DMB E-Trailer found
+    if ((buf0[0] & 0xF000) == 0xE000 && (buf0[1] & 0xF000) == 0xE000 && (buf0[2] & 0xF000) == 0xE000 &&
+        (buf0[3] & 0xF000) == 0xE000) {
+      if (!fDMB_Header && !fDMB_Trailer)
+        nDMBs++;  // both DMB Header and DMB F-Trailer were missing
+
+      if (fFormat2013)  /// 2013 Data format
+      {
+        ///!!! Put correct bits positions
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0800) >> 11;  /// ALCT FIFO FULL
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0400) >> 9;   /// TMB FIFO Full
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0080) << 8;   /// TMB End Timeout
+
+        if (fDMB_Trailer)  // F-Trailer exists
+        {
+          bCHAMB_STATUS[currentChamber] |= (buf_1[2] & 0x0E00) >> 7;   /// CFEB 1-3 FIFO Full
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x0003) << 3;   /// CFEB 4-5 FIFO Full
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x000C) << 21;  /// CFEB 6-7 FIFO Full
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x0800) >> 4;   /// ALCT Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[2] & 0x0100);        /// TMB Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x01f0) << 5;   /// CFEB 1-5 Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x0600) << 16;  /// CFEB 6-7 Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[0] & 0x0800) << 3;   /// ALCT End Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[1] & 0x001f) << 16;  /// CFEB 1-5 End Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[1] & 0x0060) << 21;  /// CFEB 6-7 End Timeout
         }
 
-      // == DMB E-Trailer found
-      if( (buf0[0]&0xF000)==0xE000 && (buf0[1]&0xF000)==0xE000 && (buf0[2]&0xF000)==0xE000 && (buf0[3]&0xF000)==0xE000 )
+      } else {
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0800) >> 11;  /// ALCT FIFO FULL
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x0400) >> 9;   /// TMB FIFO Full
+        bCHAMB_STATUS[currentChamber] |= (buf0[0] & 0x03E0) >> 3;   /// CFEB 1-5 FIFO Full
+
+        if (fDMB_Trailer)  // F-Trailer exists
         {
-          if( !fDMB_Header && !fDMB_Trailer ) nDMBs++; // both DMB Header and DMB F-Trailer were missing
+          bCHAMB_STATUS[currentChamber] |= (buf_1[2] & 0x0002) << 6;   /// ALCT Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[2] & 0x0001) << 8;   /// TMB Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x001f) << 9;   /// CFEB 1-5 Start Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x0040) << 8;   /// ALCT End Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x0020) << 10;  /// TMB End Timeout
+          bCHAMB_STATUS[currentChamber] |= (buf_1[3] & 0x0f80) << 9;   /// CFEB 1-5 End Timeout
+        }
+      }
+      fDMB_Header = false;
 
-          if (fFormat2013) /// 2013 Data format
-            {
-              ///!!! Put correct bits positions
-              bCHAMB_STATUS[currentChamber] |= (buf0[0]&0x0800)>>11;        /// ALCT FIFO FULL
-              bCHAMB_STATUS[currentChamber] |= (buf0[0]&0x0400)>>9;         /// TMB FIFO Full
-              bCHAMB_STATUS[currentChamber] |= (buf0[0]&0x0080)<<8;         /// TMB End Timeout
+      // If chamber id is unknown it is time to find it out
+      if (currentChamber == -1) {
+        currentChamber = buf0[1] & 0x0FFF;
+        for (int err = 0; err < nERRORS; ++err)
+          if (fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end()) {
+            fCHAMB_ERR[err].insert(currentChamber);
+            fCHAMB_ERR[err].erase(-1);
+          }
+        bCHAMB_STATUS[currentChamber] = bCHAMB_STATUS[-1];
+        bCHAMB_STATUS[-1] = 0;
+        bCHAMB_ERR[currentChamber] = bCHAMB_ERR[-1];
+        bCHAMB_ERR[-1] = 0;
+        bCHAMB_WRN[currentChamber] = bCHAMB_WRN[-1];
+        bCHAMB_WRN[-1] = 0;
+      }
+      ++cntCHAMB_Trailers[buf0[1] & 0x0FFF];
 
-              if( fDMB_Trailer )   // F-Trailer exists
-                {
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[2]&0x0E00)>>7;      /// CFEB 1-3 FIFO Full
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0003)<<3;      /// CFEB 4-5 FIFO Full
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x000C)<<21;     /// CFEB 6-7 FIFO Full
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0800)>>4;      /// ALCT Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[2]&0x0100);         /// TMB Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x01f0)<<5;      /// CFEB 1-5 Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0600)<<16;     /// CFEB 6-7 Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[0]&0x0800)<<3;      /// ALCT End Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[1]&0x001f)<<16;     /// CFEB 1-5 End Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[1]&0x0060)<<21;     /// CFEB 6-7 End Timeout
+      dmbSize[sourceID][currentChamber] = buf0 - dmbBuffers[sourceID][currentChamber];
 
-                }
-
-            }
-          else
-            {
-              bCHAMB_STATUS[currentChamber] |= (buf0[0]&0x0800)>>11;	/// ALCT FIFO FULL
-              bCHAMB_STATUS[currentChamber] |= (buf0[0]&0x0400)>>9;		/// TMB FIFO Full
-              bCHAMB_STATUS[currentChamber] |= (buf0[0]&0x03E0)>>3;		/// CFEB 1-5 FIFO Full
-
-              if( fDMB_Trailer )   // F-Trailer exists
-                {
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[2]&0x0002)<<6;	/// ALCT Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[2]&0x0001)<<8;	/// TMB Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x001f)<<9;	/// CFEB 1-5 Start Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0040)<<8;	/// ALCT End Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0020)<<10;	/// TMB End Timeout
-                  bCHAMB_STATUS[currentChamber] |= (buf_1[3]&0x0f80)<<9;	/// CFEB 1-5 End Timeout
-                }
-
-            }
-          fDMB_Header  = false;
-
-          // If chamber id is unknown it is time to find it out
-          if( currentChamber==-1 )
-            {
-              currentChamber = buf0[1]&0x0FFF;
-              for(int err=0; err<nERRORS; ++err)
-                if( fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end() )
-                  {
-                    fCHAMB_ERR[err].insert(currentChamber);
-                    fCHAMB_ERR[err].erase(-1);
-                  }
-              bCHAMB_STATUS[currentChamber] = bCHAMB_STATUS[-1];
-              bCHAMB_STATUS[-1] = 0;
-              bCHAMB_ERR[currentChamber] = bCHAMB_ERR[-1];
-              bCHAMB_ERR[-1] = 0;
-              bCHAMB_WRN[currentChamber] = bCHAMB_WRN[-1];
-              bCHAMB_WRN[-1] = 0;
-            }
-          ++cntCHAMB_Trailers[buf0[1]&0x0FFF];
-
-          dmbSize[sourceID][currentChamber] = buf0 - dmbBuffers[sourceID][currentChamber];
-
-          // Lost DMB F-Trailer before
-          if( !fDMB_Trailer )
-            {
-              fERROR[6] = true;
-              bERROR   |= 0x40;
-              fCHAMB_ERR[6].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x40;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x1;
-              // Check if DAVs were correct here
-              checkDAVs();
-            }
-          fDMB_Trailer = false;
+      // Lost DMB F-Trailer before
+      if (!fDMB_Trailer) {
+        fERROR[6] = true;
+        bERROR |= 0x40;
+        fCHAMB_ERR[6].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x40;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x1;
+        // Check if DAVs were correct here
+        checkDAVs();
+      }
+      fDMB_Trailer = false;
 
 #ifdef LOCAL_UNPACK
-          // Print DMB E-Trailer marker
-          COUT<<" DMB="<<(buf0[1]&0x000F);
-          COUT << "; "
-               << ALCT_WordsSinceLastHeader << "-"
-               << ALCT_WordCount << "-"
-               << ALCT_WordsExpected
-               << "      "
-               << TMB_WordsSinceLastHeader << "-"
-               << TMB_WordCount << "-"
-               << TMB_WordsExpected
-               << endl;
+      // Print DMB E-Trailer marker
+      COUT << " DMB=" << (buf0[1] & 0x000F);
+      COUT << "; " << ALCT_WordsSinceLastHeader << "-" << ALCT_WordCount << "-" << ALCT_WordsExpected << "      "
+           << TMB_WordsSinceLastHeader << "-" << TMB_WordCount << "-" << TMB_WordsExpected << endl;
 #endif
 
-          checkTriggerHeadersAndTrailers();
+      checkTriggerHeadersAndTrailers();
 
-          //
-          for(int err=0; err<nERRORS; ++err)
-            if( fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end() )
-              {
-                fCHAMB_ERR[err].erase(-1);
-                fCHAMB_ERR[err].insert(-2);
-              }
-          bCHAMB_STATUS[-2] |= bCHAMB_STATUS[-1];
-          bCHAMB_STATUS[-1] = 0;
-          bCHAMB_ERR[-2] |= bCHAMB_ERR[-1];
-          bCHAMB_ERR[-1] = 0;
-          bCHAMB_WRN[-2] |= bCHAMB_WRN[-1];
-          bCHAMB_WRN[-1] = 0;
+      //
+      for (int err = 0; err < nERRORS; ++err)
+        if (fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end()) {
+          fCHAMB_ERR[err].erase(-1);
+          fCHAMB_ERR[err].insert(-2);
+        }
+      bCHAMB_STATUS[-2] |= bCHAMB_STATUS[-1];
+      bCHAMB_STATUS[-1] = 0;
+      bCHAMB_ERR[-2] |= bCHAMB_ERR[-1];
+      bCHAMB_ERR[-1] = 0;
+      bCHAMB_WRN[-2] |= bCHAMB_WRN[-1];
+      bCHAMB_WRN[-1] = 0;
 
-          if( currentChamber != -1 )
-            for(int err=1; err<nERRORS; ++err)
-              if( fCHAMB_ERR[err].find(currentChamber) != fCHAMB_ERR[err].end() )
-                {
-                  fCHAMB_ERR[0].insert(currentChamber);
-                  bCHAMB_ERR[currentChamber] |= 0x1;
-                }
+      if (currentChamber != -1)
+        for (int err = 1; err < nERRORS; ++err)
+          if (fCHAMB_ERR[err].find(currentChamber) != fCHAMB_ERR[err].end()) {
+            fCHAMB_ERR[0].insert(currentChamber);
+            bCHAMB_ERR[currentChamber] |= 0x1;
+          }
 
-          currentChamber=-1;
+      currentChamber = -1;
 #ifdef LOCAL_UNPACK
-          /*
+      /*
                 // Print DMB E-Trailer marker
                 COUT<<" DMB="<<(buf0[1]&0x000F);
                 COUT << "; "
@@ -1458,218 +1374,198 @@ int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
           	   << endl;
           */
 #endif
-        }
-
-      // == DDU Trailer found
-      if( buf0[0]==0x8000 && buf0[1]==0x8000 && buf0[2]==0xFFFF && buf0[3]==0x8000 )
-        {
-
-/////////////////////////////////////////////////////////
-          checkDAVs();
-
-          checkTriggerHeadersAndTrailers();
-
-/////////////////////////////////////////////////////////
-
-          if( DDU_WordsSinceLastHeader>3 && !nDMBs )
-            {
-              fERROR[28]=true;
-              bERROR|=0x10000000;;
-            }
-
-          if(fDDU_Trailer)
-            {
-              fERROR[2] = true;
-              bERROR   |= 0x4;
-            } // DDU Header is missing
-          fDDU_Trailer=true;
-          fDDU_Header=false;
-
-          if( fDMB_Header || fDMB_Trailer )
-            {
-#ifdef LOCAL_UNPACK
-              COUT << " Ex-Err: DMB (Header, Trailer) " << std::endl;
-#endif
-              fERROR[5] = true;
-              bERROR   |= 0x20;
-              fCHAMB_ERR[5].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x20;
-              fCHAMB_ERR[0].insert(currentChamber);
-              bCHAMB_ERR[currentChamber] |= 0x20;
-            }	// DMB Trailer is missing
-          fDMB_Header  = false;
-          fDMB_Trailer = false;
-
-          currentChamber=-1;
-
-          for(int err=0; err<nERRORS; ++err)
-            if( fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end() )
-              {
-                fCHAMB_ERR[err].erase(-1);
-                fCHAMB_ERR[err].insert(-2);
-              }
-          bCHAMB_STATUS[-2] |= bCHAMB_STATUS[-1];
-          bCHAMB_STATUS[-1] = 0;
-          bCHAMB_ERR[-2] |= bCHAMB_ERR[-1];
-          bCHAMB_ERR[-1] = 0;
-          bCHAMB_WRN[-2] |= bCHAMB_WRN[-1];
-          bCHAMB_WRN[-1] = 0;
-
-          for(int err=1; err<nERRORS; ++err)
-            if( fCHAMB_ERR[err].find(-2) != fCHAMB_ERR[err].end() )
-              {
-                fCHAMB_ERR[0].insert(-2);
-                bCHAMB_ERR[-2] |= 0x1;
-              }
-
-          dduSize[sourceID] = buf0-dduBuffers[sourceID];
-
-          ++cntDDU_Trailers; // Increment DDUTrailer counter
-
-          // == Combining 2 words into 24bit value
-          DDU_WordCount = buf2[2] | ((buf2[3] & 0xFF) <<16) ;
-
-          if( (DDU_WordsSinceLastHeader+4) != DDU_WordCount )
-            {
-              fERROR[4] = true;
-              bERROR   |= 0x10;
-            }
-
-          if( DMB_Active!=nDMBs )
-            {
-              fERROR[24] = true;
-              bERROR    |= 0x1000000;
-            }
-
-#ifdef LOCAL_UNPACK
-          COUT<<"DDU Trailer Occurrence "<<cntDDU_Trailers<<endl;
-          COUT<<"----------------------------------------------------------"<<endl;
-          COUT<<"DDU 64-bit words = Actual - DDUcounted ="<<DDU_WordsSinceLastHeader+4<<"-"<<DDU_WordCount<<endl;
-#endif
-
-          // increment statistics Errors and Warnings (i=0 case is handled in DDU Header)
-          for(int err=1; err<nERRORS; ++err)
-            {
-              if( fERROR[err] )
-                {
-                  fERROR[0] = true;
-                  bERROR |= 0x1;
-#ifdef LOCAL_UNPACK
-                  CERR<<"\nDDU Header Occurrence = "<<cntDDU_Headers;
-                  CERR<<"  ERROR "<<err<<"  " <<sERROR[err]<<endl;
-#endif
-                }
-            }
-
-#ifdef LOCAL_UNPACK
-          for(int wrn=1; wrn<nWARNINGS; ++wrn)
-            {
-              if( fWARNING[wrn] )
-                {
-                  COUT<<"\nDDU Header Occurrence = "<<cntDDU_Headers;
-                  COUT<<"  WARNING "<<wrn<<"  "<<sWARNING[wrn]<<endl;
-                }
-            }
-#endif
-
-          bDDU_ERR[sourceID] |= bERROR;
-          bDDU_WRN[sourceID] |= bWARNING;
-          sync_stats();
-
-          DDU_WordsSinceLastHeader=0;
-          DDU_WordsSinceLastTrailer=0;
-          if (modeDDUonly)
-            {
-              buffer+=4;
-              buf_1 = &(tmpbuf[0]);  // Just for safety
-              buf0  = &(tmpbuf[4]);  // Just for safety
-              buf1  = &(tmpbuf[8]);  // Just for safety
-              buf2  = &(tmpbuf[12]); // Just for safety
-              bzero(tmpbuf, sizeof(uint16_t)*16);
-              return length-4;
-            }
-        }
-
-      if (!modeDDUonly)
-        {
-          // DCC Trailer 1 && DCC Trailer 2
-          // =VB= Added support for Sep. 2008 CMS DAQ DCC format
-          // =VB= 04.18.09 Removed (buf2[0]&0x0003) == 0x3 check for old DCC format to satisfy older format of simulated data
-          if( (buf1[3]&0xFF00) == 0xEF00 &&
-              ( ((buf2[3]&0xFF00) == 0xAF00 )
-                ||
-                (( buf2[3]&0xFF00) == 0xA000 && (buf2[0]&0x0003) == 0x0) ) )
-            {
-              // =VB= Added check that there is no DCCHeader detected to set missing DCC Header error
-              if(!fDCC_Header || fDCC_Trailer)
-                {
-                  fERROR[26] = true;
-                  bERROR|=0x4000000;
-                  fERROR[0] = true;
-                  bERROR|=0x1;
-                } // DCC Header is missing
-              fDCC_Trailer=true;
-              fDCC_Header=false;
-
-              if( fDDU_Header )
-                {
-                  // == DDU Trailer is missing
-                  fERROR[1]=true;
-                  bERROR|=0x2;
-                  fERROR[0] = true;
-                  bERROR|=0x1;
-                }
-
-              buffer+=4;
-              buf_1 = &(tmpbuf[0]);  // Just for safety
-              buf0  = &(tmpbuf[4]);  // Just for safety
-              buf1  = &(tmpbuf[8]);  // Just for safety
-              buf2  = &(tmpbuf[12]); // Just for safety
-              bzero(tmpbuf, sizeof(uint16_t)*16);
-              sync_stats();
-              return length-4;
-            }
-        }
-
-      length-=4;
-      buffer+=4;
     }
+
+    // == DDU Trailer found
+    if (buf0[0] == 0x8000 && buf0[1] == 0x8000 && buf0[2] == 0xFFFF && buf0[3] == 0x8000) {
+      /////////////////////////////////////////////////////////
+      checkDAVs();
+
+      checkTriggerHeadersAndTrailers();
+
+      /////////////////////////////////////////////////////////
+
+      if (DDU_WordsSinceLastHeader > 3 && !nDMBs) {
+        fERROR[28] = true;
+        bERROR |= 0x10000000;
+        ;
+      }
+
+      if (fDDU_Trailer) {
+        fERROR[2] = true;
+        bERROR |= 0x4;
+      }  // DDU Header is missing
+      fDDU_Trailer = true;
+      fDDU_Header = false;
+
+      if (fDMB_Header || fDMB_Trailer) {
+#ifdef LOCAL_UNPACK
+        COUT << " Ex-Err: DMB (Header, Trailer) " << std::endl;
+#endif
+        fERROR[5] = true;
+        bERROR |= 0x20;
+        fCHAMB_ERR[5].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x20;
+        fCHAMB_ERR[0].insert(currentChamber);
+        bCHAMB_ERR[currentChamber] |= 0x20;
+      }  // DMB Trailer is missing
+      fDMB_Header = false;
+      fDMB_Trailer = false;
+
+      currentChamber = -1;
+
+      for (int err = 0; err < nERRORS; ++err)
+        if (fCHAMB_ERR[err].find(-1) != fCHAMB_ERR[err].end()) {
+          fCHAMB_ERR[err].erase(-1);
+          fCHAMB_ERR[err].insert(-2);
+        }
+      bCHAMB_STATUS[-2] |= bCHAMB_STATUS[-1];
+      bCHAMB_STATUS[-1] = 0;
+      bCHAMB_ERR[-2] |= bCHAMB_ERR[-1];
+      bCHAMB_ERR[-1] = 0;
+      bCHAMB_WRN[-2] |= bCHAMB_WRN[-1];
+      bCHAMB_WRN[-1] = 0;
+
+      for (int err = 1; err < nERRORS; ++err)
+        if (fCHAMB_ERR[err].find(-2) != fCHAMB_ERR[err].end()) {
+          fCHAMB_ERR[0].insert(-2);
+          bCHAMB_ERR[-2] |= 0x1;
+        }
+
+      dduSize[sourceID] = buf0 - dduBuffers[sourceID];
+
+      ++cntDDU_Trailers;  // Increment DDUTrailer counter
+
+      // == Combining 2 words into 24bit value
+      DDU_WordCount = buf2[2] | ((buf2[3] & 0xFF) << 16);
+
+      if ((DDU_WordsSinceLastHeader + 4) != DDU_WordCount) {
+        fERROR[4] = true;
+        bERROR |= 0x10;
+      }
+
+      if (DMB_Active != nDMBs) {
+        fERROR[24] = true;
+        bERROR |= 0x1000000;
+      }
+
+#ifdef LOCAL_UNPACK
+      COUT << "DDU Trailer Occurrence " << cntDDU_Trailers << endl;
+      COUT << "----------------------------------------------------------" << endl;
+      COUT << "DDU 64-bit words = Actual - DDUcounted =" << DDU_WordsSinceLastHeader + 4 << "-" << DDU_WordCount
+           << endl;
+#endif
+
+      // increment statistics Errors and Warnings (i=0 case is handled in DDU Header)
+      for (int err = 1; err < nERRORS; ++err) {
+        if (fERROR[err]) {
+          fERROR[0] = true;
+          bERROR |= 0x1;
+#ifdef LOCAL_UNPACK
+          CERR << "\nDDU Header Occurrence = " << cntDDU_Headers;
+          CERR << "  ERROR " << err << "  " << sERROR[err] << endl;
+#endif
+        }
+      }
+
+#ifdef LOCAL_UNPACK
+      for (int wrn = 1; wrn < nWARNINGS; ++wrn) {
+        if (fWARNING[wrn]) {
+          COUT << "\nDDU Header Occurrence = " << cntDDU_Headers;
+          COUT << "  WARNING " << wrn << "  " << sWARNING[wrn] << endl;
+        }
+      }
+#endif
+
+      bDDU_ERR[sourceID] |= bERROR;
+      bDDU_WRN[sourceID] |= bWARNING;
+      sync_stats();
+
+      DDU_WordsSinceLastHeader = 0;
+      DDU_WordsSinceLastTrailer = 0;
+      if (modeDDUonly) {
+        buffer += 4;
+        buf_1 = &(tmpbuf[0]);  // Just for safety
+        buf0 = &(tmpbuf[4]);   // Just for safety
+        buf1 = &(tmpbuf[8]);   // Just for safety
+        buf2 = &(tmpbuf[12]);  // Just for safety
+        bzero(tmpbuf, sizeof(uint16_t) * 16);
+        return length - 4;
+      }
+    }
+
+    if (!modeDDUonly) {
+      // DCC Trailer 1 && DCC Trailer 2
+      // =VB= Added support for Sep. 2008 CMS DAQ DCC format
+      // =VB= 04.18.09 Removed (buf2[0]&0x0003) == 0x3 check for old DCC format to satisfy older format of simulated data
+      if ((buf1[3] & 0xFF00) == 0xEF00 &&
+          (((buf2[3] & 0xFF00) == 0xAF00) || ((buf2[3] & 0xFF00) == 0xA000 && (buf2[0] & 0x0003) == 0x0))) {
+        // =VB= Added check that there is no DCCHeader detected to set missing DCC Header error
+        if (!fDCC_Header || fDCC_Trailer) {
+          fERROR[26] = true;
+          bERROR |= 0x4000000;
+          fERROR[0] = true;
+          bERROR |= 0x1;
+        }  // DCC Header is missing
+        fDCC_Trailer = true;
+        fDCC_Header = false;
+
+        if (fDDU_Header) {
+          // == DDU Trailer is missing
+          fERROR[1] = true;
+          bERROR |= 0x2;
+          fERROR[0] = true;
+          bERROR |= 0x1;
+        }
+
+        buffer += 4;
+        buf_1 = &(tmpbuf[0]);  // Just for safety
+        buf0 = &(tmpbuf[4]);   // Just for safety
+        buf1 = &(tmpbuf[8]);   // Just for safety
+        buf2 = &(tmpbuf[12]);  // Just for safety
+        bzero(tmpbuf, sizeof(uint16_t) * 16);
+        sync_stats();
+        return length - 4;
+      }
+    }
+
+    length -= 4;
+    buffer += 4;
+  }
   //Store the tail of the buffer
   buf_1 = &(tmpbuf[0]);
-  buf0  = &(tmpbuf[4]);
-  buf1  = &(tmpbuf[8]);
-  buf2  = &(tmpbuf[12]);
-  memcpy((void*)tmpbuf,(void*)(buffer-16),sizeof(short)*16);
+  buf0 = &(tmpbuf[4]);
+  buf1 = &(tmpbuf[8]);
+  buf2 = &(tmpbuf[12]);
+  memcpy((void*)tmpbuf, (void*)(buffer - 16), sizeof(short) * 16);
 
-  if (!modeDDUonly && !fDCC_Trailer && !fDCC_Header)
-    {
-      fERROR[26] = true;
-      bERROR|=0x4000000;
-      fERROR[25] = true;
-      bERROR|=0x2000000;
-      fERROR[0]=true;
-      bERROR|=0x1;
-      sync_stats();
-      return length;
-
-    }
+  if (!modeDDUonly && !fDCC_Trailer && !fDCC_Header) {
+    fERROR[26] = true;
+    bERROR |= 0x4000000;
+    fERROR[25] = true;
+    bERROR |= 0x2000000;
+    fERROR[0] = true;
+    bERROR |= 0x1;
+    sync_stats();
+    return length;
+  }
 
   return -2;
 }
 
-
-void CSCDCCExaminer::clear()
-{
-  bzero(fERROR,   sizeof(bool)*nERRORS);
-  bzero(fWARNING, sizeof(bool)*nWARNINGS);
-  bzero(fSUM_ERROR,   sizeof(bool)*nERRORS);
-  bzero(fSUM_WARNING, sizeof(bool)*nWARNINGS);
+void CSCDCCExaminer::clear() {
+  bzero(fERROR, sizeof(bool) * nERRORS);
+  bzero(fWARNING, sizeof(bool) * nWARNINGS);
+  bzero(fSUM_ERROR, sizeof(bool) * nERRORS);
+  bzero(fSUM_WARNING, sizeof(bool) * nWARNINGS);
   bERROR = 0;
   bWARNING = 0;
   bSUM_ERROR = 0;
   bSUM_WARNING = 0;
-  for(int err=0; err<nERRORS;   ++err) fCHAMB_ERR[err].clear();
-  for(int wrn=0; wrn<nWARNINGS; ++wrn) fCHAMB_WRN[wrn].clear();
+  for (int err = 0; err < nERRORS; ++err)
+    fCHAMB_ERR[err].clear();
+  for (int wrn = 0; wrn < nWARNINGS; ++wrn)
+    fCHAMB_WRN[wrn].clear();
   bCHAMB_ERR.clear();
   bCHAMB_WRN.clear();
   bCHAMB_PAYLOAD.clear();
@@ -1684,55 +1580,46 @@ void CSCDCCExaminer::clear()
   dmbSize.clear();
 }
 
-
-void CSCDCCExaminer::zeroCounts()
-{
+void CSCDCCExaminer::zeroCounts() {
   ALCT_WordsSinceLastHeader = 0;
-  ALCT_WordsSinceLastHeaderZeroSuppressed =0;
-  ALCT_WordCount            = 0;
-  ALCT_WordsExpected        = 0;
-  ALCT_ZSE                  = 0;
-  TMB_WordsSinceLastHeader  = 0;
-  TMB_WordCount             = 0;
-  TMB_WordsExpected         = 0;
-  TMB_Tbins                 = 0;
-  CFEB_SampleWordCount      = 0;
-  CFEB_SampleCount          = 0;
-  CFEB_BSampleCount         = 0;
+  ALCT_WordsSinceLastHeaderZeroSuppressed = 0;
+  ALCT_WordCount = 0;
+  ALCT_WordsExpected = 0;
+  ALCT_ZSE = 0;
+  TMB_WordsSinceLastHeader = 0;
+  TMB_WordCount = 0;
+  TMB_WordsExpected = 0;
+  TMB_Tbins = 0;
+  CFEB_SampleWordCount = 0;
+  CFEB_SampleCount = 0;
+  CFEB_BSampleCount = 0;
 }
 
-
-void CSCDCCExaminer::checkDAVs()
-{
-  if( DAV_ALCT )
-    {
-      fERROR[21] = true;
-      bERROR   |= 0x200000;
-      fCHAMB_ERR[21].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x200000;
-      DAV_ALCT = false;
-    }
-  if( DAV_TMB  )
-    {
-      fERROR[22] = true;
-      bERROR   |= 0x400000;
-      fCHAMB_ERR[22].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x400000;
-      DAV_TMB = false;
-    }
-  if( DAV_CFEB && DAV_CFEB!=-16)
-    {
-      fERROR[23] = true;
-      bERROR   |= 0x800000;
-      fCHAMB_ERR[23].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x800000;
-      DAV_CFEB = 0;
-    }
+void CSCDCCExaminer::checkDAVs() {
+  if (DAV_ALCT) {
+    fERROR[21] = true;
+    bERROR |= 0x200000;
+    fCHAMB_ERR[21].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x200000;
+    DAV_ALCT = false;
+  }
+  if (DAV_TMB) {
+    fERROR[22] = true;
+    bERROR |= 0x400000;
+    fCHAMB_ERR[22].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x400000;
+    DAV_TMB = false;
+  }
+  if (DAV_CFEB && DAV_CFEB != -16) {
+    fERROR[23] = true;
+    bERROR |= 0x800000;
+    fCHAMB_ERR[23].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x800000;
+    DAV_CFEB = 0;
+  }
 }
 
-
-void CSCDCCExaminer::checkTriggerHeadersAndTrailers()
-{
+void CSCDCCExaminer::checkTriggerHeadersAndTrailers() {
 #ifdef LOCAL_UNPACK
   /*
   COUT << " Ex-ALCT-Word-count " << std::endl;
@@ -1741,97 +1628,88 @@ void CSCDCCExaminer::checkTriggerHeadersAndTrailers()
   COUT << " ALCT Words Expected: " << ALCT_WordsExpected << std::endl;
   */
 #endif
-  if( !fALCT_Header && ( ALCT_WordsSinceLastHeader!=ALCT_WordCount || ALCT_WordsSinceLastHeader!=ALCT_WordsExpected )
-      && ALCT_ZSE==0 )
-    {
-      fERROR[9] = true;
-      bERROR   |= 0x200;
-      fCHAMB_ERR[9].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x200;
-      ALCT_WordsSinceLastHeader = 0;
-      ALCT_WordCount            = 0;
-      ALCT_WordsSinceLastHeader = 0;
-      ALCT_WordsExpected        = 0;
-    } // ALCT Word Count Error
+  if (!fALCT_Header &&
+      (ALCT_WordsSinceLastHeader != ALCT_WordCount || ALCT_WordsSinceLastHeader != ALCT_WordsExpected) &&
+      ALCT_ZSE == 0) {
+    fERROR[9] = true;
+    bERROR |= 0x200;
+    fCHAMB_ERR[9].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x200;
+    ALCT_WordsSinceLastHeader = 0;
+    ALCT_WordCount = 0;
+    ALCT_WordsSinceLastHeader = 0;
+    ALCT_WordsExpected = 0;
+  }  // ALCT Word Count Error
 
-  if( !fALCT_Header && (ALCT_WordsSinceLastHeader!=ALCT_WordsExpected
-                        || ALCT_WordsSinceLastHeaderZeroSuppressed!=ALCT_WordCount) && ALCT_ZSE!=0 )
-    {
-      fERROR[9] = true;
-      bERROR   |= 0x200;
-      fCHAMB_ERR[9].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x200;
-      ALCT_WordsSinceLastHeaderZeroSuppressed =0;
-      ALCT_WordsSinceLastHeader = 0;
-      ALCT_WordCount            = 0;
-      ALCT_WordsSinceLastHeader = 0;
-      ALCT_WordsExpected        = 0;
-    } // ALCT Word Count Error With zero suppression
+  if (!fALCT_Header &&
+      (ALCT_WordsSinceLastHeader != ALCT_WordsExpected || ALCT_WordsSinceLastHeaderZeroSuppressed != ALCT_WordCount) &&
+      ALCT_ZSE != 0) {
+    fERROR[9] = true;
+    bERROR |= 0x200;
+    fCHAMB_ERR[9].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x200;
+    ALCT_WordsSinceLastHeaderZeroSuppressed = 0;
+    ALCT_WordsSinceLastHeader = 0;
+    ALCT_WordCount = 0;
+    ALCT_WordsSinceLastHeader = 0;
+    ALCT_WordsExpected = 0;
+  }  // ALCT Word Count Error With zero suppression
 
-  if( !fTMB_Header && ( TMB_WordsSinceLastHeader!=TMB_WordCount || TMB_WordsSinceLastHeader!=TMB_WordsExpected ) )
-    {
-      fERROR[14] = true;
-      bERROR    |= 0x4000;
-      fCHAMB_ERR[14].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x4000;
-      TMB_WordsSinceLastHeader = 0;
-      TMB_WordCount            = 0;
-      TMB_WordsSinceLastHeader = 0;
-      TMB_WordsExpected        = 0;
-    } // TMB Word Count Error
+  if (!fTMB_Header && (TMB_WordsSinceLastHeader != TMB_WordCount || TMB_WordsSinceLastHeader != TMB_WordsExpected)) {
+    fERROR[14] = true;
+    bERROR |= 0x4000;
+    fCHAMB_ERR[14].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x4000;
+    TMB_WordsSinceLastHeader = 0;
+    TMB_WordCount = 0;
+    TMB_WordsSinceLastHeader = 0;
+    TMB_WordsExpected = 0;
+  }  // TMB Word Count Error
 
-  if( (CFEB_SampleCount%8)!=0 )
-    {
-      fERROR[17] = true;
-      bERROR    |= 0x20000;
-      fCHAMB_ERR[17].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x20000;
-      CFEB_SampleCount = 0;
-    } // Number of CFEB samples != 8*n
+  if ((CFEB_SampleCount % 8) != 0) {
+    fERROR[17] = true;
+    bERROR |= 0x20000;
+    fCHAMB_ERR[17].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x20000;
+    CFEB_SampleCount = 0;
+  }  // Number of CFEB samples != 8*n
 
-  if(fALCT_Header)
-    {
-      fERROR[7] = true;  // ALCT Trailer is missing
-      bERROR   |= 0x80;
-      fCHAMB_ERR[7].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x80;
-      ALCT_WordsSinceLastHeaderZeroSuppressed =0;
-      ALCT_WordsSinceLastHeader = 0;
-      ALCT_WordsExpected        = 0;
-      fALCT_Header = false;
-    }
+  if (fALCT_Header) {
+    fERROR[7] = true;  // ALCT Trailer is missing
+    bERROR |= 0x80;
+    fCHAMB_ERR[7].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x80;
+    ALCT_WordsSinceLastHeaderZeroSuppressed = 0;
+    ALCT_WordsSinceLastHeader = 0;
+    ALCT_WordsExpected = 0;
+    fALCT_Header = false;
+  }
 
-  if(fTMB_Header)
-    {
-      fERROR[12]=true;        // TMB Trailer is missing
-      bERROR   |= 0x1000;
-      fCHAMB_ERR[12].insert(currentChamber);
-      bCHAMB_ERR[currentChamber] |= 0x1000;
-      TMB_WordsSinceLastHeader = 0;
-      TMB_WordsExpected        = 0;
-      fTMB_Header = false;
-    }
+  if (fTMB_Header) {
+    fERROR[12] = true;  // TMB Trailer is missing
+    bERROR |= 0x1000;
+    fCHAMB_ERR[12].insert(currentChamber);
+    bCHAMB_ERR[currentChamber] |= 0x1000;
+    TMB_WordsSinceLastHeader = 0;
+    TMB_WordsExpected = 0;
+    fTMB_Header = false;
+  }
 }
 
-inline void CSCDCCExaminer::sync_stats()
-{
-  for (int err=0; err<nERRORS; ++err)
+inline void CSCDCCExaminer::sync_stats() {
+  for (int err = 0; err < nERRORS; ++err)
     fSUM_ERROR[err] |= fERROR[err];
-  for (int wrn=0; wrn<nWARNINGS; ++wrn)
+  for (int wrn = 0; wrn < nWARNINGS; ++wrn)
     fSUM_WARNING[wrn] |= fWARNING[wrn];
-  bSUM_ERROR            |= bERROR;
-  bSUM_WARNING  |= bWARNING;
+  bSUM_ERROR |= bERROR;
+  bSUM_WARNING |= bWARNING;
 }
 
-inline int CSCDCCExaminer::scanbuf(const uint16_t* &buffer, int32_t length, uint16_t sig, uint16_t mask)
-{
-  for (int i=0; i<length; i++)
-    {
-      if ( (buffer[i]&mask) == sig)
-        {
-          return i;
-        }
+inline int CSCDCCExaminer::scanbuf(const uint16_t*& buffer, int32_t length, uint16_t sig, uint16_t mask) {
+  for (int i = 0; i < length; i++) {
+    if ((buffer[i] & mask) == sig) {
+      return i;
     }
+  }
   return -1;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCDCCHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCHeader.cc
@@ -4,65 +4,38 @@
 #include <cassert>
 #include <cstring>
 
-CSCDCCHeader::CSCDCCHeader(int bx, int l1a, int sourceId, int version)
-{
+CSCDCCHeader::CSCDCCHeader(int bx, int l1a, int sourceId, int version) {
   word[0] = 0x5100000000000008LL;
   word[1] = 0xD900000000000000LL;
   /// =VB= Should pass true as last parameter for FEDHeader::set() method to construct correct data
   FEDHeader::set(reinterpret_cast<unsigned char *>(data()), 1, l1a, bx, sourceId, version, true);
 }
 
-
-CSCDCCHeader::CSCDCCHeader() 
-{
+CSCDCCHeader::CSCDCCHeader() {
   word[0] = 0x5100000000000008LL;
   word[1] = 0xD900000000000000LL;
 }
 
-CSCDCCHeader::CSCDCCHeader(const CSCDCCStatusDigi & digi)
-{
-  memcpy(this, digi.header(), sizeInWords()*2);
-}
+CSCDCCHeader::CSCDCCHeader(const CSCDCCStatusDigi &digi) { memcpy(this, digi.header(), sizeInWords() * 2); }
 
+int CSCDCCHeader::getCDFEventNumber() const { return ((word[0] >> 32) & 0x00FFFFFF); }
 
+int CSCDCCHeader::getCDFBunchCounter() const { return ((word[0] >> 20) & 0xFFF); }
+int CSCDCCHeader::getCDFSourceId() const { return ((word[0] >> 8) & 0xFFF); }
+int CSCDCCHeader::getCDFFOV() const { return ((word[0] >> 4) & 0xF); }
+int CSCDCCHeader::getCDFEventType() const { return ((word[0] >> 56) & 0xF); }
 
-int CSCDCCHeader::getCDFEventNumber() const 
-{ 
-  return ((word[0]>>32)&0x00FFFFFF);
-}
-
-int CSCDCCHeader::getCDFBunchCounter() const 
-{ 
-  return ((word[0]>>20)&0xFFF);
-}
-int CSCDCCHeader::getCDFSourceId() const 
-{ 
-  return ((word[0]>>8)&0xFFF);
-}
-int CSCDCCHeader::getCDFFOV() const 
-{ 
-  return ((word[0]>>4)&0xF);
-}
-int CSCDCCHeader::getCDFEventType() const 
-{ 
-  return ((word[0]>>56)&0xF);
-}
-
-
-void CSCDCCHeader::setDAV(int slot)
-{
+void CSCDCCHeader::setDAV(int slot) {
   /* Bits 7,6,5,4,2 to indicate available DDU. 
      For slink0, the DDU slots are 5, 12, 4, 13, 3 (same as Fifo_in_use[4:0]); 
      for slink1, the DDU slots are 9, 7, 10, 6, 11
   */
-  assert(slot>=3 && slot <= 13);
+  assert(slot >= 3 && slot <= 13);
   int bit[] = {0, 0, 0, 2, 5, 7, 4, 6, 0, 7, 5, 2, 6, 4};
   word[0] |= 1 << bit[slot];
 }
 
-std::ostream & operator<<(std::ostream & os, const CSCDCCHeader & hdr) 
-{
+std::ostream &operator<<(std::ostream &os, const CSCDCCHeader &hdr) {
   os << "DCC Header" << std::endl;
   return os;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCDDUDataItr.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUDataItr.cc
@@ -2,101 +2,63 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 // theCurrentCSC starts at -1, since user is expected to next() before he dereferences
 // for the first time
-CSCDDUDataItr::CSCDDUDataItr() :
-  theDDUData(nullptr),
-  theCurrentCSC(-1),
-  theNumberOfCSCs(0),
-  theDataIsOwnedByMe(true)
-{}
+CSCDDUDataItr::CSCDDUDataItr() : theDDUData(nullptr), theCurrentCSC(-1), theNumberOfCSCs(0), theDataIsOwnedByMe(true) {}
 
-
-CSCDDUDataItr::CSCDDUDataItr(const char * buf) :
-  theDDUData(nullptr),
-  theCurrentCSC(-1),
-  theNumberOfCSCs(0),
-  theDataIsOwnedByMe(true)
-{
+CSCDDUDataItr::CSCDDUDataItr(const char *buf)
+    : theDDUData(nullptr), theCurrentCSC(-1), theNumberOfCSCs(0), theDataIsOwnedByMe(true) {
   // check if it's OK first
-  const CSCDDUHeader * dduHeader
-    = reinterpret_cast<const CSCDDUHeader *>(buf);
-  if(dduHeader->check()){
+  const CSCDDUHeader *dduHeader = reinterpret_cast<const CSCDDUHeader *>(buf);
+  if (dduHeader->check()) {
     theDDUData = new CSCDDUEventData((const uint16_t *)buf);
     theNumberOfCSCs = theDDUData->cscData().size();
   } else {
-    LogTrace ("CSCDDUDataItr|CSCRawToDigi") << "Failed DDU header check.";
+    LogTrace("CSCDDUDataItr|CSCRawToDigi") << "Failed DDU header check.";
   }
 }
-  
 
-CSCDDUDataItr::CSCDDUDataItr(const CSCDDUEventData * dduData) :
-  theDDUData(dduData),
-  theCurrentCSC(-1),
-  theNumberOfCSCs(theDDUData->cscData().size()),
-  theDataIsOwnedByMe(false)
-{
+CSCDDUDataItr::CSCDDUDataItr(const CSCDDUEventData *dduData)
+    : theDDUData(dduData),
+      theCurrentCSC(-1),
+      theNumberOfCSCs(theDDUData->cscData().size()),
+      theDataIsOwnedByMe(false) {}
+
+CSCDDUDataItr::~CSCDDUDataItr() {
+  if (theDataIsOwnedByMe)
+    delete theDDUData;
 }
 
-
-CSCDDUDataItr::~CSCDDUDataItr() 
-{
-  if(theDataIsOwnedByMe) delete theDDUData;
+CSCDDUDataItr::CSCDDUDataItr(const CSCDDUDataItr &i)
+    : theCurrentCSC(i.theCurrentCSC), theNumberOfCSCs(i.theNumberOfCSCs), theDataIsOwnedByMe(i.theDataIsOwnedByMe) {
+  if (theDataIsOwnedByMe) {
+    if (i.theDDUData != nullptr) {
+      theDDUData = new CSCDDUEventData(*(i.theDDUData));
+    }
+  } else {
+    theDDUData = i.theDDUData;
+  }
 }
 
-
-CSCDDUDataItr::CSCDDUDataItr(const CSCDDUDataItr & i) :
-  theCurrentCSC(i.theCurrentCSC),
-  theNumberOfCSCs(i.theNumberOfCSCs),
-  theDataIsOwnedByMe(i.theDataIsOwnedByMe)
-{
-  if(theDataIsOwnedByMe) 
-    {
-      if(i.theDDUData != nullptr) 
-	{
-	  theDDUData = new CSCDDUEventData(*(i.theDDUData));
-	}
+void CSCDDUDataItr::operator=(const CSCDDUDataItr &i) {
+  if (theDataIsOwnedByMe && theDDUData != i.theDDUData) {
+    delete theDDUData;
+    if (i.theDDUData != nullptr) {
+      theDDUData = new CSCDDUEventData(*(i.theDDUData));
     }
-  else
-    {
-      theDDUData = i.theDDUData;
-    }
-}
-
-
-void CSCDDUDataItr::operator=(const CSCDDUDataItr & i) 
-{
-  if(theDataIsOwnedByMe && theDDUData != i.theDDUData) 
-    {
-      delete theDDUData;
-      if(i.theDDUData != nullptr) 
-	{
-	  theDDUData = new CSCDDUEventData(*(i.theDDUData));
-	}
-    }
-  else
-    {
-      theDDUData = i.theDDUData;
-    }
+  } else {
+    theDDUData = i.theDDUData;
+  }
 
   theDDUData = i.theDDUData;
   theCurrentCSC = i.theCurrentCSC;
   theNumberOfCSCs = i.theNumberOfCSCs;
   theDataIsOwnedByMe = i.theDataIsOwnedByMe;
-}  
-
-
-bool CSCDDUDataItr::next() 
-{
-  return (++theCurrentCSC < theNumberOfCSCs);
 }
 
+bool CSCDDUDataItr::next() { return (++theCurrentCSC < theNumberOfCSCs); }
 
-const CSCEventData &  CSCDDUDataItr::operator*() 
-{
+const CSCEventData &CSCDDUDataItr::operator*() {
   assert(theCurrentCSC >= 0 && theCurrentCSC < theNumberOfCSCs);
   return theDDUData->cscData()[theCurrentCSC];
 }
-
- 

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -21,26 +21,13 @@ std::atomic<bool> CSCDDUEventData::debug{false};
 std::atomic<uint32_t> CSCDDUEventData::errMask{0xFFFFFFFF};
 #endif
 
+CSCDDUEventData::CSCDDUEventData(const CSCDDUHeader& header) { theDDUHeader = header; }
 
+CSCDDUEventData::CSCDDUEventData(const uint16_t* buf, CSCDCCExaminer* examiner) { unpack_data(buf, examiner); }
 
-CSCDDUEventData::CSCDDUEventData(const CSCDDUHeader & header) 
-{
-  theDDUHeader = header;
-}
+CSCDDUEventData::~CSCDDUEventData() {}
 
-  
-CSCDDUEventData::CSCDDUEventData(const uint16_t *buf, CSCDCCExaminer* examiner) 
-{
-  unpack_data(buf, examiner);
-}
-
-CSCDDUEventData::~CSCDDUEventData() 
-{
-}
-
-
-void CSCDDUEventData::add(CSCEventData & cscData, int dmbId, int dduInput, unsigned format_version) 
-{
+void CSCDDUEventData::add(CSCEventData& cscData, int dmbId, int dduInput, unsigned format_version) {
   theDDUHeader.setDMBDAV(dduInput);
   //@@ Tim: The following sets the word which is supposed to be CSCs in error, with bit 15 set for DMB Full
   //@@ so I think sim should not set it at all
@@ -51,295 +38,267 @@ void CSCDDUEventData::add(CSCEventData & cscData, int dmbId, int dduInput, unsig
   theData.push_back(cscData);
 }
 
-void CSCDDUEventData::decodeStatus() const 
-{
-  this->decodeStatus(theDDUTrailer.errorstat());
-}
+void CSCDDUEventData::decodeStatus() const { this->decodeStatus(theDDUTrailer.errorstat()); }
 
-void CSCDDUEventData::decodeStatus(int code) const 
-{
+void CSCDDUEventData::decodeStatus(int code) const {
   // JRG is Jason Gilmore
   // JRG, low-order 16-bit status (most serious errors):
-  if((code&errMask)>0)
-    {///this is a mask for printing out errors
-      // JRG, low-order 16-bit status (most serious errors):
-      if((code&0x0000F000)>0)
-        {
-          if((0x00008000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Critical Error, ** needs reset **";
-          if((0x00004000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Single Error, bad event";
-          if((0x00002000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Single Warning";
-          if((0x00001000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Near Full Warning";
-        }
-      if((code&0x00000F00)>0)
-        {
-          if((0x00000800&code)>0) 
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU 64-bit Alignment Error";
-          if((0x00000400&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Control DLL Error occured";
-          if((0x00000200&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU DMB Error occurred";
-          if((0x00000100&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Lost In Event Error";
-        }
-      if((code&0x000000F0)>0)
-        {
-          if((0x00000080&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Lost In Data Error occurred";
-          if((0x00000040&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Timeout Error";
-          if((0x00000020&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   TMB or ALCT CRC Error";
-          if((0x00000010&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Multiple Transmit Errors";
-        }
-      if((code&0x0000000F)>0)
-        {
-          if((0x00000008&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Sync Lost or FIFO Full Error";
-          if((0x00000004&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Fiber/FIFO Connection Error";
-          if((0x00000002&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU L1A Match Error";
-          if((0x00000001&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU DMB or CFEB CRC Error";
-        }
-      if((code&0xF0000000)>0)
-        {
-          // JRG, high-order 16-bit status (not-so-serious errors):
-          if((0x80000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU DMB LCT/DAV/Movlp Mismatch";
-          if((0x40000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU-CFEB L1 Mismatch";
-          if((0x20000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU saw no good DMB CRCs";
-          if((0x10000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU CFEB Count Error";
-        }
-      if((code&0x0F000000)>0)
-        {
-          if((0x08000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU FirstDat Error";
-          if((0x04000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU L1A-FIFO Full Error";
-          if((0x02000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Data Stuck in FIFO";
-          if((0x01000000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU NoLiveFibers Error";
-        }
-      if((code&0x00F00000)>0)
-        {
-          if((0x00800000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Spwd single-bit Warning";
-          if((0x00400000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Input FPGA Error";
-          if((0x00200000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU DAQ Stop bit set";
-          if((0x00100000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU DAQ says Not Ready";
-          if((0x00300000&code)==0x00200000)
-	    LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU DAQ Applied Backpressure";
-        }
-      if((code&0x000F0000)>0)
-        {
-          if((0x00080000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU TMB Error";
-          if((0x00040000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU ALCT Error";
-          if((0x00020000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Trigger Readout Wordcount Error";
-          if((0x00010000&code)>0)
-            LogTrace ("CSCDDUEventData|CSCRawToDigi") << "   DDU Trigger L1A Match Error";
-        }
+  if ((code & errMask) > 0) {  ///this is a mask for printing out errors
+    // JRG, low-order 16-bit status (most serious errors):
+    if ((code & 0x0000F000) > 0) {
+      if ((0x00008000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Critical Error, ** needs reset **";
+      if ((0x00004000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Single Error, bad event";
+      if ((0x00002000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Single Warning";
+      if ((0x00001000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Near Full Warning";
     }
+    if ((code & 0x00000F00) > 0) {
+      if ((0x00000800 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU 64-bit Alignment Error";
+      if ((0x00000400 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Control DLL Error occured";
+      if ((0x00000200 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU DMB Error occurred";
+      if ((0x00000100 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Lost In Event Error";
+    }
+    if ((code & 0x000000F0) > 0) {
+      if ((0x00000080 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Lost In Data Error occurred";
+      if ((0x00000040 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Timeout Error";
+      if ((0x00000020 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   TMB or ALCT CRC Error";
+      if ((0x00000010 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Multiple Transmit Errors";
+    }
+    if ((code & 0x0000000F) > 0) {
+      if ((0x00000008 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Sync Lost or FIFO Full Error";
+      if ((0x00000004 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Fiber/FIFO Connection Error";
+      if ((0x00000002 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU L1A Match Error";
+      if ((0x00000001 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU DMB or CFEB CRC Error";
+    }
+    if ((code & 0xF0000000) > 0) {
+      // JRG, high-order 16-bit status (not-so-serious errors):
+      if ((0x80000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU DMB LCT/DAV/Movlp Mismatch";
+      if ((0x40000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU-CFEB L1 Mismatch";
+      if ((0x20000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU saw no good DMB CRCs";
+      if ((0x10000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU CFEB Count Error";
+    }
+    if ((code & 0x0F000000) > 0) {
+      if ((0x08000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU FirstDat Error";
+      if ((0x04000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU L1A-FIFO Full Error";
+      if ((0x02000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Data Stuck in FIFO";
+      if ((0x01000000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU NoLiveFibers Error";
+    }
+    if ((code & 0x00F00000) > 0) {
+      if ((0x00800000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Spwd single-bit Warning";
+      if ((0x00400000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Input FPGA Error";
+      if ((0x00200000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU DAQ Stop bit set";
+      if ((0x00100000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU DAQ says Not Ready";
+      if ((0x00300000 & code) == 0x00200000)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU DAQ Applied Backpressure";
+    }
+    if ((code & 0x000F0000) > 0) {
+      if ((0x00080000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU TMB Error";
+      if ((0x00040000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU ALCT Error";
+      if ((0x00020000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Trigger Readout Wordcount Error";
+      if ((0x00010000 & code) > 0)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "   DDU Trigger L1A Match Error";
+    }
+  }
 }
 
-void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner) 
-{
+void CSCDDUEventData::unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner) {
   // just to calculate length
-  const uint16_t * inputBuf = buf;
-  const uint16_t * inputBuf0 = buf; /// To pack trailer 0 
+  const uint16_t* inputBuf = buf;
+  const uint16_t* inputBuf0 = buf;  /// To pack trailer 0
   theData.clear();
-  if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << "CSCDDUEventData::unpack_data() is called";
-  if (debug) 
-   for (int i=0;i<6;++i) 
-    {
-      LogTrace ("CSCDDUEventData|CSCRawToDigi") << i << std::hex << buf[4*i+3] << buf[4*i+2] 
-						<< buf[4*i+1] << buf[4*i];
-     std::cout << i << " " << std::hex << buf[4*i+3] << " " << buf[4*i+2] << " " 
-						<< buf[4*i+1] << " " << buf[4*i] << std::endl;
+  if (debug)
+    LogTrace("CSCDDUEventData|CSCRawToDigi") << "CSCDDUEventData::unpack_data() is called";
+  if (debug)
+    for (int i = 0; i < 6; ++i) {
+      LogTrace("CSCDDUEventData|CSCRawToDigi")
+          << i << std::hex << buf[4 * i + 3] << buf[4 * i + 2] << buf[4 * i + 1] << buf[4 * i];
+      std::cout << i << " " << std::hex << buf[4 * i + 3] << " " << buf[4 * i + 2] << " " << buf[4 * i + 1] << " "
+                << buf[4 * i] << std::endl;
     }
 
   theDDUHeader.setFromBuffer(buf);
-  
+
   if (debug) {
-    LogTrace ("CSCDDUEventData|CSCRawToDigi") << "size of ddu header in words = " << theDDUHeader.sizeInWords();
-    LogTrace ("CSCDDUEventData|CSCRawToDigi") << "sizeof(DDUHeader) = " << sizeof(theDDUHeader);
+    LogTrace("CSCDDUEventData|CSCRawToDigi") << "size of ddu header in words = " << theDDUHeader.sizeInWords();
+    LogTrace("CSCDDUEventData|CSCRawToDigi") << "sizeof(DDUHeader) = " << sizeof(theDDUHeader);
   }
   buf += theDDUHeader.sizeInWords();
-  
 
   // if (theDDUHeader.format_version() >= 0x6)
-  if (theDDUHeader.format_version() == 0x7) /// New Data Format 2013
-   {
-     theFormatVersion = 2013;
-   }
-  else if (theDDUHeader.format_version() <= 0x6) /// Older Data format before 2013
-   {
-     theFormatVersion = 2005;
-   }
-  else // Add handling for any other format version
-   {
-     theFormatVersion = 2013;
-   }
+  if (theDDUHeader.format_version() == 0x7)  /// New Data Format 2013
+  {
+    theFormatVersion = 2013;
+  } else if (theDDUHeader.format_version() <= 0x6)  /// Older Data format before 2013
+  {
+    theFormatVersion = 2005;
+  } else  // Add handling for any other format version
+  {
+    theFormatVersion = 2013;
+  }
 
- 
   // we really don't want to copy CSCEventData's while filling the vec
   theData.clear();
   theData.reserve(theDDUHeader.ncsc());
 
-  if (examiner!= nullptr) { // Use selective unpacking mode
+  if (examiner != nullptr) {  // Use selective unpacking mode
 
-    if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << "selective unpacking starting";
+    if (debug)
+      LogTrace("CSCDDUEventData|CSCRawToDigi") << "selective unpacking starting";
 
     // Find this DDU in examiner's DDUs list
-    DDUIdType dduID = theDDUHeader.source_id();	
-	
-    std::map<DDUIdType,std::map<CSCIdType,const uint16_t*> > ddus = examiner->DMB_block();
-    std::map<DDUIdType,std::map<CSCIdType,const uint16_t*> >::iterator ddu_itr = ddus.find(dduID);
+    DDUIdType dduID = theDDUHeader.source_id();
+
+    std::map<DDUIdType, std::map<CSCIdType, const uint16_t*> > ddus = examiner->DMB_block();
+    std::map<DDUIdType, std::map<CSCIdType, const uint16_t*> >::iterator ddu_itr = ddus.find(dduID);
     const uint16_t* dduBlock = (const uint16_t*)((examiner->DDU_block())[dduID]);
     uint32_t dduBufSize = (examiner->DDU_size())[dduID];
-		
-    if (ddu_itr != ddus.end() && dduBufSize!=0 && dduBlock==inputBuf) {
-      std::map<CSCIdType,const uint16_t*> &cscs = ddu_itr->second;
-      std::map<CSCIdType,const uint16_t*>::iterator csc_itr;
 
-      for (csc_itr=cscs.begin(); csc_itr != cscs.end(); ++csc_itr) {
-	short cscid = csc_itr->first;
+    if (ddu_itr != ddus.end() && dduBufSize != 0 && dduBlock == inputBuf) {
+      std::map<CSCIdType, const uint16_t*>& cscs = ddu_itr->second;
+      std::map<CSCIdType, const uint16_t*>::iterator csc_itr;
 
-        if(cscid != -1)
-        {
-	  const uint16_t* pos = (const uint16_t*)csc_itr->second;
-	
-	
+      for (csc_itr = cscs.begin(); csc_itr != cscs.end(); ++csc_itr) {
+        short cscid = csc_itr->first;
+
+        if (cscid != -1) {
+          const uint16_t* pos = (const uint16_t*)csc_itr->second;
+
           ExaminerStatusType errors = examiner->errorsForChamber(cscid);
-          if ((errors & examiner->getMask()) > 0 ) {	
-         	if (debug) 
-		LogTrace ("CSCDDUEventData|CSCRawToDigi" )
-                       << "skip unpacking of CSC " << cscid << " due format errors: 0x" << std::hex << errors << std::dec;
-	    continue;
-          } 
-	
-	  theData.push_back(CSCEventData(pos, theFormatVersion));
+          if ((errors & examiner->getMask()) > 0) {
+            if (debug)
+              LogTrace("CSCDDUEventData|CSCRawToDigi")
+                  << "skip unpacking of CSC " << cscid << " due format errors: 0x" << std::hex << errors << std::dec;
+            continue;
+          }
+
+          theData.push_back(CSCEventData(pos, theFormatVersion));
         }
       }
 
-      if (debug)
-	{
-	  LogTrace ("CSCDDUEventData|CSCRawToDigi") << "size of vector of cscData = " << theData.size();
-	}
+      if (debug) {
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "size of vector of cscData = " << theData.size();
+      }
       // decode ddu tail
-      theDDUTrailer.setFromBuffer(inputBuf+dduBufSize);
+      theDDUTrailer.setFromBuffer(inputBuf + dduBufSize);
       // memcpy(&theDDUTrailer, dduBlock+(dduBufSize-theDDUTrailer.sizeInWords())*2, theDDUTrailer.sizeInWords()*2);
-      if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << theDDUTrailer.check();
-      errorstat=theDDUTrailer.errorstat();
-      if ((errorstat&errMask) != 0)
-	{
-	  if (theDDUTrailer.check())
-	    {
-	      if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi")
-		<< "+++ CSCDDUEventData warning: DDU Trailer errors = " << std::hex << errorstat << " +++ ";
-	      if (debug) decodeStatus(errorstat);
-	    }
-	  else
-	    {
-	      if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi" )
-		<< " Unpacking lost DDU trailer - check() failed and 8 8 ffff 8 was not found ";
-	    }
-	}
+      if (debug)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << theDDUTrailer.check();
+      errorstat = theDDUTrailer.errorstat();
+      if ((errorstat & errMask) != 0) {
+        if (theDDUTrailer.check()) {
+          if (debug)
+            LogTrace("CSCDDUEventData|CSCRawToDigi")
+                << "+++ CSCDDUEventData warning: DDU Trailer errors = " << std::hex << errorstat << " +++ ";
+          if (debug)
+            decodeStatus(errorstat);
+        } else {
+          if (debug)
+            LogTrace("CSCDDUEventData|CSCRawToDigi")
+                << " Unpacking lost DDU trailer - check() failed and 8 8 ffff 8 was not found ";
+        }
+      }
 
       if (debug) {
-	LogTrace ("CSCDDUEventData|CSCRawToDigi")  << " Final errorstat " << std::hex << errorstat << std::dec ;
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << " Final errorstat " << std::hex << errorstat << std::dec;
       }
       // the trailer counts in 64-bit words
 
       // theSizeInWords = dduBufSize;
       // buf=inputBuf+dduBufSize;
-
     }
-    theSizeInWords = dduBufSize+12;
-	
+    theSizeInWords = dduBufSize + 12;
+
   } else {
-
-
-    while( (((buf[0]&0xf000) == 0x9000)||((buf[0]&0xf000) == 0xa000)) 
-	   && (buf[3] != 0x8000)) {
-	// ++i;
-	if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << "unpack csc data loop started";
-	theData.push_back(CSCEventData(buf));
-	buf += (theData.back()).size();
-	if (debug) {
-	    LogTrace ("CSCDDUEventData|CSCRawToDigi") << "size of vector of cscData = " << theData.size();
-	}
+    while ((((buf[0] & 0xf000) == 0x9000) || ((buf[0] & 0xf000) == 0xa000)) && (buf[3] != 0x8000)) {
+      // ++i;
+      if (debug)
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "unpack csc data loop started";
+      theData.push_back(CSCEventData(buf));
+      buf += (theData.back()).size();
+      if (debug) {
+        LogTrace("CSCDDUEventData|CSCRawToDigi") << "size of vector of cscData = " << theData.size();
+      }
     }
- 
+
     if (debug) {
-	LogTrace ("CSCDDUEventData|CSCRawToDigi") << "unpacking ddu trailer ";
-	LogTrace ("CSCDDUEventData|CSCRawToDigi") << std::hex << buf[3]<<" " << buf[2] 
-					 <<" " << buf[1]<<" " << buf[0];
+      LogTrace("CSCDDUEventData|CSCRawToDigi") << "unpacking ddu trailer ";
+      LogTrace("CSCDDUEventData|CSCRawToDigi") << std::hex << buf[3] << " " << buf[2] << " " << buf[1] << " " << buf[0];
     }
 
     // decode ddu tail
     theDDUTrailer.setFromBuffer(buf);
-    if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << theDDUTrailer.check();
-    errorstat=theDDUTrailer.errorstat();
-    if ((errorstat&errMask) != 0)  
-      {
-	if (theDDUTrailer.check())
-	  {
-	    if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") 
-	      << "+++ CSCDDUEventData warning: DDU Trailer errors = " << std::hex << errorstat << " +++ ";
-	    if (debug) decodeStatus(errorstat);
-	  } 
-	else 
-	  {
-	    if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi" ) 
-	      << " Unpacking lost DDU trailer - check() failed and 8 8 ffff 8 was not found ";
-	  }
+    if (debug)
+      LogTrace("CSCDDUEventData|CSCRawToDigi") << theDDUTrailer.check();
+    errorstat = theDDUTrailer.errorstat();
+    if ((errorstat & errMask) != 0) {
+      if (theDDUTrailer.check()) {
+        if (debug)
+          LogTrace("CSCDDUEventData|CSCRawToDigi")
+              << "+++ CSCDDUEventData warning: DDU Trailer errors = " << std::hex << errorstat << " +++ ";
+        if (debug)
+          decodeStatus(errorstat);
+      } else {
+        if (debug)
+          LogTrace("CSCDDUEventData|CSCRawToDigi")
+              << " Unpacking lost DDU trailer - check() failed and 8 8 ffff 8 was not found ";
       }
-   
-    if (debug) 
-      LogTrace ("CSCDDUEventData|CSCRawToDigi")  << " Final errorstat " << std::hex << errorstat << std::dec ;
+    }
+
+    if (debug)
+      LogTrace("CSCDDUEventData|CSCRawToDigi") << " Final errorstat " << std::hex << errorstat << std::dec;
     // the trailer counts in 64-bit words
     buf += theDDUTrailer.sizeInWords();
-  
+
     theSizeInWords = buf - inputBuf;
   }
 
-/// Pack Trailer 0 (to access TTS)
-theDDUTrailer0 = inputBuf0[theSizeInWords-4];
+  /// Pack Trailer 0 (to access TTS)
+  theDDUTrailer0 = inputBuf0[theSizeInWords - 4];
 }
 
-
-bool CSCDDUEventData::check() const 
-{
+bool CSCDDUEventData::check() const {
   // the trailer counts in 64-bit words
-  if (debug)
-    {
-      LogTrace ("CSCDDUEventData|CSCRawToDigi") << sizeInWords();
-      LogTrace ("CSCDDUEventData|CSCRawToDigi") << "wordcount = " << theDDUTrailer.wordcount()*4;
-    }
+  if (debug) {
+    LogTrace("CSCDDUEventData|CSCRawToDigi") << sizeInWords();
+    LogTrace("CSCDDUEventData|CSCRawToDigi") << "wordcount = " << theDDUTrailer.wordcount() * 4;
+  }
 
   return theDDUHeader.check() && theDDUTrailer.check();
 }
 
-boost::dynamic_bitset<> CSCDDUEventData::pack() 
-{
-  boost::dynamic_bitset<> result = bitset_utilities::ushortToBitset( theDDUHeader.sizeInWords()*16,
-								     theDDUHeader.data());
+boost::dynamic_bitset<> CSCDDUEventData::pack() {
+  boost::dynamic_bitset<> result =
+      bitset_utilities::ushortToBitset(theDDUHeader.sizeInWords() * 16, theDDUHeader.data());
   //std::cout <<"SANDRIK inside DDUEvdata check = ";
   //theDDUHeader.check();
   //std::cout <<std::endl;
@@ -351,18 +310,16 @@ boost::dynamic_bitset<> CSCDDUEventData::pack()
   //}
   //std::cout <<"printing out ddu header words via bitset"<<std::endl;
   //bitset_utilities::printWords(result);
- 
-  for(unsigned int i = 0; i < theData.size(); ++i) 
-    {
-      result = bitset_utilities::append(result,theData[i].pack());
-    }
-  theSizeInWords = result.size()/16 + theDDUTrailer.sizeInWords();
+
+  for (unsigned int i = 0; i < theData.size(); ++i) {
+    result = bitset_utilities::append(result, theData[i].pack());
+  }
+  theSizeInWords = result.size() / 16 + theDDUTrailer.sizeInWords();
   // 64-bit word count
-  theDDUTrailer.setWordCount(theSizeInWords/4); 
-  boost::dynamic_bitset<> dduTrailer = bitset_utilities::ushortToBitset ( theDDUTrailer.sizeInWords()*16, 
-									  theDDUTrailer.data());
-  result =  bitset_utilities::append(result,dduTrailer);
+  theDDUTrailer.setWordCount(theSizeInWords / 4);
+  boost::dynamic_bitset<> dduTrailer =
+      bitset_utilities::ushortToBitset(theDDUTrailer.sizeInWords() * 16, theDDUTrailer.data());
+  result = bitset_utilities::append(result, dduTrailer);
 
   return result;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCDDUHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUHeader.cc
@@ -1,21 +1,15 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDDUHeader.h"
-#include <cstring> // for bzero
+#include <cstring>  // for bzero
 #include <iostream>
 
-CSCDDUHeader::CSCDDUHeader() 
-{
-  bzero(this, sizeInWords()*2);
+CSCDDUHeader::CSCDDUHeader() {
+  bzero(this, sizeInWords() * 2);
   init();
 }
 
-
-CSCDDUHeader::CSCDDUHeader(unsigned bx, unsigned l1num, unsigned sourceId, unsigned fmt_version) 
-  : format_version_(fmt_version&0xF)
-  , source_id_(sourceId)
-  , bxnum_(bx)
-  , lvl1num_(l1num)
-{
-  bzero(this, sizeInWords()*2);
+CSCDDUHeader::CSCDDUHeader(unsigned bx, unsigned l1num, unsigned sourceId, unsigned fmt_version)
+    : format_version_(fmt_version & 0xF), source_id_(sourceId), bxnum_(bx), lvl1num_(l1num) {
+  bzero(this, sizeInWords() * 2);
   source_id_ = sourceId;
   bxnum_ = bx;
   lvl1num_ = l1num;
@@ -23,38 +17,30 @@ CSCDDUHeader::CSCDDUHeader(unsigned bx, unsigned l1num, unsigned sourceId, unsig
   init();
 }
 
-
-void CSCDDUHeader::init() 
-{
+void CSCDDUHeader::init() {
   bit64_ = 5;
   header2_2_ = 0x0001;
   header2_1_ = header2_3_ = 0x8000;
 }
 
-
-void CSCDDUHeader::setDMBDAV(int dduInput) 
-{
+void CSCDDUHeader::setDMBDAV(int dduInput) {
   // Set appropriate bit in dmb_dav_
 
   dmb_dav_ |= ((1 << dduInput) & 0x7FFF);  // dduInput is 0-14
 
-  live_cscs_ |= ((1 << dduInput) & 0x7FFF); // Set DDU Inputs Connected to "Live" CSCs 
+  live_cscs_ |= ((1 << dduInput) & 0x7FFF);  // Set DDU Inputs Connected to "Live" CSCs
 
   // Count bits set in dmb_dav_... for the trick used see
   // http://en.wikipedia.org/wiki/Hamming_weight or http://graphics.stanford.edu/~seander/bithacks.html
 
   ncsc_ = 0;
   unsigned short dmbdav = dmb_dav_;
-  for( ; dmbdav; ++ncsc_ )
-  {
+  for (; dmbdav; ++ncsc_) {
     dmbdav &= dmbdav - 1;
   }
 }
 
-bool CSCDDUHeader::check() const 
-{
+bool CSCDDUHeader::check() const {
   //std::cout <<"SANDRIK"<<std::hex <<header2_1_<<" "<<header2_2_ <<" "<<header2_3_<<std::endl;
-  return bit64_ == 5 && header2_1_ == 0x8000 && header2_3_ == 0x8000
-  && header2_2_ == 0x0001;
+  return bit64_ == 5 && header2_1_ == 0x8000 && header2_3_ == 0x8000 && header2_2_ == 0x0001;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
@@ -4,22 +4,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-
-CSCDMBHeader::CSCDMBHeader(uint16_t firmware_version)
-:   theHeaderFormat(), theFirmwareVersion(firmware_version) 
-{
-
+CSCDMBHeader::CSCDMBHeader(uint16_t firmware_version) : theHeaderFormat(), theFirmwareVersion(firmware_version) {
   if (theFirmwareVersion == 2013) {
     theHeaderFormat = std::make_shared<CSCDMBHeader2013>();
   } else {
     theHeaderFormat = std::make_shared<CSCDMBHeader2005>();
   }
-
 }
 
-CSCDMBHeader::CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version)
-: theHeaderFormat(), theFirmwareVersion(firmware_version) 
-{
+CSCDMBHeader::CSCDMBHeader(const uint16_t *buf, uint16_t firmware_version)
+    : theHeaderFormat(), theFirmwareVersion(firmware_version) {
   if (theFirmwareVersion == 2013) {
     theHeaderFormat = std::make_shared<CSCDMBHeader2013>(buf);
   } else {
@@ -27,24 +21,18 @@ CSCDMBHeader::CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version)
   }
 }
 
-CSCDMBHeader2005 CSCDMBHeader::dmbHeader2005()   const {
-  const CSCDMBHeader2005 * result = dynamic_cast<const CSCDMBHeader2005 *>(theHeaderFormat.get());
-  if(result == nullptr)
-  {
+CSCDMBHeader2005 CSCDMBHeader::dmbHeader2005() const {
+  const CSCDMBHeader2005 *result = dynamic_cast<const CSCDMBHeader2005 *>(theHeaderFormat.get());
+  if (result == nullptr) {
     throw cms::Exception("Could not get 2005 DMB header format");
   }
   return *result;
 }
 
-
-CSCDMBHeader2013 CSCDMBHeader::dmbHeader2013()   const {
-  const CSCDMBHeader2013 * result = dynamic_cast<const CSCDMBHeader2013 *>(theHeaderFormat.get());
-  if(result == nullptr)
-  {
+CSCDMBHeader2013 CSCDMBHeader::dmbHeader2013() const {
+  const CSCDMBHeader2013 *result = dynamic_cast<const CSCDMBHeader2013 *>(theHeaderFormat.get());
+  if (result == nullptr) {
     throw cms::Exception("Could not get 2013 DMB header format");
   }
   return *result;
 }
-
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader2005.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader2005.cc
@@ -1,152 +1,77 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h"
 #include <iostream>
 
-
-CSCDMBHeader2005::CSCDMBHeader2005() 
-{
-  bzero(data(), sizeInWords()*2);
+CSCDMBHeader2005::CSCDMBHeader2005() {
+  bzero(data(), sizeInWords() * 2);
   bits.ddu_code_1 = bits.ddu_code_2 = bits.ddu_code_3 = bits.ddu_code_4 = 0xA;
   bits.newddu_code_1 = bits.newddu_code_2 = bits.newddu_code_3 = bits.newddu_code_4 = 0x9;
 }
 
-CSCDMBHeader2005::CSCDMBHeader2005(const uint16_t * buf) 
-{
-  memcpy(data(), buf, sizeInWords()*2);
-}
+CSCDMBHeader2005::CSCDMBHeader2005(const uint16_t* buf) { memcpy(data(), buf, sizeInWords() * 2); }
 
+unsigned CSCDMBHeader2005::cfebMovlp() const { return bits.cfeb_movlp; }
 
-unsigned CSCDMBHeader2005::cfebMovlp() const 
-{
-  return bits.cfeb_movlp;
-}
+unsigned CSCDMBHeader2005::dmbCfebSync() const { return bits.dmb_cfeb_sync; }
 
+unsigned CSCDMBHeader2005::activeDavMismatch() const { return bits.active_dav_mismatch; }
 
-unsigned CSCDMBHeader2005::dmbCfebSync() const 
-{
-  return bits.dmb_cfeb_sync;
-}
+unsigned CSCDMBHeader2005::cfebAvailable() const { return bits.cfeb_dav; }
 
-unsigned CSCDMBHeader2005::activeDavMismatch() const 
-{
-  return bits.active_dav_mismatch;
-}
+unsigned CSCDMBHeader2005::nalct() const { return bits.alct_dav_1; }
 
+unsigned CSCDMBHeader2005::nclct() const { return bits.tmb_dav_1; }
 
-unsigned CSCDMBHeader2005::cfebAvailable() const 
-{
-  return bits.cfeb_dav;
-}
+unsigned CSCDMBHeader2005::crateID() const { return bits.dmb_crate; }
 
+unsigned CSCDMBHeader2005::dmbID() const { return bits.dmb_id; }
 
-unsigned CSCDMBHeader2005::nalct() const 
-{
-  return bits.alct_dav_1;
-}
+unsigned CSCDMBHeader2005::bxn() const { return bits.dmb_bxn; }
 
-unsigned CSCDMBHeader2005::nclct() const 
-{
-  return bits.tmb_dav_1;
-}
+unsigned CSCDMBHeader2005::bxn12() const { return bits.dmb_bxn1; }
 
-unsigned CSCDMBHeader2005::crateID() const 
-{
-  return bits.dmb_crate;
-}
+unsigned CSCDMBHeader2005::l1a() const { return bits.dmb_l1a; }
 
-unsigned CSCDMBHeader2005::dmbID() const 
-{
-  return bits.dmb_id;
-}
+unsigned CSCDMBHeader2005::l1a24() const { return (bits.dmb_l1a_lowo | (bits.dmb_l1a_hiwo << 12)); }
 
-unsigned CSCDMBHeader2005::bxn() const 
-{
-  return bits.dmb_bxn;
-} 
+void CSCDMBHeader2005::setL1A(int l1a) { bits.dmb_l1a = l1a; }
 
-unsigned CSCDMBHeader2005::bxn12() const
-{
-  return bits.dmb_bxn1;
-}
-
-
-
-
-unsigned CSCDMBHeader2005::l1a() const 
-{
-  return bits.dmb_l1a;
-} 
-
-unsigned CSCDMBHeader2005::l1a24() const
-{
-  return (bits.dmb_l1a_lowo | (bits.dmb_l1a_hiwo << 12)) ;
-}
-
-
-void CSCDMBHeader2005::setL1A(int l1a) 
-{
-  bits.dmb_l1a = l1a;
-}
-
-void CSCDMBHeader2005::setL1A24(int l1a)
-{
+void CSCDMBHeader2005::setL1A24(int l1a) {
   bits.dmb_l1a_lowo = l1a & 0xFFF;
-  bits.dmb_l1a_hiwo = (l1a>>12) & 0xFFF;
+  bits.dmb_l1a_hiwo = (l1a >> 12) & 0xFFF;
 }
 
-
-void CSCDMBHeader2005::setBXN(int bxn) 
-{
+void CSCDMBHeader2005::setBXN(int bxn) {
   bits.dmb_bxn = bxn & 0x3F;
   bits.dmb_bxn1 = bxn & 0xFFF;
-} 
-
-
-void CSCDMBHeader2005::setCrateAddress(int crate, int dmbId) 
-{
-    this->bits.dmb_crate = crate;
-    this->bits.dmb_id = dmbId;
 }
 
-unsigned CSCDMBHeader2005::sizeInWords() const 
-{
-  return 8;
+void CSCDMBHeader2005::setCrateAddress(int crate, int dmbId) {
+  this->bits.dmb_crate = crate;
+  this->bits.dmb_id = dmbId;
 }
+
+unsigned CSCDMBHeader2005::sizeInWords() const { return 8; }
 
 /// counts from zero
-bool CSCDMBHeader2005::cfebAvailable(unsigned icfeb)
-{
-  assert (icfeb < 5);
+bool CSCDMBHeader2005::cfebAvailable(unsigned icfeb) {
+  assert(icfeb < 5);
   return (cfebAvailable() >> icfeb) & 1;
 }
 
-unsigned CSCDMBHeader2005::format_version() const
-{ 
-  return 0;
-}
+unsigned CSCDMBHeader2005::format_version() const { return 0; }
 
-void CSCDMBHeader2005::addCFEB(int icfeb) 
-{
+void CSCDMBHeader2005::addCFEB(int icfeb) {
   assert(icfeb < 5);
   bits.cfeb_dav |= (1 << icfeb);
   bits.cfeb_active |= (1 << icfeb);
 }
 
-void CSCDMBHeader2005::addNCLCT() 
-{
-  bits.tmb_dav_1 = bits.tmb_dav_2 = bits.tmb_dav_4 = 1;
+void CSCDMBHeader2005::addNCLCT() { bits.tmb_dav_1 = bits.tmb_dav_2 = bits.tmb_dav_4 = 1; }
+
+void CSCDMBHeader2005::addNALCT() { bits.alct_dav_1 = bits.alct_dav_2 = bits.alct_dav_4 = 1; }
+
+bool CSCDMBHeader2005::check() const {
+  return (bits.ddu_code_1 == 0xA && bits.ddu_code_2 == 0xA && bits.ddu_code_3 == 0xA && bits.ddu_code_4 == 0xA &&
+          bits.newddu_code_1 == 0x9 && bits.newddu_code_2 == 0x9 && bits.newddu_code_3 == 0x9 &&
+          bits.newddu_code_4 == 0x9);
 }
-
-void CSCDMBHeader2005::addNALCT() 
-{
-  bits.alct_dav_1 = bits.alct_dav_2 = bits.alct_dav_4 = 1;
-}
-
-
-bool CSCDMBHeader2005::check() const 
-{
-    return (bits.ddu_code_1==0xA && bits.ddu_code_2==0xA && 
-	    bits.ddu_code_3==0xA && bits.ddu_code_4==0xA && 
-	    bits.newddu_code_1==0x9 && bits.newddu_code_2==0x9 &&  
-	    bits.newddu_code_3==0x9 && bits.newddu_code_4==0x9);
-}
-

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader2013.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader2013.cc
@@ -1,148 +1,77 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h"
 #include <iostream>
 
-
-CSCDMBHeader2013::CSCDMBHeader2013() 
-{
-  bzero(data(), sizeInWords()*2);
+CSCDMBHeader2013::CSCDMBHeader2013() {
+  bzero(data(), sizeInWords() * 2);
   bits.ddu_code_1 = bits.ddu_code_2 = bits.ddu_code_3 = bits.ddu_code_4 = 0xA;
   bits.newddu_code_1 = bits.newddu_code_2 = bits.newddu_code_3 = bits.newddu_code_4 = 0x9;
 }
 
-CSCDMBHeader2013::CSCDMBHeader2013(const uint16_t * buf) 
-{
-  memcpy(data(), buf, sizeInWords()*2);
-}
+CSCDMBHeader2013::CSCDMBHeader2013(const uint16_t* buf) { memcpy(data(), buf, sizeInWords() * 2); }
 
+unsigned CSCDMBHeader2013::cfebMovlp() const { return bits.cfeb_movlp; }
 
-unsigned CSCDMBHeader2013::cfebMovlp() const 
-{
-  return bits.cfeb_movlp;
-}
+unsigned CSCDMBHeader2013::dmbCfebSync() const { return bits.dmb_cfeb_sync; }
 
+unsigned CSCDMBHeader2013::activeDavMismatch() const { return bits.clct_dav_mismatch; }
 
-unsigned CSCDMBHeader2013::dmbCfebSync() const 
-{
-  return bits.dmb_cfeb_sync;
-}
+unsigned CSCDMBHeader2013::format_version() const { return bits.fmt_version; }
 
-unsigned CSCDMBHeader2013::activeDavMismatch() const 
-{
-  return bits.clct_dav_mismatch;
-}
+unsigned CSCDMBHeader2013::cfebAvailable() const { return bits.cfeb_dav; }
 
-unsigned CSCDMBHeader2013::format_version() const
-{
-  return bits.fmt_version;
-}
+unsigned CSCDMBHeader2013::nalct() const { return bits.alct_dav; }
 
+unsigned CSCDMBHeader2013::nclct() const { return bits.tmb_dav; }
 
-unsigned CSCDMBHeader2013::cfebAvailable() const 
-{
-  return bits.cfeb_dav;
-}
+unsigned CSCDMBHeader2013::crateID() const { return bits.dmb_crate; }
 
+unsigned CSCDMBHeader2013::dmbID() const { return bits.dmb_id; }
 
-unsigned CSCDMBHeader2013::nalct() const 
-{
-  return bits.alct_dav;
-}
+unsigned CSCDMBHeader2013::bxn() const { return bits.dmb_bxn; }
 
-unsigned CSCDMBHeader2013::nclct() const 
-{
-  return bits.tmb_dav;
-}
+unsigned CSCDMBHeader2013::bxn12() const { return bits.dmb_bxn1; }
 
-unsigned CSCDMBHeader2013::crateID() const 
-{
-  return bits.dmb_crate;
-}
+unsigned CSCDMBHeader2013::l1a() const { return bits.dmb_l1a; }
 
-unsigned CSCDMBHeader2013::dmbID() const 
-{
-  return bits.dmb_id;
-}
+unsigned CSCDMBHeader2013::l1a24() const { return (bits.dmb_l1a_lowo | (bits.dmb_l1a_hiwo << 12)); }
 
-unsigned CSCDMBHeader2013::bxn() const 
-{
-  return bits.dmb_bxn;
-} 
+void CSCDMBHeader2013::setL1A(int l1a) { bits.dmb_l1a = l1a & 0x1F; }
 
-unsigned CSCDMBHeader2013::bxn12() const
-{
-  return bits.dmb_bxn1;
-}
-
-unsigned CSCDMBHeader2013::l1a() const 
-{
-  return bits.dmb_l1a;
-} 
-
-unsigned CSCDMBHeader2013::l1a24() const
-{
-  return (bits.dmb_l1a_lowo | (bits.dmb_l1a_hiwo << 12)) ;
-}
-
-void CSCDMBHeader2013::setL1A(int l1a) 
-{
-  bits.dmb_l1a = l1a & 0x1F;
-}
-
-void CSCDMBHeader2013::setL1A24(int l1a)
-{
+void CSCDMBHeader2013::setL1A24(int l1a) {
   bits.dmb_l1a_lowo = l1a & 0xFFF;
-  bits.dmb_l1a_hiwo = (l1a>>12) & 0xFFF;
+  bits.dmb_l1a_hiwo = (l1a >> 12) & 0xFFF;
 }
 
-
-void CSCDMBHeader2013::setBXN(int bxn) 
-{
+void CSCDMBHeader2013::setBXN(int bxn) {
   bits.dmb_bxn1 = bxn & 0xFFF;
   bits.dmb_bxn = bxn & 0x1F;
-} 
-
-
-void CSCDMBHeader2013::setCrateAddress(int crate, int dmbId) 
-{
-    this->bits.dmb_crate = crate;
-    this->bits.dmb_id = dmbId;
 }
 
-unsigned CSCDMBHeader2013::sizeInWords() const 
-{
-  return 8;
+void CSCDMBHeader2013::setCrateAddress(int crate, int dmbId) {
+  this->bits.dmb_crate = crate;
+  this->bits.dmb_id = dmbId;
 }
+
+unsigned CSCDMBHeader2013::sizeInWords() const { return 8; }
 
 /// counts from zero
-bool CSCDMBHeader2013::cfebAvailable(unsigned icfeb)
-{
-  assert (icfeb < 7);
+bool CSCDMBHeader2013::cfebAvailable(unsigned icfeb) {
+  assert(icfeb < 7);
   return (cfebAvailable() >> icfeb) & 1;
 }
 
-void CSCDMBHeader2013::addCFEB(int icfeb) 
-{
+void CSCDMBHeader2013::addCFEB(int icfeb) {
   assert(icfeb < 7);
   bits.cfeb_dav |= (1 << icfeb);
   bits.cfeb_clct_sent |= (1 << icfeb);
 }
 
-void CSCDMBHeader2013::addNCLCT() 
-{
-  bits.tmb_dav =  bits.tmb_dav_copy =  bits.tmb_dav_copy2 = 1;
+void CSCDMBHeader2013::addNCLCT() { bits.tmb_dav = bits.tmb_dav_copy = bits.tmb_dav_copy2 = 1; }
+
+void CSCDMBHeader2013::addNALCT() { bits.alct_dav = bits.alct_dav_copy = bits.alct_dav_copy2 = 1; }
+
+bool CSCDMBHeader2013::check() const {
+  return (bits.ddu_code_1 == 0xA && bits.ddu_code_2 == 0xA && bits.ddu_code_3 == 0xA && bits.ddu_code_4 == 0xA &&
+          bits.newddu_code_1 == 0x9 && bits.newddu_code_2 == 0x9 && bits.newddu_code_3 == 0x9 &&
+          bits.newddu_code_4 == 0x9);
 }
-
-void CSCDMBHeader2013::addNALCT() 
-{
-  bits.alct_dav = bits.alct_dav_copy = bits.alct_dav_copy2 = 1;
-}
-
-
-bool CSCDMBHeader2013::check() const 
-{
-    return (bits.ddu_code_1==0xA && bits.ddu_code_2==0xA && 
-	    bits.ddu_code_3==0xA && bits.ddu_code_4==0xA && 
-	    bits.newddu_code_1==0x9 && bits.newddu_code_2==0x9 &&  
-	    bits.newddu_code_3==0x9 && bits.newddu_code_4==0x9);
-}
-

--- a/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
@@ -4,22 +4,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-
-CSCDMBTrailer::CSCDMBTrailer(uint16_t firmware_version)
-:   theTrailerFormat(), theFirmwareVersion(firmware_version) 
-{
-
+CSCDMBTrailer::CSCDMBTrailer(uint16_t firmware_version) : theTrailerFormat(), theFirmwareVersion(firmware_version) {
   if (theFirmwareVersion == 2013) {
     theTrailerFormat = std::make_shared<CSCDMBTrailer2013>();
   } else {
     theTrailerFormat = std::make_shared<CSCDMBTrailer2005>();
   }
-
 }
 
-CSCDMBTrailer::CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version)
-: theTrailerFormat(), theFirmwareVersion(firmware_version) 
-{
+CSCDMBTrailer::CSCDMBTrailer(const uint16_t *buf, uint16_t firmware_version)
+    : theTrailerFormat(), theFirmwareVersion(firmware_version) {
   if (theFirmwareVersion == 2013) {
     theTrailerFormat = std::make_shared<CSCDMBTrailer2013>(buf);
   } else {
@@ -27,24 +21,18 @@ CSCDMBTrailer::CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version)
   }
 }
 
-CSCDMBTrailer2005 CSCDMBTrailer::dmbTrailer2005()   const {
-  const CSCDMBTrailer2005 * result = dynamic_cast<const CSCDMBTrailer2005 *>(theTrailerFormat.get());
-  if(result == nullptr)
-  {
+CSCDMBTrailer2005 CSCDMBTrailer::dmbTrailer2005() const {
+  const CSCDMBTrailer2005 *result = dynamic_cast<const CSCDMBTrailer2005 *>(theTrailerFormat.get());
+  if (result == nullptr) {
     throw cms::Exception("Could not get 2005 DMB trailer format");
   }
   return *result;
 }
 
-
-CSCDMBTrailer2013 CSCDMBTrailer::dmbTrailer2013()   const {
-  const CSCDMBTrailer2013 * result = dynamic_cast<const CSCDMBTrailer2013 *>(theTrailerFormat.get());
-  if(result == nullptr)
-  {
+CSCDMBTrailer2013 CSCDMBTrailer::dmbTrailer2013() const {
+  const CSCDMBTrailer2013 *result = dynamic_cast<const CSCDMBTrailer2013 *>(theTrailerFormat.get());
+  if (result == nullptr) {
     throw cms::Exception("Could not get 2013 DMB trailer format");
   }
   return *result;
 }
-
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToPattern.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToPattern.h
@@ -24,6 +24,3 @@ private:
   edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> d_token;
   //
 };
-
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -24,532 +24,457 @@
 using namespace edm;
 using namespace std;
 
-namespace cscd2r
-{
-/// takes layer ID, converts to chamber ID, switching ME1A to ME11
-CSCDetId chamberID(const CSCDetId & cscDetId)
-{
-  CSCDetId chamberId = cscDetId.chamberId();
-  if (chamberId.ring() ==4)
-    {
+namespace cscd2r {
+  /// takes layer ID, converts to chamber ID, switching ME1A to ME11
+  CSCDetId chamberID(const CSCDetId& cscDetId) {
+    CSCDetId chamberId = cscDetId.chamberId();
+    if (chamberId.ring() == 4) {
       chamberId = CSCDetId(chamberId.endcap(), chamberId.station(), 1, chamberId.chamber(), 0);
     }
-  return chamberId;
-}
+    return chamberId;
+  }
 
-template<typename LCTCollection>
-bool accept(const CSCDetId & cscId, const LCTCollection & lcts,
-            int bxMin, int bxMax, bool me1abCheck = false)
-{
-  if (bxMin == -999) return true;
-  int nominalBX = 6;
-  CSCDetId chamberId = chamberID(cscId);
-  typename LCTCollection::Range lctRange = lcts.get(chamberId);
-  bool result = false;
-  for (typename LCTCollection::const_iterator lctItr = lctRange.first;
-       lctItr != lctRange.second; ++lctItr)
-    {
+  template <typename LCTCollection>
+  bool accept(const CSCDetId& cscId, const LCTCollection& lcts, int bxMin, int bxMax, bool me1abCheck = false) {
+    if (bxMin == -999)
+      return true;
+    int nominalBX = 6;
+    CSCDetId chamberId = chamberID(cscId);
+    typename LCTCollection::Range lctRange = lcts.get(chamberId);
+    bool result = false;
+    for (typename LCTCollection::const_iterator lctItr = lctRange.first; lctItr != lctRange.second; ++lctItr) {
       int bx = lctItr->getBX() - nominalBX;
-      if (bx >= bxMin && bx <= bxMax)
-        {
-          result = true;
-          break;
-        }
-    }
-
-  bool me1 = cscId.station() == 1 && cscId.ring() == 1;
-  //this is another "creative" recovery of smart ME1A-ME1B TMB logic cases: 
-  //wire selective readout requires at least one (A)LCT in the full chamber
-  if (me1 && result == false && me1abCheck){
-    CSCDetId me1aId = CSCDetId(chamberId.endcap(), chamberId.station(), 4, chamberId.chamber(), 0);
-    lctRange = lcts.get(me1aId);
-    for (typename LCTCollection::const_iterator lctItr = lctRange.first;
-	 lctItr != lctRange.second; ++lctItr)
-      {
-	int bx = lctItr->getBX() - nominalBX;
-	if (bx >= bxMin && bx <= bxMax)
-	  {
-	    result = true;
-	    break;
-	  }
+      if (bx >= bxMin && bx <= bxMax) {
+        result = true;
+        break;
       }
-  }
+    }
 
-  return result;
-}
-
-// need to specialize for pretriggers, since they don't have a getBX()
-template<>
-bool accept(const CSCDetId & cscId, const CSCCLCTPreTriggerCollection & lcts,
-            int bxMin, int bxMax, bool me1abCheck)
-{
-  if (bxMin == -999) return true;
-  int nominalBX = 6;
-  CSCDetId chamberId = chamberID(cscId);
-  CSCCLCTPreTriggerCollection::Range lctRange = lcts.get(chamberId);
-  bool result = false;
-  for (CSCCLCTPreTriggerCollection::const_iterator lctItr = lctRange.first;
-       lctItr != lctRange.second; ++lctItr)
-    {
-      int bx = *lctItr - nominalBX;
-      if (bx >= bxMin && bx <= bxMax)
-        {
+    bool me1 = cscId.station() == 1 && cscId.ring() == 1;
+    //this is another "creative" recovery of smart ME1A-ME1B TMB logic cases:
+    //wire selective readout requires at least one (A)LCT in the full chamber
+    if (me1 && result == false && me1abCheck) {
+      CSCDetId me1aId = CSCDetId(chamberId.endcap(), chamberId.station(), 4, chamberId.chamber(), 0);
+      lctRange = lcts.get(me1aId);
+      for (typename LCTCollection::const_iterator lctItr = lctRange.first; lctItr != lctRange.second; ++lctItr) {
+        int bx = lctItr->getBX() - nominalBX;
+        if (bx >= bxMin && bx <= bxMax) {
           result = true;
           break;
         }
+      }
     }
-  bool me1a = cscId.station() == 1 && cscId.ring() == 4;
-  if (me1a && result == false && me1abCheck) {
-    //check pretriggers in me1a as well; relevant for TMB emulator writing to separate detIds
-    lctRange = lcts.get(cscId);
-    for (CSCCLCTPreTriggerCollection::const_iterator lctItr = lctRange.first;
-	 lctItr != lctRange.second; ++lctItr)
-      {
-	int bx = *lctItr - nominalBX;
-	if (bx >= bxMin && bx <= bxMax)
-	  {
-	    result = true;
-	    break;
-	  }
-      }    
+
+    return result;
   }
-  return result;
-}
 
-}
+  // need to specialize for pretriggers, since they don't have a getBX()
+  template <>
+  bool accept(const CSCDetId& cscId, const CSCCLCTPreTriggerCollection& lcts, int bxMin, int bxMax, bool me1abCheck) {
+    if (bxMin == -999)
+      return true;
+    int nominalBX = 6;
+    CSCDetId chamberId = chamberID(cscId);
+    CSCCLCTPreTriggerCollection::Range lctRange = lcts.get(chamberId);
+    bool result = false;
+    for (CSCCLCTPreTriggerCollection::const_iterator lctItr = lctRange.first; lctItr != lctRange.second; ++lctItr) {
+      int bx = *lctItr - nominalBX;
+      if (bx >= bxMin && bx <= bxMax) {
+        result = true;
+        break;
+      }
+    }
+    bool me1a = cscId.station() == 1 && cscId.ring() == 4;
+    if (me1a && result == false && me1abCheck) {
+      //check pretriggers in me1a as well; relevant for TMB emulator writing to separate detIds
+      lctRange = lcts.get(cscId);
+      for (CSCCLCTPreTriggerCollection::const_iterator lctItr = lctRange.first; lctItr != lctRange.second; ++lctItr) {
+        int bx = *lctItr - nominalBX;
+        if (bx >= bxMin && bx <= bxMax) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  }
 
+}  // namespace cscd2r
 
-CSCDigiToRaw::CSCDigiToRaw(const edm::ParameterSet & pset)
-  : alctWindowMin_(pset.getParameter<int>("alctWindowMin")),
-    alctWindowMax_(pset.getParameter<int>("alctWindowMax")),
-    clctWindowMin_(pset.getParameter<int>("clctWindowMin")),
-    clctWindowMax_(pset.getParameter<int>("clctWindowMax")),
-    preTriggerWindowMin_(pset.getParameter<int>("preTriggerWindowMin")),
-    preTriggerWindowMax_(pset.getParameter<int>("preTriggerWindowMax"))
-{}
+CSCDigiToRaw::CSCDigiToRaw(const edm::ParameterSet& pset)
+    : alctWindowMin_(pset.getParameter<int>("alctWindowMin")),
+      alctWindowMax_(pset.getParameter<int>("alctWindowMax")),
+      clctWindowMin_(pset.getParameter<int>("clctWindowMin")),
+      clctWindowMax_(pset.getParameter<int>("clctWindowMax")),
+      preTriggerWindowMin_(pset.getParameter<int>("preTriggerWindowMin")),
+      preTriggerWindowMax_(pset.getParameter<int>("preTriggerWindowMax")) {}
 
-CSCEventData & CSCDigiToRaw::findEventData(const CSCDetId & cscDetId, FindEventDataInfo& info) const
-{
+CSCEventData& CSCDigiToRaw::findEventData(const CSCDetId& cscDetId, FindEventDataInfo& info) const {
   CSCDetId chamberId = cscd2r::chamberID(cscDetId);
   // find the entry into the map
   map<CSCDetId, CSCEventData>::iterator chamberMapItr = info.theChamberDataMap.find(chamberId);
-  if (chamberMapItr == info.theChamberDataMap.end())
-    {
-      // make an entry, telling it the correct chamberType
-      int chamberType = chamberId.iChamberType();
-      chamberMapItr = info.theChamberDataMap.insert(pair<CSCDetId, CSCEventData>(chamberId, CSCEventData(chamberType, info.formatVersion_))).first;
-    }
-  CSCEventData & cscData = chamberMapItr->second;
+  if (chamberMapItr == info.theChamberDataMap.end()) {
+    // make an entry, telling it the correct chamberType
+    int chamberType = chamberId.iChamberType();
+    chamberMapItr = info.theChamberDataMap
+                        .insert(pair<CSCDetId, CSCEventData>(chamberId, CSCEventData(chamberType, info.formatVersion_)))
+                        .first;
+  }
+  CSCEventData& cscData = chamberMapItr->second;
   cscData.dmbHeader()->setCrateAddress(info.theElectronicsMap->crate(cscDetId), info.theElectronicsMap->dmb(cscDetId));
 
-  if (info.formatVersion_ == 2013)
-    {
-      // Set DMB version field to distinguish between ME11s and other chambers (ME11 - 2, others - 1)
-      bool me11 = ((chamberId.station()==1) && (chamberId.ring()==4)) || ((chamberId.station()==1) && (chamberId.ring()==1));
-      if (me11)
-        {
-          cscData.dmbHeader()->setdmbVersion(2);
-        }
-      else
-        {
-          cscData.dmbHeader()->setdmbVersion(1);
-        }
-
+  if (info.formatVersion_ == 2013) {
+    // Set DMB version field to distinguish between ME11s and other chambers (ME11 - 2, others - 1)
+    bool me11 = ((chamberId.station() == 1) && (chamberId.ring() == 4)) ||
+                ((chamberId.station() == 1) && (chamberId.ring() == 1));
+    if (me11) {
+      cscData.dmbHeader()->setdmbVersion(2);
+    } else {
+      cscData.dmbHeader()->setdmbVersion(1);
     }
+  }
   return cscData;
 }
 
-
-
 void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
-                       const CSCCLCTPreTriggerCollection & preTriggers,
+                       const CSCCLCTPreTriggerCollection& preTriggers,
                        FindEventDataInfo& fedInfo,
                        bool usePreTriggers,
-                       bool packEverything ) const
-{  //iterate over chambers with strip digis in them
-  for (CSCStripDigiCollection::DigiRangeIterator j=stripDigis.begin(); j!=stripDigis.end(); ++j)
-    {
-      CSCDetId cscDetId=(*j).first;
-      // only digitize if there are pre-triggers
-      
-      bool me1abCheck = fedInfo.formatVersion_ == 2013;
-      /* !!! Testing. Uncomment for production */
-     if (!usePreTriggers || packEverything ||
-	(usePreTriggers && cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_, me1abCheck)) )
-        {
-          bool me1a = (cscDetId.station()==1) && (cscDetId.ring()==4);
-          bool zplus = (cscDetId.endcap() == 1);
-          bool me1b = (cscDetId.station()==1) && (cscDetId.ring()==1);
+                       bool packEverything) const {  //iterate over chambers with strip digis in them
+  for (CSCStripDigiCollection::DigiRangeIterator j = stripDigis.begin(); j != stripDigis.end(); ++j) {
+    CSCDetId cscDetId = (*j).first;
+    // only digitize if there are pre-triggers
 
-          CSCEventData & cscData = findEventData(cscDetId, fedInfo);
+    bool me1abCheck = fedInfo.formatVersion_ == 2013;
+    /* !!! Testing. Uncomment for production */
+    if (!usePreTriggers || packEverything ||
+        (usePreTriggers &&
+         cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_, me1abCheck))) {
+      bool me1a = (cscDetId.station() == 1) && (cscDetId.ring() == 4);
+      bool zplus = (cscDetId.endcap() == 1);
+      bool me1b = (cscDetId.station() == 1) && (cscDetId.ring() == 1);
 
-          std::vector<CSCStripDigi>::const_iterator digiItr = (*j).second.first;
-          std::vector<CSCStripDigi>::const_iterator last = (*j).second.second;
-          for ( ; digiItr != last; ++digiItr)
-            {
-              CSCStripDigi digi = *digiItr;
-              int strip = digi.getStrip();
-              if (fedInfo.formatVersion_ == 2013)
-                {
-                  if ( me1a && zplus )
-                    {
-                      digi.setStrip(49-strip);  // 1-48 -> 48-1
-                    }
-                  if ( me1b && !zplus)
-                    {
-                      digi.setStrip(65-strip);  // 1-64 -> 64-1
-                    }
-                  if ( me1a )
-                    {
-                      strip = digi.getStrip();  // reset back 1-16 to 65-80 digi
-                      digi.setStrip(strip+64);
-                    }
+      CSCEventData& cscData = findEventData(cscDetId, fedInfo);
 
-                }
-              else
-                {
-                  if ( me1a && zplus )
-                    {
-                      digi.setStrip(17-strip);  // 1-16 -> 16-1
-                    }
-                  if ( me1b && !zplus)
-                    {
-                      digi.setStrip(65-strip);  // 1-64 -> 64-1
-                    }
-                  if ( me1a )
-                    {
-                      strip = digi.getStrip();  // reset back 1-16 to 65-80 digi
-                      digi.setStrip(strip+64);
-                    }
-                }
-              cscData.add(digi, cscDetId.layer() );
-            }
+      std::vector<CSCStripDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCStripDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
+        CSCStripDigi digi = *digiItr;
+        int strip = digi.getStrip();
+        if (fedInfo.formatVersion_ == 2013) {
+          if (me1a && zplus) {
+            digi.setStrip(49 - strip);  // 1-48 -> 48-1
+          }
+          if (me1b && !zplus) {
+            digi.setStrip(65 - strip);  // 1-64 -> 64-1
+          }
+          if (me1a) {
+            strip = digi.getStrip();  // reset back 1-16 to 65-80 digi
+            digi.setStrip(strip + 64);
+          }
+
+        } else {
+          if (me1a && zplus) {
+            digi.setStrip(17 - strip);  // 1-16 -> 16-1
+          }
+          if (me1b && !zplus) {
+            digi.setStrip(65 - strip);  // 1-64 -> 64-1
+          }
+          if (me1a) {
+            strip = digi.getStrip();  // reset back 1-16 to 65-80 digi
+            digi.setStrip(strip + 64);
+          }
         }
+        cscData.add(digi, cscDetId.layer());
+      }
     }
+  }
 }
-
 
 void CSCDigiToRaw::add(const CSCWireDigiCollection& wireDigis,
-                       const CSCALCTDigiCollection & alctDigis,
+                       const CSCALCTDigiCollection& alctDigis,
                        FindEventDataInfo& fedInfo,
-                       bool packEverything) const
-{
+                       bool packEverything) const {
   add(alctDigis, fedInfo);
-  for (CSCWireDigiCollection::DigiRangeIterator j=wireDigis.begin(); j!=wireDigis.end(); ++j)
-    {
-      CSCDetId cscDetId=(*j).first;
-      bool me1abCheck = fedInfo.formatVersion_ == 2013;
-      if (packEverything || cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_, me1abCheck))
-        {
-          CSCEventData & cscData = findEventData(cscDetId, fedInfo);
-          std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
-          std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
-          for ( ; digiItr != last; ++digiItr)
-            {
-              cscData.add(*digiItr, cscDetId.layer() );
-            }
-        }
+  for (CSCWireDigiCollection::DigiRangeIterator j = wireDigis.begin(); j != wireDigis.end(); ++j) {
+    CSCDetId cscDetId = (*j).first;
+    bool me1abCheck = fedInfo.formatVersion_ == 2013;
+    if (packEverything || cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_, me1abCheck)) {
+      CSCEventData& cscData = findEventData(cscDetId, fedInfo);
+      std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
+      std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
+      for (; digiItr != last; ++digiItr) {
+        cscData.add(*digiItr, cscDetId.layer());
+      }
     }
-
+  }
 }
 
-void CSCDigiToRaw::add(const CSCComparatorDigiCollection & comparatorDigis,
-                       const CSCCLCTDigiCollection & clctDigis,
+void CSCDigiToRaw::add(const CSCComparatorDigiCollection& comparatorDigis,
+                       const CSCCLCTDigiCollection& clctDigis,
                        FindEventDataInfo& fedInfo,
-                       bool packEverything) const
-{
-  add(clctDigis,fedInfo);
-  for (auto const& j  : comparatorDigis)
-    {
-      CSCDetId cscDetId=j.first;
-      CSCEventData & cscData = findEventData(cscDetId, fedInfo);
-      bool me1abCheck = fedInfo.formatVersion_ == 2013;
-      if (packEverything || cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_, me1abCheck))
-        {
-          bool me1a = (cscDetId.station()==1) && (cscDetId.ring()==4);
-	  
+                       bool packEverything) const {
+  add(clctDigis, fedInfo);
+  for (auto const& j : comparatorDigis) {
+    CSCDetId cscDetId = j.first;
+    CSCEventData& cscData = findEventData(cscDetId, fedInfo);
+    bool me1abCheck = fedInfo.formatVersion_ == 2013;
+    if (packEverything || cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_, me1abCheck)) {
+      bool me1a = (cscDetId.station() == 1) && (cscDetId.ring() == 4);
 
-      for(auto digi = j.second.first; digi != j.second.second; ++digi)
-          {
-            if (fedInfo.formatVersion_ == 2013)
-              {
-                // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
-                // been done already.
-                if (me1a && digi->getStrip() <= 48)
-                  {
-                    CSCComparatorDigi digi_corr(64+digi->getStrip(),
-                                                digi->getComparator(),
-                                                digi->getTimeBinWord());
-                    cscData.add(digi_corr, cscDetId); 			// This version does ME11 strips swapping
-  		    // cscData.add(digi_corr, cscDetId.layer());        // This one doesn't
-                  }
-                else
-                  {
-		    cscData.add(*digi, cscDetId);                   	// This version does ME11 strips swapping
-                    // cscData.add(digi, cscDetId.layer());        // This one doesn't
-                  }
-              }
-            else
-              {
-                // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
-                // been done already.
-                if (me1a && digi->getStrip() <= 16)
-                  {
-                    CSCComparatorDigi digi_corr(64+digi->getStrip(),
-                                                digi->getComparator(),
-                                                digi->getTimeBinWord());
-                    cscData.add(digi_corr, cscDetId.layer());
-                  }
-                else
-                  {
-                    cscData.add(*digi, cscDetId.layer());
-                  }
-              }
+      for (auto digi = j.second.first; digi != j.second.second; ++digi) {
+        if (fedInfo.formatVersion_ == 2013) {
+          // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
+          // been done already.
+          if (me1a && digi->getStrip() <= 48) {
+            CSCComparatorDigi digi_corr(64 + digi->getStrip(), digi->getComparator(), digi->getTimeBinWord());
+            cscData.add(digi_corr, cscDetId);  // This version does ME11 strips swapping
+                                               // cscData.add(digi_corr, cscDetId.layer());        // This one doesn't
+          } else {
+            cscData.add(*digi, cscDetId);  // This version does ME11 strips swapping
+            // cscData.add(digi, cscDetId.layer());        // This one doesn't
+          }
+        } else {
+          // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
+          // been done already.
+          if (me1a && digi->getStrip() <= 16) {
+            CSCComparatorDigi digi_corr(64 + digi->getStrip(), digi->getComparator(), digi->getTimeBinWord());
+            cscData.add(digi_corr, cscDetId.layer());
+          } else {
+            cscData.add(*digi, cscDetId.layer());
           }
         }
-    }
-}
-
-void CSCDigiToRaw::add(const CSCALCTDigiCollection & alctDigis,
-                       FindEventDataInfo& fedInfo) const
-{
-  for (CSCALCTDigiCollection::DigiRangeIterator j=alctDigis.begin(); j!=alctDigis.end(); ++j)
-    {
-      CSCDetId cscDetId=(*j).first;
-      CSCEventData & cscData = findEventData(cscDetId,fedInfo);
-
-      cscData.add(std::vector<CSCALCTDigi>((*j).second.first, (*j).second.second));
-    }
-}
-
-void CSCDigiToRaw::add(const CSCCLCTDigiCollection & clctDigis,
-                       FindEventDataInfo& fedInfo) const
-{
-  for (CSCCLCTDigiCollection::DigiRangeIterator j=clctDigis.begin(); j!=clctDigis.end(); ++j)
-    {
-      CSCDetId cscDetId=(*j).first;
-      CSCEventData & cscData = findEventData(cscDetId, fedInfo);
-
-      bool me11a = cscDetId.station() == 1 && cscDetId.ring() == 4;
-      //CLCTs are packed by chamber not by A/B parts in ME11
-      //me11a appears only in simulation with SLHC algorithm settings
-      //without the shift, it's impossible to distinguish A and B parts
-      if (me11a && fedInfo.formatVersion_ == 2013){
-	std::vector<CSCCLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
-	for (std::vector<CSCCLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
-	  if (iC->getCFEB() >= 0 && iC->getCFEB() < 3){//sanity check, mostly
-	    (*iC) = CSCCLCTDigi(iC->isValid(), iC->getQuality(), iC->getPattern(), iC->getStripType(),
-			     iC->getBend(), iC->getStrip(), iC->getCFEB()+4, iC->getBX(), 
-			     iC->getTrknmb(), iC->getFullBX());
-	  }
-	}
-	cscData.add(shiftedDigis);
-      } else {
-	cscData.add(std::vector<CSCCLCTDigi>((*j).second.first, (*j).second.second));
       }
     }
+  }
 }
 
-void CSCDigiToRaw::add(const CSCCorrelatedLCTDigiCollection & corrLCTDigis, FindEventDataInfo& fedInfo) const
-{
-  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j=corrLCTDigis.begin(); j!=corrLCTDigis.end(); ++j)
-    {
-      CSCDetId cscDetId=(*j).first;
-      CSCEventData & cscData = findEventData(cscDetId, fedInfo);
+void CSCDigiToRaw::add(const CSCALCTDigiCollection& alctDigis, FindEventDataInfo& fedInfo) const {
+  for (CSCALCTDigiCollection::DigiRangeIterator j = alctDigis.begin(); j != alctDigis.end(); ++j) {
+    CSCDetId cscDetId = (*j).first;
+    CSCEventData& cscData = findEventData(cscDetId, fedInfo);
 
-      bool me11a = cscDetId.station() == 1 && cscDetId.ring() == 4;
-      //LCTs are packed by chamber not by A/B parts in ME11
-      //me11a appears only in simulation with SLHC algorithm settings
-      //without the shift, it's impossible to distinguish A and B parts
-      if (me11a && fedInfo.formatVersion_ == 2013){
-	std::vector<CSCCorrelatedLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
-        for (std::vector<CSCCorrelatedLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
-          if (iC->getStrip() >= 0 && iC->getStrip() < 96){//sanity check, mostly
-            (*iC) = CSCCorrelatedLCTDigi(iC->getTrknmb(), iC->isValid(), iC->getQuality(), 
-					 iC->getKeyWG(), iC->getStrip() + 128, iC->getPattern(),
-					 iC->getBend(), iC->getBX(), iC->getMPCLink(), 
-					 iC->getBX0(), iC->getSyncErr(), iC->getCSCID());
-          }
+    cscData.add(std::vector<CSCALCTDigi>((*j).second.first, (*j).second.second));
+  }
+}
+
+void CSCDigiToRaw::add(const CSCCLCTDigiCollection& clctDigis, FindEventDataInfo& fedInfo) const {
+  for (CSCCLCTDigiCollection::DigiRangeIterator j = clctDigis.begin(); j != clctDigis.end(); ++j) {
+    CSCDetId cscDetId = (*j).first;
+    CSCEventData& cscData = findEventData(cscDetId, fedInfo);
+
+    bool me11a = cscDetId.station() == 1 && cscDetId.ring() == 4;
+    //CLCTs are packed by chamber not by A/B parts in ME11
+    //me11a appears only in simulation with SLHC algorithm settings
+    //without the shift, it's impossible to distinguish A and B parts
+    if (me11a && fedInfo.formatVersion_ == 2013) {
+      std::vector<CSCCLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
+      for (std::vector<CSCCLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
+        if (iC->getCFEB() >= 0 && iC->getCFEB() < 3) {  //sanity check, mostly
+          (*iC) = CSCCLCTDigi(iC->isValid(),
+                              iC->getQuality(),
+                              iC->getPattern(),
+                              iC->getStripType(),
+                              iC->getBend(),
+                              iC->getStrip(),
+                              iC->getCFEB() + 4,
+                              iC->getBX(),
+                              iC->getTrknmb(),
+                              iC->getFullBX());
         }
-        cscData.add(shiftedDigis);
-      } else {
-	cscData.add(std::vector<CSCCorrelatedLCTDigi>((*j).second.first, (*j).second.second));
       }
+      cscData.add(shiftedDigis);
+    } else {
+      cscData.add(std::vector<CSCCLCTDigi>((*j).second.first, (*j).second.second));
     }
-
+  }
 }
 
+void CSCDigiToRaw::add(const CSCCorrelatedLCTDigiCollection& corrLCTDigis, FindEventDataInfo& fedInfo) const {
+  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j = corrLCTDigis.begin(); j != corrLCTDigis.end(); ++j) {
+    CSCDetId cscDetId = (*j).first;
+    CSCEventData& cscData = findEventData(cscDetId, fedInfo);
+
+    bool me11a = cscDetId.station() == 1 && cscDetId.ring() == 4;
+    //LCTs are packed by chamber not by A/B parts in ME11
+    //me11a appears only in simulation with SLHC algorithm settings
+    //without the shift, it's impossible to distinguish A and B parts
+    if (me11a && fedInfo.formatVersion_ == 2013) {
+      std::vector<CSCCorrelatedLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
+      for (std::vector<CSCCorrelatedLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
+        if (iC->getStrip() >= 0 && iC->getStrip() < 96) {  //sanity check, mostly
+          (*iC) = CSCCorrelatedLCTDigi(iC->getTrknmb(),
+                                       iC->isValid(),
+                                       iC->getQuality(),
+                                       iC->getKeyWG(),
+                                       iC->getStrip() + 128,
+                                       iC->getPattern(),
+                                       iC->getBend(),
+                                       iC->getBX(),
+                                       iC->getMPCLink(),
+                                       iC->getBX0(),
+                                       iC->getSyncErr(),
+                                       iC->getCSCID());
+        }
+      }
+      cscData.add(shiftedDigis);
+    } else {
+      cscData.add(std::vector<CSCCorrelatedLCTDigi>((*j).second.first, (*j).second.second));
+    }
+  }
+}
 
 void CSCDigiToRaw::createFedBuffers(const CSCStripDigiCollection& stripDigis,
                                     const CSCWireDigiCollection& wireDigis,
                                     const CSCComparatorDigiCollection& comparatorDigis,
                                     const CSCALCTDigiCollection& alctDigis,
                                     const CSCCLCTDigiCollection& clctDigis,
-                                    const CSCCLCTPreTriggerCollection & preTriggers,
+                                    const CSCCLCTPreTriggerCollection& preTriggers,
                                     const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
                                     FEDRawDataCollection& fed_buffers,
                                     const CSCChamberMap* mapping,
-                                    Event & e, uint16_t format_version, bool use_pre_triggers,
-				    bool packEverything) const
-{
-
+                                    Event& e,
+                                    uint16_t format_version,
+                                    bool use_pre_triggers,
+                                    bool packEverything) const {
   //bits of code from ORCA/Muon/METBFormatter - thanks, Rick:)!
 
   //get fed object from fed_buffers
   // make a map from the index of a chamber to the event data from it
   FindEventDataInfo fedInfo{mapping, format_version};
-  add(stripDigis, preTriggers,fedInfo, use_pre_triggers, packEverything);
-  add(wireDigis, alctDigis,fedInfo, packEverything);
-  add(comparatorDigis, clctDigis,fedInfo, packEverything);
-  add(correlatedLCTDigis,fedInfo);
+  add(stripDigis, preTriggers, fedInfo, use_pre_triggers, packEverything);
+  add(wireDigis, alctDigis, fedInfo, packEverything);
+  add(comparatorDigis, clctDigis, fedInfo, packEverything);
+  add(correlatedLCTDigis, fedInfo);
 
-  int l1a=e.id().event(); //need to add increments or get it from lct digis
-  int bx = l1a;//same as above
+  int l1a = e.id().event();  //need to add increments or get it from lct digis
+  int bx = l1a;              //same as above
   //int startingFED = FEDNumbering::MINCSCFEDID;
 
-  if (fedInfo.formatVersion_ == 2005) /// Handle pre-LS1 format data
-    {
-      std::map<int, CSCDCCEventData> dccMap;
-      for (int idcc=FEDNumbering::MINCSCFEDID;
-           idcc<=FEDNumbering::MAXCSCFEDID; ++idcc)
-        {
-          //idcc goes from startingFed to startingFED+7
-          // @@ if ReadoutMapping changes, this'll have to change
-          // DCCs 1,2,4,5 have 5 DDUs.  Otherwise, 4
-          //int nDDUs = (idcc < 2) || (idcc ==4) || (idcc ==5)
-          //          ? 5 : 4;
-          //@@ WARNING some DCCs only have 4 DDUs, but I'm giving them all 5, for now
-          int nDDUs = 5;
-          dccMap.insert(std::pair<int, CSCDCCEventData>(idcc, CSCDCCEventData(idcc, nDDUs, bx, l1a) ) );
-        }
-
-      for (int idcc=FEDNumbering::MINCSCFEDID;
-           idcc<=FEDNumbering::MAXCSCFEDID; ++idcc)
-        {
-
-          // for every chamber with data, add to a DDU in this DCC Event
-          for (map<CSCDetId, CSCEventData>::iterator chamberItr = fedInfo.theChamberDataMap.begin();
-               chamberItr != fedInfo.theChamberDataMap.end(); ++chamberItr)
-            {
-              int indexDCC = mapping->slink(chamberItr->first);
-              if (indexDCC == idcc)
-                {
-                  //FIXME (What does this mean? Is something wrong?)
-                  std::map<int, CSCDCCEventData>::iterator dccMapItr = dccMap.find(indexDCC);
-                  if (dccMapItr == dccMap.end())
-                    {
-                      throw cms::Exception("CSCDigiToRaw") << "Bad DCC number:" << indexDCC;
-                    }
-                  // get id's based on ChamberId from mapping
-
-                  int dduId    = mapping->ddu(chamberItr->first);
-                  int dduSlot  = mapping->dduSlot(chamberItr->first);
-                  int dduInput = mapping->dduInput(chamberItr->first);
-                  int dmbId    = mapping->dmb(chamberItr->first);
-                  dccMapItr->second.addChamber(chamberItr->second, dduId, dduSlot, dduInput, dmbId, format_version);
-                }
-            }
-        }
-
-      // FIXME: FEDRawData size set to 2*64 to add FED header and trailer
-      for (std::map<int, CSCDCCEventData>::iterator dccMapItr = dccMap.begin();
-           dccMapItr != dccMap.end(); ++dccMapItr)
-        {
-          boost::dynamic_bitset<> dccBits = dccMapItr->second.pack();
-          FEDRawData & fedRawData = fed_buffers.FEDData(dccMapItr->first);
-          fedRawData.resize(dccBits.size());
-          //fill data with dccEvent
-          bitset_utilities::bitsetToChar(dccBits, fedRawData.data());
-          FEDTrailer cscFEDTrailer(fedRawData.data()+(fedRawData.size()-8));
-          cscFEDTrailer.set(fedRawData.data()+(fedRawData.size()-8),
-                            fedRawData.size()/8,
-                            evf::compute_crc(fedRawData.data(),fedRawData.size()), 0, 0);
-        }
-
+  if (fedInfo.formatVersion_ == 2005)  /// Handle pre-LS1 format data
+  {
+    std::map<int, CSCDCCEventData> dccMap;
+    for (int idcc = FEDNumbering::MINCSCFEDID; idcc <= FEDNumbering::MAXCSCFEDID; ++idcc) {
+      //idcc goes from startingFed to startingFED+7
+      // @@ if ReadoutMapping changes, this'll have to change
+      // DCCs 1,2,4,5 have 5 DDUs.  Otherwise, 4
+      //int nDDUs = (idcc < 2) || (idcc ==4) || (idcc ==5)
+      //          ? 5 : 4;
+      //@@ WARNING some DCCs only have 4 DDUs, but I'm giving them all 5, for now
+      int nDDUs = 5;
+      dccMap.insert(std::pair<int, CSCDCCEventData>(idcc, CSCDCCEventData(idcc, nDDUs, bx, l1a)));
     }
-  else if (format_version == 2013) /// Handle post-LS1 format data
-    {
 
-      std::map<int, CSCDDUEventData> dduMap;
-      unsigned int ddu_fmt_version = 0x7; /// 2013 Format
-      const unsigned postLS1_map [] = { 841, 842, 843, 844, 845, 846, 847, 848, 849,
-                                     831, 832, 833, 834, 835, 836, 837, 838, 839,
-                                     861, 862, 863, 864, 865, 866, 867, 868, 869,
-                                     851, 852, 853, 854, 855, 856, 857, 858, 859 };
+    for (int idcc = FEDNumbering::MINCSCFEDID; idcc <= FEDNumbering::MAXCSCFEDID; ++idcc) {
+      // for every chamber with data, add to a DDU in this DCC Event
+      for (map<CSCDetId, CSCEventData>::iterator chamberItr = fedInfo.theChamberDataMap.begin();
+           chamberItr != fedInfo.theChamberDataMap.end();
+           ++chamberItr) {
+        int indexDCC = mapping->slink(chamberItr->first);
+        if (indexDCC == idcc) {
+          //FIXME (What does this mean? Is something wrong?)
+          std::map<int, CSCDCCEventData>::iterator dccMapItr = dccMap.find(indexDCC);
+          if (dccMapItr == dccMap.end()) {
+            throw cms::Exception("CSCDigiToRaw") << "Bad DCC number:" << indexDCC;
+          }
+          // get id's based on ChamberId from mapping
 
-
-      /// Create dummy DDU buffers
-      for (unsigned int i = 0; i < 36; i++)
-        {
-	  unsigned int iddu = postLS1_map[i];
-          // make a new one
-          CSCDDUHeader newDDUHeader(bx,l1a, iddu, ddu_fmt_version);
-
-          dduMap.insert(std::pair<int, CSCDDUEventData>(iddu, CSCDDUEventData(newDDUHeader) ) );
+          int dduId = mapping->ddu(chamberItr->first);
+          int dduSlot = mapping->dduSlot(chamberItr->first);
+          int dduInput = mapping->dduInput(chamberItr->first);
+          int dmbId = mapping->dmb(chamberItr->first);
+          dccMapItr->second.addChamber(chamberItr->second, dduId, dduSlot, dduInput, dmbId, format_version);
         }
-
-
-      /// Loop over post-LS1 DDU FEDs
-      for (unsigned int i = 0; i < 36; i++)
-        {
-	  unsigned int iddu = postLS1_map[i];
-          // for every chamber with data, add to a DDU in this DCC Event
-          for (map<CSCDetId, CSCEventData>::iterator chamberItr = fedInfo.theChamberDataMap.begin();
-               chamberItr != fedInfo.theChamberDataMap.end(); ++chamberItr)
-            {
-              unsigned int indexDDU = mapping->slink(chamberItr->first);
-
-              /// Lets handle possible mapping issues
-              if ( (indexDDU >= FEDNumbering::MINCSCFEDID) && (indexDDU <= FEDNumbering::MAXCSCFEDID) ) // Still preLS1 DCC FEDs mapping
-                {
-
-                  int dduID    = mapping->ddu(chamberItr->first); // try to switch to DDU ID mapping
-                  if ((dduID >= FEDNumbering::MINCSCDDUFEDID) && (dduID <= FEDNumbering::MAXCSCDDUFEDID) ) // DDU ID is in expectedi post-LS1 FED ID range
-                    {
-                      indexDDU = dduID;
-                    }
-                  else // Messy
-                    {
-                      // Lets try to change pre-LS1 1-36 ID range to post-LS1 MINCSCDDUFEDID - MAXCSCDDUFEDID range
-                      dduID &= 0xFF;
-                      if ((dduID <= 36) && (dduID > 0)) indexDDU = postLS1_map[dduID -1]; // indexDDU = FEDNumbering::MINCSCDDUFEDID + dduID-1;
-                    }
-
-                }
-
-              if (indexDDU == iddu)
-                {
-                  std::map<int, CSCDDUEventData>::iterator dduMapItr = dduMap.find(indexDDU);
-                  if (dduMapItr == dduMap.end())
-                    {
-                      throw cms::Exception("CSCDigiToRaw") << "Bad DDU number:" << indexDDU;
-                    }
-                  // get id's based on ChamberId from mapping
-
-                  int dduInput = mapping->dduInput(chamberItr->first);
-                  int dmbId    = mapping->dmb(chamberItr->first);
-		  // int crateId  = mapping->crate(chamberItr->first);
-                  dduMapItr->second.add( chamberItr->second, dmbId, dduInput, format_version );
-                }
-            }
-        }
-
-      // FIXME: FEDRawData size set to 2*64 to add FED header and trailer
-      for (std::map<int, CSCDDUEventData>::iterator dduMapItr = dduMap.begin();
-           dduMapItr != dduMap.end(); ++dduMapItr)
-        {
-          boost::dynamic_bitset<> dduBits = dduMapItr->second.pack();
-          FEDRawData & fedRawData = fed_buffers.FEDData(dduMapItr->first);
-          fedRawData.resize(dduBits.size()/8);
-          //fill data with dduEvent
-          bitset_utilities::bitsetToChar(dduBits, fedRawData.data());
-          FEDTrailer cscFEDTrailer(fedRawData.data()+(fedRawData.size()-8));
-          cscFEDTrailer.set(fedRawData.data()+(fedRawData.size()-8),
-                            fedRawData.size()/8,
-                            evf::compute_crc(fedRawData.data(),fedRawData.size()), 0, 0);
-
-        }
+      }
     }
+
+    // FIXME: FEDRawData size set to 2*64 to add FED header and trailer
+    for (std::map<int, CSCDCCEventData>::iterator dccMapItr = dccMap.begin(); dccMapItr != dccMap.end(); ++dccMapItr) {
+      boost::dynamic_bitset<> dccBits = dccMapItr->second.pack();
+      FEDRawData& fedRawData = fed_buffers.FEDData(dccMapItr->first);
+      fedRawData.resize(dccBits.size());
+      //fill data with dccEvent
+      bitset_utilities::bitsetToChar(dccBits, fedRawData.data());
+      FEDTrailer cscFEDTrailer(fedRawData.data() + (fedRawData.size() - 8));
+      cscFEDTrailer.set(fedRawData.data() + (fedRawData.size() - 8),
+                        fedRawData.size() / 8,
+                        evf::compute_crc(fedRawData.data(), fedRawData.size()),
+                        0,
+                        0);
+    }
+
+  } else if (format_version == 2013)  /// Handle post-LS1 format data
+  {
+    std::map<int, CSCDDUEventData> dduMap;
+    unsigned int ddu_fmt_version = 0x7;  /// 2013 Format
+    const unsigned postLS1_map[] = {841, 842, 843, 844, 845, 846, 847, 848, 849, 831, 832, 833,
+                                    834, 835, 836, 837, 838, 839, 861, 862, 863, 864, 865, 866,
+                                    867, 868, 869, 851, 852, 853, 854, 855, 856, 857, 858, 859};
+
+    /// Create dummy DDU buffers
+    for (unsigned int i = 0; i < 36; i++) {
+      unsigned int iddu = postLS1_map[i];
+      // make a new one
+      CSCDDUHeader newDDUHeader(bx, l1a, iddu, ddu_fmt_version);
+
+      dduMap.insert(std::pair<int, CSCDDUEventData>(iddu, CSCDDUEventData(newDDUHeader)));
+    }
+
+    /// Loop over post-LS1 DDU FEDs
+    for (unsigned int i = 0; i < 36; i++) {
+      unsigned int iddu = postLS1_map[i];
+      // for every chamber with data, add to a DDU in this DCC Event
+      for (map<CSCDetId, CSCEventData>::iterator chamberItr = fedInfo.theChamberDataMap.begin();
+           chamberItr != fedInfo.theChamberDataMap.end();
+           ++chamberItr) {
+        unsigned int indexDDU = mapping->slink(chamberItr->first);
+
+        /// Lets handle possible mapping issues
+        if ((indexDDU >= FEDNumbering::MINCSCFEDID) &&
+            (indexDDU <= FEDNumbering::MAXCSCFEDID))  // Still preLS1 DCC FEDs mapping
+        {
+          int dduID = mapping->ddu(chamberItr->first);  // try to switch to DDU ID mapping
+          if ((dduID >= FEDNumbering::MINCSCDDUFEDID) &&
+              (dduID <= FEDNumbering::MAXCSCDDUFEDID))  // DDU ID is in expectedi post-LS1 FED ID range
+          {
+            indexDDU = dduID;
+          } else  // Messy
+          {
+            // Lets try to change pre-LS1 1-36 ID range to post-LS1 MINCSCDDUFEDID - MAXCSCDDUFEDID range
+            dduID &= 0xFF;
+            if ((dduID <= 36) && (dduID > 0))
+              indexDDU = postLS1_map[dduID - 1];  // indexDDU = FEDNumbering::MINCSCDDUFEDID + dduID-1;
+          }
+        }
+
+        if (indexDDU == iddu) {
+          std::map<int, CSCDDUEventData>::iterator dduMapItr = dduMap.find(indexDDU);
+          if (dduMapItr == dduMap.end()) {
+            throw cms::Exception("CSCDigiToRaw") << "Bad DDU number:" << indexDDU;
+          }
+          // get id's based on ChamberId from mapping
+
+          int dduInput = mapping->dduInput(chamberItr->first);
+          int dmbId = mapping->dmb(chamberItr->first);
+          // int crateId  = mapping->crate(chamberItr->first);
+          dduMapItr->second.add(chamberItr->second, dmbId, dduInput, format_version);
+        }
+      }
+    }
+
+    // FIXME: FEDRawData size set to 2*64 to add FED header and trailer
+    for (std::map<int, CSCDDUEventData>::iterator dduMapItr = dduMap.begin(); dduMapItr != dduMap.end(); ++dduMapItr) {
+      boost::dynamic_bitset<> dduBits = dduMapItr->second.pack();
+      FEDRawData& fedRawData = fed_buffers.FEDData(dduMapItr->first);
+      fedRawData.resize(dduBits.size() / 8);
+      //fill data with dduEvent
+      bitset_utilities::bitsetToChar(dduBits, fedRawData.data());
+      FEDTrailer cscFEDTrailer(fedRawData.data() + (fedRawData.size() - 8));
+      cscFEDTrailer.set(fedRawData.data() + (fedRawData.size() - 8),
+                        fedRawData.size() / 8,
+                        evf::compute_crc(fedRawData.data(), fedRawData.size()),
+                        0,
+                        0);
+    }
+  }
 }
-
-

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.h
@@ -23,59 +23,53 @@ class CSCChamberMap;
 class CSCDigiToRaw {
 public:
   /// Constructor
-  explicit CSCDigiToRaw(const edm::ParameterSet & pset);
+  explicit CSCDigiToRaw(const edm::ParameterSet& pset);
 
   /// Take a vector of digis and fill the FEDRawDataCollection
   void createFedBuffers(const CSCStripDigiCollection& stripDigis,
-			const CSCWireDigiCollection& wireDigis, 
+                        const CSCWireDigiCollection& wireDigis,
                         const CSCComparatorDigiCollection& comparatorDigis,
                         const CSCALCTDigiCollection& alctDigis,
                         const CSCCLCTDigiCollection& clctDigis,
                         const CSCCLCTPreTriggerCollection& preTriggers,
                         const CSCCorrelatedLCTDigiCollection& correlatedLCTDigis,
-			FEDRawDataCollection& fed_buffers,
-		        const CSCChamberMap* theMapping, 
-			edm::Event & e, 
-			uint16_t theFormatVersion = 2005, 
-			bool usePreTriggers = true,
-			bool packEverything = false) const;
+                        FEDRawDataCollection& fed_buffers,
+                        const CSCChamberMap* theMapping,
+                        edm::Event& e,
+                        uint16_t theFormatVersion = 2005,
+                        bool usePreTriggers = true,
+                        bool packEverything = false) const;
 
 private:
   struct FindEventDataInfo {
-  FindEventDataInfo(const CSCChamberMap* map, uint16_t version):
-    theElectronicsMap{map}, formatVersion_{version} {}
+    FindEventDataInfo(const CSCChamberMap* map, uint16_t version) : theElectronicsMap{map}, formatVersion_{version} {}
 
     using ChamberDataMap = std::map<CSCDetId, CSCEventData>;
     ChamberDataMap theChamberDataMap;
     const CSCChamberMap* theElectronicsMap;
     const uint16_t formatVersion_;
   };
-    
 
   // specialized because it reverses strip direction
-  void add(const CSCStripDigiCollection& stripDigis, 
+  void add(const CSCStripDigiCollection& stripDigis,
            const CSCCLCTPreTriggerCollection& preTriggers,
            FindEventDataInfo&,
            bool usePreTriggers,
-           bool packEverything ) const;
+           bool packEverything) const;
   void add(const CSCWireDigiCollection& wireDigis,
-           const CSCALCTDigiCollection & alctDigis,
+           const CSCALCTDigiCollection& alctDigis,
            FindEventDataInfo&,
            bool packEverything) const;
   // may require CLCTs to read out comparators.  Doesn't add CLCTs.
-  void add(const CSCComparatorDigiCollection & comparatorDigis,
-           const CSCCLCTDigiCollection & clctDigis,
+  void add(const CSCComparatorDigiCollection& comparatorDigis,
+           const CSCCLCTDigiCollection& clctDigis,
            FindEventDataInfo&,
            bool packEverything) const;
-  void add(const CSCALCTDigiCollection & alctDigis,
-           FindEventDataInfo&) const;
-  void add(const CSCCLCTDigiCollection & clctDigis,
-           FindEventDataInfo&) const;
-  void add(const CSCCorrelatedLCTDigiCollection & corrLCTDigis,
-           FindEventDataInfo&) const;
+  void add(const CSCALCTDigiCollection& alctDigis, FindEventDataInfo&) const;
+  void add(const CSCCLCTDigiCollection& clctDigis, FindEventDataInfo&) const;
+  void add(const CSCCorrelatedLCTDigiCollection& corrLCTDigis, FindEventDataInfo&) const;
   /// pick out the correct data object for this chamber
-  CSCEventData & findEventData(const CSCDetId & cscDetId, 
-                               FindEventDataInfo& ) const;
+  CSCEventData& findEventData(const CSCDetId& cscDetId, FindEventDataInfo&) const;
 
   const int alctWindowMin_;
   const int alctWindowMax_;
@@ -84,8 +78,5 @@ private:
   const int preTriggerWindowMin_;
   const int preTriggerWindowMax_;
 };
-
-
-
 
 #endif

--- a/EventFilter/CSCRawToDigi/src/CSCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCEventData.cc
@@ -8,100 +8,81 @@
 #include "EventFilter/CSCRawToDigi/src/bitset_append.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
 #ifdef LOCAL_UNPACK
 bool CSCEventData::debug = false;
 #else
 std::atomic<bool> CSCEventData::debug{false};
 #endif
 
-CSCEventData::CSCEventData(int chamberType, uint16_t format_version) :
-    theDMBHeader(format_version),
-    theALCTHeader(nullptr),
-    theAnodeData(nullptr),
-    theALCTTrailer(nullptr),
-    theTMBData(nullptr),
-    theDMBTrailer(format_version),
-    theChamberType(chamberType),
-    alctZSErecovered(nullptr),
-    zseEnable(0),
-    theFormatVersion(format_version)
-{
-
-  for (unsigned i = 0; i < MAX_CFEB; ++i)
-    {
-      theCFEBData[i] = nullptr;
-    }
+CSCEventData::CSCEventData(int chamberType, uint16_t format_version)
+    : theDMBHeader(format_version),
+      theALCTHeader(nullptr),
+      theAnodeData(nullptr),
+      theALCTTrailer(nullptr),
+      theTMBData(nullptr),
+      theDMBTrailer(format_version),
+      theChamberType(chamberType),
+      alctZSErecovered(nullptr),
+      zseEnable(0),
+      theFormatVersion(format_version) {
+  for (unsigned i = 0; i < MAX_CFEB; ++i) {
+    theCFEBData[i] = nullptr;
+  }
 }
 
-
-CSCEventData::CSCEventData(const uint16_t * buf, uint16_t format_version): theFormatVersion(format_version)
-{
+CSCEventData::CSCEventData(const uint16_t* buf, uint16_t format_version) : theFormatVersion(format_version) {
   theFormatVersion = format_version;
   unpack_data(buf);
 }
 
-
-void CSCEventData::unpack_data(const uint16_t * buf)
-{
+void CSCEventData::unpack_data(const uint16_t* buf) {
   // zero everything
   init();
-  const uint16_t * pos = buf;
-  if (debug)
-    {
-      LogTrace ("CSCEventData|CSCRawToDigi") << "The event data ";
-      for (int i = 0; i < 16; ++i)
-        {
-          LogTrace ("CSCEventData|CSCRawToDigi") << std::hex << pos[i ] << " ";
-        }
+  const uint16_t* pos = buf;
+  if (debug) {
+    LogTrace("CSCEventData|CSCRawToDigi") << "The event data ";
+    for (int i = 0; i < 16; ++i) {
+      LogTrace("CSCEventData|CSCRawToDigi") << std::hex << pos[i] << " ";
     }
+  }
 
   theDMBHeader = CSCDMBHeader(pos, theFormatVersion);
-  if (!(theDMBHeader.check()))
-    {
-      LogTrace ("CSCEventData|CSCRawToDigi")  << "Bad DMB Header??? " << " first four words: ";
-      for (int i = 0; i < 4; ++i)
-        {
-          LogTrace ("CSCEventData|CSCRawToDigi") << std::hex << pos[i ] << " ";
-        }
+  if (!(theDMBHeader.check())) {
+    LogTrace("CSCEventData|CSCRawToDigi") << "Bad DMB Header??? "
+                                          << " first four words: ";
+    for (int i = 0; i < 4; ++i) {
+      LogTrace("CSCEventData|CSCRawToDigi") << std::hex << pos[i] << " ";
     }
+  }
 
+  if (debug) {
+    LogTrace("CSCEventData|CSCRawToDigi") << "nalct = " << nalct();
+    LogTrace("CSCEventData|CSCRawToDigi") << "nclct = " << nclct();
+  }
 
-  if (debug)
-    {
-      LogTrace ("CSCEventData|CSCRawToDigi") << "nalct = " << nalct();
-      LogTrace ("CSCEventData|CSCRawToDigi") << "nclct = " << nclct();
-    }
-
-  if (debug)
-    {
-      LogTrace ("CSCEventData|CSCRawToDigi") << "size in words of DMBHeader" << theDMBHeader.sizeInWords();
-      LogTrace ("CSCEventData|CSCRawToDigi") << "sizeof(DMBHeader)" << sizeof(theDMBHeader);
-    }
+  if (debug) {
+    LogTrace("CSCEventData|CSCRawToDigi") << "size in words of DMBHeader" << theDMBHeader.sizeInWords();
+    LogTrace("CSCEventData|CSCRawToDigi") << "sizeof(DMBHeader)" << sizeof(theDMBHeader);
+  }
 
   pos += theDMBHeader.sizeInWords();
 
-  if (nalct() ==1)
+  if (nalct() == 1) {
+    if (isALCT(pos))  //checking for ALCTData
     {
-      if (isALCT(pos))  //checking for ALCTData
-        {
-          theALCTHeader = new CSCALCTHeader( pos );
-          if (!theALCTHeader->check())
-            {
-              LogTrace ("CSCEventData|CSCRawToDigi") <<"+++WARNING: Corrupt ALCT data - won't attempt to decode";
-            }
-          else
-            {
-              //dataPresent|=0x40;
-              pos += theALCTHeader->sizeInWords(); //size of the header
-              //fill ALCT Digis
-              theALCTHeader->ALCTDigis();
+      theALCTHeader = new CSCALCTHeader(pos);
+      if (!theALCTHeader->check()) {
+        LogTrace("CSCEventData|CSCRawToDigi") << "+++WARNING: Corrupt ALCT data - won't attempt to decode";
+      } else {
+        //dataPresent|=0x40;
+        pos += theALCTHeader->sizeInWords();  //size of the header
+        //fill ALCT Digis
+        theALCTHeader->ALCTDigis();
 
-              //theAnodeData = new CSCAnodeData(*theALCTHeader, pos);
+        //theAnodeData = new CSCAnodeData(*theALCTHeader, pos);
 
-
-              /// The size of the ALCT payload is determined here
-              /*
+        /// The size of the ALCT payload is determined here
+        /*
               std::cout << " ****The ALCT information from CSCEventData.cc (begin)**** " << std::endl; ///to_rm
               std::cout << " alctHeader2007().size: " << theALCTHeader->alctHeader2007().sizeInWords() << std::endl; ///to_rm
               std::cout << " ALCT Header Content: " << std::endl; ///to_rm
@@ -113,37 +94,36 @@ void CSCEventData::unpack_data(const uint16_t * buf)
                            << " " << theALCTHeader->data()[k] << std::dec << std::endl;
                  }
                */
-              //std::cout << " ALCT Size: " << theAnodeData->sizeInWords() << std::endl;
-              /// Check if Zero Suppression ALCT Enabled
-              // int zseEnable = 0;
-              zseEnable = (theALCTHeader->data()[5] & 0x1000) >> 12;
-              //std::cout << " ZSE Bit: " <<  zseEnable << std::endl; /// to_rm
-              int sizeInWord_ZSE =0;
+        //std::cout << " ALCT Size: " << theAnodeData->sizeInWords() << std::endl;
+        /// Check if Zero Suppression ALCT Enabled
+        // int zseEnable = 0;
+        zseEnable = (theALCTHeader->data()[5] & 0x1000) >> 12;
+        //std::cout << " ZSE Bit: " <<  zseEnable << std::endl; /// to_rm
+        int sizeInWord_ZSE = 0;
 
-              //alctZSErecovered = new unsigned short [theAnodeData->sizeInWords()];
+        //alctZSErecovered = new unsigned short [theAnodeData->sizeInWords()];
 
-              if (zseEnable)
-                {
-                  /// Aauxilary variables neede to recover zero suppression
-                  /// Calculate the number of wire groups per layer
-                  int  nWGs_per_layer = ( (theALCTHeader->data()[6]&0x0007) + 1 ) * 16 ;
-                  /// Calculate the number of words in the layer
-                  int nWG_round_up   = int(nWGs_per_layer/12)+(nWGs_per_layer%3?1:0);
-                  //std::cout << " Words per layer: " << nWG_round_up << std::endl; ///to_rm
-                  const uint16_t * posZSE = pos;
-                  std::vector<unsigned short> alctZSErecoveredVector;
-                  alctZSErecoveredVector.clear();
+        if (zseEnable) {
+          /// Aauxilary variables neede to recover zero suppression
+          /// Calculate the number of wire groups per layer
+          int nWGs_per_layer = ((theALCTHeader->data()[6] & 0x0007) + 1) * 16;
+          /// Calculate the number of words in the layer
+          int nWG_round_up = int(nWGs_per_layer / 12) + (nWGs_per_layer % 3 ? 1 : 0);
+          //std::cout << " Words per layer: " << nWG_round_up << std::endl; ///to_rm
+          const uint16_t* posZSE = pos;
+          std::vector<unsigned short> alctZSErecoveredVector;
+          alctZSErecoveredVector.clear();
 
-                  //alctZSErecovered = new unsigned short [theAnodeData->sizeInWords()];
-                  //delete [] alctZSErecovered;
-                  //std::cout << " ALCT Buffer with ZSE: " << std::endl; ///to_rm
-                  /// unsigned short * posZSEtmpALCT = pos;
-                  /// This is just to dump the actual ALCT payload ** begin **
-                  /// For debuggin purposes
-                  //unsigned short * posZSEdebug = pos; ///to_rm
+          //alctZSErecovered = new unsigned short [theAnodeData->sizeInWords()];
+          //delete [] alctZSErecovered;
+          //std::cout << " ALCT Buffer with ZSE: " << std::endl; ///to_rm
+          /// unsigned short * posZSEtmpALCT = pos;
+          /// This is just to dump the actual ALCT payload ** begin **
+          /// For debuggin purposes
+          //unsigned short * posZSEdebug = pos; ///to_rm
 
-                  /// to_rm (8 lines)
-                  /*
+          /// to_rm (8 lines)
+          /*
                   while (*posZSEdebug != 0xDE0D){
                         unsigned short d = *posZSEdebug;
                         unsigned short c = *(posZSEdebug+1);
@@ -153,43 +133,37 @@ void CSCEventData::unpack_data(const uint16_t * buf)
                         std::cout << std::hex << a << " " << b << " " << c << " " << d << std::dec << std::endl;
                   }
                   */
-                  /// This is just to dump the actual ALCT payload ** end **
+          /// This is just to dump the actual ALCT payload ** end **
 
-                  /// Actual word counting and recovering the original ALCT payload
-                  int alctZSErecoveredPos=0;
-                  while (*posZSE != 0xDE0D)
-                    {
-                      if ( (*posZSE == 0x1000) && (*posZSE != 0x3000))
-                        {
-                          for (int j=0; j<nWG_round_up; j++)
-                            {
-                              alctZSErecoveredVector.push_back(0x0000);
-                            }
-                          alctZSErecoveredPos+=nWG_round_up;
-                        }
-                      else
-                        {
-                          alctZSErecoveredVector.push_back(*posZSE);
-                          ++alctZSErecoveredPos;
-                        }
-                      posZSE++;
-                      sizeInWord_ZSE++;
-                    }
+          /// Actual word counting and recovering the original ALCT payload
+          int alctZSErecoveredPos = 0;
+          while (*posZSE != 0xDE0D) {
+            if ((*posZSE == 0x1000) && (*posZSE != 0x3000)) {
+              for (int j = 0; j < nWG_round_up; j++) {
+                alctZSErecoveredVector.push_back(0x0000);
+              }
+              alctZSErecoveredPos += nWG_round_up;
+            } else {
+              alctZSErecoveredVector.push_back(*posZSE);
+              ++alctZSErecoveredPos;
+            }
+            posZSE++;
+            sizeInWord_ZSE++;
+          }
 
-                  alctZSErecovered = new unsigned short [alctZSErecoveredVector.size()];
+          alctZSErecovered = new unsigned short[alctZSErecoveredVector.size()];
 
-                  /// Convert the recovered vector into the array
-                  for (int l=0; l<(int)alctZSErecoveredVector.size(); l++)
-                    {
-                      alctZSErecovered[l]=alctZSErecoveredVector[l];
-                    }
+          /// Convert the recovered vector into the array
+          for (int l = 0; l < (int)alctZSErecoveredVector.size(); l++) {
+            alctZSErecovered[l] = alctZSErecoveredVector[l];
+          }
 
-                  unsigned short *posRecovered = alctZSErecovered;
-                  theAnodeData = new CSCAnodeData(*theALCTHeader, posRecovered);
+          unsigned short* posRecovered = alctZSErecovered;
+          theAnodeData = new CSCAnodeData(*theALCTHeader, posRecovered);
 
-                  /// This is to check the content of the recovered ALCT payload
-                  /// to_rm (7 lines)
-                  /*
+          /// This is to check the content of the recovered ALCT payload
+          /// to_rm (7 lines)
+          /*
                   std::cout << " The ALCT payload recovered: " << std::endl;
                   for(int k=0; k<theAnodeData->sizeInWords(); k+=4){
                      std::cout << std::hex << alctZSErecovered[k+3] << " "
@@ -198,187 +172,146 @@ void CSCEventData::unpack_data(const uint16_t * buf)
                                            << alctZSErecovered[k] << std::dec << std::endl;
                   }
                   */
-                  //delete [] alctZSErecovered;
-                  //std::cout << " ALCT SizeZSE : " << sizeInWord_ZSE << std::endl; ///to_rm
-                  //std::cout << " ALCT SizeZSE Recovered: " << alctZSErecoveredPos << std::endl; ///to_rm
-                  //std::cout << " ALCT Size Expected: " << theAnodeData->sizeInWords() << std::endl; ///to_rm
-                  pos +=sizeInWord_ZSE;
-                }
-              else
-                {
-                  //pos +=sizeInWord_ZSE;
-                  theAnodeData = new CSCAnodeData(*theALCTHeader, pos);
-                  pos += theAnodeData->sizeInWords(); // size of the data is determined during unpacking
-                }
-              //std::cout << " ****The ALCT information from CSCEventData.cc (end)**** " << std::endl; ///to_rm
-              theALCTTrailer = new CSCALCTTrailer( pos );
-              pos += theALCTTrailer->sizeInWords();
-            }
+          //delete [] alctZSErecovered;
+          //std::cout << " ALCT SizeZSE : " << sizeInWord_ZSE << std::endl; ///to_rm
+          //std::cout << " ALCT SizeZSE Recovered: " << alctZSErecoveredPos << std::endl; ///to_rm
+          //std::cout << " ALCT Size Expected: " << theAnodeData->sizeInWords() << std::endl; ///to_rm
+          pos += sizeInWord_ZSE;
+        } else {
+          //pos +=sizeInWord_ZSE;
+          theAnodeData = new CSCAnodeData(*theALCTHeader, pos);
+          pos += theAnodeData->sizeInWords();  // size of the data is determined during unpacking
         }
-      else
-        {
-          LogTrace ("CSCEventData|CSCRawToDigi") << "Error:nalct reported but no ALCT data found!!!";
-        }
+        //std::cout << " ****The ALCT information from CSCEventData.cc (end)**** " << std::endl; ///to_rm
+        theALCTTrailer = new CSCALCTTrailer(pos);
+        pos += theALCTTrailer->sizeInWords();
+      }
+    } else {
+      LogTrace("CSCEventData|CSCRawToDigi") << "Error:nalct reported but no ALCT data found!!!";
     }
+  }
 
-  if (nclct() ==1)
-    {
-      if (isTMB(pos))
-        {
-          //dataPresent|=0x20;
-          theTMBData = new CSCTMBData(pos);  //fill all TMB data
-          pos += theTMBData->size();
-        }
-      else
-        {
-          LogTrace ("CSCEventData|CSCRawToDigi") << "Error:nclct reported but no TMB data found!!!";
-        }
+  if (nclct() == 1) {
+    if (isTMB(pos)) {
+      //dataPresent|=0x20;
+      theTMBData = new CSCTMBData(pos);  //fill all TMB data
+      pos += theTMBData->size();
+    } else {
+      LogTrace("CSCEventData|CSCRawToDigi") << "Error:nclct reported but no TMB data found!!!";
     }
+  }
 
   //now let's try to find and unpack the DMBTrailer
-  bool dmbTrailerReached= false;
-  for (int i=0; i<12000; ++i)  //8000 max for cfeb + 1980ALCT + 287 TMB
-    {
-      dmbTrailerReached =
-        (*(i+pos) & 0xF000) == 0xF000 && (*(i+pos+1) & 0xF000) == 0xF000
-        && (*(i+pos+2) & 0xF000) == 0xF000 && (*(i+pos+3) & 0xF000) == 0xF000
-        && (*(i+pos+4) & 0xF000) == 0xE000 && (*(i+pos+5) & 0xF000) == 0xE000
-        && (*(i+pos+6) & 0xF000) == 0xE000 && (*(i+pos+7) & 0xF000) == 0xE000;
-      if (dmbTrailerReached)
-        {
-          // theDMBTrailer = *( (CSCDMBTrailer *) (pos+i) );
-          theDMBTrailer = CSCDMBTrailer(pos+i, theFormatVersion);
-          break;
-        }
+  bool dmbTrailerReached = false;
+  for (int i = 0; i < 12000; ++i)  //8000 max for cfeb + 1980ALCT + 287 TMB
+  {
+    dmbTrailerReached = (*(i + pos) & 0xF000) == 0xF000 && (*(i + pos + 1) & 0xF000) == 0xF000 &&
+                        (*(i + pos + 2) & 0xF000) == 0xF000 && (*(i + pos + 3) & 0xF000) == 0xF000 &&
+                        (*(i + pos + 4) & 0xF000) == 0xE000 && (*(i + pos + 5) & 0xF000) == 0xE000 &&
+                        (*(i + pos + 6) & 0xF000) == 0xE000 && (*(i + pos + 7) & 0xF000) == 0xE000;
+    if (dmbTrailerReached) {
+      // theDMBTrailer = *( (CSCDMBTrailer *) (pos+i) );
+      theDMBTrailer = CSCDMBTrailer(pos + i, theFormatVersion);
+      break;
     }
-  if (dmbTrailerReached)
-    {
-      for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
-        {
-          theCFEBData[icfeb] = nullptr;
-          int cfeb_available = theDMBHeader.cfebAvailable(icfeb);
-          unsigned int cfebTimeout = theDMBTrailer.cfeb_starttimeout() | theDMBTrailer.cfeb_endtimeout();
-          //cfeb_available cannot be trusted - need additional verification!
-          if ( cfeb_available==1 )
-            {
-              if ((cfebTimeout >> icfeb) & 1)
-                {
-                  if (debug) LogTrace ("CSCEventData|CSCRawToDigi") << "CFEB Timed out! ";
-                }
-              else
-                {
-                  //dataPresent|=(0x1>>icfeb);
-                  // Fill CFEB data and convert it into cathode digis
+  }
+  if (dmbTrailerReached) {
+    for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb) {
+      theCFEBData[icfeb] = nullptr;
+      int cfeb_available = theDMBHeader.cfebAvailable(icfeb);
+      unsigned int cfebTimeout = theDMBTrailer.cfeb_starttimeout() | theDMBTrailer.cfeb_endtimeout();
+      //cfeb_available cannot be trusted - need additional verification!
+      if (cfeb_available == 1) {
+        if ((cfebTimeout >> icfeb) & 1) {
+          if (debug)
+            LogTrace("CSCEventData|CSCRawToDigi") << "CFEB Timed out! ";
+        } else {
+          //dataPresent|=(0x1>>icfeb);
+          // Fill CFEB data and convert it into cathode digis
 
-                  // Check if we have here DCFEB  using DMB format version field (new ME11 with DCFEBs - 0x2, other chamber types 0x1)
-                  bool isDCFEB = false;
-                  if (theDMBHeader.format_version() == 2) isDCFEB = true;
+          // Check if we have here DCFEB  using DMB format version field (new ME11 with DCFEBs - 0x2, other chamber types 0x1)
+          bool isDCFEB = false;
+          if (theDMBHeader.format_version() == 2)
+            isDCFEB = true;
 
-                  theCFEBData[icfeb] = new CSCCFEBData(icfeb, pos, theFormatVersion, isDCFEB);
-                  pos += theCFEBData[icfeb]->sizeInWords();
-                }
-            }
+          theCFEBData[icfeb] = new CSCCFEBData(icfeb, pos, theFormatVersion, isDCFEB);
+          pos += theCFEBData[icfeb]->sizeInWords();
         }
-      pos += theDMBTrailer.sizeInWords();
-      size_ = pos-buf;
+      }
     }
-  else
-    {
-      LogTrace ("CSCEventData|CSCRawToDigi") << "Critical Error: DMB Trailer was not found!!! ";
-    }
+    pos += theDMBTrailer.sizeInWords();
+    size_ = pos - buf;
+  } else {
+    LogTrace("CSCEventData|CSCRawToDigi") << "Critical Error: DMB Trailer was not found!!! ";
+  }
 
   // std::cout << "CSC format: " << theFormatVersion << " " << getFormatVersion() << std::endl;
 }
 
-bool CSCEventData::isALCT(const short unsigned int * buf)
-{
-  return (((buf[0]&0xFFFF)==0xDB0A)||(((buf[0]&0xF800)==0x6000)&&((buf[1]&0xF800)==0)));
+bool CSCEventData::isALCT(const short unsigned int* buf) {
+  return (((buf[0] & 0xFFFF) == 0xDB0A) || (((buf[0] & 0xF800) == 0x6000) && ((buf[1] & 0xF800) == 0)));
 }
 
-bool CSCEventData::isTMB(const short unsigned int * buf)
-{
-  return ((buf[0]&0xFFF)==0xB0C);
-}
+bool CSCEventData::isTMB(const short unsigned int* buf) { return ((buf[0] & 0xFFF) == 0xB0C); }
 
+CSCEventData::CSCEventData(const CSCEventData& data) { copy(data); }
 
+CSCEventData::~CSCEventData() { destroy(); }
 
-CSCEventData::CSCEventData(const CSCEventData & data)
-{
-  copy(data);
-}
-
-CSCEventData::~CSCEventData()
-{
-  destroy();
-}
-
-
-CSCEventData CSCEventData::operator=(const CSCEventData & data)
-{
+CSCEventData CSCEventData::operator=(const CSCEventData& data) {
   // check for self-assignment before destructing
-  if (&data != this) destroy();
+  if (&data != this)
+    destroy();
   copy(data);
   return *this;
 }
 
-
-void CSCEventData::init()
-{
+void CSCEventData::init() {
   //dataPresent = 0;
   theALCTHeader = nullptr;
   theAnodeData = nullptr;
   theALCTTrailer = nullptr;
   theTMBData = nullptr;
-  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
-    {
-      theCFEBData[icfeb] = nullptr;
-    }
-  alctZSErecovered=nullptr;
-  zseEnable=0;
+  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb) {
+    theCFEBData[icfeb] = nullptr;
+  }
+  alctZSErecovered = nullptr;
+  zseEnable = 0;
 }
 
-
-void CSCEventData::copy(const CSCEventData & data)
-{
+void CSCEventData::copy(const CSCEventData& data) {
   init();
   theFormatVersion = data.theFormatVersion;
-  theDMBHeader  = data.theDMBHeader;
+  theDMBHeader = data.theDMBHeader;
   theDMBTrailer = data.theDMBTrailer;
   if (data.theALCTHeader != nullptr)
-    theALCTHeader  = new CSCALCTHeader(*(data.theALCTHeader));
+    theALCTHeader = new CSCALCTHeader(*(data.theALCTHeader));
   if (data.theAnodeData != nullptr)
-    theAnodeData   = new CSCAnodeData(*(data.theAnodeData));
+    theAnodeData = new CSCAnodeData(*(data.theAnodeData));
   if (data.theALCTTrailer != nullptr)
     theALCTTrailer = new CSCALCTTrailer(*(data.theALCTTrailer));
   if (data.theTMBData != nullptr)
-    theTMBData     = new CSCTMBData(*(data.theTMBData));
-  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
-    {
-      theCFEBData[icfeb] = nullptr;
-      if (data.theCFEBData[icfeb] != nullptr)
-        theCFEBData[icfeb] = new CSCCFEBData(*(data.theCFEBData[icfeb]));
-    }
-  size_  = data.size_;
+    theTMBData = new CSCTMBData(*(data.theTMBData));
+  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb) {
+    theCFEBData[icfeb] = nullptr;
+    if (data.theCFEBData[icfeb] != nullptr)
+      theCFEBData[icfeb] = new CSCCFEBData(*(data.theCFEBData[icfeb]));
+  }
+  size_ = data.size_;
   theChamberType = data.theChamberType;
-
-
 }
 
-
-void CSCEventData::destroy()
-{
-  if (zseEnable)
-    {
-      delete [] alctZSErecovered;
-    }
+void CSCEventData::destroy() {
+  if (zseEnable) {
+    delete[] alctZSErecovered;
+  }
   delete theALCTHeader;
   delete theAnodeData;
   delete theALCTTrailer;
   delete theTMBData;
-  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
-    {
-      delete theCFEBData[icfeb];
-    }
+  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb) {
+    delete theCFEBData[icfeb];
+  }
   /*
     std::cout << "Before delete alctZSErecovered " << std::endl;
     delete [] alctZSErecovered;
@@ -386,358 +319,284 @@ void CSCEventData::destroy()
   */
 }
 
-
-std::vector<CSCStripDigi> CSCEventData::stripDigis(const CSCDetId & idlayer) const
-{
+std::vector<CSCStripDigi> CSCEventData::stripDigis(const CSCDetId& idlayer) const {
   std::vector<CSCStripDigi> result;
-  for (unsigned icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
-    {
-      std::vector<CSCStripDigi> newDigis = stripDigis(idlayer, icfeb);
-      result.insert(result.end(), newDigis.begin(), newDigis.end());
-    }
+  for (unsigned icfeb = 0; icfeb < MAX_CFEB; ++icfeb) {
+    std::vector<CSCStripDigi> newDigis = stripDigis(idlayer, icfeb);
+    result.insert(result.end(), newDigis.begin(), newDigis.end());
+  }
   return result;
 }
 
-
-std::vector<CSCStripDigi> CSCEventData::stripDigis(unsigned idlayer, unsigned icfeb) const
-{
+std::vector<CSCStripDigi> CSCEventData::stripDigis(unsigned idlayer, unsigned icfeb) const {
   //  assert(ilayer > 0 && ilayer <= 6); // off because now idlayer is raw cscdetid
   std::vector<CSCStripDigi> result;
-  if (theCFEBData[icfeb] != nullptr)
-    {
-      std::vector<CSCStripDigi> newDigis = theCFEBData[icfeb]->digis(idlayer);
-      result.insert(result.end(), newDigis.begin(), newDigis.end());
-    }
+  if (theCFEBData[icfeb] != nullptr) {
+    std::vector<CSCStripDigi> newDigis = theCFEBData[icfeb]->digis(idlayer);
+    result.insert(result.end(), newDigis.begin(), newDigis.end());
+  }
 
   return result;
 }
 
-
-std::vector<CSCWireDigi> CSCEventData::wireDigis(unsigned ilayer) const
-{
-  if (theAnodeData == nullptr)
-    {
-      return std::vector<CSCWireDigi>();
-    }
-  else
-    {
-      return theAnodeData->wireDigis(ilayer);
-    }
+std::vector<CSCWireDigi> CSCEventData::wireDigis(unsigned ilayer) const {
+  if (theAnodeData == nullptr) {
+    return std::vector<CSCWireDigi>();
+  } else {
+    return theAnodeData->wireDigis(ilayer);
+  }
 }
 
-
-std::vector < std::vector<CSCStripDigi> > CSCEventData::stripDigis() const
-{
-  std::vector < std::vector<CSCStripDigi> > result;
-  for (int layer = 1; layer <= 6; ++layer)
-    {
-      std::vector<CSCStripDigi> digis = stripDigis(layer);
-      result.push_back(digis);
-    }
+std::vector<std::vector<CSCStripDigi> > CSCEventData::stripDigis() const {
+  std::vector<std::vector<CSCStripDigi> > result;
+  for (int layer = 1; layer <= 6; ++layer) {
+    std::vector<CSCStripDigi> digis = stripDigis(layer);
+    result.push_back(digis);
+  }
   return result;
 }
 
-std::vector < std::vector<CSCWireDigi> > CSCEventData::wireDigis() const
-{
-  std::vector < std::vector<CSCWireDigi> > result;
-  for (int layer = 1; layer <= 6; ++layer)
-    {
-      result.push_back(wireDigis(layer));
-    }
+std::vector<std::vector<CSCWireDigi> > CSCEventData::wireDigis() const {
+  std::vector<std::vector<CSCWireDigi> > result;
+  for (int layer = 1; layer <= 6; ++layer) {
+    result.push_back(wireDigis(layer));
+  }
   return result;
 }
 
+const CSCCFEBData* CSCEventData::cfebData(unsigned icfeb) const { return theCFEBData[icfeb]; }
 
-const CSCCFEBData* CSCEventData::cfebData(unsigned icfeb) const
-{
-  return theCFEBData[icfeb];
-}
-
-
-CSCALCTHeader* CSCEventData::alctHeader() const
-{
-  if (nalct() == 0) throw cms::Exception("No ALCT for this chamber");
+CSCALCTHeader* CSCEventData::alctHeader() const {
+  if (nalct() == 0)
+    throw cms::Exception("No ALCT for this chamber");
   return theALCTHeader;
 }
 
-CSCALCTTrailer * CSCEventData::alctTrailer() const
-{
-  if (nalct() == 0) throw cms::Exception("No ALCT for this chamber");
+CSCALCTTrailer* CSCEventData::alctTrailer() const {
+  if (nalct() == 0)
+    throw cms::Exception("No ALCT for this chamber");
   return theALCTTrailer;
 }
 
-
-CSCAnodeData * CSCEventData::alctData() const
-{
-  if (nalct() == 0) throw cms::Exception("No ALCT for this chamber");
+CSCAnodeData* CSCEventData::alctData() const {
+  if (nalct() == 0)
+    throw cms::Exception("No ALCT for this chamber");
   return theAnodeData;
 }
 
-CSCTMBData * CSCEventData::tmbData() const
-{
-  if (nclct() == 0) throw cms::Exception("No CLCT for this chamber");
+CSCTMBData* CSCEventData::tmbData() const {
+  if (nclct() == 0)
+    throw cms::Exception("No CLCT for this chamber");
   return theTMBData;
 }
 
-
-CSCTMBHeader * CSCEventData::tmbHeader() const
-{
-  if ((nclct() == 0)||(tmbData()==nullptr)) throw cms::Exception("No CLCT header for this chamber");
+CSCTMBHeader* CSCEventData::tmbHeader() const {
+  if ((nclct() == 0) || (tmbData() == nullptr))
+    throw cms::Exception("No CLCT header for this chamber");
   return tmbData()->tmbHeader();
 }
 
-CSCCLCTData * CSCEventData::clctData() const
-{
-  if ((nclct() == 0)||(tmbData()==nullptr)) throw cms::Exception("No CLCT data for this chamber");
+CSCCLCTData* CSCEventData::clctData() const {
+  if ((nclct() == 0) || (tmbData() == nullptr))
+    throw cms::Exception("No CLCT data for this chamber");
   return tmbData()->clctData();
 }
 
-
-void CSCEventData::setEventInformation(int bxnum, int lvl1num)
-{
+void CSCEventData::setEventInformation(int bxnum, int lvl1num) {
   theDMBHeader.setBXN(bxnum);
   theDMBHeader.setL1A(lvl1num);
   theDMBHeader.setL1A24(lvl1num);
-  if (theALCTHeader)
-    {
-      theALCTHeader->setEventInformation(theDMBHeader);
+  if (theALCTHeader) {
+    theALCTHeader->setEventInformation(theDMBHeader);
+  }
+  if (theTMBData) {
+    theTMBData->tmbHeader()->setEventInformation(theDMBHeader);
+
+    assert(theChamberType > 0);
+
+    theTMBData->tmbHeader()->setNCFEBs(5);
+
+    // Set number of CFEBs to 7 for Post-LS1 ME11
+    if ((theFormatVersion == 2013) && ((theChamberType == 1) || (theChamberType == 2))) {
+      theTMBData->tmbHeader()->setNCFEBs(7);
     }
-  if (theTMBData)
-    {
-      theTMBData->tmbHeader()->setEventInformation(theDMBHeader);
-
-      assert(theChamberType>0);
-
-      theTMBData->tmbHeader()->setNCFEBs(5);
-
-      // Set number of CFEBs to 7 for Post-LS1 ME11
-      if ((theFormatVersion  == 2013) && ((theChamberType == 1) || (theChamberType == 2)) ) {
-        theTMBData->tmbHeader()->setNCFEBs(7);
-      }
-/*
+    /*
       // Set number of CFEBs to 4 for ME13 chambers
       if (theChamberType == 4) { 
 	theTMBData->tmbHeader()->setNCFEBs(4);
       }
 */
-	
-    }
-  for (unsigned cfeb=0; cfeb< 7; cfeb++)
-    {
-      if (theCFEBData[cfeb]) theCFEBData[cfeb]->setL1A(lvl1num); 
-    }
-}
-
-
-void CSCEventData::checkALCTClasses()
-{
-  if (theAnodeData == nullptr)
-    {
-      assert(theChamberType>0);
-      theALCTHeader = new CSCALCTHeader(theChamberType);
-      theALCTHeader->setEventInformation(theDMBHeader);
-      theAnodeData = new CSCAnodeData(*theALCTHeader);
-      int size = theALCTHeader->sizeInWords() + theAnodeData->sizeInWords() + CSCALCTTrailer::sizeInWords();
-      theALCTTrailer = new CSCALCTTrailer(size, theALCTHeader->alctFirmwareVersion());
-      // set data available flag
-      theDMBHeader.addNALCT();
-    }
-}
-
-
-void CSCEventData::checkTMBClasses()
-{
-  int nCFEBs = 5;
-  if ((theFormatVersion  == 2013) && ((theChamberType == 1) || (theChamberType == 2)) ) {
-      nCFEBs = 7;
   }
-  if (theTMBData == nullptr)
-    {
-      if (theFormatVersion  == 2013) { // Set to TMB format for Post-LS1 data
-        theTMBData = new CSCTMBData(2013, 0x7a76, nCFEBs);
-      } else {
-	theTMBData = new CSCTMBData(2007, 0x50c3);
-      }
-      theTMBData->tmbHeader()->setEventInformation(theDMBHeader);
-      theDMBHeader.addNCLCT();
-    }
-      theTMBData->tmbHeader()->setNCFEBs(nCFEBs);
-   // std::cout << "nCFEBs: " << theTMBData->tmbHeader()->NCFEBs() << std::endl;
+  for (unsigned cfeb = 0; cfeb < 7; cfeb++) {
+    if (theCFEBData[cfeb])
+      theCFEBData[cfeb]->setL1A(lvl1num);
+  }
 }
 
+void CSCEventData::checkALCTClasses() {
+  if (theAnodeData == nullptr) {
+    assert(theChamberType > 0);
+    theALCTHeader = new CSCALCTHeader(theChamberType);
+    theALCTHeader->setEventInformation(theDMBHeader);
+    theAnodeData = new CSCAnodeData(*theALCTHeader);
+    int size = theALCTHeader->sizeInWords() + theAnodeData->sizeInWords() + CSCALCTTrailer::sizeInWords();
+    theALCTTrailer = new CSCALCTTrailer(size, theALCTHeader->alctFirmwareVersion());
+    // set data available flag
+    theDMBHeader.addNALCT();
+  }
+}
 
-void CSCEventData::add(const CSCStripDigi & digi, int layer)
-{
+void CSCEventData::checkTMBClasses() {
+  int nCFEBs = 5;
+  if ((theFormatVersion == 2013) && ((theChamberType == 1) || (theChamberType == 2))) {
+    nCFEBs = 7;
+  }
+  if (theTMBData == nullptr) {
+    if (theFormatVersion == 2013) {  // Set to TMB format for Post-LS1 data
+      theTMBData = new CSCTMBData(2013, 0x7a76, nCFEBs);
+    } else {
+      theTMBData = new CSCTMBData(2007, 0x50c3);
+    }
+    theTMBData->tmbHeader()->setEventInformation(theDMBHeader);
+    theDMBHeader.addNCLCT();
+  }
+  theTMBData->tmbHeader()->setNCFEBs(nCFEBs);
+  // std::cout << "nCFEBs: " << theTMBData->tmbHeader()->NCFEBs() << std::endl;
+}
+
+void CSCEventData::add(const CSCStripDigi& digi, int layer) {
   //@@ need special logic here for ME11
-  unsigned cfeb = (digi.getStrip()-1)/16;
+  unsigned cfeb = (digi.getStrip() - 1) / 16;
   bool sixteenSamples = false;
-  if (digi.getADCCounts().size()==16) sixteenSamples = true;
-  if (theCFEBData[cfeb] == nullptr)
-    {
-      bool isDCFEB = false;
-      if (theDMBHeader.format_version() == 2) isDCFEB = true;
-      theCFEBData[cfeb] = new CSCCFEBData(cfeb, sixteenSamples, theFormatVersion, isDCFEB);
-      theDMBHeader.addCFEB(cfeb);
-    }
+  if (digi.getADCCounts().size() == 16)
+    sixteenSamples = true;
+  if (theCFEBData[cfeb] == nullptr) {
+    bool isDCFEB = false;
+    if (theDMBHeader.format_version() == 2)
+      isDCFEB = true;
+    theCFEBData[cfeb] = new CSCCFEBData(cfeb, sixteenSamples, theFormatVersion, isDCFEB);
+    theDMBHeader.addCFEB(cfeb);
+  }
   theCFEBData[cfeb]->add(digi, layer);
-  
-  
 }
 
-
-void CSCEventData::add(const CSCWireDigi & digi, int layer)
-{
+void CSCEventData::add(const CSCWireDigi& digi, int layer) {
   checkALCTClasses();
   theAnodeData->add(digi, layer);
   theALCTHeader->setDAVForChannel(digi.getWireGroup());
   theALCTHeader->setBXNCount(digi.getWireGroupBX());
-  
 }
 
-void CSCEventData::add(const CSCComparatorDigi & digi, int layer)
-{
+void CSCEventData::add(const CSCComparatorDigi& digi, int layer) {
   checkTMBClasses();
   theTMBData->clctData()->add(digi, layer);
-  
 }
 
-void CSCEventData::add(const CSCComparatorDigi & digi, const CSCDetId & cid)
-{
+void CSCEventData::add(const CSCComparatorDigi& digi, const CSCDetId& cid) {
   checkTMBClasses();
   theTMBData->clctData()->add(digi, cid);
-  
 }
 
-
-
-void CSCEventData::add(const std::vector<CSCALCTDigi> & digis)
-{
+void CSCEventData::add(const std::vector<CSCALCTDigi>& digis) {
   checkALCTClasses();
   theALCTHeader->add(digis);
 }
 
-
-void CSCEventData::add(const std::vector<CSCCLCTDigi> & digis)
-{
+void CSCEventData::add(const std::vector<CSCCLCTDigi>& digis) {
   checkTMBClasses();
   theTMBData->tmbHeader()->add(digis);
 }
 
-void CSCEventData::add(const std::vector<CSCCorrelatedLCTDigi> & digis)
-{
+void CSCEventData::add(const std::vector<CSCCorrelatedLCTDigi>& digis) {
   checkTMBClasses();
   theTMBData->tmbHeader()->add(digis);
 }
 
-
-
-
-std::ostream & operator<<(std::ostream & os, const CSCEventData & evt)
-{
-  for (int ilayer = 1; ilayer <= 6; ++ilayer)
-    {
-      std::vector<CSCStripDigi> stripDigis = evt.stripDigis(ilayer);
-      //copy(stripDigis.begin(), stripDigis.end(), std::ostream_iterator<CSCStripDigi>(os, "\n"));
-      //print your scas here
-      std::vector<CSCWireDigi> wireDigis = evt.wireDigis(ilayer);
-      //copy(wireDigis.begin(), wireDigis.end(), std::ostream_iterator<CSCWireDigi>(os, "\n"));
-    }
+std::ostream& operator<<(std::ostream& os, const CSCEventData& evt) {
+  for (int ilayer = 1; ilayer <= 6; ++ilayer) {
+    std::vector<CSCStripDigi> stripDigis = evt.stripDigis(ilayer);
+    //copy(stripDigis.begin(), stripDigis.end(), std::ostream_iterator<CSCStripDigi>(os, "\n"));
+    //print your scas here
+    std::vector<CSCWireDigi> wireDigis = evt.wireDigis(ilayer);
+    //copy(wireDigis.begin(), wireDigis.end(), std::ostream_iterator<CSCWireDigi>(os, "\n"));
+  }
   return os;
 }
 
-boost::dynamic_bitset<> CSCEventData::pack()
-{
-  boost::dynamic_bitset<> result = bitset_utilities::ushortToBitset( theDMBHeader.sizeInWords()*16,
-                                   theDMBHeader.data());
+boost::dynamic_bitset<> CSCEventData::pack() {
+  boost::dynamic_bitset<> result =
+      bitset_utilities::ushortToBitset(theDMBHeader.sizeInWords() * 16, theDMBHeader.data());
 
   // Container for CRC calculations
   std::vector<std::pair<unsigned int, unsigned short*> > crcvec;
 
-  if (theALCTHeader != nullptr)
-    {
-      boost::dynamic_bitset<> alctHeader = theALCTHeader->pack();
-      result = bitset_utilities::append(result, alctHeader);
-      crcvec.push_back(std::make_pair(theALCTHeader->sizeInWords(), theALCTHeader->data()));
-    }
-  if (theAnodeData != nullptr)
-    {
-      boost::dynamic_bitset<> anodeData = bitset_utilities::ushortToBitset (theAnodeData->sizeInWords()*16,
-                                          theAnodeData->data());
-      result = bitset_utilities::append(result, anodeData);
-      crcvec.push_back(std::make_pair(theAnodeData->sizeInWords(), theAnodeData->data()));
+  if (theALCTHeader != nullptr) {
+    boost::dynamic_bitset<> alctHeader = theALCTHeader->pack();
+    result = bitset_utilities::append(result, alctHeader);
+    crcvec.push_back(std::make_pair(theALCTHeader->sizeInWords(), theALCTHeader->data()));
+  }
+  if (theAnodeData != nullptr) {
+    boost::dynamic_bitset<> anodeData =
+        bitset_utilities::ushortToBitset(theAnodeData->sizeInWords() * 16, theAnodeData->data());
+    result = bitset_utilities::append(result, anodeData);
+    crcvec.push_back(std::make_pair(theAnodeData->sizeInWords(), theAnodeData->data()));
+  }
+  if (theALCTTrailer != nullptr) {
+    unsigned int crc = calcALCTcrc(crcvec);
+    theALCTTrailer->setCRC(crc);
+    boost::dynamic_bitset<> alctTrailer =
+        bitset_utilities::ushortToBitset(theALCTTrailer->sizeInWords() * 16, theALCTTrailer->data());
+    result = bitset_utilities::append(result, alctTrailer);
+  }
+  if (theTMBData != nullptr) {
+    result = bitset_utilities::append(result, theTMBData->pack());
+  }
 
+  for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb) {
+    if (theCFEBData[icfeb] != nullptr) {
+      boost::dynamic_bitset<> cfebData =
+          bitset_utilities::ushortToBitset(theCFEBData[icfeb]->sizeInWords() * 16, theCFEBData[icfeb]->data());
+      result = bitset_utilities::append(result, cfebData);
     }
-  if (theALCTTrailer != nullptr)
-    {
-      unsigned int crc = calcALCTcrc(crcvec);
-      theALCTTrailer->setCRC(crc);
-      boost::dynamic_bitset<> alctTrailer =bitset_utilities::ushortToBitset(theALCTTrailer->sizeInWords()*16,
-                                           theALCTTrailer->data());
-      result = bitset_utilities::append(result, alctTrailer);
+  }
 
-    }
-  if (theTMBData != nullptr)
-    {
-      result  = bitset_utilities::append(result, theTMBData->pack());
-    }
-
-  for (int icfeb = 0;  icfeb < MAX_CFEB;  ++icfeb)
-    {
-      if (theCFEBData[icfeb] != nullptr)
-        {
-          boost::dynamic_bitset<> cfebData = bitset_utilities::ushortToBitset(theCFEBData[icfeb]->sizeInWords()*16,
-                                             theCFEBData[icfeb]->data());
-          result = bitset_utilities::append(result, cfebData);
-        }
-    }
-
-  boost::dynamic_bitset<> dmbTrailer = bitset_utilities::ushortToBitset( theDMBTrailer.sizeInWords()*16,
-                                       theDMBTrailer.data());
+  boost::dynamic_bitset<> dmbTrailer =
+      bitset_utilities::ushortToBitset(theDMBTrailer.sizeInWords() * 16, theDMBTrailer.data());
   result = bitset_utilities::append(result, dmbTrailer);
   return result;
 }
 
-unsigned int CSCEventData::calcALCTcrc(std::vector< std::pair<unsigned int, unsigned short*> > &vec)
-{
-  int CRC=0;
-//  int size=0;
+unsigned int CSCEventData::calcALCTcrc(std::vector<std::pair<unsigned int, unsigned short*> >& vec) {
+  int CRC = 0;
+  //  int size=0;
 
-  for (unsigned int n = 0; n < vec.size(); n++)
-    {
-//      size += vec[n].first;
-      for (uint16_t j=0, w=0; j<vec[n].first; j++ )
-        {
-	 
-          if (vec[n].second != nullptr) { 
-          w = vec[n].second[j] & 0xffff;
-          for (uint32_t i=15, t=0, ncrc=0; i<16; i--)
-            {
-              t = ((w >> i) & 1) ^ ((CRC >> 21) & 1);
-              ncrc = (CRC << 1) & 0x3ffffc;
-              ncrc |= (t ^ (CRC & 1)) << 1;
-              ncrc |= t;
-              CRC = ncrc;
-            }
-
-	  }
-
+  for (unsigned int n = 0; n < vec.size(); n++) {
+    //      size += vec[n].first;
+    for (uint16_t j = 0, w = 0; j < vec[n].first; j++) {
+      if (vec[n].second != nullptr) {
+        w = vec[n].second[j] & 0xffff;
+        for (uint32_t i = 15, t = 0, ncrc = 0; i < 16; i--) {
+          t = ((w >> i) & 1) ^ ((CRC >> 21) & 1);
+          ncrc = (CRC << 1) & 0x3ffffc;
+          ncrc |= (t ^ (CRC & 1)) << 1;
+          ncrc |= t;
+          CRC = ncrc;
         }
+      }
     }
+  }
 
   //  std::cout << "ALCT CRC vector size: " << size <<  ", crc: 0x" << std::hex << CRC<< std::endl;
   return CRC;
 }
 
-
-
-void CSCEventData::selfTest()
-{
+void CSCEventData::selfTest() {
   CSCEventData chamberData(5);
   CSCDetId detId(1, 3, 2, 1, 3);
   std::vector<CSCCLCTDigi> clctDigis;
   // Both CLCTs are read-out at the same (pre-trigger) bx, so the last-but-one
   // arguments in both digis must be the same.
-  clctDigis.push_back(CSCCLCTDigi(1, 1, 4, 1, 0, 30, 3, 2, 1)); // valid for 2007
+  clctDigis.push_back(CSCCLCTDigi(1, 1, 4, 1, 0, 30, 3, 2, 1));  // valid for 2007
   clctDigis.push_back(CSCCLCTDigi(1, 1, 2, 1, 1, 31, 1, 2, 2));
 
   // BX of LCT (8th argument) is 1-bit word (the least-significant bit
@@ -757,8 +616,8 @@ void CSCEventData::selfTest()
   CSCEventData newData = cscPackAndUnpack(chamberData);
 
   std::vector<CSCCLCTDigi> clcts = newData.tmbHeader()->CLCTDigis(detId.rawId());
-  assert(cscPackerCompare(clcts[0],clctDigis[0]));
-  assert(cscPackerCompare(clcts[1],clctDigis[1]));
+  assert(cscPackerCompare(clcts[0], clctDigis[0]));
+  assert(cscPackerCompare(clcts[1], clctDigis[1]));
 
   std::vector<CSCCorrelatedLCTDigi> lcts = newData.tmbHeader()->CorrelatedLCTDigis(detId.rawId());
   assert(cscPackerCompare(lcts[0], corrDigis[0]));
@@ -771,7 +630,7 @@ void CSCEventData::selfTest()
   CSCDetId me1bdet2(2, 1, 4, 4, 5);
 
   std::vector<int> sca(16, 600);
-  std::vector<unsigned short> overflow(16, 0), overlap(16, 0), errorfl(16,0);
+  std::vector<unsigned short> overflow(16, 0), overlap(16, 0), errorfl(16, 0);
   CSCStripDigi me1a(5, sca, overflow, overlap, errorfl);
   CSCStripDigi me1b(8, sca, overflow, overlap, errorfl);
 
@@ -801,6 +660,4 @@ void CSCEventData::selfTest()
   assert(me1bfs[7].pedestal() == 600);
   assert(me1abs[4].pedestal() == 600);
   assert(me1bbs[7].pedestal() == 600);
-
-
 }

--- a/EventFilter/CSCRawToDigi/src/CSCRPCData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCRPCData.cc
@@ -4,7 +4,7 @@
 
 #include <string>
 #include <cstdio>
-#include <strings.h> // for bzero
+#include <strings.h>  // for bzero
 #include <cstring>
 
 /** data format is
@@ -22,118 +22,111 @@ bool CSCRPCData::debug = false;
 std::atomic<bool> CSCRPCData::debug{false};
 #endif
 
-CSCRPCData::CSCRPCData(int ntbins) 
-  : ntbins_(ntbins), size_( 0 )
-{
+CSCRPCData::CSCRPCData(int ntbins) : ntbins_(ntbins), size_(0) {
   theData[0] = 0x6b04;
-  for(int i = 1; i < 257; ++i) {
+  for (int i = 1; i < 257; ++i) {
     // data format is bits 12-14 are RPC number, 0 to 3
-    int rpc = (i-1)/14;
+    int rpc = (i - 1) / 14;
     theData[i] = rpc << 12;
 
     // bits 8-11 of the first word of the pair is time bin
-    int tbin = ((i-1)%14)/2;
+    int tbin = ((i - 1) % 14) / 2;
     theData[i] |= tbin << 8;
   }
-  theData[257] = 0x6e04;  
+  theData[257] = 0x6e04;
 }
 
-CSCRPCData::CSCRPCData(const unsigned short * buf, int length) 
-  : size_(length)
-{
+CSCRPCData::CSCRPCData(const unsigned short* buf, int length) : size_(length) {
   //size_ = ntbins_*2*4+2;
   // header & trailer word, + 4 RPCs per time bin, 2 lines per RPC
-  ntbins_ = (size_-2)/8;
-  memcpy(theData, buf, size_*2);
+  ntbins_ = (size_ - 2) / 8;
+  memcpy(theData, buf, size_ * 2);
 }
 
 void CSCRPCData::Print() const {
-  LogTrace ("CSCRPCData|CSCRawToDigi") << "CSCRPCData.Print";
-  for(int line = 0; line < ((size_)); ++line) {
-    LogTrace("CSCRPCData|CSCRawToDigi") <<std::hex << theData[line];
+  LogTrace("CSCRPCData|CSCRawToDigi") << "CSCRPCData.Print";
+  for (int line = 0; line < ((size_)); ++line) {
+    LogTrace("CSCRPCData|CSCRawToDigi") << std::hex << theData[line];
   }
-  
-  for(int linePair = 0; linePair < ((size_-2)/2); ++linePair) {
+
+  for (int linePair = 0; linePair < ((size_ - 2) / 2); ++linePair) {
     // skip header word
-    int pos = linePair*2 + 1;
+    int pos = linePair * 2 + 1;
     // make the two pad words into one and see if it's empty
     //int pad = theData[pos] & 0xff + ((theData[pos+1] & 0x3f) << 8);
-  
-    int bxnnew = ((theData[pos+1] >> 8)  & 0x7 );
-  
-    int rpc  = (theData[pos]   >> 12) & 0x7;
-    int tbin = (theData[pos]   >> 8)  & 0xf;
-    int bxn  = bxnnew;
-  
-    LogTrace ("CSCRPCData|CSCRawToDigi") << " RPC=" << rpc << " Tbin=" <<tbin <<" BXN=" << bxn;
-  
+
+    int bxnnew = ((theData[pos + 1] >> 8) & 0x7);
+
+    int rpc = (theData[pos] >> 12) & 0x7;
+    int tbin = (theData[pos] >> 8) & 0xf;
+    int bxn = bxnnew;
+
+    LogTrace("CSCRPCData|CSCRawToDigi") << " RPC=" << rpc << " Tbin=" << tbin << " BXN=" << bxn;
   }
 }
 
 std::vector<int> CSCRPCData::BXN() const {
   std::vector<int> result;
-  for(int linePair = 0; linePair < ((size_-2)/2); ++linePair) {
+  for (int linePair = 0; linePair < ((size_ - 2) / 2); ++linePair) {
     // skip header word
-    int pos = linePair*2 + 1;
+    int pos = linePair * 2 + 1;
     /// make the two pad words into one and see if it's empty
     //int pad = theData[pos] & 0xff + ((theData[pos+1] & 0x3f) << 8);
-   
-    int bxnnew = ((theData[pos+1] >> 8)  & 0x7 ) ;
+
+    int bxnnew = ((theData[pos + 1] >> 8) & 0x7);
     //int bxnnew = (((theData[pos+1] >> 8)  & 0x3 )<<2) | ((theData[pos+1]>>6)&0x3) ;
-   
-    int rpc  = (theData[pos]   >> 12) & 0x7;
+
+    int rpc = (theData[pos] >> 12) & 0x7;
     //int tbin = (theData[pos]   >> 8)  & 0xf;
     //int bxn  = bxnnew;
     result.push_back(bxnnew);
     result.push_back(rpc);
-
-   
   }
   return result;
 }
 
 std::vector<CSCRPCDigi> CSCRPCData::digis() const {
   std::vector<CSCRPCDigi> result;
-  int bxnold =0 ;
-  int bxnnew =0 ;
+  int bxnold = 0;
+  int bxnnew = 0;
   //int bxnewGreg;
-  for(int linePair = 0; linePair < ((size_-2)/2); ++linePair) {
+  for (int linePair = 0; linePair < ((size_ - 2) / 2); ++linePair) {
     // skip header word
-    int pos = linePair*2 + 1;
-    //  LogTrace("RPC") << "+++ CSCRPCData " << std::hex << theData[pos] 
-	//			 << " " << theData[pos+1];
-    if (debug) 
-      LogTrace("CSCRPCData|CSCRawToDigi") << "+++ CSCRPCData " << std::hex << theData[pos] 
-				 << " " << theData[pos+1];
+    int pos = linePair * 2 + 1;
+    //  LogTrace("RPC") << "+++ CSCRPCData " << std::hex << theData[pos]
+    //			 << " " << theData[pos+1];
+    if (debug)
+      LogTrace("CSCRPCData|CSCRawToDigi") << "+++ CSCRPCData " << std::hex << theData[pos] << " " << theData[pos + 1];
     // make the two pad words into one and see if it's empty
-    int pad = (theData[pos] & 0xff) + ((theData[pos+1] & 0xff) << 8);
+    int pad = (theData[pos] & 0xff) + ((theData[pos + 1] & 0xff) << 8);
 
     //bxnnew = (((theData[pos+1] >> 8)  & 0x3 )<<2) | ((theData[pos+1]>>6)&0x3) ;
-    bxnnew = ((theData[pos+1] >> 8)  & 0x7 ) ;
+    bxnnew = ((theData[pos + 1] >> 8) & 0x7);
     //LogTrace("RPC") << "               " << "bxnnew" << " " << bxnnew;
     //LogTrace("RPC") << "               " << "bxnnewGreg" << " " << bxnewGreg;
-    if ( linePair == 0 ) bxnold = bxnnew;
-    if ( bxnnew - bxnold > 1 ) 
-      LogTrace("CSCRPCData|CSCRawToDigi") << "+++ CSCRPCData warning: RPC BXN is incrementing by more than 1 clock cycle";
+    if (linePair == 0)
+      bxnold = bxnnew;
+    if (bxnnew - bxnold > 1)
+      LogTrace("CSCRPCData|CSCRawToDigi")
+          << "+++ CSCRPCData warning: RPC BXN is incrementing by more than 1 clock cycle";
     bxnold = bxnnew;
 
-    if(pad != 0) {
-      if (debug) LogTrace("CSCRPCData|CSCRawToDigi") << "+++ CSCRPCData Found a PAD =" 
-					    << std::hex << pad << " " << theData[pos] 
-					    << " + " << theData[pos+1];
-      int rpc  = (theData[pos]   >> 12) & 0x7;
-      int tbin = (theData[pos]   >> 8)  & 0xf;
-      int bxn  = bxnnew;
+    if (pad != 0) {
+      if (debug)
+        LogTrace("CSCRPCData|CSCRawToDigi")
+            << "+++ CSCRPCData Found a PAD =" << std::hex << pad << " " << theData[pos] << " + " << theData[pos + 1];
+      int rpc = (theData[pos] >> 12) & 0x7;
+      int tbin = (theData[pos] >> 8) & 0xf;
+      int bxn = bxnnew;
       //LogTrace("RPC") << " rpc: " << rpc << " bxn: " << bxn << " tbin: " << tbin;
-      for(int i = 0; i < 16; ++i) {
+      for (int i = 0; i < 16; ++i) {
         // if the bit is set, make a digi
-        if((pad>>i)&1) {
-	  result.push_back(CSCRPCDigi(rpc, i, bxn, tbin));
-	  //LogTrace("RPC") << "digi-->" << " rpc: " << rpc << " i: " << i << " bxn: " << bxn << " tbin: " << tbin;
+        if ((pad >> i) & 1) {
+          result.push_back(CSCRPCDigi(rpc, i, bxn, tbin));
+          //LogTrace("RPC") << "digi-->" << " rpc: " << rpc << " i: " << i << " bxn: " << bxn << " tbin: " << tbin;
         }
       }
-    } 
+    }
   }
   return result;
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
@@ -8,51 +8,38 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB)
-{
+CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(const uint16_t *buf, int Line6BCB, int Line6ECB) {
+  size_ = UnpackBlockedCFEB(buf, Line6BCB, Line6ECB);
 
-  size_ = UnpackBlockedCFEB(buf,Line6BCB,Line6ECB);
+}  ///CSCTMBMiniScope
 
-} ///CSCTMBMiniScope
-
-
-int CSCTMBBlockedCFEB::UnpackBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB)
-{
-
-  if ((Line6ECB-Line6BCB) != 0)
-    {
-
-      for (int i=0; i<(Line6ECB-Line6BCB-1); i++)
-        {
-          BlockedCFEBdata.push_back(buf[Line6BCB+1+i]);
-        }
-
+int CSCTMBBlockedCFEB::UnpackBlockedCFEB(const uint16_t *buf, int Line6BCB, int Line6ECB) {
+  if ((Line6ECB - Line6BCB) != 0) {
+    for (int i = 0; i < (Line6ECB - Line6BCB - 1); i++) {
+      BlockedCFEBdata.push_back(buf[Line6BCB + 1 + i]);
     }
+  }
 
   //print();
-  return (Line6ECB-Line6BCB + 1);
+  return (Line6ECB - Line6BCB + 1);
 
-} ///UnpackBlockedCFEB
+}  ///UnpackBlockedCFEB
 
-std::vector< std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) const
-{
-
-  std::vector< std::vector<int> > CFEBnByLayers;
+std::vector<std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) const {
+  std::vector<std::vector<int> > CFEBnByLayers;
   CFEBnByLayers.clear();
   std::vector<int> CFEBnData;
   CFEBnData.clear();
-  int idCFEB=-1;
+  int idCFEB = -1;
 
   /// Get 4 words for a particular CFEB (CFEBn)
-  for (int i=0; i<(int)getData().size(); ++i)
-    {
-      idCFEB = (getData()[i] >> 12) & 0x7;
-      if (idCFEB==CFEBn)
-        {
-          CFEBnData.push_back(getData()[i] & 0xFFF);
-        }
-      // idCFEB = -1; /* =VB= Commented out to please static analyzer */
+  for (int i = 0; i < (int)getData().size(); ++i) {
+    idCFEB = (getData()[i] >> 12) & 0x7;
+    if (idCFEB == CFEBn) {
+      CFEBnData.push_back(getData()[i] & 0xFFF);
     }
+    // idCFEB = -1; /* =VB= Commented out to please static analyzer */
+  }
 
   std::vector<int> Layer0, Layer1, Layer2, Layer3, Layer4, Layer5;
   Layer0.clear();
@@ -62,46 +49,36 @@ std::vector< std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) 
   Layer4.clear();
   Layer5.clear();
 
-  for (int k=0; k<(int)CFEBnData.size(); ++k)
-    {
-      for (int j=0; j<12; j++)
-        {
-          int DiStr=0;
-          DiStr = (CFEBnData[k] >> j) & 0x1;
-          if ( (DiStr !=0) && (j<8) && (k==0) )
-            {
-              Layer0.push_back(j);
-            }
-          if ((DiStr !=0) && (j>7) && (j<12) && (k==0))
-            {
-              Layer1.push_back(j);
-            }
-          if ((DiStr !=0) && (j<4) && (k==1))
-            {
-              Layer1.push_back(j);
-            }
-          if ((DiStr !=0) && (j>3) && (j<12) && (k==1))
-            {
-              Layer2.push_back(j);
-            }
-          if ( (DiStr !=0) && (j<8) && (k==2) )
-            {
-              Layer3.push_back(j);
-            }
-          if ((DiStr !=0) && (j>7) && (j<12) && (k==2))
-            {
-              Layer4.push_back(j);
-            }
-          if ((DiStr !=0) && (j<4) && (k==3))
-            {
-              Layer4.push_back(j);
-            }
-          if ((DiStr !=0) && (j>3) && (j<12) && (k==3))
-            {
-              Layer5.push_back(j);
-            }
-        }
+  for (int k = 0; k < (int)CFEBnData.size(); ++k) {
+    for (int j = 0; j < 12; j++) {
+      int DiStr = 0;
+      DiStr = (CFEBnData[k] >> j) & 0x1;
+      if ((DiStr != 0) && (j < 8) && (k == 0)) {
+        Layer0.push_back(j);
+      }
+      if ((DiStr != 0) && (j > 7) && (j < 12) && (k == 0)) {
+        Layer1.push_back(j);
+      }
+      if ((DiStr != 0) && (j < 4) && (k == 1)) {
+        Layer1.push_back(j);
+      }
+      if ((DiStr != 0) && (j > 3) && (j < 12) && (k == 1)) {
+        Layer2.push_back(j);
+      }
+      if ((DiStr != 0) && (j < 8) && (k == 2)) {
+        Layer3.push_back(j);
+      }
+      if ((DiStr != 0) && (j > 7) && (j < 12) && (k == 2)) {
+        Layer4.push_back(j);
+      }
+      if ((DiStr != 0) && (j < 4) && (k == 3)) {
+        Layer4.push_back(j);
+      }
+      if ((DiStr != 0) && (j > 3) && (j < 12) && (k == 3)) {
+        Layer5.push_back(j);
+      }
     }
+  }
 
   CFEBnByLayers.push_back(Layer0);
   CFEBnByLayers.push_back(Layer1);
@@ -113,45 +90,36 @@ std::vector< std::vector<int> > CSCTMBBlockedCFEB::getSingleCFEBList(int CFEBn) 
   return CFEBnByLayers;
 }
 
-void CSCTMBBlockedCFEB::print() const
-{
-
+void CSCTMBBlockedCFEB::print() const {
   std::cout << " Blocked CFEB DiStrips List Content " << std::endl;
-  for (int i=0; i<(int)getData().size(); ++i)
-    {
-      std::cout << " word " << i << " : " << std::hex << getData()[i] << std::dec << std::endl;
-    }
+  for (int i = 0; i < (int)getData().size(); ++i) {
+    std::cout << " word " << i << " : " << std::hex << getData()[i] << std::dec << std::endl;
+  }
 
-  std::vector< std::vector<int> > anyCFEB;
+  std::vector<std::vector<int> > anyCFEB;
   anyCFEB.clear();
-  std::vector <int> anyLayer;
+  std::vector<int> anyLayer;
   anyLayer.clear();
   std::cout << std::endl;
   std::cout << " Blocked DiStrips by CFEB and Layers unpacked " << std::endl;
-  for (int z=0; z<5; ++z)
-    {
-      anyCFEB = getSingleCFEBList(z);
-      std::cout << " CFEB# " << z << std::endl;
-      int LayerCnt=0;
-      for (std::vector< std::vector<int> >::const_iterator layerIt=anyCFEB.begin(); layerIt !=anyCFEB.end(); layerIt++)
-        {
-          anyLayer=*layerIt;
-          std::cout << " Layer: " << LayerCnt;
-          if (!anyLayer.empty())
-            {
-              for (int i=0; i<(int)anyLayer.size(); i++)
-                {
-                  std::cout << " " << anyLayer[i];
-                }
-            }
-          else
-            std::cout << " No Blocked DiStrips on the Layer ";
-          std::cout << std::endl;
-          LayerCnt++;
-          anyLayer.clear();
+  for (int z = 0; z < 5; ++z) {
+    anyCFEB = getSingleCFEBList(z);
+    std::cout << " CFEB# " << z << std::endl;
+    int LayerCnt = 0;
+    for (std::vector<std::vector<int> >::const_iterator layerIt = anyCFEB.begin(); layerIt != anyCFEB.end();
+         layerIt++) {
+      anyLayer = *layerIt;
+      std::cout << " Layer: " << LayerCnt;
+      if (!anyLayer.empty()) {
+        for (int i = 0; i < (int)anyLayer.size(); i++) {
+          std::cout << " " << anyLayer[i];
         }
-      anyCFEB.clear();
+      } else
+        std::cout << " No Blocked DiStrips on the Layer ";
+      std::cout << std::endl;
+      LayerCnt++;
+      anyLayer.clear();
     }
-
+    anyCFEB.clear();
+  }
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
@@ -13,110 +13,100 @@
 #include "EventFilter/CSCRawToDigi/src/cscPackerCompare.h"
 
 #ifdef LOCAL_UNPACK
-bool CSCTMBData::debug =false;
+bool CSCTMBData::debug = false;
 #else
 std::atomic<bool> CSCTMBData::debug{false};
 #endif
 
-CSCTMBData::CSCTMBData() 
-  : theOriginalBuffer(nullptr), 
-    theB0CLine( 0 ),
-    theE0FLine( 0 ),
-    theTMBHeader(2007, 0x50c3),
-    theCLCTData(&theTMBHeader),
-    theTMBScopeIsPresent(false), 
-    theTMBScope(nullptr),
-    theTMBMiniScopeIsPresent(false), 
-    theTMBMiniScope(nullptr),
-    theBlockedCFEBIsPresent(false),
-    theTMBBlockedCFEB(nullptr),
-    theTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), 2007),
-    size_( 0 ), 
-    cWordCnt( 0 ),
-    theRPCDataIsPresent(false)
-{
-
-
-}
+CSCTMBData::CSCTMBData()
+    : theOriginalBuffer(nullptr),
+      theB0CLine(0),
+      theE0FLine(0),
+      theTMBHeader(2007, 0x50c3),
+      theCLCTData(&theTMBHeader),
+      theTMBScopeIsPresent(false),
+      theTMBScope(nullptr),
+      theTMBMiniScopeIsPresent(false),
+      theTMBMiniScope(nullptr),
+      theBlockedCFEBIsPresent(false),
+      theTMBBlockedCFEB(nullptr),
+      theTMBTrailer(theTMBHeader.sizeInWords() + theCLCTData.sizeInWords(), 2007),
+      size_(0),
+      cWordCnt(0),
+      theRPCDataIsPresent(false) {}
 
 CSCTMBData::CSCTMBData(int firmwareVersion, int firmwareRevision, int cfebs)
-  : theOriginalBuffer(nullptr),
-    theB0CLine( 0 ),
-    theE0FLine( 0 ),
-    theTMBHeader(firmwareVersion, firmwareRevision),
-    theCLCTData(&theTMBHeader),
-    theTMBScopeIsPresent(false),
-    theTMBScope(nullptr),
-    theTMBMiniScopeIsPresent(false),
-    theTMBMiniScope(nullptr),
-    theBlockedCFEBIsPresent(false),
-    theTMBBlockedCFEB(nullptr),
-    theTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), firmwareVersion),
-    size_( 0 ),
-    cWordCnt( 0 ),
-    theRPCDataIsPresent(false)
-{
-
-   theTMBHeader.setNCFEBs(cfebs);
-   theCLCTData = CSCCLCTData(&theTMBHeader);
-   theTMBTrailer = CSCTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), firmwareVersion);
-
-
+    : theOriginalBuffer(nullptr),
+      theB0CLine(0),
+      theE0FLine(0),
+      theTMBHeader(firmwareVersion, firmwareRevision),
+      theCLCTData(&theTMBHeader),
+      theTMBScopeIsPresent(false),
+      theTMBScope(nullptr),
+      theTMBMiniScopeIsPresent(false),
+      theTMBMiniScope(nullptr),
+      theBlockedCFEBIsPresent(false),
+      theTMBBlockedCFEB(nullptr),
+      theTMBTrailer(theTMBHeader.sizeInWords() + theCLCTData.sizeInWords(), firmwareVersion),
+      size_(0),
+      cWordCnt(0),
+      theRPCDataIsPresent(false) {
+  theTMBHeader.setNCFEBs(cfebs);
+  theCLCTData = CSCCLCTData(&theTMBHeader);
+  theTMBTrailer = CSCTMBTrailer(theTMBHeader.sizeInWords() + theCLCTData.sizeInWords(), firmwareVersion);
 }
 
-CSCTMBData::CSCTMBData(const uint16_t *buf) 
-  : theOriginalBuffer(buf), 
-    theTMBHeader(2007, 0x50c3),
-    theCLCTData(&theTMBHeader),
-    theTMBScopeIsPresent(false), 
-    theTMBScope(nullptr), 
-    theTMBMiniScopeIsPresent(false), 
-    theTMBMiniScope(nullptr), 
-    theBlockedCFEBIsPresent(false),
-    theTMBBlockedCFEB(nullptr),
-    theTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), 2007),
-    theRPCDataIsPresent(false){
+CSCTMBData::CSCTMBData(const uint16_t* buf)
+    : theOriginalBuffer(buf),
+      theTMBHeader(2007, 0x50c3),
+      theCLCTData(&theTMBHeader),
+      theTMBScopeIsPresent(false),
+      theTMBScope(nullptr),
+      theTMBMiniScopeIsPresent(false),
+      theTMBMiniScope(nullptr),
+      theBlockedCFEBIsPresent(false),
+      theTMBBlockedCFEB(nullptr),
+      theTMBTrailer(theTMBHeader.sizeInWords() + theCLCTData.sizeInWords(), 2007),
+      theRPCDataIsPresent(false) {
   size_ = UnpackTMB(buf);
-} 
+}
 
 // Explicitly-defined copy constructor is needed when the scope data is
 // present, to prevent the same pointer from being deleted twice. -SV.
-CSCTMBData::CSCTMBData(const CSCTMBData& data):
-  theOriginalBuffer(data.theOriginalBuffer),
-  theB0CLine(data.theB0CLine), theE0FLine(data.theE0FLine),
-  theTMBHeader(data.theTMBHeader),
-  theCLCTData(data.theCLCTData), theRPCData(data.theRPCData),
-  theTMBScopeIsPresent(data.theTMBScopeIsPresent),
-  theTMBMiniScopeIsPresent(data.theTMBMiniScopeIsPresent),
-  theBlockedCFEBIsPresent(data.theBlockedCFEBIsPresent),
-  theTMBTrailer(data.theTMBTrailer),
-  size_(data.size_), cWordCnt(data.cWordCnt),
-  theRPCDataIsPresent(data.theRPCDataIsPresent)
-{
+CSCTMBData::CSCTMBData(const CSCTMBData& data)
+    : theOriginalBuffer(data.theOriginalBuffer),
+      theB0CLine(data.theB0CLine),
+      theE0FLine(data.theE0FLine),
+      theTMBHeader(data.theTMBHeader),
+      theCLCTData(data.theCLCTData),
+      theRPCData(data.theRPCData),
+      theTMBScopeIsPresent(data.theTMBScopeIsPresent),
+      theTMBMiniScopeIsPresent(data.theTMBMiniScopeIsPresent),
+      theBlockedCFEBIsPresent(data.theBlockedCFEBIsPresent),
+      theTMBTrailer(data.theTMBTrailer),
+      size_(data.size_),
+      cWordCnt(data.cWordCnt),
+      theRPCDataIsPresent(data.theRPCDataIsPresent) {
   if (theTMBScopeIsPresent) {
     theTMBScope = new CSCTMBScope(*(data.theTMBScope));
-  }
-  else {
+  } else {
     theTMBScope = nullptr;
   }
-  
+
   if (theTMBMiniScopeIsPresent) {
     theTMBMiniScope = new CSCTMBMiniScope(*(data.theTMBMiniScope));
-  }
-  else {
+  } else {
     theTMBMiniScope = nullptr;
   }
-  
+
   if (theBlockedCFEBIsPresent) {
-     theTMBBlockedCFEB = new CSCTMBBlockedCFEB(*(data.theTMBBlockedCFEB));
-  }
-  else {
+    theTMBBlockedCFEB = new CSCTMBBlockedCFEB(*(data.theTMBBlockedCFEB));
+  } else {
     theTMBBlockedCFEB = nullptr;
   }
-  
 }
 
-CSCTMBData::~CSCTMBData(){
+CSCTMBData::~CSCTMBData() {
   if (theTMBScopeIsPresent) {
     delete theTMBScope;
     theTMBScopeIsPresent = false;
@@ -135,190 +125,180 @@ CSCTMBData::~CSCTMBData(){
 
 /// returns -1 if not found
 /// obsolete
-int findLine(const uint16_t *buf, uint16_t marker,int first,  int maxToDo) {
-  for(int i = first; i < maxToDo; ++i) { 
-    if(buf[i] == marker) {
+int findLine(const uint16_t* buf, uint16_t marker, int first, int maxToDo) {
+  for (int i = first; i < maxToDo; ++i) {
+    if (buf[i] == marker) {
       return i;
     }
   }
   return -1;
 }
-  
+
 int CSCTMBData::TMBCRCcalc() {
-  std::vector<std::bitset<16> > theTotalTMBData(theE0FLine+1-theB0CLine);
+  std::vector<std::bitset<16> > theTotalTMBData(theE0FLine + 1 - theB0CLine);
   unsigned i = 0;
-  for (unsigned int line=theB0CLine; line<theE0FLine+1;++line) {
+  for (unsigned int line = theB0CLine; line < theE0FLine + 1; ++line) {
     theTotalTMBData[i] = std::bitset<16>(theOriginalBuffer[line]);
     ++i;
   }
-  if ( !theTotalTMBData.empty() )   {
-    std::bitset<22> CRC=calCRC22(theTotalTMBData);
+  if (!theTotalTMBData.empty()) {
+    std::bitset<22> CRC = calCRC22(theTotalTMBData);
     LogTrace("CSCTMBData|CSCRawToDigi") << " Test here " << CRC.to_ulong();
     return CRC.to_ulong();
-  } 
-  else {
+  } else {
     LogTrace("CSCTMBData|CSCRawToDigi") << "theTotalTMBData doesn't exist";
     return 0;
   }
 }
 
-int CSCTMBData::UnpackTMB(const uint16_t *buf) {
+int CSCTMBData::UnpackTMB(const uint16_t* buf) {
   ///determine 2007 or 2006 version
-  unsigned short int firmwareVersion=0;
-  int Ntbins = 0 ;
-  int NRPCtbins = 0; // =VB= number of RPC tbins  
-  
-  int b0cLine=0;///assumes that buf starts at the tmb data
-                ///this is not true if something is wrong in the data 
-                ///before TMB - then we skip the whole event
+  unsigned short int firmwareVersion = 0;
+  int Ntbins = 0;
+  int NRPCtbins = 0;  // =VB= number of RPC tbins
 
-  if (buf[b0cLine]==0xdb0c) {
-    firmwareVersion=2007;
-    Ntbins = buf[b0cLine+19]&0xF8;
-    NRPCtbins = (buf[b0cLine+36]>>5)&0x1F; // =VB= get RPC tbins  
-  } 
-  else if (buf[b0cLine]==0x6b0c) {
-    firmwareVersion=2006;
-    Ntbins =  buf[b0cLine+1]&0x1f ;
+  int b0cLine = 0;  ///assumes that buf starts at the tmb data
+                    ///this is not true if something is wrong in the data
+                    ///before TMB - then we skip the whole event
+
+  if (buf[b0cLine] == 0xdb0c) {
+    firmwareVersion = 2007;
+    Ntbins = buf[b0cLine + 19] & 0xF8;
+    NRPCtbins = (buf[b0cLine + 36] >> 5) & 0x1F;  // =VB= get RPC tbins
+  } else if (buf[b0cLine] == 0x6b0c) {
+    firmwareVersion = 2006;
+    Ntbins = buf[b0cLine + 1] & 0x1f;
     NRPCtbins = Ntbins;
-  } 
-  else {
+  } else {
     LogTrace("CSCTMBData|CSCRawToDigi") << "+++ Can't find b0C flag";
   }
 
-  if ((firmwareVersion==2007)&&(!(((buf[b0cLine]&0xFFFF)==0xDB0C)&&((buf[b0cLine+1]&0xf000)==0xD000)
-	&&((buf[b0cLine+2]&0xf000)==0xD000)&&((buf[b0cLine+3]&0xf000)==0xD000)))){
+  if ((firmwareVersion == 2007) &&
+      (!(((buf[b0cLine] & 0xFFFF) == 0xDB0C) && ((buf[b0cLine + 1] & 0xf000) == 0xD000) &&
+         ((buf[b0cLine + 2] & 0xf000) == 0xD000) && ((buf[b0cLine + 3] & 0xf000) == 0xD000)))) {
     LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: error in header in 2007 format!";
   }
 
-  int MaxSizeRPC = 1+NRPCtbins*2*4+1;
+  int MaxSizeRPC = 1 + NRPCtbins * 2 * 4 + 1;
   //int MaxSizeScope = 5;
-  int e0bLine =-1;
+  int e0bLine = -1;
   switch (firmwareVersion) {
-  case 2007:
-    e0bLine = 42; //last word of header2007
-    break;
-  case 2006:
-    e0bLine = 26; //last word of header in 2006 format
-    break;
-  default:
-    edm::LogError("CSCTMBData|CSCRawToDigi") << "+++ undetermined firmware format - cant find e0bLine";
+    case 2007:
+      e0bLine = 42;  //last word of header2007
+      break;
+    case 2006:
+      e0bLine = 26;  //last word of header in 2006 format
+      break;
+    default:
+      edm::LogError("CSCTMBData|CSCRawToDigi") << "+++ undetermined firmware format - cant find e0bLine";
   }
 
-  theTMBHeader=CSCTMBHeader(buf);
-  
-  if(!theTMBHeader.check())   {
-    LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: Bad TMB header e0bLine=" << std::hex << buf[e0bLine];
+  theTMBHeader = CSCTMBHeader(buf);
+
+  if (!theTMBHeader.check()) {
+    LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: Bad TMB header e0bLine=" << std::hex
+                                        << buf[e0bLine];
     return 0;
   }
 
   int currentPosition = theTMBHeader.sizeInWords();
   int theFirmwareVersion = theTMBHeader.FirmwareVersion();
 
-  theCLCTData = CSCCLCTData(theTMBHeader.NCFEBs(), theTMBHeader.NTBins(), buf+e0bLine+1, theFirmwareVersion);
+  theCLCTData = CSCCLCTData(theTMBHeader.NCFEBs(), theTMBHeader.NTBins(), buf + e0bLine + 1, theFirmwareVersion);
 
-  if(!theCLCTData.check())   {
+  if (!theCLCTData.check()) {
     LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: Bad CLCT data";
-  }
-  else {
-    currentPosition+=theCLCTData.sizeInWords();
+  } else {
+    currentPosition += theCLCTData.sizeInWords();
   }
 
   //int i = currentPosition-1;
   //printf ( "%04x %04x %04x %04x\n",buf[i+3],buf[i+2],buf[i+1],buf[i] ) ;
- 
 
   // look for RPC
   int b04Line = currentPosition;
-  
-  if(buf[b04Line]==0x6b04) {
+
+  if (buf[b04Line] == 0x6b04) {
     // we need an e04 line to calculate the size
-    int e04Line = findLine(buf, 0x6e04, currentPosition, currentPosition+MaxSizeRPC);
-    if(e04Line != -1) {
+    int e04Line = findLine(buf, 0x6e04, currentPosition, currentPosition + MaxSizeRPC);
+    if (e04Line != -1) {
       theRPCDataIsPresent = true;
-      theRPCData = CSCRPCData(buf+b04Line, e04Line-b04Line+1);
-      currentPosition+=theRPCData.sizeInWords();
-    }
-    else {
+      theRPCData = CSCRPCData(buf + b04Line, e04Line - b04Line + 1);
+      currentPosition += theRPCData.sizeInWords();
+    } else {
       LogTrace("CSCTMBData|CSCRawToDigi") << "CSCTMBData::corrupt RPC data! Failed to find end! ";
       return 0;
     }
   }
 
-  int TotTMBReadout=0;
+  int TotTMBReadout = 0;
   switch (firmwareVersion) {
-  case 2007:
-    TotTMBReadout= 43+Ntbins*6*5+1+NRPCtbins*2*4+2+8*256+8;
-    break;
-  case 2006:
-    TotTMBReadout= 27+Ntbins*6*5+1+NRPCtbins*2*4+2+8*256+8; //see tmb2004 manual (version v2p06) page54.
-    break;
-  default:
-    edm::LogError("CSCTMBData|CSCRawToDigi") << "can't find TotTMBReadout - unknown firmware version!";
-    break;
+    case 2007:
+      TotTMBReadout = 43 + Ntbins * 6 * 5 + 1 + NRPCtbins * 2 * 4 + 2 + 8 * 256 + 8;
+      break;
+    case 2006:
+      TotTMBReadout =
+          27 + Ntbins * 6 * 5 + 1 + NRPCtbins * 2 * 4 + 2 + 8 * 256 + 8;  //see tmb2004 manual (version v2p06) page54.
+      break;
+    default:
+      edm::LogError("CSCTMBData|CSCRawToDigi") << "can't find TotTMBReadout - unknown firmware version!";
+      break;
   }
-  
-//std::cout << " !!!TMB Scope!!! " << std::endl;
-  if (buf[currentPosition]==0x6b05) {
+
+  //std::cout << " !!!TMB Scope!!! " << std::endl;
+  if (buf[currentPosition] == 0x6b05) {
     int b05Line = currentPosition;
     LogTrace("CSCTMBData|CSCRawToDigi") << "found scope!";
-    int e05Line = findLine(buf, 0x6e05, currentPosition, TotTMBReadout-currentPosition);
-    if(e05Line != -1){
+    int e05Line = findLine(buf, 0x6e05, currentPosition, TotTMBReadout - currentPosition);
+    if (e05Line != -1) {
       theTMBScopeIsPresent = true;
-      theTMBScope = new CSCTMBScope(buf,b05Line, e05Line);
+      theTMBScope = new CSCTMBScope(buf, b05Line, e05Line);
       // The size of the TMB scope data can vary, and I see no good reasons
       // not to determine it dynamically.  -SV, 5 Nov 2008.
       //currentPosition+=theTMBScope->sizeInWords();
-      currentPosition+=(e05Line-b05Line+1);
-    }
-    else {
-      LogTrace("CSCTMBData|CSCRawToDigi")
-	<< "+++ CSCTMBData warning: found 0x6b05 line, but not 0x6e05! +++";
+      currentPosition += (e05Line - b05Line + 1);
+    } else {
+      LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: found 0x6b05 line, but not 0x6e05! +++";
     }
   }
 
   /// Now Find the miniscope
-  if (buf[currentPosition]==0x6b07){
-     int Line6b07 = currentPosition;
-     LogTrace("CSCTMBData") << " TMBData ---> Begin of MiniScope found " ;
-     int Line6E07 = findLine(buf, 0x6E07, currentPosition, TotTMBReadout-currentPosition);
-     if(Line6E07 !=-1){
-       LogTrace("CSCTMBData") << " TMBData --> End of MiniScope found " << Line6E07-Line6b07+1 << " words ";
-       theTMBMiniScopeIsPresent = true;
-       theTMBMiniScope = new CSCTMBMiniScope(buf, Line6b07, Line6E07);
-       currentPosition += (Line6E07-Line6b07+1);
-     }
-     else {
-      LogTrace("CSCTMBData")
-	<< "+++ CSCTMBData warning MiniScope!: found 0x6b07 line, but not 0x6e07! +++";
+  if (buf[currentPosition] == 0x6b07) {
+    int Line6b07 = currentPosition;
+    LogTrace("CSCTMBData") << " TMBData ---> Begin of MiniScope found ";
+    int Line6E07 = findLine(buf, 0x6E07, currentPosition, TotTMBReadout - currentPosition);
+    if (Line6E07 != -1) {
+      LogTrace("CSCTMBData") << " TMBData --> End of MiniScope found " << Line6E07 - Line6b07 + 1 << " words ";
+      theTMBMiniScopeIsPresent = true;
+      theTMBMiniScope = new CSCTMBMiniScope(buf, Line6b07, Line6E07);
+      currentPosition += (Line6E07 - Line6b07 + 1);
+    } else {
+      LogTrace("CSCTMBData") << "+++ CSCTMBData warning MiniScope!: found 0x6b07 line, but not 0x6e07! +++";
     }
   }
   /// end for the mini scope
 
- /// Now Find the blocked CFEB DiStrips List Format
-  if (buf[currentPosition]==0x6BCB){
-  int Line6BCB = currentPosition;
-     LogTrace("CSCTMBData") << " TMBData ---> Begin of Blocked CFEB found " ;
-     int Line6ECB = findLine(buf, 0x6ECB, currentPosition, TotTMBReadout-currentPosition);
-     if(Line6ECB !=-1){
-       LogTrace("CSCTMBData") << " TMBData --> End of Blocked CFEB found " << Line6ECB-Line6BCB+1 << " words ";
-       theBlockedCFEBIsPresent = true;
-       theTMBBlockedCFEB = new CSCTMBBlockedCFEB(buf, Line6BCB, Line6ECB);
-       currentPosition += (Line6ECB-Line6BCB+1);
-     }
-     else {
-      LogTrace("CSCTMBData")
-	<< "+++ CSCTMBData warning Blocked CFEB!: found 0x6BCB line, but not 0x6ECB! +++";
+  /// Now Find the blocked CFEB DiStrips List Format
+  if (buf[currentPosition] == 0x6BCB) {
+    int Line6BCB = currentPosition;
+    LogTrace("CSCTMBData") << " TMBData ---> Begin of Blocked CFEB found ";
+    int Line6ECB = findLine(buf, 0x6ECB, currentPosition, TotTMBReadout - currentPosition);
+    if (Line6ECB != -1) {
+      LogTrace("CSCTMBData") << " TMBData --> End of Blocked CFEB found " << Line6ECB - Line6BCB + 1 << " words ";
+      theBlockedCFEBIsPresent = true;
+      theTMBBlockedCFEB = new CSCTMBBlockedCFEB(buf, Line6BCB, Line6ECB);
+      currentPosition += (Line6ECB - Line6BCB + 1);
+    } else {
+      LogTrace("CSCTMBData") << "+++ CSCTMBData warning Blocked CFEB!: found 0x6BCB line, but not 0x6ECB! +++";
     }
   }
- /// end for the blocked CFEB DiStrips List Format  
+  /// end for the blocked CFEB DiStrips List Format
 
-  int maxLine = findLine(buf, 0xde0f, currentPosition, TotTMBReadout-currentPosition);
-  if(maxLine == -1) 
-    {
-      LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: No e0f line!";
-      return 0;
-    }
+  int maxLine = findLine(buf, 0xde0f, currentPosition, TotTMBReadout - currentPosition);
+  if (maxLine == -1) {
+    LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: No e0f line!";
+    return 0;
+  }
 
   //Now for CRC check put this information into bitset
 
@@ -327,142 +307,121 @@ int CSCTMBData::UnpackTMB(const uint16_t *buf) {
 
   // finally, the trailer
   int e0cLine = findLine(buf, 0x6e0c, currentPosition, maxLine);
-  if (e0cLine == -1)
-    {
-      LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: No e0c line!";
-    } 
-  else 
-    {
-      theTMBTrailer = CSCTMBTrailer(buf+e0cLine, firmwareVersion);
-      LogTrace("CSCTMBData|CSCRawToDigi")
-	<< "TMB trailer size: " << theTMBTrailer.sizeInWords();
-    }
+  if (e0cLine == -1) {
+    LogTrace("CSCTMBData|CSCRawToDigi") << "+++ CSCTMBData warning: No e0c line!";
+  } else {
+    theTMBTrailer = CSCTMBTrailer(buf + e0cLine, firmwareVersion);
+    LogTrace("CSCTMBData|CSCRawToDigi") << "TMB trailer size: " << theTMBTrailer.sizeInWords();
+  }
 
   checkSize();
 
   // Dump of TMB; format proposed by JK.
 #ifdef TMBDUMP
   LogTrace("CSCTMBData") << "Dump of TMB data:";
-  for (int line = b0cLine; line <= maxLine+3; line++) {
-    LogTrace("CSCTMBData")
-      << "Adr= " << std::setw(4) << line
-      << " Data= " << std::setfill('0') << std::setw(5)
-      << std::uppercase << std::hex << buf[line] << std::dec << std::endl;
+  for (int line = b0cLine; line <= maxLine + 3; line++) {
+    LogTrace("CSCTMBData") << "Adr= " << std::setw(4) << line << " Data= " << std::setfill('0') << std::setw(5)
+                           << std::uppercase << std::hex << buf[line] << std::dec << std::endl;
   }
 #endif
 
   // size, since we count from 0 and have one more trailer word
   // there are sometimes multiple "de0f" lines in trailer, so key on "6e0c"
-  return e0cLine-b0cLine+theTMBTrailer.sizeInWords();
-} //UnpackTMB
+  return e0cLine - b0cLine + theTMBTrailer.sizeInWords();
+}  //UnpackTMB
 
-bool CSCTMBData::checkSize() const 
-{
+bool CSCTMBData::checkSize() const {
   // sum up all the components and see if they have the size indicated in the TMBTrailer
   return true;
 }
 
-std::bitset<22> CSCTMBData::calCRC22(const std::vector< std::bitset<16> >& datain)
-{
+std::bitset<22> CSCTMBData::calCRC22(const std::vector<std::bitset<16> >& datain) {
   std::bitset<22> CRC;
   CRC.reset();
-  for(unsigned int i=0;i<datain.size()-3;++i)
-    {
-      CRC=nextCRC22_D16(datain[i],CRC);
-    }
+  for (unsigned int i = 0; i < datain.size() - 3; ++i) {
+    CRC = nextCRC22_D16(datain[i], CRC);
+  }
   return CRC;
 }
 
-CSCTMBScope & CSCTMBData::tmbScope() const 
-{
-  if (!theTMBScopeIsPresent) throw("No TMBScope in this chamber");
-  return * theTMBScope;
+CSCTMBScope& CSCTMBData::tmbScope() const {
+  if (!theTMBScopeIsPresent)
+    throw("No TMBScope in this chamber");
+  return *theTMBScope;
 }
 
-CSCTMBMiniScope & CSCTMBData::tmbMiniScope() const
-{
-  if (!theTMBMiniScopeIsPresent) throw("No TMBScope in this chamber");
-  return * theTMBMiniScope;
+CSCTMBMiniScope& CSCTMBData::tmbMiniScope() const {
+  if (!theTMBMiniScopeIsPresent)
+    throw("No TMBScope in this chamber");
+  return *theTMBMiniScope;
 }
 
-
-CSCTMBBlockedCFEB & CSCTMBData::tmbBlockedCFEB() const
-{
-  if (!theBlockedCFEBIsPresent) throw("No TMB Blocked CFEB in this chamber");
-  return * theTMBBlockedCFEB;
+CSCTMBBlockedCFEB& CSCTMBData::tmbBlockedCFEB() const {
+  if (!theBlockedCFEBIsPresent)
+    throw("No TMB Blocked CFEB in this chamber");
+  return *theTMBBlockedCFEB;
 }
 
-
-std::bitset<22> CSCTMBData::nextCRC22_D16(const std::bitset<16>& D, 
-				       const std::bitset<22>& C)
-{
+std::bitset<22> CSCTMBData::nextCRC22_D16(const std::bitset<16>& D, const std::bitset<22>& C) {
   std::bitset<22> NewCRC;
-  
-  NewCRC[ 0] = D[ 0] ^ C[ 6];
-  NewCRC[ 1] = D[ 1] ^ D[ 0] ^ C[ 6] ^ C[ 7];
-  NewCRC[ 2] = D[ 2] ^ D[ 1] ^ C[ 7] ^ C[ 8];
-  NewCRC[ 3] = D[ 3] ^ D[ 2] ^ C[ 8] ^ C[ 9];
-  NewCRC[ 4] = D[ 4] ^ D[ 3] ^ C[ 9] ^ C[10];
-  NewCRC[ 5] = D[ 5] ^ D[ 4] ^ C[10] ^ C[11];
-  NewCRC[ 6] = D[ 6] ^ D[ 5] ^ C[11] ^ C[12];
-  NewCRC[ 7] = D[ 7] ^ D[ 6] ^ C[12] ^ C[13];
-  NewCRC[ 8] = D[ 8] ^ D[ 7] ^ C[13] ^ C[14];
-  NewCRC[ 9] = D[ 9] ^ D[ 8] ^ C[14] ^ C[15];
-  NewCRC[10] = D[10] ^ D[ 9] ^ C[15] ^ C[16];
+
+  NewCRC[0] = D[0] ^ C[6];
+  NewCRC[1] = D[1] ^ D[0] ^ C[6] ^ C[7];
+  NewCRC[2] = D[2] ^ D[1] ^ C[7] ^ C[8];
+  NewCRC[3] = D[3] ^ D[2] ^ C[8] ^ C[9];
+  NewCRC[4] = D[4] ^ D[3] ^ C[9] ^ C[10];
+  NewCRC[5] = D[5] ^ D[4] ^ C[10] ^ C[11];
+  NewCRC[6] = D[6] ^ D[5] ^ C[11] ^ C[12];
+  NewCRC[7] = D[7] ^ D[6] ^ C[12] ^ C[13];
+  NewCRC[8] = D[8] ^ D[7] ^ C[13] ^ C[14];
+  NewCRC[9] = D[9] ^ D[8] ^ C[14] ^ C[15];
+  NewCRC[10] = D[10] ^ D[9] ^ C[15] ^ C[16];
   NewCRC[11] = D[11] ^ D[10] ^ C[16] ^ C[17];
   NewCRC[12] = D[12] ^ D[11] ^ C[17] ^ C[18];
   NewCRC[13] = D[13] ^ D[12] ^ C[18] ^ C[19];
   NewCRC[14] = D[14] ^ D[13] ^ C[19] ^ C[20];
   NewCRC[15] = D[15] ^ D[14] ^ C[20] ^ C[21];
-  NewCRC[16] = D[15] ^ C[ 0] ^ C[21];
-  NewCRC[17] = C[ 1];
-  NewCRC[18] = C[ 2];
-  NewCRC[19] = C[ 3];
-  NewCRC[20] = C[ 4];
-  NewCRC[21] = C[ 5];
-  
+  NewCRC[16] = D[15] ^ C[0] ^ C[21];
+  NewCRC[17] = C[1];
+  NewCRC[18] = C[2];
+  NewCRC[19] = C[3];
+  NewCRC[20] = C[4];
+  NewCRC[21] = C[5];
+
   return NewCRC;
 }
 
-
-boost::dynamic_bitset<> CSCTMBData::pack() 
-{
-  boost::dynamic_bitset<> result = bitset_utilities::ushortToBitset(theTMBHeader.sizeInWords()*16,
-								    theTMBHeader.data());
-  boost::dynamic_bitset<> clctData =  bitset_utilities::ushortToBitset(theCLCTData.sizeInWords()*16,
-								       theCLCTData.data());
-  result = bitset_utilities::append(result,clctData);
+boost::dynamic_bitset<> CSCTMBData::pack() {
+  boost::dynamic_bitset<> result =
+      bitset_utilities::ushortToBitset(theTMBHeader.sizeInWords() * 16, theTMBHeader.data());
+  boost::dynamic_bitset<> clctData =
+      bitset_utilities::ushortToBitset(theCLCTData.sizeInWords() * 16, theCLCTData.data());
+  result = bitset_utilities::append(result, clctData);
   boost::dynamic_bitset<> newResult = result;
-//  theTMBTrailer.setCRC(TMBCRCcalc());
+  //  theTMBTrailer.setCRC(TMBCRCcalc());
 
-  boost::dynamic_bitset<> tmbTrailer =  bitset_utilities::ushortToBitset( theTMBTrailer.sizeInWords()*16,
-									  theTMBTrailer.data());
-  result = bitset_utilities::append(result,tmbTrailer);
-  
+  boost::dynamic_bitset<> tmbTrailer =
+      bitset_utilities::ushortToBitset(theTMBTrailer.sizeInWords() * 16, theTMBTrailer.data());
+  result = bitset_utilities::append(result, tmbTrailer);
+
   // now convert to a vector<bitset<16>>, so we can calculate the crc
   std::vector<std::bitset<16> > wordVector;
   // try to tune so it stops before the e0f line
-  for(unsigned pos = 0; pos < result.size()-16; pos += 16)
-  {
+  for (unsigned pos = 0; pos < result.size() - 16; pos += 16) {
     std::bitset<16> word;
-    for(int i = 0; i < 16; ++i)
-    {
-      word[i] = result[pos+i];
+    for (int i = 0; i < 16; ++i) {
+      word[i] = result[pos + i];
     }
     wordVector.push_back(word);
   }
   theTMBTrailer.setCRC(calCRC22(wordVector).to_ulong());
-  tmbTrailer =  bitset_utilities::ushortToBitset( theTMBTrailer.sizeInWords()*16,
-                                                  theTMBTrailer.data());
+  tmbTrailer = bitset_utilities::ushortToBitset(theTMBTrailer.sizeInWords() * 16, theTMBTrailer.data());
   newResult = bitset_utilities::append(newResult, tmbTrailer);
 
   return newResult;
 }
 
-
-void CSCTMBData::selfTest()
-{
+void CSCTMBData::selfTest() {
   CSCTMBData tmbData;
   cscClassPackerCompare(tmbData);
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cmath>
-#include <cstring> // memcpy
+#include <cstring>  // memcpy
 
 #ifdef LOCAL_UNPACK
 bool CSCTMBHeader::debug = false;
@@ -17,92 +17,65 @@ bool CSCTMBHeader::debug = false;
 std::atomic<bool> CSCTMBHeader::debug{false};
 #endif
 
-CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision):
-  theHeaderFormat(),
-  theFirmwareVersion(firmwareVersion)
-{
-  if(firmwareVersion == 2013)
-    {
-      theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
-    }
-  else if(firmwareVersion == 2006)
-    {
-      theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006());
-    }
-  else if(firmwareVersion == 2007)
-    {
-
-      /* Checks for TMB2007 firmware revisions ranges to detect data format
+CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
+    : theHeaderFormat(), theFirmwareVersion(firmwareVersion) {
+  if (firmwareVersion == 2013) {
+    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
+  } else if (firmwareVersion == 2006) {
+    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006());
+  } else if (firmwareVersion == 2007) {
+    /* Checks for TMB2007 firmware revisions ranges to detect data format
        * rev.0x50c3 - first revision with changed format 
        * rev.0x42D5 - oldest known from 06/21/2007
        * There is 4-bits year value rollover in revision number (0 in 2016)
        */
-      if((firmwareRevision >= 0x50c3) || (firmwareRevision < 0x42D5))
-        { 
-          // if (firmwareRevision >= 0x7a76) // First OTMB firmware revision with 2013 format
-          /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
-          if ((firmwareRevision >= 0x6000) || (firmwareRevision < 0x42D5))
-            {
-              theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
-            }
-          else
-            {
-              theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3());
-            }
-        }
-      else
-        {
-          theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007());
-        }
+    if ((firmwareRevision >= 0x50c3) || (firmwareRevision < 0x42D5)) {
+      // if (firmwareRevision >= 0x7a76) // First OTMB firmware revision with 2013 format
+      /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
+      if ((firmwareRevision >= 0x6000) || (firmwareRevision < 0x42D5)) {
+        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
+      } else {
+        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3());
+      }
+    } else {
+      theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007());
     }
-  else
-    {
-      edm::LogError("CSCTMBHeader|CSCRawToDigi") <<"failed to determine TMB firmware version!!";
-    }
+  } else {
+    edm::LogError("CSCTMBHeader|CSCRawToDigi") << "failed to determine TMB firmware version!!";
+  }
 }
 
 //CSCTMBHeader::CSCTMBHeader(const CSCTMBStatusDigi & digi) {
 //  CSCTMBHeader(digi.header());
 //}
 
-CSCTMBHeader::CSCTMBHeader(const unsigned short * buf)
-  : theHeaderFormat()
-{
+CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
   ///first determine the format
-  if (buf[0]==0xDB0C)
-    {
-      theFirmwareVersion=2007;
-      theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007(buf));
-      /* Checks for TMB2007 firmware revisions ranges to detect data format
+  if (buf[0] == 0xDB0C) {
+    theFirmwareVersion = 2007;
+    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007(buf));
+    /* Checks for TMB2007 firmware revisions ranges to detect data format
        * rev.0x50c3 - first revision with changed format 
        * rev.0x42D5 - oldest known from 06/21/2007
        * There is 4-bits year value rollover in revision number (0 in 2016)
        */
-      if ((theHeaderFormat->firmwareRevision() >= 0x50c3) || (theHeaderFormat->firmwareRevision() < 0x42D5))
-        {
-          // if (theHeaderFormat->firmwareRevision() >= 0x7a76) // First OTMB firmware revision with 2013 format
-          /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
-          if ((theHeaderFormat->firmwareRevision() >= 0x6000) || (theHeaderFormat->firmwareRevision() < 0x42D5))
-            {
-              theFirmwareVersion=2013;
-              theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013(buf));
-            }
-          else
-            {
-              theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3(buf));
-            }
-        }
+    if ((theHeaderFormat->firmwareRevision() >= 0x50c3) || (theHeaderFormat->firmwareRevision() < 0x42D5)) {
+      // if (theHeaderFormat->firmwareRevision() >= 0x7a76) // First OTMB firmware revision with 2013 format
+      /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
+      if ((theHeaderFormat->firmwareRevision() >= 0x6000) || (theHeaderFormat->firmwareRevision() < 0x42D5)) {
+        theFirmwareVersion = 2013;
+        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013(buf));
+      } else {
+        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3(buf));
+      }
+    }
 
-    }
-  else if (buf[0]==0x6B0C)
-    {
-      theFirmwareVersion=2006;
-      theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006(buf));
-    }
-  else
-    {
-      edm::LogError("CSCTMBHeader|CSCRawToDigi") <<"failed to determine TMB firmware version!!";
-    }
+  } else if (buf[0] == 0x6B0C) {
+    theFirmwareVersion = 2006;
+    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006(buf));
+  } else {
+    edm::LogError("CSCTMBHeader|CSCRawToDigi") << "failed to determine TMB firmware version!!";
+  }
 }
 
 /*
@@ -137,134 +110,113 @@ void CSCTMBHeader::swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2)
 }
 */
 
-
 //FIXME Pick which LCT goes first
-void CSCTMBHeader::add(const std::vector<CSCCLCTDigi> & digis)
-{
+void CSCTMBHeader::add(const std::vector<CSCCLCTDigi> &digis) {
   // sort???
-  if(!digis.empty()) { 
-	addCLCT0(digis[0]); 
-        
+  if (!digis.empty()) {
+    addCLCT0(digis[0]);
   }
-  if(digis.size() > 1) addCLCT1(digis[1]);
+  if (digis.size() > 1)
+    addCLCT1(digis[1]);
 }
 
-void CSCTMBHeader::add(const std::vector<CSCCorrelatedLCTDigi> & digis)
-{
+void CSCTMBHeader::add(const std::vector<CSCCorrelatedLCTDigi> &digis) {
   // sort???
-  if(!digis.empty()) addCorrelatedLCT0(digis[0]);
-  if(digis.size() > 1) addCorrelatedLCT1(digis[1]);
+  if (!digis.empty())
+    addCorrelatedLCT0(digis[0]);
+  if (digis.size() > 1)
+    addCorrelatedLCT1(digis[1]);
 }
 
-
-CSCTMBHeader2007 CSCTMBHeader::tmbHeader2007()   const
-{
-  CSCTMBHeader2007 * result = dynamic_cast<CSCTMBHeader2007 *>(theHeaderFormat.get());
-  if(result == nullptr)
-    {
-      throw cms::Exception("Could not get 2007 TMB header format");
-    }
+CSCTMBHeader2007 CSCTMBHeader::tmbHeader2007() const {
+  CSCTMBHeader2007 *result = dynamic_cast<CSCTMBHeader2007 *>(theHeaderFormat.get());
+  if (result == nullptr) {
+    throw cms::Exception("Could not get 2007 TMB header format");
+  }
   return *result;
 }
 
-CSCTMBHeader2007_rev0x50c3 CSCTMBHeader::tmbHeader2007_rev0x50c3()   const
-{
-  CSCTMBHeader2007_rev0x50c3 * result = dynamic_cast<CSCTMBHeader2007_rev0x50c3 *>(theHeaderFormat.get());
-  if(result == nullptr)
-    {
-      throw cms::Exception("Could not get 2007 rev0x50c3 TMB header format");
-    }
+CSCTMBHeader2007_rev0x50c3 CSCTMBHeader::tmbHeader2007_rev0x50c3() const {
+  CSCTMBHeader2007_rev0x50c3 *result = dynamic_cast<CSCTMBHeader2007_rev0x50c3 *>(theHeaderFormat.get());
+  if (result == nullptr) {
+    throw cms::Exception("Could not get 2007 rev0x50c3 TMB header format");
+  }
   return *result;
 }
 
-CSCTMBHeader2013 CSCTMBHeader::tmbHeader2013()   const
-{
-  CSCTMBHeader2013 * result = dynamic_cast<CSCTMBHeader2013 *>(theHeaderFormat.get());
-  if(result == nullptr)
-    {
-      throw cms::Exception("Could not get 2013 TMB header format");
-    }
+CSCTMBHeader2013 CSCTMBHeader::tmbHeader2013() const {
+  CSCTMBHeader2013 *result = dynamic_cast<CSCTMBHeader2013 *>(theHeaderFormat.get());
+  if (result == nullptr) {
+    throw cms::Exception("Could not get 2013 TMB header format");
+  }
   return *result;
 }
 
-
-CSCTMBHeader2006 CSCTMBHeader::tmbHeader2006()   const
-{
-  CSCTMBHeader2006 * result = dynamic_cast<CSCTMBHeader2006 *>(theHeaderFormat.get());
-  if(result == nullptr)
-    {
-      throw cms::Exception("Could not get 2006 TMB header format");
-    }
+CSCTMBHeader2006 CSCTMBHeader::tmbHeader2006() const {
+  CSCTMBHeader2006 *result = dynamic_cast<CSCTMBHeader2006 *>(theHeaderFormat.get());
+  if (result == nullptr) {
+    throw cms::Exception("Could not get 2006 TMB header format");
+  }
   return *result;
 }
 
-
-void CSCTMBHeader::selfTest()
-{
+void CSCTMBHeader::selfTest() {
   constexpr bool debug = false;
 
   // tests packing and unpacking
-  for(int station = 1; station <= 4; ++station)
-    {
-      for(int iendcap = 1; iendcap <= 2; ++iendcap)
-        {
-          CSCDetId detId(iendcap, station, 1, 1, 0);
+  for (int station = 1; station <= 4; ++station) {
+    for (int iendcap = 1; iendcap <= 2; ++iendcap) {
+      CSCDetId detId(iendcap, station, 1, 1, 0);
 
-          // the next-to-last is the BX, which only gets
-          // saved in two bits and must be the same for clct0 and clct1.
-          //CSCCLCTDigi clct0(1, 1, 4, 0, 0, 30, 3, 0, 1); // valid for 2006
-          // In 2007 firmware, there are no distrips, so the 4th argument (strip
-          // type) should always be set to 1 (halfstrips).
-          CSCCLCTDigi clct0(1, 1, 4, 1, 0, 30, 4, 2, 1); // valid for 2007
-          CSCCLCTDigi clct1(1, 1, 2, 1, 1, 31, 1, 2, 2);
+      // the next-to-last is the BX, which only gets
+      // saved in two bits and must be the same for clct0 and clct1.
+      //CSCCLCTDigi clct0(1, 1, 4, 0, 0, 30, 3, 0, 1); // valid for 2006
+      // In 2007 firmware, there are no distrips, so the 4th argument (strip
+      // type) should always be set to 1 (halfstrips).
+      CSCCLCTDigi clct0(1, 1, 4, 1, 0, 30, 4, 2, 1);  // valid for 2007
+      CSCCLCTDigi clct1(1, 1, 2, 1, 1, 31, 1, 2, 2);
 
-          // BX of LCT (8th argument) is 1-bit word (the least-significant bit
-          // of ALCT's bx).
-          CSCCorrelatedLCTDigi lct0(1, 1, 2, 10, 98, 5, 0, 1, 0, 0, 0, 0);
-          CSCCorrelatedLCTDigi lct1(2, 1, 2, 20, 15, 9, 1, 0, 0, 0, 0, 0);
+      // BX of LCT (8th argument) is 1-bit word (the least-significant bit
+      // of ALCT's bx).
+      CSCCorrelatedLCTDigi lct0(1, 1, 2, 10, 98, 5, 0, 1, 0, 0, 0, 0);
+      CSCCorrelatedLCTDigi lct1(2, 1, 2, 20, 15, 9, 1, 0, 0, 0, 0, 0);
 
-          CSCTMBHeader tmbHeader(2007, 0x50c3);
-          tmbHeader.addCLCT0(clct0);
-          tmbHeader.addCLCT1(clct1);
-          tmbHeader.addCorrelatedLCT0(lct0);
-          tmbHeader.addCorrelatedLCT1(lct1);
-          std::vector<CSCCLCTDigi> clcts = tmbHeader.CLCTDigis(detId.rawId());
-          // guess they got reordered
-          assert(cscPackerCompare(clcts[0],clct0));
-          assert(cscPackerCompare(clcts[1],clct1));
-          if (debug)
-            {
-              std::cout << "Match for: " << clct0 << "\n";
-              std::cout << "           " << clct1 << "\n \n";
-            }
+      CSCTMBHeader tmbHeader(2007, 0x50c3);
+      tmbHeader.addCLCT0(clct0);
+      tmbHeader.addCLCT1(clct1);
+      tmbHeader.addCorrelatedLCT0(lct0);
+      tmbHeader.addCorrelatedLCT1(lct1);
+      std::vector<CSCCLCTDigi> clcts = tmbHeader.CLCTDigis(detId.rawId());
+      // guess they got reordered
+      assert(cscPackerCompare(clcts[0], clct0));
+      assert(cscPackerCompare(clcts[1], clct1));
+      if (debug) {
+        std::cout << "Match for: " << clct0 << "\n";
+        std::cout << "           " << clct1 << "\n \n";
+      }
 
-          std::vector<CSCCorrelatedLCTDigi> lcts = tmbHeader.CorrelatedLCTDigis(detId.rawId());
-          assert(cscPackerCompare(lcts[0], lct0));
-          assert(cscPackerCompare(lcts[1], lct1));
-          if (debug)
-            {
-              std::cout << "Match for: " << lct0 << "\n";
-              std::cout << "           " << lct1 << "\n";
-            }
+      std::vector<CSCCorrelatedLCTDigi> lcts = tmbHeader.CorrelatedLCTDigis(detId.rawId());
+      assert(cscPackerCompare(lcts[0], lct0));
+      assert(cscPackerCompare(lcts[1], lct1));
+      if (debug) {
+        std::cout << "Match for: " << lct0 << "\n";
+        std::cout << "           " << lct1 << "\n";
+      }
 
-          // try packing and re-packing, to make sure they're the same
-          unsigned short int * data = tmbHeader.data();
-          CSCTMBHeader newHeader(data);
-          clcts = newHeader.CLCTDigis(detId.rawId());
-          assert(cscPackerCompare(clcts[0],clct0));
-          assert(cscPackerCompare(clcts[1],clct1));
-          lcts = newHeader.CorrelatedLCTDigis(detId.rawId());
-          assert(cscPackerCompare(lcts[0], lct0));
-          assert(cscPackerCompare(lcts[1], lct1));
-
-
-        }
+      // try packing and re-packing, to make sure they're the same
+      unsigned short int *data = tmbHeader.data();
+      CSCTMBHeader newHeader(data);
+      clcts = newHeader.CLCTDigis(detId.rawId());
+      assert(cscPackerCompare(clcts[0], clct0));
+      assert(cscPackerCompare(clcts[1], clct1));
+      lcts = newHeader.CorrelatedLCTDigis(detId.rawId());
+      assert(cscPackerCompare(lcts[0], lct0));
+      assert(cscPackerCompare(lcts[1], lct1));
     }
+  }
 }
 
-
-std::ostream & operator<<(std::ostream & os, const CSCTMBHeader & hdr)
-{
+std::ostream &operator<<(std::ostream &os, const CSCTMBHeader &hdr) {
   hdr.theHeaderFormat->print(os);
   return os;
 }

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader2006.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader2006.cc
@@ -2,116 +2,115 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-CSCTMBHeader2006::CSCTMBHeader2006() 
-{
-    bzero(data(), sizeInWords()*2);
-    bits.nHeaderFrames = 26;
-    bits.e0bline = 0x6E0B;
-    bits.b0cline = 0x6B0C;
-    bits.nTBins = 7;
-    bits.nCFEBs = 5;
+CSCTMBHeader2006::CSCTMBHeader2006() {
+  bzero(data(), sizeInWords() * 2);
+  bits.nHeaderFrames = 26;
+  bits.e0bline = 0x6E0B;
+  bits.b0cline = 0x6B0C;
+  bits.nTBins = 7;
+  bits.nCFEBs = 5;
 }
 
+CSCTMBHeader2006::CSCTMBHeader2006(const unsigned short* buf) { memcpy(&bits, buf, sizeInWords() * 2); }
 
-CSCTMBHeader2006::CSCTMBHeader2006(const unsigned short * buf)
-{
-  memcpy(&bits, buf, sizeInWords()*2);
+void CSCTMBHeader2006::setEventInformation(const CSCDMBHeader& dmbHeader) {
+  bits.cscID = dmbHeader.dmbID();
+  bits.l1aNumber = dmbHeader.l1a();
+  // bits.bxnCount = dmbHeader.bxn();
 }
 
-void CSCTMBHeader2006::setEventInformation(const CSCDMBHeader & dmbHeader) 
-{
-    bits.cscID = dmbHeader.dmbID();
-    bits.l1aNumber = dmbHeader.l1a();
-    // bits.bxnCount = dmbHeader.bxn();
-}
+///returns CLCT digis
+std::vector<CSCCLCTDigi> CSCTMBHeader2006::CLCTDigis(uint32_t idlayer) {
+  std::vector<CSCCLCTDigi> result;
+  ///fill digis here
+  /// for the zeroth bits.clct:
+  int shape = 0;
+  int type = 0;
 
- ///returns CLCT digis
-std::vector<CSCCLCTDigi> CSCTMBHeader2006::CLCTDigis(uint32_t idlayer) 
-{
-    std::vector<CSCCLCTDigi> result;
-    ///fill digis here
-    /// for the zeroth bits.clct:
-    int shape=0;
-    int type=0;
-
-    if ( bits.firmRevCode < 3769 ) { //3769 is may 25 2007 - date of firmware with halfstrip only patterns
+  if (bits.firmRevCode < 3769) {  //3769 is may 25 2007 - date of firmware with halfstrip only patterns
     shape = bits.clct0_shape;
-    type  = bits.clct0_strip_type;
-    }else {//new firmware only halfstrip pattern => stripType==1 and shape is 4 bits
-      shape = ( bits.clct0_strip_type<<3)+bits.clct0_shape;
-      type = 1;
-    }
-    int strip = bits.clct0_key;
-    int cfeb = (bits.clct0_cfeb_low)|(bits.clct0_cfeb_high<<1);
-    int bend = bits.clct0_bend;
-    //offlineStripNumbering(strip, cfeb, shape, bend);
+    type = bits.clct0_strip_type;
+  } else {  //new firmware only halfstrip pattern => stripType==1 and shape is 4 bits
+    shape = (bits.clct0_strip_type << 3) + bits.clct0_shape;
+    type = 1;
+  }
+  int strip = bits.clct0_key;
+  int cfeb = (bits.clct0_cfeb_low) | (bits.clct0_cfeb_high << 1);
+  int bend = bits.clct0_bend;
+  //offlineStripNumbering(strip, cfeb, shape, bend);
 
-    CSCCLCTDigi digi0(bits.clct0_valid, bits.clct0_quality, shape,
-                      type, bend, strip, cfeb, bits.clct0_bxn, 1, bits.bxnPreTrigger);
-    //digi0.setFullBX(bits.bxnPreTrigger);
-    result.push_back(digi0);
+  CSCCLCTDigi digi0(
+      bits.clct0_valid, bits.clct0_quality, shape, type, bend, strip, cfeb, bits.clct0_bxn, 1, bits.bxnPreTrigger);
+  //digi0.setFullBX(bits.bxnPreTrigger);
+  result.push_back(digi0);
 
-    /// for the first bits.clct:
-    if ( bits.firmRevCode < 3769 ) {
-      shape = bits.clct1_shape;
-      type  = bits.clct1_strip_type;
-    } else {
-      shape = (bits.clct1_strip_type<<3)+bits.clct1_shape;
-      type = 1;
-    }
+  /// for the first bits.clct:
+  if (bits.firmRevCode < 3769) {
+    shape = bits.clct1_shape;
+    type = bits.clct1_strip_type;
+  } else {
+    shape = (bits.clct1_strip_type << 3) + bits.clct1_shape;
+    type = 1;
+  }
 
-    strip = bits.clct1_key;
-    cfeb = (bits.clct1_cfeb_low)|(bits.clct1_cfeb_high<<1);
-    bend = bits.clct1_bend;
-    //offlineStripNumbering(strip, cfeb, shape, bend);
-    CSCCLCTDigi digi1(bits.clct1_valid, bits.clct1_quality, shape,
-                      type, bend, strip, cfeb, bits.clct1_bxn, 2, bits.bxnPreTrigger);
-    //digi1.setFullBX(bits.bxnPreTrigger);
-    result.push_back(digi1);
-    return result;
+  strip = bits.clct1_key;
+  cfeb = (bits.clct1_cfeb_low) | (bits.clct1_cfeb_high << 1);
+  bend = bits.clct1_bend;
+  //offlineStripNumbering(strip, cfeb, shape, bend);
+  CSCCLCTDigi digi1(
+      bits.clct1_valid, bits.clct1_quality, shape, type, bend, strip, cfeb, bits.clct1_bxn, 2, bits.bxnPreTrigger);
+  //digi1.setFullBX(bits.bxnPreTrigger);
+  result.push_back(digi1);
+  return result;
 }
 
- ///returns CorrelatedLCT digis
-std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2006::CorrelatedLCTDigis(uint32_t idlayer) const 
-{
-    std::vector<CSCCorrelatedLCTDigi> result;
-    /// for the zeroth MPC word:
-    int strip = bits.MPC_Muon0_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    CSCCorrelatedLCTDigi digi(1, bits.MPC_Muon0_vpf_, bits.MPC_Muon0_quality_,
-                              bits.MPC_Muon0_wire_, strip, bits.MPC_Muon0_clct_pattern_,
-                              bits.MPC_Muon0_bend_, bits.MPC_Muon0_bx_, 0,
-                              bits.MPC_Muon0_bc0_, bits.MPC_Muon0_SyncErr_,
-                              bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4<<3) );
-    result.push_back(digi);
-    /// for the first MPC word:
-    strip = bits.MPC_Muon1_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    digi = CSCCorrelatedLCTDigi(2, bits.MPC_Muon1_vpf_, bits.MPC_Muon1_quality_,
-                                bits.MPC_Muon1_wire_, strip, bits.MPC_Muon1_clct_pattern_,
-                                bits.MPC_Muon1_bend_, bits.MPC_Muon1_bx_, 0,
-                                bits.MPC_Muon1_bc0_, bits.MPC_Muon1_SyncErr_,
-                                bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4<<3) );
-    result.push_back(digi);
-    return result;
+///returns CorrelatedLCT digis
+std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2006::CorrelatedLCTDigis(uint32_t idlayer) const {
+  std::vector<CSCCorrelatedLCTDigi> result;
+  /// for the zeroth MPC word:
+  int strip = bits.MPC_Muon0_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  CSCCorrelatedLCTDigi digi(1,
+                            bits.MPC_Muon0_vpf_,
+                            bits.MPC_Muon0_quality_,
+                            bits.MPC_Muon0_wire_,
+                            strip,
+                            bits.MPC_Muon0_clct_pattern_,
+                            bits.MPC_Muon0_bend_,
+                            bits.MPC_Muon0_bx_,
+                            0,
+                            bits.MPC_Muon0_bc0_,
+                            bits.MPC_Muon0_SyncErr_,
+                            bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4 << 3));
+  result.push_back(digi);
+  /// for the first MPC word:
+  strip = bits.MPC_Muon1_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  digi = CSCCorrelatedLCTDigi(2,
+                              bits.MPC_Muon1_vpf_,
+                              bits.MPC_Muon1_quality_,
+                              bits.MPC_Muon1_wire_,
+                              strip,
+                              bits.MPC_Muon1_clct_pattern_,
+                              bits.MPC_Muon1_bend_,
+                              bits.MPC_Muon1_bx_,
+                              0,
+                              bits.MPC_Muon1_bc0_,
+                              bits.MPC_Muon1_SyncErr_,
+                              bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4 << 3));
+  result.push_back(digi);
+  return result;
 }
 
-void
-CSCTMBHeader2006::addALCT0(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2006::addALCT0(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2006, ALCTs belong in ALCT header");
 }
 
-
-void
-CSCTMBHeader2006::addALCT1(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2006::addALCT1(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2006, ALCTs belong in ALCT header");
 }
 
-void
-CSCTMBHeader2006::addCLCT0(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2006::addCLCT0(const CSCCLCTDigi& digi) {
   int strip = digi.getStrip();
   int cfeb = digi.getCFEB();
   int bend = digi.getBend();
@@ -124,14 +123,12 @@ CSCTMBHeader2006::addCLCT0(const CSCCLCTDigi & digi)
   bits.clct0_bend = bend;
   bits.clct0_key = strip;
   bits.clct0_cfeb_low = (cfeb & 0x1);
-  bits.clct0_cfeb_high = (cfeb>>1);
+  bits.clct0_cfeb_high = (cfeb >> 1);
   bits.clct0_bxn = digi.getBX();
   bits.bxnPreTrigger = digi.getFullBX();
 }
 
-void
-CSCTMBHeader2006::addCLCT1(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2006::addCLCT1(const CSCCLCTDigi& digi) {
   int strip = digi.getStrip();
   int cfeb = digi.getCFEB();
   int bend = digi.getBend();
@@ -144,14 +141,12 @@ CSCTMBHeader2006::addCLCT1(const CSCCLCTDigi & digi)
   bits.clct1_bend = bend;
   bits.clct1_key = strip;
   bits.clct1_cfeb_low = (cfeb & 0x1);
-  bits.clct1_cfeb_high = (cfeb>>1);
+  bits.clct1_cfeb_high = (cfeb >> 1);
   bits.clct1_bxn = digi.getBX();
   bits.bxnPreTrigger = digi.getFullBX();
 }
 
-void
-CSCTMBHeader2006::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2006::addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -165,12 +160,10 @@ CSCTMBHeader2006::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon0_bx_ = digi.getBX();
   bits.MPC_Muon0_bc0_ = digi.getBX0();
   bits.MPC_Muon0_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-void
-CSCTMBHeader2006::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2006::addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -184,29 +177,23 @@ CSCTMBHeader2006::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon1_bx_ = digi.getBX();
   bits.MPC_Muon1_bc0_ = digi.getBX0();
   bits.MPC_Muon1_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-
-void CSCTMBHeader2006::print(std::ostream & os) const
-{
-  os << "...............TMB Header.................." << "\n";
+void CSCTMBHeader2006::print(std::ostream& os) const {
+  os << "...............TMB Header.................."
+     << "\n";
   os << std::hex << "BOC LINE " << bits.b0cline << " EOB " << bits.e0bline << "\n";
-  os << std::dec << "fifoMode = " << bits.fifoMode
-     << ", nTBins = " << bits.nTBins << "\n";
-  os << "dumpCFEBs = " << bits.dumpCFEBs << ", nHeaderFrames = "
-     << bits.nHeaderFrames << "\n";
+  os << std::dec << "fifoMode = " << bits.fifoMode << ", nTBins = " << bits.nTBins << "\n";
+  os << "dumpCFEBs = " << bits.dumpCFEBs << ", nHeaderFrames = " << bits.nHeaderFrames << "\n";
   os << "boardID = " << bits.boardID << ", cscID = " << bits.cscID << "\n";
   os << "l1aNumber = " << bits.l1aNumber << ", bxnCount = " << bits.bxnCount << "\n";
-  os << "preTrigTBins = " << bits.preTrigTBins << ", nCFEBs = "<< bits.nCFEBs<< "\n";
-  os << "trigSourceVect = " << bits.trigSourceVect
-     << ", activeCFEBs = " << bits.activeCFEBs << "\n";
+  os << "preTrigTBins = " << bits.preTrigTBins << ", nCFEBs = " << bits.nCFEBs << "\n";
+  os << "trigSourceVect = " << bits.trigSourceVect << ", activeCFEBs = " << bits.activeCFEBs << "\n";
   os << "bxnPreTrigger = " << bits.bxnPreTrigger << "\n";
-  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly
-     << " clctOnly = " << bits.clctOnly
+  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly << " clctOnly = " << bits.clctOnly
      << " alctMatchTime = " << bits.alctMatchTime << "\n";
-  os << "hs_thresh = " << bits.hs_thresh << ", ds_thresh = " << bits.ds_thresh
-     << "\n";
+  os << "hs_thresh = " << bits.hs_thresh << ", ds_thresh = " << bits.ds_thresh << "\n";
   os << ".clct0_key = " << bits.clct0_key << " clct0_shape = " << bits.clct0_shape
      << " clct0_quality = " << bits.clct0_quality << "\n";
   os << "r_buf_nbusy = " << bits.r_buf_nbusy << "\n";
@@ -214,6 +201,4 @@ void CSCTMBHeader2006::print(std::ostream & os) const
   os << "..................CLCT....................." << std::endl;
 }
 
-
 //unsigned short * data()  = 0;
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader2007.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader2007.cc
@@ -2,103 +2,99 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-CSCTMBHeader2007::CSCTMBHeader2007() 
-{
-    bzero(data(), sizeInWords()*2);
-    bits.nHeaderFrames = 42;
-    bits.e0bline = 0x6E0B;
-    bits.b0cline = 0xDB0C;
-    bits.nTBins = 7;
-    bits.nCFEBs = 5;
+CSCTMBHeader2007::CSCTMBHeader2007() {
+  bzero(data(), sizeInWords() * 2);
+  bits.nHeaderFrames = 42;
+  bits.e0bline = 0x6E0B;
+  bits.b0cline = 0xDB0C;
+  bits.nTBins = 7;
+  bits.nCFEBs = 5;
 }
 
+CSCTMBHeader2007::CSCTMBHeader2007(const unsigned short* buf) { memcpy(data(), buf, sizeInWords() * 2); }
 
-CSCTMBHeader2007::CSCTMBHeader2007(const unsigned short * buf)
-{
-  memcpy(data(), buf, sizeInWords()*2);
+void CSCTMBHeader2007::setEventInformation(const CSCDMBHeader& dmbHeader) {
+  bits.cscID = dmbHeader.dmbID();
+  bits.l1aNumber = dmbHeader.l1a();
+  //    bits.bxnCount = dmbHeader.bxn();
 }
 
-  
-void CSCTMBHeader2007::setEventInformation(const CSCDMBHeader & dmbHeader) 
-{
-    bits.cscID = dmbHeader.dmbID();
-    bits.l1aNumber = dmbHeader.l1a();
-//    bits.bxnCount = dmbHeader.bxn();
+///returns CLCT digis
+std::vector<CSCCLCTDigi> CSCTMBHeader2007::CLCTDigis(uint32_t idlayer) {
+  std::vector<CSCCLCTDigi> result;
+  int strip = bits.clct0_key;
+  int cfeb = (bits.clct0_cfeb_low) | (bits.clct0_cfeb_high << 1);
+  int pattern = bits.clct0_shape;
+  int bend = bits.clct0_bend;
+  //offlineStripNumbering(strip, cfeb, pattern, bend);
+  CSCCLCTDigi digi0(
+      bits.clct0_valid, bits.clct0_quality, pattern, 1, bend, strip, cfeb, bits.clct0_bxn, 1, bits.bxnPreTrigger);
+  //digi0.setFullBX(bits.bxnPreTrigger);
+
+  strip = bits.clct1_key;
+  cfeb = (bits.clct1_cfeb_low) | (bits.clct1_cfeb_high << 1);
+  pattern = bits.clct1_shape;
+  bend = bits.clct1_bend;
+  //offlineStripNumbering(strip, cfeb, pattern, bend);
+  CSCCLCTDigi digi1(
+      bits.clct1_valid, bits.clct1_quality, pattern, 1, bend, strip, cfeb, bits.clct1_bxn, 2, bits.bxnPreTrigger);
+  //digi1.setFullBX(bits.bxnPreTrigger);
+
+  //if (digi0.isValid() && digi1.isValid()) swapCLCTs(digi0, digi1);
+
+  result.push_back(digi0);
+  result.push_back(digi1);
+
+  return result;
 }
 
- ///returns CLCT digis
-std::vector<CSCCLCTDigi> CSCTMBHeader2007::CLCTDigis(uint32_t idlayer) 
-{
-    std::vector<CSCCLCTDigi> result;
-    int strip   = bits.clct0_key;
-    int cfeb    = (bits.clct0_cfeb_low)|(bits.clct0_cfeb_high<<1);
-    int pattern = bits.clct0_shape;
-    int bend    = bits.clct0_bend;
-    //offlineStripNumbering(strip, cfeb, pattern, bend);
-    CSCCLCTDigi digi0(bits.clct0_valid, bits.clct0_quality,
-                      pattern, 1, bend, strip, cfeb, bits.clct0_bxn, 1, bits.bxnPreTrigger);
-    //digi0.setFullBX(bits.bxnPreTrigger);
-
-    strip = bits.clct1_key;
-    cfeb = (bits.clct1_cfeb_low)|(bits.clct1_cfeb_high<<1);
-    pattern = bits.clct1_shape;
-    bend    = bits.clct1_bend;
-    //offlineStripNumbering(strip, cfeb, pattern, bend);
-    CSCCLCTDigi digi1(bits.clct1_valid, bits.clct1_quality,
-                      pattern, 1, bend, strip, cfeb, bits.clct1_bxn, 2, bits.bxnPreTrigger);
-    //digi1.setFullBX(bits.bxnPreTrigger);
-
-    //if (digi0.isValid() && digi1.isValid()) swapCLCTs(digi0, digi1);
-
-    result.push_back(digi0);
-    result.push_back(digi1);
-
-
-    return result;
+///returns CorrelatedLCT digis
+std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2007::CorrelatedLCTDigis(uint32_t idlayer) const {
+  std::vector<CSCCorrelatedLCTDigi> result;
+  /// for the zeroth MPC word:
+  int strip = bits.MPC_Muon0_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  CSCCorrelatedLCTDigi digi(1,
+                            bits.MPC_Muon0_vpf_,
+                            bits.MPC_Muon0_quality_,
+                            bits.MPC_Muon0_wire_,
+                            strip,
+                            bits.MPC_Muon0_clct_pattern_,
+                            bits.MPC_Muon0_bend_,
+                            bits.MPC_Muon0_bx_,
+                            0,
+                            bits.MPC_Muon0_bc0_,
+                            bits.MPC_Muon0_SyncErr_,
+                            bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4 << 3));
+  result.push_back(digi);
+  /// for the first MPC word:
+  strip = bits.MPC_Muon1_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  digi = CSCCorrelatedLCTDigi(2,
+                              bits.MPC_Muon1_vpf_,
+                              bits.MPC_Muon1_quality_,
+                              bits.MPC_Muon1_wire_,
+                              strip,
+                              bits.MPC_Muon1_clct_pattern_,
+                              bits.MPC_Muon1_bend_,
+                              bits.MPC_Muon1_bx_,
+                              0,
+                              bits.MPC_Muon1_bc0_,
+                              bits.MPC_Muon1_SyncErr_,
+                              bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4 << 3));
+  result.push_back(digi);
+  return result;
 }
 
- ///returns CorrelatedLCT digis
-std::vector<CSCCorrelatedLCTDigi> 
-CSCTMBHeader2007::CorrelatedLCTDigis(uint32_t idlayer) const 
-{
-    std::vector<CSCCorrelatedLCTDigi> result;
-    /// for the zeroth MPC word:
-    int strip = bits.MPC_Muon0_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    CSCCorrelatedLCTDigi digi(1, bits.MPC_Muon0_vpf_, bits.MPC_Muon0_quality_,
-                              bits.MPC_Muon0_wire_, strip, bits.MPC_Muon0_clct_pattern_,
-                              bits.MPC_Muon0_bend_, bits.MPC_Muon0_bx_, 0,
-                              bits.MPC_Muon0_bc0_, bits.MPC_Muon0_SyncErr_,
-                              bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4<<3));
-    result.push_back(digi);
-    /// for the first MPC word:
-    strip = bits.MPC_Muon1_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    digi = CSCCorrelatedLCTDigi(2, bits.MPC_Muon1_vpf_, bits.MPC_Muon1_quality_,
-                                bits.MPC_Muon1_wire_, strip, bits.MPC_Muon1_clct_pattern_,
-                                bits.MPC_Muon1_bend_, bits.MPC_Muon1_bx_, 0,
-                                bits.MPC_Muon1_bc0_, bits.MPC_Muon1_SyncErr_,
-                                bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4<<3));
-    result.push_back(digi);
-    return result;
-}
-
-void
-CSCTMBHeader2007::addALCT0(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2007::addALCT0(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in ALCT header");
 }
 
-
-void
-CSCTMBHeader2007::addALCT1(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2007::addALCT1(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in ALCT header");
 }
 
-void
-CSCTMBHeader2007::addCLCT0(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2007::addCLCT0(const CSCCLCTDigi& digi) {
   int strip = digi.getStrip();
   int cfeb = digi.getCFEB();
   int bend = digi.getBend();
@@ -110,15 +106,13 @@ CSCTMBHeader2007::addCLCT0(const CSCCLCTDigi & digi)
   bits.clct0_bend = bend;
   bits.clct0_key = strip;
   bits.clct0_cfeb_low = (cfeb & 0x1);
-  bits.clct0_cfeb_high = (cfeb>>1);
+  bits.clct0_cfeb_high = (cfeb >> 1);
   bits.clct0_bxn = digi.getBX();
   bits.bxnPreTrigger = digi.getFullBX();
   bits.bxnCount = (digi.getFullBX() + 167) & 0xFFF;
 }
 
-void
-CSCTMBHeader2007::addCLCT1(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2007::addCLCT1(const CSCCLCTDigi& digi) {
   int strip = digi.getStrip();
   int cfeb = digi.getCFEB();
   int bend = digi.getBend();
@@ -130,14 +124,12 @@ CSCTMBHeader2007::addCLCT1(const CSCCLCTDigi & digi)
   bits.clct1_bend = bend;
   bits.clct1_key = strip;
   bits.clct1_cfeb_low = (cfeb & 0x1);
-  bits.clct1_cfeb_high = (cfeb>>1);
+  bits.clct1_cfeb_high = (cfeb >> 1);
   bits.clct1_bxn = digi.getBX();
   bits.bxnPreTrigger = digi.getFullBX();
 }
 
-void
-CSCTMBHeader2007::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2007::addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -151,12 +143,10 @@ CSCTMBHeader2007::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon0_bx_ = digi.getBX();
   bits.MPC_Muon0_bc0_ = digi.getBX0();
   bits.MPC_Muon0_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-void
-CSCTMBHeader2007::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2007::addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -170,34 +160,29 @@ CSCTMBHeader2007::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon1_bx_ = digi.getBX();
   bits.MPC_Muon1_bc0_ = digi.getBX0();
   bits.MPC_Muon1_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon1_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon1_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-
-void CSCTMBHeader2007::print(std::ostream & os) const
-{
-  os << "...............TMB Header.................." << "\n";
+void CSCTMBHeader2007::print(std::ostream& os) const {
+  os << "...............TMB Header.................."
+     << "\n";
   os << std::hex << "BOC LINE " << bits.b0cline << " EOB " << bits.e0bline << "\n";
-  os << std::dec << "fifoMode = " << bits.fifoMode
-     << ", nTBins = " << bits.nTBins << "\n";
-//  os << "dumpCFEBs = " << dumpCFEBs << ", nHeaderFrames = "
-//     << nHeaderFrames << "\n";
+  os << std::dec << "fifoMode = " << bits.fifoMode << ", nTBins = " << bits.nTBins << "\n";
+  //  os << "dumpCFEBs = " << dumpCFEBs << ", nHeaderFrames = "
+  //     << nHeaderFrames << "\n";
   os << "boardID = " << bits.boardID << ", cscID = " << bits.cscID << "\n";
   os << "l1aNumber = " << bits.l1aNumber << ", bxnCount = " << bits.bxnCount << "\n";
-//  os << "preTrigTBins = " << preTrigTBins << ", nCFEBs = "<< nCFEBs<< " ";
-  os << "trigSourceVect = " << bits.trigSourceVect
-     << ", activeCFEBs = " << bits.activeCFEBs <<"\n";
+  //  os << "preTrigTBins = " << preTrigTBins << ", nCFEBs = "<< nCFEBs<< " ";
+  os << "trigSourceVect = " << bits.trigSourceVect << ", activeCFEBs = " << bits.activeCFEBs << "\n";
   os << "bxnPreTrigger = " << bits.bxnPreTrigger << "\n";
-  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly
-     << " clctOnly = " << bits.clctOnly << "\n";
-//     << " alctMatchTime = " << alctMatchTime << " ";
-//  os << "hs_thresh = " << hs_thresh << ", ds_thresh = " << ds_thresh
-//     << " ";
+  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly << " clctOnly = " << bits.clctOnly << "\n";
+  //     << " alctMatchTime = " << alctMatchTime << " ";
+  //  os << "hs_thresh = " << hs_thresh << ", ds_thresh = " << ds_thresh
+  //     << " ";
   os << "clct0_key = " << bits.clct0_key << " bits.clct0_shape = " << bits.clct0_shape
      << " clct0_quality = " << bits.clct0_quality << "\n";
-//  os << "r_buf_nbusy = " << r_buf_nbusy << " ";
+  //  os << "r_buf_nbusy = " << r_buf_nbusy << " ";
 
-  os << "..................CLCT....................." << "\n";
-
+  os << "..................CLCT....................."
+     << "\n";
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader2007_rev0x50c3.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader2007_rev0x50c3.cc
@@ -2,55 +2,49 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-CSCTMBHeader2007_rev0x50c3::CSCTMBHeader2007_rev0x50c3() 
-{
-    bzero(data(), sizeInWords()*2);
-    bits.nHeaderFrames = 42;
-    bits.e0bline = 0x6E0B;
-    bits.b0cline = 0xDB0C;
-    bits.firmRevCode = 0x50c3;
-    bits.nTBins = 12;
-    bits.nCFEBs = 5;
+CSCTMBHeader2007_rev0x50c3::CSCTMBHeader2007_rev0x50c3() {
+  bzero(data(), sizeInWords() * 2);
+  bits.nHeaderFrames = 42;
+  bits.e0bline = 0x6E0B;
+  bits.b0cline = 0xDB0C;
+  bits.firmRevCode = 0x50c3;
+  bits.nTBins = 12;
+  bits.nCFEBs = 5;
 }
 
-
-CSCTMBHeader2007_rev0x50c3::CSCTMBHeader2007_rev0x50c3(const unsigned short * buf)
-{
-  memcpy(data(), buf, sizeInWords()*2);
+CSCTMBHeader2007_rev0x50c3::CSCTMBHeader2007_rev0x50c3(const unsigned short* buf) {
+  memcpy(data(), buf, sizeInWords() * 2);
 }
 
-  
-void CSCTMBHeader2007_rev0x50c3::setEventInformation(const CSCDMBHeader & dmbHeader) 
-{
-    bits.cscID = dmbHeader.dmbID();
-    bits.l1aNumber = dmbHeader.l1a24() & 0xFFF;
-//    bits.bxnCount = dmbHeader.bxn12();
+void CSCTMBHeader2007_rev0x50c3::setEventInformation(const CSCDMBHeader& dmbHeader) {
+  bits.cscID = dmbHeader.dmbID();
+  bits.l1aNumber = dmbHeader.l1a24() & 0xFFF;
+  //    bits.bxnCount = dmbHeader.bxn12();
 }
 
 ///returns CLCT digis
-std::vector<CSCCLCTDigi> CSCTMBHeader2007_rev0x50c3::CLCTDigis(uint32_t idlayer) 
-{
+std::vector<CSCCLCTDigi> CSCTMBHeader2007_rev0x50c3::CLCTDigis(uint32_t idlayer) {
   std::vector<CSCCLCTDigi> result;
   int halfstrip = bits.clct0_key_low + (bits.clct0_key_high << 7);
-  int strip   = halfstrip%32;
-  int cfeb    = halfstrip/32;
+  int strip = halfstrip % 32;
+  int cfeb = halfstrip / 32;
   int pattern = bits.clct0_shape;
-  int bend    = pattern &0x1;
+  int bend = pattern & 0x1;
 
   //offlineStripNumbering(strip, cfeb, pattern, bend);
-  CSCCLCTDigi digi0(bits.clct0_valid, bits.clct0_quality,
-		    pattern, 1, bend, strip, cfeb, bits.clct_bxn, 1, bits.bxnPreTrigger);
+  CSCCLCTDigi digi0(
+      bits.clct0_valid, bits.clct0_quality, pattern, 1, bend, strip, cfeb, bits.clct_bxn, 1, bits.bxnPreTrigger);
   //digi0.setFullBX(bits.bxnPreTrigger);
 
   halfstrip = bits.clct1_key_low + (bits.clct1_key_high << 7);
-  strip   = halfstrip%32;
-  cfeb    = halfstrip/32;
+  strip = halfstrip % 32;
+  cfeb = halfstrip / 32;
   pattern = bits.clct1_shape;
-  bend    = pattern &0x1;
+  bend = pattern & 0x1;
 
   //offlineStripNumbering(strip, cfeb, pattern, bend);
-  CSCCLCTDigi digi1(bits.clct1_valid, bits.clct1_quality,
-		    pattern, 1, bend, strip, cfeb, bits.clct_bxn, 2, bits.bxnPreTrigger);
+  CSCCLCTDigi digi1(
+      bits.clct1_valid, bits.clct1_quality, pattern, 1, bend, strip, cfeb, bits.clct_bxn, 2, bits.bxnPreTrigger);
   //digi1.setFullBX(bits.bxnPreTrigger);
   result.push_back(digi0);
   result.push_back(digi1);
@@ -58,47 +52,52 @@ std::vector<CSCCLCTDigi> CSCTMBHeader2007_rev0x50c3::CLCTDigis(uint32_t idlayer)
 }
 
 ///returns CorrelatedLCT digis
-std::vector<CSCCorrelatedLCTDigi> 
-CSCTMBHeader2007_rev0x50c3::CorrelatedLCTDigis(uint32_t idlayer) const 
-{
-    std::vector<CSCCorrelatedLCTDigi> result;
-    /// for the zeroth MPC word:
-    int strip = bits.MPC_Muon0_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    CSCCorrelatedLCTDigi digi(1, bits.MPC_Muon0_vpf_, bits.MPC_Muon0_quality_,
-                              bits.MPC_Muon0_wire_, strip, bits.MPC_Muon0_clct_pattern_,
-                              bits.MPC_Muon0_bend_, bits.MPC_Muon0_bx_, 0,
-                              bits.MPC_Muon0_bc0_, bits.MPC_Muon0_SyncErr_,
-                              bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4<<3));
-    result.push_back(digi);
-    /// for the first MPC word:
-    strip = bits.MPC_Muon1_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    digi = CSCCorrelatedLCTDigi(2, bits.MPC_Muon1_vpf_, bits.MPC_Muon1_quality_,
-                                bits.MPC_Muon1_wire_, strip, bits.MPC_Muon1_clct_pattern_,
-                                bits.MPC_Muon1_bend_, bits.MPC_Muon1_bx_, 0,
-                                bits.MPC_Muon1_bc0_, bits.MPC_Muon1_SyncErr_,
-                                bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4<<3));
-    result.push_back(digi);
-    return result;
+std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2007_rev0x50c3::CorrelatedLCTDigis(uint32_t idlayer) const {
+  std::vector<CSCCorrelatedLCTDigi> result;
+  /// for the zeroth MPC word:
+  int strip = bits.MPC_Muon0_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  CSCCorrelatedLCTDigi digi(1,
+                            bits.MPC_Muon0_vpf_,
+                            bits.MPC_Muon0_quality_,
+                            bits.MPC_Muon0_wire_,
+                            strip,
+                            bits.MPC_Muon0_clct_pattern_,
+                            bits.MPC_Muon0_bend_,
+                            bits.MPC_Muon0_bx_,
+                            0,
+                            bits.MPC_Muon0_bc0_,
+                            bits.MPC_Muon0_SyncErr_,
+                            bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4 << 3));
+  result.push_back(digi);
+  /// for the first MPC word:
+  strip = bits.MPC_Muon1_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  digi = CSCCorrelatedLCTDigi(2,
+                              bits.MPC_Muon1_vpf_,
+                              bits.MPC_Muon1_quality_,
+                              bits.MPC_Muon1_wire_,
+                              strip,
+                              bits.MPC_Muon1_clct_pattern_,
+                              bits.MPC_Muon1_bend_,
+                              bits.MPC_Muon1_bx_,
+                              0,
+                              bits.MPC_Muon1_bc0_,
+                              bits.MPC_Muon1_SyncErr_,
+                              bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4 << 3));
+  result.push_back(digi);
+  return result;
 }
 
-void
-CSCTMBHeader2007_rev0x50c3::addALCT0(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2007_rev0x50c3::addALCT0(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
 }
 
-
-void
-CSCTMBHeader2007_rev0x50c3::addALCT1(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2007_rev0x50c3::addALCT1(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
 }
 
-void
-CSCTMBHeader2007_rev0x50c3::addCLCT0(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2007_rev0x50c3::addCLCT0(const CSCCLCTDigi& digi) {
   int halfStrip = digi.getKeyStrip();
   int pattern = digi.getPattern();
   //int bend = digi.getBend();
@@ -114,9 +113,7 @@ CSCTMBHeader2007_rev0x50c3::addCLCT0(const CSCCLCTDigi & digi)
   bits.bxnPreTrigger = digi.getFullBX();
 }
 
-void
-CSCTMBHeader2007_rev0x50c3::addCLCT1(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2007_rev0x50c3::addCLCT1(const CSCCLCTDigi& digi) {
   int halfStrip = digi.getKeyStrip();
   int pattern = digi.getPattern();
   //int bend = digi.getBend();
@@ -135,9 +132,7 @@ CSCTMBHeader2007_rev0x50c3::addCLCT1(const CSCCLCTDigi & digi)
   bits.bxnCount = (digi.getFullBX() + 167) & 0xFFF;
 }
 
-void
-CSCTMBHeader2007_rev0x50c3::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2007_rev0x50c3::addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -151,12 +146,10 @@ CSCTMBHeader2007_rev0x50c3::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon0_bx_ = digi.getBX();
   bits.MPC_Muon0_bc0_ = digi.getBX0();
   bits.MPC_Muon0_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-void
-CSCTMBHeader2007_rev0x50c3::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2007_rev0x50c3::addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -170,35 +163,29 @@ CSCTMBHeader2007_rev0x50c3::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon1_bx_ = digi.getBX();
   bits.MPC_Muon1_bc0_ = digi.getBX0();
   bits.MPC_Muon1_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon1_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon1_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-
-void CSCTMBHeader2007_rev0x50c3::print(std::ostream & os) const
-{
-  os << "...............TMB Header.................." << "\n";
+void CSCTMBHeader2007_rev0x50c3::print(std::ostream& os) const {
+  os << "...............TMB Header.................."
+     << "\n";
   os << std::hex << "BOC LINE " << bits.b0cline << " EOB " << bits.e0bline << "\n";
-  os << std::dec << "fifoMode = " << bits.fifoMode
-     << ", nTBins = " << bits.nTBins << "\n";
-//  os << "dumpCFEBs = " << dumpCFEBs << ", nHeaderFrames = "
-//     << nHeaderFrames << "\n";
+  os << std::dec << "fifoMode = " << bits.fifoMode << ", nTBins = " << bits.nTBins << "\n";
+  //  os << "dumpCFEBs = " << dumpCFEBs << ", nHeaderFrames = "
+  //     << nHeaderFrames << "\n";
   os << "boardID = " << bits.boardID << ", cscID = " << bits.cscID << "\n";
   os << "l1aNumber = " << bits.l1aNumber << ", bxnCount = " << bits.bxnCount << "\n";
-//  os << "preTrigTBins = " << preTrigTBins << ", nCFEBs = "<< nCFEBs<< " ";
-  os << "trigSourceVect = " << bits.trigSourceVect
-     << ", activeCFEBs = " << bits.activeCFEBs <<"\n";
+  //  os << "preTrigTBins = " << preTrigTBins << ", nCFEBs = "<< nCFEBs<< " ";
+  os << "trigSourceVect = " << bits.trigSourceVect << ", activeCFEBs = " << bits.activeCFEBs << "\n";
   os << "bxnPreTrigger = " << bits.bxnPreTrigger << "\n";
-  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly
-     << " clctOnly = " << bits.clctOnly << "\n";
-//     << " alctMatchTime = " << alctMatchTime << " ";
-//  os << "hs_thresh = " << hs_thresh << ", ds_thresh = " << ds_thresh
-//     << " ";
-//  os << "clct0_key = " << bits.clct0_key 
-  os << " bits.clct0_shape = " << bits.clct0_shape
-     << " clct0_quality = " << bits.clct0_quality << "\n";
-//  os << "r_buf_nbusy = " << r_buf_nbusy << " ";
+  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly << " clctOnly = " << bits.clctOnly << "\n";
+  //     << " alctMatchTime = " << alctMatchTime << " ";
+  //  os << "hs_thresh = " << hs_thresh << ", ds_thresh = " << ds_thresh
+  //     << " ";
+  //  os << "clct0_key = " << bits.clct0_key
+  os << " bits.clct0_shape = " << bits.clct0_shape << " clct0_quality = " << bits.clct0_quality << "\n";
+  //  os << "r_buf_nbusy = " << r_buf_nbusy << " ";
 
-  os << "..................CLCT....................." << "\n";
-
+  os << "..................CLCT....................."
+     << "\n";
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader2013.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader2013.cc
@@ -2,55 +2,47 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-CSCTMBHeader2013::CSCTMBHeader2013() 
-{
-    bzero(data(), sizeInWords()*2);
-    bits.nHeaderFrames = 42;
-    bits.e0bline = 0x6E0B;
-    bits.b0cline = 0xDB0C;
-    bits.firmRevCode = 0x7a76;
-    bits.nTBins = 12;
-    bits.nCFEBs = 5;
+CSCTMBHeader2013::CSCTMBHeader2013() {
+  bzero(data(), sizeInWords() * 2);
+  bits.nHeaderFrames = 42;
+  bits.e0bline = 0x6E0B;
+  bits.b0cline = 0xDB0C;
+  bits.firmRevCode = 0x7a76;
+  bits.nTBins = 12;
+  bits.nCFEBs = 5;
 }
 
+CSCTMBHeader2013::CSCTMBHeader2013(const unsigned short* buf) { memcpy(data(), buf, sizeInWords() * 2); }
 
-CSCTMBHeader2013::CSCTMBHeader2013(const unsigned short * buf)
-{
-  memcpy(data(), buf, sizeInWords()*2);
-}
-
-  
-void CSCTMBHeader2013::setEventInformation(const CSCDMBHeader & dmbHeader) 
-{
-    bits.cscID = dmbHeader.dmbID();
-    bits.l1aNumber = dmbHeader.l1a24() & 0xFFF;
-//    bits.bxnCount = dmbHeader.bxn12();
+void CSCTMBHeader2013::setEventInformation(const CSCDMBHeader& dmbHeader) {
+  bits.cscID = dmbHeader.dmbID();
+  bits.l1aNumber = dmbHeader.l1a24() & 0xFFF;
+  //    bits.bxnCount = dmbHeader.bxn12();
 }
 
 ///returns CLCT digis
-std::vector<CSCCLCTDigi> CSCTMBHeader2013::CLCTDigis(uint32_t idlayer) 
-{
+std::vector<CSCCLCTDigi> CSCTMBHeader2013::CLCTDigis(uint32_t idlayer) {
   std::vector<CSCCLCTDigi> result;
   int halfstrip = bits.clct0_key_low + (bits.clct0_key_high << 7);
-  int strip   = halfstrip%32;
-  int cfeb    = halfstrip/32;
+  int strip = halfstrip % 32;
+  int cfeb = halfstrip / 32;
   int pattern = bits.clct0_shape;
-  int bend    = pattern &0x1;
+  int bend = pattern & 0x1;
 
   //offlineStripNumbering(strip, cfeb, pattern, bend);
-  CSCCLCTDigi digi0(bits.clct0_valid, bits.clct0_quality,
-		    pattern, 1, bend, strip, cfeb, bits.clct_bxn, 1, bits.bxnPreTrigger);
+  CSCCLCTDigi digi0(
+      bits.clct0_valid, bits.clct0_quality, pattern, 1, bend, strip, cfeb, bits.clct_bxn, 1, bits.bxnPreTrigger);
   //digi0.setFullBX(bits.bxnPreTrigger);
 
   halfstrip = bits.clct1_key_low + (bits.clct1_key_high << 7);
-  strip   = halfstrip%32;
-  cfeb    = halfstrip/32;
+  strip = halfstrip % 32;
+  cfeb = halfstrip / 32;
   pattern = bits.clct1_shape;
-  bend    = pattern &0x1;
+  bend = pattern & 0x1;
 
   //offlineStripNumbering(strip, cfeb, pattern, bend);
-  CSCCLCTDigi digi1(bits.clct1_valid, bits.clct1_quality,
-		    pattern, 1, bend, strip, cfeb, bits.clct_bxn, 2, bits.bxnPreTrigger);
+  CSCCLCTDigi digi1(
+      bits.clct1_valid, bits.clct1_quality, pattern, 1, bend, strip, cfeb, bits.clct_bxn, 2, bits.bxnPreTrigger);
   //digi1.setFullBX(bits.bxnPreTrigger);
   result.push_back(digi0);
   result.push_back(digi1);
@@ -58,47 +50,52 @@ std::vector<CSCCLCTDigi> CSCTMBHeader2013::CLCTDigis(uint32_t idlayer)
 }
 
 ///returns CorrelatedLCT digis
-std::vector<CSCCorrelatedLCTDigi> 
-CSCTMBHeader2013::CorrelatedLCTDigis(uint32_t idlayer) const 
-{
-    std::vector<CSCCorrelatedLCTDigi> result;
-    /// for the zeroth MPC word:
-    int strip = bits.MPC_Muon0_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    CSCCorrelatedLCTDigi digi(1, bits.MPC_Muon0_vpf_, bits.MPC_Muon0_quality_,
-                              bits.MPC_Muon0_wire_, strip, bits.MPC_Muon0_clct_pattern_,
-                              bits.MPC_Muon0_bend_, bits.MPC_Muon0_bx_, 0,
-                              bits.MPC_Muon0_bc0_, bits.MPC_Muon0_SyncErr_,
-                              bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4<<3));
-    result.push_back(digi);
-    /// for the first MPC word:
-    strip = bits.MPC_Muon1_halfstrip_clct_pattern;//this goes from 0-159
-    //offlineHalfStripNumbering(strip);
-    digi = CSCCorrelatedLCTDigi(2, bits.MPC_Muon1_vpf_, bits.MPC_Muon1_quality_,
-                                bits.MPC_Muon1_wire_, strip, bits.MPC_Muon1_clct_pattern_,
-                                bits.MPC_Muon1_bend_, bits.MPC_Muon1_bx_, 0,
-                                bits.MPC_Muon1_bc0_, bits.MPC_Muon1_SyncErr_,
-                                bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4<<3));
-    result.push_back(digi);
-    return result;
+std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2013::CorrelatedLCTDigis(uint32_t idlayer) const {
+  std::vector<CSCCorrelatedLCTDigi> result;
+  /// for the zeroth MPC word:
+  int strip = bits.MPC_Muon0_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  CSCCorrelatedLCTDigi digi(1,
+                            bits.MPC_Muon0_vpf_,
+                            bits.MPC_Muon0_quality_,
+                            bits.MPC_Muon0_wire_,
+                            strip,
+                            bits.MPC_Muon0_clct_pattern_,
+                            bits.MPC_Muon0_bend_,
+                            bits.MPC_Muon0_bx_,
+                            0,
+                            bits.MPC_Muon0_bc0_,
+                            bits.MPC_Muon0_SyncErr_,
+                            bits.MPC_Muon0_cscid_low | (bits.MPC_Muon0_cscid_bit4 << 3));
+  result.push_back(digi);
+  /// for the first MPC word:
+  strip = bits.MPC_Muon1_halfstrip_clct_pattern;  //this goes from 0-159
+  //offlineHalfStripNumbering(strip);
+  digi = CSCCorrelatedLCTDigi(2,
+                              bits.MPC_Muon1_vpf_,
+                              bits.MPC_Muon1_quality_,
+                              bits.MPC_Muon1_wire_,
+                              strip,
+                              bits.MPC_Muon1_clct_pattern_,
+                              bits.MPC_Muon1_bend_,
+                              bits.MPC_Muon1_bx_,
+                              0,
+                              bits.MPC_Muon1_bc0_,
+                              bits.MPC_Muon1_SyncErr_,
+                              bits.MPC_Muon1_cscid_low | (bits.MPC_Muon1_cscid_bit4 << 3));
+  result.push_back(digi);
+  return result;
 }
 
-void
-CSCTMBHeader2013::addALCT0(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2013::addALCT0(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
 }
 
-
-void
-CSCTMBHeader2013::addALCT1(const CSCALCTDigi & digi)
-{
+void CSCTMBHeader2013::addALCT1(const CSCALCTDigi& digi) {
   throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
 }
 
-void
-CSCTMBHeader2013::addCLCT0(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2013::addCLCT0(const CSCCLCTDigi& digi) {
   int halfStrip = digi.getKeyStrip();
   int pattern = digi.getPattern();
   //int bend = digi.getBend();
@@ -113,12 +110,9 @@ CSCTMBHeader2013::addCLCT0(const CSCCLCTDigi & digi)
   bits.clct_bxn = digi.getBX();
   bits.bxnPreTrigger = digi.getFullBX();
   bits.bxnCount = (digi.getFullBX() + 167) & 0xFFF;
-  
 }
 
-void
-CSCTMBHeader2013::addCLCT1(const CSCCLCTDigi & digi)
-{
+void CSCTMBHeader2013::addCLCT1(const CSCCLCTDigi& digi) {
   int halfStrip = digi.getKeyStrip();
   int pattern = digi.getPattern();
   //int bend = digi.getBend();
@@ -136,9 +130,7 @@ CSCTMBHeader2013::addCLCT1(const CSCCLCTDigi & digi)
   bits.bxnPreTrigger = digi.getFullBX();
 }
 
-void
-CSCTMBHeader2013::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2013::addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -152,12 +144,10 @@ CSCTMBHeader2013::addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon0_bx_ = digi.getBX();
   bits.MPC_Muon0_bc0_ = digi.getBX0();
   bits.MPC_Muon0_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon0_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-void
-CSCTMBHeader2013::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
-{
+void CSCTMBHeader2013::addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) {
   int halfStrip = digi.getStrip();
   //hardwareHalfStripNumbering(halfStrip);
 
@@ -171,36 +161,31 @@ CSCTMBHeader2013::addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi)
   bits.MPC_Muon1_bx_ = digi.getBX();
   bits.MPC_Muon1_bc0_ = digi.getBX0();
   bits.MPC_Muon1_cscid_low = digi.getCSCID() & 0x7;
-  bits.MPC_Muon1_cscid_bit4 = (digi.getCSCID()>>3) & 0x1;
+  bits.MPC_Muon1_cscid_bit4 = (digi.getCSCID() >> 3) & 0x1;
 }
 
-
-void CSCTMBHeader2013::print(std::ostream & os) const
-{
-  os << "...............TMB Header.................." << "\n";
+void CSCTMBHeader2013::print(std::ostream& os) const {
+  os << "...............TMB Header.................."
+     << "\n";
   os << std::hex << "BOC LINE " << bits.b0cline << " EOB " << bits.e0bline << "\n";
-  os << std::dec << "fifoMode = " << bits.fifoMode
-     << ", nTBins = " << bits.nTBins << "\n";
-//  os << "dumpCFEBs = " << dumpCFEBs << ", nHeaderFrames = "
-//     << nHeaderFrames << "\n";
+  os << std::dec << "fifoMode = " << bits.fifoMode << ", nTBins = " << bits.nTBins << "\n";
+  //  os << "dumpCFEBs = " << dumpCFEBs << ", nHeaderFrames = "
+  //     << nHeaderFrames << "\n";
   os << "boardID = " << bits.boardID << ", cscID = " << bits.cscID << "\n";
   os << "l1aNumber = " << bits.l1aNumber << ", bxnCount = " << bits.bxnCount << "\n";
-//  os << "preTrigTBins = " << preTrigTBins << ", nCFEBs = "<< nCFEBs<< " ";
+  //  os << "preTrigTBins = " << preTrigTBins << ", nCFEBs = "<< nCFEBs<< " ";
   os << "trigSourceVect = " << bits.trigSourceVect
-     << ", activeCFEBs = " << (bits.activeCFEBs | (bits.activeCFEBs_2 << 5))  
+     << ", activeCFEBs = " << (bits.activeCFEBs | (bits.activeCFEBs_2 << 5))
      << ", readCFEBs = " << (bits.readCFEBs | (bits.readCFEBs_2 << 5)) << "\n";
   os << "bxnPreTrigger = " << bits.bxnPreTrigger << "\n";
-  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly
-     << " clctOnly = " << bits.clctOnly << "\n";
-//     << " alctMatchTime = " << alctMatchTime << " ";
-//  os << "hs_thresh = " << hs_thresh << ", ds_thresh = " << ds_thresh
-//     << " ";
-//  os << "clct0_key = " << bits.clct0_key 
-  os << " bits.clct0_shape = " << bits.clct0_shape
-     << " clct0_quality = " << bits.clct0_quality << "\n";
-//  os << "r_buf_nbusy = " << r_buf_nbusy << " ";
+  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly << " clctOnly = " << bits.clctOnly << "\n";
+  //     << " alctMatchTime = " << alctMatchTime << " ";
+  //  os << "hs_thresh = " << hs_thresh << ", ds_thresh = " << ds_thresh
+  //     << " ";
+  //  os << "clct0_key = " << bits.clct0_key
+  os << " bits.clct0_shape = " << bits.clct0_shape << " clct0_quality = " << bits.clct0_quality << "\n";
+  //  os << "r_buf_nbusy = " << r_buf_nbusy << " ";
 
-  os << "..................CLCT....................." << "\n";
-
+  os << "..................CLCT....................."
+     << "\n";
 }
-

--- a/EventFilter/CSCRawToDigi/src/CSCTMBMiniScope.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBMiniScope.cc
@@ -1,76 +1,65 @@
 //_________________________________________________________
 //
-//  CSCTMBMiniScope July 2010  Alexander Sakharov                            
-//  Unpacks TMB Logic MiniScope Analyzer and stores in CSCTMBMiniScope.h  
+//  CSCTMBMiniScope July 2010  Alexander Sakharov
+//  Unpacks TMB Logic MiniScope Analyzer and stores in CSCTMBMiniScope.h
 //_________________________________________________________
 //
-
 
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-CSCTMBMiniScope::CSCTMBMiniScope(const uint16_t *buf,int Line6b07,int Line6E07) {
+CSCTMBMiniScope::CSCTMBMiniScope(const uint16_t *buf, int Line6b07, int Line6E07) {
+  size_ = UnpackMiniScope(buf, Line6b07, Line6E07);
 
-  size_ = UnpackMiniScope(buf,Line6b07,Line6E07);
+}  ///CSCTMBMiniScope
 
-} ///CSCTMBMiniScope
-
-
-int CSCTMBMiniScope::UnpackMiniScope(const uint16_t *buf,int Line6b07,int Line6E07) {
-
-
-  if((Line6E07-Line6b07) != 0) {
-
+int CSCTMBMiniScope::UnpackMiniScope(const uint16_t *buf, int Line6b07, int Line6E07) {
+  if ((Line6E07 - Line6b07) != 0) {
     /// Get tbin and tbin before pre-trigger
-    miniScopeTbinCount = buf[Line6b07+1] & 0x00FF;
-    miniScopeTbinPreTrigger = (buf[Line6b07+1] >> 8) & 0x000F;
-    
-    LogTrace("CSCTMBMiniScope") << " MiniScope Found | Tbin: " << miniScopeTbinCount <<
-                 " | Tbin Pretrigger: " << miniScopeTbinPreTrigger << std::endl;
-        
-     miniScopeAdress.clear();
-     miniScopeData.clear();
+    miniScopeTbinCount = buf[Line6b07 + 1] & 0x00FF;
+    miniScopeTbinPreTrigger = (buf[Line6b07 + 1] >> 8) & 0x000F;
 
-     for(int i=0; i<miniScopeTbinCount; i++){
-        miniScopeAdress.push_back(284+i);
-        miniScopeData.push_back(buf[Line6b07 + 1+i]);
-     }
-     
-     //print();
-  } ///end if((Line6E07-Line6b07)
+    LogTrace("CSCTMBMiniScope") << " MiniScope Found | Tbin: " << miniScopeTbinCount
+                                << " | Tbin Pretrigger: " << miniScopeTbinPreTrigger << std::endl;
 
+    miniScopeAdress.clear();
+    miniScopeData.clear();
 
-  return (Line6E07-Line6b07 + 1);
+    for (int i = 0; i < miniScopeTbinCount; i++) {
+      miniScopeAdress.push_back(284 + i);
+      miniScopeData.push_back(buf[Line6b07 + 1 + i]);
+    }
 
-} ///UnpackScope
+    //print();
+  }  ///end if((Line6E07-Line6b07)
+
+  return (Line6E07 - Line6b07 + 1);
+
+}  ///UnpackScope
 
 std::vector<int> CSCTMBMiniScope::getChannelsInTbin(int data) const {
-                 std::vector<int> channelInTbin;
-                 channelInTbin.clear();
-                 for(int k=0; k<14; k++){
-                              int chBit=0;
-                              chBit = (data >> k) & 0x1;
-                              if(chBit !=0)
-                              channelInTbin.push_back(k);
-        }
-        return channelInTbin;
+  std::vector<int> channelInTbin;
+  channelInTbin.clear();
+  for (int k = 0; k < 14; k++) {
+    int chBit = 0;
+    chBit = (data >> k) & 0x1;
+    if (chBit != 0)
+      channelInTbin.push_back(k);
+  }
+  return channelInTbin;
 }
 
-
 void CSCTMBMiniScope::print() const {
-     for(unsigned int k=0; k<getAdr().size();++k){
-           if(k==0){
-             std::cout << " Adr = " << getAdr()[k] << " | Data: " 
-                                     << std::hex <<  getData()[k] << std::dec << std::endl;
-           }
-           else{
-           std::cout << " Adr = " << getAdr()[k] << " | Data: " 
-                                     << std::hex <<  getData()[k] << std::dec << " ==>| Ch# ";
-                                      for(unsigned int j=0; j<getChannelsInTbin(getData()[k]).size(); j++){
-                                         std::cout << " " << getChannelsInTbin(getData()[k])[j];
-                                      }
-                                     std::cout << std::endl;
-           }
-           }
+  for (unsigned int k = 0; k < getAdr().size(); ++k) {
+    if (k == 0) {
+      std::cout << " Adr = " << getAdr()[k] << " | Data: " << std::hex << getData()[k] << std::dec << std::endl;
+    } else {
+      std::cout << " Adr = " << getAdr()[k] << " | Data: " << std::hex << getData()[k] << std::dec << " ==>| Ch# ";
+      for (unsigned int j = 0; j < getChannelsInTbin(getData()[k]).size(); j++) {
+        std::cout << " " << getChannelsInTbin(getData()[k])[j];
+      }
+      std::cout << std::endl;
+    }
+  }
 }

--- a/EventFilter/CSCRawToDigi/src/CSCTMBScope.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBScope.cc
@@ -1,7 +1,7 @@
 //_________________________________________________________
 //
-//  CSCTMBScope 9/11/03  B.Mohr                             
-//  Unpacks TMB Logic Analyzer and stores in CSCTMBScope.h  
+//  CSCTMBScope 9/11/03  B.Mohr
+//  Unpacks TMB Logic Analyzer and stores in CSCTMBScope.h
 //_________________________________________________________
 //
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBScope.h"
@@ -14,42 +14,37 @@ bool CSCTMBScope::debug = false;
 std::atomic<bool> CSCTMBScope::debug{false};
 #endif
 
-CSCTMBScope::CSCTMBScope(const uint16_t *buf,int b05Line,int e05Line) {
+CSCTMBScope::CSCTMBScope(const uint16_t *buf, int b05Line, int e05Line) {
+  size_ = UnpackScope(buf, b05Line, e05Line);
 
-  size_ = UnpackScope(buf,b05Line,e05Line);
+}  //CSCTMBScope
 
-} //CSCTMBScope
-
-
-int CSCTMBScope::UnpackScope(const uint16_t *buf,int b05Line,int e05Line) {
-
-  int pretrig_chan[4]={0,0,0,0};
-  unsigned int tbin_strt,tbin_stop;
-  unsigned int ibit,jbit,itbin,ich,iram,iline,iadr;
+int CSCTMBScope::UnpackScope(const uint16_t *buf, int b05Line, int e05Line) {
+  int pretrig_chan[4] = {0, 0, 0, 0};
+  unsigned int tbin_strt, tbin_stop;
+  unsigned int ibit, jbit, itbin, ich, iram, iline, iadr;
   unsigned int lct_bxn;
 
-
-  if(debug) {
+  if (debug) {
     LogTrace("CSCTMBScope|CSCRawToDigi") << " .....TMBHeader -- unpacking Logic Analyzer......";
   }
 
-  if((e05Line-b05Line) == 1537) {
-
-    if(debug) 
-     LogTrace("CSCTMBScope|CSCRawToDigi") << "Scope data found";
+  if ((e05Line - b05Line) == 1537) {
+    if (debug)
+      LogTrace("CSCTMBScope|CSCRawToDigi") << "Scope data found";
 
     //load scope_ram from raw-hits format readout
     iline = b05Line + 1;
-    for(iram=0;iram<6;iram++){
-      for(iadr=0;iadr<256;iadr++) {
-	itbin = iadr;   //ram_sel*256
-	scope_ram[itbin][iram] = buf[iline];
-	iline++;
+    for (iram = 0; iram < 6; iram++) {
+      for (iadr = 0; iadr < 256; iadr++) {
+        itbin = iadr;  //ram_sel*256
+        scope_ram[itbin][iram] = buf[iline];
+        iline++;
       }
     }
 
-    for(ich=0;ich<51;ich++) data[ich]=0;  //clear all data
-
+    for (ich = 0; ich < 51; ich++)
+      data[ich] = 0;  //clear all data
 
     //----- find pretrig chan offset -----------------
     pretrig_chan[0] = GetPretrig(0);
@@ -58,151 +53,149 @@ int CSCTMBScope::UnpackScope(const uint16_t *buf,int b05Line,int e05Line) {
     pretrig_chan[3] = GetPretrig(64);
 
     //----- ram 1 ------------------------------------
-    tbin_strt = pretrig_chan[0]-7;
-    tbin_stop = pretrig_chan[0]+24;
+    tbin_strt = pretrig_chan[0] - 7;
+    tbin_stop = pretrig_chan[0] + 24;
 
-    for(ich=0;ich<=14;ich++) {
-      iram=ich/16;
-      jbit=0;
-      for(itbin=tbin_strt;itbin<=tbin_stop;itbin++) {
-	ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
-	data[ich] = (ibit << jbit) | data[ich];
-	jbit++;
+    for (ich = 0; ich <= 14; ich++) {
+      iram = ich / 16;
+      jbit = 0;
+      for (itbin = tbin_strt; itbin <= tbin_stop; itbin++) {
+        ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
+        data[ich] = (ibit << jbit) | data[ich];
+        jbit++;
       }
     }
 
     //----- ram 2 ------------------------------------
-    for(ich=16;ich<=30;ich++) {
-      iram=ich/16;
-      jbit=0;
-      for(itbin=tbin_strt;itbin<=tbin_stop;itbin++) {
-	ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
-	data[ich-1] = (ibit << jbit) | data[ich-1];
-	jbit++;
+    for (ich = 16; ich <= 30; ich++) {
+      iram = ich / 16;
+      jbit = 0;
+      for (itbin = tbin_strt; itbin <= tbin_stop; itbin++) {
+        ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
+        data[ich - 1] = (ibit << jbit) | data[ich - 1];
+        jbit++;
       }
     }
 
     //----- ram 3 ------------------------------------
-    tbin_strt = pretrig_chan[1]-7;
-    tbin_stop = pretrig_chan[1]+24;
+    tbin_strt = pretrig_chan[1] - 7;
+    tbin_stop = pretrig_chan[1] + 24;
 
-    for(ich=32;ich<=36;ich++) {
-      iram=ich/16;
-      jbit=0;
-      for(itbin=tbin_strt;itbin<=tbin_stop;itbin++) {
-	ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
-	data[ich-2] = (ibit << jbit) | data[ich-2];
-	jbit++;
+    for (ich = 32; ich <= 36; ich++) {
+      iram = ich / 16;
+      jbit = 0;
+      for (itbin = tbin_strt; itbin <= tbin_stop; itbin++) {
+        ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
+        data[ich - 2] = (ibit << jbit) | data[ich - 2];
+        jbit++;
       }
     }
 
-    tbin_strt = pretrig_chan[1]-7+120;
-    tbin_stop = pretrig_chan[1]+24+120;
+    tbin_strt = pretrig_chan[1] - 7 + 120;
+    tbin_stop = pretrig_chan[1] + 24 + 120;
 
-    for(ich=37;ich<=40;ich++) {
-      iram=ich/16;
-      jbit=0;
-      for(itbin=tbin_strt;itbin<=tbin_stop;itbin++) {
-	ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
-	data[ich-2] = (ibit << jbit) | data[ich-2];
-	jbit++;
+    for (ich = 37; ich <= 40; ich++) {
+      iram = ich / 16;
+      jbit = 0;
+      for (itbin = tbin_strt; itbin <= tbin_stop; itbin++) {
+        ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
+        data[ich - 2] = (ibit << jbit) | data[ich - 2];
+        jbit++;
       }
     }
 
-    tbin_strt = pretrig_chan[1]-7;
-    tbin_stop = pretrig_chan[1]+24;
+    tbin_strt = pretrig_chan[1] - 7;
+    tbin_stop = pretrig_chan[1] + 24;
 
-    for(ich=41;ich<=46;ich++) {
-      iram=ich/16;
-      jbit=0;
-      for(itbin=tbin_strt;itbin<=tbin_stop;itbin++) {
-	ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
-	data[ich-2] = (ibit << jbit) | data[ich-2];
-	jbit++;
+    for (ich = 41; ich <= 46; ich++) {
+      iram = ich / 16;
+      jbit = 0;
+      for (itbin = tbin_strt; itbin <= tbin_stop; itbin++) {
+        ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
+        data[ich - 2] = (ibit << jbit) | data[ich - 2];
+        jbit++;
       }
     }
 
     //----- ram 4 ------------------------------------
-    tbin_strt = pretrig_chan[2]-7;
-    tbin_stop = pretrig_chan[2]+24;
+    tbin_strt = pretrig_chan[2] - 7;
+    tbin_stop = pretrig_chan[2] + 24;
 
-    for(ich=48;ich<=53;ich++) {
-      iram=ich/16;
-      jbit=0;
-      for(itbin=tbin_strt;itbin<=tbin_stop;itbin++) {
-	ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
-	data[ich-3] = (ibit << jbit) | data[ich-3];
-	jbit++;
+    for (ich = 48; ich <= 53; ich++) {
+      iram = ich / 16;
+      jbit = 0;
+      for (itbin = tbin_strt; itbin <= tbin_stop; itbin++) {
+        ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
+        data[ich - 3] = (ibit << jbit) | data[ich - 3];
+        jbit++;
       }
     }
 
     //----- ram 5 - bxn ------------------------------
     lct_bxn = 0;
-    jbit=0;
+    jbit = 0;
 
-    for(ich=65;ich<=76;ich++) {
-      iram=ich/16;
+    for (ich = 65; ich <= 76; ich++) {
+      iram = ich / 16;
       itbin = pretrig_chan[3];
-      ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
+      ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
       lct_bxn = (ibit << jbit) | lct_bxn;
       jbit++;
     }
-    data[51]=lct_bxn;
+    data[51] = lct_bxn;
 
-    if(debug) 
-      LogTrace("CSCTMBScope|CSCRawToDigi") << "Scope bxn at LCT (seq_pretrig): " 
-				  << lct_bxn;
+    if (debug)
+      LogTrace("CSCTMBScope|CSCRawToDigi") << "Scope bxn at LCT (seq_pretrig): " << lct_bxn;
 
     //----- now read back decoded scope data ---------
-    if(debug) {
-      for(ich=0;ich<=50;ich++) {
-	for(itbin=0;itbin<32;itbin++) {
-	  ibit = (data[ich] >> itbin ) & 1;
-	  if(ibit == 0) LogTrace("CSCTMBScope|CSCRawToDigi") << "_";    //display symbol for logic 0
-	  if(ibit == 1) LogTrace("CSCTMBScope|CSCRawToDigi") << "-";    //display symbol for logic 1
-	}
+    if (debug) {
+      for (ich = 0; ich <= 50; ich++) {
+        for (itbin = 0; itbin < 32; itbin++) {
+          ibit = (data[ich] >> itbin) & 1;
+          if (ibit == 0)
+            LogTrace("CSCTMBScope|CSCRawToDigi") << "_";  //display symbol for logic 0
+          if (ibit == 1)
+            LogTrace("CSCTMBScope|CSCRawToDigi") << "-";  //display symbol for logic 1
+        }
       }
     }
 
-  } //end if(b05-e05)
-
+  }  //end if(b05-e05)
 
   //-------------- if no scope data: fill everything with 0 --------------------
   else {
-    for(ich=0;ich<51;ich++) data[ich]=0;
-    lct_bxn  = 0xff0000;    //value not possible for real data (short)
+    for (ich = 0; ich < 51; ich++)
+      data[ich] = 0;
+    lct_bxn = 0xff0000;  //value not possible for real data (short)
     data[51] = lct_bxn;
 
-    if(debug) 
-      LogTrace("CSCTMBScope|CSCRawToDigi")  << "No scope data found: wrdcnt: " 
-				   << (e05Line-b05Line);
+    if (debug)
+      LogTrace("CSCTMBScope|CSCRawToDigi") << "No scope data found: wrdcnt: " << (e05Line - b05Line);
   }
 
-  if(debug) {
-     LogTrace("CSCTMBScope|CSCRawToDigi") << " .....END -- unpacking Logic Analyzer...........";
+  if (debug) {
+    LogTrace("CSCTMBScope|CSCRawToDigi") << " .....END -- unpacking Logic Analyzer...........";
   }
 
   return (e05Line - b05Line + 1);
 
-} //UnpackScope
-
+}  //UnpackScope
 
 int CSCTMBScope::GetPretrig(int ich) {
-
-  unsigned int ibit,itbin,iram;
+  unsigned int ibit, itbin, iram;
   int value = 0;
 
-  ibit=0;
-  itbin=0;
-  iram=ich/16;
-  while(!ibit) {
-    ibit = (scope_ram[itbin][iram] >> (ich%16) ) & 1;
+  ibit = 0;
+  itbin = 0;
+  iram = ich / 16;
+  while (!ibit) {
+    ibit = (scope_ram[itbin][iram] >> (ich % 16)) & 1;
     value = itbin;
     itbin++;
   }
 
-  if(debug)
+  if (debug)
     LogTrace("CSCTMBScope|CSCRawToDigi") << "TMB SCOPE: ------- Pretrig value: " << value;
   return value;
 
-} //GetPretrig
+}  //GetPretrig

--- a/EventFilter/CSCRawToDigi/src/CSCTMBTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBTrailer.cc
@@ -3,9 +3,7 @@
 #include <iostream>
 #include <cassert>
 
-CSCTMBTrailer::CSCTMBTrailer(int wordCount, int firmwareVersion) 
-: theFirmwareVersion(firmwareVersion)
-{
+CSCTMBTrailer::CSCTMBTrailer(int wordCount, int firmwareVersion) : theFirmwareVersion(firmwareVersion) {
   //FIXME do firmware version
   theData[0] = 0x6e0c;
   // all the necessary lines from this thing first
@@ -13,68 +11,55 @@ CSCTMBTrailer::CSCTMBTrailer(int wordCount, int firmwareVersion)
   // see if we need thePadding to make a multiple of 4
   thePadding = 0;
 
-  if(wordCount%4==2) 
-    {
-      theData[1] = 0x2AAA;
-      theData[2] = 0x5555;
-      thePadding = 2;
-      wordCount += thePadding;
-    }
+  if (wordCount % 4 == 2) {
+    theData[1] = 0x2AAA;
+    theData[2] = 0x5555;
+    thePadding = 2;
+    wordCount += thePadding;
+  }
   // the next four words start with 11011, or a D
-  for(int i = 1; i < 5; ++i) 
-    {
-      theData[i+thePadding] = 0xD800;
-    }
+  for (int i = 1; i < 5; ++i) {
+    theData[i + thePadding] = 0xD800;
+  }
   theData[de0fOffset()] = 0xde0f;
   // word count excludes the trailer
-  theData[4+thePadding] |= wordCount;
+  theData[4 + thePadding] |= wordCount;
 }
 
-
-CSCTMBTrailer::CSCTMBTrailer(const uint16_t * buf, unsigned short int firmwareVersion) 
-: theFirmwareVersion(firmwareVersion)
-{
+CSCTMBTrailer::CSCTMBTrailer(const uint16_t* buf, unsigned short int firmwareVersion)
+    : theFirmwareVersion(firmwareVersion) {
   // take a little too much, maybe
   memcpy(theData, buf, 14);
-  switch (firmwareVersion){
-  case 2006:
-    // if there's padding, there'll be a de0f in the 6th word.
-    // If not, you'll be in CFEB-land, where they won't be de0f.
-    thePadding = (theData[5] == 0xde0f ? 2 : 0);
-    break;
-  case 2007:
-    ///in 2007 format de0f line moved
-    // =VB= check for 1st word to be 0xDE0F, then check 3rd 
-    // to handle freaky cases of double 0xDE0F signatures in trailer 
-    thePadding = (theData[1] == 0xde0f ? 0 : (theData[3] == 0xde0f ? 2 : 0)); 
-//    thePadding = (theData[3] == 0xde0f ? 2 : 0);
-    break;
-  default: 
-    edm::LogError("CSCTMBTrailer|CSCRawToDigi")
-      <<"failed to contruct: firmware version is bad/not defined!";
+  switch (firmwareVersion) {
+    case 2006:
+      // if there's padding, there'll be a de0f in the 6th word.
+      // If not, you'll be in CFEB-land, where they won't be de0f.
+      thePadding = (theData[5] == 0xde0f ? 2 : 0);
+      break;
+    case 2007:
+      ///in 2007 format de0f line moved
+      // =VB= check for 1st word to be 0xDE0F, then check 3rd
+      // to handle freaky cases of double 0xDE0F signatures in trailer
+      thePadding = (theData[1] == 0xde0f ? 0 : (theData[3] == 0xde0f ? 2 : 0));
+      //    thePadding = (theData[3] == 0xde0f ? 2 : 0);
+      break;
+    default:
+      edm::LogError("CSCTMBTrailer|CSCRawToDigi") << "failed to contruct: firmware version is bad/not defined!";
   }
 }
 
-unsigned int CSCTMBTrailer::crc22() const 
-{  
-  return (theData[crcOffset()] & 0x07ff) +
-            ((theData[crcOffset()+1] & 0x07ff) << 11);
+unsigned int CSCTMBTrailer::crc22() const {
+  return (theData[crcOffset()] & 0x07ff) + ((theData[crcOffset() + 1] & 0x07ff) << 11);
 }
 
-
-void CSCTMBTrailer::setCRC(int crc) 
-{
+void CSCTMBTrailer::setCRC(int crc) {
   theData[crcOffset()] |= (crc & 0x07ff);
-  theData[crcOffset()+1] |= ((crc>>11) & 0x07ff);
+  theData[crcOffset() + 1] |= ((crc >> 11) & 0x07ff);
 }
 
+int CSCTMBTrailer::wordCount() const { return theData[4 + thePadding] & 0x7ff; }
 
-int CSCTMBTrailer::wordCount() const {return theData[4+thePadding] & 0x7ff;}
-
-
-
-void CSCTMBTrailer::selfTest()
-{
+void CSCTMBTrailer::selfTest() {
   CSCTMBTrailer trailer(104, 2006);
   unsigned int crc = 0xb00b1;
   trailer.setCRC(crc);
@@ -84,6 +69,4 @@ void CSCTMBTrailer::selfTest()
   crc = 0xb00b1;
   trailer2.setCRC(crc);
   assert(trailer2.crc22() == 0xb00b1);
-
 }
-

--- a/EventFilter/CSCRawToDigi/src/bitset_append.cc
+++ b/EventFilter/CSCRawToDigi/src/bitset_append.cc
@@ -1,67 +1,50 @@
 ///this file contains additional dynamic_bitset methods
 
-#include "EventFilter/CSCRawToDigi/src/bitset_append.h" 
+#include "EventFilter/CSCRawToDigi/src/bitset_append.h"
 #include <iostream>
 #include <cstdio>
 
 namespace bitset_utilities {
 
   ///this method takes two bitsets bs1 and bs2 and returns result of bs2 appended to the end of bs1
-  boost::dynamic_bitset<> append(const boost::dynamic_bitset<> & bs1, 
-				 const boost::dynamic_bitset<> & bs2)
-  {
-    boost::dynamic_bitset<> result(bs1.size()+bs2.size());
+  boost::dynamic_bitset<> append(const boost::dynamic_bitset<> &bs1, const boost::dynamic_bitset<> &bs2) {
+    boost::dynamic_bitset<> result(bs1.size() + bs2.size());
     unsigned size1 = bs1.size();
-    for(unsigned i = 0; i < size1; ++i)
-      {
-	result[i] = bs1[i];
-      }
-    for(unsigned i = 0; i < bs2.size(); ++i)
-      {
-	result[size1+i] = bs2[i];
-      }
+    for (unsigned i = 0; i < size1; ++i) {
+      result[i] = bs1[i];
+    }
+    for (unsigned i = 0; i < bs2.size(); ++i) {
+      result[size1 + i] = bs2[i];
+    }
     return result;
   }
 
   ///this method takes numberOfBits bits from unsigned short * array and returns them in the bitset obj.
-  boost::dynamic_bitset<> ushortToBitset(const unsigned int numberOfBits,
-					 unsigned short * buf)
-  {
+  boost::dynamic_bitset<> ushortToBitset(const unsigned int numberOfBits, unsigned short *buf) {
     boost::dynamic_bitset<> result(numberOfBits);
-    for(unsigned i = 0; i < result.size(); ++i)
-      {
-        result[i] = (buf[i/16]>>(i%16)) & 0x1;
-      }
+    for (unsigned i = 0; i < result.size(); ++i) {
+      result[i] = (buf[i / 16] >> (i % 16)) & 0x1;
+    }
     return result;
   }
 
-
-  ///this method takes bitset obj and returns char * array 
-  void bitsetToChar(const boost::dynamic_bitset<> & bs, unsigned char * result)
-  {
-    for(unsigned i = 0; i < bs.size(); ++i)
-      {
-        result[i/8] =  (bs[i+7]<<7)+
-	  (bs[i+6]<<6)+
-	  (bs[i+5]<<5)+
-	  (bs[i+4]<<4)+ 
-	  (bs[i+3]<<3)+
-	  (bs[i+2]<<2)+
-	  (bs[i+1]<<1)+
-	  bs[i];
-	i+=7;
-      }
-  }
-
-  void printWords(const boost::dynamic_bitset<> & bs) 
-  {
-    constexpr unsigned int nShorts = 30000;
-    unsigned char words[nShorts*2];
-    bitsetToChar(bs, words);
-    unsigned short * buf= (unsigned short *) words;
-    for (int unsigned i=0;i<bs.size()/16 && i+3 < nShorts;++i) {
-      printf("%04x %04x %04x %04x\n",buf[i+3],buf[i+2],buf[i+1],buf[i]);
-      i+=3;
+  ///this method takes bitset obj and returns char * array
+  void bitsetToChar(const boost::dynamic_bitset<> &bs, unsigned char *result) {
+    for (unsigned i = 0; i < bs.size(); ++i) {
+      result[i / 8] = (bs[i + 7] << 7) + (bs[i + 6] << 6) + (bs[i + 5] << 5) + (bs[i + 4] << 4) + (bs[i + 3] << 3) +
+                      (bs[i + 2] << 2) + (bs[i + 1] << 1) + bs[i];
+      i += 7;
     }
   }
-}
+
+  void printWords(const boost::dynamic_bitset<> &bs) {
+    constexpr unsigned int nShorts = 30000;
+    unsigned char words[nShorts * 2];
+    bitsetToChar(bs, words);
+    unsigned short *buf = (unsigned short *)words;
+    for (int unsigned i = 0; i < bs.size() / 16 && i + 3 < nShorts; ++i) {
+      printf("%04x %04x %04x %04x\n", buf[i + 3], buf[i + 2], buf[i + 1], buf[i]);
+      i += 3;
+    }
+  }
+}  // namespace bitset_utilities

--- a/EventFilter/CSCRawToDigi/src/bitset_append.h
+++ b/EventFilter/CSCRawToDigi/src/bitset_append.h
@@ -3,16 +3,13 @@
 #include <boost/dynamic_bitset.hpp>
 
 namespace bitset_utilities {
-   boost::dynamic_bitset<> append(const boost::dynamic_bitset<> & bs1, 
-				  const boost::dynamic_bitset<> & bs2);
+  boost::dynamic_bitset<> append(const boost::dynamic_bitset<>& bs1, const boost::dynamic_bitset<>& bs2);
 
-   boost::dynamic_bitset<> ushortToBitset(const unsigned int numberOfBits,
-					  unsigned short * buf);
-   void bitsetToChar(const boost::dynamic_bitset<> & bs, unsigned char * result);
+  boost::dynamic_bitset<> ushortToBitset(const unsigned int numberOfBits, unsigned short* buf);
+  void bitsetToChar(const boost::dynamic_bitset<>& bs, unsigned char* result);
 
-   void printWords(const boost::dynamic_bitset<> & bs);
+  void printWords(const boost::dynamic_bitset<>& bs);
 
+}  // namespace bitset_utilities
 
-}
- 
 #endif

--- a/EventFilter/CSCRawToDigi/src/cscPackerCompare.h
+++ b/EventFilter/CSCRawToDigi/src/cscPackerCompare.h
@@ -2,43 +2,36 @@
 #include <typeinfo>
 #include "EventFilter/CSCRawToDigi/src/bitset_append.h"
 
-
 /** Compares two objects, and prints them out if they differ
  */
 
 template <class T>
-bool cscPackerCompare(const T & t1, const T & t2)
-{
+bool cscPackerCompare(const T &t1, const T &t2) {
   bool result = true;
-  if(t1 != t2) {
-    std::cerr << "Mismatch:\n"<< t1 << "\n" << t2 << std::endl;
+  if (t1 != t2) {
+    std::cerr << "Mismatch:\n" << t1 << "\n" << t2 << std::endl;
     result = false;
   }
   return result;
 }
 
-
 template <class T>
-T cscPackAndUnpack(T & t)
-{
+T cscPackAndUnpack(T &t) {
   boost::dynamic_bitset<> firstPack = t.pack();
   unsigned char data[10000];
   bitset_utilities::bitsetToChar(firstPack, data);
   return T((unsigned short int *)data);
 }
 
-
 // packs a class, then unpacks, packs again, and compares
 template <class T>
-bool cscClassPackerCompare(T & t)
-{
+bool cscClassPackerCompare(T &t) {
   boost::dynamic_bitset<> firstPack = t.pack();
   unsigned char data[1000];
   bitset_utilities::bitsetToChar(firstPack, data);
   T newObject((unsigned short int *)data);
   boost::dynamic_bitset<> secondPack = newObject.pack();
-  if(firstPack != secondPack)
-  {
+  if (firstPack != secondPack) {
     std::cerr << "Mismatch in " << typeid(t).name() << "\n";
     bitset_utilities::printWords(firstPack);
     bitset_utilities::printWords(secondPack);
@@ -46,4 +39,3 @@ bool cscClassPackerCompare(T & t)
   }
   return true;
 }
-     

--- a/EventFilter/CSCRawToDigi/test/cscRawToDigiTest.cpp
+++ b/EventFilter/CSCRawToDigi/test/cscRawToDigiTest.cpp
@@ -5,8 +5,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h"
 
-int main()
-{
+int main() {
   CSCTMBHeader::selfTest();
   CSCALCTHeader::selfTest(2007);
   CSCALCTHeader::selfTest(2006);
@@ -18,4 +17,3 @@ int main()
   CSCAnodeData2006::selfTest();
   CSCAnodeData2007::selfTest();
 }
-

--- a/EventFilter/GEMRawToDigi/interface/AMC13Event.h
+++ b/EventFilter/GEMRawToDigi/interface/AMC13Event.h
@@ -4,96 +4,96 @@
 #include "AMCdata.h"
 
 namespace gem {
-  
+
   union CDFHeader {
     uint64_t word;
     struct {
-      uint64_t fov       : 8;  // not used
-      uint64_t sourceId  : 12; // FED number assigned by CDAQ
-      uint64_t bxId      : 12; // Bunch crossing 0...3563
-      uint64_t lv1Id     : 24; // Level 1 ID (hardware event number)
+      uint64_t fov : 8;        // not used
+      uint64_t sourceId : 12;  // FED number assigned by CDAQ
+      uint64_t bxId : 12;      // Bunch crossing 0...3563
+      uint64_t lv1Id : 24;     // Level 1 ID (hardware event number)
       uint64_t eventType : 4;  // Event Type (1 for normal, 2 for calibration)
-      uint64_t cb5       : 4;  // 0x5
+      uint64_t cb5 : 4;        // 0x5
     };
   };
   union AMC13Header {
     uint64_t word;
     struct {
-      uint64_t cb0       : 4;  // 0x0
-      uint64_t orbitN    : 32; // Orbit Number
-      uint64_t reserved0 : 16; // reserved
-      uint64_t nAMC      : 4;  // Number of AMCs following (0 to 12)
-      uint64_t calType   : 4;  // Calibration event type
-      uint64_t uFov      : 4;  // Format version: 0x1
+      uint64_t cb0 : 4;         // 0x0
+      uint64_t orbitN : 32;     // Orbit Number
+      uint64_t reserved0 : 16;  // reserved
+      uint64_t nAMC : 4;        // Number of AMCs following (0 to 12)
+      uint64_t calType : 4;     // Calibration event type
+      uint64_t uFov : 4;        // Format version: 0x1
     };
   };
   union AMC13Trailer {
     uint64_t word;
     struct {
-      uint64_t bxIdT     : 12; // bx id
-      uint64_t lv1IdT    : 8;  // level 1 id
-      uint64_t blkN      : 8;  // block number
-      uint64_t crc32     : 36; // Overall CRC (first 34 bits)
+      uint64_t bxIdT : 12;  // bx id
+      uint64_t lv1IdT : 8;  // level 1 id
+      uint64_t blkN : 8;    // block number
+      uint64_t crc32 : 36;  // Overall CRC (first 34 bits)
     };
   };
   union CDFTrailer {
     uint64_t word;
     struct {
-      uint64_t tts       : 8;  // tts (first 4 bits)
-      uint64_t evtStat   : 4;  // event status
-      uint64_t crcCDF    : 20; // CDF crc (first 16 bits)
-      uint64_t evtLength : 24; // event length
-      uint64_t cbA       : 8;  // 0xA (first 4 bits)
+      uint64_t tts : 8;         // tts (first 4 bits)
+      uint64_t evtStat : 4;     // event status
+      uint64_t crcCDF : 20;     // CDF crc (first 16 bits)
+      uint64_t evtLength : 24;  // event length
+      uint64_t cbA : 8;         // 0xA (first 4 bits)
     };
   };
 
-  class AMC13Event
-  {
-    
+  class AMC13Event {
   public:
     AMC13Event() {}
-    ~AMC13Event() {amcHeaders_.clear(); amcs_.clear();}
+    ~AMC13Event() {
+      amcHeaders_.clear();
+      amcs_.clear();
+    }
 
-    void setCDFHeader(uint64_t word) { cdfh_ = word;}
+    void setCDFHeader(uint64_t word) { cdfh_ = word; }
     void setCDFHeader(uint8_t Evt_ty, uint32_t LV1_id, uint16_t BX_id, uint16_t Source_id);
-    uint64_t getCDFHeader() const { return cdfh_;}
+    uint64_t getCDFHeader() const { return cdfh_; }
 
-    void setAMC13Header(uint64_t word) { amc13h_ = word;}
+    void setAMC13Header(uint64_t word) { amc13h_ = word; }
     void setAMC13Header(uint8_t CalTyp, uint8_t nAMC, uint32_t OrN);
-    uint64_t getAMC13Header() const { return amc13h_;}
+    uint64_t getAMC13Header() const { return amc13h_; }
 
-    void setAMC13Trailer(uint64_t word) { amc13t_ = word;}
+    void setAMC13Trailer(uint64_t word) { amc13t_ = word; }
     void setAMC13Trailer(uint8_t Blk_NoT, uint8_t LV1_idT, uint16_t BX_idT);
-    uint64_t getAMC13Trailer() const { return amc13t_;}
+    uint64_t getAMC13Trailer() const { return amc13t_; }
 
-    void setCDFTrailer(uint64_t word) { cdft_ = word;}
+    void setCDFTrailer(uint64_t word) { cdft_ = word; }
     void setCDFTrailer(uint32_t EvtLength);
-    uint64_t getCDFTrailer() const { return cdft_;}
+    uint64_t getCDFTrailer() const { return cdft_; }
 
-    uint16_t bxId() const {return CDFHeader{cdfh_}.bxId;}
-    uint32_t lv1Id() const {return CDFHeader{cdfh_}.lv1Id;}
-    uint16_t sourceId() const {return CDFHeader{cdfh_}.sourceId;}
+    uint16_t bxId() const { return CDFHeader{cdfh_}.bxId; }
+    uint32_t lv1Id() const { return CDFHeader{cdfh_}.lv1Id; }
+    uint16_t sourceId() const { return CDFHeader{cdfh_}.sourceId; }
 
-    uint8_t  nAMC() const {return AMC13Header{amc13h_}.nAMC;}
-    
-    const std::vector<uint64_t> * getAMCheaders() const {return &amcHeaders_;}
+    uint8_t nAMC() const { return AMC13Header{amc13h_}.nAMC; }
+
+    const std::vector<uint64_t>* getAMCheaders() const { return &amcHeaders_; }
     void addAMCheader(uint64_t word);
     void addAMCheader(uint32_t AMC_size, uint8_t Blk_No, uint8_t AMC_No, uint16_t BoardID);
 
-    const std::vector<AMCdata> * getAMCpayloads() const {return &amcs_;}   
-    void addAMCpayload(const AMCdata& a) {amcs_.push_back(a);}
-    
+    const std::vector<AMCdata>* getAMCpayloads() const { return &amcs_; }
+    void addAMCpayload(const AMCdata& a) { amcs_.push_back(a); }
+
   private:
-    uint64_t cdfh_;   // CDFHeader
-    uint64_t amc13h_; // AMC13Header
-    uint64_t amc13t_; // AMC13Trailer
-    uint64_t cdft_;   // CDFTrailer
-     
+    uint64_t cdfh_;    // CDFHeader
+    uint64_t amc13h_;  // AMC13Header
+    uint64_t amc13t_;  // AMC13Trailer
+    uint64_t cdft_;    // CDFTrailer
+
     // AMC headers
-    std::vector<uint64_t> amcHeaders_;    
+    std::vector<uint64_t> amcHeaders_;
     // AMCs payload
     std::vector<AMCdata> amcs_;
-
   };
-}
+}  // namespace gem
 #endif

--- a/EventFilter/GEMRawToDigi/interface/AMCdata.h
+++ b/EventFilter/GEMRawToDigi/interface/AMCdata.h
@@ -4,114 +4,112 @@
 #include <vector>
 
 namespace gem {
-  
+
   union AMCheader1 {
     uint64_t word;
     struct {
-      uint64_t dataLength : 20; // Overall size of this FED event fragment 
-      uint64_t bxID       : 12; // Bunch crossing ID
-      uint64_t l1AID      : 24; // L1A number – basically this is like event number, but it’s reset by resync
-      uint64_t AMCnum     : 4;  // Slot number of the AMC
-      uint64_t reserved   : 4;  // not used
+      uint64_t dataLength : 20;  // Overall size of this FED event fragment
+      uint64_t bxID : 12;        // Bunch crossing ID
+      uint64_t l1AID : 24;       // L1A number – basically this is like event number, but it’s reset by resync
+      uint64_t AMCnum : 4;       // Slot number of the AMC
+      uint64_t reserved : 4;     // not used
     };
   };
   union AMCheader2 {
     uint64_t word;
     struct {
-      uint64_t boardID    : 16; // 8bit long GLIB serial number 
-      uint64_t orbitNum   : 16;
-      uint64_t param3     : 8;
-      uint64_t param2     : 8;
-      uint64_t param1     : 8;
-      uint64_t runType    : 4;  // run types like physics, cosmics, threshold scan, latency scan, etc..
-      uint64_t formatVer  : 4;  // Current format version = 0x0
+      uint64_t boardID : 16;  // 8bit long GLIB serial number
+      uint64_t orbitNum : 16;
+      uint64_t param3 : 8;
+      uint64_t param2 : 8;
+      uint64_t param1 : 8;
+      uint64_t runType : 4;    // run types like physics, cosmics, threshold scan, latency scan, etc..
+      uint64_t formatVer : 4;  // Current format version = 0x0
     };
   };
   union AMCTrailer {
     uint64_t word;
     struct {
-      uint64_t dataLengthT: 20; // Overall size of this FED event fragment 
-      uint64_t l1AIDT     : 12; // 8bit long GLIB serial number (first 8 bits)
-      uint64_t crc        : 32;
+      uint64_t dataLengthT : 20;  // Overall size of this FED event fragment
+      uint64_t l1AIDT : 12;       // 8bit long GLIB serial number (first 8 bits)
+      uint64_t crc : 32;
     };
   };
   union EventHeader {
     uint64_t word;
     struct {
-      uint64_t ttsState   : 11; // GLIB TTS state at the moment when this event was built.
-      uint64_t davCnt     : 5;  // Number of chamber blocks
-      uint64_t buffState  : 24; // buffer error 
-      uint64_t davList    : 24; // Bitmask indicating which inputs/chambers have data
+      uint64_t ttsState : 11;   // GLIB TTS state at the moment when this event was built.
+      uint64_t davCnt : 5;      // Number of chamber blocks
+      uint64_t buffState : 24;  // buffer error
+      uint64_t davList : 24;    // Bitmask indicating which inputs/chambers have data
     };
   };
   union EventTrailer {
     uint64_t word;
     struct {
-      uint64_t oosGlib    : 40; // GLIB is out‐of‐sync (critical): L1A ID is different for different chambers in this event (1 bit)
-      uint64_t chTimeOut  : 24; // GLIB did not receive data from a particular input for this L1A 
+      uint64_t
+          oosGlib : 40;  // GLIB is out‐of‐sync (critical): L1A ID is different for different chambers in this event (1 bit)
+      uint64_t chTimeOut : 24;  // GLIB did not receive data from a particular input for this L1A
     };
   };
 
-  class AMCdata
-  {
-    
+  class AMCdata {
   public:
-    AMCdata() {};
-    ~AMCdata() {gebd_.clear();}
+    AMCdata(){};
+    ~AMCdata() { gebd_.clear(); }
 
-    void setAMCheader1(uint64_t word) { amch1_ = word;}
+    void setAMCheader1(uint64_t word) { amch1_ = word; }
     void setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, uint8_t AMCnum);
-    uint64_t getAMCheader1() const { return amch1_;}
+    uint64_t getAMCheader1() const { return amch1_; }
 
-    void setAMCheader2(uint64_t word) { amch2_ = word;}
+    void setAMCheader2(uint64_t word) { amch2_ = word; }
     void setAMCheader2(uint16_t boardID, uint16_t orbitNum, uint8_t runType);
-    uint64_t getAMCheader2() const { return amch2_;}
+    uint64_t getAMCheader2() const { return amch2_; }
 
-    void setAMCTrailer(uint64_t word) { amct_ = word;}
-    uint64_t getAMCTrailer() const { return amct_;}
+    void setAMCTrailer(uint64_t word) { amct_ = word; }
+    uint64_t getAMCTrailer() const { return amct_; }
 
-    void setGEMeventHeader(uint64_t word) { eh_ = word;}
+    void setGEMeventHeader(uint64_t word) { eh_ = word; }
     void setGEMeventHeader(uint8_t davCnt, uint32_t davList);
-    uint64_t getGEMeventHeader() const { return eh_;}
+    uint64_t getGEMeventHeader() const { return eh_; }
 
-    void setGEMeventTrailer(uint64_t word) { et_ = word;}
-    uint64_t getGEMeventTrailer() const { return et_;}
+    void setGEMeventTrailer(uint64_t word) { et_ = word; }
+    uint64_t getGEMeventTrailer() const { return et_; }
 
-    uint32_t dataLength() const {return AMCheader1{amch1_}.dataLength;}
-    uint16_t bx()         const {return AMCheader1{amch1_}.bxID;}
-    uint32_t l1A()        const {return AMCheader1{amch1_}.l1AID;}
-    uint8_t  amcNum()     const {return AMCheader1{amch1_}.AMCnum;}
+    uint32_t dataLength() const { return AMCheader1{amch1_}.dataLength; }
+    uint16_t bx() const { return AMCheader1{amch1_}.bxID; }
+    uint32_t l1A() const { return AMCheader1{amch1_}.l1AID; }
+    uint8_t amcNum() const { return AMCheader1{amch1_}.AMCnum; }
 
-    uint16_t boardId()    const {return AMCheader2{amch2_}.boardID;}
-    uint16_t orbitNum()   const {return AMCheader2{amch2_}.orbitNum;}
-    uint8_t  param3()     const {return AMCheader2{amch2_}.param3;}
-    uint8_t  param2()     const {return AMCheader2{amch2_}.param2;}
-    uint8_t  param1()     const {return AMCheader2{amch2_}.param1;}
-    uint8_t  runType()    const {return AMCheader2{amch2_}.runType;}
-    uint8_t  formatVer()  const {return AMCheader2{amch2_}.formatVer;}
-    
-    uint16_t ttsState()   const {return EventHeader{eh_}.ttsState;}
-    uint8_t  davCnt()     const {return EventHeader{eh_}.davCnt;}
-    uint32_t buffState()  const {return EventHeader{eh_}.buffState;}
-    uint32_t davList()    const {return EventHeader{eh_}.davList;}
+    uint16_t boardId() const { return AMCheader2{amch2_}.boardID; }
+    uint16_t orbitNum() const { return AMCheader2{amch2_}.orbitNum; }
+    uint8_t param3() const { return AMCheader2{amch2_}.param3; }
+    uint8_t param2() const { return AMCheader2{amch2_}.param2; }
+    uint8_t param1() const { return AMCheader2{amch2_}.param1; }
+    uint8_t runType() const { return AMCheader2{amch2_}.runType; }
+    uint8_t formatVer() const { return AMCheader2{amch2_}.formatVer; }
 
-    uint8_t  oosGlib()    const {return EventTrailer{et_}.oosGlib;}
-    uint32_t chTimeOut()  const {return EventTrailer{et_}.chTimeOut;}
-    
+    uint16_t ttsState() const { return EventHeader{eh_}.ttsState; }
+    uint8_t davCnt() const { return EventHeader{eh_}.davCnt; }
+    uint32_t buffState() const { return EventHeader{eh_}.buffState; }
+    uint32_t davList() const { return EventHeader{eh_}.davList; }
+
+    uint8_t oosGlib() const { return EventTrailer{et_}.oosGlib; }
+    uint32_t chTimeOut() const { return EventTrailer{et_}.chTimeOut; }
+
     //!Adds GEB data to vector
-    void addGEB(GEBdata g) {gebd_.push_back(g);}
+    void addGEB(GEBdata g) { gebd_.push_back(g); }
     //!Returns a vector of GEB data
-    const std::vector<GEBdata> * gebs() const {return &gebd_;}
-  
-  private:
+    const std::vector<GEBdata>* gebs() const { return &gebd_; }
 
+  private:
     uint64_t amch1_;
     uint64_t amch2_;
     uint64_t amct_;
     uint64_t eh_;
     uint64_t et_;
 
-    std::vector<GEBdata> gebd_; ///<Vector of GEB data
+    std::vector<GEBdata> gebd_;  ///<Vector of GEB data
   };
-}
+}  // namespace gem
 #endif

--- a/EventFilter/GEMRawToDigi/interface/GEBdata.h
+++ b/EventFilter/GEMRawToDigi/interface/GEBdata.h
@@ -8,81 +8,77 @@ namespace gem {
   // BX mismatch GLIB OH / BX mismatch GLIB VFAT / OOS GLIB OH / OOS GLIB VFAT / No VFAT marker
   // Event size warn / L1AFIFO near full / InFIFO near full / EvtFIFO near full / Event size overflow
   // L1AFIFO full / InFIFO full / EvtFIFO full
-  union GEBchamberHeader {      
+  union GEBchamberHeader {
     uint64_t word;
     struct {
-      uint64_t inputStatus     : 23; // Input status (critical) only first 13 bits used
-      uint64_t vfatWordCnt     : 12; // Size of VFAT payload in 64bit words expected to send to AMC13
-      uint64_t inputID         : 5 ; // GLIB input ID (starting at 0)
-      uint64_t zeroSupWordsCnt : 24; // Bitmask indicating if certain VFAT blocks have been zero suppressed
+      uint64_t inputStatus : 23;      // Input status (critical) only first 13 bits used
+      uint64_t vfatWordCnt : 12;      // Size of VFAT payload in 64bit words expected to send to AMC13
+      uint64_t inputID : 5;           // GLIB input ID (starting at 0)
+      uint64_t zeroSupWordsCnt : 24;  // Bitmask indicating if certain VFAT blocks have been zero suppressed
     };
   };
-  union GEBchamberTrailer {      
+  union GEBchamberTrailer {
     uint64_t word;
     struct {
-      uint64_t ecOH         : 20; // OH event counter
-      uint64_t bcOH         : 14; // OH bunch crossing
-      uint64_t stuckData    : 1;  // Input status (warning): There was data in InFIFO or EvtFIFO when L1A FIFO was empty
-      uint64_t inFIFOund    : 1;  // Input status (critical): Input FIFO underflow occurred while sending this event
-      uint64_t vfatWordCntT : 12; // Size of VFAT payload in 64bit words sent to AMC13 
-      uint64_t ohcrc        : 16; // CRC of OH data (currently not available – filled with 0)
+      uint64_t ecOH : 20;      // OH event counter
+      uint64_t bcOH : 14;      // OH bunch crossing
+      uint64_t stuckData : 1;  // Input status (warning): There was data in InFIFO or EvtFIFO when L1A FIFO was empty
+      uint64_t inFIFOund : 1;  // Input status (critical): Input FIFO underflow occurred while sending this event
+      uint64_t vfatWordCntT : 12;  // Size of VFAT payload in 64bit words sent to AMC13
+      uint64_t ohcrc : 16;         // CRC of OH data (currently not available – filled with 0)
     };
   };
 
-  class GEBdata
-  {
+  class GEBdata {
   public:
-    
-    GEBdata() {};
-    ~GEBdata() {vfatd_.clear();}
+    GEBdata(){};
+    ~GEBdata() { vfatd_.clear(); }
 
     //!Read chamberHeader from the block.
-    void setChamberHeader(uint64_t word) { ch_ = word;}
-    void setChamberHeader(uint16_t vfatWordCnt, uint8_t inputID)
-    {
-      GEBchamberHeader u;  
+    void setChamberHeader(uint64_t word) { ch_ = word; }
+    void setChamberHeader(uint16_t vfatWordCnt, uint8_t inputID) {
+      GEBchamberHeader u;
       u.vfatWordCnt = vfatWordCnt;
       u.inputID = inputID;
       ch_ = u.word;
     }
-    uint64_t getChamberHeader() const { return ch_;}
+    uint64_t getChamberHeader() const { return ch_; }
 
     //!Read chamberTrailer from the block.
-    void setChamberTrailer(uint64_t word) { ct_ = word;}
-    void setChamberTrailer(uint32_t ecOH, uint16_t bcOH, uint16_t vfatWordCntT)
-    {
-      GEBchamberTrailer u;  
+    void setChamberTrailer(uint64_t word) { ct_ = word; }
+    void setChamberTrailer(uint32_t ecOH, uint16_t bcOH, uint16_t vfatWordCntT) {
+      GEBchamberTrailer u;
       u.ecOH = ecOH;
       u.bcOH = bcOH;
-      u.vfatWordCntT = vfatWordCntT;      
+      u.vfatWordCntT = vfatWordCntT;
       ct_ = u.word;
     }
-    uint64_t getChamberTrailer() const { return ct_;}
+    uint64_t getChamberTrailer() const { return ct_; }
 
-    uint32_t inputStatus()     const {return GEBchamberHeader{ch_}.inputStatus;}
-    uint16_t vfatWordCnt()     const {return GEBchamberHeader{ch_}.vfatWordCnt;}
-    uint8_t  inputID()         const {return GEBchamberHeader{ch_}.inputID;}
-    uint16_t zeroSupWordsCnt() const {return GEBchamberHeader{ch_}.zeroSupWordsCnt;}
+    uint32_t inputStatus() const { return GEBchamberHeader{ch_}.inputStatus; }
+    uint16_t vfatWordCnt() const { return GEBchamberHeader{ch_}.vfatWordCnt; }
+    uint8_t inputID() const { return GEBchamberHeader{ch_}.inputID; }
+    uint16_t zeroSupWordsCnt() const { return GEBchamberHeader{ch_}.zeroSupWordsCnt; }
 
-    uint32_t ecOH()            const {return GEBchamberTrailer{ct_}.ecOH;}
-    uint16_t bcOH()            const {return GEBchamberTrailer{ct_}.bcOH;}
-    uint8_t  stuckData()       const {return GEBchamberTrailer{ct_}.stuckData;}
-    uint8_t  inFIFOund()       const {return GEBchamberTrailer{ct_}.inFIFOund;}
-    uint16_t vfatWordCntT()    const {return GEBchamberTrailer{ct_}.vfatWordCntT;}
-    uint16_t ohcrc()           const {return GEBchamberTrailer{ct_}.ohcrc;}
+    uint32_t ecOH() const { return GEBchamberTrailer{ct_}.ecOH; }
+    uint16_t bcOH() const { return GEBchamberTrailer{ct_}.bcOH; }
+    uint8_t stuckData() const { return GEBchamberTrailer{ct_}.stuckData; }
+    uint8_t inFIFOund() const { return GEBchamberTrailer{ct_}.inFIFOund; }
+    uint16_t vfatWordCntT() const { return GEBchamberTrailer{ct_}.vfatWordCntT; }
+    uint16_t ohcrc() const { return GEBchamberTrailer{ct_}.ohcrc; }
 
     //!Adds VFAT data to the vector
-    void addVFAT(VFATdata v) {vfatd_.push_back(v);}
+    void addVFAT(VFATdata v) { vfatd_.push_back(v); }
     //!Returns the vector of FVAT data
-    const std::vector<VFATdata> * vFATs() const {return &vfatd_;}  
+    const std::vector<VFATdata>* vFATs() const { return &vfatd_; }
 
     static const int sizeGebID = 5;
-    
+
   private:
-    uint64_t ch_; // GEBchamberHeader
-    uint64_t ct_; // GEBchamberTrailer
+    uint64_t ch_;  // GEBchamberHeader
+    uint64_t ct_;  // GEBchamberTrailer
 
     std::vector<VFATdata> vfatd_;
   };
-}
+}  // namespace gem
 #endif

--- a/EventFilter/GEMRawToDigi/interface/GEMVfatStatusDigi.h
+++ b/EventFilter/GEMRawToDigi/interface/GEMVfatStatusDigi.h
@@ -5,24 +5,21 @@
 #include "EventFilter/GEMRawToDigi/interface/VFATdata.h"
 
 class GEMVfatStatusDigi {
+public:
+  GEMVfatStatusDigi(gem::VFATdata &vfat);
+  GEMVfatStatusDigi() {}
 
- public:
-  GEMVfatStatusDigi(gem::VFATdata &vfat); 
-  GEMVfatStatusDigi(){}
-  
-  uint8_t  quality() const { return quality_; }
-  uint8_t  flag() const { return flag_; }
-  int      phi() const { return phi_; }
+  uint8_t quality() const { return quality_; }
+  uint8_t flag() const { return flag_; }
+  int phi() const { return phi_; }
   uint16_t bc() const { return bc_; }
-  uint8_t  ec() const { return ec_; }
-  
- private:
+  uint8_t ec() const { return ec_; }
 
-  uint8_t  quality_;    /// quality flag - bit: 0 good, 1 crc fail, 2 b1010 fail, 3 b1100 fail, 4 b1110
-  uint8_t  flag_;       /// Control Flags: 4 bits, Hamming Error/AFULL/SEUlogic/SUEI2C
-  int      phi_;        /// vfat local phi postion in chamber
+private:
+  uint8_t quality_;  /// quality flag - bit: 0 good, 1 crc fail, 2 b1010 fail, 3 b1100 fail, 4 b1110
+  uint8_t flag_;     /// Control Flags: 4 bits, Hamming Error/AFULL/SEUlogic/SUEI2C
+  int phi_;          /// vfat local phi postion in chamber
   uint16_t bc_;
-  uint8_t  ec_;
-  
+  uint8_t ec_;
 };
 #endif

--- a/EventFilter/GEMRawToDigi/interface/VFATdata.h
+++ b/EventFilter/GEMRawToDigi/interface/VFATdata.h
@@ -9,44 +9,43 @@ namespace gem {
     uint64_t word;
     // v3 dataformat
     struct {
-      uint64_t msData1  : 16; ///<channels from 65to128
-      uint64_t bc       : 16; ///<Bunch Crossing number, 16 bits
-      uint64_t ec       : 8;  ///<Event Counter, 8 bits
-      uint64_t header   : 8;  ///<normally 0x1E. 0x5E indicates that the VFAT3 internal buffer is half-full, so it's like a warning
+      uint64_t msData1 : 16;  ///<channels from 65to128
+      uint64_t bc : 16;       ///<Bunch Crossing number, 16 bits
+      uint64_t ec : 8;        ///<Event Counter, 8 bits
+      uint64_t
+          header : 8;  ///<normally 0x1E. 0x5E indicates that the VFAT3 internal buffer is half-full, so it's like a warning
       uint64_t crcCheck : 8;  ///<bits 183:177 are not used, should be 0, bit 176 is 1 if CTP7 detected a CRC mismatch
-      uint64_t pos      : 8;  ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
+      uint64_t pos : 8;       ///<an 8bit value indicating the VFAT position on this GEB (it can be 0 to 23)
     };
     // v2 dataformat
     struct {
-      uint64_t msData1v2: 16; ///<channels from 65to128 - placeholder since msData1 reads same info
-      uint64_t chipID   : 12; ///<Chip ID, 12 bits
-      uint64_t b1110    : 4;  ///<1110:4 Control bits, shoud be 1110
-      uint64_t flag     : 4;  ///<Control Flags: 4 bits, Hamming Error/AFULL/SEUlogic/SUEI2C
-      uint64_t ecV2     : 8;  ///<Event Counter, 8 bits
-      uint64_t b1100    : 4;  ///<1100:4, Control bits, shoud be 1100
-      uint64_t bcV2     : 12; ///<Bunch Crossing number, 12 bits
-      uint64_t b1010    : 4;  ///<1010:4 Control bits, shoud be 1010
+      uint64_t msData1v2 : 16;  ///<channels from 65to128 - placeholder since msData1 reads same info
+      uint64_t chipID : 12;     ///<Chip ID, 12 bits
+      uint64_t b1110 : 4;       ///<1110:4 Control bits, shoud be 1110
+      uint64_t flag : 4;        ///<Control Flags: 4 bits, Hamming Error/AFULL/SEUlogic/SUEI2C
+      uint64_t ecV2 : 8;        ///<Event Counter, 8 bits
+      uint64_t b1100 : 4;       ///<1100:4, Control bits, shoud be 1100
+      uint64_t bcV2 : 12;       ///<Bunch Crossing number, 12 bits
+      uint64_t b1010 : 4;       ///<1010:4 Control bits, shoud be 1010
     };
   };
   union VFATsecond {
     uint64_t word;
     struct {
-      uint64_t lsData1  : 16; ///<channels from 1to64 
-      uint64_t msData2  : 48; ///<channels from 65to128
+      uint64_t lsData1 : 16;  ///<channels from 1to64
+      uint64_t msData2 : 48;  ///<channels from 65to128
     };
   };
   union VFATthird {
     uint64_t word;
     struct {
-      uint64_t crc      : 16; ///<Check Sum value, 16 bits
-      uint64_t lsData2  : 48; ///<channels from 1to64 
+      uint64_t crc : 16;      ///<Check Sum value, 16 bits
+      uint64_t lsData2 : 48;  ///<channels from 1to64
     };
   };
-      
-  class VFATdata
-  {
+
+  class VFATdata {
   public:
-    
     VFATdata();
     // this constructor only used for packing sim digis
     VFATdata(const int vfatVer,
@@ -58,73 +57,72 @@ namespace gem {
     ~VFATdata() {}
 
     //!Read first word from the block.
-    void read_fw(uint64_t word) { fw_ = word;}
-    uint64_t get_fw() const { return fw_;}
+    void read_fw(uint64_t word) { fw_ = word; }
+    uint64_t get_fw() const { return fw_; }
 
     //!Read second word from the block.
-    void read_sw(uint64_t word) { sw_ = word;}
-    uint64_t get_sw() const { return sw_;}
+    void read_sw(uint64_t word) { sw_ = word; }
+    uint64_t get_sw() const { return sw_; }
 
     //!Read third word from the block.
-    void read_tw(uint64_t word) { tw_ = word;}
-    uint64_t get_tw() const { return tw_;}
+    void read_tw(uint64_t word) { tw_ = word; }
+    uint64_t get_tw() const { return tw_; }
 
     // local phi in chamber
-    void setPhi(int i) {phiPos_ = i;}
-    int phi() const {return phiPos_;}
-    
-    uint64_t lsData() const {
-      return uint64_t(VFATsecond{sw_}.lsData1) << 48 | VFATthird{tw_}.lsData2;
-    }
-    uint64_t msData() const {
-      return uint64_t(VFATfirst{fw_}.msData1) << 48 | VFATsecond{sw_}.msData2;
-    }
-    
+    void setPhi(int i) { phiPos_ = i; }
+    int phi() const { return phiPos_; }
+
+    uint64_t lsData() const { return uint64_t(VFATsecond{sw_}.lsData1) << 48 | VFATthird{tw_}.lsData2; }
+    uint64_t msData() const { return uint64_t(VFATfirst{fw_}.msData1) << 48 | VFATsecond{sw_}.msData2; }
+
     uint16_t bc() const {
-      if (ver_==2) return VFATfirst{fw_}.bcV2;
+      if (ver_ == 2)
+        return VFATfirst{fw_}.bcV2;
       return VFATfirst{fw_}.bc;
     }
-    uint8_t  ec() const {
-      if (ver_==2) return VFATfirst{fw_}.ecV2;
+    uint8_t ec() const {
+      if (ver_ == 2)
+        return VFATfirst{fw_}.ecV2;
       return VFATfirst{fw_}.ec;
     }
     uint16_t vfatId() const {
-      if (ver_==2) return VFATfirst{fw_}.chipID;
+      if (ver_ == 2)
+        return VFATfirst{fw_}.chipID;
       return VFATfirst{fw_}.pos;
     }
 
-    void setVersion(int i) {ver_ = i;}
-    int version() const {return ver_;}
+    void setVersion(int i) { ver_ = i; }
+    int version() const { return ver_; }
 
-    /// quality flag - bit: 0 good, 1 crc fail, 2 b1010 fail, 3 b1100 fail, 4 b1110 
+    /// quality flag - bit: 0 good, 1 crc fail, 2 b1010 fail, 3 b1100 fail, 4 b1110
     uint8_t quality();
 
     /// v3
-    uint8_t   header     () const {return VFATfirst{fw_}.header;      }
-    uint8_t   crcCheck   () const {return VFATfirst{fw_}.crcCheck;    }
-    uint8_t   position   () const {return VFATfirst{fw_}.pos;         }
+    uint8_t header() const { return VFATfirst{fw_}.header; }
+    uint8_t crcCheck() const { return VFATfirst{fw_}.crcCheck; }
+    uint8_t position() const { return VFATfirst{fw_}.pos; }
 
     /// v2
-    uint8_t   b1010      () const { return VFATfirst{fw_}.b1010;      }
-    uint8_t   b1100      () const { return VFATfirst{fw_}.b1100;      }
-    uint8_t   b1110      () const { return VFATfirst{fw_}.b1110;      }
-    uint8_t   flag       () const { return VFATfirst{fw_}.flag;       }
-    uint16_t  chipID     () const { return VFATfirst{fw_}.chipID;     }
-    uint16_t  crc        () const { return VFATthird{tw_}.crc;        }
-    
-    uint16_t crc_cal(uint16_t crc_in, uint16_t dato);    
+    uint8_t b1010() const { return VFATfirst{fw_}.b1010; }
+    uint8_t b1100() const { return VFATfirst{fw_}.b1100; }
+    uint8_t b1110() const { return VFATfirst{fw_}.b1110; }
+    uint8_t flag() const { return VFATfirst{fw_}.flag; }
+    uint16_t chipID() const { return VFATfirst{fw_}.chipID; }
+    uint16_t crc() const { return VFATthird{tw_}.crc; }
+
+    uint16_t crc_cal(uint16_t crc_in, uint16_t dato);
     uint16_t checkCRC();
-    
+
     static const int nChannels = 128;
     static const int sizeChipID = 12;
-    
-  private:    
-    int      ver_;        /// vfat version
-    int      phiPos_;     /// phi position of vfat in chamber
-    
-    uint64_t fw_; // VFAT first word
-    uint64_t sw_; // VFAT second word
-    uint64_t tw_; // VFAT third word
+
+  private:
+    int ver_;     /// vfat version
+    int phiPos_;  /// phi position of vfat in chamber
+
+    uint64_t fw_;  // VFAT first word
+    uint64_t sw_;  // VFAT second word
+    uint64_t tw_;  // VFAT third word
   };
-}
+}  // namespace gem
 #endif

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -20,139 +20,131 @@
 
 using namespace gem;
 
-GEMDigiToRawModule::GEMDigiToRawModule(const edm::ParameterSet & pset):
-  event_type_(pset.getParameter<int>("eventType")),
-  digi_token(consumes<GEMDigiCollection>( pset.getParameter<edm::InputTag>("gemDigi") )),
-  useDBEMap_(pset.getParameter<bool>("useDBEMap"))
-{
+GEMDigiToRawModule::GEMDigiToRawModule(const edm::ParameterSet& pset)
+    : event_type_(pset.getParameter<int>("eventType")),
+      digi_token(consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("gemDigi"))),
+      useDBEMap_(pset.getParameter<bool>("useDBEMap")) {
   produces<FEDRawDataCollection>();
 }
 
-void GEMDigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDigiToRawModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("gemDigi", edm::InputTag("simMuonGEMDigis"));
   desc.add<int>("eventType", 0);
   desc.add<bool>("useDBEMap", false);
-  descriptions.add("gemPackerDefault", desc);  
+  descriptions.add("gemPackerDefault", desc);
 }
 
-std::shared_ptr<GEMROMapping> GEMDigiToRawModule::globalBeginRun(edm::Run const&, edm::EventSetup const& iSetup) const
-{
+std::shared_ptr<GEMROMapping> GEMDigiToRawModule::globalBeginRun(edm::Run const&, edm::EventSetup const& iSetup) const {
   auto gemROmap = std::make_shared<GEMROMapping>();
   if (useDBEMap_) {
     edm::ESHandle<GEMeMap> gemEMapRcd;
     iSetup.get<GEMeMapRcd>().get(gemEMapRcd);
     auto gemEMap = std::make_unique<GEMeMap>(*(gemEMapRcd.product()));
     gemEMap->convert(*gemROmap);
-    gemEMap.reset();    
-  }
-  else {
+    gemEMap.reset();
+  } else {
     // no EMap in DB, using dummy
     auto gemEMap = std::make_unique<GEMeMap>();
     gemEMap->convertDummy(*gemROmap);
-    gemEMap.reset();    
+    gemEMap.reset();
   }
   return gemROmap;
 }
 
-void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event & iEvent, edm::EventSetup const&) const
-{
+void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
   auto fedRawDataCol = std::make_unique<FEDRawDataCollection>();
 
   edm::Handle<GEMDigiCollection> gemDigis;
-  iEvent.getByToken( digi_token, gemDigis );
+  iEvent.getByToken(digi_token, gemDigis);
   if (!gemDigis.isValid()) {
     iEvent.put(std::move(fedRawDataCol));
     return;
   }
-  
+
   auto gemROMap = runCache(iEvent.getRun().index());
-  
+
   std::vector<std::unique_ptr<AMC13Event>> amc13Events;
-  amc13Events.reserve(FEDNumbering::MAXGEMFEDID-FEDNumbering::MINGEMFEDID+1);
+  amc13Events.reserve(FEDNumbering::MAXGEMFEDID - FEDNumbering::MINGEMFEDID + 1);
 
-  for (unsigned int fedId=FEDNumbering::MINGEMFEDID; fedId<=FEDNumbering::MAXGEMFEDID; ++fedId) { 
-  std::unique_ptr<AMC13Event> amc13Event = std::make_unique<AMC13Event>();
+  for (unsigned int fedId = FEDNumbering::MINGEMFEDID; fedId <= FEDNumbering::MAXGEMFEDID; ++fedId) {
+    std::unique_ptr<AMC13Event> amc13Event = std::make_unique<AMC13Event>();
 
-    for (uint8_t amcNum=0; amcNum < GEMeMap::maxAMCs_; ++amcNum) { 
+    for (uint8_t amcNum = 0; amcNum < GEMeMap::maxAMCs_; ++amcNum) {
       std::unique_ptr<AMCdata> amcData = std::make_unique<AMCdata>();
 
-      for (uint8_t gebId=0; gebId < GEMeMap::maxGEBs_; ++gebId) { 
+      for (uint8_t gebId = 0; gebId < GEMeMap::maxGEBs_; ++gebId) {
         std::unique_ptr<GEBdata> gebData = std::make_unique<GEBdata>();
         GEMROMapping::chamEC geb_ec{fedId, amcNum, gebId};
-        
-        if (!gemROMap->isValidChamber(geb_ec)) continue;
+
+        if (!gemROMap->isValidChamber(geb_ec))
+          continue;
         GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
 
         auto vfats = gemROMap->getVfats(geb_dc.detId);
         for (auto vfat_ec : vfats) {
-
           GEMROMapping::vfatDC vfat_dc = gemROMap->vfatPos(vfat_ec);
-          GEMDetId  gemId = vfat_dc.detId;
+          GEMDetId gemId = vfat_dc.detId;
           uint16_t vfatId = vfat_ec.vfatAdd;
 
-          for (uint16_t bc = 0; bc < 2*GEMeMap::amcBX_; ++bc) {
+          for (uint16_t bc = 0; bc < 2 * GEMeMap::amcBX_; ++bc) {
             bool hasDigi = false;
 
-            uint64_t lsData  = 0; ///<channels from 1to64 
-            uint64_t msData  = 0; ///<channels from 65to128
-	
-            GEMDigiCollection::Range range = gemDigis->get(gemId);
-            for (GEMDigiCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt) {
+            uint64_t lsData = 0;  ///<channels from 1to64
+            uint64_t msData = 0;  ///<channels from 65to128
 
-              const GEMDigi & digi = (*digiIt);
-              if (digi.bx() != bc-GEMeMap::amcBX_) continue;
-	  
-              int localStrip = digi.strip() - vfat_dc.localPhi*GEMeMap::maxChan_;	  
+            GEMDigiCollection::Range range = gemDigis->get(gemId);
+            for (GEMDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+              const GEMDigi& digi = (*digiIt);
+              if (digi.bx() != bc - GEMeMap::amcBX_)
+                continue;
+
+              int localStrip = digi.strip() - vfat_dc.localPhi * GEMeMap::maxChan_;
 
               // skip strips not in current vFat
-              if (localStrip < 0 || localStrip > GEMeMap::maxChan_ -1) continue;
+              if (localStrip < 0 || localStrip > GEMeMap::maxChan_ - 1)
+                continue;
 
               hasDigi = true;
               GEMROMapping::stripNum stMap = {vfat_dc.vfatType, localStrip};
               GEMROMapping::channelNum chMap = gemROMap->hitPos(stMap);
-	  
-              if (chMap.chNum < 64) lsData |= 1UL << chMap.chNum;
-              else msData |= 1UL << (chMap.chNum-64);
+
+              if (chMap.chNum < 64)
+                lsData |= 1UL << chMap.chNum;
+              else
+                msData |= 1UL << (chMap.chNum - 64);
 
               LogDebug("GEMDigiToRawModule")
-                << " fed: " << fedId
-                << " amc:" << int(amcNum)
-                << " geb:" << int(gebId)
-                << " vfat:"<< vfat_dc.localPhi
-                << ",type: "<< vfat_dc.vfatType
-                << " id:"<< gemId
-                << " ch:"<< chMap.chNum
-                << " st:"<< digi.strip()
-                << " bx:"<< digi.bx();
-
+                  << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId)
+                  << " vfat:" << vfat_dc.localPhi << ",type: " << vfat_dc.vfatType << " id:" << gemId
+                  << " ch:" << chMap.chNum << " st:" << digi.strip() << " bx:" << digi.bx();
             }
-      
-            if (!hasDigi) continue;
+
+            if (!hasDigi)
+              continue;
             // only make vfat with hits
             auto vfatData = std::make_unique<VFATdata>(geb_dc.vfatVer, bc, 0, vfatId, lsData, msData);
             gebData->addVFAT(*vfatData);
           }
 
-        } // end of vfats in GEB
-        
+        }  // end of vfats in GEB
+
         if (!gebData->vFATs()->empty()) {
-          gebData->setChamberHeader(gebData->vFATs()->size()*3, gebId);
-          gebData->setChamberTrailer(0, 0, gebData->vFATs()->size()*3);
+          gebData->setChamberHeader(gebData->vFATs()->size() * 3, gebId);
+          gebData->setChamberTrailer(0, 0, gebData->vFATs()->size() * 3);
           amcData->addGEB(*gebData);
         }
-        
-      } // end of GEB loop
+
+      }  // end of GEB loop
 
       if (!amcData->gebs()->empty()) {
         amcData->setAMCheader1(0, GEMeMap::amcBX_, 0, amcNum);
         amcData->setAMCheader2(amcNum, 0, 1);
-        amcData->setGEMeventHeader(amcData->gebs()->size(), 0);        
+        amcData->setGEMeventHeader(amcData->gebs()->size(), 0);
         amc13Event->addAMCpayload(*amcData);
-      }      
-      
-    } // end of AMC loop
+      }
+
+    }  // end of AMC loop
 
     if (!amc13Event->getAMCpayloads()->empty()) {
       // CDFHeader
@@ -173,7 +165,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event & iEvent, edm::Ev
         uint16_t BoardID = 0;
         amc13Event->addAMCheader(AMC_size, Blk_No, AMC_No, BoardID);
       }
-    
+
       //AMC13 trailer
       uint8_t Blk_NoT = 0;
       uint8_t LV1_idT = 0;
@@ -181,54 +173,55 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event & iEvent, edm::Ev
       amc13Event->setAMC13Trailer(Blk_NoT, LV1_idT, BX_idT);
       //CDF trailer
       uint32_t EvtLength = 0;
-      amc13Event->setCDFTrailer(EvtLength);  
+      amc13Event->setCDFTrailer(EvtLength);
       amc13Events.emplace_back(std::move(amc13Event));
-    }// finished making amc13Event data    
-    
-  } // end of FED loop
-  
+    }  // finished making amc13Event data
+
+  }  // end of FED loop
+
   // read out amc13Events into fedRawData
-  for (const auto & amc13e : amc13Events) {
-    std::vector<uint64_t> words;    
+  for (const auto& amc13e : amc13Events) {
+    std::vector<uint64_t> words;
     words.emplace_back(amc13e->getCDFHeader());
-    words.emplace_back(amc13e->getAMC13Header());    
-    
-    for (const auto & w: *amc13e->getAMCheaders())
+    words.emplace_back(amc13e->getAMC13Header());
+
+    for (const auto& w : *amc13e->getAMCheaders())
       words.emplace_back(w);
 
-    for (const auto & amc : *amc13e->getAMCpayloads()) {
+    for (const auto& amc : *amc13e->getAMCpayloads()) {
       words.emplace_back(amc.getAMCheader1());
       words.emplace_back(amc.getAMCheader2());
       words.emplace_back(amc.getGEMeventHeader());
-      
-      for (const auto & geb: *amc.gebs()) {
+
+      for (const auto& geb : *amc.gebs()) {
         words.emplace_back(geb.getChamberHeader());
 
-        for (const auto & vfat: *geb.vFATs()) {
+        for (const auto& vfat : *geb.vFATs()) {
           words.emplace_back(vfat.get_fw());
           words.emplace_back(vfat.get_sw());
           words.emplace_back(vfat.get_tw());
         }
-	
+
         words.emplace_back(geb.getChamberTrailer());
       }
-      
+
       words.emplace_back(amc.getGEMeventTrailer());
       words.emplace_back(amc.getAMCTrailer());
     }
-    
+
     words.emplace_back(amc13e->getAMC13Trailer());
     words.emplace_back(amc13e->getCDFTrailer());
 
-    FEDRawData & fedRawData = fedRawDataCol->FEDData(amc13e->sourceId());
-    
+    FEDRawData& fedRawData = fedRawDataCol->FEDData(amc13e->sourceId());
+
     int dataSize = (words.size()) * sizeof(uint64_t);
     fedRawData.resize(dataSize);
-    
-    uint64_t * w = reinterpret_cast<uint64_t* >(fedRawData.data());  
-    for (const auto & word: words) *(w++) = word;
-    
-    LogDebug("GEMDigiToRawModule") <<" words " << words.size();
+
+    uint64_t* w = reinterpret_cast<uint64_t*>(fedRawData.data());
+    for (const auto& word : words)
+      *(w++) = word;
+
+    LogDebug("GEMDigiToRawModule") << " words " << words.size();
   }
 
   iEvent.put(std::move(fedRawDataCol));

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.h
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.h
@@ -25,25 +25,22 @@ namespace edm {
 }
 
 class GEMDigiToRawModule : public edm::global::EDProducer<edm::RunCache<GEMROMapping> > {
- public:
+public:
   /// Constructor
-  GEMDigiToRawModule(const edm::ParameterSet & pset);
+  GEMDigiToRawModule(const edm::ParameterSet& pset);
 
   // global::EDProducer
-  std::shared_ptr<GEMROMapping> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;  
+  std::shared_ptr<GEMROMapping> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
-  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {};
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override{};
 
   // Fill parameters descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
-
+private:
   int event_type_;
   edm::EDGetTokenT<GEMDigiCollection> digi_token;
   bool useDBEMap_;
 };
 DEFINE_FWK_MODULE(GEMDigiToRawModule);
 #endif
-
-

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -16,50 +16,45 @@
 
 using namespace gem;
 
-GEMRawToDigiModule::GEMRawToDigiModule(const edm::ParameterSet & pset) :
-  fed_token(consumes<FEDRawDataCollection>( pset.getParameter<edm::InputTag>("InputLabel") )),
-  useDBEMap_(pset.getParameter<bool>("useDBEMap")),
-  unPackStatusDigis_(pset.getParameter<bool>("unPackStatusDigis"))
-{
-  produces<GEMDigiCollection>(); 
+GEMRawToDigiModule::GEMRawToDigiModule(const edm::ParameterSet& pset)
+    : fed_token(consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("InputLabel"))),
+      useDBEMap_(pset.getParameter<bool>("useDBEMap")),
+      unPackStatusDigis_(pset.getParameter<bool>("unPackStatusDigis")) {
+  produces<GEMDigiCollection>();
   if (unPackStatusDigis_) {
     produces<GEMVfatStatusDigiCollection>("vfatStatus");
     produces<GEMGEBdataCollection>("gebStatus");
-    produces<GEMAMCdataCollection>("AMCdata"); 
-    produces<GEMAMC13EventCollection>("AMC13Event"); 
+    produces<GEMAMCdataCollection>("AMCdata");
+    produces<GEMAMC13EventCollection>("AMC13Event");
   }
 }
 
-void GEMRawToDigiModule::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMRawToDigiModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector")); 
+  desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
   desc.add<bool>("useDBEMap", false);
   desc.add<bool>("unPackStatusDigis", false);
-  descriptions.add("muonGEMDigisDefault", desc);  
+  descriptions.add("muonGEMDigisDefault", desc);
 }
 
-std::shared_ptr<GEMROMapping> GEMRawToDigiModule::globalBeginRun(edm::Run const&, edm::EventSetup const& iSetup) const
-{
+std::shared_ptr<GEMROMapping> GEMRawToDigiModule::globalBeginRun(edm::Run const&, edm::EventSetup const& iSetup) const {
   auto gemROmap = std::make_shared<GEMROMapping>();
   if (useDBEMap_) {
     edm::ESHandle<GEMeMap> gemEMapRcd;
     iSetup.get<GEMeMapRcd>().get(gemEMapRcd);
     auto gemEMap = std::make_unique<GEMeMap>(*(gemEMapRcd.product()));
     gemEMap->convert(*gemROmap);
-    gemEMap.reset();    
-  }
-  else {
+    gemEMap.reset();
+  } else {
     // no EMap in DB, using dummy
     auto gemEMap = std::make_unique<GEMeMap>();
     gemEMap->convertDummy(*gemROmap);
-    gemEMap.reset();    
+    gemEMap.reset();
   }
   return gemROmap;
 }
 
-void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event & iEvent, edm::EventSetup const&) const
-{
+void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
   auto outGEMDigis = std::make_unique<GEMDigiCollection>();
   auto outVFATStatus = std::make_unique<GEMVfatStatusDigiCollection>();
   auto outGEBStatus = std::make_unique<GEMGEBdataCollection>();
@@ -68,34 +63,35 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event & iEvent, edm::Ev
 
   // Take raw from the event
   edm::Handle<FEDRawDataCollection> fed_buffers;
-  iEvent.getByToken( fed_token, fed_buffers );
-  
+  iEvent.getByToken(fed_token, fed_buffers);
+
   auto gemROMap = runCache(iEvent.getRun().index());
-  
-  for (unsigned int fedId=FEDNumbering::MINGEMFEDID; fedId<=FEDNumbering::MAXGEMFEDID; ++fedId) { 
+
+  for (unsigned int fedId = FEDNumbering::MINGEMFEDID; fedId <= FEDNumbering::MAXGEMFEDID; ++fedId) {
     const FEDRawData& fedData = fed_buffers->FEDData(fedId);
-    
-    int nWords = fedData.size()/sizeof(uint64_t);
-    LogDebug("GEMRawToDigiModule") <<" words " << nWords;
-    
-    if (nWords<5) continue;
-    const unsigned char * data = fedData.data();
-    
+
+    int nWords = fedData.size() / sizeof(uint64_t);
+    LogDebug("GEMRawToDigiModule") << " words " << nWords;
+
+    if (nWords < 5)
+      continue;
+    const unsigned char* data = fedData.data();
+
     auto amc13Event = std::make_unique<AMC13Event>();
-    
-    const uint64_t* word = reinterpret_cast<const uint64_t* >(data);
-    
+
+    const uint64_t* word = reinterpret_cast<const uint64_t*>(data);
+
     amc13Event->setCDFHeader(*word);
     amc13Event->setAMC13Header(*(++word));
-    
+
     // Readout out AMC headers
     for (uint8_t i = 0; i < amc13Event->nAMC(); ++i)
       amc13Event->addAMCheader(*(++word));
-    
+
     // Readout out AMC payloads
     for (uint8_t i = 0; i < amc13Event->nAMC(); ++i) {
       auto amcData = std::make_unique<AMCdata>();
-      amcData->setAMCheader1(*(++word));      
+      amcData->setAMCheader1(*(++word));
       amcData->setAMCheader2(*(++word));
       amcData->setGEMeventHeader(*(++word));
       uint16_t amcBx = amcData->bx();
@@ -103,121 +99,115 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event & iEvent, edm::Ev
 
       // Fill GEB
       for (uint8_t j = 0; j < amcData->davCnt(); ++j) {
-	auto gebData = std::make_unique<GEBdata>();
-	gebData->setChamberHeader(*(++word));
-	
-	uint8_t gebId = gebData->inputID();
-	GEMROMapping::chamEC geb_ec = {fedId, amcNum, gebId};        
-	GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
-	GEMDetId gemChId = geb_dc.detId;
+        auto gebData = std::make_unique<GEBdata>();
+        gebData->setChamberHeader(*(++word));
 
-	for (uint16_t k = 0; k < gebData->vfatWordCnt()/3; k++) {
-	  auto vfatData = std::make_unique<VFATdata>();
-	  vfatData->read_fw(*(++word));
-	  vfatData->read_sw(*(++word));
-	  vfatData->read_tw(*(++word));
-	  
+        uint8_t gebId = gebData->inputID();
+        GEMROMapping::chamEC geb_ec = {fedId, amcNum, gebId};
+        GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
+        GEMDetId gemChId = geb_dc.detId;
+
+        for (uint16_t k = 0; k < gebData->vfatWordCnt() / 3; k++) {
+          auto vfatData = std::make_unique<VFATdata>();
+          vfatData->read_fw(*(++word));
+          vfatData->read_sw(*(++word));
+          vfatData->read_tw(*(++word));
+
           vfatData->setVersion(geb_dc.vfatVer);
           uint16_t vfatId = vfatData->vfatId();
           GEMROMapping::vfatEC vfat_ec = {vfatId, gemChId};
-          
-	  // check if ChipID exists.
-	  if (!gemROMap->isValidChipID(vfat_ec)) {
-	    edm::LogWarning("GEMRawToDigiModule") << "InValid: amcNum "<< int(amcNum)
-						  << " gebId "<< int(gebId)
-						  << " vfatId "<< int(vfatId)
-						  << " vfat Pos "<< int(vfatData->position());
-	    continue;
-	  }
+
+          // check if ChipID exists.
+          if (!gemROMap->isValidChipID(vfat_ec)) {
+            edm::LogWarning("GEMRawToDigiModule")
+                << "InValid: amcNum " << int(amcNum) << " gebId " << int(gebId) << " vfatId " << int(vfatId)
+                << " vfat Pos " << int(vfatData->position());
+            continue;
+          }
           // check vfat data
-	  if (vfatData->quality()) {
-	    edm::LogWarning("GEMRawToDigiModule") << "Quality "<< int(vfatData->quality())
-						  << " b1010 "<< int(vfatData->b1010())
-						  << " b1100 "<< int(vfatData->b1100())
-						  << " b1110 "<< int(vfatData->b1110());
-	    if (vfatData->crc() != vfatData->checkCRC() ) {
-	      edm::LogWarning("GEMRawToDigiModule") << "DIFFERENT CRC :"
-						    <<vfatData->crc()<<"   "<<vfatData->checkCRC();	      
-	    }
-	  }
-	            
+          if (vfatData->quality()) {
+            edm::LogWarning("GEMRawToDigiModule")
+                << "Quality " << int(vfatData->quality()) << " b1010 " << int(vfatData->b1010()) << " b1100 "
+                << int(vfatData->b1100()) << " b1110 " << int(vfatData->b1110());
+            if (vfatData->crc() != vfatData->checkCRC()) {
+              edm::LogWarning("GEMRawToDigiModule")
+                  << "DIFFERENT CRC :" << vfatData->crc() << "   " << vfatData->checkCRC();
+            }
+          }
+
           GEMROMapping::vfatDC vfat_dc = gemROMap->vfatPos(vfat_ec);
 
-	  vfatData->setPhi(vfat_dc.localPhi);
+          vfatData->setPhi(vfat_dc.localPhi);
           GEMDetId gemId = vfat_dc.detId;
-	  uint16_t bc=vfatData->bc();
-	  // strip bx = vfat bx - amc bx
-	  int bx = bc-amcBx;
-          
-	  for (int chan = 0; chan < VFATdata::nChannels; ++chan) {
-	    uint8_t chan0xf = 0;
-	    if (chan < 64) chan0xf = ((vfatData->lsData() >> chan) & 0x1);
-	    else chan0xf = ((vfatData->msData() >> (chan-64)) & 0x1);
+          uint16_t bc = vfatData->bc();
+          // strip bx = vfat bx - amc bx
+          int bx = bc - amcBx;
 
-	    // no hits
-	    if (chan0xf==0) continue;
-	    	             
+          for (int chan = 0; chan < VFATdata::nChannels; ++chan) {
+            uint8_t chan0xf = 0;
+            if (chan < 64)
+              chan0xf = ((vfatData->lsData() >> chan) & 0x1);
+            else
+              chan0xf = ((vfatData->msData() >> (chan - 64)) & 0x1);
+
+            // no hits
+            if (chan0xf == 0)
+              continue;
+
             GEMROMapping::channelNum chMap = {vfat_dc.vfatType, chan};
             GEMROMapping::stripNum stMap = gemROMap->hitPos(chMap);
 
-            int stripId = stMap.stNum + vfatData->phi()*GEMeMap::maxChan_;    
-            
-	    GEMDigi digi(stripId,bx);
+            int stripId = stMap.stNum + vfatData->phi() * GEMeMap::maxChan_;
+
+            GEMDigi digi(stripId, bx);
 
             LogDebug("GEMRawToDigiModule")
-              << " fed: " << fedId
-              << " amc:" << int(amcNum)
-              << " geb:" << int(gebId)
-              << " vfat:"<< vfat_dc.localPhi
-              << ",type: "<< vfat_dc.vfatType
-              << " id:"<< gemId
-              << " ch:"<< chMap.chNum
-              << " st:"<< digi.strip()
-              << " bx:"<< digi.bx();
-            
-	    outGEMDigis.get()->insertDigi(gemId,digi);
-	    
-	  }// end of channel loop
-	  
-	  if (unPackStatusDigis_) {
-            outVFATStatus.get()->insertDigi(gemId, GEMVfatStatusDigi(*vfatData));
-	  }
+                << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId) << " vfat:" << vfat_dc.localPhi
+                << ",type: " << vfat_dc.vfatType << " id:" << gemId << " ch:" << chMap.chNum << " st:" << digi.strip()
+                << " bx:" << digi.bx();
 
-	} // end of vfat loop
-	
-	gebData->setChamberTrailer(*(++word));
-	
+            outGEMDigis.get()->insertDigi(gemId, digi);
+
+          }  // end of channel loop
+
+          if (unPackStatusDigis_) {
+            outVFATStatus.get()->insertDigi(gemId, GEMVfatStatusDigi(*vfatData));
+          }
+
+        }  // end of vfat loop
+
+        gebData->setChamberTrailer(*(++word));
+
         if (unPackStatusDigis_) {
-	  outGEBStatus.get()->insertDigi(gemChId.chamberId(), (*gebData)); 
+          outGEBStatus.get()->insertDigi(gemChId.chamberId(), (*gebData));
         }
-	
-      } // end of geb loop
-      
+
+      }  // end of geb loop
+
       amcData->setGEMeventTrailer(*(++word));
       amcData->setAMCTrailer(*(++word));
-      
+
       if (unPackStatusDigis_) {
         outAMCdata.get()->insertDigi(amcData->boardId(), (*amcData));
       }
 
-    } // end of amc loop
-    
+    }  // end of amc loop
+
     amc13Event->setAMC13Trailer(*(++word));
     amc13Event->setCDFTrailer(*(++word));
-     
+
     if (unPackStatusDigis_) {
       outAMC13Event.get()->insertDigi(amc13Event->bxId(), AMC13Event(*amc13Event));
     }
-    
-  } // end of amc13Event
-  
+
+  }  // end of amc13Event
+
   iEvent.put(std::move(outGEMDigis));
-  
+
   if (unPackStatusDigis_) {
     iEvent.put(std::move(outVFATStatus), "vfatStatus");
     iEvent.put(std::move(outGEBStatus), "gebStatus");
     iEvent.put(std::move(outAMCdata), "AMCdata");
     iEvent.put(std::move(outAMC13Event), "AMC13Event");
   }
-  
 }

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.h
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.h
@@ -27,28 +27,26 @@
 #include "EventFilter/GEMRawToDigi/interface/VFATdata.h"
 
 namespace edm {
-   class ConfigurationDescriptions;
+  class ConfigurationDescriptions;
 }
 
 class GEMRawToDigiModule : public edm::global::EDProducer<edm::RunCache<GEMROMapping> > {
- public:
+public:
   /// Constructor
-  GEMRawToDigiModule(const edm::ParameterSet & pset);
+  GEMRawToDigiModule(const edm::ParameterSet& pset);
 
   // global::EDProducer
-  std::shared_ptr<GEMROMapping> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;  
+  std::shared_ptr<GEMROMapping> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
-  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {};
-  
-  // Fill parameters descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const override{};
 
- private:
-  
+  // Fill parameters descriptions
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
   edm::EDGetTokenT<FEDRawDataCollection> fed_token;
   bool useDBEMap_;
   bool unPackStatusDigis_;
-
 };
 DEFINE_FWK_MODULE(GEMRawToDigiModule);
 #endif

--- a/EventFilter/GEMRawToDigi/src/AMC13Event.cc
+++ b/EventFilter/GEMRawToDigi/src/AMC13Event.cc
@@ -3,9 +3,8 @@
 
 using namespace gem;
 
-void AMC13Event::setCDFHeader(uint8_t Evt_ty, uint32_t LV1_id, uint16_t BX_id, uint16_t Source_id)
-{
-  CDFHeader u;  
+void AMC13Event::setCDFHeader(uint8_t Evt_ty, uint32_t LV1_id, uint16_t BX_id, uint16_t Source_id) {
+  CDFHeader u;
   u.cb5 = 0x5;
   u.eventType = Evt_ty;
   u.lv1Id = LV1_id;
@@ -14,8 +13,7 @@ void AMC13Event::setCDFHeader(uint8_t Evt_ty, uint32_t LV1_id, uint16_t BX_id, u
   cdfh_ = u.word;
 }
 
-void AMC13Event::setAMC13Header(uint8_t CalTyp, uint8_t nAMC, uint32_t OrN)
-{
+void AMC13Event::setAMC13Header(uint8_t CalTyp, uint8_t nAMC, uint32_t OrN) {
   AMC13Header u;
   u.cb0 = 0x0;
   u.calType = CalTyp;
@@ -24,8 +22,7 @@ void AMC13Event::setAMC13Header(uint8_t CalTyp, uint8_t nAMC, uint32_t OrN)
   amc13h_ = u.word;
 }
 
-void AMC13Event::setAMC13Trailer(uint8_t Blk_NoT, uint8_t LV1_idT, uint16_t BX_idT)
-{
+void AMC13Event::setAMC13Trailer(uint8_t Blk_NoT, uint8_t LV1_idT, uint16_t BX_idT) {
   AMC13Trailer u;
   u.blkN = Blk_NoT;
   u.lv1IdT = LV1_idT;
@@ -33,28 +30,20 @@ void AMC13Event::setAMC13Trailer(uint8_t Blk_NoT, uint8_t LV1_idT, uint16_t BX_i
   amc13t_ = u.word;
 }
 
-void AMC13Event::setCDFTrailer(uint32_t EvtLength)
-{
+void AMC13Event::setCDFTrailer(uint32_t EvtLength) {
   CDFTrailer u;
   u.cbA = 0xA;
   u.evtLength = EvtLength;
   cdft_ = u.word;
 }
 
-void AMC13Event::addAMCheader(uint64_t word)
-{
-  amcHeaders_.push_back(word);
-}
+void AMC13Event::addAMCheader(uint64_t word) { amcHeaders_.push_back(word); }
 
-void AMC13Event::addAMCheader(uint32_t AMC_size, uint8_t Blk_No, uint8_t AMC_No, uint16_t BoardID)
-{
-  // AMC Header word 
+void AMC13Event::addAMCheader(uint32_t AMC_size, uint8_t Blk_No, uint8_t AMC_No, uint16_t BoardID) {
+  // AMC Header word
   // 55 - 32  | 27 - 20 | 19 - 16 | 15 - 0  |
-  // AMC_size | Blk_No  | AMC_No  | BoardID |  
-  uint64_t word =
-    (static_cast<uint64_t>(AMC_size & 0x00ffffff) << 32) |
-    (static_cast<uint64_t>(Blk_No & 0xff) << 20) |
-    (static_cast<uint64_t>(AMC_No & 0x0f) << 16) |
-    (static_cast<uint64_t>(BoardID & 0xffff));
+  // AMC_size | Blk_No  | AMC_No  | BoardID |
+  uint64_t word = (static_cast<uint64_t>(AMC_size & 0x00ffffff) << 32) | (static_cast<uint64_t>(Blk_No & 0xff) << 20) |
+                  (static_cast<uint64_t>(AMC_No & 0x0f) << 16) | (static_cast<uint64_t>(BoardID & 0xffff));
   amcHeaders_.push_back(word);
 }

--- a/EventFilter/GEMRawToDigi/src/AMCdata.cc
+++ b/EventFilter/GEMRawToDigi/src/AMCdata.cc
@@ -3,9 +3,8 @@
 
 using namespace gem;
 
-void AMCdata::setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, uint8_t AMCnum)
-{
-  AMCheader1 u;  
+void AMCdata::setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, uint8_t AMCnum) {
+  AMCheader1 u;
   u.dataLength = dataLength;
   u.bxID = bxID;
   u.l1AID = l1AID;
@@ -13,18 +12,16 @@ void AMCdata::setAMCheader1(uint32_t dataLength, uint16_t bxID, uint32_t l1AID, 
   amch1_ = u.word;
 }
 
-void AMCdata::setAMCheader2(uint16_t boardID, uint16_t orbitNum, uint8_t runType)
-{
-  AMCheader2 u;  
+void AMCdata::setAMCheader2(uint16_t boardID, uint16_t orbitNum, uint8_t runType) {
+  AMCheader2 u;
   u.boardID = boardID;
   u.orbitNum = orbitNum;
   u.runType = runType;
   amch2_ = u.word;
 }
 
-void AMCdata::setGEMeventHeader(uint8_t davCnt, uint32_t davList)
-{
-  EventHeader u;  
+void AMCdata::setGEMeventHeader(uint8_t davCnt, uint32_t davList) {
+  EventHeader u;
   u.davCnt = davCnt;
   u.davList = davList;
   eh_ = u.word;

--- a/EventFilter/GEMRawToDigi/src/GEMVfatStatusDigi.cc
+++ b/EventFilter/GEMRawToDigi/src/GEMVfatStatusDigi.cc
@@ -1,11 +1,10 @@
 #include "EventFilter/GEMRawToDigi/interface/GEMVfatStatusDigi.h"
 #include <iostream>
 
-GEMVfatStatusDigi::GEMVfatStatusDigi(gem::VFATdata &vfat)
-{
+GEMVfatStatusDigi::GEMVfatStatusDigi(gem::VFATdata &vfat) {
   quality_ = vfat.quality();
-  flag_    = vfat.flag();
-  phi_     = vfat.phi();
-  ec_      = vfat.ec();
-  bc_      = vfat.bc();
+  flag_ = vfat.flag();
+  phi_ = vfat.phi();
+  ec_ = vfat.ec();
+  bc_ = vfat.bc();
 };

--- a/EventFilter/GEMRawToDigi/src/VFATdata.cc
+++ b/EventFilter/GEMRawToDigi/src/VFATdata.cc
@@ -2,17 +2,14 @@
 #include <iostream>
 using namespace gem;
 
-VFATdata::VFATdata() {
-  ver_ = 1;
-}    
+VFATdata::VFATdata() { ver_ = 1; }
 
 VFATdata::VFATdata(const int vfatVer,
                    const uint16_t BC,
-		   const uint8_t EC,
-		   const uint16_t chipID,
-		   const uint64_t lsDatas,
-		   const uint64_t msDatas)
-{
+                   const uint8_t EC,
+                   const uint16_t chipID,
+                   const uint64_t lsDatas,
+                   const uint64_t msDatas) {
   // this constructor only used for packing sim digis
   VFATfirst fw;
   VFATsecond sw;
@@ -20,30 +17,29 @@ VFATdata::VFATdata(const int vfatVer,
 
   fw.word = 0;
   sw.word = 0;
-  tw.word = 0;  
+  tw.word = 0;
   fw.header = 0x1E;
 
   if (vfatVer == 3) {
     fw.bc = BC;
     fw.ec = EC;
     fw.pos = chipID;
-  }
-  else {
+  } else {
     fw.chipID = chipID;
     fw.b1110 = 14;
     fw.b1100 = 12;
     fw.b1010 = 10;
-    fw.ecV2  = EC;
-    fw.bcV2  = BC;    
+    fw.ecV2 = EC;
+    fw.bcV2 = BC;
   }
-  
+
   sw.lsData1 = lsDatas >> 48;
   tw.lsData2 = lsDatas & 0x0000ffffffffffff;
-  
+
   fw.msData1 = msDatas >> 48;
   sw.msData2 = msDatas & 0x0000ffffffffffff;
   ver_ = vfatVer;
-  
+
   fw_ = fw.word;
   sw_ = sw.word;
   tw_ = tw.word;
@@ -54,50 +50,57 @@ VFATdata::VFATdata(const int vfatVer,
   tw_ = tw.word;
 }
 
-uint8_t VFATdata::quality() {  
-  uint8_t q = 0;  
+uint8_t VFATdata::quality() {
+  uint8_t q = 0;
   if (ver_ == 2) {
-    if (VFATthird{tw_}.crc != checkCRC()) q = 1;
-    if (VFATfirst{fw_}.b1010 != 10) q |= 1UL << 1;
-    if (VFATfirst{fw_}.b1100 != 12) q |= 1UL << 2;
-    if (VFATfirst{fw_}.b1110 != 14) q |= 1UL << 3;
+    if (VFATthird{tw_}.crc != checkCRC())
+      q = 1;
+    if (VFATfirst{fw_}.b1010 != 10)
+      q |= 1UL << 1;
+    if (VFATfirst{fw_}.b1100 != 12)
+      q |= 1UL << 2;
+    if (VFATfirst{fw_}.b1110 != 14)
+      q |= 1UL << 3;
   }
-  // quality test not yet implemented in v3  
+  // quality test not yet implemented in v3
   return q;
 }
 
-uint16_t VFATdata::crc_cal(uint16_t crc_in, uint16_t dato)
-{
+uint16_t VFATdata::crc_cal(uint16_t crc_in, uint16_t dato) {
   uint16_t v = 0x0001;
   uint16_t mask = 0x0001;
-  uint16_t d=0x0000;
+  uint16_t d = 0x0000;
   uint16_t crc_temp = crc_in;
   unsigned char datalen = 16;
-  for (int i=0; i<datalen; i++) {
-    if (dato & v) d = 0x0001;
-    else d = 0x0000;
-    if ((crc_temp & mask)^d) crc_temp = crc_temp>>1 ^ 0x8408;
-    else crc_temp = crc_temp>>1;
-    v<<=1;
+  for (int i = 0; i < datalen; i++) {
+    if (dato & v)
+      d = 0x0001;
+    else
+      d = 0x0000;
+    if ((crc_temp & mask) ^ d)
+      crc_temp = crc_temp >> 1 ^ 0x8408;
+    else
+      crc_temp = crc_temp >> 1;
+    v <<= 1;
   }
   return crc_temp;
 }
 
-uint16_t VFATdata::checkCRC()
-{
+uint16_t VFATdata::checkCRC() {
   uint16_t vfatBlockWords[12];
-  vfatBlockWords[11] = ((0x000f & VFATfirst{fw_}.b1010)<<12) | VFATfirst{fw_}.bcV2;
-  vfatBlockWords[10] = ((0x000f & VFATfirst{fw_}.b1100)<<12) | ((0x00ff & VFATfirst{fw_}.ecV2) <<4) | (0x000f & VFATfirst{fw_}.flag);
-  vfatBlockWords[9]  = ((0x000f & VFATfirst{fw_}.b1110)<<12) | VFATfirst{fw_}.chipID;
-  vfatBlockWords[8]  = (0xffff000000000000 & msData()) >> 48;
-  vfatBlockWords[7]  = (0x0000ffff00000000 & msData()) >> 32;
-  vfatBlockWords[6]  = (0x00000000ffff0000 & msData()) >> 16;
-  vfatBlockWords[5]  = (0x000000000000ffff & msData());
-  vfatBlockWords[4]  = (0xffff000000000000 & lsData()) >> 48;
-  vfatBlockWords[3]  = (0x0000ffff00000000 & lsData()) >> 32;
-  vfatBlockWords[2]  = (0x00000000ffff0000 & lsData()) >> 16;
-  vfatBlockWords[1]  = (0x000000000000ffff & lsData());
-  
+  vfatBlockWords[11] = ((0x000f & VFATfirst{fw_}.b1010) << 12) | VFATfirst{fw_}.bcV2;
+  vfatBlockWords[10] =
+      ((0x000f & VFATfirst{fw_}.b1100) << 12) | ((0x00ff & VFATfirst{fw_}.ecV2) << 4) | (0x000f & VFATfirst{fw_}.flag);
+  vfatBlockWords[9] = ((0x000f & VFATfirst{fw_}.b1110) << 12) | VFATfirst{fw_}.chipID;
+  vfatBlockWords[8] = (0xffff000000000000 & msData()) >> 48;
+  vfatBlockWords[7] = (0x0000ffff00000000 & msData()) >> 32;
+  vfatBlockWords[6] = (0x00000000ffff0000 & msData()) >> 16;
+  vfatBlockWords[5] = (0x000000000000ffff & msData());
+  vfatBlockWords[4] = (0xffff000000000000 & lsData()) >> 48;
+  vfatBlockWords[3] = (0x0000ffff00000000 & lsData()) >> 32;
+  vfatBlockWords[2] = (0x00000000ffff0000 & lsData()) >> 16;
+  vfatBlockWords[1] = (0x000000000000ffff & lsData());
+
   uint16_t crc_fin = 0xffff;
   for (int i = 11; i >= 1; i--) {
     crc_fin = crc_cal(crc_fin, vfatBlockWords[i]);

--- a/RecoCTPPS/PixelLocal/interface/CTPPSPixelClusterProducer.h
+++ b/RecoCTPPS/PixelLocal/interface/CTPPSPixelClusterProducer.h
@@ -16,7 +16,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
- 
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -36,30 +36,29 @@
 #include <vector>
 #include <set>
 
-class CTPPSPixelClusterProducer : public edm::stream::EDProducer<>
-{
+class CTPPSPixelClusterProducer : public edm::stream::EDProducer<> {
 public:
-  explicit CTPPSPixelClusterProducer(const edm::ParameterSet& param);
- 
+  explicit CTPPSPixelClusterProducer(const edm::ParameterSet &param);
+
   ~CTPPSPixelClusterProducer() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   edm::ParameterSet param_;
   int verbosity_;
- 
+
   edm::InputTag src_;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelDigi>> tokenCTPPSPixelDigi_;
 
   RPixDetClusterizer clusterizer_;
-  
-  void run(const edm::DetSetVector<CTPPSPixelDigi> &input, edm::DetSetVector<CTPPSPixelCluster> &output, const CTPPSPixelAnalysisMask *mask);
 
-  CTPPSPixelGainCalibrationDBService theGainCalibrationDB; 
+  void run(const edm::DetSetVector<CTPPSPixelDigi> &input,
+           edm::DetSetVector<CTPPSPixelCluster> &output,
+           const CTPPSPixelAnalysisMask *mask);
+
+  CTPPSPixelGainCalibrationDBService theGainCalibrationDB;
 };
-
-
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/CTPPSPixelGainCalibrationDBService.h
+++ b/RecoCTPPS/PixelLocal/interface/CTPPSPixelGainCalibrationDBService.h
@@ -4,7 +4,7 @@
 //
 // Package:     RecoCTPPS/PixelLocal
 // Class  :     CTPPSPixelGainCalibrationDBService
-// 
+//
 /**\class CTPPSPixelGainCalibrationDBService CTPPSPixelGainCalibrationDBService.h "RecoCTPPS/PixelLocal/interface/CTPPSPixelGainCalibrationDBService.h"
 
  Description: [one line class summary]
@@ -20,18 +20,17 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
-class CTPPSPixelGainCalibrationDBService
-{
+class CTPPSPixelGainCalibrationDBService {
+public:
+  CTPPSPixelGainCalibrationDBService();
+  virtual ~CTPPSPixelGainCalibrationDBService();
+  virtual void getDB(const edm::Event& e, const edm::EventSetup& c);
+  const CTPPSPixelGainCalibrations* getCalibs() const { return pPixelGainCalibrations; }
 
-   public:
-      CTPPSPixelGainCalibrationDBService();
-      virtual ~CTPPSPixelGainCalibrationDBService();
-      virtual void getDB(const edm::Event& e, const edm::EventSetup& c);
-      const CTPPSPixelGainCalibrations* getCalibs() const {return pPixelGainCalibrations;}
-   private:
-      CTPPSPixelGainCalibrationDBService(const CTPPSPixelGainCalibrationDBService&) = delete; 
-      const CTPPSPixelGainCalibrations* pPixelGainCalibrations;
-      const CTPPSPixelGainCalibrationDBService& operator=(const CTPPSPixelGainCalibrationDBService&) = delete; 
+private:
+  CTPPSPixelGainCalibrationDBService(const CTPPSPixelGainCalibrationDBService&) = delete;
+  const CTPPSPixelGainCalibrations* pPixelGainCalibrations;
+  const CTPPSPixelGainCalibrationDBService& operator=(const CTPPSPixelGainCalibrationDBService&) = delete;
 };
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/CTPPSPixelRecHitProducer.h
+++ b/RecoCTPPS/PixelLocal/interface/CTPPSPixelRecHitProducer.h
@@ -15,7 +15,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
- 
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -24,29 +24,27 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
-#include "RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h" 
+#include "RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h"
 
-
-class CTPPSPixelRecHitProducer : public edm::stream::EDProducer<>
-{
+class CTPPSPixelRecHitProducer : public edm::stream::EDProducer<> {
 public:
-  explicit CTPPSPixelRecHitProducer(const edm::ParameterSet& param);
-  
+  explicit CTPPSPixelRecHitProducer(const edm::ParameterSet &param);
+
   ~CTPPSPixelRecHitProducer() override;
-  
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   edm::ParameterSet param_;
   int verbosity_;
-  
+
   edm::InputTag src_;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelCluster>> tokenCTPPSPixelCluster_;
-  
+
   RPixClusterToHit cluster2hit_;
-  
+
   void run(const edm::DetSetVector<CTPPSPixelCluster> &input, edm::DetSetVector<CTPPSPixelRecHit> &output);
 };
 

--- a/RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h
@@ -12,20 +12,18 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h"
 #include "Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h"
 
-class RPixClusterToHit{
-
+class RPixClusterToHit {
 public:
+  RPixClusterToHit(edm::ParameterSet const &conf);
 
-  RPixClusterToHit(edm::ParameterSet const& conf);
-
-  void buildHits(unsigned int detId, const std::vector<CTPPSPixelCluster> &clusters, std::vector<CTPPSPixelRecHit> &hits);
-  void make_hit(CTPPSPixelCluster aCluster,  std::vector<CTPPSPixelRecHit> &hits );
+  void buildHits(unsigned int detId,
+                 const std::vector<CTPPSPixelCluster> &clusters,
+                 std::vector<CTPPSPixelRecHit> &hits);
+  void make_hit(CTPPSPixelCluster aCluster, std::vector<CTPPSPixelRecHit> &hits);
   ~RPixClusterToHit();
 
 private:
-
   int verbosity_;
-
 };
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/RPixDetClusterizer.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetClusterizer.h
@@ -24,48 +24,38 @@
 #include <set>
 
 class RPixCalibDigi : public CTPPSPixelDigi {
-
 public:
-
-RPixCalibDigi(unsigned char row, unsigned char col, unsigned short adc, unsigned short ele) : CTPPSPixelDigi(row,col,adc){
+  RPixCalibDigi(unsigned char row, unsigned char col, unsigned short adc, unsigned short ele)
+      : CTPPSPixelDigi(row, col, adc) {
     electrons_ = ele;
   }
 
-RPixCalibDigi() : CTPPSPixelDigi(){
-    electrons_ = 0;
-}
+  RPixCalibDigi() : CTPPSPixelDigi() { electrons_ = 0; }
 
-  int electrons() const {
-    return electrons_;
-  }
-  void set_electrons(int a) {
-    electrons_=a;
-  }
+  int electrons() const { return electrons_; }
+  void set_electrons(int a) { electrons_ = a; }
 
 private:
-
   int electrons_;
-
 };
 
-
-class RPixDetClusterizer{
-
+class RPixDetClusterizer {
 public:
+  RPixDetClusterizer(edm::ParameterSet const &conf);
 
-  RPixDetClusterizer(edm::ParameterSet const& conf);
+  void buildClusters(unsigned int detId,
+                     const std::vector<CTPPSPixelDigi> &digi,
+                     std::vector<CTPPSPixelCluster> &clusters,
+                     const CTPPSPixelGainCalibrations *pcalibration,
+                     const CTPPSPixelAnalysisMask *mask);
+  int calibrate(unsigned int, int, int, int, const CTPPSPixelGainCalibrations *pcalibration);
 
-  void buildClusters(unsigned int detId, const std::vector<CTPPSPixelDigi> &digi, std::vector<CTPPSPixelCluster> &clusters, const CTPPSPixelGainCalibrations * pcalibration, const CTPPSPixelAnalysisMask*  mask);
-  int calibrate(unsigned int, int, int, int ,const CTPPSPixelGainCalibrations * pcalibration);
-
-  void make_cluster( RPixCalibDigi const &aSeed,  std::vector<CTPPSPixelCluster> &clusters );
+  void make_cluster(RPixCalibDigi const &aSeed, std::vector<CTPPSPixelCluster> &clusters);
   ~RPixDetClusterizer();
 
-
 private:
-
   std::set<CTPPSPixelDigi> rpix_digi_set_;
-  std::map<unsigned int,RPixCalibDigi> calib_rpix_digi_map_;
+  std::map<unsigned int, RPixCalibDigi> calib_rpix_digi_map_;
   const edm::ParameterSet &params_;
   int verbosity_;
   unsigned short SeedADCThreshold_;
@@ -78,18 +68,13 @@ private:
   std::vector<RPixCalibDigi> SeedVector_;
 };
 
-
-
-class RPixTempCluster{
-
+class RPixTempCluster {
 public:
-
-  RPixTempCluster()
-  {
-    isize=0; 
-    curr=0; 
+  RPixTempCluster() {
+    isize = 0;
+    curr = 0;
   }
-  ~RPixTempCluster(){}
+  ~RPixTempCluster() {}
 
   static constexpr unsigned short MAXSIZE = 256;
   unsigned short adc[MAXSIZE];
@@ -99,20 +84,18 @@ public:
   unsigned short curr;
 
   // stack interface (unsafe ok for use below)
-  unsigned short top() const { return curr;}
-  void pop() { ++curr;}   
-  bool empty() { return curr==isize;}
+  unsigned short top() const { return curr; }
+  void pop() { ++curr; }
+  bool empty() { return curr == isize; }
 
   bool addPixel(unsigned char myrow, unsigned char mycol, unsigned short const iadc) {
-    if (isize==MAXSIZE) return false;
-    adc[isize]=iadc;
-    row[isize]=myrow;
-    col[isize++]=mycol;
+    if (isize == MAXSIZE)
+      return false;
+    adc[isize] = iadc;
+    row[isize] = myrow;
+    col[isize++] = mycol;
     return true;
   }
- 
-
 };
-
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h
@@ -18,7 +18,6 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 
-
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 #include "CLHEP/Vector/ThreeVector.h"
 #include "CLHEP/Vector/RotationInterfaces.h"
@@ -26,34 +25,30 @@
 
 #include <vector>
 
-class RPixDetPatternFinder{
-  
+class RPixDetPatternFinder {
 public:
-  RPixDetPatternFinder(edm::ParameterSet const& parameterSet) {}
-  
-  virtual ~RPixDetPatternFinder() {};
+  RPixDetPatternFinder(edm::ParameterSet const &parameterSet) {}
 
-  typedef struct{
-    CLHEP::Hep3Vector    globalPoint;
+  virtual ~RPixDetPatternFinder(){};
+
+  typedef struct {
+    CLHEP::Hep3Vector globalPoint;
     math::Error<3>::type globalError;
-    CTPPSPixelRecHit     recHit     ;
-    CTPPSPixelDetId      detId      ;
+    CTPPSPixelRecHit recHit;
+    CTPPSPixelDetId detId;
   } PointInPlane;
   typedef std::vector<PointInPlane> Road;
-  
-  void setHits(const edm::DetSetVector<CTPPSPixelRecHit> *hitVector) {hitVector_ = hitVector; }
-  virtual void findPattern()=0;
-  void clear(){
-    patternVector_.clear();
-  }
-  std::vector<Road> const& getPatterns() const {return patternVector_; }
-  void setGeometry(const CTPPSGeometry *geometry) {geometry_ = geometry; }
-  
+
+  void setHits(const edm::DetSetVector<CTPPSPixelRecHit> *hitVector) { hitVector_ = hitVector; }
+  virtual void findPattern() = 0;
+  void clear() { patternVector_.clear(); }
+  std::vector<Road> const &getPatterns() const { return patternVector_; }
+  void setGeometry(const CTPPSGeometry *geometry) { geometry_ = geometry; }
+
 protected:
   const edm::DetSetVector<CTPPSPixelRecHit> *hitVector_;
   std::vector<Road> patternVector_;
   const CTPPSGeometry *geometry_;
-  
 };
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
@@ -16,42 +16,38 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
 #include "RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h"
 
-
 #include "CLHEP/Vector/ThreeVector.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 
 #include <vector>
 #include <map>
 
-class RPixDetTrackFinder{
+class RPixDetTrackFinder {
+public:
+  RPixDetTrackFinder(edm::ParameterSet const &parameterSet) : romanPotId_(CTPPSPixelDetId(0, 2, 3, 0)) {}
 
-  public:
-    RPixDetTrackFinder(edm::ParameterSet const& parameterSet): romanPotId_(CTPPSPixelDetId(0, 2, 3, 0)) {}
-    
-    virtual ~RPixDetTrackFinder() {};
+  virtual ~RPixDetTrackFinder(){};
 
-    void setHits(std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > *hitMap) {hitMap_ = hitMap; }
-    virtual void findTracks(int run)=0;
-    virtual void initialize()=0;
-    void clear(){
-      localTrackVector_.clear();
-    }
-    std::vector<CTPPSPixelLocalTrack> const& getLocalTracks() const {return localTrackVector_; }
-    void setRomanPotId(CTPPSPixelDetId rpId) {romanPotId_ = rpId;};
-    void setGeometry(const CTPPSGeometry *geometry) {geometry_ = geometry; }
-    void setListOfPlanes(std::vector<uint32_t> listOfAllPlanes) { listOfAllPlanes_ = listOfAllPlanes; } 
-    void setZ0(double z0) { z0_ = z0; }
+  void setHits(std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > *hitMap) {
+    hitMap_ = hitMap;
+  }
+  virtual void findTracks(int run) = 0;
+  virtual void initialize() = 0;
+  void clear() { localTrackVector_.clear(); }
+  std::vector<CTPPSPixelLocalTrack> const &getLocalTracks() const { return localTrackVector_; }
+  void setRomanPotId(CTPPSPixelDetId rpId) { romanPotId_ = rpId; };
+  void setGeometry(const CTPPSGeometry *geometry) { geometry_ = geometry; }
+  void setListOfPlanes(std::vector<uint32_t> listOfAllPlanes) { listOfAllPlanes_ = listOfAllPlanes; }
+  void setZ0(double z0) { z0_ = z0; }
 
-
-  protected:
-    std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > *hitMap_;
-    std::vector<CTPPSPixelLocalTrack>  localTrackVector_;
-    CTPPSPixelDetId  romanPotId_;
-    const CTPPSGeometry *geometry_;
-    uint32_t numberOfPlanesPerPot_;
-    std::vector<uint32_t> listOfAllPlanes_;
-    double z0_;
-
+protected:
+  std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > *hitMap_;
+  std::vector<CTPPSPixelLocalTrack> localTrackVector_;
+  CTPPSPixelDetId romanPotId_;
+  const CTPPSGeometry *geometry_;
+  uint32_t numberOfPlanesPerPot_;
+  std::vector<uint32_t> listOfAllPlanes_;
+  double z0_;
 };
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h
@@ -21,51 +21,48 @@
 #include <vector>
 #include <map>
 
-class RPixPlaneCombinatoryTracking : public RPixDetTrackFinder{
+class RPixPlaneCombinatoryTracking : public RPixDetTrackFinder {
+public:
+  RPixPlaneCombinatoryTracking(edm::ParameterSet const &parameterSet);
+  ~RPixPlaneCombinatoryTracking() override;
+  void initialize() override;
+  void findTracks(int run) override;
 
-  public:
-    RPixPlaneCombinatoryTracking(edm::ParameterSet const& parameterSet);
-    ~RPixPlaneCombinatoryTracking() override;
-    void initialize() override;
-    void findTracks(int run) override;
+private:
+  typedef std::vector<std::vector<uint32_t> > PlaneCombinations;
+  typedef std::vector<RPixDetPatternFinder::PointInPlane> PointInPlaneList;
+  typedef std::map<CTPPSPixelDetId, size_t> HitReferences;
+  typedef std::map<HitReferences, PointInPlaneList> PointAndReferenceMap;
+  typedef std::pair<HitReferences, PointInPlaneList> PointAndReferencePair;
 
-  private:
-    typedef std::vector<std::vector<uint32_t> > PlaneCombinations;
-    typedef std::vector<RPixDetPatternFinder::PointInPlane> PointInPlaneList;
-    typedef std::map<CTPPSPixelDetId, size_t> HitReferences;
-    typedef std::map< HitReferences, PointInPlaneList > PointAndReferenceMap;
-    typedef std::pair<HitReferences, PointInPlaneList > PointAndReferencePair;
+  int verbosity_;
+  uint32_t trackMinNumberOfPoints_;
+  double maximumChi2OverNDF_;
+  double maximumXLocalDistanceFromTrack_;
+  double maximumYLocalDistanceFromTrack_;
+  PlaneCombinations possiblePlaneCombinations_;
 
-    int verbosity_;
-    uint32_t trackMinNumberOfPoints_;
-    double maximumChi2OverNDF_;
-    double maximumXLocalDistanceFromTrack_;
-    double maximumYLocalDistanceFromTrack_;
-    PlaneCombinations possiblePlaneCombinations_;
-    
-    void getPlaneCombinations(const std::vector<uint32_t> &inputPlaneList, uint32_t numberToExtract, PlaneCombinations &planeCombinations) const;
-    CTPPSPixelLocalTrack fitTrack(PointInPlaneList pointList);
-    void getHitCombinations(
-        const std::map<CTPPSPixelDetId, PointInPlaneList > &mapOfAllHits, 
-        std::map<CTPPSPixelDetId, PointInPlaneList >::iterator mapIterator,
-        HitReferences tmpHitPlaneMap,
-        const PointInPlaneList &tmpHitVector,
-        PointAndReferenceMap &outputMap);
-    PointAndReferenceMap produceAllHitCombination(PlaneCombinations inputPlaneCombination);
-    bool calculatePointOnDetector(CTPPSPixelLocalTrack *track, CTPPSPixelDetId planeId, GlobalPoint &planeLineIntercept);
-    static bool functionForPlaneOrdering(
-        PointAndReferencePair a,
-        PointAndReferencePair b) { 
-        return (a.second.size() > b.second.size()); }
-    std::vector<PointAndReferencePair > orderCombinationsPerNumberOrPoints(
-        PointAndReferenceMap inputMap);
+  void getPlaneCombinations(const std::vector<uint32_t> &inputPlaneList,
+                            uint32_t numberToExtract,
+                            PlaneCombinations &planeCombinations) const;
+  CTPPSPixelLocalTrack fitTrack(PointInPlaneList pointList);
+  void getHitCombinations(const std::map<CTPPSPixelDetId, PointInPlaneList> &mapOfAllHits,
+                          std::map<CTPPSPixelDetId, PointInPlaneList>::iterator mapIterator,
+                          HitReferences tmpHitPlaneMap,
+                          const PointInPlaneList &tmpHitVector,
+                          PointAndReferenceMap &outputMap);
+  PointAndReferenceMap produceAllHitCombination(PlaneCombinations inputPlaneCombination);
+  bool calculatePointOnDetector(CTPPSPixelLocalTrack *track, CTPPSPixelDetId planeId, GlobalPoint &planeLineIntercept);
+  static bool functionForPlaneOrdering(PointAndReferencePair a, PointAndReferencePair b) {
+    return (a.second.size() > b.second.size());
+  }
+  std::vector<PointAndReferencePair> orderCombinationsPerNumberOrPoints(PointAndReferenceMap inputMap);
 
-
-    inline uint32_t factorial(uint32_t x) const {
-      if(x==0) return 1;
-      return (x == 1 ? x : x * factorial(x - 1));
-    }
-
+  inline uint32_t factorial(uint32_t x) const {
+    if (x == 0)
+      return 1;
+    return (x == 1 ? x : x * factorial(x - 1));
+  }
 };
 
 #endif

--- a/RecoCTPPS/PixelLocal/interface/RPixRoadFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixRoadFinder.h
@@ -16,13 +16,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelCluster.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
-#include "RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h" 
+#include "RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h"
 #include "RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h"
 
 #include "FWCore/Framework/interface/ESWatcher.h"
@@ -31,27 +30,21 @@
 #include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
 #include "Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h"
 
-
 #include <vector>
 #include <set>
 
+class RPixRoadFinder : public RPixDetPatternFinder {
+public:
+  explicit RPixRoadFinder(const edm::ParameterSet &param);
+  ~RPixRoadFinder() override;
+  void findPattern() override;
 
-
-class RPixRoadFinder : public RPixDetPatternFinder{
-
-  public:
-    explicit RPixRoadFinder(const edm::ParameterSet& param);
-    ~RPixRoadFinder() override;
-    void findPattern() override;
-
-  private:
-    int verbosity_;
-    double roadRadius_;
-    unsigned int minRoadSize_;
-    unsigned int maxRoadSize_;
-    void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, const CTPPSGeometry & geometry, std::vector<Road> &roads);
-
+private:
+  int verbosity_;
+  double roadRadius_;
+  unsigned int minRoadSize_;
+  unsigned int maxRoadSize_;
+  void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, const CTPPSGeometry &geometry, std::vector<Road> &roads);
 };
-
 
 #endif

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelClusterProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelClusterProducer.cc
@@ -2,76 +2,69 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoCTPPS/PixelLocal/interface/CTPPSPixelClusterProducer.h"
 
-CTPPSPixelClusterProducer::CTPPSPixelClusterProducer(const edm::ParameterSet& conf) :
-  param_(conf) ,
-  clusterizer_(conf){
-  
+CTPPSPixelClusterProducer::CTPPSPixelClusterProducer(const edm::ParameterSet &conf) : param_(conf), clusterizer_(conf) {
   src_ = conf.getParameter<std::string>("label");
-  verbosity_ = conf.getUntrackedParameter<int> ("RPixVerbosity");
-	 
+  verbosity_ = conf.getUntrackedParameter<int>("RPixVerbosity");
+
   tokenCTPPSPixelDigi_ = consumes<edm::DetSetVector<CTPPSPixelDigi> >(edm::InputTag(src_));
- 
-  produces<edm::DetSetVector<CTPPSPixelCluster> > ();
-  }
 
-CTPPSPixelClusterProducer::~CTPPSPixelClusterProducer() {
-
+  produces<edm::DetSetVector<CTPPSPixelCluster> >();
 }
 
-void CTPPSPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions){
+CTPPSPixelClusterProducer::~CTPPSPixelClusterProducer() {}
+
+void CTPPSPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<int>("RPixVerbosity",0);
+  desc.addUntracked<int>("RPixVerbosity", 0);
   desc.add<std::string>("label", "ctppsPixelDigis");
-  desc.add<int>("SeedADCThreshold",2);
-  desc.add<int>("ADCThreshold",2);
-  desc.add<double>("ElectronADCGain",135.0);
-  desc.add<int>("VCaltoElectronGain",50);
-  desc.add<int>("VCaltoElectronOffset",-411);
-  desc.add<bool>("doSingleCalibration",false); 
- descriptions.add("ctppsPixelClusters", desc);
+  desc.add<int>("SeedADCThreshold", 2);
+  desc.add<int>("ADCThreshold", 2);
+  desc.add<double>("ElectronADCGain", 135.0);
+  desc.add<int>("VCaltoElectronGain", 50);
+  desc.add<int>("VCaltoElectronOffset", -411);
+  desc.add<bool>("doSingleCalibration", false);
+  descriptions.add("ctppsPixelClusters", desc);
 }
 
-void CTPPSPixelClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
-/// get inputs
+void CTPPSPixelClusterProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  /// get inputs
   edm::Handle<edm::DetSetVector<CTPPSPixelDigi> > rpd;
   iEvent.getByToken(tokenCTPPSPixelDigi_, rpd);
- 
-// get analysis mask to mask channels
+
+  // get analysis mask to mask channels
   edm::ESHandle<CTPPSPixelAnalysisMask> aMask;
 
-  if(!rpd->empty())
+  if (!rpd->empty())
     iSetup.get<CTPPSPixelAnalysisMaskRcd>().get(aMask);
-  
-  edm::DetSetVector<CTPPSPixelCluster>  output;
 
-// run clusterisation
-  if (!rpd->empty()){
-// get calibration DB
-    theGainCalibrationDB.getDB(iEvent,iSetup);
+  edm::DetSetVector<CTPPSPixelCluster> output;
+
+  // run clusterisation
+  if (!rpd->empty()) {
+    // get calibration DB
+    theGainCalibrationDB.getDB(iEvent, iSetup);
     run(*rpd, output, aMask.product());
   }
-// write output
+  // write output
   iEvent.put(std::make_unique<edm::DetSetVector<CTPPSPixelCluster> >(output));
-
 }
 
-void CTPPSPixelClusterProducer::run(const edm::DetSetVector<CTPPSPixelDigi> &input, 
-				    edm::DetSetVector<CTPPSPixelCluster> &output, const CTPPSPixelAnalysisMask * mask){
+void CTPPSPixelClusterProducer::run(const edm::DetSetVector<CTPPSPixelDigi> &input,
+                                    edm::DetSetVector<CTPPSPixelCluster> &output,
+                                    const CTPPSPixelAnalysisMask *mask) {
+  for (const auto &ds_digi : input) {
+    edm::DetSet<CTPPSPixelCluster> &ds_cluster = output.find_or_insert(ds_digi.id);
+    clusterizer_.buildClusters(ds_digi.id, ds_digi.data, ds_cluster.data, theGainCalibrationDB.getCalibs(), mask);
 
-  for (const auto &ds_digi : input)
-    {
-      edm::DetSet<CTPPSPixelCluster> &ds_cluster = output.find_or_insert(ds_digi.id);
-      clusterizer_.buildClusters(ds_digi.id, ds_digi.data, ds_cluster.data, theGainCalibrationDB.getCalibs(), mask);
-
-      if(verbosity_){
-	unsigned int cluN=0;
-	for(std::vector<CTPPSPixelCluster>::iterator iit = ds_cluster.data.begin(); iit != ds_cluster.data.end(); iit++){
-	  edm::LogInfo("CTPPSPixelClusterProducer") << "Cluster " << ++cluN <<" avg row " 
-					       << (*iit).avg_row()<< " avg col " << (*iit).avg_col()<<" ADC.size " << (*iit).size();
-	}
+    if (verbosity_) {
+      unsigned int cluN = 0;
+      for (std::vector<CTPPSPixelCluster>::iterator iit = ds_cluster.data.begin(); iit != ds_cluster.data.end();
+           iit++) {
+        edm::LogInfo("CTPPSPixelClusterProducer") << "Cluster " << ++cluN << " avg row " << (*iit).avg_row()
+                                                  << " avg col " << (*iit).avg_col() << " ADC.size " << (*iit).size();
       }
     }
+  }
 }
 
-DEFINE_FWK_MODULE( CTPPSPixelClusterProducer);
+DEFINE_FWK_MODULE(CTPPSPixelClusterProducer);

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
- 
+
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -19,7 +19,6 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
 #include "DataFormats/DetId/interface/DetId.h"
-
 
 #include "RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h"
 #include "RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h"
@@ -36,16 +35,14 @@
 #include "RecoCTPPS/PixelLocal/interface/RPixRoadFinder.h"
 #include "RecoCTPPS/PixelLocal/interface/RPixPlaneCombinatoryTracking.h"
 
-
-class CTPPSPixelLocalTrackProducer : public edm::stream::EDProducer<>
-{
+class CTPPSPixelLocalTrackProducer : public edm::stream::EDProducer<> {
 public:
-  explicit CTPPSPixelLocalTrackProducer(const edm::ParameterSet& parameterSet);
- 
+  explicit CTPPSPixelLocalTrackProducer(const edm::ParameterSet &parameterSet);
+
   ~CTPPSPixelLocalTrackProducer() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   int verbosity_;
@@ -53,7 +50,7 @@ private:
   int maxHitPerRomanPot_;
   int maxTrackPerRomanPot_;
   int maxTrackPerPattern_;
- 
+
   edm::InputTag inputTag_;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelRecHit>> tokenCTPPSPixelRecHit_;
   edm::ESWatcher<VeryForwardRealGeometryRecord> geometryWatcher_;
@@ -61,108 +58,96 @@ private:
   std::vector<uint32_t> listOfAllPlanes_;
 
   std::unique_ptr<RPixDetPatternFinder> patternFinder_;
-  std::unique_ptr<RPixDetTrackFinder>   trackFinder_  ;
+  std::unique_ptr<RPixDetTrackFinder> trackFinder_;
 
   void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, edm::DetSetVector<CTPPSPixelLocalTrack> &output);
-  
 };
 
 //------------------------------------------------------------------------------------------------//
 
-CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterSet& parameterSet)
-{
-  inputTag_             = parameterSet.getParameter<std::string>  ("label");
-  verbosity_            = parameterSet.getUntrackedParameter<int> ("verbosity");
-  maxHitPerRomanPot_    = parameterSet.getParameter<int> ("maxHitPerRomanPot");
-  maxHitPerPlane_       = parameterSet.getParameter<int> ("maxHitPerPlane");
-  maxTrackPerRomanPot_  = parameterSet.getParameter<int> ("maxTrackPerRomanPot");
-  maxTrackPerPattern_   = parameterSet.getParameter<int> ("maxTrackPerPattern");
-  numberOfPlanesPerPot_ = parameterSet.getParameter<int> ("numberOfPlanesPerPot");
+CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterSet &parameterSet) {
+  inputTag_ = parameterSet.getParameter<std::string>("label");
+  verbosity_ = parameterSet.getUntrackedParameter<int>("verbosity");
+  maxHitPerRomanPot_ = parameterSet.getParameter<int>("maxHitPerRomanPot");
+  maxHitPerPlane_ = parameterSet.getParameter<int>("maxHitPerPlane");
+  maxTrackPerRomanPot_ = parameterSet.getParameter<int>("maxTrackPerRomanPot");
+  maxTrackPerPattern_ = parameterSet.getParameter<int>("maxTrackPerPattern");
+  numberOfPlanesPerPot_ = parameterSet.getParameter<int>("numberOfPlanesPerPot");
 
   std::string patternFinderAlgorithm = parameterSet.getParameter<std::string>("patternFinderAlgorithm");
-  std::string trackFitterAlgorithm  = parameterSet.getParameter<std::string>("trackFinderAlgorithm" );
+  std::string trackFitterAlgorithm = parameterSet.getParameter<std::string>("trackFinderAlgorithm");
 
   // pattern algorithm selector
-  if(patternFinderAlgorithm == "RPixRoadFinder"){
+  if (patternFinderAlgorithm == "RPixRoadFinder") {
     patternFinder_ = std::unique_ptr<RPixRoadFinder>(new RPixRoadFinder(parameterSet));
+  } else {
+    throw cms::Exception("CTPPSPixelLocalTrackProducer")
+        << "Pattern finder algorithm" << patternFinderAlgorithm << " does not exist";
   }
-  else{
-    throw cms::Exception("CTPPSPixelLocalTrackProducer") << "Pattern finder algorithm" << patternFinderAlgorithm << " does not exist";
-  }
-  
+
   listOfAllPlanes_.reserve(6);
-  for(uint32_t i=0; i<numberOfPlanesPerPot_; ++i){
+  for (uint32_t i = 0; i < numberOfPlanesPerPot_; ++i) {
     listOfAllPlanes_.push_back(i);
   }
 
   //tracking algorithm selector
-  if(trackFitterAlgorithm == "RPixPlaneCombinatoryTracking"){
+  if (trackFitterAlgorithm == "RPixPlaneCombinatoryTracking") {
     trackFinder_ = std::unique_ptr<RPixPlaneCombinatoryTracking>(new RPixPlaneCombinatoryTracking(parameterSet));
-  }
-  else{
-    throw cms::Exception("CTPPSPixelLocalTrackProducer") << "Tracking fitter algorithm" << trackFitterAlgorithm << " does not exist";
+  } else {
+    throw cms::Exception("CTPPSPixelLocalTrackProducer")
+        << "Tracking fitter algorithm" << trackFitterAlgorithm << " does not exist";
   }
   trackFinder_->setListOfPlanes(listOfAllPlanes_);
   trackFinder_->initialize();
-  
-  tokenCTPPSPixelRecHit_ = consumes<edm::DetSetVector<CTPPSPixelRecHit> >(edm::InputTag(inputTag_));
- 
-  produces<edm::DetSetVector<CTPPSPixelLocalTrack> > ();
 
+  tokenCTPPSPixelRecHit_ = consumes<edm::DetSetVector<CTPPSPixelRecHit>>(edm::InputTag(inputTag_));
+
+  produces<edm::DetSetVector<CTPPSPixelLocalTrack>>();
 }
 
 //------------------------------------------------------------------------------------------------//
 
-CTPPSPixelLocalTrackProducer::~CTPPSPixelLocalTrackProducer(){
-}
+CTPPSPixelLocalTrackProducer::~CTPPSPixelLocalTrackProducer() {}
 
 //------------------------------------------------------------------------------------------------//
 
-void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions){
+void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<std::string>    ("label"                            , "ctppsPixelRecHits"           )
-    ->setComment( "label of the RecHits input for the tracking algorithm"                       );
-  desc.add<std::string>    ("patternFinderAlgorithm"           , "RPixRoadFinder"              )
-    ->setComment( "algorithm type for pattern finder"                                           );
-  desc.add<std::string>    ("trackFinderAlgorithm"             , "RPixPlaneCombinatoryTracking")
-    ->setComment( "algorithm type for track finder"                                             );
-  desc.add<uint>           ("trackMinNumberOfPoints"           , 3                             )
-    ->setComment( "minimum number of planes to produce a track"                                 );
-  desc.addUntracked<int>   ("verbosity"                        , 0                             )
-    ->setComment( "verbosity for track producer"                                                );
-  desc.add<double>         ("maximumChi2OverNDF"               , 5.                            )
-    ->setComment( "maximum Chi2OverNDF for accepting the track"                                 );
-  desc.add<double>         ("maximumXLocalDistanceFromTrack"   , 0.2                           )
-    ->setComment( "maximum x distance in mm to associate a point not used for fit to the track" );
-  desc.add<double>         ("maximumYLocalDistanceFromTrack"   , 0.3                           )
-    ->setComment( "maximum y distance in mm to associate a point not used for fit to the track" );
-  desc.add<int>            ("maxHitPerPlane"                   , 20                            )
-    ->setComment( "maximum hits per plane, events with higher number will not be fitted"        );
-  desc.add<int>            ("maxHitPerRomanPot"                , 60                            )
-    ->setComment( "maximum hits per roman pot, events with higher number will not be fitted"    );
-  desc.add<int>            ("maxTrackPerRomanPot"              , 10                            )
-    ->setComment( "maximum tracks per roman pot, events with higher track will not be saved"    );
-  desc.add<int>            ("maxTrackPerPattern"               , 5                             )
-    ->setComment( "maximum tracks per pattern, events with higher track will not be saved"      );
-  desc.add<int>            ("numberOfPlanesPerPot"             , 6                             )
-    ->setComment( "number of planes per pot"                                                    );
-  desc.add<double>         ("roadRadius"                       , 1.0                           )
-    ->setComment( "radius of pattern search window"                                             );
-  desc.add<int>            ("minRoadSize"                      , 3                             )
-    ->setComment( "minimum number of points in a pattern"                                       );
-  desc.add<int>            ("maxRoadSize"                      , 20                            )
-    ->setComment( "maximum number of points in a pattern"                                       );
+  desc.add<std::string>("label", "ctppsPixelRecHits")
+      ->setComment("label of the RecHits input for the tracking algorithm");
+  desc.add<std::string>("patternFinderAlgorithm", "RPixRoadFinder")->setComment("algorithm type for pattern finder");
+  desc.add<std::string>("trackFinderAlgorithm", "RPixPlaneCombinatoryTracking")
+      ->setComment("algorithm type for track finder");
+  desc.add<uint>("trackMinNumberOfPoints", 3)->setComment("minimum number of planes to produce a track");
+  desc.addUntracked<int>("verbosity", 0)->setComment("verbosity for track producer");
+  desc.add<double>("maximumChi2OverNDF", 5.)->setComment("maximum Chi2OverNDF for accepting the track");
+  desc.add<double>("maximumXLocalDistanceFromTrack", 0.2)
+      ->setComment("maximum x distance in mm to associate a point not used for fit to the track");
+  desc.add<double>("maximumYLocalDistanceFromTrack", 0.3)
+      ->setComment("maximum y distance in mm to associate a point not used for fit to the track");
+  desc.add<int>("maxHitPerPlane", 20)
+      ->setComment("maximum hits per plane, events with higher number will not be fitted");
+  desc.add<int>("maxHitPerRomanPot", 60)
+      ->setComment("maximum hits per roman pot, events with higher number will not be fitted");
+  desc.add<int>("maxTrackPerRomanPot", 10)
+      ->setComment("maximum tracks per roman pot, events with higher track will not be saved");
+  desc.add<int>("maxTrackPerPattern", 5)
+      ->setComment("maximum tracks per pattern, events with higher track will not be saved");
+  desc.add<int>("numberOfPlanesPerPot", 6)->setComment("number of planes per pot");
+  desc.add<double>("roadRadius", 1.0)->setComment("radius of pattern search window");
+  desc.add<int>("minRoadSize", 3)->setComment("minimum number of points in a pattern");
+  desc.add<int>("maxRoadSize", 20)->setComment("maximum number of points in a pattern");
 
   descriptions.add("ctppsPixelLocalTracks", desc);
 }
 
 //------------------------------------------------------------------------------------------------//
 
-void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Step A: get inputs
-  
-  edm::Handle<edm::DetSetVector<CTPPSPixelRecHit> > recHits;
+
+  edm::Handle<edm::DetSetVector<CTPPSPixelRecHit>> recHits;
   iEvent.getByToken(tokenCTPPSPixelRecHit_, recHits);
   edm::DetSetVector<CTPPSPixelRecHit> recHitVector(*recHits);
 
@@ -172,39 +157,42 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
   const CTPPSGeometry &geometry = *geometryHandler;
   geometryWatcher_.check(iSetup);
 
-  std::vector<CTPPSPixelDetId> listOfPotWithHighOccupancyPlanes; 
+  std::vector<CTPPSPixelDetId> listOfPotWithHighOccupancyPlanes;
   std::map<CTPPSPixelDetId, uint32_t> mapHitPerPot;
 
-  for(const auto & recHitSet : recHitVector){
-    
-    if(verbosity_>2) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"Hits found in plane = "<<recHitSet.detId()<< " number = " << recHitSet.size() ;
+  for (const auto &recHitSet : recHitVector) {
+    if (verbosity_ > 2)
+      edm::LogInfo("CTPPSPixelLocalTrackProducer")
+          << "Hits found in plane = " << recHitSet.detId() << " number = " << recHitSet.size();
     CTPPSPixelDetId tmpRomanPotId = CTPPSPixelDetId(recHitSet.detId()).getRPId();
     uint32_t hitOnPlane = recHitSet.size();
 
     //Get the number of hits per pot
-    if(mapHitPerPot.find(tmpRomanPotId)==mapHitPerPot.end()){
+    if (mapHitPerPot.find(tmpRomanPotId) == mapHitPerPot.end()) {
       mapHitPerPot[tmpRomanPotId] = hitOnPlane;
-    }
-    else mapHitPerPot[tmpRomanPotId]+=hitOnPlane;
+    } else
+      mapHitPerPot[tmpRomanPotId] += hitOnPlane;
 
     //check is the plane occupancy is too high and save the corresponding pot
-    if(maxHitPerPlane_>=0 && hitOnPlane>(uint32_t)maxHitPerPlane_){
-      if(verbosity_>2) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<" ---> To many hits in the plane, pot will be excluded from tracking cleared";
+    if (maxHitPerPlane_ >= 0 && hitOnPlane > (uint32_t)maxHitPerPlane_) {
+      if (verbosity_ > 2)
+        edm::LogInfo("CTPPSPixelLocalTrackProducer")
+            << " ---> To many hits in the plane, pot will be excluded from tracking cleared";
       listOfPotWithHighOccupancyPlanes.push_back(tmpRomanPotId);
     }
   }
 
   //remove rechit for pot with too many hits or containing planes with too many hits
-  for(const auto & recHitSet : recHitVector){
+  for (const auto &recHitSet : recHitVector) {
     const auto tmpDetectorId = CTPPSPixelDetId(recHitSet.detId());
     const auto tmpRomanPotId = tmpDetectorId.getRPId();
 
-    if((maxHitPerRomanPot_>=0 && mapHitPerPot[tmpRomanPotId]>(uint32_t)maxHitPerRomanPot_) || 
-      find (listOfPotWithHighOccupancyPlanes.begin(), listOfPotWithHighOccupancyPlanes.end(), tmpRomanPotId) != listOfPotWithHighOccupancyPlanes.end() ){
+    if ((maxHitPerRomanPot_ >= 0 && mapHitPerPot[tmpRomanPotId] > (uint32_t)maxHitPerRomanPot_) ||
+        find(listOfPotWithHighOccupancyPlanes.begin(), listOfPotWithHighOccupancyPlanes.end(), tmpRomanPotId) !=
+            listOfPotWithHighOccupancyPlanes.end()) {
       edm::DetSet<CTPPSPixelRecHit> &tmpDetSet = recHitVector[tmpDetectorId];
       tmpDetSet.clear();
     }
-
   }
 
   edm::DetSetVector<CTPPSPixelLocalTrack> foundTracks;
@@ -220,28 +208,30 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
   //loop on all the patterns
   int numberOfTracks = 0;
 
-  for(const auto & pattern : patternVector){
+  for (const auto &pattern : patternVector) {
     CTPPSPixelDetId firstHitDetId = CTPPSPixelDetId(pattern.at(0).detId);
     CTPPSPixelDetId romanPotId = firstHitDetId.getRPId();
-    
-    std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane> > hitOnPlaneMap; //hit of the pattern organized by plane
+
+    std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane>>
+        hitOnPlaneMap;  //hit of the pattern organized by plane
 
     //loop on all the hits of the pattern
-    for(const auto & hit : pattern){
+    for (const auto &hit : pattern) {
       CTPPSPixelDetId hitDetId = CTPPSPixelDetId(hit.detId);
       CTPPSPixelDetId tmpRomanPotId = hitDetId.getRPId();
 
-      if(tmpRomanPotId!=romanPotId){ //check that the hits belong to the same tracking station
-        throw cms::Exception("CTPPSPixelLocalTrackProducer") << "Hits in the pattern must belong to the same tracking station";
+      if (tmpRomanPotId != romanPotId) {  //check that the hits belong to the same tracking station
+        throw cms::Exception("CTPPSPixelLocalTrackProducer")
+            << "Hits in the pattern must belong to the same tracking station";
       }
 
-      if(hitOnPlaneMap.find(hitDetId)==hitOnPlaneMap.end()){ //add the plane key in case it is the first hit of that plane
+      if (hitOnPlaneMap.find(hitDetId) ==
+          hitOnPlaneMap.end()) {  //add the plane key in case it is the first hit of that plane
         std::vector<RPixDetPatternFinder::PointInPlane> hitOnPlane;
         hitOnPlane.push_back(hit);
         hitOnPlaneMap[hitDetId] = hitOnPlane;
-      }
-      else hitOnPlaneMap[hitDetId].push_back(hit); //add the hit to an existing plane key
-    
+      } else
+        hitOnPlaneMap[hitDetId].push_back(hit);  //add the hit to an existing plane key
     }
 
     trackFinder_->clear();
@@ -252,37 +242,40 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event& iEvent, const edm::EventS
     trackFinder_->findTracks(iEvent.getRun().id().run());
     std::vector<CTPPSPixelLocalTrack> tmpTracksVector = trackFinder_->getLocalTracks();
 
-    if(verbosity_>2)edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"tmpTracksVector = "<<tmpTracksVector.size();
-    if(maxTrackPerPattern_>=0 && tmpTracksVector.size()>(uint32_t)maxTrackPerPattern_){
-      if(verbosity_>2)edm::LogInfo("CTPPSPixelLocalTrackProducer")<<" ---> To many tracks in the pattern, cleared";
+    if (verbosity_ > 2)
+      edm::LogInfo("CTPPSPixelLocalTrackProducer") << "tmpTracksVector = " << tmpTracksVector.size();
+    if (maxTrackPerPattern_ >= 0 && tmpTracksVector.size() > (uint32_t)maxTrackPerPattern_) {
+      if (verbosity_ > 2)
+        edm::LogInfo("CTPPSPixelLocalTrackProducer") << " ---> To many tracks in the pattern, cleared";
       continue;
     }
 
-    for(const auto & track : tmpTracksVector){
+    for (const auto &track : tmpTracksVector) {
       ++numberOfTracks;
       edm::DetSet<CTPPSPixelLocalTrack> &tmpDetSet = foundTracks.find_or_insert(romanPotId);
-        tmpDetSet.push_back(track);
+      tmpDetSet.push_back(track);
     }
-
-
   }
 
-  if(verbosity_>1) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"Number of tracks will be saved = "<<numberOfTracks;
+  if (verbosity_ > 1)
+    edm::LogInfo("CTPPSPixelLocalTrackProducer") << "Number of tracks will be saved = " << numberOfTracks;
 
-  for(const auto & track : foundTracks){
-    if(verbosity_>1) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<"Track found in detId = "<<track.detId()<< " number = " << track.size() ;
-    if(maxTrackPerRomanPot_>=0 && track.size()>(uint32_t)maxTrackPerRomanPot_){
-      if(verbosity_>1) edm::LogInfo("CTPPSPixelLocalTrackProducer")<<" ---> Too many tracks in the pot, cleared";
+  for (const auto &track : foundTracks) {
+    if (verbosity_ > 1)
+      edm::LogInfo("CTPPSPixelLocalTrackProducer")
+          << "Track found in detId = " << track.detId() << " number = " << track.size();
+    if (maxTrackPerRomanPot_ >= 0 && track.size() > (uint32_t)maxTrackPerRomanPot_) {
+      if (verbosity_ > 1)
+        edm::LogInfo("CTPPSPixelLocalTrackProducer") << " ---> Too many tracks in the pot, cleared";
       CTPPSPixelDetId tmpRomanPotId = CTPPSPixelDetId(track.detId());
       edm::DetSet<CTPPSPixelLocalTrack> &tmpDetSet = foundTracks[tmpRomanPotId];
       tmpDetSet.clear();
     }
   }
 
-  iEvent.put(std::make_unique<edm::DetSetVector<CTPPSPixelLocalTrack> >(foundTracks));
+  iEvent.put(std::make_unique<edm::DetSetVector<CTPPSPixelLocalTrack>>(foundTracks));
 
   return;
-
 }
 
-DEFINE_FWK_MODULE( CTPPSPixelLocalTrackProducer);
+DEFINE_FWK_MODULE(CTPPSPixelLocalTrackProducer);

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelRecHitProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelRecHitProducer.cc
@@ -1,49 +1,42 @@
 #include "RecoCTPPS/PixelLocal/interface/CTPPSPixelRecHitProducer.h"
 
-
-CTPPSPixelRecHitProducer::CTPPSPixelRecHitProducer(const edm::ParameterSet& conf) :
-  param_(conf), cluster2hit_(conf)
-{
+CTPPSPixelRecHitProducer::CTPPSPixelRecHitProducer(const edm::ParameterSet &conf) : param_(conf), cluster2hit_(conf) {
   src_ = conf.getParameter<edm::InputTag>("RPixClusterTag");
-  verbosity_ = conf.getUntrackedParameter<int> ("RPixVerbosity");	 
+  verbosity_ = conf.getUntrackedParameter<int>("RPixVerbosity");
   tokenCTPPSPixelCluster_ = consumes<edm::DetSetVector<CTPPSPixelCluster> >(src_);
-  produces<edm::DetSetVector<CTPPSPixelRecHit> > ();
+  produces<edm::DetSetVector<CTPPSPixelRecHit> >();
 }
 
 CTPPSPixelRecHitProducer::~CTPPSPixelRecHitProducer() {}
 
-void CTPPSPixelRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions){
+void CTPPSPixelRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<int>("RPixVerbosity",0);
-  desc.add<edm::InputTag>("RPixClusterTag",edm::InputTag("ctppsPixelClusters"));
+  desc.addUntracked<int>("RPixVerbosity", 0);
+  desc.add<edm::InputTag>("RPixClusterTag", edm::InputTag("ctppsPixelClusters"));
   descriptions.add("ctppsPixelRecHits", desc);
 }
 
-void CTPPSPixelRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-   
-	edm::Handle<edm::DetSetVector<CTPPSPixelCluster> > rpCl;
-	iEvent.getByToken(tokenCTPPSPixelCluster_, rpCl);
+void CTPPSPixelRecHitProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::Handle<edm::DetSetVector<CTPPSPixelCluster> > rpCl;
+  iEvent.getByToken(tokenCTPPSPixelCluster_, rpCl);
 
-	edm::DetSetVector<CTPPSPixelRecHit>  output;
+  edm::DetSetVector<CTPPSPixelRecHit> output;
 
-// run reconstruction
-	if (!rpCl->empty())
-	  run(*rpCl, output);
+  // run reconstruction
+  if (!rpCl->empty())
+    run(*rpCl, output);
 
-	iEvent.put(std::make_unique<edm::DetSetVector<CTPPSPixelRecHit> >(output));
-
+  iEvent.put(std::make_unique<edm::DetSetVector<CTPPSPixelRecHit> >(output));
 }
 
-void CTPPSPixelRecHitProducer::run(const edm::DetSetVector<CTPPSPixelCluster> &input, edm::DetSetVector<CTPPSPixelRecHit> &output){
+void CTPPSPixelRecHitProducer::run(const edm::DetSetVector<CTPPSPixelCluster> &input,
+                                   edm::DetSetVector<CTPPSPixelRecHit> &output) {
+  for (const auto &ds_cluster : input) {
+    edm::DetSet<CTPPSPixelRecHit> &ds_rechit = output.find_or_insert(ds_cluster.id);
 
-  for (const auto &ds_cluster : input)
-    {
-      edm::DetSet<CTPPSPixelRecHit> &ds_rechit = output.find_or_insert(ds_cluster.id);
-
-//calculate the cluster parameters and convert it into a rechit 
-      cluster2hit_.buildHits(ds_cluster.id, ds_cluster.data, ds_rechit.data);
-      
-    }
+    //calculate the cluster parameters and convert it into a rechit
+    cluster2hit_.buildHits(ds_cluster.id, ds_cluster.data, ds_rechit.data);
+  }
 }
 
-DEFINE_FWK_MODULE( CTPPSPixelRecHitProducer);
+DEFINE_FWK_MODULE(CTPPSPixelRecHitProducer);

--- a/RecoCTPPS/PixelLocal/src/CTPPSPixelGainCalibrationDBService.cc
+++ b/RecoCTPPS/PixelLocal/src/CTPPSPixelGainCalibrationDBService.cc
@@ -2,7 +2,7 @@
 //
 // Package:     RecoCTPPS/PixelLocal
 // Class  :     CTPPSPixelGainCalibrationDBService
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -18,22 +18,18 @@
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
 #include "CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h"
 
-CTPPSPixelGainCalibrationDBService::CTPPSPixelGainCalibrationDBService()
-{
-}
+CTPPSPixelGainCalibrationDBService::CTPPSPixelGainCalibrationDBService() {}
 
-CTPPSPixelGainCalibrationDBService::~CTPPSPixelGainCalibrationDBService()
-{
-}
+CTPPSPixelGainCalibrationDBService::~CTPPSPixelGainCalibrationDBService() {}
 
-void CTPPSPixelGainCalibrationDBService::getDB(const edm::Event& iEvent, const edm::EventSetup& iSetup){
-
- edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("CTPPSPixelGainCalibrationsRcd"));
- if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
-  //record not found   
-   throw cms::Exception("CTPPSPixelGainCalibrationService") << "Record CTPPSPixelGainCalibrationsRcd does not exist";
- }
- edm::ESHandle<CTPPSPixelGainCalibrations> calhandle;
- iSetup.get<CTPPSPixelGainCalibrationsRcd>().get(calhandle);
- pPixelGainCalibrations=calhandle.product();
+void CTPPSPixelGainCalibrationDBService::getDB(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::eventsetup::EventSetupRecordKey recordKey(
+      edm::eventsetup::EventSetupRecordKey::TypeTag::findType("CTPPSPixelGainCalibrationsRcd"));
+  if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    //record not found
+    throw cms::Exception("CTPPSPixelGainCalibrationService") << "Record CTPPSPixelGainCalibrationsRcd does not exist";
+  }
+  edm::ESHandle<CTPPSPixelGainCalibrations> calhandle;
+  iSetup.get<CTPPSPixelGainCalibrationsRcd>().get(calhandle);
+  pPixelGainCalibrations = calhandle.product();
 }

--- a/RecoCTPPS/PixelLocal/src/RPixClusterToHit.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixClusterToHit.cc
@@ -1,128 +1,128 @@
 #include "RecoCTPPS/PixelLocal/interface/RPixClusterToHit.h"
 
-
-RPixClusterToHit::RPixClusterToHit(edm::ParameterSet const& conf)
-{
-verbosity_ = conf.getUntrackedParameter<int>("RPixVerbosity");
+RPixClusterToHit::RPixClusterToHit(edm::ParameterSet const &conf) {
+  verbosity_ = conf.getUntrackedParameter<int>("RPixVerbosity");
 }
 
-RPixClusterToHit::~RPixClusterToHit(){}
+RPixClusterToHit::~RPixClusterToHit() {}
 
-void RPixClusterToHit::buildHits(unsigned int detId, const std::vector<CTPPSPixelCluster> &clusters, std::vector<CTPPSPixelRecHit> &hits)
-{
-  
-  if(verbosity_) edm::LogInfo("RPixClusterToHit")<<" RPixClusterToHit "<<detId<<" received cluster array of size = "<<clusters.size();
-   for(unsigned int i=0; i<clusters.size();i++){
-     make_hit(clusters[i],hits);
+void RPixClusterToHit::buildHits(unsigned int detId,
+                                 const std::vector<CTPPSPixelCluster> &clusters,
+                                 std::vector<CTPPSPixelRecHit> &hits) {
+  if (verbosity_)
+    edm::LogInfo("RPixClusterToHit") << " RPixClusterToHit " << detId
+                                     << " received cluster array of size = " << clusters.size();
+  for (unsigned int i = 0; i < clusters.size(); i++) {
+    make_hit(clusters[i], hits);
   }
-
 }
 
+void RPixClusterToHit::make_hit(CTPPSPixelCluster aCluster, std::vector<CTPPSPixelRecHit> &hits) {
+  // take a cluster, generate a rec hit and push it in the rec hit vector
 
-void RPixClusterToHit::make_hit(CTPPSPixelCluster aCluster,  std::vector<CTPPSPixelRecHit> &hits ){
-
-// take a cluster, generate a rec hit and push it in the rec hit vector
-
-//call the topology
+  //call the topology
   CTPPSPixelSimTopology topology;
-//call the numbering inside the ROC
+  //call the numbering inside the ROC
   CTPPSPixelIndices pxlInd;
-// get information from the cluster 
-// get the whole cluster size and row/col size
+  // get information from the cluster
+  // get the whole cluster size and row/col size
   unsigned int thisClusterSize = aCluster.size();
   unsigned int thisClusterRowSize = aCluster.sizeRow();
   unsigned int thisClusterColSize = aCluster.sizeCol();
 
-// get the minimum pixel row/col
+  // get the minimum pixel row/col
   unsigned int thisClusterMinRow = aCluster.minPixelRow();
   unsigned int thisClusterMinCol = aCluster.minPixelCol();
 
-// calculate "on edge" flag
+  // calculate "on edge" flag
   bool anEdgePixel = false;
-  if(aCluster.minPixelRow() == 0 || aCluster.minPixelCol() == 0 ||  
-     int(aCluster.minPixelRow()+aCluster.rowSpan()) == (pxlInd.getDefaultRowDetSize()-1) ||  
-     int(aCluster.minPixelCol()+aCluster.colSpan()) == (pxlInd.getDefaultColDetSize()-1) ) 
+  if (aCluster.minPixelRow() == 0 || aCluster.minPixelCol() == 0 ||
+      int(aCluster.minPixelRow() + aCluster.rowSpan()) == (pxlInd.getDefaultRowDetSize() - 1) ||
+      int(aCluster.minPixelCol() + aCluster.colSpan()) == (pxlInd.getDefaultColDetSize() - 1))
     anEdgePixel = true;
 
-// check for bad (ADC=0) pixels in cluster 
+  // check for bad (ADC=0) pixels in cluster
   bool aBadPixel = false;
-  for(unsigned int i = 0; i < thisClusterSize; i++){
-    if(aCluster.pixelADC(i)==0) aBadPixel = true;
-  } 
+  for (unsigned int i = 0; i < thisClusterSize; i++) {
+    if (aCluster.pixelADC(i) == 0)
+      aBadPixel = true;
+  }
 
-// check for spanning two ROCs
+  // check for spanning two ROCs
   bool twoRocs = false;
-  int currROCId = pxlInd.getROCId(aCluster.pixelCol(0),aCluster.pixelRow(0) ); 
+  int currROCId = pxlInd.getROCId(aCluster.pixelCol(0), aCluster.pixelRow(0));
 
-  for(unsigned int i = 1; i < thisClusterSize; i++){
-    if(pxlInd.getROCId(aCluster.pixelCol(i),aCluster.pixelRow(i) ) != currROCId){
+  for (unsigned int i = 1; i < thisClusterSize; i++) {
+    if (pxlInd.getROCId(aCluster.pixelCol(i), aCluster.pixelRow(i)) != currROCId) {
       twoRocs = true;
       break;
     }
   }
 
-//estimate position and error of the hit
+  //estimate position and error of the hit
   double avgWLocalX = 0;
   double avgWLocalY = 0;
   double weights = 0;
   double weightedVarianceX = 0.;
   double weightedVarianceY = 0.;
 
-  if(verbosity_)
+  if (verbosity_)
     edm::LogInfo("RPixClusterToHit") << " hit pixels: ";
 
-  for(unsigned int i = 0; i < thisClusterSize; i++){
-    
-    if(verbosity_)edm::LogInfo("RPixClusterToHit") << aCluster.pixelRow(i) << " " << aCluster.pixelCol(i)<<" " << aCluster.pixelADC(i);
+  for (unsigned int i = 0; i < thisClusterSize; i++) {
+    if (verbosity_)
+      edm::LogInfo("RPixClusterToHit") << aCluster.pixelRow(i) << " " << aCluster.pixelCol(i) << " "
+                                       << aCluster.pixelADC(i);
 
     double minPxlX = 0;
     double minPxlY = 0;
     double maxPxlX = 0;
     double maxPxlY = 0;
-    topology.pixelRange(aCluster.pixelRow(i),aCluster.pixelCol(i),minPxlX,maxPxlX,minPxlY, maxPxlY);
-    double halfSizeX = (maxPxlX-minPxlX)/2.;
-    double halfSizeY = (maxPxlY-minPxlY)/2.;
+    topology.pixelRange(aCluster.pixelRow(i), aCluster.pixelCol(i), minPxlX, maxPxlX, minPxlY, maxPxlY);
+    double halfSizeX = (maxPxlX - minPxlX) / 2.;
+    double halfSizeY = (maxPxlY - minPxlY) / 2.;
     double avgPxlX = minPxlX + halfSizeX;
     double avgPxlY = minPxlY + halfSizeY;
-//error propagation
-    weightedVarianceX += aCluster.pixelADC(i)*aCluster.pixelADC(i)*halfSizeX*halfSizeX/3.;
-    weightedVarianceY += aCluster.pixelADC(i)*aCluster.pixelADC(i)*halfSizeY*halfSizeY/3.;
-    
-    avgWLocalX += avgPxlX*aCluster.pixelADC(i);
-    avgWLocalY += avgPxlY*aCluster.pixelADC(i);
+    //error propagation
+    weightedVarianceX += aCluster.pixelADC(i) * aCluster.pixelADC(i) * halfSizeX * halfSizeX / 3.;
+    weightedVarianceY += aCluster.pixelADC(i) * aCluster.pixelADC(i) * halfSizeY * halfSizeY / 3.;
+
+    avgWLocalX += avgPxlX * aCluster.pixelADC(i);
+    avgWLocalY += avgPxlY * aCluster.pixelADC(i);
     weights += aCluster.pixelADC(i);
+  }
 
-  } 
-
-  if(weights == 0){
+  if (weights == 0) {
     edm::LogError("RPixClusterToHit") << " unexpected weights = 0 for cluster (Row_min, Row_max, Col_min, Col_max) = ("
-				      << aCluster.minPixelRow() << ","
-				      << aCluster.minPixelRow()+aCluster.rowSpan() << ","
-				      << aCluster.minPixelCol() << ","
-				      << aCluster.minPixelCol()+aCluster.colSpan()
-				      << ")"; 
+                                      << aCluster.minPixelRow() << "," << aCluster.minPixelRow() + aCluster.rowSpan()
+                                      << "," << aCluster.minPixelCol() << ","
+                                      << aCluster.minPixelCol() + aCluster.colSpan() << ")";
     return;
   }
 
-  double invWeights = 1./weights;
-  double avgLocalX = avgWLocalX*invWeights;
-  double avgLocalY = avgWLocalY*invWeights;
-  
-  double varianceX = weightedVarianceX*invWeights*invWeights;
-  double varianceY = weightedVarianceY*invWeights*invWeights;
+  double invWeights = 1. / weights;
+  double avgLocalX = avgWLocalX * invWeights;
+  double avgLocalY = avgWLocalY * invWeights;
 
-  LocalPoint lp(avgLocalX,avgLocalY,0);
-  LocalError le(varianceX,0,varianceY);
-  CTPPSPixelRecHit rh(lp,le,anEdgePixel,aBadPixel,twoRocs,thisClusterMinRow,thisClusterMinCol,thisClusterSize,thisClusterRowSize,thisClusterColSize);
-  if(verbosity_)edm::LogInfo("RPixClusterToHit") << lp << " with error " << le ;
+  double varianceX = weightedVarianceX * invWeights * invWeights;
+  double varianceY = weightedVarianceY * invWeights * invWeights;
+
+  LocalPoint lp(avgLocalX, avgLocalY, 0);
+  LocalError le(varianceX, 0, varianceY);
+  CTPPSPixelRecHit rh(lp,
+                      le,
+                      anEdgePixel,
+                      aBadPixel,
+                      twoRocs,
+                      thisClusterMinRow,
+                      thisClusterMinCol,
+                      thisClusterSize,
+                      thisClusterRowSize,
+                      thisClusterColSize);
+  if (verbosity_)
+    edm::LogInfo("RPixClusterToHit") << lp << " with error " << le;
 
   hits.push_back(rh);
 
   return;
-
 }
-
-
-
-
-

--- a/RecoCTPPS/PixelLocal/src/RPixDetClusterizer.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixDetClusterizer.cc
@@ -8,12 +8,9 @@ namespace {
   constexpr int maxRow = CTPPSPixelCluster::MAXROW;
   constexpr double highRangeCal = 1800.;
   constexpr double lowRangeCal = 260.;
-}
+}  // namespace
 
-
-RPixDetClusterizer::RPixDetClusterizer(edm::ParameterSet const& conf):
-  params_(conf), SeedVector_(0)
-{
+RPixDetClusterizer::RPixDetClusterizer(edm::ParameterSet const &conf) : params_(conf), SeedVector_(0) {
   verbosity_ = conf.getUntrackedParameter<int>("RPixVerbosity");
   SeedADCThreshold_ = conf.getParameter<int>("SeedADCThreshold");
   ADCThreshold_ = conf.getParameter<int>("ADCThreshold");
@@ -21,137 +18,142 @@ RPixDetClusterizer::RPixDetClusterizer(edm::ParameterSet const& conf):
   VcaltoElectronGain_ = conf.getParameter<int>("VCaltoElectronGain");
   VcaltoElectronOffset_ = conf.getParameter<int>("VCaltoElectronOffset");
   doSingleCalibration_ = conf.getParameter<bool>("doSingleCalibration");
-
 }
 
-RPixDetClusterizer::~RPixDetClusterizer(){}
+RPixDetClusterizer::~RPixDetClusterizer() {}
 
-void RPixDetClusterizer::buildClusters(unsigned int detId, const std::vector<CTPPSPixelDigi> &digi, std::vector<CTPPSPixelCluster> &clusters, const CTPPSPixelGainCalibrations * pcalibrations,const CTPPSPixelAnalysisMask* maskera)
-{
-
-  std::map<uint32_t, CTPPSPixelROCAnalysisMask> const & mask = maskera->analysisMask;
-  std::map<uint32_t, CTPPSPixelROCAnalysisMask>::const_iterator mask_it = mask.find(detId); 
+void RPixDetClusterizer::buildClusters(unsigned int detId,
+                                       const std::vector<CTPPSPixelDigi> &digi,
+                                       std::vector<CTPPSPixelCluster> &clusters,
+                                       const CTPPSPixelGainCalibrations *pcalibrations,
+                                       const CTPPSPixelAnalysisMask *maskera) {
+  std::map<uint32_t, CTPPSPixelROCAnalysisMask> const &mask = maskera->analysisMask;
+  std::map<uint32_t, CTPPSPixelROCAnalysisMask>::const_iterator mask_it = mask.find(detId);
 
   std::set<std::pair<unsigned char, unsigned char> > maskedPixels;
-  if( mask_it != mask.end()) maskedPixels = mask_it->second.maskedPixels;
+  if (mask_it != mask.end())
+    maskedPixels = mask_it->second.maskedPixels;
 
-  if(verbosity_) edm::LogInfo("RPixDetClusterizer")<<detId<<" received digi.size()="<<digi.size();
+  if (verbosity_)
+    edm::LogInfo("RPixDetClusterizer") << detId << " received digi.size()=" << digi.size();
 
-// creating a set of CTPPSPixelDigi's and fill it
+  // creating a set of CTPPSPixelDigi's and fill it
 
   rpix_digi_set_.clear();
-  rpix_digi_set_.insert(digi.begin(),digi.end());
+  rpix_digi_set_.insert(digi.begin(), digi.end());
   SeedVector_.clear();
 
-// calibrate digis here
+  // calibrate digis here
   calib_rpix_digi_map_.clear();
 
-  for( auto const &RPdit : rpix_digi_set_){
-
+  for (auto const &RPdit : rpix_digi_set_) {
     uint8_t row = RPdit.row();
     uint8_t column = RPdit.column();
-    if( row > maxRow || column > maxCol)
-      throw cms::Exception("CTPPSDigiOutofRange") 
-	<< " row = " << row << "  column = "<<column;
+    if (row > maxRow || column > maxCol)
+      throw cms::Exception("CTPPSDigiOutofRange") << " row = " << row << "  column = " << column;
 
-    std::pair<unsigned char, unsigned char> pixel = std::make_pair(row,column);
+    std::pair<unsigned char, unsigned char> pixel = std::make_pair(row, column);
     unsigned short adc = RPdit.adc();
     unsigned short electrons = 0;
 
-// check if pixel is noisy or dead (i.e. in the mask)
+    // check if pixel is noisy or dead (i.e. in the mask)
     const bool is_in = maskedPixels.find(pixel) != maskedPixels.end();
-    if(!is_in){
-//calibrate digi and store the new ones
-      electrons = calibrate(detId,adc,row,column,pcalibrations);
-      if(electrons < SeedADCThreshold_*ElectronADCGain_) electrons = SeedADCThreshold_*ElectronADCGain_;
-      RPixCalibDigi calibDigi(row,column,adc,electrons);
-      unsigned int index = column*maxRow + row;
-      calib_rpix_digi_map_.insert(std::pair<unsigned int, RPixCalibDigi> (index, calibDigi));
+    if (!is_in) {
+      //calibrate digi and store the new ones
+      electrons = calibrate(detId, adc, row, column, pcalibrations);
+      if (electrons < SeedADCThreshold_ * ElectronADCGain_)
+        electrons = SeedADCThreshold_ * ElectronADCGain_;
+      RPixCalibDigi calibDigi(row, column, adc, electrons);
+      unsigned int index = column * maxRow + row;
+      calib_rpix_digi_map_.insert(std::pair<unsigned int, RPixCalibDigi>(index, calibDigi));
       SeedVector_.push_back(calibDigi);
     }
   }
-  if(verbosity_) edm::LogInfo("RPixDetClusterizer")<<" RPix set size = "<<calib_rpix_digi_map_.size();
+  if (verbosity_)
+    edm::LogInfo("RPixDetClusterizer") << " RPix set size = " << calib_rpix_digi_map_.size();
 
-  for(auto SeedIt : SeedVector_){
-    make_cluster( SeedIt, clusters);
+  for (auto SeedIt : SeedVector_) {
+    make_cluster(SeedIt, clusters);
   }
 }
 
-void RPixDetClusterizer::make_cluster(RPixCalibDigi const &aSeed,  std::vector<CTPPSPixelCluster> &clusters ){
-/// check if seed already used
-  unsigned int seedIndex = aSeed.column()*maxRow + aSeed.row();
-  if( calib_rpix_digi_map_.find(seedIndex)==calib_rpix_digi_map_.end() ){
+void RPixDetClusterizer::make_cluster(RPixCalibDigi const &aSeed, std::vector<CTPPSPixelCluster> &clusters) {
+  /// check if seed already used
+  unsigned int seedIndex = aSeed.column() * maxRow + aSeed.row();
+  if (calib_rpix_digi_map_.find(seedIndex) == calib_rpix_digi_map_.end()) {
     return;
   }
-// creating a temporary cluster
+  // creating a temporary cluster
   RPixTempCluster atempCluster;
 
-// filling the cluster with the seed
-  atempCluster.addPixel(aSeed.row(),aSeed.column(),aSeed.electrons());
+  // filling the cluster with the seed
+  atempCluster.addPixel(aSeed.row(), aSeed.column(), aSeed.electrons());
   calib_rpix_digi_map_.erase(seedIndex);
 
-  while ( ! atempCluster.empty()) {
-  //This is the standard algorithm to find and add a pixel
-    auto curInd = atempCluster.top(); 
+  while (!atempCluster.empty()) {
+    //This is the standard algorithm to find and add a pixel
+    auto curInd = atempCluster.top();
     atempCluster.pop();
-    for ( auto c = std::max(0,int(atempCluster.col[curInd])-1); c < std::min(int(atempCluster.col[curInd])+2,maxCol) ; ++c) {
-      for ( auto r = std::max(0,int(atempCluster.row[curInd])-1); r < std::min(int(atempCluster.row[curInd])+2,maxRow); ++r)  {
-	
-	unsigned int currIndex = c*maxRow + r;
-	if(calib_rpix_digi_map_.find(currIndex)!=calib_rpix_digi_map_.end() ){
-	  if(!atempCluster.addPixel( r,c,calib_rpix_digi_map_[currIndex].electrons() )) {
-	    CTPPSPixelCluster acluster(atempCluster.isize,atempCluster.adc, atempCluster.row,atempCluster.col);
-	    clusters.push_back(acluster);
-	    return;
-	  }
-	  calib_rpix_digi_map_.erase(currIndex);
-	}
- 
+    for (auto c = std::max(0, int(atempCluster.col[curInd]) - 1);
+         c < std::min(int(atempCluster.col[curInd]) + 2, maxCol);
+         ++c) {
+      for (auto r = std::max(0, int(atempCluster.row[curInd]) - 1);
+           r < std::min(int(atempCluster.row[curInd]) + 2, maxRow);
+           ++r) {
+        unsigned int currIndex = c * maxRow + r;
+        if (calib_rpix_digi_map_.find(currIndex) != calib_rpix_digi_map_.end()) {
+          if (!atempCluster.addPixel(r, c, calib_rpix_digi_map_[currIndex].electrons())) {
+            CTPPSPixelCluster acluster(atempCluster.isize, atempCluster.adc, atempCluster.row, atempCluster.col);
+            clusters.push_back(acluster);
+            return;
+          }
+          calib_rpix_digi_map_.erase(currIndex);
+        }
       }
     }
-	     
+
   }  // while accretion
 
-  CTPPSPixelCluster cluster(atempCluster.isize,atempCluster.adc, atempCluster.row,atempCluster.col);
+  CTPPSPixelCluster cluster(atempCluster.isize, atempCluster.adc, atempCluster.row, atempCluster.col);
   clusters.push_back(cluster);
 }
 
-int RPixDetClusterizer::calibrate(unsigned int detId, int adc, int row, int col, const CTPPSPixelGainCalibrations *pcalibrations){
+int RPixDetClusterizer::calibrate(
+    unsigned int detId, int adc, int row, int col, const CTPPSPixelGainCalibrations *pcalibrations) {
+  float gain = 0;
+  float pedestal = 0;
+  int electrons = 0;
 
-  float gain=0;
-  float pedestal=0;
-  int electrons=0;
-  
-  if(!doSingleCalibration_){
+  if (!doSingleCalibration_) {
+    const CTPPSPixelGainCalibration &DetCalibs = pcalibrations->getGainCalibration(detId);
 
-    const CTPPSPixelGainCalibration& DetCalibs = pcalibrations->getGainCalibration(detId);
-
-    if(DetCalibs.getDetId() != 0){
-      gain = DetCalibs.getGain(col,row)*highRangeCal/lowRangeCal;
-      pedestal = DetCalibs.getPed(col,row);
-      float vcal = (adc - pedestal)*gain;
-      electrons = int(vcal*VcaltoElectronGain_ + VcaltoElectronOffset_);
-    }
-    else{
+    if (DetCalibs.getDetId() != 0) {
+      gain = DetCalibs.getGain(col, row) * highRangeCal / lowRangeCal;
+      pedestal = DetCalibs.getPed(col, row);
+      float vcal = (adc - pedestal) * gain;
+      electrons = int(vcal * VcaltoElectronGain_ + VcaltoElectronOffset_);
+    } else {
       gain = ElectronADCGain_;
       pedestal = 0;
-      electrons = int(adc*gain-pedestal);
+      electrons = int(adc * gain - pedestal);
     }
 
-
-    if(verbosity_) edm::LogInfo("RPixCalibration") << "calibrate:  adc = " << adc << " electrons = " << electrons << " gain = " << gain << " pedestal = " << pedestal ;
-  }else{
+    if (verbosity_)
+      edm::LogInfo("RPixCalibration") << "calibrate:  adc = " << adc << " electrons = " << electrons
+                                      << " gain = " << gain << " pedestal = " << pedestal;
+  } else {
     gain = ElectronADCGain_;
     pedestal = 0;
-    electrons = int(adc*gain-pedestal);
-    if(verbosity_) edm::LogInfo("RPixCalibration") << "calibrate:  adc = " << adc << " electrons = " << electrons << " ElectronADCGain = " << gain << " pedestal = " << pedestal ;
+    electrons = int(adc * gain - pedestal);
+    if (verbosity_)
+      edm::LogInfo("RPixCalibration") << "calibrate:  adc = " << adc << " electrons = " << electrons
+                                      << " ElectronADCGain = " << gain << " pedestal = " << pedestal;
   }
-  if (electrons<0) {
-    edm::LogInfo("RPixCalibration") << "RPixDetClusterizer::calibrate: *** electrons < 0 *** --> " << electrons << "  --> electrons = 0";
+  if (electrons < 0) {
+    edm::LogInfo("RPixCalibration") << "RPixDetClusterizer::calibrate: *** electrons < 0 *** --> " << electrons
+                                    << "  --> electrons = 0";
     electrons = 0;
   }
 
   return electrons;
-
 }
-

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -13,45 +13,42 @@
 
 //------------------------------------------------------------------------------------------------//
 
-RPixPlaneCombinatoryTracking::RPixPlaneCombinatoryTracking(edm::ParameterSet const& parameterSet) : 
-  RPixDetTrackFinder(parameterSet){
-
+RPixPlaneCombinatoryTracking::RPixPlaneCombinatoryTracking(edm::ParameterSet const &parameterSet)
+    : RPixDetTrackFinder(parameterSet) {
   trackMinNumberOfPoints_ = parameterSet.getParameter<uint>("trackMinNumberOfPoints");
-  verbosity_ = parameterSet.getUntrackedParameter<int> ("verbosity");
+  verbosity_ = parameterSet.getUntrackedParameter<int>("verbosity");
   maximumChi2OverNDF_ = parameterSet.getParameter<double>("maximumChi2OverNDF");
-  maximumXLocalDistanceFromTrack_= parameterSet.getParameter<double>("maximumXLocalDistanceFromTrack");
-  maximumYLocalDistanceFromTrack_= parameterSet.getParameter<double>("maximumYLocalDistanceFromTrack");
-  numberOfPlanesPerPot_ = parameterSet.getParameter<int> ("numberOfPlanesPerPot"   );
+  maximumXLocalDistanceFromTrack_ = parameterSet.getParameter<double>("maximumXLocalDistanceFromTrack");
+  maximumYLocalDistanceFromTrack_ = parameterSet.getParameter<double>("maximumYLocalDistanceFromTrack");
+  numberOfPlanesPerPot_ = parameterSet.getParameter<int>("numberOfPlanesPerPot");
 
-  if(trackMinNumberOfPoints_<3){
-    throw cms::Exception("RPixPlaneCombinatoryTracking") << "Minimum number of planes required for tracking is 3, "
-                                                         << "tracking is not possible with " 
-                                                         << trackMinNumberOfPoints_ << " hits";
+  if (trackMinNumberOfPoints_ < 3) {
+    throw cms::Exception("RPixPlaneCombinatoryTracking")
+        << "Minimum number of planes required for tracking is 3, "
+        << "tracking is not possible with " << trackMinNumberOfPoints_ << " hits";
   }
 }
 
 //------------------------------------------------------------------------------------------------//
-    
-RPixPlaneCombinatoryTracking::~RPixPlaneCombinatoryTracking() {
-  possiblePlaneCombinations_.clear();
-}
+
+RPixPlaneCombinatoryTracking::~RPixPlaneCombinatoryTracking() { possiblePlaneCombinations_.clear(); }
 
 //------------------------------------------------------------------------------------------------//
 
 void RPixPlaneCombinatoryTracking::initialize() {
- 
-  uint32_t numberOfCombinations = factorial(numberOfPlanesPerPot_)/
-                                  (factorial(numberOfPlanesPerPot_-trackMinNumberOfPoints_)
-                                   *factorial(trackMinNumberOfPoints_));
-  if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Number of combinations = "<<numberOfCombinations;
+  uint32_t numberOfCombinations =
+      factorial(numberOfPlanesPerPot_) /
+      (factorial(numberOfPlanesPerPot_ - trackMinNumberOfPoints_) * factorial(trackMinNumberOfPoints_));
+  if (verbosity_ >= 2)
+    edm::LogInfo("RPixPlaneCombinatoryTracking") << "Number of combinations = " << numberOfCombinations;
   possiblePlaneCombinations_.reserve(numberOfCombinations);
 
-  getPlaneCombinations(listOfAllPlanes_,trackMinNumberOfPoints_,possiblePlaneCombinations_);
+  getPlaneCombinations(listOfAllPlanes_, trackMinNumberOfPoints_, possiblePlaneCombinations_);
 
-  if(verbosity_>=2) {
-    for( const auto & vec : possiblePlaneCombinations_){
-      for( const auto & num : vec){
-        edm::LogInfo("RPixPlaneCombinatoryTracking")<<num<<" - ";
+  if (verbosity_ >= 2) {
+    for (const auto &vec : possiblePlaneCombinations_) {
+      for (const auto &num : vec) {
+        edm::LogInfo("RPixPlaneCombinatoryTracking") << num << " - ";
       }
       edm::LogInfo("RPixPlaneCombinatoryTracking");
     }
@@ -59,26 +56,27 @@ void RPixPlaneCombinatoryTracking::initialize() {
 }
 
 //------------------------------------------------------------------------------------------------//
-    
+
 //This function produces all the possible plane combinations extracting numberToExtract planes over numberOfPlanes planes
-void RPixPlaneCombinatoryTracking::getPlaneCombinations(const std::vector<uint32_t> &inputPlaneList, uint32_t numberToExtract, PlaneCombinations &planeCombinations) const
-{
-    uint32_t numberOfPlanes = inputPlaneList.size();
-    std::string bitmask(numberToExtract, 1); // numberToExtract leading 1's
-    bitmask.resize(numberOfPlanes, 0); // numberOfPlanes-numberToExtract trailing 0's
-    planeCombinations.clear();
+void RPixPlaneCombinatoryTracking::getPlaneCombinations(const std::vector<uint32_t> &inputPlaneList,
+                                                        uint32_t numberToExtract,
+                                                        PlaneCombinations &planeCombinations) const {
+  uint32_t numberOfPlanes = inputPlaneList.size();
+  std::string bitmask(numberToExtract, 1);  // numberToExtract leading 1's
+  bitmask.resize(numberOfPlanes, 0);        // numberOfPlanes-numberToExtract trailing 0's
+  planeCombinations.clear();
 
-    // store the combination and permute bitmask
-    do {
-      planeCombinations.push_back(std::vector<uint32_t>());
-      for (uint32_t i = 0; i < numberOfPlanes; ++i) { // [0..numberOfPlanes-1] integers
-        if (bitmask[i]) planeCombinations.back().push_back(inputPlaneList.at(i));
-      }
-    } while (std::prev_permutation(bitmask.begin(), bitmask.end()));
+  // store the combination and permute bitmask
+  do {
+    planeCombinations.push_back(std::vector<uint32_t>());
+    for (uint32_t i = 0; i < numberOfPlanes; ++i) {  // [0..numberOfPlanes-1] integers
+      if (bitmask[i])
+        planeCombinations.back().push_back(inputPlaneList.at(i));
+    }
+  } while (std::prev_permutation(bitmask.begin(), bitmask.end()));
 
-    return;
+  return;
 }
-
 
 //------------------------------------------------------------------------------------------------//
 
@@ -86,95 +84,93 @@ void RPixPlaneCombinatoryTracking::getPlaneCombinations(const std::vector<uint32
 //This function avoids to write for loops in cascade which will not allow to define arbitrarily the minimum number of planes to use
 //The output is stored in a map containing the vector of points and as a key the map of the point forming this vector.
 //This allows to erase the points already used for the track fit
-void RPixPlaneCombinatoryTracking::getHitCombinations(
-  const std::map<CTPPSPixelDetId, PointInPlaneList > &mapOfAllHits, 
-  std::map<CTPPSPixelDetId, PointInPlaneList >::iterator mapIterator,
-  HitReferences tmpHitPlaneMap,
-  const PointInPlaneList &tmpHitVector,
-  PointAndReferenceMap &outputMap)
-{
-    //At this point I selected one hit per plane
-    if (mapIterator == mapOfAllHits.end())
-    {
-        outputMap[tmpHitPlaneMap] = tmpHitVector;
-        return;
-    }
-    for (size_t i=0; i<mapIterator->second.size(); i++){
-      HitReferences newHitPlaneMap = tmpHitPlaneMap;
-      newHitPlaneMap[mapIterator->first] = i;
-      PointInPlaneList newVector = tmpHitVector;
-      newVector.push_back(mapIterator->second[i]);
-      std::map<CTPPSPixelDetId, PointInPlaneList >::iterator tmpMapIterator = mapIterator;
-      getHitCombinations(mapOfAllHits, ++tmpMapIterator, newHitPlaneMap, newVector, outputMap);
-    }
+void RPixPlaneCombinatoryTracking::getHitCombinations(const std::map<CTPPSPixelDetId, PointInPlaneList> &mapOfAllHits,
+                                                      std::map<CTPPSPixelDetId, PointInPlaneList>::iterator mapIterator,
+                                                      HitReferences tmpHitPlaneMap,
+                                                      const PointInPlaneList &tmpHitVector,
+                                                      PointAndReferenceMap &outputMap) {
+  //At this point I selected one hit per plane
+  if (mapIterator == mapOfAllHits.end()) {
+    outputMap[tmpHitPlaneMap] = tmpHitVector;
+    return;
+  }
+  for (size_t i = 0; i < mapIterator->second.size(); i++) {
+    HitReferences newHitPlaneMap = tmpHitPlaneMap;
+    newHitPlaneMap[mapIterator->first] = i;
+    PointInPlaneList newVector = tmpHitVector;
+    newVector.push_back(mapIterator->second[i]);
+    std::map<CTPPSPixelDetId, PointInPlaneList>::iterator tmpMapIterator = mapIterator;
+    getHitCombinations(mapOfAllHits, ++tmpMapIterator, newHitPlaneMap, newVector, outputMap);
+  }
 }
 
 //------------------------------------------------------------------------------------------------//
 
-RPixPlaneCombinatoryTracking::PointAndReferenceMap
-RPixPlaneCombinatoryTracking::produceAllHitCombination(PlaneCombinations inputPlaneCombination){
-  
+RPixPlaneCombinatoryTracking::PointAndReferenceMap RPixPlaneCombinatoryTracking::produceAllHitCombination(
+    PlaneCombinations inputPlaneCombination) {
   PointAndReferenceMap mapOfAllPoints;
-  CTPPSPixelDetId tmpRpId = romanPotId_; //in order to avoid to modify the data member
-  
-  if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Searching for all combinations...";
-  //Loop on all the plane combinations
-  for( const auto & planeCombination : inputPlaneCombination){
+  CTPPSPixelDetId tmpRpId = romanPotId_;  //in order to avoid to modify the data member
 
-    std::map<CTPPSPixelDetId, PointInPlaneList > selectedCombinationHitOnPlane;
+  if (verbosity_ >= 2)
+    edm::LogInfo("RPixPlaneCombinatoryTracking") << "Searching for all combinations...";
+  //Loop on all the plane combinations
+  for (const auto &planeCombination : inputPlaneCombination) {
+    std::map<CTPPSPixelDetId, PointInPlaneList> selectedCombinationHitOnPlane;
     bool allPlaneAsHits = true;
 
     //Loop on all the possible combinations
-    //In this loop the selectedCombinationHitOnPlane is filled 
+    //In this loop the selectedCombinationHitOnPlane is filled
     //and cases in which one of the selected plane is empty are skipped
-    for( const auto & plane : planeCombination){
+    for (const auto &plane : planeCombination) {
       tmpRpId.setPlane(plane);
       CTPPSPixelDetId planeDetId = tmpRpId;
-      if(hitMap_->find(planeDetId) == hitMap_->end()){
-        if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"No data on arm "<<planeDetId.arm()<<" station "<<planeDetId.station()
-                                  <<" rp " <<planeDetId.rp()<<" plane "<<planeDetId.plane();
+      if (hitMap_->find(planeDetId) == hitMap_->end()) {
+        if (verbosity_ >= 2)
+          edm::LogInfo("RPixPlaneCombinatoryTracking")
+              << "No data on arm " << planeDetId.arm() << " station " << planeDetId.station() << " rp "
+              << planeDetId.rp() << " plane " << planeDetId.plane();
         allPlaneAsHits = false;
         break;
       }
-      if(selectedCombinationHitOnPlane.find(planeDetId)!=selectedCombinationHitOnPlane.end()){
-           throw cms::Exception("RPixPlaneCombinatoryTracking") 
-             <<"selectedCombinationHitOnPlane contains already detId "<<planeDetId
-             <<"Error in the algorithm which created all the possible plane combinations";
+      if (selectedCombinationHitOnPlane.find(planeDetId) != selectedCombinationHitOnPlane.end()) {
+        throw cms::Exception("RPixPlaneCombinatoryTracking")
+            << "selectedCombinationHitOnPlane contains already detId " << planeDetId
+            << "Error in the algorithm which created all the possible plane combinations";
       }
       selectedCombinationHitOnPlane[planeDetId] = (*hitMap_)[planeDetId];
     }
-    if(!allPlaneAsHits) continue;
-    
-    //I add the all the hit combinations to the full list of plane combinations
-    auto mapIterator=selectedCombinationHitOnPlane.begin();
-    HitReferences tmpHitPlaneMap; //empty map of plane id and hit number needed the getHitCombinations algorithm
-    PointInPlaneList tmpHitVector; //empty vector of hits needed for the getHitCombinations algorithm
-    getHitCombinations(selectedCombinationHitOnPlane,mapIterator,tmpHitPlaneMap,tmpHitVector,mapOfAllPoints);
-    if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Number of possible tracks "<<mapOfAllPoints.size();
+    if (!allPlaneAsHits)
+      continue;
 
-  } //end of loops on all the combinations
+    //I add the all the hit combinations to the full list of plane combinations
+    auto mapIterator = selectedCombinationHitOnPlane.begin();
+    HitReferences tmpHitPlaneMap;   //empty map of plane id and hit number needed the getHitCombinations algorithm
+    PointInPlaneList tmpHitVector;  //empty vector of hits needed for the getHitCombinations algorithm
+    getHitCombinations(selectedCombinationHitOnPlane, mapIterator, tmpHitPlaneMap, tmpHitVector, mapOfAllPoints);
+    if (verbosity_ >= 2)
+      edm::LogInfo("RPixPlaneCombinatoryTracking") << "Number of possible tracks " << mapOfAllPoints.size();
+
+  }  //end of loops on all the combinations
 
   return mapOfAllPoints;
-
 }
 
 //------------------------------------------------------------------------------------------------//
 
-void RPixPlaneCombinatoryTracking::findTracks(int run){
-
+void RPixPlaneCombinatoryTracking::findTracks(int run) {
   //The loop search for all the possible tracks starting from the one with the smallest chiSquare/NDF
   //The loop stops when the number of planes with recorded hits is less than the minimum number of planes required
   //or if the track with minimum chiSquare found has a chiSquare higher than the maximum required
 
-  while(hitMap_->size()>=trackMinNumberOfPoints_){
+  while (hitMap_->size() >= trackMinNumberOfPoints_) {
+    if (verbosity_ >= 1)
+      edm::LogInfo("RPixPlaneCombinatoryTracking") << "Number of plane with hits " << hitMap_->size();
+    if (verbosity_ >= 2)
+      for (const auto &plane : *hitMap_)
+        edm::LogInfo("RPixPlaneCombinatoryTracking")
+            << "\tarm " << plane.first.arm() << " station " << plane.first.station() << " rp " << plane.first.rp()
+            << " plane " << plane.first.plane() << " : " << plane.second.size();
 
-    if(verbosity_>=1) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Number of plane with hits "<<hitMap_->size();
-    if(verbosity_>=2) for(const auto & plane : *hitMap_) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"\tarm "<<plane.first.arm()
-                                                                 <<" station "<<plane.first.station()
-                                                                 <<" rp " <<plane.first.rp()
-                                                                 <<" plane "<<plane.first.plane()
-                                                                 <<" : "<<plane.second.size();
-    
     //I create the map of all the possible combinations of a group of trackMinNumberOfPoints_ points
     //and the key keeps the reference of which planes and which hit numbers form the combination
     PointAndReferenceMap mapOfAllMinRequiredPoint;
@@ -182,19 +178,22 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
     mapOfAllMinRequiredPoint = produceAllHitCombination(possiblePlaneCombinations_);
 
     //Fit all the possible combinations with minimum number of planes required and find the track with minimum chi2
-    double theMinChiSquaredOverNDF = maximumChi2OverNDF_+1.; //in order to break the loop in case no track is found;
+    double theMinChiSquaredOverNDF = maximumChi2OverNDF_ + 1.;  //in order to break the loop in case no track is found;
     HitReferences pointMapWithMinChiSquared;
     PointInPlaneList pointsWithMinChiSquared;
     CTPPSPixelLocalTrack bestTrack;
 
-    if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Number of combinations of trackMinNumberOfPoints_ planes "
-                              <<mapOfAllMinRequiredPoint.size();
-    for(const auto & pointsAndRef : mapOfAllMinRequiredPoint){
+    if (verbosity_ >= 2)
+      edm::LogInfo("RPixPlaneCombinatoryTracking")
+          << "Number of combinations of trackMinNumberOfPoints_ planes " << mapOfAllMinRequiredPoint.size();
+    for (const auto &pointsAndRef : mapOfAllMinRequiredPoint) {
       CTPPSPixelLocalTrack tmpTrack = fitTrack(pointsAndRef.second);
       double tmpChiSquaredOverNDF = tmpTrack.getChiSquaredOverNDF();
-      if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"ChiSquare of the present track "<<tmpChiSquaredOverNDF;
-      if(!tmpTrack.isValid() || tmpChiSquaredOverNDF>maximumChi2OverNDF_ || tmpChiSquaredOverNDF==0.) continue; //validity check
-      if(tmpChiSquaredOverNDF<theMinChiSquaredOverNDF){
+      if (verbosity_ >= 2)
+        edm::LogInfo("RPixPlaneCombinatoryTracking") << "ChiSquare of the present track " << tmpChiSquaredOverNDF;
+      if (!tmpTrack.isValid() || tmpChiSquaredOverNDF > maximumChi2OverNDF_ || tmpChiSquaredOverNDF == 0.)
+        continue;  //validity check
+      if (tmpChiSquaredOverNDF < theMinChiSquaredOverNDF) {
         theMinChiSquaredOverNDF = tmpChiSquaredOverNDF;
         pointMapWithMinChiSquared = pointsAndRef.first;
         pointsWithMinChiSquared = pointsAndRef.second;
@@ -204,25 +203,27 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
 
     //The loop on the fit of all tracks is done, the track with minimum chiSquared is found
     // and it is verified that it complies with the maximumChi2OverNDF_ requirement
-    if(theMinChiSquaredOverNDF > maximumChi2OverNDF_) break;
+    if (theMinChiSquaredOverNDF > maximumChi2OverNDF_)
+      break;
 
     //The list of planes not included in the minimum chiSquare track is produced.
-    std::vector<uint32_t>  listOfExcludedPlanes;
-    for(const auto & plane : listOfAllPlanes_){
-      CTPPSPixelDetId tmpRpId = romanPotId_; //in order to avoid to modify the data member
+    std::vector<uint32_t> listOfExcludedPlanes;
+    for (const auto &plane : listOfAllPlanes_) {
+      CTPPSPixelDetId tmpRpId = romanPotId_;  //in order to avoid to modify the data member
       tmpRpId.setPlane(plane);
       CTPPSPixelDetId planeDetId = tmpRpId;
-      if(pointMapWithMinChiSquared.find(planeDetId)==pointMapWithMinChiSquared.end()) 
+      if (pointMapWithMinChiSquared.find(planeDetId) == pointMapWithMinChiSquared.end())
         listOfExcludedPlanes.push_back(plane);
     }
 
     //I produce all the possible combinations of planes to be added to the track,
     //excluding the case of no other plane added since it has been already fitted.
     PlaneCombinations planePointedHitListCombination;
-    for(uint32_t i=1; i<=listOfExcludedPlanes.size(); ++i){
+    for (uint32_t i = 1; i <= listOfExcludedPlanes.size(); ++i) {
       PlaneCombinations tmpPlaneCombination;
-      getPlaneCombinations(listOfExcludedPlanes,i,tmpPlaneCombination);
-      for(const auto & combination : tmpPlaneCombination) planePointedHitListCombination.push_back(combination);
+      getPlaneCombinations(listOfExcludedPlanes, i, tmpPlaneCombination);
+      for (const auto &combination : tmpPlaneCombination)
+        planePointedHitListCombination.push_back(combination);
     }
 
     //I produce all the possible combinations of points to be added to the track
@@ -230,32 +231,38 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
     PointAndReferenceMap mapOfPointCombinationToBeAdded;
     mapOfPointCombinationToBeAdded = produceAllHitCombination(planePointedHitListCombination);
     //The found hit combination is added to the hits selected by the best fit;
-    for(const auto & element : mapOfPointCombinationToBeAdded){
-      HitReferences newPointMap = pointMapWithMinChiSquared; 
+    for (const auto &element : mapOfPointCombinationToBeAdded) {
+      HitReferences newPointMap = pointMapWithMinChiSquared;
       PointInPlaneList newPoints = pointsWithMinChiSquared;
-      for(const auto & pointRef : element.first ) newPointMap[pointRef.first] = pointRef.second; //add the new point reference
-      for(const auto & point    : element.second) newPoints.push_back(point);
-      mapOfAllPointWithAtLeastBestFitSelected[newPointMap]=newPoints;
+      for (const auto &pointRef : element.first)
+        newPointMap[pointRef.first] = pointRef.second;  //add the new point reference
+      for (const auto &point : element.second)
+        newPoints.push_back(point);
+      mapOfAllPointWithAtLeastBestFitSelected[newPointMap] = newPoints;
     }
-  
+
     //I fit all the possible combination of the minimum plane best fit hits plus hits from the other planes
-    if(verbosity_>=1) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Minimum chiSquare over NDF for all the tracks "<<theMinChiSquaredOverNDF;
+    if (verbosity_ >= 1)
+      edm::LogInfo("RPixPlaneCombinatoryTracking")
+          << "Minimum chiSquare over NDF for all the tracks " << theMinChiSquaredOverNDF;
 
     // I look for the tracks with maximum number of points with a chiSquare over NDF smaller than maximumChi2OverNDF_
     // If more than one track fulfill the chiSquare requirement with the same number of points I choose the one with smaller chiSquare
-    std::vector<PointAndReferencePair > orderedVectorOfAllPointWithAtLeastBestFitSelected =
-      orderCombinationsPerNumberOrPoints(mapOfAllPointWithAtLeastBestFitSelected);
+    std::vector<PointAndReferencePair> orderedVectorOfAllPointWithAtLeastBestFitSelected =
+        orderCombinationsPerNumberOrPoints(mapOfAllPointWithAtLeastBestFitSelected);
     int currentNumberOfPlanes = 0;
-    theMinChiSquaredOverNDF = maximumChi2OverNDF_+1.; //in order to break the loop in case no track is found;
+    theMinChiSquaredOverNDF = maximumChi2OverNDF_ + 1.;  //in order to break the loop in case no track is found;
     bool foundTrackWithCurrentNumberOfPlanes = false;
-    for(const auto & pointsAndRef : orderedVectorOfAllPointWithAtLeastBestFitSelected){
+    for (const auto &pointsAndRef : orderedVectorOfAllPointWithAtLeastBestFitSelected) {
       int tmpNumberOfPlanes = pointsAndRef.second.size();
       // If a valid track has been already found with an higher number of planes the loop stops.
-      if(foundTrackWithCurrentNumberOfPlanes && tmpNumberOfPlanes<currentNumberOfPlanes) break;
+      if (foundTrackWithCurrentNumberOfPlanes && tmpNumberOfPlanes < currentNumberOfPlanes)
+        break;
       CTPPSPixelLocalTrack tmpTrack = fitTrack(pointsAndRef.second);
       double tmpChiSquaredOverNDF = tmpTrack.getChiSquaredOverNDF();
-      if(!tmpTrack.isValid() || tmpChiSquaredOverNDF>maximumChi2OverNDF_ || tmpChiSquaredOverNDF==0.) continue; //validity check
-      if(tmpChiSquaredOverNDF<theMinChiSquaredOverNDF){
+      if (!tmpTrack.isValid() || tmpChiSquaredOverNDF > maximumChi2OverNDF_ || tmpChiSquaredOverNDF == 0.)
+        continue;  //validity check
+      if (tmpChiSquaredOverNDF < theMinChiSquaredOverNDF) {
         theMinChiSquaredOverNDF = tmpChiSquaredOverNDF;
         pointMapWithMinChiSquared = pointsAndRef.first;
         bestTrack = tmpTrack;
@@ -264,79 +271,85 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
       }
     }
 
-    if(verbosity_>=1) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"The best track has " << bestTrack.getNDF()/2 + 2 ;
-   
-    std::vector<uint32_t>  listOfPlaneNotUsedForFit = listOfAllPlanes_;
+    if (verbosity_ >= 1)
+      edm::LogInfo("RPixPlaneCombinatoryTracking") << "The best track has " << bestTrack.getNDF() / 2 + 2;
+
+    std::vector<uint32_t> listOfPlaneNotUsedForFit = listOfAllPlanes_;
     //remove the hits belonging to the tracks from the full list of hits
-    for(const auto & hitToErase : pointMapWithMinChiSquared){
-      std::map<CTPPSPixelDetId, PointInPlaneList >::iterator hitMapElement = hitMap_->find(hitToErase.first);
-      if(hitMapElement==hitMap_->end()){
-           throw cms::Exception("RPixPlaneCombinatoryTracking") 
-             <<"The found tracks has hit belonging to a plane which does not have hits";
+    for (const auto &hitToErase : pointMapWithMinChiSquared) {
+      std::map<CTPPSPixelDetId, PointInPlaneList>::iterator hitMapElement = hitMap_->find(hitToErase.first);
+      if (hitMapElement == hitMap_->end()) {
+        throw cms::Exception("RPixPlaneCombinatoryTracking")
+            << "The found tracks has hit belonging to a plane which does not have hits";
       }
       std::vector<uint32_t>::iterator planeIt;
-      planeIt = std::find (listOfPlaneNotUsedForFit.begin(), listOfPlaneNotUsedForFit.end(), hitToErase.first.plane());
+      planeIt = std::find(listOfPlaneNotUsedForFit.begin(), listOfPlaneNotUsedForFit.end(), hitToErase.first.plane());
       listOfPlaneNotUsedForFit.erase(planeIt);
-      hitMapElement->second.erase(hitMapElement->second.begin()+hitToErase.second);
+      hitMapElement->second.erase(hitMapElement->second.begin() + hitToErase.second);
       //if the plane at which the hit was erased is empty it is removed from the hit map
-      if(hitMapElement->second.empty()) hitMap_->erase(hitMapElement);
+      if (hitMapElement->second.empty())
+        hitMap_->erase(hitMapElement);
     }
 
     //search for hit on the other planes which may belong to the same track
     //even if they did not contributed to the track
     //in case of multiple hit, the closest one to the track will be considered
     //If a hit is found these will not be erased from the list of all hits
-    //If no hit is found, the point on the plane intersecting the track will be saved by a CTPPSPixelFittedRecHit 
+    //If no hit is found, the point on the plane intersecting the track will be saved by a CTPPSPixelFittedRecHit
     //with the isRealHit_ flag set to false
-    for(const auto & plane : listOfPlaneNotUsedForFit){
-      CTPPSPixelDetId tmpPlaneId = romanPotId_; //in order to avoid to modify the data member
+    for (const auto &plane : listOfPlaneNotUsedForFit) {
+      CTPPSPixelDetId tmpPlaneId = romanPotId_;  //in order to avoid to modify the data member
       tmpPlaneId.setPlane(plane);
-      std::unique_ptr<CTPPSPixelFittedRecHit> 
-        fittedRecHit(new CTPPSPixelFittedRecHit());
+      std::unique_ptr<CTPPSPixelFittedRecHit> fittedRecHit(new CTPPSPixelFittedRecHit());
       GlobalPoint pointOnDet;
       calculatePointOnDetector(&bestTrack, tmpPlaneId, pointOnDet);
 
-
-      if(hitMap_->find(tmpPlaneId) != hitMap_->end()){
+      if (hitMap_->find(tmpPlaneId) != hitMap_->end()) {
         //I convert the hit search window defined in local coordinated into global
-        //This avoids to convert the global plane-line intersection in order not to call the the geometry 
-        math::Vector<3>::type maxGlobalPointDistance(maximumXLocalDistanceFromTrack_,maximumYLocalDistanceFromTrack_,0.);
-        
+        //This avoids to convert the global plane-line intersection in order not to call the the geometry
+        math::Vector<3>::type maxGlobalPointDistance(
+            maximumXLocalDistanceFromTrack_, maximumYLocalDistanceFromTrack_, 0.);
+
         DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(tmpPlaneId)->rotation();
         AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
-        theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0), tmpPlaneRotationMatrixMap(0, 1), tmpPlaneRotationMatrixMap(0, 2),
-                                        tmpPlaneRotationMatrixMap(1, 0), tmpPlaneRotationMatrixMap(1, 1), tmpPlaneRotationMatrixMap(1, 2),
-                                        tmpPlaneRotationMatrixMap(2, 0), tmpPlaneRotationMatrixMap(2, 1), tmpPlaneRotationMatrixMap(2, 2));
+        theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0),
+                                        tmpPlaneRotationMatrixMap(0, 1),
+                                        tmpPlaneRotationMatrixMap(0, 2),
+                                        tmpPlaneRotationMatrixMap(1, 0),
+                                        tmpPlaneRotationMatrixMap(1, 1),
+                                        tmpPlaneRotationMatrixMap(1, 2),
+                                        tmpPlaneRotationMatrixMap(2, 0),
+                                        tmpPlaneRotationMatrixMap(2, 1),
+                                        tmpPlaneRotationMatrixMap(2, 2));
 
         maxGlobalPointDistance = tmpPlaneRotationMatrixMap * maxGlobalPointDistance;
         //I avoid the Sqrt since it will not be saved
-        double maximumXdistance = maxGlobalPointDistance[0]*maxGlobalPointDistance[0];
-        double maximumYdistance = maxGlobalPointDistance[1]*maxGlobalPointDistance[1];
-        double minimumDistance = 1. + maximumXdistance + maximumYdistance; // to be sure that the first min distance is from a real point
-        for(const auto & hit : (*hitMap_)[tmpPlaneId]){
+        double maximumXdistance = maxGlobalPointDistance[0] * maxGlobalPointDistance[0];
+        double maximumYdistance = maxGlobalPointDistance[1] * maxGlobalPointDistance[1];
+        double minimumDistance =
+            1. + maximumXdistance + maximumYdistance;  // to be sure that the first min distance is from a real point
+        for (const auto &hit : (*hitMap_)[tmpPlaneId]) {
           double xResidual = hit.globalPoint.x() - pointOnDet.x();
           double yResidual = hit.globalPoint.y() - pointOnDet.y();
-          double xDistance = xResidual*xResidual;
-          double yDistance = yResidual*yResidual;
+          double xDistance = xResidual * xResidual;
+          double yDistance = yResidual * yResidual;
           double distance = xDistance + yDistance;
-          if(xDistance < maximumXdistance && yDistance < maximumYdistance && distance < minimumDistance){
-            LocalPoint residuals(xResidual,yResidual,0.);
+          if (xDistance < maximumXdistance && yDistance < maximumYdistance && distance < minimumDistance) {
+            LocalPoint residuals(xResidual, yResidual, 0.);
             math::Error<3>::type globalError = hit.globalError;
-            LocalPoint pulls(xResidual/std::sqrt(globalError[0][0]),yResidual/std::sqrt(globalError[1][1]),0.);
+            LocalPoint pulls(xResidual / std::sqrt(globalError[0][0]), yResidual / std::sqrt(globalError[1][1]), 0.);
             fittedRecHit.reset(new CTPPSPixelFittedRecHit(hit.recHit, pointOnDet, residuals, pulls));
             fittedRecHit->setIsRealHit(true);
           }
         }
-      }
-      else{
+      } else {
         LocalPoint fakePoint;
         LocalError fakeError;
-        CTPPSPixelRecHit fakeRecHit(fakePoint,fakeError);
+        CTPPSPixelRecHit fakeRecHit(fakePoint, fakeError);
         fittedRecHit.reset(new CTPPSPixelFittedRecHit(fakeRecHit, pointOnDet, fakePoint, fakePoint));
       }
 
       bestTrack.addHit(tmpPlaneId, *fittedRecHit);
-  
     }
 
     localTrackVector_.push_back(bestTrack);
@@ -344,24 +357,24 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
     int pointForTracking = 0;
     int pointOnTrack = 0;
 
-    if(verbosity_>=1){
-      for(const auto & planeHits : bestTrack.getHits()){
-        for(const auto & fittedhit : planeHits){
-          if(fittedhit.getIsUsedForFit()) ++pointForTracking;
-          if(fittedhit.getIsRealHit()) ++pointOnTrack;
+    if (verbosity_ >= 1) {
+      for (const auto &planeHits : bestTrack.getHits()) {
+        for (const auto &fittedhit : planeHits) {
+          if (fittedhit.getIsUsedForFit())
+            ++pointForTracking;
+          if (fittedhit.getIsRealHit())
+            ++pointOnTrack;
         }
       }
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Best track has "<<pointForTracking<<" points used for the fit and "
-               << pointOnTrack<<" points belonging to the track\n";
+      edm::LogInfo("RPixPlaneCombinatoryTracking")
+          << "Best track has " << pointForTracking << " points used for the fit and " << pointOnTrack
+          << " points belonging to the track\n";
     }
 
-
-    
-  } //close of the while loop on all the hits
-
+  }  //close of the while loop on all the hits
 
   // recoInfo_ calculation
-  // Hardcoded shift periods: 
+  // Hardcoded shift periods:
   // Before run 300802: No shift
   // Starting from run 300802: Sec45 St2 Rp3 Pl 0,2,3 ROC 0 shifted.
   // Starting from run 303338: No shift.
@@ -371,62 +384,56 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
 
   // These variables hold the information of the runs when the detector was taking data in 3+3 Mode and which planes were bx-shifted
   // These values will never be changed and the 3+3 Mode will never be used again in the future
-  const CTPPSPixelDetId rpId_arm0_st2 = CTPPSPixelDetId(0,2,3);
-  const CTPPSPixelDetId rpId_arm1_st2 = CTPPSPixelDetId(1,2,3);
-  static const std::map< unsigned int, std::map< CTPPSPixelDetId,std::vector<bool> > > isPlaneShifted =
-  {
-    {
-      0,{
-        {rpId_arm0_st2,{false,false,false,false,false,false}}, // Shift Period 0 Sec45
-        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 1 Sec56
-      }
-    },
-    {
-      300802,{
-        {rpId_arm0_st2,{true,false,true,true,false,false}}, // Shift Period 1 Sec45
-        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 1 Sec56
-      }
-    },
-    {
-      303338,{
-        {rpId_arm0_st2,{false,false,false,false,false,false}}, // Shift Period 2 Sec45
-        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 2 Sec56
-      }
-    },
-    {
-      305169,{
-        {rpId_arm0_st2,{false,true,false,true,false,true}}, // Shift Period 3 Sec45
-        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 3 Sec56
-      }
-    },
-    {
-      305965,{
-        {rpId_arm0_st2,{false,true,false,true,false,true}}, // Shift Period 4 Sec45
-        {rpId_arm1_st2,{false,false,true,false,true,true}}  // Shift Period 4 Sec56
-      }
-    },
-    {
-      307083,{
-        {rpId_arm0_st2,{false,false,false,false,false,false}}, // Shift Period 0 Sec45
-        {rpId_arm1_st2,{false,false,false,false,false,false}}  // Shift Period 1 Sec56
-      }
-    }
-  }; // map< shiftedPeriod, map<DetID,shiftScheme> >
-  const auto& shiftStatusInitialRun = std::prev(isPlaneShifted.upper_bound(run));
+  const CTPPSPixelDetId rpId_arm0_st2 = CTPPSPixelDetId(0, 2, 3);
+  const CTPPSPixelDetId rpId_arm1_st2 = CTPPSPixelDetId(1, 2, 3);
+  static const std::map<unsigned int, std::map<CTPPSPixelDetId, std::vector<bool> > > isPlaneShifted = {
+      {0,
+       {
+           {rpId_arm0_st2, {false, false, false, false, false, false}},  // Shift Period 0 Sec45
+           {rpId_arm1_st2, {false, false, false, false, false, false}}   // Shift Period 1 Sec56
+       }},
+      {300802,
+       {
+           {rpId_arm0_st2, {true, false, true, true, false, false}},    // Shift Period 1 Sec45
+           {rpId_arm1_st2, {false, false, false, false, false, false}}  // Shift Period 1 Sec56
+       }},
+      {303338,
+       {
+           {rpId_arm0_st2, {false, false, false, false, false, false}},  // Shift Period 2 Sec45
+           {rpId_arm1_st2, {false, false, false, false, false, false}}   // Shift Period 2 Sec56
+       }},
+      {305169,
+       {
+           {rpId_arm0_st2, {false, true, false, true, false, true}},    // Shift Period 3 Sec45
+           {rpId_arm1_st2, {false, false, false, false, false, false}}  // Shift Period 3 Sec56
+       }},
+      {305965,
+       {
+           {rpId_arm0_st2, {false, true, false, true, false, true}},  // Shift Period 4 Sec45
+           {rpId_arm1_st2, {false, false, true, false, true, true}}   // Shift Period 4 Sec56
+       }},
+      {307083,
+       {
+           {rpId_arm0_st2, {false, false, false, false, false, false}},  // Shift Period 0 Sec45
+           {rpId_arm1_st2, {false, false, false, false, false, false}}   // Shift Period 1 Sec56
+       }}};                                                              // map< shiftedPeriod, map<DetID,shiftScheme> >
+  const auto &shiftStatusInitialRun = std::prev(isPlaneShifted.upper_bound(run));
   unsigned short shiftedROC = 10;
   CTPPSPixelIndices pixelIndices;
 
   // Selecting the shifted ROC
-  if(romanPotId_.arm() == 0) shiftedROC = 0;
-  if(romanPotId_.arm() == 1) shiftedROC = 5;
+  if (romanPotId_.arm() == 0)
+    shiftedROC = 0;
+  if (romanPotId_.arm() == 1)
+    shiftedROC = 5;
 
   // Loop over found tracks to set recoInfo_
-  for(auto & track : localTrackVector_){
-    if(romanPotId_ != rpId_arm0_st2 && romanPotId_ != rpId_arm1_st2){
+  for (auto &track : localTrackVector_) {
+    if (romanPotId_ != rpId_arm0_st2 && romanPotId_ != rpId_arm1_st2) {
       track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);
-      if(verbosity_>=2) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"Analyzing run: "<<run
-        <<"\nTrack belongs to Arm "<<romanPotId_.arm()<<" Station "
-        <<romanPotId_.station();
+      if (verbosity_ >= 2)
+        edm::LogInfo("RPixPlaneCombinatoryTracking") << "Analyzing run: " << run << "\nTrack belongs to Arm "
+                                                     << romanPotId_.arm() << " Station " << romanPotId_.station();
 
       continue;
     }
@@ -434,83 +441,101 @@ void RPixPlaneCombinatoryTracking::findTracks(int run){
     unsigned short bxNonShiftedPlanesUsed = 0;
     unsigned short hitInShiftedROC = 0;
 
-    auto const& fittedHits = track.getHits();
-    auto const& planeFlags = (shiftStatusInitialRun->second).at(romanPotId_);
+    auto const &fittedHits = track.getHits();
+    auto const &planeFlags = (shiftStatusInitialRun->second).at(romanPotId_);
 
-    for(const auto & planeHits : fittedHits){
+    for (const auto &planeHits : fittedHits) {
       unsigned short plane = CTPPSPixelDetId(planeHits.detId()).plane();
-      for(const auto & hit : planeHits){
-        if(hit.getIsUsedForFit()){
-          if(pixelIndices.getROCId(hit.minPixelCol(),hit.minPixelRow()) == shiftedROC) hitInShiftedROC++; // Count how many hits are in the shifted ROC
-          if(planeFlags.at(plane)) bxShiftedPlanesUsed++; // Count how many bx-shifted planes are used
-          else if(planeFlags != std::vector<bool>(6,false)) bxNonShiftedPlanesUsed++; // Count how many non-bx-shifted planes are used, only if there are shifted planes 
+      for (const auto &hit : planeHits) {
+        if (hit.getIsUsedForFit()) {
+          if (pixelIndices.getROCId(hit.minPixelCol(), hit.minPixelRow()) == shiftedROC)
+            hitInShiftedROC++;  // Count how many hits are in the shifted ROC
+          if (planeFlags.at(plane))
+            bxShiftedPlanesUsed++;  // Count how many bx-shifted planes are used
+          else if (planeFlags != std::vector<bool>(6, false))
+            bxNonShiftedPlanesUsed++;  // Count how many non-bx-shifted planes are used, only if there are shifted planes
         }
       }
     }
 
     // Set recoInfo_ value
-    track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::invalid); // Initially setting it as invalid. It has to match one of the following options.
-    if(hitInShiftedROC < 3) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);
-    else{
-      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);    // Default value for runs without bx-shift
-      if(bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::allShiftedPlanes); // Track reconstructed in a shifted ROC, only with bx-shifted planes
-      if(bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
-      if(bxShiftedPlanesUsed >  0 && bxNonShiftedPlanesUsed >  0) track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::mixedPlanes);      // Track reconstructed in a shifted ROC, with mixed planes
+    track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::
+                          invalid);  // Initially setting it as invalid. It has to match one of the following options.
+    if (hitInShiftedROC < 3)
+      track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);
+    else {
+      if (bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 0)
+        track.setRecoInfo(
+            CTPPSpixelLocalTrackReconstructionInfo::notShiftedRun);  // Default value for runs without bx-shift
+      if (bxShiftedPlanesUsed == 3 && bxNonShiftedPlanesUsed == 0)
+        track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::
+                              allShiftedPlanes);  // Track reconstructed in a shifted ROC, only with bx-shifted planes
+      if (bxShiftedPlanesUsed == 0 && bxNonShiftedPlanesUsed == 3)
+        track.setRecoInfo(
+            CTPPSpixelLocalTrackReconstructionInfo::
+                noShiftedPlanes);  // Track reconstructed in a shifted ROC, only with non-bx-shifted planes
+      if (bxShiftedPlanesUsed > 0 && bxNonShiftedPlanesUsed > 0)
+        track.setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo::
+                              mixedPlanes);  // Track reconstructed in a shifted ROC, with mixed planes
     }
-    if(bxShiftedPlanesUsed + bxNonShiftedPlanesUsed > 6){
-      throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "More than six points found for a track, skipping.";
+    if (bxShiftedPlanesUsed + bxNonShiftedPlanesUsed > 6) {
+      throw cms::Exception("RPixPlaneCombinatoryTracking") << "Error in RPixPlaneCombinatoryTracking::findTracks -> "
+                                                           << "More than six points found for a track, skipping.";
       continue;
     }
-    if(track.getRecoInfo() == CTPPSpixelLocalTrackReconstructionInfo::invalid){
-      throw cms::Exception("RPixPlaneCombinatoryTracking")<<"Error in RPixPlaneCombinatoryTracking::findTracks -> " << "recoInfo has not been set properly.";
+    if (track.getRecoInfo() == CTPPSpixelLocalTrackReconstructionInfo::invalid) {
+      throw cms::Exception("RPixPlaneCombinatoryTracking") << "Error in RPixPlaneCombinatoryTracking::findTracks -> "
+                                                           << "recoInfo has not been set properly.";
     }
 
-    if(verbosity_>=2){
-      edm::LogInfo("RPixPlaneCombinatoryTracking")<<" Track belongs to Arm "<<romanPotId_.arm()<<" Station "<<romanPotId_.station()<<"\nFirst run with this bx-shift configuration: "
-      << shiftStatusInitialRun->first<<"\nTrack reconstructed with: "<<bxShiftedPlanesUsed<<" bx-shifted planes, "<<bxNonShiftedPlanesUsed<<" non-bx-shifted planes, "<<hitInShiftedROC
-      <<" hits in the bx-shifted ROC"<<"\nrecoInfo = "<<(unsigned short)track.getRecoInfo();
-      if(planeFlags != std::vector<bool>(6,false)) edm::LogInfo("RPixPlaneCombinatoryTracking")<<"The shifted ROC is ROC"<<shiftedROC;
+    if (verbosity_ >= 2) {
+      edm::LogInfo("RPixPlaneCombinatoryTracking")
+          << " Track belongs to Arm " << romanPotId_.arm() << " Station " << romanPotId_.station()
+          << "\nFirst run with this bx-shift configuration: " << shiftStatusInitialRun->first
+          << "\nTrack reconstructed with: " << bxShiftedPlanesUsed << " bx-shifted planes, " << bxNonShiftedPlanesUsed
+          << " non-bx-shifted planes, " << hitInShiftedROC << " hits in the bx-shifted ROC"
+          << "\nrecoInfo = " << (unsigned short)track.getRecoInfo();
+      if (planeFlags != std::vector<bool>(6, false))
+        edm::LogInfo("RPixPlaneCombinatoryTracking") << "The shifted ROC is ROC" << shiftedROC;
     }
   }
   return;
-
 }
 
 //------------------------------------------------------------------------------------------------//
 
-CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList pointList){
-  
+CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList pointList) {
   uint32_t const numberOfPlanes = 6;
-  math::Vector<2*numberOfPlanes>::type xyCoordinates;
-  math::Error<2*numberOfPlanes>::type varianceMatrix;
-  math::Matrix<2*numberOfPlanes, 4>::type zMatrix;
-  
+  math::Vector<2 * numberOfPlanes>::type xyCoordinates;
+  math::Error<2 * numberOfPlanes>::type varianceMatrix;
+  math::Matrix<2 * numberOfPlanes, 4>::type zMatrix;
+
   //The matrices and vector xyCoordinates, varianceMatrix and varianceMatrix are built from the points
-  for(uint32_t iHit = 0; iHit < numberOfPlanes; iHit++) {
+  for (uint32_t iHit = 0; iHit < numberOfPlanes; iHit++) {
     if (iHit < pointList.size()) {
       CLHEP::Hep3Vector globalPoint = pointList[iHit].globalPoint;
-      xyCoordinates[2*iHit]        = globalPoint.x()    ;
-      xyCoordinates[2*iHit + 1]    = globalPoint.y()    ;
-      zMatrix      (2*iHit, 0)     = 1.                 ;
-      zMatrix      (2*iHit, 2)     = globalPoint.z()-z0_;
-      zMatrix      (2*iHit + 1, 1) = 1.                 ;
-      zMatrix      (2*iHit+ 1 , 3) = globalPoint.z()-z0_;
-      
+      xyCoordinates[2 * iHit] = globalPoint.x();
+      xyCoordinates[2 * iHit + 1] = globalPoint.y();
+      zMatrix(2 * iHit, 0) = 1.;
+      zMatrix(2 * iHit, 2) = globalPoint.z() - z0_;
+      zMatrix(2 * iHit + 1, 1) = 1.;
+      zMatrix(2 * iHit + 1, 3) = globalPoint.z() - z0_;
+
       AlgebraicMatrix33 globalError = pointList[iHit].globalError;
-      varianceMatrix(2*iHit, 2*iHit)         = globalError(0, 0);
-      varianceMatrix(2*iHit, 2*iHit + 1)     = globalError(0, 1);
-      varianceMatrix(2*iHit + 1, 2*iHit)     = globalError(1, 0);
-      varianceMatrix(2*iHit + 1, 2*iHit + 1) = globalError(1, 1);
+      varianceMatrix(2 * iHit, 2 * iHit) = globalError(0, 0);
+      varianceMatrix(2 * iHit, 2 * iHit + 1) = globalError(0, 1);
+      varianceMatrix(2 * iHit + 1, 2 * iHit) = globalError(1, 0);
+      varianceMatrix(2 * iHit + 1, 2 * iHit + 1) = globalError(1, 1);
     } else {
-      varianceMatrix(2*iHit, 2*iHit)         = 1.;
-      varianceMatrix(2*iHit + 1, 2*iHit + 1) = 1.;
-    }    
+      varianceMatrix(2 * iHit, 2 * iHit) = 1.;
+      varianceMatrix(2 * iHit + 1, 2 * iHit + 1) = 1.;
+    }
   }
 
   //Get real point variance matrix
   if (!varianceMatrix.Invert()) {
     edm::LogError("RPixPlaneCombinatoryTracking") << "Error in RPixPlaneCombinatoryTracking::fitTrack -> "
-    << "Point variance matrix is singular, skipping.";
+                                                  << "Point variance matrix is singular, skipping.";
     CTPPSPixelLocalTrack badTrack;
     badTrack.setValid(false);
     return badTrack;
@@ -521,41 +546,40 @@ CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList poi
   //To have the real parameter covariance matrix, covarianceMatrix needs to be inverted
   if (!covarianceMatrix.Invert()) {
     edm::LogError("RPixPlaneCombinatoryTracking") << "Error in RPixPlaneCombinatoryTracking::fitTrack -> "
-    << "Parameter covariance matrix is singular, skipping.";
+                                                  << "Parameter covariance matrix is singular, skipping.";
     CTPPSPixelLocalTrack badTrack;
     badTrack.setValid(false);
     return badTrack;
   }
 
   // track parameters: (x0, y0, tx, ty); x = x0 + tx*(z-z0)
-  math::Vector<4>::type zMatrixTransposeTimesVarianceMatrixTimesXyCoordinates = 
-    ROOT::Math::Transpose(zMatrix) * varianceMatrix * xyCoordinates;
-  math::Vector<4>::type parameterVector = 
-    covarianceMatrix * zMatrixTransposeTimesVarianceMatrixTimesXyCoordinates;
-  math::Vector<2*numberOfPlanes>::type xyCoordinatesMinusZmatrixTimesParameters =
-    xyCoordinates - (zMatrix * parameterVector);
+  math::Vector<4>::type zMatrixTransposeTimesVarianceMatrixTimesXyCoordinates =
+      ROOT::Math::Transpose(zMatrix) * varianceMatrix * xyCoordinates;
+  math::Vector<4>::type parameterVector = covarianceMatrix * zMatrixTransposeTimesVarianceMatrixTimesXyCoordinates;
+  math::Vector<2 *numberOfPlanes>::type xyCoordinatesMinusZmatrixTimesParameters =
+      xyCoordinates - (zMatrix * parameterVector);
 
-  double chiSquare =
-    ROOT::Math::Dot(xyCoordinatesMinusZmatrixTimesParameters, (varianceMatrix * xyCoordinatesMinusZmatrixTimesParameters));
+  double chiSquare = ROOT::Math::Dot(xyCoordinatesMinusZmatrixTimesParameters,
+                                     (varianceMatrix * xyCoordinatesMinusZmatrixTimesParameters));
 
   CTPPSPixelLocalTrack goodTrack(z0_, parameterVector, covarianceMatrix, chiSquare);
   goodTrack.setValid(true);
 
-  for(const auto & hit : pointList){
+  for (const auto &hit : pointList) {
     CLHEP::Hep3Vector globalPoint = hit.globalPoint;
     GlobalPoint pointOnDet;
     bool foundPoint = calculatePointOnDetector(&goodTrack, hit.detId, pointOnDet);
-    if(!foundPoint){
+    if (!foundPoint) {
       CTPPSPixelLocalTrack badTrack;
       badTrack.setValid(false);
       return badTrack;
     }
     double xResidual = globalPoint.x() - pointOnDet.x();
     double yResidual = globalPoint.y() - pointOnDet.y();
-    LocalPoint residuals(xResidual,yResidual);
+    LocalPoint residuals(xResidual, yResidual);
 
     math::Error<3>::type globalError(hit.globalError);
-    LocalPoint pulls(xResidual/std::sqrt(globalError(0, 0)),yResidual/std::sqrt(globalError(0, 0)));
+    LocalPoint pulls(xResidual / std::sqrt(globalError(0, 0)), yResidual / std::sqrt(globalError(0, 0)));
 
     CTPPSPixelFittedRecHit fittedRecHit(hit.recHit, pointOnDet, residuals, pulls);
     fittedRecHit.setIsUsedForFit(true);
@@ -563,63 +587,64 @@ CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList poi
   }
 
   return goodTrack;
-
 }
 
 //------------------------------------------------------------------------------------------------//
 
 //The method calculates the hit pointed by the track on the detector plane
-bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack *track, CTPPSPixelDetId planeId,
-                                                            GlobalPoint &planeLineIntercept)
-{
+bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack *track,
+                                                            CTPPSPixelDetId planeId,
+                                                            GlobalPoint &planeLineIntercept) {
   double z0 = track->getZ0();
   CTPPSPixelLocalTrack::ParameterVector parameters = track->getParameterVector();
 
   math::Vector<3>::type pointOnLine(parameters[0], parameters[1], z0);
   GlobalVector tmpLineUnitVector = track->getDirectionVector();
-  math::Vector<3>::type lineUnitVector(tmpLineUnitVector.x(),tmpLineUnitVector.y(),tmpLineUnitVector.z());
+  math::Vector<3>::type lineUnitVector(tmpLineUnitVector.x(), tmpLineUnitVector.y(), tmpLineUnitVector.z());
 
-  CLHEP::Hep3Vector tmpPointLocal(0.,0.,0.);
-  CLHEP::Hep3Vector tmpPointOnPlane = geometry_->localToGlobal(planeId,tmpPointLocal);
- 
+  CLHEP::Hep3Vector tmpPointLocal(0., 0., 0.);
+  CLHEP::Hep3Vector tmpPointOnPlane = geometry_->localToGlobal(planeId, tmpPointLocal);
+
   math::Vector<3>::type pointOnPlane(tmpPointOnPlane.x(), tmpPointOnPlane.y(), tmpPointOnPlane.z());
-  math::Vector<3>::type planeUnitVector(0.,0.,1.);
+  math::Vector<3>::type planeUnitVector(0., 0., 1.);
 
   DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(planeId)->rotation();
   AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
-  theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0), tmpPlaneRotationMatrixMap(0, 1), tmpPlaneRotationMatrixMap(0, 2),
-                                  tmpPlaneRotationMatrixMap(1, 0), tmpPlaneRotationMatrixMap(1, 1), tmpPlaneRotationMatrixMap(1, 2),
-                                  tmpPlaneRotationMatrixMap(2, 0), tmpPlaneRotationMatrixMap(2, 1), tmpPlaneRotationMatrixMap(2, 2));
+  theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0),
+                                  tmpPlaneRotationMatrixMap(0, 1),
+                                  tmpPlaneRotationMatrixMap(0, 2),
+                                  tmpPlaneRotationMatrixMap(1, 0),
+                                  tmpPlaneRotationMatrixMap(1, 1),
+                                  tmpPlaneRotationMatrixMap(1, 2),
+                                  tmpPlaneRotationMatrixMap(2, 0),
+                                  tmpPlaneRotationMatrixMap(2, 1),
+                                  tmpPlaneRotationMatrixMap(2, 2));
 
   planeUnitVector = tmpPlaneRotationMatrixMap * planeUnitVector;
 
   double denominator = ROOT::Math::Dot(lineUnitVector, planeUnitVector);
-  if(denominator==0){
+  if (denominator == 0) {
     edm::LogError("RPixPlaneCombinatoryTracking")
-      << "Error in RPixPlaneCombinatoryTracking::calculatePointOnDetector -> "
-      << "Fitted line and plane are parallel. Removing this track";
+        << "Error in RPixPlaneCombinatoryTracking::calculatePointOnDetector -> "
+        << "Fitted line and plane are parallel. Removing this track";
     return false;
   }
 
   double distanceFromLinePoint = ROOT::Math::Dot((pointOnPlane - pointOnLine), planeUnitVector) / denominator;
 
-  math::Vector<3>::type tmpPlaneLineIntercept = distanceFromLinePoint*lineUnitVector + pointOnLine;
+  math::Vector<3>::type tmpPlaneLineIntercept = distanceFromLinePoint * lineUnitVector + pointOnLine;
   planeLineIntercept = GlobalPoint(tmpPlaneLineIntercept[0], tmpPlaneLineIntercept[1], tmpPlaneLineIntercept[2]);
 
   return true;
-
 }
 //------------------------------------------------------------------------------------------------//
 
 // The method sorts the possible point combinations in order to process before fits on the highest possible number of points
-std::vector<RPixPlaneCombinatoryTracking::PointAndReferencePair > 
-  RPixPlaneCombinatoryTracking::orderCombinationsPerNumberOrPoints(
-  PointAndReferenceMap inputMap){
-
-  std::vector<PointAndReferencePair > sortedVector(inputMap.begin(),inputMap.end());
-  std::sort(sortedVector.begin(),sortedVector.end(),functionForPlaneOrdering);
+std::vector<RPixPlaneCombinatoryTracking::PointAndReferencePair>
+RPixPlaneCombinatoryTracking::orderCombinationsPerNumberOrPoints(PointAndReferenceMap inputMap) {
+  std::vector<PointAndReferencePair> sortedVector(inputMap.begin(), inputMap.end());
+  std::sort(sortedVector.begin(), sortedVector.end(), functionForPlaneOrdering);
 
   return sortedVector;
-
 }
 //------------------------------------------------------------------------------------------------//

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -11,7 +11,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 //needed for the geometry:
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -27,96 +26,92 @@
 
 //------------------------------------------------------------------------------------------------//
 
-RPixRoadFinder::RPixRoadFinder(edm::ParameterSet const& parameterSet) : 
-  RPixDetPatternFinder(parameterSet){
-
-  verbosity_ = parameterSet.getUntrackedParameter<int> ("verbosity");
+RPixRoadFinder::RPixRoadFinder(edm::ParameterSet const& parameterSet) : RPixDetPatternFinder(parameterSet) {
+  verbosity_ = parameterSet.getUntrackedParameter<int>("verbosity");
   roadRadius_ = parameterSet.getParameter<double>("roadRadius");
   minRoadSize_ = parameterSet.getParameter<int>("minRoadSize");
   maxRoadSize_ = parameterSet.getParameter<int>("maxRoadSize");
-
 }
 
 //------------------------------------------------------------------------------------------------//
 
-RPixRoadFinder::~RPixRoadFinder(){
-}
+RPixRoadFinder::~RPixRoadFinder() {}
 
 //------------------------------------------------------------------------------------------------//
 
-void RPixRoadFinder::findPattern(){
-
+void RPixRoadFinder::findPattern() {
   Road temp_all_hits;
   temp_all_hits.clear();
 
-// convert local hit sto global and push them to a vector
-  for(const auto & ds_rh2 : *hitVector_){
+  // convert local hit sto global and push them to a vector
+  for (const auto& ds_rh2 : *hitVector_) {
     const auto myid = CTPPSPixelDetId(ds_rh2.id);
-    for (const auto & it_rh : ds_rh2.data){
-      CLHEP::Hep3Vector localV(it_rh.getPoint().x(),it_rh.getPoint().y(),it_rh.getPoint().z() );
-      CLHEP::Hep3Vector globalV = geometry_->localToGlobal(ds_rh2.id,localV);
+    for (const auto& it_rh : ds_rh2.data) {
+      CLHEP::Hep3Vector localV(it_rh.getPoint().x(), it_rh.getPoint().y(), it_rh.getPoint().z());
+      CLHEP::Hep3Vector globalV = geometry_->localToGlobal(ds_rh2.id, localV);
       math::Error<3>::type localError;
       localError[0][0] = it_rh.getError().xx();
       localError[0][1] = it_rh.getError().xy();
-      localError[0][2] =                  0.;
+      localError[0][2] = 0.;
       localError[1][0] = it_rh.getError().xy();
       localError[1][1] = it_rh.getError().yy();
-      localError[1][2] =                  0.;
-      localError[2][0] =                  0.;
-      localError[2][1] =                  0.;
-      localError[2][2] =                  0.;
-      if(verbosity_>2) edm::LogInfo("RPixRoadFinder")<<"Hits = "<<ds_rh2.data.size();
+      localError[1][2] = 0.;
+      localError[2][0] = 0.;
+      localError[2][1] = 0.;
+      localError[2][2] = 0.;
+      if (verbosity_ > 2)
+        edm::LogInfo("RPixRoadFinder") << "Hits = " << ds_rh2.data.size();
 
       DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(myid)->rotation();
       AlgebraicMatrix33 theRotationTMatrix;
-      theRotationMatrix.GetComponents(theRotationTMatrix(0, 0), theRotationTMatrix(0, 1), theRotationTMatrix(0, 2),
-                                      theRotationTMatrix(1, 0), theRotationTMatrix(1, 1), theRotationTMatrix(1, 2),
-                                      theRotationTMatrix(2, 0), theRotationTMatrix(2, 1), theRotationTMatrix(2, 2));
+      theRotationMatrix.GetComponents(theRotationTMatrix(0, 0),
+                                      theRotationTMatrix(0, 1),
+                                      theRotationTMatrix(0, 2),
+                                      theRotationTMatrix(1, 0),
+                                      theRotationTMatrix(1, 1),
+                                      theRotationTMatrix(1, 2),
+                                      theRotationTMatrix(2, 0),
+                                      theRotationTMatrix(2, 1),
+                                      theRotationTMatrix(2, 2));
 
       math::Error<3>::type globalError = ROOT::Math::SimilarityT(theRotationTMatrix, localError);
-      PointInPlane thePointAndRecHit = {globalV,globalError,it_rh,myid};
+      PointInPlane thePointAndRecHit = {globalV, globalError, it_rh, myid};
       temp_all_hits.push_back(thePointAndRecHit);
     }
-
   }
-  
+
   Road::iterator it_gh1 = temp_all_hits.begin();
   Road::iterator it_gh2;
 
   patternVector_.clear();
 
-//look for points near wrt each other
-// starting algorithm
-  while( it_gh1 != temp_all_hits.end() && temp_all_hits.size() >= minRoadSize_){
+  //look for points near wrt each other
+  // starting algorithm
+  while (it_gh1 != temp_all_hits.end() && temp_all_hits.size() >= minRoadSize_) {
     Road temp_road;
-  
+
     it_gh2 = it_gh1;
 
     CLHEP::Hep3Vector currPoint = it_gh1->globalPoint;
     CTPPSPixelDetId currDet = CTPPSPixelDetId(it_gh1->detId);
 
-    while( it_gh2 != temp_all_hits.end()){
+    while (it_gh2 != temp_all_hits.end()) {
       bool same_pot = false;
       CTPPSPixelDetId tmpGh2Id = CTPPSPixelDetId(it_gh2->detId);
-      if ( currDet.getRPId() == tmpGh2Id.getRPId() ) same_pot = true;
+      if (currDet.getRPId() == tmpGh2Id.getRPId())
+        same_pot = true;
       CLHEP::Hep3Vector subtraction = currPoint - it_gh2->globalPoint;
 
-      if(subtraction.perp() < roadRadius_ && same_pot) {  /// 1mm
+      if (subtraction.perp() < roadRadius_ && same_pot) {  /// 1mm
         temp_road.push_back(*it_gh2);
         temp_all_hits.erase(it_gh2);
-      }else{
+      } else {
         ++it_gh2;
       }
-
     }
 
-    if(temp_road.size() >= minRoadSize_ && temp_road.size() < maxRoadSize_ )patternVector_.push_back(temp_road);
-   
+    if (temp_road.size() >= minRoadSize_ && temp_road.size() < maxRoadSize_)
+      patternVector_.push_back(temp_road);
   }
-// end of algorithm
-
-
-
+  // end of algorithm
 }
-
-

--- a/RecoHI/HiEgammaAlgos/interface/EcalClusterIsoCalculator.h
+++ b/RecoHI/HiEgammaAlgos/interface/EcalClusterIsoCalculator.h
@@ -14,12 +14,12 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-
-class EcalClusterIsoCalculator
-{
+class EcalClusterIsoCalculator {
 public:
-
-  EcalClusterIsoCalculator(const edm::Event &iEvent, const edm::EventSetup &iSetup, const edm::Handle<reco::BasicClusterCollection> barrel, const edm::Handle<reco::BasicClusterCollection> endcap);
+  EcalClusterIsoCalculator(const edm::Event &iEvent,
+                           const edm::EventSetup &iSetup,
+                           const edm::Handle<reco::BasicClusterCollection> barrel,
+                           const edm::Handle<reco::BasicClusterCollection> endcap);
 
   /// Return the ecal cluster energy in a cone around the SC
   double getEcalClusterIso(const reco::SuperClusterRef clus, const double radius, const double threshold);
@@ -27,11 +27,9 @@ public:
   double getBkgSubEcalClusterIso(const reco::SuperClusterRef clus, const double radius, const double threshold);
 
 private:
-
   const reco::BasicClusterCollection *fEBclusters_;
   const reco::BasicClusterCollection *fEEclusters_;
-  const CaloGeometry                 *geometry_;
-
+  const CaloGeometry *geometry_;
 };
 
 #endif

--- a/RecoHI/HiEgammaAlgos/interface/HcalRechitIsoCalculator.h
+++ b/RecoHI/HiEgammaAlgos/interface/HcalRechitIsoCalculator.h
@@ -16,26 +16,30 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-class HcalRechitIsoCalculator
-{
+class HcalRechitIsoCalculator {
 public:
-
-  HcalRechitIsoCalculator(const edm::Event &iEvent, const edm::EventSetup &iSetup,
-	       const edm::Handle<HBHERecHitCollection> hbhe,
-	       const edm::Handle<HFRecHitCollection> hfLabel,
-	       const edm::Handle<HORecHitCollection> hoLabel) ;
+  HcalRechitIsoCalculator(const edm::Event &iEvent,
+                          const edm::EventSetup &iSetup,
+                          const edm::Handle<HBHERecHitCollection> hbhe,
+                          const edm::Handle<HFRecHitCollection> hfLabel,
+                          const edm::Handle<HORecHitCollection> hoLabel);
 
   /// Return the hcal rechit energy in a cone around the SC
-  double getHcalRechitIso (const reco::SuperClusterRef clus, const double i, const double threshold, const double innerR=0.0);
+  double getHcalRechitIso(const reco::SuperClusterRef clus,
+                          const double i,
+                          const double threshold,
+                          const double innerR = 0.0);
   /// Return the background-subtracted hcal rechit energy in a cone around the SC
-  double getBkgSubHcalRechitIso(const reco::SuperClusterRef clus, const double i, const double threshold, const double innerR=0.0);
+  double getBkgSubHcalRechitIso(const reco::SuperClusterRef clus,
+                                const double i,
+                                const double threshold,
+                                const double innerR = 0.0);
 
 private:
-
-  const HBHERecHitCollection         *fHBHERecHits_;
-  const HORecHitCollection           *fHORecHits_;
-  const HFRecHitCollection           *fHFRecHits_;
-  const CaloGeometry                 *geometry_;
+  const HBHERecHitCollection *fHBHERecHits_;
+  const HORecHitCollection *fHORecHits_;
+  const HFRecHitCollection *fHFRecHits_;
+  const CaloGeometry *geometry_;
 };
 
 #endif

--- a/RecoHI/HiEgammaAlgos/interface/HiBremRecoveryClusterAlgo.h
+++ b/RecoHI/HiEgammaAlgos/interface/HiBremRecoveryClusterAlgo.h
@@ -10,7 +10,6 @@
 
 #include <vector>
 
-
 /*
   The HiBremRecoveryClusterAlgo class encapsulates the functionality needed
   to perform the SuperClustering.
@@ -19,69 +18,57 @@
   from the event are sorted by energy
 */
 
-class HiBremRecoveryClusterAlgo
-{
- public:
-  
-  enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 }; 
+class HiBremRecoveryClusterAlgo {
+public:
+  enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
-  HiBremRecoveryClusterAlgo(double eb_sc_road_etasize = 0.06, // Search window in eta - Barrel
-			  double eb_sc_road_phisize = 0.80, // Search window in phi - Barrel
-			  double ec_sc_road_etasize = 0.14, // Search window in eta - Endcap
-			  double ec_sc_road_phisize = 0.40, // Search window in eta - Endcap
-			  double theSeedTransverseEnergyThreshold = 0.40,
-			  double theBarrelBremEnergyThreshold = 2.3,
-			  double theEndcapBremEnergyThreshold = 5.7,
-			  VerbosityLevel the_verbosity = pERROR
-			  )
-  {
-      // e*_rdeta_ and e*_rdphi_ are half the total window 
-      // because they correspond to one direction (positive or negative)
-      eb_rdeta_ = eb_sc_road_etasize / 2;
-      eb_rdphi_ = eb_sc_road_phisize / 2;
-      ec_rdeta_ = ec_sc_road_etasize / 2;
-      ec_rdphi_ = ec_sc_road_phisize / 2;
+  HiBremRecoveryClusterAlgo(double eb_sc_road_etasize = 0.06,  // Search window in eta - Barrel
+                            double eb_sc_road_phisize = 0.80,  // Search window in phi - Barrel
+                            double ec_sc_road_etasize = 0.14,  // Search window in eta - Endcap
+                            double ec_sc_road_phisize = 0.40,  // Search window in eta - Endcap
+                            double theSeedTransverseEnergyThreshold = 0.40,
+                            double theBarrelBremEnergyThreshold = 2.3,
+                            double theEndcapBremEnergyThreshold = 5.7,
+                            VerbosityLevel the_verbosity = pERROR) {
+    // e*_rdeta_ and e*_rdphi_ are half the total window
+    // because they correspond to one direction (positive or negative)
+    eb_rdeta_ = eb_sc_road_etasize / 2;
+    eb_rdphi_ = eb_sc_road_phisize / 2;
+    ec_rdeta_ = ec_sc_road_etasize / 2;
+    ec_rdphi_ = ec_sc_road_phisize / 2;
 
-      seedTransverseEnergyThreshold = theSeedTransverseEnergyThreshold;
-      BarrelBremEnergyThreshold = theBarrelBremEnergyThreshold;
-      EndcapBremEnergyThreshold = theEndcapBremEnergyThreshold;
-      verbosity = the_verbosity;
+    seedTransverseEnergyThreshold = theSeedTransverseEnergyThreshold;
+    BarrelBremEnergyThreshold = theBarrelBremEnergyThreshold;
+    EndcapBremEnergyThreshold = theEndcapBremEnergyThreshold;
+    verbosity = the_verbosity;
   }
 
-  void setVerbosity(VerbosityLevel the_verbosity)
-  {
-      verbosity = the_verbosity;
-  }
- 
+  void setVerbosity(VerbosityLevel the_verbosity) { verbosity = the_verbosity; }
+
   // the method called from outside to do the SuperClustering - returns a vector of SCs:
-  reco::SuperClusterCollection makeSuperClusters(reco::CaloClusterPtrVector & clusters);
-  
- private:
-  
+  reco::SuperClusterCollection makeSuperClusters(reco::CaloClusterPtrVector &clusters);
+
+private:
   // make superclusters out of clusters produced by the Island algorithm:
-  void makeIslandSuperClusters(reco::CaloClusterPtrVector &clusters_v, 
-			       double etaRoad, double phiRoad);
-  
+  void makeIslandSuperClusters(reco::CaloClusterPtrVector &clusters_v, double etaRoad, double phiRoad);
+
   // return true if the cluster is within the search phi-eta window of the seed
-  bool match(reco::CaloClusterPtr seed_p, 
-	     reco::CaloClusterPtr cluster_p,
-	     double etaRoad, double phiRoad);
-  
+  bool match(reco::CaloClusterPtr seed_p, reco::CaloClusterPtr cluster_p, double etaRoad, double phiRoad);
+
   VerbosityLevel verbosity;
 
   double eb_rdeta_;
   double eb_rdphi_;
   double ec_rdeta_;
   double ec_rdphi_;
-  
+
   double seedTransverseEnergyThreshold;
 
   // Barrel Basic Cluster threshold in the brem recovery process
   double BarrelBremEnergyThreshold;
   double EndcapBremEnergyThreshold;
-  
+
   reco::SuperClusterCollection superclusters_v;
-  
 };
 
 #endif

--- a/RecoHI/HiEgammaAlgos/interface/HiEgammaSCEnergyCorrectionAlgo.h
+++ b/RecoHI/HiEgammaAlgos/interface/HiEgammaSCEnergyCorrectionAlgo.h
@@ -12,8 +12,8 @@
 
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h" 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
@@ -23,55 +23,50 @@
 class HiEgammaSCEnergyCorrectionAlgo {
 public:
   // the Verbosity levels
-  enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 }; 
-  
+  enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
+
   // public member functions
-  HiEgammaSCEnergyCorrectionAlgo(float noise, 
-				 reco::CaloCluster::AlgoId theAlgo,
-				 const edm::ParameterSet& pSet, 
-				 VerbosityLevel verbosity = pERROR
-                                 );
-  ~HiEgammaSCEnergyCorrectionAlgo(){}
-  
+  HiEgammaSCEnergyCorrectionAlgo(float noise,
+                                 reco::CaloCluster::AlgoId theAlgo,
+                                 const edm::ParameterSet &pSet,
+                                 VerbosityLevel verbosity = pERROR);
+  ~HiEgammaSCEnergyCorrectionAlgo() {}
+
   // take a SuperCluster and return a corrected SuperCluster
-  reco::SuperCluster applyCorrection(const reco::SuperCluster &cl, 
-				     const EcalRecHitCollection &rhc, 
-				     reco::CaloCluster::AlgoId theAlgo, 
-				     const CaloSubdetectorGeometry* geometry,
-				     const CaloTopology *topology,
-				     EcalClusterFunctionBaseClass* EnergyCorrectionClass);
-  
+  reco::SuperCluster applyCorrection(const reco::SuperCluster &cl,
+                                     const EcalRecHitCollection &rhc,
+                                     reco::CaloCluster::AlgoId theAlgo,
+                                     const CaloSubdetectorGeometry *geometry,
+                                     const CaloTopology *topology,
+                                     EcalClusterFunctionBaseClass *EnergyCorrectionClass);
+
   // function to set the verbosity level
-  void setVerbosity(VerbosityLevel verbosity)
-  {
-    verbosity_ = verbosity;
-  }
- 
+  void setVerbosity(VerbosityLevel verbosity) { verbosity_ = verbosity; }
+
 private:
-  
   // correction factor as a function of number of crystals,
-  // BasicCluster algo and location in the detector    
-  float fNCrystals(int nCry, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const ;
+  // BasicCluster algo and location in the detector
+  float fNCrystals(int nCry, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
   float fBrem(float widthRatio, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
   float fEta(float eta, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
   float fEtEta(float et, float eta, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
-  
-  // Return the number of crystals in a BasicCluster above 
+
+  // Return the number of crystals in a BasicCluster above
   // 2sigma noise level
-  int nCrystalsGT2Sigma(reco::BasicCluster const & seed, EcalRecHitCollection const &rhc) const;
-    
-    float sigmaElectronicNoise_;
-  
-   //  the verbosity level
+  int nCrystalsGT2Sigma(reco::BasicCluster const &seed, EcalRecHitCollection const &rhc) const;
+
+  float sigmaElectronicNoise_;
+
+  //  the verbosity level
   VerbosityLevel verbosity_;
-  
+
   reco::CaloCluster::AlgoId theAlgo_;
-  
+
   // parameters
   std::vector<double> p_fEta_;
   std::vector<double> p_fBremTh_, p_fBrem_;
   std::vector<double> p_fEtEta_;
-  
+
   double minR9Barrel_;
   double minR9Endcap_;
   double maxR9_;

--- a/RecoHI/HiEgammaAlgos/interface/HiPhotonType.h
+++ b/RecoHI/HiEgammaAlgos/interface/HiPhotonType.h
@@ -20,40 +20,35 @@
 
 #include <vector>
 
-class HiGammaJetSignalDef
-{
- public:
-
+class HiGammaJetSignalDef {
+public:
   HiGammaJetSignalDef();
   HiGammaJetSignalDef(const reco::GenParticleCollection *sigPartic);
-  bool IsIsolated(const reco::GenParticle &pp)            ;
-  bool IsIsolatedPP(const reco::GenParticle &pp)            ;
-  bool IsIsolatedJP(const reco::GenParticle &pp)            ;
+  bool IsIsolated(const reco::GenParticle &pp);
+  bool IsIsolatedPP(const reco::GenParticle &pp);
+  bool IsIsolatedJP(const reco::GenParticle &pp);
 
   //  bool IsSignal(const reco::Candidate &pp, double dPhi, bool isIso);
   //  int getIndex(const reco::Candidate &pp);
-  double getDeltaR (const reco::Candidate &track1, const reco::Candidate &track2);
+  double getDeltaR(const reco::Candidate &track1, const reco::Candidate &track2);
   double getDeltaPhi(const reco::Candidate &track1, const reco::Candidate &track2);
   double PI;
 
- private:
-  const reco::GenParticleCollection        *fSigParticles;
-
+private:
+  const reco::GenParticleCollection *fSigParticles;
 };
 
-class HiPhotonType
-{
- public:
+class HiPhotonType {
+public:
   HiPhotonType(edm::Handle<reco::GenParticleCollection> inputHandle);
   bool IsPrompt(const reco::GenParticle &pp);
   bool IsIsolated(const reco::GenParticle &pp);
   //  bool IsIsolatedPP(const reco::GenParticle &pp);
   //  bool IsIsolatedJP(const reco::GenParticle &pp);
   double PI;
- 
- private:
+
+private:
   HiGammaJetSignalDef mcisocut;
 };
 
 #endif
-

--- a/RecoHI/HiEgammaAlgos/interface/TrackIsoCalculator.h
+++ b/RecoHI/HiEgammaAlgos/interface/TrackIsoCalculator.h
@@ -19,20 +19,20 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-class TrackIsoCalculator
-{
+class TrackIsoCalculator {
 public:
-
-  TrackIsoCalculator(const edm::Event &iEvent, const edm::EventSetup &iSetup, const edm::Handle<reco::TrackCollection> trackLabel, const std::string trackQuality_) ;
+  TrackIsoCalculator(const edm::Event &iEvent,
+                     const edm::EventSetup &iSetup,
+                     const edm::Handle<reco::TrackCollection> trackLabel,
+                     const std::string trackQuality_);
 
   /// Return the tracker energy in a cone around the photon
-  double getTrackIso(const reco::Photon clus, const double i, const double threshold, const double innerDR=0);
+  double getTrackIso(const reco::Photon clus, const double i, const double threshold, const double innerDR = 0);
   /// Return the background-subtracted tracker energy in a cone around the photon
-  double getBkgSubTrackIso(const reco::Photon clus, const double i, const double threshold, const double innerDR=0);
+  double getBkgSubTrackIso(const reco::Photon clus, const double i, const double threshold, const double innerDR = 0);
 
 private:
-
-  edm::Handle<reco::TrackCollection>  recCollection;
+  edm::Handle<reco::TrackCollection> recCollection;
   std::string trackQuality_;
 };
 

--- a/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
+++ b/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
@@ -5,7 +5,7 @@
 //
 // Package:    HiEgammaSCCorrectionMaker
 // Class:      HiEgammaSCCorrectionMaker
-// 
+//
 /**\class HiEgammaSCCorrectionMaker HiEgammaSCCorrectionMaker.cc HiEgammaSCCorrectionMaker/HiEgammaSCCorrectionMaker/src/HiEgammaSCCorrectionMaker.cc
 
  Description: Producer of corrected SuperClusters
@@ -30,46 +30,41 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 
 #include "RecoHI/HiEgammaAlgos/interface/HiEgammaSCEnergyCorrectionAlgo.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h" 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
-
 class HiEgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
-	
-   public:
-     explicit HiEgammaSCCorrectionMaker(const edm::ParameterSet&);
-     ~HiEgammaSCCorrectionMaker() override;
-     void produce(edm::Event&, const edm::EventSetup&) override;
+public:
+  explicit HiEgammaSCCorrectionMaker(const edm::ParameterSet&);
+  ~HiEgammaSCCorrectionMaker() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
+private:
+  std::unique_ptr<EcalClusterFunctionBaseClass> EnergyCorrection_;
 
-     std::unique_ptr<EcalClusterFunctionBaseClass> EnergyCorrection_;
+  // the debug level
+  HiEgammaSCEnergyCorrectionAlgo::VerbosityLevel verbosity_;
 
-     // the debug level
-     HiEgammaSCEnergyCorrectionAlgo::VerbosityLevel verbosity_;
+  // pointer to the correction algo object
+  std::unique_ptr<HiEgammaSCEnergyCorrectionAlgo> energyCorrector_;
 
-     // pointer to the correction algo object
-     std::unique_ptr<HiEgammaSCEnergyCorrectionAlgo> energyCorrector_;
-    
-     // vars for the correction algo
-     bool applyEnergyCorrection_;
-     //     bool oldEnergyScaleCorrection_;
-     double sigmaElectronicNoise_;
-     double etThresh_;
-     
-     // vars to get products
-     edm::InputTag rHInputProducerTag_;
-     edm::InputTag sCInputProducerTag_;
-     edm::EDGetTokenT<EcalRecHitCollection> rHInputProducer_;
-     edm::EDGetTokenT<reco::SuperClusterCollection> sCInputProducer_;
+  // vars for the correction algo
+  bool applyEnergyCorrection_;
+  //     bool oldEnergyScaleCorrection_;
+  double sigmaElectronicNoise_;
+  double etThresh_;
 
-     reco::CaloCluster::AlgoId sCAlgo_;
-     std::string outputCollection_;
-     edm::ESHandle<CaloTopology> theCaloTopo_;
+  // vars to get products
+  edm::InputTag rHInputProducerTag_;
+  edm::InputTag sCInputProducerTag_;
+  edm::EDGetTokenT<EcalRecHitCollection> rHInputProducer_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> sCInputProducer_;
 
-
+  reco::CaloCluster::AlgoId sCAlgo_;
+  std::string outputCollection_;
+  edm::ESHandle<CaloTopology> theCaloTopo_;
 };
 #endif

--- a/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
@@ -2,7 +2,7 @@
 //111
 // Package:    HiSpikeCleaner
 // Class:      HiSpikeCleaner
-// 
+//
 /**\class HiSpikeCleaner HiSpikeCleaner.cc RecoHI/HiSpikeCleaner/src/HiSpikeCleaner.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Mon Nov  1 18:22:21 CET 2010
 //
 //
-
 
 // system include files
 #include <memory>
@@ -40,8 +39,6 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 
-
-
 //
 // class declaration
 //
@@ -50,163 +47,149 @@ class HiSpikeCleaner : public edm::stream::EDProducer<> {
 public:
   explicit HiSpikeCleaner(const edm::ParameterSet&);
   ~HiSpikeCleaner() override;
-  
-private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   // ----------member data ---------------------------
-  
-  edm::EDGetTokenT<reco::SuperClusterCollection>  sCInputProducerToken_;
-  edm::EDGetTokenT<EcalRecHitCollection>  rHInputProducerBToken_;
-  edm::EDGetTokenT<EcalRecHitCollection>  rHInputProducerEToken_;
-  
+
+  edm::EDGetTokenT<reco::SuperClusterCollection> sCInputProducerToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> rHInputProducerBToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> rHInputProducerEToken_;
+
   std::string outputCollection_;
   double TimingCut_;
   double swissCutThr_;
-  double etCut_; 
+  double etCut_;
 };
 
-HiSpikeCleaner::HiSpikeCleaner(const edm::ParameterSet& iConfig)
-{
-   //register your products
-/* Examples
+HiSpikeCleaner::HiSpikeCleaner(const edm::ParameterSet& iConfig) {
+  //register your products
+  /* Examples
    produces<ExampleData2>();
 
    //if do put with a label
    produces<ExampleData2>("label");
 */
-   //now do what ever other initialization is needed
-   
-  rHInputProducerBToken_  = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitProducerBarrel"));
-  rHInputProducerEToken_  = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitProducerEndcap"));
-  
-  sCInputProducerToken_  = consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("originalSuperClusterProducer"));
-  TimingCut_      = iConfig.getUntrackedParameter<double>  ("TimingCut",4.0);
-  swissCutThr_      = iConfig.getUntrackedParameter<double>("swissCutThr",0.95);
-  etCut_            = iConfig.getParameter<double>("etCut");
-  
+  //now do what ever other initialization is needed
+
+  rHInputProducerBToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitProducerBarrel"));
+  rHInputProducerEToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitProducerEndcap"));
+
+  sCInputProducerToken_ =
+      consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("originalSuperClusterProducer"));
+  TimingCut_ = iConfig.getUntrackedParameter<double>("TimingCut", 4.0);
+  swissCutThr_ = iConfig.getUntrackedParameter<double>("swissCutThr", 0.95);
+  etCut_ = iConfig.getParameter<double>("etCut");
+
   outputCollection_ = iConfig.getParameter<std::string>("outputColl");
-  produces<reco::SuperClusterCollection>(outputCollection_);  
+  produces<reco::SuperClusterCollection>(outputCollection_);
 }
 
-
-HiSpikeCleaner::~HiSpikeCleaner()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+HiSpikeCleaner::~HiSpikeCleaner() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-HiSpikeCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void HiSpikeCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   // Get raw SuperClusters from the event    
-   Handle<reco::SuperClusterCollection> pRawSuperClusters;
-   try { 
-      iEvent.getByToken(sCInputProducerToken_, pRawSuperClusters);
-   } catch ( cms::Exception& ex ) {
-     edm::LogError("EgammaSCCorrectionMakerError") 
-       << "Error! can't get the rawSuperClusters ";
-   }    
-   
-   // Get the RecHits from the event
-   Handle<EcalRecHitCollection> pRecHitsB;
-   try { 
-      iEvent.getByToken(rHInputProducerBToken_, pRecHitsB);
-   } catch ( cms::Exception& ex ) {
-     edm::LogError("EgammaSCCorrectionMakerError") 
-       << "Error! can't get the RecHits ";
-   }    
+  // Get raw SuperClusters from the event
+  Handle<reco::SuperClusterCollection> pRawSuperClusters;
+  try {
+    iEvent.getByToken(sCInputProducerToken_, pRawSuperClusters);
+  } catch (cms::Exception& ex) {
+    edm::LogError("EgammaSCCorrectionMakerError") << "Error! can't get the rawSuperClusters ";
+  }
 
-   // Get the RecHits from the event                                                                                                            
-   Handle<EcalRecHitCollection> pRecHitsE;
-   try {
-     iEvent.getByToken(rHInputProducerEToken_, pRecHitsE);
-   } catch ( cms::Exception& ex ) {
-     edm::LogError("EgammaSCCorrectionMakerError")
-       << "Error! can't get the RecHits ";
-   }
+  // Get the RecHits from the event
+  Handle<EcalRecHitCollection> pRecHitsB;
+  try {
+    iEvent.getByToken(rHInputProducerBToken_, pRecHitsB);
+  } catch (cms::Exception& ex) {
+    edm::LogError("EgammaSCCorrectionMakerError") << "Error! can't get the RecHits ";
+  }
 
-   
-   // get the channel status from the DB                                                                                                     
-   //   edm::ESHandle<EcalChannelStatus> chStatus;
-   //   iSetup.get<EcalChannelStatusRcd>().get(chStatus);
-   
-   edm::ESHandle<EcalSeverityLevelAlgo> ecalSevLvlAlgoHndl;
-   iSetup.get<EcalSeverityLevelAlgoRcd>().get(ecalSevLvlAlgoHndl);
-   
-   
-   // Create a pointer to the RecHits and raw SuperClusters
-   const reco::SuperClusterCollection *rawClusters = pRawSuperClusters.product();
-   
-   
-   EcalClusterLazyTools lazyTool(iEvent, iSetup, rHInputProducerBToken_,rHInputProducerEToken_);
+  // Get the RecHits from the event
+  Handle<EcalRecHitCollection> pRecHitsE;
+  try {
+    iEvent.getByToken(rHInputProducerEToken_, pRecHitsE);
+  } catch (cms::Exception& ex) {
+    edm::LogError("EgammaSCCorrectionMakerError") << "Error! can't get the RecHits ";
+  }
 
-   // Define a collection of corrected SuperClusters to put back into the event
-   auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
-   
-   //  Loop over raw clusters and make corrected ones
-   reco::SuperClusterCollection::const_iterator aClus;
-   for(aClus = rawClusters->begin(); aClus != rawClusters->end(); aClus++)
-      {
-	 double theEt = aClus->energy()/cosh( aClus->eta() ) ;
-	 //	 std::cout << " et of SC = " << theEt << std::endl;
+  // get the channel status from the DB
+  //   edm::ESHandle<EcalChannelStatus> chStatus;
+  //   iSetup.get<EcalChannelStatusRcd>().get(chStatus);
 
-	 if ( theEt < etCut_ )  continue;   // cut off low pT superclusters 
-	 
-	 bool flagS = true;
-	 float swissCrx(0);
-	 
-	 const reco::CaloClusterPtr seed = aClus->seed();
-	 DetId id = lazyTool.getMaximum(*seed).first;
-	 const EcalRecHitCollection & rechits = *pRecHitsB;
-	 EcalRecHitCollection::const_iterator it = rechits.find( id );
-	 
-	 if( it != rechits.end() ) {
-	    ecalSevLvlAlgoHndl->severityLevel(id, rechits);
-	    swissCrx = EcalTools::swissCross   (id, rechits, 0.,true);
-	    //	    std::cout << "swissCross = " << swissCrx <<std::endl;
-	    // std::cout << " timing = " << it->time() << std::endl;
-	 }
-	 
-	 if ( fabs(it->time()) > TimingCut_ ) {
-	    flagS = false;
-	    //	    std::cout << " timing = " << it->time() << std::endl;
-	    //   std::cout << " timing is bad........" << std::endl; 
-	 }
-	 if ( swissCrx > (float)swissCutThr_ ) {
-	    flagS = false ;     // swissCross cut
-	    //	    std::cout << "swissCross = " << swissCrx <<std::endl;   
-	    //   std::cout << " removed by swiss cross cut" << std::endl;
-	 }
-	 // - kGood        --> good channel
-	 // - kProblematic --> problematic (e.g. noisy)
-	 // - kRecovered   --> recovered (e.g. an originally dead or saturated)
-	 // - kTime        --> the channel is out of time (e.g. spike)
-	 // - kWeird       --> weird (e.g. spike)
-	 // - kBad         --> bad, not suitable to be used in the reconstruction
-	 //   enum EcalSeverityLevel { kGood=0, kProblematic, kRecovered, kTime, kWeird, kBad };
-	    
-	 
-	 reco::SuperCluster newClus;
-	 if ( flagS == true)
-	    newClus=*aClus;
-	 else
-	    continue;
-	 corrClusters->push_back(newClus);
-      }
-   
-   // Put collection of corrected SuperClusters into the event
-   iEvent.put(std::move(corrClusters), outputCollection_);   
-   
+  edm::ESHandle<EcalSeverityLevelAlgo> ecalSevLvlAlgoHndl;
+  iSetup.get<EcalSeverityLevelAlgoRcd>().get(ecalSevLvlAlgoHndl);
+
+  // Create a pointer to the RecHits and raw SuperClusters
+  const reco::SuperClusterCollection* rawClusters = pRawSuperClusters.product();
+
+  EcalClusterLazyTools lazyTool(iEvent, iSetup, rHInputProducerBToken_, rHInputProducerEToken_);
+
+  // Define a collection of corrected SuperClusters to put back into the event
+  auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
+
+  //  Loop over raw clusters and make corrected ones
+  reco::SuperClusterCollection::const_iterator aClus;
+  for (aClus = rawClusters->begin(); aClus != rawClusters->end(); aClus++) {
+    double theEt = aClus->energy() / cosh(aClus->eta());
+    //	 std::cout << " et of SC = " << theEt << std::endl;
+
+    if (theEt < etCut_)
+      continue;  // cut off low pT superclusters
+
+    bool flagS = true;
+    float swissCrx(0);
+
+    const reco::CaloClusterPtr seed = aClus->seed();
+    DetId id = lazyTool.getMaximum(*seed).first;
+    const EcalRecHitCollection& rechits = *pRecHitsB;
+    EcalRecHitCollection::const_iterator it = rechits.find(id);
+
+    if (it != rechits.end()) {
+      ecalSevLvlAlgoHndl->severityLevel(id, rechits);
+      swissCrx = EcalTools::swissCross(id, rechits, 0., true);
+      //	    std::cout << "swissCross = " << swissCrx <<std::endl;
+      // std::cout << " timing = " << it->time() << std::endl;
+    }
+
+    if (fabs(it->time()) > TimingCut_) {
+      flagS = false;
+      //	    std::cout << " timing = " << it->time() << std::endl;
+      //   std::cout << " timing is bad........" << std::endl;
+    }
+    if (swissCrx > (float)swissCutThr_) {
+      flagS = false;  // swissCross cut
+                      //	    std::cout << "swissCross = " << swissCrx <<std::endl;
+                      //   std::cout << " removed by swiss cross cut" << std::endl;
+    }
+    // - kGood        --> good channel
+    // - kProblematic --> problematic (e.g. noisy)
+    // - kRecovered   --> recovered (e.g. an originally dead or saturated)
+    // - kTime        --> the channel is out of time (e.g. spike)
+    // - kWeird       --> weird (e.g. spike)
+    // - kBad         --> bad, not suitable to be used in the reconstruction
+    //   enum EcalSeverityLevel { kGood=0, kProblematic, kRecovered, kTime, kWeird, kBad };
+
+    reco::SuperCluster newClus;
+    if (flagS == true)
+      newClus = *aClus;
+    else
+      continue;
+    corrClusters->push_back(newClus);
+  }
+
+  // Put collection of corrected SuperClusters into the event
+  iEvent.put(std::move(corrClusters), outputCollection_);
 }
 
 //define this as a plug-in

--- a/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.cc
@@ -22,108 +22,102 @@
 // Class header file
 #include "RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.h"
 
+HiSuperClusterProducer::HiSuperClusterProducer(const edm::ParameterSet& ps) {
+  // The verbosity level
+  std::string verbosityString = ps.getParameter<std::string>("VerbosityLevel");
+  if (verbosityString == "DEBUG")
+    verbosity = HiBremRecoveryClusterAlgo::pDEBUG;
+  else if (verbosityString == "WARNING")
+    verbosity = HiBremRecoveryClusterAlgo::pWARNING;
+  else if (verbosityString == "INFO")
+    verbosity = HiBremRecoveryClusterAlgo::pINFO;
+  else
+    verbosity = HiBremRecoveryClusterAlgo::pERROR;
 
-HiSuperClusterProducer::HiSuperClusterProducer(const edm::ParameterSet& ps)
-{
-   // The verbosity level
-   std::string verbosityString = ps.getParameter<std::string>("VerbosityLevel");
-   if      (verbosityString == "DEBUG")   verbosity = HiBremRecoveryClusterAlgo::pDEBUG;
-   else if (verbosityString == "WARNING") verbosity = HiBremRecoveryClusterAlgo::pWARNING;
-   else if (verbosityString == "INFO")    verbosity = HiBremRecoveryClusterAlgo::pINFO;
-   else                                   verbosity = HiBremRecoveryClusterAlgo::pERROR;
+  endcapSuperclusterCollection_ = ps.getParameter<std::string>("endcapSuperclusterCollection");
+  barrelSuperclusterCollection_ = ps.getParameter<std::string>("barrelSuperclusterCollection");
 
+  doBarrel_ = ps.getParameter<bool>("doBarrel");
+  doEndcaps_ = ps.getParameter<bool>("doEndcaps");
 
-   endcapSuperclusterCollection_ = ps.getParameter<std::string>("endcapSuperclusterCollection");
-   barrelSuperclusterCollection_ = ps.getParameter<std::string>("barrelSuperclusterCollection");
+  barrelEtaSearchRoad_ = ps.getParameter<double>("barrelEtaSearchRoad");
+  barrelPhiSearchRoad_ = ps.getParameter<double>("barrelPhiSearchRoad");
+  endcapEtaSearchRoad_ = ps.getParameter<double>("endcapEtaSearchRoad");
+  endcapPhiSearchRoad_ = ps.getParameter<double>("endcapPhiSearchRoad");
+  seedTransverseEnergyThreshold_ = ps.getParameter<double>("seedTransverseEnergyThreshold");
+  barrelBCEnergyThreshold_ = ps.getParameter<double>("barrelBCEnergyThreshold");
+  endcapBCEnergyThreshold_ = ps.getParameter<double>("endcapBCEnergyThreshold");
 
-   doBarrel_ = ps.getParameter<bool>("doBarrel");
-   doEndcaps_ = ps.getParameter<bool>("doEndcaps");
+  if (verbosityString == "INFO") {
+    std::cout << "Barrel BC Energy threshold = " << barrelBCEnergyThreshold_ << std::endl;
+    std::cout << "Endcap BC Energy threshold = " << endcapBCEnergyThreshold_ << std::endl;
+  }
 
+  bremAlgo_p = new HiBremRecoveryClusterAlgo(barrelEtaSearchRoad_,
+                                             barrelPhiSearchRoad_,
+                                             endcapEtaSearchRoad_,
+                                             endcapPhiSearchRoad_,
+                                             seedTransverseEnergyThreshold_,
+                                             barrelBCEnergyThreshold_,
+                                             endcapBCEnergyThreshold_,
+                                             verbosity);
 
-   barrelEtaSearchRoad_ = ps.getParameter<double>("barrelEtaSearchRoad");
-   barrelPhiSearchRoad_ = ps.getParameter<double>("barrelPhiSearchRoad");
-   endcapEtaSearchRoad_ = ps.getParameter<double>("endcapEtaSearchRoad");
-   endcapPhiSearchRoad_ = ps.getParameter<double>("endcapPhiSearchRoad");
-   seedTransverseEnergyThreshold_ = ps.getParameter<double>("seedTransverseEnergyThreshold");
-   barrelBCEnergyThreshold_ = ps.getParameter<double>("barrelBCEnergyThreshold");
-   endcapBCEnergyThreshold_ = ps.getParameter<double>("endcapBCEnergyThreshold");
+  produces<reco::SuperClusterCollection>(endcapSuperclusterCollection_);
+  produces<reco::SuperClusterCollection>(barrelSuperclusterCollection_);
 
-   if (verbosityString == "INFO") {
-      std::cout <<"Barrel BC Energy threshold = "<<barrelBCEnergyThreshold_<<std::endl;
-      std::cout <<"Endcap BC Energy threshold = "<<endcapBCEnergyThreshold_<<std::endl;
-   }
+  eeClustersToken_ = consumes<reco::BasicClusterCollection>(edm::InputTag(
+      ps.getParameter<std::string>("endcapClusterProducer"), ps.getParameter<std::string>("endcapClusterCollection")));
+  ebClustersToken_ = consumes<reco::BasicClusterCollection>(edm::InputTag(
+      ps.getParameter<std::string>("barrelClusterProducer"), ps.getParameter<std::string>("barrelClusterCollection")));
 
-   bremAlgo_p = new HiBremRecoveryClusterAlgo(barrelEtaSearchRoad_, barrelPhiSearchRoad_, 
-                                              endcapEtaSearchRoad_, endcapPhiSearchRoad_, 
-                                              seedTransverseEnergyThreshold_,
-                                              barrelBCEnergyThreshold_,
-                                              endcapBCEnergyThreshold_,
-                                              verbosity);
-
-   produces< reco::SuperClusterCollection >(endcapSuperclusterCollection_);
-   produces< reco::SuperClusterCollection >(barrelSuperclusterCollection_);
-
-   eeClustersToken_ =  consumes<reco::BasicClusterCollection>(edm::InputTag(ps.getParameter<std::string>("endcapClusterProducer"), 
-									    ps.getParameter<std::string>("endcapClusterCollection")));
-   ebClustersToken_ =  consumes<reco::BasicClusterCollection>(edm::InputTag(ps.getParameter<std::string>("barrelClusterProducer"), 
-									    ps.getParameter<std::string>("barrelClusterCollection")));
-
-   totalE = 0;
-   noSuperClusters = 0;
-   nEvt_ = 0;
+  totalE = 0;
+  noSuperClusters = 0;
+  nEvt_ = 0;
 }
 
-
-HiSuperClusterProducer::~HiSuperClusterProducer()
-{
-   delete bremAlgo_p;
-}
+HiSuperClusterProducer::~HiSuperClusterProducer() { delete bremAlgo_p; }
 
 void HiSuperClusterProducer::endJob() {
-   double averEnergy = 0.;
-   std::ostringstream str;
-   str << "HiSuperClusterProducer::endJob()\n"
-       << "  total # reconstructed super clusters: " << noSuperClusters << "\n"
-       << "  total energy of all clusters: " << totalE << "\n";
-   if(noSuperClusters>0) { 
-     averEnergy = totalE / noSuperClusters;
-     str << "  average SuperCluster energy = " << averEnergy << "\n";
-   }
-   edm::LogInfo("HiSuperClusterProducerInfo") << str.str() << "\n";
- 
+  double averEnergy = 0.;
+  std::ostringstream str;
+  str << "HiSuperClusterProducer::endJob()\n"
+      << "  total # reconstructed super clusters: " << noSuperClusters << "\n"
+      << "  total energy of all clusters: " << totalE << "\n";
+  if (noSuperClusters > 0) {
+    averEnergy = totalE / noSuperClusters;
+    str << "  average SuperCluster energy = " << averEnergy << "\n";
+  }
+  edm::LogInfo("HiSuperClusterProducerInfo") << str.str() << "\n";
 }
 
-
-void HiSuperClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  if(doEndcaps_)
+void HiSuperClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  if (doEndcaps_)
     produceSuperclustersForECALPart(evt, eeClustersToken_, endcapSuperclusterCollection_);
 
-  if(doBarrel_)
+  if (doBarrel_)
     produceSuperclustersForECALPart(evt, ebClustersToken_, barrelSuperclusterCollection_);
 
   nEvt_++;
 }
 
-
-void HiSuperClusterProducer::produceSuperclustersForECALPart(edm::Event& evt, 
-							     const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
-							     std::string superclusterCollection)
-{
+void HiSuperClusterProducer::produceSuperclustersForECALPart(
+    edm::Event& evt,
+    const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
+    std::string superclusterCollection) {
   // get the cluster collection out and turn it to a BasicClusterRefVector:
-  reco::CaloClusterPtrVector *clusterPtrVector_p = new reco::CaloClusterPtrVector;
+  reco::CaloClusterPtrVector* clusterPtrVector_p = new reco::CaloClusterPtrVector;
   getClusterPtrVector(evt, clustersToken, clusterPtrVector_p);
 
   // run the brem recovery and get the SC collection
-  auto superclusters_ap = std::make_unique<reco::SuperClusterCollection>(bremAlgo_p->makeSuperClusters(*clusterPtrVector_p));
+  auto superclusters_ap =
+      std::make_unique<reco::SuperClusterCollection>(bremAlgo_p->makeSuperClusters(*clusterPtrVector_p));
 
   // count the total energy and the number of superclusters
   reco::SuperClusterCollection::iterator it;
-  for (it = superclusters_ap->begin(); it != superclusters_ap->end(); it++)
-    {
-      totalE += it->energy();
-      noSuperClusters++;
-    }
+  for (it = superclusters_ap->begin(); it != superclusters_ap->end(); it++) {
+    totalE += it->energy();
+    noSuperClusters++;
+  }
 
   // put the SC collection in the event
   evt.put(std::move(superclusters_ap), superclusterCollection);
@@ -131,27 +125,23 @@ void HiSuperClusterProducer::produceSuperclustersForECALPart(edm::Event& evt,
   delete clusterPtrVector_p;
 }
 
-
-void HiSuperClusterProducer::getClusterPtrVector(edm::Event& evt, const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken, reco::CaloClusterPtrVector *clusterPtrVector_p)
-{  
+void HiSuperClusterProducer::getClusterPtrVector(edm::Event& evt,
+                                                 const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
+                                                 reco::CaloClusterPtrVector* clusterPtrVector_p) {
   edm::Handle<reco::BasicClusterCollection> bccHandle;
 
   evt.getByToken(clustersToken, bccHandle);
 
-  if (!(bccHandle.isValid()))
-    {
-      edm::LogError("HiSuperClusterProducerError") << "could not get a handle on the BasicCluster Collection!";
-      clusterPtrVector_p = nullptr;
-    }
+  if (!(bccHandle.isValid())) {
+    edm::LogError("HiSuperClusterProducerError") << "could not get a handle on the BasicCluster Collection!";
+    clusterPtrVector_p = nullptr;
+  }
 
-  const reco::BasicClusterCollection *clusterCollection_p = bccHandle.product();
-  for (unsigned int i = 0; i < clusterCollection_p->size(); i++)
-    {
-      clusterPtrVector_p->push_back(reco::CaloClusterPtr(bccHandle, i));
-    }
-}                               
+  const reco::BasicClusterCollection* clusterCollection_p = bccHandle.product();
+  for (unsigned int i = 0; i < clusterCollection_p->size(); i++) {
+    clusterPtrVector_p->push_back(reco::CaloClusterPtr(bccHandle, i));
+  }
+}
 
-
-
-//define this as a plug-in                                                                                                                                                   
+//define this as a plug-in
 DEFINE_FWK_MODULE(HiSuperClusterProducer);

--- a/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.h
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.h
@@ -16,59 +16,54 @@
 
 //
 
+class HiSuperClusterProducer : public edm::stream::EDProducer<> {
+public:
+  HiSuperClusterProducer(const edm::ParameterSet& ps);
 
-class HiSuperClusterProducer : public edm::stream::EDProducer<> 
-{
-  
-  public:
+  ~HiSuperClusterProducer() override;
 
-      HiSuperClusterProducer(const edm::ParameterSet& ps);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob();
 
-      ~HiSuperClusterProducer() override;
+private:
+  int nMaxPrintout_;  // max # of printouts
+  int nEvt_;          // internal counter of events
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob();
+  HiBremRecoveryClusterAlgo::VerbosityLevel verbosity;
 
-   private:
+  std::string endcapSuperclusterCollection_;
+  std::string barrelSuperclusterCollection_;
 
-      int nMaxPrintout_; // max # of printouts
-      int nEvt_;         // internal counter of events
- 
-      HiBremRecoveryClusterAlgo::VerbosityLevel verbosity;
+  edm::EDGetTokenT<reco::BasicClusterCollection> eeClustersToken_;
+  edm::EDGetTokenT<reco::BasicClusterCollection> ebClustersToken_;
 
-      std::string endcapSuperclusterCollection_;
-      std::string barrelSuperclusterCollection_;
+  float barrelEtaSearchRoad_;
+  float barrelPhiSearchRoad_;
+  float endcapEtaSearchRoad_;
+  float endcapPhiSearchRoad_;
+  float seedTransverseEnergyThreshold_;
+  float barrelBCEnergyThreshold_;
+  float endcapBCEnergyThreshold_;
 
-      edm::EDGetTokenT<reco::BasicClusterCollection>  eeClustersToken_;
-      edm::EDGetTokenT<reco::BasicClusterCollection>  ebClustersToken_;
+  bool doBarrel_;
+  bool doEndcaps_;
 
-      float barrelEtaSearchRoad_;
-      float barrelPhiSearchRoad_;
-      float endcapEtaSearchRoad_; 
-      float endcapPhiSearchRoad_;
-      float seedTransverseEnergyThreshold_;
-      float barrelBCEnergyThreshold_;
-      float endcapBCEnergyThreshold_;
+  HiBremRecoveryClusterAlgo* bremAlgo_p;
 
-      bool doBarrel_;
-      bool doEndcaps_;
+  double totalE;
+  int noSuperClusters;
 
-      HiBremRecoveryClusterAlgo * bremAlgo_p;
+  void getClusterPtrVector(edm::Event& evt,
+                           const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
+                           reco::CaloClusterPtrVector*);
 
-      double totalE;
-      int noSuperClusters;
+  void produceSuperclustersForECALPart(edm::Event& evt,
+                                       const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
+                                       std::string superclusterColection);
 
-      
-      void getClusterPtrVector(edm::Event& evt, const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken, reco::CaloClusterPtrVector *);
-  
-      void produceSuperclustersForECALPart(edm::Event& evt, 
-					   const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
-					   std::string superclusterColection);
+  void outputValidationInfo(reco::SuperClusterCollection& superclusterCollection);
 
-      void outputValidationInfo(reco::SuperClusterCollection &superclusterCollection);
-    
-      bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0));}
+  bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
 };
-
 
 #endif

--- a/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
@@ -20,16 +20,13 @@
 #include "RecoHI/HiEgammaAlgos/interface/TrackIsoCalculator.h"
 
 class photonIsolationHIProducer : public edm::stream::EDProducer<> {
-
- public:
-
-  explicit photonIsolationHIProducer (const edm::ParameterSet& ps);
+public:
+  explicit photonIsolationHIProducer(const edm::ParameterSet& ps);
   ~photonIsolationHIProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
- private:
-
+private:
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
   edm::EDGetTokenT<reco::PhotonCollection> photonProducer_;
@@ -43,33 +40,25 @@ class photonIsolationHIProducer : public edm::stream::EDProducer<> {
   edm::EDGetTokenT<reco::TrackCollection> tracks_;
 
   std::string trackQuality_;
-
 };
 
 photonIsolationHIProducer::photonIsolationHIProducer(const edm::ParameterSet& config)
-  :
-  photonProducer_   (
-    consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photonProducer"))),
-  barrelEcalHits_   (
-    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("ebRecHitCollection"))),
-  endcapEcalHits_   (
-    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("eeRecHitCollection"))),
-  hbhe_ ( consumes<HBHERecHitCollection>(config.getParameter<edm::InputTag>("hbhe"))),
-  hf_ ( consumes<HFRecHitCollection>(config.getParameter<edm::InputTag>("hf"))),
-  ho_ ( consumes<HORecHitCollection>(config.getParameter<edm::InputTag>("ho"))),
-  barrelClusters_ ( consumes<reco::BasicClusterCollection>(config.getParameter<edm::InputTag>("basicClusterBarrel"))),
-  endcapClusters_ ( consumes<reco::BasicClusterCollection>(config.getParameter<edm::InputTag>("basicClusterEndcap"))),
-  tracks_ ( consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("trackCollection"))),
-  trackQuality_ ( config.getParameter<std::string>("trackQuality"))
-{
-  produces< reco::HIPhotonIsolationMap >();
+    : photonProducer_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photonProducer"))),
+      barrelEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("ebRecHitCollection"))),
+      endcapEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("eeRecHitCollection"))),
+      hbhe_(consumes<HBHERecHitCollection>(config.getParameter<edm::InputTag>("hbhe"))),
+      hf_(consumes<HFRecHitCollection>(config.getParameter<edm::InputTag>("hf"))),
+      ho_(consumes<HORecHitCollection>(config.getParameter<edm::InputTag>("ho"))),
+      barrelClusters_(consumes<reco::BasicClusterCollection>(config.getParameter<edm::InputTag>("basicClusterBarrel"))),
+      endcapClusters_(consumes<reco::BasicClusterCollection>(config.getParameter<edm::InputTag>("basicClusterEndcap"))),
+      tracks_(consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("trackCollection"))),
+      trackQuality_(config.getParameter<std::string>("trackQuality")) {
+  produces<reco::HIPhotonIsolationMap>();
 }
 
 photonIsolationHIProducer::~photonIsolationHIProducer() {}
 
-void
-photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::PhotonCollection> photons;
   evt.getByToken(photonProducer_, photons);
   edm::Handle<EcalRecHitCollection> barrelEcalHits;
@@ -93,40 +82,39 @@ photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   reco::HIPhotonIsolationMap::Filler filler(*outputMap);
   std::vector<reco::HIPhotonIsolation> isoVector;
 
-  EcalClusterIsoCalculator CxC(evt,es, barrelClusters, endcapClusters);
-  HcalRechitIsoCalculator RxC(evt,es, hbhe, hf, ho);
+  EcalClusterIsoCalculator CxC(evt, es, barrelClusters, endcapClusters);
+  HcalRechitIsoCalculator RxC(evt, es, hbhe, hf, ho);
   TrackIsoCalculator TxC(evt, es, trackCollection, trackQuality_);
   EcalClusterLazyTools lazyTool(evt, es, barrelEcalHits_, endcapEcalHits_);
 
-  for (reco::PhotonCollection::const_iterator phoItr = photons->begin(); phoItr != photons->end(); ++phoItr)
-  {
+  for (reco::PhotonCollection::const_iterator phoItr = photons->begin(); phoItr != photons->end(); ++phoItr) {
     reco::HIPhotonIsolation iso;
     // HI-style isolation info
-    iso.ecalClusterIsoR1(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(),1,0));
-    iso.ecalClusterIsoR2(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(),2,0));
-    iso.ecalClusterIsoR3(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(),3,0));
-    iso.ecalClusterIsoR4(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(),4,0));
-    iso.ecalClusterIsoR5(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(),5,0));
+    iso.ecalClusterIsoR1(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(), 1, 0));
+    iso.ecalClusterIsoR2(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(), 2, 0));
+    iso.ecalClusterIsoR3(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(), 3, 0));
+    iso.ecalClusterIsoR4(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(), 4, 0));
+    iso.ecalClusterIsoR5(CxC.getBkgSubEcalClusterIso(phoItr->superCluster(), 5, 0));
 
-    iso.hcalRechitIsoR1(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(),1,0));
-    iso.hcalRechitIsoR2(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(),2,0));
-    iso.hcalRechitIsoR3(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(),3,0));
-    iso.hcalRechitIsoR4(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(),4,0));
-    iso.hcalRechitIsoR5(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(),5,0));
+    iso.hcalRechitIsoR1(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(), 1, 0));
+    iso.hcalRechitIsoR2(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(), 2, 0));
+    iso.hcalRechitIsoR3(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(), 3, 0));
+    iso.hcalRechitIsoR4(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(), 4, 0));
+    iso.hcalRechitIsoR5(RxC.getBkgSubHcalRechitIso(phoItr->superCluster(), 5, 0));
 
-    iso.trackIsoR1PtCut20(TxC.getBkgSubTrackIso(*phoItr,1,2));
-    iso.trackIsoR2PtCut20(TxC.getBkgSubTrackIso(*phoItr,2,2));
-    iso.trackIsoR3PtCut20(TxC.getBkgSubTrackIso(*phoItr,3,2));
-    iso.trackIsoR4PtCut20(TxC.getBkgSubTrackIso(*phoItr,4,2));
-    iso.trackIsoR5PtCut20(TxC.getBkgSubTrackIso(*phoItr,5,2));
+    iso.trackIsoR1PtCut20(TxC.getBkgSubTrackIso(*phoItr, 1, 2));
+    iso.trackIsoR2PtCut20(TxC.getBkgSubTrackIso(*phoItr, 2, 2));
+    iso.trackIsoR3PtCut20(TxC.getBkgSubTrackIso(*phoItr, 3, 2));
+    iso.trackIsoR4PtCut20(TxC.getBkgSubTrackIso(*phoItr, 4, 2));
+    iso.trackIsoR5PtCut20(TxC.getBkgSubTrackIso(*phoItr, 5, 2));
 
     // ecal spike rejection info (seed timing)
-    const reco::CaloClusterPtr  seed = phoItr->superCluster()->seed();
-    const DetId &id = lazyTool.getMaximum(*seed).first;
-    float time  = -999.;
-    const EcalRecHitCollection & rechits = ( phoItr->isEB() ? *barrelEcalHits : *endcapEcalHits);
-    EcalRecHitCollection::const_iterator it = rechits.find( id );
-    if( it != rechits.end() ) {
+    const reco::CaloClusterPtr seed = phoItr->superCluster()->seed();
+    const DetId& id = lazyTool.getMaximum(*seed).first;
+    float time = -999.;
+    const EcalRecHitCollection& rechits = (phoItr->isEB() ? *barrelEcalHits : *endcapEcalHits);
+    EcalRecHitCollection::const_iterator it = rechits.find(id);
+    if (it != rechits.end()) {
       time = it->time();
     }
     iso.seedTime(time);
@@ -137,29 +125,28 @@ photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     float eLeft = lazyTool.eLeft(*seed);
     float eTop = lazyTool.eTop(*seed);
     float eBottom = lazyTool.eBottom(*seed);
-    iso.swissCrx( 1 - (eRight + eLeft + eTop + eBottom)/eMax );
+    iso.swissCrx(1 - (eRight + eLeft + eTop + eBottom) / eMax);
 
     isoVector.push_back(iso);
   }
-  filler.insert(photons, isoVector.begin(), isoVector.end() );
+  filler.insert(photons, isoVector.begin(), isoVector.end());
   filler.fill();
   evt.put(std::move(outputMap));
 }
 
-void
-photonIsolationHIProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void photonIsolationHIProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("photonProducer",edm::InputTag("photons"));
-  desc.add<edm::InputTag>("ebRecHitCollection",edm::InputTag("ecalRecHit:EcalRecHitsEB"));
-  desc.add<edm::InputTag>("eeRecHitCollection",edm::InputTag("ecalRecHit:EcalRecHitsEE"));
-  desc.add<edm::InputTag>("hbhe",edm::InputTag("hbhereco"));
-  desc.add<edm::InputTag>("hf",edm::InputTag("hfreco"));
-  desc.add<edm::InputTag>("ho",edm::InputTag("horeco"));
-  desc.add<edm::InputTag>("basicClusterBarrel",edm::InputTag("islandBasicClusters:islandBarrelBasicClusters"));
-  desc.add<edm::InputTag>("basicClusterEndcap",edm::InputTag("islandBasicClusters:islandEndcapBasicClusters"));
-  desc.add<edm::InputTag>("trackCollection",edm::InputTag("hiGeneralTracks"));
-  desc.add<std::string>("trackQuality","highPurity");
+  desc.add<edm::InputTag>("photonProducer", edm::InputTag("photons"));
+  desc.add<edm::InputTag>("ebRecHitCollection", edm::InputTag("ecalRecHit:EcalRecHitsEB"));
+  desc.add<edm::InputTag>("eeRecHitCollection", edm::InputTag("ecalRecHit:EcalRecHitsEE"));
+  desc.add<edm::InputTag>("hbhe", edm::InputTag("hbhereco"));
+  desc.add<edm::InputTag>("hf", edm::InputTag("hfreco"));
+  desc.add<edm::InputTag>("ho", edm::InputTag("horeco"));
+  desc.add<edm::InputTag>("basicClusterBarrel", edm::InputTag("islandBasicClusters:islandBarrelBasicClusters"));
+  desc.add<edm::InputTag>("basicClusterEndcap", edm::InputTag("islandBasicClusters:islandEndcapBasicClusters"));
+  desc.add<edm::InputTag>("trackCollection", edm::InputTag("hiGeneralTracks"));
+  desc.add<std::string>("trackQuality", "highPurity");
 
   descriptions.add("photonIsolationHIProducer", desc);
 }

--- a/RecoHI/HiEgammaAlgos/src/EcalClusterIsoCalculator.cc
+++ b/RecoHI/HiEgammaAlgos/src/EcalClusterIsoCalculator.cc
@@ -12,130 +12,131 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 
-
 using namespace edm;
 using namespace reco;
 using namespace std;
 
-EcalClusterIsoCalculator::EcalClusterIsoCalculator(const edm::Event &iEvent, const edm::EventSetup &iSetup, const edm::Handle<BasicClusterCollection> pEBclusters, const edm::Handle<BasicClusterCollection> pEEclusters)
-{
-  if(pEBclusters.isValid())
-     fEBclusters_ = pEBclusters.product();
-   else
-     fEBclusters_ = nullptr;
+EcalClusterIsoCalculator::EcalClusterIsoCalculator(const edm::Event &iEvent,
+                                                   const edm::EventSetup &iSetup,
+                                                   const edm::Handle<BasicClusterCollection> pEBclusters,
+                                                   const edm::Handle<BasicClusterCollection> pEEclusters) {
+  if (pEBclusters.isValid())
+    fEBclusters_ = pEBclusters.product();
+  else
+    fEBclusters_ = nullptr;
 
-   if(pEEclusters.isValid())
-     fEEclusters_ = pEEclusters.product();
-   else
-     fEEclusters_ = nullptr;
+  if (pEEclusters.isValid())
+    fEEclusters_ = pEEclusters.product();
+  else
+    fEEclusters_ = nullptr;
 
-   ESHandle<CaloGeometry> geometryHandle;
-   iSetup.get<CaloGeometryRecord>().get(geometryHandle);
-   if(geometryHandle.isValid())
-     geometry_ = geometryHandle.product();
-   else
-     geometry_ = nullptr;
+  ESHandle<CaloGeometry> geometryHandle;
+  iSetup.get<CaloGeometryRecord>().get(geometryHandle);
+  if (geometryHandle.isValid())
+    geometry_ = geometryHandle.product();
+  else
+    geometry_ = nullptr;
 }
 
-double EcalClusterIsoCalculator::getEcalClusterIso(const reco::SuperClusterRef cluster, const double x, const double threshold)
-{
-   if(!fEBclusters_) {
-      return -100;
-   }
+double EcalClusterIsoCalculator::getEcalClusterIso(const reco::SuperClusterRef cluster,
+                                                   const double x,
+                                                   const double threshold) {
+  if (!fEBclusters_) {
+    return -100;
+  }
 
-   if(!fEEclusters_) {
-      return -100;
-   }
+  if (!fEEclusters_) {
+    return -100;
+  }
 
-   math::XYZVector SClusPoint(cluster->position().x(),
-                          cluster->position().y(),
-                          cluster->position().z());
+  math::XYZVector SClusPoint(cluster->position().x(), cluster->position().y(), cluster->position().z());
 
-   double TotalEt = 0;
+  double TotalEt = 0;
 
-   TotalEt = - cluster->rawEnergy()/cosh(cluster->eta());
+  TotalEt = -cluster->rawEnergy() / cosh(cluster->eta());
 
-   // Loop over barrel basic clusters
-   for(BasicClusterCollection::const_iterator iclu = fEBclusters_->begin();
-       iclu != fEBclusters_->end(); ++iclu) {
-      const BasicCluster *clu = &(*iclu);
-      math::XYZVector ClusPoint(clu->x(),clu->y(),clu->z());
-      double eta = ClusPoint.eta();
+  // Loop over barrel basic clusters
+  for (BasicClusterCollection::const_iterator iclu = fEBclusters_->begin(); iclu != fEBclusters_->end(); ++iclu) {
+    const BasicCluster *clu = &(*iclu);
+    math::XYZVector ClusPoint(clu->x(), clu->y(), clu->z());
+    double eta = ClusPoint.eta();
 
-      double dR2 = reco::deltaR2(*clu, *cluster);
+    double dR2 = reco::deltaR2(*clu, *cluster);
 
-      if (dR2 < (x*x*0.01)) {
-         double et = clu->energy()/cosh(eta);
-         if (et<threshold) et=0;
-         TotalEt += et;
-      }
-   }
+    if (dR2 < (x * x * 0.01)) {
+      double et = clu->energy() / cosh(eta);
+      if (et < threshold)
+        et = 0;
+      TotalEt += et;
+    }
+  }
 
-   for(BasicClusterCollection::const_iterator iclu = fEEclusters_->begin();
-       iclu != fEEclusters_->end(); ++iclu) {
-      const BasicCluster *clu = &(*iclu);
-      const GlobalPoint clusPoint(clu->x(),clu->y(),clu->z());
-      math::XYZVector ClusPoint(clu->x(),clu->y(),clu->z());
-      double eta = ClusPoint.eta();
+  for (BasicClusterCollection::const_iterator iclu = fEEclusters_->begin(); iclu != fEEclusters_->end(); ++iclu) {
+    const BasicCluster *clu = &(*iclu);
+    const GlobalPoint clusPoint(clu->x(), clu->y(), clu->z());
+    math::XYZVector ClusPoint(clu->x(), clu->y(), clu->z());
+    double eta = ClusPoint.eta();
 
-      double dR2 = reco::deltaR2(*clu, *cluster);
+    double dR2 = reco::deltaR2(*clu, *cluster);
 
-      if (dR2 < (x*x*0.01)) {
-         double et = clu->energy()/cosh(eta);
-         if (et<threshold) et=0;
-         TotalEt += et;
-      }
-   }
+    if (dR2 < (x * x * 0.01)) {
+      double et = clu->energy() / cosh(eta);
+      if (et < threshold)
+        et = 0;
+      TotalEt += et;
+    }
+  }
 
-   return TotalEt;
+  return TotalEt;
 }
 
-double EcalClusterIsoCalculator::getBkgSubEcalClusterIso(const reco::SuperClusterRef cluster, const double x, double const threshold)
-{
-   if(!fEBclusters_) {
-      return -100;
-   }
+double EcalClusterIsoCalculator::getBkgSubEcalClusterIso(const reco::SuperClusterRef cluster,
+                                                         const double x,
+                                                         double const threshold) {
+  if (!fEBclusters_) {
+    return -100;
+  }
 
-   if(!fEEclusters_) {
-      return -100;
-   }
+  if (!fEEclusters_) {
+    return -100;
+  }
 
-   double SClusterEta = cluster->eta();
-   double TotalEt = 0;
+  double SClusterEta = cluster->eta();
+  double TotalEt = 0;
 
-   TotalEt = - cluster->rawEnergy()/cosh(cluster->eta());
+  TotalEt = -cluster->rawEnergy() / cosh(cluster->eta());
 
-   for(BasicClusterCollection::const_iterator iclu = fEBclusters_->begin();
-       iclu != fEBclusters_->end(); ++iclu) {
-      const BasicCluster *clu = &(*iclu);
-      math::XYZVector ClusPoint(clu->x(),clu->y(),clu->z());
-      double eta = ClusPoint.eta();
+  for (BasicClusterCollection::const_iterator iclu = fEBclusters_->begin(); iclu != fEBclusters_->end(); ++iclu) {
+    const BasicCluster *clu = &(*iclu);
+    math::XYZVector ClusPoint(clu->x(), clu->y(), clu->z());
+    double eta = ClusPoint.eta();
 
-      double dEta = fabs(eta-SClusterEta);
+    double dEta = fabs(eta - SClusterEta);
 
-     if (dEta<x*0.1) {
-         double et = clu->energy()/cosh(eta);
-         if (et<threshold) et=0;
-         TotalEt += et;
-      }
-   }
+    if (dEta < x * 0.1) {
+      double et = clu->energy() / cosh(eta);
+      if (et < threshold)
+        et = 0;
+      TotalEt += et;
+    }
+  }
 
-   for(BasicClusterCollection::const_iterator iclu = fEEclusters_->begin();
-       iclu != fEEclusters_->end(); ++iclu) {
-      const BasicCluster *clu = &(*iclu);
-      math::XYZVector ClusPoint(clu->x(),clu->y(),clu->z());
-      double eta = ClusPoint.eta();
-      double dEta = fabs(eta-SClusterEta);
+  for (BasicClusterCollection::const_iterator iclu = fEEclusters_->begin(); iclu != fEEclusters_->end(); ++iclu) {
+    const BasicCluster *clu = &(*iclu);
+    math::XYZVector ClusPoint(clu->x(), clu->y(), clu->z());
+    double eta = ClusPoint.eta();
+    double dEta = fabs(eta - SClusterEta);
 
-      if (dEta<x*0.1) {
-         double et = clu->energy()/cosh(eta);
-         if (et<threshold) et=0;
-         TotalEt += et;
-      }
-   }
+    if (dEta < x * 0.1) {
+      double et = clu->energy() / cosh(eta);
+      if (et < threshold)
+        et = 0;
+      TotalEt += et;
+    }
+  }
 
-   double Cx = getEcalClusterIso(cluster,x,threshold);
-   double CCx = (Cx - TotalEt / 40.0 * x) * (1/(1-x/40.));
+  double Cx = getEcalClusterIso(cluster, x, threshold);
+  double CCx = (Cx - TotalEt / 40.0 * x) * (1 / (1 - x / 40.));
 
-   return CCx;
+  return CCx;
 }

--- a/RecoHI/HiEgammaAlgos/src/HcalRechitIsoCalculator.cc
+++ b/RecoHI/HiEgammaAlgos/src/HcalRechitIsoCalculator.cc
@@ -10,90 +10,97 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-
 using namespace edm;
 using namespace reco;
 
-HcalRechitIsoCalculator::HcalRechitIsoCalculator(const edm::Event &iEvent, const edm::EventSetup &iSetup, const edm::Handle<HBHERecHitCollection> hbhe, const edm::Handle<HFRecHitCollection> hf, const edm::Handle<HORecHitCollection> ho)
-{
-  if(hf.isValid())
+HcalRechitIsoCalculator::HcalRechitIsoCalculator(const edm::Event &iEvent,
+                                                 const edm::EventSetup &iSetup,
+                                                 const edm::Handle<HBHERecHitCollection> hbhe,
+                                                 const edm::Handle<HFRecHitCollection> hf,
+                                                 const edm::Handle<HORecHitCollection> ho) {
+  if (hf.isValid())
     fHFRecHits_ = hf.product();
   else
     fHFRecHits_ = nullptr;
 
-  if(ho.isValid())
+  if (ho.isValid())
     fHORecHits_ = ho.product();
   else
     fHORecHits_ = nullptr;
 
-  if(hbhe.isValid())
+  if (hbhe.isValid())
     fHBHERecHits_ = hbhe.product();
   else
     fHBHERecHits_ = nullptr;
 
   ESHandle<CaloGeometry> geometryHandle;
   iSetup.get<CaloGeometryRecord>().get(geometryHandle);
-  if(geometryHandle.isValid())
+  if (geometryHandle.isValid())
     geometry_ = geometryHandle.product();
   else
     geometry_ = nullptr;
-
 }
 
+double HcalRechitIsoCalculator::getHcalRechitIso(const reco::SuperClusterRef cluster,
+                                                 const double x,
+                                                 const double threshold,
+                                                 const double innerR) {
+  if (!fHBHERecHits_) {
+    return -100;
+  }
 
-double HcalRechitIsoCalculator::getHcalRechitIso(const reco::SuperClusterRef cluster, const double x, const double threshold, const double innerR )
-{
-   if(!fHBHERecHits_) {
-     return -100;
-   }
+  double TotalEt = 0;
 
-   double TotalEt = 0;
+  for (size_t index = 0; index < fHBHERecHits_->size(); index++) {
+    const HBHERecHit &rechit = (*fHBHERecHits_)[index];
+    const DetId &detid = rechit.id();
+    const GlobalPoint &hitpoint = geometry_->getPosition(detid);
+    double eta = hitpoint.eta();
 
-   for(size_t index = 0; index < fHBHERecHits_->size(); index++) {
-      const HBHERecHit &rechit = (*fHBHERecHits_)[index];
-      const DetId &detid = rechit.id();
-      const GlobalPoint& hitpoint = geometry_->getPosition(detid);
-      double eta = hitpoint.eta();
+    double dR2 = reco::deltaR2(*cluster, hitpoint);
+    // veto inner cone///////////////
+    if (dR2 < innerR * innerR)
+      continue;
+    /////////////////////////////////
+    if (dR2 < (x * x * 0.01)) {
+      double et = rechit.energy() / cosh(eta);
+      if (et < threshold)
+        et = 0;
+      TotalEt += et;
+    }
+  }
 
-      double dR2 = reco::deltaR2(*cluster, hitpoint);
-      // veto inner cone///////////////
-      if ( dR2 < innerR*innerR )  continue;
-      /////////////////////////////////
-      if (dR2< (x*x*0.01)) {
-	 double et = rechit.energy()/cosh(eta);
-         if (et<threshold) et=0;
-         TotalEt += et;
-      }
-   }
-
-   return TotalEt;
+  return TotalEt;
 }
 
-double HcalRechitIsoCalculator::getBkgSubHcalRechitIso(const reco::SuperClusterRef cluster, const double x, const double threshold, const double innerR )
-{
-   if(!fHBHERecHits_) {
-      return -100;
-   }
+double HcalRechitIsoCalculator::getBkgSubHcalRechitIso(const reco::SuperClusterRef cluster,
+                                                       const double x,
+                                                       const double threshold,
+                                                       const double innerR) {
+  if (!fHBHERecHits_) {
+    return -100;
+  }
 
-   double SClusterEta = cluster->eta();
-   double TotalEt = 0;
+  double SClusterEta = cluster->eta();
+  double TotalEt = 0;
 
-   for(size_t index = 0; index < fHBHERecHits_->size(); index++) {
-      const HBHERecHit &rechit = (*fHBHERecHits_)[index];
-      const DetId &detid = rechit.id();
-      const GlobalPoint& hitpoint = geometry_->getPosition(detid);
-      double eta = hitpoint.eta();
-      double dEta = fabs(eta-SClusterEta);
+  for (size_t index = 0; index < fHBHERecHits_->size(); index++) {
+    const HBHERecHit &rechit = (*fHBHERecHits_)[index];
+    const DetId &detid = rechit.id();
+    const GlobalPoint &hitpoint = geometry_->getPosition(detid);
+    double eta = hitpoint.eta();
+    double dEta = fabs(eta - SClusterEta);
 
-      if (dEta<x*0.1) {
-         double et = rechit.energy()/cosh(eta);
-         if (et<threshold) et=0;
-         TotalEt += et;
-      }
-   }
+    if (dEta < x * 0.1) {
+      double et = rechit.energy() / cosh(eta);
+      if (et < threshold)
+        et = 0;
+      TotalEt += et;
+    }
+  }
 
-   double Rx = getHcalRechitIso(cluster,x,threshold,innerR);
-   double CRx = (Rx - TotalEt * (0.01*x*x - innerR*innerR) / (2 * 2 * 0.1 * x))*(1/(1-x/40.)) ;
+  double Rx = getHcalRechitIso(cluster, x, threshold, innerR);
+  double CRx = (Rx - TotalEt * (0.01 * x * x - innerR * innerR) / (2 * 2 * 0.1 * x)) * (1 / (1 - x / 40.));
 
-   return CRx;
+  return CRx;
 }

--- a/RecoHI/HiEgammaAlgos/src/HiBremRecoveryClusterAlgo.cc
+++ b/RecoHI/HiEgammaAlgos/src/HiBremRecoveryClusterAlgo.cc
@@ -2,8 +2,8 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
-reco::SuperClusterCollection HiBremRecoveryClusterAlgo::makeSuperClusters(reco::CaloClusterPtrVector & clustersCollection)
-{
+reco::SuperClusterCollection HiBremRecoveryClusterAlgo::makeSuperClusters(
+    reco::CaloClusterPtrVector &clustersCollection) {
   const float etaBorder = 1.479;
 
   superclusters_v.clear();
@@ -13,161 +13,153 @@ reco::SuperClusterCollection HiBremRecoveryClusterAlgo::makeSuperClusters(reco::
   reco::CaloClusterPtrVector islandClustersEndCap_v;
 
   // ...and populate them:
-  for (reco::CaloCluster_iterator it = clustersCollection.begin(); it != clustersCollection.end(); it++)
-  {
-    
-     reco::CaloClusterPtr cluster_p = *it;
-     if (cluster_p->algo() == reco::CaloCluster::island) 
-     {
-        if (verbosity <= pINFO)
-        {
-           std::cout <<"Basic Cluster: (eta,phi,energy) = "<<cluster_p->position().eta()<<" "<<cluster_p->position().phi()<<" "
-        					          <<cluster_p->energy()<<std::endl;
-        }
+  for (reco::CaloCluster_iterator it = clustersCollection.begin(); it != clustersCollection.end(); it++) {
+    reco::CaloClusterPtr cluster_p = *it;
+    if (cluster_p->algo() == reco::CaloCluster::island) {
+      if (verbosity <= pINFO) {
+        std::cout << "Basic Cluster: (eta,phi,energy) = " << cluster_p->position().eta() << " "
+                  << cluster_p->position().phi() << " " << cluster_p->energy() << std::endl;
+      }
 
-        // if the basic cluster pass the energy threshold -> fill it into the list
-        if (fabs(cluster_p->position().eta()) < etaBorder)
-        {
-           if (cluster_p->energy() > BarrelBremEnergyThreshold) islandClustersBarrel_v.push_back(cluster_p);
-        } else {
-           if (cluster_p->energy() > EndcapBremEnergyThreshold) islandClustersEndCap_v.push_back(cluster_p);
-        }
-     }
+      // if the basic cluster pass the energy threshold -> fill it into the list
+      if (fabs(cluster_p->position().eta()) < etaBorder) {
+        if (cluster_p->energy() > BarrelBremEnergyThreshold)
+          islandClustersBarrel_v.push_back(cluster_p);
+      } else {
+        if (cluster_p->energy() > EndcapBremEnergyThreshold)
+          islandClustersEndCap_v.push_back(cluster_p);
+      }
+    }
   }
 
   // make the superclusters from the Barrel clusters - Island
   makeIslandSuperClusters(islandClustersBarrel_v, eb_rdeta_, eb_rdphi_);
-  
+
   // make the superclusters from the EndCap clusters - Island
   makeIslandSuperClusters(islandClustersEndCap_v, ec_rdeta_, ec_rdphi_);
 
   return superclusters_v;
 }
 
-void HiBremRecoveryClusterAlgo::makeIslandSuperClusters(reco::CaloClusterPtrVector &clusters_v, 
-						      double etaRoad, double phiRoad)
-{
+void HiBremRecoveryClusterAlgo::makeIslandSuperClusters(reco::CaloClusterPtrVector &clusters_v,
+                                                        double etaRoad,
+                                                        double phiRoad) {
   // Vector of usedSeedEnergy, use the seed energy to check if this cluster is used.
   std::vector<double> usedSeedEnergy;
   usedSeedEnergy.clear();
 
   // Main brem recovery loop
-  for ( reco::CaloCluster_iterator currentSeed = clusters_v.begin(); currentSeed != clusters_v.end(); ++currentSeed)
-  {
-     if (verbosity <= pINFO) {
-    	std::cout <<"Current Cluster: "<<(*currentSeed)->energy()<<" "<<(std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentSeed)->energy()) 
-    	     != usedSeedEnergy.end())<<std::endl;
-     }
+  for (reco::CaloCluster_iterator currentSeed = clusters_v.begin(); currentSeed != clusters_v.end(); ++currentSeed) {
+    if (verbosity <= pINFO) {
+      std::cout << "Current Cluster: " << (*currentSeed)->energy() << " "
+                << (std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentSeed)->energy()) !=
+                    usedSeedEnergy.end())
+                << std::endl;
+    }
 
-     // check this seed was not already used
-     if (std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentSeed)->energy()) 
-    	     != usedSeedEnergy.end()) continue;
+    // check this seed was not already used
+    if (std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentSeed)->energy()) != usedSeedEnergy.end())
+      continue;
 
-     // Does our highest energy cluster have high enough energy? If not, continue instead of break to be robust
-     if ((*currentSeed)->energy() * sin((*currentSeed)->position().theta()) < seedTransverseEnergyThreshold) continue;
+    // Does our highest energy cluster have high enough energy? If not, continue instead of break to be robust
+    if ((*currentSeed)->energy() * sin((*currentSeed)->position().theta()) < seedTransverseEnergyThreshold)
+      continue;
 
-     // if yes, make it a seed for a new SuperCluster, the position of the SC is calculated by energy weighted sum:
-     double energy_ = (*currentSeed)->energy();
-     math::XYZVector position_((*currentSeed)->position().X(), 
-        		       (*currentSeed)->position().Y(), 
-        		       (*currentSeed)->position().Z());
-     position_ *= energy_;
-     usedSeedEnergy.push_back((*currentSeed)->energy());
+    // if yes, make it a seed for a new SuperCluster, the position of the SC is calculated by energy weighted sum:
+    double energy_ = (*currentSeed)->energy();
+    math::XYZVector position_(
+        (*currentSeed)->position().X(), (*currentSeed)->position().Y(), (*currentSeed)->position().Z());
+    position_ *= energy_;
+    usedSeedEnergy.push_back((*currentSeed)->energy());
 
-     // Printout if verbose
-     if (verbosity <= pINFO)
-     {
-       std::cout << "*****************************" << std::endl;
-       std::cout << "******NEW SUPERCLUSTER*******" << std::endl;
-       std::cout << "Seed R = " << (*currentSeed)->position().Rho() << std::endl;
-       std::cout << "Seed Et = " << (*currentSeed)->energy()* sin((*currentSeed)->position().theta()) << std::endl;
-     }
+    // Printout if verbose
+    if (verbosity <= pINFO) {
+      std::cout << "*****************************" << std::endl;
+      std::cout << "******NEW SUPERCLUSTER*******" << std::endl;
+      std::cout << "Seed R = " << (*currentSeed)->position().Rho() << std::endl;
+      std::cout << "Seed Et = " << (*currentSeed)->energy() * sin((*currentSeed)->position().theta()) << std::endl;
+    }
 
-     // and add the matching clusters:
-     reco::CaloClusterPtrVector constituentClusters;
-     constituentClusters.push_back( *currentSeed );
-     reco::CaloCluster_iterator currentCluster = currentSeed + 1;
+    // and add the matching clusters:
+    reco::CaloClusterPtrVector constituentClusters;
+    constituentClusters.push_back(*currentSeed);
+    reco::CaloCluster_iterator currentCluster = currentSeed + 1;
 
-     // loop over the clusters
-     while (currentCluster != clusters_v.end())
-     {
-        // Print out the basic clusters
+    // loop over the clusters
+    while (currentCluster != clusters_v.end()) {
+      // Print out the basic clusters
+      if (verbosity <= pINFO) {
+        std::cout << "->Cluster: " << (*currentCluster)->energy() << " Used = "
+                  << (std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentCluster)->energy()) !=
+                      usedSeedEnergy.end())
+                  << " Matched = " << match(*currentSeed, *currentCluster, etaRoad, phiRoad) << std::endl;
+      }
+
+      // if it's in the search window, and unused
+      if (match(*currentSeed, *currentCluster, etaRoad, phiRoad) &&
+          (std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentCluster)->energy()) ==
+           usedSeedEnergy.end())) {
+        // Add basic cluster
+        constituentClusters.push_back(*currentCluster);
+        energy_ += (*currentCluster)->energy();
+        position_ += (*currentCluster)->energy() * math::XYZVector((*currentCluster)->position().X(),
+                                                                   (*currentCluster)->position().Y(),
+                                                                   (*currentCluster)->position().Z());
+        // Add the cluster to the used list
+        usedSeedEnergy.push_back((*currentCluster)->energy());
+
         if (verbosity <= pINFO) {
-           std::cout <<"->Cluster: "<<(*currentCluster)->energy()
-                     <<" Used = "<<(std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentCluster)->energy()) != usedSeedEnergy.end())
-                     <<" Matched = "<<match(*currentSeed, *currentCluster, etaRoad, phiRoad)<<std::endl;
+          std::cout << "Cluster R = " << (*currentCluster)->position().Rho() << std::endl;
         }
+      }
+      ++currentCluster;
+    }
 
-        // if it's in the search window, and unused
-        if (match(*currentSeed, *currentCluster, etaRoad, phiRoad)
-            && (std::find(usedSeedEnergy.begin(), usedSeedEnergy.end(), (*currentCluster)->energy()) == usedSeedEnergy.end()))
-        {
-           // Add basic cluster
-           constituentClusters.push_back(*currentCluster);
-           energy_   += (*currentCluster)->energy();
-           position_ += (*currentCluster)->energy() * math::XYZVector((*currentCluster)->position().X(), 
-                                                                      (*currentCluster)->position().Y(), 
-                                                                      (*currentCluster)->position().Z()); 
-           // Add the cluster to the used list
-           usedSeedEnergy.push_back((*currentCluster)->energy());
+    // Calculate the final position
+    position_ /= energy_;
 
-           if (verbosity <= pINFO) 
-           {
-              std::cout << "Cluster R = " << (*currentCluster)->position().Rho() << std::endl;
-           }
+    if (verbosity <= pINFO) {
+      std::cout << "Final SuperCluster R = " << position_.Rho() << std::endl;
+    }
 
-        }
-        ++currentCluster;
-     }
+    // Add the supercluster to the new collection
+    reco::SuperCluster newSuperCluster(
+        energy_, math::XYZPoint(position_.X(), position_.Y(), position_.Z()), (*currentSeed), constituentClusters);
 
-     // Calculate the final position
-     position_ /= energy_;
+    superclusters_v.push_back(newSuperCluster);
 
-     if (verbosity <= pINFO)
-     {
-       std::cout << "Final SuperCluster R = " << position_.Rho() << std::endl;
-     }
-
-     // Add the supercluster to the new collection
-     reco::SuperCluster newSuperCluster(energy_, 
-        				math::XYZPoint(position_.X(), position_.Y(), position_.Z()), 
-        				(*currentSeed), 
-        				constituentClusters);
-
-     superclusters_v.push_back(newSuperCluster);
-
-     if (verbosity <= pINFO)
-       {
-         std::cout << "created a new supercluster of: " << std::endl;
-         std::cout << "Energy = " << newSuperCluster.energy() << std::endl;
-         std::cout << "Position in (R, phi, theta, eta) = (" 
-        	   << newSuperCluster.position().Rho() << ", " 
-        	   << newSuperCluster.position().phi() << ", "
-        	   << newSuperCluster.position().theta() << ", "
-        	   << newSuperCluster.position().eta() << ")" << std::endl;
-       }
+    if (verbosity <= pINFO) {
+      std::cout << "created a new supercluster of: " << std::endl;
+      std::cout << "Energy = " << newSuperCluster.energy() << std::endl;
+      std::cout << "Position in (R, phi, theta, eta) = (" << newSuperCluster.position().Rho() << ", "
+                << newSuperCluster.position().phi() << ", " << newSuperCluster.position().theta() << ", "
+                << newSuperCluster.position().eta() << ")" << std::endl;
+    }
   }
   clusters_v.clear();
   usedSeedEnergy.clear();
 }
 
-
-bool HiBremRecoveryClusterAlgo::match(reco::CaloClusterPtr seed_p, 
-				    reco::CaloClusterPtr cluster_p,
-				    double dEtaMax, double dPhiMax)
-{
+bool HiBremRecoveryClusterAlgo::match(reco::CaloClusterPtr seed_p,
+                                      reco::CaloClusterPtr cluster_p,
+                                      double dEtaMax,
+                                      double dPhiMax) {
   math::XYZPoint clusterPosition = cluster_p->position();
   math::XYZPoint seedPosition = seed_p->position();
 
   double dPhi = acos(cos(seedPosition.phi() - clusterPosition.phi()));
- 
+
   double dEta = fabs(seedPosition.eta() - clusterPosition.eta());
   if (verbosity <= pINFO) {
-     std::cout <<"seed phi: "<<seedPosition.phi()<<" cluster phi: "<<clusterPosition.phi()<<" dphi = "<<dPhi<<" dphiMax = "<<dPhiMax<<std::endl;
-     std::cout <<"seed eta: "<<seedPosition.eta()<<" cluster eta: "<<clusterPosition.eta()<<" deta = "<<dEta<<" detaMax = "<<dEtaMax<<std::endl;
+    std::cout << "seed phi: " << seedPosition.phi() << " cluster phi: " << clusterPosition.phi() << " dphi = " << dPhi
+              << " dphiMax = " << dPhiMax << std::endl;
+    std::cout << "seed eta: " << seedPosition.eta() << " cluster eta: " << clusterPosition.eta() << " deta = " << dEta
+              << " detaMax = " << dEtaMax << std::endl;
   }
-  if (dEta > dEtaMax) return false;
-  if (dPhi > dPhiMax) return false;
+  if (dEta > dEtaMax)
+    return false;
+  if (dPhi > dPhiMax)
+    return false;
 
   return true;
 }

--- a/RecoHI/HiEgammaAlgos/src/HiEgammaSCEnergyCorrectionAlgo.cc
+++ b/RecoHI/HiEgammaAlgos/src/HiEgammaSCEnergyCorrectionAlgo.cc
@@ -7,277 +7,286 @@
 #include <string>
 #include <vector>
 
-HiEgammaSCEnergyCorrectionAlgo::HiEgammaSCEnergyCorrectionAlgo(float noise, 
-							   reco::CaloCluster::AlgoId theAlgo,
-							   const edm::ParameterSet& pSet,
-							   HiEgammaSCEnergyCorrectionAlgo::VerbosityLevel verbosity
-							   )
-{
+HiEgammaSCEnergyCorrectionAlgo::HiEgammaSCEnergyCorrectionAlgo(
+    float noise,
+    reco::CaloCluster::AlgoId theAlgo,
+    const edm::ParameterSet& pSet,
+    HiEgammaSCEnergyCorrectionAlgo::VerbosityLevel verbosity) {
   sigmaElectronicNoise_ = noise;
   verbosity_ = verbosity;
-  
-  // Parameters
-  p_fBrem_ = pSet.getParameter< std::vector <double> > ("fBremVect");
-  p_fBremTh_ = pSet.getParameter< std::vector <double> > ("fBremThVect");
-  p_fEta_ = pSet.getParameter< std::vector <double> > ("fEtaVect");
-  p_fEtEta_ = pSet.getParameter< std::vector <double> > ("fEtEtaVect");
 
-  // Min R9 
+  // Parameters
+  p_fBrem_ = pSet.getParameter<std::vector<double> >("fBremVect");
+  p_fBremTh_ = pSet.getParameter<std::vector<double> >("fBremThVect");
+  p_fEta_ = pSet.getParameter<std::vector<double> >("fEtaVect");
+  p_fEtEta_ = pSet.getParameter<std::vector<double> >("fEtEtaVect");
+
+  // Min R9
   minR9Barrel_ = pSet.getParameter<double>("minR9Barrel");
   minR9Endcap_ = pSet.getParameter<double>("minR9Endcap");
 
   // Max R9
   maxR9_ = pSet.getParameter<double>("maxR9");
-
 }
 
+reco::SuperCluster HiEgammaSCEnergyCorrectionAlgo::applyCorrection(const reco::SuperCluster& cl,
+                                                                   const EcalRecHitCollection& rhc,
+                                                                   reco::CaloCluster::AlgoId theAlgo,
+                                                                   const CaloSubdetectorGeometry* geometry,
+                                                                   const CaloTopology* topology,
+                                                                   EcalClusterFunctionBaseClass* EnergyCorrection) {
+  // Print out a little bit of trivial info to be sure all is well
+  if (verbosity_ <= pINFO) {
+    std::cout << "   HiEgammaSCEnergyCorrectionAlgo::applyCorrection" << std::endl;
+    std::cout << "   SC has energy " << cl.energy() << std::endl;
+    std::cout << "   Will correct now.... " << std::endl;
+  }
 
+  // Get the seed cluster
+  const reco::CaloClusterPtr& seedC = cl.seed();
 
-reco::SuperCluster 
-HiEgammaSCEnergyCorrectionAlgo::applyCorrection(const reco::SuperCluster &cl, 
-						const EcalRecHitCollection &rhc, reco::CaloCluster::AlgoId theAlgo, 
-						const CaloSubdetectorGeometry* geometry,
-						const CaloTopology *topology, EcalClusterFunctionBaseClass* EnergyCorrection)
-{	
-	
-   // Print out a little bit of trivial info to be sure all is well
-   if (verbosity_ <= pINFO)
-   {
-      std::cout << "   HiEgammaSCEnergyCorrectionAlgo::applyCorrection" << std::endl;
-      std::cout << "   SC has energy " << cl.energy() << std::endl;
-      std::cout << "   Will correct now.... " << std::endl;
-   }
+  if (verbosity_ <= pINFO) {
+    std::cout << "   Seed cluster energy... " << seedC->energy() << std::endl;
+  }
 
-   // Get the seed cluster  	
-   const reco::CaloClusterPtr& seedC = cl.seed();
+  // Get the constituent clusters
+  reco::CaloClusterPtrVector clusters_v;
 
-   if (verbosity_ <= pINFO)
-   {
-      std::cout << "   Seed cluster energy... " << seedC->energy() << std::endl;
-   }
+  if (verbosity_ <= pINFO)
+    std::cout << "   Constituent cluster energies... ";
 
-   // Get the constituent clusters
-   reco::CaloClusterPtrVector clusters_v;
+  for (reco::CaloCluster_iterator cluster = cl.clustersBegin(); cluster != cl.clustersEnd(); cluster++) {
+    clusters_v.push_back(*cluster);
+    if (verbosity_ <= pINFO)
+      std::cout << (*cluster)->energy() << ", ";
+  }
+  if (verbosity_ <= pINFO)
+    std::cout << std::endl;
 
-   if (verbosity_ <= pINFO) std::cout << "   Constituent cluster energies... ";
+  // Find the algorithm used to construct the basic clusters making up the supercluster
+  if (verbosity_ <= pINFO) {
+    std::cout << "   The seed cluster used algo " << theAlgo;
+  }
 
-   for(reco::CaloCluster_iterator cluster = cl.clustersBegin(); cluster != cl.clustersEnd(); cluster ++)
-   {
-      clusters_v.push_back(*cluster);
-      if (verbosity_ <= pINFO) std::cout << (*cluster)->energy() << ", ";
-   }
-   if (verbosity_ <= pINFO) std::cout << std::endl;
+  // Find the detector region of the supercluster
+  // where is the seed cluster?
+  std::vector<std::pair<DetId, float> > const& seedHits = seedC->hitsAndFractions();
+  EcalSubdetector theBase = EcalSubdetector(seedHits.at(0).first.subdetId());
+  if (verbosity_ <= pINFO) {
+    std::cout << "   seed cluster location == " << theBase << std::endl;
+  }
 
-   // Find the algorithm used to construct the basic clusters making up the supercluster	
-   if (verbosity_ <= pINFO) 
-   {
-      std::cout << "   The seed cluster used algo " << theAlgo;  
-   }
- 
-   // Find the detector region of the supercluster
-   // where is the seed cluster?
-   std::vector<std::pair<DetId, float> > const & seedHits = seedC->hitsAndFractions();  
-   EcalSubdetector theBase = EcalSubdetector(seedHits.at(0).first.subdetId());
-   if (verbosity_ <= pINFO)
-   {
-      std::cout << "   seed cluster location == " << theBase << std::endl;
-   }
+  // Get number of crystals 2sigma above noise in seed basiccluster
+  int nCryGT2Sigma = nCrystalsGT2Sigma(*seedC, rhc);
+  if (verbosity_ <= pINFO) {
+    std::cout << "   nCryGT2Sigma " << nCryGT2Sigma << std::endl;
+  }
 
-   // Get number of crystals 2sigma above noise in seed basiccluster      
-   int nCryGT2Sigma = nCrystalsGT2Sigma(*seedC,rhc);
-   if (verbosity_ <= pINFO)
-   {
-      std::cout << "   nCryGT2Sigma " << nCryGT2Sigma << std::endl;
-   }
+  // Supercluster enery - seed basiccluster energy
+  float bremsEnergy = cl.energy() - seedC->energy();
+  if (verbosity_ <= pINFO) {
+    std::cout << "   bremsEnergy " << bremsEnergy << std::endl;
+  }
 
-   // Supercluster enery - seed basiccluster energy
-   float bremsEnergy = cl.energy() - seedC->energy();
-   if (verbosity_ <= pINFO)
-   {
-      std::cout << "   bremsEnergy " << bremsEnergy << std::endl;
-   }
+  // Create a SuperClusterShapeAlgo
+  // which calculates phiWidth and etaWidth
+  SuperClusterShapeAlgo SCShape(&rhc, geometry);
 
-   // Create a SuperClusterShapeAlgo
-   // which calculates phiWidth and etaWidth
-   SuperClusterShapeAlgo SCShape(&rhc, geometry);
+  double phiWidth = 0.;
+  double etaWidth = 0.;
 
-   double phiWidth = 0.;
-   double etaWidth = 0.;
- 
-   // Calculate phiWidth & etaWidth for SuperClusters
-   SCShape.Calculate_Covariances(cl);
-   phiWidth = SCShape.phiWidth();
-   etaWidth = SCShape.etaWidth();
+  // Calculate phiWidth & etaWidth for SuperClusters
+  SCShape.Calculate_Covariances(cl);
+  phiWidth = SCShape.phiWidth();
+  etaWidth = SCShape.etaWidth();
 
-   // Calculate r9 and 5x5 energy
-   float e3x3    =   EcalClusterTools::e3x3(  *(cl.seed()), &rhc, &(*topology));
-   float e5x5    =   EcalClusterTools::e5x5(  *(cl.seed()), &rhc, &(*topology));
-   float r9 = e3x3 / cl.rawEnergy();
+  // Calculate r9 and 5x5 energy
+  float e3x3 = EcalClusterTools::e3x3(*(cl.seed()), &rhc, &(*topology));
+  float e5x5 = EcalClusterTools::e5x5(*(cl.seed()), &rhc, &(*topology));
+  float r9 = e3x3 / cl.rawEnergy();
 
-   // Calculate the new supercluster energy 
-   // as a function of number of crystals in the seed basiccluster for Endcap 
-   // lslslsor apply new Enegry SCale correction
-   float newEnergy = 0;
+  // Calculate the new supercluster energy
+  // as a function of number of crystals in the seed basiccluster for Endcap
+  // lslslsor apply new Enegry SCale correction
+  float newEnergy = 0;
 
-   // if r9 > maxR9_ -> uncaptured brem.
-   if ((r9 < minR9Barrel_&&theBase == EcalBarrel) || (r9 < minR9Endcap_&&theBase == EcalEndcap)) {     
-      // if r9 is greater than threshold, then use the SC raw energy
-      newEnergy = (cl.rawEnergy())/ fEta(cl.eta(), theAlgo, theBase) / 
-	fBrem(phiWidth/etaWidth, theAlgo, theBase)
-	/fEtEta(cl.energy()/cosh(cl.eta()), cl.eta(), theAlgo, theBase);
+  // if r9 > maxR9_ -> uncaptured brem.
+  if ((r9 < minR9Barrel_ && theBase == EcalBarrel) || (r9 < minR9Endcap_ && theBase == EcalEndcap)) {
+    // if r9 is greater than threshold, then use the SC raw energy
+    newEnergy = (cl.rawEnergy()) / fEta(cl.eta(), theAlgo, theBase) / fBrem(phiWidth / etaWidth, theAlgo, theBase) /
+                fEtEta(cl.energy() / cosh(cl.eta()), cl.eta(), theAlgo, theBase);
 
-   }  else {
-      if (r9 < maxR9_) {
-         // use 5x5 energy if r9 < threshold
-         newEnergy = e5x5 / fEta(cl.eta(), theAlgo, theBase);
-      } else {
-         // it comes from a uncaptured brem, doesn't correct
-         newEnergy = cl.rawEnergy();
-      }
-   }
-   
-   if (newEnergy > 2* cl.rawEnergy()) newEnergy = cl.rawEnergy();  // avoid very large correction due to the uncaptured brem
+  } else {
+    if (r9 < maxR9_) {
+      // use 5x5 energy if r9 < threshold
+      newEnergy = e5x5 / fEta(cl.eta(), theAlgo, theBase);
+    } else {
+      // it comes from a uncaptured brem, doesn't correct
+      newEnergy = cl.rawEnergy();
+    }
+  }
 
-   // Create a new supercluster with the corrected energy 
-   if (verbosity_ <= pINFO)
-   {
-      std::cout << "   UNCORRECTED SC has energy... " << cl.energy() << std::endl;
-      std::cout << "   CORRECTED SC has energy... " << newEnergy << std::endl;
-      std::cout << "   Size..." <<cl.size() << std::endl;
-      std::cout << "   Seed nCryGT2Sigma Size..." <<nCryGT2Sigma << std::endl;
-   }
+  if (newEnergy > 2 * cl.rawEnergy())
+    newEnergy = cl.rawEnergy();  // avoid very large correction due to the uncaptured brem
 
-   reco::SuperCluster corrCl(newEnergy, 
-   math::XYZPoint(cl.position().X(), cl.position().Y(), cl.position().Z()),
-   cl.seed(), clusters_v, cl.preshowerEnergy());
+  // Create a new supercluster with the corrected energy
+  if (verbosity_ <= pINFO) {
+    std::cout << "   UNCORRECTED SC has energy... " << cl.energy() << std::endl;
+    std::cout << "   CORRECTED SC has energy... " << newEnergy << std::endl;
+    std::cout << "   Size..." << cl.size() << std::endl;
+    std::cout << "   Seed nCryGT2Sigma Size..." << nCryGT2Sigma << std::endl;
+  }
 
-   //set the flags, although we should implement a ctor in SuperCluster
-   corrCl.setFlags(cl.flags());
-   corrCl.setPhiWidth(phiWidth);
-   corrCl.setEtaWidth(etaWidth);
-   
-   return corrCl;
+  reco::SuperCluster corrCl(newEnergy,
+                            math::XYZPoint(cl.position().X(), cl.position().Y(), cl.position().Z()),
+                            cl.seed(),
+                            clusters_v,
+                            cl.preshowerEnergy());
+
+  //set the flags, although we should implement a ctor in SuperCluster
+  corrCl.setFlags(cl.flags());
+  corrCl.setPhiWidth(phiWidth);
+  corrCl.setEtaWidth(etaWidth);
+
+  return corrCl;
 }
 
-float HiEgammaSCEnergyCorrectionAlgo::fEtEta(float et, float eta, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const
-{
+float HiEgammaSCEnergyCorrectionAlgo::fEtEta(float et,
+                                             float eta,
+                                             reco::CaloCluster::AlgoId theAlgo,
+                                             EcalSubdetector theBase) const {
   int offset = 0;
   float factor;
-  if((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) { 
-      offset = 0;
-  } else if((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) { 
-      offset = 7;
+  if ((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) {
+    offset = 0;
+  } else if ((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) {
+    offset = 7;
   }
-  
+
   // Et dependent correction
-  factor = (p_fEtEta_[0+offset] + p_fEtEta_[1+offset]*sqrt(et));
+  factor = (p_fEtEta_[0 + offset] + p_fEtEta_[1 + offset] * sqrt(et));
   // eta dependent correction
-  factor *= (p_fEtEta_[2+offset] + p_fEtEta_[3+offset]*fabs(eta) +
-	     p_fEtEta_[4+offset]*eta*eta + p_fEtEta_[5+offset]*eta*eta*fabs(eta) + + p_fEtEta_[6+offset]*eta*eta*eta*eta);
+  factor *= (p_fEtEta_[2 + offset] + p_fEtEta_[3 + offset] * fabs(eta) + p_fEtEta_[4 + offset] * eta * eta +
+             p_fEtEta_[5 + offset] * eta * eta * fabs(eta) + +p_fEtEta_[6 + offset] * eta * eta * eta * eta);
 
   // Constraint correction factor
-  if (factor< 0.66f ) factor = 0.66f;
-  if (factor> 1.5f  ) factor = 1.5f;
+  if (factor < 0.66f)
+    factor = 0.66f;
+  if (factor > 1.5f)
+    factor = 1.5f;
 
   return factor;
-
 }
 
-float HiEgammaSCEnergyCorrectionAlgo::fEta(float eta, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const
-{
+float HiEgammaSCEnergyCorrectionAlgo::fEta(float eta,
+                                           reco::CaloCluster::AlgoId theAlgo,
+                                           EcalSubdetector theBase) const {
   int offset = 0;
   float factor;
-  if((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) { 
-      offset = 0;
-  } else if((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) { 
-      offset = 3;
+  if ((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) {
+    offset = 0;
+  } else if ((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) {
+    offset = 3;
   }
 
-  factor = (p_fEta_[0+offset] + p_fEta_[1+offset]*fabs(eta) + p_fEta_[2+offset]*eta*eta);
+  factor = (p_fEta_[0 + offset] + p_fEta_[1 + offset] * fabs(eta) + p_fEta_[2 + offset] * eta * eta);
 
   // Constraint correction factor
-  if (factor< 0.66f ) factor = 0.66f;
-  if (factor> 1.5f  ) factor = 1.5f;
+  if (factor < 0.66f)
+    factor = 0.66f;
+  if (factor > 1.5f)
+    factor = 1.5f;
 
   return factor;
 }
 
-float HiEgammaSCEnergyCorrectionAlgo::fBrem(float brem, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const
-{
+float HiEgammaSCEnergyCorrectionAlgo::fBrem(float brem,
+                                            reco::CaloCluster::AlgoId theAlgo,
+                                            EcalSubdetector theBase) const {
   int det = 0;
   int offset = 0;
   float factor;
-  if((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) { 
-      det = 0;
-      offset = 0;
-  } else if((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) { 
-      det = 1;
-      offset = 6;
+  if ((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) {
+    det = 0;
+    offset = 0;
+  } else if ((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) {
+    det = 1;
+    offset = 6;
   }
-  
+
   if (brem < p_fBremTh_[det]) {
-     factor = p_fBrem_[0+offset] + p_fBrem_[1+offset]*brem + p_fBrem_[2+offset]*brem*brem;
+    factor = p_fBrem_[0 + offset] + p_fBrem_[1 + offset] * brem + p_fBrem_[2 + offset] * brem * brem;
   } else {
-     factor = p_fBrem_[3+offset] + p_fBrem_[4+offset]*brem + p_fBrem_[5+offset]*brem*brem;
+    factor = p_fBrem_[3 + offset] + p_fBrem_[4 + offset] * brem + p_fBrem_[5 + offset] * brem * brem;
   };
 
   // Constraint correction factor
-  if (factor< 0.66f ) factor = 0.66f;
-  if (factor> 1.5f  ) factor = 1.5f;
-  
+  if (factor < 0.66f)
+    factor = 0.66f;
+  if (factor > 1.5f)
+    factor = 1.5f;
+
   return factor;
 }
 
 //   char *var ="rawEnergy/cosh(genMatchedEta)/(1.01606-0.0162668*abs(eta))/genMatchedPt/(1.022-0.02812*phiWidth/etaWidth+0.001637*phiWidth*phiWidth/etaWidth/etaWidth)/((0.682554+0.0253013*scSize-(0.0007907)*scSize*scSize+(1.166e-5)*scSize*scSize*scSize-(6.7387e-8)*scSize*scSize*scSize*scSize)*(scSize<40)+(scSize>=40))/((1.016-0.009877*((clustersSize<=4)*clustersSize+(clustersSize>4)*4)))";
 
-float HiEgammaSCEnergyCorrectionAlgo::fNCrystals(int nCry, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const
-{
+float HiEgammaSCEnergyCorrectionAlgo::fNCrystals(int nCry,
+                                                 reco::CaloCluster::AlgoId theAlgo,
+                                                 EcalSubdetector theBase) const {
+  float x = (float)nCry;
+  float result = 1.f;
 
-  float x  = (float) nCry;
-  float result =1.f;
-  
-  if((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) { 
-        float const p0 = 0.682554f;     
-        float const p1 = 0.0253013f;
-        float const p2 = -0.0007907f;
-        float const p3 = 1.166e-5f;
-        float const p4 = -6.7387e-8f;
-        if (x < 10.f) x = 10.f;
-        if (x < 40.f) result = p0 + x*(p1 + x*(p2 + x*(p3 + x*p4))); else result = 1.f;
-      }
-        
-    else if((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) {    
-        
-        float const p0 = 0.712185f;     
-        float const p1 = 0.0273609f;
-        float const p2 = -0.00103818f;
-        float const p3 = 2.01828e-05f;
-        float const p4 = -1.71438e-07f;
-        if (x < 10.f) x = 10.f;
-	if (x < 40.f) result = p0 + x*(p1 + x*(p2 + x*(p3 + x*p4))); else result = 1.f;   
-      }
-      
-    else {
-      if (verbosity_ <= pINFO)
-      {
-        std::cout << "trying to correct unknown cluster!!!" << std::endl;
-      }
+  if ((theBase == EcalBarrel) && (theAlgo == reco::CaloCluster::island)) {
+    float const p0 = 0.682554f;
+    float const p1 = 0.0253013f;
+    float const p2 = -0.0007907f;
+    float const p3 = 1.166e-5f;
+    float const p4 = -6.7387e-8f;
+    if (x < 10.f)
+      x = 10.f;
+    if (x < 40.f)
+      result = p0 + x * (p1 + x * (p2 + x * (p3 + x * p4)));
+    else
+      result = 1.f;
+  }
+
+  else if ((theBase == EcalEndcap) && (theAlgo == reco::CaloCluster::island)) {
+    float const p0 = 0.712185f;
+    float const p1 = 0.0273609f;
+    float const p2 = -0.00103818f;
+    float const p3 = 2.01828e-05f;
+    float const p4 = -1.71438e-07f;
+    if (x < 10.f)
+      x = 10.f;
+    if (x < 40.f)
+      result = p0 + x * (p1 + x * (p2 + x * (p3 + x * p4)));
+    else
+      result = 1.f;
+  }
+
+  else {
+    if (verbosity_ <= pINFO) {
+      std::cout << "trying to correct unknown cluster!!!" << std::endl;
     }
-  
-  if (result > 1.5f) result = 1.5f;
-  if (result < 0.5f) result = 0.5f;
+  }
 
-  return result;  
+  if (result > 1.5f)
+    result = 1.5f;
+  if (result < 0.5f)
+    result = 0.5f;
+
+  return result;
 }
 
-int HiEgammaSCEnergyCorrectionAlgo::nCrystalsGT2Sigma(reco::BasicCluster const & seed, EcalRecHitCollection const &rhc) const {
+int HiEgammaSCEnergyCorrectionAlgo::nCrystalsGT2Sigma(reco::BasicCluster const& seed,
+                                                      EcalRecHitCollection const& rhc) const {
   // return number of crystals 2Sigma above
   // electronic noise
-  
-  std::vector<std::pair<DetId,float > > const & hits = seed.hitsAndFractions();
 
-  if (verbosity_ <= pINFO)
-  {
+  std::vector<std::pair<DetId, float> > const& hits = seed.hitsAndFractions();
+
+  if (verbosity_ <= pINFO) {
     std::cout << "      HiEgammaSCEnergyCorrectionAlgo::nCrystalsGT2Sigma" << std::endl;
     std::cout << "      Will calculate number of crystals above 2sigma noise" << std::endl;
     std::cout << "      sigmaElectronicNoise = " << sigmaElectronicNoise_ << std::endl;
@@ -285,19 +294,17 @@ int HiEgammaSCEnergyCorrectionAlgo::nCrystalsGT2Sigma(reco::BasicCluster const &
   }
 
   int nCry = 0;
-  for(std::vector<std::pair<DetId,float > >::const_iterator hit = hits.begin(); hit != hits.end(); ++hit)
-    {
-      // need to get hit by DetID in order to get energy
-      EcalRecHitCollection::const_iterator aHit = rhc.find((*hit).first);
-      // better the hit to exists....
-      if(aHit->energy()>2.f*sigmaElectronicNoise_) ++nCry;
-    }
-
-  if (verbosity_ <= pINFO)
-  {
-    std::cout << "         " << nCry << " of these above 2sigma noise" << std::endl;  
+  for (std::vector<std::pair<DetId, float> >::const_iterator hit = hits.begin(); hit != hits.end(); ++hit) {
+    // need to get hit by DetID in order to get energy
+    EcalRecHitCollection::const_iterator aHit = rhc.find((*hit).first);
+    // better the hit to exists....
+    if (aHit->energy() > 2.f * sigmaElectronicNoise_)
+      ++nCry;
   }
- 
+
+  if (verbosity_ <= pINFO) {
+    std::cout << "         " << nCry << " of these above 2sigma noise" << std::endl;
+  }
+
   return nCry;
 }
-

--- a/RecoHI/HiEgammaAlgos/src/HiPhotonType.cc
+++ b/RecoHI/HiEgammaAlgos/src/HiPhotonType.cc
@@ -13,229 +13,198 @@
 using namespace edm;
 using namespace reco;
 
-HiPhotonType::HiPhotonType(edm::Handle<GenParticleCollection> inputHandle)
-{
+HiPhotonType::HiPhotonType(edm::Handle<GenParticleCollection> inputHandle) {
   using namespace std;
 
   const GenParticleCollection *collection1 = inputHandle.product();
-   mcisocut = HiGammaJetSignalDef(collection1);
-   PI = 3.141592653589793238462643383279502884197169399375105820974945;
-  
-} 
-
-
-bool HiPhotonType::IsIsolated(const reco::GenParticle &pp)
-{
-  using namespace std;
-  using namespace edm;
-  using namespace reco;
-   // Check if a given particle is isolated.
-
-  return  mcisocut.IsIsolatedPP(pp);
-}
-
-
-
-bool HiPhotonType::IsPrompt(const reco::GenParticle &pp)
-{
-  using namespace std;
-  if ( pp.pdgId() != 22)
-    return false;
-
-  if ( pp.mother() ==nullptr ) 
-    {
-      //      cout <<    "No mom for this particle.." << endl;
-      return false;
-    }
-  else 
-    {
-      if (pp.mother()->pdgId() == 22)
-	{
-	  cout << " found a prompt photon" << endl;
-	  return true;
-	}
-      else
-	return false;
-    }    
-}
-
-
-HiGammaJetSignalDef::HiGammaJetSignalDef () :
-  fSigParticles(nullptr)
-{   PI = 3.141592653589793238462643383279502884197169399375105820974945;
-}
-HiGammaJetSignalDef::HiGammaJetSignalDef (const reco::GenParticleCollection  *sigParticles) :
-  fSigParticles(nullptr)
-{
-  using namespace std;
-
-  fSigParticles =  sigParticles;
+  mcisocut = HiGammaJetSignalDef(collection1);
   PI = 3.141592653589793238462643383279502884197169399375105820974945;
-
 }
 
-bool HiGammaJetSignalDef::IsIsolated(const reco::GenParticle &pp)
-{
+bool HiPhotonType::IsIsolated(const reco::GenParticle &pp) {
   using namespace std;
   using namespace edm;
   using namespace reco;
   // Check if a given particle is isolated.
 
-  double  EtCone = 0;
-  double  EtPhoton = 0;
-  double  PtMaxHadron = 0;
-  double  cone = 0.5;
+  return mcisocut.IsIsolatedPP(pp);
+}
+
+bool HiPhotonType::IsPrompt(const reco::GenParticle &pp) {
+  using namespace std;
+  if (pp.pdgId() != 22)
+    return false;
+
+  if (pp.mother() == nullptr) {
+    //      cout <<    "No mom for this particle.." << endl;
+    return false;
+  } else {
+    if (pp.mother()->pdgId() == 22) {
+      cout << " found a prompt photon" << endl;
+      return true;
+    } else
+      return false;
+  }
+}
+
+HiGammaJetSignalDef::HiGammaJetSignalDef() : fSigParticles(nullptr) {
+  PI = 3.141592653589793238462643383279502884197169399375105820974945;
+}
+HiGammaJetSignalDef::HiGammaJetSignalDef(const reco::GenParticleCollection *sigParticles) : fSigParticles(nullptr) {
+  using namespace std;
+
+  fSigParticles = sigParticles;
+  PI = 3.141592653589793238462643383279502884197169399375105820974945;
+}
+
+bool HiGammaJetSignalDef::IsIsolated(const reco::GenParticle &pp) {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  // Check if a given particle is isolated.
+
+  double EtCone = 0;
+  double EtPhoton = 0;
+  double PtMaxHadron = 0;
+  double cone = 0.5;
   const int maxindex = (int)fSigParticles->size();
-  for(int i=0; i < maxindex ; ++i) {
+  for (int i = 0; i < maxindex; ++i) {
+    const GenParticle &p = (*fSigParticles)[i];
 
-    const GenParticle &p=(*fSigParticles)[i];
-
-    if(p.status()!=1)
+    if (p.status() != 1)
       continue;
     if (p.collisionId() != pp.collisionId())
       continue;
 
-    int apid= abs(p.pdgId());
-    if(apid>11 &&  apid<20)
-      continue; //get rid of muons and neutrinos
+    int apid = abs(p.pdgId());
+    if (apid > 11 && apid < 20)
+      continue;  //get rid of muons and neutrinos
 
-    if(getDeltaR(p,pp)>cone)
+    if (getDeltaR(p, pp) > cone)
       continue;
 
-    double et=p.et();
+    double et = p.et();
     double pt = p.pt();
-    EtCone+=et;
+    EtCone += et;
     bool isHadron = false;
-    if ( fabs(pp.pdgId())>100 && fabs(pp.pdgId()) != 310)
+    if (fabs(pp.pdgId()) > 100 && fabs(pp.pdgId()) != 310)
       isHadron = true;
 
-    if(apid>100 && apid!=310 && pt>PtMaxHadron)
-      {
-	if ( (isHadron == true) && (fabs(pp.pt()-pt)<0.001) && (pp.pdgId()==p.pdgId()) )
-	  continue;
-	else
-	  PtMaxHadron=pt;
-      }
-
+    if (apid > 100 && apid != 310 && pt > PtMaxHadron) {
+      if ((isHadron == true) && (fabs(pp.pt() - pt) < 0.001) && (pp.pdgId() == p.pdgId()))
+        continue;
+      else
+        PtMaxHadron = pt;
+    }
   }
   EtPhoton = pp.et();
 
   // isolation cuts
-  if(EtCone-EtPhoton > 5+EtPhoton/20)
+  if (EtCone - EtPhoton > 5 + EtPhoton / 20)
     return kFALSE;
-  if(PtMaxHadron > 4.5+EtPhoton/40)
+  if (PtMaxHadron > 4.5 + EtPhoton / 40)
     return kFALSE;
 
   return kTRUE;
-
 }
 
-bool HiGammaJetSignalDef::IsIsolatedPP(const reco::GenParticle &pp)
-{
+bool HiGammaJetSignalDef::IsIsolatedPP(const reco::GenParticle &pp) {
   using namespace std;
   using namespace edm;
   using namespace reco;
 
-  // Check if a given particle is isolated. 
+  // Check if a given particle is isolated.
 
-    double  EtCone = 0;
-    double  EtPhoton = 0;
-    double  cone = 0.4;
+  double EtCone = 0;
+  double EtPhoton = 0;
+  double cone = 0.4;
 
-    const int maxindex = (int)fSigParticles->size();
-    for(int i=0; i < maxindex ; ++i) {
+  const int maxindex = (int)fSigParticles->size();
+  for (int i = 0; i < maxindex; ++i) {
+    const GenParticle &p = (*fSigParticles)[i];
 
-      const GenParticle &p=(*fSigParticles)[i];
+    if (p.status() != 1)
+      continue;
+    if (p.collisionId() != pp.collisionId())
+      continue;
 
-      if(p.status()!=1)
-	continue;
-      if (p.collisionId() != pp.collisionId())
-	continue;
+    //int apid= abs(p.pdgId());
+    //  if(apid>11 &&  apid<20)
+    //  continue; //get rid of muons and neutrinos
 
-      //int apid= abs(p.pdgId());
-      //  if(apid>11 &&  apid<20)
-      //  continue; //get rid of muons and neutrinos 
+    if (getDeltaR(p, pp) > cone)
+      continue;
+    double et = p.et();
+    //  double pt = p.pt();
+    EtCone += et;
+  }
 
-	if(getDeltaR(p,pp)>cone)
-	  continue;
-	double et=p.et();
-	//  double pt = p.pt();
-	EtCone+=et;
+  EtPhoton = pp.et();
 
-    }
+  // isolation cuts
 
-    EtPhoton = pp.et();
+  if (EtCone - EtPhoton > 5)
+    return kFALSE;
+  //if(PtMaxHadron > 4.5+EtPhoton/40)
+  //  return kFALSE;
 
-    // isolation cuts 
-
-      if(EtCone-EtPhoton > 5)
-	return kFALSE;
-      //if(PtMaxHadron > 4.5+EtPhoton/40)
-      //  return kFALSE;
-
-      return kTRUE;
-
+  return kTRUE;
 }
-bool HiGammaJetSignalDef::IsIsolatedJP(const reco::GenParticle &pp)
-{
+bool HiGammaJetSignalDef::IsIsolatedJP(const reco::GenParticle &pp) {
   using namespace std;
   using namespace edm;
   using namespace reco;
 
-  // Check if a given particle is isolated. 
+  // Check if a given particle is isolated.
 
-    double  EtCone = 0;
-    double  EtPhoton = 0;
-    double  cone = 0.4;
+  double EtCone = 0;
+  double EtPhoton = 0;
+  double cone = 0.4;
 
-    const int maxindex = (int)fSigParticles->size();
-    for(int i=0; i < maxindex ; ++i) {
+  const int maxindex = (int)fSigParticles->size();
+  for (int i = 0; i < maxindex; ++i) {
+    const GenParticle &p = (*fSigParticles)[i];
 
-      const GenParticle &p=(*fSigParticles)[i];
+    if (p.status() != 1)
+      continue;
+    if (p.collisionId() != pp.collisionId())
+      continue;
 
-      if(p.status()!=1)
-	continue;
-      if (p.collisionId() != pp.collisionId())
-	continue;
+    if (getDeltaR(p, pp) > cone)
+      continue;
 
-      if(getDeltaR(p,pp)>cone)
-	continue;
+    double et = p.et();
+    //  double pt = p.pt();
+    EtCone += et;
+  }
+  EtPhoton = pp.et();
 
-      double et=p.et();
-      //  double pt = p.pt();           
-      EtCone+=et;
+  // isolation cuts
 
-    }
-    EtPhoton = pp.et();
-
-    // isolation cuts   
-
-      if(EtCone-EtPhoton > 5)
-	return kFALSE;
-      return kTRUE;
-
+  if (EtCone - EtPhoton > 5)
+    return kFALSE;
+  return kTRUE;
 }
 
-double HiGammaJetSignalDef::getDeltaR(const reco::Candidate &track1, const reco::Candidate &track2)
-{
+double HiGammaJetSignalDef::getDeltaR(const reco::Candidate &track1, const reco::Candidate &track2) {
   double dEta = track1.eta() - track2.eta();
   double dPhi = track1.phi() - track2.phi();
 
-  while(dPhi >= PI)       dPhi -= (2.0*PI);
-  while(dPhi < (-1.0*PI)) dPhi += (2.0*PI);
+  while (dPhi >= PI)
+    dPhi -= (2.0 * PI);
+  while (dPhi < (-1.0 * PI))
+    dPhi += (2.0 * PI);
 
-  return sqrt(dEta*dEta+dPhi*dPhi);
+  return sqrt(dEta * dEta + dPhi * dPhi);
 }
 
-double HiGammaJetSignalDef::getDeltaPhi(const reco::Candidate &track1, const reco::Candidate &track2)
-{
+double HiGammaJetSignalDef::getDeltaPhi(const reco::Candidate &track1, const reco::Candidate &track2) {
   double dPhi = track1.phi() - track2.phi();
 
-  while(dPhi >= PI)       dPhi -= (2.0*PI);
-  while(dPhi < (-1.0*PI)) dPhi += (2.0*PI);
+  while (dPhi >= PI)
+    dPhi -= (2.0 * PI);
+  while (dPhi < (-1.0 * PI))
+    dPhi += (2.0 * PI);
 
   return dPhi;
 }
-
-
-

--- a/RecoHI/HiEgammaAlgos/src/TrackIsoCalculator.cc
+++ b/RecoHI/HiEgammaAlgos/src/TrackIsoCalculator.cc
@@ -16,63 +16,69 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 
-TrackIsoCalculator::TrackIsoCalculator (const edm::Event &iEvent, const edm::EventSetup &iSetup, const edm::Handle<reco::TrackCollection> trackLabel, const std::string trackQuality)
-{
+TrackIsoCalculator::TrackIsoCalculator(const edm::Event &iEvent,
+                                       const edm::EventSetup &iSetup,
+                                       const edm::Handle<reco::TrackCollection> trackLabel,
+                                       const std::string trackQuality) {
   recCollection = trackLabel;
   trackQuality_ = trackQuality;
 }
 
-double TrackIsoCalculator::getTrackIso(const reco::Photon cluster, const double x, const double threshold, const double innerDR)
-{
+double TrackIsoCalculator::getTrackIso(const reco::Photon cluster,
+                                       const double x,
+                                       const double threshold,
+                                       const double innerDR) {
   double TotalPt = 0;
 
-  for(reco::TrackCollection::const_iterator
-	recTrack = recCollection->begin(); recTrack!= recCollection->end(); recTrack++)
-  {
+  for (reco::TrackCollection::const_iterator recTrack = recCollection->begin(); recTrack != recCollection->end();
+       recTrack++) {
     bool goodtrack = recTrack->quality(reco::TrackBase::qualityByName(trackQuality_));
-    if(!goodtrack) continue;
+    if (!goodtrack)
+      continue;
 
     double pt = recTrack->pt();
     double dR2 = reco::deltaR2(cluster, *recTrack);
-    if(dR2 >= (0.01 * x*x))
+    if (dR2 >= (0.01 * x * x))
       continue;
-    if(dR2 < innerDR*innerDR)
+    if (dR2 < innerDR * innerDR)
       continue;
-    if(pt > threshold)
+    if (pt > threshold)
       TotalPt = TotalPt + pt;
   }
 
   return TotalPt;
 }
 
-double TrackIsoCalculator::getBkgSubTrackIso(const reco::Photon cluster, const double x, const double threshold, const double innerDR)
-{
+double TrackIsoCalculator::getBkgSubTrackIso(const reco::Photon cluster,
+                                             const double x,
+                                             const double threshold,
+                                             const double innerDR) {
   double SClusterEta = cluster.eta();
   double TotalPt = 0;
 
   TotalPt = 0;
 
-  for(reco::TrackCollection::const_iterator
-	recTrack = recCollection->begin(); recTrack!= recCollection->end(); recTrack++)
-  {
+  for (reco::TrackCollection::const_iterator recTrack = recCollection->begin(); recTrack != recCollection->end();
+       recTrack++) {
     bool goodtrack = recTrack->quality(reco::TrackBase::qualityByName(trackQuality_));
-    if(!goodtrack) continue;
+    if (!goodtrack)
+      continue;
 
     double pt = recTrack->pt();
     double eta2 = recTrack->eta();
-    double dEta = fabs(eta2-SClusterEta);
+    double dEta = fabs(eta2 - SClusterEta);
     double dR2 = reco::deltaR2(cluster, *recTrack);
-    if(dEta >= 0.1 * x)
+    if (dEta >= 0.1 * x)
       continue;
-    if(dR2 < innerDR*innerDR)
+    if (dR2 < innerDR * innerDR)
       continue;
 
-    if(pt > threshold)
+    if (pt > threshold)
       TotalPt = TotalPt + pt;
   }
 
-  double Tx = getTrackIso(cluster,x,threshold,innerDR);
-  double CTx = (Tx - TotalPt / 40.0 * x)*(1/(1-x/40.));
+  double Tx = getTrackIso(cluster, x, threshold, innerDR);
+  double CTx = (Tx - TotalPt / 40.0 * x) * (1 / (1 - x / 40.));
 
   return CTx;
 }

--- a/RecoHI/HiEgammaAlgos/test/patTest/PATHIPhotonTestModule.cc
+++ b/RecoHI/HiEgammaAlgos/test/patTest/PATHIPhotonTestModule.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PatAlgos
 // Class:      PATHIPhotonTestModule
-// 
+//
 /**\class PATHIPhotonTestModule PATHIPhotonTestModule.cc PhysicsTools/PatAlgos/test/PATHIPhotonTestModule.cc
 
  Description: Test Photon isolation variables in PAT
@@ -16,7 +16,6 @@
 //         Created:  Mon July 1 11:53:50 EST 2009
 //
 //
-
 
 // system include files
 #include <memory>
@@ -44,125 +43,109 @@
 #include <string>
 #include "TNtuple.h"
 
-namespace edm { using ::std::advance; }
+namespace edm {
+  using ::std::advance;
+}
 
 //
 // class decleration
 //
 
 class PATHIPhotonTestModule : public edm::EDAnalyzer {
-   public:
-      explicit PATHIPhotonTestModule(const edm::ParameterSet&);
-      ~PATHIPhotonTestModule();
+public:
+  explicit PATHIPhotonTestModule(const edm::ParameterSet&);
+  ~PATHIPhotonTestModule();
 
+private:
+  virtual void beginJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob();
 
-   private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-   
-      // ----------member data ---------------------------
-      edm::InputTag photons_;
-      std::string   label_;
-      enum TestMode { TestRead, TestWrite, TestExternal };
-      TestMode mode_;
-      TNtuple *datatemp;
-      edm::Service<TFileService> fs;
+  // ----------member data ---------------------------
+  edm::InputTag photons_;
+  std::string label_;
+  enum TestMode { TestRead, TestWrite, TestExternal };
+  TestMode mode_;
+  TNtuple* datatemp;
+  edm::Service<TFileService> fs;
 };
 
 //
 // constructors and destructor
 //
-PATHIPhotonTestModule::PATHIPhotonTestModule(const edm::ParameterSet& iConfig):
-  photons_(iConfig.getParameter<edm::InputTag>("photons"))
-{
-}
+PATHIPhotonTestModule::PATHIPhotonTestModule(const edm::ParameterSet& iConfig)
+    : photons_(iConfig.getParameter<edm::InputTag>("photons")) {}
 
-
-PATHIPhotonTestModule::~PATHIPhotonTestModule()
-{
-}
+PATHIPhotonTestModule::~PATHIPhotonTestModule() {}
 
 // ------------ method called to for each event  ------------
-void
-PATHIPhotonTestModule::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void PATHIPhotonTestModule::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   edm::Handle<edm::View<pat::Photon> > photons;
-   iEvent.getByLabel(photons_,photons);
+  edm::Handle<edm::View<pat::Photon>> photons;
+  iEvent.getByLabel(photons_, photons);
 
-   auto output = std::make_unique<std::vector<pat::Photon>>();
+  auto output = std::make_unique<std::vector<pat::Photon>>();
 
-   for (edm::View<pat::Photon>::const_iterator photon = photons->begin(), end = photons->end(); photon != end; ++photon) {
-   	   
-      Float_t var[100];
-      
-      int idx = 0;
-      var[idx] = photon->et();
+  for (edm::View<pat::Photon>::const_iterator photon = photons->begin(), end = photons->end(); photon != end;
+       ++photon) {
+    Float_t var[100];
+
+    int idx = 0;
+    var[idx] = photon->et();
+    idx++;
+
+    for (int i = 1; i < 6; i++) {
+      var[idx] = photon->userFloat(Form("isoCC%d", i));
       idx++;
-            
-      for (int i=1;i<6;i++){
-         var[idx]=photon->userFloat(Form("isoCC%d",i));
-	 idx++;       
-      }
+    }
 
-      for (int i=1;i<6;i++){
-         var[idx]=photon->userFloat(Form("isoCR%d",i));
-	 idx++;    
-      }
-
-      for (int i=1;i<5;i++){
-         for (int j=1;j<5;j++){
-            var[idx]=photon->userFloat(Form("isoT%d%d",i,j));
-	    idx++;     
-	 }  
-      }
-
-      for (int i=1;i<5;i++){
-         for (int j=1;j<5;j++){
-            var[idx]=photon->userFloat(Form("isoDR%d%d",i,j));
-	    idx++;     
-	 }  
-      }
- 
-      var[idx] = photon->e3x3();
+    for (int i = 1; i < 6; i++) {
+      var[idx] = photon->userFloat(Form("isoCR%d", i));
       idx++;
-      var[idx] = photon->e5x5();
-      idx++;
-      
-      
-      
+    }
 
+    for (int i = 1; i < 5; i++) {
+      for (int j = 1; j < 5; j++) {
+        var[idx] = photon->userFloat(Form("isoT%d%d", i, j));
+        idx++;
+      }
+    }
 
+    for (int i = 1; i < 5; i++) {
+      for (int j = 1; j < 5; j++) {
+        var[idx] = photon->userFloat(Form("isoDR%d%d", i, j));
+        idx++;
+      }
+    }
 
-datatemp->Fill(var);
-   }
+    var[idx] = photon->e3x3();
+    idx++;
+    var[idx] = photon->e5x5();
+    idx++;
 
+    datatemp->Fill(var);
+  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-PATHIPhotonTestModule::beginJob()
-{
-
-   datatemp = fs->make<TNtuple>("gammas", "photon candidate info", 
-                                "et:"
-				"cC1:cC2:cC3:cC4:cC5:cR1:cR2:cR3:cR4:cR5:"
-				"T11:T12:T13:T14:"
-				"T21:T22:T23:T24:"
-				"T31:T32:T33:T34:"
-				"T41:T42:T43:T44:"
-				"dR11:dR12:dR13:dR14:"
-				"dR21:dR22:dR23:dR24:"
-				"dR31:dR32:dR33:dR34:"
-				"dR41:dR42:dR43:dR44");
-   }
+void PATHIPhotonTestModule::beginJob() {
+  datatemp = fs->make<TNtuple>("gammas",
+                               "photon candidate info",
+                               "et:"
+                               "cC1:cC2:cC3:cC4:cC5:cR1:cR2:cR3:cR4:cR5:"
+                               "T11:T12:T13:T14:"
+                               "T21:T22:T23:T24:"
+                               "T31:T32:T33:T34:"
+                               "T41:T42:T43:T44:"
+                               "dR11:dR12:dR13:dR14:"
+                               "dR21:dR22:dR23:dR24:"
+                               "dR31:dR32:dR33:dR34:"
+                               "dR41:dR42:dR43:dR44");
+}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-PATHIPhotonTestModule::endJob() {
-}
+void PATHIPhotonTestModule::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(PATHIPhotonTestModule);

--- a/RecoParticleFlow/Benchmark/interface/BenchmarkTree.h
+++ b/RecoParticleFlow/Benchmark/interface/BenchmarkTree.h
@@ -1,44 +1,34 @@
 #ifndef RecoParticleFlow_Benchmark_BenchmarkTree_h
 #define RecoParticleFlow_Benchmark_BenchmarkTree_h
 
-
 #include <TTree.h>
 
 class BenchmarkTreeEntry {
-
- public:
-  BenchmarkTreeEntry() : 
-    deltaEt(999), 
-    deltaEta(-9),
-    eta(-10),
-    et(-1)
-    {}
+public:
+  BenchmarkTreeEntry() : deltaEt(999), deltaEta(-9), eta(-10), et(-1) {}
 
   BenchmarkTreeEntry& operator=(const BenchmarkTreeEntry& other) {
-    deltaEt= other.deltaEt;
-    deltaEta= other.deltaEta;
-    eta= other.eta;
-    et= other.et;
+    deltaEt = other.deltaEt;
+    deltaEta = other.deltaEta;
+    eta = other.eta;
+    et = other.et;
 
     return *this;
   }
-  
+
   float deltaEt;
   float deltaEta;
   float eta;
   float et;
 };
 
-
 class BenchmarkTree : public TTree {
-  
- public:
-  BenchmarkTree( const char* name,
-			const char* title);
+public:
+  BenchmarkTree(const char* name, const char* title);
   using TTree::Fill;
-  void Fill( const BenchmarkTreeEntry& entry );
-  
- private:
+  void Fill(const BenchmarkTreeEntry& entry);
+
+private:
   BenchmarkTreeEntry* entry_;
 };
 

--- a/RecoParticleFlow/Benchmark/interface/GenericBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/GenericBenchmark.h
@@ -4,7 +4,6 @@
 //COLIN: necessary?
 #include "RecoParticleFlow/Benchmark/interface/PFBenchmarkAlgo.h"
 
-
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/METReco/interface/MET.h"
@@ -15,52 +14,46 @@
 #include <TH2F.h>
 #include <TFile.h>
 
-class DQMStore; // CMSSW_2_X_X
+class DQMStore;  // CMSSW_2_X_X
 
 class BenchmarkTree;
 
-
 //COLIN: this class REALLY needs to be cleaned up and rationalized, on the model of PFCandidateBenchmark.
-class GenericBenchmark{
-
- public:
-
+class GenericBenchmark {
+public:
   GenericBenchmark();
   virtual ~GenericBenchmark() noexcept(false);
 
-  void setup(DQMStore *DQM = nullptr, 
-	     bool PlotAgainstReco_=true, 
-	     float minDeltaEt = -100., float maxDeltaEt = 50., 
-	     float minDeltaPhi = -0.5, float maxDeltaPhi = 0.5,
-	     bool doMetPlots=false);
+  void setup(DQMStore *DQM = nullptr,
+             bool PlotAgainstReco_ = true,
+             float minDeltaEt = -100.,
+             float maxDeltaEt = 50.,
+             float minDeltaPhi = -0.5,
+             float maxDeltaPhi = 0.5,
+             bool doMetPlots = false);
 
-  template< typename C>
-  void fill(const C *RecoCollection, 
-	    const C *GenCollection,
-	    bool startFromGen=false, 
-	    bool PlotAgainstReco =true, 
-	    bool onlyTwoJets = false, 
-	    double recPt_cut = -1., 
-	    double minEta_cut = -1., 
-	    double maxEta_cut = -1., 
-	    double deltaR_cut = -1.);
-
+  template <typename C>
+  void fill(const C *RecoCollection,
+            const C *GenCollection,
+            bool startFromGen = false,
+            bool PlotAgainstReco = true,
+            bool onlyTwoJets = false,
+            double recPt_cut = -1.,
+            double minEta_cut = -1.,
+            double maxEta_cut = -1.,
+            double deltaR_cut = -1.);
 
   void write(std::string Filename);
 
   void setfile(TFile *file);
 
- private:
-  
-  bool accepted(const reco::Candidate* particle,
-		double ptCut,
-		double minEtaCut,
-		double maxEtaCut ) const;
+private:
+  bool accepted(const reco::Candidate *particle, double ptCut, double minEtaCut, double maxEtaCut) const;
 
-  void fillHistos( const reco::Candidate* genParticle,
-		   const reco::Candidate* recParticle,
-		   double deltaR_cut,
-		   bool plotAgainstReco);
+  void fillHistos(const reco::Candidate *genParticle,
+                  const reco::Candidate *recParticle,
+                  double deltaR_cut,
+                  bool plotAgainstReco);
 
   TFile *file_;
 
@@ -93,7 +86,6 @@ class GenericBenchmark{
 
   TH1F *hNRec;
 
-
   TH1F *hEtGen;
   TH1F *hEtaGen;
   TH2F *hEtvsEtaGen;
@@ -122,28 +114,25 @@ class GenericBenchmark{
   TH2F *hRecSetOverTrueSetvsTrueSet;
   TH2F *hTrueMexvsTrueSet;
 
-  BenchmarkTree*  tree_;
+  BenchmarkTree *tree_;
 
   bool doMetPlots_;
 
- protected:
-
+protected:
   DQMStore *dbe_;
   PFBenchmarkAlgo *algo_;
-
 };
 
-template< typename C>
-void GenericBenchmark::fill(const C *RecoCollection, 
-			    const C *GenCollection,
-			    bool startFromGen, 
-			    bool PlotAgainstReco, 
-			    bool onlyTwoJets, 
-			    double recPt_cut, 
-			    double minEta_cut, 
-			    double maxEta_cut, 
-			    double deltaR_cut) {
-
+template <typename C>
+void GenericBenchmark::fill(const C *RecoCollection,
+                            const C *GenCollection,
+                            bool startFromGen,
+                            bool PlotAgainstReco,
+                            bool onlyTwoJets,
+                            double recPt_cut,
+                            double minEta_cut,
+                            double maxEta_cut,
+                            double deltaR_cut) {
   //if (doMetPlots_)
   //{
   //  const reco::MET* met1=static_cast<const reco::MET*>(&((*RecoCollection)[0]));
@@ -152,94 +141,88 @@ void GenericBenchmark::fill(const C *RecoCollection,
 
   // loop over reco particles
 
-  if( !startFromGen) {
+  if (!startFromGen) {
     int nRec = 0;
     for (unsigned int i = 0; i < RecoCollection->size(); i++) {
-      
       // generate histograms comparing the reco and truth candidate (truth = closest in delta-R)
       const reco::Candidate *particle = &(*RecoCollection)[i];
-      
-      assert( particle!=nullptr ); 
-      if( !accepted(particle, recPt_cut, 
-		    minEta_cut, maxEta_cut)) continue;
 
-    
+      assert(particle != nullptr);
+      if (!accepted(particle, recPt_cut, minEta_cut, maxEta_cut))
+        continue;
+
       // Count the number of jets with a larger energy
-      if( onlyTwoJets ) {
-	unsigned highJets = 0;
-	for(unsigned j=0; j<RecoCollection->size(); j++) { 
-	  const reco::Candidate *otherParticle = &(*RecoCollection)[j];
-	  if ( j != i && otherParticle->pt() > particle->pt() ) highJets++;
-	}
-	if ( highJets > 1 ) continue;
-      }		
+      if (onlyTwoJets) {
+        unsigned highJets = 0;
+        for (unsigned j = 0; j < RecoCollection->size(); j++) {
+          const reco::Candidate *otherParticle = &(*RecoCollection)[j];
+          if (j != i && otherParticle->pt() > particle->pt())
+            highJets++;
+        }
+        if (highJets > 1)
+          continue;
+      }
       nRec++;
-      
-      const reco::Candidate *gen_particle = algo_->matchByDeltaR(particle,
-								 GenCollection);
-      if(gen_particle==nullptr) continue; 
 
-
+      const reco::Candidate *gen_particle = algo_->matchByDeltaR(particle, GenCollection);
+      if (gen_particle == nullptr)
+        continue;
 
       // fill histograms
-      fillHistos( gen_particle, particle, deltaR_cut, PlotAgainstReco);
+      fillHistos(gen_particle, particle, deltaR_cut, PlotAgainstReco);
     }
 
     hNRec->Fill(nRec);
   }
 
   // loop over gen particles
-  
+
   //   std::cout<<"Reco size = "<<RecoCollection->size()<<", ";
   //   std::cout<<"Gen size = "<<GenCollection->size()<<std::endl;
 
   int nGen = 0;
   for (unsigned int i = 0; i < GenCollection->size(); i++) {
+    const reco::Candidate *gen_particle = &(*GenCollection)[i];
 
-    const reco::Candidate *gen_particle = &(*GenCollection)[i]; 
-
-    if( !accepted(gen_particle, recPt_cut, minEta_cut, maxEta_cut)) {
+    if (!accepted(gen_particle, recPt_cut, minEta_cut, maxEta_cut)) {
       continue;
     }
 
-    hEtaGen->Fill(gen_particle->eta() );
-    hPhiGen->Fill(gen_particle->phi() );
-    hEtGen->Fill(gen_particle->et() );
-    hEtvsEtaGen->Fill(gen_particle->eta(),gen_particle->et() );
-    hEtvsPhiGen->Fill(gen_particle->phi(),gen_particle->et() );
+    hEtaGen->Fill(gen_particle->eta());
+    hPhiGen->Fill(gen_particle->phi());
+    hEtGen->Fill(gen_particle->et());
+    hEtvsEtaGen->Fill(gen_particle->eta(), gen_particle->et());
+    hEtvsPhiGen->Fill(gen_particle->phi(), gen_particle->et());
 
-    const reco::Candidate *rec_particle = algo_->matchByDeltaR(gen_particle,
-							       RecoCollection);
+    const reco::Candidate *rec_particle = algo_->matchByDeltaR(gen_particle, RecoCollection);
     nGen++;
-    if(! rec_particle) continue; // no match
+    if (!rec_particle)
+      continue;  // no match
     // must make a cut on delta R - so let's do the cut
 
-    double deltaR = algo_->deltaR(rec_particle,gen_particle);
-    if (deltaR>deltaR_cut && deltaR_cut != -1.)
+    double deltaR = algo_->deltaR(rec_particle, gen_particle);
+    if (deltaR > deltaR_cut && deltaR_cut != -1.)
       continue;
-    
-    hEtaSeen->Fill(gen_particle->eta() );
-    hPhiSeen->Fill(gen_particle->phi() );
-    hEtSeen->Fill(gen_particle->et() );
-    hEtvsEtaSeen->Fill(gen_particle->eta(),gen_particle->et() );
-    hEtvsPhiSeen->Fill(gen_particle->phi(),gen_particle->et() );
 
-    hPhiRec->Fill(rec_particle->phi() );
-    hEtRec->Fill(rec_particle->et() );
-    hExRec->Fill(rec_particle->px() );
-    hEyRec->Fill(rec_particle->py() );
+    hEtaSeen->Fill(gen_particle->eta());
+    hPhiSeen->Fill(gen_particle->phi());
+    hEtSeen->Fill(gen_particle->et());
+    hEtvsEtaSeen->Fill(gen_particle->eta(), gen_particle->et());
+    hEtvsPhiSeen->Fill(gen_particle->phi(), gen_particle->et());
 
-    hEtRecvsEt->Fill(gen_particle->et(),rec_particle->et());
-    if (gen_particle->et()!=0.0) hEtRecOverTrueEtvsTrueEt->Fill(gen_particle->et(),rec_particle->et()/gen_particle->et());
+    hPhiRec->Fill(rec_particle->phi());
+    hEtRec->Fill(rec_particle->et());
+    hExRec->Fill(rec_particle->px());
+    hEyRec->Fill(rec_particle->py());
 
-    if( startFromGen ) 
-      fillHistos( gen_particle, rec_particle, deltaR_cut, PlotAgainstReco);
+    hEtRecvsEt->Fill(gen_particle->et(), rec_particle->et());
+    if (gen_particle->et() != 0.0)
+      hEtRecOverTrueEtvsTrueEt->Fill(gen_particle->et(), rec_particle->et() / gen_particle->et());
 
-    
+    if (startFromGen)
+      fillHistos(gen_particle, rec_particle, deltaR_cut, PlotAgainstReco);
   }
   hNGen->Fill(nGen);
-
 }
 
-
-#endif // RecoParticleFlow_Benchmark_GenericBenchmark_h
+#endif  // RecoParticleFlow_Benchmark_GenericBenchmark_h

--- a/RecoParticleFlow/Benchmark/interface/PFBenchmarkAlgo.h
+++ b/RecoParticleFlow/Benchmark/interface/PFBenchmarkAlgo.h
@@ -15,7 +15,6 @@
 
 class PFBenchmarkAlgo {
 public:
-
   // Calculate Delta-Et for the pair of Candidates (T - U)
   template <typename T, typename U>
   static double deltaEt(const T *, const U *);
@@ -28,14 +27,14 @@ public:
   template <typename T, typename U>
   static double deltaPhi(const T *, const U *);
 
-  // Calculate Delta-R for the pair of Candidates 
+  // Calculate Delta-R for the pair of Candidates
   template <typename T, typename U>
   static double deltaR(const T *, const U *);
 
   // Match Candidate T to a Candidate in the Collection based on minimum Delta-R
   template <typename T, typename Collection>
   static const typename Collection::value_type *matchByDeltaR(const T *, const Collection *);
-  
+
   // Match Candidate T to a Candidate U in the Collection based on minimum Delta-Et
   template <typename T, typename Collection>
   static const typename Collection::value_type *matchByDeltaEt(const T *, const Collection *);
@@ -61,11 +60,10 @@ public:
   static Collection findAllInEtWindow(const T *, const Collection *, double);
 
 private:
-
   // std::vector sort helper function
-  template <typename T, typename U, template <typename,typename> class Sorter>
-  static void vector_sort(std::vector<T> &candidates, Sorter<T,U> S) {
-    sort(candidates.begin(),candidates.end(),S);
+  template <typename T, typename U, template <typename, typename> class Sorter>
+  static void vector_sort(std::vector<T> &candidates, Sorter<T, U> S) {
+    sort(candidates.begin(), candidates.end(), S);
   }
 
   // std::vector push_back helper function
@@ -75,8 +73,8 @@ private:
   }
 
   // edm::OwnVector sort helper functions
-  template <typename T, typename U, template <typename,typename> class Sorter>
-  static void vector_sort(edm::OwnVector<T> &candidates, Sorter<T,U> S) {
+  template <typename T, typename U, template <typename, typename> class Sorter>
+  static void vector_sort(edm::OwnVector<T> &candidates, Sorter<T, U> S) {
     candidates.sort(S);
   }
 
@@ -85,7 +83,6 @@ private:
   static void vector_add(const T *c1, edm::OwnVector<T> &candidates) {
     candidates.push_back((T *const)c1->clone());
   }
-
 };
 
 // ========================================================================
@@ -93,275 +90,263 @@ private:
 // ========================================================================
 
 // Helper class for sorting U Collections by Delta-R to a Candidate T
-template <typename T, typename U> class deltaRSorter {
+template <typename T, typename U>
+class deltaRSorter {
 public:
-
   deltaRSorter(const T *Ref) { cref = Ref; }
   bool operator()(const U &c1, const U &c2) const {
-    return PFBenchmarkAlgo::deltaR(cref,&c1) < PFBenchmarkAlgo::deltaR(cref,&c2);
+    return PFBenchmarkAlgo::deltaR(cref, &c1) < PFBenchmarkAlgo::deltaR(cref, &c2);
   }
 
 private:
-
   const T *cref;
-
 };
 
 // Helper class for sorting U Collections by Delta-Et to a Candidate T
-template <typename T, typename U> class deltaEtSorter {
+template <typename T, typename U>
+class deltaEtSorter {
 public:
-
   deltaEtSorter(const T *Ref) { cref = Ref; }
   bool operator()(const U &c1, const U &c2) const {
-    return fabs(PFBenchmarkAlgo::deltaEt(cref,&c1)) < fabs(PFBenchmarkAlgo::deltaEt(cref,&c2));
+    return fabs(PFBenchmarkAlgo::deltaEt(cref, &c1)) < fabs(PFBenchmarkAlgo::deltaEt(cref, &c2));
   }
 
 private:
-
   const T *cref;
-
 };
 
 // Calculate Delta-Et for Candidates (T - U)
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaEt(const T *c1, const U *c2) {
-
   if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaEt for invalid Candidate(s)";
 
   return c1->et() - c2->et();
-
 }
 
 // Calculate Delta-Eta for Candidates (T - U)
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaEta(const T *c1, const U *c2) {
-
   if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaEta for invalid Candidate(s)";
 
   return c1->eta() - c2->eta();
-
 }
 
 // Calculate Delta-Phi for Candidates (T - U)
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaPhi(const T *c1, const U *c2) {
-
   if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaPhi for invalid Candidate(s)";
 
-  
   double phi1 = c1->phi();
-  if (phi1 > M_PI) phi1 -= ceil((phi1 - M_PI) / (2 * M_PI)) * 2 * M_PI;
-  if (phi1 <= - M_PI) phi1 += ceil((phi1 + M_PI) / (-2. * M_PI)) * 2. * M_PI;
+  if (phi1 > M_PI)
+    phi1 -= ceil((phi1 - M_PI) / (2 * M_PI)) * 2 * M_PI;
+  if (phi1 <= -M_PI)
+    phi1 += ceil((phi1 + M_PI) / (-2. * M_PI)) * 2. * M_PI;
 
   double phi2 = c2->phi();
-  if (phi2 > M_PI) phi2 -= ceil((phi2 - M_PI) / (2 * M_PI)) * 2 * M_PI;
-  if (phi2 <= - M_PI) phi2 += ceil((phi2 + M_PI) / (-2. * M_PI)) * 2 * M_PI;
+  if (phi2 > M_PI)
+    phi2 -= ceil((phi2 - M_PI) / (2 * M_PI)) * 2 * M_PI;
+  if (phi2 <= -M_PI)
+    phi2 += ceil((phi2 + M_PI) / (-2. * M_PI)) * 2 * M_PI;
 
   // alternative method:
   // while (phi > M_PI) phi -= 2 * M_PI;
   // while (phi <= - M_PI) phi += 2 * M_PI;
 
-  double deltaphi=-999.0;
-  if (fabs(phi1 - phi2)<M_PI)
-  {
-    deltaphi=(phi1-phi2);
-  }
-  else
-  {
-    if ((phi1-phi2)>0.0)
-    {
-      deltaphi=(2*M_PI - fabs(phi1 - phi2));
-    }
-    else
-    {
-      deltaphi=-(2*M_PI - fabs(phi1 - phi2));
+  double deltaphi = -999.0;
+  if (fabs(phi1 - phi2) < M_PI) {
+    deltaphi = (phi1 - phi2);
+  } else {
+    if ((phi1 - phi2) > 0.0) {
+      deltaphi = (2 * M_PI - fabs(phi1 - phi2));
+    } else {
+      deltaphi = -(2 * M_PI - fabs(phi1 - phi2));
     }
   }
   return deltaphi;
   //return ( (fabs(phi1 - phi2)<M_PI)?(phi1-phi2):(2*M_PI - fabs(phi1 - phi2) ) ); // FL: wrong
 }
- 
-// Calculate Delta-R for Candidates 
+
+// Calculate Delta-R for Candidates
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaR(const T *c1, const U *c2) {
-
   if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaR for invalid Candidate(s)";
 
-  return sqrt(std::pow(deltaPhi(c1,c2),2) + std::pow(deltaEta(c1,c2),2));
-
+  return sqrt(std::pow(deltaPhi(c1, c2), 2) + std::pow(deltaEta(c1, c2), 2));
 }
 
 // Match Candidate T to a Candidate in the Collection based on minimum Delta-R
 template <typename T, typename Collection>
 const typename Collection::value_type *PFBenchmarkAlgo::matchByDeltaR(const T *c1, const Collection *candidates) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of the Candidate and Collection
-  if (!c1) throw cms::Exception("Invalid Arg") << "attempted to match invalid Candidate";
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to match to invalid Collection";
+  if (!c1)
+    throw cms::Exception("Invalid Arg") << "attempted to match invalid Candidate";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to match to invalid Collection";
 
   double minDeltaR = 9999.;
   const U *match = nullptr;
-  
+
   // Loop Over the Candidates...
   for (unsigned int i = 0; i < candidates->size(); i++) {
-
     const U *c2 = &(*candidates)[i];
-    if (!c2) throw cms::Exception("Invalid Arg") << "attempted to match to invalid Candidate";
+    if (!c2)
+      throw cms::Exception("Invalid Arg") << "attempted to match to invalid Candidate";
 
     // Find Minimal Delta-R
-    double dR = deltaR(c1,c2);
-    if (dR <= minDeltaR) { match = c2; minDeltaR = dR; }
-  
+    double dR = deltaR(c1, c2);
+    if (dR <= minDeltaR) {
+      match = c2;
+      minDeltaR = dR;
+    }
   }
 
   // Return the Candidate with the smallest dR
   return match;
-
 }
 
 // Match Candidate T to a Candidate U in the Collection based on minimum Delta-Et
 template <typename T, typename Collection>
 const typename Collection::value_type *PFBenchmarkAlgo::matchByDeltaEt(const T *c1, const Collection *candidates) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of the Candidate and Collection
-  if (!c1) throw cms::Exception("Invalid Arg") << "attempted to match invalid Candidate";
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to match to invalid Collection";
+  if (!c1)
+    throw cms::Exception("Invalid Arg") << "attempted to match invalid Candidate";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to match to invalid Collection";
 
   double minDeltaEt = 9999.;
   const U *match = NULL;
 
   // Loop Over the Candidates...
   for (unsigned int i = 0; i < candidates->size(); i++) {
-
     const T *c2 = &(*candidates)[i];
-    if (!c2) throw cms::Exception("Invalid Arg") << "attempted to match to invalid Candidate";
+    if (!c2)
+      throw cms::Exception("Invalid Arg") << "attempted to match to invalid Candidate";
 
     // Find Minimal Delta-R
-    double dEt = fabs(deltaEt(c1,c2));
-    if (dEt <= minDeltaEt) { match = c2; minDeltaEt = dEt; }
-
+    double dEt = fabs(deltaEt(c1, c2));
+    if (dEt <= minDeltaEt) {
+      match = c2;
+      minDeltaEt = dEt;
+    }
   }
 
   // Return the Candidate with the smallest dR
   return match;
-
 }
 
 // Copy the Collection (useful when sorting)
 template <typename T, typename Collection>
 Collection PFBenchmarkAlgo::copyCollection(const Collection *candidates) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of the Collection
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to copy invalid Collection";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to copy invalid Collection";
 
   Collection copy;
 
   for (unsigned int i = 0; i < candidates->size(); i++)
-    vector_add(&(*candidates)[i],copy);
+    vector_add(&(*candidates)[i], copy);
 
   return copy;
-
 }
-
 
 // Sort the U Candidates to the Candidate T based on minimum Delta-R
 template <typename T, typename Collection>
 void PFBenchmarkAlgo::sortByDeltaR(const T *c1, Collection &candidates) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of Candidate and Collection
-  if (!c1) throw cms::Exception("Invalid Arg") << "attempted to sort by invalid Candidate";
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to sort invalid Candidates";
+  if (!c1)
+    throw cms::Exception("Invalid Arg") << "attempted to sort by invalid Candidate";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to sort invalid Candidates";
 
   // Sort the collection
-  vector_sort(candidates,deltaRSorter<T,U>(c1));
-
+  vector_sort(candidates, deltaRSorter<T, U>(c1));
 }
 
 // Sort the U Candidates to the Candidate T based on minimum Delta-Et
 template <typename T, typename Collection>
 void PFBenchmarkAlgo::sortByDeltaEt(const T *c1, Collection &candidates) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of Candidate and Collection
-  if (!c1) throw cms::Exception("Invalid Arg") << "attempted to sort by invalid Candidate";
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to sort invalid Candidates";
+  if (!c1)
+    throw cms::Exception("Invalid Arg") << "attempted to sort by invalid Candidate";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to sort invalid Candidates";
 
   // Sort the collection
-  vector_sort(candidates,deltaEtSorter<T,U>(c1));
-
+  vector_sort(candidates, deltaEtSorter<T, U>(c1));
 }
 
 // Constrain the U Candidates to the T Candidate based on Delta-R to T
 template <typename T, typename Collection>
 Collection PFBenchmarkAlgo::findAllInCone(const T *c1, const Collection *candidates, double ConeSize) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of Candidate and the Collection
-  if (!c1) throw cms::Exception("Invalid Arg") << "attempted to constrain to invalid Candidate";
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to constrain invalid Collection";
-  if (ConeSize <= 0) throw cms::Exception("Invalid Arg") << "zero or negative cone size specified";
+  if (!c1)
+    throw cms::Exception("Invalid Arg") << "attempted to constrain to invalid Candidate";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to constrain invalid Collection";
+  if (ConeSize <= 0)
+    throw cms::Exception("Invalid Arg") << "zero or negative cone size specified";
 
   Collection constrained;
 
   for (unsigned int i = 0; i < candidates->size(); i++) {
-
     const U *c2 = &(*candidates)[i];
 
     // Add in-cone Candidates to the new Collection
-    double dR = deltaR(c1,c2);
-    if (dR < ConeSize) vector_add(c2,constrained);
-
+    double dR = deltaR(c1, c2);
+    if (dR < ConeSize)
+      vector_add(c2, constrained);
   }
 
   // Sort and return Collection
-  sortByDeltaR(c1,constrained);
+  sortByDeltaR(c1, constrained);
   return constrained;
-
 }
 
 // Constrain the U Candidates to the T Candidate based on Delta-Et to T
 template <typename T, typename Collection>
 Collection PFBenchmarkAlgo::findAllInEtWindow(const T *c1, const Collection *candidates, double EtWindow) {
-
   typedef typename Collection::value_type U;
 
   // Try to verify the validity of Candidate and the Collection
-  if (!c1) throw cms::Exception("Invalid Arg") << "attempted to constrain to invalid Candidate";
-  if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to constrain invalid Collection";
-  if (EtWindow <= 0) throw cms::Exception("Invalid Arg") << "zero or negative cone size specified";
+  if (!c1)
+    throw cms::Exception("Invalid Arg") << "attempted to constrain to invalid Candidate";
+  if (!candidates)
+    throw cms::Exception("Invalid Arg") << "attempted to constrain invalid Collection";
+  if (EtWindow <= 0)
+    throw cms::Exception("Invalid Arg") << "zero or negative cone size specified";
 
   Collection constrained;
 
   //CandidateCollection::const_iterator candidate;
   //for (candidate = candidates->begin(); candidate != candidates->end(); candidate++) {
   for (unsigned int i = 0; i < candidates->size(); i++) {
-
     const U *c2 = &(*candidates)[i];
 
     // Add in-cone Candidates to the new Collection
-    double dEt = fabs(deltaEt(c1,c2));
-    if (dEt < EtWindow) vector_add(c2,constrained);
-
+    double dEt = fabs(deltaEt(c1, c2));
+    if (dEt < EtWindow)
+      vector_add(c2, constrained);
   }
 
   // Sort and return Collection
-  sortByDeltaEt(c1,constrained);
+  sortByDeltaEt(c1, constrained);
   return constrained;
-
 }
 
-#endif // RecoParticleFlow_Benchmark_PFBenchmarkAlgo_h
+#endif  // RecoParticleFlow_Benchmark_PFBenchmarkAlgo_h

--- a/RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h
@@ -16,7 +16,7 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
-//#include "FWCore/ServiceRegistry/interface/Service.h" 
+//#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "TH1F.h"
 #include "TH2F.h"
@@ -24,67 +24,63 @@
 #include <TFile.h>
 #include <vector>
 
-
 class DQMStore;
 
 class PFJetBenchmark {
-	
- public:
-	
+public:
   PFJetBenchmark();
   virtual ~PFJetBenchmark();
-	
-  void setup(
-	     std::string Filename,
-	     bool debug, 
-	     bool plotAgainstReco=false, 
-	     bool onlyTwoJets=true,
-	     double deltaRMax=0.1,
-             std::string benchmarkLabel_ = "ParticleFlow", 
-	     double recPt = -1, 
-	     double maxEta = -1,
-	     DQMStore * dbe_store = nullptr
-	     );
-  void process(const reco::PFJetCollection& , const reco::GenJetCollection& );
-  void gettrue (const reco::GenJet* truth, double& true_ChargedHadEnergy, 
-		double& true_NeutralHadEnergy, double& true_NeutralEmEnergy);
-  void printPFJet (const reco::PFJet*);
-  void printGenJet (const reco::GenJet*);
-  double resPtMax() const {return resPtMax_;};
-  double resChargedHadEnergyMax() const {return resChargedHadEnergyMax_;};
-  double resNeutralHadEnergyMax() const {return resNeutralHadEnergyMax_;};
-  double resNeutralEmEnergyMax() const {return resNeutralEmEnergyMax_;};
-//  void save();	
+
+  void setup(std::string Filename,
+             bool debug,
+             bool plotAgainstReco = false,
+             bool onlyTwoJets = true,
+             double deltaRMax = 0.1,
+             std::string benchmarkLabel_ = "ParticleFlow",
+             double recPt = -1,
+             double maxEta = -1,
+             DQMStore *dbe_store = nullptr);
+  void process(const reco::PFJetCollection &, const reco::GenJetCollection &);
+  void gettrue(const reco::GenJet *truth,
+               double &true_ChargedHadEnergy,
+               double &true_NeutralHadEnergy,
+               double &true_NeutralEmEnergy);
+  void printPFJet(const reco::PFJet *);
+  void printGenJet(const reco::GenJet *);
+  double resPtMax() const { return resPtMax_; };
+  double resChargedHadEnergyMax() const { return resChargedHadEnergyMax_; };
+  double resNeutralHadEnergyMax() const { return resNeutralHadEnergyMax_; };
+  double resNeutralEmEnergyMax() const { return resNeutralEmEnergyMax_; };
+  //  void save();
   void write();
-	
- private:
-		
+
+private:
   TFile *file_;
-	
+
   // histograms
   // Jets inclusive  distributions  (Pt > 20 GeV)
   TH1F *hNjets;
   TH1F *hjetsPt;
   TH1F *hjetsEta;
-  TH2F *hRPtvsEta ;
-  TH2F *hDEtavsEta ;
-  TH2F *hDPhivsEta ;
-  TH2F *hRNeutvsEta ;
-  TH2F *hRNEUTvsEta ; 
-  TH2F *hRNONLvsEta ;
-  TH2F *hRHCALvsEta ; 
-  TH2F *hRHONLvsEta ;
-  TH2F *hRCHEvsEta ;
+  TH2F *hRPtvsEta;
+  TH2F *hDEtavsEta;
+  TH2F *hDPhivsEta;
+  TH2F *hRNeutvsEta;
+  TH2F *hRNEUTvsEta;
+  TH2F *hRNONLvsEta;
+  TH2F *hRHCALvsEta;
+  TH2F *hRHONLvsEta;
+  TH2F *hRCHEvsEta;
   TH2F *hNCHvsEta;
-  TH2F* hNCH0vsEta;
-  TH2F* hNCH1vsEta;
-  TH2F* hNCH2vsEta;
-  TH2F* hNCH3vsEta;
-  TH2F* hNCH4vsEta;
-  TH2F* hNCH5vsEta;
-  TH2F* hNCH6vsEta;
-  TH2F* hNCH7vsEta;
-	
+  TH2F *hNCH0vsEta;
+  TH2F *hNCH1vsEta;
+  TH2F *hNCH2vsEta;
+  TH2F *hNCH3vsEta;
+  TH2F *hNCH4vsEta;
+  TH2F *hNCH5vsEta;
+  TH2F *hNCH6vsEta;
+  TH2F *hNCH7vsEta;
+
   // delta Pt or E quantities for Barrel
   TH1F *hBRPt;
   TH1F *hBRPt20_40;
@@ -105,8 +101,8 @@ class PFJetBenchmark {
   TH1F *hBRNHE;
   TH1F *hBRNEE;
   TH1F *hBRneut;
-  TH2F *hBRPtvsPt ;
-  TH2F *hBRCHEvsPt ;
+  TH2F *hBRPtvsPt;
+  TH2F *hBRCHEvsPt;
   TH2F *hBRNHEvsPt;
   TH2F *hBRNEEvsPt;
   TH2F *hBRneutvsPt;
@@ -118,17 +114,17 @@ class PFJetBenchmark {
   TH2F *hBDPhivsPt;
   TH2F *hBNCHvsPt;
   TH1F *hBNCH;
-  TH2F* hBNCH0vsPt;
-  TH2F* hBNCH1vsPt;
-  TH2F* hBNCH2vsPt;
-  TH2F* hBNCH3vsPt;
-  TH2F* hBNCH4vsPt;
-  TH2F* hBNCH5vsPt;
-  TH2F* hBNCH6vsPt;
-  TH2F* hBNCH7vsPt;
-	
+  TH2F *hBNCH0vsPt;
+  TH2F *hBNCH1vsPt;
+  TH2F *hBNCH2vsPt;
+  TH2F *hBNCH3vsPt;
+  TH2F *hBNCH4vsPt;
+  TH2F *hBNCH5vsPt;
+  TH2F *hBNCH6vsPt;
+  TH2F *hBNCH7vsPt;
+
   // delta Pt or E quantities for Endcap
-  TH1F *hERPt ;
+  TH1F *hERPt;
   TH1F *hERPt20_40;
   TH1F *hERPt40_60;
   TH1F *hERPt60_80;
@@ -147,9 +143,9 @@ class PFJetBenchmark {
   TH1F *hERNHE;
   TH1F *hERNEE;
   TH1F *hERneut;
-  TH2F *hERPtvsPt ;
+  TH2F *hERPtvsPt;
   TH2F *hERCHEvsPt;
-  TH2F *hERNHEvsPt ;
+  TH2F *hERNHEvsPt;
   TH2F *hERNEEvsPt;
   TH2F *hERneutvsPt;
   TH2F *hERNEUTvsP;
@@ -160,17 +156,17 @@ class PFJetBenchmark {
   TH2F *hEDPhivsPt;
   TH2F *hENCHvsPt;
   TH1F *hENCH;
-  TH2F* hENCH0vsPt;
-  TH2F* hENCH1vsPt;
-  TH2F* hENCH2vsPt;
-  TH2F* hENCH3vsPt;
-  TH2F* hENCH4vsPt;
-  TH2F* hENCH5vsPt;
-  TH2F* hENCH6vsPt;
-  TH2F* hENCH7vsPt;
-	
+  TH2F *hENCH0vsPt;
+  TH2F *hENCH1vsPt;
+  TH2F *hENCH2vsPt;
+  TH2F *hENCH3vsPt;
+  TH2F *hENCH4vsPt;
+  TH2F *hENCH5vsPt;
+  TH2F *hENCH6vsPt;
+  TH2F *hENCH7vsPt;
+
   // delta Pt or E quantities for Forward
-  TH1F *hFRPt ;
+  TH1F *hFRPt;
   TH1F *hFRPt20_40;
   TH1F *hFRPt40_60;
   TH1F *hFRPt60_80;
@@ -189,9 +185,9 @@ class PFJetBenchmark {
   TH1F *hFRNHE;
   TH1F *hFRNEE;
   TH1F *hFRneut;
-  TH2F *hFRPtvsPt ;
+  TH2F *hFRPtvsPt;
   TH2F *hFRCHEvsPt;
-  TH2F *hFRNHEvsPt ;
+  TH2F *hFRNHEvsPt;
   TH2F *hFRNEEvsPt;
   TH2F *hFRneutvsPt;
   TH2F *hFRNEUTvsP;
@@ -202,18 +198,18 @@ class PFJetBenchmark {
   TH2F *hFDPhivsPt;
   TH2F *hFNCHvsPt;
   TH1F *hFNCH;
-  TH2F* hFNCH0vsPt;
-  TH2F* hFNCH1vsPt;
-  TH2F* hFNCH2vsPt;
-  TH2F* hFNCH3vsPt;
-  TH2F* hFNCH4vsPt;
-  TH2F* hFNCH5vsPt;
-  TH2F* hFNCH6vsPt;
-  TH2F* hFNCH7vsPt;
-	
-  std::string outputFile_;	
- protected:
-		
+  TH2F *hFNCH0vsPt;
+  TH2F *hFNCH1vsPt;
+  TH2F *hFNCH2vsPt;
+  TH2F *hFNCH3vsPt;
+  TH2F *hFNCH4vsPt;
+  TH2F *hFNCH5vsPt;
+  TH2F *hFNCH6vsPt;
+  TH2F *hFNCH7vsPt;
+
+  std::string outputFile_;
+
+protected:
   PFBenchmarkAlgo *algo_;
   bool debug_;
   bool plotAgainstReco_;
@@ -222,11 +218,11 @@ class PFJetBenchmark {
   double resPtMax_;
   double resChargedHadEnergyMax_;
   double resNeutralHadEnergyMax_;
-  double resNeutralEmEnergyMax_; 
+  double resNeutralEmEnergyMax_;
   double recPt_cut;
   double maxEta_cut;
   unsigned int entry_;
   DQMStore *dbe_;
 };
 
-#endif // RecoParticleFlow_Benchmark_PFJetBenchmark_h
+#endif  // RecoParticleFlow_Benchmark_PFJetBenchmark_h

--- a/RecoParticleFlow/Benchmark/interface/PFMETBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFMETBenchmark.h
@@ -19,80 +19,74 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 
-//#include "FWCore/ServiceRegistry/interface/Service.h" 
+//#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "TH1F.h"
 #include "TH2F.h"
 #include <string>
 #include <TFile.h>
 
-
 class DQMStore;
 
 class PFMETBenchmark {
-	
- public:
-	
+public:
   PFMETBenchmark();
   virtual ~PFMETBenchmark();
-	
-  void setup(
-	     std::string Filename,
-	     bool debug, 
-	     bool plotAgainstReco=false, 
-             std::string benchmarkLabel_ = "ParticleFlow", 
-	     DQMStore * dbe_store = nullptr
-	     );
-  void process(const reco::PFMETCollection& , 
-	       const reco::GenParticleCollection&, 
-	       const reco::CaloMETCollection&, 
-	       const reco::METCollection& );
-  void calculateQuantities(const reco::PFMETCollection&, 
-			   const reco::GenParticleCollection&, 
-			   const reco::CaloMETCollection&,
-			   const reco::METCollection&);
-  void calculateQuantities(const reco::PFMETCollection&, 
-			   const reco::GenParticleCollection&, 
-			   const reco::CaloMETCollection&,
-			   const reco::METCollection&,
-			   const std::vector<reco::CaloJet>&,
-			   const std::vector<reco::CaloJet>&);
-  float getTrueMET(){return true_met;}
-  float getTruePhi(){return true_phi;}
-  float getTrueSET(){return true_set;}
-  float getPFMET(){return rec_met;}
-  float getPFMEX(){return rec_mex-true_mex;}
-  float getPFMEY(){return rec_mey-true_mey;}
-  float getPFPhi(){return rec_phi;}
-  float getPFSET(){return rec_set;}
-  float getCaloMET(){return calo_met;}
-  float getCaloMEX(){return calo_mex-true_mex;}
-  float getCaloMEY(){return calo_mey-true_mey;}
-  float getCaloPhi(){return calo_phi;}
-  float getCaloSET(){return calo_set;}
-  float getTCMET(){return tc_met;}
-  float getTCMEX(){return tc_mex-true_mex;}
-  float getTCMEY(){return tc_mey-true_mey;}
-  float getTCPhi(){return tc_phi;}
-  float getTCSET(){return tc_set;}
-  float getDeltaPFMET(){return rec_met - true_met;}
-  float getDeltaPFPhi(){return mpi_pi(rec_phi - true_phi);}
-  float getDeltaPFSET(){return rec_set - true_set;}
-  float getDeltaCaloMET(){return calo_met - true_met;}
-  float getDeltaCaloPhi(){return mpi_pi(calo_phi - true_phi);}
-  float getDeltaCaloSET(){return calo_set - true_set;}
-  float getDeltaTCMET(){return tc_met - true_met;}
-  float getDeltaTCPhi(){return mpi_pi(tc_phi - true_phi);}
-  float getDeltaTCSET(){return tc_set - true_set;}
+
+  void setup(std::string Filename,
+             bool debug,
+             bool plotAgainstReco = false,
+             std::string benchmarkLabel_ = "ParticleFlow",
+             DQMStore* dbe_store = nullptr);
+  void process(const reco::PFMETCollection&,
+               const reco::GenParticleCollection&,
+               const reco::CaloMETCollection&,
+               const reco::METCollection&);
+  void calculateQuantities(const reco::PFMETCollection&,
+                           const reco::GenParticleCollection&,
+                           const reco::CaloMETCollection&,
+                           const reco::METCollection&);
+  void calculateQuantities(const reco::PFMETCollection&,
+                           const reco::GenParticleCollection&,
+                           const reco::CaloMETCollection&,
+                           const reco::METCollection&,
+                           const std::vector<reco::CaloJet>&,
+                           const std::vector<reco::CaloJet>&);
+  float getTrueMET() { return true_met; }
+  float getTruePhi() { return true_phi; }
+  float getTrueSET() { return true_set; }
+  float getPFMET() { return rec_met; }
+  float getPFMEX() { return rec_mex - true_mex; }
+  float getPFMEY() { return rec_mey - true_mey; }
+  float getPFPhi() { return rec_phi; }
+  float getPFSET() { return rec_set; }
+  float getCaloMET() { return calo_met; }
+  float getCaloMEX() { return calo_mex - true_mex; }
+  float getCaloMEY() { return calo_mey - true_mey; }
+  float getCaloPhi() { return calo_phi; }
+  float getCaloSET() { return calo_set; }
+  float getTCMET() { return tc_met; }
+  float getTCMEX() { return tc_mex - true_mex; }
+  float getTCMEY() { return tc_mey - true_mey; }
+  float getTCPhi() { return tc_phi; }
+  float getTCSET() { return tc_set; }
+  float getDeltaPFMET() { return rec_met - true_met; }
+  float getDeltaPFPhi() { return mpi_pi(rec_phi - true_phi); }
+  float getDeltaPFSET() { return rec_set - true_set; }
+  float getDeltaCaloMET() { return calo_met - true_met; }
+  float getDeltaCaloPhi() { return mpi_pi(calo_phi - true_phi); }
+  float getDeltaCaloSET() { return calo_set - true_set; }
+  float getDeltaTCMET() { return tc_met - true_met; }
+  float getDeltaTCPhi() { return mpi_pi(tc_phi - true_phi); }
+  float getDeltaTCSET() { return tc_set - true_set; }
   double mpi_pi(double angle);
   void analyse();
   //void FitSlicesInY(TH2F*, TH1F*, TH1F*, bool, int);
   void write();
-	
- private:
-		
-  TFile *file_;
-	
+
+private:
+  TFile* file_;
+
   // histograms
   // delta Pt or E quantities for Barrel
   TProfile* profileSETvsSETresp;
@@ -143,14 +137,14 @@ class PFMETBenchmark {
   TH2F* hDeltaTCMEXvstrueSET;
   TH2F* hTCMETvstrueMET;
 
-  //TH1F *hmeanPF;   
-  //TH1F *hmeanCalo; 
-  //TH1F *hsigmaPF;  
+  //TH1F *hmeanPF;
+  //TH1F *hmeanCalo;
+  //TH1F *hsigmaPF;
   //TH1F *hsigmaCalo;
-  //TH1F *hrmsPF;    
-  //TH1F *hrmsCalo;  
+  //TH1F *hrmsPF;
+  //TH1F *hrmsCalo;
 
-  std::string outputFile_;	
+  std::string outputFile_;
 
   double true_set;
   double true_met;
@@ -173,12 +167,11 @@ class PFMETBenchmark {
   double tc_phi;
   double tc_set;
 
- protected:
-		
-  PFBenchmarkAlgo *algo_;
+protected:
+  PFBenchmarkAlgo* algo_;
   bool debug_;
   bool plotAgainstReco_;
-  DQMStore *dbe_;
+  DQMStore* dbe_;
 };
 
-#endif // RecoParticleFlow_Benchmark_PFMETBenchmark_h
+#endif  // RecoParticleFlow_Benchmark_PFMETBenchmark_h

--- a/RecoParticleFlow/Benchmark/interface/PFTauElecRejectionBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFTauElecRejectionBenchmark.h
@@ -31,34 +31,31 @@ class TH2F;
 //class DQMStore; // CMSSW_2_X_X not needed here?
 
 class PFTauElecRejectionBenchmark {
-	
- public:
-  
+public:
   PFTauElecRejectionBenchmark();
   virtual ~PFTauElecRejectionBenchmark();
-  
-  void setup(
-	     std::string Filename,
-	     std::string benchmarkLabel,
-	     double maxDeltaR, 
-	     double minRecoPt, 
-	     double maxRecoAbsEta, 
-	     double minMCPt, 
-	     double maxMCAbsEta, 
-	     std::string sGenMatchObjectLabel,
-	     bool applyEcalCrackCut,
-	     DQMStore * db_store);
-  void process(edm::Handle<edm::HepMCProduct> mcevt, edm::Handle<reco::PFTauCollection> pfTaus, 
-	       edm::Handle<reco::PFTauDiscriminator> pfTauIsoDiscr, 
-	       edm::Handle<reco::PFTauDiscriminator> pfTauElecDiscr);
+
+  void setup(std::string Filename,
+             std::string benchmarkLabel,
+             double maxDeltaR,
+             double minRecoPt,
+             double maxRecoAbsEta,
+             double minMCPt,
+             double maxMCAbsEta,
+             std::string sGenMatchObjectLabel,
+             bool applyEcalCrackCut,
+             DQMStore *db_store);
+  void process(edm::Handle<edm::HepMCProduct> mcevt,
+               edm::Handle<reco::PFTauCollection> pfTaus,
+               edm::Handle<reco::PFTauDiscriminator> pfTauIsoDiscr,
+               edm::Handle<reco::PFTauDiscriminator> pfTauElecDiscr);
   void write();
-	
- private:
-		
+
+private:
   bool isInEcalCrack(double eta) const;
 
   TFile *file_;
-  std::string outputFile_;	
+  std::string outputFile_;
   std::string benchmarkLabel_;
   double maxDeltaR_;
   double minMCPt_;
@@ -115,12 +112,10 @@ class PFTauElecRejectionBenchmark {
   TH1F *hleadGsfTk_eta;
   TH1F *hleadGsfTk_phi;
 
-	
   std::vector<TLorentzVector> _GenObjects;
 
- protected:
-		
+protected:
   DQMStore *db_;
 };
 
-#endif // RecoParticleFlow_Benchmark_PFTauElecRejectionBenchmark_h
+#endif  // RecoParticleFlow_Benchmark_PFTauElecRejectionBenchmark_h

--- a/RecoParticleFlow/Benchmark/src/BenchmarkTree.cc
+++ b/RecoParticleFlow/Benchmark/src/BenchmarkTree.cc
@@ -1,16 +1,10 @@
 #include "RecoParticleFlow/Benchmark/interface/BenchmarkTree.h"
 
-
-
-BenchmarkTree::BenchmarkTree( const char* name,
-			      const char* title) 
-  : TTree( name, title ), 
-    entry_( new BenchmarkTreeEntry ) {
- 
-  Branch( "benchmarkEntry","BenchmarkTreeEntry", &entry_ );
+BenchmarkTree::BenchmarkTree(const char* name, const char* title) : TTree(name, title), entry_(new BenchmarkTreeEntry) {
+  Branch("benchmarkEntry", "BenchmarkTreeEntry", &entry_);
 }
 
-void BenchmarkTree::Fill( const BenchmarkTreeEntry& entry ) {
+void BenchmarkTree::Fill(const BenchmarkTreeEntry& entry) {
   *entry_ = entry;
   TTree::Fill();
 }

--- a/RecoParticleFlow/Benchmark/src/GenericBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/GenericBenchmark.cc
@@ -8,29 +8,29 @@
 #include <TROOT.h>
 #include <TFile.h>
 
-//Colin: it seems a bit strange to use the preprocessor for that kind of 
+//Colin: it seems a bit strange to use the preprocessor for that kind of
 //thing. Looks like all these macros could be replaced by plain functions.
 
 // preprocessor macro for booking 1d histos with DQMStore -or- bare Root
-#define BOOK1D(name,title,nbinsx,lowx,highx)				\
-  h##name = DQM ? DQM->book1D(#name,title,nbinsx,lowx,highx)->getTH1F() \
-    : new TH1F(#name,title,nbinsx,lowx,highx)
+#define BOOK1D(name, title, nbinsx, lowx, highx) \
+  h##name =                                      \
+      DQM ? DQM->book1D(#name, title, nbinsx, lowx, highx)->getTH1F() : new TH1F(#name, title, nbinsx, lowx, highx)
 
 // preprocessor macro for booking 2d histos with DQMStore -or- bare Root
-#define BOOK2D(name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)		\
-  h##name = DQM ? DQM->book2D(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)->getTH2F() \
-    : new TH2F(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)
-
+#define BOOK2D(name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)                            \
+  h##name = DQM ? DQM->book2D(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)->getTH2F() \
+                : new TH2F(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)
 
 // all versions OK
 // preprocesor macro for setting axis titles
 
-#define SETAXES(name,xtitle,ytitle)					\
-  h##name->GetXaxis()->SetTitle(xtitle); h##name->GetYaxis()->SetTitle(ytitle)
+#define SETAXES(name, xtitle, ytitle)    \
+  h##name->GetXaxis()->SetTitle(xtitle); \
+  h##name->GetYaxis()->SetTitle(ytitle)
 
-#define ET (PlotAgainstReco_)?"reconstructed E_{T} [GeV]":"generated E_{T} [GeV]"
-#define ETA (PlotAgainstReco_)?"reconstructed #eta":"generated #eta"
-#define PHI (PlotAgainstReco_)?"reconstructed #phi (rad)":"generated #phi (rad)"
+#define ET (PlotAgainstReco_) ? "reconstructed E_{T} [GeV]" : "generated E_{T} [GeV]"
+#define ETA (PlotAgainstReco_) ? "reconstructed #eta" : "generated #eta"
+#define PHI (PlotAgainstReco_) ? "reconstructed #phi (rad)" : "generated #phi (rad)"
 
 using namespace std;
 
@@ -38,9 +38,13 @@ GenericBenchmark::GenericBenchmark() {}
 
 GenericBenchmark::~GenericBenchmark() noexcept(false) {}
 
-void GenericBenchmark::setup(DQMStore *DQM, bool PlotAgainstReco_, float minDeltaEt, float maxDeltaEt,
-			     float minDeltaPhi, float maxDeltaPhi, bool doMetPlots) {
-
+void GenericBenchmark::setup(DQMStore* DQM,
+                             bool PlotAgainstReco_,
+                             float minDeltaEt,
+                             float maxDeltaEt,
+                             float minDeltaPhi,
+                             float maxDeltaPhi,
+                             bool doMetPlots) {
   //std::cout << "minDeltaPhi = " << minDeltaPhi << std::endl;
 
   // CMSSW_2_X_X
@@ -75,241 +79,187 @@ void GenericBenchmark::setup(DQMStore *DQM, bool PlotAgainstReco_, float minDelt
   //float minDeltaPhi = -0.5;
   //float maxDeltaPhi = 0.5;
 
-
   // delta et quantities
-  BOOK1D(DeltaEt,"#DeltaE_{T}", nbinsEt, minDeltaEt, maxDeltaEt);
-  BOOK1D(DeltaEx,"#DeltaE_{X}", nbinsEt, minDeltaEt, maxDeltaEt);
-  BOOK1D(DeltaEy,"#DeltaE_{Y}", nbinsEt, minDeltaEt, maxDeltaEt);
-  BOOK2D(DeltaEtvsEt,"#DeltaE_{T} vs E_{T}",
-	 nbinsEt, minEt, maxEt,
-	 nbinsEt,minDeltaEt, maxDeltaEt);
-  BOOK2D(DeltaEtOverEtvsEt,"#DeltaE_{T}/E_{T} vsE_{T}",
-	 nbinsEt, minEt, maxEt,
-	 nbinsEt,-1,1);
-  BOOK2D(DeltaEtvsEta,"#DeltaE_{T} vs #eta",
-	 nbinsEta, minEta, maxEta,
-	 nbinsEt,minDeltaEt, maxDeltaEt);
-  BOOK2D(DeltaEtOverEtvsEta,"#DeltaE_{T}/E_{T} vs #eta",
-	 nbinsEta, minEta, maxEta,
-	 100,-1,1);
-  BOOK2D(DeltaEtvsPhi,"#DeltaE_{T} vs #phi",
-	 200,-M_PI,M_PI,
-	 nbinsEt,minDeltaEt, maxDeltaEt);
-  BOOK2D(DeltaEtOverEtvsPhi,"#DeltaE_{T}/E_{T} vs #Phi",
-	 200,-M_PI,M_PI,
-	 100,-1,1);
-  BOOK2D(DeltaEtvsDeltaR,"#DeltaE_{T} vs #DeltaR",
-	 100,0,1,
-	 nbinsEt,minDeltaEt, maxDeltaEt);
-  BOOK2D(DeltaEtOverEtvsDeltaR,"#DeltaE_{T}/E_{T} vs #DeltaR",
-	 100,0,1,
-	 100,-1,1);
+  BOOK1D(DeltaEt, "#DeltaE_{T}", nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK1D(DeltaEx, "#DeltaE_{X}", nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK1D(DeltaEy, "#DeltaE_{Y}", nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK2D(DeltaEtvsEt, "#DeltaE_{T} vs E_{T}", nbinsEt, minEt, maxEt, nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK2D(DeltaEtOverEtvsEt, "#DeltaE_{T}/E_{T} vsE_{T}", nbinsEt, minEt, maxEt, nbinsEt, -1, 1);
+  BOOK2D(DeltaEtvsEta, "#DeltaE_{T} vs #eta", nbinsEta, minEta, maxEta, nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK2D(DeltaEtOverEtvsEta, "#DeltaE_{T}/E_{T} vs #eta", nbinsEta, minEta, maxEta, 100, -1, 1);
+  BOOK2D(DeltaEtvsPhi, "#DeltaE_{T} vs #phi", 200, -M_PI, M_PI, nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK2D(DeltaEtOverEtvsPhi, "#DeltaE_{T}/E_{T} vs #Phi", 200, -M_PI, M_PI, 100, -1, 1);
+  BOOK2D(DeltaEtvsDeltaR, "#DeltaE_{T} vs #DeltaR", 100, 0, 1, nbinsEt, minDeltaEt, maxDeltaEt);
+  BOOK2D(DeltaEtOverEtvsDeltaR, "#DeltaE_{T}/E_{T} vs #DeltaR", 100, 0, 1, 100, -1, 1);
 
   // delta eta quantities
-  BOOK1D(DeltaEta,"#Delta#eta",nbinsDeltaEta,minDeltaEta,maxDeltaEta);
-  BOOK2D(DeltaEtavsEt,"#Delta#eta vs E_{T}",
-	 nbinsEt, minEt, maxEt,
-	 nbinsDeltaEta,minDeltaEta,maxDeltaEta);
-  BOOK2D(DeltaEtavsEta,"#Delta#eta vs #eta",
-	 nbinsEta, minEta, maxEta,
-	 nbinsDeltaEta,minDeltaEta,maxDeltaEta);
+  BOOK1D(DeltaEta, "#Delta#eta", nbinsDeltaEta, minDeltaEta, maxDeltaEta);
+  BOOK2D(DeltaEtavsEt, "#Delta#eta vs E_{T}", nbinsEt, minEt, maxEt, nbinsDeltaEta, minDeltaEta, maxDeltaEta);
+  BOOK2D(DeltaEtavsEta, "#Delta#eta vs #eta", nbinsEta, minEta, maxEta, nbinsDeltaEta, minDeltaEta, maxDeltaEta);
 
   // delta phi quantities
-  BOOK1D(DeltaPhi,"#Delta#phi",nbinsDeltaPhi,minDeltaPhi,maxDeltaPhi);
-  BOOK2D(DeltaPhivsEt,"#Delta#phi vs E_{T}",
-	 nbinsEt, minEt, maxEt,
-	 nbinsDeltaPhi,minDeltaPhi,maxDeltaPhi);
-  BOOK2D(DeltaPhivsEta,"#Delta#phi vs #eta",
-	 nbinsEta, minEta, maxEta,
-	 nbinsDeltaPhi,minDeltaPhi,maxDeltaPhi);
+  BOOK1D(DeltaPhi, "#Delta#phi", nbinsDeltaPhi, minDeltaPhi, maxDeltaPhi);
+  BOOK2D(DeltaPhivsEt, "#Delta#phi vs E_{T}", nbinsEt, minEt, maxEt, nbinsDeltaPhi, minDeltaPhi, maxDeltaPhi);
+  BOOK2D(DeltaPhivsEta, "#Delta#phi vs #eta", nbinsEta, minEta, maxEta, nbinsDeltaPhi, minDeltaPhi, maxDeltaPhi);
 
   // delta R quantities
-  BOOK1D(DeltaR,"#DeltaR",100,0,1);
-  BOOK2D(DeltaRvsEt,"#DeltaR vs E_{T}",
-	 nbinsEt, minEt, maxEt,
-	 100,0,1);
-  BOOK2D(DeltaRvsEta,"#DeltaR vs #eta",
-	 nbinsEta, minEta, maxEta,
-	 100,0,1);
+  BOOK1D(DeltaR, "#DeltaR", 100, 0, 1);
+  BOOK2D(DeltaRvsEt, "#DeltaR vs E_{T}", nbinsEt, minEt, maxEt, 100, 0, 1);
+  BOOK2D(DeltaRvsEta, "#DeltaR vs #eta", nbinsEta, minEta, maxEta, 100, 0, 1);
 
-  BOOK1D(NRec,"Number of reconstructed objects",20,0,20);
+  BOOK1D(NRec, "Number of reconstructed objects", 20, 0, 20);
 
   // seen and gen distributions, for efficiency computation
-  BOOK1D(EtaSeen,"seen #eta",100,-5,5);
-  BOOK1D(PhiSeen,"seen #phi",100,-3.5,3.5);
-  BOOK1D(EtSeen,"seen E_{T}",nbinsEt, minEt, maxEt);
-  BOOK2D(EtvsEtaSeen,"seen E_{T} vs eta",100,-5,5,200, 0, 200);
-  BOOK2D(EtvsPhiSeen,"seen E_{T} vs seen #phi",100,-3.5,3.5,200, 0, 200);  
+  BOOK1D(EtaSeen, "seen #eta", 100, -5, 5);
+  BOOK1D(PhiSeen, "seen #phi", 100, -3.5, 3.5);
+  BOOK1D(EtSeen, "seen E_{T}", nbinsEt, minEt, maxEt);
+  BOOK2D(EtvsEtaSeen, "seen E_{T} vs eta", 100, -5, 5, 200, 0, 200);
+  BOOK2D(EtvsPhiSeen, "seen E_{T} vs seen #phi", 100, -3.5, 3.5, 200, 0, 200);
 
-  BOOK1D(PhiRec,"Rec #phi",100,-3.5,3.5);
-  BOOK1D(EtRec,"Rec E_{T}",nbinsEt, minEt, maxEt);
-  BOOK1D(ExRec,"Rec E_{X}",nbinsEt, -maxEt, maxEt);
-  BOOK1D(EyRec,"Rec E_{Y}",nbinsEt, -maxEt, maxEt);
+  BOOK1D(PhiRec, "Rec #phi", 100, -3.5, 3.5);
+  BOOK1D(EtRec, "Rec E_{T}", nbinsEt, minEt, maxEt);
+  BOOK1D(ExRec, "Rec E_{X}", nbinsEt, -maxEt, maxEt);
+  BOOK1D(EyRec, "Rec E_{Y}", nbinsEt, -maxEt, maxEt);
 
-  BOOK2D(EtRecvsEt,"Rec E_{T} vs E_{T}",
-	 nbinsEt, minEt, maxEt,
-	 nbinsEt, minEt, maxEt);
-  BOOK2D(EtRecOverTrueEtvsTrueEt,"Rec E_{T} / E_{T} vs E_{T}",
-	 nbinsEt, minEt, maxEt,
-	 1000, 0., 100.);
+  BOOK2D(EtRecvsEt, "Rec E_{T} vs E_{T}", nbinsEt, minEt, maxEt, nbinsEt, minEt, maxEt);
+  BOOK2D(EtRecOverTrueEtvsTrueEt, "Rec E_{T} / E_{T} vs E_{T}", nbinsEt, minEt, maxEt, 1000, 0., 100.);
 
-  BOOK1D(EtaGen,"generated #eta",100,-5,5);
-  BOOK1D(PhiGen,"generated #phi",100,-3.5,3.5);
-  BOOK1D(EtGen,"generated E_{T}",nbinsEt, minEt, maxEt);
-  BOOK2D(EtvsEtaGen,"generated E_{T} vs generated #eta",100,-5,5,200, 0, 200);  
-  BOOK2D(EtvsPhiGen,"generated E_{T} vs generated #phi",100,-3.5,3.5, 200, 0, 200);  
+  BOOK1D(EtaGen, "generated #eta", 100, -5, 5);
+  BOOK1D(PhiGen, "generated #phi", 100, -3.5, 3.5);
+  BOOK1D(EtGen, "generated E_{T}", nbinsEt, minEt, maxEt);
+  BOOK2D(EtvsEtaGen, "generated E_{T} vs generated #eta", 100, -5, 5, 200, 0, 200);
+  BOOK2D(EtvsPhiGen, "generated E_{T} vs generated #phi", 100, -3.5, 3.5, 200, 0, 200);
 
-  BOOK1D(NGen,"Number of generated objects",20,0,20);
+  BOOK1D(NGen, "Number of generated objects", 20, 0, 20);
 
-  if (doMetPlots)
-  {
-    BOOK1D(SumEt,"SumEt", 1000, 0., 3000.);
-    BOOK1D(TrueSumEt,"TrueSumEt", 1000, 0., 3000.);
-    BOOK2D(DeltaSetvsSet,"#DeltaSEt vs trueSEt",
-	   3000, 0., 3000.,
-	   1000,-1000., 1000.);
-    BOOK2D(DeltaMexvsSet,"#DeltaMEX vs trueSEt",
-	   3000, 0., 3000.,
-	   1000,-400., 400.);
-    BOOK2D(DeltaSetOverSetvsSet,"#DeltaSetOverSet vs trueSet",
-	   3000, 0., 3000.,
-	   1000,-1., 1.);
-    BOOK2D(RecSetvsTrueSet,"Set vs trueSet",
-	   3000, 0., 3000.,
-	   3000,0., 3000.);
-    BOOK2D(RecSetOverTrueSetvsTrueSet,"Set/trueSet vs trueSet",
-	   3000, 0., 3000.,
-	   500,0., 2.);
-    BOOK2D(TrueMexvsTrueSet,"trueMex vs trueSet",
-	   3000,0., 3000.,
-	   nbinsEt, -maxEt, maxEt);
+  if (doMetPlots) {
+    BOOK1D(SumEt, "SumEt", 1000, 0., 3000.);
+    BOOK1D(TrueSumEt, "TrueSumEt", 1000, 0., 3000.);
+    BOOK2D(DeltaSetvsSet, "#DeltaSEt vs trueSEt", 3000, 0., 3000., 1000, -1000., 1000.);
+    BOOK2D(DeltaMexvsSet, "#DeltaMEX vs trueSEt", 3000, 0., 3000., 1000, -400., 400.);
+    BOOK2D(DeltaSetOverSetvsSet, "#DeltaSetOverSet vs trueSet", 3000, 0., 3000., 1000, -1., 1.);
+    BOOK2D(RecSetvsTrueSet, "Set vs trueSet", 3000, 0., 3000., 3000, 0., 3000.);
+    BOOK2D(RecSetOverTrueSetvsTrueSet, "Set/trueSet vs trueSet", 3000, 0., 3000., 500, 0., 2.);
+    BOOK2D(TrueMexvsTrueSet, "trueMex vs trueSet", 3000, 0., 3000., nbinsEt, -maxEt, maxEt);
   }
   // number of truth particles found within given cone radius of reco
   //BOOK2D(NumInConeVsConeSize,NumInConeVsConeSize,100,0,1,25,0,25);
 
   // Set Axis Titles
- 
+
   // delta et quantities
-  SETAXES(DeltaEt,"#DeltaE_{T} [GeV]","");
-  SETAXES(DeltaEx,"#DeltaE_{X} [GeV]","");
-  SETAXES(DeltaEy,"#DeltaE_{Y} [GeV]","");
-  SETAXES(DeltaEtvsEt,ET,"#DeltaE_{T} [GeV]");
-  SETAXES(DeltaEtOverEtvsEt,ET,"#DeltaE_{T}/E_{T}");
-  SETAXES(DeltaEtvsEta,ETA,"#DeltaE_{T} [GeV]");
-  SETAXES(DeltaEtOverEtvsEta,ETA,"#DeltaE_{T}/E_{T}");
-  SETAXES(DeltaEtvsPhi,PHI,"#DeltaE_{T} [GeV]");
-  SETAXES(DeltaEtOverEtvsPhi,PHI,"#DeltaE_{T}/E_{T}");
-  SETAXES(DeltaEtvsDeltaR,"#DeltaR","#DeltaE_{T} [GeV]");
-  SETAXES(DeltaEtOverEtvsDeltaR,"#DeltaR","#DeltaE_{T}/E_{T}");
+  SETAXES(DeltaEt, "#DeltaE_{T} [GeV]", "");
+  SETAXES(DeltaEx, "#DeltaE_{X} [GeV]", "");
+  SETAXES(DeltaEy, "#DeltaE_{Y} [GeV]", "");
+  SETAXES(DeltaEtvsEt, ET, "#DeltaE_{T} [GeV]");
+  SETAXES(DeltaEtOverEtvsEt, ET, "#DeltaE_{T}/E_{T}");
+  SETAXES(DeltaEtvsEta, ETA, "#DeltaE_{T} [GeV]");
+  SETAXES(DeltaEtOverEtvsEta, ETA, "#DeltaE_{T}/E_{T}");
+  SETAXES(DeltaEtvsPhi, PHI, "#DeltaE_{T} [GeV]");
+  SETAXES(DeltaEtOverEtvsPhi, PHI, "#DeltaE_{T}/E_{T}");
+  SETAXES(DeltaEtvsDeltaR, "#DeltaR", "#DeltaE_{T} [GeV]");
+  SETAXES(DeltaEtOverEtvsDeltaR, "#DeltaR", "#DeltaE_{T}/E_{T}");
 
   // delta eta quantities
-  SETAXES(DeltaEta,"#Delta#eta","Events");
-  SETAXES(DeltaEtavsEt,ET,"#Delta#eta");
-  SETAXES(DeltaEtavsEta,ETA,"#Delta#eta");
+  SETAXES(DeltaEta, "#Delta#eta", "Events");
+  SETAXES(DeltaEtavsEt, ET, "#Delta#eta");
+  SETAXES(DeltaEtavsEta, ETA, "#Delta#eta");
 
   // delta phi quantities
-  SETAXES(DeltaPhi,"#Delta#phi [rad]","Events");
-  SETAXES(DeltaPhivsEt,ET,"#Delta#phi [rad]");
-  SETAXES(DeltaPhivsEta,ETA,"#Delta#phi [rad]");
+  SETAXES(DeltaPhi, "#Delta#phi [rad]", "Events");
+  SETAXES(DeltaPhivsEt, ET, "#Delta#phi [rad]");
+  SETAXES(DeltaPhivsEta, ETA, "#Delta#phi [rad]");
 
   // delta R quantities
-  SETAXES(DeltaR,"#DeltaR","Events");
-  SETAXES(DeltaRvsEt,ET,"#DeltaR");
-  SETAXES(DeltaRvsEta,ETA,"#DeltaR");
+  SETAXES(DeltaR, "#DeltaR", "Events");
+  SETAXES(DeltaRvsEt, ET, "#DeltaR");
+  SETAXES(DeltaRvsEta, ETA, "#DeltaR");
 
-  SETAXES(NRec,"Number of Rec Objects","");
-  
-  SETAXES(EtaSeen,"seen #eta","");
-  SETAXES(PhiSeen,"seen #phi [rad]","");
-  SETAXES(EtSeen,"seen E_{T} [GeV]","");
-  SETAXES(EtvsEtaSeen,"seen #eta","seen E_{T}");
-  SETAXES(EtvsPhiSeen,"seen #phi [rad]","seen E_{T}");
+  SETAXES(NRec, "Number of Rec Objects", "");
 
-  SETAXES(PhiRec,"#phi [rad]","");
-  SETAXES(EtRec,"E_{T} [GeV]","");
-  SETAXES(ExRec,"E_{X} [GeV]","");
-  SETAXES(EyRec,"E_{Y} [GeV]","");
-  SETAXES(EtRecvsEt,ET,"Rec E_{T} [GeV]");
-  SETAXES(EtRecOverTrueEtvsTrueEt,ET,"Rec E_{T} / E_{T} [GeV]");
+  SETAXES(EtaSeen, "seen #eta", "");
+  SETAXES(PhiSeen, "seen #phi [rad]", "");
+  SETAXES(EtSeen, "seen E_{T} [GeV]", "");
+  SETAXES(EtvsEtaSeen, "seen #eta", "seen E_{T}");
+  SETAXES(EtvsPhiSeen, "seen #phi [rad]", "seen E_{T}");
 
-  SETAXES(EtaGen,"generated #eta","");
-  SETAXES(PhiGen,"generated #phi [rad]","");
-  SETAXES(EtGen,"generated E_{T} [GeV]","");
-  SETAXES(EtvsPhiGen,"generated #phi [rad]","generated E_{T} [GeV]");
-  SETAXES(EtvsEtaGen,"generated #eta","generated E_{T} [GeV]");
+  SETAXES(PhiRec, "#phi [rad]", "");
+  SETAXES(EtRec, "E_{T} [GeV]", "");
+  SETAXES(ExRec, "E_{X} [GeV]", "");
+  SETAXES(EyRec, "E_{Y} [GeV]", "");
+  SETAXES(EtRecvsEt, ET, "Rec E_{T} [GeV]");
+  SETAXES(EtRecOverTrueEtvsTrueEt, ET, "Rec E_{T} / E_{T} [GeV]");
 
-  SETAXES(NGen,"Number of Gen Objects","");
-  
-  if (doMetPlots)
-  {
-    SETAXES(SumEt,"SumEt [GeV]","");
-    SETAXES(TrueSumEt,"TrueSumEt [GeV]","");
-    SETAXES(DeltaSetvsSet,"TrueSumEt","#DeltaSumEt [GeV]");
-    SETAXES(DeltaMexvsSet,"TrueSumEt","#DeltaMEX [GeV]");
-    SETAXES(DeltaSetOverSetvsSet,"TrueSumEt","#DeltaSumEt/trueSumEt");
-    SETAXES(RecSetvsTrueSet,"TrueSumEt","SumEt");
-    SETAXES(RecSetOverTrueSetvsTrueSet,"TrueSumEt","SumEt/trueSumEt");
-    SETAXES(TrueMexvsTrueSet,"TrueSumEt","TrueMEX");
+  SETAXES(EtaGen, "generated #eta", "");
+  SETAXES(PhiGen, "generated #phi [rad]", "");
+  SETAXES(EtGen, "generated E_{T} [GeV]", "");
+  SETAXES(EtvsPhiGen, "generated #phi [rad]", "generated E_{T} [GeV]");
+  SETAXES(EtvsEtaGen, "generated #eta", "generated E_{T} [GeV]");
+
+  SETAXES(NGen, "Number of Gen Objects", "");
+
+  if (doMetPlots) {
+    SETAXES(SumEt, "SumEt [GeV]", "");
+    SETAXES(TrueSumEt, "TrueSumEt [GeV]", "");
+    SETAXES(DeltaSetvsSet, "TrueSumEt", "#DeltaSumEt [GeV]");
+    SETAXES(DeltaMexvsSet, "TrueSumEt", "#DeltaMEX [GeV]");
+    SETAXES(DeltaSetOverSetvsSet, "TrueSumEt", "#DeltaSumEt/trueSumEt");
+    SETAXES(RecSetvsTrueSet, "TrueSumEt", "SumEt");
+    SETAXES(RecSetOverTrueSetvsTrueSet, "TrueSumEt", "SumEt/trueSumEt");
+    SETAXES(TrueMexvsTrueSet, "TrueSumEt", "TrueMEX");
   }
 
   TDirectory* oldpwd = gDirectory;
 
+  TIter next(gROOT->GetListOfFiles());
 
-  TIter next( gROOT->GetListOfFiles() );
+  const bool debug = false;
 
-  const bool debug=false;
-
-  while ( TFile *file = (TFile *)next() )
-  {
-    if (debug) cout<<"file "<<file->GetName()<<endl;
+  while (TFile* file = (TFile*)next()) {
+    if (debug)
+      cout << "file " << file->GetName() << endl;
   }
-  if (DQM)
-  {
-    cout<<"DQM subdir"<<endl;
-    cout<< DQM->pwd().c_str()<<endl;
+  if (DQM) {
+    cout << "DQM subdir" << endl;
+    cout << DQM->pwd().c_str() << endl;
 
-    DQM->cd( DQM->pwd() );
+    DQM->cd(DQM->pwd());
   }
 
-  if (debug)
-  {
-    cout<<"current dir"<<endl;
+  if (debug) {
+    cout << "current dir" << endl;
     gDirectory->pwd();
   }
-  
+
   oldpwd->cd();
   //gDirectory->pwd();
 
-  doMetPlots_=doMetPlots;
+  doMetPlots_ = doMetPlots;
 
   //   tree_ = new BenchmarkTree("genericBenchmark", "Generic Benchmark TTree");
 }
 
 bool GenericBenchmark::accepted(const reco::Candidate* particle,
-				double ptCut,
-				double minEtaCut,
-				double maxEtaCut ) const {
- 
+                                double ptCut,
+                                double minEtaCut,
+                                double maxEtaCut) const {
   //skip reconstructed PFJets with p_t < recPt_cut
   if (particle->pt() < ptCut and ptCut != -1.)
     return false;
 
-  if (fabs(particle->eta())>maxEtaCut and maxEtaCut > 0)
+  if (fabs(particle->eta()) > maxEtaCut and maxEtaCut > 0)
     return false;
-  if (fabs(particle->eta())<minEtaCut and minEtaCut > 0)
+  if (fabs(particle->eta()) < minEtaCut and minEtaCut > 0)
     return false;
 
   //accepted!
   return true;
- 
 }
 
-
-void GenericBenchmark::fillHistos( const reco::Candidate* genParticle,
-				   const reco::Candidate* recParticle,
-				   double deltaR_cut,
-				   bool plotAgainstReco ) {
-
+void GenericBenchmark::fillHistos(const reco::Candidate* genParticle,
+                                  const reco::Candidate* recParticle,
+                                  double deltaR_cut,
+                                  bool plotAgainstReco) {
   // get the quantities to place on the denominator and/or divide by
   double et = genParticle->et();
   double eta = genParticle->eta();
@@ -321,48 +271,47 @@ void GenericBenchmark::fillHistos( const reco::Candidate* genParticle,
   //std::cout << "FL : rec eta = " << recParticle->eta() << std::endl;
   //std::cout << "FL : rec phi = " <<recParticle-> phi() << std::endl;
 
-  if (plotAgainstReco) { 
-    et = recParticle->et(); 
-    eta = recParticle->eta(); 
-    phi = recParticle->phi(); 
+  if (plotAgainstReco) {
+    et = recParticle->et();
+    eta = recParticle->eta();
+    phi = recParticle->phi();
   }
-  
-    
+
   // get the delta quantities
-  double deltaEt = algo_->deltaEt(recParticle,genParticle);
-  double deltaR = algo_->deltaR(recParticle,genParticle);
-  double deltaEta = algo_->deltaEta(recParticle,genParticle);
-  double deltaPhi = algo_->deltaPhi(recParticle,genParticle);
-   
+  double deltaEt = algo_->deltaEt(recParticle, genParticle);
+  double deltaR = algo_->deltaR(recParticle, genParticle);
+  double deltaEta = algo_->deltaEta(recParticle, genParticle);
+  double deltaPhi = algo_->deltaPhi(recParticle, genParticle);
+
   //std::cout << "FL :deltaR_cut = " << deltaR_cut << std::endl;
   //std::cout << "FL :deltaR = " << deltaR << std::endl;
 
-  if (deltaR>deltaR_cut && deltaR_cut != -1.)
-    return;  
+  if (deltaR > deltaR_cut && deltaR_cut != -1.)
+    return;
 
   hDeltaEt->Fill(deltaEt);
-  hDeltaEx->Fill(recParticle->px()-genParticle->px());
-  hDeltaEy->Fill(recParticle->py()-genParticle->py());
-  hDeltaEtvsEt->Fill(et,deltaEt);
-  hDeltaEtOverEtvsEt->Fill(et,deltaEt/et);
-  hDeltaEtvsEta->Fill(eta,deltaEt);
-  hDeltaEtOverEtvsEta->Fill(eta,deltaEt/et);
-  hDeltaEtvsPhi->Fill(phi,deltaEt);
-  hDeltaEtOverEtvsPhi->Fill(phi,deltaEt/et);
-  hDeltaEtvsDeltaR->Fill(deltaR,deltaEt);
-  hDeltaEtOverEtvsDeltaR->Fill(deltaR,deltaEt/et);
-    
+  hDeltaEx->Fill(recParticle->px() - genParticle->px());
+  hDeltaEy->Fill(recParticle->py() - genParticle->py());
+  hDeltaEtvsEt->Fill(et, deltaEt);
+  hDeltaEtOverEtvsEt->Fill(et, deltaEt / et);
+  hDeltaEtvsEta->Fill(eta, deltaEt);
+  hDeltaEtOverEtvsEta->Fill(eta, deltaEt / et);
+  hDeltaEtvsPhi->Fill(phi, deltaEt);
+  hDeltaEtOverEtvsPhi->Fill(phi, deltaEt / et);
+  hDeltaEtvsDeltaR->Fill(deltaR, deltaEt);
+  hDeltaEtOverEtvsDeltaR->Fill(deltaR, deltaEt / et);
+
   hDeltaEta->Fill(deltaEta);
-  hDeltaEtavsEt->Fill(et,deltaEta);
-  hDeltaEtavsEta->Fill(eta,deltaEta);
-    
+  hDeltaEtavsEt->Fill(et, deltaEta);
+  hDeltaEtavsEta->Fill(eta, deltaEta);
+
   hDeltaPhi->Fill(deltaPhi);
-  hDeltaPhivsEt->Fill(et,deltaPhi);
-  hDeltaPhivsEta->Fill(eta,deltaPhi);
+  hDeltaPhivsEt->Fill(et, deltaPhi);
+  hDeltaPhivsEta->Fill(eta, deltaPhi);
 
   hDeltaR->Fill(deltaR);
-  hDeltaRvsEt->Fill(et,deltaR);
-  hDeltaRvsEta->Fill(eta,deltaR);
+  hDeltaRvsEt->Fill(et, deltaR);
+  hDeltaRvsEta->Fill(eta, deltaR);
 
   BenchmarkTreeEntry entry;
   entry.deltaEt = deltaEt;
@@ -370,42 +319,33 @@ void GenericBenchmark::fillHistos( const reco::Candidate* genParticle,
   entry.et = et;
   entry.eta = eta;
 
-  if (doMetPlots_)
-  {
-    const reco::MET* met1=static_cast<const reco::MET*>(genParticle);
-    const reco::MET* met2=static_cast<const reco::MET*>(recParticle);
-    if (met1!=nullptr && met2!=nullptr)
-    {
+  if (doMetPlots_) {
+    const reco::MET* met1 = static_cast<const reco::MET*>(genParticle);
+    const reco::MET* met2 = static_cast<const reco::MET*>(recParticle);
+    if (met1 != nullptr && met2 != nullptr) {
       //std::cout << "FL: met1.sumEt() = " << (*met1).sumEt() << std::endl;
       hTrueSumEt->Fill((*met1).sumEt());
       hSumEt->Fill((*met2).sumEt());
-      hDeltaSetvsSet->Fill((*met1).sumEt(),(*met2).sumEt()-(*met1).sumEt());
-      hDeltaMexvsSet->Fill((*met1).sumEt(),recParticle->px()-genParticle->px());
-      hDeltaMexvsSet->Fill((*met1).sumEt(),recParticle->py()-genParticle->py());
-      if ((*met1).sumEt()>0.01) hDeltaSetOverSetvsSet->Fill((*met1).sumEt(),((*met2).sumEt()-(*met1).sumEt())/(*met1).sumEt());
-      hRecSetvsTrueSet->Fill((*met1).sumEt(),(*met2).sumEt());
-      hRecSetOverTrueSetvsTrueSet->Fill((*met1).sumEt(),(*met2).sumEt()/((*met1).sumEt()));
-      hTrueMexvsTrueSet->Fill((*met1).sumEt(),(*met1).px());
-      hTrueMexvsTrueSet->Fill((*met1).sumEt(),(*met1).py());
-    }
-    else
-    {
+      hDeltaSetvsSet->Fill((*met1).sumEt(), (*met2).sumEt() - (*met1).sumEt());
+      hDeltaMexvsSet->Fill((*met1).sumEt(), recParticle->px() - genParticle->px());
+      hDeltaMexvsSet->Fill((*met1).sumEt(), recParticle->py() - genParticle->py());
+      if ((*met1).sumEt() > 0.01)
+        hDeltaSetOverSetvsSet->Fill((*met1).sumEt(), ((*met2).sumEt() - (*met1).sumEt()) / (*met1).sumEt());
+      hRecSetvsTrueSet->Fill((*met1).sumEt(), (*met2).sumEt());
+      hRecSetOverTrueSetvsTrueSet->Fill((*met1).sumEt(), (*met2).sumEt() / ((*met1).sumEt()));
+      hTrueMexvsTrueSet->Fill((*met1).sumEt(), (*met1).px());
+      hTrueMexvsTrueSet->Fill((*met1).sumEt(), (*met1).py());
+    } else {
       std::cout << "Warning : reco::MET* == NULL" << std::endl;
     }
   }
 
   //     tree_->Fill(entry);
-
 }
 
 void GenericBenchmark::write(std::string Filename) {
-
   if (!Filename.empty() && file_)
     file_->Write(Filename.c_str());
-
 }
 
-void GenericBenchmark::setfile(TFile *file)
-{
-  file_=file;
-}
+void GenericBenchmark::setfile(TFile* file) { file_ = file; }

--- a/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
@@ -6,35 +6,42 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 // preprocessor macro for booking 1d histos with DQMStore -or- bare Root
-#define BOOK1D(name,title,nbinsx,lowx,highx) \
-  h##name = dbe_ ? dbe_->book1D(#name,title,nbinsx,lowx,highx)->getTH1F() \
-    : new TH1F(#name,title,nbinsx,lowx,highx)
+#define BOOK1D(name, title, nbinsx, lowx, highx) \
+  h##name =                                      \
+      dbe_ ? dbe_->book1D(#name, title, nbinsx, lowx, highx)->getTH1F() : new TH1F(#name, title, nbinsx, lowx, highx)
 
 // preprocessor macro for booking 2d histos with DQMStore -or- bare Root
-#define BOOK2D(name,title,nbinsx,lowx,highx,nbinsy,lowy,highy) \
-  h##name = dbe_ ? dbe_->book2D(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)->getTH2F() \
-    : new TH2F(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)
+#define BOOK2D(name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)                              \
+  h##name = dbe_ ? dbe_->book2D(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)->getTH2F() \
+                 : new TH2F(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)
 
 //macros for building barrel and endcap histos with one call
-#define DBOOK1D(name,title,nbinsx,lowx,highx) \
-  BOOK1D(B##name,"Barrel "#title,nbinsx,lowx,highx); BOOK1D(E##name,"Endcap "#title,nbinsx,lowx,highx); BOOK1D(F##name,"Forward "#title,nbinsx,lowx,highx);
-#define DBOOK2D(name,title,nbinsx,lowx,highx,nbinsy,lowy,highy) \
-  BOOK2D(B##name,"Barrel "#title,nbinsx,lowx,highx,nbinsy,lowy,highy); BOOK2D(E##name,"Endcap "#title,nbinsx,lowx,highx,nbinsy,lowy,highy); BOOK2D(F##name,"Forward "#title,nbinsx,lowx,highx,nbinsy,lowy,highy);
+#define DBOOK1D(name, title, nbinsx, lowx, highx)         \
+  BOOK1D(B##name, "Barrel " #title, nbinsx, lowx, highx); \
+  BOOK1D(E##name, "Endcap " #title, nbinsx, lowx, highx); \
+  BOOK1D(F##name, "Forward " #title, nbinsx, lowx, highx);
+#define DBOOK2D(name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)         \
+  BOOK2D(B##name, "Barrel " #title, nbinsx, lowx, highx, nbinsy, lowy, highy); \
+  BOOK2D(E##name, "Endcap " #title, nbinsx, lowx, highx, nbinsy, lowy, highy); \
+  BOOK2D(F##name, "Forward " #title, nbinsx, lowx, highx, nbinsy, lowy, highy);
 
 // all versions OK
 // preprocesor macro for setting axis titles
-#define SETAXES(name,xtitle,ytitle) \
-  h##name->GetXaxis()->SetTitle(xtitle); h##name->GetYaxis()->SetTitle(ytitle)
+#define SETAXES(name, xtitle, ytitle)    \
+  h##name->GetXaxis()->SetTitle(xtitle); \
+  h##name->GetYaxis()->SetTitle(ytitle)
 
 //macro for setting the titles for barrel and endcap together
-#define DSETAXES(name,xtitle,ytitle) \
-  SETAXES(B##name,xtitle,ytitle);SETAXES(E##name,xtitle,ytitle);SETAXES(F##name,xtitle,ytitle);
+#define DSETAXES(name, xtitle, ytitle) \
+  SETAXES(B##name, xtitle, ytitle);    \
+  SETAXES(E##name, xtitle, ytitle);    \
+  SETAXES(F##name, xtitle, ytitle);
 /*#define SET2AXES(name,xtitle,ytitle) \
   hE##name->GetXaxis()->SetTitle(xtitle); hE##name->GetYaxis()->SetTitle(ytitle);  hB##name->GetXaxis()->SetTitle(xtitle); hB##name->GetYaxis()->SetTitle(ytitle)
 */
 
-#define PT (plotAgainstReco_)?"reconstructed P_{T}" :"generated P_{T}"
-#define P (plotAgainstReco_)?"generated P" :"generated P"
+#define PT (plotAgainstReco_) ? "reconstructed P_{T}" : "generated P_{T}"
+#define P (plotAgainstReco_) ? "generated P" : "generated P"
 
 using namespace reco;
 using namespace std;
@@ -42,146 +49,144 @@ using namespace std;
 PFJetBenchmark::PFJetBenchmark() : file_(nullptr), entry_(0) {}
 
 PFJetBenchmark::~PFJetBenchmark() {
-  if(file_) file_->Close();
+  if (file_)
+    file_->Close();
 }
 
 void PFJetBenchmark::write() {
-   // Store the DAQ Histograms 
+  // Store the DAQ Histograms
   if (!outputFile_.empty()) {
     if (dbe_)
-          dbe_->save(outputFile_);
+      dbe_->save(outputFile_);
     // use bare Root if no DQM (FWLite applications)
     else if (file_) {
-       file_->Write(outputFile_.c_str());
-       cout << "Benchmark output written to file " << outputFile_.c_str() << endl;
-       file_->Close();
-       }
-  }
-  else 
-    cout << "No output file specified ("<<outputFile_<<"). Results will not be saved!" << endl;
-    
-} 
+      file_->Write(outputFile_.c_str());
+      cout << "Benchmark output written to file " << outputFile_.c_str() << endl;
+      file_->Close();
+    }
+  } else
+    cout << "No output file specified (" << outputFile_ << "). Results will not be saved!" << endl;
+}
 
-void PFJetBenchmark::setup(
-			   string Filename,
-			   bool debug, 
-			   bool plotAgainstReco,
-			   bool onlyTwoJets,
-			   double deltaRMax, 
-			   string benchmarkLabel_, 
-			   double recPt, 
-			   double maxEta, 
-			   DQMStore * dbe_store) {
-  debug_ = debug; 
+void PFJetBenchmark::setup(string Filename,
+                           bool debug,
+                           bool plotAgainstReco,
+                           bool onlyTwoJets,
+                           double deltaRMax,
+                           string benchmarkLabel_,
+                           double recPt,
+                           double maxEta,
+                           DQMStore* dbe_store) {
+  debug_ = debug;
   plotAgainstReco_ = plotAgainstReco;
   onlyTwoJets_ = onlyTwoJets;
   deltaRMax_ = deltaRMax;
-  outputFile_=Filename;
+  outputFile_ = Filename;
   recPt_cut = recPt;
-  maxEta_cut= maxEta;
+  maxEta_cut = maxEta;
   file_ = nullptr;
   dbe_ = dbe_store;
   // print parameters
-  cout<< "PFJetBenchmark Setup parameters =============================================="<<endl;
-  cout << "Filename to write histograms " << Filename<<endl;
-  cout << "PFJetBenchmark debug " << debug_<< endl;
+  cout << "PFJetBenchmark Setup parameters ==============================================" << endl;
+  cout << "Filename to write histograms " << Filename << endl;
+  cout << "PFJetBenchmark debug " << debug_ << endl;
   cout << "plotAgainstReco " << plotAgainstReco_ << endl;
   cout << "onlyTwoJets " << onlyTwoJets_ << endl;
   cout << "deltaRMax " << deltaRMax << endl;
   cout << "benchmarkLabel " << benchmarkLabel_ << endl;
   cout << "recPt_cut " << recPt_cut << endl;
   cout << "maxEta_cut " << maxEta_cut << endl;
-  
+
   // Book histogram
 
   // Establish DQM Store
-  string path = "PFTask/Benchmarks/"+ benchmarkLabel_ + "/";
-  if (plotAgainstReco) path += "Reco"; else path += "Gen";
+  string path = "PFTask/Benchmarks/" + benchmarkLabel_ + "/";
+  if (plotAgainstReco)
+    path += "Reco";
+  else
+    path += "Gen";
   if (dbe_) {
     dbe_->setCurrentFolder(path);
-  }
-  else {
+  } else {
     file_ = new TFile(outputFile_.c_str(), "recreate");
-//    TTree * tr = new TTree("PFTast");
-//    tr->Branch("Benchmarks/ParticleFlow")
-    cout << "Info: DQM is not available to provide data storage service. Using TFile to save histograms. "<<endl;
+    //    TTree * tr = new TTree("PFTast");
+    //    tr->Branch("Benchmarks/ParticleFlow")
+    cout << "Info: DQM is not available to provide data storage service. Using TFile to save histograms. " << endl;
   }
   // Jets inclusive  distributions  (Pt > 20 or specified recPt GeV)
   char cutString[35];
-  sprintf(cutString,"Jet multiplicity P_{T}>%4.1f GeV", recPt_cut);
-  BOOK1D(Njets,cutString,50, 0, 50);
+  sprintf(cutString, "Jet multiplicity P_{T}>%4.1f GeV", recPt_cut);
+  BOOK1D(Njets, cutString, 50, 0, 50);
 
-  BOOK1D(jetsPt,"Jets P_{T} Distribution",100, 0, 500);
+  BOOK1D(jetsPt, "Jets P_{T} Distribution", 100, 0, 500);
 
-  sprintf(cutString,"Jets #eta Distribution |#eta|<%4.1f", maxEta_cut);
-  BOOK1D(jetsEta,cutString,100, -5, 5);
-	
-  BOOK2D(RPtvsEta,"#DeltaP_{T}/P_{T} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(RNeutvsEta,"R_{Neutral} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(RNEUTvsEta,"R_{HCAL+ECAL} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(RNONLvsEta,"R_{HCAL+ECAL - Hcal Only} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(RHCALvsEta,"R_{HCAL} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(RHONLvsEta,"R_{HCAL only} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(RCHEvsEta,"R_{Charged} vs #eta",200, -5., 5., 200,-1,1); 
-  BOOK2D(NCHvsEta,"N_{Charged} vs #eta",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH0vsEta,"N_{Charged} vs #eta, iter 0",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH1vsEta,"N_{Charged} vs #eta, iter 1",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH2vsEta,"N_{Charged} vs #eta, iter 2",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH3vsEta,"N_{Charged} vs #eta, iter 3",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH4vsEta,"N_{Charged} vs #eta, iter 4",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH5vsEta,"N_{Charged} vs #eta, iter 5",200, -5., 5., 200,0.,200.);
-  BOOK2D(NCH6vsEta,"N_{Charged} vs #eta, iter 6",200, -5., 5., 200,0.,200.);
+  sprintf(cutString, "Jets #eta Distribution |#eta|<%4.1f", maxEta_cut);
+  BOOK1D(jetsEta, cutString, 100, -5, 5);
+
+  BOOK2D(RPtvsEta, "#DeltaP_{T}/P_{T} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(RNeutvsEta, "R_{Neutral} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(RNEUTvsEta, "R_{HCAL+ECAL} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(RNONLvsEta, "R_{HCAL+ECAL - Hcal Only} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(RHCALvsEta, "R_{HCAL} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(RHONLvsEta, "R_{HCAL only} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(RCHEvsEta, "R_{Charged} vs #eta", 200, -5., 5., 200, -1, 1);
+  BOOK2D(NCHvsEta, "N_{Charged} vs #eta", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH0vsEta, "N_{Charged} vs #eta, iter 0", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH1vsEta, "N_{Charged} vs #eta, iter 1", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH2vsEta, "N_{Charged} vs #eta, iter 2", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH3vsEta, "N_{Charged} vs #eta, iter 3", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH4vsEta, "N_{Charged} vs #eta, iter 4", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH5vsEta, "N_{Charged} vs #eta, iter 5", 200, -5., 5., 200, 0., 200.);
+  BOOK2D(NCH6vsEta, "N_{Charged} vs #eta, iter 6", 200, -5., 5., 200, 0., 200.);
   // delta Pt or E quantities for Barrel
-  DBOOK1D(RPt,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RCHE,#DeltaE/E (charged had),80,-2,2);
-  DBOOK1D(RNHE,#DeltaE/E (neutral had),80,-2,2);
-  DBOOK1D(RNEE,#DeltaE/E (neutral em),80,-2,2);
-  DBOOK1D(Rneut,#DeltaE/E (neutral),80,-2,2);
-  DBOOK1D(NCH, #N_{charged},200,0.,200.);
-  DBOOK2D(RPtvsPt,#DeltaP_{T}/P_{T} vs P_{T},250, 0, 500, 200,-1,1);       //used to be 50 bin for each in x-direction
-  DBOOK2D(RCHEvsPt,#DeltaE/E (charged had) vs P_{T},250, 0, 500, 120,-1,2);
-  DBOOK2D(RNHEvsPt,#DeltaE/E (neutral had) vs P_{T},250, 0, 500, 120,-1,2);
-  DBOOK2D(RNEEvsPt,#DeltaE/E (neutral em) vs P_{T},250, 0, 500, 120,-1,2);
-  DBOOK2D(RneutvsPt,#DeltaE/E (neutral) vs P_{T},250, 0, 500, 120,-1,2);
-  DBOOK2D(NCHvsPt,N_{charged} vs P_{T},250,0,500,200,0.,200.);
-  DBOOK2D(NCH0vsPt, N_{charged} vs P_{T} iter 0,250,0,500,200,0.,200.);
-  DBOOK2D(NCH1vsPt, N_{charged} vs P_{T} iter 1,250,0,500,200,0.,200.);
-  DBOOK2D(NCH2vsPt, N_{charged} vs P_{T} iter 2,250,0,500,200,0.,200.);
-  DBOOK2D(NCH3vsPt, N_{charged} vs P_{T} iter 3,250,0,500,200,0.,200.);
-  DBOOK2D(NCH4vsPt, N_{charged} vs P_{T} iter 4,250,0,500,200,0.,200.);
-  DBOOK2D(NCH5vsPt, N_{charged} vs P_{T} iter 5,250,0,500,200,0.,200.);
-  DBOOK2D(NCH6vsPt, N_{charged} vs P_{T} iter 6,250,0,500,200,0.,200.);
+  DBOOK1D(RPt, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RCHE, #DeltaE / E(charged had), 80, -2, 2);
+  DBOOK1D(RNHE, #DeltaE / E(neutral had), 80, -2, 2);
+  DBOOK1D(RNEE, #DeltaE / E(neutral em), 80, -2, 2);
+  DBOOK1D(Rneut, #DeltaE / E(neutral), 80, -2, 2);
+  DBOOK1D(NCH, #N_{charged}, 200, 0., 200.);
+  DBOOK2D(RPtvsPt, #DeltaP_{T} / P_{T} vs P_{T}, 250, 0, 500, 200, -1, 1);  //used to be 50 bin for each in x-direction
+  DBOOK2D(RCHEvsPt, #DeltaE / E(charged had) vs P_{T}, 250, 0, 500, 120, -1, 2);
+  DBOOK2D(RNHEvsPt, #DeltaE / E(neutral had) vs P_{T}, 250, 0, 500, 120, -1, 2);
+  DBOOK2D(RNEEvsPt, #DeltaE / E(neutral em) vs P_{T}, 250, 0, 500, 120, -1, 2);
+  DBOOK2D(RneutvsPt, #DeltaE / E(neutral) vs P_{T}, 250, 0, 500, 120, -1, 2);
+  DBOOK2D(NCHvsPt, N_{charged} vs P_{T}, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH0vsPt, N_{charged} vs P_{T} iter 0, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH1vsPt, N_{charged} vs P_{T} iter 1, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH2vsPt, N_{charged} vs P_{T} iter 2, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH3vsPt, N_{charged} vs P_{T} iter 3, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH4vsPt, N_{charged} vs P_{T} iter 4, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH5vsPt, N_{charged} vs P_{T} iter 5, 250, 0, 500, 200, 0., 200.);
+  DBOOK2D(NCH6vsPt, N_{charged} vs P_{T} iter 6, 250, 0, 500, 200, 0., 200.);
 
-  
+  DBOOK2D(RNEUTvsP, #DeltaE / E(ECAL + HCAL) vs P, 250, 0, 1000, 150, -1.5, 1.5);
+  DBOOK2D(RNONLvsP, #DeltaE / E(ECAL + HCAL - only) vs P, 250, 0, 1000, 150, -1.5, 1.5);
+  DBOOK2D(RHCALvsP, #DeltaE / E(HCAL) vs P, 250, 0, 1000, 150, -1.5, 1.5);
+  DBOOK2D(RHONLvsP, #DeltaE / E(HCAL only) vs P, 250, 0, 1000, 150, -1.5, 1.5);
+  DBOOK1D(RPt20_40, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt40_60, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt60_80, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt80_100, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt100_150, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt150_200, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt200_250, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt250_300, #DeltaP_{T} / P_{T}, 80, -1, 1);
+  DBOOK1D(RPt300_400, #DeltaP_{T} / P_{T}, 160, -1, 1);
+  DBOOK1D(RPt400_500, #DeltaP_{T} / P_{T}, 160, -1, 1);
+  DBOOK1D(RPt500_750, #DeltaP_{T} / P_{T}, 160, -1, 1);
+  DBOOK1D(RPt750_1250, #DeltaP_{T} / P_{T}, 160, -1, 1);
+  DBOOK1D(RPt1250_2000, #DeltaP_{T} / P_{T}, 160, -1, 1);
+  DBOOK1D(RPt2000_5000, #DeltaP_{T} / P_{T}, 160, -1, 1);
 
-  DBOOK2D(RNEUTvsP,#DeltaE/E (ECAL+HCAL) vs P,250, 0, 1000, 150,-1.5,1.5);
-  DBOOK2D(RNONLvsP,#DeltaE/E (ECAL+HCAL-only) vs P,250, 0, 1000, 150,-1.5,1.5);
-  DBOOK2D(RHCALvsP,#DeltaE/E (HCAL) vs P,250, 0, 1000, 150,-1.5,1.5);
-  DBOOK2D(RHONLvsP,#DeltaE/E (HCAL only) vs P,250, 0, 1000, 150,-1.5,1.5);
-  DBOOK1D(RPt20_40,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt40_60,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt60_80,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt80_100,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt100_150,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt150_200,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt200_250,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt250_300,#DeltaP_{T}/P_{T},80,-1,1);
-  DBOOK1D(RPt300_400,#DeltaP_{T}/P_{T},160,-1,1);
-  DBOOK1D(RPt400_500,#DeltaP_{T}/P_{T},160,-1,1);
-  DBOOK1D(RPt500_750,#DeltaP_{T}/P_{T},160,-1,1);
-  DBOOK1D(RPt750_1250,#DeltaP_{T}/P_{T},160,-1,1);
-  DBOOK1D(RPt1250_2000,#DeltaP_{T}/P_{T},160,-1,1);
-  DBOOK1D(RPt2000_5000,#DeltaP_{T}/P_{T},160,-1,1);
+  DBOOK2D(DEtavsPt, #Delta #eta vs P_{T}, 1000, 0, 2000, 500, -0.5, 0.5);
+  DBOOK2D(DPhivsPt, #Delta #phi vs P_{T}, 1000, 0, 2000, 500, -0.5, 0.5);
+  BOOK2D(DEtavsEta, "#Delta#eta vs P_{T}", 1000, -5., +5., 500, -0.5, 0.5);
+  BOOK2D(DPhivsEta, "#Delta#phi vs P_{T}", 1000, -5., +5., 500, -0.5, 0.5);
 
-  DBOOK2D(DEtavsPt,#Delta#eta vs P_{T},1000,0,2000,500,-0.5,0.5);
-  DBOOK2D(DPhivsPt,#Delta#phi vs P_{T},1000,0,2000,500,-0.5,0.5);
-  BOOK2D(DEtavsEta,"#Delta#eta vs P_{T}",1000,-5.,+5.,500,-0.5,0.5);
-  BOOK2D(DPhivsEta,"#Delta#phi vs P_{T}",1000,-5.,+5.,500,-0.5,0.5);
-	
- // Set Axis Titles
- 
- // Jets inclusive  distributions  (Pt > 20 GeV)
-  SETAXES(Njets,"","Multiplicity");
+  // Set Axis Titles
+
+  // Jets inclusive  distributions  (Pt > 20 GeV)
+  SETAXES(Njets, "", "Multiplicity");
   SETAXES(jetsPt, PT, "Number of Events");
   SETAXES(jetsEta, "#eta", "Number of Events");
   SETAXES(RNeutvsEta, "#eta", "#DeltaE/E (Neutral)");
@@ -192,7 +197,7 @@ void PFJetBenchmark::setup(
   SETAXES(RCHEvsEta, "#eta", "#DeltaE/E (Charged)");
   SETAXES(RPtvsEta, "#eta", "#DeltaP_{T}/P_{T}");
   SETAXES(DEtavsEta, "#eta", "#Delta#eta");
-  SETAXES(DPhivsEta,"#eta", "#Delta#phi");
+  SETAXES(DPhivsEta, "#eta", "#Delta#phi");
   // delta Pt or E quantities for Barrel and Endcap
   DSETAXES(RPt, "#DeltaP_{T}/P_{T}", "Events");
   DSETAXES(RPt20_40, "#DeltaP_{T}/P_{T}", "Events");
@@ -224,40 +229,40 @@ void PFJetBenchmark::setup(
   DSETAXES(RNONLvsP, P, "#DeltaE/E(ECAL+HCAL-only)");
   DSETAXES(DEtavsPt, PT, "#Delta#eta");
   DSETAXES(DPhivsPt, PT, "#Delta#phi");
-
 }
-
 
 void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::GenJetCollection& genJets) {
   // loop over reco  pf  jets
   resPtMax_ = 0.;
   resChargedHadEnergyMax_ = 0.;
   resNeutralHadEnergyMax_ = 0.;
-  resNeutralEmEnergyMax_ = 0.; 
+  resNeutralEmEnergyMax_ = 0.;
   int NPFJets = 0;
-	
-  for(unsigned i=0; i<pfJets.size(); i++) {   
 
+  for (unsigned i = 0; i < pfJets.size(); i++) {
     // Count the number of jets with a larger energy
     unsigned highJets = 0;
-    for(unsigned j=0; j<pfJets.size(); j++) { 
-      if ( j != i && pfJets[j].pt() > pfJets[i].pt() ) highJets++;
+    for (unsigned j = 0; j < pfJets.size(); j++) {
+      if (j != i && pfJets[j].pt() > pfJets[i].pt())
+        highJets++;
     }
-    if ( onlyTwoJets_ && highJets > 1 ) continue;
-		
-		
+    if (onlyTwoJets_ && highJets > 1)
+      continue;
+
     const reco::PFJet& pfj = pfJets[i];
     double rec_pt = pfj.pt();
     double rec_eta = pfj.eta();
     double rec_phi = pfj.phi();
 
     // skip PFjets with pt < recPt_cut GeV
-    if (rec_pt<recPt_cut and recPt_cut != -1.) continue;
+    if (rec_pt < recPt_cut and recPt_cut != -1.)
+      continue;
     // skip PFjets with eta > maxEta_cut
-    if (fabs(rec_eta)>maxEta_cut and maxEta_cut != -1.) continue;
+    if (fabs(rec_eta) > maxEta_cut and maxEta_cut != -1.)
+      continue;
 
     NPFJets++;
-		
+
     // fill inclusive PFjet distribution pt > 20 GeV
     hNjets->Fill(NPFJets);
     hjetsPt->Fill(rec_pt);
@@ -267,22 +272,28 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
     bool Barrel = false;
     bool Endcap = false;
     bool Forward = false;
-    if (std::abs(rec_eta) < 1.4 ) Barrel = true;
-    if (std::abs (rec_eta) > 1.6 && std::abs (rec_eta) < 2.4 ) Endcap = true;
-    if (std::abs (rec_eta) > 2.5 && std::abs (rec_eta) < 2.9 ) Forward = true;
-    if (std::abs (rec_eta) > 3.1 && std::abs (rec_eta) < 4.7 ) Forward = true;
+    if (std::abs(rec_eta) < 1.4)
+      Barrel = true;
+    if (std::abs(rec_eta) > 1.6 && std::abs(rec_eta) < 2.4)
+      Endcap = true;
+    if (std::abs(rec_eta) > 2.5 && std::abs(rec_eta) < 2.9)
+      Forward = true;
+    if (std::abs(rec_eta) > 3.1 && std::abs(rec_eta) < 4.7)
+      Forward = true;
 
     // do only barrel for now
     //  if(!Barrel) continue;
 
     // look for the closets gen Jet : truth
-    const GenJet *truth = algo_->matchByDeltaR(&pfj,&genJets);
-    if(!truth) continue;   
+    const GenJet* truth = algo_->matchByDeltaR(&pfj, &genJets);
+    if (!truth)
+      continue;
     double deltaR = algo_->deltaR(&pfj, truth);
     // check deltaR is small enough
-    if(deltaR < deltaRMax_ || (abs(rec_eta)>2.5 && deltaR < 0.2) || deltaRMax_ == -1.0 ) {//start case deltaR < deltaRMax
+    if (deltaR < deltaRMax_ || (abs(rec_eta) > 2.5 && deltaR < 0.2) ||
+        deltaRMax_ == -1.0) {  //start case deltaR < deltaRMax
 
-      // generate histograms comparing the reco and truth candidate (truth = closest in delta-R) 
+      // generate histograms comparing the reco and truth candidate (truth = closest in delta-R)
       // get the quantities to place on the denominator and/or divide by
       double pt_denom;
       double true_E = truth->p();
@@ -290,32 +301,36 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
       double true_eta = truth->eta();
       double true_phi = truth->phi();
 
-      if (plotAgainstReco_) {pt_denom = rec_pt;}
-      else {pt_denom = true_pt;}
+      if (plotAgainstReco_) {
+        pt_denom = rec_pt;
+      } else {
+        pt_denom = true_pt;
+      }
       // get true specific quantities
       double true_ChargedHadEnergy;
       double true_NeutralHadEnergy;
       double true_NeutralEmEnergy;
-      gettrue (truth, true_ChargedHadEnergy, true_NeutralHadEnergy, true_NeutralEmEnergy);
+      gettrue(truth, true_ChargedHadEnergy, true_NeutralHadEnergy, true_NeutralEmEnergy);
       double true_NeutralEnergy = true_NeutralHadEnergy + true_NeutralEmEnergy;
       double rec_ChargedHadEnergy = pfj.chargedHadronEnergy();
       double rec_NeutralHadEnergy = pfj.neutralHadronEnergy();
       double rec_NeutralEmEnergy = pfj.neutralEmEnergy();
       double rec_NeutralEnergy = rec_NeutralHadEnergy + rec_NeutralEmEnergy;
       double rec_ChargedMultiplicity = pfj.chargedMultiplicity();
-      std::vector <PFCandidatePtr> constituents = pfj.getPFConstituents ();
-      std::vector <unsigned int> chMult(9, static_cast<unsigned int>(0)); 
-      for (unsigned ic = 0; ic < constituents.size (); ++ic) {
-	if ( constituents[ic]->particleId() > 3 ) continue;
-	reco::TrackRef trackRef = constituents[ic]->trackRef();
-	if ( trackRef.isNull() ) {
-	  //std::cout << "Warning in entry " << entry_ 
-	  //	    << " : a track with Id " << constituents[ic]->particleId() 
-	  //	    << " has no track ref.." << std::endl;
-	  continue;
-	}
-	unsigned int iter = trackRef->algo()>6 ? 6: trackRef->algo();
-	++(chMult[iter]);
+      std::vector<PFCandidatePtr> constituents = pfj.getPFConstituents();
+      std::vector<unsigned int> chMult(9, static_cast<unsigned int>(0));
+      for (unsigned ic = 0; ic < constituents.size(); ++ic) {
+        if (constituents[ic]->particleId() > 3)
+          continue;
+        reco::TrackRef trackRef = constituents[ic]->trackRef();
+        if (trackRef.isNull()) {
+          //std::cout << "Warning in entry " << entry_
+          //	    << " : a track with Id " << constituents[ic]->particleId()
+          //	    << " has no track ref.." << std::endl;
+          continue;
+        }
+        unsigned int iter = trackRef->algo() > 6 ? 6 : trackRef->algo();
+        ++(chMult[iter]);
       }
 
       bool plot1 = false;
@@ -332,380 +347,442 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
       double cut5 = 0.0001;
       double cut6 = 0.0001;
       double cut7 = 0.0001;
-      double resPt =0.;
-      double resChargedHadEnergy= 0.;
-      double resNeutralHadEnergy= 0.;
-      double resNeutralEmEnergy= 0.;
-      double resNeutralEnergy= 0.;
+      double resPt = 0.;
+      double resChargedHadEnergy = 0.;
+      double resNeutralHadEnergy = 0.;
+      double resNeutralEmEnergy = 0.;
+      double resNeutralEnergy = 0.;
 
       double resHCALEnergy = 0.;
       double resNEUTEnergy = 0.;
-      if ( rec_NeutralHadEnergy > cut6 && rec_ChargedHadEnergy < cut1 ) { 
-	double true_NEUTEnergy = true_NeutralHadEnergy + true_NeutralEmEnergy;
-	double true_HCALEnergy = true_NEUTEnergy - rec_NeutralEmEnergy;
-	double rec_NEUTEnergy = rec_NeutralHadEnergy+rec_NeutralEmEnergy; 
-	double rec_HCALEnergy = rec_NeutralHadEnergy; 
-	resHCALEnergy = (rec_HCALEnergy-true_HCALEnergy)/rec_HCALEnergy;
-	resNEUTEnergy = (rec_NEUTEnergy-true_NEUTEnergy)/rec_NEUTEnergy;
-	if ( rec_NeutralEmEnergy > cut7 ) {
-	  plot6 = true;
-	} else {
-	  plot7 = true;
-	}
+      if (rec_NeutralHadEnergy > cut6 && rec_ChargedHadEnergy < cut1) {
+        double true_NEUTEnergy = true_NeutralHadEnergy + true_NeutralEmEnergy;
+        double true_HCALEnergy = true_NEUTEnergy - rec_NeutralEmEnergy;
+        double rec_NEUTEnergy = rec_NeutralHadEnergy + rec_NeutralEmEnergy;
+        double rec_HCALEnergy = rec_NeutralHadEnergy;
+        resHCALEnergy = (rec_HCALEnergy - true_HCALEnergy) / rec_HCALEnergy;
+        resNEUTEnergy = (rec_NEUTEnergy - true_NEUTEnergy) / rec_NEUTEnergy;
+        if (rec_NeutralEmEnergy > cut7) {
+          plot6 = true;
+        } else {
+          plot7 = true;
+        }
       }
 
       // get relative delta quantities (protect against division by zero!)
-      if (true_pt > 0.0001){
-	resPt = (rec_pt -true_pt)/true_pt ; 
-	plot1 = true;}
-      if (true_ChargedHadEnergy > cut1){
-	resChargedHadEnergy = (rec_ChargedHadEnergy- true_ChargedHadEnergy)/true_ChargedHadEnergy;
-	plot2 = true;}
-      if (true_NeutralHadEnergy > cut2){
-	resNeutralHadEnergy = (rec_NeutralHadEnergy- true_NeutralHadEnergy)/true_NeutralHadEnergy;
-	plot3 = true;}
-      else 
-	if (rec_NeutralHadEnergy > cut3){
-	  resNeutralHadEnergy = (rec_NeutralHadEnergy- true_NeutralHadEnergy)/rec_NeutralHadEnergy;
-	  plot3 = true;}
-      if (true_NeutralEmEnergy > cut4){
-	resNeutralEmEnergy = (rec_NeutralEmEnergy- true_NeutralEmEnergy)/true_NeutralEmEnergy;
-	plot4 = true;}
-      if (true_NeutralEnergy > cut5){
-	resNeutralEnergy = (rec_NeutralEnergy- true_NeutralEnergy)/true_NeutralEnergy;
-	plot5 = true;}
-      
+      if (true_pt > 0.0001) {
+        resPt = (rec_pt - true_pt) / true_pt;
+        plot1 = true;
+      }
+      if (true_ChargedHadEnergy > cut1) {
+        resChargedHadEnergy = (rec_ChargedHadEnergy - true_ChargedHadEnergy) / true_ChargedHadEnergy;
+        plot2 = true;
+      }
+      if (true_NeutralHadEnergy > cut2) {
+        resNeutralHadEnergy = (rec_NeutralHadEnergy - true_NeutralHadEnergy) / true_NeutralHadEnergy;
+        plot3 = true;
+      } else if (rec_NeutralHadEnergy > cut3) {
+        resNeutralHadEnergy = (rec_NeutralHadEnergy - true_NeutralHadEnergy) / rec_NeutralHadEnergy;
+        plot3 = true;
+      }
+      if (true_NeutralEmEnergy > cut4) {
+        resNeutralEmEnergy = (rec_NeutralEmEnergy - true_NeutralEmEnergy) / true_NeutralEmEnergy;
+        plot4 = true;
+      }
+      if (true_NeutralEnergy > cut5) {
+        resNeutralEnergy = (rec_NeutralEnergy - true_NeutralEnergy) / true_NeutralEnergy;
+        plot5 = true;
+      }
+
       //double deltaEta = algo_->deltaEta(&pfj, truth);
       //double deltaPhi = algo_->deltaPhi(&pfj, truth);
 
       // Print outliers for further debugging
-      if ( ( resPt > 0.2 && true_pt > 100. ) || 
-	   ( resPt < -0.5 && true_pt > 100. ) ) {
-	//if ( ( true_pt > 50. && 
-	//     ( ( truth->eta()>3.0 && rec_eta-truth->eta() < -0.1 ) || 
-	//       ( truth->eta()<-3.0 && rec_eta-truth->eta() > 0.1 ) ))) {
-	std::cout << "Entry " << entry_ 
-		  << " resPt = " << resPt
-		  <<" resCharged  " << resChargedHadEnergy
-		  <<" resNeutralHad  " << resNeutralHadEnergy
-		  << " resNeutralEm  " << resNeutralEmEnergy
-		  << " pT (T/R) " << true_pt << "/" << rec_pt 
-		  << " Eta (T/R) " << truth->eta() << "/" << rec_eta 
-		  << " Phi (T/R) " << truth->phi() << "/" << rec_phi 
-		  << std::endl;
+      if ((resPt > 0.2 && true_pt > 100.) || (resPt < -0.5 && true_pt > 100.)) {
+        //if ( ( true_pt > 50. &&
+        //     ( ( truth->eta()>3.0 && rec_eta-truth->eta() < -0.1 ) ||
+        //       ( truth->eta()<-3.0 && rec_eta-truth->eta() > 0.1 ) ))) {
+        std::cout << "Entry " << entry_ << " resPt = " << resPt << " resCharged  " << resChargedHadEnergy
+                  << " resNeutralHad  " << resNeutralHadEnergy << " resNeutralEm  " << resNeutralEmEnergy
+                  << " pT (T/R) " << true_pt << "/" << rec_pt << " Eta (T/R) " << truth->eta() << "/" << rec_eta
+                  << " Phi (T/R) " << truth->phi() << "/" << rec_phi << std::endl;
 
-	// check overlapping PF jets
-	const reco::PFJet* pfoj = nullptr; 
-	double dRo = 1E9;
-	for(unsigned j=0; j<pfJets.size(); j++) { 
-	  const reco::PFJet& pfo = pfJets[j];
-	  if ( j != i &&  algo_->deltaR(&pfj,&pfo) < dRo && pfo.pt() > 0.25*pfj.pt()) { 
-	    dRo = algo_->deltaR(&pfj,&pfo);	
-	    pfoj = &pfo;
-	  }
-	}
-	
-	// Check overlapping Gen Jet 
-	math::XYZTLorentzVector overlappinGenJet(0.,0.,0.,0.);
-	const reco::GenJet* genoj = nullptr;
-	double dRgo = 1E9;
-	for(unsigned j=0; j<genJets.size(); j++) { 
-	  const reco::GenJet* gjo = &(genJets[j]);
-	  if ( gjo != truth && algo_->deltaR(truth,gjo) < dRgo && gjo->pt() > 0.25*truth->pt() ) { 
-	    dRgo = algo_->deltaR(truth,gjo);
-	    genoj = gjo;
-	  }
-	}
-	
-	if ( dRo < 0.8 && dRgo < 0.8 && algo_->deltaR(genoj,pfoj) < 2.*deltaRMax_ ) 
-	  std::cout << "Excess probably due to overlapping jets (DR = " <<   algo_->deltaR(genoj,pfoj) << "),"
-		    << " at DeltaR(T/R) = " << dRgo << "/" << dRo  
-		    << " with pT(T/R) " << genoj->pt() << "/" << pfoj->pt()
-		    << " and Eta (T/R) " << genoj->eta() << "/" << pfoj->eta()
-		    << " and Phi (T/R) " << genoj->phi() << "/" << pfoj->phi()
-		    << std::endl;
+        // check overlapping PF jets
+        const reco::PFJet* pfoj = nullptr;
+        double dRo = 1E9;
+        for (unsigned j = 0; j < pfJets.size(); j++) {
+          const reco::PFJet& pfo = pfJets[j];
+          if (j != i && algo_->deltaR(&pfj, &pfo) < dRo && pfo.pt() > 0.25 * pfj.pt()) {
+            dRo = algo_->deltaR(&pfj, &pfo);
+            pfoj = &pfo;
+          }
+        }
+
+        // Check overlapping Gen Jet
+        math::XYZTLorentzVector overlappinGenJet(0., 0., 0., 0.);
+        const reco::GenJet* genoj = nullptr;
+        double dRgo = 1E9;
+        for (unsigned j = 0; j < genJets.size(); j++) {
+          const reco::GenJet* gjo = &(genJets[j]);
+          if (gjo != truth && algo_->deltaR(truth, gjo) < dRgo && gjo->pt() > 0.25 * truth->pt()) {
+            dRgo = algo_->deltaR(truth, gjo);
+            genoj = gjo;
+          }
+        }
+
+        if (dRo < 0.8 && dRgo < 0.8 && algo_->deltaR(genoj, pfoj) < 2. * deltaRMax_)
+          std::cout << "Excess probably due to overlapping jets (DR = " << algo_->deltaR(genoj, pfoj) << "),"
+                    << " at DeltaR(T/R) = " << dRgo << "/" << dRo << " with pT(T/R) " << genoj->pt() << "/"
+                    << pfoj->pt() << " and Eta (T/R) " << genoj->eta() << "/" << pfoj->eta() << " and Phi (T/R) "
+                    << genoj->phi() << "/" << pfoj->phi() << std::endl;
       }
 
-      if(std::abs(resPt) > std::abs(resPtMax_)) resPtMax_ = resPt;
-      if(std::abs(resChargedHadEnergy) > std::abs(resChargedHadEnergyMax_) ) resChargedHadEnergyMax_ = resChargedHadEnergy;
-      if(std::abs(resNeutralHadEnergy) > std::abs(resNeutralHadEnergyMax_) ) resNeutralHadEnergyMax_ = resNeutralHadEnergy;
-      if(std::abs(resNeutralEmEnergy) > std::abs(resNeutralEmEnergyMax_) ) resNeutralEmEnergyMax_ = resNeutralEmEnergy;
+      if (std::abs(resPt) > std::abs(resPtMax_))
+        resPtMax_ = resPt;
+      if (std::abs(resChargedHadEnergy) > std::abs(resChargedHadEnergyMax_))
+        resChargedHadEnergyMax_ = resChargedHadEnergy;
+      if (std::abs(resNeutralHadEnergy) > std::abs(resNeutralHadEnergyMax_))
+        resNeutralHadEnergyMax_ = resNeutralHadEnergy;
+      if (std::abs(resNeutralEmEnergy) > std::abs(resNeutralEmEnergyMax_))
+        resNeutralEmEnergyMax_ = resNeutralEmEnergy;
       if (debug_) {
-	cout << i <<"  =========PFJet Pt "<< rec_pt
-	     << " eta " << rec_eta
-	     << " phi " << rec_phi
-	     << " Charged Had Energy " << rec_ChargedHadEnergy
-	     << " Neutral Had Energy " << rec_NeutralHadEnergy
-	     << " Neutral elm Energy " << rec_NeutralEmEnergy << endl;
-	cout << " matching Gen Jet Pt " << true_pt
-	     << " eta " << truth->eta()
-	     << " phi " << truth->phi()
-	     << " Charged Had Energy " << true_ChargedHadEnergy
-	     << " Neutral Had Energy " << true_NeutralHadEnergy
-	     << " Neutral elm Energy " << true_NeutralEmEnergy << endl;
-	printPFJet(&pfj);
-	//      cout<<pfj.print()<<endl;
-	printGenJet(truth);
-	//cout <<truth->print()<<endl;
-				
-	cout << "==============deltaR " << deltaR << "  resPt " << resPt
-	     << " resChargedHadEnergy " << resChargedHadEnergy
-	     << " resNeutralHadEnergy " << resNeutralHadEnergy
-	     << " resNeutralEmEnergy " << resNeutralEmEnergy
-	     << endl;
-      }
-			
+        cout << i << "  =========PFJet Pt " << rec_pt << " eta " << rec_eta << " phi " << rec_phi
+             << " Charged Had Energy " << rec_ChargedHadEnergy << " Neutral Had Energy " << rec_NeutralHadEnergy
+             << " Neutral elm Energy " << rec_NeutralEmEnergy << endl;
+        cout << " matching Gen Jet Pt " << true_pt << " eta " << truth->eta() << " phi " << truth->phi()
+             << " Charged Had Energy " << true_ChargedHadEnergy << " Neutral Had Energy " << true_NeutralHadEnergy
+             << " Neutral elm Energy " << true_NeutralEmEnergy << endl;
+        printPFJet(&pfj);
+        //      cout<<pfj.print()<<endl;
+        printGenJet(truth);
+        //cout <<truth->print()<<endl;
 
-      if(plot1) {
-	if ( rec_eta > 0. ) 
-	  hDEtavsEta->Fill(true_eta,rec_eta-true_eta);
-	else
-	  hDEtavsEta->Fill(true_eta,-rec_eta+true_eta);
-	hDPhivsEta->Fill(true_eta,rec_phi-true_phi);
+        cout << "==============deltaR " << deltaR << "  resPt " << resPt << " resChargedHadEnergy "
+             << resChargedHadEnergy << " resNeutralHadEnergy " << resNeutralHadEnergy << " resNeutralEmEnergy "
+             << resNeutralEmEnergy << endl;
+      }
 
-	hRPtvsEta->Fill(true_eta, resPt);
-	hNCHvsEta->Fill(true_eta, rec_ChargedMultiplicity);
-	hNCH0vsEta->Fill(true_eta,chMult[0]);
-	hNCH1vsEta->Fill(true_eta,chMult[1]);
-	hNCH2vsEta->Fill(true_eta,chMult[2]);
-	hNCH3vsEta->Fill(true_eta,chMult[3]);
-	hNCH4vsEta->Fill(true_eta,chMult[4]);
-	hNCH5vsEta->Fill(true_eta,chMult[5]);
-	hNCH6vsEta->Fill(true_eta,chMult[6]);
-	hNCH7vsEta->Fill(true_eta,chMult[7]);
+      if (plot1) {
+        if (rec_eta > 0.)
+          hDEtavsEta->Fill(true_eta, rec_eta - true_eta);
+        else
+          hDEtavsEta->Fill(true_eta, -rec_eta + true_eta);
+        hDPhivsEta->Fill(true_eta, rec_phi - true_phi);
+
+        hRPtvsEta->Fill(true_eta, resPt);
+        hNCHvsEta->Fill(true_eta, rec_ChargedMultiplicity);
+        hNCH0vsEta->Fill(true_eta, chMult[0]);
+        hNCH1vsEta->Fill(true_eta, chMult[1]);
+        hNCH2vsEta->Fill(true_eta, chMult[2]);
+        hNCH3vsEta->Fill(true_eta, chMult[3]);
+        hNCH4vsEta->Fill(true_eta, chMult[4]);
+        hNCH5vsEta->Fill(true_eta, chMult[5]);
+        hNCH6vsEta->Fill(true_eta, chMult[6]);
+        hNCH7vsEta->Fill(true_eta, chMult[7]);
       }
-      if(plot2)hRCHEvsEta->Fill(true_eta, resChargedHadEnergy);
-      if(plot5)hRNeutvsEta->Fill(true_eta, resNeutralEnergy);
-      if(plot6) { 
-	hRHCALvsEta->Fill(true_eta, resHCALEnergy);
-	hRNEUTvsEta->Fill(true_eta, resNEUTEnergy);
+      if (plot2)
+        hRCHEvsEta->Fill(true_eta, resChargedHadEnergy);
+      if (plot5)
+        hRNeutvsEta->Fill(true_eta, resNeutralEnergy);
+      if (plot6) {
+        hRHCALvsEta->Fill(true_eta, resHCALEnergy);
+        hRNEUTvsEta->Fill(true_eta, resNEUTEnergy);
       }
-      if(plot7) {  
-	hRHONLvsEta->Fill(true_eta, resHCALEnergy);
-	hRNONLvsEta->Fill(true_eta, resNEUTEnergy);
+      if (plot7) {
+        hRHONLvsEta->Fill(true_eta, resHCALEnergy);
+        hRNONLvsEta->Fill(true_eta, resNEUTEnergy);
       }
 
       // fill histograms for relative delta quantitites of matched jets
       // delta Pt or E quantities for Barrel
-      if (Barrel){
-	if(plot1) { 
-	  hBRPt->Fill (resPt);
-	  if ( pt_denom >  20. && pt_denom <  40. ) hBRPt20_40->Fill (resPt);
-	  if ( pt_denom >  40. && pt_denom <  60. ) hBRPt40_60->Fill (resPt);
-	  if ( pt_denom >  60. && pt_denom <  80. ) hBRPt60_80->Fill (resPt);
-	  if ( pt_denom >  80. && pt_denom < 100. ) hBRPt80_100->Fill (resPt);
-	  if ( pt_denom > 100. && pt_denom < 150. ) hBRPt100_150->Fill (resPt);
-	  if ( pt_denom > 150. && pt_denom < 200. ) hBRPt150_200->Fill (resPt);
-	  if ( pt_denom > 200. && pt_denom < 250. ) hBRPt200_250->Fill (resPt);
-	  if ( pt_denom > 250. && pt_denom < 300. ) hBRPt250_300->Fill (resPt);
-	  if ( pt_denom > 300. && pt_denom < 400. ) hBRPt300_400->Fill (resPt);
-	  if ( pt_denom > 400. && pt_denom < 500. ) hBRPt400_500->Fill (resPt);
-	  if ( pt_denom > 500. && pt_denom < 750. ) hBRPt500_750->Fill (resPt);
-	  if ( pt_denom > 750. && pt_denom < 1250. ) hBRPt750_1250->Fill (resPt);
-	  if ( pt_denom > 1250. && pt_denom < 2000. ) hBRPt1250_2000->Fill (resPt);
-	  if ( pt_denom > 2000. && pt_denom < 5000. ) hBRPt2000_5000->Fill (resPt);
-	  hBNCH->Fill(rec_ChargedMultiplicity);
-	  hBNCH0vsPt->Fill(pt_denom,chMult[0]);
-	  hBNCH1vsPt->Fill(pt_denom,chMult[1]);
-	  hBNCH2vsPt->Fill(pt_denom,chMult[2]);
-	  hBNCH3vsPt->Fill(pt_denom,chMult[3]);
-	  hBNCH4vsPt->Fill(pt_denom,chMult[4]);
-	  hBNCH5vsPt->Fill(pt_denom,chMult[5]);
-	  hBNCH6vsPt->Fill(pt_denom,chMult[6]);
-	  hBNCH7vsPt->Fill(pt_denom,chMult[7]);
-	  hBNCHvsPt->Fill(pt_denom,rec_ChargedMultiplicity);
-	  if ( rec_eta > 0. ) 
-	    hBDEtavsPt->Fill(pt_denom,rec_eta-true_eta);
-	  else
-	    hBDEtavsPt->Fill(pt_denom,-rec_eta+true_eta);
-	  hBDPhivsPt->Fill(pt_denom,rec_phi-true_phi);
-	}
-	if(plot2)hBRCHE->Fill(resChargedHadEnergy);
-	if(plot3)hBRNHE->Fill(resNeutralHadEnergy);
-	if(plot4)hBRNEE->Fill(resNeutralEmEnergy);
-	if(plot5)hBRneut->Fill(resNeutralEnergy);
-	if(plot1)hBRPtvsPt->Fill(pt_denom, resPt);
-	if(plot2)hBRCHEvsPt->Fill(pt_denom, resChargedHadEnergy);
-	if(plot3)hBRNHEvsPt->Fill(pt_denom, resNeutralHadEnergy);
-	if(plot4)hBRNEEvsPt->Fill(pt_denom, resNeutralEmEnergy);
-	if(plot5)hBRneutvsPt->Fill(pt_denom, resNeutralEnergy);
-	if(plot6) { 
-	  hBRHCALvsP->Fill(true_E, resHCALEnergy);
-	  hBRNEUTvsP->Fill(true_E, resNEUTEnergy);
-	}
-	if(plot7) { 
-	  hBRHONLvsP->Fill(true_E, resHCALEnergy);
-	  hBRNONLvsP->Fill(true_E, resNEUTEnergy);
-	}
-
+      if (Barrel) {
+        if (plot1) {
+          hBRPt->Fill(resPt);
+          if (pt_denom > 20. && pt_denom < 40.)
+            hBRPt20_40->Fill(resPt);
+          if (pt_denom > 40. && pt_denom < 60.)
+            hBRPt40_60->Fill(resPt);
+          if (pt_denom > 60. && pt_denom < 80.)
+            hBRPt60_80->Fill(resPt);
+          if (pt_denom > 80. && pt_denom < 100.)
+            hBRPt80_100->Fill(resPt);
+          if (pt_denom > 100. && pt_denom < 150.)
+            hBRPt100_150->Fill(resPt);
+          if (pt_denom > 150. && pt_denom < 200.)
+            hBRPt150_200->Fill(resPt);
+          if (pt_denom > 200. && pt_denom < 250.)
+            hBRPt200_250->Fill(resPt);
+          if (pt_denom > 250. && pt_denom < 300.)
+            hBRPt250_300->Fill(resPt);
+          if (pt_denom > 300. && pt_denom < 400.)
+            hBRPt300_400->Fill(resPt);
+          if (pt_denom > 400. && pt_denom < 500.)
+            hBRPt400_500->Fill(resPt);
+          if (pt_denom > 500. && pt_denom < 750.)
+            hBRPt500_750->Fill(resPt);
+          if (pt_denom > 750. && pt_denom < 1250.)
+            hBRPt750_1250->Fill(resPt);
+          if (pt_denom > 1250. && pt_denom < 2000.)
+            hBRPt1250_2000->Fill(resPt);
+          if (pt_denom > 2000. && pt_denom < 5000.)
+            hBRPt2000_5000->Fill(resPt);
+          hBNCH->Fill(rec_ChargedMultiplicity);
+          hBNCH0vsPt->Fill(pt_denom, chMult[0]);
+          hBNCH1vsPt->Fill(pt_denom, chMult[1]);
+          hBNCH2vsPt->Fill(pt_denom, chMult[2]);
+          hBNCH3vsPt->Fill(pt_denom, chMult[3]);
+          hBNCH4vsPt->Fill(pt_denom, chMult[4]);
+          hBNCH5vsPt->Fill(pt_denom, chMult[5]);
+          hBNCH6vsPt->Fill(pt_denom, chMult[6]);
+          hBNCH7vsPt->Fill(pt_denom, chMult[7]);
+          hBNCHvsPt->Fill(pt_denom, rec_ChargedMultiplicity);
+          if (rec_eta > 0.)
+            hBDEtavsPt->Fill(pt_denom, rec_eta - true_eta);
+          else
+            hBDEtavsPt->Fill(pt_denom, -rec_eta + true_eta);
+          hBDPhivsPt->Fill(pt_denom, rec_phi - true_phi);
+        }
+        if (plot2)
+          hBRCHE->Fill(resChargedHadEnergy);
+        if (plot3)
+          hBRNHE->Fill(resNeutralHadEnergy);
+        if (plot4)
+          hBRNEE->Fill(resNeutralEmEnergy);
+        if (plot5)
+          hBRneut->Fill(resNeutralEnergy);
+        if (plot1)
+          hBRPtvsPt->Fill(pt_denom, resPt);
+        if (plot2)
+          hBRCHEvsPt->Fill(pt_denom, resChargedHadEnergy);
+        if (plot3)
+          hBRNHEvsPt->Fill(pt_denom, resNeutralHadEnergy);
+        if (plot4)
+          hBRNEEvsPt->Fill(pt_denom, resNeutralEmEnergy);
+        if (plot5)
+          hBRneutvsPt->Fill(pt_denom, resNeutralEnergy);
+        if (plot6) {
+          hBRHCALvsP->Fill(true_E, resHCALEnergy);
+          hBRNEUTvsP->Fill(true_E, resNEUTEnergy);
+        }
+        if (plot7) {
+          hBRHONLvsP->Fill(true_E, resHCALEnergy);
+          hBRNONLvsP->Fill(true_E, resNEUTEnergy);
+        }
       }
       // delta Pt or E quantities for Endcap
-      if (Endcap){
-	if(plot1) {
-	  hERPt->Fill (resPt);
-	  if ( pt_denom >  20. && pt_denom <  40. ) hERPt20_40->Fill (resPt);
-	  if ( pt_denom >  40. && pt_denom <  60. ) hERPt40_60->Fill (resPt);
-	  if ( pt_denom >  60. && pt_denom <  80. ) hERPt60_80->Fill (resPt);
-	  if ( pt_denom >  80. && pt_denom < 100. ) hERPt80_100->Fill (resPt);
-	  if ( pt_denom > 100. && pt_denom < 150. ) hERPt100_150->Fill (resPt);
-	  if ( pt_denom > 150. && pt_denom < 200. ) hERPt150_200->Fill (resPt);
-	  if ( pt_denom > 200. && pt_denom < 250. ) hERPt200_250->Fill (resPt);
-	  if ( pt_denom > 250. && pt_denom < 300. ) hERPt250_300->Fill (resPt);
-	  if ( pt_denom > 300. && pt_denom < 400. ) hERPt300_400->Fill (resPt);
-	  if ( pt_denom > 400. && pt_denom < 500. ) hERPt400_500->Fill (resPt);
-	  if ( pt_denom > 500. && pt_denom < 750. ) hERPt500_750->Fill (resPt);
-	  if ( pt_denom > 750. && pt_denom < 1250. ) hERPt750_1250->Fill (resPt);
-	  if ( pt_denom > 1250. && pt_denom < 2000. ) hERPt1250_2000->Fill (resPt);
-	  if ( pt_denom > 2000. && pt_denom < 5000. ) hERPt2000_5000->Fill (resPt);
-	  hENCH->Fill(rec_ChargedMultiplicity);
-	  hENCHvsPt->Fill(pt_denom,rec_ChargedMultiplicity);
-	  hENCH0vsPt->Fill(pt_denom,chMult[0]);
-	  hENCH1vsPt->Fill(pt_denom,chMult[1]);
-	  hENCH2vsPt->Fill(pt_denom,chMult[2]);
-	  hENCH3vsPt->Fill(pt_denom,chMult[3]);
-	  hENCH4vsPt->Fill(pt_denom,chMult[4]);
-	  hENCH5vsPt->Fill(pt_denom,chMult[5]);
-	  hENCH6vsPt->Fill(pt_denom,chMult[6]);
-	  hENCH7vsPt->Fill(pt_denom,chMult[7]);
-	  if ( rec_eta > 0. ) 
-	    hEDEtavsPt->Fill(pt_denom,rec_eta-true_eta);
-	  else
-	    hEDEtavsPt->Fill(pt_denom,-rec_eta+true_eta);
-	  hEDPhivsPt->Fill(pt_denom,rec_phi-true_phi);
-	}
-	if(plot2)hERCHE->Fill(resChargedHadEnergy);
-	if(plot3)hERNHE->Fill(resNeutralHadEnergy);
-	if(plot4)hERNEE->Fill(resNeutralEmEnergy);
-	if(plot5)hERneut->Fill(resNeutralEnergy);
-	if(plot1)hERPtvsPt->Fill(pt_denom, resPt);
-	if(plot2)hERCHEvsPt->Fill(pt_denom, resChargedHadEnergy);
-	if(plot3)hERNHEvsPt->Fill(pt_denom, resNeutralHadEnergy);
-	if(plot4)hERNEEvsPt->Fill(pt_denom, resNeutralEmEnergy);
-	if(plot5)hERneutvsPt->Fill(pt_denom, resNeutralEnergy);
-	if(plot6) {
-	  hERHCALvsP->Fill(true_E, resHCALEnergy);
-	  hERNEUTvsP->Fill(true_E, resNEUTEnergy);
-	}
-	if(plot7) {
-	  hERHONLvsP->Fill(true_E, resHCALEnergy);
-	  hERNONLvsP->Fill(true_E, resNEUTEnergy);
-	}
-      }						
+      if (Endcap) {
+        if (plot1) {
+          hERPt->Fill(resPt);
+          if (pt_denom > 20. && pt_denom < 40.)
+            hERPt20_40->Fill(resPt);
+          if (pt_denom > 40. && pt_denom < 60.)
+            hERPt40_60->Fill(resPt);
+          if (pt_denom > 60. && pt_denom < 80.)
+            hERPt60_80->Fill(resPt);
+          if (pt_denom > 80. && pt_denom < 100.)
+            hERPt80_100->Fill(resPt);
+          if (pt_denom > 100. && pt_denom < 150.)
+            hERPt100_150->Fill(resPt);
+          if (pt_denom > 150. && pt_denom < 200.)
+            hERPt150_200->Fill(resPt);
+          if (pt_denom > 200. && pt_denom < 250.)
+            hERPt200_250->Fill(resPt);
+          if (pt_denom > 250. && pt_denom < 300.)
+            hERPt250_300->Fill(resPt);
+          if (pt_denom > 300. && pt_denom < 400.)
+            hERPt300_400->Fill(resPt);
+          if (pt_denom > 400. && pt_denom < 500.)
+            hERPt400_500->Fill(resPt);
+          if (pt_denom > 500. && pt_denom < 750.)
+            hERPt500_750->Fill(resPt);
+          if (pt_denom > 750. && pt_denom < 1250.)
+            hERPt750_1250->Fill(resPt);
+          if (pt_denom > 1250. && pt_denom < 2000.)
+            hERPt1250_2000->Fill(resPt);
+          if (pt_denom > 2000. && pt_denom < 5000.)
+            hERPt2000_5000->Fill(resPt);
+          hENCH->Fill(rec_ChargedMultiplicity);
+          hENCHvsPt->Fill(pt_denom, rec_ChargedMultiplicity);
+          hENCH0vsPt->Fill(pt_denom, chMult[0]);
+          hENCH1vsPt->Fill(pt_denom, chMult[1]);
+          hENCH2vsPt->Fill(pt_denom, chMult[2]);
+          hENCH3vsPt->Fill(pt_denom, chMult[3]);
+          hENCH4vsPt->Fill(pt_denom, chMult[4]);
+          hENCH5vsPt->Fill(pt_denom, chMult[5]);
+          hENCH6vsPt->Fill(pt_denom, chMult[6]);
+          hENCH7vsPt->Fill(pt_denom, chMult[7]);
+          if (rec_eta > 0.)
+            hEDEtavsPt->Fill(pt_denom, rec_eta - true_eta);
+          else
+            hEDEtavsPt->Fill(pt_denom, -rec_eta + true_eta);
+          hEDPhivsPt->Fill(pt_denom, rec_phi - true_phi);
+        }
+        if (plot2)
+          hERCHE->Fill(resChargedHadEnergy);
+        if (plot3)
+          hERNHE->Fill(resNeutralHadEnergy);
+        if (plot4)
+          hERNEE->Fill(resNeutralEmEnergy);
+        if (plot5)
+          hERneut->Fill(resNeutralEnergy);
+        if (plot1)
+          hERPtvsPt->Fill(pt_denom, resPt);
+        if (plot2)
+          hERCHEvsPt->Fill(pt_denom, resChargedHadEnergy);
+        if (plot3)
+          hERNHEvsPt->Fill(pt_denom, resNeutralHadEnergy);
+        if (plot4)
+          hERNEEvsPt->Fill(pt_denom, resNeutralEmEnergy);
+        if (plot5)
+          hERneutvsPt->Fill(pt_denom, resNeutralEnergy);
+        if (plot6) {
+          hERHCALvsP->Fill(true_E, resHCALEnergy);
+          hERNEUTvsP->Fill(true_E, resNEUTEnergy);
+        }
+        if (plot7) {
+          hERHONLvsP->Fill(true_E, resHCALEnergy);
+          hERNONLvsP->Fill(true_E, resNEUTEnergy);
+        }
+      }
       // delta Pt or E quantities for Forward
-      if (Forward){
-	if(plot1) {
-	  hFRPt->Fill (resPt);
-	  if ( pt_denom >  20. && pt_denom <  40. ) hFRPt20_40->Fill (resPt);
-	  if ( pt_denom >  40. && pt_denom <  60. ) hFRPt40_60->Fill (resPt);
-	  if ( pt_denom >  60. && pt_denom <  80. ) hFRPt60_80->Fill (resPt);
-	  if ( pt_denom >  80. && pt_denom < 100. ) hFRPt80_100->Fill (resPt);
-	  if ( pt_denom > 100. && pt_denom < 150. ) hFRPt100_150->Fill (resPt);
-	  if ( pt_denom > 150. && pt_denom < 200. ) hFRPt150_200->Fill (resPt);
-	  if ( pt_denom > 200. && pt_denom < 250. ) hFRPt200_250->Fill (resPt);
-	  if ( pt_denom > 250. && pt_denom < 300. ) hFRPt250_300->Fill (resPt);
-	  if ( pt_denom > 300. && pt_denom < 400. ) hFRPt300_400->Fill (resPt);
-	  if ( pt_denom > 400. && pt_denom < 500. ) hFRPt400_500->Fill (resPt);
-	  if ( pt_denom > 500. && pt_denom < 750. ) hFRPt500_750->Fill (resPt);
-	  if ( pt_denom > 750. && pt_denom < 1250. ) hFRPt750_1250->Fill (resPt);
-	  if ( pt_denom > 1250. && pt_denom < 2000. ) hFRPt1250_2000->Fill (resPt);
-	  if ( pt_denom > 2000. && pt_denom < 5000. ) hFRPt2000_5000->Fill (resPt);
-	  if ( rec_eta > 0. ) 
-	    hFDEtavsPt->Fill(pt_denom,rec_eta-true_eta);
-	  else
-	    hFDEtavsPt->Fill(pt_denom,-rec_eta+true_eta);
-	  hFDPhivsPt->Fill(pt_denom,rec_phi-true_phi);
-	}
-	if(plot2)hFRCHE->Fill(resChargedHadEnergy);
-	if(plot3)hFRNHE->Fill(resNeutralHadEnergy);
-	if(plot4)hFRNEE->Fill(resNeutralEmEnergy);
-	if(plot5)hFRneut->Fill(resNeutralEnergy);
-	if(plot1)hFRPtvsPt->Fill(pt_denom, resPt);
-	if(plot2)hFRCHEvsPt->Fill(pt_denom, resChargedHadEnergy);
-	if(plot3)hFRNHEvsPt->Fill(pt_denom, resNeutralHadEnergy);
-	if(plot4)hFRNEEvsPt->Fill(pt_denom, resNeutralEmEnergy);
-	if(plot5)hFRneutvsPt->Fill(pt_denom, resNeutralEnergy);
-	if(plot6) {
-	  hFRHCALvsP->Fill(true_E, resHCALEnergy);
-	  hFRNEUTvsP->Fill(true_E, resNEUTEnergy);
-	}
-	if(plot7) {
-	  hFRHONLvsP->Fill(true_E, resHCALEnergy);
-	  hFRNONLvsP->Fill(true_E, resNEUTEnergy);
-	}
-      }						
-    } // end case deltaR < deltaRMax
-		
-  } // i loop on pf Jets	
+      if (Forward) {
+        if (plot1) {
+          hFRPt->Fill(resPt);
+          if (pt_denom > 20. && pt_denom < 40.)
+            hFRPt20_40->Fill(resPt);
+          if (pt_denom > 40. && pt_denom < 60.)
+            hFRPt40_60->Fill(resPt);
+          if (pt_denom > 60. && pt_denom < 80.)
+            hFRPt60_80->Fill(resPt);
+          if (pt_denom > 80. && pt_denom < 100.)
+            hFRPt80_100->Fill(resPt);
+          if (pt_denom > 100. && pt_denom < 150.)
+            hFRPt100_150->Fill(resPt);
+          if (pt_denom > 150. && pt_denom < 200.)
+            hFRPt150_200->Fill(resPt);
+          if (pt_denom > 200. && pt_denom < 250.)
+            hFRPt200_250->Fill(resPt);
+          if (pt_denom > 250. && pt_denom < 300.)
+            hFRPt250_300->Fill(resPt);
+          if (pt_denom > 300. && pt_denom < 400.)
+            hFRPt300_400->Fill(resPt);
+          if (pt_denom > 400. && pt_denom < 500.)
+            hFRPt400_500->Fill(resPt);
+          if (pt_denom > 500. && pt_denom < 750.)
+            hFRPt500_750->Fill(resPt);
+          if (pt_denom > 750. && pt_denom < 1250.)
+            hFRPt750_1250->Fill(resPt);
+          if (pt_denom > 1250. && pt_denom < 2000.)
+            hFRPt1250_2000->Fill(resPt);
+          if (pt_denom > 2000. && pt_denom < 5000.)
+            hFRPt2000_5000->Fill(resPt);
+          if (rec_eta > 0.)
+            hFDEtavsPt->Fill(pt_denom, rec_eta - true_eta);
+          else
+            hFDEtavsPt->Fill(pt_denom, -rec_eta + true_eta);
+          hFDPhivsPt->Fill(pt_denom, rec_phi - true_phi);
+        }
+        if (plot2)
+          hFRCHE->Fill(resChargedHadEnergy);
+        if (plot3)
+          hFRNHE->Fill(resNeutralHadEnergy);
+        if (plot4)
+          hFRNEE->Fill(resNeutralEmEnergy);
+        if (plot5)
+          hFRneut->Fill(resNeutralEnergy);
+        if (plot1)
+          hFRPtvsPt->Fill(pt_denom, resPt);
+        if (plot2)
+          hFRCHEvsPt->Fill(pt_denom, resChargedHadEnergy);
+        if (plot3)
+          hFRNHEvsPt->Fill(pt_denom, resNeutralHadEnergy);
+        if (plot4)
+          hFRNEEvsPt->Fill(pt_denom, resNeutralEmEnergy);
+        if (plot5)
+          hFRneutvsPt->Fill(pt_denom, resNeutralEnergy);
+        if (plot6) {
+          hFRHCALvsP->Fill(true_E, resHCALEnergy);
+          hFRNEUTvsP->Fill(true_E, resNEUTEnergy);
+        }
+        if (plot7) {
+          hFRHONLvsP->Fill(true_E, resHCALEnergy);
+          hFRNONLvsP->Fill(true_E, resNEUTEnergy);
+        }
+      }
+    }  // end case deltaR < deltaRMax
+
+  }  // i loop on pf Jets
 
   // Increment counter
   entry_++;
 }
 
-void PFJetBenchmark::gettrue (const reco::GenJet* truth, double& true_ChargedHadEnergy, 
-			      double& true_NeutralHadEnergy, double& true_NeutralEmEnergy){
-  std::vector <const GenParticle*> mcparts = truth->getGenConstituents ();
+void PFJetBenchmark::gettrue(const reco::GenJet* truth,
+                             double& true_ChargedHadEnergy,
+                             double& true_NeutralHadEnergy,
+                             double& true_NeutralEmEnergy) {
+  std::vector<const GenParticle*> mcparts = truth->getGenConstituents();
   true_NeutralEmEnergy = 0.;
   true_ChargedHadEnergy = 0.;
   true_NeutralHadEnergy = 0.;
-  // for each MC particle in turn  
-  for (unsigned i = 0; i < mcparts.size (); i++) {
+  // for each MC particle in turn
+  for (unsigned i = 0; i < mcparts.size(); i++) {
     const GenParticle* mcpart = mcparts[i];
-    int PDG = std::abs( mcpart->pdgId());
-    double e = mcpart->energy(); 
-    switch(PDG){  // start PDG switch
-    case 22: // photon
-      true_NeutralEmEnergy += e;
-      break;
-    case 211: // pi
-    case 321: // K
-    case 2212: // p
-    case 11: //electrons (until recognised)
-      true_ChargedHadEnergy += e;
-      break;
-    case 310: // K_S0
-    case 130: // K_L0
-    case 3122: // Lambda0
-    case 2112: // n0
-      true_NeutralHadEnergy += e;
-    default:
-      break;
-    }  // end PDG switch		
-  }  // end loop on constituents.
+    int PDG = std::abs(mcpart->pdgId());
+    double e = mcpart->energy();
+    switch (PDG) {  // start PDG switch
+      case 22:      // photon
+        true_NeutralEmEnergy += e;
+        break;
+      case 211:   // pi
+      case 321:   // K
+      case 2212:  // p
+      case 11:    //electrons (until recognised)
+        true_ChargedHadEnergy += e;
+        break;
+      case 310:   // K_S0
+      case 130:   // K_L0
+      case 3122:  // Lambda0
+      case 2112:  // n0
+        true_NeutralHadEnergy += e;
+      default:
+        break;
+    }  // end PDG switch
+  }    // end loop on constituents.
 }
 
-void PFJetBenchmark::printPFJet(const reco::PFJet* pfj){
-  cout<<setiosflags(ios::right);
-  cout<<setiosflags(ios::fixed);
-  cout<<setprecision(3);
+void PFJetBenchmark::printPFJet(const reco::PFJet* pfj) {
+  cout << setiosflags(ios::right);
+  cout << setiosflags(ios::fixed);
+  cout << setprecision(3);
 
-  cout << "PFJet  p/px/py/pz/pt: " << pfj->p() << "/" << pfj->px () 
-       << "/" << pfj->py() << "/" << pfj->pz() << "/" << pfj->pt() << endl
-       << "    eta/phi: " << pfj->eta () << "/" << pfj->phi () << endl   		
+  cout << "PFJet  p/px/py/pz/pt: " << pfj->p() << "/" << pfj->px() << "/" << pfj->py() << "/" << pfj->pz() << "/"
+       << pfj->pt() << endl
+       << "    eta/phi: " << pfj->eta() << "/" << pfj->phi() << endl
        << "    PFJet specific:" << std::endl
-       << "      charged/neutral hadrons energy: " << pfj->chargedHadronEnergy () << '/' << pfj->neutralHadronEnergy () << endl
-       << "      charged/neutral em energy: " << pfj->chargedEmEnergy () << '/' << pfj->neutralEmEnergy () << endl
-       << "      charged muon energy: " << pfj->chargedMuEnergy () << '/' << endl
-       << "      charged/neutral multiplicity: " << pfj->chargedMultiplicity () << '/' << pfj->neutralMultiplicity () << endl;
-  
+       << "      charged/neutral hadrons energy: " << pfj->chargedHadronEnergy() << '/' << pfj->neutralHadronEnergy()
+       << endl
+       << "      charged/neutral em energy: " << pfj->chargedEmEnergy() << '/' << pfj->neutralEmEnergy() << endl
+       << "      charged muon energy: " << pfj->chargedMuEnergy() << '/' << endl
+       << "      charged/neutral multiplicity: " << pfj->chargedMultiplicity() << '/' << pfj->neutralMultiplicity()
+       << endl;
+
   // And print the constituents
   std::cout << pfj->print() << std::endl;
 
-  cout<<resetiosflags(ios::right|ios::fixed);
+  cout << resetiosflags(ios::right | ios::fixed);
 }
 
-
-void PFJetBenchmark::printGenJet (const reco::GenJet* truth){
-  std::vector <const GenParticle*> mcparts = truth->getGenConstituents ();
-  cout << "GenJet p/px/py/pz/pt: " << truth->p() << '/' << truth->px () 
-       << '/' << truth->py() << '/' << truth->pz() << '/' << truth->pt() << endl
-       << "    eta/phi: " << truth->eta () << '/' << truth->phi () << endl
+void PFJetBenchmark::printGenJet(const reco::GenJet* truth) {
+  std::vector<const GenParticle*> mcparts = truth->getGenConstituents();
+  cout << "GenJet p/px/py/pz/pt: " << truth->p() << '/' << truth->px() << '/' << truth->py() << '/' << truth->pz()
+       << '/' << truth->pt() << endl
+       << "    eta/phi: " << truth->eta() << '/' << truth->phi() << endl
        << "    # of constituents: " << mcparts.size() << endl;
   cout << "    constituents:" << endl;
-  for (unsigned i = 0; i < mcparts.size (); i++) {
+  for (unsigned i = 0; i < mcparts.size(); i++) {
     const GenParticle* mcpart = mcparts[i];
-    cout << "      #" << i << "  PDG code:" << mcpart->pdgId() 
-	 << ", p/pt/eta/phi: " << mcpart->p() << '/' << mcpart->pt() 
-	 << '/' << mcpart->eta() << '/' << mcpart->phi() << endl;	
-  }    
+    cout << "      #" << i << "  PDG code:" << mcpart->pdgId() << ", p/pt/eta/phi: " << mcpart->p() << '/'
+         << mcpart->pt() << '/' << mcpart->eta() << '/' << mcpart->phi() << endl;
+  }
 }
-

--- a/RecoParticleFlow/Benchmark/src/PFMETBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFMETBenchmark.cc
@@ -3,26 +3,26 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 // preprocessor macro for booking 1d histos with DQMStore -or- bare Root
-#define BOOK1D(name,title,nbinsx,lowx,highx) \
-  h##name = dbe_ ? dbe_->book1D(#name,title,nbinsx,lowx,highx)->getTH1F() \
-    : new TH1F(#name,title,nbinsx,lowx,highx)
+#define BOOK1D(name, title, nbinsx, lowx, highx) \
+  h##name =                                      \
+      dbe_ ? dbe_->book1D(#name, title, nbinsx, lowx, highx)->getTH1F() : new TH1F(#name, title, nbinsx, lowx, highx)
 
 // preprocessor macro for booking 2d histos with DQMStore -or- bare Root
-#define BOOK2D(name,title,nbinsx,lowx,highx,nbinsy,lowy,highy) \
-  h##name = dbe_ ? dbe_->book2D(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)->getTH2F() \
-    : new TH2F(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)
+#define BOOK2D(name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)                              \
+  h##name = dbe_ ? dbe_->book2D(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)->getTH2F() \
+                 : new TH2F(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)
 
 // all versions OK
 // preprocesor macro for setting axis titles
-#define SETAXES(name,xtitle,ytitle) \
-  h##name->GetXaxis()->SetTitle(xtitle); h##name->GetYaxis()->SetTitle(ytitle)
-
+#define SETAXES(name, xtitle, ytitle)    \
+  h##name->GetXaxis()->SetTitle(xtitle); \
+  h##name->GetYaxis()->SetTitle(ytitle)
 
 /*#define SET2AXES(name,xtitle,ytitle) \
   hE##name->GetXaxis()->SetTitle(xtitle); hE##name->GetYaxis()->SetTitle(ytitle);  hB##name->GetXaxis()->SetTitle(xtitle); hB##name->GetYaxis()->SetTitle(ytitle)
 */
 
-#define PT (plotAgainstReco_)?"reconstructed P_{T}" :"generated P_{T}"
+#define PT (plotAgainstReco_) ? "reconstructed P_{T}" : "generated P_{T}"
 
 using namespace reco;
 using namespace std;
@@ -30,110 +30,107 @@ using namespace std;
 PFMETBenchmark::PFMETBenchmark() : file_(nullptr) {}
 
 PFMETBenchmark::~PFMETBenchmark() {
-  if(file_) file_->Close();
+  if (file_)
+    file_->Close();
 }
 
 void PFMETBenchmark::write() {
-   // Store the DAQ Histograms 
+  // Store the DAQ Histograms
   if (!outputFile_.empty()) {
     if (dbe_)
-          dbe_->save(outputFile_);
+      dbe_->save(outputFile_);
     // use bare Root if no DQM (FWLite applications)
     else if (file_) {
-       file_->Write(outputFile_.c_str());
-       cout << "Benchmark output written to file " << outputFile_.c_str() << endl;
-       file_->Close();
-       }
-  }
-  else 
-    cout << "No output file specified ("<<outputFile_<<"). Results will not be saved!" << endl;
-    
-} 
+      file_->Write(outputFile_.c_str());
+      cout << "Benchmark output written to file " << outputFile_.c_str() << endl;
+      file_->Close();
+    }
+  } else
+    cout << "No output file specified (" << outputFile_ << "). Results will not be saved!" << endl;
+}
 
 void PFMETBenchmark::setup(
-			   string Filename,
-			   bool debug, 
-			   bool plotAgainstReco,
-			   string benchmarkLabel_, 
-			   DQMStore * dbe_store) {
-  debug_ = debug; 
+    string Filename, bool debug, bool plotAgainstReco, string benchmarkLabel_, DQMStore* dbe_store) {
+  debug_ = debug;
   plotAgainstReco_ = plotAgainstReco;
-  outputFile_=Filename;
+  outputFile_ = Filename;
   file_ = nullptr;
   dbe_ = dbe_store;
   // print parameters
   //cout<< "PFMETBenchmark Setup parameters =============================================="<<endl;
-  cout << "Filename to write histograms " << Filename<<endl;
-  cout << "PFMETBenchmark debug " << debug_<< endl;
+  cout << "Filename to write histograms " << Filename << endl;
+  cout << "PFMETBenchmark debug " << debug_ << endl;
   cout << "plotAgainstReco " << plotAgainstReco_ << endl;
   cout << "benchmarkLabel " << benchmarkLabel_ << endl;
-  
+
   // Book histogram
 
   // Establish DQM Store
-  string path = "PFTask/Benchmarks/"+ benchmarkLabel_ + "/";
-  if (plotAgainstReco) path += "Reco"; else path += "Gen";
+  string path = "PFTask/Benchmarks/" + benchmarkLabel_ + "/";
+  if (plotAgainstReco)
+    path += "Reco";
+  else
+    path += "Gen";
   if (dbe_) {
     dbe_->setCurrentFolder(path);
-  }
-  else {
+  } else {
     file_ = new TFile(outputFile_.c_str(), "recreate");
-//    TTree * tr = new TTree("PFTast");
-//    tr->Branch("Benchmarks/ParticleFlow")
-    cout << "Info: DQM is not available to provide data storage service. Using TFile to save histograms. "<<endl;
+    //    TTree * tr = new TTree("PFTast");
+    //    tr->Branch("Benchmarks/ParticleFlow")
+    cout << "Info: DQM is not available to provide data storage service. Using TFile to save histograms. " << endl;
   }
 
   // delta Pt or E quantities for Barrel
-  BOOK1D(MEX,"Particle Flow",400,-200,200);
-  BOOK1D(DeltaMEX,"Particle Flow",400,-200,200);
-  BOOK1D(DeltaMET,"Particle Flow",400,-200,200);
-  BOOK1D(DeltaPhi,"Particle Flow", 1000, -3.2, 3.2);
-  BOOK1D(DeltaSET,"Particle Flow",400,-200,200);
-  BOOK2D(SETvsDeltaMET,"Particle Flow",200, 0.0, 1000.0, 400, -200.0, 200.0);        
-  BOOK2D(SETvsDeltaSET,"Particle Flow",200, 0.0, 1000.0, 400, -200.0, 200.0);       
+  BOOK1D(MEX, "Particle Flow", 400, -200, 200);
+  BOOK1D(DeltaMEX, "Particle Flow", 400, -200, 200);
+  BOOK1D(DeltaMET, "Particle Flow", 400, -200, 200);
+  BOOK1D(DeltaPhi, "Particle Flow", 1000, -3.2, 3.2);
+  BOOK1D(DeltaSET, "Particle Flow", 400, -200, 200);
+  BOOK2D(SETvsDeltaMET, "Particle Flow", 200, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(SETvsDeltaSET, "Particle Flow", 200, 0.0, 1000.0, 400, -200.0, 200.0);
   profileSETvsSETresp = new TProfile("#DeltaPFSET / trueSET vs trueSET", "", 200, 0.0, 1000.0, -1.0, 1.0);
-  profileMETvsMETresp = new TProfile("#DeltaPFMET / trueMET vs trueMET", "", 50, 0.0,  200.0, -1.0, 1.0);
-	
-  BOOK1D(CaloMEX,"Calorimeter",400,-200,200);
-  BOOK1D(DeltaCaloMEX,"Calorimeter",400,-200,200);
-  BOOK1D(DeltaCaloMET,"Calorimeter",400,-200,200);
-  BOOK1D(DeltaCaloPhi,"Calorimeter", 1000, -3.2, 3.2);
-  BOOK1D(DeltaCaloSET,"Calorimeter",400,-200,200);
-  BOOK2D(CaloSETvsDeltaCaloMET,"Calorimeter",200, 0.0, 1000.0, 400, -200.0, 200.0);        
-  BOOK2D(CaloSETvsDeltaCaloSET,"Calorimeter",200, 0.0, 1000.0, 400, -200.0, 200.0);       
+  profileMETvsMETresp = new TProfile("#DeltaPFMET / trueMET vs trueMET", "", 50, 0.0, 200.0, -1.0, 1.0);
+
+  BOOK1D(CaloMEX, "Calorimeter", 400, -200, 200);
+  BOOK1D(DeltaCaloMEX, "Calorimeter", 400, -200, 200);
+  BOOK1D(DeltaCaloMET, "Calorimeter", 400, -200, 200);
+  BOOK1D(DeltaCaloPhi, "Calorimeter", 1000, -3.2, 3.2);
+  BOOK1D(DeltaCaloSET, "Calorimeter", 400, -200, 200);
+  BOOK2D(CaloSETvsDeltaCaloMET, "Calorimeter", 200, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(CaloSETvsDeltaCaloSET, "Calorimeter", 200, 0.0, 1000.0, 400, -200.0, 200.0);
   profileCaloSETvsCaloSETresp = new TProfile("#DeltaCaloSET / trueSET vs trueSET", "", 200, 0.0, 1000.0, -1.0, 1.0);
-  profileCaloMETvsCaloMETresp = new TProfile("#DeltaCaloMET / trueMET vs trueMET", "", 200, 0.0,  200.0, -1.0, 1.0);
+  profileCaloMETvsCaloMETresp = new TProfile("#DeltaCaloMET / trueMET vs trueMET", "", 200, 0.0, 200.0, -1.0, 1.0);
 
-  BOOK2D(DeltaPFMETvstrueMET,"Particle Flow", 500, 0.0, 1000.0, 400, -200.0, 200.0);      
-  BOOK2D(DeltaCaloMETvstrueMET,"Calorimeter", 500, 0.0, 1000.0, 400, -200.0, 200.0);      
-  BOOK2D(DeltaPFPhivstrueMET,"Particle Flow", 500, 0.0, 1000.0, 400, -3.2, 3.2);      
-  BOOK2D(DeltaCaloPhivstrueMET,"Calorimeter", 500, 0.0, 1000.0, 400, -3.2, 3.2);      
-  BOOK2D(CaloMETvstrueMET,"Calorimeter", 500, 0.0, 1000.0, 500, 0.0, 1000.0);      
-  BOOK2D(PFMETvstrueMET,"Particle Flow", 500, 0.0, 1000.0, 500, 0.0, 1000.0);
+  BOOK2D(DeltaPFMETvstrueMET, "Particle Flow", 500, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(DeltaCaloMETvstrueMET, "Calorimeter", 500, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(DeltaPFPhivstrueMET, "Particle Flow", 500, 0.0, 1000.0, 400, -3.2, 3.2);
+  BOOK2D(DeltaCaloPhivstrueMET, "Calorimeter", 500, 0.0, 1000.0, 400, -3.2, 3.2);
+  BOOK2D(CaloMETvstrueMET, "Calorimeter", 500, 0.0, 1000.0, 500, 0.0, 1000.0);
+  BOOK2D(PFMETvstrueMET, "Particle Flow", 500, 0.0, 1000.0, 500, 0.0, 1000.0);
 
-  BOOK2D(DeltaCaloMEXvstrueSET,"Calorimeter",200, 0.0, 1000.0, 400, -200.0, 200.0);
-  BOOK2D(DeltaPFMEXvstrueSET,"Particle Flow",200, 0.0, 1000.0, 400, -200.0, 200.0);
-   
-  BOOK1D(TrueMET,"MC truth", 500, 0.0, 1000.0);      
-  BOOK1D(CaloMET,"Calorimeter", 500, 0.0, 1000.0);
-  BOOK1D(PFMET,"Particle Flow", 500, 0.0, 1000.0);
+  BOOK2D(DeltaCaloMEXvstrueSET, "Calorimeter", 200, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(DeltaPFMEXvstrueSET, "Particle Flow", 200, 0.0, 1000.0, 400, -200.0, 200.0);
 
-  BOOK1D(TCMEX,"Track Corrected",400,-200,200);
-  BOOK1D(DeltaTCMEX,"Track Corrected",400,-200,200);
-  BOOK1D(DeltaTCMET,"Track Corrected",400,-200,200);
-  BOOK1D(DeltaTCPhi,"Track Corrected", 1000, -3.2, 3.2);
-  BOOK1D(DeltaTCSET,"Track Corrected",400,-200,200);
-  BOOK2D(TCSETvsDeltaTCMET,"Track Corrected",200, 0.0, 1000.0, 400, -200.0, 200.0);        
-  BOOK2D(TCSETvsDeltaTCSET,"Track Corrected",200, 0.0, 1000.0, 400, -200.0, 200.0);       
+  BOOK1D(TrueMET, "MC truth", 500, 0.0, 1000.0);
+  BOOK1D(CaloMET, "Calorimeter", 500, 0.0, 1000.0);
+  BOOK1D(PFMET, "Particle Flow", 500, 0.0, 1000.0);
+
+  BOOK1D(TCMEX, "Track Corrected", 400, -200, 200);
+  BOOK1D(DeltaTCMEX, "Track Corrected", 400, -200, 200);
+  BOOK1D(DeltaTCMET, "Track Corrected", 400, -200, 200);
+  BOOK1D(DeltaTCPhi, "Track Corrected", 1000, -3.2, 3.2);
+  BOOK1D(DeltaTCSET, "Track Corrected", 400, -200, 200);
+  BOOK2D(TCSETvsDeltaTCMET, "Track Corrected", 200, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(TCSETvsDeltaTCSET, "Track Corrected", 200, 0.0, 1000.0, 400, -200.0, 200.0);
   profileTCSETvsTCSETresp = new TProfile("#DeltaTCSET / trueSET vs trueSET", "", 200, 0.0, 1000.0, -1.0, 1.0);
-  profileTCMETvsTCMETresp = new TProfile("#DeltaTCMET / trueMET vs trueMET", "", 200, 0.0,  200.0, -1.0, 1.0);
-	
-  BOOK1D(TCMET,"Track Corrected",500,0,1000);
-  BOOK2D(DeltaTCMETvstrueMET,"Track Corrected", 500, 0.0, 1000.0, 400, -200.0, 200.0);
-  BOOK2D(DeltaTCPhivstrueMET,"Track Corrected", 500, 0.0, 1000.0, 400, -3.2, 3.2);
+  profileTCMETvsTCMETresp = new TProfile("#DeltaTCMET / trueMET vs trueMET", "", 200, 0.0, 200.0, -1.0, 1.0);
 
-  BOOK2D(DeltaTCMEXvstrueSET,"Track Corrected", 200, 0.0, 1000.0, 400, -200.0, 200.0);
-  BOOK2D(TCMETvstrueMET,"Track Corrected", 200, 0.0, 1000.0, 500, 0.0, 1000.0);
+  BOOK1D(TCMET, "Track Corrected", 500, 0, 1000);
+  BOOK2D(DeltaTCMETvstrueMET, "Track Corrected", 500, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(DeltaTCPhivstrueMET, "Track Corrected", 500, 0.0, 1000.0, 400, -3.2, 3.2);
+
+  BOOK2D(DeltaTCMEXvstrueSET, "Track Corrected", 200, 0.0, 1000.0, 400, -200.0, 200.0);
+  BOOK2D(TCMETvstrueMET, "Track Corrected", 200, 0.0, 1000.0, 500, 0.0, 1000.0);
 
   //BOOK1D(meanPF,    "Mean PFMEX", 100, 0.0, 1600.0);
   //BOOK1D(meanCalo,  "Mean CaloMEX", 100, 0.0, 1600.0);
@@ -144,11 +141,11 @@ void PFMETBenchmark::setup(
 
   // Set Axis Titles
   // delta Pt or E quantities for Barrel and Endcap
-  SETAXES(MEX, "MEX",  "Events");
-  SETAXES(DeltaMEX, "#DeltaMEX",  "Events");
-  SETAXES(DeltaMET, "#DeltaMET",  "Events");
+  SETAXES(MEX, "MEX", "Events");
+  SETAXES(DeltaMEX, "#DeltaMEX", "Events");
+  SETAXES(DeltaMET, "#DeltaMET", "Events");
   SETAXES(DeltaPhi, "#Delta#phi", "Events");
-  SETAXES(DeltaSET, "#DeltaSET",  "Events");
+  SETAXES(DeltaSET, "#DeltaSET", "Events");
   SETAXES(SETvsDeltaMET, "SET", "#DeltaMET");
   SETAXES(SETvsDeltaSET, "SET", "#DeltaSET");
 
@@ -165,19 +162,19 @@ void PFMETBenchmark::setup(
   SETAXES(PFMET, "PFMET", "Events");
   SETAXES(TCMET, "TCMET", "Events");
 
-  SETAXES(CaloMEX, "MEX",  "Events");
-  SETAXES(DeltaCaloMEX, "#DeltaMEX",  "Events");
-  SETAXES(DeltaCaloMET, "#DeltaMET",  "Events");
+  SETAXES(CaloMEX, "MEX", "Events");
+  SETAXES(DeltaCaloMEX, "#DeltaMEX", "Events");
+  SETAXES(DeltaCaloMET, "#DeltaMET", "Events");
   SETAXES(DeltaCaloPhi, "#Delta#phi", "Events");
-  SETAXES(DeltaCaloSET, "#DeltaSET",  "Events");
+  SETAXES(DeltaCaloSET, "#DeltaSET", "Events");
   SETAXES(CaloSETvsDeltaCaloMET, "SET", "#DeltaMET");
   SETAXES(CaloSETvsDeltaCaloSET, "SET", "#DeltaSET");
 
-  SETAXES(TCMEX, "MEX",  "Events");
-  SETAXES(DeltaTCMEX, "#DeltaMEX",  "Events");
-  SETAXES(DeltaTCMET, "#DeltaMET",  "Events");
+  SETAXES(TCMEX, "MEX", "Events");
+  SETAXES(DeltaTCMEX, "#DeltaMEX", "Events");
+  SETAXES(DeltaTCMET, "#DeltaMET", "Events");
   SETAXES(DeltaTCPhi, "#Delta#phi", "Events");
-  SETAXES(DeltaTCSET, "#DeltaSET",  "Events");
+  SETAXES(DeltaTCSET, "#DeltaSET", "Events");
   SETAXES(TCSETvsDeltaTCMET, "SET", "#DeltaMET");
   SETAXES(TCSETvsDeltaTCSET, "SET", "#DeltaSET");
 
@@ -188,35 +185,37 @@ void PFMETBenchmark::setup(
   SETAXES(TCMETvstrueMET, "trueMET", "TCMET");
 }
 
-
 //void PFMETBenchmark::process(const reco::PFMETCollection& pfMets, const reco::GenMETCollection& genMets) {
-void PFMETBenchmark::process( const reco::PFMETCollection& pfMets, 
-			      const reco::GenParticleCollection& genParticleList, 
-			      const reco::CaloMETCollection& caloMets,
-			      const reco::METCollection& tcMets ) {
+void PFMETBenchmark::process(const reco::PFMETCollection& pfMets,
+                             const reco::GenParticleCollection& genParticleList,
+                             const reco::CaloMETCollection& caloMets,
+                             const reco::METCollection& tcMets) {
   calculateQuantities(pfMets, genParticleList, caloMets, tcMets);
   if (debug_) {
-    cout << "  =========PFMET  " << rec_met  << ", " << rec_phi  << endl;
+    cout << "  =========PFMET  " << rec_met << ", " << rec_phi << endl;
     cout << "  =========GenMET " << true_met << ", " << true_phi << endl;
     cout << "  =========CaloMET " << calo_met << ", " << calo_phi << endl;
     cout << "  =========TCMET " << tc_met << ", " << tc_phi << endl;
-  }			
+  }
   // fill histograms
   hTrueMET->Fill(true_met);
   // delta Pt or E quantities
   // PF
-  hDeltaMET->Fill( rec_met - true_met );
-  hMEX->Fill( rec_mex );
-  hMEX->Fill( rec_mey );
-  hDeltaMEX->Fill( rec_mex - true_mex );
-  hDeltaMEX->Fill( rec_mey - true_mey );
-  hDeltaPhi->Fill( rec_phi - true_phi );
-  hDeltaSET->Fill( rec_set - true_set );
-  if( true_met > 5.0 ) hSETvsDeltaMET->Fill( rec_set, rec_met - true_met );
-  else                 hSETvsDeltaMET->Fill( rec_set, rec_mex - true_mex );
-  hSETvsDeltaSET->Fill( rec_set, rec_set - true_set );
-  if( true_met > 5.0 ) profileMETvsMETresp->Fill(true_met, (rec_met-true_met)/true_met);
-  profileSETvsSETresp->Fill(true_set, (rec_set-true_set)/true_set);
+  hDeltaMET->Fill(rec_met - true_met);
+  hMEX->Fill(rec_mex);
+  hMEX->Fill(rec_mey);
+  hDeltaMEX->Fill(rec_mex - true_mex);
+  hDeltaMEX->Fill(rec_mey - true_mey);
+  hDeltaPhi->Fill(rec_phi - true_phi);
+  hDeltaSET->Fill(rec_set - true_set);
+  if (true_met > 5.0)
+    hSETvsDeltaMET->Fill(rec_set, rec_met - true_met);
+  else
+    hSETvsDeltaMET->Fill(rec_set, rec_mex - true_mex);
+  hSETvsDeltaSET->Fill(rec_set, rec_set - true_set);
+  if (true_met > 5.0)
+    profileMETvsMETresp->Fill(true_met, (rec_met - true_met) / true_met);
+  profileSETvsSETresp->Fill(true_set, (rec_set - true_set) / true_set);
 
   hDeltaPFMETvstrueMET->Fill(true_met, rec_met - true_met);
   hDeltaPFPhivstrueMET->Fill(true_met, rec_phi - true_phi);
@@ -227,18 +226,21 @@ void PFMETBenchmark::process( const reco::PFMETCollection& pfMets,
   hDeltaPFMEXvstrueSET->Fill(true_set, rec_mey - true_mey);
 
   // Calo
-  hDeltaCaloMET->Fill( calo_met - true_met );
-  hCaloMEX->Fill( calo_mex );
-  hCaloMEX->Fill( calo_mey );
-  hDeltaCaloMEX->Fill( calo_mex - true_mex);
-  hDeltaCaloMEX->Fill( calo_mey - true_mey);
-  hDeltaCaloPhi->Fill( calo_phi - true_phi );
-  hDeltaCaloSET->Fill( calo_set - true_set );
-  if( true_met > 5.0 ) hCaloSETvsDeltaCaloMET->Fill( calo_set, calo_met - true_met );
-  else                 hCaloSETvsDeltaCaloMET->Fill( calo_set, calo_mex - true_mex);
-  hCaloSETvsDeltaCaloSET->Fill( calo_set, calo_set - true_set );
-  if( true_met > 5.0 ) profileCaloMETvsCaloMETresp->Fill(true_met, (calo_met-true_met)/true_met);
-  profileCaloSETvsCaloSETresp->Fill(true_set, (calo_set-true_set)/true_set);
+  hDeltaCaloMET->Fill(calo_met - true_met);
+  hCaloMEX->Fill(calo_mex);
+  hCaloMEX->Fill(calo_mey);
+  hDeltaCaloMEX->Fill(calo_mex - true_mex);
+  hDeltaCaloMEX->Fill(calo_mey - true_mey);
+  hDeltaCaloPhi->Fill(calo_phi - true_phi);
+  hDeltaCaloSET->Fill(calo_set - true_set);
+  if (true_met > 5.0)
+    hCaloSETvsDeltaCaloMET->Fill(calo_set, calo_met - true_met);
+  else
+    hCaloSETvsDeltaCaloMET->Fill(calo_set, calo_mex - true_mex);
+  hCaloSETvsDeltaCaloSET->Fill(calo_set, calo_set - true_set);
+  if (true_met > 5.0)
+    profileCaloMETvsCaloMETresp->Fill(true_met, (calo_met - true_met) / true_met);
+  profileCaloSETvsCaloSETresp->Fill(true_set, (calo_set - true_set) / true_set);
 
   hDeltaCaloMETvstrueMET->Fill(true_met, calo_met - true_met);
   hDeltaCaloPhivstrueMET->Fill(true_met, calo_phi - true_phi);
@@ -249,65 +251,66 @@ void PFMETBenchmark::process( const reco::PFMETCollection& pfMets,
   hDeltaCaloMEXvstrueSET->Fill(true_set, calo_mey - true_mey);
 
   // TC
-  hDeltaTCMET->Fill( tc_met - true_met );
-  hTCMET->Fill( tc_met );
-  hTCMEX->Fill( tc_mex );
-  hTCMEX->Fill( tc_mey );
-  hDeltaTCMEX->Fill( tc_mex - true_mex);
-  hDeltaTCMEX->Fill( tc_mey - true_mey);
-  hDeltaTCPhi->Fill( tc_phi - true_phi );
-  hDeltaTCSET->Fill( tc_set - true_set );
-  if( true_met > 5.0 ) hTCSETvsDeltaTCMET->Fill( tc_set, tc_met - true_met );
-  else                 hTCSETvsDeltaTCMET->Fill( tc_set, tc_mex - true_mex);
-  hTCSETvsDeltaTCSET->Fill( tc_set, tc_set - true_set );
-  if( true_met > 5.0 ) profileTCMETvsTCMETresp->Fill(true_met, (tc_met-true_met)/true_met);
-  profileTCSETvsTCSETresp->Fill(true_set, (tc_set-true_set)/true_set);
+  hDeltaTCMET->Fill(tc_met - true_met);
+  hTCMET->Fill(tc_met);
+  hTCMEX->Fill(tc_mex);
+  hTCMEX->Fill(tc_mey);
+  hDeltaTCMEX->Fill(tc_mex - true_mex);
+  hDeltaTCMEX->Fill(tc_mey - true_mey);
+  hDeltaTCPhi->Fill(tc_phi - true_phi);
+  hDeltaTCSET->Fill(tc_set - true_set);
+  if (true_met > 5.0)
+    hTCSETvsDeltaTCMET->Fill(tc_set, tc_met - true_met);
+  else
+    hTCSETvsDeltaTCMET->Fill(tc_set, tc_mex - true_mex);
+  hTCSETvsDeltaTCSET->Fill(tc_set, tc_set - true_set);
+  if (true_met > 5.0)
+    profileTCMETvsTCMETresp->Fill(true_met, (tc_met - true_met) / true_met);
+  profileTCSETvsTCSETresp->Fill(true_set, (tc_set - true_set) / true_set);
 
-  hDeltaTCMETvstrueMET->Fill( true_met, tc_met - true_met);
-  hDeltaTCPhivstrueMET->Fill( true_met, tc_phi - true_phi);
-  hDeltaTCMEXvstrueSET->Fill( true_set, tc_mex - true_mex);
-  hDeltaTCMEXvstrueSET->Fill( true_set, tc_mey - true_mey);
-  hTCMETvstrueMET->Fill( true_met, tc_met );
-
+  hDeltaTCMETvstrueMET->Fill(true_met, tc_met - true_met);
+  hDeltaTCPhivstrueMET->Fill(true_met, tc_phi - true_phi);
+  hDeltaTCMEXvstrueSET->Fill(true_set, tc_mex - true_mex);
+  hDeltaTCMEXvstrueSET->Fill(true_set, tc_mey - true_mey);
+  hTCMETvstrueMET->Fill(true_met, tc_met);
 }
 
-void PFMETBenchmark::calculateQuantities( const reco::PFMETCollection& pfMets, 
-					  const reco::GenParticleCollection& genParticleList, 
-					  const reco::CaloMETCollection& caloMets,
-					  const reco::METCollection& tcMets) 
-{
-  const reco::PFMET&    pfm = pfMets[0];
-  const reco::CaloMET&  cm  = caloMets[0];
-  const reco::MET&  tcm  = tcMets[0];
+void PFMETBenchmark::calculateQuantities(const reco::PFMETCollection& pfMets,
+                                         const reco::GenParticleCollection& genParticleList,
+                                         const reco::CaloMETCollection& caloMets,
+                                         const reco::METCollection& tcMets) {
+  const reco::PFMET& pfm = pfMets[0];
+  const reco::CaloMET& cm = caloMets[0];
+  const reco::MET& tcm = tcMets[0];
 
-  double trueMEY  = 0.0;
-  double trueMEX  = 0.0;;
-  true_set  = 0.0;;
+  double trueMEY = 0.0;
+  double trueMEX = 0.0;
+  ;
+  true_set = 0.0;
+  ;
 
   //  for( genParticle = genParticleList.begin(); genParticle != genParticleList.end(); genParticle++ )
-  for( unsigned i = 0; i < genParticleList.size(); i++ ) {
-    if( genParticleList[i].status() == 1 && fabs(genParticleList[i].eta()) < 5.0 ) { 
-      if( std::abs(genParticleList[i].pdgId()) == 12 ||
-	  std::abs(genParticleList[i].pdgId()) == 14 ||
-	  std::abs(genParticleList[i].pdgId()) == 16 || 
-	  std::abs(genParticleList[i].pdgId()) < 7   || 
-	  std::abs(genParticleList[i].pdgId()) == 21 ) {
-	trueMEX += genParticleList[i].px();
-	trueMEY += genParticleList[i].py();
+  for (unsigned i = 0; i < genParticleList.size(); i++) {
+    if (genParticleList[i].status() == 1 && fabs(genParticleList[i].eta()) < 5.0) {
+      if (std::abs(genParticleList[i].pdgId()) == 12 || std::abs(genParticleList[i].pdgId()) == 14 ||
+          std::abs(genParticleList[i].pdgId()) == 16 || std::abs(genParticleList[i].pdgId()) < 7 ||
+          std::abs(genParticleList[i].pdgId()) == 21) {
+        trueMEX += genParticleList[i].px();
+        trueMEY += genParticleList[i].py();
       } else {
-	true_set += genParticleList[i].pt();
+        true_set += genParticleList[i].pt();
       }
     }
   }
   true_mex = -trueMEX;
   true_mey = -trueMEY;
-  true_met = sqrt( trueMEX*trueMEX + trueMEY*trueMEY );
-  true_phi = atan2(trueMEY,trueMEX);
-  rec_met  = pfm.pt();
-  rec_mex  = pfm.px();
-  rec_mex  = pfm.py();
-  rec_phi  = pfm.phi();
-  rec_set  = pfm.sumEt();
+  true_met = sqrt(trueMEX * trueMEX + trueMEY * trueMEY);
+  true_phi = atan2(trueMEY, trueMEX);
+  rec_met = pfm.pt();
+  rec_mex = pfm.px();
+  rec_mex = pfm.py();
+  rec_phi = pfm.phi();
+  rec_set = pfm.sumEt();
   calo_met = cm.pt();
   calo_mex = cm.px();
   calo_mey = cm.py();
@@ -320,84 +323,81 @@ void PFMETBenchmark::calculateQuantities( const reco::PFMETCollection& pfMets,
   tc_set = tcm.sumEt();
 
   if (debug_) {
-    cout << "  =========PFMET  " << rec_met  << ", " << rec_phi  << endl;
+    cout << "  =========PFMET  " << rec_met << ", " << rec_phi << endl;
     cout << "  =========trueMET " << true_met << ", " << true_phi << endl;
     cout << "  =========CaloMET " << calo_met << ", " << calo_phi << endl;
     cout << "  =========TCMET " << tc_met << ", " << tc_phi << endl;
-  }			
+  }
 }
 
-void PFMETBenchmark::calculateQuantities( const reco::PFMETCollection& pfMets, 
-					  const reco::GenParticleCollection& genParticleList, 
-					  const reco::CaloMETCollection& caloMets,
-					  const reco::METCollection& tcMets,
-					  const std::vector<reco::CaloJet>& caloJets,
-					  const std::vector<reco::CaloJet>& corr_caloJets) 
-{
-  const reco::PFMET&    pfm = pfMets[0];
-  const reco::CaloMET&  cm  = caloMets[0];
-  const reco::MET&  tcm  = tcMets[0];
+void PFMETBenchmark::calculateQuantities(const reco::PFMETCollection& pfMets,
+                                         const reco::GenParticleCollection& genParticleList,
+                                         const reco::CaloMETCollection& caloMets,
+                                         const reco::METCollection& tcMets,
+                                         const std::vector<reco::CaloJet>& caloJets,
+                                         const std::vector<reco::CaloJet>& corr_caloJets) {
+  const reco::PFMET& pfm = pfMets[0];
+  const reco::CaloMET& cm = caloMets[0];
+  const reco::MET& tcm = tcMets[0];
 
-  double trueMEY  = 0.0;
-  double trueMEX  = 0.0;;
-  true_set  = 0.0;;
+  double trueMEY = 0.0;
+  double trueMEX = 0.0;
+  ;
+  true_set = 0.0;
+  ;
 
   //  for( genParticle = genParticleList.begin(); genParticle != genParticleList.end(); genParticle++ )
-  for( unsigned i = 0; i < genParticleList.size(); i++ ) {
-    if( genParticleList[i].status() == 1 && fabs(genParticleList[i].eta()) < 5.0 ) { 
-      if( std::abs(genParticleList[i].pdgId()) == 12 ||
-	  std::abs(genParticleList[i].pdgId()) == 14 ||
-	  std::abs(genParticleList[i].pdgId()) == 16 || 
-	  std::abs(genParticleList[i].pdgId()) < 7   || 
-	  std::abs(genParticleList[i].pdgId()) == 21 ) {
-	trueMEX += genParticleList[i].px();
-	trueMEY += genParticleList[i].py();
+  for (unsigned i = 0; i < genParticleList.size(); i++) {
+    if (genParticleList[i].status() == 1 && fabs(genParticleList[i].eta()) < 5.0) {
+      if (std::abs(genParticleList[i].pdgId()) == 12 || std::abs(genParticleList[i].pdgId()) == 14 ||
+          std::abs(genParticleList[i].pdgId()) == 16 || std::abs(genParticleList[i].pdgId()) < 7 ||
+          std::abs(genParticleList[i].pdgId()) == 21) {
+        trueMEX += genParticleList[i].px();
+        trueMEY += genParticleList[i].py();
       } else {
-	true_set += genParticleList[i].pt();
+        true_set += genParticleList[i].pt();
       }
     }
   }
   true_mex = -trueMEX;
   true_mey = -trueMEY;
-  true_met = sqrt( trueMEX*trueMEX + trueMEY*trueMEY );
-  true_phi = atan2(trueMEY,trueMEX);
-  rec_met  = pfm.pt();
-  rec_mex  = pfm.px();
-  rec_mex  = pfm.py();
-  rec_phi  = pfm.phi();
-  rec_set  = pfm.sumEt();
+  true_met = sqrt(trueMEX * trueMEX + trueMEY * trueMEY);
+  true_phi = atan2(trueMEY, trueMEX);
+  rec_met = pfm.pt();
+  rec_mex = pfm.px();
+  rec_mex = pfm.py();
+  rec_phi = pfm.phi();
+  rec_set = pfm.sumEt();
 
   // propagation of the JEC to the caloMET:
   double caloJetCorPX = 0.0;
   double caloJetCorPY = 0.0;
 
-  for(unsigned int caloJetc=0;caloJetc<caloJets.size();++caloJetc)
-  {
+  for (unsigned int caloJetc = 0; caloJetc < caloJets.size(); ++caloJetc) {
     //std::cout << "caloJets[" << caloJetc << "].pt() = " << caloJets[caloJetc].pt() << std::endl;
     //std::cout << "caloJets[" << caloJetc << "].phi() = " << caloJets[caloJetc].phi() << std::endl;
     //std::cout << "caloJets[" << caloJetc << "].eta() = " << caloJets[caloJetc].eta() << std::endl;
     //}
-    for(unsigned int corr_caloJetc=0;corr_caloJetc<corr_caloJets.size();++corr_caloJetc)
-    {
+    for (unsigned int corr_caloJetc = 0; corr_caloJetc < corr_caloJets.size(); ++corr_caloJetc) {
       //std::cout << "corr_caloJets[" << corr_caloJetc << "].pt() = " << corr_caloJets[corr_caloJetc].pt() << std::endl;
       //std::cout << "corr_caloJets[" << corr_caloJetc << "].phi() = " << corr_caloJets[corr_caloJetc].phi() << std::endl;
       //std::cout << "corr_caloJets[" << corr_caloJetc << "].eta() = " << corr_caloJets[corr_caloJetc].eta() << std::endl;
       //}
       Float_t DeltaPhi = corr_caloJets[corr_caloJetc].phi() - caloJets[caloJetc].phi();
       Float_t DeltaEta = corr_caloJets[corr_caloJetc].eta() - caloJets[caloJetc].eta();
-      Float_t DeltaR2 = DeltaPhi*DeltaPhi + DeltaEta*DeltaEta;
-      if( DeltaR2 < 0.0001 && caloJets[caloJetc].pt() > 20.0 ) 
-      {
-	caloJetCorPX += (corr_caloJets[corr_caloJetc].px() - caloJets[caloJetc].px());
-	caloJetCorPY += (corr_caloJets[corr_caloJetc].py() - caloJets[caloJetc].py());
+      Float_t DeltaR2 = DeltaPhi * DeltaPhi + DeltaEta * DeltaEta;
+      if (DeltaR2 < 0.0001 && caloJets[caloJetc].pt() > 20.0) {
+        caloJetCorPX += (corr_caloJets[corr_caloJetc].px() - caloJets[caloJetc].px());
+        caloJetCorPY += (corr_caloJets[corr_caloJetc].py() - caloJets[caloJetc].py());
       }
     }
   }
-  double corr_calomet=sqrt((cm.px()-caloJetCorPX)*(cm.px()-caloJetCorPX)+(cm.py()-caloJetCorPY)*(cm.py()-caloJetCorPY));
+  double corr_calomet =
+      sqrt((cm.px() - caloJetCorPX) * (cm.px() - caloJetCorPX) + (cm.py() - caloJetCorPY) * (cm.py() - caloJetCorPY));
   calo_met = corr_calomet;
-  calo_mex = cm.px()-caloJetCorPX;
-  calo_mey = cm.py()-caloJetCorPY;
-  calo_phi = atan2((cm.py()-caloJetCorPY),(cm.px()-caloJetCorPX));
+  calo_mex = cm.px() - caloJetCorPX;
+  calo_mey = cm.py() - caloJetCorPY;
+  calo_phi = atan2((cm.py() - caloJetCorPY), (cm.px() - caloJetCorPX));
   //calo_met = cm.pt();
   //calo_mex = cm.px();
   //calo_mey = cm.py();
@@ -411,23 +411,22 @@ void PFMETBenchmark::calculateQuantities( const reco::PFMETCollection& pfMets,
   tc_set = tcm.sumEt();
 
   if (debug_) {
-    cout << "  =========PFMET  " << rec_met  << ", " << rec_phi  << endl;
+    cout << "  =========PFMET  " << rec_met << ", " << rec_phi << endl;
     cout << "  =========trueMET " << true_met << ", " << true_phi << endl;
     cout << "  =========CaloMET " << calo_met << ", " << calo_phi << endl;
     cout << "  =========TCMET " << tc_met << ", " << tc_phi << endl;
-  }			
+  }
 }
 
 //double fitf(double *x, double *par)
 //{
-//  double fitval = sqrt( par[0]*par[0] + 
-//			par[1]*par[1]*(x[0]-par[3]) + 
+//  double fitval = sqrt( par[0]*par[0] +
+//			par[1]*par[1]*(x[0]-par[3]) +
 //			par[2]*par[2]*(x[0]-par[3])*(x[0]-par[3]) );
 //  return fitval;
 //}
 
-void PFMETBenchmark::analyse() 
-{
+void PFMETBenchmark::analyse() {
   //Define fit functions and histograms
   //TF1* func1 = new TF1("fit1", fitf, 0, 40, 4);
   //TF1* func2 = new TF1("fit2", fitf, 0, 40, 4);
@@ -437,8 +436,8 @@ void PFMETBenchmark::analyse()
   //fit gaussian to Delta MET corresponding to different slices in MET, store fit values (mean,sigma) in histos
   ////FitSlicesInY(hSETvsDeltaMET, hmeanPF, hrmsPF, false, 1); //set option flag for RMS or gaussian
   ////FitSlicesInY(hSETvsDeltaMET, hmeanPF, hsigmaPF, true, 1); //set option flag for RMS or gaussian
-  ////FitSlicesInY(hCaloSETvsDeltaCaloMET, hmeanCalo, hrmsCalo, false, 2); 
-  ////FitSlicesInY(hCaloSETvsDeltaCaloMET, hmeanCalo, hsigmaCalo, true, 2); 
+  ////FitSlicesInY(hCaloSETvsDeltaCaloMET, hmeanCalo, hrmsCalo, false, 2);
+  ////FitSlicesInY(hCaloSETvsDeltaCaloMET, hmeanCalo, hsigmaCalo, true, 2);
 
   ////SETAXES(meanPF,    "SET", "Mean(MEX)");
   ////SETAXES(meanCalo,  "SET", "Mean(MEX)");
@@ -539,7 +538,7 @@ void PFMETBenchmark::analyse()
 //
 //  //default is to fit with a gaussian
 //  TF1 *f1 = 0;
-//  if (f1 == 0) 
+//  if (f1 == 0)
 //    {
 //      //f1 = (TF1*)gROOT->GetFunction("gaus");
 //      if (f1 == 0) f1 = new TF1("gaus","gaus", fYaxis->GetXmin(), fYaxis->GetXmax());
@@ -560,22 +559,22 @@ void PFMETBenchmark::analyse()
 //  char *name   = new char[2000];
 //  char *title  = new char[2000];
 //  const TArrayD *bins = fXaxis->GetXbins();
-//  for( ipar=0; ipar < npar; ipar++ ) 
+//  for( ipar=0; ipar < npar; ipar++ )
 //    {
-//      if( ipar == 1 ) 
+//      if( ipar == 1 )
 //	if( type == 1 )   sprintf(name,"meanPF");
 //	else              sprintf(name,"meanCalo");
 //      else
-//	if( doGausFit ) 
+//	if( doGausFit )
 //	  if( type == 1 ) sprintf(name,"sigmaPF");
 //	  else            sprintf(name,"sigmaCalo");
-//	else 
+//	else
 //	  if( type == 1 ) sprintf(name,"rmsPF");
 //	  else            sprintf(name,"rmsCalo");
 //      if( type == 1 )     sprintf(title,"Particle Flow");
 //      else                sprintf(title,"Calorimeter");
 //      delete gDirectory->FindObject(name);
-//      if (bins->fN == 0) 
+//      if (bins->fN == 0)
 //	hlist[ipar] = new TH1F(name,title, nbins, fXaxis->GetXmin(), fXaxis->GetXmax());
 //      else
 //	hlist[ipar] = new TH1F(name,title, nbins,bins->fArray);
@@ -589,7 +588,7 @@ void PFMETBenchmark::analyse()
 //  //Loop on all bins in X, generate a projection along Y
 //  Int_t bin;
 //  Int_t nentries;
-//  for( bin = (Int_t) binmin; bin <= (Int_t) binmax; bin += (Int_t)ngroup ) 
+//  for( bin = (Int_t) binmin; bin <= (Int_t) binmax; bin += (Int_t)ngroup )
 //    {
 //      TH1F *hpy = (TH1F*) h->ProjectionY("_temp", (Int_t) bin, (Int_t) (bin + ngroup - 1), "e");
 //      if(hpy == 0) continue;
@@ -597,12 +596,12 @@ void PFMETBenchmark::analyse()
 //      if(nentries == 0 ) {delete hpy; continue;}
 //      f1->SetParameters(parsave);
 //      hpy->Fit( f1, opt.Data() );
-//      Int_t npfits = f1->GetNumberFitPoints(); 
+//      Int_t npfits = f1->GetNumberFitPoints();
 //      //cout << "bin = " << bin << "; Npfits = " << npfits << "; npar = " << npar << endl;
-//      if( npfits > npar ) 
+//      if( npfits > npar )
 //	{
 //	  Int_t biny = bin + (Int_t)ngroup/2;
-//	  for( ipar=0; ipar < npar; ipar++ ) 
+//	  for( ipar=0; ipar < npar; ipar++ )
 //	    {
 //	      if( doGausFit ) hlist[ipar]->Fill( fXaxis->GetBinCenter(biny), f1->GetParameter(ipar) );
 //	      else            hlist[ipar]->Fill( fXaxis->GetBinCenter(biny), hpy->GetRMS() );
@@ -619,13 +618,12 @@ void PFMETBenchmark::analyse()
 //  cout << "Entries = " << hlist[0]->GetEntries() << endl;
 //}
 
-double   
-PFMETBenchmark::mpi_pi(double angle) {
-
+double PFMETBenchmark::mpi_pi(double angle) {
   const double pi = 3.14159265358979323;
-  const double pi2 = pi*2.;
-  while(angle>pi) angle -= pi2;
-  while(angle<-pi) angle += pi2;
+  const double pi2 = pi * 2.;
+  while (angle > pi)
+    angle -= pi2;
+  while (angle < -pi)
+    angle += pi2;
   return angle;
-
 }

--- a/RecoParticleFlow/Benchmark/src/PFTauElecRejectionBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFTauElecRejectionBenchmark.cc
@@ -1,20 +1,20 @@
 #include "RecoParticleFlow/Benchmark/interface/PFTauElecRejectionBenchmark.h"
 
 // preprocessor macro for booking 1d histos with DQMStore -or- bare Root
-#define BOOK1D(name,title,nbinsx,lowx,highx) \
-  h##name = db_ ? db_->book1D(#name,title,nbinsx,lowx,highx)->getTH1F() \
-    : new TH1F(#name,title,nbinsx,lowx,highx)
+#define BOOK1D(name, title, nbinsx, lowx, highx) \
+  h##name =                                      \
+      db_ ? db_->book1D(#name, title, nbinsx, lowx, highx)->getTH1F() : new TH1F(#name, title, nbinsx, lowx, highx)
 
 // preprocessor macro for booking 2d histos with DQMStore -or- bare Root
-#define BOOK2D(name,title,nbinsx,lowx,highx,nbinsy,lowy,highy) \
-  h##name = db_ ? db_->book2D(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)->getTH2F() \
-    : new TH2F(#name,title,nbinsx,lowx,highx,nbinsy,lowy,highy)
+#define BOOK2D(name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)                            \
+  h##name = db_ ? db_->book2D(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)->getTH2F() \
+                : new TH2F(#name, title, nbinsx, lowx, highx, nbinsy, lowy, highy)
 
 // all versions OK
 // preprocesor macro for setting axis titles
-#define SETAXES(name,xtitle,ytitle) \
-  h##name->GetXaxis()->SetTitle(xtitle); h##name->GetYaxis()->SetTitle(ytitle)
-
+#define SETAXES(name, xtitle, ytitle)    \
+  h##name->GetXaxis()->SetTitle(xtitle); \
+  h##name->GetYaxis()->SetTitle(ytitle)
 
 using namespace reco;
 using namespace std;
@@ -24,55 +24,52 @@ class MonitorElement;
 PFTauElecRejectionBenchmark::PFTauElecRejectionBenchmark() : file_(nullptr) {}
 
 PFTauElecRejectionBenchmark::~PFTauElecRejectionBenchmark() {
-  if(file_) file_->Close();
+  if (file_)
+    file_->Close();
 }
 
 void PFTauElecRejectionBenchmark::write() {
-   // Store the DAQ Histograms 
+  // Store the DAQ Histograms
   if (!outputFile_.empty()) {
     if (db_)
-          db_->save(outputFile_);
+      db_->save(outputFile_);
     // use bare Root if no DQM (FWLite applications)
     else if (file_) {
-       file_->Write(outputFile_.c_str());
-       cout << "Benchmark output written to file " << outputFile_.c_str() << endl;
-       file_->Close();
-       }
-  }
-  else 
-    cout << "No output file specified ("<<outputFile_<<"). Results will not be saved!" << endl;
-    
-} 
+      file_->Write(outputFile_.c_str());
+      cout << "Benchmark output written to file " << outputFile_.c_str() << endl;
+      file_->Close();
+    }
+  } else
+    cout << "No output file specified (" << outputFile_ << "). Results will not be saved!" << endl;
+}
 
-
-void PFTauElecRejectionBenchmark::setup(
-					string Filename,
-					string benchmarkLabel,
-					double maxDeltaR, 
-					double minRecoPt, 
-					double maxRecoAbsEta, 
-					double minMCPt, 
-					double maxMCAbsEta, 
-					string sGenMatchObjectLabel,
-					bool applyEcalCrackCut,
-					DQMStore * db_store) {
+void PFTauElecRejectionBenchmark::setup(string Filename,
+                                        string benchmarkLabel,
+                                        double maxDeltaR,
+                                        double minRecoPt,
+                                        double maxRecoAbsEta,
+                                        double minMCPt,
+                                        double maxMCAbsEta,
+                                        string sGenMatchObjectLabel,
+                                        bool applyEcalCrackCut,
+                                        DQMStore* db_store) {
   maxDeltaR_ = maxDeltaR;
   benchmarkLabel_ = benchmarkLabel;
-  outputFile_=Filename;
+  outputFile_ = Filename;
   minRecoPt_ = minRecoPt;
-  maxRecoAbsEta_= maxRecoAbsEta;
+  maxRecoAbsEta_ = maxRecoAbsEta;
   minMCPt_ = minMCPt;
-  maxMCAbsEta_= maxMCAbsEta;
+  maxMCAbsEta_ = maxMCAbsEta;
   sGenMatchObjectLabel_ = sGenMatchObjectLabel;
-  applyEcalCrackCut_= applyEcalCrackCut;
+  applyEcalCrackCut_ = applyEcalCrackCut;
 
   file_ = nullptr;
   db_ = db_store;
 
   // print parameters
-  cout<< "PFTauElecRejectionBenchmark Setup parameters =============================================="<<endl;
-  cout << "Filename to write histograms " << Filename<<endl;
-  cout << "Benchmark label name " << benchmarkLabel_<<endl;
+  cout << "PFTauElecRejectionBenchmark Setup parameters ==============================================" << endl;
+  cout << "Filename to write histograms " << Filename << endl;
+  cout << "Benchmark label name " << benchmarkLabel_ << endl;
   cout << "maxDeltaRMax " << maxDeltaR << endl;
   cout << "minRecoPt " << minRecoPt_ << endl;
   cout << "maxRecoAbsEta " << maxRecoAbsEta_ << endl;
@@ -84,285 +81,267 @@ void PFTauElecRejectionBenchmark::setup(
   // Book histogram
 
   // Establish DQM Store
-  string path = "PFTask/Benchmarks/"+ benchmarkLabel_ + "/";
+  string path = "PFTask/Benchmarks/" + benchmarkLabel_ + "/";
   path += "Gen";
   if (db_) {
     db_->setCurrentFolder(path);
-  }
-  else {
+  } else {
     file_ = new TFile(outputFile_.c_str(), "recreate");
-    cout << "Info: DQM is not available to provide data storage service. Using TFile to save histograms. "<<endl;
+    cout << "Info: DQM is not available to provide data storage service. Using TFile to save histograms. " << endl;
   }
 
   // E/p
-  BOOK1D(EoverP,"E/p",100, 0., 4.);
+  BOOK1D(EoverP, "E/p", 100, 0., 4.);
   SETAXES(EoverP, "E/p", "Entries");
 
-  BOOK1D(EoverP_barrel,"E/p barrel",100, 0., 4.);
+  BOOK1D(EoverP_barrel, "E/p barrel", 100, 0., 4.);
   SETAXES(EoverP_barrel, "E/p barrel", "Entries");
 
-  BOOK1D(EoverP_endcap,"E/p endcap",100, 0., 4.);
+  BOOK1D(EoverP_endcap, "E/p endcap", 100, 0., 4.);
   SETAXES(EoverP_endcap, "E/p endcap", "Entries");
 
-  BOOK1D(EoverP_preid0,"E/p (preid=0)",100, 0., 4.);
+  BOOK1D(EoverP_preid0, "E/p (preid=0)", 100, 0., 4.);
   SETAXES(EoverP_preid0, "E/p", "Entries");
 
-  BOOK1D(EoverP_preid1,"E/p (preid=1)",100, 0., 4.);
+  BOOK1D(EoverP_preid1, "E/p (preid=1)", 100, 0., 4.);
   SETAXES(EoverP_preid1, "E/p", "Entries");
 
   // H/p
-  BOOK1D(HoverP,"H/p",100, 0., 2.);
+  BOOK1D(HoverP, "H/p", 100, 0., 2.);
   SETAXES(HoverP, "H/p", "Entries");
 
-  BOOK1D(HoverP_barrel,"H/p barrel",100, 0., 2.);
+  BOOK1D(HoverP_barrel, "H/p barrel", 100, 0., 2.);
   SETAXES(HoverP_barrel, "H/p barrel", "Entries");
 
-  BOOK1D(HoverP_endcap,"H/p endcap",100, 0., 2.);
+  BOOK1D(HoverP_endcap, "H/p endcap", 100, 0., 2.);
   SETAXES(HoverP_endcap, "H/p endcap", "Entries");
 
-  BOOK1D(HoverP_preid0,"H/p (preid=0)",100, 0., 2.);
+  BOOK1D(HoverP_preid0, "H/p (preid=0)", 100, 0., 2.);
   SETAXES(HoverP_preid0, "H/p", "Entries");
 
-  BOOK1D(HoverP_preid1,"H/p (preid=1)",100, 0., 2.);
+  BOOK1D(HoverP_preid1, "H/p (preid=1)", 100, 0., 2.);
   SETAXES(HoverP_preid1, "H/p", "Entries");
 
   // emfrac
-  BOOK1D(Emfrac,"EM fraction",100, 0., 1.01);
+  BOOK1D(Emfrac, "EM fraction", 100, 0., 1.01);
   SETAXES(Emfrac, "em fraction", "Entries");
 
-  BOOK1D(Emfrac_barrel,"EM fraction barrel",100, 0., 1.01);
+  BOOK1D(Emfrac_barrel, "EM fraction barrel", 100, 0., 1.01);
   SETAXES(Emfrac_barrel, "em fraction barrel", "Entries");
 
-  BOOK1D(Emfrac_endcap,"EM fraction endcap",100, 0., 1.01);
+  BOOK1D(Emfrac_endcap, "EM fraction endcap", 100, 0., 1.01);
   SETAXES(Emfrac_endcap, "em fraction endcap", "Entries");
 
-  BOOK1D(Emfrac_preid0,"EM fraction (preid=0)",100, 0., 1.01);
+  BOOK1D(Emfrac_preid0, "EM fraction (preid=0)", 100, 0., 1.01);
   SETAXES(Emfrac_preid0, "em fraction", "Entries");
 
-  BOOK1D(Emfrac_preid1,"EM fraction (preid=1)",100, 0., 1.01);
+  BOOK1D(Emfrac_preid1, "EM fraction (preid=1)", 100, 0., 1.01);
   SETAXES(Emfrac_preid1, "em fraction", "Entries");
 
   // PreID
-  BOOK1D(ElecPreID,"PFElectron PreID decision",6, 0., 1.01);
+  BOOK1D(ElecPreID, "PFElectron PreID decision", 6, 0., 1.01);
   SETAXES(ElecPreID, "PFElectron PreID decision", "Entries");
 
   // MVA
-  BOOK1D(ElecMVA,"PFElectron MVA",100, -1.01, 1.01);
+  BOOK1D(ElecMVA, "PFElectron MVA", 100, -1.01, 1.01);
   SETAXES(ElecMVA, "PFElectron MVA", "Entries");
 
   // Discriminant
-  BOOK1D(TauElecDiscriminant,"PFTau-Electron Discriminant",6, 0., 1.01);
+  BOOK1D(TauElecDiscriminant, "PFTau-Electron Discriminant", 6, 0., 1.01);
   SETAXES(TauElecDiscriminant, "PFTau-Electron Discriminant", "Entries");
 
-
   // PFCand clusters
-  BOOK1D(pfcand_deltaEta,"PFCand cluster dEta",100, 0., 0.8);
+  BOOK1D(pfcand_deltaEta, "PFCand cluster dEta", 100, 0., 0.8);
   SETAXES(pfcand_deltaEta, "PFCand cluster #Delta(#eta)", "Entries");
 
-  BOOK1D(pfcand_deltaEta_weightE,"PFCand cluster dEta, energy weighted",100, 0., 0.8);
+  BOOK1D(pfcand_deltaEta_weightE, "PFCand cluster dEta, energy weighted", 100, 0., 0.8);
   SETAXES(pfcand_deltaEta_weightE, "PFCand cluster #Delta(#eta)", "Entries");
 
-  BOOK1D(pfcand_deltaPhiOverQ,"PFCand cluster dPhi/q",100, -0.8, 0.8);
+  BOOK1D(pfcand_deltaPhiOverQ, "PFCand cluster dPhi/q", 100, -0.8, 0.8);
   SETAXES(pfcand_deltaPhiOverQ, "PFCand cluster #Delta(#phi)/q", "Entries");
 
-  BOOK1D(pfcand_deltaPhiOverQ_weightE,"PFCand cluster dEta/q, energy weighted",100, -0.8, 0.8);
+  BOOK1D(pfcand_deltaPhiOverQ_weightE, "PFCand cluster dEta/q, energy weighted", 100, -0.8, 0.8);
   SETAXES(pfcand_deltaPhiOverQ_weightE, "PFCand cluster #Delta(#phi)/q", "Entries");
 
-
   // Leading KF track
-  BOOK1D(leadTk_pt,"leading KF track pt",100, 0., 80.);
+  BOOK1D(leadTk_pt, "leading KF track pt", 100, 0., 80.);
   SETAXES(leadTk_pt, "leading KF track p_{T} (GeV)", "Entries");
 
-  BOOK1D(leadTk_eta,"leading KF track eta",100, -4., 4.);
+  BOOK1D(leadTk_eta, "leading KF track eta", 100, -4., 4.);
   SETAXES(leadTk_eta, "leading KF track #eta", "Entries");
 
-  BOOK1D(leadTk_phi,"leading KF track phi",100, -3.2, 3.2);
+  BOOK1D(leadTk_phi, "leading KF track phi", 100, -3.2, 3.2);
   SETAXES(leadTk_phi, "leading KF track #phi", "Entries");
 
   // Leading Gsf track
-  BOOK1D(leadGsfTk_pt,"leading Gsf track pt",100, 0., 80.);
+  BOOK1D(leadGsfTk_pt, "leading Gsf track pt", 100, 0., 80.);
   SETAXES(leadGsfTk_pt, "leading Gsf track p_{T} (GeV)", "Entries");
 
-  BOOK1D(leadGsfTk_eta,"leading Gsf track eta",100, -4., 4.);
+  BOOK1D(leadGsfTk_eta, "leading Gsf track eta", 100, -4., 4.);
   SETAXES(leadGsfTk_eta, "leading Gsf track #eta", "Entries");
 
-  BOOK1D(leadGsfTk_phi,"leading Gsf track phi",100, -3.2, 3.2);
+  BOOK1D(leadGsfTk_phi, "leading Gsf track phi", 100, -3.2, 3.2);
   SETAXES(leadGsfTk_phi, "leading Gsf track #phi", "Entries");
 
-
   // H/p vs E/p
-  BOOK2D(HoPvsEoP,"H/p vs. E/p",100, 0., 2., 100, 0., 2.);
+  BOOK2D(HoPvsEoP, "H/p vs. E/p", 100, 0., 2., 100, 0., 2.);
   SETAXES(HoPvsEoP, "E/p", "H/p");
 
-  BOOK2D(HoPvsEoP_preid0,"H/p vs. E/p (preid=0)",100, 0., 2., 100, 0., 2.);
+  BOOK2D(HoPvsEoP_preid0, "H/p vs. E/p (preid=0)", 100, 0., 2., 100, 0., 2.);
   SETAXES(HoPvsEoP_preid0, "E/p", "H/p");
 
-  BOOK2D(HoPvsEoP_preid1,"H/p vs. E/p (preid=0)",100, 0., 2., 100, 0., 2.);
+  BOOK2D(HoPvsEoP_preid1, "H/p vs. E/p (preid=0)", 100, 0., 2., 100, 0., 2.);
   SETAXES(HoPvsEoP_preid1, "E/p", "H/p");
 
   // em fraction vs E/p
-  BOOK2D(EmfracvsEoP,"emfrac vs. E/p",100, 0., 2., 100, 0., 1.01);
+  BOOK2D(EmfracvsEoP, "emfrac vs. E/p", 100, 0., 2., 100, 0., 1.01);
   SETAXES(EmfracvsEoP, "E/p", "em fraction");
 
-  BOOK2D(EmfracvsEoP_preid0,"emfrac vs. E/p (preid=0)",100, 0., 2., 100, 0., 1.01);
+  BOOK2D(EmfracvsEoP_preid0, "emfrac vs. E/p (preid=0)", 100, 0., 2., 100, 0., 1.01);
   SETAXES(EmfracvsEoP_preid0, "E/p", "em fraction");
 
-  BOOK2D(EmfracvsEoP_preid1,"emfrac vs. E/p (preid=0)",100, 0., 2., 100, 0., 1.01);
+  BOOK2D(EmfracvsEoP_preid1, "emfrac vs. E/p (preid=0)", 100, 0., 2., 100, 0., 1.01);
   SETAXES(EmfracvsEoP_preid1, "E/p", "em fraction");
-
-
 }
 
-
-void PFTauElecRejectionBenchmark::process(edm::Handle<edm::HepMCProduct> mcevt, edm::Handle<reco::PFTauCollection> pfTaus, 
-					  edm::Handle<reco::PFTauDiscriminator> pfTauIsoDiscr, 
-					  edm::Handle<reco::PFTauDiscriminator> pfTauElecDiscr) {
-
-
+void PFTauElecRejectionBenchmark::process(edm::Handle<edm::HepMCProduct> mcevt,
+                                          edm::Handle<reco::PFTauCollection> pfTaus,
+                                          edm::Handle<reco::PFTauDiscriminator> pfTauIsoDiscr,
+                                          edm::Handle<reco::PFTauDiscriminator> pfTauElecDiscr) {
   // Find Gen Objects to be matched with
-  HepMC::GenEvent * generated_event = new HepMC::GenEvent(*(mcevt->GetEvent()));
+  HepMC::GenEvent* generated_event = new HepMC::GenEvent(*(mcevt->GetEvent()));
   _GenObjects.clear();
-  
+
   TLorentzVector taunet;
   HepMC::GenEvent::particle_iterator p;
   for (p = generated_event->particles_begin(); p != generated_event->particles_end(); p++) {
-    if(std::abs((*p)->pdg_id()) == 15&&(*p)->status()==2) { 
-      bool lept_decay = false;     
-      TLorentzVector tau((*p)->momentum().px(),(*p)->momentum().py(),(*p)->momentum().pz(),(*p)->momentum().e());
+    if (std::abs((*p)->pdg_id()) == 15 && (*p)->status() == 2) {
+      bool lept_decay = false;
+      TLorentzVector tau((*p)->momentum().px(), (*p)->momentum().py(), (*p)->momentum().pz(), (*p)->momentum().e());
       HepMC::GenVertex::particle_iterator z = (*p)->end_vertex()->particles_begin(HepMC::descendants);
-      for(; z != (*p)->end_vertex()->particles_end(HepMC::descendants); z++) {
-	if(std::abs((*z)->pdg_id()) == 11 || std::abs((*z)->pdg_id()) == 13) lept_decay=true;
-	if(std::abs((*z)->pdg_id()) == 16)
-	  taunet.SetPxPyPzE((*z)->momentum().px(),(*z)->momentum().py(),(*z)->momentum().pz(),(*z)->momentum().e());
-	
+      for (; z != (*p)->end_vertex()->particles_end(HepMC::descendants); z++) {
+        if (std::abs((*z)->pdg_id()) == 11 || std::abs((*z)->pdg_id()) == 13)
+          lept_decay = true;
+        if (std::abs((*z)->pdg_id()) == 16)
+          taunet.SetPxPyPzE((*z)->momentum().px(), (*z)->momentum().py(), (*z)->momentum().pz(), (*z)->momentum().e());
       }
-      if(lept_decay==false) {
-	TLorentzVector jetMom=tau-taunet;
-	if (sGenMatchObjectLabel_=="tau") _GenObjects.push_back(jetMom);
+      if (lept_decay == false) {
+        TLorentzVector jetMom = tau - taunet;
+        if (sGenMatchObjectLabel_ == "tau")
+          _GenObjects.push_back(jetMom);
       }
-    } else if(std::abs((*p)->pdg_id()) == 11&&(*p)->status()==1) { 
-      TLorentzVector elec((*p)->momentum().px(),(*p)->momentum().py(),(*p)->momentum().pz(),(*p)->momentum().e());
-      if (sGenMatchObjectLabel_=="e") _GenObjects.push_back(elec);
-    } 
+    } else if (std::abs((*p)->pdg_id()) == 11 && (*p)->status() == 1) {
+      TLorentzVector elec((*p)->momentum().px(), (*p)->momentum().py(), (*p)->momentum().pz(), (*p)->momentum().e());
+      if (sGenMatchObjectLabel_ == "e")
+        _GenObjects.push_back(elec);
+    }
   }
- 
+
   ////////////
 
-  
   // Loop over all PFTaus
   math::XYZPointF myleadTkEcalPos;
-  for (PFTauCollection::size_type iPFTau=0;iPFTau<pfTaus->size();iPFTau++) { 
-    PFTauRef thePFTau(pfTaus,iPFTau); 
+  for (PFTauCollection::size_type iPFTau = 0; iPFTau < pfTaus->size(); iPFTau++) {
+    PFTauRef thePFTau(pfTaus, iPFTau);
     if ((*pfTauIsoDiscr)[thePFTau] == 1) {
       if ((*thePFTau).et() > minRecoPt_ && std::abs((*thePFTau).eta()) < maxRecoAbsEta_) {
+        // Check if track goes to Ecal crack
+        reco::TrackRef myleadTk;
+        const reco::PFCandidatePtr& pflch = thePFTau->leadPFChargedHadrCand();
+        if (pflch.isNonnull()) {
+          myleadTk = pflch->trackRef();
+          myleadTkEcalPos = pflch->positionAtECALEntrance();
 
-	// Check if track goes to Ecal crack
-	reco::TrackRef myleadTk;
-	const reco::PFCandidatePtr& pflch = thePFTau->leadPFChargedHadrCand();
-	if(pflch.isNonnull()){
-	  myleadTk=pflch->trackRef();
-	  myleadTkEcalPos = pflch->positionAtECALEntrance();
-	  
-	  if(myleadTk.isNonnull()){ 
-	    if (applyEcalCrackCut_ && isInEcalCrack(std::abs((double)myleadTkEcalPos.eta()))) {
-	      continue; // do nothing
-	    } else {
+          if (myleadTk.isNonnull()) {
+            if (applyEcalCrackCut_ && isInEcalCrack(std::abs((double)myleadTkEcalPos.eta()))) {
+              continue;  // do nothing
+            } else {
+              // Match with gen object
+              for (unsigned int i = 0; i < _GenObjects.size(); i++) {
+                if (_GenObjects[i].Et() >= minMCPt_ && std::abs(_GenObjects[i].Eta()) < maxMCAbsEta_) {
+                  TLorentzVector pftau((*thePFTau).px(), (*thePFTau).py(), (*thePFTau).pz(), (*thePFTau).energy());
+                  double GenDeltaR = pftau.DeltaR(_GenObjects[i]);
+                  if (GenDeltaR < maxDeltaR_) {
+                    hleadTk_pt->Fill((float)myleadTk->pt());
+                    hleadTk_eta->Fill((float)myleadTk->eta());
+                    hleadTk_phi->Fill((float)myleadTk->phi());
 
-	      // Match with gen object
-	      for (unsigned int i = 0; i<_GenObjects.size();i++) {
-		if (_GenObjects[i].Et() >= minMCPt_ && std::abs(_GenObjects[i].Eta()) < maxMCAbsEta_ ) {
-		  TLorentzVector pftau((*thePFTau).px(),(*thePFTau).py(),(*thePFTau).pz(),(*thePFTau).energy());
-		  double GenDeltaR = pftau.DeltaR(_GenObjects[i]);
-		  if (GenDeltaR<maxDeltaR_) {
-		    
-		    hleadTk_pt->Fill((float)myleadTk->pt());
-		    hleadTk_eta->Fill((float)myleadTk->eta());
-		    hleadTk_phi->Fill((float)myleadTk->phi());
+                    hEoverP->Fill((*thePFTau).ecalStripSumEOverPLead());
+                    hHoverP->Fill((*thePFTau).hcal3x3OverPLead());
+                    hEmfrac->Fill((*thePFTau).emFraction());
 
-		    hEoverP->Fill((*thePFTau).ecalStripSumEOverPLead());
-		    hHoverP->Fill((*thePFTau).hcal3x3OverPLead());
-		    hEmfrac->Fill((*thePFTau).emFraction());
+                    if (std::abs(myleadTk->eta()) < 1.5) {
+                      hEoverP_barrel->Fill((*thePFTau).ecalStripSumEOverPLead());
+                      hHoverP_barrel->Fill((*thePFTau).hcal3x3OverPLead());
+                      hEmfrac_barrel->Fill((*thePFTau).emFraction());
+                    } else if (std::abs(myleadTk->eta()) > 1.5 && std::abs(myleadTk->eta()) < 2.5) {
+                      hEoverP_endcap->Fill((*thePFTau).ecalStripSumEOverPLead());
+                      hHoverP_endcap->Fill((*thePFTau).hcal3x3OverPLead());
+                      hEmfrac_endcap->Fill((*thePFTau).emFraction());
+                    }
 
-		    if (std::abs(myleadTk->eta())<1.5) {
-		      hEoverP_barrel->Fill((*thePFTau).ecalStripSumEOverPLead());
-		      hHoverP_barrel->Fill((*thePFTau).hcal3x3OverPLead());
-		      hEmfrac_barrel->Fill((*thePFTau).emFraction());
-		    } else if (std::abs(myleadTk->eta())>1.5 && std::abs(myleadTk->eta())<2.5) {
-		      hEoverP_endcap->Fill((*thePFTau).ecalStripSumEOverPLead());
-		      hHoverP_endcap->Fill((*thePFTau).hcal3x3OverPLead());
-		      hEmfrac_endcap->Fill((*thePFTau).emFraction());
-		    }
+                    // if -999 fill in -1 bin!
+                    if ((*thePFTau).electronPreIDOutput() < -1)
+                      hElecMVA->Fill(-1);
+                    else
+                      hElecMVA->Fill((*thePFTau).electronPreIDOutput());
 
-		    // if -999 fill in -1 bin!
-		    if ((*thePFTau).electronPreIDOutput()<-1)
-		      hElecMVA->Fill(-1);
-		    else
-		      hElecMVA->Fill((*thePFTau).electronPreIDOutput());
+                    hTauElecDiscriminant->Fill((*pfTauElecDiscr)[thePFTau]);
 
-		    hTauElecDiscriminant->Fill((*pfTauElecDiscr)[thePFTau]);
+                    hHoPvsEoP->Fill((*thePFTau).ecalStripSumEOverPLead(), (*thePFTau).hcal3x3OverPLead());
+                    hEmfracvsEoP->Fill((*thePFTau).emFraction(), (*thePFTau).hcal3x3OverPLead());
 
-		    hHoPvsEoP->Fill((*thePFTau).ecalStripSumEOverPLead(),(*thePFTau).hcal3x3OverPLead());
-		    hEmfracvsEoP->Fill((*thePFTau).emFraction(),(*thePFTau).hcal3x3OverPLead());
+                    if ((*thePFTau).electronPreIDDecision() == 1) {
+                      hEoverP_preid1->Fill((*thePFTau).ecalStripSumEOverPLead());
+                      hHoverP_preid1->Fill((*thePFTau).hcal3x3OverPLead());
+                      hEmfrac_preid1->Fill((*thePFTau).emFraction());
+                      hHoPvsEoP_preid1->Fill((*thePFTau).ecalStripSumEOverPLead(), (*thePFTau).hcal3x3OverPLead());
+                      hEmfracvsEoP_preid1->Fill((*thePFTau).emFraction(), (*thePFTau).hcal3x3OverPLead());
+                    } else {
+                      hEoverP_preid0->Fill((*thePFTau).ecalStripSumEOverPLead());
+                      hHoverP_preid0->Fill((*thePFTau).hcal3x3OverPLead());
+                      hEmfrac_preid0->Fill((*thePFTau).emFraction());
+                      hHoPvsEoP_preid0->Fill((*thePFTau).ecalStripSumEOverPLead(), (*thePFTau).hcal3x3OverPLead());
+                      hEmfracvsEoP_preid0->Fill((*thePFTau).emFraction(), (*thePFTau).hcal3x3OverPLead());
+                    }
+                  }
+                }
 
-		    if ((*thePFTau).electronPreIDDecision()==1) {
-		      hEoverP_preid1->Fill((*thePFTau).ecalStripSumEOverPLead());
-		      hHoverP_preid1->Fill((*thePFTau).hcal3x3OverPLead());
-		      hEmfrac_preid1->Fill((*thePFTau).emFraction());
-		      hHoPvsEoP_preid1->Fill((*thePFTau).ecalStripSumEOverPLead(),(*thePFTau).hcal3x3OverPLead());
-		      hEmfracvsEoP_preid1->Fill((*thePFTau).emFraction(),(*thePFTau).hcal3x3OverPLead());
-		    } else {
-		      hEoverP_preid0->Fill((*thePFTau).ecalStripSumEOverPLead());
-		      hHoverP_preid0->Fill((*thePFTau).hcal3x3OverPLead());
-		      hEmfrac_preid0->Fill((*thePFTau).emFraction());
-		      hHoPvsEoP_preid0->Fill((*thePFTau).ecalStripSumEOverPLead(),(*thePFTau).hcal3x3OverPLead());
-		      hEmfracvsEoP_preid0->Fill((*thePFTau).emFraction(),(*thePFTau).hcal3x3OverPLead());
-		    }
+                // Loop over all PFCands for cluster plots
+                std::vector<CandidatePtr> myPFCands = (*thePFTau).pfTauTagInfoRef()->PFCands();
+                for (int i = 0; i < (int)myPFCands.size(); i++) {
+                  const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(myPFCands[i].get());
+                  if (pfCand == nullptr)
+                    continue;
 
+                  math::XYZPointF candPos;
+                  if (std::abs(pfCand->pdgId()) == 211 ||
+                      std::abs(pfCand->pdgId()) == 11)  // if charged hadron or electron
+                    candPos = pfCand->positionAtECALEntrance();
+                  else
+                    candPos = math::XYZPointF(pfCand->px(), pfCand->py(), pfCand->pz());
 
-		  }
-		}
+                  //double deltaR   = ROOT::Math::VectorUtil::DeltaR(myleadTkEcalPos,candPos);
+                  double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myleadTkEcalPos, candPos);
+                  double deltaEta = std::abs(myleadTkEcalPos.eta() - myPFCands[i]->eta());
+                  double deltaPhiOverQ = deltaPhi / (double)myleadTk->charge();
 
-		// Loop over all PFCands for cluster plots  
-		std::vector<CandidatePtr> myPFCands=(*thePFTau).pfTauTagInfoRef()->PFCands();
-		for(int i=0;i<(int)myPFCands.size();i++){
-		  const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(myPFCands[i].get());
-		  if (pfCand == nullptr)
-		    continue;
-		  
-		  math::XYZPointF candPos;
-		  if (std::abs(pfCand->pdgId()) == 211 || std::abs(pfCand->pdgId()) == 11) // if charged hadron or electron
-		    candPos = pfCand->positionAtECALEntrance();
-		  else
-		    candPos = math::XYZPointF(pfCand->px(),pfCand->py(),pfCand->pz());
-
-		  //double deltaR   = ROOT::Math::VectorUtil::DeltaR(myleadTkEcalPos,candPos);
-		  double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myleadTkEcalPos,candPos);
-		  double deltaEta = std::abs(myleadTkEcalPos.eta()-myPFCands[i]->eta());
-		  double deltaPhiOverQ = deltaPhi/(double)myleadTk->charge();
-		  
-		  hpfcand_deltaEta->Fill(deltaEta);
-		  hpfcand_deltaEta_weightE->Fill(deltaEta*pfCand->ecalEnergy());
-		  hpfcand_deltaPhiOverQ->Fill(deltaPhiOverQ);
-		  hpfcand_deltaPhiOverQ_weightE->Fill(deltaPhiOverQ*pfCand->ecalEnergy());	
-		  
-		}
-
-	      }
-
-	    }
-	  }
-	}
-
+                  hpfcand_deltaEta->Fill(deltaEta);
+                  hpfcand_deltaEta_weightE->Fill(deltaEta * pfCand->ecalEnergy());
+                  hpfcand_deltaPhiOverQ->Fill(deltaPhiOverQ);
+                  hpfcand_deltaPhiOverQ_weightE->Fill(deltaPhiOverQ * pfCand->ecalEnergy());
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
 }
 
 // Ecal crack  map from Egamma POG
-bool PFTauElecRejectionBenchmark::isInEcalCrack(double eta) const{  
-  return (eta < 0.018 || 
-	  (eta>0.423 && eta<0.461) ||
-	  (eta>0.770 && eta<0.806) ||
-	  (eta>1.127 && eta<1.163) ||
-	  (eta>1.460 && eta<1.558));
+bool PFTauElecRejectionBenchmark::isInEcalCrack(double eta) const {
+  return (eta < 0.018 || (eta > 0.423 && eta < 0.461) || (eta > 0.770 && eta < 0.806) || (eta > 1.127 && eta < 1.163) ||
+          (eta > 1.460 && eta < 1.558));
 }

--- a/RecoTracker/TrackProducer/interface/AlgoProductTraits.h
+++ b/RecoTracker/TrackProducer/interface/AlgoProductTraits.h
@@ -6,18 +6,17 @@
 #include <vector>
 class Trajectory;
 
-
 template <class T>
 class AlgoProductTraits {
 public:
-  using TrackCollection=std::vector<T>;
-  using TrackView=edm::View<T>;
-  struct  AlgoProduct {
-    Trajectory * trajectory;
-    T * track;
+  using TrackCollection = std::vector<T>;
+  using TrackView = edm::View<T>;
+  struct AlgoProduct {
+    Trajectory* trajectory;
+    T* track;
     PropagationDirection pDir;
     int indexInput;
   };
-  using AlgoProductCollection = std::vector< AlgoProduct >;
+  using AlgoProductCollection = std::vector<AlgoProduct>;
 };
 #endif  //AlgoProductTraits_H

--- a/RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h
@@ -8,9 +8,7 @@
 #ifndef DAFTrackProducerAlgorithm_h
 #define DAFTrackProducerAlgorithm_h
 
-
 #include "AlgoProductTraits.h"
-
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
@@ -29,8 +27,8 @@ class TrajectoryStateOnSurface;
 class TransientTrackingRecHitBuilder;
 class MultiRecHitCollector;
 class SiTrackerMultiRecHitUpdator;
-namespace reco{
-	class Track;
+namespace reco {
+  class Track;
 }
 
 class DAFTrackProducerAlgorithm : public AlgoProductTraits<reco::Track> {
@@ -39,74 +37,70 @@ public:
   using TrackCollection = typename Base::TrackCollection;
   using AlgoProductCollection = typename Base::AlgoProductCollection;
 
-  using TrajAnnealingCollection=std::vector<TrajAnnealing>;
+  using TrajAnnealingCollection = std::vector<TrajAnnealing>;
 
 public:
- 
   DAFTrackProducerAlgorithm(const edm::ParameterSet& conf);
   ~DAFTrackProducerAlgorithm() {}
-  
-  /// Run the Final Fit taking TrackCandidates as input
-  void runWithCandidate(const TrackingGeometry *, 
-			const MagneticField *, 
-			//const TrackCandidateCollection&,
-			const TrajTrackAssociationCollection&,
-			const MeasurementTrackerEvent *measTk,
-			const TrajectoryFitter *,
-			const TransientTrackingRecHitBuilder*,
-			const MultiRecHitCollector* measurementTracker,
-			const SiTrackerMultiRecHitUpdator*,
-			const reco::BeamSpot&,
-			AlgoProductCollection &,
-			TrajAnnealingCollection &,
-			bool ,
-			AlgoProductCollection& , 
-			AlgoProductCollection&) const;
 
- private:
+  /// Run the Final Fit taking TrackCandidates as input
+  void runWithCandidate(const TrackingGeometry*,
+                        const MagneticField*,
+                        //const TrackCandidateCollection&,
+                        const TrajTrackAssociationCollection&,
+                        const MeasurementTrackerEvent* measTk,
+                        const TrajectoryFitter*,
+                        const TransientTrackingRecHitBuilder*,
+                        const MultiRecHitCollector* measurementTracker,
+                        const SiTrackerMultiRecHitUpdator*,
+                        const reco::BeamSpot&,
+                        AlgoProductCollection&,
+                        TrajAnnealingCollection&,
+                        bool,
+                        AlgoProductCollection&,
+                        AlgoProductCollection&) const;
+
+private:
   /// Construct Tracks to be put in the event
-  bool buildTrack(const Trajectory,
-		  AlgoProductCollection& algoResults,
-		  float,
-		  const reco::BeamSpot&, 
-		  const reco::TrackRef* ) const;
+  bool buildTrack(
+      const Trajectory, AlgoProductCollection& algoResults, float, const reco::BeamSpot&, const reco::TrackRef*) const;
 
   /// accomplishes the fitting-smoothing step for each annealing value
-  Trajectory fit(const std::pair<TransientTrackingRecHit::RecHitContainer,
-                                    TrajectoryStateOnSurface>& hits,
-                                    const TrajectoryFitter * theFitter,
-                                    Trajectory vtraj) const;
+  Trajectory fit(const std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface>& hits,
+                 const TrajectoryFitter* theFitter,
+                 Trajectory vtraj) const;
 
   //calculates the ndof according to the DAF prescription
   float calculateNdof(const Trajectory vtraj) const;
 
-  //creates MultiRecHits out of a KF trajectory 	
+  //creates MultiRecHits out of a KF trajectory
   std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> collectHits(
-              const Trajectory vtraj,
-              const MultiRecHitCollector* measurementCollector,
-              const MeasurementTrackerEvent *measTk     ) const;
+      const Trajectory vtraj,
+      const MultiRecHitCollector* measurementCollector,
+      const MeasurementTrackerEvent* measTk) const;
 
   //updates the hits with the specified annealing factor
   std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> updateHits(
-	      const Trajectory vtraj,
-              const SiTrackerMultiRecHitUpdator* updator,
-	      const MeasurementTrackerEvent* theMTE,
-              double annealing) const; 
+      const Trajectory vtraj,
+      const SiTrackerMultiRecHitUpdator* updator,
+      const MeasurementTrackerEvent* theMTE,
+      double annealing) const;
 
   //removes from the trajectory isolated hits with very low weight
-  void filter(const TrajectoryFitter* fitter, 
-	      std::vector<Trajectory>& input, 
-	      int minhits, std::vector<Trajectory>& output,
-	      const TransientTrackingRecHitBuilder* builder) const;
+  void filter(const TrajectoryFitter* fitter,
+              std::vector<Trajectory>& input,
+              int minhits,
+              std::vector<Trajectory>& output,
+              const TransientTrackingRecHitBuilder* builder) const;
 
   int countingGoodHits(const Trajectory traj) const;
 
-  int checkHits( Trajectory iInitTraj, const Trajectory iFinalTraj) const; 
+  int checkHits(Trajectory iInitTraj, const Trajectory iFinalTraj) const;
 
   void PrintHit(const TrackingRecHit* const& hit, TrajectoryStateOnSurface& tsos) const;
 
   edm::ParameterSet conf_;
-  int minHits_;  
+  int minHits_;
 };
 
 #endif

--- a/RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h
@@ -25,49 +25,46 @@ class TrajectoryStateClosestToBeamLineBuilder;
 
 class GsfTrackProducerBase : public TrackProducerBase<reco::GsfTrack> {
 public:
-
   /// Constructor
-  explicit GsfTrackProducerBase(bool trajectoryInEvent, bool split) :
-  TrackProducerBase<reco::GsfTrack>(trajectoryInEvent),
-    useSplitting(split){}
-  
+  explicit GsfTrackProducerBase(bool trajectoryInEvent, bool split)
+      : TrackProducerBase<reco::GsfTrack>(trajectoryInEvent), useSplitting(split) {}
+
   /// Put produced collections in the event
   virtual void putInEvt(edm::Event&,
-			const Propagator* prop,
-			const MeasurementTracker* measTk,
-			std::unique_ptr<TrackingRecHitCollection>&,
-			std::unique_ptr<reco::GsfTrackCollection>&,
-			std::unique_ptr<reco::TrackExtraCollection>&,
-			std::unique_ptr<reco::GsfTrackExtraCollection>&,
-			std::unique_ptr<std::vector<Trajectory> >&,
-			AlgoProductCollection&,
-			TransientTrackingRecHitBuilder const*,
-			const reco::BeamSpot&, const TrackerTopology *ttopo);
-
+                        const Propagator* prop,
+                        const MeasurementTracker* measTk,
+                        std::unique_ptr<TrackingRecHitCollection>&,
+                        std::unique_ptr<reco::GsfTrackCollection>&,
+                        std::unique_ptr<reco::TrackExtraCollection>&,
+                        std::unique_ptr<reco::GsfTrackExtraCollection>&,
+                        std::unique_ptr<std::vector<Trajectory> >&,
+                        AlgoProductCollection&,
+                        TransientTrackingRecHitBuilder const*,
+                        const reco::BeamSpot&,
+                        const TrackerTopology* ttopo);
 
 protected:
-  void fillStates (TrajectoryStateOnSurface tsos, std::vector<reco::GsfComponent5D>& states) const;
-  void fillMode (reco::GsfTrack& track, const TrajectoryStateOnSurface innertsos,
-		 const Propagator& gsfProp,
-		 const TransverseImpactPointExtrapolator& tipExtrapolator,
-		 TrajectoryStateClosestToBeamLineBuilder& tscblBuilder,
-		 const reco::BeamSpot& bs) const;
+  void fillStates(TrajectoryStateOnSurface tsos, std::vector<reco::GsfComponent5D>& states) const;
+  void fillMode(reco::GsfTrack& track,
+                const TrajectoryStateOnSurface innertsos,
+                const Propagator& gsfProp,
+                const TransverseImpactPointExtrapolator& tipExtrapolator,
+                TrajectoryStateClosestToBeamLineBuilder& tscblBuilder,
+                const reco::BeamSpot& bs) const;
 
 private:
   /// local parameters rescaled with q/p from mode
-  void localParametersFromQpMode (const TrajectoryStateOnSurface tsos,
-				  AlgebraicVector5& parameters,
-				  AlgebraicSymMatrix55& covariance) const;
+  void localParametersFromQpMode(const TrajectoryStateOnSurface tsos,
+                                 AlgebraicVector5& parameters,
+                                 AlgebraicSymMatrix55& covariance) const;
   /// position, momentum and estimated deltaP at an intermediate measurement (true if successful)
-  bool computeModeAtTM (const TrajectoryMeasurement& tm,
-			reco::GsfTrackExtra::Point& position,
-			reco::GsfTrackExtra::Vector& momentum,
-			Measurement1D& deltaP) const;
+  bool computeModeAtTM(const TrajectoryMeasurement& tm,
+                       reco::GsfTrackExtra::Point& position,
+                       reco::GsfTrackExtra::Vector& momentum,
+                       Measurement1D& deltaP) const;
 
 private:
-bool useSplitting;
-
+  bool useSplitting;
 };
 
-     
 #endif

--- a/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
@@ -15,34 +15,31 @@ class Trajectory;
 
 class KfTrackProducerBase : public TrackProducerBase<reco::Track> {
 public:
-
   /// Constructor
-  explicit KfTrackProducerBase(bool trajectoryInEvent, bool split) :
-    TrackProducerBase<reco::Track>(trajectoryInEvent),useSplitting(split) {}
+  explicit KfTrackProducerBase(bool trajectoryInEvent, bool split)
+      : TrackProducerBase<reco::Track>(trajectoryInEvent), useSplitting(split) {}
 
   /// Put produced collections in the event
   virtual void putInEvt(edm::Event&,
-			const Propagator* prop,
-			const MeasurementTracker* measTk,
-			std::unique_ptr<TrackingRecHitCollection>&,
-			std::unique_ptr<reco::TrackCollection>&,
-			std::unique_ptr<reco::TrackExtraCollection>&,
-			std::unique_ptr<std::vector<Trajectory> >&,
-			std::unique_ptr<std::vector<int> >&,
-			AlgoProductCollection&,
-			TransientTrackingRecHitBuilder const*,
-                        const TrackerTopology *ttopo,
-			//allow to fill different tracks collections if necessary ::
-			//0: not needed
-			//1: Before DAF
-			//2: After DAF	
-			int BeforeOrAfter = 0);
-
+                        const Propagator* prop,
+                        const MeasurementTracker* measTk,
+                        std::unique_ptr<TrackingRecHitCollection>&,
+                        std::unique_ptr<reco::TrackCollection>&,
+                        std::unique_ptr<reco::TrackExtraCollection>&,
+                        std::unique_ptr<std::vector<Trajectory> >&,
+                        std::unique_ptr<std::vector<int> >&,
+                        AlgoProductCollection&,
+                        TransientTrackingRecHitBuilder const*,
+                        const TrackerTopology* ttopo,
+                        //allow to fill different tracks collections if necessary ::
+                        //0: not needed
+                        //1: Before DAF
+                        //2: After DAF
+                        int BeforeOrAfter = 0);
 
   //  void setSecondHitPattern(Trajectory* traj, reco::Track& track);
- private:
+private:
   bool useSplitting;
-
 };
 
 #endif

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
@@ -7,7 +7,6 @@
  *  \author cerati
  */
 
-
 #include "AlgoProductTraits.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,7 +21,6 @@
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 
-
 class MagneticField;
 class TrackingGeometry;
 class Propagator;
@@ -30,16 +28,15 @@ class Trajectory;
 class TrajectoryStateOnSurface;
 
 struct FitterCloner {
-   std::unique_ptr<TrajectoryFitter> fitter;
-   TkClonerImpl hitCloner;
+  std::unique_ptr<TrajectoryFitter> fitter;
+  TkClonerImpl hitCloner;
 
-  FitterCloner(const TrajectoryFitter * theFitter,const TransientTrackingRecHitBuilder* builder):
-    fitter(theFitter->clone()),
-    hitCloner(static_cast<TkTransientTrackingRecHitBuilder const *>(builder)->cloner()){
+  FitterCloner(const TrajectoryFitter *theFitter, const TransientTrackingRecHitBuilder *builder)
+      : fitter(theFitter->clone()),
+        hitCloner(static_cast<TkTransientTrackingRecHitBuilder const *>(builder)->cloner()) {
     fitter->setHitCloner(&hitCloner);
   }
 };
-
 
 template <class T>
 class TrackProducerAlgorithm : public AlgoProductTraits<T> {
@@ -49,97 +46,94 @@ public:
   using TrackView = typename Base::TrackView;
   using AlgoProductCollection = typename Base::AlgoProductCollection;
 
-  using SeedRef= edm::RefToBase<TrajectorySeed>;
-  using VtxConstraintAssociationCollection = edm::AssociationMap<edm::OneToOne<std::vector<T>,std::vector<VertexConstraint> > > ;
-  
-public:
+  using SeedRef = edm::RefToBase<TrajectorySeed>;
+  using VtxConstraintAssociationCollection =
+      edm::AssociationMap<edm::OneToOne<std::vector<T>, std::vector<VertexConstraint> > >;
 
+public:
   /// Constructor
-  TrackProducerAlgorithm(const edm::ParameterSet& conf) : 
-    algo_(reco::TrackBase::algoByName(conf.getParameter<std::string>("AlgorithmName"))),
-    originalAlgo_(reco::TrackBase::undefAlgorithm),
-    stopReason_(0),
-    reMatchSplitHits_(false),
-    usePropagatorForPCA_(false)
-      {
-        geometricInnerState_ = (conf.exists("GeometricInnerState") ?
-	  conf.getParameter<bool>( "GeometricInnerState" ) : true);
-	if (conf.exists("reMatchSplitHits"))
-	  reMatchSplitHits_=conf.getParameter<bool>("reMatchSplitHits");
-        if (conf.exists("usePropagatorForPCA"))
-          usePropagatorForPCA_ = conf.getParameter<bool>("usePropagatorForPCA");
-      }
+  TrackProducerAlgorithm(const edm::ParameterSet &conf)
+      : algo_(reco::TrackBase::algoByName(conf.getParameter<std::string>("AlgorithmName"))),
+        originalAlgo_(reco::TrackBase::undefAlgorithm),
+        stopReason_(0),
+        reMatchSplitHits_(false),
+        usePropagatorForPCA_(false) {
+    geometricInnerState_ = (conf.exists("GeometricInnerState") ? conf.getParameter<bool>("GeometricInnerState") : true);
+    if (conf.exists("reMatchSplitHits"))
+      reMatchSplitHits_ = conf.getParameter<bool>("reMatchSplitHits");
+    if (conf.exists("usePropagatorForPCA"))
+      usePropagatorForPCA_ = conf.getParameter<bool>("usePropagatorForPCA");
+  }
 
   /// Destructor
   ~TrackProducerAlgorithm() {}
-  
+
   /// Run the Final Fit taking TrackCandidates as input
-  void runWithCandidate(const TrackingGeometry *, 
-			const MagneticField *, 
-			const TrackCandidateCollection&,
-			const TrajectoryFitter *,
-			const Propagator *,
-			const TransientTrackingRecHitBuilder*,
-			const reco::BeamSpot&,
-			AlgoProductCollection &);
+  void runWithCandidate(const TrackingGeometry *,
+                        const MagneticField *,
+                        const TrackCandidateCollection &,
+                        const TrajectoryFitter *,
+                        const Propagator *,
+                        const TransientTrackingRecHitBuilder *,
+                        const reco::BeamSpot &,
+                        AlgoProductCollection &);
 
   /// Run the Final Fit taking Tracks as input (for Refitter)
-  void runWithTrack(const TrackingGeometry *, 
-		    const MagneticField *, 
-		    const TrackView&,
-		    const TrajectoryFitter *,
-		    const Propagator *,
-		    const TransientTrackingRecHitBuilder*,
-		    const reco::BeamSpot&,
-		    AlgoProductCollection &);
+  void runWithTrack(const TrackingGeometry *,
+                    const MagneticField *,
+                    const TrackView &,
+                    const TrajectoryFitter *,
+                    const Propagator *,
+                    const TransientTrackingRecHitBuilder *,
+                    const reco::BeamSpot &,
+                    AlgoProductCollection &);
 
   /// Run the Final Fit taking TrackMomConstraintAssociation as input (Refitter with momentum constraint)
-  void runWithMomentum(const TrackingGeometry *, 
-		       const MagneticField *, 
-		       const TrackMomConstraintAssociationCollection&,
-		       const TrajectoryFitter *,
-		       const Propagator *,
-		       const TransientTrackingRecHitBuilder*,
-		       const reco::BeamSpot&,
-		       AlgoProductCollection &);
+  void runWithMomentum(const TrackingGeometry *,
+                       const MagneticField *,
+                       const TrackMomConstraintAssociationCollection &,
+                       const TrajectoryFitter *,
+                       const Propagator *,
+                       const TransientTrackingRecHitBuilder *,
+                       const reco::BeamSpot &,
+                       AlgoProductCollection &);
 
   /// Run the Final Fit taking TrackVtxConstraintAssociation as input (Refitter with vertex constraint)
   ///   currently hit sorting is disabled - will work (only) with standard tracks
-  void runWithVertex(const TrackingGeometry *, 
-		     const MagneticField *, 
-		     const VtxConstraintAssociationCollection&,
-		     const TrajectoryFitter *,
-		     const Propagator *,
-		     const TransientTrackingRecHitBuilder*,
-		     const reco::BeamSpot&,
-		     AlgoProductCollection &);
+  void runWithVertex(const TrackingGeometry *,
+                     const MagneticField *,
+                     const VtxConstraintAssociationCollection &,
+                     const TrajectoryFitter *,
+                     const Propagator *,
+                     const TransientTrackingRecHitBuilder *,
+                     const reco::BeamSpot &,
+                     AlgoProductCollection &);
 
   /// Run the Final Fit taking TrackParamConstraintAssociation as input (Refitter with complete track parameters constraint)
   ///   currently hit sorting is disabled - will work (only) with standard tracks
-  void runWithTrackParameters(const TrackingGeometry *, 
-			      const MagneticField *, 
-			      const TrackParamConstraintAssociationCollection&,
-			      const TrajectoryFitter *,
-			      const Propagator *,
-			      const TransientTrackingRecHitBuilder*,
-			      const reco::BeamSpot&,
-			      AlgoProductCollection &);
+  void runWithTrackParameters(const TrackingGeometry *,
+                              const MagneticField *,
+                              const TrackParamConstraintAssociationCollection &,
+                              const TrajectoryFitter *,
+                              const Propagator *,
+                              const TransientTrackingRecHitBuilder *,
+                              const reco::BeamSpot &,
+                              AlgoProductCollection &);
 
   /// Construct Tracks to be put in the event
   bool buildTrack(const TrajectoryFitter *,
-		  const Propagator *,
-		  AlgoProductCollection& ,
-		  TransientTrackingRecHit::RecHitContainer&,
-		  TrajectoryStateOnSurface& ,
-		  const TrajectorySeed&,		  
-		  float,
-		  const reco::BeamSpot&,
-		  SeedRef seedRef = SeedRef(),
-		  int qualityMask=0,
-		  signed char nLoops=0);
+                  const Propagator *,
+                  AlgoProductCollection &,
+                  TransientTrackingRecHit::RecHitContainer &,
+                  TrajectoryStateOnSurface &,
+                  const TrajectorySeed &,
+                  float,
+                  const reco::BeamSpot &,
+                  SeedRef seedRef = SeedRef(),
+                  int qualityMask = 0,
+                  signed char nLoops = 0);
 
-
- private:
+private:
   reco::TrackBase::TrackAlgorithm algo_;
   reco::TrackBase::TrackAlgorithm originalAlgo_;
   reco::TrackBase::AlgoMask algoMask_;
@@ -149,40 +143,38 @@ public:
   bool geometricInnerState_;
   bool usePropagatorForPCA_;
 
-  TrajectoryStateOnSurface getInitialState(const T * theT,
-					   TransientTrackingRecHit::RecHitContainer& hits,
-					   const TrackingGeometry * theG,
-					   const MagneticField * theMF);
-
+  TrajectoryStateOnSurface getInitialState(const T *theT,
+                                           TransientTrackingRecHit::RecHitContainer &hits,
+                                           const TrackingGeometry *theG,
+                                           const MagneticField *theMF);
 };
 
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc"
 
-template <> bool
-TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter *,
-						const Propagator *,
-						AlgoProductCollection& ,
-						TransientTrackingRecHit::RecHitContainer&,
-						TrajectoryStateOnSurface& ,
-						const TrajectorySeed&,
-						float,
-						const reco::BeamSpot&,
-						SeedRef seedRef,
-						int qualityMask,
-						signed char nLoops);
+template <>
+bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter *,
+                                                     const Propagator *,
+                                                     AlgoProductCollection &,
+                                                     TransientTrackingRecHit::RecHitContainer &,
+                                                     TrajectoryStateOnSurface &,
+                                                     const TrajectorySeed &,
+                                                     float,
+                                                     const reco::BeamSpot &,
+                                                     SeedRef seedRef,
+                                                     int qualityMask,
+                                                     signed char nLoops);
 
-
-template <> bool
-TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter *,
-						   const Propagator *,
-						   AlgoProductCollection& ,
-						   TransientTrackingRecHit::RecHitContainer&,
-						   TrajectoryStateOnSurface& ,
-						   const TrajectorySeed&,
-						   float,
-						   const reco::BeamSpot&,
-						   SeedRef seedRef,
-						   int qualityMask,
-						   signed char nLoops);
+template <>
+bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter *,
+                                                        const Propagator *,
+                                                        AlgoProductCollection &,
+                                                        TransientTrackingRecHit::RecHitContainer &,
+                                                        TrajectoryStateOnSurface &,
+                                                        const TrajectorySeed &,
+                                                        float,
+                                                        const reco::BeamSpot &,
+                                                        SeedRef seedRef,
+                                                        int qualityMask,
+                                                        signed char nLoops);
 
 #endif

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
@@ -30,404 +30,437 @@
 
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
-template <class T> void
-TrackProducerAlgorithm<T>::runWithCandidate(const TrackingGeometry * theG,
-					    const MagneticField * theMF,
-					    const TrackCandidateCollection& theTCCollection,
-					    const TrajectoryFitter * theFitter,
-					    const Propagator * thePropagator,
-					    const TransientTrackingRecHitBuilder* builder,
-			   		    const reco::BeamSpot& bs,
-					    AlgoProductCollection& algoResults)
-{
+template <class T>
+void TrackProducerAlgorithm<T>::runWithCandidate(const TrackingGeometry* theG,
+                                                 const MagneticField* theMF,
+                                                 const TrackCandidateCollection& theTCCollection,
+                                                 const TrajectoryFitter* theFitter,
+                                                 const Propagator* thePropagator,
+                                                 const TransientTrackingRecHitBuilder* builder,
+                                                 const reco::BeamSpot& bs,
+                                                 AlgoProductCollection& algoResults) {
   LogDebug("TrackProducer") << "Number of TrackCandidates: " << theTCCollection.size() << "\n";
 
-  int cont = 0; int ntc=0;
-  for (auto const  theTC : theTCCollection)
-    {
+  int cont = 0;
+  int ntc = 0;
+  for (auto const theTC : theTCCollection) {
+    PTrajectoryStateOnDet const& state = theTC.trajectoryStateOnDet();
+    const TrackCandidate::range& recHitVec = theTC.recHits();
+    const TrajectorySeed& seed = theTC.seed();
 
-      PTrajectoryStateOnDet const & state = theTC.trajectoryStateOnDet();
-      const TrackCandidate::range & recHitVec=theTC.recHits();
-      const TrajectorySeed & seed = theTC.seed();
+    //convert PTrajectoryStateOnDet to TrajectoryStateOnSurface
 
-      //convert PTrajectoryStateOnDet to TrajectoryStateOnSurface
-  
-      DetId  detId(state.detId());
-      TrajectoryStateOnSurface theTSOS = trajectoryStateTransform::transientState( state,
-								     &(theG->idToDet(detId)->surface()), 
-								     theMF);
+    DetId detId(state.detId());
+    TrajectoryStateOnSurface theTSOS =
+        trajectoryStateTransform::transientState(state, &(theG->idToDet(detId)->surface()), theMF);
 
-      LogDebug("TrackProducer") << "Initial TSOS\n" << theTSOS << "\n";
-      
-      //convert the TrackingRecHit vector to a TransientTrackingRecHit vector
-      TrackingRecHit::RecHitContainer hits;
-      
-      float ndof=0;     
-      //  we assume are transient...
-      for (auto  i = recHitVec.first; i!=recHitVec.second; ++i){
-	hits.push_back((*i).cloneSH());  // major waste, will be soon fitted and recloned...
-      }      
+    LogDebug("TrackProducer") << "Initial TSOS\n" << theTSOS << "\n";
 
-      stopReason_ = theTC.stopReason();
-      //build Track
-      LogDebug("TrackProducer") << "going to buildTrack"<< "\n";
-      FitterCloner fc(theFitter,builder);   
-      bool ok = buildTrack(fc.fitter.get(),thePropagator,algoResults, hits, theTSOS, seed, ndof, bs,
-      	      		    theTC.seedRef(),0,theTC.nLoops());
-      LogDebug("TrackProducer") << "buildTrack result: " << ok << "\n";
-      if(ok) { algoResults.back().indexInput=ntc; ++cont;  }
-      ++ntc;
+    //convert the TrackingRecHit vector to a TransientTrackingRecHit vector
+    TrackingRecHit::RecHitContainer hits;
+
+    float ndof = 0;
+    //  we assume are transient...
+    for (auto i = recHitVec.first; i != recHitVec.second; ++i) {
+      hits.push_back((*i).cloneSH());  // major waste, will be soon fitted and recloned...
     }
+
+    stopReason_ = theTC.stopReason();
+    //build Track
+    LogDebug("TrackProducer") << "going to buildTrack"
+                              << "\n";
+    FitterCloner fc(theFitter, builder);
+    bool ok = buildTrack(
+        fc.fitter.get(), thePropagator, algoResults, hits, theTSOS, seed, ndof, bs, theTC.seedRef(), 0, theTC.nLoops());
+    LogDebug("TrackProducer") << "buildTrack result: " << ok << "\n";
+    if (ok) {
+      algoResults.back().indexInput = ntc;
+      ++cont;
+    }
+    ++ntc;
+  }
   LogDebug("TrackProducer") << "Number of Tracks found: " << cont << "\n";
   // std::cout << "VICkfProducer " << "Number of Tracks found: " << cont << std::endl;
 }
 
-
 // the following are called by the Refitter(s)
 
-template <class T> void
-TrackProducerAlgorithm<T>::runWithTrack(const TrackingGeometry * theG,
-					const MagneticField * theMF,
-					const TrackView& theTCollection,
-					const TrajectoryFitter * theFitter,
-					const Propagator * thePropagator,
-					const TransientTrackingRecHitBuilder* gbuilder,
-			   		const reco::BeamSpot& bs,
-					AlgoProductCollection& algoResults)
-{
+template <class T>
+void TrackProducerAlgorithm<T>::runWithTrack(const TrackingGeometry* theG,
+                                             const MagneticField* theMF,
+                                             const TrackView& theTCollection,
+                                             const TrajectoryFitter* theFitter,
+                                             const Propagator* thePropagator,
+                                             const TransientTrackingRecHitBuilder* gbuilder,
+                                             const reco::BeamSpot& bs,
+                                             AlgoProductCollection& algoResults) {
   LogDebug("TrackProducer") << "Number of input Tracks: " << theTCollection.size() << "\n";
-  const TkTransientTrackingRecHitBuilder * builder = dynamic_cast<TkTransientTrackingRecHitBuilder const *>(gbuilder);
+  const TkTransientTrackingRecHitBuilder* builder = dynamic_cast<TkTransientTrackingRecHitBuilder const*>(gbuilder);
   assert(builder);
   int cont = 0;
-  for (auto i=theTCollection.begin(); i!=theTCollection.end();i++)
-    {
-      try{
-	const T * theT = &(*i);
-	float ndof=0;
-	PropagationDirection seedDir = theT->seedDirection();
+  for (auto i = theTCollection.begin(); i != theTCollection.end(); i++) {
+    try {
+      const T* theT = &(*i);
+      float ndof = 0;
+      PropagationDirection seedDir = theT->seedDirection();
 
-	// WARNING: here we assume that the hits are correcly sorted according to seedDir
-	TransientTrackingRecHit::RecHitContainer hits;       
-	for (trackingRecHit_iterator i=theT->recHitsBegin(); i!=theT->recHitsEnd(); i++){
-	     if (reMatchSplitHits_){
-	   	//re-match hits that belong together
-      		trackingRecHit_iterator next = i; next++;
-                if (next != theT->recHitsEnd() && (*i)->isValid()){
-			//check whether hit and nexthit are on glued module
-			DetId hitId = (**i).geographicalId();
+      // WARNING: here we assume that the hits are correcly sorted according to seedDir
+      TransientTrackingRecHit::RecHitContainer hits;
+      for (trackingRecHit_iterator i = theT->recHitsBegin(); i != theT->recHitsEnd(); i++) {
+        if (reMatchSplitHits_) {
+          //re-match hits that belong together
+          trackingRecHit_iterator next = i;
+          next++;
+          if (next != theT->recHitsEnd() && (*i)->isValid()) {
+            //check whether hit and nexthit are on glued module
+            DetId hitId = (**i).geographicalId();
 
-			if(hitId.det() == DetId::Tracker) {
-                          if(GeomDetEnumerators::isTrackerStrip((**i).det()->subDetector())) {
-			    SiStripDetId stripId(hitId);
-			    if (stripId.partnerDetId() == (*next)->geographicalId().rawId()){
-			      //yes they are parterns in a glued geometry.
-			      DetId gluedId = stripId.glued();
-			      const SiStripRecHit2D *mono=nullptr;
-			      const SiStripRecHit2D *stereo=nullptr;
-			      if (stripId.stereo()==0){
-				mono=dynamic_cast<const SiStripRecHit2D *>(&**i);
-				stereo=dynamic_cast<const SiStripRecHit2D *>(&**next);
-			      }
-			      else{
-				mono=dynamic_cast<const SiStripRecHit2D *>(&**next);
-				stereo=dynamic_cast<const SiStripRecHit2D *>(&**i);
-			      }
-			      if (!mono	|| !stereo){
-					edm::LogError("TrackProducerAlgorithm")
-						<<"cannot get a SiStripRecHit2D from the rechit."<<hitId.rawId()
-						<<" "<<gluedId.rawId()
-						<<" "<<stripId.partnerDetId()
-						<<" "<<(*next)->geographicalId().rawId();
-				}
-			      LocalPoint pos;//null
-			      LocalError err;//null
-			      hits.push_back(std::make_shared<SiStripMatchedRecHit2D>(pos,err, *builder->geometry()->idToDet(gluedId), mono,stereo));
-			      //the local position and error is dummy but the fitter does not need that anyways
-			      i++;
-			      continue;//go to next.
-			    }//consecutive hits are on parterns module.
-		  }}//is a strip module
-	      }//next is not the end of hits
-	   }//if rematching option is on.
+            if (hitId.det() == DetId::Tracker) {
+              if (GeomDetEnumerators::isTrackerStrip((**i).det()->subDetector())) {
+                SiStripDetId stripId(hitId);
+                if (stripId.partnerDetId() == (*next)->geographicalId().rawId()) {
+                  //yes they are parterns in a glued geometry.
+                  DetId gluedId = stripId.glued();
+                  const SiStripRecHit2D* mono = nullptr;
+                  const SiStripRecHit2D* stereo = nullptr;
+                  if (stripId.stereo() == 0) {
+                    mono = dynamic_cast<const SiStripRecHit2D*>(&**i);
+                    stereo = dynamic_cast<const SiStripRecHit2D*>(&**next);
+                  } else {
+                    mono = dynamic_cast<const SiStripRecHit2D*>(&**next);
+                    stereo = dynamic_cast<const SiStripRecHit2D*>(&**i);
+                  }
+                  if (!mono || !stereo) {
+                    edm::LogError("TrackProducerAlgorithm")
+                        << "cannot get a SiStripRecHit2D from the rechit." << hitId.rawId() << " " << gluedId.rawId()
+                        << " " << stripId.partnerDetId() << " " << (*next)->geographicalId().rawId();
+                  }
+                  LocalPoint pos;  //null
+                  LocalError err;  //null
+                  hits.push_back(std::make_shared<SiStripMatchedRecHit2D>(
+                      pos, err, *builder->geometry()->idToDet(gluedId), mono, stereo));
+                  //the local position and error is dummy but the fitter does not need that anyways
+                  i++;
+                  continue;  //go to next.
+                }            //consecutive hits are on parterns module.
+              }
+            }  //is a strip module
+          }    //next is not the end of hits
+        }      //if rematching option is on.
 
-
-	  if ((**i).geographicalId()!=0U)  hits.push_back( (**i).cloneForFit(*builder->geometry()->idToDet( (**i).geographicalId() ) ) );
-	}
-	
-	TrajectoryStateOnSurface theInitialStateForRefitting = getInitialState(theT,hits,theG,theMF);
-
-	// the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-	if (seedDir==anyDirection){//if anyDirection the seed direction is not stored in the root file: keep same order
-	  throw cms::Exception("TrackProducer") 
-	    << "ERROR: trying to refit a track which doesn't have a properly filled 'seed direction' data member" << std::endl;
-	}
-
-	const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(),
-						   TrajectorySeed::recHitContainer(), seedDir);
-	// =========================
-	//LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
-
-	//set the algo_ member in order to propagate the old alog name
-	algo_=theT->algo();	
-	originalAlgo_ = theT->originalAlgo();
-	algoMask_ = theT->algoMask();
-
-        stopReason_ = theT->stopReason();
-
-	//=====  the hits are in the same order as they were in the track::extra.
-        FitterCloner fc(theFitter,builder);        
-	bool ok = buildTrack(fc.fitter.get(),thePropagator,algoResults, hits, theInitialStateForRefitting, 
-			     seed, ndof, bs, theT->seedRef(),theT->qualityMask(),theT->nLoops());
-	if(ok) cont++;
-      }catch ( cms::Exception & e){
-	edm::LogError("TrackProducer") << "Genexception1: " << e.explainSelf() <<"\n";      
-        throw;
+        if ((**i).geographicalId() != 0U)
+          hits.push_back((**i).cloneForFit(*builder->geometry()->idToDet((**i).geographicalId())));
       }
+
+      TrajectoryStateOnSurface theInitialStateForRefitting = getInitialState(theT, hits, theG, theMF);
+
+      // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
+      if (seedDir ==
+          anyDirection) {  //if anyDirection the seed direction is not stored in the root file: keep same order
+        throw cms::Exception("TrackProducer")
+            << "ERROR: trying to refit a track which doesn't have a properly filled 'seed direction' data member"
+            << std::endl;
+      }
+
+      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      // =========================
+      //LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
+
+      //set the algo_ member in order to propagate the old alog name
+      algo_ = theT->algo();
+      originalAlgo_ = theT->originalAlgo();
+      algoMask_ = theT->algoMask();
+
+      stopReason_ = theT->stopReason();
+
+      //=====  the hits are in the same order as they were in the track::extra.
+      FitterCloner fc(theFitter, builder);
+      bool ok = buildTrack(fc.fitter.get(),
+                           thePropagator,
+                           algoResults,
+                           hits,
+                           theInitialStateForRefitting,
+                           seed,
+                           ndof,
+                           bs,
+                           theT->seedRef(),
+                           theT->qualityMask(),
+                           theT->nLoops());
+      if (ok)
+        cont++;
+    } catch (cms::Exception& e) {
+      edm::LogError("TrackProducer") << "Genexception1: " << e.explainSelf() << "\n";
+      throw;
     }
+  }
   LogDebug("TrackProducer") << "Number of Tracks found: " << cont << "\n";
-  
 }
 
-template <class T> void
-TrackProducerAlgorithm<T>::runWithMomentum(const TrackingGeometry * theG,
-					   const MagneticField * theMF,
-					   const TrackMomConstraintAssociationCollection& theTCollectionWithConstraint,
-					   const TrajectoryFitter * theFitter,
-					   const Propagator * thePropagator,
-					   const TransientTrackingRecHitBuilder* gbuilder,
-			   		   const reco::BeamSpot& bs,
-					   AlgoProductCollection& algoResults){
-  
+template <class T>
+void TrackProducerAlgorithm<T>::runWithMomentum(
+    const TrackingGeometry* theG,
+    const MagneticField* theMF,
+    const TrackMomConstraintAssociationCollection& theTCollectionWithConstraint,
+    const TrajectoryFitter* theFitter,
+    const Propagator* thePropagator,
+    const TransientTrackingRecHitBuilder* gbuilder,
+    const reco::BeamSpot& bs,
+    AlgoProductCollection& algoResults) {
   LogDebug("TrackProducer") << "Number of input Tracks: " << theTCollectionWithConstraint.size() << "\n";
-    const TkTransientTrackingRecHitBuilder * builder = dynamic_cast<TkTransientTrackingRecHitBuilder const *>(gbuilder);
+  const TkTransientTrackingRecHitBuilder* builder = dynamic_cast<TkTransientTrackingRecHitBuilder const*>(gbuilder);
 
   int cont = 0;
-  for (TrackMomConstraintAssociationCollection::const_iterator i=theTCollectionWithConstraint.begin(); i!=theTCollectionWithConstraint.end();i++) {
-      try{
-	const T * theT = i->key.get();
+  for (TrackMomConstraintAssociationCollection::const_iterator i = theTCollectionWithConstraint.begin();
+       i != theTCollectionWithConstraint.end();
+       i++) {
+    try {
+      const T* theT = i->key.get();
 
-	LogDebug("TrackProducer") << "Running Refitter with Momentum Constraint. p=" << i->val->momentum << " err=" << i->val->error;
+      LogDebug("TrackProducer") << "Running Refitter with Momentum Constraint. p=" << i->val->momentum
+                                << " err=" << i->val->error;
 
-	float ndof=0;
-	PropagationDirection seedDir = theT->seedDirection();
+      float ndof = 0;
+      PropagationDirection seedDir = theT->seedDirection();
 
-	// WARNING: here we assume that the hits are correcly sorted according to seedDir
-	TransientTrackingRecHit::RecHitContainer hits;       
-	for (trackingRecHit_iterator j=theT->recHitsBegin(); j!=theT->recHitsEnd();++j) {
-          if ((**j).geographicalId()!=0U)  hits.push_back( (**j).cloneForFit(*builder->geometry()->idToDet( (**j).geographicalId() ) ) );
-	}
-
-	TrajectoryStateOnSurface theInitialStateForRefitting = getInitialState(theT,hits,theG,theMF);
-
-	double mom = i->val->momentum;//10;
-	double err = i->val->error;//0.01;
-	TransientTrackingRecHit::RecHitPointer testhit = 
-	  TRecHit1DMomConstraint::build(((int)(theInitialStateForRefitting.charge())),
-					mom,err,
-					&theInitialStateForRefitting.surface());
-	
-	//no insert in OwnVector...
-	TransientTrackingRecHit::RecHitContainer tmpHits;	
-	tmpHits.push_back(testhit);
-	for (TransientTrackingRecHit::RecHitContainer::const_iterator i=hits.begin(); i!=hits.end(); i++){
-	  tmpHits.push_back(*i);
-	}
-	hits.swap(tmpHits);
-	
-	// the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-	const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(),
-						   TrajectorySeed::recHitContainer(), seedDir);
-	// =========================
-	//LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
-	
-	//=====  the hits are in the same order as they were in the track::extra.
-        FitterCloner fc(theFitter,builder);     
-	bool ok = buildTrack(fc.fitter.get(),thePropagator,algoResults, hits, theInitialStateForRefitting,
-			     seed, ndof, bs, theT->seedRef(),theT->qualityMask(),theT->nLoops());
-	if(ok) cont++;
-      }catch ( cms::Exception & e){
-	edm::LogError("TrackProducer") << "cms::Exception: " << e.explainSelf() <<"\n";      
-        throw;
+      // WARNING: here we assume that the hits are correcly sorted according to seedDir
+      TransientTrackingRecHit::RecHitContainer hits;
+      for (trackingRecHit_iterator j = theT->recHitsBegin(); j != theT->recHitsEnd(); ++j) {
+        if ((**j).geographicalId() != 0U)
+          hits.push_back((**j).cloneForFit(*builder->geometry()->idToDet((**j).geographicalId())));
       }
+
+      TrajectoryStateOnSurface theInitialStateForRefitting = getInitialState(theT, hits, theG, theMF);
+
+      double mom = i->val->momentum;  //10;
+      double err = i->val->error;     //0.01;
+      TransientTrackingRecHit::RecHitPointer testhit = TRecHit1DMomConstraint::build(
+          ((int)(theInitialStateForRefitting.charge())), mom, err, &theInitialStateForRefitting.surface());
+
+      //no insert in OwnVector...
+      TransientTrackingRecHit::RecHitContainer tmpHits;
+      tmpHits.push_back(testhit);
+      for (TransientTrackingRecHit::RecHitContainer::const_iterator i = hits.begin(); i != hits.end(); i++) {
+        tmpHits.push_back(*i);
+      }
+      hits.swap(tmpHits);
+
+      // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
+      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      // =========================
+      //LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
+
+      //=====  the hits are in the same order as they were in the track::extra.
+      FitterCloner fc(theFitter, builder);
+      bool ok = buildTrack(fc.fitter.get(),
+                           thePropagator,
+                           algoResults,
+                           hits,
+                           theInitialStateForRefitting,
+                           seed,
+                           ndof,
+                           bs,
+                           theT->seedRef(),
+                           theT->qualityMask(),
+                           theT->nLoops());
+      if (ok)
+        cont++;
+    } catch (cms::Exception& e) {
+      edm::LogError("TrackProducer") << "cms::Exception: " << e.explainSelf() << "\n";
+      throw;
     }
+  }
   LogDebug("TrackProducer") << "Number of Tracks found: " << cont << "\n";
-  
 }
 
-
-template <class T> void
-TrackProducerAlgorithm<T>::runWithTrackParameters(const TrackingGeometry * theG,
-						  const MagneticField * theMF,
-						  const TrackParamConstraintAssociationCollection& theTCollectionWithConstraint,
-						  const TrajectoryFitter * theFitter,
-						  const Propagator * thePropagator,
-						  const TransientTrackingRecHitBuilder* gbuilder,
-						  const reco::BeamSpot& bs,
-						  AlgoProductCollection& algoResults)
-{
+template <class T>
+void TrackProducerAlgorithm<T>::runWithTrackParameters(
+    const TrackingGeometry* theG,
+    const MagneticField* theMF,
+    const TrackParamConstraintAssociationCollection& theTCollectionWithConstraint,
+    const TrajectoryFitter* theFitter,
+    const Propagator* thePropagator,
+    const TransientTrackingRecHitBuilder* gbuilder,
+    const reco::BeamSpot& bs,
+    AlgoProductCollection& algoResults) {
   LogDebug("TrackProducer") << "Number of input Tracks: " << theTCollectionWithConstraint.size() << "\n";
-  const TkTransientTrackingRecHitBuilder * builder = dynamic_cast<TkTransientTrackingRecHitBuilder const *>(gbuilder);
+  const TkTransientTrackingRecHitBuilder* builder = dynamic_cast<TkTransientTrackingRecHitBuilder const*>(gbuilder);
 
   int cont = 0;
 
-  for ( typename TrackParamConstraintAssociationCollection::const_iterator i=theTCollectionWithConstraint.begin(); 
-	i!=theTCollectionWithConstraint.end();i++) {
-      try{
-	const T * theT = i->key.get();
+  for (typename TrackParamConstraintAssociationCollection::const_iterator i = theTCollectionWithConstraint.begin();
+       i != theTCollectionWithConstraint.end();
+       i++) {
+    try {
+      const T* theT = i->key.get();
 
-	LogDebug("TrackProducer") << "Running Refitter with Track Parameter Constraint. TSOS = " << *(i->val);
+      LogDebug("TrackProducer") << "Running Refitter with Track Parameter Constraint. TSOS = " << *(i->val);
 
-	TransientTrackingRecHit::RecHitPointer constraintHit = TRecHit5DParamConstraint::build( *(i->val) );
+      TransientTrackingRecHit::RecHitPointer constraintHit = TRecHit5DParamConstraint::build(*(i->val));
 
-	// WARNING: here we assume that the hits are correcly sorted according to seedDir
-	TransientTrackingRecHit::RecHitContainer hits;       
-	hits.push_back( constraintHit );
-	for (trackingRecHit_iterator j=theT->recHitsBegin(); j!=theT->recHitsEnd(); ++j){
-          if ((**j).geographicalId()!=0U)  hits.push_back( (**j).cloneForFit(*builder->geometry()->idToDet( (**j).geographicalId() ) ) );
-	}
-
-	float ndof=0;
-	PropagationDirection seedDir = theT->seedDirection();
-
-	// the best guess for the initial state for refitting is obviously the constraint tsos itself
-	TrajectoryStateOnSurface theInitialStateForRefitting = *(i->val);
-
-	// the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-	const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(),
-						   TrajectorySeed::recHitContainer(), seedDir);
-
-	//=====  the hits are in the same order as they were in the track::extra.        
-        FitterCloner fc(theFitter,builder);
-	bool ok = buildTrack(fc.fitter.get(),thePropagator,algoResults, hits, theInitialStateForRefitting,
-			     seed, ndof, bs, theT->seedRef(),theT->qualityMask(),theT->nLoops());
-	if(ok) cont++;
-      } catch ( cms::Exception & e){
-	edm::LogError("TrackProducer") << "cms::Exception: " << e.explainSelf() <<"\n";      
-        throw;
+      // WARNING: here we assume that the hits are correcly sorted according to seedDir
+      TransientTrackingRecHit::RecHitContainer hits;
+      hits.push_back(constraintHit);
+      for (trackingRecHit_iterator j = theT->recHitsBegin(); j != theT->recHitsEnd(); ++j) {
+        if ((**j).geographicalId() != 0U)
+          hits.push_back((**j).cloneForFit(*builder->geometry()->idToDet((**j).geographicalId())));
       }
+
+      float ndof = 0;
+      PropagationDirection seedDir = theT->seedDirection();
+
+      // the best guess for the initial state for refitting is obviously the constraint tsos itself
+      TrajectoryStateOnSurface theInitialStateForRefitting = *(i->val);
+
+      // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
+      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+
+      //=====  the hits are in the same order as they were in the track::extra.
+      FitterCloner fc(theFitter, builder);
+      bool ok = buildTrack(fc.fitter.get(),
+                           thePropagator,
+                           algoResults,
+                           hits,
+                           theInitialStateForRefitting,
+                           seed,
+                           ndof,
+                           bs,
+                           theT->seedRef(),
+                           theT->qualityMask(),
+                           theT->nLoops());
+      if (ok)
+        cont++;
+    } catch (cms::Exception& e) {
+      edm::LogError("TrackProducer") << "cms::Exception: " << e.explainSelf() << "\n";
+      throw;
     }
+  }
   LogDebug("TrackProducer") << "Number of Tracks found: " << cont << "\n";
 }
 
-
-template <class T> void
-TrackProducerAlgorithm<T>::runWithVertex(const TrackingGeometry * theG,
-					 const MagneticField * theMF,
-					 const VtxConstraintAssociationCollection& theTCollectionWithConstraint,
-					 const TrajectoryFitter * theFitter,
-					 const Propagator * thePropagator,
-					 const TransientTrackingRecHitBuilder* gbuilder,
-			   		 const reco::BeamSpot& bs,
-					 AlgoProductCollection& algoResults){
-  const TkTransientTrackingRecHitBuilder * builder = dynamic_cast<TkTransientTrackingRecHitBuilder const *>(gbuilder);
+template <class T>
+void TrackProducerAlgorithm<T>::runWithVertex(const TrackingGeometry* theG,
+                                              const MagneticField* theMF,
+                                              const VtxConstraintAssociationCollection& theTCollectionWithConstraint,
+                                              const TrajectoryFitter* theFitter,
+                                              const Propagator* thePropagator,
+                                              const TransientTrackingRecHitBuilder* gbuilder,
+                                              const reco::BeamSpot& bs,
+                                              AlgoProductCollection& algoResults) {
+  const TkTransientTrackingRecHitBuilder* builder = dynamic_cast<TkTransientTrackingRecHitBuilder const*>(gbuilder);
 
   LogDebug("TrackProducer") << "Number of input Tracks: " << theTCollectionWithConstraint.size() << "\n";
-  
-//   PropagatorWithMaterial myPropagator(anyDirection,0.105,theMF);
-  AnalyticalPropagator myPropagator(theMF,anyDirection);  // no material surface inside 1st hit
+
+  //   PropagatorWithMaterial myPropagator(anyDirection,0.105,theMF);
+  AnalyticalPropagator myPropagator(theMF, anyDirection);  // no material surface inside 1st hit
   TransverseImpactPointExtrapolator extrapolator(myPropagator);
 
   int cont = 0;
-  for ( typename VtxConstraintAssociationCollection::const_iterator i=theTCollectionWithConstraint.begin(); 
-	i!=theTCollectionWithConstraint.end();i++) {
-      try{
-	const T * theT = i->key.get();
+  for (typename VtxConstraintAssociationCollection::const_iterator i = theTCollectionWithConstraint.begin();
+       i != theTCollectionWithConstraint.end();
+       i++) {
+    try {
+      const T* theT = i->key.get();
 
-	LogDebug("TrackProducer") << "Running Refitter with Vertex Constraint. pos=" << i->val->first << " err=" << i->val->second.matrix();
+      LogDebug("TrackProducer") << "Running Refitter with Vertex Constraint. pos=" << i->val->first
+                                << " err=" << i->val->second.matrix();
 
-	float ndof=0;
-	PropagationDirection seedDir = theT->seedDirection();
+      float ndof = 0;
+      PropagationDirection seedDir = theT->seedDirection();
 
+      // FreeTrajectoryState from track position and momentum
+      GlobalPoint tkpos(theT->vertex().x(), theT->vertex().y(), theT->vertex().z());
+      GlobalVector tkmom(theT->momentum().x(), theT->momentum().y(), theT->momentum().z());
+      FreeTrajectoryState fts(tkpos, tkmom, theT->charge(), theMF);
+      // Extrapolation to transverse IP plane at vertex constraint position
+      GlobalPoint pos = i->val->first;
+      GlobalError err = i->val->second;
+      TrajectoryStateOnSurface tsosAtVtx = extrapolator.extrapolate(fts, pos);
+      const Surface& surfAtVtx = tsosAtVtx.surface();
+      // Conversion of vertex constraint parameters and errors to local system
+      //   (assumes projection normal to plane - sufficient if transverse components are small)
+      LocalPoint vtxPosL = surfAtVtx.toLocal(pos);
+      LocalError vtxErrL = ErrorFrameTransformer().transform(err, surfAtVtx);
+      // Construction of the virtual hit
+      TransientTrackingRecHit::RecHitPointer vtxhit = TRecHit2DPosConstraint::build(vtxPosL, vtxErrL, &surfAtVtx);
 
-	// FreeTrajectoryState from track position and momentum
-	GlobalPoint tkpos(theT->vertex().x(),theT->vertex().y(),theT->vertex().z());
-	GlobalVector tkmom(theT->momentum().x(),theT->momentum().y(),theT->momentum().z());
-	FreeTrajectoryState fts(tkpos,tkmom,theT->charge(),theMF);
-	// Extrapolation to transverse IP plane at vertex constraint position
-	GlobalPoint pos = i->val->first;
-	GlobalError err = i->val->second;
-	TrajectoryStateOnSurface tsosAtVtx = extrapolator.extrapolate(fts,pos);
-	const Surface& surfAtVtx = tsosAtVtx.surface();
-	// Conversion of vertex constraint parameters and errors to local system
-	//   (assumes projection normal to plane - sufficient if transverse components are small)
-	LocalPoint vtxPosL = surfAtVtx.toLocal(pos);
-	LocalError vtxErrL = ErrorFrameTransformer().transform(err,surfAtVtx);
-	// Construction of the virtual hit
-	TransientTrackingRecHit::RecHitPointer vtxhit = 
-	  TRecHit2DPosConstraint::build(vtxPosL,vtxErrL,&surfAtVtx);
-
-	// WARNING: here we assume that the hits are correcly sorted according to seedDir
-	TransientTrackingRecHit::RecHitContainer hits;       
-	for (trackingRecHit_iterator j=theT->recHitsBegin(); j!=theT->recHitsEnd(); ++j){
-          if ((**j).geographicalId()!=0U)  hits.push_back( (**j).cloneForFit(*builder->geometry()->idToDet( (**j).geographicalId() ) ) );
-	}
-
-	TrajectoryStateOnSurface theInitialStateForRefitting = getInitialState(theT,hits,theG,theMF);
-
-// 	const LocalPoint testpoint(0,0,0);
-// 	GlobalPoint pos = i->val->first;
-// 	GlobalError err = i->val->second;
-
-// 	Propagator* myPropagator = new PropagatorWithMaterial(anyDirection,0.105,theMF);
-// 	TransverseImpactPointExtrapolator extrapolator(*myPropagator);
-// 	TrajectoryStateOnSurface tsosAtVtx = extrapolator.extrapolate(theInitialStateForRefitting,pos);
-	
-// 	const Surface * surfAtVtx = &tsosAtVtx.surface();
-	
-
-// 	LocalError testerror = ErrorFrameTransformer().transform(err, *surfAtVtx);
-	
-	
-// 	TransientTrackingRecHit::RecHitPointer testhit = TRecHit2DPosConstraint::build(testpoint,testerror,surfAtVtx);
-	
-	//push constraining hit and sort along seed direction
-// 	hits.push_back(testhit);
-// 	RecHitSorter sorter = RecHitSorter();
-// 	hits = sorter.sortHits(hits,seedDir);   // warning: I doubt it works for cosmic or beam halo tracks
-	//insertion of the constraint in the lists of hits
-	//  (assume hits ordered from inside to outside)
-	hits.insert(hits.begin(),vtxhit);
-
-	//use the state on the surface of the first hit (could be the constraint or not)
-	theInitialStateForRefitting = 
-	  myPropagator.propagate(theInitialStateForRefitting,*(hits[0]->surface()));
-
-	// the seed has dummy state and hits.What matters for the fitting is the seedDirection;
-	const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(),
-						   TrajectorySeed::recHitContainer(), seedDir);
-	// =========================
-	//LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
-
-	//=====  the hits are in the same order as they were in the track::extra.        
-        FitterCloner fc(theFitter,builder);
-	bool ok = buildTrack(fc.fitter.get(),thePropagator,algoResults, hits, theInitialStateForRefitting,
-			     seed, ndof, bs, theT->seedRef(),theT->qualityMask(),theT->nLoops());
-	if(ok) cont++;
-      } catch ( cms::Exception & e){
-	edm::LogError("TrackProducer") << "cms::Exception: " << e.explainSelf() <<"\n";      
-        throw;
+      // WARNING: here we assume that the hits are correcly sorted according to seedDir
+      TransientTrackingRecHit::RecHitContainer hits;
+      for (trackingRecHit_iterator j = theT->recHitsBegin(); j != theT->recHitsEnd(); ++j) {
+        if ((**j).geographicalId() != 0U)
+          hits.push_back((**j).cloneForFit(*builder->geometry()->idToDet((**j).geographicalId())));
       }
-    }
-  LogDebug("TrackProducer") << "Number of Tracks found: " << cont << "\n";
 
+      TrajectoryStateOnSurface theInitialStateForRefitting = getInitialState(theT, hits, theG, theMF);
+
+      // 	const LocalPoint testpoint(0,0,0);
+      // 	GlobalPoint pos = i->val->first;
+      // 	GlobalError err = i->val->second;
+
+      // 	Propagator* myPropagator = new PropagatorWithMaterial(anyDirection,0.105,theMF);
+      // 	TransverseImpactPointExtrapolator extrapolator(*myPropagator);
+      // 	TrajectoryStateOnSurface tsosAtVtx = extrapolator.extrapolate(theInitialStateForRefitting,pos);
+
+      // 	const Surface * surfAtVtx = &tsosAtVtx.surface();
+
+      // 	LocalError testerror = ErrorFrameTransformer().transform(err, *surfAtVtx);
+
+      // 	TransientTrackingRecHit::RecHitPointer testhit = TRecHit2DPosConstraint::build(testpoint,testerror,surfAtVtx);
+
+      //push constraining hit and sort along seed direction
+      // 	hits.push_back(testhit);
+      // 	RecHitSorter sorter = RecHitSorter();
+      // 	hits = sorter.sortHits(hits,seedDir);   // warning: I doubt it works for cosmic or beam halo tracks
+      //insertion of the constraint in the lists of hits
+      //  (assume hits ordered from inside to outside)
+      hits.insert(hits.begin(), vtxhit);
+
+      //use the state on the surface of the first hit (could be the constraint or not)
+      theInitialStateForRefitting = myPropagator.propagate(theInitialStateForRefitting, *(hits[0]->surface()));
+
+      // the seed has dummy state and hits.What matters for the fitting is the seedDirection;
+      const TrajectorySeed seed = TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), seedDir);
+      // =========================
+      //LogDebug("TrackProducer") << "seed.direction()=" << seed.direction();
+
+      //=====  the hits are in the same order as they were in the track::extra.
+      FitterCloner fc(theFitter, builder);
+      bool ok = buildTrack(fc.fitter.get(),
+                           thePropagator,
+                           algoResults,
+                           hits,
+                           theInitialStateForRefitting,
+                           seed,
+                           ndof,
+                           bs,
+                           theT->seedRef(),
+                           theT->qualityMask(),
+                           theT->nLoops());
+      if (ok)
+        cont++;
+    } catch (cms::Exception& e) {
+      edm::LogError("TrackProducer") << "cms::Exception: " << e.explainSelf() << "\n";
+      throw;
+    }
+  }
+  LogDebug("TrackProducer") << "Number of Tracks found: " << cont << "\n";
 }
 
-template <class T> TrajectoryStateOnSurface
-TrackProducerAlgorithm<T>::getInitialState(const T * theT,
-					   TransientTrackingRecHit::RecHitContainer& hits,
-					   const TrackingGeometry * theG,
-					   const MagneticField * theMF){
-
+template <class T>
+TrajectoryStateOnSurface TrackProducerAlgorithm<T>::getInitialState(const T* theT,
+                                                                    TransientTrackingRecHit::RecHitContainer& hits,
+                                                                    const TrackingGeometry* theG,
+                                                                    const MagneticField* theMF) {
   TrajectoryStateOnSurface theInitialStateForRefitting;
   //the starting state is the state closest to the first hit along seedDirection.
   //avoiding to use transientTrack, it should be faster;
-  TrajectoryStateOnSurface innerStateFromTrack=trajectoryStateTransform::innerStateOnSurface(*theT,*theG,theMF);
-  TrajectoryStateOnSurface outerStateFromTrack=trajectoryStateTransform::outerStateOnSurface(*theT,*theG,theMF);
-  TrajectoryStateOnSurface initialStateFromTrack = 
-    ( (innerStateFromTrack.globalPosition()-hits.front()->det()->position()).mag2() <
-      (outerStateFromTrack.globalPosition()-hits.front()->det()->position()).mag2() ) ? 
-    innerStateFromTrack: outerStateFromTrack;       
-  
+  TrajectoryStateOnSurface innerStateFromTrack = trajectoryStateTransform::innerStateOnSurface(*theT, *theG, theMF);
+  TrajectoryStateOnSurface outerStateFromTrack = trajectoryStateTransform::outerStateOnSurface(*theT, *theG, theMF);
+  TrajectoryStateOnSurface initialStateFromTrack =
+      ((innerStateFromTrack.globalPosition() - hits.front()->det()->position()).mag2() <
+       (outerStateFromTrack.globalPosition() - hits.front()->det()->position()).mag2())
+          ? innerStateFromTrack
+          : outerStateFromTrack;
+
   // error is rescaled, but correlation are kept.
   initialStateFromTrack.rescaleError(100);
   return initialStateFromTrack;
@@ -439,4 +472,3 @@ TrackProducerAlgorithm<T>::getInitialState(const T * theT,
   return theInitialStateForRefitting;
   */
 }
-

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -7,7 +7,6 @@
  *  \author cerati
  */
 
-
 #include "AlgoProductTraits.h"
 
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -26,7 +25,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/ClusterRemovalInfo.h"
 #include <RecoTracker/MeasurementDet/interface/MeasurementTracker.h>
 
-#include<tuple>
+#include <tuple>
 
 class Propagator;
 class TrajectoryStateUpdator;
@@ -43,24 +42,22 @@ public:
   using TrackView = typename Base::TrackView;
   using TrackCollection = typename Base::TrackCollection;
   using AlgoProductCollection = typename Base::AlgoProductCollection;
-public:
 
+public:
   /// Constructor
-  TrackProducerBase(bool trajectoryInEvent = false):
-     trajectoryInEvent_(trajectoryInEvent),
-        rekeyClusterRefs_(false) {}
+  TrackProducerBase(bool trajectoryInEvent = false) : trajectoryInEvent_(trajectoryInEvent), rekeyClusterRefs_(false) {}
 
   /// Destructor
   virtual ~TrackProducerBase() noexcept(false);
-  
+
   /// Get needed services from the Event Setup
   virtual void getFromES(const edm::EventSetup&,
-			 edm::ESHandle<TrackerGeometry>& ,
-			 edm::ESHandle<MagneticField>& ,
-			 edm::ESHandle<TrajectoryFitter>& ,
-			 edm::ESHandle<Propagator>& ,
-			 edm::ESHandle<MeasurementTracker>& ,
-			 edm::ESHandle<TransientTrackingRecHitBuilder>& );
+                         edm::ESHandle<TrackerGeometry>&,
+                         edm::ESHandle<MagneticField>&,
+                         edm::ESHandle<TrajectoryFitter>&,
+                         edm::ESHandle<Propagator>&,
+                         edm::ESHandle<MeasurementTracker>&,
+                         edm::ESHandle<TransientTrackingRecHitBuilder>&);
 
   /// Get TrackCandidateCollection from the Event (needed by TrackProducer)
   virtual void getFromEvt(edm::Event&, edm::Handle<TrackCandidateCollection>&, reco::BeamSpot&);
@@ -71,34 +68,42 @@ public:
   virtual void produce(edm::Event&, const edm::EventSetup&) = 0;
 
   /// Set parameter set
-  void setConf(const edm::ParameterSet& conf){conf_=conf;}
+  void setConf(const edm::ParameterSet& conf) { conf_ = conf; }
 
   /// set label of source collection
-  void setSrc(const edm::EDGetToken& src, const edm::EDGetTokenT<reco::BeamSpot>& bsSrc, const edm::EDGetTokenT<MeasurementTrackerEvent> &mteSrc) {
-    src_ = src; bsSrc_ = bsSrc; mteSrc_ = mteSrc;
+  void setSrc(const edm::EDGetToken& src,
+              const edm::EDGetTokenT<reco::BeamSpot>& bsSrc,
+              const edm::EDGetTokenT<MeasurementTrackerEvent>& mteSrc) {
+    src_ = src;
+    bsSrc_ = bsSrc;
+    mteSrc_ = mteSrc;
   }
 
   /// set the aliases of produced collections
-  void setAlias(std::string alias){
-    alias.erase(alias.size()-6,alias.size());
-    alias_=alias;
+  void setAlias(std::string alias) {
+    alias.erase(alias.size() - 6, alias.size());
+    alias_ = alias;
   }
 
   /// Sets the information on cluster removal, and turns it on
-  void setClusterRemovalInfo(const edm::InputTag &clusterRemovalInfo) {
+  void setClusterRemovalInfo(const edm::InputTag& clusterRemovalInfo) {
     rekeyClusterRefs_ = true;
     clusterRemovalInfo_ = clusterRemovalInfo;
   }
 
-  void setSecondHitPattern(Trajectory* traj, T& track, 
-			   const Propagator* prop, const MeasurementTrackerEvent* measTk,
+  void setSecondHitPattern(Trajectory* traj,
+                           T& track,
+                           const Propagator* prop,
+                           const MeasurementTrackerEvent* measTk,
                            const TrackerTopology* ttopo);
 
-  const edm::ParameterSet& getConf() const {return conf_;}
- protected:
+  const edm::ParameterSet& getConf() const { return conf_; }
+
+protected:
   edm::ParameterSet conf_;
   edm::EDGetToken src_;
- protected:
+
+protected:
   std::string alias_;
   bool trajectoryInEvent_;
   edm::OrphanHandle<TrackCollection> rTracks_;
@@ -109,7 +114,6 @@ public:
   edm::InputTag clusterRemovalInfo_;
 
   edm::ESHandle<NavigationSchool> theSchool;
-
 };
 
 #include "RecoTracker/TrackProducer/interface/TrackProducerBase.icc"

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -9,10 +9,10 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h" 
-#include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h" 
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
@@ -24,7 +24,7 @@
 // #include "TrackingTools/DetLayers/interface/NavigationSetter.h"
 
 #include <TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h>
-#include <TrackingTools/DetLayers/interface/GeometricSearchDet.h> 
+#include <TrackingTools/DetLayers/interface/GeometricSearchDet.h>
 #include <RecoTracker/MeasurementDet/interface/MeasurementTracker.h>
 #include <RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h>
 #include <TrackingTools/MeasurementDet/interface/MeasurementDet.h>
@@ -34,220 +34,234 @@
 
 //destructor
 template <class T>
-TrackProducerBase<T>::~TrackProducerBase() noexcept(false) { }
+TrackProducerBase<T>::~TrackProducerBase() noexcept(false) {}
 
 // member functions
 // ------------ method called to produce the data  ------------
 
-template <class T> void 
-TrackProducerBase<T>::getFromES(const edm::EventSetup& setup,
-				  edm::ESHandle<TrackerGeometry>& theG,
-				  edm::ESHandle<MagneticField>& theMF,
-				  edm::ESHandle<TrajectoryFitter>& theFitter,
-				  edm::ESHandle<Propagator>& thePropagator,
-				  edm::ESHandle<MeasurementTracker>& theMeasTk,
-				  edm::ESHandle<TransientTrackingRecHitBuilder>& theBuilder)
-{
+template <class T>
+void TrackProducerBase<T>::getFromES(const edm::EventSetup& setup,
+                                     edm::ESHandle<TrackerGeometry>& theG,
+                                     edm::ESHandle<MagneticField>& theMF,
+                                     edm::ESHandle<TrajectoryFitter>& theFitter,
+                                     edm::ESHandle<Propagator>& thePropagator,
+                                     edm::ESHandle<MeasurementTracker>& theMeasTk,
+                                     edm::ESHandle<TransientTrackingRecHitBuilder>& theBuilder) {
   //
   //get geometry
   //
-  LogDebug("TrackProducer") << "get geometry" << "\n";
+  LogDebug("TrackProducer") << "get geometry"
+                            << "\n";
   setup.get<TrackerDigiGeometryRecord>().get(theG);
   //
   //get magnetic field
   //
-  LogDebug("TrackProducer") << "get magnetic field" << "\n";
+  LogDebug("TrackProducer") << "get magnetic field"
+                            << "\n";
   // 2014/02/11 mia:
   // we should get rid of the boolean parameter useSimpleMF,
   // and use only a string magneticField [instead of SimpleMagneticField]
   // or better an edm::ESInputTag (at the moment HLT does not handle ESInputTag)
   bool useSimpleMF = false;
-  if (conf_.exists("useSimpleMF")) useSimpleMF = conf_.getParameter<bool>("useSimpleMF");
-  std::string mfName = "";			
-  if (useSimpleMF){
-     mfName = conf_.getParameter<std::string>("SimpleMagneticField"); 
+  if (conf_.exists("useSimpleMF"))
+    useSimpleMF = conf_.getParameter<bool>("useSimpleMF");
+  std::string mfName = "";
+  if (useSimpleMF) {
+    mfName = conf_.getParameter<std::string>("SimpleMagneticField");
   }
-  setup.get<IdealMagneticFieldRecord>().get(mfName, theMF);  
+  setup.get<IdealMagneticFieldRecord>().get(mfName, theMF);
   //  edm::ESInputTag mfESInputTag(mfName);
-  //  setup.get<IdealMagneticFieldRecord>().get(mfESInputTag, theMF);  
+  //  setup.get<IdealMagneticFieldRecord>().get(mfESInputTag, theMF);
 
   //
   // get the fitter from the ES
   //
-  LogDebug("TrackProducer") << "get the fitter from the ES" << "\n";
-  std::string fitterName = conf_.getParameter<std::string>("Fitter");   
-  setup.get<TrajectoryFitter::Record>().get(fitterName,theFitter);
+  LogDebug("TrackProducer") << "get the fitter from the ES"
+                            << "\n";
+  std::string fitterName = conf_.getParameter<std::string>("Fitter");
+  setup.get<TrajectoryFitter::Record>().get(fitterName, theFitter);
   //
   // get also the propagator
   //
-  LogDebug("TrackProducer") << "get also the propagator" << "\n";
-  std::string propagatorName = conf_.getParameter<std::string>("Propagator");   
-  setup.get<TrackingComponentsRecord>().get(propagatorName,thePropagator);
+  LogDebug("TrackProducer") << "get also the propagator"
+                            << "\n";
+  std::string propagatorName = conf_.getParameter<std::string>("Propagator");
+  setup.get<TrackingComponentsRecord>().get(propagatorName, thePropagator);
 
   //
   // get the builder
   //
-  LogDebug("TrackProducer") << "get also the TransientTrackingRecHitBuilder" << "\n";
-  std::string builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  setup.get<TransientRecHitRecord>().get(builderName,theBuilder);
+  LogDebug("TrackProducer") << "get also the TransientTrackingRecHitBuilder"
+                            << "\n";
+  std::string builderName = conf_.getParameter<std::string>("TTRHBuilder");
+  setup.get<TransientRecHitRecord>().get(builderName, theBuilder);
 
   //
-  // get also the measurementTracker and the NavigationSchool 
+  // get also the measurementTracker and the NavigationSchool
   // (they are necessary to fill in the secondary hit patterns)
   //
 
   LogDebug("TrackProducer") << "get a navigation school";
-  std::string theNavigationSchool ="";
-  if (conf_.exists("NavigationSchool")) theNavigationSchool= conf_.getParameter<std::string>("NavigationSchool");
-  else edm::LogWarning("TrackProducerBase")<<" NavigationSchool parameter not set. secondary hit pattern will not be filled.";
-  if (!theNavigationSchool.empty()){
+  std::string theNavigationSchool = "";
+  if (conf_.exists("NavigationSchool"))
+    theNavigationSchool = conf_.getParameter<std::string>("NavigationSchool");
+  else
+    edm::LogWarning("TrackProducerBase")
+        << " NavigationSchool parameter not set. secondary hit pattern will not be filled.";
+  if (!theNavigationSchool.empty()) {
     setup.get<NavigationSchoolRecord>().get(theNavigationSchool, theSchool);
-    LogDebug("TrackProducer") << "get also the measTk" << "\n";
+    LogDebug("TrackProducer") << "get also the measTk"
+                              << "\n";
     std::string measTkName = conf_.getParameter<std::string>("MeasurementTracker");
-    setup.get<CkfComponentsRecord>().get(measTkName,theMeasTk);
-  }
-  else{
-    theSchool = edm::ESHandle<NavigationSchool>(); //put an invalid handle
-    theMeasTk = edm::ESHandle<MeasurementTracker>(); //put an invalid handle
+    setup.get<CkfComponentsRecord>().get(measTkName, theMeasTk);
+  } else {
+    theSchool = edm::ESHandle<NavigationSchool>();    //put an invalid handle
+    theMeasTk = edm::ESHandle<MeasurementTracker>();  //put an invalid handle
   }
 }
 
-template <class T> void
-TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,edm::Handle<TrackCandidateCollection>& theTCCollection, reco::BeamSpot& bs)
-{
-  //		
+template <class T>
+void TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,
+                                      edm::Handle<TrackCandidateCollection>& theTCCollection,
+                                      reco::BeamSpot& bs) {
+  //
   //get the TrackCandidateCollection from the event
   //
-  LogDebug("TrackProducer") << 
-  	"get the TrackCandidateCollection from the event, source is " << conf_.getParameter<edm::InputTag>( "src" ) <<"\n";
-  theEvent.getByToken(src_,theTCCollection );  
+  LogDebug("TrackProducer") << "get the TrackCandidateCollection from the event, source is "
+                            << conf_.getParameter<edm::InputTag>("src") << "\n";
+  theEvent.getByToken(src_, theTCCollection);
 
   //get the BeamSpot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
-  if ( recoBeamSpotHandle.isValid() )
+  theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
+  if (recoBeamSpotHandle.isValid())
     bs = *recoBeamSpotHandle;
-  else 
+  else
     edm::LogWarning("TrackProducerBase") << " BeamSpot is not valid";
 }
 
-template <class T> void
-TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,edm::Handle<TrackView>& theTCollection, reco::BeamSpot& bs)
-{
+template <class T>
+void TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,
+                                      edm::Handle<TrackView>& theTCollection,
+                                      reco::BeamSpot& bs) {
   //
   //get the TrackCollection from the event
   //
-  LogDebug("TrackProducer") << 
-  	"get the TrackCollection from the event, source is " << conf_.getParameter<edm::InputTag>( "src" ) <<"\n";
-  theEvent.getByToken(src_,theTCollection );  
+  LogDebug("TrackProducer") << "get the TrackCollection from the event, source is "
+                            << conf_.getParameter<edm::InputTag>("src") << "\n";
+  theEvent.getByToken(src_, theTCollection);
 
   //get the BeamSpot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
-  if ( recoBeamSpotHandle.isValid() )
+  theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
+  if (recoBeamSpotHandle.isValid())
     bs = *recoBeamSpotHandle;
-  else 
+  else
     edm::LogWarning("TrackProducerBase") << " BeamSpot is not valid";
 }
 
 #include <TrackingTools/DetLayers/interface/DetLayer.h>
 #include <DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h>
 
-template <class T> void
-TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track, 
-					  const Propagator* prop, const MeasurementTrackerEvent* measTk,
-                                          const TrackerTopology* ttopo){
+template <class T>
+void TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj,
+                                               T& track,
+                                               const Propagator* prop,
+                                               const MeasurementTrackerEvent* measTk,
+                                               const TrackerTopology* ttopo) {
   using namespace std;
   /// have to clone the propagator in order to change its propagation direction.
   std::unique_ptr<Propagator> localProp(prop->clone());
 
   //use negative sigma=-3.0 in order to use a more conservative definition of isInside() for Bounds classes.
-  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,1.e12);  // same as defauts....
+  Chi2MeasurementEstimator estimator(30., -3.0, 0.5, 2.0, 0.5, 1.e12);  // same as defauts....
 
-  // WARNING: At the moment the trajectories has the measurements with reversed sorting after the track smoothing. 
+  // WARNING: At the moment the trajectories has the measurements with reversed sorting after the track smoothing.
   // Therefore the lastMeasurement is the inner one (for LHC-like tracks)
-  if(!traj->firstMeasurement().updatedState().isValid() ||
-      !traj->lastMeasurement().updatedState().isValid()) return;
+  if (!traj->firstMeasurement().updatedState().isValid() || !traj->lastMeasurement().updatedState().isValid())
+    return;
 
-    const FreeTrajectoryState*  outerState = traj->firstMeasurement().updatedState().freeState();    
-    const FreeTrajectoryState*  innerState = traj->lastMeasurement().updatedState().freeState(); 
-    TrajectoryStateOnSurface const & outerTSOS = traj->firstMeasurement().updatedState();
-    TrajectoryStateOnSurface const & innerTSOS = traj->lastMeasurement().updatedState();
-    const DetLayer* outerLayer = traj->firstMeasurement().layer();
-    const DetLayer* innerLayer = traj->lastMeasurement().layer();
+  const FreeTrajectoryState* outerState = traj->firstMeasurement().updatedState().freeState();
+  const FreeTrajectoryState* innerState = traj->lastMeasurement().updatedState().freeState();
+  TrajectoryStateOnSurface const& outerTSOS = traj->firstMeasurement().updatedState();
+  TrajectoryStateOnSurface const& innerTSOS = traj->lastMeasurement().updatedState();
+  const DetLayer* outerLayer = traj->firstMeasurement().layer();
+  const DetLayer* innerLayer = traj->lastMeasurement().layer();
 
-    if (!outerLayer || !innerLayer){
-      //means  that the trajectory was fit/smoothed in a special case: not setting those pointers
-	edm::LogError("TrackProducer") << "the trajectory was fit/smoothed in a special case: not setting those pointers.\n"
-			<<" Filling the secondary hit patterns was requested. So I will bail out.";
-	throw cms::Exception("TrackProducerBase")<<"the trajectory was fit/smoothed in a special case: not setting those pointers.\n"
-			<<" Filling the secondary hit patterns was requested. So I will bail out.";
-    }
-    
-    //WARNING: we are assuming that the hits were originally sorted along momentum (and therefore oppositeToMomentum after smoothing)
-    PropagationDirection dirForInnerLayers = oppositeToMomentum;
-    PropagationDirection dirForOuterLayers = alongMomentum;
-    auto outIn = traj->direction() != oppositeToMomentum;
-    if(outIn){
-	dirForInnerLayers = alongMomentum;
-	dirForOuterLayers = oppositeToMomentum;
-        // std::cout << "Iin setSecondHitPattern() logic. Trajectory direction (after smoothing) was not oppositeToMomentum. .. algo= " << track.algo() << std::endl;
-    }
-    // ----------- this previous block of code is not very safe. It should rely less on the sorting of the trajectory measurements -----
+  if (!outerLayer || !innerLayer) {
+    //means  that the trajectory was fit/smoothed in a special case: not setting those pointers
+    edm::LogError("TrackProducer") << "the trajectory was fit/smoothed in a special case: not setting those pointers.\n"
+                                   << " Filling the secondary hit patterns was requested. So I will bail out.";
+    throw cms::Exception("TrackProducerBase")
+        << "the trajectory was fit/smoothed in a special case: not setting those pointers.\n"
+        << " Filling the secondary hit patterns was requested. So I will bail out.";
+  }
 
-   
-    // Now all code looks as InOut in particular names
-    // we will take care of OutIn only where it matters (MISSING_INNER vs _OUTER)
-    
-    LogDebug("TrackProducer") << "calling inner compLayers()...";
-    auto const & innerCompLayers = (*theSchool).compatibleLayers(*innerLayer,*innerState,dirForInnerLayers);
-    LogDebug("TrackProducer") << "calling outer compLayers()...";
-    auto const & outerCompLayers = (*theSchool).compatibleLayers(*outerLayer,*outerState,dirForOuterLayers);
+  //WARNING: we are assuming that the hits were originally sorted along momentum (and therefore oppositeToMomentum after smoothing)
+  PropagationDirection dirForInnerLayers = oppositeToMomentum;
+  PropagationDirection dirForOuterLayers = alongMomentum;
+  auto outIn = traj->direction() != oppositeToMomentum;
+  if (outIn) {
+    dirForInnerLayers = alongMomentum;
+    dirForOuterLayers = oppositeToMomentum;
+    // std::cout << "Iin setSecondHitPattern() logic. Trajectory direction (after smoothing) was not oppositeToMomentum. .. algo= " << track.algo() << std::endl;
+  }
+  // ----------- this previous block of code is not very safe. It should rely less on the sorting of the trajectory measurements -----
 
-    LogDebug("TrackProducer")
-      << "inner DetLayer  sub: " 
-      << innerLayer->subDetector() <<"\n"
-      << "outer DetLayer  sub: " 
-      << outerLayer->subDetector() << "\n"
-      << "innerstate position rho: " << innerState->position().perp() << " z: "<< innerState->position().z()<<"\n"
-      << "innerstate state pT: " << innerState->momentum().perp() << " pz: "<< innerState->momentum().z()<<"\n"
-      << "outerstate position rho: " << outerState->position().perp() << " z: "<< outerState->position().z()<<"\n"
-      << "outerstate state pT: " << outerState->momentum().perp() << " pz: "<< outerState->momentum().z()<<"\n"
+  // Now all code looks as InOut in particular names
+  // we will take care of OutIn only where it matters (MISSING_INNER vs _OUTER)
 
-      << "innerLayers: " << innerCompLayers.size() << "\n"
-      << "outerLayers: " << outerCompLayers.size() << "\n";
+  LogDebug("TrackProducer") << "calling inner compLayers()...";
+  auto const& innerCompLayers = (*theSchool).compatibleLayers(*innerLayer, *innerState, dirForInnerLayers);
+  LogDebug("TrackProducer") << "calling outer compLayers()...";
+  auto const& outerCompLayers = (*theSchool).compatibleLayers(*outerLayer, *outerState, dirForOuterLayers);
 
+  LogDebug("TrackProducer") << "inner DetLayer  sub: " << innerLayer->subDetector() << "\n"
+                            << "outer DetLayer  sub: " << outerLayer->subDetector() << "\n"
+                            << "innerstate position rho: " << innerState->position().perp()
+                            << " z: " << innerState->position().z() << "\n"
+                            << "innerstate state pT: " << innerState->momentum().perp()
+                            << " pz: " << innerState->momentum().z() << "\n"
+                            << "outerstate position rho: " << outerState->position().perp()
+                            << " z: " << outerState->position().z() << "\n"
+                            << "outerstate state pT: " << outerState->momentum().perp()
+                            << " pz: " << outerState->momentum().z() << "\n"
 
-    auto loopOverLayer = [&](decltype(innerCompLayers) compLayers, TrajectoryStateOnSurface const & tsos) {
-      for(auto it : compLayers){
-        if (it->basicComponents().empty()) {
-	        //this should never happen. but better protect for it
-	        edm::LogWarning("TrackProducer")<<"a detlayer with no components: I cannot figure out a DetId from this layer. please investigate.";
-	        continue;
-        }
-        auto const & detWithState = it->compatibleDets(tsos,*localProp,estimator);
-        if(detWithState.empty()) continue;
-        DetId id = detWithState.front().first->geographicalId();
-        MeasurementDetWithData const & measDet = measTk->idToDet(id);
-        if(measDet.isActive() && !measDet.hasBadComponents(detWithState.front().second)){
-	        InvalidTrackingRecHit tmpHit(*detWithState.front().first, outIn ? TrackingRecHit::missing_outer : TrackingRecHit::missing_inner);
-	        track.appendHitPattern(tmpHit, *ttopo);
-	        //cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
-        }else{
-	        //cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;
-                InvalidTrackingRecHit tmpHit(*detWithState.front().first, outIn ? TrackingRecHit::inactive_outer : TrackingRecHit::inactive_inner);
-                track.appendHitPattern(tmpHit, *ttopo);
-        }
-      } //end loop over layers
-    }; // end lambda
+                            << "innerLayers: " << innerCompLayers.size() << "\n"
+                            << "outerLayers: " << outerCompLayers.size() << "\n";
 
-   localProp->setPropagationDirection(oppositeToMomentum);
-   loopOverLayer(innerCompLayers,innerTSOS);
+  auto loopOverLayer =
+      [&](decltype(innerCompLayers) compLayers, TrajectoryStateOnSurface const& tsos) {
+        for (auto it : compLayers) {
+          if (it->basicComponents().empty()) {
+            //this should never happen. but better protect for it
+            edm::LogWarning("TrackProducer")
+                << "a detlayer with no components: I cannot figure out a DetId from this layer. please investigate.";
+            continue;
+          }
+          auto const& detWithState = it->compatibleDets(tsos, *localProp, estimator);
+          if (detWithState.empty())
+            continue;
+          DetId id = detWithState.front().first->geographicalId();
+          MeasurementDetWithData const& measDet = measTk->idToDet(id);
+          if (measDet.isActive() && !measDet.hasBadComponents(detWithState.front().second)) {
+            InvalidTrackingRecHit tmpHit(*detWithState.front().first,
+                                         outIn ? TrackingRecHit::missing_outer : TrackingRecHit::missing_inner);
+            track.appendHitPattern(tmpHit, *ttopo);
+            //cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
+          } else {
+            //cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;
+            InvalidTrackingRecHit tmpHit(*detWithState.front().first,
+                                         outIn ? TrackingRecHit::inactive_outer : TrackingRecHit::inactive_inner);
+            track.appendHitPattern(tmpHit, *ttopo);
+          }
+        }  //end loop over layers
+      };   // end lambda
 
-   localProp->setPropagationDirection(alongMomentum);
-   outIn = !outIn;  // if inOut should mark missing_outer
-   loopOverLayer(outerCompLayers,outerTSOS);
+  localProp->setPropagationDirection(oppositeToMomentum);
+  loopOverLayer(innerCompLayers, innerTSOS);
 
+  localProp->setPropagationDirection(alongMomentum);
+  outIn = !outIn;  // if inOut should mark missing_outer
+  loopOverLayer(outerCompLayers, outerTSOS);
 }
-
-

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -100,7 +100,7 @@ TrackProducerBase<T>::getFromES(const edm::EventSetup& setup,
   std::string theNavigationSchool ="";
   if (conf_.exists("NavigationSchool")) theNavigationSchool= conf_.getParameter<std::string>("NavigationSchool");
   else edm::LogWarning("TrackProducerBase")<<" NavigationSchool parameter not set. secondary hit pattern will not be filled.";
-  if (theNavigationSchool!=""){
+  if (!theNavigationSchool.empty()){
     setup.get<NavigationSchoolRecord>().get(theNavigationSchool, theSchool);
     LogDebug("TrackProducer") << "get also the measTk" << "\n";
     std::string measTkName = conf_.getParameter<std::string>("MeasurementTracker");
@@ -226,7 +226,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
 	        continue;
         }
         auto const & detWithState = it->compatibleDets(tsos,*localProp,estimator);
-        if(!detWithState.size()) continue;
+        if(detWithState.empty()) continue;
         DetId id = detWithState.front().first->geographicalId();
         MeasurementDetWithData const & measDet = measTk->idToDet(id);
         if(measDet.isActive() && !measDet.hasBadComponents(detWithState.front().second)){

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
@@ -17,86 +17,79 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-
-DAFTrackProducer::DAFTrackProducer(const edm::ParameterSet& iConfig):
-  KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),false),
-  theAlgo(iConfig)
-{
+DAFTrackProducer::DAFTrackProducer(const edm::ParameterSet& iConfig)
+    : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"), false), theAlgo(iConfig) {
   setConf(iConfig);
-  setSrc( consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>( "src" )),
-          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )),
-          consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>( "MeasurementTrackerEvent") ));
-  srcTT_ = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>( "src" ));
-  setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
+  setSrc(consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")),
+         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
+         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  srcTT_ = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  setAlias(iConfig.getParameter<std::string>("@module_label"));
 
   //register your products
-  produces<reco::TrackCollection>().setBranchAlias( alias_ + "Tracks" );
-  produces<reco::TrackExtraCollection>().setBranchAlias( alias_ + "TrackExtras" );
-  produces<TrackingRecHitCollection>().setBranchAlias( alias_ + "RecHits" );
+  produces<reco::TrackCollection>().setBranchAlias(alias_ + "Tracks");
+  produces<reco::TrackExtraCollection>().setBranchAlias(alias_ + "TrackExtras");
+  produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
   produces<std::vector<Trajectory> >();
   produces<TrajTrackAssociationCollection>();
-  produces<TrajAnnealingCollection>().setBranchAlias( alias_ + "TrajectoryAnnealing" );
-  produces<reco::TrackCollection>("beforeDAF").setBranchAlias( alias_ + "TracksBeforeDAF" );
-  produces<reco::TrackExtraCollection>("beforeDAF").setBranchAlias( alias_ + "TrackExtrasBeforeDAF" );
-  produces<reco::TrackCollection>("afterDAF").setBranchAlias( alias_ + "TracksAfterDAF" );
-  produces<reco::TrackExtraCollection>("afterDAF").setBranchAlias( alias_ + "TrackExtrasAfterDAF" );
+  produces<TrajAnnealingCollection>().setBranchAlias(alias_ + "TrajectoryAnnealing");
+  produces<reco::TrackCollection>("beforeDAF").setBranchAlias(alias_ + "TracksBeforeDAF");
+  produces<reco::TrackExtraCollection>("beforeDAF").setBranchAlias(alias_ + "TrackExtrasBeforeDAF");
+  produces<reco::TrackCollection>("afterDAF").setBranchAlias(alias_ + "TracksAfterDAF");
+  produces<reco::TrackExtraCollection>("afterDAF").setBranchAlias(alias_ + "TrackExtrasAfterDAF");
 
   TrajAnnSaving_ = iConfig.getParameter<bool>("TrajAnnealingSaving");
 }
 
-
-void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup)
-{
+void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup) {
   edm::LogInfo("DAFTrackProducer") << "Analyzing event number: " << theEvent.id() << "\n";
-  
-  //empty output collections
-  std::unique_ptr<TrackingRecHitCollection>    outputRHColl (new TrackingRecHitCollection);
-  std::unique_ptr<reco::TrackCollection>       outputTColl(new reco::TrackCollection);
-  std::unique_ptr<reco::TrackExtraCollection>  outputTEColl(new reco::TrackExtraCollection);
-  std::unique_ptr<std::vector<Trajectory> >    outputTrajectoryColl(new std::vector<Trajectory>);
-  std::unique_ptr<TrajAnnealingCollection>     outputTrajAnnColl(new TrajAnnealingCollection);
-  std::unique_ptr<std::vector<int> >           outputIndecesInputColl(new std::vector<int>);
 
- 
+  //empty output collections
+  std::unique_ptr<TrackingRecHitCollection> outputRHColl(new TrackingRecHitCollection);
+  std::unique_ptr<reco::TrackCollection> outputTColl(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> outputTEColl(new reco::TrackExtraCollection);
+  std::unique_ptr<std::vector<Trajectory> > outputTrajectoryColl(new std::vector<Trajectory>);
+  std::unique_ptr<TrajAnnealingCollection> outputTrajAnnColl(new TrajAnnealingCollection);
+  std::unique_ptr<std::vector<int> > outputIndecesInputColl(new std::vector<int>);
+
   //new tracks collections (changes before and after DAF)
-  std::unique_ptr<TrackingRecHitCollection>    outputRHCollBeforeDAF (new TrackingRecHitCollection);
-  std::unique_ptr<reco::TrackCollection>       outputTCollBeforeDAF(new reco::TrackCollection);
-  std::unique_ptr<reco::TrackExtraCollection>  outputTECollBeforeDAF(new reco::TrackExtraCollection);
-  std::unique_ptr<std::vector<Trajectory> >    outputTrajectoryCollBeforeDAF(new std::vector<Trajectory>);
-  std::unique_ptr<std::vector<int> >           outputIndecesInputCollBeforeDAF(new std::vector<int>);
+  std::unique_ptr<TrackingRecHitCollection> outputRHCollBeforeDAF(new TrackingRecHitCollection);
+  std::unique_ptr<reco::TrackCollection> outputTCollBeforeDAF(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> outputTECollBeforeDAF(new reco::TrackExtraCollection);
+  std::unique_ptr<std::vector<Trajectory> > outputTrajectoryCollBeforeDAF(new std::vector<Trajectory>);
+  std::unique_ptr<std::vector<int> > outputIndecesInputCollBeforeDAF(new std::vector<int>);
   //----
-  std::unique_ptr<TrackingRecHitCollection>    outputRHCollAfterDAF (new TrackingRecHitCollection);
-  std::unique_ptr<reco::TrackCollection>       outputTCollAfterDAF(new reco::TrackCollection);
-  std::unique_ptr<reco::TrackExtraCollection>  outputTECollAfterDAF(new reco::TrackExtraCollection);
-  std::unique_ptr<std::vector<Trajectory> >    outputTrajectoryCollAfterDAF(new std::vector<Trajectory>);
-  std::unique_ptr<std::vector<int> >           outputIndecesInputCollAfterDAF(new std::vector<int>);
+  std::unique_ptr<TrackingRecHitCollection> outputRHCollAfterDAF(new TrackingRecHitCollection);
+  std::unique_ptr<reco::TrackCollection> outputTCollAfterDAF(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> outputTECollAfterDAF(new reco::TrackExtraCollection);
+  std::unique_ptr<std::vector<Trajectory> > outputTrajectoryCollAfterDAF(new std::vector<Trajectory>);
+  std::unique_ptr<std::vector<int> > outputIndecesInputCollAfterDAF(new std::vector<int>);
 
   //declare and get stuff to be retrieved from ES
   edm::ESHandle<TrackerGeometry> theG;
   edm::ESHandle<MagneticField> theMF;
   edm::ESHandle<TrajectoryFitter> theFitter;
   edm::ESHandle<Propagator> thePropagator;
-  edm::ESHandle<MeasurementTracker>  theMeasTk;
+  edm::ESHandle<MeasurementTracker> theMeasTk;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
+  getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
   edm::ESHandle<TrackerTopology> httopo;
   setup.get<TrackerTopologyRcd>().get(httopo);
 
-  //get additional es_modules needed by the DAF	
+  //get additional es_modules needed by the DAF
   edm::ESHandle<MultiRecHitCollector> measurementCollectorHandle;
   std::string measurementCollectorName = getConf().getParameter<std::string>("MeasurementCollector");
   setup.get<MultiRecHitRecord>().get(measurementCollectorName, measurementCollectorHandle);
   edm::ESHandle<SiTrackerMultiRecHitUpdator> updatorHandle;
-  std::string updatorName = getConf().getParameter<std::string>("UpdatorName");	
-  setup.get<MultiRecHitRecord>().get(updatorName, updatorHandle);	 
+  std::string updatorName = getConf().getParameter<std::string>("UpdatorName");
+  setup.get<MultiRecHitRecord>().get(updatorName, updatorHandle);
 
   //get MeasurementTrackerEvent
   edm::Handle<MeasurementTrackerEvent> mte;
   theEvent.getByToken(mteSrc_, mte);
 
-
-  //declare and get TrackCollection 
+  //declare and get TrackCollection
   AlgoProductCollection algoResults;
   reco::BeamSpot bs;
   TrajAnnealingCollection trajannResults;
@@ -104,66 +97,101 @@ void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   //declare and get  new tracks collections
   AlgoProductCollection algoResultsBeforeDAF;
   AlgoProductCollection algoResultsAfterDAF;
-  try{
-
+  try {
     edm::Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-    getFromEvt(theEvent,trajTrackAssociationHandle,bs);
+    getFromEvt(theEvent, trajTrackAssociationHandle, bs);
 
+    //run the algorithm
+    LogDebug("DAFTrackProducer") << "run the DAF algorithm"
+                                 << "\n";
+    theAlgo.runWithCandidate(theG.product(),
+                             theMF.product(),
+                             *trajTrackAssociationHandle,
+                             &*mte,
+                             theFitter.product(),
+                             theBuilder.product(),
+                             measurementCollectorHandle.product(),
+                             updatorHandle.product(),
+                             bs,
+                             algoResults,
+                             trajannResults,
+                             TrajAnnSaving_,
+                             algoResultsBeforeDAF,
+                             algoResultsAfterDAF);
 
-    //run the algorithm  
-    LogDebug("DAFTrackProducer") << "run the DAF algorithm" << "\n";
-    theAlgo.runWithCandidate(theG.product(), theMF.product(),  
-			     *trajTrackAssociationHandle, 
-			     &*mte,
-                             theFitter.product(), theBuilder.product(), 
-			     measurementCollectorHandle.product(), updatorHandle.product(), bs, 
-			     algoResults, trajannResults, TrajAnnSaving_,
-			     algoResultsBeforeDAF, algoResultsAfterDAF);
-    
-  } catch (cms::Exception &e){ 
-    edm::LogInfo("DAFTrackProducer") << "cms::Exception caught!!!" << "\n" << e << "\n"; 
-    throw; 
+  } catch (cms::Exception& e) {
+    edm::LogInfo("DAFTrackProducer") << "cms::Exception caught!!!"
+                                     << "\n"
+                                     << e << "\n";
+    throw;
   }
 
   //put everything in the event
-  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), 
-           outputRHColl, outputTColl, outputTEColl, 
-           outputTrajectoryColl,  outputIndecesInputColl, algoResults, theBuilder.product(), httopo.product());
+  putInEvt(theEvent,
+           thePropagator.product(),
+           theMeasTk.product(),
+           outputRHColl,
+           outputTColl,
+           outputTEColl,
+           outputTrajectoryColl,
+           outputIndecesInputColl,
+           algoResults,
+           theBuilder.product(),
+           httopo.product());
   putInEvtTrajAnn(theEvent, trajannResults, outputTrajAnnColl);
 
   //put in theEvent before and after DAF tracks collections
-  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), 
-           outputRHCollBeforeDAF, outputTCollBeforeDAF, outputTECollBeforeDAF, 
-           outputTrajectoryCollBeforeDAF,  outputIndecesInputCollBeforeDAF, algoResultsBeforeDAF, theBuilder.product(), httopo.product(), 1);
-  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), 
-           outputRHCollAfterDAF, outputTCollAfterDAF, outputTECollAfterDAF, 
-           outputTrajectoryCollAfterDAF,  outputIndecesInputCollAfterDAF, algoResultsAfterDAF, theBuilder.product(), httopo.product(), 2);
+  putInEvt(theEvent,
+           thePropagator.product(),
+           theMeasTk.product(),
+           outputRHCollBeforeDAF,
+           outputTCollBeforeDAF,
+           outputTECollBeforeDAF,
+           outputTrajectoryCollBeforeDAF,
+           outputIndecesInputCollBeforeDAF,
+           algoResultsBeforeDAF,
+           theBuilder.product(),
+           httopo.product(),
+           1);
+  putInEvt(theEvent,
+           thePropagator.product(),
+           theMeasTk.product(),
+           outputRHCollAfterDAF,
+           outputTCollAfterDAF,
+           outputTECollAfterDAF,
+           outputTrajectoryCollAfterDAF,
+           outputIndecesInputCollAfterDAF,
+           algoResultsAfterDAF,
+           theBuilder.product(),
+           httopo.product(),
+           2);
 
-  LogDebug("DAFTrackProducer") << "end the DAF algorithm." << "\n";
+  LogDebug("DAFTrackProducer") << "end the DAF algorithm."
+                               << "\n";
 }
 //----------------------------------------------------------------------------------------------------------//
-void DAFTrackProducer::getFromEvt(edm::Event& theEvent,edm::Handle<TrajTrackAssociationCollection>& trajTrackAssociationHandle, reco::BeamSpot& bs)
-{
-
+void DAFTrackProducer::getFromEvt(edm::Event& theEvent,
+                                  edm::Handle<TrajTrackAssociationCollection>& trajTrackAssociationHandle,
+                                  reco::BeamSpot& bs) {
   //get the TrajTrackMap from the event
   //WARNING: src has always to be redefined in cfg file
-  theEvent.getByToken(srcTT_,trajTrackAssociationHandle);
+  theEvent.getByToken(srcTT_, trajTrackAssociationHandle);
 
   //get the BeamSpot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
+  theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
   bs = *recoBeamSpotHandle;
-
 }
 //----------------------------------------------------------------------------------------------------------//
-void DAFTrackProducer::putInEvtTrajAnn(edm::Event& theEvent, TrajAnnealingCollection & trajannResults,
-				std::unique_ptr<TrajAnnealingCollection>& outputTrajAnnColl){
+void DAFTrackProducer::putInEvtTrajAnn(edm::Event& theEvent,
+                                       TrajAnnealingCollection& trajannResults,
+                                       std::unique_ptr<TrajAnnealingCollection>& outputTrajAnnColl) {
   const int size = trajannResults.size();
   outputTrajAnnColl->reserve(size);
 
-  for(unsigned int i = 0; i < trajannResults.size() ; i++){
+  for (unsigned int i = 0; i < trajannResults.size(); i++) {
     outputTrajAnnColl->push_back(trajannResults[i]);
   }
 
-  theEvent.put( std::move(outputTrajAnnColl) );
+  theEvent.put(std::move(outputTrajAnnColl));
 }

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
@@ -16,9 +16,8 @@
 
 class DAFTrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
-
   typedef std::vector<Trajectory> TrajectoryCollection;
-//  typedef std::vector<TrajAnnealing> TrajAnnealingCollection;
+  //  typedef std::vector<TrajAnnealing> TrajAnnealingCollection;
   explicit DAFTrackProducer(const edm::ParameterSet& iConfig);
 
   // Implementation of produce method
@@ -28,12 +27,12 @@ private:
   DAFTrackProducerAlgorithm theAlgo;
   using TrackProducerBase<reco::Track>::getFromEvt;
   void getFromEvt(edm::Event&, edm::Handle<TrajTrackAssociationCollection>&, reco::BeamSpot&);
-  void putInEvtTrajAnn(edm::Event& theEvent, TrajAnnealingCollection & trajannResults,
-                std::unique_ptr<TrajAnnealingCollection>& selTrajAnn);
+  void putInEvtTrajAnn(edm::Event& theEvent,
+                       TrajAnnealingCollection& trajannResults,
+                       std::unique_ptr<TrajAnnealingCollection>& selTrajAnn);
 
   bool TrajAnnSaving_;
   edm::EDGetToken srcTT_;
-  
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.cc
+++ b/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.cc
@@ -2,7 +2,7 @@
 //
 // Package:    ExtraFromSeeds
 // Class:      ExtraFromSeeds
-// 
+//
 /**\class ExtraFromSeeds ExtraFromSeeds.cc RecoTracker/ExtraFromSeeds/src/ExtraFromSeeds.cc
 
  Description: [one line class summary]
@@ -16,83 +16,68 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
 #include "RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h"
 
-
 //
 // constructors and destructor
 //
-ExtraFromSeeds::ExtraFromSeeds(const edm::ParameterSet& iConfig):
-  tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks")))
-{
+ExtraFromSeeds::ExtraFromSeeds(const edm::ParameterSet& iConfig)
+    : tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))) {
   produces<ExtremeLight>();
   produces<TrackingRecHitCollection>();
-  
 }
 
-
-ExtraFromSeeds::~ExtraFromSeeds()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+ExtraFromSeeds::~ExtraFromSeeds() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-ExtraFromSeeds::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-
+void ExtraFromSeeds::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   // in
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByToken(tracks_,tracks);
+  iEvent.getByToken(tracks_, tracks);
 
-  // out  
+  // out
   std::unique_ptr<ExtremeLight> exxtralOut(new ExtremeLight());
   exxtralOut->resize(tracks->size());
 
   std::unique_ptr<TrackingRecHitCollection> hitOut(new TrackingRecHitCollection());
   TrackingRecHitRefProd rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
-  hitOut->reserve(3*tracks->size());
+  hitOut->reserve(3 * tracks->size());
 
-  for (unsigned int ie=0;ie!=tracks->size();++ie){
-    const reco::Track & track = (*tracks)[ie];
-    const reco::TrackExtra & extra = *track.extra();
+  for (unsigned int ie = 0; ie != tracks->size(); ++ie) {
+    const reco::Track& track = (*tracks)[ie];
+    const reco::TrackExtra& extra = *track.extra();
     //only for high purity tracks
-    if (!track.quality(reco::TrackBase::highPurity)) continue;
+    if (!track.quality(reco::TrackBase::highPurity))
+      continue;
 
-    TrajectorySeed::range seedRange=extra.seedRef()->recHits();
+    TrajectorySeed::range seedRange = extra.seedRef()->recHits();
     TrajectorySeed::const_iterator seedHit;
-    (*exxtralOut)[ie]=extra.seedRef()->nHits();
-    for (seedHit=seedRange.first;seedHit!=seedRange.second;++seedHit){
-      TrackingRecHit * hit = seedHit->clone();
-      hitOut->push_back( hit );
+    (*exxtralOut)[ie] = extra.seedRef()->nHits();
+    for (seedHit = seedRange.first; seedHit != seedRange.second; ++seedHit) {
+      TrackingRecHit* hit = seedHit->clone();
+      hitOut->push_back(hit);
     }
-
   }
-  
+
   iEvent.put(std::move(exxtralOut));
-	     iEvent.put(std::move(hitOut));
+  iEvent.put(std::move(hitOut));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-ExtraFromSeeds::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void ExtraFromSeeds::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
-
-

--- a/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h
+++ b/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h
@@ -5,7 +5,7 @@
 //
 // Package:    ExtraFromSeeds
 // Class:      ExtraFromSeeds
-// 
+//
 /**\class ExtraFromSeeds ExtraFromSeeds.cc RecoTracker/ExtraFromSeeds/src/ExtraFromSeeds.cc
 
  Description: [one line class summary]
@@ -18,7 +18,6 @@
 //         Created:  Fri Feb 17 12:03:11 CET 2012
 //
 //
-
 
 // system include files
 #include <memory>
@@ -37,25 +36,24 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-
 //
 // class declaration
 //
 
 class ExtraFromSeeds : public edm::global::EDProducer<> {
-   public:
-      explicit ExtraFromSeeds(const edm::ParameterSet&);
-      ~ExtraFromSeeds() override;
+public:
+  explicit ExtraFromSeeds(const edm::ParameterSet&);
+  ~ExtraFromSeeds() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   edm::EDGetTokenT<reco::TrackCollection> tracks_;
   typedef std::vector<unsigned int> ExtremeLight;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -9,7 +9,6 @@
   \author   Giovanni Petrucciani
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -35,111 +34,121 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-
-
-template<class T>
+template <class T>
 class FakeTrackProducer : public edm::stream::EDProducer<> {
-    public:
-      explicit FakeTrackProducer(const edm::ParameterSet & iConfig);
-      ~FakeTrackProducer() override { }
+public:
+  explicit FakeTrackProducer(const edm::ParameterSet &iConfig);
+  ~FakeTrackProducer() override {}
 
-      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-    private:
-      /// Labels for input collections
-      edm::EDGetTokenT<std::vector<T>> src_;
+  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
-      /// Muon selection
-      //StringCutObjectSelector<T> selector_;
+private:
+  /// Labels for input collections
+  edm::EDGetTokenT<std::vector<T>> src_;
 
-      const PTrajectoryStateOnDet & getState(const TrajectorySeed &seed) const { return seed.startingState(); }
-      const PTrajectoryStateOnDet & getState(const TrackCandidate &seed) const { return seed.trajectoryStateOnDet(); }
-      TrajectorySeed::range  getHits (const TrajectorySeed &seed) const { return seed.recHits(); }
-      TrajectorySeed::range  getHits (const TrackCandidate &seed) const { return seed.recHits(); }
+  /// Muon selection
+  //StringCutObjectSelector<T> selector_;
+
+  const PTrajectoryStateOnDet &getState(const TrajectorySeed &seed) const { return seed.startingState(); }
+  const PTrajectoryStateOnDet &getState(const TrackCandidate &seed) const { return seed.trajectoryStateOnDet(); }
+  TrajectorySeed::range getHits(const TrajectorySeed &seed) const { return seed.recHits(); }
+  TrajectorySeed::range getHits(const TrackCandidate &seed) const { return seed.recHits(); }
 };
 
-
-template<typename T>
-FakeTrackProducer<T>::FakeTrackProducer(const edm::ParameterSet & iConfig) :
-    src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src")))
-    //,selector_(iConfig.existsAs<std::string>("cut") ? iConfig.getParameter<std::string>("cut") : "", true)
+template <typename T>
+FakeTrackProducer<T>::FakeTrackProducer(const edm::ParameterSet &iConfig)
+    : src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src")))
+//,selector_(iConfig.existsAs<std::string>("cut") ? iConfig.getParameter<std::string>("cut") : "", true)
 {
-    produces<std::vector<reco::Track> >(); 
-    produces<std::vector<reco::TrackExtra> >();
-    produces<edm::OwnVector<TrackingRecHit> >();
+  produces<std::vector<reco::Track>>();
+  produces<std::vector<reco::TrackExtra>>();
+  produces<edm::OwnVector<TrackingRecHit>>();
 }
 
-template<typename T>
-void 
-FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
+template <typename T>
+void FakeTrackProducer<T>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
 
+  edm::ESHandle<TrackerGeometry> theGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry);
+  edm::ESHandle<MagneticField> theMagField;
+  iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology &ttopo = *httopo;
 
-    edm::ESHandle<TrackerGeometry> theGeometry;
-    iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry);
-    edm::ESHandle<MagneticField>   theMagField;
-    iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
-    edm::ESHandle<TrackerTopology> httopo;
-    iSetup.get<TrackerTopologyRcd>().get(httopo);
-    const TrackerTopology& ttopo = *httopo;
+  Handle<vector<T>> src;
+  iEvent.getByToken(src_, src);
 
-    Handle<vector<T> > src;
-    iEvent.getByToken(src_, src);
+  unique_ptr<vector<reco::Track>> out(new vector<reco::Track>());
+  out->reserve(src->size());
+  unique_ptr<vector<reco::TrackExtra>> outEx(new vector<reco::TrackExtra>());
+  outEx->reserve(src->size());
+  unique_ptr<OwnVector<TrackingRecHit>> outHits(new OwnVector<TrackingRecHit>());
 
-    unique_ptr<vector<reco::Track> > out(new vector<reco::Track>());
-    out->reserve(src->size());
-    unique_ptr<vector<reco::TrackExtra> > outEx(new vector<reco::TrackExtra>());
-    outEx->reserve(src->size());
-    unique_ptr<OwnVector<TrackingRecHit> > outHits(new OwnVector<TrackingRecHit>());
-
-    TrackingRecHitRefProd rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
-    reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-    for (typename vector<T>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        const T &mu = *it;
-        //if (!selector_(mu)) continue;
-        const PTrajectoryStateOnDet & pstate = getState(mu);
-        const GeomDet *det = theGeometry->idToDet(DetId(pstate.detId()));
-        if (det == nullptr) { std::cerr << "ERROR:  bogus detid " << pstate.detId() << std::endl; continue; }
-        TrajectoryStateOnSurface state = trajectoryStateTransform::transientState(pstate, & det->surface(), &*theMagField);
-        GlobalPoint  gx = state.globalPosition();
-        GlobalVector gp = state.globalMomentum();
-        reco::Track::Point x(gx.x(), gx.y(), gx.z());
-        reco::Track::Vector p(gp.x(), gp.y(), gp.z());
-        int charge = state.localParameters().charge();
-        out->push_back(reco::Track(1.0,1.0,x,p,charge,reco::Track::CovarianceMatrix()));
-        TrajectorySeed::range hits = getHits(mu);
-        out->back().appendHits(hits.first, hits.second, ttopo);
-        // Now Track Extra
-        const TrackingRecHit *hit0 =  &*hits.first;
-        const TrackingRecHit *hit1 = &*(hits.second-1);
-        const GeomDet *det0 = theGeometry->idToDet(hit0->geographicalId());
-        const GeomDet *det1 = theGeometry->idToDet(hit1->geographicalId());
-        if (det0 == nullptr || det1 == nullptr) { std::cerr << "ERROR:  bogus detids at beginning or end of range" << std::endl; continue; }
-        GlobalPoint gx0 = det0->toGlobal(hit0->localPosition());
-        GlobalPoint gx1 = det1->toGlobal(hit1->localPosition());
-        reco::Track::Point x0(gx0.x(), gx0.y(), gx0.z());
-        reco::Track::Point x1(gx1.x(), gx1.y(), gx1.z());
-        if (x0.R() > x1.R()) std::swap(x0,x1);
-        outEx->push_back( reco::TrackExtra(x1, p, true, x0, p, true, 
-                                reco::Track::CovarianceMatrix(), hit0->geographicalId().rawId(),
-                                reco::Track::CovarianceMatrix(), hit1->geographicalId().rawId(),
-                                alongMomentum) );
-        out->back().setExtra( reco::TrackExtraRef( rTrackExtras, outEx->size()-1 ) );
-        reco::TrackExtra &ex = outEx->back();    
-        auto const firstHitIndex = outHits->size();
-        for (OwnVector<TrackingRecHit>::const_iterator it2 = hits.first; it2 != hits.second; ++it2) {
-            outHits->push_back(*it2);
-        } 
-        ex.setHits( rHits, firstHitIndex, outHits->size()-firstHitIndex);
+  TrackingRecHitRefProd rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
+  reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  for (typename vector<T>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    const T &mu = *it;
+    //if (!selector_(mu)) continue;
+    const PTrajectoryStateOnDet &pstate = getState(mu);
+    const GeomDet *det = theGeometry->idToDet(DetId(pstate.detId()));
+    if (det == nullptr) {
+      std::cerr << "ERROR:  bogus detid " << pstate.detId() << std::endl;
+      continue;
     }
+    TrajectoryStateOnSurface state = trajectoryStateTransform::transientState(pstate, &det->surface(), &*theMagField);
+    GlobalPoint gx = state.globalPosition();
+    GlobalVector gp = state.globalMomentum();
+    reco::Track::Point x(gx.x(), gx.y(), gx.z());
+    reco::Track::Vector p(gp.x(), gp.y(), gp.z());
+    int charge = state.localParameters().charge();
+    out->push_back(reco::Track(1.0, 1.0, x, p, charge, reco::Track::CovarianceMatrix()));
+    TrajectorySeed::range hits = getHits(mu);
+    out->back().appendHits(hits.first, hits.second, ttopo);
+    // Now Track Extra
+    const TrackingRecHit *hit0 = &*hits.first;
+    const TrackingRecHit *hit1 = &*(hits.second - 1);
+    const GeomDet *det0 = theGeometry->idToDet(hit0->geographicalId());
+    const GeomDet *det1 = theGeometry->idToDet(hit1->geographicalId());
+    if (det0 == nullptr || det1 == nullptr) {
+      std::cerr << "ERROR:  bogus detids at beginning or end of range" << std::endl;
+      continue;
+    }
+    GlobalPoint gx0 = det0->toGlobal(hit0->localPosition());
+    GlobalPoint gx1 = det1->toGlobal(hit1->localPosition());
+    reco::Track::Point x0(gx0.x(), gx0.y(), gx0.z());
+    reco::Track::Point x1(gx1.x(), gx1.y(), gx1.z());
+    if (x0.R() > x1.R())
+      std::swap(x0, x1);
+    outEx->push_back(reco::TrackExtra(x1,
+                                      p,
+                                      true,
+                                      x0,
+                                      p,
+                                      true,
+                                      reco::Track::CovarianceMatrix(),
+                                      hit0->geographicalId().rawId(),
+                                      reco::Track::CovarianceMatrix(),
+                                      hit1->geographicalId().rawId(),
+                                      alongMomentum));
+    out->back().setExtra(reco::TrackExtraRef(rTrackExtras, outEx->size() - 1));
+    reco::TrackExtra &ex = outEx->back();
+    auto const firstHitIndex = outHits->size();
+    for (OwnVector<TrackingRecHit>::const_iterator it2 = hits.first; it2 != hits.second; ++it2) {
+      outHits->push_back(*it2);
+    }
+    ex.setHits(rHits, firstHitIndex, outHits->size() - firstHitIndex);
+  }
 
-    iEvent.put(std::move(out));
-    iEvent.put(std::move(outEx));
-    iEvent.put(std::move(outHits));
+  iEvent.put(std::move(out));
+  iEvent.put(std::move(outEx));
+  iEvent.put(std::move(outHits));
 }
 
-typedef  FakeTrackProducer<TrajectorySeed> FakeTrackProducerFromSeed;
-typedef  FakeTrackProducer<TrackCandidate> FakeTrackProducerFromCandidate;
+typedef FakeTrackProducer<TrajectorySeed> FakeTrackProducerFromSeed;
+typedef FakeTrackProducer<TrackCandidate> FakeTrackProducerFromCandidate;
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(FakeTrackProducerFromSeed);
 DEFINE_FWK_MODULE(FakeTrackProducerFromCandidate);

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -18,40 +18,36 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig):
-  GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
-		       iConfig.getParameter<bool>("useHitsSplitting")),
-  theAlgo(iConfig)
-{
+GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig)
+    : GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
+                           iConfig.getParameter<bool>("useHitsSplitting")),
+      theAlgo(iConfig) {
   setConf(iConfig);
-  setSrc( consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>( "src" )), 
-          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )),
-          consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>( "MeasurementTrackerEvent") ));
-  setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
-//   string a = alias_;
-//   a.erase(a.size()-6,a.size());
+  setSrc(consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>("src")),
+         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
+         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  setAlias(iConfig.getParameter<std::string>("@module_label"));
+  //   string a = alias_;
+  //   a.erase(a.size()-6,a.size());
   //register your products
-  produces<reco::GsfTrackCollection>().setBranchAlias( alias_ + "GsfTracks" );
-  produces<reco::TrackExtraCollection>().setBranchAlias( alias_ + "TrackExtras" );
-  produces<reco::GsfTrackExtraCollection>().setBranchAlias( alias_ + "GsfTrackExtras" );
-  produces<TrackingRecHitCollection>().setBranchAlias( alias_ + "RecHits" );
-  produces<std::vector<Trajectory> >() ;
+  produces<reco::GsfTrackCollection>().setBranchAlias(alias_ + "GsfTracks");
+  produces<reco::TrackExtraCollection>().setBranchAlias(alias_ + "TrackExtras");
+  produces<reco::GsfTrackExtraCollection>().setBranchAlias(alias_ + "GsfTrackExtras");
+  produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
+  produces<std::vector<Trajectory> >();
   produces<TrajGsfTrackAssociationCollection>();
-
 }
 
-
-void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup)
-{
+void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup) {
   edm::LogInfo("GsfTrackProducer") << "Analyzing event number: " << theEvent.id() << "\n";
   //
   // create empty output collections
   //
-  std::unique_ptr<TrackingRecHitCollection> outputRHColl (new TrackingRecHitCollection);
+  std::unique_ptr<TrackingRecHitCollection> outputRHColl(new TrackingRecHitCollection);
   std::unique_ptr<reco::GsfTrackCollection> outputTColl(new reco::GsfTrackCollection);
   std::unique_ptr<reco::TrackExtraCollection> outputTEColl(new reco::TrackExtraCollection);
   std::unique_ptr<reco::GsfTrackExtraCollection> outputGsfTEColl(new reco::GsfTrackExtraCollection);
-  std::unique_ptr<std::vector<Trajectory> >    outputTrajectoryColl(new std::vector<Trajectory>);
+  std::unique_ptr<std::vector<Trajectory> > outputTrajectoryColl(new std::vector<Trajectory>);
 
   //
   //declare and get stuff to be retrieved from ES
@@ -60,9 +56,9 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<MagneticField> theMF;
   edm::ESHandle<TrajectoryFitter> theFitter;
   edm::ESHandle<Propagator> thePropagator;
-  edm::ESHandle<MeasurementTracker>  theMeasTk;
+  edm::ESHandle<MeasurementTracker> theMeasTk;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
+  getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
   edm::ESHandle<TrackerTopology> httopo;
   setup.get<TrackerTopologyRcd>().get(httopo);
@@ -72,22 +68,45 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   //
   AlgoProductCollection algoResults;
   reco::BeamSpot bs;
-  try{  
+  try {
     edm::Handle<TrackCandidateCollection> theTCCollection;
-    getFromEvt(theEvent,theTCCollection,bs);
-    
+    getFromEvt(theEvent, theTCCollection, bs);
+
     //
-    //run the algorithm  
+    //run the algorithm
     //
-    LogDebug("GsfTrackProducer") << "run the algorithm" << "\n";
-    theAlgo.runWithCandidate(theG.product(), theMF.product(), *theTCCollection, 
-			     theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);
-  } catch (cms::Exception &e){ edm::LogInfo("GsfTrackProducer") << "cms::Exception caught!!!" << "\n" << e << "\n"; throw; }
+    LogDebug("GsfTrackProducer") << "run the algorithm"
+                                 << "\n";
+    theAlgo.runWithCandidate(theG.product(),
+                             theMF.product(),
+                             *theTCCollection,
+                             theFitter.product(),
+                             thePropagator.product(),
+                             theBuilder.product(),
+                             bs,
+                             algoResults);
+  } catch (cms::Exception& e) {
+    edm::LogInfo("GsfTrackProducer") << "cms::Exception caught!!!"
+                                     << "\n"
+                                     << e << "\n";
+    throw;
+  }
   //
   //put everything in the event
-  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputGsfTEColl,
-	   outputTrajectoryColl, algoResults, theBuilder.product(), bs, httopo.product());
-  LogDebug("GsfTrackProducer") << "end" << "\n";
+  putInEvt(theEvent,
+           thePropagator.product(),
+           theMeasTk.product(),
+           outputRHColl,
+           outputTColl,
+           outputTEColl,
+           outputGsfTEColl,
+           outputTrajectoryColl,
+           algoResults,
+           theBuilder.product(),
+           bs,
+           httopo.product());
+  LogDebug("GsfTrackProducer") << "end"
+                               << "\n";
 }
 
 void GsfTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -102,8 +121,8 @@ void GsfTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<std::string>("TTRHBuilder", std::string("WithTrackAngle"));
   desc.add<std::string>("Propagator", std::string("fwdElectronPropagator"));
   desc.add<std::string>("NavigationSchool", std::string("SimpleNavigationSchool"));
-  desc.add<std::string>("MeasurementTracker", std::string(""));                   
-  desc.add<edm::InputTag>("MeasurementTrackerEvent", edm::InputTag("MeasurementTrackerEvent")); 
+  desc.add<std::string>("MeasurementTracker", std::string(""));
+  desc.add<edm::InputTag>("MeasurementTrackerEvent", edm::InputTag("MeasurementTrackerEvent"));
   desc.add<bool>("GeometricInnerState", false);
   desc.add<std::string>("AlgorithmName", std::string("gsf"));
 

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.h
@@ -13,7 +13,6 @@
 
 class GsfTrackProducer : public GsfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
-
   explicit GsfTrackProducer(const edm::ParameterSet& iConfig);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -21,7 +20,6 @@ public:
 
 private:
   TrackProducerAlgorithm<reco::GsfTrack> theAlgo;
-
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -27,7 +27,7 @@ GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig):
   setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
   std::string  constraint_str = iConfig.getParameter<std::string>( "constraint" );
 
-  if (constraint_str == "") constraint_ = none;
+  if (constraint_str.empty()) constraint_ = none;
 //   else if (constraint_str == "momentum") constraint_ = momentum;
   else if (constraint_str == "vertex") {
     constraint_ = vertex;

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -15,49 +15,50 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig):
-  GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
-		       iConfig.getParameter<bool>("useHitsSplitting")),
-  theAlgo(iConfig)
-{
+GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig)
+    : GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
+                           iConfig.getParameter<bool>("useHitsSplitting")),
+      theAlgo(iConfig) {
   setConf(iConfig);
-  setSrc( consumes<edm::View<reco::GsfTrack>>(iConfig.getParameter<edm::InputTag>( "src" )), 
-          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )),
-          consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>( "MeasurementTrackerEvent") ));
-  setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
-  std::string  constraint_str = iConfig.getParameter<std::string>( "constraint" );
+  setSrc(consumes<edm::View<reco::GsfTrack>>(iConfig.getParameter<edm::InputTag>("src")),
+         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
+         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  setAlias(iConfig.getParameter<std::string>("@module_label"));
+  std::string constraint_str = iConfig.getParameter<std::string>("constraint");
 
-  if (constraint_str.empty()) constraint_ = none;
-//   else if (constraint_str == "momentum") constraint_ = momentum;
+  if (constraint_str.empty())
+    constraint_ = none;
+  //   else if (constraint_str == "momentum") constraint_ = momentum;
   else if (constraint_str == "vertex") {
     constraint_ = vertex;
-    gsfTrackVtxConstraintTag_ = consumes<GsfTrackVtxConstraintAssociationCollection>(iConfig.getParameter<edm::InputTag>("gsfTrackVtxConstraintTag"));
+    gsfTrackVtxConstraintTag_ = consumes<GsfTrackVtxConstraintAssociationCollection>(
+        iConfig.getParameter<edm::InputTag>("gsfTrackVtxConstraintTag"));
   } else {
-    edm::LogError("GsfTrackRefitter")<<"constraint: "<<constraint_str<<" not understood. Set it to 'momentum', 'vertex' or leave it empty";    
-    throw cms::Exception("GsfTrackRefitter") << "unknown type of contraint! Set it to 'momentum', 'vertex' or leave it empty";    
+    edm::LogError("GsfTrackRefitter") << "constraint: " << constraint_str
+                                      << " not understood. Set it to 'momentum', 'vertex' or leave it empty";
+    throw cms::Exception("GsfTrackRefitter")
+        << "unknown type of contraint! Set it to 'momentum', 'vertex' or leave it empty";
   }
 
   //register your products
-  produces<reco::GsfTrackCollection>().setBranchAlias( alias_ + "GsfTracks" );
-  produces<reco::TrackExtraCollection>().setBranchAlias( alias_ + "TrackExtras" );
-  produces<reco::GsfTrackExtraCollection>().setBranchAlias( alias_ + "GsfTrackExtras" );
-  produces<TrackingRecHitCollection>().setBranchAlias( alias_ + "RecHits" );
-  produces<std::vector<Trajectory> >() ;
+  produces<reco::GsfTrackCollection>().setBranchAlias(alias_ + "GsfTracks");
+  produces<reco::TrackExtraCollection>().setBranchAlias(alias_ + "TrackExtras");
+  produces<reco::GsfTrackExtraCollection>().setBranchAlias(alias_ + "GsfTrackExtras");
+  produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
+  produces<std::vector<Trajectory>>();
   produces<TrajGsfTrackAssociationCollection>();
-
 }
 
-void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
-{
+void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup) {
   edm::LogInfo("GsfTrackRefitter") << "Analyzing event number: " << theEvent.id() << "\n";
   //
   // create empty output collections
   //
-  std::unique_ptr<TrackingRecHitCollection>   outputRHColl (new TrackingRecHitCollection);
-  std::unique_ptr<reco::GsfTrackCollection>      outputTColl(new reco::GsfTrackCollection);
+  std::unique_ptr<TrackingRecHitCollection> outputRHColl(new TrackingRecHitCollection);
+  std::unique_ptr<reco::GsfTrackCollection> outputTColl(new reco::GsfTrackCollection);
   std::unique_ptr<reco::TrackExtraCollection> outputTEColl(new reco::TrackExtraCollection);
   std::unique_ptr<reco::GsfTrackExtraCollection> outputGsfTEColl(new reco::GsfTrackExtraCollection);
-  std::unique_ptr<std::vector<Trajectory> >   outputTrajectoryColl(new std::vector<Trajectory>);
+  std::unique_ptr<std::vector<Trajectory>> outputTrajectoryColl(new std::vector<Trajectory>);
 
   //
   //declare and get stuff to be retrieved from ES
@@ -66,10 +67,10 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<MagneticField> theMF;
   edm::ESHandle<TrajectoryFitter> theFitter;
   edm::ESHandle<Propagator> thePropagator;
-  edm::ESHandle<MeasurementTracker>  theMeasTk;
+  edm::ESHandle<MeasurementTracker> theMeasTk;
   //  getFromES(setup,theG,theMF,theFitter,thePropagator);
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
+  getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
   edm::ESHandle<TrackerTopology> httopo;
   setup.get<TrackerTopologyRcd>().get(httopo);
@@ -79,42 +80,77 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   //
   AlgoProductCollection algoResults;
   reco::BeamSpot bs;
-  switch(constraint_){
-  case none :
-    {
+  switch (constraint_) {
+    case none: {
       edm::Handle<edm::View<reco::GsfTrack>> theTCollection;
-      getFromEvt(theEvent,theTCollection,bs);
-      if (theTCollection.failedToGet()){
-	edm::LogError("GsfTrackRefitter")<<"could not get the reco::GsfTrackCollection."; return;}
-      LogDebug("GsfTrackRefitter") << "run the algorithm" << "\n";
+      getFromEvt(theEvent, theTCollection, bs);
+      if (theTCollection.failedToGet()) {
+        edm::LogError("GsfTrackRefitter") << "could not get the reco::GsfTrackCollection.";
+        return;
+      }
+      LogDebug("GsfTrackRefitter") << "run the algorithm"
+                                   << "\n";
       try {
-	theAlgo.runWithTrack(theG.product(), theMF.product(), *theTCollection, 
-			     theFitter.product(), thePropagator.product(),  
-			     theBuilder.product(), bs, algoResults);
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack." << "\n" << e << "\n"; throw; }
+        theAlgo.runWithTrack(theG.product(),
+                             theMF.product(),
+                             *theTCollection,
+                             theFitter.product(),
+                             thePropagator.product(),
+                             theBuilder.product(),
+                             bs,
+                             algoResults);
+      } catch (cms::Exception& e) {
+        edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack."
+                                       << "\n"
+                                       << e << "\n";
+        throw;
+      }
       break;
     }
-  case vertex :
-    {
+    case vertex: {
       edm::Handle<GsfTrackVtxConstraintAssociationCollection> theTCollectionWithConstraint;
       theEvent.getByToken(gsfTrackVtxConstraintTag_, theTCollectionWithConstraint);
       edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-      theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
-      bs = *recoBeamSpotHandle;      
-      if (theTCollectionWithConstraint.failedToGet()){
-	edm::LogError("TrackRefitter")<<"could not get TrackVtxConstraintAssociationCollection product."; break;}
-      LogDebug("TrackRefitter") << "run the algorithm" << "\n";
+      theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
+      bs = *recoBeamSpotHandle;
+      if (theTCollectionWithConstraint.failedToGet()) {
+        edm::LogError("TrackRefitter") << "could not get TrackVtxConstraintAssociationCollection product.";
+        break;
+      }
+      LogDebug("TrackRefitter") << "run the algorithm"
+                                << "\n";
       try {
-      theAlgo.runWithVertex(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
-			    theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);      
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack." << "\n" << e << "\n"; throw; }
+        theAlgo.runWithVertex(theG.product(),
+                              theMF.product(),
+                              *theTCollectionWithConstraint,
+                              theFitter.product(),
+                              thePropagator.product(),
+                              theBuilder.product(),
+                              bs,
+                              algoResults);
+      } catch (cms::Exception& e) {
+        edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack."
+                                       << "\n"
+                                       << e << "\n";
+        throw;
+      }
     }
-    //default... there cannot be any other possibility due to the check in the ctor
+      //default... there cannot be any other possibility due to the check in the ctor
   }
-  
-  //put everything in th event
-  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(),
-	   outputRHColl, outputTColl, outputTEColl, outputGsfTEColl, outputTrajectoryColl, algoResults, theBuilder.product(), bs, httopo.product());
-  LogDebug("GsfTrackRefitter") << "end" << "\n";
-}
 
+  //put everything in th event
+  putInEvt(theEvent,
+           thePropagator.product(),
+           theMeasTk.product(),
+           outputRHColl,
+           outputTColl,
+           outputTEColl,
+           outputGsfTEColl,
+           outputTrajectoryColl,
+           algoResults,
+           theBuilder.product(),
+           bs,
+           httopo.product());
+  LogDebug("GsfTrackRefitter") << "end"
+                               << "\n";
+}

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
@@ -13,7 +13,6 @@
 
 class GsfTrackRefitter : public GsfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
-
   /// Constructor
   explicit GsfTrackRefitter(const edm::ParameterSet& iConfig);
 
@@ -22,9 +21,11 @@ public:
 
 private:
   TrackProducerAlgorithm<reco::GsfTrack> theAlgo;
-  enum Constraint { none, 
-// 		    momentum, 
-		    vertex };
+  enum Constraint {
+    none,
+    // 		    momentum,
+    vertex
+  };
   Constraint constraint_;
   edm::EDGetTokenT<GsfTrackVtxConstraintAssociationCollection> gsfTrackVtxConstraintTag_;
 };

--- a/RecoTracker/TrackProducer/plugins/GsfVertexConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfVertexConstraintProducer.cc
@@ -18,18 +18,17 @@
 // class decleration
 //
 
-class GsfVertexConstraintProducer: public edm::global::EDProducer<> {
+class GsfVertexConstraintProducer : public edm::global::EDProducer<> {
 public:
   explicit GsfVertexConstraintProducer(const edm::ParameterSet&);
   ~GsfVertexConstraintProducer() override = default;
 
 private:
   void produce(edm::StreamID streamid, edm::Event&, const edm::EventSetup&) const override;
-      
+
   // ----------member data ---------------------------
   const edm::InputTag srcTrkTag_;
   edm::EDGetTokenT<reco::GsfTrackCollection> trkToken_;
-
 };
 
 //
@@ -43,9 +42,8 @@ private:
 //
 // constructors and destructor
 //
-GsfVertexConstraintProducer::GsfVertexConstraintProducer(const edm::ParameterSet& iConfig) :
-srcTrkTag_(iConfig.getParameter<edm::InputTag>("src"))
-{
+GsfVertexConstraintProducer::GsfVertexConstraintProducer(const edm::ParameterSet& iConfig)
+    : srcTrkTag_(iConfig.getParameter<edm::InputTag>("src")) {
   //declare the consumes
   trkToken_ = consumes<reco::GsfTrackCollection>(edm::InputTag(srcTrkTag_));
 
@@ -56,31 +54,32 @@ srcTrkTag_(iConfig.getParameter<edm::InputTag>("src"))
   //now do what ever other initialization is needed
 }
 
-
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void GsfVertexConstraintProducer::produce(edm::StreamID streamid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void GsfVertexConstraintProducer::produce(edm::StreamID streamid,
+                                          edm::Event& iEvent,
+                                          const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<reco::GsfTrackCollection> theTCollection;
   iEvent.getByToken(trkToken_, theTCollection);
-  
+
   edm::RefProd<std::vector<VertexConstraint> > rPairs = iEvent.getRefBeforePut<std::vector<VertexConstraint> >();
   std::unique_ptr<std::vector<VertexConstraint> > pairs(new std::vector<VertexConstraint>);
-  std::unique_ptr<GsfTrackVtxConstraintAssociationCollection> output(new GsfTrackVtxConstraintAssociationCollection(theTCollection, rPairs));
-  
+  std::unique_ptr<GsfTrackVtxConstraintAssociationCollection> output(
+      new GsfTrackVtxConstraintAssociationCollection(theTCollection, rPairs));
+
   int index = 0;
-  for (reco::GsfTrackCollection::const_iterator i=theTCollection->begin(); i!=theTCollection->end();i++) {
-    VertexConstraint tmp(GlobalPoint(0,0,0),GlobalError(0.01,0,0.01,0,0,0.001));
+  for (reco::GsfTrackCollection::const_iterator i = theTCollection->begin(); i != theTCollection->end(); i++) {
+    VertexConstraint tmp(GlobalPoint(0, 0, 0), GlobalError(0.01, 0, 0.01, 0, 0, 0.001));
     pairs->push_back(tmp);
-    output->insert(reco::GsfTrackRef(theTCollection,index), edm::Ref<std::vector<VertexConstraint> >(rPairs,index) );
+    output->insert(reco::GsfTrackRef(theTCollection, index), edm::Ref<std::vector<VertexConstraint> >(rPairs, index));
     index++;
   }
-  
+
   iEvent.put(std::move(pairs));
   iEvent.put(std::move(output));
 }

--- a/RecoTracker/TrackProducer/plugins/MomentumConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/MomentumConstraintProducer.cc
@@ -16,7 +16,6 @@ Implementation:
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -38,7 +37,7 @@ Implementation:
 // class declaration
 //
 
-class MomentumConstraintProducer: public edm::global::EDProducer<> {
+class MomentumConstraintProducer : public edm::global::EDProducer<> {
 public:
   explicit MomentumConstraintProducer(const edm::ParameterSet&);
   ~MomentumConstraintProducer() override = default;
@@ -64,10 +63,10 @@ private:
 //
 // constructors and destructor
 //
-MomentumConstraintProducer::MomentumConstraintProducer(const edm::ParameterSet& iConfig):
-  srcTag_(iConfig.getParameter<edm::InputTag>("src")),
-  fixedmom_(iConfig.getParameter<double>("fixedMomentum")),
-  fixedmomerr_(iConfig.getParameter<double>("fixedMomentumError"))
+MomentumConstraintProducer::MomentumConstraintProducer(const edm::ParameterSet& iConfig)
+    : srcTag_(iConfig.getParameter<edm::InputTag>("src")),
+      fixedmom_(iConfig.getParameter<double>("fixedMomentum")),
+      fixedmomerr_(iConfig.getParameter<double>("fixedMomentumError"))
 
 {
   //register your products
@@ -79,40 +78,40 @@ MomentumConstraintProducer::MomentumConstraintProducer(const edm::ParameterSet& 
   srcToken_ = iC.consumes<reco::TrackCollection>(srcTag_);
 }
 
-
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void MomentumConstraintProducer::produce(edm::StreamID streamid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void MomentumConstraintProducer::produce(edm::StreamID streamid,
+                                         edm::Event& iEvent,
+                                         const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<reco::TrackCollection> theTCollection;
-  iEvent.getByToken(srcToken_,theTCollection);
+  iEvent.getByToken(srcToken_, theTCollection);
 
   edm::RefProd<std::vector<MomentumConstraint>> rPairs = iEvent.getRefBeforePut<std::vector<MomentumConstraint>>();
 
   std::unique_ptr<std::vector<MomentumConstraint>> pairs(new std::vector<MomentumConstraint>);
-  std::unique_ptr<TrackMomConstraintAssociationCollection> output(new TrackMomConstraintAssociationCollection(theTCollection, rPairs));
+  std::unique_ptr<TrackMomConstraintAssociationCollection> output(
+      new TrackMomConstraintAssociationCollection(theTCollection, rPairs));
 
   int index = 0;
-  for (reco::TrackCollection::const_iterator i=theTCollection->begin(); i!=theTCollection->end();i++) {
+  for (reco::TrackCollection::const_iterator i = theTCollection->begin(); i != theTCollection->end(); i++) {
     //    MomentumConstraint tmp(10.,0.01) ;
 
-    MomentumConstraint tmp(fixedmom_,fixedmomerr_) ;
-    if(fixedmom_< 0.0){
-      tmp= MomentumConstraint(i->p(),fixedmomerr_);
+    MomentumConstraint tmp(fixedmom_, fixedmomerr_);
+    if (fixedmom_ < 0.0) {
+      tmp = MomentumConstraint(i->p(), fixedmomerr_);
     }
     pairs->push_back(tmp);
-    output->insert(reco::TrackRef(theTCollection,index), edm::Ref<std::vector<MomentumConstraint>>(rPairs,index) );
+    output->insert(reco::TrackRef(theTCollection, index), edm::Ref<std::vector<MomentumConstraint>>(rPairs, index));
     index++;
   }
 
   iEvent.put(std::move(pairs));
   iEvent.put(std::move(output));
-
 }
 
 //define this as a plug-in

--- a/RecoTracker/TrackProducer/plugins/QualityFilter.cc
+++ b/RecoTracker/TrackProducer/plugins/QualityFilter.cc
@@ -9,21 +9,20 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 class dso_hidden QualityFilter final : public edm::stream::EDProducer<> {
- public:
+public:
   explicit QualityFilter(const edm::ParameterSet&);
   ~QualityFilter() override;
-  
- private:
+
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
-  
+  virtual void endJob();
+
   // ----------member data ---------------------------
- private:
-  
-  edm::EDGetTokenT<std::vector<Trajectory> >       trajTag; 
-  edm::EDGetTokenT<TrajTrackAssociationCollection> tassTag; 
+private:
+  edm::EDGetTokenT<std::vector<Trajectory> > trajTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> tassTag;
   reco::TrackBase::TrackQuality trackQuality_;
-  bool copyExtras_;  
+  bool copyExtras_;
 };
 
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -41,52 +40,40 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 
-
-QualityFilter::QualityFilter(const edm::ParameterSet& iConfig)
-{
+QualityFilter::QualityFilter(const edm::ParameterSet& iConfig) {
   copyExtras_ = iConfig.getUntrackedParameter<bool>("copyExtras", false);
 
   produces<reco::TrackCollection>();
   if (copyExtras_) {
-      produces<TrackingRecHitCollection>();
-      produces<reco::TrackExtraCollection>();
+    produces<TrackingRecHitCollection>();
+    produces<reco::TrackExtraCollection>();
   }
   produces<std::vector<Trajectory> >();
   produces<TrajTrackAssociationCollection>();
 
   trajTag = consumes<std::vector<Trajectory> >(iConfig.getParameter<edm::InputTag>("recTracks"));
   tassTag = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("recTracks"));
-  trackQuality_=TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
+  trackQuality_ = TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
 }
 
-
-QualityFilter::~QualityFilter()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+QualityFilter::~QualityFilter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-  
+void QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   unique_ptr<TrackCollection> selTracks(new TrackCollection);
   unique_ptr<TrackingRecHitCollection> selHits(copyExtras_ ? new TrackingRecHitCollection() : nullptr);
   unique_ptr<TrackExtraCollection> selTrackExtras(copyExtras_ ? new TrackExtraCollection() : nullptr);
-  unique_ptr<vector<Trajectory> > outputTJ(new vector<Trajectory> );
-  unique_ptr<TrajTrackAssociationCollection> trajTrackMap( new TrajTrackAssociationCollection() );
-  
-  
-  TrackExtraRefProd rTrackExtras; 
+  unique_ptr<vector<Trajectory> > outputTJ(new vector<Trajectory>);
+  unique_ptr<TrajTrackAssociationCollection> trajTrackMap(new TrajTrackAssociationCollection());
+
+  TrackExtraRefProd rTrackExtras;
   TrackingRecHitRefProd rHits;
   if (copyExtras_) {
     rTrackExtras = iEvent.getRefBeforePut<TrackExtraCollection>();
@@ -95,101 +82,90 @@ QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   Handle<std::vector<Trajectory> > TrajectoryCollection;
   Handle<TrajTrackAssociationCollection> assoMap;
-  
-  iEvent.getByToken(trajTag,TrajectoryCollection);
-  iEvent.getByToken(tassTag,assoMap);
 
-
+  iEvent.getByToken(trajTag, TrajectoryCollection);
+  iEvent.getByToken(tassTag, assoMap);
 
   TrajTrackAssociationCollection::const_iterator it = assoMap->begin();
   TrajTrackAssociationCollection::const_iterator lastAssoc = assoMap->end();
-  for( ; it != lastAssoc; ++it ) {
+  for (; it != lastAssoc; ++it) {
     const Ref<vector<Trajectory> > traj = it->key;
     const reco::TrackRef itc = it->val;
     bool goodTk = (itc->quality(trackQuality_));
- 
-    
-    if (goodTk){
-      auto const & track =(*itc);
-      //tracks and trajectories
-      selTracks->push_back( track );
-      outputTJ->push_back( *traj );
-      if (copyExtras_) {
-          //TRACKING HITS
-          trackingRecHit_iterator irhit   =(*itc).recHitsBegin();
-          trackingRecHit_iterator lasthit =(*itc).recHitsEnd();
-          for (; irhit!=lasthit; ++irhit) {
-            selHits->push_back((*irhit)->clone() );
-          }
-      }
-          
-    }
 
+    if (goodTk) {
+      auto const& track = (*itc);
+      //tracks and trajectories
+      selTracks->push_back(track);
+      outputTJ->push_back(*traj);
+      if (copyExtras_) {
+        //TRACKING HITS
+        trackingRecHit_iterator irhit = (*itc).recHitsBegin();
+        trackingRecHit_iterator lasthit = (*itc).recHitsEnd();
+        for (; irhit != lasthit; ++irhit) {
+          selHits->push_back((*irhit)->clone());
+        }
+      }
+    }
   }
 
   unsigned nTracks = selTracks->size();
   if (copyExtras_) {
-      //PUT TRACKING HITS IN THE EVENT
-    OrphanHandle<TrackingRecHitCollection> theRecoHits = iEvent.put(std::move(selHits) );
+    //PUT TRACKING HITS IN THE EVENT
+    OrphanHandle<TrackingRecHitCollection> theRecoHits = iEvent.put(std::move(selHits));
     edm::RefProd<TrackingRecHitCollection> theRecoHitsProd(theRecoHits);
 
-      //PUT TRACK EXTRA IN THE EVENT
-      selTrackExtras->reserve(nTracks);
-      unsigned hits=0;
+    //PUT TRACK EXTRA IN THE EVENT
+    selTrackExtras->reserve(nTracks);
+    unsigned hits = 0;
 
-      for ( unsigned index = 0; index<nTracks; ++index ) { 
-        auto const & aTrack = (*selTracks)[index];
-        selTrackExtras->emplace_back(aTrack.outerPosition(),
-                               aTrack.outerMomentum(),
-                               aTrack.outerOk(),
-                               aTrack.innerPosition(),
-                               aTrack.innerMomentum(),
-                               aTrack.innerOk(),
-                               aTrack.outerStateCovariance(),
-                               aTrack.outerDetId(),
-                               aTrack.innerStateCovariance(),
-                               aTrack.innerDetId(),
-                               aTrack.seedDirection(),
-                               aTrack.seedRef()
-                               );
-            
-        auto & aTrackExtra = selTrackExtras->back();
-        //unsigned nHits = aTrack.numberOfValidHits();
-        auto nHits = aTrack.recHitsSize();
-        aTrackExtra.setHits(theRecoHitsProd, hits, nHits);
-        hits += nHits;
-        selTrackExtras->push_back(aTrackExtra);
-      }
+    for (unsigned index = 0; index < nTracks; ++index) {
+      auto const& aTrack = (*selTracks)[index];
+      selTrackExtras->emplace_back(aTrack.outerPosition(),
+                                   aTrack.outerMomentum(),
+                                   aTrack.outerOk(),
+                                   aTrack.innerPosition(),
+                                   aTrack.innerMomentum(),
+                                   aTrack.innerOk(),
+                                   aTrack.outerStateCovariance(),
+                                   aTrack.outerDetId(),
+                                   aTrack.innerStateCovariance(),
+                                   aTrack.innerDetId(),
+                                   aTrack.seedDirection(),
+                                   aTrack.seedRef());
 
-      //CORRECT REF TO TRACK
-      OrphanHandle<TrackExtraCollection> theRecoTrackExtras = iEvent.put(std::move(selTrackExtras)); 
-      for ( unsigned index = 0; index<nTracks; ++index ) { 
-        const reco::TrackExtraRef theTrackExtraRef(theRecoTrackExtras,index);
-          (*selTracks)[index].setExtra(theTrackExtraRef);
-      }
-  } // END IF COPY EXTRAS
+      auto& aTrackExtra = selTrackExtras->back();
+      //unsigned nHits = aTrack.numberOfValidHits();
+      auto nHits = aTrack.recHitsSize();
+      aTrackExtra.setHits(theRecoHitsProd, hits, nHits);
+      hits += nHits;
+      selTrackExtras->push_back(aTrackExtra);
+    }
+
+    //CORRECT REF TO TRACK
+    OrphanHandle<TrackExtraCollection> theRecoTrackExtras = iEvent.put(std::move(selTrackExtras));
+    for (unsigned index = 0; index < nTracks; ++index) {
+      const reco::TrackExtraRef theTrackExtraRef(theRecoTrackExtras, index);
+      (*selTracks)[index].setExtra(theTrackExtraRef);
+    }
+  }  // END IF COPY EXTRAS
 
   //TRACKS AND TRAJECTORIES
   OrphanHandle<TrackCollection> theRecoTracks = iEvent.put(std::move(selTracks));
   OrphanHandle<vector<Trajectory> > theRecoTrajectories = iEvent.put(std::move(outputTJ));
 
-  //TRACKS<->TRAJECTORIES MAP 
+  //TRACKS<->TRAJECTORIES MAP
   nTracks = theRecoTracks->size();
-  for ( unsigned index = 0; index<nTracks; ++index ) { 
-    Ref<vector<Trajectory> > trajRef( theRecoTrajectories, index );
-    Ref<TrackCollection>    tkRef( theRecoTracks, index );
-    trajTrackMap->insert(trajRef,tkRef);
+  for (unsigned index = 0; index < nTracks; ++index) {
+    Ref<vector<Trajectory> > trajRef(theRecoTrajectories, index);
+    Ref<TrackCollection> tkRef(theRecoTracks, index);
+    trajTrackMap->insert(trajRef, tkRef);
   }
   //MAP IN THE EVENT
-  iEvent.put( std::move(trajTrackMap) );
+  iEvent.put(std::move(trajTrackMap));
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-QualityFilter::endJob() {
-}
-
-
+void QualityFilter::endJob() {}
 
 DEFINE_FWK_MODULE(QualityFilter);
-

--- a/RecoTracker/TrackProducer/plugins/SealModules.cc
+++ b/RecoTracker/TrackProducer/plugins/SealModules.cc
@@ -7,7 +7,7 @@
 #include "RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h"
 #include "RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h"
 
-// 
+//
 DEFINE_FWK_MODULE(DAFTrackProducer);
 DEFINE_FWK_MODULE(TrackProducer);
 DEFINE_FWK_MODULE(TrackRefitter);

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.h
@@ -15,7 +15,6 @@
 
 class TrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
-
   /// Constructor
   explicit TrackProducer(const edm::ParameterSet& iConfig);
 
@@ -25,17 +24,16 @@ public:
   /// Get Transient Tracks
   std::vector<reco::TransientTrack> getTransient(edm::Event&, const edm::EventSetup&);
 
-//   /// Put produced collections in the event
-//   virtual void putInEvt(edm::Event&,
-// 			std::unique_ptr<TrackingRecHitCollection>&,
-// 			std::unique_ptr<TrackCollection>&,
-// 			std::unique_ptr<reco::TrackExtraCollection>&,
-// 			std::unique_ptr<std::vector<Trajectory> >&,
-// 			AlgoProductCollection&);
+  //   /// Put produced collections in the event
+  //   virtual void putInEvt(edm::Event&,
+  // 			std::unique_ptr<TrackingRecHitCollection>&,
+  // 			std::unique_ptr<TrackCollection>&,
+  // 			std::unique_ptr<reco::TrackExtraCollection>&,
+  // 			std::unique_ptr<std::vector<Trajectory> >&,
+  // 			AlgoProductCollection&);
 
 private:
   TrackProducerAlgorithm<reco::Track> theAlgo;
-
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -27,7 +27,7 @@ TrackRefitter::TrackRefitter(const edm::ParameterSet& iConfig):
   edm::InputTag trkconstrcoll = iConfig.getParameter<edm::InputTag>( "srcConstr" );
   
 
-  if (constraint_str == "") constraint_ = none;
+  if (constraint_str.empty()) constraint_ = none;
   else if (constraint_str == "momentum") { constraint_ = momentum; trkconstrcoll_ = consumes<TrackMomConstraintAssociationCollection>(trkconstrcoll); }
   else if (constraint_str == "vertex")   { constraint_ = vertex;   trkconstrcoll_ = consumes<TrackVtxConstraintAssociationCollection>(trkconstrcoll); }
   else if (constraint_str == "trackParameters") { constraint_ = trackParameters;  trkconstrcoll_ = consumes<TrackParamConstraintAssociationCollection>(trkconstrcoll); }

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -13,50 +13,56 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-TrackRefitter::TrackRefitter(const edm::ParameterSet& iConfig):
-  KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
-		      iConfig.getParameter<bool>("useHitsSplitting")),
-  theAlgo(iConfig)
-{
+TrackRefitter::TrackRefitter(const edm::ParameterSet &iConfig)
+    : KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
+                          iConfig.getParameter<bool>("useHitsSplitting")),
+      theAlgo(iConfig) {
   setConf(iConfig);
-  setSrc( consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>( "src" )), 
-          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )),
-          consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>( "MeasurementTrackerEvent") ));
-  setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
-  std::string  constraint_str = iConfig.getParameter<std::string>( "constraint" );
-  edm::InputTag trkconstrcoll = iConfig.getParameter<edm::InputTag>( "srcConstr" );
-  
+  setSrc(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("src")),
+         consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")),
+         consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent")));
+  setAlias(iConfig.getParameter<std::string>("@module_label"));
+  std::string constraint_str = iConfig.getParameter<std::string>("constraint");
+  edm::InputTag trkconstrcoll = iConfig.getParameter<edm::InputTag>("srcConstr");
 
-  if (constraint_str.empty()) constraint_ = none;
-  else if (constraint_str == "momentum") { constraint_ = momentum; trkconstrcoll_ = consumes<TrackMomConstraintAssociationCollection>(trkconstrcoll); }
-  else if (constraint_str == "vertex")   { constraint_ = vertex;   trkconstrcoll_ = consumes<TrackVtxConstraintAssociationCollection>(trkconstrcoll); }
-  else if (constraint_str == "trackParameters") { constraint_ = trackParameters;  trkconstrcoll_ = consumes<TrackParamConstraintAssociationCollection>(trkconstrcoll); }
-  else {
-    edm::LogError("TrackRefitter")<<"constraint: "<<constraint_str<<" not understood. Set it to 'momentum', 'vertex', 'trackParameters' or leave it empty";
-    throw cms::Exception("TrackRefitter") << "unknown type of contraint! Set it to 'momentum', 'vertex', 'trackParameters' or leave it empty";    
+  if (constraint_str.empty())
+    constraint_ = none;
+  else if (constraint_str == "momentum") {
+    constraint_ = momentum;
+    trkconstrcoll_ = consumes<TrackMomConstraintAssociationCollection>(trkconstrcoll);
+  } else if (constraint_str == "vertex") {
+    constraint_ = vertex;
+    trkconstrcoll_ = consumes<TrackVtxConstraintAssociationCollection>(trkconstrcoll);
+  } else if (constraint_str == "trackParameters") {
+    constraint_ = trackParameters;
+    trkconstrcoll_ = consumes<TrackParamConstraintAssociationCollection>(trkconstrcoll);
+  } else {
+    edm::LogError("TrackRefitter")
+        << "constraint: " << constraint_str
+        << " not understood. Set it to 'momentum', 'vertex', 'trackParameters' or leave it empty";
+    throw cms::Exception("TrackRefitter")
+        << "unknown type of contraint! Set it to 'momentum', 'vertex', 'trackParameters' or leave it empty";
   }
 
   //register your products
-  produces<reco::TrackCollection>().setBranchAlias( alias_ + "Tracks" );
-  produces<reco::TrackExtraCollection>().setBranchAlias( alias_ + "TrackExtras" );
-  produces<TrackingRecHitCollection>().setBranchAlias( alias_ + "RecHits" );
-  produces<std::vector<Trajectory> >() ;
-  produces<std::vector<int> >() ;
+  produces<reco::TrackCollection>().setBranchAlias(alias_ + "Tracks");
+  produces<reco::TrackExtraCollection>().setBranchAlias(alias_ + "TrackExtras");
+  produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
+  produces<std::vector<Trajectory>>();
+  produces<std::vector<int>>();
   produces<TrajTrackAssociationCollection>();
-
 }
 
-void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
-{
+void TrackRefitter::produce(edm::Event &theEvent, const edm::EventSetup &setup) {
   LogDebug("TrackRefitter") << "Analyzing event number: " << theEvent.id() << "\n";
   //
   // create empty output collections
   //
-  std::unique_ptr<TrackingRecHitCollection>   outputRHColl (new TrackingRecHitCollection);
-  std::unique_ptr<reco::TrackCollection>      outputTColl(new reco::TrackCollection);
+  std::unique_ptr<TrackingRecHitCollection> outputRHColl(new TrackingRecHitCollection);
+  std::unique_ptr<reco::TrackCollection> outputTColl(new reco::TrackCollection);
   std::unique_ptr<reco::TrackExtraCollection> outputTEColl(new reco::TrackExtraCollection);
-  std::unique_ptr<std::vector<Trajectory> >   outputTrajectoryColl(new std::vector<Trajectory>);
-  std::unique_ptr<std::vector<int> >           outputIndecesInputColl(new std::vector<int>);
+  std::unique_ptr<std::vector<Trajectory>> outputTrajectoryColl(new std::vector<Trajectory>);
+  std::unique_ptr<std::vector<int>> outputIndecesInputColl(new std::vector<int>);
 
   //
   //declare and get stuff to be retrieved from ES
@@ -65,9 +71,9 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   edm::ESHandle<MagneticField> theMF;
   edm::ESHandle<TrajectoryFitter> theFitter;
   edm::ESHandle<Propagator> thePropagator;
-  edm::ESHandle<MeasurementTracker>  theMeasTk;
+  edm::ESHandle<MeasurementTracker> theMeasTk;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
+  getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
   edm::ESHandle<TrackerTopology> httopo;
   setup.get<TrackerTopologyRcd>().get(httopo);
@@ -77,90 +83,152 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   //
   AlgoProductCollection algoResults;
   reco::BeamSpot bs;
-  switch(constraint_){
-  case none :
-    {
+  switch (constraint_) {
+    case none: {
       edm::Handle<edm::View<reco::Track>> theTCollection;
-      getFromEvt(theEvent,theTCollection,bs);
+      getFromEvt(theEvent, theTCollection, bs);
 
       LogDebug("TrackRefitter") << "TrackRefitter::produce(none):Number of Trajectories:" << (*theTCollection).size();
 
-      if (bs.position()==math::XYZPoint(0.,0.,0.) && bs.type() == reco::BeamSpot::Unknown) {
-	edm::LogError("TrackRefitter") << " BeamSpot is (0,0,0), it is probably because is not valid in the event"; break; }
+      if (bs.position() == math::XYZPoint(0., 0., 0.) && bs.type() == reco::BeamSpot::Unknown) {
+        edm::LogError("TrackRefitter") << " BeamSpot is (0,0,0), it is probably because is not valid in the event";
+        break;
+      }
 
-      if (theTCollection.failedToGet()){
+      if (theTCollection.failedToGet()) {
         edm::EDConsumerBase::Labels labels;
         labelsForToken(src_, labels);
-	edm::LogError("TrackRefitter")<<"could not get the reco::TrackCollection." << labels.module; break;}
-      LogDebug("TrackRefitter") << "run the algorithm" << "\n";
+        edm::LogError("TrackRefitter") << "could not get the reco::TrackCollection." << labels.module;
+        break;
+      }
+      LogDebug("TrackRefitter") << "run the algorithm"
+                                << "\n";
 
       try {
-	theAlgo.runWithTrack(theG.product(), theMF.product(), *theTCollection, 
-			     theFitter.product(), thePropagator.product(), 
-			     theBuilder.product(), bs, algoResults);
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack." << "\n" << e << "\n"; throw; }
+        theAlgo.runWithTrack(theG.product(),
+                             theMF.product(),
+                             *theTCollection,
+                             theFitter.product(),
+                             thePropagator.product(),
+                             theBuilder.product(),
+                             bs,
+                             algoResults);
+      } catch (cms::Exception &e) {
+        edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack."
+                                       << "\n"
+                                       << e << "\n";
+        throw;
+      }
       break;
     }
-  case momentum :
-    {
+    case momentum: {
       edm::Handle<TrackMomConstraintAssociationCollection> theTCollectionWithConstraint;
-      theEvent.getByToken(trkconstrcoll_,theTCollectionWithConstraint);
-
+      theEvent.getByToken(trkconstrcoll_, theTCollectionWithConstraint);
 
       edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-      theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
-      if (!recoBeamSpotHandle.isValid()) break;
-      bs = *recoBeamSpotHandle;      
-      if (theTCollectionWithConstraint.failedToGet()){
-	//edm::LogError("TrackRefitter")<<"could not get TrackMomConstraintAssociationCollection product.";
-	break;}
-      LogDebug("TrackRefitter") << "run the algorithm" << "\n";
+      theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
+      if (!recoBeamSpotHandle.isValid())
+        break;
+      bs = *recoBeamSpotHandle;
+      if (theTCollectionWithConstraint.failedToGet()) {
+        //edm::LogError("TrackRefitter")<<"could not get TrackMomConstraintAssociationCollection product.";
+        break;
+      }
+      LogDebug("TrackRefitter") << "run the algorithm"
+                                << "\n";
       try {
-	theAlgo.runWithMomentum(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
-				theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithMomentum." << "\n" << e << "\n"; throw; }
+        theAlgo.runWithMomentum(theG.product(),
+                                theMF.product(),
+                                *theTCollectionWithConstraint,
+                                theFitter.product(),
+                                thePropagator.product(),
+                                theBuilder.product(),
+                                bs,
+                                algoResults);
+      } catch (cms::Exception &e) {
+        edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithMomentum."
+                                       << "\n"
+                                       << e << "\n";
+        throw;
+      }
       break;
     }
-  case  vertex :
-    {
+    case vertex: {
       edm::Handle<TrackVtxConstraintAssociationCollection> theTCollectionWithConstraint;
-      theEvent.getByToken(trkconstrcoll_,theTCollectionWithConstraint);
+      theEvent.getByToken(trkconstrcoll_, theTCollectionWithConstraint);
       edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-      theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
-      if (!recoBeamSpotHandle.isValid()) break;
-      bs = *recoBeamSpotHandle;      
-      if (theTCollectionWithConstraint.failedToGet()){
-	edm::LogError("TrackRefitter")<<"could not get TrackVtxConstraintAssociationCollection product."; break;}
-      LogDebug("TrackRefitter") << "run the algorithm" << "\n";
+      theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
+      if (!recoBeamSpotHandle.isValid())
+        break;
+      bs = *recoBeamSpotHandle;
+      if (theTCollectionWithConstraint.failedToGet()) {
+        edm::LogError("TrackRefitter") << "could not get TrackVtxConstraintAssociationCollection product.";
+        break;
+      }
+      LogDebug("TrackRefitter") << "run the algorithm"
+                                << "\n";
       try {
-      theAlgo.runWithVertex(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
-			    theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);      
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithVertex." << "\n" << e << "\n"; throw; }
+        theAlgo.runWithVertex(theG.product(),
+                              theMF.product(),
+                              *theTCollectionWithConstraint,
+                              theFitter.product(),
+                              thePropagator.product(),
+                              theBuilder.product(),
+                              bs,
+                              algoResults);
+      } catch (cms::Exception &e) {
+        edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithVertex."
+                                       << "\n"
+                                       << e << "\n";
+        throw;
+      }
       break;
     }
-  case trackParameters :
-    {
+    case trackParameters: {
       edm::Handle<TrackParamConstraintAssociationCollection> theTCollectionWithConstraint;
-      theEvent.getByToken(trkconstrcoll_,theTCollectionWithConstraint);
+      theEvent.getByToken(trkconstrcoll_, theTCollectionWithConstraint);
       edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-      theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
-      if (!recoBeamSpotHandle.isValid()) break;
-      bs = *recoBeamSpotHandle;      
-      if (theTCollectionWithConstraint.failedToGet()){
-	//edm::LogError("TrackRefitter")<<"could not get TrackParamConstraintAssociationCollection product.";
-	break;}
-      LogDebug("TrackRefitter") << "run the algorithm" << "\n";
+      theEvent.getByToken(bsSrc_, recoBeamSpotHandle);
+      if (!recoBeamSpotHandle.isValid())
+        break;
+      bs = *recoBeamSpotHandle;
+      if (theTCollectionWithConstraint.failedToGet()) {
+        //edm::LogError("TrackRefitter")<<"could not get TrackParamConstraintAssociationCollection product.";
+        break;
+      }
+      LogDebug("TrackRefitter") << "run the algorithm"
+                                << "\n";
       try {
-      theAlgo.runWithTrackParameters(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
-				     theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);      
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrackParameters." << "\n" << e << "\n"; throw; }
+        theAlgo.runWithTrackParameters(theG.product(),
+                                       theMF.product(),
+                                       *theTCollectionWithConstraint,
+                                       theFitter.product(),
+                                       thePropagator.product(),
+                                       theBuilder.product(),
+                                       bs,
+                                       algoResults);
+      } catch (cms::Exception &e) {
+        edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrackParameters."
+                                       << "\n"
+                                       << e << "\n";
+        throw;
+      }
     }
-    //default... there cannot be any other possibility due to the check in the ctor
+      //default... there cannot be any other possibility due to the check in the ctor
   }
 
-  
   //put everything in th event
-  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl,  outputIndecesInputColl, algoResults,theBuilder.product(), httopo.product());
-  LogDebug("TrackRefitter") << "end" << "\n";
+  putInEvt(theEvent,
+           thePropagator.product(),
+           theMeasTk.product(),
+           outputRHColl,
+           outputTColl,
+           outputTEColl,
+           outputTrajectoryColl,
+           outputIndecesInputColl,
+           algoResults,
+           theBuilder.product(),
+           httopo.product());
+  LogDebug("TrackRefitter") << "end"
+                            << "\n";
 }
-

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.h
@@ -13,7 +13,6 @@
 
 class TrackRefitter : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
-
   /// Constructor
   explicit TrackRefitter(const edm::ParameterSet& iConfig);
 
@@ -25,7 +24,6 @@ private:
   enum Constraint { none, momentum, vertex, trackParameters };
   Constraint constraint_;
   edm::EDGetToken trkconstrcoll_;
-
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/TwoBodyDecayConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TwoBodyDecayConstraintProducer.cc
@@ -35,23 +35,18 @@
 // #include "TLorentzVector.h"
 // #include "Alignment/TwoBodyDecay/interface/TwoBodyDecayModel.h"
 
-
-class TwoBodyDecayConstraintProducer: public edm::global::EDProducer<>
-{
-
+class TwoBodyDecayConstraintProducer : public edm::global::EDProducer<> {
 public:
-
   explicit TwoBodyDecayConstraintProducer(const edm::ParameterSet&);
   ~TwoBodyDecayConstraintProducer() override = default;
 
 private:
-
   void produce(edm::StreamID streamid, edm::Event&, const edm::EventSetup&) const override;
 
-  std::pair<bool, TrajectoryStateOnSurface> innermostState( const reco::TransientTrack& ttrack ) const;
-  bool match( const TrajectoryStateOnSurface& newTsos, const TrajectoryStateOnSurface& oldTsos ) const;
+  std::pair<bool, TrajectoryStateOnSurface> innermostState(const reco::TransientTrack& ttrack) const;
+  bool match(const TrajectoryStateOnSurface& newTsos, const TrajectoryStateOnSurface& oldTsos) const;
 
-  const edm::InputTag srcTag_; 
+  const edm::InputTag srcTag_;
   const edm::InputTag bsSrcTag_;
 
   const TwoBodyDecayFitter tbdFitter_;
@@ -67,39 +62,37 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> trackCollToken_;
   edm::EDGetTokenT<reco::BeamSpot> bsToken_;
 
-//   // debug
-//   std::map<std::string, TH1F*> histos_;
+  //   // debug
+  //   std::map<std::string, TH1F*> histos_;
 };
 
-
-TwoBodyDecayConstraintProducer::TwoBodyDecayConstraintProducer( const edm::ParameterSet& iConfig ) :
-  srcTag_( iConfig.getParameter<edm::InputTag>( "src" ) ),
-  bsSrcTag_( iConfig.getParameter<edm::InputTag>( "beamSpot" ) ),
-  tbdFitter_( iConfig ),
-  primaryMass_( iConfig.getParameter<double>( "primaryMass" ) ),
-  primaryWidth_( iConfig.getParameter<double>( "primaryWidth" ) ),
-  secondaryMass_( iConfig.getParameter<double>( "secondaryMass" ) ),
-  sigmaPositionCutValue_( iConfig.getParameter<double>( "sigmaPositionCut" ) ),
-  chi2CutValue_( iConfig.getParameter<double>( "chi2Cut" ) ),
-  errorRescaleValue_( iConfig.getParameter<double>( "rescaleError" ) )
-{
+TwoBodyDecayConstraintProducer::TwoBodyDecayConstraintProducer(const edm::ParameterSet& iConfig)
+    : srcTag_(iConfig.getParameter<edm::InputTag>("src")),
+      bsSrcTag_(iConfig.getParameter<edm::InputTag>("beamSpot")),
+      tbdFitter_(iConfig),
+      primaryMass_(iConfig.getParameter<double>("primaryMass")),
+      primaryWidth_(iConfig.getParameter<double>("primaryWidth")),
+      secondaryMass_(iConfig.getParameter<double>("secondaryMass")),
+      sigmaPositionCutValue_(iConfig.getParameter<double>("sigmaPositionCut")),
+      chi2CutValue_(iConfig.getParameter<double>("chi2Cut")),
+      errorRescaleValue_(iConfig.getParameter<double>("rescaleError")) {
   trackCollToken_ = consumes<reco::TrackCollection>(edm::InputTag(srcTag_));
   bsToken_ = consumes<reco::BeamSpot>(edm::InputTag(bsSrcTag_));
 
   produces<std::vector<TrackParamConstraint> >();
   produces<TrackParamConstraintAssociationCollection>();
 
-//   //debug
-//   histos_["deltaEta1"] = new TH1F( "deltaEta1", "deltaEta1", 200, -1., 1. );
-//   histos_["deltaP1"] = new TH1F( "deltaP1", "deltaP1", 200, -50., 50. );
+  //   //debug
+  //   histos_["deltaEta1"] = new TH1F( "deltaEta1", "deltaEta1", 200, -1., 1. );
+  //   histos_["deltaP1"] = new TH1F( "deltaP1", "deltaP1", 200, -50., 50. );
 
-//   histos_["deltaEta2"] = new TH1F( "deltaEta2", "deltaEta2", 200, -1., 1. );
-//   histos_["deltaP2"] = new TH1F( "deltaP2", "deltaP2", 200, -50., 50. );
+  //   histos_["deltaEta2"] = new TH1F( "deltaEta2", "deltaEta2", 200, -1., 1. );
+  //   histos_["deltaP2"] = new TH1F( "deltaP2", "deltaP2", 200, -50., 50. );
 }
 
-
-void TwoBodyDecayConstraintProducer::produce(edm::StreamID streamid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void TwoBodyDecayConstraintProducer::produce(edm::StreamID streamid,
+                                             edm::Event& iEvent,
+                                             const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<reco::TrackCollection> trackColl;
@@ -109,104 +102,103 @@ void TwoBodyDecayConstraintProducer::produce(edm::StreamID streamid, edm::Event&
   iEvent.getByToken(bsToken_, beamSpot);
 
   ESHandle<MagneticField> magField;
-  iSetup.get<IdealMagneticFieldRecord>().get( magField );
+  iSetup.get<IdealMagneticFieldRecord>().get(magField);
 
-  edm::RefProd<std::vector<TrackParamConstraint> > rPairs = iEvent.getRefBeforePut<std::vector<TrackParamConstraint> >();
+  edm::RefProd<std::vector<TrackParamConstraint> > rPairs =
+      iEvent.getRefBeforePut<std::vector<TrackParamConstraint> >();
   std::unique_ptr<std::vector<TrackParamConstraint> > pairs(new std::vector<TrackParamConstraint>);
-  std::unique_ptr<TrackParamConstraintAssociationCollection> output(new TrackParamConstraintAssociationCollection(trackColl, rPairs));
-  
-  if ( trackColl->size() == 2 )
-  {
+  std::unique_ptr<TrackParamConstraintAssociationCollection> output(
+      new TrackParamConstraintAssociationCollection(trackColl, rPairs));
+
+  if (trackColl->size() == 2) {
     /// Construct virtual measurement (for TBD)
-    TwoBodyDecayVirtualMeasurement vm( primaryMass_, primaryWidth_, secondaryMass_, *beamSpot.product() );
+    TwoBodyDecayVirtualMeasurement vm(primaryMass_, primaryWidth_, secondaryMass_, *beamSpot.product());
 
     /// Get transient tracks from track collection
     std::vector<reco::TransientTrack> ttracks(2);
-    ttracks[0] = reco::TransientTrack( reco::TrackRef( trackColl, 0 ), magField.product() );
-    ttracks[0].setES( iSetup );
-    ttracks[1] = reco::TransientTrack( reco::TrackRef( trackColl, 1 ), magField.product() );
-    ttracks[1].setES( iSetup );
+    ttracks[0] = reco::TransientTrack(reco::TrackRef(trackColl, 0), magField.product());
+    ttracks[0].setES(iSetup);
+    ttracks[1] = reco::TransientTrack(reco::TrackRef(trackColl, 1), magField.product());
+    ttracks[1].setES(iSetup);
 
     /// Fit the TBD
-    TwoBodyDecay tbd = tbdFitter_.estimate( ttracks, vm );
+    TwoBodyDecay tbd = tbdFitter_.estimate(ttracks, vm);
 
-    if ( !tbd.isValid() or ( tbd.chi2() > chi2CutValue_ ) ) return;
+    if (!tbd.isValid() or (tbd.chi2() > chi2CutValue_))
+      return;
 
     /// Get the innermost trajectory states
-    std::pair<bool, TrajectoryStateOnSurface> oldInnermostState1 = innermostState( ttracks[0] );
-    std::pair<bool, TrajectoryStateOnSurface> oldInnermostState2 = innermostState( ttracks[1] );
-    if ( !oldInnermostState1.second.isValid() || !oldInnermostState2.second.isValid() ) return;
+    std::pair<bool, TrajectoryStateOnSurface> oldInnermostState1 = innermostState(ttracks[0]);
+    std::pair<bool, TrajectoryStateOnSurface> oldInnermostState2 = innermostState(ttracks[1]);
+    if (!oldInnermostState1.second.isValid() || !oldInnermostState2.second.isValid())
+      return;
 
     /// Construct the TBD trajectory states
-    TwoBodyDecayTrajectoryState::TsosContainer trackTsos( oldInnermostState1.second, oldInnermostState2.second );
-    TwoBodyDecayTrajectoryState tbdTrajState( trackTsos, tbd, secondaryMass_, magField.product(), true );
-    if ( !tbdTrajState.isValid() ) return;
+    TwoBodyDecayTrajectoryState::TsosContainer trackTsos(oldInnermostState1.second, oldInnermostState2.second);
+    TwoBodyDecayTrajectoryState tbdTrajState(trackTsos, tbd, secondaryMass_, magField.product(), true);
+    if (!tbdTrajState.isValid())
+      return;
 
     /// Match the old and the new estimates for the trajectory state
-    bool match1 = match( tbdTrajState.trajectoryStates(true).first, oldInnermostState1.second );
-    bool match2 = match( tbdTrajState.trajectoryStates(true).second, oldInnermostState2.second );
-    if ( !match1 || !match2 ) return;
+    bool match1 = match(tbdTrajState.trajectoryStates(true).first, oldInnermostState1.second);
+    bool match2 = match(tbdTrajState.trajectoryStates(true).second, oldInnermostState2.second);
+    if (!match1 || !match2)
+      return;
 
     // re-scale error of constraintTsos
-    tbdTrajState.rescaleError( errorRescaleValue_ );
+    tbdTrajState.rescaleError(errorRescaleValue_);
 
     // produce constraint for first track
     pairs->push_back(tbdTrajState.trajectoryStates(true).first);
-    output->insert( reco::TrackRef(trackColl,0), edm::Ref<std::vector<TrackParamConstraint> >(rPairs,0) );
+    output->insert(reco::TrackRef(trackColl, 0), edm::Ref<std::vector<TrackParamConstraint> >(rPairs, 0));
 
     // produce constraint for second track
     pairs->push_back(tbdTrajState.trajectoryStates(true).second);
-    output->insert( reco::TrackRef(trackColl,1), edm::Ref<std::vector<TrackParamConstraint> >(rPairs,1) );
+    output->insert(reco::TrackRef(trackColl, 1), edm::Ref<std::vector<TrackParamConstraint> >(rPairs, 1));
 
-//     // debug
-//     if ( tbd.isValid() ) {
-//       TwoBodyDecayModel model;
-//       const std::pair< AlgebraicVector, AlgebraicVector > fitMomenta = model.cartesianSecondaryMomenta( tbd );
+    //     // debug
+    //     if ( tbd.isValid() ) {
+    //       TwoBodyDecayModel model;
+    //       const std::pair< AlgebraicVector, AlgebraicVector > fitMomenta = model.cartesianSecondaryMomenta( tbd );
 
-//       TLorentzVector recoMomentum1( ttracks[0].track().px(), ttracks[0].track().py(), ttracks[0].track().pz(),
-// 				    sqrt((ttracks[0].track().p()*ttracks[0].track().p())+0.105658*0.105658) );
-//       TLorentzVector fitMomentum1( fitMomenta.first[0], fitMomenta.first[1], fitMomenta.first[2],
-// 				   sqrt( fitMomenta.first.normsq()+0.105658*0.105658) );
-//       histos_["deltaP1"]->Fill( recoMomentum1.P() - fitMomentum1.P() );
-//       histos_["deltaEta1"]->Fill( recoMomentum1.Eta() - fitMomentum1.Eta() );
+    //       TLorentzVector recoMomentum1( ttracks[0].track().px(), ttracks[0].track().py(), ttracks[0].track().pz(),
+    // 				    sqrt((ttracks[0].track().p()*ttracks[0].track().p())+0.105658*0.105658) );
+    //       TLorentzVector fitMomentum1( fitMomenta.first[0], fitMomenta.first[1], fitMomenta.first[2],
+    // 				   sqrt( fitMomenta.first.normsq()+0.105658*0.105658) );
+    //       histos_["deltaP1"]->Fill( recoMomentum1.P() - fitMomentum1.P() );
+    //       histos_["deltaEta1"]->Fill( recoMomentum1.Eta() - fitMomentum1.Eta() );
 
-//       TLorentzVector recoMomentum2( ttracks[1].track().px(), ttracks[1].track().py(), ttracks[1].track().pz(),
-// 				    sqrt((ttracks[1].track().p()*ttracks[1].track().p())+0.105658*0.105658) );
-//       TLorentzVector fitMomentum2( fitMomenta.second[0], fitMomenta.second[1], fitMomenta.second[2],
-// 				   sqrt( fitMomenta.second.normsq()+0.105658*0.105658) );
-//       histos_["deltaP2"]->Fill( recoMomentum2.P() - fitMomentum2.P() );
-//       histos_["deltaEta2"]->Fill( recoMomentum2.Eta() - fitMomentum2.Eta() );
-//     }
+    //       TLorentzVector recoMomentum2( ttracks[1].track().px(), ttracks[1].track().py(), ttracks[1].track().pz(),
+    // 				    sqrt((ttracks[1].track().p()*ttracks[1].track().p())+0.105658*0.105658) );
+    //       TLorentzVector fitMomentum2( fitMomenta.second[0], fitMomenta.second[1], fitMomenta.second[2],
+    // 				   sqrt( fitMomenta.second.normsq()+0.105658*0.105658) );
+    //       histos_["deltaP2"]->Fill( recoMomentum2.P() - fitMomentum2.P() );
+    //       histos_["deltaEta2"]->Fill( recoMomentum2.Eta() - fitMomentum2.Eta() );
+    //     }
   }
-  
+
   iEvent.put(std::move(pairs));
   iEvent.put(std::move(output));
 }
 
-
-std::pair<bool, TrajectoryStateOnSurface>
-TwoBodyDecayConstraintProducer::innermostState( const reco::TransientTrack& ttrack ) const
-{
+std::pair<bool, TrajectoryStateOnSurface> TwoBodyDecayConstraintProducer::innermostState(
+    const reco::TransientTrack& ttrack) const {
   double outerR = ttrack.outermostMeasurementState().globalPosition().perp();
   double innerR = ttrack.innermostMeasurementState().globalPosition().perp();
-  bool insideOut = ( outerR > innerR );
-  return std::make_pair( insideOut, insideOut ? ttrack.innermostMeasurementState() : ttrack.outermostMeasurementState() );
+  bool insideOut = (outerR > innerR);
+  return std::make_pair(insideOut, insideOut ? ttrack.innermostMeasurementState() : ttrack.outermostMeasurementState());
 }
 
-
-bool
-TwoBodyDecayConstraintProducer::match( const TrajectoryStateOnSurface& newTsos,
-				       const TrajectoryStateOnSurface& oldTsos ) const
-{
+bool TwoBodyDecayConstraintProducer::match(const TrajectoryStateOnSurface& newTsos,
+                                           const TrajectoryStateOnSurface& oldTsos) const {
   LocalPoint lp1 = newTsos.localPosition();
   LocalPoint lp2 = oldTsos.localPosition();
 
   double deltaX = lp1.x() - lp2.x();
   double deltaY = lp1.y() - lp2.y();
 
-  return ( ( fabs(deltaX) < sigmaPositionCutValue_ ) && ( fabs(deltaY) < sigmaPositionCutValue_ ) );
+  return ((fabs(deltaX) < sigmaPositionCutValue_) && (fabs(deltaY) < sigmaPositionCutValue_));
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(TwoBodyDecayConstraintProducer);

--- a/RecoTracker/TrackProducer/plugins/TwoBodyDecayMomConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TwoBodyDecayMomConstraintProducer.cc
@@ -36,29 +36,24 @@
 // #include "TLorentzVector.h"
 // #include "Alignment/TwoBodyDecay/interface/TwoBodyDecayModel.h"
 
-
-class TwoBodyDecayMomConstraintProducer: public edm::global::EDProducer<>
-{
-
+class TwoBodyDecayMomConstraintProducer : public edm::global::EDProducer<> {
 public:
-
   explicit TwoBodyDecayMomConstraintProducer(const edm::ParameterSet&);
   ~TwoBodyDecayMomConstraintProducer() override = default;
 
 private:
-
   void produce(edm::StreamID streamid, edm::Event&, const edm::EventSetup&) const override;
 
-  std::pair<double, double> momentaAtVertex( const TwoBodyDecay& tbd ) const;
+  std::pair<double, double> momentaAtVertex(const TwoBodyDecay& tbd) const;
 
-  std::pair<double, double> momentaAtInnermostSurface( const TwoBodyDecay& tbd,
-						       const std::vector<reco::TransientTrack>& ttracks,
-						       const MagneticField* magField ) const;
+  std::pair<double, double> momentaAtInnermostSurface(const TwoBodyDecay& tbd,
+                                                      const std::vector<reco::TransientTrack>& ttracks,
+                                                      const MagneticField* magField) const;
 
-  std::pair<bool, TrajectoryStateOnSurface> innermostState( const reco::TransientTrack& ttrack ) const;
-  bool match( const TrajectoryStateOnSurface& newTsos, const TrajectoryStateOnSurface& oldTsos ) const;
+  std::pair<bool, TrajectoryStateOnSurface> innermostState(const reco::TransientTrack& ttrack) const;
+  bool match(const TrajectoryStateOnSurface& newTsos, const TrajectoryStateOnSurface& oldTsos) const;
 
-  const edm::InputTag srcTag_; 
+  const edm::InputTag srcTag_;
   const edm::InputTag bsSrcTag_;
 
   const TwoBodyDecayFitter tbdFitter_;
@@ -79,42 +74,38 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> trackCollToken_;
   edm::EDGetTokenT<reco::BeamSpot> bsToken_;
 
-//   // debug
-//   std::map<std::string, TH1F*> histos_;
+  //   // debug
+  //   std::map<std::string, TH1F*> histos_;
 };
 
-
-TwoBodyDecayMomConstraintProducer::TwoBodyDecayMomConstraintProducer( const edm::ParameterSet& iConfig ) :
-  srcTag_( iConfig.getParameter<edm::InputTag>( "src" ) ),
-  bsSrcTag_( iConfig.getParameter<edm::InputTag>( "beamSpot" ) ),
-  tbdFitter_( iConfig ),
-  primaryMass_( iConfig.getParameter<double>( "primaryMass" ) ),
-  primaryWidth_( iConfig.getParameter<double>( "primaryWidth" ) ),
-  secondaryMass_( iConfig.getParameter<double>( "secondaryMass" ) ),
-  sigmaPositionCutValue_( iConfig.getParameter<double>( "sigmaPositionCut" ) ),
-  chi2CutValue_( iConfig.getParameter<double>( "chi2Cut" ) ),
-  fixedMomentumError_( iConfig.getParameter<double>( "fixedMomentumError" ) ),
-  momentumForRefitting_( momentumForRefittingFromString( iConfig.getParameter<std::string>( "momentumForRefitting" ) ) )
-{
+TwoBodyDecayMomConstraintProducer::TwoBodyDecayMomConstraintProducer(const edm::ParameterSet& iConfig)
+    : srcTag_(iConfig.getParameter<edm::InputTag>("src")),
+      bsSrcTag_(iConfig.getParameter<edm::InputTag>("beamSpot")),
+      tbdFitter_(iConfig),
+      primaryMass_(iConfig.getParameter<double>("primaryMass")),
+      primaryWidth_(iConfig.getParameter<double>("primaryWidth")),
+      secondaryMass_(iConfig.getParameter<double>("secondaryMass")),
+      sigmaPositionCutValue_(iConfig.getParameter<double>("sigmaPositionCut")),
+      chi2CutValue_(iConfig.getParameter<double>("chi2Cut")),
+      fixedMomentumError_(iConfig.getParameter<double>("fixedMomentumError")),
+      momentumForRefitting_(momentumForRefittingFromString(iConfig.getParameter<std::string>("momentumForRefitting"))) {
   trackCollToken_ = consumes<reco::TrackCollection>(edm::InputTag(srcTag_));
   bsToken_ = consumes<reco::BeamSpot>(edm::InputTag(bsSrcTag_));
 
-  produces< std::vector<MomentumConstraint> >();
+  produces<std::vector<MomentumConstraint> >();
   produces<TrackMomConstraintAssociationCollection>();
 
-//   //debug
-//   histos_["deltaEta1"] = new TH1F( "deltaEta1", "deltaEta1", 200, -1., 1. );
-//   histos_["deltaP1"] = new TH1F( "deltaP1", "deltaP1", 200, -50., 50. );
+  //   //debug
+  //   histos_["deltaEta1"] = new TH1F( "deltaEta1", "deltaEta1", 200, -1., 1. );
+  //   histos_["deltaP1"] = new TH1F( "deltaP1", "deltaP1", 200, -50., 50. );
 
-//   histos_["deltaEta2"] = new TH1F( "deltaEta2", "deltaEta2", 200, -1., 1. );
-//   histos_["deltaP2"] = new TH1F( "deltaP2", "deltaP2", 200, -50., 50. );
+  //   histos_["deltaEta2"] = new TH1F( "deltaEta2", "deltaEta2", 200, -1., 1. );
+  //   histos_["deltaP2"] = new TH1F( "deltaP2", "deltaP2", 200, -50., 50. );
 }
 
-
-
-
-void TwoBodyDecayMomConstraintProducer::produce(edm::StreamID streamid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void TwoBodyDecayMomConstraintProducer::produce(edm::StreamID streamid,
+                                                edm::Event& iEvent,
+                                                const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<reco::TrackCollection> trackColl;
@@ -124,151 +115,139 @@ void TwoBodyDecayMomConstraintProducer::produce(edm::StreamID streamid, edm::Eve
   iEvent.getByToken(bsToken_, beamSpot);
 
   ESHandle<MagneticField> magField;
-  iSetup.get<IdealMagneticFieldRecord>().get( magField );
+  iSetup.get<IdealMagneticFieldRecord>().get(magField);
 
   edm::RefProd<std::vector<MomentumConstraint> > rPairs = iEvent.getRefBeforePut<std::vector<MomentumConstraint> >();
   std::unique_ptr<std::vector<MomentumConstraint> > pairs(new std::vector<MomentumConstraint>);
-  std::unique_ptr<TrackMomConstraintAssociationCollection> output(new TrackMomConstraintAssociationCollection(trackColl, rPairs));
-    
-  if ( trackColl->size() == 2 )
-  {
+  std::unique_ptr<TrackMomConstraintAssociationCollection> output(
+      new TrackMomConstraintAssociationCollection(trackColl, rPairs));
+
+  if (trackColl->size() == 2) {
     /// Construct virtual measurement (for TBD)
-    TwoBodyDecayVirtualMeasurement vm( primaryMass_, primaryWidth_, secondaryMass_, *beamSpot.product() );
+    TwoBodyDecayVirtualMeasurement vm(primaryMass_, primaryWidth_, secondaryMass_, *beamSpot.product());
 
     /// Get transient tracks from track collection
     std::vector<reco::TransientTrack> ttracks(2);
-    ttracks[0] = reco::TransientTrack( reco::TrackRef( trackColl, 0 ), magField.product() );
-    ttracks[0].setES( iSetup );
-    ttracks[1] = reco::TransientTrack( reco::TrackRef( trackColl, 1 ), magField.product() );
-    ttracks[1].setES( iSetup );
+    ttracks[0] = reco::TransientTrack(reco::TrackRef(trackColl, 0), magField.product());
+    ttracks[0].setES(iSetup);
+    ttracks[1] = reco::TransientTrack(reco::TrackRef(trackColl, 1), magField.product());
+    ttracks[1].setES(iSetup);
 
     /// Fit the TBD
-    TwoBodyDecay tbd = tbdFitter_.estimate( ttracks, vm );
+    TwoBodyDecay tbd = tbdFitter_.estimate(ttracks, vm);
 
-    if ( !tbd.isValid() or ( tbd.chi2() > chi2CutValue_ ) ) return;
+    if (!tbd.isValid() or (tbd.chi2() > chi2CutValue_))
+      return;
 
     std::pair<double, double> fitMomenta;
-    if ( momentumForRefitting_ == atVertex ) {
-      fitMomenta = momentaAtVertex( tbd );
-    } else if ( momentumForRefitting_ == atInnermostSurface ) {
-      fitMomenta = momentaAtInnermostSurface( tbd, ttracks, magField.product() );
-    } // no other possibility!!!
+    if (momentumForRefitting_ == atVertex) {
+      fitMomenta = momentaAtVertex(tbd);
+    } else if (momentumForRefitting_ == atInnermostSurface) {
+      fitMomenta = momentaAtInnermostSurface(tbd, ttracks, magField.product());
+    }  // no other possibility!!!
 
-    if ( ( fitMomenta.first > 0. ) and ( fitMomenta.second > 0. ) )
-    {
+    if ((fitMomenta.first > 0.) and (fitMomenta.second > 0.)) {
       // produce constraint for first track
-      MomentumConstraint constraint1( fitMomenta.first, fixedMomentumError_ );
-      pairs->push_back( constraint1 );
+      MomentumConstraint constraint1(fitMomenta.first, fixedMomentumError_);
+      pairs->push_back(constraint1);
       output->insert(reco::TrackRef(trackColl, 0), edm::Ref<std::vector<MomentumConstraint> >(rPairs, 0));
 
       // produce constraint for second track
-      MomentumConstraint constraint2( fitMomenta.second, fixedMomentumError_ );
-      pairs->push_back( constraint2 );
+      MomentumConstraint constraint2(fitMomenta.second, fixedMomentumError_);
+      pairs->push_back(constraint2);
       output->insert(reco::TrackRef(trackColl, 1), edm::Ref<std::vector<MomentumConstraint> >(rPairs, 1));
     }
 
-//     // debug
-//     if ( tbd.isValid() and ( fitMomenta.first > 0. ) and ( fitMomenta.second > 0. ) ) {
-//       TwoBodyDecayModel model;
-//       const std::pair< AlgebraicVector, AlgebraicVector > fitMomenta = model.cartesianSecondaryMomenta( tbd );
+    //     // debug
+    //     if ( tbd.isValid() and ( fitMomenta.first > 0. ) and ( fitMomenta.second > 0. ) ) {
+    //       TwoBodyDecayModel model;
+    //       const std::pair< AlgebraicVector, AlgebraicVector > fitMomenta = model.cartesianSecondaryMomenta( tbd );
 
-//       TLorentzVector recoMomentum1( ttracks[0].track().px(), ttracks[0].track().py(), ttracks[0].track().pz(),
-// 				    sqrt((ttracks[0].track().p()*ttracks[0].track().p())+0.105658*0.105658) );
-//       TLorentzVector fitMomentum1( fitMomenta.first[0], fitMomenta.first[1], fitMomenta.first[2],
-// 				   sqrt( fitMomenta.first.normsq()+0.105658*0.105658) );
-//       histos_["deltaP1"]->Fill( recoMomentum1.P() - fitMomentum1.P() );
-//       histos_["deltaEta1"]->Fill( recoMomentum1.Eta() - fitMomentum1.Eta() );
+    //       TLorentzVector recoMomentum1( ttracks[0].track().px(), ttracks[0].track().py(), ttracks[0].track().pz(),
+    // 				    sqrt((ttracks[0].track().p()*ttracks[0].track().p())+0.105658*0.105658) );
+    //       TLorentzVector fitMomentum1( fitMomenta.first[0], fitMomenta.first[1], fitMomenta.first[2],
+    // 				   sqrt( fitMomenta.first.normsq()+0.105658*0.105658) );
+    //       histos_["deltaP1"]->Fill( recoMomentum1.P() - fitMomentum1.P() );
+    //       histos_["deltaEta1"]->Fill( recoMomentum1.Eta() - fitMomentum1.Eta() );
 
-//       TLorentzVector recoMomentum2( ttracks[1].track().px(), ttracks[1].track().py(), ttracks[1].track().pz(),
-// 				    sqrt((ttracks[1].track().p()*ttracks[1].track().p())+0.105658*0.105658) );
-//       TLorentzVector fitMomentum2( fitMomenta.second[0], fitMomenta.second[1], fitMomenta.second[2],
-// 				   sqrt( fitMomenta.second.normsq()+0.105658*0.105658) );
-//       histos_["deltaP2"]->Fill( recoMomentum2.P() - fitMomentum2.P() );
-//       histos_["deltaEta2"]->Fill( recoMomentum2.Eta() - fitMomentum2.Eta() );
-//     }
+    //       TLorentzVector recoMomentum2( ttracks[1].track().px(), ttracks[1].track().py(), ttracks[1].track().pz(),
+    // 				    sqrt((ttracks[1].track().p()*ttracks[1].track().p())+0.105658*0.105658) );
+    //       TLorentzVector fitMomentum2( fitMomenta.second[0], fitMomenta.second[1], fitMomenta.second[2],
+    // 				   sqrt( fitMomenta.second.normsq()+0.105658*0.105658) );
+    //       histos_["deltaP2"]->Fill( recoMomentum2.P() - fitMomentum2.P() );
+    //       histos_["deltaEta2"]->Fill( recoMomentum2.Eta() - fitMomentum2.Eta() );
+    //     }
   }
-  
+
   iEvent.put(std::move(pairs));
   iEvent.put(std::move(output));
 }
 
-
-std::pair<double, double>
-TwoBodyDecayMomConstraintProducer::momentaAtVertex( const TwoBodyDecay& tbd ) const
-{
+std::pair<double, double> TwoBodyDecayMomConstraintProducer::momentaAtVertex(const TwoBodyDecay& tbd) const {
   // construct global trajectory parameters at the starting point
-  TwoBodyDecayModel tbdDecayModel( tbd[TwoBodyDecayParameters::mass], secondaryMass_ );
-  std::pair< AlgebraicVector, AlgebraicVector > secondaryMomenta = tbdDecayModel.cartesianSecondaryMomenta( tbd );
+  TwoBodyDecayModel tbdDecayModel(tbd[TwoBodyDecayParameters::mass], secondaryMass_);
+  std::pair<AlgebraicVector, AlgebraicVector> secondaryMomenta = tbdDecayModel.cartesianSecondaryMomenta(tbd);
 
-  return std::make_pair( secondaryMomenta.first.norm(),
-			 secondaryMomenta.second.norm() );
+  return std::make_pair(secondaryMomenta.first.norm(), secondaryMomenta.second.norm());
 }
 
-
-std::pair<double, double>
-TwoBodyDecayMomConstraintProducer::momentaAtInnermostSurface( const TwoBodyDecay& tbd,
-							      const std::vector<reco::TransientTrack>& ttracks,
-							      const MagneticField* magField) const
-{
-  std::pair<double, double> result = std::make_pair( -1., -1. );
+std::pair<double, double> TwoBodyDecayMomConstraintProducer::momentaAtInnermostSurface(
+    const TwoBodyDecay& tbd, const std::vector<reco::TransientTrack>& ttracks, const MagneticField* magField) const {
+  std::pair<double, double> result = std::make_pair(-1., -1.);
 
   /// Get the innermost trajectory states
-  std::pair<bool, TrajectoryStateOnSurface> oldInnermostState1 = innermostState( ttracks[0] );
-  std::pair<bool, TrajectoryStateOnSurface> oldInnermostState2 = innermostState( ttracks[1] );
-  if ( !oldInnermostState1.second.isValid() || !oldInnermostState2.second.isValid() ) return result;
+  std::pair<bool, TrajectoryStateOnSurface> oldInnermostState1 = innermostState(ttracks[0]);
+  std::pair<bool, TrajectoryStateOnSurface> oldInnermostState2 = innermostState(ttracks[1]);
+  if (!oldInnermostState1.second.isValid() || !oldInnermostState2.second.isValid())
+    return result;
 
   /// Construct the TBD trajectory states
-  TwoBodyDecayTrajectoryState::TsosContainer trackTsos( oldInnermostState1.second, oldInnermostState2.second );
-  TwoBodyDecayTrajectoryState tbdTrajState( trackTsos, tbd, secondaryMass_, magField, true );
-  if ( !tbdTrajState.isValid() ) return result;
+  TwoBodyDecayTrajectoryState::TsosContainer trackTsos(oldInnermostState1.second, oldInnermostState2.second);
+  TwoBodyDecayTrajectoryState tbdTrajState(trackTsos, tbd, secondaryMass_, magField, true);
+  if (!tbdTrajState.isValid())
+    return result;
 
   /// Match the old and the new estimates for the trajectory state
-  bool match1 = match( tbdTrajState.trajectoryStates(true).first, oldInnermostState1.second );
-  bool match2 = match( tbdTrajState.trajectoryStates(true).second, oldInnermostState2.second );
-  if ( !match1 || !match2 ) return result;
+  bool match1 = match(tbdTrajState.trajectoryStates(true).first, oldInnermostState1.second);
+  bool match2 = match(tbdTrajState.trajectoryStates(true).second, oldInnermostState2.second);
+  if (!match1 || !match2)
+    return result;
 
-  result = std::make_pair( fabs( 1./tbdTrajState.trajectoryStates(true).first.localParameters().qbp() ),
-			   fabs( 1./tbdTrajState.trajectoryStates(true).second.localParameters().qbp() ) );
+  result = std::make_pair(fabs(1. / tbdTrajState.trajectoryStates(true).first.localParameters().qbp()),
+                          fabs(1. / tbdTrajState.trajectoryStates(true).second.localParameters().qbp()));
   return result;
 }
 
-
-std::pair<bool, TrajectoryStateOnSurface>
-TwoBodyDecayMomConstraintProducer::innermostState( const reco::TransientTrack& ttrack ) const
-{
+std::pair<bool, TrajectoryStateOnSurface> TwoBodyDecayMomConstraintProducer::innermostState(
+    const reco::TransientTrack& ttrack) const {
   double outerR = ttrack.outermostMeasurementState().globalPosition().perp();
   double innerR = ttrack.innermostMeasurementState().globalPosition().perp();
-  bool insideOut = ( outerR > innerR );
-  return std::make_pair( insideOut, insideOut ? ttrack.innermostMeasurementState() : ttrack.outermostMeasurementState() );
+  bool insideOut = (outerR > innerR);
+  return std::make_pair(insideOut, insideOut ? ttrack.innermostMeasurementState() : ttrack.outermostMeasurementState());
 }
 
-
-bool
-TwoBodyDecayMomConstraintProducer::match( const TrajectoryStateOnSurface& newTsos,
-				       const TrajectoryStateOnSurface& oldTsos ) const
-{
+bool TwoBodyDecayMomConstraintProducer::match(const TrajectoryStateOnSurface& newTsos,
+                                              const TrajectoryStateOnSurface& oldTsos) const {
   LocalPoint lp1 = newTsos.localPosition();
   LocalPoint lp2 = oldTsos.localPosition();
 
   double deltaX = lp1.x() - lp2.x();
   double deltaY = lp1.y() - lp2.y();
 
-  return ( ( fabs(deltaX) < sigmaPositionCutValue_ ) && ( fabs(deltaY) < sigmaPositionCutValue_ ) );
+  return ((fabs(deltaX) < sigmaPositionCutValue_) && (fabs(deltaY) < sigmaPositionCutValue_));
 }
 
 TwoBodyDecayMomConstraintProducer::MomentumForRefitting
 TwoBodyDecayMomConstraintProducer::momentumForRefittingFromString(std::string strMomentumForRefitting) {
-  if ( strMomentumForRefitting == "atVertex" ) {
+  if (strMomentumForRefitting == "atVertex") {
     return atVertex;
-  } else if ( strMomentumForRefitting == "atInnermostSurface" ) {
+  } else if (strMomentumForRefitting == "atInnermostSurface") {
     return atInnermostSurface;
   } else {
     throw cms::Exception("TwoBodyDecayMomConstraintProducer") << "value of config  variable 'momentumForRefitting': "
                                                               << "has to be 'atVertex' or 'atInnermostSurface'";
   }
 }
-
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(TwoBodyDecayMomConstraintProducer);

--- a/RecoTracker/TrackProducer/plugins/VertexConstraintProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/VertexConstraintProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    VertexConstraintProducer
 // Class:      VertexConstraintProducer
-// 
+//
 /**\class VertexConstraintProducer VertexConstraintProducer.cc RecoTracker/ConstraintProducerTest/src/VertexConstraintProducer.cc
 
 Description: <one line class summary>
@@ -15,7 +15,6 @@ Implementation:
 //         Created:  Tue Jul 10 15:05:02 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -40,21 +39,20 @@ Implementation:
 // class decleration
 //
 
-class VertexConstraintProducer: public edm::global::EDProducer<> {
+class VertexConstraintProducer : public edm::global::EDProducer<> {
 public:
   explicit VertexConstraintProducer(const edm::ParameterSet&);
   ~VertexConstraintProducer() override = default;
 
 private:
   void produce(edm::StreamID streamid, edm::Event&, const edm::EventSetup&) const override;
-      
+
   // ----------member data ---------------------------
   const edm::InputTag srcTrkTag_;
   edm::EDGetTokenT<reco::TrackCollection> trkToken_;
 
   const edm::InputTag srcVtxTag_;
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
-
 };
 
 //
@@ -68,10 +66,9 @@ private:
 //
 // constructors and destructor
 //
-VertexConstraintProducer::VertexConstraintProducer(const edm::ParameterSet& iConfig) :
-srcTrkTag_(iConfig.getParameter<edm::InputTag>("srcTrk")),
-srcVtxTag_(iConfig.getParameter<edm::InputTag>("srcVtx"))
-{
+VertexConstraintProducer::VertexConstraintProducer(const edm::ParameterSet& iConfig)
+    : srcTrkTag_(iConfig.getParameter<edm::InputTag>("srcTrk")),
+      srcVtxTag_(iConfig.getParameter<edm::InputTag>("srcVtx")) {
   //declare the consumes
   trkToken_ = consumes<reco::TrackCollection>(edm::InputTag(srcTrkTag_));
   vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag(srcVtxTag_));
@@ -83,14 +80,14 @@ srcVtxTag_(iConfig.getParameter<edm::InputTag>("srcVtx"))
   //now do what ever other initialization is needed
 }
 
-
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void VertexConstraintProducer::produce(edm::StreamID streamid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void VertexConstraintProducer::produce(edm::StreamID streamid,
+                                       edm::Event& iEvent,
+                                       const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   Handle<reco::TrackCollection> theTCollection;
@@ -101,25 +98,25 @@ void VertexConstraintProducer::produce(edm::StreamID streamid, edm::Event& iEven
 
   edm::RefProd<std::vector<VertexConstraint> > rPairs = iEvent.getRefBeforePut<std::vector<VertexConstraint> >();
   std::unique_ptr<std::vector<VertexConstraint> > pairs(new std::vector<VertexConstraint>);
-  std::unique_ptr<TrackVtxConstraintAssociationCollection> output(new TrackVtxConstraintAssociationCollection(theTCollection, rPairs));
+  std::unique_ptr<TrackVtxConstraintAssociationCollection> output(
+      new TrackVtxConstraintAssociationCollection(theTCollection, rPairs));
 
   int index = 0;
-  
+
   //primary vertex extraction
 
-  if (!theVertexHandle->empty()){
+  if (!theVertexHandle->empty()) {
     const reco::Vertex& pv = theVertexHandle->front();
-    for (reco::TrackCollection::const_iterator i=theTCollection->begin(); i!=theTCollection->end();i++) {
-      VertexConstraint tmp(
-        GlobalPoint(pv.x(), pv.y(), pv.z()),
-        GlobalError(
-        pv.covariance(0, 0),
-        pv.covariance(1, 0), pv.covariance(1, 1),
-        pv.covariance(2, 0), pv.covariance(2, 1), pv.covariance(2, 2)
-        )
-        );
+    for (reco::TrackCollection::const_iterator i = theTCollection->begin(); i != theTCollection->end(); i++) {
+      VertexConstraint tmp(GlobalPoint(pv.x(), pv.y(), pv.z()),
+                           GlobalError(pv.covariance(0, 0),
+                                       pv.covariance(1, 0),
+                                       pv.covariance(1, 1),
+                                       pv.covariance(2, 0),
+                                       pv.covariance(2, 1),
+                                       pv.covariance(2, 2)));
       pairs->push_back(tmp);
-      output->insert(reco::TrackRef(theTCollection,index), edm::Ref<std::vector<VertexConstraint> >(rPairs,index) );
+      output->insert(reco::TrackRef(theTCollection, index), edm::Ref<std::vector<VertexConstraint> >(rPairs, index));
       index++;
     }
   }

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -24,163 +24,156 @@
 #include "TrackingTools/PatternTools/interface/TrajAnnealing.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
 
+DAFTrackProducerAlgorithm::DAFTrackProducerAlgorithm(const edm::ParameterSet& conf)
+    : conf_(conf), minHits_(conf.getParameter<int>("MinHits")) {}
 
-DAFTrackProducerAlgorithm::DAFTrackProducerAlgorithm(const edm::ParameterSet& conf):
-  conf_(conf),
-  minHits_(conf.getParameter<int>("MinHits")){}
-
-
-void DAFTrackProducerAlgorithm::runWithCandidate(const TrackingGeometry * theG,
-					         const MagneticField * theMF,
-						 const TrajTrackAssociationCollection& TTmap,
-						 const MeasurementTrackerEvent *measTk,
-					         const TrajectoryFitter * theFitter,
-					         const TransientTrackingRecHitBuilder* builder,
-						 const MultiRecHitCollector* measurementCollector,
-						 const SiTrackerMultiRecHitUpdator* updator,
-						 const reco::BeamSpot& bs,
-					         AlgoProductCollection& algoResults,
-						 TrajAnnealingCollection& trajann,
-						 bool TrajAnnSaving_,
-						 AlgoProductCollection& algoResultsBeforeDAF, 
-						 AlgoProductCollection& algoResultsAfterDAF) const
-{
+void DAFTrackProducerAlgorithm::runWithCandidate(const TrackingGeometry* theG,
+                                                 const MagneticField* theMF,
+                                                 const TrajTrackAssociationCollection& TTmap,
+                                                 const MeasurementTrackerEvent* measTk,
+                                                 const TrajectoryFitter* theFitter,
+                                                 const TransientTrackingRecHitBuilder* builder,
+                                                 const MultiRecHitCollector* measurementCollector,
+                                                 const SiTrackerMultiRecHitUpdator* updator,
+                                                 const reco::BeamSpot& bs,
+                                                 AlgoProductCollection& algoResults,
+                                                 TrajAnnealingCollection& trajann,
+                                                 bool TrajAnnSaving_,
+                                                 AlgoProductCollection& algoResultsBeforeDAF,
+                                                 AlgoProductCollection& algoResultsAfterDAF) const {
   LogDebug("DAFTrackProducerAlgorithm") << "Size of map: " << TTmap.size() << "\n";
 
   int cont = 0;
   int nTracksChanged = 0;
 
-  for (TrajTrackAssociationCollection::const_iterator itTTmap = TTmap.begin(); itTTmap != TTmap.end(); itTTmap++){
-
-    const edm::Ref<std::vector<Trajectory> > BeforeDAFTraj  = itTTmap->key;
+  for (TrajTrackAssociationCollection::const_iterator itTTmap = TTmap.begin(); itTTmap != TTmap.end(); itTTmap++) {
+    const edm::Ref<std::vector<Trajectory> > BeforeDAFTraj = itTTmap->key;
     std::vector<TrajectoryMeasurement> BeforeDAFTrajMeas = BeforeDAFTraj->measurements();
     const reco::TrackRef BeforeDAFTrack = itTTmap->val;
 
     float ndof = 0;
     Trajectory CurrentTraj;
 
-    if(BeforeDAFTraj->isValid()){
-      LogDebug("DAFTrackProducerAlgorithm") << "The trajectory #" << cont+1 << " is valid. \n";
+    if (BeforeDAFTraj->isValid()) {
+      LogDebug("DAFTrackProducerAlgorithm") << "The trajectory #" << cont + 1 << " is valid. \n";
 
       //getting the MultiRecHit collection and the trajectory with a first fit-smooth round
-      std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> hits = collectHits(*BeforeDAFTraj, measurementCollector, &*measTk);
+      std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> hits =
+          collectHits(*BeforeDAFTraj, measurementCollector, &*measTk);
 
       //new initial fit
       CurrentTraj = fit(hits, theFitter, *BeforeDAFTraj);
 
       //starting the annealing program
-      for (std::vector<double>::const_iterator ian = updator->getAnnealingProgram().begin(); 
-           ian != updator->getAnnealingProgram().end(); ian++){
+      for (std::vector<double>::const_iterator ian = updator->getAnnealingProgram().begin();
+           ian != updator->getAnnealingProgram().end();
+           ian++) {
+        if (CurrentTraj.isValid()) {
+          LogDebug("DAFTrackProducerAlgorithm") << "Seed direction is " << CurrentTraj.seed().direction()
+                                                << ".Traj direction is " << CurrentTraj.direction() << std::endl;
 
-        if (CurrentTraj.isValid()){
-
-	  LogDebug("DAFTrackProducerAlgorithm") << "Seed direction is " << CurrentTraj.seed().direction() 
-	 	                                << ".Traj direction is " << CurrentTraj.direction() << std::endl;
-
-          //updating MultiRecHits and fit-smooth again 
-	  std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> curiterationhits = 
-									updateHits(CurrentTraj, updator, &*measTk, *ian);
-          if( curiterationhits.first.size() < 3 ){
-            LogDebug("DAFTrackProducerAlgorithm") << "Rejecting trajectory with " << curiterationhits.first.size() <<" hits" << std::endl;
+          //updating MultiRecHits and fit-smooth again
+          std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> curiterationhits =
+              updateHits(CurrentTraj, updator, &*measTk, *ian);
+          if (curiterationhits.first.size() < 3) {
+            LogDebug("DAFTrackProducerAlgorithm")
+                << "Rejecting trajectory with " << curiterationhits.first.size() << " hits" << std::endl;
             CurrentTraj = Trajectory();
             break;
           }
 
-	  CurrentTraj = fit(curiterationhits, theFitter, CurrentTraj);
+          CurrentTraj = fit(curiterationhits, theFitter, CurrentTraj);
 
- 	  //saving trajectory for each annealing cycle ...
-	  if(TrajAnnSaving_){
+          //saving trajectory for each annealing cycle ...
+          if (TrajAnnSaving_) {
             TrajAnnealing temp(CurrentTraj, *ian);
-	    trajann.push_back(temp);
+            trajann.push_back(temp);
           }
 
-          LogDebug("DAFTrackProducerAlgorithm") << "done annealing value "  <<  (*ian) ;
+          LogDebug("DAFTrackProducerAlgorithm") << "done annealing value " << (*ian);
 
-	} 
-        else break;
-      } //end annealing cycle
+        } else
+          break;
+      }  //end annealing cycle
 
-      int percOfHitsUnchangedAfterDAF = (1.*checkHits(*BeforeDAFTraj, CurrentTraj)/(1.*BeforeDAFTrajMeas.size()))*100.; 
-      LogDebug("DAFTrackProducerAlgorithm") << "Ended annealing program with " << percOfHitsUnchangedAfterDAF << " unchanged." << std::endl;
- 
+      int percOfHitsUnchangedAfterDAF =
+          (1. * checkHits(*BeforeDAFTraj, CurrentTraj) / (1. * BeforeDAFTrajMeas.size())) * 100.;
+      LogDebug("DAFTrackProducerAlgorithm")
+          << "Ended annealing program with " << percOfHitsUnchangedAfterDAF << " unchanged." << std::endl;
+
       //computing the ndof keeping into account the weights
       ndof = calculateNdof(CurrentTraj);
- 
+
       //checking if the trajectory has the minimum number of valid hits ( weight (>1e-6) )
       //in order to remove tracks with too many outliers.
       int goodHits = countingGoodHits(CurrentTraj);
 
-      if( goodHits >= minHits_) {
+      if (goodHits >= minHits_) {
         bool ok = buildTrack(CurrentTraj, algoResults, ndof, bs, &BeforeDAFTrack);
         // or filtered?
-        if(ok) cont++;
- 
-        //saving tracks before and after DAF 
-        if( (100. - percOfHitsUnchangedAfterDAF) > 0.){
+        if (ok)
+          cont++;
+
+        //saving tracks before and after DAF
+        if ((100. - percOfHitsUnchangedAfterDAF) > 0.) {
           bool okBefore = buildTrack(*BeforeDAFTraj, algoResultsBeforeDAF, ndof, bs, &BeforeDAFTrack);
-          bool okAfter  = buildTrack(CurrentTraj, algoResultsAfterDAF, ndof, bs, &BeforeDAFTrack);
-          if( okBefore && okAfter ) nTracksChanged++;
+          bool okAfter = buildTrack(CurrentTraj, algoResultsAfterDAF, ndof, bs, &BeforeDAFTrack);
+          if (okBefore && okAfter)
+            nTracksChanged++;
         }
       } else {
-        LogDebug("DAFTrackProducerAlgorithm") << "Rejecting trajectory with " << CurrentTraj.foundHits()<<" hits"; 
+        LogDebug("DAFTrackProducerAlgorithm") << "Rejecting trajectory with " << CurrentTraj.foundHits() << " hits";
       }
-    } //end run on track collection
+    }  //end run on track collection
     else {
       LogDebug("DAFTrackProducerAlgorithm") << "Rejecting empty trajectory" << std::endl;
     }
-  } //end run on track collection
+  }  //end run on track collection
 
   LogDebug("DAFTrackProducerAlgorithm") << "Number of Tracks found:   " << cont << "\n";
   LogDebug("DAFTrackProducerAlgorithm") << "Number of Tracks changed: " << nTracksChanged << "\n";
-
 }
 /*------------------------------------------------------------------------------------------------------*/
-std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface>
-DAFTrackProducerAlgorithm::collectHits(const Trajectory vtraj,
-                                       const MultiRecHitCollector* measurementCollector,
-                                       const MeasurementTrackerEvent *measTk) const
-{
-
+std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> DAFTrackProducerAlgorithm::collectHits(
+    const Trajectory vtraj,
+    const MultiRecHitCollector* measurementCollector,
+    const MeasurementTrackerEvent* measTk) const {
   LogDebug("DAFTrackProducerAlgorithm") << "Calling DAFTrackProducerAlgorithm::collectHits";
 
-  //getting the traj measurements from the MeasurementCollector 
+  //getting the traj measurements from the MeasurementCollector
   int nHits = 0;
   TransientTrackingRecHit::RecHitContainer hits;
   std::vector<TrajectoryMeasurement> collectedmeas = measurementCollector->recHits(vtraj, measTk);
 
-  //if the MeasurementCollector is empty, make an "empty" pair 
+  //if the MeasurementCollector is empty, make an "empty" pair
   //else taking the collected measured hits and building the pair
-  if( collectedmeas.empty() ) 
+  if (collectedmeas.empty())
     return std::make_pair(TransientTrackingRecHit::RecHitContainer(), TrajectoryStateOnSurface());
 
-  for(  std::vector<TrajectoryMeasurement>::const_iterator iter = collectedmeas.begin(); 
-	iter!=collectedmeas.end(); iter++ ){
-
+  for (std::vector<TrajectoryMeasurement>::const_iterator iter = collectedmeas.begin(); iter != collectedmeas.end();
+       iter++) {
     nHits++;
     hits.push_back(iter->recHit());
-  
   }
-  
 
-  //TrajectoryStateWithArbitraryError() == Creates a TrajectoryState with the same parameters 
+  //TrajectoryStateWithArbitraryError() == Creates a TrajectoryState with the same parameters
   //     as the input one, but with "infinite" errors, i.e. errors so big that they don't
-  //     bias a fit starting with this state. 
+  //     bias a fit starting with this state.
   //return std::make_pair(hits,TrajectoryStateWithArbitraryError()(collectedmeas.front().predictedState()));
 
-  // I do not have to rescale the error because it is already rescaled in the fit code 
+  // I do not have to rescale the error because it is already rescaled in the fit code
   TrajectoryStateOnSurface initialStateFromTrack = collectedmeas.front().predictedState();
 
-  LogDebug("DAFTrackProducerAlgorithm") << "Pair (hits, TSOS)  with TSOS predicted(collectedmeas.front().predictedState())";
+  LogDebug("DAFTrackProducerAlgorithm")
+      << "Pair (hits, TSOS)  with TSOS predicted(collectedmeas.front().predictedState())";
   return std::make_pair(hits, initialStateFromTrack);
-
 }
 /*------------------------------------------------------------------------------------------------------*/
-std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface>
-DAFTrackProducerAlgorithm::updateHits(const Trajectory vtraj,
-				      const SiTrackerMultiRecHitUpdator* updator,
-				      const MeasurementTrackerEvent* theMTE,
-				      double annealing) const 
-{
+std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface> DAFTrackProducerAlgorithm::updateHits(
+    const Trajectory vtraj,
+    const SiTrackerMultiRecHitUpdator* updator,
+    const MeasurementTrackerEvent* theMTE,
+    double annealing) const {
   LogDebug("DAFTrackProducerAlgorithm") << "Calling DAFTrackProducerAlgorithm::updateHits";
   TransientTrackingRecHit::RecHitContainer hits;
   std::vector<TrajectoryMeasurement> vmeas = vtraj.measurements();
@@ -188,22 +181,23 @@ DAFTrackProducerAlgorithm::updateHits(const Trajectory vtraj,
   unsigned int hitcounter = 1;
 
   //I run inversely on the trajectory obtained and update the state
-  for (imeas = vmeas.rbegin(); imeas != vmeas.rend(); imeas++, hitcounter++){
-
+  for (imeas = vmeas.rbegin(); imeas != vmeas.rend(); imeas++, hitcounter++) {
     DetId id = imeas->recHit()->geographicalId();
     MeasurementDetWithData measDet = theMTE->idToDet(id);
 
     TrajectoryStateCombiner combiner;
     TrajectoryStateOnSurface combtsos;
-    if (hitcounter == vmeas.size()) combtsos = imeas->predictedState();   //fwd
-    else if (hitcounter == 1) combtsos = imeas->backwardPredictedState(); //bwd
-    else combtsos = combiner(imeas->backwardPredictedState(), imeas->predictedState());
+    if (hitcounter == vmeas.size())
+      combtsos = imeas->predictedState();  //fwd
+    else if (hitcounter == 1)
+      combtsos = imeas->backwardPredictedState();  //bwd
+    else
+      combtsos = combiner(imeas->backwardPredictedState(), imeas->predictedState());
 
     PrintHit(&*imeas->recHit(), combtsos);
-    if(imeas->recHit()->isValid()){
-    TransientTrackingRecHit::RecHitPointer updated = updator->update(imeas->recHit(), 
-						combtsos, measDet, annealing);
-    hits.push_back(updated);
+    if (imeas->recHit()->isValid()) {
+      TransientTrackingRecHit::RecHitPointer updated = updator->update(imeas->recHit(), combtsos, measDet, annealing);
+      hits.push_back(updated);
     } else {
       hits.push_back(imeas->recHit());
     }
@@ -214,283 +208,283 @@ DAFTrackProducerAlgorithm::updateHits(const Trajectory vtraj,
   //return std::make_pair(hits,TrajectoryStateWithArbitraryError()(vmeas.back().updatedState()));
   LogDebug("DAFTrackProducerAlgorithm") << "Pair (hits, TSOS)  with TSOS predicted (vmeas.back().predictedState())";
 
-  return std::make_pair(hits,updatedStateFromTrack);
+  return std::make_pair(hits, updatedStateFromTrack);
 }
 /*------------------------------------------------------------------------------------------------------*/
-Trajectory DAFTrackProducerAlgorithm::fit(const std::pair<TransientTrackingRecHit::RecHitContainer,
-        	                          TrajectoryStateOnSurface>& hits,
-                                          const TrajectoryFitter * theFitter,
-                                          Trajectory vtraj) const {
-
+Trajectory DAFTrackProducerAlgorithm::fit(
+    const std::pair<TransientTrackingRecHit::RecHitContainer, TrajectoryStateOnSurface>& hits,
+    const TrajectoryFitter* theFitter,
+    Trajectory vtraj) const {
   //creating a new trajectory starting from the direction of the seed of the input one and the hits
-  Trajectory newVec = theFitter->fitOne(TrajectorySeed(PTrajectoryStateOnDet(),
-                                                                 BasicTrajectorySeed::recHitContainer(),
-                                                                 vtraj.seed().direction()),
-                                                                 hits.first, hits.second);
+  Trajectory newVec = theFitter->fitOne(
+      TrajectorySeed(PTrajectoryStateOnDet(), BasicTrajectorySeed::recHitContainer(), vtraj.seed().direction()),
+      hits.first,
+      hits.second);
 
-  if( newVec.isValid() )  return newVec; 
-  else{
+  if (newVec.isValid())
+    return newVec;
+  else {
     LogDebug("DAFTrackProducerAlgorithm") << "Fit no valid.";
     return Trajectory();
   }
-
 }
 /*------------------------------------------------------------------------------------------------------*/
-bool DAFTrackProducerAlgorithm::buildTrack (const Trajectory vtraj,
-					    AlgoProductCollection& algoResults,
-					    float ndof,
-					    const reco::BeamSpot& bs,
-					    const reco::TrackRef* BeforeDAFTrack) const
-{
-  LogDebug("DAFTrackProducerAlgorithm") <<" BUILDER " << std::endl;;
+bool DAFTrackProducerAlgorithm::buildTrack(const Trajectory vtraj,
+                                           AlgoProductCollection& algoResults,
+                                           float ndof,
+                                           const reco::BeamSpot& bs,
+                                           const reco::TrackRef* BeforeDAFTrack) const {
+  LogDebug("DAFTrackProducerAlgorithm") << " BUILDER " << std::endl;
+  ;
   TrajectoryStateOnSurface innertsos;
-  
-  if ( vtraj.isValid() ){
 
-    std::unique_ptr<Trajectory> theTraj(new Trajectory( vtraj ));
-    
+  if (vtraj.isValid()) {
+    std::unique_ptr<Trajectory> theTraj(new Trajectory(vtraj));
+
     if (vtraj.direction() == alongMomentum) {
-    //if (theTraj->direction() == oppositeToMomentum) {
+      //if (theTraj->direction() == oppositeToMomentum) {
       innertsos = vtraj.firstMeasurement().updatedState();
-    } else { 
+    } else {
       innertsos = vtraj.lastMeasurement().updatedState();
     }
-    
-    TSCBLBuilderNoMaterial tscblBuilder;
-    TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(*(innertsos.freeState()),bs);
 
-    if (tscbl.isValid()==false) return false;
+    TSCBLBuilderNoMaterial tscblBuilder;
+    TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(*(innertsos.freeState()), bs);
+
+    if (tscbl.isValid() == false)
+      return false;
 
     GlobalPoint v = tscbl.trackStateAtPCA().position();
-    math::XYZPoint  pos( v.x(), v.y(), v.z() );
+    math::XYZPoint pos(v.x(), v.y(), v.z());
     GlobalVector p = tscbl.trackStateAtPCA().momentum();
-    math::XYZVector mom( p.x(), p.y(), p.z() );
+    math::XYZVector mom(p.x(), p.y(), p.z());
 
     //    LogDebug("TrackProducer") <<v<<p<<std::endl;
 
     auto algo = (*BeforeDAFTrack)->algo();
     std::unique_ptr<reco::Track> theTrack(new reco::Track(vtraj.chiSquared(),
-                                                          ndof, //in the DAF the ndof is not-integer
-                                                          pos, mom, tscbl.trackStateAtPCA().charge(),
-                                                          tscbl.trackStateAtPCA().curvilinearError(), algo));
+                                                          ndof,  //in the DAF the ndof is not-integer
+                                                          pos,
+                                                          mom,
+                                                          tscbl.trackStateAtPCA().charge(),
+                                                          tscbl.trackStateAtPCA().curvilinearError(),
+                                                          algo));
     theTrack->setQualityMask((*BeforeDAFTrack)->qualityMask());
 
-    AlgoProduct aProduct{theTraj.release(), theTrack.release(), vtraj.direction(),0};
+    AlgoProduct aProduct{theTraj.release(), theTrack.release(), vtraj.direction(), 0};
     algoResults.push_back(aProduct);
 
     return true;
-  } 
-  else {
-    LogDebug("DAFTrackProducerAlgorithm") <<" BUILDER NOT POSSIBLE: traj is not valid" << std::endl;;
+  } else {
+    LogDebug("DAFTrackProducerAlgorithm") << " BUILDER NOT POSSIBLE: traj is not valid" << std::endl;
+    ;
     return false;
   }
 }
 /*------------------------------------------------------------------------------------------------------*/
-int DAFTrackProducerAlgorithm::countingGoodHits(const Trajectory traj) const{
-
+int DAFTrackProducerAlgorithm::countingGoodHits(const Trajectory traj) const {
   int ngoodhits = 0;
   std::vector<TrajectoryMeasurement> vtm = traj.measurements();
 
-  for (std::vector<TrajectoryMeasurement>::const_iterator tm = vtm.begin(); tm != vtm.end(); tm++){
+  for (std::vector<TrajectoryMeasurement>::const_iterator tm = vtm.begin(); tm != vtm.end(); tm++) {
     //if the rechit is valid
     if (tm->recHit()->isValid()) {
-      SiTrackerMultiRecHit const & mHit = dynamic_cast<SiTrackerMultiRecHit const &>(*tm->recHit());
+      SiTrackerMultiRecHit const& mHit = dynamic_cast<SiTrackerMultiRecHit const&>(*tm->recHit());
       std::vector<const TrackingRecHit*> components = mHit.recHits();
 
       int iComp = 0;
 
-      for(std::vector<const TrackingRecHit*>::const_iterator iter = components.begin(); iter != components.end(); iter++, iComp++){ 
+      for (std::vector<const TrackingRecHit*>::const_iterator iter = components.begin(); iter != components.end();
+           iter++, iComp++) {
         //if there is at least one component with weight higher than 1e-6 then the hit is not an outlier
-        if (mHit.weight(iComp)>1e-6) {
-	  ngoodhits++; 
-	  iComp++; 
-	  break;
-	}
+        if (mHit.weight(iComp) > 1e-6) {
+          ngoodhits++;
+          iComp++;
+          break;
+        }
       }
-
-    }   
+    }
   }
-  
-  LogDebug("DAFTrackProducerAlgorithm") << "Original number of valid hits " << traj.foundHits() << " -> hit with good weight (>1e-6) are " << ngoodhits;
-  return ngoodhits;
 
+  LogDebug("DAFTrackProducerAlgorithm") << "Original number of valid hits " << traj.foundHits()
+                                        << " -> hit with good weight (>1e-6) are " << ngoodhits;
+  return ngoodhits;
 }
 /*------------------------------------------------------------------------------------------------------*/
 
-void  DAFTrackProducerAlgorithm::filter(const TrajectoryFitter* fitter, std::vector<Trajectory>& input, 
-					int minhits, std::vector<Trajectory>& output,
-					const TransientTrackingRecHitBuilder* builder) const 
-{
-  if (input.empty()) return;
+void DAFTrackProducerAlgorithm::filter(const TrajectoryFitter* fitter,
+                                       std::vector<Trajectory>& input,
+                                       int minhits,
+                                       std::vector<Trajectory>& output,
+                                       const TransientTrackingRecHitBuilder* builder) const {
+  if (input.empty())
+    return;
 
   int ngoodhits = 0;
-  std::vector<TrajectoryMeasurement> vtm = input[0].measurements();	
+  std::vector<TrajectoryMeasurement> vtm = input[0].measurements();
   TransientTrackingRecHit::RecHitContainer hits;
 
-  //count the number of non-outlier and non-invalid hits	
-  for (std::vector<TrajectoryMeasurement>::reverse_iterator tm=vtm.rbegin(); tm!=vtm.rend();tm++){
+  //count the number of non-outlier and non-invalid hits
+  for (std::vector<TrajectoryMeasurement>::reverse_iterator tm = vtm.rbegin(); tm != vtm.rend(); tm++) {
     //if the rechit is valid
     if (tm->recHit()->isValid()) {
-      SiTrackerMultiRecHit const & mHit = dynamic_cast<SiTrackerMultiRecHit const &>(*tm->recHit());
+      SiTrackerMultiRecHit const& mHit = dynamic_cast<SiTrackerMultiRecHit const&>(*tm->recHit());
       std::vector<const TrackingRecHit*> components = mHit.recHits();
       int iComp = 0;
       bool isGood = false;
-      for(std::vector<const TrackingRecHit*>::const_iterator iter = components.begin(); iter != components.end(); iter++, iComp++){        
-	//if there is at least one component with weight higher than 1e-6 then the hit is not an outlier
-        if (mHit.weight(iComp)>1e-6) {ngoodhits++; iComp++; isGood = true; break;}
+      for (std::vector<const TrackingRecHit*>::const_iterator iter = components.begin(); iter != components.end();
+           iter++, iComp++) {
+        //if there is at least one component with weight higher than 1e-6 then the hit is not an outlier
+        if (mHit.weight(iComp) > 1e-6) {
+          ngoodhits++;
+          iComp++;
+          isGood = true;
+          break;
+        }
       }
       if (isGood) {
-        TkClonerImpl hc = static_cast<TkTransientTrackingRecHitBuilder const *>(builder)->cloner();
-        auto tempHit = hc.makeShared(tm->recHit(),tm->updatedState());
+        TkClonerImpl hc = static_cast<TkTransientTrackingRecHitBuilder const*>(builder)->cloner();
+        auto tempHit = hc.makeShared(tm->recHit(), tm->updatedState());
         hits.push_back(tempHit);
-      }
-      else hits.push_back(std::make_shared<InvalidTrackingRecHit>(*tm->recHit()->det(), TrackingRecHit::missing));
+      } else
+        hits.push_back(std::make_shared<InvalidTrackingRecHit>(*tm->recHit()->det(), TrackingRecHit::missing));
     } else {
-      TkClonerImpl hc = static_cast<TkTransientTrackingRecHitBuilder const *>(builder)->cloner();
-      auto tempHit = hc.makeShared(tm->recHit(),tm->updatedState());
+      TkClonerImpl hc = static_cast<TkTransientTrackingRecHitBuilder const*>(builder)->cloner();
+      auto tempHit = hc.makeShared(tm->recHit(), tm->updatedState());
       hits.push_back(tempHit);
     }
   }
 
+  LogDebug("DAFTrackProducerAlgorithm") << "Original number of valid hits " << input[0].foundHits()
+                                        << "; after filtering " << ngoodhits;
+  if (ngoodhits > input[0].foundHits())
+    edm::LogError("DAFTrackProducerAlgorithm")
+        << "Something wrong: the number of good hits from DAFTrackProducerAlgorithm::filter " << ngoodhits
+        << " is higher than the original one " << input[0].foundHits();
 
-  LogDebug("DAFTrackProducerAlgorithm") << "Original number of valid hits " << input[0].foundHits() << "; after filtering " << ngoodhits;
-  if (ngoodhits>input[0].foundHits()) 
-    edm::LogError("DAFTrackProducerAlgorithm") << "Something wrong: the number of good hits from DAFTrackProducerAlgorithm::filter " 
-					  << ngoodhits << " is higher than the original one " << input[0].foundHits();
-
-  if (ngoodhits < minhits) return;	
+  if (ngoodhits < minhits)
+    return;
 
   TrajectoryStateOnSurface curstartingTSOS = input.front().lastMeasurement().updatedState();
-  LogDebug("DAFTrackProducerAlgorithm") << "starting tsos for final refitting " << curstartingTSOS ;
+  LogDebug("DAFTrackProducerAlgorithm") << "starting tsos for final refitting " << curstartingTSOS;
   //curstartingTSOS.rescaleError(100);
 
-  output = fitter->fit(TrajectorySeed(PTrajectoryStateOnDet(),
-                                      BasicTrajectorySeed::recHitContainer(),
-                                      input.front().seed().direction()),
-  	                              hits,
-        	                      TrajectoryStateWithArbitraryError()(curstartingTSOS));
+  output = fitter->fit(
+      TrajectorySeed(PTrajectoryStateOnDet(), BasicTrajectorySeed::recHitContainer(), input.front().seed().direction()),
+      hits,
+      TrajectoryStateWithArbitraryError()(curstartingTSOS));
 
   LogDebug("DAFTrackProducerAlgorithm") << "After filtering " << output.size() << " trajectories";
-
 }
 /*------------------------------------------------------------------------------------------------------*/
-float DAFTrackProducerAlgorithm::calculateNdof(const Trajectory vtraj) const 
-{
-
-  if (!vtraj.isValid()) return 0;
+float DAFTrackProducerAlgorithm::calculateNdof(const Trajectory vtraj) const {
+  if (!vtraj.isValid())
+    return 0;
   float ndof = 0;
   const std::vector<TrajectoryMeasurement>& meas = vtraj.measurements();
-  for (std::vector<TrajectoryMeasurement>::const_iterator iter = meas.begin(); iter != meas.end(); iter++){
-
-    if (iter->recHit()->isValid()){
-      SiTrackerMultiRecHit const & mHit = dynamic_cast<SiTrackerMultiRecHit const &>(*iter->recHit());
+  for (std::vector<TrajectoryMeasurement>::const_iterator iter = meas.begin(); iter != meas.end(); iter++) {
+    if (iter->recHit()->isValid()) {
+      SiTrackerMultiRecHit const& mHit = dynamic_cast<SiTrackerMultiRecHit const&>(*iter->recHit());
       std::vector<const TrackingRecHit*> components = mHit.recHits();
       int iComp = 0;
-      for(std::vector<const TrackingRecHit*>::const_iterator iter2 = components.begin(); iter2 != components.end(); iter2++, iComp++){
+      for (std::vector<const TrackingRecHit*>::const_iterator iter2 = components.begin(); iter2 != components.end();
+           iter2++, iComp++) {
         if ((*iter2)->isValid())
-	  ndof += ((*iter2)->dimension())*mHit.weight(iComp);
+          ndof += ((*iter2)->dimension()) * mHit.weight(iComp);
       }
-
     }
   }
 
-  return ndof-5;
-
+  return ndof - 5;
 }
 //------------------------------------------------------------------------------------------------
-int DAFTrackProducerAlgorithm::checkHits( Trajectory iInitTraj, const Trajectory iFinalTraj) const {
-
+int DAFTrackProducerAlgorithm::checkHits(Trajectory iInitTraj, const Trajectory iFinalTraj) const {
   std::vector<TrajectoryMeasurement> initmeasurements = iInitTraj.measurements();
   std::vector<TrajectoryMeasurement> finalmeasurements = iFinalTraj.measurements();
   std::vector<TrajectoryMeasurement>::iterator jmeas;
   int nSame = 0;
   int ihit = 0;
 
-  if( initmeasurements.empty() || finalmeasurements.empty() ){
+  if (initmeasurements.empty() || finalmeasurements.empty()) {
     LogDebug("DAFTrackProducerAlgorithm") << "Initial or Final Trajectory empty.";
     return 0;
   }
 
-  if( initmeasurements.size() != finalmeasurements.size() ) {
-    LogDebug("DAFTrackProducerAlgorithm") << "Initial Trajectory size(" << initmeasurements.size() << " hits) "
-					  << "is different to final traj size (" << finalmeasurements.size() << ")! No checkHits possible! ";
+  if (initmeasurements.size() != finalmeasurements.size()) {
+    LogDebug("DAFTrackProducerAlgorithm")
+        << "Initial Trajectory size(" << initmeasurements.size() << " hits) "
+        << "is different to final traj size (" << finalmeasurements.size() << ")! No checkHits possible! ";
     return 0;
   }
-          
-  for(jmeas = initmeasurements.begin(); jmeas != initmeasurements.end(); jmeas++){
 
+  for (jmeas = initmeasurements.begin(); jmeas != initmeasurements.end(); jmeas++) {
     const TrackingRecHit* initHit = jmeas->recHit()->hit();
-    if(!initHit->isValid() && ihit == 0 ) continue;
+    if (!initHit->isValid() && ihit == 0)
+      continue;
 
-    if(initHit->isValid()){
-
+    if (initHit->isValid()) {
       TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
-      const TrackingRecHit* MaxWeightHit=nullptr;
+      const TrackingRecHit* MaxWeightHit = nullptr;
       float maxweight = 0;
-  
+
       const SiTrackerMultiRecHit* mrh = dynamic_cast<const SiTrackerMultiRecHit*>(finalHit);
-      if (mrh){
+      if (mrh) {
         std::vector<const TrackingRecHit*> components = mrh->recHits();
         std::vector<const TrackingRecHit*>::const_iterator icomp;
-        int hitcounter=0;
+        int hitcounter = 0;
 
         for (icomp = components.begin(); icomp != components.end(); icomp++) {
-          if((*icomp)->isValid()) {
+          if ((*icomp)->isValid()) {
             double weight = mrh->weight(hitcounter);
-            if(weight > maxweight) {
+            if (weight > maxweight) {
               MaxWeightHit = *icomp;
               maxweight = weight;
             }
           }
           hitcounter++;
         }
-        if(!MaxWeightHit) continue;
+        if (!MaxWeightHit)
+          continue;
 
-        auto myref1 = reinterpret_cast<const BaseTrackerRecHit *>(initHit)->firstClusterRef();
-        auto myref2 = reinterpret_cast<const BaseTrackerRecHit *>(MaxWeightHit)->firstClusterRef();
+        auto myref1 = reinterpret_cast<const BaseTrackerRecHit*>(initHit)->firstClusterRef();
+        auto myref2 = reinterpret_cast<const BaseTrackerRecHit*>(MaxWeightHit)->firstClusterRef();
 
-        if( myref1 == myref2 ){
-          nSame++; 	
+        if (myref1 == myref2) {
+          nSame++;
         } else {
-	  LogDebug("DAFTrackProducerAlgorithm") << "diverso hit!" << std::endl;
-	  TrajectoryStateOnSurface dummState;
-	  LogTrace("DAFTrackProducerAlgorithm") << "  This hit was:\n ";
-	  PrintHit(initHit, dummState);
-	  LogTrace("DAFTrackProducerAlgorithm") << "  instead now is:\n ";
-	  PrintHit(MaxWeightHit, dummState);
-	}
+          LogDebug("DAFTrackProducerAlgorithm") << "diverso hit!" << std::endl;
+          TrajectoryStateOnSurface dummState;
+          LogTrace("DAFTrackProducerAlgorithm") << "  This hit was:\n ";
+          PrintHit(initHit, dummState);
+          LogTrace("DAFTrackProducerAlgorithm") << "  instead now is:\n ";
+          PrintHit(MaxWeightHit, dummState);
+        }
       }
     } else {
-
       TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
-      if(!finalHit->isValid()){
+      if (!finalHit->isValid()) {
         nSame++;
       }
     }
-  
-      ihit++;
+
+    ihit++;
   }
 
   return nSame;
 }
 
-
-
-void DAFTrackProducerAlgorithm::PrintHit(const TrackingRecHit* const& hit, TrajectoryStateOnSurface& tsos) const
-{
-  if (hit->isValid()){
-
-    LogTrace("DAFTrackProducerAlgorithm") << "  Valid Hit with DetId " << hit->geographicalId().rawId() << " and dim:" << hit->dimension()
-                        << " local position " << hit->localPosition()
-                        << " global position " << hit->globalPosition()
-                        << " and r " << hit->globalPosition().perp() ;
-    if(tsos.isValid())  LogTrace("DAFTrackProducerAlgorithm") << "  TSOS combtsos " << tsos.localPosition() ;
+void DAFTrackProducerAlgorithm::PrintHit(const TrackingRecHit* const& hit, TrajectoryStateOnSurface& tsos) const {
+  if (hit->isValid()) {
+    LogTrace("DAFTrackProducerAlgorithm")
+        << "  Valid Hit with DetId " << hit->geographicalId().rawId() << " and dim:" << hit->dimension()
+        << " local position " << hit->localPosition() << " global position " << hit->globalPosition() << " and r "
+        << hit->globalPosition().perp();
+    if (tsos.isValid())
+      LogTrace("DAFTrackProducerAlgorithm") << "  TSOS combtsos " << tsos.localPosition();
 
   } else {
     LogTrace("DAFTrackProducerAlgorithm") << "  Invalid Hit with DetId " << hit->geographicalId().rawId();
   }
-
 }
-

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -27,20 +27,18 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
-void 
-GsfTrackProducerBase::putInEvt(edm::Event& evt,
-			       const Propagator* prop,
-			       const MeasurementTracker* measTk,
-			       std::unique_ptr<TrackingRecHitCollection>& selHits,
-			       std::unique_ptr<reco::GsfTrackCollection>& selTracks,
-			       std::unique_ptr<reco::TrackExtraCollection>& selTrackExtras,
-			       std::unique_ptr<reco::GsfTrackExtraCollection>& selGsfTrackExtras,
-			       std::unique_ptr<std::vector<Trajectory> >&   selTrajectories,
-			       AlgoProductCollection& algoResults,
-			       TransientTrackingRecHitBuilder const * hitBuilder,
-			       const reco::BeamSpot& bs, const TrackerTopology *ttopo)
-{
-
+void GsfTrackProducerBase::putInEvt(edm::Event& evt,
+                                    const Propagator* prop,
+                                    const MeasurementTracker* measTk,
+                                    std::unique_ptr<TrackingRecHitCollection>& selHits,
+                                    std::unique_ptr<reco::GsfTrackCollection>& selTracks,
+                                    std::unique_ptr<reco::TrackExtraCollection>& selTrackExtras,
+                                    std::unique_ptr<reco::GsfTrackExtraCollection>& selGsfTrackExtras,
+                                    std::unique_ptr<std::vector<Trajectory> >& selTrajectories,
+                                    AlgoProductCollection& algoResults,
+                                    TransientTrackingRecHitBuilder const* hitBuilder,
+                                    const reco::BeamSpot& bs,
+                                    const TrackerTopology* ttopo) {
   TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
   reco::TrackExtraRefProd rTrackExtras = evt.getRefBeforePut<reco::TrackExtraCollection>();
   reco::GsfTrackExtraRefProd rGsfTrackExtras = evt.getRefBeforePut<reco::GsfTrackExtraCollection>();
@@ -49,35 +47,36 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
   edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
   edm::Ref<reco::GsfTrackExtraCollection>::key_type idxGsf = 0;
   edm::Ref<reco::GsfTrackCollection>::key_type iTkRef = 0;
-  edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;
+  edm::Ref<std::vector<Trajectory> >::key_type iTjRef = 0;
   std::map<unsigned int, unsigned int> tjTkMap;
 
   TSCBLBuilderNoMaterial tscblBuilder;
-  
-  for(auto & i : algoResults){
-    Trajectory * theTraj = i.trajectory;
-    if(trajectoryInEvent_) {
+
+  for (auto& i : algoResults) {
+    Trajectory* theTraj = i.trajectory;
+    if (trajectoryInEvent_) {
       selTrajectories->push_back(*theTraj);
       iTjRef++;
     }
 
-    reco::GsfTrack * theTrack = i.track;
-    PropagationDirection seedDir = i.pDir;  
-    
+    reco::GsfTrack* theTrack = i.track;
+    PropagationDirection seedDir = i.pDir;
+
     LogDebug("TrackProducer") << "In GsfTrackProducerBase::putInEvt - seedDir=" << seedDir;
 
-    reco::GsfTrack t = * theTrack;
-    selTracks->push_back( t );
+    reco::GsfTrack t = *theTrack;
+    selTracks->push_back(t);
     iTkRef++;
 
     // Store indices in local map (starts at 0)
-    if(trajectoryInEvent_) tjTkMap[iTjRef-1] = iTkRef-1;
+    if (trajectoryInEvent_)
+      tjTkMap[iTjRef - 1] = iTkRef - 1;
 
     //sets the outermost and innermost TSOSs
     TrajectoryStateOnSurface outertsos;
     TrajectoryStateOnSurface innertsos;
     unsigned int innerId, outerId;
-    
+
     // ---  NOTA BENE: the convention is to sort hits and measurements "along the momentum".
     // This is consistent with innermost and outermost labels only for tracks from LHC collision
     if (theTraj->direction() == alongMomentum) {
@@ -85,7 +84,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
       innertsos = theTraj->firstMeasurement().updatedState();
       outerId = theTraj->lastMeasurement().recHit()->geographicalId().rawId();
       innerId = theTraj->firstMeasurement().recHit()->geographicalId().rawId();
-    } else { 
+    } else {
       outertsos = theTraj->firstMeasurement().updatedState();
       innertsos = theTraj->lastMeasurement().updatedState();
       outerId = theTraj->firstMeasurement().recHit()->geographicalId().rawId();
@@ -94,34 +93,40 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
     //build the TrackExtra
     GlobalPoint v = outertsos.globalParameters().position();
     GlobalVector p = outertsos.globalParameters().momentum();
-    math::XYZVector outmom( p.x(), p.y(), p.z() );
-    math::XYZPoint  outpos( v.x(), v.y(), v.z() );
+    math::XYZVector outmom(p.x(), p.y(), p.z());
+    math::XYZPoint outpos(v.x(), v.y(), v.z());
     v = innertsos.globalParameters().position();
     p = innertsos.globalParameters().momentum();
-    math::XYZVector inmom( p.x(), p.y(), p.z() );
-    math::XYZPoint  inpos( v.x(), v.y(), v.z() );
+    math::XYZVector inmom(p.x(), p.y(), p.z());
+    math::XYZPoint inpos(v.x(), v.y(), v.z());
 
-    reco::TrackExtraRef teref= reco::TrackExtraRef ( rTrackExtras, idx ++ );
-    reco::GsfTrack & track = selTracks->back();
-    track.setExtra( teref );
-    
+    reco::TrackExtraRef teref = reco::TrackExtraRef(rTrackExtras, idx++);
+    reco::GsfTrack& track = selTracks->back();
+    track.setExtra(teref);
+
     //======= I want to set the second hitPattern here =============
-    if (theSchool.isValid())
-      {
-        edm::Handle<MeasurementTrackerEvent> mte;
-        evt.getByToken(mteSrc_, mte);
-	// NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,prop,&*mte, ttopo);
-      }
+    if (theSchool.isValid()) {
+      edm::Handle<MeasurementTrackerEvent> mte;
+      evt.getByToken(mteSrc_, mte);
+      // NavigationSetter setter( *theSchool );
+      setSecondHitPattern(theTraj, track, prop, &*mte, ttopo);
+    }
     //==============================================================
-    
-    selTrackExtras->push_back( reco::TrackExtra (outpos, outmom, true, inpos, inmom, true,
-						 outertsos.curvilinearError(), outerId,
-						 innertsos.curvilinearError(), innerId,
-						 seedDir, theTraj->seedRef()));
 
+    selTrackExtras->push_back(reco::TrackExtra(outpos,
+                                               outmom,
+                                               true,
+                                               inpos,
+                                               inmom,
+                                               true,
+                                               outertsos.curvilinearError(),
+                                               outerId,
+                                               innertsos.curvilinearError(),
+                                               innerId,
+                                               seedDir,
+                                               theTraj->seedRef()));
 
-    reco::TrackExtra & tx = selTrackExtras->back();
+    reco::TrackExtra& tx = selTrackExtras->back();
 
     // ---  NOTA BENE: the convention is to sort hits and measurements "along the momentum".
     // This is consistent with innermost and outermost labels only for tracks from LHC collisions
@@ -129,12 +134,12 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
     reco::TrackExtra::Chi2sFive chi2s;
     Traj2TrackHits t2t;
     auto ih = selHits->size();
-    t2t(*theTraj,*selHits,trajParams,chi2s);
+    t2t(*theTraj, *selHits, trajParams, chi2s);
     auto ie = selHits->size();
-    tx.setHits(rHits,ih,ie-ih);
-    tx.setTrajParams(std::move(trajParams),std::move(chi2s));
-    for (;ih<ie; ++ih) {
-      auto const & hit = (*selHits)[ih];
+    tx.setHits(rHits, ih, ie - ih);
+    tx.setTrajParams(std::move(trajParams), std::move(chi2s));
+    for (; ih < ie; ++ih) {
+      auto const& hit = (*selHits)[ih];
       track.appendHitPattern(hit, *ttopo);
     }
 
@@ -142,61 +147,57 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
 
     std::vector<reco::GsfTangent> tangents;
     const Trajectory::DataContainer& measurements = theTraj->measurements();
-    if ( measurements.size()>2 ) {
-      tangents.reserve(measurements.size()-2);
-      Trajectory::DataContainer::const_iterator ibegin,iend;
+    if (measurements.size() > 2) {
+      tangents.reserve(measurements.size() - 2);
+      Trajectory::DataContainer::const_iterator ibegin, iend;
       int increment(0);
       if (theTraj->direction() == alongMomentum) {
-	ibegin = measurements.begin() + 1;
-	iend = measurements.end() - 1;
-	increment = 1;
-      }
-      else {
-	ibegin = measurements.end() - 2;
-	iend = measurements.begin();
-	increment = -1;
+        ibegin = measurements.begin() + 1;
+        iend = measurements.end() - 1;
+        increment = 1;
+      } else {
+        ibegin = measurements.end() - 2;
+        iend = measurements.begin();
+        increment = -1;
       }
       math::XYZPoint position;
       math::XYZVector momentum;
       Measurement1D deltaP;
       // only measurements on "mono" detectors
-      for ( Trajectory::DataContainer::const_iterator i=ibegin;
-	    i!=iend; i+=increment ) {
-	if ( i->recHit().get() ) {
-	  DetId detId(i->recHit()->geographicalId());
-	  if ( detId.det()==DetId::Tracker ) {
-	    int subdetId = detId.subdetId();
-	    if ( subdetId==SiStripDetId::TIB || subdetId==SiStripDetId::TID || 
-		 subdetId==SiStripDetId::TOB || subdetId==SiStripDetId::TEC ) {
-	      if ( SiStripDetId(detId).stereo() )  continue;	    
-	    }
-	  }
-	}
-	bool valid = computeModeAtTM(*i,position,momentum,deltaP);
-	if ( valid ) {
-	  tangents.push_back(reco::GsfTangent(position,momentum,deltaP));
-	}
+      for (Trajectory::DataContainer::const_iterator i = ibegin; i != iend; i += increment) {
+        if (i->recHit().get()) {
+          DetId detId(i->recHit()->geographicalId());
+          if (detId.det() == DetId::Tracker) {
+            int subdetId = detId.subdetId();
+            if (subdetId == SiStripDetId::TIB || subdetId == SiStripDetId::TID || subdetId == SiStripDetId::TOB ||
+                subdetId == SiStripDetId::TEC) {
+              if (SiStripDetId(detId).stereo())
+                continue;
+            }
+          }
+        }
+        bool valid = computeModeAtTM(*i, position, momentum, deltaP);
+        if (valid) {
+          tangents.push_back(reco::GsfTangent(position, momentum, deltaP));
+        }
       }
     }
-    
 
     //build the GsfTrackExtra
     std::vector<reco::GsfComponent5D> outerStates;
-    fillStates(outertsos,outerStates);
+    fillStates(outertsos, outerStates);
     std::vector<reco::GsfComponent5D> innerStates;
-    fillStates(innertsos,innerStates);
-    
+    fillStates(innertsos, innerStates);
 
-    reco::GsfTrackExtraRef terefGsf = reco::GsfTrackExtraRef ( rGsfTrackExtras, idxGsf ++ );
-    track.setGsfExtra( terefGsf );
-    selGsfTrackExtras->push_back( reco::GsfTrackExtra (outerStates, outertsos.localParameters().pzSign(),
-						       innerStates, innertsos.localParameters().pzSign(),
-						       tangents));
+    reco::GsfTrackExtraRef terefGsf = reco::GsfTrackExtraRef(rGsfTrackExtras, idxGsf++);
+    track.setGsfExtra(terefGsf);
+    selGsfTrackExtras->push_back(reco::GsfTrackExtra(
+        outerStates, outertsos.localParameters().pzSign(), innerStates, innertsos.localParameters().pzSign(), tangents));
 
-    if ( innertsos.isValid() ) {
-      GsfPropagatorAdapter gsfProp(AnalyticalPropagator(innertsos.magneticField(),anyDirection));
+    if (innertsos.isValid()) {
+      GsfPropagatorAdapter gsfProp(AnalyticalPropagator(innertsos.magneticField(), anyDirection));
       TransverseImpactPointExtrapolator tipExtrapolator(gsfProp);
-      fillMode(track,innertsos,gsfProp,tipExtrapolator,tscblBuilder,bs);
+      fillMode(track, innertsos, gsfProp, tipExtrapolator, tscblBuilder, bs);
     }
 
     delete theTrack;
@@ -206,124 +207,115 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
   LogTrace("TrackingRegressionTest") << "========== TrackProducer Info ===================";
   LogTrace("TrackingRegressionTest") << "number of finalGsfTracks: " << selTracks->size();
   for (reco::GsfTrackCollection::const_iterator it = selTracks->begin(); it != selTracks->end(); it++) {
-    LogTrace("TrackingRegressionTest") << "track's n valid and invalid hit, chi2, pt : " 
-				       << it->found() << " , " 
-				       << it->lost()  <<" , " 
-				       << it->normalizedChi2() << " , "
-				       << it->pt() << " , "
-				       << it->eta() ;
+    LogTrace("TrackingRegressionTest") << "track's n valid and invalid hit, chi2, pt : " << it->found() << " , "
+                                       << it->lost() << " , " << it->normalizedChi2() << " , " << it->pt() << " , "
+                                       << it->eta();
   }
   LogTrace("TrackingRegressionTest") << "=================================================";
-  
 
-  rTracks_ = evt.put(std::move(selTracks) );
-  evt.put(std::move(selTrackExtras) );
-  evt.put(std::move(selGsfTrackExtras) );
-  evt.put(std::move(selHits) );
+  rTracks_ = evt.put(std::move(selTracks));
+  evt.put(std::move(selTrackExtras));
+  evt.put(std::move(selGsfTrackExtras));
+  evt.put(std::move(selHits));
 
-  if(trajectoryInEvent_) {
+  if (trajectoryInEvent_) {
     edm::OrphanHandle<std::vector<Trajectory> > rTrajs = evt.put(std::move(selTrajectories));
 
     // Now Create traj<->tracks association map
-    std::unique_ptr<TrajGsfTrackAssociationCollection> trajTrackMap( new TrajGsfTrackAssociationCollection(rTrajs, rTracks_) );
-    for ( std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); 
-	  i != tjTkMap.end(); i++ ) {
-      edm::Ref<std::vector<Trajectory> > trajRef( rTrajs, (*i).first );
-      edm::Ref<reco::GsfTrackCollection>    tkRef( rTracks_, (*i).second );
-      trajTrackMap->insert( edm::Ref<std::vector<Trajectory> >( rTrajs, (*i).first ),
-			    edm::Ref<reco::GsfTrackCollection>( rTracks_, (*i).second ) );
+    std::unique_ptr<TrajGsfTrackAssociationCollection> trajTrackMap(
+        new TrajGsfTrackAssociationCollection(rTrajs, rTracks_));
+    for (std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); i != tjTkMap.end(); i++) {
+      edm::Ref<std::vector<Trajectory> > trajRef(rTrajs, (*i).first);
+      edm::Ref<reco::GsfTrackCollection> tkRef(rTracks_, (*i).second);
+      trajTrackMap->insert(edm::Ref<std::vector<Trajectory> >(rTrajs, (*i).first),
+                           edm::Ref<reco::GsfTrackCollection>(rTracks_, (*i).second));
     }
-    evt.put( std::move(trajTrackMap) );
+    evt.put(std::move(trajTrackMap));
   }
 }
 
-void
-GsfTrackProducerBase::fillStates (TrajectoryStateOnSurface tsos,
-				  std::vector<reco::GsfComponent5D>& states) const
-{
+void GsfTrackProducerBase::fillStates(TrajectoryStateOnSurface tsos, std::vector<reco::GsfComponent5D>& states) const {
   reco::GsfComponent5D::ParameterVector pLocS;
   reco::GsfComponent5D::CovarianceMatrix cLocS;
   GetComponents comps(tsos);
-  auto const &  components = comps();
+  auto const& components = comps();
   states.reserve(components.size());
-  for (auto const & st : components)
-    states.emplace_back(st.weight(),st.localParameters().vector(),st.localError().matrix());
+  for (auto const& st : components)
+    states.emplace_back(st.weight(), st.localParameters().vector(), st.localError().matrix());
 }
 
-void
-GsfTrackProducerBase::fillMode (reco::GsfTrack& track, const TrajectoryStateOnSurface innertsos,
-				const Propagator& gsfProp,
-				const TransverseImpactPointExtrapolator& tipExtrapolator,
-				TrajectoryStateClosestToBeamLineBuilder& tscblBuilder,
-				const reco::BeamSpot& bs) const
-{
+void GsfTrackProducerBase::fillMode(reco::GsfTrack& track,
+                                    const TrajectoryStateOnSurface innertsos,
+                                    const Propagator& gsfProp,
+                                    const TransverseImpactPointExtrapolator& tipExtrapolator,
+                                    TrajectoryStateClosestToBeamLineBuilder& tscblBuilder,
+                                    const reco::BeamSpot& bs) const {
   // Get transverse impact parameter plane (from mean). This is a first approximation;
   // the mode is then extrapolated to the
   // final position closest to the beamline.
-  GlobalPoint bsPos(bs.position().x()+(track.vz()-bs.position().z())*bs.dxdz(),
-		    bs.position().y()+(track.vz()-bs.position().z())*bs.dydz(),
-		    track.vz());
-  TrajectoryStateOnSurface vtxTsos = tipExtrapolator.extrapolate(innertsos,bsPos);
-  if ( !vtxTsos.isValid() )  vtxTsos = innertsos;
+  GlobalPoint bsPos(bs.position().x() + (track.vz() - bs.position().z()) * bs.dxdz(),
+                    bs.position().y() + (track.vz() - bs.position().z()) * bs.dydz(),
+                    track.vz());
+  TrajectoryStateOnSurface vtxTsos = tipExtrapolator.extrapolate(innertsos, bsPos);
+  if (!vtxTsos.isValid())
+    vtxTsos = innertsos;
   // extrapolate mixture
-  vtxTsos = gsfProp.propagate(innertsos,vtxTsos.surface());
-  if ( !vtxTsos.isValid() )  return;              // failed (GsfTrack keeps mode = mean)
+  vtxTsos = gsfProp.propagate(innertsos, vtxTsos.surface());
+  if (!vtxTsos.isValid())
+    return;  // failed (GsfTrack keeps mode = mean)
   // extract mode
   // build perigee parameters (for covariance to be stored)
   AlgebraicVector5 modeParameters;
   AlgebraicSymMatrix55 modeCovariance;
   // set parameters and variances for "mode" state (local parameters)
-  for ( unsigned int iv=0; iv<5; ++iv ) {
-    MultiGaussianState1D state1D = MultiGaussianStateTransform::multiState1D(vtxTsos,iv);
+  for (unsigned int iv = 0; iv < 5; ++iv) {
+    MultiGaussianState1D state1D = MultiGaussianStateTransform::multiState1D(vtxTsos, iv);
     GaussianSumUtilities1D utils(state1D);
     modeParameters(iv) = utils.mode().mean();
-    modeCovariance(iv,iv) = utils.mode().variance();
-    if ( !utils.modeIsValid() ) {
+    modeCovariance(iv, iv) = utils.mode().variance();
+    if (!utils.modeIsValid()) {
       // if mode calculation fails: use mean
       modeParameters(iv) = utils.mean();
-      modeCovariance(iv,iv) = utils.variance();
+      modeCovariance(iv, iv) = utils.variance();
     }
   }
   // complete covariance matrix
   // approximation: use correlations from mean
   const AlgebraicSymMatrix55& meanCovariance(vtxTsos.localError().matrix());
-  for ( unsigned int iv1=0; iv1<5; ++iv1 ) {
-    for ( unsigned int iv2=0; iv2<iv1; ++iv2 ) {
-      double cov12 = meanCovariance(iv1,iv2) * 
-	sqrt(modeCovariance(iv1,iv1)/meanCovariance(iv1,iv1)*
-	     modeCovariance(iv2,iv2)/meanCovariance(iv2,iv2));
-      modeCovariance(iv1,iv2) = modeCovariance(iv2,iv1) = cov12;
+  for (unsigned int iv1 = 0; iv1 < 5; ++iv1) {
+    for (unsigned int iv2 = 0; iv2 < iv1; ++iv2) {
+      double cov12 = meanCovariance(iv1, iv2) * sqrt(modeCovariance(iv1, iv1) / meanCovariance(iv1, iv1) *
+                                                     modeCovariance(iv2, iv2) / meanCovariance(iv2, iv2));
+      modeCovariance(iv1, iv2) = modeCovariance(iv2, iv1) = cov12;
     }
   }
-  TrajectoryStateOnSurface modeTsos(LocalTrajectoryParameters(modeParameters,
-							      vtxTsos.localParameters().pzSign()),
-				    LocalTrajectoryError(modeCovariance),
-				    vtxTsos.surface(),
-				    vtxTsos.magneticField(),
-				    vtxTsos.surfaceSide());
-  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(*modeTsos.freeState(),bs);
-  if ( !tscbl.isValid() )  return;            // failed (GsfTrack keeps mode = mean)
+  TrajectoryStateOnSurface modeTsos(LocalTrajectoryParameters(modeParameters, vtxTsos.localParameters().pzSign()),
+                                    LocalTrajectoryError(modeCovariance),
+                                    vtxTsos.surface(),
+                                    vtxTsos.magneticField(),
+                                    vtxTsos.surfaceSide());
+  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(*modeTsos.freeState(), bs);
+  if (!tscbl.isValid())
+    return;  // failed (GsfTrack keeps mode = mean)
   //
   // extract state at PCA and create momentum vector and covariance matrix
   //
   const FreeTrajectoryState& fts = tscbl.trackStateAtPCA();
   GlobalVector tscblMom = fts.momentum();
-  reco::GsfTrack::Vector mom(tscblMom.x(),tscblMom.y(),tscblMom.z());
+  reco::GsfTrack::Vector mom(tscblMom.x(), tscblMom.y(), tscblMom.z());
   reco::GsfTrack::CovarianceMatrixMode cov;
   const AlgebraicSymMatrix55& tscblCov = fts.curvilinearError().matrix();
-  for ( unsigned int iv1=0; iv1<reco::GsfTrack::dimensionMode; ++iv1 ) {
-    for ( unsigned int iv2=0; iv2<reco::GsfTrack::dimensionMode; ++iv2 ) {
-      cov(iv1,iv2) = tscblCov(iv1,iv2);
+  for (unsigned int iv1 = 0; iv1 < reco::GsfTrack::dimensionMode; ++iv1) {
+    for (unsigned int iv2 = 0; iv2 < reco::GsfTrack::dimensionMode; ++iv2) {
+      cov(iv1, iv2) = tscblCov(iv1, iv2);
     }
-  } 
-  track.setMode(fts.charge(),mom,cov);
+  }
+  track.setMode(fts.charge(), mom, cov);
 }
 
-void
-GsfTrackProducerBase::localParametersFromQpMode (const TrajectoryStateOnSurface tsos,
-						 AlgebraicVector5& parameters,
-						 AlgebraicSymMatrix55& covariance) const
-{
+void GsfTrackProducerBase::localParametersFromQpMode(const TrajectoryStateOnSurface tsos,
+                                                     AlgebraicVector5& parameters,
+                                                     AlgebraicSymMatrix55& covariance) const {
   //
   // parameters and errors from combined state
   //
@@ -332,36 +324,35 @@ GsfTrackProducerBase::localParametersFromQpMode (const TrajectoryStateOnSurface 
   //
   // mode for parameter 0 (q/p)
   //
-  MultiGaussianState1D qpState(MultiGaussianStateTransform::multiState1D(tsos,0));
+  MultiGaussianState1D qpState(MultiGaussianStateTransform::multiState1D(tsos, 0));
   GaussianSumUtilities1D qpGS(qpState);
-  if ( !qpGS.modeIsValid() )  return;
+  if (!qpGS.modeIsValid())
+    return;
   double qp = qpGS.mode().mean();
   double varQp = qpGS.mode().variance();
   //
   // replace q/p value and variance, rescale correlation terms
   //   (heuristic procedure - alternative would be mode in 5D ...)
   //
-  double VarQpRatio = sqrt(varQp/covariance(0,0));
+  double VarQpRatio = sqrt(varQp / covariance(0, 0));
   parameters(0) = qp;
-  covariance(0,0) = varQp;
-  for ( int i=1; i<5; ++i )  covariance(i,0) *= VarQpRatio;
+  covariance(0, 0) = varQp;
+  for (int i = 1; i < 5; ++i)
+    covariance(i, 0) *= VarQpRatio;
 }
 
-bool
-GsfTrackProducerBase::computeModeAtTM (const TrajectoryMeasurement& tm,
-				       reco::GsfTrackExtra::Point& position,
-				       reco::GsfTrackExtra::Vector& momentum,
-				       Measurement1D& deltaP) const
-{  
+bool GsfTrackProducerBase::computeModeAtTM(const TrajectoryMeasurement& tm,
+                                           reco::GsfTrackExtra::Point& position,
+                                           reco::GsfTrackExtra::Vector& momentum,
+                                           Measurement1D& deltaP) const {
   //
   // states
   //
   TrajectoryStateOnSurface const& fwdState = tm.forwardPredictedState();
   TrajectoryStateOnSurface const& bwdState = tm.backwardPredictedState();
-  TrajectoryStateOnSurface const& upState  = tm.updatedState();
+  TrajectoryStateOnSurface const& upState = tm.updatedState();
 
-
-  if ( !fwdState.isValid() || !bwdState.isValid() || !upState.isValid() ) {
+  if (!fwdState.isValid() || !bwdState.isValid() || !upState.isValid()) {
     return false;
   }
   //
@@ -369,14 +360,14 @@ GsfTrackProducerBase::computeModeAtTM (const TrajectoryMeasurement& tm,
   //  following PF code
   //
   GlobalPoint pos = upState.globalPosition();
-  position = reco::GsfTrackExtra::Point(pos.x(),pos.y(),pos.z());
+  position = reco::GsfTrackExtra::Point(pos.x(), pos.y(), pos.z());
   GlobalVector mom;
-  bool result = multiTrajectoryStateMode::momentumFromModeCartesian(upState,mom);
-  if ( !result ) {
-//     std::cout << "momentumFromModeCartesian failed" << std::endl;
+  bool result = multiTrajectoryStateMode::momentumFromModeCartesian(upState, mom);
+  if (!result) {
+    //     std::cout << "momentumFromModeCartesian failed" << std::endl;
     return false;
   }
-  momentum = reco::GsfTrackExtra::Vector(mom.x(),mom.y(),mom.z());
+  momentum = reco::GsfTrackExtra::Vector(mom.x(), mom.y(), mom.z());
   //
   // calculation from deltaP from fit to forward & backward predictions
   //  (momentum from mode) and hit
@@ -384,17 +375,17 @@ GsfTrackProducerBase::computeModeAtTM (const TrajectoryMeasurement& tm,
   // prepare input parameter vectors and covariance matrices
   AlgebraicVector5 fwdPars = fwdState.localParameters().vector();
   AlgebraicSymMatrix55 fwdCov = fwdState.localError().matrix();
-  localParametersFromQpMode(fwdState,fwdPars,fwdCov);
+  localParametersFromQpMode(fwdState, fwdPars, fwdCov);
   AlgebraicVector5 bwdPars = bwdState.localParameters().vector();
   AlgebraicSymMatrix55 bwdCov = bwdState.localError().matrix();
-  localParametersFromQpMode(bwdState,bwdPars,bwdCov);
-  LocalPoint hitPos(0.,0.,0.);
-  LocalError hitErr(-1.,-1.,-1.);
-  if ( tm.recHit()->isValid() ) {
+  localParametersFromQpMode(bwdState, bwdPars, bwdCov);
+  LocalPoint hitPos(0., 0., 0.);
+  LocalError hitErr(-1., -1., -1.);
+  if (tm.recHit()->isValid()) {
     hitPos = tm.recHit()->localPosition();
     hitErr = tm.recHit()->localPositionError();
-  }    
-  CollinearFitAtTM2 collinearFit(fwdPars,fwdCov,bwdPars,bwdCov,hitPos,hitErr);
+  }
+  CollinearFitAtTM2 collinearFit(fwdPars, fwdCov, bwdPars, bwdCov, hitPos, hitErr);
   deltaP = collinearFit.deltaP();
 
   return true;

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -18,46 +18,43 @@
 
 #include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"
 
-
 void KfTrackProducerBase::putInEvt(edm::Event& evt,
-				   const Propagator* prop,
-				   const MeasurementTracker* measTk,
-				   std::unique_ptr<TrackingRecHitCollection>& selHits,
-				   std::unique_ptr<reco::TrackCollection>& selTracks,
-				   std::unique_ptr<reco::TrackExtraCollection>& selTrackExtras,
-				   std::unique_ptr<std::vector<Trajectory> >&   selTrajectories,
-				   std::unique_ptr<std::vector<int> >& indecesInput,
-				   AlgoProductCollection& algoResults,
-				   TransientTrackingRecHitBuilder const * hitBuilder,
-                                   const TrackerTopology *ttopo,
-                                   int BeforeOrAfter)
-{
-
+                                   const Propagator* prop,
+                                   const MeasurementTracker* measTk,
+                                   std::unique_ptr<TrackingRecHitCollection>& selHits,
+                                   std::unique_ptr<reco::TrackCollection>& selTracks,
+                                   std::unique_ptr<reco::TrackExtraCollection>& selTrackExtras,
+                                   std::unique_ptr<std::vector<Trajectory> >& selTrajectories,
+                                   std::unique_ptr<std::vector<int> >& indecesInput,
+                                   AlgoProductCollection& algoResults,
+                                   TransientTrackingRecHitBuilder const* hitBuilder,
+                                   const TrackerTopology* ttopo,
+                                   int BeforeOrAfter) {
   TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
   reco::TrackExtraRefProd rTrackExtras = evt.getRefBeforePut<reco::TrackExtraCollection>();
 
   edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
   edm::Ref<reco::TrackCollection>::key_type iTkRef = 0;
-  edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;
+  edm::Ref<std::vector<Trajectory> >::key_type iTjRef = 0;
   std::map<unsigned int, unsigned int> tjTkMap;
 
   selTracks->reserve(algoResults.size());
   selTrackExtras->reserve(algoResults.size());
-  if(trajectoryInEvent_) selTrajectories->reserve(algoResults.size());
+  if (trajectoryInEvent_)
+    selTrajectories->reserve(algoResults.size());
 
-  for(AlgoProductCollection::iterator i=algoResults.begin(); i!=algoResults.end();i++){
+  for (AlgoProductCollection::iterator i = algoResults.begin(); i != algoResults.end(); i++) {
     auto theTraj = (*i).trajectory;
     (*indecesInput).push_back((*i).indexInput);
-    if(trajectoryInEvent_) {
+    if (trajectoryInEvent_) {
       selTrajectories->push_back(*theTraj);
       iTjRef++;
     }
 
-
     auto theTrack = (*i).track;
-    
-    // Hits are going to be re-sorted along momentum few lines later. 
-    // Therefore the direction stored in the TrackExtra 
+
+    // Hits are going to be re-sorted along momentum few lines later.
+    // Therefore the direction stored in the TrackExtra
     // has to be "alongMomentum" as well. Anyway, this direction can be differnt from the one of the orignal
     // seed! The name seedDirection() for the Track's method (and the corresponding data member) is
     // misleading and should be changed into something like "hitsDirection()". TO BE FIXED!
@@ -66,19 +63,19 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
 
     LogDebug("TrackProducer") << "In KfTrackProducerBase::putInEvt - seedDir=" << seedDir;
 
-
     selTracks->push_back(std::move(*theTrack));
     delete theTrack;
     iTkRef++;
 
     // Store indices in local map (starts at 0)
-    if(trajectoryInEvent_) tjTkMap[iTjRef-1] = iTkRef-1;
-    
+    if (trajectoryInEvent_)
+      tjTkMap[iTjRef - 1] = iTkRef - 1;
+
     //sets the outermost and innermost TSOSs
     TrajectoryStateOnSurface outertsos;
     TrajectoryStateOnSurface innertsos;
     unsigned int innerId, outerId;
-    
+
     // ---  NOTA BENE: the convention is to sort hits and measurements "along the momentum".
     // This is consistent with innermost and outermost labels only for tracks from LHC collision
     if (theTraj->direction() == alongMomentum) {
@@ -86,7 +83,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
       innertsos = theTraj->firstMeasurement().updatedState();
       outerId = theTraj->lastMeasurement().recHit()->geographicalId().rawId();
       innerId = theTraj->firstMeasurement().recHit()->geographicalId().rawId();
-    } else { 
+    } else {
       outertsos = theTraj->firstMeasurement().updatedState();
       innertsos = theTraj->lastMeasurement().updatedState();
       outerId = theTraj->firstMeasurement().recHit()->geographicalId().rawId();
@@ -96,51 +93,58 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
     //build the TrackExtra
     GlobalPoint v = outertsos.globalParameters().position();
     GlobalVector p = outertsos.globalParameters().momentum();
-    math::XYZVector outmom( p.x(), p.y(), p.z() );
-    math::XYZPoint  outpos( v.x(), v.y(), v.z() );
+    math::XYZVector outmom(p.x(), p.y(), p.z());
+    math::XYZPoint outpos(v.x(), v.y(), v.z());
     v = innertsos.globalParameters().position();
     p = innertsos.globalParameters().momentum();
-    math::XYZVector inmom( p.x(), p.y(), p.z() );
-    math::XYZPoint  inpos( v.x(), v.y(), v.z() );
+    math::XYZVector inmom(p.x(), p.y(), p.z());
+    math::XYZPoint inpos(v.x(), v.y(), v.z());
 
-    reco::TrackExtraRef teref= reco::TrackExtraRef ( rTrackExtras, idx ++ );
-    reco::Track & track = selTracks->back();
-    track.setExtra( teref );
+    reco::TrackExtraRef teref = reco::TrackExtraRef(rTrackExtras, idx++);
+    reco::Track& track = selTracks->back();
+    track.setExtra(teref);
     //======= I want to set the second hitPattern here =============
-    if (theSchool.isValid())
-      {
-        edm::Handle<MeasurementTrackerEvent> mte;
-        evt.getByToken(mteSrc_, mte);
-	// NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,prop,&*mte, ttopo);
-      }
+    if (theSchool.isValid()) {
+      edm::Handle<MeasurementTrackerEvent> mte;
+      evt.getByToken(mteSrc_, mte);
+      // NavigationSetter setter( *theSchool );
+      setSecondHitPattern(theTraj, track, prop, &*mte, ttopo);
+    }
     //==============================================================
-    
-    selTrackExtras->push_back( reco::TrackExtra (outpos, outmom, true, inpos, inmom, true,
-						 outertsos.curvilinearError(), outerId,
-						 innertsos.curvilinearError(), innerId,
-    						 seedDir, theTraj->seedRef()));
 
-    // FIXME will remove this obsolete config-param in a future PR 
+    selTrackExtras->push_back(reco::TrackExtra(outpos,
+                                               outmom,
+                                               true,
+                                               inpos,
+                                               inmom,
+                                               true,
+                                               outertsos.curvilinearError(),
+                                               outerId,
+                                               innertsos.curvilinearError(),
+                                               innerId,
+                                               seedDir,
+                                               theTraj->seedRef()));
+
+    // FIXME will remove this obsolete config-param in a future PR
     assert(!useSplitting);
 
-    reco::TrackExtra & tx = selTrackExtras->back();
+    reco::TrackExtra& tx = selTrackExtras->back();
     // ---  NOTA BENE: the convention is to sort hits and measurements "along the momentum".
     // This is consistent with innermost and outermost labels only for tracks from LHC collisions
     reco::TrackExtra::TrajParams trajParams;
-    reco::TrackExtra::Chi2sFive chi2s; 
+    reco::TrackExtra::Chi2sFive chi2s;
     Traj2TrackHits t2t;
     auto ih = selHits->size();
-    t2t(*theTraj,*selHits,trajParams,chi2s);
+    t2t(*theTraj, *selHits, trajParams, chi2s);
     auto ie = selHits->size();
-    tx.setHits(rHits,ih,ie-ih);
-    tx.setTrajParams(std::move(trajParams),std::move(chi2s));
-    assert(tx.trajParams().size()==tx.recHitsSize());
-    for (;ih<ie; ++ih) {
-      auto const & hit = (*selHits)[ih];
+    tx.setHits(rHits, ih, ie - ih);
+    tx.setTrajParams(std::move(trajParams), std::move(chi2s));
+    assert(tx.trajParams().size() == tx.recHitsSize());
+    for (; ih < ie; ++ih) {
+      auto const& hit = (*selHits)[ih];
       track.appendHitPattern(hit, *ttopo);
     }
-    
+
     // ----
     tx.setResiduals(trajectoryToResiduals(*theTraj));
 
@@ -149,58 +153,52 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
 
   // Now we can re-set refs to hits, as they have already been cloned
   if (rekeyClusterRefs_) {
-      ClusterRemovalRefSetter refSetter(evt, clusterRemovalInfo_);
-      for (TrackingRecHitCollection::iterator it = selHits->begin(), ed = selHits->end(); it != ed; ++it) {
-          refSetter.reKey(&*it);
-      }
+    ClusterRemovalRefSetter refSetter(evt, clusterRemovalInfo_);
+    for (TrackingRecHitCollection::iterator it = selHits->begin(), ed = selHits->end(); it != ed; ++it) {
+      refSetter.reKey(&*it);
+    }
   }
 
   LogTrace("TrackingRegressionTest") << "========== TrackProducer Info ===================";
   LogTrace("TrackingRegressionTest") << "number of finalTracks: " << selTracks->size();
   for (reco::TrackCollection::const_iterator it = selTracks->begin(); it != selTracks->end(); it++) {
-    LogTrace("TrackingRegressionTest") << "track's n valid and invalid hit, chi2, pt, eta : " 
-				       << it->found() << " , " 
-				       << it->lost()  <<" , " 
-				       << it->normalizedChi2() << " , "
-				       << it->pt() << " , "
-				       << it->eta() ;
+    LogTrace("TrackingRegressionTest") << "track's n valid and invalid hit, chi2, pt, eta : " << it->found() << " , "
+                                       << it->lost() << " , " << it->normalizedChi2() << " , " << it->pt() << " , "
+                                       << it->eta();
   }
   LogTrace("TrackingRegressionTest") << "=================================================";
-  
+
   selTracks->shrink_to_fit();
   selTrackExtras->shrink_to_fit();
   selHits->shrink_to_fit();
   indecesInput->shrink_to_fit();
-  if(BeforeOrAfter == 1){
-    rTracks_ = evt.put(std::move(selTracks), "beforeDAF" );
+  if (BeforeOrAfter == 1) {
+    rTracks_ = evt.put(std::move(selTracks), "beforeDAF");
     evt.put(std::move(selTrackExtras), "beforeDAF");
     evt.put(std::move(indecesInput), "beforeDAF");
-  } else if (BeforeOrAfter == 2){
-    rTracks_ = evt.put(std::move(selTracks), "afterDAF" );
-    evt.put( std::move(selTrackExtras), "afterDAF" );
+  } else if (BeforeOrAfter == 2) {
+    rTracks_ = evt.put(std::move(selTracks), "afterDAF");
+    evt.put(std::move(selTrackExtras), "afterDAF");
     evt.put(std::move(indecesInput), "afterDAF");
   } else {
-    rTracks_ = evt.put(std::move(selTracks) );
-    evt.put(std::move(selTrackExtras) );
-    evt.put(std::move(selHits) );
+    rTracks_ = evt.put(std::move(selTracks));
+    evt.put(std::move(selTrackExtras));
+    evt.put(std::move(selHits));
     evt.put(std::move(indecesInput));
   }
 
-
-  if(trajectoryInEvent_ && BeforeOrAfter == 0) {
+  if (trajectoryInEvent_ && BeforeOrAfter == 0) {
     selTrajectories->shrink_to_fit();
     edm::OrphanHandle<std::vector<Trajectory> > rTrajs = evt.put(std::move(selTrajectories));
 
     // Now Create traj<->tracks association map
-    std::unique_ptr<TrajTrackAssociationCollection> trajTrackMap( new TrajTrackAssociationCollection(rTrajs, rTracks_) );
-    for ( std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); 
-          i != tjTkMap.end(); i++ ) {
-      edm::Ref<std::vector<Trajectory> > trajRef( rTrajs, (*i).first );
-      edm::Ref<reco::TrackCollection>    tkRef( rTracks_, (*i).second );
-      trajTrackMap->insert( edm::Ref<std::vector<Trajectory> >( rTrajs, (*i).first ),
-                            edm::Ref<reco::TrackCollection>( rTracks_, (*i).second ) );
+    std::unique_ptr<TrajTrackAssociationCollection> trajTrackMap(new TrajTrackAssociationCollection(rTrajs, rTracks_));
+    for (std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); i != tjTkMap.end(); i++) {
+      edm::Ref<std::vector<Trajectory> > trajRef(rTrajs, (*i).first);
+      edm::Ref<reco::TrackCollection> tkRef(rTracks_, (*i).second);
+      trajTrackMap->insert(edm::Ref<std::vector<Trajectory> >(rTrajs, (*i).first),
+                           edm::Ref<reco::TrackCollection>(rTracks_, (*i).second));
     }
-    evt.put( std::move(trajTrackMap) );
+    evt.put(std::move(trajTrackMap));
   }
 }
-

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -34,334 +34,367 @@
 #else
 #define DPRINT(x) LogTrace(x)
 #endif
-  
 
 namespace {
 #ifdef STAT_TSB
   struct StatCount {
-    long long totTrack=0;
-    long long totLoop=0;
-    long long totGsfTrack=0;
-    long long totFound=0;
-    long long totLost=0;
+    long long totTrack = 0;
+    long long totLoop = 0;
+    long long totGsfTrack = 0;
+    long long totFound = 0;
+    long long totLost = 0;
     long long totAlgo[15];
     void track(int l) {
-      if (l>0) ++totLoop; else ++totTrack;
+      if (l > 0)
+        ++totLoop;
+      else
+        ++totTrack;
     }
-    void hits(int f, int l) { totFound+=f; totLost+=l;} 
-    void gsf() {++totGsfTrack;}
-    void algo(int a) { if (a>=0 && a<15) ++totAlgo[a];}
-
+    void hits(int f, int l) {
+      totFound += f;
+      totLost += l;
+    }
+    void gsf() { ++totGsfTrack; }
+    void algo(int a) {
+      if (a >= 0 && a < 15)
+        ++totAlgo[a];
+    }
 
     void print() const {
-      std::cout << "TrackProducer stat\nTrack/Loop/Gsf/FoundHits/LostHits//algos "
-    		<<  totTrack <<'/'<< totLoop <<'/'<< totGsfTrack  <<'/'<< totFound  <<'/'<< totLost<<'/';
-      for (auto a : totAlgo) std::cout << '/'<< a;
-	std::cout  << std::endl;
+      std::cout << "TrackProducer stat\nTrack/Loop/Gsf/FoundHits/LostHits//algos " << totTrack << '/' << totLoop << '/'
+                << totGsfTrack << '/' << totFound << '/' << totLost << '/';
+      for (auto a : totAlgo)
+        std::cout << '/' << a;
+      std::cout << std::endl;
     }
     StatCount() {}
-    ~StatCount() { print();}
+    ~StatCount() { print(); }
   };
   StatCount statCount;
 
 #else
   struct StatCount {
-    void track(int){}
-    void hits(int, int){}
-    void gsf(){}
-    void algo(int){}
+    void track(int) {}
+    void hits(int, int) {}
+    void gsf() {}
+    void algo(int) {}
   };
   CMS_THREAD_SAFE StatCount statCount;
 #endif
 
+}  // namespace
 
-}
-
-
-
-
-template <> bool
-TrackProducerAlgorithm<reco::Track>::buildTrack (const TrajectoryFitter * theFitter,
-						 const Propagator * thePropagator,
-						 AlgoProductCollection& algoResults,
-						 TransientTrackingRecHit::RecHitContainer& hits,
-						 TrajectoryStateOnSurface& theTSOS,
-						 const TrajectorySeed& seed,
-						 float ndof,
-						 const reco::BeamSpot& bs,
-						 SeedRef seedRef,
-						 int qualityMask,signed char nLoops)
-{
+template <>
+bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter* theFitter,
+                                                     const Propagator* thePropagator,
+                                                     AlgoProductCollection& algoResults,
+                                                     TransientTrackingRecHit::RecHitContainer& hits,
+                                                     TrajectoryStateOnSurface& theTSOS,
+                                                     const TrajectorySeed& seed,
+                                                     float ndof,
+                                                     const reco::BeamSpot& bs,
+                                                     SeedRef seedRef,
+                                                     int qualityMask,
+                                                     signed char nLoops) {
   //variable declarations
 
   PropagationDirection seedDir = seed.direction();
-      
+
   //perform the fit: the result's size is 1 if it succeded, 0 if fails
-  Trajectory && trajTmp = theFitter->fitOne(seed, hits, theTSOS,(nLoops>0) ? TrajectoryFitter::looper : TrajectoryFitter::standard);
-  if UNLIKELY(!trajTmp.isValid()) {
-     DPRINT("TrackFitters") << "fit failed " << algo_ << ": " <<  hits.size() <<'|' << int(nLoops) << ' ' << std::endl; 
-     return false;
-  }
-  
-  
+  Trajectory&& trajTmp =
+      theFitter->fitOne(seed, hits, theTSOS, (nLoops > 0) ? TrajectoryFitter::looper : TrajectoryFitter::standard);
+  if
+    UNLIKELY(!trajTmp.isValid()) {
+      DPRINT("TrackFitters") << "fit failed " << algo_ << ": " << hits.size() << '|' << int(nLoops) << ' ' << std::endl;
+      return false;
+    }
+
   auto theTraj = new Trajectory(std::move(trajTmp));
   theTraj->setSeedRef(seedRef);
-  
-  statCount.hits(theTraj->foundHits(),theTraj->lostHits());
+
+  statCount.hits(theTraj->foundHits(), theTraj->lostHits());
   statCount.algo(int(algo_));
 
   // TrajectoryStateOnSurface innertsos;
   // if (theTraj->direction() == alongMomentum) {
   //  innertsos = theTraj->firstMeasurement().updatedState();
-  // } else { 
+  // } else {
   //  innertsos = theTraj->lastMeasurement().updatedState();
   // }
-  
+
   ndof = 0;
-  for (auto const & tm : theTraj->measurements()) {
-    auto const & h = tm.recHitR();
-    if (h.isValid()) ndof = ndof + float(h.dimension())*h.weight();  // two virtual calls!
+  for (auto const& tm : theTraj->measurements()) {
+    auto const& h = tm.recHitR();
+    if (h.isValid())
+      ndof = ndof + float(h.dimension()) * h.weight();  // two virtual calls!
   }
-  
+
   ndof -= 5.f;
-  if UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue())<DBL_MIN) ++ndof;  // same as -4
- 
+  if
+    UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue()) < DBL_MIN)++ ndof;  // same as -4
 
 #if defined(VI_DEBUG) || defined(EDM_ML_DEBUG)
-int chit[7]={};
-int kk=0;
-for (auto const & tm : theTraj->measurements()) {
-  ++kk;
-  auto const & hit = tm.recHitR();
-  if (!hit.isValid()) ++chit[0];
-  if (hit.det()==nullptr) ++chit[1];
-  if ( trackerHitRTTI::isUndef(hit) ) continue;
-  if(0) std::cout << "h " << kk << ": "<< hit.localPosition() << ' ' << hit.localPositionError() << ' ' << tm.estimate() << std::endl;
-  if ( hit.dimension()!=2 ) {
-    ++chit[2];
-  } else if ( trackerHitRTTI::isFromDet(hit) ) {
-    auto const & thit = static_cast<BaseTrackerRecHit const&>(hit);
-    auto const & clus = thit.firstClusterRef();
-    if (clus.isPixel()) ++chit[3];
-    else if (thit.isMatched()) {
-      ++chit[4];
-    } else  if (thit.isProjected()) {
-      ++chit[5];
-    } else {
-      ++chit[6];
-        }
+  int chit[7] = {};
+  int kk = 0;
+  for (auto const& tm : theTraj->measurements()) {
+    ++kk;
+    auto const& hit = tm.recHitR();
+    if (!hit.isValid())
+      ++chit[0];
+    if (hit.det() == nullptr)
+      ++chit[1];
+    if (trackerHitRTTI::isUndef(hit))
+      continue;
+    if (0)
+      std::cout << "h " << kk << ": " << hit.localPosition() << ' ' << hit.localPositionError() << ' ' << tm.estimate()
+                << std::endl;
+    if (hit.dimension() != 2) {
+      ++chit[2];
+    } else if (trackerHitRTTI::isFromDet(hit)) {
+      auto const& thit = static_cast<BaseTrackerRecHit const&>(hit);
+      auto const& clus = thit.firstClusterRef();
+      if (clus.isPixel())
+        ++chit[3];
+      else if (thit.isMatched()) {
+        ++chit[4];
+      } else if (thit.isProjected()) {
+        ++chit[5];
+      } else {
+        ++chit[6];
+      }
+    }
   }
- }
 
-   std::ostringstream ss;
-   ss << algo_ << ": " <<  hits.size() <<'|' <<theTraj->measurements().size()<<'|' << int(nLoops) << ' ';   for (auto c:chit) ss << c <<'/'; ss << std::endl;
-   DPRINT("TrackProducer") << ss.str();
+  std::ostringstream ss;
+  ss << algo_ << ": " << hits.size() << '|' << theTraj->measurements().size() << '|' << int(nLoops) << ' ';
+  for (auto c : chit)
+    ss << c << '/';
+  ss << std::endl;
+  DPRINT("TrackProducer") << ss.str();
 
 #endif
- 
+
   //if geometricInnerState_ is false the state for projection to beam line is the state attached to the first hit: to be used for loopers
   //if geometricInnerState_ is true the state for projection to beam line is the one from the (geometrically) closest measurement to the beam line: to be sued for non-collision tracks
   //the two shouuld give the same result for collision tracks that are NOT loopers
   TrajectoryStateOnSurface stateForProjectionToBeamLineOnSurface;
   if (geometricInnerState_) {
-    stateForProjectionToBeamLineOnSurface = theTraj->closestMeasurement(GlobalPoint(bs.x0(),bs.y0(),bs.z0())).updatedState();
+    stateForProjectionToBeamLineOnSurface =
+        theTraj->closestMeasurement(GlobalPoint(bs.x0(), bs.y0(), bs.z0())).updatedState();
   } else {
     if (theTraj->direction() == alongMomentum) {
       stateForProjectionToBeamLineOnSurface = theTraj->firstMeasurement().updatedState();
-    } else { 
+    } else {
       stateForProjectionToBeamLineOnSurface = theTraj->lastMeasurement().updatedState();
     }
   }
 
-  if UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()){
-    edm::LogError("CannotPropagateToBeamLine")<<"the state on the closest measurement isnot valid. skipping track.";
-    delete theTraj;
-    return false;
-  }
-  const FreeTrajectoryState & stateForProjectionToBeamLine=*stateForProjectionToBeamLineOnSurface.freeState();
-  
+  if
+    UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()) {
+      edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
+      delete theTraj;
+      return false;
+    }
+  const FreeTrajectoryState& stateForProjectionToBeamLine = *stateForProjectionToBeamLineOnSurface.freeState();
+
   LogDebug("TrackProducer") << "stateForProjectionToBeamLine=" << stateForProjectionToBeamLine;
-  
-//  TSCBLBuilderNoMaterial tscblBuilder;
-//  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
+
+  //  TSCBLBuilderNoMaterial tscblBuilder;
+  //  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
 
   TrajectoryStateClosestToBeamLine tscbl;
-  if (usePropagatorForPCA_){
+  if (usePropagatorForPCA_) {
     //std::cout << "PROPAGATOR FOR PCA" << std::endl;
     TSCBLBuilderWithPropagator tscblBuilder(*thePropagator);
-    tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
+    tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
   } else {
     TSCBLBuilderNoMaterial tscblBuilder;
-    tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
+    tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
   }
 
-  
-  if UNLIKELY(!tscbl.isValid()) {
-    delete theTraj;
-    return false;
-  }
-  
+  if
+    UNLIKELY(!tscbl.isValid()) {
+      delete theTraj;
+      return false;
+    }
+
   GlobalPoint v = tscbl.trackStateAtPCA().position();
-  math::XYZPoint  pos( v.x(), v.y(), v.z() );
+  math::XYZPoint pos(v.x(), v.y(), v.z());
   GlobalVector p = tscbl.trackStateAtPCA().momentum();
-  math::XYZVector mom( p.x(), p.y(), p.z() );
-  
+  math::XYZVector mom(p.x(), p.y(), p.z());
+
   LogDebug("TrackProducer") << "pos=" << v << " mom=" << p << " pt=" << p.perp() << " mag=" << p.mag();
-  
+
   auto theTrack = new reco::Track(theTraj->chiSquared(),
-			     int(ndof),//FIXME fix weight() in TrackingRecHit
-			     pos, mom, tscbl.trackStateAtPCA().charge(), 
-			     tscbl.trackStateAtPCA().curvilinearError(),
-			     algo_);
-  
-  if(originalAlgo_ != reco::TrackBase::undefAlgorithm) theTrack->setOriginalAlgorithm(originalAlgo_);
-  if(algoMask_.any())                                  theTrack->setAlgoMask(algoMask_);
+                                  int(ndof),  //FIXME fix weight() in TrackingRecHit
+                                  pos,
+                                  mom,
+                                  tscbl.trackStateAtPCA().charge(),
+                                  tscbl.trackStateAtPCA().curvilinearError(),
+                                  algo_);
+
+  if (originalAlgo_ != reco::TrackBase::undefAlgorithm)
+    theTrack->setOriginalAlgorithm(originalAlgo_);
+  if (algoMask_.any())
+    theTrack->setAlgoMask(algoMask_);
   theTrack->setQualityMask(qualityMask);
   theTrack->setNLoops(nLoops);
   theTrack->setStopReason(stopReason_);
 
   LogDebug("TrackProducer") << "theTrack->pt()=" << theTrack->pt();
-  
-  LogDebug("TrackProducer") <<"track done\n";
-  
-  AlgoProduct aProduct{theTraj,theTrack,seedDir,0};
+
+  LogDebug("TrackProducer") << "track done\n";
+
+  AlgoProduct aProduct{theTraj, theTrack, seedDir, 0};
   algoResults.push_back(aProduct);
-  
+
   statCount.track(nLoops);
 
   return true;
-} 
+}
 
-template <> bool
-TrackProducerAlgorithm<reco::GsfTrack>::buildTrack (const TrajectoryFitter * theFitter,
-						    const Propagator * thePropagator,
-						    AlgoProductCollection& algoResults,
-						    TransientTrackingRecHit::RecHitContainer& hits,
-						    TrajectoryStateOnSurface& theTSOS,
-						    const TrajectorySeed& seed,
-						    float ndof,
-						    const reco::BeamSpot& bs,
-						    SeedRef seedRef,
-						    int qualityMask,signed char nLoops)
-{
-
+template <>
+bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* theFitter,
+                                                        const Propagator* thePropagator,
+                                                        AlgoProductCollection& algoResults,
+                                                        TransientTrackingRecHit::RecHitContainer& hits,
+                                                        TrajectoryStateOnSurface& theTSOS,
+                                                        const TrajectorySeed& seed,
+                                                        float ndof,
+                                                        const reco::BeamSpot& bs,
+                                                        SeedRef seedRef,
+                                                        int qualityMask,
+                                                        signed char nLoops) {
   PropagationDirection seedDir = seed.direction();
-  
-  Trajectory && trajTmp = theFitter->fitOne(seed, hits, theTSOS,(nLoops>0) ? TrajectoryFitter::looper: TrajectoryFitter::standard);
-  if UNLIKELY(!trajTmp.isValid()) return false;
-  
-  
-  auto theTraj = new Trajectory( std::move(trajTmp) );
+
+  Trajectory&& trajTmp =
+      theFitter->fitOne(seed, hits, theTSOS, (nLoops > 0) ? TrajectoryFitter::looper : TrajectoryFitter::standard);
+  if
+    UNLIKELY(!trajTmp.isValid()) return false;
+
+  auto theTraj = new Trajectory(std::move(trajTmp));
   theTraj->setSeedRef(seedRef);
 
-#ifdef EDM_ML_DEBUG  
+#ifdef EDM_ML_DEBUG
   TrajectoryStateOnSurface innertsos;
   TrajectoryStateOnSurface outertsos;
 
   if (theTraj->direction() == alongMomentum) {
     innertsos = theTraj->firstMeasurement().updatedState();
     outertsos = theTraj->lastMeasurement().updatedState();
-  } else { 
+  } else {
     innertsos = theTraj->lastMeasurement().updatedState();
-     outertsos = theTraj->firstMeasurement().updatedState();
+    outertsos = theTraj->firstMeasurement().updatedState();
   }
   std::ostringstream ss;
-  auto dc = [&](TrajectoryStateOnSurface const & tsos){ 
-     std::vector<TrajectoryStateOnSurface> const & components = tsos.components();
-     auto sinTheta =  std::sin(tsos.globalMomentum().theta());
-     for (auto const & ic : components) ss << ic.weight() << "/"; ss << "\n";
-     for (auto const & ic : components) ss << ic.localParameters().vector()[0]/sinTheta << "/"; ss << "\n";
-     for (auto const & ic : components) ss << std::sqrt(ic.localError().matrix()(0,0))/sinTheta << "/"; 
+  auto dc = [&](TrajectoryStateOnSurface const& tsos) {
+    std::vector<TrajectoryStateOnSurface> const& components = tsos.components();
+    auto sinTheta = std::sin(tsos.globalMomentum().theta());
+    for (auto const& ic : components)
+      ss << ic.weight() << "/";
+    ss << "\n";
+    for (auto const& ic : components)
+      ss << ic.localParameters().vector()[0] / sinTheta << "/";
+    ss << "\n";
+    for (auto const& ic : components)
+      ss << std::sqrt(ic.localError().matrix()(0, 0)) / sinTheta << "/";
   };
-  ss  << "\ninner comps\n";
+  ss << "\ninner comps\n";
   dc(innertsos);
-  ss  << "\nouter comps\n";
+  ss << "\nouter comps\n";
   dc(outertsos);
-  LogDebug("TrackProducer")
- 	   << "Nr. of first / last states = "
-  	   << innertsos.components().size() << " "
-           << outertsos.components().size() << ss.str();
-#endif  
+  LogDebug("TrackProducer") << "Nr. of first / last states = " << innertsos.components().size() << " "
+                            << outertsos.components().size() << ss.str();
+#endif
 
   ndof = 0;
-  for (auto const & tm : theTraj->measurements()) {
-    auto const & h = tm.recHitR();
-    if (h.isValid()) ndof = ndof + h.dimension()*h.weight();
+  for (auto const& tm : theTraj->measurements()) {
+    auto const& h = tm.recHitR();
+    if (h.isValid())
+      ndof = ndof + h.dimension() * h.weight();
   }
-  
+
   ndof = ndof - 5;
-  if UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue())<DBL_MIN) ++ndof;  // same as -4
-  
-  
+  if
+    UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue()) < DBL_MIN)++ ndof;  // same as -4
+
   //if geometricInnerState_ is false the state for projection to beam line is the state attached to the first hit: to be used for loopers
   //if geometricInnerState_ is true the state for projection to beam line is the one from the (geometrically) closest measurement to the beam line: to be sued for non-collision tracks
   //the two shouuld give the same result for collision tracks that are NOT loopers
   TrajectoryStateOnSurface stateForProjectionToBeamLineOnSurface;
   if (geometricInnerState_) {
-    stateForProjectionToBeamLineOnSurface = theTraj->closestMeasurement(GlobalPoint(bs.x0(),bs.y0(),bs.z0())).updatedState();
+    stateForProjectionToBeamLineOnSurface =
+        theTraj->closestMeasurement(GlobalPoint(bs.x0(), bs.y0(), bs.z0())).updatedState();
   } else {
     if (theTraj->direction() == alongMomentum) {
       stateForProjectionToBeamLineOnSurface = theTraj->firstMeasurement().updatedState();
-    } else { 
+    } else {
       stateForProjectionToBeamLineOnSurface = theTraj->lastMeasurement().updatedState();
     }
   }
 
-  if UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()){
-      edm::LogError("CannotPropagateToBeamLine")<<"the state on the closest measurement isnot valid. skipping track.";
-      delete theTraj;
-      return false;
-    }    
-  
-  const FreeTrajectoryState & stateForProjectionToBeamLine=*stateForProjectionToBeamLineOnSurface.freeState();
-  
-  LogDebug("GsfTrackProducer") << "stateForProjectionToBeamLine=" << stateForProjectionToBeamLine;
-  
-//  TSCBLBuilderNoMaterial tscblBuilder;
-//  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
-
-  TrajectoryStateClosestToBeamLine tscbl;
-  if (usePropagatorForPCA_){
-    TSCBLBuilderWithPropagator tscblBuilder(*thePropagator);
-    tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);    
-  } else {
-    TSCBLBuilderNoMaterial tscblBuilder;
-    tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
-  }  
-
-  
-  if UNLIKELY(tscbl.isValid()==false) {
+  if
+    UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()) {
+      edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
       delete theTraj;
       return false;
     }
-  
+
+  const FreeTrajectoryState& stateForProjectionToBeamLine = *stateForProjectionToBeamLineOnSurface.freeState();
+
+  LogDebug("GsfTrackProducer") << "stateForProjectionToBeamLine=" << stateForProjectionToBeamLine;
+
+  //  TSCBLBuilderNoMaterial tscblBuilder;
+  //  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(stateForProjectionToBeamLine,bs);
+
+  TrajectoryStateClosestToBeamLine tscbl;
+  if (usePropagatorForPCA_) {
+    TSCBLBuilderWithPropagator tscblBuilder(*thePropagator);
+    tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
+  } else {
+    TSCBLBuilderNoMaterial tscblBuilder;
+    tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
+  }
+
+  if
+    UNLIKELY(tscbl.isValid() == false) {
+      delete theTraj;
+      return false;
+    }
+
   GlobalPoint v = tscbl.trackStateAtPCA().position();
-  math::XYZPoint  pos( v.x(), v.y(), v.z() );
+  math::XYZPoint pos(v.x(), v.y(), v.z());
   GlobalVector p = tscbl.trackStateAtPCA().momentum();
-  math::XYZVector mom( p.x(), p.y(), p.z() );
-  
+  math::XYZVector mom(p.x(), p.y(), p.z());
+
   LogDebug("GsfTrackProducer") << "pos=" << v << " mom=" << p << " pt=" << p.perp() << " mag=" << p.mag();
-  
-  auto theTrack = new reco::GsfTrack(theTraj->chiSquared(),
-				int(ndof),//FIXME fix weight() in TrackingRecHit
-				//			       theTraj->foundHits(),//FIXME to be fixed in Trajectory.h
-				//			       0, //FIXME no corresponding method in trajectory.h
-				//			       theTraj->lostHits(),//FIXME to be fixed in Trajectory.h
-				pos, mom, tscbl.trackStateAtPCA().charge(), tscbl.trackStateAtPCA().curvilinearError());    
+
+  auto theTrack =
+      new reco::GsfTrack(theTraj->chiSquared(),
+                         int(ndof),  //FIXME fix weight() in TrackingRecHit
+                         //			       theTraj->foundHits(),//FIXME to be fixed in Trajectory.h
+                         //			       0, //FIXME no corresponding method in trajectory.h
+                         //			       theTraj->lostHits(),//FIXME to be fixed in Trajectory.h
+                         pos,
+                         mom,
+                         tscbl.trackStateAtPCA().charge(),
+                         tscbl.trackStateAtPCA().curvilinearError());
   theTrack->setAlgorithm(algo_);
-  if(originalAlgo_ != reco::TrackBase::undefAlgorithm) theTrack->setOriginalAlgorithm(originalAlgo_);
-  if(algoMask_.any())                                  theTrack->setAlgoMask(algoMask_);
+  if (originalAlgo_ != reco::TrackBase::undefAlgorithm)
+    theTrack->setOriginalAlgorithm(originalAlgo_);
+  if (algoMask_.any())
+    theTrack->setAlgoMask(algoMask_);
 
   theTrack->setStopReason(stopReason_);
 
-  LogDebug("GsfTrackProducer") <<"track done\n";
-  
-  AlgoProduct aProduct{theTraj,theTrack,seedDir,0};
+  LogDebug("GsfTrackProducer") << "track done\n";
 
-  LogDebug("GsfTrackProducer") <<"track done1\n";
+  AlgoProduct aProduct{theTraj, theTrack, seedDir, 0};
+
+  LogDebug("GsfTrackProducer") << "track done1\n";
   algoResults.push_back(aProduct);
-  LogDebug("GsfTrackProducer") <<"track done2\n";
-  
+  LogDebug("GsfTrackProducer") << "track done2\n";
+
   statCount.gsf();
   return true;
-} 
+}

--- a/RecoTracker/TrackProducer/src/TrajectoryToResiduals.cc
+++ b/RecoTracker/TrackProducer/src/TrajectoryToResiduals.cc
@@ -4,57 +4,49 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-reco::TrackResiduals trajectoryToResiduals (const Trajectory &trajectory)
-{
-     reco::TrackResiduals residuals;
-     residuals.resize(trajectory.measurements().size());
-     int i_residual = 0;
-     Trajectory::DataContainer::const_iterator i_fwd = 
-	  trajectory.measurements().begin(); 
-     Trajectory::DataContainer::const_reverse_iterator i_bwd = 
-	  trajectory.measurements().rbegin(); 
-     Trajectory::DataContainer::const_iterator i_end = 
-	  trajectory.measurements().end(); 
-     Trajectory::DataContainer::const_reverse_iterator i_rend = 
-	  trajectory.measurements().rend(); 
-     bool forward = trajectory.direction() == alongMomentum;
-     for (; forward ? i_fwd != i_end : i_bwd != i_rend; 
-	  ++i_fwd, ++i_bwd, ++i_residual) {
-	  const TrajectoryMeasurement *i = forward ? &*i_fwd : &*i_bwd;
-	  if (!i->recHit()->isValid()||i->recHit()->det()==nullptr) 
-	       continue;
-	  TrajectoryStateCombiner combine;
-	  if (!i->forwardPredictedState().isValid() || !i->backwardPredictedState().isValid())
-	    {
-	      edm::LogError("InvalideState")<<"one of the step is invalid";
-	      continue;
-	    }
+reco::TrackResiduals trajectoryToResiduals(const Trajectory &trajectory) {
+  reco::TrackResiduals residuals;
+  residuals.resize(trajectory.measurements().size());
+  int i_residual = 0;
+  Trajectory::DataContainer::const_iterator i_fwd = trajectory.measurements().begin();
+  Trajectory::DataContainer::const_reverse_iterator i_bwd = trajectory.measurements().rbegin();
+  Trajectory::DataContainer::const_iterator i_end = trajectory.measurements().end();
+  Trajectory::DataContainer::const_reverse_iterator i_rend = trajectory.measurements().rend();
+  bool forward = trajectory.direction() == alongMomentum;
+  for (; forward ? i_fwd != i_end : i_bwd != i_rend; ++i_fwd, ++i_bwd, ++i_residual) {
+    const TrajectoryMeasurement *i = forward ? &*i_fwd : &*i_bwd;
+    if (!i->recHit()->isValid() || i->recHit()->det() == nullptr)
+      continue;
+    TrajectoryStateCombiner combine;
+    if (!i->forwardPredictedState().isValid() || !i->backwardPredictedState().isValid()) {
+      edm::LogError("InvalideState") << "one of the step is invalid";
+      continue;
+    }
 
-	  TrajectoryStateOnSurface && combo = combine(i->forwardPredictedState(),
-       						   i->backwardPredictedState());
-	  
-	  if (!combo.isValid()){
-	    edm::LogError("InvalideState")<<"the combined state is invalid";
-	    continue;
-	  }
+    TrajectoryStateOnSurface &&combo = combine(i->forwardPredictedState(), i->backwardPredictedState());
 
-	  LocalPoint && combo_localpos = combo.localPosition();
-	  LocalError && combo_localerr = combo.localError().positionError();
-	  LocalPoint && dethit_localpos = i->recHit()->localPosition();     
-	  LocalError && dethit_localerr = i->recHit()->localPositionError();
-	  auto const &  error_including_alignment = dethit_localerr; // align error nwo is included 
-          {
-	       auto x = (dethit_localpos.x() - combo_localpos.x());
-	       auto y = (dethit_localpos.y() - combo_localpos.y()); 
-	       residuals.setResidualXY(i_residual, x, y);
-          }
-          {
-	       auto x = (dethit_localpos.x() - combo_localpos.x()) / 
-		    std::sqrt(error_including_alignment.xx() + combo_localerr.xx());
-	       auto y = (dethit_localpos.y() - combo_localpos.y()) / 
-		    std::sqrt(error_including_alignment.yy() + combo_localerr.yy());
-	       residuals.setPullXY(i_residual, x, y);
-	  }
-     }
-     return residuals;
+    if (!combo.isValid()) {
+      edm::LogError("InvalideState") << "the combined state is invalid";
+      continue;
+    }
+
+    LocalPoint &&combo_localpos = combo.localPosition();
+    LocalError &&combo_localerr = combo.localError().positionError();
+    LocalPoint &&dethit_localpos = i->recHit()->localPosition();
+    LocalError &&dethit_localerr = i->recHit()->localPositionError();
+    auto const &error_including_alignment = dethit_localerr;  // align error nwo is included
+    {
+      auto x = (dethit_localpos.x() - combo_localpos.x());
+      auto y = (dethit_localpos.y() - combo_localpos.y());
+      residuals.setResidualXY(i_residual, x, y);
+    }
+    {
+      auto x =
+          (dethit_localpos.x() - combo_localpos.x()) / std::sqrt(error_including_alignment.xx() + combo_localerr.xx());
+      auto y =
+          (dethit_localpos.y() - combo_localpos.y()) / std::sqrt(error_including_alignment.yy() + combo_localerr.yy());
+      residuals.setPullXY(i_residual, x, y);
+    }
+  }
+  return residuals;
 }

--- a/RecoTracker/TrackProducer/src/TrajectoryToResiduals.h
+++ b/RecoTracker/TrackProducer/src/TrajectoryToResiduals.h
@@ -4,6 +4,6 @@
 #include "DataFormats/TrackReco/interface/TrackResiduals.h"
 
 class Trajectory;
-reco::TrackResiduals trajectoryToResiduals (const Trajectory &);
+reco::TrackResiduals trajectoryToResiduals(const Trajectory &);
 
 #endif

--- a/RecoTracker/TrackProducer/test/FakeCPEFiller.cc
+++ b/RecoTracker/TrackProducer/test/FakeCPEFiller.cc
@@ -4,7 +4,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -42,29 +41,26 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelFakeCPE.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripFakeCPE.h"
 
-
 //
 // class declaration
 //
 
 class FakeCPEFiller final : public edm::one::EDFilter<> {
-   public:
-      explicit FakeCPEFiller(const edm::ParameterSet&);
-      ~FakeCPEFiller() = default;
+public:
+  explicit FakeCPEFiller(const edm::ParameterSet&);
+  ~FakeCPEFiller() = default;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      bool filter(edm::Event&, const edm::EventSetup&) override;
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
 
-      // ----------member data ---------------------------
-  
-  edm::EDGetTokenT<std::vector<Trajectory> >      inputTraj_;
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<std::vector<Trajectory> > inputTraj_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   FakeCPE fakeCPE;
-
-
 };
 
 //
@@ -78,62 +74,57 @@ class FakeCPEFiller final : public edm::one::EDFilter<> {
 //
 // constructors and destructor
 //
-FakeCPEFiller::FakeCPEFiller(const edm::ParameterSet& iConfig):
-inputTraj_(consumes<std::vector<Trajectory> >(edm::InputTag("FinalTracks"))),
-  trackerHitAssociatorConfig_(iConfig,consumesCollector())
-{
-}
-
+FakeCPEFiller::FakeCPEFiller(const edm::ParameterSet& iConfig)
+    : inputTraj_(consumes<std::vector<Trajectory> >(edm::InputTag("FinalTracks"))),
+      trackerHitAssociatorConfig_(iConfig, consumesCollector()) {}
 
 // ------------ method called on each new Event  ------------
-bool
-FakeCPEFiller::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+bool FakeCPEFiller::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  bool accept = true;
+  fakeCPE.map().clear();
 
-   bool accept = true;
-   fakeCPE.map().clear();
+  edm::ESHandle<TransientTrackingRecHitBuilder> theB;
+  iSetup.get<TransientRecHitRecord>().get("Fake", theB);
 
-   edm::ESHandle<TransientTrackingRecHitBuilder> theB;
-   iSetup.get<TransientRecHitRecord>().get("Fake",theB);
+  auto const& ttb = static_cast<TkTransientTrackingRecHitBuilder const&>(*theB);
+  const_cast<StripFakeCPE*>(static_cast<StripFakeCPE const*>(ttb.stripClusterParameterEstimator()))
+      ->setFakeCPE(&fakeCPE);
+  const_cast<PixelFakeCPE*>(static_cast<PixelFakeCPE const*>(ttb.pixelClusterParameterEstimator()))
+      ->setFakeCPE(&fakeCPE);
 
-   auto const & ttb = static_cast<TkTransientTrackingRecHitBuilder const &>(*theB);
-   const_cast<StripFakeCPE*>(static_cast<StripFakeCPE const *>(ttb.stripClusterParameterEstimator()))->setFakeCPE(&fakeCPE);
-   const_cast<PixelFakeCPE*>(static_cast<PixelFakeCPE const *>(ttb.pixelClusterParameterEstimator()))->setFakeCPE(&fakeCPE);
-  
+  using namespace edm;
 
+  edm::ESHandle<GlobalTrackingGeometry> globalGeometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
 
-   using namespace edm;
+  Handle<std::vector<Trajectory> > trajH;
+  iEvent.getByToken(inputTraj_, trajH);
 
-   edm::ESHandle<GlobalTrackingGeometry> globalGeometry;
-   iSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
-   
-   Handle<std::vector<Trajectory> > trajH;
-   iEvent.getByToken(inputTraj_,trajH);
-   
-   TrackerHitAssociator HitAssoc(iEvent, trackerHitAssociatorConfig_);
-  
-   using LocalValues = std::pair<LocalPoint,LocalError>;
+  TrackerHitAssociator HitAssoc(iEvent, trackerHitAssociatorConfig_);
 
-   for (unsigned int j =0 ; j<trajH->size();++j) {
+  using LocalValues = std::pair<LocalPoint, LocalError>;
 
-     const std::vector<TrajectoryMeasurement> &tms = (*trajH)[j].measurements();
+  for (unsigned int j = 0; j < trajH->size(); ++j) {
+    const std::vector<TrajectoryMeasurement>& tms = (*trajH)[j].measurements();
 
-     for (unsigned int i=0;i<tms.size();++i) {      
-       TrajectoryStateOnSurface updatedState   = tms[i].updatedState();
+    for (unsigned int i = 0; i < tms.size(); ++i) {
+      TrajectoryStateOnSurface updatedState = tms[i].updatedState();
 
-       if (!updatedState.isValid()) continue;
-       
-       if (!tms[i].recHit()->isValid()) continue;
-   
-       auto const & thit = static_cast<BaseTrackerRecHit const&>(*tms[i].recHit());
-       auto const & clus = thit.firstClusterRef();
+      if (!updatedState.isValid())
+        continue;
 
-       auto const & simHits = HitAssoc.associateHit(*(tms[i].recHit()));
+      if (!tms[i].recHit()->isValid())
+        continue;
 
-       std::cout << "rechit " << thit.detUnit()->geographicalId().rawId() << ' '
-                   << thit.localPosition() <<' ' << thit.localPositionError() << ' ' << simHits.size() << std::endl;
+      auto const& thit = static_cast<BaseTrackerRecHit const&>(*tms[i].recHit());
+      auto const& clus = thit.firstClusterRef();
 
-/*        
+      auto const& simHits = HitAssoc.associateHit(*(tms[i].recHit()));
+
+      std::cout << "rechit " << thit.detUnit()->geographicalId().rawId() << ' ' << thit.localPosition() << ' '
+                << thit.localPositionError() << ' ' << simHits.size() << std::endl;
+
+      /*        
         if (simHits.empty()) {
           LocalValues lv(thit.localPosition(),thit.localPositionError());
          // Fill The Map
@@ -145,38 +136,39 @@ FakeCPEFiller::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 */
 
-       bool ok=false;
-       for (auto const & sh : simHits) {
-	 
-	 if(sh.processType() !=0) continue;
+      bool ok = false;
+      for (auto const& sh : simHits) {
+        if (sh.processType() != 0)
+          continue;
 
-	 std::cout << "simhit " << sh.localPosition() << std::endl;
+        std::cout << "simhit " << sh.localPosition() << std::endl;
 
-         LocalValues lv(sh.localPosition(),thit.localPositionError());  // fill with simhit and rechit error (in alternative hand-made error)
-         //LocalValues lv(thit.localPosition(),thit.localPositionError());  // fill with rechit (to verify nothing changes!)
-	 // Fill The Map
-         if (clus.isPixel()) 
-              fakeCPE.map().add(clus.pixelCluster(), *thit.detUnit(),lv);
-         else
-             fakeCPE.map().add(clus.stripCluster(), *thit.detUnit(),lv);
-         ok=true;
-         break; 
+        LocalValues lv(
+            sh.localPosition(),
+            thit.localPositionError());  // fill with simhit and rechit error (in alternative hand-made error)
+        //LocalValues lv(thit.localPosition(),thit.localPositionError());  // fill with rechit (to verify nothing changes!)
+        // Fill The Map
+        if (clus.isPixel())
+          fakeCPE.map().add(clus.pixelCluster(), *thit.detUnit(), lv);
+        else
+          fakeCPE.map().add(clus.stripCluster(), *thit.detUnit(), lv);
+        ok = true;
+        break;
 
-       } // closes loop on simHits
-       if (!ok) {
+      }  // closes loop on simHits
+      if (!ok) {
         std::cout << "SimHit non found in det " << thit.detUnit()->geographicalId().rawId() << std::endl;
-        accept=false;
-       }
-     } // closes loop on trajectory measurements
-     
-   } // closes loop on trajectories
+        accept = false;
+      }
+    }  // closes loop on trajectory measurements
 
-  return accept; // false if  just one hit did not match
+  }  // closes loop on trajectories
+
+  return accept;  // false if  just one hit did not match
 }
- 
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-FakeCPEFiller::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void FakeCPEFiller::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
@@ -185,4 +177,3 @@ FakeCPEFiller::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(FakeCPEFiller);
-

--- a/RecoTracker/TrackProducer/test/TrackAnalyzer.cc
+++ b/RecoTracker/TrackProducer/test/TrackAnalyzer.cc
@@ -23,13 +23,12 @@
 using namespace edm;
 
 class TrackAnalyzer : public edm::EDAnalyzer {
- public:
+public:
   TrackAnalyzer(const edm::ParameterSet& pset) {}
 
-  ~TrackAnalyzer(){}
+  ~TrackAnalyzer() {}
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){
-
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {
     //
     // extract tracker geometry
     //
@@ -38,50 +37,48 @@ class TrackAnalyzer : public edm::EDAnalyzer {
 
     using namespace std;
 
-    std::cout << "\nEvent ID = "<< event.id() << std::endl ;
+    std::cout << "\nEvent ID = " << event.id() << std::endl;
 
     edm::Handle<reco::TrackCollection> trackCollection;
-        event.getByLabel("ctfWithMaterialTracks", trackCollection);
-	//event.getByType(trackCollection);
-    
+    event.getByLabel("ctfWithMaterialTracks", trackCollection);
+    //event.getByType(trackCollection);
+
     const reco::TrackCollection tC = *(trackCollection.product());
 
-    std::cout << "Reconstructed "<< tC.size() << " tracks" << std::endl ;
+    std::cout << "Reconstructed " << tC.size() << " tracks" << std::endl;
 
-    int i=1;
-    for (reco::TrackCollection::const_iterator track=tC.begin(); track!=tC.end(); track++){
-      std::cout << "Track number "<< i << std::endl ;
-      std::cout << "\tmomentum: " << track->momentum()<< std::endl;
-      std::cout << "\tPT: " << track->pt()<< std::endl;
-      std::cout << "\tvertex: " << track->vertex()<< std::endl;
-      std::cout << "\timpact parameter: " << track->d0()<< std::endl;
-      std::cout << "\tcharge: " << track->charge()<< std::endl;
-      std::cout << "\tnormalizedChi2: " << track->normalizedChi2()<< std::endl;
+    int i = 1;
+    for (reco::TrackCollection::const_iterator track = tC.begin(); track != tC.end(); track++) {
+      std::cout << "Track number " << i << std::endl;
+      std::cout << "\tmomentum: " << track->momentum() << std::endl;
+      std::cout << "\tPT: " << track->pt() << std::endl;
+      std::cout << "\tvertex: " << track->vertex() << std::endl;
+      std::cout << "\timpact parameter: " << track->d0() << std::endl;
+      std::cout << "\tcharge: " << track->charge() << std::endl;
+      std::cout << "\tnormalizedChi2: " << track->normalizedChi2() << std::endl;
 
       i++;
-      cout<<"\tFrom EXTRA : "<<endl;
-      cout<<"\t\touter PT "<< track->outerPt()<<endl;
+      cout << "\tFrom EXTRA : " << endl;
+      cout << "\t\touter PT " << track->outerPt() << endl;
       std::cout << "\t direction: " << track->seedDirection() << std::endl;
-      if(!track->seedRef().isNull())
-	std::cout << "\t direction from seedRef: " << track->seedRef()->direction() << std::endl;
+      if (!track->seedRef().isNull())
+        std::cout << "\t direction from seedRef: " << track->seedRef()->direction() << std::endl;
       //
       // try and access Hits
       //
-      cout <<"\t\tNumber of RecHits "<<track->recHitsSize()<<endl;      
-      for (trackingRecHit_iterator it = track->recHitsBegin();  it != track->recHitsEnd(); it++){
-	if ((*it)->isValid()){
-	  cout <<"\t\t\tRecHit on det "<<(*it)->geographicalId().rawId()<<endl;
-	  cout <<"\t\t\tRecHit in LP "<<(*it)->localPosition()<<endl;
-	  cout <<"\t\t\tRecHit in GP "<<theG->idToDet((*it)->geographicalId())->surface().toGlobal((*it)->localPosition()) <<endl;
-	}else{
-	  cout <<"\t\t Invalid Hit On "<<(*it)->geographicalId().rawId()<<endl;
-	}
+      cout << "\t\tNumber of RecHits " << track->recHitsSize() << endl;
+      for (trackingRecHit_iterator it = track->recHitsBegin(); it != track->recHitsEnd(); it++) {
+        if ((*it)->isValid()) {
+          cout << "\t\t\tRecHit on det " << (*it)->geographicalId().rawId() << endl;
+          cout << "\t\t\tRecHit in LP " << (*it)->localPosition() << endl;
+          cout << "\t\t\tRecHit in GP "
+               << theG->idToDet((*it)->geographicalId())->surface().toGlobal((*it)->localPosition()) << endl;
+        } else {
+          cout << "\t\t Invalid Hit On " << (*it)->geographicalId().rawId() << endl;
+        }
       }
-      
     }
   }
 };
 
-
 DEFINE_FWK_MODULE(TrackAnalyzer);
-

--- a/RecoTracker/TrackProducer/test/TrackValidator.cc
+++ b/RecoTracker/TrackProducer/test/TrackValidator.cc
@@ -10,8 +10,8 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h" 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
@@ -30,100 +30,95 @@ using namespace std;
 using namespace reco;
 
 class TrackValidator : public edm::EDAnalyzer {
- public:
+public:
   TrackValidator(const edm::ParameterSet& pset)
-    : sim(pset.getParameter<string>("sim")),
-      label(pset.getParameter< vector<string> >("label")),
-      out(pset.getParameter<string>("out")),
-      open(pset.getParameter<string>("open")),
-      min(pset.getParameter<double>("min")),
-      max(pset.getParameter<double>("max")),
-      nint(pset.getParameter<int>("nint")),
-      partId(pset.getParameter<int>("partId"))
-  {
-    hFile = new TFile( out.c_str(), open.c_str() );
+      : sim(pset.getParameter<string>("sim")),
+        label(pset.getParameter<vector<string> >("label")),
+        out(pset.getParameter<string>("out")),
+        open(pset.getParameter<string>("open")),
+        min(pset.getParameter<double>("min")),
+        max(pset.getParameter<double>("max")),
+        nint(pset.getParameter<int>("nint")),
+        partId(pset.getParameter<int>("partId")) {
+    hFile = new TFile(out.c_str(), open.c_str());
   }
 
-  ~TrackValidator(){
-    if (hFile!=0) {
+  ~TrackValidator() {
+    if (hFile != 0) {
       hFile->Close();
       delete hFile;
     }
   }
 
   void beginRun(edm::Run const& run, const edm::EventSetup& setup) override {
-
-    for (unsigned int j=0;j<label.size();j++){
-      
+    for (unsigned int j = 0; j < label.size(); j++) {
       vector<double> etaintervalsv;
-      vector<int>    totSIMv,totRECv;
-      vector<TH1F*>  ptdistribv;
-      vector<TH1F*>  etadistribv;
-  
-      double step=(max-min)/nint;
-      ostringstream title,name;
+      vector<int> totSIMv, totRECv;
+      vector<TH1F*> ptdistribv;
+      vector<TH1F*> etadistribv;
+
+      double step = (max - min) / nint;
+      ostringstream title, name;
       etaintervalsv.push_back(0);
-      for (double d=min;d<max;d=d+step) {
-	etaintervalsv.push_back(d+step);
-	totSIMv.push_back(0);
-	totRECv.push_back(0);
-	name.str("");
-	title.str("");
-	name <<"pt["<<d<<","<<d+step<<"]";
-	title <<"p_{t} residue "<< d << "<#eta<"<<d+step;
-	ptdistribv.push_back(new TH1F(name.str().c_str(),title.str().c_str(), 200, -2, 2 ));
-	name.str("");
-	title.str("");
-	name <<"eta["<<d<<","<<d+step<<"]";
-	title <<"eta residue "<< d << "<#eta<"<<d+step;
-	etadistribv.push_back(new TH1F(name.str().c_str(),title.str().c_str(), 200, -0.2, 0.2 ));
+      for (double d = min; d < max; d = d + step) {
+        etaintervalsv.push_back(d + step);
+        totSIMv.push_back(0);
+        totRECv.push_back(0);
+        name.str("");
+        title.str("");
+        name << "pt[" << d << "," << d + step << "]";
+        title << "p_{t} residue " << d << "<#eta<" << d + step;
+        ptdistribv.push_back(new TH1F(name.str().c_str(), title.str().c_str(), 200, -2, 2));
+        name.str("");
+        title.str("");
+        name << "eta[" << d << "," << d + step << "]";
+        title << "eta residue " << d << "<#eta<" << d + step;
+        etadistribv.push_back(new TH1F(name.str().c_str(), title.str().c_str(), 200, -0.2, 0.2));
       }
       etaintervals.push_back(etaintervalsv);
       totSIM.push_back(totSIMv);
       totREC.push_back(totRECv);
       ptdistrib.push_back(ptdistribv);
       etadistrib.push_back(etadistribv);
-     
-      h_ptSIM.push_back( new TH1F("ptSIM", "generated p_{t}", 5500, 0, 110 ) );
-      h_etaSIM.push_back( new TH1F("etaSIM", "generated pseudorapidity", 500, 0, 5 ) );
-      h_tracksSIM.push_back( new TH1F("tracksSIM","number of simluated tracks",100,-0.5,99.5) );
-      h_vertposSIM.push_back( new TH1F("vertposSIM","Transverse position of sim vertices",1000,-0.5,10000.5) );
-      
+
+      h_ptSIM.push_back(new TH1F("ptSIM", "generated p_{t}", 5500, 0, 110));
+      h_etaSIM.push_back(new TH1F("etaSIM", "generated pseudorapidity", 500, 0, 5));
+      h_tracksSIM.push_back(new TH1F("tracksSIM", "number of simluated tracks", 100, -0.5, 99.5));
+      h_vertposSIM.push_back(new TH1F("vertposSIM", "Transverse position of sim vertices", 1000, -0.5, 10000.5));
+
       //     h_pt     = new TH1F("pt", "p_{t} residue", 2000, -500, 500 );
-      h_pt.push_back( new TH1F("pullPt", "pull of p_{t}", 100, -10, 10 ) );
-      h_pt2.push_back( new TH1F("pt2", "p_{t} residue (#tracks>1)", 300, -15, 15 ) );
-      h_eta.push_back( new TH1F("eta", "pseudorapidity residue", 1000, -0.1, 0.1 ) );
-      h_tracks.push_back( new TH1F("tracks","number of reconstructed tracks",10,-0.5,9.5) );
-      h_nchi2.push_back( new TH1F("nchi2", "normalized chi2", 200, 0, 20 ) );
-      h_hits.push_back( new TH1F("hits", "number of hits per track", 30, -0.5, 29.5 ) );
-      h_effic.push_back( new TH1F("effic","efficiency vs #eta",nint,&etaintervals[j][0]) );
-      h_ptrmsh.push_back( new TH1F("PtRMS","PtRMS vs #eta",nint,&etaintervals[j][0]) );
-      h_deltaeta.push_back( new TH1F("etaRMS","etaRMS vs #eta",nint,&etaintervals[j][0]) );
-      h_charge.push_back( new TH1F("charge","charge",3,-1.5,1.5) );
-      
-      h_pullTheta.push_back( new TH1F("pullTheta","pull of theta parameter",100,-10,10) );
-      h_pullPhi0.push_back( new TH1F("pullPhi0","pull of phi0 parameter",100,-10,10) );
-      h_pullD0.push_back( new TH1F("pullD0","pull of d0 parameter",100,-10,10) );
-      h_pullDz.push_back( new TH1F("pullDz","pull of dz parameter",100,-10,10) );
-      h_pullK.push_back( new TH1F("pullK","pull of k parameter",100,-10,10) );
-      
-      chi2_vs_nhits.push_back( new TH2F("chi2_vs_nhits","chi2 vs nhits",25,0,25,100,0,10) );
-      chi2_vs_eta.push_back( new TH2F("chi2_vs_eta","chi2 vs eta",nint,min,max,100,0,10) );
-      nhits_vs_eta.push_back( new TH2F("nhits_vs_eta","nhits vs eta",nint,min,max,25,0,25) );
-      ptres_vs_eta.push_back( new TH2F("ptres_vs_eta","ptresidue vs eta",nint,min,max,200,-2,2) );
-      etares_vs_eta.push_back( new TH2F("etares_vs_eta","etaresidue vs eta",nint,min,max,200,-0.1,0.1) );
+      h_pt.push_back(new TH1F("pullPt", "pull of p_{t}", 100, -10, 10));
+      h_pt2.push_back(new TH1F("pt2", "p_{t} residue (#tracks>1)", 300, -15, 15));
+      h_eta.push_back(new TH1F("eta", "pseudorapidity residue", 1000, -0.1, 0.1));
+      h_tracks.push_back(new TH1F("tracks", "number of reconstructed tracks", 10, -0.5, 9.5));
+      h_nchi2.push_back(new TH1F("nchi2", "normalized chi2", 200, 0, 20));
+      h_hits.push_back(new TH1F("hits", "number of hits per track", 30, -0.5, 29.5));
+      h_effic.push_back(new TH1F("effic", "efficiency vs #eta", nint, &etaintervals[j][0]));
+      h_ptrmsh.push_back(new TH1F("PtRMS", "PtRMS vs #eta", nint, &etaintervals[j][0]));
+      h_deltaeta.push_back(new TH1F("etaRMS", "etaRMS vs #eta", nint, &etaintervals[j][0]));
+      h_charge.push_back(new TH1F("charge", "charge", 3, -1.5, 1.5));
+
+      h_pullTheta.push_back(new TH1F("pullTheta", "pull of theta parameter", 100, -10, 10));
+      h_pullPhi0.push_back(new TH1F("pullPhi0", "pull of phi0 parameter", 100, -10, 10));
+      h_pullD0.push_back(new TH1F("pullD0", "pull of d0 parameter", 100, -10, 10));
+      h_pullDz.push_back(new TH1F("pullDz", "pull of dz parameter", 100, -10, 10));
+      h_pullK.push_back(new TH1F("pullK", "pull of k parameter", 100, -10, 10));
+
+      chi2_vs_nhits.push_back(new TH2F("chi2_vs_nhits", "chi2 vs nhits", 25, 0, 25, 100, 0, 10));
+      chi2_vs_eta.push_back(new TH2F("chi2_vs_eta", "chi2 vs eta", nint, min, max, 100, 0, 10));
+      nhits_vs_eta.push_back(new TH2F("nhits_vs_eta", "nhits vs eta", nint, min, max, 25, 0, 25));
+      ptres_vs_eta.push_back(new TH2F("ptres_vs_eta", "ptresidue vs eta", nint, min, max, 200, -2, 2));
+      etares_vs_eta.push_back(new TH2F("etares_vs_eta", "etaresidue vs eta", nint, min, max, 200, -0.1, 0.1));
     }
 
-    setup.get<IdealMagneticFieldRecord>().get(theMF);  
-
+    setup.get<IdealMagneticFieldRecord>().get(theMF);
   }
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override{
-std::cout << "In TrackValidator\n";
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) override {
+    std::cout << "In TrackValidator\n";
     edm::ESHandle<TransientTrackBuilder> theB;
-    setup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
-    for (unsigned int w=0;w<label.size();w++){
-
+    setup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+    for (unsigned int w = 0; w < label.size(); w++) {
       //
       //get collections from the event
       //
@@ -140,198 +135,210 @@ std::cout << "In TrackValidator\n";
       const reco::TrackCollection tC = *(trackCollection.product());
 
       vector<TransientTrack> t_tks = (*theB).build(trackCollection);
-      cout << "Found: " << t_tks.size() << " reconstructed tracks" << "\n";
+      cout << "Found: " << t_tks.size() << " reconstructed tracks"
+           << "\n";
 
       //
       //fill simulation histograms
       //
-      int st=0;
-      for (SimTrackContainer::const_iterator simTrack=simTC.begin(); simTrack!=simTC.end(); simTrack++){
-	if (abs(simTrack->momentum().eta())>max || 
-	    abs(simTrack->momentum().eta())<min) continue;
-	st++;
-	h_ptSIM[w]->Fill(simTrack->momentum().pt());
-	h_etaSIM[w]->Fill(simTrack->momentum().eta());
+      int st = 0;
+      for (SimTrackContainer::const_iterator simTrack = simTC.begin(); simTrack != simTC.end(); simTrack++) {
+        if (abs(simTrack->momentum().eta()) > max || abs(simTrack->momentum().eta()) < min)
+          continue;
+        st++;
+        h_ptSIM[w]->Fill(simTrack->momentum().pt());
+        h_etaSIM[w]->Fill(simTrack->momentum().eta());
 
-	h_vertposSIM[w]->Fill(simVC[simTrack->vertIndex()].position().pt());
-	
-	if (simTrack->type()!=partId) continue;
-	//compute number of tracks per eta interval
-	int i=0;
-	for (vector<double>::iterator h=etaintervals[w].begin(); h!=etaintervals[w].end()-1; h++){
-	  if (abs(simTrack->momentum().eta())>etaintervals[w][i]&&
-	      abs(simTrack->momentum().eta())<etaintervals[w][i+1]) {
-	    totSIM[w][i]++;
-	    bool doit=false;
-	    for (reco::TrackCollection::const_iterator track=tC.begin(); track!=tC.end(); track++){
-	      if (abs(track->pt()-simTrack->momentum().pt())<(simTrack->momentum().pt()*0.1)) doit=true; 
-	    }
-	    if (doit) totREC[w][i]++;
-	  }
-	  i++;
-	}
+        h_vertposSIM[w]->Fill(simVC[simTrack->vertIndex()].position().pt());
+
+        if (simTrack->type() != partId)
+          continue;
+        //compute number of tracks per eta interval
+        int i = 0;
+        for (vector<double>::iterator h = etaintervals[w].begin(); h != etaintervals[w].end() - 1; h++) {
+          if (abs(simTrack->momentum().eta()) > etaintervals[w][i] &&
+              abs(simTrack->momentum().eta()) < etaintervals[w][i + 1]) {
+            totSIM[w][i]++;
+            bool doit = false;
+            for (reco::TrackCollection::const_iterator track = tC.begin(); track != tC.end(); track++) {
+              if (abs(track->pt() - simTrack->momentum().pt()) < (simTrack->momentum().pt() * 0.1))
+                doit = true;
+            }
+            if (doit)
+              totREC[w][i]++;
+          }
+          i++;
+        }
       }
-      if (st!=0) h_tracksSIM[w]->Fill(st);
+      if (st != 0)
+        h_tracksSIM[w]->Fill(st);
 
       //       for (SimVertexContainer::const_iterator simVertex=simVC.begin();simVertex!=simVC.end();simVertex++){
       // 	h_vertposSIM[w]->Fill(simVertex->position().perp());
-//       }
-      
+      //       }
+
       //
       //fill reconstructed track histograms
       //
-      int rt=0;
-      for (vector<TransientTrack>::const_iterator track=t_tks.begin(); track!=t_tks.end(); track++){
-      
-	TrajectoryStateClosestToPoint tscp = track->impactPointTSCP();
-	cout << tscp.perigeeParameters().vector() << tscp.perigeeError().covarianceMatrix()<<endl;
+      int rt = 0;
+      for (vector<TransientTrack>::const_iterator track = t_tks.begin(); track != t_tks.end(); track++) {
+        TrajectoryStateClosestToPoint tscp = track->impactPointTSCP();
+        cout << tscp.perigeeParameters().vector() << tscp.perigeeError().covarianceMatrix() << endl;
 
-	if (abs(track->track().eta())>max || abs(track->track().eta())<min) continue;
+        if (abs(track->track().eta()) > max || abs(track->track().eta()) < min)
+          continue;
 
-	rt++;
+        rt++;
 
-	//nchi2 and hits global distributions
-	h_nchi2[w]->Fill(track->normalizedChi2());
-	h_hits[w]->Fill(track->numberOfValidHits());
-	chi2_vs_nhits[w]->Fill(track->numberOfValidHits(),track->normalizedChi2());
-	chi2_vs_eta[w]->Fill(track->track().eta(),track->normalizedChi2());
-	nhits_vs_eta[w]->Fill(track->track().eta(),track->numberOfValidHits());
-	h_charge[w]->Fill( track->charge() );
+        //nchi2 and hits global distributions
+        h_nchi2[w]->Fill(track->normalizedChi2());
+        h_hits[w]->Fill(track->numberOfValidHits());
+        chi2_vs_nhits[w]->Fill(track->numberOfValidHits(), track->normalizedChi2());
+        chi2_vs_eta[w]->Fill(track->track().eta(), track->normalizedChi2());
+        nhits_vs_eta[w]->Fill(track->track().eta(), track->numberOfValidHits());
+        h_charge[w]->Fill(track->charge());
 
-	//pt, eta residue, theta, phi0, d0, dz pull
-	double ptres =1000;
-	double etares=1000;
-	double thetares=1000;
-	double phi0res=1000;
-	double d0res=1000;
-	double dzres=1000;
-	double kres=1000;
-	for (SimTrackContainer::const_iterator simTrack=simTC.begin(); simTrack!=simTC.end(); simTrack++){
-	  if (simTrack->type()!=partId) continue;
-	  double tmp=track->track().pt()-simTrack->momentum().pt();
-	  if (tC.size()>1) h_pt2[w]->Fill(tmp);
-	  if (abs(tmp)<abs(ptres)) {
-	    ptres=tmp; 
+        //pt, eta residue, theta, phi0, d0, dz pull
+        double ptres = 1000;
+        double etares = 1000;
+        double thetares = 1000;
+        double phi0res = 1000;
+        double d0res = 1000;
+        double dzres = 1000;
+        double kres = 1000;
+        for (SimTrackContainer::const_iterator simTrack = simTC.begin(); simTrack != simTC.end(); simTrack++) {
+          if (simTrack->type() != partId)
+            continue;
+          double tmp = track->track().pt() - simTrack->momentum().pt();
+          if (tC.size() > 1)
+            h_pt2[w]->Fill(tmp);
+          if (abs(tmp) < abs(ptres)) {
+            ptres = tmp;
 
+            etares = track->initialFreeState().momentum().eta() - simTrack->momentum().eta();
+            thetares =
+                (tscp.perigeeParameters().theta() - simTrack->momentum().theta()) / tscp.perigeeError().thetaError();
+            phi0res = (tscp.perigeeParameters().phi() - simTrack->momentum().phi()) / tscp.perigeeError().phiError();
+            d0res =
+                (tscp.perigeeParameters().transverseImpactParameter() - simVC[simTrack->vertIndex()].position().pt()) /
+                tscp.perigeeError().transverseImpactParameterError();
+            dzres =
+                (tscp.perigeeParameters().longitudinalImpactParameter() - simVC[simTrack->vertIndex()].position().z()) /
+                tscp.perigeeError().longitudinalImpactParameterError();
 
-	    etares=track->initialFreeState().momentum().eta()-simTrack->momentum().eta();
-	    thetares=(tscp.perigeeParameters().theta()-simTrack->momentum().theta())/tscp.perigeeError().thetaError();
-	    phi0res=(tscp.perigeeParameters().phi()-simTrack->momentum().phi())/tscp.perigeeError().phiError();
-	    d0res=(tscp.perigeeParameters().transverseImpactParameter()-simVC[simTrack->vertIndex()].position().pt())/tscp.perigeeError().transverseImpactParameterError();
-	    dzres=(tscp.perigeeParameters().longitudinalImpactParameter()-simVC[simTrack->vertIndex()].position().z())/tscp.perigeeError().longitudinalImpactParameterError();
+            const math::XYZTLorentzVectorD& vertexPosition = simVC[simTrack->vertIndex()].position();
+            GlobalVector magField =
+                theMF->inTesla(GlobalPoint(vertexPosition.x(), vertexPosition.y(), vertexPosition.z()));
+            kres = (tscp.perigeeParameters().transverseCurvature() -
+                    (-track->charge() * 2.99792458e-3 * magField.z() / simTrack->momentum().pt())) /
+                   tscp.perigeeError().transverseCurvatureError();
 
-	    
-	    const math::XYZTLorentzVectorD& vertexPosition = simVC[simTrack->vertIndex()].position();
-	    GlobalVector magField=theMF->inTesla(GlobalPoint(vertexPosition.x(),vertexPosition.y(),vertexPosition.z()));
-	    kres=(tscp.perigeeParameters().transverseCurvature()-(-track->charge()*2.99792458e-3 * magField.z()/simTrack->momentum().pt()))/
-	    tscp.perigeeError().transverseCurvatureError();
+            // 	    cout << "track->d0(): " << track->d0() << endl;
+            // 	    cout << "simVC[simTrack->vertIndex()].position().perp(): " << simVC[simTrack->vertIndex()].position().perp() << endl;
+            // 	    cout << "track->dz(): " << track->dz() << endl;
+            // 	    cout << "simVC[simTrack->vertIndex()].position().z(): " << simVC[simTrack->vertIndex()].position().z() << endl;
+            // 	    cout << "track->transverseCurvature(): " << track->transverseCurvature() << endl;
 
-// 	    cout << "track->d0(): " << track->d0() << endl;
-// 	    cout << "simVC[simTrack->vertIndex()].position().perp(): " << simVC[simTrack->vertIndex()].position().perp() << endl;
-// 	    cout << "track->dz(): " << track->dz() << endl;
-// 	    cout << "simVC[simTrack->vertIndex()].position().z(): " << simVC[simTrack->vertIndex()].position().z() << endl;
-// 	    cout << "track->transverseCurvature(): " << track->transverseCurvature() << endl;
+            // 	    cout << "-track->charge()*2.99792458e-3 * 4./simTrack->momentum().perp(): " << -track->charge()*2.99792458e-3 * 4./simTrack->momentum().perp() << endl;
+            // 	    cout << "-track->charge()*2.99792458e-3 * 4./simTrack->momentum().perp(): " << -track->charge()*2.99792458e-3 * magField.z()/simTrack->momentum().perp() << endl;
+          }
+        }
+        cout << etares << endl;
+        h_pt[w]->Fill(
+            ptres / (tscp.perigeeError().transverseCurvatureError() / tscp.perigeeParameters().transverseCurvature()));
+        h_eta[w]->Fill(etares);
+        ptres_vs_eta[w]->Fill(track->track().eta(), ptres);
+        etares_vs_eta[w]->Fill(track->track().eta(), etares);
+        h_pullTheta[w]->Fill(thetares);
+        h_pullPhi0[w]->Fill(phi0res);
+        h_pullD0[w]->Fill(d0res);
+        h_pullDz[w]->Fill(dzres);
+        h_pullK[w]->Fill(kres);
 
-// 	    cout << "-track->charge()*2.99792458e-3 * 4./simTrack->momentum().perp(): " << -track->charge()*2.99792458e-3 * 4./simTrack->momentum().perp() << endl;
-// 	    cout << "-track->charge()*2.99792458e-3 * 4./simTrack->momentum().perp(): " << -track->charge()*2.99792458e-3 * magField.z()/simTrack->momentum().perp() << endl;
-
-
-	  }
-	}
-	cout << etares<<endl;
-	h_pt[w]->Fill(ptres/(tscp.perigeeError().transverseCurvatureError()
-			     /tscp.perigeeParameters().transverseCurvature()));
-	h_eta[w]->Fill(etares);
-	ptres_vs_eta[w]->Fill(track->track().eta(),ptres);
-	etares_vs_eta[w]->Fill(track->track().eta(),etares);
-	h_pullTheta[w]->Fill(thetares);
-	h_pullPhi0[w]->Fill(phi0res);
-	h_pullD0[w]->Fill(d0res);
-	h_pullDz[w]->Fill(dzres);
-	h_pullK[w]->Fill(kres);
-	
-
-	//pt residue distribution per eta interval
-	int i=0;
-	for (vector<TH1F*>::iterator h=ptdistrib[w].begin(); h!=ptdistrib[w].end(); h++){
-	  for (SimTrackContainer::const_iterator simTrack=simTC.begin(); simTrack!=simTC.end(); simTrack++){
-	    if (simTrack->type()!=partId) continue;
-	    ptres=1000;
-	    if (abs(simTrack->momentum().eta())>etaintervals[w][i]&&
-		abs(simTrack->momentum().eta())<etaintervals[w][i+1]) {
-	      double tmp=track->track().pt()-simTrack->momentum().pt();
-	      if (abs(tmp)<abs(ptres)) ptres=tmp;
-	    }
-	  }
-	  (*h)->Fill(ptres);
-	  i++;
-	}
-	//eta residue distribution per eta interval
-	i=0;
-	for (vector<TH1F*>::iterator h=etadistrib[w].begin(); h!=etadistrib[w].end(); h++){
-	  for (SimTrackContainer::const_iterator simTrack=simTC.begin(); simTrack!=simTC.end(); simTrack++){
-	    if (simTrack->type()!=partId) continue;
-	    etares=1000; 
-	    ptres =1000;
-	    if (abs(simTrack->momentum().eta())>etaintervals[w][i]&&
-		abs(simTrack->momentum().eta())<etaintervals[w][i+1]) {
-	      double tmp=track->track().pt()-simTrack->momentum().pt();
-	      if (abs(tmp)<abs(ptres)) etares=track->track().eta()-simTrack->momentum().eta();
-	    }
-	  }
-	  (*h)->Fill(etares);
-	  i++;
-	}
+        //pt residue distribution per eta interval
+        int i = 0;
+        for (vector<TH1F*>::iterator h = ptdistrib[w].begin(); h != ptdistrib[w].end(); h++) {
+          for (SimTrackContainer::const_iterator simTrack = simTC.begin(); simTrack != simTC.end(); simTrack++) {
+            if (simTrack->type() != partId)
+              continue;
+            ptres = 1000;
+            if (abs(simTrack->momentum().eta()) > etaintervals[w][i] &&
+                abs(simTrack->momentum().eta()) < etaintervals[w][i + 1]) {
+              double tmp = track->track().pt() - simTrack->momentum().pt();
+              if (abs(tmp) < abs(ptres))
+                ptres = tmp;
+            }
+          }
+          (*h)->Fill(ptres);
+          i++;
+        }
+        //eta residue distribution per eta interval
+        i = 0;
+        for (vector<TH1F*>::iterator h = etadistrib[w].begin(); h != etadistrib[w].end(); h++) {
+          for (SimTrackContainer::const_iterator simTrack = simTC.begin(); simTrack != simTC.end(); simTrack++) {
+            if (simTrack->type() != partId)
+              continue;
+            etares = 1000;
+            ptres = 1000;
+            if (abs(simTrack->momentum().eta()) > etaintervals[w][i] &&
+                abs(simTrack->momentum().eta()) < etaintervals[w][i + 1]) {
+              double tmp = track->track().pt() - simTrack->momentum().pt();
+              if (abs(tmp) < abs(ptres))
+                etares = track->track().eta() - simTrack->momentum().eta();
+            }
+          }
+          (*h)->Fill(etares);
+          i++;
+        }
       }
-      if (rt!=0) h_tracks[w]->Fill(rt);
-
+      if (rt != 0)
+        h_tracks[w]->Fill(rt);
     }
-
   }
 
   void endJob() override {
+    for (unsigned int w = 0; w < label.size(); w++) {
+      TDirectory* p = hFile->mkdir(label[w].c_str());
 
-    for (unsigned int w=0;w<label.size();w++){
-      TDirectory * p = hFile->mkdir(label[w].c_str());
-      
       //write simulation histos
-      TDirectory * simD = p->mkdir("simulation");
+      TDirectory* simD = p->mkdir("simulation");
       simD->cd();
       h_ptSIM[w]->Write();
       h_etaSIM[w]->Write();
       h_tracksSIM[w]->Write();
       h_vertposSIM[w]->Write();
-      
+
       //fill pt rms plot versus eta and write pt residue distribution per eta interval histo
-      TDirectory * ptD = p->mkdir("ptdistribution");
+      TDirectory* ptD = p->mkdir("ptdistribution");
       ptD->cd();
-      int i=0;
-      for (vector<TH1F*>::iterator h=ptdistrib[w].begin(); h!=ptdistrib[w].end(); h++){
-	(*h)->Write();
-	h_ptrmsh[w]->Fill(etaintervals[w][i+1]-0.00001 ,(*h)->GetRMS());
-	i++;
+      int i = 0;
+      for (vector<TH1F*>::iterator h = ptdistrib[w].begin(); h != ptdistrib[w].end(); h++) {
+        (*h)->Write();
+        h_ptrmsh[w]->Fill(etaintervals[w][i + 1] - 0.00001, (*h)->GetRMS());
+        i++;
       }
-      
+
       //fill eta rms plot versus eta and write eta residue distribution per eta interval histo
-      TDirectory * etaD = p->mkdir("etadistribution");
+      TDirectory* etaD = p->mkdir("etadistribution");
       etaD->cd();
-      i=0;
-      for (vector<TH1F*>::iterator h=etadistrib[w].begin(); h!=etadistrib[w].end(); h++){
-	(*h)->Write();
-	h_deltaeta[w]->Fill(etaintervals[w][i+1]-0.00001 ,(*h)->GetRMS());
-	i++;
+      i = 0;
+      for (vector<TH1F*>::iterator h = etadistrib[w].begin(); h != etadistrib[w].end(); h++) {
+        (*h)->Write();
+        h_deltaeta[w]->Fill(etaintervals[w][i + 1] - 0.00001, (*h)->GetRMS());
+        i++;
       }
-      
+
       //write the other histos
       p->cd();
-      int j=0;
-      for (vector<int>::iterator h=totSIM[w].begin(); h!=totSIM[w].end(); h++){
-	if (totSIM[w][j])
-	h_effic[w]->Fill(etaintervals[w][j+1]-0.00001, ((double) totREC[w][j])/((double) totSIM[w][j]));
-	else h_effic[w]->Fill(etaintervals[w][j+1]-0.00001, 0);
-	j++;
+      int j = 0;
+      for (vector<int>::iterator h = totSIM[w].begin(); h != totSIM[w].end(); h++) {
+        if (totSIM[w][j])
+          h_effic[w]->Fill(etaintervals[w][j + 1] - 0.00001, ((double)totREC[w][j]) / ((double)totSIM[w][j]));
+        else
+          h_effic[w]->Fill(etaintervals[w][j + 1] - 0.00001, 0);
+        j++;
       }
-      
+
       h_pt[w]->Write();
       h_pt2[w]->Write();
       h_eta[w]->Write();
@@ -347,7 +354,7 @@ std::cout << "In TrackValidator\n";
       ptres_vs_eta[w]->Write();
       etares_vs_eta[w]->Write();
       h_charge[w]->Write();
-      
+
       h_pullTheta[w]->Write();
       h_pullPhi0[w]->Write();
       h_pullD0[w]->Write();
@@ -356,32 +363,28 @@ std::cout << "In TrackValidator\n";
     }
 
     hFile->Close();
-
   }
 
 private:
   string sim;
   vector<string> label;
   string out, open;
-  double  min, max;
+  double min, max;
   int nint, partId;
 
   vector<TH1F*> h_ptSIM, h_etaSIM, h_tracksSIM, h_vertposSIM;
   vector<TH1F*> h_tracks, h_nchi2, h_hits, h_effic, h_ptrmsh, h_deltaeta, h_charge;
-  vector<TH1F*> h_pt, h_eta, h_pullTheta,h_pullPhi0,h_pullD0,h_pullDz,h_pullK, h_pt2;
+  vector<TH1F*> h_pt, h_eta, h_pullTheta, h_pullPhi0, h_pullD0, h_pullDz, h_pullK, h_pt2;
   vector<TH2F*> chi2_vs_nhits, chi2_vs_eta, nhits_vs_eta, ptres_vs_eta, etares_vs_eta;
 
-  vector< vector<double> > etaintervals;
-  vector< vector<int> > totSIM,totREC;
+  vector<vector<double> > etaintervals;
+  vector<vector<int> > totSIM, totREC;
 
-  vector< vector<TH1F*> > ptdistrib;
-  vector< vector<TH1F*> > etadistrib;
-  TFile *  hFile;  
+  vector<vector<TH1F*> > ptdistrib;
+  vector<vector<TH1F*> > etadistrib;
+  TFile* hFile;
 
   edm::ESHandle<MagneticField> theMF;
-
 };
 
-
 DEFINE_FWK_MODULE(TrackValidator);
-

--- a/RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
+++ b/RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TrajectoryAnalyzer
 // Class:      TrajectoryAnalyzer
-// 
+//
 /**\class TrajectoryAnalyzer TrajectoryAnalyzer.cc RecoTracker/TrackProducer/test/TrajectoryAnalyzer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Mon Oct 16 10:38:20 CEST 2006
 //
 //
-
 
 // system include files
 #include <memory>
@@ -35,27 +34,24 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 
-#include<iostream>
+#include <iostream>
 // #define COUT(x) edm::LogVerbatim(x)
-#define COUT(x) std::cout<<x<<' '
-
+#define COUT(x) std::cout << x << ' '
 
 //
 // class decleration
 //
 
-
 class TrajectoryAnalyzer : public edm::stream::EDAnalyzer<> {
-   public:
-      explicit TrajectoryAnalyzer(const edm::ParameterSet&);
-      ~TrajectoryAnalyzer();
+public:
+  explicit TrajectoryAnalyzer(const edm::ParameterSet&);
+  ~TrajectoryAnalyzer();
 
+private:
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-
-      // ----------member data ---------------------------
-   edm::EDGetTokenT<std::vector<Trajectory>> trajTag;
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<std::vector<Trajectory>> trajTag;
 };
 
 //
@@ -69,51 +65,46 @@ class TrajectoryAnalyzer : public edm::stream::EDAnalyzer<> {
 //
 // constructors and destructor
 //
-TrajectoryAnalyzer::TrajectoryAnalyzer(const edm::ParameterSet& iConfig) :
-  trajTag(consumes<std::vector<Trajectory>>(iConfig.getParameter<edm::InputTag>("trajectoryInput"))){}
+TrajectoryAnalyzer::TrajectoryAnalyzer(const edm::ParameterSet& iConfig)
+    : trajTag(consumes<std::vector<Trajectory>>(iConfig.getParameter<edm::InputTag>("trajectoryInput"))) {}
 
-
-TrajectoryAnalyzer::~TrajectoryAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+TrajectoryAnalyzer::~TrajectoryAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-TrajectoryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-  
-   Handle<std::vector<Trajectory> > trajCollectionHandle;
-   iEvent.getByToken(trajTag,trajCollectionHandle);
-   
-   COUT("TrajectoryAnalyzer") << "trajColl->size(): " << trajCollectionHandle->size() << std::endl;
-   for(auto it = trajCollectionHandle->begin(); it!=trajCollectionHandle->end();it++){
-     COUT("TrajectoryAnalyzer") << "this traj has " << it->foundHits() << " valid hits"  << " , "
-					    << "isValid: " << it->isValid() << std::endl;
+void TrajectoryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-     auto const & tmColl = it->measurements();
-     for(auto itTraj = tmColl.begin(); itTraj!=tmColl.end(); itTraj++){
-       if(! itTraj->updatedState().isValid()) continue;
-       COUT("TrajectoryAnalyzer") << "tm number: " << (itTraj - tmColl.begin()) + 1<< " , "
-					      << "tm.backwardState.pt: " << itTraj->backwardPredictedState().globalMomentum().perp() << " , "
-					      << "tm.forwardState.pt:  " << itTraj->forwardPredictedState().globalMomentum().perp() << " , "
-					      << "tm.updatedState.pt:  " << itTraj->updatedState().globalMomentum().perp()  << " , "
-					      << "tm.globalPos.perp: "   << itTraj->updatedState().globalPosition().perp() << std::endl;       
-     }
-   }
+  Handle<std::vector<Trajectory>> trajCollectionHandle;
+  iEvent.getByToken(trajTag, trajCollectionHandle);
 
+  COUT("TrajectoryAnalyzer") << "trajColl->size(): " << trajCollectionHandle->size() << std::endl;
+  for (auto it = trajCollectionHandle->begin(); it != trajCollectionHandle->end(); it++) {
+    COUT("TrajectoryAnalyzer") << "this traj has " << it->foundHits() << " valid hits"
+                               << " , "
+                               << "isValid: " << it->isValid() << std::endl;
+
+    auto const& tmColl = it->measurements();
+    for (auto itTraj = tmColl.begin(); itTraj != tmColl.end(); itTraj++) {
+      if (!itTraj->updatedState().isValid())
+        continue;
+      COUT("TrajectoryAnalyzer") << "tm number: " << (itTraj - tmColl.begin()) + 1 << " , "
+                                 << "tm.backwardState.pt: " << itTraj->backwardPredictedState().globalMomentum().perp()
+                                 << " , "
+                                 << "tm.forwardState.pt:  " << itTraj->forwardPredictedState().globalMomentum().perp()
+                                 << " , "
+                                 << "tm.updatedState.pt:  " << itTraj->updatedState().globalMomentum().perp() << " , "
+                                 << "tm.globalPos.perp: " << itTraj->updatedState().globalPosition().perp()
+                                 << std::endl;
+    }
+  }
 }
-
-
 
 //define this as a plug-in
 


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/352//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


