### PR TITLE
Remove ListOfRecordToMerge configuration parameter from SiPixelQualityESProducer

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
@@ -71,21 +71,6 @@ SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf
 {
   edm::LogInfo("SiPixelQualityESProducer::SiPixelQualityESProducer");
 
-  // The following check is done only because the earlier code
-  // (essentially) threw an exception if either of the parameters were
-  // missing. I'm not sure if that is really required (in which case
-  // the whole parameter could be removed).
-  auto toGet = conf_.getParameter<std::vector< edm::ParameterSet >>("ListOfRecordToMerge");
-  auto throwIfNotFound = [&toGet](const std::string& recordName) {
-    if(std::find_if(toGet.begin(), toGet.end(), [&recordName](const edm::ParameterSet& pset) {
-          return pset.getParameter<std::string>("record") == recordName;
-        }) == toGet.end()) {
-      throw cms::Exception("Configuration") << "Did not find a PSet with record='" << recordName << "' from ListOfRecordToMerge";
-    }
-  };
-  throwIfNotFound("SiPixelDetVOffRcd");
-  throwIfNotFound("SiPixelQualityFromDbRcd");
-
   auto label = conf_.exists("siPixelQualityLabel")?conf_.getParameter<std::string>("siPixelQualityLabel"):std::string{};
   auto setConsumes = [](edm::ESConsumesCollector&& cc, Tokens& tokens, const std::string& label) {
     cc.setConsumes(tokens.voffToken_).setConsumes(tokens.dbobjectToken_, edm::ESInputTag{"", label});

--- a/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
@@ -1,14 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelQualityESProducer = cms.ESProducer(
-    "SiPixelQualityESProducer",
-    ListOfRecordToMerge = cms.VPSet(
-        cms.PSet(  record = cms.string( "SiPixelQualityFromDbRcd" ),
-                   tag = cms.string( "" )
-                   ),
-        cms.PSet(  record = cms.string( "SiPixelDetVOffRcd" ),
-                   tag = cms.string( "" )
-                   )
-        ),
+siPixelQualityESProducer = cms.ESProducer("SiPixelQualityESProducer",
     siPixelQualityLabel = cms.string(""),
-    )
+)


### PR DESCRIPTION
#### PR description:

Following the comment https://github.com/cms-sw/cmssw/pull/27042#discussion_r289608117 this PR proposes to remove the `ListOfRecordToMerge` parameter from `SiPixelQualityESProducer` as the parameter is no longer used. I also removed the parameter from the `cfi` file, but a larger cleanup on configuration fragments/files could also be done.

#### PR validation:

Code compiles.