### PR TITLE
Running code-format for daq-l1-reconstruction

### DIFF
--- a/DataFormats/Scalers/interface/BeamSpotOnline.h
+++ b/DataFormats/Scalers/interface/BeamSpotOnline.h
@@ -25,12 +25,10 @@
 /// \class BeamSpotOnline.h
 /// \brief Persistable copy of online BeamSpotOnline value
 
-class BeamSpotOnline
-{
- public:
-
+class BeamSpotOnline {
+public:
   BeamSpotOnline();
-  BeamSpotOnline(const unsigned char * rawData);
+  BeamSpotOnline(const unsigned char* rawData);
   virtual ~BeamSpotOnline();
 
   /// name method
@@ -39,30 +37,30 @@ class BeamSpotOnline
   /// empty method (= false)
   bool empty() const { return false; }
 
-  unsigned int trigType() const            { return(trigType_);}
-  unsigned int eventID() const             { return(eventID_);}
-  unsigned int sourceID() const            { return(sourceID_);}
-  unsigned int bunchNumber() const         { return(bunchNumber_);}
+  unsigned int trigType() const { return (trigType_); }
+  unsigned int eventID() const { return (eventID_); }
+  unsigned int sourceID() const { return (sourceID_); }
+  unsigned int bunchNumber() const { return (bunchNumber_); }
 
-  int version() const                      { return(version_);}
-  timespec collectionTime() const          { return(collectionTime_.get_timespec());}
+  int version() const { return (version_); }
+  timespec collectionTime() const { return (collectionTime_.get_timespec()); }
 
-  float x()  const                         { return(x_);}
-  float y()  const                         { return(y_);}
-  float z()  const                         { return(z_);}
-  float dxdz()  const                      { return(dxdz_);}
-  float dydz()  const                      { return(dydz_);}
-  float err_x()  const                     { return(err_x_);}
-  float err_y()  const                     { return(err_y_);}
-  float err_z()  const                     { return(err_z_);}
-  float err_dxdz()  const                  { return(err_dxdz_);}
-  float err_dydz()  const                  { return(err_dydz_);}
-  float width_x()  const                   { return(width_x_);}
-  float width_y()  const                   { return(width_y_);}
-  float sigma_z()  const                   { return(sigma_z_);}
-  float err_width_x()  const               { return(err_width_x_);}
-  float err_width_y()  const               { return(err_width_y_);}
-  float err_sigma_z()  const               { return(err_sigma_z_);}
+  float x() const { return (x_); }
+  float y() const { return (y_); }
+  float z() const { return (z_); }
+  float dxdz() const { return (dxdz_); }
+  float dydz() const { return (dydz_); }
+  float err_x() const { return (err_x_); }
+  float err_y() const { return (err_y_); }
+  float err_z() const { return (err_z_); }
+  float err_dxdz() const { return (err_dxdz_); }
+  float err_dydz() const { return (err_dydz_); }
+  float width_x() const { return (width_x_); }
+  float width_y() const { return (width_y_); }
+  float sigma_z() const { return (sigma_z_); }
+  float err_width_x() const { return (err_width_x_); }
+  float err_width_y() const { return (err_width_y_); }
+  float err_sigma_z() const { return (err_sigma_z_); }
 
   /// equality operator
   int operator==(const BeamSpotOnline& e) const { return false; }
@@ -71,7 +69,6 @@ class BeamSpotOnline
   int operator!=(const BeamSpotOnline& e) const { return false; }
 
 protected:
-
   unsigned int trigType_;
   unsigned int eventID_;
   unsigned int sourceID_;

--- a/DataFormats/Scalers/interface/DcsStatus.h
+++ b/DataFormats/Scalers/interface/DcsStatus.h
@@ -25,46 +25,42 @@
 /// \class DcsStatus.h
 /// \brief Persistable copy of online DcsStatus flag values
 
-class DcsStatus
-{
- public:
-
+class DcsStatus {
+public:
   static const int partitionList[];
-  static const char * const partitionName[];
+  static const char* const partitionName[];
 
-  enum
-  {
-    EBp         =     0,
-    EBm         =     1,
-    EEp         =     2,
-    EEm         =     3,
-    HBHEa       =     5,
-    HBHEb       =     6,
-    HBHEc       =     7,
-    HF          =     8,
-    HO          =     9,
-    RPC         =    12,
-    DT0         =    13,
-    DTp         =    14,
-    DTm         =    15,
-    CSCp        =    16,
-    CSCm        =    17,
-    CASTOR      =    20,
-    ZDC         =    22,
-    TIBTID      =    24,
-    TOB         =    25,
-    TECp        =    26,
-    TECm        =    27,
-    BPIX        =    28,
-    FPIX        =    29,
-    ESp         =    30,
-    ESm         =    31,
-    nPartitions =    25
+  enum {
+    EBp = 0,
+    EBm = 1,
+    EEp = 2,
+    EEm = 3,
+    HBHEa = 5,
+    HBHEb = 6,
+    HBHEc = 7,
+    HF = 8,
+    HO = 9,
+    RPC = 12,
+    DT0 = 13,
+    DTp = 14,
+    DTm = 15,
+    CSCp = 16,
+    CSCm = 17,
+    CASTOR = 20,
+    ZDC = 22,
+    TIBTID = 24,
+    TOB = 25,
+    TECp = 26,
+    TECm = 27,
+    BPIX = 28,
+    FPIX = 29,
+    ESp = 30,
+    ESm = 31,
+    nPartitions = 25
   };
 
-
   DcsStatus();
-  DcsStatus(const unsigned char * rawData);
+  DcsStatus(const unsigned char* rawData);
   virtual ~DcsStatus();
 
   /// name method
@@ -73,21 +69,20 @@ class DcsStatus
   /// empty method (= false)
   bool empty() const { return false; }
 
-  unsigned int trigType() const            { return(trigType_);}
-  unsigned int eventID() const             { return(eventID_);}
-  unsigned int sourceID() const            { return(sourceID_);}
-  unsigned int bunchNumber() const         { return(bunchNumber_);}
+  unsigned int trigType() const { return (trigType_); }
+  unsigned int eventID() const { return (eventID_); }
+  unsigned int sourceID() const { return (sourceID_); }
+  unsigned int bunchNumber() const { return (bunchNumber_); }
 
-  int version() const                      { return(version_);}
-  timespec collectionTime() const          { return(collectionTime_.get_timespec());}
+  int version() const { return (version_); }
+  timespec collectionTime() const { return (collectionTime_.get_timespec()); }
 
-  unsigned int ready()  const              { return(ready_);}
+  unsigned int ready() const { return (ready_); }
 
-  bool ready(int partitionNumber) const 
-  { return(  (ready_ & ( 1 << partitionNumber )) != 0 );}
+  bool ready(int partitionNumber) const { return ((ready_ & (1 << partitionNumber)) != 0); }
 
-  float magnetCurrent() const     { return(magnetCurrent_);}
-  float magnetTemperature() const { return(magnetTemperature_);}
+  float magnetCurrent() const { return (magnetCurrent_); }
+  float magnetTemperature() const { return (magnetTemperature_); }
 
   /// equality operator
   int operator==(const DcsStatus& e) const { return false; }
@@ -96,7 +91,6 @@ class DcsStatus
   int operator!=(const DcsStatus& e) const { return false; }
 
 protected:
-
   unsigned int trigType_;
   unsigned int eventID_;
   unsigned int sourceID_;

--- a/DataFormats/Scalers/interface/L1AcceptBunchCrossing.h
+++ b/DataFormats/Scalers/interface/L1AcceptBunchCrossing.h
@@ -31,31 +31,26 @@
  *
  */
 
-
 /// \class L1AcceptBunchCrossings.h
 /// \brief Persistable copy of Scalers L1Accept bunch crossing info
 
-class L1AcceptBunchCrossing
-{
- public:
-
+class L1AcceptBunchCrossing {
+public:
   L1AcceptBunchCrossing();
   L1AcceptBunchCrossing(const int l1AcceptOffset__,
-			const unsigned int orbitNumber__,
-			const unsigned int bunchCrossing__,
-			const unsigned int eventType__);
-  L1AcceptBunchCrossing(const int index,
-			const unsigned long long data);
+                        const unsigned int orbitNumber__,
+                        const unsigned int bunchCrossing__,
+                        const unsigned int eventType__);
+  L1AcceptBunchCrossing(const int index, const unsigned long long data);
   virtual ~L1AcceptBunchCrossing();
 
-  enum
-  {
-    ORBIT_NUMBER_SHIFT   = 32ULL,
-    ORBIT_NUMBER_MASK    = 0xFFFFFFFFULL,
+  enum {
+    ORBIT_NUMBER_SHIFT = 32ULL,
+    ORBIT_NUMBER_MASK = 0xFFFFFFFFULL,
     BUNCH_CROSSING_SHIFT = 4ULL,
-    BUNCH_CROSSING_MASK  = 0xFFFULL,
-    EVENT_TYPE_SHIFT     = 0,
-    EVENT_TYPE_MASK      = 0xFULL
+    BUNCH_CROSSING_MASK = 0xFFFULL,
+    EVENT_TYPE_SHIFT = 0,
+    EVENT_TYPE_MASK = 0xFULL
   };
 
   /// name method
@@ -64,10 +59,10 @@ class L1AcceptBunchCrossing
   /// empty method (= false)
   bool empty() const { return false; }
 
-  int l1AcceptOffset() const         { return(l1AcceptOffset_);}
-  unsigned int orbitNumber() const   { return(orbitNumber_);}
-  unsigned int bunchCrossing() const { return(bunchCrossing_);}
-  unsigned int eventType() const     { return(eventType_);}
+  int l1AcceptOffset() const { return (l1AcceptOffset_); }
+  unsigned int orbitNumber() const { return (orbitNumber_); }
+  unsigned int bunchCrossing() const { return (bunchCrossing_); }
+  unsigned int eventType() const { return (eventType_); }
 
   /// equality operator
   int operator==(const L1AcceptBunchCrossing& e) const { return false; }
@@ -76,12 +71,10 @@ class L1AcceptBunchCrossing
   int operator!=(const L1AcceptBunchCrossing& e) const { return false; }
 
 protected:
-
-  int          l1AcceptOffset_;
+  int l1AcceptOffset_;
   unsigned int orbitNumber_;
   unsigned int bunchCrossing_;
   unsigned int eventType_;
-
 };
 
 /// Pretty-print operator for L1AcceptBunchCrossings

--- a/DataFormats/Scalers/interface/L1TriggerRates.h
+++ b/DataFormats/Scalers/interface/L1TriggerRates.h
@@ -22,21 +22,14 @@
  *
  */
 
-
 /// \class L1TriggerRates.h
 /// \brief Persistable copy of L1 Trigger Rates
 
 class L1TriggerScalers;
 
-class L1TriggerRates
-{
- public:
-
-  enum
-  {
-    N_BX = 3654,
-    N_BX_ACTIVE = 2808
-  };
+class L1TriggerRates {
+public:
+  enum { N_BX = 3654, N_BX_ACTIVE = 2808 };
 
 #define BX_SPACING (double)25E-9
 
@@ -46,8 +39,7 @@ class L1TriggerRates
   virtual ~L1TriggerRates();
 
   void computeRunRates(L1TriggerScalers const& t);
-  void computeRates(L1TriggerScalers const& t1,
-		    L1TriggerScalers const& t2);
+  void computeRates(L1TriggerScalers const& t1, L1TriggerScalers const& t2);
 
   /// name method
   std::string name() const { return "L1TriggerRates"; }
@@ -57,141 +49,99 @@ class L1TriggerRates
 
   /// get the data
 
-  int version() const { return(version_);}
-  timespec collectionTimeSummary() { return(collectionTimeSummary_.get_timespec());}
+  int version() const { return (version_); }
+  timespec collectionTimeSummary() { return (collectionTimeSummary_.get_timespec()); }
 
-  double deltaT()       const { return(deltaT_);}
-  double deltaTActive() const { return(deltaTActive_);}
-  double deltaTRun()       const { return(deltaTRun_);}
-  double deltaTRunActive() const { return(deltaTRunActive_);}
+  double deltaT() const { return (deltaT_); }
+  double deltaTActive() const { return (deltaTActive_); }
+  double deltaTRun() const { return (deltaTRun_); }
+  double deltaTRunActive() const { return (deltaTRunActive_); }
 
   // Instantaneous Rate accessors
-  double triggerNumberRate() const            
-  { return(triggerNumberRate_);}
+  double triggerNumberRate() const { return (triggerNumberRate_); }
 
-  double eventNumberRate() const              
-  { return(eventNumberRate_);}
+  double eventNumberRate() const { return (eventNumberRate_); }
 
-  double finalTriggersGeneratedRate() const         
-  { return(finalTriggersGeneratedRate_);}
-  double finalTriggersDistributedRate() const         
-  { return(finalTriggersDistributedRate_);}
+  double finalTriggersGeneratedRate() const { return (finalTriggersGeneratedRate_); }
+  double finalTriggersDistributedRate() const { return (finalTriggersDistributedRate_); }
 
-  double randomTriggersRate() const          
-  { return(randomTriggersRate_);}
+  double randomTriggersRate() const { return (randomTriggersRate_); }
 
-  double calibrationTriggersRate() const     
-  { return(calibrationTriggersRate_);}
+  double calibrationTriggersRate() const { return (calibrationTriggersRate_); }
 
-  double totalTestTriggersRate() const                 
-  { return(totalTestTriggersRate_);}
+  double totalTestTriggersRate() const { return (totalTestTriggersRate_); }
 
-  double orbitNumberRate() const              
-  { return(orbitNumberRate_);}
+  double orbitNumberRate() const { return (orbitNumberRate_); }
 
-  double numberResetsRate() const             
-  { return(numberResetsRate_);}
+  double numberResetsRate() const { return (numberResetsRate_); }
 
-  double deadTimePercent() const                 
-  { return(deadTimePercent_);}
+  double deadTimePercent() const { return (deadTimePercent_); }
 
-  double deadTimeActivePercent() const           
-  { return(deadTimeActivePercent_);}
+  double deadTimeActivePercent() const { return (deadTimeActivePercent_); }
 
-  double deadTimeActiveCalibrationPercent() const
-  { return(deadTimeActiveCalibrationPercent_);}
+  double deadTimeActiveCalibrationPercent() const { return (deadTimeActiveCalibrationPercent_); }
 
-  double deadTimeActivePrivatePercent() const    
-  { return(deadTimeActivePrivatePercent_);}
+  double deadTimeActivePrivatePercent() const { return (deadTimeActivePrivatePercent_); }
 
-  double deadTimeActivePartitionPercent() const  
-  { return(deadTimeActivePartitionPercent_);}
+  double deadTimeActivePartitionPercent() const { return (deadTimeActivePartitionPercent_); }
 
-  double deadTimeActiveThrottlePercent() const   
-  { return(deadTimeActiveThrottlePercent_);}
+  double deadTimeActiveThrottlePercent() const { return (deadTimeActiveThrottlePercent_); }
 
-  double deadTimeActiveTimeSlotPercent() const   
-  { return(deadTimeActiveTimeSlotPercent_);}
+  double deadTimeActiveTimeSlotPercent() const { return (deadTimeActiveTimeSlotPercent_); }
 
-  double finalTriggersInvalidBCPercent() const       
-  { return(finalTriggersInvalidBCPercent_);}
+  double finalTriggersInvalidBCPercent() const { return (finalTriggersInvalidBCPercent_); }
 
-  double lostFinalTriggersPercent() const             
-  { return(lostFinalTriggersPercent_);}
+  double lostFinalTriggersPercent() const { return (lostFinalTriggersPercent_); }
 
-  double lostFinalTriggersActivePercent() const       
-  { return(lostFinalTriggersActivePercent_);}
+  double lostFinalTriggersActivePercent() const { return (lostFinalTriggersActivePercent_); }
 
-  timespec collectionTimeDetails() const 
-  { return(collectionTimeDetails_.get_timespec());}
+  timespec collectionTimeDetails() const { return (collectionTimeDetails_.get_timespec()); }
 
-  std::vector<double> triggersRate() const    { return(triggersRate_);}
-  std::vector<double> testTriggersRate() const
-  { return(testTriggersRate_);}
+  std::vector<double> triggersRate() const { return (triggersRate_); }
+  std::vector<double> testTriggersRate() const { return (testTriggersRate_); }
 
   // Run Rate Accessors
-  double triggerNumberRunRate() const            
-  { return(triggerNumberRunRate_);}
+  double triggerNumberRunRate() const { return (triggerNumberRunRate_); }
 
-  double eventNumberRunRate() const              
-  { return(eventNumberRunRate_);}
+  double eventNumberRunRate() const { return (eventNumberRunRate_); }
 
-  double finalTriggersDistributedRunRate() const         
-  { return(finalTriggersDistributedRunRate_);}
+  double finalTriggersDistributedRunRate() const { return (finalTriggersDistributedRunRate_); }
 
-  double finalTriggersGeneratedRunRate() const      
-  { return(finalTriggersGeneratedRunRate_);}
+  double finalTriggersGeneratedRunRate() const { return (finalTriggersGeneratedRunRate_); }
 
-  double randomTriggersRunRate() const          
-  { return(randomTriggersRunRate_);}
+  double randomTriggersRunRate() const { return (randomTriggersRunRate_); }
 
-  double calibrationTriggersRunRate() const     
-  { return(calibrationTriggersRunRate_);}
+  double calibrationTriggersRunRate() const { return (calibrationTriggersRunRate_); }
 
-  double totalTestTriggersRunRate() const                 
-  { return(totalTestTriggersRunRate_);}
+  double totalTestTriggersRunRate() const { return (totalTestTriggersRunRate_); }
 
-  double orbitNumberRunRate() const              
-  { return(orbitNumberRunRate_);}
+  double orbitNumberRunRate() const { return (orbitNumberRunRate_); }
 
-  double numberResetsRunRate() const             
-  { return(numberResetsRunRate_);}
+  double numberResetsRunRate() const { return (numberResetsRunRate_); }
 
-  double deadTimeRunPercent() const                 
-  { return(deadTimeRunPercent_);}
+  double deadTimeRunPercent() const { return (deadTimeRunPercent_); }
 
-  double deadTimeActiveRunPercent() const           
-  { return(deadTimeActiveRunPercent_);}
+  double deadTimeActiveRunPercent() const { return (deadTimeActiveRunPercent_); }
 
-  double deadTimeActiveCalibrationRunPercent() const
-  { return(deadTimeActiveCalibrationRunPercent_);}
+  double deadTimeActiveCalibrationRunPercent() const { return (deadTimeActiveCalibrationRunPercent_); }
 
-  double deadTimeActivePrivateRunPercent() const    
-  { return(deadTimeActivePrivateRunPercent_);}
+  double deadTimeActivePrivateRunPercent() const { return (deadTimeActivePrivateRunPercent_); }
 
-  double deadTimeActivePartitionRunPercent() const  
-  { return(deadTimeActivePartitionRunPercent_);}
+  double deadTimeActivePartitionRunPercent() const { return (deadTimeActivePartitionRunPercent_); }
 
-  double deadTimeActiveThrottleRunPercent() const   
-  { return(deadTimeActiveThrottleRunPercent_);}
+  double deadTimeActiveThrottleRunPercent() const { return (deadTimeActiveThrottleRunPercent_); }
 
-  double deadTimeActiveTimeSlotRunPercent() const   
-  { return(deadTimeActiveTimeSlotRunPercent_);}
+  double deadTimeActiveTimeSlotRunPercent() const { return (deadTimeActiveTimeSlotRunPercent_); }
 
-  double finalTriggersInvalidBCRunPercent() const       
-  { return(finalTriggersInvalidBCRunPercent_);}
+  double finalTriggersInvalidBCRunPercent() const { return (finalTriggersInvalidBCRunPercent_); }
 
-  double lostFinalTriggersRunPercent() const             
-  { return(lostFinalTriggersRunPercent_);}
+  double lostFinalTriggersRunPercent() const { return (lostFinalTriggersRunPercent_); }
 
-  double lostFinalTriggersActiveRunPercent() const       
-  { return(lostFinalTriggersActiveRunPercent_);}
+  double lostFinalTriggersActiveRunPercent() const { return (lostFinalTriggersActiveRunPercent_); }
 
-  std::vector<double> triggersRunRate() const    
-  { return(triggersRunRate_);}
+  std::vector<double> triggersRunRate() const { return (triggersRunRate_); }
 
-  std::vector<double> testTriggersRunRate() const    
-  { return(testTriggersRunRate_);}
+  std::vector<double> testTriggersRunRate() const { return (testTriggersRunRate_); }
 
   /// equality operator
   int operator==(const L1TriggerRates& e) const { return false; }
@@ -200,7 +150,6 @@ class L1TriggerRates
   int operator!=(const L1TriggerRates& e) const { return false; }
 
 protected:
-
   int version_;
   TimeSpec collectionTimeSummary_;
 
@@ -257,7 +206,6 @@ protected:
   std::vector<double> triggersRunRate_;
   std::vector<double> testTriggersRunRate_;
 };
-
 
 /// Pretty-print operator for L1TriggerRates
 std::ostream& operator<<(std::ostream& s, const L1TriggerRates& c);

--- a/DataFormats/Scalers/interface/L1TriggerScalers.h
+++ b/DataFormats/Scalers/interface/L1TriggerScalers.h
@@ -22,22 +22,15 @@
  *
  */
 
-
 /// \class L1TriggerScalers.h
 /// \brief Persistable copy of L1 Trigger Scalers
 
-class L1TriggerScalers
-{
- public:
-
-  enum 
-  {
-    nL1Triggers          = 128,
-    nL1TestTriggers      = 64
-  };
+class L1TriggerScalers {
+public:
+  enum { nL1Triggers = 128, nL1TestTriggers = 64 };
 
   L1TriggerScalers();
-  L1TriggerScalers(const unsigned char * rawData);
+  L1TriggerScalers(const unsigned char* rawData);
   virtual ~L1TriggerScalers();
 
   /// name method
@@ -47,73 +40,47 @@ class L1TriggerScalers
   bool empty() const { return false; }
 
   // Data accessor methods
-  int version() const { return(version_);}
+  int version() const { return (version_); }
 
-  unsigned int trigType() const            { return(trigType_);}
-  unsigned int eventID() const             { return(eventID_);}
-  unsigned int sourceID() const            { return(sourceID_);}
-  unsigned int bunchNumber() const         { return(bunchNumber_);}
+  unsigned int trigType() const { return (trigType_); }
+  unsigned int eventID() const { return (eventID_); }
+  unsigned int sourceID() const { return (sourceID_); }
+  unsigned int bunchNumber() const { return (bunchNumber_); }
 
-  timespec collectionTimeSpecial() const
-  { return(collectionTimeSpecial_.get_timespec());}
+  timespec collectionTimeSpecial() const { return (collectionTimeSpecial_.get_timespec()); }
 
-  unsigned int orbitNumber() const           
-  { return(orbitNumber_);}
-  unsigned int luminositySection() const           
-  { return(luminositySection_);}
-  unsigned int bunchCrossingErrors() const           
-  { return(bunchCrossingErrors_);}
+  unsigned int orbitNumber() const { return (orbitNumber_); }
+  unsigned int luminositySection() const { return (luminositySection_); }
+  unsigned int bunchCrossingErrors() const { return (bunchCrossingErrors_); }
 
-  timespec collectionTimeSummary() const 
-  { return(collectionTimeSummary_.get_timespec());}
+  timespec collectionTimeSummary() const { return (collectionTimeSummary_.get_timespec()); }
 
-  unsigned int triggerNumber() const         
-  { return(triggerNumber_);}
-  unsigned int eventNumber() const           
-  { return(eventNumber_);}
-  unsigned int finalTriggersDistributed() const      
-  { return(finalTriggersDistributed_);}
-  unsigned int calibrationTriggers() const  
-  { return(calibrationTriggers_);}
-  unsigned int randomTriggers() const       
-  { return(randomTriggers_);}
-  unsigned int totalTestTriggers() const
-  { return(totalTestTriggers_);}
-  unsigned int finalTriggersGenerated() const   
-  { return(finalTriggersGenerated_);}
-  unsigned int finalTriggersInvalidBC() const   
-  { return(finalTriggersInvalidBC_);}
+  unsigned int triggerNumber() const { return (triggerNumber_); }
+  unsigned int eventNumber() const { return (eventNumber_); }
+  unsigned int finalTriggersDistributed() const { return (finalTriggersDistributed_); }
+  unsigned int calibrationTriggers() const { return (calibrationTriggers_); }
+  unsigned int randomTriggers() const { return (randomTriggers_); }
+  unsigned int totalTestTriggers() const { return (totalTestTriggers_); }
+  unsigned int finalTriggersGenerated() const { return (finalTriggersGenerated_); }
+  unsigned int finalTriggersInvalidBC() const { return (finalTriggersInvalidBC_); }
 
-  unsigned long long deadTime() const              
-  { return(deadTime_);}
-  unsigned long long lostFinalTriggers() const
-  { return(lostFinalTriggers_);}
-  unsigned long long deadTimeActive() const        
-  { return(deadTimeActive_);}
-  unsigned long long lostFinalTriggersActive() const
-  { return(lostFinalTriggersActive_);}
+  unsigned long long deadTime() const { return (deadTime_); }
+  unsigned long long lostFinalTriggers() const { return (lostFinalTriggers_); }
+  unsigned long long deadTimeActive() const { return (deadTimeActive_); }
+  unsigned long long lostFinalTriggersActive() const { return (lostFinalTriggersActive_); }
 
-  unsigned long long deadTimeActivePrivate() const   
-  { return(deadTimeActivePrivate_);}
-  unsigned long long deadTimeActivePartition() const 
-  { return(deadTimeActivePartition_);}
-  unsigned long long deadTimeActiveThrottle() const
-  { return(deadTimeActiveThrottle_);}
-  unsigned long long deadTimeActiveCalibration() const
-  { return(deadTimeActiveCalibration_);}
-  unsigned long long deadTimeActiveTimeSlot() const
-  { return(deadTimeActiveTimeSlot_);}
-  unsigned int numberResets() const          
-  { return(numberResets_);}
+  unsigned long long deadTimeActivePrivate() const { return (deadTimeActivePrivate_); }
+  unsigned long long deadTimeActivePartition() const { return (deadTimeActivePartition_); }
+  unsigned long long deadTimeActiveThrottle() const { return (deadTimeActiveThrottle_); }
+  unsigned long long deadTimeActiveCalibration() const { return (deadTimeActiveCalibration_); }
+  unsigned long long deadTimeActiveTimeSlot() const { return (deadTimeActiveTimeSlot_); }
+  unsigned int numberResets() const { return (numberResets_); }
 
-  timespec collectionTimeDetails() const
-  { return(collectionTimeDetails_.get_timespec());}
+  timespec collectionTimeDetails() const { return (collectionTimeDetails_.get_timespec()); }
 
-  std::vector<unsigned int> triggers() const 
-  { return(triggers_);}
+  std::vector<unsigned int> triggers() const { return (triggers_); }
 
-  std::vector<unsigned int> testTriggers() const
-  { return(testTriggers_);}
+  std::vector<unsigned int> testTriggers() const { return (testTriggers_); }
 
   /// equality operator
   int operator==(const L1TriggerScalers& e) const { return false; }
@@ -129,20 +96,20 @@ protected:
   unsigned int sourceID_;
   unsigned int bunchNumber_;
 
-  TimeSpec           collectionTimeSpecial_;
-  unsigned int       orbitNumber_;
-  unsigned int       luminositySection_;
-  unsigned short     bunchCrossingErrors_;
+  TimeSpec collectionTimeSpecial_;
+  unsigned int orbitNumber_;
+  unsigned int luminositySection_;
+  unsigned short bunchCrossingErrors_;
 
-  TimeSpec           collectionTimeSummary_;
-  unsigned int       triggerNumber_;
-  unsigned int       eventNumber_;
-  unsigned int       finalTriggersDistributed_;
-  unsigned int       calibrationTriggers_;
-  unsigned int       randomTriggers_;
-  unsigned int       totalTestTriggers_;
-  unsigned int       finalTriggersGenerated_;
-  unsigned int       finalTriggersInvalidBC_;
+  TimeSpec collectionTimeSummary_;
+  unsigned int triggerNumber_;
+  unsigned int eventNumber_;
+  unsigned int finalTriggersDistributed_;
+  unsigned int calibrationTriggers_;
+  unsigned int randomTriggers_;
+  unsigned int totalTestTriggers_;
+  unsigned int finalTriggersGenerated_;
+  unsigned int finalTriggersInvalidBC_;
   unsigned long long deadTime_;
   unsigned long long lostFinalTriggers_;
   unsigned long long deadTimeActive_;
@@ -152,13 +119,12 @@ protected:
   unsigned long long deadTimeActiveThrottle_;
   unsigned long long deadTimeActiveCalibration_;
   unsigned long long deadTimeActiveTimeSlot_;
-  unsigned int       numberResets_;
+  unsigned int numberResets_;
 
   TimeSpec collectionTimeDetails_;
   std::vector<unsigned int> triggers_;
   std::vector<unsigned int> testTriggers_;
 };
-
 
 /// Pretty-print operator for L1TriggerScalers
 std::ostream& operator<<(std::ostream& s, const L1TriggerScalers& c);

--- a/DataFormats/Scalers/interface/Level1TriggerRates.h
+++ b/DataFormats/Scalers/interface/Level1TriggerRates.h
@@ -22,38 +22,27 @@
  *
  */
 
-
 /// \class Level1TriggerRates.h
 /// \brief Persistable copy of Level1 Trigger Rates
 
 class Level1TriggerScalers;
 
-class Level1TriggerRates
-{
- public:
-
+class Level1TriggerRates {
+public:
 #define BX_SPACING (double)25E-9
 
   Level1TriggerRates();
   Level1TriggerRates(Level1TriggerScalers const& s);
-  Level1TriggerRates(Level1TriggerScalers const& s,
-		     int runNumber);
-  Level1TriggerRates(Level1TriggerScalers const& s1, 
-		     Level1TriggerScalers const& s2);
-  Level1TriggerRates(Level1TriggerScalers const& s1, 
-		     Level1TriggerScalers const& s2,
-		     int runNumber);
+  Level1TriggerRates(Level1TriggerScalers const& s, int runNumber);
+  Level1TriggerRates(Level1TriggerScalers const& s1, Level1TriggerScalers const& s2);
+  Level1TriggerRates(Level1TriggerScalers const& s1, Level1TriggerScalers const& s2, int runNumber);
   virtual ~Level1TriggerRates();
 
   void computeRates(Level1TriggerScalers const& t1);
-  void computeRates(Level1TriggerScalers const& t1, 
-		    int runNumber);
+  void computeRates(Level1TriggerScalers const& t1, int runNumber);
 
-  void computeRates(Level1TriggerScalers const& t1,
-		    Level1TriggerScalers const& t2);
-  void computeRates(Level1TriggerScalers const& t1,
-		    Level1TriggerScalers const& t2,
-		    int runNumber);
+  void computeRates(Level1TriggerScalers const& t1, Level1TriggerScalers const& t2);
+  void computeRates(Level1TriggerScalers const& t1, Level1TriggerScalers const& t2, int runNumber);
 
   /// name method
   std::string name() const { return "Level1TriggerRates"; }
@@ -63,69 +52,56 @@ class Level1TriggerRates
 
   /// get the data
 
-  int version() const { return(version_);}
-  timespec collectionTime() { return(collectionTime_.get_timespec());}
+  int version() const { return (version_); }
+  timespec collectionTime() { return (collectionTime_.get_timespec()); }
 
-  unsigned long long deltaNS()  const { return(deltaNS_);}
-  double deltaT()               const { return(deltaT_);}
+  unsigned long long deltaNS() const { return (deltaNS_); }
+  double deltaT() const { return (deltaT_); }
 
-  double gtTriggersRate() const 
-  { return(gtTriggersRate_);}
+  double gtTriggersRate() const { return (gtTriggersRate_); }
 
-  double gtEventsRate() const 
-  { return(gtEventsRate_);}
+  double gtEventsRate() const { return (gtEventsRate_); }
 
-  timespec collectionTimeLumiSeg() 
-  { return(collectionTimeLumiSeg_.get_timespec());}
+  timespec collectionTimeLumiSeg() { return (collectionTimeLumiSeg_.get_timespec()); }
 
-  double triggersPhysicsGeneratedFDLRate() const 
-  { return(triggersPhysicsGeneratedFDLRate_);}
+  double triggersPhysicsGeneratedFDLRate() const { return (triggersPhysicsGeneratedFDLRate_); }
 
-  double triggersPhysicsLostRate() const 
-  { return(triggersPhysicsLostRate_);}
+  double triggersPhysicsLostRate() const { return (triggersPhysicsLostRate_); }
 
-  double triggersPhysicsLostBeamActiveRate() const 
-  { return(triggersPhysicsLostBeamActiveRate_);}
+  double triggersPhysicsLostBeamActiveRate() const { return (triggersPhysicsLostBeamActiveRate_); }
 
-  double triggersPhysicsLostBeamInactiveRate() const 
-  { return(triggersPhysicsLostBeamInactiveRate_);}
+  double triggersPhysicsLostBeamInactiveRate() const { return (triggersPhysicsLostBeamInactiveRate_); }
 
-  double l1AsPhysicsRate() const     { return(l1AsPhysicsRate_);}
+  double l1AsPhysicsRate() const { return (l1AsPhysicsRate_); }
 
-  double l1AsRandomRate() const      { return(l1AsRandomRate_);}
+  double l1AsRandomRate() const { return (l1AsRandomRate_); }
 
-  double l1AsTestRate() const        { return(l1AsTestRate_);}
+  double l1AsTestRate() const { return (l1AsTestRate_); }
 
-  double l1AsCalibrationRate() const { return(l1AsCalibrationRate_);}
+  double l1AsCalibrationRate() const { return (l1AsCalibrationRate_); }
 
-  double deadtimePercent() const     { return(deadtimePercent_);}
+  double deadtimePercent() const { return (deadtimePercent_); }
 
-  double deadtimeBeamActivePercent() const 
-  { return(deadtimeBeamActivePercent_);}
+  double deadtimeBeamActivePercent() const { return (deadtimeBeamActivePercent_); }
 
-  double deadtimeBeamActiveTriggerRulesPercent() const 
-  { return(deadtimeBeamActiveTriggerRulesPercent_);}
+  double deadtimeBeamActiveTriggerRulesPercent() const { return (deadtimeBeamActiveTriggerRulesPercent_); }
 
-  double deadtimeBeamActiveCalibrationPercent() const 
-  { return(deadtimeBeamActiveCalibrationPercent_);}
+  double deadtimeBeamActiveCalibrationPercent() const { return (deadtimeBeamActiveCalibrationPercent_); }
 
-  double deadtimeBeamActivePrivateOrbitPercent() const 
-  { return(deadtimeBeamActivePrivateOrbitPercent_);}
+  double deadtimeBeamActivePrivateOrbitPercent() const { return (deadtimeBeamActivePrivateOrbitPercent_); }
 
-  double deadtimeBeamActivePartitionControllerPercent() const 
-  { return(deadtimeBeamActivePartitionControllerPercent_);}
+  double deadtimeBeamActivePartitionControllerPercent() const {
+    return (deadtimeBeamActivePartitionControllerPercent_);
+  }
 
-  double deadtimeBeamActiveTimeSlotPercent() const 
-  { return(deadtimeBeamActiveTimeSlotPercent_);}
+  double deadtimeBeamActiveTimeSlotPercent() const { return (deadtimeBeamActiveTimeSlotPercent_); }
 
-  timespec collectionTime() const 
-  { return(collectionTime_.get_timespec());}
+  timespec collectionTime() const { return (collectionTime_.get_timespec()); }
 
-  timespec collectionTimeLumiSeg() const 
-  { return(collectionTimeLumiSeg_.get_timespec());}
+  timespec collectionTimeLumiSeg() const { return (collectionTimeLumiSeg_.get_timespec()); }
 
-  std::vector<double> gtAlgoCountsRate() const { return(gtAlgoCountsRate_);}
-  std::vector<double> gtTechCountsRate() const { return(gtTechCountsRate_);}
+  std::vector<double> gtAlgoCountsRate() const { return (gtAlgoCountsRate_); }
+  std::vector<double> gtTechCountsRate() const { return (gtTechCountsRate_); }
 
   /// equality operator
   int operator==(const Level1TriggerRates& e) const { return false; }
@@ -134,7 +110,6 @@ class Level1TriggerRates
   int operator!=(const Level1TriggerRates& e) const { return false; }
 
 protected:
-
   int version_;
 
   TimeSpec collectionTime_;
@@ -163,7 +138,6 @@ protected:
   std::vector<double> gtAlgoCountsRate_;
   std::vector<double> gtTechCountsRate_;
 };
-
 
 /// Pretty-print operator for Level1TriggerRates
 std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c);

--- a/DataFormats/Scalers/interface/Level1TriggerScalers.h
+++ b/DataFormats/Scalers/interface/Level1TriggerScalers.h
@@ -20,20 +20,12 @@
  *
  */
 
-
 /// \class Level1TriggerScalers.h
 /// \brief Persistable copy of Level1 Trigger Scalers
 
-class Level1TriggerScalers
-{
- public:
-
-  enum 
-  {
-    nLevel1Triggers          = 128,
-    nLevel1TestTriggers      = 64,
-    firstShortLSRun          = 125574
-  };
+class Level1TriggerScalers {
+public:
+  enum { nLevel1Triggers = 128, nLevel1TestTriggers = 64, firstShortLSRun = 125574 };
 
   static const unsigned long long N_BX = 3564ULL;
   static const unsigned long long N_BX_ACTIVE = 2808ULL;
@@ -41,7 +33,7 @@ class Level1TriggerScalers
   static const unsigned long long N_BX_LUMI_SECTION = N_ORBITS_LUMI_SECTION * N_BX;
 
   Level1TriggerScalers();
-  Level1TriggerScalers(const unsigned char * rawData);
+  Level1TriggerScalers(const unsigned char* rawData);
   virtual ~Level1TriggerScalers();
 
   /// name method
@@ -51,75 +43,61 @@ class Level1TriggerScalers
   bool empty() const { return false; }
 
   // Data accessor methods
-  int version() const { return(version_);}
+  int version() const { return (version_); }
 
-  unsigned int trigType() const            { return(trigType_);}
-  unsigned int eventID() const             { return(eventID_);}
-  unsigned int sourceID() const            { return(sourceID_);}
-  unsigned int bunchNumber() const         { return(bunchNumber_);}
+  unsigned int trigType() const { return (trigType_); }
+  unsigned int eventID() const { return (eventID_); }
+  unsigned int sourceID() const { return (sourceID_); }
+  unsigned int bunchNumber() const { return (bunchNumber_); }
 
-  struct timespec collectionTime() const
-  { return(collectionTime_.get_timespec());}
+  struct timespec collectionTime() const {
+    return (collectionTime_.get_timespec());
+  }
 
-  unsigned int lumiSegmentNr() const        { return(lumiSegmentNr_);}
-  unsigned int lumiSegmentOrbits() const    { return(lumiSegmentOrbits_);}
-  unsigned int orbitNr() const              { return(orbitNr_);}
+  unsigned int lumiSegmentNr() const { return (lumiSegmentNr_); }
+  unsigned int lumiSegmentOrbits() const { return (lumiSegmentOrbits_); }
+  unsigned int orbitNr() const { return (orbitNr_); }
 
-  unsigned int gtResets() const             { return(gtResets_);}
-  unsigned int bunchCrossingErrors() const  { return(bunchCrossingErrors_);}
-  unsigned long long gtTriggers() const     { return(gtTriggers_);}
-  unsigned long long gtEvents() const       { return(gtEvents_);}
-  float gtTriggersRate() const              { return(gtTriggersRate_);}
-  float gtEventsRate() const                { return(gtEventsRate_);}
-  int prescaleIndexAlgo() const             { return(prescaleIndexAlgo_);}
-  int prescaleIndexTech() const             { return(prescaleIndexTech_);}
+  unsigned int gtResets() const { return (gtResets_); }
+  unsigned int bunchCrossingErrors() const { return (bunchCrossingErrors_); }
+  unsigned long long gtTriggers() const { return (gtTriggers_); }
+  unsigned long long gtEvents() const { return (gtEvents_); }
+  float gtTriggersRate() const { return (gtTriggersRate_); }
+  float gtEventsRate() const { return (gtEventsRate_); }
+  int prescaleIndexAlgo() const { return (prescaleIndexAlgo_); }
+  int prescaleIndexTech() const { return (prescaleIndexTech_); }
 
-  struct timespec collectionTimeLumiSeg() const
-  { return(collectionTimeLumiSeg_.get_timespec());}
+  struct timespec collectionTimeLumiSeg() const {
+    return (collectionTimeLumiSeg_.get_timespec());
+  }
 
-  unsigned int lumiSegmentNrLumiSeg() const      
-  { return(lumiSegmentNrLumiSeg_);}
+  unsigned int lumiSegmentNrLumiSeg() const { return (lumiSegmentNrLumiSeg_); }
 
-  unsigned long long triggersPhysicsGeneratedFDL() const 
-  { return(triggersPhysicsGeneratedFDL_);}
-  unsigned long long triggersPhysicsLost() const 
-  { return(triggersPhysicsLost_);}
-  unsigned long long triggersPhysicsLostBeamActive() const 
-  { return(triggersPhysicsLostBeamActive_);}
-  unsigned long long triggersPhysicsLostBeamInactive() const 
-  { return(triggersPhysicsLostBeamInactive_);}
-  unsigned long long l1AsPhysics() const 
-  { return(l1AsPhysics_);}
-  unsigned long long l1AsRandom() const 
-  { return(l1AsRandom_);}
-  unsigned long long l1AsTest() const 
-  { return(l1AsTest_);}
-  unsigned long long l1AsCalibration() const 
-  { return(l1AsCalibration_);}
-  unsigned long long deadtime() const 
-  { return(deadtime_);}
-  unsigned long long deadtimeBeamActive() const 
-  { return(deadtimeBeamActive_);}
-  unsigned long long deadtimeBeamActiveTriggerRules() const 
-  { return(deadtimeBeamActiveTriggerRules_);}
-  unsigned long long deadtimeBeamActiveCalibration() const 
-  { return(deadtimeBeamActiveCalibration_);}
-  unsigned long long deadtimeBeamActivePrivateOrbit() const 
-  { return(deadtimeBeamActivePrivateOrbit_);}
-  unsigned long long deadtimeBeamActivePartitionController() const 
-  { return(deadtimeBeamActivePartitionController_);}
-  unsigned long long deadtimeBeamActiveTimeSlot() const 
-  { return(deadtimeBeamActiveTimeSlot_);}
+  unsigned long long triggersPhysicsGeneratedFDL() const { return (triggersPhysicsGeneratedFDL_); }
+  unsigned long long triggersPhysicsLost() const { return (triggersPhysicsLost_); }
+  unsigned long long triggersPhysicsLostBeamActive() const { return (triggersPhysicsLostBeamActive_); }
+  unsigned long long triggersPhysicsLostBeamInactive() const { return (triggersPhysicsLostBeamInactive_); }
+  unsigned long long l1AsPhysics() const { return (l1AsPhysics_); }
+  unsigned long long l1AsRandom() const { return (l1AsRandom_); }
+  unsigned long long l1AsTest() const { return (l1AsTest_); }
+  unsigned long long l1AsCalibration() const { return (l1AsCalibration_); }
+  unsigned long long deadtime() const { return (deadtime_); }
+  unsigned long long deadtimeBeamActive() const { return (deadtimeBeamActive_); }
+  unsigned long long deadtimeBeamActiveTriggerRules() const { return (deadtimeBeamActiveTriggerRules_); }
+  unsigned long long deadtimeBeamActiveCalibration() const { return (deadtimeBeamActiveCalibration_); }
+  unsigned long long deadtimeBeamActivePrivateOrbit() const { return (deadtimeBeamActivePrivateOrbit_); }
+  unsigned long long deadtimeBeamActivePartitionController() const { return (deadtimeBeamActivePartitionController_); }
+  unsigned long long deadtimeBeamActiveTimeSlot() const { return (deadtimeBeamActiveTimeSlot_); }
 
-  unsigned int lastOrbitCounter0() const { return(lastOrbitCounter0_);}
-  unsigned int lastTestEnable() const    { return(lastTestEnable_);}
-  unsigned int lastResync() const        { return(lastResync_);}
-  unsigned int lastStart() const         { return(lastStart_);}
-  unsigned int lastEventCounter0() const { return(lastEventCounter0_);}
-  unsigned int lastHardReset() const     { return(lastHardReset_);}
-  unsigned long long spare0() const      { return(spare0_);}
-  unsigned long long spare1() const      { return(spare1_);}
-  unsigned long long spare2() const      { return(spare2_);}
+  unsigned int lastOrbitCounter0() const { return (lastOrbitCounter0_); }
+  unsigned int lastTestEnable() const { return (lastTestEnable_); }
+  unsigned int lastResync() const { return (lastResync_); }
+  unsigned int lastStart() const { return (lastStart_); }
+  unsigned int lastEventCounter0() const { return (lastEventCounter0_); }
+  unsigned int lastHardReset() const { return (lastHardReset_); }
+  unsigned long long spare0() const { return (spare0_); }
+  unsigned long long spare1() const { return (spare1_); }
+  unsigned long long spare2() const { return (spare2_); }
 
   static double rateLS(unsigned long long counts);
   static double rateLS(unsigned int counts);
@@ -131,11 +109,9 @@ class Level1TriggerScalers
   static double percentLS(unsigned long long counts, int runNumber);
   static double percentLSActive(unsigned long long counts, int runNumber);
 
-  std::vector<unsigned int> gtAlgoCounts() const 
-  { return(gtAlgoCounts_);}
+  std::vector<unsigned int> gtAlgoCounts() const { return (gtAlgoCounts_); }
 
-  std::vector<unsigned int> gtTechCounts() const
-  { return(gtTechCounts_);}
+  std::vector<unsigned int> gtTechCounts() const { return (gtTechCounts_); }
 
   /// equality operator
   int operator==(const Level1TriggerScalers& e) const { return false; }
@@ -151,7 +127,7 @@ protected:
   unsigned int sourceID_;
   unsigned int bunchNumber_;
 
-  TimeSpec    collectionTime_;
+  TimeSpec collectionTime_;
   unsigned int lumiSegmentNr_;
   unsigned int lumiSegmentOrbits_;
   unsigned int orbitNr_;
@@ -164,7 +140,7 @@ protected:
   int prescaleIndexAlgo_;
   int prescaleIndexTech_;
 
-  TimeSpec    collectionTimeLumiSeg_;
+  TimeSpec collectionTimeLumiSeg_;
   unsigned int lumiSegmentNrLumiSeg_;
   unsigned long long triggersPhysicsGeneratedFDL_;
   unsigned long long triggersPhysicsLost_;
@@ -185,8 +161,8 @@ protected:
   std::vector<unsigned int> gtAlgoCounts_;
   std::vector<unsigned int> gtTechCounts_;
 
-  // Orbit counter markers indicating when the last BGO 
-  // command of a particular type was received, relative 
+  // Orbit counter markers indicating when the last BGO
+  // command of a particular type was received, relative
   // to the last OrbitCounter0 (OC0), for this L1 accept
   unsigned int lastOrbitCounter0_;
   unsigned int lastTestEnable_;
@@ -200,7 +176,6 @@ protected:
   unsigned long long spare1_;
   unsigned long long spare2_;
 };
-
 
 /// Pretty-print operator for Level1TriggerScalers
 std::ostream& operator<<(std::ostream& s, const Level1TriggerScalers& c);

--- a/DataFormats/Scalers/interface/LumiScalers.h
+++ b/DataFormats/Scalers/interface/LumiScalers.h
@@ -22,22 +22,16 @@
  *
  */
 
-
 /// \class LumiScalers.h
 /// \brief Persistable copy of HF Lumi Scalers
 
-class LumiScalers
-{
- public:
-
+class LumiScalers {
+public:
   LumiScalers();
-  LumiScalers(const unsigned char * rawData);
+  LumiScalers(const unsigned char* rawData);
   virtual ~LumiScalers();
 
-  enum
-  {
-    nOcc = 2
-  };
+  enum { nOcc = 2 };
 
   /// name method
   std::string name() const { return "LumiScalers"; }
@@ -45,57 +39,49 @@ class LumiScalers
   /// empty method (= false)
   bool empty() const { return false; }
 
-  unsigned int trigType() const            { return(trigType_);}
-  unsigned int eventID() const             { return(eventID_);}
-  unsigned int sourceID() const            { return(sourceID_);}
-  unsigned int bunchNumber() const         { return(bunchNumber_);}
+  unsigned int trigType() const { return (trigType_); }
+  unsigned int eventID() const { return (eventID_); }
+  unsigned int sourceID() const { return (sourceID_); }
+  unsigned int bunchNumber() const { return (bunchNumber_); }
 
-  int version() const                      { return(version_);}
-  timespec collectionTime() const          { return(collectionTime_.get_timespec());}
-  float normalization() const              { return(normalization_);}
-  float deadTimeNormalization() const  
-  { return(deadTimeNormalization_);}
+  int version() const { return (version_); }
+  timespec collectionTime() const { return (collectionTime_.get_timespec()); }
+  float normalization() const { return (normalization_); }
+  float deadTimeNormalization() const { return (deadTimeNormalization_); }
 
-  float lumiFill() const                   { return(lumiFill_);}
-  float lumiRun() const                    { return(lumiRun_);}
-  float liveLumiFill() const               { return(liveLumiFill_);}
-  float liveLumiRun() const                { return(liveLumiRun_);}
-  float instantLumi() const                { return(instantLumi_);}
-  float instantLumiErr() const             { return(instantLumiErr_);}
-  unsigned char instantLumiQlty() const    { return(instantLumiQlty_);}
+  float lumiFill() const { return (lumiFill_); }
+  float lumiRun() const { return (lumiRun_); }
+  float liveLumiFill() const { return (liveLumiFill_); }
+  float liveLumiRun() const { return (liveLumiRun_); }
+  float instantLumi() const { return (instantLumi_); }
+  float instantLumiErr() const { return (instantLumiErr_); }
+  unsigned char instantLumiQlty() const { return (instantLumiQlty_); }
 
-  float lumiETFill() const                 { return(lumiETFill_);}
-  float lumiETRun() const                  { return(lumiETRun_);}
-  float liveLumiETFill() const             { return(liveLumiETFill_);}
-  float liveLumiETRun() const              { return(liveLumiETRun_);}
-  float instantETLumi() const              { return(instantETLumi_);}
-  float instantETLumiErr() const           { return(instantETLumiErr_);}
-  unsigned char instantETLumiQlty() const  { return(instantETLumiQlty_);}
+  float lumiETFill() const { return (lumiETFill_); }
+  float lumiETRun() const { return (lumiETRun_); }
+  float liveLumiETFill() const { return (liveLumiETFill_); }
+  float liveLumiETRun() const { return (liveLumiETRun_); }
+  float instantETLumi() const { return (instantETLumi_); }
+  float instantETLumiErr() const { return (instantETLumiErr_); }
+  unsigned char instantETLumiQlty() const { return (instantETLumiQlty_); }
 
-  std::vector<float> lumiOccFill() const      
-  { return(lumiOccFill_);}
-  std::vector<float> lumiOccRun() const      
-  { return(lumiOccRun_);}
-  std::vector<float> liveLumiOccFill() const      
-  { return(liveLumiOccFill_);}
-  std::vector<float> liveLumiOccRun() const      
-  { return(liveLumiOccRun_);}
-  std::vector<float> instantOccLumi() const      
-  { return(instantOccLumi_);}
-  std::vector<float> instantOccLumiErr() const   
-  { return(instantOccLumiErr_);}
-  std::vector<unsigned char> instantOccLumiQlty() const  
-  { return(instantOccLumiQlty_);}
-  std::vector<float> lumiNoise() const    { return(lumiNoise_);}
+  std::vector<float> lumiOccFill() const { return (lumiOccFill_); }
+  std::vector<float> lumiOccRun() const { return (lumiOccRun_); }
+  std::vector<float> liveLumiOccFill() const { return (liveLumiOccFill_); }
+  std::vector<float> liveLumiOccRun() const { return (liveLumiOccRun_); }
+  std::vector<float> instantOccLumi() const { return (instantOccLumi_); }
+  std::vector<float> instantOccLumiErr() const { return (instantOccLumiErr_); }
+  std::vector<unsigned char> instantOccLumiQlty() const { return (instantOccLumiQlty_); }
+  std::vector<float> lumiNoise() const { return (lumiNoise_); }
 
-  unsigned int sectionNumber() const       { return(sectionNumber_);}
-  unsigned int startOrbit() const          { return(startOrbit_);}
-  unsigned int numOrbits() const           { return(numOrbits_);}
+  unsigned int sectionNumber() const { return (sectionNumber_); }
+  unsigned int startOrbit() const { return (startOrbit_); }
+  unsigned int numOrbits() const { return (numOrbits_); }
 
-  float pileup() const                     { return(pileup_);}
-  float pileupRMS() const                  { return(pileupRMS_);}
-  float bunchLumi() const                  { return(bunchLumi_);}
-  float spare() const                      { return(spare_);}
+  float pileup() const { return (pileup_); }
+  float pileupRMS() const { return (pileupRMS_); }
+  float bunchLumi() const { return (bunchLumi_); }
+  float spare() const { return (spare_); }
 
   /// equality operator
   int operator==(const LumiScalers& e) const { return false; }
@@ -104,7 +90,6 @@ class LumiScalers
   int operator!=(const LumiScalers& e) const { return false; }
 
 protected:
-
   unsigned int trigType_;
   unsigned int eventID_;
   unsigned int sourceID_;
@@ -152,7 +137,6 @@ protected:
   float bunchLumi_;
   float spare_;
 };
-
 
 /// Pretty-print operator for LumiScalers
 std::ostream& operator<<(std::ostream& s, const LumiScalers& c);

--- a/DataFormats/Scalers/interface/ScalersRaw.h
+++ b/DataFormats/Scalers/interface/ScalersRaw.h
@@ -24,43 +24,40 @@
 /// \class ScalersRaw.h
 /// \brief Raw Data Level 1 Global Trigger Scalers and Lumi Scalers
 
-class ScalersRaw
-{
- public:
-  enum
-  {
-    N_L1_TRIGGERS_v1      = 128,
+class ScalersRaw {
+public:
+  enum {
+    N_L1_TRIGGERS_v1 = 128,
     N_L1_TEST_TRIGGERS_v1 = 64,
-    N_LUMI_OCC_v1         = 2,
-    N_BX_v2               = 4,
-    N_BX_v6               = 8,
-    N_SPARE_v5            = 3,
-    I_SPARE_PILEUP_v7     = 0,
-    I_SPARE_PILEUPRMS_v7  = 1,
-    I_SPARE_BUNCHLUMI_v8  = 2,
-    I_SPARE_SPARE_v8      = 3,
-    SCALERS_FED_ID        = 735
+    N_LUMI_OCC_v1 = 2,
+    N_BX_v2 = 4,
+    N_BX_v6 = 8,
+    N_SPARE_v5 = 3,
+    I_SPARE_PILEUP_v7 = 0,
+    I_SPARE_PILEUPRMS_v7 = 1,
+    I_SPARE_BUNCHLUMI_v8 = 2,
+    I_SPARE_SPARE_v8 = 3,
+    SCALERS_FED_ID = 735
   };
 };
 
-struct TriggerScalersRaw_v1
-{
-  unsigned int       collectionTimeSpecial_sec;
-  unsigned int       collectionTimeSpecial_nsec;
-  unsigned int       ORBIT_NUMBER;          /* ORBITNR          */
-  unsigned int       LUMINOSITY_SEGMENT;
-  unsigned short     BC_ERRORS;            
+struct TriggerScalersRaw_v1 {
+  unsigned int collectionTimeSpecial_sec;
+  unsigned int collectionTimeSpecial_nsec;
+  unsigned int ORBIT_NUMBER; /* ORBITNR          */
+  unsigned int LUMINOSITY_SEGMENT;
+  unsigned short BC_ERRORS;
 
-  unsigned int       collectionTimeSummary_sec;
-  unsigned int       collectionTimeSummary_nsec;
-  unsigned int       TRIGGER_NR;            /* TRIGNR_          */
-  unsigned int       EVENT_NR;              /* EVNR             */
-  unsigned int       FINOR_DISTRIBUTED;     /* PHYS_L1A      ?? */
-  unsigned int       CAL_TRIGGER;           /* CAL_L1A_         */
-  unsigned int       RANDOM_TRIGGER;        /* RNDM_L1A_        */
-  unsigned int       TEST_TRIGGER;          /* TECHTRIG_        */
-  unsigned int       FINOR_GENERATED;       /* FINOR_        ?? */
-  unsigned int       FINOR_IN_INVALID_BC;   /* LOST_BC_      ?? */
+  unsigned int collectionTimeSummary_sec;
+  unsigned int collectionTimeSummary_nsec;
+  unsigned int TRIGGER_NR;                  /* TRIGNR_          */
+  unsigned int EVENT_NR;                    /* EVNR             */
+  unsigned int FINOR_DISTRIBUTED;           /* PHYS_L1A      ?? */
+  unsigned int CAL_TRIGGER;                 /* CAL_L1A_         */
+  unsigned int RANDOM_TRIGGER;              /* RNDM_L1A_        */
+  unsigned int TEST_TRIGGER;                /* TECHTRIG_        */
+  unsigned int FINOR_GENERATED;             /* FINOR_        ?? */
+  unsigned int FINOR_IN_INVALID_BC;         /* LOST_BC_      ?? */
   unsigned long long DEADTIME;              /* DEADT_           */
   unsigned long long LOST_FINOR;            /* LOST_TRIG_    ?? */
   unsigned long long DEADTIMEA;             /* DEADT_A          */
@@ -70,16 +67,15 @@ struct TriggerScalersRaw_v1
   unsigned long long THROTTLE_DEADTIMEA;    /* DEADT_THROTTLE_A */
   unsigned long long CALIBRATION_DEADTIMEA; /* DEADT_CALIBR_A   */
   unsigned long long TIMESLOT_DEADTIMEA;    /*                  */
-  unsigned int       NR_OF_RESETS;          /* NR_RESETS_       */
+  unsigned int NR_OF_RESETS;                /* NR_RESETS_       */
 
-  unsigned int       collectionTimeDetails_sec;
-  unsigned int       collectionTimeDetails_nsec;
-  unsigned int       ALGO_RATE[ScalersRaw::N_L1_TRIGGERS_v1];
-  unsigned int       TEST_RATE[ScalersRaw::N_L1_TEST_TRIGGERS_v1];
+  unsigned int collectionTimeDetails_sec;
+  unsigned int collectionTimeDetails_nsec;
+  unsigned int ALGO_RATE[ScalersRaw::N_L1_TRIGGERS_v1];
+  unsigned int TEST_RATE[ScalersRaw::N_L1_TEST_TRIGGERS_v1];
 };
 
-struct TriggerScalersRaw_v3
-{
+struct TriggerScalersRaw_v3 {
   unsigned int collectionTime_sec;
   unsigned int collectionTime_nsec;
   unsigned int lumiSegmentNr;
@@ -117,8 +113,7 @@ struct TriggerScalersRaw_v3
   unsigned int gtTechCounts[ScalersRaw::N_L1_TEST_TRIGGERS_v1];
 };
 
-struct LumiScalersRaw_v1
-{
+struct LumiScalersRaw_v1 {
   unsigned int collectionTime_sec;
   unsigned int collectionTime_nsec;
   float DeadtimeNormalization;
@@ -154,8 +149,7 @@ struct LumiScalersRaw_v1
   unsigned int numOrbits;
 };
 
-struct BeamSpotOnlineRaw_v4
-{
+struct BeamSpotOnlineRaw_v4 {
   unsigned int collectionTime_sec;
   unsigned int collectionTime_nsec;
   float x;
@@ -176,8 +170,7 @@ struct BeamSpotOnlineRaw_v4
   float err_sigma_z;
 };
 
-struct DcsStatusRaw_v4
-{
+struct DcsStatusRaw_v4 {
   unsigned int collectionTime_sec;
   unsigned int collectionTime_nsec;
   unsigned int ready;
@@ -185,87 +178,80 @@ struct DcsStatusRaw_v4
   float magnetTemperature;
 };
 
-struct ScalersEventRecordRaw_v1
-{
+struct ScalersEventRecordRaw_v1 {
   unsigned long long header;
   int version;
   struct TriggerScalersRaw_v1 trig;
-  struct LumiScalersRaw_v1    lumi;
+  struct LumiScalersRaw_v1 lumi;
   unsigned int filler;
   unsigned long long trailer;
 };
 
-struct ScalersEventRecordRaw_v2
-{
+struct ScalersEventRecordRaw_v2 {
   unsigned long long header;
   int version;
   struct TriggerScalersRaw_v1 trig;
-  struct LumiScalersRaw_v1    lumi;
+  struct LumiScalersRaw_v1 lumi;
   unsigned int filler;
   unsigned long long bx[ScalersRaw::N_BX_v2];
   unsigned long long trailer;
 };
 
-struct ScalersEventRecordRaw_v3
-{
+struct ScalersEventRecordRaw_v3 {
   unsigned long long header;
   int version;
   struct TriggerScalersRaw_v3 trig;
-  struct LumiScalersRaw_v1    lumi;
+  struct LumiScalersRaw_v1 lumi;
   unsigned int filler;
   unsigned long long bx[ScalersRaw::N_BX_v2];
   unsigned long long trailer;
 };
 
-struct ScalersEventRecordRaw_v4
-{
+struct ScalersEventRecordRaw_v4 {
   unsigned long long header;
   int version;
   struct TriggerScalersRaw_v3 trig;
-  struct LumiScalersRaw_v1    lumi;
+  struct LumiScalersRaw_v1 lumi;
   struct BeamSpotOnlineRaw_v4 beamSpotOnline;
-  struct DcsStatusRaw_v4      dcsStatus;
+  struct DcsStatusRaw_v4 dcsStatus;
   unsigned long long bx[ScalersRaw::N_BX_v2];
   unsigned long long trailer;
 };
 
-
-struct ScalersEventRecordRaw_v5
-{
-  unsigned long long          header;
-  int                         version;
+struct ScalersEventRecordRaw_v5 {
+  unsigned long long header;
+  int version;
   struct TriggerScalersRaw_v3 trig;
-  struct LumiScalersRaw_v1    lumi;
+  struct LumiScalersRaw_v1 lumi;
   struct BeamSpotOnlineRaw_v4 beamSpotOnline;
-  struct DcsStatusRaw_v4      dcsStatus;
-  unsigned int                lastOrbitCounter0;
-  unsigned int                lastTestEnable;
-  unsigned int                lastResync;
-  unsigned int                lastStart;
-  unsigned int                lastEventCounter0;
-  unsigned int                lastHardReset;
-  unsigned long long          spare[ScalersRaw::N_SPARE_v5];
-  unsigned long long          bx[ScalersRaw::N_BX_v2];
-  unsigned long long          trailer;
+  struct DcsStatusRaw_v4 dcsStatus;
+  unsigned int lastOrbitCounter0;
+  unsigned int lastTestEnable;
+  unsigned int lastResync;
+  unsigned int lastStart;
+  unsigned int lastEventCounter0;
+  unsigned int lastHardReset;
+  unsigned long long spare[ScalersRaw::N_SPARE_v5];
+  unsigned long long bx[ScalersRaw::N_BX_v2];
+  unsigned long long trailer;
 };
 
-struct ScalersEventRecordRaw_v6
-{
-  unsigned long long          header;
-  int                         version;
+struct ScalersEventRecordRaw_v6 {
+  unsigned long long header;
+  int version;
   struct TriggerScalersRaw_v3 trig;
-  struct LumiScalersRaw_v1    lumi;
+  struct LumiScalersRaw_v1 lumi;
   struct BeamSpotOnlineRaw_v4 beamSpotOnline;
-  struct DcsStatusRaw_v4      dcsStatus;
-  unsigned int                lastOrbitCounter0;
-  unsigned int                lastTestEnable;
-  unsigned int                lastResync;
-  unsigned int                lastStart;
-  unsigned int                lastEventCounter0;
-  unsigned int                lastHardReset;
-  unsigned long long          spare[ScalersRaw::N_SPARE_v5];
-  unsigned long long          bx[ScalersRaw::N_BX_v6];
-  unsigned long long          trailer;
+  struct DcsStatusRaw_v4 dcsStatus;
+  unsigned int lastOrbitCounter0;
+  unsigned int lastTestEnable;
+  unsigned int lastResync;
+  unsigned int lastStart;
+  unsigned int lastEventCounter0;
+  unsigned int lastHardReset;
+  unsigned long long spare[ScalersRaw::N_SPARE_v5];
+  unsigned long long bx[ScalersRaw::N_BX_v6];
+  unsigned long long trailer;
 };
 
 #pragma pack(pop)

--- a/DataFormats/Scalers/interface/TimeSpec.h
+++ b/DataFormats/Scalers/interface/TimeSpec.h
@@ -5,31 +5,22 @@
 #include <ctime>
 
 class TimeSpec {
-
 public:
+  TimeSpec() : tv_sec_(0), tv_nsec_(0) {}
 
-  TimeSpec() :
-    tv_sec_(0),
-    tv_nsec_(0) {}
+  TimeSpec(long tv_sec, long tv_nsec) : tv_sec_(tv_sec), tv_nsec_(tv_nsec) {}
 
-  TimeSpec(long tv_sec, long tv_nsec) :
-    tv_sec_(tv_sec),
-    tv_nsec_(tv_nsec) {}
+  TimeSpec(timespec const& ts) : tv_sec_(static_cast<long>(ts.tv_sec)), tv_nsec_(static_cast<long>(ts.tv_nsec)) {}
 
-  TimeSpec(timespec const& ts) :
-    tv_sec_(static_cast<long>(ts.tv_sec)),
-    tv_nsec_(static_cast<long>(ts.tv_nsec)) {}
-
-  long tv_sec() const { return tv_sec_; } 
+  long tv_sec() const { return tv_sec_; }
   long tv_nsec() const { return tv_nsec_; }
 
-  void set_tv_sec(long value) { tv_sec_ = value; } 
+  void set_tv_sec(long value) { tv_sec_ = value; }
   void set_tv_nsec(long value) { tv_nsec_ = value; }
 
   timespec get_timespec() const;
 
 private:
-
   long tv_sec_;   // seconds
   long tv_nsec_;  // nanoseconds
 };

--- a/DataFormats/Scalers/src/BeamSpotOnline.cc
+++ b/DataFormats/Scalers/src/BeamSpotOnline.cc
@@ -7,112 +7,101 @@
 #include <cstdio>
 #include <ostream>
 
-BeamSpotOnline::BeamSpotOnline() : 
-   trigType_(0),
-   eventID_(0),
-   sourceID_(0),
-   bunchNumber_(0),
-   version_(0),
-   collectionTime_(0,0),
-   x_((float)0.0),
-   y_((float)0.0),
-   z_((float)0.0),
-   dxdz_((float)0.0),
-   dydz_((float)0.0),
-   err_x_((float)0.0),
-   err_y_((float)0.0),
-   err_z_((float)0.0),
-   err_dxdz_((float)0.0),
-   err_dydz_((float)0.0),
-   width_x_((float)0.0),
-   width_y_((float)0.0),
-   sigma_z_((float)0.0),
-   err_width_x_((float)0.0),
-   err_width_y_((float)0.0),
-   err_sigma_z_((float)0.0)
-{ 
-}
+BeamSpotOnline::BeamSpotOnline()
+    : trigType_(0),
+      eventID_(0),
+      sourceID_(0),
+      bunchNumber_(0),
+      version_(0),
+      collectionTime_(0, 0),
+      x_((float)0.0),
+      y_((float)0.0),
+      z_((float)0.0),
+      dxdz_((float)0.0),
+      dydz_((float)0.0),
+      err_x_((float)0.0),
+      err_y_((float)0.0),
+      err_z_((float)0.0),
+      err_dxdz_((float)0.0),
+      err_dydz_((float)0.0),
+      width_x_((float)0.0),
+      width_y_((float)0.0),
+      sigma_z_((float)0.0),
+      err_width_x_((float)0.0),
+      err_width_y_((float)0.0),
+      err_sigma_z_((float)0.0) {}
 
-BeamSpotOnline::BeamSpotOnline(const unsigned char * rawData)
-{ 
+BeamSpotOnline::BeamSpotOnline(const unsigned char* rawData) {
   BeamSpotOnline();
 
-  struct ScalersEventRecordRaw_v4 const* raw 
-    = reinterpret_cast<struct ScalersEventRecordRaw_v4 const*>(rawData);
-  trigType_     = ( raw->header >> 56 ) &        0xFULL;
-  eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
-  sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;
-  bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
+  struct ScalersEventRecordRaw_v4 const* raw = reinterpret_cast<struct ScalersEventRecordRaw_v4 const*>(rawData);
+  trigType_ = (raw->header >> 56) & 0xFULL;
+  eventID_ = (raw->header >> 32) & 0x00FFFFFFULL;
+  sourceID_ = (raw->header >> 8) & 0x00000FFFULL;
+  bunchNumber_ = (raw->header >> 20) & 0xFFFULL;
 
   version_ = raw->version;
-  if ( version_ >= 4 )
-  {
+  if (version_ >= 4) {
     collectionTime_.set_tv_sec(static_cast<long>(raw->beamSpotOnline.collectionTime_sec));
     collectionTime_.set_tv_nsec(raw->beamSpotOnline.collectionTime_nsec);
-    x_           = raw->beamSpotOnline.x;
-    y_           = raw->beamSpotOnline.y;
-    z_           = raw->beamSpotOnline.z;
-    dxdz_        = raw->beamSpotOnline.dxdz;
-    dydz_        = raw->beamSpotOnline.dydz;
-    err_x_       = raw->beamSpotOnline.err_x;
-    err_y_       = raw->beamSpotOnline.err_y;
-    err_z_       = raw->beamSpotOnline.err_z;
-    err_dxdz_    = raw->beamSpotOnline.err_dxdz;
-    err_dydz_    = raw->beamSpotOnline.err_dydz;
-    width_x_     = raw->beamSpotOnline.width_x;
-    width_y_     = raw->beamSpotOnline.width_y;
-    sigma_z_     = raw->beamSpotOnline.sigma_z;
+    x_ = raw->beamSpotOnline.x;
+    y_ = raw->beamSpotOnline.y;
+    z_ = raw->beamSpotOnline.z;
+    dxdz_ = raw->beamSpotOnline.dxdz;
+    dydz_ = raw->beamSpotOnline.dydz;
+    err_x_ = raw->beamSpotOnline.err_x;
+    err_y_ = raw->beamSpotOnline.err_y;
+    err_z_ = raw->beamSpotOnline.err_z;
+    err_dxdz_ = raw->beamSpotOnline.err_dxdz;
+    err_dydz_ = raw->beamSpotOnline.err_dydz;
+    width_x_ = raw->beamSpotOnline.width_x;
+    width_y_ = raw->beamSpotOnline.width_y;
+    sigma_z_ = raw->beamSpotOnline.sigma_z;
     err_width_x_ = raw->beamSpotOnline.err_width_x;
     err_width_y_ = raw->beamSpotOnline.err_width_y;
     err_sigma_z_ = raw->beamSpotOnline.err_sigma_z;
   }
 }
 
-BeamSpotOnline::~BeamSpotOnline() { } 
-
+BeamSpotOnline::~BeamSpotOnline() {}
 
 /// Pretty-print operator for BeamSpotOnline
-std::ostream& operator<<(std::ostream& s, const BeamSpotOnline& c) 
-{
+std::ostream& operator<<(std::ostream& s, const BeamSpotOnline& c) {
   char zeit[128];
   constexpr size_t kLineBufferSize = 157;
   char line[kLineBufferSize];
-  struct tm * hora;
+  struct tm* hora;
 
-  s << "BeamSpotOnline    Version: " << c.version() << 
-    "   SourceID: "<< c.sourceID() << std::endl;
+  s << "BeamSpotOnline    Version: " << c.version() << "   SourceID: " << c.sourceID() << std::endl;
 
   timespec ts = c.collectionTime();
   hora = gmtime(&ts.tv_sec);
   strftime(zeit, sizeof(zeit), "%Y.%m.%d %H:%M:%S", hora);
-  snprintf(line, kLineBufferSize,
-           " CollectionTime: %s.%9.9d", zeit, 
-           (int)ts.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, (int)ts.tv_nsec);
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " TrigType: %d   EventID: %d    BunchNumber: %d", 
-           c.trigType(), c.eventID(), c.bunchNumber());
+  snprintf(line,
+           kLineBufferSize,
+           " TrigType: %d   EventID: %d    BunchNumber: %d",
+           c.trigType(),
+           c.eventID(),
+           c.bunchNumber());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           "    x: %e +/- %e   width: %e +/- %e",
-           c.x(), c.err_x(), c.width_x(), c.err_width_x());
+  snprintf(
+      line, kLineBufferSize, "    x: %e +/- %e   width: %e +/- %e", c.x(), c.err_x(), c.width_x(), c.err_width_x());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           "    y: %e +/- %e   width: %e +/- %e",
-           c.y(), c.err_y(), c.width_y(), c.err_width_y());
+  snprintf(
+      line, kLineBufferSize, "    y: %e +/- %e   width: %e +/- %e", c.y(), c.err_y(), c.width_y(), c.err_width_y());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           "    z: %e +/- %e   sigma: %e +/- %e",
-           c.z(), c.err_z(), c.sigma_z(), c.err_sigma_z());
+  snprintf(
+      line, kLineBufferSize, "    z: %e +/- %e   sigma: %e +/- %e", c.z(), c.err_z(), c.sigma_z(), c.err_sigma_z());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " dxdy: %e +/- %e    dydz: %e +/- %e",
-           c.dxdz(), c.err_dxdz(), c.dydz(), c.err_dydz());
+  snprintf(
+      line, kLineBufferSize, " dxdy: %e +/- %e    dydz: %e +/- %e", c.dxdz(), c.err_dxdz(), c.dydz(), c.err_dydz());
   s << line << std::endl;
   return s;
 }

--- a/DataFormats/Scalers/src/DcsStatus.cc
+++ b/DataFormats/Scalers/src/DcsStatus.cc
@@ -7,139 +7,84 @@
 #include <cstdio>
 #include <ostream>
 
-const int DcsStatus::partitionList[DcsStatus::nPartitions] = {
-  EBp         ,
-  EBm         ,
-  EEp         ,
-  EEm         ,
-  HBHEa       ,
-  HBHEb       ,
-  HBHEc       ,
-  HF          ,
-  HO          ,
-  RPC         ,
-  DT0         ,
-  DTp         ,
-  DTm         ,
-  CSCp        ,
-  CSCm        ,
-  CASTOR      ,
-  ZDC         ,
-  TIBTID      ,
-  TOB         ,
-  TECp        ,
-  TECm        ,
-  BPIX        ,
-  FPIX        ,
-  ESp         ,
-  ESm };
+const int DcsStatus::partitionList[DcsStatus::nPartitions] = {EBp, EBm,  EEp,  EEm,  HBHEa, HBHEb, HBHEc,  HF,  HO,
+                                                              RPC, DT0,  DTp,  DTm,  CSCp,  CSCm,  CASTOR, ZDC, TIBTID,
+                                                              TOB, TECp, TECm, BPIX, FPIX,  ESp,   ESm};
 
-const char * const DcsStatus::partitionName[DcsStatus::nPartitions] = {
-  "EBp"         ,
-  "EBm"         ,
-  "EEp"         ,
-  "EEm"         ,
-  "HBHEa"       ,
-  "HBHEb"       ,
-  "HBHEc"       ,
-  "HF"          ,
-  "HO"          ,
-  "RPC"         ,
-  "DT0"         ,
-  "DTp"         ,
-  "DTm"         ,
-  "CSCp"        ,
-  "CSCm"        ,
-  "CASTOR"      ,
-  "ZDC"         ,
-  "TIBTID"      ,
-  "TOB"         ,
-  "TECp"        ,
-  "TECm"        ,
-  "BPIX"        ,
-  "FPIX"        ,
-  "ESp"         ,
-  "ESm" };
+const char* const DcsStatus::partitionName[DcsStatus::nPartitions] = {
+    "EBp",  "EBm",  "EEp",    "EEm", "HBHEa",  "HBHEb", "HBHEc", "HF",   "HO",   "RPC",  "DT0", "DTp", "DTm",
+    "CSCp", "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm", "BPIX", "FPIX", "ESp", "ESm"};
 
-DcsStatus::DcsStatus() : 
-   trigType_(0),
-   eventID_(0),
-   sourceID_(0),
-   bunchNumber_(0),
-   version_(0),
-   collectionTime_(0,0),
-   ready_(0),
-   magnetCurrent_((float)0.0),
-   magnetTemperature_((float)0.0)
-{ 
-}
+DcsStatus::DcsStatus()
+    : trigType_(0),
+      eventID_(0),
+      sourceID_(0),
+      bunchNumber_(0),
+      version_(0),
+      collectionTime_(0, 0),
+      ready_(0),
+      magnetCurrent_((float)0.0),
+      magnetTemperature_((float)0.0) {}
 
-DcsStatus::DcsStatus(const unsigned char * rawData)
-{ 
+DcsStatus::DcsStatus(const unsigned char* rawData) {
   DcsStatus();
 
-  struct ScalersEventRecordRaw_v4 const * raw 
-    = reinterpret_cast<struct ScalersEventRecordRaw_v4 const *>(rawData);
-  trigType_     = ( raw->header >> 56 ) &        0xFULL;
-  eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
-  sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;
-  bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
+  struct ScalersEventRecordRaw_v4 const* raw = reinterpret_cast<struct ScalersEventRecordRaw_v4 const*>(rawData);
+  trigType_ = (raw->header >> 56) & 0xFULL;
+  eventID_ = (raw->header >> 32) & 0x00FFFFFFULL;
+  sourceID_ = (raw->header >> 8) & 0x00000FFFULL;
+  bunchNumber_ = (raw->header >> 20) & 0xFFFULL;
 
   version_ = raw->version;
-  if ( version_ >= 4 )
-  {
+  if (version_ >= 4) {
     collectionTime_.set_tv_sec(static_cast<long>(raw->dcsStatus.collectionTime_sec));
     collectionTime_.set_tv_nsec(raw->dcsStatus.collectionTime_nsec);
-    ready_             = raw->dcsStatus.ready;
-    magnetCurrent_     = raw->dcsStatus.magnetCurrent;
+    ready_ = raw->dcsStatus.ready;
+    magnetCurrent_ = raw->dcsStatus.magnetCurrent;
     magnetTemperature_ = raw->dcsStatus.magnetTemperature;
   }
 }
 
-DcsStatus::~DcsStatus() { } 
-
+DcsStatus::~DcsStatus() {}
 
 /// Pretty-print operator for DcsStatus
-std::ostream& operator<<(std::ostream& s, const DcsStatus& c) 
-{
+std::ostream& operator<<(std::ostream& s, const DcsStatus& c) {
   constexpr size_t kZeitBufferSize = 128;
   char zeit[kZeitBufferSize];
   constexpr size_t kLineBufferSize = 157;
   char line[kLineBufferSize];
-  struct tm * hora;
+  struct tm* hora;
 
-  s << "DcsStatus    Version: " << c.version() << 
-    "   SourceID: "<< c.sourceID() << std::endl;
+  s << "DcsStatus    Version: " << c.version() << "   SourceID: " << c.sourceID() << std::endl;
 
   timespec ts = c.collectionTime();
   hora = gmtime(&ts.tv_sec);
   strftime(zeit, kZeitBufferSize, "%Y.%m.%d %H:%M:%S", hora);
-  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, 
-	  (int)ts.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, (int)ts.tv_nsec);
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " TrigType: %d   EventID: %d    BunchNumber: %d", 
-	  c.trigType(), c.eventID(), c.bunchNumber());
+  snprintf(line,
+           kLineBufferSize,
+           " TrigType: %d   EventID: %d    BunchNumber: %d",
+           c.trigType(),
+           c.eventID(),
+           c.bunchNumber());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " MagnetCurrent: %e    MagnetTemperature: %e", 
-	  c.magnetCurrent(), c.magnetTemperature());
+  snprintf(
+      line, kLineBufferSize, " MagnetCurrent: %e    MagnetTemperature: %e", c.magnetCurrent(), c.magnetTemperature());
   s << line << std::endl;
 
-  snprintf(line,kLineBufferSize," Ready: %d  0x%8.8X", c.ready(), c.ready());
+  snprintf(line, kLineBufferSize, " Ready: %d  0x%8.8X", c.ready(), c.ready());
   s << line << std::endl;
 
-  for ( int i=0; i<DcsStatus::nPartitions; i++)
-  {
-    if ( c.ready(DcsStatus::partitionList[i]))
-    {
-      snprintf(line,kLineBufferSize,"  %2d %6s: READY", i, DcsStatus::partitionName[i]);
+  for (int i = 0; i < DcsStatus::nPartitions; i++) {
+    if (c.ready(DcsStatus::partitionList[i])) {
+      snprintf(line, kLineBufferSize, "  %2d %6s: READY", i, DcsStatus::partitionName[i]);
+    } else {
+      snprintf(line, kLineBufferSize, "  %2d %6s: NOT READY", i, DcsStatus::partitionName[i]);
     }
-    else
-    {
-      snprintf(line,kLineBufferSize,"  %2d %6s: NOT READY", i, DcsStatus::partitionName[i]);
-    }
-  s << line << std::endl;
+    s << line << std::endl;
   }
   return s;
 }

--- a/DataFormats/Scalers/src/L1AcceptBunchCrossing.cc
+++ b/DataFormats/Scalers/src/L1AcceptBunchCrossing.cc
@@ -6,52 +6,39 @@
 #include "DataFormats/Scalers/interface/ScalersRaw.h"
 #include <cstdio>
 
-L1AcceptBunchCrossing::L1AcceptBunchCrossing() : 
-  l1AcceptOffset_(0),
-  orbitNumber_(0),
-  bunchCrossing_(0),
-  eventType_(0)
-{ 
-}
+L1AcceptBunchCrossing::L1AcceptBunchCrossing()
+    : l1AcceptOffset_(0), orbitNumber_(0), bunchCrossing_(0), eventType_(0) {}
 
 L1AcceptBunchCrossing::L1AcceptBunchCrossing(const int l1AcceptOffset__,
-					     const unsigned int orbitNumber__,
-					     const unsigned int bunchCrossing__,
-					     const unsigned int eventType__) : 
-  l1AcceptOffset_(l1AcceptOffset__),
-  orbitNumber_(orbitNumber__),
-  bunchCrossing_(bunchCrossing__),
-  eventType_(eventType__)
-{ 
+                                             const unsigned int orbitNumber__,
+                                             const unsigned int bunchCrossing__,
+                                             const unsigned int eventType__)
+    : l1AcceptOffset_(l1AcceptOffset__),
+      orbitNumber_(orbitNumber__),
+      bunchCrossing_(bunchCrossing__),
+      eventType_(eventType__) {}
+
+L1AcceptBunchCrossing::L1AcceptBunchCrossing(const int index, const unsigned long long data) {
+  l1AcceptOffset_ = -index;
+  orbitNumber_ = (unsigned int)((data >> ORBIT_NUMBER_SHIFT) & ORBIT_NUMBER_MASK);
+  bunchCrossing_ = (unsigned int)((data >> BUNCH_CROSSING_SHIFT) & BUNCH_CROSSING_MASK);
+  eventType_ = (unsigned int)((data >> EVENT_TYPE_SHIFT) & EVENT_TYPE_MASK);
 }
 
-L1AcceptBunchCrossing::L1AcceptBunchCrossing(const int index, 
-					     const unsigned long long data)
-{ 
-  l1AcceptOffset_ =  - index;
-  orbitNumber_    = (unsigned int) (( data >> ORBIT_NUMBER_SHIFT ) 
-				    & ORBIT_NUMBER_MASK);
-  bunchCrossing_  = (unsigned int) (( data >> BUNCH_CROSSING_SHIFT ) 
-				    & BUNCH_CROSSING_MASK );
-  eventType_      = (unsigned int) (( data >> EVENT_TYPE_SHIFT )
-				    & EVENT_TYPE_MASK);
-}
-
-L1AcceptBunchCrossing::~L1AcceptBunchCrossing() { } 
+L1AcceptBunchCrossing::~L1AcceptBunchCrossing() {}
 
 /// Pretty-print operator for L1AcceptBunchCrossing
-std::ostream& operator<<(std::ostream& s, const L1AcceptBunchCrossing& c) 
-{
+std::ostream& operator<<(std::ostream& s, const L1AcceptBunchCrossing& c) {
   char line[128];
 
-  sprintf(line, 
-  "L1AcceptBC Offset:%2d  Orbit:%10d [0x%8.8X]  BC:%4d [0x%3.3X]  EvtTyp:%d", 
-	  c.l1AcceptOffset(),
-	  c.orbitNumber(), 
-	  c.orbitNumber(), 
-	  c.bunchCrossing(), 
-	  c.bunchCrossing(), 
-	  c.eventType());
+  sprintf(line,
+          "L1AcceptBC Offset:%2d  Orbit:%10d [0x%8.8X]  BC:%4d [0x%3.3X]  EvtTyp:%d",
+          c.l1AcceptOffset(),
+          c.orbitNumber(),
+          c.orbitNumber(),
+          c.bunchCrossing(),
+          c.bunchCrossing(),
+          c.eventType());
   s << line << std::endl;
 
   return s;

--- a/DataFormats/Scalers/src/L1TriggerRates.cc
+++ b/DataFormats/Scalers/src/L1TriggerRates.cc
@@ -8,167 +8,140 @@
 #include <iostream>
 #include <cstdio>
 
-L1TriggerRates::L1TriggerRates():
-  version_(0),
-  collectionTimeSummary_(0,0),
-  deltaT_(0),
-  deltaTActive_(0),
-  triggerNumberRate_(0.0),
-  eventNumberRate_(0.0),
-  finalTriggersDistributedRate_(0.0),
-  finalTriggersGeneratedRate_(0.0),
-  randomTriggersRate_(0.0),
-  calibrationTriggersRate_(0.0),
-  totalTestTriggersRate_(0.0),
-  orbitNumberRate_(0.0),
-  numberResetsRate_(0.0),
-  deadTimePercent_(0.0),
-  deadTimeActivePercent_(0.0),
-  deadTimeActiveCalibrationPercent_(0.0),
-  deadTimeActivePrivatePercent_(0.0),
-  deadTimeActivePartitionPercent_(0.0),
-  deadTimeActiveThrottlePercent_(0.0),
-  deadTimeActiveTimeSlotPercent_(0.0),
-  finalTriggersInvalidBCPercent_(0.0),
-  lostFinalTriggersPercent_(0.0),
-  lostFinalTriggersActivePercent_(0.0),
-  triggersRate_(L1TriggerScalers::nL1Triggers),
-  testTriggersRate_(L1TriggerScalers::nL1TestTriggers),
-  triggerNumberRunRate_(0.0),
-  eventNumberRunRate_(0.0),
-  finalTriggersDistributedRunRate_(0.0),
-  finalTriggersGeneratedRunRate_(0.0),
-  randomTriggersRunRate_(0.0),
-  calibrationTriggersRunRate_(0.0),
-  totalTestTriggersRunRate_(0.0),
-  orbitNumberRunRate_(0.0),
-  numberResetsRunRate_(0.0),
-  deadTimeRunPercent_(0.0),
-  deadTimeActiveRunPercent_(0.0),
-  deadTimeActiveCalibrationRunPercent_(0.0),
-  deadTimeActivePrivateRunPercent_(0.0),
-  deadTimeActivePartitionRunPercent_(0.0),
-  deadTimeActiveThrottleRunPercent_(0.0),
-  deadTimeActiveTimeSlotRunPercent_(0.0),
-  finalTriggersInvalidBCRunPercent_(0.0),
-  lostFinalTriggersRunPercent_(0.0),
-  lostFinalTriggersActiveRunPercent_(0.0),
-  collectionTimeDetails_(0,0),
-  triggersRunRate_(L1TriggerScalers::nL1Triggers),
-  testTriggersRunRate_(L1TriggerScalers::nL1TestTriggers)
-{ 
-}
+L1TriggerRates::L1TriggerRates()
+    : version_(0),
+      collectionTimeSummary_(0, 0),
+      deltaT_(0),
+      deltaTActive_(0),
+      triggerNumberRate_(0.0),
+      eventNumberRate_(0.0),
+      finalTriggersDistributedRate_(0.0),
+      finalTriggersGeneratedRate_(0.0),
+      randomTriggersRate_(0.0),
+      calibrationTriggersRate_(0.0),
+      totalTestTriggersRate_(0.0),
+      orbitNumberRate_(0.0),
+      numberResetsRate_(0.0),
+      deadTimePercent_(0.0),
+      deadTimeActivePercent_(0.0),
+      deadTimeActiveCalibrationPercent_(0.0),
+      deadTimeActivePrivatePercent_(0.0),
+      deadTimeActivePartitionPercent_(0.0),
+      deadTimeActiveThrottlePercent_(0.0),
+      deadTimeActiveTimeSlotPercent_(0.0),
+      finalTriggersInvalidBCPercent_(0.0),
+      lostFinalTriggersPercent_(0.0),
+      lostFinalTriggersActivePercent_(0.0),
+      triggersRate_(L1TriggerScalers::nL1Triggers),
+      testTriggersRate_(L1TriggerScalers::nL1TestTriggers),
+      triggerNumberRunRate_(0.0),
+      eventNumberRunRate_(0.0),
+      finalTriggersDistributedRunRate_(0.0),
+      finalTriggersGeneratedRunRate_(0.0),
+      randomTriggersRunRate_(0.0),
+      calibrationTriggersRunRate_(0.0),
+      totalTestTriggersRunRate_(0.0),
+      orbitNumberRunRate_(0.0),
+      numberResetsRunRate_(0.0),
+      deadTimeRunPercent_(0.0),
+      deadTimeActiveRunPercent_(0.0),
+      deadTimeActiveCalibrationRunPercent_(0.0),
+      deadTimeActivePrivateRunPercent_(0.0),
+      deadTimeActivePartitionRunPercent_(0.0),
+      deadTimeActiveThrottleRunPercent_(0.0),
+      deadTimeActiveTimeSlotRunPercent_(0.0),
+      finalTriggersInvalidBCRunPercent_(0.0),
+      lostFinalTriggersRunPercent_(0.0),
+      lostFinalTriggersActiveRunPercent_(0.0),
+      collectionTimeDetails_(0, 0),
+      triggersRunRate_(L1TriggerScalers::nL1Triggers),
+      testTriggersRunRate_(L1TriggerScalers::nL1TestTriggers) {}
 
-L1TriggerRates::L1TriggerRates(L1TriggerScalers const& s)
-{ 
+L1TriggerRates::L1TriggerRates(L1TriggerScalers const& s) {
   L1TriggerRates();
   computeRunRates(s);
 }
 
-L1TriggerRates::L1TriggerRates(L1TriggerScalers const& s1,
-			       L1TriggerScalers const& s2)
-{  
+L1TriggerRates::L1TriggerRates(L1TriggerScalers const& s1, L1TriggerScalers const& s2) {
   L1TriggerRates();
 
-  const L1TriggerScalers *t1 = &s1;
-  const L1TriggerScalers *t2 = &s2;
+  const L1TriggerScalers* t1 = &s1;
+  const L1TriggerScalers* t2 = &s2;
 
   // Choose the later sample to be t2
-  if ( t1->orbitNumber() > t2->orbitNumber())
-  {
+  if (t1->orbitNumber() > t2->orbitNumber()) {
     t1 = &s2;
     t2 = &s1;
   }
 
   computeRunRates(*t2);
-  computeRates(*t1,*t2);
+  computeRates(*t1, *t2);
 }
 
-L1TriggerRates::~L1TriggerRates() { } 
+L1TriggerRates::~L1TriggerRates() {}
 
-
-void L1TriggerRates::computeRates(L1TriggerScalers const& t1,
-				  L1TriggerScalers const& t2)
-{
+void L1TriggerRates::computeRates(L1TriggerScalers const& t1, L1TriggerScalers const& t2) {
   double deltaOrbit = (double)t2.orbitNumber() - (double)t1.orbitNumber();
-  if ( deltaOrbit > 0 )
-  {
+  if (deltaOrbit > 0) {
     // Convert orbits into crossings and time in seconds
-    double deltaBC       = deltaOrbit * N_BX;
+    double deltaBC = deltaOrbit * N_BX;
     double deltaBCActive = deltaOrbit * N_BX_ACTIVE;
-    deltaT_              = deltaBC * BX_SPACING;
-    deltaTActive_        = deltaBCActive * BX_SPACING;
+    deltaT_ = deltaBC * BX_SPACING;
+    deltaTActive_ = deltaBCActive * BX_SPACING;
 
-    triggerNumberRate_ = ((double)t2.triggerNumber() 
-			  - (double)t1.triggerNumber()) / deltaT_;
-    eventNumberRate_ = ((double)t2.eventNumber() 
-			- (double)t1.eventNumber()) / deltaT_;
-    finalTriggersDistributedRate_ = ((double)t2.finalTriggersDistributed() 
-	      	     - (double)t1.finalTriggersDistributed()) / deltaT_;
-    finalTriggersGeneratedRate_ = ((double)t2.finalTriggersGenerated() 
-	- (double)t1.finalTriggersGenerated()) / deltaT_;
-    randomTriggersRate_ = ((double)t2.randomTriggers() 
-			    - (double)t1.randomTriggers()) / deltaT_;
-    calibrationTriggersRate_ = ((double)t2.calibrationTriggers() 
-				 - (double)t1.calibrationTriggers()) / deltaT_;
-    totalTestTriggersRate_ = ((double)t2.totalTestTriggers() 
-		     - (double)t1.totalTestTriggers()) / deltaT_;
-    orbitNumberRate_ = ((double)t2.orbitNumber() 
-			- (double)t1.orbitNumber()) / deltaT_;
-    numberResetsRate_ = ((double)t2.numberResets() 
-			 - (double)t1.numberResets()) / deltaT_;
-    
-    deadTimePercent_ = 100.0 * ((double)t2.deadTime() 
-				- (double)t1.deadTime()) / deltaBC;
-    deadTimeActivePercent_ = 100.0 * ((double)t2.deadTimeActive() 
-			   - (double)t1.deadTimeActive()) / deltaBCActive;
-    deadTimeActiveCalibrationPercent_ = 100.0 * ((double)t2.deadTimeActiveCalibration() 
-				      - (double)t1.deadTimeActiveCalibration()) / deltaBCActive;
-    deadTimeActivePrivatePercent_ = 100.0 * ((double)t2.deadTimeActivePrivate() 
-				  - (double)t1.deadTimeActivePrivate()) / deltaBCActive;
-    deadTimeActivePartitionPercent_ = 100.0 * ((double)t2.deadTimeActivePartition() 
-				    - (double)t1.deadTimeActivePartition()) / deltaBCActive;
-    deadTimeActiveThrottlePercent_ = 100.0 * ((double)t2.deadTimeActiveThrottle() 
-				   - (double)t1.deadTimeActiveThrottle()) / deltaBCActive;
-    deadTimeActiveTimeSlotPercent_ = 100.0 * ((double)t2.deadTimeActiveTimeSlot() 
-			     - (double)t1.deadTimeActiveTimeSlot()) / deltaBCActive;
-    finalTriggersInvalidBCPercent_ = 100.0 * ((double)t2.finalTriggersInvalidBC() 
-			       - (double)t1.finalTriggersInvalidBC()) / deltaBC;
-    lostFinalTriggersPercent_ = 100.0 * ((double)t2.lostFinalTriggers() 
-			 - (double)t1.lostFinalTriggers()) / deltaBC;
-    lostFinalTriggersActivePercent_ = 100.0 * ((double)t2.lostFinalTriggersActive() 
-			       - (double)t1.lostFinalTriggersActive()) / deltaBCActive;
+    triggerNumberRate_ = ((double)t2.triggerNumber() - (double)t1.triggerNumber()) / deltaT_;
+    eventNumberRate_ = ((double)t2.eventNumber() - (double)t1.eventNumber()) / deltaT_;
+    finalTriggersDistributedRate_ =
+        ((double)t2.finalTriggersDistributed() - (double)t1.finalTriggersDistributed()) / deltaT_;
+    finalTriggersGeneratedRate_ = ((double)t2.finalTriggersGenerated() - (double)t1.finalTriggersGenerated()) / deltaT_;
+    randomTriggersRate_ = ((double)t2.randomTriggers() - (double)t1.randomTriggers()) / deltaT_;
+    calibrationTriggersRate_ = ((double)t2.calibrationTriggers() - (double)t1.calibrationTriggers()) / deltaT_;
+    totalTestTriggersRate_ = ((double)t2.totalTestTriggers() - (double)t1.totalTestTriggers()) / deltaT_;
+    orbitNumberRate_ = ((double)t2.orbitNumber() - (double)t1.orbitNumber()) / deltaT_;
+    numberResetsRate_ = ((double)t2.numberResets() - (double)t1.numberResets()) / deltaT_;
+
+    deadTimePercent_ = 100.0 * ((double)t2.deadTime() - (double)t1.deadTime()) / deltaBC;
+    deadTimeActivePercent_ = 100.0 * ((double)t2.deadTimeActive() - (double)t1.deadTimeActive()) / deltaBCActive;
+    deadTimeActiveCalibrationPercent_ =
+        100.0 * ((double)t2.deadTimeActiveCalibration() - (double)t1.deadTimeActiveCalibration()) / deltaBCActive;
+    deadTimeActivePrivatePercent_ =
+        100.0 * ((double)t2.deadTimeActivePrivate() - (double)t1.deadTimeActivePrivate()) / deltaBCActive;
+    deadTimeActivePartitionPercent_ =
+        100.0 * ((double)t2.deadTimeActivePartition() - (double)t1.deadTimeActivePartition()) / deltaBCActive;
+    deadTimeActiveThrottlePercent_ =
+        100.0 * ((double)t2.deadTimeActiveThrottle() - (double)t1.deadTimeActiveThrottle()) / deltaBCActive;
+    deadTimeActiveTimeSlotPercent_ =
+        100.0 * ((double)t2.deadTimeActiveTimeSlot() - (double)t1.deadTimeActiveTimeSlot()) / deltaBCActive;
+    finalTriggersInvalidBCPercent_ =
+        100.0 * ((double)t2.finalTriggersInvalidBC() - (double)t1.finalTriggersInvalidBC()) / deltaBC;
+    lostFinalTriggersPercent_ = 100.0 * ((double)t2.lostFinalTriggers() - (double)t1.lostFinalTriggers()) / deltaBC;
+    lostFinalTriggersActivePercent_ =
+        100.0 * ((double)t2.lostFinalTriggersActive() - (double)t1.lostFinalTriggersActive()) / deltaBCActive;
 
     int length1 = t1.triggers().size();
     int length2 = t2.triggers().size();
     int minLength;
-    ( length1 >= length2 ) ? minLength = length2 : minLength=length1;
+    (length1 >= length2) ? minLength = length2 : minLength = length1;
     std::vector<unsigned int> triggers1 = t1.triggers();
     std::vector<unsigned int> triggers2 = t2.triggers();
-    for ( int i=0; i<minLength; i++)
-    {
-      double rate = ((double)triggers2[i] -
-		     (double)triggers1[i] ) / deltaT_;
+    for (int i = 0; i < minLength; i++) {
+      double rate = ((double)triggers2[i] - (double)triggers1[i]) / deltaT_;
       triggersRate_.push_back(rate);
     }
 
-
     length1 = t1.testTriggers().size();
     length2 = t2.testTriggers().size();
-    ( length1 >= length2 ) ? minLength = length2 : minLength=length1;
+    (length1 >= length2) ? minLength = length2 : minLength = length1;
     std::vector<unsigned int> testTriggers1 = t1.testTriggers();
     std::vector<unsigned int> testTriggers2 = t2.testTriggers();
-    for ( int i=0; i<minLength; i++)
-    {
-      double rate = ((double)testTriggers2[i] -
-		     (double)testTriggers1[i] ) / deltaT_;
+    for (int i = 0; i < minLength; i++) {
+      double rate = ((double)testTriggers2[i] - (double)testTriggers1[i]) / deltaT_;
       testTriggersRate_.push_back(rate);
     }
   }
 }
 
-void L1TriggerRates::computeRunRates(L1TriggerScalers const& t)
-{
+void L1TriggerRates::computeRunRates(L1TriggerScalers const& t) {
   version_ = t.version();
 
   collectionTimeSummary_.set_tv_sec(static_cast<long>(t.collectionTimeSummary().tv_sec));
@@ -178,25 +151,23 @@ void L1TriggerRates::computeRunRates(L1TriggerScalers const& t)
   collectionTimeDetails_.set_tv_nsec(t.collectionTimeDetails().tv_nsec);
 
   double deltaOrbit = (double)t.orbitNumber();
-  if ( deltaOrbit > 0 )
-  {
+  if (deltaOrbit > 0) {
     // Convert orbits into crossings and time in seconds
-    double deltaBC       = deltaOrbit * N_BX;
+    double deltaBC = deltaOrbit * N_BX;
     double deltaBCActive = deltaOrbit * N_BX_ACTIVE;
-    deltaTRun_           = deltaBC * BX_SPACING;
-    deltaTRunActive_     = deltaBCActive * BX_SPACING;
+    deltaTRun_ = deltaBC * BX_SPACING;
+    deltaTRunActive_ = deltaBCActive * BX_SPACING;
 
     triggerNumberRunRate_ = (double)t.triggerNumber() / deltaTRun_;
     eventNumberRunRate_ = (double)t.eventNumber() / deltaTRun_;
-    finalTriggersDistributedRunRate_ = (double)t.finalTriggersDistributed() 
-      / deltaTRun_;
+    finalTriggersDistributedRunRate_ = (double)t.finalTriggersDistributed() / deltaTRun_;
     finalTriggersGeneratedRunRate_ = (double)t.finalTriggersGenerated() / deltaTRun_;
     randomTriggersRunRate_ = (double)t.randomTriggers() / deltaTRun_;
     calibrationTriggersRunRate_ = (double)t.calibrationTriggers() / deltaTRun_;
     totalTestTriggersRunRate_ = (double)t.totalTestTriggers() / deltaTRun_;
     orbitNumberRunRate_ = (double)t.orbitNumber() / deltaTRun_;
     numberResetsRunRate_ = (double)t.numberResets() / deltaTRun_;
-    
+
     deadTimeRunPercent_ = 100.0 * (double)t.deadTime() / deltaBC;
     deadTimeActiveRunPercent_ = 100.0 * (double)t.deadTimeActive() / deltaBCActive;
     deadTimeActiveCalibrationRunPercent_ = 100.0 * (double)t.deadTimeActiveCalibration() / deltaBCActive;
@@ -209,172 +180,176 @@ void L1TriggerRates::computeRunRates(L1TriggerScalers const& t)
     lostFinalTriggersActiveRunPercent_ = 100.0 * (double)t.lostFinalTriggersActive() / deltaBCActive;
 
     int length = t.triggers().size();
-    for ( int i=0; i<length; i++)
-    {
+    for (int i = 0; i < length; i++) {
       double rate = ((double)t.triggers()[i]) / deltaTRun_;
       triggersRunRate_.push_back(rate);
     }
   }
 }
 
-
 /// Pretty-print operator for L1TriggerRates
-std::ostream& operator<<(std::ostream& s, const L1TriggerRates& c) 
-{
-  s << "L1TriggerRates Version: " << c.version() 
-    << " Differential Rates in Hz, DeltaT: " <<
-    c.deltaT() << " sec" << std::endl;
+std::ostream& operator<<(std::ostream& s, const L1TriggerRates& c) {
+  s << "L1TriggerRates Version: " << c.version() << " Differential Rates in Hz, DeltaT: " << c.deltaT() << " sec"
+    << std::endl;
   char line[128];
 
-  sprintf(line,
-	  " TriggerNumber:       %e  EventNumber:             %e",
-	  c.triggerNumberRate(), c.eventNumberRate());
+  sprintf(line, " TriggerNumber:       %e  EventNumber:             %e", c.triggerNumberRate(), c.eventNumberRate());
   s << line << std::endl;
 
   sprintf(line,
-	  " TriggersDistributed: %e  TriggersGenerated:     %e",
-	  c.finalTriggersDistributedRate(), c.finalTriggersGeneratedRate());
+          " TriggersDistributed: %e  TriggersGenerated:     %e",
+          c.finalTriggersDistributedRate(),
+          c.finalTriggersGeneratedRate());
   s << line << std::endl;
 
   sprintf(line,
-	  " RandomTriggers:      %e  CalibrationTriggers:    %e",
-	  c.randomTriggersRate(), c.calibrationTriggersRate());
+          " RandomTriggers:      %e  CalibrationTriggers:    %e",
+          c.randomTriggersRate(),
+          c.calibrationTriggersRate());
+  s << line << std::endl;
+
+  sprintf(
+      line, " TotalTestTriggers:   %e  OrbitNumber:             %e", c.totalTestTriggersRate(), c.orbitNumberRate());
+  s << line << std::endl;
+
+  sprintf(
+      line, " NumberResets:        %e  DeadTime:                %3.3f%%", c.numberResetsRate(), c.deadTimePercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " TotalTestTriggers:   %e  OrbitNumber:             %e",
-	  c.totalTestTriggersRate(), c.orbitNumberRate());
+          " DeadTimeActive:        %3.3f%%    DeadTimeActiveCalibration:  %3.3f%%",
+          c.deadTimeActivePercent(),
+          c.deadTimeActiveCalibrationPercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " NumberResets:        %e  DeadTime:                %3.3f%%",
-	  c.numberResetsRate(), c.deadTimePercent());
+          " LostTriggers:          %3.3f%%    DeadTimeActivePartition:    %3.3f%%",
+          c.lostFinalTriggersPercent(),
+          c.deadTimeActivePartitionPercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " DeadTimeActive:        %3.3f%%    DeadTimeActiveCalibration:  %3.3f%%",
-	  c.deadTimeActivePercent(), 
-	  c.deadTimeActiveCalibrationPercent());
+          " LostTriggersActive:    %3.3f%%    DeadTimeActiveThrottle:     %3.3f%%",
+          c.lostFinalTriggersActivePercent(),
+          c.deadTimeActiveThrottlePercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " LostTriggers:          %3.3f%%    DeadTimeActivePartition:    %3.3f%%",
-	  c.lostFinalTriggersPercent(), 
-	  c.deadTimeActivePartitionPercent());
+          " TriggersInvalidBC:     %3.3f%%    DeadTimeActivePrivate:      %3.3f%%",
+          c.finalTriggersInvalidBCPercent(),
+          c.deadTimeActivePrivatePercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " LostTriggersActive:    %3.3f%%    DeadTimeActiveThrottle:     %3.3f%%",
-	  c.lostFinalTriggersActivePercent(),
-	  c.deadTimeActiveThrottlePercent());
-  s << line << std::endl;
-
-  sprintf(line,
-	  " TriggersInvalidBC:     %3.3f%%    DeadTimeActivePrivate:      %3.3f%%",
-	  c.finalTriggersInvalidBCPercent(), 
-	  c.deadTimeActivePrivatePercent());
-  s << line << std::endl;
-
-  sprintf(line,
-	  "                                   DeadTimeActiveTimeSlot:     %3.3f%%",
-	  c.deadTimeActiveTimeSlotPercent());
+          "                                   DeadTimeActiveTimeSlot:     %3.3f%%",
+          c.deadTimeActiveTimeSlotPercent());
   s << line << std::endl;
 
   std::vector<double> triggersRate = c.triggersRate();
   int length = triggersRate.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    sprintf(line," %3.3d:%e    %3.3d:%e    %3.3d:%e    %3.3d:%e",
-	    i,              triggersRate[i], 
-	    (i+length),     triggersRate[i+length], 
-	    (i+(length*2)), triggersRate[i+(length*2)], 
-	    (i+(length*3)), triggersRate[i+(length*3)]);
+  for (int i = 0; i < length; i++) {
+    sprintf(line,
+            " %3.3d:%e    %3.3d:%e    %3.3d:%e    %3.3d:%e",
+            i,
+            triggersRate[i],
+            (i + length),
+            triggersRate[i + length],
+            (i + (length * 2)),
+            triggersRate[i + (length * 2)],
+            (i + (length * 3)),
+            triggersRate[i + (length * 3)]);
     s << line << std::endl;
   }
 
   std::vector<double> testTriggersRate = c.testTriggersRate();
   length = testTriggersRate.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    sprintf(line," %3.3d:%e    %3.3d:%e    %3.3d:%e    %3.3d:%e",
-	    i,              testTriggersRate[i], 
-	    (i+length),     testTriggersRate[i+length], 
-	    (i+(length*2)), testTriggersRate[i+(length*2)], 
-	    (i+(length*3)), testTriggersRate[i+(length*3)]);
+  for (int i = 0; i < length; i++) {
+    sprintf(line,
+            " %3.3d:%e    %3.3d:%e    %3.3d:%e    %3.3d:%e",
+            i,
+            testTriggersRate[i],
+            (i + length),
+            testTriggersRate[i + length],
+            (i + (length * 2)),
+            testTriggersRate[i + (length * 2)],
+            (i + (length * 3)),
+            testTriggersRate[i + (length * 3)]);
     s << line << std::endl;
   }
 
-
   // Run Average rates
 
-  s << "L1TriggerRates Version: " << c.version() 
-    << " Run Average Rates in Hz, DeltaT: " <<
-    c.deltaTRun() << " sec" << std::endl;
+  s << "L1TriggerRates Version: " << c.version() << " Run Average Rates in Hz, DeltaT: " << c.deltaTRun() << " sec"
+    << std::endl;
 
-  sprintf(line,
-	  " TriggerNumber:     %e  EventNumber:             %e",
-	  c.triggerNumberRunRate(), c.eventNumberRunRate());
+  sprintf(
+      line, " TriggerNumber:     %e  EventNumber:             %e", c.triggerNumberRunRate(), c.eventNumberRunRate());
   s << line << std::endl;
 
   sprintf(line,
-	  " TriggersDistributed:  %e  TriggersGenerated:     %e",
-	  c.finalTriggersDistributedRunRate(), 
-	  c.finalTriggersGeneratedRunRate());
+          " TriggersDistributed:  %e  TriggersGenerated:     %e",
+          c.finalTriggersDistributedRunRate(),
+          c.finalTriggersGeneratedRunRate());
   s << line << std::endl;
 
   sprintf(line,
-	  " RandomTriggers:   %e  CalibrationTriggers:    %e",
-	  c.randomTriggersRunRate(), c.calibrationTriggersRunRate());
+          " RandomTriggers:   %e  CalibrationTriggers:    %e",
+          c.randomTriggersRunRate(),
+          c.calibrationTriggersRunRate());
   s << line << std::endl;
 
   sprintf(line,
-	  " TotalTestTriggers: %e  OrbitNumber:             %e",
-	  c.totalTestTriggersRunRate(), c.orbitNumberRunRate());
+          " TotalTestTriggers: %e  OrbitNumber:             %e",
+          c.totalTestTriggersRunRate(),
+          c.orbitNumberRunRate());
   s << line << std::endl;
 
   sprintf(line,
-	  " NumberResets:      %e  DeadTime:                %3.3f%%",
-	  c.numberResetsRunRate(), c.deadTimeRunPercent());
+          " NumberResets:      %e  DeadTime:                %3.3f%%",
+          c.numberResetsRunRate(),
+          c.deadTimeRunPercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " DeadTimeActive:        %3.3f%%    DeadTimeActiveCalibration:  %3.3f%%",
-	  c.deadTimeActiveRunPercent(), 
-	  c.deadTimeActiveCalibrationRunPercent());
+          " DeadTimeActive:        %3.3f%%    DeadTimeActiveCalibration:  %3.3f%%",
+          c.deadTimeActiveRunPercent(),
+          c.deadTimeActiveCalibrationRunPercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " LostTriggers:          %3.3f%%    DeadTimeActivePartition:    %3.3f%%",
-	  c.lostFinalTriggersRunPercent(), 
-	  c.deadTimeActivePartitionRunPercent());
+          " LostTriggers:          %3.3f%%    DeadTimeActivePartition:    %3.3f%%",
+          c.lostFinalTriggersRunPercent(),
+          c.deadTimeActivePartitionRunPercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " LostTriggersActive:    %3.3f%%    DeadTimeActiveThrottle:     %3.3f%%",
-	  c.lostFinalTriggersActiveRunPercent(),
-	  c.deadTimeActiveThrottleRunPercent());
+          " LostTriggersActive:    %3.3f%%    DeadTimeActiveThrottle:     %3.3f%%",
+          c.lostFinalTriggersActiveRunPercent(),
+          c.deadTimeActiveThrottleRunPercent());
   s << line << std::endl;
 
   sprintf(line,
-	  " FinalTriggersInvalidBC:    %3.3f%%    DeadTimeActivePrivate:      %3.3f%%",
-	  c.finalTriggersInvalidBCRunPercent(), 
-	  c.deadTimeActivePrivateRunPercent());
+          " FinalTriggersInvalidBC:    %3.3f%%    DeadTimeActivePrivate:      %3.3f%%",
+          c.finalTriggersInvalidBCRunPercent(),
+          c.deadTimeActivePrivateRunPercent());
   s << line << std::endl;
 
-  sprintf(line,
-	  " DeadTimeActiveTimeSlot:      %3.3f%%",
-	  c.deadTimeActiveTimeSlotRunPercent());
+  sprintf(line, " DeadTimeActiveTimeSlot:      %3.3f%%", c.deadTimeActiveTimeSlotRunPercent());
   s << line << std::endl;
 
   std::vector<double> triggersRunRate = c.triggersRunRate();
   length = triggersRunRate.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    sprintf(line," %3.3d:%e    %3.3d:%e    %3.3d:%e    %3.3d:%e",
-	    i,              triggersRunRate[i], 
-	    (i+length),     triggersRunRate[i+length], 
-	    (i+(length*2)), triggersRunRate[i+(length*2)], 
-	    (i+(length*3)), triggersRunRate[i+(length*3)]);
+  for (int i = 0; i < length; i++) {
+    sprintf(line,
+            " %3.3d:%e    %3.3d:%e    %3.3d:%e    %3.3d:%e",
+            i,
+            triggersRunRate[i],
+            (i + length),
+            triggersRunRate[i + length],
+            (i + (length * 2)),
+            triggersRunRate[i + (length * 2)],
+            (i + (length * 3)),
+            triggersRunRate[i + (length * 3)]);
     s << line << std::endl;
   }
 

--- a/DataFormats/Scalers/src/L1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/L1TriggerScalers.cc
@@ -9,221 +9,228 @@
 #include <iostream>
 #include <cstdio>
 
-L1TriggerScalers::L1TriggerScalers():
-  version_(0),
-  collectionTimeSpecial_(0,0),
-  orbitNumber_(0),
-  luminositySection_(0),
-  bunchCrossingErrors_(0),
-  collectionTimeSummary_(0,0),
-  triggerNumber_(0),
-  eventNumber_(0),
-  finalTriggersDistributed_(0),
-  calibrationTriggers_(0),
-  randomTriggers_(0),
-  totalTestTriggers_(0),
-  finalTriggersGenerated_(0),
-  finalTriggersInvalidBC_(0),
-  deadTime_(0),
-  lostFinalTriggers_(0),
-  deadTimeActive_(0),
-  lostFinalTriggersActive_(0),
-  deadTimeActivePrivate_(0),
-  deadTimeActivePartition_(0),
-  deadTimeActiveThrottle_(0),
-  deadTimeActiveCalibration_(0),
-  deadTimeActiveTimeSlot_(0),
-  numberResets_(0),
-  collectionTimeDetails_(0,0),
-  triggers_(nL1Triggers),
-  testTriggers_(nL1TestTriggers)
-{ 
-}
+L1TriggerScalers::L1TriggerScalers()
+    : version_(0),
+      collectionTimeSpecial_(0, 0),
+      orbitNumber_(0),
+      luminositySection_(0),
+      bunchCrossingErrors_(0),
+      collectionTimeSummary_(0, 0),
+      triggerNumber_(0),
+      eventNumber_(0),
+      finalTriggersDistributed_(0),
+      calibrationTriggers_(0),
+      randomTriggers_(0),
+      totalTestTriggers_(0),
+      finalTriggersGenerated_(0),
+      finalTriggersInvalidBC_(0),
+      deadTime_(0),
+      lostFinalTriggers_(0),
+      deadTimeActive_(0),
+      lostFinalTriggersActive_(0),
+      deadTimeActivePrivate_(0),
+      deadTimeActivePartition_(0),
+      deadTimeActiveThrottle_(0),
+      deadTimeActiveCalibration_(0),
+      deadTimeActiveTimeSlot_(0),
+      numberResets_(0),
+      collectionTimeDetails_(0, 0),
+      triggers_(nL1Triggers),
+      testTriggers_(nL1TestTriggers) {}
 
-L1TriggerScalers::L1TriggerScalers(const unsigned char * rawData)
-{ 
+L1TriggerScalers::L1TriggerScalers(const unsigned char* rawData) {
   L1TriggerScalers();
 
-  struct ScalersEventRecordRaw_v1 const * raw 
-    = reinterpret_cast<struct ScalersEventRecordRaw_v1 const *>(rawData);
+  struct ScalersEventRecordRaw_v1 const* raw = reinterpret_cast<struct ScalersEventRecordRaw_v1 const*>(rawData);
 
-  trigType_     = ( raw->header >> 56 ) &        0xFULL;
-  eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
-  sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;
-  bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
+  trigType_ = (raw->header >> 56) & 0xFULL;
+  eventID_ = (raw->header >> 32) & 0x00FFFFFFULL;
+  sourceID_ = (raw->header >> 8) & 0x00000FFFULL;
+  bunchNumber_ = (raw->header >> 20) & 0xFFFULL;
 
   version_ = raw->version;
-  if ( ( version_ == 1 ) || ( version_ == 2 ) )
-  {
-    collectionTimeSpecial_.set_tv_sec( static_cast<long>(
-      raw->trig.collectionTimeSpecial_sec));
-    collectionTimeSpecial_.set_tv_nsec( 
-      raw->trig.collectionTimeSpecial_nsec);
-    orbitNumber_               = raw->trig.ORBIT_NUMBER;
-    luminositySection_         = raw->trig.LUMINOSITY_SEGMENT;
-    bunchCrossingErrors_       = raw->trig.BC_ERRORS;
+  if ((version_ == 1) || (version_ == 2)) {
+    collectionTimeSpecial_.set_tv_sec(static_cast<long>(raw->trig.collectionTimeSpecial_sec));
+    collectionTimeSpecial_.set_tv_nsec(raw->trig.collectionTimeSpecial_nsec);
+    orbitNumber_ = raw->trig.ORBIT_NUMBER;
+    luminositySection_ = raw->trig.LUMINOSITY_SEGMENT;
+    bunchCrossingErrors_ = raw->trig.BC_ERRORS;
 
-    collectionTimeSummary_.set_tv_sec( static_cast<long>(
-      raw->trig.collectionTimeSummary_sec));
-    collectionTimeSummary_.set_tv_nsec( 
-      raw->trig.collectionTimeSummary_nsec);
+    collectionTimeSummary_.set_tv_sec(static_cast<long>(raw->trig.collectionTimeSummary_sec));
+    collectionTimeSummary_.set_tv_nsec(raw->trig.collectionTimeSummary_nsec);
 
-    triggerNumber_             = raw->trig.TRIGGER_NR;
-    eventNumber_               = raw->trig.EVENT_NR;
-    finalTriggersDistributed_  = raw->trig.FINOR_DISTRIBUTED;
-    calibrationTriggers_       = raw->trig.CAL_TRIGGER;
-    randomTriggers_            = raw->trig.RANDOM_TRIGGER;
-    totalTestTriggers_         = raw->trig.TEST_TRIGGER;
+    triggerNumber_ = raw->trig.TRIGGER_NR;
+    eventNumber_ = raw->trig.EVENT_NR;
+    finalTriggersDistributed_ = raw->trig.FINOR_DISTRIBUTED;
+    calibrationTriggers_ = raw->trig.CAL_TRIGGER;
+    randomTriggers_ = raw->trig.RANDOM_TRIGGER;
+    totalTestTriggers_ = raw->trig.TEST_TRIGGER;
 
-    finalTriggersGenerated_    = raw->trig.FINOR_GENERATED;
-    finalTriggersInvalidBC_    = raw->trig.FINOR_IN_INVALID_BC;
+    finalTriggersGenerated_ = raw->trig.FINOR_GENERATED;
+    finalTriggersInvalidBC_ = raw->trig.FINOR_IN_INVALID_BC;
 
-    deadTime_                  = raw->trig.DEADTIME;
-    lostFinalTriggers_         = raw->trig.LOST_FINOR;
-    deadTimeActive_            = raw->trig.DEADTIMEA;
-    lostFinalTriggersActive_   = raw->trig.LOST_FINORA;
-    deadTimeActivePrivate_     = raw->trig.PRIV_DEADTIMEA;
-    deadTimeActivePartition_   = raw->trig.PTCSTATUS_DEADTIMEA;
-    deadTimeActiveThrottle_    = raw->trig.THROTTLE_DEADTIMEA;
+    deadTime_ = raw->trig.DEADTIME;
+    lostFinalTriggers_ = raw->trig.LOST_FINOR;
+    deadTimeActive_ = raw->trig.DEADTIMEA;
+    lostFinalTriggersActive_ = raw->trig.LOST_FINORA;
+    deadTimeActivePrivate_ = raw->trig.PRIV_DEADTIMEA;
+    deadTimeActivePartition_ = raw->trig.PTCSTATUS_DEADTIMEA;
+    deadTimeActiveThrottle_ = raw->trig.THROTTLE_DEADTIMEA;
     deadTimeActiveCalibration_ = raw->trig.CALIBRATION_DEADTIMEA;
-    deadTimeActiveTimeSlot_    = raw->trig.TIMESLOT_DEADTIMEA;
-    numberResets_              = raw->trig.NR_OF_RESETS;
+    deadTimeActiveTimeSlot_ = raw->trig.TIMESLOT_DEADTIMEA;
+    numberResets_ = raw->trig.NR_OF_RESETS;
 
-    collectionTimeDetails_.set_tv_sec( static_cast<long>(
-      raw->trig.collectionTimeDetails_sec));
-    collectionTimeDetails_.set_tv_nsec(
-      raw->trig.collectionTimeDetails_nsec);
+    collectionTimeDetails_.set_tv_sec(static_cast<long>(raw->trig.collectionTimeDetails_sec));
+    collectionTimeDetails_.set_tv_nsec(raw->trig.collectionTimeDetails_nsec);
 
-    for ( int i=0; i<ScalersRaw::N_L1_TRIGGERS_v1; i++)
-    { triggers_.push_back( raw->trig.ALGO_RATE[i]);}
+    for (int i = 0; i < ScalersRaw::N_L1_TRIGGERS_v1; i++) {
+      triggers_.push_back(raw->trig.ALGO_RATE[i]);
+    }
 
-    for ( int i=0; i<ScalersRaw::N_L1_TEST_TRIGGERS_v1; i++)
-    { testTriggers_.push_back( raw->trig.TEST_RATE[i]);}
+    for (int i = 0; i < ScalersRaw::N_L1_TEST_TRIGGERS_v1; i++) {
+      testTriggers_.push_back(raw->trig.TEST_RATE[i]);
+    }
   }
 }
 
-L1TriggerScalers::~L1TriggerScalers() { } 
-
+L1TriggerScalers::~L1TriggerScalers() {}
 
 /// Pretty-print operator for L1TriggerScalers
-std::ostream& operator<<(std::ostream& s,L1TriggerScalers const &c) 
-{
-  s << "L1TriggerScalers    Version:" << c.version() <<
-    "   SourceID: " << c.sourceID() << std::endl;
+std::ostream& operator<<(std::ostream& s, L1TriggerScalers const& c) {
+  s << "L1TriggerScalers    Version:" << c.version() << "   SourceID: " << c.sourceID() << std::endl;
   constexpr size_t kLineBufferSize = 164;
   char line[kLineBufferSize];
   char zeitHeaven[128];
   char zeitHell[128];
   char zeitLimbo[128];
-  struct tm * horaHeaven;
-  struct tm * horaHell;
-  struct tm * horaLimbo;
+  struct tm* horaHeaven;
+  struct tm* horaHell;
+  struct tm* horaLimbo;
 
-  sprintf(line, " TrigType: %d   EventID: %d    BunchNumber: %d", 
-	  c.trigType(), c.eventID(), c.bunchNumber());
+  sprintf(line, " TrigType: %d   EventID: %d    BunchNumber: %d", c.trigType(), c.eventID(), c.bunchNumber());
   s << line << std::endl;
 
   timespec secondsToHeaven = c.collectionTimeSummary();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  snprintf(line, kLineBufferSize, " CollectionTimeSummary: %s.%9.9d" , 
-	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTimeSummary: %s.%9.9d", zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
 
-  timespec secondsToHell= c.collectionTimeSpecial();
+  timespec secondsToHell = c.collectionTimeSpecial();
   horaHell = gmtime(&secondsToHell.tv_sec);
   strftime(zeitHell, sizeof(zeitHell), "%Y.%m.%d %H:%M:%S", horaHell);
-  snprintf(line, kLineBufferSize, " CollectionTimeSpecial: %s.%9.9d" , 
-	  zeitHell, (int)secondsToHell.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTimeSpecial: %s.%9.9d", zeitHell, (int)secondsToHell.tv_nsec);
   s << line << std::endl;
 
-  timespec secondsToLimbo= c.collectionTimeDetails();
+  timespec secondsToLimbo = c.collectionTimeDetails();
   horaLimbo = gmtime(&secondsToLimbo.tv_sec);
   strftime(zeitLimbo, sizeof(zeitLimbo), "%Y.%m.%d %H:%M:%S", horaLimbo);
-  snprintf(line, kLineBufferSize, " CollectionTimeDetails: %s.%9.9d" , 
-	  zeitLimbo, (int)secondsToLimbo.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTimeDetails: %s.%9.9d", zeitLimbo, (int)secondsToLimbo.tv_nsec);
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " LuminositySection: %15d  BunchCrossingErrors:      %15d",
-	  c.luminositySection(), c.bunchCrossingErrors());
+  snprintf(line,
+           kLineBufferSize,
+           " LuminositySection: %15d  BunchCrossingErrors:      %15d",
+           c.luminositySection(),
+           c.bunchCrossingErrors());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " TriggerNumber:     %15d  EventNumber:              %15d",
-	  c.triggerNumber(), c.eventNumber());
+  snprintf(line,
+           kLineBufferSize,
+           " TriggerNumber:     %15d  EventNumber:              %15d",
+           c.triggerNumber(),
+           c.eventNumber());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " TriggersDistributed:    %10d  TriggersGenerated:        %15d",
-	  c.finalTriggersDistributed(), 
-	  c.finalTriggersGenerated());
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersDistributed:    %10d  TriggersGenerated:        %15d",
+           c.finalTriggersDistributed(),
+           c.finalTriggersGenerated());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " TriggersInvalidBC: %15d  CalibrationTriggers:      %15d",
-	  c.finalTriggersInvalidBC(), c.calibrationTriggers());
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersInvalidBC: %15d  CalibrationTriggers:      %15d",
+           c.finalTriggersInvalidBC(),
+           c.calibrationTriggers());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " TestTriggers:      %15d  RandomTriggers:           %15d",
-	  c.totalTestTriggers(), c.randomTriggers());
+  snprintf(line,
+           kLineBufferSize,
+           " TestTriggers:      %15d  RandomTriggers:           %15d",
+           c.totalTestTriggers(),
+           c.randomTriggers());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " DeadTime:          %15d  DeadTimeActiveTimeSlot:   %15ld",
-	  c.numberResets(), (long int)c.deadTime());
+  snprintf(line,
+           kLineBufferSize,
+           " DeadTime:          %15d  DeadTimeActiveTimeSlot:   %15ld",
+           c.numberResets(),
+           (long int)c.deadTime());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " DeadTimeActive:    %15ld  DeadTimeActiveCalibration:%15ld",
-	  (long int)c.deadTimeActive(), 
-	  (long int)c.deadTimeActiveCalibration());
+  snprintf(line,
+           kLineBufferSize,
+           " DeadTimeActive:    %15ld  DeadTimeActiveCalibration:%15ld",
+           (long int)c.deadTimeActive(),
+           (long int)c.deadTimeActiveCalibration());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " LostTriggers:      %15ld  DeadTimeActivePartition:  %15ld",
-	  (long int)c.lostFinalTriggers(), 
-	  (long int)c.deadTimeActivePartition());
+  snprintf(line,
+           kLineBufferSize,
+           " LostTriggers:      %15ld  DeadTimeActivePartition:  %15ld",
+           (long int)c.lostFinalTriggers(),
+           (long int)c.deadTimeActivePartition());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " LostTriggersActive:%15ld  DeadTimeActiveThrottle:   %15ld",
-	  (long int)c.lostFinalTriggersActive(),
-	  (long int)c.deadTimeActiveThrottle());
+  snprintf(line,
+           kLineBufferSize,
+           " LostTriggersActive:%15ld  DeadTimeActiveThrottle:   %15ld",
+           (long int)c.lostFinalTriggersActive(),
+           (long int)c.deadTimeActiveThrottle());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " NumberResets:      %15d  DeadTimeActivePrivate:    %15ld",
-	  c.numberResets(),
-	  (long int)c.deadTimeActivePrivate());
+  snprintf(line,
+           kLineBufferSize,
+           " NumberResets:      %15d  DeadTimeActivePrivate:    %15ld",
+           c.numberResets(),
+           (long int)c.deadTimeActivePrivate());
   s << line << std::endl;
 
   s << "Physics Triggers" << std::endl;
   std::vector<unsigned int> triggers = c.triggers();
   int length = triggers.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize,
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
              " %3.3d: %10d    %3.3d: %10d    %3.3d: %10d    %3.3d: %10d",
-	    i,              triggers[i], 
-	    (i+length),     triggers[i+length], 
-	    (i+(length*2)), triggers[i+(length*2)], 
-	    (i+(length*3)), triggers[i+(length*3)]);
+             i,
+             triggers[i],
+             (i + length),
+             triggers[i + length],
+             (i + (length * 2)),
+             triggers[i + (length * 2)],
+             (i + (length * 3)),
+             triggers[i + (length * 3)]);
     s << line << std::endl;
   }
 
   s << "Test Triggers" << std::endl;
   std::vector<unsigned int> testTriggers = c.testTriggers();
   length = testTriggers.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize,
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
              " %3.3d: %10d    %3.3d: %10d    %3.3d: %10d    %3.3d: %10d",
-	    i,              testTriggers[i], 
-	    (i+length),     testTriggers[i+length], 
-	    (i+(length*2)), testTriggers[i+(length*2)], 
-	    (i+(length*3)), testTriggers[i+(length*3)]);
+             i,
+             testTriggers[i],
+             (i + length),
+             testTriggers[i + length],
+             (i + (length * 2)),
+             testTriggers[i + (length * 2)],
+             (i + (length * 3)),
+             testTriggers[i + (length * 3)]);
     s << line << std::endl;
   }
   return s;

--- a/DataFormats/Scalers/src/Level1TriggerRates.cc
+++ b/DataFormats/Scalers/src/Level1TriggerRates.cc
@@ -8,303 +8,264 @@
 #include <iostream>
 #include <cstdio>
 
-Level1TriggerRates::Level1TriggerRates():
-  version_(0),
-  collectionTime_(0,0),
-  deltaNS_(0),
-  deltaT_(0.0),
-  gtTriggersRate_(0.0),
-  gtEventsRate_(0.0),
-  collectionTimeLumiSeg_(0,0),
-  triggersPhysicsGeneratedFDLRate_(0.0),
-  triggersPhysicsLostRate_(0.0),
-  triggersPhysicsLostBeamActiveRate_(0.0),
-  triggersPhysicsLostBeamInactiveRate_(0.0),
-  l1AsPhysicsRate_(0.0),
-  l1AsRandomRate_(0.0),
-  l1AsTestRate_(0.0),
-  l1AsCalibrationRate_(0.0),
-  deadtimePercent_(0.0),
-  deadtimeBeamActivePercent_(0.0),
-  deadtimeBeamActiveTriggerRulesPercent_(0.0),
-  deadtimeBeamActiveCalibrationPercent_(0.0),
-  deadtimeBeamActivePrivateOrbitPercent_(0.0),
-  deadtimeBeamActivePartitionControllerPercent_(0.0),
-  deadtimeBeamActiveTimeSlotPercent_(0.0),
-  gtAlgoCountsRate_(Level1TriggerScalers::nLevel1Triggers),
-  gtTechCountsRate_(Level1TriggerScalers::nLevel1TestTriggers)
-{ 
+Level1TriggerRates::Level1TriggerRates()
+    : version_(0),
+      collectionTime_(0, 0),
+      deltaNS_(0),
+      deltaT_(0.0),
+      gtTriggersRate_(0.0),
+      gtEventsRate_(0.0),
+      collectionTimeLumiSeg_(0, 0),
+      triggersPhysicsGeneratedFDLRate_(0.0),
+      triggersPhysicsLostRate_(0.0),
+      triggersPhysicsLostBeamActiveRate_(0.0),
+      triggersPhysicsLostBeamInactiveRate_(0.0),
+      l1AsPhysicsRate_(0.0),
+      l1AsRandomRate_(0.0),
+      l1AsTestRate_(0.0),
+      l1AsCalibrationRate_(0.0),
+      deadtimePercent_(0.0),
+      deadtimeBeamActivePercent_(0.0),
+      deadtimeBeamActiveTriggerRulesPercent_(0.0),
+      deadtimeBeamActiveCalibrationPercent_(0.0),
+      deadtimeBeamActivePrivateOrbitPercent_(0.0),
+      deadtimeBeamActivePartitionControllerPercent_(0.0),
+      deadtimeBeamActiveTimeSlotPercent_(0.0),
+      gtAlgoCountsRate_(Level1TriggerScalers::nLevel1Triggers),
+      gtTechCountsRate_(Level1TriggerScalers::nLevel1TestTriggers) {}
+
+Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s) {
+  Level1TriggerRates(s, Level1TriggerScalers::firstShortLSRun);
 }
 
-Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s)
-{
-  Level1TriggerRates(s,Level1TriggerScalers::firstShortLSRun);
-}
-
-Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s,
-				       int runNumber)
-{ 
+Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s, int runNumber) {
   Level1TriggerRates();
-  computeRates(s,runNumber);
+  computeRates(s, runNumber);
 }
 
-Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s1,
-				       Level1TriggerScalers const& s2)
-{
-  Level1TriggerRates(s1,s2,Level1TriggerScalers::firstShortLSRun);
+Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s1, Level1TriggerScalers const& s2) {
+  Level1TriggerRates(s1, s2, Level1TriggerScalers::firstShortLSRun);
 }
 
-Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s1,
-				       Level1TriggerScalers const& s2,
-				       int runNumber)
-{  
+Level1TriggerRates::Level1TriggerRates(Level1TriggerScalers const& s1, Level1TriggerScalers const& s2, int runNumber) {
   Level1TriggerRates();
-  computeRates(s1,s2,runNumber);
+  computeRates(s1, s2, runNumber);
 }
 
-Level1TriggerRates::~Level1TriggerRates() { } 
+Level1TriggerRates::~Level1TriggerRates() {}
 
+void Level1TriggerRates::computeRates(Level1TriggerScalers const& t) {
+  computeRates(t, Level1TriggerScalers::firstShortLSRun);
+}
 
-void Level1TriggerRates::computeRates(Level1TriggerScalers const& t)
-{ computeRates(t,Level1TriggerScalers::firstShortLSRun);}
-
-void Level1TriggerRates::computeRates(Level1TriggerScalers const& t,
-				      int run)
-{
+void Level1TriggerRates::computeRates(Level1TriggerScalers const& t, int run) {
   version_ = t.version();
 
   collectionTime_.set_tv_sec(static_cast<long>(t.collectionTime().tv_sec));
   collectionTime_.set_tv_nsec(t.collectionTime().tv_nsec);
 
   gtTriggersRate_ = t.gtTriggersRate();
-  gtEventsRate_   = t.gtEventsRate();
+  gtEventsRate_ = t.gtEventsRate();
 
   collectionTimeLumiSeg_.set_tv_sec(static_cast<long>(t.collectionTimeLumiSeg().tv_sec));
   collectionTimeLumiSeg_.set_tv_nsec(t.collectionTimeLumiSeg().tv_nsec);
 
-  triggersPhysicsGeneratedFDLRate_ 
-    = Level1TriggerScalers::rateLS(t.triggersPhysicsGeneratedFDL(),run);
-  triggersPhysicsLostRate_ 
-    = Level1TriggerScalers::rateLS(t.triggersPhysicsLost(),run);
-  triggersPhysicsLostBeamActiveRate_ 
-    = Level1TriggerScalers::rateLS(t.triggersPhysicsLostBeamActive(),run);
-  triggersPhysicsLostBeamInactiveRate_ 
-    = Level1TriggerScalers::rateLS(t.triggersPhysicsLostBeamInactive(),run);
+  triggersPhysicsGeneratedFDLRate_ = Level1TriggerScalers::rateLS(t.triggersPhysicsGeneratedFDL(), run);
+  triggersPhysicsLostRate_ = Level1TriggerScalers::rateLS(t.triggersPhysicsLost(), run);
+  triggersPhysicsLostBeamActiveRate_ = Level1TriggerScalers::rateLS(t.triggersPhysicsLostBeamActive(), run);
+  triggersPhysicsLostBeamInactiveRate_ = Level1TriggerScalers::rateLS(t.triggersPhysicsLostBeamInactive(), run);
 
-  l1AsPhysicsRate_ = Level1TriggerScalers::rateLS(t.l1AsPhysics(),run);
-  l1AsRandomRate_ = Level1TriggerScalers::rateLS(t.l1AsRandom(),run);
-  l1AsTestRate_ = Level1TriggerScalers::rateLS(t.l1AsTest(),run);
-  l1AsCalibrationRate_ = Level1TriggerScalers::rateLS(t.l1AsCalibration(),run);
+  l1AsPhysicsRate_ = Level1TriggerScalers::rateLS(t.l1AsPhysics(), run);
+  l1AsRandomRate_ = Level1TriggerScalers::rateLS(t.l1AsRandom(), run);
+  l1AsTestRate_ = Level1TriggerScalers::rateLS(t.l1AsTest(), run);
+  l1AsCalibrationRate_ = Level1TriggerScalers::rateLS(t.l1AsCalibration(), run);
 
-  deadtimePercent_ = Level1TriggerScalers::percentLS(t.deadtime(),run);
-  deadtimeBeamActivePercent_ =
-    Level1TriggerScalers::percentLSActive(t.deadtimeBeamActive(),run);
+  deadtimePercent_ = Level1TriggerScalers::percentLS(t.deadtime(), run);
+  deadtimeBeamActivePercent_ = Level1TriggerScalers::percentLSActive(t.deadtimeBeamActive(), run);
   deadtimeBeamActiveTriggerRulesPercent_ =
-    Level1TriggerScalers::percentLSActive(t.deadtimeBeamActiveTriggerRules(),run);
-  deadtimeBeamActiveCalibrationPercent_ =
-    Level1TriggerScalers::percentLSActive(t.deadtimeBeamActiveCalibration(),run);
+      Level1TriggerScalers::percentLSActive(t.deadtimeBeamActiveTriggerRules(), run);
+  deadtimeBeamActiveCalibrationPercent_ = Level1TriggerScalers::percentLSActive(t.deadtimeBeamActiveCalibration(), run);
   deadtimeBeamActivePrivateOrbitPercent_ =
-    Level1TriggerScalers::percentLSActive(t.deadtimeBeamActivePrivateOrbit(),run);
+      Level1TriggerScalers::percentLSActive(t.deadtimeBeamActivePrivateOrbit(), run);
   deadtimeBeamActivePartitionControllerPercent_ =
-    Level1TriggerScalers::percentLSActive(t.deadtimeBeamActivePartitionController(),run);
-  deadtimeBeamActiveTimeSlotPercent_ =
-    Level1TriggerScalers::percentLSActive(t.deadtimeBeamActiveTimeSlot(),run);
+      Level1TriggerScalers::percentLSActive(t.deadtimeBeamActivePartitionController(), run);
+  deadtimeBeamActiveTimeSlotPercent_ = Level1TriggerScalers::percentLSActive(t.deadtimeBeamActiveTimeSlot(), run);
 
   const std::vector<unsigned int> gtAlgoCounts = t.gtAlgoCounts();
-  for ( std::vector<unsigned int>::const_iterator counts = gtAlgoCounts.begin();
-	counts != gtAlgoCounts.end(); ++counts)
-  {
-    gtAlgoCountsRate_.push_back(Level1TriggerScalers::rateLS(*counts,run));
+  for (std::vector<unsigned int>::const_iterator counts = gtAlgoCounts.begin(); counts != gtAlgoCounts.end();
+       ++counts) {
+    gtAlgoCountsRate_.push_back(Level1TriggerScalers::rateLS(*counts, run));
   }
 
   const std::vector<unsigned int> gtTechCounts = t.gtTechCounts();
-  for ( std::vector<unsigned int>::const_iterator counts = gtTechCounts.begin();
-	counts != gtTechCounts.end(); ++counts)
-  {
-    gtTechCountsRate_.push_back(Level1TriggerScalers::rateLS(*counts,run));
+  for (std::vector<unsigned int>::const_iterator counts = gtTechCounts.begin(); counts != gtTechCounts.end();
+       ++counts) {
+    gtTechCountsRate_.push_back(Level1TriggerScalers::rateLS(*counts, run));
   }
 
   deltaNS_ = 0ULL;
   deltaT_ = 0.0;
 }
 
-void Level1TriggerRates::computeRates(Level1TriggerScalers const& t1,
-				      Level1TriggerScalers const& t2)
-{
-  computeRates(t1,t2,Level1TriggerScalers::firstShortLSRun);
+void Level1TriggerRates::computeRates(Level1TriggerScalers const& t1, Level1TriggerScalers const& t2) {
+  computeRates(t1, t2, Level1TriggerScalers::firstShortLSRun);
 }
 
-void Level1TriggerRates::computeRates(Level1TriggerScalers const& t1,
-				      Level1TriggerScalers const& t2,
-				      int run)
-{
-  computeRates(t1,run);
+void Level1TriggerRates::computeRates(Level1TriggerScalers const& t1, Level1TriggerScalers const& t2, int run) {
+  computeRates(t1, run);
 
-  unsigned long long zeit1 = 
-    ( (unsigned long long)t1.collectionTime().tv_sec * 1000000000ULL)| 
-    ( (unsigned long long)t1.collectionTime().tv_nsec );
-  unsigned long long zeit2 = 
-    ( (unsigned long long)t2.collectionTime().tv_sec * 1000000000ULL)| 
-    ( (unsigned long long)t2.collectionTime().tv_nsec );
+  unsigned long long zeit1 = ((unsigned long long)t1.collectionTime().tv_sec * 1000000000ULL) |
+                             ((unsigned long long)t1.collectionTime().tv_nsec);
+  unsigned long long zeit2 = ((unsigned long long)t2.collectionTime().tv_sec * 1000000000ULL) |
+                             ((unsigned long long)t2.collectionTime().tv_nsec);
 
-  deltaT_  = 0.0;
+  deltaT_ = 0.0;
   deltaNS_ = 0ULL;
-  if ( zeit2 > zeit1 ) 
-  {
+  if (zeit2 > zeit1) {
     deltaNS_ = zeit2 - zeit1;
-    deltaT_  = ((double)deltaNS_) / 1.0E9;
-    gtTriggersRate_ = 
-      ((double)(t2.gtTriggers()-t1.gtTriggers()))/deltaT_;
-    gtEventsRate_   = 
-      ((double)(t2.gtEvents()-t1.gtEvents()))/deltaT_;
+    deltaT_ = ((double)deltaNS_) / 1.0E9;
+    gtTriggersRate_ = ((double)(t2.gtTriggers() - t1.gtTriggers())) / deltaT_;
+    gtEventsRate_ = ((double)(t2.gtEvents() - t1.gtEvents())) / deltaT_;
   }
 }
 
-
 /// Pretty-print operator for Level1TriggerRates
-std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c) 
-{
+std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c) {
   constexpr size_t kLineBufferSize = 164;
   char line[kLineBufferSize];
   char zeitHeaven[128];
-  struct tm * horaHeaven;
+  struct tm* horaHeaven;
 
-  s << "Level1TriggerRates Version: " << c.version() 
-    << " Rates in Hz, DeltaT: ";
+  s << "Level1TriggerRates Version: " << c.version() << " Rates in Hz, DeltaT: ";
 
-  if ( c.deltaNS() > 0 )
-  {
+  if (c.deltaNS() > 0) {
     s << c.deltaT() << " sec" << std::endl;
-  }
-  else
-  {
+  } else {
     s << "n/a" << std::endl;
   }
 
   struct timespec secondsToHeaven = c.collectionTime();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  snprintf(line, kLineBufferSize, " CollectionTime:        %s.%9.9d" , 
-           zeitHeaven, (int)secondsToHeaven.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTime:        %s.%9.9d", zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
-  
-  snprintf(line, kLineBufferSize, 
-           " GtTriggersRate:                              %22.3f Hz",
-           c.gtTriggersRate());
+
+  snprintf(line, kLineBufferSize, " GtTriggersRate:                              %22.3f Hz", c.gtTriggersRate());
   s << line << std::endl;
-  
-  snprintf(line, kLineBufferSize,
-           " GtEventsRate:                                %22.3f Hz",
-           c.gtEventsRate());
+
+  snprintf(line, kLineBufferSize, " GtEventsRate:                                %22.3f Hz", c.gtEventsRate());
   s << line << std::endl;
 
   secondsToHeaven = c.collectionTimeLumiSeg();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  snprintf(line, kLineBufferSize, " CollectionTimeLumiSeg: %s.%9.9d" , 
-	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTimeLumiSeg: %s.%9.9d", zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
-  
-  snprintf(line, kLineBufferSize,
+
+  snprintf(line,
+           kLineBufferSize,
            " TriggersPhysicsGeneratedFDLRate:             %22.3f Hz",
            c.triggersPhysicsGeneratedFDLRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " TriggersPhysicsLostRate:                     %22.3f Hz",
-           c.triggersPhysicsLostRate());
+  snprintf(
+      line, kLineBufferSize, " TriggersPhysicsLostRate:                     %22.3f Hz", c.triggersPhysicsLostRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
+  snprintf(line,
+           kLineBufferSize,
            " TriggersPhysicsLostBeamActiveRate:           %22.3f Hz",
            c.triggersPhysicsLostBeamActiveRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-          " TriggersPhysicsLostBeamInactiveRate:         %22.3f Hz",
-	  c.triggersPhysicsLostBeamInactiveRate());
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersPhysicsLostBeamInactiveRate:         %22.3f Hz",
+           c.triggersPhysicsLostBeamInactiveRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-          " L1AsPhysicsRate:                             %22.3f Hz",
-	  c.l1AsPhysicsRate());
+  snprintf(line, kLineBufferSize, " L1AsPhysicsRate:                             %22.3f Hz", c.l1AsPhysicsRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, 
-           " L1AsRandomRate:                              %22.3f Hz",
-           c.l1AsRandomRate());
+  snprintf(line, kLineBufferSize, " L1AsRandomRate:                              %22.3f Hz", c.l1AsRandomRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " L1AsTestRate:                                %22.3f Hz",
-           c.l1AsTestRate());
+  snprintf(line, kLineBufferSize, " L1AsTestRate:                                %22.3f Hz", c.l1AsTestRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " L1AsCalibrationRate:                         %22.3f Hz",
-           c.l1AsCalibrationRate());
+  snprintf(line, kLineBufferSize, " L1AsCalibrationRate:                         %22.3f Hz", c.l1AsCalibrationRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " DeadtimePercent:                             %22.3f %%",
-           c.deadtimePercent());
+  snprintf(line, kLineBufferSize, " DeadtimePercent:                             %22.3f %%", c.deadtimePercent());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-           " DeadtimeBeamActivePercent:                   %22.3f %%",
-           c.deadtimeBeamActivePercent());
+  snprintf(
+      line, kLineBufferSize, " DeadtimeBeamActivePercent:                   %22.3f %%", c.deadtimeBeamActivePercent());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
+  snprintf(line,
+           kLineBufferSize,
            " DeadtimeBeamActiveTriggerRulesPercent:       %22.3f %%",
            c.deadtimeBeamActiveTriggerRulesPercent());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
+  snprintf(line,
+           kLineBufferSize,
            " DeadtimeBeamActiveCalibrationPercent:        %22.3f %%",
            c.deadtimeBeamActiveCalibrationPercent());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
+  snprintf(line,
+           kLineBufferSize,
            " DeadtimeBeamActivePrivateOrbitPercent:       %22.3f %%",
            c.deadtimeBeamActivePrivateOrbitPercent());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
+  snprintf(line,
+           kLineBufferSize,
            " DeadtimeBeamActivePartitionControllerPercent:%22.3f %%",
            c.deadtimeBeamActivePartitionControllerPercent());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, 
-          " DeadtimeBeamActiveTimeSlotPercent:           %22.3f %%",
-	  c.deadtimeBeamActiveTimeSlotPercent());
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActiveTimeSlotPercent:           %22.3f %%",
+           c.deadtimeBeamActiveTimeSlotPercent());
   s << line << std::endl;
 
   s << "Physics GtAlgoCountsRate, Hz" << std::endl;
   const std::vector<double> gtAlgoCountsRate = c.gtAlgoCountsRate();
   int length = gtAlgoCountsRate.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize,
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
              " %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f",
-             i,              gtAlgoCountsRate[i], 
-             (i+length),     gtAlgoCountsRate[i+length], 
-             (i+(length*2)), gtAlgoCountsRate[i+(length*2)], 
-             (i+(length*3)), gtAlgoCountsRate[i+(length*3)]);
+             i,
+             gtAlgoCountsRate[i],
+             (i + length),
+             gtAlgoCountsRate[i + length],
+             (i + (length * 2)),
+             gtAlgoCountsRate[i + (length * 2)],
+             (i + (length * 3)),
+             gtAlgoCountsRate[i + (length * 3)]);
     s << line << std::endl;
   }
 
   s << "Test GtTechCountsRate, Hz" << std::endl;
   const std::vector<double> gtTechCountsRate = c.gtTechCountsRate();
   length = gtTechCountsRate.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize,
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
              " %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f",
-             i,              gtTechCountsRate[i], 
-             (i+length),     gtTechCountsRate[i+length], 
-             (i+(length*2)), gtTechCountsRate[i+(length*2)], 
-             (i+(length*3)), gtTechCountsRate[i+(length*3)]);
+             i,
+             gtTechCountsRate[i],
+             (i + length),
+             gtTechCountsRate[i + length],
+             (i + (length * 2)),
+             gtTechCountsRate[i + (length * 2)],
+             (i + (length * 3)),
+             gtTechCountsRate[i + (length * 3)]);
     s << line << std::endl;
   }
   return s;

--- a/DataFormats/Scalers/src/Level1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/Level1TriggerScalers.cc
@@ -9,395 +9,407 @@
 #include <ctime>
 #include <cstdio>
 
-Level1TriggerScalers::Level1TriggerScalers():
-  version_(0),
-  trigType_(0),
-  eventID_(0),
-  sourceID_(0),
-  bunchNumber_(0),
-  collectionTime_(0,0),
-  lumiSegmentNr_(0),
-  lumiSegmentOrbits_(0),
-  orbitNr_(0),
-  gtResets_(0),
-  bunchCrossingErrors_(0),
-  gtTriggers_(0),
-  gtEvents_(0),
-  gtTriggersRate_((float)0.0),
-  gtEventsRate_((float)0.0),
-  prescaleIndexAlgo_(0),
-  prescaleIndexTech_(0),
-  collectionTimeLumiSeg_(0,0),
-  lumiSegmentNrLumiSeg_(0),
-  triggersPhysicsGeneratedFDL_(0),
-  triggersPhysicsLost_(0),
-  triggersPhysicsLostBeamActive_(0),
-  triggersPhysicsLostBeamInactive_(0),
-  l1AsPhysics_(0),
-  l1AsRandom_(0),
-  l1AsTest_(0),
-  l1AsCalibration_(0),
-  deadtime_(0),
-  deadtimeBeamActive_(0),
-  deadtimeBeamActiveTriggerRules_(0),
-  deadtimeBeamActiveCalibration_(0),
-  deadtimeBeamActivePrivateOrbit_(0),
-  deadtimeBeamActivePartitionController_(0),
-  deadtimeBeamActiveTimeSlot_(0),
-  gtAlgoCounts_(nLevel1Triggers),
-  gtTechCounts_(nLevel1TestTriggers),
-  lastOrbitCounter0_(0),
-  lastTestEnable_(0),
-  lastResync_(0),
-  lastStart_(0),
-  lastEventCounter0_(0),
-  lastHardReset_(0),
-  spare0_(0ULL),
-  spare1_(0ULL),
-  spare2_(0ULL)
-{ 
-}
+Level1TriggerScalers::Level1TriggerScalers()
+    : version_(0),
+      trigType_(0),
+      eventID_(0),
+      sourceID_(0),
+      bunchNumber_(0),
+      collectionTime_(0, 0),
+      lumiSegmentNr_(0),
+      lumiSegmentOrbits_(0),
+      orbitNr_(0),
+      gtResets_(0),
+      bunchCrossingErrors_(0),
+      gtTriggers_(0),
+      gtEvents_(0),
+      gtTriggersRate_((float)0.0),
+      gtEventsRate_((float)0.0),
+      prescaleIndexAlgo_(0),
+      prescaleIndexTech_(0),
+      collectionTimeLumiSeg_(0, 0),
+      lumiSegmentNrLumiSeg_(0),
+      triggersPhysicsGeneratedFDL_(0),
+      triggersPhysicsLost_(0),
+      triggersPhysicsLostBeamActive_(0),
+      triggersPhysicsLostBeamInactive_(0),
+      l1AsPhysics_(0),
+      l1AsRandom_(0),
+      l1AsTest_(0),
+      l1AsCalibration_(0),
+      deadtime_(0),
+      deadtimeBeamActive_(0),
+      deadtimeBeamActiveTriggerRules_(0),
+      deadtimeBeamActiveCalibration_(0),
+      deadtimeBeamActivePrivateOrbit_(0),
+      deadtimeBeamActivePartitionController_(0),
+      deadtimeBeamActiveTimeSlot_(0),
+      gtAlgoCounts_(nLevel1Triggers),
+      gtTechCounts_(nLevel1TestTriggers),
+      lastOrbitCounter0_(0),
+      lastTestEnable_(0),
+      lastResync_(0),
+      lastStart_(0),
+      lastEventCounter0_(0),
+      lastHardReset_(0),
+      spare0_(0ULL),
+      spare1_(0ULL),
+      spare2_(0ULL) {}
 
-Level1TriggerScalers::Level1TriggerScalers(const unsigned char * rawData)
-{ 
+Level1TriggerScalers::Level1TriggerScalers(const unsigned char* rawData) {
   Level1TriggerScalers();
 
-  struct ScalersEventRecordRaw_v5 const * raw 
-    = reinterpret_cast<struct ScalersEventRecordRaw_v5 const *>(rawData);
+  struct ScalersEventRecordRaw_v5 const* raw = reinterpret_cast<struct ScalersEventRecordRaw_v5 const*>(rawData);
 
-  trigType_     = ( raw->header >> 56 ) &        0xFULL;
-  eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
-  sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;
-  bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
+  trigType_ = (raw->header >> 56) & 0xFULL;
+  eventID_ = (raw->header >> 32) & 0x00FFFFFFULL;
+  sourceID_ = (raw->header >> 8) & 0x00000FFFULL;
+  bunchNumber_ = (raw->header >> 20) & 0xFFFULL;
 
-  version_      = raw->version;
-  if ( version_ >= 3 )
-  {
-    collectionTime_.set_tv_sec( static_cast<long>(
-      raw->trig.collectionTime_sec));
-    collectionTime_.set_tv_nsec( 
-      raw->trig.collectionTime_nsec);
+  version_ = raw->version;
+  if (version_ >= 3) {
+    collectionTime_.set_tv_sec(static_cast<long>(raw->trig.collectionTime_sec));
+    collectionTime_.set_tv_nsec(raw->trig.collectionTime_nsec);
 
-    lumiSegmentNr_        = raw->trig.lumiSegmentNr;
-    lumiSegmentOrbits_    = raw->trig.lumiSegmentOrbits;
-    orbitNr_              = raw->trig.orbitNr;
-    gtResets_             = raw->trig.gtResets;
-    bunchCrossingErrors_  = raw->trig.bunchCrossingErrors;
-    gtTriggers_           = raw->trig.gtTriggers;
-    gtEvents_             = raw->trig.gtEvents;
-    gtTriggersRate_       = raw->trig.gtTriggersRate;
-    gtEventsRate_         = raw->trig.gtEventsRate;
-    prescaleIndexAlgo_    = raw->trig.prescaleIndexAlgo;
-    prescaleIndexTech_    = raw->trig.prescaleIndexTech;
+    lumiSegmentNr_ = raw->trig.lumiSegmentNr;
+    lumiSegmentOrbits_ = raw->trig.lumiSegmentOrbits;
+    orbitNr_ = raw->trig.orbitNr;
+    gtResets_ = raw->trig.gtResets;
+    bunchCrossingErrors_ = raw->trig.bunchCrossingErrors;
+    gtTriggers_ = raw->trig.gtTriggers;
+    gtEvents_ = raw->trig.gtEvents;
+    gtTriggersRate_ = raw->trig.gtTriggersRate;
+    gtEventsRate_ = raw->trig.gtEventsRate;
+    prescaleIndexAlgo_ = raw->trig.prescaleIndexAlgo;
+    prescaleIndexTech_ = raw->trig.prescaleIndexTech;
 
-    collectionTimeLumiSeg_.set_tv_sec( static_cast<long>(
-      raw->trig.collectionTimeLumiSeg_sec));
-    collectionTimeLumiSeg_.set_tv_nsec( 
-      raw->trig.collectionTimeLumiSeg_nsec);
+    collectionTimeLumiSeg_.set_tv_sec(static_cast<long>(raw->trig.collectionTimeLumiSeg_sec));
+    collectionTimeLumiSeg_.set_tv_nsec(raw->trig.collectionTimeLumiSeg_nsec);
 
-    lumiSegmentNrLumiSeg_           = raw->trig.lumiSegmentNrLumiSeg;
-    triggersPhysicsGeneratedFDL_    = raw->trig.triggersPhysicsGeneratedFDL;
-    triggersPhysicsLost_            = raw->trig.triggersPhysicsLost;
-    triggersPhysicsLostBeamActive_  = raw->trig.triggersPhysicsLostBeamActive;
-    triggersPhysicsLostBeamInactive_ = 
-      raw->trig.triggersPhysicsLostBeamInactive;
+    lumiSegmentNrLumiSeg_ = raw->trig.lumiSegmentNrLumiSeg;
+    triggersPhysicsGeneratedFDL_ = raw->trig.triggersPhysicsGeneratedFDL;
+    triggersPhysicsLost_ = raw->trig.triggersPhysicsLost;
+    triggersPhysicsLostBeamActive_ = raw->trig.triggersPhysicsLostBeamActive;
+    triggersPhysicsLostBeamInactive_ = raw->trig.triggersPhysicsLostBeamInactive;
 
-    l1AsPhysics_                    = raw->trig.l1AsPhysics;
-    l1AsRandom_                     = raw->trig.l1AsRandom;
-    l1AsTest_                       = raw->trig.l1AsTest;
-    l1AsCalibration_                = raw->trig.l1AsCalibration;
-    deadtime_                       = raw->trig.deadtime;
-    deadtimeBeamActive_             = raw->trig.deadtimeBeamActive;
+    l1AsPhysics_ = raw->trig.l1AsPhysics;
+    l1AsRandom_ = raw->trig.l1AsRandom;
+    l1AsTest_ = raw->trig.l1AsTest;
+    l1AsCalibration_ = raw->trig.l1AsCalibration;
+    deadtime_ = raw->trig.deadtime;
+    deadtimeBeamActive_ = raw->trig.deadtimeBeamActive;
     deadtimeBeamActiveTriggerRules_ = raw->trig.deadtimeBeamActiveTriggerRules;
-    deadtimeBeamActiveCalibration_  = raw->trig.deadtimeBeamActiveCalibration;
+    deadtimeBeamActiveCalibration_ = raw->trig.deadtimeBeamActiveCalibration;
     deadtimeBeamActivePrivateOrbit_ = raw->trig.deadtimeBeamActivePrivateOrbit;
-    deadtimeBeamActivePartitionController_ = 
-      raw->trig.deadtimeBeamActivePartitionController;
+    deadtimeBeamActivePartitionController_ = raw->trig.deadtimeBeamActivePartitionController;
     deadtimeBeamActiveTimeSlot_ = raw->trig.deadtimeBeamActiveTimeSlot;
 
-    for ( int i=0; i<ScalersRaw::N_L1_TRIGGERS_v1; i++)
-    { gtAlgoCounts_.push_back( raw->trig.gtAlgoCounts[i]);}
+    for (int i = 0; i < ScalersRaw::N_L1_TRIGGERS_v1; i++) {
+      gtAlgoCounts_.push_back(raw->trig.gtAlgoCounts[i]);
+    }
 
-    for ( int i=0; i<ScalersRaw::N_L1_TEST_TRIGGERS_v1; i++)
-    { gtTechCounts_.push_back( raw->trig.gtTechCounts[i]);}
+    for (int i = 0; i < ScalersRaw::N_L1_TEST_TRIGGERS_v1; i++) {
+      gtTechCounts_.push_back(raw->trig.gtTechCounts[i]);
+    }
 
-    if ( version_ >= 5 )
-    {
+    if (version_ >= 5) {
       lastOrbitCounter0_ = raw->lastOrbitCounter0;
-      lastTestEnable_    = raw->lastTestEnable;
-      lastResync_        = raw->lastResync;
-      lastStart_         = raw->lastStart;
+      lastTestEnable_ = raw->lastTestEnable;
+      lastResync_ = raw->lastResync;
+      lastStart_ = raw->lastStart;
       lastEventCounter0_ = raw->lastEventCounter0;
-      lastHardReset_     = raw->lastHardReset;
-      spare0_            = raw->spare[0];
-      spare1_            = raw->spare[1];
-      spare2_            = raw->spare[2];
-    }
-    else
-    {
+      lastHardReset_ = raw->lastHardReset;
+      spare0_ = raw->spare[0];
+      spare1_ = raw->spare[1];
+      spare2_ = raw->spare[2];
+    } else {
       lastOrbitCounter0_ = 0UL;
-      lastTestEnable_    = 0UL;
-      lastResync_        = 0UL;
-      lastStart_         = 0UL;
+      lastTestEnable_ = 0UL;
+      lastResync_ = 0UL;
+      lastStart_ = 0UL;
       lastEventCounter0_ = 0UL;
-      lastHardReset_     = 0UL;
-      spare0_            = 0ULL;
-      spare1_            = 0ULL;
-      spare2_            = 0ULL;
+      lastHardReset_ = 0UL;
+      spare0_ = 0ULL;
+      spare1_ = 0ULL;
+      spare2_ = 0ULL;
     }
   }
 }
 
-Level1TriggerScalers::~Level1TriggerScalers() { } 
+Level1TriggerScalers::~Level1TriggerScalers() {}
 
-double Level1TriggerScalers::rateLS(unsigned int counts)
-{ return(rateLS(counts,firstShortLSRun));}
+double Level1TriggerScalers::rateLS(unsigned int counts) { return (rateLS(counts, firstShortLSRun)); }
 
-double Level1TriggerScalers::rateLS(unsigned long long counts)
-{ return(rateLS(counts,firstShortLSRun));}
+double Level1TriggerScalers::rateLS(unsigned long long counts) { return (rateLS(counts, firstShortLSRun)); }
 
-double Level1TriggerScalers::rateLS(unsigned int counts,
-				    int runNumber)
-{ 
+double Level1TriggerScalers::rateLS(unsigned int counts, int runNumber) {
   unsigned long long counts64 = (unsigned long long)counts;
-  return(rateLS(counts64,runNumber));
+  return (rateLS(counts64, runNumber));
 }
 
-double Level1TriggerScalers::rateLS(unsigned long long counts,
-				    int runNumber)
-{ 
+double Level1TriggerScalers::rateLS(unsigned long long counts, int runNumber) {
   double rate;
-  if (( runNumber >= firstShortLSRun ) || ( runNumber <= 1 ))
-  {
+  if ((runNumber >= firstShortLSRun) || (runNumber <= 1)) {
     rate = ((double)counts) / 23.31040958083832;
-  }
-  else
-  {
+  } else {
     rate = ((double)counts) / 93.24163832335329;
   }
-  return(rate);
+  return (rate);
 }
 
-double Level1TriggerScalers::percentLS(unsigned long long counts)
-{ return(percentLS(counts,firstShortLSRun));}
+double Level1TriggerScalers::percentLS(unsigned long long counts) { return (percentLS(counts, firstShortLSRun)); }
 
-double Level1TriggerScalers::percentLS(unsigned long long counts,
-				       int runNumber)
-{ 
+double Level1TriggerScalers::percentLS(unsigned long long counts, int runNumber) {
   double percent;
-  if (( runNumber >= firstShortLSRun ) || ( runNumber <= 1 ))
-  {
-    percent = ((double)counts) /  9342812.16;
-  }
-  else
-  {
+  if ((runNumber >= firstShortLSRun) || (runNumber <= 1)) {
+    percent = ((double)counts) / 9342812.16;
+  } else {
     percent = ((double)counts) / 37371248.64;
   }
-  if ( percent > 100.0000 ) { percent = 100.0;}
-  return(percent);
+  if (percent > 100.0000) {
+    percent = 100.0;
+  }
+  return (percent);
 }
 
-double Level1TriggerScalers::percentLSActive(unsigned long long counts)
-{ return(percentLSActive(counts,firstShortLSRun));}
+double Level1TriggerScalers::percentLSActive(unsigned long long counts) {
+  return (percentLSActive(counts, firstShortLSRun));
+}
 
-double Level1TriggerScalers::percentLSActive(unsigned long long counts,
-				       int runNumber)
-{ 
+double Level1TriggerScalers::percentLSActive(unsigned long long counts, int runNumber) {
   double percent;
-  if (( runNumber >= firstShortLSRun ) || ( runNumber <= 1 ))
-  {
-    percent = ((double)counts) /  7361003.52;
-  }
-  else
-  {
+  if ((runNumber >= firstShortLSRun) || (runNumber <= 1)) {
+    percent = ((double)counts) / 7361003.52;
+  } else {
     percent = ((double)counts) / 29444014.08;
   }
-  if ( percent > 100.0000 ) { percent = 100.0;}
-  return(percent);
+  if (percent > 100.0000) {
+    percent = 100.0;
+  }
+  return (percent);
 }
 
 /// Pretty-print operator for Level1TriggerScalers
-std::ostream& operator<<(std::ostream& s,Level1TriggerScalers const &c) 
-{
-  s << "Level1TriggerScalers    Version:" << c.version() <<
-    "   SourceID: " << c.sourceID() << std::endl;
+std::ostream& operator<<(std::ostream& s, Level1TriggerScalers const& c) {
+  s << "Level1TriggerScalers    Version:" << c.version() << "   SourceID: " << c.sourceID() << std::endl;
   constexpr size_t kLineBufferSize = 164;
   char line[kLineBufferSize];
   char zeitHeaven[128];
-  struct tm * horaHeaven;
+  struct tm* horaHeaven;
 
-  snprintf(line, kLineBufferSize, " TrigType: %d   EventID: %d    BunchNumber: %d", 
-	  c.trigType(), c.eventID(), c.bunchNumber());
+  snprintf(line,
+           kLineBufferSize,
+           " TrigType: %d   EventID: %d    BunchNumber: %d",
+           c.trigType(),
+           c.eventID(),
+           c.bunchNumber());
   s << line << std::endl;
 
   struct timespec secondsToHeaven = c.collectionTime();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  snprintf(line, kLineBufferSize, " CollectionTime:        %s.%9.9d" , 
-	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTime:        %s.%9.9d", zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " LumiSegmentNr:        %10u   LumiSegmentOrbits:     %10u",
-	  c.lumiSegmentNr(), c.lumiSegmentOrbits());
+  snprintf(line,
+           kLineBufferSize,
+           " LumiSegmentNr:        %10u   LumiSegmentOrbits:     %10u",
+           c.lumiSegmentNr(),
+           c.lumiSegmentOrbits());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " LumiSegmentNrLumiSeg: %10u   OrbitNr:               %10u ",
-	  c.lumiSegmentNrLumiSeg(),  c.orbitNr());
+  snprintf(line,
+           kLineBufferSize,
+           " LumiSegmentNrLumiSeg: %10u   OrbitNr:               %10u ",
+           c.lumiSegmentNrLumiSeg(),
+           c.orbitNr());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " GtResets:             %10u   BunchCrossingErrors:   %10u",
-	  c.gtResets(), c.bunchCrossingErrors());
+  snprintf(line,
+           kLineBufferSize,
+           " GtResets:             %10u   BunchCrossingErrors:   %10u",
+           c.gtResets(),
+           c.bunchCrossingErrors());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize,
-	  " PrescaleIndexAlgo:    %10d   PrescaleIndexTech:     %10d",
-	  c.prescaleIndexAlgo(), c.prescaleIndexTech());
+  snprintf(line,
+           kLineBufferSize,
+           " PrescaleIndexAlgo:    %10d   PrescaleIndexTech:     %10d",
+           c.prescaleIndexAlgo(),
+           c.prescaleIndexTech());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " GtTriggers:                      %20llu %22.3f Hz", 
-	  c.gtTriggers(), c.gtTriggersRate());
+  snprintf(
+      line, kLineBufferSize, " GtTriggers:                      %20llu %22.3f Hz", c.gtTriggers(), c.gtTriggersRate());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " GtEvents:                        %20llu %22.3f Hz", 
-	  c.gtEvents(), c.gtEventsRate());
+  snprintf(line, kLineBufferSize, " GtEvents:                        %20llu %22.3f Hz", c.gtEvents(), c.gtEventsRate());
   s << line << std::endl;
 
   secondsToHeaven = c.collectionTimeLumiSeg();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  snprintf(line, kLineBufferSize, " CollectionTimeLumiSeg: %s.%9.9d" , 
-	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTimeLumiSeg: %s.%9.9d", zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
 
-
-  snprintf(line, kLineBufferSize, " TriggersPhysicsGeneratedFDL:     %20llu %22.3f Hz",
-	  c.triggersPhysicsGeneratedFDL(),
-	  Level1TriggerScalers::rateLS(c.triggersPhysicsGeneratedFDL()));
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersPhysicsGeneratedFDL:     %20llu %22.3f Hz",
+           c.triggersPhysicsGeneratedFDL(),
+           Level1TriggerScalers::rateLS(c.triggersPhysicsGeneratedFDL()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " TriggersPhysicsLost:             %20llu %22.3f Hz",
-	  c.triggersPhysicsLost(),
-	  Level1TriggerScalers::rateLS(c.triggersPhysicsLost()));
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersPhysicsLost:             %20llu %22.3f Hz",
+           c.triggersPhysicsLost(),
+           Level1TriggerScalers::rateLS(c.triggersPhysicsLost()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " TriggersPhysicsLostBeamActive:   %20llu %22.3f Hz",
-	  c.triggersPhysicsLostBeamActive(),
-	  Level1TriggerScalers::rateLS(c.triggersPhysicsLostBeamActive()));
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersPhysicsLostBeamActive:   %20llu %22.3f Hz",
+           c.triggersPhysicsLostBeamActive(),
+           Level1TriggerScalers::rateLS(c.triggersPhysicsLostBeamActive()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " TriggersPhysicsLostBeamInactive: %20llu %22.3f Hz",
-	  c.triggersPhysicsLostBeamInactive(),
-	  Level1TriggerScalers::rateLS(c.triggersPhysicsLostBeamInactive()));
+  snprintf(line,
+           kLineBufferSize,
+           " TriggersPhysicsLostBeamInactive: %20llu %22.3f Hz",
+           c.triggersPhysicsLostBeamInactive(),
+           Level1TriggerScalers::rateLS(c.triggersPhysicsLostBeamInactive()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " L1AsPhysics:                     %20llu %22.3f Hz",
-	  c.l1AsPhysics(),
-	  Level1TriggerScalers::rateLS(c.l1AsPhysics()));
+  snprintf(line,
+           kLineBufferSize,
+           " L1AsPhysics:                     %20llu %22.3f Hz",
+           c.l1AsPhysics(),
+           Level1TriggerScalers::rateLS(c.l1AsPhysics()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " L1AsRandom:                      %20llu %22.3f Hz",
-	  c.l1AsRandom(),
-	  Level1TriggerScalers::rateLS(c.l1AsRandom()));
+  snprintf(line,
+           kLineBufferSize,
+           " L1AsRandom:                      %20llu %22.3f Hz",
+           c.l1AsRandom(),
+           Level1TriggerScalers::rateLS(c.l1AsRandom()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " L1AsTest:                        %20llu %22.3f Hz",
-	  c.l1AsTest(),
-	  Level1TriggerScalers::rateLS(c.l1AsTest()));
+  snprintf(line,
+           kLineBufferSize,
+           " L1AsTest:                        %20llu %22.3f Hz",
+           c.l1AsTest(),
+           Level1TriggerScalers::rateLS(c.l1AsTest()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " L1AsCalibration:                 %20llu %22.3f Hz",
-	  c.l1AsCalibration(),
-	  Level1TriggerScalers::rateLS(c.l1AsCalibration()));
+  snprintf(line,
+           kLineBufferSize,
+           " L1AsCalibration:                 %20llu %22.3f Hz",
+           c.l1AsCalibration(),
+           Level1TriggerScalers::rateLS(c.l1AsCalibration()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " Deadtime:                             %20llu %17.3f%%",
-	  c.deadtime(),
-	  Level1TriggerScalers::percentLS(c.deadtime()));
+  snprintf(line,
+           kLineBufferSize,
+           " Deadtime:                             %20llu %17.3f%%",
+           c.deadtime(),
+           Level1TriggerScalers::percentLS(c.deadtime()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " DeadtimeBeamActive:                   %20llu %17.3f%%",
-	  c.deadtimeBeamActive(),
-	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActive()));
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActive:                   %20llu %17.3f%%",
+           c.deadtimeBeamActive(),
+           Level1TriggerScalers::percentLSActive(c.deadtimeBeamActive()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " DeadtimeBeamActiveTriggerRules:       %20llu %17.3f%%",
-	  c.deadtimeBeamActiveTriggerRules(),
-	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveTriggerRules()));
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActiveTriggerRules:       %20llu %17.3f%%",
+           c.deadtimeBeamActiveTriggerRules(),
+           Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveTriggerRules()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " DeadtimeBeamActiveCalibration:        %20llu %17.3f%%",
-	  c.deadtimeBeamActiveCalibration(),
-	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveCalibration()));
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActiveCalibration:        %20llu %17.3f%%",
+           c.deadtimeBeamActiveCalibration(),
+           Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveCalibration()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " DeadtimeBeamActivePrivateOrbit:       %20llu %17.3f%%",
-	  c.deadtimeBeamActivePrivateOrbit(),
-	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActivePrivateOrbit()));
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActivePrivateOrbit:       %20llu %17.3f%%",
+           c.deadtimeBeamActivePrivateOrbit(),
+           Level1TriggerScalers::percentLSActive(c.deadtimeBeamActivePrivateOrbit()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " DeadtimeBeamActivePartitionController:%20llu %17.3f%%",
-	  c.deadtimeBeamActivePartitionController(),
-	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActivePartitionController()));
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActivePartitionController:%20llu %17.3f%%",
+           c.deadtimeBeamActivePartitionController(),
+           Level1TriggerScalers::percentLSActive(c.deadtimeBeamActivePartitionController()));
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " DeadtimeBeamActiveTimeSlot:           %20llu %17.3f%%",
-	  c.deadtimeBeamActiveTimeSlot(),
-	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveTimeSlot()));
+  snprintf(line,
+           kLineBufferSize,
+           " DeadtimeBeamActiveTimeSlot:           %20llu %17.3f%%",
+           c.deadtimeBeamActiveTimeSlot(),
+           Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveTimeSlot()));
   s << line << std::endl;
 
   s << "Physics GtAlgoCounts" << std::endl;
   const std::vector<unsigned int> gtAlgoCounts = c.gtAlgoCounts();
   int length = gtAlgoCounts.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
-	    i,              gtAlgoCounts[i], 
-	    (i+length),     gtAlgoCounts[i+length], 
-	    (i+(length*2)), gtAlgoCounts[i+(length*2)], 
-	    (i+(length*3)), gtAlgoCounts[i+(length*3)]);
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
+             " %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
+             i,
+             gtAlgoCounts[i],
+             (i + length),
+             gtAlgoCounts[i + length],
+             (i + (length * 2)),
+             gtAlgoCounts[i + (length * 2)],
+             (i + (length * 3)),
+             gtAlgoCounts[i + (length * 3)]);
     s << line << std::endl;
   }
 
   s << "Test GtTechCounts" << std::endl;
   const std::vector<unsigned int> gtTechCounts = c.gtTechCounts();
   length = gtTechCounts.size() / 4;
-  for ( int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
-	    i,              gtTechCounts[i], 
-	    (i+length),     gtTechCounts[i+length], 
-	    (i+(length*2)), gtTechCounts[i+(length*2)], 
-	    (i+(length*3)), gtTechCounts[i+(length*3)]);
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
+             " %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
+             i,
+             gtTechCounts[i],
+             (i + length),
+             gtTechCounts[i + length],
+             (i + (length * 2)),
+             gtTechCounts[i + (length * 2)],
+             (i + (length * 3)),
+             gtTechCounts[i + (length * 3)]);
     s << line << std::endl;
   }
 
-  if ( c.version() >= 5 )
-  {
-    snprintf(line, kLineBufferSize," LastOrbitCounter0:  %10u  0x%8.8X", c.lastOrbitCounter0(),
-	    c.lastOrbitCounter0()); 
+  if (c.version() >= 5) {
+    snprintf(line, kLineBufferSize, " LastOrbitCounter0:  %10u  0x%8.8X", c.lastOrbitCounter0(), c.lastOrbitCounter0());
     s << line << std::endl;
-    
-    snprintf(line, kLineBufferSize," LastTestEnable:     %10u  0x%8.8X", c.lastTestEnable(),
-	    c.lastTestEnable()); 
+
+    snprintf(line, kLineBufferSize, " LastTestEnable:     %10u  0x%8.8X", c.lastTestEnable(), c.lastTestEnable());
     s << line << std::endl;
-    
-    snprintf(line, kLineBufferSize," LastResync:         %10u  0x%8.8X", c.lastResync(),
-	    c.lastResync()); 
+
+    snprintf(line, kLineBufferSize, " LastResync:         %10u  0x%8.8X", c.lastResync(), c.lastResync());
     s << line << std::endl;
-    
-    snprintf(line, kLineBufferSize," LastStart:          %10u  0x%8.8X", c.lastStart(),
-	    c.lastStart()); 
+
+    snprintf(line, kLineBufferSize, " LastStart:          %10u  0x%8.8X", c.lastStart(), c.lastStart());
     s << line << std::endl;
-    
-    snprintf(line, kLineBufferSize," LastEventCounter0:  %10u  0x%8.8X", c.lastEventCounter0(),
-	    c.lastEventCounter0()); 
+
+    snprintf(line, kLineBufferSize, " LastEventCounter0:  %10u  0x%8.8X", c.lastEventCounter0(), c.lastEventCounter0());
     s << line << std::endl;
-    
-    snprintf(line, kLineBufferSize," LastHardReset:      %10u  0x%8.8X", c.lastHardReset(),
-	    c.lastHardReset()); 
+
+    snprintf(line, kLineBufferSize, " LastHardReset:      %10u  0x%8.8X", c.lastHardReset(), c.lastHardReset());
     s << line << std::endl;
   }
 

--- a/DataFormats/Scalers/src/LumiScalers.cc
+++ b/DataFormats/Scalers/src/LumiScalers.cc
@@ -8,92 +8,82 @@
 #include <cstdio>
 #include <ostream>
 
-LumiScalers::LumiScalers() : 
-   trigType_(0),
-   eventID_(0),
-   sourceID_(0),
-   bunchNumber_(0),
-   version_(0),
-   normalization_(0.0),
-   deadTimeNormalization_(0.0),
-   lumiFill_(0.0),
-   lumiRun_(0.0),
-   liveLumiFill_(0.0),
-   liveLumiRun_(0.0),
-   instantLumi_(0.0),
-   instantLumiErr_(0.0),
-   instantLumiQlty_(0),
-   lumiETFill_(0.0),
-   lumiETRun_(0.0),
-   liveLumiETFill_(0.0),
-   liveLumiETRun_(0.0),
-   instantETLumi_(0.0),
-   instantETLumiErr_(0.0),
-   instantETLumiQlty_(0),
-   lumiOccFill_(nOcc),
-   lumiOccRun_(nOcc),
-   liveLumiOccFill_(nOcc),
-   liveLumiOccRun_(nOcc),
-   instantOccLumi_(nOcc),
-   instantOccLumiErr_(nOcc),
-   instantOccLumiQlty_(nOcc),
-   lumiNoise_(nOcc),
-   sectionNumber_(0),
-   startOrbit_(0),
-   numOrbits_(0),
-   pileup_(0.0),
-   pileupRMS_(0.0),
-   bunchLumi_(0.0),
-   spare_(0.0)
-{ 
-}
+LumiScalers::LumiScalers()
+    : trigType_(0),
+      eventID_(0),
+      sourceID_(0),
+      bunchNumber_(0),
+      version_(0),
+      normalization_(0.0),
+      deadTimeNormalization_(0.0),
+      lumiFill_(0.0),
+      lumiRun_(0.0),
+      liveLumiFill_(0.0),
+      liveLumiRun_(0.0),
+      instantLumi_(0.0),
+      instantLumiErr_(0.0),
+      instantLumiQlty_(0),
+      lumiETFill_(0.0),
+      lumiETRun_(0.0),
+      liveLumiETFill_(0.0),
+      liveLumiETRun_(0.0),
+      instantETLumi_(0.0),
+      instantETLumiErr_(0.0),
+      instantETLumiQlty_(0),
+      lumiOccFill_(nOcc),
+      lumiOccRun_(nOcc),
+      liveLumiOccFill_(nOcc),
+      liveLumiOccRun_(nOcc),
+      instantOccLumi_(nOcc),
+      instantOccLumiErr_(nOcc),
+      instantOccLumiQlty_(nOcc),
+      lumiNoise_(nOcc),
+      sectionNumber_(0),
+      startOrbit_(0),
+      numOrbits_(0),
+      pileup_(0.0),
+      pileupRMS_(0.0),
+      bunchLumi_(0.0),
+      spare_(0.0) {}
 
-LumiScalers::LumiScalers(const unsigned char * rawData)
-{ 
+LumiScalers::LumiScalers(const unsigned char* rawData) {
   LumiScalers();
 
-  struct ScalersEventRecordRaw_v1 const* raw 
-    = reinterpret_cast<struct ScalersEventRecordRaw_v1 const*>(rawData);
-  trigType_     = ( raw->header >> 56 ) &        0xFULL;
-  eventID_      = ( raw->header >> 32 ) & 0x00FFFFFFULL;
-  sourceID_     = ( raw->header >>  8 ) & 0x00000FFFULL;
-  bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
-  version_      = raw->version;
+  struct ScalersEventRecordRaw_v1 const* raw = reinterpret_cast<struct ScalersEventRecordRaw_v1 const*>(rawData);
+  trigType_ = (raw->header >> 56) & 0xFULL;
+  eventID_ = (raw->header >> 32) & 0x00FFFFFFULL;
+  sourceID_ = (raw->header >> 8) & 0x00000FFFULL;
+  bunchNumber_ = (raw->header >> 20) & 0xFFFULL;
+  version_ = raw->version;
 
-  struct LumiScalersRaw_v1 const * lumi = nullptr;
+  struct LumiScalersRaw_v1 const* lumi = nullptr;
 
-  if ( version_ >= 1 )
-  {
-    if ( version_ <= 2 )
-    {
-      lumi = & (raw->lumi);
-    }
-    else 
-    {
-      struct ScalersEventRecordRaw_v3 const* raw3 
-	= reinterpret_cast<struct ScalersEventRecordRaw_v3 const*>(rawData);
-      lumi = & (raw3->lumi);
+  if (version_ >= 1) {
+    if (version_ <= 2) {
+      lumi = &(raw->lumi);
+    } else {
+      struct ScalersEventRecordRaw_v3 const* raw3 = reinterpret_cast<struct ScalersEventRecordRaw_v3 const*>(rawData);
+      lumi = &(raw3->lumi);
     }
     collectionTime_.set_tv_sec(static_cast<long>(lumi->collectionTime_sec));
     collectionTime_.set_tv_nsec(lumi->collectionTime_nsec);
-    deadTimeNormalization_  = lumi->DeadtimeNormalization;
-    normalization_          = lumi->Normalization;
-    lumiFill_               = lumi->LumiFill;
-    lumiRun_                = lumi->LumiRun;
-    liveLumiFill_           = lumi->LiveLumiFill;
-    liveLumiRun_            = lumi->LiveLumiRun;
-    instantLumi_            = lumi->InstantLumi;
-    instantLumiErr_         = lumi->InstantLumiErr;
-    instantLumiQlty_        = lumi->InstantLumiQlty;
-    lumiETFill_             = lumi->LumiETFill;
-    lumiETRun_              = lumi->LumiETRun;
-    liveLumiETFill_         = lumi->LiveLumiETFill;
-    liveLumiETRun_          = lumi->LiveLumiETRun;
-    instantETLumi_          = lumi->InstantETLumi;
-    instantETLumiErr_       = lumi->InstantETLumiErr;
-    instantETLumiQlty_      = lumi->InstantETLumiQlty;
-    for ( int i=0; i<ScalersRaw::N_LUMI_OCC_v1; i++)
-    {
+    deadTimeNormalization_ = lumi->DeadtimeNormalization;
+    normalization_ = lumi->Normalization;
+    lumiFill_ = lumi->LumiFill;
+    lumiRun_ = lumi->LumiRun;
+    liveLumiFill_ = lumi->LiveLumiFill;
+    liveLumiRun_ = lumi->LiveLumiRun;
+    instantLumi_ = lumi->InstantLumi;
+    instantLumiErr_ = lumi->InstantLumiErr;
+    instantLumiQlty_ = lumi->InstantLumiQlty;
+    lumiETFill_ = lumi->LumiETFill;
+    lumiETRun_ = lumi->LumiETRun;
+    liveLumiETFill_ = lumi->LiveLumiETFill;
+    liveLumiETRun_ = lumi->LiveLumiETRun;
+    instantETLumi_ = lumi->InstantETLumi;
+    instantETLumiErr_ = lumi->InstantETLumiErr;
+    instantETLumiQlty_ = lumi->InstantETLumiQlty;
+    for (int i = 0; i < ScalersRaw::N_LUMI_OCC_v1; i++) {
       lumiOccFill_.push_back(lumi->LumiOccFill[i]);
       lumiOccRun_.push_back(lumi->LumiOccRun[i]);
       liveLumiOccFill_.push_back(lumi->LiveLumiOccFill[i]);
@@ -104,127 +94,141 @@ LumiScalers::LumiScalers(const unsigned char * rawData)
       lumiNoise_.push_back(lumi->lumiNoise[i]);
     }
     sectionNumber_ = lumi->sectionNumber;
-    startOrbit_    = lumi->startOrbit;
-    numOrbits_     = lumi->numOrbits;
+    startOrbit_ = lumi->startOrbit;
+    numOrbits_ = lumi->numOrbits;
 
-    if ( version_ >= 7 )
-    {
-      struct ScalersEventRecordRaw_v6 const * raw6 
-	= (struct ScalersEventRecordRaw_v6 const *)rawData;
-      float const* fspare = reinterpret_cast<float const*>( raw6->spare);
-      pileup_    = fspare[ScalersRaw::I_SPARE_PILEUP_v7];
+    if (version_ >= 7) {
+      struct ScalersEventRecordRaw_v6 const* raw6 = (struct ScalersEventRecordRaw_v6 const*)rawData;
+      float const* fspare = reinterpret_cast<float const*>(raw6->spare);
+      pileup_ = fspare[ScalersRaw::I_SPARE_PILEUP_v7];
       pileupRMS_ = fspare[ScalersRaw::I_SPARE_PILEUPRMS_v7];
-      if ( version_ >= 8 )
-      {
-	bunchLumi_ = fspare[ScalersRaw::I_SPARE_BUNCHLUMI_v8];
-	spare_     = fspare[ScalersRaw::I_SPARE_SPARE_v8];
+      if (version_ >= 8) {
+        bunchLumi_ = fspare[ScalersRaw::I_SPARE_BUNCHLUMI_v8];
+        spare_ = fspare[ScalersRaw::I_SPARE_SPARE_v8];
+      } else {
+        bunchLumi_ = (float)0.0;
+        spare_ = (float)0.0;
       }
-      else
-      {
-	bunchLumi_ = (float)0.0; 
-	spare_     = (float)0.0;
-     }
-    }
-    else
-    {
-      pileup_    = (float)0.0;
+    } else {
+      pileup_ = (float)0.0;
       pileupRMS_ = (float)0.0;
       bunchLumi_ = (float)0.0;
-      spare_     = (float)0.0;
+      spare_ = (float)0.0;
     }
   }
 }
 
-LumiScalers::~LumiScalers() { } 
-
+LumiScalers::~LumiScalers() {}
 
 /// Pretty-print operator for LumiScalers
-std::ostream& operator<<(std::ostream& s, const LumiScalers& c) 
-{
+std::ostream& operator<<(std::ostream& s, const LumiScalers& c) {
   char zeit[128];
   constexpr size_t kLineBufferSize = 157;
   char line[kLineBufferSize];
-  struct tm * hora;
+  struct tm* hora;
 
-  s << "LumiScalers    Version: " << c.version() << 
-    "   SourceID: "<< c.sourceID() << std::endl;
+  s << "LumiScalers    Version: " << c.version() << "   SourceID: " << c.sourceID() << std::endl;
 
   timespec ts = c.collectionTime();
   hora = gmtime(&ts.tv_sec);
   strftime(zeit, sizeof(zeit), "%Y.%m.%d %H:%M:%S", hora);
-  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, 
-	  (int)ts.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, (int)ts.tv_nsec);
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize, " TrigType: %d   EventID: %d    BunchNumber: %d", 
-	  c.trigType(), c.eventID(), c.bunchNumber());
+  snprintf(line,
+           kLineBufferSize,
+           " TrigType: %d   EventID: %d    BunchNumber: %d",
+           c.trigType(),
+           c.eventID(),
+           c.bunchNumber());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize," SectionNumber: %10d   StartOrbit: %10d  NumOrbits: %10d",
-	  c.sectionNumber(), c.startOrbit(), c.numOrbits());
+  snprintf(line,
+           kLineBufferSize,
+           " SectionNumber: %10d   StartOrbit: %10d  NumOrbits: %10d",
+           c.sectionNumber(),
+           c.startOrbit(),
+           c.numOrbits());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize," Normalization: %e  DeadTimeNormalization: %e",
-	  c.normalization(), c.deadTimeNormalization());
+  snprintf(line,
+           kLineBufferSize,
+           " Normalization: %e  DeadTimeNormalization: %e",
+           c.normalization(),
+           c.deadTimeNormalization());
   s << line << std::endl;
 
   // Integrated Luminosity
 
-  snprintf(line, kLineBufferSize," LumiFill:            %e   LumiRun:            %e", 
-	  c.lumiFill(), c.lumiRun());
+  snprintf(line, kLineBufferSize, " LumiFill:            %e   LumiRun:            %e", c.lumiFill(), c.lumiRun());
   s << line << std::endl;
-  snprintf(line, kLineBufferSize," LiveLumiFill:        %e   LiveLumiRun:        %e", 
-	  c.liveLumiFill(), c.liveLumiRun());
-  s << line << std::endl;
-
-  snprintf(line, kLineBufferSize," LumiETFill:          %e   LumiETRun:          %e", 
-	  c.lumiFill(), c.lumiRun());
+  snprintf(
+      line, kLineBufferSize, " LiveLumiFill:        %e   LiveLumiRun:        %e", c.liveLumiFill(), c.liveLumiRun());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize," LiveLumiETFill:      %e   LiveLumETiRun:      %e", 
-	  c.liveLumiETFill(), c.liveLumiETRun());
+  snprintf(line, kLineBufferSize, " LumiETFill:          %e   LumiETRun:          %e", c.lumiFill(), c.lumiRun());
+  s << line << std::endl;
+
+  snprintf(
+      line, kLineBufferSize, " LiveLumiETFill:      %e   LiveLumETiRun:      %e", c.liveLumiETFill(), c.liveLumiETRun());
   s << line << std::endl;
 
   int length = c.instantOccLumi().size();
-  for (int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize,
-	       " LumiOccFill[%d]:      %e   LumiOccRun[%d]:      %e", 
-	    i, c.lumiOccFill()[i], i, c.lumiOccRun()[i]);
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
+             " LumiOccFill[%d]:      %e   LumiOccRun[%d]:      %e",
+             i,
+             c.lumiOccFill()[i],
+             i,
+             c.lumiOccRun()[i]);
     s << line << std::endl;
 
-    snprintf(line, kLineBufferSize,
-	       " LiveLumiOccFill[%d]:  %e   LiveLumiOccRun[%d]:  %e", 
-	    i, c.liveLumiOccFill()[i], i, c.liveLumiOccRun()[i]);
+    snprintf(line,
+             kLineBufferSize,
+             " LiveLumiOccFill[%d]:  %e   LiveLumiOccRun[%d]:  %e",
+             i,
+             c.liveLumiOccFill()[i],
+             i,
+             c.liveLumiOccRun()[i]);
     s << line << std::endl;
   }
 
   // Instantaneous Luminosity
 
-  snprintf(line, kLineBufferSize," InstantLumi:       %e  Err: %e  Qlty: %d",
-	  c.instantLumi(), c.instantLumiErr(), c.instantLumiQlty());
+  snprintf(line,
+           kLineBufferSize,
+           " InstantLumi:       %e  Err: %e  Qlty: %d",
+           c.instantLumi(),
+           c.instantLumiErr(),
+           c.instantLumiQlty());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize," InstantETLumi:     %e  Err: %e  Qlty: %d",
-	  c.instantETLumi(), c.instantETLumiErr(), c.instantETLumiQlty());
+  snprintf(line,
+           kLineBufferSize,
+           " InstantETLumi:     %e  Err: %e  Qlty: %d",
+           c.instantETLumi(),
+           c.instantETLumiErr(),
+           c.instantETLumiQlty());
   s << line << std::endl;
 
-  for (int i=0; i<length; i++)
-  {
-    snprintf(line, kLineBufferSize," InstantOccLumi[%d]: %e  Err: %e  Qlty: %d",
-	    i, c.instantOccLumi()[i], c.instantOccLumiErr()[i], 
-	    c.instantOccLumiQlty()[i]);
+  for (int i = 0; i < length; i++) {
+    snprintf(line,
+             kLineBufferSize,
+             " InstantOccLumi[%d]: %e  Err: %e  Qlty: %d",
+             i,
+             c.instantOccLumi()[i],
+             c.instantOccLumiErr()[i],
+             c.instantOccLumiQlty()[i]);
     s << line << std::endl;
-    snprintf(line, kLineBufferSize,"      LumiNoise[%d]: %e", i, c.lumiNoise()[i]);
+    snprintf(line, kLineBufferSize, "      LumiNoise[%d]: %e", i, c.lumiNoise()[i]);
     s << line << std::endl;
   }
 
-  snprintf(line, kLineBufferSize," Pileup: %f       PileupRMS: %f", 
-	  c.pileup(), c.pileupRMS());
+  snprintf(line, kLineBufferSize, " Pileup: %f       PileupRMS: %f", c.pileup(), c.pileupRMS());
   s << line << std::endl;
 
-  snprintf(line, kLineBufferSize," BunchLumi: %f    Spare: %f", 
-	   c.bunchLumi(), c.spare());
+  snprintf(line, kLineBufferSize, " BunchLumi: %f    Spare: %f", c.bunchLumi(), c.spare());
   s << line << std::endl;
 
   return s;

--- a/DataFormats/Scalers/src/classes.h
+++ b/DataFormats/Scalers/src/classes.h
@@ -13,4 +13,3 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
-

--- a/DataFormats/Scalers/test/ScalersTest.cpp
+++ b/DataFormats/Scalers/test/ScalersTest.cpp
@@ -1,7 +1,7 @@
 //
 // File: ScalersTest.cpp         (W.Badgett)
 //
-// Program to test Scalers RawToDigi conversion from binary raw 
+// Program to test Scalers RawToDigi conversion from binary raw
 // data file
 //
 
@@ -9,7 +9,6 @@
 #include "DataFormats/Scalers/interface/L1TriggerRates.h"
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 #include "DataFormats/Scalers/interface/ScalersRaw.h"
-
 
 #include <iostream>
 #include <math.h>
@@ -20,72 +19,52 @@
 #include <cstring>
 #include <unistd.h>
 
-const char * fileName = "scalers.dat";
+const char *fileName = "scalers.dat";
 
-int main(int argc, char** argv)
-{
-  unsigned char buffer [sizeof(struct ScalersEventRecordRaw_v1)];
+int main(int argc, char **argv) {
+  unsigned char buffer[sizeof(struct ScalersEventRecordRaw_v1)];
   int ctr = 0;
   int retcod;
   int bytes = 1;
   const L1TriggerScalers *previousTrig = NULL;
   int fd = open(fileName, O_RDONLY);
 
-  if ( fd > 0 )
-  {
-    while ( bytes > 0 )
-    {
-      bytes = read(fd,buffer,sizeof(struct ScalersEventRecordRaw_v1));
-      if ( bytes <= 0 )
-      {
-	retcod = errno;
-	if ( retcod == 0 )
-	{
-	  printf("Finished reading file %s with %d events\n", fileName,
-		 ctr);
-	}
-	else
-	{
-	  printf("Error %s reading file %s\n", fileName,
-		 strerror(errno));
-	}
-      }
-      else
-      {
-	ctr++;
-	printf("\n******* Event %d Read %d bytes from %s *******\n", 
-	       ctr, bytes, fileName);
-	const L1TriggerScalers *trig = new L1TriggerScalers(buffer);
-	std::cout << *trig;
+  if (fd > 0) {
+    while (bytes > 0) {
+      bytes = read(fd, buffer, sizeof(struct ScalersEventRecordRaw_v1));
+      if (bytes <= 0) {
+        retcod = errno;
+        if (retcod == 0) {
+          printf("Finished reading file %s with %d events\n", fileName, ctr);
+        } else {
+          printf("Error %s reading file %s\n", fileName, strerror(errno));
+        }
+      } else {
+        ctr++;
+        printf("\n******* Event %d Read %d bytes from %s *******\n", ctr, bytes, fileName);
+        const L1TriggerScalers *trig = new L1TriggerScalers(buffer);
+        std::cout << *trig;
 
-	if ( ctr > 1 )
-	{
-	  const L1TriggerScalers *previousTrigSave = previousTrig;
-	  if ( previousTrig->orbitNumber() <
-	       trig->orbitNumber() )
-	  {
-	    L1TriggerRates rates(*previousTrig,*trig);
-	    std::cout << std::endl;
-	    std::cout << rates;
-	    previousTrig = trig;
-	  }
-	  delete(previousTrigSave);
-	}
-	else
-	{
-	  previousTrig = trig;
-	}
-	std::cout << std::endl;
-	LumiScalers lumi(buffer);
-	std::cout << lumi;
+        if (ctr > 1) {
+          const L1TriggerScalers *previousTrigSave = previousTrig;
+          if (previousTrig->orbitNumber() < trig->orbitNumber()) {
+            L1TriggerRates rates(*previousTrig, *trig);
+            std::cout << std::endl;
+            std::cout << rates;
+            previousTrig = trig;
+          }
+          delete (previousTrigSave);
+        } else {
+          previousTrig = trig;
+        }
+        std::cout << std::endl;
+        LumiScalers lumi(buffer);
+        std::cout << lumi;
       }
     }
     close(fd);
-  }
-  else
-  {
-    printf("Error %s opening file %s\n", fileName,
-	   strerror(errno));
+  } else {
+    printf("Error %s opening file %s\n", fileName, strerror(errno));
   }
   return 0;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category daq,l1,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/369//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


