### PR TITLE
Running code-format for db-reconstruction

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
@@ -11,15 +11,13 @@
 //  V2.20 - Add directory path selection to the ascii pushfile method
 //  V2.21 - Move templateStore to the heap, fix variable name in pushfile()
 
-
 // Build the template storage structure from several pieces
 
 #ifndef SiPixelGenError_h
 #define SiPixelGenError_h 1
 
-
-#include<vector>
-#include<cassert>
+#include <vector>
+#include <cassert>
 #include "boost/multi_array.hpp"
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
@@ -27,76 +25,73 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #endif
 
-struct SiPixelGenErrorEntry { //!< Basic template entry corresponding to a single set of track angles
-   int runnum;              //!< number of pixelav run used to generate this entry
-   float cotalpha;          //!< cot(alpha) is proportional to cluster length in x and is basis of interpolation
-   float cotbeta;           //!< cot(beta) is proportional to cluster length in y and is basis of interpolation
-   float qavg;              //!< average cluster charge for this set of track angles (now includes threshold effects)
-   float pixmax;            //!< maximum charge for individual pixels in cluster
-   float dyone;             //!< mean offset/correction for one pixel y-clusters
-   float syone;             //!< rms for one pixel y-clusters
-   float dxone;             //!< mean offset/correction for one pixel x-clusters
-   float sxone;             //!< rms for one pixel x-clusters
-   float dytwo;             //!< mean offset/correction for one double-pixel y-clusters
-   float sytwo;             //!< rms for one double-pixel y-clusters
-   float dxtwo;             //!< mean offset/correction for one double-pixel x-clusters
-   float sxtwo;             //!< rms for one double-pixel x-clusters
-   float qmin;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
-   float qmin2;
-   float yavggen[4];        //!< generic algorithm: average y-bias of reconstruction binned in 4 charge bins
-   float yrmsgen[4];        //!< generic algorithm: average y-rms of reconstruction binned in 4 charge bins
-   float xavggen[4];        //!< generic algorithm: average x-bias of reconstruction binned in 4 charge bins
-   float xrmsgen[4];        //!< generic algorithm: average x-rms of reconstruction binned in 4 charge bins
-} ;
+struct SiPixelGenErrorEntry {  //!< Basic template entry corresponding to a single set of track angles
+  int runnum;                  //!< number of pixelav run used to generate this entry
+  float cotalpha;              //!< cot(alpha) is proportional to cluster length in x and is basis of interpolation
+  float cotbeta;               //!< cot(beta) is proportional to cluster length in y and is basis of interpolation
+  float qavg;                  //!< average cluster charge for this set of track angles (now includes threshold effects)
+  float pixmax;                //!< maximum charge for individual pixels in cluster
+  float dyone;                 //!< mean offset/correction for one pixel y-clusters
+  float syone;                 //!< rms for one pixel y-clusters
+  float dxone;                 //!< mean offset/correction for one pixel x-clusters
+  float sxone;                 //!< rms for one pixel x-clusters
+  float dytwo;                 //!< mean offset/correction for one double-pixel y-clusters
+  float sytwo;                 //!< rms for one double-pixel y-clusters
+  float dxtwo;                 //!< mean offset/correction for one double-pixel x-clusters
+  float sxtwo;                 //!< rms for one double-pixel x-clusters
+  float qmin;                  //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
+  float qmin2;
+  float yavggen[4];  //!< generic algorithm: average y-bias of reconstruction binned in 4 charge bins
+  float yrmsgen[4];  //!< generic algorithm: average y-rms of reconstruction binned in 4 charge bins
+  float xavggen[4];  //!< generic algorithm: average x-bias of reconstruction binned in 4 charge bins
+  float xrmsgen[4];  //!< generic algorithm: average x-rms of reconstruction binned in 4 charge bins
+};
 
+struct SiPixelGenErrorHeader {  //!< template header structure
+  int ID;                       //!< template ID number
+  int NTy;                      //!< number of Template y entries
+  int NTyx;                     //!< number of Template y-slices of x entries
+  int NTxx;                     //!< number of Template x-entries in each slice
+  int Dtype;                    //!< detector type (0=BPix, 1=FPix)
+  float qscale;                 //!< Charge scaling to match cmssw and pixelav
+  float lorywidth;              //!< estimate of y-lorentz width for optimal resolution
+  float lorxwidth;              //!< estimate of x-lorentz width for optimal resolution
+  float lorybias;               //!< estimate of y-lorentz bias
+  float lorxbias;               //!< estimate of x-lorentz bias
+  float Vbias;                  //!< detector bias potential in Volts
+  float temperature;            //!< detector temperature in deg K
+  float fluence;                //!< radiation fluence in n_eq/cm^2
+  float s50;                    //!< 1/2 of the multihit dcol threshold in electrons
+  float ss50;                   //!< 1/2 of the single hit dcol threshold in electrons
+  char title[80];               //!< template title
+  int templ_version;            //!< Version number of the template to ensure code compatibility
+  float Bfield;                 //!< Bfield in Tesla
+  float fbin[3];                //!< The QBin definitions in Q_clus/Q_avg
+  float xsize;                  //!< pixel size (for future use in upgraded geometry)
+  float ysize;                  //!< pixel size (for future use in upgraded geometry)
+  float zsize;                  //!< pixel size (for future use in upgraded geometry)
+};
 
-
-
-
-struct SiPixelGenErrorHeader {           //!< template header structure
-   int ID;                 //!< template ID number
-   int NTy;                //!< number of Template y entries
-   int NTyx;               //!< number of Template y-slices of x entries
-   int NTxx;               //!< number of Template x-entries in each slice
-   int Dtype;              //!< detector type (0=BPix, 1=FPix)
-   float qscale;           //!< Charge scaling to match cmssw and pixelav
-   float lorywidth;        //!< estimate of y-lorentz width for optimal resolution
-   float lorxwidth;        //!< estimate of x-lorentz width for optimal resolution
-   float lorybias;         //!< estimate of y-lorentz bias
-   float lorxbias;         //!< estimate of x-lorentz bias
-   float Vbias;            //!< detector bias potential in Volts
-   float temperature;      //!< detector temperature in deg K
-   float fluence;          //!< radiation fluence in n_eq/cm^2
-   float s50;              //!< 1/2 of the multihit dcol threshold in electrons
-   float ss50;             //!< 1/2 of the single hit dcol threshold in electrons
-   char title[80];         //!< template title
-   int templ_version;      //!< Version number of the template to ensure code compatibility
-   float Bfield;           //!< Bfield in Tesla
-   float fbin[3];          //!< The QBin definitions in Q_clus/Q_avg
-   float xsize;            //!< pixel size (for future use in upgraded geometry)
-   float ysize;            //!< pixel size (for future use in upgraded geometry)
-   float zsize;            //!< pixel size (for future use in upgraded geometry)
-} ;
-
-
-
-struct SiPixelGenErrorStore { //!< template storage structure
-   SiPixelGenErrorHeader head;
+struct SiPixelGenErrorStore {  //!< template storage structure
+  SiPixelGenErrorHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
-   float cotbetaY[60];
-   float cotbetaX[5];
-   float cotalphaX[29];
-   SiPixelGenErrorEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
-   SiPixelGenErrorEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
+  float cotbetaY[60];
+  float cotbetaX[5];
+  float cotalphaX[29];
+  SiPixelGenErrorEntry
+      enty[60];  //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
+  SiPixelGenErrorEntry entx
+      [5]
+      [29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
 #else
-   float* cotbetaY;
-   float* cotbetaX;
-   float* cotalphaX;   
-   boost::multi_array<SiPixelGenErrorEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
-   boost::multi_array<SiPixelGenErrorEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
+  float* cotbetaY;
+  float* cotbetaX;
+  float* cotalphaX;
+  boost::multi_array<SiPixelGenErrorEntry, 1> enty;  //!< use 1d entry to store [60] barrel entries or [28] fpix entries
+  boost::multi_array<SiPixelGenErrorEntry, 2>
+      entx;  //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
 #endif
-} ;
-
+};
 
 // ******************************************************************************************
 //! \class SiPixelGenError
@@ -115,72 +110,109 @@ struct SiPixelGenErrorStore { //!< template storage structure
 // ******************************************************************************************
 class SiPixelGenError {
 public:
-   SiPixelGenError(const std::vector< SiPixelGenErrorStore > & thePixelTemp) : thePixelTemp_(thePixelTemp) { id_current_ = -1; index_id_ = -1;} //!< Constructor for cases in which template store already exists
-   
-// Load the private store with info from the file with the index (int) filenum from directory dir:
-//   ${dir}generror_summary_zp${filenum}.out
-   static bool pushfile(int filenum, std::vector< SiPixelGenErrorStore > & pixelTemp , std::string dir = "");
-    
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   static bool pushfile(const SiPixelGenErrorDBObject& dbobject, std::vector< SiPixelGenErrorStore > & pixelTemp);     // load the private store with info from db
-#endif
-   
-   // initialize the binary search information;
-   static void postInit(std::vector< SiPixelGenErrorStore > & thePixelTemp_);
-   
-   
-   // Interpolate input beta angle to estimate the average charge. return qbin flag for input cluster charge, and estimate y/x errors and biases for the Generic Algorithm.
-   int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, bool irradiationCorrections,
-            int& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
-            float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
-            
-// Overload to provide backward compatibility
+  SiPixelGenError(const std::vector<SiPixelGenErrorStore>& thePixelTemp) : thePixelTemp_(thePixelTemp) {
+    id_current_ = -1;
+    index_id_ = -1;
+  }  //!< Constructor for cases in which template store already exists
 
-   int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
-            float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
-   // Overloaded method to provide only the LA parameters
-   int qbin(int id);
-   
-   float lorywidth() {return lorywidth_;}                            //!< signed lorentz y-width (microns)
-   float lorxwidth() {return lorxwidth_;}                            //!< signed lorentz x-width (microns)
-   float lorybias() {return lorybias_;}                              //!< signed lorentz y-bias (microns)
-   float lorxbias() {return lorxbias_;}                              //!< signed lorentz x-bias (microns)
-   
-   float fbin(int i) {
+  // Load the private store with info from the file with the index (int) filenum from directory dir:
+  //   ${dir}generror_summary_zp${filenum}.out
+  static bool pushfile(int filenum, std::vector<SiPixelGenErrorStore>& pixelTemp, std::string dir = "");
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 2) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xminc2m called with illegal index = " << i << std::endl;}
+  static bool pushfile(const SiPixelGenErrorDBObject& dbobject,
+                       std::vector<SiPixelGenErrorStore>& pixelTemp);  // load the private store with info from db
+#endif
+
+  // initialize the binary search information;
+  static void postInit(std::vector<SiPixelGenErrorStore>& thePixelTemp_);
+
+  // Interpolate input beta angle to estimate the average charge. return qbin flag for input cluster charge, and estimate y/x errors and biases for the Generic Algorithm.
+  int qbin(int id,
+           float cotalpha,
+           float cotbeta,
+           float locBz,
+           float locBx,
+           float qclus,
+           bool irradiationCorrections,
+           int& pixmx,
+           float& sigmay,
+           float& deltay,
+           float& sigmax,
+           float& deltax,
+           float& sy1,
+           float& dy1,
+           float& sy2,
+           float& dy2,
+           float& sx1,
+           float& dx1,
+           float& sx2,
+           float& dx2);
+
+  // Overload to provide backward compatibility
+
+  int qbin(int id,
+           float cotalpha,
+           float cotbeta,
+           float locBz,
+           float locBx,
+           float qclus,
+           float& pixmx,
+           float& sigmay,
+           float& deltay,
+           float& sigmax,
+           float& deltax,
+           float& sy1,
+           float& dy1,
+           float& sy2,
+           float& dy2,
+           float& sx1,
+           float& dx1,
+           float& sx2,
+           float& dx2);
+  // Overloaded method to provide only the LA parameters
+  int qbin(int id);
+
+  float lorywidth() { return lorywidth_; }  //!< signed lorentz y-width (microns)
+  float lorxwidth() { return lorxwidth_; }  //!< signed lorentz x-width (microns)
+  float lorybias() { return lorybias_; }    //!< signed lorentz y-bias (microns)
+  float lorxbias() { return lorxbias_; }    //!< signed lorentz x-bias (microns)
+
+  float fbin(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 2) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::chi2xminc2m called with illegal index = " << i << std::endl;
+    }
 #else
-      assert(i>=0 && i<3);
+    assert(i >= 0 && i < 3);
 #endif
-      return fbin_[i];} //!< Return lower bound of Qbin definition
-   float xsize() {return xsize_;}                                    //!< pixel x-size (microns)
-   float ysize() {return ysize_;}                                    //!< pixel y-size (microns)
-   float zsize() {return zsize_;}                                    //!< pixel z-size or thickness (microns)
-   
-private:
-   
-   // Keep current template interpolaion parameters
-   
-   int id_current_;           //!< current id
-   int index_id_;             //!< current index
-   
-   
-   // Keep results of last interpolation to return through member functions
-   
-   float lorxwidth_;         //!< Lorentz x-width
-   float lorywidth_;         //!< Lorentz y-width (sign corrected for fpix frame)
-   float lorxbias_;         //!< Lorentz x-width
-   float lorybias_;         //!< Lorentz y-width (sign corrected for fpix frame)
-   float fbin_[3];          //!< The QBin definitions in Q_clus/Q_avg
-   float xsize_;             //!< Pixel x-size
-   float ysize_;             //!< Pixel y-size
-   float zsize_;             //!< Pixel z-size (thickness)
-   
-   
-   // The actual template store is a std::vector container
-   
-   const std::vector< SiPixelGenErrorStore > & thePixelTemp_;
-} ;
+    return fbin_[i];
+  }                                 //!< Return lower bound of Qbin definition
+  float xsize() { return xsize_; }  //!< pixel x-size (microns)
+  float ysize() { return ysize_; }  //!< pixel y-size (microns)
+  float zsize() { return zsize_; }  //!< pixel z-size or thickness (microns)
 
+private:
+  // Keep current template interpolaion parameters
+
+  int id_current_;  //!< current id
+  int index_id_;    //!< current index
+
+  // Keep results of last interpolation to return through member functions
+
+  float lorxwidth_;  //!< Lorentz x-width
+  float lorywidth_;  //!< Lorentz y-width (sign corrected for fpix frame)
+  float lorxbias_;   //!< Lorentz x-width
+  float lorybias_;   //!< Lorentz y-width (sign corrected for fpix frame)
+  float fbin_[3];    //!< The QBin definitions in Q_clus/Q_avg
+  float xsize_;      //!< Pixel x-size
+  float ysize_;      //!< Pixel y-size
+  float zsize_;      //!< Pixel z-size (thickness)
+
+  // The actual template store is a std::vector container
+
+  const std::vector<SiPixelGenErrorStore>& thePixelTemp_;
+};
 
 #endif

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -80,9 +80,6 @@
 //  V10.21 - Address runtime issues in pushfile() for gcc 7.X due to using tempfile as char string + misc. cleanup [Petar]
 //  V10.22 - Move templateStore to the heap, fix variable name in pushfile() [Petar]
 
-
-
-
 // Created by Morris Swartz on 10/27/06.
 //
 //
@@ -94,8 +91,8 @@
 
 #include "SiPixelTemplateDefs.h"
 
-#include<vector>
-#include<cassert>
+#include <vector>
+#include <cassert>
 #include "boost/multi_array.hpp"
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
@@ -103,137 +100,138 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #endif
 
-struct SiPixelTemplateEntry { //!< Basic template entry corresponding to a single set of track angles
-   int runnum;              //!< number of pixelav run used to generate this entry
-   float alpha;             //!< alpha track angle (defined in CMS CMS IN 2004/014)
-   float cotalpha;          //!< cot(alpha) is proportional to cluster length in x and is basis of interpolation
-   float beta;              //!< beta track angle (defined in CMS CMS IN 2004/014)
-   float cotbeta;           //!< cot(beta) is proportional to cluster length in y and is basis of interpolation
-   float costrk[3];            //!< direction cosines of tracks used to generate this entry
-   float qavg;              //!< average cluster charge for this set of track angles (now includes threshold effects)
-   float pixmax;            //!< maximum charge for individual pixels in cluster
-   float symax;             //!< average pixel signal for y-projection of cluster
-   float dyone;             //!< mean offset/correction for one pixel y-clusters
-   float syone;             //!< rms for one pixel y-clusters
-   float sxmax;             //!< average pixel signal for x-projection of cluster
-   float dxone;             //!< mean offset/correction for one pixel x-clusters
-   float sxone;             //!< rms for one pixel x-clusters
-   float dytwo;             //!< mean offset/correction for one double-pixel y-clusters
-   float sytwo;             //!< rms for one double-pixel y-clusters
-   float dxtwo;             //!< mean offset/correction for one double-pixel x-clusters
-   float sxtwo;             //!< rms for one double-pixel x-clusters
-   float qmin;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
-   float qmin2;             //!< tighter minimum cluster charge for valid hit (keeps 99.8% of simulated hits)
-   float yavggen[4];        //!< generic algorithm: average y-bias of reconstruction binned in 4 charge bins
-   float yrmsgen[4];        //!< generic algorithm: average y-rms of reconstruction binned in 4 charge bins
-   float xavggen[4];        //!< generic algorithm: average x-bias of reconstruction binned in 4 charge bins
-   float xrmsgen[4];        //!< generic algorithm: average x-rms of reconstruction binned in 4 charge bins
-   
-   float clsleny;           //!< cluster y-length in pixels at signal height symax/2
-   float clslenx;           //!< cluster x-length in pixels at signal height sxmax/2
-   float mpvvav;            //!< most probable charge in Vavilov distribution (not actually for larger kappa)
-   float sigmavav;          //!< "sigma" scale fctor for Vavilov distribution
-   float kappavav;          //!< kappa parameter for Vavilov distribution
-   float mpvvav2;           //!< most probable charge in Vavilov distribution for 2 merged clusters (not actually for larger kappa)
-   float sigmavav2;         //!< "sigma" scale fctor for Vavilov distribution for 2 merged clusters
-   float kappavav2;         //!< kappa parameter for Vavilov distribution for 2 merged clusters
-   float ypar[2][5];        //!< projected y-pixel uncertainty parameterization
-   float ytemp[9][TYSIZE];  //!< templates for y-reconstruction (binned over 1 central pixel)
-   float xpar[2][5];        //!< projected x-pixel uncertainty parameterization
-   float xtemp[9][TXSIZE];  //!< templates for x-reconstruction (binned over 1 central pixel)
-   float yavg[4];           //!< average y-bias of reconstruction binned in 4 charge bins
-   float yrms[4];           //!< average y-rms of reconstruction binned in 4 charge bins
-   float ygx0[4];           //!< average y0 from Gaussian fit binned in 4 charge bins
-   float ygsig[4];          //!< average sigma_y from Gaussian fit binned in 4 charge bins
-   float yflpar[4][6];      //!< Aqfl-parameterized y-correction in 4 charge bins
-   float xavg[4];           //!< average x-bias of reconstruction binned in 4 charge bins
-   float xrms[4];           //!< average x-rms of reconstruction binned in 4 charge bins
-   float xgx0[4];           //!< average x0 from Gaussian fit binned in 4 charge bins
-   float xgsig[4];          //!< average sigma_x from Gaussian fit binned in 4 charge bins
-   float xflpar[4][6];      //!< Aqfl-parameterized x-correction in 4 charge bins
-   float chi2yavg[4];       //!< average y chi^2 in 4 charge bins
-   float chi2ymin[4];       //!< minimum of y chi^2 in 4 charge bins
-   float chi2xavg[4];       //!< average x chi^2 in 4 charge bins
-   float chi2xmin[4];       //!< minimum of x chi^2 in 4 charge bins
-   float chi2yavgone;       //!< average y chi^2 for 1 pixel clusters
-   float chi2yminone;       //!< minimum of y chi^2 for 1 pixel clusters
-   float chi2xavgone;       //!< average x chi^2 for 1 pixel clusters
-   float chi2xminone;       //!< minimum of x chi^2 for 1 pixel clusters
-   float yavgc2m[4];        //!< 1st pass chi2 min search: average y-bias of reconstruction binned in 4 charge bins
-   float yrmsc2m[4];        //!< 1st pass chi2 min search: average y-rms of reconstruction binned in 4 charge bins
-   float chi2yavgc2m[4];    //!< 1st pass chi2 min search: average y chi^2 in 4 charge bins (merged clusters)
-   float chi2yminc2m[4];    //!< 1st pass chi2 min search: minimum of y chi^2 in 4 charge bins (merged clusters)
-   float xavgc2m[4];        //!< 1st pass chi2 min search: average x-bias of reconstruction binned in 4 charge bins
-   float xrmsc2m[4];        //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins
-   float chi2xavgc2m[4];    //!< 1st pass chi2 min search: average x chi^2 in 4 charge bins (merged clusters)
-   float chi2xminc2m[4];    //!< 1st pass chi2 min search: minimum of x chi^2 in 4 charge bins (merged clusters)
-   float ygx0gen[4];        //!< generic algorithm: average y0 from Gaussian fit binned in 4 charge bins
-   float ygsiggen[4];       //!< generic algorithm: average sigma_y from Gaussian fit binned in 4 charge bins
-   float xgx0gen[4];        //!< generic algorithm: average x0 from Gaussian fit binned in 4 charge bins
-   float xgsiggen[4];       //!< generic algorithm: average sigma_x from Gaussian fit binned in 4 charge bins
-   float qbfrac[3];         //!< fraction of sample in qbin = 0-2 (>=3 is the complement)
-   float fracyone;          //!< fraction of sample with ysize = 1
-   float fracxone;          //!< fraction of sample with xsize = 1
-   float fracytwo;          //!< fraction of double pixel sample with ysize = 1
-   float fracxtwo;          //!< fraction of double pixel sample with xsize = 1
-   float qavg_avg;          //!< average cluster charge of clusters that are less than qavg (normalize 2-D simple templates)
-   float r_qMeas_qTrue;     //!< ratio of measured to true cluster charge
-   float spare[1];
-} ;
+struct SiPixelTemplateEntry {  //!< Basic template entry corresponding to a single set of track angles
+  int runnum;                  //!< number of pixelav run used to generate this entry
+  float alpha;                 //!< alpha track angle (defined in CMS CMS IN 2004/014)
+  float cotalpha;              //!< cot(alpha) is proportional to cluster length in x and is basis of interpolation
+  float beta;                  //!< beta track angle (defined in CMS CMS IN 2004/014)
+  float cotbeta;               //!< cot(beta) is proportional to cluster length in y and is basis of interpolation
+  float costrk[3];             //!< direction cosines of tracks used to generate this entry
+  float qavg;                  //!< average cluster charge for this set of track angles (now includes threshold effects)
+  float pixmax;                //!< maximum charge for individual pixels in cluster
+  float symax;                 //!< average pixel signal for y-projection of cluster
+  float dyone;                 //!< mean offset/correction for one pixel y-clusters
+  float syone;                 //!< rms for one pixel y-clusters
+  float sxmax;                 //!< average pixel signal for x-projection of cluster
+  float dxone;                 //!< mean offset/correction for one pixel x-clusters
+  float sxone;                 //!< rms for one pixel x-clusters
+  float dytwo;                 //!< mean offset/correction for one double-pixel y-clusters
+  float sytwo;                 //!< rms for one double-pixel y-clusters
+  float dxtwo;                 //!< mean offset/correction for one double-pixel x-clusters
+  float sxtwo;                 //!< rms for one double-pixel x-clusters
+  float qmin;                  //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
+  float qmin2;                 //!< tighter minimum cluster charge for valid hit (keeps 99.8% of simulated hits)
+  float yavggen[4];            //!< generic algorithm: average y-bias of reconstruction binned in 4 charge bins
+  float yrmsgen[4];            //!< generic algorithm: average y-rms of reconstruction binned in 4 charge bins
+  float xavggen[4];            //!< generic algorithm: average x-bias of reconstruction binned in 4 charge bins
+  float xrmsgen[4];            //!< generic algorithm: average x-rms of reconstruction binned in 4 charge bins
 
+  float clsleny;   //!< cluster y-length in pixels at signal height symax/2
+  float clslenx;   //!< cluster x-length in pixels at signal height sxmax/2
+  float mpvvav;    //!< most probable charge in Vavilov distribution (not actually for larger kappa)
+  float sigmavav;  //!< "sigma" scale fctor for Vavilov distribution
+  float kappavav;  //!< kappa parameter for Vavilov distribution
+  float mpvvav2;  //!< most probable charge in Vavilov distribution for 2 merged clusters (not actually for larger kappa)
+  float sigmavav2;         //!< "sigma" scale fctor for Vavilov distribution for 2 merged clusters
+  float kappavav2;         //!< kappa parameter for Vavilov distribution for 2 merged clusters
+  float ypar[2][5];        //!< projected y-pixel uncertainty parameterization
+  float ytemp[9][TYSIZE];  //!< templates for y-reconstruction (binned over 1 central pixel)
+  float xpar[2][5];        //!< projected x-pixel uncertainty parameterization
+  float xtemp[9][TXSIZE];  //!< templates for x-reconstruction (binned over 1 central pixel)
+  float yavg[4];           //!< average y-bias of reconstruction binned in 4 charge bins
+  float yrms[4];           //!< average y-rms of reconstruction binned in 4 charge bins
+  float ygx0[4];           //!< average y0 from Gaussian fit binned in 4 charge bins
+  float ygsig[4];          //!< average sigma_y from Gaussian fit binned in 4 charge bins
+  float yflpar[4][6];      //!< Aqfl-parameterized y-correction in 4 charge bins
+  float xavg[4];           //!< average x-bias of reconstruction binned in 4 charge bins
+  float xrms[4];           //!< average x-rms of reconstruction binned in 4 charge bins
+  float xgx0[4];           //!< average x0 from Gaussian fit binned in 4 charge bins
+  float xgsig[4];          //!< average sigma_x from Gaussian fit binned in 4 charge bins
+  float xflpar[4][6];      //!< Aqfl-parameterized x-correction in 4 charge bins
+  float chi2yavg[4];       //!< average y chi^2 in 4 charge bins
+  float chi2ymin[4];       //!< minimum of y chi^2 in 4 charge bins
+  float chi2xavg[4];       //!< average x chi^2 in 4 charge bins
+  float chi2xmin[4];       //!< minimum of x chi^2 in 4 charge bins
+  float chi2yavgone;       //!< average y chi^2 for 1 pixel clusters
+  float chi2yminone;       //!< minimum of y chi^2 for 1 pixel clusters
+  float chi2xavgone;       //!< average x chi^2 for 1 pixel clusters
+  float chi2xminone;       //!< minimum of x chi^2 for 1 pixel clusters
+  float yavgc2m[4];        //!< 1st pass chi2 min search: average y-bias of reconstruction binned in 4 charge bins
+  float yrmsc2m[4];        //!< 1st pass chi2 min search: average y-rms of reconstruction binned in 4 charge bins
+  float chi2yavgc2m[4];    //!< 1st pass chi2 min search: average y chi^2 in 4 charge bins (merged clusters)
+  float chi2yminc2m[4];    //!< 1st pass chi2 min search: minimum of y chi^2 in 4 charge bins (merged clusters)
+  float xavgc2m[4];        //!< 1st pass chi2 min search: average x-bias of reconstruction binned in 4 charge bins
+  float xrmsc2m[4];        //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins
+  float chi2xavgc2m[4];    //!< 1st pass chi2 min search: average x chi^2 in 4 charge bins (merged clusters)
+  float chi2xminc2m[4];    //!< 1st pass chi2 min search: minimum of x chi^2 in 4 charge bins (merged clusters)
+  float ygx0gen[4];        //!< generic algorithm: average y0 from Gaussian fit binned in 4 charge bins
+  float ygsiggen[4];       //!< generic algorithm: average sigma_y from Gaussian fit binned in 4 charge bins
+  float xgx0gen[4];        //!< generic algorithm: average x0 from Gaussian fit binned in 4 charge bins
+  float xgsiggen[4];       //!< generic algorithm: average sigma_x from Gaussian fit binned in 4 charge bins
+  float qbfrac[3];         //!< fraction of sample in qbin = 0-2 (>=3 is the complement)
+  float fracyone;          //!< fraction of sample with ysize = 1
+  float fracxone;          //!< fraction of sample with xsize = 1
+  float fracytwo;          //!< fraction of double pixel sample with ysize = 1
+  float fracxtwo;          //!< fraction of double pixel sample with xsize = 1
+  float qavg_avg;       //!< average cluster charge of clusters that are less than qavg (normalize 2-D simple templates)
+  float r_qMeas_qTrue;  //!< ratio of measured to true cluster charge
+  float spare[1];
+};
 
+struct SiPixelTemplateHeader {  //!< template header structure
+  int ID;                       //!< template ID number
+  int NTy;                      //!< number of Template y entries
+  int NTyx;                     //!< number of Template y-slices of x entries
+  int NTxx;                     //!< number of Template x-entries in each slice
+  int Dtype;                    //!< detector type (0=BPix, 1=FPix)
+  float qscale;                 //!< Charge scaling to match cmssw and pixelav
+  float lorywidth;              //!< estimate of y-lorentz width for optimal resolution
+  float lorxwidth;              //!< estimate of x-lorentz width for optimal resolution
+  float lorybias;               //!< estimate of y-lorentz bias
+  float lorxbias;               //!< estimate of x-lorentz bias
+  float Vbias;                  //!< detector bias potential in Volts
+  float temperature;            //!< detector temperature in deg K
+  float fluence;                //!< radiation fluence in n_eq/cm^2
+  float s50;                    //!< 1/2 of the multihit dcol threshold in electrons
+  float ss50;                   //!< 1/2 of the single hit dcol threshold in electrons
+  char title[80];               //!< template title
+  int templ_version;            //!< Version number of the template to ensure code compatibility
+  float Bfield;                 //!< Bfield in Tesla
+  float fbin[3];                //!< The QBin definitions in Q_clus/Q_avg
+  float xsize;                  //!< pixel size (for future use in upgraded geometry)
+  float ysize;                  //!< pixel size (for future use in upgraded geometry)
+  float zsize;                  //!< pixel size (for future use in upgraded geometry)
+};
 
-
-struct SiPixelTemplateHeader {           //!< template header structure
-   int ID;                 //!< template ID number
-   int NTy;                //!< number of Template y entries
-   int NTyx;               //!< number of Template y-slices of x entries
-   int NTxx;               //!< number of Template x-entries in each slice
-   int Dtype;              //!< detector type (0=BPix, 1=FPix)
-   float qscale;           //!< Charge scaling to match cmssw and pixelav
-   float lorywidth;        //!< estimate of y-lorentz width for optimal resolution
-   float lorxwidth;        //!< estimate of x-lorentz width for optimal resolution
-   float lorybias;         //!< estimate of y-lorentz bias
-   float lorxbias;         //!< estimate of x-lorentz bias
-   float Vbias;            //!< detector bias potential in Volts
-   float temperature;      //!< detector temperature in deg K
-   float fluence;          //!< radiation fluence in n_eq/cm^2
-   float s50;              //!< 1/2 of the multihit dcol threshold in electrons
-   float ss50;             //!< 1/2 of the single hit dcol threshold in electrons
-   char title[80];         //!< template title
-   int templ_version;      //!< Version number of the template to ensure code compatibility
-   float Bfield;           //!< Bfield in Tesla
-   float fbin[3];          //!< The QBin definitions in Q_clus/Q_avg
-   float xsize;            //!< pixel size (for future use in upgraded geometry)
-   float ysize;            //!< pixel size (for future use in upgraded geometry)
-   float zsize;            //!< pixel size (for future use in upgraded geometry)
-} ;
-
-
-
-struct SiPixelTemplateStore { //!< template storage structure
-   SiPixelTemplateHeader head;
+struct SiPixelTemplateStore {  //!< template storage structure
+  SiPixelTemplateHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
-   float cotbetaY[60];
-   float cotbetaX[5];
-   float cotalphaX[29];
-   SiPixelTemplateEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
-   SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
-   void destroy() {};
+  float cotbetaY[60];
+  float cotbetaX[5];
+  float cotalphaX[29];
+  SiPixelTemplateEntry
+      enty[60];  //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
+  SiPixelTemplateEntry entx
+      [5]
+      [29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
+  void destroy(){};
 #else
-   float* cotbetaY = nullptr;
-   float* cotbetaX = nullptr;
-   float* cotalphaX = nullptr;
-   boost::multi_array<SiPixelTemplateEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
-   boost::multi_array<SiPixelTemplateEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
-   void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
-      if (cotbetaY!=nullptr) delete[] cotbetaY;
-      if (cotbetaX!=nullptr) delete[] cotbetaX;
-      if (cotalphaX!=nullptr) delete[] cotalphaX;
-   }
+  float* cotbetaY = nullptr;
+  float* cotbetaX = nullptr;
+  float* cotalphaX = nullptr;
+  boost::multi_array<SiPixelTemplateEntry, 1> enty;  //!< use 1d entry to store [60] barrel entries or [28] fpix entries
+  boost::multi_array<SiPixelTemplateEntry, 2>
+      entx;         //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
+  void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
+    if (cotbetaY != nullptr)
+      delete[] cotbetaY;
+    if (cotbetaX != nullptr)
+      delete[] cotbetaX;
+    if (cotalphaX != nullptr)
+      delete[] cotalphaX;
+  }
 #endif
-} ;
-
+};
 
 // ******************************************************************************************
 //! \class SiPixelTemplate
@@ -256,402 +254,531 @@ struct SiPixelTemplateStore { //!< template storage structure
 // ******************************************************************************************
 class SiPixelTemplate {
 public:
-   SiPixelTemplate(const std::vector< SiPixelTemplateStore > & thePixelTemp) : thePixelTemp_(thePixelTemp) { id_current_ = -1; index_id_ = -1; cota_current_ = 0.; cotb_current_ = 0.; } //!< Constructor for cases in which template store already exists
-   
+  SiPixelTemplate(const std::vector<SiPixelTemplateStore>& thePixelTemp) : thePixelTemp_(thePixelTemp) {
+    id_current_ = -1;
+    index_id_ = -1;
+    cota_current_ = 0.;
+    cotb_current_ = 0.;
+  }  //!< Constructor for cases in which template store already exists
 
 // Load the private store with info from the file with the index (int) filenum from directory dir:
 //   ${dir}template_summary_zp${filenum}.out
 #ifdef SI_PIXEL_TEMPLATE_STANDALONE
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & pixelTemp , std::string dir = "");
-#else   
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & pixelTemp , std::string dir = "CalibTracker/SiPixelESProducers/data/");   // *&^%$#@!  Different default dir -- remove once FastSim is updated.
-   static bool pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & pixelTemp);     // load the private store with info from db
-#endif
-   
-   // initialize the rest;
-   static void postInit(std::vector< SiPixelTemplateStore > & thePixelTemp_);
-   
-   // Interpolate input alpha and beta angles to produce a working template for each individual hit.
-   bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
-   
-   // Interpolate input alpha and beta angles to produce a working template for each individual hit.
-   bool interpolate(int id, float cotalpha, float cotbeta, float locBz);
-   
-   // overload for compatibility.
-   bool interpolate(int id, float cotalpha, float cotbeta);
-   
-   // retreive interpolated templates.
-   void ytemp(int fybin, int lybin, float ytemplate[41][BYSIZE]);
-   
-   void xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE]);
-   
-   //Method to estimate the central pixel of the interpolated y-template
-   int cytemp();
-   
-   //Method to estimate the central pixel of the interpolated x-template
-   int cxtemp();
-   
-   // new methods to build templates from two interpolated clusters (for splitting)
-   void ytemp3d_int(int nypix, int& nybins);
-   
-   void ytemp3d(int j, int k, std::vector<float>& ytemplate);
-   
-   void xtemp3d_int(int nxpix, int& nxbins);
-   
-   void xtemp3d(int j, int k, std::vector<float>& xtemplate);
-   
-   // Convert vector of projected signals into uncertainties for fitting.
-   void ysigma2(int fypix, int lypix, float sythr, float ysum[BYSIZE], float ysig2[BYSIZE]);
-   
-   void ysigma2(float qpixel, int index, float& ysig2);
-   
-   void xsigma2(int fxpix, int lxpix, float sxthr, float xsum[BXSIZE], float xsig2[BXSIZE]);
-   
-   // Interpolate qfl correction in y.
-   float yflcorr(int binq, float qfly);
-   
-   // Interpolate qfl correction in x.
-   float xflcorr(int binq, float qflx);
-   
-   int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
-            float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
-   
-   int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
-            float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
-   
-   // Overload to use for cluster splitting
-   int qbin(int id, float cotalpha, float cotbeta, float qclus);
-   
-   // Overload to keep legacy interface
-   int qbin(int id, float cotbeta, float qclus);
-   
-   // Method to return template errors for fastsim
-   void temperrors(int id, float cotalpha, float cotbeta, int qBin, float& sigmay, float& sigmax, float& sy1, float& sy2, float& sx1, float& sx2);
-   
-   //Method to return qbin and size probabilities for fastsim
-   void qbin_dist(int id, float cotalpha, float cotbeta, float qbin_frac[4], float& ny1_frac, float& ny2_frac, float& nx1_frac, float& nx2_frac);
-   
-   //Method to calculate simple 2D templates
-   bool simpletemplate2D(float xhitp, float yhitp, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2]);
-   
-   //Method to interpolate Vavilov distribution parameters
-   void vavilov_pars(double& mpv, double& sigma, double& kappa);
-   
-   //Method to interpolate 2-cluster Vavilov distribution parameters
-   void vavilov2_pars(double& mpv, double& sigma, double& kappa);
-   
-   
-   float qavg() {return qavg_;}        //!< average cluster charge for this set of track angles
-   float pixmax() {return pixmax_;}         //!< maximum pixel charge
-   float qscale() {return qscale_;}         //!< charge scaling factor
-   float s50() {return s50_;}               //!< 1/2 of the pixel threshold signal in electrons
-   float ss50() {return ss50_;}               //!< 1/2 of the single pixel per double column threshold in electrons
-   float symax() {return symax_;}             //!< average pixel signal for y-projection of cluster
-   float dyone() {return dyone_;}             //!< mean offset/correction for one pixel y-clusters
-   float syone() {return syone_;}             //!< rms for one pixel y-clusters
-   float dytwo() {return dytwo_;}             //!< mean offset/correction for one double-pixel y-clusters
-   float sytwo() {return sytwo_;}            //!< rms for one double-pixel y-clusters
-   float sxmax() {return sxmax_;}            //!< average pixel signal for x-projection of cluster
-   float dxone() {return dxone_;}             //!< mean offset/correction for one pixel x-clusters
-   float sxone() {return sxone_;}             //!< rms for one pixel x-clusters
-   float dxtwo() {return dxtwo_;}             //!< mean offset/correction for one double-pixel x-clusters
-   float sxtwo() {return sxtwo_;}             //!< rms for one double-pixel x-clusters
-   float qmin() {return qmin_;}               //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
-   float qmin(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 1) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qmin called with illegal index = " << i << std::endl;}
+  static bool pushfile(int filenum, std::vector<SiPixelTemplateStore>& pixelTemp, std::string dir = "");
 #else
-      assert(i>=0 && i<2);
+  static bool pushfile(
+      int filenum,
+      std::vector<SiPixelTemplateStore>& pixelTemp,
+      std::string dir =
+          "CalibTracker/SiPixelESProducers/data/");  // *&^%$#@!  Different default dir -- remove once FastSim is updated.
+  static bool pushfile(const SiPixelTemplateDBObject& dbobject,
+                       std::vector<SiPixelTemplateStore>& pixelTemp);  // load the private store with info from db
 #endif
-      if(i==0){return qmin_;}else{return qmin2_;}} //!< minimum cluster charge for valid hit (keeps 99.9% or 99.8% of simulated hits)
-   float clsleny() {return clsleny_;}         //!< y-size of smaller interpolated template in pixels
-   float clslenx() {return clslenx_;}         //!< x-size of smaller interpolated template in pixels
-   float yratio() {return yratio_;}            //!< fractional distance in y between cotbeta templates
-   float yxratio() {return yxratio_;}           //!< fractional distance in y between cotalpha templates slices
-   float xxratio() {return xxratio_;}           //!< fractional distance in x between cotalpha templates
-   float yavg(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yavg called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return yavg_[i];}         //!< average y-bias of reconstruction binned in 4 charge bins
-   float yrms(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yrms called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return yrms_[i];}         //!< average y-rms of reconstruction binned in 4 charge bins
-   float ygx0(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ygx0 called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return ygx0_[i];}         //!< average y0 from Gaussian fit binned in 4 charge bins
-   float ygsig(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ygsig called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return ygsig_[i];}       //!< average sigma_y from Gaussian fit binned in 4 charge bins
-   float xavg(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xavg called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return xavg_[i];}         //!< average x-bias of reconstruction binned in 4 charge bins
-   float xrms(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xrms called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return xrms_[i];}         //!< average x-rms of reconstruction binned in 4 charge bins
-   float xgx0(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xgx0 called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return xgx0_[i];}         //!< average x0 from Gaussian fit binned in 4 charge bins
-   float xgsig(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xgsig called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return xgsig_[i];}       //!< average sigma_x from Gaussian fit binned in 4 charge bins
-   float chi2yavg(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2yavg called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2yavg_[i];} //!< average y chi^2 in 4 charge bins
-   float chi2ymin(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2ymin called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2ymin_[i];} //!< minimum y chi^2 in 4 charge bins
-   float chi2xavg(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xavg called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2xavg_[i];} //!< averaage x chi^2 in 4 charge bins
-   float chi2xmin(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xmin called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2xmin_[i];} //!< minimum y chi^2 in 4 charge bins
-   float yavgc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yavgc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return yavgc2m_[i];}   //!< 1st pass chi2 min search: average y-bias of reconstruction binned in 4 charge bins
-   float yrmsc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yrmsc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return yrmsc2m_[i];}   //!< 1st pass chi2 min search: average y-rms of reconstruction binned in 4 charge bins
-   float chi2yavgc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2yavgc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2yavgc2m_[i];}   //!< 1st pass chi2 min search: average y-chisq for merged clusters
-   float chi2yminc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2yminc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2yminc2m_[i];} //!< 1st pass chi2 min search: minimum y-chisq for merged clusters
-   float xavgc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xavgc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return xavgc2m_[i];}   //!< 1st pass chi2 min search: average x-bias of reconstruction binned in 4 charge bins
-   float xrmsc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xrmsc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return xrmsc2m_[i];}   //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins
-   float chi2xavgc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xavgc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2xavgc2m_[i];}   //!< 1st pass chi2 min search: average x-chisq for merged clusters
-   float chi2xminc2m(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 3) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xminc2m called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<4);
-#endif
-      return chi2xminc2m_[i];} //!< 1st pass chi2 min search: minimum x-chisq for merged clusters
-   float fbin(int i) {
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(i < 0 || i > 2) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate::fbin called with illegal index = " << i << std::endl;}
-#else
-      assert(i>=0 && i<3);
-#endif
-      return fbin_[i];} //!< Return lower bound of Qbin definition
-   
-   float chi2yavgone() {return chi2yavgone_;}                        //!< //!< average y chi^2 for 1 pixel clusters
-   float chi2yminone() {return chi2yminone_;}                        //!< //!< minimum of y chi^2 for 1 pixel clusters
-   float chi2xavgone() {return chi2xavgone_;}                        //!< //!< average x chi^2 for 1 pixel clusters
-   float chi2xminone() {return chi2xminone_;}                        //!< //!< minimum of x chi^2 for 1 pixel clusters
-   float lorywidth() {return lorywidth_;}                            //!< signed lorentz y-width (microns)
-   float lorxwidth() {return lorxwidth_;}                            //!< signed lorentz x-width (microns)
-   //float lorybias() {return lorywidth_;}                            //!< signed lorentz y-width (microns)
-   //float lorxbias() {return lorxwidth_;}                            //!< signed lorentz x-width (microns)
-   float lorybias() {return lorybias_;}                            //!< signed lorentz y-width (microns)
-   float lorxbias() {return lorxbias_;}                            //!< signed lorentz x-width (microns)
-   float mpvvav() {return mpvvav_;}                                  //!< most probable charge in Vavilov distribution (not actually for larger kappa)
-   float sigmavav() {return sigmavav_;}                              //!< "sigma" scale fctor for Vavilov distribution
-   float kappavav() {return kappavav_;}                              //!< kappa parameter for Vavilov distribution
-   float mpvvav2() {return mpvvav2_;}                                //!< most probable charge in 2-cluster Vavilov distribution (not actually for larger kappa)
-   float sigmavav2() {return sigmavav2_;}                            //!< "sigma" scale fctor for 2-cluster Vavilov distribution
-   float kappavav2() {return kappavav2_;}                            //!< kappa parameter for 2-cluster Vavilov distribution
-   float xsize() {return xsize_;}                                    //!< pixel x-size (microns)
-   float ysize() {return ysize_;}                                    //!< pixel y-size (microns)
-   float zsize() {return zsize_;}                                    //!< pixel z-size or thickness (microns)
-   float r_qMeas_qTrue() {return r_qMeas_qTrue_;}                    //!< ratio of measured to true cluster charge
-   float fracyone() {return fracyone_;}                              //!< The simulated fraction of single pixel y-clusters 
-   float fracxone() {return fracxone_;}                              //!< The simulated fraction of single pixel x-clusters 
-   float fracytwo() {return fracytwo_;}                              //!< The simulated fraction of single double-size pixel y-clusters 
-   float fracxtwo() {return fracxtwo_;}                              //!< The simulated fraction of single double-size pixel x-clusters 
-   //  float yspare(int i) {assert(i>=0 && i<5); return pyspare[i];}    //!< vector of 5 spares interpolated in beta only
-   //  float xspare(int i) {assert(i>=0 && i<10); return pxspare[i];}    //!< vector of 10 spares interpolated in alpha and beta
-   
-   
-private:
-   
-   // Keep current template interpolaion parameters
-   
-   int id_current_;           //!< current id
-   int index_id_;             //!< current index
-   float cota_current_;       //!< current cot alpha
-   float cotb_current_;       //!< current cot beta
-   float abs_cotb_;           //!< absolute value of cot beta
-   bool success_;             //!< true if cotalpha, cotbeta are inside of the acceptance (dynamically loaded)
-   
-   
-   // Keep results of last interpolation to return through member functions
-   
-   float qavg_;              //!< average cluster charge for this set of track angles
-   float pixmax_;            //!< maximum pixel charge
-   float qscale_;            //!< charge scaling factor
-   float s50_;               //!< 1/2 of the pixel single col threshold signal in electrons
-   float ss50_;              //!< 1/2 of the pixel double col threshold signal in electrons
-   float symax_;             //!< average pixel signal for y-projection of cluster
-   float syparmax_;          //!< maximum pixel signal for parameterization of y uncertainties
-   float dyone_;             //!< mean offset/correction for one pixel y-clusters
-   float syone_;             //!< rms for one pixel y-clusters
-   float dytwo_;             //!< mean offset/correction for one double-pixel y-clusters
-   float sytwo_;             //!< rms for one double-pixel y-clusters
-   float sxmax_;             //!< average pixel signal for x-projection of cluster
-   float sxparmax_;          //!< maximum pixel signal for parameterization of x uncertainties
-   float dxone_;             //!< mean offset/correction for one pixel x-clusters
-   float sxone_;             //!< rms for one pixel x-clusters
-   float dxtwo_;             //!< mean offset/correction for one double-pixel x-clusters
-   float sxtwo_;             //!< rms for one double-pixel x-clusters
-   float qmin_;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
-   float clsleny_;           //!< y-cluster length of smaller interpolated template in pixels
-   float clslenx_;           //!< x-cluster length of smaller interpolated template in pixels
-   float yratio_;            //!< fractional distance in y between cotbeta templates
-   float yparl_[2][5];       //!< projected y-pixel uncertainty parameterization for smaller cotbeta
-   float yparh_[2][5];       //!< projected y-pixel uncertainty parameterization for larger cotbeta
-   float xparly0_[2][5];     //!< projected x-pixel uncertainty parameterization for smaller cotbeta (central alpha)
-   float xparhy0_[2][5];     //!< projected x-pixel uncertainty parameterization for larger cotbeta (central alpha)
-   float ytemp_[9][BYSIZE];  //!< templates for y-reconstruction (binned over 5 central pixels)
-   float yxratio_;           //!< fractional distance in y between x-slices of cotalpha templates
-   float xxratio_;           //!< fractional distance in x between cotalpha templates
-   float xpar0_[2][5];       //!< projected x-pixel uncertainty parameterization for central cotalpha
-   float xparl_[2][5];       //!< projected x-pixel uncertainty parameterization for smaller cotalpha
-   float xparh_[2][5];       //!< projected x-pixel uncertainty parameterization for larger cotalpha
-   float xtemp_[9][BXSIZE];  //!< templates for x-reconstruction (binned over 5 central pixels)
-   float yavg_[4];           //!< average y-bias of reconstruction binned in 4 charge bins
-   float yrms_[4];           //!< average y-rms of reconstruction binned in 4 charge bins
-   float ygx0_[4];           //!< average y0 from Gaussian fit binned in 4 charge bins
-   float ygsig_[4];          //!< average sigma_y from Gaussian fit binned in 4 charge bins
-   float yflparl_[4][6];     //!< Aqfl-parameterized y-correction in 4 charge bins for smaller cotbeta
-   float yflparh_[4][6];     //!< Aqfl-parameterized y-correction in 4 charge bins for larger cotbeta
-   float xavg_[4];           //!< average x-bias of reconstruction binned in 4 charge bins
-   float xrms_[4];           //!< average x-rms of reconstruction binned in 4 charge bins
-   float xgx0_[4];           //!< average x0 from Gaussian fit binned in 4 charge bins
-   float xgsig_[4];           //!< sigma from Gaussian fit binned in 4 charge bins
-   float xflparll_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for smaller cotbeta, cotalpha
-   float xflparlh_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for smaller cotbeta, larger cotalpha
-   float xflparhl_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for larger cotbeta, smaller cotalpha
-   float xflparhh_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for larger cotbeta, cotalpha
-   float chi2yavg_[4];       //!< average y chi^2 in 4 charge bins
-   float chi2ymin_[4];       //!< minimum of y chi^2 in 4 charge bins
-   float chi2xavg_[4];       //!< average x chi^2 in 4 charge bins
-   float chi2xmin_[4];       //!< minimum of x chi^2 in 4 charge bins
-   float yavgc2m_[4];        //!< 1st pass chi2 min search: average y-bias of reconstruction binned in 4 charge bins
-   float yrmsc2m_[4];        //!< 1st pass chi2 min search: average y-rms of reconstruction binned in 4 charge bins
-   float chi2yavgc2m_[4];    //!< 1st pass chi2 min search: average y-chisq for merged clusters
-   float chi2yminc2m_[4];    //!< 1st pass chi2 min search: minimum y-chisq for merged clusters
-   float xavgc2m_[4];        //!< 1st pass chi2 min search: average x-bias of reconstruction binned in 4 charge bins
-   float xrmsc2m_[4];        //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins
-   float chi2xavgc2m_[4];    //!< 1st pass chi2 min search: average x-chisq for merged clusters
-   float chi2xminc2m_[4];    //!< 1st pass chi2 min search: minimum x-chisq for merged clusters
-   float chi2yavgone_;       //!< average y chi^2 for 1 pixel clusters
-   float chi2yminone_;       //!< minimum of y chi^2 for 1 pixel clusters
-   float chi2xavgone_;       //!< average x chi^2 for 1 pixel clusters
-   float chi2xminone_;       //!< minimum of x chi^2 for 1 pixel clusters
-   float qmin2_;             //!< tighter minimum cluster charge for valid hit (keeps 99.8% of simulated hits)
-   float mpvvav_;            //!< most probable charge in Vavilov distribution (not actually for larger kappa)
-   float sigmavav_;          //!< "sigma" scale fctor for Vavilov distribution
-   float kappavav_;          //!< kappa parameter for Vavilov distribution
-   float mpvvav2_;           //!< most probable charge in 2-cluster Vavilov distribution (not actually for larger kappa)
-   float sigmavav2_;         //!< "sigma" scale fctor for 2-cluster Vavilov distribution
-   float kappavav2_;         //!< kappa parameter for 2-cluster Vavilov distribution
-   float lorywidth_;         //!< Lorentz y-width (sign corrected for fpix frame)
-   float lorxwidth_;         //!< Lorentz x-width
-   float lorybias_;          //!< Lorentz y-bias
-   float lorxbias_;          //!< Lorentz x-bias
-   float xsize_;             //!< Pixel x-size
-   float ysize_;             //!< Pixel y-size
-   float zsize_;             //!< Pixel z-size (thickness)
-   float qavg_avg_;          //!< average of cluster charge less than qavg
-   float nybins_;            //!< number of bins in each dimension of the y-splitting template
-   float nxbins_;            //!< number of bins in each dimension of the x-splitting template
-   float r_qMeas_qTrue_;     //!< ratio of measured to true cluster charges
-   float fbin_[3];           //!< The QBin definitions in Q_clus/Q_avg
-   float fracyone_;          //!< The simulated fraction of single pixel y-clusters 
-   float fracxone_;          //!< The simulated fraction of single pixel x-clusters 
-   float fracytwo_;          //!< The simulated fraction of single double-size pixel y-clusters 
-   float fracxtwo_;          //!< The simulated fraction of single double-size pixel x-clusters 
-   boost::multi_array<float,2> temp2dy_; //!< 2d-primitive for spltting 3-d template
-   boost::multi_array<float,2> temp2dx_; //!< 2d-primitive for spltting 3-d template
-   
-   
-   // The actual template store is a std::vector container
-   
-   const std::vector< SiPixelTemplateStore > & thePixelTemp_;
-} ;
 
+  // initialize the rest;
+  static void postInit(std::vector<SiPixelTemplateStore>& thePixelTemp_);
+
+  // Interpolate input alpha and beta angles to produce a working template for each individual hit.
+  bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
+
+  // Interpolate input alpha and beta angles to produce a working template for each individual hit.
+  bool interpolate(int id, float cotalpha, float cotbeta, float locBz);
+
+  // overload for compatibility.
+  bool interpolate(int id, float cotalpha, float cotbeta);
+
+  // retreive interpolated templates.
+  void ytemp(int fybin, int lybin, float ytemplate[41][BYSIZE]);
+
+  void xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE]);
+
+  //Method to estimate the central pixel of the interpolated y-template
+  int cytemp();
+
+  //Method to estimate the central pixel of the interpolated x-template
+  int cxtemp();
+
+  // new methods to build templates from two interpolated clusters (for splitting)
+  void ytemp3d_int(int nypix, int& nybins);
+
+  void ytemp3d(int j, int k, std::vector<float>& ytemplate);
+
+  void xtemp3d_int(int nxpix, int& nxbins);
+
+  void xtemp3d(int j, int k, std::vector<float>& xtemplate);
+
+  // Convert vector of projected signals into uncertainties for fitting.
+  void ysigma2(int fypix, int lypix, float sythr, float ysum[BYSIZE], float ysig2[BYSIZE]);
+
+  void ysigma2(float qpixel, int index, float& ysig2);
+
+  void xsigma2(int fxpix, int lxpix, float sxthr, float xsum[BXSIZE], float xsig2[BXSIZE]);
+
+  // Interpolate qfl correction in y.
+  float yflcorr(int binq, float qfly);
+
+  // Interpolate qfl correction in x.
+  float xflcorr(int binq, float qflx);
+
+  int qbin(int id,
+           float cotalpha,
+           float cotbeta,
+           float locBz,
+           float locBx,
+           float qclus,
+           float& pixmx,
+           float& sigmay,
+           float& deltay,
+           float& sigmax,
+           float& deltax,
+           float& sy1,
+           float& dy1,
+           float& sy2,
+           float& dy2,
+           float& sx1,
+           float& dx1,
+           float& sx2,
+           float& dx2);
+
+  int qbin(int id,
+           float cotalpha,
+           float cotbeta,
+           float locBz,
+           float qclus,
+           float& pixmx,
+           float& sigmay,
+           float& deltay,
+           float& sigmax,
+           float& deltax,
+           float& sy1,
+           float& dy1,
+           float& sy2,
+           float& dy2,
+           float& sx1,
+           float& dx1,
+           float& sx2,
+           float& dx2);
+
+  // Overload to use for cluster splitting
+  int qbin(int id, float cotalpha, float cotbeta, float qclus);
+
+  // Overload to keep legacy interface
+  int qbin(int id, float cotbeta, float qclus);
+
+  // Method to return template errors for fastsim
+  void temperrors(int id,
+                  float cotalpha,
+                  float cotbeta,
+                  int qBin,
+                  float& sigmay,
+                  float& sigmax,
+                  float& sy1,
+                  float& sy2,
+                  float& sx1,
+                  float& sx2);
+
+  //Method to return qbin and size probabilities for fastsim
+  void qbin_dist(int id,
+                 float cotalpha,
+                 float cotbeta,
+                 float qbin_frac[4],
+                 float& ny1_frac,
+                 float& ny2_frac,
+                 float& nx1_frac,
+                 float& nx2_frac);
+
+  //Method to calculate simple 2D templates
+  bool simpletemplate2D(
+      float xhitp, float yhitp, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2]);
+
+  //Method to interpolate Vavilov distribution parameters
+  void vavilov_pars(double& mpv, double& sigma, double& kappa);
+
+  //Method to interpolate 2-cluster Vavilov distribution parameters
+  void vavilov2_pars(double& mpv, double& sigma, double& kappa);
+
+  float qavg() { return qavg_; }      //!< average cluster charge for this set of track angles
+  float pixmax() { return pixmax_; }  //!< maximum pixel charge
+  float qscale() { return qscale_; }  //!< charge scaling factor
+  float s50() { return s50_; }        //!< 1/2 of the pixel threshold signal in electrons
+  float ss50() { return ss50_; }      //!< 1/2 of the single pixel per double column threshold in electrons
+  float symax() { return symax_; }    //!< average pixel signal for y-projection of cluster
+  float dyone() { return dyone_; }    //!< mean offset/correction for one pixel y-clusters
+  float syone() { return syone_; }    //!< rms for one pixel y-clusters
+  float dytwo() { return dytwo_; }    //!< mean offset/correction for one double-pixel y-clusters
+  float sytwo() { return sytwo_; }    //!< rms for one double-pixel y-clusters
+  float sxmax() { return sxmax_; }    //!< average pixel signal for x-projection of cluster
+  float dxone() { return dxone_; }    //!< mean offset/correction for one pixel x-clusters
+  float sxone() { return sxone_; }    //!< rms for one pixel x-clusters
+  float dxtwo() { return dxtwo_; }    //!< mean offset/correction for one double-pixel x-clusters
+  float sxtwo() { return sxtwo_; }    //!< rms for one double-pixel x-clusters
+  float qmin() { return qmin_; }      //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
+  float qmin(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 1) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qmin called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 2);
+#endif
+    if (i == 0) {
+      return qmin_;
+    } else {
+      return qmin2_;
+    }
+  }  //!< minimum cluster charge for valid hit (keeps 99.9% or 99.8% of simulated hits)
+  float clsleny() { return clsleny_; }  //!< y-size of smaller interpolated template in pixels
+  float clslenx() { return clslenx_; }  //!< x-size of smaller interpolated template in pixels
+  float yratio() { return yratio_; }    //!< fractional distance in y between cotbeta templates
+  float yxratio() { return yxratio_; }  //!< fractional distance in y between cotalpha templates slices
+  float xxratio() { return xxratio_; }  //!< fractional distance in x between cotalpha templates
+  float yavg(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yavg called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return yavg_[i];
+  }  //!< average y-bias of reconstruction binned in 4 charge bins
+  float yrms(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yrms called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return yrms_[i];
+  }  //!< average y-rms of reconstruction binned in 4 charge bins
+  float ygx0(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ygx0 called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return ygx0_[i];
+  }  //!< average y0 from Gaussian fit binned in 4 charge bins
+  float ygsig(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ygsig called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return ygsig_[i];
+  }  //!< average sigma_y from Gaussian fit binned in 4 charge bins
+  float xavg(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xavg called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return xavg_[i];
+  }  //!< average x-bias of reconstruction binned in 4 charge bins
+  float xrms(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xrms called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return xrms_[i];
+  }  //!< average x-rms of reconstruction binned in 4 charge bins
+  float xgx0(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xgx0 called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return xgx0_[i];
+  }  //!< average x0 from Gaussian fit binned in 4 charge bins
+  float xgsig(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xgsig called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return xgsig_[i];
+  }  //!< average sigma_x from Gaussian fit binned in 4 charge bins
+  float chi2yavg(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2yavg called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2yavg_[i];
+  }  //!< average y chi^2 in 4 charge bins
+  float chi2ymin(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2ymin called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2ymin_[i];
+  }  //!< minimum y chi^2 in 4 charge bins
+  float chi2xavg(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xavg called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2xavg_[i];
+  }  //!< averaage x chi^2 in 4 charge bins
+  float chi2xmin(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::chi2xmin called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2xmin_[i];
+  }  //!< minimum y chi^2 in 4 charge bins
+  float yavgc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yavgc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return yavgc2m_[i];
+  }  //!< 1st pass chi2 min search: average y-bias of reconstruction binned in 4 charge bins
+  float yrmsc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yrmsc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return yrmsc2m_[i];
+  }  //!< 1st pass chi2 min search: average y-rms of reconstruction binned in 4 charge bins
+  float chi2yavgc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::chi2yavgc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2yavgc2m_[i];
+  }  //!< 1st pass chi2 min search: average y-chisq for merged clusters
+  float chi2yminc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::chi2yminc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2yminc2m_[i];
+  }  //!< 1st pass chi2 min search: minimum y-chisq for merged clusters
+  float xavgc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xavgc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return xavgc2m_[i];
+  }  //!< 1st pass chi2 min search: average x-bias of reconstruction binned in 4 charge bins
+  float xrmsc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xrmsc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return xrmsc2m_[i];
+  }  //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins
+  float chi2xavgc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::chi2xavgc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2xavgc2m_[i];
+  }  //!< 1st pass chi2 min search: average x-chisq for merged clusters
+  float chi2xminc2m(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 3) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::chi2xminc2m called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 4);
+#endif
+    return chi2xminc2m_[i];
+  }  //!< 1st pass chi2 min search: minimum x-chisq for merged clusters
+  float fbin(int i) {
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+    if (i < 0 || i > 2) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::fbin called with illegal index = " << i << std::endl;
+    }
+#else
+    assert(i >= 0 && i < 3);
+#endif
+    return fbin_[i];
+  }  //!< Return lower bound of Qbin definition
+
+  float chi2yavgone() { return chi2yavgone_; }  //!< //!< average y chi^2 for 1 pixel clusters
+  float chi2yminone() { return chi2yminone_; }  //!< //!< minimum of y chi^2 for 1 pixel clusters
+  float chi2xavgone() { return chi2xavgone_; }  //!< //!< average x chi^2 for 1 pixel clusters
+  float chi2xminone() { return chi2xminone_; }  //!< //!< minimum of x chi^2 for 1 pixel clusters
+  float lorywidth() { return lorywidth_; }      //!< signed lorentz y-width (microns)
+  float lorxwidth() { return lorxwidth_; }      //!< signed lorentz x-width (microns)
+  //float lorybias() {return lorywidth_;}                            //!< signed lorentz y-width (microns)
+  //float lorxbias() {return lorxwidth_;}                            //!< signed lorentz x-width (microns)
+  float lorybias() { return lorybias_; }  //!< signed lorentz y-width (microns)
+  float lorxbias() { return lorxbias_; }  //!< signed lorentz x-width (microns)
+  float mpvvav() { return mpvvav_; }  //!< most probable charge in Vavilov distribution (not actually for larger kappa)
+  float sigmavav() { return sigmavav_; }  //!< "sigma" scale fctor for Vavilov distribution
+  float kappavav() { return kappavav_; }  //!< kappa parameter for Vavilov distribution
+  float mpvvav2() {
+    return mpvvav2_;
+  }  //!< most probable charge in 2-cluster Vavilov distribution (not actually for larger kappa)
+  float sigmavav2() { return sigmavav2_; }          //!< "sigma" scale fctor for 2-cluster Vavilov distribution
+  float kappavav2() { return kappavav2_; }          //!< kappa parameter for 2-cluster Vavilov distribution
+  float xsize() { return xsize_; }                  //!< pixel x-size (microns)
+  float ysize() { return ysize_; }                  //!< pixel y-size (microns)
+  float zsize() { return zsize_; }                  //!< pixel z-size or thickness (microns)
+  float r_qMeas_qTrue() { return r_qMeas_qTrue_; }  //!< ratio of measured to true cluster charge
+  float fracyone() { return fracyone_; }            //!< The simulated fraction of single pixel y-clusters
+  float fracxone() { return fracxone_; }            //!< The simulated fraction of single pixel x-clusters
+  float fracytwo() { return fracytwo_; }            //!< The simulated fraction of single double-size pixel y-clusters
+  float fracxtwo() { return fracxtwo_; }            //!< The simulated fraction of single double-size pixel x-clusters
+  //  float yspare(int i) {assert(i>=0 && i<5); return pyspare[i];}    //!< vector of 5 spares interpolated in beta only
+  //  float xspare(int i) {assert(i>=0 && i<10); return pxspare[i];}    //!< vector of 10 spares interpolated in alpha and beta
+
+private:
+  // Keep current template interpolaion parameters
+
+  int id_current_;      //!< current id
+  int index_id_;        //!< current index
+  float cota_current_;  //!< current cot alpha
+  float cotb_current_;  //!< current cot beta
+  float abs_cotb_;      //!< absolute value of cot beta
+  bool success_;        //!< true if cotalpha, cotbeta are inside of the acceptance (dynamically loaded)
+
+  // Keep results of last interpolation to return through member functions
+
+  float qavg_;              //!< average cluster charge for this set of track angles
+  float pixmax_;            //!< maximum pixel charge
+  float qscale_;            //!< charge scaling factor
+  float s50_;               //!< 1/2 of the pixel single col threshold signal in electrons
+  float ss50_;              //!< 1/2 of the pixel double col threshold signal in electrons
+  float symax_;             //!< average pixel signal for y-projection of cluster
+  float syparmax_;          //!< maximum pixel signal for parameterization of y uncertainties
+  float dyone_;             //!< mean offset/correction for one pixel y-clusters
+  float syone_;             //!< rms for one pixel y-clusters
+  float dytwo_;             //!< mean offset/correction for one double-pixel y-clusters
+  float sytwo_;             //!< rms for one double-pixel y-clusters
+  float sxmax_;             //!< average pixel signal for x-projection of cluster
+  float sxparmax_;          //!< maximum pixel signal for parameterization of x uncertainties
+  float dxone_;             //!< mean offset/correction for one pixel x-clusters
+  float sxone_;             //!< rms for one pixel x-clusters
+  float dxtwo_;             //!< mean offset/correction for one double-pixel x-clusters
+  float sxtwo_;             //!< rms for one double-pixel x-clusters
+  float qmin_;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
+  float clsleny_;           //!< y-cluster length of smaller interpolated template in pixels
+  float clslenx_;           //!< x-cluster length of smaller interpolated template in pixels
+  float yratio_;            //!< fractional distance in y between cotbeta templates
+  float yparl_[2][5];       //!< projected y-pixel uncertainty parameterization for smaller cotbeta
+  float yparh_[2][5];       //!< projected y-pixel uncertainty parameterization for larger cotbeta
+  float xparly0_[2][5];     //!< projected x-pixel uncertainty parameterization for smaller cotbeta (central alpha)
+  float xparhy0_[2][5];     //!< projected x-pixel uncertainty parameterization for larger cotbeta (central alpha)
+  float ytemp_[9][BYSIZE];  //!< templates for y-reconstruction (binned over 5 central pixels)
+  float yxratio_;           //!< fractional distance in y between x-slices of cotalpha templates
+  float xxratio_;           //!< fractional distance in x between cotalpha templates
+  float xpar0_[2][5];       //!< projected x-pixel uncertainty parameterization for central cotalpha
+  float xparl_[2][5];       //!< projected x-pixel uncertainty parameterization for smaller cotalpha
+  float xparh_[2][5];       //!< projected x-pixel uncertainty parameterization for larger cotalpha
+  float xtemp_[9][BXSIZE];  //!< templates for x-reconstruction (binned over 5 central pixels)
+  float yavg_[4];           //!< average y-bias of reconstruction binned in 4 charge bins
+  float yrms_[4];           //!< average y-rms of reconstruction binned in 4 charge bins
+  float ygx0_[4];           //!< average y0 from Gaussian fit binned in 4 charge bins
+  float ygsig_[4];          //!< average sigma_y from Gaussian fit binned in 4 charge bins
+  float yflparl_[4][6];     //!< Aqfl-parameterized y-correction in 4 charge bins for smaller cotbeta
+  float yflparh_[4][6];     //!< Aqfl-parameterized y-correction in 4 charge bins for larger cotbeta
+  float xavg_[4];           //!< average x-bias of reconstruction binned in 4 charge bins
+  float xrms_[4];           //!< average x-rms of reconstruction binned in 4 charge bins
+  float xgx0_[4];           //!< average x0 from Gaussian fit binned in 4 charge bins
+  float xgsig_[4];          //!< sigma from Gaussian fit binned in 4 charge bins
+  float xflparll_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for smaller cotbeta, cotalpha
+  float xflparlh_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for smaller cotbeta, larger cotalpha
+  float xflparhl_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for larger cotbeta, smaller cotalpha
+  float xflparhh_[4][6];    //!< Aqfl-parameterized x-correction in 4 charge bins for larger cotbeta, cotalpha
+  float chi2yavg_[4];       //!< average y chi^2 in 4 charge bins
+  float chi2ymin_[4];       //!< minimum of y chi^2 in 4 charge bins
+  float chi2xavg_[4];       //!< average x chi^2 in 4 charge bins
+  float chi2xmin_[4];       //!< minimum of x chi^2 in 4 charge bins
+  float yavgc2m_[4];        //!< 1st pass chi2 min search: average y-bias of reconstruction binned in 4 charge bins
+  float yrmsc2m_[4];        //!< 1st pass chi2 min search: average y-rms of reconstruction binned in 4 charge bins
+  float chi2yavgc2m_[4];    //!< 1st pass chi2 min search: average y-chisq for merged clusters
+  float chi2yminc2m_[4];    //!< 1st pass chi2 min search: minimum y-chisq for merged clusters
+  float xavgc2m_[4];        //!< 1st pass chi2 min search: average x-bias of reconstruction binned in 4 charge bins
+  float xrmsc2m_[4];        //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins
+  float chi2xavgc2m_[4];    //!< 1st pass chi2 min search: average x-chisq for merged clusters
+  float chi2xminc2m_[4];    //!< 1st pass chi2 min search: minimum x-chisq for merged clusters
+  float chi2yavgone_;       //!< average y chi^2 for 1 pixel clusters
+  float chi2yminone_;       //!< minimum of y chi^2 for 1 pixel clusters
+  float chi2xavgone_;       //!< average x chi^2 for 1 pixel clusters
+  float chi2xminone_;       //!< minimum of x chi^2 for 1 pixel clusters
+  float qmin2_;             //!< tighter minimum cluster charge for valid hit (keeps 99.8% of simulated hits)
+  float mpvvav_;            //!< most probable charge in Vavilov distribution (not actually for larger kappa)
+  float sigmavav_;          //!< "sigma" scale fctor for Vavilov distribution
+  float kappavav_;          //!< kappa parameter for Vavilov distribution
+  float mpvvav2_;           //!< most probable charge in 2-cluster Vavilov distribution (not actually for larger kappa)
+  float sigmavav2_;         //!< "sigma" scale fctor for 2-cluster Vavilov distribution
+  float kappavav2_;         //!< kappa parameter for 2-cluster Vavilov distribution
+  float lorywidth_;         //!< Lorentz y-width (sign corrected for fpix frame)
+  float lorxwidth_;         //!< Lorentz x-width
+  float lorybias_;          //!< Lorentz y-bias
+  float lorxbias_;          //!< Lorentz x-bias
+  float xsize_;             //!< Pixel x-size
+  float ysize_;             //!< Pixel y-size
+  float zsize_;             //!< Pixel z-size (thickness)
+  float qavg_avg_;          //!< average of cluster charge less than qavg
+  float nybins_;            //!< number of bins in each dimension of the y-splitting template
+  float nxbins_;            //!< number of bins in each dimension of the x-splitting template
+  float r_qMeas_qTrue_;     //!< ratio of measured to true cluster charges
+  float fbin_[3];           //!< The QBin definitions in Q_clus/Q_avg
+  float fracyone_;          //!< The simulated fraction of single pixel y-clusters
+  float fracxone_;          //!< The simulated fraction of single pixel x-clusters
+  float fracytwo_;          //!< The simulated fraction of single double-size pixel y-clusters
+  float fracxtwo_;          //!< The simulated fraction of single double-size pixel x-clusters
+  boost::multi_array<float, 2> temp2dy_;  //!< 2d-primitive for spltting 3-d template
+  boost::multi_array<float, 2> temp2dx_;  //!< 2d-primitive for spltting 3-d template
+
+  // The actual template store is a std::vector container
+
+  const std::vector<SiPixelTemplateStore>& thePixelTemp_;
+};
 
 #endif

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -27,8 +27,8 @@
 #ifndef SiPixelTemplate2D_h
 #define SiPixelTemplate2D_h 1
 
-#include<vector>
-#include<cassert>
+#include <vector>
+#include <cassert>
 #include "boost/multi_array.hpp"
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
@@ -39,85 +39,76 @@
 #include "SiPixelTemplateDefs.h"
 #endif
 
-struct SiPixelTemplateEntry2D { //!< Basic template entry corresponding to a single set of track angles
-   int runnum;              //!< number of pixelav run used to generate this entry
-   float cotalpha;          //!< cot(alpha) is proportional to cluster length in x and is basis of interpolation
-   float cotbeta;           //!< cot(beta) is proportional to cluster length in y and is basis of interpolation
-   float costrk[3];         //!< direction cosines of tracks used to generate this entry
-   float qavg;              //!< average cluster charge for this set of track angles
-   float pixmax;            //!< maximum charge for individual pixels in cluster
-   float sxymax;            //!< average pixel signal for use of the error parameterization
-   int iymin;               //!< the minimum nonzero pixel yindex in template (saves time during interpolation)
-   int iymax;               //!< the maximum nonzero pixel yindex in template (saves time during interpolation)
-   int jxmin;               //!< the minimum nonzero pixel xindex in template (saves time during interpolation)
-   int jxmax;               //!< the maximum nonzero pixel xindex in template (saves time during interpolation)
-   float xypar[2][5];       //!< pixel uncertainty parameterization
-   float lanpar[2][5];      //!< pixel landau distribution parameters
-   short int xytemp[7][7][T2YSIZE][T2XSIZE];  //!< templates for y-reconstruction (binned over 1 central pixel)
-   float chi2ppix;          //!< average chi^2 per pixel
-   float chi2scale;         //!< scale factor for the chi2 distribution
-   float chi2avgone;        //!< average y chi^2 for 1 pixel clusters
-   float chi2minone;        //!< minimum of y chi^2 for 1 pixel clusters
-   float clsleny;           //!< cluster y-length in pixels at signal height symax/2
-   float clslenx;           //!< cluster x-length in pixels at signal height sxmax/2
-   float mpvvav;            //!< most probable charge in Vavilov distribution (not actually for larger kappa)
-   float sigmavav;          //!< "sigma" scale fctor for Vavilov distribution
-   float kappavav;          //!< kappa parameter for Vavilov distribution
-   float scalexavg;         //!< average x-error scale factor
-   float scaleyavg;         //!< average y-error scale factor
-   float delyavg;           //!< average length difference between template and cluster
-   float delysig;           //!< rms of length difference between template and cluster
-   float scalex[4];         //!< x-error scale factor in 4 charge bins
-   float scaley[4];         //!< y-error scale factor in 4 charge bins
-   float offsetx[4];        //!< x-offset in 4 charge bins
-   float offsety[4];        //!< y-offset in 4 charge bins
-   float spare[3];
-} ;
+struct SiPixelTemplateEntry2D {  //!< Basic template entry corresponding to a single set of track angles
+  int runnum;                    //!< number of pixelav run used to generate this entry
+  float cotalpha;                //!< cot(alpha) is proportional to cluster length in x and is basis of interpolation
+  float cotbeta;                 //!< cot(beta) is proportional to cluster length in y and is basis of interpolation
+  float costrk[3];               //!< direction cosines of tracks used to generate this entry
+  float qavg;                    //!< average cluster charge for this set of track angles
+  float pixmax;                  //!< maximum charge for individual pixels in cluster
+  float sxymax;                  //!< average pixel signal for use of the error parameterization
+  int iymin;                     //!< the minimum nonzero pixel yindex in template (saves time during interpolation)
+  int iymax;                     //!< the maximum nonzero pixel yindex in template (saves time during interpolation)
+  int jxmin;                     //!< the minimum nonzero pixel xindex in template (saves time during interpolation)
+  int jxmax;                     //!< the maximum nonzero pixel xindex in template (saves time during interpolation)
+  float xypar[2][5];             //!< pixel uncertainty parameterization
+  float lanpar[2][5];            //!< pixel landau distribution parameters
+  short int xytemp[7][7][T2YSIZE][T2XSIZE];  //!< templates for y-reconstruction (binned over 1 central pixel)
+  float chi2ppix;                            //!< average chi^2 per pixel
+  float chi2scale;                           //!< scale factor for the chi2 distribution
+  float chi2avgone;                          //!< average y chi^2 for 1 pixel clusters
+  float chi2minone;                          //!< minimum of y chi^2 for 1 pixel clusters
+  float clsleny;                             //!< cluster y-length in pixels at signal height symax/2
+  float clslenx;                             //!< cluster x-length in pixels at signal height sxmax/2
+  float mpvvav;      //!< most probable charge in Vavilov distribution (not actually for larger kappa)
+  float sigmavav;    //!< "sigma" scale fctor for Vavilov distribution
+  float kappavav;    //!< kappa parameter for Vavilov distribution
+  float scalexavg;   //!< average x-error scale factor
+  float scaleyavg;   //!< average y-error scale factor
+  float delyavg;     //!< average length difference between template and cluster
+  float delysig;     //!< rms of length difference between template and cluster
+  float scalex[4];   //!< x-error scale factor in 4 charge bins
+  float scaley[4];   //!< y-error scale factor in 4 charge bins
+  float offsetx[4];  //!< x-offset in 4 charge bins
+  float offsety[4];  //!< y-offset in 4 charge bins
+  float spare[3];
+};
 
+struct SiPixelTemplateHeader2D {  //!< template header structure
+  int ID;                         //!< template ID number
+  int NTy;                        //!< number of Template y entries
+  int NTyx;                       //!< number of Template y-slices of x entries
+  int NTxx;                       //!< number of Template x-entries in each slice
+  int Dtype;                      //!< detector type (0=BPix, 1=FPix)
+  float qscale;                   //!< Charge scaling to match cmssw and pixelav
+  float lorywidth;                //!< estimate of y-lorentz width for optimal resolution
+  float lorxwidth;                //!< estimate of x-lorentz width for optimal resolution
+  float lorybias;                 //!< estimate of y-lorentz bias
+  float lorxbias;                 //!< estimate of x-lorentz bias
+  float Vbias;                    //!< detector bias potential in Volts
+  float temperature;              //!< detector temperature in deg K
+  float fluence;                  //!< radiation fluence in n_eq/cm^2
+  float s50;                      //!< 1/2 of the multihit dcol threshold in electrons
+  float ss50;                     //!< 1/2 of the single hit dcol threshold in electrons
+  char title[80];                 //!< template title
+  int templ_version;              //!< Version number of the template to ensure code compatibility
+  float Bfield;                   //!< Bfield in Tesla
+  float fbin[3];                  //!< The QBin definitions in Q_clus/Q_avg
+  float xsize;                    //!< pixel size (for future use in upgraded geometry)
+  float ysize;                    //!< pixel size (for future use in upgraded geometry)
+  float zsize;                    //!< pixel size (for future use in upgraded geometry)
+};
 
-
-
-struct SiPixelTemplateHeader2D {           //!< template header structure
-   int ID;                 //!< template ID number
-   int NTy;                //!< number of Template y entries
-   int NTyx;               //!< number of Template y-slices of x entries
-   int NTxx;               //!< number of Template x-entries in each slice
-   int Dtype;              //!< detector type (0=BPix, 1=FPix)
-   float qscale;           //!< Charge scaling to match cmssw and pixelav
-   float lorywidth;        //!< estimate of y-lorentz width for optimal resolution
-   float lorxwidth;        //!< estimate of x-lorentz width for optimal resolution
-   float lorybias;         //!< estimate of y-lorentz bias
-   float lorxbias;         //!< estimate of x-lorentz bias
-   float Vbias;            //!< detector bias potential in Volts
-   float temperature;      //!< detector temperature in deg K
-   float fluence;          //!< radiation fluence in n_eq/cm^2
-   float s50;              //!< 1/2 of the multihit dcol threshold in electrons
-   float ss50;             //!< 1/2 of the single hit dcol threshold in electrons
-   char title[80];         //!< template title
-   int templ_version;      //!< Version number of the template to ensure code compatibility
-   float Bfield;           //!< Bfield in Tesla
-   float fbin[3];          //!< The QBin definitions in Q_clus/Q_avg
-   float xsize;            //!< pixel size (for future use in upgraded geometry)
-   float ysize;            //!< pixel size (for future use in upgraded geometry)
-   float zsize;            //!< pixel size (for future use in upgraded geometry)
-} ;
-
-
-
-struct SiPixelTemplateStore2D { //!< template storage structure
-   SiPixelTemplateHeader2D head;
-   SiPixelTemplateEntry2D** entry = nullptr;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
-   void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
-      if (entry!=nullptr) {
-         delete[] entry[0];
-         delete[] entry;
-      }
-
-   }
-
-} ;
-
-
+struct SiPixelTemplateStore2D {  //!< template storage structure
+  SiPixelTemplateHeader2D head;
+  SiPixelTemplateEntry2D** entry = nullptr;  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
+  void destroy() {                           // deletes arrays created by pushfile method of SiPixelTemplate
+    if (entry != nullptr) {
+      delete[] entry[0];
+      delete[] entry;
+    }
+  }
+};
 
 // ******************************************************************************************
 //! \class SiPixelTemplate2D
@@ -140,166 +131,227 @@ struct SiPixelTemplateStore2D { //!< template storage structure
 // ******************************************************************************************
 class SiPixelTemplate2D {
 public:
-   SiPixelTemplate2D(const std::vector< SiPixelTemplateStore2D > & thePixelTemp) : thePixelTemp_(thePixelTemp) {id_current_ = -1; index_id_ = -1; cota_current_ = 0.; cotb_current_ = 0.;} //!< Default constructor
-   
-// load the private store with info from the
-   // file with the index (int) filenum ${dir}template_summary_zp${filenum}.out
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & pixelTemp, std::string dir = "");     
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   static bool pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & pixelTemp);     // load the private store with info from db
-#endif
-   
-   //  Initialize things before interpolating
-   
-   void sideload(SiPixelTemplateEntry2D* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize);
-   
-   //  Initialize things before interpolating
-   bool getid(int id);
+  SiPixelTemplate2D(const std::vector<SiPixelTemplateStore2D>& thePixelTemp) : thePixelTemp_(thePixelTemp) {
+    id_current_ = -1;
+    index_id_ = -1;
+    cota_current_ = 0.;
+    cotb_current_ = 0.;
+  }  //!< Default constructor
 
-   bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
-   
-   // Interpolate input alpha and beta angles to produce a working template for each individual hit.
-   
-   // Works with Phase 0+1
-   bool xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2], bool dervatives, float dpdx2d[2][BXM2][BYM2], float& QTemplate);
-   
-   // Overload for backward compatibility
-   
-   bool xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2]);
-   
-   // Overload for backward compatibility with re-weighting code
-   
-   bool xytemp(int id, float cotalpha, float cotbeta, float xhit, float yhit, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2]);
-   
-   void xysigma2(float qpixel, int index, float& xysig2);
-   
-   // Get the interpolated Landau distribution parameters
-   
-   void landau_par(float lanpar[2][5]);
-   
-   float qavg() {return qavg_;}        //!< average cluster charge for this set of track angles
-   float pixmax() {return pixmax_;}    //!< maximum pixel charge
-   float qscale() {return qscale_;}    //!< charge scaling factor
-   float s50() {return s50_;}          //!< 1/2 of the pixel threshold signal in adc units
-   float sxymax() {return sxymax_;}    //!< max pixel signal for pixel error calculation
-   float scalex(int i) {if(checkIllegalIndex("scalex",3,i)) {return scalex_[i];} else {return 0.f;}}   //!< x-error scale factor in 4 charge bins
-   float scaley(int i) {if(checkIllegalIndex("scaley",3,i)) {return scaley_[i];} else {return 0.f;}} //!< y-error scale factor in 4 charge bins
-   float offsetx(int i) {if(checkIllegalIndex("offsetx",3,i)) {return offsetx_[i];} else {return 0.f;}} //!< x-offset in 4 charge bins
-   float offsety(int i) {if(checkIllegalIndex("offsety",3,i)) {return offsety_[i];} else {return 0.f;}} //!< y-offset in 4 charge bins
-   float fbin(int i) {if(checkIllegalIndex("fbin",2,i)) {return fbin_[i];} else {return 0.f;}} //!< Return lower bound of Qbin definition
-   float sizex() {return clslenx_;}                             //!< return x size of template cluster
-   float sizey() {return clsleny_;}                             //!< return y size of template cluster
-   float chi2ppix() {return chi2ppix_;}                         //!< average chi^2 per struck pixel
-   float chi2scale() {return chi2scale_;}                       //!< scale factor for chi^2 distribution
-   float chi2avgone() {return chi2avgone_;}                        //!< average y chi^2 for 1 pixel clusters
-   float chi2minone() {return chi2minone_;}                        //!< minimum of y chi^2 for 1 pixel clusters
-   float mpvvav() {return mpvvav_;}                             //!< most probable Q in Vavilov distribution
-   float sigmavav() {return sigmavav_;}                         //!< scale factor in Vavilov distribution
-   float kappavav() {return kappavav_;}                         //!< kappa parameter in Vavilov distribution
-   float lorydrift() {return lorydrift_;}                            //!< signed lorentz y-width (microns)
-   float lorxdrift() {return lorxdrift_;}                            //!< signed lorentz x-width (microns)
-   float clsleny() {return clsleny_;}                                //!< cluster y-size
-   float clslenx() {return clslenx_;}                                //!< cluster x-size
-   float scaleyavg() {return scaleyavg_;}                            //!< y-reco error scaling factor
-   float scalexavg() {return scalexavg_;}                            //!< x-reco error scaling factor
-   float delyavg() {return delyavg_;}                            //!< average difference between clsleny_ and cluster length [with threshold effects]
-   float delysig() {return delysig_;}                            //!< rms difference between clsleny_ and cluster length [with threshold effects]
-   float xsize() {return xsize_;}                                    //!< pixel x-size (microns)
-   float ysize() {return ysize_;}                                    //!< pixel y-size (microns)
-   float zsize() {return zsize_;}                                    //!< pixel z-size or thickness (microns)
-   int storesize() {return (int)thePixelTemp_.size();}               //!< return the size of the template store (the number of stored IDs
-   
+  // load the private store with info from the
+  // file with the index (int) filenum ${dir}template_summary_zp${filenum}.out
+  static bool pushfile(int filenum, std::vector<SiPixelTemplateStore2D>& pixelTemp, std::string dir = "");
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  static bool pushfile(const SiPixel2DTemplateDBObject& dbobject,
+                       std::vector<SiPixelTemplateStore2D>& pixelTemp);  // load the private store with info from db
+#endif
+
+  //  Initialize things before interpolating
+
+  void sideload(SiPixelTemplateEntry2D* entry,
+                int iDtype,
+                float locBx,
+                float locBz,
+                float lorwdy,
+                float lorwdx,
+                float q50,
+                float fbin[3],
+                float xsize,
+                float ysize,
+                float zsize);
+
+  //  Initialize things before interpolating
+  bool getid(int id);
+
+  bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
+
+  // Interpolate input alpha and beta angles to produce a working template for each individual hit.
+
+  // Works with Phase 0+1
+  bool xytemp(float xhit,
+              float yhit,
+              bool ydouble[BYM2],
+              bool xdouble[BXM2],
+              float template2d[BXM2][BYM2],
+              bool dervatives,
+              float dpdx2d[2][BXM2][BYM2],
+              float& QTemplate);
+
+  // Overload for backward compatibility
+
+  bool xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2]);
+
+  // Overload for backward compatibility with re-weighting code
+
+  bool xytemp(int id,
+              float cotalpha,
+              float cotbeta,
+              float xhit,
+              float yhit,
+              std::vector<bool>& ydouble,
+              std::vector<bool>& xdouble,
+              float template2d[BXM2][BYM2]);
+
+  void xysigma2(float qpixel, int index, float& xysig2);
+
+  // Get the interpolated Landau distribution parameters
+
+  void landau_par(float lanpar[2][5]);
+
+  float qavg() { return qavg_; }      //!< average cluster charge for this set of track angles
+  float pixmax() { return pixmax_; }  //!< maximum pixel charge
+  float qscale() { return qscale_; }  //!< charge scaling factor
+  float s50() { return s50_; }        //!< 1/2 of the pixel threshold signal in adc units
+  float sxymax() { return sxymax_; }  //!< max pixel signal for pixel error calculation
+  float scalex(int i) {
+    if (checkIllegalIndex("scalex", 3, i)) {
+      return scalex_[i];
+    } else {
+      return 0.f;
+    }
+  }  //!< x-error scale factor in 4 charge bins
+  float scaley(int i) {
+    if (checkIllegalIndex("scaley", 3, i)) {
+      return scaley_[i];
+    } else {
+      return 0.f;
+    }
+  }  //!< y-error scale factor in 4 charge bins
+  float offsetx(int i) {
+    if (checkIllegalIndex("offsetx", 3, i)) {
+      return offsetx_[i];
+    } else {
+      return 0.f;
+    }
+  }  //!< x-offset in 4 charge bins
+  float offsety(int i) {
+    if (checkIllegalIndex("offsety", 3, i)) {
+      return offsety_[i];
+    } else {
+      return 0.f;
+    }
+  }  //!< y-offset in 4 charge bins
+  float fbin(int i) {
+    if (checkIllegalIndex("fbin", 2, i)) {
+      return fbin_[i];
+    } else {
+      return 0.f;
+    }
+  }                                           //!< Return lower bound of Qbin definition
+  float sizex() { return clslenx_; }          //!< return x size of template cluster
+  float sizey() { return clsleny_; }          //!< return y size of template cluster
+  float chi2ppix() { return chi2ppix_; }      //!< average chi^2 per struck pixel
+  float chi2scale() { return chi2scale_; }    //!< scale factor for chi^2 distribution
+  float chi2avgone() { return chi2avgone_; }  //!< average y chi^2 for 1 pixel clusters
+  float chi2minone() { return chi2minone_; }  //!< minimum of y chi^2 for 1 pixel clusters
+  float mpvvav() { return mpvvav_; }          //!< most probable Q in Vavilov distribution
+  float sigmavav() { return sigmavav_; }      //!< scale factor in Vavilov distribution
+  float kappavav() { return kappavav_; }      //!< kappa parameter in Vavilov distribution
+  float lorydrift() { return lorydrift_; }    //!< signed lorentz y-width (microns)
+  float lorxdrift() { return lorxdrift_; }    //!< signed lorentz x-width (microns)
+  float clsleny() { return clsleny_; }        //!< cluster y-size
+  float clslenx() { return clslenx_; }        //!< cluster x-size
+  float scaleyavg() { return scaleyavg_; }    //!< y-reco error scaling factor
+  float scalexavg() { return scalexavg_; }    //!< x-reco error scaling factor
+  float delyavg() {
+    return delyavg_;
+  }  //!< average difference between clsleny_ and cluster length [with threshold effects]
+  float delysig() { return delysig_; }  //!< rms difference between clsleny_ and cluster length [with threshold effects]
+  float xsize() { return xsize_; }      //!< pixel x-size (microns)
+  float ysize() { return ysize_; }      //!< pixel y-size (microns)
+  float zsize() { return zsize_; }      //!< pixel z-size or thickness (microns)
+  int storesize() {
+    return (int)thePixelTemp_.size();
+  }  //!< return the size of the template store (the number of stored IDs
+
 private:
-
-   bool checkIllegalIndex(const std::string whichMethod, int indMax, int i) 
-      {
+  bool checkIllegalIndex(const std::string whichMethod, int indMax, int i) {
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         if(i < 0 || i > indMax) {throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::"<< whichMethod <<" called with illegal index = " << i << std::endl;}
+    if (i < 0 || i > indMax) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate2D::" << whichMethod << " called with illegal index = " << i << std::endl;
+    }
 #else
-         assert(i>=0 && i<indMax+1);
+    assert(i >= 0 && i < indMax + 1);
 
 #endif
-         return true;
-   }
+    return true;
+  }
 
-   
-   // Keep current template interpolaion parameters
-   
-   int id_current_;           //!< current id
-   int index_id_;             //!< current index
-   float cota_current_;       //!< current cot alpha
-   float cotb_current_;       //!< current cot beta
-   int Nyx_;                  //!< number of cot(beta)-entries (columns) in template
-   int Nxx_;                  //!< number of cot(alpha)-entries (rows) in template
-   int Dtype_;                //!< flags BPix (=0) or FPix (=1)
-   float cotbeta0_;           //!< minimum cot(beta) covered
-   float cotbeta1_;           //!< maximum cot(beta) covered
-   float deltacotb_;          //!< cot(beta) bin size
-   float cotalpha0_;          //!< minimum cot(alpha) covered
-   float cotalpha1_;          //!< maximum cot(alpha) covered
-   float deltacota_;          //!< cot(alpha) bin size
-   int iy0_;                  //!< index of nearest cot(beta) bin
-   int iy1_;                  //!< index of next-nearest cot(beta) bin
-   float adcotb_;             //!< fractional pixel distance of cot(beta) from iy0_
-   int jx0_;                  //!< index of nearest cot(alpha) bin
-   int jx1_;                  //!< index of next-nearest cot(alpha) bin
-   float adcota_;             //!< fractional pixel distance of cot(alpha) from jx0_
-   int imin_;                 //!< min y index of templated cluster
-   int imax_;                 //!< max y index of templated cluster
-   int jmin_;                 //!< min x index of templated cluster
-   int jmax_;                 //!< max x index of templated cluster
-   bool flip_y_;              //!< flip y sign-sensitive quantities
-   bool flip_x_;              //!< flip x sign-sensitive quantities
-   bool success_;             //!< true if cotalpha, cotbeta are inside of the acceptance (dynamically loaded)
-   
-   
-   // Keep results of last interpolation to return through member functions
-   
-   float qavg_;              //!< average cluster charge for this set of track angles
-   float pixmax_;            //!< maximum pixel charge
-   float qscale_;            //!< charge scaling factor
-   float s50_;               //!< 1/2 of the pixel threshold signal in adc units
-   float sxymax_;            //!< average pixel signal for y-projection of cluster
-   float xytemp_[BXM2][BYM2];//!< template for xy-reconstruction
-   float xypary0x0_[2][5];   //!< Polynomial error parameterization at ix0,iy0
-   float xypary1x0_[2][5];   //!< Polynomial error parameterization at ix0,iy1
-   float xypary0x1_[2][5];   //!< Polynomial error parameterization at ix1,iy0
-   float lanpar_[2][5];      //!< Interpolated Landau parameters
-   float chi2ppix_;          //!< average chi^2 per struck pixel
-   float chi2scale_;         //!< scale factor for chi2 distribution
-   float chi2avgone_;        //!< average chi^2 for 1 pixel clusters
-   float chi2minone_;        //!< minimum of chi^2 for 1 pixel clusters
-   float clsleny_;            //!< projected y-length of cluster
-   float clslenx_;            //!< projected x-length of cluster
-   float scalexavg_;         //!< average x-error scale factor
-   float scaleyavg_;         //!< average y-error scale factor
-   float delyavg_;            //!< average difference between clsleny_ and cluster length [with threshold effects]
-   float delysig_;            //!< rms of difference between clsleny_ and cluster length [with threshold effects]
-   float scalex_[4];         //!< x-error scale factor in charge bins
-   float scaley_[4];         //!< y-error scale factor in charge bins
-   float offsetx_[4];        //!< x-offset in charge bins
-   float offsety_[4];        //!< y-offset in charge bins
-   float mpvvav_;            //!< most probable Q in Vavilov distribution
-   float sigmavav_;          //!< scale factor in Vavilov distribution
-   float kappavav_;          //!< kappa parameter in Vavilov distribution
-   float lorywidth_;         //!< Lorentz y-width (sign corrected for fpix frame)
-   float lorxwidth_;         //!< Lorentz x-width
-   float lorydrift_;         //!< Lorentz y-drift
-   float lorxdrift_;         //!< Lorentz x-drift
-   float xsize_;             //!< Pixel x-size
-   float ysize_;             //!< Pixel y-size
-   float zsize_;             //!< Pixel z-size (thickness)
-   float fbin_[3];           //!< The QBin definitions in Q_clus/Q_avg
-   const SiPixelTemplateEntry2D* entry00_; // Pointer to presently interpolated point [iy,ix]
-   const SiPixelTemplateEntry2D* entry10_; // Pointer to presently interpolated point [iy+1,ix]
-   const SiPixelTemplateEntry2D* entry01_; // Pointer to presently interpolated point [iy,ix+1]
-   
-   // The actual template store is a std::vector container
-   
-   const std::vector< SiPixelTemplateStore2D > & thePixelTemp_;
-   
-} ;
+  // Keep current template interpolaion parameters
 
+  int id_current_;      //!< current id
+  int index_id_;        //!< current index
+  float cota_current_;  //!< current cot alpha
+  float cotb_current_;  //!< current cot beta
+  int Nyx_;             //!< number of cot(beta)-entries (columns) in template
+  int Nxx_;             //!< number of cot(alpha)-entries (rows) in template
+  int Dtype_;           //!< flags BPix (=0) or FPix (=1)
+  float cotbeta0_;      //!< minimum cot(beta) covered
+  float cotbeta1_;      //!< maximum cot(beta) covered
+  float deltacotb_;     //!< cot(beta) bin size
+  float cotalpha0_;     //!< minimum cot(alpha) covered
+  float cotalpha1_;     //!< maximum cot(alpha) covered
+  float deltacota_;     //!< cot(alpha) bin size
+  int iy0_;             //!< index of nearest cot(beta) bin
+  int iy1_;             //!< index of next-nearest cot(beta) bin
+  float adcotb_;        //!< fractional pixel distance of cot(beta) from iy0_
+  int jx0_;             //!< index of nearest cot(alpha) bin
+  int jx1_;             //!< index of next-nearest cot(alpha) bin
+  float adcota_;        //!< fractional pixel distance of cot(alpha) from jx0_
+  int imin_;            //!< min y index of templated cluster
+  int imax_;            //!< max y index of templated cluster
+  int jmin_;            //!< min x index of templated cluster
+  int jmax_;            //!< max x index of templated cluster
+  bool flip_y_;         //!< flip y sign-sensitive quantities
+  bool flip_x_;         //!< flip x sign-sensitive quantities
+  bool success_;        //!< true if cotalpha, cotbeta are inside of the acceptance (dynamically loaded)
+
+  // Keep results of last interpolation to return through member functions
+
+  float qavg_;                //!< average cluster charge for this set of track angles
+  float pixmax_;              //!< maximum pixel charge
+  float qscale_;              //!< charge scaling factor
+  float s50_;                 //!< 1/2 of the pixel threshold signal in adc units
+  float sxymax_;              //!< average pixel signal for y-projection of cluster
+  float xytemp_[BXM2][BYM2];  //!< template for xy-reconstruction
+  float xypary0x0_[2][5];     //!< Polynomial error parameterization at ix0,iy0
+  float xypary1x0_[2][5];     //!< Polynomial error parameterization at ix0,iy1
+  float xypary0x1_[2][5];     //!< Polynomial error parameterization at ix1,iy0
+  float lanpar_[2][5];        //!< Interpolated Landau parameters
+  float chi2ppix_;            //!< average chi^2 per struck pixel
+  float chi2scale_;           //!< scale factor for chi2 distribution
+  float chi2avgone_;          //!< average chi^2 for 1 pixel clusters
+  float chi2minone_;          //!< minimum of chi^2 for 1 pixel clusters
+  float clsleny_;             //!< projected y-length of cluster
+  float clslenx_;             //!< projected x-length of cluster
+  float scalexavg_;           //!< average x-error scale factor
+  float scaleyavg_;           //!< average y-error scale factor
+  float delyavg_;             //!< average difference between clsleny_ and cluster length [with threshold effects]
+  float delysig_;             //!< rms of difference between clsleny_ and cluster length [with threshold effects]
+  float scalex_[4];           //!< x-error scale factor in charge bins
+  float scaley_[4];           //!< y-error scale factor in charge bins
+  float offsetx_[4];          //!< x-offset in charge bins
+  float offsety_[4];          //!< y-offset in charge bins
+  float mpvvav_;              //!< most probable Q in Vavilov distribution
+  float sigmavav_;            //!< scale factor in Vavilov distribution
+  float kappavav_;            //!< kappa parameter in Vavilov distribution
+  float lorywidth_;           //!< Lorentz y-width (sign corrected for fpix frame)
+  float lorxwidth_;           //!< Lorentz x-width
+  float lorydrift_;           //!< Lorentz y-drift
+  float lorxdrift_;           //!< Lorentz x-drift
+  float xsize_;               //!< Pixel x-size
+  float ysize_;               //!< Pixel y-size
+  float zsize_;               //!< Pixel z-size (thickness)
+  float fbin_[3];             //!< The QBin definitions in Q_clus/Q_avg
+  const SiPixelTemplateEntry2D* entry00_;  // Pointer to presently interpolated point [iy,ix]
+  const SiPixelTemplateEntry2D* entry10_;  // Pointer to presently interpolated point [iy+1,ix]
+  const SiPixelTemplateEntry2D* entry01_;  // Pointer to presently interpolated point [iy,ix+1]
+
+  // The actual template store is a std::vector container
+
+  const std::vector<SiPixelTemplateStore2D>& thePixelTemp_;
+};
 
 #endif

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
@@ -19,26 +19,26 @@
 //#define SI_PIXEL_TEMPLATE_USE_BOOST 1
 
 #define TYSIZE 21
-#define THY 10 // = TYSIZE/2
-#define THYP1 THY+1
-#define TYTEN 210 // = 10*TYSIZE
-#define BYSIZE TYSIZE+4
-#define BHY 12 // = BYSIZE/2
-#define BYM1 TYSIZE+3
-#define BYM2 TYSIZE+2
-#define BYM3 TYSIZE+1
+#define THY 10  // = TYSIZE/2
+#define THYP1 THY + 1
+#define TYTEN 210  // = 10*TYSIZE
+#define BYSIZE TYSIZE + 4
+#define BHY 12  // = BYSIZE/2
+#define BYM1 TYSIZE + 3
+#define BYM2 TYSIZE + 2
+#define BYM3 TYSIZE + 1
 #define TXSIZE 13
-#define THX 6 // = TXSIZE/2
-#define THXP1 THX+1
-#define BXSIZE TXSIZE+4
-#define BHX 8 // = BXSIZE/2
-#define BXM1 TXSIZE+3
-#define BXM2 TXSIZE+2
-#define BXM3 TXSIZE+1
+#define THX 6  // = TXSIZE/2
+#define THXP1 THX + 1
+#define BXSIZE TXSIZE + 4
+#define BHX 8  // = BXSIZE/2
+#define BXM1 TXSIZE + 3
+#define BXM2 TXSIZE + 2
+#define BXM3 TXSIZE + 1
 #define T2YSIZE 21
 #define T2XSIZE 7
-#define T2HY 10  // = T2YSIZE/2
-#define T2HYP1 T2HY+1 // = T2YSIZE/2+1
-#define T2HX 3  // = T2XSIZE/2
+#define T2HY 10          // = T2YSIZE/2
+#define T2HYP1 T2HY + 1  // = T2YSIZE/2+1
+#define T2HX 3           // = T2XSIZE/2
 
 #endif

--- a/CondFormats/SiPixelTransient/interface/SimplePixel.h
+++ b/CondFormats/SiPixelTransient/interface/SimplePixel.h
@@ -5,23 +5,28 @@
 #ifndef SimplePixel_h
 #define SimplePixel_h 1
 
+class SimplePixel {  //!< struck pixel class for use in simpletemplate2D
 
-class SimplePixel { //!< struck pixel class for use in simpletemplate2D
-   
 public:
-   
-   SimplePixel() {s = 0.; x = 0.; y = 0.; i = 0; j = 0; btype = 0;} //!< Default constructor
-   
-   bool operator < (const SimplePixel& rhs) const {return (this->s < rhs.s);}  //!< define < operator so that std::list can sort these by path length
-   
-   float s;     //!< distance from track entry
-   float x;     //!< x coordinate of boundary intersection
-   float y;     //!< y coordinate of boundary intersection
-   int i;       //!< x index of traversed pixel
-   int j;       //!< y index of traversed pixel
-   int btype;   //!< type of boundary (0=end, 1 = x-boundary, 2 = y-boundary)
-   
-} ;
+  SimplePixel() {
+    s = 0.;
+    x = 0.;
+    y = 0.;
+    i = 0;
+    j = 0;
+    btype = 0;
+  }  //!< Default constructor
 
+  bool operator<(const SimplePixel& rhs) const {
+    return (this->s < rhs.s);
+  }  //!< define < operator so that std::list can sort these by path length
+
+  float s;    //!< distance from track entry
+  float x;    //!< x coordinate of boundary intersection
+  float y;    //!< y coordinate of boundary intersection
+  int i;      //!< x index of traversed pixel
+  int j;      //!< y index of traversed pixel
+  int btype;  //!< type of boundary (0=end, 1 = x-boundary, 2 = y-boundary)
+};
 
 #endif

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -82,7 +82,6 @@
 //  V10.21 - Address runtime issues in pushfile() for gcc 7.X due to using tempfile as char string + misc. cleanup [Petar]
 //  V10.22 - Move templateStore to the heap, fix variable name in pushfile() [Petar]
 
-
 //  Created by Morris Swartz on 10/27/06.
 //
 //
@@ -100,8 +99,6 @@
 #include <sstream>
 #include <fstream>
 #include <list>
-
-
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
@@ -128,836 +125,1166 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename template_summary_zpNNNN
 //****************************************************************
-bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > & pixelTemp , std::string dir)
-{
-   // Add template stored in external file numbered filenum to theTemplateStore
-   
-   // Local variables
-   int i, j, k, l;
-   float qavg_avg;
-   char c;
-   const int code_version={17};
-   
-   //  Create a filename for this run
-   std::string tempfile = std::to_string(filenum);
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   // If integer filenum has less than 4 digits, prepend 0's until we have four numerical characters, e.g. "0292"
-   int nzeros = 4-tempfile.length();
-   if (nzeros > 0)
-     tempfile = std::string(nzeros, '0') + tempfile;
-   /// Alt implementation: for (unsigned cnt=4-tempfile.length(); cnt > 0; cnt-- ){ tempfile = "0" + tempfile; }
+bool SiPixelTemplate::pushfile(int filenum, std::vector<SiPixelTemplateStore>& pixelTemp, std::string dir) {
+  // Add template stored in external file numbered filenum to theTemplateStore
 
-   tempfile = dir + "template_summary_zp" + tempfile + ".out";
-   edm::FileInPath file( tempfile );         // Find the file in CMSSW
-   tempfile = file.fullPath();               // Put it back with the whole path.
+  // Local variables
+  int i, j, k, l;
+  float qavg_avg;
+  char c;
+  const int code_version = {17};
+
+  //  Create a filename for this run
+  std::string tempfile = std::to_string(filenum);
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  // If integer filenum has less than 4 digits, prepend 0's until we have four numerical characters, e.g. "0292"
+  int nzeros = 4 - tempfile.length();
+  if (nzeros > 0)
+    tempfile = std::string(nzeros, '0') + tempfile;
+  /// Alt implementation: for (unsigned cnt=4-tempfile.length(); cnt > 0; cnt-- ){ tempfile = "0" + tempfile; }
+
+  tempfile = dir + "template_summary_zp" + tempfile + ".out";
+  edm::FileInPath file(tempfile);  // Find the file in CMSSW
+  tempfile = file.fullPath();      // Put it back with the whole path.
 
 #else
-   // This is the same as above, but more elegant.  (Elegance not allowed in CMSSW...)
-   std::ostringstream tout;
-   tout << "template_summary_zp" << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
-   tempfile = tout.str();
+  // This is the same as above, but more elegant.  (Elegance not allowed in CMSSW...)
+  std::ostringstream tout;
+  tout << "template_summary_zp" << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
+  tempfile = tout.str();
 
 #endif
-   
-   //  Open the template file
-   //
-   std::ifstream in_file(tempfile);
-   if(in_file.is_open() && in_file.good()) {
-   
-      
-      // Create a local template storage entry
-      
-      SiPixelTemplateStore theCurrentTemp;
-      
-      // Read-in a header string first and print it
-      
-      for (i=0; (c=in_file.get()) != '\n'; ++i) {
-         if(i < 79) {theCurrentTemp.head.title[i] = c;}
-      }
-      if(i > 78) {i=78;}
-      theCurrentTemp.head.title[i+1] ='\0';
-      LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-      
-      // next, the header information
-      
-      in_file >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-      >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-      >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
-      
-      if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL; return false;}
-      
-      if(theCurrentTemp.head.templ_version > 17) {
-         in_file >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias
-         >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0]
-         >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0B, no template load"
-            << ENDL; return false;}
-      } else {
-         theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
-         theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
-         theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-         theCurrentTemp.head.fbin[0] = 1.5f;
-         theCurrentTemp.head.fbin[1] = 1.00f;
-         theCurrentTemp.head.fbin[2] = 0.85f;
-      }
-      
-      LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
-      << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
-      << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-      << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-      << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
-      << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
-      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
-      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1]
-      << ", " << theCurrentTemp.head.fbin[2]
-      << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
-      
-      
-      if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelTemplate") << "code expects version " << code_version << " finds "<< theCurrentTemp.head.templ_version <<", no template load" << ENDL; return false;}
-      
-#ifdef SI_PIXEL_TEMPLATE_USE_BOOST
-      
-      // next, layout the 1-d/2-d structures needed to store template
-      
-      theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
-      theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
-      theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
 
-      theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
-      
-      theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
-      
-#endif
-      
-      // next, loop over all y-angle entries
-      
-      for (i=0; i < theCurrentTemp.head.NTy; ++i) {
-         
-         in_file >> theCurrentTemp.enty[i].runnum >> theCurrentTemp.enty[i].costrk[0]
-         >> theCurrentTemp.enty[i].costrk[1] >> theCurrentTemp.enty[i].costrk[2];
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 1, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         // Calculate the alpha, beta, and cot(beta) for this entry
-         
-         theCurrentTemp.enty[i].alpha = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[0]));
-         
-         theCurrentTemp.enty[i].cotalpha = theCurrentTemp.enty[i].costrk[0]/theCurrentTemp.enty[i].costrk[2];
-         
-         theCurrentTemp.enty[i].beta = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[1]));
-         
-         theCurrentTemp.enty[i].cotbeta = theCurrentTemp.enty[i].costrk[1]/theCurrentTemp.enty[i].costrk[2];
-         
-         in_file >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].symax >> theCurrentTemp.enty[i].dyone
-         >> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].sxmax >> theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 2, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         in_file >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo
-         >> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >> theCurrentTemp.enty[i].clslenx;
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         
-         if(theCurrentTemp.enty[i].qmin <= 0.) {LOGERROR("SiPixelTemplate") << "Error in template ID " << theCurrentTemp.head.ID << " qmin = " << theCurrentTemp.enty[i].qmin << ", run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         
-         for (j=0; j<2; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].ypar[j][0] >> theCurrentTemp.enty[i].ypar[j][1]
-            >> theCurrentTemp.enty[i].ypar[j][2] >> theCurrentTemp.enty[i].ypar[j][3] >> theCurrentTemp.enty[i].ypar[j][4];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 4, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-            
-         }
-         
-         for (j=0; j<9; ++j) {
-            
-            for (k=0; k<TYSIZE; ++k) {in_file >> theCurrentTemp.enty[i].ytemp[j][k];}
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 5, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<2; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].xpar[j][0] >> theCurrentTemp.enty[i].xpar[j][1]
-            >> theCurrentTemp.enty[i].xpar[j][2] >> theCurrentTemp.enty[i].xpar[j][3] >> theCurrentTemp.enty[i].xpar[j][4];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 6, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-            
-         }
-         
-         qavg_avg = 0.f;
-         for (j=0; j<9; ++j) {
-            
-            for (k=0; k<TXSIZE; ++k) {in_file >> theCurrentTemp.enty[i].xtemp[j][k]; qavg_avg += theCurrentTemp.enty[i].xtemp[j][k];}
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 7, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         theCurrentTemp.enty[i].qavg_avg = qavg_avg/9.;
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].yavg[j] >> theCurrentTemp.enty[i].yrms[j] >> theCurrentTemp.enty[i].ygx0[j] >> theCurrentTemp.enty[i].ygsig[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 8, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].yflpar[j][0] >> theCurrentTemp.enty[i].yflpar[j][1] >> theCurrentTemp.enty[i].yflpar[j][2]
-            >> theCurrentTemp.enty[i].yflpar[j][3] >> theCurrentTemp.enty[i].yflpar[j][4] >> theCurrentTemp.enty[i].yflpar[j][5];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 9, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].xavg[j] >> theCurrentTemp.enty[i].xrms[j] >> theCurrentTemp.enty[i].xgx0[j] >> theCurrentTemp.enty[i].xgsig[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 10, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].xflpar[j][0] >> theCurrentTemp.enty[i].xflpar[j][1] >> theCurrentTemp.enty[i].xflpar[j][2]
-            >> theCurrentTemp.enty[i].xflpar[j][3] >> theCurrentTemp.enty[i].xflpar[j][4] >> theCurrentTemp.enty[i].xflpar[j][5];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 11, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].chi2yavg[j] >> theCurrentTemp.enty[i].chi2ymin[j] >> theCurrentTemp.enty[i].chi2xavg[j] >> theCurrentTemp.enty[i].chi2xmin[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 12, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].yavgc2m[j] >> theCurrentTemp.enty[i].yrmsc2m[j] >> theCurrentTemp.enty[i].chi2yavgc2m[j] >> theCurrentTemp.enty[i].chi2yminc2m[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 13, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].xavgc2m[j] >> theCurrentTemp.enty[i].xrmsc2m[j] >> theCurrentTemp.enty[i].chi2xavgc2m[j] >> theCurrentTemp.enty[i].chi2xminc2m[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >> theCurrentTemp.enty[i].ygx0gen[j] >> theCurrentTemp.enty[i].ygsiggen[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14a, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            in_file >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j] >> theCurrentTemp.enty[i].xgx0gen[j] >> theCurrentTemp.enty[i].xgsiggen[j];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14b, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         in_file >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >> theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2
-         >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >> theCurrentTemp.enty[i].r_qMeas_qTrue >> theCurrentTemp.enty[i].spare[0];
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         in_file >> theCurrentTemp.enty[i].mpvvav2 >> theCurrentTemp.enty[i].sigmavav2 >> theCurrentTemp.enty[i].kappavav2 >> theCurrentTemp.enty[i].qbfrac[0] >> theCurrentTemp.enty[i].qbfrac[1]
-         >> theCurrentTemp.enty[i].qbfrac[2] >> theCurrentTemp.enty[i].fracyone >> theCurrentTemp.enty[i].fracxone >> theCurrentTemp.enty[i].fracytwo >> theCurrentTemp.enty[i].fracxtwo;
-         //		theCurrentTemp.enty[i].qbfrac[3] = 1. - theCurrentTemp.enty[i].qbfrac[0] - theCurrentTemp.enty[i].qbfrac[1] - theCurrentTemp.enty[i].qbfrac[2];
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 16, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
+  //  Open the template file
+  //
+  std::ifstream in_file(tempfile);
+  if (in_file.is_open() && in_file.good()) {
+    // Create a local template storage entry
+
+    SiPixelTemplateStore theCurrentTemp;
+
+    // Read-in a header string first and print it
+
+    for (i = 0; (c = in_file.get()) != '\n'; ++i) {
+      if (i < 79) {
+        theCurrentTemp.head.title[i] = c;
       }
-      
-      // next, loop over all barrel x-angle entries
-      
-      for (k=0; k < theCurrentTemp.head.NTyx; ++k) {
-         
-         for (i=0; i < theCurrentTemp.head.NTxx; ++i) {
-            
-            in_file >> theCurrentTemp.entx[k][i].runnum >> theCurrentTemp.entx[k][i].costrk[0]
-            >> theCurrentTemp.entx[k][i].costrk[1] >> theCurrentTemp.entx[k][i].costrk[2];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 17, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            // Calculate the alpha, beta, and cot(beta) for this entry
-            
-            theCurrentTemp.entx[k][i].alpha = static_cast<float>(atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[0]));
-            
-            theCurrentTemp.entx[k][i].cotalpha = theCurrentTemp.entx[k][i].costrk[0]/theCurrentTemp.entx[k][i].costrk[2];
-            
-            theCurrentTemp.entx[k][i].beta = static_cast<float>(atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[1]));
-            
-            theCurrentTemp.entx[k][i].cotbeta = theCurrentTemp.entx[k][i].costrk[1]/theCurrentTemp.entx[k][i].costrk[2];
-            
-            in_file >> theCurrentTemp.entx[k][i].qavg >> theCurrentTemp.entx[k][i].pixmax >> theCurrentTemp.entx[k][i].symax >> theCurrentTemp.entx[k][i].dyone
-            >> theCurrentTemp.entx[k][i].syone >> theCurrentTemp.entx[k][i].sxmax >> theCurrentTemp.entx[k][i].dxone >> theCurrentTemp.entx[k][i].sxone;
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 18, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            in_file >> theCurrentTemp.entx[k][i].dytwo >> theCurrentTemp.entx[k][i].sytwo >> theCurrentTemp.entx[k][i].dxtwo
-            >> theCurrentTemp.entx[k][i].sxtwo >> theCurrentTemp.entx[k][i].qmin >> theCurrentTemp.entx[k][i].clsleny >> theCurrentTemp.entx[k][i].clslenx;
-            //			   >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav;
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 19, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            for (j=0; j<2; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].ypar[j][0] >> theCurrentTemp.entx[k][i].ypar[j][1]
-               >> theCurrentTemp.entx[k][i].ypar[j][2] >> theCurrentTemp.entx[k][i].ypar[j][3] >> theCurrentTemp.entx[k][i].ypar[j][4];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 20, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<9; ++j) {
-               
-               for (l=0; l<TYSIZE; ++l) {in_file >> theCurrentTemp.entx[k][i].ytemp[j][l];}
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 21, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<2; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].xpar[j][0] >> theCurrentTemp.entx[k][i].xpar[j][1]
-               >> theCurrentTemp.entx[k][i].xpar[j][2] >> theCurrentTemp.entx[k][i].xpar[j][3] >> theCurrentTemp.entx[k][i].xpar[j][4];
-               
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 22, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            qavg_avg = 0.f;
-            for (j=0; j<9; ++j) {
-               
-               for (l=0; l<TXSIZE; ++l) {in_file >> theCurrentTemp.entx[k][i].xtemp[j][l]; qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];}
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 23, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            theCurrentTemp.entx[k][i].qavg_avg = qavg_avg/9.;
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].yavg[j] >> theCurrentTemp.entx[k][i].yrms[j] >> theCurrentTemp.entx[k][i].ygx0[j] >> theCurrentTemp.entx[k][i].ygsig[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 24, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].yflpar[j][0] >> theCurrentTemp.entx[k][i].yflpar[j][1] >> theCurrentTemp.entx[k][i].yflpar[j][2]
-               >> theCurrentTemp.entx[k][i].yflpar[j][3] >> theCurrentTemp.entx[k][i].yflpar[j][4] >> theCurrentTemp.entx[k][i].yflpar[j][5];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 25, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].xavg[j] >> theCurrentTemp.entx[k][i].xrms[j] >> theCurrentTemp.entx[k][i].xgx0[j] >> theCurrentTemp.entx[k][i].xgsig[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 26, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].xflpar[j][0] >> theCurrentTemp.entx[k][i].xflpar[j][1] >> theCurrentTemp.entx[k][i].xflpar[j][2]
-               >> theCurrentTemp.entx[k][i].xflpar[j][3] >> theCurrentTemp.entx[k][i].xflpar[j][4] >> theCurrentTemp.entx[k][i].xflpar[j][5];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 27, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].chi2yavg[j] >> theCurrentTemp.entx[k][i].chi2ymin[j] >> theCurrentTemp.entx[k][i].chi2xavg[j] >> theCurrentTemp.entx[k][i].chi2xmin[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 28, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].yavgc2m[j] >> theCurrentTemp.entx[k][i].yrmsc2m[j] >> theCurrentTemp.entx[k][i].chi2yavgc2m[j] >> theCurrentTemp.entx[k][i].chi2yminc2m[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 29, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].xavgc2m[j] >> theCurrentTemp.entx[k][i].xrmsc2m[j] >> theCurrentTemp.entx[k][i].chi2xavgc2m[j] >> theCurrentTemp.entx[k][i].chi2xminc2m[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 30, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].yavggen[j] >> theCurrentTemp.entx[k][i].yrmsgen[j] >> theCurrentTemp.entx[k][i].ygx0gen[j] >> theCurrentTemp.entx[k][i].ygsiggen[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 30a, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               in_file >> theCurrentTemp.entx[k][i].xavggen[j] >> theCurrentTemp.entx[k][i].xrmsgen[j] >> theCurrentTemp.entx[k][i].xgx0gen[j] >> theCurrentTemp.entx[k][i].xgsiggen[j];
-               
-               if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 30b, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            in_file >> theCurrentTemp.entx[k][i].chi2yavgone >> theCurrentTemp.entx[k][i].chi2yminone >> theCurrentTemp.entx[k][i].chi2xavgone >> theCurrentTemp.entx[k][i].chi2xminone >> theCurrentTemp.entx[k][i].qmin2
-            >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].r_qMeas_qTrue >> theCurrentTemp.entx[k][i].spare[0];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 31, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            in_file >> theCurrentTemp.entx[k][i].mpvvav2 >> theCurrentTemp.entx[k][i].sigmavav2 >> theCurrentTemp.entx[k][i].kappavav2 >> theCurrentTemp.entx[k][i].qbfrac[0] >> theCurrentTemp.entx[k][i].qbfrac[1]
-            >> theCurrentTemp.entx[k][i].qbfrac[2] >> theCurrentTemp.entx[k][i].fracyone >> theCurrentTemp.entx[k][i].fracxone >> theCurrentTemp.entx[k][i].fracytwo >> theCurrentTemp.entx[k][i].fracxtwo;
-            //		theCurrentTemp.entx[k][i].qbfrac[3] = 1. - theCurrentTemp.entx[k][i].qbfrac[0] - theCurrentTemp.entx[k][i].qbfrac[1] - theCurrentTemp.entx[k][i].qbfrac[2];
-            
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 32, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-         }
-      }
-      
-      
-      in_file.close();
-      
-      // Add this template to the store
-      
-      pixelTemp.push_back(theCurrentTemp);
-      
-      postInit(pixelTemp);
-      return true;
-      
-   } else {
-      
-      // If file didn't open, report this
-      
-      LOGERROR("SiPixelTemplate") << "Error opening File" << tempfile << ENDL;
+    }
+    if (i > 78) {
+      i = 78;
+    }
+    theCurrentTemp.head.title[i + 1] = '\0';
+    LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
+
+    // next, the header information
+
+    in_file >> theCurrentTemp.head.ID >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >>
+        theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >>
+        theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >>
+        theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >>
+        theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
+        theCurrentTemp.head.zsize;
+
+    if (in_file.fail()) {
+      LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL;
       return false;
-      
-   }
-   
-} // TempInit
+    }
 
+    if (theCurrentTemp.head.templ_version > 17) {
+      in_file >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
+          theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 0B, no template load" << ENDL;
+        return false;
+      }
+    } else {
+      theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+      theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth / 2.f;
+      theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth / 2.f;
+      theCurrentTemp.head.fbin[0] = 1.5f;
+      theCurrentTemp.head.fbin[1] = 1.00f;
+      theCurrentTemp.head.fbin[2] = 0.85f;
+    }
+
+    LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
+                               << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
+                               << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx
+                               << ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
+                               << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+                               << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
+                               << ", Q-scaling factor " << theCurrentTemp.head.qscale << ", 1/2 multi dcol threshold "
+                               << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
+                               << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias "
+                               << theCurrentTemp.head.lorybias << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
+                               << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+                               << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", "
+                               << theCurrentTemp.head.fbin[1] << ", " << theCurrentTemp.head.fbin[2]
+                               << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size "
+                               << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+
+    if (theCurrentTemp.head.templ_version < code_version) {
+      LOGERROR("SiPixelTemplate") << "code expects version " << code_version << " finds "
+                                  << theCurrentTemp.head.templ_version << ", no template load" << ENDL;
+      return false;
+    }
+
+#ifdef SI_PIXEL_TEMPLATE_USE_BOOST
+
+    // next, layout the 1-d/2-d structures needed to store template
+
+    theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
+    theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
+    theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
+
+    theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
+
+    theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
+
+#endif
+
+    // next, loop over all y-angle entries
+
+    for (i = 0; i < theCurrentTemp.head.NTy; ++i) {
+      in_file >> theCurrentTemp.enty[i].runnum >> theCurrentTemp.enty[i].costrk[0] >>
+          theCurrentTemp.enty[i].costrk[1] >> theCurrentTemp.enty[i].costrk[2];
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 1, no template load, run # " << theCurrentTemp.enty[i].runnum
+                                    << ENDL;
+        return false;
+      }
+
+      // Calculate the alpha, beta, and cot(beta) for this entry
+
+      theCurrentTemp.enty[i].alpha =
+          static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[0]));
+
+      theCurrentTemp.enty[i].cotalpha = theCurrentTemp.enty[i].costrk[0] / theCurrentTemp.enty[i].costrk[2];
+
+      theCurrentTemp.enty[i].beta =
+          static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[1]));
+
+      theCurrentTemp.enty[i].cotbeta = theCurrentTemp.enty[i].costrk[1] / theCurrentTemp.enty[i].costrk[2];
+
+      in_file >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].symax >>
+          theCurrentTemp.enty[i].dyone >> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].sxmax >>
+          theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 2, no template load, run # " << theCurrentTemp.enty[i].runnum
+                                    << ENDL;
+        return false;
+      }
+
+      in_file >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo >>
+          theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >>
+          theCurrentTemp.enty[i].clslenx;
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum
+                                    << ENDL;
+        return false;
+      }
+
+      if (theCurrentTemp.enty[i].qmin <= 0.) {
+        LOGERROR("SiPixelTemplate") << "Error in template ID " << theCurrentTemp.head.ID
+                                    << " qmin = " << theCurrentTemp.enty[i].qmin << ", run # "
+                                    << theCurrentTemp.enty[i].runnum << ENDL;
+        return false;
+      }
+
+      for (j = 0; j < 2; ++j) {
+        in_file >> theCurrentTemp.enty[i].ypar[j][0] >> theCurrentTemp.enty[i].ypar[j][1] >>
+            theCurrentTemp.enty[i].ypar[j][2] >> theCurrentTemp.enty[i].ypar[j][3] >> theCurrentTemp.enty[i].ypar[j][4];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 4, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 9; ++j) {
+        for (k = 0; k < TYSIZE; ++k) {
+          in_file >> theCurrentTemp.enty[i].ytemp[j][k];
+        }
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 5, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 2; ++j) {
+        in_file >> theCurrentTemp.enty[i].xpar[j][0] >> theCurrentTemp.enty[i].xpar[j][1] >>
+            theCurrentTemp.enty[i].xpar[j][2] >> theCurrentTemp.enty[i].xpar[j][3] >> theCurrentTemp.enty[i].xpar[j][4];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 6, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      qavg_avg = 0.f;
+      for (j = 0; j < 9; ++j) {
+        for (k = 0; k < TXSIZE; ++k) {
+          in_file >> theCurrentTemp.enty[i].xtemp[j][k];
+          qavg_avg += theCurrentTemp.enty[i].xtemp[j][k];
+        }
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 7, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+      theCurrentTemp.enty[i].qavg_avg = qavg_avg / 9.;
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].yavg[j] >> theCurrentTemp.enty[i].yrms[j] >> theCurrentTemp.enty[i].ygx0[j] >>
+            theCurrentTemp.enty[i].ygsig[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 8, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].yflpar[j][0] >> theCurrentTemp.enty[i].yflpar[j][1] >>
+            theCurrentTemp.enty[i].yflpar[j][2] >> theCurrentTemp.enty[i].yflpar[j][3] >>
+            theCurrentTemp.enty[i].yflpar[j][4] >> theCurrentTemp.enty[i].yflpar[j][5];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 9, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].xavg[j] >> theCurrentTemp.enty[i].xrms[j] >> theCurrentTemp.enty[i].xgx0[j] >>
+            theCurrentTemp.enty[i].xgsig[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 10, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].xflpar[j][0] >> theCurrentTemp.enty[i].xflpar[j][1] >>
+            theCurrentTemp.enty[i].xflpar[j][2] >> theCurrentTemp.enty[i].xflpar[j][3] >>
+            theCurrentTemp.enty[i].xflpar[j][4] >> theCurrentTemp.enty[i].xflpar[j][5];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 11, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].chi2yavg[j] >> theCurrentTemp.enty[i].chi2ymin[j] >>
+            theCurrentTemp.enty[i].chi2xavg[j] >> theCurrentTemp.enty[i].chi2xmin[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 12, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].yavgc2m[j] >> theCurrentTemp.enty[i].yrmsc2m[j] >>
+            theCurrentTemp.enty[i].chi2yavgc2m[j] >> theCurrentTemp.enty[i].chi2yminc2m[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 13, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].xavgc2m[j] >> theCurrentTemp.enty[i].xrmsc2m[j] >>
+            theCurrentTemp.enty[i].chi2xavgc2m[j] >> theCurrentTemp.enty[i].chi2xminc2m[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 14, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >>
+            theCurrentTemp.enty[i].ygx0gen[j] >> theCurrentTemp.enty[i].ygsiggen[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 14a, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        in_file >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j] >>
+            theCurrentTemp.enty[i].xgx0gen[j] >> theCurrentTemp.enty[i].xgsiggen[j];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 14b, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      in_file >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >>
+          theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2 >>
+          theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >>
+          theCurrentTemp.enty[i].r_qMeas_qTrue >> theCurrentTemp.enty[i].spare[0];
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # "
+                                    << theCurrentTemp.enty[i].runnum << ENDL;
+        return false;
+      }
+
+      in_file >> theCurrentTemp.enty[i].mpvvav2 >> theCurrentTemp.enty[i].sigmavav2 >>
+          theCurrentTemp.enty[i].kappavav2 >> theCurrentTemp.enty[i].qbfrac[0] >> theCurrentTemp.enty[i].qbfrac[1] >>
+          theCurrentTemp.enty[i].qbfrac[2] >> theCurrentTemp.enty[i].fracyone >> theCurrentTemp.enty[i].fracxone >>
+          theCurrentTemp.enty[i].fracytwo >> theCurrentTemp.enty[i].fracxtwo;
+      //		theCurrentTemp.enty[i].qbfrac[3] = 1. - theCurrentTemp.enty[i].qbfrac[0] - theCurrentTemp.enty[i].qbfrac[1] - theCurrentTemp.enty[i].qbfrac[2];
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 16, no template load, run # "
+                                    << theCurrentTemp.enty[i].runnum << ENDL;
+        return false;
+      }
+    }
+
+    // next, loop over all barrel x-angle entries
+
+    for (k = 0; k < theCurrentTemp.head.NTyx; ++k) {
+      for (i = 0; i < theCurrentTemp.head.NTxx; ++i) {
+        in_file >> theCurrentTemp.entx[k][i].runnum >> theCurrentTemp.entx[k][i].costrk[0] >>
+            theCurrentTemp.entx[k][i].costrk[1] >> theCurrentTemp.entx[k][i].costrk[2];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 17, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        // Calculate the alpha, beta, and cot(beta) for this entry
+
+        theCurrentTemp.entx[k][i].alpha = static_cast<float>(
+            atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[0]));
+
+        theCurrentTemp.entx[k][i].cotalpha = theCurrentTemp.entx[k][i].costrk[0] / theCurrentTemp.entx[k][i].costrk[2];
+
+        theCurrentTemp.entx[k][i].beta = static_cast<float>(
+            atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[1]));
+
+        theCurrentTemp.entx[k][i].cotbeta = theCurrentTemp.entx[k][i].costrk[1] / theCurrentTemp.entx[k][i].costrk[2];
+
+        in_file >> theCurrentTemp.entx[k][i].qavg >> theCurrentTemp.entx[k][i].pixmax >>
+            theCurrentTemp.entx[k][i].symax >> theCurrentTemp.entx[k][i].dyone >> theCurrentTemp.entx[k][i].syone >>
+            theCurrentTemp.entx[k][i].sxmax >> theCurrentTemp.entx[k][i].dxone >> theCurrentTemp.entx[k][i].sxone;
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 18, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        in_file >> theCurrentTemp.entx[k][i].dytwo >> theCurrentTemp.entx[k][i].sytwo >>
+            theCurrentTemp.entx[k][i].dxtwo >> theCurrentTemp.entx[k][i].sxtwo >> theCurrentTemp.entx[k][i].qmin >>
+            theCurrentTemp.entx[k][i].clsleny >> theCurrentTemp.entx[k][i].clslenx;
+        //			   >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav;
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 19, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        for (j = 0; j < 2; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].ypar[j][0] >> theCurrentTemp.entx[k][i].ypar[j][1] >>
+              theCurrentTemp.entx[k][i].ypar[j][2] >> theCurrentTemp.entx[k][i].ypar[j][3] >>
+              theCurrentTemp.entx[k][i].ypar[j][4];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 20, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 9; ++j) {
+          for (l = 0; l < TYSIZE; ++l) {
+            in_file >> theCurrentTemp.entx[k][i].ytemp[j][l];
+          }
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 21, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 2; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].xpar[j][0] >> theCurrentTemp.entx[k][i].xpar[j][1] >>
+              theCurrentTemp.entx[k][i].xpar[j][2] >> theCurrentTemp.entx[k][i].xpar[j][3] >>
+              theCurrentTemp.entx[k][i].xpar[j][4];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 22, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        qavg_avg = 0.f;
+        for (j = 0; j < 9; ++j) {
+          for (l = 0; l < TXSIZE; ++l) {
+            in_file >> theCurrentTemp.entx[k][i].xtemp[j][l];
+            qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];
+          }
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 23, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+        theCurrentTemp.entx[k][i].qavg_avg = qavg_avg / 9.;
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].yavg[j] >> theCurrentTemp.entx[k][i].yrms[j] >>
+              theCurrentTemp.entx[k][i].ygx0[j] >> theCurrentTemp.entx[k][i].ygsig[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 24, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].yflpar[j][0] >> theCurrentTemp.entx[k][i].yflpar[j][1] >>
+              theCurrentTemp.entx[k][i].yflpar[j][2] >> theCurrentTemp.entx[k][i].yflpar[j][3] >>
+              theCurrentTemp.entx[k][i].yflpar[j][4] >> theCurrentTemp.entx[k][i].yflpar[j][5];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 25, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].xavg[j] >> theCurrentTemp.entx[k][i].xrms[j] >>
+              theCurrentTemp.entx[k][i].xgx0[j] >> theCurrentTemp.entx[k][i].xgsig[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 26, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].xflpar[j][0] >> theCurrentTemp.entx[k][i].xflpar[j][1] >>
+              theCurrentTemp.entx[k][i].xflpar[j][2] >> theCurrentTemp.entx[k][i].xflpar[j][3] >>
+              theCurrentTemp.entx[k][i].xflpar[j][4] >> theCurrentTemp.entx[k][i].xflpar[j][5];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 27, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].chi2yavg[j] >> theCurrentTemp.entx[k][i].chi2ymin[j] >>
+              theCurrentTemp.entx[k][i].chi2xavg[j] >> theCurrentTemp.entx[k][i].chi2xmin[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 28, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].yavgc2m[j] >> theCurrentTemp.entx[k][i].yrmsc2m[j] >>
+              theCurrentTemp.entx[k][i].chi2yavgc2m[j] >> theCurrentTemp.entx[k][i].chi2yminc2m[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 29, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].xavgc2m[j] >> theCurrentTemp.entx[k][i].xrmsc2m[j] >>
+              theCurrentTemp.entx[k][i].chi2xavgc2m[j] >> theCurrentTemp.entx[k][i].chi2xminc2m[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 30, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].yavggen[j] >> theCurrentTemp.entx[k][i].yrmsgen[j] >>
+              theCurrentTemp.entx[k][i].ygx0gen[j] >> theCurrentTemp.entx[k][i].ygsiggen[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 30a, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          in_file >> theCurrentTemp.entx[k][i].xavggen[j] >> theCurrentTemp.entx[k][i].xrmsgen[j] >>
+              theCurrentTemp.entx[k][i].xgx0gen[j] >> theCurrentTemp.entx[k][i].xgsiggen[j];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 30b, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        in_file >> theCurrentTemp.entx[k][i].chi2yavgone >> theCurrentTemp.entx[k][i].chi2yminone >>
+            theCurrentTemp.entx[k][i].chi2xavgone >> theCurrentTemp.entx[k][i].chi2xminone >>
+            theCurrentTemp.entx[k][i].qmin2 >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >>
+            theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].r_qMeas_qTrue >>
+            theCurrentTemp.entx[k][i].spare[0];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 31, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        in_file >> theCurrentTemp.entx[k][i].mpvvav2 >> theCurrentTemp.entx[k][i].sigmavav2 >>
+            theCurrentTemp.entx[k][i].kappavav2 >> theCurrentTemp.entx[k][i].qbfrac[0] >>
+            theCurrentTemp.entx[k][i].qbfrac[1] >> theCurrentTemp.entx[k][i].qbfrac[2] >>
+            theCurrentTemp.entx[k][i].fracyone >> theCurrentTemp.entx[k][i].fracxone >>
+            theCurrentTemp.entx[k][i].fracytwo >> theCurrentTemp.entx[k][i].fracxtwo;
+        //		theCurrentTemp.entx[k][i].qbfrac[3] = 1. - theCurrentTemp.entx[k][i].qbfrac[0] - theCurrentTemp.entx[k][i].qbfrac[1] - theCurrentTemp.entx[k][i].qbfrac[2];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 32, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+      }
+    }
+
+    in_file.close();
+
+    // Add this template to the store
+
+    pixelTemp.push_back(theCurrentTemp);
+
+    postInit(pixelTemp);
+    return true;
+
+  } else {
+    // If file didn't open, report this
+
+    LOGERROR("SiPixelTemplate") << "Error opening File" << tempfile << ENDL;
+    return false;
+  }
+
+}  // TempInit
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-
 
 //****************************************************************
 //! This routine initializes the global template structures from an
 //! external file template_summary_zpNNNN where NNNN are four digits
 //! \param dbobject - db storing multiple template calibrations
 //****************************************************************
-bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & pixelTemp)
-{
-   // Add template stored in external dbobject to theTemplateStore
-   
-   // Local variables
-   int i, j, k, l;
-   float qavg_avg;
-   const int code_version={17};
-   
-   // We must create a new object because dbobject must be a const and our stream must not be
-   auto db(dbobject.reader());
-   
-   // Create a local template storage entry
-   /// SiPixelTemplateStore theCurrentTemp;    // large, don't allocate it on the stack
-   auto tmpPtr = std::make_unique<SiPixelTemplateStore>(); // must be allocated on the heap instead
-   auto & theCurrentTemp = *tmpPtr;
+bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vector<SiPixelTemplateStore>& pixelTemp) {
+  // Add template stored in external dbobject to theTemplateStore
 
-   // Fill the template storage for each template calibration stored in the db
-   for(int m=0; m<db.numOfTempl(); ++m) {
-      
-      // Read-in a header string first and print it
-      
-      SiPixelTemplateDBObject::char2float temp;
-      for (i=0; i<20; ++i) {
-         temp.f = db.sVector()[db.index()];
-         theCurrentTemp.head.title[4*i] = temp.c[0];
-         theCurrentTemp.head.title[4*i+1] = temp.c[1];
-         theCurrentTemp.head.title[4*i+2] = temp.c[2];
-         theCurrentTemp.head.title[4*i+3] = temp.c[3];
-         db.incrementIndex(1);
+  // Local variables
+  int i, j, k, l;
+  float qavg_avg;
+  const int code_version = {17};
+
+  // We must create a new object because dbobject must be a const and our stream must not be
+  auto db(dbobject.reader());
+
+  // Create a local template storage entry
+  /// SiPixelTemplateStore theCurrentTemp;    // large, don't allocate it on the stack
+  auto tmpPtr = std::make_unique<SiPixelTemplateStore>();  // must be allocated on the heap instead
+  auto& theCurrentTemp = *tmpPtr;
+
+  // Fill the template storage for each template calibration stored in the db
+  for (int m = 0; m < db.numOfTempl(); ++m) {
+    // Read-in a header string first and print it
+
+    SiPixelTemplateDBObject::char2float temp;
+    for (i = 0; i < 20; ++i) {
+      temp.f = db.sVector()[db.index()];
+      theCurrentTemp.head.title[4 * i] = temp.c[0];
+      theCurrentTemp.head.title[4 * i + 1] = temp.c[1];
+      theCurrentTemp.head.title[4 * i + 2] = temp.c[2];
+      theCurrentTemp.head.title[4 * i + 3] = temp.c[3];
+      db.incrementIndex(1);
+    }
+    theCurrentTemp.head.title[79] = '\0';
+    LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
+
+    // next, the header information
+
+    db >> theCurrentTemp.head.ID >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >>
+        theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >>
+        theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >>
+        theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >>
+        theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
+        theCurrentTemp.head.zsize;
+
+    if (db.fail()) {
+      LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL;
+      return false;
+    }
+
+    LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title
+                               << " code version = " << code_version << " object version "
+                               << theCurrentTemp.head.templ_version << ENDL;
+
+    if (theCurrentTemp.head.templ_version > 17) {
+      db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
+          theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 0B, no template load" << ENDL;
+        return false;
       }
-      theCurrentTemp.head.title[79] = '\0';
-      LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-	  	  
-      // next, the header information
-      
-      db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-	     >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-	     >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
-      
-      if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0A, no template load" << ENDL; return false;}
-      
-      LOGINFO("SiPixelTemplate") << "Loading Pixel Template File - " << theCurrentTemp.head.title
-      <<" code version = "<<code_version
-      <<" object version "<<theCurrentTemp.head.templ_version
-      << ENDL;
-      
-      if(theCurrentTemp.head.templ_version > 17) {
-         db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 0B, no template load"
-            << ENDL; return false;}
-      } else {
-         theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
-         theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
-         theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-         theCurrentTemp.head.fbin[0] = 1.50f;
-         theCurrentTemp.head.fbin[1] = 1.00f;
-         theCurrentTemp.head.fbin[2] = 0.85f;
-         //std::cout<<" set fbin  "<< theCurrentTemp.head.fbin[0]<<" "<<theCurrentTemp.head.fbin[1]<<" "
-         //	     <<theCurrentTemp.head.fbin[2]<<std::endl;
-      }
-      
-      LOGINFO("SiPixelTemplate")
-      << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
-      << theCurrentTemp.head.templ_version << ", Bfield = "
-      << theCurrentTemp.head.Bfield<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = "
-      << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = "
-      << theCurrentTemp.head.Dtype<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-      << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
-      << ", Q-scaling factor " << theCurrentTemp.head.qscale
-      << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
-      << theCurrentTemp.head.ss50<< ", y Lorentz Width " << theCurrentTemp.head.lorywidth
-      << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
-      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
-      << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
-      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0]
-      << ", " << theCurrentTemp.head.fbin[1]
-      << ", " << theCurrentTemp.head.fbin[2]
-      << ", pixel x-size " << theCurrentTemp.head.xsize
-      << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
-      
-      if(theCurrentTemp.head.templ_version < code_version) {
-         LOGINFO("SiPixelTemplate") << "code expects version "<< code_version << " finds "
-         << theCurrentTemp.head.templ_version <<", load anyway " << ENDL;
-         //return false; // dk
-      }
-      
-      
+    } else {
+      theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+      theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth / 2.f;
+      theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth / 2.f;
+      theCurrentTemp.head.fbin[0] = 1.50f;
+      theCurrentTemp.head.fbin[1] = 1.00f;
+      theCurrentTemp.head.fbin[2] = 0.85f;
+      //std::cout<<" set fbin  "<< theCurrentTemp.head.fbin[0]<<" "<<theCurrentTemp.head.fbin[1]<<" "
+      //	     <<theCurrentTemp.head.fbin[2]<<std::endl;
+    }
+
+    LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
+                               << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
+                               << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx
+                               << ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
+                               << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+                               << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
+                               << ", Q-scaling factor " << theCurrentTemp.head.qscale << ", 1/2 multi dcol threshold "
+                               << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
+                               << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias "
+                               << theCurrentTemp.head.lorybias << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
+                               << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+                               << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", "
+                               << theCurrentTemp.head.fbin[1] << ", " << theCurrentTemp.head.fbin[2]
+                               << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size "
+                               << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+
+    if (theCurrentTemp.head.templ_version < code_version) {
+      LOGINFO("SiPixelTemplate") << "code expects version " << code_version << " finds "
+                                 << theCurrentTemp.head.templ_version << ", load anyway " << ENDL;
+      //return false; // dk
+    }
+
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST
-      
-      // next, layout the 1-d/2-d structures needed to store template
-      theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
-      theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
-      theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
-      theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
-      theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
-      
-#endif
-      
-      // next, loop over all barrel y-angle entries
-      
-      for (i=0; i < theCurrentTemp.head.NTy; ++i) {
-         
-         db >> theCurrentTemp.enty[i].runnum >> theCurrentTemp.enty[i].costrk[0]
-         >> theCurrentTemp.enty[i].costrk[1] >> theCurrentTemp.enty[i].costrk[2];
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 1, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         // Calculate the alpha, beta, and cot(beta) for this entry
-         
-         theCurrentTemp.enty[i].alpha = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[0]));
-         
-         theCurrentTemp.enty[i].cotalpha = theCurrentTemp.enty[i].costrk[0]/theCurrentTemp.enty[i].costrk[2];
-         
-         theCurrentTemp.enty[i].beta = static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[1]));
-         
-         theCurrentTemp.enty[i].cotbeta = theCurrentTemp.enty[i].costrk[1]/theCurrentTemp.enty[i].costrk[2];
-         
-         db >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].symax >> theCurrentTemp.enty[i].dyone
-         >> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].sxmax >> theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 2, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         db >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo
-         >> theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >> theCurrentTemp.enty[i].clslenx;
-         //			     >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav;
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         if(theCurrentTemp.enty[i].qmin <= 0.) {LOGERROR("SiPixelTemplate") << "Error in template ID " << theCurrentTemp.head.ID << " qmin = " << theCurrentTemp.enty[i].qmin << ", run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         for (j=0; j<2; ++j) {
-            
-            db >> theCurrentTemp.enty[i].ypar[j][0] >> theCurrentTemp.enty[i].ypar[j][1]
-            >> theCurrentTemp.enty[i].ypar[j][2] >> theCurrentTemp.enty[i].ypar[j][3] >> theCurrentTemp.enty[i].ypar[j][4];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 4, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-            
-         }
-         
-         for (j=0; j<9; ++j) {
-            
-            for (k=0; k<TYSIZE; ++k) {db >> theCurrentTemp.enty[i].ytemp[j][k];}
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 5, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<2; ++j) {
-            
-            db >> theCurrentTemp.enty[i].xpar[j][0] >> theCurrentTemp.enty[i].xpar[j][1]
-            >> theCurrentTemp.enty[i].xpar[j][2] >> theCurrentTemp.enty[i].xpar[j][3] >> theCurrentTemp.enty[i].xpar[j][4];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 6, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-            
-         }
-         
-         qavg_avg = 0.f;
-         for (j=0; j<9; ++j) {
-            
-            for (k=0; k<TXSIZE; ++k) {db >> theCurrentTemp.enty[i].xtemp[j][k]; qavg_avg += theCurrentTemp.enty[i].xtemp[j][k];}
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 7, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         theCurrentTemp.enty[i].qavg_avg = qavg_avg/9.;
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].yavg[j] >> theCurrentTemp.enty[i].yrms[j] >> theCurrentTemp.enty[i].ygx0[j] >> theCurrentTemp.enty[i].ygsig[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 8, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].yflpar[j][0] >> theCurrentTemp.enty[i].yflpar[j][1] >> theCurrentTemp.enty[i].yflpar[j][2]
-            >> theCurrentTemp.enty[i].yflpar[j][3] >> theCurrentTemp.enty[i].yflpar[j][4] >> theCurrentTemp.enty[i].yflpar[j][5];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 9, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].xavg[j] >> theCurrentTemp.enty[i].xrms[j] >> theCurrentTemp.enty[i].xgx0[j] >> theCurrentTemp.enty[i].xgsig[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 10, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].xflpar[j][0] >> theCurrentTemp.enty[i].xflpar[j][1] >> theCurrentTemp.enty[i].xflpar[j][2]
-            >> theCurrentTemp.enty[i].xflpar[j][3] >> theCurrentTemp.enty[i].xflpar[j][4] >> theCurrentTemp.enty[i].xflpar[j][5];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 11, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].chi2yavg[j] >> theCurrentTemp.enty[i].chi2ymin[j] >> theCurrentTemp.enty[i].chi2xavg[j] >> theCurrentTemp.enty[i].chi2xmin[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 12, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].yavgc2m[j] >> theCurrentTemp.enty[i].yrmsc2m[j] >> theCurrentTemp.enty[i].chi2yavgc2m[j] >> theCurrentTemp.enty[i].chi2yminc2m[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 13, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].xavgc2m[j] >> theCurrentTemp.enty[i].xrmsc2m[j] >> theCurrentTemp.enty[i].chi2xavgc2m[j] >> theCurrentTemp.enty[i].chi2xminc2m[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >> theCurrentTemp.enty[i].ygx0gen[j] >> theCurrentTemp.enty[i].ygsiggen[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14a, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         for (j=0; j<4; ++j) {
-            
-            db >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j] >> theCurrentTemp.enty[i].xgx0gen[j] >> theCurrentTemp.enty[i].xgsiggen[j];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 14b, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         }
-         
-         
-         db >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >> theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2
-         >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >> theCurrentTemp.enty[i].r_qMeas_qTrue >> theCurrentTemp.enty[i].spare[0];
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-         db >> theCurrentTemp.enty[i].mpvvav2 >> theCurrentTemp.enty[i].sigmavav2 >> theCurrentTemp.enty[i].kappavav2 >> theCurrentTemp.enty[i].qbfrac[0] >> theCurrentTemp.enty[i].qbfrac[1]
-         >> theCurrentTemp.enty[i].qbfrac[2] >> theCurrentTemp.enty[i].fracyone >> theCurrentTemp.enty[i].fracxone >> theCurrentTemp.enty[i].fracytwo >> theCurrentTemp.enty[i].fracxtwo;
-         //			theCurrentTemp.enty[i].qbfrac[3] = 1. - theCurrentTemp.enty[i].qbfrac[0] - theCurrentTemp.enty[i].qbfrac[1] - theCurrentTemp.enty[i].qbfrac[2];
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 16, no template load, run # " << theCurrentTemp.enty[i].runnum << ENDL; return false;}
-         
-      }
-      
-      // next, loop over all barrel x-angle entries
-      
-      for (k=0; k < theCurrentTemp.head.NTyx; ++k) {
-         
-         for (i=0; i < theCurrentTemp.head.NTxx; ++i) {
-            
-            db >> theCurrentTemp.entx[k][i].runnum >> theCurrentTemp.entx[k][i].costrk[0]
-            >> theCurrentTemp.entx[k][i].costrk[1] >> theCurrentTemp.entx[k][i].costrk[2];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 17, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            // Calculate the alpha, beta, and cot(beta) for this entry
-            
-            theCurrentTemp.entx[k][i].alpha = static_cast<float>(atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[0]));
-            
-            theCurrentTemp.entx[k][i].cotalpha = theCurrentTemp.entx[k][i].costrk[0]/theCurrentTemp.entx[k][i].costrk[2];
-            
-            theCurrentTemp.entx[k][i].beta = static_cast<float>(atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[1]));
-            
-            theCurrentTemp.entx[k][i].cotbeta = theCurrentTemp.entx[k][i].costrk[1]/theCurrentTemp.entx[k][i].costrk[2];
-            
-            db >> theCurrentTemp.entx[k][i].qavg >> theCurrentTemp.entx[k][i].pixmax >> theCurrentTemp.entx[k][i].symax >> theCurrentTemp.entx[k][i].dyone
-            >> theCurrentTemp.entx[k][i].syone >> theCurrentTemp.entx[k][i].sxmax >> theCurrentTemp.entx[k][i].dxone >> theCurrentTemp.entx[k][i].sxone;
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 18, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            db >> theCurrentTemp.entx[k][i].dytwo >> theCurrentTemp.entx[k][i].sytwo >> theCurrentTemp.entx[k][i].dxtwo
-            >> theCurrentTemp.entx[k][i].sxtwo >> theCurrentTemp.entx[k][i].qmin >> theCurrentTemp.entx[k][i].clsleny >> theCurrentTemp.entx[k][i].clslenx;
-            //                     >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav;
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 19, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            for (j=0; j<2; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].ypar[j][0] >> theCurrentTemp.entx[k][i].ypar[j][1]
-               >> theCurrentTemp.entx[k][i].ypar[j][2] >> theCurrentTemp.entx[k][i].ypar[j][3] >> theCurrentTemp.entx[k][i].ypar[j][4];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 20, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<9; ++j) {
-               
-               for (l=0; l<TYSIZE; ++l) {db >> theCurrentTemp.entx[k][i].ytemp[j][l];}
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 21, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            
-            
-            for (j=0; j<2; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].xpar[j][0] >> theCurrentTemp.entx[k][i].xpar[j][1]
-               >> theCurrentTemp.entx[k][i].xpar[j][2] >> theCurrentTemp.entx[k][i].xpar[j][3] >> theCurrentTemp.entx[k][i].xpar[j][4];
-               
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 22, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            qavg_avg = 0.f;
-            for (j=0; j<9; ++j) {
-               
-               for (l=0; l<TXSIZE; ++l) {db >> theCurrentTemp.entx[k][i].xtemp[j][l]; qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];}
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 23, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            theCurrentTemp.entx[k][i].qavg_avg = qavg_avg/9.;
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].yavg[j] >> theCurrentTemp.entx[k][i].yrms[j] >> theCurrentTemp.entx[k][i].ygx0[j] >> theCurrentTemp.entx[k][i].ygsig[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 24, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].yflpar[j][0] >> theCurrentTemp.entx[k][i].yflpar[j][1] >> theCurrentTemp.entx[k][i].yflpar[j][2]
-               >> theCurrentTemp.entx[k][i].yflpar[j][3] >> theCurrentTemp.entx[k][i].yflpar[j][4] >> theCurrentTemp.entx[k][i].yflpar[j][5];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 25, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].xavg[j] >> theCurrentTemp.entx[k][i].xrms[j] >> theCurrentTemp.entx[k][i].xgx0[j] >> theCurrentTemp.entx[k][i].xgsig[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 26, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].xflpar[j][0] >> theCurrentTemp.entx[k][i].xflpar[j][1] >> theCurrentTemp.entx[k][i].xflpar[j][2]
-               >> theCurrentTemp.entx[k][i].xflpar[j][3] >> theCurrentTemp.entx[k][i].xflpar[j][4] >> theCurrentTemp.entx[k][i].xflpar[j][5];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 27, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].chi2yavg[j] >> theCurrentTemp.entx[k][i].chi2ymin[j] >> theCurrentTemp.entx[k][i].chi2xavg[j] >> theCurrentTemp.entx[k][i].chi2xmin[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 28, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].yavgc2m[j] >> theCurrentTemp.entx[k][i].yrmsc2m[j] >> theCurrentTemp.entx[k][i].chi2yavgc2m[j] >> theCurrentTemp.entx[k][i].chi2yminc2m[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 29, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].xavgc2m[j] >> theCurrentTemp.entx[k][i].xrmsc2m[j] >> theCurrentTemp.entx[k][i].chi2xavgc2m[j] >> theCurrentTemp.entx[k][i].chi2xminc2m[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 30, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].yavggen[j] >> theCurrentTemp.entx[k][i].yrmsgen[j] >> theCurrentTemp.entx[k][i].ygx0gen[j] >> theCurrentTemp.entx[k][i].ygsiggen[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 30a, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            for (j=0; j<4; ++j) {
-               
-               db >> theCurrentTemp.entx[k][i].xavggen[j] >> theCurrentTemp.entx[k][i].xrmsgen[j] >> theCurrentTemp.entx[k][i].xgx0gen[j] >> theCurrentTemp.entx[k][i].xgsiggen[j];
-               
-               if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 30b, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            }
-            
-            
-            db >> theCurrentTemp.entx[k][i].chi2yavgone >> theCurrentTemp.entx[k][i].chi2yminone >> theCurrentTemp.entx[k][i].chi2xavgone >> theCurrentTemp.entx[k][i].chi2xminone >> theCurrentTemp.entx[k][i].qmin2
-            >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].r_qMeas_qTrue >> theCurrentTemp.entx[k][i].spare[0];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 31, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-            db >> theCurrentTemp.entx[k][i].mpvvav2 >> theCurrentTemp.entx[k][i].sigmavav2 >> theCurrentTemp.entx[k][i].kappavav2 >> theCurrentTemp.entx[k][i].qbfrac[0] >> theCurrentTemp.entx[k][i].qbfrac[1]
-            >> theCurrentTemp.entx[k][i].qbfrac[2] >> theCurrentTemp.entx[k][i].fracyone >> theCurrentTemp.entx[k][i].fracxone >> theCurrentTemp.entx[k][i].fracytwo >> theCurrentTemp.entx[k][i].fracxtwo;
-            //				theCurrentTemp.entx[k][i].qbfrac[3] = 1. - theCurrentTemp.entx[k][i].qbfrac[0] - theCurrentTemp.entx[k][i].qbfrac[1] - theCurrentTemp.entx[k][i].qbfrac[2];
-            
-            if(db.fail()) {LOGERROR("SiPixelTemplate") << "Error reading file 32, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
-            
-         }
-      }
-      
-      
-      // Add this template to the store
-      
-      pixelTemp.push_back(theCurrentTemp);
-      
-   }
-   postInit(pixelTemp);
-   return true;
-   
-} // TempInit
+
+    // next, layout the 1-d/2-d structures needed to store template
+    theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
+    theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
+    theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
+    theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
+    theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
 
 #endif
 
+    // next, loop over all barrel y-angle entries
 
-void SiPixelTemplate::postInit(std::vector< SiPixelTemplateStore > & thePixelTemp_) {
-   /*
+    for (i = 0; i < theCurrentTemp.head.NTy; ++i) {
+      db >> theCurrentTemp.enty[i].runnum >> theCurrentTemp.enty[i].costrk[0] >> theCurrentTemp.enty[i].costrk[1] >>
+          theCurrentTemp.enty[i].costrk[2];
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 1, no template load, run # " << theCurrentTemp.enty[i].runnum
+                                    << ENDL;
+        return false;
+      }
+
+      // Calculate the alpha, beta, and cot(beta) for this entry
+
+      theCurrentTemp.enty[i].alpha =
+          static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[0]));
+
+      theCurrentTemp.enty[i].cotalpha = theCurrentTemp.enty[i].costrk[0] / theCurrentTemp.enty[i].costrk[2];
+
+      theCurrentTemp.enty[i].beta =
+          static_cast<float>(atan2((double)theCurrentTemp.enty[i].costrk[2], (double)theCurrentTemp.enty[i].costrk[1]));
+
+      theCurrentTemp.enty[i].cotbeta = theCurrentTemp.enty[i].costrk[1] / theCurrentTemp.enty[i].costrk[2];
+
+      db >> theCurrentTemp.enty[i].qavg >> theCurrentTemp.enty[i].pixmax >> theCurrentTemp.enty[i].symax >>
+          theCurrentTemp.enty[i].dyone >> theCurrentTemp.enty[i].syone >> theCurrentTemp.enty[i].sxmax >>
+          theCurrentTemp.enty[i].dxone >> theCurrentTemp.enty[i].sxone;
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 2, no template load, run # " << theCurrentTemp.enty[i].runnum
+                                    << ENDL;
+        return false;
+      }
+
+      db >> theCurrentTemp.enty[i].dytwo >> theCurrentTemp.enty[i].sytwo >> theCurrentTemp.enty[i].dxtwo >>
+          theCurrentTemp.enty[i].sxtwo >> theCurrentTemp.enty[i].qmin >> theCurrentTemp.enty[i].clsleny >>
+          theCurrentTemp.enty[i].clslenx;
+      //			     >> theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav;
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 3, no template load, run # " << theCurrentTemp.enty[i].runnum
+                                    << ENDL;
+        return false;
+      }
+
+      if (theCurrentTemp.enty[i].qmin <= 0.) {
+        LOGERROR("SiPixelTemplate") << "Error in template ID " << theCurrentTemp.head.ID
+                                    << " qmin = " << theCurrentTemp.enty[i].qmin << ", run # "
+                                    << theCurrentTemp.enty[i].runnum << ENDL;
+        return false;
+      }
+
+      for (j = 0; j < 2; ++j) {
+        db >> theCurrentTemp.enty[i].ypar[j][0] >> theCurrentTemp.enty[i].ypar[j][1] >>
+            theCurrentTemp.enty[i].ypar[j][2] >> theCurrentTemp.enty[i].ypar[j][3] >> theCurrentTemp.enty[i].ypar[j][4];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 4, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 9; ++j) {
+        for (k = 0; k < TYSIZE; ++k) {
+          db >> theCurrentTemp.enty[i].ytemp[j][k];
+        }
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 5, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 2; ++j) {
+        db >> theCurrentTemp.enty[i].xpar[j][0] >> theCurrentTemp.enty[i].xpar[j][1] >>
+            theCurrentTemp.enty[i].xpar[j][2] >> theCurrentTemp.enty[i].xpar[j][3] >> theCurrentTemp.enty[i].xpar[j][4];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 6, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      qavg_avg = 0.f;
+      for (j = 0; j < 9; ++j) {
+        for (k = 0; k < TXSIZE; ++k) {
+          db >> theCurrentTemp.enty[i].xtemp[j][k];
+          qavg_avg += theCurrentTemp.enty[i].xtemp[j][k];
+        }
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 7, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+      theCurrentTemp.enty[i].qavg_avg = qavg_avg / 9.;
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].yavg[j] >> theCurrentTemp.enty[i].yrms[j] >> theCurrentTemp.enty[i].ygx0[j] >>
+            theCurrentTemp.enty[i].ygsig[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 8, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].yflpar[j][0] >> theCurrentTemp.enty[i].yflpar[j][1] >>
+            theCurrentTemp.enty[i].yflpar[j][2] >> theCurrentTemp.enty[i].yflpar[j][3] >>
+            theCurrentTemp.enty[i].yflpar[j][4] >> theCurrentTemp.enty[i].yflpar[j][5];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 9, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].xavg[j] >> theCurrentTemp.enty[i].xrms[j] >> theCurrentTemp.enty[i].xgx0[j] >>
+            theCurrentTemp.enty[i].xgsig[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 10, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].xflpar[j][0] >> theCurrentTemp.enty[i].xflpar[j][1] >>
+            theCurrentTemp.enty[i].xflpar[j][2] >> theCurrentTemp.enty[i].xflpar[j][3] >>
+            theCurrentTemp.enty[i].xflpar[j][4] >> theCurrentTemp.enty[i].xflpar[j][5];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 11, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].chi2yavg[j] >> theCurrentTemp.enty[i].chi2ymin[j] >>
+            theCurrentTemp.enty[i].chi2xavg[j] >> theCurrentTemp.enty[i].chi2xmin[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 12, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].yavgc2m[j] >> theCurrentTemp.enty[i].yrmsc2m[j] >>
+            theCurrentTemp.enty[i].chi2yavgc2m[j] >> theCurrentTemp.enty[i].chi2yminc2m[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 13, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].xavgc2m[j] >> theCurrentTemp.enty[i].xrmsc2m[j] >>
+            theCurrentTemp.enty[i].chi2xavgc2m[j] >> theCurrentTemp.enty[i].chi2xminc2m[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 14, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].yavggen[j] >> theCurrentTemp.enty[i].yrmsgen[j] >>
+            theCurrentTemp.enty[i].ygx0gen[j] >> theCurrentTemp.enty[i].ygsiggen[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 14a, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      for (j = 0; j < 4; ++j) {
+        db >> theCurrentTemp.enty[i].xavggen[j] >> theCurrentTemp.enty[i].xrmsgen[j] >>
+            theCurrentTemp.enty[i].xgx0gen[j] >> theCurrentTemp.enty[i].xgsiggen[j];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 14b, no template load, run # "
+                                      << theCurrentTemp.enty[i].runnum << ENDL;
+          return false;
+        }
+      }
+
+      db >> theCurrentTemp.enty[i].chi2yavgone >> theCurrentTemp.enty[i].chi2yminone >>
+          theCurrentTemp.enty[i].chi2xavgone >> theCurrentTemp.enty[i].chi2xminone >> theCurrentTemp.enty[i].qmin2 >>
+          theCurrentTemp.enty[i].mpvvav >> theCurrentTemp.enty[i].sigmavav >> theCurrentTemp.enty[i].kappavav >>
+          theCurrentTemp.enty[i].r_qMeas_qTrue >> theCurrentTemp.enty[i].spare[0];
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 15, no template load, run # "
+                                    << theCurrentTemp.enty[i].runnum << ENDL;
+        return false;
+      }
+
+      db >> theCurrentTemp.enty[i].mpvvav2 >> theCurrentTemp.enty[i].sigmavav2 >> theCurrentTemp.enty[i].kappavav2 >>
+          theCurrentTemp.enty[i].qbfrac[0] >> theCurrentTemp.enty[i].qbfrac[1] >> theCurrentTemp.enty[i].qbfrac[2] >>
+          theCurrentTemp.enty[i].fracyone >> theCurrentTemp.enty[i].fracxone >> theCurrentTemp.enty[i].fracytwo >>
+          theCurrentTemp.enty[i].fracxtwo;
+      //			theCurrentTemp.enty[i].qbfrac[3] = 1. - theCurrentTemp.enty[i].qbfrac[0] - theCurrentTemp.enty[i].qbfrac[1] - theCurrentTemp.enty[i].qbfrac[2];
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate") << "Error reading file 16, no template load, run # "
+                                    << theCurrentTemp.enty[i].runnum << ENDL;
+        return false;
+      }
+    }
+
+    // next, loop over all barrel x-angle entries
+
+    for (k = 0; k < theCurrentTemp.head.NTyx; ++k) {
+      for (i = 0; i < theCurrentTemp.head.NTxx; ++i) {
+        db >> theCurrentTemp.entx[k][i].runnum >> theCurrentTemp.entx[k][i].costrk[0] >>
+            theCurrentTemp.entx[k][i].costrk[1] >> theCurrentTemp.entx[k][i].costrk[2];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 17, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        // Calculate the alpha, beta, and cot(beta) for this entry
+
+        theCurrentTemp.entx[k][i].alpha = static_cast<float>(
+            atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[0]));
+
+        theCurrentTemp.entx[k][i].cotalpha = theCurrentTemp.entx[k][i].costrk[0] / theCurrentTemp.entx[k][i].costrk[2];
+
+        theCurrentTemp.entx[k][i].beta = static_cast<float>(
+            atan2((double)theCurrentTemp.entx[k][i].costrk[2], (double)theCurrentTemp.entx[k][i].costrk[1]));
+
+        theCurrentTemp.entx[k][i].cotbeta = theCurrentTemp.entx[k][i].costrk[1] / theCurrentTemp.entx[k][i].costrk[2];
+
+        db >> theCurrentTemp.entx[k][i].qavg >> theCurrentTemp.entx[k][i].pixmax >> theCurrentTemp.entx[k][i].symax >>
+            theCurrentTemp.entx[k][i].dyone >> theCurrentTemp.entx[k][i].syone >> theCurrentTemp.entx[k][i].sxmax >>
+            theCurrentTemp.entx[k][i].dxone >> theCurrentTemp.entx[k][i].sxone;
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 18, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        db >> theCurrentTemp.entx[k][i].dytwo >> theCurrentTemp.entx[k][i].sytwo >> theCurrentTemp.entx[k][i].dxtwo >>
+            theCurrentTemp.entx[k][i].sxtwo >> theCurrentTemp.entx[k][i].qmin >> theCurrentTemp.entx[k][i].clsleny >>
+            theCurrentTemp.entx[k][i].clslenx;
+        //                     >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >> theCurrentTemp.entx[k][i].kappavav;
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 19, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        for (j = 0; j < 2; ++j) {
+          db >> theCurrentTemp.entx[k][i].ypar[j][0] >> theCurrentTemp.entx[k][i].ypar[j][1] >>
+              theCurrentTemp.entx[k][i].ypar[j][2] >> theCurrentTemp.entx[k][i].ypar[j][3] >>
+              theCurrentTemp.entx[k][i].ypar[j][4];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 20, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 9; ++j) {
+          for (l = 0; l < TYSIZE; ++l) {
+            db >> theCurrentTemp.entx[k][i].ytemp[j][l];
+          }
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 21, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 2; ++j) {
+          db >> theCurrentTemp.entx[k][i].xpar[j][0] >> theCurrentTemp.entx[k][i].xpar[j][1] >>
+              theCurrentTemp.entx[k][i].xpar[j][2] >> theCurrentTemp.entx[k][i].xpar[j][3] >>
+              theCurrentTemp.entx[k][i].xpar[j][4];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 22, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        qavg_avg = 0.f;
+        for (j = 0; j < 9; ++j) {
+          for (l = 0; l < TXSIZE; ++l) {
+            db >> theCurrentTemp.entx[k][i].xtemp[j][l];
+            qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];
+          }
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 23, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+        theCurrentTemp.entx[k][i].qavg_avg = qavg_avg / 9.;
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].yavg[j] >> theCurrentTemp.entx[k][i].yrms[j] >>
+              theCurrentTemp.entx[k][i].ygx0[j] >> theCurrentTemp.entx[k][i].ygsig[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 24, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].yflpar[j][0] >> theCurrentTemp.entx[k][i].yflpar[j][1] >>
+              theCurrentTemp.entx[k][i].yflpar[j][2] >> theCurrentTemp.entx[k][i].yflpar[j][3] >>
+              theCurrentTemp.entx[k][i].yflpar[j][4] >> theCurrentTemp.entx[k][i].yflpar[j][5];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 25, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].xavg[j] >> theCurrentTemp.entx[k][i].xrms[j] >>
+              theCurrentTemp.entx[k][i].xgx0[j] >> theCurrentTemp.entx[k][i].xgsig[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 26, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].xflpar[j][0] >> theCurrentTemp.entx[k][i].xflpar[j][1] >>
+              theCurrentTemp.entx[k][i].xflpar[j][2] >> theCurrentTemp.entx[k][i].xflpar[j][3] >>
+              theCurrentTemp.entx[k][i].xflpar[j][4] >> theCurrentTemp.entx[k][i].xflpar[j][5];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 27, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].chi2yavg[j] >> theCurrentTemp.entx[k][i].chi2ymin[j] >>
+              theCurrentTemp.entx[k][i].chi2xavg[j] >> theCurrentTemp.entx[k][i].chi2xmin[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 28, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].yavgc2m[j] >> theCurrentTemp.entx[k][i].yrmsc2m[j] >>
+              theCurrentTemp.entx[k][i].chi2yavgc2m[j] >> theCurrentTemp.entx[k][i].chi2yminc2m[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 29, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].xavgc2m[j] >> theCurrentTemp.entx[k][i].xrmsc2m[j] >>
+              theCurrentTemp.entx[k][i].chi2xavgc2m[j] >> theCurrentTemp.entx[k][i].chi2xminc2m[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 30, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].yavggen[j] >> theCurrentTemp.entx[k][i].yrmsgen[j] >>
+              theCurrentTemp.entx[k][i].ygx0gen[j] >> theCurrentTemp.entx[k][i].ygsiggen[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 30a, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        for (j = 0; j < 4; ++j) {
+          db >> theCurrentTemp.entx[k][i].xavggen[j] >> theCurrentTemp.entx[k][i].xrmsgen[j] >>
+              theCurrentTemp.entx[k][i].xgx0gen[j] >> theCurrentTemp.entx[k][i].xgsiggen[j];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate") << "Error reading file 30b, no template load, run # "
+                                        << theCurrentTemp.entx[k][i].runnum << ENDL;
+            return false;
+          }
+        }
+
+        db >> theCurrentTemp.entx[k][i].chi2yavgone >> theCurrentTemp.entx[k][i].chi2yminone >>
+            theCurrentTemp.entx[k][i].chi2xavgone >> theCurrentTemp.entx[k][i].chi2xminone >>
+            theCurrentTemp.entx[k][i].qmin2 >> theCurrentTemp.entx[k][i].mpvvav >> theCurrentTemp.entx[k][i].sigmavav >>
+            theCurrentTemp.entx[k][i].kappavav >> theCurrentTemp.entx[k][i].r_qMeas_qTrue >>
+            theCurrentTemp.entx[k][i].spare[0];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 31, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+
+        db >> theCurrentTemp.entx[k][i].mpvvav2 >> theCurrentTemp.entx[k][i].sigmavav2 >>
+            theCurrentTemp.entx[k][i].kappavav2 >> theCurrentTemp.entx[k][i].qbfrac[0] >>
+            theCurrentTemp.entx[k][i].qbfrac[1] >> theCurrentTemp.entx[k][i].qbfrac[2] >>
+            theCurrentTemp.entx[k][i].fracyone >> theCurrentTemp.entx[k][i].fracxone >>
+            theCurrentTemp.entx[k][i].fracytwo >> theCurrentTemp.entx[k][i].fracxtwo;
+        //				theCurrentTemp.entx[k][i].qbfrac[3] = 1. - theCurrentTemp.entx[k][i].qbfrac[0] - theCurrentTemp.entx[k][i].qbfrac[1] - theCurrentTemp.entx[k][i].qbfrac[2];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate") << "Error reading file 32, no template load, run # "
+                                      << theCurrentTemp.entx[k][i].runnum << ENDL;
+          return false;
+        }
+      }
+    }
+
+    // Add this template to the store
+
+    pixelTemp.push_back(theCurrentTemp);
+  }
+  postInit(pixelTemp);
+  return true;
+
+}  // TempInit
+
+#endif
+
+void SiPixelTemplate::postInit(std::vector<SiPixelTemplateStore>& thePixelTemp_) {
+  /*
     std::cout << "SiPixelTemplate size " << thePixelTemp_.size() << std::endl;
     #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
     std::cout <<"uses C arrays" << std::endl;
@@ -973,17 +1300,16 @@ void SiPixelTemplate::postInit(std::vector< SiPixelTemplateStore > & thePixelTem
     ++i;
     }
     */
-   
-   for (auto & templ : thePixelTemp_) {
-      for ( auto iy=0; iy<templ.head.NTy; ++iy ) templ.cotbetaY[iy]=templ.enty[iy].cotbeta;
-      for ( auto iy=0; iy<templ.head.NTyx; ++iy )  templ.cotbetaX[iy]= templ.entx[iy][0].cotbeta;
-      for ( auto ix=0; ix<templ.head.NTxx; ++ix ) templ.cotalphaX[ix]=templ.entx[0][ix].cotalpha;
-   }
-   
+
+  for (auto& templ : thePixelTemp_) {
+    for (auto iy = 0; iy < templ.head.NTy; ++iy)
+      templ.cotbetaY[iy] = templ.enty[iy].cotbeta;
+    for (auto iy = 0; iy < templ.head.NTyx; ++iy)
+      templ.cotbetaX[iy] = templ.entx[iy][0].cotbeta;
+    for (auto ix = 0; ix < templ.head.NTxx; ++ix)
+      templ.cotalphaX[ix] = templ.entx[0][ix].cotalpha;
+  }
 }
-
-
-
 
 // ************************************************************************************************************
 //! Interpolate input alpha and beta angles to produce a working template for each individual hit.
@@ -997,495 +1323,595 @@ void SiPixelTemplate::postInit(std::vector< SiPixelTemplateStore > & thePixelTem
 //!                    for Phase 1 FPix IP-related tracks, locBx/locBz > 0 for cot(alpha) > 0 and locBx/locBz < 0 for cot(alpha) < 0
 //!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
 // ************************************************************************************************************
-bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx){
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   int i, j;
-   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
-   float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0, cotbeta0;
-   bool flip_x, flip_y;
-   //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
-   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
-   
-   
-   // Check to see if interpolation is valid
-   if(id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
-      
-      cota_current_ = cotalpha; cotb_current_ = cotbeta; success_ = true;
-      
-      if(id != id_current_) {
-         
-         // Find the index corresponding to id
-         
-         index_id_ = -1;
-         for(i=0; i<(int)thePixelTemp_.size(); ++i) {
-            
-            //std::cout<<i<<" "<<id<<" "<<thePixelTemp_[i].head.ID<<std::endl;
-            
-            if(id == thePixelTemp_[i].head.ID) {
-               
-               index_id_ = i;
-               id_current_ = id;
-               
-               // Copy the charge scaling factor to the private variable
-               
-               qscale_ = thePixelTemp_[index_id_].head.qscale;
-               
-               // Copy the pseudopixel signal size to the private variable
-               
-               s50_ = thePixelTemp_[index_id_].head.s50;
-               
-               // Copy Qbinning info to private variables
-               
-               for(j=0; j<3; ++j) {fbin_[j] = thePixelTemp_[index_id_].head.fbin[j];}
-               //std::cout<<" set fbin  "<< fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
-               
-               // Pixel sizes to the private variables
-               
-               xsize_ = thePixelTemp_[index_id_].head.xsize;
-               ysize_ = thePixelTemp_[index_id_].head.ysize;
-               zsize_ = thePixelTemp_[index_id_].head.zsize;
-               
-               break;
-            }
-         }
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx) {
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  int i, j;
+  int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
+  float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0,
+      cotbeta0;
+  bool flip_x, flip_y;
+  //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
+  float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
+
+  // Check to see if interpolation is valid
+  if (id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
+    cota_current_ = cotalpha;
+    cotb_current_ = cotbeta;
+    success_ = true;
+
+    if (id != id_current_) {
+      // Find the index corresponding to id
+
+      index_id_ = -1;
+      for (i = 0; i < (int)thePixelTemp_.size(); ++i) {
+        //std::cout<<i<<" "<<id<<" "<<thePixelTemp_[i].head.ID<<std::endl;
+
+        if (id == thePixelTemp_[i].head.ID) {
+          index_id_ = i;
+          id_current_ = id;
+
+          // Copy the charge scaling factor to the private variable
+
+          qscale_ = thePixelTemp_[index_id_].head.qscale;
+
+          // Copy the pseudopixel signal size to the private variable
+
+          s50_ = thePixelTemp_[index_id_].head.s50;
+
+          // Copy Qbinning info to private variables
+
+          for (j = 0; j < 3; ++j) {
+            fbin_[j] = thePixelTemp_[index_id_].head.fbin[j];
+          }
+          //std::cout<<" set fbin  "<< fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
+
+          // Pixel sizes to the private variables
+
+          xsize_ = thePixelTemp_[index_id_].head.xsize;
+          ysize_ = thePixelTemp_[index_id_].head.ysize;
+          zsize_ = thePixelTemp_[index_id_].head.zsize;
+
+          break;
+        }
       }
-      
+    }
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
-         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::interpolate can't find needed template ID = " << id << std::endl;
-      }
+    if (index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::interpolate can't find needed template ID = " << id << std::endl;
+    }
 #else
-      assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
+    assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
 #endif
-      
-      // Interpolate the absolute value of cot(beta)
-      
-      abs_cotb_ = std::abs(cotbeta);
-      
-      //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)
-      
-      cotalpha0 =  thePixelTemp_[index_id_].enty[0].cotalpha;
-      qcorrect=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta*cotbeta+cotalpha0*cotalpha0));
-      
-      // for some cosmics, the ususal gymnastics are incorrect
-      cota = cotalpha;
-      cotb = abs_cotb_;
-      flip_x = false;
-      flip_y = false;
-      switch(thePixelTemp_[index_id_].head.Dtype) {
-         case 0:
-            if(cotbeta < 0.f) {flip_y = true;}
-            break;
-         case 1:
-            if(locBz < 0.f) {
-               cotb = cotbeta;
-            } else {
-               cotb = -cotbeta;
-               flip_y = true;
-            }
-            break;
-         case 2:
-         case 3:
-         case 4:
-         case 5:
-            if(locBx*locBz < 0.f) {
-               cota = -cotalpha;
-               flip_x = true;
-            }
-            if(locBx > 0.f) {
-               cotb = cotbeta;
-            } else {
-               cotb = -cotbeta;
-               flip_y = true;
-            }
-            break;
-         default:
+
+    // Interpolate the absolute value of cot(beta)
+
+    abs_cotb_ = std::abs(cotbeta);
+
+    //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)
+
+    cotalpha0 = thePixelTemp_[index_id_].enty[0].cotalpha;
+    qcorrect =
+        std::sqrt((1.f + cotbeta * cotbeta + cotalpha * cotalpha) / (1.f + cotbeta * cotbeta + cotalpha0 * cotalpha0));
+
+    // for some cosmics, the ususal gymnastics are incorrect
+    cota = cotalpha;
+    cotb = abs_cotb_;
+    flip_x = false;
+    flip_y = false;
+    switch (thePixelTemp_[index_id_].head.Dtype) {
+      case 0:
+        if (cotbeta < 0.f) {
+          flip_y = true;
+        }
+        break;
+      case 1:
+        if (locBz < 0.f) {
+          cotb = cotbeta;
+        } else {
+          cotb = -cotbeta;
+          flip_y = true;
+        }
+        break;
+      case 2:
+      case 3:
+      case 4:
+      case 5:
+        if (locBx * locBz < 0.f) {
+          cota = -cotalpha;
+          flip_x = true;
+        }
+        if (locBx > 0.f) {
+          cotb = cotbeta;
+        } else {
+          cotb = -cotbeta;
+          flip_y = true;
+        }
+        break;
+      default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-            throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+        throw cms::Exception("DataCorrupt")
+            << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #else
-            std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+        std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #endif
-      }
-      
-      Ny = thePixelTemp_[index_id_].head.NTy;
-      Nyx = thePixelTemp_[index_id_].head.NTyx;
-      Nxx = thePixelTemp_[index_id_].head.NTxx;
-      
+    }
+
+    Ny = thePixelTemp_[index_id_].head.NTy;
+    Nyx = thePixelTemp_[index_id_].head.NTyx;
+    Nxx = thePixelTemp_[index_id_].head.NTxx;
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      if(Ny < 2 || Nyx < 1 || Nxx < 2) {
-         throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
-      }
+    if (Ny < 2 || Nyx < 1 || Nxx < 2) {
+      throw cms::Exception("DataCorrupt")
+          << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx
+          << std::endl;
+    }
 #else
-      assert(Ny > 1 && Nyx > 0 && Nxx > 1);
+    assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
-      imaxx = Nyx - 1;
-      imidy = Nxx/2;
-      
-      // next, loop over all y-angle entries
-      
-      ilow = 0;
-      yratio = 0.f;
-      
-      if(cotb >= thePixelTemp_[index_id_].enty[Ny-1].cotbeta) {
-         
-         ilow = Ny-2;
-         yratio = 1.;
-         success_ = false;
-         
+    imaxx = Nyx - 1;
+    imidy = Nxx / 2;
+
+    // next, loop over all y-angle entries
+
+    ilow = 0;
+    yratio = 0.f;
+
+    if (cotb >= thePixelTemp_[index_id_].enty[Ny - 1].cotbeta) {
+      ilow = Ny - 2;
+      yratio = 1.;
+      success_ = false;
+
+    } else {
+      if (cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
+        for (i = 0; i < Ny - 1; ++i) {
+          if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
+            ilow = i;
+            yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
+                     (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
+            break;
+          }
+        }
       } else {
-         
-         if(cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
-            
-            for (i=0; i<Ny-1; ++i) {
-               
-               if( thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i+1].cotbeta) {
-                  
-                  ilow = i;
-                  yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta)/(thePixelTemp_[index_id_].enty[i+1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
-                  break;
-               }
-            }
-         } else { success_ = false; }
+        success_ = false;
       }
-      
-      ihigh=ilow + 1;
-      
-      // Interpolate/store all y-related quantities (flip displacements when flip_y)
-      
-      yratio_ = yratio;
-      qavg_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].qavg + yratio*thePixelTemp_[index_id_].enty[ihigh].qavg;
-      qavg_ *= qcorrect;
-      symax = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].symax + yratio*thePixelTemp_[index_id_].enty[ihigh].symax;
-      syparmax_ = symax;
-      sxmax = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sxmax + yratio*thePixelTemp_[index_id_].enty[ihigh].sxmax;
-      dyone_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].dyone + yratio*thePixelTemp_[index_id_].enty[ihigh].dyone;
-      if(flip_y) {dyone_ = -dyone_;}
-      syone_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].syone + yratio*thePixelTemp_[index_id_].enty[ihigh].syone;
-      dytwo_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].dytwo + yratio*thePixelTemp_[index_id_].enty[ihigh].dytwo;
-      if(flip_y) {dytwo_ = -dytwo_;}
-      sytwo_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sytwo + yratio*thePixelTemp_[index_id_].enty[ihigh].sytwo;
-      qmin_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].qmin + yratio*thePixelTemp_[index_id_].enty[ihigh].qmin;
-      qmin_ *= qcorrect;
-      qmin2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].qmin2 + yratio*thePixelTemp_[index_id_].enty[ihigh].qmin2;
-      qmin2_ *= qcorrect;
-      mpvvav_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].mpvvav + yratio*thePixelTemp_[index_id_].enty[ihigh].mpvvav;
-      mpvvav_ *= qcorrect;
-      sigmavav_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sigmavav + yratio*thePixelTemp_[index_id_].enty[ihigh].sigmavav;
-      kappavav_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].kappavav + yratio*thePixelTemp_[index_id_].enty[ihigh].kappavav;
-      mpvvav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].mpvvav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
-      mpvvav2_ *= qcorrect;
-      sigmavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sigmavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
-      kappavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].kappavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].kappavav2;
-      clsleny_ = fminf(thePixelTemp_[index_id_].enty[ilow].clsleny, thePixelTemp_[index_id_].enty[ihigh].clsleny);
-      qavg_avg_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].qavg_avg + yratio*thePixelTemp_[index_id_].enty[ihigh].qavg_avg;
-      qavg_avg_ *= qcorrect;
-      for(i=0; i<2 ; ++i) {
-         for(j=0; j<5 ; ++j) {
-            // Charge loss switches sides when cot(beta) changes sign
-            if(flip_y) {
-               yparl_[1-i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
-               yparh_[1-i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
-            } else {
-               yparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
-               yparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
-            }
-            if(flip_x) {
-               xparly0_[1-i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
-               xparhy0_[1-i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
-            } else {
-               xparly0_[i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
-               xparhy0_[i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
-            }
-         }
+    }
+
+    ihigh = ilow + 1;
+
+    // Interpolate/store all y-related quantities (flip displacements when flip_y)
+
+    yratio_ = yratio;
+    qavg_ =
+        (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qavg + yratio * thePixelTemp_[index_id_].enty[ihigh].qavg;
+    qavg_ *= qcorrect;
+    symax = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].symax +
+            yratio * thePixelTemp_[index_id_].enty[ihigh].symax;
+    syparmax_ = symax;
+    sxmax = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sxmax +
+            yratio * thePixelTemp_[index_id_].enty[ihigh].sxmax;
+    dyone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].dyone +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].dyone;
+    if (flip_y) {
+      dyone_ = -dyone_;
+    }
+    syone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].syone +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].syone;
+    dytwo_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].dytwo +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].dytwo;
+    if (flip_y) {
+      dytwo_ = -dytwo_;
+    }
+    sytwo_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sytwo +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].sytwo;
+    qmin_ =
+        (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qmin + yratio * thePixelTemp_[index_id_].enty[ihigh].qmin;
+    qmin_ *= qcorrect;
+    qmin2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qmin2 +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].qmin2;
+    qmin2_ *= qcorrect;
+    mpvvav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav +
+              yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav;
+    mpvvav_ *= qcorrect;
+    sigmavav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav +
+                yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav;
+    kappavav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav +
+                yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav;
+    mpvvav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav2 +
+               yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
+    mpvvav2_ *= qcorrect;
+    sigmavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav2 +
+                 yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
+    kappavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav2 +
+                 yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav2;
+    clsleny_ = fminf(thePixelTemp_[index_id_].enty[ilow].clsleny, thePixelTemp_[index_id_].enty[ihigh].clsleny);
+    qavg_avg_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qavg_avg +
+                yratio * thePixelTemp_[index_id_].enty[ihigh].qavg_avg;
+    qavg_avg_ *= qcorrect;
+    for (i = 0; i < 2; ++i) {
+      for (j = 0; j < 5; ++j) {
+        // Charge loss switches sides when cot(beta) changes sign
+        if (flip_y) {
+          yparl_[1 - i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
+          yparh_[1 - i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
+        } else {
+          yparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
+          yparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
+        }
+        if (flip_x) {
+          xparly0_[1 - i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
+          xparhy0_[1 - i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
+        } else {
+          xparly0_[i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
+          xparhy0_[i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
+        }
       }
-      
-      for(i=0; i<4; ++i) {
-         yavg_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yavg[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yavg[i];
-         if(flip_y) {yavg_[i] = -yavg_[i];}
-         yrms_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yrms[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yrms[i];
-         //	      ygx0_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ygx0[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].ygx0[i];
-         //	      if(flip_y) {ygx0_[i] = -ygx0_[i];}
-         //	      ygsig_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ygsig[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].ygsig[i];
-         //	      xrms[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xrms[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xrms[i];
-         //	      xgsig[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xgsig[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xgsig[i];
-         chi2yavg_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yavg[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yavg[i];
-         chi2ymin_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2ymin[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2ymin[i];
-         chi2xavg[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xavg[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xavg[i];
-         chi2xmin[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xmin[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xmin[i];
-         yavgc2m_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yavgc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yavgc2m[i];
-         if(flip_y) {yavgc2m_[i] = -yavgc2m_[i];}
-         yrmsc2m_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yrmsc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yrmsc2m[i];
-         chi2yavgc2m_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yavgc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yavgc2m[i];
-         //	      if(flip_y) {chi2yavgc2m_[i] = -chi2yavgc2m_[i];}
-         chi2yminc2m_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yminc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yminc2m[i];
-         //	      xrmsc2m[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xrmsc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xrmsc2m[i];
-         chi2xavgc2m[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xavgc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xavgc2m[i];
-         chi2xminc2m[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xminc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xminc2m[i];
-         for(j=0; j<6 ; ++j) {
-            yflparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].yflpar[i][j];
-            yflparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].yflpar[i][j];
-            
-            // Since Q_fl is odd under cotbeta, it flips qutomatically, change only even terms
-            
-            if(flip_y && (j == 0 || j == 2 || j == 4)) {
-               yflparl_[i][j] = - yflparl_[i][j];
-               yflparh_[i][j] = - yflparh_[i][j];
-            }
-         }
+    }
+
+    for (i = 0; i < 4; ++i) {
+      yavg_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yavg[i] +
+                 yratio * thePixelTemp_[index_id_].enty[ihigh].yavg[i];
+      if (flip_y) {
+        yavg_[i] = -yavg_[i];
       }
-      
-      //// Single pixel cluster probabilities
-      
-      chi2yavgone_=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yavgone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yavgone;
-      chi2yminone_=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yminone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yminone;
-      chi2xavgone=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xavgone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xavgone;
-      chi2xminone=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xminone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xminone;
-      
-      fracyone_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].fracyone + yratio*thePixelTemp_[index_id_].enty[ihigh].fracyone;
-      fracytwo_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].fracytwo + yratio*thePixelTemp_[index_id_].enty[ihigh].fracytwo;
-      //       for(i=0; i<10; ++i) {
-      //		    pyspare[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yspare[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yspare[i];
-      //       }
-      
-      // Interpolate and build the y-template
-      
-      for(i=0; i<9; ++i) {
-         ytemp_[i][0] = 0.f;
-         ytemp_[i][1] = 0.f;
-         ytemp_[i][BYM2] = 0.f;
-         ytemp_[i][BYM1] = 0.f;
-         for(j=0; j<TYSIZE; ++j) {
-            
-            // Flip the basic y-template when the cotbeta is negative
-            
-            if(flip_y) {
-               ytemp_[8-i][BYM3-j]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ytemp[i][j] + yratio*thePixelTemp_[index_id_].enty[ihigh].ytemp[i][j];
-            } else {
-               ytemp_[i][j+2]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ytemp[i][j] + yratio*thePixelTemp_[index_id_].enty[ihigh].ytemp[i][j];
-            }
-         }
+      yrms_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yrms[i] +
+                 yratio * thePixelTemp_[index_id_].enty[ihigh].yrms[i];
+      //	      ygx0_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ygx0[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].ygx0[i];
+      //	      if(flip_y) {ygx0_[i] = -ygx0_[i];}
+      //	      ygsig_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ygsig[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].ygsig[i];
+      //	      xrms[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xrms[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xrms[i];
+      //	      xgsig[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xgsig[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xgsig[i];
+      chi2yavg_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yavg[i] +
+                     yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yavg[i];
+      chi2ymin_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2ymin[i] +
+                     yratio * thePixelTemp_[index_id_].enty[ihigh].chi2ymin[i];
+      chi2xavg[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xavg[i] +
+                    yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xavg[i];
+      chi2xmin[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xmin[i] +
+                    yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xmin[i];
+      yavgc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yavgc2m[i] +
+                    yratio * thePixelTemp_[index_id_].enty[ihigh].yavgc2m[i];
+      if (flip_y) {
+        yavgc2m_[i] = -yavgc2m_[i];
       }
-      
-      // next, loop over all x-angle entries, first, find relevant y-slices
-      
-      iylow = 0;
-      yxratio = 0.f;
-      
-      if(abs_cotb_ >= thePixelTemp_[index_id_].entx[Nyx-1][0].cotbeta) {
-         
-         iylow = Nyx-2;
-         yxratio = 1.f;
-         
-      } else if(abs_cotb_ >= thePixelTemp_[index_id_].entx[0][0].cotbeta) {
-         
-         for (i=0; i<Nyx-1; ++i) {
-            
-            if( thePixelTemp_[index_id_].entx[i][0].cotbeta <= abs_cotb_ && abs_cotb_ < thePixelTemp_[index_id_].entx[i+1][0].cotbeta) {
-               
-               iylow = i;
-               yxratio = (abs_cotb_ - thePixelTemp_[index_id_].entx[i][0].cotbeta)/(thePixelTemp_[index_id_].entx[i+1][0].cotbeta - thePixelTemp_[index_id_].entx[i][0].cotbeta);
-               break;
-            }
-         }
+      yrmsc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yrmsc2m[i] +
+                    yratio * thePixelTemp_[index_id_].enty[ihigh].yrmsc2m[i];
+      chi2yavgc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yavgc2m[i] +
+                        yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yavgc2m[i];
+      //	      if(flip_y) {chi2yavgc2m_[i] = -chi2yavgc2m_[i];}
+      chi2yminc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yminc2m[i] +
+                        yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yminc2m[i];
+      //	      xrmsc2m[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xrmsc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xrmsc2m[i];
+      chi2xavgc2m[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xavgc2m[i] +
+                       yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xavgc2m[i];
+      chi2xminc2m[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xminc2m[i] +
+                       yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xminc2m[i];
+      for (j = 0; j < 6; ++j) {
+        yflparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].yflpar[i][j];
+        yflparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].yflpar[i][j];
+
+        // Since Q_fl is odd under cotbeta, it flips qutomatically, change only even terms
+
+        if (flip_y && (j == 0 || j == 2 || j == 4)) {
+          yflparl_[i][j] = -yflparl_[i][j];
+          yflparh_[i][j] = -yflparh_[i][j];
+        }
       }
-      
-      iyhigh=iylow + 1;
-      
-      ilow = 0;
-      xxratio = 0.f;
-      
-      if(cota >= thePixelTemp_[index_id_].entx[0][Nxx-1].cotalpha) {
-         
-         ilow = Nxx-2;
-         xxratio = 1.f;
-         success_ = false;
-         
+    }
+
+    //// Single pixel cluster probabilities
+
+    chi2yavgone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yavgone +
+                   yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yavgone;
+    chi2yminone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yminone +
+                   yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yminone;
+    chi2xavgone = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xavgone +
+                  yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xavgone;
+    chi2xminone = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xminone +
+                  yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xminone;
+
+    fracyone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].fracyone +
+                yratio * thePixelTemp_[index_id_].enty[ihigh].fracyone;
+    fracytwo_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].fracytwo +
+                yratio * thePixelTemp_[index_id_].enty[ihigh].fracytwo;
+    //       for(i=0; i<10; ++i) {
+    //		    pyspare[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yspare[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yspare[i];
+    //       }
+
+    // Interpolate and build the y-template
+
+    for (i = 0; i < 9; ++i) {
+      ytemp_[i][0] = 0.f;
+      ytemp_[i][1] = 0.f;
+      ytemp_[i][BYM2] = 0.f;
+      ytemp_[i][BYM1] = 0.f;
+      for (j = 0; j < TYSIZE; ++j) {
+        // Flip the basic y-template when the cotbeta is negative
+
+        if (flip_y) {
+          ytemp_[8 - i][BYM3 - j] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].ytemp[i][j] +
+                                    yratio * thePixelTemp_[index_id_].enty[ihigh].ytemp[i][j];
+        } else {
+          ytemp_[i][j + 2] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].ytemp[i][j] +
+                             yratio * thePixelTemp_[index_id_].enty[ihigh].ytemp[i][j];
+        }
+      }
+    }
+
+    // next, loop over all x-angle entries, first, find relevant y-slices
+
+    iylow = 0;
+    yxratio = 0.f;
+
+    if (abs_cotb_ >= thePixelTemp_[index_id_].entx[Nyx - 1][0].cotbeta) {
+      iylow = Nyx - 2;
+      yxratio = 1.f;
+
+    } else if (abs_cotb_ >= thePixelTemp_[index_id_].entx[0][0].cotbeta) {
+      for (i = 0; i < Nyx - 1; ++i) {
+        if (thePixelTemp_[index_id_].entx[i][0].cotbeta <= abs_cotb_ &&
+            abs_cotb_ < thePixelTemp_[index_id_].entx[i + 1][0].cotbeta) {
+          iylow = i;
+          yxratio = (abs_cotb_ - thePixelTemp_[index_id_].entx[i][0].cotbeta) /
+                    (thePixelTemp_[index_id_].entx[i + 1][0].cotbeta - thePixelTemp_[index_id_].entx[i][0].cotbeta);
+          break;
+        }
+      }
+    }
+
+    iyhigh = iylow + 1;
+
+    ilow = 0;
+    xxratio = 0.f;
+
+    if (cota >= thePixelTemp_[index_id_].entx[0][Nxx - 1].cotalpha) {
+      ilow = Nxx - 2;
+      xxratio = 1.f;
+      success_ = false;
+
+    } else {
+      if (cota >= thePixelTemp_[index_id_].entx[0][0].cotalpha) {
+        for (i = 0; i < Nxx - 1; ++i) {
+          if (thePixelTemp_[index_id_].entx[0][i].cotalpha <= cota &&
+              cota < thePixelTemp_[index_id_].entx[0][i + 1].cotalpha) {
+            ilow = i;
+            xxratio = (cota - thePixelTemp_[index_id_].entx[0][i].cotalpha) /
+                      (thePixelTemp_[index_id_].entx[0][i + 1].cotalpha - thePixelTemp_[index_id_].entx[0][i].cotalpha);
+            break;
+          }
+        }
       } else {
-         
-         if(cota >= thePixelTemp_[index_id_].entx[0][0].cotalpha) {
-            
-            for (i=0; i<Nxx-1; ++i) {
-               
-               if( thePixelTemp_[index_id_].entx[0][i].cotalpha <= cota && cota < thePixelTemp_[index_id_].entx[0][i+1].cotalpha) {
-                  
-                  ilow = i;
-                  xxratio = (cota - thePixelTemp_[index_id_].entx[0][i].cotalpha)/(thePixelTemp_[index_id_].entx[0][i+1].cotalpha - thePixelTemp_[index_id_].entx[0][i].cotalpha);
-                  break;
-               }
-            }
-         } else { success_ = false; }
+        success_ = false;
       }
-      
-      ihigh=ilow + 1;
-      
-      // Interpolate/store all x-related quantities
-      
-      yxratio_ = yxratio;
-      xxratio_ = xxratio;
-      
-      // sxparmax defines the maximum charge for which the parameters xpar are defined (not rescaled by cotbeta)
-      
-      sxparmax_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].sxmax + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].sxmax;
-      sxmax_ = sxparmax_;
-      if(thePixelTemp_[index_id_].entx[imaxx][imidy].sxmax != 0.f) {sxmax_=sxmax_/thePixelTemp_[index_id_].entx[imaxx][imidy].sxmax*sxmax;}
-      symax_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].symax + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].symax;
-      if(thePixelTemp_[index_id_].entx[imaxx][imidy].symax != 0.f) {symax_=symax_/thePixelTemp_[index_id_].entx[imaxx][imidy].symax*symax;}
-      dxone_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].dxone + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].dxone;
-      if(flip_x) {dxone_ = -dxone_;}
-      sxone_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].sxone + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].sxone;
-      dxtwo_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].dxtwo + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].dxtwo;
-      if(flip_x) {dxtwo_ = -dxtwo_;}
-      sxtwo_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].sxtwo;
-      clslenx_ = fminf(thePixelTemp_[index_id_].entx[0][ilow].clslenx, thePixelTemp_[index_id_].entx[0][ihigh].clslenx);
-      
-      for(i=0; i<2 ; ++i) {
-         for(j=0; j<5 ; ++j) {
-            // Charge loss switches sides when cot(alpha) changes sign
-            if(flip_x) {
-               xpar0_[1-i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
-               xparl_[1-i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
-               xparh_[1-i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
-            } else {
-               xpar0_[i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
-               xparl_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
-               xparh_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
-            }
-         }
+    }
+
+    ihigh = ilow + 1;
+
+    // Interpolate/store all x-related quantities
+
+    yxratio_ = yxratio;
+    xxratio_ = xxratio;
+
+    // sxparmax defines the maximum charge for which the parameters xpar are defined (not rescaled by cotbeta)
+
+    sxparmax_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[imaxx][ilow].sxmax +
+                xxratio * thePixelTemp_[index_id_].entx[imaxx][ihigh].sxmax;
+    sxmax_ = sxparmax_;
+    if (thePixelTemp_[index_id_].entx[imaxx][imidy].sxmax != 0.f) {
+      sxmax_ = sxmax_ / thePixelTemp_[index_id_].entx[imaxx][imidy].sxmax * sxmax;
+    }
+    symax_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[imaxx][ilow].symax +
+             xxratio * thePixelTemp_[index_id_].entx[imaxx][ihigh].symax;
+    if (thePixelTemp_[index_id_].entx[imaxx][imidy].symax != 0.f) {
+      symax_ = symax_ / thePixelTemp_[index_id_].entx[imaxx][imidy].symax * symax;
+    }
+    dxone_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].dxone +
+             xxratio * thePixelTemp_[index_id_].entx[0][ihigh].dxone;
+    if (flip_x) {
+      dxone_ = -dxone_;
+    }
+    sxone_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].sxone +
+             xxratio * thePixelTemp_[index_id_].entx[0][ihigh].sxone;
+    dxtwo_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].dxtwo +
+             xxratio * thePixelTemp_[index_id_].entx[0][ihigh].dxtwo;
+    if (flip_x) {
+      dxtwo_ = -dxtwo_;
+    }
+    sxtwo_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].sxtwo +
+             xxratio * thePixelTemp_[index_id_].entx[0][ihigh].sxtwo;
+    clslenx_ = fminf(thePixelTemp_[index_id_].entx[0][ilow].clslenx, thePixelTemp_[index_id_].entx[0][ihigh].clslenx);
+
+    for (i = 0; i < 2; ++i) {
+      for (j = 0; j < 5; ++j) {
+        // Charge loss switches sides when cot(alpha) changes sign
+        if (flip_x) {
+          xpar0_[1 - i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
+          xparl_[1 - i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
+          xparh_[1 - i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
+        } else {
+          xpar0_[i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
+          xparl_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
+          xparh_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
+        }
       }
-      
-      // pixmax is the maximum allowed pixel charge (used for truncation)
-      
-      pixmax_=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].pixmax + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].pixmax)
-      +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].pixmax + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].pixmax);
-      
-      
-      r_qMeas_qTrue_=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].r_qMeas_qTrue + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].r_qMeas_qTrue)
-      +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].r_qMeas_qTrue + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].r_qMeas_qTrue);
-      
-      
-      for(i=0; i<4; ++i) {
-         xavg_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xavg[i])
-         +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavg[i]);
-         if(flip_x) {xavg_[i] = -xavg_[i];}
-         
-         xrms_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xrms[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xrms[i])
-         +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xrms[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrms[i]);
-         
-         //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xgx0[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xgx0[i])
-         //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xgx0[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xgx0[i]);
-         
-         //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xgsig[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xgsig[i])
-         //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xgsig[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xgsig[i]);
-         
-         xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xavgc2m[i])
-         +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavgc2m[i]);
-         if(flip_x) {xavgc2m_[i] = -xavgc2m_[i];}
-         
-         xrmsc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xrmsc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xrmsc2m[i])
-         +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xrmsc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrmsc2m[i]);
-         
-         //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].chi2xavgc2m[i])
-         //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgc2m[i]);
-         
-         //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].chi2xminc2m[i])
-         //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminc2m[i]);
-         //
-         //  Try new interpolation scheme
-         //
-         //	      chi2xavg_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xavg[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xavg[i]);
-         //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xavg[i] != 0.f) {chi2xavg_[i]=chi2xavg_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xavg[i]*chi2xavg[i];}
-         //
-         //	      chi2xmin_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xmin[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xmin[i]);
-         //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i] != 0.f) {chi2xmin_[i]=chi2xmin_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i]*chi2xmin[i];}
-         //
-         chi2xavg_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavg[i]);
-         if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavg[i] != 0.f) {chi2xavg_[i]=chi2xavg_[i]/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavg[i]*chi2xavg[i];}
-         
-         chi2xmin_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xmin[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xmin[i]);
-         if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xmin[i] != 0.f) {chi2xmin_[i]=chi2xmin_[i]/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xmin[i]*chi2xmin[i];}
-         
-         chi2xavgc2m_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgc2m[i]);
-         if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgc2m[i] != 0.f) {chi2xavgc2m_[i]=chi2xavgc2m_[i]/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgc2m[i]*chi2xavgc2m[i];}
-         
-         chi2xminc2m_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminc2m[i]);
-         if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminc2m[i] != 0.f) {chi2xminc2m_[i]=chi2xminc2m_[i]/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminc2m[i]*chi2xminc2m[i];}
-         
-         for(j=0; j<6 ; ++j) {
-            xflparll_[i][j] = thePixelTemp_[index_id_].entx[iylow][ilow].xflpar[i][j];
-            xflparlh_[i][j] = thePixelTemp_[index_id_].entx[iylow][ihigh].xflpar[i][j];
-            xflparhl_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ilow].xflpar[i][j];
-            xflparhh_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ihigh].xflpar[i][j];
-            // Since Q_fl is odd under cotalpha, it flips qutomatically, change only even terms
-            if(flip_x && (j == 0 || j == 2 || j == 4)) {
-               xflparll_[i][j] = -xflparll_[i][j];
-               xflparlh_[i][j] = -xflparlh_[i][j];
-               xflparhl_[i][j] = -xflparhl_[i][j];
-               xflparhh_[i][j] = -xflparhh_[i][j];
-            }
-         }
+    }
+
+    // pixmax is the maximum allowed pixel charge (used for truncation)
+
+    pixmax_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].pixmax +
+                                 xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].pixmax) +
+              yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].pixmax +
+                         xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].pixmax);
+
+    r_qMeas_qTrue_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].r_qMeas_qTrue +
+                                        xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].r_qMeas_qTrue) +
+                     yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].r_qMeas_qTrue +
+                                xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].r_qMeas_qTrue);
+
+    for (i = 0; i < 4; ++i) {
+      xavg_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xavg[i] +
+                                    xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xavg[i]) +
+                 yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xavg[i] +
+                            xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavg[i]);
+      if (flip_x) {
+        xavg_[i] = -xavg_[i];
       }
-      
-      
-      // Do the spares next
-      
-      chi2xavgone_=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgone + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgone);
-      if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgone != 0.f) {chi2xavgone_=chi2xavgone_/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgone*chi2xavgone;}
-      
-      chi2xminone_=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminone + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminone);
-      if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone != 0.f) {chi2xminone_=chi2xminone_/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone*chi2xminone;}
-      
-      fracxone_ = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].fracxone + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].fracxone)
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxone + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxone);
-      fracxtwo_ = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].fracxtwo + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].fracxtwo)
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxtwo + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxtwo);
-   
-      //       for(i=0; i<10; ++i) {
-      //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xspare[i])
-      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xspare[i]);
-      //       }
-      
-      // Interpolate and build the x-template
-      
-      //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
-      
-      cotbeta0 =  thePixelTemp_[index_id_].entx[iyhigh][0].cotbeta;
-      qxtempcor=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta0*cotbeta0+cotalpha*cotalpha));
-      
-      for(i=0; i<9; ++i) {
-         xtemp_[i][0] = 0.f;
-         xtemp_[i][1] = 0.f;
-         xtemp_[i][BXM2] = 0.f;
-         xtemp_[i][BXM1] = 0.f;
-         for(j=0; j<TXSIZE; ++j) {
-            //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
-            //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
-            //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j];
-            if(flip_x) {
-               xtemp_[8-i][BXM3-j]=qxtempcor*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
-            } else {
-               xtemp_[i][j+2]=qxtempcor*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
-            }
-         }
+
+      xrms_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xrms[i] +
+                                    xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xrms[i]) +
+                 yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xrms[i] +
+                            xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrms[i]);
+
+      //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xgx0[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xgx0[i])
+      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xgx0[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xgx0[i]);
+
+      //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xgsig[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xgsig[i])
+      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xgsig[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xgsig[i]);
+
+      xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xavgc2m[i] +
+                                       xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xavgc2m[i]) +
+                    yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xavgc2m[i] +
+                               xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavgc2m[i]);
+      if (flip_x) {
+        xavgc2m_[i] = -xavgc2m_[i];
       }
-      
-      lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
-      lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
-      lorybias_ = thePixelTemp_[index_id_].head.lorybias;
-      lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
-      if(flip_x) {lorxwidth_ = -lorxwidth_; lorxbias_ = -lorxbias_;}
-      if(flip_y) {lorywidth_ = -lorywidth_; lorybias_ = -lorybias_;}
-      
-      
-   }
-   
-   return success_;
-} // interpolate
 
+      xrmsc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xrmsc2m[i] +
+                                       xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xrmsc2m[i]) +
+                    yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xrmsc2m[i] +
+                               xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrmsc2m[i]);
 
+      //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].chi2xavgc2m[i])
+      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgc2m[i]);
 
+      //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].chi2xminc2m[i])
+      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminc2m[i]);
+      //
+      //  Try new interpolation scheme
+      //
+      //	      chi2xavg_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xavg[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xavg[i]);
+      //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xavg[i] != 0.f) {chi2xavg_[i]=chi2xavg_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xavg[i]*chi2xavg[i];}
+      //
+      //	      chi2xmin_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xmin[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xmin[i]);
+      //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i] != 0.f) {chi2xmin_[i]=chi2xmin_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i]*chi2xmin[i];}
+      //
+      chi2xavg_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavg[i] +
+                      xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavg[i]);
+      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavg[i] != 0.f) {
+        chi2xavg_[i] = chi2xavg_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavg[i] * chi2xavg[i];
+      }
 
+      chi2xmin_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xmin[i] +
+                      xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xmin[i]);
+      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xmin[i] != 0.f) {
+        chi2xmin_[i] = chi2xmin_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xmin[i] * chi2xmin[i];
+      }
+
+      chi2xavgc2m_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgc2m[i] +
+                         xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgc2m[i]);
+      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgc2m[i] != 0.f) {
+        chi2xavgc2m_[i] =
+            chi2xavgc2m_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgc2m[i] * chi2xavgc2m[i];
+      }
+
+      chi2xminc2m_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminc2m[i] +
+                         xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminc2m[i]);
+      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminc2m[i] != 0.f) {
+        chi2xminc2m_[i] =
+            chi2xminc2m_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminc2m[i] * chi2xminc2m[i];
+      }
+
+      for (j = 0; j < 6; ++j) {
+        xflparll_[i][j] = thePixelTemp_[index_id_].entx[iylow][ilow].xflpar[i][j];
+        xflparlh_[i][j] = thePixelTemp_[index_id_].entx[iylow][ihigh].xflpar[i][j];
+        xflparhl_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ilow].xflpar[i][j];
+        xflparhh_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ihigh].xflpar[i][j];
+        // Since Q_fl is odd under cotalpha, it flips qutomatically, change only even terms
+        if (flip_x && (j == 0 || j == 2 || j == 4)) {
+          xflparll_[i][j] = -xflparll_[i][j];
+          xflparlh_[i][j] = -xflparlh_[i][j];
+          xflparhl_[i][j] = -xflparhl_[i][j];
+          xflparhh_[i][j] = -xflparhh_[i][j];
+        }
+      }
+    }
+
+    // Do the spares next
+
+    chi2xavgone_ = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgone +
+                    xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgone);
+    if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgone != 0.f) {
+      chi2xavgone_ = chi2xavgone_ / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgone * chi2xavgone;
+    }
+
+    chi2xminone_ = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminone +
+                    xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminone);
+    if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone != 0.f) {
+      chi2xminone_ = chi2xminone_ / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone * chi2xminone;
+    }
+
+    fracxone_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].fracxone +
+                                   xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].fracxone) +
+                yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxone +
+                           xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxone);
+    fracxtwo_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].fracxtwo +
+                                   xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].fracxtwo) +
+                yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxtwo +
+                           xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxtwo);
+
+    //       for(i=0; i<10; ++i) {
+    //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xspare[i])
+    //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xspare[i]);
+    //       }
+
+    // Interpolate and build the x-template
+
+    //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
+
+    cotbeta0 = thePixelTemp_[index_id_].entx[iyhigh][0].cotbeta;
+    qxtempcor =
+        std::sqrt((1.f + cotbeta * cotbeta + cotalpha * cotalpha) / (1.f + cotbeta0 * cotbeta0 + cotalpha * cotalpha));
+
+    for (i = 0; i < 9; ++i) {
+      xtemp_[i][0] = 0.f;
+      xtemp_[i][1] = 0.f;
+      xtemp_[i][BXM2] = 0.f;
+      xtemp_[i][BXM1] = 0.f;
+      for (j = 0; j < TXSIZE; ++j) {
+        //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
+        //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
+        //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j];
+        if (flip_x) {
+          xtemp_[8 - i][BXM3 - j] =
+              qxtempcor * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] +
+                           xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
+        } else {
+          xtemp_[i][j + 2] = qxtempcor * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] +
+                                          xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
+        }
+      }
+    }
+
+    lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
+    lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
+    lorybias_ = thePixelTemp_[index_id_].head.lorybias;
+    lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
+    if (flip_x) {
+      lorxwidth_ = -lorxwidth_;
+      lorxbias_ = -lorxbias_;
+    }
+    if (flip_y) {
+      lorywidth_ = -lorywidth_;
+      lorybias_ = -lorybias_;
+    }
+  }
+
+  return success_;
+}  // interpolate
 
 // ************************************************************************************************************
 //! Interpolate input alpha and beta angles to produce a working template for each individual hit.
@@ -1494,19 +1920,20 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
 //! Use this for Phase 1, IP related hits
 // ************************************************************************************************************
-bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta)
-{
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   float locBx = 1.f;
-   if(cotbeta < 0.f) {locBx = -1.f;}
-   float locBz = locBx;
-   if(cotalpha < 0.f) {locBz = -locBx;}
-   return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta) {
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  float locBx = 1.f;
+  if (cotbeta < 0.f) {
+    locBx = -1.f;
+  }
+  float locBz = locBx;
+  if (cotalpha < 0.f) {
+    locBz = -locBx;
+  }
+  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
 }
-
-
 
 // ************************************************************************************************************
 //! Interpolate input alpha and beta angles to produce a working template for each individual hit.
@@ -1515,15 +1942,13 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta)
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
 //! Use this for Phase 0, IP related hits
 // ************************************************************************************************************
-bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz)
-{
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   float locBx = 1.f;
-   return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
-}
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz) {
+  // Interpolate for a new set of track angles
 
+  // Local variables
+  float locBx = 1.f;
+  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
+}
 
 // ************************************************************************************************************
 //! Return vector of y errors (squared) for an input vector of projected signals
@@ -1537,75 +1962,84 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 void SiPixelTemplate::ysigma2(int fypix, int lypix, float sythr, float ysum[25], float ysig2[25])
 
 {
-   // Interpolate using quantities already stored in the private variables
-   
-   // Local variables
-   int i;
-   float sigi, sigi2, sigi3, sigi4, symax, qscale, s25;
-   
-   // Make sure that input is OK
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(fypix < 2 || fypix >= BYM2) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ysigma2 called with fypix = " << fypix << std::endl;
-   }
-#else
-   assert(fypix > 1 && fypix < BYM2);
-#endif
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(lypix < fypix || lypix >= BYM2) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ysigma2 called with lypix/fypix = " << lypix << "/" << fypix << std::endl;
-   }
-#else
-   assert(lypix >= fypix && lypix < BYM2);
-#endif
-   
-   // Define the maximum signal to use in the parameterization
-   
-   symax = symax_;
-   s25 = 0.5f*s50_;
-   if(symax_ > syparmax_) {symax = syparmax_;}
-   
-   // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
-   
-   for(i=fypix-2; i<=lypix+2; ++i) {
-      if(i < fypix || i > lypix) {
-         
-         // Nearest pseudopixels have uncertainties of 50% of threshold, next-nearest have 10% of threshold
-         
-         ysig2[i] = s50_*s50_;
-      } else {
-         if(ysum[i] < symax) {
-            sigi = ysum[i];
-            qscale = 1.f;
-            if(sigi < s25) sigi = s25;
-         } else {
-            sigi = symax;
-            qscale = ysum[i]/symax;
-         }
-         sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
-         if(i <= BHY) {
-            ysig2[i] = (1.f-yratio_)*
-            (yparl_[0][0]+yparl_[0][1]*sigi+yparl_[0][2]*sigi2+yparl_[0][3]*sigi3+yparl_[0][4]*sigi4)
-            + yratio_*
-            (yparh_[0][0]+yparh_[0][1]*sigi+yparh_[0][2]*sigi2+yparh_[0][3]*sigi3+yparh_[0][4]*sigi4);
-         } else {
-            ysig2[i] = (1.f-yratio_)*
-            (yparl_[1][0]+yparl_[1][1]*sigi+yparl_[1][2]*sigi2+yparl_[1][3]*sigi3+yparl_[1][4]*sigi4)
-            + yratio_*
-            (yparh_[1][0]+yparh_[1][1]*sigi+yparh_[1][2]*sigi2+yparh_[1][3]*sigi3+yparh_[1][4]*sigi4);
-         }
-         ysig2[i] *=qscale;
-         if(ysum[i] > sythr) {ysig2[i] = 1.e8;}
-         if(ysig2[i] <= 0.f) {LOGERROR("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_ <<
-            ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_ <<  ", sigi = " << sigi << ENDL;}
-      }
-   }
-   
-   return;
-   
-} // End ysigma2
+  // Interpolate using quantities already stored in the private variables
 
+  // Local variables
+  int i;
+  float sigi, sigi2, sigi3, sigi4, symax, qscale, s25;
+
+  // Make sure that input is OK
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (fypix < 2 || fypix >= BYM2) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ysigma2 called with fypix = " << fypix << std::endl;
+  }
+#else
+  assert(fypix > 1 && fypix < BYM2);
+#endif
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (lypix < fypix || lypix >= BYM2) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ysigma2 called with lypix/fypix = " << lypix << "/"
+                                        << fypix << std::endl;
+  }
+#else
+  assert(lypix >= fypix && lypix < BYM2);
+#endif
+
+  // Define the maximum signal to use in the parameterization
+
+  symax = symax_;
+  s25 = 0.5f * s50_;
+  if (symax_ > syparmax_) {
+    symax = syparmax_;
+  }
+
+  // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
+
+  for (i = fypix - 2; i <= lypix + 2; ++i) {
+    if (i < fypix || i > lypix) {
+      // Nearest pseudopixels have uncertainties of 50% of threshold, next-nearest have 10% of threshold
+
+      ysig2[i] = s50_ * s50_;
+    } else {
+      if (ysum[i] < symax) {
+        sigi = ysum[i];
+        qscale = 1.f;
+        if (sigi < s25)
+          sigi = s25;
+      } else {
+        sigi = symax;
+        qscale = ysum[i] / symax;
+      }
+      sigi2 = sigi * sigi;
+      sigi3 = sigi2 * sigi;
+      sigi4 = sigi3 * sigi;
+      if (i <= BHY) {
+        ysig2[i] = (1.f - yratio_) * (yparl_[0][0] + yparl_[0][1] * sigi + yparl_[0][2] * sigi2 + yparl_[0][3] * sigi3 +
+                                      yparl_[0][4] * sigi4) +
+                   yratio_ * (yparh_[0][0] + yparh_[0][1] * sigi + yparh_[0][2] * sigi2 + yparh_[0][3] * sigi3 +
+                              yparh_[0][4] * sigi4);
+      } else {
+        ysig2[i] = (1.f - yratio_) * (yparl_[1][0] + yparl_[1][1] * sigi + yparl_[1][2] * sigi2 + yparl_[1][3] * sigi3 +
+                                      yparl_[1][4] * sigi4) +
+                   yratio_ * (yparh_[1][0] + yparh_[1][1] * sigi + yparh_[1][2] * sigi2 + yparh_[1][3] * sigi3 +
+                              yparh_[1][4] * sigi4);
+      }
+      ysig2[i] *= qscale;
+      if (ysum[i] > sythr) {
+        ysig2[i] = 1.e8;
+      }
+      if (ysig2[i] <= 0.f) {
+        LOGERROR("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_
+                                    << ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_
+                                    << ", sigi = " << sigi << ENDL;
+      }
+    }
+  }
+
+  return;
+
+}  // End ysigma2
 
 // ************************************************************************************************************
 //! Return y error (squared) for an input signal and yindex
@@ -1617,60 +2051,66 @@ void SiPixelTemplate::ysigma2(int fypix, int lypix, float sythr, float ysum[25],
 void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
 
 {
-   // Interpolate using quantities already stored in the private variables
-   
-   // Local variables
-   float sigi, sigi2, sigi3, sigi4, symax, qscale, err2, s25;
-   
-   // Make sure that input is OK
-   
+  // Interpolate using quantities already stored in the private variables
+
+  // Local variables
+  float sigi, sigi2, sigi3, sigi4, symax, qscale, err2, s25;
+
+  // Make sure that input is OK
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index < 2 || index >= BYM2) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ysigma2 called with index = " << index << std::endl;
-   }
+  if (index < 2 || index >= BYM2) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ysigma2 called with index = " << index << std::endl;
+  }
 #else
-   assert(index > 1 && index < BYM2);
+  assert(index > 1 && index < BYM2);
 #endif
-   
-   // Define the maximum signal to use in the parameterization
-   
-   symax = symax_;
-   s25 = 0.5f*s50_;
-   if(symax_ > syparmax_) {symax = syparmax_;}
-   
-   // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
-   
-			if(qpixel < symax) {
-            sigi = qpixel;
-            qscale = 1.f;
-            if(sigi < s25) sigi = s25;
-         } else {
-            sigi = symax;
-            qscale = qpixel/symax;
-         }
-			sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
-			if(index <= BHY) {
-            err2 = (1.f-yratio_)*
-            (yparl_[0][0]+yparl_[0][1]*sigi+yparl_[0][2]*sigi2+yparl_[0][3]*sigi3+yparl_[0][4]*sigi4)
-            + yratio_*
-            (yparh_[0][0]+yparh_[0][1]*sigi+yparh_[0][2]*sigi2+yparh_[0][3]*sigi3+yparh_[0][4]*sigi4);
-         } else {
-            err2 = (1.f-yratio_)*
-            (yparl_[1][0]+yparl_[1][1]*sigi+yparl_[1][2]*sigi2+yparl_[1][3]*sigi3+yparl_[1][4]*sigi4)
-            + yratio_*
-            (yparh_[1][0]+yparh_[1][1]*sigi+yparh_[1][2]*sigi2+yparh_[1][3]*sigi3+yparh_[1][4]*sigi4);
-         }
-			ysig2 =qscale*err2;
-			if(ysig2 <= 0.f) {LOGERROR("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_ <<
-            ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_ <<  ", sigi = " << sigi << ENDL;}
-   
-   return;
-   
-} // End ysigma2
 
+  // Define the maximum signal to use in the parameterization
 
+  symax = symax_;
+  s25 = 0.5f * s50_;
+  if (symax_ > syparmax_) {
+    symax = syparmax_;
+  }
 
+  // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
 
+  if (qpixel < symax) {
+    sigi = qpixel;
+    qscale = 1.f;
+    if (sigi < s25)
+      sigi = s25;
+  } else {
+    sigi = symax;
+    qscale = qpixel / symax;
+  }
+  sigi2 = sigi * sigi;
+  sigi3 = sigi2 * sigi;
+  sigi4 = sigi3 * sigi;
+  if (index <= BHY) {
+    err2 =
+        (1.f - yratio_) *
+            (yparl_[0][0] + yparl_[0][1] * sigi + yparl_[0][2] * sigi2 + yparl_[0][3] * sigi3 + yparl_[0][4] * sigi4) +
+        yratio_ *
+            (yparh_[0][0] + yparh_[0][1] * sigi + yparh_[0][2] * sigi2 + yparh_[0][3] * sigi3 + yparh_[0][4] * sigi4);
+  } else {
+    err2 =
+        (1.f - yratio_) *
+            (yparl_[1][0] + yparl_[1][1] * sigi + yparl_[1][2] * sigi2 + yparl_[1][3] * sigi3 + yparl_[1][4] * sigi4) +
+        yratio_ *
+            (yparh_[1][0] + yparh_[1][1] * sigi + yparh_[1][2] * sigi2 + yparh_[1][3] * sigi3 + yparh_[1][4] * sigi4);
+  }
+  ysig2 = qscale * err2;
+  if (ysig2 <= 0.f) {
+    LOGERROR("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_
+                                << ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_
+                                << ", sigi = " << sigi << ENDL;
+  }
+
+  return;
+
+}  // End ysigma2
 
 // ************************************************************************************************************
 //! Return vector of x errors (squared) for an input vector of projected signals
@@ -1684,108 +2124,115 @@ void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
 void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11], float xsig2[11])
 
 {
-   // Interpolate using quantities already stored in the private variables
-   
-   // Local variables
-   int i;
-   float sigi, sigi2, sigi3, sigi4, yint, sxmax, x0, qscale, s25;
-   
-   // Make sure that input is OK
-   
+  // Interpolate using quantities already stored in the private variables
+
+  // Local variables
+  int i;
+  float sigi, sigi2, sigi3, sigi4, yint, sxmax, x0, qscale, s25;
+
+  // Make sure that input is OK
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(fxpix < 2 || fxpix >= BXM2) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xsigma2 called with fxpix = " << fxpix << std::endl;
-   }
+  if (fxpix < 2 || fxpix >= BXM2) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xsigma2 called with fxpix = " << fxpix << std::endl;
+  }
 #else
-   assert(fxpix > 1 && fxpix < BXM2);
+  assert(fxpix > 1 && fxpix < BXM2);
 #endif
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(lxpix < fxpix || lxpix >= BXM2) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xsigma2 called with lxpix/fxpix = " << lxpix << "/" << fxpix << std::endl;
-   }
+  if (lxpix < fxpix || lxpix >= BXM2) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xsigma2 called with lxpix/fxpix = " << lxpix << "/"
+                                        << fxpix << std::endl;
+  }
 #else
-   assert(lxpix >= fxpix && lxpix < BXM2);
+  assert(lxpix >= fxpix && lxpix < BXM2);
 #endif
-   
-   // Define the maximum signal to use in the parameterization
-   
-   sxmax = sxmax_;
-   s25 = 0.5f*s50_;
-   if(sxmax_ > sxparmax_) {sxmax = sxparmax_;}
-   
-   // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
-   
-   for(i=fxpix-2; i<=lxpix+2; ++i) {
-      if(i < fxpix || i > lxpix) {
-         
-         // Nearest pseudopixels have uncertainties of 50% of threshold, next-nearest have 10% of threshold
-         
-         xsig2[i] = s50_*s50_;
+
+  // Define the maximum signal to use in the parameterization
+
+  sxmax = sxmax_;
+  s25 = 0.5f * s50_;
+  if (sxmax_ > sxparmax_) {
+    sxmax = sxparmax_;
+  }
+
+  // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
+
+  for (i = fxpix - 2; i <= lxpix + 2; ++i) {
+    if (i < fxpix || i > lxpix) {
+      // Nearest pseudopixels have uncertainties of 50% of threshold, next-nearest have 10% of threshold
+
+      xsig2[i] = s50_ * s50_;
+    } else {
+      if (xsum[i] < sxmax) {
+        sigi = xsum[i];
+        qscale = 1.f;
+        if (sigi < s25)
+          sigi = s25;
       } else {
-         if(xsum[i] < sxmax) {
-            sigi = xsum[i];
-            qscale = 1.f;
-            if(sigi < s25) sigi = s25;
-         } else {
-            sigi = sxmax;
-            qscale = xsum[i]/sxmax;
-         }
-         sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
-         
-         // First, do the cotbeta interpolation
-         
-         if(i <= BHX) {
-            yint = (1.f-yratio_)*
-            (xparly0_[0][0]+xparly0_[0][1]*sigi+xparly0_[0][2]*sigi2+xparly0_[0][3]*sigi3+xparly0_[0][4]*sigi4)
-            + yratio_*
-            (xparhy0_[0][0]+xparhy0_[0][1]*sigi+xparhy0_[0][2]*sigi2+xparhy0_[0][3]*sigi3+xparhy0_[0][4]*sigi4);
-         } else {
-            yint = (1.f-yratio_)*
-            (xparly0_[1][0]+xparly0_[1][1]*sigi+xparly0_[1][2]*sigi2+xparly0_[1][3]*sigi3+xparly0_[1][4]*sigi4)
-            + yratio_*
-            (xparhy0_[1][0]+xparhy0_[1][1]*sigi+xparhy0_[1][2]*sigi2+xparhy0_[1][3]*sigi3+xparhy0_[1][4]*sigi4);
-         }
-         
-         // Next, do the cotalpha interpolation
-         
-         if(i <= BHX) {
-            xsig2[i] = (1.f-xxratio_)*
-            (xparl_[0][0]+xparl_[0][1]*sigi+xparl_[0][2]*sigi2+xparl_[0][3]*sigi3+xparl_[0][4]*sigi4)
-            + xxratio_*
-            (xparh_[0][0]+xparh_[0][1]*sigi+xparh_[0][2]*sigi2+xparh_[0][3]*sigi3+xparh_[0][4]*sigi4);
-         } else {
-            xsig2[i] = (1.f-xxratio_)*
-            (xparl_[1][0]+xparl_[1][1]*sigi+xparl_[1][2]*sigi2+xparl_[1][3]*sigi3+xparl_[1][4]*sigi4)
-            + xxratio_*
-            (xparh_[1][0]+xparh_[1][1]*sigi+xparh_[1][2]*sigi2+xparh_[1][3]*sigi3+xparh_[1][4]*sigi4);
-         }
-         
-         // Finally, get the mid-point value of the cotalpha function
-         
-         if(i <= BHX) {
-            x0 = xpar0_[0][0]+xpar0_[0][1]*sigi+xpar0_[0][2]*sigi2+xpar0_[0][3]*sigi3+xpar0_[0][4]*sigi4;
-         } else {
-            x0 = xpar0_[1][0]+xpar0_[1][1]*sigi+xpar0_[1][2]*sigi2+xpar0_[1][3]*sigi3+xpar0_[1][4]*sigi4;
-         }
-         
-         // Finally, rescale the yint value for cotalpha variation
-         
-         if(x0 != 0.f) {xsig2[i] = xsig2[i]/x0 * yint;}
-         xsig2[i] *=qscale;
-         if(xsum[i] > sxthr) {xsig2[i] = 1.e8;}
-         if(xsig2[i] <= 0.f) {LOGERROR("SiPixelTemplate") << "neg x-error-squared, id = " << id_current_ << ", index = " << index_id_ <<
-            ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_  << ", sigi = " << sigi << ENDL;}
+        sigi = sxmax;
+        qscale = xsum[i] / sxmax;
       }
-   }
-   
-   return;
-   
-} // End xsigma2
+      sigi2 = sigi * sigi;
+      sigi3 = sigi2 * sigi;
+      sigi4 = sigi3 * sigi;
 
+      // First, do the cotbeta interpolation
 
+      if (i <= BHX) {
+        yint = (1.f - yratio_) * (xparly0_[0][0] + xparly0_[0][1] * sigi + xparly0_[0][2] * sigi2 +
+                                  xparly0_[0][3] * sigi3 + xparly0_[0][4] * sigi4) +
+               yratio_ * (xparhy0_[0][0] + xparhy0_[0][1] * sigi + xparhy0_[0][2] * sigi2 + xparhy0_[0][3] * sigi3 +
+                          xparhy0_[0][4] * sigi4);
+      } else {
+        yint = (1.f - yratio_) * (xparly0_[1][0] + xparly0_[1][1] * sigi + xparly0_[1][2] * sigi2 +
+                                  xparly0_[1][3] * sigi3 + xparly0_[1][4] * sigi4) +
+               yratio_ * (xparhy0_[1][0] + xparhy0_[1][1] * sigi + xparhy0_[1][2] * sigi2 + xparhy0_[1][3] * sigi3 +
+                          xparhy0_[1][4] * sigi4);
+      }
 
+      // Next, do the cotalpha interpolation
 
+      if (i <= BHX) {
+        xsig2[i] = (1.f - xxratio_) * (xparl_[0][0] + xparl_[0][1] * sigi + xparl_[0][2] * sigi2 +
+                                       xparl_[0][3] * sigi3 + xparl_[0][4] * sigi4) +
+                   xxratio_ * (xparh_[0][0] + xparh_[0][1] * sigi + xparh_[0][2] * sigi2 + xparh_[0][3] * sigi3 +
+                               xparh_[0][4] * sigi4);
+      } else {
+        xsig2[i] = (1.f - xxratio_) * (xparl_[1][0] + xparl_[1][1] * sigi + xparl_[1][2] * sigi2 +
+                                       xparl_[1][3] * sigi3 + xparl_[1][4] * sigi4) +
+                   xxratio_ * (xparh_[1][0] + xparh_[1][1] * sigi + xparh_[1][2] * sigi2 + xparh_[1][3] * sigi3 +
+                               xparh_[1][4] * sigi4);
+      }
 
+      // Finally, get the mid-point value of the cotalpha function
+
+      if (i <= BHX) {
+        x0 = xpar0_[0][0] + xpar0_[0][1] * sigi + xpar0_[0][2] * sigi2 + xpar0_[0][3] * sigi3 + xpar0_[0][4] * sigi4;
+      } else {
+        x0 = xpar0_[1][0] + xpar0_[1][1] * sigi + xpar0_[1][2] * sigi2 + xpar0_[1][3] * sigi3 + xpar0_[1][4] * sigi4;
+      }
+
+      // Finally, rescale the yint value for cotalpha variation
+
+      if (x0 != 0.f) {
+        xsig2[i] = xsig2[i] / x0 * yint;
+      }
+      xsig2[i] *= qscale;
+      if (xsum[i] > sxthr) {
+        xsig2[i] = 1.e8;
+      }
+      if (xsig2[i] <= 0.f) {
+        LOGERROR("SiPixelTemplate") << "neg x-error-squared, id = " << id_current_ << ", index = " << index_id_
+                                    << ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_
+                                    << ", sigi = " << sigi << ENDL;
+      }
+    }
+  }
+
+  return;
+
+}  // End xsigma2
 
 // ************************************************************************************************************
 //! Return interpolated y-correction for input charge bin and qfly
@@ -1795,49 +2242,53 @@ void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11],
 float SiPixelTemplate::yflcorr(int binq, float qfly)
 
 {
-   // Interpolate using quantities already stored in the private variables
-   
-   // Local variables
-   float qfl, qfl2, qfl3, qfl4, qfl5, dy;
-   
-   // Make sure that input is OK
-   
+  // Interpolate using quantities already stored in the private variables
+
+  // Local variables
+  float qfl, qfl2, qfl3, qfl4, qfl5, dy;
+
+  // Make sure that input is OK
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(binq < 0 || binq > 3) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yflcorr called with binq = " << binq << std::endl;
-   }
+  if (binq < 0 || binq > 3) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yflcorr called with binq = " << binq << std::endl;
+  }
 #else
-   assert(binq >= 0 && binq < 4);
+  assert(binq >= 0 && binq < 4);
 #endif
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(fabs((double)qfly) > 1.) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yflcorr called with qfly = " << qfly << std::endl;
-   }
+  if (fabs((double)qfly) > 1.) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::yflcorr called with qfly = " << qfly << std::endl;
+  }
 #else
-   assert(fabs((double)qfly) <= 1.);
+  assert(fabs((double)qfly) <= 1.);
 #endif
-   
-   // Define the maximum signal to allow before de-weighting a pixel
-   
-   qfl = qfly;
-   
-   if(qfl < -0.9f) {qfl = -0.9f;}
-   if(qfl > 0.9f) {qfl = 0.9f;}
-   
-   // Interpolate between the two polynomials
-   
-   qfl2 = qfl*qfl; qfl3 = qfl2*qfl; qfl4 = qfl3*qfl; qfl5 = qfl4*qfl;
-   dy = (1.f-yratio_)*(yflparl_[binq][0]+yflparl_[binq][1]*qfl+yflparl_[binq][2]*qfl2+yflparl_[binq][3]*qfl3+yflparl_[binq][4]*qfl4+yflparl_[binq][5]*qfl5)
-   + yratio_*(yflparh_[binq][0]+yflparh_[binq][1]*qfl+yflparh_[binq][2]*qfl2+yflparh_[binq][3]*qfl3+yflparh_[binq][4]*qfl4+yflparh_[binq][5]*qfl5);
-   
-   return dy;
-   
-} // End yflcorr
 
+  // Define the maximum signal to allow before de-weighting a pixel
 
+  qfl = qfly;
 
+  if (qfl < -0.9f) {
+    qfl = -0.9f;
+  }
+  if (qfl > 0.9f) {
+    qfl = 0.9f;
+  }
 
+  // Interpolate between the two polynomials
 
+  qfl2 = qfl * qfl;
+  qfl3 = qfl2 * qfl;
+  qfl4 = qfl3 * qfl;
+  qfl5 = qfl4 * qfl;
+  dy = (1.f - yratio_) * (yflparl_[binq][0] + yflparl_[binq][1] * qfl + yflparl_[binq][2] * qfl2 +
+                          yflparl_[binq][3] * qfl3 + yflparl_[binq][4] * qfl4 + yflparl_[binq][5] * qfl5) +
+       yratio_ * (yflparh_[binq][0] + yflparh_[binq][1] * qfl + yflparh_[binq][2] * qfl2 + yflparh_[binq][3] * qfl3 +
+                  yflparh_[binq][4] * qfl4 + yflparh_[binq][5] * qfl5);
+
+  return dy;
+
+}  // End yflcorr
 
 // ************************************************************************************************************
 //! Return interpolated x-correction for input charge bin and qflx
@@ -1847,48 +2298,59 @@ float SiPixelTemplate::yflcorr(int binq, float qfly)
 float SiPixelTemplate::xflcorr(int binq, float qflx)
 
 {
-   // Interpolate using quantities already stored in the private variables
-   
-   // Local variables
-   float qfl, qfl2, qfl3, qfl4, qfl5, dx;
-   
-   // Make sure that input is OK
-   
+  // Interpolate using quantities already stored in the private variables
+
+  // Local variables
+  float qfl, qfl2, qfl3, qfl4, qfl5, dx;
+
+  // Make sure that input is OK
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(binq < 0 || binq > 3) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xflcorr called with binq = " << binq << std::endl;
-   }
+  if (binq < 0 || binq > 3) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xflcorr called with binq = " << binq << std::endl;
+  }
 #else
-   assert(binq >= 0 && binq < 4);
+  assert(binq >= 0 && binq < 4);
 #endif
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(fabs((double)qflx) > 1.) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xflcorr called with qflx = " << qflx << std::endl;
-   }
+  if (fabs((double)qflx) > 1.) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xflcorr called with qflx = " << qflx << std::endl;
+  }
 #else
-   assert(fabs((double)qflx) <= 1.);
+  assert(fabs((double)qflx) <= 1.);
 #endif
-   
-   // Define the maximum signal to allow before de-weighting a pixel
-   
-   qfl = qflx;
-   
-   if(qfl < -0.9f) {qfl = -0.9f;}
-   if(qfl > 0.9f) {qfl = 0.9f;}
-   
-   // Interpolate between the two polynomials
-   
-   qfl2 = qfl*qfl; qfl3 = qfl2*qfl; qfl4 = qfl3*qfl; qfl5 = qfl4*qfl;
-   dx = (1.f - yxratio_)*((1.f-xxratio_)*(xflparll_[binq][0]+xflparll_[binq][1]*qfl+xflparll_[binq][2]*qfl2+xflparll_[binq][3]*qfl3+xflparll_[binq][4]*qfl4+xflparll_[binq][5]*qfl5)
-                          + xxratio_*(xflparlh_[binq][0]+xflparlh_[binq][1]*qfl+xflparlh_[binq][2]*qfl2+xflparlh_[binq][3]*qfl3+xflparlh_[binq][4]*qfl4+xflparlh_[binq][5]*qfl5))
-   + yxratio_*((1.f-xxratio_)*(xflparhl_[binq][0]+xflparhl_[binq][1]*qfl+xflparhl_[binq][2]*qfl2+xflparhl_[binq][3]*qfl3+xflparhl_[binq][4]*qfl4+xflparhl_[binq][5]*qfl5)
-               + xxratio_*(xflparhh_[binq][0]+xflparhh_[binq][1]*qfl+xflparhh_[binq][2]*qfl2+xflparhh_[binq][3]*qfl3+xflparhh_[binq][4]*qfl4+xflparhh_[binq][5]*qfl5));
-   
-   return dx;
-   
-} // End xflcorr
 
+  // Define the maximum signal to allow before de-weighting a pixel
 
+  qfl = qflx;
+
+  if (qfl < -0.9f) {
+    qfl = -0.9f;
+  }
+  if (qfl > 0.9f) {
+    qfl = 0.9f;
+  }
+
+  // Interpolate between the two polynomials
+
+  qfl2 = qfl * qfl;
+  qfl3 = qfl2 * qfl;
+  qfl4 = qfl3 * qfl;
+  qfl5 = qfl4 * qfl;
+  dx = (1.f - yxratio_) *
+           ((1.f - xxratio_) * (xflparll_[binq][0] + xflparll_[binq][1] * qfl + xflparll_[binq][2] * qfl2 +
+                                xflparll_[binq][3] * qfl3 + xflparll_[binq][4] * qfl4 + xflparll_[binq][5] * qfl5) +
+            xxratio_ * (xflparlh_[binq][0] + xflparlh_[binq][1] * qfl + xflparlh_[binq][2] * qfl2 +
+                        xflparlh_[binq][3] * qfl3 + xflparlh_[binq][4] * qfl4 + xflparlh_[binq][5] * qfl5)) +
+       yxratio_ *
+           ((1.f - xxratio_) * (xflparhl_[binq][0] + xflparhl_[binq][1] * qfl + xflparhl_[binq][2] * qfl2 +
+                                xflparhl_[binq][3] * qfl3 + xflparhl_[binq][4] * qfl4 + xflparhl_[binq][5] * qfl5) +
+            xxratio_ * (xflparhh_[binq][0] + xflparhh_[binq][1] * qfl + xflparhh_[binq][2] * qfl2 +
+                        xflparhh_[binq][3] * qfl3 + xflparhh_[binq][4] * qfl4 + xflparhh_[binq][5] * qfl5));
+
+  return dx;
+
+}  // End xflcorr
 
 // ************************************************************************************************************
 //! Return interpolated y-template in single call
@@ -1899,74 +2361,72 @@ float SiPixelTemplate::xflcorr(int binq, float qflx)
 void SiPixelTemplate::ytemp(int fybin, int lybin, float ytemplate[41][BYSIZE])
 
 {
-   // Retrieve already interpolated quantities
-   
-   // Local variables
-   int i, j;
-   
-   // Verify that input parameters are in valid range
-   
+  // Retrieve already interpolated quantities
+
+  // Local variables
+  int i, j;
+
+  // Verify that input parameters are in valid range
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(fybin < 0 || fybin > 40) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ytemp called with fybin = " << fybin << std::endl;
-   }
+  if (fybin < 0 || fybin > 40) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ytemp called with fybin = " << fybin << std::endl;
+  }
 #else
-   assert(fybin >= 0 && fybin < 41);
+  assert(fybin >= 0 && fybin < 41);
 #endif
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(lybin < 0 || lybin > 40) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ytemp called with lybin = " << lybin << std::endl;
-   }
+  if (lybin < 0 || lybin > 40) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ytemp called with lybin = " << lybin << std::endl;
+  }
 #else
-   assert(lybin >= 0 && lybin < 41);
+  assert(lybin >= 0 && lybin < 41);
 #endif
-   
-   // Build the y-template, the central 25 bins are here in all cases
-   
-   for(i=0; i<9; ++i) {
-      for(j=0; j<BYSIZE; ++j) {
-         ytemplate[i+16][j]=ytemp_[i][j];
-      }
-   }
-   for(i=0; i<8; ++i) {
-      ytemplate[i+8][BYM1] = 0.f;
-      for(j=0; j<BYM1; ++j) {
-         ytemplate[i+8][j]=ytemp_[i][j+1];
-      }
-   }
-   for(i=1; i<9; ++i) {
-      ytemplate[i+24][0] = 0.f;
-      for(j=0; j<BYM1; ++j) {
-         ytemplate[i+24][j+1]=ytemp_[i][j];
-      }
-   }
-   
-   //  Add	more bins if needed
-   
-   if(fybin < 8) {
-      for(i=0; i<8; ++i) {
-         ytemplate[i][BYM2] = 0.f;
-         ytemplate[i][BYM1] = 0.f;
-         for(j=0; j<BYM2; ++j) {
-            ytemplate[i][j]=ytemp_[i][j+2];
-         }
-      }
-   }
-   if(lybin > 32) {
-  	   for(i=1; i<9; ++i) {
-         ytemplate[i+32][0] = 0.f;
-         ytemplate[i+32][1] = 0.f;
-         for(j=0; j<BYM2; ++j) {
-            ytemplate[i+32][j+2]=ytemp_[i][j];
-         }
-      }
-   }
-   
-   return;
-   
-} // End ytemp
 
+  // Build the y-template, the central 25 bins are here in all cases
 
+  for (i = 0; i < 9; ++i) {
+    for (j = 0; j < BYSIZE; ++j) {
+      ytemplate[i + 16][j] = ytemp_[i][j];
+    }
+  }
+  for (i = 0; i < 8; ++i) {
+    ytemplate[i + 8][BYM1] = 0.f;
+    for (j = 0; j < BYM1; ++j) {
+      ytemplate[i + 8][j] = ytemp_[i][j + 1];
+    }
+  }
+  for (i = 1; i < 9; ++i) {
+    ytemplate[i + 24][0] = 0.f;
+    for (j = 0; j < BYM1; ++j) {
+      ytemplate[i + 24][j + 1] = ytemp_[i][j];
+    }
+  }
+
+  //  Add	more bins if needed
+
+  if (fybin < 8) {
+    for (i = 0; i < 8; ++i) {
+      ytemplate[i][BYM2] = 0.f;
+      ytemplate[i][BYM1] = 0.f;
+      for (j = 0; j < BYM2; ++j) {
+        ytemplate[i][j] = ytemp_[i][j + 2];
+      }
+    }
+  }
+  if (lybin > 32) {
+    for (i = 1; i < 9; ++i) {
+      ytemplate[i + 32][0] = 0.f;
+      ytemplate[i + 32][1] = 0.f;
+      for (j = 0; j < BYM2; ++j) {
+        ytemplate[i + 32][j + 2] = ytemp_[i][j];
+      }
+    }
+  }
+
+  return;
+
+}  // End ytemp
 
 // ************************************************************************************************************
 //! Return interpolated y-template in single call
@@ -1977,73 +2437,72 @@ void SiPixelTemplate::ytemp(int fybin, int lybin, float ytemplate[41][BYSIZE])
 void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE])
 
 {
-   // Retrieve already interpolated quantities
-   
-   // Local variables
-   int i, j;
-   
-   // Verify that input parameters are in valid range
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(fxbin < 0 || fxbin > 40) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xtemp called with fxbin = " << fxbin << std::endl;
-   }
-#else
-   assert(fxbin >= 0 && fxbin < 41);
-#endif
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(lxbin < 0 || lxbin > 40) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xtemp called with lxbin = " << lxbin << std::endl;
-   }
-#else
-   assert(lxbin >= 0 && lxbin < 41);
-#endif
-   
-   // Build the x-template, the central 25 bins are here in all cases
-   
-   for(i=0; i<9; ++i) {
-      for(j=0; j<BXSIZE; ++j) {
-         xtemplate[i+16][j]=xtemp_[i][j];
-      }
-   }
-   for(i=0; i<8; ++i) {
-      xtemplate[i+8][BXM1] = 0.f;
-      for(j=0; j<BXM1; ++j) {
-         xtemplate[i+8][j]=xtemp_[i][j+1];
-      }
-   }
-   for(i=1; i<9; ++i) {
-      xtemplate[i+24][0] = 0.f;
-      for(j=0; j<BXM1; ++j) {
-         xtemplate[i+24][j+1]=xtemp_[i][j];
-      }
-   }
-   
-   //  Add more bins if needed
-   
-   if(fxbin < 8) {
-      for(i=0; i<8; ++i) {
-         xtemplate[i][BXM2] = 0.f;
-         xtemplate[i][BXM1] = 0.f;
-         for(j=0; j<BXM2; ++j) {
-            xtemplate[i][j]=xtemp_[i][j+2];
-         }
-      }
-   }
-   if(lxbin > 32) {
-      for(i=1; i<9; ++i) {
-         xtemplate[i+32][0] = 0.f;
-         xtemplate[i+32][1] = 0.f;
-         for(j=0; j<BXM2; ++j) {
-            xtemplate[i+32][j+2]=xtemp_[i][j];
-         }
-      }
-   }
-   
-   return;
-   
-} // End xtemp
+  // Retrieve already interpolated quantities
 
+  // Local variables
+  int i, j;
+
+  // Verify that input parameters are in valid range
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (fxbin < 0 || fxbin > 40) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xtemp called with fxbin = " << fxbin << std::endl;
+  }
+#else
+  assert(fxbin >= 0 && fxbin < 41);
+#endif
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (lxbin < 0 || lxbin > 40) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xtemp called with lxbin = " << lxbin << std::endl;
+  }
+#else
+  assert(lxbin >= 0 && lxbin < 41);
+#endif
+
+  // Build the x-template, the central 25 bins are here in all cases
+
+  for (i = 0; i < 9; ++i) {
+    for (j = 0; j < BXSIZE; ++j) {
+      xtemplate[i + 16][j] = xtemp_[i][j];
+    }
+  }
+  for (i = 0; i < 8; ++i) {
+    xtemplate[i + 8][BXM1] = 0.f;
+    for (j = 0; j < BXM1; ++j) {
+      xtemplate[i + 8][j] = xtemp_[i][j + 1];
+    }
+  }
+  for (i = 1; i < 9; ++i) {
+    xtemplate[i + 24][0] = 0.f;
+    for (j = 0; j < BXM1; ++j) {
+      xtemplate[i + 24][j + 1] = xtemp_[i][j];
+    }
+  }
+
+  //  Add more bins if needed
+
+  if (fxbin < 8) {
+    for (i = 0; i < 8; ++i) {
+      xtemplate[i][BXM2] = 0.f;
+      xtemplate[i][BXM1] = 0.f;
+      for (j = 0; j < BXM2; ++j) {
+        xtemplate[i][j] = xtemp_[i][j + 2];
+      }
+    }
+  }
+  if (lxbin > 32) {
+    for (i = 1; i < 9; ++i) {
+      xtemplate[i + 32][0] = 0.f;
+      xtemplate[i + 32][1] = 0.f;
+      for (j = 0; j < BXM2; ++j) {
+        xtemplate[i + 32][j + 2] = xtemp_[i][j];
+      }
+    }
+  }
+
+  return;
+
+}  // End xtemp
 
 // ************************************************************************************************************
 //! Return central pixel of y template pixels above readout threshold
@@ -2051,48 +2510,52 @@ void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE])
 int SiPixelTemplate::cytemp()
 
 {
-   // Retrieve already interpolated quantities
-   
-   // Local variables
-   int j;
-   
-   // Analyze only pixels along the central entry
-   // First, find the maximum signal and then work out to the edges
-   
-   float sigmax = 0.f;
-   float qedge = 2.*s50_;
-   int jmax = -1;
-   
-   for(j=0; j<BYSIZE; ++j) {
-      if(ytemp_[4][j] > sigmax) {
-         sigmax = ytemp_[4][j];
-         jmax = j;
-      }
-   }
-   if(sigmax < qedge) {qedge = s50_;}
-   if(sigmax < qedge || jmax<1 || jmax>BYM2) {return -1;}
-   
-   //  Now search forward and backward
-   
-   int jend = jmax;
-   
-   for(j=jmax+1; j<BYM1; ++j) {
-      if(ytemp_[4][j] < qedge) break;
-      jend = j;
-   }
-   
-   int jbeg = jmax;
-   
-   for(j=jmax-1; j>0; --j) {
-      if(ytemp_[4][j] < qedge) break;
-      jbeg = j;
-   }
-   
-   return (jbeg+jend)/2;
-   
-} // End cytemp
+  // Retrieve already interpolated quantities
 
+  // Local variables
+  int j;
 
+  // Analyze only pixels along the central entry
+  // First, find the maximum signal and then work out to the edges
+
+  float sigmax = 0.f;
+  float qedge = 2. * s50_;
+  int jmax = -1;
+
+  for (j = 0; j < BYSIZE; ++j) {
+    if (ytemp_[4][j] > sigmax) {
+      sigmax = ytemp_[4][j];
+      jmax = j;
+    }
+  }
+  if (sigmax < qedge) {
+    qedge = s50_;
+  }
+  if (sigmax < qedge || jmax < 1 || jmax > BYM2) {
+    return -1;
+  }
+
+  //  Now search forward and backward
+
+  int jend = jmax;
+
+  for (j = jmax + 1; j < BYM1; ++j) {
+    if (ytemp_[4][j] < qedge)
+      break;
+    jend = j;
+  }
+
+  int jbeg = jmax;
+
+  for (j = jmax - 1; j > 0; --j) {
+    if (ytemp_[4][j] < qedge)
+      break;
+    jbeg = j;
+  }
+
+  return (jbeg + jend) / 2;
+
+}  // End cytemp
 
 // ************************************************************************************************************
 //! Return central pixel of x-template pixels above readout threshold
@@ -2100,47 +2563,52 @@ int SiPixelTemplate::cytemp()
 int SiPixelTemplate::cxtemp()
 
 {
-   // Retrieve already interpolated quantities
-   
-   // Local variables
-   int j;
-   
-   // Analyze only pixels along the central entry
-   // First, find the maximum signal and then work out to the edges
-   
-   float sigmax = 0.f;
-   float qedge = 2.*s50_;
-   int jmax = -1;
-   
-   for(j=0; j<BXSIZE; ++j) {
-      if(xtemp_[4][j] > sigmax) {
-         sigmax = xtemp_[4][j];
-         jmax = j;
-      }
-   }
-   if(sigmax < qedge) {qedge = s50_;}
-   if(sigmax < qedge || jmax<1 || jmax>BXM2) {return -1;}
-   
-   //  Now search forward and backward
-   
-   int jend = jmax;
-   
-   for(j=jmax+1; j<BXM1; ++j) {
-      if(xtemp_[4][j] < qedge) break;
-      jend = j;
-   }
-   
-   int jbeg = jmax;
-   
-   for(j=jmax-1; j>0; --j) {
-      if(xtemp_[4][j] < qedge) break;
-      jbeg = j;
-   }
-   
-   return (jbeg+jend)/2;
-   
-} // End cxtemp
+  // Retrieve already interpolated quantities
 
+  // Local variables
+  int j;
+
+  // Analyze only pixels along the central entry
+  // First, find the maximum signal and then work out to the edges
+
+  float sigmax = 0.f;
+  float qedge = 2. * s50_;
+  int jmax = -1;
+
+  for (j = 0; j < BXSIZE; ++j) {
+    if (xtemp_[4][j] > sigmax) {
+      sigmax = xtemp_[4][j];
+      jmax = j;
+    }
+  }
+  if (sigmax < qedge) {
+    qedge = s50_;
+  }
+  if (sigmax < qedge || jmax < 1 || jmax > BXM2) {
+    return -1;
+  }
+
+  //  Now search forward and backward
+
+  int jend = jmax;
+
+  for (j = jmax + 1; j < BXM1; ++j) {
+    if (xtemp_[4][j] < qedge)
+      break;
+    jend = j;
+  }
+
+  int jbeg = jmax;
+
+  for (j = jmax - 1; j > 0; --j) {
+    if (xtemp_[4][j] < qedge)
+      break;
+    jbeg = j;
+  }
+
+  return (jbeg + jend) / 2;
+
+}  // End cxtemp
 
 // ************************************************************************************************************
 //! Make interpolated 3d y-template (stored as class variables)
@@ -2150,75 +2618,75 @@ int SiPixelTemplate::cxtemp()
 void SiPixelTemplate::ytemp3d_int(int nypix, int& nybins)
 
 {
-   
-   // Retrieve already interpolated quantities
-   
-   // Local variables
-   int i, j, k;
-   int ioff0, ioffp, ioffm;
-   
-   // Verify that input parameters are in valid range
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(nypix < 1 || nypix >= BYM3) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ytemp3d called with nypix = " << nypix << std::endl;
-   }
-#else
-   assert(nypix > 0 && nypix < BYM3);
-#endif
-   
-   // Calculate the size of the shift in pixels needed to span the entire cluster
-   
-   float diff = fabsf(nypix - clsleny_)/2. + 1.f;
-   int nshift = (int)diff;
-   if((diff - nshift) > 0.5f) {++nshift;}
-   
-   // Calculate the number of bins needed to specify each hit range
-   
-   nybins_ = 9 + 16*nshift;
-   
-   // Create a 2-d working template with the correct size
-   
-   temp2dy_.resize(boost::extents[nybins_][BYSIZE]);
-   
-   //  The 9 central bins are copied from the interpolated private store
-   
-   ioff0 = 8*nshift;
-   
-   for(i=0; i<9; ++i) {
-      for(j=0; j<BYSIZE; ++j) {
-         temp2dy_[i+ioff0][j]=ytemp_[i][j];
-      }
-   }
-   
-   // Add the +- shifted templates
-   
-   for(k=1; k<=nshift; ++k) {
-      ioffm=ioff0-k*8;
-      for(i=0; i<8; ++i) {
-         for(j=0; j<k; ++j) {
-            temp2dy_[i+ioffm][BYM1-j] = 0.f;
-         }
-         for(j=0; j<BYSIZE-k; ++j) {
-            temp2dy_[i+ioffm][j]=ytemp_[i][j+k];
-         }
-      }
-      ioffp=ioff0+k*8;
-      for(i=1; i<9; ++i) {
-         for(j=0; j<k; ++j) {
-            temp2dy_[i+ioffp][j] = 0.f;
-         }
-         for(j=0; j<BYSIZE-k; ++j) {
-            temp2dy_[i+ioffp][j+k]=ytemp_[i][j];
-         }
-      }
-   }
-   
-   nybins = nybins_;
-   return;
-   
-} // End ytemp3d_int
+  // Retrieve already interpolated quantities
 
+  // Local variables
+  int i, j, k;
+  int ioff0, ioffp, ioffm;
+
+  // Verify that input parameters are in valid range
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (nypix < 1 || nypix >= BYM3) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::ytemp3d called with nypix = " << nypix << std::endl;
+  }
+#else
+  assert(nypix > 0 && nypix < BYM3);
+#endif
+
+  // Calculate the size of the shift in pixels needed to span the entire cluster
+
+  float diff = fabsf(nypix - clsleny_) / 2. + 1.f;
+  int nshift = (int)diff;
+  if ((diff - nshift) > 0.5f) {
+    ++nshift;
+  }
+
+  // Calculate the number of bins needed to specify each hit range
+
+  nybins_ = 9 + 16 * nshift;
+
+  // Create a 2-d working template with the correct size
+
+  temp2dy_.resize(boost::extents[nybins_][BYSIZE]);
+
+  //  The 9 central bins are copied from the interpolated private store
+
+  ioff0 = 8 * nshift;
+
+  for (i = 0; i < 9; ++i) {
+    for (j = 0; j < BYSIZE; ++j) {
+      temp2dy_[i + ioff0][j] = ytemp_[i][j];
+    }
+  }
+
+  // Add the +- shifted templates
+
+  for (k = 1; k <= nshift; ++k) {
+    ioffm = ioff0 - k * 8;
+    for (i = 0; i < 8; ++i) {
+      for (j = 0; j < k; ++j) {
+        temp2dy_[i + ioffm][BYM1 - j] = 0.f;
+      }
+      for (j = 0; j < BYSIZE - k; ++j) {
+        temp2dy_[i + ioffm][j] = ytemp_[i][j + k];
+      }
+    }
+    ioffp = ioff0 + k * 8;
+    for (i = 1; i < 9; ++i) {
+      for (j = 0; j < k; ++j) {
+        temp2dy_[i + ioffp][j] = 0.f;
+      }
+      for (j = 0; j < BYSIZE - k; ++j) {
+        temp2dy_[i + ioffp][j + k] = ytemp_[i][j];
+      }
+    }
+  }
+
+  nybins = nybins_;
+  return;
+
+}  // End ytemp3d_int
 
 // ************************************************************************************************************
 //! Return interpolated 3d y-template in single call
@@ -2228,21 +2696,20 @@ void SiPixelTemplate::ytemp3d_int(int nypix, int& nybins)
 void SiPixelTemplate::ytemp3d(int i, int j, std::vector<float>& ytemplate)
 
 {
-   // Sum two 2-d templates to make the 3-d template
-   if(i >= 0 && i < nybins_ && j <= i) {
-      for(int k=0; k<BYSIZE; ++k) {
-         ytemplate[k]=temp2dy_[i][k]+temp2dy_[j][k];
-      }
-   } else {
-      for(int k=0; k<BYSIZE; ++k) {
-         ytemplate[k]=0.;
-      }
-   }
-   
-   return;
-   
-} // End ytemp3d
+  // Sum two 2-d templates to make the 3-d template
+  if (i >= 0 && i < nybins_ && j <= i) {
+    for (int k = 0; k < BYSIZE; ++k) {
+      ytemplate[k] = temp2dy_[i][k] + temp2dy_[j][k];
+    }
+  } else {
+    for (int k = 0; k < BYSIZE; ++k) {
+      ytemplate[k] = 0.;
+    }
+  }
 
+  return;
+
+}  // End ytemp3d
 
 // ************************************************************************************************************
 //! Make interpolated 3d x-template (stored as class variables)
@@ -2252,76 +2719,76 @@ void SiPixelTemplate::ytemp3d(int i, int j, std::vector<float>& ytemplate)
 void SiPixelTemplate::xtemp3d_int(int nxpix, int& nxbins)
 
 {
-   // Retrieve already interpolated quantities
-   
-   // Local variables
-   int i, j, k;
-   int ioff0, ioffp, ioffm;
-   
-   // Verify that input parameters are in valid range
-   
+  // Retrieve already interpolated quantities
+
+  // Local variables
+  int i, j, k;
+  int ioff0, ioffp, ioffm;
+
+  // Verify that input parameters are in valid range
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(nxpix < 1 || nxpix >= BXM3) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xtemp3d called with nxpix = " << nxpix << std::endl;
-   }
+  if (nxpix < 1 || nxpix >= BXM3) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::xtemp3d called with nxpix = " << nxpix << std::endl;
+  }
 #else
-   assert(nxpix > 0 && nxpix < BXM3);
+  assert(nxpix > 0 && nxpix < BXM3);
 #endif
-   
-   // Calculate the size of the shift in pixels needed to span the entire cluster
-   
-   float diff = fabsf(nxpix - clslenx_)/2.f + 1.f;
-   int nshift = (int)diff;
-   if((diff - nshift) > 0.5f) {++nshift;}
-   
-   // Calculate the number of bins needed to specify each hit range
-   
-   nxbins_ = 9 + 16*nshift;
-   
-   // Create a 2-d working template with the correct size
-   
-   temp2dx_.resize(boost::extents[nxbins_][BXSIZE]);
-   
-   //  The 9 central bins are copied from the interpolated private store
-   
-   ioff0 = 8*nshift;
-   
-   for(i=0; i<9; ++i) {
-      for(j=0; j<BXSIZE; ++j) {
-         temp2dx_[i+ioff0][j]=xtemp_[i][j];
-      }
-   }
-   
-   // Add the +- shifted templates
-   
-   for(k=1; k<=nshift; ++k) {
-      ioffm=ioff0-k*8;
-      for(i=0; i<8; ++i) {
-         for(j=0; j<k; ++j) {
-            temp2dx_[i+ioffm][BXM1-j] = 0.f;
-         }
-         for(j=0; j<BXSIZE-k; ++j) {
-            temp2dx_[i+ioffm][j]=xtemp_[i][j+k];
-         }
-      }
-      ioffp=ioff0+k*8;
-      for(i=1; i<9; ++i) {
-         for(j=0; j<k; ++j) {
-            temp2dx_[i+ioffp][j] = 0.f;
-         }
-         for(j=0; j<BXSIZE-k; ++j) {
-            temp2dx_[i+ioffp][j+k]=xtemp_[i][j];
-         }
-      }
-   }
-   
-   nxbins = nxbins_;
-   
-   return;
-   
-} // End xtemp3d_int
 
+  // Calculate the size of the shift in pixels needed to span the entire cluster
 
+  float diff = fabsf(nxpix - clslenx_) / 2.f + 1.f;
+  int nshift = (int)diff;
+  if ((diff - nshift) > 0.5f) {
+    ++nshift;
+  }
+
+  // Calculate the number of bins needed to specify each hit range
+
+  nxbins_ = 9 + 16 * nshift;
+
+  // Create a 2-d working template with the correct size
+
+  temp2dx_.resize(boost::extents[nxbins_][BXSIZE]);
+
+  //  The 9 central bins are copied from the interpolated private store
+
+  ioff0 = 8 * nshift;
+
+  for (i = 0; i < 9; ++i) {
+    for (j = 0; j < BXSIZE; ++j) {
+      temp2dx_[i + ioff0][j] = xtemp_[i][j];
+    }
+  }
+
+  // Add the +- shifted templates
+
+  for (k = 1; k <= nshift; ++k) {
+    ioffm = ioff0 - k * 8;
+    for (i = 0; i < 8; ++i) {
+      for (j = 0; j < k; ++j) {
+        temp2dx_[i + ioffm][BXM1 - j] = 0.f;
+      }
+      for (j = 0; j < BXSIZE - k; ++j) {
+        temp2dx_[i + ioffm][j] = xtemp_[i][j + k];
+      }
+    }
+    ioffp = ioff0 + k * 8;
+    for (i = 1; i < 9; ++i) {
+      for (j = 0; j < k; ++j) {
+        temp2dx_[i + ioffp][j] = 0.f;
+      }
+      for (j = 0; j < BXSIZE - k; ++j) {
+        temp2dx_[i + ioffp][j + k] = xtemp_[i][j];
+      }
+    }
+  }
+
+  nxbins = nxbins_;
+
+  return;
+
+}  // End xtemp3d_int
 
 // ************************************************************************************************************
 //! Return interpolated 3d x-template in single call
@@ -2331,21 +2798,20 @@ void SiPixelTemplate::xtemp3d_int(int nxpix, int& nxbins)
 void SiPixelTemplate::xtemp3d(int i, int j, std::vector<float>& xtemplate)
 
 {
-   // Sum two 2-d templates to make the 3-d template
-   if(i >= 0 && i < nxbins_ && j <= i) {
-      for(int k=0; k<BXSIZE; ++k) {
-         xtemplate[k]=temp2dx_[i][k]+temp2dx_[j][k];
-      }
-   } else {
-      for(int k=0; k<BXSIZE; ++k) {
-         xtemplate[k]=0.;
-      }
-   }
-   
-   return;
-   
-} // End xtemp3d
+  // Sum two 2-d templates to make the 3-d template
+  if (i >= 0 && i < nxbins_ && j <= i) {
+    for (int k = 0; k < BXSIZE; ++k) {
+      xtemplate[k] = temp2dx_[i][k] + temp2dx_[j][k];
+    }
+  } else {
+    for (int k = 0; k < BXSIZE; ++k) {
+      xtemplate[k] = 0.;
+    }
+  }
 
+  return;
+
+}  // End xtemp3d
 
 // ************************************************************************************************************
 //! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge
@@ -2376,254 +2842,308 @@ void SiPixelTemplate::xtemp3d(int i, int j, std::vector<float>& xtemplate)
 //! \param lorywidth - (output) the estimated y Lorentz width
 //! \param lorxwidth - (output) the estimated x Lorentz width
 // ************************************************************************************************************
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, float& pixmx,
-                          float& sigmay, float& deltay, float& sigmax, float& deltax,float& sy1, float& dy1, float& sy2,
-                          float& dy2, float& sx1, float& dx1, float& sx2, float& dx2) // float& lorywidth, float& lorxwidth)
+int SiPixelTemplate::qbin(int id,
+                          float cotalpha,
+                          float cotbeta,
+                          float locBz,
+                          float locBx,
+                          float qclus,
+                          float& pixmx,
+                          float& sigmay,
+                          float& deltay,
+                          float& sigmax,
+                          float& deltax,
+                          float& sy1,
+                          float& dy1,
+                          float& sy2,
+                          float& dy2,
+                          float& sx1,
+                          float& dx1,
+                          float& sx2,
+                          float& dx2)  // float& lorywidth, float& lorxwidth)
 {
-   // Interpolate for a new set of track angles
-   
-   
-   // Find the index corresponding to id
-   
-   int index = -1;
-   for( int i=0; i<(int)thePixelTemp_.size(); ++i) {
-      if(id == thePixelTemp_[i].head.ID) {
-         index = i;
-         break;
+  // Interpolate for a new set of track angles
+
+  // Find the index corresponding to id
+
+  int index = -1;
+  for (int i = 0; i < (int)thePixelTemp_.size(); ++i) {
+    if (id == thePixelTemp_[i].head.ID) {
+      index = i;
+      break;
+    }
+  }
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (index < 0 || index >= (int)thePixelTemp_.size()) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin can't find needed template ID = " << id << std::endl;
+  }
+#else
+  assert(index >= 0 && index < (int)thePixelTemp_.size());
+#endif
+
+  //
+
+  auto const& templ = thePixelTemp_[index];
+
+  // Interpolate the absolute value of cot(beta)
+
+  auto acotb = std::abs(cotbeta);
+
+  //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)
+
+  auto cotalpha0 = thePixelTemp_[index].enty[0].cotalpha;
+  auto qcorrect =
+      std::sqrt((1.f + cotbeta * cotbeta + cotalpha * cotalpha) / (1.f + cotbeta * cotbeta + cotalpha0 * cotalpha0));
+
+  // for some cosmics, the ususal gymnastics are incorrect
+
+  float cota = cotalpha;
+  float cotb = abs_cotb_;
+  bool flip_x = false;
+  bool flip_y = false;
+  switch (thePixelTemp_[index_id_].head.Dtype) {
+    case 0:
+      if (cotbeta < 0.f) {
+        flip_y = true;
       }
-   }
-   
+      break;
+    case 1:
+      if (locBz < 0.f) {
+        cotb = cotbeta;
+      } else {
+        cotb = -cotbeta;
+        flip_y = true;
+      }
+      break;
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+      if (locBx * locBz < 0.f) {
+        cota = -cotalpha;
+        flip_x = true;
+      }
+      if (locBx > 0.f) {
+        cotb = cotbeta;
+      } else {
+        cotb = -cotbeta;
+        flip_y = true;
+      }
+      break;
+    default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index < 0 || index >= (int)thePixelTemp_.size()) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin can't find needed template ID = " << id << std::endl;
-   }
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #else
-   assert(index >= 0 && index < (int)thePixelTemp_.size());
+      std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #endif
-   
-   //
-   
-   
-   auto const & templ = thePixelTemp_[index];
-   
-   // Interpolate the absolute value of cot(beta)
-   
-   auto acotb = std::abs(cotbeta);
-   
-   //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)
-   
-   auto cotalpha0 =  thePixelTemp_[index].enty[0].cotalpha;
-   auto qcorrect=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta*cotbeta+cotalpha0*cotalpha0));
-   
-   // for some cosmics, the ususal gymnastics are incorrect
-   
-   float cota = cotalpha;
-   float cotb = abs_cotb_;
-   bool flip_x = false;
-   bool flip_y = false;
-   switch(thePixelTemp_[index_id_].head.Dtype) {
-      case 0:
-         if(cotbeta < 0.f) {flip_y = true;}
-         break;
-      case 1:
-         if(locBz < 0.f) {
-            cotb = cotbeta;
-         } else {
-            cotb = -cotbeta;
-            flip_y = true;
-         }
-         break;
-      case 2:
-      case 3:
-      case 4:
-      case 5:
-         if(locBx*locBz < 0.f) {
-            cota = -cotalpha;
-            flip_x = true;
-         }
-         if(locBx > 0.f) {
-            cotb = cotbeta;
-         } else {
-            cotb = -cotbeta;
-            flip_y = true;
-         }
-         break;
-      default:
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
-#else
-         std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
-#endif
-   }
-   
-   
-   // Copy the charge scaling factor to the private variable
-   
-   
-   auto qscale = thePixelTemp_[index].head.qscale;
-   
-   
-   /*
+  }
+
+  // Copy the charge scaling factor to the private variable
+
+  auto qscale = thePixelTemp_[index].head.qscale;
+
+  /*
     lorywidth = thePixelTemp_[index].head.lorywidth;
     if(locBz > 0.f) {lorywidth = -lorywidth;}
     lorxwidth = thePixelTemp_[index].head.lorxwidth;
     */
-   
-   
-   auto Ny = thePixelTemp_[index].head.NTy;
-   auto Nyx = thePixelTemp_[index].head.NTyx;
-   auto Nxx = thePixelTemp_[index].head.NTxx;
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(Ny < 2 || Nyx < 1 || Nxx < 2) {
-      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
-   }
-#else
-   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
-#endif
-   
-   // next, loop over all y-angle entries
-   
-   auto ilow = 0;
-   auto ihigh = 0;
-   auto yratio = 0.f;
-   
-   {
-      auto j = std::lower_bound(templ.cotbetaY,templ.cotbetaY+Ny,cotb);
-      if (j==templ.cotbetaY+Ny) { --j;  yratio = 1.f; }
-      else if (j==templ.cotbetaY) { ++j; yratio = 0.f;}
-      else { yratio = (cotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
-      
-      ihigh = j-templ.cotbetaY;
-      ilow = ihigh-1;
-   }
-   
-   
-   
-   // Interpolate/store all y-related quantities (flip displacements when flip_y)
-   
-   dy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dyone + yratio*thePixelTemp_[index].enty[ihigh].dyone;
-   if(flip_y) {dy1 = -dy1;}
-   sy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].syone + yratio*thePixelTemp_[index].enty[ihigh].syone;
-   dy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dytwo + yratio*thePixelTemp_[index].enty[ihigh].dytwo;
-   if(flip_y) {dy2 = -dy2;}
-   sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;
-   
-   auto qavg = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qavg + yratio*thePixelTemp_[index].enty[ihigh].qavg;
-   qavg *= qcorrect;
-   auto qmin = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin + yratio*thePixelTemp_[index].enty[ihigh].qmin;
-   qmin *= qcorrect;
-   auto qmin2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin2 + yratio*thePixelTemp_[index].enty[ihigh].qmin2;
-   qmin2 *= qcorrect;
-   
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(qavg <= 0.f || qmin <= 0.f) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin, qavg or qmin <= 0,"
-      << " Probably someone called the generic pixel reconstruction with an illegal trajectory state" << std::endl;
-   }
-#else
-   assert(qavg > 0.f && qmin > 0.f);
-#endif
-   
-   //  Scale the input charge to account for differences between pixelav and CMSSW simulation or data
-   
-   auto qtotal = qscale*qclus;
-   
-   // uncertainty and final corrections depend upon total charge bin
-   auto fq = qtotal/qavg;
-   int  binq;
-   
-   if(fq > fbin_[0]) {
-      binq=0;
-      //std::cout<<" fq "<<fq<<" "<<qtotal<<" "<<qavg<<" "<<qclus<<" "<<qscale<<" "
-      //       <<fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
-   } else {
-      if(fq > fbin_[1]) {
-         binq=1;
-      } else {
-         if(fq > fbin_[2]) {
-            binq=2;
-         } else {
-            binq=3;
-         }
-      }
-   }
-   
-   auto yavggen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yavggen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yavggen[binq];
-   if(flip_y) {yavggen = -yavggen;}
-   auto yrmsgen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yrmsgen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yrmsgen[binq];
-   
-   
-   // next, loop over all x-angle entries, first, find relevant y-slices
-   
-   auto iylow = 0;
-   auto iyhigh = 0;
-   auto yxratio = 0.f;
-   
-   
-   {
-      auto j = std::lower_bound(templ.cotbetaX,templ.cotbetaX+Nyx,acotb);
-      if (j==templ.cotbetaX+Nyx) { --j;  yxratio = 1.f; }
-      else if (j==templ.cotbetaX) { ++j; yxratio = 0.f;}
-      else { yxratio = (acotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
-      
-      iyhigh = j-templ.cotbetaX;
-      iylow = iyhigh -1;
-   }
-   
-   
-   
-   // Unneded:  ilow = ihigh = 0;
-   auto xxratio = 0.f;
-   
-   {
-      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cota);
-      if (j==templ.cotalphaX+Nxx) { --j;  xxratio = 1.f; }
-      else if (j==templ.cotalphaX) { ++j; xxratio = 0.f;}
-      else { xxratio = (cota - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
-      
-      ihigh = j-templ.cotalphaX;
-      ilow = ihigh-1;
-   }
-   
-   
-   
-   dx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxone + xxratio*thePixelTemp_[index].entx[0][ihigh].dxone;
-   if(flip_x) {dx1 = -dx1;}
-   sx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxone + xxratio*thePixelTemp_[index].entx[0][ihigh].sxone;
-   dx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].dxtwo;
-   if(flip_x) {dx2 = -dx2;}
-   sx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].sxtwo;
-   
-   // pixmax is the maximum allowed pixel charge (used for truncation)
-   
-   pixmx=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iylow][ihigh].pixmax)
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].pixmax);
-   
-   auto xavggen = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xavggen[binq] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xavggen[binq])
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xavggen[binq] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xavggen[binq]);
-   if(flip_x) {xavggen = -xavggen;}
-   
-   auto xrmsgen = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xrmsgen[binq] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xrmsgen[binq])
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xrmsgen[binq] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xrmsgen[binq]);
-   
-   
-   
-   //  Take the errors and bias from the correct charge bin
-   
-   sigmay = yrmsgen; deltay = yavggen;
-   
-   sigmax = xrmsgen; deltax = xavggen;
-   
-   // If the charge is too small (then flag it)
-   
-   if(qtotal < 0.95f*qmin) {binq = 5;} else {if(qtotal < 0.95f*qmin2) {binq = 4;}}
-   
-   return binq;
-   
-} // qbin
 
+  auto Ny = thePixelTemp_[index].head.NTy;
+  auto Nyx = thePixelTemp_[index].head.NTyx;
+  auto Nxx = thePixelTemp_[index].head.NTxx;
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (Ny < 2 || Nyx < 1 || Nxx < 2) {
+    throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny
+                                        << "/" << Nyx << "/" << Nxx << std::endl;
+  }
+#else
+  assert(Ny > 1 && Nyx > 0 && Nxx > 1);
+#endif
+
+  // next, loop over all y-angle entries
+
+  auto ilow = 0;
+  auto ihigh = 0;
+  auto yratio = 0.f;
+
+  {
+    auto j = std::lower_bound(templ.cotbetaY, templ.cotbetaY + Ny, cotb);
+    if (j == templ.cotbetaY + Ny) {
+      --j;
+      yratio = 1.f;
+    } else if (j == templ.cotbetaY) {
+      ++j;
+      yratio = 0.f;
+    } else {
+      yratio = (cotb - (*(j - 1))) / ((*j) - (*(j - 1)));
+    }
+
+    ihigh = j - templ.cotbetaY;
+    ilow = ihigh - 1;
+  }
+
+  // Interpolate/store all y-related quantities (flip displacements when flip_y)
+
+  dy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dyone + yratio * thePixelTemp_[index].enty[ihigh].dyone;
+  if (flip_y) {
+    dy1 = -dy1;
+  }
+  sy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].syone + yratio * thePixelTemp_[index].enty[ihigh].syone;
+  dy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dytwo + yratio * thePixelTemp_[index].enty[ihigh].dytwo;
+  if (flip_y) {
+    dy2 = -dy2;
+  }
+  sy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].sytwo + yratio * thePixelTemp_[index].enty[ihigh].sytwo;
+
+  auto qavg = (1.f - yratio) * thePixelTemp_[index].enty[ilow].qavg + yratio * thePixelTemp_[index].enty[ihigh].qavg;
+  qavg *= qcorrect;
+  auto qmin = (1.f - yratio) * thePixelTemp_[index].enty[ilow].qmin + yratio * thePixelTemp_[index].enty[ihigh].qmin;
+  qmin *= qcorrect;
+  auto qmin2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].qmin2 + yratio * thePixelTemp_[index].enty[ihigh].qmin2;
+  qmin2 *= qcorrect;
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (qavg <= 0.f || qmin <= 0.f) {
+    throw cms::Exception("DataCorrupt")
+        << "SiPixelTemplate::qbin, qavg or qmin <= 0,"
+        << " Probably someone called the generic pixel reconstruction with an illegal trajectory state" << std::endl;
+  }
+#else
+  assert(qavg > 0.f && qmin > 0.f);
+#endif
+
+  //  Scale the input charge to account for differences between pixelav and CMSSW simulation or data
+
+  auto qtotal = qscale * qclus;
+
+  // uncertainty and final corrections depend upon total charge bin
+  auto fq = qtotal / qavg;
+  int binq;
+
+  if (fq > fbin_[0]) {
+    binq = 0;
+    //std::cout<<" fq "<<fq<<" "<<qtotal<<" "<<qavg<<" "<<qclus<<" "<<qscale<<" "
+    //       <<fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
+  } else {
+    if (fq > fbin_[1]) {
+      binq = 1;
+    } else {
+      if (fq > fbin_[2]) {
+        binq = 2;
+      } else {
+        binq = 3;
+      }
+    }
+  }
+
+  auto yavggen = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yavggen[binq] +
+                 yratio * thePixelTemp_[index].enty[ihigh].yavggen[binq];
+  if (flip_y) {
+    yavggen = -yavggen;
+  }
+  auto yrmsgen = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yrmsgen[binq] +
+                 yratio * thePixelTemp_[index].enty[ihigh].yrmsgen[binq];
+
+  // next, loop over all x-angle entries, first, find relevant y-slices
+
+  auto iylow = 0;
+  auto iyhigh = 0;
+  auto yxratio = 0.f;
+
+  {
+    auto j = std::lower_bound(templ.cotbetaX, templ.cotbetaX + Nyx, acotb);
+    if (j == templ.cotbetaX + Nyx) {
+      --j;
+      yxratio = 1.f;
+    } else if (j == templ.cotbetaX) {
+      ++j;
+      yxratio = 0.f;
+    } else {
+      yxratio = (acotb - (*(j - 1))) / ((*j) - (*(j - 1)));
+    }
+
+    iyhigh = j - templ.cotbetaX;
+    iylow = iyhigh - 1;
+  }
+
+  // Unneded:  ilow = ihigh = 0;
+  auto xxratio = 0.f;
+
+  {
+    auto j = std::lower_bound(templ.cotalphaX, templ.cotalphaX + Nxx, cota);
+    if (j == templ.cotalphaX + Nxx) {
+      --j;
+      xxratio = 1.f;
+    } else if (j == templ.cotalphaX) {
+      ++j;
+      xxratio = 0.f;
+    } else {
+      xxratio = (cota - (*(j - 1))) / ((*j) - (*(j - 1)));
+    }
+
+    ihigh = j - templ.cotalphaX;
+    ilow = ihigh - 1;
+  }
+
+  dx1 =
+      (1.f - xxratio) * thePixelTemp_[index].entx[0][ilow].dxone + xxratio * thePixelTemp_[index].entx[0][ihigh].dxone;
+  if (flip_x) {
+    dx1 = -dx1;
+  }
+  sx1 =
+      (1.f - xxratio) * thePixelTemp_[index].entx[0][ilow].sxone + xxratio * thePixelTemp_[index].entx[0][ihigh].sxone;
+  dx2 =
+      (1.f - xxratio) * thePixelTemp_[index].entx[0][ilow].dxtwo + xxratio * thePixelTemp_[index].entx[0][ihigh].dxtwo;
+  if (flip_x) {
+    dx2 = -dx2;
+  }
+  sx2 =
+      (1.f - xxratio) * thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio * thePixelTemp_[index].entx[0][ihigh].sxtwo;
+
+  // pixmax is the maximum allowed pixel charge (used for truncation)
+
+  pixmx = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].pixmax +
+                             xxratio * thePixelTemp_[index].entx[iylow][ihigh].pixmax) +
+          yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].pixmax +
+                     xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].pixmax);
+
+  auto xavggen = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].xavggen[binq] +
+                                    xxratio * thePixelTemp_[index].entx[iylow][ihigh].xavggen[binq]) +
+                 yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].xavggen[binq] +
+                            xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].xavggen[binq]);
+  if (flip_x) {
+    xavggen = -xavggen;
+  }
+
+  auto xrmsgen = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].xrmsgen[binq] +
+                                    xxratio * thePixelTemp_[index].entx[iylow][ihigh].xrmsgen[binq]) +
+                 yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].xrmsgen[binq] +
+                            xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].xrmsgen[binq]);
+
+  //  Take the errors and bias from the correct charge bin
+
+  sigmay = yrmsgen;
+  deltay = yavggen;
+
+  sigmax = xrmsgen;
+  deltax = xavggen;
+
+  // If the charge is too small (then flag it)
+
+  if (qtotal < 0.95f * qmin) {
+    binq = 5;
+  } else {
+    if (qtotal < 0.95f * qmin2) {
+      binq = 4;
+    }
+  }
+
+  return binq;
+
+}  // qbin
 
 // ************************************************************************************************************
 //! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge
@@ -2654,19 +3174,51 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
 //! \param lorywidth - (output) the estimated y Lorentz width
 //! \param lorxwidth - (output) the estimated x Lorentz width
 // ************************************************************************************************************
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx,
-                          float& sigmay, float& deltay, float& sigmax, float& deltax,float& sy1, float& dy1, float& sy2,
-                          float& dy2, float& sx1, float& dx1, float& sx2, float& dx2) // float& lorywidth, float& lorxwidth)
+int SiPixelTemplate::qbin(int id,
+                          float cotalpha,
+                          float cotbeta,
+                          float locBz,
+                          float qclus,
+                          float& pixmx,
+                          float& sigmay,
+                          float& deltay,
+                          float& sigmax,
+                          float& deltax,
+                          float& sy1,
+                          float& dy1,
+                          float& sy2,
+                          float& dy2,
+                          float& sx1,
+                          float& dx1,
+                          float& sx2,
+                          float& dx2)  // float& lorywidth, float& lorxwidth)
 {
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   float locBx = 1.f; //  lorywidth, lorxwidth;
-   
-   return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, locBx, qclus, pixmx, sigmay, deltay, sigmax, deltax,
-                                sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
-   
-} // qbin
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  float locBx = 1.f;  //  lorywidth, lorxwidth;
+
+  return SiPixelTemplate::qbin(id,
+                               cotalpha,
+                               cotbeta,
+                               locBz,
+                               locBx,
+                               qclus,
+                               pixmx,
+                               sigmay,
+                               deltay,
+                               sigmax,
+                               deltax,
+                               sy1,
+                               dy1,
+                               sy2,
+                               dy2,
+                               sx1,
+                               dx1,
+                               sx2,
+                               dx2);  // , lorywidth, lorxwidth);
+
+}  // qbin
 
 // ************************************************************************************************************
 //! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge
@@ -2711,22 +3263,42 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
 //! \param qclus - (input) the cluster charge in electrons
 // ************************************************************************************************************
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float qclus)
-{
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz; //  lorywidth, lorxwidth;
-   // Local variables
-   float locBx = 1.f;
-   if(cotbeta < 0.f) {locBx = -1.f;}
-   locBz = locBx;
-   if(cotalpha < 0.f) {locBz = -locBx;}
-   
-   return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, locBx, qclus, pixmx, sigmay, deltay, sigmax, deltax,
-                                sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
-   
-} // qbin
+int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float qclus) {
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz;  //  lorywidth, lorxwidth;
+  // Local variables
+  float locBx = 1.f;
+  if (cotbeta < 0.f) {
+    locBx = -1.f;
+  }
+  locBz = locBx;
+  if (cotalpha < 0.f) {
+    locBz = -locBx;
+  }
+
+  return SiPixelTemplate::qbin(id,
+                               cotalpha,
+                               cotbeta,
+                               locBz,
+                               locBx,
+                               qclus,
+                               pixmx,
+                               sigmay,
+                               deltay,
+                               sigmax,
+                               deltax,
+                               sy1,
+                               dy1,
+                               sy2,
+                               dy2,
+                               sx1,
+                               dx1,
+                               sx2,
+                               dx2);  // , lorywidth, lorxwidth);
+
+}  // qbin
 
 // ************************************************************************************************************
 //! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge
@@ -2735,24 +3307,42 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float qclus)
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
 //! \param qclus - (input) the cluster charge in electrons
 // ************************************************************************************************************
-int SiPixelTemplate::qbin(int id, float cotbeta, float qclus)
-{
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz, locBx; //, lorywidth, lorxwidth;
-   const float cotalpha = 0.f;
-   locBx = 1.f;
-   if(cotbeta < 0.f) {locBx = -1.f;}
-   locBz = locBx;
-   if(cotalpha < 0.f) {locBz = -locBx;}
-   return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, locBx, qclus, pixmx, sigmay, deltay, sigmax, deltax,
-                                sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
-   
-} // qbin
+int SiPixelTemplate::qbin(int id, float cotbeta, float qclus) {
+  // Interpolate for a new set of track angles
 
+  // Local variables
+  float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz,
+      locBx;  //, lorywidth, lorxwidth;
+  const float cotalpha = 0.f;
+  locBx = 1.f;
+  if (cotbeta < 0.f) {
+    locBx = -1.f;
+  }
+  locBz = locBx;
+  if (cotalpha < 0.f) {
+    locBz = -locBx;
+  }
+  return SiPixelTemplate::qbin(id,
+                               cotalpha,
+                               cotbeta,
+                               locBz,
+                               locBx,
+                               qclus,
+                               pixmx,
+                               sigmay,
+                               deltay,
+                               sigmax,
+                               deltax,
+                               sy1,
+                               dy1,
+                               sy2,
+                               dy2,
+                               sx1,
+                               dx1,
+                               sx2,
+                               dx2);  // , lorywidth, lorxwidth);
 
-
+}  // qbin
 
 // ************************************************************************************************************
 //! Interpolate beta/alpha angles to produce estimated errors for fastsim
@@ -2767,193 +3357,194 @@ int SiPixelTemplate::qbin(int id, float cotbeta, float qclus)
 //! \param sx1 - (output) the estimated x-error for 1 single-pixel clusters in microns
 //! \param sx2 - (output) the estimated x-error for 1 double-pixel clusters in microns
 // ************************************************************************************************************
-void SiPixelTemplate::temperrors(int id, float cotalpha, float cotbeta, int qBin, float& sigmay, float& sigmax, float& sy1, float& sy2, float& sx1, float& sx2)
+void SiPixelTemplate::temperrors(int id,
+                                 float cotalpha,
+                                 float cotbeta,
+                                 int qBin,
+                                 float& sigmay,
+                                 float& sigmax,
+                                 float& sy1,
+                                 float& sy2,
+                                 float& sx1,
+                                 float& sx2)
 
 {
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   int i;
-   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
-   float yratio, yxratio, xxratio;
-   float acotb, cotb;
-   float yrms, xrms;
-   //bool flip_y;
-   
-   
-   // Find the index corresponding to id
-   
-   index = -1;
-   for(i=0; i<(int)thePixelTemp_.size(); ++i) {
-      
-      if(id == thePixelTemp_[i].head.ID) {
-         
-         index = i;
-         break;
-      }
-   }
-   
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  int i;
+  int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
+  float yratio, yxratio, xxratio;
+  float acotb, cotb;
+  float yrms, xrms;
+  //bool flip_y;
+
+  // Find the index corresponding to id
+
+  index = -1;
+  for (i = 0; i < (int)thePixelTemp_.size(); ++i) {
+    if (id == thePixelTemp_[i].head.ID) {
+      index = i;
+      break;
+    }
+  }
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index < 0 || index >= (int)thePixelTemp_.size()) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::temperrors can't find needed template ID = " << id << std::endl;
-   }
+  if (index < 0 || index >= (int)thePixelTemp_.size()) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::temperrors can't find needed template ID = " << id
+                                        << std::endl;
+  }
 #else
-   assert(index >= 0 && index < (int)thePixelTemp_.size());
+  assert(index >= 0 && index < (int)thePixelTemp_.size());
 #endif
-   
-   
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(qBin < 0 || qBin > 5) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::temperrors called with illegal qBin = " << qBin << std::endl;
-   }
+  if (qBin < 0 || qBin > 5) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::temperrors called with illegal qBin = " << qBin
+                                        << std::endl;
+  }
 #else
-   assert(qBin >= 0 && qBin < 6);
+  assert(qBin >= 0 && qBin < 6);
 #endif
-   
-   // The error information for qBin > 3 is taken to be the same as qBin=3
-   
-   if(qBin > 3) {qBin = 3;}
-   //
-   
-   // Interpolate the absolute value of cot(beta)
-   
-   acotb = fabs((double)cotbeta);
-   // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
-   
-   // for some cosmics, the ususal gymnastics are incorrect
-   
-   //	if(thePixelTemp_[index].head.Dtype == 0) {
-   cotb = acotb;
-   //flip_y = false;
-   //if(cotbeta < 0.f) {flip_y = true;}
-   //	} else {
-   //	    if(locBz < 0.f) {
-   //			cotb = cotbeta;
-   //			flip_y = false;
-   //		} else {
-   //			cotb = -cotbeta;
-   //			flip_y = true;
-   //		}
-   //	}
-   
-   // Copy the charge scaling factor to the private variable
-   
-   Ny = thePixelTemp_[index].head.NTy;
-   Nyx = thePixelTemp_[index].head.NTyx;
-   Nxx = thePixelTemp_[index].head.NTxx;
-   
+
+  // The error information for qBin > 3 is taken to be the same as qBin=3
+
+  if (qBin > 3) {
+    qBin = 3;
+  }
+  //
+
+  // Interpolate the absolute value of cot(beta)
+
+  acotb = fabs((double)cotbeta);
+  // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
+
+  // for some cosmics, the ususal gymnastics are incorrect
+
+  //	if(thePixelTemp_[index].head.Dtype == 0) {
+  cotb = acotb;
+  //flip_y = false;
+  //if(cotbeta < 0.f) {flip_y = true;}
+  //	} else {
+  //	    if(locBz < 0.f) {
+  //			cotb = cotbeta;
+  //			flip_y = false;
+  //		} else {
+  //			cotb = -cotbeta;
+  //			flip_y = true;
+  //		}
+  //	}
+
+  // Copy the charge scaling factor to the private variable
+
+  Ny = thePixelTemp_[index].head.NTy;
+  Nyx = thePixelTemp_[index].head.NTyx;
+  Nxx = thePixelTemp_[index].head.NTxx;
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(Ny < 2 || Nyx < 1 || Nxx < 2) {
-      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
-   }
+  if (Ny < 2 || Nyx < 1 || Nxx < 2) {
+    throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny
+                                        << "/" << Nyx << "/" << Nxx << std::endl;
+  }
 #else
-   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
+  assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
-   
-   // next, loop over all y-angle entries
-   
-   ilow = 0;
-   yratio = 0.f;
-   
-   if(cotb >= thePixelTemp_[index].enty[Ny-1].cotbeta) {
-      
-      ilow = Ny-2;
-      yratio = 1.f;
-      
-   } else {
-      
-      if(cotb >= thePixelTemp_[index].enty[0].cotbeta) {
-         
-         for (i=0; i<Ny-1; ++i) {
-            
-            if( thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i+1].cotbeta) {
-               
-               ilow = i;
-               yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta)/(thePixelTemp_[index].enty[i+1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
-               break;
-            }
-         }
+
+  // next, loop over all y-angle entries
+
+  ilow = 0;
+  yratio = 0.f;
+
+  if (cotb >= thePixelTemp_[index].enty[Ny - 1].cotbeta) {
+    ilow = Ny - 2;
+    yratio = 1.f;
+
+  } else {
+    if (cotb >= thePixelTemp_[index].enty[0].cotbeta) {
+      for (i = 0; i < Ny - 1; ++i) {
+        if (thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i + 1].cotbeta) {
+          ilow = i;
+          yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta) /
+                   (thePixelTemp_[index].enty[i + 1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
+          break;
+        }
       }
-   }
-   
-   ihigh=ilow + 1;
-   
-   // Interpolate/store all y-related quantities (flip displacements when flip_y)
-   
-   sy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].syone + yratio*thePixelTemp_[index].enty[ihigh].syone;
-   sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;
-   yrms=(1.f - yratio)*thePixelTemp_[index].enty[ilow].yrms[qBin] + yratio*thePixelTemp_[index].enty[ihigh].yrms[qBin];
-   
-   
-   // next, loop over all x-angle entries, first, find relevant y-slices
-   
-   iylow = 0;
-   yxratio = 0.f;
-   
-   if(acotb >= thePixelTemp_[index].entx[Nyx-1][0].cotbeta) {
-      
-      iylow = Nyx-2;
-      yxratio = 1.f;
-      
-   } else if(acotb >= thePixelTemp_[index].entx[0][0].cotbeta) {
-      
-      for (i=0; i<Nyx-1; ++i) {
-         
-         if( thePixelTemp_[index].entx[i][0].cotbeta <= acotb && acotb < thePixelTemp_[index].entx[i+1][0].cotbeta) {
-            
-            iylow = i;
-            yxratio = (acotb - thePixelTemp_[index].entx[i][0].cotbeta)/(thePixelTemp_[index].entx[i+1][0].cotbeta - thePixelTemp_[index].entx[i][0].cotbeta);
-            break;
-         }
+    }
+  }
+
+  ihigh = ilow + 1;
+
+  // Interpolate/store all y-related quantities (flip displacements when flip_y)
+
+  sy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].syone + yratio * thePixelTemp_[index].enty[ihigh].syone;
+  sy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].sytwo + yratio * thePixelTemp_[index].enty[ihigh].sytwo;
+  yrms = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yrms[qBin] +
+         yratio * thePixelTemp_[index].enty[ihigh].yrms[qBin];
+
+  // next, loop over all x-angle entries, first, find relevant y-slices
+
+  iylow = 0;
+  yxratio = 0.f;
+
+  if (acotb >= thePixelTemp_[index].entx[Nyx - 1][0].cotbeta) {
+    iylow = Nyx - 2;
+    yxratio = 1.f;
+
+  } else if (acotb >= thePixelTemp_[index].entx[0][0].cotbeta) {
+    for (i = 0; i < Nyx - 1; ++i) {
+      if (thePixelTemp_[index].entx[i][0].cotbeta <= acotb && acotb < thePixelTemp_[index].entx[i + 1][0].cotbeta) {
+        iylow = i;
+        yxratio = (acotb - thePixelTemp_[index].entx[i][0].cotbeta) /
+                  (thePixelTemp_[index].entx[i + 1][0].cotbeta - thePixelTemp_[index].entx[i][0].cotbeta);
+        break;
       }
-   }
-   
-   iyhigh=iylow + 1;
-   
-   ilow = 0;
-   xxratio = 0.f;
-   
-   if(cotalpha >= thePixelTemp_[index].entx[0][Nxx-1].cotalpha) {
-      
-      ilow = Nxx-2;
-      xxratio = 1.f;
-      
-   } else {
-      
-      if(cotalpha >= thePixelTemp_[index].entx[0][0].cotalpha) {
-         
-         for (i=0; i<Nxx-1; ++i) {
-            
-            if( thePixelTemp_[index].entx[0][i].cotalpha <= cotalpha && cotalpha < thePixelTemp_[index].entx[0][i+1].cotalpha) {
-               
-               ilow = i;
-               xxratio = (cotalpha - thePixelTemp_[index].entx[0][i].cotalpha)/(thePixelTemp_[index].entx[0][i+1].cotalpha - thePixelTemp_[index].entx[0][i].cotalpha);
-               break;
-            }
-         }
+    }
+  }
+
+  iyhigh = iylow + 1;
+
+  ilow = 0;
+  xxratio = 0.f;
+
+  if (cotalpha >= thePixelTemp_[index].entx[0][Nxx - 1].cotalpha) {
+    ilow = Nxx - 2;
+    xxratio = 1.f;
+
+  } else {
+    if (cotalpha >= thePixelTemp_[index].entx[0][0].cotalpha) {
+      for (i = 0; i < Nxx - 1; ++i) {
+        if (thePixelTemp_[index].entx[0][i].cotalpha <= cotalpha &&
+            cotalpha < thePixelTemp_[index].entx[0][i + 1].cotalpha) {
+          ilow = i;
+          xxratio = (cotalpha - thePixelTemp_[index].entx[0][i].cotalpha) /
+                    (thePixelTemp_[index].entx[0][i + 1].cotalpha - thePixelTemp_[index].entx[0][i].cotalpha);
+          break;
+        }
       }
-   }
-   
-   ihigh=ilow + 1;
-   
-   sx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxone + xxratio*thePixelTemp_[index].entx[0][ihigh].sxone;
-   sx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].sxtwo;
-   
-   xrms=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xrms[qBin] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xrms[qBin])
-			+yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xrms[qBin] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xrms[qBin]);
-   
-   
-   
-   
-   //  Take the errors and bias from the correct charge bin
-   
-   sigmay = yrms;
-   
-   sigmax = xrms;
-   
-   return;
-   
-} // temperrors
+    }
+  }
+
+  ihigh = ilow + 1;
+
+  sx1 =
+      (1.f - xxratio) * thePixelTemp_[index].entx[0][ilow].sxone + xxratio * thePixelTemp_[index].entx[0][ihigh].sxone;
+  sx2 =
+      (1.f - xxratio) * thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio * thePixelTemp_[index].entx[0][ihigh].sxtwo;
+
+  xrms = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].xrms[qBin] +
+                            xxratio * thePixelTemp_[index].entx[iylow][ihigh].xrms[qBin]) +
+         yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].xrms[qBin] +
+                    xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].xrms[qBin]);
+
+  //  Take the errors and bias from the correct charge bin
+
+  sigmay = yrms;
+
+  sigmax = xrms;
+
+  return;
+
+}  // temperrors
 
 // ************************************************************************************************************
 //! Interpolate beta/alpha angles to produce estimated errors for fastsim
@@ -2966,179 +3557,181 @@ void SiPixelTemplate::temperrors(int id, float cotalpha, float cotbeta, int qBin
 //! \param nx1_frac - (output) the probability for xsize = 1 for a single-size pixel
 //! \param nx2_frac - (output) the probability for xsize = 1 for a double-size pixel
 // ************************************************************************************************************
-void SiPixelTemplate::qbin_dist(int id, float cotalpha, float cotbeta, float qbin_frac[4], float& ny1_frac, float& ny2_frac, float& nx1_frac, float& nx2_frac)
+void SiPixelTemplate::qbin_dist(int id,
+                                float cotalpha,
+                                float cotbeta,
+                                float qbin_frac[4],
+                                float& ny1_frac,
+                                float& ny2_frac,
+                                float& nx1_frac,
+                                float& nx2_frac)
 
 {
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   int i;
-   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
-   float yratio, yxratio, xxratio;
-   float acotb, cotb;
-   float qfrac[4];
-   //bool flip_y;
-			
-   // Find the index corresponding to id
-   
-   index = -1;
-   for(i=0; i<(int)thePixelTemp_.size(); ++i) {
-      
-      if(id == thePixelTemp_[i].head.ID) {
-         
-         index = i;
-         //				id_current_ = id;
-         break;
-      }
-   }
-   
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  int i;
+  int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
+  float yratio, yxratio, xxratio;
+  float acotb, cotb;
+  float qfrac[4];
+  //bool flip_y;
+
+  // Find the index corresponding to id
+
+  index = -1;
+  for (i = 0; i < (int)thePixelTemp_.size(); ++i) {
+    if (id == thePixelTemp_[i].head.ID) {
+      index = i;
+      //				id_current_ = id;
+      break;
+    }
+  }
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index < 0 || index >= (int)thePixelTemp_.size()) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::temperrors can't find needed template ID = " << id << std::endl;
-   }
+  if (index < 0 || index >= (int)thePixelTemp_.size()) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate::temperrors can't find needed template ID = " << id
+                                        << std::endl;
+  }
 #else
-   assert(index >= 0 && index < (int)thePixelTemp_.size());
+  assert(index >= 0 && index < (int)thePixelTemp_.size());
 #endif
-   
-   //
-   
-   // Interpolate the absolute value of cot(beta)
-   
-   acotb = fabs((double)cotbeta);
-   // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
-   
-   
-   // for some cosmics, the ususal gymnastics are incorrect
-   
-   //	if(thePixelTemp_[index].head.Dtype == 0) {
-   cotb = acotb;
-   //flip_y = false;
-   //if(cotbeta < 0.f) {flip_y = true;}
-   //	} else {
-   //	    if(locBz < 0.f) {
-   //			cotb = cotbeta;
-   //			flip_y = false;
-   //		} else {
-   //			cotb = -cotbeta;
-   //			flip_y = true;
-   //		}
-   //	}
-   
-   // Copy the charge scaling factor to the private variable
-   
-   Ny = thePixelTemp_[index].head.NTy;
-   Nyx = thePixelTemp_[index].head.NTyx;
-   Nxx = thePixelTemp_[index].head.NTxx;
-   
+
+  //
+
+  // Interpolate the absolute value of cot(beta)
+
+  acotb = fabs((double)cotbeta);
+  // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
+
+  // for some cosmics, the ususal gymnastics are incorrect
+
+  //	if(thePixelTemp_[index].head.Dtype == 0) {
+  cotb = acotb;
+  //flip_y = false;
+  //if(cotbeta < 0.f) {flip_y = true;}
+  //	} else {
+  //	    if(locBz < 0.f) {
+  //			cotb = cotbeta;
+  //			flip_y = false;
+  //		} else {
+  //			cotb = -cotbeta;
+  //			flip_y = true;
+  //		}
+  //	}
+
+  // Copy the charge scaling factor to the private variable
+
+  Ny = thePixelTemp_[index].head.NTy;
+  Nyx = thePixelTemp_[index].head.NTyx;
+  Nxx = thePixelTemp_[index].head.NTxx;
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(Ny < 2 || Nyx < 1 || Nxx < 2) {
-      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
-   }
+  if (Ny < 2 || Nyx < 1 || Nxx < 2) {
+    throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny
+                                        << "/" << Nyx << "/" << Nxx << std::endl;
+  }
 #else
-   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
+  assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
-   
-   // next, loop over all y-angle entries
-   
-   ilow = 0;
-   yratio = 0.f;
-   
-   if(cotb >= thePixelTemp_[index].enty[Ny-1].cotbeta) {
-      
-      ilow = Ny-2;
-      yratio = 1.f;
-      
-   } else {
-      
-      if(cotb >= thePixelTemp_[index].enty[0].cotbeta) {
-         
-         for (i=0; i<Ny-1; ++i) {
-            
-            if( thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i+1].cotbeta) {
-               
-               ilow = i;
-               yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta)/(thePixelTemp_[index].enty[i+1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
-               break;
-            }
-         }
+
+  // next, loop over all y-angle entries
+
+  ilow = 0;
+  yratio = 0.f;
+
+  if (cotb >= thePixelTemp_[index].enty[Ny - 1].cotbeta) {
+    ilow = Ny - 2;
+    yratio = 1.f;
+
+  } else {
+    if (cotb >= thePixelTemp_[index].enty[0].cotbeta) {
+      for (i = 0; i < Ny - 1; ++i) {
+        if (thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i + 1].cotbeta) {
+          ilow = i;
+          yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta) /
+                   (thePixelTemp_[index].enty[i + 1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
+          break;
+        }
       }
-   }
-   
-   ihigh=ilow + 1;
-   
-   // Interpolate/store all y-related quantities (flip displacements when flip_y)
-   ny1_frac = (1.f - yratio)*thePixelTemp_[index].enty[ilow].fracyone + yratio*thePixelTemp_[index].enty[ihigh].fracyone;
-   ny2_frac = (1.f - yratio)*thePixelTemp_[index].enty[ilow].fracytwo + yratio*thePixelTemp_[index].enty[ihigh].fracytwo;
-   
-   // next, loop over all x-angle entries, first, find relevant y-slices
-   
-   iylow = 0;
-   yxratio = 0.f;
-   
-   if(acotb >= thePixelTemp_[index].entx[Nyx-1][0].cotbeta) {
-      
-      iylow = Nyx-2;
-      yxratio = 1.f;
-      
-   } else if(acotb >= thePixelTemp_[index].entx[0][0].cotbeta) {
-      
-      for (i=0; i<Nyx-1; ++i) {
-         
-         if( thePixelTemp_[index].entx[i][0].cotbeta <= acotb && acotb < thePixelTemp_[index].entx[i+1][0].cotbeta) {
-            
-            iylow = i;
-            yxratio = (acotb - thePixelTemp_[index].entx[i][0].cotbeta)/(thePixelTemp_[index].entx[i+1][0].cotbeta - thePixelTemp_[index].entx[i][0].cotbeta);
-            break;
-         }
+    }
+  }
+
+  ihigh = ilow + 1;
+
+  // Interpolate/store all y-related quantities (flip displacements when flip_y)
+  ny1_frac =
+      (1.f - yratio) * thePixelTemp_[index].enty[ilow].fracyone + yratio * thePixelTemp_[index].enty[ihigh].fracyone;
+  ny2_frac =
+      (1.f - yratio) * thePixelTemp_[index].enty[ilow].fracytwo + yratio * thePixelTemp_[index].enty[ihigh].fracytwo;
+
+  // next, loop over all x-angle entries, first, find relevant y-slices
+
+  iylow = 0;
+  yxratio = 0.f;
+
+  if (acotb >= thePixelTemp_[index].entx[Nyx - 1][0].cotbeta) {
+    iylow = Nyx - 2;
+    yxratio = 1.f;
+
+  } else if (acotb >= thePixelTemp_[index].entx[0][0].cotbeta) {
+    for (i = 0; i < Nyx - 1; ++i) {
+      if (thePixelTemp_[index].entx[i][0].cotbeta <= acotb && acotb < thePixelTemp_[index].entx[i + 1][0].cotbeta) {
+        iylow = i;
+        yxratio = (acotb - thePixelTemp_[index].entx[i][0].cotbeta) /
+                  (thePixelTemp_[index].entx[i + 1][0].cotbeta - thePixelTemp_[index].entx[i][0].cotbeta);
+        break;
       }
-   }
-   
-   iyhigh=iylow + 1;
-   
-   ilow = 0;
-   xxratio = 0.f;
-   
-   if(cotalpha >= thePixelTemp_[index].entx[0][Nxx-1].cotalpha) {
-      
-      ilow = Nxx-2;
-      xxratio = 1.f;
-      
-   } else {
-      
-      if(cotalpha >= thePixelTemp_[index].entx[0][0].cotalpha) {
-         
-         for (i=0; i<Nxx-1; ++i) {
-            
-            if( thePixelTemp_[index].entx[0][i].cotalpha <= cotalpha && cotalpha < thePixelTemp_[index].entx[0][i+1].cotalpha) {
-               
-               ilow = i;
-               xxratio = (cotalpha - thePixelTemp_[index].entx[0][i].cotalpha)/(thePixelTemp_[index].entx[0][i+1].cotalpha - thePixelTemp_[index].entx[0][i].cotalpha);
-               break;
-            }
-         }
+    }
+  }
+
+  iyhigh = iylow + 1;
+
+  ilow = 0;
+  xxratio = 0.f;
+
+  if (cotalpha >= thePixelTemp_[index].entx[0][Nxx - 1].cotalpha) {
+    ilow = Nxx - 2;
+    xxratio = 1.f;
+
+  } else {
+    if (cotalpha >= thePixelTemp_[index].entx[0][0].cotalpha) {
+      for (i = 0; i < Nxx - 1; ++i) {
+        if (thePixelTemp_[index].entx[0][i].cotalpha <= cotalpha &&
+            cotalpha < thePixelTemp_[index].entx[0][i + 1].cotalpha) {
+          ilow = i;
+          xxratio = (cotalpha - thePixelTemp_[index].entx[0][i].cotalpha) /
+                    (thePixelTemp_[index].entx[0][i + 1].cotalpha - thePixelTemp_[index].entx[0][i].cotalpha);
+          break;
+        }
       }
-   }
-   
-   ihigh=ilow + 1;
-   
-   for(i=0; i<3; ++i) {
-      qfrac[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].qbfrac[i] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].qbfrac[i])
-      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].qbfrac[i] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].qbfrac[i]);
-   }
-   nx1_frac = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].fracxone + xxratio*thePixelTemp_[index].entx[iylow][ihigh].fracxone)
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].fracxone + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].fracxone);
-   nx2_frac = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].fracxtwo + xxratio*thePixelTemp_[index].entx[iylow][ihigh].fracxtwo)
-   +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].fracxtwo + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].fracxtwo);
-   
-   
-   
-   qbin_frac[0] = qfrac[0];
-   qbin_frac[1] = qbin_frac[0] + qfrac[1];
-   qbin_frac[2] = qbin_frac[1] + qfrac[2];
-   qbin_frac[3] = 1.f;
-   return;
-   
-} // qbin
+    }
+  }
+
+  ihigh = ilow + 1;
+
+  for (i = 0; i < 3; ++i) {
+    qfrac[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].qbfrac[i] +
+                                  xxratio * thePixelTemp_[index].entx[iylow][ihigh].qbfrac[i]) +
+               yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].qbfrac[i] +
+                          xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].qbfrac[i]);
+  }
+  nx1_frac = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].fracxone +
+                                xxratio * thePixelTemp_[index].entx[iylow][ihigh].fracxone) +
+             yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].fracxone +
+                        xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].fracxone);
+  nx2_frac = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index].entx[iylow][ilow].fracxtwo +
+                                xxratio * thePixelTemp_[index].entx[iylow][ihigh].fracxtwo) +
+             yxratio * ((1.f - xxratio) * thePixelTemp_[index].entx[iyhigh][ilow].fracxtwo +
+                        xxratio * thePixelTemp_[index].entx[iyhigh][ihigh].fracxtwo);
+
+  qbin_frac[0] = qfrac[0];
+  qbin_frac[1] = qbin_frac[0] + qfrac[1];
+  qbin_frac[2] = qbin_frac[1] + qfrac[2];
+  qbin_frac[3] = 1.f;
+  return;
+
+}  // qbin
 
 // *************************************************************************************************************************************
 //! Make simple 2-D templates from track angles set in interpolate and hit position.
@@ -3150,367 +3743,384 @@ void SiPixelTemplate::qbin_dist(int id, float cotalpha, float cotbeta, float qbi
 //! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
 // *************************************************************************************************************************************
 
-bool SiPixelTemplate::simpletemplate2D(float xhit, float yhit, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2])
-{
-   
-   // Local variables
-   
-   float x0, y0, xf, yf, xi, yi, sf, si, s0, qpix, slopey, slopex, ds;
-   int i, j, jpix0, ipix0, jpixf, ipixf, jpix, ipix, nx, ny, anx, any, jmax, imax;
-   float qtotal;
-   //	double path;
-   std::list<SimplePixel> list;
-   std::list<SimplePixel>::iterator listIter, listEnd;	
-   
-   // Calculate the entry and exit points for the line charge from the track
-   
-   x0 = xhit - 0.5*zsize_*cota_current_;
-   y0 = yhit - 0.5*zsize_*cotb_current_;
-   
-   jpix0 = floor(x0/xsize_)+1;
-   ipix0 = floor(y0/ysize_)+1;
-   
-   if(jpix0 < 0 || jpix0 > BXM3) {return false;}
-   if(ipix0 < 0 || ipix0 > BYM3) {return false;}
-   
-   xf = xhit + 0.5*zsize_*cota_current_ + lorxwidth_;
-   yf = yhit + 0.5*zsize_*cotb_current_ + lorywidth_;
-   
-   jpixf = floor(xf/xsize_)+1;
-   ipixf = floor(yf/ysize_)+1;
-   
-   if(jpixf < 0 || jpixf > BXM3) {return false;}
-   if(ipixf < 0 || ipixf > BYM3) {return false;}
-   
-   // total charge length 
-   
-   sf = std::sqrt((xf-x0)*(xf-x0) + (yf-y0)*(yf-y0));
-   if((xf-x0) != 0.f) {slopey = (yf-y0)/(xf-x0);} else { slopey = 1.e10;}
-   if((yf-y0) != 0.f) {slopex = (xf-x0)/(yf-y0);} else { slopex = 1.e10;}
-   
-   // use average charge in this direction
-   
-   qtotal = qavg_avg_;
-   
-   SimplePixel element;
-   element.s = sf;
-   element.x = xf;
-   element.y = yf;
-   element.i = ipixf;
-   element.j = jpixf;
-   element.btype = 0;
-   list.push_back(element);
-   
-   //  nx is the number of x interfaces crossed by the line charge	
-   
-   nx = jpixf - jpix0;
-   anx = abs(nx);
-   if(anx > 0) {
-      if(nx > 0) {
-         for(j=jpix0; j<jpixf; ++j) {
-            xi = xsize_*j;
-            yi = slopey*(xi-x0) + y0;
-            ipix = (int)(yi/ysize_)+1;
-            si = std::sqrt((xi-x0)*(xi-x0) + (yi-y0)*(yi-y0));
-            element.s = si;
-            element.x = xi;
-            element.y = yi;
-            element.i = ipix;
-            element.j = j;
-            element.btype = 1;
-            list.push_back(element);
-         }
+bool SiPixelTemplate::simpletemplate2D(
+    float xhit, float yhit, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2]) {
+  // Local variables
+
+  float x0, y0, xf, yf, xi, yi, sf, si, s0, qpix, slopey, slopex, ds;
+  int i, j, jpix0, ipix0, jpixf, ipixf, jpix, ipix, nx, ny, anx, any, jmax, imax;
+  float qtotal;
+  //	double path;
+  std::list<SimplePixel> list;
+  std::list<SimplePixel>::iterator listIter, listEnd;
+
+  // Calculate the entry and exit points for the line charge from the track
+
+  x0 = xhit - 0.5 * zsize_ * cota_current_;
+  y0 = yhit - 0.5 * zsize_ * cotb_current_;
+
+  jpix0 = floor(x0 / xsize_) + 1;
+  ipix0 = floor(y0 / ysize_) + 1;
+
+  if (jpix0 < 0 || jpix0 > BXM3) {
+    return false;
+  }
+  if (ipix0 < 0 || ipix0 > BYM3) {
+    return false;
+  }
+
+  xf = xhit + 0.5 * zsize_ * cota_current_ + lorxwidth_;
+  yf = yhit + 0.5 * zsize_ * cotb_current_ + lorywidth_;
+
+  jpixf = floor(xf / xsize_) + 1;
+  ipixf = floor(yf / ysize_) + 1;
+
+  if (jpixf < 0 || jpixf > BXM3) {
+    return false;
+  }
+  if (ipixf < 0 || ipixf > BYM3) {
+    return false;
+  }
+
+  // total charge length
+
+  sf = std::sqrt((xf - x0) * (xf - x0) + (yf - y0) * (yf - y0));
+  if ((xf - x0) != 0.f) {
+    slopey = (yf - y0) / (xf - x0);
+  } else {
+    slopey = 1.e10;
+  }
+  if ((yf - y0) != 0.f) {
+    slopex = (xf - x0) / (yf - y0);
+  } else {
+    slopex = 1.e10;
+  }
+
+  // use average charge in this direction
+
+  qtotal = qavg_avg_;
+
+  SimplePixel element;
+  element.s = sf;
+  element.x = xf;
+  element.y = yf;
+  element.i = ipixf;
+  element.j = jpixf;
+  element.btype = 0;
+  list.push_back(element);
+
+  //  nx is the number of x interfaces crossed by the line charge
+
+  nx = jpixf - jpix0;
+  anx = abs(nx);
+  if (anx > 0) {
+    if (nx > 0) {
+      for (j = jpix0; j < jpixf; ++j) {
+        xi = xsize_ * j;
+        yi = slopey * (xi - x0) + y0;
+        ipix = (int)(yi / ysize_) + 1;
+        si = std::sqrt((xi - x0) * (xi - x0) + (yi - y0) * (yi - y0));
+        element.s = si;
+        element.x = xi;
+        element.y = yi;
+        element.i = ipix;
+        element.j = j;
+        element.btype = 1;
+        list.push_back(element);
+      }
+    } else {
+      for (j = jpix0; j > jpixf; --j) {
+        xi = xsize_ * (j - 1);
+        yi = slopey * (xi - x0) + y0;
+        ipix = (int)(yi / ysize_) + 1;
+        si = std::sqrt((xi - x0) * (xi - x0) + (yi - y0) * (yi - y0));
+        element.s = si;
+        element.x = xi;
+        element.y = yi;
+        element.i = ipix;
+        element.j = j;
+        element.btype = 1;
+        list.push_back(element);
+      }
+    }
+  }
+
+  ny = ipixf - ipix0;
+  any = abs(ny);
+  if (any > 0) {
+    if (ny > 0) {
+      for (i = ipix0; i < ipixf; ++i) {
+        yi = ysize_ * i;
+        xi = slopex * (yi - y0) + x0;
+        jpix = (int)(xi / xsize_) + 1;
+        si = std::sqrt((xi - x0) * (xi - x0) + (yi - y0) * (yi - y0));
+        element.s = si;
+        element.x = xi;
+        element.y = yi;
+        element.i = i;
+        element.j = jpix;
+        element.btype = 2;
+        list.push_back(element);
+      }
+    } else {
+      for (i = ipix0; i > ipixf; --i) {
+        yi = ysize_ * (i - 1);
+        xi = slopex * (yi - y0) + x0;
+        jpix = (int)(xi / xsize_) + 1;
+        si = std::sqrt((xi - x0) * (xi - x0) + (yi - y0) * (yi - y0));
+        element.s = si;
+        element.x = xi;
+        element.y = yi;
+        element.i = i;
+        element.j = jpix;
+        element.btype = 2;
+        list.push_back(element);
+      }
+    }
+  }
+
+  imax = std::max(ipix0, ipixf);
+  jmax = std::max(jpix0, jpixf);
+
+  // Sort the list according to the distance from the initial point
+
+  list.sort();
+
+  // Look for double pixels and adjust the list appropriately
+
+  for (i = 1; i < imax; ++i) {
+    if (ydouble[i - 1]) {
+      listIter = list.begin();
+      if (ny > 0) {
+        while (listIter != list.end()) {
+          if (listIter->i == i && listIter->btype == 2) {
+            listIter = list.erase(listIter);
+            continue;
+          }
+          if (listIter->i > i) {
+            --(listIter->i);
+          }
+          ++listIter;
+        }
       } else {
-         for(j=jpix0; j>jpixf; --j) {
-            xi = xsize_*(j-1);
-            yi = slopey*(xi-x0) + y0;
-            ipix = (int)(yi/ysize_)+1;
-            si = std::sqrt((xi-x0)*(xi-x0) + (yi-y0)*(yi-y0));
-            element.s = si;
-            element.x = xi;
-            element.y = yi;
-            element.i = ipix;
-            element.j = j;
-            element.btype = 1;
-            list.push_back(element);
-         }
+        while (listIter != list.end()) {
+          if (listIter->i == i + 1 && listIter->btype == 2) {
+            listIter = list.erase(listIter);
+            continue;
+          }
+          if (listIter->i > i + 1) {
+            --(listIter->i);
+          }
+          ++listIter;
+        }
       }
-   }
-   
-   ny = ipixf - ipix0;
-   any = abs(ny);
-   if(any > 0) {
-      if(ny > 0) {
-         for(i=ipix0; i<ipixf; ++i) {
-            yi = ysize_*i;
-            xi = slopex*(yi-y0) + x0;
-            jpix = (int)(xi/xsize_)+1;
-            si = std::sqrt((xi-x0)*(xi-x0) + (yi-y0)*(yi-y0));
-            element.s = si;
-            element.x = xi;
-            element.y = yi;
-            element.i = i;
-            element.j = jpix;
-            element.btype = 2;
-            list.push_back(element);
-         }
+    }
+  }
+
+  for (j = 1; j < jmax; ++j) {
+    if (xdouble[j - 1]) {
+      listIter = list.begin();
+      if (nx > 0) {
+        while (listIter != list.end()) {
+          if (listIter->j == j && listIter->btype == 1) {
+            listIter = list.erase(listIter);
+            continue;
+          }
+          if (listIter->j > j) {
+            --(listIter->j);
+          }
+          ++listIter;
+        }
       } else {
-         for(i=ipix0; i>ipixf; --i) {
-            yi = ysize_*(i-1);
-            xi = slopex*(yi-y0) + x0;
-            jpix = (int)(xi/xsize_)+1;
-            si = std::sqrt((xi-x0)*(xi-x0) + (yi-y0)*(yi-y0));
-            element.s = si;
-            element.x = xi;
-            element.y = yi;
-            element.i = i;
-            element.j = jpix;
-            element.btype = 2;
-            list.push_back(element);
-         }
+        while (listIter != list.end()) {
+          if (listIter->j == j + 1 && listIter->btype == 1) {
+            listIter = list.erase(listIter);
+            continue;
+          }
+          if (listIter->j > j + 1) {
+            --(listIter->j);
+          }
+          ++listIter;
+        }
       }
-   }
-   
-   imax = std::max(ipix0, ipixf);
-   jmax = std::max(jpix0, jpixf);
-   
-   // Sort the list according to the distance from the initial point
-   
-   list.sort();
-   
-   // Look for double pixels and adjust the list appropriately
-   
-   for(i=1; i<imax; ++i) {
-      if(ydouble[i-1]) {
-         listIter = list.begin();
-         if(ny > 0) {
-            while(listIter != list.end()) {
-               if(listIter->i == i && listIter->btype == 2) {
-                  listIter = list.erase(listIter);
-                  continue;
-               }
-               if(listIter->i > i) {
-                  --(listIter->i);
-               }
-               ++listIter;
-            }
-         } else {
-            while(listIter != list.end()) {
-               if(listIter->i == i+1 && listIter->btype == 2) {
-                  listIter = list.erase(listIter);
-                  continue;
-               }
-               if(listIter->i > i+1) {
-                  --(listIter->i);
-               }
-               ++listIter;
-            }				
-         }
-      }
-   }
-   
-   for(j=1; j<jmax; ++j) {
-      if(xdouble[j-1]) {
-         listIter = list.begin();
-         if(nx > 0) {
-            while(listIter != list.end()) {
-               if(listIter->j == j && listIter->btype == 1) {
-                  listIter = list.erase(listIter);
-                  continue;
-               }
-               if(listIter->j > j) {
-                  --(listIter->j);
-               }
-               ++listIter;
-            }
-         } else {
-            while(listIter != list.end()) {
-               if(listIter->j == j+1 && listIter->btype == 1) {
-                  listIter = list.erase(listIter);
-                  continue;
-               }
-               if(listIter->j > j+1) {
-                  --(listIter->j);
-               }
-               ++listIter;
-            }				
-         }
-      }
-   }
-   
-   // The list now contains the path lengths of the line charge in each pixel from (x0,y0).  Cacluate the lengths of the segments and the charge. 
-   
-   s0 = 0.f;
-   listIter = list.begin();
-   listEnd = list.end();
-   for( ;listIter != listEnd; ++listIter) {
-      si = listIter->s;
-      ds = si - s0;
-      s0 = si;
-      j = listIter->j;
-      i = listIter->i;
-      if(sf > 0.f) { qpix = qtotal*ds/sf;} else {qpix = qtotal;}
-      template2d[j][i] += qpix;
-   }
-   
-   return true;
-   
+    }
+  }
+
+  // The list now contains the path lengths of the line charge in each pixel from (x0,y0).  Cacluate the lengths of the segments and the charge.
+
+  s0 = 0.f;
+  listIter = list.begin();
+  listEnd = list.end();
+  for (; listIter != listEnd; ++listIter) {
+    si = listIter->s;
+    ds = si - s0;
+    s0 = si;
+    j = listIter->j;
+    i = listIter->i;
+    if (sf > 0.f) {
+      qpix = qtotal * ds / sf;
+    } else {
+      qpix = qtotal;
+    }
+    template2d[j][i] += qpix;
+  }
+
+  return true;
+
 }  // simpletemplate2D
 
-
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce Vavilov parameters for the charge distribution 
+// ************************************************************************************************************
+//! Interpolate beta/alpha angles to produce Vavilov parameters for the charge distribution
 //! \param mpv   - (output) the Vavilov most probable charge (well, not really the most probable esp at large kappa)
 //! \param sigma - (output) the Vavilov sigma parameter
 //! \param kappa - (output) the Vavilov kappa parameter [0.01 (Landau-like) < kappa < 10 (Gaussian-like)
-// ************************************************************************************************************ 
+// ************************************************************************************************************
 void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
 
 {
-   // Local variables 
-   int i;
-   int ilow, ihigh, Ny;
-   float yratio, cotb, cotalpha0, arg;
-   
-   // Interpolate in cotbeta only for the correct total path length (converts cotalpha, cotbeta into an effective cotbeta) 
-   
-   cotalpha0 =  thePixelTemp_[index_id_].enty[0].cotalpha;
-   arg = cotb_current_*cotb_current_ + cota_current_*cota_current_ - cotalpha0*cotalpha0;
-   if(arg < 0.f) arg = 0.f;
-   cotb = std::sqrt(arg);
-   
-   // Copy the charge scaling factor to the private variable     
-   
-   Ny = thePixelTemp_[index_id_].head.NTy;
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(Ny < 2) {
-      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny = " << Ny << std::endl;
-   }
-#else
-   assert(Ny > 1);
-#endif
-   
-   // next, loop over all y-angle entries   
-   
-   ilow = 0;
-   yratio = 0.f;
-   
-   if(cotb >= thePixelTemp_[index_id_].enty[Ny-1].cotbeta) {
-      
-      ilow = Ny-2;
-      yratio = 1.f;
-      
-   } else {
-      
-      if(cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
-         
-         for (i=0; i<Ny-1; ++i) { 
-            
-            if( thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i+1].cotbeta) {
-               
-               ilow = i;
-               yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta)/(thePixelTemp_[index_id_].enty[i+1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
-               break;			 
-            }
-         }
-      } 
-   }
-   
-   ihigh=ilow + 1;
-   
-   // Interpolate Vavilov parameters
-   
-   mpvvav_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].mpvvav + yratio*thePixelTemp_[index_id_].enty[ihigh].mpvvav;
-   sigmavav_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sigmavav + yratio*thePixelTemp_[index_id_].enty[ihigh].sigmavav;
-   kappavav_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].kappavav + yratio*thePixelTemp_[index_id_].enty[ihigh].kappavav;
-   
-   // Copy to parameter list
-   
-   
-   mpv = (double)mpvvav_;
-   sigma = (double)sigmavav_;
-   kappa = (double)kappavav_;
-   
-   return;
-   
-} // vavilov_pars
+  // Local variables
+  int i;
+  int ilow, ihigh, Ny;
+  float yratio, cotb, cotalpha0, arg;
 
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce Vavilov parameters for the 2-cluster charge distribution 
+  // Interpolate in cotbeta only for the correct total path length (converts cotalpha, cotbeta into an effective cotbeta)
+
+  cotalpha0 = thePixelTemp_[index_id_].enty[0].cotalpha;
+  arg = cotb_current_ * cotb_current_ + cota_current_ * cota_current_ - cotalpha0 * cotalpha0;
+  if (arg < 0.f)
+    arg = 0.f;
+  cotb = std::sqrt(arg);
+
+  // Copy the charge scaling factor to the private variable
+
+  Ny = thePixelTemp_[index_id_].head.NTy;
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (Ny < 2) {
+    throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny = " << Ny
+                                        << std::endl;
+  }
+#else
+  assert(Ny > 1);
+#endif
+
+  // next, loop over all y-angle entries
+
+  ilow = 0;
+  yratio = 0.f;
+
+  if (cotb >= thePixelTemp_[index_id_].enty[Ny - 1].cotbeta) {
+    ilow = Ny - 2;
+    yratio = 1.f;
+
+  } else {
+    if (cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
+      for (i = 0; i < Ny - 1; ++i) {
+        if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
+          ilow = i;
+          yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
+                   (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
+          break;
+        }
+      }
+    }
+  }
+
+  ihigh = ilow + 1;
+
+  // Interpolate Vavilov parameters
+
+  mpvvav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav +
+            yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav;
+  sigmavav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav +
+              yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav;
+  kappavav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav +
+              yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav;
+
+  // Copy to parameter list
+
+  mpv = (double)mpvvav_;
+  sigma = (double)sigmavav_;
+  kappa = (double)kappavav_;
+
+  return;
+
+}  // vavilov_pars
+
+// ************************************************************************************************************
+//! Interpolate beta/alpha angles to produce Vavilov parameters for the 2-cluster charge distribution
 //! \param mpv   - (output) the Vavilov most probable charge (well, not really the most probable esp at large kappa)
 //! \param sigma - (output) the Vavilov sigma parameter
 //! \param kappa - (output) the Vavilov kappa parameter [0.01 (Landau-like) < kappa < 10 (Gaussian-like)
-// ************************************************************************************************************ 
+// ************************************************************************************************************
 void SiPixelTemplate::vavilov2_pars(double& mpv, double& sigma, double& kappa)
 
 {
-   // Local variables 
-   int i;
-   int ilow, ihigh, Ny;
-   float yratio, cotb, cotalpha0, arg;
-   
-   // Interpolate in cotbeta only for the correct total path length (converts cotalpha, cotbeta into an effective cotbeta) 
-   
-   cotalpha0 =  thePixelTemp_[index_id_].enty[0].cotalpha;
-   arg = cotb_current_*cotb_current_ + cota_current_*cota_current_ - cotalpha0*cotalpha0;
-   if(arg < 0.f) arg = 0.f;
-   cotb = std::sqrt(arg);
-   
-   // Copy the charge scaling factor to the private variable     
-   
-   Ny = thePixelTemp_[index_id_].head.NTy;
-   
+  // Local variables
+  int i;
+  int ilow, ihigh, Ny;
+  float yratio, cotb, cotalpha0, arg;
+
+  // Interpolate in cotbeta only for the correct total path length (converts cotalpha, cotbeta into an effective cotbeta)
+
+  cotalpha0 = thePixelTemp_[index_id_].enty[0].cotalpha;
+  arg = cotb_current_ * cotb_current_ + cota_current_ * cota_current_ - cotalpha0 * cotalpha0;
+  if (arg < 0.f)
+    arg = 0.f;
+  cotb = std::sqrt(arg);
+
+  // Copy the charge scaling factor to the private variable
+
+  Ny = thePixelTemp_[index_id_].head.NTy;
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(Ny < 2) {
-      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny = " << Ny << std::endl;
-   }
+  if (Ny < 2) {
+    throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny = " << Ny
+                                        << std::endl;
+  }
 #else
-   assert(Ny > 1);
+  assert(Ny > 1);
 #endif
-   
-   // next, loop over all y-angle entries   
-   
-   ilow = 0;
-   yratio = 0.f;
-   
-   if(cotb >= thePixelTemp_[index_id_].enty[Ny-1].cotbeta) {
-      
-      ilow = Ny-2;
-      yratio = 1.f;
-      
-   } else {
-      
-      if(cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
-         
-         for (i=0; i<Ny-1; ++i) { 
-            
-            if( thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i+1].cotbeta) {
-               
-               ilow = i;
-               yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta)/(thePixelTemp_[index_id_].enty[i+1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
-               break;			 
-            }
-         }
-      } 
-   }
-   
-   ihigh=ilow + 1;
-   
-   // Interpolate Vavilov parameters
-   
-   mpvvav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].mpvvav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
-   sigmavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sigmavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
-   kappavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].kappavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].kappavav2;
-   
-   // Copy to parameter list
-   
-   mpv = (double)mpvvav2_;
-   sigma = (double)sigmavav2_;
-   kappa = (double)kappavav2_;
-   
-   return;
-   
-} // vavilov2_pars
 
+  // next, loop over all y-angle entries
 
+  ilow = 0;
+  yratio = 0.f;
+
+  if (cotb >= thePixelTemp_[index_id_].enty[Ny - 1].cotbeta) {
+    ilow = Ny - 2;
+    yratio = 1.f;
+
+  } else {
+    if (cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
+      for (i = 0; i < Ny - 1; ++i) {
+        if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
+          ilow = i;
+          yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
+                   (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
+          break;
+        }
+      }
+    }
+  }
+
+  ihigh = ilow + 1;
+
+  // Interpolate Vavilov parameters
+
+  mpvvav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav2 +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
+  sigmavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav2 +
+               yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
+  kappavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav2 +
+               yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav2;
+
+  // Copy to parameter list
+
+  mpv = (double)mpvvav2_;
+  sigma = (double)sigmavav2_;
+  kappa = (double)kappavav2_;
+
+  return;
+
+}  // vavilov2_pars

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -36,7 +36,6 @@
 #include <sstream>
 #include <fstream>
 
-
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
@@ -59,237 +58,266 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename template_summary_zpNNNN
 //****************************************************************
-bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & pixelTemp, std::string dir)
-{
-   // Add template stored in external file numbered filenum to theTemplateStore
-   
-   // Local variables
-   const int code_version={21};
-   
-   //  Create a filename for this run
-   std::string tempfile = std::to_string(filenum);
-   
-   
-   //  Create different path in CMSSW than standalone
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   // If integer filenum has less than 4 digits, prepend 0's until we have four numerical characters, e.g. "0292"
-   int nzeros = 4-tempfile.length();
-   if (nzeros > 0)
-     tempfile = std::string(nzeros, '0') + tempfile;
-   /// Alt implementation: for (unsigned cnt=4-tempfile.length(); cnt > 0; cnt-- ){ tempfile = "0" + tempfile; }
+bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D>& pixelTemp, std::string dir) {
+  // Add template stored in external file numbered filenum to theTemplateStore
 
-   tempfile = dir + "template_summary2D_zp" + tempfile + ".out";
-   edm::FileInPath file( tempfile );         // Find the file in CMSSW
-   tempfile = file.fullPath();               // Put it back with the whole path.
+  // Local variables
+  const int code_version = {21};
+
+  //  Create a filename for this run
+  std::string tempfile = std::to_string(filenum);
+
+  //  Create different path in CMSSW than standalone
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  // If integer filenum has less than 4 digits, prepend 0's until we have four numerical characters, e.g. "0292"
+  int nzeros = 4 - tempfile.length();
+  if (nzeros > 0)
+    tempfile = std::string(nzeros, '0') + tempfile;
+  /// Alt implementation: for (unsigned cnt=4-tempfile.length(); cnt > 0; cnt-- ){ tempfile = "0" + tempfile; }
+
+  tempfile = dir + "template_summary2D_zp" + tempfile + ".out";
+  edm::FileInPath file(tempfile);  // Find the file in CMSSW
+  tempfile = file.fullPath();      // Put it back with the whole path.
 
 #else
-   // This is the same as above, but more elegant.
-   std::ostringstream tout;
-   tout << "template_summary2D_zp" << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
-   tempfile = tout.str();
+  // This is the same as above, but more elegant.
+  std::ostringstream tout;
+  tout << "template_summary2D_zp" << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
+  tempfile = tout.str();
 
 #endif
-   
-   //  Open the template file
-   //
-   std::ifstream in_file(tempfile);
-   if(in_file.is_open() && in_file.good()) {
 
-      // Create a local template storage entry
-      SiPixelTemplateStore2D theCurrentTemp;
-      
-      // Read-in a header string first and print it
-      char c;
-      for (int i=0; (c=in_file.get()) != '\n'; ++i) {
-         if(i < 79) {theCurrentTemp.head.title[i] = c;}
-         else       {theCurrentTemp.head.title[79] ='\0';}
-      }
-      LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-      
-      // next, the header information
-      in_file >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-      >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-      >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
-      
-      if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL; return false;}
-      
-      if(theCurrentTemp.head.templ_version > 17) {
-         in_file >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias
-         >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0]
-         >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
-         
-         if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load"
-            << ENDL; return false;}
+  //  Open the template file
+  //
+  std::ifstream in_file(tempfile);
+  if (in_file.is_open() && in_file.good()) {
+    // Create a local template storage entry
+    SiPixelTemplateStore2D theCurrentTemp;
+
+    // Read-in a header string first and print it
+    char c;
+    for (int i = 0; (c = in_file.get()) != '\n'; ++i) {
+      if (i < 79) {
+        theCurrentTemp.head.title[i] = c;
       } else {
-// This is for older [legacy] payloads 
-         theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
-         theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
-         theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-         theCurrentTemp.head.fbin[0] = 1.5f;
-         theCurrentTemp.head.fbin[1] = 1.00f;
-         theCurrentTemp.head.fbin[2] = 0.85f;
+        theCurrentTemp.head.title[79] = '\0';
       }
-      
-      LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
-      << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
-      << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-      << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-      << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
-      << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
-      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
-      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1]
-      << ", " << theCurrentTemp.head.fbin[2]
-      << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
-      
-      if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelTemplate2D") << "code expects version " << code_version << ", no template load" << ENDL; return false;}
-      
-      if(theCurrentTemp.head.NTy != 0) {LOGERROR("SiPixelTemplate2D") << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL; return false;}
-      
-      // next, layout the 2-d structure needed to store template
-      
-      theCurrentTemp.entry = new SiPixelTemplateEntry2D*[theCurrentTemp.head.NTyx];
-      theCurrentTemp.entry[0] = new SiPixelTemplateEntry2D[theCurrentTemp.head.NTyx*theCurrentTemp.head.NTxx];
-      for(int i = 1; i < theCurrentTemp.head.NTyx; ++i) theCurrentTemp.entry[i] = theCurrentTemp.entry[i-1] + theCurrentTemp.head.NTxx;      
+    }
+    LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
 
-      // Read in the file info
-      
-      for (int iy=0; iy < theCurrentTemp.head.NTyx; ++iy) {
-         for(int jx=0; jx < theCurrentTemp.head.NTxx; ++jx) {
-            
-            in_file >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0]
-            >> theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
-            
-            if(in_file.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;
-	      return false;
-	    }
-            
-            // Calculate cot(alpha) and cot(beta) for this entry
-            
-            theCurrentTemp.entry[iy][jx].cotalpha = theCurrentTemp.entry[iy][jx].costrk[0]/theCurrentTemp.entry[iy][jx].costrk[2];
-            
-            theCurrentTemp.entry[iy][jx].cotbeta = theCurrentTemp.entry[iy][jx].costrk[1]/theCurrentTemp.entry[iy][jx].costrk[2];
-            
-            in_file >> theCurrentTemp.entry[iy][jx].qavg >> theCurrentTemp.entry[iy][jx].pixmax >> theCurrentTemp.entry[iy][jx].sxymax >> theCurrentTemp.entry[iy][jx].iymin
-            >> theCurrentTemp.entry[iy][jx].iymax >> theCurrentTemp.entry[iy][jx].jxmin >> theCurrentTemp.entry[iy][jx].jxmax;
-            
-            if(in_file.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry; 
-	      return false;
-	    }
-            
-            for (int k=0; k<2; ++k) {
-               
-               in_file >> theCurrentTemp.entry[iy][jx].xypar[k][0] >> theCurrentTemp.entry[iy][jx].xypar[k][1]
-               >> theCurrentTemp.entry[iy][jx].xypar[k][2] >> theCurrentTemp.entry[iy][jx].xypar[k][3] >> theCurrentTemp.entry[iy][jx].xypar[k][4];
-               
-               if(in_file.fail()) {
-		 LOGERROR("SiPixelTemplate2D") << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-		 delete [] theCurrentTemp.entry[0];
-		 delete [] theCurrentTemp.entry;
-		 return false;
-	       }               
-            }
-            
-            for (int k=0; k<2; ++k) {
-               
-               in_file >> theCurrentTemp.entry[iy][jx].lanpar[k][0] >> theCurrentTemp.entry[iy][jx].lanpar[k][1]
-               >> theCurrentTemp.entry[iy][jx].lanpar[k][2] >> theCurrentTemp.entry[iy][jx].lanpar[k][3] >> theCurrentTemp.entry[iy][jx].lanpar[k][4];
-               
-               if(in_file.fail()) {
-		 LOGERROR("SiPixelTemplate2D") << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-		 delete [] theCurrentTemp.entry[0];
-		 delete [] theCurrentTemp.entry;
-		 return false;
-	       }
-               
-            }
-            
-      
-//  Read the 2D template entries as floats [they are formatted that way] and cast to short ints
+    // next, the header information
+    in_file >> theCurrentTemp.head.ID >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >>
+        theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >>
+        theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >>
+        theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >>
+        theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
+        theCurrentTemp.head.zsize;
 
-            float dummy[T2YSIZE];
-            for (int l=0; l<7; ++l) {
-               for (int k=0; k<7; ++k) {
-                  for (int j=0; j<T2XSIZE; ++j) {
-                     for (int i=0; i<T2YSIZE; ++i) {
-                        in_file >> dummy[i];                       
-                     }                     
-                     if(in_file.fail()) {
-		       LOGERROR("SiPixelTemplate2D") << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-		       delete [] theCurrentTemp.entry[0];
-		       delete [] theCurrentTemp.entry;
-		       return false;
-		     }
-                     for (int i=0; i<T2YSIZE; ++i) {
-                        theCurrentTemp.entry[iy][jx].xytemp[k][l][i][j] = (short int)dummy[i];                        
-                     }                    
-                  }
-               }
-            }
-            
-            
-            in_file >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >> theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1]
-            >> theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3]>> theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1]
-            >> theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
-            
-            if(in_file.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;
-	      return false;
-	    }
-            
-            in_file >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >> theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav
-            >> theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >> theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >> theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
-            
-            if(in_file.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-            in_file >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >> theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3]
-            >> theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >> theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3]
-            >> theCurrentTemp.entry[iy][jx].spare[1]  >> theCurrentTemp.entry[iy][jx].spare[2];
-            
-            if(in_file.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-         }
-         
-      }
-      
-      
-      in_file.close();
-      
-      // Add this template to the store
-      
-      pixelTemp.push_back(theCurrentTemp);
-      
-      return true;
-      
-   } else {
-      
-      // If file didn't open, report this
-      
-      LOGERROR("SiPixelTemplate2D") << "Error opening File" << tempfile << ENDL;
+    if (in_file.fail()) {
+      LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL;
       return false;
-      
-   }
-   
-} // TempInit
+    }
 
+    if (theCurrentTemp.head.templ_version > 17) {
+      in_file >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
+          theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+
+      if (in_file.fail()) {
+        LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load" << ENDL;
+        return false;
+      }
+    } else {
+      // This is for older [legacy] payloads
+      theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+      theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth / 2.f;
+      theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth / 2.f;
+      theCurrentTemp.head.fbin[0] = 1.5f;
+      theCurrentTemp.head.fbin[1] = 1.00f;
+      theCurrentTemp.head.fbin[2] = 0.85f;
+    }
+
+    LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
+                                 << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
+                                 << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx
+                                 << ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
+                                 << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+                                 << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
+                                 << ", Q-scaling factor " << theCurrentTemp.head.qscale << ", 1/2 multi dcol threshold "
+                                 << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
+                                 << theCurrentTemp.head.ss50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth
+                                 << ", y Lorentz Bias " << theCurrentTemp.head.lorybias << ", x Lorentz width "
+                                 << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+                                 << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", "
+                                 << theCurrentTemp.head.fbin[1] << ", " << theCurrentTemp.head.fbin[2]
+                                 << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size "
+                                 << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+
+    if (theCurrentTemp.head.templ_version < code_version) {
+      LOGERROR("SiPixelTemplate2D") << "code expects version " << code_version << ", no template load" << ENDL;
+      return false;
+    }
+
+    if (theCurrentTemp.head.NTy != 0) {
+      LOGERROR("SiPixelTemplate2D")
+          << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL;
+      return false;
+    }
+
+    // next, layout the 2-d structure needed to store template
+
+    theCurrentTemp.entry = new SiPixelTemplateEntry2D*[theCurrentTemp.head.NTyx];
+    theCurrentTemp.entry[0] = new SiPixelTemplateEntry2D[theCurrentTemp.head.NTyx * theCurrentTemp.head.NTxx];
+    for (int i = 1; i < theCurrentTemp.head.NTyx; ++i)
+      theCurrentTemp.entry[i] = theCurrentTemp.entry[i - 1] + theCurrentTemp.head.NTxx;
+
+    // Read in the file info
+
+    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy) {
+      for (int jx = 0; jx < theCurrentTemp.head.NTxx; ++jx) {
+        in_file >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0] >>
+            theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        // Calculate cot(alpha) and cot(beta) for this entry
+
+        theCurrentTemp.entry[iy][jx].cotalpha =
+            theCurrentTemp.entry[iy][jx].costrk[0] / theCurrentTemp.entry[iy][jx].costrk[2];
+
+        theCurrentTemp.entry[iy][jx].cotbeta =
+            theCurrentTemp.entry[iy][jx].costrk[1] / theCurrentTemp.entry[iy][jx].costrk[2];
+
+        in_file >> theCurrentTemp.entry[iy][jx].qavg >> theCurrentTemp.entry[iy][jx].pixmax >>
+            theCurrentTemp.entry[iy][jx].sxymax >> theCurrentTemp.entry[iy][jx].iymin >>
+            theCurrentTemp.entry[iy][jx].iymax >> theCurrentTemp.entry[iy][jx].jxmin >>
+            theCurrentTemp.entry[iy][jx].jxmax;
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        for (int k = 0; k < 2; ++k) {
+          in_file >> theCurrentTemp.entry[iy][jx].xypar[k][0] >> theCurrentTemp.entry[iy][jx].xypar[k][1] >>
+              theCurrentTemp.entry[iy][jx].xypar[k][2] >> theCurrentTemp.entry[iy][jx].xypar[k][3] >>
+              theCurrentTemp.entry[iy][jx].xypar[k][4];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            delete[] theCurrentTemp.entry[0];
+            delete[] theCurrentTemp.entry;
+            return false;
+          }
+        }
+
+        for (int k = 0; k < 2; ++k) {
+          in_file >> theCurrentTemp.entry[iy][jx].lanpar[k][0] >> theCurrentTemp.entry[iy][jx].lanpar[k][1] >>
+              theCurrentTemp.entry[iy][jx].lanpar[k][2] >> theCurrentTemp.entry[iy][jx].lanpar[k][3] >>
+              theCurrentTemp.entry[iy][jx].lanpar[k][4];
+
+          if (in_file.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            delete[] theCurrentTemp.entry[0];
+            delete[] theCurrentTemp.entry;
+            return false;
+          }
+        }
+
+        //  Read the 2D template entries as floats [they are formatted that way] and cast to short ints
+
+        float dummy[T2YSIZE];
+        for (int l = 0; l < 7; ++l) {
+          for (int k = 0; k < 7; ++k) {
+            for (int j = 0; j < T2XSIZE; ++j) {
+              for (int i = 0; i < T2YSIZE; ++i) {
+                in_file >> dummy[i];
+              }
+              if (in_file.fail()) {
+                LOGERROR("SiPixelTemplate2D")
+                    << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+                delete[] theCurrentTemp.entry[0];
+                delete[] theCurrentTemp.entry;
+                return false;
+              }
+              for (int i = 0; i < T2YSIZE; ++i) {
+                theCurrentTemp.entry[iy][jx].xytemp[k][l][i][j] = (short int)dummy[i];
+              }
+            }
+          }
+        }
+
+        in_file >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >>
+            theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1] >>
+            theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3] >>
+            theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1] >>
+            theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        in_file >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >>
+            theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav >>
+            theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >>
+            theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >>
+            theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        in_file >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >>
+            theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3] >>
+            theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >>
+            theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3] >>
+            theCurrentTemp.entry[iy][jx].spare[1] >> theCurrentTemp.entry[iy][jx].spare[2];
+
+        if (in_file.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+      }
+    }
+
+    in_file.close();
+
+    // Add this template to the store
+
+    pixelTemp.push_back(theCurrentTemp);
+
+    return true;
+
+  } else {
+    // If file didn't open, report this
+
+    LOGERROR("SiPixelTemplate2D") << "Error opening File" << tempfile << ENDL;
+    return false;
+  }
+
+}  // TempInit
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 
@@ -298,303 +326,321 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
 //! external file template_summary_zpNNNN where NNNN are four digits
 //! \param dbobject - db storing multiple template calibrations
 //****************************************************************
-bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & pixelTemp)
-{
-   // Add template stored in external dbobject to theTemplateStore
-   
-   const int code_version={21};
-   
-   // We must create a new object because dbobject must be a const and our stream must not be
-   SiPixel2DTemplateDBObject db = dbobject;
-   
-   // Create a local template storage entry
-   SiPixelTemplateStore2D theCurrentTemp;
-   
-   // Fill the template storage for each template calibration stored in the db
-   for(int m=0; m<db.numOfTempl(); ++m)
-   {
-      
-      // Read-in a header string first and print it
-      
-      SiPixel2DTemplateDBObject::char2float temp;
-      for (int i=0; i<20; ++i) {
-         temp.f = db.sVector()[db.index()];
-         theCurrentTemp.head.title[4*i] = temp.c[0];
-         theCurrentTemp.head.title[4*i+1] = temp.c[1];
-         theCurrentTemp.head.title[4*i+2] = temp.c[2];
-         theCurrentTemp.head.title[4*i+3] = temp.c[3];
-         db.incrementIndex(1);
-      }
-      theCurrentTemp.head.title[79] = '\0';
-      LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-	  	  
-      // next, the header information
-      
-      db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-	     >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-	     >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
-      
-      if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL; return false;}
-      
-      LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title
-      <<" code version = "<<code_version
-      <<" object version "<<theCurrentTemp.head.templ_version
-      << ENDL;
-      
-      if(theCurrentTemp.head.templ_version > 17) {
-         db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
-         
-         if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load"
-            << ENDL; return false;}
-      } else {
-// This is for older [legacy] payloads and the numbers are indeed magic [they are part of the payload for v>17]
-         theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
-         theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
-         theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-         theCurrentTemp.head.fbin[0] = 1.50f;
-         theCurrentTemp.head.fbin[1] = 1.00f;
-         theCurrentTemp.head.fbin[2] = 0.85f;
-      }
-      
-      LOGINFO("SiPixelTemplate2D")
-      << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
-      << theCurrentTemp.head.templ_version << ", Bfield = "
-      << theCurrentTemp.head.Bfield<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = "
-      << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = "
-      << theCurrentTemp.head.Dtype<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-      << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
-      << ", Q-scaling factor " << theCurrentTemp.head.qscale
-      << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
-      << theCurrentTemp.head.ss50<< ", y Lorentz Width " << theCurrentTemp.head.lorywidth
-      << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
-      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
-      << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
-      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0]
-      << ", " << theCurrentTemp.head.fbin[1]
-      << ", " << theCurrentTemp.head.fbin[2]
-      << ", pixel x-size " << theCurrentTemp.head.xsize
-      << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
-      
-      if(theCurrentTemp.head.templ_version < code_version) {
-         LOGINFO("SiPixelTemplate2D") << "code expects version "<< code_version << " finds "
-         << theCurrentTemp.head.templ_version <<", load anyway " << ENDL;
-      }
-      
-      if(theCurrentTemp.head.NTy != 0) {LOGERROR("SiPixelTemplate2D") << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL; return false;}
-      
-      
-      // next, layout the 2-d structure needed to store template
-      
-      theCurrentTemp.entry = new SiPixelTemplateEntry2D*[theCurrentTemp.head.NTyx];
-      theCurrentTemp.entry[0] = new SiPixelTemplateEntry2D[theCurrentTemp.head.NTyx*theCurrentTemp.head.NTxx];
-      for(int i = 1; i < theCurrentTemp.head.NTyx; ++i) theCurrentTemp.entry[i] = theCurrentTemp.entry[i-1] + theCurrentTemp.head.NTxx;
-      
-      // Read in the file info
-      
-      for (int iy=0; iy < theCurrentTemp.head.NTyx; ++iy) {
-         for(int jx=0; jx < theCurrentTemp.head.NTxx; ++jx) {
-            
-            db >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0]
-            >> theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
-            
-            if(db.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-            // Calculate cot(alpha) and cot(beta) for this entry
-            
-            theCurrentTemp.entry[iy][jx].cotalpha = theCurrentTemp.entry[iy][jx].costrk[0]/theCurrentTemp.entry[iy][jx].costrk[2];
-            
-            theCurrentTemp.entry[iy][jx].cotbeta = theCurrentTemp.entry[iy][jx].costrk[1]/theCurrentTemp.entry[iy][jx].costrk[2];
-            
-            db >> theCurrentTemp.entry[iy][jx].qavg >> theCurrentTemp.entry[iy][jx].pixmax >> theCurrentTemp.entry[iy][jx].sxymax >> theCurrentTemp.entry[iy][jx].iymin
-            >> theCurrentTemp.entry[iy][jx].iymax >> theCurrentTemp.entry[iy][jx].jxmin >> theCurrentTemp.entry[iy][jx].jxmax;
-            
-            if(db.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-            for (int k=0; k<2; ++k) {
-               
-               db >> theCurrentTemp.entry[iy][jx].xypar[k][0] >> theCurrentTemp.entry[iy][jx].xypar[k][1]
-               >> theCurrentTemp.entry[iy][jx].xypar[k][2] >> theCurrentTemp.entry[iy][jx].xypar[k][3] >> theCurrentTemp.entry[iy][jx].xypar[k][4];
-               
-               if(db.fail()) {
-		 LOGERROR("SiPixelTemplate2D") << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-		 delete [] theCurrentTemp.entry[0];
-		 delete [] theCurrentTemp.entry;	      
-		 return false;
-	       }
-               
-            }
-            
-            for (int k=0; k<2; ++k) {
-               
-               db >> theCurrentTemp.entry[iy][jx].lanpar[k][0] >> theCurrentTemp.entry[iy][jx].lanpar[k][1]
-               >> theCurrentTemp.entry[iy][jx].lanpar[k][2] >> theCurrentTemp.entry[iy][jx].lanpar[k][3] >> theCurrentTemp.entry[iy][jx].lanpar[k][4];
-               
-               if(db.fail()) {
-		 LOGERROR("SiPixelTemplate2D") << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-		 delete [] theCurrentTemp.entry[0];
-		 delete [] theCurrentTemp.entry;	      
-		 return false;
-	       }
-               
-            }
-            
-//  Read the 2D template entries as floats [they are formatted that way] and cast to short ints
+bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
+                                 std::vector<SiPixelTemplateStore2D>& pixelTemp) {
+  // Add template stored in external dbobject to theTemplateStore
 
-            float dummy[T2YSIZE];
-            for (int l=0; l<7; ++l) {
-               for (int k=0; k<7; ++k) {
-                  for (int j=0; j<T2XSIZE; ++j) {
-                     for (int i=0; i<T2YSIZE; ++i) {
-                        db >> dummy[i];                       
-                     }                     
-                     if(db.fail()) {
-		       LOGERROR("SiPixelTemplate2D") << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-		       delete [] theCurrentTemp.entry[0];
-		       delete [] theCurrentTemp.entry;	      
-		       return false;
-		     }
-                     for (int i=0; i<T2YSIZE; ++i) {
-                        theCurrentTemp.entry[iy][jx].xytemp[k][l][i][j] = (short int)dummy[i];                        
-                     }                    
-                  }
-               }
-            }
-            
-            db >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >> theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1]
-            >> theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3]>> theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1]
-            >> theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
-            
-            if(db.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-            db >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >> theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav
-            >> theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >> theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >> theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
-            
-            if(db.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-            db >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >> theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3]
-            >> theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >> theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3]
-            >> theCurrentTemp.entry[iy][jx].spare[1]  >> theCurrentTemp.entry[iy][jx].spare[2];
-            
-            if(db.fail()) {
-	      LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; 
-	      delete [] theCurrentTemp.entry[0];
-	      delete [] theCurrentTemp.entry;	      
-	      return false;
-	    }
-            
-         }
+  const int code_version = {21};
+
+  // We must create a new object because dbobject must be a const and our stream must not be
+  SiPixel2DTemplateDBObject db = dbobject;
+
+  // Create a local template storage entry
+  SiPixelTemplateStore2D theCurrentTemp;
+
+  // Fill the template storage for each template calibration stored in the db
+  for (int m = 0; m < db.numOfTempl(); ++m) {
+    // Read-in a header string first and print it
+
+    SiPixel2DTemplateDBObject::char2float temp;
+    for (int i = 0; i < 20; ++i) {
+      temp.f = db.sVector()[db.index()];
+      theCurrentTemp.head.title[4 * i] = temp.c[0];
+      theCurrentTemp.head.title[4 * i + 1] = temp.c[1];
+      theCurrentTemp.head.title[4 * i + 2] = temp.c[2];
+      theCurrentTemp.head.title[4 * i + 3] = temp.c[3];
+      db.incrementIndex(1);
+    }
+    theCurrentTemp.head.title[79] = '\0';
+    LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
+
+    // next, the header information
+
+    db >> theCurrentTemp.head.ID >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >>
+        theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >>
+        theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >>
+        theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >>
+        theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
+        theCurrentTemp.head.zsize;
+
+    if (db.fail()) {
+      LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL;
+      return false;
+    }
+
+    LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title
+                                 << " code version = " << code_version << " object version "
+                                 << theCurrentTemp.head.templ_version << ENDL;
+
+    if (theCurrentTemp.head.templ_version > 17) {
+      db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
+          theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+
+      if (db.fail()) {
+        LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load" << ENDL;
+        return false;
       }
-         
-// Add this template to the store
-   
-   pixelTemp.push_back(theCurrentTemp);    
-     
-   }
-   
-   
-   return true;
-   
-} // TempInit
+    } else {
+      // This is for older [legacy] payloads and the numbers are indeed magic [they are part of the payload for v>17]
+      theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+      theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth / 2.f;
+      theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth / 2.f;
+      theCurrentTemp.head.fbin[0] = 1.50f;
+      theCurrentTemp.head.fbin[1] = 1.00f;
+      theCurrentTemp.head.fbin[2] = 0.85f;
+    }
+
+    LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
+                                 << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
+                                 << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx
+                                 << ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
+                                 << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+                                 << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
+                                 << ", Q-scaling factor " << theCurrentTemp.head.qscale << ", 1/2 multi dcol threshold "
+                                 << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
+                                 << theCurrentTemp.head.ss50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth
+                                 << ", y Lorentz Bias " << theCurrentTemp.head.lorybias << ", x Lorentz width "
+                                 << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+                                 << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", "
+                                 << theCurrentTemp.head.fbin[1] << ", " << theCurrentTemp.head.fbin[2]
+                                 << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size "
+                                 << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+
+    if (theCurrentTemp.head.templ_version < code_version) {
+      LOGINFO("SiPixelTemplate2D") << "code expects version " << code_version << " finds "
+                                   << theCurrentTemp.head.templ_version << ", load anyway " << ENDL;
+    }
+
+    if (theCurrentTemp.head.NTy != 0) {
+      LOGERROR("SiPixelTemplate2D")
+          << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL;
+      return false;
+    }
+
+    // next, layout the 2-d structure needed to store template
+
+    theCurrentTemp.entry = new SiPixelTemplateEntry2D*[theCurrentTemp.head.NTyx];
+    theCurrentTemp.entry[0] = new SiPixelTemplateEntry2D[theCurrentTemp.head.NTyx * theCurrentTemp.head.NTxx];
+    for (int i = 1; i < theCurrentTemp.head.NTyx; ++i)
+      theCurrentTemp.entry[i] = theCurrentTemp.entry[i - 1] + theCurrentTemp.head.NTxx;
+
+    // Read in the file info
+
+    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy) {
+      for (int jx = 0; jx < theCurrentTemp.head.NTxx; ++jx) {
+        db >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0] >>
+            theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        // Calculate cot(alpha) and cot(beta) for this entry
+
+        theCurrentTemp.entry[iy][jx].cotalpha =
+            theCurrentTemp.entry[iy][jx].costrk[0] / theCurrentTemp.entry[iy][jx].costrk[2];
+
+        theCurrentTemp.entry[iy][jx].cotbeta =
+            theCurrentTemp.entry[iy][jx].costrk[1] / theCurrentTemp.entry[iy][jx].costrk[2];
+
+        db >> theCurrentTemp.entry[iy][jx].qavg >> theCurrentTemp.entry[iy][jx].pixmax >>
+            theCurrentTemp.entry[iy][jx].sxymax >> theCurrentTemp.entry[iy][jx].iymin >>
+            theCurrentTemp.entry[iy][jx].iymax >> theCurrentTemp.entry[iy][jx].jxmin >>
+            theCurrentTemp.entry[iy][jx].jxmax;
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        for (int k = 0; k < 2; ++k) {
+          db >> theCurrentTemp.entry[iy][jx].xypar[k][0] >> theCurrentTemp.entry[iy][jx].xypar[k][1] >>
+              theCurrentTemp.entry[iy][jx].xypar[k][2] >> theCurrentTemp.entry[iy][jx].xypar[k][3] >>
+              theCurrentTemp.entry[iy][jx].xypar[k][4];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            delete[] theCurrentTemp.entry[0];
+            delete[] theCurrentTemp.entry;
+            return false;
+          }
+        }
+
+        for (int k = 0; k < 2; ++k) {
+          db >> theCurrentTemp.entry[iy][jx].lanpar[k][0] >> theCurrentTemp.entry[iy][jx].lanpar[k][1] >>
+              theCurrentTemp.entry[iy][jx].lanpar[k][2] >> theCurrentTemp.entry[iy][jx].lanpar[k][3] >>
+              theCurrentTemp.entry[iy][jx].lanpar[k][4];
+
+          if (db.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            delete[] theCurrentTemp.entry[0];
+            delete[] theCurrentTemp.entry;
+            return false;
+          }
+        }
+
+        //  Read the 2D template entries as floats [they are formatted that way] and cast to short ints
+
+        float dummy[T2YSIZE];
+        for (int l = 0; l < 7; ++l) {
+          for (int k = 0; k < 7; ++k) {
+            for (int j = 0; j < T2XSIZE; ++j) {
+              for (int i = 0; i < T2YSIZE; ++i) {
+                db >> dummy[i];
+              }
+              if (db.fail()) {
+                LOGERROR("SiPixelTemplate2D")
+                    << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+                delete[] theCurrentTemp.entry[0];
+                delete[] theCurrentTemp.entry;
+                return false;
+              }
+              for (int i = 0; i < T2YSIZE; ++i) {
+                theCurrentTemp.entry[iy][jx].xytemp[k][l][i][j] = (short int)dummy[i];
+              }
+            }
+          }
+        }
+
+        db >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >>
+            theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1] >>
+            theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3] >>
+            theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1] >>
+            theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        db >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >>
+            theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav >>
+            theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >>
+            theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >>
+            theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+
+        db >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >>
+            theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3] >>
+            theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >>
+            theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3] >>
+            theCurrentTemp.entry[iy][jx].spare[1] >> theCurrentTemp.entry[iy][jx].spare[2];
+
+        if (db.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # "
+                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+          delete[] theCurrentTemp.entry[0];
+          delete[] theCurrentTemp.entry;
+          return false;
+        }
+      }
+    }
+
+    // Add this template to the store
+
+    pixelTemp.push_back(theCurrentTemp);
+  }
+
+  return true;
+
+}  // TempInit
 
 #endif
 
+bool SiPixelTemplate2D::getid(int id) {
+  if (id != id_current_) {
+    // Find the index corresponding to id
 
-bool SiPixelTemplate2D::getid(int id)
-{
-   if(id != id_current_) {
-      
-      // Find the index corresponding to id
-      
-      index_id_ = -1;
-      for(int i=0; i<(int)thePixelTemp_.size(); ++i) {
-         
-         if(id == thePixelTemp_[i].head.ID) {
-            
-            index_id_ = i;
-            id_current_ = id;
-            
-            // Copy the charge scaling factor to the private variable
-            
-            Dtype_ = thePixelTemp_[index_id_].head.Dtype;
-            
-            // Copy the charge scaling factor to the private variable
-            
-            qscale_ = thePixelTemp_[index_id_].head.qscale;
-            
-            // Copy the pseudopixel signal size to the private variable
-            
-            s50_ = thePixelTemp_[index_id_].head.s50;
-            
-            // Copy Qbinning info to private variables
-            
-            for(int j=0; j<3; ++j) {fbin_[j] = thePixelTemp_[index_id_].head.fbin[j];}
-            
-            // Copy the Lorentz widths to private variables
-            
-            lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
-            lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
-            
-            // Copy the pixel sizes private variables
-            
-            xsize_ = thePixelTemp_[index_id_].head.xsize;
-            ysize_ = thePixelTemp_[index_id_].head.ysize;
-            zsize_ = thePixelTemp_[index_id_].head.zsize;
-            
-            // Determine the size of this template
-            
-            Nyx_ = thePixelTemp_[index_id_].head.NTyx;
-            Nxx_ = thePixelTemp_[index_id_].head.NTxx;
+    index_id_ = -1;
+    for (int i = 0; i < (int)thePixelTemp_.size(); ++i) {
+      if (id == thePixelTemp_[i].head.ID) {
+        index_id_ = i;
+        id_current_ = id;
+
+        // Copy the charge scaling factor to the private variable
+
+        Dtype_ = thePixelTemp_[index_id_].head.Dtype;
+
+        // Copy the charge scaling factor to the private variable
+
+        qscale_ = thePixelTemp_[index_id_].head.qscale;
+
+        // Copy the pseudopixel signal size to the private variable
+
+        s50_ = thePixelTemp_[index_id_].head.s50;
+
+        // Copy Qbinning info to private variables
+
+        for (int j = 0; j < 3; ++j) {
+          fbin_[j] = thePixelTemp_[index_id_].head.fbin[j];
+        }
+
+        // Copy the Lorentz widths to private variables
+
+        lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
+        lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
+
+        // Copy the pixel sizes private variables
+
+        xsize_ = thePixelTemp_[index_id_].head.xsize;
+        ysize_ = thePixelTemp_[index_id_].head.ysize;
+        zsize_ = thePixelTemp_[index_id_].head.zsize;
+
+        // Determine the size of this template
+
+        Nyx_ = thePixelTemp_[index_id_].head.NTyx;
+        Nxx_ = thePixelTemp_[index_id_].head.NTxx;
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-            if(Nyx_ < 2 || Nxx_ < 2) {
-               throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Nyx/Nxx = " << Nyx_ << "/" << Nxx_ << std::endl;
-            }
+        if (Nyx_ < 2 || Nxx_ < 2) {
+          throw cms::Exception("DataCorrupt") << "template ID = " << id_current_
+                                              << "has too few entries: Nyx/Nxx = " << Nyx_ << "/" << Nxx_ << std::endl;
+        }
 #else
-            assert(Nyx_ > 1 && Nxx_ > 1);
+        assert(Nyx_ > 1 && Nxx_ > 1);
 #endif
-            int imidx = Nxx_/2;
-            
-            cotalpha0_ =  thePixelTemp_[index_id_].entry[0][0].cotalpha;
-            cotalpha1_ =  thePixelTemp_[index_id_].entry[0][Nxx_-1].cotalpha;
-            deltacota_ = (cotalpha1_-cotalpha0_)/(float)(Nxx_-1);
-            
-            cotbeta0_ =  thePixelTemp_[index_id_].entry[0][imidx].cotbeta;
-            cotbeta1_ =  thePixelTemp_[index_id_].entry[Nyx_-1][imidx].cotbeta;
-            deltacotb_ = (cotbeta1_-cotbeta0_)/(float)(Nyx_-1);
-            
-            break;
-         }
+        int imidx = Nxx_ / 2;
+
+        cotalpha0_ = thePixelTemp_[index_id_].entry[0][0].cotalpha;
+        cotalpha1_ = thePixelTemp_[index_id_].entry[0][Nxx_ - 1].cotalpha;
+        deltacota_ = (cotalpha1_ - cotalpha0_) / (float)(Nxx_ - 1);
+
+        cotbeta0_ = thePixelTemp_[index_id_].entry[0][imidx].cotbeta;
+        cotbeta1_ = thePixelTemp_[index_id_].entry[Nyx_ - 1][imidx].cotbeta;
+        deltacotb_ = (cotbeta1_ - cotbeta0_) / (float)(Nyx_ - 1);
+
+        break;
       }
-   }
+    }
+  }
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::interpolate can't find needed template ID = " << id
-      << ", Are you using the correct global tag?" << std::endl;
-   }
+  if (index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::interpolate can't find needed template ID = " << id
+                                        << ", Are you using the correct global tag?" << std::endl;
+  }
 #else
-   assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
+  assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
 #endif
-   return true;
+  return true;
 }
 
 // *************************************************************************************************************************************
@@ -610,225 +656,224 @@ bool SiPixelTemplate2D::getid(int id)
 //!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
 // *************************************************************************************************************************************
 
-bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx)
-{
-   
-   
-   // Interpolate for a new set of track angles
-   
-   // Local variables
+bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx) {
+  // Interpolate for a new set of track angles
 
-   float acotb, dcota, dcotb;
-   
-   // Check to see if interpolation is valid
-   
-   if(id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
-      cota_current_ = cotalpha; cotb_current_ = cotbeta;
-      success_ = getid(id);
-   }
-   
+  // Local variables
+
+  float acotb, dcota, dcotb;
+
+  // Check to see if interpolation is valid
+
+  if (id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
+    cota_current_ = cotalpha;
+    cotb_current_ = cotbeta;
+    success_ = getid(id);
+  }
+
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::interpolate can't find needed template ID = " << id
-      << ", Are you using the correct global tag?" << std::endl;
-   }
+  if (index_id_ < 0 || index_id_ >= (int)thePixelTemp_.size()) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::interpolate can't find needed template ID = " << id
+                                        << ", Are you using the correct global tag?" << std::endl;
+  }
 #else
-   assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
+  assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
 #endif
-   
-   // Check angle limits and et up interpolation parameters
-   
-   float cota = cotalpha;
-   flip_x_ = false;
-   flip_y_ = false;
-   switch(Dtype_) {
-      case 0:
-         if(cotbeta < 0.f) {flip_y_ = true;}
-         break;
-      case 1:
-         if(locBz > 0.f) {flip_y_ = true;}
-         break;
-      case 2:
-      case 3:
-      case 4:
-      case 5:
-         if(locBx*locBz < 0.f) {
-            cota = fabs(cotalpha);
-            flip_x_ = true;
-         }
-         if(locBx < 0.f) {flip_y_ = true;}
-         break;
-      default:
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
-#else
-         std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
-#endif
+
+  // Check angle limits and et up interpolation parameters
+
+  float cota = cotalpha;
+  flip_x_ = false;
+  flip_y_ = false;
+  switch (Dtype_) {
+    case 0:
+      if (cotbeta < 0.f) {
+        flip_y_ = true;
       }
-   
-   if(cota < cotalpha0_) {
-      success_ = false;
-      jx0_ = 0;
-      jx1_ = 1;
-      adcota_ = 0.f;
-   } else if(cota > cotalpha1_) {
-      success_ = false;
-      jx0_ = Nxx_ - 1;
+      break;
+    case 1:
+      if (locBz > 0.f) {
+        flip_y_ = true;
+      }
+      break;
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+      if (locBx * locBz < 0.f) {
+        cota = fabs(cotalpha);
+        flip_x_ = true;
+      }
+      if (locBx < 0.f) {
+        flip_y_ = true;
+      }
+      break;
+    default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+      throw cms::Exception("DataCorrupt")
+          << "SiPixelTemplate2D::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+#else
+      std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+#endif
+  }
+
+  if (cota < cotalpha0_) {
+    success_ = false;
+    jx0_ = 0;
+    jx1_ = 1;
+    adcota_ = 0.f;
+  } else if (cota > cotalpha1_) {
+    success_ = false;
+    jx0_ = Nxx_ - 1;
+    jx1_ = jx0_ - 1;
+    adcota_ = 0.f;
+  } else {
+    jx0_ = (int)((cota - cotalpha0_) / deltacota_ + 0.5f);
+    dcota = (cota - (cotalpha0_ + jx0_ * deltacota_)) / deltacota_;
+    adcota_ = fabs(dcota);
+    if (dcota > 0.f) {
+      jx1_ = jx0_ + 1;
+      if (jx1_ > Nxx_ - 1)
+        jx1_ = jx0_ - 1;
+    } else {
       jx1_ = jx0_ - 1;
-      adcota_ = 0.f;
-   } else {
-      jx0_ = (int)((cota-cotalpha0_)/deltacota_+0.5f);
-      dcota = (cota - (cotalpha0_ + jx0_*deltacota_))/deltacota_;
-      adcota_ = fabs(dcota);
-      if(dcota > 0.f) {jx1_ = jx0_ + 1;if(jx1_ > Nxx_-1) jx1_ = jx0_-1;} else {jx1_ = jx0_ - 1; if(jx1_ < 0) jx1_ = jx0_+1;}
-   }
-   
-   // Interpolate the absolute value of cot(beta)
-   
-   acotb = fabs(cotbeta);
-   
-   if(acotb < cotbeta0_) {
-      success_ = false;
-      iy0_ = 0;
-      iy1_ = 1;
-      adcotb_ = 0.f;
-   } else if(acotb > cotbeta1_) {
-      success_ = false;
-      iy0_ = Nyx_ - 1;
-      iy1_ = iy0_ - 1;
-      adcotb_ = 0.f;
-   } else {
-      iy0_ = (int)((acotb-cotbeta0_)/deltacotb_+0.5f);
-      dcotb = (acotb - (cotbeta0_ + iy0_*deltacotb_))/deltacotb_;
-      adcotb_ = fabs(dcotb);
-      if(dcotb > 0.f) {iy1_ = iy0_ + 1; if(iy1_ > Nyx_-1) iy1_ = iy0_-1;} else {iy1_ = iy0_ - 1; if(iy1_ < 0) iy1_ = iy0_+1;}
-   }
-   
-   //  Calculate signed quantities
-   
-   lorydrift_ = lorywidth_/2.;
-   if(flip_y_) lorydrift_ = -lorydrift_;
-   lorxdrift_ = lorxwidth_/2.;
-   if(flip_x_) lorxdrift_ = -lorxdrift_;
-   
-   // Use pointers to the three angle pairs used in the interpolation
-   
-   
-   entry00_ = &thePixelTemp_[index_id_].entry[iy0_][jx0_];
-   entry10_ = &thePixelTemp_[index_id_].entry[iy1_][jx0_];
-   entry01_ = &thePixelTemp_[index_id_].entry[iy0_][jx1_];
-   
-   // Interpolate things in cot(alpha)-cot(beta)
-   
-   qavg_ = entry00_->qavg
-   +adcota_*(entry01_->qavg - entry00_->qavg)
-   +adcotb_*(entry10_->qavg - entry00_->qavg);
-   
-   pixmax_ = entry00_->pixmax
-   +adcota_*(entry01_->pixmax - entry00_->pixmax)
-   +adcotb_*(entry10_->pixmax - entry00_->pixmax);
-   
-   sxymax_ = entry00_->sxymax
-   +adcota_*(entry01_->sxymax - entry00_->sxymax)
-   +adcotb_*(entry10_->sxymax - entry00_->sxymax);
-   
-   chi2avgone_ = entry00_->chi2avgone
-   +adcota_*(entry01_->chi2avgone - entry00_->chi2avgone)
-   +adcotb_*(entry10_->chi2avgone - entry00_->chi2avgone);
-   
-   chi2minone_ = entry00_->chi2minone
-   +adcota_*(entry01_->chi2minone - entry00_->chi2minone)
-   +adcotb_*(entry10_->chi2minone - entry00_->chi2minone);
-   
-   clsleny_ = entry00_->clsleny
-   +adcota_*(entry01_->clsleny - entry00_->clsleny)
-   +adcotb_*(entry10_->clsleny - entry00_->clsleny);
-   
-   clslenx_ = entry00_->clslenx
-   +adcota_*(entry01_->clslenx - entry00_->clslenx)
-   +adcotb_*(entry10_->clslenx - entry00_->clslenx);
-   
-   
-   chi2ppix_ = entry00_->chi2ppix
-   +adcota_*(entry01_->chi2ppix - entry00_->chi2ppix)
-   +adcotb_*(entry10_->chi2ppix - entry00_->chi2ppix);
-   
-   chi2scale_ = entry00_->chi2scale
-   +adcota_*(entry01_->chi2scale - entry00_->chi2scale)
-   +adcotb_*(entry10_->chi2scale - entry00_->chi2scale);
-   
-   scaleyavg_ = entry00_->scaleyavg
-   +adcota_*(entry01_->scaleyavg - entry00_->scaleyavg)
-   +adcotb_*(entry10_->scaleyavg - entry00_->scaleyavg);
-   
-   scalexavg_ = entry00_->scalexavg
-   +adcota_*(entry01_->scalexavg - entry00_->scalexavg)
-   +adcotb_*(entry10_->scalexavg - entry00_->scalexavg);
-   
-   delyavg_ = entry00_->delyavg
-   +adcota_*(entry01_->delyavg - entry00_->delyavg)
-   +adcotb_*(entry10_->delyavg - entry00_->delyavg);
-   
-   delysig_ = entry00_->delysig
-   +adcota_*(entry01_->delysig - entry00_->delysig)
-   +adcotb_*(entry10_->delysig - entry00_->delysig);
-   
-   mpvvav_ = entry00_->mpvvav
-   +adcota_*(entry01_->mpvvav - entry00_->mpvvav)
-   +adcotb_*(entry10_->mpvvav - entry00_->mpvvav);
-   
-   sigmavav_ = entry00_->sigmavav
-   +adcota_*(entry01_->sigmavav - entry00_->sigmavav)
-   +adcotb_*(entry10_->sigmavav - entry00_->sigmavav);
-   
-   kappavav_ = entry00_->kappavav
-   +adcota_*(entry01_->kappavav - entry00_->kappavav)
-   +adcotb_*(entry10_->kappavav - entry00_->kappavav);
-   
-   for(int i=0; i<4 ; ++i) {
-      scalex_[i] = entry00_->scalex[i]
-      +adcota_*(entry01_->scalex[i] - entry00_->scalex[i])
-      +adcotb_*(entry10_->scalex[i] - entry00_->scalex[i]);
-      
-      scaley_[i] = entry00_->scaley[i]
-      +adcota_*(entry01_->scaley[i] - entry00_->scaley[i])
-      +adcotb_*(entry10_->scaley[i] - entry00_->scaley[i]);
-      
-      offsetx_[i] = entry00_->offsetx[i]
-      +adcota_*(entry01_->offsetx[i] - entry00_->offsetx[i])
-      +adcotb_*(entry10_->offsetx[i] - entry00_->offsetx[i]);
-      if(flip_x_) offsetx_[i] = -offsetx_[i];
-      
-      offsety_[i] = entry00_->offsety[i]
-      +adcota_*(entry01_->offsety[i] - entry00_->offsety[i])
-      +adcotb_*(entry10_->offsety[i] - entry00_->offsety[i]);
-      if(flip_y_) offsety_[i] = -offsety_[i];
-   }
-   
-   for(int i=0; i<2 ; ++i) {
-      for(int j=0; j<5 ; ++j) {
-         // Charge loss switches sides when cot(beta) changes sign
-         if(flip_y_) {
-            xypary0x0_[1-i][j] = (float)entry00_->xypar[i][j];
-            xypary1x0_[1-i][j] = (float)entry10_->xypar[i][j];
-            xypary0x1_[1-i][j] = (float)entry01_->xypar[i][j];
-            lanpar_[1-i][j] = entry00_->lanpar[i][j]
-            +adcota_*(entry01_->lanpar[i][j] - entry00_->lanpar[i][j])
-            +adcotb_*(entry10_->lanpar[i][j] - entry00_->lanpar[i][j]);
-         } else {
-            xypary0x0_[i][j] = (float)entry00_->xypar[i][j];
-            xypary1x0_[i][j] = (float)entry10_->xypar[i][j];
-            xypary0x1_[i][j] = (float)entry01_->xypar[i][j];
-            lanpar_[i][j] = entry00_->lanpar[i][j]
-            +adcota_*(entry01_->lanpar[i][j] - entry00_->lanpar[i][j])
-            +adcotb_*(entry10_->lanpar[i][j] - entry00_->lanpar[i][j]);
-         }
-      }
-   }
-   
-   return success_;
-} // interpolate
+      if (jx1_ < 0)
+        jx1_ = jx0_ + 1;
+    }
+  }
 
+  // Interpolate the absolute value of cot(beta)
+
+  acotb = fabs(cotbeta);
+
+  if (acotb < cotbeta0_) {
+    success_ = false;
+    iy0_ = 0;
+    iy1_ = 1;
+    adcotb_ = 0.f;
+  } else if (acotb > cotbeta1_) {
+    success_ = false;
+    iy0_ = Nyx_ - 1;
+    iy1_ = iy0_ - 1;
+    adcotb_ = 0.f;
+  } else {
+    iy0_ = (int)((acotb - cotbeta0_) / deltacotb_ + 0.5f);
+    dcotb = (acotb - (cotbeta0_ + iy0_ * deltacotb_)) / deltacotb_;
+    adcotb_ = fabs(dcotb);
+    if (dcotb > 0.f) {
+      iy1_ = iy0_ + 1;
+      if (iy1_ > Nyx_ - 1)
+        iy1_ = iy0_ - 1;
+    } else {
+      iy1_ = iy0_ - 1;
+      if (iy1_ < 0)
+        iy1_ = iy0_ + 1;
+    }
+  }
+
+  //  Calculate signed quantities
+
+  lorydrift_ = lorywidth_ / 2.;
+  if (flip_y_)
+    lorydrift_ = -lorydrift_;
+  lorxdrift_ = lorxwidth_ / 2.;
+  if (flip_x_)
+    lorxdrift_ = -lorxdrift_;
+
+  // Use pointers to the three angle pairs used in the interpolation
+
+  entry00_ = &thePixelTemp_[index_id_].entry[iy0_][jx0_];
+  entry10_ = &thePixelTemp_[index_id_].entry[iy1_][jx0_];
+  entry01_ = &thePixelTemp_[index_id_].entry[iy0_][jx1_];
+
+  // Interpolate things in cot(alpha)-cot(beta)
+
+  qavg_ = entry00_->qavg + adcota_ * (entry01_->qavg - entry00_->qavg) + adcotb_ * (entry10_->qavg - entry00_->qavg);
+
+  pixmax_ = entry00_->pixmax + adcota_ * (entry01_->pixmax - entry00_->pixmax) +
+            adcotb_ * (entry10_->pixmax - entry00_->pixmax);
+
+  sxymax_ = entry00_->sxymax + adcota_ * (entry01_->sxymax - entry00_->sxymax) +
+            adcotb_ * (entry10_->sxymax - entry00_->sxymax);
+
+  chi2avgone_ = entry00_->chi2avgone + adcota_ * (entry01_->chi2avgone - entry00_->chi2avgone) +
+                adcotb_ * (entry10_->chi2avgone - entry00_->chi2avgone);
+
+  chi2minone_ = entry00_->chi2minone + adcota_ * (entry01_->chi2minone - entry00_->chi2minone) +
+                adcotb_ * (entry10_->chi2minone - entry00_->chi2minone);
+
+  clsleny_ = entry00_->clsleny + adcota_ * (entry01_->clsleny - entry00_->clsleny) +
+             adcotb_ * (entry10_->clsleny - entry00_->clsleny);
+
+  clslenx_ = entry00_->clslenx + adcota_ * (entry01_->clslenx - entry00_->clslenx) +
+             adcotb_ * (entry10_->clslenx - entry00_->clslenx);
+
+  chi2ppix_ = entry00_->chi2ppix + adcota_ * (entry01_->chi2ppix - entry00_->chi2ppix) +
+              adcotb_ * (entry10_->chi2ppix - entry00_->chi2ppix);
+
+  chi2scale_ = entry00_->chi2scale + adcota_ * (entry01_->chi2scale - entry00_->chi2scale) +
+               adcotb_ * (entry10_->chi2scale - entry00_->chi2scale);
+
+  scaleyavg_ = entry00_->scaleyavg + adcota_ * (entry01_->scaleyavg - entry00_->scaleyavg) +
+               adcotb_ * (entry10_->scaleyavg - entry00_->scaleyavg);
+
+  scalexavg_ = entry00_->scalexavg + adcota_ * (entry01_->scalexavg - entry00_->scalexavg) +
+               adcotb_ * (entry10_->scalexavg - entry00_->scalexavg);
+
+  delyavg_ = entry00_->delyavg + adcota_ * (entry01_->delyavg - entry00_->delyavg) +
+             adcotb_ * (entry10_->delyavg - entry00_->delyavg);
+
+  delysig_ = entry00_->delysig + adcota_ * (entry01_->delysig - entry00_->delysig) +
+             adcotb_ * (entry10_->delysig - entry00_->delysig);
+
+  mpvvav_ = entry00_->mpvvav + adcota_ * (entry01_->mpvvav - entry00_->mpvvav) +
+            adcotb_ * (entry10_->mpvvav - entry00_->mpvvav);
+
+  sigmavav_ = entry00_->sigmavav + adcota_ * (entry01_->sigmavav - entry00_->sigmavav) +
+              adcotb_ * (entry10_->sigmavav - entry00_->sigmavav);
+
+  kappavav_ = entry00_->kappavav + adcota_ * (entry01_->kappavav - entry00_->kappavav) +
+              adcotb_ * (entry10_->kappavav - entry00_->kappavav);
+
+  for (int i = 0; i < 4; ++i) {
+    scalex_[i] = entry00_->scalex[i] + adcota_ * (entry01_->scalex[i] - entry00_->scalex[i]) +
+                 adcotb_ * (entry10_->scalex[i] - entry00_->scalex[i]);
+
+    scaley_[i] = entry00_->scaley[i] + adcota_ * (entry01_->scaley[i] - entry00_->scaley[i]) +
+                 adcotb_ * (entry10_->scaley[i] - entry00_->scaley[i]);
+
+    offsetx_[i] = entry00_->offsetx[i] + adcota_ * (entry01_->offsetx[i] - entry00_->offsetx[i]) +
+                  adcotb_ * (entry10_->offsetx[i] - entry00_->offsetx[i]);
+    if (flip_x_)
+      offsetx_[i] = -offsetx_[i];
+
+    offsety_[i] = entry00_->offsety[i] + adcota_ * (entry01_->offsety[i] - entry00_->offsety[i]) +
+                  adcotb_ * (entry10_->offsety[i] - entry00_->offsety[i]);
+    if (flip_y_)
+      offsety_[i] = -offsety_[i];
+  }
+
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      // Charge loss switches sides when cot(beta) changes sign
+      if (flip_y_) {
+        xypary0x0_[1 - i][j] = (float)entry00_->xypar[i][j];
+        xypary1x0_[1 - i][j] = (float)entry10_->xypar[i][j];
+        xypary0x1_[1 - i][j] = (float)entry01_->xypar[i][j];
+        lanpar_[1 - i][j] = entry00_->lanpar[i][j] + adcota_ * (entry01_->lanpar[i][j] - entry00_->lanpar[i][j]) +
+                            adcotb_ * (entry10_->lanpar[i][j] - entry00_->lanpar[i][j]);
+      } else {
+        xypary0x0_[i][j] = (float)entry00_->xypar[i][j];
+        xypary1x0_[i][j] = (float)entry10_->xypar[i][j];
+        xypary0x1_[i][j] = (float)entry01_->xypar[i][j];
+        lanpar_[i][j] = entry00_->lanpar[i][j] + adcota_ * (entry01_->lanpar[i][j] - entry00_->lanpar[i][j]) +
+                        adcotb_ * (entry10_->lanpar[i][j] - entry00_->lanpar[i][j]);
+      }
+    }
+  }
+
+  return success_;
+}  // interpolate
 
 // *************************************************************************************************************************************
 //! Load template info for single angle point to invoke template reco for template generation
@@ -838,114 +883,128 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
 //! \param      sizez - (input) pixel z-size
 // *************************************************************************************************************************************
 
-void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize)
-{
-   // Set class variables to the input parameters
-   
-   entry00_ = entry;
-   entry01_ = entry;
-   entry10_ = entry;
-   Dtype_ = iDtype;
-   lorywidth_ = lorwdy;
-   lorxwidth_ = lorwdx;
-   xsize_ = xsize;
-   ysize_ = ysize;
-   zsize_ = zsize;
-   s50_ = q50;
-   qscale_ = 1.f;
-   for(int i=0; i<3; ++i) {fbin_[i] = fbin[i];}
-   
-   // Set other class variables
-   
-   adcota_ = 0.f;
-   adcotb_ = 0.f;
-   
-   // Interpolate things in cot(alpha)-cot(beta)
-   
-   qavg_ = entry00_->qavg;
-   
-   pixmax_ = entry00_->pixmax;
-   
-   sxymax_ = entry00_->sxymax;
-   
-   clsleny_ = entry00_->clsleny;
-   
-   clslenx_ = entry00_->clslenx;
-   
-   scaleyavg_ = 1.f;
-   
-   scalexavg_ = 1.f;
-   
-   delyavg_ = 0.f;
-   
-   delysig_ = 0.f;
-   
-   for(int i=0; i<4 ; ++i) {
-      scalex_[i] = 1.f;
-      scaley_[i] = 1.f;
-      offsetx_[i] = 0.f;
-      offsety_[i] = 0.f;
-   }
-   
-   // This works only for IP-related tracks
-   
-   flip_x_ = false;
-   flip_y_ = false;
-   float cotbeta = entry00_->cotbeta;
-   switch(Dtype_) {
-      case 0:
-         if(cotbeta < 0.f) {flip_y_ = true;}
-         break;
-      case 1:
-         if(locBz > 0.f) {
-            flip_y_ = true;
-         }
-         break;
-      case 2:
-      case 3:
-      case 4:
-      case 5:
-         if(locBx*locBz < 0.f) {
-            flip_x_ = true;
-         }
-         if(locBx < 0.f) {
-            flip_y_ = true;
-         }
-         break;
-      default:
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::illegal subdetector ID = " << iDtype << std::endl;
-#else
-         std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
-#endif
-   }
-   
-   //  Calculate signed quantities
-   
-   lorydrift_ = lorywidth_/2.;
-   if(flip_y_) lorydrift_ = -lorydrift_;
-   lorxdrift_ = lorxwidth_/2.;
-   if(flip_x_) lorxdrift_ = -lorxdrift_;
-   
-   for(int i=0; i<2 ; ++i) {
-      for(int j=0; j<5 ; ++j) {
-         // Charge loss switches sides when cot(beta) changes sign
-         if(flip_y_) {
-            xypary0x0_[1-i][j] = (float)entry00_->xypar[i][j];
-            xypary1x0_[1-i][j] = (float)entry00_->xypar[i][j];
-            xypary0x1_[1-i][j] = (float)entry00_->xypar[i][j];
-            lanpar_[1-i][j] = entry00_->lanpar[i][j];
-         } else {
-            xypary0x0_[i][j] = (float)entry00_->xypar[i][j];
-            xypary1x0_[i][j] = (float)entry00_->xypar[i][j];
-            xypary0x1_[i][j] = (float)entry00_->xypar[i][j];
-            lanpar_[i][j] = entry00_->lanpar[i][j];
-         }
-      }
-   }
-   return;
-}
+void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry,
+                                 int iDtype,
+                                 float locBx,
+                                 float locBz,
+                                 float lorwdy,
+                                 float lorwdx,
+                                 float q50,
+                                 float fbin[3],
+                                 float xsize,
+                                 float ysize,
+                                 float zsize) {
+  // Set class variables to the input parameters
 
+  entry00_ = entry;
+  entry01_ = entry;
+  entry10_ = entry;
+  Dtype_ = iDtype;
+  lorywidth_ = lorwdy;
+  lorxwidth_ = lorwdx;
+  xsize_ = xsize;
+  ysize_ = ysize;
+  zsize_ = zsize;
+  s50_ = q50;
+  qscale_ = 1.f;
+  for (int i = 0; i < 3; ++i) {
+    fbin_[i] = fbin[i];
+  }
+
+  // Set other class variables
+
+  adcota_ = 0.f;
+  adcotb_ = 0.f;
+
+  // Interpolate things in cot(alpha)-cot(beta)
+
+  qavg_ = entry00_->qavg;
+
+  pixmax_ = entry00_->pixmax;
+
+  sxymax_ = entry00_->sxymax;
+
+  clsleny_ = entry00_->clsleny;
+
+  clslenx_ = entry00_->clslenx;
+
+  scaleyavg_ = 1.f;
+
+  scalexavg_ = 1.f;
+
+  delyavg_ = 0.f;
+
+  delysig_ = 0.f;
+
+  for (int i = 0; i < 4; ++i) {
+    scalex_[i] = 1.f;
+    scaley_[i] = 1.f;
+    offsetx_[i] = 0.f;
+    offsety_[i] = 0.f;
+  }
+
+  // This works only for IP-related tracks
+
+  flip_x_ = false;
+  flip_y_ = false;
+  float cotbeta = entry00_->cotbeta;
+  switch (Dtype_) {
+    case 0:
+      if (cotbeta < 0.f) {
+        flip_y_ = true;
+      }
+      break;
+    case 1:
+      if (locBz > 0.f) {
+        flip_y_ = true;
+      }
+      break;
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+      if (locBx * locBz < 0.f) {
+        flip_x_ = true;
+      }
+      if (locBx < 0.f) {
+        flip_y_ = true;
+      }
+      break;
+    default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::illegal subdetector ID = " << iDtype << std::endl;
+#else
+      std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
+#endif
+  }
+
+  //  Calculate signed quantities
+
+  lorydrift_ = lorywidth_ / 2.;
+  if (flip_y_)
+    lorydrift_ = -lorydrift_;
+  lorxdrift_ = lorxwidth_ / 2.;
+  if (flip_x_)
+    lorxdrift_ = -lorxdrift_;
+
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      // Charge loss switches sides when cot(beta) changes sign
+      if (flip_y_) {
+        xypary0x0_[1 - i][j] = (float)entry00_->xypar[i][j];
+        xypary1x0_[1 - i][j] = (float)entry00_->xypar[i][j];
+        xypary0x1_[1 - i][j] = (float)entry00_->xypar[i][j];
+        lanpar_[1 - i][j] = entry00_->lanpar[i][j];
+      } else {
+        xypary0x0_[i][j] = (float)entry00_->xypar[i][j];
+        xypary1x0_[i][j] = (float)entry00_->xypar[i][j];
+        xypary0x1_[i][j] = (float)entry00_->xypar[i][j];
+        lanpar_[i][j] = entry00_->lanpar[i][j];
+      }
+    }
+  }
+  return;
+}
 
 // *************************************************************************************************************************************
 //! \param       xhit - (input) x-position of hit relative to the lower left corner of pixel[1][1] (to allow for the "padding" of the two-d clusters in the splitter)
@@ -955,484 +1014,628 @@ void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry, int iDtype, floa
 //! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
 // *************************************************************************************************************************************
 
-bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2], bool derivatives, float dpdx2d[2][BXM2][BYM2], float& QTemplate)
-{
-   // Interpolate for a new set of track angles
-   
-   // Local variables
-   int pixx, pixy, k0, k1, l0, l1, deltax, deltay, iflipy, jflipx, imin, imax, jmin, jmax;
-   int m, n;
-   float dx, dy, ddx, ddy, adx, ady;
-   //   const float deltaxy[2] = {8.33f, 12.5f};
-   const float deltaxy[2] = {16.67f, 25.0f};
-   
-   // Check to see if interpolation is valid
-   
-   
-   // next, determine the indices of the closest point in k (y-displacement), l (x-displacement)
-   // pixy and pixx are the indices of the struck pixel in the (Ty,Tx) system
-   // k0,k1 are the k-indices of the closest and next closest point
-   // l0,l1 are the l-indices of the closest and next closest point
-   
-   pixy = (int)floorf(yhit/ysize_);
-   dy = yhit-(pixy+0.5f)*ysize_;
-   if(flip_y_) {dy = -dy;}
-   k0 = (int)(dy/ysize_*6.f+3.5f);
-   if(k0 < 0) k0 = 0;
-   if(k0 > 6) k0 = 6;
-   ddy = 6.f*dy/ysize_ - (k0-3);
-   ady = fabs(ddy);
-   if(ddy > 0.f) {k1 = k0 + 1; if(k1 > 6) k1 = k0-1;} else {k1 = k0 - 1; if(k1 < 0) k1 = k0+1;}
-   pixx = (int)floorf(xhit/xsize_);
-   dx = xhit-(pixx+0.5f)*xsize_;
-   if(flip_x_) {dx = -dx;}
-   l0 = (int)(dx/xsize_*6.f+3.5f);
-   if(l0 < 0) l0 = 0;
-   if(l0 > 6) l0 = 6;
-   ddx = 6.f*dx/xsize_ - (l0-3);
-   adx = fabs(ddx);
-   if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
-   
-   // OK, lets do the template interpolation.
-   
-   // First find the limits of the indices for non-zero pixels
-   
-   imin = std::min(entry00_->iymin,entry10_->iymin);
-   imin_ = std::min(imin,entry01_->iymin);
-   
-   jmin = std::min(entry00_->jxmin,entry10_->jxmin);
-   jmin_ = std::min(jmin,entry01_->jxmin);
-   
-   imax = std::max(entry00_->iymax,entry10_->iymax);
-   imax_ = std::max(imax,entry01_->iymax);
-   
-   jmax = std::max(entry00_->jxmax,entry10_->jxmax);
-   jmax_ = std::max(jmax,entry01_->jxmax);
-   
-   // Calculate the x and y offsets to make the new template
-   
-   // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
-   
-   ++pixy; ++pixx;
-   
-   // In the template store, the struck pixel is always (THy,THx)
-   
-   deltax = pixx - T2HX;
-   deltay = pixy - T2HY;
-   
-   //  First zero the local 2-d template
-   
-   for(int j=0; j<BXM2; ++j) {for(int i=0; i<BYM2; ++i) {xytemp_[j][i] = 0.f;}}
-   
-   // Loop over the non-zero part of the template index space and interpolate
-   
-   for(int j=jmin_; j<=jmax_; ++j) {
+bool SiPixelTemplate2D::xytemp(float xhit,
+                               float yhit,
+                               bool ydouble[BYM2],
+                               bool xdouble[BXM2],
+                               float template2d[BXM2][BYM2],
+                               bool derivatives,
+                               float dpdx2d[2][BXM2][BYM2],
+                               float& QTemplate) {
+  // Interpolate for a new set of track angles
+
+  // Local variables
+  int pixx, pixy, k0, k1, l0, l1, deltax, deltay, iflipy, jflipx, imin, imax, jmin, jmax;
+  int m, n;
+  float dx, dy, ddx, ddy, adx, ady;
+  //   const float deltaxy[2] = {8.33f, 12.5f};
+  const float deltaxy[2] = {16.67f, 25.0f};
+
+  // Check to see if interpolation is valid
+
+  // next, determine the indices of the closest point in k (y-displacement), l (x-displacement)
+  // pixy and pixx are the indices of the struck pixel in the (Ty,Tx) system
+  // k0,k1 are the k-indices of the closest and next closest point
+  // l0,l1 are the l-indices of the closest and next closest point
+
+  pixy = (int)floorf(yhit / ysize_);
+  dy = yhit - (pixy + 0.5f) * ysize_;
+  if (flip_y_) {
+    dy = -dy;
+  }
+  k0 = (int)(dy / ysize_ * 6.f + 3.5f);
+  if (k0 < 0)
+    k0 = 0;
+  if (k0 > 6)
+    k0 = 6;
+  ddy = 6.f * dy / ysize_ - (k0 - 3);
+  ady = fabs(ddy);
+  if (ddy > 0.f) {
+    k1 = k0 + 1;
+    if (k1 > 6)
+      k1 = k0 - 1;
+  } else {
+    k1 = k0 - 1;
+    if (k1 < 0)
+      k1 = k0 + 1;
+  }
+  pixx = (int)floorf(xhit / xsize_);
+  dx = xhit - (pixx + 0.5f) * xsize_;
+  if (flip_x_) {
+    dx = -dx;
+  }
+  l0 = (int)(dx / xsize_ * 6.f + 3.5f);
+  if (l0 < 0)
+    l0 = 0;
+  if (l0 > 6)
+    l0 = 6;
+  ddx = 6.f * dx / xsize_ - (l0 - 3);
+  adx = fabs(ddx);
+  if (ddx > 0.f) {
+    l1 = l0 + 1;
+    if (l1 > 6)
+      l1 = l0 - 1;
+  } else {
+    l1 = l0 - 1;
+    if (l1 < 0)
+      l1 = l0 + 1;
+  }
+
+  // OK, lets do the template interpolation.
+
+  // First find the limits of the indices for non-zero pixels
+
+  imin = std::min(entry00_->iymin, entry10_->iymin);
+  imin_ = std::min(imin, entry01_->iymin);
+
+  jmin = std::min(entry00_->jxmin, entry10_->jxmin);
+  jmin_ = std::min(jmin, entry01_->jxmin);
+
+  imax = std::max(entry00_->iymax, entry10_->iymax);
+  imax_ = std::max(imax, entry01_->iymax);
+
+  jmax = std::max(entry00_->jxmax, entry10_->jxmax);
+  jmax_ = std::max(jmax, entry01_->jxmax);
+
+  // Calculate the x and y offsets to make the new template
+
+  // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+
+  ++pixy;
+  ++pixx;
+
+  // In the template store, the struck pixel is always (THy,THx)
+
+  deltax = pixx - T2HX;
+  deltay = pixy - T2HY;
+
+  //  First zero the local 2-d template
+
+  for (int j = 0; j < BXM2; ++j) {
+    for (int i = 0; i < BYM2; ++i) {
+      xytemp_[j][i] = 0.f;
+    }
+  }
+
+  // Loop over the non-zero part of the template index space and interpolate
+
+  for (int j = jmin_; j <= jmax_; ++j) {
+    // Flip indices as needed
+    if (flip_x_) {
+      jflipx = T2XSIZE - 1 - j;
+      m = deltax + jflipx;
+    } else {
+      m = deltax + j;
+    }
+    for (int i = imin_; i <= imax_; ++i) {
+      if (flip_y_) {
+        iflipy = T2YSIZE - 1 - i;
+        n = deltay + iflipy;
+      } else {
+        n = deltay + i;
+      }
+      if (m >= 0 && m <= BXM3 && n >= 0 && n <= BYM3) {
+        xytemp_[m][n] = (float)entry00_->xytemp[k0][l0][i][j] +
+                        adx * (float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                        ady * (float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                        adcota_ * (float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                        adcotb_ * (float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+      }
+    }
+  }
+
+  //combine rows and columns to simulate double pixels
+
+  for (int n = 1; n < BYM3; ++n) {
+    if (ydouble[n]) {
+      //  Combine the y-columns
+      for (int m = 1; m < BXM3; ++m) {
+        xytemp_[m][n] += xytemp_[m][n + 1];
+      }
+      //  Now shift the remaining pixels over by one column
+      for (int i = n + 1; i < BYM3; ++i) {
+        for (int m = 1; m < BXM3; ++m) {
+          xytemp_[m][i] = xytemp_[m][i + 1];
+        }
+      }
+    }
+  }
+
+  //combine rows and columns to simulate double pixels
+
+  for (int m = 1; m < BXM3; ++m) {
+    if (xdouble[m]) {
+      //  Combine the x-rows
+      for (int n = 1; n < BYM3; ++n) {
+        xytemp_[m][n] += xytemp_[m + 1][n];
+      }
+      //  Now shift the remaining pixels over by one row
+      for (int j = m + 1; j < BXM3; ++j) {
+        for (n = 1; n < BYM3; ++n) {
+          xytemp_[j][n] = xytemp_[j + 1][n];
+        }
+      }
+    }
+  }
+
+  //  Finally, loop through and increment the external template
+
+  float qtemptot = 0.f;
+
+  for (int n = 1; n < BYM3; ++n) {
+    for (int m = 1; m < BXM3; ++m) {
+      if (xytemp_[m][n] != 0.f) {
+        template2d[m][n] += xytemp_[m][n];
+        qtemptot += xytemp_[m][n];
+      }
+    }
+  }
+
+  QTemplate = qtemptot;
+
+  if (derivatives) {
+    float dxytempdx[2][BXM2][BYM2], dxytempdy[2][BXM2][BYM2];
+
+    for (int k = 0; k < 2; ++k) {
+      for (int i = 0; i < BXM2; ++i) {
+        for (int j = 0; j < BYM2; ++j) {
+          dxytempdx[k][i][j] = 0.f;
+          dxytempdy[k][i][j] = 0.f;
+          dpdx2d[k][i][j] = 0.f;
+        }
+      }
+    }
+
+    // First do shifted +x template
+
+    pixx = (int)floorf((xhit + deltaxy[0]) / xsize_);
+    dx = (xhit + deltaxy[0]) - (pixx + 0.5f) * xsize_;
+    if (flip_x_) {
+      dx = -dx;
+    }
+    l0 = (int)(dx / xsize_ * 6.f + 3.5f);
+    if (l0 < 0)
+      l0 = 0;
+    if (l0 > 6)
+      l0 = 6;
+    ddx = 6.f * dx / xsize_ - (l0 - 3);
+    adx = fabs(ddx);
+    if (ddx > 0.f) {
+      l1 = l0 + 1;
+      if (l1 > 6)
+        l1 = l0 - 1;
+    } else {
+      l1 = l0 - 1;
+      if (l1 < 0)
+        l1 = l0 + 1;
+    }
+
+    // OK, lets do the template interpolation.
+
+    // Calculate the x and y offsets to make the new template
+
+    // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+
+    ++pixx;
+
+    // In the template store, the struck pixel is always (THy,THx)
+
+    deltax = pixx - T2HX;
+
+    // Loop over the non-zero part of the template index space and interpolate
+
+    for (int j = jmin_; j <= jmax_; ++j) {
       // Flip indices as needed
-      if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
-      for(int i=imin_; i<=imax_; ++i) {
-         if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
-         if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
-            xytemp_[m][n] = (float)entry00_->xytemp[k0][l0][i][j]
-            + adx*(float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j])
-            + ady*(float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-            + adcota_*(float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-            + adcotb_*(float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
-         }
+      if (flip_x_) {
+        jflipx = T2XSIZE - 1 - j;
+        m = deltax + jflipx;
+      } else {
+        m = deltax + j;
       }
-   }
-   
-   //combine rows and columns to simulate double pixels
-   
-   for(int n=1; n<BYM3; ++n) {
-      if(ydouble[n]) {
-         //  Combine the y-columns
-         for(int m=1; m<BXM3; ++m) {
-            xytemp_[m][n] += xytemp_[m][n+1];
-         }
-         //  Now shift the remaining pixels over by one column
-         for(int i=n+1; i<BYM3; ++i) {
-            for(int m=1; m<BXM3; ++m) {
-               xytemp_[m][i] = xytemp_[m][i+1];
-            }
-         }
+      for (int i = imin_; i <= imax_; ++i) {
+        if (flip_y_) {
+          iflipy = T2YSIZE - 1 - i;
+          n = deltay + iflipy;
+        } else {
+          n = deltay + i;
+        }
+        if (m >= 0 && m <= BXM3 && n >= 0 && n <= BYM3) {
+          dxytempdx[1][m][n] = (float)entry00_->xytemp[k0][l0][i][j] +
+                               adx * (float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               ady * (float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcota_ * (float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcotb_ * (float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+        }
       }
-   }
-   
-   //combine rows and columns to simulate double pixels
-   
-   for(int m=1; m<BXM3; ++m) {
-      if(xdouble[m]) {
-         //  Combine the x-rows
-         for(int n=1; n<BYM3; ++n) {
-            xytemp_[m][n] += xytemp_[m+1][n];
-         }
-         //  Now shift the remaining pixels over by one row
-         for(int j=m+1; j<BXM3; ++j) {
-            for(n=1; n<BYM3; ++n) {
-               xytemp_[j][n] = xytemp_[j+1][n];
-            }
-         }
-      }
-   }
-   
-   //  Finally, loop through and increment the external template
-   
-   float qtemptot = 0.f;
-   
-   for(int n=1; n<BYM3; ++n) {
-      for(int m=1; m<BXM3; ++m) {
-         if(xytemp_[m][n] != 0.f) {template2d[m][n] += xytemp_[m][n]; qtemptot += xytemp_[m][n];}
-      }
-   }
-   
-   QTemplate = qtemptot;
-   
-   if(derivatives) {
-      
-      float dxytempdx[2][BXM2][BYM2], dxytempdy[2][BXM2][BYM2];
-      
-      for(int k = 0; k<2; ++k) {
-         for(int i = 0; i<BXM2; ++i) {
-            for(int j = 0; j<BYM2; ++j) {
-               dxytempdx[k][i][j] = 0.f;
-               dxytempdy[k][i][j] = 0.f;
-               dpdx2d[k][i][j] = 0.f;
-            }
-         }
-      }
-      
-      // First do shifted +x template
-      
-      pixx = (int)floorf((xhit+deltaxy[0])/xsize_);
-      dx = (xhit+deltaxy[0])-(pixx+0.5f)*xsize_;
-      if(flip_x_) {dx = -dx;}
-      l0 = (int)(dx/xsize_*6.f+3.5f);
-      if(l0 < 0) l0 = 0;
-      if(l0 > 6) l0 = 6;
-      ddx = 6.f*dx/xsize_ - (l0-3);
-      adx = fabs(ddx);
-      if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
-      
-      // OK, lets do the template interpolation.
-      
-      // Calculate the x and y offsets to make the new template
-      
-      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
-      
-      ++pixx;
-      
-      // In the template store, the struck pixel is always (THy,THx)
-      
-      deltax = pixx - T2HX;
-      
-      // Loop over the non-zero part of the template index space and interpolate
-      
-      for(int j=jmin_; j<=jmax_; ++j) {
-         // Flip indices as needed
-         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
-         for(int i=imin_; i<=imax_; ++i) {
-            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
-            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
-               dxytempdx[1][m][n] = (float)entry00_->xytemp[k0][l0][i][j]
-               + adx*(float)(entry00_->xytemp[k0][l1][i][j] -   entry00_->xytemp[k0][l0][i][j])
-               + ady*(float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcota_*(float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcotb_*(float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int n=1; n<BYM3; ++n) {
-         if(ydouble[n]) {
-            //  Combine the y-columns
-            for(int m=1; m<BXM3; ++m) {
-               dxytempdx[1][m][n] += dxytempdx[1][m][n+1];
-            }
-            //  Now shift the remaining pixels over by one column
-            for(int i=n+1; i<BYM3; ++i) {
-               for(int m=1; m<BXM3; ++m) {
-                  dxytempdx[1][m][i] = dxytempdx[1][m][i+1];
-               }
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int m=1; m<BXM3; ++m) {
-         if(xdouble[m]) {
-            //  Combine the x-rows
-            for(int n=1; n<BYM3; ++n) {
-               dxytempdx[1][m][n] += dxytempdx[1][m+1][n];
-            }
-            //  Now shift the remaining pixels over by one row
-            for(int j=m+1; j<BXM3; ++j) {
-               for(int n=1; n<BYM3; ++n) {
-                  dxytempdx[1][j][n] = dxytempdx[1][j+1][n];
-               }
-            }
-         }
-      }
-      
-      // Next do shifted -x template
-      
-      pixx = (int)floorf((xhit-deltaxy[0])/xsize_);
-      dx = (xhit-deltaxy[0])-(pixx+0.5f)*xsize_;
-      if(flip_x_) {dx = -dx;}
-      l0 = (int)(dx/xsize_*6.f+3.5f);
-      if(l0 < 0) l0 = 0;
-      if(l0 > 6) l0 = 6;
-      ddx = 6.f*dx/xsize_ - (l0-3);
-      adx = fabs(ddx);
-      if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
-      
-      // OK, lets do the template interpolation.
-      
-      // Calculate the x and y offsets to make the new template
-      
-      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
-      
-      ++pixx;
-      
-      // In the template store, the struck pixel is always (THy,THx)
-      
-      deltax = pixx - T2HX;
-      
-      // Loop over the non-zero part of the template index space and interpolate
-      
-      for(int j=jmin_; j<=jmax_; ++j) {
-         // Flip indices as needed
-         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
-         for(int i=imin_; i<=imax_; ++i) {
-            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
-            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
-               dxytempdx[0][m][n]  = (float)entry00_->xytemp[k0][l0][i][j]
-               + adx*(float)(entry00_->xytemp[k0][l1][i][j] -   entry00_->xytemp[k0][l0][i][j])
-               + ady*(float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcota_*(float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcotb_*(float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int n=1; n<BYM3; ++n) {
-         if(ydouble[n]) {
-            //  Combine the y-columns
-            for(int m=1; m<BXM3; ++m) {
-               dxytempdx[0][m][n] += dxytempdx[0][m][n+1];
-            }
-            //  Now shift the remaining pixels over by one column
-            for(int i=n+1; i<BYM3; ++i) {
-               for(int m=1; m<BXM3; ++m) {
-                  dxytempdx[0][m][i] = dxytempdx[0][m][i+1];
-               }
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int m=1; m<BXM3; ++m) {
-         if(xdouble[m]) {
-            //  Combine the x-rows
-            for(int n=1; n<BYM3; ++n) {
-               dxytempdx[0][m][n] += dxytempdx[0][m+1][n];
-            }
-            //  Now shift the remaining pixels over by one row
-            for(int j=m+1; j<BXM3; ++j) {
-               for(int n=1; n<BYM3; ++n) {
-                  dxytempdx[0][j][n] = dxytempdx[0][j+1][n];
-               }
-            }
-         }
-      }
-      
-      
-      //  Finally, normalize the derivatives and copy the results to the output array
-      
-      for(int n=1; n<BYM3; ++n) {
-         for(int m=1; m<BXM3; ++m) {
-            dpdx2d[0][m][n] = (dxytempdx[1][m][n] - dxytempdx[0][m][n])/(2.*deltaxy[0]);
-         }
-      }
-      
-      // Next, do shifted y template
-      
-      pixy = (int)floorf((yhit+deltaxy[1])/ysize_);
-      dy = (yhit+deltaxy[1])-(pixy+0.5f)*ysize_;
-      if(flip_y_) {dy = -dy;}
-      k0 = (int)(dy/ysize_*6.f+3.5f);
-      if(k0 < 0) k0 = 0;
-      if(k0 > 6) k0 = 6;
-      ddy = 6.f*dy/ysize_ - (k0-3);
-      ady = fabs(ddy);
-      if(ddy > 0.f) {k1 = k0 + 1; if(k1 > 6) k1 = k0-1;} else {k1 = k0 - 1; if(k1 < 0) k1 = k0+1;}
-      pixx = (int)floorf(xhit/xsize_);
-      dx = xhit-(pixx+0.5f)*xsize_;
-      if(flip_x_) {dx = -dx;}
-      l0 = (int)(dx/xsize_*6.f+3.5f);
-      if(l0 < 0) l0 = 0;
-      if(l0 > 6) l0 = 6;
-      ddx = 6.f*dx/xsize_ - (l0-3);
-      adx = fabs(ddx);
-      if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
-      
-      // OK, lets do the template interpolation.
-      
-      // Calculate the x and y offsets to make the new template
-      
-      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
-      
-      ++pixy; ++pixx;
-      
-      // In the template store, the struck pixel is always (THy,THx)
-      
-      deltax = pixx - T2HX;
-      deltay = pixy - T2HY;
-      
-      // Loop over the non-zero part of the template index space and interpolate
-      
-      for(int j=jmin_; j<=jmax_; ++j) {
-         // Flip indices as needed
-         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
-         for(int i=imin_; i<=imax_; ++i) {
-            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
-            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
-               dxytempdy[1][m][n] = (float)entry00_->xytemp[k0][l0][i][j]
-               + adx*(float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + ady*(float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcota_*(float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcotb_*(float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int n=1; n<BYM3; ++n) {
-         if(ydouble[n]) {
-            //  Combine the y-columns
-            for(int m=1; m<BXM3; ++m) {
-               dxytempdy[1][m][n] += dxytempdy[1][m][n+1];
-            }
-            //  Now shift the remaining pixels over by one column
-            for(int i=n+1; i<BYM3; ++i) {
-               for(int m=1; m<BXM3; ++m) {
-                  dxytempdy[1][m][i] = dxytempdy[1][m][i+1];
-               }
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int m=1; m<BXM3; ++m) {
-         if(xdouble[m]) {
-            //  Combine the x-rows
-            for(int n=1; n<BYM3; ++n) {
-               dxytempdy[1][m][n] += dxytempdy[1][m+1][n];
-            }
-            //  Now shift the remaining pixels over by one row
-            for(int j=m+1; j<BXM3; ++j) {
-               for(int n=1; n<BYM3; ++n) {
-                  dxytempdy[1][j][n] = dxytempdy[1][j+1][n];
-               }
-            }
-         }
-      }
-      
-      // Next, do shifted -y template
-      
-      pixy = (int)floorf((yhit-deltaxy[1])/ysize_);
-      dy = (yhit-deltaxy[1])-(pixy+0.5f)*ysize_;
-      if(flip_y_) {dy = -dy;}
-      k0 = (int)(dy/ysize_*6.f+3.5f);
-      if(k0 < 0) k0 = 0;
-      if(k0 > 6) k0 = 6;
-      ddy = 6.f*dy/ysize_ - (k0-3);
-      ady = fabs(ddy);
-      if(ddy > 0.f) {k1 = k0 + 1; if(k1 > 6) k1 = k0-1;} else {k1 = k0 - 1; if(k1 < 0) k1 = k0+1;}
-      
-      // OK, lets do the template interpolation.
-      
-      // Calculate the x and y offsets to make the new template
-      
-      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
-      
-      ++pixy;
-      
-      // In the template store, the struck pixel is always (THy,THx)
-      
-      deltay = pixy - T2HY;
-      
-      // Loop over the non-zero part of the template index space and interpolate
-      
-      for(int j=jmin_; j<=jmax_; ++j) {
-         // Flip indices as needed
-         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
-         for(int i=imin_; i<=imax_; ++i) {
-            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
-            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
-               dxytempdy[0][m][n] = (float)entry00_->xytemp[k0][l0][i][j]
-               + adx*(float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + ady*(float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcota_*(float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
-               + adcotb_*(float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int n=1; n<BYM3; ++n) {
-         if(ydouble[n]) {
-            //  Combine the y-columns
-            for(int m=1; m<BXM3; ++m) {
-               dxytempdy[0][m][n] += dxytempdy[0][m][n+1];
-            }
-            //  Now shift the remaining pixels over by one column
-            for(int i=n+1; i<BYM3; ++i) {
-               for(int m=1; m<BXM3; ++m) {
-                  dxytempdy[0][m][i] = dxytempdy[0][m][i+1];
-               }
-            }
-         }
-      }
-      
-      //combine rows and columns to simulate double pixels
-      
-      for(int m=1; m<BXM3; ++m) {
-         if(xdouble[m]) {
-            //  Combine the x-rows
-            for(int n=1; n<BYM3; ++n) {
-               dxytempdy[0][m][n] += dxytempdy[0][m+1][n];
-            }
-            //  Now shift the remaining pixels over by one row
-            for(int j=m+1; j<BXM3; ++j) {
-               for(int n=1; n<BYM3; ++n) {
-                  dxytempdy[0][j][n] = dxytempdy[0][j+1][n];
-               }
-            }
-         }
-      }
-      
-      //  Finally, normalize the derivatives and copy the results to the output array
-      
-      for(int n=1; n<BYM3; ++n) {
-         for(int m=1; m<BXM3; ++m) {
-            dpdx2d[1][m][n] = (dxytempdy[1][m][n] - dxytempdy[0][m][n])/(2.*deltaxy[1]);
-         }
-      }
-   }
-   
-   return success_;
-} // xytemp
+    }
 
+    //combine rows and columns to simulate double pixels
 
+    for (int n = 1; n < BYM3; ++n) {
+      if (ydouble[n]) {
+        //  Combine the y-columns
+        for (int m = 1; m < BXM3; ++m) {
+          dxytempdx[1][m][n] += dxytempdx[1][m][n + 1];
+        }
+        //  Now shift the remaining pixels over by one column
+        for (int i = n + 1; i < BYM3; ++i) {
+          for (int m = 1; m < BXM3; ++m) {
+            dxytempdx[1][m][i] = dxytempdx[1][m][i + 1];
+          }
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int m = 1; m < BXM3; ++m) {
+      if (xdouble[m]) {
+        //  Combine the x-rows
+        for (int n = 1; n < BYM3; ++n) {
+          dxytempdx[1][m][n] += dxytempdx[1][m + 1][n];
+        }
+        //  Now shift the remaining pixels over by one row
+        for (int j = m + 1; j < BXM3; ++j) {
+          for (int n = 1; n < BYM3; ++n) {
+            dxytempdx[1][j][n] = dxytempdx[1][j + 1][n];
+          }
+        }
+      }
+    }
+
+    // Next do shifted -x template
+
+    pixx = (int)floorf((xhit - deltaxy[0]) / xsize_);
+    dx = (xhit - deltaxy[0]) - (pixx + 0.5f) * xsize_;
+    if (flip_x_) {
+      dx = -dx;
+    }
+    l0 = (int)(dx / xsize_ * 6.f + 3.5f);
+    if (l0 < 0)
+      l0 = 0;
+    if (l0 > 6)
+      l0 = 6;
+    ddx = 6.f * dx / xsize_ - (l0 - 3);
+    adx = fabs(ddx);
+    if (ddx > 0.f) {
+      l1 = l0 + 1;
+      if (l1 > 6)
+        l1 = l0 - 1;
+    } else {
+      l1 = l0 - 1;
+      if (l1 < 0)
+        l1 = l0 + 1;
+    }
+
+    // OK, lets do the template interpolation.
+
+    // Calculate the x and y offsets to make the new template
+
+    // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+
+    ++pixx;
+
+    // In the template store, the struck pixel is always (THy,THx)
+
+    deltax = pixx - T2HX;
+
+    // Loop over the non-zero part of the template index space and interpolate
+
+    for (int j = jmin_; j <= jmax_; ++j) {
+      // Flip indices as needed
+      if (flip_x_) {
+        jflipx = T2XSIZE - 1 - j;
+        m = deltax + jflipx;
+      } else {
+        m = deltax + j;
+      }
+      for (int i = imin_; i <= imax_; ++i) {
+        if (flip_y_) {
+          iflipy = T2YSIZE - 1 - i;
+          n = deltay + iflipy;
+        } else {
+          n = deltay + i;
+        }
+        if (m >= 0 && m <= BXM3 && n >= 0 && n <= BYM3) {
+          dxytempdx[0][m][n] = (float)entry00_->xytemp[k0][l0][i][j] +
+                               adx * (float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               ady * (float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcota_ * (float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcotb_ * (float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int n = 1; n < BYM3; ++n) {
+      if (ydouble[n]) {
+        //  Combine the y-columns
+        for (int m = 1; m < BXM3; ++m) {
+          dxytempdx[0][m][n] += dxytempdx[0][m][n + 1];
+        }
+        //  Now shift the remaining pixels over by one column
+        for (int i = n + 1; i < BYM3; ++i) {
+          for (int m = 1; m < BXM3; ++m) {
+            dxytempdx[0][m][i] = dxytempdx[0][m][i + 1];
+          }
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int m = 1; m < BXM3; ++m) {
+      if (xdouble[m]) {
+        //  Combine the x-rows
+        for (int n = 1; n < BYM3; ++n) {
+          dxytempdx[0][m][n] += dxytempdx[0][m + 1][n];
+        }
+        //  Now shift the remaining pixels over by one row
+        for (int j = m + 1; j < BXM3; ++j) {
+          for (int n = 1; n < BYM3; ++n) {
+            dxytempdx[0][j][n] = dxytempdx[0][j + 1][n];
+          }
+        }
+      }
+    }
+
+    //  Finally, normalize the derivatives and copy the results to the output array
+
+    for (int n = 1; n < BYM3; ++n) {
+      for (int m = 1; m < BXM3; ++m) {
+        dpdx2d[0][m][n] = (dxytempdx[1][m][n] - dxytempdx[0][m][n]) / (2. * deltaxy[0]);
+      }
+    }
+
+    // Next, do shifted y template
+
+    pixy = (int)floorf((yhit + deltaxy[1]) / ysize_);
+    dy = (yhit + deltaxy[1]) - (pixy + 0.5f) * ysize_;
+    if (flip_y_) {
+      dy = -dy;
+    }
+    k0 = (int)(dy / ysize_ * 6.f + 3.5f);
+    if (k0 < 0)
+      k0 = 0;
+    if (k0 > 6)
+      k0 = 6;
+    ddy = 6.f * dy / ysize_ - (k0 - 3);
+    ady = fabs(ddy);
+    if (ddy > 0.f) {
+      k1 = k0 + 1;
+      if (k1 > 6)
+        k1 = k0 - 1;
+    } else {
+      k1 = k0 - 1;
+      if (k1 < 0)
+        k1 = k0 + 1;
+    }
+    pixx = (int)floorf(xhit / xsize_);
+    dx = xhit - (pixx + 0.5f) * xsize_;
+    if (flip_x_) {
+      dx = -dx;
+    }
+    l0 = (int)(dx / xsize_ * 6.f + 3.5f);
+    if (l0 < 0)
+      l0 = 0;
+    if (l0 > 6)
+      l0 = 6;
+    ddx = 6.f * dx / xsize_ - (l0 - 3);
+    adx = fabs(ddx);
+    if (ddx > 0.f) {
+      l1 = l0 + 1;
+      if (l1 > 6)
+        l1 = l0 - 1;
+    } else {
+      l1 = l0 - 1;
+      if (l1 < 0)
+        l1 = l0 + 1;
+    }
+
+    // OK, lets do the template interpolation.
+
+    // Calculate the x and y offsets to make the new template
+
+    // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+
+    ++pixy;
+    ++pixx;
+
+    // In the template store, the struck pixel is always (THy,THx)
+
+    deltax = pixx - T2HX;
+    deltay = pixy - T2HY;
+
+    // Loop over the non-zero part of the template index space and interpolate
+
+    for (int j = jmin_; j <= jmax_; ++j) {
+      // Flip indices as needed
+      if (flip_x_) {
+        jflipx = T2XSIZE - 1 - j;
+        m = deltax + jflipx;
+      } else {
+        m = deltax + j;
+      }
+      for (int i = imin_; i <= imax_; ++i) {
+        if (flip_y_) {
+          iflipy = T2YSIZE - 1 - i;
+          n = deltay + iflipy;
+        } else {
+          n = deltay + i;
+        }
+        if (m >= 0 && m <= BXM3 && n >= 0 && n <= BYM3) {
+          dxytempdy[1][m][n] = (float)entry00_->xytemp[k0][l0][i][j] +
+                               adx * (float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               ady * (float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcota_ * (float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcotb_ * (float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int n = 1; n < BYM3; ++n) {
+      if (ydouble[n]) {
+        //  Combine the y-columns
+        for (int m = 1; m < BXM3; ++m) {
+          dxytempdy[1][m][n] += dxytempdy[1][m][n + 1];
+        }
+        //  Now shift the remaining pixels over by one column
+        for (int i = n + 1; i < BYM3; ++i) {
+          for (int m = 1; m < BXM3; ++m) {
+            dxytempdy[1][m][i] = dxytempdy[1][m][i + 1];
+          }
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int m = 1; m < BXM3; ++m) {
+      if (xdouble[m]) {
+        //  Combine the x-rows
+        for (int n = 1; n < BYM3; ++n) {
+          dxytempdy[1][m][n] += dxytempdy[1][m + 1][n];
+        }
+        //  Now shift the remaining pixels over by one row
+        for (int j = m + 1; j < BXM3; ++j) {
+          for (int n = 1; n < BYM3; ++n) {
+            dxytempdy[1][j][n] = dxytempdy[1][j + 1][n];
+          }
+        }
+      }
+    }
+
+    // Next, do shifted -y template
+
+    pixy = (int)floorf((yhit - deltaxy[1]) / ysize_);
+    dy = (yhit - deltaxy[1]) - (pixy + 0.5f) * ysize_;
+    if (flip_y_) {
+      dy = -dy;
+    }
+    k0 = (int)(dy / ysize_ * 6.f + 3.5f);
+    if (k0 < 0)
+      k0 = 0;
+    if (k0 > 6)
+      k0 = 6;
+    ddy = 6.f * dy / ysize_ - (k0 - 3);
+    ady = fabs(ddy);
+    if (ddy > 0.f) {
+      k1 = k0 + 1;
+      if (k1 > 6)
+        k1 = k0 - 1;
+    } else {
+      k1 = k0 - 1;
+      if (k1 < 0)
+        k1 = k0 + 1;
+    }
+
+    // OK, lets do the template interpolation.
+
+    // Calculate the x and y offsets to make the new template
+
+    // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+
+    ++pixy;
+
+    // In the template store, the struck pixel is always (THy,THx)
+
+    deltay = pixy - T2HY;
+
+    // Loop over the non-zero part of the template index space and interpolate
+
+    for (int j = jmin_; j <= jmax_; ++j) {
+      // Flip indices as needed
+      if (flip_x_) {
+        jflipx = T2XSIZE - 1 - j;
+        m = deltax + jflipx;
+      } else {
+        m = deltax + j;
+      }
+      for (int i = imin_; i <= imax_; ++i) {
+        if (flip_y_) {
+          iflipy = T2YSIZE - 1 - i;
+          n = deltay + iflipy;
+        } else {
+          n = deltay + i;
+        }
+        if (m >= 0 && m <= BXM3 && n >= 0 && n <= BYM3) {
+          dxytempdy[0][m][n] = (float)entry00_->xytemp[k0][l0][i][j] +
+                               adx * (float)(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               ady * (float)(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcota_ * (float)(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]) +
+                               adcotb_ * (float)(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int n = 1; n < BYM3; ++n) {
+      if (ydouble[n]) {
+        //  Combine the y-columns
+        for (int m = 1; m < BXM3; ++m) {
+          dxytempdy[0][m][n] += dxytempdy[0][m][n + 1];
+        }
+        //  Now shift the remaining pixels over by one column
+        for (int i = n + 1; i < BYM3; ++i) {
+          for (int m = 1; m < BXM3; ++m) {
+            dxytempdy[0][m][i] = dxytempdy[0][m][i + 1];
+          }
+        }
+      }
+    }
+
+    //combine rows and columns to simulate double pixels
+
+    for (int m = 1; m < BXM3; ++m) {
+      if (xdouble[m]) {
+        //  Combine the x-rows
+        for (int n = 1; n < BYM3; ++n) {
+          dxytempdy[0][m][n] += dxytempdy[0][m + 1][n];
+        }
+        //  Now shift the remaining pixels over by one row
+        for (int j = m + 1; j < BXM3; ++j) {
+          for (int n = 1; n < BYM3; ++n) {
+            dxytempdy[0][j][n] = dxytempdy[0][j + 1][n];
+          }
+        }
+      }
+    }
+
+    //  Finally, normalize the derivatives and copy the results to the output array
+
+    for (int n = 1; n < BYM3; ++n) {
+      for (int m = 1; m < BXM3; ++m) {
+        dpdx2d[1][m][n] = (dxytempdy[1][m][n] - dxytempdy[0][m][n]) / (2. * deltaxy[1]);
+      }
+    }
+  }
+
+  return success_;
+}  // xytemp
 
 // *************************************************************************************************************************************
 //! Interpolate stored 2-D information for input angles and hit position to make a 2-D template
@@ -1443,19 +1646,17 @@ bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool 
 //! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
 // *************************************************************************************************************************************
 
-bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2])
-{
-   // Interpolate for a new set of track angles
-   
-   bool derivatives = false;
-   float dpdx2d[2][BXM2][BYM2];
-   float QTemplate;
-   
-   return SiPixelTemplate2D::xytemp(xhit, yhit, ydouble, xdouble, template2d, derivatives, dpdx2d, QTemplate);
-   
-} // xytemp
+bool SiPixelTemplate2D::xytemp(
+    float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2]) {
+  // Interpolate for a new set of track angles
 
+  bool derivatives = false;
+  float dpdx2d[2][BXM2][BYM2];
+  float QTemplate;
 
+  return SiPixelTemplate2D::xytemp(xhit, yhit, ydouble, xdouble, template2d, derivatives, dpdx2d, QTemplate);
+
+}  // xytemp
 
 // *************************************************************************************************************************************
 //! Interpolate stored 2-D information for input angles and hit position to make a 2-D template
@@ -1469,37 +1670,50 @@ bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool 
 //! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
 // *************************************************************************************************************************************
 
-bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float xhit, float yhit, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2])
-{
-   
-   // Local variables
-   
-   bool derivatives = false;
-   float dpdx2d[2][BXM2][BYM2];
-   float QTemplate;
-   float locBx = 1.f;
-   if(cotbeta < 0.f) {locBx = -1.f;}
-   float locBz = locBx;
-   if(cotalpha < 0.f) {locBz = -locBx;}
-   
-   bool yd[BYM2], xd[BXM2];
-   
-   yd[0] = false; yd[BYM2-1] = false;
-   for(int i=0; i<TYSIZE; ++i) { yd[i+1] = ydouble[i];}
-   xd[0] = false; xd[BXM2-1] = false;
-   for(int j=0; j<TXSIZE; ++j) { xd[j+1] = xdouble[j];}
-   
-   
-   // Interpolate for a new set of track angles
-   
-   if(SiPixelTemplate2D::interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
-      return SiPixelTemplate2D::xytemp(xhit, yhit, yd, xd, template2d, derivatives, dpdx2d, QTemplate);
-   } else {
-      return false;
-   }
-   
-} // xytemp
+bool SiPixelTemplate2D::xytemp(int id,
+                               float cotalpha,
+                               float cotbeta,
+                               float xhit,
+                               float yhit,
+                               std::vector<bool>& ydouble,
+                               std::vector<bool>& xdouble,
+                               float template2d[BXM2][BYM2]) {
+  // Local variables
 
+  bool derivatives = false;
+  float dpdx2d[2][BXM2][BYM2];
+  float QTemplate;
+  float locBx = 1.f;
+  if (cotbeta < 0.f) {
+    locBx = -1.f;
+  }
+  float locBz = locBx;
+  if (cotalpha < 0.f) {
+    locBz = -locBx;
+  }
+
+  bool yd[BYM2], xd[BXM2];
+
+  yd[0] = false;
+  yd[BYM2 - 1] = false;
+  for (int i = 0; i < TYSIZE; ++i) {
+    yd[i + 1] = ydouble[i];
+  }
+  xd[0] = false;
+  xd[BXM2 - 1] = false;
+  for (int j = 0; j < TXSIZE; ++j) {
+    xd[j + 1] = xdouble[j];
+  }
+
+  // Interpolate for a new set of track angles
+
+  if (SiPixelTemplate2D::interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
+    return SiPixelTemplate2D::xytemp(xhit, yhit, yd, xd, template2d, derivatives, dpdx2d, QTemplate);
+  } else {
+    return false;
+  }
+
+}  // xytemp
 
 // ************************************************************************************************************
 //! Return y error (squared) for an input signal and yindex
@@ -1511,51 +1725,60 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float xhit
 void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
 
 {
-   // Interpolate using quantities already stored in the private variables
-   
-   // Local variables
-   float sigi, sigi2, sigi3, sigi4, qscale, err2, err00;
-   
-   // Make sure that input is OK
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index < 1 || index >= BYM2) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::ysigma2 called with index = " << index << std::endl;
-   }
-#else
-   assert(index > 0 && index < BYM2);
-#endif
-   
-   // Define the maximum signal to use in the parameterization
-   
-   // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
-   
-   if(qpixel < sxymax_) {
-      sigi = qpixel;
-      qscale = 1.f;
-   } else {
-      sigi = sxymax_;
-      qscale = qpixel/sxymax_;
-   }
-   sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
-   if(index <= T2HYP1) {
-      err00 = xypary0x0_[0][0]+xypary0x0_[0][1]*sigi+xypary0x0_[0][2]*sigi2+xypary0x0_[0][3]*sigi3+xypary0x0_[0][4]*sigi4;
-      err2 = err00
-	+adcota_*(xypary0x1_[0][0]+xypary0x1_[0][1]*sigi+xypary0x1_[0][2]*sigi2+xypary0x1_[0][3]*sigi3+xypary0x1_[0][4]*sigi4 - err00)
-	+adcotb_*(xypary1x0_[0][0]+xypary1x0_[0][1]*sigi+xypary1x0_[0][2]*sigi2+xypary1x0_[0][3]*sigi3+xypary1x0_[0][4]*sigi4 - err00);
-   } else {
-      err00 = xypary0x0_[1][0]+xypary0x0_[1][1]*sigi+xypary0x0_[1][2]*sigi2+xypary0x0_[1][3]*sigi3+xypary0x0_[1][4]*sigi4;
-      err2 = err00
-	+adcota_*(xypary0x1_[1][0]+xypary0x1_[1][1]*sigi+xypary0x1_[1][2]*sigi2+xypary0x1_[1][3]*sigi3+xypary0x1_[1][4]*sigi4 - err00)
-	+adcotb_*(xypary1x0_[1][0]+xypary1x0_[1][1]*sigi+xypary1x0_[1][2]*sigi2+xypary1x0_[1][3]*sigi3+xypary1x0_[1][4]*sigi4 - err00);
-   }
-   xysig2 =qscale*err2;
-   if(xysig2 <= 0.f) {xysig2 = s50_*s50_;}
-   
-   return;
-   
-} // End xysigma2
+  // Interpolate using quantities already stored in the private variables
 
+  // Local variables
+  float sigi, sigi2, sigi3, sigi4, qscale, err2, err00;
+
+  // Make sure that input is OK
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+  if (index < 1 || index >= BYM2) {
+    throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::ysigma2 called with index = " << index << std::endl;
+  }
+#else
+  assert(index > 0 && index < BYM2);
+#endif
+
+  // Define the maximum signal to use in the parameterization
+
+  // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
+
+  if (qpixel < sxymax_) {
+    sigi = qpixel;
+    qscale = 1.f;
+  } else {
+    sigi = sxymax_;
+    qscale = qpixel / sxymax_;
+  }
+  sigi2 = sigi * sigi;
+  sigi3 = sigi2 * sigi;
+  sigi4 = sigi3 * sigi;
+  if (index <= T2HYP1) {
+    err00 = xypary0x0_[0][0] + xypary0x0_[0][1] * sigi + xypary0x0_[0][2] * sigi2 + xypary0x0_[0][3] * sigi3 +
+            xypary0x0_[0][4] * sigi4;
+    err2 = err00 +
+           adcota_ * (xypary0x1_[0][0] + xypary0x1_[0][1] * sigi + xypary0x1_[0][2] * sigi2 + xypary0x1_[0][3] * sigi3 +
+                      xypary0x1_[0][4] * sigi4 - err00) +
+           adcotb_ * (xypary1x0_[0][0] + xypary1x0_[0][1] * sigi + xypary1x0_[0][2] * sigi2 + xypary1x0_[0][3] * sigi3 +
+                      xypary1x0_[0][4] * sigi4 - err00);
+  } else {
+    err00 = xypary0x0_[1][0] + xypary0x0_[1][1] * sigi + xypary0x0_[1][2] * sigi2 + xypary0x0_[1][3] * sigi3 +
+            xypary0x0_[1][4] * sigi4;
+    err2 = err00 +
+           adcota_ * (xypary0x1_[1][0] + xypary0x1_[1][1] * sigi + xypary0x1_[1][2] * sigi2 + xypary0x1_[1][3] * sigi3 +
+                      xypary0x1_[1][4] * sigi4 - err00) +
+           adcotb_ * (xypary1x0_[1][0] + xypary1x0_[1][1] * sigi + xypary1x0_[1][2] * sigi2 + xypary1x0_[1][3] * sigi3 +
+                      xypary1x0_[1][4] * sigi4 - err00);
+  }
+  xysig2 = qscale * err2;
+  if (xysig2 <= 0.f) {
+    xysig2 = s50_ * s50_;
+  }
+
+  return;
+
+}  // End xysigma2
 
 // ************************************************************************************************************
 //! Return the Landau probability parameters for this set of cot(alpha, cot(beta)
@@ -1563,16 +1786,13 @@ void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
 void SiPixelTemplate2D::landau_par(float lanpar[2][5])
 
 {
-   // Interpolate using quantities already stored in the private variables
+  // Interpolate using quantities already stored in the private variables
 
-   for(int i=0; i<2; ++i) {
-      for(int j=0; j<5; ++j) {
-         lanpar[i][j] = lanpar_[i][j];
-      }
-   }
-   return;
-   
-} // End lan_par
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      lanpar[i][j] = lanpar_[i][j];
+    }
+  }
+  return;
 
-
-
+}  // End lan_par


### PR DESCRIPTION

Applying code-format for CMSSW category db,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/370//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


