### PR TITLE
Running code-format for analysis-simulation

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.cc
@@ -14,75 +14,66 @@ typedef CaloCleaner<HORecHit> HORecHitColCleaner;
 typedef CaloCleaner<CastorRecHit> CastorRecHitColCleaner;
 typedef CaloCleaner<ZDCRecHit> ZDCRecHitColCleaner;
 
-
 //-------------------------------------------------------------------------------
 // define 'buildRecHit' functions used for different types of recHits
 //-------------------------------------------------------------------------------
-  
-
 
 template <typename T>
-void  CaloCleaner<T>::fill_correction_map(TrackDetMatchInfo *,  std::map<uint32_t, float> *)
-{
-  assert(0); // CV: make sure general function never gets called;
-             //     always use template specializations
+void CaloCleaner<T>::fill_correction_map(TrackDetMatchInfo *, std::map<uint32_t, float> *) {
+  assert(0);  // CV: make sure general function never gets called;
+              //     always use template specializations
 }
 
 template <>
-void  CaloCleaner<EcalRecHit>::fill_correction_map(TrackDetMatchInfo * info,  std::map<uint32_t, float> * cor_map)
-{
-  if (is_preshower_){
-     for ( std::vector<DetId>::const_iterator detId = info->crossedPreshowerIds.begin(); detId != info->crossedPreshowerIds.end(); ++detId ) {
-       (*cor_map) [detId->rawId()] = 9999999; // just remove all energy (Below 0 is not possible)  
-      }
-    } 
-  else {
-    for(std::vector<const EcalRecHit*>::const_iterator hit=info->crossedEcalRecHits.begin(); hit!=info->crossedEcalRecHits.end(); hit++){
+void CaloCleaner<EcalRecHit>::fill_correction_map(TrackDetMatchInfo *info, std::map<uint32_t, float> *cor_map) {
+  if (is_preshower_) {
+    for (std::vector<DetId>::const_iterator detId = info->crossedPreshowerIds.begin();
+         detId != info->crossedPreshowerIds.end();
+         ++detId) {
+      (*cor_map)[detId->rawId()] = 9999999;  // just remove all energy (Below 0 is not possible)
+    }
+  } else {
+    for (std::vector<const EcalRecHit *>::const_iterator hit = info->crossedEcalRecHits.begin();
+         hit != info->crossedEcalRecHits.end();
+         hit++) {
       //    (*cor_map) [(*hit)->detid().rawId()] +=(*hit)->energy();
-      (*cor_map) [(*hit)->detid().rawId()] =(*hit)->energy(); 
+      (*cor_map)[(*hit)->detid().rawId()] = (*hit)->energy();
     }
   }
 }
 
-
 template <>
-void  CaloCleaner<HBHERecHit>::fill_correction_map(TrackDetMatchInfo * info,  std::map<uint32_t, float> * cor_map)
-{
-  for(std::vector<const HBHERecHit*>::const_iterator hit = info->crossedHcalRecHits.begin(); hit != info->crossedHcalRecHits.end(); hit++) {
-    (*cor_map) [(*hit)->detid().rawId()] =(*hit)->energy(); 
+void CaloCleaner<HBHERecHit>::fill_correction_map(TrackDetMatchInfo *info, std::map<uint32_t, float> *cor_map) {
+  for (std::vector<const HBHERecHit *>::const_iterator hit = info->crossedHcalRecHits.begin();
+       hit != info->crossedHcalRecHits.end();
+       hit++) {
+    (*cor_map)[(*hit)->detid().rawId()] = (*hit)->energy();
   }
 }
 
-
 template <>
-void  CaloCleaner<HORecHit>::fill_correction_map(TrackDetMatchInfo * info,  std::map<uint32_t, float> * cor_map)
-{
-  for(std::vector<const HORecHit*>::const_iterator hit = info->crossedHORecHits.begin(); hit != info->crossedHORecHits.end(); hit++) {
-    (*cor_map) [(*hit)->detid().rawId()] =(*hit)->energy(); 
+void CaloCleaner<HORecHit>::fill_correction_map(TrackDetMatchInfo *info, std::map<uint32_t, float> *cor_map) {
+  for (std::vector<const HORecHit *>::const_iterator hit = info->crossedHORecHits.begin();
+       hit != info->crossedHORecHits.end();
+       hit++) {
+    (*cor_map)[(*hit)->detid().rawId()] = (*hit)->energy();
   }
 }
 
-
 template <>
-void  CaloCleaner<HFRecHit>::fill_correction_map(TrackDetMatchInfo * info,  std::map<uint32_t, float> * cor_map)
-{
- return; // No corrections for HF 
+void CaloCleaner<HFRecHit>::fill_correction_map(TrackDetMatchInfo *info, std::map<uint32_t, float> *cor_map) {
+  return;  // No corrections for HF
 }
 
 template <>
-void  CaloCleaner<CastorRecHit>::fill_correction_map(TrackDetMatchInfo * info,  std::map<uint32_t, float> * cor_map)
-{
- return;// No corrections for Castor
+void CaloCleaner<CastorRecHit>::fill_correction_map(TrackDetMatchInfo *info, std::map<uint32_t, float> *cor_map) {
+  return;  // No corrections for Castor
 }
 
 template <>
-void  CaloCleaner<ZDCRecHit>::fill_correction_map(TrackDetMatchInfo * info,  std::map<uint32_t, float> * cor_map)
-{
- return;// No corrections for Castor
+void CaloCleaner<ZDCRecHit>::fill_correction_map(TrackDetMatchInfo *info, std::map<uint32_t, float> *cor_map) {
+  return;  // No corrections for Castor
 }
-
-
-
 
 DEFINE_FWK_MODULE(EcalRecHitColCleaner);
 DEFINE_FWK_MODULE(HBHERecHitColCleaner);
@@ -91,6 +82,3 @@ DEFINE_FWK_MODULE(HORecHitColCleaner);
 DEFINE_FWK_MODULE(HFRecHitColCleaner);
 DEFINE_FWK_MODULE(CastorRecHitColCleaner);
 DEFINE_FWK_MODULE(ZDCRecHitColCleaner);
-
-
-

--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.h
@@ -32,99 +32,98 @@
 #include <iostream>
 #include <map>
 
-
 template <typename T>
-class CaloCleaner : public  edm::stream::EDProducer<>
-{
- public:
+class CaloCleaner : public edm::stream::EDProducer<> {
+public:
   explicit CaloCleaner(const edm::ParameterSet&);
   ~CaloCleaner() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef edm::SortedCollection<T> RecHitCollection;
 
   const edm::EDGetTokenT<edm::View<pat::Muon> > mu_input_;
 
-  std::map<std::string,  edm::EDGetTokenT<RecHitCollection > > inputs_;
- 
+  std::map<std::string, edm::EDGetTokenT<RecHitCollection> > inputs_;
+
   TrackDetectorAssociator trackAssociator_;
   TrackAssociatorParameters parameters_;
-  
+
   bool is_preshower_;
-  void fill_correction_map(TrackDetMatchInfo *,  std::map<uint32_t, float> *);
-  
+  void fill_correction_map(TrackDetMatchInfo*, std::map<uint32_t, float>*);
 };
 
 template <typename T>
-CaloCleaner<T>::CaloCleaner(const edm::ParameterSet& iConfig) :
-    mu_input_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonCollection")))
-{ 
-  std::vector<edm::InputTag> inCollections =  iConfig.getParameter<std::vector<edm::InputTag> >("oldCollection");
-  for (auto inCollection : inCollections){
-     inputs_[inCollection.instance()] = consumes<RecHitCollection >(inCollection);
-     produces<RecHitCollection>(inCollection.instance());
+CaloCleaner<T>::CaloCleaner(const edm::ParameterSet& iConfig)
+    : mu_input_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonCollection"))) {
+  std::vector<edm::InputTag> inCollections = iConfig.getParameter<std::vector<edm::InputTag> >("oldCollection");
+  for (auto inCollection : inCollections) {
+    inputs_[inCollection.instance()] = consumes<RecHitCollection>(inCollection);
+    produces<RecHitCollection>(inCollection.instance());
   }
-  
-  is_preshower_ =iConfig.getUntrackedParameter<bool>("is_preshower", false);
+
+  is_preshower_ = iConfig.getUntrackedParameter<bool>("is_preshower", false);
   edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
   edm::ConsumesCollector iC = consumesCollector();
-  parameters_.loadParameters( parameters, iC );
-   //trackAssociator_.useDefaultPropagator();
- 
+  parameters_.loadParameters(parameters, iC);
+  //trackAssociator_.useDefaultPropagator();
 }
 
 template <typename T>
-CaloCleaner<T>::~CaloCleaner()
-{
-// nothing to be done yet...  
+CaloCleaner<T>::~CaloCleaner() {
+  // nothing to be done yet...
 }
 
-
 template <typename T>
-void CaloCleaner<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CaloCleaner<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ESHandle<Propagator> propagator;
   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagator);
   trackAssociator_.setPropagator(propagator.product());
-  
-  edm::Handle< edm::View<pat::Muon> > muonHandle;
+
+  edm::Handle<edm::View<pat::Muon> > muonHandle;
   iEvent.getByToken(mu_input_, muonHandle);
   edm::View<pat::Muon> muons = *muonHandle;
-  
-  std::map<uint32_t, float>    correction_map;
+
+  std::map<uint32_t, float> correction_map;
 
   // Fill the correction map
   for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {
-    // get the basic informaiton like fill reco mouon does 
+    // get the basic informaiton like fill reco mouon does
     //     RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
     const reco::Track* track = nullptr;
-    if      ( iMuon->track().isNonnull() ) track = iMuon->track().get();
-    else if ( iMuon->standAloneMuon().isNonnull() ) track = iMuon->standAloneMuon().get();
-    else throw cms::Exception("FatalError") << "Failed to fill muon id information for a muon with undefined references to tracks";
-    TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *track, parameters_,TrackDetectorAssociator::Any);
-    fill_correction_map(&info,&correction_map);
+    if (iMuon->track().isNonnull())
+      track = iMuon->track().get();
+    else if (iMuon->standAloneMuon().isNonnull())
+      track = iMuon->standAloneMuon().get();
+    else
+      throw cms::Exception("FatalError")
+          << "Failed to fill muon id information for a muon with undefined references to tracks";
+    TrackDetMatchInfo info =
+        trackAssociator_.associate(iEvent, iSetup, *track, parameters_, TrackDetectorAssociator::Any);
+    fill_correction_map(&info, &correction_map);
   }
-  
-  // Copy the old collection and correct if necessary 
-  for (auto input_ : inputs_){
-    std::unique_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());   
+
+  // Copy the old collection and correct if necessary
+  for (auto input_ : inputs_) {
+    std::unique_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());
     edm::Handle<RecHitCollection> recHitCollection;
-   // iEvent.getByToken(input_.second[0], recHitCollection);   
-    iEvent.getByToken(input_.second, recHitCollection);  
-    for ( typename RecHitCollection::const_iterator recHit = recHitCollection->begin(); recHit != recHitCollection->end(); ++recHit ) {
-    if (correction_map[recHit->detid().rawId()] > 0){
-	float new_energy =  recHit->energy() - correction_map[recHit->detid().rawId()];
-	if (new_energy <= 0) continue; // Do not save empty Hits
-	T newRecHit(*recHit);
-	newRecHit.setEnergy(new_energy); 
-	recHitCollection_output->push_back(newRecHit);
+    // iEvent.getByToken(input_.second[0], recHitCollection);
+    iEvent.getByToken(input_.second, recHitCollection);
+    for (typename RecHitCollection::const_iterator recHit = recHitCollection->begin();
+         recHit != recHitCollection->end();
+         ++recHit) {
+      if (correction_map[recHit->detid().rawId()] > 0) {
+        float new_energy = recHit->energy() - correction_map[recHit->detid().rawId()];
+        if (new_energy <= 0)
+          continue;  // Do not save empty Hits
+        T newRecHit(*recHit);
+        newRecHit.setEnergy(new_energy);
+        recHitCollection_output->push_back(newRecHit);
+      } else {
+        recHitCollection_output->push_back(*recHit);
       }
-      else{
-	recHitCollection_output->push_back(*recHit);
-      }  
-     /* For the inveted collection   
+      /* For the inveted collection   
      if (correction_map[recHit->detid().rawId()] > 0){
 	float new_energy =   correction_map[recHit->detid().rawId()];
 	if (new_energy < 0) new_energy =0;
@@ -132,15 +131,10 @@ void CaloCleaner<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	newRecHit.setEnergy(new_energy); 
 	recHitCollection_output->push_back(newRecHit);
       }*/
-
-      
-      
-      
     }
     // Save the new collection
     recHitCollection_output->sort();
-    iEvent.put(std::move(recHitCollection_output),input_.first); 
+    iEvent.put(std::move(recHitCollection_output), input_.first);
   }
-
 }
 #endif

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
@@ -1,13 +1,11 @@
 #include "TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/Common/interface/SortedCollection.h"
-
 
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/DTRecHit/interface/DTSLRecCluster.h"
@@ -18,7 +16,6 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/HcalRecHit/interface/ZDCRecHit.h"
-
 
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/OwnVector.h"
@@ -37,45 +34,45 @@ typedef CollectionMerger<edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair>
 typedef CollectionMerger<edm::RangeMap<CSCDetId, edm::OwnVector<CSCRecHit2D> >, CSCRecHit2D> CSCRecHitColMerger;
 typedef CollectionMerger<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit> >, RPCRecHit> RPCRecHitColMerger;
 
-
-
 // -------- Here Tracker Merger -----------
 template <typename T1, typename T2>
-void  CollectionMerger<T1,T2>::fill_output_obj_tracker(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections, bool print_pixel)
-{
-
-    std::map<uint32_t, std::vector<BaseHit> >   output_map;
+void CollectionMerger<T1, T2>::fill_output_obj_tracker(std::unique_ptr<MergeCollection> &output,
+                                                       std::vector<edm::Handle<MergeCollection> > &inputCollections,
+                                                       bool print_pixel) {
+  std::map<uint32_t, std::vector<BaseHit> > output_map;
   // First merge the collections with the help of the output map
-  for (auto const & inputCollection : inputCollections){
-   for ( typename MergeCollection::const_iterator clustSet = inputCollection->begin(); clustSet!= inputCollection->end(); ++clustSet ) {
-      DetId detIdObject( clustSet->detId() );
-      for (typename edmNew::DetSet<BaseHit>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end(); ++clustIt ) {
+  for (auto const &inputCollection : inputCollections) {
+    for (typename MergeCollection::const_iterator clustSet = inputCollection->begin();
+         clustSet != inputCollection->end();
+         ++clustSet) {
+      DetId detIdObject(clustSet->detId());
+      for (typename edmNew::DetSet<BaseHit>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end();
+           ++clustIt) {
         output_map[detIdObject.rawId()].push_back(*clustIt);
-       }
+      }
     }
   }
   // Now save it into the standard CMSSW format, with the standard Filler
-  for (typename std::map<uint32_t, std::vector<BaseHit> >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
-     DetId detIdObject(outHits->first);
-     typename MergeCollection::FastFiller spc(*output, detIdObject);
-     for (auto Hit : outHits->second){
-       spc.push_back(Hit);
-     }
-   }
-
+  for (typename std::map<uint32_t, std::vector<BaseHit> >::const_iterator outHits = output_map.begin();
+       outHits != output_map.end();
+       ++outHits) {
+    DetId detIdObject(outHits->first);
+    typename MergeCollection::FastFiller spc(*output, detIdObject);
+    for (auto Hit : outHits->second) {
+      spc.push_back(Hit);
+    }
+  }
 }
 
-
-
-
 template <typename T1, typename T2>
-void  CollectionMerger<T1,T2>::fill_output_obj_calo(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  std::map<uint32_t, BaseHit >   output_map;
+void CollectionMerger<T1, T2>::fill_output_obj_calo(std::unique_ptr<MergeCollection> &output,
+                                                    std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  std::map<uint32_t, BaseHit> output_map;
   // First merge the two collections again
-  for (auto const & inputCollection : inputCollections){
-    for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
-      DetId detIdObject( recHit->detid().rawId() );
+  for (auto const &inputCollection : inputCollections) {
+    for (typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit != inputCollection->end();
+         ++recHit) {
+      DetId detIdObject(recHit->detid().rawId());
       T2 *akt_calo_obj = &output_map[detIdObject.rawId()];
       float new_energy = akt_calo_obj->energy() + recHit->energy();
       T2 newRecHit(*recHit);
@@ -84,121 +81,112 @@ void  CollectionMerger<T1,T2>::fill_output_obj_calo(std::unique_ptr<MergeCollect
     }
   }
   // Now save it into the standard CMSSW format
-  for (typename std::map<uint32_t, BaseHit >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
+  for (typename std::map<uint32_t, BaseHit>::const_iterator outHits = output_map.begin(); outHits != output_map.end();
+       ++outHits) {
     output->push_back(outHits->second);
   }
-  output->sort(); //Do a sort for this collection
+  output->sort();  //Do a sort for this collection
 }
-
-
 
 // -------- Here Muon Chamber Merger -----------
 template <typename T1, typename T2>
-void  CollectionMerger<T1,T2>::fill_output_obj_muonchamber(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  std::map<uint32_t, std::vector<BaseHit> >   output_map;
+void CollectionMerger<T1, T2>::fill_output_obj_muonchamber(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  std::map<uint32_t, std::vector<BaseHit> > output_map;
   // First merge the collections with the help of the output map
-  for (auto const & inputCollection : inputCollections){
-   for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
-      DetId detIdObject( recHit->geographicalId() );
+  for (auto const &inputCollection : inputCollections) {
+    for (typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit != inputCollection->end();
+         ++recHit) {
+      DetId detIdObject(recHit->geographicalId());
       output_map[detIdObject].push_back(*recHit);
-      }
+    }
   }
   // Now save it into the standard CMSSW format, with the standard Filler
-  for (typename std::map<uint32_t, std::vector<BaseHit> >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
-        output->put((typename T1::id_iterator::value_type) outHits->first , outHits->second.begin(), outHits->second.end()); // The DTLayerId misses the automatic type cast
-   }
+  for (typename std::map<uint32_t, std::vector<BaseHit> >::const_iterator outHits = output_map.begin();
+       outHits != output_map.end();
+       ++outHits) {
+    output->put((typename T1::id_iterator::value_type)outHits->first,
+                outHits->second.begin(),
+                outHits->second.end());  // The DTLayerId misses the automatic type cast
+  }
 }
-
-
-
 
 // Here some overloaded functions, which are needed such that the right merger function is called for the indivudal Collections
 template <typename T1, typename T2>
-void  CollectionMerger<T1,T2>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  assert(0); // CV: make sure general function never gets called;
-             //     always use template specializations
+void CollectionMerger<T1, T2>::fill_output_obj(std::unique_ptr<MergeCollection> &output,
+                                               std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  assert(0);  // CV: make sure general function never gets called;
+              //     always use template specializations
 }
 
 // Start with the Tracker collections
 template <>
-void  CollectionMerger<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
- fill_output_obj_tracker(output,inputCollections,true);
-
+void CollectionMerger<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_tracker(output, inputCollections, true);
 }
-
 
 template <>
-void  CollectionMerger<edmNew::DetSetVector<SiStripCluster>, SiStripCluster>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_tracker(output,inputCollections);
+void CollectionMerger<edmNew::DetSetVector<SiStripCluster>, SiStripCluster>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_tracker(output, inputCollections);
 }
-
 
 // Next are the Calo entries
 template <>
-void  CollectionMerger<edm::SortedCollection<EcalRecHit>,  EcalRecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_calo(output,inputCollections);
-}
-
-
-template <>
-void  CollectionMerger<edm::SortedCollection<HBHERecHit>, HBHERecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_calo(output,inputCollections);
+void CollectionMerger<edm::SortedCollection<EcalRecHit>, EcalRecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_calo(output, inputCollections);
 }
 
 template <>
-void  CollectionMerger<edm::SortedCollection<HFRecHit>, HFRecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_calo(output,inputCollections);
+void CollectionMerger<edm::SortedCollection<HBHERecHit>, HBHERecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_calo(output, inputCollections);
 }
 
 template <>
-void  CollectionMerger<edm::SortedCollection<HORecHit>, HORecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_calo(output,inputCollections);
+void CollectionMerger<edm::SortedCollection<HFRecHit>, HFRecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_calo(output, inputCollections);
 }
 
 template <>
-void  CollectionMerger<edm::SortedCollection<CastorRecHit>, CastorRecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_calo(output,inputCollections);
+void CollectionMerger<edm::SortedCollection<HORecHit>, HORecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_calo(output, inputCollections);
 }
-
 
 template <>
-void  CollectionMerger<edm::SortedCollection<ZDCRecHit>, ZDCRecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_calo(output,inputCollections);
+void CollectionMerger<edm::SortedCollection<CastorRecHit>, CastorRecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_calo(output, inputCollections);
 }
 
-
+template <>
+void CollectionMerger<edm::SortedCollection<ZDCRecHit>, ZDCRecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_calo(output, inputCollections);
+}
 
 // Here the Muon Chamber
 template <>
-void  CollectionMerger<edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair> >, DTRecHit1DPair >::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_muonchamber(output,inputCollections);
+void CollectionMerger<edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair> >, DTRecHit1DPair>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_muonchamber(output, inputCollections);
 }
 
 template <>
-void  CollectionMerger<edm::RangeMap<CSCDetId, edm::OwnVector<CSCRecHit2D> >, CSCRecHit2D >::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_muonchamber(output,inputCollections);
+void CollectionMerger<edm::RangeMap<CSCDetId, edm::OwnVector<CSCRecHit2D> >, CSCRecHit2D>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_muonchamber(output, inputCollections);
 }
-
 
 template <>
-void  CollectionMerger<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit> >, RPCRecHit>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
-{
-  fill_output_obj_muonchamber(output,inputCollections);
+void CollectionMerger<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit> >, RPCRecHit>::fill_output_obj(
+    std::unique_ptr<MergeCollection> &output, std::vector<edm::Handle<MergeCollection> > &inputCollections) {
+  fill_output_obj_muonchamber(output, inputCollections);
 }
-
-
 
 DEFINE_FWK_MODULE(PixelColMerger);
 DEFINE_FWK_MODULE(StripColMerger);

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
@@ -20,7 +20,6 @@
 #include "DataFormats/MuonReco/interface/MuonEnergy.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
@@ -31,74 +30,63 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 
-
 //#include "TauAnalysis/MCEmbeddingTools/interface/embeddingAuxFunctions.h"
 #include <string>
 #include <iostream>
 #include <map>
 
-
-
 template <typename T1, typename T2>
-class CollectionMerger : public  edm::stream::EDProducer<>
-{
- public:
-  explicit CollectionMerger(const edm::ParameterSet&);
+class CollectionMerger : public edm::stream::EDProducer<> {
+public:
+  explicit CollectionMerger(const edm::ParameterSet &);
   ~CollectionMerger() override;
 
- private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
   typedef T1 MergeCollection;
   typedef T2 BaseHit;
-  std::map<std::string,  std::vector<edm::EDGetTokenT<MergeCollection > > > inputs_;
+  std::map<std::string, std::vector<edm::EDGetTokenT<MergeCollection> > > inputs_;
 
-  
-  void fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections);
-  void fill_output_obj_tracker(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections, bool print_pixel=false);
-  void fill_output_obj_calo(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections);
-  void fill_output_obj_muonchamber(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections);
-  
-
- 
-
+  void fill_output_obj(std::unique_ptr<MergeCollection> &output,
+                       std::vector<edm::Handle<MergeCollection> > &inputCollections);
+  void fill_output_obj_tracker(std::unique_ptr<MergeCollection> &output,
+                               std::vector<edm::Handle<MergeCollection> > &inputCollections,
+                               bool print_pixel = false);
+  void fill_output_obj_calo(std::unique_ptr<MergeCollection> &output,
+                            std::vector<edm::Handle<MergeCollection> > &inputCollections);
+  void fill_output_obj_muonchamber(std::unique_ptr<MergeCollection> &output,
+                                   std::vector<edm::Handle<MergeCollection> > &inputCollections);
 };
 
 template <typename T1, typename T2>
-CollectionMerger<T1,T2>::CollectionMerger(const edm::ParameterSet& iConfig)
-{
-  std::vector<edm::InputTag> inCollections =  iConfig.getParameter<std::vector<edm::InputTag> >("mergCollections");
-  for (auto const & inCollection : inCollections){
-    inputs_[inCollection.instance()].push_back(consumes<MergeCollection >(inCollection));  
+CollectionMerger<T1, T2>::CollectionMerger(const edm::ParameterSet &iConfig) {
+  std::vector<edm::InputTag> inCollections = iConfig.getParameter<std::vector<edm::InputTag> >("mergCollections");
+  for (auto const &inCollection : inCollections) {
+    inputs_[inCollection.instance()].push_back(consumes<MergeCollection>(inCollection));
   }
-  for (auto toproduce : inputs_){
-  //  std::cout<<toproduce.first<<"\t"<<toproduce.second.size()<<std::endl;
-    produces<MergeCollection>(toproduce.first);  
-  
- }
+  for (auto toproduce : inputs_) {
+    //  std::cout<<toproduce.first<<"\t"<<toproduce.second.size()<<std::endl;
+    produces<MergeCollection>(toproduce.first);
+  }
 }
 
 template <typename T1, typename T2>
-CollectionMerger<T1,T2>::~CollectionMerger()
-{
-// nothing to be done yet...  
+CollectionMerger<T1, T2>::~CollectionMerger() {
+  // nothing to be done yet...
 }
 
-
 template <typename T1, typename T2>
-void CollectionMerger<T1,T2>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   
-  for (auto input_ : inputs_){
-    std::unique_ptr<MergeCollection > output(new MergeCollection());
+void CollectionMerger<T1, T2>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  for (auto input_ : inputs_) {
+    std::unique_ptr<MergeCollection> output(new MergeCollection());
     std::vector<edm::Handle<MergeCollection> > inputCollections;
     inputCollections.resize(input_.second.size());
-    for (unsigned id = 0; id<input_.second.size(); id++){
+    for (unsigned id = 0; id < input_.second.size(); id++) {
       iEvent.getByToken(input_.second[id], inputCollections[id]);
-     }
-    fill_output_obj(output,inputCollections);   
-    iEvent.put(std::move(output),input_.first);
-  
+    }
+    fill_output_obj(output, inputCollections);
+    iEvent.put(std::move(output), input_.first);
   }
 }
 #endif

--- a/TauAnalysis/MCEmbeddingTools/plugins/DYToMuMuGenFilter.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/DYToMuMuGenFilter.cc
@@ -12,114 +12,88 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+class DYToMuMuGenFilter : public edm::stream::EDFilter<> {
+public:
+  explicit DYToMuMuGenFilter(const edm::ParameterSet&);
+  ~DYToMuMuGenFilter() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-class DYToMuMuGenFilter: public edm::stream::EDFilter<> {
-   public:
-      explicit DYToMuMuGenFilter(const edm::ParameterSet&);
-      ~DYToMuMuGenFilter() override;
+private:
+  void beginStream(edm::StreamID) override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  edm::InputTag inputTag_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollection_;
 
-   private:
-      void beginStream(edm::StreamID) override;
-      bool filter(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
-      
-      edm::InputTag inputTag_;
-      edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollection_;
+  edm::Handle<reco::GenParticleCollection> gen_handle;
 
-      edm::Handle<reco::GenParticleCollection> gen_handle;
-      
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
-
-
-
-DYToMuMuGenFilter::DYToMuMuGenFilter(const edm::ParameterSet& iConfig)
-{
-  inputTag_= iConfig.getParameter<edm::InputTag>("inputTag");
+DYToMuMuGenFilter::DYToMuMuGenFilter(const edm::ParameterSet& iConfig) {
+  inputTag_ = iConfig.getParameter<edm::InputTag>("inputTag");
   genParticleCollection_ = consumes<reco::GenParticleCollection>(inputTag_);
 }
 
-
-DYToMuMuGenFilter::~DYToMuMuGenFilter() {
-}
-
+DYToMuMuGenFilter::~DYToMuMuGenFilter() {}
 
 bool DYToMuMuGenFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  iEvent.getByToken(genParticleCollection_, gen_handle);
 
+  for (unsigned int i = 0; i < gen_handle->size(); i++) {
+    const reco::GenParticle gen_particle = (*gen_handle)[i];
+    // Check if Z Boson decayed into two leptons
+    if (gen_particle.pdgId() == 23 && gen_particle.numberOfDaughters() == 2) {
+      //Debug output
+      //std::cout << "pdgId" << gen_particle.pdgId() << std::endl;
+      //std::cout << "nDau" << gen_particle.numberOfDaughters() << std::endl;
+      //std::cout << "Dau1" << gen_particle->daughters->at(0).pdgId() << std::endl;
+      //std::cout << "Dau2" << gen_particle.numberOfDaughters() << std::endl;
+      //std::cout << "Dau1 " << gen_particle.daughter(0)->pdgId() << std::endl;
+      //std::cout << "Dau2 " << gen_particle.daughter(1)->pdgId() << std::endl;
+      //std::cout << gen_particle.daughter(1)->pdgId()+gen_particle.daughter(0)->pdgId() << std::endl;
 
-    iEvent.getByToken(genParticleCollection_, gen_handle);
-    
-    for(unsigned int i = 0; i < gen_handle->size(); i++)
-    {
-      const reco::GenParticle gen_particle = (*gen_handle)[i];
-		// Check if Z Boson decayed into two leptons
-		if (gen_particle.pdgId() == 23 && gen_particle.numberOfDaughters() == 2)
-		{
-			//Debug output
-			//std::cout << "pdgId" << gen_particle.pdgId() << std::endl;
-			//std::cout << "nDau" << gen_particle.numberOfDaughters() << std::endl;
-			//std::cout << "Dau1" << gen_particle->daughters->at(0).pdgId() << std::endl;
-			//std::cout << "Dau2" << gen_particle.numberOfDaughters() << std::endl;
-			//std::cout << "Dau1 " << gen_particle.daughter(0)->pdgId() << std::endl;
-			//std::cout << "Dau2 " << gen_particle.daughter(1)->pdgId() << std::endl;
-			//std::cout << gen_particle.daughter(1)->pdgId()+gen_particle.daughter(0)->pdgId() << std::endl;
-			
-			// Check if daugther particles are muons
-		  if (std::abs(gen_particle.daughter(0)->pdgId()) == 13  
-		      && std::abs(gen_particle.daughter(0)->eta())<2.6  
-		      && std::abs(gen_particle.daughter(1)->eta())<2.6
-		      && gen_particle.daughter(0)->pt()>7
-		      && gen_particle.daughter(1)->pt()>7)
-			{
-			  //std::cout << "pdgId" << gen_particle.pdgId() << std::endl;
-			  //std::cout << "nDau" << gen_particle.numberOfDaughters() << std::endl;
-			  //std::cout << "Dau1 " << gen_particle.daughter(0)->pdgId() << std::endl;
-			  //std::cout << "Dau1 pt " << gen_particle.daughter(0)->pt() << std::endl;
-			  //std::cout << "Dau1 pt " << gen_particle.daughter(0)->eta() << std::endl;
-			  //std::cout << "Dau2 " << gen_particle.daughter(1)->pdgId() << std::endl;
-			  //std::cout << "Dau2 pt " << gen_particle.daughter(1)->pt() << std::endl;
-			  //std::cout << "Dau2 pt " << gen_particle.daughter(1)->eta() << std::endl;
-			  //std::cout << gen_particle.daughter(1)->pdgId()+gen_particle.daughter(0)->pdgId() << std::endl;
-			  return true;
-			}
-			else
-			{ 
-				return false;
-			}
-		}
+      // Check if daugther particles are muons
+      if (std::abs(gen_particle.daughter(0)->pdgId()) == 13 && std::abs(gen_particle.daughter(0)->eta()) < 2.6 &&
+          std::abs(gen_particle.daughter(1)->eta()) < 2.6 && gen_particle.daughter(0)->pt() > 7 &&
+          gen_particle.daughter(1)->pt() > 7) {
+        //std::cout << "pdgId" << gen_particle.pdgId() << std::endl;
+        //std::cout << "nDau" << gen_particle.numberOfDaughters() << std::endl;
+        //std::cout << "Dau1 " << gen_particle.daughter(0)->pdgId() << std::endl;
+        //std::cout << "Dau1 pt " << gen_particle.daughter(0)->pt() << std::endl;
+        //std::cout << "Dau1 pt " << gen_particle.daughter(0)->eta() << std::endl;
+        //std::cout << "Dau2 " << gen_particle.daughter(1)->pdgId() << std::endl;
+        //std::cout << "Dau2 pt " << gen_particle.daughter(1)->pt() << std::endl;
+        //std::cout << "Dau2 pt " << gen_particle.daughter(1)->eta() << std::endl;
+        //std::cout << gen_particle.daughter(1)->pdgId()+gen_particle.daughter(0)->pdgId() << std::endl;
+        return true;
+      } else {
+        return false;
+      }
     }
-    return false;
+  }
+  return false;
 }
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-DYToMuMuGenFilter::beginStream(edm::StreamID)
-{
-}
+void DYToMuMuGenFilter::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-DYToMuMuGenFilter::endStream() {
-}
+void DYToMuMuGenFilter::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-DYToMuMuGenFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void DYToMuMuGenFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
-
-
 
 DEFINE_FWK_MODULE(DYToMuMuGenFilter);

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -133,7 +133,7 @@ EmbeddingLHEProducer::EmbeddingLHEProducer(const edm::ParameterSet& iConfig)
 
    write_lheout=false;
    std::string lhe_ouputfile = iConfig.getUntrackedParameter<std::string>("lhe_outputfilename","");
-   if (lhe_ouputfile !=""){
+   if (!lhe_ouputfile.empty()){
      write_lheout=true;
      file.open(lhe_ouputfile, std::fstream::out | std::fstream::trunc);
    }

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <algorithm>
 #include <iostream>
@@ -57,432 +56,403 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "CLHEP/Random/RandExponential.h"
 
-
-
 //
 // class declaration
 //
 
-namespace CLHEP{
+namespace CLHEP {
   class HepRandomEngine;
 }
 
+class EmbeddingLHEProducer : public edm::one::EDProducer<edm::BeginRunProducer, edm::EndRunProducer> {
+public:
+  explicit EmbeddingLHEProducer(const edm::ParameterSet &);
+  ~EmbeddingLHEProducer() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
+private:
+  void beginJob() override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
 
-class EmbeddingLHEProducer : public edm::one::EDProducer<edm::BeginRunProducer,
-                                                        edm::EndRunProducer> {
-   public:
-      explicit EmbeddingLHEProducer(const edm::ParameterSet&);
-      ~EmbeddingLHEProducer() override;
+  void beginRunProduce(edm::Run &run, edm::EventSetup const &es) override;
+  void endRunProduce(edm::Run &, edm::EventSetup const &) override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void fill_lhe_from_mumu(TLorentzVector &positiveLepton,
+                          TLorentzVector &negativeLepton,
+                          lhef::HEPEUP &outlhe,
+                          CLHEP::HepRandomEngine *engine);
+  void fill_lhe_with_particle(lhef::HEPEUP &outlhe, TLorentzVector &particle, int pdgid, double spin, double ctau);
 
-   private:
-      void beginJob() override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
+  void transform_mumu_to_tautau(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton);
+  const reco::Candidate *find_original_muon(const reco::Candidate *muon);
+  void assign_4vector(TLorentzVector &Lepton, const pat::Muon *muon, std::string FSRmode);
+  void mirror(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton);
+  void rotate180(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton);
 
-      void beginRunProduce(edm::Run& run, edm::EventSetup const& es) override;
-      void endRunProduce(edm::Run&, edm::EventSetup const&) override;
+  LHERunInfoProduct::Header give_slha();
 
-      void fill_lhe_from_mumu(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton, lhef::HEPEUP &outlhe, CLHEP::HepRandomEngine* engine);
-      void fill_lhe_with_particle(lhef::HEPEUP &outlhe, TLorentzVector &particle, int pdgid, double spin, double ctau);
+  edm::EDGetTokenT<edm::View<pat::Muon>> muonsCollection_;
+  edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
+  int particleToEmbed_;
+  bool mirror_, rotate180_;
+  const double tauMass_ = 1.77682;
+  const double elMass_ = 0.00051;
+  const int embeddingParticles[3]{11, 13, 15};
 
-      void transform_mumu_to_tautau(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton);
-      const reco::Candidate* find_original_muon(const reco::Candidate* muon);
-      void assign_4vector(TLorentzVector &Lepton, const pat::Muon* muon, std::string FSRmode);
-      void mirror(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton);
-      void rotate180(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton);
+  std::ofstream file;
+  bool write_lheout;
 
-      LHERunInfoProduct::Header give_slha();
-
-      edm::EDGetTokenT<edm::View<pat::Muon>> muonsCollection_;
-      edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
-      int particleToEmbed_;
-      bool mirror_,rotate180_;
-      const double tauMass_ = 1.77682;
-      const double elMass_ = 0.00051;
-      const int embeddingParticles[3] {11,13,15};
-
-      std::ofstream file;
-      bool write_lheout;
-
-      // instead of reconstruted 4vectors of muons generated are taken to study FSR. Possible modes:
-      // afterFSR - muons without FSR photons taken into account
-      // beforeFSR - muons with FSR photons taken into account
-      std::string studyFSRmode_;
+  // instead of reconstruted 4vectors of muons generated are taken to study FSR. Possible modes:
+  // afterFSR - muons without FSR photons taken into account
+  // beforeFSR - muons with FSR photons taken into account
+  std::string studyFSRmode_;
 };
 
 //
 // constructors and destructor
 //
-EmbeddingLHEProducer::EmbeddingLHEProducer(const edm::ParameterSet& iConfig)
-{
-   //register your products
-   produces<LHEEventProduct>();
-   produces<LHERunInfoProduct, edm::Transition::BeginRun>();
-   produces<math::XYZTLorentzVectorD>("vertexPosition");
+EmbeddingLHEProducer::EmbeddingLHEProducer(const edm::ParameterSet &iConfig) {
+  //register your products
+  produces<LHEEventProduct>();
+  produces<LHERunInfoProduct, edm::Transition::BeginRun>();
+  produces<math::XYZTLorentzVectorD>("vertexPosition");
 
-   muonsCollection_ = consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"));
-   vertexCollection_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
-   particleToEmbed_ = iConfig.getParameter<int>("particleToEmbed");
-   mirror_ = iConfig.getParameter<bool>("mirror");
-   rotate180_ = iConfig.getParameter<bool>("rotate180");
-   studyFSRmode_ = iConfig.getUntrackedParameter<std::string>("studyFSRmode","");
+  muonsCollection_ = consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"));
+  vertexCollection_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
+  particleToEmbed_ = iConfig.getParameter<int>("particleToEmbed");
+  mirror_ = iConfig.getParameter<bool>("mirror");
+  rotate180_ = iConfig.getParameter<bool>("rotate180");
+  studyFSRmode_ = iConfig.getUntrackedParameter<std::string>("studyFSRmode", "");
 
-   write_lheout=false;
-   std::string lhe_ouputfile = iConfig.getUntrackedParameter<std::string>("lhe_outputfilename","");
-   if (!lhe_ouputfile.empty()){
-     write_lheout=true;
-     file.open(lhe_ouputfile, std::fstream::out | std::fstream::trunc);
-   }
+  write_lheout = false;
+  std::string lhe_ouputfile = iConfig.getUntrackedParameter<std::string>("lhe_outputfilename", "");
+  if (!lhe_ouputfile.empty()) {
+    write_lheout = true;
+    file.open(lhe_ouputfile, std::fstream::out | std::fstream::trunc);
+  }
 
-   //check if particle can be embedded
-    if (std::find(std::begin(embeddingParticles), std::end(embeddingParticles),
-      particleToEmbed_) == std::end(embeddingParticles)) {
-      throw cms::Exception("Configuration")
-        << "The given particle to embed is not in the list of allowed particles.";
-    }
+  //check if particle can be embedded
+  if (std::find(std::begin(embeddingParticles), std::end(embeddingParticles), particleToEmbed_) ==
+      std::end(embeddingParticles)) {
+    throw cms::Exception("Configuration") << "The given particle to embed is not in the list of allowed particles.";
+  }
 
-   edm::Service<edm::RandomNumberGenerator> rng;
-   if ( ! rng.isAvailable()) {
-     throw cms::Exception("Configuration")
-       << "The EmbeddingLHEProducer requires the RandomNumberGeneratorService\n"
-          "which is not present in the configuration file. \n"
-          "You must add the service\n"
-          "in the configuration file or remove the modules that require it.";
-    }
-
-
+  edm::Service<edm::RandomNumberGenerator> rng;
+  if (!rng.isAvailable()) {
+    throw cms::Exception("Configuration") << "The EmbeddingLHEProducer requires the RandomNumberGeneratorService\n"
+                                             "which is not present in the configuration file. \n"
+                                             "You must add the service\n"
+                                             "in the configuration file or remove the modules that require it.";
+  }
 }
 
-
-EmbeddingLHEProducer::~EmbeddingLHEProducer()
-{
-}
-
+EmbeddingLHEProducer::~EmbeddingLHEProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-EmbeddingLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    using namespace edm;
+void EmbeddingLHEProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
 
-    edm::Service<edm::RandomNumberGenerator> rng;
-    CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
+  edm::Service<edm::RandomNumberGenerator> rng;
+  CLHEP::HepRandomEngine *engine = &rng->getEngine(iEvent.streamID());
 
+  edm::Handle<edm::View<pat::Muon>> muonHandle;
+  iEvent.getByToken(muonsCollection_, muonHandle);
+  edm::View<pat::Muon> coll_muons = *muonHandle;
 
-    edm::Handle< edm::View<pat::Muon> > muonHandle;
-    iEvent.getByToken(muonsCollection_, muonHandle);
-    edm::View<pat::Muon> coll_muons = *muonHandle;
+  Handle<std::vector<reco::Vertex>> coll_vertices;
+  iEvent.getByToken(vertexCollection_, coll_vertices);
 
-    Handle<std::vector<reco::Vertex>> coll_vertices;
-    iEvent.getByToken(vertexCollection_ , coll_vertices);
+  TLorentzVector positiveLepton, negativeLepton;
+  bool mu_plus_found = false;
+  bool mu_minus_found = false;
+  lhef::HEPEUP hepeup;
+  hepeup.IDPRUP = 0;
+  hepeup.XWGTUP = 1;
+  hepeup.SCALUP = -1;
+  hepeup.AQEDUP = -1;
+  hepeup.AQCDUP = -1;
+  // Assuming Pt-Order
+  for (edm::View<pat::Muon>::const_iterator muon = coll_muons.begin(); muon != coll_muons.end(); ++muon) {
+    if (muon->charge() == 1 && !mu_plus_found) {
+      assign_4vector(positiveLepton, &(*muon), studyFSRmode_);
+      mu_plus_found = true;
+    } else if (muon->charge() == -1 && !mu_minus_found) {
+      assign_4vector(negativeLepton, &(*muon), studyFSRmode_);
+      mu_minus_found = true;
+    } else if (mu_minus_found && mu_plus_found)
+      break;
+  }
+  mirror(positiveLepton, negativeLepton);                    // if no mirror, function does nothing.
+  rotate180(positiveLepton, negativeLepton);                 // if no rotate180, function does nothing
+  transform_mumu_to_tautau(positiveLepton, negativeLepton);  // if MuonEmbedding, function does nothing.
+  fill_lhe_from_mumu(positiveLepton, negativeLepton, hepeup, engine);
 
-    TLorentzVector positiveLepton, negativeLepton;
-    bool mu_plus_found = false;
-    bool mu_minus_found = false;
-    lhef::HEPEUP hepeup;
-    hepeup.IDPRUP = 0;
-    hepeup.XWGTUP = 1;
-    hepeup.SCALUP = -1;
-    hepeup.AQEDUP = -1;
-    hepeup.AQCDUP = -1;
-    // Assuming Pt-Order
-    for (edm::View<pat::Muon>::const_iterator muon=  coll_muons.begin(); muon!= coll_muons.end();  ++muon)
-    {
-      if (muon->charge() == 1 && !mu_plus_found)
-      {
-        assign_4vector(positiveLepton, &(*muon), studyFSRmode_);
-        mu_plus_found = true;
-      }
-      else if (muon->charge() == -1 && !mu_minus_found)
-      {
-        assign_4vector(negativeLepton, &(*muon), studyFSRmode_);
-        mu_minus_found = true;
-      }
-      else if (mu_minus_found && mu_plus_found) break;
-    }
-    mirror(positiveLepton,negativeLepton); // if no mirror, function does nothing.
-    rotate180(positiveLepton,negativeLepton); // if no rotate180, function does nothing
-    transform_mumu_to_tautau(positiveLepton,negativeLepton); // if MuonEmbedding, function does nothing.
-    fill_lhe_from_mumu(positiveLepton,negativeLepton,hepeup,engine);
+  double originalXWGTUP_ = 1.;
+  std::unique_ptr<LHEEventProduct> product(new LHEEventProduct(hepeup, originalXWGTUP_));
 
-    double originalXWGTUP_ = 1.;
-    std::unique_ptr<LHEEventProduct> product( new LHEEventProduct(hepeup,originalXWGTUP_) );
+  if (write_lheout)
+    std::copy(product->begin(), product->end(), std::ostream_iterator<std::string>(file));
 
-    if (write_lheout) std::copy(product->begin(), product->end(), std::ostream_iterator<std::string>(file));
-
-    iEvent.put(std::move(product));
-    // Saving vertex position
-    std::unique_ptr<math::XYZTLorentzVectorD> vertex_position (new math::XYZTLorentzVectorD(coll_vertices->at(0).x(),coll_vertices->at(0).y(),coll_vertices->at(0).z(),0.0));
-    iEvent.put(std::move(vertex_position), "vertexPosition");
-
+  iEvent.put(std::move(product));
+  // Saving vertex position
+  std::unique_ptr<math::XYZTLorentzVectorD> vertex_position(
+      new math::XYZTLorentzVectorD(coll_vertices->at(0).x(), coll_vertices->at(0).y(), coll_vertices->at(0).z(), 0.0));
+  iEvent.put(std::move(vertex_position), "vertexPosition");
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-EmbeddingLHEProducer::beginJob()
-{
-}
+void EmbeddingLHEProducer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-EmbeddingLHEProducer::endJob() {
-}
+void EmbeddingLHEProducer::endJob() {}
 
 // ------------ method called when starting to processes a run  ------------
 
-void
-EmbeddingLHEProducer::beginRunProduce(edm::Run &run, edm::EventSetup const&)
-{
-    // fill HEPRUP common block and store in edm::Run
-    lhef::HEPRUP heprup;
+void EmbeddingLHEProducer::beginRunProduce(edm::Run &run, edm::EventSetup const &) {
+  // fill HEPRUP common block and store in edm::Run
+  lhef::HEPRUP heprup;
 
-    // set number of processes: 1 for Z to tau tau
-    heprup.resize(1);
+  // set number of processes: 1 for Z to tau tau
+  heprup.resize(1);
 
-    //Process independent information
+  //Process independent information
 
-    //beam particles ID (two protons)
-    //heprup.IDBMUP.first = 2212;
-    //heprup.IDBMUP.second = 2212;
+  //beam particles ID (two protons)
+  //heprup.IDBMUP.first = 2212;
+  //heprup.IDBMUP.second = 2212;
 
-    //beam particles energies (both 6.5 GeV)
-    //heprup.EBMUP.first = 6500.;
-    //heprup.EBMUP.second = 6500.;
+  //beam particles energies (both 6.5 GeV)
+  //heprup.EBMUP.first = 6500.;
+  //heprup.EBMUP.second = 6500.;
 
-    //take default pdf group for both beamparticles
-    //heprup.PDFGUP.first = -1;
-    //heprup.PDFGUP.second = -1;
+  //take default pdf group for both beamparticles
+  //heprup.PDFGUP.first = -1;
+  //heprup.PDFGUP.second = -1;
 
-    //take certan pdf set ID (same as in officially produced DYJets LHE files)
-    //heprup.PDFSUP.first = -1;
-    //heprup.PDFSUP.second = -1;
+  //take certan pdf set ID (same as in officially produced DYJets LHE files)
+  //heprup.PDFSUP.first = -1;
+  //heprup.PDFSUP.second = -1;
 
-    //master switch for event weight iterpretation (same as in officially produced DYJets LHE files)
-    heprup.IDWTUP = 3;
+  //master switch for event weight iterpretation (same as in officially produced DYJets LHE files)
+  heprup.IDWTUP = 3;
 
-    //Information for first process (Z to tau tau), for now only placeholder:
-    heprup.XSECUP[0] = 1.;
-    heprup.XERRUP[0] = 0;
-    heprup.XMAXUP[0] = 1;
-    heprup.LPRUP[0]= 1;
+  //Information for first process (Z to tau tau), for now only placeholder:
+  heprup.XSECUP[0] = 1.;
+  heprup.XERRUP[0] = 0;
+  heprup.XMAXUP[0] = 1;
+  heprup.LPRUP[0] = 1;
 
+  std::unique_ptr<LHERunInfoProduct> runInfo(new LHERunInfoProduct(heprup));
+  runInfo->addHeader(give_slha());
 
-    std::unique_ptr<LHERunInfoProduct> runInfo(new LHERunInfoProduct(heprup));
-    runInfo->addHeader(give_slha());
-
-
-    if (write_lheout)std::copy(runInfo->begin(), runInfo->end(),std::ostream_iterator<std::string>(file));
-    run.put(std::move(runInfo));
-
-
+  if (write_lheout)
+    std::copy(runInfo->begin(), runInfo->end(), std::ostream_iterator<std::string>(file));
+  run.put(std::move(runInfo));
 }
 
-
-void
-EmbeddingLHEProducer::endRunProduce(edm::Run& run, edm::EventSetup const& es)
-{
-    if (write_lheout) {
-      file << LHERunInfoProduct::endOfFile();
-      file.close();
-    }
+void EmbeddingLHEProducer::endRunProduce(edm::Run &run, edm::EventSetup const &es) {
+  if (write_lheout) {
+    file << LHERunInfoProduct::endOfFile();
+    file.close();
+  }
 }
 
-void
-EmbeddingLHEProducer::fill_lhe_from_mumu(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton, lhef::HEPEUP &outlhe, CLHEP::HepRandomEngine* engine)
-{
+void EmbeddingLHEProducer::fill_lhe_from_mumu(TLorentzVector &positiveLepton,
+                                              TLorentzVector &negativeLepton,
+                                              lhef::HEPEUP &outlhe,
+                                              CLHEP::HepRandomEngine *engine) {
+  TLorentzVector Z = positiveLepton + negativeLepton;
+  int leptonPDGID = particleToEmbed_;
 
-    TLorentzVector Z = positiveLepton + negativeLepton;
-    int leptonPDGID = particleToEmbed_;
+  // double tau_ctau = 0.00871100; //cm
+  double tau_ctau0 = 8.71100e-02;  // mm (for Pythia)
+  double tau_ctau_p =
+      tau_ctau0 * CLHEP::RandExponential::shoot(engine);  // return -std::log(HepRandom::getTheEngine()->flat());
+  // replaces tau = process[iNow].tau0() * rndmPtr->exp(); from pythia8212/src/ProcessContainer.cc which is not initialized for ProcessLevel:all = off mode (no beam particle mode)
+  double tau_ctau_n = tau_ctau0 * CLHEP::RandExponential::shoot(engine);
+  //std::cout<<"tau_ctau P: "<<tau_ctau_p<<" tau_ctau N:  "<<tau_ctau_n<<std::endl;
 
-   // double tau_ctau = 0.00871100; //cm
-    double tau_ctau0 = 8.71100e-02; // mm (for Pythia)
-    double tau_ctau_p = tau_ctau0 * CLHEP::RandExponential::shoot(engine); // return -std::log(HepRandom::getTheEngine()->flat());
-    // replaces tau = process[iNow].tau0() * rndmPtr->exp(); from pythia8212/src/ProcessContainer.cc which is not initialized for ProcessLevel:all = off mode (no beam particle mode)
-    double tau_ctau_n = tau_ctau0 * CLHEP::RandExponential::shoot(engine);
-    //std::cout<<"tau_ctau P: "<<tau_ctau_p<<" tau_ctau N:  "<<tau_ctau_n<<std::endl;
+  fill_lhe_with_particle(outlhe, Z, 23, 9.0, 0);
+  fill_lhe_with_particle(outlhe, positiveLepton, -leptonPDGID, 1.0, tau_ctau_p);
+  fill_lhe_with_particle(outlhe, negativeLepton, leptonPDGID, -1.0, tau_ctau_n);
 
-    fill_lhe_with_particle(outlhe, Z,23,9.0, 0);
-    fill_lhe_with_particle(outlhe, positiveLepton,-leptonPDGID,1.0, tau_ctau_p);
-    fill_lhe_with_particle(outlhe, negativeLepton,leptonPDGID,-1.0, tau_ctau_n);
+  return;
+}
 
+void EmbeddingLHEProducer::fill_lhe_with_particle(
+    lhef::HEPEUP &outlhe, TLorentzVector &particle, int pdgid, double spin, double ctau) {
+  // Pay attention to different index conventions:
+  // 'particleindex' follows usual C++ index conventions starting at 0 for a list.
+  // 'motherindex' follows the LHE index conventions: 0 is for 'not defined', so the listing starts at 1.
+  // That means: LHE index 1 == C++ index 0.
+  int particleindex = outlhe.NUP;
+  outlhe.resize(outlhe.NUP + 1);
+
+  outlhe.PUP[particleindex][0] = particle.Px();
+  outlhe.PUP[particleindex][1] = particle.Py();
+  outlhe.PUP[particleindex][2] = particle.Pz();
+  outlhe.PUP[particleindex][3] = particle.E();
+  outlhe.PUP[particleindex][4] = particle.M();
+  outlhe.IDUP[particleindex] = pdgid;
+  outlhe.SPINUP[particleindex] = spin;
+  outlhe.VTIMUP[particleindex] = ctau;
+
+  outlhe.ICOLUP[particleindex].first = 0;
+  outlhe.ICOLUP[particleindex].second = 0;
+
+  if (std::abs(pdgid) == 23) {
+    outlhe.MOTHUP[particleindex].first = 0;  // No Mother
+    outlhe.MOTHUP[particleindex].second = 0;
+    outlhe.ISTUP[particleindex] = 2;  // status
+  }
+
+  if (std::find(std::begin(embeddingParticles), std::end(embeddingParticles), std::abs(pdgid)) !=
+      std::end(embeddingParticles)) {
+    outlhe.MOTHUP[particleindex].first = 1;   // Mother is the Z (first partile)
+    outlhe.MOTHUP[particleindex].second = 1;  // Mother is the Z (first partile)
+
+    outlhe.ISTUP[particleindex] = 1;  //status
+  }
+
+  return;
+}
+
+void EmbeddingLHEProducer::transform_mumu_to_tautau(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton) {
+  // No corrections applied for muon embedding
+  double lep_mass;
+  if (particleToEmbed_ == 11) {
+    lep_mass = elMass_;
+  } else if (particleToEmbed_ == 15) {
+    lep_mass = tauMass_;
+  } else {
     return;
-}
+  }
 
-void EmbeddingLHEProducer::fill_lhe_with_particle(lhef::HEPEUP &outlhe, TLorentzVector &particle, int pdgid, double spin, double ctau)
-{
-    // Pay attention to different index conventions:
-    // 'particleindex' follows usual C++ index conventions starting at 0 for a list.
-    // 'motherindex' follows the LHE index conventions: 0 is for 'not defined', so the listing starts at 1.
-    // That means: LHE index 1 == C++ index 0.
-    int particleindex = outlhe.NUP;
-    outlhe.resize(outlhe.NUP+1);
+  TLorentzVector Z = positiveLepton + negativeLepton;
 
-    outlhe.PUP[particleindex][0] = particle.Px();
-    outlhe.PUP[particleindex][1] = particle.Py();
-    outlhe.PUP[particleindex][2] = particle.Pz();
-    outlhe.PUP[particleindex][3] = particle.E();
-    outlhe.PUP[particleindex][4] = particle.M();
-    outlhe.IDUP[particleindex] = pdgid;
-    outlhe.SPINUP[particleindex] = spin;
-    outlhe.VTIMUP[particleindex] = ctau;
+  TVector3 boost_from_Z_to_LAB = Z.BoostVector();
+  TVector3 boost_from_LAB_to_Z = -Z.BoostVector();
 
-    outlhe.ICOLUP[particleindex].first = 0;
-    outlhe.ICOLUP[particleindex].second = 0;
+  // Boosting the two leptons to Z restframe, then both are back to back. This means, same 3-momentum squared
+  positiveLepton.Boost(boost_from_LAB_to_Z);
+  negativeLepton.Boost(boost_from_LAB_to_Z);
 
-    if (std::abs(pdgid) == 23){
-      outlhe.MOTHUP[particleindex].first = 0; // No Mother
-      outlhe.MOTHUP[particleindex].second = 0;
-      outlhe.ISTUP[particleindex] = 2; // status
-
-    }
-
-    if (std::find(std::begin(embeddingParticles), std::end(embeddingParticles),
-     std::abs(pdgid)) != std::end(embeddingParticles)) {
-      outlhe.MOTHUP[particleindex].first = 1;  // Mother is the Z (first partile)
-      outlhe.MOTHUP[particleindex].second = 1; // Mother is the Z (first partile)
-
-      outlhe.ISTUP[particleindex] = 1;//status
-    }
-
+  // Energy of tau = 0.5*Z-mass
+  double lep_mass_squared = lep_mass * lep_mass;
+  double lep_energy_squared = 0.25 * Z.M2();
+  double lep_3momentum_squared = lep_energy_squared - lep_mass_squared;
+  if (lep_3momentum_squared < 0) {
+    edm::LogWarning("TauEmbedding") << "3-Momentum squared is negative";
     return;
+  }
+
+  //Computing scale, applying it on the 3-momenta and building new 4 momenta of the taus
+  double scale = std::sqrt(lep_3momentum_squared / positiveLepton.Vect().Mag2());
+  positiveLepton.SetPxPyPzE(scale * positiveLepton.Px(),
+                            scale * positiveLepton.Py(),
+                            scale * positiveLepton.Pz(),
+                            std::sqrt(lep_energy_squared));
+  negativeLepton.SetPxPyPzE(scale * negativeLepton.Px(),
+                            scale * negativeLepton.Py(),
+                            scale * negativeLepton.Pz(),
+                            std::sqrt(lep_energy_squared));
+
+  //Boosting the new taus back to LAB frame
+  positiveLepton.Boost(boost_from_Z_to_LAB);
+  negativeLepton.Boost(boost_from_Z_to_LAB);
+
+  return;
 }
 
+void EmbeddingLHEProducer::assign_4vector(TLorentzVector &Lepton, const pat::Muon *muon, std::string FSRmode) {
+  if ("afterFSR" == FSRmode && muon->genParticle() != nullptr) {
+    const reco::GenParticle *afterFSRMuon = muon->genParticle();
+    Lepton.SetPxPyPzE(
+        afterFSRMuon->p4().px(), afterFSRMuon->p4().py(), afterFSRMuon->p4().pz(), afterFSRMuon->p4().e());
+  } else if ("beforeFSR" == FSRmode && muon->genParticle() != nullptr) {
+    const reco::Candidate *beforeFSRMuon = find_original_muon(muon->genParticle());
+    Lepton.SetPxPyPzE(
+        beforeFSRMuon->p4().px(), beforeFSRMuon->p4().py(), beforeFSRMuon->p4().pz(), beforeFSRMuon->p4().e());
+  } else {
+    Lepton.SetPxPyPzE(muon->p4().px(), muon->p4().py(), muon->p4().pz(), muon->p4().e());
+  }
+  return;
+}
 
+const reco::Candidate *EmbeddingLHEProducer::find_original_muon(const reco::Candidate *muon) {
+  if (muon->mother(0) == nullptr)
+    return muon;
+  if (muon->pdgId() == muon->mother(0)->pdgId())
+    return find_original_muon(muon->mother(0));
+  else
+    return muon;
+}
 
-
-void EmbeddingLHEProducer::transform_mumu_to_tautau(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton)
-{
-    // No corrections applied for muon embedding
-    double lep_mass;
-    if (particleToEmbed_ == 11) {
-      lep_mass = elMass_;
-    } else if (particleToEmbed_ == 15) {
-      lep_mass = tauMass_;
-    } else {
-      return;
-    }
-
-    TLorentzVector Z = positiveLepton + negativeLepton;
-
-    TVector3 boost_from_Z_to_LAB = Z.BoostVector();
-    TVector3 boost_from_LAB_to_Z = -Z.BoostVector();
-
-    // Boosting the two leptons to Z restframe, then both are back to back. This means, same 3-momentum squared
-    positiveLepton.Boost(boost_from_LAB_to_Z);
-    negativeLepton.Boost(boost_from_LAB_to_Z);
-
-    // Energy of tau = 0.5*Z-mass
-    double lep_mass_squared = lep_mass*lep_mass;
-    double lep_energy_squared = 0.25*Z.M2();
-    double lep_3momentum_squared = lep_energy_squared - lep_mass_squared;
-    if (lep_3momentum_squared < 0)
-    {
-        edm::LogWarning("TauEmbedding") << "3-Momentum squared is negative";
-        return;
-    }
-
-    //Computing scale, applying it on the 3-momenta and building new 4 momenta of the taus
-    double scale = std::sqrt(lep_3momentum_squared/positiveLepton.Vect().Mag2());
-    positiveLepton.SetPxPyPzE(scale*positiveLepton.Px(),scale*positiveLepton.Py(),scale*positiveLepton.Pz(),std::sqrt(lep_energy_squared));
-    negativeLepton.SetPxPyPzE(scale*negativeLepton.Px(),scale*negativeLepton.Py(),scale*negativeLepton.Pz(),std::sqrt(lep_energy_squared));
-
-    //Boosting the new taus back to LAB frame
-    positiveLepton.Boost(boost_from_Z_to_LAB);
-    negativeLepton.Boost(boost_from_Z_to_LAB);
-
+void EmbeddingLHEProducer::rotate180(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton) {
+  if (!rotate180_)
     return;
+  edm::LogInfo("TauEmbedding") << "Applying 180<C2><B0> rotation";
+  // By construction, the 3-momenta of mu-, mu+ and Z are in one plane.
+  // That means, one vector for perpendicular projection can be used for both leptons.
+  TLorentzVector Z = positiveLepton + negativeLepton;
+
+  edm::LogInfo("TauEmbedding") << "MuMinus before. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta()
+                               << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M();
+
+  TVector3 Z3 = Z.Vect();
+  TVector3 positiveLepton3 = positiveLepton.Vect();
+  TVector3 negativeLepton3 = negativeLepton.Vect();
+
+  TVector3 p3_perp = positiveLepton3 - positiveLepton3.Dot(Z3) / Z3.Dot(Z3) * Z3;
+  p3_perp = p3_perp.Unit();
+
+  positiveLepton3 -= 2 * positiveLepton3.Dot(p3_perp) * p3_perp;
+  negativeLepton3 -= 2 * negativeLepton3.Dot(p3_perp) * p3_perp;
+
+  positiveLepton.SetVect(positiveLepton3);
+  negativeLepton.SetVect(negativeLepton3);
+
+  edm::LogInfo("TauEmbedding") << "MuMinus after. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta()
+                               << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M();
+
+  return;
 }
 
-void EmbeddingLHEProducer::assign_4vector(TLorentzVector &Lepton, const pat::Muon* muon, std::string FSRmode)
-{
-    if("afterFSR" == FSRmode && muon->genParticle() != nullptr)
-    {
-        const reco::GenParticle* afterFSRMuon = muon->genParticle();
-        Lepton.SetPxPyPzE(afterFSRMuon->p4().px(),afterFSRMuon->p4().py(),afterFSRMuon->p4().pz(), afterFSRMuon->p4().e());
-    }
-    else if ("beforeFSR" == FSRmode && muon->genParticle() != nullptr)
-    {
-        const reco::Candidate* beforeFSRMuon = find_original_muon(muon->genParticle());
-        Lepton.SetPxPyPzE(beforeFSRMuon->p4().px(),beforeFSRMuon->p4().py(),beforeFSRMuon->p4().pz(), beforeFSRMuon->p4().e());
-    }
-    else
-    {
-        Lepton.SetPxPyPzE(muon->p4().px(),muon->p4().py(),muon->p4().pz(), muon->p4().e());
-    }
+void EmbeddingLHEProducer::mirror(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton) {
+  if (!mirror_)
     return;
+  edm::LogInfo("TauEmbedding") << "Applying mirroring";
+  TLorentzVector Z = positiveLepton + negativeLepton;
+
+  edm::LogInfo("TauEmbedding") << "MuMinus before. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta()
+                               << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M();
+
+  TVector3 Z3 = Z.Vect();
+  TVector3 positiveLepton3 = positiveLepton.Vect();
+  TVector3 negativeLepton3 = negativeLepton.Vect();
+
+  TVector3 beam(0., 0., 1.);
+  TVector3 perpToZandBeam = Z3.Cross(beam).Unit();
+
+  positiveLepton3 -= 2 * positiveLepton3.Dot(perpToZandBeam) * perpToZandBeam;
+  negativeLepton3 -= 2 * negativeLepton3.Dot(perpToZandBeam) * perpToZandBeam;
+
+  positiveLepton.SetVect(positiveLepton3);
+  negativeLepton.SetVect(negativeLepton3);
+
+  edm::LogInfo("TauEmbedding") << "MuMinus after. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta()
+                               << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M();
+
+  return;
 }
 
-const reco::Candidate* EmbeddingLHEProducer::find_original_muon(const reco::Candidate* muon)
-{
-    if(muon->mother(0) == nullptr) return muon;
-    if(muon->pdgId() == muon->mother(0)->pdgId()) return find_original_muon(muon->mother(0));
-    else return muon;
-}
-
-void EmbeddingLHEProducer::rotate180(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton)
-{
-    if (!rotate180_) return;
-    edm::LogInfo("TauEmbedding") << "Applying 180<C2><B0> rotation" ;
-    // By construction, the 3-momenta of mu-, mu+ and Z are in one plane.
-    // That means, one vector for perpendicular projection can be used for both leptons.
-    TLorentzVector Z = positiveLepton + negativeLepton;
-
-    edm::LogInfo("TauEmbedding") << "MuMinus before. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta() << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M();
-
-    TVector3 Z3 = Z.Vect();
-    TVector3 positiveLepton3 = positiveLepton.Vect();
-    TVector3 negativeLepton3 = negativeLepton.Vect();
-
-    TVector3 p3_perp = positiveLepton3 - positiveLepton3.Dot(Z3)/Z3.Dot(Z3)*Z3;
-    p3_perp = p3_perp.Unit();
-
-    positiveLepton3 -= 2*positiveLepton3.Dot(p3_perp)*p3_perp;
-    negativeLepton3 -= 2*negativeLepton3.Dot(p3_perp)*p3_perp;
-
-    positiveLepton.SetVect(positiveLepton3);
-    negativeLepton.SetVect(negativeLepton3);
-
-    edm::LogInfo("TauEmbedding") << "MuMinus after. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta() << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M();
-
-    return;
-}
-
-void EmbeddingLHEProducer::mirror(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton)
-{
-    if(!mirror_) return;
-    edm::LogInfo("TauEmbedding")<< "Applying mirroring" ;
-    TLorentzVector Z = positiveLepton + negativeLepton;
-
-    edm::LogInfo("TauEmbedding") << "MuMinus before. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta() << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M() ;
-
-    TVector3 Z3 = Z.Vect();
-    TVector3 positiveLepton3 = positiveLepton.Vect();
-    TVector3 negativeLepton3 = negativeLepton.Vect();
-
-    TVector3 beam(0.,0.,1.);
-    TVector3 perpToZandBeam = Z3.Cross(beam).Unit();
-
-    positiveLepton3 -= 2*positiveLepton3.Dot(perpToZandBeam)*perpToZandBeam;
-    negativeLepton3 -= 2*negativeLepton3.Dot(perpToZandBeam)*perpToZandBeam;
-
-    positiveLepton.SetVect(positiveLepton3);
-    negativeLepton.SetVect(negativeLepton3);
-
-    edm::LogInfo("TauEmbedding") << "MuMinus after. Pt: " << negativeLepton.Pt() << " Eta: " << negativeLepton.Eta() << " Phi: " << negativeLepton.Phi() << " Mass: " << negativeLepton.M() ;
-
-    return;
-}
-
-
-LHERunInfoProduct::Header EmbeddingLHEProducer::give_slha(){
+LHERunInfoProduct::Header EmbeddingLHEProducer::give_slha() {
   LHERunInfoProduct::Header slhah("slha");
 
   slhah.addLine("######################################################################\n");
@@ -520,7 +490,9 @@ LHERunInfoProduct::Header EmbeddingLHEProducer::give_slha(){
   slhah.addLine("  16 0.000000 # vt : 0.0 \n");
   slhah.addLine("  21 0.000000 # g : 0.0 \n");
   slhah.addLine("  22 0.000000 # a : 0.0 \n");
-  slhah.addLine("  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) \n");
+  slhah.addLine(
+      "  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - "
+      "(aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) \n");
   slhah.addLine("\n");
   slhah.addLine("###################################\n");
   slhah.addLine("## INFORMATION FOR SMINPUTS\n");
@@ -575,11 +547,8 @@ LHERunInfoProduct::Header EmbeddingLHEProducer::give_slha(){
   return slhah;
 }
 
-
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-EmbeddingLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void EmbeddingLHEProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingVertexCorrector.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingVertexCorrector.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TauAnalysis/EmbeddingProducer
 // Class:      EmbeddingVertexCorrector
-// 
+//
 /**\class EmbeddingVertexCorrector EmbeddingVertexCorrector.cc TauAnalysis/EmbeddingProducer/plugins/EmbeddingVertexCorrector.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Sat, 23 Apr 2016 21:47:13 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -48,9 +47,8 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 namespace HepMC {
-   class FourVector ;
+  class FourVector;
 }
 
 //
@@ -58,83 +56,71 @@ namespace HepMC {
 //
 
 class EmbeddingVertexCorrector : public edm::stream::EDProducer<> {
-   public:
-      explicit EmbeddingVertexCorrector(const edm::ParameterSet&);
-      ~EmbeddingVertexCorrector() override;
+public:
+  explicit EmbeddingVertexCorrector(const edm::ParameterSet&);
+  ~EmbeddingVertexCorrector() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginRun(const edm::Run & , const edm::EventSetup& iEventSetup) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void beginRun(const edm::Run&, const edm::EventSetup& iEventSetup) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      // ----------member data ---------------------------
-      edm::InputTag sourceLabel;
-      edm::InputTag vertexPositionLabel;
+  // ----------member data ---------------------------
+  edm::InputTag sourceLabel;
+  edm::InputTag vertexPositionLabel;
 };
 
 //
 // constructors and destructor
 //
-EmbeddingVertexCorrector::EmbeddingVertexCorrector(const edm::ParameterSet& iConfig)
-{
-   produces<edm::HepMCProduct>();
+EmbeddingVertexCorrector::EmbeddingVertexCorrector(const edm::ParameterSet& iConfig) {
+  produces<edm::HepMCProduct>();
 
-   sourceLabel = iConfig.getParameter<edm::InputTag>("src");
-   consumes<edm::HepMCProduct>(sourceLabel);
-   vertexPositionLabel = edm::InputTag("externalLHEProducer","vertexPosition");
-   consumes<math::XYZTLorentzVectorD>(vertexPositionLabel);
+  sourceLabel = iConfig.getParameter<edm::InputTag>("src");
+  consumes<edm::HepMCProduct>(sourceLabel);
+  vertexPositionLabel = edm::InputTag("externalLHEProducer", "vertexPosition");
+  consumes<math::XYZTLorentzVectorD>(vertexPositionLabel);
 }
 
-EmbeddingVertexCorrector::~EmbeddingVertexCorrector()
-{
-}
+EmbeddingVertexCorrector::~EmbeddingVertexCorrector() {}
 
 //
 // member functions
 //
 
+void EmbeddingVertexCorrector::beginRun(const edm::Run&, const edm::EventSetup& iEventSetup) {
+  // edm::ESHandle< SimBeamSpotObjects > beamhandle;
+  // iEventSetup.get<SimBeamSpotObjectsRcd>().get(beamhandle);
 
-void
-EmbeddingVertexCorrector::beginRun(const edm::Run & , const edm::EventSetup& iEventSetup)
-{
-   // edm::ESHandle< SimBeamSpotObjects > beamhandle;
-   // iEventSetup.get<SimBeamSpotObjectsRcd>().get(beamhandle);
-    
-    edm::ESHandle< BeamSpotObjects > beamhandle;
-    iEventSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
-    
-    
-    edm::LogInfo("TauEmbedding")<<"beam handle\n"<<(*beamhandle);
+  edm::ESHandle<BeamSpotObjects> beamhandle;
+  iEventSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
 
-
+  edm::LogInfo("TauEmbedding") << "beam handle\n" << (*beamhandle);
 }
 // ------------ method called to produce the data  ------------
-void
-EmbeddingVertexCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void EmbeddingVertexCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   // Retrieving generated Z to TauTau Event 
-   Handle<edm::HepMCProduct> InputGenEvent;
-   iEvent.getByLabel(sourceLabel, InputGenEvent);
-   HepMC::GenEvent* genevent = new HepMC::GenEvent(*InputGenEvent->GetEvent());
-   std::unique_ptr<edm::HepMCProduct> CorrectedGenEvent(new edm::HepMCProduct(genevent));
+  // Retrieving generated Z to TauTau Event
+  Handle<edm::HepMCProduct> InputGenEvent;
+  iEvent.getByLabel(sourceLabel, InputGenEvent);
+  HepMC::GenEvent* genevent = new HepMC::GenEvent(*InputGenEvent->GetEvent());
+  std::unique_ptr<edm::HepMCProduct> CorrectedGenEvent(new edm::HepMCProduct(genevent));
 
-   //Retrieving vertex position from input and creating vertex shift
-   Handle<math::XYZTLorentzVectorD> vertex_position;
-   iEvent.getByLabel(vertexPositionLabel, vertex_position); 
-   HepMC::FourVector vertex_shift(vertex_position.product()->x()*cm, vertex_position.product()->y()*cm, vertex_position.product()->z()*cm); 
-   
-   // Apply vertex shift to all production vertices of the event
-   CorrectedGenEvent->applyVtxGen(&vertex_shift);   
-   iEvent.put(std::move(CorrectedGenEvent));
+  //Retrieving vertex position from input and creating vertex shift
+  Handle<math::XYZTLorentzVectorD> vertex_position;
+  iEvent.getByLabel(vertexPositionLabel, vertex_position);
+  HepMC::FourVector vertex_shift(
+      vertex_position.product()->x() * cm, vertex_position.product()->y() * cm, vertex_position.product()->z() * cm);
 
+  // Apply vertex shift to all production vertices of the event
+  CorrectedGenEvent->applyVtxGen(&vertex_shift);
+  iEvent.put(std::move(CorrectedGenEvent));
 }
- 
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-EmbeddingVertexCorrector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void EmbeddingVertexCorrector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuMuForEmbeddingSelector.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuMuForEmbeddingSelector.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TauAnalysis/EmbeddingProducer
 // Class:      MuMuForEmbeddingSelector
-// 
+//
 /**\class MuMuForEmbeddingSelector MuMuForEmbeddingSelector.cc TauAnalysis/EmbeddingProducer/plugins/MuMuForEmbeddingSelector.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Mon, 13 Jun 2016 11:05:32 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -38,31 +37,30 @@
 //
 
 class MuMuForEmbeddingSelector : public edm::stream::EDProducer<> {
-   public:
-      explicit MuMuForEmbeddingSelector(const edm::ParameterSet&);
-      ~MuMuForEmbeddingSelector() override;
+public:
+  explicit MuMuForEmbeddingSelector(const edm::ParameterSet&);
+  ~MuMuForEmbeddingSelector() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<edm::View<reco::CompositeCandidate>> ZmumuCandidates_;
-      double ZMass = 91.0;
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<edm::View<reco::CompositeCandidate>> ZmumuCandidates_;
+  double ZMass = 91.0;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -71,11 +69,11 @@ class MuMuForEmbeddingSelector : public edm::stream::EDProducer<> {
 //
 // constructors and destructor
 //
-MuMuForEmbeddingSelector::MuMuForEmbeddingSelector(const edm::ParameterSet& iConfig) :
-   ZmumuCandidates_(consumes< edm::View<reco::CompositeCandidate> >(iConfig.getParameter<edm::InputTag>("ZmumuCandidatesCollection")))
-{
-   //register your products
-/* Examples
+MuMuForEmbeddingSelector::MuMuForEmbeddingSelector(const edm::ParameterSet& iConfig)
+    : ZmumuCandidates_(consumes<edm::View<reco::CompositeCandidate>>(
+          iConfig.getParameter<edm::InputTag>("ZmumuCandidatesCollection"))) {
+  //register your products
+  /* Examples
    produces<ExampleData2>();
 
    //if do put with a label
@@ -84,63 +82,49 @@ MuMuForEmbeddingSelector::MuMuForEmbeddingSelector(const edm::ParameterSet& iCon
    //if you want to put into the Run
    produces<ExampleData2,InRun>();
 */
-   produces<edm::RefVector<pat::MuonCollection>>();
-   
-   //now do what ever other initialization is needed
+  produces<edm::RefVector<pat::MuonCollection>>();
+
+  //now do what ever other initialization is needed
 }
 
-
-MuMuForEmbeddingSelector::~MuMuForEmbeddingSelector()
-{
- 
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-
+MuMuForEmbeddingSelector::~MuMuForEmbeddingSelector() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-MuMuForEmbeddingSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-  edm::Handle< edm::View<reco::CompositeCandidate> > ZmumuCandidatesHandle;
+void MuMuForEmbeddingSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  edm::Handle<edm::View<reco::CompositeCandidate>> ZmumuCandidatesHandle;
   iEvent.getByToken(ZmumuCandidates_, ZmumuCandidatesHandle);
   edm::View<reco::CompositeCandidate> ZmumuCandidates = *ZmumuCandidatesHandle;
 
-   const reco::CompositeCandidate* chosenZCand = nullptr;
-   double massDifference = -1.0;
-   for (edm::View<reco::CompositeCandidate>::const_iterator iZCand = ZmumuCandidates.begin(); iZCand != ZmumuCandidates.end(); ++iZCand)
-   {
-      if (std::abs(ZMass - iZCand->mass()) < massDifference || massDifference < 0)
-      {
-         massDifference = std::abs(ZMass - iZCand->mass());
-         chosenZCand = &(*iZCand);
-      }
-      
-   }
-   std::unique_ptr<edm::RefVector<pat::MuonCollection>> prod(new edm::RefVector<pat::MuonCollection>());
-   prod->reserve(2);
-   prod->push_back(chosenZCand->daughter(0)->masterClone().castTo<pat::MuonRef>());
-   prod->push_back(chosenZCand->daughter(1)->masterClone().castTo<pat::MuonRef>());
-   iEvent.put(std::move(prod));
+  const reco::CompositeCandidate* chosenZCand = nullptr;
+  double massDifference = -1.0;
+  for (edm::View<reco::CompositeCandidate>::const_iterator iZCand = ZmumuCandidates.begin();
+       iZCand != ZmumuCandidates.end();
+       ++iZCand) {
+    if (std::abs(ZMass - iZCand->mass()) < massDifference || massDifference < 0) {
+      massDifference = std::abs(ZMass - iZCand->mass());
+      chosenZCand = &(*iZCand);
+    }
+  }
+  std::unique_ptr<edm::RefVector<pat::MuonCollection>> prod(new edm::RefVector<pat::MuonCollection>());
+  prod->reserve(2);
+  prod->push_back(chosenZCand->daughter(0)->masterClone().castTo<pat::MuonRef>());
+  prod->push_back(chosenZCand->daughter(1)->masterClone().castTo<pat::MuonRef>());
+  iEvent.put(std::move(prod));
 }
-
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-MuMuForEmbeddingSelector::beginStream(edm::StreamID)
-{
-}
+void MuMuForEmbeddingSelector::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-MuMuForEmbeddingSelector::endStream() {
-}
+void MuMuForEmbeddingSelector::endStream() {}
 
 // ------------ method called when starting to processes a run  ------------
 /*
@@ -149,7 +133,7 @@ MuMuForEmbeddingSelector::beginRun(edm::Run const&, edm::EventSetup const&)
 {
 }
 */
- 
+
 // ------------ method called when ending the processing of a run  ------------
 /*
 void
@@ -157,7 +141,7 @@ MuMuForEmbeddingSelector::endRun(edm::Run const&, edm::EventSetup const&)
 {
 }
 */
- 
+
 // ------------ method called when starting to processes a luminosity block  ------------
 /*
 void
@@ -165,7 +149,7 @@ MuMuForEmbeddingSelector::beginLuminosityBlock(edm::LuminosityBlock const&, edm:
 {
 }
 */
- 
+
 // ------------ method called when ending the processing of a luminosity block  ------------
 /*
 void
@@ -173,10 +157,9 @@ MuMuForEmbeddingSelector::endLuminosityBlock(edm::LuminosityBlock const&, edm::E
 {
 }
 */
- 
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-MuMuForEmbeddingSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void MuMuForEmbeddingSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
@@ -1,6 +1,5 @@
 #include "TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h"
 
-
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/DTRecHit/interface/DTSLRecCluster.h"
 #include "DataFormats/DTRecHit/interface/DTRecHit1DPair.h"
@@ -10,90 +9,83 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 
-
-
 typedef MuonDetCleaner<CSCDetId, CSCRecHit2D> CSCRecHitColCleaner;
 typedef MuonDetCleaner<DTLayerId, DTRecHit1DPair> DTRecHitColCleaner;
 typedef MuonDetCleaner<RPCDetId, RPCRecHit> RPCRecHitColCleaner;
-
 
 //-------------------------------------------------------------------------------
 // define 'getDetIds' functions used for different types of recHits
 //-------------------------------------------------------------------------------
 
-
 template <typename T1, typename T2>
-uint32_t MuonDetCleaner<T1,T2>::getRawDetId(const T2& recHit)
-{
-  assert(0); // CV: make sure general function never gets called;
-             //     always use template specializations
+uint32_t MuonDetCleaner<T1, T2>::getRawDetId(const T2& recHit) {
+  assert(0);  // CV: make sure general function never gets called;
+              //     always use template specializations
 }
 
 template <>
-uint32_t MuonDetCleaner<CSCDetId, CSCRecHit2D>::getRawDetId(const CSCRecHit2D& recHit)
-{
+uint32_t MuonDetCleaner<CSCDetId, CSCRecHit2D>::getRawDetId(const CSCRecHit2D& recHit) {
   return recHit.cscDetId().rawId();
 }
 
 template <>
-uint32_t MuonDetCleaner<DTLayerId, DTRecHit1DPair>::getRawDetId(const DTRecHit1DPair& recHit)
-{
+uint32_t MuonDetCleaner<DTLayerId, DTRecHit1DPair>::getRawDetId(const DTRecHit1DPair& recHit) {
   return recHit.geographicalId().rawId();
 }
 
 template <>
-uint32_t MuonDetCleaner<RPCDetId, RPCRecHit>::getRawDetId(const RPCRecHit& recHit)
-{
+uint32_t MuonDetCleaner<RPCDetId, RPCRecHit>::getRawDetId(const RPCRecHit& recHit) {
   return recHit.rpcId().rawId();
 }
-
 
 //-------------------------------------------------------------------------------
 // find out what the kind of RecHit used by imput muons rechit
 //-------------------------------------------------------------------------------
 
 template <typename T1, typename T2>
-bool MuonDetCleaner<T1,T2>::checkrecHit(const TrackingRecHit& recHit)
-{
-  edm::LogError("TauEmbedding")<<"!!!! Please add the checkrecHit for the individual class templates "
-  assert(0);
+bool MuonDetCleaner<T1, T2>::checkrecHit(const TrackingRecHit& recHit) {
+  edm::LogError("TauEmbedding") << "!!!! Please add the checkrecHit for the individual class templates " assert(0);
 }
-
 
 template <>
-bool MuonDetCleaner<CSCDetId, CSCRecHit2D>::checkrecHit(const TrackingRecHit& recHit)
-{	    
-   const std::type_info &hit_type = typeid(recHit);
-   if (hit_type == typeid(CSCSegment))  {return true;}  // This should be the default one (which are included in the global (outer) muon track)
-   else if (hit_type == typeid(CSCRecHit2D)) {return true;}
-   //else {std::cout<<"else "<<hit_type.name()<<std::endl;}    
-   return false;
+bool MuonDetCleaner<CSCDetId, CSCRecHit2D>::checkrecHit(const TrackingRecHit& recHit) {
+  const std::type_info& hit_type = typeid(recHit);
+  if (hit_type == typeid(CSCSegment)) {
+    return true;
+  }  // This should be the default one (which are included in the global (outer) muon track)
+  else if (hit_type == typeid(CSCRecHit2D)) {
+    return true;
+  }
+  //else {std::cout<<"else "<<hit_type.name()<<std::endl;}
+  return false;
 }
-
 
 template <>
-bool MuonDetCleaner<DTLayerId, DTRecHit1DPair>::checkrecHit(const TrackingRecHit& recHit)
-{	    
-   const std::type_info &hit_type = typeid(recHit);
-   if (hit_type == typeid(DTRecSegment4D))  {return true;}  // This should be the default one (which are included in the global (outer) muon track)
-   else if (hit_type == typeid(DTRecHit1D)) {return true;}
-   else if (hit_type == typeid(DTSLRecCluster)) {return true; }
-   else if (hit_type == typeid(DTSLRecSegment2D)) {return true; }
-  // else {std::cout<<"else "<<hit_type.name()<<std::endl;}	    
-   return false;
+bool MuonDetCleaner<DTLayerId, DTRecHit1DPair>::checkrecHit(const TrackingRecHit& recHit) {
+  const std::type_info& hit_type = typeid(recHit);
+  if (hit_type == typeid(DTRecSegment4D)) {
+    return true;
+  }  // This should be the default one (which are included in the global (outer) muon track)
+  else if (hit_type == typeid(DTRecHit1D)) {
+    return true;
+  } else if (hit_type == typeid(DTSLRecCluster)) {
+    return true;
+  } else if (hit_type == typeid(DTSLRecSegment2D)) {
+    return true;
+  }
+  // else {std::cout<<"else "<<hit_type.name()<<std::endl;}
+  return false;
 }
-
 
 template <>
-bool MuonDetCleaner<RPCDetId, RPCRecHit>::checkrecHit(const TrackingRecHit& recHit)
-{	    
-   const std::type_info &hit_type = typeid(recHit);
-   if (hit_type == typeid(RPCRecHit))  {return true;}  // This should be the default one (which are included in the global (outer) muon track)
-   //else {std::cout<<"else "<<hit_type.name()<<std::endl;}	    
-   return false;
+bool MuonDetCleaner<RPCDetId, RPCRecHit>::checkrecHit(const TrackingRecHit& recHit) {
+  const std::type_info& hit_type = typeid(recHit);
+  if (hit_type == typeid(RPCRecHit)) {
+    return true;
+  }  // This should be the default one (which are included in the global (outer) muon track)
+  //else {std::cout<<"else "<<hit_type.name()<<std::endl;}
+  return false;
 }
-
-
 
 DEFINE_FWK_MODULE(CSCRecHitColCleaner);
 DEFINE_FWK_MODULE(DTRecHitColCleaner);

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h
@@ -15,7 +15,6 @@
 #ifndef TauAnalysis_MCEmbeddingTools_MuonDetCleaner_H
 #define TauAnalysis_MCEmbeddingTools_MuonDetCleaner_H
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -33,121 +32,114 @@
 #include <map>
 
 template <typename T1, typename T2>
-class MuonDetCleaner : public edm::stream::EDProducer<>
-{
- public:
+class MuonDetCleaner : public edm::stream::EDProducer<> {
+public:
   explicit MuonDetCleaner(const edm::ParameterSet&);
   ~MuonDetCleaner() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef edm::RangeMap<T1, edm::OwnVector<T2> > RecHitCollection;
-  void fillVetoHits(const TrackingRecHit& , std::vector<uint32_t>* );
-  
+  void fillVetoHits(const TrackingRecHit&, std::vector<uint32_t>*);
+
   uint32_t getRawDetId(const T2&);
-  bool checkrecHit(const TrackingRecHit&); 
+  bool checkrecHit(const TrackingRecHit&);
 
   const edm::EDGetTokenT<edm::View<pat::Muon> > mu_input_;
-  
-  std::map<std::string,  edm::EDGetTokenT<RecHitCollection > > inputs_;
-  
+
+  std::map<std::string, edm::EDGetTokenT<RecHitCollection> > inputs_;
 };
 
 template <typename T1, typename T2>
-MuonDetCleaner<T1,T2>::MuonDetCleaner(const edm::ParameterSet& iConfig):
-    mu_input_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonCollection"))) 
-{
-  std::vector<edm::InputTag> inCollections =  iConfig.getParameter<std::vector<edm::InputTag> >("oldCollection");
-  for (auto inCollection : inCollections){
-     inputs_[inCollection.instance()] = consumes<RecHitCollection >(inCollection);
-     produces<RecHitCollection>(inCollection.instance());
+MuonDetCleaner<T1, T2>::MuonDetCleaner(const edm::ParameterSet& iConfig)
+    : mu_input_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonCollection"))) {
+  std::vector<edm::InputTag> inCollections = iConfig.getParameter<std::vector<edm::InputTag> >("oldCollection");
+  for (auto inCollection : inCollections) {
+    inputs_[inCollection.instance()] = consumes<RecHitCollection>(inCollection);
+    produces<RecHitCollection>(inCollection.instance());
   }
-    
 }
 
 template <typename T1, typename T2>
-MuonDetCleaner<T1,T2>::~MuonDetCleaner()
-{
-// nothing to be done yet...  
+MuonDetCleaner<T1, T2>::~MuonDetCleaner() {
+  // nothing to be done yet...
 }
 
 template <typename T1, typename T2>
-void MuonDetCleaner<T1,T2>::produce(edm::Event& iEvent, const edm::EventSetup& es)
-{
-   std::map<T1, std::vector<T2> > recHits_output; // This data format is easyer to handle
-   std::vector<uint32_t> vetoHits;
-  
+void MuonDetCleaner<T1, T2>::produce(edm::Event& iEvent, const edm::EventSetup& es) {
+  std::map<T1, std::vector<T2> > recHits_output;  // This data format is easyer to handle
+  std::vector<uint32_t> vetoHits;
+
   // First fill the veto RecHits colletion with the Hits from the input muons
-   edm::Handle< edm::View<pat::Muon> > muonHandle;
-   iEvent.getByToken(mu_input_, muonHandle);
-   edm::View<pat::Muon> muons = *muonHandle;
-   for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {     
-      const reco::Track* track = nullptr;
-      if( iMuon->isGlobalMuon() ) track = iMuon->outerTrack().get();
-      else if  ( iMuon->isStandAloneMuon() ) track =   iMuon->outerTrack().get();
-      else if  ( iMuon->isRPCMuon() ) track =   iMuon->innerTrack().get(); // To add, try to access the rpc track 
-      else if  ( iMuon->isTrackerMuon() ) track = iMuon->innerTrack().get();
-      else {
-	edm::LogError("TauEmbedding")<<"The imput muon: "<<(*iMuon)<<" must be either global or does or be tracker muon";
-	assert(0);
-      }
-      
-      
-     for (trackingRecHit_iterator hitIt = track->recHitsBegin(); hitIt != track->recHitsEnd(); ++hitIt) {
-        const TrackingRecHit &murechit = **hitIt; // Base class for all rechits 
-        if(!(murechit).isValid()) continue;
-        if (!checkrecHit(murechit)) continue;   // Check if the hit belongs to a specifc detector section   
-        fillVetoHits(murechit,&vetoHits); // Go back to the very basic rechits 
-       }
-   }
+  edm::Handle<edm::View<pat::Muon> > muonHandle;
+  iEvent.getByToken(mu_input_, muonHandle);
+  edm::View<pat::Muon> muons = *muonHandle;
+  for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {
+    const reco::Track* track = nullptr;
+    if (iMuon->isGlobalMuon())
+      track = iMuon->outerTrack().get();
+    else if (iMuon->isStandAloneMuon())
+      track = iMuon->outerTrack().get();
+    else if (iMuon->isRPCMuon())
+      track = iMuon->innerTrack().get();  // To add, try to access the rpc track
+    else if (iMuon->isTrackerMuon())
+      track = iMuon->innerTrack().get();
+    else {
+      edm::LogError("TauEmbedding") << "The imput muon: " << (*iMuon)
+                                    << " must be either global or does or be tracker muon";
+      assert(0);
+    }
 
-   
-   // Now this can also handle different instance
-   for (auto input_ : inputs_){
-    // Second read in the RecHit Colltection which is to be replaced, without the vetoRecHits   
+    for (trackingRecHit_iterator hitIt = track->recHitsBegin(); hitIt != track->recHitsEnd(); ++hitIt) {
+      const TrackingRecHit& murechit = **hitIt;  // Base class for all rechits
+      if (!(murechit).isValid())
+        continue;
+      if (!checkrecHit(murechit))
+        continue;                         // Check if the hit belongs to a specifc detector section
+      fillVetoHits(murechit, &vetoHits);  // Go back to the very basic rechits
+    }
+  }
+
+  // Now this can also handle different instance
+  for (auto input_ : inputs_) {
+    // Second read in the RecHit Colltection which is to be replaced, without the vetoRecHits
     typedef edm::Handle<RecHitCollection> RecHitCollectionHandle;
     RecHitCollectionHandle RecHitinput;
     iEvent.getByToken(input_.second, RecHitinput);
-    for ( typename RecHitCollection::const_iterator recHit = RecHitinput->begin(); recHit != RecHitinput->end(); ++recHit ) { // loop over the basic rec hit collection (DT CSC or RPC)
-	//if (find(vetoHits.begin(),vetoHits.end(),getRawDetId(*recHit)) == vetoHits.end()) continue; // For the invertec selcetion
-        if (find(vetoHits.begin(),vetoHits.end(),getRawDetId(*recHit)) != vetoHits.end()) continue; // If the hit is not in the  
-	T1 detId(getRawDetId(*recHit));
-	recHits_output[detId].push_back(*recHit);	
+    for (typename RecHitCollection::const_iterator recHit = RecHitinput->begin(); recHit != RecHitinput->end();
+         ++recHit) {  // loop over the basic rec hit collection (DT CSC or RPC)
+      //if (find(vetoHits.begin(),vetoHits.end(),getRawDetId(*recHit)) == vetoHits.end()) continue; // For the invertec selcetion
+      if (find(vetoHits.begin(), vetoHits.end(), getRawDetId(*recHit)) != vetoHits.end())
+        continue;  // If the hit is not in the
+      T1 detId(getRawDetId(*recHit));
+      recHits_output[detId].push_back(*recHit);
     }
-  
-    
-    
+
     // Last step savet the output in the CMSSW Data Format
     std::unique_ptr<RecHitCollection> output(new RecHitCollection());
-    for ( typename std::map<T1, std::vector<T2> >::const_iterator recHit = recHits_output.begin(); recHit != recHits_output.end(); ++recHit ) {
+    for (typename std::map<T1, std::vector<T2> >::const_iterator recHit = recHits_output.begin();
+         recHit != recHits_output.end();
+         ++recHit) {
       output->put(recHit->first, recHit->second.begin(), recHit->second.end());
     }
     output->post_insert();
-    iEvent.put(std::move(output),input_.first);
-   }
+    iEvent.put(std::move(output), input_.first);
+  }
 }
-
 
 template <typename T1, typename T2>
-void MuonDetCleaner<T1,T2>::fillVetoHits(const TrackingRecHit& rh, std::vector<uint32_t>* HitsList)
-{
-    std::vector<const TrackingRecHit*> rh_components = rh.recHits();
-    if ( rh_components.empty() ) {
-      HitsList->push_back(rh.rawId());
-    } 
-    else {
-      for ( std::vector<const TrackingRecHit*>::const_iterator rh_component = rh_components.begin(); rh_component != rh_components.end(); ++rh_component ) {
-	fillVetoHits(**rh_component, HitsList);
-      }
+void MuonDetCleaner<T1, T2>::fillVetoHits(const TrackingRecHit& rh, std::vector<uint32_t>* HitsList) {
+  std::vector<const TrackingRecHit*> rh_components = rh.recHits();
+  if (rh_components.empty()) {
+    HitsList->push_back(rh.rawId());
+  } else {
+    for (std::vector<const TrackingRecHit*>::const_iterator rh_component = rh_components.begin();
+         rh_component != rh_components.end();
+         ++rh_component) {
+      fillVetoHits(**rh_component, HitsList);
     }
+  }
 }
 
-
-
-
 #endif
-
-
-
-

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.cc
@@ -7,8 +7,6 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 
-
-
 #include "DataFormats/EgammaTrackReco/interface/ConversionTrack.h"
 #include "DataFormats/EgammaTrackReco/interface/ConversionTrackFwd.h"
 
@@ -20,7 +18,6 @@
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
@@ -37,351 +34,312 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
-
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
 
-
-
 typedef TrackMergeremb<reco::TrackCollection> TrackColMerger;
-typedef TrackMergeremb<reco::MuonCollection > MuonColMerger;
-typedef TrackMergeremb<reco::GsfElectronCollection > GsfElectronColMerger;
-typedef TrackMergeremb<reco::PhotonCollection > PhotonColMerger;
-typedef TrackMergeremb<reco::PFCandidateCollection > PFColMerger;
-
-
+typedef TrackMergeremb<reco::MuonCollection> MuonColMerger;
+typedef TrackMergeremb<reco::GsfElectronCollection> GsfElectronColMerger;
+typedef TrackMergeremb<reco::PhotonCollection> PhotonColMerger;
+typedef TrackMergeremb<reco::PFCandidateCollection> PFColMerger;
 
 // Here some overloaded functions, which are needed such that the right merger function is called for the indivudal Collections
 template <typename T1>
-void  TrackMergeremb<T1>::willproduce(std::string instance, std::string alias)
-{
+void TrackMergeremb<T1>::willproduce(std::string instance, std::string alias) {
   produces<TrackCollectionemb>(instance);
 }
 
 template <typename T1>
-void  TrackMergeremb<T1>::willconsume(const edm::ParameterSet& iConfig)
-{
-
-}
+void TrackMergeremb<T1>::willconsume(const edm::ParameterSet& iConfig) {}
 
 template <typename T1>
-void  TrackMergeremb<T1>::merg_and_put(edm::Event& iEvent, std::string instance,  std::vector<edm::EDGetTokenT<TrackCollectionemb> > &to_merge)
-{
+void TrackMergeremb<T1>::merg_and_put(edm::Event& iEvent,
+                                      std::string instance,
+                                      std::vector<edm::EDGetTokenT<TrackCollectionemb> >& to_merge) {
+  std::unique_ptr<TrackCollectionemb> outTracks = std::unique_ptr<TrackCollectionemb>(new TrackCollectionemb);
 
-    std::unique_ptr<TrackCollectionemb> outTracks = std::unique_ptr<TrackCollectionemb>(new TrackCollectionemb);
-   
-    for (auto akt_collection : to_merge){
-        edm::Handle<TrackCollectionemb> track_col_in;  
-        iEvent.getByToken(akt_collection, track_col_in);
-          
-        size_t sedref_it = 0;
-        for (typename TrackCollectionemb::const_iterator it = track_col_in->begin(); it != track_col_in->end(); ++it, ++sedref_it) {
-        outTracks->push_back( typename T1::value_type( *it ) );
-	    	    
-        }
-	          
-    }// end merge 
-    
-    iEvent.put(std::move(outTracks),instance); 
-  
-}
+  for (auto akt_collection : to_merge) {
+    edm::Handle<TrackCollectionemb> track_col_in;
+    iEvent.getByToken(akt_collection, track_col_in);
 
-template <>
-void  TrackMergeremb<reco::TrackCollection>::willproduce(std::string instance, std::string alias)
-{
-
-    produces<reco::TrackCollection>(instance).setBranchAlias( alias + "Tracks" );
-    produces<reco::TrackExtraCollection>(instance).setBranchAlias( alias + "TrackExtras" );
-    produces<TrackingRecHitCollection>(instance).setBranchAlias( alias + "RecHits" );
-    produces<TrackToTrackMapnew>();
-    
-}
-
-template <>
-void  TrackMergeremb<reco::TrackCollection>::merg_and_put(edm::Event& iEvent, std::string instance,  std::vector<edm::EDGetTokenT<reco::TrackCollection> > &to_merge )
-{
-    
-    std::unique_ptr<reco::TrackCollection> outTracks = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection);
-    std::unique_ptr<reco::TrackExtraCollection> outTracks_ex = std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
-    std::unique_ptr<TrackingRecHitCollection> outTracks_rh = std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
-    std::unique_ptr<TrackToTrackMapnew> outTracks_refs = std::unique_ptr<TrackToTrackMapnew>(new TrackToTrackMapnew()); 
-    
-    auto rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-   // auto rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
-      
-   std::vector<reco::TrackRefVector> trackRefColl;
-   //std::vector<reco::TrackRef> trackRefColl;
-    
-    for (auto akt_collection : to_merge){
-        edm::Handle<reco::TrackCollection> track_col_in;  
-        iEvent.getByToken(akt_collection, track_col_in);
-          
-        unsigned sedref_it = 0;
-        for (reco::TrackCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end(); ++it, ++sedref_it) {
-        outTracks->push_back( reco::Track( *it ) );
-        outTracks_ex->push_back( reco::TrackExtra( *it->extra() ) );
-        outTracks->back().setExtra( reco::TrackExtraRef( rTrackExtras, outTracks_ex->size() - 1) );	
-	reco::TrackRef trackRefold(track_col_in, sedref_it);
-	
-	reco::TrackRefVector trackRefColl_helpvec;
-	trackRefColl_helpvec.push_back(trackRefold);
-	trackRefColl.push_back(trackRefColl_helpvec);	
-        }
-	          
-    }// end merge 
-    
-    
-    edm::OrphanHandle<reco::TrackCollection> trackHandle = iEvent.put(std::move(outTracks),instance);
-    iEvent.put(std::move(outTracks_ex),instance);
-    
-    
-    TrackToTrackMapnew::Filler filler(*outTracks_refs);
-    filler.insert(trackHandle, trackRefColl.begin(), trackRefColl.end() );
-    filler.fill();
-    
-    iEvent.put(std::move(outTracks_refs));
-    iEvent.put(std::move(outTracks_rh),instance); // not implemented so far
-    
-}
-
-
-
-template <>
-void  TrackMergeremb<reco::GsfTrackCollection>::willproduce(std::string instance, std::string alias)
-{
-    produces<reco::GsfTrackCollection>(instance).setBranchAlias( alias + "GsfTracks" );
-    produces<reco::TrackExtraCollection>(instance).setBranchAlias( alias + "TrackExtras" );
-    produces<reco::GsfTrackExtraCollection>(instance).setBranchAlias( alias + "GsfTrackExtras" );
-    produces<TrackingRecHitCollection>(instance).setBranchAlias( alias + "RecHits" );
-}
-
-template <>
-void  TrackMergeremb<reco::GsfTrackCollection>::merg_and_put(edm::Event& iEvent, std::string instance,  std::vector<edm::EDGetTokenT<reco::GsfTrackCollection> > &to_merge )
-{
-    std::unique_ptr<reco::GsfTrackCollection> outTracks = std::unique_ptr<reco::GsfTrackCollection>(new reco::GsfTrackCollection);
-    std::unique_ptr<reco::TrackExtraCollection> outTracks_ex = std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
-    std::unique_ptr<reco::GsfTrackExtraCollection> outTracks_exgsf = std::unique_ptr<reco::GsfTrackExtraCollection>(new reco::GsfTrackExtraCollection());
-    std::unique_ptr<TrackingRecHitCollection> outTracks_rh = std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
-    
-    
-    auto rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-    auto rTrackExtras_gsf = iEvent.getRefBeforePut<reco::GsfTrackExtraCollection>();
-    
-    auto rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
-      
-    for (auto akt_collection : to_merge){
-        edm::Handle<reco::GsfTrackCollection> track_col_in;  
-        iEvent.getByToken(akt_collection, track_col_in);
-          
-        size_t sedref_it = 0;
-        for (reco::GsfTrackCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end(); ++it, ++sedref_it) {
-        outTracks->push_back( reco::GsfTrack( *it ) );
-        outTracks_ex->push_back( reco::TrackExtra( *it->extra() ) );
-        outTracks_exgsf->push_back( reco::GsfTrackExtra( *it->gsfExtra() ) );
-        
-        outTracks->back().setExtra( reco::TrackExtraRef( rTrackExtras, outTracks_ex->size() - 1) );
-        outTracks->back().setGsfExtra( reco::GsfTrackExtraRef( rTrackExtras_gsf, outTracks_exgsf->size() - 1) );
-        }
-	          
-    }// end merge 
-    
-    
-    iEvent.put(std::move(outTracks),instance);
-    iEvent.put(std::move(outTracks_ex),instance);
-    iEvent.put(std::move(outTracks_exgsf),instance);
-    iEvent.put(std::move(outTracks_rh),instance);
-
-}
-
-
-
-template <>
-void  TrackMergeremb<reco::MuonCollection >::willproduce(std::string instance, std::string alias)
-{
-   produces<reco::MuonCollection>();
-   produces<reco::CaloMuonCollection>();
-   produces<reco::MuonTimeExtraMap>("combined");
-   produces<reco::MuonTimeExtraMap>("dt");
-   produces<reco::MuonTimeExtraMap>("csc");
-  
-   // todo make this configurable (or not )
-   produces<reco::IsoDepositMap>("tracker");
-   produces<reco::IsoDepositMap>("ecal");
-   produces<reco::IsoDepositMap>("hcal");
-   produces<reco::IsoDepositMap>("ho");
-   produces<reco::IsoDepositMap>("jets");
-   
-   produces<reco::MuonToMuonMap>();
-   
-    
-}
-
-template <>
-void  TrackMergeremb<reco::MuonCollection >::willconsume(const edm::ParameterSet& iConfig)
-{
-
-   inputs_fixtrackrefs_ = consumes<TrackToTrackMapnew >( edm::InputTag("generalTracks") );
-   inputs_fixtrackcol_ = consumes<reco::TrackCollection >( edm::InputTag("generalTracks") );
-   
-   
-   
-}
-
-
-template <>
-void  TrackMergeremb<reco::MuonCollection  >::merg_and_put(edm::Event& iEvent, std::string instance,  std::vector<edm::EDGetTokenT<reco::MuonCollection> > &to_merge )
-{
-    std::unique_ptr<reco::MuonCollection> outTracks = std::unique_ptr<reco::MuonCollection>(new reco::MuonCollection);
-    std::unique_ptr<reco::CaloMuonCollection> calomu = std::unique_ptr<reco::CaloMuonCollection>(new reco::CaloMuonCollection); //not implemented so far 
-    
-    edm::Handle<TrackToTrackMapnew> track_ref_map;
-    iEvent.getByToken(inputs_fixtrackrefs_, track_ref_map);
-    
-    edm::Handle<reco::TrackCollection> track_new_col;
-    iEvent.getByToken(inputs_fixtrackcol_, track_new_col);   
-    std::map<reco::TrackRef , reco::TrackRef > simple_track_to_track_map; //I didn't find a more elegant way, so just build a good old fassion std::map
-     for (unsigned abc =0;  abc < track_new_col->size();  ++abc) {
-      reco::TrackRef trackRef(track_new_col, abc);      
-      simple_track_to_track_map[((*track_ref_map)[trackRef])[0]] = trackRef;
+    size_t sedref_it = 0;
+    for (typename TrackCollectionemb::const_iterator it = track_col_in->begin(); it != track_col_in->end();
+         ++it, ++sedref_it) {
+      outTracks->push_back(typename T1::value_type(*it));
     }
-    
-    std::vector<reco::MuonRef> muonRefColl;
-    reco::MuonRefProd outputMuonsRefProd = iEvent.getRefBeforePut<reco::MuonCollection>();
-    unsigned new_idx=0;
-    for (auto akt_collection : to_merge){
-        edm::Handle<reco::MuonCollection> track_col_in;  
-        iEvent.getByToken(akt_collection, track_col_in);
-	unsigned old_idx=0;
-        for (reco::MuonCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end(); ++it, ++old_idx, ++new_idx) {
-        outTracks->push_back( reco::Muon( *it ) );
-	 reco::MuonRef muRefold(track_col_in, old_idx);
-	 muonRefColl.push_back(muRefold);
-	 reco::MuonRef muRefnew(outputMuonsRefProd, new_idx);
-                  
-        if (it->track().isNonnull()){
-            //std::cout<<"pfmerge tr: "<<it->trackRef().id()<< " "<< it->trackRef().key()<< " " << simple_track_to_track_map[it->trackRef()].id() <<  " " << simple_track_to_track_map[it->trackRef()].key() <<std::endl;
-	    outTracks->back().setTrack( simple_track_to_track_map[it->track()]  );
-	 }
-        }
-	          
-    }// end merge 
-    
-     const int nMuons=outTracks->size();
 
-     std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
-     std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
-     std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
-     std::vector<reco::IsoDeposit> trackDepColl(nMuons);
-     std::vector<reco::IsoDeposit> ecalDepColl(nMuons);
-     std::vector<reco::IsoDeposit> hcalDepColl(nMuons);
-     std::vector<reco::IsoDeposit> hoDepColl(nMuons);
-     std::vector<reco::IsoDeposit> jetDepColl(nMuons);
-          
-    edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(std::move(outTracks));
-    
-    auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = ""){
-     typedef  edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;
-     std::unique_ptr<MapType > oMap(new MapType());
-     {
-       typename MapType::Filler filler(*oMap);
-       filler.insert(refH, vec.begin(), vec.end());
-       vec.clear();
-       filler.fill();
-     }
-     ev.put(std::move(oMap), cAl);
-    };
-    
-   fillMap(muonHandle, combinedTimeColl, iEvent, "combined");
-   fillMap(muonHandle, dtTimeColl, iEvent, "dt");
-   fillMap(muonHandle, cscTimeColl, iEvent, "csc");
-   fillMap(muonHandle, trackDepColl, iEvent, "tracker");
-   fillMap(muonHandle, ecalDepColl, iEvent, "ecal");
-   fillMap(muonHandle, hcalDepColl, iEvent, "hcal");
-   fillMap(muonHandle, hoDepColl, iEvent, "ho");
-   fillMap(muonHandle, jetDepColl, iEvent, "jets");
-   fillMap(muonHandle, muonRefColl, iEvent);   
-   iEvent.put(std::move(calomu));   
-    
+  }  // end merge
+
+  iEvent.put(std::move(outTracks), instance);
 }
 
-
+template <>
+void TrackMergeremb<reco::TrackCollection>::willproduce(std::string instance, std::string alias) {
+  produces<reco::TrackCollection>(instance).setBranchAlias(alias + "Tracks");
+  produces<reco::TrackExtraCollection>(instance).setBranchAlias(alias + "TrackExtras");
+  produces<TrackingRecHitCollection>(instance).setBranchAlias(alias + "RecHits");
+  produces<TrackToTrackMapnew>();
+}
 
 template <>
-void  TrackMergeremb<reco::PFCandidateCollection >::willproduce(std::string instance, std::string alias)
-{
+void TrackMergeremb<reco::TrackCollection>::merg_and_put(
+    edm::Event& iEvent, std::string instance, std::vector<edm::EDGetTokenT<reco::TrackCollection> >& to_merge) {
+  std::unique_ptr<reco::TrackCollection> outTracks = std::unique_ptr<reco::TrackCollection>(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> outTracks_ex =
+      std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
+  std::unique_ptr<TrackingRecHitCollection> outTracks_rh =
+      std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+  std::unique_ptr<TrackToTrackMapnew> outTracks_refs = std::unique_ptr<TrackToTrackMapnew>(new TrackToTrackMapnew());
 
+  auto rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  // auto rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
+
+  std::vector<reco::TrackRefVector> trackRefColl;
+  //std::vector<reco::TrackRef> trackRefColl;
+
+  for (auto akt_collection : to_merge) {
+    edm::Handle<reco::TrackCollection> track_col_in;
+    iEvent.getByToken(akt_collection, track_col_in);
+
+    unsigned sedref_it = 0;
+    for (reco::TrackCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end();
+         ++it, ++sedref_it) {
+      outTracks->push_back(reco::Track(*it));
+      outTracks_ex->push_back(reco::TrackExtra(*it->extra()));
+      outTracks->back().setExtra(reco::TrackExtraRef(rTrackExtras, outTracks_ex->size() - 1));
+      reco::TrackRef trackRefold(track_col_in, sedref_it);
+
+      reco::TrackRefVector trackRefColl_helpvec;
+      trackRefColl_helpvec.push_back(trackRefold);
+      trackRefColl.push_back(trackRefColl_helpvec);
+    }
+
+  }  // end merge
+
+  edm::OrphanHandle<reco::TrackCollection> trackHandle = iEvent.put(std::move(outTracks), instance);
+  iEvent.put(std::move(outTracks_ex), instance);
+
+  TrackToTrackMapnew::Filler filler(*outTracks_refs);
+  filler.insert(trackHandle, trackRefColl.begin(), trackRefColl.end());
+  filler.fill();
+
+  iEvent.put(std::move(outTracks_refs));
+  iEvent.put(std::move(outTracks_rh), instance);  // not implemented so far
+}
+
+template <>
+void TrackMergeremb<reco::GsfTrackCollection>::willproduce(std::string instance, std::string alias) {
+  produces<reco::GsfTrackCollection>(instance).setBranchAlias(alias + "GsfTracks");
+  produces<reco::TrackExtraCollection>(instance).setBranchAlias(alias + "TrackExtras");
+  produces<reco::GsfTrackExtraCollection>(instance).setBranchAlias(alias + "GsfTrackExtras");
+  produces<TrackingRecHitCollection>(instance).setBranchAlias(alias + "RecHits");
+}
+
+template <>
+void TrackMergeremb<reco::GsfTrackCollection>::merg_and_put(
+    edm::Event& iEvent, std::string instance, std::vector<edm::EDGetTokenT<reco::GsfTrackCollection> >& to_merge) {
+  std::unique_ptr<reco::GsfTrackCollection> outTracks =
+      std::unique_ptr<reco::GsfTrackCollection>(new reco::GsfTrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> outTracks_ex =
+      std::unique_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
+  std::unique_ptr<reco::GsfTrackExtraCollection> outTracks_exgsf =
+      std::unique_ptr<reco::GsfTrackExtraCollection>(new reco::GsfTrackExtraCollection());
+  std::unique_ptr<TrackingRecHitCollection> outTracks_rh =
+      std::unique_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+
+  auto rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  auto rTrackExtras_gsf = iEvent.getRefBeforePut<reco::GsfTrackExtraCollection>();
+
+  auto rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
+
+  for (auto akt_collection : to_merge) {
+    edm::Handle<reco::GsfTrackCollection> track_col_in;
+    iEvent.getByToken(akt_collection, track_col_in);
+
+    size_t sedref_it = 0;
+    for (reco::GsfTrackCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end();
+         ++it, ++sedref_it) {
+      outTracks->push_back(reco::GsfTrack(*it));
+      outTracks_ex->push_back(reco::TrackExtra(*it->extra()));
+      outTracks_exgsf->push_back(reco::GsfTrackExtra(*it->gsfExtra()));
+
+      outTracks->back().setExtra(reco::TrackExtraRef(rTrackExtras, outTracks_ex->size() - 1));
+      outTracks->back().setGsfExtra(reco::GsfTrackExtraRef(rTrackExtras_gsf, outTracks_exgsf->size() - 1));
+    }
+
+  }  // end merge
+
+  iEvent.put(std::move(outTracks), instance);
+  iEvent.put(std::move(outTracks_ex), instance);
+  iEvent.put(std::move(outTracks_exgsf), instance);
+  iEvent.put(std::move(outTracks_rh), instance);
+}
+
+template <>
+void TrackMergeremb<reco::MuonCollection>::willproduce(std::string instance, std::string alias) {
+  produces<reco::MuonCollection>();
+  produces<reco::CaloMuonCollection>();
+  produces<reco::MuonTimeExtraMap>("combined");
+  produces<reco::MuonTimeExtraMap>("dt");
+  produces<reco::MuonTimeExtraMap>("csc");
+
+  // todo make this configurable (or not )
+  produces<reco::IsoDepositMap>("tracker");
+  produces<reco::IsoDepositMap>("ecal");
+  produces<reco::IsoDepositMap>("hcal");
+  produces<reco::IsoDepositMap>("ho");
+  produces<reco::IsoDepositMap>("jets");
+
+  produces<reco::MuonToMuonMap>();
+}
+
+template <>
+void TrackMergeremb<reco::MuonCollection>::willconsume(const edm::ParameterSet& iConfig) {
+  inputs_fixtrackrefs_ = consumes<TrackToTrackMapnew>(edm::InputTag("generalTracks"));
+  inputs_fixtrackcol_ = consumes<reco::TrackCollection>(edm::InputTag("generalTracks"));
+}
+
+template <>
+void TrackMergeremb<reco::MuonCollection>::merg_and_put(
+    edm::Event& iEvent, std::string instance, std::vector<edm::EDGetTokenT<reco::MuonCollection> >& to_merge) {
+  std::unique_ptr<reco::MuonCollection> outTracks = std::unique_ptr<reco::MuonCollection>(new reco::MuonCollection);
+  std::unique_ptr<reco::CaloMuonCollection> calomu =
+      std::unique_ptr<reco::CaloMuonCollection>(new reco::CaloMuonCollection);  //not implemented so far
+
+  edm::Handle<TrackToTrackMapnew> track_ref_map;
+  iEvent.getByToken(inputs_fixtrackrefs_, track_ref_map);
+
+  edm::Handle<reco::TrackCollection> track_new_col;
+  iEvent.getByToken(inputs_fixtrackcol_, track_new_col);
+  std::map<reco::TrackRef, reco::TrackRef>
+      simple_track_to_track_map;  //I didn't find a more elegant way, so just build a good old fassion std::map
+  for (unsigned abc = 0; abc < track_new_col->size(); ++abc) {
+    reco::TrackRef trackRef(track_new_col, abc);
+    simple_track_to_track_map[((*track_ref_map)[trackRef])[0]] = trackRef;
+  }
+
+  std::vector<reco::MuonRef> muonRefColl;
+  reco::MuonRefProd outputMuonsRefProd = iEvent.getRefBeforePut<reco::MuonCollection>();
+  unsigned new_idx = 0;
+  for (auto akt_collection : to_merge) {
+    edm::Handle<reco::MuonCollection> track_col_in;
+    iEvent.getByToken(akt_collection, track_col_in);
+    unsigned old_idx = 0;
+    for (reco::MuonCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end();
+         ++it, ++old_idx, ++new_idx) {
+      outTracks->push_back(reco::Muon(*it));
+      reco::MuonRef muRefold(track_col_in, old_idx);
+      muonRefColl.push_back(muRefold);
+      reco::MuonRef muRefnew(outputMuonsRefProd, new_idx);
+
+      if (it->track().isNonnull()) {
+        //std::cout<<"pfmerge tr: "<<it->trackRef().id()<< " "<< it->trackRef().key()<< " " << simple_track_to_track_map[it->trackRef()].id() <<  " " << simple_track_to_track_map[it->trackRef()].key() <<std::endl;
+        outTracks->back().setTrack(simple_track_to_track_map[it->track()]);
+      }
+    }
+
+  }  // end merge
+
+  const int nMuons = outTracks->size();
+
+  std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
+  std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
+  std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
+  std::vector<reco::IsoDeposit> trackDepColl(nMuons);
+  std::vector<reco::IsoDeposit> ecalDepColl(nMuons);
+  std::vector<reco::IsoDeposit> hcalDepColl(nMuons);
+  std::vector<reco::IsoDeposit> hoDepColl(nMuons);
+  std::vector<reco::IsoDeposit> jetDepColl(nMuons);
+
+  edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(std::move(outTracks));
+
+  auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = "") {
+    typedef edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;
+    std::unique_ptr<MapType> oMap(new MapType());
+    {
+      typename MapType::Filler filler(*oMap);
+      filler.insert(refH, vec.begin(), vec.end());
+      vec.clear();
+      filler.fill();
+    }
+    ev.put(std::move(oMap), cAl);
+  };
+
+  fillMap(muonHandle, combinedTimeColl, iEvent, "combined");
+  fillMap(muonHandle, dtTimeColl, iEvent, "dt");
+  fillMap(muonHandle, cscTimeColl, iEvent, "csc");
+  fillMap(muonHandle, trackDepColl, iEvent, "tracker");
+  fillMap(muonHandle, ecalDepColl, iEvent, "ecal");
+  fillMap(muonHandle, hcalDepColl, iEvent, "hcal");
+  fillMap(muonHandle, hoDepColl, iEvent, "ho");
+  fillMap(muonHandle, jetDepColl, iEvent, "jets");
+  fillMap(muonHandle, muonRefColl, iEvent);
+  iEvent.put(std::move(calomu));
+}
+
+template <>
+void TrackMergeremb<reco::PFCandidateCollection>::willproduce(std::string instance, std::string alias) {
   produces<reco::PFCandidateCollection>(instance);
- // std::cout<<"Produce PF Collection: "<<instance<<std::endl;  
-    
+  // std::cout<<"Produce PF Collection: "<<instance<<std::endl;
 }
-
 
 template <>
-void  TrackMergeremb<reco::PFCandidateCollection>::willconsume(const edm::ParameterSet& iConfig)
-{
-
-   inputs_fixtrackrefs_ = consumes<TrackToTrackMapnew >( edm::InputTag("generalTracks") );
-   inputs_fixtrackcol_ = consumes<reco::TrackCollection >( edm::InputTag("generalTracks") );
-   inputs_fixmurefs_ = consumes<reco::MuonToMuonMap >( edm::InputTag("muons1stStep") );
-   inputs_fixmucol_ = consumes<reco::MuonCollection >( edm::InputTag("muons1stStep") );
-   
-   
+void TrackMergeremb<reco::PFCandidateCollection>::willconsume(const edm::ParameterSet& iConfig) {
+  inputs_fixtrackrefs_ = consumes<TrackToTrackMapnew>(edm::InputTag("generalTracks"));
+  inputs_fixtrackcol_ = consumes<reco::TrackCollection>(edm::InputTag("generalTracks"));
+  inputs_fixmurefs_ = consumes<reco::MuonToMuonMap>(edm::InputTag("muons1stStep"));
+  inputs_fixmucol_ = consumes<reco::MuonCollection>(edm::InputTag("muons1stStep"));
 }
-
-
 
 template <>
-void  TrackMergeremb<reco::PFCandidateCollection >::merg_and_put(edm::Event& iEvent, std::string instance,  std::vector<edm::EDGetTokenT<reco::PFCandidateCollection> > &to_merge )
-{
-    std::unique_ptr<reco::PFCandidateCollection> outTracks = std::unique_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
-    
-    edm::Handle<TrackToTrackMapnew> track_ref_map;
-    iEvent.getByToken(inputs_fixtrackrefs_, track_ref_map);
-    
-    edm::Handle<reco::TrackCollection> track_new_col;
-    iEvent.getByToken(inputs_fixtrackcol_, track_new_col);   
-    std::map<reco::TrackRef , reco::TrackRef > simple_track_to_track_map; //I didn't find a more elegant way, so just build a good old fassion std::map
-     for (unsigned abc =0;  abc < track_new_col->size();  ++abc) {
-      reco::TrackRef trackRef(track_new_col, abc);      
-      simple_track_to_track_map[((*track_ref_map)[trackRef])[0]] = trackRef;
-    }
-    
-    
-    edm::Handle<reco::MuonToMuonMap> muon_ref_map;
-    iEvent.getByToken(inputs_fixmurefs_, muon_ref_map);
-    
-    edm::Handle<reco::MuonCollection> muon_new_col;
-    iEvent.getByToken(inputs_fixmucol_, muon_new_col);   
-    std::map<reco::MuonRef , reco::MuonRef > simple_mu_to_mu_map; //I didn't find a more elegant way, so just build a good old fassion std::map
-    for (unsigned abc =0;  abc < muon_new_col->size();  ++abc) {
-      reco::MuonRef muRef(muon_new_col, abc);      
-      simple_mu_to_mu_map[(*muon_ref_map)[muRef]] = muRef;
-    }
-    
-    
-      
-    for (auto akt_collection : to_merge){
-        edm::Handle<reco::PFCandidateCollection> track_col_in;  
-        iEvent.getByToken(akt_collection, track_col_in);     
-        for (reco::PFCandidateCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end(); ++it) {
-        outTracks->push_back( reco::PFCandidate( *it ) );
-	//if (fabs(it->pdgId()) == 13){
-	if (it->trackRef().isNonnull() && outTracks->back().charge()){
-            //std::cout<<"pfmerge tr: "<<it->trackRef().id()<< " "<< it->trackRef().key()<< " " << simple_track_to_track_map[it->trackRef()].id() <<  " " << simple_track_to_track_map[it->trackRef()].key() <<std::endl;   
-	    outTracks->back().setTrackRef( simple_track_to_track_map[it->trackRef()]  );
-	 }	 
-        if (it->muonRef().isNonnull()){
-        	//std::cout<<"pfmerge mu: "<<it->muonRef().id()<< " "<< it->muonRef().key()<< " " << simple_mu_to_mu_map[it->muonRef()].id() <<  " " << simple_mu_to_mu_map[it->muonRef()].key() <<std::endl;
-		outTracks->back().setMuonRef( simple_mu_to_mu_map[it->muonRef()]  );		
-	        }
-	 
-        }	          
-    }// end merge 
+void TrackMergeremb<reco::PFCandidateCollection>::merg_and_put(
+    edm::Event& iEvent, std::string instance, std::vector<edm::EDGetTokenT<reco::PFCandidateCollection> >& to_merge) {
+  std::unique_ptr<reco::PFCandidateCollection> outTracks =
+      std::unique_ptr<reco::PFCandidateCollection>(new reco::PFCandidateCollection);
 
-    iEvent.put(std::move(outTracks),instance);
-     
+  edm::Handle<TrackToTrackMapnew> track_ref_map;
+  iEvent.getByToken(inputs_fixtrackrefs_, track_ref_map);
+
+  edm::Handle<reco::TrackCollection> track_new_col;
+  iEvent.getByToken(inputs_fixtrackcol_, track_new_col);
+  std::map<reco::TrackRef, reco::TrackRef>
+      simple_track_to_track_map;  //I didn't find a more elegant way, so just build a good old fassion std::map
+  for (unsigned abc = 0; abc < track_new_col->size(); ++abc) {
+    reco::TrackRef trackRef(track_new_col, abc);
+    simple_track_to_track_map[((*track_ref_map)[trackRef])[0]] = trackRef;
+  }
+
+  edm::Handle<reco::MuonToMuonMap> muon_ref_map;
+  iEvent.getByToken(inputs_fixmurefs_, muon_ref_map);
+
+  edm::Handle<reco::MuonCollection> muon_new_col;
+  iEvent.getByToken(inputs_fixmucol_, muon_new_col);
+  std::map<reco::MuonRef, reco::MuonRef>
+      simple_mu_to_mu_map;  //I didn't find a more elegant way, so just build a good old fassion std::map
+  for (unsigned abc = 0; abc < muon_new_col->size(); ++abc) {
+    reco::MuonRef muRef(muon_new_col, abc);
+    simple_mu_to_mu_map[(*muon_ref_map)[muRef]] = muRef;
+  }
+
+  for (auto akt_collection : to_merge) {
+    edm::Handle<reco::PFCandidateCollection> track_col_in;
+    iEvent.getByToken(akt_collection, track_col_in);
+    for (reco::PFCandidateCollection::const_iterator it = track_col_in->begin(); it != track_col_in->end(); ++it) {
+      outTracks->push_back(reco::PFCandidate(*it));
+      //if (fabs(it->pdgId()) == 13){
+      if (it->trackRef().isNonnull() && outTracks->back().charge()) {
+        //std::cout<<"pfmerge tr: "<<it->trackRef().id()<< " "<< it->trackRef().key()<< " " << simple_track_to_track_map[it->trackRef()].id() <<  " " << simple_track_to_track_map[it->trackRef()].key() <<std::endl;
+        outTracks->back().setTrackRef(simple_track_to_track_map[it->trackRef()]);
+      }
+      if (it->muonRef().isNonnull()) {
+        //std::cout<<"pfmerge mu: "<<it->muonRef().id()<< " "<< it->muonRef().key()<< " " << simple_mu_to_mu_map[it->muonRef()].id() <<  " " << simple_mu_to_mu_map[it->muonRef()].key() <<std::endl;
+        outTracks->back().setMuonRef(simple_mu_to_mu_map[it->muonRef()]);
+      }
+    }
+  }  // end merge
+
+  iEvent.put(std::move(outTracks), instance);
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.h
@@ -12,13 +12,11 @@
 #ifndef TauAnalysis_MCEmbeddingTools_TrackMergeremb_H
 #define TauAnalysis_MCEmbeddingTools_TrackMergeremb_H
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 
 #include "DataFormats/MuonReco/interface/MuonQuality.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -32,72 +30,57 @@
 #include <iostream>
 #include <map>
 
-
-
 template <typename T1>
-class TrackMergeremb : public edm::stream::EDProducer<>
-{
- public:
+class TrackMergeremb : public edm::stream::EDProducer<> {
+public:
   explicit TrackMergeremb(const edm::ParameterSet&);
   ~TrackMergeremb() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   typedef T1 TrackCollectionemb;
-  
-  
+
   void willproduce(std::string instance, std::string alias);
   void willconsume(const edm::ParameterSet& iConfig);
-  void merg_and_put(edm::Event&, std::string ,  std::vector<edm::EDGetTokenT<TrackCollectionemb> > & );
-  
-  std::map<std::string,  std::vector<edm::EDGetTokenT<TrackCollectionemb > > > inputs_;
-  std::map<std::string,  std::vector<edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > > > inputs_qual_;
-  
+  void merg_and_put(edm::Event&, std::string, std::vector<edm::EDGetTokenT<TrackCollectionemb> >&);
+
+  std::map<std::string, std::vector<edm::EDGetTokenT<TrackCollectionemb> > > inputs_;
+  std::map<std::string, std::vector<edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > > > inputs_qual_;
+
   //typedef edm::ValueMap<reco::TrackRef> TrackToTrackMapnew;
   typedef edm::ValueMap<reco::TrackRefVector> TrackToTrackMapnew;
-  
-  
-  edm::EDGetTokenT<TrackToTrackMapnew > inputs_fixtrackrefs_;
-  edm::EDGetTokenT<reco::TrackCollection > inputs_fixtrackcol_;
-  
-  edm::EDGetTokenT<reco::MuonToMuonMap > inputs_fixmurefs_;
-  edm::EDGetTokenT<reco::MuonCollection > inputs_fixmucol_;
-  
 
+  edm::EDGetTokenT<TrackToTrackMapnew> inputs_fixtrackrefs_;
+  edm::EDGetTokenT<reco::TrackCollection> inputs_fixtrackcol_;
+
+  edm::EDGetTokenT<reco::MuonToMuonMap> inputs_fixmurefs_;
+  edm::EDGetTokenT<reco::MuonCollection> inputs_fixmucol_;
 };
 
 template <typename T1>
-TrackMergeremb<T1>::TrackMergeremb(const edm::ParameterSet& iConfig)
-{
-  std::string alias( iConfig.getParameter<std::string>( "@module_label" ) );
-  std::vector<edm::InputTag> inCollections =  iConfig.getParameter<std::vector<edm::InputTag> >("mergCollections");
-  for (auto inCollection : inCollections){
-     inputs_[inCollection.instance()].push_back(consumes<TrackCollectionemb >(inCollection) );    
+TrackMergeremb<T1>::TrackMergeremb(const edm::ParameterSet& iConfig) {
+  std::string alias(iConfig.getParameter<std::string>("@module_label"));
+  std::vector<edm::InputTag> inCollections = iConfig.getParameter<std::vector<edm::InputTag> >("mergCollections");
+  for (auto inCollection : inCollections) {
+    inputs_[inCollection.instance()].push_back(consumes<TrackCollectionemb>(inCollection));
   }
   willconsume(iConfig);
-  for (auto toproduce : inputs_){
-    willproduce(toproduce.first,alias);     
+  for (auto toproduce : inputs_) {
+    willproduce(toproduce.first, alias);
   }
 }
 
 template <typename T1>
-TrackMergeremb<T1>::~TrackMergeremb()
-{
-// nothing to be done yet...  
+TrackMergeremb<T1>::~TrackMergeremb() {
+  // nothing to be done yet...
 }
 
-
 template <typename T1>
-void TrackMergeremb<T1>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   
-  for (auto input_ : inputs_){
-      
-    merg_and_put(iEvent,input_.first, input_.second);
+void TrackMergeremb<T1>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  for (auto input_ : inputs_) {
+    merg_and_put(iEvent, input_.first, input_.second);
 
-  }// end instance
-  
-  
+  }  // end instance
 }
 #endif

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.cc
@@ -8,57 +8,43 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 
-
-
-
 typedef TrackerCleaner<SiPixelCluster> PixelColCleaner;
 typedef TrackerCleaner<SiStripCluster> StripColCleaner;
-
 
 //-------------------------------------------------------------------------------
 // define 'buildRecHit' functions used for different types of recHits
 //-------------------------------------------------------------------------------
-  
 
 template <typename T>
-bool TrackerCleaner<T>::match_rechit_type(const TrackingRecHit &murechit){
-   
-     assert(0); // CV: make sure general function never gets called;
-             //     always use template specializations
-     return false;
-   
- }
- 
- 
+bool TrackerCleaner<T>::match_rechit_type(const TrackingRecHit &murechit) {
+  assert(0);  // CV: make sure general function never gets called;
+              //     always use template specializations
+  return false;
+}
+
 template <>
-bool TrackerCleaner<SiStripCluster>::match_rechit_type(const TrackingRecHit &murechit){
-  
-     const std::type_info &hit_type = typeid(murechit);
-     if (hit_type == typeid(SiStripRecHit2D)) return true;
-     else if (hit_type == typeid(SiStripRecHit1D)) return true;
-     else if (hit_type == typeid(SiStripMatchedRecHit2D)) return true;
-     else if (hit_type == typeid(ProjectedSiStripRecHit2D))  return true;
+bool TrackerCleaner<SiStripCluster>::match_rechit_type(const TrackingRecHit &murechit) {
+  const std::type_info &hit_type = typeid(murechit);
+  if (hit_type == typeid(SiStripRecHit2D))
+    return true;
+  else if (hit_type == typeid(SiStripRecHit1D))
+    return true;
+  else if (hit_type == typeid(SiStripMatchedRecHit2D))
+    return true;
+  else if (hit_type == typeid(ProjectedSiStripRecHit2D))
+    return true;
 
-     
-     
-     return false;
-   
- }
- 
- template <>
-bool TrackerCleaner<SiPixelCluster>::match_rechit_type(const TrackingRecHit &murechit){
-   
+  return false;
+}
 
-      const std::type_info &hit_type = typeid(murechit);
-     if (hit_type == typeid(SiPixelRecHit)) return true;
+template <>
+bool TrackerCleaner<SiPixelCluster>::match_rechit_type(const TrackingRecHit &murechit) {
+  const std::type_info &hit_type = typeid(murechit);
+  if (hit_type == typeid(SiPixelRecHit))
+    return true;
 
-     return false;
-   
- }
- 
+  return false;
+}
 
 DEFINE_FWK_MODULE(PixelColCleaner);
 DEFINE_FWK_MODULE(StripColCleaner);
-
-
-

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.h
@@ -30,105 +30,95 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 
-
 #include <string>
 #include <iostream>
 #include <map>
 
-
 template <typename T>
-class TrackerCleaner : public edm::stream::EDProducer<>
-{
- public:
+class TrackerCleaner : public edm::stream::EDProducer<> {
+public:
   explicit TrackerCleaner(const edm::ParameterSet&);
   ~TrackerCleaner() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   const edm::EDGetTokenT<edm::View<pat::Muon> > mu_input_;
   typedef edmNew::DetSetVector<T> TrackClusterCollection;
-   
-  std::map<std::string,  edm::EDGetTokenT<TrackClusterCollection > > inputs_;
-  
-  bool match_rechit_type(const TrackingRecHit &murechit);
 
+  std::map<std::string, edm::EDGetTokenT<TrackClusterCollection> > inputs_;
 
+  bool match_rechit_type(const TrackingRecHit& murechit);
 };
 
 template <typename T>
-TrackerCleaner<T>::TrackerCleaner(const edm::ParameterSet& iConfig) :
-    mu_input_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonCollection")))
-  
+TrackerCleaner<T>::TrackerCleaner(const edm::ParameterSet& iConfig)
+    : mu_input_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonCollection")))
+
 {
-  std::vector<edm::InputTag> inCollections =  iConfig.getParameter<std::vector<edm::InputTag> >("oldCollection");
-  for (auto inCollection : inCollections){
-     inputs_[inCollection.instance()] = consumes<TrackClusterCollection >(inCollection);
-     produces<TrackClusterCollection>(inCollection.instance());
+  std::vector<edm::InputTag> inCollections = iConfig.getParameter<std::vector<edm::InputTag> >("oldCollection");
+  for (auto inCollection : inCollections) {
+    inputs_[inCollection.instance()] = consumes<TrackClusterCollection>(inCollection);
+    produces<TrackClusterCollection>(inCollection.instance());
   }
-    
-  
 }
 
-
 template <typename T>
-TrackerCleaner<T>::~TrackerCleaner()
-{
-// nothing to be done yet...  
+TrackerCleaner<T>::~TrackerCleaner() {
+  // nothing to be done yet...
 }
 
-
 template <typename T>
-void TrackerCleaner<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  
-   using namespace edm;
-   
-   edm::Handle< edm::View<pat::Muon> > muonHandle;
-   iEvent.getByToken(mu_input_, muonHandle);
-   edm::View<pat::Muon> muons = *muonHandle;
-   
-  for (auto input_ : inputs_){
-   
-   edm::Handle<TrackClusterCollection > inputClusters;
-   iEvent.getByToken(input_.second, inputClusters);
+void TrackerCleaner<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   std::vector<bool> vetodClusters;
+  edm::Handle<edm::View<pat::Muon> > muonHandle;
+  iEvent.getByToken(mu_input_, muonHandle);
+  edm::View<pat::Muon> muons = *muonHandle;
 
-   vetodClusters.resize(inputClusters->dataSize(), false);
+  for (auto input_ : inputs_) {
+    edm::Handle<TrackClusterCollection> inputClusters;
+    iEvent.getByToken(input_.second, inputClusters);
 
-   for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {   
-    if(!iMuon->isGlobalMuon() ) continue;
-    const reco::Track* mutrack = iMuon->globalTrack().get();
-  //  reco::Track *mutrack = new reco::Track(*(iMuon->innerTrack() ));
-    for (trackingRecHit_iterator hitIt = mutrack->recHitsBegin(); hitIt != mutrack->recHitsEnd(); ++hitIt) {
-        const TrackingRecHit &murechit = **hitIt;     
-        if(!(murechit).isValid()) continue;
-	
-	if (match_rechit_type(murechit)){
-	  auto & thit = reinterpret_cast<BaseTrackerRecHit const&>(murechit);
-          auto const & cluster = thit.firstClusterRef();
-	  vetodClusters[cluster.key()]=true;
-	}
-	
-	    
-     }	
-  }
-  std::unique_ptr<TrackClusterCollection > output(new TrackClusterCollection());
+    std::vector<bool> vetodClusters;
+
+    vetodClusters.resize(inputClusters->dataSize(), false);
+
+    for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {
+      if (!iMuon->isGlobalMuon())
+        continue;
+      const reco::Track* mutrack = iMuon->globalTrack().get();
+      //  reco::Track *mutrack = new reco::Track(*(iMuon->innerTrack() ));
+      for (trackingRecHit_iterator hitIt = mutrack->recHitsBegin(); hitIt != mutrack->recHitsEnd(); ++hitIt) {
+        const TrackingRecHit& murechit = **hitIt;
+        if (!(murechit).isValid())
+          continue;
+
+        if (match_rechit_type(murechit)) {
+          auto& thit = reinterpret_cast<BaseTrackerRecHit const&>(murechit);
+          auto const& cluster = thit.firstClusterRef();
+          vetodClusters[cluster.key()] = true;
+        }
+      }
+    }
+    std::unique_ptr<TrackClusterCollection> output(new TrackClusterCollection());
 
     int idx = 0;
-    for ( typename TrackClusterCollection::const_iterator clustSet = inputClusters->begin(); clustSet != inputClusters->end(); ++clustSet ) { 
-      DetId detIdObject( clustSet->detId() );
+    for (typename TrackClusterCollection::const_iterator clustSet = inputClusters->begin();
+         clustSet != inputClusters->end();
+         ++clustSet) {
+      DetId detIdObject(clustSet->detId());
       typename TrackClusterCollection::FastFiller spc(*output, detIdObject);
-      for (typename edmNew::DetSet<T>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end(); ++clustIt ) { 
-        idx++;  
-        if (vetodClusters[idx-1]) continue;
-	//if (!vetodClusters[idx-1]) continue; for inverted selction
+      for (typename edmNew::DetSet<T>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end();
+           ++clustIt) {
+        idx++;
+        if (vetodClusters[idx - 1])
+          continue;
+        //if (!vetodClusters[idx-1]) continue; for inverted selction
         spc.push_back(*clustIt);
       }
     }
-    iEvent.put(std::move(output),input_.first);
+    iEvent.put(std::move(output), input_.first);
   }
-  
 }
 #endif


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/359//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


