### PR TITLE
Herwig7 hadron flavour identification - backport to 102X

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -160,6 +160,8 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
        partonMode_="Herwig6";
      else if( moduleName.find("ThePEG")!=std::string::npos )
        partonMode_="Herwig++";
+     else if( moduleName.find("Herwig7")!=std::string::npos )
+       partonMode_="Herwig++";
      else if( moduleName.find("Sherpa")!=std::string::npos )
        partonMode_="Sherpa";
      else
@@ -251,18 +253,21 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
        leptons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
    }
 
-   // select partons
+   // select algorithmic partons
+
    if ( partonMode_!="Undefined" ) {
      partonSelector_->run(particles,partons);
-     for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
-     {
-      if(!fullChainPhysPartons_)
-      {
-         if( !(it->status()==3 || (( partonMode_=="Pythia8" ) && (it->status()==23)))) continue;
-      }
-       if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
-       physicsPartons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
-     }
+   }
+
+   // select physics partons
+   for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
+   {
+    if(!fullChainPhysPartons_)
+    {
+       if( !(it->status()==3 || (( partonMode_=="Pythia8" ) && (it->status()==23)))) continue;
+    }
+     if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
+     physicsPartons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
    }
 
    iEvent.put(std::move(bHadrons), "bHadrons" );


### PR DESCRIPTION
#### PR description:

A backport of https://github.com/cms-sw/cmssw/pull/26885 (incorporation of hadron flavour identification with Herwig7) to 102X 