### PR TITLE
 Validation/Configuration/python/autoValidation.py Phase2 modification

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -1,19 +1,19 @@
 autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLiteTracking','validationHarvesting'],
                    'trackingOnlyValidation' : ['globalPrevalidationTrackingOnly','globalValidationTrackingOnly','postValidation_trackingOnly'],
                    'pixelTrackingOnlyValidation' : ['globalPrevalidationPixelTrackingOnly','globalValidationPixelTrackingOnly','postValidation_trackingOnly'],
-                   'trackingValidation': ['globalPrevalidationTracking','globalValidationTrackingOnly','postValidationTracking'], #
-                   'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'], #
-                   'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'], #
-                   'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'], #
-                   'electronOnlyValidation' : ['', 'electronValidationSequence', 'electronPostValidationSequence'], # OK
-                   'hcalOnlyValidation' : ['globalPrevalidationHCAL','globalValidationHCAL','postValidation_HCAL'], #
-                   'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'], #
+                   'trackingValidation': ['globalPrevalidationTracking','globalValidationTrackingOnly','postValidationTracking'],
+                   'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'],
+                   'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'],
+                   'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'],
+                   'electronOnlyValidation' : ['', 'electronValidationSequence', 'electronPostValidationSequence'],
+                   'hcalOnlyValidation' : ['globalPrevalidationHCAL','globalValidationHCAL','postValidation_HCAL'],
+                   'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'],
                    'miniAODValidation' : ['prevalidationMiniAOD','validationMiniAOD','validationHarvestingMiniAOD'],
-                   'standardValidation' : ['prevalidation','validation','validationHarvesting'], # pas bon
-                   'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'], # pas bon
-                   'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'], #
-                   'MTDValidation' : ['', 'globalValidationMTD', ''], #
-                   'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'], #
+                   'standardValidation' : ['prevalidation','validation','validationHarvesting'],
+                   'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'],
+                   'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
+                   'MTDValidation' : ['', 'globalValidationMTD', ''],
+                   'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],
                  }
 
 _phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'bTagOnlyValidation','hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation']

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -20,4 +20,3 @@ _phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','J
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])
-print('A que coucou')

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -1,21 +1,23 @@
 autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLiteTracking','validationHarvesting'],
                    'trackingOnlyValidation' : ['globalPrevalidationTrackingOnly','globalValidationTrackingOnly','postValidation_trackingOnly'],
                    'pixelTrackingOnlyValidation' : ['globalPrevalidationPixelTrackingOnly','globalValidationPixelTrackingOnly','postValidation_trackingOnly'],
-                   'trackingValidation': ['globalPrevalidationTracking','globalValidationTrackingOnly','postValidationTracking'],
-                   'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'],
-                   'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'],
-                   'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'],
-                   'hcalOnlyValidation' : ['globalPrevalidationHCAL','globalValidationHCAL','postValidation_HCAL'],
-                   'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'],
+                   'trackingValidation': ['globalPrevalidationTracking','globalValidationTrackingOnly','postValidationTracking'], #
+                   'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'], #
+                   'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'], #
+                   'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'], #
+                   'electronOnlyValidation' : ['', 'electronValidationSequence', 'electronPostValidationSequence'], # OK
+                   'hcalOnlyValidation' : ['globalPrevalidationHCAL','globalValidationHCAL','postValidation_HCAL'], #
+                   'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'], #
                    'miniAODValidation' : ['prevalidationMiniAOD','validationMiniAOD','validationHarvestingMiniAOD'],
-                   'standardValidation' : ['prevalidation','validation','validationHarvesting'],
-                   'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'],
-                   'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
-                   'MTDValidation' : ['', 'globalValidationMTD', ''],
-                   'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],
+                   'standardValidation' : ['prevalidation','validation','validationHarvesting'], # pas bon
+                   'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'], # pas bon
+                   'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'], #
+                   'MTDValidation' : ['', 'globalValidationMTD', ''], #
+                   'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'], #
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation','bTagOnlyValidation','hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'bTagOnlyValidation','hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])
+print('A que coucou')


### PR DESCRIPTION
#### PR description:

add electronValidation sequence in Phase2 because RECO branches did not appear into the root files (only the miniAOD ones). One line added in Validation/Configuration/python/autoValidation.py and one one sequence (electronOnlyValidation) added in autoValidation. 

#### PR validation:

tests with :

27434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D35_GenSimHLBeamSpotFull14+DigiFullTrigger_2023D35+RecoFullGlobal_2023D35+HARVESTFullGlobal_2023D35/
29434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D42_GenSimHLBeamSpotFull14+DigiFullTrigger_2023D42+RecoFullGlobal_2023D42+HARVESTFullGlobal_2023D42/
20434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+DigiFullTrigger_2023D19+RecoFullGlobal_2023D19+HARVESTFullGlobal_2023D19/
20034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/
11624.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_2021+RecoFull_2021+HARVESTFull_2021+ALCAFull_2021/
10824.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2018_GenSimFull+DigiFull_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018/

and all ran perfectly (the 2 last tests (11624 & 10824) are made to verify if the introduction did not alter the results.). 

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch -> OK
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html) -> OK
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) -> OK

@beaudett 
