### PR TITLE
Update global tags to include new EGamma regression

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -46,7 +46,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v4',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '106X_mcRun1_design_v2',
+    'run1_design'       :   '106X_mcRun1_design_v3',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '106X_mcRun1_realistic_v2',
+    'run1_mc'           :   '106X_mcRun1_realistic_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '106X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '106X_mcRun1_pA_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '106X_mcRun2_startup_v3',
+    'run2_mc_50ns'      :   '106X_mcRun2_startup_v4',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v3',
+    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '106X_mcRun2_design_v4',
+    'run2_design'       :   '106X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '106X_mcRun2_asymptotic_v4',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '106X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v12',
+    'run1_data'         :   '106X_dataRun2_v13',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v12',
+    'run2_data'         :   '106X_dataRun2_v13',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v11',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v12',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v7',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v8',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v8',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v9',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -52,25 +52,25 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v4',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_upgrade2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '106X_upgrade2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '106X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '106X_upgrade2023_realistic_v5'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '106X_mcRun1_design_forPR26892_v1',
+    'run1_design'       :   '106X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '106X_mcRun1_realistic_forPR26892_v1',
+    'run1_mc'           :   '106X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_forPR26892_v1',
+    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '106X_mcRun1_pA_forPR26892_v1',
+    'run1_mc_pa'        :   '106X_mcRun1_pA_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '106X_mcRun2_startup_forPR26892_v2',
+    'run2_mc_50ns'      :   '106X_mcRun2_startup_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_forPR26892_v2',
+    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '106X_mcRun2_design_forPR26892_v3',
+    'run2_design'       :   '106X_mcRun2_design_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '106X_mcRun2_asymptotic_forPR26892_v3',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_forPR26892_v2',
+    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '106X_mcRun2_pA_forPR26892_v2',
+    'run2_mc_pa'        :   '106X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_forPR26892_v11',
+    'run1_data'         :   '106X_dataRun2_v12',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_forPR26892_v11',
+    'run2_data'         :   '106X_dataRun2_v12',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_forPR26892_v10',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v11',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_forPR26892_v6',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_forPR26892_v7',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_forPR26892_v7',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v8',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,33 +44,33 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_forPR26892_v4',
+    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_forPR26892_v3',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_forPR26892_v3',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_forPR26892_v4',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_forPR26892_v2',
+    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_forPR26892_v4',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_upgrade2021_design_forPR26892_v1', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '106X_upgrade2021_design_v2', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_forPR26892_v5', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '106X_upgrade2023_realistic_forPR26892_v3'
+    'phase2_realistic'         : '106X_upgrade2023_realistic_v4'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '106X_mcRun1_design_v1',
+    'run1_design'       :   '106X_mcRun1_design_forPR26892_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '106X_mcRun1_realistic_v1',
+    'run1_mc'           :   '106X_mcRun1_realistic_forPR26892_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_forPR26892_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '106X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '106X_mcRun1_pA_forPR26892_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '106X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '106X_mcRun2_startup_forPR26892_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v2',
+    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_forPR26892_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '106X_mcRun2_design_v3',
+    'run2_design'       :   '106X_mcRun2_design_forPR26892_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '106X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_forPR26892_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_forPR26892_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '106X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '106X_mcRun2_pA_forPR26892_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v11',
+    'run1_data'         :   '106X_dataRun2_forPR26892_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v11',
+    'run2_data'         :   '106X_dataRun2_forPR26892_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v10',
+    'run2_data_relval'  :   '106X_dataRun2_relval_forPR26892_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v6',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_forPR26892_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v7',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v7',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_forPR26892_v7',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_forPR26892_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,33 +44,33 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v4',
+    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_forPR26892_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_forPR26892_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v3',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_forPR26892_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_forPR26892_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_forPR26892_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v4',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_forPR26892_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_upgrade2021_design_v1', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '106X_upgrade2021_design_forPR26892_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_forPR26892_v5', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '106X_upgrade2023_realistic_v3'
+    'phase2_realistic'         : '106X_upgrade2023_realistic_forPR26892_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,7 +56,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v3',
+    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:

This PR adds test GTs needed to test PR #26892 and should be merged simultaneously with that PR. I created a separate PR so that I could launch the PR tests myself now but the two PRs could be merged if that's more convenient. The naming of the GTs will be fixed with the autoCond update that finalizes the 2017 UL data and MC GTs. The diffs of the changed GTs with respect to the current autoCond GTs are below:

106X_mcRun1_design_forPR26892_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_design_forPR26892_v1/106X_mcRun1_design_v1
106X_mcRun1_realistic_forPR26892_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_realistic_forPR26892_v1/106X_mcRun1_realistic_v1
106X_mcRun1_HeavyIon_forPR26892_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_HeavyIon_forPR26892_v1/106X_mcRun1_HeavyIon_v1
106X_mcRun1_pA_forPR26892_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_pA_forPR26892_v1/106X_mcRun1_pA_v1
106X_mcRun2_startup_forPR26892_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_startup_forPR26892_v2/106X_mcRun2_startup_v2
106X_mcRun2_asymptotic_l1stage1_forPR26892_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_l1stage1_forPR26892_v2/106X_mcRun2_asymptotic_l1stage1_v2
106X_mcRun2_design_forPR26892_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_design_forPR26892_v3/106X_mcRun2_design_v3
106X_mcRun2_asymptotic_forPR26892_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_forPR26892_v3/106X_mcRun2_asymptotic_v3
106X_mcRun2_HeavyIon_forPR26892_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_HeavyIon_forPR26892_v2/106X_mcRun2_HeavyIon_v2
106X_mcRun2_pA_forPR26892_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_pA_forPR26892_v2/106X_mcRun2_pA_v2
106X_dataRun2_forPR26892_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_forPR26892_v11/106X_dataRun2_v11
106X_dataRun2_relval_forPR26892_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_forPR26892_v10/106X_dataRun2_relval_v10
106X_dataRun2_PromptLike_HEfail_forPR26892_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_forPR26892_v6/106X_dataRun2_PromptLike_HEfail_v6
106X_dataRun2_PromptLike_forPR26892_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_forPR26892_v7/106X_dataRun2_PromptLike_v7
106X_dataRun2_PromptLike_HI_forPR26892_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_forPR26892_v7/106X_dataRun2_PromptLike_HI_v7
106X_mc2017_design_IdealBS_forPR26892_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_design_IdealBS_forPR26892_v4/106X_mc2017_design_IdealBS_v4
106X_mc2017_realistic_forPR26892_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_forPR26892_v3/106X_mc2017_realistic_v3
106X_upgrade2018_design_forPR26892_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_design_forPR26892_v3/106X_upgrade2018_design_v3
106X_upgrade2018_realistic_forPR26892_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_forPR26892_v4/106X_upgrade2018_realistic_v4
106X_upgrade2018_realistic_HI_forPR26892_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HI_forPR26892_v2/106X_upgrade2018_realistic_HI_v2
106X_upgrade2018_realistic_HEfail_forPR26892_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_forPR26892_v4/106X_upgrade2018_realistic_HEfail_v4
106X_upgrade2021_design_forPR26892_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_design_forPR26892_v1/106X_upgrade2021_design_v1
106X_upgrade2021_realistic_forPR26892_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_forPR26892_v5/106X_upgrade2021_realistic_v5
106X_upgrade2023_realistic_forPR26892_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2023_realistic_forPR26892_v3/106X_upgrade2023_realistic_v3

#### PR validation:

Tested with PR #26892 on workflow 27434.0.

#### if this PR is a backport please specify the original PR:

This PR will need to be backported to 10_6_X.