### PR TITLE
Returning a lost method call in DQM bin by bin comparison tool

### DIFF
--- a/DQMServices/FileIO/scripts/compareHistograms.py
+++ b/DQMServices/FileIO/scripts/compareHistograms.py
@@ -165,7 +165,7 @@ def flatten_file(file, run_nr):
    return result
 
 def traverse_till_end(node, dirs_list, result, run_nr):
-   new_dir_list = dirs_list + [node.GetName()]
+   new_dir_list = dirs_list + [get_node_name(node)]
    if hasattr(node, 'GetListOfKeys'): 
       for key in node.GetListOfKeys():
          traverse_till_end(key.ReadObj(), new_dir_list, result, run_nr)


### PR DESCRIPTION
#### PR description:

Returning the somehow lost method call. This should have been committed here: #27085 

#### PR validation:

A tool was validated locally.
