### PR TITLE
Running code-format for generators

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/DQMRivetClient.h
+++ b/GeneratorInterface/RivetInterface/interface/DQMRivetClient.h
@@ -12,36 +12,36 @@
 class DQMStore;
 class MonitorElement;
 
-class DQMRivetClient : public edm::EDAnalyzer 
-{
- public:
+class DQMRivetClient : public edm::EDAnalyzer {
+public:
   DQMRivetClient(const edm::ParameterSet& pset);
-  ~DQMRivetClient() override {};
+  ~DQMRivetClient() override{};
 
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override {};
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override{};
 
   void endJob() override;
 
   /// EndRun
   void endRun(const edm::Run& r, const edm::EventSetup& c) override;
-  
-  struct LumiOption
-  {
+
+  struct LumiOption {
     std::string name, normHistName;
     double xsection;
   };
 
-  struct ScaleFactorOption
-  {
+  struct ScaleFactorOption {
     std::string name;
     double scale;
   };
 
   void normalizeToIntegral(const std::string& startDir, const std::string& histName, const std::string& normHistName);
-  void normalizeToLumi(const std::string& startDir, const std::string& histName, const std::string& normHistName, double xsection);
+  void normalizeToLumi(const std::string& startDir,
+                       const std::string& histName,
+                       const std::string& normHistName,
+                       double xsection);
   void scaleByFactor(const std::string& startDir, const std::string& histName, double factor);
 
- private:
+private:
   unsigned int verbose_;
 
   DQMStore* theDQM;
@@ -51,8 +51,6 @@ class DQMRivetClient : public edm::EDAnalyzer
   std::vector<DQMGenericClient::NormOption> normOptions_;
   std::vector<LumiOption> lumiOptions_;
   std::vector<ScaleFactorOption> scaleOptions_;
-
-
 };
 
 #endif

--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -15,30 +15,33 @@
 #include "Rivet/AnalysisHandler.hh"
 #include "GeneratorInterface/RivetInterface/interface/RivetAnalysis.h"
 
-class ParticleLevelProducer : public edm::one::EDProducer<edm::one::SharedResources>
-{
+class ParticleLevelProducer : public edm::one::EDProducer<edm::one::SharedResources> {
 public:
   ParticleLevelProducer(const edm::ParameterSet& pset);
   ~ParticleLevelProducer() override {}
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
-  void addGenJet(Rivet::Jet jet, std::unique_ptr<reco::GenJetCollection> &jets,
-                 std::unique_ptr<reco::GenParticleCollection> &consts, edm::RefProd<reco::GenParticleCollection>& constsRefHandle, int &iConstituent,
-                 std::unique_ptr<reco::GenParticleCollection> &tags, edm::RefProd<reco::GenParticleCollection>& tagsRefHandle, int &iTag);
-  
-  template<typename T> reco::Candidate::LorentzVector p4(const T& p) const
-  {
+  void addGenJet(Rivet::Jet jet,
+                 std::unique_ptr<reco::GenJetCollection>& jets,
+                 std::unique_ptr<reco::GenParticleCollection>& consts,
+                 edm::RefProd<reco::GenParticleCollection>& constsRefHandle,
+                 int& iConstituent,
+                 std::unique_ptr<reco::GenParticleCollection>& tags,
+                 edm::RefProd<reco::GenParticleCollection>& tagsRefHandle,
+                 int& iTag);
+
+  template <typename T>
+  reco::Candidate::LorentzVector p4(const T& p) const {
     return reco::Candidate::LorentzVector(p.px(), p.py(), p.pz(), p.energy());
   }
 
   const edm::EDGetTokenT<edm::HepMCProduct> srcToken_;
 
   reco::Particle::Point genVertex_;
-  
+
   Rivet::RivetAnalysis* rivetAnalysis_;
   Rivet::AnalysisHandler analysisHandler_;
-
 };
 
 #endif

--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -21,168 +21,161 @@
 namespace Rivet {
 
   class RivetAnalysis : public Analysis {
+  public:
+    ParticleVector leptons() const { return _leptons; }
+    ParticleVector photons() const { return _photons; }
+    ParticleVector neutrinos() const { return _neutrinos; }
+    Jets jets() const { return _jets; }
+    Jets fatjets() const { return _fatjets; }
+    Vector3 met() const { return _met; }
 
-    public:
-      ParticleVector leptons() const {return _leptons;}
-      ParticleVector photons() const {return _photons;}
-      ParticleVector neutrinos() const {return _neutrinos;}
-      Jets jets() const {return _jets;}
-      Jets fatjets() const {return _fatjets;}
-      Vector3 met() const {return _met;}
+  private:
+    bool _usePromptFinalStates;
+    bool _excludePromptLeptonsFromJetClustering;
+    bool _excludeNeutrinosFromJetClustering;
 
-    private:
-      bool _usePromptFinalStates;
-      bool _excludePromptLeptonsFromJetClustering;
-      bool _excludeNeutrinosFromJetClustering;
-      
-      double _particleMinPt, _particleMaxEta;
-      double _lepConeSize, _lepMinPt, _lepMaxEta;
-      double _jetConeSize, _jetMinPt, _jetMaxEta;
-      double _fatJetConeSize, _fatJetMinPt, _fatJetMaxEta;
-      
-      ParticleVector _leptons, _photons, _neutrinos;
-      Jets _jets, _fatjets;
-      Vector3 _met;
+    double _particleMinPt, _particleMaxEta;
+    double _lepConeSize, _lepMinPt, _lepMaxEta;
+    double _jetConeSize, _jetMinPt, _jetMaxEta;
+    double _fatJetConeSize, _fatJetMinPt, _fatJetMaxEta;
 
-    public:
-      RivetAnalysis(const edm::ParameterSet& pset) : Analysis("RivetAnalysis"),
-      _usePromptFinalStates(pset.getParameter<bool>("usePromptFinalStates")),
-      _excludePromptLeptonsFromJetClustering(pset.getParameter<bool>("excludePromptLeptonsFromJetClustering")),
-      _excludeNeutrinosFromJetClustering(pset.getParameter<bool>("excludeNeutrinosFromJetClustering")),
+    ParticleVector _leptons, _photons, _neutrinos;
+    Jets _jets, _fatjets;
+    Vector3 _met;
 
-      _particleMinPt  (pset.getParameter<double>("particleMinPt")),
-      _particleMaxEta (pset.getParameter<double>("particleMaxEta")),
-      
-      _lepConeSize (pset.getParameter<double>("lepConeSize")),
-      _lepMinPt    (pset.getParameter<double>("lepMinPt")),
-      _lepMaxEta   (pset.getParameter<double>("lepMaxEta")),
-      
-      _jetConeSize (pset.getParameter<double>("jetConeSize")),
-      _jetMinPt    (pset.getParameter<double>("jetMinPt")),
-      _jetMaxEta   (pset.getParameter<double>("jetMaxEta")),
-      
-      _fatJetConeSize (pset.getParameter<double>("fatJetConeSize")),
-      _fatJetMinPt    (pset.getParameter<double>("fatJetMinPt")),
-      _fatJetMaxEta   (pset.getParameter<double>("fatJetMaxEta"))
-      {
-      }
+  public:
+    RivetAnalysis(const edm::ParameterSet& pset)
+        : Analysis("RivetAnalysis"),
+          _usePromptFinalStates(pset.getParameter<bool>("usePromptFinalStates")),
+          _excludePromptLeptonsFromJetClustering(pset.getParameter<bool>("excludePromptLeptonsFromJetClustering")),
+          _excludeNeutrinosFromJetClustering(pset.getParameter<bool>("excludeNeutrinosFromJetClustering")),
 
-      // Initialize Rivet projections
-      void init() override {
-        // Cuts
-        Cut particle_cut = (Cuts::abseta < _particleMaxEta) and (Cuts::pT > _particleMinPt*GeV);
-        Cut lepton_cut   = (Cuts::abseta < _lepMaxEta)      and (Cuts::pT > _lepMinPt*GeV);
-        
-        // Generic final state
-        FinalState fs(particle_cut);
-        
-        // Dressed leptons
-        ChargedLeptons charged_leptons(fs);
-        IdentifiedFinalState photons(fs);
-        photons.acceptIdPair(PID::PHOTON);
-        
-        PromptFinalState prompt_leptons(charged_leptons);
-        prompt_leptons.acceptMuonDecays(true);
-        prompt_leptons.acceptTauDecays(true);
-        addProjection(prompt_leptons, "PromptLeptons");
-        
-        PromptFinalState prompt_photons(photons);
-        prompt_photons.acceptMuonDecays(true);
-        prompt_photons.acceptTauDecays(true);
-        
-        // useDecayPhotons=true allows for photons with tau ancestor,
-        // photons from hadrons are vetoed by the PromptFinalState;
-        // will be default DressedLeptons behaviour for Rivet >= 2.5.4
-        DressedLeptons dressed_leptons(prompt_photons, prompt_leptons, _lepConeSize, 
-                       lepton_cut, /*useDecayPhotons*/ true);
-        if (not _usePromptFinalStates)
-          dressed_leptons = DressedLeptons(photons, charged_leptons, _lepConeSize, 
-                            lepton_cut, /*useDecayPhotons*/ true);
-        addProjection(dressed_leptons, "DressedLeptons");
-        
-        // Photons
-        if (_usePromptFinalStates) {
-          // We remove the photons used up for lepton dressing in this case
-          VetoedFinalState vetoed_prompt_photons(prompt_photons);
-          vetoed_prompt_photons.addVetoOnThisFinalState(dressed_leptons);
-          addProjection(vetoed_prompt_photons, "Photons");
-        }
-        else
-          addProjection(photons, "Photons");
-        
-        // Jets
-        VetoedFinalState fsForJets(fs);
-        if (_usePromptFinalStates and _excludePromptLeptonsFromJetClustering)
-          fsForJets.addVetoOnThisFinalState(dressed_leptons);
-        JetAlg::InvisiblesStrategy invisiblesStrategy = JetAlg::DECAY_INVISIBLES;
-        if (_excludeNeutrinosFromJetClustering)
-          invisiblesStrategy = JetAlg::NO_INVISIBLES;
-        addProjection(FastJets(fsForJets, FastJets::ANTIKT, _jetConeSize,
-                               JetAlg::ALL_MUONS, invisiblesStrategy), "Jets");
-        
-        // FatJets
-        addProjection(FastJets(fsForJets, FastJets::ANTIKT, _fatJetConeSize), "FatJets");
-        
-        // Neutrinos
-        IdentifiedFinalState neutrinos(fs);
-        neutrinos.acceptNeutrinos();
-        if (_usePromptFinalStates) {
-          PromptFinalState prompt_neutrinos(neutrinos);
-          prompt_neutrinos.acceptMuonDecays(true);
-          prompt_neutrinos.acceptTauDecays(true);
-          addProjection(prompt_neutrinos, "Neutrinos");
-        }
-        else
-          addProjection(neutrinos, "Neutrinos");
-        
-        // MET
-        addProjection(MissingMomentum(fs), "MET");
-      };
+          _particleMinPt(pset.getParameter<double>("particleMinPt")),
+          _particleMaxEta(pset.getParameter<double>("particleMaxEta")),
 
-      // Apply Rivet projections
-      void analyze(const Event& event) override {
-        _jets.clear();
-        _fatjets.clear();
-        _leptons.clear();
-        _photons.clear();
-        _neutrinos.clear();
-        
-        // Get analysis objects from projections
-        Cut jet_cut    = (Cuts::abseta < _jetMaxEta)    and (Cuts::pT > _jetMinPt*GeV);
-        Cut fatjet_cut = (Cuts::abseta < _fatJetMaxEta) and (Cuts::pT > _fatJetMinPt*GeV);
-        
-        _leptons   = applyProjection<DressedLeptons>(event, "DressedLeptons").particlesByPt();
-        // search tau ancestors
-        Particles promptleptons = applyProjection<PromptFinalState>(event, "PromptLeptons").particles();
-        for ( auto & lepton : _leptons ) {
-          const auto & cl = lepton.constituents().front(); // this has no ancestors anymore :(
-          for ( auto const & pl : promptleptons ) {
-            if (cl.momentum() == pl.momentum()) {
-              for ( auto & p : pl.ancestors()) {
-                if (p.abspid() == 15) {
-                  p.setMomentum(p.momentum()*10e-20);
-                  lepton.addConstituent(p, false);
-                }
+          _lepConeSize(pset.getParameter<double>("lepConeSize")),
+          _lepMinPt(pset.getParameter<double>("lepMinPt")),
+          _lepMaxEta(pset.getParameter<double>("lepMaxEta")),
+
+          _jetConeSize(pset.getParameter<double>("jetConeSize")),
+          _jetMinPt(pset.getParameter<double>("jetMinPt")),
+          _jetMaxEta(pset.getParameter<double>("jetMaxEta")),
+
+          _fatJetConeSize(pset.getParameter<double>("fatJetConeSize")),
+          _fatJetMinPt(pset.getParameter<double>("fatJetMinPt")),
+          _fatJetMaxEta(pset.getParameter<double>("fatJetMaxEta")) {}
+
+    // Initialize Rivet projections
+    void init() override {
+      // Cuts
+      Cut particle_cut = (Cuts::abseta < _particleMaxEta) and (Cuts::pT > _particleMinPt * GeV);
+      Cut lepton_cut = (Cuts::abseta < _lepMaxEta) and (Cuts::pT > _lepMinPt * GeV);
+
+      // Generic final state
+      FinalState fs(particle_cut);
+
+      // Dressed leptons
+      ChargedLeptons charged_leptons(fs);
+      IdentifiedFinalState photons(fs);
+      photons.acceptIdPair(PID::PHOTON);
+
+      PromptFinalState prompt_leptons(charged_leptons);
+      prompt_leptons.acceptMuonDecays(true);
+      prompt_leptons.acceptTauDecays(true);
+      addProjection(prompt_leptons, "PromptLeptons");
+
+      PromptFinalState prompt_photons(photons);
+      prompt_photons.acceptMuonDecays(true);
+      prompt_photons.acceptTauDecays(true);
+
+      // useDecayPhotons=true allows for photons with tau ancestor,
+      // photons from hadrons are vetoed by the PromptFinalState;
+      // will be default DressedLeptons behaviour for Rivet >= 2.5.4
+      DressedLeptons dressed_leptons(
+          prompt_photons, prompt_leptons, _lepConeSize, lepton_cut, /*useDecayPhotons*/ true);
+      if (not _usePromptFinalStates)
+        dressed_leptons = DressedLeptons(photons, charged_leptons, _lepConeSize, lepton_cut, /*useDecayPhotons*/ true);
+      addProjection(dressed_leptons, "DressedLeptons");
+
+      // Photons
+      if (_usePromptFinalStates) {
+        // We remove the photons used up for lepton dressing in this case
+        VetoedFinalState vetoed_prompt_photons(prompt_photons);
+        vetoed_prompt_photons.addVetoOnThisFinalState(dressed_leptons);
+        addProjection(vetoed_prompt_photons, "Photons");
+      } else
+        addProjection(photons, "Photons");
+
+      // Jets
+      VetoedFinalState fsForJets(fs);
+      if (_usePromptFinalStates and _excludePromptLeptonsFromJetClustering)
+        fsForJets.addVetoOnThisFinalState(dressed_leptons);
+      JetAlg::InvisiblesStrategy invisiblesStrategy = JetAlg::DECAY_INVISIBLES;
+      if (_excludeNeutrinosFromJetClustering)
+        invisiblesStrategy = JetAlg::NO_INVISIBLES;
+      addProjection(FastJets(fsForJets, FastJets::ANTIKT, _jetConeSize, JetAlg::ALL_MUONS, invisiblesStrategy), "Jets");
+
+      // FatJets
+      addProjection(FastJets(fsForJets, FastJets::ANTIKT, _fatJetConeSize), "FatJets");
+
+      // Neutrinos
+      IdentifiedFinalState neutrinos(fs);
+      neutrinos.acceptNeutrinos();
+      if (_usePromptFinalStates) {
+        PromptFinalState prompt_neutrinos(neutrinos);
+        prompt_neutrinos.acceptMuonDecays(true);
+        prompt_neutrinos.acceptTauDecays(true);
+        addProjection(prompt_neutrinos, "Neutrinos");
+      } else
+        addProjection(neutrinos, "Neutrinos");
+
+      // MET
+      addProjection(MissingMomentum(fs), "MET");
+    };
+
+    // Apply Rivet projections
+    void analyze(const Event& event) override {
+      _jets.clear();
+      _fatjets.clear();
+      _leptons.clear();
+      _photons.clear();
+      _neutrinos.clear();
+
+      // Get analysis objects from projections
+      Cut jet_cut = (Cuts::abseta < _jetMaxEta) and (Cuts::pT > _jetMinPt * GeV);
+      Cut fatjet_cut = (Cuts::abseta < _fatJetMaxEta) and (Cuts::pT > _fatJetMinPt * GeV);
+
+      _leptons = applyProjection<DressedLeptons>(event, "DressedLeptons").particlesByPt();
+      // search tau ancestors
+      Particles promptleptons = applyProjection<PromptFinalState>(event, "PromptLeptons").particles();
+      for (auto& lepton : _leptons) {
+        const auto& cl = lepton.constituents().front();  // this has no ancestors anymore :(
+        for (auto const& pl : promptleptons) {
+          if (cl.momentum() == pl.momentum()) {
+            for (auto& p : pl.ancestors()) {
+              if (p.abspid() == 15) {
+                p.setMomentum(p.momentum() * 10e-20);
+                lepton.addConstituent(p, false);
               }
-              break;
             }
+            break;
           }
         }
-        
-        _jets      = applyProjection<FastJets>(event, "Jets").jetsByPt(jet_cut);
-        _fatjets   = applyProjection<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
-        _photons   = applyProjection<FinalState>(event, "Photons").particlesByPt();
-        _neutrinos = applyProjection<FinalState>(event, "Neutrinos").particlesByPt();
-        _met       = applyProjection<MissingMomentum>(event, "MET").missingMomentum().p3();
-      };
+      }
 
-      // Do nothing here
-      void finalize() override {};
+      _jets = applyProjection<FastJets>(event, "Jets").jetsByPt(jet_cut);
+      _fatjets = applyProjection<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
+      _photons = applyProjection<FinalState>(event, "Photons").particlesByPt();
+      _neutrinos = applyProjection<FinalState>(event, "Neutrinos").particlesByPt();
+      _met = applyProjection<MissingMomentum>(event, "MET").missingMomentum().p3();
+    };
 
-      std::string status() const override { return "VALIDATED"; }
+    // Do nothing here
+    void finalize() override{};
 
+    std::string status() const override { return "VALIDATED"; }
   };
 
-}
+}  // namespace Rivet
 
 #endif

--- a/GeneratorInterface/RivetInterface/plugins/DQMRivetClient.cc
+++ b/GeneratorInterface/RivetInterface/plugins/DQMRivetClient.cc
@@ -30,31 +30,28 @@ typedef MonitorElement ME;
 
 TPRegexp metacharacters("[\\^\\$\\.\\*\\+\\?\\|\\(\\)\\{\\}\\[\\]]");
 
-DQMRivetClient::DQMRivetClient(const ParameterSet& pset)
-{
-  
+DQMRivetClient::DQMRivetClient(const ParameterSet& pset) {
   typedef std::vector<edm::ParameterSet> VPSet;
   typedef std::vector<std::string> vstring;
   typedef boost::escaped_list_separator<char> elsc;
 
-  elsc commonEscapes("\\", " \t", "\'"); 
+  elsc commonEscapes("\\", " \t", "\'");
 
   // Parse Normalization commands
   vstring normCmds = pset.getUntrackedParameter<vstring>("normalizationToIntegral", vstring());
-  for ( vstring::const_iterator normCmd = normCmds.begin();
-        normCmd != normCmds.end(); ++normCmd )
-  {
-    if ( normCmd->empty() ) continue;
+  for (vstring::const_iterator normCmd = normCmds.begin(); normCmd != normCmds.end(); ++normCmd) {
+    if (normCmd->empty())
+      continue;
     boost::tokenizer<elsc> tokens(*normCmd, commonEscapes);
 
     vector<string> args;
-    for(boost::tokenizer<elsc>::const_iterator iToken = tokens.begin();
-        iToken != tokens.end(); ++iToken) {
-      if ( iToken->empty() ) continue;
+    for (boost::tokenizer<elsc>::const_iterator iToken = tokens.begin(); iToken != tokens.end(); ++iToken) {
+      if (iToken->empty())
+        continue;
       args.push_back(*iToken);
     }
 
-    if ( args.empty() or args.size() > 2 ) {
+    if (args.empty() or args.size() > 2) {
       LogInfo("DQMRivetClient") << "Wrong input to normCmds\n";
       continue;
     }
@@ -67,9 +64,7 @@ DQMRivetClient::DQMRivetClient(const ParameterSet& pset)
   }
 
   VPSet normSets = pset.getUntrackedParameter<VPSet>("normalizationToIntegralSets", VPSet());
-  for ( VPSet::const_iterator normSet = normSets.begin();
-        normSet != normSets.end(); ++normSet )
-  {
+  for (VPSet::const_iterator normSet = normSets.begin(); normSet != normSets.end(); ++normSet) {
     DQMGenericClient::NormOption opt;
     opt.name = normSet->getUntrackedParameter<string>("name");
     opt.normHistName = normSet->getUntrackedParameter<string>("normalizedTo", opt.name);
@@ -77,52 +72,50 @@ DQMRivetClient::DQMRivetClient(const ParameterSet& pset)
     normOptions_.push_back(opt);
   }
 
-  //normalize to lumi 
+  //normalize to lumi
   vstring lumiCmds = pset.getUntrackedParameter<vstring>("normalizationToLumi", vstring());
-  for ( vstring::const_iterator lumiCmd = lumiCmds.begin();
-        lumiCmd != lumiCmds.end(); ++lumiCmd )
-  {
-    if ( lumiCmd->empty() ) continue;
+  for (vstring::const_iterator lumiCmd = lumiCmds.begin(); lumiCmd != lumiCmds.end(); ++lumiCmd) {
+    if (lumiCmd->empty())
+      continue;
     boost::tokenizer<elsc> tokens(*lumiCmd, commonEscapes);
 
     vector<string> args;
-    for(boost::tokenizer<elsc>::const_iterator iToken = tokens.begin();
-        iToken != tokens.end(); ++iToken) {
-      if ( iToken->empty() ) continue;
+    for (boost::tokenizer<elsc>::const_iterator iToken = tokens.begin(); iToken != tokens.end(); ++iToken) {
+      if (iToken->empty())
+        continue;
       args.push_back(*iToken);
     }
 
-    if ( args.size() != 2 ) {
+    if (args.size() != 2) {
       LogInfo("DQMRivetClient") << "Wrong input to lumiCmds\n";
       continue;
     }
 
     DQMRivetClient::LumiOption opt;
     opt.name = args[0];
-    opt.normHistName = args[1] ;
+    opt.normHistName = args[1];
     opt.xsection = pset.getUntrackedParameter<double>("xsection", -1.);
     //opt.xsection = atof(args[2].c_str());
 
-    //std::cout << opt.name << " " << opt.normHistName << " " << opt.xsection << std::endl; 
+    //std::cout << opt.name << " " << opt.normHistName << " " << opt.xsection << std::endl;
     lumiOptions_.push_back(opt);
-  } 
+  }
 
   //multiply by a number
   vstring scaleCmds = pset.getUntrackedParameter<vstring>("scaleBy", vstring());
-  for ( vstring::const_iterator scaleCmd = scaleCmds.begin();
-        scaleCmd != scaleCmds.end(); ++scaleCmd )
-  {
-    if ( scaleCmd->empty() ) continue;
+  for (vstring::const_iterator scaleCmd = scaleCmds.begin(); scaleCmd != scaleCmds.end(); ++scaleCmd) {
+    if (scaleCmd->empty())
+      continue;
     boost::tokenizer<elsc> tokens(*scaleCmd, commonEscapes);
 
     vector<string> args;
-    for(boost::tokenizer<elsc>::const_iterator iToken = tokens.begin();
-        iToken != tokens.end(); ++iToken) {
-      if ( iToken->empty() ) continue;
+    for (boost::tokenizer<elsc>::const_iterator iToken = tokens.begin(); iToken != tokens.end(); ++iToken) {
+      if (iToken->empty())
+        continue;
       args.push_back(*iToken);
     }
 
-    if ( args.empty() or args.size() > 2 ) {
+    if (args.empty() or args.size() > 2) {
       LogInfo("DQMRivetClient") << "Wrong input to normCmds\n";
       continue;
     }
@@ -131,16 +124,13 @@ DQMRivetClient::DQMRivetClient(const ParameterSet& pset)
     opt.name = args[0];
     opt.scale = atof(args[1].c_str());
     scaleOptions_.push_back(opt);
-  }  
-   
+  }
 
   outputFileName_ = pset.getUntrackedParameter<string>("outputFileName", "");
   subDirs_ = pset.getUntrackedParameter<vstring>("subDirs");
-
 }
 
 void DQMRivetClient::endRun(const edm::Run& r, const edm::EventSetup& c) {
-
   typedef vector<string> vstring;
 
   // Update 2009-09-23
@@ -151,12 +141,10 @@ void DQMRivetClient::endRun(const edm::Run& r, const edm::EventSetup& c) {
   // It more robust to do the histogram manipulation in
   // this endRun function
 
-
-  
   theDQM = nullptr;
   theDQM = Service<DQMStore>().operator->();
 
-  if ( ! theDQM ) {
+  if (!theDQM) {
     LogInfo("DQMRivetClient") << "Cannot create DQMStore instance\n";
     return;
   }
@@ -164,115 +152,112 @@ void DQMRivetClient::endRun(const edm::Run& r, const edm::EventSetup& c) {
   // Process wildcard in the sub-directory
   set<string> subDirSet;
 
-  for(vstring::const_iterator iSubDir = subDirs_.begin();
-      iSubDir != subDirs_.end(); ++iSubDir) {
+  for (vstring::const_iterator iSubDir = subDirs_.begin(); iSubDir != subDirs_.end(); ++iSubDir) {
     string subDir = *iSubDir;
 
-    if ( subDir[subDir.size()-1] == '/' ) subDir.erase(subDir.size()-1);
+    if (subDir[subDir.size() - 1] == '/')
+      subDir.erase(subDir.size() - 1);
 
     subDirSet.insert(subDir);
   }
 
-  for(set<string>::const_iterator iSubDir = subDirSet.begin();
-      iSubDir != subDirSet.end(); ++iSubDir) {
+  for (set<string>::const_iterator iSubDir = subDirSet.begin(); iSubDir != subDirSet.end(); ++iSubDir) {
     const string& dirName = *iSubDir;
-    for ( vector<DQMGenericClient::NormOption>::const_iterator normOption = normOptions_.begin();
-          normOption != normOptions_.end(); ++normOption ){
+    for (vector<DQMGenericClient::NormOption>::const_iterator normOption = normOptions_.begin();
+         normOption != normOptions_.end();
+         ++normOption) {
       normalizeToIntegral(dirName, normOption->name, normOption->normHistName);
     }
   }
 
-  for(set<string>::const_iterator iSubDir = subDirSet.begin();
-      iSubDir != subDirSet.end(); ++iSubDir) {
+  for (set<string>::const_iterator iSubDir = subDirSet.begin(); iSubDir != subDirSet.end(); ++iSubDir) {
     const string& dirName = *iSubDir;
-    for ( vector<LumiOption>::const_iterator lumiOption = lumiOptions_.begin();
-          lumiOption != lumiOptions_.end(); ++lumiOption ){
+    for (vector<LumiOption>::const_iterator lumiOption = lumiOptions_.begin(); lumiOption != lumiOptions_.end();
+         ++lumiOption) {
       normalizeToLumi(dirName, lumiOption->name, lumiOption->normHistName, lumiOption->xsection);
     }
   }
 
-  for(set<string>::const_iterator iSubDir = subDirSet.begin();
-      iSubDir != subDirSet.end(); ++iSubDir) {
+  for (set<string>::const_iterator iSubDir = subDirSet.begin(); iSubDir != subDirSet.end(); ++iSubDir) {
     const string& dirName = *iSubDir;
-    for ( vector<ScaleFactorOption>::const_iterator scaleOption = scaleOptions_.begin();
-          scaleOption != scaleOptions_.end(); ++scaleOption ){
+    for (vector<ScaleFactorOption>::const_iterator scaleOption = scaleOptions_.begin();
+         scaleOption != scaleOptions_.end();
+         ++scaleOption) {
       scaleByFactor(dirName, scaleOption->name, scaleOption->scale);
     }
   }
 
-
-  if ( ! outputFileName_.empty() ) theDQM->save(outputFileName_);
-  
+  if (!outputFileName_.empty())
+    theDQM->save(outputFileName_);
 }
 
-void DQMRivetClient::endJob()
-{
-
+void DQMRivetClient::endJob() {
   // Update 2009-09-23
   // Migrated all code from here to endRun
 
-  LogTrace ("DQMRivetClient") << "inside of DQMGenericClient::endJob()"
-                                << endl;
-
+  LogTrace("DQMRivetClient") << "inside of DQMGenericClient::endJob()" << endl;
 }
 
-void DQMRivetClient::normalizeToIntegral(const std::string& startDir, const std::string& histName, const std::string& normHistName) 
-{
-  if ( ! theDQM->dirExists(startDir) ) {
+void DQMRivetClient::normalizeToIntegral(const std::string& startDir,
+                                         const std::string& histName,
+                                         const std::string& normHistName) {
+  if (!theDQM->dirExists(startDir)) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "Cannot find sub-directory " << startDir << endl;
+                              << "Cannot find sub-directory " << startDir << endl;
     return;
   }
 
   theDQM->cd();
 
-  ME* element = theDQM->get(startDir+"/"+histName);
-  ME* normME = theDQM->get(startDir+"/"+normHistName);
+  ME* element = theDQM->get(startDir + "/" + histName);
+  ME* normME = theDQM->get(startDir + "/" + normHistName);
 
-  if ( !element ) {
+  if (!element) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "No such element '" << histName << "' found\n";
+                              << "No such element '" << histName << "' found\n";
     return;
   }
 
-  if ( !normME ) {
+  if (!normME) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "No such element '" << normHistName << "' found\n";
+                              << "No such element '" << normHistName << "' found\n";
     return;
   }
 
-  TH1F* hist  = element->getTH1F();
-  if ( !hist) {
+  TH1F* hist = element->getTH1F();
+  if (!hist) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "Cannot create TH1F from ME\n";
+                              << "Cannot create TH1F from ME\n";
     return;
   }
 
   TH1F* normHist = normME->getTH1F();
-  if ( !normHist ) {
+  if (!normHist) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "Cannot create TH1F from ME\n";
+                              << "Cannot create TH1F from ME\n";
     return;
   }
 
   const double entries = normHist->Integral();
-  if ( entries != 0 ) {
-    hist->Scale(1./entries, "width");
-  }
-  else {
-    LogInfo("DQMRivetClient") << "normalizeToEntries() : " 
-                                   << "Zero entries in histogram\n";
+  if (entries != 0) {
+    hist->Scale(1. / entries, "width");
+  } else {
+    LogInfo("DQMRivetClient") << "normalizeToEntries() : "
+                              << "Zero entries in histogram\n";
   }
 
   return;
 }
 
-void DQMRivetClient::normalizeToLumi(const std::string& startDir, const std::string& histName, const std::string& normHistName, double xsection){
+void DQMRivetClient::normalizeToLumi(const std::string& startDir,
+                                     const std::string& histName,
+                                     const std::string& normHistName,
+                                     double xsection) {
   normalizeToIntegral(startDir, histName, normHistName);
   theDQM->cd();
-  ME* element = theDQM->get(startDir+"/"+histName);
-  TH1F* hist  = element->getTH1F();
-  if ( !hist) {
+  ME* element = theDQM->get(startDir + "/" + histName);
+  TH1F* hist = element->getTH1F();
+  if (!hist) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
                               << "Cannot create TH1F from ME\n";
     return;
@@ -281,27 +266,27 @@ void DQMRivetClient::normalizeToLumi(const std::string& startDir, const std::str
   return;
 }
 
-void DQMRivetClient::scaleByFactor(const std::string& startDir, const std::string& histName, double factor){
-  if ( ! theDQM->dirExists(startDir) ) {
+void DQMRivetClient::scaleByFactor(const std::string& startDir, const std::string& histName, double factor) {
+  if (!theDQM->dirExists(startDir)) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "Cannot find sub-directory " << startDir << endl;
+                              << "Cannot find sub-directory " << startDir << endl;
     return;
   }
 
   theDQM->cd();
 
-  ME* element = theDQM->get(startDir+"/"+histName);
+  ME* element = theDQM->get(startDir + "/" + histName);
 
-  if ( !element ) {
+  if (!element) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "No such element '" << histName << "' found\n";
+                              << "No such element '" << histName << "' found\n";
     return;
   }
 
-  TH1F* hist  = element->getTH1F();
-  if ( !hist) {
+  TH1F* hist = element->getTH1F();
+  if (!hist) {
     LogInfo("DQMRivetClient") << "normalizeToEntries() : "
-                                     << "Cannot create TH1F from ME\n";
+                              << "Cannot create TH1F from ME\n";
     return;
   }
   hist->Scale(factor);

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -24,11 +24,10 @@
 
 using namespace std;
 
-class GenParticles2HepMCConverter : public edm::stream::EDProducer<>
-{
+class GenParticles2HepMCConverter : public edm::stream::EDProducer<> {
 public:
   explicit GenParticles2HepMCConverter(const edm::ParameterSet& pset);
-  ~GenParticles2HepMCConverter() override {};
+  ~GenParticles2HepMCConverter() override{};
 
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
@@ -41,22 +40,19 @@ private:
   const double cmEnergy_;
 
 private:
-  inline HepMC::FourVector FourVector(const reco::Candidate::Point& point)
-  {
-    return HepMC::FourVector(10*point.x(), 10*point.y(), 10*point.z(), 0);
+  inline HepMC::FourVector FourVector(const reco::Candidate::Point& point) {
+    return HepMC::FourVector(10 * point.x(), 10 * point.y(), 10 * point.z(), 0);
   };
 
-  inline HepMC::FourVector FourVector(const reco::Candidate::LorentzVector& lvec)
-  {
+  inline HepMC::FourVector FourVector(const reco::Candidate::LorentzVector& lvec) {
     // Avoid negative mass, set minimum m^2 = 0
     return HepMC::FourVector(lvec.px(), lvec.py(), lvec.pz(), std::hypot(lvec.P(), std::max(0., lvec.mass())));
   };
-
-
 };
 
-GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet& pset):
-  cmEnergy_(pset.getUntrackedParameter<double>("cmEnergy", 13000)) // dummy value to set incident proton pz for particle gun samples
+GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet& pset)
+    : cmEnergy_(pset.getUntrackedParameter<double>(
+          "cmEnergy", 13000))  // dummy value to set incident proton pz for particle gun samples
 {
   genParticlesToken_ = consumes<reco::CandidateView>(pset.getParameter<edm::InputTag>("genParticles"));
   genEventInfoToken_ = consumes<GenEventInfoProduct>(pset.getParameter<edm::InputTag>("genEventInfo"));
@@ -65,8 +61,7 @@ GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet
   produces<edm::HepMCProduct>("unsmeared");
 }
 
-void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSetup& eventSetup)
-{
+void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSetup& eventSetup) {
   edm::Handle<reco::CandidateView> genParticlesHandle;
   event.getByToken(genParticlesToken_, genParticlesHandle);
 
@@ -86,7 +81,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   // Set PDF
   const gen::PdfInfo* pdf = genEventInfoHandle->pdf();
-  if ( pdf != nullptr ) {
+  if (pdf != nullptr) {
     const int pdf_id1 = pdf->id.first, pdf_id2 = pdf->id.second;
     const double pdf_x1 = pdf->x.first, pdf_x2 = pdf->x.second;
     const double pdf_scalePDF = pdf->scalePDF;
@@ -97,19 +92,20 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   // Prepare list of HepMC::GenParticles
   std::map<const reco::Candidate*, HepMC::GenParticle*> genCandToHepMCMap;
-  HepMC::GenParticle* hepmc_parton1 = nullptr, * hepmc_parton2 = nullptr;
+  HepMC::GenParticle *hepmc_parton1 = nullptr, *hepmc_parton2 = nullptr;
   std::vector<HepMC::GenParticle*> hepmc_particles;
-  const reco::Candidate* parton1 = nullptr, * parton2 = nullptr;
-  for ( unsigned int i=0, n=genParticlesHandle->size(); i<n; ++i )
-  {
+  const reco::Candidate *parton1 = nullptr, *parton2 = nullptr;
+  for (unsigned int i = 0, n = genParticlesHandle->size(); i < n; ++i) {
     const reco::Candidate* p = &genParticlesHandle->at(i);
     HepMC::GenParticle* hepmc_particle = new HepMC::GenParticle(FourVector(p->p4()), p->pdgId(), p->status());
-    hepmc_particle->suggest_barcode(i+1);
+    hepmc_particle->suggest_barcode(i + 1);
 
     // Assign particle's generated mass from the standard particle data table
     double particleMass;
-    if ( pTable_->particle(p->pdgId()) ) particleMass = pTable_->particle(p->pdgId())->mass();
-    else particleMass = p->mass();
+    if (pTable_->particle(p->pdgId()))
+      particleMass = pTable_->particle(p->pdgId())->mass();
+    else
+      particleMass = p->mass();
 
     hepmc_particle->set_generated_mass(particleMass);
 
@@ -117,12 +113,11 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
     genCandToHepMCMap[p] = hepmc_particle;
 
     // Find incident proton pair
-    if ( p->mother() == nullptr and std::abs(p->eta()) > 5 and std::abs(p->pz()) > 1000 ) {
-      if ( !parton1 and p->pz() > 0 ) {
+    if (p->mother() == nullptr and std::abs(p->eta()) > 5 and std::abs(p->pz()) > 1000) {
+      if (!parton1 and p->pz() > 0) {
         parton1 = p;
         hepmc_parton1 = hepmc_particle;
-      }
-      else if ( !parton2 and p->pz() < 0 ) {
+      } else if (!parton2 and p->pz() < 0) {
         parton2 = p;
         hepmc_parton2 = hepmc_particle;
       }
@@ -131,17 +126,16 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   HepMC::GenVertex* vertex1 = nullptr;
   HepMC::GenVertex* vertex2 = nullptr;
-  if ( parton1 == nullptr and parton2 == nullptr ) {
+  if (parton1 == nullptr and parton2 == nullptr) {
     // Particle gun samples do not have incident partons. Put dummy incident particle and prod vertex
     // Note: leave parton1 and parton2 as nullptr since it is not used anymore after creating hepmc_parton1 and 2
-    const reco::Candidate::LorentzVector nullP4(0,0,0,0);
-    const reco::Candidate::LorentzVector beamP4(0,0,cmEnergy_/2, cmEnergy_/2);
+    const reco::Candidate::LorentzVector nullP4(0, 0, 0, 0);
+    const reco::Candidate::LorentzVector beamP4(0, 0, cmEnergy_ / 2, cmEnergy_ / 2);
     vertex1 = new HepMC::GenVertex(FourVector(nullP4));
     vertex2 = new HepMC::GenVertex(FourVector(nullP4));
-    hepmc_parton1 =  new HepMC::GenParticle(FourVector(+beamP4), 2212, 4);
-    hepmc_parton2 =  new HepMC::GenParticle(FourVector(-beamP4), 2212, 4);
-  }
-  else {
+    hepmc_parton1 = new HepMC::GenParticle(FourVector(+beamP4), 2212, 4);
+    hepmc_parton2 = new HepMC::GenParticle(FourVector(-beamP4), 2212, 4);
+  } else {
     // Put incident beam particles : proton -> parton vertex
     vertex1 = new HepMC::GenVertex(FourVector(parton1->vertex()));
     vertex2 = new HepMC::GenVertex(FourVector(parton2->vertex()));
@@ -157,25 +151,21 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   ParticleToVertexMap particleToVertexMap;
   particleToVertexMap[parton1] = vertex1;
   particleToVertexMap[parton2] = vertex2;
-  for ( unsigned int i=0, n=genParticlesHandle->size(); i<n; ++i )
-  {
+  for (unsigned int i = 0, n = genParticlesHandle->size(); i < n; ++i) {
     const reco::Candidate* p = &genParticlesHandle->at(i);
-    if ( p == parton1 or p == parton2 ) continue;
+    if (p == parton1 or p == parton2)
+      continue;
 
     // Connect mother-daughters for the other cases
-    for ( unsigned int j=0, nMothers=p->numberOfMothers(); j<nMothers; ++j )
-    {
+    for (unsigned int j = 0, nMothers = p->numberOfMothers(); j < nMothers; ++j) {
       // Mother-daughter hierarchy defines vertex
       const reco::Candidate* elder = p->mother(j)->daughter(0);
       HepMC::GenVertex* vertex;
-      if ( particleToVertexMap.find(elder) == particleToVertexMap.end() )
-      {
+      if (particleToVertexMap.find(elder) == particleToVertexMap.end()) {
         vertex = new HepMC::GenVertex(FourVector(elder->vertex()));
         hepmc_event->add_vertex(vertex);
         particleToVertexMap[elder] = vertex;
-      }
-      else
-      {
+      } else {
         vertex = particleToVertexMap[elder];
       }
 
@@ -188,28 +178,29 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   // Finalize HepMC event record
   bool hasSignalVertex = false;
-  if ( !signalParticlePdgIds_.empty() ) {
+  if (!signalParticlePdgIds_.empty()) {
     // Loop over all vertices to assign the signal vertex, decaying to a signal particle
-    for ( auto v = hepmc_event->vertices_begin(); v != hepmc_event->vertices_end(); ++v ) {
-      for ( auto p = (*v)->particles_begin(HepMC::children);
-            p != (*v)->particles_end(HepMC::children); ++p ) {
+    for (auto v = hepmc_event->vertices_begin(); v != hepmc_event->vertices_end(); ++v) {
+      for (auto p = (*v)->particles_begin(HepMC::children); p != (*v)->particles_end(HepMC::children); ++p) {
         const int pdgId = (*p)->pdg_id();
-        if ( std::find(signalParticlePdgIds_.begin(), signalParticlePdgIds_.end(), pdgId) != signalParticlePdgIds_.end() ) {
+        if (std::find(signalParticlePdgIds_.begin(), signalParticlePdgIds_.end(), pdgId) !=
+            signalParticlePdgIds_.end()) {
           hepmc_event->set_signal_process_vertex(*v);
           hasSignalVertex = true;
           break;
         }
       }
-      if ( hasSignalVertex ) break;
+      if (hasSignalVertex)
+        break;
     }
   }
   // Set the default signal vertex if still not set
-  if ( !hasSignalVertex ) hepmc_event->set_signal_process_vertex(*(vertex1->vertices_begin()));
+  if (!hasSignalVertex)
+    hepmc_event->set_signal_process_vertex(*(vertex1->vertices_begin()));
 
   std::unique_ptr<edm::HepMCProduct> hepmc_product(new edm::HepMCProduct());
   hepmc_product->addHepMCData(hepmc_event);
   event.put(std::move(hepmc_product), "unsmeared");
-
 }
 
 DEFINE_FWK_MODULE(GenParticles2HepMCConverter);

--- a/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc
@@ -8,24 +8,22 @@
 
 #include "HepPDT/ParticleID.hh"
 
-MergedGenParticleProducer::MergedGenParticleProducer(const edm::ParameterSet& config)
-{
+MergedGenParticleProducer::MergedGenParticleProducer(const edm::ParameterSet& config) {
   input_pruned_ = consumes<edm::View<reco::GenParticle>>(config.getParameter<edm::InputTag>("inputPruned"));
   input_packed_ = consumes<edm::View<pat::PackedGenParticle>>(config.getParameter<edm::InputTag>("inputPacked"));
 
   produces<reco::GenParticleCollection>();
 }
 
-void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-{
+void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   // Need a ref to the product now for creating the mother/daughter refs
   auto ref = event.getRefBeforePut<reco::GenParticleCollection>();
 
   // Get the input collections
-  edm::Handle<edm::View<reco::GenParticle> > pruned_handle;
+  edm::Handle<edm::View<reco::GenParticle>> pruned_handle;
   event.getByToken(input_pruned_, pruned_handle);
 
-  edm::Handle<edm::View<pat::PackedGenParticle> > packed_handle;
+  edm::Handle<edm::View<pat::PackedGenParticle>> packed_handle;
   event.getByToken(input_packed_, packed_handle);
 
   // First determine which packed particles are also still in the pruned collection
@@ -39,7 +37,8 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
   for (unsigned int i = 0; i < pruned_handle->size(); ++i) {
     reco::GenParticle const& src = pruned_handle->at(i);
     pruned_idx_map[&src] = i;
-    if (src.status() != 1) continue;
+    if (src.status() != 1)
+      continue;
 
     // Convert the pruned GenParticle into a PackedGenParticle then do an exact
     // floating point comparison of the pt, eta and phi
@@ -50,15 +49,17 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
     unsigned found_matches = 0;
     for (unsigned j = 0; j < packed_handle->size(); ++j) {
       pat::PackedGenParticle const& pk = packed_handle->at(j);
-      if ( pks.pdgId() != pk.pdgId() or pks.p4() != pk.p4() ) continue;
+      if (pks.pdgId() != pk.pdgId() or pks.p4() != pk.p4())
+        continue;
       ++found_matches;
       st1_dup_map[&pk] = &src;
     }
     if (found_matches > 1) {
-      edm::LogWarning("MergedGenParticleProducer") << "Found multiple packed matches for: " << i << "\t" << src.pdgId() << "\t" << src.pt() << "\t" << src.y() << "\n";
-    }
-    else if (found_matches == 0 && std::abs(src.y()) < 6.0) {
-      edm::LogWarning("MergedGenParticleProducer") << "unmatched status 1: " << i << "\t" << src.pdgId() << "\t" << src.pt() << "\t" << src.y() << "\n";
+      edm::LogWarning("MergedGenParticleProducer") << "Found multiple packed matches for: " << i << "\t" << src.pdgId()
+                                                   << "\t" << src.pt() << "\t" << src.y() << "\n";
+    } else if (found_matches == 0 && std::abs(src.y()) < 6.0) {
+      edm::LogWarning("MergedGenParticleProducer")
+          << "unmatched status 1: " << i << "\t" << src.pdgId() << "\t" << src.pt() << "\t" << src.y() << "\n";
     }
   }
 
@@ -67,17 +68,19 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
   unsigned int nPhotonsFromPrunedHadron = 0;
   for (unsigned int j = 0; j < packed_handle->size(); ++j) {
     pat::PackedGenParticle const& pk = packed_handle->at(j);
-    if (isPhotonFromPrunedHadron(pk)) ++nPhotonsFromPrunedHadron;
+    if (isPhotonFromPrunedHadron(pk))
+      ++nPhotonsFromPrunedHadron;
   }
 
   // At this point we know what the size of the merged GenParticle will be so we can create it
-  const unsigned int n = pruned_handle->size() + (packed_handle->size() - st1_dup_map.size()) + nPhotonsFromPrunedHadron;
+  const unsigned int n =
+      pruned_handle->size() + (packed_handle->size() - st1_dup_map.size()) + nPhotonsFromPrunedHadron;
   auto cands = std::unique_ptr<reco::GenParticleCollection>(new reco::GenParticleCollection(n));
 
   // First copy in all the pruned candidates
   for (unsigned i = 0; i < pruned_handle->size(); ++i) {
     reco::GenParticle const& old_cand = pruned_handle->at(i);
-    reco::GenParticle & new_cand = cands->at(i);
+    reco::GenParticle& new_cand = cands->at(i);
     new_cand = reco::GenParticle(pruned_handle->at(i));
     // Update the mother and daughter refs to this new merged collection
     new_cand.resetMothers(ref.id());
@@ -93,14 +96,15 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
   // Now copy in the packed candidates that are not already in the pruned
   for (unsigned i = 0, idx = pruned_handle->size(); i < packed_handle->size(); ++i) {
     pat::PackedGenParticle const& pk = packed_handle->at(i);
-    if (st1_dup_map.count(&pk)) continue;
-    reco::GenParticle & new_cand = cands->at(idx);
+    if (st1_dup_map.count(&pk))
+      continue;
+    reco::GenParticle& new_cand = cands->at(idx);
     new_cand = reco::GenParticle(pk.charge(), pk.p4(), pk.vertex(), pk.pdgId(), 1, true);
 
     // Insert dummy pi0 mothers for orphaned photons
     if (isPhotonFromPrunedHadron(pk)) {
       ++idx;
-      reco::GenParticle & dummy_mother = cands->at(idx);
+      reco::GenParticle& dummy_mother = cands->at(idx);
       dummy_mother = reco::GenParticle(0, pk.p4(), pk.vertex(), 111, 2, true);
       for (unsigned m = 0; m < pk.numberOfMothers(); ++m) {
         new_cand.addMother(reco::GenParticleRef(ref, idx));
@@ -111,11 +115,11 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
           new_cand.setVertex(pk.mother(m)->vertex());
         }
         // Should then add the GenParticle as a daughter of its dummy mother
-        dummy_mother.addDaughter(reco::GenParticleRef(ref, idx-1));
+        dummy_mother.addDaughter(reco::GenParticleRef(ref, idx - 1));
       }
     }
     // Connect to mother from pruned particles
-    reco::GenParticle & daughter = cands->at(idx);
+    reco::GenParticle& daughter = cands->at(idx);
     for (unsigned m = 0; m < pk.numberOfMothers(); ++m) {
       daughter.addMother(reco::GenParticleRef(ref, pruned_idx_map.at(pk.mother(m))));
       // Since the packed candidates drop the vertex position we'll take this from the mother
@@ -131,14 +135,15 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
   event.put(std::move(cands));
 }
 
-bool MergedGenParticleProducer::isPhotonFromPrunedHadron(const pat::PackedGenParticle& pk) const
-{
+bool MergedGenParticleProducer::isPhotonFromPrunedHadron(const pat::PackedGenParticle& pk) const {
   if (pk.pdgId() == 22 and pk.statusFlags().isDirectHadronDecayProduct()) {
     // no mother
-    if (pk.numberOfMothers() == 0) return true;
+    if (pk.numberOfMothers() == 0)
+      return true;
     // miniaod mother not compatible with the status flag
     HepPDT::ParticleID motherid(pk.mother(0)->pdgId());
-    if (not (motherid.isHadron() and pk.mother(0)->status() == 2)) return true;
+    if (not(motherid.isHadron() and pk.mother(0)->status() == 2))
+      return true;
   }
   return false;
 }

--- a/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.hh
+++ b/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.hh
@@ -8,13 +8,12 @@
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include <vector>
 
-class MergedGenParticleProducer : public edm::stream::EDProducer<>
-{
- public:
+class MergedGenParticleProducer : public edm::stream::EDProducer<> {
+public:
   MergedGenParticleProducer(const edm::ParameterSet& pset);
-  ~MergedGenParticleProducer() override {};
+  ~MergedGenParticleProducer() override{};
 
- private:
+private:
   void produce(edm::Event& event, const edm::EventSetup&) override;
   bool isPhotonFromPrunedHadron(const pat::PackedGenParticle& pk) const;
 

--- a/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.hh
+++ b/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.hh
@@ -12,7 +12,7 @@ class MergedGenParticleProducer : public edm::stream::EDProducer<>
 {
  public:
   MergedGenParticleProducer(const edm::ParameterSet& pset);
-  ~MergedGenParticleProducer() {};
+  ~MergedGenParticleProducer() override {};
 
  private:
   void produce(edm::Event& event, const edm::EventSetup&) override;

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -141,7 +141,7 @@ void ParticleLevelProducer::produce(edm::Event& event, const edm::EventSetup& ev
     lepJet.setPdgId(lepton.pdgId());
     lepJet.setCharge(lepton.charge());
 
-    for (auto const & p : lepton.constituents()) {
+    for (auto const& p : lepton.constituents()) {
       // ghost taus (momentum scaled with 10e-20 in RivetAnalysis.h already)
       if (p.abspid() == 15) {
         tags->push_back(reco::GenParticle(p.charge(), p4(p), genVertex_, p.pdgId(), 2, true));

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -8,25 +8,22 @@
 
 // Definition of the StatusCode and Category enums
 //#include "HiggsTemplateCrossSections.h"
-#include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h" // 
+#include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"  //
 
 #include <atomic>
 
 namespace Rivet {
-  
-  /// @class HiggsTemplateCrossSections 
+
+  /// @class HiggsTemplateCrossSections
   /// @brief  Rivet routine for classifying MC events according to the Higgs template cross section categories
   /// @author Jim Lacey (DESY) <james.lacey@cern.ch,jlacey@desy.de>
   /// @author Dag Gillberg (Carleton University) <dag.gillberg@cern.ch>
   class HiggsTemplateCrossSections : public Analysis {
   public:
     // Constructor
-    HiggsTemplateCrossSections()
-      : Analysis("HiggsTemplateCrossSections"),
-	m_HiggsProdMode(HTXS::UNKNOWN) {}
+    HiggsTemplateCrossSections() : Analysis("HiggsTemplateCrossSections"), m_HiggsProdMode(HTXS::UNKNOWN) {}
 
   public:
-
     /// @name Utility methods
     /// Methods to identify the Higgs boson and
     /// associated vector boson and to build jets
@@ -34,74 +31,84 @@ namespace Rivet {
 
     /// follow a "propagating" particle and return its last instance
     Particle getLastInstance(Particle ptcl) {
-      if ( ptcl.genParticle()->end_vertex() ) {
-	if ( !hasChild(ptcl.genParticle(),ptcl.pdgId()) ) return ptcl;
-	else return getLastInstance(ptcl.children()[0]);
+      if (ptcl.genParticle()->end_vertex()) {
+        if (!hasChild(ptcl.genParticle(), ptcl.pdgId()))
+          return ptcl;
+        else
+          return getLastInstance(ptcl.children()[0]);
       }
       return ptcl;
     }
-    
+
     /// @brief Whether particle p originate from any of the ptcls
-    bool originateFrom(const Particle& p, const Particles& ptcls ) {
-      const GenVertex* prodVtx = p.genParticle()->production_vertex();
-      if (prodVtx == nullptr) return false;
+    bool originateFrom(const Particle &p, const Particles &ptcls) {
+      const GenVertex *prodVtx = p.genParticle()->production_vertex();
+      if (prodVtx == nullptr)
+        return false;
       // for each ancestor, check if it matches any of the input particles
-      for (const auto & ancestor:particles(prodVtx, HepMC::ancestors)){ 
-	for ( auto part:ptcls ) 
-	  if ( ancestor==part.genParticle() ) return true;
+      for (const auto &ancestor : particles(prodVtx, HepMC::ancestors)) {
+        for (auto part : ptcls)
+          if (ancestor == part.genParticle())
+            return true;
       }
       // if we get here, no ancetor matched any input particle
-      return false; 
-    }
-    
-    /// @brief Whether particle p originates from p2
-    bool originateFrom(const Particle& p, const Particle& p2 ) { 
-      Particles ptcls = {p2}; return originateFrom(p,ptcls);
-    }
-    
-    /// @brief Checks whether the input particle has a child with a given PDGID 
-    bool hasChild(const GenParticle *ptcl, int pdgID) {
-      for (auto child:Particle(*ptcl).children())
-        if (child.pdgId()==pdgID) return true;
       return false;
     }
-    
-    /// @brief Checks whether the input particle has a parent with a given PDGID 
+
+    /// @brief Whether particle p originates from p2
+    bool originateFrom(const Particle &p, const Particle &p2) {
+      Particles ptcls = {p2};
+      return originateFrom(p, ptcls);
+    }
+
+    /// @brief Checks whether the input particle has a child with a given PDGID
+    bool hasChild(const GenParticle *ptcl, int pdgID) {
+      for (auto child : Particle(*ptcl).children())
+        if (child.pdgId() == pdgID)
+          return true;
+      return false;
+    }
+
+    /// @brief Checks whether the input particle has a parent with a given PDGID
     bool hasParent(const GenParticle *ptcl, int pdgID) {
-      for (auto parent:particles(ptcl->production_vertex(),HepMC::parents))
-        if (parent->pdg_id()==pdgID) return true;
+      for (auto parent : particles(ptcl->production_vertex(), HepMC::parents))
+        if (parent->pdg_id() == pdgID)
+          return true;
       return false;
     }
 
     /// @brief Return true is particle decays to quarks
     bool quarkDecay(const Particle &p) {
-      for (auto child:p.children())
-        if (PID::isQuark(child.pdgId())) return true;
+      for (auto child : p.children())
+        if (PID::isQuark(child.pdgId()))
+          return true;
       return false;
     }
-    
+
     /// @brief Returns the classification object with the error code set.
     ///        Prints an warning message, and keeps track of number of errors
-    HiggsClassification error(HiggsClassification &cat, HTXS::ErrorCode err, 
-			      std::string msg="", int NmaxWarnings=20) {
+    HiggsClassification error(HiggsClassification &cat,
+                              HTXS::ErrorCode err,
+                              std::string msg = "",
+                              int NmaxWarnings = 20) {
       // Set the error, and keep statistics
       cat.errorCode = err;
       ++m_errorCount[err];
 
       // Print warning message to the screen/log
       static std::atomic<int> Nwarnings{0};
-      if ( !msg.empty() && ++Nwarnings < NmaxWarnings )
-	  MSG_WARNING(msg);
+      if (!msg.empty() && ++Nwarnings < NmaxWarnings)
+        MSG_WARNING(msg);
 
       return cat;
     }
     /// @}
 
     /// @brief Main classificaion method.
-    HiggsClassification classifyEvent(const Event& event, const HTXS::HiggsProdMode prodMode ) {
+    HiggsClassification classifyEvent(const Event &event, const HTXS::HiggsProdMode prodMode) {
+      if (m_HiggsProdMode == HTXS::UNKNOWN)
+        m_HiggsProdMode = prodMode;
 
-      if (m_HiggsProdMode==HTXS::UNKNOWN) m_HiggsProdMode = prodMode; 
-      
       // the classification object
       HiggsClassification cat;
       cat.prodMode = prodMode;
@@ -114,10 +121,11 @@ namespace Rivet {
       cat.stage1_1_fine_cat_pTjet25GeV = HTXS::Stage1_1_Fine::UNKNOWN;
       cat.stage1_1_fine_cat_pTjet30GeV = HTXS::Stage1_1_Fine::UNKNOWN;
 
-      if (prodMode == HTXS::UNKNOWN) 
-	return error(cat,HTXS::PRODMODE_DEFINED,
-		     "Unkown Higgs production mechanism. Cannot classify event."                                                                       
-		     " Classification for all events will most likely fail.");
+      if (prodMode == HTXS::UNKNOWN)
+        return error(cat,
+                     HTXS::PRODMODE_DEFINED,
+                     "Unkown Higgs production mechanism. Cannot classify event."
+                     " Classification for all events will most likely fail.");
 
       /*****
        * Step 1. 
@@ -126,93 +134,105 @@ namespace Rivet {
        */
 
       GenVertex *HSvtx = event.genEvent()->signal_process_vertex();
-      int Nhiggs=0;
-      for ( const GenParticle *ptcl : Rivet::particles(event.genEvent()) ) {
-
+      int Nhiggs = 0;
+      for (const GenParticle *ptcl : Rivet::particles(event.genEvent())) {
         // a) Reject all non-Higgs particles
-        if ( !PID::isHiggs(ptcl->pdg_id()) ) continue;
+        if (!PID::isHiggs(ptcl->pdg_id()))
+          continue;
         // b) select only the final Higgs boson copy, prior to decay
-        if ( ptcl->end_vertex() && !hasChild(ptcl,PID::HIGGS) ) {
-          cat.higgs = Particle(ptcl); ++Nhiggs;
+        if (ptcl->end_vertex() && !hasChild(ptcl, PID::HIGGS)) {
+          cat.higgs = Particle(ptcl);
+          ++Nhiggs;
         }
         // c) if HepMC::signal_proces_vertex is missing
         //    set hard-scatter vertex based on first Higgs boson
-        if ( HSvtx==nullptr && ptcl->production_vertex() && !hasParent(ptcl,PID::HIGGS) )
-	  HSvtx = ptcl->production_vertex();
+        if (HSvtx == nullptr && ptcl->production_vertex() && !hasParent(ptcl, PID::HIGGS))
+          HSvtx = ptcl->production_vertex();
       }
 
       // Make sure things are in order so far
-      if (Nhiggs!=1) 
-	return error(cat,HTXS::HIGGS_IDENTIFICATION,
-		     "Current event has "+std::to_string(Nhiggs)+" Higgs bosons. There must be only one.");
-      if (cat.higgs.children().size()<2) 
-	return error(cat,HTXS::HIGGS_DECAY_IDENTIFICATION,
-		     "Could not identify Higgs boson decay products.");
+      if (Nhiggs != 1)
+        return error(cat,
+                     HTXS::HIGGS_IDENTIFICATION,
+                     "Current event has " + std::to_string(Nhiggs) + " Higgs bosons. There must be only one.");
+      if (cat.higgs.children().size() < 2)
+        return error(cat, HTXS::HIGGS_DECAY_IDENTIFICATION, "Could not identify Higgs boson decay products.");
 
-      if (HSvtx == nullptr) 
-	return error(cat,HTXS::HS_VTX_IDENTIFICATION,"Cannot find hard-scatter vertex of current event.");
+      if (HSvtx == nullptr)
+        return error(cat, HTXS::HS_VTX_IDENTIFICATION, "Cannot find hard-scatter vertex of current event.");
 
       /*****
        * Step 2. 
        *   Identify associated vector bosons
        */
- 
+
       // Find associated vector bosons
       bool is_uncatdV = false;
       Particles uncatV_decays;
-      FourMomentum uncatV_p4(0,0,0,0);
-      FourVector uncatV_v4(0,0,0,0);
-      int nWs=0, nZs=0, nTop=0;
-      if ( isVH(prodMode) ) {
-	for (auto ptcl:particles(HSvtx,HepMC::children)) {
-	  if (PID::isW(ptcl->pdg_id())) { ++nWs; cat.V=Particle(ptcl); }
-	  if (PID::isZ(ptcl->pdg_id())) { ++nZs; cat.V=Particle(ptcl); }
-	}
-	if(nWs+nZs>0) cat.V = getLastInstance(cat.V);
-	else {
-	  for (auto ptcl:particles(HSvtx,HepMC::children)) {
-	    if (!PID::isHiggs(ptcl->pdg_id())) {
-	      uncatV_decays += Particle(ptcl);
-	      uncatV_p4 += Particle(ptcl).momentum();
-	      // uncatV_v4 += Particle(ptcl).origin();
-	    }
-	  }
-	  // is_uncatdV = true; cat.V = Particle(24,uncatV_p4,uncatV_v4);
-	  is_uncatdV = true; cat.V = Particle(24,uncatV_p4);
-	}
+      FourMomentum uncatV_p4(0, 0, 0, 0);
+      FourVector uncatV_v4(0, 0, 0, 0);
+      int nWs = 0, nZs = 0, nTop = 0;
+      if (isVH(prodMode)) {
+        for (auto ptcl : particles(HSvtx, HepMC::children)) {
+          if (PID::isW(ptcl->pdg_id())) {
+            ++nWs;
+            cat.V = Particle(ptcl);
+          }
+          if (PID::isZ(ptcl->pdg_id())) {
+            ++nZs;
+            cat.V = Particle(ptcl);
+          }
+        }
+        if (nWs + nZs > 0)
+          cat.V = getLastInstance(cat.V);
+        else {
+          for (auto ptcl : particles(HSvtx, HepMC::children)) {
+            if (!PID::isHiggs(ptcl->pdg_id())) {
+              uncatV_decays += Particle(ptcl);
+              uncatV_p4 += Particle(ptcl).momentum();
+              // uncatV_v4 += Particle(ptcl).origin();
+            }
+          }
+          // is_uncatdV = true; cat.V = Particle(24,uncatV_p4,uncatV_v4);
+          is_uncatdV = true;
+          cat.V = Particle(24, uncatV_p4);
+        }
       }
-      
-      if ( !is_uncatdV ){
 
-	if ( isVH(prodMode) && !cat.V.genParticle()->end_vertex() )
-	  return error(cat,HTXS::VH_DECAY_IDENTIFICATION,"Vector boson does not decay!");
+      if (!is_uncatdV) {
+        if (isVH(prodMode) && !cat.V.genParticle()->end_vertex())
+          return error(cat, HTXS::VH_DECAY_IDENTIFICATION, "Vector boson does not decay!");
 
-	if ( isVH(prodMode) && cat.V.children().size()<2 )
-	  return error(cat,HTXS::VH_DECAY_IDENTIFICATION,"Vector boson does not decay!");
-	
-	if ( ( prodMode==HTXS::WH && (nZs>0||nWs!=1) ) ||
-	     ( (prodMode==HTXS::QQ2ZH||prodMode==HTXS::GG2ZH) && (nZs!=1||nWs>0) ) ) 
-	  return error(cat,HTXS::VH_IDENTIFICATION,"Found "+std::to_string(nWs)+" W-bosons and "+
-		       std::to_string(nZs)+" Z-bosons. Inconsitent with VH expectation.");
+        if (isVH(prodMode) && cat.V.children().size() < 2)
+          return error(cat, HTXS::VH_DECAY_IDENTIFICATION, "Vector boson does not decay!");
+
+        if ((prodMode == HTXS::WH && (nZs > 0 || nWs != 1)) ||
+            ((prodMode == HTXS::QQ2ZH || prodMode == HTXS::GG2ZH) && (nZs != 1 || nWs > 0)))
+          return error(cat,
+                       HTXS::VH_IDENTIFICATION,
+                       "Found " + std::to_string(nWs) + " W-bosons and " + std::to_string(nZs) +
+                           " Z-bosons. Inconsitent with VH expectation.");
       }
-      
+
       // Find and store the W-bosons from ttH->WbWbH
       Particles Ws;
-      if ( prodMode==HTXS::TTH || prodMode==HTXS::TH ){
-	// loop over particles produced in hard-scatter vertex
-      	for ( auto ptcl : particles(HSvtx,HepMC::children) ) {
-      	  if ( !PID::isTop(ptcl->pdg_id()) ) continue;
-	  ++nTop;
-	  Particle top = getLastInstance(Particle(ptcl));
-	  if ( top.genParticle()->end_vertex() ) 
-	    for (auto child:top.children())
-	      if ( PID::isW(child.pdgId()) ) Ws += child;
-	}
+      if (prodMode == HTXS::TTH || prodMode == HTXS::TH) {
+        // loop over particles produced in hard-scatter vertex
+        for (auto ptcl : particles(HSvtx, HepMC::children)) {
+          if (!PID::isTop(ptcl->pdg_id()))
+            continue;
+          ++nTop;
+          Particle top = getLastInstance(Particle(ptcl));
+          if (top.genParticle()->end_vertex())
+            for (auto child : top.children())
+              if (PID::isW(child.pdgId()))
+                Ws += child;
+        }
       }
 
       // Make sure result make sense
-      if ( (prodMode==HTXS::TTH && Ws.size()<2) || (prodMode==HTXS::TH && Ws.empty() ) )
-	return error(cat,HTXS::TOP_W_IDENTIFICATION,"Failed to identify W-boson(s) from t-decay!");
+      if ((prodMode == HTXS::TTH && Ws.size() < 2) || (prodMode == HTXS::TH && Ws.empty()))
+        return error(cat, HTXS::TOP_W_IDENTIFICATION, "Failed to identify W-boson(s) from t-decay!");
 
       /*****
        * Step 3.
@@ -224,89 +244,101 @@ namespace Rivet {
       // Either the vector boson produced in association with the Higgs boson,
       // or the ones produced from decays of top quarks produced with the Higgs
       Particles leptonicVs;
-      if ( !is_uncatdV ){
-	if ( isVH(prodMode) && !quarkDecay(cat.V) ) leptonicVs += cat.V;
-      }else leptonicVs = uncatV_decays;
-      for ( auto W:Ws ) if ( W.genParticle()->end_vertex() && !quarkDecay(W) ) leptonicVs += W;
+      if (!is_uncatdV) {
+        if (isVH(prodMode) && !quarkDecay(cat.V))
+          leptonicVs += cat.V;
+      } else
+        leptonicVs = uncatV_decays;
+      for (auto W : Ws)
+        if (W.genParticle()->end_vertex() && !quarkDecay(W))
+          leptonicVs += W;
 
       // Obtain all stable, final-state particles
       const ParticleVector FS = applyProjection<FinalState>(event, "FS").particles();
       Particles hadrons;
-      FourMomentum sum(0,0,0,0), vSum(0,0,0,0), hSum(0,0,0,0);
-      for ( const Particle &p : FS ) {
+      FourMomentum sum(0, 0, 0, 0), vSum(0, 0, 0, 0), hSum(0, 0, 0, 0);
+      for (const Particle &p : FS) {
         // Add up the four momenta of all stable particles as a cross check
-	sum += p.momentum();
-	// ignore particles from the Higgs boson
-	if ( originateFrom(p,cat.higgs) ) { hSum += p.momentum(); continue; }
-	// Cross-check the V decay products for VH
-	if ( isVH(prodMode) && !is_uncatdV && originateFrom(p,Ws) ) vSum += p.momentum();
-	// ignore final state particles from leptonic V decays
-	if ( !leptonicVs.empty() && originateFrom(p,leptonicVs) ) continue;
-	// All particles reaching here are considered hadrons and will be used to build jets
-	hadrons += p;
+        sum += p.momentum();
+        // ignore particles from the Higgs boson
+        if (originateFrom(p, cat.higgs)) {
+          hSum += p.momentum();
+          continue;
+        }
+        // Cross-check the V decay products for VH
+        if (isVH(prodMode) && !is_uncatdV && originateFrom(p, Ws))
+          vSum += p.momentum();
+        // ignore final state particles from leptonic V decays
+        if (!leptonicVs.empty() && originateFrom(p, leptonicVs))
+          continue;
+        // All particles reaching here are considered hadrons and will be used to build jets
+        hadrons += p;
       }
-      
+
       cat.p4decay_higgs = hSum;
       cat.p4decay_V = vSum;
 
       FinalState fps_temp;
-      FastJets jets(fps_temp, FastJets::ANTIKT, 0.4 );
+      FastJets jets(fps_temp, FastJets::ANTIKT, 0.4);
       jets.calc(hadrons);
 
-      cat.jets25 = jets.jetsByPt( Cuts::pT > 25.0 );
-      cat.jets30 = jets.jetsByPt( Cuts::pT > 30.0 );
- 
+      cat.jets25 = jets.jetsByPt(Cuts::pT > 25.0);
+      cat.jets30 = jets.jetsByPt(Cuts::pT > 30.0);
+
       // check that four mometum sum of all stable particles satisfies momentum consevation
-/*
+      /*
       if ( sum.pt()>0.1 )
 	return error(cat,HTXS::MOMENTUM_CONSERVATION,"Four vector sum does not amount to pT=0, m=E=sqrt(s), but pT="+
 		     std::to_string(sum.pt())+" GeV and m = "+std::to_string(sum.mass())+" GeV");
-*/      
+*/
       // check if V-boson was not included in the event record but decay particles were
       // EFT contact interaction: return UNKNOWN for category but set all event/particle kinematics
-      if(is_uncatdV) 
-	return error(cat,HTXS::VH_IDENTIFICATION,"Failed to identify associated V-boson!");
-       
+      if (is_uncatdV)
+        return error(cat, HTXS::VH_IDENTIFICATION, "Failed to identify associated V-boson!");
+
       /*****
        * Step 4.
        *   Classify and save output
        */
-      
-      // Apply the categorization categorization
-      cat.stage0_cat = getStage0Category(prodMode,cat.higgs,cat.V);
-      cat.stage1_cat_pTjet25GeV = getStage1Category(prodMode,cat.higgs,cat.jets25,cat.V);
-      cat.stage1_cat_pTjet30GeV = getStage1Category(prodMode,cat.higgs,cat.jets30,cat.V);
-      cat.stage1_1_cat_pTjet25GeV = getStage1_1_Category(prodMode,cat.higgs,cat.jets25,cat.V);
-      cat.stage1_1_cat_pTjet30GeV = getStage1_1_Category(prodMode,cat.higgs,cat.jets30,cat.V);
-      cat.stage1_1_fine_cat_pTjet25GeV = getStage1_1_Fine_Category(prodMode,cat.higgs,cat.jets25,cat.V);
-      cat.stage1_1_fine_cat_pTjet30GeV = getStage1_1_Fine_Category(prodMode,cat.higgs,cat.jets30,cat.V);
 
-      cat.errorCode = HTXS::SUCCESS; ++m_errorCount[HTXS::SUCCESS];
+      // Apply the categorization categorization
+      cat.stage0_cat = getStage0Category(prodMode, cat.higgs, cat.V);
+      cat.stage1_cat_pTjet25GeV = getStage1Category(prodMode, cat.higgs, cat.jets25, cat.V);
+      cat.stage1_cat_pTjet30GeV = getStage1Category(prodMode, cat.higgs, cat.jets30, cat.V);
+      cat.stage1_1_cat_pTjet25GeV = getStage1_1_Category(prodMode, cat.higgs, cat.jets25, cat.V);
+      cat.stage1_1_cat_pTjet30GeV = getStage1_1_Category(prodMode, cat.higgs, cat.jets30, cat.V);
+      cat.stage1_1_fine_cat_pTjet25GeV = getStage1_1_Fine_Category(prodMode, cat.higgs, cat.jets25, cat.V);
+      cat.stage1_1_fine_cat_pTjet30GeV = getStage1_1_Fine_Category(prodMode, cat.higgs, cat.jets30, cat.V);
+
+      cat.errorCode = HTXS::SUCCESS;
+      ++m_errorCount[HTXS::SUCCESS];
 
       return cat;
-    }    
+    }
 
     /// @name Categorization methods
     /// Methods to assign the truth category based
-    /// on the identified Higgs boson and associated 
+    /// on the identified Higgs boson and associated
     /// vector bosons and/or reconstructed jets
     /// @{
-    
+
     /// @brief Return bin index of x given the provided bin edges. 0=first bin, -1=underflow bin.
     int getBin(double x, std::vector<double> bins) {
-      for (size_t i=1;i<bins.size();++i)
-        if (x<bins[i]) return i-1;
-      return bins.size()-1;
+      for (size_t i = 1; i < bins.size(); ++i)
+        if (x < bins[i])
+          return i - 1;
+      return bins.size() - 1;
     }
-    
+
     /// @brief VBF topolog selection
     /// 0 = fail loose selction: m_jj > 400 GeV and Dy_jj > 2.8
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass tight selection
     int vbfTopology(const Jets &jets, const Particle &higgs) {
-      if (jets.size()<2) return 0;
-      const FourMomentum &j1=jets[0].momentum(), &j2=jets[1].momentum();
-      bool VBFtopo = (j1+j2).mass() > 400.0 && std::abs(j1.rapidity()-j2.rapidity()) > 2.8;
-      return VBFtopo ? (j1+j2+higgs.momentum()).pt()<25 ? 2 : 1 : 0;
+      if (jets.size() < 2)
+        return 0;
+      const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
+      bool VBFtopo = (j1 + j2).mass() > 400.0 && std::abs(j1.rapidity() - j2.rapidity()) > 2.8;
+      return VBFtopo ? (j1 + j2 + higgs.momentum()).pt() < 25 ? 2 : 1 : 0;
     }
 
     /// @brief VBF topology selection Stage1.1
@@ -314,12 +346,16 @@ namespace Rivet {
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
     /// 3 pass tight (m_jj>700 GeV), but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
     int vbfTopology_Stage1_1(const Jets &jets, const Particle &higgs) {
-      if (jets.size()<2) return 0;
-      const FourMomentum &j1=jets[0].momentum(), &j2=jets[1].momentum();
-      double mjj = (j1+j2).mass();
-      if(mjj>350 && mjj<=700) return (j1+j2+higgs.momentum()).pt()<25 ? 1 : 2;
-      else if(mjj>700) return (j1+j2+higgs.momentum()).pt()<25 ? 3 : 4;
-      else return 0;
+      if (jets.size() < 2)
+        return 0;
+      const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
+      double mjj = (j1 + j2).mass();
+      if (mjj > 350 && mjj <= 700)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 1 : 2;
+      else if (mjj > 700)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 3 : 4;
+      else
+        return 0;
     }
 
     /// @brief VBF topology selection for Stage1.1 Fine
@@ -329,263 +365,341 @@ namespace Rivet {
     /// 5 pass 1000<m_jj<1500 GeV, but fail additional cut pT(Hjj)<25. 6 pass pT(Hjj)>25 selection
     /// 7 pass m_jj>1500 GeV, but fail additional cut pT(Hjj)<25. 8 pass pT(Hjj)>25 selection
     int vbfTopology_Stage1_1_Fine(const Jets &jets, const Particle &higgs) {
-        if (jets.size()<2) return 0;
-        const FourMomentum &j1=jets[0].momentum(), &j2=jets[1].momentum();
-        double mjj = (j1+j2).mass();
-        if(mjj>350 && mjj<=700) return (j1+j2+higgs.momentum()).pt()<25 ? 1 : 2;
-        else if(mjj>700 && mjj<=1000) return (j1+j2+higgs.momentum()).pt()<25 ? 3 : 4;
-        else if(mjj>1000 && mjj<=1500) return (j1+j2+higgs.momentum()).pt()<25 ? 5 : 6;
-        else if(mjj>1500) return (j1+j2+higgs.momentum()).pt()<25 ? 7 : 8;
-        else return 0;
+      if (jets.size() < 2)
+        return 0;
+      const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
+      double mjj = (j1 + j2).mass();
+      if (mjj > 350 && mjj <= 700)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 1 : 2;
+      else if (mjj > 700 && mjj <= 1000)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 3 : 4;
+      else if (mjj > 1000 && mjj <= 1500)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 5 : 6;
+      else if (mjj > 1500)
+        return (j1 + j2 + higgs.momentum()).pt() < 25 ? 7 : 8;
+      else
+        return 0;
     }
 
     /// @brief Whether the Higgs is produced in association with a vector boson (VH)
-    bool isVH(HTXS::HiggsProdMode p) { return p==HTXS::WH || p==HTXS::QQ2ZH || p==HTXS::GG2ZH; }
-    
+    bool isVH(HTXS::HiggsProdMode p) { return p == HTXS::WH || p == HTXS::QQ2ZH || p == HTXS::GG2ZH; }
+
     /// @brief Stage-0 HTXS categorization
     HTXS::Stage0::Category getStage0Category(const HTXS::HiggsProdMode prodMode,
-					     const Particle &higgs,
-					     const Particle &V) {
+                                             const Particle &higgs,
+                                             const Particle &V) {
       using namespace HTXS::Stage0;
-      int ctrlHiggs = std::abs(higgs.rapidity())<2.5;
+      int ctrlHiggs = std::abs(higgs.rapidity()) < 2.5;
       // Special cases first, qq→Hqq
-      if ( (prodMode==HTXS::WH||prodMode==HTXS::QQ2ZH) && quarkDecay(V) ) {
-	return ctrlHiggs ? VH2HQQ : VH2HQQ_FWDH;
-      } else if ( prodMode==HTXS::GG2ZH && quarkDecay(V) ) {
-	return Category(HTXS::GGF*10 + ctrlHiggs);
+      if ((prodMode == HTXS::WH || prodMode == HTXS::QQ2ZH) && quarkDecay(V)) {
+        return ctrlHiggs ? VH2HQQ : VH2HQQ_FWDH;
+      } else if (prodMode == HTXS::GG2ZH && quarkDecay(V)) {
+        return Category(HTXS::GGF * 10 + ctrlHiggs);
       }
       // General case after
-      return  Category(prodMode*10 + ctrlHiggs);
+      return Category(prodMode * 10 + ctrlHiggs);
     }
 
     /// @brief Stage-1 categorization
     HTXS::Stage1::Category getStage1Category(const HTXS::HiggsProdMode prodMode,
-					     const Particle &higgs,
-					     const Jets &jets,
-					     const Particle &V) {
+                                             const Particle &higgs,
+                                             const Jets &jets,
+                                             const Particle &V) {
       using namespace HTXS::Stage1;
-      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
       double pTj1 = !jets.empty() ? jets[0].momentum().pt() : 0;
-      int vbfTopo = vbfTopology(jets,higgs);
+      int vbfTopo = vbfTopology(jets, higgs);
 
       // 1. GGF Stage 1 categories
       //    Following YR4 write-up: XXXXX
-      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
-	if (fwdHiggs)        return GG2H_FWDH;
-	if (Njets==0)        return GG2H_0J;
-	else if (Njets==1)   return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-	else if (Njets>=2) {
-	  // events with pT_H>200 get priority over VBF cuts
-	  if(higgs.pt()<=200){
-	    if      (vbfTopo==2) return GG2H_VBFTOPO_JET3VETO;
-	    else if (vbfTopo==1) return GG2H_VBFTOPO_JET3;
-	  }
-	  // Njets >= 2jets without VBF topology
-	  return Category(GG2H_GE2J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-	}
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs)
+          return GG2H_FWDH;
+        if (Njets == 0)
+          return GG2H_0J;
+        else if (Njets == 1)
+          return Category(GG2H_1J_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        else if (Njets >= 2) {
+          // events with pT_H>200 get priority over VBF cuts
+          if (higgs.pt() <= 200) {
+            if (vbfTopo == 2)
+              return GG2H_VBFTOPO_JET3VETO;
+            else if (vbfTopo == 1)
+              return GG2H_VBFTOPO_JET3;
+          }
+          // Njets >= 2jets without VBF topology
+          return Category(GG2H_GE2J_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        }
       }
       // 2. Electroweak qq->Hqq Stage 1 categories
-      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
-	if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
-      	if (pTj1>200) return QQ2HQQ_PTJET1_GT200;
-	if (vbfTopo==2) return QQ2HQQ_VBFTOPO_JET3VETO;
-	if (vbfTopo==1) return QQ2HQQ_VBFTOPO_JET3;
-	double mjj = jets.size()>1 ? (jets[0].mom()+jets[1].mom()).mass():0;
-	if ( 60 < mjj && mjj < 120 ) return QQ2HQQ_VH2JET;
-      	return QQ2HQQ_REST;
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5)
+          return QQ2HQQ_FWDH;
+        if (pTj1 > 200)
+          return QQ2HQQ_PTJET1_GT200;
+        if (vbfTopo == 2)
+          return QQ2HQQ_VBFTOPO_JET3VETO;
+        if (vbfTopo == 1)
+          return QQ2HQQ_VBFTOPO_JET3;
+        double mjj = jets.size() > 1 ? (jets[0].mom() + jets[1].mom()).mass() : 0;
+        if (60 < mjj && mjj < 120)
+          return QQ2HQQ_VH2JET;
+        return QQ2HQQ_REST;
       }
       // 3. WH->Hlv categories
-      else if (prodMode==HTXS::WH) {
-	if (fwdHiggs) return QQ2HLNU_FWDH;
-	else if (V.pt()<150) return QQ2HLNU_PTV_0_150;
-      	else if (V.pt()>250) return QQ2HLNU_PTV_GT250;
-      	// 150 < pTV/GeV < 250
-      	return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs)
+          return QQ2HLNU_FWDH;
+        else if (V.pt() < 150)
+          return QQ2HLNU_PTV_0_150;
+        else if (V.pt() > 250)
+          return QQ2HLNU_PTV_GT250;
+        // 150 < pTV/GeV < 250
+        return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
       }
       // 4. qq->ZH->llH categories
-      else if (prodMode==HTXS::QQ2ZH) {
-	if (fwdHiggs) return QQ2HLL_FWDH;
-      	else if (V.pt()<150) return QQ2HLL_PTV_0_150;
-      	else if (V.pt()>250) return QQ2HLL_PTV_GT250;
-      	// 150 < pTV/GeV < 250
-      	return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs)
+          return QQ2HLL_FWDH;
+        else if (V.pt() < 150)
+          return QQ2HLL_PTV_0_150;
+        else if (V.pt() > 250)
+          return QQ2HLL_PTV_GT250;
+        // 150 < pTV/GeV < 250
+        return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
       }
       // 5. gg->ZH->llH categories
-      else if (prodMode==HTXS::GG2ZH ) {
-	if (fwdHiggs) return GG2HLL_FWDH;
-	if      (V.pt()<150) return GG2HLL_PTV_0_150;
-	else if (jets.empty()) return GG2HLL_PTV_GT150_0J;
-	return GG2HLL_PTV_GT150_GE1J;
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs)
+          return GG2HLL_FWDH;
+        if (V.pt() < 150)
+          return GG2HLL_PTV_0_150;
+        else if (jets.empty())
+          return GG2HLL_PTV_GT150_0J;
+        return GG2HLL_PTV_GT150_GE1J;
       }
       // 6.ttH,bbH,tH categories
-      else if (prodMode==HTXS::TTH) return Category(TTH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      else if (prodMode == HTXS::TTH)
+        return Category(TTH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(TH_FWDH + ctrlHiggs);
       return UNKNOWN;
     }
 
     /// @brief Stage-1.1 categorization
     HTXS::Stage1_1::Category getStage1_1_Category(const HTXS::HiggsProdMode prodMode,
-						  const Particle &higgs,
-						  const Jets &jets,
-						  const Particle &V) {
+                                                  const Particle &higgs,
+                                                  const Jets &jets,
+                                                  const Particle &V) {
       using namespace HTXS::Stage1_1;
-      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_1(jets,higgs);
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_1(jets, higgs);
 
       // 1. GGF Stage 1 categories
       //    Following YR4 write-up: XXXXX
-      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
-	if (fwdHiggs)        return GG2H_FWDH;
-	if ( higgs.pt()>200 ) return GG2H_PTH_GT200;
-	if (Njets==0)  return higgs.pt()<10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
-	if (Njets==1)  return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-	if (Njets>1){
-	  //VBF topology
-	  if(vbfTopo) return Category(GG2H_MJJ_350_700_PTHJJ_0_25+vbfTopo-1);
-	  //Njets >= 2jets without VBF topology (mjj<350)
-	  return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-	}
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs)
+          return GG2H_FWDH;
+        if (higgs.pt() > 200)
+          return GG2H_PTH_GT200;
+        if (Njets == 0)
+          return higgs.pt() < 10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
+        if (Njets == 1)
+          return Category(GG2H_1J_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        if (Njets > 1) {
+          //VBF topology
+          if (vbfTopo)
+            return Category(GG2H_MJJ_350_700_PTHJJ_0_25 + vbfTopo - 1);
+          //Njets >= 2jets without VBF topology (mjj<350)
+          return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        }
       }
 
       // 2. Electroweak qq->Hqq Stage 1.1 categories
-      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
-	if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
-	int Njets=jets.size();
-	if (Njets==0)        return QQ2HQQ_0J;
-	else if (Njets==1)   return QQ2HQQ_1J;
-	else if (Njets>=2) {
-	  double mjj = (jets[0].mom()+jets[1].mom()).mass();
-	  if ( mjj < 60 )      return QQ2HQQ_MJJ_0_60;
-	  else if ( 60 < mjj && mjj < 120 ) return QQ2HQQ_MJJ_60_120;
-	  else if ( 120 < mjj && mjj < 350 ) return QQ2HQQ_MJJ_120_350;
-	  else if (  mjj > 350 ) {
-            if (higgs.pt()>200) return QQ2HQQ_MJJ_GT350_PTH_GT200;
-            if(vbfTopo) return Category(QQ2HQQ_MJJ_GT350_PTH_GT200+vbfTopo);
-	  }
-	}
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5)
+          return QQ2HQQ_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return QQ2HQQ_0J;
+        else if (Njets == 1)
+          return QQ2HQQ_1J;
+        else if (Njets >= 2) {
+          double mjj = (jets[0].mom() + jets[1].mom()).mass();
+          if (mjj < 60)
+            return QQ2HQQ_MJJ_0_60;
+          else if (60 < mjj && mjj < 120)
+            return QQ2HQQ_MJJ_60_120;
+          else if (120 < mjj && mjj < 350)
+            return QQ2HQQ_MJJ_120_350;
+          else if (mjj > 350) {
+            if (higgs.pt() > 200)
+              return QQ2HQQ_MJJ_GT350_PTH_GT200;
+            if (vbfTopo)
+              return Category(QQ2HQQ_MJJ_GT350_PTH_GT200 + vbfTopo);
+          }
+        }
       }
       // 3. WH->Hlv categories
-      else if (prodMode==HTXS::WH) {
-        if (fwdHiggs) return QQ2HLNU_FWDH;
-        else if (V.pt()<75) return QQ2HLNU_PTV_0_75;
-        else if (V.pt()<150) return QQ2HLNU_PTV_75_150;
-	else if (V.pt()>250) return QQ2HLNU_PTV_GT250;
-	// 150 < pTV/GeV < 250
-	return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs)
+          return QQ2HLNU_FWDH;
+        else if (V.pt() < 75)
+          return QQ2HLNU_PTV_0_75;
+        else if (V.pt() < 150)
+          return QQ2HLNU_PTV_75_150;
+        else if (V.pt() > 250)
+          return QQ2HLNU_PTV_GT250;
+        // 150 < pTV/GeV < 250
+        return jets.empty() ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
       }
       // 4. qq->ZH->llH categories
-      else if (prodMode==HTXS::QQ2ZH) {
-        if (fwdHiggs) return QQ2HLL_FWDH;
-        else if (V.pt()<75) return QQ2HLL_PTV_0_75;
-        else if (V.pt()<150) return QQ2HLL_PTV_75_150;
-	else if (V.pt()>250) return QQ2HLL_PTV_GT250;
-	// 150 < pTV/GeV < 250
-	return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs)
+          return QQ2HLL_FWDH;
+        else if (V.pt() < 75)
+          return QQ2HLL_PTV_0_75;
+        else if (V.pt() < 150)
+          return QQ2HLL_PTV_75_150;
+        else if (V.pt() > 250)
+          return QQ2HLL_PTV_GT250;
+        // 150 < pTV/GeV < 250
+        return jets.empty() ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
       }
       // 5. gg->ZH->llH categories
-      else if (prodMode==HTXS::GG2ZH ) {
-        if (fwdHiggs) return GG2HLL_FWDH;
-        else if (V.pt()<75) return GG2HLL_PTV_0_75;
-        else if (V.pt()<150) return GG2HLL_PTV_75_150;
-        else if (V.pt()>250) return GG2HLL_PTV_GT250;
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs)
+          return GG2HLL_FWDH;
+        else if (V.pt() < 75)
+          return GG2HLL_PTV_0_75;
+        else if (V.pt() < 150)
+          return GG2HLL_PTV_75_150;
+        else if (V.pt() > 250)
+          return GG2HLL_PTV_GT250;
         return jets.empty() ? GG2HLL_PTV_150_250_0J : GG2HLL_PTV_150_250_GE1J;
       }
       // 6.ttH,bbH,tH categories
-      else if (prodMode==HTXS::TTH) return Category(TTH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      else if (prodMode == HTXS::TTH)
+        return Category(TTH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(TH_FWDH + ctrlHiggs);
       return UNKNOWN;
     }
 
     /// @brief Stage-1_1 categorization
     HTXS::Stage1_1_Fine::Category getStage1_1_Fine_Category(const HTXS::HiggsProdMode prodMode,
-							    const Particle &higgs,
-							    const Jets &jets,
-							    const Particle &V) {
+                                                            const Particle &higgs,
+                                                            const Jets &jets,
+                                                            const Particle &V) {
       using namespace HTXS::Stage1_1_Fine;
-      int Njets=jets.size(), ctrlHiggs = std::abs(higgs.rapidity())<2.5, fwdHiggs = !ctrlHiggs;
-      int vbfTopo = vbfTopology_Stage1_1_Fine(jets,higgs);
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_1_Fine(jets, higgs);
 
       // 1. GGF Stage 1.1 categories
       //    Following YR4 write-up: XXXXX
-      if (prodMode==HTXS::GGF || (prodMode==HTXS::GG2ZH && quarkDecay(V)) ) {
-	if (fwdHiggs)        return GG2H_FWDH;
-	if ( higgs.pt()>200 ) return GG2H_PTH_GT200;
-	if (Njets==0)  return higgs.pt()<10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
-	if (Njets==1)  return Category(GG2H_1J_PTH_0_60+getBin(higgs.pt(),{0,60,120,200}));
-	if (Njets>1){
-	  //double mjj = (jets[0].mom()+jets[1].mom()).mass();
-	  double pTHjj = (jets[0].momentum()+jets[1].momentum()+higgs.momentum()).pt();
-	  //VBF topology
-	  if(vbfTopo) return Category(GG2H_MJJ_350_700_PTHJJ_0_25+vbfTopo-1);
-	  //Njets >= 2jets without VBF topology (mjj<350)
-	  if (pTHjj<25) return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_0_25+getBin(higgs.pt(),{0,60,120,200}));
-	  else return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_GT25+getBin(higgs.pt(),{0,60,120,200}));
-	}
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs)
+          return GG2H_FWDH;
+        if (higgs.pt() > 200)
+          return GG2H_PTH_GT200;
+        if (Njets == 0)
+          return higgs.pt() < 10 ? GG2H_0J_PTH_0_10 : GG2H_0J_PTH_GT10;
+        if (Njets == 1)
+          return Category(GG2H_1J_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        if (Njets > 1) {
+          //double mjj = (jets[0].mom()+jets[1].mom()).mass();
+          double pTHjj = (jets[0].momentum() + jets[1].momentum() + higgs.momentum()).pt();
+          //VBF topology
+          if (vbfTopo)
+            return Category(GG2H_MJJ_350_700_PTHJJ_0_25 + vbfTopo - 1);
+          //Njets >= 2jets without VBF topology (mjj<350)
+          if (pTHjj < 25)
+            return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_0_25 + getBin(higgs.pt(), {0, 60, 120, 200}));
+          else
+            return Category(GG2H_GE2J_MJJ_0_350_PTH_0_60_PTHJJ_GT25 + getBin(higgs.pt(), {0, 60, 120, 200}));
+        }
       }
 
       // 2. Electroweak qq->Hqq Stage 1.1 categories
-      else if (prodMode==HTXS::VBF || ( isVH(prodMode) && quarkDecay(V)) ) {
-	if (std::abs(higgs.rapidity())>2.5) return QQ2HQQ_FWDH;
-	int Njets=jets.size();
-	if (Njets==0)        return QQ2HQQ_0J;
-	else if (Njets==1)   return QQ2HQQ_1J;
-	else if (Njets>=2) {
-	  double mjj = (jets[0].mom()+jets[1].mom()).mass();
-	  double pTHjj = (jets[0].momentum()+jets[1].momentum()+higgs.momentum()).pt();
-	  if (mjj<350){
-            if (pTHjj<25) return Category(QQ2HQQ_MJJ_0_60_PTHJJ_0_25+getBin(mjj,{0,60,120,350}));
-            else return Category(QQ2HQQ_MJJ_0_60_PTHJJ_GT25+getBin(mjj,{0,60,120,350}));
-	  } else { //mjj>350 GeV
-            if (higgs.pt()<200){
-	      return Category(QQ2HQQ_MJJ_350_700_PTHJJ_0_25+vbfTopo-1);
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5)
+          return QQ2HQQ_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return QQ2HQQ_0J;
+        else if (Njets == 1)
+          return QQ2HQQ_1J;
+        else if (Njets >= 2) {
+          double mjj = (jets[0].mom() + jets[1].mom()).mass();
+          double pTHjj = (jets[0].momentum() + jets[1].momentum() + higgs.momentum()).pt();
+          if (mjj < 350) {
+            if (pTHjj < 25)
+              return Category(QQ2HQQ_MJJ_0_60_PTHJJ_0_25 + getBin(mjj, {0, 60, 120, 350}));
+            else
+              return Category(QQ2HQQ_MJJ_0_60_PTHJJ_GT25 + getBin(mjj, {0, 60, 120, 350}));
+          } else {  //mjj>350 GeV
+            if (higgs.pt() < 200) {
+              return Category(QQ2HQQ_MJJ_350_700_PTHJJ_0_25 + vbfTopo - 1);
             } else {
-	      return Category(QQ2HQQ_PTH_GT200_MJJ_350_700_PTHJJ_0_25+vbfTopo-1);
+              return Category(QQ2HQQ_PTH_GT200_MJJ_350_700_PTHJJ_0_25 + vbfTopo - 1);
             }
-	  }
-	}
+          }
+        }
       }
       // 3. WH->Hlv categories
-      else if (prodMode==HTXS::WH) {
-        if (fwdHiggs) return QQ2HLNU_FWDH;
-        int Njets=jets.size();
-        if (Njets==0) return Category(QQ2HLNU_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
-        if (Njets==1) return Category(QQ2HLNU_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
-        return Category(QQ2HLNU_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs)
+          return QQ2HLNU_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return Category(QQ2HLNU_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        if (Njets == 1)
+          return Category(QQ2HLNU_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        return Category(QQ2HLNU_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400}));
       }
       // 4. qq->ZH->llH categories
-      else if (prodMode==HTXS::QQ2ZH) {
-        if (fwdHiggs) return QQ2HLL_FWDH;
-        int Njets=jets.size();
-        if (Njets==0) return Category(QQ2HLL_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
-        if (Njets==1) return Category(QQ2HLL_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
-        return Category(QQ2HLL_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs)
+          return QQ2HLL_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return Category(QQ2HLL_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        if (Njets == 1)
+          return Category(QQ2HLL_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        return Category(QQ2HLL_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400}));
       }
       // 5. gg->ZH->llH categories
-      else if (prodMode==HTXS::GG2ZH ) {
-        if (fwdHiggs) return GG2HLL_FWDH;
-        int Njets=jets.size();
-        if (Njets==0) return Category(GG2HLL_PTV_0_75_0J+getBin(V.pt(),{0,75,150,250,400}));
-        if (Njets==1) return Category(GG2HLL_PTV_0_75_1J+getBin(V.pt(),{0,75,150,250,400}));
-        return Category(GG2HLL_PTV_0_75_GE2J+getBin(V.pt(),{0,75,150,250,400}));
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs)
+          return GG2HLL_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return Category(GG2HLL_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        if (Njets == 1)
+          return Category(GG2HLL_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400}));
+        return Category(GG2HLL_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400}));
       }
       // 6.ttH,bbH,tH categories
-      else if (prodMode==HTXS::TTH) return Category(TTH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::BBH) return Category(BBH_FWDH+ctrlHiggs);
-      else if (prodMode==HTXS::TH ) return Category(TH_FWDH+ctrlHiggs);
+      else if (prodMode == HTXS::TTH)
+        return Category(TTH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(TH_FWDH + ctrlHiggs);
       return UNKNOWN;
     }
 
-
     /// @}
-
 
     /// @name Default Rivet analysis methods and steering methods
     /// @{
 
     /// @brief Sets the Higgs production mode
-    void setHiggsProdMode( HTXS::HiggsProdMode prodMode ){ m_HiggsProdMode = prodMode; }
+    void setHiggsProdMode(HTXS::HiggsProdMode prodMode) { m_HiggsProdMode = prodMode; }
 
     /// @brief default Rivet Analysis::init method
     /// Booking of histograms, initializing Rivet projection
@@ -596,131 +710,153 @@ namespace Rivet {
       printf("==============================================================\n");
       // check that the production mode has been set
       // if running in standalone Rivet the production mode is set through an env variable
-      if (m_HiggsProdMode==HTXS::UNKNOWN) {
-	char *pm_env = getenv("HIGGSPRODMODE");
-	string pm(pm_env==nullptr?"":pm_env);
-        if      ( pm == "GGF"   ) m_HiggsProdMode = HTXS::GGF;
-        else if ( pm == "VBF"   ) m_HiggsProdMode = HTXS::VBF;
-        else if ( pm == "WH"    ) m_HiggsProdMode = HTXS::WH;
-        else if ( pm == "ZH"    ) m_HiggsProdMode = HTXS::QQ2ZH;
-        else if ( pm == "QQ2ZH" ) m_HiggsProdMode = HTXS::QQ2ZH;
-        else if ( pm == "GG2ZH" ) m_HiggsProdMode = HTXS::GG2ZH;
-        else if ( pm == "TTH"   ) m_HiggsProdMode = HTXS::TTH;
-        else if ( pm == "BBH"   ) m_HiggsProdMode = HTXS::BBH;
-        else if ( pm == "TH"    ) m_HiggsProdMode = HTXS::TH;
+      if (m_HiggsProdMode == HTXS::UNKNOWN) {
+        char *pm_env = getenv("HIGGSPRODMODE");
+        string pm(pm_env == nullptr ? "" : pm_env);
+        if (pm == "GGF")
+          m_HiggsProdMode = HTXS::GGF;
+        else if (pm == "VBF")
+          m_HiggsProdMode = HTXS::VBF;
+        else if (pm == "WH")
+          m_HiggsProdMode = HTXS::WH;
+        else if (pm == "ZH")
+          m_HiggsProdMode = HTXS::QQ2ZH;
+        else if (pm == "QQ2ZH")
+          m_HiggsProdMode = HTXS::QQ2ZH;
+        else if (pm == "GG2ZH")
+          m_HiggsProdMode = HTXS::GG2ZH;
+        else if (pm == "TTH")
+          m_HiggsProdMode = HTXS::TTH;
+        else if (pm == "BBH")
+          m_HiggsProdMode = HTXS::BBH;
+        else if (pm == "TH")
+          m_HiggsProdMode = HTXS::TH;
         else {
           MSG_WARNING("No HIGGSPRODMODE shell variable found. Needed when running Rivet stand-alone.");
         }
       }
 
       // Projections for final state particles
-      const FinalState FS; 
-      addProjection(FS,"FS");
+      const FinalState FS;
+      addProjection(FS, "FS");
 
       // initialize the histograms with for each of the stages
       initializeHistos();
       m_sumw = 0.0;
       printf("==============================================================\n");
-      printf("========             Higgs prod mode %d              =========\n",m_HiggsProdMode);
+      printf("========             Higgs prod mode %d              =========\n", m_HiggsProdMode);
       printf("========          Sucessful Initialization           =========\n");
       printf("==============================================================\n");
     }
-        
-    // Perform the per-event analysis
-    void analyze(const Event& event) override {
 
+    // Perform the per-event analysis
+    void analyze(const Event &event) override {
       // get the classification
-      HiggsClassification cat = classifyEvent(event,m_HiggsProdMode);
+      HiggsClassification cat = classifyEvent(event, m_HiggsProdMode);
 
       // Fill histograms: categorization --> linerize the categories
       const double weight = event.weight();
       m_sumw += weight;
 
-      int F=cat.stage0_cat%10, P=cat.stage1_cat_pTjet30GeV/100;
-      hist_stage0->fill( cat.stage0_cat/10*2+F, weight );
-      
+      int F = cat.stage0_cat % 10, P = cat.stage1_cat_pTjet30GeV / 100;
+      hist_stage0->fill(cat.stage0_cat / 10 * 2 + F, weight);
+
       // Stage 1 enum offsets for each production mode: GGF=12, VBF=6, WH= 5, QQ2ZH=5, GG2ZH=4, TTH=2, BBH=2, TH=2
-      vector<int> offset({0,1,13,19,24,29,33,35,37,39});
+      vector<int> offset({0, 1, 13, 19, 24, 29, 33, 35, 37, 39});
       int off = offset[P];
-      hist_stage1_pTjet25->fill(cat.stage1_cat_pTjet25GeV%100 + off, weight);
-      hist_stage1_pTjet30->fill(cat.stage1_cat_pTjet30GeV%100 + off, weight);
+      hist_stage1_pTjet25->fill(cat.stage1_cat_pTjet25GeV % 100 + off, weight);
+      hist_stage1_pTjet30->fill(cat.stage1_cat_pTjet30GeV % 100 + off, weight);
 
       // Fill histograms: variables used in the categorization
-      hist_pT_Higgs->fill(cat.higgs.pT(),weight);
-      hist_y_Higgs->fill(cat.higgs.rapidity(),weight);
-      hist_pT_V->fill(cat.V.pT(),weight);
+      hist_pT_Higgs->fill(cat.higgs.pT(), weight);
+      hist_y_Higgs->fill(cat.higgs.rapidity(), weight);
+      hist_pT_V->fill(cat.V.pT(), weight);
 
-      hist_Njets25->fill(cat.jets25.size(),weight);
-      hist_Njets30->fill(cat.jets30.size(),weight);
+      hist_Njets25->fill(cat.jets25.size(), weight);
+      hist_Njets30->fill(cat.jets30.size(), weight);
 
       // Jet variables. Use jet collection with pT threshold at 30 GeV
-      if (!cat.jets30.empty()) hist_pT_jet1->fill(cat.jets30[0].pt(),weight);
-      if (cat.jets30.size()>=2) {
-	const FourMomentum &j1 = cat.jets30[0].momentum(), &j2 = cat.jets30[1].momentum();
-	hist_deltay_jj->fill(std::abs(j1.rapidity()-j2.rapidity()),weight);
-	hist_dijet_mass->fill((j1+j2).mass(),weight);
-	hist_pT_Hjj->fill((j1+j2+cat.higgs.momentum()).pt(),weight);
+      if (!cat.jets30.empty())
+        hist_pT_jet1->fill(cat.jets30[0].pt(), weight);
+      if (cat.jets30.size() >= 2) {
+        const FourMomentum &j1 = cat.jets30[0].momentum(), &j2 = cat.jets30[1].momentum();
+        hist_deltay_jj->fill(std::abs(j1.rapidity() - j2.rapidity()), weight);
+        hist_dijet_mass->fill((j1 + j2).mass(), weight);
+        hist_pT_Hjj->fill((j1 + j2 + cat.higgs.momentum()).pt(), weight);
       }
-    }
-    
-    void printClassificationSummary(){
-      MSG_INFO (" ====================================================== ");
-      MSG_INFO ("      Higgs Template X-Sec Categorization Tool          ");
-      MSG_INFO ("                Status Code Summary                     ");
-      MSG_INFO (" ====================================================== ");
-      bool allSuccess = (numEvents()==m_errorCount[HTXS::SUCCESS]);
-      if ( allSuccess ) MSG_INFO ("     >>>> All "<< m_errorCount[HTXS::SUCCESS] <<" events successfully categorized!");
-      else{
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::SUCCESS] <<" events successfully categorized");
-	MSG_INFO ("     >>>> --> the following errors occured:");
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::PRODMODE_DEFINED] <<" had an undefined Higgs production mode.");
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::MOMENTUM_CONSERVATION] <<" failed momentum conservation.");
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::HIGGS_IDENTIFICATION] <<" failed to identify a valid Higgs boson.");
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::HS_VTX_IDENTIFICATION] <<" failed to identify the hard scatter vertex.");
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::VH_IDENTIFICATION] <<" VH: to identify a valid V-boson.");
-	MSG_INFO ("     >>>> "<< m_errorCount[HTXS::TOP_W_IDENTIFICATION] <<" failed to identify valid Ws from top decay.");
-      }
-      MSG_INFO (" ====================================================== ");
-      MSG_INFO (" ====================================================== ");
     }
 
+    void printClassificationSummary() {
+      MSG_INFO(" ====================================================== ");
+      MSG_INFO("      Higgs Template X-Sec Categorization Tool          ");
+      MSG_INFO("                Status Code Summary                     ");
+      MSG_INFO(" ====================================================== ");
+      bool allSuccess = (numEvents() == m_errorCount[HTXS::SUCCESS]);
+      if (allSuccess)
+        MSG_INFO("     >>>> All " << m_errorCount[HTXS::SUCCESS] << " events successfully categorized!");
+      else {
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::SUCCESS] << " events successfully categorized");
+        MSG_INFO("     >>>> --> the following errors occured:");
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::PRODMODE_DEFINED] << " had an undefined Higgs production mode.");
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::MOMENTUM_CONSERVATION] << " failed momentum conservation.");
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::HIGGS_IDENTIFICATION]
+                              << " failed to identify a valid Higgs boson.");
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::HS_VTX_IDENTIFICATION]
+                              << " failed to identify the hard scatter vertex.");
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::VH_IDENTIFICATION] << " VH: to identify a valid V-boson.");
+        MSG_INFO("     >>>> " << m_errorCount[HTXS::TOP_W_IDENTIFICATION]
+                              << " failed to identify valid Ws from top decay.");
+      }
+      MSG_INFO(" ====================================================== ");
+      MSG_INFO(" ====================================================== ");
+    }
 
     void finalize() override {
       printClassificationSummary();
-      double sf = m_sumw>0?1.0/m_sumw:1.0;
-      for (auto hist:{hist_stage0,hist_stage1_pTjet25,hist_stage1_pTjet30,hist_Njets25,hist_Njets30,
-	    hist_pT_Higgs,hist_y_Higgs,hist_pT_V,hist_pT_jet1,hist_deltay_jj,hist_dijet_mass,hist_pT_Hjj})
-	scale(hist, sf);
+      double sf = m_sumw > 0 ? 1.0 / m_sumw : 1.0;
+      for (auto hist : {hist_stage0,
+                        hist_stage1_pTjet25,
+                        hist_stage1_pTjet30,
+                        hist_Njets25,
+                        hist_Njets30,
+                        hist_pT_Higgs,
+                        hist_y_Higgs,
+                        hist_pT_V,
+                        hist_pT_jet1,
+                        hist_deltay_jj,
+                        hist_dijet_mass,
+                        hist_pT_Hjj})
+        scale(hist, sf);
     }
-    
+
     /*
      *  initialize histograms
      */
 
-    void initializeHistos(){
-      hist_stage0          = bookHisto1D("HTXS_stage0",20,0,20);
-      hist_stage1_pTjet25  = bookHisto1D("HTXS_stage1_pTjet25",40,0,40);
-      hist_stage1_pTjet30  = bookHisto1D("HTXS_stage1_pTjet30",40,0,40);
-      hist_pT_Higgs    = bookHisto1D("pT_Higgs",80,0,400);
-      hist_y_Higgs     = bookHisto1D("y_Higgs",80,-4,4);
-      hist_pT_V        = bookHisto1D("pT_V",80,0,400);
-      hist_pT_jet1     = bookHisto1D("pT_jet1",80,0,400);
-      hist_deltay_jj   = bookHisto1D("deltay_jj",50,0,10);
-      hist_dijet_mass  = bookHisto1D("m_jj",50,0,2000);
-      hist_pT_Hjj      = bookHisto1D("pT_Hjj",50,0,250);
-      hist_Njets25     = bookHisto1D("Njets25",10,0,10);
-      hist_Njets30     = bookHisto1D("Njets30",10,0,10);
+    void initializeHistos() {
+      hist_stage0 = bookHisto1D("HTXS_stage0", 20, 0, 20);
+      hist_stage1_pTjet25 = bookHisto1D("HTXS_stage1_pTjet25", 40, 0, 40);
+      hist_stage1_pTjet30 = bookHisto1D("HTXS_stage1_pTjet30", 40, 0, 40);
+      hist_pT_Higgs = bookHisto1D("pT_Higgs", 80, 0, 400);
+      hist_y_Higgs = bookHisto1D("y_Higgs", 80, -4, 4);
+      hist_pT_V = bookHisto1D("pT_V", 80, 0, 400);
+      hist_pT_jet1 = bookHisto1D("pT_jet1", 80, 0, 400);
+      hist_deltay_jj = bookHisto1D("deltay_jj", 50, 0, 10);
+      hist_dijet_mass = bookHisto1D("m_jj", 50, 0, 2000);
+      hist_pT_Hjj = bookHisto1D("pT_Hjj", 50, 0, 250);
+      hist_Njets25 = bookHisto1D("Njets25", 10, 0, 10);
+      hist_Njets30 = bookHisto1D("Njets30", 10, 0, 10);
     }
     /// @}
 
     /*
      *    initialize private members used in the classification procedure
      */
-    
+
   private:
     double m_sumw;
     HTXS::HiggsProdMode m_HiggsProdMode;
-    std::map<HTXS::ErrorCode,size_t> m_errorCount;
+    std::map<HTXS::ErrorCode, size_t> m_errorCount;
     Histo1DPtr hist_stage0;
     Histo1DPtr hist_stage1_pTjet25, hist_stage1_pTjet30;
     Histo1DPtr hist_pT_Higgs, hist_y_Higgs;
@@ -737,7 +873,6 @@ namespace Rivet {
   DECLARE_RIVET_PLUGIN(HiggsTemplateCrossSections);
 #endif
 
-}
+}  // namespace Rivet
 
 #endif
-    

--- a/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
+++ b/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
@@ -9,28 +9,24 @@ namespace HTXS {
 
   /// Error code: whether the classification was successful or failed
   enum ErrorCode {
-    UNDEFINED=-99,
-    SUCCESS = 0,               ///< successful classification
-    PRODMODE_DEFINED = 1,      ///< production mode not defined
-    MOMENTUM_CONSERVATION = 2, ///< failed momentum conservation
-    HIGGS_IDENTIFICATION = 3,  ///< failed to identify Higgs boson
+    UNDEFINED = -99,
+    SUCCESS = 0,                     ///< successful classification
+    PRODMODE_DEFINED = 1,            ///< production mode not defined
+    MOMENTUM_CONSERVATION = 2,       ///< failed momentum conservation
+    HIGGS_IDENTIFICATION = 3,        ///< failed to identify Higgs boson
     HIGGS_DECAY_IDENTIFICATION = 4,  ///< failed to identify Higgs boson decay products
-    HS_VTX_IDENTIFICATION = 5, ///< failed to identify hard scatter vertex
-    VH_IDENTIFICATION = 6,     ///< failed to identify associated vector boson
+    HS_VTX_IDENTIFICATION = 5,       ///< failed to identify hard scatter vertex
+    VH_IDENTIFICATION = 6,           ///< failed to identify associated vector boson
     VH_DECAY_IDENTIFICATION = 7,     ///< failed to identify associated vector boson decay products
-    TOP_W_IDENTIFICATION = 8   ///< failed to identify top decay
+    TOP_W_IDENTIFICATION = 8         ///< failed to identify top decay
   };
 
   /// Higgs production modes, corresponding to input sample
-  enum HiggsProdMode {
-    UNKNOWN = 0,
-    GGF = 1, VBF = 2, WH = 3, QQ2ZH = 4, GG2ZH = 5,
-    TTH = 6, BBH = 7, TH = 8 
-  };
-  
+  enum HiggsProdMode { UNKNOWN = 0, GGF = 1, VBF = 2, WH = 3, QQ2ZH = 4, GG2ZH = 5, TTH = 6, BBH = 7, TH = 8 };
+
   /// Additional identifier flag for TH production modes
-  enum tH_type { noTH=0, THQB=1, TWH=2 };
-  
+  enum tH_type { noTH = 0, THQB = 1, TWH = 2 };
+
   ///   Two digit number of format PF
   ///   P is digit for the physics process
   ///   and F is 0 for |yH|>2.5 and 11 for |yH|<2.5 ("in fiducial")
@@ -39,10 +35,27 @@ namespace HTXS {
   namespace Stage0 {
     /// @enum Stage-0 ategorization: Two-digit number of format PF, with P for process and F being 0 for |yH|>2.5 and 1 for |yH|<2.5
     enum Category {
-      UNKNOWN  = 0, GG2H_FWDH = 10, GG2H = 11, VBF_FWDH = 20, VBF = 21, VH2HQQ_FWDH = 22, VH2HQQ = 23,
-      QQ2HLNU_FWDH = 30, QQ2HLNU = 31, QQ2HLL_FWDH = 40, QQ2HLL = 41, GG2HLL_FWDH = 50, GG2HLL = 51,
-      TTH_FWDH = 60, TTH = 61, BBH_FWDH = 70, BBH = 71, TH_FWDH = 80, TH = 81 };
-  }
+      UNKNOWN = 0,
+      GG2H_FWDH = 10,
+      GG2H = 11,
+      VBF_FWDH = 20,
+      VBF = 21,
+      VH2HQQ_FWDH = 22,
+      VH2HQQ = 23,
+      QQ2HLNU_FWDH = 30,
+      QQ2HLNU = 31,
+      QQ2HLL_FWDH = 40,
+      QQ2HLL = 41,
+      GG2HLL_FWDH = 50,
+      GG2HLL = 51,
+      TTH_FWDH = 60,
+      TTH = 61,
+      BBH_FWDH = 70,
+      BBH = 71,
+      TH_FWDH = 80,
+      TH = 81
+    };
+  }  // namespace Stage0
 
   /// Categorization Stage 1:
   /// Three digit integer of format PF
@@ -50,19 +63,27 @@ namespace HTXS {
   /// F is a unique integer ( F < 99 ) corresponding to each Stage1 phase-space region (bin)
   namespace Stage1 {
     enum Category {
-      UNKNOWN  = 0,
+      UNKNOWN = 0,
       // Gluon fusion
       GG2H_FWDH = 100,
-      GG2H_VBFTOPO_JET3VETO = 101, GG2H_VBFTOPO_JET3 = 102,
-      GG2H_0J   = 103,
-      GG2H_1J_PTH_0_60 = 104,      GG2H_1J_PTH_60_120 = 105,
-      GG2H_1J_PTH_120_200 = 106,   GG2H_1J_PTH_GT200 = 107,
-      GG2H_GE2J_PTH_0_60 = 108,      GG2H_GE2J_PTH_60_120 = 109,
-      GG2H_GE2J_PTH_120_200 = 110,   GG2H_GE2J_PTH_GT200 = 111,
+      GG2H_VBFTOPO_JET3VETO = 101,
+      GG2H_VBFTOPO_JET3 = 102,
+      GG2H_0J = 103,
+      GG2H_1J_PTH_0_60 = 104,
+      GG2H_1J_PTH_60_120 = 105,
+      GG2H_1J_PTH_120_200 = 106,
+      GG2H_1J_PTH_GT200 = 107,
+      GG2H_GE2J_PTH_0_60 = 108,
+      GG2H_GE2J_PTH_60_120 = 109,
+      GG2H_GE2J_PTH_120_200 = 110,
+      GG2H_GE2J_PTH_GT200 = 111,
       // "VBF"
       QQ2HQQ_FWDH = 200,
-      QQ2HQQ_VBFTOPO_JET3VETO = 201, QQ2HQQ_VBFTOPO_JET3 = 202,
-      QQ2HQQ_VH2JET = 203, QQ2HQQ_REST = 204, QQ2HQQ_PTJET1_GT200 = 205,
+      QQ2HQQ_VBFTOPO_JET3VETO = 201,
+      QQ2HQQ_VBFTOPO_JET3 = 202,
+      QQ2HQQ_VH2JET = 203,
+      QQ2HQQ_REST = 204,
+      QQ2HQQ_PTJET1_GT200 = 205,
       // qq -> WH
       QQ2HLNU_FWDH = 300,
       QQ2HLNU_PTV_0_150 = 301,
@@ -81,22 +102,25 @@ namespace HTXS {
       GG2HLL_PTV_GT150_0J = 502,
       GG2HLL_PTV_GT150_GE1J = 503,
       // ttH
-      TTH_FWDH = 600, TTH = 601,
+      TTH_FWDH = 600,
+      TTH = 601,
       // bbH
-      BBH_FWDH = 700, BBH = 701,
+      BBH_FWDH = 700,
+      BBH = 701,
       // tH
-      TH_FWDH = 800, TH = 801
+      TH_FWDH = 800,
+      TH = 801
     };
-  } // namespace Stage1
+  }  // namespace Stage1
 
-namespace Stage1_1 {
+  namespace Stage1_1 {
     enum Category {
-      UNKNOWN  = 0,
+      UNKNOWN = 0,
       // Gluon fusion
       GG2H_FWDH = 100,
       GG2H_PTH_GT200 = 101,
-      GG2H_0J_PTH_0_10   = 102,
-      GG2H_0J_PTH_GT10   = 103,
+      GG2H_0J_PTH_0_10 = 102,
+      GG2H_0J_PTH_GT10 = 103,
       GG2H_1J_PTH_0_60 = 104,
       GG2H_1J_PTH_60_120 = 105,
       GG2H_1J_PTH_120_200 = 106,
@@ -141,22 +165,25 @@ namespace Stage1_1 {
       GG2HLL_PTV_150_250_GE1J = 504,
       GG2HLL_PTV_GT250 = 505,
       // ttH
-      TTH_FWDH = 600, TTH = 601,
+      TTH_FWDH = 600,
+      TTH = 601,
       // bbH
-      BBH_FWDH = 700, BBH = 701,
+      BBH_FWDH = 700,
+      BBH = 701,
       // tH
-      TH_FWDH = 800, TH = 801
+      TH_FWDH = 800,
+      TH = 801
     };
-  } // namespace Stage1_1
+  }  // namespace Stage1_1
 
   namespace Stage1_1_Fine {
     enum Category {
-      UNKNOWN  = 0,
+      UNKNOWN = 0,
       // Gluon fusion
       GG2H_FWDH = 100,
       GG2H_PTH_GT200 = 101,
-      GG2H_0J_PTH_0_10   = 102,
-      GG2H_0J_PTH_GT10   = 103,
+      GG2H_0J_PTH_0_10 = 102,
+      GG2H_0J_PTH_GT10 = 103,
       GG2H_1J_PTH_0_60 = 104,
       GG2H_1J_PTH_60_120 = 105,
       GG2H_1J_PTH_120_200 = 106,
@@ -252,131 +279,133 @@ namespace Stage1_1 {
       GG2HLL_PTV_250_400_GE2J = 514,
       GG2HLL_PTV_GT400_GE2J = 515,
       // ttH
-      TTH_FWDH = 600, TTH = 601,
+      TTH_FWDH = 600,
+      TTH = 601,
       // bbH
-      BBH_FWDH = 700, BBH = 701,
+      BBH_FWDH = 700,
+      BBH = 701,
       // tH
-      TH_FWDH = 800, TH = 801
+      TH_FWDH = 800,
+      TH = 801
     };
-  } // namespace Stage1_1_Fine
+  }  // namespace Stage1_1_Fine
 
+  //#ifdef ROOT_TLorentzVector
+  //typedef TLorentzVector TLV;
+  typedef math::XYZTLorentzVectorD TLV;
+  typedef std::vector<TLV> TLVs;
 
-//#ifdef ROOT_TLorentzVector
-    //typedef TLorentzVector TLV;
-    typedef math::XYZTLorentzVectorD TLV;
-    typedef std::vector<TLV> TLVs;
-    
-    template <class vec4>
-      TLV MakeTLV(vec4 const p) { return TLV(p.px(),p.py(),p.pz(),p.E()); }
-    
-    template <class Vvec4>
-      inline TLVs MakeTLVs(Vvec4 const &rivet_jets){ 
-      TLVs jets; for ( auto jet:rivet_jets ) jets.push_back(MakeTLV(jet)); 
-      return jets; 
+  template <class vec4>
+  TLV MakeTLV(vec4 const p) {
+    return TLV(p.px(), p.py(), p.pz(), p.E());
+  }
+
+  template <class Vvec4>
+  inline TLVs MakeTLVs(Vvec4 const &rivet_jets) {
+    TLVs jets;
+    for (auto jet : rivet_jets)
+      jets.push_back(MakeTLV(jet));
+    return jets;
+  }
+
+  // Structure holding information about the current event:
+  // Four-momenta and event classification according to the
+  // Higgs Template Cross Section
+  struct HiggsClassification {
+    // Higgs production mode
+    HTXS::HiggsProdMode prodMode;
+    // The Higgs boson
+    TLV higgs;
+    // The Higgs boson decay products
+    TLV p4decay_higgs;
+    // Associated vector bosons
+    TLV V;
+    // The V-boson decay products
+    TLV p4decay_V;
+    // Jets are built ignoring Higgs decay products and leptons from V decays
+    // jets with pT > 25 GeV and 30 GeV
+    TLVs jets25, jets30;
+    // Event categorization according to YR4 wrtietup
+    // https://cds.cern.ch/record/2138079
+    HTXS::Stage0::Category stage0_cat;
+    HTXS::Stage1::Category stage1_cat_pTjet25GeV;
+    HTXS::Stage1::Category stage1_cat_pTjet30GeV;
+    HTXS::Stage1_1::Category stage1_1_cat_pTjet25GeV;
+    HTXS::Stage1_1::Category stage1_1_cat_pTjet30GeV;
+    HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet25GeV;
+    HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet30GeV;
+    // Error code :: classification was succesful or some error occured
+    HTXS::ErrorCode errorCode;
+  };
+
+  template <class category>
+  inline HTXS::HiggsClassification Rivet2Root(category const &htxs_cat_rivet) {
+    HTXS::HiggsClassification cat;
+    cat.prodMode = htxs_cat_rivet.prodMode;
+    cat.errorCode = htxs_cat_rivet.errorCode;
+    cat.higgs = MakeTLV(htxs_cat_rivet.higgs);
+    cat.V = MakeTLV(htxs_cat_rivet.V);
+    cat.p4decay_higgs = MakeTLV(htxs_cat_rivet.p4decay_higgs);
+    cat.p4decay_V = MakeTLV(htxs_cat_rivet.p4decay_V);
+    cat.jets25 = MakeTLVs(htxs_cat_rivet.jets25);
+    cat.jets30 = MakeTLVs(htxs_cat_rivet.jets30);
+    cat.stage0_cat = htxs_cat_rivet.stage0_cat;
+    cat.stage1_cat_pTjet25GeV = htxs_cat_rivet.stage1_cat_pTjet25GeV;
+    cat.stage1_cat_pTjet30GeV = htxs_cat_rivet.stage1_cat_pTjet30GeV;
+    cat.stage1_1_cat_pTjet25GeV = htxs_cat_rivet.stage1_1_cat_pTjet25GeV;
+    cat.stage1_1_cat_pTjet30GeV = htxs_cat_rivet.stage1_1_cat_pTjet30GeV;
+    cat.stage1_1_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_1_fine_cat_pTjet25GeV;
+    cat.stage1_1_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_1_fine_cat_pTjet30GeV;
+    return cat;
+  }
+
+  inline int HTXSstage1_to_HTXSstage1FineIndex(HTXS::Stage1::Category stage1, HiggsProdMode prodMode, tH_type tH) {
+    if (stage1 == HTXS::Stage1::Category::UNKNOWN)
+      return 0;
+    int P = (int)(stage1 / 100);
+    int F = (int)(stage1 % 100);
+    // 1.a spit tH categories
+    if (prodMode == HiggsProdMode::TH) {
+      // check that tH splitting is valid for Stage-1 FineIndex
+      // else return unknown category
+      if (tH == tH_type::noTH)
+        return 0;
+      // check if forward tH
+      int fwdH = F == 0 ? 0 : 1;
+      return (49 + 2 * (tH - 1) + fwdH);
     }
-    
-    // Structure holding information about the current event:
-    // Four-momenta and event classification according to the
-    // Higgs Template Cross Section
-    struct HiggsClassification {
-      // Higgs production mode
-      HTXS::HiggsProdMode prodMode;
-      // The Higgs boson
-      TLV higgs;
-      // The Higgs boson decay products
-      TLV p4decay_higgs;
-      // Associated vector bosons
-      TLV V;
-      // The V-boson decay products
-      TLV p4decay_V;
-      // Jets are built ignoring Higgs decay products and leptons from V decays
-      // jets with pT > 25 GeV and 30 GeV
-      TLVs jets25, jets30;
-      // Event categorization according to YR4 wrtietup
-      // https://cds.cern.ch/record/2138079
-      HTXS::Stage0::Category stage0_cat;
-      HTXS::Stage1::Category stage1_cat_pTjet25GeV;
-      HTXS::Stage1::Category stage1_cat_pTjet30GeV;
-      HTXS::Stage1_1::Category stage1_1_cat_pTjet25GeV;
-      HTXS::Stage1_1::Category stage1_1_cat_pTjet30GeV;
-      HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet25GeV;
-      HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet30GeV;
-      // Error code :: classification was succesful or some error occured
-      HTXS::ErrorCode errorCode;
-    };
-    
-    template <class category>
-      inline HTXS::HiggsClassification Rivet2Root(category const &htxs_cat_rivet){
-      HTXS::HiggsClassification cat;
-      cat.prodMode = htxs_cat_rivet.prodMode;
-      cat.errorCode = htxs_cat_rivet.errorCode;
-      cat.higgs = MakeTLV(htxs_cat_rivet.higgs);
-      cat.V = MakeTLV(htxs_cat_rivet.V);
-      cat.p4decay_higgs = MakeTLV(htxs_cat_rivet.p4decay_higgs);
-      cat.p4decay_V = MakeTLV(htxs_cat_rivet.p4decay_V);
-      cat.jets25 = MakeTLVs(htxs_cat_rivet.jets25);
-      cat.jets30 = MakeTLVs(htxs_cat_rivet.jets30);
-      cat.stage0_cat = htxs_cat_rivet.stage0_cat;
-      cat.stage1_cat_pTjet25GeV = htxs_cat_rivet.stage1_cat_pTjet25GeV;
-      cat.stage1_cat_pTjet30GeV = htxs_cat_rivet.stage1_cat_pTjet30GeV;
-      cat.stage1_1_cat_pTjet25GeV = htxs_cat_rivet.stage1_1_cat_pTjet25GeV;
-      cat.stage1_1_cat_pTjet30GeV = htxs_cat_rivet.stage1_1_cat_pTjet30GeV;
-      cat.stage1_1_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_1_fine_cat_pTjet25GeV;
-      cat.stage1_1_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_1_fine_cat_pTjet30GeV;
-      return cat;    
-    }
-    
+    // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
+    // offset vector 1: input is the Higgs prodMode
+    // first two indicies are dummies, given that this is only called for prodMode=2,3,4
+    std::vector<int> pMode_offset = {0, 0, 13, 19, 25};
+    if (P == 2)
+      return (F + pMode_offset[prodMode]);
+    // 1.c remaining categories
+    // offset vector 2: input is the Stage-1 category P
+    // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
+    std::vector<int> catP_offset = {0, 1, 0, 31, 36, 41, 45, 47};
+    return (F + catP_offset[P]);
+  }
 
-    
-    inline int HTXSstage1_to_HTXSstage1FineIndex(HTXS::Stage1::Category stage1, 
-						 HiggsProdMode prodMode, tH_type tH) {
+  inline int HTXSstage1_to_HTXSstage1FineIndex(const HiggsClassification &stxs,
+                                               tH_type tH = noTH,
+                                               bool jets_pT25 = false) {
+    HTXS::Stage1::Category stage1 = jets_pT25 == false ? stxs.stage1_cat_pTjet30GeV : stxs.stage1_cat_pTjet25GeV;
+    return HTXSstage1_to_HTXSstage1FineIndex(stage1, stxs.prodMode, tH);
+  }
 
-      if(stage1==HTXS::Stage1::Category::UNKNOWN) return 0;
-      int P = (int)(stage1 / 100);
-      int F = (int)(stage1 % 100);
-      // 1.a spit tH categories
-      if (prodMode==HiggsProdMode::TH) {
-	// check that tH splitting is valid for Stage-1 FineIndex
-	// else return unknown category
-	if(tH==tH_type::noTH) return 0;
-	// check if forward tH
-	int fwdH = F==0?0:1;
-	return (49 + 2*(tH-1) +fwdH);
-      }
-      // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
-      // offset vector 1: input is the Higgs prodMode 
-      // first two indicies are dummies, given that this is only called for prodMode=2,3,4 
-      std::vector<int> pMode_offset = {0,0,13,19,25};
-      if (P==2) return (F + pMode_offset[prodMode]);
-      // 1.c remaining categories
-      // offset vector 2: input is the Stage-1 category P 
-      // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
-      std::vector<int> catP_offset = {0,1,0,31,36,41,45,47};
-      return (F + catP_offset[P]);
-    }
+  inline int HTXSstage1_to_index(HTXS::Stage1::Category stage1) {
+    // the Stage-1 categories
+    int P = (int)(stage1 / 100);
+    int F = (int)(stage1 % 100);
+    std::vector<int> offset{0, 1, 13, 19, 24, 29, 33, 35, 37, 39};
+    // convert to linear values
+    return (F + offset[P]);
+  }
 
-    inline int HTXSstage1_to_HTXSstage1FineIndex(const HiggsClassification &stxs, 
-						 tH_type tH=noTH, bool jets_pT25 = false) {
-      HTXS::Stage1::Category stage1 = 
-	jets_pT25==false?stxs.stage1_cat_pTjet30GeV:
-	stxs.stage1_cat_pTjet25GeV;
-      return HTXSstage1_to_HTXSstage1FineIndex(stage1,stxs.prodMode,tH);
-    }
-    
-    inline int HTXSstage1_to_index(HTXS::Stage1::Category stage1) {
-      // the Stage-1 categories
-      int P = (int)(stage1 / 100);
-      int F = (int)(stage1 % 100);    
-      std::vector<int> offset{0,1,13,19,24,29,33,35,37,39};
-      // convert to linear values
-      return ( F + offset[P] );
-    }
+  // #endif
 
-     
-// #endif 
-
-} // namespace HTXS
-
+}  // namespace HTXS
 
 #ifdef RIVET_Particle_HH
 //#ifdef HIGGSTRUTHCLASSIFIER_HIGGSTRUTHCLASSIFIER_CC
@@ -417,9 +446,7 @@ namespace Rivet {
     /// Error code: Whether classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };
-} // namespace Rivet
+}  // namespace Rivet
 #endif
-
-
 
 #endif

--- a/SimDataFormats/HTXS/src/classes.h
+++ b/SimDataFormats/HTXS/src/classes.h
@@ -1,3 +1,2 @@
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-


### PR DESCRIPTION

Applying code-format for CMSSW category generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/362//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


