### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/CommonTools/UtilAlgos/interface/AndPairSelector.h
+++ b/CommonTools/UtilAlgos/interface/AndPairSelector.h
@@ -5,17 +5,16 @@
 
 namespace reco {
   namespace modules {
-    
-    template<typename S1, typename S2>
+
+    template <typename S1, typename S2>
     struct ParameterAdapter<AndPairSelector<S1, S2> > {
-      static AndPairSelector<S1, S2> make(const edm::ParameterSet & cfg) {
-	return AndPairSelector<S1, S2>(modules::make<S1>(cfg.getParameter<edm::ParameterSet>("cut1")), 
-				       modules::make<S2>(cfg.getParameter<edm::ParameterSet>("cut2"))); 
+      static AndPairSelector<S1, S2> make(const edm::ParameterSet& cfg) {
+        return AndPairSelector<S1, S2>(modules::make<S1>(cfg.getParameter<edm::ParameterSet>("cut1")),
+                                       modules::make<S2>(cfg.getParameter<edm::ParameterSet>("cut2")));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/AndSelector.h
+++ b/CommonTools/UtilAlgos/interface/AndSelector.h
@@ -8,28 +8,28 @@
 namespace reco {
   namespace modules {
 
-    template<typename S1, typename S2, typename S3, typename S4, typename S5>
+    template <typename S1, typename S2, typename S3, typename S4, typename S5>
     struct ParameterAdapter<AndSelector<S1, S2, S3, S4, S5> > {
-      static AndSelector<S1, S2, S3, S4, S5> make( const edm::ParameterSet & cfg ) {
-	return AndSelector<S1, S2, S3, S4, S5>( modules::make<S1>( cfg ),
-						modules::make<S2>( cfg ),
-						modules::make<S3>( cfg ),
-						modules::make<S4>( cfg ),
-						modules::make<S5>( cfg ) );
+      static AndSelector<S1, S2, S3, S4, S5> make(const edm::ParameterSet& cfg) {
+        return AndSelector<S1, S2, S3, S4, S5>(modules::make<S1>(cfg),
+                                               modules::make<S2>(cfg),
+                                               modules::make<S3>(cfg),
+                                               modules::make<S4>(cfg),
+                                               modules::make<S5>(cfg));
       }
-      static AndSelector<S1, S2, S3, S4, S5> make( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) {
-	return AndSelector<S1, S2, S3, S4, S5>( modules::make<S1>( cfg, iC ),
-						modules::make<S2>( cfg, iC ),
-						modules::make<S3>( cfg, iC ),
-						modules::make<S4>( cfg, iC ),
-						modules::make<S5>( cfg, iC ) );
+      static AndSelector<S1, S2, S3, S4, S5> make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
+        return AndSelector<S1, S2, S3, S4, S5>(modules::make<S1>(cfg, iC),
+                                               modules::make<S2>(cfg, iC),
+                                               modules::make<S3>(cfg, iC),
+                                               modules::make<S4>(cfg, iC),
+                                               modules::make<S5>(cfg, iC));
       }
-      static AndSelector<S1, S2, S3, S4, S5> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return AndSelector<S1, S2, S3, S4, S5>( modules::make<S1>( cfg, iC ),
-						modules::make<S2>( cfg, iC ),
-						modules::make<S3>( cfg, iC ),
-						modules::make<S4>( cfg, iC ),
-						modules::make<S5>( cfg, iC ) );
+      static AndSelector<S1, S2, S3, S4, S5> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return AndSelector<S1, S2, S3, S4, S5>(modules::make<S1>(cfg, iC),
+                                               modules::make<S2>(cfg, iC),
+                                               modules::make<S3>(cfg, iC),
+                                               modules::make<S4>(cfg, iC),
+                                               modules::make<S5>(cfg, iC));
       }
 
       static void fillPSetDescription(edm::ParameterSetDescription& desc) {
@@ -41,25 +41,23 @@ namespace reco {
       }
     };
 
-    template<typename S1, typename S2, typename S3, typename S4>
+    template <typename S1, typename S2, typename S3, typename S4>
     struct ParameterAdapter<AndSelector<S1, S2, S3, S4> > {
-      static AndSelector<S1, S2, S3, S4> make( const edm::ParameterSet & cfg ) {
-	return AndSelector<S1, S2, S3, S4>( modules::make<S1>( cfg ),
-					    modules::make<S2>( cfg ),
-					    modules::make<S3>( cfg ),
-					    modules::make<S4>( cfg ) );
+      static AndSelector<S1, S2, S3, S4> make(const edm::ParameterSet& cfg) {
+        return AndSelector<S1, S2, S3, S4>(
+            modules::make<S1>(cfg), modules::make<S2>(cfg), modules::make<S3>(cfg), modules::make<S4>(cfg));
       }
-      static AndSelector<S1, S2, S3, S4> make( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) {
-	return AndSelector<S1, S2, S3, S4>( modules::make<S1>( cfg, iC ),
-					    modules::make<S2>( cfg, iC ),
-					    modules::make<S3>( cfg, iC ),
-					    modules::make<S4>( cfg, iC ) );
+      static AndSelector<S1, S2, S3, S4> make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
+        return AndSelector<S1, S2, S3, S4>(modules::make<S1>(cfg, iC),
+                                           modules::make<S2>(cfg, iC),
+                                           modules::make<S3>(cfg, iC),
+                                           modules::make<S4>(cfg, iC));
       }
-      static AndSelector<S1, S2, S3, S4> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return AndSelector<S1, S2, S3, S4>( modules::make<S1>( cfg, iC ),
-					    modules::make<S2>( cfg, iC ),
-					    modules::make<S3>( cfg, iC ),
-					    modules::make<S4>( cfg, iC ) );
+      static AndSelector<S1, S2, S3, S4> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return AndSelector<S1, S2, S3, S4>(modules::make<S1>(cfg, iC),
+                                           modules::make<S2>(cfg, iC),
+                                           modules::make<S3>(cfg, iC),
+                                           modules::make<S4>(cfg, iC));
       }
 
       static void fillPSetDescription(edm::ParameterSetDescription& desc) {
@@ -70,22 +68,18 @@ namespace reco {
       }
     };
 
-    template<typename S1, typename S2, typename S3>
+    template <typename S1, typename S2, typename S3>
     struct ParameterAdapter<AndSelector<S1, S2, S3> > {
-      static AndSelector<S1, S2, S3> make( const edm::ParameterSet & cfg ) {
-	return AndSelector<S1, S2, S3>( modules::make<S1>( cfg ),
-					modules::make<S2>( cfg ),
-					modules::make<S3>( cfg ) );
+      static AndSelector<S1, S2, S3> make(const edm::ParameterSet& cfg) {
+        return AndSelector<S1, S2, S3>(modules::make<S1>(cfg), modules::make<S2>(cfg), modules::make<S3>(cfg));
       }
-      static AndSelector<S1, S2, S3> make( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) {
-	return AndSelector<S1, S2, S3>( modules::make<S1>( cfg, iC ),
-					modules::make<S2>( cfg, iC ),
-					modules::make<S3>( cfg, iC ) );
+      static AndSelector<S1, S2, S3> make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
+        return AndSelector<S1, S2, S3>(
+            modules::make<S1>(cfg, iC), modules::make<S2>(cfg, iC), modules::make<S3>(cfg, iC));
       }
-      static AndSelector<S1, S2, S3> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return AndSelector<S1, S2, S3>( modules::make<S1>( cfg, iC ),
-					modules::make<S2>( cfg, iC ),
-					modules::make<S3>( cfg, iC ) );
+      static AndSelector<S1, S2, S3> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return AndSelector<S1, S2, S3>(
+            modules::make<S1>(cfg, iC), modules::make<S2>(cfg, iC), modules::make<S3>(cfg, iC));
       }
 
       static void fillPSetDescription(edm::ParameterSetDescription& desc) {
@@ -95,19 +89,16 @@ namespace reco {
       }
     };
 
-    template<typename S1, typename S2>
+    template <typename S1, typename S2>
     struct ParameterAdapter<AndSelector<S1, S2> > {
-      static AndSelector<S1, S2> make( const edm::ParameterSet & cfg ) {
-	return AndSelector<S1, S2>( modules::make<S1>( cfg ),
-				    modules::make<S2>( cfg ) );
+      static AndSelector<S1, S2> make(const edm::ParameterSet& cfg) {
+        return AndSelector<S1, S2>(modules::make<S1>(cfg), modules::make<S2>(cfg));
       }
-      static AndSelector<S1, S2> make( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) {
-	return AndSelector<S1, S2>( modules::make<S1>( cfg, iC ),
-				    modules::make<S2>( cfg, iC ) );
+      static AndSelector<S1, S2> make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
+        return AndSelector<S1, S2>(modules::make<S1>(cfg, iC), modules::make<S2>(cfg, iC));
       }
-      static AndSelector<S1, S2> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return AndSelector<S1, S2>( modules::make<S1>( cfg, iC ),
-				    modules::make<S2>( cfg, iC ) );
+      static AndSelector<S1, S2> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return AndSelector<S1, S2>(modules::make<S1>(cfg, iC), modules::make<S2>(cfg, iC));
       }
 
       static void fillPSetDescription(edm::ParameterSetDescription& desc) {
@@ -116,8 +107,7 @@ namespace reco {
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/AnyPairSelector.h
+++ b/CommonTools/UtilAlgos/interface/AnyPairSelector.h
@@ -5,16 +5,13 @@
 
 namespace reco {
   namespace modules {
-    
-    template<>
+
+    template <>
     struct ParameterAdapter<AnyPairSelector> {
-      static AnyPairSelector make( const edm::ParameterSet & cfg ) {
-	return AnyPairSelector();
-      }
+      static AnyPairSelector make(const edm::ParameterSet& cfg) { return AnyPairSelector(); }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/AnySelector.h
+++ b/CommonTools/UtilAlgos/interface/AnySelector.h
@@ -8,23 +8,16 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<AnySelector> {
-      static AnySelector make( const edm::ParameterSet & cfg ) {
-	return AnySelector();
-      }
-      static AnySelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) {
-	return AnySelector();
-      }
-      static AnySelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return AnySelector();
-      }
+      static AnySelector make(const edm::ParameterSet& cfg) { return AnySelector(); }
+      static AnySelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) { return AnySelector(); }
+      static AnySelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) { return AnySelector(); }
 
       static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h
+++ b/CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h
@@ -13,11 +13,12 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-template<typename CKey, typename CVal>
+template <typename CKey, typename CVal>
 class AssociationMapOneToOne2Association : public edm::EDProducer {
- public:
+public:
   AssociationMapOneToOne2Association(const edm::ParameterSet&);
- private:
+
+private:
   typedef edm::AssociationMap<edm::OneToOne<CKey, CVal> > am_t;
   typedef edm::Association<CVal> as_t;
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -30,13 +31,13 @@ class AssociationMapOneToOne2Association : public edm::EDProducer {
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "DataFormats/Common/interface/CloneTrait.h"
 
-template<typename CKey, typename CVal>
-AssociationMapOneToOne2Association<CKey, CVal>::AssociationMapOneToOne2Association(const edm::ParameterSet& cfg) :
-  am_(consumes<am_t>(cfg.template getParameter<edm::InputTag>("src"))) {
+template <typename CKey, typename CVal>
+AssociationMapOneToOne2Association<CKey, CVal>::AssociationMapOneToOne2Association(const edm::ParameterSet& cfg)
+    : am_(consumes<am_t>(cfg.template getParameter<edm::InputTag>("src"))) {
   produces<as_t>();
 }
 
-template<typename CKey, typename CVal>
+template <typename CKey, typename CVal>
 void AssociationMapOneToOne2Association<CKey, CVal>::produce(edm::Event& evt, const edm::EventSetup&) {
   using namespace edm;
   using namespace std;
@@ -49,7 +50,7 @@ void AssociationMapOneToOne2Association<CKey, CVal>::produce(edm::Event& evt, co
   size_t size = am->size();
   vector<int> indices;
   indices.reserve(size);
-  for(typename am_t::const_iterator i = am->begin(); i != am->end(); ++i) {
+  for (typename am_t::const_iterator i = am->begin(); i != am->end(); ++i) {
     indices.push_back(i->val.key());
   }
   filler.insert(am->refProd().key, indices.begin(), indices.end());

--- a/CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h
+++ b/CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h
@@ -12,11 +12,12 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-template<typename KeyRefProd, typename CVal>
+template <typename KeyRefProd, typename CVal>
 class AssociationVector2ValueMap : public edm::EDProducer {
- public:
+public:
   AssociationVector2ValueMap(const edm::ParameterSet&);
- private:
+
+private:
   typedef edm::AssociationVector<KeyRefProd, CVal> av_t;
   typedef typename CVal::value_type value_t;
   typedef edm::ValueMap<value_t> vm_t;
@@ -31,13 +32,13 @@ class AssociationVector2ValueMap : public edm::EDProducer {
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "DataFormats/Common/interface/CloneTrait.h"
 
-template<typename KeyRefProd, typename CVal>
-AssociationVector2ValueMap<KeyRefProd, CVal>::AssociationVector2ValueMap(const edm::ParameterSet& cfg) :
-  av_(consumes<av_t>(cfg.template getParameter<edm::InputTag>("src"))) {
+template <typename KeyRefProd, typename CVal>
+AssociationVector2ValueMap<KeyRefProd, CVal>::AssociationVector2ValueMap(const edm::ParameterSet& cfg)
+    : av_(consumes<av_t>(cfg.template getParameter<edm::InputTag>("src"))) {
   produces<vm_t>();
 }
 
-template<typename KeyRefProd, typename CVal>
+template <typename KeyRefProd, typename CVal>
 void AssociationVector2ValueMap<KeyRefProd, CVal>::produce(edm::Event& evt, const edm::EventSetup&) {
   using namespace edm;
   using namespace std;
@@ -50,7 +51,7 @@ void AssociationVector2ValueMap<KeyRefProd, CVal>::produce(edm::Event& evt, cons
   size_t size = av->size();
   vector<value_t> values;
   values.reserve(size);
-  for(typename av_t::const_iterator i = av->begin(); i != av->end(); ++i) {
+  for (typename av_t::const_iterator i = av->begin(); i != av->end(); ++i) {
     values.push_back(i->second);
   }
   filler.insert(av->keyProduct(), values.begin(), values.end());

--- a/CommonTools/UtilAlgos/interface/AssociationVectorSelector.h
+++ b/CommonTools/UtilAlgos/interface/AssociationVectorSelector.h
@@ -12,12 +12,12 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/UtilAlgos/interface/AnySelector.h"
 
-template<typename KeyRefProd, typename CVal,
-	 typename KeySelector = AnySelector, typename ValSelector = AnySelector>
+template <typename KeyRefProd, typename CVal, typename KeySelector = AnySelector, typename ValSelector = AnySelector>
 class AssociationVectorSelector : public edm::EDProducer {
- public:
+public:
   AssociationVectorSelector(const edm::ParameterSet&);
- private:
+
+private:
   typedef edm::AssociationVector<KeyRefProd, CVal> association_t;
   typedef typename association_t::CKey collection_t;
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -32,18 +32,20 @@ class AssociationVectorSelector : public edm::EDProducer {
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "DataFormats/Common/interface/CloneTrait.h"
 
-template<typename KeyRefProd, typename CVal, typename KeySelector, typename ValSelector>
-AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::AssociationVectorSelector(const edm::ParameterSet& cfg) :
-  associationToken_(consumes<association_t>(cfg.template getParameter<edm::InputTag>("association"))),
-  selectKey_(reco::modules::make<KeySelector>(cfg, consumesCollector())),
-  selectVal_(reco::modules::make<ValSelector>(cfg, consumesCollector())) {
+template <typename KeyRefProd, typename CVal, typename KeySelector, typename ValSelector>
+AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::AssociationVectorSelector(
+    const edm::ParameterSet& cfg)
+    : associationToken_(consumes<association_t>(cfg.template getParameter<edm::InputTag>("association"))),
+      selectKey_(reco::modules::make<KeySelector>(cfg, consumesCollector())),
+      selectVal_(reco::modules::make<ValSelector>(cfg, consumesCollector())) {
   std::string alias(cfg.template getParameter<std::string>("@module_label"));
   produces<collection_t>().setBranchAlias(alias);
   produces<association_t>().setBranchAlias(alias + "Association");
 }
 
-template<typename KeyRefProd, typename CVal, typename KeySelector, typename ValSelector>
-void AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::produce(edm::Event& evt, const edm::EventSetup&) {
+template <typename KeyRefProd, typename CVal, typename KeySelector, typename ValSelector>
+void AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::produce(edm::Event& evt,
+                                                                                    const edm::EventSetup&) {
   using namespace edm;
   using namespace std;
   Handle<association_t> association;
@@ -53,10 +55,9 @@ void AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::prod
   size_t size = association->size();
   selected->reserve(size);
   selectedValues.reserve(size);
-  for(typename association_t::const_iterator i = association->begin();
-      i != association->end(); ++i) {
-    const typename association_t::key_type & obj = * i->first;
-    if(selectKey_(obj)&&selectVal_(i->second)) {
+  for (typename association_t::const_iterator i = association->begin(); i != association->end(); ++i) {
+    const typename association_t::key_type& obj = *i->first;
+    if (selectKey_(obj) && selectVal_(i->second)) {
       typedef typename edm::clonehelper::CloneTrait<collection_t>::type clone_t;
       selected->push_back(clone_t::clone(obj));
       selectedValues.push_back(i->second);
@@ -68,7 +69,7 @@ void AssociationVectorSelector<KeyRefProd, CVal, KeySelector, ValSelector>::prod
   unique_ptr<association_t> selectedAssociation(new association_t(ref, selected.get()));
   size = selected->size();
   OrphanHandle<collection_t> oh = evt.put(std::move(selected));
-  for(size_t i = 0; i != size; ++i)
+  for (size_t i = 0; i != size; ++i)
     selectedAssociation->setValue(i, selectedValues[i]);
   evt.put(std::move(selectedAssociation));
 }

--- a/CommonTools/UtilAlgos/interface/CollectionAdder.h
+++ b/CommonTools/UtilAlgos/interface/CollectionAdder.h
@@ -13,20 +13,22 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-template<typename C>
+template <typename C>
 class CollectionAdder : public edm::EDProducer {
 public:
   typedef C collection;
-  CollectionAdder(const edm::ParameterSet & cfg ) :
-    srcTokens_(edm::vector_transform(cfg.template getParameter<std::vector<edm::InputTag> >("src"), [this](edm::InputTag const & tag){return consumes<collection>(tag);})) {
+  CollectionAdder(const edm::ParameterSet& cfg)
+      : srcTokens_(edm::vector_transform(cfg.template getParameter<std::vector<edm::InputTag>>("src"),
+                                         [this](edm::InputTag const& tag) { return consumes<collection>(tag); })) {
     produces<collection>();
   }
+
 private:
   std::vector<edm::EDGetTokenT<collection>> srcTokens_;
-  void produce(edm::Event & evt, const edm::EventSetup&) override {
+  void produce(edm::Event& evt, const edm::EventSetup&) override {
     std::unique_ptr<collection> coll(new collection);
     typename collection::Filler filler(*coll);
-    for(size_t i = 0; i < srcTokens_.size(); ++i ) {
+    for (size_t i = 0; i < srcTokens_.size(); ++i) {
       edm::Handle<collection> src;
       evt.getByToken(srcTokens_[i], src);
       *coll += *src;
@@ -36,4 +38,3 @@ private:
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/CollectionFilterTrait.h
+++ b/CommonTools/UtilAlgos/interface/CollectionFilterTrait.h
@@ -10,47 +10,49 @@
 
 namespace helper {
 
-  template<typename C, typename S, typename N>
+  template <typename C, typename S, typename N>
   struct CollectionFilter {
-    static bool filter( const C & source, const S & select, const N & sizeSelect ) {
+    static bool filter(const C& source, const S& select, const N& sizeSelect) {
       size_t n = 0;
-      for( typename C::const_iterator i = source.begin(); i != source.end(); ++ i )
-	if ( select( * i ) ) n ++;
-      return sizeSelect( n );      
+      for (typename C::const_iterator i = source.begin(); i != source.end(); ++i)
+        if (select(*i))
+          n++;
+      return sizeSelect(n);
     }
   };
 
-  template<typename C, typename S>
+  template <typename C, typename S>
   struct CollectionFilter<C, S, MinNumberSelector> {
-    static bool filter( const C& source, const S & select, const MinNumberSelector & sizeSelect ) {
+    static bool filter(const C& source, const S& select, const MinNumberSelector& sizeSelect) {
       size_t n = 0;
-      for( typename C::const_iterator i = source.begin(); i != source.end(); ++ i ) {
-	if ( select( * i ) ) n ++;
-	if ( sizeSelect( n ) ) return true;
+      for (typename C::const_iterator i = source.begin(); i != source.end(); ++i) {
+        if (select(*i))
+          n++;
+        if (sizeSelect(n))
+          return true;
       }
       return false;
     }
   };
 
-  template<typename C, typename N>
+  template <typename C, typename N>
   struct CollectionSizeFilter {
-    template<typename S>
-    static bool filter( const C & source, const S & , const N & sizeSelect ) {
-      return sizeSelect( source.size() );
+    template <typename S>
+    static bool filter(const C& source, const S&, const N& sizeSelect) {
+      return sizeSelect(source.size());
     }
   };
 
-  template<typename C, typename S, typename N>
+  template <typename C, typename S, typename N>
   struct CollectionFilterTrait {
     typedef CollectionFilter<C, S, N> type;
   };
 
-  template<typename C, typename N>
+  template <typename C, typename N>
   struct CollectionFilterTrait<C, AnySelector, N> {
     typedef CollectionSizeFilter<C, N> type;
   };
 
-}
+}  // namespace helper
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/DeltaPhiMinPairSelector.h
+++ b/CommonTools/UtilAlgos/interface/DeltaPhiMinPairSelector.h
@@ -5,16 +5,15 @@
 
 namespace reco {
   namespace modules {
-    
-    template<>
+
+    template <>
     struct ParameterAdapter<DeltaPhiMinPairSelector> {
-      static DeltaPhiMinPairSelector make( const edm::ParameterSet & cfg ) {
-	return DeltaPhiMinPairSelector( cfg.getParameter<double>( "deltaPhiMin" ) );
+      static DeltaPhiMinPairSelector make(const edm::ParameterSet& cfg) {
+        return DeltaPhiMinPairSelector(cfg.getParameter<double>("deltaPhiMin"));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/DeltaR.h
+++ b/CommonTools/UtilAlgos/interface/DeltaR.h
@@ -5,18 +5,13 @@
 
 namespace reco {
   namespace modules {
-    
-    template<typename T1, typename T2>
+
+    template <typename T1, typename T2>
     struct ParameterAdapter<DeltaR<T1, T2> > {
-      static DeltaR<T1, T2> make( const edm::ParameterSet & cfg ) {
-	return DeltaR<T1, T2>();
-      }
+      static DeltaR<T1, T2> make(const edm::ParameterSet& cfg) { return DeltaR<T1, T2>(); }
     };
-    
-  }
-}
 
-
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/DeltaRMinPairSelector.h
+++ b/CommonTools/UtilAlgos/interface/DeltaRMinPairSelector.h
@@ -5,16 +5,15 @@
 
 namespace reco {
   namespace modules {
-    
-    template<>
+
+    template <>
     struct ParameterAdapter<DeltaRMinPairSelector> {
-      static DeltaRMinPairSelector make( const edm::ParameterSet & cfg ) {
-	return DeltaRMinPairSelector( cfg.getParameter<double>( "deltaRMin" ) );
+      static DeltaRMinPairSelector make(const edm::ParameterSet& cfg) {
+        return DeltaRMinPairSelector(cfg.getParameter<double>("deltaRMin"));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/DetIdSelector.h
+++ b/CommonTools/UtilAlgos/interface/DetIdSelector.h
@@ -10,26 +10,24 @@ namespace edm {
 }
 
 class DetIdSelector {
- public:
+public:
   DetIdSelector();
   DetIdSelector(const std::string& selstring);
   DetIdSelector(const std::vector<std::string>& selstrings);
   DetIdSelector(const edm::ParameterSet& selconfig);
 
-  bool isSelected(const DetId& detid ) const;
+  bool isSelected(const DetId& detid) const;
   bool isSelected(const unsigned int& rawid) const;
-  bool operator()(const DetId& detid ) const;
+  bool operator()(const DetId& detid) const;
   bool operator()(const unsigned int& rawid) const;
-  inline bool isValid() const { return !m_selections.empty();}
+  inline bool isValid() const { return !m_selections.empty(); }
 
- private:
-
+private:
   void addSelection(const std::string& selstring);
   void addSelection(const std::vector<std::string>& selstrings);
 
   std::vector<unsigned int> m_selections;
   std::vector<unsigned int> m_masks;
-
 };
 
-#endif // DetIdSelector_h
+#endif  // DetIdSelector_h

--- a/CommonTools/UtilAlgos/interface/DummySelector.h
+++ b/CommonTools/UtilAlgos/interface/DummySelector.h
@@ -18,27 +18,29 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class DummySelector {
 public:
-  explicit DummySelector(const edm::ParameterSet&, edm::ConsumesCollector & iC) : updated_(false) { }
+  explicit DummySelector(const edm::ParameterSet&, edm::ConsumesCollector& iC) : updated_(false) {}
   void newEvent(const edm::Event&, const edm::EventSetup&) { updated_ = true; }
-  template<typename T>
+  template <typename T>
   bool operator()(const T&) {
-    if(!updated_)
-      throw edm::Exception(edm::errors::Configuration)
-	<< "DummySelector: forgot to call newEvent\n";
+    if (!updated_)
+      throw edm::Exception(edm::errors::Configuration) << "DummySelector: forgot to call newEvent\n";
     return true;
   }
+
 private:
   bool updated_;
 };
 
 namespace dummy {
-  template<typename T>
-  inline bool select(const T&) { return true; }
-}
+  template <typename T>
+  inline bool select(const T&) {
+    return true;
+  }
+}  // namespace dummy
 
 EVENTSETUP_STD_INIT(DummySelector);
 

--- a/CommonTools/UtilAlgos/interface/EtMinSelector.h
+++ b/CommonTools/UtilAlgos/interface/EtMinSelector.h
@@ -8,19 +8,16 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<EtMinSelector> {
-      static EtMinSelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return EtMinSelector( cfg.getParameter<double>( "etMin" ) );
+      static EtMinSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return EtMinSelector(cfg.getParameter<double>("etMin"));
       }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-        desc.add<double>("etMin", 0.);
-      }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<double>("etMin", 0.); }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/EtaRangeSelector.h
+++ b/CommonTools/UtilAlgos/interface/EtaRangeSelector.h
@@ -8,12 +8,10 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<EtaRangeSelector> {
-      static EtaRangeSelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return
-	  EtaRangeSelector( cfg.getParameter<double>( "etaMin" ),
-			    cfg.getParameter<double>( "etaMax" ) );
+      static EtaRangeSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return EtaRangeSelector(cfg.getParameter<double>("etaMin"), cfg.getParameter<double>("etaMax"));
       }
 
       static void fillPSetDescription(edm::ParameterSetDescription& desc) {
@@ -22,8 +20,7 @@ namespace reco {
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/EventSelector.h
+++ b/CommonTools/UtilAlgos/interface/EventSelector.h
@@ -15,28 +15,29 @@
 
 class EventSelector {
 public:
-  EventSelector () {}
-  EventSelector (const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) :
-    EventSelector(iConfig, iC) {}
-  EventSelector (const edm::ParameterSet& iConfig, edm::ConsumesCollector & iC) {
+  EventSelector() {}
+  EventSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) : EventSelector(iConfig, iC) {}
+  EventSelector(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) {
     std::string selector = iConfig.getParameter<std::string>("selector");
-    name_ = iConfig.getUntrackedParameter<std::string>("name",selector);
+    name_ = iConfig.getUntrackedParameter<std::string>("name", selector);
   }
-  virtual ~EventSelector () {}
+  virtual ~EventSelector() {}
   /// name of the module (from configuration)
-  const std::string& name () const {return name_;}
-  const std::vector<std::string> & description() { return description_;}
+  const std::string& name() const { return name_; }
+  const std::vector<std::string>& description() { return description_; }
   /// decision of the selector module
-  virtual bool select (const edm::Event&) const = 0;
+  virtual bool select(const edm::Event&) const = 0;
 
- protected:
+protected:
   std::string name_;
   std::vector<std::string> description_;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-typedef edmplugin::PluginFactory< EventSelector* (const edm::ParameterSet&, edm::ConsumesCollector &&) > EventSelectorFactory;
-typedef edmplugin::PluginFactory< EventSelector* (const edm::ParameterSet&, edm::ConsumesCollector &) > EventSelectorFactoryFromHelper;
+typedef edmplugin::PluginFactory<EventSelector*(const edm::ParameterSet&, edm::ConsumesCollector&&)>
+    EventSelectorFactory;
+typedef edmplugin::PluginFactory<EventSelector*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    EventSelectorFactoryFromHelper;
 
 #endif

--- a/CommonTools/UtilAlgos/interface/EventSelectorAdapter.h
+++ b/CommonTools/UtilAlgos/interface/EventSelectorAdapter.h
@@ -20,14 +20,11 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-template<typename T>
-class EventSelectorAdapter : public edm::global::EDFilter<>
-{
- public:
+template <typename T>
+class EventSelectorAdapter : public edm::global::EDFilter<> {
+public:
   // constructor
-  explicit EventSelectorAdapter(const edm::ParameterSet& cfg) :
-    eventSelector_( cfg, consumesCollector() ) {
-  }
+  explicit EventSelectorAdapter(const edm::ParameterSet& cfg) : eventSelector_(cfg, consumesCollector()) {}
 
   // destructor
   ~EventSelectorAdapter() override {}
@@ -38,11 +35,12 @@ class EventSelectorAdapter : public edm::global::EDFilter<>
     descriptions.addWithDefaultLabel(desc);
   }
 
- private:
-  bool filter(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const override { return eventSelector_(evt, es); }
+private:
+  bool filter(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const override {
+    return eventSelector_(evt, es);
+  }
 
   T eventSelector_;
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/EventSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/EventSelectorBase.h
@@ -17,24 +17,22 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class EventSelectorBase
-{
- public:
-  // constructor 
+class EventSelectorBase {
+public:
+  // constructor
   explicit EventSelectorBase() {}
-  
+
   // destructor
   virtual ~EventSelectorBase() {}
-  
+
   // function implementing actual cut
   // ( return value = true  : event passes cut
-  //                  false : event fails cut ) 
+  //                  false : event fails cut )
   virtual bool operator()(edm::Event&, const edm::EventSetup&) const = 0;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-typedef edmplugin::PluginFactory<EventSelectorBase* (const edm::ParameterSet&)> EventSelectorPluginFactory;
+typedef edmplugin::PluginFactory<EventSelectorBase*(const edm::ParameterSet&)> EventSelectorPluginFactory;
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/EventSetupInitTrait.h
+++ b/CommonTools/UtilAlgos/interface/EventSetupInitTrait.h
@@ -6,7 +6,7 @@
 namespace edm {
   class EventSetup;
   class Event;
-}
+}  // namespace edm
 
 namespace helpers {
   struct NullAndOperand;
@@ -15,135 +15,133 @@ namespace helpers {
 namespace reco {
   namespace modules {
     /// take no action (default)
-    template<typename T>
+    template <typename T>
     struct NoEventSetupInit {
-      static void init(T &, const edm::Event&, const edm::EventSetup&) { }
+      static void init(T&, const edm::Event&, const edm::EventSetup&) {}
     };
 
     /// implement common interface defined in:
     /// https://twiki.cern.ch/twiki/bin/view/CMS/SelectorInterface
     struct CommonSelectorEventSetupInit {
-      template<typename Selector>
-      static void init( Selector & selector,
-			const edm::Event & evt,
-			const edm::EventSetup& es ) { 
-	selector.newEvent(evt, es);
+      template <typename Selector>
+      static void init(Selector& selector, const edm::Event& evt, const edm::EventSetup& es) {
+        selector.newEvent(evt, es);
       }
     };
 
-    template<typename T>
+    template <typename T>
     struct EventSetupInit {
       typedef NoEventSetupInit<T> type;
     };
 
-    template<typename T1, typename T2, typename T3 = helpers::NullAndOperand, 
-      typename T4 = helpers::NullAndOperand, typename T5 = helpers::NullAndOperand>
+    template <typename T1,
+              typename T2,
+              typename T3 = helpers::NullAndOperand,
+              typename T4 = helpers::NullAndOperand,
+              typename T5 = helpers::NullAndOperand>
     struct CombinedEventSetupInit {
-      template<template<typename, typename, typename, typename, typename> class SelectorT>
-      static void init(SelectorT<T1, T2, T3, T4, T5>& selector,
-		       const edm::Event & evt,
-		       const edm::EventSetup& es) {
+      template <template <typename, typename, typename, typename, typename> class SelectorT>
+      static void init(SelectorT<T1, T2, T3, T4, T5>& selector, const edm::Event& evt, const edm::EventSetup& es) {
         EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-	EventSetupInit<T2>::type::init(selector.s2_, evt, es);
-	EventSetupInit<T3>::type::init(selector.s3_, evt, es);
-	EventSetupInit<T4>::type::init(selector.s4_, evt, es);
-	EventSetupInit<T5>::type::init(selector.s5_, evt, es);
+        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
+        EventSetupInit<T3>::type::init(selector.s3_, evt, es);
+        EventSetupInit<T4>::type::init(selector.s4_, evt, es);
+        EventSetupInit<T5>::type::init(selector.s5_, evt, es);
       }
     };
-    
-    template<typename T1, typename T2, typename T3, typename T4>
+
+    template <typename T1, typename T2, typename T3, typename T4>
     struct CombinedEventSetupInit<T1, T2, T3, T4, helpers::NullAndOperand> {
-      template<template<typename, typename, typename, typename, typename> class SelectorT>
+      template <template <typename, typename, typename, typename, typename> class SelectorT>
       static void init(SelectorT<T1, T2, T3, T4, helpers::NullAndOperand>& selector,
-		       const edm::Event & evt,
-		       const edm::EventSetup& es) {
+                       const edm::Event& evt,
+                       const edm::EventSetup& es) {
         EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-	EventSetupInit<T2>::type::init(selector.s2_, evt, es);
-	EventSetupInit<T3>::type::init(selector.s3_, evt, es);
-	EventSetupInit<T4>::type::init(selector.s4_, evt, es);
+        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
+        EventSetupInit<T3>::type::init(selector.s3_, evt, es);
+        EventSetupInit<T4>::type::init(selector.s4_, evt, es);
       }
     };
-    
-    template<typename T1, typename T2, typename T3>
+
+    template <typename T1, typename T2, typename T3>
     struct CombinedEventSetupInit<T1, T2, T3, helpers::NullAndOperand, helpers::NullAndOperand> {
-      template<template<typename, typename, typename, typename, typename> class SelectorT>
+      template <template <typename, typename, typename, typename, typename> class SelectorT>
       static void init(SelectorT<T1, T2, T3, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
-		       const edm::Event & evt,
-		       const edm::EventSetup& es) {
+                       const edm::Event& evt,
+                       const edm::EventSetup& es) {
         EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-	EventSetupInit<T2>::type::init(selector.s2_, evt, es);
-	EventSetupInit<T3>::type::init(selector.s3_, evt, es);
+        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
+        EventSetupInit<T3>::type::init(selector.s3_, evt, es);
       }
     };
-    
-    template<typename T1, typename T2>
+
+    template <typename T1, typename T2>
     struct CombinedEventSetupInit<T1, T2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand> {
-      template<template<typename, typename, typename, typename, typename> class SelectorT>
-      static void init(SelectorT<T1, T2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
-		       const edm::Event & evt,
-		       const edm::EventSetup& es) {
+      template <template <typename, typename, typename, typename, typename> class SelectorT>
+      static void init(
+          SelectorT<T1, T2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
+          const edm::Event& evt,
+          const edm::EventSetup& es) {
         EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-	EventSetupInit<T2>::type::init(selector.s2_, evt, es);
+        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
       }
     };
-    
-    template<typename T1, typename T2, typename T3, typename T4, typename T5>
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5>
     struct EventSetupInit<AndSelector<T1, T2, T3, T4, T5> > {
       typedef CombinedEventSetupInit<T1, T2, T3, T4, T5> type;
     };
 
-    template<typename T1, typename T2, typename T3, typename T4, typename T5>
+    template <typename T1, typename T2, typename T3, typename T4, typename T5>
     struct EventSetupInit<OrSelector<T1, T2, T3, T4, T5> > {
       typedef CombinedEventSetupInit<T1, T2, T3, T4, T5> type;
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
-#define EVENTSETUP_STD_INIT(SELECTOR) \
-namespace reco { \
-  namespace modules { \
-    template<> \
-    struct EventSetupInit<SELECTOR> { \
-      typedef CommonSelectorEventSetupInit type; \
-    }; \
-  } \
-} \
-struct __useless_ignoreme
+#define EVENTSETUP_STD_INIT(SELECTOR)              \
+  namespace reco {                                 \
+    namespace modules {                            \
+      template <>                                  \
+      struct EventSetupInit<SELECTOR> {            \
+        typedef CommonSelectorEventSetupInit type; \
+      };                                           \
+    }                                              \
+  }                                                \
+  struct __useless_ignoreme
 
-#define EVENTSETUP_STD_INIT_T1(SELECTOR) \
-namespace reco { \
-  namespace modules { \
-    template<typename T1> \
-    struct EventSetupInit<SELECTOR<T1> > {	 \
-      typedef CommonSelectorEventSetupInit type; \
-    }; \
-  } \
-} \
-struct __useless_ignoreme
+#define EVENTSETUP_STD_INIT_T1(SELECTOR)           \
+  namespace reco {                                 \
+    namespace modules {                            \
+      template <typename T1>                       \
+      struct EventSetupInit<SELECTOR<T1> > {       \
+        typedef CommonSelectorEventSetupInit type; \
+      };                                           \
+    }                                              \
+  }                                                \
+  struct __useless_ignoreme
 
-#define EVENTSETUP_STD_INIT_T2(SELECTOR) \
-namespace reco { \
-  namespace modules { \
-    template<typename T1, typename T2>			 \
-    struct EventSetupInit<SELECTOR<T1, T2> > {		 \
-      typedef CommonSelectorEventSetupInit type; \
-    }; \
-  } \
-} \
-struct __useless_ignoreme
+#define EVENTSETUP_STD_INIT_T2(SELECTOR)           \
+  namespace reco {                                 \
+    namespace modules {                            \
+      template <typename T1, typename T2>          \
+      struct EventSetupInit<SELECTOR<T1, T2> > {   \
+        typedef CommonSelectorEventSetupInit type; \
+      };                                           \
+    }                                              \
+  }                                                \
+  struct __useless_ignoreme
 
-#define EVENTSETUP_STD_INIT_T3(SELECTOR) \
-namespace reco { \
-  namespace modules { \
-    template<typename T1, typename T2, typename T3>		 \
-    struct EventSetupInit<SELECTOR<T1, T2, T3> > {		 \
-      typedef CommonSelectorEventSetupInit type; \
-    }; \
-  } \
-} \
-struct __useless_ignoreme
-
+#define EVENTSETUP_STD_INIT_T3(SELECTOR)               \
+  namespace reco {                                     \
+    namespace modules {                                \
+      template <typename T1, typename T2, typename T3> \
+      struct EventSetupInit<SELECTOR<T1, T2, T3> > {   \
+        typedef CommonSelectorEventSetupInit type;     \
+      };                                               \
+    }                                                  \
+  }                                                    \
+  struct __useless_ignoreme
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/ExpressionHisto.h
+++ b/CommonTools/UtilAlgos/interface/ExpressionHisto.h
@@ -1,1 +1,1 @@
-#include "CommonTools/Utils/interface/ExpressionHisto.h" 
+#include "CommonTools/Utils/interface/ExpressionHisto.h"

--- a/CommonTools/UtilAlgos/interface/FreeFunctionSelector.h
+++ b/CommonTools/UtilAlgos/interface/FreeFunctionSelector.h
@@ -6,11 +6,9 @@
  *
  * \version $Id: FreeFunctionSelector.h,v 1.1 2008/01/22 11:17:58 llista Exp $
  */
-template<typename T, bool (*f)(const T&)>
+template <typename T, bool (*f)(const T&)>
 struct FreeFunctionSelector {
-  bool operator()(const T& t) {
-    return f(t);
-  }
+  bool operator()(const T& t) { return f(t); }
 };
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -18,16 +16,12 @@ struct FreeFunctionSelector {
 
 namespace reco {
   namespace modules {
-    template<typename T, bool (*f)(const T&)>
+    template <typename T, bool (*f)(const T&)>
     struct ParameterAdapter<FreeFunctionSelector<T, f> > {
       typedef FreeFunctionSelector<T, f> value_type;
-      static value_type make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) {
-	return value_type();
-      }
+      static value_type make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) { return value_type(); }
     };
-  }
-}
-
-
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h
+++ b/CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h
@@ -1,7 +1,6 @@
 #ifndef CommonTools_UtilAlgos_FwdPtrConversionFactory_h
 #define CommonTools_UtilAlgos_FwdPtrConversionFactory_h
 
-
 /**
   \class    "CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h"
   \brief    Converts back and forth from FwdPtr to instances. 
@@ -13,28 +12,24 @@
 #include "DataFormats/Common/interface/FwdPtr.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 
-
 namespace edm {
   /// Factory class template for how to produce products
   /// from a FwdPtr. This particular example is for copy
-  /// construction, but the same signature can be used elsewhere. 
-  template<class T>
+  /// construction, but the same signature can be used elsewhere.
+  template <class T>
   struct ProductFromFwdPtrFactory {
-    T operator() (edm::FwdPtr<T> const &r)  const  { return T(*r); }
+    T operator()(edm::FwdPtr<T> const &r) const { return T(*r); }
   };
-
-
-
 
   /// Factory class template for how to produce FwdPtrs
-  /// from a View. 
-  template<class T>
+  /// from a View.
+  template <class T>
   struct FwdPtrFromProductFactory {
-    edm::FwdPtr<T> operator() (edm::View<T> const & view, unsigned int i)  const  { return edm::FwdPtr<T>(view.ptrAt(i),view.ptrAt(i)); }
+    edm::FwdPtr<T> operator()(edm::View<T> const &view, unsigned int i) const {
+      return edm::FwdPtr<T>(view.ptrAt(i), view.ptrAt(i));
+    }
   };
 
-
-
-}
+}  // namespace edm
 
 #endif

--- a/CommonTools/UtilAlgos/interface/FwdPtrProducer.h
+++ b/CommonTools/UtilAlgos/interface/FwdPtrProducer.h
@@ -1,7 +1,6 @@
 #ifndef CommonTools_UtilAlgos_FwdPtrProducer_h
 #define CommonTools_UtilAlgos_FwdPtrProducer_h
 
-
 /**
   \class    edm::FwdPtrProducer FwdPtrProducer.h "CommonTools/UtilAlgos/interface/FwdPtrProducer.h"
   \brief    Produces a list of FwdPtr's to an input collection.
@@ -9,7 +8,6 @@
 
   \author   Salvatore Rappoccio
 */
-
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -22,40 +20,35 @@
 
 namespace edm {
 
-
-  template < class T, class H = FwdPtrFromProductFactory<T> >
-    class FwdPtrProducer : public edm::stream::EDProducer<> {
-  public :
-    explicit FwdPtrProducer( edm::ParameterSet const & params ) :
-       srcToken_( consumes<edm::View<T> >( params.getParameter<edm::InputTag>("src") ) )
-    {
-      produces< std::vector< edm::FwdPtr<T> > > ();
+  template <class T, class H = FwdPtrFromProductFactory<T> >
+  class FwdPtrProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit FwdPtrProducer(edm::ParameterSet const& params)
+        : srcToken_(consumes<edm::View<T> >(params.getParameter<edm::InputTag>("src"))) {
+      produces<std::vector<edm::FwdPtr<T> > >();
     }
 
     ~FwdPtrProducer() override {}
 
-    void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override {
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+      edm::Handle<edm::View<T> > hSrc;
+      iEvent.getByToken(srcToken_, hSrc);
 
-      edm::Handle< edm::View<T> > hSrc;
-      iEvent.getByToken( srcToken_, hSrc );
+      std::unique_ptr<std::vector<edm::FwdPtr<T> > > pOutputFwdPtr(new std::vector<edm::FwdPtr<T> >);
 
-      std::unique_ptr< std::vector< edm::FwdPtr<T> > > pOutputFwdPtr ( new std::vector<edm::FwdPtr<T> > );
-
-      for ( typename edm::View<T>::const_iterator ibegin = hSrc->begin(),
-	      iend = hSrc->end(),
-	      i = ibegin; i!= iend; ++i ) {
-	H factory;
-	FwdPtr<T> ptr = factory( *hSrc, i - ibegin );
-	pOutputFwdPtr->push_back( ptr );
+      for (typename edm::View<T>::const_iterator ibegin = hSrc->begin(), iend = hSrc->end(), i = ibegin; i != iend;
+           ++i) {
+        H factory;
+        FwdPtr<T> ptr = factory(*hSrc, i - ibegin);
+        pOutputFwdPtr->push_back(ptr);
       }
-
 
       iEvent.put(std::move(pOutputFwdPtr));
     }
 
-  protected :
+  protected:
     edm::EDGetTokenT<edm::View<T> > srcToken_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/CommonTools/UtilAlgos/interface/HistoAnalyzer.h
+++ b/CommonTools/UtilAlgos/interface/HistoAnalyzer.h
@@ -18,17 +18,17 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/UtilAlgos/interface/ExpressionHisto.h"
 
-template<typename C>
+template <typename C>
 class HistoAnalyzer : public edm::EDAnalyzer {
 public:
   /// constructor from parameter set
-  HistoAnalyzer( const edm::ParameterSet& );
+  HistoAnalyzer(const edm::ParameterSet&);
   /// destructor
   ~HistoAnalyzer() override;
 
 protected:
   /// process an event
-  void analyze( const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   /// label of the collection to be read in
@@ -38,66 +38,61 @@ private:
   /// label of the weight collection (can be null for weights = 1)
   edm::EDGetTokenT<double> weightsToken_;
   /// vector of the histograms
-  std::vector<ExpressionHisto<typename C::value_type>* > vhistograms;
+  std::vector<ExpressionHisto<typename C::value_type>*> vhistograms;
 };
 
-template<typename C>
-HistoAnalyzer<C>::HistoAnalyzer( const edm::ParameterSet& par ) :
-  srcToken_(consumes<C>(par.template getParameter<edm::InputTag>("src"))),
-  usingWeights_(par.exists("weights")),
-  weightsToken_(mayConsume<double>(par.template getUntrackedParameter<edm::InputTag>("weights", edm::InputTag("fake"))))
-{
-   edm::Service<TFileService> fs;
-   std::vector<edm::ParameterSet> histograms =
-                                   par.template getParameter<std::vector<edm::ParameterSet> >("histograms");
-   std::vector<edm::ParameterSet>::const_iterator it = histograms.begin();
-   std::vector<edm::ParameterSet>::const_iterator end = histograms.end();
+template <typename C>
+HistoAnalyzer<C>::HistoAnalyzer(const edm::ParameterSet& par)
+    : srcToken_(consumes<C>(par.template getParameter<edm::InputTag>("src"))),
+      usingWeights_(par.exists("weights")),
+      weightsToken_(
+          mayConsume<double>(par.template getUntrackedParameter<edm::InputTag>("weights", edm::InputTag("fake")))) {
+  edm::Service<TFileService> fs;
+  std::vector<edm::ParameterSet> histograms = par.template getParameter<std::vector<edm::ParameterSet> >("histograms");
+  std::vector<edm::ParameterSet>::const_iterator it = histograms.begin();
+  std::vector<edm::ParameterSet>::const_iterator end = histograms.end();
 
-   // create the histograms from the given parameter sets
-   for (; it!=end; ++it)
-   {
-      ExpressionHisto<typename C::value_type>* hist = new ExpressionHisto<typename C::value_type>(*it);
-      hist->initialize(fs->tFileDirectory());
-      vhistograms.push_back(hist);
-   }
-
+  // create the histograms from the given parameter sets
+  for (; it != end; ++it) {
+    ExpressionHisto<typename C::value_type>* hist = new ExpressionHisto<typename C::value_type>(*it);
+    hist->initialize(fs->tFileDirectory());
+    vhistograms.push_back(hist);
+  }
 }
 
-template<typename C>
-HistoAnalyzer<C>::~HistoAnalyzer()
-{
-   // delete all histograms and clear the vector of pointers
-   typename std::vector<ExpressionHisto<typename C::value_type>* >::iterator it = vhistograms.begin();
-   typename std::vector<ExpressionHisto<typename C::value_type>* >::iterator end = vhistograms.end();
-   for (;it!=end; ++it){
-     (*it)->~ExpressionHisto<typename C::value_type>();
-   }
-   vhistograms.clear();
+template <typename C>
+HistoAnalyzer<C>::~HistoAnalyzer() {
+  // delete all histograms and clear the vector of pointers
+  typename std::vector<ExpressionHisto<typename C::value_type>*>::iterator it = vhistograms.begin();
+  typename std::vector<ExpressionHisto<typename C::value_type>*>::iterator end = vhistograms.end();
+  for (; it != end; ++it) {
+    (*it)->~ExpressionHisto<typename C::value_type>();
+  }
+  vhistograms.clear();
 }
 
-template<typename C>
-void HistoAnalyzer<C>::analyze( const edm::Event& iEvent, const edm::EventSetup&)
-{
-   edm::Handle<C> coll;
-   iEvent.getByToken( srcToken_, coll);
-   double weight = 1.0;
-   if (usingWeights_) {
-       edm::Handle<double> weightColl;
-       iEvent.getByToken( weightsToken_, weightColl );
-       weight = *weightColl;
-   }
+template <typename C>
+void HistoAnalyzer<C>::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<C> coll;
+  iEvent.getByToken(srcToken_, coll);
+  double weight = 1.0;
+  if (usingWeights_) {
+    edm::Handle<double> weightColl;
+    iEvent.getByToken(weightsToken_, weightColl);
+    weight = *weightColl;
+  }
 
-   typename std::vector<ExpressionHisto<typename C::value_type>* >::iterator it = vhistograms.begin();
-   typename std::vector<ExpressionHisto<typename C::value_type>* >::iterator end = vhistograms.end();
+  typename std::vector<ExpressionHisto<typename C::value_type>*>::iterator it = vhistograms.begin();
+  typename std::vector<ExpressionHisto<typename C::value_type>*>::iterator end = vhistograms.end();
 
-   for (;it!=end; ++it){
-      uint32_t i = 0;
-      for( typename C::const_iterator elem=coll->begin(); elem!=coll->end(); ++elem, ++i ) {
-         if (!(*it)->fill( *elem, weight, i )) {
-            break;
-         }
+  for (; it != end; ++it) {
+    uint32_t i = 0;
+    for (typename C::const_iterator elem = coll->begin(); elem != coll->end(); ++elem, ++i) {
+      if (!(*it)->fill(*elem, weight, i)) {
+        break;
       }
-   }
+    }
+  }
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/InputTagDistributor.h
+++ b/CommonTools/UtilAlgos/interface/InputTagDistributor.h
@@ -11,57 +11,60 @@
 #include <map>
 #include <iostream>
 
-class InputTagDistributor{
- public:
-  InputTagDistributor(const edm::ParameterSet & pset, edm::ConsumesCollector& iC){
-    std::vector< std::string > inpuTags = pset.getParameterNamesForType<edm::InputTag>();
-    for (std::vector< std::string >::iterator i=inpuTags.begin();i!=inpuTags.end();++i)
-      inputTags_[*i]=pset.getParameter<edm::InputTag>(*i);
+class InputTagDistributor {
+public:
+  InputTagDistributor(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
+    std::vector<std::string> inpuTags = pset.getParameterNamesForType<edm::InputTag>();
+    for (std::vector<std::string>::iterator i = inpuTags.begin(); i != inpuTags.end(); ++i)
+      inputTags_[*i] = pset.getParameter<edm::InputTag>(*i);
   }
-  const edm::InputTag & inputTag(std::string s){
+  const edm::InputTag& inputTag(std::string s) {
     std::map<std::string, edm::InputTag>::iterator findMe = inputTags_.find(s);
-    if (findMe!=inputTags_.end())
+    if (findMe != inputTags_.end())
       return findMe->second;
-    else{
+    else {
       std::stringstream known;
-      for (findMe=inputTags_.begin();findMe!=inputTags_.end();++findMe)
-	known<<findMe->first<<" ---> "<<findMe->second<<"\n";
-      edm::LogError("InputTagDistributor")<<" cannot distribute InputTag: "<<s<<"\n knonw mapping is:\n"<<known.str();
+      for (findMe = inputTags_.begin(); findMe != inputTags_.end(); ++findMe)
+        known << findMe->first << " ---> " << findMe->second << "\n";
+      edm::LogError("InputTagDistributor") << " cannot distribute InputTag: " << s << "\n knonw mapping is:\n"
+                                           << known.str();
     }
     return inputTags_[s];
   }
 
- private:
+private:
   std::map<std::string, edm::InputTag> inputTags_;
 };
 
-
-class InputTagDistributorService{
- private:
+class InputTagDistributorService {
+private:
   InputTagDistributor* SetInputTagDistributorUniqueInstance_;
   std::map<std::string, InputTagDistributor*> multipleInstance_;
 
- public:
-  InputTagDistributorService(const edm::ParameterSet & iConfig,edm::ActivityRegistry & r ){
-    r.watchPreModuleConstruction(this, &InputTagDistributorService::preModule );
+public:
+  InputTagDistributorService(const edm::ParameterSet& iConfig, edm::ActivityRegistry& r) {
+    r.watchPreModuleConstruction(this, &InputTagDistributorService::preModule);
   };
   ~InputTagDistributorService(){};
 
-  InputTagDistributor & init(std::string user, const edm::ParameterSet & iConfig, edm::ConsumesCollector&& iC){
-    if (multipleInstance_.find(user)!=multipleInstance_.end()){
-      std::cerr<<user<<" InputTagDistributor user already defined."<<std::endl;
-      throw;}
-    else SetInputTagDistributorUniqueInstance_ = new InputTagDistributor(iConfig, iC);
+  InputTagDistributor& init(std::string user, const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
+    if (multipleInstance_.find(user) != multipleInstance_.end()) {
+      std::cerr << user << " InputTagDistributor user already defined." << std::endl;
+      throw;
+    } else
+      SetInputTagDistributorUniqueInstance_ = new InputTagDistributor(iConfig, iC);
     multipleInstance_[user] = SetInputTagDistributorUniqueInstance_;
     return (*SetInputTagDistributorUniqueInstance_);
   }
-  void preModule(const edm::ModuleDescription& desc){
+  void preModule(const edm::ModuleDescription& desc) {
     //does a set with the module name, except that it does not throw on non-configured modules
-    std::map<std::string, InputTagDistributor*>::iterator f=multipleInstance_.find(desc.moduleLabel());
-    if (f != multipleInstance_.end()) SetInputTagDistributorUniqueInstance_ = f->second;
-    else{
+    std::map<std::string, InputTagDistributor*>::iterator f = multipleInstance_.find(desc.moduleLabel());
+    if (f != multipleInstance_.end())
+      SetInputTagDistributorUniqueInstance_ = f->second;
+    else {
       //do not say anything but set it to zero to get a safe crash in get() if ever called
-      SetInputTagDistributorUniqueInstance_=nullptr;}
+      SetInputTagDistributorUniqueInstance_ = nullptr;
+    }
   }
   /*  InputTagDistributor & set(std::string & user){
     std::map<std::string, InputTagDistributor*>::iterator f=multipleInstance_.find(user);
@@ -74,39 +77,39 @@ class InputTagDistributorService{
       return (*SetInputTagDistributorUniqueInstance_);
     }
     }*/
-  InputTagDistributor & get(){
-    if (!SetInputTagDistributorUniqueInstance_){
-      std::cerr<<" SetInputTagDistributorUniqueInstance_ is not valid."<<std::endl;
+  InputTagDistributor& get() {
+    if (!SetInputTagDistributorUniqueInstance_) {
+      std::cerr << " SetInputTagDistributorUniqueInstance_ is not valid." << std::endl;
       throw;
+    } else {
+      return (*SetInputTagDistributorUniqueInstance_);
     }
-    else{ return (*SetInputTagDistributorUniqueInstance_);}
   }
 
-  edm::InputTag retrieve(std::string src,const edm::ParameterSet & pset){
+  edm::InputTag retrieve(std::string src, const edm::ParameterSet& pset) {
     //if used without setting any InputTag mapping
     if (multipleInstance_.empty())
       return pset.getParameter<edm::InputTag>(src);
 
     // some mapping was setup
-    InputTagDistributor & which=get();
-    std::map<std::string, InputTagDistributor*>::iterator inverseMap=multipleInstance_.begin();
-    std::map<std::string, InputTagDistributor*>::iterator inverseMap_end=multipleInstance_.end();
-    for (;inverseMap!=inverseMap_end;++inverseMap) if (inverseMap->second==&which) break;
-    LogDebug("InputTagDistributor")<<"typeCode: "<<pset.retrieve(src).typeCode()
-	     <<"\n"<<pset.dump()<<"\n"
-	     <<"looking for: "<<src
-	     <<" by user: "<< inverseMap->first
-	     <<std::endl;
+    InputTagDistributor& which = get();
+    std::map<std::string, InputTagDistributor*>::iterator inverseMap = multipleInstance_.begin();
+    std::map<std::string, InputTagDistributor*>::iterator inverseMap_end = multipleInstance_.end();
+    for (; inverseMap != inverseMap_end; ++inverseMap)
+      if (inverseMap->second == &which)
+        break;
+    LogDebug("InputTagDistributor") << "typeCode: " << pset.retrieve(src).typeCode() << "\n"
+                                    << pset.dump() << "\n"
+                                    << "looking for: " << src << " by user: " << inverseMap->first << std::endl;
     std::string typeCode;
-    typeCode+=pset.retrieve(src).typeCode();
-    std::string iTC;iTC+='S';
-    if (typeCode==iTC)
+    typeCode += pset.retrieve(src).typeCode();
+    std::string iTC;
+    iTC += 'S';
+    if (typeCode == iTC)
       return which.inputTag(pset.getParameter<std::string>(src));
     else
       return pset.getParameter<edm::InputTag>(src);
   }
 };
-
-
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MCMatchSelector.h
+++ b/CommonTools/UtilAlgos/interface/MCMatchSelector.h
@@ -10,34 +10,35 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace reco {
-  template<typename T1, typename T2>
+  template <typename T1, typename T2>
   class MCMatchSelector {
   public:
-    MCMatchSelector(const edm::ParameterSet& cfg) : 
-      checkCharge_(cfg.getParameter<bool>("checkCharge")) { 
-      std::vector<int> ids = 
-	cfg.getParameter< std::vector<int> >("mcPdgId");
-      for ( std::vector<int>::const_iterator i=ids.begin();
-	    i!=ids.end(); ++i )  ids_.insert(*i);
-      std::vector<int> status = 
-	cfg.getParameter< std::vector<int> >("mcStatus");
-      for ( std::vector<int>::const_iterator i=status.begin();
-	    i!=status.end(); ++i )  status_.insert(*i);
+    MCMatchSelector(const edm::ParameterSet& cfg) : checkCharge_(cfg.getParameter<bool>("checkCharge")) {
+      std::vector<int> ids = cfg.getParameter<std::vector<int> >("mcPdgId");
+      for (std::vector<int>::const_iterator i = ids.begin(); i != ids.end(); ++i)
+        ids_.insert(*i);
+      std::vector<int> status = cfg.getParameter<std::vector<int> >("mcStatus");
+      for (std::vector<int>::const_iterator i = status.begin(); i != status.end(); ++i)
+        status_.insert(*i);
     }
     /// true if match is possible
-    bool operator()( const T1 & c, const T2 & mc ) const {
-      if ( checkCharge_ && c.charge() != mc.charge() ) return false;
-      if ( !ids_.empty() ) {
-	if ( ids_.find(abs(mc.pdgId()))==ids_.end() )  return false;
+    bool operator()(const T1& c, const T2& mc) const {
+      if (checkCharge_ && c.charge() != mc.charge())
+        return false;
+      if (!ids_.empty()) {
+        if (ids_.find(abs(mc.pdgId())) == ids_.end())
+          return false;
       }
-      if ( status_.empty() )  return true;
-      return status_.find(mc.status())!=status_.end();
+      if (status_.empty())
+        return true;
+      return status_.find(mc.status()) != status_.end();
     }
+
   private:
     bool checkCharge_;
     std::set<int> ids_;
     std::set<int> status_;
   };
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MasslessInvariantMass.h
+++ b/CommonTools/UtilAlgos/interface/MasslessInvariantMass.h
@@ -5,18 +5,13 @@
 
 namespace reco {
   namespace modules {
-    
-    template<>
+
+    template <>
     struct ParameterAdapter<MasslessInvariantMass> {
-      static MasslessInvariantMass make( const edm::ParameterSet & cfg ) {
-	return MasslessInvariantMass();
-      }
+      static MasslessInvariantMass make(const edm::ParameterSet& cfg) { return MasslessInvariantMass(); }
     };
-    
-  }
-}
 
-
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/MasterCollectionHelper.h
+++ b/CommonTools/UtilAlgos/interface/MasterCollectionHelper.h
@@ -18,47 +18,49 @@
 #include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
 
 namespace helper {
-  template<typename C1>
+  template <typename C1>
   struct MasterCollection {
     typedef edm::Ref<C1> ref_type;
-    explicit MasterCollection(const edm::Handle<C1> & handle, edm::Event const& event) : 
-      handle_(handle) { }
+    explicit MasterCollection(const edm::Handle<C1>& handle, edm::Event const& event) : handle_(handle) {}
     size_t size() const { return handle_->size(); }
     size_t index(size_t i) const { return i; }
-    const edm::Handle<C1> & get() const { return handle_; }
+    const edm::Handle<C1>& get() const { return handle_; }
     ref_type getRef(size_t idx) const { return ref_type(get(), idx); }
-    template<typename R>
-    R getConcreteRef(size_t idx) const { return getRef(idx); }
+    template <typename R>
+    R getConcreteRef(size_t idx) const {
+      return getRef(idx);
+    }
+
   private:
     edm::Handle<C1> handle_;
   };
-  
-  template<typename T>
+
+  template <typename T>
   struct MasterCollection<edm::View<T> > {
     typedef edm::RefToBase<T> ref_type;
-    explicit MasterCollection(const edm::Handle<edm::View<T> > & handle, edm::Event const& event) :
-      handle_(handle) {
-      if(!handle_->empty()) {
+    explicit MasterCollection(const edm::Handle<edm::View<T> >& handle, edm::Event const& event) : handle_(handle) {
+      if (!handle_->empty()) {
         ref_ = edm::makeRefToBaseProdFrom(handle_->refAt(0), event);
       }
     }
-    size_t size() const { 
-      if (ref_.isNull()) return 0;
-      return ref_->size(); 
+    size_t size() const {
+      if (ref_.isNull())
+        return 0;
+      return ref_->size();
     }
-    size_t index(size_t i) const { 
-      return handle_->refAt(i).key(); 
-    }
-    const edm::RefToBaseProd<T> & get() const { return ref_; }
+    size_t index(size_t i) const { return handle_->refAt(i).key(); }
+    const edm::RefToBaseProd<T>& get() const { return ref_; }
     ref_type getRef(size_t idx) const { return ref_type(get(), idx); }
-    template<typename R>
-    R getConcreteRef(size_t idx) const { return getRef(idx).template castTo<R>(); }
+    template <typename R>
+    R getConcreteRef(size_t idx) const {
+      return getRef(idx).template castTo<R>();
+    }
+
   private:
     edm::Handle<edm::View<T> > handle_;
     edm::RefToBaseProd<T> ref_;
   };
 
-}
+}  // namespace helper
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/MatchByDEta.h
+++ b/CommonTools/UtilAlgos/interface/MatchByDEta.h
@@ -7,17 +7,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace reco {
-  template <typename T1, typename T2> class MatchByDEta {
+  template <typename T1, typename T2>
+  class MatchByDEta {
   public:
-    MatchByDEta (const edm::ParameterSet& cfg) :
-      maxDEta_(cfg.getParameter<double>("maxDeltaEta")) {}
-    bool operator() (const T1& t1, const T2& t2) const {
-      return fabs(t1.eta()-t2.eta()) < maxDEta_;
-    }
+    MatchByDEta(const edm::ParameterSet& cfg) : maxDEta_(cfg.getParameter<double>("maxDeltaEta")) {}
+    bool operator()(const T1& t1, const T2& t2) const { return fabs(t1.eta() - t2.eta()) < maxDEta_; }
+
   private:
     double maxDEta_;
   };
-}
-
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MatchByDR.h
+++ b/CommonTools/UtilAlgos/interface/MatchByDR.h
@@ -8,18 +8,16 @@
 #include "CommonTools/UtilAlgos/interface/DeltaR.h"
 
 namespace reco {
-  template <typename T1, typename T2> class MatchByDR {
+  template <typename T1, typename T2>
+  class MatchByDR {
   public:
-    MatchByDR (const edm::ParameterSet& cfg) :
-      maxDR_(cfg.getParameter<double>("maxDeltaR")) {}
-    bool operator() (const T1& t1, const T2& t2) const {
-      return deltaR_(t1,t2)<maxDR_;
-    }
+    MatchByDR(const edm::ParameterSet& cfg) : maxDR_(cfg.getParameter<double>("maxDeltaR")) {}
+    bool operator()(const T1& t1, const T2& t2) const { return deltaR_(t1, t2) < maxDR_; }
+
   private:
-    DeltaR<T1,T2> deltaR_;
+    DeltaR<T1, T2> deltaR_;
     double maxDR_;
   };
-}
-
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MatchByDRDPt.h
+++ b/CommonTools/UtilAlgos/interface/MatchByDRDPt.h
@@ -8,20 +8,18 @@
 #include "CommonTools/UtilAlgos/interface/MatchByDR.h"
 
 namespace reco {
-  template <typename T1, typename T2> class MatchByDRDPt {
+  template <typename T1, typename T2>
+  class MatchByDRDPt {
   public:
-    MatchByDRDPt (const edm::ParameterSet& cfg) :
-      deltaR_(cfg),
-      maxDPtRel_(cfg.getParameter<double>("maxDPtRel")) {}
-    bool operator() (const T1& t1, const T2& t2) const {
-      return fabs(t1.pt()-t2.pt())/t2.pt()<maxDPtRel_ &&
-	deltaR_(t1,t2);
+    MatchByDRDPt(const edm::ParameterSet& cfg) : deltaR_(cfg), maxDPtRel_(cfg.getParameter<double>("maxDPtRel")) {}
+    bool operator()(const T1& t1, const T2& t2) const {
+      return fabs(t1.pt() - t2.pt()) / t2.pt() < maxDPtRel_ && deltaR_(t1, t2);
     }
+
   private:
-    reco::MatchByDR<T1,T2> deltaR_;
+    reco::MatchByDR<T1, T2> deltaR_;
     double maxDPtRel_;
   };
-}
-
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MatchLessByDEta.h
+++ b/CommonTools/UtilAlgos/interface/MatchLessByDEta.h
@@ -7,27 +7,26 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace reco {
-  template <typename C1, typename C2> struct MatchLessByDEta {
-  public: 
-    MatchLessByDEta ( const edm::ParameterSet& cfg,
-		     const C1& c1, const C2& c2) :
-      c1_(c1), c2_(c2) {}
-    bool operator() (const std::pair<size_t,size_t>& p1,
-		     const std::pair<size_t,size_t>& p2) const {
+  template <typename C1, typename C2>
+  struct MatchLessByDEta {
+  public:
+    MatchLessByDEta(const edm::ParameterSet& cfg, const C1& c1, const C2& c2) : c1_(c1), c2_(c2) {}
+    bool operator()(const std::pair<size_t, size_t>& p1, const std::pair<size_t, size_t>& p2) const {
       typedef typename C1::value_type T1;
       typedef typename C2::value_type T2;
       const T1& p1_1 = c1_[p1.first];
       const T2& p1_2 = c2_[p1.second];
       const T1& p2_1 = c1_[p2.first];
       const T2& p2_2 = c2_[p2.second];
-      if ( fabs(p1_1.eta()-p1_2.eta()) <
-	   fabs(p2_1.eta()-p2_2.eta()) )  return true;
+      if (fabs(p1_1.eta() - p1_2.eta()) < fabs(p2_1.eta() - p2_2.eta()))
+        return true;
       return false;
     }
+
   private:
     const C1& c1_;
     const C2& c2_;
   };
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MatchLessByDPt.h
+++ b/CommonTools/UtilAlgos/interface/MatchLessByDPt.h
@@ -8,29 +8,30 @@
 // #include "CommonTools/UtilAlgos/interface/DeltaR.h"
 
 namespace reco {
-  template <typename C1, typename C2> struct MatchLessByDPt {
-  public: 
-    MatchLessByDPt ( const edm::ParameterSet& cfg,
-		     const C1& c1, const C2& c2) :
-//       deltaR_(cfg), 
-      c1_(c1), c2_(c2) {}
-    bool operator() (const std::pair<size_t,size_t>& p1,
-		     const std::pair<size_t,size_t>& p2) const {
+  template <typename C1, typename C2>
+  struct MatchLessByDPt {
+  public:
+    MatchLessByDPt(const edm::ParameterSet& cfg, const C1& c1, const C2& c2)
+        :  //       deltaR_(cfg),
+          c1_(c1),
+          c2_(c2) {}
+    bool operator()(const std::pair<size_t, size_t>& p1, const std::pair<size_t, size_t>& p2) const {
       typedef typename C1::value_type T1;
       typedef typename C2::value_type T2;
       const T1& p1_1 = c1_[p1.first];
       const T2& p1_2 = c2_[p1.second];
       const T1& p2_1 = c1_[p2.first];
       const T2& p2_2 = c2_[p2.second];
-      if ( fabs(p1_1.pt()-p1_2.pt())/p1_2.pt() <
-	   fabs(p2_1.pt()-p2_2.pt())/p2_2.pt() )  return true;
+      if (fabs(p1_1.pt() - p1_2.pt()) / p1_2.pt() < fabs(p2_1.pt() - p2_2.pt()) / p2_2.pt())
+        return true;
       return false;
     }
+
   private:
     //     DeltaR deltaR_;
     const C1& c1_;
     const C2& c2_;
   };
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/Matcher.h
+++ b/CommonTools/UtilAlgos/interface/Matcher.h
@@ -17,10 +17,10 @@
 
 namespace reco {
   namespace modules {
-    template<typename C1, typename C2, typename M = edm::AssociationMap<edm::OneToOne<C1, C2> > >
+    template <typename C1, typename C2, typename M = edm::AssociationMap<edm::OneToOne<C1, C2> > >
     class MatcherBase : public edm::EDProducer {
     public:
-      MatcherBase( const edm::ParameterSet & );
+      MatcherBase(const edm::ParameterSet&);
       ~MatcherBase() override;
 
     protected:
@@ -29,35 +29,32 @@ namespace reco {
       typedef M MatchMap;
 
     private:
-      void produce( edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
       edm::EDGetTokenT<C1> srcToken_;
       edm::EDGetTokenT<C2> matchedToken_;
       double distMin_;
-      virtual double matchDistance( const T1 &, const T2 & ) const = 0;
-      virtual bool select( const T1 &, const T2 & ) const = 0;
+      virtual double matchDistance(const T1&, const T2&) const = 0;
+      virtual bool select(const T1&, const T2&) const = 0;
     };
 
-    template<typename C1, typename C2,
-             typename S, typename D = DeltaR<typename C1::value_type, typename C2::value_type>,
-             typename M =  edm::AssociationMap<edm::OneToOne<C1, C2> > >
+    template <typename C1,
+              typename C2,
+              typename S,
+              typename D = DeltaR<typename C1::value_type, typename C2::value_type>,
+              typename M = edm::AssociationMap<edm::OneToOne<C1, C2> > >
     class Matcher : public MatcherBase<C1, C2, M> {
     public:
-      Matcher(  const edm::ParameterSet & cfg ) :
-	MatcherBase<C1, C2, M>( cfg ),
-        select_( reco::modules::make<S>( cfg ) ),
-	distance_( reco::modules::make<D>( cfg ) ) { }
-      ~Matcher() override { }
+      Matcher(const edm::ParameterSet& cfg)
+          : MatcherBase<C1, C2, M>(cfg), select_(reco::modules::make<S>(cfg)), distance_(reco::modules::make<D>(cfg)) {}
+      ~Matcher() override {}
+
     private:
       typedef typename MatcherBase<C1, C2, M>::T1 T1;
       typedef typename MatcherBase<C1, C2, M>::T2 T2;
       typedef typename MatcherBase<C1, C2, M>::MatchMap MatchMap;
 
-      double matchDistance( const T1 & c1, const T2 & c2 ) const override {
-	return distance_( c1, c2 );
-      }
-      bool select( const T1 & c1, const T2 & c2 ) const override {
-	return select_( c1, c2 );
-      }
+      double matchDistance(const T1& c1, const T2& c2) const override { return distance_(c1, c2); }
+      bool select(const T1& c1, const T2& c2) const override { return select_(c1, c2); }
       S select_;
       D distance_;
     };
@@ -66,57 +63,55 @@ namespace reco {
       typedef std::pair<size_t, double> MatchPair;
 
       struct SortBySecond {
-	bool operator()( const MatchPair & p1, const MatchPair & p2 ) const {
-	  return p1.second < p2.second;
-	}
+        bool operator()(const MatchPair& p1, const MatchPair& p2) const { return p1.second < p2.second; }
       };
-    }
+    }  // namespace helper
 
-    template<typename C1, typename C2, typename M>
-    MatcherBase<C1, C2, M>::MatcherBase( const edm::ParameterSet & cfg ) :
-      srcToken_( consumes<C1>( cfg.template getParameter<edm::InputTag>( "src" ) ) ),
-      matchedToken_( consumes<C2>( cfg.template getParameter<edm::InputTag>( "matched" ) ) ),
-      distMin_( cfg.template getParameter<double>( "distMin" ) ) {
+    template <typename C1, typename C2, typename M>
+    MatcherBase<C1, C2, M>::MatcherBase(const edm::ParameterSet& cfg)
+        : srcToken_(consumes<C1>(cfg.template getParameter<edm::InputTag>("src"))),
+          matchedToken_(consumes<C2>(cfg.template getParameter<edm::InputTag>("matched"))),
+          distMin_(cfg.template getParameter<double>("distMin")) {
       produces<MatchMap>();
     }
 
-    template<typename C1, typename C2, typename M>
-    MatcherBase<C1, C2, M>::~MatcherBase() { }
+    template <typename C1, typename C2, typename M>
+    MatcherBase<C1, C2, M>::~MatcherBase() {}
 
-    template<typename C1, typename C2, typename M>
-    void MatcherBase<C1, C2, M>::produce( edm::Event& evt, const edm::EventSetup& ) {
+    template <typename C1, typename C2, typename M>
+    void MatcherBase<C1, C2, M>::produce(edm::Event& evt, const edm::EventSetup&) {
       using namespace edm;
       using namespace std;
       Handle<C2> matched;
-      evt.getByToken( matchedToken_, matched );
+      evt.getByToken(matchedToken_, matched);
       Handle<C1> cands;
-      evt.getByToken( srcToken_, cands );
+      evt.getByToken(srcToken_, cands);
       typedef typename MatchMap::ref_type ref_type;
       typedef typename ref_type::key_type key_ref_type;
       typedef typename ref_type::value_type value_ref_type;
-      unique_ptr<MatchMap> matchMap( new MatchMap( ref_type( key_ref_type( cands ),
-							   value_ref_type( matched ) ) ) );
-      for( size_t c = 0; c != cands->size(); ++ c ) {
-	const T1 & cand = (*cands)[ c ];
-	vector<helper::MatchPair> v;
-	for( size_t m = 0; m != matched->size(); ++ m ) {
-	  const T2 & match = ( * matched )[ m ];
-	  if ( select( cand, match ) ) {
-	    double dist = matchDistance( cand, match );
-	    if ( dist < distMin_ ) v.push_back( make_pair( m, dist ) );
-	  }
-	}
-	if ( !v.empty() ) {
-	  size_t mMin = min_element( v.begin(), v.end(), helper::SortBySecond() )->first;
-	  typedef typename MatchMap::key_type key_type;
-	  typedef typename MatchMap::data_type data_type;
-	  matchMap->insert( edm::getRef( cands, c ), edm::getRef( matched, mMin ) );
-	}
+      unique_ptr<MatchMap> matchMap(new MatchMap(ref_type(key_ref_type(cands), value_ref_type(matched))));
+      for (size_t c = 0; c != cands->size(); ++c) {
+        const T1& cand = (*cands)[c];
+        vector<helper::MatchPair> v;
+        for (size_t m = 0; m != matched->size(); ++m) {
+          const T2& match = (*matched)[m];
+          if (select(cand, match)) {
+            double dist = matchDistance(cand, match);
+            if (dist < distMin_)
+              v.push_back(make_pair(m, dist));
+          }
+        }
+        if (!v.empty()) {
+          size_t mMin = min_element(v.begin(), v.end(), helper::SortBySecond())->first;
+          typedef typename MatchMap::key_type key_type;
+          typedef typename MatchMap::data_type data_type;
+          matchMap->insert(edm::getRef(cands, c), edm::getRef(matched, mMin));
+        }
       }
       evt.put(std::move(matchMap));
     }
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/MaxNumberSelector.h
+++ b/CommonTools/UtilAlgos/interface/MaxNumberSelector.h
@@ -8,19 +8,16 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<MaxNumberSelector> {
-      static MaxNumberSelector make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) {
-	return MaxNumberSelector(cfg.getParameter<unsigned int>("maxNumber"));
+      static MaxNumberSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return MaxNumberSelector(cfg.getParameter<unsigned int>("maxNumber"));
       }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-        desc.add<unsigned int>("maxNumber", 0);
-      }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<unsigned int>("maxNumber", 0); }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/MaxSelector.h
+++ b/CommonTools/UtilAlgos/interface/MaxSelector.h
@@ -7,15 +7,14 @@
 namespace reco {
   namespace modules {
 
-    template<typename T>
+    template <typename T>
     struct ParameterAdapter<MaxSelector<T> > {
-      static MaxSelector<T> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return MaxSelector<T>( cfg.template getParameter<double>( "max" ) );
+      static MaxSelector<T> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return MaxSelector<T>(cfg.template getParameter<double>("max"));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/Merger.h
+++ b/CommonTools/UtilAlgos/interface/Merger.h
@@ -25,47 +25,48 @@
 #include "DataFormats/Common/interface/CloneTrait.h"
 #include <vector>
 
-template<typename InputCollection,
-	 typename OutputCollection = InputCollection,
-	 typename P = typename edm::clonehelper::CloneTrait<InputCollection>::type>
+template <typename InputCollection,
+          typename OutputCollection = InputCollection,
+          typename P = typename edm::clonehelper::CloneTrait<InputCollection>::type>
 class Merger : public edm::global::EDProducer<> {
 public:
   /// constructor from parameter set
-  explicit Merger( const edm::ParameterSet& );
+  explicit Merger(const edm::ParameterSet&);
   /// destructor
   ~Merger() override;
 
 private:
   /// process an event
-  void produce( edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   /// vector of strings
   typedef std::vector<edm::EDGetTokenT<InputCollection> > vtoken;
   /// labels of the collections to be merged
   vtoken srcToken_;
 };
 
-template<typename InputCollection, typename OutputCollection, typename P>
-Merger<InputCollection, OutputCollection, P>::Merger( const edm::ParameterSet& par ) :
-  srcToken_( edm::vector_transform(par.template getParameter<std::vector<edm::InputTag> >( "src" ), [this](edm::InputTag const & tag){return consumes<InputCollection>(tag);} ) ) {
+template <typename InputCollection, typename OutputCollection, typename P>
+Merger<InputCollection, OutputCollection, P>::Merger(const edm::ParameterSet& par)
+    : srcToken_(edm::vector_transform(par.template getParameter<std::vector<edm::InputTag> >("src"),
+                                      [this](edm::InputTag const& tag) { return consumes<InputCollection>(tag); })) {
   produces<OutputCollection>();
 }
 
-template<typename InputCollection, typename OutputCollection, typename P>
-Merger<InputCollection, OutputCollection, P>::~Merger() {
-}
+template <typename InputCollection, typename OutputCollection, typename P>
+Merger<InputCollection, OutputCollection, P>::~Merger() {}
 
-template<typename InputCollection, typename OutputCollection, typename P>
-void Merger<InputCollection, OutputCollection, P>::produce( edm::StreamID, edm::Event& evt, const edm::EventSetup&) const {
-  std::unique_ptr<OutputCollection> coll( new OutputCollection );
-  for( typename vtoken::const_iterator s = srcToken_.begin(); s != srcToken_.end(); ++ s ) {
+template <typename InputCollection, typename OutputCollection, typename P>
+void Merger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
+                                                           edm::Event& evt,
+                                                           const edm::EventSetup&) const {
+  std::unique_ptr<OutputCollection> coll(new OutputCollection);
+  for (typename vtoken::const_iterator s = srcToken_.begin(); s != srcToken_.end(); ++s) {
     edm::Handle<InputCollection> h;
-    evt.getByToken( * s, h );
-    for( typename InputCollection::const_iterator c = h->begin(); c != h->end(); ++c ) {
-      coll->push_back( P::clone( * c ) );
+    evt.getByToken(*s, h);
+    for (typename InputCollection::const_iterator c = h->begin(); c != h->end(); ++c) {
+      coll->push_back(P::clone(*c));
     }
   }
   evt.put(std::move(coll));
 }
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/MinNumberSelector.h
+++ b/CommonTools/UtilAlgos/interface/MinNumberSelector.h
@@ -8,19 +8,16 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<MinNumberSelector> {
-      static MinNumberSelector make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) {
-	return MinNumberSelector(cfg.getParameter<unsigned int>("minNumber"));
+      static MinNumberSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return MinNumberSelector(cfg.getParameter<unsigned int>("minNumber"));
       }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-        desc.add<unsigned int>("minNumber", 0);
-      }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<unsigned int>("minNumber", 0); }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/NewMatcher.h
+++ b/CommonTools/UtilAlgos/interface/NewMatcher.h
@@ -19,12 +19,12 @@
 namespace reco {
   namespace modulesNew {
 
-    template<typename C1, typename C2,
-             typename S, typename D = DeltaR<typename C1::value_type, typename C2::value_type> >
+    template <typename C1, typename C2, typename S, typename D = DeltaR<typename C1::value_type, typename C2::value_type> >
     class Matcher : public edm::EDProducer {
     public:
-      Matcher(const edm::ParameterSet & cfg);
+      Matcher(const edm::ParameterSet& cfg);
       ~Matcher() override;
+
     private:
       typedef typename C1::value_type T1;
       typedef typename C2::value_type T2;
@@ -33,12 +33,8 @@ namespace reco {
       edm::EDGetTokenT<C1> srcToken_;
       edm::EDGetTokenT<C2> matchedToken_;
       double distMin_;
-      double matchDistance(const T1 & c1, const T2 & c2) const {
-	return distance_(c1, c2);
-      }
-      bool select(const T1 & c1, const T2 & c2) const {
-	return select_(c1, c2);
-      }
+      double matchDistance(const T1& c1, const T2& c2) const { return distance_(c1, c2); }
+      bool select(const T1& c1, const T2& c2) const { return select_(c1, c2); }
       S select_;
       D distance_;
     };
@@ -47,26 +43,24 @@ namespace reco {
       typedef std::pair<size_t, double> MatchPair;
 
       struct SortBySecond {
-	bool operator()(const MatchPair & p1, const MatchPair & p2) const {
-	  return p1.second < p2.second;
-	}
+        bool operator()(const MatchPair& p1, const MatchPair& p2) const { return p1.second < p2.second; }
       };
-    }
+    }  // namespace helper
 
-    template<typename C1, typename C2, typename S, typename D>
-    Matcher<C1, C2, S, D>::Matcher(const edm::ParameterSet & cfg) :
-      srcToken_(consumes<C1>(cfg.template getParameter<edm::InputTag>("src"))),
-      matchedToken_(consumes<C2>(cfg.template getParameter<edm::InputTag>("matched"))),
-      distMin_(cfg.template getParameter<double>("distMin")),
-      select_(reco::modules::make<S>(cfg)),
-      distance_(reco::modules::make<D>(cfg)) {
+    template <typename C1, typename C2, typename S, typename D>
+    Matcher<C1, C2, S, D>::Matcher(const edm::ParameterSet& cfg)
+        : srcToken_(consumes<C1>(cfg.template getParameter<edm::InputTag>("src"))),
+          matchedToken_(consumes<C2>(cfg.template getParameter<edm::InputTag>("matched"))),
+          distMin_(cfg.template getParameter<double>("distMin")),
+          select_(reco::modules::make<S>(cfg)),
+          distance_(reco::modules::make<D>(cfg)) {
       produces<MatchMap>();
     }
 
-    template<typename C1, typename C2, typename S, typename D>
-    Matcher<C1, C2, S, D>::~Matcher() { }
+    template <typename C1, typename C2, typename S, typename D>
+    Matcher<C1, C2, S, D>::~Matcher() {}
 
-    template<typename C1, typename C2, typename S, typename D>
+    template <typename C1, typename C2, typename S, typename D>
     void Matcher<C1, C2, S, D>::produce(edm::Event& evt, const edm::EventSetup&) {
       using namespace edm;
       using namespace std;
@@ -76,33 +70,34 @@ namespace reco {
       evt.getByToken(srcToken_, cands);
       unique_ptr<MatchMap> matchMap(new MatchMap(matched));
       size_t size = cands->size();
-      if( size != 0 ) {
-	typename MatchMap::Filler filler(*matchMap);
-	::helper::MasterCollection<C1> master(cands, evt);
-	std::vector<int> indices(master.size(), -1);
-	for(size_t c = 0; c != size; ++ c) {
-	  const T1 & cand = (*cands)[c];
-	  vector<helper::MatchPair> v;
-	  for(size_t m = 0; m != matched->size(); ++m) {
-	    const T2 & match = (* matched)[m];
-	    if (select(cand, match)) {
-	      double dist = matchDistance(cand, match);
-	      if (dist < distMin_) v.push_back(make_pair(m, dist));
-	    }
-	  }
-	  if(!v.empty()) {
-	    size_t idx = master.index(c);
-	    assert(idx < indices.size());
-	    indices[idx] = min_element(v.begin(), v.end(), helper::SortBySecond())->first;
-	  }
-	}
-	filler.insert(master.get(), indices.begin(), indices.end());
-	filler.fill();
+      if (size != 0) {
+        typename MatchMap::Filler filler(*matchMap);
+        ::helper::MasterCollection<C1> master(cands, evt);
+        std::vector<int> indices(master.size(), -1);
+        for (size_t c = 0; c != size; ++c) {
+          const T1& cand = (*cands)[c];
+          vector<helper::MatchPair> v;
+          for (size_t m = 0; m != matched->size(); ++m) {
+            const T2& match = (*matched)[m];
+            if (select(cand, match)) {
+              double dist = matchDistance(cand, match);
+              if (dist < distMin_)
+                v.push_back(make_pair(m, dist));
+            }
+          }
+          if (!v.empty()) {
+            size_t idx = master.index(c);
+            assert(idx < indices.size());
+            indices[idx] = min_element(v.begin(), v.end(), helper::SortBySecond())->first;
+          }
+        }
+        filler.insert(master.get(), indices.begin(), indices.end());
+        filler.fill();
       }
       evt.put(std::move(matchMap));
     }
 
-  }
-}
+  }  // namespace modulesNew
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/NonNullNumberSelector.h
+++ b/CommonTools/UtilAlgos/interface/NonNullNumberSelector.h
@@ -6,15 +6,12 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<NonNullNumberSelector> {
-      static NonNullNumberSelector make( const edm::ParameterSet & cfg ) {
-	return NonNullNumberSelector();
-      }
+      static NonNullNumberSelector make(const edm::ParameterSet& cfg) { return NonNullNumberSelector(); }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/NtpProducer.h
+++ b/CommonTools/UtilAlgos/interface/NtpProducer.h
@@ -17,17 +17,17 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-template<typename C>
+template <typename C>
 class NtpProducer : public edm::EDProducer {
 public:
   /// constructor from parameter set
-  NtpProducer( const edm::ParameterSet& );
+  NtpProducer(const edm::ParameterSet&);
   /// destructor
   ~NtpProducer() override;
 
 protected:
   /// process an event
-  void produce( edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   /// label of the collection to be read in
@@ -39,59 +39,57 @@ private:
   bool eventInfo_;
 };
 
-template<typename C>
-NtpProducer<C>::NtpProducer( const edm::ParameterSet& par ) :
-  srcToken_( consumes<C>( par.template getParameter<edm::InputTag>( "src" ) ) ),
-  lazyParser_( par.template getUntrackedParameter<bool>( "lazyParser", false ) ),
-  prefix_( par.template getUntrackedParameter<std::string>( "prefix","" ) ),
-  eventInfo_( par.template getUntrackedParameter<bool>( "eventInfo",true ) ){
-  std::vector<edm::ParameterSet> variables =
-                                   par.template getParameter<std::vector<edm::ParameterSet> >("variables");
-   std::vector<edm::ParameterSet>::const_iterator
-     q = variables.begin(), end = variables.end();
-   if(eventInfo_){
-     produces<edm::EventNumber_t>( prefix_+"EventNumber" ).setBranchAlias( prefix_ + "EventNumber" );
-     produces<unsigned int>( prefix_ + "RunNumber" ).setBranchAlias( prefix_ + "RunNumber" );
-     produces<unsigned int>( prefix_ + "LumiBlock" ).setBranchAlias( prefix_ + "Lumiblock" );
-   }
-   for (; q!=end; ++q) {
-     std::string tag = prefix_ + q->getUntrackedParameter<std::string>("tag");
-     StringObjectFunction<typename C::value_type> quantity(q->getUntrackedParameter<std::string>("quantity"), lazyParser_);
-     tags_.push_back(std::make_pair(tag, quantity));
-     produces<std::vector<float> >(tag).setBranchAlias(tag);
-
-   }
+template <typename C>
+NtpProducer<C>::NtpProducer(const edm::ParameterSet& par)
+    : srcToken_(consumes<C>(par.template getParameter<edm::InputTag>("src"))),
+      lazyParser_(par.template getUntrackedParameter<bool>("lazyParser", false)),
+      prefix_(par.template getUntrackedParameter<std::string>("prefix", "")),
+      eventInfo_(par.template getUntrackedParameter<bool>("eventInfo", true)) {
+  std::vector<edm::ParameterSet> variables = par.template getParameter<std::vector<edm::ParameterSet> >("variables");
+  std::vector<edm::ParameterSet>::const_iterator q = variables.begin(), end = variables.end();
+  if (eventInfo_) {
+    produces<edm::EventNumber_t>(prefix_ + "EventNumber").setBranchAlias(prefix_ + "EventNumber");
+    produces<unsigned int>(prefix_ + "RunNumber").setBranchAlias(prefix_ + "RunNumber");
+    produces<unsigned int>(prefix_ + "LumiBlock").setBranchAlias(prefix_ + "Lumiblock");
+  }
+  for (; q != end; ++q) {
+    std::string tag = prefix_ + q->getUntrackedParameter<std::string>("tag");
+    StringObjectFunction<typename C::value_type> quantity(q->getUntrackedParameter<std::string>("quantity"),
+                                                          lazyParser_);
+    tags_.push_back(std::make_pair(tag, quantity));
+    produces<std::vector<float> >(tag).setBranchAlias(tag);
+  }
 }
 
-template<typename C>
-NtpProducer<C>::~NtpProducer() {
-}
+template <typename C>
+NtpProducer<C>::~NtpProducer() {}
 
-template<typename C>
-void NtpProducer<C>::produce( edm::Event& iEvent, const edm::EventSetup&) {
-   edm::Handle<C> coll;
-   iEvent.getByToken(srcToken_, coll);
-   if(eventInfo_){
-     std::unique_ptr<edm::EventNumber_t> event( new edm::EventNumber_t );
-     std::unique_ptr<unsigned int> run( new unsigned int );
-     std::unique_ptr<unsigned int> lumi( new unsigned int );
-     *event = iEvent.id().event();
-     *run = iEvent.id().run();
-     *lumi = iEvent.luminosityBlock();
-     iEvent.put(std::move(event), prefix_ + "EventNumber" );
-     iEvent.put(std::move(run), prefix_ + "RunNumber" );
-     iEvent.put(std::move(lumi), prefix_ + "LumiBlock" );
-   }
-   typename std::vector<std::pair<std::string, StringObjectFunction<typename C::value_type> > >::const_iterator
-     q = tags_.begin(), end = tags_.end();
-   for(;q!=end; ++q) {
-     std::unique_ptr<std::vector<float> > x(new std::vector<float>);
-     x->reserve(coll->size());
-     for (typename C::const_iterator elem=coll->begin(); elem!=coll->end(); ++elem ) {
-       x->push_back(q->second(*elem));
-     }
-     iEvent.put(std::move(x), q->first);
-   }
+template <typename C>
+void NtpProducer<C>::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<C> coll;
+  iEvent.getByToken(srcToken_, coll);
+  if (eventInfo_) {
+    std::unique_ptr<edm::EventNumber_t> event(new edm::EventNumber_t);
+    std::unique_ptr<unsigned int> run(new unsigned int);
+    std::unique_ptr<unsigned int> lumi(new unsigned int);
+    *event = iEvent.id().event();
+    *run = iEvent.id().run();
+    *lumi = iEvent.luminosityBlock();
+    iEvent.put(std::move(event), prefix_ + "EventNumber");
+    iEvent.put(std::move(run), prefix_ + "RunNumber");
+    iEvent.put(std::move(lumi), prefix_ + "LumiBlock");
+  }
+  typename std::vector<std::pair<std::string, StringObjectFunction<typename C::value_type> > >::const_iterator
+      q = tags_.begin(),
+      end = tags_.end();
+  for (; q != end; ++q) {
+    std::unique_ptr<std::vector<float> > x(new std::vector<float>);
+    x->reserve(coll->size());
+    for (typename C::const_iterator elem = coll->begin(); elem != coll->end(); ++elem) {
+      x->push_back(q->second(*elem));
+    }
+    iEvent.put(std::move(x), q->first);
+  }
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/NullPostProcessor.h
+++ b/CommonTools/UtilAlgos/interface/NullPostProcessor.h
@@ -11,20 +11,18 @@ namespace edm {
   class EDFilter;
   class Event;
   class ParameterSet;
-}
+}  // namespace edm
 
 namespace helper {
 
-  template<typename OutputCollection, typename EdmFilter=edm::EDFilter>
+  template <typename OutputCollection, typename EdmFilter = edm::EDFilter>
   struct NullPostProcessor {
-    NullPostProcessor( const edm::ParameterSet & iConfig, edm::ConsumesCollector && iC ) :
-      NullPostProcessor( iConfig ) { }
-    NullPostProcessor( const edm::ParameterSet & iConfig ) { }
-    void init( EdmFilter & ) { }
-    void process( edm::OrphanHandle<OutputCollection>, edm::Event & ) { }
+    NullPostProcessor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) : NullPostProcessor(iConfig) {}
+    NullPostProcessor(const edm::ParameterSet& iConfig) {}
+    void init(EdmFilter&) {}
+    void process(edm::OrphanHandle<OutputCollection>, edm::Event&) {}
   };
 
-}
+}  // namespace helper
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/ObjectCountEventSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectCountEventSelector.h
@@ -22,19 +22,17 @@
 #include "CommonTools/UtilAlgos/interface/CollectionFilterTrait.h"
 #include "CommonTools/UtilAlgos/interface/EventSelectorBase.h"
 
-template<typename C,
-	 typename S = AnySelector,
-	 typename N = MinNumberSelector,
-         typename CS = typename helper::CollectionFilterTrait<C, S, N>::type>
-class ObjectCountEventSelector : public EventSelectorBase
-{
- public:
+template <typename C,
+          typename S = AnySelector,
+          typename N = MinNumberSelector,
+          typename CS = typename helper::CollectionFilterTrait<C, S, N>::type>
+class ObjectCountEventSelector : public EventSelectorBase {
+public:
   /// constructor
-  explicit ObjectCountEventSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    srcToken_( iC.consumes<C>(cfg.template getParameter<edm::InputTag>( "src" ) ) ),
-    select_( reco::modules::make<S>( cfg, iC ) ),
-    sizeSelect_( reco::modules::make<N>( cfg, iC ) ) {
-  }
+  explicit ObjectCountEventSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : srcToken_(iC.consumes<C>(cfg.template getParameter<edm::InputTag>("src"))),
+        select_(reco::modules::make<S>(cfg, iC)),
+        sizeSelect_(reco::modules::make<N>(cfg, iC)) {}
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
     desc.add<edm::InputTag>("src", edm::InputTag());
@@ -44,11 +42,11 @@ class ObjectCountEventSelector : public EventSelectorBase
 
   bool operator()(edm::Event& evt, const edm::EventSetup&) const override {
     edm::Handle<C> source;
-    evt.getByToken( srcToken_, source );
-    return CS::filter( * source, select_, sizeSelect_ );
+    evt.getByToken(srcToken_, source);
+    return CS::filter(*source, select_, sizeSelect_);
   }
 
- private:
+private:
   /// source collection label
   edm::EDGetTokenT<C> srcToken_;
 
@@ -60,4 +58,3 @@ class ObjectCountEventSelector : public EventSelectorBase
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/ObjectCountFilter.h
+++ b/CommonTools/UtilAlgos/interface/ObjectCountFilter.h
@@ -22,12 +22,12 @@
 #include "CommonTools/UtilAlgos/interface/EventSelectorAdapter.h"
 #include "CommonTools/UtilAlgos/interface/ObjectCountEventSelector.h"
 
-template<typename C, 
-	 typename S = AnySelector,
-	 typename N = MinNumberSelector,
-	 typename CS = typename helper::CollectionFilterTrait<C, S, N>::type>
+template <typename C,
+          typename S = AnySelector,
+          typename N = MinNumberSelector,
+          typename CS = typename helper::CollectionFilterTrait<C, S, N>::type>
 struct ObjectCountFilter {
-  typedef EventSelectorAdapter< ObjectCountEventSelector<C, S, N, CS> > type;
+  typedef EventSelectorAdapter<ObjectCountEventSelector<C, S, N, CS> > type;
 };
 
 #endif

--- a/CommonTools/UtilAlgos/interface/ObjectPairCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectPairCollectionSelector.h
@@ -20,37 +20,40 @@
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include <vector>
 
-namespace edm { class Event; }
+namespace edm {
+  class Event;
+}
 
-template<typename InputCollection, typename Selector,
-	 typename StoreContainer = std::vector<const typename InputCollection::value_type *>,
-	 typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
+template <typename InputCollection,
+          typename Selector,
+          typename StoreContainer = std::vector<const typename InputCollection::value_type *>,
+          typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 class ObjectPairCollectionSelector {
 public:
   typedef InputCollection collection;
 
 private:
-  typedef const typename InputCollection::value_type * reference;
+  typedef const typename InputCollection::value_type *reference;
   typedef StoreContainer container;
   typedef typename container::const_iterator const_iterator;
 
 public:
-  ObjectPairCollectionSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) :
-    select_(reco::modules::make<Selector>(cfg)) { }
+  ObjectPairCollectionSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC)
+      : select_(reco::modules::make<Selector>(cfg)) {}
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
   void select(const edm::Handle<InputCollection> &c, const edm::Event &, const edm::EventSetup &) {
     unsigned int s = c->size();
     std::vector<bool> v(s, false);
-    for(unsigned int i = 0; i < s; ++i)
-      for(unsigned int j = i + 1; j < s; ++j) {
-	if(select_((*c)[i], (*c)[j]))
-	  v[i] = v[j] = true;
+    for (unsigned int i = 0; i < s; ++i)
+      for (unsigned int j = i + 1; j < s; ++j) {
+        if (select_((*c)[i], (*c)[j]))
+          v[i] = v[j] = true;
       }
     selected_.clear();
-    for(unsigned int i = 0; i < s; ++i)
-    if (v[i])
-      addRef_(selected_, c, i);
+    for (unsigned int i = 0; i < s; ++i)
+      if (v[i])
+        addRef_(selected_, c, i);
   }
 
 private:
@@ -60,4 +63,3 @@ private:
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/ObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelector.h
@@ -28,33 +28,35 @@
 #include <memory>
 #include <algorithm>
 
-template<typename Selector,
-         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
-	 typename SizeSelector = NonNullNumberSelector,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter>,
-	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
-	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
-	 typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
-	 >
+template <typename Selector,
+          typename OutputCollection =
+              typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
+          typename SizeSelector = NonNullNumberSelector,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter>,
+          typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
+          typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
+          typename Init = typename ::reco::modules::EventSetupInit<Selector>::type>
 class ObjectSelector : public Base {
 public:
   /// constructor
   // ObjectSelector()=default;
-  explicit ObjectSelector(const edm::ParameterSet & cfg) :
-    Base(cfg),
-    srcToken_( this-> template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
-    filter_(false),
-    selector_(cfg, this->consumesCollector()),
-    sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
-    postProcessor_(cfg, this->consumesCollector()) {
+  explicit ObjectSelector(const edm::ParameterSet& cfg)
+      : Base(cfg),
+        srcToken_(
+            this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
+        filter_(false),
+        selector_(cfg, this->consumesCollector()),
+        sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
+        postProcessor_(cfg, this->consumesCollector()) {
     const std::string filter("filter");
     std::vector<std::string> bools = cfg.template getParameterNamesForType<bool>();
     bool found = std::find(bools.begin(), bools.end(), filter) != bools.end();
-    if (found) filter_ = cfg.template getParameter<bool>(filter);
-    postProcessor_.init(* this);
-   }
+    if (found)
+      filter_ = cfg.template getParameter<bool>(filter);
+    postProcessor_.init(*this);
+  }
   /// destructor
-  ~ObjectSelector() override { }
+  ~ObjectSelector() override {}
 
 private:
   /// process one event
@@ -66,7 +68,7 @@ private:
     StoreManager manager(source);
     selector_.select(source, evt, es);
     manager.cloneAndStore(selector_.begin(), selector_.end(), evt);
-    bool result = (! filter_ || sizeSelector_(manager.size()));
+    bool result = (!filter_ || sizeSelector_(manager.size()));
     edm::OrphanHandle<OutputCollection> filtered = manager.put(evt);
     postProcessor_.process(filtered, evt);
     return result;
@@ -84,4 +86,3 @@ private:
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
@@ -21,25 +21,25 @@
  * true), EDProducers are better for the unscheduled mode than
  * EDFilters.
  */
-template<typename Selector,
-         typename OutputCollection,
-         typename PostProcessor,
-         typename StoreManager,
-         typename Base,
-         typename Init
-         >
+template <typename Selector,
+          typename OutputCollection,
+          typename PostProcessor,
+          typename StoreManager,
+          typename Base,
+          typename Init>
 class ObjectSelectorProducer : public Base {
 public:
   /// constructor
-  explicit ObjectSelectorProducer(const edm::ParameterSet & cfg) :
-    Base(cfg),
-    srcToken_( this-> template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
-    selector_(cfg, this->consumesCollector()),
-    postProcessor_(cfg, this->consumesCollector()) {
-    postProcessor_.init(* this);
-   }
+  explicit ObjectSelectorProducer(const edm::ParameterSet& cfg)
+      : Base(cfg),
+        srcToken_(
+            this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
+        selector_(cfg, this->consumesCollector()),
+        postProcessor_(cfg, this->consumesCollector()) {
+    postProcessor_.init(*this);
+  }
   /// destructor
-  ~ObjectSelectorProducer() override { }
+  ~ObjectSelectorProducer() override {}
 
 private:
   /// process one event
@@ -60,6 +60,5 @@ private:
   /// post processor
   PostProcessor postProcessor_;
 };
-
 
 #endif

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorStream.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorStream.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/UtilAlgos
 // Class  :     ObjectSelectorStream
-// 
+//
 /**\class ObjectSelectorStream ObjectSelectorStream.h "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 
  Description: Template for constructing stream based object selector modules
@@ -22,13 +22,20 @@
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 
-template<typename Selector,
-         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
-	 typename SizeSelector = NonNullNumberSelector,
-  typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<>>,
-  typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::type,
-  typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
-  >
-  using ObjectSelectorStream = ObjectSelector<Selector,OutputCollection,SizeSelector, PostProcessor,StoreManager, typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::base, Init>;
+template <typename Selector,
+          typename OutputCollection =
+              typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
+          typename SizeSelector = NonNullNumberSelector,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<>>,
+          typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::type,
+          typename Init = typename ::reco::modules::EventSetupInit<Selector>::type>
+using ObjectSelectorStream =
+    ObjectSelector<Selector,
+                   OutputCollection,
+                   SizeSelector,
+                   PostProcessor,
+                   StoreManager,
+                   typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDFilter<>>::base,
+                   Init>;
 
 #endif

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h
@@ -4,12 +4,18 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h"
 
-template<typename Selector,
-         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
-         typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDProducer<>>,
-         typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::type,
-         typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
-         >
-  using ObjectSelectorStreamProducer = ObjectSelectorProducer<Selector, OutputCollection, PostProcessor, StoreManager, typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::base, Init>;
+template <
+    typename Selector,
+    typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
+    typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDProducer<>>,
+    typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::type,
+    typename Init = typename ::reco::modules::EventSetupInit<Selector>::type>
+using ObjectSelectorStreamProducer =
+    ObjectSelectorProducer<Selector,
+                           OutputCollection,
+                           PostProcessor,
+                           StoreManager,
+                           typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::base,
+                           Init>;
 
 #endif

--- a/CommonTools/UtilAlgos/interface/OrSelector.h
+++ b/CommonTools/UtilAlgos/interface/OrSelector.h
@@ -5,47 +5,41 @@
 
 namespace reco {
   namespace modules {
-    
-    template<typename S1, typename S2, typename S3, typename S4, typename S5>
+
+    template <typename S1, typename S2, typename S3, typename S4, typename S5>
     struct ParameterAdapter<OrSelector<S1, S2, S3, S4, S5> > {
-      static OrSelector<S1, S2, S3, S4, S5> make( const edm::ParameterSet & cfg ) {
-	return OrSelector<S1, S2, S3, S4, S5>( modules::make<S1>( cfg ), 
-					       modules::make<S2>( cfg ), 
-					       modules::make<S3>( cfg ), 
-					       modules::make<S4>( cfg ), 
-					       modules::make<S5>( cfg ) ); 
+      static OrSelector<S1, S2, S3, S4, S5> make(const edm::ParameterSet& cfg) {
+        return OrSelector<S1, S2, S3, S4, S5>(modules::make<S1>(cfg),
+                                              modules::make<S2>(cfg),
+                                              modules::make<S3>(cfg),
+                                              modules::make<S4>(cfg),
+                                              modules::make<S5>(cfg));
       }
     };
-    
-    template<typename S1, typename S2, typename S3, typename S4>
+
+    template <typename S1, typename S2, typename S3, typename S4>
     struct ParameterAdapter<OrSelector<S1, S2, S3, S4> > {
-      static OrSelector<S1, S2, S3, S4> make( const edm::ParameterSet & cfg ) {
-	return OrSelector<S1, S2, S3, S4>( modules::make<S1>( cfg ), 
-					   modules::make<S2>( cfg ), 
-					   modules::make<S3>( cfg ), 
-					   modules::make<S4>( cfg ) ); 
+      static OrSelector<S1, S2, S3, S4> make(const edm::ParameterSet& cfg) {
+        return OrSelector<S1, S2, S3, S4>(
+            modules::make<S1>(cfg), modules::make<S2>(cfg), modules::make<S3>(cfg), modules::make<S4>(cfg));
       }
     };
-    
-    template<typename S1, typename S2, typename S3>
+
+    template <typename S1, typename S2, typename S3>
     struct ParameterAdapter<OrSelector<S1, S2, S3> > {
-      static OrSelector<S1, S2, S3> make( const edm::ParameterSet & cfg ) {
-	return OrSelector<S1, S2, S3>( modules::make<S1>( cfg ), 
-				       modules::make<S2>( cfg ), 
-				       modules::make<S3>( cfg ) ); 
+      static OrSelector<S1, S2, S3> make(const edm::ParameterSet& cfg) {
+        return OrSelector<S1, S2, S3>(modules::make<S1>(cfg), modules::make<S2>(cfg), modules::make<S3>(cfg));
       }
     };
-    
-    template<typename S1, typename S2>
+
+    template <typename S1, typename S2>
     struct ParameterAdapter<OrSelector<S1, S2> > {
-      static OrSelector<S1, S2> make( const edm::ParameterSet & cfg ) {
-	return OrSelector<S1, S2>( modules::make<S1>( cfg ), 
-				   modules::make<S2>( cfg ) ); 
+      static OrSelector<S1, S2> make(const edm::ParameterSet& cfg) {
+        return OrSelector<S1, S2>(modules::make<S1>(cfg), modules::make<S2>(cfg));
       }
     };
-    
-  }
-}
+
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/OverlapExclusionSelector.h
+++ b/CommonTools/UtilAlgos/interface/OverlapExclusionSelector.h
@@ -6,41 +6,42 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-namespace edm { class EventSetup; }
+namespace edm {
+  class EventSetup;
+}
 
-template<typename C, typename T, typename O>
+template <typename C, typename T, typename O>
 class OverlapExclusionSelector {
 public:
-  OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector && iC) :
-    OverlapExclusionSelector(cfg, iC) {};
-  OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector & iC);
+  OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : OverlapExclusionSelector(cfg, iC){};
+  OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
   void newEvent(const edm::Event&, const edm::EventSetup&) const;
   bool operator()(const T&) const;
+
 private:
   edm::EDGetTokenT<C> srcToken_;
   mutable typename C::const_iterator begin_, end_;
   O overlap_;
 };
 
-template<typename C, typename T, typename O>
-OverlapExclusionSelector<C, T, O>::OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector & iC) :
-  srcToken_(iC.consumes<C>(cfg.template getParameter<edm::InputTag>("overlap"))),
-  overlap_(cfg) {
-}
+template <typename C, typename T, typename O>
+OverlapExclusionSelector<C, T, O>::OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
+    : srcToken_(iC.consumes<C>(cfg.template getParameter<edm::InputTag>("overlap"))), overlap_(cfg) {}
 
-template<typename C, typename T, typename O>
-       void OverlapExclusionSelector<C, T, O>::newEvent(const edm::Event& evt, const edm::EventSetup&) const {
+template <typename C, typename T, typename O>
+void OverlapExclusionSelector<C, T, O>::newEvent(const edm::Event& evt, const edm::EventSetup&) const {
   edm::Handle<C> h;
   evt.getByToken(srcToken_, h);
   begin_ = h->begin();
   end_ = h->end();
 }
 
-template<typename C, typename T, typename O>
+template <typename C, typename T, typename O>
 bool OverlapExclusionSelector<C, T, O>::operator()(const T& t) const {
   bool noOverlap = true;
-  for(typename C::const_iterator i = begin_; i != end_; ++i) {
-    if(overlap_(*i, t)) {
+  for (typename C::const_iterator i = begin_; i != end_; ++i) {
+    if (overlap_(*i, t)) {
       noOverlap = false;
       break;
     }

--- a/CommonTools/UtilAlgos/interface/PairSelector.h
+++ b/CommonTools/UtilAlgos/interface/PairSelector.h
@@ -7,20 +7,17 @@
 namespace reco {
   namespace modules {
 
-    template<typename S1, typename S2>
+    template <typename S1, typename S2>
     struct ParameterAdapter<PairSelector<S1, S2> > {
-      static PairSelector<S1, S2> make( const edm::ParameterSet & cfg ) {
-	return PairSelector<S1, S2>( modules::make<S1>( cfg ),
-				     modules::make<S2>( cfg ) );
+      static PairSelector<S1, S2> make(const edm::ParameterSet& cfg) {
+        return PairSelector<S1, S2>(modules::make<S1>(cfg), modules::make<S2>(cfg));
       }
-      static PairSelector<S1, S2> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return PairSelector<S1, S2>( modules::make<S1>( cfg, iC ),
-				     modules::make<S2>( cfg, iC ) );
+      static PairSelector<S1, S2> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return PairSelector<S1, S2>(modules::make<S1>(cfg, iC), modules::make<S2>(cfg, iC));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/ParameterAdapter.h
+++ b/CommonTools/UtilAlgos/interface/ParameterAdapter.h
@@ -8,33 +8,25 @@
 namespace reco {
   namespace modules {
 
-    template<typename S>
+    template <typename S>
     struct ParameterAdapter {
-      static S make(const edm::ParameterSet & cfg) {
-	return S(cfg);
-      }
-      static S make(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) {
-	return S(cfg, iC);
-      }
-      static S make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) {
-	return S(cfg, iC);
-      }
+      static S make(const edm::ParameterSet& cfg) { return S(cfg); }
+      static S make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) { return S(cfg, iC); }
+      static S make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) { return S(cfg, iC); }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-        S::template fillPSetDescription(desc);
-      }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { S::template fillPSetDescription(desc); }
     };
 
-    template<typename S>
-    S make(const edm::ParameterSet & cfg) {
+    template <typename S>
+    S make(const edm::ParameterSet& cfg) {
       return ParameterAdapter<S>::make(cfg);
     }
-    template<typename S>
-    S make(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) {
+    template <typename S>
+    S make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
       return ParameterAdapter<S>::make(cfg, iC);
     }
-    template<typename S>
-    S make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) {
+    template <typename S>
+    S make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
       return ParameterAdapter<S>::make(cfg, iC);
     }
 
@@ -42,26 +34,19 @@ namespace reco {
     void fillPSetDescription(edm::ParameterSetDescription& desc) {
       ParameterAdapter<S>::fillPSetDescription(desc);
     }
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
-#define NOPARAMETER_ADAPTER(TYPE) \
-namespace reco { \
-  namespace modules { \
-    struct ParameterAdapter<TYPE> { \
-      static TYPE make(const edm::ParameterSet & cfg) { \
-	return TYPE(); \
-      } \
-      static TYPE make(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) { \
-	return TYPE(); \
-      } \
-      static TYPE make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) { \
-	return TYPE(); \
-      } \
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {} \
-    }; \
-  } \
-}
+#define NOPARAMETER_ADAPTER(TYPE)                                                                      \
+  namespace reco {                                                                                     \
+    namespace modules {                                                                                \
+      struct ParameterAdapter<TYPE> {                                                                  \
+        static TYPE make(const edm::ParameterSet& cfg) { return TYPE(); }                              \
+        static TYPE make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) { return TYPE(); } \
+        static TYPE make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) { return TYPE(); }  \
+        static void fillPSetDescription(edm::ParameterSetDescription& desc) {}                         \
+      };                                                                                               \
+    }                                                                                                  \
+  }
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/PdgIdExcluder.h
+++ b/CommonTools/UtilAlgos/interface/PdgIdExcluder.h
@@ -7,14 +7,14 @@
 namespace reco {
   namespace modules {
 
-    template<>
-      struct ParameterAdapter<PdgIdExcluder> {
-	static PdgIdExcluder make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	  return PdgIdExcluder( cfg.getParameter<std::vector<int> >( "pdgId" ) );
-	}
-      };
+    template <>
+    struct ParameterAdapter<PdgIdExcluder> {
+      static PdgIdExcluder make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return PdgIdExcluder(cfg.getParameter<std::vector<int> >("pdgId"));
+      }
+    };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/PdgIdSelector.h
+++ b/CommonTools/UtilAlgos/interface/PdgIdSelector.h
@@ -7,30 +7,25 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<PdgIdSelector> {
-      static PdgIdSelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return PdgIdSelector( cfg.getParameter<std::vector<int> >( "pdgId" ) );
+      static PdgIdSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return PdgIdSelector(cfg.getParameter<std::vector<int> >("pdgId"));
       }
     };
 
-  }
-}
-
+  }  // namespace modules
+}  // namespace reco
 
 // Introducing a simpler way to use a string object selector outside of the
 // heavily-templated infrastructure above. This simply translates the cfg
 // into the string that the functor expects.
-namespace reco{
-    class PdgIdSelectorHandler : public PdgIdSelector  {
-    public:
-      explicit PdgIdSelectorHandler( const edm::ParameterSet & cfg ) :
-        PdgIdSelector(cfg.getParameter<std::vector<int> >("pdgId"))
-      {
-      }
+namespace reco {
+  class PdgIdSelectorHandler : public PdgIdSelector {
+  public:
+    explicit PdgIdSelectorHandler(const edm::ParameterSet& cfg)
+        : PdgIdSelector(cfg.getParameter<std::vector<int> >("pdgId")) {}
   };
-}
-
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/PhysObjectMatcher.h
+++ b/CommonTools/UtilAlgos/interface/PhysObjectMatcher.h
@@ -26,23 +26,21 @@ namespace reco {
 
   namespace helper {
     /// Default class for ranking matches: sorting by smaller distance.
-    template<typename D, typename C1, typename C2> class LessByMatchDistance {
+    template <typename D, typename C1, typename C2>
+    class LessByMatchDistance {
     public:
-      LessByMatchDistance (const edm::ParameterSet& cfg,
-			   const C1& c1, const C2& c2) :
-	distance_(reco::modules::make<D>(cfg)), c1_(c1), c2_(c2) {}
-      bool operator() (const std::pair<size_t,size_t>& p1,
-		       const std::pair<size_t,size_t>& p2) const {
-	return
-	  distance_(c1_[p1.first],c2_[p1.second])<
-	  distance_(c1_[p2.first],c2_[p2.second]);
+      LessByMatchDistance(const edm::ParameterSet& cfg, const C1& c1, const C2& c2)
+          : distance_(reco::modules::make<D>(cfg)), c1_(c1), c2_(c2) {}
+      bool operator()(const std::pair<size_t, size_t>& p1, const std::pair<size_t, size_t>& p2) const {
+        return distance_(c1_[p1.first], c2_[p1.second]) < distance_(c1_[p2.first], c2_[p2.second]);
       }
+
     private:
       D distance_;
       const C1& c1_;
       const C2& c2_;
     };
-  }
+  }  // namespace helper
 
   // Template arguments:
   // C1 .. candidate collection to be matched
@@ -52,18 +50,16 @@ namespace reco {
   //         default: deltaR cut
   // Q ... ranking of matches
   //         default: by smaller deltaR
-  template<typename C1, typename C2, typename S,
-	   typename D = reco::MatchByDR<typename C1::value_type,
-					typename C2::value_type>,
-	   typename Q =
-	   helper::LessByMatchDistance< DeltaR<typename C1::value_type,
-					       typename C2::value_type>,
-					C1, C2 >
-  >
+  template <typename C1,
+            typename C2,
+            typename S,
+            typename D = reco::MatchByDR<typename C1::value_type, typename C2::value_type>,
+            typename Q = helper::LessByMatchDistance<DeltaR<typename C1::value_type, typename C2::value_type>, C1, C2> >
   class PhysObjectMatcher : public edm::stream::EDProducer<> {
   public:
-    PhysObjectMatcher(const edm::ParameterSet & cfg);
+    PhysObjectMatcher(const edm::ParameterSet& cfg);
     ~PhysObjectMatcher() override;
+
   private:
     typedef typename C1::value_type T1;
     typedef typename C2::value_type T2;
@@ -74,38 +70,36 @@ namespace reco {
     edm::ParameterSet config_;
     edm::EDGetTokenT<C1> srcToken_;
     edm::EDGetTokenT<C2> matchedToken_;
-    bool resolveAmbiguities_;            // resolve ambiguities after
-                                         //   first pass?
-    bool resolveByMatchQuality_;         // resolve by (global) quality
-                                         //   of match (otherwise: by order
-                                         //   of test candidates)
-    bool select(const T1 & c1, const T2 & c2) const {
-      return select_(c1, c2);
-    }
+    bool resolveAmbiguities_;     // resolve ambiguities after
+                                  //   first pass?
+    bool resolveByMatchQuality_;  // resolve by (global) quality
+                                  //   of match (otherwise: by order
+                                  //   of test candidates)
+    bool select(const T1& c1, const T2& c2) const { return select_(c1, c2); }
     S select_;
     D distance_;
-//     DeltaR<typename C1::value_type, typename C2::value_type> testDR_;
+    //     DeltaR<typename C1::value_type, typename C2::value_type> testDR_;
   };
 
-  template<typename C1, typename C2, typename S, typename D, typename Q>
-  PhysObjectMatcher<C1, C2, S, D, Q>::PhysObjectMatcher(const edm::ParameterSet & cfg) :
-    config_(cfg),
-    srcToken_(consumes<C1>(cfg.template getParameter<edm::InputTag>("src"))),
-    matchedToken_(consumes<C2>(cfg.template getParameter<edm::InputTag>("matched"))),
-    resolveAmbiguities_(cfg.template getParameter<bool>("resolveAmbiguities")),
-    resolveByMatchQuality_(cfg.template getParameter<bool>("resolveByMatchQuality")),
-    select_(reco::modules::make<S>(cfg)),
-    distance_(reco::modules::make<D>(cfg)) {
+  template <typename C1, typename C2, typename S, typename D, typename Q>
+  PhysObjectMatcher<C1, C2, S, D, Q>::PhysObjectMatcher(const edm::ParameterSet& cfg)
+      : config_(cfg),
+        srcToken_(consumes<C1>(cfg.template getParameter<edm::InputTag>("src"))),
+        matchedToken_(consumes<C2>(cfg.template getParameter<edm::InputTag>("matched"))),
+        resolveAmbiguities_(cfg.template getParameter<bool>("resolveAmbiguities")),
+        resolveByMatchQuality_(cfg.template getParameter<bool>("resolveByMatchQuality")),
+        select_(reco::modules::make<S>(cfg)),
+        distance_(reco::modules::make<D>(cfg)) {
     // definition of the product
     produces<MatchMap>();
     // set resolveByMatchQuality only if ambiguities are to be resolved
     resolveByMatchQuality_ = resolveByMatchQuality_ && resolveAmbiguities_;
   }
 
-  template<typename C1, typename C2, typename S, typename D, typename Q>
-  PhysObjectMatcher<C1, C2, S, D, Q>::~PhysObjectMatcher() { }
+  template <typename C1, typename C2, typename S, typename D, typename Q>
+  PhysObjectMatcher<C1, C2, S, D, Q>::~PhysObjectMatcher() {}
 
-  template<typename C1, typename C2, typename S, typename D, typename Q>
+  template <typename C1, typename C2, typename S, typename D, typename Q>
   void PhysObjectMatcher<C1, C2, S, D, Q>::produce(edm::Event& evt, const edm::EventSetup&) {
     using namespace edm;
     using namespace std;
@@ -119,72 +113,75 @@ namespace reco {
     // create product
     unique_ptr<MatchMap> matchMap(new MatchMap(matched));
     size_t size = cands->size();
-    if( size != 0 ) {
+    if (size != 0) {
       //
       // create helpers
       //
-      Q comparator(config_,*cands,*matched);
+      Q comparator(config_, *cands, *matched);
       typename MatchMap::Filler filler(*matchMap);
       ::helper::MasterCollection<C1> master(cands, evt);
       vector<int> indices(master.size(), -1);      // result: indices in target collection
-      vector<bool> mLock(matched->size(),false);   // locks in target collection
+      vector<bool> mLock(matched->size(), false);  // locks in target collection
       MatchContainer matchPairs;                   // container of matched pairs
       // loop over candidates
-      for(size_t c = 0; c != size; ++ c) {
-	const T1 & cand = (*cands)[c];
-	// no global comparison of match quality -> reset the container for each candidate
-	if ( !resolveByMatchQuality_ )  matchPairs.clear();
-	// loop over target collection
-	for(size_t m = 0; m != matched->size(); ++m) {
-	  const T2 & match = (* matched)[m];
-	  // check lock and preselection
-	  if ( !mLock[m] && select(cand, match)) {
-//  	    double dist = testDR_(cand,match);
-//   	    cout << "dist between c = " << c << " and m = "
-//   		 << m << " is " << dist << " at pts of "
-//  		 << cand.pt() << " " << match.pt() << endl;
-	    // matching requirement fulfilled -> store pair of indices
-	    if ( distance_(cand,match) )  matchPairs.push_back(make_pair(c,m));
-	  }
-	}
-	// if match(es) found and no global ambiguity resolution requested
-	if ( !matchPairs.empty() && !resolveByMatchQuality_ ) {
-	  // look for and store best match
-	  size_t idx = master.index(c);
-	  assert(idx < indices.size());
-	  size_t index = min_element(matchPairs.begin(), matchPairs.end(), comparator)->second;
-	  indices[idx] = index;
-	  // if ambiguity resolution by order of (reco) candidates:
-	  //   lock element in target collection
-	  if ( resolveAmbiguities_ )  mLock[index] = true;
-// 	  {
-// 	    MatchContainer::const_iterator i = min_element(matchPairs.begin(), matchPairs.end(), comparator);
-//  	    cout << "smallest distance for c = " << c << " is "
-//  		 << testDR_((*cands)[(*i).first],
-// 			    (*matched)[(*i).second]) << endl;
-// 	  }
-	}
+      for (size_t c = 0; c != size; ++c) {
+        const T1& cand = (*cands)[c];
+        // no global comparison of match quality -> reset the container for each candidate
+        if (!resolveByMatchQuality_)
+          matchPairs.clear();
+        // loop over target collection
+        for (size_t m = 0; m != matched->size(); ++m) {
+          const T2& match = (*matched)[m];
+          // check lock and preselection
+          if (!mLock[m] && select(cand, match)) {
+            //  	    double dist = testDR_(cand,match);
+            //   	    cout << "dist between c = " << c << " and m = "
+            //   		 << m << " is " << dist << " at pts of "
+            //  		 << cand.pt() << " " << match.pt() << endl;
+            // matching requirement fulfilled -> store pair of indices
+            if (distance_(cand, match))
+              matchPairs.push_back(make_pair(c, m));
+          }
+        }
+        // if match(es) found and no global ambiguity resolution requested
+        if (!matchPairs.empty() && !resolveByMatchQuality_) {
+          // look for and store best match
+          size_t idx = master.index(c);
+          assert(idx < indices.size());
+          size_t index = min_element(matchPairs.begin(), matchPairs.end(), comparator)->second;
+          indices[idx] = index;
+          // if ambiguity resolution by order of (reco) candidates:
+          //   lock element in target collection
+          if (resolveAmbiguities_)
+            mLock[index] = true;
+          // 	  {
+          // 	    MatchContainer::const_iterator i = min_element(matchPairs.begin(), matchPairs.end(), comparator);
+          //  	    cout << "smallest distance for c = " << c << " is "
+          //  		 << testDR_((*cands)[(*i).first],
+          // 			    (*matched)[(*i).second]) << endl;
+          // 	  }
+        }
       }
       // ambiguity resolution by global match quality (if requested)
-      if ( resolveByMatchQuality_ ) {
-	// sort container of all matches by quality
-	sort(matchPairs.begin(),matchPairs.end(),comparator);
-	vector<bool> cLock(master.size(),false);
-	// loop over sorted container
-	for ( MatchContainer::const_iterator i=matchPairs.begin();
-	      i!=matchPairs.end(); ++i ) {
-	  size_t c = (*i).first;
-	  size_t m = (*i).second;
-// 	  cout << "rel dp = " << ((*cands)[c].pt()-(*matched)[m].pt())/(*matched)[m].pt() << endl;
-	  // accept only pairs without any lock
-	  if ( mLock[m] || cLock[c] )  continue;
-	  // store index to target collection and lock the two items
-	  size_t idx = master.index(c);
-	  assert(idx < indices.size());
-	  indices[idx] = m;
-	  mLock[m] = true;
-	  cLock[c] = true;
-	}
+      if (resolveByMatchQuality_) {
+        // sort container of all matches by quality
+        sort(matchPairs.begin(), matchPairs.end(), comparator);
+        vector<bool> cLock(master.size(), false);
+        // loop over sorted container
+        for (MatchContainer::const_iterator i = matchPairs.begin(); i != matchPairs.end(); ++i) {
+          size_t c = (*i).first;
+          size_t m = (*i).second;
+          // 	  cout << "rel dp = " << ((*cands)[c].pt()-(*matched)[m].pt())/(*matched)[m].pt() << endl;
+          // accept only pairs without any lock
+          if (mLock[m] || cLock[c])
+            continue;
+          // store index to target collection and lock the two items
+          size_t idx = master.index(c);
+          assert(idx < indices.size());
+          indices[idx] = m;
+          mLock[m] = true;
+          cLock[c] = true;
+        }
       }
       filler.insert(master.get(), indices.begin(), indices.end());
       filler.fill();
@@ -192,6 +189,6 @@ namespace reco {
     evt.put(std::move(matchMap));
   }
 
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
+++ b/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
@@ -1,7 +1,6 @@
 #ifndef CommonTools_UtilAlgos_ProductFromFwdPtrProducer_h
 #define CommonTools_UtilAlgos_ProductFromFwdPtrProducer_h
 
-
 /**
   \class    edm::ProductFromFwdPtrProducer ProductFromFwdPtrProducer.h "CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h"
   \brief    Produces a list of objects "by value" that correspond to the FwdPtr's from an input collection.
@@ -9,7 +8,6 @@
 
   \author   Salvatore Rappoccio
 */
-
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -22,41 +20,36 @@
 
 namespace edm {
 
-
-
-  template < class T, class H = ProductFromFwdPtrFactory<T> >
-    class ProductFromFwdPtrProducer : public edm::global::EDProducer<> {
-  public :
-    explicit ProductFromFwdPtrProducer( edm::ParameterSet const & params ) :
-      srcToken_   ( consumes< std::vector<edm::FwdPtr<T> > >( params.getParameter<edm::InputTag>("src") ) )
-    {
-      produces< std::vector<T> > ();
+  template <class T, class H = ProductFromFwdPtrFactory<T> >
+  class ProductFromFwdPtrProducer : public edm::global::EDProducer<> {
+  public:
+    explicit ProductFromFwdPtrProducer(edm::ParameterSet const& params)
+        : srcToken_(consumes<std::vector<edm::FwdPtr<T> > >(params.getParameter<edm::InputTag>("src"))) {
+      produces<std::vector<T> >();
     }
 
     ~ProductFromFwdPtrProducer() override {}
 
-  void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override {
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
+      edm::Handle<std::vector<edm::FwdPtr<T> > > hSrc;
+      iEvent.getByToken(srcToken_, hSrc);
 
-      edm::Handle< std::vector<edm::FwdPtr<T> > > hSrc;
-      iEvent.getByToken( srcToken_, hSrc );
+      std::unique_ptr<std::vector<T> > pOutput(new std::vector<T>);
 
-      std::unique_ptr< std::vector<T> > pOutput ( new std::vector<T> );
-
-      for ( typename std::vector< edm::FwdPtr<T> >::const_iterator ibegin = hSrc->begin(),
-	      iend = hSrc->end(),
-	      i = ibegin; i!= iend; ++i ) {
-	H factory;
-	T t = factory(*i);
-	pOutput->push_back( t );
+      for (typename std::vector<edm::FwdPtr<T> >::const_iterator ibegin = hSrc->begin(), iend = hSrc->end(), i = ibegin;
+           i != iend;
+           ++i) {
+        H factory;
+        T t = factory(*i);
+        pOutput->push_back(t);
       }
-
 
       iEvent.put(std::move(pOutput));
     }
 
-  protected :
-    const edm::EDGetTokenT< std::vector<edm::FwdPtr<T> > > srcToken_;
+  protected:
+    const edm::EDGetTokenT<std::vector<edm::FwdPtr<T> > > srcToken_;
   };
-}
+}  // namespace edm
 
 #endif

--- a/CommonTools/UtilAlgos/interface/PtMinSelector.h
+++ b/CommonTools/UtilAlgos/interface/PtMinSelector.h
@@ -8,19 +8,16 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<PtMinSelector> {
-      static PtMinSelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return PtMinSelector( cfg.getParameter<double>( "ptMin" ) );
+      static PtMinSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return PtMinSelector(cfg.getParameter<double>("ptMin"));
       }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-        desc.add<double>("ptMin", 0.);
-      }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<double>("ptMin", 0.); }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/RangeObjectPairSelector.h
+++ b/CommonTools/UtilAlgos/interface/RangeObjectPairSelector.h
@@ -5,21 +5,17 @@
 
 namespace reco {
   namespace modules {
-    
-    template<typename F>
+
+    template <typename F>
     struct ParameterAdapter<RangeObjectPairSelector<F> > {
-      static RangeObjectPairSelector<F> make( const edm::ParameterSet & cfg ) {
-	return RangeObjectPairSelector<F>( cfg.template getParameter<double>( "rangeMin" ),
-					   cfg.template getParameter<double>( "rangeMax" ),
-					   reco::modules::make<F>( cfg )
-					   );
+      static RangeObjectPairSelector<F> make(const edm::ParameterSet& cfg) {
+        return RangeObjectPairSelector<F>(cfg.template getParameter<double>("rangeMin"),
+                                          cfg.template getParameter<double>("rangeMax"),
+                                          reco::modules::make<F>(cfg));
       }
     };
-    
-  }
-}
 
-
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/RefSelector.h
+++ b/CommonTools/UtilAlgos/interface/RefSelector.h
@@ -7,15 +7,14 @@
 namespace reco {
   namespace modules {
 
-    template<typename S>
+    template <typename S>
     struct ParameterAdapter<RefSelector<S> > {
-      static RefSelector<S> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return RefSelector<S>( modules::make<S>( cfg, iC ) );
+      static RefSelector<S> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return RefSelector<S>(modules::make<S>(cfg, iC));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h
+++ b/CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h
@@ -14,37 +14,36 @@
 
 namespace helper {
 
-  template<typename InputCollection>
+  template <typename InputCollection>
   struct SelectedOutputCollectionTrait {
     typedef InputCollection type;
   };
 
-  template<typename K, typename C>
+  template <typename K, typename C>
   struct SelectedOutputCollectionTrait<edm::AssociationVector<edm::RefProd<K>, C> > {
     typedef typename edm::RefProd<K>::product_type type;
   };
 
-  template<typename T, typename C>
+  template <typename T, typename C>
   struct SelectedOutputCollectionTrait<edm::AssociationVector<edm::RefToBaseProd<T>, C> > {
     typedef typename edm::RefToBaseVector<T> type;
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectedOutputCollectionTrait<edm::View<T> > {
     typedef typename edm::RefToBaseVector<T> type;
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectedOutputCollectionTrait<edm::RefToBaseVector<T> > {
     typedef typename edm::RefToBaseVector<T> type;
   };
 
-  template<typename C>
+  template <typename C>
   struct SelectedOutputCollectionTrait<edm::RefVector<C> > {
     typedef typename edm::RefVector<C> type;
   };
 
-}
+}  // namespace helper
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SelectionAdderTrait.h
+++ b/CommonTools/UtilAlgos/interface/SelectionAdderTrait.h
@@ -14,135 +14,133 @@
 
 namespace helper {
 
-  template<typename StoreContainer>
+  template <typename StoreContainer>
   struct SelectionCopyAdder {
-    template<typename C>
-    void operator()( StoreContainer & selected, const edm::Handle<C> & c, size_t idx ) {
-      selected.push_back( ( * c )[ idx ] );
+    template <typename C>
+    void operator()(StoreContainer &selected, const edm::Handle<C> &c, size_t idx) {
+      selected.push_back((*c)[idx]);
     }
   };
 
-  template<typename StoreContainer>
+  template <typename StoreContainer>
   struct SelectionPointerAdder {
-    template<typename C>
-    void operator()( StoreContainer & selected, const edm::Handle<C> & c, size_t idx ) {
-      selected.push_back( & ( * c )[ idx ] );
+    template <typename C>
+    void operator()(StoreContainer &selected, const edm::Handle<C> &c, size_t idx) {
+      selected.push_back(&(*c)[idx]);
     }
   };
 
-  template<typename StoreContainer>
+  template <typename StoreContainer>
   struct SelectionPointerDerefAdder {
-    template<typename C>
-    void operator()( StoreContainer & selected, const edm::Handle<C> & c, size_t idx ) {
-      selected.push_back( & * ( * c )[ idx ] );
+    template <typename C>
+    void operator()(StoreContainer &selected, const edm::Handle<C> &c, size_t idx) {
+      selected.push_back(&*(*c)[idx]);
     }
   };
 
-  template<typename StoreContainer>
+  template <typename StoreContainer>
   struct SelectionFirstPointerAdder {
-    template<typename C>
-    void operator()( StoreContainer & selected, const edm::Handle<C> & c, size_t idx ) {
-      selected.push_back( & * ( ( * c )[ idx ].first ) );
+    template <typename C>
+    void operator()(StoreContainer &selected, const edm::Handle<C> &c, size_t idx) {
+      selected.push_back(&*((*c)[idx].first));
     }
   };
 
-  template<typename StoreContainer>
+  template <typename StoreContainer>
   struct SelectionFirstRefAdder {
-    template<typename C>
-    void operator()( StoreContainer & selected, const edm::Handle<C> & c, size_t idx ) {
-      selected.push_back( ( * c )[ idx ].first );
+    template <typename C>
+    void operator()(StoreContainer &selected, const edm::Handle<C> &c, size_t idx) {
+      selected.push_back((*c)[idx].first);
     }
   };
 
-  template<typename StoreContainer>
+  template <typename StoreContainer>
   struct SelectionRefAdder {
-    template<typename C>
-    void operator()( StoreContainer & selected, const edm::Handle<C> & c, size_t idx ) {
-      selected.push_back( edm::Ref<C>( c, idx ) );
+    template <typename C>
+    void operator()(StoreContainer &selected, const edm::Handle<C> &c, size_t idx) {
+      selected.push_back(edm::Ref<C>(c, idx));
     }
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectionRefViewAdder {
-    void operator()( edm::RefToBaseVector<T> & selected, const edm::Handle<edm::View<T> > & c, size_t idx ) {
-      selected.push_back( c->refAt( idx ) );
+    void operator()(edm::RefToBaseVector<T> &selected, const edm::Handle<edm::View<T> > &c, size_t idx) {
+      selected.push_back(c->refAt(idx));
     }
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectionPtrViewAdder {
-    void operator()( edm::PtrVector<T> & selected, const edm::Handle<edm::View<T> > & c, size_t idx ) {
-      selected.push_back( c->ptrAt( idx ) );
+    void operator()(edm::PtrVector<T> &selected, const edm::Handle<edm::View<T> > &c, size_t idx) {
+      selected.push_back(c->ptrAt(idx));
     }
   };
 
-  template<typename InputCollection, typename StoreContainer>
+  template <typename InputCollection, typename StoreContainer>
   struct SelectionAdderTrait {
-    static_assert(sizeof(InputCollection) == 0); 
+    static_assert(sizeof(InputCollection) == 0);
   };
 
-  template<typename InputCollection, typename T>
+  template <typename InputCollection, typename T>
   struct SelectionAdderTrait<InputCollection, std::vector<const T *> > {
     typedef SelectionPointerAdder<std::vector<const T *> > type;
   };
 
-  template<typename InputCollection, typename C>
+  template <typename InputCollection, typename C>
   struct SelectionAdderTrait<InputCollection, edm::RefVector<C> > {
     typedef SelectionRefAdder<edm::RefVector<C> > type;
   };
 
-  template<typename C>
+  template <typename C>
   struct SelectionAdderTrait<edm::RefVector<C>, edm::RefVector<C> > {
     typedef SelectionCopyAdder<edm::RefVector<C> > type;
   };
 
-  template<typename C, typename T>
+  template <typename C, typename T>
   struct SelectionAdderTrait<edm::RefVector<C>, std::vector<const T *> > {
     typedef SelectionPointerDerefAdder<std::vector<const T *> > type;
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectionAdderTrait<edm::RefToBaseVector<T>, edm::RefToBaseVector<T> > {
     typedef SelectionCopyAdder<edm::RefToBaseVector<T> > type;
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectionAdderTrait<edm::RefToBaseVector<T>, std::vector<const T *> > {
     typedef SelectionPointerDerefAdder<std::vector<const T *> > type;
   };
 
-  template<typename K, typename C, typename T>
+  template <typename K, typename C, typename T>
   struct SelectionAdderTrait<edm::AssociationVector<edm::RefProd<K>, C>, std::vector<const T *> > {
     typedef SelectionFirstPointerAdder<std::vector<const T *> > type;
   };
 
-  template<typename C, typename T>
+  template <typename C, typename T>
   struct SelectionAdderTrait<edm::AssociationVector<edm::RefToBaseProd<T>, C>, std::vector<const T *> > {
     typedef SelectionFirstPointerAdder<std::vector<const T *> > type;
   };
 
-  template<typename K, typename C>
+  template <typename K, typename C>
   struct SelectionAdderTrait<edm::AssociationVector<edm::RefProd<K>, C>, edm::RefVector<K> > {
     typedef SelectionFirstRefAdder<edm::RefVector<K> > type;
   };
 
-  template<typename T, typename C>
-  struct SelectionAdderTrait<edm::AssociationVector<edm::RefToBaseProd<T>, C>, 
-			     edm::RefToBaseVector<T> > {
+  template <typename T, typename C>
+  struct SelectionAdderTrait<edm::AssociationVector<edm::RefToBaseProd<T>, C>, edm::RefToBaseVector<T> > {
     typedef SelectionFirstRefAdder<edm::RefToBaseVector<T> > type;
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectionAdderTrait<edm::View<T>, edm::RefToBaseVector<T> > {
     typedef SelectionRefViewAdder<T> type;
   };
 
-  template<typename T>
+  template <typename T>
   struct SelectionAdderTrait<edm::View<T>, edm::PtrVector<T> > {
     typedef SelectionPtrViewAdder<T> type;
   };
 
-}
+}  // namespace helper
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
@@ -21,34 +21,38 @@
 
 namespace reco {
   namespace modules {
-    template<typename S> struct SingleElementCollectionRefSelectorEventSetupInit;
+    template <typename S>
+    struct SingleElementCollectionRefSelectorEventSetupInit;
   }
-}
+}  // namespace reco
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
-template<typename InputType, typename Selector,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<edm::View<InputType> >::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename RefAdder = typename ::helper::SelectionAdderTrait<edm::View<InputType>, StoreContainer>::type>
+template <typename InputType,
+          typename Selector,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<edm::View<InputType> >::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename RefAdder = typename ::helper::SelectionAdderTrait<edm::View<InputType>, StoreContainer>::type>
 struct SingleElementCollectionRefSelector {
   typedef edm::View<InputType> InputCollection;
   typedef InputCollection collection;
   typedef StoreContainer container;
   typedef Selector selector;
   typedef typename container::const_iterator const_iterator;
-  SingleElementCollectionRefSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) :
-    select_(reco::modules::make<Selector>(cfg, iC)) { }
+  SingleElementCollectionRefSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : select_(reco::modules::make<Selector>(cfg, iC)) {}
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
-  void select(const edm::Handle<InputCollection> & c, const edm::Event &, const edm::EventSetup&) {
+  void select(const edm::Handle<InputCollection>& c, const edm::Event&, const edm::EventSetup&) {
     selected_.clear();
-    for(size_t idx = 0; idx < c->size(); ++ idx) {
-      if(select_(c->refAt(idx))) addRef_(selected_, c, idx);
+    for (size_t idx = 0; idx < c->size(); ++idx) {
+      if (select_(c->refAt(idx)))
+        addRef_(selected_, c, idx);
     }
   }
+
 private:
   container selected_;
   selector select_;
@@ -60,20 +64,19 @@ private:
 
 namespace reco {
   namespace modules {
-    template<typename S>
+    template <typename S>
     struct SingleElementCollectionRefSelectorEventSetupInit {
-      static void init(S & s, const edm::Event & ev, const edm::EventSetup& es) {
-	typedef typename EventSetupInit<typename S::selector>::type ESI;
-	ESI::init(s.select_, ev, es);
+      static void init(S& s, const edm::Event& ev, const edm::EventSetup& es) {
+        typedef typename EventSetupInit<typename S::selector>::type ESI;
+        ESI::init(s.select_, ev, es);
       }
     };
 
-    template<typename I, typename S, typename O, typename C, typename R>
+    template <typename I, typename S, typename O, typename C, typename R>
     struct EventSetupInit<SingleElementCollectionRefSelector<I, S, O, C, R> > {
       typedef SingleElementCollectionRefSelectorEventSetupInit<SingleElementCollectionRefSelector<I, S, O, C, R> > type;
     };
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
@@ -20,34 +20,37 @@
 
 namespace reco {
   namespace modules {
-    template<typename S> struct SingleElementCollectionSelectorEventSetupInit;
+    template <typename S>
+    struct SingleElementCollectionSelectorEventSetupInit;
   }
-}
+}  // namespace reco
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
-template<typename InputCollection, typename Selector,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
+template <typename InputCollection,
+          typename Selector,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 struct SingleElementCollectionSelector {
   typedef InputCollection collection;
   typedef StoreContainer container;
   typedef Selector selector;
   typedef typename container::const_iterator const_iterator;
-  SingleElementCollectionSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) :
-    select_(reco::modules::make<Selector>(cfg, iC)) { }
+  SingleElementCollectionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : select_(reco::modules::make<Selector>(cfg, iC)) {}
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
-  void select(const edm::Handle<InputCollection> & c, const edm::Event &, const edm::EventSetup&) {
+  void select(const edm::Handle<InputCollection>& c, const edm::Event&, const edm::EventSetup&) {
     selected_.clear();
-    for(size_t idx = 0; idx < c->size(); ++ idx) {
-      if(select_((*c)[idx]))
-	addRef_(selected_, c, idx);
+    for (size_t idx = 0; idx < c->size(); ++idx) {
+      if (select_((*c)[idx]))
+        addRef_(selected_, c, idx);
     }
   }
+
 private:
   container selected_;
   selector select_;
@@ -59,20 +62,19 @@ private:
 
 namespace reco {
   namespace modules {
-    template<typename S>
+    template <typename S>
     struct SingleElementCollectionSelectorEventSetupInit {
-      static void init(S & s, const edm::Event & ev, const edm::EventSetup& es) {
-	typedef typename EventSetupInit<typename S::selector>::type ESI;
-	ESI::init(s.select_, ev, es);
+      static void init(S& s, const edm::Event& ev, const edm::EventSetup& es) {
+        typedef typename EventSetupInit<typename S::selector>::type ESI;
+        ESI::init(s.select_, ev, es);
       }
     };
 
-    template<typename I, typename S, typename O, typename C, typename R>
+    template <typename I, typename S, typename O, typename C, typename R>
     struct EventSetupInit<SingleElementCollectionSelector<I, S, O, C, R> > {
       typedef SingleElementCollectionSelectorEventSetupInit<SingleElementCollectionSelector<I, S, O, C, R> > type;
     };
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
@@ -21,27 +21,29 @@
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
-template<typename InputCollection, typename Selector,
-	 typename OutputCollection = typename helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename helper::StoreContainerTrait<OutputCollection>::type,
-	 typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
+template <typename InputCollection,
+          typename Selector,
+          typename OutputCollection = typename helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename helper::StoreContainerTrait<OutputCollection>::type,
+          typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 struct SingleElementCollectionSelectorPlusEvent {
   typedef InputCollection collection;
   typedef StoreContainer container;
   typedef typename container::const_iterator const_iterator;
-  SingleElementCollectionSelectorPlusEvent( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    select_( reco::modules::make<Selector>( cfg, iC ) ) { }
+  SingleElementCollectionSelectorPlusEvent(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC)
+      : select_(reco::modules::make<Selector>(cfg, iC)) {}
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
-  void select(const edm::Handle<InputCollection> & c, const edm::Event &ev, const edm::EventSetup &) {
+  void select(const edm::Handle<InputCollection> &c, const edm::Event &ev, const edm::EventSetup &) {
     selected_.clear();
-    for(size_t idx = 0; idx < c->size(); ++ idx) {
-      if(select_( edm::Ref<InputCollection>(c,idx), ev) ) //(*c)[idx]
-	addRef_(selected_, c, idx);
+    for (size_t idx = 0; idx < c->size(); ++idx) {
+      if (select_(edm::Ref<InputCollection>(c, idx), ev))  //(*c)[idx]
+        addRef_(selected_, c, idx);
     }
   }
+
 private:
   StoreContainer selected_;
   Selector select_;
@@ -49,4 +51,3 @@ private:
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SingleObjectRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectRefSelector.h
@@ -11,22 +11,30 @@
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h"
 #include "DataFormats/Common/interface/View.h"
 
-template<typename InputType, typename Selector,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<edm::View<InputType> >::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
-	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
-	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
-	 typename RefAdder = typename ::helper::SelectionAdderTrait<edm::View<InputType>, StoreContainer>::type>
-class SingleObjectRefSelector :
-  public ObjectSelector<SingleElementCollectionRefSelector<InputType, Selector, OutputCollection, StoreContainer, RefAdder>,
-			OutputCollection, NonNullNumberSelector, PostProcessor, StoreManager, Base> {
+template <typename InputType,
+          typename Selector,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<edm::View<InputType> >::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection>,
+          typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::type,
+          typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDFilter>::base,
+          typename RefAdder = typename ::helper::SelectionAdderTrait<edm::View<InputType>, StoreContainer>::type>
+class SingleObjectRefSelector
+    : public ObjectSelector<
+          SingleElementCollectionRefSelector<InputType, Selector, OutputCollection, StoreContainer, RefAdder>,
+          OutputCollection,
+          NonNullNumberSelector,
+          PostProcessor,
+          StoreManager,
+          Base> {
 public:
-  explicit SingleObjectRefSelector(const edm::ParameterSet & cfg) :
-    ObjectSelector<SingleElementCollectionRefSelector<InputType, Selector, OutputCollection, StoreContainer, RefAdder>,
-                   OutputCollection, NonNullNumberSelector, PostProcessor>( cfg ) { }
-  ~SingleObjectRefSelector() override { }
+  explicit SingleObjectRefSelector(const edm::ParameterSet& cfg)
+      : ObjectSelector<
+            SingleElementCollectionRefSelector<InputType, Selector, OutputCollection, StoreContainer, RefAdder>,
+            OutputCollection,
+            NonNullNumberSelector,
+            PostProcessor>(cfg) {}
+  ~SingleObjectRefSelector() override {}
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleObjectSelector.h
@@ -9,64 +9,69 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h"
 
-
-
 /* the following is just to ease transition
  *    grep -r SingleObjectSelector * | wc 
  *      209     540   22532
  */
 
-
-template<typename InputCollection, typename Selector, 
-	 typename EdmFilter,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, EdmFilter>,
-	 typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::type,
-	 typename Base = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::base,
-	 typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
-class SingleObjectSelectorBase : 
-  public ObjectSelector<SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>, 
-			OutputCollection, NonNullNumberSelector, PostProcessor, StoreManager, Base> {
+template <typename InputCollection,
+          typename Selector,
+          typename EdmFilter,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, EdmFilter>,
+          typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::type,
+          typename Base = typename ::helper::StoreManagerTrait<OutputCollection, EdmFilter>::base,
+          typename RefAdder = typename ::helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
+class SingleObjectSelectorBase
+    : public ObjectSelector<
+          SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>,
+          OutputCollection,
+          NonNullNumberSelector,
+          PostProcessor,
+          StoreManager,
+          Base> {
 public:
   // SingleObjectSelectorBase() = default;
-  explicit SingleObjectSelectorBase( const edm::ParameterSet & cfg ) :
-    ObjectSelector<SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>, 
-		   OutputCollection, NonNullNumberSelector, PostProcessor, StoreManager, Base>( cfg ) { }
-  ~SingleObjectSelectorBase() override { }
+  explicit SingleObjectSelectorBase(const edm::ParameterSet& cfg)
+      : ObjectSelector<
+            SingleElementCollectionSelector<InputCollection, Selector, OutputCollection, StoreContainer, RefAdder>,
+            OutputCollection,
+            NonNullNumberSelector,
+            PostProcessor,
+            StoreManager,
+            Base>(cfg) {}
+  ~SingleObjectSelectorBase() override {}
 };
 
-
-
-template<typename InputCollection, typename Selector,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter> >
-using SingleObjectSelectorLegacy = SingleObjectSelectorBase<InputCollection,Selector, edm::EDFilter, 
-							    OutputCollection,StoreContainer,PostProcessor
-							    >;
-
-
+template <typename InputCollection,
+          typename Selector,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDFilter> >
+using SingleObjectSelectorLegacy =
+    SingleObjectSelectorBase<InputCollection, Selector, edm::EDFilter, OutputCollection, StoreContainer, PostProcessor>;
 
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 
-template<typename InputCollection, typename Selector,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
-using SingleObjectSelectorStream = SingleObjectSelectorBase<InputCollection,Selector, edm::stream::EDFilter<>,
-							    OutputCollection,StoreContainer,PostProcessor
-							    >;
+template <typename InputCollection,
+          typename Selector,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
+using SingleObjectSelectorStream = SingleObjectSelectorBase<InputCollection,
+                                                            Selector,
+                                                            edm::stream::EDFilter<>,
+                                                            OutputCollection,
+                                                            StoreContainer,
+                                                            PostProcessor>;
 
-
-template<typename InputCollection, typename Selector,
-	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
-	 typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
-using SingleObjectSelector = SingleObjectSelectorStream<InputCollection,Selector,
-							OutputCollection,StoreContainer,PostProcessor>;
-
-
+template <typename InputCollection,
+          typename Selector,
+          typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,
+          typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDFilter<> > >
+using SingleObjectSelector =
+    SingleObjectSelectorStream<InputCollection, Selector, OutputCollection, StoreContainer, PostProcessor>;
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
@@ -24,42 +24,42 @@
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
-template<typename InputCollection, typename Comparator,
-	 typename OutputCollection = typename helper::SelectedOutputCollectionTrait<InputCollection>::type,
-	 typename StoreContainer = typename helper::StoreContainerTrait<OutputCollection>::type,
-	 typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
+template <typename InputCollection,
+          typename Comparator,
+          typename OutputCollection = typename helper::SelectedOutputCollectionTrait<InputCollection>::type,
+          typename StoreContainer = typename helper::StoreContainerTrait<OutputCollection>::type,
+          typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
 class SortCollectionSelector {
 public:
   typedef InputCollection collection;
+
 private:
-  typedef const typename InputCollection::value_type * reference;
+  typedef const typename InputCollection::value_type *reference;
   typedef std::pair<reference, size_t> pair;
   typedef StoreContainer container;
   typedef typename container::const_iterator const_iterator;
 
 public:
-  SortCollectionSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector && iC) :
-    compare_(Comparator()),
-    maxNumber_(cfg.template getParameter<unsigned int>("maxNumber")) { }
+  SortCollectionSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC)
+      : compare_(Comparator()), maxNumber_(cfg.template getParameter<unsigned int>("maxNumber")) {}
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
-  void select(const edm::Handle<InputCollection> & c, const edm::Event &, const edm::EventSetup&) {
+  void select(const edm::Handle<InputCollection> &c, const edm::Event &, const edm::EventSetup &) {
     std::vector<pair> v;
-    for(size_t idx = 0; idx < c->size(); ++ idx)
+    for (size_t idx = 0; idx < c->size(); ++idx)
       v.push_back(std::make_pair(&(*c)[idx], idx));
     std::sort(v.begin(), v.end(), compare_);
     selected_.clear();
-    for(size_t i = 0; i < maxNumber_ && i < v.size(); ++i)
+    for (size_t i = 0; i < maxNumber_ && i < v.size(); ++i)
       addRef_(selected_, c, v[i].second);
   }
+
 private:
   struct PairComparator {
-    PairComparator(const Comparator & cmp) : cmp_(cmp) { }
-    bool operator()(const pair & t1, const pair & t2) const {
-      return cmp_(*t1.first, *t2.first);
-    }
+    PairComparator(const Comparator &cmp) : cmp_(cmp) {}
+    bool operator()(const pair &t1, const pair &t2) const { return cmp_(*t1.first, *t2.first); }
     Comparator cmp_;
   };
   PairComparator compare_;
@@ -69,4 +69,3 @@ private:
 };
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/StatusSelector.h
+++ b/CommonTools/UtilAlgos/interface/StatusSelector.h
@@ -7,15 +7,14 @@
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<StatusSelector> {
-      static StatusSelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return StatusSelector( cfg.getParameter<std::vector<int> >( "status" ) );
+      static StatusSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return StatusSelector(cfg.getParameter<std::vector<int> >("status"));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/StoreContainerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreContainerTrait.h
@@ -10,31 +10,30 @@
 #include "DataFormats/Common/interface/AssociationVector.h"
 
 namespace helper {
-  template<typename OutputCollection>
-    struct StoreContainerTrait {
-      typedef std::vector<const typename OutputCollection::value_type *> type;
+  template <typename OutputCollection>
+  struct StoreContainerTrait {
+    typedef std::vector<const typename OutputCollection::value_type *> type;
   };
 
-  template<typename C>
+  template <typename C>
   struct StoreContainerTrait<edm::RefVector<C> > {
     typedef edm::RefVector<C> type;
   };
 
-  template<typename T>
+  template <typename T>
   struct StoreContainerTrait<edm::RefToBaseVector<T> > {
     typedef edm::RefToBaseVector<T> type;
   };
 
-  template<typename T>
+  template <typename T>
   struct StoreContainerTrait<edm::PtrVector<T> > {
     typedef edm::PtrVector<T> type;
   };
 
-  template<typename R, typename C>
-   struct StoreContainerTrait<edm::AssociationVector<R, C> > {
-     typedef typename StoreContainerTrait<typename R::product_type>::type type;
+  template <typename R, typename C>
+  struct StoreContainerTrait<edm::AssociationVector<R, C> > {
+    typedef typename StoreContainerTrait<typename R::product_type>::type type;
   };
-}
+}  // namespace helper
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/StringCutEventSelector.h
+++ b/CommonTools/UtilAlgos/interface/StringCutEventSelector.h
@@ -8,130 +8,138 @@
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-template<typename Object, bool any=false>
-class  StringCutEventSelector : public EventSelector {
- public:
-  StringCutEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector && iC) :
-    StringCutEventSelector(pset, iC) {}
-  StringCutEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector & iC) :
-    EventSelector(pset, iC),
-    src_(edm::Service<InputTagDistributorService>()->retrieve("src",pset)),
-    srcToken_(iC.consumes<edm::View<Object> >(src_)),
-    f_(pset.getParameter<std::string>("cut")),
-    //put this guy to 0 to do the check on "all" object in the collection
-    nFirst_(pset.getParameter<unsigned int>("nFirst")),
-    order_(nullptr)
-      {
-	  std::stringstream ss;
-	  ss<<"string cut based selection on collection: "<<src_;
-	  description_.push_back(ss.str());
-	  ss.str("");
-	  description_.push_back(std::string("selection cut is: ")+pset.getParameter<std::string>("cut"));
-	  if (pset.exists("order"))
-	    order_ = new StringObjectFunction<Object>( pset.getParameter<std::string>("order"));
-      }
-
-    bool select (const edm::Event& e) const override{
-      edm::Handle<edm::View<Object> > oH;
-      e.getByToken(srcToken_, oH);
-      std::vector<const Object*> copyToSort(oH->size());
-      for (uint i=0;i!=oH->size();++i)  copyToSort[i]= &(*oH)[i];
-      if (order_)std::sort(copyToSort.begin(), copyToSort.end(), sortByStringFunction<Object>(order_));
-      
-      //reject events if not enough object in collection
-      //      if ((nFirst_!=0) && (oH->size()<nFirst_)) return false;
-      unsigned int i=0;
-      unsigned int found=0;
-      for (;i!=oH->size();i++)
-	{ 
-	  const Object & o = *(copyToSort[i]);
-	  if (any){
-	    if (f_(o)) ++found;
-	    if (found>=nFirst_)
-	      return true;
-	  }
-	  else{
-	    //stop doing the check if reaching too far in the collection
-	    if ((nFirst_!=0) && (i>=nFirst_)) break;
-	    if (!f_(o)) return false;
-	  }
-	}
-      return !any;
-    }
-
- private:
-    edm::InputTag src_;
-    edm::EDGetTokenT<edm::View<Object> > srcToken_;
-    StringCutObjectSelector<Object> f_;
-    unsigned int nFirst_;
-    StringObjectFunction<Object> *order_;
-};
-
-
-template<typename Object, bool existenceMatter=true>
-class  StringCutsEventSelector : public EventSelector {
- public:
-  StringCutsEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector && iC) :
-    StringCutsEventSelector(pset, iC) {}
-  StringCutsEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector & iC) :
-    EventSelector(pset, iC),
-    src_(edm::Service<InputTagDistributorService>()->retrieve("src",pset)),
-    srcToken_(iC.consumes<edm::View<Object> >(src_)),
-    order_(nullptr)
-      {
-	std::vector<std::string> selection=pset.getParameter<std::vector<std::string > >("cut");
-	std::stringstream ss;
-	ss<<"string cut based selection on collection: "<<src_;
-	description_.push_back(ss.str());	    ss.str("");
-	description_.push_back("selection cuts are:");
-	for (unsigned int i=0;i!=selection.size();i++)
-	  if (selection[i]!="-"){
-	    f_.push_back( new StringCutObjectSelector<Object>(selection[i]));
-	    ss<<"["<<i<<"]: "<<selection[i];
-	    description_.push_back(ss.str());           ss.str("");
-	  }
-	  else
-	    {
-	      f_.push_back(nullptr);
-	      ss<<"["<<i<<"]: no selection";
-	      description_.push_back(ss.str());           ss.str("");
-	    }
-	if (pset.exists("order"))
-	  order_ = new StringObjectFunction<Object>( pset.getParameter<std::string>("order"));
-      }
-  ~StringCutsEventSelector() override{
-    unsigned int i=0; 
-    for (;i!=f_.size();i++) 
-      if (f_[i]){ 
-	delete f_[i];f_[i]=nullptr;
-      }
-    if (order_) delete order_;
+template <typename Object, bool any = false>
+class StringCutEventSelector : public EventSelector {
+public:
+  StringCutEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+      : StringCutEventSelector(pset, iC) {}
+  StringCutEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
+      : EventSelector(pset, iC),
+        src_(edm::Service<InputTagDistributorService>()->retrieve("src", pset)),
+        srcToken_(iC.consumes<edm::View<Object> >(src_)),
+        f_(pset.getParameter<std::string>("cut")),
+        //put this guy to 0 to do the check on "all" object in the collection
+        nFirst_(pset.getParameter<unsigned int>("nFirst")),
+        order_(nullptr) {
+    std::stringstream ss;
+    ss << "string cut based selection on collection: " << src_;
+    description_.push_back(ss.str());
+    ss.str("");
+    description_.push_back(std::string("selection cut is: ") + pset.getParameter<std::string>("cut"));
+    if (pset.exists("order"))
+      order_ = new StringObjectFunction<Object>(pset.getParameter<std::string>("order"));
   }
 
-    bool select (const edm::Event& e) const override{
-      edm::Handle<edm::View<Object> > oH;
-      e.getByToken(srcToken_, oH);
-      std::vector<const Object*> copyToSort(oH->size());
-      for (uint i=0;i!=oH->size();++i)  copyToSort[i]= &(*oH)[i];
-      if (order_)std::sort(copyToSort.begin(), copyToSort.end(), sortByStringFunction<Object>(order_));
+  bool select(const edm::Event& e) const override {
+    edm::Handle<edm::View<Object> > oH;
+    e.getByToken(srcToken_, oH);
+    std::vector<const Object*> copyToSort(oH->size());
+    for (uint i = 0; i != oH->size(); ++i)
+      copyToSort[i] = &(*oH)[i];
+    if (order_)
+      std::sort(copyToSort.begin(), copyToSort.end(), sortByStringFunction<Object>(order_));
 
-      unsigned int i=0;
-      if (existenceMatter && oH->size()<f_.size()) return false;
-      for (;i!=f_.size();i++)
-	{
-	  if (!existenceMatter && i==oH->size()) break;
-	  if (!f_[i]) continue;
-	  const Object & o = *(copyToSort[i]);
-	  if (!(*f_[i])(o)) return false;
-	}
-      return true;
+    //reject events if not enough object in collection
+    //      if ((nFirst_!=0) && (oH->size()<nFirst_)) return false;
+    unsigned int i = 0;
+    unsigned int found = 0;
+    for (; i != oH->size(); i++) {
+      const Object& o = *(copyToSort[i]);
+      if (any) {
+        if (f_(o))
+          ++found;
+        if (found >= nFirst_)
+          return true;
+      } else {
+        //stop doing the check if reaching too far in the collection
+        if ((nFirst_ != 0) && (i >= nFirst_))
+          break;
+        if (!f_(o))
+          return false;
+      }
     }
+    return !any;
+  }
 
- private:
-    edm::InputTag src_;
-    edm::EDGetTokenT<edm::View<Object> > srcToken_;
-    std::vector<StringCutObjectSelector<Object> *> f_;
-    StringObjectFunction<Object> * order_;
+private:
+  edm::InputTag src_;
+  edm::EDGetTokenT<edm::View<Object> > srcToken_;
+  StringCutObjectSelector<Object> f_;
+  unsigned int nFirst_;
+  StringObjectFunction<Object>* order_;
+};
+
+template <typename Object, bool existenceMatter = true>
+class StringCutsEventSelector : public EventSelector {
+public:
+  StringCutsEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
+      : StringCutsEventSelector(pset, iC) {}
+  StringCutsEventSelector(const edm::ParameterSet& pset, edm::ConsumesCollector& iC)
+      : EventSelector(pset, iC),
+        src_(edm::Service<InputTagDistributorService>()->retrieve("src", pset)),
+        srcToken_(iC.consumes<edm::View<Object> >(src_)),
+        order_(nullptr) {
+    std::vector<std::string> selection = pset.getParameter<std::vector<std::string> >("cut");
+    std::stringstream ss;
+    ss << "string cut based selection on collection: " << src_;
+    description_.push_back(ss.str());
+    ss.str("");
+    description_.push_back("selection cuts are:");
+    for (unsigned int i = 0; i != selection.size(); i++)
+      if (selection[i] != "-") {
+        f_.push_back(new StringCutObjectSelector<Object>(selection[i]));
+        ss << "[" << i << "]: " << selection[i];
+        description_.push_back(ss.str());
+        ss.str("");
+      } else {
+        f_.push_back(nullptr);
+        ss << "[" << i << "]: no selection";
+        description_.push_back(ss.str());
+        ss.str("");
+      }
+    if (pset.exists("order"))
+      order_ = new StringObjectFunction<Object>(pset.getParameter<std::string>("order"));
+  }
+  ~StringCutsEventSelector() override {
+    unsigned int i = 0;
+    for (; i != f_.size(); i++)
+      if (f_[i]) {
+        delete f_[i];
+        f_[i] = nullptr;
+      }
+    if (order_)
+      delete order_;
+  }
+
+  bool select(const edm::Event& e) const override {
+    edm::Handle<edm::View<Object> > oH;
+    e.getByToken(srcToken_, oH);
+    std::vector<const Object*> copyToSort(oH->size());
+    for (uint i = 0; i != oH->size(); ++i)
+      copyToSort[i] = &(*oH)[i];
+    if (order_)
+      std::sort(copyToSort.begin(), copyToSort.end(), sortByStringFunction<Object>(order_));
+
+    unsigned int i = 0;
+    if (existenceMatter && oH->size() < f_.size())
+      return false;
+    for (; i != f_.size(); i++) {
+      if (!existenceMatter && i == oH->size())
+        break;
+      if (!f_[i])
+        continue;
+      const Object& o = *(copyToSort[i]);
+      if (!(*f_[i])(o))
+        return false;
+    }
+    return true;
+  }
+
+private:
+  edm::InputTag src_;
+  edm::EDGetTokenT<edm::View<Object> > srcToken_;
+  std::vector<StringCutObjectSelector<Object>*> f_;
+  StringObjectFunction<Object>* order_;
 };
 
 #endif

--- a/CommonTools/UtilAlgos/interface/StringCutObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/StringCutObjectSelector.h
@@ -8,34 +8,28 @@
 namespace reco {
   namespace modules {
 
-    template<typename T, bool Lazy>
+    template <typename T, bool Lazy>
     struct ParameterAdapter<StringCutObjectSelector<T, Lazy> > {
-      static StringCutObjectSelector<T, Lazy> make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
-	return StringCutObjectSelector<T, Lazy>( cfg.template getParameter<std::string>( "cut" ) );
+      static StringCutObjectSelector<T, Lazy> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return StringCutObjectSelector<T, Lazy>(cfg.template getParameter<std::string>("cut"));
       }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
-        desc.add<std::string>("cut", "");
-      }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::string>("cut", ""); }
     };
 
-  }
-}
-
+  }  // namespace modules
+}  // namespace reco
 
 // Introducing a simpler way to use a string object selector outside of the
 // heavily-templated infrastructure above. This simply translates the cfg
 // into the string that the functor expects.
-namespace reco{
-  template< typename T, bool Lazy>
-    class StringCutObjectSelectorHandler : public StringCutObjectSelector<T,Lazy>  {
-    public:
-      explicit StringCutObjectSelectorHandler( const edm::ParameterSet & cfg ) :
-        StringCutObjectSelector<T, Lazy>(cfg.getParameter<std::string>("cut"))
-      {
-      }
+namespace reco {
+  template <typename T, bool Lazy>
+  class StringCutObjectSelectorHandler : public StringCutObjectSelector<T, Lazy> {
+  public:
+    explicit StringCutObjectSelectorHandler(const edm::ParameterSet& cfg)
+        : StringCutObjectSelector<T, Lazy>(cfg.getParameter<std::string>("cut")) {}
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/CommonTools/UtilAlgos/interface/TFileService.h
+++ b/CommonTools/UtilAlgos/interface/TFileService.h
@@ -25,7 +25,7 @@ namespace edm {
   class ModuleDescription;
   class ParameterSet;
   class StreamContext;
-}
+}  // namespace edm
 
 class TFileService {
 public:
@@ -34,12 +34,12 @@ public:
   /// destructor
   ~TFileService();
   /// return opened TFile
-  TFile & file() const { return * file_; }
+  TFile &file() const { return *file_; }
 
   /// Hook for writing info into JR
   void afterBeginJob();
 
-  TFileDirectory & tFileDirectory() { return tFileDirectory_; }
+  TFileDirectory &tFileDirectory() { return tFileDirectory_; }
 
   // The next 6 functions do nothing more than forward function calls
   // to the TFileDirectory data member.
@@ -49,24 +49,24 @@ public:
   bool cd() const { return tFileDirectory_.cd(); }
 
   // returns a TDirectory pointer
-  TDirectory *getBareDirectory (const std::string &subdir = "") const {
+  TDirectory *getBareDirectory(const std::string &subdir = "") const {
     return tFileDirectory_.getBareDirectory(subdir);
   }
 
   // reutrns a "T" pointer matched to objname
-  template< typename T > T* getObject (const std::string &objname,
-                                       const std::string &subdir = "") {
+  template <typename T>
+  T *getObject(const std::string &objname, const std::string &subdir = "") {
     return tFileDirectory_.getObject<T>(objname, subdir);
   }
 
   /// make new ROOT object
-  template<typename T, typename ... Args>
-  T* make(const Args& ... args) const {
-    return tFileDirectory_.make<T>(args ...);
+  template <typename T, typename... Args>
+  T *make(const Args &... args) const {
+    return tFileDirectory_.make<T>(args...);
   }
 
   /// create a new subdirectory
-  TFileDirectory mkdir( const std::string & dir, const std::string & descr = "" ) {
+  TFileDirectory mkdir(const std::string &dir, const std::string &descr = "") {
     return tFileDirectory_.mkdir(dir, descr);
   }
 
@@ -78,27 +78,24 @@ public:
 private:
   static thread_local TFileDirectory tFileDirectory_;
   /// pointer to opened TFile
-  TFile * file_;
+  TFile *file_;
   std::string fileName_;
   bool fileNameRecorded_;
   bool closeFileFast_;
 
   // set current directory according to module name and prepair to create directory
-  void setDirectoryName( const edm::ModuleDescription & desc );
-  void preModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
-  void postModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
-  void preModuleGlobal(edm::GlobalContext const&, edm::ModuleCallingContext const&);
-  void postModuleGlobal(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+  void setDirectoryName(const edm::ModuleDescription &desc);
+  void preModuleEvent(edm::StreamContext const &, edm::ModuleCallingContext const &);
+  void postModuleEvent(edm::StreamContext const &, edm::ModuleCallingContext const &);
+  void preModuleGlobal(edm::GlobalContext const &, edm::ModuleCallingContext const &);
+  void postModuleGlobal(edm::GlobalContext const &, edm::ModuleCallingContext const &);
 };
 
 namespace edm {
   namespace service {
     // This function is needed so that there will be only one instance
     // of this service per process when "subprocesses" are being used.
-    inline
-    bool isProcessWideService(TFileService const*) {
-      return true;
-    }
-  }
-}
+    inline bool isProcessWideService(TFileService const *) { return true; }
+  }  // namespace service
+}  // namespace edm
 #endif

--- a/CommonTools/UtilAlgos/plugins/DeltaROverlapExclusionSelector.h
+++ b/CommonTools/UtilAlgos/plugins/DeltaROverlapExclusionSelector.h
@@ -3,10 +3,8 @@
 #include "CommonTools/UtilAlgos/interface/OverlapExclusionSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-  edm::View<reco::Candidate> ,
-  OverlapExclusionSelector<edm::View<reco::Candidate> ,
-                           reco::Candidate, 
-                           reco::MatchByDR<reco::Candidate, reco::Candidate> >
-  > DeltaROverlapExclusionSelector;
-
+typedef SingleObjectSelector<edm::View<reco::Candidate>,
+                             OverlapExclusionSelector<edm::View<reco::Candidate>,
+                                                      reco::Candidate,
+                                                      reco::MatchByDR<reco::Candidate, reco::Candidate> > >
+    DeltaROverlapExclusionSelector;

--- a/CommonTools/UtilAlgos/plugins/DoubleProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/DoubleProducer.cc
@@ -10,9 +10,10 @@
 
 class DoubleProducer : public edm::EDProducer {
 public:
-  DoubleProducer( const edm::ParameterSet & cfg );
+  DoubleProducer(const edm::ParameterSet& cfg);
+
 private:
-  void produce( edm::Event & evt, const edm::EventSetup&) override;
+  void produce(edm::Event& evt, const edm::EventSetup&) override;
   double value_;
 };
 
@@ -22,16 +23,15 @@ private:
 using namespace edm;
 using namespace std;
 
-DoubleProducer::DoubleProducer( const ParameterSet & cfg ) :
-value_( cfg.getParameter<double>( "value" ) ){
+DoubleProducer::DoubleProducer(const ParameterSet& cfg) : value_(cfg.getParameter<double>("value")) {
   produces<double>();
 }
 
-void DoubleProducer::produce( Event & evt, const EventSetup & ) {
-  unique_ptr<double> value( new double( value_ ) );
+void DoubleProducer::produce(Event& evt, const EventSetup&) {
+  unique_ptr<double> value(new double(value_));
   evt.put(std::move(value));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( DoubleProducer );
+DEFINE_FWK_MODULE(DoubleProducer);

--- a/CommonTools/UtilAlgos/plugins/EventCountProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/EventCountProducer.cc
@@ -2,13 +2,12 @@
 //
 // Package:    EventCountProducer
 // Class:      EventCountProducer
-// 
+//
 /**\class EventCountProducer EventCountProducer.cc CommonTools/UtilAlgos/plugins/EventCountProducer.cc
 
 Description: An event counter that can store the number of events in the lumi block 
 
 */
-
 
 // system include files
 #include <memory>
@@ -26,59 +25,45 @@ Description: An event counter that can store the number of events in the lumi bl
 
 #include "DataFormats/Common/interface/MergeableCounter.h"
 
-
-class EventCountProducer : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks,
-                                                       edm::EndLuminosityBlockProducer> {
+class EventCountProducer
+    : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks, edm::EndLuminosityBlockProducer> {
 public:
   explicit EventCountProducer(const edm::ParameterSet&);
   ~EventCountProducer() override;
 
 private:
-  void produce(edm::Event &, const edm::EventSetup&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void endLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) override;
-  void endLuminosityBlockProduce(edm::LuminosityBlock &, const edm::EventSetup&) override;
-      
+  void endLuminosityBlockProduce(edm::LuminosityBlock&, const edm::EventSetup&) override;
+
   // ----------member data ---------------------------
 
   unsigned int eventsProcessedInLumi_;
-
 };
-
-
 
 using namespace edm;
 using namespace std;
 
-
-
-EventCountProducer::EventCountProducer(const edm::ParameterSet& iConfig){
+EventCountProducer::EventCountProducer(const edm::ParameterSet& iConfig) {
   produces<edm::MergeableCounter, edm::Transition::EndLuminosityBlock>();
 }
 
+EventCountProducer::~EventCountProducer() {}
 
-EventCountProducer::~EventCountProducer(){}
-
-
-void
-EventCountProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+void EventCountProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   eventsProcessedInLumi_++;
   return;
 }
 
-
-void 
-EventCountProducer::beginLuminosityBlock(const LuminosityBlock & theLuminosityBlock, const EventSetup & theSetup) {
+void EventCountProducer::beginLuminosityBlock(const LuminosityBlock& theLuminosityBlock, const EventSetup& theSetup) {
   eventsProcessedInLumi_ = 0;
   return;
 }
 
-void 
-EventCountProducer::endLuminosityBlock(LuminosityBlock const& theLuminosityBlock, const EventSetup & theSetup) {
-}
+void EventCountProducer::endLuminosityBlock(LuminosityBlock const& theLuminosityBlock, const EventSetup& theSetup) {}
 
-void 
-EventCountProducer::endLuminosityBlockProduce(LuminosityBlock & theLuminosityBlock, const EventSetup & theSetup) {
+void EventCountProducer::endLuminosityBlockProduce(LuminosityBlock& theLuminosityBlock, const EventSetup& theSetup) {
   LogTrace("EventCounting") << "endLumi: adding " << eventsProcessedInLumi_ << " events" << endl;
 
   unique_ptr<edm::MergeableCounter> numEventsPtr(new edm::MergeableCounter);
@@ -87,8 +72,6 @@ EventCountProducer::endLuminosityBlockProduce(LuminosityBlock & theLuminosityBlo
 
   return;
 }
-
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(EventCountProducer);

--- a/CommonTools/UtilAlgos/plugins/InputTagDistributorService.cc
+++ b/CommonTools/UtilAlgos/plugins/InputTagDistributorService.cc
@@ -4,4 +4,4 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 #include "CommonTools/UtilAlgos/interface/InputTagDistributor.h"
-DEFINE_FWK_SERVICE( InputTagDistributorService );
+DEFINE_FWK_SERVICE(InputTagDistributorService);

--- a/CommonTools/UtilAlgos/plugins/StopAfterNEvents.cc
+++ b/CommonTools/UtilAlgos/plugins/StopAfterNEvents.cc
@@ -3,10 +3,11 @@
 
 class StopAfterNEvents : public edm::EDFilter {
 public:
-  StopAfterNEvents( const edm::ParameterSet & );
+  StopAfterNEvents(const edm::ParameterSet&);
   ~StopAfterNEvents() override;
+
 private:
-  bool filter( edm::Event &, edm::EventSetup const& ) override;
+  bool filter(edm::Event&, edm::EventSetup const&) override;
   const int nMax_;
   int n_;
   const bool verbose_;
@@ -17,24 +18,21 @@ private:
 using namespace std;
 using namespace edm;
 
-StopAfterNEvents::StopAfterNEvents( const ParameterSet & pset ) :
-  nMax_( pset.getParameter<int>( "maxEvents" ) ), n_( 0 ),
-  verbose_( pset.getUntrackedParameter<bool>( "verbose", false ) ) {
-}
+StopAfterNEvents::StopAfterNEvents(const ParameterSet& pset)
+    : nMax_(pset.getParameter<int>("maxEvents")), n_(0), verbose_(pset.getUntrackedParameter<bool>("verbose", false)) {}
 
-StopAfterNEvents::~StopAfterNEvents() {
-}
+StopAfterNEvents::~StopAfterNEvents() {}
 
 bool StopAfterNEvents::filter(Event&, EventSetup const&) {
-  if ( n_ < 0 ) return true;
-  n_ ++ ;
+  if (n_ < 0)
+    return true;
+  n_++;
   bool ret = n_ <= nMax_;
-  if ( verbose_ )
-    cout << ">>> filtering event" << n_ << "/" << nMax_ 
-	      << "(" <<  ( ret ? "true" : "false" ) << ")" << endl;
+  if (verbose_)
+    cout << ">>> filtering event" << n_ << "/" << nMax_ << "(" << (ret ? "true" : "false") << ")" << endl;
   return ret;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( StopAfterNEvents );
+DEFINE_FWK_MODULE(StopAfterNEvents);

--- a/CommonTools/UtilAlgos/plugins/TFileService.cc
+++ b/CommonTools/UtilAlgos/plugins/TFileService.cc
@@ -2,4 +2,4 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-DEFINE_FWK_SERVICE( TFileService );
+DEFINE_FWK_SERVICE(TFileService);

--- a/CommonTools/UtilAlgos/src/DetIdSelector.cc
+++ b/CommonTools/UtilAlgos/src/DetIdSelector.cc
@@ -3,85 +3,53 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+DetIdSelector::DetIdSelector() : m_selections(), m_masks() {}
 
-DetIdSelector::DetIdSelector():
-  m_selections(),m_masks()
-{}
+DetIdSelector::DetIdSelector(const std::string& selstring) : m_selections(), m_masks() { addSelection(selstring); }
 
-DetIdSelector::DetIdSelector(const std::string& selstring):
-  m_selections(),m_masks()
-{
-  addSelection(selstring);
-}
-
-DetIdSelector::DetIdSelector(const std::vector<std::string>& selstrings):
-  m_selections(),m_masks()
-{
+DetIdSelector::DetIdSelector(const std::vector<std::string>& selstrings) : m_selections(), m_masks() {
   addSelection(selstrings);
 }
 
-DetIdSelector::DetIdSelector(const edm::ParameterSet& selconfig):
-  m_selections(),m_masks()
-{
-
+DetIdSelector::DetIdSelector(const edm::ParameterSet& selconfig) : m_selections(), m_masks() {
   const std::vector<std::string> selstrings = selconfig.getUntrackedParameter<std::vector<std::string> >("selection");
   addSelection(selstrings);
-
 }
 
 void DetIdSelector::addSelection(const std::string& selstring) {
-
   unsigned int selection;
   unsigned int mask;
 
-  if(selstring.substr(0,2) == "0x") {
-    sscanf(selstring.c_str(),"%x-%x",&mask,&selection);
-  }
-  else {
-    sscanf(selstring.c_str(),"%u-%u",&mask,&selection);
+  if (selstring.substr(0, 2) == "0x") {
+    sscanf(selstring.c_str(), "%x-%x", &mask, &selection);
+  } else {
+    sscanf(selstring.c_str(), "%u-%u", &mask, &selection);
   }
 
   m_selections.push_back(selection);
   m_masks.push_back(mask);
 
   LogDebug("Selection added") << "Selection " << selection << " with mask " << mask << " added";
-
 }
 
 void DetIdSelector::addSelection(const std::vector<std::string>& selstrings) {
-
-  for(std::vector<std::string>::const_iterator selstring=selstrings.begin();selstring!=selstrings.end();++selstring) {
+  for (std::vector<std::string>::const_iterator selstring = selstrings.begin(); selstring != selstrings.end();
+       ++selstring) {
     addSelection(*selstring);
   }
-
 }
 
 bool DetIdSelector::isSelected(const unsigned int& rawid) const {
-
-  for(unsigned int i=0; i<m_selections.size() ; ++i) {
-    if((m_masks[i] & rawid) == m_selections[i]) return true;
+  for (unsigned int i = 0; i < m_selections.size(); ++i) {
+    if ((m_masks[i] & rawid) == m_selections[i])
+      return true;
   }
 
   return false;
 }
 
-bool DetIdSelector::isSelected(const DetId& detid) const {
+bool DetIdSelector::isSelected(const DetId& detid) const { return isSelected(detid.rawId()); }
 
-  return isSelected(detid.rawId());
+bool DetIdSelector::operator()(const DetId& detid) const { return isSelected(detid.rawId()); }
 
-}
-
-bool DetIdSelector::operator()(const DetId& detid) const {
-
-  return isSelected(detid.rawId());
-
-}
-
-bool DetIdSelector::operator()(const unsigned int& rawid) const {
-
-  return isSelected(rawid);
-
-}
-
-
-
+bool DetIdSelector::operator()(const unsigned int& rawid) const { return isSelected(rawid); }

--- a/CommonTools/UtilAlgos/src/InputTagDistributor.cc
+++ b/CommonTools/UtilAlgos/src/InputTagDistributor.cc
@@ -1,3 +1,1 @@
 #include "CommonTools/UtilAlgos/interface/InputTagDistributor.h"
-
-

--- a/CommonTools/UtilAlgos/test/TestTFileServiceAnalyzer.cc
+++ b/CommonTools/UtilAlgos/test/TestTFileServiceAnalyzer.cc
@@ -4,17 +4,17 @@
 class TestTFileServiceAnalyzer : public edm::EDAnalyzer {
 public:
   /// constructor
-  TestTFileServiceAnalyzer( const edm::ParameterSet & );
+  TestTFileServiceAnalyzer(const edm::ParameterSet&);
 
 private:
   /// process one event
-  void analyze( const edm::Event& , const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   /// histograms
-  TH1F * h_test1, * h_test2;
+  TH1F *h_test1, *h_test2;
   /// TTree
-  TTree * tree_test;
+  TTree* tree_test;
   /// entry for TTree test
-  int testInt; 
+  int testInt;
   /// sub-directory name
   std::string dir1_, dir2_;
 };
@@ -25,29 +25,28 @@ private:
 using namespace edm;
 using namespace std;
 
-TestTFileServiceAnalyzer::TestTFileServiceAnalyzer( const ParameterSet & cfg ) :
-  dir1_( cfg.getParameter<string>( "dir1" ) ),
-  dir2_( cfg.getParameter<string>( "dir2" ) ) {
+TestTFileServiceAnalyzer::TestTFileServiceAnalyzer(const ParameterSet& cfg)
+    : dir1_(cfg.getParameter<string>("dir1")), dir2_(cfg.getParameter<string>("dir2")) {
   Service<TFileService> fs;
-  if ( dir1_.empty() ) {
-    h_test1 = fs->make<TH1F>( "test1"  , "test histogram #1", 100,  0., 100. );
+  if (dir1_.empty()) {
+    h_test1 = fs->make<TH1F>("test1", "test histogram #1", 100, 0., 100.);
   } else {
-    TFileDirectory dir1 = fs->mkdir( dir1_ );
-    h_test1 = dir1.make<TH1F>( "test1"  , "test histogram #1", 100,  0., 100. );
+    TFileDirectory dir1 = fs->mkdir(dir1_);
+    h_test1 = dir1.make<TH1F>("test1", "test histogram #1", 100, 0., 100.);
   }
-  if ( dir2_.empty() ) {
-    h_test2 = fs->make<TH1F>( "test2"  , "test histogram #2", 100,  0., 100. );
+  if (dir2_.empty()) {
+    h_test2 = fs->make<TH1F>("test2", "test histogram #2", 100, 0., 100.);
   } else {
-    TFileDirectory dir2 = fs->mkdir( dir2_ );
-    h_test2 = dir2.make<TH1F>( "test2"  , "test histogram #2", 100,  0., 100. );
+    TFileDirectory dir2 = fs->mkdir(dir2_);
+    h_test2 = dir2.make<TH1F>("test2", "test histogram #2", 100, 0., 100.);
   }
-  tree_test = fs->make<TTree>("Test","Test Tree",1);
+  tree_test = fs->make<TTree>("Test", "Test Tree", 1);
   tree_test->Branch("TestBranch", &testInt, "testInt/I");
 }
 
-void TestTFileServiceAnalyzer::analyze( const Event& evt, const EventSetup& ) {
-  h_test1->Fill( 50. );
-  h_test2->Fill( 60. );
+void TestTFileServiceAnalyzer::analyze(const Event& evt, const EventSetup&) {
+  h_test1->Fill(50.);
+  h_test2->Fill(60.);
   // fill test TTree
   testInt = 70;
   tree_test->Fill();
@@ -55,5 +54,4 @@ void TestTFileServiceAnalyzer::analyze( const Event& evt, const EventSetup& ) {
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( TestTFileServiceAnalyzer );
-
+DEFINE_FWK_MODULE(TestTFileServiceAnalyzer);

--- a/CommonTools/Utils/bin/runFormulaEvaluator.cc
+++ b/CommonTools/Utils/bin/runFormulaEvaluator.cc
@@ -3,10 +3,9 @@
 #include <vector>
 
 int main(int argc, char** argv) {
+  while (true) {
+    std::cout << ">type in formula\n>" << std::flush;
 
-  while(true) {
-    std::cout <<">type in formula\n>"<<std::flush;
-    
     std::string form;
     std::cin >> form;
 
@@ -15,7 +14,7 @@ int main(int argc, char** argv) {
     std::vector<double> x;
     std::vector<double> v;
 
-    std::cout << eval.evaluate(x,v)<<std::endl;
+    std::cout << eval.evaluate(x, v) << std::endl;
   }
 
   return 0;

--- a/CommonTools/Utils/interface/AndPairSelector.h
+++ b/CommonTools/Utils/interface/AndPairSelector.h
@@ -7,13 +7,14 @@
  * $Id: AndPairSelector.h,v 1.1 2009/02/24 14:40:26 llista Exp $
  */
 
-template<typename S1, typename S2>
+template <typename S1, typename S2>
 struct AndPairSelector {
-  AndPairSelector(const S1 & s1, const S2 & s2) : s1_(s1), s2_(s2) { }
-  template<typename T1, typename T2>
-  bool operator()(const T1 & t1, const T2 & t2) const {
+  AndPairSelector(const S1& s1, const S2& s2) : s1_(s1), s2_(s2) {}
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
     return s1_(t1) && s2_(t2);
   }
+
 private:
   S1 s1_;
   S2 s2_;

--- a/CommonTools/Utils/interface/AndSelector.h
+++ b/CommonTools/Utils/interface/AndSelector.h
@@ -13,19 +13,22 @@ namespace helpers {
 
 namespace reco {
   namespace modules {
-    template<typename T1, typename T2, typename T3, typename T4, typename T5> struct CombinedEventSetupInit;
+    template <typename T1, typename T2, typename T3, typename T4, typename T5>
+    struct CombinedEventSetupInit;
   }
-}
+}  // namespace reco
 
-template<typename S1, typename S2, 
-	 typename S3 = helpers::NullAndOperand, typename S4 = helpers::NullAndOperand,
-	 typename S5 = helpers::NullAndOperand>
+template <typename S1,
+          typename S2,
+          typename S3 = helpers::NullAndOperand,
+          typename S4 = helpers::NullAndOperand,
+          typename S5 = helpers::NullAndOperand>
 struct AndSelector {
-  AndSelector( const S1 & s1, const S2 & s2, const S3 & s3, const S4 & s4, const S5 & s5 ) :
-    s1_( s1 ), s2_( s2 ), s3_( s3 ), s4_( s4 ), s5_( s5 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) && s2_( t ) && s3_( t ) && s4_( t ) && s5_( t );
+  AndSelector(const S1& s1, const S2& s2, const S3& s3, const S4& s4, const S5& s5)
+      : s1_(s1), s2_(s2), s3_(s3), s4_(s4), s5_(s5) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) && s2_(t) && s3_(t) && s4_(t) && s5_(t);
   }
 
 private:
@@ -37,37 +40,37 @@ private:
   S5 s5_;
 };
 
-
-template<typename S1, typename S2>
+template <typename S1, typename S2>
 struct AndSelector<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand> {
-  AndSelector( const S1 & s1, const S2 & s2 ) :
-    s1_( s1 ), s2_( s2 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) && s2_( t );
+  AndSelector(const S1& s1, const S2& s2) : s1_(s1), s2_(s2) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) && s2_(t);
   }
-  template<typename T1, typename T2>
-  bool operator()( const T1 & t1, const T2 & t2 ) const { 
-    return s1_( t1 ) && s2_( t2 );
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
+    return s1_(t1) && s2_(t2);
   }
+
 private:
-  friend struct reco::modules::CombinedEventSetupInit<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>;
+  friend struct reco::modules::
+      CombinedEventSetupInit<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>;
   S1 s1_;
   S2 s2_;
 };
 
-template<typename S1, typename S2, typename S3>
+template <typename S1, typename S2, typename S3>
 struct AndSelector<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand> {
-  AndSelector( const S1 & s1, const S2 & s2, const S3 & s3 ) :
-    s1_( s1 ), s2_( s2 ), s3_( s3 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) && s2_( t ) && s3_( t );
+  AndSelector(const S1& s1, const S2& s2, const S3& s3) : s1_(s1), s2_(s2), s3_(s3) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) && s2_(t) && s3_(t);
   }
-  template<typename T1, typename T2, typename T3>
-  bool operator()( const T1 & t1,  const T2 & t2,  const T3 & t3 ) const {
-    return s1_( t1 ) && s2_( t2 ) && s3_( t3 );
+  template <typename T1, typename T2, typename T3>
+  bool operator()(const T1& t1, const T2& t2, const T3& t3) const {
+    return s1_(t1) && s2_(t2) && s3_(t3);
   }
+
 private:
   friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand>;
   S1 s1_;
@@ -75,18 +78,18 @@ private:
   S3 s3_;
 };
 
-template<typename S1, typename S2, typename S3, typename S4>
+template <typename S1, typename S2, typename S3, typename S4>
 struct AndSelector<S1, S2, S3, S4, helpers::NullAndOperand> {
-  AndSelector( const S1 & s1, const S2 & s2, const S3 & s3, const S4 & s4 ) :
-    s1_( s1 ), s2_( s2 ), s3_( s3 ), s4_( s4 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) && s2_( t ) && s3_( t ) && s4_( t );
+  AndSelector(const S1& s1, const S2& s2, const S3& s3, const S4& s4) : s1_(s1), s2_(s2), s3_(s3), s4_(s4) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) && s2_(t) && s3_(t) && s4_(t);
   }
-  template<typename T1, typename T2, typename T3, typename T4>
-  bool operator()( const T1 & t1,  const T2 & t2,  const T3 & t3, const T4 & t4 ) const {
-    return s1_( t1 ) && s2_( t2 ) && s3_( t3 ) && s4_( t4 );
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4) const {
+    return s1_(t1) && s2_(t2) && s3_(t3) && s4_(t4);
   }
+
 private:
   friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, helpers::NullAndOperand>;
   S1 s1_;

--- a/CommonTools/Utils/interface/AnyPairSelector.h
+++ b/CommonTools/Utils/interface/AnyPairSelector.h
@@ -8,8 +8,10 @@
  */
 
 struct AnyPairSelector {
-  template<typename T1, typename T2>
-  bool operator()( const T1 &, const T2 & ) const { return true; }
+  template <typename T1, typename T2>
+  bool operator()(const T1 &, const T2 &) const {
+    return true;
+  }
 };
 
 #endif

--- a/CommonTools/Utils/interface/AnySelector.h
+++ b/CommonTools/Utils/interface/AnySelector.h
@@ -8,8 +8,10 @@
  */
 
 struct AnySelector {
-  template<typename T>
-  bool operator()( const T & ) const { return true; }
+  template <typename T>
+  bool operator()(const T&) const {
+    return true;
+  }
 };
 
 #endif

--- a/CommonTools/Utils/interface/DeltaPhiMinPairSelector.h
+++ b/CommonTools/Utils/interface/DeltaPhiMinPairSelector.h
@@ -9,16 +9,14 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 struct DeltaPhiMinPairSelector {
-  DeltaPhiMinPairSelector( double deltaPhiMin ) : 
-    deltaPhiMin_( deltaPhiMin ) { }
-  template<typename T1, typename T2>
-  bool operator()( const T1 & t1, const T2 & t2 ) const { 
-    return deltaPhi( t1.phi(), t2.phi() ) > deltaPhiMin_;
+  DeltaPhiMinPairSelector(double deltaPhiMin) : deltaPhiMin_(deltaPhiMin) {}
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
+    return deltaPhi(t1.phi(), t2.phi()) > deltaPhiMin_;
   }
 
 private:
   double deltaPhiMin_;
 };
-
 
 #endif

--- a/CommonTools/Utils/interface/DeltaRMinPairSelector.h
+++ b/CommonTools/Utils/interface/DeltaRMinPairSelector.h
@@ -9,16 +9,14 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 struct DeltaRMinPairSelector {
-  DeltaRMinPairSelector( double deltaRMin ) : 
-    deltaRMin2_( deltaRMin * deltaRMin ) { }
-  template<typename T1, typename T2>
-  bool operator()( const T1 & t1, const T2 & t2 ) const { 
-    return deltaR2( t1, t2 ) > deltaRMin2_;
+  DeltaRMinPairSelector(double deltaRMin) : deltaRMin2_(deltaRMin * deltaRMin) {}
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
+    return deltaR2(t1, t2) > deltaRMin2_;
   }
 
 private:
   double deltaRMin2_;
 };
-
 
 #endif

--- a/CommonTools/Utils/interface/DynArray.h
+++ b/CommonTools/Utils/interface/DynArray.h
@@ -1,63 +1,91 @@
 #ifndef CommonTools_Utils_DynArray_H
 #define CommonTools_Utils_DynArray_H
 
-template<typename T>
+template <typename T>
 class DynArray {
 public:
-   T * a=nullptr;
-   unsigned int s=0;
-public :
-   using size_type = unsigned int;
-   using value_type = T;
-   using reference = T&;
-   using const_reference = T const&;
+  T* a = nullptr;
+  unsigned int s = 0;
 
-  DynArray(){}
+public:
+  using size_type = unsigned int;
+  using value_type = T;
+  using reference = T&;
+  using const_reference = T const&;
 
-  explicit DynArray(unsigned char * storage) : a((T*)(storage)), s(0){}
+  DynArray() {}
 
-  DynArray(unsigned char * storage, unsigned int isize) : a((T*)(storage)), s(isize){
-    for (auto i=0U; i<s; ++i) new((begin()+i)) T();
+  explicit DynArray(unsigned char* storage) : a((T*)(storage)), s(0) {}
+
+  DynArray(unsigned char* storage, unsigned int isize) : a((T*)(storage)), s(isize) {
+    for (auto i = 0U; i < s; ++i)
+      new ((begin() + i)) T();
   }
-  DynArray(unsigned char * storage, unsigned int isize, T const& it) : a((T*)(storage)), s(isize){
-    for (auto i=0U; i<s; ++i) new((begin()+i)) T(it);
+  DynArray(unsigned char* storage, unsigned int isize, T const& it) : a((T*)(storage)), s(isize) {
+    for (auto i = 0U; i < s; ++i)
+      new ((begin() + i)) T(it);
   }
 
   DynArray(DynArray const&) = delete;
-  DynArray & operator=(DynArray const &) = delete;
+  DynArray& operator=(DynArray const&) = delete;
 
-  DynArray(DynArray && other) { a=other.a; s=other.s; other.s=0; other.a=nullptr;}
-  DynArray & operator=(DynArray && other) { a=other.a; s=other.s; other.s=0; other.a=nullptr; return *this;}
+  DynArray(DynArray&& other) {
+    a = other.a;
+    s = other.s;
+    other.s = 0;
+    other.a = nullptr;
+  }
+  DynArray& operator=(DynArray&& other) {
+    a = other.a;
+    s = other.s;
+    other.s = 0;
+    other.a = nullptr;
+    return *this;
+  }
 
+  ~DynArray() {
+    for (auto i = 0U; i < s; ++i)
+      a[i].~T();
+  }
 
-  ~DynArray() { for (auto i=0U; i<s; ++i) a[i].~T(); }
+  T& operator[](unsigned int i) { return a[i]; }
+  T* begin() { return a; }
+  T* end() { return a + s; }
+  T& front() { return a[0]; }
+  T& back() { return a[s - 1]; }
 
-   T & operator[](unsigned int i) { return a[i];}
-   T * begin() { return a;}
-   T * end() { return a+s;}
-   T & front() { return a[0];}
-   T & back() { return a[s-1];}
+  T const& operator[](unsigned int i) const { return a[i]; }
+  T const* begin() const { return a; }
+  T const* end() const { return a + s; }
+  unsigned int size() const { return s; }
+  bool empty() const { return 0 == s; }
 
-   T const & operator[](unsigned int i) const { return a[i];}
-   T const * begin() const { return a;}
-   T const * end() const { return a+s;}
-   unsigned int size() const { return s;}
-   bool empty() const { return 0==s;}
+  T const* data() const { return a; }
+  T const& front() const { return a[0]; }
+  T const& back() const { return a[s - 1]; }
 
-   T const * data() const { return a; }
-   T const &front() const { return a[0];}
-   T const & back() const { return a[s-1];}
-
-   void pop_back() {back().~T(); --s;}
-   void push_back(T const& t) {new((begin()+s)) T(t);++s;}
-   void	push_back(T && t) {new((begin()+s)) T(t);++s;}
-
-
+  void pop_back() {
+    back().~T();
+    --s;
+  }
+  void push_back(T const& t) {
+    new ((begin() + s)) T(t);
+    ++s;
+  }
+  void push_back(T&& t) {
+    new ((begin() + s)) T(t);
+    ++s;
+  }
 };
 
-#define unInitDynArray(T,n,x)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage)
-#define declareDynArray(T,n,x)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage,n)
-#define initDynArray(T,n,x,i)  alignas(alignof(T)) unsigned char x ## _storage[sizeof(T)*n]; DynArray<T> x(x ## _storage,n,i)
+#define unInitDynArray(T, n, x)                                 \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * n]; \
+  DynArray<T> x(x##_storage)
+#define declareDynArray(T, n, x)                                \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * n]; \
+  DynArray<T> x(x##_storage, n)
+#define initDynArray(T, n, x, i)                                \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * n]; \
+  DynArray<T> x(x##_storage, n, i)
 
-
-#endif // CommonTools_Utils_DynArray_H
+#endif  // CommonTools_Utils_DynArray_H

--- a/CommonTools/Utils/interface/EtComparator.h
+++ b/CommonTools/Utils/interface/EtComparator.h
@@ -12,26 +12,21 @@
  *
  */
 
-template<typename T>
+template <typename T>
 struct LessByEt {
   typedef T first_argument_type;
   typedef T second_argument_type;
-  bool operator()( const T & t1, const T & t2 ) const {
-    return t1.et() < t2.et();
-  }
+  bool operator()(const T& t1, const T& t2) const { return t1.et() < t2.et(); }
 };
 
-template<typename T>
+template <typename T>
 struct GreaterByEt {
   typedef T first_argument_type;
   typedef T second_argument_type;
-  bool operator()( const T & t1, const T & t2 ) const {
-    return t1.et() > t2.et();
-  }
+  bool operator()(const T& t1, const T& t2) const { return t1.et() > t2.et(); }
 };
 
-
-#include<limits>
+#include <limits>
 #include <cmath>
 
 template <class T>
@@ -39,10 +34,10 @@ struct NumericSafeLessByEt {
   typedef T first_argument_type;
   typedef T second_argument_type;
   bool operator()(const T& a1, const T& a2) {
-    return
-      fabs (a1.et()-a2.et()) > std::numeric_limits<double>::epsilon() ? a1.et() < a2.et() :
-      fabs (a1.px()-a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() < a2.px() :
-      a1.pz() < a2.pz();
+    return fabs(a1.et() - a2.et()) > std::numeric_limits<double>::epsilon()
+               ? a1.et() < a2.et()
+               : fabs(a1.px() - a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() < a2.px()
+                                                                                  : a1.pz() < a2.pz();
   }
 };
 
@@ -51,10 +46,10 @@ struct NumericSafeGreaterByEt {
   typedef T first_argument_type;
   typedef T second_argument_type;
   bool operator()(const T& a1, const T& a2) {
-    return
-      fabs (a1.et()-a2.et()) > std::numeric_limits<double>::epsilon() ? a1.et() > a2.et() :
-      fabs (a1.px()-a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() > a2.px() :
-      a1.pz() > a2.pz();
+    return fabs(a1.et() - a2.et()) > std::numeric_limits<double>::epsilon()
+               ? a1.et() > a2.et()
+               : fabs(a1.px() - a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() > a2.px()
+                                                                                  : a1.pz() > a2.pz();
   }
 };
 

--- a/CommonTools/Utils/interface/EtMinSelector.h
+++ b/CommonTools/Utils/interface/EtMinSelector.h
@@ -8,9 +8,11 @@
  */
 
 struct EtMinSelector {
-  EtMinSelector( double etMin ) : etMin_( etMin ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { return t.et() >= etMin_; }
+  EtMinSelector(double etMin) : etMin_(etMin) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return t.et() >= etMin_;
+  }
 
 private:
   double etMin_;

--- a/CommonTools/Utils/interface/EtaRangeSelector.h
+++ b/CommonTools/Utils/interface/EtaRangeSelector.h
@@ -8,13 +8,13 @@
  */
 
 struct EtaRangeSelector {
-  EtaRangeSelector( double etaMin, double etaMax ) : 
-    etaMin_( etaMin ), etaMax_( etaMax ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
+  EtaRangeSelector(double etaMin, double etaMax) : etaMin_(etaMin), etaMax_(etaMax) {}
+  template <typename T>
+  bool operator()(const T& t) const {
     double eta = t.eta();
-    return ( eta >= etaMin_ && eta <= etaMax_ ); 
+    return (eta >= etaMin_ && eta <= etaMax_);
   }
+
 private:
   double etaMin_, etaMax_;
 };

--- a/CommonTools/Utils/interface/Exception.h
+++ b/CommonTools/Utils/interface/Exception.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     Exception
-// 
+//
 /**\class Exception Exception.h CommonTools/Utils/interface/Exception.h
 
  Description: <one line class summary>
@@ -27,89 +27,83 @@
 
 // forward declarations
 namespace reco {
-   namespace parser {
-      enum SyntaxErrors {
-         kSyntaxError,
-         kMissingClosingParenthesis,
-         kSpecialError
-      };
-      
-      typedef boost::spirit::classic::parser_error<reco::parser::SyntaxErrors> BaseException;
-      
-      ///returns the appropriate 'what' message for the exception
-      inline const char * baseExceptionWhat(const BaseException& e) {
-         switch(e.descriptor) {
-            case kMissingClosingParenthesis:
-            return "Missing close parenthesis.";
-            case kSyntaxError:
-            return "Syntax error.";
-            case kSpecialError:
-            default:
-               break;
-         }
-         return e.what();
+  namespace parser {
+    enum SyntaxErrors { kSyntaxError, kMissingClosingParenthesis, kSpecialError };
+
+    typedef boost::spirit::classic::parser_error<reco::parser::SyntaxErrors> BaseException;
+
+    ///returns the appropriate 'what' message for the exception
+    inline const char* baseExceptionWhat(const BaseException& e) {
+      switch (e.descriptor) {
+        case kMissingClosingParenthesis:
+          return "Missing close parenthesis.";
+        case kSyntaxError:
+          return "Syntax error.";
+        case kSpecialError:
+        default:
+          break;
       }
-      class Exception : public BaseException {
+      return e.what();
+    }
+    class Exception : public BaseException {
+    public:
+      Exception(const char* iIterator) : BaseException(iIterator, kSpecialError) {}
+      Exception(const Exception& iOther) : BaseException(iOther) { ost_ << iOther.ost_.str(); }
+      ~Exception() throw() override {}
 
-      public:
-         Exception(const char* iIterator) : BaseException(iIterator,kSpecialError) {}
-         Exception(const Exception& iOther) : BaseException(iOther) {
-            ost_ << iOther.ost_.str();
-         }
-         ~Exception() throw() override {}
-
-         // ---------- const member functions ---------------------
-         const char* what() const throw() override { what_ = ost_.str(); return what_.c_str();}
-
-         // ---------- static member functions --------------------
-
-         // ---------- member functions ---------------------------
-
-         template<class T>
-         friend Exception& operator<<(Exception&, const T&);
-         template<class T>
-         friend Exception& operator<<(const Exception&, const T&);
-         friend Exception& operator<<(Exception&, std::ostream&(*f)(std::ostream&));
-         friend Exception& operator<<(const Exception&, std::ostream&(*f)(std::ostream&));
-         friend Exception& operator<<(Exception&, std::ios_base&(*f)(std::ios_base&));
-         friend Exception& operator<<(const Exception&, std::ios_base&(*f)(std::ios_base&));
-      private:
-
-         //const Exception& operator=(const Exception&); // stop default
-
-         // ---------- member data --------------------------------
-         std::ostringstream ost_;
-         mutable std::string what_; //needed since ost_.str() returns a temporary string
-      };
-      
-      template<class T>
-       inline Exception& operator<<(Exception& e, const T& iT) {
-         e.ost_ << iT;
-         return e;
+      // ---------- const member functions ---------------------
+      const char* what() const throw() override {
+        what_ = ost_.str();
+        return what_.c_str();
       }
-      template<class T>
-      inline Exception& operator<<(const Exception& e, const T& iT) {
-         return operator<<(const_cast<Exception&>(e), iT);
-      }
-      inline Exception& operator<<(Exception& e, std::ostream&(*f)(std::ostream&))
-      {
-         f(e.ost_);
-         return e;
-      }
-      inline Exception& operator<<(const Exception& e, std::ostream&(*f)(std::ostream&))
-      {
-         f(const_cast<Exception&>(e).ost_);
-         return const_cast<Exception&>(e);
-      }
-      inline Exception& operator<<(Exception& e, std::ios_base&(*f)(std::ios_base&)) {
-         f(e.ost_);
-         return e;
-      }      
-      inline Exception& operator<<(const Exception& e, std::ios_base&(*f)(std::ios_base&)) {
-         f(const_cast<Exception&>(e).ost_);
-         return const_cast<Exception&>(e);
-      }
-   }
-}
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+      template <class T>
+      friend Exception& operator<<(Exception&, const T&);
+      template <class T>
+      friend Exception& operator<<(const Exception&, const T&);
+      friend Exception& operator<<(Exception&, std::ostream& (*f)(std::ostream&));
+      friend Exception& operator<<(const Exception&, std::ostream& (*f)(std::ostream&));
+      friend Exception& operator<<(Exception&, std::ios_base& (*f)(std::ios_base&));
+      friend Exception& operator<<(const Exception&, std::ios_base& (*f)(std::ios_base&));
+
+    private:
+      //const Exception& operator=(const Exception&); // stop default
+
+      // ---------- member data --------------------------------
+      std::ostringstream ost_;
+      mutable std::string what_;  //needed since ost_.str() returns a temporary string
+    };
+
+    template <class T>
+    inline Exception& operator<<(Exception& e, const T& iT) {
+      e.ost_ << iT;
+      return e;
+    }
+    template <class T>
+    inline Exception& operator<<(const Exception& e, const T& iT) {
+      return operator<<(const_cast<Exception&>(e), iT);
+    }
+    inline Exception& operator<<(Exception& e, std::ostream& (*f)(std::ostream&)) {
+      f(e.ost_);
+      return e;
+    }
+    inline Exception& operator<<(const Exception& e, std::ostream& (*f)(std::ostream&)) {
+      f(const_cast<Exception&>(e).ost_);
+      return const_cast<Exception&>(e);
+    }
+    inline Exception& operator<<(Exception& e, std::ios_base& (*f)(std::ios_base&)) {
+      f(e.ost_);
+      return e;
+    }
+    inline Exception& operator<<(const Exception& e, std::ios_base& (*f)(std::ios_base&)) {
+      f(const_cast<Exception&>(e).ost_);
+      return const_cast<Exception&>(e);
+    }
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/interface/ExpressionEvaluator.h
+++ b/CommonTools/Utils/interface/ExpressionEvaluator.h
@@ -1,41 +1,37 @@
 #ifndef CommonToolsUtilsExpressionEvaluator_H
 #define CommonToolsUtilsExpressionEvaluator_H
 
-
-#include<string>
+#include <string>
 
 namespace reco {
 
-class ExpressionEvaluator {
-public:
-  ExpressionEvaluator(const char * pkg,  const char * iname, const std::string & iexpr);
-  ~ExpressionEvaluator();
-  
-  template<typename EXPR, typename... CArgs>
-  EXPR * expr() const { 
-    typedef EXPR * factoryP();
-    return reinterpret_cast<factoryP*>(m_expr)();
+  class ExpressionEvaluator {
+  public:
+    ExpressionEvaluator(const char* pkg, const char* iname, const std::string& iexpr);
+    ~ExpressionEvaluator();
+
+    template <typename EXPR, typename... CArgs>
+    EXPR* expr() const {
+      typedef EXPR* factoryP();
+      return reinterpret_cast<factoryP*>(m_expr)();
+    }
+
+  private:
+    std::string m_name;
+    void* m_expr;
+  };
+
+  template <typename EXPR>
+  EXPR* expressionEvaluator(const char* pkg, const char* iname, const std::string& iexpr) {
+    ExpressionEvaluator ee(pkg, iname, iexpr);
+    return ee.expr<EXPR>();
   }
 
-private:
-
-  std::string m_name;
-  void * m_expr;
-};
-
-
-  template< typename EXPR>
-  EXPR * expressionEvaluator(const char * pkg,  const char * iname, const std::string & iexpr) {
-    ExpressionEvaluator ee(pkg, iname,iexpr);
-    return ee.expr<EXPR>();
- }
-
-}
+}  // namespace reco
 
 #define SINGLE_ARG(...) __VA_ARGS__
 #define RECO_XSTR(...) RECO_STR(__VA_ARGS__)
 #define RECO_STR(...) #__VA_ARGS__
-#define reco_expressionEvaluator(pkg, EXPR, iexpr) reco::expressionEvaluator<EXPR>(pkg,RECO_XSTR(EXPR),iexpr)
+#define reco_expressionEvaluator(pkg, EXPR, iexpr) reco::expressionEvaluator<EXPR>(pkg, RECO_XSTR(EXPR), iexpr)
 
-#endif // CommonToolsUtilsExpressionEvaluator_H
-
+#endif  // CommonToolsUtilsExpressionEvaluator_H

--- a/CommonTools/Utils/interface/ExpressionEvaluatorTemplates.h
+++ b/CommonTools/Utils/interface/ExpressionEvaluatorTemplates.h
@@ -1,72 +1,76 @@
 #ifndef CommonToolsUtilsExpressionEvaluatorTemplates_H
-#define	CommonToolsUtilsExpressionEvaluatorTemplates_H
+#define CommonToolsUtilsExpressionEvaluatorTemplates_H
 #include <vector>
 #include <algorithm>
-#include<numeric>
-#include<limits>
-#include<memory>
-#include<tuple>
+#include <numeric>
+#include <limits>
+#include <memory>
+#include <tuple>
 
 namespace reco {
 
-  template<typename Ret, typename... Args>
+  template <typename Ret, typename... Args>
   struct genericExpression {
-    virtual Ret operator()(Args ...) const =0;
+    virtual Ret operator()(Args...) const = 0;
     virtual ~genericExpression(){};
   };
 
-
-  template<typename Object>
+  template <typename Object>
   struct CutOnObject {
     virtual bool eval(Object const&) const = 0;
     virtual ~CutOnObject(){};
   };
 
-  template<typename Object>
+  template <typename Object>
   struct ValueOnObject {
-    virtual double eval(Object const&) const =0;
+    virtual double eval(Object const&) const = 0;
     virtual ~ValueOnObject(){};
   };
 
-  template<typename Object>
+  template <typename Object>
   struct MaskCollection {
-    using Collection = std::vector<Object const *>;
+    using Collection = std::vector<Object const*>;
     using Mask = std::vector<bool>;
-    template<typename F>
+    template <typename F>
     void mask(Collection const& cands, Mask& mask, F f) const {
-      mask.resize(cands.size()); 
-      std::transform(cands.begin(),cands.end(),mask.begin(), [&](typename Collection::value_type const & c){ return f(*c);});
+      mask.resize(cands.size());
+      std::transform(
+          cands.begin(), cands.end(), mask.begin(), [&](typename Collection::value_type const& c) { return f(*c); });
     }
     virtual void eval(Collection const&, Mask&) const = 0;
     virtual ~MaskCollection(){};
   };
 
-  template<typename Object>
+  template <typename Object>
   struct SelectInCollection {
-    using Collection = std::vector<Object const *>;
-    template<typename F>
+    using Collection = std::vector<Object const*>;
+    template <typename F>
     void select(Collection& cands, F f) const {
-      cands.erase(std::remove_if(cands.begin(),cands.end(),[&](typename Collection::value_type const &c){return !f(*c);}),cands.end());
+      cands.erase(
+          std::remove_if(cands.begin(), cands.end(), [&](typename Collection::value_type const& c) { return !f(*c); }),
+          cands.end());
     }
     virtual void eval(Collection&) const = 0;
     virtual ~SelectInCollection(){};
   };
 
-  template<typename Object>
+  template <typename Object>
   struct SelectIndecesInCollection {
-    using Collection = std::vector<Object const *>;
+    using Collection = std::vector<Object const*>;
     using Indices = std::vector<unsigned int>;
-    template<typename F>
-    void select(Collection const & cands, Indices& inds, F f) const {
-      unsigned int i=0;
-      for (auto const & c : cands) { if(f(*c)) inds.push_back(i); ++i; }
+    template <typename F>
+    void select(Collection const& cands, Indices& inds, F f) const {
+      unsigned int i = 0;
+      for (auto const& c : cands) {
+        if (f(*c))
+          inds.push_back(i);
+        ++i;
+      }
     }
     virtual void eval(Collection const&, Indices&) const = 0;
     virtual ~SelectIndecesInCollection(){};
   };
 
+}  // namespace reco
 
-}
-
-#endif	// CommonToolsUtilsExpressionEvaluatorTemplates_H
-
+#endif  // CommonToolsUtilsExpressionEvaluatorTemplates_H

--- a/CommonTools/Utils/interface/ExpressionHisto.h
+++ b/CommonTools/Utils/interface/ExpressionHisto.h
@@ -4,7 +4,7 @@
 //
 // Package:     UtilAlgos
 // Class  :     ExpressionHisto
-// 
+//
 /**\class ExpressionHisto ExpressionHisto.h CommonTools/Utils/interface/ExpressionHisto.h
 
  Description: Histogram tool using expressions 
@@ -30,81 +30,83 @@
 #include "TH1F.h"
 #include "TH1.h"
 
-template<typename T>
+template <typename T>
 class ExpressionHisto {
 public:
   ExpressionHisto(const edm::ParameterSet& iConfig);
   ~ExpressionHisto();
-  
+
   void initialize(TFileDirectory& fs);
-/** Plot the quantity for the specified element and index.
+  /** Plot the quantity for the specified element and index.
     Returns true if the quantity has been plotted, false otherwise.
     A return value of "false" means "please don't send any more elements".
     The default "i = 0" is to keep backwards compatibility with usages outside
     HistoAnalyzer */
-  bool fill(const T& element, double weight=1.0, uint32_t i=0);  
-  
+  bool fill(const T& element, double weight = 1.0, uint32_t i = 0);
+
 private:
   double min, max;
   int nbins;
   std::string name, description;
   uint32_t nhistos;
-  bool     separatePlots;
-  TH1F ** hist;
-  StringObjectFunction<T> function;      
+  bool separatePlots;
+  TH1F** hist;
+  StringObjectFunction<T> function;
 };
 
-template<typename T>
-ExpressionHisto<T>::ExpressionHisto(const edm::ParameterSet& iConfig):
-  min(iConfig.template getUntrackedParameter<double>("min")),
-  max(iConfig.template getUntrackedParameter<double>("max")),
-  nbins(iConfig.template getUntrackedParameter<int>("nbins")),
-  name(iConfig.template getUntrackedParameter<std::string>("name")),
-  description(iConfig.template getUntrackedParameter<std::string>("description")),
-  function(iConfig.template getUntrackedParameter<std::string>("plotquantity"), 
-           iConfig.template getUntrackedParameter<bool>("lazyParsing", false)) {
+template <typename T>
+ExpressionHisto<T>::ExpressionHisto(const edm::ParameterSet& iConfig)
+    : min(iConfig.template getUntrackedParameter<double>("min")),
+      max(iConfig.template getUntrackedParameter<double>("max")),
+      nbins(iConfig.template getUntrackedParameter<int>("nbins")),
+      name(iConfig.template getUntrackedParameter<std::string>("name")),
+      description(iConfig.template getUntrackedParameter<std::string>("description")),
+      function(iConfig.template getUntrackedParameter<std::string>("plotquantity"),
+               iConfig.template getUntrackedParameter<bool>("lazyParsing", false)) {
   int32_t itemsToPlot = iConfig.template getUntrackedParameter<int32_t>("itemsToPlot", -1);
   if (itemsToPlot <= 0) {
-      nhistos = 1; separatePlots = false;
+    nhistos = 1;
+    separatePlots = false;
   } else {
-      nhistos = itemsToPlot; separatePlots = true;
+    nhistos = itemsToPlot;
+    separatePlots = true;
   }
 }
 
-template<typename T>
-ExpressionHisto<T>::~ExpressionHisto() {
-}
+template <typename T>
+ExpressionHisto<T>::~ExpressionHisto() {}
 
-template<typename T>
-void ExpressionHisto<T>::initialize(TFileDirectory& fs) 
-{
-   hist = new TH1F*[nhistos];
-   char buff[1024],baff[1024];
-   if (separatePlots) {
-       for (uint32_t i = 0; i < nhistos; i++) {
-               if (strstr(name.c_str(), "%d") != nullptr) {
-                       snprintf(buff, 1024, name.c_str(), i+1);
-               } else {
-                       snprintf(buff, 1024, "%s [#%d]", name.c_str(), i+1);
-               }
-               if (strstr(description.c_str(), "%d") != nullptr) {
-                       snprintf(baff, 1024, description.c_str(), i+1);
-               } else {
-                       snprintf(baff, 1024, "%s [#%d]", description.c_str(), i+1);
-               }
-               hist[i] = fs.make<TH1F>(buff,baff,nbins,min,max);
-       }
-    } else {
-       hist[0] = fs.make<TH1F>(name.c_str(),description.c_str(),nbins,min,max);
+template <typename T>
+void ExpressionHisto<T>::initialize(TFileDirectory& fs) {
+  hist = new TH1F*[nhistos];
+  char buff[1024], baff[1024];
+  if (separatePlots) {
+    for (uint32_t i = 0; i < nhistos; i++) {
+      if (strstr(name.c_str(), "%d") != nullptr) {
+        snprintf(buff, 1024, name.c_str(), i + 1);
+      } else {
+        snprintf(buff, 1024, "%s [#%d]", name.c_str(), i + 1);
+      }
+      if (strstr(description.c_str(), "%d") != nullptr) {
+        snprintf(baff, 1024, description.c_str(), i + 1);
+      } else {
+        snprintf(baff, 1024, "%s [#%d]", description.c_str(), i + 1);
+      }
+      hist[i] = fs.make<TH1F>(buff, baff, nbins, min, max);
     }
+  } else {
+    hist[0] = fs.make<TH1F>(name.c_str(), description.c_str(), nbins, min, max);
+  }
 }
 
-template<typename T>
-bool ExpressionHisto<T>::fill(const T& element, double weight, uint32_t i) 
-{
-  if (!separatePlots) hist[0]->Fill( function(element), weight );
-  else if (i < nhistos)  hist[i]->Fill( function(element), weight );
-  else return false;
+template <typename T>
+bool ExpressionHisto<T>::fill(const T& element, double weight, uint32_t i) {
+  if (!separatePlots)
+    hist[0]->Fill(function(element), weight);
+  else if (i < nhistos)
+    hist[i]->Fill(function(element), weight);
+  else
+    return false;
   return true;
 }
 

--- a/CommonTools/Utils/interface/FormulaEvaluator.h
+++ b/CommonTools/Utils/interface/FormulaEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     FormulaEvaluator
-// 
+//
 /**\class FormulaEvaluator FormulaEvaluator.h "CommonTools/Utils/interface/FormulaEvaluator.h"
 
  Description: [one line class summary]
@@ -30,17 +30,17 @@
 namespace reco {
   namespace formula {
     struct ArrayAdaptor {
-    ArrayAdaptor(double const* iStart, size_t iSize):
-      m_start(iStart), m_size(iSize) {}
+      ArrayAdaptor(double const* iStart, size_t iSize) : m_start(iStart), m_size(iSize) {}
       size_t size() const { return m_size; }
-      bool empty() const {return m_size == 0; }
+      bool empty() const { return m_size == 0; }
       double const* start() const { return m_start; }
+
     private:
       double const* m_start;
       size_t m_size;
     };
     inline double const* startingAddress(ArrayAdaptor const& iV) {
-      if(iV.empty()) {
+      if (iV.empty()) {
         return nullptr;
       }
       return iV.start();
@@ -48,57 +48,53 @@ namespace reco {
 
     class EvaluatorBase;
     inline double const* startingAddress(std::vector<double> const& iV) {
-      if(iV.empty()) {
+      if (iV.empty()) {
         return nullptr;
       }
       return &iV[0];
     }
 
-    template<size_t t>
-      inline double const* startingAddress(std::array<double,t> const& iV) {
-      if(iV.empty()) {
+    template <size_t t>
+    inline double const* startingAddress(std::array<double, t> const& iV) {
+      if (iV.empty()) {
         return nullptr;
       }
       return &iV[0];
     }
 
-  }
+  }  // namespace formula
 
-  class FormulaEvaluator
-  {
-    
+  class FormulaEvaluator {
   public:
     explicit FormulaEvaluator(std::string const& iFormula);
 
     // ---------- const member functions ---------------------
-    template<typename V, typename P>
-      double evaluate( V const& iVariables, P const& iParameters) const {
+    template <typename V, typename P>
+    double evaluate(V const& iVariables, P const& iParameters) const {
       if (m_nVariables > iVariables.size()) {
         throwWrongNumberOfVariables(iVariables.size());
       }
       if (m_nParameters > iParameters.size()) {
         throwWrongNumberOfParameters(iParameters.size());
       }
-      return evaluate( formula::startingAddress(iVariables),
-                       formula::startingAddress(iParameters));
+      return evaluate(formula::startingAddress(iVariables), formula::startingAddress(iParameters));
     }
-    
+
     unsigned int numberOfParameters() const { return m_nParameters; }
     unsigned int numberOfVariables() const { return m_nVariables; }
 
     std::vector<std::string> abstractSyntaxTree() const;
-    
+
   private:
     double evaluate(double const* iVariables, double const* iParameters) const;
 
-    void throwWrongNumberOfVariables(size_t) const ;
+    void throwWrongNumberOfVariables(size_t) const;
     void throwWrongNumberOfParameters(size_t) const;
 
-    std::shared_ptr<formula::EvaluatorBase const> m_evaluator; 
+    std::shared_ptr<formula::EvaluatorBase const> m_evaluator;
     unsigned int m_nVariables = 0;
     unsigned int m_nParameters = 0;
-
-};
-}
+  };
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/interface/FunctionMinSelector.h
+++ b/CommonTools/Utils/interface/FunctionMinSelector.h
@@ -7,13 +7,11 @@
  * $Id: FunctionMinSelector.h,v 1.1 2009/02/24 14:40:26 llista Exp $
  */
 
-template<typename F>
+template <typename F>
 struct FunctionMinSelector {
-  explicit FunctionMinSelector( double minCut ) :
-    minCut_( minCut ) { }
-  bool operator()( const typename F::type & t ) const {
-    return f( t ) >= minCut_;
-  }
+  explicit FunctionMinSelector(double minCut) : minCut_(minCut) {}
+  bool operator()(const typename F::type& t) const { return f(t) >= minCut_; }
+
 private:
   F f;
   double minCut_;

--- a/CommonTools/Utils/interface/MasslessInvariantMass.h
+++ b/CommonTools/Utils/interface/MasslessInvariantMass.h
@@ -4,11 +4,11 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 
 struct MasslessInvariantMass {
-  template<typename T1, typename T2>
-  double operator()( const T1 & t1, const T2 & t2 ) const {
+  template <typename T1, typename T2>
+  double operator()(const T1& t1, const T2& t2) const {
     math::XYZVector p1 = t1.momentum(), p2 = t2.momentum();
-    math::XYZTLorentzVector v1( p1.x(), p1.y(), p1.z(), p1.r() ), v2( p2.x(), p2.y(), p2.z(), p2.r() );
-    return ( v1 + v2 ).mass();
+    math::XYZTLorentzVector v1(p1.x(), p1.y(), p1.z(), p1.r()), v2(p2.x(), p2.y(), p2.z(), p2.r());
+    return (v1 + v2).mass();
   }
 };
 

--- a/CommonTools/Utils/interface/MaxFunctionSelector.h
+++ b/CommonTools/Utils/interface/MaxFunctionSelector.h
@@ -7,11 +7,10 @@
  * $Id: MaxFunctionSelector.h,v 1.1 2009/02/24 14:40:26 llista Exp $
  */
 
-template<typename T, double (T::*fun)() const>
+template <typename T, double (T::*fun)() const>
 struct MaxFunctionSelector {
-  MaxFunctionSelector( double max ) : 
-    max_( max ) { }
-  bool operator()( const T & t ) const { return (t.*fun)() <= max_; }
+  MaxFunctionSelector(double max) : max_(max) {}
+  bool operator()(const T& t) const { return (t.*fun)() <= max_; }
 
 private:
   double max_;

--- a/CommonTools/Utils/interface/MaxNumberSelector.h
+++ b/CommonTools/Utils/interface/MaxNumberSelector.h
@@ -8,8 +8,7 @@
  */
 
 struct MaxNumberSelector {
-  MaxNumberSelector(unsigned int maxNumber) : 
-    maxNumber_(maxNumber) { }
+  MaxNumberSelector(unsigned int maxNumber) : maxNumber_(maxNumber) {}
   bool operator()(unsigned int number) const { return number <= maxNumber_; }
 
 private:

--- a/CommonTools/Utils/interface/MaxObjectPairSelector.h
+++ b/CommonTools/Utils/interface/MaxObjectPairSelector.h
@@ -7,13 +7,12 @@
  * $Id: MaxObjectPairSelector.h,v 1.3 2007/06/18 18:33:53 llista Exp $
  */
 
-template<typename F>
+template <typename F>
 struct MaxObjectPairSelector {
-  MaxObjectPairSelector( double max ) : 
-    max_( max ), fun_() { }
-  template<typename T1, typename T2>
-  bool operator()( const T1 & t1, const T2 & t2 ) const { 
-    return fun_( t1, t2 ) <= max_;
+  MaxObjectPairSelector(double max) : max_(max), fun_() {}
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
+    return fun_(t1, t2) <= max_;
   }
 
 private:

--- a/CommonTools/Utils/interface/MaxSelector.h
+++ b/CommonTools/Utils/interface/MaxSelector.h
@@ -7,10 +7,10 @@
  * $Id: MaxSelector.h,v 1.1 2009/02/24 14:40:26 llista Exp $
  */
 
-template<typename T>
+template <typename T>
 struct MaxSelector {
-  MaxSelector( T max ) : max_( max ) { }
-  bool operator()( T t ) const { return t <= max_; }
+  MaxSelector(T max) : max_(max) {}
+  bool operator()(T t) const { return t <= max_; }
 
 private:
   T max_;

--- a/CommonTools/Utils/interface/MinFunctionSelector.h
+++ b/CommonTools/Utils/interface/MinFunctionSelector.h
@@ -7,11 +7,11 @@
  * $Id: MinFunctionSelector.h,v 1.1 2009/02/24 14:40:26 llista Exp $
  */
 
-template<typename T, double (T::*fun)() const>
+template <typename T, double (T::*fun)() const>
 struct MinFunctionSelector {
-  MinFunctionSelector( double min ) : 
-    min_( min ) { }
-  bool operator()( const T & t ) const { return (t.*fun)() >= min_; }
+  MinFunctionSelector(double min) : min_(min) {}
+  bool operator()(const T& t) const { return (t.*fun)() >= min_; }
+
 private:
   double min_;
 };

--- a/CommonTools/Utils/interface/MinNumberSelector.h
+++ b/CommonTools/Utils/interface/MinNumberSelector.h
@@ -8,8 +8,7 @@
  */
 
 struct MinNumberSelector {
-  MinNumberSelector(unsigned int minNumber) : 
-    minNumber_(minNumber) { }
+  MinNumberSelector(unsigned int minNumber) : minNumber_(minNumber) {}
   bool operator()(unsigned int number) const { return number >= minNumber_; }
 
 private:

--- a/CommonTools/Utils/interface/MinObjectPairSelector.h
+++ b/CommonTools/Utils/interface/MinObjectPairSelector.h
@@ -7,13 +7,12 @@
  * $Id: MinObjectPairSelector.h,v 1.3 2007/06/18 18:33:54 llista Exp $
  */
 
-template<typename F>
+template <typename F>
 struct MinObjectPairSelector {
-  MinObjectPairSelector( double min ) : 
-    min_( min ), fun_() { }
-  template<typename T1, typename T2>
-  bool operator()( const T1 & t1, const T2 & t2 ) const { 
-    return min_ <= fun_( t1, t2 ); 
+  MinObjectPairSelector(double min) : min_(min), fun_() {}
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
+    return min_ <= fun_(t1, t2);
   }
 
 private:

--- a/CommonTools/Utils/interface/NonNullNumberSelector.h
+++ b/CommonTools/Utils/interface/NonNullNumberSelector.h
@@ -8,8 +8,8 @@
  */
 
 struct NonNullNumberSelector {
-  NonNullNumberSelector() { }
-  bool operator()( unsigned int number ) const { return number > 0; }
+  NonNullNumberSelector() {}
+  bool operator()(unsigned int number) const { return number > 0; }
 };
 
 #endif

--- a/CommonTools/Utils/interface/OrSelector.h
+++ b/CommonTools/Utils/interface/OrSelector.h
@@ -13,20 +13,24 @@ namespace helpers {
 
 namespace reco {
   namespace modules {
-    template<typename T1, typename T2, typename T3, typename T4, typename T5> struct CombinedEventSetupInit;
+    template <typename T1, typename T2, typename T3, typename T4, typename T5>
+    struct CombinedEventSetupInit;
   }
-}
+}  // namespace reco
 
-template<typename S1, typename S2, 
-	 typename S3 = helpers::NullOrOperand, typename S4 = helpers::NullOrOperand,
-	 typename S5 = helpers::NullOrOperand>
+template <typename S1,
+          typename S2,
+          typename S3 = helpers::NullOrOperand,
+          typename S4 = helpers::NullOrOperand,
+          typename S5 = helpers::NullOrOperand>
 struct OrSelector {
-  OrSelector( const S1 & s1, const S2 & s2, const S3 & s3, const S4 & s4, const S5 & s5 ) :
-    s1_( s1 ), s2_( s2 ), s3_( s3 ), s4_( s4 ), s5_( s5 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) || s2_( t ) || s3_( t ) || s4_( t ) || s5_( t );
+  OrSelector(const S1& s1, const S2& s2, const S3& s3, const S4& s4, const S5& s5)
+      : s1_(s1), s2_(s2), s3_(s3), s4_(s4), s5_(s5) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) || s2_(t) || s3_(t) || s4_(t) || s5_(t);
   }
+
 private:
   friend class reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, S5>;
   S1 s1_;
@@ -36,30 +40,30 @@ private:
   S5 s5_;
 };
 
-
-template<typename S1, typename S2>
+template <typename S1, typename S2>
 struct OrSelector<S1, S2, helpers::NullOrOperand, helpers::NullOrOperand, helpers::NullOrOperand> {
-  OrSelector( const S1 & s1, const S2 & s2 ) :
-    s1_( s1 ), s2_( s2 ) { }
+  OrSelector(const S1& s1, const S2& s2) : s1_(s1), s2_(s2) {}
 
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) || s2_( t );
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) || s2_(t);
   }
+
 private:
-  friend class reco::modules::CombinedEventSetupInit<S1, S2, helpers::NullOrOperand, helpers::NullOrOperand, helpers::NullOrOperand>;
+  friend class reco::modules::
+      CombinedEventSetupInit<S1, S2, helpers::NullOrOperand, helpers::NullOrOperand, helpers::NullOrOperand>;
   S1 s1_;
   S2 s2_;
 };
 
-template<typename S1, typename S2, typename S3>
+template <typename S1, typename S2, typename S3>
 struct OrSelector<S1, S2, S3, helpers::NullOrOperand, helpers::NullOrOperand> {
-  OrSelector( const S1 & s1, const S2 & s2, const S3 & s3 ) :
-    s1_( s1 ), s2_( s2 ), s3_( s3 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) || s2_( t ) || s3_( t );
+  OrSelector(const S1& s1, const S2& s2, const S3& s3) : s1_(s1), s2_(s2), s3_(s3) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) || s2_(t) || s3_(t);
   }
+
 private:
   friend class reco::modules::CombinedEventSetupInit<S1, S2, S3, helpers::NullOrOperand, helpers::NullOrOperand>;
   S1 s1_;
@@ -67,14 +71,14 @@ private:
   S3 s3_;
 };
 
-template<typename S1, typename S2, typename S3, typename S4>
+template <typename S1, typename S2, typename S3, typename S4>
 struct OrSelector<S1, S2, S3, S4, helpers::NullOrOperand> {
-  OrSelector( const S1 & s1, const S2 & s2, const S3 & s3, const S4 & s4 ) :
-    s1_( s1 ), s2_( s2 ), s3_( s3 ), s4_( s4 ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return s1_( t ) || s2_( t ) || s3_( t ) || s4_( t );
+  OrSelector(const S1& s1, const S2& s2, const S3& s3, const S4& s4) : s1_(s1), s2_(s2), s3_(s3), s4_(s4) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return s1_(t) || s2_(t) || s3_(t) || s4_(t);
   }
+
 private:
   friend class reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, helpers::NullOrOperand>;
   S1 s1_;

--- a/CommonTools/Utils/interface/PairSelector.h
+++ b/CommonTools/Utils/interface/PairSelector.h
@@ -7,13 +7,14 @@
  * $Id: PairSelector.h,v 1.1 2009/02/24 14:40:26 llista Exp $
  */
 
-template<typename S1, typename S2>
+template <typename S1, typename S2>
 struct PairSelector {
-  PairSelector(const S1 & s1, const S2 & s2) : s1_(s1), s2_(s2) { }
-  template<typename T>
-  bool operator()(const T & t) const {
+  PairSelector(const S1& s1, const S2& s2) : s1_(s1), s2_(s2) {}
+  template <typename T>
+  bool operator()(const T& t) const {
     return s1_(t.first) && s2_(t.second);
   }
+
 private:
   S1 s1_;
   S2 s2_;

--- a/CommonTools/Utils/interface/PdgIdExcluder.h
+++ b/CommonTools/Utils/interface/PdgIdExcluder.h
@@ -10,17 +10,18 @@
 #include <algorithm>
 
 struct PdgIdExcluder {
-  explicit PdgIdExcluder( const std::vector<int> & pdgId ) {
+  explicit PdgIdExcluder(const std::vector<int>& pdgId) {
     pdgId_.reserve(pdgId.size());
-    for( int i : pdgId) {
-      pdgId_.push_back( abs( i ) );
+    for (int i : pdgId) {
+      pdgId_.push_back(abs(i));
     }
   }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return std::find( pdgId_.begin(), pdgId_.end(), abs( t.pdgId() ) ) == pdgId_.end();
+  template <typename T>
+  bool operator()(const T& t) const {
+    return std::find(pdgId_.begin(), pdgId_.end(), abs(t.pdgId())) == pdgId_.end();
   }
-  private:
+
+private:
   std::vector<int> pdgId_;
 };
 

--- a/CommonTools/Utils/interface/PdgIdSelector.h
+++ b/CommonTools/Utils/interface/PdgIdSelector.h
@@ -10,21 +10,22 @@
 #include <algorithm>
 
 struct PdgIdSelector {
-  PdgIdSelector( const std::vector<int> & pdgId ) { 
-    for( std::vector<int>::const_iterator i = pdgId.begin(); i != pdgId.end(); ++ i )
-      pdgId_.push_back( abs( * i ) );
-     begin_ = pdgId_.begin();
-     end_ = pdgId_.end();
+  PdgIdSelector(const std::vector<int>& pdgId) {
+    for (std::vector<int>::const_iterator i = pdgId.begin(); i != pdgId.end(); ++i)
+      pdgId_.push_back(abs(*i));
+    begin_ = pdgId_.begin();
+    end_ = pdgId_.end();
   }
-  PdgIdSelector( const PdgIdSelector & o ) :
-    pdgId_( o.pdgId_ ), begin_( pdgId_.begin() ), end_( pdgId_.end() ) { }
-  PdgIdSelector & operator==( const PdgIdSelector & o ) {
-    * this = o; return * this;
+  PdgIdSelector(const PdgIdSelector& o) : pdgId_(o.pdgId_), begin_(pdgId_.begin()), end_(pdgId_.end()) {}
+  PdgIdSelector& operator==(const PdgIdSelector& o) {
+    *this = o;
+    return *this;
   }
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return std::find( begin_, end_, abs( t.pdgId() ) ) != end_;
+  template <typename T>
+  bool operator()(const T& t) const {
+    return std::find(begin_, end_, abs(t.pdgId())) != end_;
   }
+
 private:
   std::vector<int> pdgId_;
   std::vector<int>::const_iterator begin_, end_;

--- a/CommonTools/Utils/interface/PointerComparator.h
+++ b/CommonTools/Utils/interface/PointerComparator.h
@@ -13,18 +13,16 @@
  */
 #include "FWCore/Utilities/interface/EDMException.h"
 
-template<typename C>
+template <typename C>
 struct PointerComparator {
   typedef typename C::first_argument_type first_argument_type;
   typedef typename C::second_argument_type second_argument_type;
-    bool operator()( const first_argument_type * t1, const second_argument_type * t2 ) const {
-      if ( t1 == 0 || t2 == 0 )
-        throw edm::Exception( edm::errors::NullPointerError )
-           << "PointerComparator: passed null pointer."; 
-      return cmp( *t1, *t2 );
-    }
+  bool operator()(const first_argument_type* t1, const second_argument_type* t2) const {
+    if (t1 == 0 || t2 == 0)
+      throw edm::Exception(edm::errors::NullPointerError) << "PointerComparator: passed null pointer.";
+    return cmp(*t1, *t2);
+  }
   C cmp;
 };
-
 
 #endif

--- a/CommonTools/Utils/interface/PtComparator.h
+++ b/CommonTools/Utils/interface/PtComparator.h
@@ -13,25 +13,21 @@
  *
  */
 
-template<typename T>
+template <typename T>
 struct LessByPt {
   typedef T first_argument_type;
   typedef T second_argument_type;
-  bool operator()( const T & t1, const T & t2 ) const {
-    return t1.pt() < t2.pt();
-  }
+  bool operator()(const T& t1, const T& t2) const { return t1.pt() < t2.pt(); }
 };
 
-template<typename T>
+template <typename T>
 struct GreaterByPt {
   typedef T first_argument_type;
   typedef T second_argument_type;
-  bool operator()( const T & t1, const T & t2 ) const {
-    return t1.pt() > t2.pt();
-  }
+  bool operator()(const T& t1, const T& t2) const { return t1.pt() > t2.pt(); }
 };
 
-#include<limits>
+#include <limits>
 #include <cmath>
 
 template <class T>
@@ -39,10 +35,10 @@ struct NumericSafeLessByPt {
   typedef T first_argument_type;
   typedef T second_argument_type;
   bool operator()(const T& a1, const T& a2) {
-    return
-      fabs (a1.pt()-a2.pt()) > std::numeric_limits<double>::epsilon() ? a1.pt() < a2.pt() :
-      fabs (a1.px()-a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() < a2.px() :
-      a1.pz() < a2.pz();
+    return fabs(a1.pt() - a2.pt()) > std::numeric_limits<double>::epsilon()
+               ? a1.pt() < a2.pt()
+               : fabs(a1.px() - a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() < a2.px()
+                                                                                  : a1.pz() < a2.pz();
   }
 };
 
@@ -51,10 +47,10 @@ struct NumericSafeGreaterByPt {
   typedef T first_argument_type;
   typedef T second_argument_type;
   bool operator()(const T& a1, const T& a2) {
-    return
-      fabs (a1.pt()-a2.pt()) > std::numeric_limits<double>::epsilon() ? a1.pt() > a2.pt() :
-      fabs (a1.px()-a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() > a2.px() :
-      a1.pz() > a2.pz();
+    return fabs(a1.pt() - a2.pt()) > std::numeric_limits<double>::epsilon()
+               ? a1.pt() > a2.pt()
+               : fabs(a1.px() - a2.px()) > std::numeric_limits<double>::epsilon() ? a1.px() > a2.px()
+                                                                                  : a1.pz() > a2.pz();
   }
 };
 

--- a/CommonTools/Utils/interface/PtMinSelector.h
+++ b/CommonTools/Utils/interface/PtMinSelector.h
@@ -8,9 +8,11 @@
  */
 
 struct PtMinSelector {
-  PtMinSelector( double ptMin ) : ptMin_( ptMin ) { }
-  template<typename T>
-  bool operator()( const T & t ) const { return t.pt() >= ptMin_; }
+  PtMinSelector(double ptMin) : ptMin_(ptMin) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return t.pt() >= ptMin_;
+  }
 
 private:
   double ptMin_;

--- a/CommonTools/Utils/interface/RangeObjectPairSelector.h
+++ b/CommonTools/Utils/interface/RangeObjectPairSelector.h
@@ -7,17 +7,15 @@
  * $Id: RangeObjectPairSelector.h,v 1.4 2007/06/18 18:33:54 llista Exp $
  */
 
-template<typename F>
+template <typename F>
 struct RangeObjectPairSelector {
   typedef F function;
-  RangeObjectPairSelector( double min, double max, const F & fun ) : 
-    min_( min ), max_( max ), fun_( fun ) { }
-  RangeObjectPairSelector( double min, double max ) : 
-    min_( min ), max_( max ), fun_() { }
-  template<typename T1, typename T2>
-  bool operator()( const T1 & t1, const T2 & t2 ) const { 
-    double x = fun_( t1, t2 );
-    return ( min_ <= x && x <= max_ ); 
+  RangeObjectPairSelector(double min, double max, const F& fun) : min_(min), max_(max), fun_(fun) {}
+  RangeObjectPairSelector(double min, double max) : min_(min), max_(max), fun_() {}
+  template <typename T1, typename T2>
+  bool operator()(const T1& t1, const T2& t2) const {
+    double x = fun_(t1, t2);
+    return (min_ <= x && x <= max_);
   }
 
 private:

--- a/CommonTools/Utils/interface/RangeSelector.h
+++ b/CommonTools/Utils/interface/RangeSelector.h
@@ -8,14 +8,14 @@
  */
 #include <string>
 
-template<typename T, double (T::*fun)() const>
+template <typename T, double (T::*fun)() const>
 struct RangeSelector {
-  RangeSelector( double min, double max ) : 
-    min_( min ), max_( max ) { }
-  bool operator()( const T & t ) const { 
+  RangeSelector(double min, double max) : min_(min), max_(max) {}
+  bool operator()(const T& t) const {
     double x = (t.*fun)();
-    return min_ <= x && x <= max_; 
+    return min_ <= x && x <= max_;
   }
+
 private:
   double min_, max_;
 };

--- a/CommonTools/Utils/interface/RefSelector.h
+++ b/CommonTools/Utils/interface/RefSelector.h
@@ -1,13 +1,14 @@
 #ifndef CommonTools_Utils_RefSelector_h
 #define CommonTools_Utils_RefSelector_h
 
-template<typename S>
+template <typename S>
 struct RefSelector {
-  RefSelector( const S & sel ) : sel_( sel ) { }
-  template<typename Ref>
-  bool operator()( const Ref & ref ) const {
-    return sel_( * ref );
+  RefSelector(const S& sel) : sel_(sel) {}
+  template <typename Ref>
+  bool operator()(const Ref& ref) const {
+    return sel_(*ref);
   }
+
 private:
   S sel_;
 };

--- a/CommonTools/Utils/interface/Selection.h
+++ b/CommonTools/Utils/interface/Selection.h
@@ -2,54 +2,77 @@
 #define CommonTools_Utils_Selection_h
 #include <vector>
 
-template<typename C, 
-	 typename Selector,
-	 typename StoreContainer = std::vector<const typename C::value_type *> >
+template <typename C, typename Selector, typename StoreContainer = std::vector<const typename C::value_type*> >
 class Selection {
 public:
   typedef typename C::value_type value_type;
   typedef typename C::size_type size_type;
-  typedef value_type & reference;
-  typedef const value_type & const_reference;
-  Selection( const C & c, const Selector & sel ) :
-    select_( sel ) {
-    for( typename C::const_iterator i = c.begin(); i != c.end(); ++i ) {
-      if ( select_( *i ) ) selected_.push_back( & * i );
+  typedef value_type& reference;
+  typedef const value_type& const_reference;
+  Selection(const C& c, const Selector& sel) : select_(sel) {
+    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
+      if (select_(*i))
+        selected_.push_back(&*i);
     }
   }
   class const_iterator {
   public:
-    typedef typename Selection<C,Selector,StoreContainer>::value_type value_type;
-    typedef value_type * pointer;
-    typedef value_type & reference;
+    typedef typename Selection<C, Selector, StoreContainer>::value_type value_type;
+    typedef value_type* pointer;
+    typedef value_type& reference;
     typedef std::ptrdiff_t difference_type;
     typedef typename StoreContainer::const_iterator::iterator_category iterator_category;
-    const_iterator(const typename StoreContainer::const_iterator & it) : i(it) { }
-    const_iterator(const const_iterator & it) : i(it.i) { }
+    const_iterator(const typename StoreContainer::const_iterator& it) : i(it) {}
+    const_iterator(const const_iterator& it) : i(it.i) {}
     const_iterator() {}
-    const_iterator & operator=(const const_iterator & it) { i = it.i; return *this; }
-    const_iterator& operator++() { ++i; return *this; }
-    const_iterator operator++(int) { const_iterator ci = *this; ++i; return ci; }
-    const_iterator& operator--() { --i; return *this; }
-    const_iterator operator--(int) { const_iterator ci = *this; --i; return ci; }
-    difference_type operator-(const const_iterator & o) const { return i - o.i; }
+    const_iterator& operator=(const const_iterator& it) {
+      i = it.i;
+      return *this;
+    }
+    const_iterator& operator++() {
+      ++i;
+      return *this;
+    }
+    const_iterator operator++(int) {
+      const_iterator ci = *this;
+      ++i;
+      return ci;
+    }
+    const_iterator& operator--() {
+      --i;
+      return *this;
+    }
+    const_iterator operator--(int) {
+      const_iterator ci = *this;
+      --i;
+      return ci;
+    }
+    difference_type operator-(const const_iterator& o) const { return i - o.i; }
     const_iterator operator+(difference_type n) const { return const_iterator(i + n); }
     const_iterator operator-(difference_type n) const { return const_iterator(i - n); }
-    bool operator<(const const_iterator & o) const { return i < o.i; }
+    bool operator<(const const_iterator& o) const { return i < o.i; }
     bool operator==(const const_iterator& ci) const { return i == ci.i; }
     bool operator!=(const const_iterator& ci) const { return i != ci.i; }
-    const value_type & operator *() const { return **i; }
-    const value_type * operator->() const { return & (operator*()); }
-    const_iterator & operator +=(difference_type d) { i += d; return *this; }
-    const_iterator & operator -=(difference_type d) { i -= d; return *this; }
+    const value_type& operator*() const { return **i; }
+    const value_type* operator->() const { return &(operator*()); }
+    const_iterator& operator+=(difference_type d) {
+      i += d;
+      return *this;
+    }
+    const_iterator& operator-=(difference_type d) {
+      i -= d;
+      return *this;
+    }
+
   private:
     typename StoreContainer::const_iterator i;
   };
-  const_iterator begin() const { return const_iterator( selected_.begin() ); }
-  const_iterator end() const { return const_iterator( selected_.end() ); }
+  const_iterator begin() const { return const_iterator(selected_.begin()); }
+  const_iterator end() const { return const_iterator(selected_.end()); }
   size_type size() const { return selected_.size(); }
   bool empty() const { return selected_.empty(); }
-  const_reference operator[]( size_type i ) { return * selected_[i]; }
+  const_reference operator[](size_type i) { return *selected_[i]; }
+
 private:
   Selector select_;
   StoreContainer selected_;

--- a/CommonTools/Utils/interface/StatusSelector.h
+++ b/CommonTools/Utils/interface/StatusSelector.h
@@ -10,21 +10,22 @@
 #include <algorithm>
 
 struct StatusSelector {
-  StatusSelector( const std::vector<int> & status ) { 
-    for( std::vector<int>::const_iterator i = status.begin(); i != status.end(); ++ i )
-      status_.push_back( * i );
+  StatusSelector(const std::vector<int>& status) {
+    for (std::vector<int>::const_iterator i = status.begin(); i != status.end(); ++i)
+      status_.push_back(*i);
     begin_ = status_.begin();
     end_ = status_.end();
   }
-  StatusSelector( const StatusSelector & o ) :
-    status_( o.status_ ), begin_( status_.begin() ), end_( status_.end() ) { }
-  StatusSelector & operator==( const StatusSelector & o ) {
-    * this = o; return * this;
-  } 
-  template<typename T>
-  bool operator()( const T & t ) const { 
-    return std::find( begin_, end_, t.status() ) != end_;
+  StatusSelector(const StatusSelector& o) : status_(o.status_), begin_(status_.begin()), end_(status_.end()) {}
+  StatusSelector& operator==(const StatusSelector& o) {
+    *this = o;
+    return *this;
   }
+  template <typename T>
+  bool operator()(const T& t) const {
+    return std::find(begin_, end_, t.status()) != end_;
+  }
+
 private:
   std::vector<int> status_;
   std::vector<int>::const_iterator begin_, end_;

--- a/CommonTools/Utils/interface/StringCutObjectSelector.h
+++ b/CommonTools/Utils/interface/StringCutObjectSelector.h
@@ -12,22 +12,17 @@
 #include "CommonTools/Utils/interface/cutParser.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 
-template<typename T, bool DefaultLazyness=false>
+template <typename T, bool DefaultLazyness = false>
 struct StringCutObjectSelector {
-  StringCutObjectSelector(const std::string & cut, bool lazy=DefaultLazyness) : 
-    type_(typeid(T)) {
-    if(! reco::parser::cutParser<T>(cut, select_, lazy)) {
-      throw edm::Exception(edm::errors::Configuration,
-			   "failed to parse \"" + cut + "\"");
+  StringCutObjectSelector(const std::string &cut, bool lazy = DefaultLazyness) : type_(typeid(T)) {
+    if (!reco::parser::cutParser<T>(cut, select_, lazy)) {
+      throw edm::Exception(edm::errors::Configuration, "failed to parse \"" + cut + "\"");
     }
   }
-  StringCutObjectSelector(const reco::parser::SelectorPtr & select) : 
-    select_(select),
-    type_(typeid(T)) {
-  }
-  bool operator()(const T & t) const {
-    edm::ObjectWithDict o(type_, const_cast<T *>(& t));
-    return (*select_)(o);  
+  StringCutObjectSelector(const reco::parser::SelectorPtr &select) : select_(select), type_(typeid(T)) {}
+  bool operator()(const T &t) const {
+    edm::ObjectWithDict o(type_, const_cast<T *>(&t));
+    return (*select_)(o);
   }
 
 private:

--- a/CommonTools/Utils/interface/StringObjectFunction.h
+++ b/CommonTools/Utils/interface/StringObjectFunction.h
@@ -12,22 +12,17 @@
 #include "CommonTools/Utils/interface/expressionParser.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 
-template<typename T, bool DefaultLazyness=false>
+template <typename T, bool DefaultLazyness = false>
 struct StringObjectFunction {
-  StringObjectFunction(const std::string & expr, bool lazy=DefaultLazyness) : 
-    type_(typeid(T)) {
-    if(! reco::parser::expressionParser<T>(expr, expr_, lazy)) {
-      throw edm::Exception(edm::errors::Configuration,
-			   "failed to parse \"" + expr + "\"");
+  StringObjectFunction(const std::string &expr, bool lazy = DefaultLazyness) : type_(typeid(T)) {
+    if (!reco::parser::expressionParser<T>(expr, expr_, lazy)) {
+      throw edm::Exception(edm::errors::Configuration, "failed to parse \"" + expr + "\"");
     }
   }
-  StringObjectFunction(const reco::parser::ExpressionPtr & expr) : 
-    expr_(expr),
-    type_(typeid(T)) {
-  }
-  double operator()(const T & t) const {
-    edm::ObjectWithDict o(type_, const_cast<T *>(& t));
-    return expr_->value(o);  
+  StringObjectFunction(const reco::parser::ExpressionPtr &expr) : expr_(expr), type_(typeid(T)) {}
+  double operator()(const T &t) const {
+    edm::ObjectWithDict o(type_, const_cast<T *>(&t));
+    return expr_->value(o);
   }
 
 private:
@@ -35,16 +30,16 @@ private:
   edm::TypeWithDict type_;
 };
 
-template <typename Object> class sortByStringFunction  {
- public:
-  sortByStringFunction(StringObjectFunction<Object> * f) : f_(f){}
-  ~sortByStringFunction(){}
+template <typename Object>
+class sortByStringFunction {
+public:
+  sortByStringFunction(StringObjectFunction<Object> *f) : f_(f) {}
+  ~sortByStringFunction() {}
 
-  bool operator() (const Object * o1, const Object * o2) {
-    return (*f_)(*o1) > (*f_)(*o2);
-  }
- private:
-  StringObjectFunction<Object> * f_;
+  bool operator()(const Object *o1, const Object *o2) { return (*f_)(*o1) > (*f_)(*o2); }
+
+private:
+  StringObjectFunction<Object> *f_;
 };
 
 #endif

--- a/CommonTools/Utils/interface/StringToEnumValue.h
+++ b/CommonTools/Utils/interface/StringToEnumValue.h
@@ -1,7 +1,6 @@
 #ifndef _CommonTools_Utils_StringToEnumValue_h_
 #define _CommonTools_Utils_StringToEnumValue_h_
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 #include "TEnum.h"
 #include "TEnumConstant.h"
@@ -9,7 +8,6 @@
 #include <string>
 #include <sstream>
 #include <vector>
-
 
 /**
 
@@ -24,17 +22,16 @@
 */
 
 template <typename MyEnum>
-int StringToEnumValue(std::string const& enumConstName){
-   TEnum* en = TEnum::GetEnum(typeid(MyEnum));
-   if (en != nullptr){
-      if (TEnumConstant const* enc = en->GetConstant(enumConstName.c_str())){
-         return enc->GetValue();
-      }
-   }
-   assert(0);
-   return -1;
+int StringToEnumValue(std::string const& enumConstName) {
+  TEnum* en = TEnum::GetEnum(typeid(MyEnum));
+  if (en != nullptr) {
+    if (TEnumConstant const* enc = en->GetConstant(enumConstName.c_str())) {
+      return enc->GetValue();
+    }
+  }
+  assert(0);
+  return -1;
 }
-
 
 /**
 
@@ -56,20 +53,18 @@ int StringToEnumValue(std::string const& enumConstName){
 
 */
 
-
-template <class MyType> 
-std::vector<int> StringToEnumValue(const std::vector<std::string> & enumNames){
-  
-  using std::vector;
+template <class MyType>
+std::vector<int> StringToEnumValue(const std::vector<std::string>& enumNames) {
   using std::string;
+  using std::vector;
 
   vector<int> ret;
-  vector<string>::const_iterator str=enumNames.begin();
-  for (;str!=enumNames.end();++str){
-    ret.push_back( StringToEnumValue<MyType>(*str));
+  vector<string>::const_iterator str = enumNames.begin();
+  for (; str != enumNames.end(); ++str) {
+    ret.push_back(StringToEnumValue<MyType>(*str));
   }
   return ret;
 
-} // 
+}  //
 
 #endif

--- a/CommonTools/Utils/interface/TFileDirectory.h
+++ b/CommonTools/Utils/interface/TFileDirectory.h
@@ -14,85 +14,76 @@
 #include "TH1.h"
 
 namespace fwlite {
-   class TFileService;
+  class TFileService;
 }
 
 class TFileService;
 class TFile;
-class TDirectory; 
+class TDirectory;
 
 class TFileDirectory {
-   public:
+public:
+  TFileDirectory() : file_(nullptr), dir_(), descr_(), path_() {}
 
-      TFileDirectory() : file_(nullptr), dir_(), descr_(), path_() {
-      }
+  /// descructor
+  virtual ~TFileDirectory() {}
 
-      /// descructor
-      virtual ~TFileDirectory() { }
+  // cd()s to requested directory and returns true (if it is not
+  // able to cd, it throws exception).
+  bool cd() const;
 
-      // cd()s to requested directory and returns true (if it is not
-      // able to cd, it throws exception).
-      bool cd () const;
+  // returns a TDirectory pointer
+  TDirectory *getBareDirectory(const std::string &subdir = "") const;
 
-      // returns a TDirectory pointer
-      TDirectory *getBareDirectory (const std::string &subdir = "") const;
-      
-      // reutrns a "T" pointer matched to objname
-      template< typename T > T* getObject (const std::string &objname,
-                                           const std::string &subdir = "")
-      {
-         TObject *objPtr = _getObj (objname, subdir);
-         // Ok, we've got it.  Let's see if it's a histogram
-         T * retval = dynamic_cast< T* > ( objPtr );
-         if ( ! retval )
-         {
-            // object isn't a of class T
-            throw
-               cms::Exception ("ObjectNotCorrectlyTyped")
-               << "Object named " << objname << " is not of correct type";
-         }
-         return retval;
-      }
+  // reutrns a "T" pointer matched to objname
+  template <typename T>
+  T *getObject(const std::string &objname, const std::string &subdir = "") {
+    TObject *objPtr = _getObj(objname, subdir);
+    // Ok, we've got it.  Let's see if it's a histogram
+    T *retval = dynamic_cast<T *>(objPtr);
+    if (!retval) {
+      // object isn't a of class T
+      throw cms::Exception("ObjectNotCorrectlyTyped") << "Object named " << objname << " is not of correct type";
+    }
+    return retval;
+  }
 
-      /// make new ROOT object
-      template<typename T, typename ... Args>
-      T* make(const Args& ... args) const {
-         TDirectory *d = _cd();
-         T* t = new T(args ...);
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
+  /// make new ROOT object
+  template <typename T, typename... Args>
+  T *make(const Args &... args) const {
+    TDirectory *d = _cd();
+    T *t = new T(args...);
+    ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
+    if (func) {
+      TH1AddDirectorySentry sentry;
+      func(t, d);
+    } else {
+      d->Append(t);
+    }
+    return t;
+  }
 
-      /// create a new subdirectory
-      TFileDirectory mkdir( const std::string & dir, const std::string & descr = "" );
-      /// return the full path of the stored histograms
-      std::string fullPath() const;
+  /// create a new subdirectory
+  TFileDirectory mkdir(const std::string &dir, const std::string &descr = "");
+  /// return the full path of the stored histograms
+  std::string fullPath() const;
 
-   private:
-      
-      TObject* _getObj (const std::string &objname, 
-                        const std::string &subdir = "") const;
+private:
+  TObject *_getObj(const std::string &objname, const std::string &subdir = "") const;
 
-      TDirectory* _cd (const std::string &subdir = "",
-                       bool createNeededDirectories = true) const;
+  TDirectory *_cd(const std::string &subdir = "", bool createNeededDirectories = true) const;
 
-      // it's completely insane that this needs to be const since
-      // 'mkdir' clearly changes things, but that's the way the cookie
-      // crumbles...
-      TDirectory* _mkdir (TDirectory *dirPtr,
-                          const std::string &dir, 
-                          const std::string &description) const;
+  // it's completely insane that this needs to be const since
+  // 'mkdir' clearly changes things, but that's the way the cookie
+  // crumbles...
+  TDirectory *_mkdir(TDirectory *dirPtr, const std::string &dir, const std::string &description) const;
 
-      TFileDirectory( const std::string & dir, const std::string & descr,
-                      TFile * file, const std::string & path ) : 
-         file_( file ), dir_( dir ), descr_( descr ), path_( path ) {
-      }
-      friend class TFileService;
-      friend class fwlite::TFileService;
-      TFile * file_;
-      std::string dir_, descr_, path_;
+  TFileDirectory(const std::string &dir, const std::string &descr, TFile *file, const std::string &path)
+      : file_(file), dir_(dir), descr_(descr), path_(path) {}
+  friend class TFileService;
+  friend class fwlite::TFileService;
+  TFile *file_;
+  std::string dir_, descr_, path_;
 };
 
 #endif

--- a/CommonTools/Utils/interface/TH1AddDirectorySentry.h
+++ b/CommonTools/Utils/interface/TH1AddDirectorySentry.h
@@ -4,7 +4,7 @@
 //
 // Package:     UtilAlgos
 // Class  :     TH1AddDirectorySentry
-// 
+//
 /**\class TH1AddDirectorySentry TH1AddDirectorySentry.h CommonTools/UtilAlgos/interface/TH1AddDirectorySentry.h
 
  Description: Manages the status of the ROOT directory
@@ -21,19 +21,15 @@
 // $Id: TH1AddDirectorySentry.h,v 1.1 2009/03/03 13:07:28 llista Exp $
 //
 
-class TH1AddDirectorySentry
-{
+class TH1AddDirectorySentry {
+public:
+  TH1AddDirectorySentry();
+  ~TH1AddDirectorySentry();
 
-   public:
-      TH1AddDirectorySentry();
-      ~TH1AddDirectorySentry();
-
-
-   private:
-      TH1AddDirectorySentry(const TH1AddDirectorySentry&) = delete;
-      TH1AddDirectorySentry& operator=(const TH1AddDirectorySentry&) = delete;
-      bool status_;
+private:
+  TH1AddDirectorySentry(const TH1AddDirectorySentry&) = delete;
+  TH1AddDirectorySentry& operator=(const TH1AddDirectorySentry&) = delete;
+  bool status_;
 };
-
 
 #endif

--- a/CommonTools/Utils/interface/cutParser.h
+++ b/CommonTools/Utils/interface/cutParser.h
@@ -7,13 +7,13 @@
 
 namespace reco {
   namespace parser {
-    bool cutParser(const edm::TypeWithDict &t, const std::string & cut, SelectorPtr & sel, bool lazy) ;
+    bool cutParser(const edm::TypeWithDict &t, const std::string &cut, SelectorPtr &sel, bool lazy);
 
-    template<typename T>
-    inline bool cutParser(const std::string & cut, SelectorPtr & sel, bool lazy=false) {
-        return reco::parser::cutParser(edm::TypeWithDict(typeid(T)), cut, sel, lazy);
+    template <typename T>
+    inline bool cutParser(const std::string &cut, SelectorPtr &sel, bool lazy = false) {
+      return reco::parser::cutParser(edm::TypeWithDict(typeid(T)), cut, sel, lazy);
     }
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/interface/expressionParser.h
+++ b/CommonTools/Utils/interface/expressionParser.h
@@ -7,14 +7,14 @@
 
 namespace reco {
   namespace parser {
-  bool expressionParser(const edm::TypeWithDict &t, const std::string & value, ExpressionPtr & expr, bool lazy) ;
+    bool expressionParser(const edm::TypeWithDict &t, const std::string &value, ExpressionPtr &expr, bool lazy);
 
-  template<typename T>
-  bool expressionParser( const std::string & value, ExpressionPtr & expr, bool lazy=false) {
-    return reco::parser::expressionParser(edm::TypeWithDict(typeid(T)), value, expr, lazy);
-  }
+    template <typename T>
+    bool expressionParser(const std::string &value, ExpressionPtr &expr, bool lazy = false) {
+      return reco::parser::expressionParser(edm::TypeWithDict(typeid(T)), value, expr, lazy);
+    }
 
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/plugins/CPUSpender.cc
+++ b/CommonTools/Utils/plugins/CPUSpender.cc
@@ -4,31 +4,30 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-class CPUSpender: public edm::stream::EDAnalyzer<> {
-
- public:
+class CPUSpender : public edm::stream::EDAnalyzer<> {
+public:
   /// Constructor
-  CPUSpender(const edm::ParameterSet& pset) { timePerEvent_= pset.getUntrackedParameter<int>("secPerEvent");}
+  CPUSpender(const edm::ParameterSet& pset) { timePerEvent_ = pset.getUntrackedParameter<int>("secPerEvent"); }
 
   /// Destructor
   ~CPUSpender() override {}
 
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override {
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override {
     time_t s = time(nullptr);
-    while (time(nullptr)-s < timePerEvent_) { continue;}
+    while (time(nullptr) - s < timePerEvent_) {
+      continue;
+    }
   }
 
   // Operations
   void beginJob() {}
   void endJob() {}
-  
+
 protected:
   //  void printTrackRecHits(const reco::Track &, edm::ESHandle<GlobalTrackingGeometry>) const;
-  
- private:
+
+private:
   unsigned int timePerEvent_;
 };
 
-
 DEFINE_FWK_MODULE(CPUSpender);
-

--- a/CommonTools/Utils/src/Abort.cc
+++ b/CommonTools/Utils/src/Abort.cc
@@ -3,7 +3,6 @@
 
 using namespace reco::parser;
 
-void Abort::operator()( const char *, const char * ) const {
-  throw edm::Exception( edm::errors::Configuration,
-			std::string( "parse rule not implemented yet" ) );
+void Abort::operator()(const char *, const char *) const {
+  throw edm::Exception(edm::errors::Configuration, std::string("parse rule not implemented yet"));
 }

--- a/CommonTools/Utils/src/Abort.h
+++ b/CommonTools/Utils/src/Abort.h
@@ -14,9 +14,9 @@
 namespace reco {
   namespace parser {
     struct Abort {
-      void operator()( const char *, const char * ) const;
+      void operator()(const char *, const char *) const;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/AndCombiner.h
+++ b/CommonTools/Utils/src/AndCombiner.h
@@ -14,17 +14,15 @@
 #include "CommonTools/Utils/src/SelectorPtr.h"
 
 namespace reco {
-  namespace parser {    
-     struct AndCombiner : public SelectorBase {
-      AndCombiner(SelectorPtr lhs, SelectorPtr rhs) :
-	lhs_(lhs), rhs_(rhs) { }
-      bool operator()(const edm::ObjectWithDict& o) const override {
-	return (*lhs_)(o) && (*rhs_)(o);
-      }
+  namespace parser {
+    struct AndCombiner : public SelectorBase {
+      AndCombiner(SelectorPtr lhs, SelectorPtr rhs) : lhs_(lhs), rhs_(rhs) {}
+      bool operator()(const edm::ObjectWithDict& o) const override { return (*lhs_)(o) && (*rhs_)(o); }
+
     private:
       SelectorPtr lhs_, rhs_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/AnyMethodArgument.h
+++ b/CommonTools/Utils/src/AnyMethodArgument.h
@@ -23,95 +23,126 @@ namespace reco {
     // AnyMethodArgument variant
     template <typename T>
     struct matches_another_integral_type {
-        static bool const value = 
-            boost::is_same<T, int8_t>::value  || boost::is_same<T, uint8_t>::value  ||
-            boost::is_same<T, int16_t>::value || boost::is_same<T, uint16_t>::value ||
-            boost::is_same<T, int32_t>::value || boost::is_same<T, uint32_t>::value ||
-            boost::is_same<T, int64_t>::value || boost::is_same<T, uint64_t>::value;
+      static bool const value = boost::is_same<T, int8_t>::value || boost::is_same<T, uint8_t>::value ||
+                                boost::is_same<T, int16_t>::value || boost::is_same<T, uint16_t>::value ||
+                                boost::is_same<T, int32_t>::value || boost::is_same<T, uint32_t>::value ||
+                                boost::is_same<T, int64_t>::value || boost::is_same<T, uint64_t>::value;
     };
 
     // size_t on 32-bit Os X is type unsigned long, which doesn't match uint32_t,
     // so add unsigned long if it doesn't match any of the other integral types.
     // Use "unsigned long" rather than size_t as PtrVector has unsigned long as
     // size_type
-    typedef boost::mpl::if_<matches_another_integral_type<unsigned long>,
-        boost::variant<int8_t, uint8_t,
-                       int16_t, uint16_t,
-                       int32_t, uint32_t,
-                       int64_t, uint64_t,
-                       double,float,
-                       std::string>,
-        boost::variant<int8_t, uint8_t,
-                       int16_t, uint16_t,
-                       int32_t, uint32_t,
-                       int64_t, uint64_t,
+    typedef boost::mpl::if_<
+        matches_another_integral_type<unsigned long>,
+        boost::
+            variant<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, double, float, std::string>,
+        boost::variant<int8_t,
+                       uint8_t,
+                       int16_t,
+                       uint16_t,
+                       int32_t,
+                       uint32_t,
+                       int64_t,
+                       uint64_t,
                        unsigned long,
-                       double,float,
+                       double,
+                       float,
                        std::string> >::type AnyMethodArgument;
 
     class AnyMethodArgumentFixup : public boost::static_visitor<std::pair<AnyMethodArgument, int> > {
-        private:
-            edm::TypeWithDict dataType_;
-            template<typename From, typename To>
-            std::pair<AnyMethodArgument, int> retOk_(const From &f, int cast) const {
-                return std::pair<AnyMethodArgument,int>(AnyMethodArgument(static_cast<To>(f)), cast);
-            }
+    private:
+      edm::TypeWithDict dataType_;
+      template <typename From, typename To>
+      std::pair<AnyMethodArgument, int> retOk_(const From &f, int cast) const {
+        return std::pair<AnyMethodArgument, int>(AnyMethodArgument(static_cast<To>(f)), cast);
+      }
 
-            // correct return for each int output type
-            std::pair<AnyMethodArgument,int> doInt(int t) const {
-                if (dataType_ == typeid(int8_t))   { return retOk_<int,int8_t>  (t,0); }
-                if (dataType_ == typeid(uint8_t))  { return retOk_<int,uint8_t> (t,0); }
-                if (dataType_ == typeid(int16_t))  { return retOk_<int,int16_t> (t,0); }
-                if (dataType_ == typeid(uint16_t)) { return retOk_<int,uint16_t>(t,0); }
-                if (dataType_ == typeid(int32_t))  { return retOk_<int,int32_t> (t,0); }
-                if (dataType_ == typeid(uint32_t)) { return retOk_<int,uint32_t>(t,0); }
-                if (dataType_ == typeid(int64_t))  { return retOk_<int,int64_t> (t,0); }
-                if (dataType_ == typeid(uint64_t)) { return retOk_<int,uint64_t>(t,0); }
-                if (dataType_ == typeid(unsigned long)) { return retOk_<int,unsigned long>  (t,0); } // harmless if unsigned long matches another type
-                if (dataType_ == typeid(double))   { return retOk_<int,double>  (t,1); }
-                if (dataType_ == typeid(float))    { return retOk_<int,float>   (t,1); }
-                return std::pair<AnyMethodArgument,int>(t,-1);
-            }
-        public:
-            AnyMethodArgumentFixup(const edm::TypeWithDict& type) : 
-                dataType_(type)
-            {
-            }
+      // correct return for each int output type
+      std::pair<AnyMethodArgument, int> doInt(int t) const {
+        if (dataType_ == typeid(int8_t)) {
+          return retOk_<int, int8_t>(t, 0);
+        }
+        if (dataType_ == typeid(uint8_t)) {
+          return retOk_<int, uint8_t>(t, 0);
+        }
+        if (dataType_ == typeid(int16_t)) {
+          return retOk_<int, int16_t>(t, 0);
+        }
+        if (dataType_ == typeid(uint16_t)) {
+          return retOk_<int, uint16_t>(t, 0);
+        }
+        if (dataType_ == typeid(int32_t)) {
+          return retOk_<int, int32_t>(t, 0);
+        }
+        if (dataType_ == typeid(uint32_t)) {
+          return retOk_<int, uint32_t>(t, 0);
+        }
+        if (dataType_ == typeid(int64_t)) {
+          return retOk_<int, int64_t>(t, 0);
+        }
+        if (dataType_ == typeid(uint64_t)) {
+          return retOk_<int, uint64_t>(t, 0);
+        }
+        if (dataType_ == typeid(unsigned long)) {
+          return retOk_<int, unsigned long>(t, 0);
+        }  // harmless if unsigned long matches another type
+        if (dataType_ == typeid(double)) {
+          return retOk_<int, double>(t, 1);
+        }
+        if (dataType_ == typeid(float)) {
+          return retOk_<int, float>(t, 1);
+        }
+        return std::pair<AnyMethodArgument, int>(t, -1);
+      }
 
-            // we handle all integer types through 'int', as that's the way they are parsed by boost::spirit
-            template<typename I>
-            typename boost::enable_if<boost::is_integral<I>, std::pair<AnyMethodArgument,int> >::type
-            operator()(const I &t) const { return doInt(t); }
+    public:
+      AnyMethodArgumentFixup(const edm::TypeWithDict &type) : dataType_(type) {}
 
-            template<typename F>
-            typename boost::enable_if<boost::is_floating_point<F>, std::pair<AnyMethodArgument,int> >::type
-            operator()(const F &t) const { 
-                if (dataType_ == typeid(double)) { return retOk_<F,double>(t,0); }
-                if (dataType_ == typeid(float))  { return retOk_<F,float> (t,0); }
-                return std::pair<AnyMethodArgument,int>(t,-1);
-            }
+      // we handle all integer types through 'int', as that's the way they are parsed by boost::spirit
+      template <typename I>
+      typename boost::enable_if<boost::is_integral<I>, std::pair<AnyMethodArgument, int> >::type operator()(
+          const I &t) const {
+        return doInt(t);
+      }
 
-            std::pair<AnyMethodArgument,int> operator()(const std::string &t) const { 
-                if (dataType_.isEnum()) {
-                    if (dataType_.dataMemberSize() == 0) {
-                        throw parser::Exception(t.c_str()) << "Enumerator '" << dataType_.name() << "' has no keys.\nPerhaps the dictionary is missing?\n";
-                    }
-                    int ival = dataType_.stringToEnumValue(t);
-                    // std::cerr << "  value is = " << dataType_.stringToEnumValue(t) << std::endl;
-                    return std::pair<AnyMethodArgument,int>(ival,1);
-                }
-                if (dataType_ == typeid(std::string)) { return std::pair<AnyMethodArgument,int>(t,0); }
-                return std::pair<AnyMethodArgument,int>(t,-1);
-            }
+      template <typename F>
+      typename boost::enable_if<boost::is_floating_point<F>, std::pair<AnyMethodArgument, int> >::type operator()(
+          const F &t) const {
+        if (dataType_ == typeid(double)) {
+          return retOk_<F, double>(t, 0);
+        }
+        if (dataType_ == typeid(float)) {
+          return retOk_<F, float>(t, 0);
+        }
+        return std::pair<AnyMethodArgument, int>(t, -1);
+      }
 
+      std::pair<AnyMethodArgument, int> operator()(const std::string &t) const {
+        if (dataType_.isEnum()) {
+          if (dataType_.dataMemberSize() == 0) {
+            throw parser::Exception(t.c_str())
+                << "Enumerator '" << dataType_.name() << "' has no keys.\nPerhaps the dictionary is missing?\n";
+          }
+          int ival = dataType_.stringToEnumValue(t);
+          // std::cerr << "  value is = " << dataType_.stringToEnumValue(t) << std::endl;
+          return std::pair<AnyMethodArgument, int>(ival, 1);
+        }
+        if (dataType_ == typeid(std::string)) {
+          return std::pair<AnyMethodArgument, int>(t, 0);
+        }
+        return std::pair<AnyMethodArgument, int>(t, -1);
+      }
     };
-    
+
     class AnyMethodArgument2VoidPtr : public boost::static_visitor<void *> {
-        public:
-            template<typename T>
-            void * operator()(const T &t) const { return const_cast<void*>(static_cast<const void *>(&t)); }
+    public:
+      template <typename T>
+      void *operator()(const T &t) const {
+        return const_cast<void *>(static_cast<const void *>(&t));
+      }
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/AnyObjSelector.h
+++ b/CommonTools/Utils/src/AnyObjSelector.h
@@ -5,9 +5,9 @@
 namespace reco {
   namespace parser {
     class AnyObjSelector : public SelectorBase {
-      bool operator()(const edm::ObjectWithDict & c) const override { return true; }
+      bool operator()(const edm::ObjectWithDict& c) const override { return true; }
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/BinaryCutSetter.h
+++ b/CommonTools/Utils/src/BinaryCutSetter.h
@@ -14,21 +14,20 @@
 #include "CommonTools/Utils/src/LogicalBinaryOperator.h"
 
 namespace reco {
-  namespace parser {    
-    template<typename Op>
+  namespace parser {
+    template <typename Op>
     struct BinaryCutSetter {
-      BinaryCutSetter(SelectorStack & selStack) :
-	selStack_(selStack) { }
+      BinaryCutSetter(SelectorStack& selStack) : selStack_(selStack) {}
       void operator()(const char*, const char*) const {
-	selStack_.push_back(SelectorPtr(new LogicalBinaryOperator<Op>(selStack_)));
-      }     
+        selStack_.push_back(SelectorPtr(new LogicalBinaryOperator<Op>(selStack_)));
+      }
       void operator()(const char&) const {
-	const char * c;
-	operator()(c, c);
-      }  
-      SelectorStack & selStack_;
+        const char* c;
+        operator()(c, c);
+      }
+      SelectorStack& selStack_;
     };
-  }
- }
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/BinarySelector.h
+++ b/CommonTools/Utils/src/BinarySelector.h
@@ -18,18 +18,18 @@
 namespace reco {
   namespace parser {
     struct BinarySelector : public SelectorBase {
-      BinarySelector( boost::shared_ptr<ExpressionBase> lhs,
-		      boost::shared_ptr<ComparisonBase> cmp,
-		      boost::shared_ptr<ExpressionBase> rhs ) :
-	lhs_( lhs ), cmp_( cmp ), rhs_( rhs ) { }
-      bool operator()( const edm::ObjectWithDict & o ) const override {
-	return cmp_->compare( lhs_->value( o ), rhs_->value( o ) );
+      BinarySelector(boost::shared_ptr<ExpressionBase> lhs,
+                     boost::shared_ptr<ComparisonBase> cmp,
+                     boost::shared_ptr<ExpressionBase> rhs)
+          : lhs_(lhs), cmp_(cmp), rhs_(rhs) {}
+      bool operator()(const edm::ObjectWithDict& o) const override {
+        return cmp_->compare(lhs_->value(o), rhs_->value(o));
       }
       boost::shared_ptr<ExpressionBase> lhs_;
       boost::shared_ptr<ComparisonBase> cmp_;
       boost::shared_ptr<ExpressionBase> rhs_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/BinarySelectorSetter.h
+++ b/CommonTools/Utils/src/BinarySelectorSetter.h
@@ -18,34 +18,36 @@
 #include <boost/shared_ptr.hpp>
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     class BinarySelectorSetter {
     public:
-      BinarySelectorSetter(SelectorStack& selStack,
-			    ComparisonStack& cmpStack, ExpressionStack& expStack) : 
-	selStack_(selStack), cmpStack_(cmpStack), expStack_(expStack) { }
-      
-      void operator()(const char * begin, const char *) const {
-	if(expStack_.empty())
-	  throw Exception(begin)
-	    << "Grammar error: empty expression stack. Please contact developer.";
-	if(cmpStack_.empty())
-	  throw Exception(begin)
-	    << "Grammar error: empty comparator stack. Please contact developer." << "\"";
-	boost::shared_ptr<ExpressionBase> rhs = expStack_.back(); expStack_.pop_back();
-	boost::shared_ptr<ExpressionBase> lhs = expStack_.back(); expStack_.pop_back();
-	boost::shared_ptr<ComparisonBase> comp = cmpStack_.back(); cmpStack_.pop_back();
-#ifdef BOOST_SPIRIT_DEBUG 
-	BOOST_SPIRIT_DEBUG_OUT << "pushing binary selector" << std::endl;
+      BinarySelectorSetter(SelectorStack& selStack, ComparisonStack& cmpStack, ExpressionStack& expStack)
+          : selStack_(selStack), cmpStack_(cmpStack), expStack_(expStack) {}
+
+      void operator()(const char* begin, const char*) const {
+        if (expStack_.empty())
+          throw Exception(begin) << "Grammar error: empty expression stack. Please contact developer.";
+        if (cmpStack_.empty())
+          throw Exception(begin) << "Grammar error: empty comparator stack. Please contact developer."
+                                 << "\"";
+        boost::shared_ptr<ExpressionBase> rhs = expStack_.back();
+        expStack_.pop_back();
+        boost::shared_ptr<ExpressionBase> lhs = expStack_.back();
+        expStack_.pop_back();
+        boost::shared_ptr<ComparisonBase> comp = cmpStack_.back();
+        cmpStack_.pop_back();
+#ifdef BOOST_SPIRIT_DEBUG
+        BOOST_SPIRIT_DEBUG_OUT << "pushing binary selector" << std::endl;
 #endif
-	selStack_.push_back(SelectorPtr(new BinarySelector(lhs, comp, rhs)));
+        selStack_.push_back(SelectorPtr(new BinarySelector(lhs, comp, rhs)));
       }
+
     private:
-      SelectorStack & selStack_;
-      ComparisonStack & cmpStack_;
-      ExpressionStack & expStack_;
+      SelectorStack& selStack_;
+      ComparisonStack& cmpStack_;
+      ExpressionStack& expStack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/CandForTest.h
+++ b/CommonTools/Utils/src/CandForTest.h
@@ -1,15 +1,13 @@
 // Only for Unit test
 namespace eetest {
   struct CandForTest {
+    CandForTest() {}
+    CandForTest(float p, float e, float q) : d{p, e, q} {}
 
-    CandForTest(){}
-    CandForTest(float p,float e, float q) : d{p,e,q}{}
-
-    float pt() const  { return d[0]; }  
-    float eta() const { return d[1]; }  
-    float phi() const { return d[2]; }  
+    float pt() const { return d[0]; }
+    float eta() const { return d[1]; }
+    float phi() const { return d[2]; }
 
     float d[3];
-
   };
-}
+}  // namespace eetest

--- a/CommonTools/Utils/src/Comparison.h
+++ b/CommonTools/Utils/src/Comparison.h
@@ -14,13 +14,14 @@
 
 namespace reco {
   namespace parser {
-    template<class CompT>
+    template <class CompT>
     struct Comparison : public ComparisonBase {
       bool compare(double lhs, double rhs) const override { return comp(lhs, rhs); }
+
     private:
       CompT comp;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ComparisonBase.h
+++ b/CommonTools/Utils/src/ComparisonBase.h
@@ -14,10 +14,10 @@
 namespace reco {
   namespace parser {
     struct ComparisonBase {
-      virtual ~ComparisonBase() { }
-      virtual bool compare( double, double ) const = 0;
+      virtual ~ComparisonBase() {}
+      virtual bool compare(double, double) const = 0;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
-#endif   
+#endif

--- a/CommonTools/Utils/src/ComparisonSetter.cc
+++ b/CommonTools/Utils/src/ComparisonSetter.cc
@@ -1,14 +1,20 @@
 #include "CommonTools/Utils/src/ComparisonSetter.h"
 
-#ifdef BOOST_SPIRIT_DEBUG 
+#ifdef BOOST_SPIRIT_DEBUG
 namespace reco {
-   namespace parser {
-      template<> const std::string cmp_out<std::less<double> >::value = "<";
-      template<> const std::string cmp_out<std::greater<double> >::value = ">";
-      template<> const std::string cmp_out<std::less_equal<double> >::value = "<=";
-      template<> const std::string cmp_out<std::greater_equal<double> >::value = ">=";
-      template<> const std::string cmp_out<std::equal_to<double> >::value = "=";
-      template<> const std::string cmp_out<std::not_equal_to<double> >::value = "!=";      
-   }
-}
+  namespace parser {
+    template <>
+    const std::string cmp_out<std::less<double> >::value = "<";
+    template <>
+    const std::string cmp_out<std::greater<double> >::value = ">";
+    template <>
+    const std::string cmp_out<std::less_equal<double> >::value = "<=";
+    template <>
+    const std::string cmp_out<std::greater_equal<double> >::value = ">=";
+    template <>
+    const std::string cmp_out<std::equal_to<double> >::value = "=";
+    template <>
+    const std::string cmp_out<std::not_equal_to<double> >::value = "!=";
+  }  // namespace parser
+}  // namespace reco
 #endif

--- a/CommonTools/Utils/src/ComparisonSetter.h
+++ b/CommonTools/Utils/src/ComparisonSetter.h
@@ -12,30 +12,34 @@
  */
 #include "CommonTools/Utils/src/ComparisonStack.h"
 #include "CommonTools/Utils/src/Comparison.h"
-#ifdef BOOST_SPIRIT_DEBUG 
+#ifdef BOOST_SPIRIT_DEBUG
 #include <iostream>
 #include <string>
 #endif
 
 namespace reco {
   namespace parser {
-#ifdef BOOST_SPIRIT_DEBUG 
-    template <typename Op> struct cmp_out { static const std::string value; };
+#ifdef BOOST_SPIRIT_DEBUG
+    template <typename Op>
+    struct cmp_out {
+      static const std::string value;
+    };
 #endif
 
-    template<class CompT>
+    template <class CompT>
     struct ComparisonSetter {
-      ComparisonSetter(ComparisonStack & stack) : stack_(stack) { }
+      ComparisonSetter(ComparisonStack& stack) : stack_(stack) {}
       void operator()(const char) const {
-#ifdef BOOST_SPIRIT_DEBUG 
-	BOOST_SPIRIT_DEBUG_OUT << "pushing comparison: " << cmp_out<CompT>::value << std::endl;
+#ifdef BOOST_SPIRIT_DEBUG
+        BOOST_SPIRIT_DEBUG_OUT << "pushing comparison: " << cmp_out<CompT>::value << std::endl;
 #endif
-	stack_.push_back(boost::shared_ptr<ComparisonBase>(new Comparison<CompT>()));
+        stack_.push_back(boost::shared_ptr<ComparisonBase>(new Comparison<CompT>()));
       }
+
     private:
-      ComparisonStack & stack_;
+      ComparisonStack& stack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ComparisonStack.h
+++ b/CommonTools/Utils/src/ComparisonStack.h
@@ -17,7 +17,7 @@ namespace reco {
   namespace parser {
     struct ComparisonBase;
     typedef std::vector<boost::shared_ptr<ComparisonBase> > ComparisonStack;
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/CutSetter.h
+++ b/CommonTools/Utils/src/CutSetter.h
@@ -15,21 +15,20 @@
 #include <cassert>
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct CutSetter {
-      CutSetter(SelectorPtr & cut, SelectorStack & selStack) :
-	cut_(cut), selStack_(selStack) { }
-      
+      CutSetter(SelectorPtr& cut, SelectorStack& selStack) : cut_(cut), selStack_(selStack) {}
+
       void operator()(const char*, const char*) const {
-	assert(nullptr == cut_.get());
-	assert(!selStack_.empty());
-	cut_ = selStack_.back();
-	selStack_.pop_back();
+        assert(nullptr == cut_.get());
+        assert(!selStack_.empty());
+        cut_ = selStack_.back();
+        selStack_.pop_back();
       }
-      SelectorPtr & cut_;
-      SelectorStack & selStack_;
+      SelectorPtr& cut_;
+      SelectorStack& selStack_;
     };
-  }
- }
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ErrorCodes.h
+++ b/CommonTools/Utils/src/ErrorCodes.h
@@ -4,7 +4,7 @@
 //
 // Package:     Utilities
 // Class  :     ErrorCodes
-// 
+//
 /**\enum ErrorCodes ErrorCodes.h CommonTools/Utils/interface/ErrorCodes.h
 
  Description: enum containing the various ways data/function member lookups can fail
@@ -26,21 +26,21 @@
 // forward declarations
 
 namespace reco {
-   namespace parser {
-      enum ErrorCodes {
-         kNoError = 0,
-         kNameDoesNotExist,
-         kIsNotPublic,
-         kIsStatic,
-         kIsNotConst,
-         kIsFunctionAddedByROOT,
-         kIsConstructor,
-         kIsDestructor,
-         kIsOperator,
-         kWrongNumberOfArguments,
-         kWrongArgumentType,
-         kOverloaded
-      };
-   }
-}
+  namespace parser {
+    enum ErrorCodes {
+      kNoError = 0,
+      kNameDoesNotExist,
+      kIsNotPublic,
+      kIsStatic,
+      kIsNotConst,
+      kIsFunctionAddedByROOT,
+      kIsConstructor,
+      kIsDestructor,
+      kIsOperator,
+      kWrongNumberOfArguments,
+      kWrongArgumentType,
+      kOverloaded
+    };
+  }
+}  // namespace reco
 #endif

--- a/CommonTools/Utils/src/ExpressionBase.h
+++ b/CommonTools/Utils/src/ExpressionBase.h
@@ -11,16 +11,18 @@
 #include <boost/shared_ptr.hpp>
 #include <vector>
 
-namespace edm { class ObjectWithDict; }
+namespace edm {
+  class ObjectWithDict;
+}
 
 namespace reco {
   namespace parser {
     struct ExpressionBase {
-      virtual ~ExpressionBase() { }
-      virtual double value( const edm::ObjectWithDict & ) const = 0;
+      virtual ~ExpressionBase() {}
+      virtual double value(const edm::ObjectWithDict&) const = 0;
     };
     typedef boost::shared_ptr<ExpressionBase> ExpressionPtr;
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionBinaryOperator.h
+++ b/CommonTools/Utils/src/ExpressionBinaryOperator.h
@@ -15,20 +15,21 @@
 
 namespace reco {
   namespace parser {
-    template<typename Op>
+    template <typename Op>
     struct ExpressionBinaryOperator : public ExpressionBase {
-      double value(const edm::ObjectWithDict& o) const override { 
-	return op_((*lhs_).value(o), (*rhs_).value(o));
+      double value(const edm::ObjectWithDict& o) const override { return op_((*lhs_).value(o), (*rhs_).value(o)); }
+      ExpressionBinaryOperator(ExpressionStack& expStack) {
+        rhs_ = expStack.back();
+        expStack.pop_back();
+        lhs_ = expStack.back();
+        expStack.pop_back();
       }
-      ExpressionBinaryOperator(ExpressionStack & expStack) { 
-	rhs_ = expStack.back(); expStack.pop_back();
-	lhs_ = expStack.back(); expStack.pop_back();
-      }
+
     private:
       Op op_;
       ExpressionPtr lhs_, rhs_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionBinaryOperatorSetter.h
+++ b/CommonTools/Utils/src/ExpressionBinaryOperatorSetter.h
@@ -17,21 +17,22 @@
 namespace reco {
   namespace parser {
 
-    template<typename T>
+    template <typename T>
     struct power_of {
       T operator()(T lhs, T rhs) const { return pow(lhs, rhs); }
     };
 
-    template<typename Op>
+    template <typename Op>
     struct ExpressionBinaryOperatorSetter {
-      ExpressionBinaryOperatorSetter(ExpressionStack & stack) : stack_(stack) { }
+      ExpressionBinaryOperatorSetter(ExpressionStack& stack) : stack_(stack) {}
       void operator()(const char*, const char*) const {
-	stack_.push_back(ExpressionPtr(new ExpressionBinaryOperator<Op>(stack_)));
+        stack_.push_back(ExpressionPtr(new ExpressionBinaryOperator<Op>(stack_)));
       }
+
     private:
-      ExpressionStack & stack_;
+      ExpressionStack& stack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionCondition.h
+++ b/CommonTools/Utils/src/ExpressionCondition.h
@@ -18,19 +18,23 @@
 namespace reco {
   namespace parser {
     struct ExpressionCondition : public ExpressionBase {
-      double value(const edm::ObjectWithDict& o) const override { 
-	return (*cond_)(o) ? true_->value(o) : false_->value(o);
+      double value(const edm::ObjectWithDict& o) const override {
+        return (*cond_)(o) ? true_->value(o) : false_->value(o);
       }
-      ExpressionCondition(ExpressionStack & expStack, SelectorStack & selStack) { 
-	false_ = expStack.back(); expStack.pop_back();
-	true_  = expStack.back(); expStack.pop_back();
-	cond_  = selStack.back(); selStack.pop_back();
+      ExpressionCondition(ExpressionStack& expStack, SelectorStack& selStack) {
+        false_ = expStack.back();
+        expStack.pop_back();
+        true_ = expStack.back();
+        expStack.pop_back();
+        cond_ = selStack.back();
+        selStack.pop_back();
       }
-      private:
+
+    private:
       ExpressionPtr true_, false_;
       SelectorPtr cond_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionConditionSetter.cc
+++ b/CommonTools/Utils/src/ExpressionConditionSetter.cc
@@ -4,7 +4,7 @@
 using namespace reco::parser;
 
 void ExpressionConditionSetter::operator()(const char *, const char *) const {
-  ExpressionBase * ep = new ExpressionCondition(expStack_, selStack_);
+  ExpressionBase *ep = new ExpressionCondition(expStack_, selStack_);
   ExpressionPtr e(ep);
   expStack_.push_back(e);
 }

--- a/CommonTools/Utils/src/ExpressionConditionSetter.h
+++ b/CommonTools/Utils/src/ExpressionConditionSetter.h
@@ -15,14 +15,15 @@
 namespace reco {
   namespace parser {
     struct ExpressionConditionSetter {
-      ExpressionConditionSetter(ExpressionStack & expStack, SelectorStack & selStack) : 
-	expStack_(expStack), selStack_(selStack) { }
+      ExpressionConditionSetter(ExpressionStack &expStack, SelectorStack &selStack)
+          : expStack_(expStack), selStack_(selStack) {}
       void operator()(const char *, const char *) const;
+
     private:
-      ExpressionStack & expStack_;
-      SelectorStack & selStack_;
+      ExpressionStack &expStack_;
+      SelectorStack &selStack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionEvaluator.cc
+++ b/CommonTools/Utils/src/ExpressionEvaluator.cc
@@ -19,8 +19,7 @@
 #define COUT LogDebug("ExpressionEvaluator")
 #endif
 
-using namespace	reco::exprEvalDetails;
-
+using namespace reco::exprEvalDetails;
 
 namespace {
   std::string generateName() {
@@ -29,133 +28,132 @@ namespace {
     return n1;
   }
 
- void remove(std::string const & name) {
-  std::string sfile = "/tmp/"+name+".cc";
-  std::string ofile = "/tmp/"+name+".so";
+  void remove(std::string const& name) {
+    std::string sfile = "/tmp/" + name + ".cc";
+    std::string ofile = "/tmp/" + name + ".so";
 
-  std::string rm="rm -f "; rm+=sfile+' '+ofile;
+    std::string rm = "rm -f ";
+    rm += sfile + ' ' + ofile;
 
-  system(rm.c_str());
+    system(rm.c_str());
+  }
 
- }
-
- std::string patchArea() {
+  std::string patchArea() {
     auto n1 = execSysCommand("pushd $CMSSW_BASE > /dev/null;scram tool tag cmssw CMSSW_BASE; popd > /dev/null");
     n1.pop_back();
     COUT << "base area " << n1 << std::endl;
-    return n1[0]=='/' ? n1 : std::string();
- }
+    return n1[0] == '/' ? n1 : std::string();
+  }
 
+}  // namespace
 
-}
+namespace reco {
 
-namespace reco{
+  ExpressionEvaluator::ExpressionEvaluator(const char* pkg, const char* iname, std::string const& iexpr)
+      : m_name("VI_" + generateName()) {
+    std::string pch = pkg;
+    pch += "/src/precompile.h";
+    std::string quote("\"");
 
-ExpressionEvaluator::ExpressionEvaluator(const char * pkg, const char * iname, std::string const & iexpr) :
-  m_name("VI_"+generateName())
-{
+    std::string sfile = "/tmp/" + m_name + ".cc";
+    std::string ofile = "/tmp/" + m_name + ".so";
 
+    auto arch = edm::getEnvironmentVariable("SCRAM_ARCH");
+    auto baseDir = edm::getEnvironmentVariable("CMSSW_BASE");
+    auto relDir = edm::getEnvironmentVariable("CMSSW_RELEASE_BASE");
 
-  std::string pch = pkg; pch += "/src/precompile.h";
-  std::string quote("\"");
+    std::string incDir = "/include/" + arch + "/";
+    std::string cxxf;
+    {
+      // look in local dir
+      std::string file = baseDir + incDir + pch + ".cxxflags";
+      std::ifstream ss(file.c_str());
+      COUT << "local file: " << file << std::endl;
+      if (ss) {
+        std::getline(ss, cxxf);
+        incDir = baseDir + incDir;
+      } else {
+        // look in release area
+        std::string file = relDir + incDir + pch + ".cxxflags";
+        COUT << "file in release area: " << file << std::endl;
+        std::ifstream ss(file.c_str());
+        if (ss) {
+          std::getline(ss, cxxf);
+          incDir = relDir + incDir;
+        } else {
+          // look in release is a patch area
+          auto paDir = patchArea();
+          if (paDir.empty())
+            throw cms::Exception("ExpressionEvaluator", "error in opening patch area for " + baseDir);
+          std::string file = paDir + incDir + pch + ".cxxflags";
+          COUT << "file in base release area: " << file << std::endl;
+          std::ifstream ss(file.c_str());
+          if (!ss)
+            throw cms::Exception(
+                "ExpressionEvaluator",
+                pch + " file not found neither in " + baseDir + " nor in " + relDir + " nor in " + paDir);
+          std::getline(ss, cxxf);
+          incDir = paDir + incDir;
+        }
+      }
 
-  
-  std::string sfile = "/tmp/"+m_name+".cc";
-  std::string ofile = "/tmp/"+m_name+".so";
-
-  auto arch = edm::getEnvironmentVariable("SCRAM_ARCH");
-  auto baseDir = edm::getEnvironmentVariable("CMSSW_BASE");
-  auto relDir = edm::getEnvironmentVariable("CMSSW_RELEASE_BASE");
-
-
-  std::string incDir = "/include/" + arch + "/";
-  std::string cxxf;
-  {
-    // look in local dir
-    std::string file = baseDir + incDir + pch + ".cxxflags";
-    std::ifstream ss(file.c_str());
-    COUT << "local file: " << file << std::endl;
-    if (ss) {
-      std::getline(ss,cxxf);
-      incDir = baseDir + incDir;
-    } else {
-       // look in release area 
-       std::string file = relDir + incDir + pch + ".cxxflags";
-       COUT << "file in release area: " << file << std::endl;
-       std::ifstream ss(file.c_str());
-       if (ss) {
-         std::getline(ss,cxxf);
-         incDir = relDir + incDir;
-       } else {
-         // look in release is a patch area 
-         auto paDir = patchArea();
-         if (paDir.empty())  throw  cms::Exception("ExpressionEvaluator", "error in opening patch area for "+ baseDir);
-         std::string file = paDir + incDir + pch + ".cxxflags";
-         COUT << "file in base release area: " << file << std::endl;
-         std::ifstream ss(file.c_str());
-         if (!ss)  throw  cms::Exception("ExpressionEvaluator", pch + " file not found neither in " + baseDir + " nor in " + relDir  + " nor in " + paDir);
-         std::getline(ss,cxxf);
-         incDir = paDir + incDir;
-       }
+      {
+        std::regex rq("-I[^ ]+");
+        cxxf = std::regex_replace(cxxf, rq, std::string(""));
+      }
+      {
+        std::regex rq("=\"");
+        cxxf = std::regex_replace(cxxf, rq, std::string("='\""));
+      }
+      {
+        std::regex rq("\" ");
+        cxxf = std::regex_replace(cxxf, rq, std::string("\"' "));
+      }
+      COUT << '|' << cxxf << "|\n" << std::endl;
     }
 
-    { std::regex rq("-I[^ ]+"); cxxf = std::regex_replace(cxxf,rq,std::string("")); }
-    { std::regex rq("=\""); cxxf = std::regex_replace(cxxf,rq,std::string("='\"")); }
-    { std::regex rq("\" "); cxxf = std::regex_replace(cxxf,rq,std::string("\"' ")); }
-    COUT << '|' << cxxf << "|\n" << std::endl;
+    std::string cpp = "c++ -H -Wall -shared -Winvalid-pch ";
+    cpp += cxxf;
+    cpp += " -I" + incDir;
+    cpp += " -o " + ofile + ' ' + sfile + " 2>&1\n";
 
+    COUT << cpp << std::endl;
+
+    //  prepare the file to compile
+    std::string factory = "factory" + m_name;
+
+    std::string source = std::string("#include ") + quote + pch + quote + "\n";
+    source += "struct " + m_name + " final : public " + iname + "{\n";
+    source += iexpr;
+    source += "\n};\n";
+
+    source += "extern " + quote + 'C' + quote + ' ' + std::string(iname) + "* " + factory + "() {\n";
+    source += "static " + m_name + " local;\n";
+    source += "return &local;\n}\n";
+
+    COUT << source << std::endl;
+
+    {
+      std::ofstream tmp(sfile.c_str());
+      tmp << source << std::endl;
+    }
+
+    // compile
+    auto ss = execSysCommand(cpp);
+    COUT << ss << std::endl;
+
+    void* dl = dlopen(ofile.c_str(), RTLD_LAZY);
+    if (!dl) {
+      remove(m_name);
+      throw cms::Exception("ExpressionEvaluator",
+                           std::string("compilation/linking failed\n") + cpp + ss + "dlerror " + dlerror());
+      return;
+    }
+
+    m_expr = dlsym(dl, factory.c_str());
+    remove(m_name);
   }
 
-  std::string cpp = "c++ -H -Wall -shared -Winvalid-pch "; cpp+=cxxf;
-  cpp += " -I" + incDir; 
-  cpp += " -o " + ofile + ' ' + sfile+" 2>&1\n";
+  ExpressionEvaluator::~ExpressionEvaluator() { remove(m_name); }
 
-  COUT << cpp << std::endl;
-
-
-  //  prepare the file to compile
-  std::string factory = "factory" + m_name;
-
-  std::string source = std::string("#include ")+quote+ pch +quote+"\n";
-  source+="struct "+m_name+" final : public "+iname + "{\n";
-  source+=iexpr;
-  source+="\n};\n";
-
-
-  source += "extern " + quote+'C'+quote+' ' + std::string(iname) + "* "+factory+"() {\n";
-  source += "static "+m_name+" local;\n";
-  source += "return &local;\n}\n";
-
-
-  COUT << source << std::endl;
-
-  {
-    std::ofstream tmp(sfile.c_str());
-    tmp<<source << std::endl;                                                                        
-  }
-
-
-
-  // compile 
-  auto ss = execSysCommand(cpp);
-  COUT << ss << std::endl;
-
-  void * dl = dlopen(ofile.c_str(),RTLD_LAZY);
-  if (!dl) {
-     remove(m_name);
-     throw  cms::Exception("ExpressionEvaluator", std::string("compilation/linking failed\n") +  cpp + ss + "dlerror " + dlerror());
-    return;
-  }
-
-  m_expr = dlsym(dl,factory.c_str());
-  remove(m_name);
-}
-
-
-ExpressionEvaluator::~ExpressionEvaluator(){
-  remove(m_name);
-}
-
-
-
-}
+}  // namespace reco

--- a/CommonTools/Utils/src/ExpressionFunctionSetter.cc
+++ b/CommonTools/Utils/src/ExpressionFunctionSetter.cc
@@ -9,61 +9,154 @@
 
 namespace reco {
   namespace parser {
-    struct abs_f { double operator()( double x ) const { return fabs( x ); } };
-    struct acos_f { double operator()( double x ) const { return acos( x ); } };
-    struct asin_f { double operator()( double x ) const { return asin( x ); } };
-    struct atan_f { double operator()( double x ) const { return atan( x ); } };
-    struct atan2_f { double operator()( double x, double y ) const { return atan2( x, y ); } };
-    struct chi2prob_f { double operator()( double x, double y ) const { return ROOT::Math::chisquared_cdf_c( x, y ); } };
-    struct cos_f { double operator()( double x ) const { return cos( x ); } };
-    struct cosh_f { double operator()( double x ) const { return cosh( x ); } };
-    struct deltaR_f { double operator()( double e1, double p1, double e2, double p2 ) const { return reco::deltaR(e1,p1,e2,p2); } };
-    struct deltaPhi_f { double operator()( double p1, double p2 ) const { return reco::deltaPhi(p1,p2); } };
-    struct exp_f { double operator()( double x ) const { return exp( x ); } };
-    struct hypot_f { double operator()( double x, double y ) const { return hypot( x, y ); } };
-    struct log_f { double operator()( double x ) const { return log( x ); } };
-    struct log10_f { double operator()( double x ) const { return log10( x ); } };
-    struct max_f { double operator()( double x, double y ) const { return std::max( x, y ); } };
-    struct min_f { double operator()( double x, double y ) const { return std::min( x, y ); } };
-    struct pow_f { double operator()( double x, double y ) const { return pow( x, y ); } };
-    struct sin_f { double operator()( double x ) const { return sin( x ); } };
-    struct sinh_f { double operator()( double x ) const { return sinh( x ); } };
-    struct sqrt_f { double operator()( double x ) const { return sqrt( x ); } };
-    struct tan_f { double operator()( double x ) const { return tan( x ); } };
-    struct tanh_f { double operator()( double x ) const { return tanh( x ); } };
-    struct test_bit_f { double operator()( double mask, double iBit ) const { return (int(mask) >> int(iBit)) & 1; } };
-  }
-}
+    struct abs_f {
+      double operator()(double x) const { return fabs(x); }
+    };
+    struct acos_f {
+      double operator()(double x) const { return acos(x); }
+    };
+    struct asin_f {
+      double operator()(double x) const { return asin(x); }
+    };
+    struct atan_f {
+      double operator()(double x) const { return atan(x); }
+    };
+    struct atan2_f {
+      double operator()(double x, double y) const { return atan2(x, y); }
+    };
+    struct chi2prob_f {
+      double operator()(double x, double y) const { return ROOT::Math::chisquared_cdf_c(x, y); }
+    };
+    struct cos_f {
+      double operator()(double x) const { return cos(x); }
+    };
+    struct cosh_f {
+      double operator()(double x) const { return cosh(x); }
+    };
+    struct deltaR_f {
+      double operator()(double e1, double p1, double e2, double p2) const { return reco::deltaR(e1, p1, e2, p2); }
+    };
+    struct deltaPhi_f {
+      double operator()(double p1, double p2) const { return reco::deltaPhi(p1, p2); }
+    };
+    struct exp_f {
+      double operator()(double x) const { return exp(x); }
+    };
+    struct hypot_f {
+      double operator()(double x, double y) const { return hypot(x, y); }
+    };
+    struct log_f {
+      double operator()(double x) const { return log(x); }
+    };
+    struct log10_f {
+      double operator()(double x) const { return log10(x); }
+    };
+    struct max_f {
+      double operator()(double x, double y) const { return std::max(x, y); }
+    };
+    struct min_f {
+      double operator()(double x, double y) const { return std::min(x, y); }
+    };
+    struct pow_f {
+      double operator()(double x, double y) const { return pow(x, y); }
+    };
+    struct sin_f {
+      double operator()(double x) const { return sin(x); }
+    };
+    struct sinh_f {
+      double operator()(double x) const { return sinh(x); }
+    };
+    struct sqrt_f {
+      double operator()(double x) const { return sqrt(x); }
+    };
+    struct tan_f {
+      double operator()(double x) const { return tan(x); }
+    };
+    struct tanh_f {
+      double operator()(double x) const { return tanh(x); }
+    };
+    struct test_bit_f {
+      double operator()(double mask, double iBit) const { return (int(mask) >> int(iBit)) & 1; }
+    };
+  }  // namespace parser
+}  // namespace reco
 
 using namespace reco::parser;
 
-void ExpressionFunctionSetter::operator()( const char *, const char * ) const {
-  Function fun = funStack_.back(); funStack_.pop_back();
+void ExpressionFunctionSetter::operator()(const char *, const char *) const {
+  Function fun = funStack_.back();
+  funStack_.pop_back();
   ExpressionPtr funExp;
-  switch( fun ) {
-  case( kAbs      ) : funExp.reset( new ExpressionUnaryOperator <abs_f  >   ( expStack_ ) ); break;
-  case( kAcos     ) : funExp.reset( new ExpressionUnaryOperator <acos_f >   ( expStack_ ) ); break;
-  case( kAsin     ) : funExp.reset( new ExpressionUnaryOperator <asin_f >   ( expStack_ ) ); break;
-  case( kAtan     ) : funExp.reset( new ExpressionUnaryOperator <atan_f >   ( expStack_ ) ); break;
-  case( kAtan2    ) : funExp.reset( new ExpressionBinaryOperator<atan2_f>   ( expStack_ ) ); break;
-  case( kChi2Prob ) : funExp.reset( new ExpressionBinaryOperator<chi2prob_f>( expStack_ ) ); break;
-  case( kCos      ) : funExp.reset( new ExpressionUnaryOperator <cos_f  >   ( expStack_ ) ); break;
-  case( kCosh     ) : funExp.reset( new ExpressionUnaryOperator <cosh_f >   ( expStack_ ) ); break;
-  case( kDeltaR   ) : funExp.reset( new ExpressionQuaterOperator<deltaR_f>  ( expStack_ ) ); break;
-  case( kDeltaPhi ) : funExp.reset( new ExpressionBinaryOperator<deltaPhi_f>( expStack_ ) ); break;
-  case( kExp      ) : funExp.reset( new ExpressionUnaryOperator <exp_f  >   ( expStack_ ) ); break;
-  case( kHypot    ) : funExp.reset( new ExpressionBinaryOperator<hypot_f>   ( expStack_ ) ); break;
-  case( kLog      ) : funExp.reset( new ExpressionUnaryOperator <log_f  >   ( expStack_ ) ); break;
-  case( kLog10    ) : funExp.reset( new ExpressionUnaryOperator <log10_f>   ( expStack_ ) ); break;
-  case( kMax      ) : funExp.reset( new ExpressionBinaryOperator<max_f>     ( expStack_ ) ); break;
-  case( kMin      ) : funExp.reset( new ExpressionBinaryOperator<min_f>     ( expStack_ ) ); break;
-  case( kPow      ) : funExp.reset( new ExpressionBinaryOperator<pow_f  >   ( expStack_ ) ); break;
-  case( kSin      ) : funExp.reset( new ExpressionUnaryOperator <sin_f  >   ( expStack_ ) ); break;
-  case( kSinh     ) : funExp.reset( new ExpressionUnaryOperator <sinh_f >   ( expStack_ ) ); break;
-  case( kSqrt     ) : funExp.reset( new ExpressionUnaryOperator <sqrt_f >   ( expStack_ ) ); break;
-  case( kTan      ) : funExp.reset( new ExpressionUnaryOperator <tan_f  >   ( expStack_ ) ); break;
-  case( kTanh     ) : funExp.reset( new ExpressionUnaryOperator <tanh_f >   ( expStack_ ) ); break;
-  case( kTestBit  ) : funExp.reset( new ExpressionBinaryOperator<test_bit_f>( expStack_ ) ); break;
+  switch (fun) {
+    case (kAbs):
+      funExp.reset(new ExpressionUnaryOperator<abs_f>(expStack_));
+      break;
+    case (kAcos):
+      funExp.reset(new ExpressionUnaryOperator<acos_f>(expStack_));
+      break;
+    case (kAsin):
+      funExp.reset(new ExpressionUnaryOperator<asin_f>(expStack_));
+      break;
+    case (kAtan):
+      funExp.reset(new ExpressionUnaryOperator<atan_f>(expStack_));
+      break;
+    case (kAtan2):
+      funExp.reset(new ExpressionBinaryOperator<atan2_f>(expStack_));
+      break;
+    case (kChi2Prob):
+      funExp.reset(new ExpressionBinaryOperator<chi2prob_f>(expStack_));
+      break;
+    case (kCos):
+      funExp.reset(new ExpressionUnaryOperator<cos_f>(expStack_));
+      break;
+    case (kCosh):
+      funExp.reset(new ExpressionUnaryOperator<cosh_f>(expStack_));
+      break;
+    case (kDeltaR):
+      funExp.reset(new ExpressionQuaterOperator<deltaR_f>(expStack_));
+      break;
+    case (kDeltaPhi):
+      funExp.reset(new ExpressionBinaryOperator<deltaPhi_f>(expStack_));
+      break;
+    case (kExp):
+      funExp.reset(new ExpressionUnaryOperator<exp_f>(expStack_));
+      break;
+    case (kHypot):
+      funExp.reset(new ExpressionBinaryOperator<hypot_f>(expStack_));
+      break;
+    case (kLog):
+      funExp.reset(new ExpressionUnaryOperator<log_f>(expStack_));
+      break;
+    case (kLog10):
+      funExp.reset(new ExpressionUnaryOperator<log10_f>(expStack_));
+      break;
+    case (kMax):
+      funExp.reset(new ExpressionBinaryOperator<max_f>(expStack_));
+      break;
+    case (kMin):
+      funExp.reset(new ExpressionBinaryOperator<min_f>(expStack_));
+      break;
+    case (kPow):
+      funExp.reset(new ExpressionBinaryOperator<pow_f>(expStack_));
+      break;
+    case (kSin):
+      funExp.reset(new ExpressionUnaryOperator<sin_f>(expStack_));
+      break;
+    case (kSinh):
+      funExp.reset(new ExpressionUnaryOperator<sinh_f>(expStack_));
+      break;
+    case (kSqrt):
+      funExp.reset(new ExpressionUnaryOperator<sqrt_f>(expStack_));
+      break;
+    case (kTan):
+      funExp.reset(new ExpressionUnaryOperator<tan_f>(expStack_));
+      break;
+    case (kTanh):
+      funExp.reset(new ExpressionUnaryOperator<tanh_f>(expStack_));
+      break;
+    case (kTestBit):
+      funExp.reset(new ExpressionBinaryOperator<test_bit_f>(expStack_));
+      break;
   };
-  expStack_.push_back( funExp );
+  expStack_.push_back(funExp);
 }

--- a/CommonTools/Utils/src/ExpressionFunctionSetter.h
+++ b/CommonTools/Utils/src/ExpressionFunctionSetter.h
@@ -15,14 +15,15 @@
 namespace reco {
   namespace parser {
     struct ExpressionFunctionSetter {
-      ExpressionFunctionSetter( ExpressionStack & expStack, FunctionStack & funStack ) : 
-	expStack_( expStack ), funStack_( funStack ) { }
-      void operator()( const char *, const char * ) const;
+      ExpressionFunctionSetter(ExpressionStack &expStack, FunctionStack &funStack)
+          : expStack_(expStack), funStack_(funStack) {}
+      void operator()(const char *, const char *) const;
+
     private:
-      ExpressionStack & expStack_;
-      FunctionStack & funStack_;
+      ExpressionStack &expStack_;
+      FunctionStack &funStack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionNumber.h
+++ b/CommonTools/Utils/src/ExpressionNumber.h
@@ -15,12 +15,13 @@
 namespace reco {
   namespace parser {
     struct ExpressionNumber : public ExpressionBase {
-      double value( const edm::ObjectWithDict& ) const override { return value_; }
-      ExpressionNumber( double value ) : value_( value ) { }
+      double value(const edm::ObjectWithDict&) const override { return value_; }
+      ExpressionNumber(double value) : value_(value) {}
+
     private:
       double value_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionNumberSetter.h
+++ b/CommonTools/Utils/src/ExpressionNumberSetter.h
@@ -16,14 +16,13 @@
 namespace reco {
   namespace parser {
     struct ExpressionNumberSetter {
-      ExpressionNumberSetter(ExpressionStack & stack) : stack_(stack) { }
-      void operator()(double n) const {
-	stack_.push_back(ExpressionPtr(new ExpressionNumber(n)));
-      }
+      ExpressionNumberSetter(ExpressionStack& stack) : stack_(stack) {}
+      void operator()(double n) const { stack_.push_back(ExpressionPtr(new ExpressionNumber(n))); }
+
     private:
-      ExpressionStack & stack_;
+      ExpressionStack& stack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionPtr.h
+++ b/CommonTools/Utils/src/ExpressionPtr.h
@@ -15,7 +15,7 @@ namespace reco {
   namespace parser {
     struct ExpressionBase;
     typedef boost::shared_ptr<ExpressionBase> ExpressionPtr;
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionQuaterOperator.h
+++ b/CommonTools/Utils/src/ExpressionQuaterOperator.h
@@ -15,22 +15,27 @@
 
 namespace reco {
   namespace parser {
-    template<typename Op>
+    template <typename Op>
     struct ExpressionQuaterOperator : public ExpressionBase {
-      double value(const edm::ObjectWithDict& o) const override { 
-	return op_(args_[0]->value(o), args_[1]->value(o), args_[2]->value(o), args_[3]->value(o));
+      double value(const edm::ObjectWithDict& o) const override {
+        return op_(args_[0]->value(o), args_[1]->value(o), args_[2]->value(o), args_[3]->value(o));
       }
-      ExpressionQuaterOperator(ExpressionStack & expStack) { 
-	args_[3] = expStack.back(); expStack.pop_back();
-	args_[2] = expStack.back(); expStack.pop_back();
-	args_[1] = expStack.back(); expStack.pop_back();
-	args_[0] = expStack.back(); expStack.pop_back();
+      ExpressionQuaterOperator(ExpressionStack& expStack) {
+        args_[3] = expStack.back();
+        expStack.pop_back();
+        args_[2] = expStack.back();
+        expStack.pop_back();
+        args_[1] = expStack.back();
+        expStack.pop_back();
+        args_[0] = expStack.back();
+        expStack.pop_back();
       }
+
     private:
       Op op_;
       ExpressionPtr args_[4];
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionSelectorSetter.h
+++ b/CommonTools/Utils/src/ExpressionSelectorSetter.h
@@ -20,29 +20,31 @@
 #include <functional>
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     class ExpressionSelectorSetter {
     public:
-      ExpressionSelectorSetter(SelectorStack& selStack, ExpressionStack& expStack) : 
-	selStack_(selStack), expStack_(expStack) { }
-      
-      void operator()(const char * begin, const char *) const {
-	if(expStack_.empty())
-	  throw Exception(begin)
-	    << "Grammar error: empty expression stack. Please contact developer." << "\"";
-	boost::shared_ptr<ExpressionBase> rhs = expStack_.back(); expStack_.pop_back();
-	boost::shared_ptr<ExpressionBase> lhs(new ExpressionNumber(0.0));
-	boost::shared_ptr<ComparisonBase> comp(new Comparison<std::not_equal_to<double> >());
-#ifdef BOOST_SPIRIT_DEBUG 
-	BOOST_SPIRIT_DEBUG_OUT << "pushing expression selector" << std::endl;
+      ExpressionSelectorSetter(SelectorStack& selStack, ExpressionStack& expStack)
+          : selStack_(selStack), expStack_(expStack) {}
+
+      void operator()(const char* begin, const char*) const {
+        if (expStack_.empty())
+          throw Exception(begin) << "Grammar error: empty expression stack. Please contact developer."
+                                 << "\"";
+        boost::shared_ptr<ExpressionBase> rhs = expStack_.back();
+        expStack_.pop_back();
+        boost::shared_ptr<ExpressionBase> lhs(new ExpressionNumber(0.0));
+        boost::shared_ptr<ComparisonBase> comp(new Comparison<std::not_equal_to<double> >());
+#ifdef BOOST_SPIRIT_DEBUG
+        BOOST_SPIRIT_DEBUG_OUT << "pushing expression selector" << std::endl;
 #endif
-	selStack_.push_back(SelectorPtr(new BinarySelector(lhs, comp, rhs)));
+        selStack_.push_back(SelectorPtr(new BinarySelector(lhs, comp, rhs)));
       }
+
     private:
-      SelectorStack & selStack_;
-      ExpressionStack & expStack_;
+      SelectorStack& selStack_;
+      ExpressionStack& expStack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionSetter.cc
+++ b/CommonTools/Utils/src/ExpressionSetter.cc
@@ -6,9 +6,9 @@
 
 using namespace reco::parser;
 
-void ExpressionSetter::operator()( const char *begin, const char * ) const {
-  if ( exprStack_.empty() ) 
-    throw Exception( begin )
-      << "Grammar error: When trying parse an expression, expression stack is empty! Please contact a developer.";
+void ExpressionSetter::operator()(const char *begin, const char *) const {
+  if (exprStack_.empty())
+    throw Exception(begin)
+        << "Grammar error: When trying parse an expression, expression stack is empty! Please contact a developer.";
   expr_ = exprStack_.back();
 }

--- a/CommonTools/Utils/src/ExpressionSetter.h
+++ b/CommonTools/Utils/src/ExpressionSetter.h
@@ -14,16 +14,15 @@
 #include "CommonTools/Utils/src/ExpressionStack.h"
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct ExpressionSetter {
-      ExpressionSetter( ExpressionPtr & expr, ExpressionStack & exprStack ) :
-	expr_( expr ), exprStack_( exprStack ) { }
-      
-      void operator()( const char*, const char* ) const;
-      ExpressionPtr & expr_;
-      ExpressionStack & exprStack_;
+      ExpressionSetter(ExpressionPtr& expr, ExpressionStack& exprStack) : expr_(expr), exprStack_(exprStack) {}
+
+      void operator()(const char*, const char*) const;
+      ExpressionPtr& expr_;
+      ExpressionStack& exprStack_;
     };
-  }
- }
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionStack.h
+++ b/CommonTools/Utils/src/ExpressionStack.h
@@ -18,7 +18,7 @@ namespace reco {
     struct ExpressionBase;
 
     typedef std::vector<boost::shared_ptr<ExpressionBase> > ExpressionStack;
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionUnaryOperator.h
+++ b/CommonTools/Utils/src/ExpressionUnaryOperator.h
@@ -15,19 +15,19 @@
 
 namespace reco {
   namespace parser {
-    template<typename Op>
+    template <typename Op>
     struct ExpressionUnaryOperator : public ExpressionBase {
-      double value(const edm::ObjectWithDict& o) const override { 
-	return op_((*exp_).value(o));
+      double value(const edm::ObjectWithDict& o) const override { return op_((*exp_).value(o)); }
+      ExpressionUnaryOperator(ExpressionStack& expStack) {
+        exp_ = expStack.back();
+        expStack.pop_back();
       }
-      ExpressionUnaryOperator(ExpressionStack & expStack) { 
-	exp_ = expStack.back(); expStack.pop_back();
-      }
+
     private:
       Op op_;
       ExpressionPtr exp_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionUnaryOperatorSetter.cc
+++ b/CommonTools/Utils/src/ExpressionUnaryOperatorSetter.cc
@@ -2,6 +2,7 @@
 
 using namespace reco::parser;
 
-#ifdef BOOST_SPIRIT_DEBUG 
-template<> const std::string op1_out<std::negate<double> >::value = "-";
+#ifdef BOOST_SPIRIT_DEBUG
+template <>
+const std::string op1_out<std::negate<double> >::value = "-";
 #endif

--- a/CommonTools/Utils/src/ExpressionUnaryOperatorSetter.h
+++ b/CommonTools/Utils/src/ExpressionUnaryOperatorSetter.h
@@ -12,30 +12,34 @@
  */
 #include "CommonTools/Utils/src/ExpressionUnaryOperator.h"
 #include "CommonTools/Utils/src/ExpressionStack.h"
-#ifdef BOOST_SPIRIT_DEBUG 
+#ifdef BOOST_SPIRIT_DEBUG
 #include <string>
 #include <iostream>
 #endif
 namespace reco {
   namespace parser {
 
-#ifdef BOOST_SPIRIT_DEBUG 
-    template <typename Op> struct op1_out { static const std::string value; };
+#ifdef BOOST_SPIRIT_DEBUG
+    template <typename Op>
+    struct op1_out {
+      static const std::string value;
+    };
 #endif
 
-    template<typename Op>
+    template <typename Op>
     struct ExpressionUnaryOperatorSetter {
-      ExpressionUnaryOperatorSetter(ExpressionStack & stack) : stack_(stack) { }
+      ExpressionUnaryOperatorSetter(ExpressionStack& stack) : stack_(stack) {}
       void operator()(const char*, const char*) const {
-#ifdef BOOST_SPIRIT_DEBUG 
-	BOOST_SPIRIT_DEBUG_OUT << "pushing unary operator" << op1_out<Op>::value << std::endl;
-#endif	
-	stack_.push_back(ExpressionPtr(new ExpressionUnaryOperator<Op>(stack_)));
+#ifdef BOOST_SPIRIT_DEBUG
+        BOOST_SPIRIT_DEBUG_OUT << "pushing unary operator" << op1_out<Op>::value << std::endl;
+#endif
+        stack_.push_back(ExpressionPtr(new ExpressionUnaryOperator<Op>(stack_)));
       }
+
     private:
-      ExpressionStack & stack_;
+      ExpressionStack& stack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/ExpressionVar.cc
+++ b/CommonTools/Utils/src/ExpressionVar.cc
@@ -12,49 +12,37 @@
 using namespace reco::parser;
 using namespace std;
 
-void ExpressionVar::initObjects_()
-{
+void ExpressionVar::initObjects_() {
   objects_.resize(methods_.size());
   std::vector<edm::ObjectWithDict>::iterator IO = objects_.begin();
   for (std::vector<MethodInvoker>::const_iterator I = methods_.begin(), E = methods_.end(); I != E; ++IO, ++I) {
     if (I->isFunction()) {
       edm::TypeWithDict retType = I->method().finalReturnType();
       needsDestructor_.push_back(makeStorage(*IO, retType));
-    }
-    else {
+    } else {
       *IO = edm::ObjectWithDict();
       needsDestructor_.push_back(false);
     }
   }
 }
 
-ExpressionVar::ExpressionVar(const vector<MethodInvoker>& methods,
-                             method::TypeCode retType)
-  : methods_(methods)
-  , retType_(retType)
-{
+ExpressionVar::ExpressionVar(const vector<MethodInvoker>& methods, method::TypeCode retType)
+    : methods_(methods), retType_(retType) {
   initObjects_();
 }
 
-ExpressionVar::ExpressionVar(const ExpressionVar& rhs)
-  : methods_(rhs.methods_)
-  , retType_(rhs.retType_)
-{
+ExpressionVar::ExpressionVar(const ExpressionVar& rhs) : methods_(rhs.methods_), retType_(rhs.retType_) {
   initObjects_();
 }
 
-ExpressionVar::~ExpressionVar()
-{
-  for (std::vector<edm::ObjectWithDict>::iterator I = objects_.begin(),
-      E = objects_.end(); I != E; ++I) {
+ExpressionVar::~ExpressionVar() {
+  for (std::vector<edm::ObjectWithDict>::iterator I = objects_.begin(), E = objects_.end(); I != E; ++I) {
     delStorage(*I);
   }
   objects_.clear();
 }
 
-void
-ExpressionVar::delStorage(edm::ObjectWithDict& obj)
-{
+void ExpressionVar::delStorage(edm::ObjectWithDict& obj) {
   if (!obj.address()) {
     return;
   }
@@ -62,28 +50,22 @@ ExpressionVar::delStorage(edm::ObjectWithDict& obj)
     // just delete a void*, as that's what it was
     void** p = static_cast<void**>(obj.address());
     delete p;
-  }
-  else {
+  } else {
     //std::cout << "Calling Destruct on a " <<
     //  obj.typeOf().qualifiedName() << std::endl;
     obj.typeOf().deallocate(obj.address());
   }
 }
 
-bool
-ExpressionVar::makeStorage(edm::ObjectWithDict& obj,
-                           const edm::TypeWithDict& retType)
-{
+bool ExpressionVar::makeStorage(edm::ObjectWithDict& obj, const edm::TypeWithDict& retType) {
   static const edm::TypeWithDict tVoid(edm::TypeWithDict::byName("void"));
   bool ret = false;
   if (retType == tVoid) {
     obj = edm::ObjectWithDict::byType(tVoid);
-  }
-  else if (retType.isPointer() || retType.isReference()) {
+  } else if (retType.isPointer() || retType.isReference()) {
     // in this case, I have to allocate a void*, not an object!
     obj = edm::ObjectWithDict(retType, new void*);
-  }
-  else {
+  } else {
     obj = edm::ObjectWithDict(retType, retType.allocate());
     ret = retType.isClass();
     //std::cout << "ExpressionVar: reserved memory at "  << obj.address() <<
@@ -93,45 +75,44 @@ ExpressionVar::makeStorage(edm::ObjectWithDict& obj,
   return ret;
 }
 
-bool ExpressionVar::isValidReturnType(method::TypeCode retType)
-{
+bool ExpressionVar::isValidReturnType(method::TypeCode retType) {
   using namespace method;
   bool ret = false;
   switch (retType) {
-    case (doubleType) :
+    case (doubleType):
       ret = true;
       break;
-    case (floatType) :
+    case (floatType):
       ret = true;
       break;
-    case (intType) :
+    case (intType):
       ret = true;
       break;
-    case (uIntType) :
+    case (uIntType):
       ret = true;
       break;
-    case (shortType) :
+    case (shortType):
       ret = true;
       break;
-    case (uShortType) :
+    case (uShortType):
       ret = true;
       break;
-    case (longType) :
+    case (longType):
       ret = true;
       break;
-    case (uLongType) :
+    case (uLongType):
       ret = true;
       break;
-    case (charType) :
+    case (charType):
       ret = true;
       break;
-    case (uCharType) :
+    case (uCharType):
       ret = true;
       break;
-    case (boolType) :
+    case (boolType):
       ret = true;
       break;
-    case (enumType) :
+    case (enumType):
       ret = true;
       break;
     case (invalid):
@@ -141,8 +122,7 @@ bool ExpressionVar::isValidReturnType(method::TypeCode retType)
   return ret;
 }
 
-double ExpressionVar::value(const edm::ObjectWithDict& obj) const
-{
+double ExpressionVar::value(const edm::ObjectWithDict& obj) const {
   edm::ObjectWithDict val(obj);
   std::vector<edm::ObjectWithDict>::iterator IO = objects_.begin();
   for (std::vector<MethodInvoker>::const_iterator I = methods_.begin(), E = methods_.end(); I != E; ++I, ++IO) {
@@ -150,7 +130,8 @@ double ExpressionVar::value(const edm::ObjectWithDict& obj) const
   }
   double ret = objToDouble(val, retType_);
   std::vector<bool>::const_reverse_iterator RIB = needsDestructor_.rbegin();
-  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI = objects_.rbegin(), RE = objects_.rend(); RI != RE; ++RIB, ++RI) {
+  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI = objects_.rbegin(), RE = objects_.rend(); RI != RE;
+       ++RIB, ++RI) {
     if (*RIB) {
       RI->destruct(false);
     }
@@ -158,10 +139,7 @@ double ExpressionVar::value(const edm::ObjectWithDict& obj) const
   return ret;
 }
 
-double
-ExpressionVar::objToDouble(const edm::ObjectWithDict& obj,
-                           method::TypeCode type)
-{
+double ExpressionVar::objToDouble(const edm::ObjectWithDict& obj, method::TypeCode type) {
   using namespace method;
   void* addr = obj.address();
   double ret = 0.0;
@@ -210,18 +188,11 @@ ExpressionVar::objToDouble(const edm::ObjectWithDict& obj,
   return ret;
 }
 
-ExpressionLazyVar::ExpressionLazyVar(const std::vector<LazyInvoker>& methods)
-  : methods_(methods)
-{
-}
+ExpressionLazyVar::ExpressionLazyVar(const std::vector<LazyInvoker>& methods) : methods_(methods) {}
 
-ExpressionLazyVar::~ExpressionLazyVar()
-{
-}
+ExpressionLazyVar::~ExpressionLazyVar() {}
 
-double
-ExpressionLazyVar::value(const edm::ObjectWithDict& o) const
-{
+double ExpressionLazyVar::value(const edm::ObjectWithDict& o) const {
   edm::ObjectWithDict val = o;
   std::vector<LazyInvoker>::const_iterator I = methods_.begin();
   std::vector<LazyInvoker>::const_iterator E = methods_.end() - 1;
@@ -229,11 +200,10 @@ ExpressionLazyVar::value(const edm::ObjectWithDict& o) const
     val = I->invoke(val, objects_);
   }
   double ret = I->invokeLast(val, objects_);
-  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI =
-      objects_.rbegin(), RE = objects_.rend(); RI != RE; ++RI) {
+  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI = objects_.rbegin(), RE = objects_.rend(); RI != RE;
+       ++RI) {
     RI->destruct(false);
   }
   objects_.clear();
   return ret;
 }
-

--- a/CommonTools/Utils/src/ExpressionVar.h
+++ b/CommonTools/Utils/src/ExpressionVar.h
@@ -17,58 +17,56 @@
 #include <vector>
 
 namespace reco {
-namespace parser {
+  namespace parser {
 
-/// Evaluate an object's method or datamember (or chain of them) to get a number
-class ExpressionVar : public ExpressionBase {
-private: // Private Data Members
-  std::vector<MethodInvoker> methods_;
-  mutable std::vector<edm::ObjectWithDict> objects_;
-  mutable std::vector<bool> needsDestructor_;
-  method::TypeCode retType_;
+    /// Evaluate an object's method or datamember (or chain of them) to get a number
+    class ExpressionVar : public ExpressionBase {
+    private:  // Private Data Members
+      std::vector<MethodInvoker> methods_;
+      mutable std::vector<edm::ObjectWithDict> objects_;
+      mutable std::vector<bool> needsDestructor_;
+      method::TypeCode retType_;
 
-private: // Private Methods
-  void initObjects_();
+    private:  // Private Methods
+      void initObjects_();
 
-public: // Public Static Methods
-  static bool isValidReturnType(method::TypeCode);
+    public:  // Public Static Methods
+      static bool isValidReturnType(method::TypeCode);
 
-  /// performs the needed conversion from void* to double
-  /// this method is used also from the ExpressionLazyVar code
-  static double objToDouble(const edm::ObjectWithDict& obj,
-                            method::TypeCode type);
+      /// performs the needed conversion from void* to double
+      /// this method is used also from the ExpressionLazyVar code
+      static double objToDouble(const edm::ObjectWithDict& obj, method::TypeCode type);
 
-  /// allocate an object to hold the result of a given member (if needed)
-  /// this method is used also from the LazyInvoker code
-  /// returns true if objects returned from this will require a destructor
-  static bool makeStorage(edm::ObjectWithDict& obj,
-                          const edm::TypeWithDict& retType);
+      /// allocate an object to hold the result of a given member (if needed)
+      /// this method is used also from the LazyInvoker code
+      /// returns true if objects returned from this will require a destructor
+      static bool makeStorage(edm::ObjectWithDict& obj, const edm::TypeWithDict& retType);
 
-  /// delete an objecty, if needed
-  /// this method is used also from the LazyInvoker code
-  static void delStorage(edm::ObjectWithDict&);
+      /// delete an objecty, if needed
+      /// this method is used also from the LazyInvoker code
+      static void delStorage(edm::ObjectWithDict&);
 
-public: // Public Methods
-  ExpressionVar(const std::vector<MethodInvoker>& methods,
-                method::TypeCode retType);
-  ExpressionVar(const ExpressionVar&);
-  ~ExpressionVar() override;
-  double value(const edm::ObjectWithDict&) const override;
-};
+    public:  // Public Methods
+      ExpressionVar(const std::vector<MethodInvoker>& methods, method::TypeCode retType);
+      ExpressionVar(const ExpressionVar&);
+      ~ExpressionVar() override;
+      double value(const edm::ObjectWithDict&) const override;
+    };
 
-/// Same as ExpressionVar but with lazy resolution of object methods
-/// using the dynamic type of the object, and not the one fixed at compile time
-class ExpressionLazyVar : public ExpressionBase {
-private: // Private Data Members
-  std::vector<LazyInvoker> methods_;
-  mutable std::vector<edm::ObjectWithDict> objects_;
-public:
-  ExpressionLazyVar(const std::vector<LazyInvoker>& methods);
-  ~ExpressionLazyVar() override;
-  double value(const edm::ObjectWithDict&) const override;
-};
+    /// Same as ExpressionVar but with lazy resolution of object methods
+    /// using the dynamic type of the object, and not the one fixed at compile time
+    class ExpressionLazyVar : public ExpressionBase {
+    private:  // Private Data Members
+      std::vector<LazyInvoker> methods_;
+      mutable std::vector<edm::ObjectWithDict> objects_;
 
-} // namespace parser
-} // namespace reco
+    public:
+      ExpressionLazyVar(const std::vector<LazyInvoker>& methods);
+      ~ExpressionLazyVar() override;
+      double value(const edm::ObjectWithDict&) const override;
+    };
 
-#endif // CommonTools_Utils_ExpressionVar_h
+  }  // namespace parser
+}  // namespace reco
+
+#endif  // CommonTools_Utils_ExpressionVar_h

--- a/CommonTools/Utils/src/ExpressionVarSetter.cc
+++ b/CommonTools/Utils/src/ExpressionVarSetter.cc
@@ -6,28 +6,28 @@
 using namespace reco::parser;
 using namespace std;
 
-void ExpressionVarSetter::operator()(const char * begin, const char* end) const {
-  //std::cerr << "ExpressionVarSetter: Pushed [" << std::string(begin,end) << "]" << std::endl;  
-  if (!methStack_.empty())          push(begin,end);
-  else if (!lazyMethStack_.empty()) lazyPush(begin,end);
-  else throw Exception(begin) << " Expression didn't parse neither hastily nor lazyly. This must not happen.\n";
+void ExpressionVarSetter::operator()(const char *begin, const char *end) const {
+  //std::cerr << "ExpressionVarSetter: Pushed [" << std::string(begin,end) << "]" << std::endl;
+  if (!methStack_.empty())
+    push(begin, end);
+  else if (!lazyMethStack_.empty())
+    lazyPush(begin, end);
+  else
+    throw Exception(begin) << " Expression didn't parse neither hastily nor lazyly. This must not happen.\n";
 }
 
 void ExpressionVarSetter::push(const char *begin, const char *end) const {
   edm::TypeWithDict type = typeStack_.back();
   method::TypeCode retType = reco::typeCode(type);
-  if(retType == method::invalid) {
-    throw  Exception(begin)
-      << "member \"" << methStack_.back().methodName() << "\" has an invalid return type: \"" 
-      <<  methStack_.back().returnTypeName() << "\"";
+  if (retType == method::invalid) {
+    throw Exception(begin) << "member \"" << methStack_.back().methodName() << "\" has an invalid return type: \""
+                           << methStack_.back().returnTypeName() << "\"";
   }
-  if(!ExpressionVar::isValidReturnType(retType)) {
-     throw Exception(begin)
-       << "member \"" << methStack_.back().methodName() 
-       << "\" return type is \"" << methStack_.back().returnTypeName() 
-       << "\" which is not convertible to double.";
+  if (!ExpressionVar::isValidReturnType(retType)) {
+    throw Exception(begin) << "member \"" << methStack_.back().methodName() << "\" return type is \""
+                           << methStack_.back().returnTypeName() << "\" which is not convertible to double.";
   }
-  
+
   exprStack_.push_back(boost::shared_ptr<ExpressionBase>(new ExpressionVar(methStack_, retType)));
   methStack_.clear();
   typeStack_.resize(1);
@@ -38,4 +38,3 @@ void ExpressionVarSetter::lazyPush(const char *begin, const char *end) const {
   lazyMethStack_.clear();
   typeStack_.resize(1);
 }
-

--- a/CommonTools/Utils/src/ExpressionVarSetter.h
+++ b/CommonTools/Utils/src/ExpressionVarSetter.h
@@ -17,26 +17,23 @@
 namespace reco {
   namespace parser {
     struct ExpressionVarSetter {
-      ExpressionVarSetter(ExpressionStack & exprStack, 
-			  MethodStack & methStack, 
-			  LazyMethodStack & lazyMethStack, 
-			  TypeStack & typeStack) : 
-	exprStack_(exprStack), 
-	methStack_(methStack),
-	lazyMethStack_(lazyMethStack),
-	typeStack_(typeStack) { }
+      ExpressionVarSetter(ExpressionStack &exprStack,
+                          MethodStack &methStack,
+                          LazyMethodStack &lazyMethStack,
+                          TypeStack &typeStack)
+          : exprStack_(exprStack), methStack_(methStack), lazyMethStack_(lazyMethStack), typeStack_(typeStack) {}
       void operator()(const char *, const char *) const;
 
     private:
       void push(const char *, const char *) const;
       void lazyPush(const char *, const char *) const;
 
-      ExpressionStack & exprStack_;
-      MethodStack & methStack_;
-      LazyMethodStack & lazyMethStack_;
-      TypeStack & typeStack_;
+      ExpressionStack &exprStack_;
+      MethodStack &methStack_;
+      LazyMethodStack &lazyMethStack_;
+      TypeStack &typeStack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     FormulaEvaluator
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -39,12 +39,12 @@ namespace {
 
 #if defined(DEBUG_AST)
   void printAST(formula::EvaluatorBase* e) {
-    std::cout <<"printAST"<<std::endl;
-    for(auto const& n: e->abstractSyntaxTree()) {
-      std::cout <<n<<std::endl;
+    std::cout << "printAST" << std::endl;
+    for (auto const& n : e->abstractSyntaxTree()) {
+      std::cout << n << std::endl;
     }
   }
-#define DEBUG_STATE(_v_) std::cout <<_v_<<std::endl
+#define DEBUG_STATE(_v_) std::cout << _v_ << std::endl
 #else
   inline void printAST(void*) {}
 #define DEBUG_STATE(_v_)
@@ -53,9 +53,9 @@ namespace {
   struct EvaluatorInfo {
     std::shared_ptr<reco::formula::EvaluatorBase> evaluator;
     std::shared_ptr<reco::formula::EvaluatorBase> top;
-    int nextParseIndex=0;
-    unsigned int maxNumVariables=0;
-    unsigned int maxNumParameters=0;
+    int nextParseIndex = 0;
+    unsigned int maxNumVariables = 0;
+    unsigned int maxNumParameters = 0;
   };
 
   class ExpressionElementFinderBase {
@@ -67,16 +67,17 @@ namespace {
     virtual ~ExpressionElementFinderBase() = default;
   };
 
-  std::string::const_iterator findMatchingParenthesis(std::string::const_iterator iBegin, std::string::const_iterator iEnd) {
+  std::string::const_iterator findMatchingParenthesis(std::string::const_iterator iBegin,
+                                                      std::string::const_iterator iEnd) {
     if (iBegin == iEnd) {
       return iBegin;
     }
-    if( *iBegin != '(') {
+    if (*iBegin != '(') {
       return iBegin;
     }
     int level = 1;
     size_t index = 0;
-    for( auto it = iBegin+1; it != iEnd; ++it) {
+    for (auto it = iBegin + 1; it != iEnd; ++it) {
       ++index;
       if (*it == '(') {
         ++level;
@@ -92,7 +93,7 @@ namespace {
 
   class ConstantFinder : public ExpressionElementFinderBase {
     bool checkStart(char iSymbol) const final {
-      if( iSymbol == '-' or iSymbol == '.' or std::isdigit(iSymbol) ) {
+      if (iSymbol == '-' or iSymbol == '.' or std::isdigit(iSymbol)) {
         return true;
       }
       return false;
@@ -101,24 +102,23 @@ namespace {
     EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const final {
       EvaluatorInfo info;
       try {
-        size_t endIndex=0;
-        std::string s(iBegin,iEnd);
+        size_t endIndex = 0;
+        std::string s(iBegin, iEnd);
         double value = stod(s, &endIndex);
 
         info.nextParseIndex = endIndex;
         info.evaluator = std::make_shared<reco::formula::ConstantEvaluator>(value);
         info.top = info.evaluator;
-      } catch ( std::invalid_argument const& ) {}
+      } catch (std::invalid_argument const&) {
+      }
 
       return info;
-
     }
   };
 
-
   class ParameterFinder : public ExpressionElementFinderBase {
     bool checkStart(char iSymbol) const final {
-      if( iSymbol == '[') {
+      if (iSymbol == '[') {
         return true;
       }
       return false;
@@ -126,63 +126,70 @@ namespace {
 
     EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const final {
       EvaluatorInfo info;
-      if(iEnd == iBegin) {
+      if (iEnd == iBegin) {
         return info;
       }
-      if(*iBegin != '[') {
+      if (*iBegin != '[') {
         return info;
       }
       info.nextParseIndex = 1;
       try {
-        size_t endIndex=0;
-        std::string s(iBegin+1,iEnd);
+        size_t endIndex = 0;
+        std::string s(iBegin + 1, iEnd);
         unsigned long value = stoul(s, &endIndex);
-        
-        if( iBegin+endIndex+1 == iEnd or *(iBegin+1+endIndex) != ']' ) {
+
+        if (iBegin + endIndex + 1 == iEnd or *(iBegin + 1 + endIndex) != ']') {
           return info;
         }
-        
-        
-        info.nextParseIndex = endIndex+2;
-        info.maxNumParameters = value+1;
+
+        info.nextParseIndex = endIndex + 2;
+        info.maxNumParameters = value + 1;
         info.evaluator = std::make_shared<reco::formula::ParameterEvaluator>(value);
         info.top = info.evaluator;
-      } catch ( std::invalid_argument const& ) {}
-      
-      return info;
+      } catch (std::invalid_argument const&) {
+      }
 
+      return info;
     }
   };
-  
+
   class VariableFinder : public ExpressionElementFinderBase {
     bool checkStart(char iSymbol) const final {
-      if( iSymbol == 'x' or iSymbol == 'y' or iSymbol == 'z' or iSymbol == 't' ) {
+      if (iSymbol == 'x' or iSymbol == 'y' or iSymbol == 'z' or iSymbol == 't') {
         return true;
       }
       return false;
     }
-    
+
     EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const final {
       EvaluatorInfo info;
-      if(iBegin == iEnd) {
+      if (iBegin == iEnd) {
         return info;
       }
       unsigned int index = 4;
       switch (*iBegin) {
-      case 'x':
-        { index = 0; break;}
-      case 'y':
-        { index = 1; break;}
-      case 'z':
-        { index = 2; break;}
-      case 't':
-        {index = 3; break;}
+        case 'x': {
+          index = 0;
+          break;
+        }
+        case 'y': {
+          index = 1;
+          break;
+        }
+        case 'z': {
+          index = 2;
+          break;
+        }
+        case 't': {
+          index = 3;
+          break;
+        }
       }
-      if(index == 4) {
+      if (index == 4) {
         return info;
       }
       info.nextParseIndex = 1;
-      info.maxNumVariables = index+1;
+      info.maxNumVariables = index + 1;
       info.evaluator = std::make_shared<reco::formula::VariableEvaluator>(index);
       info.top = info.evaluator;
       return info;
@@ -193,12 +200,9 @@ namespace {
 
   class FunctionFinder : public ExpressionElementFinderBase {
   public:
-    FunctionFinder(ExpressionFinder const* iEF):
-      m_expressionFinder(iEF) {};
+    FunctionFinder(ExpressionFinder const* iEF) : m_expressionFinder(iEF){};
 
-    bool checkStart(char iSymbol) const final {
-      return std::isalpha(iSymbol);
-    }
+    bool checkStart(char iSymbol) const final { return std::isalpha(iSymbol); }
 
     EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const final;
 
@@ -206,13 +210,11 @@ namespace {
     ExpressionFinder const* m_expressionFinder;
   };
 
-
-  EvaluatorInfo createBinaryOperatorEvaluator( ExpressionFinder const&,
-                                               std::string::const_iterator iBegin,
-                                               std::string::const_iterator iEnd) ;
+  EvaluatorInfo createBinaryOperatorEvaluator(ExpressionFinder const&,
+                                              std::string::const_iterator iBegin,
+                                              std::string::const_iterator iEnd);
 
   class ExpressionFinder {
-
   public:
     ExpressionFinder() {
       m_elements.reserve(4);
@@ -221,56 +223,60 @@ namespace {
       m_elements.emplace_back(new ParameterFinder{});
       m_elements.emplace_back(new VariableFinder{});
     }
-  
+
     bool checkStart(char iChar) const {
-      if ( '(' == iChar or '-' == iChar or '+' ==iChar) {
+      if ('(' == iChar or '-' == iChar or '+' == iChar) {
         return true;
       }
-      for( auto const& e : m_elements) {
-        if (e->checkStart(iChar) ) {
+      for (auto const& e : m_elements) {
+        if (e->checkStart(iChar)) {
           return true;
         }
       }
       return false;
     }
 
-    EvaluatorInfo createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase> iPreviousBinary) const {
-      EvaluatorInfo leftEvaluatorInfo ;
+    EvaluatorInfo createEvaluator(std::string::const_iterator iBegin,
+                                  std::string::const_iterator iEnd,
+                                  std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase> iPreviousBinary) const {
+      EvaluatorInfo leftEvaluatorInfo;
 
-      if( iBegin == iEnd) {
+      if (iBegin == iEnd) {
         return leftEvaluatorInfo;
       }
       //Start with '+'
-      if (*iBegin == '+' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
-        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd, iPreviousBinary);
+      if (*iBegin == '+' and iEnd - iBegin > 1 and not std::isdigit(*(iBegin + 1))) {
+        leftEvaluatorInfo = createEvaluator(iBegin + 1, iEnd, iPreviousBinary);
 
         //have to account for the '+' we skipped over
-        leftEvaluatorInfo.nextParseIndex +=1;
-        if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
+        leftEvaluatorInfo.nextParseIndex += 1;
+        if (nullptr == leftEvaluatorInfo.evaluator.get()) {
           return leftEvaluatorInfo;
         }
       }
       //Start with '-'
-      else if (*iBegin == '-' and iEnd -iBegin > 1 and not std::isdigit( *(iBegin+1) ) ) {
-        leftEvaluatorInfo = createEvaluator(iBegin+1, iEnd,iPreviousBinary);
+      else if (*iBegin == '-' and iEnd - iBegin > 1 and not std::isdigit(*(iBegin + 1))) {
+        leftEvaluatorInfo = createEvaluator(iBegin + 1, iEnd, iPreviousBinary);
 
         //have to account for the '+' we skipped over
-        leftEvaluatorInfo.nextParseIndex +=1;
-        if( nullptr == leftEvaluatorInfo.evaluator.get() ) {
+        leftEvaluatorInfo.nextParseIndex += 1;
+        if (nullptr == leftEvaluatorInfo.evaluator.get()) {
           return leftEvaluatorInfo;
         }
-        leftEvaluatorInfo.evaluator = std::make_shared<reco::formula::UnaryMinusEvaluator>( std::move(leftEvaluatorInfo.top));
+        leftEvaluatorInfo.evaluator =
+            std::make_shared<reco::formula::UnaryMinusEvaluator>(std::move(leftEvaluatorInfo.top));
         leftEvaluatorInfo.top = leftEvaluatorInfo.evaluator;
       }
       //Start with '('
-      else if( *iBegin == '(') {
-        auto endParenthesis = findMatchingParenthesis(iBegin,iEnd);
-        if(iBegin== endParenthesis) {
+      else if (*iBegin == '(') {
+        auto endParenthesis = findMatchingParenthesis(iBegin, iEnd);
+        if (iBegin == endParenthesis) {
           return leftEvaluatorInfo;
         }
-        leftEvaluatorInfo = createEvaluator(iBegin+1,endParenthesis,std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
+        leftEvaluatorInfo =
+            createEvaluator(iBegin + 1, endParenthesis, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
         ++leftEvaluatorInfo.nextParseIndex;
-        if(leftEvaluatorInfo.evaluator.get() == nullptr) {
+        if (leftEvaluatorInfo.evaluator.get() == nullptr) {
           return leftEvaluatorInfo;
         }
         //need to account for closing parenthesis
@@ -282,10 +288,10 @@ namespace {
       } else {
         //Does not start with a '('
         int maxParseDistance = 0;
-        for( auto const& e: m_elements) {
-          if(e->checkStart(*iBegin) ) {
-            leftEvaluatorInfo = e->createEvaluator(iBegin,iEnd);
-            if(leftEvaluatorInfo.evaluator != nullptr) {
+        for (auto const& e : m_elements) {
+          if (e->checkStart(*iBegin)) {
+            leftEvaluatorInfo = e->createEvaluator(iBegin, iEnd);
+            if (leftEvaluatorInfo.evaluator != nullptr) {
               break;
             }
             if (leftEvaluatorInfo.nextParseIndex > maxParseDistance) {
@@ -293,14 +299,14 @@ namespace {
             }
           }
         }
-        if(leftEvaluatorInfo.evaluator.get() == nullptr) {
+        if (leftEvaluatorInfo.evaluator.get() == nullptr) {
           //failed to parse
           leftEvaluatorInfo.nextParseIndex = maxParseDistance;
           return leftEvaluatorInfo;
         }
       }
       //did we evaluate the full expression?
-      if(leftEvaluatorInfo.nextParseIndex == iEnd-iBegin) {
+      if (leftEvaluatorInfo.nextParseIndex == iEnd - iBegin) {
         if (iPreviousBinary) {
           iPreviousBinary->setRightEvaluator(leftEvaluatorInfo.top);
           leftEvaluatorInfo.top = iPreviousBinary;
@@ -311,8 +317,8 @@ namespace {
       }
 
       //see if this is a binary expression
-      auto fullExpression = createBinaryOperatorEvaluator(*this, iBegin+leftEvaluatorInfo.nextParseIndex, iEnd);
-      fullExpression.nextParseIndex +=leftEvaluatorInfo.nextParseIndex;
+      auto fullExpression = createBinaryOperatorEvaluator(*this, iBegin + leftEvaluatorInfo.nextParseIndex, iEnd);
+      fullExpression.nextParseIndex += leftEvaluatorInfo.nextParseIndex;
       fullExpression.maxNumVariables = std::max(leftEvaluatorInfo.maxNumVariables, fullExpression.maxNumVariables);
       fullExpression.maxNumParameters = std::max(leftEvaluatorInfo.maxNumParameters, fullExpression.maxNumParameters);
       if (iBegin + fullExpression.nextParseIndex != iEnd) {
@@ -320,7 +326,7 @@ namespace {
         fullExpression.evaluator.reset();
       }
 
-      if(fullExpression.evaluator == nullptr) {
+      if (fullExpression.evaluator == nullptr) {
         //we had a parsing problem
         return fullExpression;
       }
@@ -331,13 +337,13 @@ namespace {
       auto topNode = fullExpression.top;
       auto binaryEval = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>(fullExpression.evaluator.get());
       if (iPreviousBinary) {
-        if (iPreviousBinary->precedence() >= fullExpression.evaluator->precedence() ) {
+        if (iPreviousBinary->precedence() >= fullExpression.evaluator->precedence()) {
           DEBUG_STATE("prec >=");
           iPreviousBinary->setRightEvaluator(leftEvaluatorInfo.evaluator);
           binaryEval->setLeftEvaluator(iPreviousBinary);
         } else {
           binaryEval->setLeftEvaluator(leftEvaluatorInfo.evaluator);
-          if(iPreviousBinary->precedence()<topNode->precedence() ) {
+          if (iPreviousBinary->precedence() < topNode->precedence()) {
             DEBUG_STATE(" switch topNode");
             topNode = iPreviousBinary;
             iPreviousBinary->setRightEvaluator(fullExpression.top);
@@ -347,17 +353,19 @@ namespace {
             // to the present node and swap it with the rhs of the 'previous' binary expression
             // becuase we need the present expression to be evaluated earlier than the 'previous'.
             std::shared_ptr<reco::formula::EvaluatorBase> toSwap = iPreviousBinary;
-            auto parentBinary = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>(topNode.get()); 
+            auto parentBinary = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>(topNode.get());
             do {
-              if(parentBinary->lhs() == binaryEval or parentBinary->lhs()->precedence() > iPreviousBinary->precedence()) {
+              if (parentBinary->lhs() == binaryEval or
+                  parentBinary->lhs()->precedence() > iPreviousBinary->precedence()) {
                 parentBinary->swapLeftEvaluator(toSwap);
                 iPreviousBinary->setRightEvaluator(toSwap);
               } else {
                 //try the next one in the chain
-                parentBinary = const_cast<reco::formula::BinaryOperatorEvaluatorBase*>( dynamic_cast<const reco::formula::BinaryOperatorEvaluatorBase*>(parentBinary->lhs()));
+                parentBinary = const_cast<reco::formula::BinaryOperatorEvaluatorBase*>(
+                    dynamic_cast<const reco::formula::BinaryOperatorEvaluatorBase*>(parentBinary->lhs()));
                 assert(parentBinary != nullptr);
               }
-            } while(iPreviousBinary->rhs() == nullptr);
+            } while (iPreviousBinary->rhs() == nullptr);
           }
         }
       } else {
@@ -373,20 +381,19 @@ namespace {
 
   private:
     std::vector<std::unique_ptr<ExpressionElementFinderBase>> m_elements;
-
   };
 
-  template<typename Op>
+  template <typename Op>
   EvaluatorInfo createBinaryOperatorEvaluatorT(int iSymbolLength,
                                                reco::formula::EvaluatorBase::Precedence iPrec,
                                                ExpressionFinder const& iEF,
                                                std::string::const_iterator iBegin,
                                                std::string::const_iterator iEnd) {
-    auto op = std::make_shared<reco::formula::BinaryOperatorEvaluator<Op> >(iPrec);
-    EvaluatorInfo evalInfo = iEF.createEvaluator(iBegin+iSymbolLength,iEnd,op);
+    auto op = std::make_shared<reco::formula::BinaryOperatorEvaluator<Op>>(iPrec);
+    EvaluatorInfo evalInfo = iEF.createEvaluator(iBegin + iSymbolLength, iEnd, op);
     evalInfo.nextParseIndex += iSymbolLength;
 
-    if(evalInfo.evaluator.get() == nullptr) {
+    if (evalInfo.evaluator.get() == nullptr) {
       return evalInfo;
     }
 
@@ -395,160 +402,110 @@ namespace {
   }
 
   struct power {
-    double operator()(double iLHS, double iRHS) const {
-      return std::pow(iLHS,iRHS);
-    }
+    double operator()(double iLHS, double iRHS) const { return std::pow(iLHS, iRHS); }
   };
 
-
-  EvaluatorInfo 
-  createBinaryOperatorEvaluator( ExpressionFinder const& iEF,
-                                 std::string::const_iterator iBegin,
-                                 std::string::const_iterator iEnd) {
+  EvaluatorInfo createBinaryOperatorEvaluator(ExpressionFinder const& iEF,
+                                              std::string::const_iterator iBegin,
+                                              std::string::const_iterator iEnd) {
     EvaluatorInfo evalInfo;
-    if(iBegin == iEnd) {
+    if (iBegin == iEnd) {
       return evalInfo;
     }
 
-    if(*iBegin == '+') {
-      return createBinaryOperatorEvaluatorT<std::plus<double>>(1,
-                                                               reco::formula::EvaluatorBase::Precedence::kPlusMinus,
-                                                               iEF,
-                                                               iBegin,
-                                                               iEnd);
+    if (*iBegin == '+') {
+      return createBinaryOperatorEvaluatorT<std::plus<double>>(
+          1, reco::formula::EvaluatorBase::Precedence::kPlusMinus, iEF, iBegin, iEnd);
     }
 
-    else if(*iBegin == '-') {
-      return createBinaryOperatorEvaluatorT<std::minus<double>>(1,
-                                                                reco::formula::EvaluatorBase::Precedence::kPlusMinus,
-                                                                iEF,
-                                                                iBegin,
-                                                                iEnd);
-    }
-    else if(*iBegin == '*') {
-      return createBinaryOperatorEvaluatorT<std::multiplies<double>>(1,
-                                                                     reco::formula::EvaluatorBase::Precedence::kMultDiv,
-                                                                     iEF,
-                                                                     iBegin,
-                                                                     iEnd);
-    }
-    else if(*iBegin == '/') {
-      return createBinaryOperatorEvaluatorT<std::divides<double>>(1,
-                                                                  reco::formula::EvaluatorBase::Precedence::kMultDiv,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
+    else if (*iBegin == '-') {
+      return createBinaryOperatorEvaluatorT<std::minus<double>>(
+          1, reco::formula::EvaluatorBase::Precedence::kPlusMinus, iEF, iBegin, iEnd);
+    } else if (*iBegin == '*') {
+      return createBinaryOperatorEvaluatorT<std::multiplies<double>>(
+          1, reco::formula::EvaluatorBase::Precedence::kMultDiv, iEF, iBegin, iEnd);
+    } else if (*iBegin == '/') {
+      return createBinaryOperatorEvaluatorT<std::divides<double>>(
+          1, reco::formula::EvaluatorBase::Precedence::kMultDiv, iEF, iBegin, iEnd);
     }
 
-    else if(*iBegin == '^') {
-      return createBinaryOperatorEvaluatorT<power>(1,
-                                                                  reco::formula::EvaluatorBase::Precedence::kPower,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
-    }
-    else if (*iBegin =='<' and iBegin+1 != iEnd and *(iBegin+1) == '=') {
-      return createBinaryOperatorEvaluatorT<std::less_equal<double>>(2,
-                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
+    else if (*iBegin == '^') {
+      return createBinaryOperatorEvaluatorT<power>(
+          1, reco::formula::EvaluatorBase::Precedence::kPower, iEF, iBegin, iEnd);
+    } else if (*iBegin == '<' and iBegin + 1 != iEnd and *(iBegin + 1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::less_equal<double>>(
+          2, reco::formula::EvaluatorBase::Precedence::kComparison, iEF, iBegin, iEnd);
 
-    }
-    else if (*iBegin =='>' and iBegin+1 != iEnd and *(iBegin+1) == '=') {
-      return createBinaryOperatorEvaluatorT<std::greater_equal<double>>(2,
-                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
+    } else if (*iBegin == '>' and iBegin + 1 != iEnd and *(iBegin + 1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::greater_equal<double>>(
+          2, reco::formula::EvaluatorBase::Precedence::kComparison, iEF, iBegin, iEnd);
 
-    }
-    else if (*iBegin =='<' ) {
-      return createBinaryOperatorEvaluatorT<std::less<double>>(1,
-                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
+    } else if (*iBegin == '<') {
+      return createBinaryOperatorEvaluatorT<std::less<double>>(
+          1, reco::formula::EvaluatorBase::Precedence::kComparison, iEF, iBegin, iEnd);
 
-    }
-    else if (*iBegin =='>' ) {
-      return createBinaryOperatorEvaluatorT<std::greater<double>>(1,
-                                                                  reco::formula::EvaluatorBase::Precedence::kComparison,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
+    } else if (*iBegin == '>') {
+      return createBinaryOperatorEvaluatorT<std::greater<double>>(
+          1, reco::formula::EvaluatorBase::Precedence::kComparison, iEF, iBegin, iEnd);
 
-    }
-    else if (*iBegin =='=' and iBegin+1 != iEnd and *(iBegin+1) == '=' ) {
-      return createBinaryOperatorEvaluatorT<std::equal_to<double>>(2,
-                                                                  reco::formula::EvaluatorBase::Precedence::kIdentity,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
+    } else if (*iBegin == '=' and iBegin + 1 != iEnd and *(iBegin + 1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::equal_to<double>>(
+          2, reco::formula::EvaluatorBase::Precedence::kIdentity, iEF, iBegin, iEnd);
 
-    }
-    else if (*iBegin =='!' and iBegin+1 != iEnd and *(iBegin+1) == '=' ) {
-      return createBinaryOperatorEvaluatorT<std::not_equal_to<double>>(2,
-                                                                  reco::formula::EvaluatorBase::Precedence::kIdentity,
-                                                                  iEF,
-                                                                  iBegin,
-                                                                  iEnd);
-
+    } else if (*iBegin == '!' and iBegin + 1 != iEnd and *(iBegin + 1) == '=') {
+      return createBinaryOperatorEvaluatorT<std::not_equal_to<double>>(
+          2, reco::formula::EvaluatorBase::Precedence::kIdentity, iEF, iBegin, iEnd);
     }
     return evalInfo;
   }
 
-
-  template<typename Op>
-  EvaluatorInfo
-  checkForSingleArgFunction(std::string::const_iterator iBegin,
-                            std::string::const_iterator iEnd,
-                            ExpressionFinder const* iExpressionFinder,
-                            const std::string& iName,
-                            Op op) {
+  template <typename Op>
+  EvaluatorInfo checkForSingleArgFunction(std::string::const_iterator iBegin,
+                                          std::string::const_iterator iEnd,
+                                          ExpressionFinder const* iExpressionFinder,
+                                          const std::string& iName,
+                                          Op op) {
     EvaluatorInfo info;
-    if(iName.size()+2 > static_cast<unsigned int>(iEnd-iBegin) ) {
+    if (iName.size() + 2 > static_cast<unsigned int>(iEnd - iBegin)) {
       return info;
     }
-    auto pos = iName.find(&(*iBegin), 0,iName.size());
+    auto pos = iName.find(&(*iBegin), 0, iName.size());
 
-    if(std::string::npos == pos or *(iBegin+iName.size()) != '(') {
-      return info;
-    }
-    
-    info.nextParseIndex = iName.size()+1;
-
-    auto itEndParen = findMatchingParenthesis(iBegin+iName.size(),iEnd);
-    if(iBegin+iName.size() == itEndParen) {
+    if (std::string::npos == pos or *(iBegin + iName.size()) != '(') {
       return info;
     }
 
-    auto argEvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itEndParen,
-                                                               std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
+    info.nextParseIndex = iName.size() + 1;
+
+    auto itEndParen = findMatchingParenthesis(iBegin + iName.size(), iEnd);
+    if (iBegin + iName.size() == itEndParen) {
+      return info;
+    }
+
+    auto argEvaluatorInfo = iExpressionFinder->createEvaluator(
+        iBegin + iName.size() + 1, itEndParen, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
     info.nextParseIndex += argEvaluatorInfo.nextParseIndex;
-    if(argEvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
+    if (argEvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex + 1 != 1 + itEndParen - iBegin) {
       return info;
     }
     //account for closing parenthesis
     ++info.nextParseIndex;
 
-    info.evaluator = std::make_shared<reco::formula::FunctionOneArgEvaluator>(std::move(argEvaluatorInfo.top),
-                                                                              op);
+    info.evaluator = std::make_shared<reco::formula::FunctionOneArgEvaluator>(std::move(argEvaluatorInfo.top), op);
     info.top = info.evaluator;
     return info;
   }
 
   std::string::const_iterator findCommaNotInParenthesis(std::string::const_iterator iBegin,
-                                                        std::string::const_iterator iEnd ) {
+                                                        std::string::const_iterator iEnd) {
     int level = 0;
     std::string::const_iterator it = iBegin;
-    for(; it != iEnd; ++it) {
+    for (; it != iEnd; ++it) {
       if (*it == '(') {
         ++level;
-      } else if(*it == ')') {
+      } else if (*it == ')') {
         --level;
-      }
-      else if( *it ==',' and level == 0 ) {
+      } else if (*it == ',' and level == 0) {
         return it;
       }
     }
@@ -556,53 +513,52 @@ namespace {
     return it;
   }
 
-
-  template<typename Op>
-  EvaluatorInfo
-  checkForTwoArgsFunction(std::string::const_iterator iBegin,
-                          std::string::const_iterator iEnd,
-                          ExpressionFinder const* iExpressionFinder,
-                          const std::string& iName,
-                          Op op) {
+  template <typename Op>
+  EvaluatorInfo checkForTwoArgsFunction(std::string::const_iterator iBegin,
+                                        std::string::const_iterator iEnd,
+                                        ExpressionFinder const* iExpressionFinder,
+                                        const std::string& iName,
+                                        Op op) {
     EvaluatorInfo info;
-    if(iName.size()+2 > static_cast<unsigned int>(iEnd-iBegin) ) {
+    if (iName.size() + 2 > static_cast<unsigned int>(iEnd - iBegin)) {
       return info;
     }
-    auto pos = iName.find(&(*iBegin), 0,iName.size());
+    auto pos = iName.find(&(*iBegin), 0, iName.size());
 
-    if(std::string::npos == pos or *(iBegin+iName.size()) != '(') {
-      return info;
-    }
-    
-    info.nextParseIndex = iName.size()+1;
-
-    auto itEndParen = findMatchingParenthesis(iBegin+iName.size(),iEnd);
-    if(iBegin+iName.size() == itEndParen) {
+    if (std::string::npos == pos or *(iBegin + iName.size()) != '(') {
       return info;
     }
 
-    auto itComma = findCommaNotInParenthesis(iBegin+iName.size()+1, itEndParen);
+    info.nextParseIndex = iName.size() + 1;
 
-    auto arg1EvaluatorInfo = iExpressionFinder->createEvaluator(iBegin+iName.size()+1, itComma, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
+    auto itEndParen = findMatchingParenthesis(iBegin + iName.size(), iEnd);
+    if (iBegin + iName.size() == itEndParen) {
+      return info;
+    }
+
+    auto itComma = findCommaNotInParenthesis(iBegin + iName.size() + 1, itEndParen);
+
+    auto arg1EvaluatorInfo = iExpressionFinder->createEvaluator(
+        iBegin + iName.size() + 1, itComma, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
     info.nextParseIndex += arg1EvaluatorInfo.nextParseIndex;
-    if(arg1EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex != itComma-iBegin ) {
+    if (arg1EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex != itComma - iBegin) {
       return info;
     }
     //account for commas
     ++info.nextParseIndex;
 
-    auto arg2EvaluatorInfo = iExpressionFinder->createEvaluator(itComma+1, itEndParen, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
+    auto arg2EvaluatorInfo = iExpressionFinder->createEvaluator(
+        itComma + 1, itEndParen, std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
     info.nextParseIndex += arg2EvaluatorInfo.nextParseIndex;
 
-    if(arg2EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex+1 != 1+itEndParen - iBegin) {
+    if (arg2EvaluatorInfo.evaluator.get() == nullptr or info.nextParseIndex + 1 != 1 + itEndParen - iBegin) {
       return info;
     }
     //account for closing parenthesis
     ++info.nextParseIndex;
 
-    info.evaluator = std::make_shared<reco::formula::FunctionTwoArgsEvaluator>(std::move(arg1EvaluatorInfo.top),
-                                                                               std::move(arg2EvaluatorInfo.top),
-                                                                               op);
+    info.evaluator = std::make_shared<reco::formula::FunctionTwoArgsEvaluator>(
+        std::move(arg1EvaluatorInfo.top), std::move(arg2EvaluatorInfo.top), op);
     info.top = info.evaluator;
     return info;
   }
@@ -610,7 +566,7 @@ namespace {
   const std::string k_log("log");
   const std::string k_log10("log10");
   const std::string k_TMath__Log("TMath::Log");
-  double const kLog10Inv = 1./std::log(10.);
+  double const kLog10Inv = 1. / std::log(10.);
   const std::string k_exp("exp");
   const std::string k_pow("pow");
   const std::string k_TMath__Power("TMath::Power");
@@ -626,110 +582,118 @@ namespace {
   const std::string k_abs("abs");
   const std::string k_TMath__Abs("TMath::Abs");
 
-
-  EvaluatorInfo 
-  FunctionFinder::createEvaluator(std::string::const_iterator iBegin, std::string::const_iterator iEnd) const {
+  EvaluatorInfo FunctionFinder::createEvaluator(std::string::const_iterator iBegin,
+                                                std::string::const_iterator iEnd) const {
     EvaluatorInfo info;
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_erf, [](double iArg)->double { return std::erf(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_erf, [](double iArg) -> double { return std::erf(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_TMath__Erf, [](double iArg)->double { return std::erf(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Erf, [](double iArg) -> double { return std::erf(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_TMath__Landau, [](double iArg)->double { return TMath::Landau(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Landau, [](double iArg) -> double { return TMath::Landau(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_log, [](double iArg)->double { return std::log(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_log, [](double iArg) -> double { return std::log(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_TMath__Log, [](double iArg)->double { return std::log(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Log, [](double iArg) -> double { return std::log(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_log10, [](double iArg)->double { return std::log(iArg)*kLog10Inv; } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_log10, [](double iArg) -> double { return std::log(iArg) * kLog10Inv; });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_exp, [](double iArg)->double { return std::exp(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_exp, [](double iArg) -> double { return std::exp(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_sqrt, [](double iArg)->double { return std::sqrt(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_sqrt, [](double iArg) -> double { return std::sqrt(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_TMath__Sqrt, [](double iArg)->double { return std::sqrt(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Sqrt, [](double iArg) -> double { return std::sqrt(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_abs, [](double iArg)->double { return std::abs(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_abs, [](double iArg) -> double { return std::abs(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
-                                     k_TMath__Abs, [](double iArg)->double { return std::abs(iArg); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Abs, [](double iArg) -> double { return std::abs(iArg); });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
-                                   k_pow, [](double iArg1, double iArg2)->double { return std::pow(iArg1,iArg2); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder, k_pow, [](double iArg1, double iArg2) -> double {
+      return std::pow(iArg1, iArg2);
+    });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
-                                   k_TMath__Power, [](double iArg1, double iArg2)->double { return std::pow(iArg1,iArg2); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForTwoArgsFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Power, [](double iArg1, double iArg2) -> double {
+          return std::pow(iArg1, iArg2);
+        });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
-                                   k_max, [](double iArg1, double iArg2)->double { return std::max(iArg1,iArg2); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder, k_max, [](double iArg1, double iArg2) -> double {
+      return std::max(iArg1, iArg2);
+    });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
-                                   k_min, [](double iArg1, double iArg2)->double { return std::min(iArg1,iArg2); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder, k_min, [](double iArg1, double iArg2) -> double {
+      return std::min(iArg1, iArg2);
+    });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
-                                   k_TMath__Max, [](double iArg1, double iArg2)->double { return std::max(iArg1,iArg2); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForTwoArgsFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Max, [](double iArg1, double iArg2) -> double {
+          return std::max(iArg1, iArg2);
+        });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
-    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder,
-                                   k_TMath__Min, [](double iArg1, double iArg2)->double { return std::min(iArg1,iArg2); } );
-    if(info.evaluator.get() != nullptr) {
+    info = checkForTwoArgsFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Min, [](double iArg1, double iArg2) -> double {
+          return std::min(iArg1, iArg2);
+        });
+    if (info.evaluator.get() != nullptr) {
       return info;
     }
 
@@ -737,8 +701,8 @@ namespace {
   };
 
   ExpressionFinder const s_expressionFinder;
-  
-}
+
+}  // namespace
 //
 // constants, enums and typedefs
 //
@@ -750,32 +714,34 @@ namespace {
 //
 // constructors and destructor
 //
-FormulaEvaluator::FormulaEvaluator( std::string const& iFormula )
-{
+FormulaEvaluator::FormulaEvaluator(std::string const& iFormula) {
   //remove white space
   std::string formula;
   formula.reserve(iFormula.size());
-  std::copy_if(iFormula.begin(), iFormula.end(), std::back_inserter(formula), [](const char iC) { return iC != ' '; } );
+  std::copy_if(iFormula.begin(), iFormula.end(), std::back_inserter(formula), [](const char iC) { return iC != ' '; });
 
-  auto info  = s_expressionFinder.createEvaluator(formula.begin(), formula.end(),std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
+  auto info = s_expressionFinder.createEvaluator(
+      formula.begin(), formula.end(), std::shared_ptr<reco::formula::BinaryOperatorEvaluatorBase>());
 
-  if(info.nextParseIndex != static_cast<int>(formula.size()) or info.top.get() == nullptr) {
+  if (info.nextParseIndex != static_cast<int>(formula.size()) or info.top.get() == nullptr) {
     auto lastIndex = info.nextParseIndex;
-    if(formula.size() != iFormula.size()) {
-      lastIndex =0;
-      for(decltype(info.nextParseIndex) index=0; index < info.nextParseIndex; ++index, ++lastIndex) {
-        while(iFormula[lastIndex] != formula[index]) { 
-          assert(iFormula[lastIndex]==' '); 
-          ++lastIndex; 
+    if (formula.size() != iFormula.size()) {
+      lastIndex = 0;
+      for (decltype(info.nextParseIndex) index = 0; index < info.nextParseIndex; ++index, ++lastIndex) {
+        while (iFormula[lastIndex] != formula[index]) {
+          assert(iFormula[lastIndex] == ' ');
+          ++lastIndex;
         }
       }
     }
-    throw cms::Exception("FormulaEvaluatorParseError")<<"While parsing '"<<iFormula<<"' could not parse beyond '"<<std::string(iFormula.begin(),iFormula.begin()+lastIndex) <<"'";
+    throw cms::Exception("FormulaEvaluatorParseError")
+        << "While parsing '" << iFormula << "' could not parse beyond '"
+        << std::string(iFormula.begin(), iFormula.begin() + lastIndex) << "'";
   }
 
   DEBUG_STATE("DONE parsing");
   printAST(info.top.get());
-  
+
   m_evaluator = std::move(info.top);
   m_nVariables = info.maxNumVariables;
   m_nParameters = info.maxNumParameters;
@@ -784,22 +750,17 @@ FormulaEvaluator::FormulaEvaluator( std::string const& iFormula )
 //
 // const member functions
 //
-double
-FormulaEvaluator::evaluate(double const* iVariables, double const* iParameters) const
-{
+double FormulaEvaluator::evaluate(double const* iVariables, double const* iParameters) const {
   return m_evaluator->evaluate(iVariables, iParameters);
 }
 
-void 
-FormulaEvaluator::throwWrongNumberOfVariables(size_t iSize) const {
-  throw cms::Exception("WrongNumVariables")<<"FormulaEvaluator expected at least "<<m_nVariables<<" but was passed only "<<iSize;
+void FormulaEvaluator::throwWrongNumberOfVariables(size_t iSize) const {
+  throw cms::Exception("WrongNumVariables")
+      << "FormulaEvaluator expected at least " << m_nVariables << " but was passed only " << iSize;
 }
-void 
-FormulaEvaluator::throwWrongNumberOfParameters(size_t iSize) const {
-  throw cms::Exception("WrongNumParameters")<<"FormulaEvaluator expected at least "<<m_nParameters<<" but was passed only "<<iSize;
+void FormulaEvaluator::throwWrongNumberOfParameters(size_t iSize) const {
+  throw cms::Exception("WrongNumParameters")
+      << "FormulaEvaluator expected at least " << m_nParameters << " but was passed only " << iSize;
 }
 
-std::vector<std::string> 
-FormulaEvaluator::abstractSyntaxTree() const {
-  return m_evaluator->abstractSyntaxTree();
-}
+std::vector<std::string> FormulaEvaluator::abstractSyntaxTree() const { return m_evaluator->abstractSyntaxTree(); }

--- a/CommonTools/Utils/src/Function.h
+++ b/CommonTools/Utils/src/Function.h
@@ -9,25 +9,44 @@
  * \version $Revision: 1.3 $
  *
  */
-#ifdef BOOST_SPIRIT_DEBUG 
+#ifdef BOOST_SPIRIT_DEBUG
 #include <string>
 #endif
 
 namespace reco {
-  namespace parser {    
-    enum Function { 
-      kAbs, kAcos, kAsin, kAtan, kAtan2, kChi2Prob, kCos, kCosh, kExp, kHypot,
-      kLog, kLog10, kMax, kMin, kPow, kSin, kSinh, kSqrt, kTan, kTanh,
-      kDeltaR, kDeltaPhi, kTestBit
+  namespace parser {
+    enum Function {
+      kAbs,
+      kAcos,
+      kAsin,
+      kAtan,
+      kAtan2,
+      kChi2Prob,
+      kCos,
+      kCosh,
+      kExp,
+      kHypot,
+      kLog,
+      kLog10,
+      kMax,
+      kMin,
+      kPow,
+      kSin,
+      kSinh,
+      kSqrt,
+      kTan,
+      kTanh,
+      kDeltaR,
+      kDeltaPhi,
+      kTestBit
     };
 
-#ifdef BOOST_SPIRIT_DEBUG 
-  static const std::string functionNames[] = 
-    { "abs", "acos", "asin", "atan", "atan2", "chi2prob", "cos", "cosh", "exp", "hypot", 
-      "log", "log10", "max", "min", "pow", "sin", "sinh", "sqrt", "tan", "tanh",
-      "deltaR", "deltaPhi", "test_bit" };
+#ifdef BOOST_SPIRIT_DEBUG
+    static const std::string functionNames[] = {
+        "abs", "acos", "asin", "atan", "atan2", "chi2prob", "cos", "cosh", "exp",    "hypot",    "log",     "log10",
+        "max", "min",  "pow",  "sin",  "sinh",  "sqrt",     "tan", "tanh", "deltaR", "deltaPhi", "test_bit"};
 #endif
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/FunctionSetter.h
+++ b/CommonTools/Utils/src/FunctionSetter.h
@@ -13,34 +13,34 @@
 #include "CommonTools/Utils/src/FunctionStack.h"
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct FunctionSetter {
-      FunctionSetter(Function fun, FunctionStack& stack):
-	fun_(fun), stack_(stack) {}
-      
-      void operator()(const char *, const char *) const { 
-#ifdef BOOST_SPIRIT_DEBUG 
-	BOOST_SPIRIT_DEBUG_OUT << "pushing math function: " << functionNames[ fun_ ] << std::endl;
+      FunctionSetter(Function fun, FunctionStack& stack) : fun_(fun), stack_(stack) {}
+
+      void operator()(const char*, const char*) const {
+#ifdef BOOST_SPIRIT_DEBUG
+        BOOST_SPIRIT_DEBUG_OUT << "pushing math function: " << functionNames[fun_] << std::endl;
 #endif
-	stack_.push_back(fun_); 
+        stack_.push_back(fun_);
       }
+
     private:
       Function fun_;
-      FunctionStack & stack_;
+      FunctionStack& stack_;
     };
 
-    struct FunctionSetterCommit { 
-        FunctionSetterCommit(FunctionStack& stackFrom, FunctionStack& stackTo):
-            from_(stackFrom), to_(stackTo) {}
-        void operator()(const char &) const { 
-            to_.push_back(from_.back());
-            from_.clear();
-        }
-        private:
-            FunctionStack & from_;
-            FunctionStack & to_;
+    struct FunctionSetterCommit {
+      FunctionSetterCommit(FunctionStack& stackFrom, FunctionStack& stackTo) : from_(stackFrom), to_(stackTo) {}
+      void operator()(const char&) const {
+        to_.push_back(from_.back());
+        from_.clear();
+      }
+
+    private:
+      FunctionStack& from_;
+      FunctionStack& to_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/FunctionStack.h
+++ b/CommonTools/Utils/src/FunctionStack.h
@@ -13,9 +13,9 @@
 #include <vector>
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     typedef std::vector<Function> FunctionStack;
   }
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/Grammar.h
+++ b/CommonTools/Utils/src/Grammar.h
@@ -41,205 +41,173 @@
 // #include "CommonTools/Utils/src/Abort.h"
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct Grammar : public boost::spirit::classic::grammar<Grammar> {
-       
       SelectorPtr dummySel_;
       ExpressionPtr dummyExpr_;
-      SelectorPtr * sel_; 
-      ExpressionPtr * expr_;
-      bool            lazy_;
+      SelectorPtr* sel_;
+      ExpressionPtr* expr_;
+      bool lazy_;
       mutable ExpressionStack exprStack;
       mutable ComparisonStack cmpStack;
       mutable SelectorStack selStack;
       mutable FunctionStack funStack, finalFunStack;
-      mutable MethodStack         methStack;
-      mutable LazyMethodStack     lazyMethStack;
+      mutable MethodStack methStack;
+      mutable LazyMethodStack lazyMethStack;
       mutable MethodArgumentStack methArgStack;
       mutable TypeStack typeStack;
       mutable IntStack intStack;
 
-      Grammar(SelectorPtr & sel, const edm::TypeWithDict& iType, bool lazy=false) : 
-   	sel_(& sel), expr_(& dummyExpr_), lazy_(lazy) { 
-   	typeStack.push_back(iType);
+      Grammar(SelectorPtr& sel, const edm::TypeWithDict& iType, bool lazy = false)
+          : sel_(&sel), expr_(&dummyExpr_), lazy_(lazy) {
+        typeStack.push_back(iType);
       }
 
-      Grammar(ExpressionPtr & expr, const edm::TypeWithDict& iType, bool lazy=false) : 
-   	sel_(& dummySel_), expr_(& expr), lazy_(lazy) { 
-   	typeStack.push_back(iType);
+      Grammar(ExpressionPtr& expr, const edm::TypeWithDict& iType, bool lazy = false)
+          : sel_(&dummySel_), expr_(&expr), lazy_(lazy) {
+        typeStack.push_back(iType);
       }
 
       template <typename ScannerT>
-      struct definition : 
-	public boost::spirit::classic::grammar_def<boost::spirit::classic::rule<ScannerT>, 
-						   boost::spirit::classic::same, 
-						   boost::spirit::classic::same>{  
-	typedef boost::spirit::classic::rule<ScannerT> rule;
-	rule number, var, arrayAccess, metharg, method, term, power, factor, function1, function2, function4, expression, 
-	  comparison_op, binary_comp, trinary_comp,
-	  logical_combiner, logical_expression, nocond_expression, cond_expression, logical_factor, logical_term,
-	  or_op, and_op, cut, fun;
-	definition(const Grammar & self) {
-	  using namespace boost::spirit::classic;
-	  using namespace std;
+      struct definition : public boost::spirit::classic::grammar_def<boost::spirit::classic::rule<ScannerT>,
+                                                                     boost::spirit::classic::same,
+                                                                     boost::spirit::classic::same> {
+        typedef boost::spirit::classic::rule<ScannerT> rule;
+        rule number, var, arrayAccess, metharg, method, term, power, factor, function1, function2, function4,
+            expression, comparison_op, binary_comp, trinary_comp, logical_combiner, logical_expression,
+            nocond_expression, cond_expression, logical_factor, logical_term, or_op, and_op, cut, fun;
+        definition(const Grammar& self) {
+          using namespace boost::spirit::classic;
+          using namespace std;
 
-	  ExpressionNumberSetter number_s(self.exprStack);
-	  IntSetter int_s(self.intStack);
-	  ExpressionVarSetter var_s(self.exprStack, self.methStack, self.lazyMethStack, self.typeStack);
-	  ExpressionConditionSetter cond_s(self.exprStack, self.selStack);
-	  MethodArgumentSetter methodArg_s(self.methArgStack);
-	  MethodSetter method_s(self.methStack, self.lazyMethStack, self.typeStack, self.methArgStack, self.lazy_);
-	  ComparisonSetter<less_equal<double> > less_equal_s(self.cmpStack);
-	  ComparisonSetter<less<double> > less_s(self.cmpStack);
-	  ComparisonSetter<equal_to<double> > equal_to_s(self.cmpStack);
-	  ComparisonSetter<greater_equal<double> > greater_equal_s(self.cmpStack);
-	  ComparisonSetter<greater<double> > greater_s(self.cmpStack);
-	  ComparisonSetter<not_equal_to<double> > not_equal_to_s(self.cmpStack);
-	  FunctionSetter 
-	    abs_s(kAbs, self.funStack), acos_s(kAcos, self.funStack), asin_s(kAsin, self.funStack),
-	    atan2_s(kAtan, self.funStack), atan_s(kAtan, self.funStack), 
-	    chi2prob_s(kChi2Prob, self.funStack), 
-            cosh_s(kCosh, self.funStack), 
-	    cos_s(kCos, self.funStack), exp_s(kExp, self.funStack), hypot_s(kHypot, self.funStack), log_s(kLog, self.funStack), 
-	    log10_s(kLog10, self.funStack), max_s(kMax, self.funStack), min_s(kMin, self.funStack),
-	    pow_s(kPow, self.funStack), sinh_s(kSinh, self.funStack), 
-	    sin_s(kSin, self.funStack), sqrt_s(kSqrt, self.funStack), tanh_s(kTanh, self.funStack), 
-	    tan_s(kTan, self.funStack),
-            deltaPhi_s(kDeltaPhi, self.funStack), deltaR_s(kDeltaR, self.funStack), 
-            test_bit_s(kTestBit, self.funStack);
+          ExpressionNumberSetter number_s(self.exprStack);
+          IntSetter int_s(self.intStack);
+          ExpressionVarSetter var_s(self.exprStack, self.methStack, self.lazyMethStack, self.typeStack);
+          ExpressionConditionSetter cond_s(self.exprStack, self.selStack);
+          MethodArgumentSetter methodArg_s(self.methArgStack);
+          MethodSetter method_s(self.methStack, self.lazyMethStack, self.typeStack, self.methArgStack, self.lazy_);
+          ComparisonSetter<less_equal<double> > less_equal_s(self.cmpStack);
+          ComparisonSetter<less<double> > less_s(self.cmpStack);
+          ComparisonSetter<equal_to<double> > equal_to_s(self.cmpStack);
+          ComparisonSetter<greater_equal<double> > greater_equal_s(self.cmpStack);
+          ComparisonSetter<greater<double> > greater_s(self.cmpStack);
+          ComparisonSetter<not_equal_to<double> > not_equal_to_s(self.cmpStack);
+          FunctionSetter abs_s(kAbs, self.funStack), acos_s(kAcos, self.funStack), asin_s(kAsin, self.funStack),
+              atan2_s(kAtan, self.funStack), atan_s(kAtan, self.funStack), chi2prob_s(kChi2Prob, self.funStack),
+              cosh_s(kCosh, self.funStack), cos_s(kCos, self.funStack), exp_s(kExp, self.funStack),
+              hypot_s(kHypot, self.funStack), log_s(kLog, self.funStack), log10_s(kLog10, self.funStack),
+              max_s(kMax, self.funStack), min_s(kMin, self.funStack), pow_s(kPow, self.funStack),
+              sinh_s(kSinh, self.funStack), sin_s(kSin, self.funStack), sqrt_s(kSqrt, self.funStack),
+              tanh_s(kTanh, self.funStack), tan_s(kTan, self.funStack), deltaPhi_s(kDeltaPhi, self.funStack),
+              deltaR_s(kDeltaR, self.funStack), test_bit_s(kTestBit, self.funStack);
           FunctionSetterCommit funOk_s(self.funStack, self.finalFunStack);
-	  TrinarySelectorSetter trinary_s(self.selStack, self.cmpStack, self.exprStack);
-	  BinarySelectorSetter binary_s(self.selStack, self.cmpStack, self.exprStack);
-	  ExpressionSelectorSetter expr_sel_s(self.selStack, self.exprStack);
-	  BinaryCutSetter<logical_and<bool> > and_s(self.selStack);
-	  BinaryCutSetter<logical_or<bool> > or_s(self.selStack);
-	  UnaryCutSetter<logical_not<bool> > not_s(self.selStack);
-	  CutSetter cut_s(* self.sel_, self.selStack);
-	  ExpressionSetter expr_s(* self.expr_, self.exprStack);
-	  ExpressionBinaryOperatorSetter<plus<double> > plus_s(self.exprStack);
-	  ExpressionBinaryOperatorSetter<minus<double> > minus_s(self.exprStack);
-	  ExpressionBinaryOperatorSetter<multiplies<double> > multiplies_s(self.exprStack);
-	  ExpressionBinaryOperatorSetter<divides<double> > divides_s(self.exprStack);
-	  ExpressionBinaryOperatorSetter<power_of<double> > power_of_s(self.exprStack);
-	  ExpressionUnaryOperatorSetter<negate<double> > negate_s(self.exprStack);
-	  ExpressionFunctionSetter fun_s(self.exprStack, self.finalFunStack);
-	  //	  Abort abort_s;
-	  BOOST_SPIRIT_DEBUG_RULE(var);
-	  BOOST_SPIRIT_DEBUG_RULE(arrayAccess);
-	  BOOST_SPIRIT_DEBUG_RULE(method);
-	  BOOST_SPIRIT_DEBUG_RULE(logical_expression);
-	  BOOST_SPIRIT_DEBUG_RULE(cond_expression);
-	  BOOST_SPIRIT_DEBUG_RULE(logical_term);
-	  BOOST_SPIRIT_DEBUG_RULE(logical_factor);
-	  BOOST_SPIRIT_DEBUG_RULE(number);
-	  BOOST_SPIRIT_DEBUG_RULE(metharg);
-	  BOOST_SPIRIT_DEBUG_RULE(function1);
-	  BOOST_SPIRIT_DEBUG_RULE(function2);
-	  BOOST_SPIRIT_DEBUG_RULE(function4);
-	  BOOST_SPIRIT_DEBUG_RULE(expression);
-	  BOOST_SPIRIT_DEBUG_RULE(term);
-	  BOOST_SPIRIT_DEBUG_RULE(power);
-	  BOOST_SPIRIT_DEBUG_RULE(factor);
-	  BOOST_SPIRIT_DEBUG_RULE(or_op);
-	  BOOST_SPIRIT_DEBUG_RULE(and_op);
-	  BOOST_SPIRIT_DEBUG_RULE(comparison_op);
-	  BOOST_SPIRIT_DEBUG_RULE(binary_comp);
-	  BOOST_SPIRIT_DEBUG_RULE(trinary_comp);
-	  BOOST_SPIRIT_DEBUG_RULE(cut);
-	  BOOST_SPIRIT_DEBUG_RULE(fun);
-  
-	  boost::spirit::classic::assertion<SyntaxErrors> expectParenthesis(kMissingClosingParenthesis);
-	  boost::spirit::classic::assertion<SyntaxErrors> expect(kSyntaxError);
-  
-	  number = 
-	    real_p [ number_s ];
-          metharg = ( strict_real_p [ methodArg_s ] ) |
-                    ( int_p [ methodArg_s ] ) |
-                    ( ch_p('"' ) >> *(~ch_p('"' ))  >> ch_p('"' ) ) [ methodArg_s ] |
-                    ( ch_p('\'') >> *(~ch_p('\''))  >> ch_p('\'') ) [ methodArg_s ];
-	  var = // alnum_p doesn't accept underscores, so we use chset<>; lexeme_d needed to avoid whitespace skipping within method names
-	    (lexeme_d[alpha_p >> * chset<>("a-zA-Z0-9_")] >>  
-	      ch_p('(') >> metharg >> * (ch_p(',') >> metharg ) >> expectParenthesis(ch_p(')'))) [ method_s ] |
-	    ( (lexeme_d[alpha_p >> * chset<>("a-zA-Z0-9_")]) [ method_s ] >> ! (ch_p('(') >> ch_p(')')) ) ;
-          arrayAccess = ( ch_p('[') >> metharg >> * (ch_p(',') >> metharg ) >> expectParenthesis(ch_p(']'))) [ method_s ];
-	  method = 
-	    (var >> * (arrayAccess | (ch_p('.') >> expect(var)))) [ var_s ];
-	  function1 = 
-	    chseq_p("abs")  [ abs_s ]  | chseq_p("acos") [ acos_s ] | chseq_p("asin") [ asin_s ] |
-	    chseq_p("atan") [ atan_s ] | chseq_p("cosh") [ cosh_s ] | chseq_p("cos") [ cos_s ] |
-	    chseq_p("exp")  [ exp_s ]  | chseq_p("log") [ log_s ] | chseq_p("log10") [ log10_s ] |
-	    chseq_p("sinh") [ sinh_s ] | chseq_p("sin") [ sin_s ] | chseq_p("sqrt") [ sqrt_s ] |
-	    chseq_p("tanh") [ tanh_s ] | chseq_p("tan") [ tan_s ];
-	  function2 = 
-	    chseq_p("atan2") [ atan2_s ] | chseq_p("chi2prob") [ chi2prob_s ] | chseq_p("pow") [ pow_s ] |
-            chseq_p("min") [ min_s ] | chseq_p("max") [ max_s ] | chseq_p("deltaPhi") [deltaPhi_s]  | chseq_p("hypot") [hypot_s] | chseq_p("test_bit") [test_bit_s] ;
-          function4 =
-            chseq_p("deltaR") [deltaR_s];
-	  expression =
-	    cond_expression |
-	    nocond_expression;
-	  nocond_expression = 
-	    term >> (* (('+' >> expect(term)) [ plus_s ] |
-			('-' >> expect(term)) [ minus_s ]));
-	  cond_expression = 
-	     (ch_p('?') >> logical_expression >> ch_p('?') >> expect(expression) >> ch_p(":") >> expect(expression)) [cond_s];
-	  term = 
-	    power >> * (('*' >> expect(power)) [ multiplies_s ] |
-			('/' >> expect(power)) [ divides_s ]);
-	  power = 
-	    factor >> * (('^' >> expect(factor)) [ power_of_s ]);
-	  factor = 
-	    number | 
-	    (function1 >> ch_p('(') [funOk_s ] >> expect(expression) >> expectParenthesis(ch_p(')'))) [ fun_s ] |
-	    (function2 >> ch_p('(') [funOk_s ] >> expect(expression) >> 
-	     expect(ch_p(',')) >> expect(expression) >> expectParenthesis(ch_p(')'))) [ fun_s ] |
-            (function4 >> ch_p('(') [funOk_s ] >> expect(expression) >> expect(ch_p(',')) >> expect(expression) >> expect(ch_p(',')) >> expect(expression) >> 
-             expect(ch_p(',')) >> expect(expression) >> expectParenthesis(ch_p(')'))) [ fun_s ] |
-            //NOTE: no expect around the first ch_p('(') otherwise it can't parse a method that starts like a function name (i.e. maxSomething)
-	    method | 
-	    //NOTE: no 'expectedParenthesis around ending ')' because at this point the partial phrase
-	    //       "(a"
-	    //could refer to an expression, e.g., "(a+b)*c" or a logical expression "(a<1) &&"
-	    //so we need to allow the parser to 'backup' and try a different approach.
-	    //NOTE: if the parser were changed so a logical expression could be used as an expression,e.g.
-	    //  (a<b)+1 <2
-	    // then we could remove such an ambiguity.
-	    ch_p('(') >> expression >> ch_p(')') |   
-	    (ch_p('-') >> factor) [ negate_s ] |
-	    (ch_p('+') >> factor);
-	  comparison_op = 
-	    (ch_p('<') >> ch_p('=') [ less_equal_s    ]) | 
-	    (ch_p('<')              [ less_s          ]) | 
-	    (ch_p('=') >> ch_p('=') [ equal_to_s      ]) | 
-	    (ch_p('=')              [ equal_to_s      ]) | 
-	    (ch_p('>') >> ch_p('=') [ greater_equal_s ]) | 
-	    (ch_p('>')              [ greater_s       ]) | 
-	    (ch_p('!') >> ch_p('=') [ not_equal_to_s  ]);
-	  binary_comp = 
-	    (expression >> comparison_op >> expect(expression)) [ binary_s ];
-	  trinary_comp = 
-	    (expression >> comparison_op >> expect(expression) >> comparison_op >> expect(expression)) [ trinary_s ];
-	  or_op = ch_p('|') >> ch_p('|') | ch_p('|');
-	  and_op = ch_p('&') >> ch_p('&') | ch_p('&'); 
-	  logical_expression = 
-            logical_term >> * (or_op >> expect(logical_term)) [ or_s ];
-	  logical_term = 
-            logical_factor >> * (and_op >> expect(logical_factor)) [ and_s ];
-	  logical_factor =
-	    trinary_comp | 
-	    binary_comp |
-	    ch_p('(') >> logical_expression >> expectParenthesis(ch_p(')')) |
-	    (ch_p('!') >> expect(logical_factor)) [ not_s ] |
-	    expression [ expr_sel_s ];
-;
-	  cut = logical_expression [ cut_s ];
-	  fun = expression [ expr_s ];
-	  this->start_parsers(cut, fun);
-	}
+          TrinarySelectorSetter trinary_s(self.selStack, self.cmpStack, self.exprStack);
+          BinarySelectorSetter binary_s(self.selStack, self.cmpStack, self.exprStack);
+          ExpressionSelectorSetter expr_sel_s(self.selStack, self.exprStack);
+          BinaryCutSetter<logical_and<bool> > and_s(self.selStack);
+          BinaryCutSetter<logical_or<bool> > or_s(self.selStack);
+          UnaryCutSetter<logical_not<bool> > not_s(self.selStack);
+          CutSetter cut_s(*self.sel_, self.selStack);
+          ExpressionSetter expr_s(*self.expr_, self.exprStack);
+          ExpressionBinaryOperatorSetter<plus<double> > plus_s(self.exprStack);
+          ExpressionBinaryOperatorSetter<minus<double> > minus_s(self.exprStack);
+          ExpressionBinaryOperatorSetter<multiplies<double> > multiplies_s(self.exprStack);
+          ExpressionBinaryOperatorSetter<divides<double> > divides_s(self.exprStack);
+          ExpressionBinaryOperatorSetter<power_of<double> > power_of_s(self.exprStack);
+          ExpressionUnaryOperatorSetter<negate<double> > negate_s(self.exprStack);
+          ExpressionFunctionSetter fun_s(self.exprStack, self.finalFunStack);
+          //	  Abort abort_s;
+          BOOST_SPIRIT_DEBUG_RULE(var);
+          BOOST_SPIRIT_DEBUG_RULE(arrayAccess);
+          BOOST_SPIRIT_DEBUG_RULE(method);
+          BOOST_SPIRIT_DEBUG_RULE(logical_expression);
+          BOOST_SPIRIT_DEBUG_RULE(cond_expression);
+          BOOST_SPIRIT_DEBUG_RULE(logical_term);
+          BOOST_SPIRIT_DEBUG_RULE(logical_factor);
+          BOOST_SPIRIT_DEBUG_RULE(number);
+          BOOST_SPIRIT_DEBUG_RULE(metharg);
+          BOOST_SPIRIT_DEBUG_RULE(function1);
+          BOOST_SPIRIT_DEBUG_RULE(function2);
+          BOOST_SPIRIT_DEBUG_RULE(function4);
+          BOOST_SPIRIT_DEBUG_RULE(expression);
+          BOOST_SPIRIT_DEBUG_RULE(term);
+          BOOST_SPIRIT_DEBUG_RULE(power);
+          BOOST_SPIRIT_DEBUG_RULE(factor);
+          BOOST_SPIRIT_DEBUG_RULE(or_op);
+          BOOST_SPIRIT_DEBUG_RULE(and_op);
+          BOOST_SPIRIT_DEBUG_RULE(comparison_op);
+          BOOST_SPIRIT_DEBUG_RULE(binary_comp);
+          BOOST_SPIRIT_DEBUG_RULE(trinary_comp);
+          BOOST_SPIRIT_DEBUG_RULE(cut);
+          BOOST_SPIRIT_DEBUG_RULE(fun);
+
+          boost::spirit::classic::assertion<SyntaxErrors> expectParenthesis(kMissingClosingParenthesis);
+          boost::spirit::classic::assertion<SyntaxErrors> expect(kSyntaxError);
+
+          number = real_p[number_s];
+          metharg = (strict_real_p[methodArg_s]) | (int_p[methodArg_s]) |
+                    (ch_p('"') >> *(~ch_p('"')) >> ch_p('"'))[methodArg_s] |
+                    (ch_p('\'') >> *(~ch_p('\'')) >> ch_p('\''))[methodArg_s];
+          var =  // alnum_p doesn't accept underscores, so we use chset<>; lexeme_d needed to avoid whitespace skipping within method names
+              (lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")] >> ch_p('(') >> metharg >> *(ch_p(',') >> metharg) >>
+               expectParenthesis(ch_p(')')))[method_s] |
+              ((lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")])[method_s] >> !(ch_p('(') >> ch_p(')')));
+          arrayAccess = (ch_p('[') >> metharg >> *(ch_p(',') >> metharg) >> expectParenthesis(ch_p(']')))[method_s];
+          method = (var >> *(arrayAccess | (ch_p('.') >> expect(var))))[var_s];
+          function1 = chseq_p("abs")[abs_s] | chseq_p("acos")[acos_s] | chseq_p("asin")[asin_s] |
+                      chseq_p("atan")[atan_s] | chseq_p("cosh")[cosh_s] | chseq_p("cos")[cos_s] |
+                      chseq_p("exp")[exp_s] | chseq_p("log")[log_s] | chseq_p("log10")[log10_s] |
+                      chseq_p("sinh")[sinh_s] | chseq_p("sin")[sin_s] | chseq_p("sqrt")[sqrt_s] |
+                      chseq_p("tanh")[tanh_s] | chseq_p("tan")[tan_s];
+          function2 = chseq_p("atan2")[atan2_s] | chseq_p("chi2prob")[chi2prob_s] | chseq_p("pow")[pow_s] |
+                      chseq_p("min")[min_s] | chseq_p("max")[max_s] | chseq_p("deltaPhi")[deltaPhi_s] |
+                      chseq_p("hypot")[hypot_s] | chseq_p("test_bit")[test_bit_s];
+          function4 = chseq_p("deltaR")[deltaR_s];
+          expression = cond_expression | nocond_expression;
+          nocond_expression = term >> (*(('+' >> expect(term))[plus_s] | ('-' >> expect(term))[minus_s]));
+          cond_expression = (ch_p('?') >> logical_expression >> ch_p('?') >> expect(expression) >> ch_p(":") >>
+                             expect(expression))[cond_s];
+          term = power >> *(('*' >> expect(power))[multiplies_s] | ('/' >> expect(power))[divides_s]);
+          power = factor >> *(('^' >> expect(factor))[power_of_s]);
+          factor =
+              number | (function1 >> ch_p('(')[funOk_s] >> expect(expression) >> expectParenthesis(ch_p(')')))[fun_s] |
+              (function2 >> ch_p('(')[funOk_s] >> expect(expression) >> expect(ch_p(',')) >> expect(expression) >>
+               expectParenthesis(ch_p(')')))[fun_s] |
+              (function4 >> ch_p('(')[funOk_s] >> expect(expression) >> expect(ch_p(',')) >> expect(expression) >>
+               expect(ch_p(',')) >> expect(expression) >> expect(ch_p(',')) >> expect(expression) >>
+               expectParenthesis(ch_p(')')))[fun_s] |
+              //NOTE: no expect around the first ch_p('(') otherwise it can't parse a method that starts like a function name (i.e. maxSomething)
+              method |
+              //NOTE: no 'expectedParenthesis around ending ')' because at this point the partial phrase
+              //       "(a"
+              //could refer to an expression, e.g., "(a+b)*c" or a logical expression "(a<1) &&"
+              //so we need to allow the parser to 'backup' and try a different approach.
+              //NOTE: if the parser were changed so a logical expression could be used as an expression,e.g.
+              //  (a<b)+1 <2
+              // then we could remove such an ambiguity.
+              ch_p('(') >> expression >> ch_p(')') | (ch_p('-') >> factor)[negate_s] | (ch_p('+') >> factor);
+          comparison_op = (ch_p('<') >> ch_p('=')[less_equal_s]) | (ch_p('<')[less_s]) |
+                          (ch_p('=') >> ch_p('=')[equal_to_s]) | (ch_p('=')[equal_to_s]) |
+                          (ch_p('>') >> ch_p('=')[greater_equal_s]) | (ch_p('>')[greater_s]) |
+                          (ch_p('!') >> ch_p('=')[not_equal_to_s]);
+          binary_comp = (expression >> comparison_op >> expect(expression))[binary_s];
+          trinary_comp =
+              (expression >> comparison_op >> expect(expression) >> comparison_op >> expect(expression))[trinary_s];
+          or_op = ch_p('|') >> ch_p('|') | ch_p('|');
+          and_op = ch_p('&') >> ch_p('&') | ch_p('&');
+          logical_expression = logical_term >> *(or_op >> expect(logical_term))[or_s];
+          logical_term = logical_factor >> *(and_op >> expect(logical_factor))[and_s];
+          logical_factor = trinary_comp | binary_comp |
+                           ch_p('(') >> logical_expression >> expectParenthesis(ch_p(')')) |
+                           (ch_p('!') >> expect(logical_factor))[not_s] | expression[expr_sel_s];
+          ;
+          cut = logical_expression[cut_s];
+          fun = expression[expr_s];
+          this->start_parsers(cut, fun);
+        }
       };
     };
-  }
-}
-
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/IntSetter.h
+++ b/CommonTools/Utils/src/IntSetter.h
@@ -14,14 +14,13 @@
 namespace reco {
   namespace parser {
     struct IntSetter {
-      IntSetter( IntStack & stack ) : stack_( stack ) { }
-      void operator()(int n) const {
-	stack_.push_back(n);
-      }
+      IntSetter(IntStack& stack) : stack_(stack) {}
+      void operator()(int n) const { stack_.push_back(n); }
+
     private:
-      IntStack & stack_;
+      IntStack& stack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/IntStack.h
+++ b/CommonTools/Utils/src/IntStack.h
@@ -15,6 +15,6 @@ namespace reco {
   namespace parser {
     typedef std::vector<int> IntStack;
   }
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/LogicalBinaryOperator.cc
+++ b/CommonTools/Utils/src/LogicalBinaryOperator.cc
@@ -3,10 +3,9 @@
 using namespace reco::parser;
 template <>
 bool LogicalBinaryOperator<std::logical_and<bool> >::operator()(const edm::ObjectWithDict &o) const {
-   return (*lhs_)(o) && (*rhs_)(o);
+  return (*lhs_)(o) && (*rhs_)(o);
 }
 template <>
 bool LogicalBinaryOperator<std::logical_or<bool> >::operator()(const edm::ObjectWithDict &o) const {
-   return (*lhs_)(o) || (*rhs_)(o);
+  return (*lhs_)(o) || (*rhs_)(o);
 }
-

--- a/CommonTools/Utils/src/LogicalBinaryOperator.h
+++ b/CommonTools/Utils/src/LogicalBinaryOperator.h
@@ -14,24 +14,27 @@
 #include "CommonTools/Utils/src/SelectorStack.h"
 
 namespace reco {
-  namespace parser {    
-    template<typename Op>
+  namespace parser {
+    template <typename Op>
     struct LogicalBinaryOperator : public SelectorBase {
-      LogicalBinaryOperator(SelectorStack & selStack) {
-	rhs_ = selStack.back(); selStack.pop_back();
-	lhs_ = selStack.back(); selStack.pop_back();
+      LogicalBinaryOperator(SelectorStack &selStack) {
+        rhs_ = selStack.back();
+        selStack.pop_back();
+        lhs_ = selStack.back();
+        selStack.pop_back();
       }
-      bool operator()(const edm::ObjectWithDict& o) const override ;
-      private:
+      bool operator()(const edm::ObjectWithDict &o) const override;
+
+    private:
       Op op_;
       SelectorPtr lhs_, rhs_;
     };
 
-template <>
-bool LogicalBinaryOperator<std::logical_and<bool> >::operator()(const edm::ObjectWithDict &o) const ;
-template <>
-bool LogicalBinaryOperator<std::logical_or<bool> >::operator()(const edm::ObjectWithDict &o) const ;
-  }
-}
+    template <>
+    bool LogicalBinaryOperator<std::logical_and<bool> >::operator()(const edm::ObjectWithDict &o) const;
+    template <>
+    bool LogicalBinaryOperator<std::logical_or<bool> >::operator()(const edm::ObjectWithDict &o) const;
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/LogicalUnaryOperator.h
+++ b/CommonTools/Utils/src/LogicalUnaryOperator.h
@@ -14,20 +14,20 @@
 #include "CommonTools/Utils/src/SelectorStack.h"
 
 namespace reco {
-  namespace parser {    
-    template<typename Op>
+  namespace parser {
+    template <typename Op>
     struct LogicalUnaryOperator : public SelectorBase {
-      LogicalUnaryOperator(SelectorStack & selStack) {
-	rhs_ = selStack.back(); selStack.pop_back();
+      LogicalUnaryOperator(SelectorStack& selStack) {
+        rhs_ = selStack.back();
+        selStack.pop_back();
       }
-      bool operator()(const edm::ObjectWithDict& o) const override {
-	return op_((*rhs_)(o));
-      }
-      private:
+      bool operator()(const edm::ObjectWithDict& o) const override { return op_((*rhs_)(o)); }
+
+    private:
       Op op_;
       SelectorPtr rhs_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/MethodArgumentSetter.h
+++ b/CommonTools/Utils/src/MethodArgumentSetter.h
@@ -15,24 +15,25 @@
 namespace reco {
   namespace parser {
     struct MethodArgumentSetter {
-      MethodArgumentSetter( MethodArgumentStack & stack ) : stack_( stack ) { }
-      template<typename T>
+      MethodArgumentSetter(MethodArgumentStack &stack) : stack_(stack) {}
+      template <typename T>
       void operator()(const T &n) const {
-	stack_.push_back( AnyMethodArgument(n) );
+        stack_.push_back(AnyMethodArgument(n));
       }
       void operator()(const char *begin, const char *end) const {
-        assert(begin+1 <= end-1); // the quotes are included in [begin,end[ range.        
+        assert(begin + 1 <= end - 1);  // the quotes are included in [begin,end[ range.
         //in boost 1.67, the parser appends any extra white space to the
         // end
-        if(*(end-1) != *begin) {
+        if (*(end - 1) != *begin) {
           --end;
         }
-        stack_.push_back( AnyMethodArgument(std::string(begin+1,end-1)) );
+        stack_.push_back(AnyMethodArgument(std::string(begin + 1, end - 1)));
       }
+
     private:
-      MethodArgumentStack & stack_;
+      MethodArgumentStack &stack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/MethodArgumentStack.h
+++ b/CommonTools/Utils/src/MethodArgumentStack.h
@@ -13,9 +13,9 @@
 #include <vector>
 
 namespace reco {
-namespace parser {
-typedef std::vector<AnyMethodArgument> MethodArgumentStack;
-} // namespace reco
-} // namespace parser
+  namespace parser {
+    typedef std::vector<AnyMethodArgument> MethodArgumentStack;
+  }  // namespace parser
+}  // namespace reco
 
-#endif // CommonTools_Utils_MethodArgumentStack_h
+#endif  // CommonTools_Utils_MethodArgumentStack_h

--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -10,14 +10,8 @@
 using namespace reco::parser;
 using namespace std;
 
-MethodInvoker::
-MethodInvoker(const edm::FunctionWithDict& method,
-              const vector<AnyMethodArgument>& ints)
-  : method_(method)
-  , member_()
-  , ints_(ints)
-  , isFunction_(true)
-{
+MethodInvoker::MethodInvoker(const edm::FunctionWithDict& method, const vector<AnyMethodArgument>& ints)
+    : method_(method), member_(), ints_(ints), isFunction_(true) {
   setArgs();
   if (isFunction_) {
     retTypeFinal_ = method_.finalReturnType();
@@ -36,13 +30,8 @@ MethodInvoker(const edm::FunctionWithDict& method,
   //   std::endl;
 }
 
-MethodInvoker::
-MethodInvoker(const edm::MemberWithDict& member)
-  : method_()
-  , member_(member)
-  , ints_()
-  , isFunction_(false)
-{
+MethodInvoker::MethodInvoker(const edm::MemberWithDict& member)
+    : method_(), member_(member), ints_(), isFunction_(false) {
   setArgs();
   //std::cout <<
   //  "Booking " <<
@@ -58,66 +47,49 @@ MethodInvoker(const edm::MemberWithDict& member)
   //  std::endl;
 }
 
-MethodInvoker::
-MethodInvoker(const MethodInvoker& rhs)
-  : method_(rhs.method_)
-  , member_(rhs.member_)
-  , ints_(rhs.ints_)
-  , isFunction_(rhs.isFunction_)
-  , retTypeFinal_(rhs.retTypeFinal_)
-{
+MethodInvoker::MethodInvoker(const MethodInvoker& rhs)
+    : method_(rhs.method_),
+      member_(rhs.member_),
+      ints_(rhs.ints_),
+      isFunction_(rhs.isFunction_),
+      retTypeFinal_(rhs.retTypeFinal_) {
   setArgs();
 }
 
-MethodInvoker&
-MethodInvoker::
-operator=(const MethodInvoker& rhs)
-{
+MethodInvoker& MethodInvoker::operator=(const MethodInvoker& rhs) {
   if (this != &rhs) {
     method_ = rhs.method_;
     member_ = rhs.member_;
     ints_ = rhs.ints_;
     isFunction_ = rhs.isFunction_;
-    retTypeFinal_ =rhs.retTypeFinal_;
+    retTypeFinal_ = rhs.retTypeFinal_;
 
     setArgs();
   }
   return *this;
 }
 
-void
-MethodInvoker::
-setArgs()
-{
+void MethodInvoker::setArgs() {
   for (size_t i = 0; i < ints_.size(); ++i) {
     args_.push_back(boost::apply_visitor(AnyMethodArgument2VoidPtr(), ints_[i]));
   }
 }
 
-std::string
-MethodInvoker::
-methodName() const
-{
+std::string MethodInvoker::methodName() const {
   if (isFunction_) {
     return method_.name();
   }
   return member_.name();
 }
 
-std::string
-MethodInvoker::
-returnTypeName() const
-{
+std::string MethodInvoker::returnTypeName() const {
   if (isFunction_) {
     return method_.typeName();
   }
   return member_.typeOf().qualifiedName();
 }
 
-edm::ObjectWithDict
-MethodInvoker::
-invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
-{
+edm::ObjectWithDict MethodInvoker::invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const {
   edm::ObjectWithDict ret = retstore;
   edm::TypeWithDict retType;
   if (isFunction_) {
@@ -129,9 +101,8 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
     //  << std::endl;
     method_.invoke(o, &ret, args_);
     // this is correct, it takes pointers and refs into account
-    retType = retTypeFinal_; 
-  }
-  else {
+    retType = retTypeFinal_;
+  } else {
     //std::cout << "Invoking " << methodName()
     //  << " from " << member_.declaringType().qualifiedName()
     //  << " on an instance of " << o.dynamicType().qualifiedName()
@@ -146,16 +117,14 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
   //  returnTypeName() << ") at " << addr << std::endl;
   if (addr == nullptr) {
     throw edm::Exception(edm::errors::InvalidReference)
-        << "method \"" << methodName() << "\" called with " << args_.size()
-        << " arguments returned a null pointer ";
+        << "method \"" << methodName() << "\" called with " << args_.size() << " arguments returned a null pointer ";
   }
   //std::cout << "Return type is " << retType.qualifiedName() << std::endl;
   if (retType.isPointer() || retType.isReference()) {
     // both need void** -> void* conversion
     if (retType.isPointer()) {
       retType = retType.toType();
-    }
-    else {
+    } else {
       // strip cv & ref flags
       // FIXME: This is only true if the propery passed to the constructor
       //       overrides the const and reference flags.
@@ -166,45 +135,31 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
   }
   if (!bool(ret)) {
     throw edm::Exception(edm::errors::Configuration)
-        << "method \"" << methodName()
-        << "\" returned void invoked on object of type \""
-        << o.typeOf().qualifiedName() << "\"\n";
+        << "method \"" << methodName() << "\" returned void invoked on object of type \"" << o.typeOf().qualifiedName()
+        << "\"\n";
   }
   return ret;
 }
 
-LazyInvoker::
-LazyInvoker(const std::string& name,
-            const std::vector<AnyMethodArgument>& args)
-  : name_(name)
-  , argsBeforeFixups_(args)
-{
-}
+LazyInvoker::LazyInvoker(const std::string& name, const std::vector<AnyMethodArgument>& args)
+    : name_(name), argsBeforeFixups_(args) {}
 
-LazyInvoker::~LazyInvoker()
-{
-}
+LazyInvoker::~LazyInvoker() {}
 
-const SingleInvoker&
-LazyInvoker::
-invoker(const edm::TypeWithDict& type) const
-{
+const SingleInvoker& LazyInvoker::invoker(const edm::TypeWithDict& type) const {
   //std::cout << "LazyInvoker for " << name_ << " called on type " <<
   //  type.qualifiedName() << std::endl;
   const edm::TypeID thetype(type.typeInfo());
   auto found = invokers_.find(thetype);
-  if( found != invokers_.cend() ) {
+  if (found != invokers_.cend()) {
     return *(found->second);
   }
   auto to_add = std::make_shared<SingleInvoker>(type, name_, argsBeforeFixups_);
-  auto emplace_result = invokers_.insert(std::make_pair(thetype,to_add) );
+  auto emplace_result = invokers_.insert(std::make_pair(thetype, to_add));
   return *(emplace_result.first->second);
 }
 
-edm::ObjectWithDict
-LazyInvoker::
-invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
-{
+edm::ObjectWithDict LazyInvoker::invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const {
   pair<edm::ObjectWithDict, bool> ret(o, false);
   do {
     edm::TypeWithDict type = ret.first.typeOf();
@@ -212,16 +167,11 @@ invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
       type = ret.first.dynamicType();
     }
     ret = invoker(type).invoke(edm::ObjectWithDict(type, ret.first.address()), v);
-  }
-  while (ret.second == false);
+  } while (ret.second == false);
   return ret.first;
 }
 
-double
-LazyInvoker::
-invokeLast(const edm::ObjectWithDict& o,
-           std::vector<edm::ObjectWithDict>& v) const
-{
+double LazyInvoker::invokeLast(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const {
   pair<edm::ObjectWithDict, bool> ret(o, false);
   const SingleInvoker* i = nullptr;
   do {
@@ -231,15 +181,13 @@ invokeLast(const edm::ObjectWithDict& o,
     }
     i = &invoker(type);
     ret = i->invoke(edm::ObjectWithDict(type, ret.first.address()), v);
-  }
-  while (ret.second == false);
+  } while (ret.second == false);
   return i->retToDouble(ret.first);
 }
 
-SingleInvoker::
-SingleInvoker(const edm::TypeWithDict& type, const std::string& name,
-              const std::vector<AnyMethodArgument>& args)
-{
+SingleInvoker::SingleInvoker(const edm::TypeWithDict& type,
+                             const std::string& name,
+                             const std::vector<AnyMethodArgument>& args) {
   TypeStack typeStack(1, type);
   LazyMethodStack dummy;
   MethodArgumentStack dummy2;
@@ -251,8 +199,7 @@ SingleInvoker(const edm::TypeWithDict& type, const std::string& name,
   if (invokers_.front().isFunction()) {
     edm::TypeWithDict retType = invokers_.front().method().finalReturnType();
     storageNeedsDestructor_ = ExpressionVar::makeStorage(storage_, retType);
-  }
-  else {
+  } else {
     storage_ = edm::ObjectWithDict();
     storageNeedsDestructor_ = false;
   }
@@ -261,24 +208,17 @@ SingleInvoker(const edm::TypeWithDict& type, const std::string& name,
   retType_ = reco::typeCode(typeStack[1]);
 }
 
-SingleInvoker::
-~SingleInvoker()
-{
-  ExpressionVar::delStorage(storage_);
-}
+SingleInvoker::~SingleInvoker() { ExpressionVar::delStorage(storage_); }
 
-pair<edm::ObjectWithDict, bool>
-SingleInvoker::
-invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
-{
+pair<edm::ObjectWithDict, bool> SingleInvoker::invoke(const edm::ObjectWithDict& o,
+                                                      std::vector<edm::ObjectWithDict>& v) const {
   // std::cerr << "[SingleInvoker::invoke] member " <<
   //   invokers_.front().method().qualifiedName() <<
   //   " of type " <<
   //   o.typeOf().qualifiedName() <<
   //   (!isRefGet_ ? " is one shot" : " needs another round") <<
   //   std::endl;
-  pair<edm::ObjectWithDict, bool>
-  ret(invokers_.front().invoke(o, storage_), !isRefGet_);
+  pair<edm::ObjectWithDict, bool> ret(invokers_.front().invoke(o, storage_), !isRefGet_);
   if (storageNeedsDestructor_) {
     //std::cerr << "Storage type: " << storage_.typeOf().qualifiedName() <<
     //  ", I have to call the destructor." << std::endl;
@@ -287,24 +227,15 @@ invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
   return ret;
 }
 
-double
-SingleInvoker::
-retToDouble(const edm::ObjectWithDict& o) const
-{
+double SingleInvoker::retToDouble(const edm::ObjectWithDict& o) const {
   if (!ExpressionVar::isValidReturnType(retType_)) {
     throwFailedConversion(o);
   }
   return ExpressionVar::objToDouble(o, retType_);
 }
 
-void
-SingleInvoker::
-throwFailedConversion(const edm::ObjectWithDict& o) const
-{
+void SingleInvoker::throwFailedConversion(const edm::ObjectWithDict& o) const {
   throw edm::Exception(edm::errors::Configuration)
-      << "member \"" << invokers_.back().methodName()
-      << "\" return type is \"" << invokers_.back().returnTypeName()
-      << "\" retured a \"" << o.typeOf().qualifiedName()
-      << "\" which is not convertible to double.";
+      << "member \"" << invokers_.back().methodName() << "\" return type is \"" << invokers_.back().returnTypeName()
+      << "\" retured a \"" << o.typeOf().qualifiedName() << "\" which is not convertible to double.";
 }
-

--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -23,113 +23,111 @@ namespace edm {
       return hasher(std::string(tid.name()));
     }
   };
-}
+}  // namespace edm
 
 namespace reco {
-namespace parser {
+  namespace parser {
 
-class MethodInvoker {
-private: // Private Data Members
-  edm::FunctionWithDict method_;
-  edm::MemberWithDict member_;
-  std::vector<AnyMethodArgument> ints_; // already fixed to the correct type
-  std::vector<void*> args_;
+    class MethodInvoker {
+    private:  // Private Data Members
+      edm::FunctionWithDict method_;
+      edm::MemberWithDict member_;
+      std::vector<AnyMethodArgument> ints_;  // already fixed to the correct type
+      std::vector<void*> args_;
 
-  bool isFunction_;
-  edm::TypeWithDict retTypeFinal_;
-private: // Private Function Members
-  void setArgs();
-public: // Public Function Members
-  explicit MethodInvoker(const edm::FunctionWithDict& method,
-                         const std::vector<AnyMethodArgument>& ints =
-                           std::vector<AnyMethodArgument>());
-  explicit MethodInvoker(const edm::MemberWithDict&);
-  MethodInvoker(const MethodInvoker&);
-  MethodInvoker& operator=(const MethodInvoker&);
+      bool isFunction_;
+      edm::TypeWithDict retTypeFinal_;
 
-  edm::FunctionWithDict const method() const { return method_; }
-  edm::MemberWithDict const member() const { return member_; }
-  bool isFunction() const { return isFunction_; }
-  std::string methodName() const;
-  std::string returnTypeName() const;
+    private:  // Private Function Members
+      void setArgs();
 
-  /// Invokes the method, putting the result in retval.
-  /// Returns the Object that points to the result value,
-  /// after removing any "*" and "&"
-  /// Caller code is responsible for allocating retstore
-  /// before calling 'invoke', and of deallocating it afterwards
-  edm::ObjectWithDict invoke(const edm::ObjectWithDict& obj,
-                             edm::ObjectWithDict& retstore) const;
-};
+    public:  // Public Function Members
+      explicit MethodInvoker(const edm::FunctionWithDict& method,
+                             const std::vector<AnyMethodArgument>& ints = std::vector<AnyMethodArgument>());
+      explicit MethodInvoker(const edm::MemberWithDict&);
+      MethodInvoker(const MethodInvoker&);
+      MethodInvoker& operator=(const MethodInvoker&);
 
-/// A bigger brother of the MethodInvoker:
-/// - it owns also the object in which to store the result
-/// - it handles by itself the popping out of Refs and Ptrs
-/// in this way, it can map 1-1 to a name and set of args
-struct SingleInvoker : boost::noncopyable {
-private: // Private Data Members
-  method::TypeCode retType_;
-  std::vector<MethodInvoker> invokers_;
-  mutable edm::ObjectWithDict storage_;
-  bool storageNeedsDestructor_;
-  /// true if this invoker just pops out a ref and returns (ref.get(), false)
-  bool isRefGet_;
-public:
-  SingleInvoker(const edm::TypeWithDict&, const std::string& name,
-                const std::vector<AnyMethodArgument>& args);
-  ~SingleInvoker();
+      edm::FunctionWithDict const method() const { return method_; }
+      edm::MemberWithDict const member() const { return member_; }
+      bool isFunction() const { return isFunction_; }
+      std::string methodName() const;
+      std::string returnTypeName() const;
 
-  /// If the member is found in object o, evaluate and
-  /// return (value,true)
-  /// If the member is not found but o is a Ref/RefToBase/Ptr,
-  /// (return o.get(), false)
-  /// the actual edm::ObjectWithDict where the result is stored
-  /// will be pushed in vector so that, if needed, its destructor
-  /// can be called
-  std::pair<edm::ObjectWithDict, bool>
-  invoke(const edm::ObjectWithDict& o,
-         std::vector<edm::ObjectWithDict>& v) const;
+      /// Invokes the method, putting the result in retval.
+      /// Returns the Object that points to the result value,
+      /// after removing any "*" and "&"
+      /// Caller code is responsible for allocating retstore
+      /// before calling 'invoke', and of deallocating it afterwards
+      edm::ObjectWithDict invoke(const edm::ObjectWithDict& obj, edm::ObjectWithDict& retstore) const;
+    };
 
-  /// convert the output of invoke to a double, if possible
-  double retToDouble(const edm::ObjectWithDict&) const;
+    /// A bigger brother of the MethodInvoker:
+    /// - it owns also the object in which to store the result
+    /// - it handles by itself the popping out of Refs and Ptrs
+    /// in this way, it can map 1-1 to a name and set of args
+    struct SingleInvoker : boost::noncopyable {
+    private:  // Private Data Members
+      method::TypeCode retType_;
+      std::vector<MethodInvoker> invokers_;
+      mutable edm::ObjectWithDict storage_;
+      bool storageNeedsDestructor_;
+      /// true if this invoker just pops out a ref and returns (ref.get(), false)
+      bool isRefGet_;
 
-  void throwFailedConversion(const edm::ObjectWithDict&) const;
-};
+    public:
+      SingleInvoker(const edm::TypeWithDict&, const std::string& name, const std::vector<AnyMethodArgument>& args);
+      ~SingleInvoker();
 
+      /// If the member is found in object o, evaluate and
+      /// return (value,true)
+      /// If the member is not found but o is a Ref/RefToBase/Ptr,
+      /// (return o.get(), false)
+      /// the actual edm::ObjectWithDict where the result is stored
+      /// will be pushed in vector so that, if needed, its destructor
+      /// can be called
+      std::pair<edm::ObjectWithDict, bool> invoke(const edm::ObjectWithDict& o,
+                                                  std::vector<edm::ObjectWithDict>& v) const;
 
-/// Keeps different SingleInvokers for each dynamic type of the objects passed to invoke()
-struct LazyInvoker {
-  typedef std::shared_ptr<SingleInvoker> SingleInvokerPtr;
-  typedef tbb::concurrent_unordered_map<edm::TypeID, SingleInvokerPtr,edm::TypeIDHasher> InvokerMap;
-private: // Private Data Members
-  std::string name_;
-  std::vector<AnyMethodArgument> argsBeforeFixups_;
-  // the shared ptr is only to make the code exception safe
-  // otherwise I think it could leak if the constructor of
-  // SingleInvoker throws an exception (which can happen) 
-  mutable InvokerMap invokers_;
-private: // Private Function Members
-  const SingleInvoker& invoker(const edm::TypeWithDict&) const;
-public: // Public Function Members
-  explicit LazyInvoker(const std::string& name,
-                       const std::vector<AnyMethodArgument>& args);
-  ~LazyInvoker();
+      /// convert the output of invoke to a double, if possible
+      double retToDouble(const edm::ObjectWithDict&) const;
 
-  /// invoke method, returns object that points to result
-  /// (after stripping '*' and '&')
-  /// the object is still owned by the LazyInvoker
-  /// the actual edm::ObjectWithDict where the result is
-  /// stored will be pushed in vector
-  /// so that, if needed, its destructor can be called
-  edm::ObjectWithDict invoke(const edm::ObjectWithDict& o,
-                             std::vector<edm::ObjectWithDict>& v) const;
+      void throwFailedConversion(const edm::ObjectWithDict&) const;
+    };
 
-  /// invoke and coerce result to double
-  double invokeLast(const edm::ObjectWithDict& o,
-                    std::vector<edm::ObjectWithDict>& v) const;
-};
+    /// Keeps different SingleInvokers for each dynamic type of the objects passed to invoke()
+    struct LazyInvoker {
+      typedef std::shared_ptr<SingleInvoker> SingleInvokerPtr;
+      typedef tbb::concurrent_unordered_map<edm::TypeID, SingleInvokerPtr, edm::TypeIDHasher> InvokerMap;
 
-} // namesapce parser
-} // namespace reco
+    private:  // Private Data Members
+      std::string name_;
+      std::vector<AnyMethodArgument> argsBeforeFixups_;
+      // the shared ptr is only to make the code exception safe
+      // otherwise I think it could leak if the constructor of
+      // SingleInvoker throws an exception (which can happen)
+      mutable InvokerMap invokers_;
 
-#endif // CommonTools_Utils_MethodInvoker_h
+    private:  // Private Function Members
+      const SingleInvoker& invoker(const edm::TypeWithDict&) const;
+
+    public:  // Public Function Members
+      explicit LazyInvoker(const std::string& name, const std::vector<AnyMethodArgument>& args);
+      ~LazyInvoker();
+
+      /// invoke method, returns object that points to result
+      /// (after stripping '*' and '&')
+      /// the object is still owned by the LazyInvoker
+      /// the actual edm::ObjectWithDict where the result is
+      /// stored will be pushed in vector
+      /// so that, if needed, its destructor can be called
+      edm::ObjectWithDict invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const;
+
+      /// invoke and coerce result to double
+      double invokeLast(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const;
+    };
+
+  }  // namespace parser
+}  // namespace reco
+
+#endif  // CommonTools_Utils_MethodInvoker_h

--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -12,19 +12,16 @@
 using namespace reco::parser;
 using namespace std;
 
-void
-MethodSetter::
-operator()(const char* begin, const char* end) const
-{
+void MethodSetter::operator()(const char* begin, const char* end) const {
   string name(begin, end);
   string::size_type parenthesis = name.find_first_of('(');
   if ((*begin == '[') || (*begin == '(')) {
-    name.insert(0, "operator..");    // operator..[arg];
-    parenthesis = 10;                //           ^--- idx = 10
-    name[8] = *begin;                // operator[.[arg];
-    name[9] = name[name.size() - 1]; // operator[][arg];
-    name[10] = '(';                  // operator[](arg];
-    name[name.size() - 1] = ')';     // operator[](arg);
+    name.insert(0, "operator..");     // operator..[arg];
+    parenthesis = 10;                 //           ^--- idx = 10
+    name[8] = *begin;                 // operator[.[arg];
+    name[9] = name[name.size() - 1];  // operator[][arg];
+    name[10] = '(';                   // operator[](arg];
+    name[name.size() - 1] = ')';      // operator[](arg);
     // we don't actually need the last two, but just for extra care
     //std::cout << "Transformed {" << string(begin,end) << "} into
     //  {"<< name <<"}" << std::endl;
@@ -33,11 +30,9 @@ operator()(const char* begin, const char* end) const
   if (parenthesis != string::npos) {
     name.erase(parenthesis, name.size());
     if (intStack_.empty()) {
-      throw Exception(begin)
-          << "expected method argument, but non given.";
+      throw Exception(begin) << "expected method argument, but non given.";
     }
-    for (vector<AnyMethodArgument>::const_iterator i = intStack_.begin();
-         i != intStack_.end(); ++i) {
+    for (vector<AnyMethodArgument>::const_iterator i = intStack_.begin(); i != intStack_.end(); ++i) {
       args.push_back(*i);
     }
     intStack_.clear();
@@ -51,8 +46,7 @@ operator()(const char* begin, const char* end) const
   if (lazy_) {
     // for lazy parsing we just push method name and arguments
     lazyMethStack_.push_back(LazyInvoker(name, args));
-  }
-  else {
+  } else {
     // otherwise we really have to resolve the method
     push(name, args, begin);
   }
@@ -60,26 +54,18 @@ operator()(const char* begin, const char* end) const
   //  " args " << (lazy_ ? "(lazy)" : "(immediate)") << std::endl;
 }
 
-bool
-MethodSetter::
-push(const string& name, const vector<AnyMethodArgument>& args,
-     const char* begin, bool deep) const
-{
+bool MethodSetter::push(const string& name, const vector<AnyMethodArgument>& args, const char* begin, bool deep) const {
   edm::TypeWithDict type = typeStack_.back();
   vector<AnyMethodArgument> fixups;
   int error = 0;
-  pair<edm::FunctionWithDict, bool> mem =
-    reco::findMethod(type, name, args, fixups, begin, error);
+  pair<edm::FunctionWithDict, bool> mem = reco::findMethod(type, name, args, fixups, begin, error);
   if (bool(mem.first)) {
     // We found the method.
     edm::TypeWithDict retType = reco::returnType(mem.first);
     if (!bool(retType)) {
       // Invalid return type, fatal error, throw.
-      throw Exception(begin)
-          << "member \"" << mem.first.name()
-          << "\" return type is invalid:\n"
-          << "  return type: \""
-          << mem.first.typeName() << "\"\n";
+      throw Exception(begin) << "member \"" << mem.first.name() << "\" return type is invalid:\n"
+                             << "  return type: \"" << mem.first.typeName() << "\"\n";
     }
     typeStack_.push_back(retType);
     // check for edm::Ref, edm::RefToBase, edm::Ptr
@@ -94,8 +80,7 @@ push(const string& name, const vector<AnyMethodArgument>& args,
       // note: we have not found the method, so we have not
       // fixupped the arguments
       push(name, args, begin);
-    }
-    else {
+    } else {
       // With fixups.
       //std::cout << "Not mem.second, so book " << mem.first.name()
       //  << " with #args = " << fixups.size() << std::endl;
@@ -107,34 +92,26 @@ push(const string& name, const vector<AnyMethodArgument>& args,
     // Fatal error, throw.
     switch (error) {
       case reco::parser::kIsNotPublic:
-        throw Exception(begin)
-            << "method named \"" << name << "\" for type \""
-            << type.name() << "\" is not publically accessible.";
+        throw Exception(begin) << "method named \"" << name << "\" for type \"" << type.name()
+                               << "\" is not publically accessible.";
         break;
       case reco::parser::kIsStatic:
-        throw Exception(begin)
-            << "method named \"" << name << "\" for type \""
-            << type.name() << "\" is static.";
+        throw Exception(begin) << "method named \"" << name << "\" for type \"" << type.name() << "\" is static.";
         break;
       case reco::parser::kIsNotConst:
-        throw Exception(begin)
-            << "method named \"" << name << "\" for type \""
-            << type.name() << "\" is not const.";
+        throw Exception(begin) << "method named \"" << name << "\" for type \"" << type.name() << "\" is not const.";
         break;
       case reco::parser::kWrongNumberOfArguments:
-        throw Exception(begin)
-            << "method named \"" << name << "\" for type \""
-            << type.name() << "\" was passed the wrong number of arguments.";
+        throw Exception(begin) << "method named \"" << name << "\" for type \"" << type.name()
+                               << "\" was passed the wrong number of arguments.";
         break;
       case reco::parser::kWrongArgumentType:
-        throw Exception(begin)
-            << "method named \"" << name << "\" for type \""
-            << type.name() << "\" was passed the wrong types of arguments.";
+        throw Exception(begin) << "method named \"" << name << "\" for type \"" << type.name()
+                               << "\" was passed the wrong types of arguments.";
         break;
       default:
-        throw Exception(begin)
-            << "method named \"" << name << "\" for type \""
-            << type.name() << "\" is not usable in this context.";
+        throw Exception(begin) << "method named \"" << name << "\" for type \"" << type.name()
+                               << "\" is not usable in this context.";
     }
   }
   // Not a method, check for a data member.
@@ -144,20 +121,16 @@ push(const string& name, const vector<AnyMethodArgument>& args,
     // Not a data member either, fatal error, throw.
     switch (error) {
       case reco::parser::kNameDoesNotExist:
-        throw Exception(begin)
-            << "no method or data member named \"" << name
-            << "\" found for type \""
-            << type.name() << "\"";
+        throw Exception(begin) << "no method or data member named \"" << name << "\" found for type \"" << type.name()
+                               << "\"";
         break;
       case reco::parser::kIsNotPublic:
-        throw Exception(begin)
-            << "data member named \"" << name << "\" for type \""
-            << type.name() << "\" is not publically accessible.";
+        throw Exception(begin) << "data member named \"" << name << "\" for type \"" << type.name()
+                               << "\" is not publically accessible.";
         break;
       default:
-        throw Exception(begin)
-            << "data member named \"" << name << "\" for type \""
-            << type.name() << "\" is not usable in this context.";
+        throw Exception(begin) << "data member named \"" << name << "\" for type \"" << type.name()
+                               << "\" is not usable in this context.";
         break;
     }
   }
@@ -166,4 +139,3 @@ push(const string& name, const vector<AnyMethodArgument>& args,
   methStack_.push_back(MethodInvoker(member));
   return true;
 }
-

--- a/CommonTools/Utils/src/MethodSetter.h
+++ b/CommonTools/Utils/src/MethodSetter.h
@@ -12,62 +12,61 @@
 #include "CommonTools/Utils/src/MethodArgumentStack.h"
 
 namespace reco {
-namespace parser {
+  namespace parser {
 
-class MethodSetter {
-private:
-  MethodStack& methStack_;
-  LazyMethodStack& lazyMethStack_;
-  TypeStack& typeStack_;
-  MethodArgumentStack& intStack_;
-  bool lazy_;
-public:
-  explicit
-  MethodSetter(MethodStack& methStack, LazyMethodStack& lazyMethStack,
-               TypeStack& typeStack, MethodArgumentStack& intStack,
-               bool lazy = false)
-    : methStack_(methStack)
-    , lazyMethStack_(lazyMethStack)
-    , typeStack_(typeStack)
-    , intStack_(intStack)
-    , lazy_(lazy)
-  {
-  }
+    class MethodSetter {
+    private:
+      MethodStack& methStack_;
+      LazyMethodStack& lazyMethStack_;
+      TypeStack& typeStack_;
+      MethodArgumentStack& intStack_;
+      bool lazy_;
 
-  void operator()(const char*, const char*) const;
+    public:
+      explicit MethodSetter(MethodStack& methStack,
+                            LazyMethodStack& lazyMethStack,
+                            TypeStack& typeStack,
+                            MethodArgumentStack& intStack,
+                            bool lazy = false)
+          : methStack_(methStack),
+            lazyMethStack_(lazyMethStack),
+            typeStack_(typeStack),
+            intStack_(intStack),
+            lazy_(lazy) {}
 
-  /// Resolve the name to either a function member or a data member,
-  /// push a MethodInvoker on the MethodStack, and its return type to
-  /// the TypeStack (after stripping "*" and "&").
-  ///
-  /// This method is used also by the LazyInvoker to perform the fetch once
-  /// the final type is known.
-  ///
-  /// If the object is an edm::Ref/Ptr/RefToBase and the method is not
-  /// found in the class:
-  ///
-  ///  1)  it pushes a no-argument 'get()' method
-  ///
-  ///  2)  if deep = true, it attempts to resolve and push the method on
-  ///      the object to which the edm ref points to.  In that case, the
-  ///      MethodStack will contain two more items after this call instead
-  ///      of just one.  This behaviour is what you want for non-lazy parsing.
-  ///
-  ///  2b) if instead deep = false, it just pushes the 'get' on the stack.
-  ///      this will allow the LazyInvoker to then re-discover the runtime
-  ///      type of the pointee
-  ///
-  ///  The method will:
-  ///     - throw exception, if the member can't be resolved
-  ///     - return 'false' if deep = false and it only pushed
-  //        a 'get' on the stack
-  ///     - return true otherwise
-  ///
-  bool push(const std::string&, const std::vector<AnyMethodArgument>&,
-            const char*, bool deep = true) const;
-};
+      void operator()(const char*, const char*) const;
 
-} // namespace parser
-} // namespace reco
+      /// Resolve the name to either a function member or a data member,
+      /// push a MethodInvoker on the MethodStack, and its return type to
+      /// the TypeStack (after stripping "*" and "&").
+      ///
+      /// This method is used also by the LazyInvoker to perform the fetch once
+      /// the final type is known.
+      ///
+      /// If the object is an edm::Ref/Ptr/RefToBase and the method is not
+      /// found in the class:
+      ///
+      ///  1)  it pushes a no-argument 'get()' method
+      ///
+      ///  2)  if deep = true, it attempts to resolve and push the method on
+      ///      the object to which the edm ref points to.  In that case, the
+      ///      MethodStack will contain two more items after this call instead
+      ///      of just one.  This behaviour is what you want for non-lazy parsing.
+      ///
+      ///  2b) if instead deep = false, it just pushes the 'get' on the stack.
+      ///      this will allow the LazyInvoker to then re-discover the runtime
+      ///      type of the pointee
+      ///
+      ///  The method will:
+      ///     - throw exception, if the member can't be resolved
+      ///     - return 'false' if deep = false and it only pushed
+      //        a 'get' on the stack
+      ///     - return true otherwise
+      ///
+      bool push(const std::string&, const std::vector<AnyMethodArgument>&, const char*, bool deep = true) const;
+    };
 
-#endif // CommonTools_Utils_MethodSetter_h
+  }  // namespace parser
+}  // namespace reco
+
+#endif  // CommonTools_Utils_MethodSetter_h

--- a/CommonTools/Utils/src/MethodStack.h
+++ b/CommonTools/Utils/src/MethodStack.h
@@ -13,10 +13,10 @@
 #include <vector>
 
 namespace reco {
-namespace parser {
-typedef std::vector<MethodInvoker> MethodStack;
-typedef std::vector<LazyInvoker> LazyMethodStack;
-} // namespace parser
-} // namespace reco
+  namespace parser {
+    typedef std::vector<MethodInvoker> MethodStack;
+    typedef std::vector<LazyInvoker> LazyMethodStack;
+  }  // namespace parser
+}  // namespace reco
 
-#endif // CommonTools_Utils_MethodStack_h
+#endif  // CommonTools_Utils_MethodStack_h

--- a/CommonTools/Utils/src/NotCombiner.h
+++ b/CommonTools/Utils/src/NotCombiner.h
@@ -14,17 +14,15 @@
 #include "CommonTools/Utils/src/SelectorPtr.h"
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct NotCombiner : public SelectorBase {
-      NotCombiner( SelectorPtr arg ) :
-	arg_( arg ) {}
-      bool operator()( const edm::ObjectWithDict& o ) const override {
-	return ! (*arg_)( o );
-      }
+      NotCombiner(SelectorPtr arg) : arg_(arg) {}
+      bool operator()(const edm::ObjectWithDict& o) const override { return !(*arg_)(o); }
+
     private:
       SelectorPtr arg_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/OrCombiner.h
+++ b/CommonTools/Utils/src/OrCombiner.h
@@ -14,17 +14,15 @@
 #include "CommonTools/Utils/src/SelectorPtr.h"
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct OrCombiner : public SelectorBase {
-      OrCombiner( SelectorPtr lhs, SelectorPtr rhs ) :
-	lhs_( lhs ), rhs_( rhs ) {}
-      bool operator()( const edm::ObjectWithDict& o ) const override {
-	return (*lhs_)( o ) || (*rhs_)( o );
-      }
+      OrCombiner(SelectorPtr lhs, SelectorPtr rhs) : lhs_(lhs), rhs_(rhs) {}
+      bool operator()(const edm::ObjectWithDict& o) const override { return (*lhs_)(o) || (*rhs_)(o); }
+
     private:
       SelectorPtr lhs_, rhs_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/SelectorBase.h
+++ b/CommonTools/Utils/src/SelectorBase.h
@@ -10,18 +10,20 @@
  *
  */
 
-namespace edm {class ObjectWithDict;}
+namespace edm {
+  class ObjectWithDict;
+}
 
 namespace reco {
   namespace parser {
     class SelectorBase {
     public:
       /// destructor
-      virtual ~SelectorBase() { }
+      virtual ~SelectorBase() {}
       /// return true if the object is selected
-      virtual bool operator()(const edm::ObjectWithDict & c) const = 0;
+      virtual bool operator()(const edm::ObjectWithDict& c) const = 0;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/SelectorPtr.h
+++ b/CommonTools/Utils/src/SelectorPtr.h
@@ -16,7 +16,7 @@ namespace reco {
   namespace parser {
     class SelectorBase;
     typedef boost::shared_ptr<SelectorBase> SelectorPtr;
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/SelectorStack.h
+++ b/CommonTools/Utils/src/SelectorStack.h
@@ -17,6 +17,6 @@ namespace reco {
   namespace parser {
     typedef std::vector<SelectorPtr> SelectorStack;
   }
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/TFileDirectory.cc
+++ b/CommonTools/Utils/src/TFileDirectory.cc
@@ -5,163 +5,112 @@
 
 #include "boost/regex.hpp"
 
-
-
 using namespace std;
 
-TDirectory * 
-TFileDirectory::getBareDirectory (const string &subdir) const 
-{
-   return _cd (subdir, false);
+TDirectory *TFileDirectory::getBareDirectory(const string &subdir) const { return _cd(subdir, false); }
+
+bool TFileDirectory::cd() const {
+  _cd("", false);
+  return true;
 }
 
-bool
-TFileDirectory::cd () const
-{
-   _cd ("", false);
-   return true;
-}
-
-TDirectory *
-TFileDirectory::_cd (const string &subdir, bool createNeededDirectories) const
-{
-   string fpath = fullPath();
-   if (subdir.length())
-   {
-      // not empty, we need to append it to path
-      if (fpath.length())
-      {
-         // path is also not empty, so add a slash and let's get going.
-         fpath += "/" + subdir;
-      } else {
-         // path doesn't exist, so just use subdir
-         fpath = subdir;
+TDirectory *TFileDirectory::_cd(const string &subdir, bool createNeededDirectories) const {
+  string fpath = fullPath();
+  if (subdir.length()) {
+    // not empty, we need to append it to path
+    if (fpath.length()) {
+      // path is also not empty, so add a slash and let's get going.
+      fpath += "/" + subdir;
+    } else {
+      // path doesn't exist, so just use subdir
+      fpath = subdir;
+    }
+  }
+  TDirectory *dir = file_->GetDirectory(fpath.c_str());
+  if (dir == nullptr) {
+    // we didn't find the directory
+    //
+    // If we're not supposed to create the diretory, then we should
+    // complain now that it doesn't exist.
+    if (!createNeededDirectories) {
+      cout << "here " << fpath << endl;
+      throw cms::Exception("InvalidDirectory") << "directory " << fpath << " doesn't exist.";
+    }
+    if (!path_.empty()) {
+      dir = file_->GetDirectory(path_.c_str());
+      if (dir == nullptr) {
+        throw cms::Exception("InvalidDirectory") << "Can't change directory to path: " << path_;
       }
-   }
-   TDirectory * dir = file_->GetDirectory( fpath.c_str() );
-   if ( dir == nullptr ) 
-   {      
-      // we didn't find the directory
-      //
-      // If we're not supposed to create the diretory, then we should
-      // complain now that it doesn't exist.
-      if (! createNeededDirectories)
-      {
-         cout << "here " << fpath << endl;
-         throw 
-            cms::Exception( "InvalidDirectory" ) 
-            << "directory " << fpath << " doesn't exist.";
-      }
-      if ( ! path_.empty() ) 
-      {
-         dir = file_->GetDirectory( path_.c_str() );
-         if ( dir == nullptr )
-         {
-            throw 
-               cms::Exception( "InvalidDirectory" ) 
-               << "Can't change directory to path: " << path_;
-         }
-      } else 
-      {
-         // the base path 'path_' is empty, so just use the pointer to
-         // the file.
-         dir = file_;
-      }
-      // if a subdirectory was passed in, then this directory better
-      // already exist (since you shoudln't be cd'ing into a directory
-      // before making it and the cd with a subdir is only used to get
-      // histograms that are already made).
-      if (subdir.length())
-      {
-         throw 
-            cms::Exception( "InvalidDirectory" ) 
-            << "directory " << fpath << " doesn't exist.";
-      }
-      // if we're here, then that means that this is the first time
-      // that we are calling cd() on this directory AND cd() has not
-      // been called with a subdirectory, so go ahead and make the
-      // directory.
-      dir = _mkdir (dir, dir_, descr_);
-   }
-   bool ok = file_->cd( fpath.c_str() );
-   if ( ! ok )
-   {
-      throw 
-         cms::Exception( "InvalidDirectory" ) 
-         << "Can't change directory to path: " << fpath;
-   }
-   return dir;
+    } else {
+      // the base path 'path_' is empty, so just use the pointer to
+      // the file.
+      dir = file_;
+    }
+    // if a subdirectory was passed in, then this directory better
+    // already exist (since you shoudln't be cd'ing into a directory
+    // before making it and the cd with a subdir is only used to get
+    // histograms that are already made).
+    if (subdir.length()) {
+      throw cms::Exception("InvalidDirectory") << "directory " << fpath << " doesn't exist.";
+    }
+    // if we're here, then that means that this is the first time
+    // that we are calling cd() on this directory AND cd() has not
+    // been called with a subdirectory, so go ahead and make the
+    // directory.
+    dir = _mkdir(dir, dir_, descr_);
+  }
+  bool ok = file_->cd(fpath.c_str());
+  if (!ok) {
+    throw cms::Exception("InvalidDirectory") << "Can't change directory to path: " << fpath;
+  }
+  return dir;
 }
 
-TDirectory*
-TFileDirectory::_mkdir (TDirectory *dirPtr, 
-                        const string &subdirName, 
-                        const string &description) const
-{
-   // do we have this one already
-   TDirectory *subdirPtr = dirPtr->GetDirectory (subdirName.c_str());
-   if (subdirPtr)
-   {
-      subdirPtr->cd();
-      return subdirPtr;
-   }
-   // if we're here, then this directory doesn't exist.  Is this
-   // directory a subdirectory?
-   const boost::regex subdirRE ("(.+?)/([^/]+)");
-   boost::smatch matches;
-   TDirectory *parentDir = nullptr;
-   string useName = subdirName;
-   if( boost::regex_match (subdirName, matches, subdirRE) )
-   {
-      parentDir = _mkdir (dirPtr, matches[1], description);
-      useName = matches[2];
-   } else {
-      // This is not a subdirectory, so we're golden
-      parentDir = dirPtr;
-   }
-   subdirPtr = parentDir->mkdir (useName.c_str());
-   if ( ! subdirPtr )
-   {
-      throw 
-         cms::Exception( "InvalidDirectory" ) 
-            << "Can't create directory " << dir_ << " in path: " << path_;
-   }
-   subdirPtr->cd();
-   return subdirPtr;
+TDirectory *TFileDirectory::_mkdir(TDirectory *dirPtr, const string &subdirName, const string &description) const {
+  // do we have this one already
+  TDirectory *subdirPtr = dirPtr->GetDirectory(subdirName.c_str());
+  if (subdirPtr) {
+    subdirPtr->cd();
+    return subdirPtr;
+  }
+  // if we're here, then this directory doesn't exist.  Is this
+  // directory a subdirectory?
+  const boost::regex subdirRE("(.+?)/([^/]+)");
+  boost::smatch matches;
+  TDirectory *parentDir = nullptr;
+  string useName = subdirName;
+  if (boost::regex_match(subdirName, matches, subdirRE)) {
+    parentDir = _mkdir(dirPtr, matches[1], description);
+    useName = matches[2];
+  } else {
+    // This is not a subdirectory, so we're golden
+    parentDir = dirPtr;
+  }
+  subdirPtr = parentDir->mkdir(useName.c_str());
+  if (!subdirPtr) {
+    throw cms::Exception("InvalidDirectory") << "Can't create directory " << dir_ << " in path: " << path_;
+  }
+  subdirPtr->cd();
+  return subdirPtr;
 }
 
-TObject*
-TFileDirectory::_getObj (const string &objname, const string &subdir) const
-{
-   TObject *objPtr = getBareDirectory (subdir)->Get (objname.c_str());
-   if ( ! objPtr)
-   {
-      // no histogram found by that name.  Sorry dude.
-      if (subdir.length())
-      {
-         throw
-            cms::Exception ("ObjectNotFound")
-            << "Can not find object named " << objname
-            << " in subdir " << subdir;
-      } else {
-         throw
-            cms::Exception ("ObjectNotFound")
-            << "Can not find object named " << objname;
-      }
-   } // if nothing found
-   return objPtr;
+TObject *TFileDirectory::_getObj(const string &objname, const string &subdir) const {
+  TObject *objPtr = getBareDirectory(subdir)->Get(objname.c_str());
+  if (!objPtr) {
+    // no histogram found by that name.  Sorry dude.
+    if (subdir.length()) {
+      throw cms::Exception("ObjectNotFound") << "Can not find object named " << objname << " in subdir " << subdir;
+    } else {
+      throw cms::Exception("ObjectNotFound") << "Can not find object named " << objname;
+    }
+  }  // if nothing found
+  return objPtr;
 }
 
-std::string 
-TFileDirectory::fullPath() const 
-{
-   return string( path_.empty() ? dir_ : path_ + "/" + dir_ );
-}
+std::string TFileDirectory::fullPath() const { return string(path_.empty() ? dir_ : path_ + "/" + dir_); }
 
-TFileDirectory 
-TFileDirectory::mkdir( const std::string & dir, const std::string & descr ) 
-{
-   TH1AddDirectorySentry sentry;
-   _cd();
-   return TFileDirectory( dir, descr, file_, fullPath() );
+TFileDirectory TFileDirectory::mkdir(const std::string &dir, const std::string &descr) {
+  TH1AddDirectorySentry sentry;
+  _cd();
+  return TFileDirectory(dir, descr, file_, fullPath());
 }

--- a/CommonTools/Utils/src/TH1AddDirectorySentry.cc
+++ b/CommonTools/Utils/src/TH1AddDirectorySentry.cc
@@ -2,7 +2,7 @@
 //
 // Package:     UtilAlgos
 // Class  :     TH1AddDirectorySentry
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -17,7 +17,6 @@
 // user include files
 #include "CommonTools/Utils/interface/TH1AddDirectorySentry.h"
 
-
 //
 // constants, enums and typedefs
 //
@@ -29,14 +28,6 @@
 //
 // constructors and destructor
 //
-TH1AddDirectorySentry::TH1AddDirectorySentry():
-   status_(TH1::AddDirectoryStatus())
-{
-   TH1::AddDirectory(true);
-}
+TH1AddDirectorySentry::TH1AddDirectorySentry() : status_(TH1::AddDirectoryStatus()) { TH1::AddDirectory(true); }
 
-TH1AddDirectorySentry::~TH1AddDirectorySentry()
-{
-   TH1::AddDirectory(status_);
-}
-
+TH1AddDirectorySentry::~TH1AddDirectorySentry() { TH1::AddDirectory(status_); }

--- a/CommonTools/Utils/src/TrinarySelector.h
+++ b/CommonTools/Utils/src/TrinarySelector.h
@@ -16,18 +16,16 @@
 #include <boost/shared_ptr.hpp>
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     struct TrinarySelector : public SelectorBase {
-      TrinarySelector( boost::shared_ptr<ExpressionBase> lhs,
-		       boost::shared_ptr<ComparisonBase> cmp1,
-		       boost::shared_ptr<ExpressionBase> mid,
-		       boost::shared_ptr<ComparisonBase> cmp2,
-		       boost::shared_ptr<ExpressionBase> rhs ) :
-	lhs_( lhs ), cmp1_( cmp1 ), mid_( mid ), cmp2_( cmp2 ),rhs_( rhs ) {}
-      bool operator()( const edm::ObjectWithDict& o ) const override {
-	return 
-	  cmp1_->compare( lhs_->value( o ), mid_->value( o ) ) &&
-	  cmp2_->compare( mid_->value( o ), rhs_->value( o ) );
+      TrinarySelector(boost::shared_ptr<ExpressionBase> lhs,
+                      boost::shared_ptr<ComparisonBase> cmp1,
+                      boost::shared_ptr<ExpressionBase> mid,
+                      boost::shared_ptr<ComparisonBase> cmp2,
+                      boost::shared_ptr<ExpressionBase> rhs)
+          : lhs_(lhs), cmp1_(cmp1), mid_(mid), cmp2_(cmp2), rhs_(rhs) {}
+      bool operator()(const edm::ObjectWithDict& o) const override {
+        return cmp1_->compare(lhs_->value(o), mid_->value(o)) && cmp2_->compare(mid_->value(o), rhs_->value(o));
       }
       boost::shared_ptr<ExpressionBase> lhs_;
       boost::shared_ptr<ComparisonBase> cmp1_;
@@ -35,7 +33,7 @@ namespace reco {
       boost::shared_ptr<ComparisonBase> cmp2_;
       boost::shared_ptr<ExpressionBase> rhs_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/TrinarySelectorSetter.h
+++ b/CommonTools/Utils/src/TrinarySelectorSetter.h
@@ -17,31 +17,35 @@
 #include <boost/shared_ptr.hpp>
 
 namespace reco {
-  namespace parser {    
+  namespace parser {
     class TrinarySelectorSetter {
     public:
-      TrinarySelectorSetter(SelectorStack& selStack,
-			     ComparisonStack& cmpStack, 
-			     ExpressionStack& expStack) : 
-	selStack_(selStack), cmpStack_(cmpStack), expStack_(expStack) { }
-      
-      void operator()(const char *, const char *) const {
-	boost::shared_ptr<ExpressionBase> rhs = expStack_.back(); expStack_.pop_back();
-	boost::shared_ptr<ExpressionBase> mid = expStack_.back(); expStack_.pop_back();
-	boost::shared_ptr<ExpressionBase> lhs = expStack_.back(); expStack_.pop_back();
-	boost::shared_ptr<ComparisonBase> comp2 = cmpStack_.back(); cmpStack_.pop_back();
-	boost::shared_ptr<ComparisonBase> comp1 = cmpStack_.back(); cmpStack_.pop_back();
-#ifdef BOOST_SPIRIT_DEBUG 
-	BOOST_SPIRIT_DEBUG_OUT << "pushing trinary selector" << std::endl;
+      TrinarySelectorSetter(SelectorStack& selStack, ComparisonStack& cmpStack, ExpressionStack& expStack)
+          : selStack_(selStack), cmpStack_(cmpStack), expStack_(expStack) {}
+
+      void operator()(const char*, const char*) const {
+        boost::shared_ptr<ExpressionBase> rhs = expStack_.back();
+        expStack_.pop_back();
+        boost::shared_ptr<ExpressionBase> mid = expStack_.back();
+        expStack_.pop_back();
+        boost::shared_ptr<ExpressionBase> lhs = expStack_.back();
+        expStack_.pop_back();
+        boost::shared_ptr<ComparisonBase> comp2 = cmpStack_.back();
+        cmpStack_.pop_back();
+        boost::shared_ptr<ComparisonBase> comp1 = cmpStack_.back();
+        cmpStack_.pop_back();
+#ifdef BOOST_SPIRIT_DEBUG
+        BOOST_SPIRIT_DEBUG_OUT << "pushing trinary selector" << std::endl;
 #endif
-	selStack_.push_back(SelectorPtr(new TrinarySelector(lhs, comp1, mid, comp2, rhs)));
+        selStack_.push_back(SelectorPtr(new TrinarySelector(lhs, comp1, mid, comp2, rhs)));
       }
+
     private:
       SelectorStack& selStack_;
       ComparisonStack& cmpStack_;
       ExpressionStack& expStack_;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/TypeCode.h
+++ b/CommonTools/Utils/src/TypeCode.h
@@ -10,16 +10,22 @@
 
 namespace reco {
   namespace method {
-    enum TypeCode { 
-      doubleType = 0, floatType,
-      intType, uIntType,
-      charType, uCharType,
-      shortType, uShortType, 
-      longType, uLongType, 
-      boolType, enumType,
+    enum TypeCode {
+      doubleType = 0,
+      floatType,
+      intType,
+      uIntType,
+      charType,
+      uCharType,
+      shortType,
+      uShortType,
+      longType,
+      uLongType,
+      boolType,
+      enumType,
       invalid
     };
   }
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/TypeStack.h
+++ b/CommonTools/Utils/src/TypeStack.h
@@ -16,6 +16,6 @@ namespace reco {
   namespace parser {
     typedef std::vector<edm::TypeWithDict> TypeStack;
   }
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/UnaryCutSetter.h
+++ b/CommonTools/Utils/src/UnaryCutSetter.h
@@ -14,21 +14,20 @@
 #include "CommonTools/Utils/src/LogicalUnaryOperator.h"
 
 namespace reco {
-  namespace parser {    
-    template<typename Op>
+  namespace parser {
+    template <typename Op>
     struct UnaryCutSetter {
-      UnaryCutSetter(SelectorStack & selStack) :
-	selStack_(selStack) { }
+      UnaryCutSetter(SelectorStack& selStack) : selStack_(selStack) {}
       void operator()(const char*, const char*) const {
-	selStack_.push_back(SelectorPtr(new LogicalUnaryOperator<Op>(selStack_)));
-      }     
+        selStack_.push_back(SelectorPtr(new LogicalUnaryOperator<Op>(selStack_)));
+      }
       void operator()(const char&) const {
-	const char * c;
-	operator()(c, c);
-      }     
-      SelectorStack & selStack_;
+        const char* c;
+        operator()(c, c);
+      }
+      SelectorStack& selStack_;
     };
-  }
- }
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/cutParser.cc
+++ b/CommonTools/Utils/src/cutParser.cc
@@ -4,26 +4,28 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 using namespace reco::parser;
-bool reco::parser::cutParser(const edm::TypeWithDict &t, const std::string & cut, SelectorPtr & sel, bool lazy=false) {
-    bool justBlanks = true;
-    for(std::string::const_iterator c = cut.begin(); c != cut.end(); ++c) {
-        if(*c != ' ') { justBlanks = false; break; }
+bool reco::parser::cutParser(const edm::TypeWithDict& t, const std::string& cut, SelectorPtr& sel, bool lazy = false) {
+  bool justBlanks = true;
+  for (std::string::const_iterator c = cut.begin(); c != cut.end(); ++c) {
+    if (*c != ' ') {
+      justBlanks = false;
+      break;
     }
-    if(justBlanks) {
-        sel = SelectorPtr(new AnyObjSelector);
-        return true;
-    } else {
-        using namespace boost::spirit::classic;
-        Grammar grammar(sel, t, lazy);
-        bool returnValue = false;
-        const char* startingFrom =cut.c_str();
-        try {
-            returnValue = parse(startingFrom, grammar.use_parser<0>() >> end_p, space_p).full;
-        } 
-        catch(BaseException& e) {
-            throw edm::Exception(edm::errors::Configuration)<<"Cut parser error:"<<baseExceptionWhat(e)<<" (char "<<e.where-startingFrom<<")\n";
-        }
-        return returnValue;
+  }
+  if (justBlanks) {
+    sel = SelectorPtr(new AnyObjSelector);
+    return true;
+  } else {
+    using namespace boost::spirit::classic;
+    Grammar grammar(sel, t, lazy);
+    bool returnValue = false;
+    const char* startingFrom = cut.c_str();
+    try {
+      returnValue = parse(startingFrom, grammar.use_parser<0>() >> end_p, space_p).full;
+    } catch (BaseException& e) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "Cut parser error:" << baseExceptionWhat(e) << " (char " << e.where - startingFrom << ")\n";
     }
-} 
-
+    return returnValue;
+  }
+}

--- a/CommonTools/Utils/src/expressionParser.cc
+++ b/CommonTools/Utils/src/expressionParser.cc
@@ -4,15 +4,19 @@
 
 using namespace reco::parser;
 
-bool reco::parser::expressionParser(const edm::TypeWithDict &t, const std::string & value, ExpressionPtr & expr, bool lazy) {
-    using namespace boost::spirit::classic;
-    Grammar grammar(expr, t, lazy);
-    bool returnValue = false;
-    const char* startingFrom = value.c_str();
-    try {
-        returnValue=parse(startingFrom, grammar.use_parser<1>() >> end_p, space_p).full;
-    } catch(BaseException&e){
-        throw edm::Exception(edm::errors::Configuration)<<"Expression parser error:"<<baseExceptionWhat(e)<<" (char "<<e.where-startingFrom<<")\n";
-    }
-    return returnValue;
+bool reco::parser::expressionParser(const edm::TypeWithDict& t,
+                                    const std::string& value,
+                                    ExpressionPtr& expr,
+                                    bool lazy) {
+  using namespace boost::spirit::classic;
+  Grammar grammar(expr, t, lazy);
+  bool returnValue = false;
+  const char* startingFrom = value.c_str();
+  try {
+    returnValue = parse(startingFrom, grammar.use_parser<1>() >> end_p, space_p).full;
+  } catch (BaseException& e) {
+    throw edm::Exception(edm::errors::Configuration)
+        << "Expression parser error:" << baseExceptionWhat(e) << " (char " << e.where - startingFrom << ")\n";
+  }
+  return returnValue;
 }

--- a/CommonTools/Utils/src/findDataMember.cc
+++ b/CommonTools/Utils/src/findDataMember.cc
@@ -27,42 +27,35 @@
 
 namespace reco {
 
-edm::
-MemberWithDict
-findDataMember(const edm::TypeWithDict& iType,
-               const std::string& iName,
-               int& oError)
-{
-  edm::MemberWithDict ret;
-  oError = parser::kNameDoesNotExist;
-  edm::TypeWithDict type = iType;
-  if (!bool(type)) {
-    return ret;
-  }
-  if (type.isPointer()) {
-    type = type.toType();
-  }
-  ret = type.dataMemberByName(iName);
-  if (!bool(ret)) {
-    // check base classes
-    edm::TypeBases bases(type);
-    for (auto const& B : bases) {
-      ret = findDataMember(edm::BaseWithDict(B).typeOf(), iName, oError);
-      //only stop if we found it or some other error happened
-      if (bool(ret) || (oError != parser::kNameDoesNotExist)) {
-        break;
+  edm::MemberWithDict findDataMember(const edm::TypeWithDict& iType, const std::string& iName, int& oError) {
+    edm::MemberWithDict ret;
+    oError = parser::kNameDoesNotExist;
+    edm::TypeWithDict type = iType;
+    if (!bool(type)) {
+      return ret;
+    }
+    if (type.isPointer()) {
+      type = type.toType();
+    }
+    ret = type.dataMemberByName(iName);
+    if (!bool(ret)) {
+      // check base classes
+      edm::TypeBases bases(type);
+      for (auto const& B : bases) {
+        ret = findDataMember(edm::BaseWithDict(B).typeOf(), iName, oError);
+        //only stop if we found it or some other error happened
+        if (bool(ret) || (oError != parser::kNameDoesNotExist)) {
+          break;
+        }
       }
     }
+    if (bool(ret) && !ret.isPublic()) {
+      ret = edm::MemberWithDict();
+      oError = parser::kIsNotPublic;
+    } else if (bool(ret)) {
+      oError = parser::kNoError;
+    }
+    return ret;
   }
-  if (bool(ret) && !ret.isPublic()) {
-    ret = edm::MemberWithDict();
-    oError = parser::kIsNotPublic;
-  }
-  else if (bool(ret)) {
-    oError = parser::kNoError;
-  }
-  return ret;
-}
 
-} // namespace reco
-
+}  // namespace reco

--- a/CommonTools/Utils/src/findDataMember.h
+++ b/CommonTools/Utils/src/findDataMember.h
@@ -4,7 +4,7 @@
 //
 // Package:     Utilities
 // Class  :     findDataMember
-// 
+//
 /**\class findDataMember findDataMember.h CommonTools/Util/interface/findDataMember.h
 
  Description: finds a DataMember with a specific name for a Type
@@ -27,7 +27,7 @@
 
 // forward declarations
 namespace reco {
-   edm::MemberWithDict findDataMember(const edm::TypeWithDict& iType, const std::string& iName, int& oError);
+  edm::MemberWithDict findDataMember(const edm::TypeWithDict& iType, const std::string& iName, int& oError);
 }
 
 #endif

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -8,55 +8,47 @@
 
 #include <cassert>
 
-using AnyMethodArgument=reco::parser::AnyMethodArgument;
+using AnyMethodArgument = reco::parser::AnyMethodArgument;
 
 /// Checks for errors which show we got the correct function
 /// but we cannot use it.
-static
-bool
-fatalErrorCondition(const int err)
-{
-  return (err == reco::parser::kIsNotPublic) ||
-         (err == reco::parser::kIsStatic) ||
-         (err == reco::parser::kIsFunctionAddedByROOT) ||
-         (err == reco::parser::kIsConstructor) ||
-         (err == reco::parser::kIsDestructor) ||
-         (err == reco::parser::kIsOperator);
+static bool fatalErrorCondition(const int err) {
+  return (err == reco::parser::kIsNotPublic) || (err == reco::parser::kIsStatic) ||
+         (err == reco::parser::kIsFunctionAddedByROOT) || (err == reco::parser::kIsConstructor) ||
+         (err == reco::parser::kIsDestructor) || (err == reco::parser::kIsOperator);
 }
 
 namespace reco {
 
-int
-checkMethod(const edm::FunctionWithDict& mem,
-            const edm::TypeWithDict& type,
-            const std::vector<AnyMethodArgument>& args,
-            std::vector<AnyMethodArgument>& fixuppedArgs)
-{
-  int casts = 0;
-  if (mem.isConstructor()) {
-    return -1 * parser::kIsConstructor;
-  }
-  if (mem.isDestructor()) {
-    return -1 * parser::kIsDestructor;
-  }
-  // Some operators are allowed, e.g. operator[].
-  //if (mem.isOperator()) {
-  //  return -1 * parser::kIsOperator;
-  //}
-  if (!mem.isPublic()) {
-    return -1 * parser::kIsNotPublic;
-  }
-  if (mem.isStatic()) {
-    return -1 * parser::kIsStatic;
-  }
-  if (!mem.isConst()) {
-    return -1 * parser::kIsNotConst;
-  }
-  if (mem.name().substr(0, 2) == "__") {
-    return -1 * parser::kIsFunctionAddedByROOT;
-  }
-  // Functions from a base class are allowed.
-  //if (mem.declaringType() != type) {
+  int checkMethod(const edm::FunctionWithDict& mem,
+                  const edm::TypeWithDict& type,
+                  const std::vector<AnyMethodArgument>& args,
+                  std::vector<AnyMethodArgument>& fixuppedArgs) {
+    int casts = 0;
+    if (mem.isConstructor()) {
+      return -1 * parser::kIsConstructor;
+    }
+    if (mem.isDestructor()) {
+      return -1 * parser::kIsDestructor;
+    }
+    // Some operators are allowed, e.g. operator[].
+    //if (mem.isOperator()) {
+    //  return -1 * parser::kIsOperator;
+    //}
+    if (!mem.isPublic()) {
+      return -1 * parser::kIsNotPublic;
+    }
+    if (mem.isStatic()) {
+      return -1 * parser::kIsStatic;
+    }
+    if (!mem.isConst()) {
+      return -1 * parser::kIsNotConst;
+    }
+    if (mem.name().substr(0, 2) == "__") {
+      return -1 * parser::kIsFunctionAddedByROOT;
+    }
+    // Functions from a base class are allowed.
+    //if (mem.declaringType() != type) {
     //std::cerr <<
     //  "\nMETHOD OVERLOAD " <<
     //  mem.name() <<
@@ -66,139 +58,114 @@ checkMethod(const edm::FunctionWithDict& mem,
     //  mem.declaringType().qualifiedName() <<
     //  std::endl;
     //return -1 * parser::kOverloaded;
-  //}
+    //}
 
-  size_t minArgs = mem.functionParameterSize(true);
-  size_t maxArgs = mem.functionParameterSize(false);
-  if ((args.size() < minArgs) || (args.size() > maxArgs)) {
-    return -1 * parser::kWrongNumberOfArguments;
+    size_t minArgs = mem.functionParameterSize(true);
+    size_t maxArgs = mem.functionParameterSize(false);
+    if ((args.size() < minArgs) || (args.size() > maxArgs)) {
+      return -1 * parser::kWrongNumberOfArguments;
+    }
+    //std::cerr <<
+    //  "\nMETHOD " <<
+    //  mem.name() <<
+    //  " of " <<
+    //  mem.declaringType().name() <<
+    //  ", min #args = " <<
+    //  minArgs <<
+    //  ", max #args = " <<
+    //  maxArgs <<
+    //  ", args = " <<
+    //  args.size() <<
+    //  std::endl;
+    if (!args.empty()) {
+      std::vector<AnyMethodArgument> tmpFixups;
+      size_t i = 0;
+      for (auto const& param : mem) {
+        edm::TypeWithDict parameter(param);
+        std::pair<AnyMethodArgument, int> fixup =
+            boost::apply_visitor(reco::parser::AnyMethodArgumentFixup(parameter), args[i]);
+        //std::cerr <<
+        //  "\t ARG " <<
+        //  i <<
+        //  " type is " <<
+        //  parameter.name() <<
+        //  " conversion = " <<
+        //  fixup.second <<
+        //  std::endl;
+        if (fixup.second >= 0) {
+          tmpFixups.push_back(fixup.first);
+          casts += fixup.second;
+        } else {
+          return -1 * parser::kWrongArgumentType;
+        }
+        if (++i == args.size()) {
+          break;
+        }
+      }
+      fixuppedArgs.swap(tmpFixups);
+    }
+    //std::cerr <<
+    //  "\nMETHOD " <<
+    //  mem.name() <<
+    //  " of " <<
+    //  mem.declaringType().name() <<
+    //  ", min #args = " <<
+    //  minArgs <<
+    //  ", max #args = " <<
+    //  maxArgs <<
+    //  ", args = " <<
+    //  args.size() <<
+    //  " fixupped args = " <<
+    //  fixuppedArgs.size() <<
+    //  "(" << casts <<
+    //  " implicit casts)" <<
+    //  std::endl;
+    return casts;
   }
-  //std::cerr <<
-  //  "\nMETHOD " <<
-  //  mem.name() <<
-  //  " of " <<
-  //  mem.declaringType().name() <<
-  //  ", min #args = " <<
-  //  minArgs <<
-  //  ", max #args = " <<
-  //  maxArgs <<
-  //  ", args = " <<
-  //  args.size() <<
-  //  std::endl;
-  if (!args.empty()) {
-    std::vector<AnyMethodArgument> tmpFixups;
-    size_t i = 0;
-    for (auto const& param : mem) {
-      edm::TypeWithDict parameter(param);
-      std::pair<AnyMethodArgument, int> fixup =
-        boost::apply_visitor(reco::parser::AnyMethodArgumentFixup(parameter),
-                             args[i]);
-      //std::cerr <<
-      //  "\t ARG " <<
-      //  i <<
-      //  " type is " <<
-      //  parameter.name() <<
-      //  " conversion = " <<
-      //  fixup.second <<
-      //  std::endl;
-      if (fixup.second >= 0) {
-        tmpFixups.push_back(fixup.first);
-        casts += fixup.second;
-      }
-      else {
-        return -1 * parser::kWrongArgumentType;
-      }
-      if (++i == args.size()) {
+
+  typedef std::pair<int, edm::FunctionWithDict> OK;
+
+  bool nCasts(const OK& a, const OK& b) { return a.first < b.first; }
+
+  std::pair<edm::FunctionWithDict, bool> findMethod(const edm::TypeWithDict& t, /*class=in*/
+                                                    const std::string& name,    /*function member name=in*/
+                                                    const std::vector<AnyMethodArgument>& args,   /*args=in*/
+                                                    std::vector<AnyMethodArgument>& fixuppedArgs, /*args=out*/
+                                                    const char* iIterator,                        /*???=out*/
+                                                    int& oError)                                  /*err code=out*/
+  {
+    oError = parser::kNameDoesNotExist;
+    edm::TypeWithDict type = t;
+    if (!bool(type)) {
+      throw parser::Exception(iIterator) << "No dictionary for class \"" << type.name() << "\".";
+    }
+    while (type.isPointer() || type.isReference()) {
+      type = type.toType();
+    }
+    while (type.isTypedef()) {
+      edm::TypeWithDict theType = type.finalType();
+      if (theType == type) {
         break;
       }
+      type = theType;
     }
-    fixuppedArgs.swap(tmpFixups);
-  }
-  //std::cerr <<
-  //  "\nMETHOD " <<
-  //  mem.name() <<
-  //  " of " <<
-  //  mem.declaringType().name() <<
-  //  ", min #args = " <<
-  //  minArgs <<
-  //  ", max #args = " <<
-  //  maxArgs <<
-  //  ", args = " <<
-  //  args.size() <<
-  //  " fixupped args = " <<
-  //  fixuppedArgs.size() <<
-  //  "(" << casts <<
-  //  " implicit casts)" <<
-  //  std::endl;
-  return casts;
-}
-
-typedef std::pair<int, edm::FunctionWithDict> OK;
-
-bool
-nCasts(const OK& a, const OK& b)
-{
-  return a.first < b.first;
-}
-
-std::pair<edm::FunctionWithDict, bool>
-findMethod(const edm::TypeWithDict& t, /*class=in*/
-           const std::string& name, /*function member name=in*/
-           const std::vector<AnyMethodArgument>& args, /*args=in*/
-           std::vector<AnyMethodArgument>& fixuppedArgs, /*args=out*/
-           const char* iIterator, /*???=out*/
-           int& oError) /*err code=out*/
-{
-  oError = parser::kNameDoesNotExist;
-  edm::TypeWithDict type = t;
-  if (!bool(type)) {
-    throw parser::Exception(iIterator) << "No dictionary for class \"" <<
-          type.name() << "\".";
-  }
-  while (type.isPointer() || type.isReference()) {
-    type = type.toType();
-  }
-  while (type.isTypedef()) {
-    edm::TypeWithDict theType = type.finalType();
-    if(theType == type) {
-      break;
-    }
-    type = theType;
-  }
-  // strip const, volatile, c++ ref, ..
-  type = type.stripConstRef();
-  // Create our return value.
-  std::pair<edm::FunctionWithDict, bool> mem;
-  //FIXME: We must initialize mem.first!
-  mem.second = false;
-  // suitable members and number of integer->real casts required to get them
-  std::vector<std::pair<int, edm::FunctionWithDict> > oks;
-  std::string theArgs;
-  for(auto const& item : args) {
-    if(!theArgs.empty()) {
-      theArgs += ',';
-    }
-    theArgs += edm::TypeID(item.type()).className();
-  }
-  edm::FunctionWithDict f = type.functionMemberByName(name, theArgs, true);
-  if(bool(f)) {
-    int casts = checkMethod(f, type, args, fixuppedArgs);
-    if (casts > -1) {
-      oks.push_back(std::make_pair(casts, f));
-    } else {
-      oError = -1 * casts;
-      //is this a show stopper error?
-      if (fatalErrorCondition(oError)) {
-        return mem;
+    // strip const, volatile, c++ ref, ..
+    type = type.stripConstRef();
+    // Create our return value.
+    std::pair<edm::FunctionWithDict, bool> mem;
+    //FIXME: We must initialize mem.first!
+    mem.second = false;
+    // suitable members and number of integer->real casts required to get them
+    std::vector<std::pair<int, edm::FunctionWithDict> > oks;
+    std::string theArgs;
+    for (auto const& item : args) {
+      if (!theArgs.empty()) {
+        theArgs += ',';
       }
+      theArgs += edm::TypeID(item.type()).className();
     }
-  } else {
-    edm::TypeFunctionMembers functions(type);
-    for (auto const& F : functions) {
-      if (std::string(F->GetName()) != name) {
-        continue;
-      }
-      edm::FunctionWithDict f(F);
+    edm::FunctionWithDict f = type.functionMemberByName(name, theArgs, true);
+    if (bool(f)) {
       int casts = checkMethod(f, type, args, fixuppedArgs);
       if (casts > -1) {
         oks.push_back(std::make_pair(casts, f));
@@ -209,84 +176,93 @@ findMethod(const edm::TypeWithDict& t, /*class=in*/
           return mem;
         }
       }
-    }
-  }
-  //std::cout << "At base scope (type " << (type.name()) << ") found " <<
-  //  oks.size() << " methods." << std::endl;
-  // found at least one method
-  if (!oks.empty()) {
-    if (oks.size() > 1) {
-      // sort by number of conversions needed
-      sort(oks.begin(), oks.end(), nCasts);
-      if (oks[0].first == oks[1].first) { // two methods with same ambiguity
-        throw parser::Exception(iIterator) << "Can't resolve method \"" <<
-              name << "\" for class \"" << type.name() <<
-              "\", the two candidates " << oks[0].second.name() << " and " <<
-              oks[1].second.name() <<
-              " require the same number of integer->real conversions (" <<
-              oks[0].first << ").";
-      }
-      // We must fixup the args again, as both good methods
-      // have pushed them on fixuppedArgs.
-      fixuppedArgs.clear();
-      checkMethod(oks.front().second, type, args, fixuppedArgs);
-    }
-    mem.first = oks.front().second;
-  }
-  // if nothing was found, look in parent scopes without
-  // checking for cross-scope overloading, as it is not
-  // allowed
-  int baseError = parser::kNameDoesNotExist;
-  if (!bool(mem.first)) {
-    edm::TypeBases bases(type);
-    for (auto const& B : bases) {
-      mem = findMethod(edm::BaseWithDict(B).typeOf(), name, args,
-                       fixuppedArgs, iIterator, baseError);
-      if (bool(mem.first)) {
-        break;
-      }
-      if (fatalErrorCondition(baseError)) {
-        oError = baseError;
-        return mem;
-      }
-    }
-  }
-  // otherwise see if this object is just a Ref or Ptr and we should pop it out
-  if (!bool(mem.first)) {
-    // check for edm::Ref or edm::RefToBase or edm::Ptr
-    if (type.isTemplateInstance()) {
-      std::string name = type.templateName();
-      if (!name.compare("edm::Ref") || !name.compare("edm::RefToBase") ||
-          !name.compare("edm::Ptr")) {
-        // in this case  i think 'get' should be taken with no arguments!
-        std::vector<AnyMethodArgument> empty;
-        std::vector<AnyMethodArgument> empty2;
-        int error = 0;
-        mem = findMethod(type, "get", empty, empty2, iIterator, error);
-        if (!bool(mem.first)) {
-          throw parser::Exception(iIterator) <<
-                "No member \"get\" in reference of type \"" <<
-                type.name() << "\".";
+    } else {
+      edm::TypeFunctionMembers functions(type);
+      for (auto const& F : functions) {
+        if (std::string(F->GetName()) != name) {
+          continue;
         }
-        mem.second = true;
+        edm::FunctionWithDict f(F);
+        int casts = checkMethod(f, type, args, fixuppedArgs);
+        if (casts > -1) {
+          oks.push_back(std::make_pair(casts, f));
+        } else {
+          oError = -1 * casts;
+          //is this a show stopper error?
+          if (fatalErrorCondition(oError)) {
+            return mem;
+          }
+        }
       }
     }
-  }
-  //if (!bool(mem.first)) {
-  //  throw edm::Exception(edm::errors::Configuration) << "member \""" <<
-  //        name << "\"" not found in class \""  << type.name() << "\"";
-  //}
-  if (bool(mem.first)) {
-    oError = parser::kNoError;
-  }
-  else {
-    // use error from base check if we never found function in primary class
-    if (oError == parser::kNameDoesNotExist) {
-      oError = baseError;
+    //std::cout << "At base scope (type " << (type.name()) << ") found " <<
+    //  oks.size() << " methods." << std::endl;
+    // found at least one method
+    if (!oks.empty()) {
+      if (oks.size() > 1) {
+        // sort by number of conversions needed
+        sort(oks.begin(), oks.end(), nCasts);
+        if (oks[0].first == oks[1].first) {  // two methods with same ambiguity
+          throw parser::Exception(iIterator)
+              << "Can't resolve method \"" << name << "\" for class \"" << type.name() << "\", the two candidates "
+              << oks[0].second.name() << " and " << oks[1].second.name()
+              << " require the same number of integer->real conversions (" << oks[0].first << ").";
+        }
+        // We must fixup the args again, as both good methods
+        // have pushed them on fixuppedArgs.
+        fixuppedArgs.clear();
+        checkMethod(oks.front().second, type, args, fixuppedArgs);
+      }
+      mem.first = oks.front().second;
     }
+    // if nothing was found, look in parent scopes without
+    // checking for cross-scope overloading, as it is not
+    // allowed
+    int baseError = parser::kNameDoesNotExist;
+    if (!bool(mem.first)) {
+      edm::TypeBases bases(type);
+      for (auto const& B : bases) {
+        mem = findMethod(edm::BaseWithDict(B).typeOf(), name, args, fixuppedArgs, iIterator, baseError);
+        if (bool(mem.first)) {
+          break;
+        }
+        if (fatalErrorCondition(baseError)) {
+          oError = baseError;
+          return mem;
+        }
+      }
+    }
+    // otherwise see if this object is just a Ref or Ptr and we should pop it out
+    if (!bool(mem.first)) {
+      // check for edm::Ref or edm::RefToBase or edm::Ptr
+      if (type.isTemplateInstance()) {
+        std::string name = type.templateName();
+        if (!name.compare("edm::Ref") || !name.compare("edm::RefToBase") || !name.compare("edm::Ptr")) {
+          // in this case  i think 'get' should be taken with no arguments!
+          std::vector<AnyMethodArgument> empty;
+          std::vector<AnyMethodArgument> empty2;
+          int error = 0;
+          mem = findMethod(type, "get", empty, empty2, iIterator, error);
+          if (!bool(mem.first)) {
+            throw parser::Exception(iIterator) << "No member \"get\" in reference of type \"" << type.name() << "\".";
+          }
+          mem.second = true;
+        }
+      }
+    }
+    //if (!bool(mem.first)) {
+    //  throw edm::Exception(edm::errors::Configuration) << "member \""" <<
+    //        name << "\"" not found in class \""  << type.name() << "\"";
+    //}
+    if (bool(mem.first)) {
+      oError = parser::kNoError;
+    } else {
+      // use error from base check if we never found function in primary class
+      if (oError == parser::kNameDoesNotExist) {
+        oError = baseError;
+      }
+    }
+    return mem;
   }
-  return mem;
-}
 
-} // namespace reco
-
+}  // namespace reco

--- a/CommonTools/Utils/src/findMethod.h
+++ b/CommonTools/Utils/src/findMethod.h
@@ -6,14 +6,14 @@
 #include "CommonTools/Utils/src/AnyMethodArgument.h"
 
 namespace reco {
-  // second pair member is true if a reference is found 
+  // second pair member is true if a reference is found
   // of type edm::Ref, edm::RefToBase or edm::Ptr
-  std::pair<edm::FunctionWithDict, bool> findMethod(const edm::TypeWithDict & type,
-						   const std::string & name,
-						   const std::vector<reco::parser::AnyMethodArgument> &args,
-                                                   std::vector<reco::parser::AnyMethodArgument> &fixuppedArgs,
-                                                   const char* where,
-                                                   int& oError);
-}
+  std::pair<edm::FunctionWithDict, bool> findMethod(const edm::TypeWithDict& type,
+                                                    const std::string& name,
+                                                    const std::vector<reco::parser::AnyMethodArgument>& args,
+                                                    std::vector<reco::parser::AnyMethodArgument>& fixuppedArgs,
+                                                    const char* where,
+                                                    int& oError);
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
+++ b/CommonTools/Utils/src/formulaBinaryOperatorEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     formulaBinaryOperatorEvaluator
-// 
+//
 /**\class reco::formula::BinaryOperatorEvaluator formulaBinaryOperatorEvaluator.h "formulaBinaryOperatorEvaluator.h"
 
  Description: [one line class summary]
@@ -30,27 +30,18 @@ namespace reco {
   namespace formula {
     class BinaryOperatorEvaluatorBase : public EvaluatorBase {
     public:
-    BinaryOperatorEvaluatorBase( std::shared_ptr<EvaluatorBase> iLHS, 
-                                 std::shared_ptr<EvaluatorBase> iRHS,
-                                 Precedence iPrec) :
-      EvaluatorBase(iPrec),
-        m_lhs(iLHS),
-        m_rhs(iRHS) {}
+      BinaryOperatorEvaluatorBase(std::shared_ptr<EvaluatorBase> iLHS,
+                                  std::shared_ptr<EvaluatorBase> iRHS,
+                                  Precedence iPrec)
+          : EvaluatorBase(iPrec), m_lhs(iLHS), m_rhs(iRHS) {}
 
-    BinaryOperatorEvaluatorBase(Precedence iPrec) :
-      EvaluatorBase(iPrec) {}
+      BinaryOperatorEvaluatorBase(Precedence iPrec) : EvaluatorBase(iPrec) {}
 
-      void swapLeftEvaluator(std::shared_ptr<EvaluatorBase>& iNew ) {
-        m_lhs.swap(iNew);
-      }
+      void swapLeftEvaluator(std::shared_ptr<EvaluatorBase>& iNew) { m_lhs.swap(iNew); }
 
-      void setLeftEvaluator(std::shared_ptr<EvaluatorBase> iOther) {
-        m_lhs = std::move(iOther);
-      }
-      void setRightEvaluator(std::shared_ptr<EvaluatorBase> iOther) {
-        m_rhs = std::move(iOther);
-      }
-      
+      void setLeftEvaluator(std::shared_ptr<EvaluatorBase> iOther) { m_lhs = std::move(iOther); }
+      void setRightEvaluator(std::shared_ptr<EvaluatorBase> iOther) { m_rhs = std::move(iOther); }
+
       EvaluatorBase const* lhs() const { return m_lhs.get(); }
       EvaluatorBase const* rhs() const { return m_rhs.get(); }
 
@@ -59,54 +50,49 @@ namespace reco {
       std::shared_ptr<EvaluatorBase> m_rhs;
     };
 
-    template<typename Op>
-      class BinaryOperatorEvaluator : public BinaryOperatorEvaluatorBase
-    {
-      
+    template <typename Op>
+    class BinaryOperatorEvaluator : public BinaryOperatorEvaluatorBase {
     public:
-      BinaryOperatorEvaluator(std::shared_ptr<EvaluatorBase> iLHS, 
+      BinaryOperatorEvaluator(std::shared_ptr<EvaluatorBase> iLHS,
                               std::shared_ptr<EvaluatorBase> iRHS,
-                              Precedence iPrec):
-      BinaryOperatorEvaluatorBase(std::move(iLHS), std::move(iRHS), iPrec) {}
+                              Precedence iPrec)
+          : BinaryOperatorEvaluatorBase(std::move(iLHS), std::move(iRHS), iPrec) {}
 
-    BinaryOperatorEvaluator(Precedence iPrec):
-      BinaryOperatorEvaluatorBase(iPrec) {}
+      BinaryOperatorEvaluator(Precedence iPrec) : BinaryOperatorEvaluatorBase(iPrec) {}
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final {
-        return m_operator(lhs()->evaluate(iVariables,iParameters),rhs()->evaluate(iVariables,iParameters));
+        return m_operator(lhs()->evaluate(iVariables, iParameters), rhs()->evaluate(iVariables, iParameters));
       }
 
       std::vector<std::string> abstractSyntaxTree() const final {
         std::vector<std::string> ret;
-        if( lhs()) {
+        if (lhs()) {
           ret = shiftAST(lhs()->abstractSyntaxTree());
         } else {
           ret.emplace_back(".nullptr");
         }
-        if(rhs() ){
+        if (rhs()) {
           auto child = shiftAST(rhs()->abstractSyntaxTree());
-          for(auto& v: child) {
+          for (auto& v : child) {
             ret.emplace_back(std::move(v));
           }
         } else {
           ret.emplace_back(".nullptr");
         }
-        ret.emplace(ret.begin(), std::string("op ")+std::to_string(precedence()) );
+        ret.emplace(ret.begin(), std::string("op ") + std::to_string(precedence()));
         return ret;
       }
 
     private:
       BinaryOperatorEvaluator(const BinaryOperatorEvaluator&) = delete;
-      
+
       const BinaryOperatorEvaluator& operator=(const BinaryOperatorEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       Op m_operator;
-
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaConstantEvaluator.cc
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::ConstantEvaluator
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -15,7 +15,6 @@
 // user include files
 #include "formulaConstantEvaluator.h"
 
-
 namespace reco {
   namespace formula {
     double ConstantEvaluator::evaluate(double const* /*iVariables*/, double const* /*iParameters*/) const {
@@ -23,7 +22,7 @@ namespace reco {
     }
 
     std::vector<std::string> ConstantEvaluator::abstractSyntaxTree() const {
-      return std::vector<std::string>{1, std::to_string(m_value) };
+      return std::vector<std::string>{1, std::to_string(m_value)};
     }
-  }
-}
+  }  // namespace formula
+}  // namespace reco

--- a/CommonTools/Utils/src/formulaConstantEvaluator.h
+++ b/CommonTools/Utils/src/formulaConstantEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::ConstantEvaluator
-// 
+//
 /**\class reco::formula::ConstantEvaluator formulaConstantEvaluator.h "formulaConstantEvaluator.h"
 
  Description: [one line class summary]
@@ -27,27 +27,23 @@
 
 namespace reco {
   namespace formula {
-    class ConstantEvaluator : public EvaluatorBase
-    {
-      
+    class ConstantEvaluator : public EvaluatorBase {
     public:
       explicit ConstantEvaluator(double iValue) : m_value(iValue) {}
-      
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final;
-      std::vector<std::string> abstractSyntaxTree() const final ;
-      
+      std::vector<std::string> abstractSyntaxTree() const final;
+
     private:
       ConstantEvaluator(const ConstantEvaluator&) = delete;
-      
+
       const ConstantEvaluator& operator=(const ConstantEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       double m_value;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaEvaluatorBase.cc
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::EvaluatorBase
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -16,7 +16,6 @@
 // user include files
 #include "CommonTools/Utils/src/formulaEvaluatorBase.h"
 
-
 //
 // constants, enums and typedefs
 //
@@ -28,25 +27,15 @@
 //
 // constructors and destructor
 //
-reco::formula::EvaluatorBase::EvaluatorBase():
-  m_precedence(static_cast<unsigned int>(Precedence::kFunction))
-{
-}
+reco::formula::EvaluatorBase::EvaluatorBase() : m_precedence(static_cast<unsigned int>(Precedence::kFunction)) {}
 
-reco::formula::EvaluatorBase::EvaluatorBase(Precedence iPrec):
-  m_precedence(static_cast<unsigned int>(iPrec))
-{
-}
+reco::formula::EvaluatorBase::EvaluatorBase(Precedence iPrec) : m_precedence(static_cast<unsigned int>(iPrec)) {}
 
-reco::formula::EvaluatorBase::~EvaluatorBase()
-{
-}
+reco::formula::EvaluatorBase::~EvaluatorBase() {}
 
-std::vector<std::string> 
-reco::formula::shiftAST(std::vector<std::string> child) {
-  for(auto& c: child) {
-    c.insert(c.begin(),'.');
+std::vector<std::string> reco::formula::shiftAST(std::vector<std::string> child) {
+  for (auto& c : child) {
+    c.insert(c.begin(), '.');
   }
   return child;
 }
-

--- a/CommonTools/Utils/src/formulaEvaluatorBase.h
+++ b/CommonTools/Utils/src/formulaEvaluatorBase.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::EvaluatorBase
-// 
+//
 /**\class reco::formula::EvaluatorBase formulaEvaluatorBase.h "formulaEvaluatorBase.h"
 
  Description: Base class for formula evaluators
@@ -31,27 +31,25 @@
 namespace reco {
   namespace formula {
     std::vector<std::string> shiftAST(std::vector<std::string> child);
-    class EvaluatorBase
-    {
-      
+    class EvaluatorBase {
     public:
       enum class Precedence {
-          kIdentity = 1,
-          kComparison=2,
-          kPlusMinus = 3,
-          kMultDiv = 4,
-          kPower = 5,
-          kFunction = 6, //default
-          kParenthesis = 7,
-          kUnaryMinusOperator = 8
-          };
+        kIdentity = 1,
+        kComparison = 2,
+        kPlusMinus = 3,
+        kMultDiv = 4,
+        kPower = 5,
+        kFunction = 6,  //default
+        kParenthesis = 7,
+        kUnaryMinusOperator = 8
+      };
 
       EvaluatorBase();
       EvaluatorBase(Precedence);
       virtual ~EvaluatorBase();
-      
+
       // ---------- const member functions ---------------------
-      //inputs are considered to be 'arrays' which have already been validated to 
+      //inputs are considered to be 'arrays' which have already been validated to
       // be of the appropriate length
       virtual double evaluate(double const* iVariables, double const* iParameters) const = 0;
       virtual std::vector<std::string> abstractSyntaxTree() const = 0;
@@ -60,15 +58,14 @@ namespace reco {
       void setPrecedenceToParenthesis() { m_precedence = static_cast<unsigned int>(Precedence::kParenthesis); }
 
     private:
-      EvaluatorBase(const EvaluatorBase&) = delete; 
-      
+      EvaluatorBase(const EvaluatorBase&) = delete;
+
       const EvaluatorBase& operator=(const EvaluatorBase&) = delete;
-      
+
       // ---------- member data --------------------------------
       unsigned int m_precedence;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionOneArgEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     formulaFunctionOneArgEvaluator
-// 
+//
 /**\class reco::formula::FunctionOneArgEvaluator formulaFunctionOneArgEvaluator.h "formulaFunctionOneArgEvaluator.h"
 
  Description: [one line class summary]
@@ -29,35 +29,32 @@
 
 namespace reco {
   namespace formula {
-    class FunctionOneArgEvaluator : public EvaluatorBase
-    {
-      
+    class FunctionOneArgEvaluator : public EvaluatorBase {
     public:
-      template<typename T>
-      explicit FunctionOneArgEvaluator(std::shared_ptr<EvaluatorBase> iArg, T iFunc):
-        m_arg(std::move(iArg)),
-        m_function(iFunc) {}
-       
+      template <typename T>
+      explicit FunctionOneArgEvaluator(std::shared_ptr<EvaluatorBase> iArg, T iFunc)
+          : m_arg(std::move(iArg)), m_function(iFunc) {}
+
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final {
-        return m_function( m_arg->evaluate(iVariables,iParameters) );
+        return m_function(m_arg->evaluate(iVariables, iParameters));
       }
       std::vector<std::string> abstractSyntaxTree() const final {
         auto ret = shiftAST(m_arg->abstractSyntaxTree());
         ret.emplace(ret.begin(), "func 1 arg");
         return ret;
       }
+
     private:
       FunctionOneArgEvaluator(const FunctionOneArgEvaluator&) = delete;
-      
+
       const FunctionOneArgEvaluator& operator=(const FunctionOneArgEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       std::shared_ptr<EvaluatorBase> m_arg;
       std::function<double(double)> m_function;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
+++ b/CommonTools/Utils/src/formulaFunctionTwoArgsEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     formulaFunctionTwoArgsEvaluator
-// 
+//
 /**\class reco::formula::FunctionTwoArgsEvaluator formulaFunctionTwoArgsEvaluator.h "formulaFunctionTwoArgsEvaluator.h"
 
  Description: [one line class summary]
@@ -29,27 +29,19 @@
 
 namespace reco {
   namespace formula {
-    class FunctionTwoArgsEvaluator : public EvaluatorBase
-    {
-      
+    class FunctionTwoArgsEvaluator : public EvaluatorBase {
     public:
-      template<typename T>
-    FunctionTwoArgsEvaluator(std::shared_ptr<EvaluatorBase> iArg1,
-                             std::shared_ptr<EvaluatorBase> iArg2,
-                             T iFunc):
-      m_arg1(std::move(iArg1)),
-        m_arg2(std::move(iArg2)),
-        m_function(iFunc)
-        {}
+      template <typename T>
+      FunctionTwoArgsEvaluator(std::shared_ptr<EvaluatorBase> iArg1, std::shared_ptr<EvaluatorBase> iArg2, T iFunc)
+          : m_arg1(std::move(iArg1)), m_arg2(std::move(iArg2)), m_function(iFunc) {}
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final {
-        return m_function( m_arg1->evaluate(iVariables,iParameters),
-                           m_arg2->evaluate(iVariables,iParameters) );
+        return m_function(m_arg1->evaluate(iVariables, iParameters), m_arg2->evaluate(iVariables, iParameters));
       }
       std::vector<std::string> abstractSyntaxTree() const final {
         auto ret = shiftAST(m_arg1->abstractSyntaxTree());
-        for(auto& v: shiftAST(m_arg2->abstractSyntaxTree()) ) {
+        for (auto& v : shiftAST(m_arg2->abstractSyntaxTree())) {
           ret.emplace_back(std::move(v));
         }
         ret.emplace(ret.begin(), "func 2 args");
@@ -58,16 +50,15 @@ namespace reco {
 
     private:
       FunctionTwoArgsEvaluator(const FunctionTwoArgsEvaluator&) = delete;
-      
+
       const FunctionTwoArgsEvaluator& operator=(const FunctionTwoArgsEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       std::shared_ptr<EvaluatorBase> m_arg1;
       std::shared_ptr<EvaluatorBase> m_arg2;
-      std::function<double(double,double)> m_function;
+      std::function<double(double, double)> m_function;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaParameterEvaluator.cc
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::ParameterEvaluator
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -15,14 +15,13 @@
 // user include files
 #include "formulaParameterEvaluator.h"
 
-
 namespace reco {
   namespace formula {
     double ParameterEvaluator::evaluate(double const* /*iVariables*/, double const* iParameters) const {
       return iParameters[m_index];
     }
     std::vector<std::string> ParameterEvaluator::abstractSyntaxTree() const {
-      return std::vector<std::string>{1, std::string("par[")+std::to_string(m_index)+"]"};
+      return std::vector<std::string>{1, std::string("par[") + std::to_string(m_index) + "]"};
     }
-  }
-}
+  }  // namespace formula
+}  // namespace reco

--- a/CommonTools/Utils/src/formulaParameterEvaluator.h
+++ b/CommonTools/Utils/src/formulaParameterEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::ParameterEvaluator
-// 
+//
 /**\class reco::formula::ParameterEvaluator formulaParameterEvaluator.h "formulaParameterEvaluator.h"
 
  Description: [one line class summary]
@@ -27,27 +27,23 @@
 
 namespace reco {
   namespace formula {
-    class ParameterEvaluator : public EvaluatorBase
-    {
-      
+    class ParameterEvaluator : public EvaluatorBase {
     public:
       explicit ParameterEvaluator(unsigned int iIndex) : m_index(iIndex) {}
-      
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final;
       std::vector<std::string> abstractSyntaxTree() const final;
-      
+
     private:
       ParameterEvaluator(const ParameterEvaluator&) = delete;
-      
+
       const ParameterEvaluator& operator=(const ParameterEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       unsigned int m_index;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
+++ b/CommonTools/Utils/src/formulaUnaryMinusEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     formulaUnaryMinusEvaluator
-// 
+//
 /**\class reco::formula::UnaryMinusEvaluator formulaUnaryMinusEvaluator.h "formulaUnaryMinusEvaluator.h"
 
  Description: [one line class summary]
@@ -29,33 +29,30 @@
 
 namespace reco {
   namespace formula {
-    class UnaryMinusEvaluator : public EvaluatorBase
-    {
-      
+    class UnaryMinusEvaluator : public EvaluatorBase {
     public:
-      explicit UnaryMinusEvaluator(std::shared_ptr<EvaluatorBase> iArg):
-      EvaluatorBase(Precedence::kUnaryMinusOperator ),
-      m_arg(std::move(iArg)) {}
-       
+      explicit UnaryMinusEvaluator(std::shared_ptr<EvaluatorBase> iArg)
+          : EvaluatorBase(Precedence::kUnaryMinusOperator), m_arg(std::move(iArg)) {}
+
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final {
-        return -1. * m_arg->evaluate(iVariables,iParameters) ;
+        return -1. * m_arg->evaluate(iVariables, iParameters);
       }
       std::vector<std::string> abstractSyntaxTree() const final {
         auto ret = shiftAST(m_arg->abstractSyntaxTree());
         ret.emplace(ret.begin(), "unary minus");
         return ret;
       }
+
     private:
       UnaryMinusEvaluator(const UnaryMinusEvaluator&) = delete;
-      
+
       const UnaryMinusEvaluator& operator=(const UnaryMinusEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       std::shared_ptr<EvaluatorBase> m_arg;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/formulaVariableEvaluator.cc
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::VariableEvaluator
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -15,7 +15,6 @@
 // user include files
 #include "formulaVariableEvaluator.h"
 
-
 namespace reco {
   namespace formula {
     double VariableEvaluator::evaluate(double const* iVariables, double const* /*iParameters*/) const {
@@ -23,7 +22,7 @@ namespace reco {
     }
 
     std::vector<std::string> VariableEvaluator::abstractSyntaxTree() const {
-      return std::vector<std::string>{1, std::string("var[")+std::to_string(m_index)+"]"};
+      return std::vector<std::string>{1, std::string("var[") + std::to_string(m_index) + "]"};
     }
-  }
-}
+  }  // namespace formula
+}  // namespace reco

--- a/CommonTools/Utils/src/formulaVariableEvaluator.h
+++ b/CommonTools/Utils/src/formulaVariableEvaluator.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/Utils
 // Class  :     reco::formula::VariableEvaluator
-// 
+//
 /**\class reco::formula::VariableEvaluator formulaVariableEvaluator.h "formulaVariableEvaluator.h"
 
  Description: [one line class summary]
@@ -27,27 +27,23 @@
 
 namespace reco {
   namespace formula {
-    class VariableEvaluator : public EvaluatorBase
-    {
-      
+    class VariableEvaluator : public EvaluatorBase {
     public:
       explicit VariableEvaluator(unsigned int iIndex) : m_index(iIndex) {}
-      
 
       // ---------- const member functions ---------------------
       double evaluate(double const* iVariables, double const* iParameters) const final;
       std::vector<std::string> abstractSyntaxTree() const final;
-      
+
     private:
       VariableEvaluator(const VariableEvaluator&) = delete;
-      
+
       const VariableEvaluator& operator=(const VariableEvaluator&) = delete;
-      
+
       // ---------- member data --------------------------------
       unsigned int m_index;
     };
-  }
-}
-
+  }  // namespace formula
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/src/popenCPP.cc
+++ b/CommonTools/Utils/src/popenCPP.cc
@@ -6,69 +6,63 @@
 #include <string>
 #include <istream>
 
+namespace {
+  class fbuf final : public std::streambuf {
+    FILE *file;
+    char *buf;
+    constexpr static size_t bufsz = 4096;
 
-namespace{
-        class fbuf final : public std::streambuf{
-                FILE *file;
-                char *buf;
-                constexpr static size_t bufsz = 4096;
-        public:
-                fbuf(FILE *f);
-                ~fbuf() override;
-        protected:
-                std::streambuf *setbuf(char_type *s, std::streamsize n) override;
-                int sync() override;
-                int_type underflow() override;
-        };
+  public:
+    fbuf(FILE *f);
+    ~fbuf() override;
 
-        class cfstream final : public std::istream{
-                fbuf buf;
-        public:
-                cfstream(FILE *f);
-        };
+  protected:
+    std::streambuf *setbuf(char_type *s, std::streamsize n) override;
+    int sync() override;
+    int_type underflow() override;
+  };
+
+  class cfstream final : public std::istream {
+    fbuf buf;
+
+  public:
+    cfstream(FILE *f);
+  };
+}  // namespace
+
+std::unique_ptr<std::istream> reco::exprEvalDetails::popenCPP(const std::string &cmdline) {
+  FILE *f = popen(cmdline.c_str(), "r");
+  if (!f)
+    throw cms::Exception("PopenCPP", "(\"" + cmdline + "\") failed");
+  return std::unique_ptr<std::istream>(new cfstream(f));
 }
 
-std::unique_ptr<std::istream> reco::exprEvalDetails::popenCPP(const std::string &cmdline){
-        FILE *f = popen(cmdline.c_str(), "r");
-        if(!f)
-	  throw  cms::Exception("PopenCPP","(\""+cmdline+"\") failed");
-        return std::unique_ptr<std::istream>(new cfstream(f));
+fbuf::fbuf(FILE *f) : file(f), buf(new char[bufsz]) { this->setg(this->buf, this->buf + bufsz, this->buf + bufsz); }
+
+fbuf::~fbuf() {
+  delete[] this->buf;
+  pclose(this->file);
 }
 
+std::streambuf *fbuf::setbuf(char_type *s, std::streamsize n) { return nullptr; }
 
-fbuf::fbuf(FILE *f)
-        : file(f), buf(new char[bufsz]){
-        this->setg(this->buf, this->buf+bufsz, this->buf+bufsz);
+int fbuf::sync() {
+  if (fflush(this->file) != 0)
+    return -1;
+  return 0;
 }
 
-fbuf::~fbuf(){
-        delete [] this->buf;
-        pclose(this->file);
+fbuf::int_type fbuf::underflow() {
+  if (this->gptr() < this->egptr()) {
+    char c = *this->gptr();
+    this->setg(this->eback(), this->gptr() + 1, this->egptr());
+    return traits_type::to_int_type(c);
+  }
+  size_t n = fread(this->buf, 1, sizeof(this->buf), this->file);
+  if (n == 0)
+    return traits_type::eof();
+  this->setg(this->buf, this->buf, this->buf + n);
+  return traits_type::to_int_type(*this->gptr());
 }
 
-std::streambuf *fbuf::setbuf(char_type *s, std::streamsize n){
-        return nullptr;
-}
-
-int fbuf::sync(){
-        if(fflush(this->file) != 0)
-                return -1;
-        return 0;
-}
-
-fbuf::int_type fbuf::underflow(){
-        if(this->gptr() < this->egptr()){
-                char c = *this->gptr();
-                this->setg(this->eback(), this->gptr()+1, this->egptr());
-                return traits_type::to_int_type(c);
-        }
-        size_t n = fread(this->buf, 1, sizeof(this->buf), this->file);
-        if(n == 0)
-                return traits_type::eof();
-        this->setg(this->buf, this->buf, this->buf+n);
-        return traits_type::to_int_type(*this->gptr());
-}
-
-cfstream::cfstream(FILE *f)
-        : std::istream(&buf), buf(f){
-}
+cfstream::cfstream(FILE *f) : std::istream(&buf), buf(f) {}

--- a/CommonTools/Utils/src/popenCPP.h
+++ b/CommonTools/Utils/src/popenCPP.h
@@ -1,28 +1,24 @@
 #ifndef CommonToolsUtils_popenCPP_H
 #define CommonToolsUtils_popenCPP_H
-#include<memory>
-#include<string>
+#include <memory>
+#include <string>
 #include <sstream>
-
 
 namespace reco {
   namespace exprEvalDetails {
 
     std::unique_ptr<std::istream> popenCPP(const std::string &cmdline);
 
-    inline
-    std::string execSysCommand(const std::string &cmdline){
-     std::ostringstream n1;
-     {
-       auto s1 = popenCPP(cmdline+" 2>&1");
-       n1 << s1->rdbuf();
-     }
-     return n1.str();
+    inline std::string execSysCommand(const std::string &cmdline) {
+      std::ostringstream n1;
+      {
+        auto s1 = popenCPP(cmdline + " 2>&1");
+        n1 << s1->rdbuf();
+      }
+      return n1.str();
     }
 
-  }
-}
+  }  // namespace exprEvalDetails
+}  // namespace reco
 
-
-#endif // CommonToolsUtils__popenCPP_H
-
+#endif  // CommonToolsUtils__popenCPP_H

--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -13,47 +13,41 @@ using namespace std;
 
 namespace reco {
 
-  edm::TypeWithDict returnType(const edm::FunctionWithDict& func) {
-    return func.finalReturnType();
-  }
+  edm::TypeWithDict returnType(const edm::FunctionWithDict& func) { return func.finalReturnType(); }
 
-  TypeCode returnTypeCode(const edm::FunctionWithDict& func) {
-    return typeCode(returnType(func));
-  }
+  TypeCode returnTypeCode(const edm::FunctionWithDict& func) { return typeCode(returnType(func)); }
 
   //this is already alphabetized
-  static const std::vector<std::pair<char const* const, method::TypeCode> > retTypeVec {
-     {"bool", boolType},
-     {"char", charType},
-     {"double", doubleType},
-     {"float", floatType},
-     {"int", intType},
-     {"long", longType},
-     {"long int", longType},
-     {"short", shortType},
-     {"short int", shortType},
-     {"size_t", uLongType},
-     {"unsigned char", uCharType},
-     {"unsigned int", uIntType},
-     {"unsigned long", uLongType},
-     {"unsigned long int", uLongType},
-     {"unsigned short", uShortType},
-     {"unsigned short int", uShortType}
-  };
+  static const std::vector<std::pair<char const* const, method::TypeCode> > retTypeVec{
+      {"bool", boolType},
+      {"char", charType},
+      {"double", doubleType},
+      {"float", floatType},
+      {"int", intType},
+      {"long", longType},
+      {"long int", longType},
+      {"short", shortType},
+      {"short int", shortType},
+      {"size_t", uLongType},
+      {"unsigned char", uCharType},
+      {"unsigned int", uIntType},
+      {"unsigned long", uLongType},
+      {"unsigned long int", uLongType},
+      {"unsigned short", uShortType},
+      {"unsigned short int", uShortType}};
 
   TypeCode typeCode(const edm::TypeWithDict& t) {
     typedef std::pair<const char* const, method::TypeCode> Values;
     std::string name = t.name();
-    auto f = std::equal_range(retTypeVec.begin(), retTypeVec.end(),
-      Values{name.c_str(), enumType},
-      [](const Values& iLHS, const Values& iRHS) -> bool {
-        return std::strcmp(iLHS.first, iRHS.first) < 0;
-      });
+    auto f = std::equal_range(
+        retTypeVec.begin(),
+        retTypeVec.end(),
+        Values{name.c_str(), enumType},
+        [](const Values& iLHS, const Values& iRHS) -> bool { return std::strcmp(iLHS.first, iRHS.first) < 0; });
     if (f.first == f.second) {
       return t.isEnum() ? enumType : invalid;
     }
     return f.first->second;
   }
 
-} // namespace reco
-
+}  // namespace reco

--- a/CommonTools/Utils/src/returnType.h
+++ b/CommonTools/Utils/src/returnType.h
@@ -11,13 +11,13 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 
 namespace edm {
-class FunctionWithDict;
+  class FunctionWithDict;
 }
 
 namespace reco {
   edm::TypeWithDict returnType(const edm::FunctionWithDict&);
   method::TypeCode returnTypeCode(const edm::FunctionWithDict&);
   method::TypeCode typeCode(const edm::TypeWithDict&);
-}
+}  // namespace reco
 
-#endif // CommonTools_Utils_returnType_h
+#endif  // CommonTools_Utils_returnType_h

--- a/CommonTools/Utils/test/ExprEvalPopen_t.cpp
+++ b/CommonTools/Utils/test/ExprEvalPopen_t.cpp
@@ -1,37 +1,34 @@
 #include "CommonTools/Utils/src/popenCPP.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include<iostream>
-#include<string>
-
+#include <iostream>
+#include <string>
 
 using namespace reco::exprEvalDetails;
 
 int main() {
-
-  try { 
+  try {
     char c;
     {
-    auto ss = popenCPP("c++ -v 2>&1");
-    while (ss->get(c)) std::cout << c;
-    std::cout << std::endl;
+      auto ss = popenCPP("c++ -v 2>&1");
+      while (ss->get(c))
+        std::cout << c;
+      std::cout << std::endl;
     }
-    
 
     {
-    auto n1 = execSysCommand( "c++ -v");
-    std::cout << "\n|" << n1 << '|' << std::endl;
+      auto n1 = execSysCommand("c++ -v");
+      std::cout << "\n|" << n1 << '|' << std::endl;
     }
 
-    std::cout << "\n|" <<  execSysCommand("uuidgen | sed 's/-//g'") << '|' << std::endl;
+    std::cout << "\n|" << execSysCommand("uuidgen | sed 's/-//g'") << '|' << std::endl;
 
-    std::cout << "\n|" <<  execSysCommand("notexisting 2>&1") << '|' << std::endl;
+    std::cout << "\n|" << execSysCommand("notexisting 2>&1") << '|' << std::endl;
 
-  }catch( cms::Exception const & e) {
-    std::cout << e.what()  << std::endl;
-  }catch(...) {
+  } catch (cms::Exception const& e) {
+    std::cout << e.what() << std::endl;
+  } catch (...) {
     std::cout << "unknown error...." << std::endl;
   }
 
   return 0;
-
 }

--- a/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
+++ b/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
@@ -10,82 +10,82 @@
 #include <atomic>
 
 int main() {
-
-   // build fake test package...
-   std::string pkg = "ExpressionEvaluatorTests/EEUnitTest";
+  // build fake test package...
+  std::string pkg = "ExpressionEvaluatorTests/EEUnitTest";
 
   using reco::ExpressionEvaluator;
 
-  using vcut = reco::genericExpression<bool,int,int>;
+  using vcut = reco::genericExpression<bool, int, int>;
   using Cand = eetest::CandForTest;
   using MyExpr = reco::MaskCollection<eetest::CandForTest>;
 
   std::vector<Cand> oriC;
   MyExpr::Collection c;
-  for (int i=5; i<15; ++i) { oriC.emplace_back(Cand(i,1,1)); c.push_back(&oriC.back()); }
+  for (int i = 5; i < 15; ++i) {
+    oriC.emplace_back(Cand(i, 1, 1));
+    c.push_back(&oriC.back());
+  }
   MyExpr::Mask r;
 
-  std::string expr = "void eval(Collection const & c,  Mask & r) const override{ r.resize(c.size()); std::transform(c.begin(),c.end(),r.begin(), [](Collection::value_type const & c){ return (*c).pt()>10;}); }";
+  std::string expr =
+      "void eval(Collection const & c,  Mask & r) const override{ r.resize(c.size()); "
+      "std::transform(c.begin(),c.end(),r.begin(), [](Collection::value_type const & c){ return (*c).pt()>10;}); }";
 
-  ExpressionEvaluator parser("CommonTools/Utils", "reco::MaskCollection<eetest::CandForTest>",expr);
+  ExpressionEvaluator parser("CommonTools/Utils", "reco::MaskCollection<eetest::CandForTest>", expr);
 
   auto func = parser.expr<MyExpr>();
 
-  func->eval(c,r);
+  func->eval(c, r);
 
-  std::cout << r.size()  << ' '  <<  std::count(r.begin(),r.end(),true) << std::endl;
-
+  std::cout << r.size() << ' ' << std::count(r.begin(), r.end(), true) << std::endl;
 
   std::string cut = "bool operator()(int i, int j) const override { return i<10&& j<5; }";
 
   // ExpressionEvaluator parser2("ExpressionEvaluatorTests/EEUnitTest","eetest::vcut",cut.c_str());
   // auto mcut = parser2.expr<eetest::vcut>();
 
-  auto const & mcut = *reco_expressionEvaluator("CommonTools/Utils",SINGLE_ARG(reco::genericExpression<bool, int, int>),cut);
+  auto const& mcut =
+      *reco_expressionEvaluator("CommonTools/Utils", SINGLE_ARG(reco::genericExpression<bool, int, int>), cut);
 
-  std::cout << mcut(2,7) << ' ' << mcut(3, 4) << std::endl;
+  std::cout << mcut(2, 7) << ' ' << mcut(3, 4) << std::endl;
 
   try {
     std::string cut = "bool operator()(int i, int j) const override { return i<10&& j<5; }";
-    ExpressionEvaluator parser2("Bla/Blo","eetest::vcut",cut);
+    ExpressionEvaluator parser2("Bla/Blo", "eetest::vcut", cut);
     auto mcut = parser2.expr<vcut>();
-    std::cout << (*mcut)(2,7) << ' ' << (*mcut)(3, 4) << std::endl;
-  }catch( cms::Exception const & e) {
-    std::cout << e.what()  << std::endl;
-  }catch(...) {
+    std::cout << (*mcut)(2, 7) << ' ' << (*mcut)(3, 4) << std::endl;
+  } catch (cms::Exception const& e) {
+    std::cout << e.what() << std::endl;
+  } catch (...) {
     std::cout << "unknown error...." << std::endl;
   }
-
 
   try {
     std::string cut = "bool operator()(int i, int j) override { return i<10&& j<5; }";
-    auto const & mcut = *reco_expressionEvaluator("CommonTools/Utils",SINGLE_ARG(reco::genericExpression<bool,int,int>),cut);
-    std::cout << mcut(2,7) << ' ' << mcut(3, 4) << std::endl;
- 
- }catch( cms::Exception const & e) {
-    std::cout << e.what()  << std::endl;
-  }catch(...) {
+    auto const& mcut =
+        *reco_expressionEvaluator("CommonTools/Utils", SINGLE_ARG(reco::genericExpression<bool, int, int>), cut);
+    std::cout << mcut(2, 7) << ' ' << mcut(3, 4) << std::endl;
+
+  } catch (cms::Exception const& e) {
+    std::cout << e.what() << std::endl;
+  } catch (...) {
     std::cout << "unknown error...." << std::endl;
   }
-
 
   // stress test
   std::atomic<int> j(0);
 #pragma omp parallel num_threads(8)
   {
-    reco::genericExpression<bool, int, int> const * acut = nullptr;
-    for (int i=0; i<200; ++i) {
-      acut = reco_expressionEvaluator("CommonTools/Utils",SINGLE_ARG(reco::genericExpression<bool, int, int>),cut);
-      (*acut)(2,7);
-      std::cerr << j++ <<',';
+    reco::genericExpression<bool, int, int> const* acut = nullptr;
+    for (int i = 0; i < 200; ++i) {
+      acut = reco_expressionEvaluator("CommonTools/Utils", SINGLE_ARG(reco::genericExpression<bool, int, int>), cut);
+      (*acut)(2, 7);
+      std::cerr << j++ << ',';
     }
   }
   std::cerr << std::endl;
 
-
-
   std::cout << "If HERE OK" << std::endl;
 
   return 0;
-
 }

--- a/CommonTools/Utils/test/testAssociationMapFilterValues.cc
+++ b/CommonTools/Utils/test/testAssociationMapFilterValues.cc
@@ -18,30 +18,31 @@ public:
   void checkOneToManyQuality();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( testAssociationMapFilterValues );
+CPPUNIT_TEST_SUITE_REGISTRATION(testAssociationMapFilterValues);
 
 namespace {
   class Base {
   public:
-    explicit Base(double v): v_(v) {}
+    explicit Base(double v) : v_(v) {}
     virtual ~Base() {}
 
     double value() const { return v_; }
+
   private:
     double v_;
   };
 
-  class Derived: public Base {
+  class Derived : public Base {
   public:
-    explicit Derived(double v): Base(v) {}
+    explicit Derived(double v) : Base(v) {}
     virtual ~Derived() {}
   };
-}
+}  // namespace
 
 void testAssociationMapFilterValues::checkOneToOne() {
   typedef std::vector<int> CKey;
   typedef std::vector<double> CVal;
-  typedef edm::AssociationMap<edm::OneToOne<CKey, CVal, unsigned char> > Assoc;
+  typedef edm::AssociationMap<edm::OneToOne<CKey, CVal, unsigned char>> Assoc;
 
   CKey keys{1, 2, 3};
   CVal values{1.0, 2.0, 3.0};
@@ -55,24 +56,24 @@ void testAssociationMapFilterValues::checkOneToOne() {
   // vector of Refs
   std::vector<edm::Ref<CVal>> keep{edm::Ref<CVal>(&values, 0), edm::Ref<CVal>(&values, 2)};
   Assoc filtered = associationMapFilterValues(map, keep);
-  CPPUNIT_ASSERT( filtered.size() == 2 );
-  CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end() );
-  CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end() );
-  CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end() );
+  CPPUNIT_ASSERT(filtered.size() == 2);
+  CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end());
+  CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end());
+  CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end());
 
   // RefVector
   edm::RefVector<CVal> keep2;
   keep2.push_back(edm::Ref<CVal>(&values, 1));
   filtered = associationMapFilterValues(map, keep2);
-  CPPUNIT_ASSERT( filtered.size() == 1 );
-  CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 0)) == filtered.end() );
-  CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 1)) != filtered.end() );
-  CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 2)) == filtered.end() );
+  CPPUNIT_ASSERT(filtered.size() == 1);
+  CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 0)) == filtered.end());
+  CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 1)) != filtered.end());
+  CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 2)) == filtered.end());
 
   // Mostly check that it compiles
   edm::View<CVal> keepView;
   filtered = associationMapFilterValues(map, keepView);
-  CPPUNIT_ASSERT( filtered.size() == 0 );
+  CPPUNIT_ASSERT(filtered.size() == 0);
 }
 
 void testAssociationMapFilterValues::checkOneToMany() {
@@ -80,7 +81,7 @@ void testAssociationMapFilterValues::checkOneToMany() {
   {
     typedef std::vector<int> CKey;
     typedef std::vector<double> CVal;
-    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char>> Assoc;
 
     CKey keys{1, 2, 3};
     CVal values{1.0, 2.0, 3.0, 4.0};
@@ -95,10 +96,10 @@ void testAssociationMapFilterValues::checkOneToMany() {
     std::vector<edm::Ref<CVal>> keep{edm::Ref<CVal>(&values, 0), edm::Ref<CVal>(&values, 2)};
 
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 2 );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end() );
+    CPPUNIT_ASSERT(filtered.size() == 2);
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end());
   }
 
   // Ref data
@@ -106,7 +107,7 @@ void testAssociationMapFilterValues::checkOneToMany() {
     typedef std::vector<int> CKey;
     typedef std::vector<double> Data;
     typedef std::vector<edm::Ref<Data>> CVal;
-    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char>> Assoc;
 
     CKey keys{1, 2, 3};
     Data data{1.0, 2.0, 3.0, 4.0};
@@ -123,11 +124,11 @@ void testAssociationMapFilterValues::checkOneToMany() {
     std::vector<edm::Ref<CVal>> keep{edm::Ref<CVal>(&values, 0), edm::Ref<CVal>(&values, 2)};
 
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 3 );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 3)) != filtered.end() );
+    CPPUNIT_ASSERT(filtered.size() == 3);
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 3)) != filtered.end());
   }
 
   // RefToBase data
@@ -135,16 +136,14 @@ void testAssociationMapFilterValues::checkOneToMany() {
     typedef std::vector<int> CKey;
     typedef std::vector<Derived> Data;
     typedef std::vector<edm::RefToBase<Base>> CVal;
-    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char>> Assoc;
 
     CKey keys{1, 2, 3};
     Data data{Derived(1.0), Derived(2.0), Derived(3.0), Derived(4.0)};
 
-    CVal values{
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 0)),
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 1)),
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 2))
-    };
+    CVal values{edm::RefToBase<Base>(edm::Ref<Data>(&data, 0)),
+                edm::RefToBase<Base>(edm::Ref<Data>(&data, 1)),
+                edm::RefToBase<Base>(edm::Ref<Data>(&data, 2))};
 
     auto refprod = Assoc::ref_type(edm::RefProd<CKey>(&keys), edm::RefProd<CVal>(&values));
     auto map = Assoc(refprod);
@@ -154,29 +153,27 @@ void testAssociationMapFilterValues::checkOneToMany() {
     map.insert(edm::Ref<CKey>(&keys, 2), edm::Ref<CVal>(&values, 0));
     map.insert(edm::Ref<CKey>(&keys, 3), edm::Ref<CVal>(&values, 2));
 
-    std::vector<edm::RefToBase<Base>> keep{
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 0)),
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 2))
-    };
+    std::vector<edm::RefToBase<Base>> keep{edm::RefToBase<Base>(edm::Ref<Data>(&data, 0)),
+                                           edm::RefToBase<Base>(edm::Ref<Data>(&data, 2))};
 
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 3 );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end() );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 3)) != filtered.end() );
+    CPPUNIT_ASSERT(filtered.size() == 3);
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 0)) != filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 2)) != filtered.end());
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 3)) != filtered.end());
   }
 
   // View, mostly check that it compiles
   {
     typedef std::vector<int> CKey;
     typedef edm::View<Base> CVal;
-    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToMany<CKey, CVal, unsigned char>> Assoc;
 
     Assoc map;
     edm::View<Base> keep;
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 0 );
+    CPPUNIT_ASSERT(filtered.size() == 0);
   }
 }
 
@@ -185,7 +182,7 @@ void testAssociationMapFilterValues::checkOneToManyQuality() {
   {
     typedef std::vector<int> CKey;
     typedef std::vector<double> CVal;
-    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char>> Assoc;
 
     CKey keys{1, 2, 3};
     CVal values{1.0, 2.0, 3.0, 4.0};
@@ -200,15 +197,15 @@ void testAssociationMapFilterValues::checkOneToManyQuality() {
     std::vector<edm::Ref<CVal>> keep{edm::Ref<CVal>(&values, 0), edm::Ref<CVal>(&values, 2)};
 
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 2 );
+    CPPUNIT_ASSERT(filtered.size() == 2);
     auto found = filtered.find(edm::Ref<CKey>(&keys, 0));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 1 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.1 );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end() );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 1);
+    CPPUNIT_ASSERT(found->val[0].second == 0.1);
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 1)) == filtered.end());
     found = filtered.find(edm::Ref<CKey>(&keys, 2));
-    CPPUNIT_ASSERT( found->val.size() == 1 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.3 );
+    CPPUNIT_ASSERT(found->val.size() == 1);
+    CPPUNIT_ASSERT(found->val[0].second == 0.3);
   }
 
   // Ref data
@@ -216,7 +213,7 @@ void testAssociationMapFilterValues::checkOneToManyQuality() {
     typedef std::vector<int> CKey;
     typedef std::vector<double> Data;
     typedef std::vector<edm::Ref<Data>> CVal;
-    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char>> Assoc;
 
     CKey keys{1, 2, 3};
     Data data{1.0, 2.0, 3.0, 4.0};
@@ -233,21 +230,21 @@ void testAssociationMapFilterValues::checkOneToManyQuality() {
     std::vector<edm::Ref<CVal>> keep{edm::Ref<CVal>(&values, 0), edm::Ref<CVal>(&values, 1)};
 
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 3 );
+    CPPUNIT_ASSERT(filtered.size() == 3);
     auto found = filtered.find(edm::Ref<CKey>(&keys, 0));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 1 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.1 );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 1);
+    CPPUNIT_ASSERT(found->val[0].second == 0.1);
     found = filtered.find(edm::Ref<CKey>(&keys, 1));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 1 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.2 );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 1);
+    CPPUNIT_ASSERT(found->val[0].second == 0.2);
     found = filtered.find(edm::Ref<CKey>(&keys, 2));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 2 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.3 );
-    CPPUNIT_ASSERT( found->val[1].second == 0.4 );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 3)) == filtered.end() );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 2);
+    CPPUNIT_ASSERT(found->val[0].second == 0.3);
+    CPPUNIT_ASSERT(found->val[1].second == 0.4);
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 3)) == filtered.end());
   }
 
   // RefToBase data
@@ -255,16 +252,14 @@ void testAssociationMapFilterValues::checkOneToManyQuality() {
     typedef std::vector<int> CKey;
     typedef std::vector<Derived> Data;
     typedef std::vector<edm::RefToBase<Base>> CVal;
-    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char>> Assoc;
 
     CKey keys{1, 2, 3};
     Data data{Derived(1.0), Derived(2.0), Derived(3.0), Derived(4.0)};
 
-    CVal values{
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 0)),
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 1)),
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 2))
-    };
+    CVal values{edm::RefToBase<Base>(edm::Ref<Data>(&data, 0)),
+                edm::RefToBase<Base>(edm::Ref<Data>(&data, 1)),
+                edm::RefToBase<Base>(edm::Ref<Data>(&data, 2))};
 
     auto refprod = Assoc::ref_type(edm::RefProd<CKey>(&keys), edm::RefProd<CVal>(&values));
     auto map = Assoc(refprod);
@@ -276,40 +271,38 @@ void testAssociationMapFilterValues::checkOneToManyQuality() {
     map.insert(edm::Ref<CKey>(&keys, 3), std::make_pair(edm::Ref<CVal>(&values, 2), 0.5));
     map.insert(edm::Ref<CKey>(&keys, 3), std::make_pair(edm::Ref<CVal>(&values, 0), 0.7));
 
-    std::vector<edm::RefToBase<Base>> keep{
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 2)),
-      edm::RefToBase<Base>(edm::Ref<Data>(&data, 1))
-    };
+    std::vector<edm::RefToBase<Base>> keep{edm::RefToBase<Base>(edm::Ref<Data>(&data, 2)),
+                                           edm::RefToBase<Base>(edm::Ref<Data>(&data, 1))};
 
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 3 );
-    CPPUNIT_ASSERT( filtered.find(edm::Ref<CKey>(&keys, 0)) == filtered.end() );
+    CPPUNIT_ASSERT(filtered.size() == 3);
+    CPPUNIT_ASSERT(filtered.find(edm::Ref<CKey>(&keys, 0)) == filtered.end());
     auto found = filtered.find(edm::Ref<CKey>(&keys, 1));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 1 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.2 );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 1);
+    CPPUNIT_ASSERT(found->val[0].second == 0.2);
     found = filtered.find(edm::Ref<CKey>(&keys, 2));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 1 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.3 );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 1);
+    CPPUNIT_ASSERT(found->val[0].second == 0.3);
     found = filtered.find(edm::Ref<CKey>(&keys, 3));
-    CPPUNIT_ASSERT( found != filtered.end() );
-    CPPUNIT_ASSERT( found->val.size() == 2 );
-    CPPUNIT_ASSERT( found->val[0].first->get()->value() == 2.0 );
-    CPPUNIT_ASSERT( found->val[0].second == 0.6 );
-    CPPUNIT_ASSERT( found->val[1].first->get()->value() == 3.0 );
-    CPPUNIT_ASSERT( found->val[1].second == 0.5 );
+    CPPUNIT_ASSERT(found != filtered.end());
+    CPPUNIT_ASSERT(found->val.size() == 2);
+    CPPUNIT_ASSERT(found->val[0].first->get()->value() == 2.0);
+    CPPUNIT_ASSERT(found->val[0].second == 0.6);
+    CPPUNIT_ASSERT(found->val[1].first->get()->value() == 3.0);
+    CPPUNIT_ASSERT(found->val[1].second == 0.5);
   }
 
   // View, mostly check that it compiles
   {
     typedef std::vector<int> CKey;
     typedef edm::View<Base> CVal;
-    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char> > Assoc;
+    typedef edm::AssociationMap<edm::OneToManyWithQuality<CKey, CVal, double, unsigned char>> Assoc;
 
     Assoc map;
     edm::View<Base> keep;
     Assoc filtered = associationMapFilterValues(map, keep);
-    CPPUNIT_ASSERT( filtered.size() == 0 );
+    CPPUNIT_ASSERT(filtered.size() == 0);
   }
 }

--- a/CommonTools/Utils/test/testComparators.cc
+++ b/CommonTools/Utils/test/testComparators.cc
@@ -12,46 +12,46 @@ class testComparators : public CppUnit::TestFixture {
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( testComparators );
+CPPUNIT_TEST_SUITE_REGISTRATION(testComparators);
 
 namespace test {
   struct A {
-    explicit A( double x ) : x_( x ) { }
+    explicit A(double x) : x_(x) {}
     double pt() const { return x_; }
     double et() const { return x_; }
     double px() const { return x_; }
     double py() const { return x_; }
     double pz() const { return x_; }
+
   private:
     double x_;
   };
-}
+}  // namespace test
 
 void testComparators::checkAll() {
   using namespace test;
-  A a( 1 ), b( 2 );
+  A a(1), b(2);
 
   LessByPt<A> cmp1;
   LessByEt<A> cmp2;
   NumericSafeLessByPt<A> cmp3;
   NumericSafeLessByEt<A> cmp4;
-  CPPUNIT_ASSERT( cmp1( a, b ) ); 
-  CPPUNIT_ASSERT( cmp2( a, b ) ); 
-  CPPUNIT_ASSERT( cmp3( a, b ) ); 
-  CPPUNIT_ASSERT( cmp4( a, b ) ); 
+  CPPUNIT_ASSERT(cmp1(a, b));
+  CPPUNIT_ASSERT(cmp2(a, b));
+  CPPUNIT_ASSERT(cmp3(a, b));
+  CPPUNIT_ASSERT(cmp4(a, b));
 
   GreaterByPt<A> cmp5;
   GreaterByEt<A> cmp6;
   NumericSafeGreaterByPt<A> cmp7;
   NumericSafeGreaterByEt<A> cmp8;
-  CPPUNIT_ASSERT( cmp5( b, a ) ); 
-  CPPUNIT_ASSERT( cmp6( b, a ) ); 
-  CPPUNIT_ASSERT( cmp7( b, a ) ); 
-  CPPUNIT_ASSERT( cmp8( b, a ) ); 
+  CPPUNIT_ASSERT(cmp5(b, a));
+  CPPUNIT_ASSERT(cmp6(b, a));
+  CPPUNIT_ASSERT(cmp7(b, a));
+  CPPUNIT_ASSERT(cmp8(b, a));
   PointerComparator<LessByPt<A> > cmp9;
-  CPPUNIT_ASSERT( cmp9( &a, &b ) );
-
+  CPPUNIT_ASSERT(cmp9(&a, &b));
 }

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -9,31 +9,22 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include <typeinfo>
 
-
-
-#include "DataFormats/GeometrySurface/interface/Surface.h" 
+#include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
 
 // A fake Det class
 
 class MyDet : public GeomDet {
- public:
-  MyDet(BoundPlane * bp) :
-    GeomDet(bp){}
-  
-  virtual DetId geographicalId() const {return DetId();}
-  virtual std::vector< const GeomDet*> components() const {
-    return std::vector< const GeomDet*>();
-  }
-  
+public:
+  MyDet(BoundPlane *bp) : GeomDet(bp) {}
+
+  virtual DetId geographicalId() const { return DetId(); }
+  virtual std::vector<const GeomDet *> components() const { return std::vector<const GeomDet *>(); }
+
   /// Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::DT;}
-  
-};  
-
-
-
+  virtual SubDetector subDetector() const { return GeomDetEnumerators::DT; }
+};
 
 class testCutParser : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testCutParser);
@@ -43,7 +34,7 @@ class testCutParser : public CppUnit::TestFixture {
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
   void check(const std::string &, bool);
   void checkHit(const std::string &, bool, const SiStripRecHit2D &);
   void checkMuon(const std::string &, bool, const reco::Muon &);
@@ -55,44 +46,42 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testCutParser);
 
-void testCutParser::check(const std::string & cut, bool res) {
+void testCutParser::check(const std::string &cut, bool res) {
   for (int lazy = 0; lazy <= 1; ++lazy) {
-  std::cerr << "parsing " << (lazy ? "lazy " : "") << "cut: \"" << cut << "\"" << std::endl;
-  sel.reset();
-  CPPUNIT_ASSERT(reco::parser::cutParser<reco::Track>(cut, sel, lazy));
-  CPPUNIT_ASSERT((*sel)(o) == res);
-  StringCutObjectSelector<reco::Track> select(cut, lazy);
-  CPPUNIT_ASSERT(select(trk) == res);
+    std::cerr << "parsing " << (lazy ? "lazy " : "") << "cut: \"" << cut << "\"" << std::endl;
+    sel.reset();
+    CPPUNIT_ASSERT(reco::parser::cutParser<reco::Track>(cut, sel, lazy));
+    CPPUNIT_ASSERT((*sel)(o) == res);
+    StringCutObjectSelector<reco::Track> select(cut, lazy);
+    CPPUNIT_ASSERT(select(trk) == res);
   }
 }
 
-void testCutParser::checkHit(const std::string & cut, bool res, const SiStripRecHit2D &hit) {
+void testCutParser::checkHit(const std::string &cut, bool res, const SiStripRecHit2D &hit) {
   edm::TypeWithDict t(typeid(SiStripRecHit2D));
   o = edm::ObjectWithDict(t, const_cast<void *>(static_cast<const void *>(&hit)));
   for (int lazy = 0; lazy <= 1; ++lazy) {
-  std::cerr << "parsing " << (lazy ? "lazy " : "") << "cut: \"" << cut << "\"" << std::endl;
-  sel.reset();
-  CPPUNIT_ASSERT(reco::parser::cutParser<SiStripRecHit2D>(cut, sel, lazy));
-  CPPUNIT_ASSERT((*sel)(o) == res);
-  StringCutObjectSelector<SiStripRecHit2D> select(cut, lazy);
-  CPPUNIT_ASSERT(select(hit) == res);
+    std::cerr << "parsing " << (lazy ? "lazy " : "") << "cut: \"" << cut << "\"" << std::endl;
+    sel.reset();
+    CPPUNIT_ASSERT(reco::parser::cutParser<SiStripRecHit2D>(cut, sel, lazy));
+    CPPUNIT_ASSERT((*sel)(o) == res);
+    StringCutObjectSelector<SiStripRecHit2D> select(cut, lazy);
+    CPPUNIT_ASSERT(select(hit) == res);
   }
 }
 
-void testCutParser::checkMuon(const std::string & cut, bool res, const reco::Muon &mu) {
+void testCutParser::checkMuon(const std::string &cut, bool res, const reco::Muon &mu) {
   edm::TypeWithDict t(typeid(reco::Muon));
   o = edm::ObjectWithDict(t, const_cast<void *>(static_cast<const void *>(&mu)));
   sel.reset();
   for (int lazy = 0; lazy <= 1; ++lazy) {
-  std::cerr << "parsing " << (lazy ? "lazy " : "") << "cut: \"" << cut << "\"" << std::endl;
-  CPPUNIT_ASSERT(reco::parser::cutParser<reco::Muon>(cut, sel, lazy));
-  CPPUNIT_ASSERT((*sel)(o) == res);
-  StringCutObjectSelector<reco::Muon> select(cut, lazy);
-  CPPUNIT_ASSERT(select(mu) == res);
+    std::cerr << "parsing " << (lazy ? "lazy " : "") << "cut: \"" << cut << "\"" << std::endl;
+    CPPUNIT_ASSERT(reco::parser::cutParser<reco::Muon>(cut, sel, lazy));
+    CPPUNIT_ASSERT((*sel)(o) == res);
+    StringCutObjectSelector<reco::Muon> select(cut, lazy);
+    CPPUNIT_ASSERT(select(mu) == res);
   }
 }
-
-
 
 void testCutParser::checkAll() {
   using namespace reco;
@@ -100,90 +89,86 @@ void testCutParser::checkAll() {
   const int ndof = 10;
   reco::Track::Point v(1, 2, 3);
   reco::Track::Vector p(0, 3, 10);
-  double e[] = { 1.1,
-                 1.2, 2.2,
-                 1.3, 2.3, 3.3,
-                 1.4, 2.4, 3.4, 4.4,
-                 1.5, 2.5, 3.5, 4.5, 5.5 };
+  double e[] = {1.1, 1.2, 2.2, 1.3, 2.3, 3.3, 1.4, 2.4, 3.4, 4.4, 1.5, 2.5, 3.5, 4.5, 5.5};
   reco::TrackBase::CovarianceMatrix cov(e, e + 15);
   trk = reco::Track(chi2, ndof, v, p, -1, cov);
   trk.setQuality(reco::Track::highPurity);
 
-  GlobalPoint gp(0,0,0);
-  BoundPlane* plane = new BoundPlane( gp, Surface::RotationType());
+  GlobalPoint gp(0, 0, 0);
+  BoundPlane *plane = new BoundPlane(gp, Surface::RotationType());
   MyDet mdet(plane);
- 
-  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), mdet, SiStripRecHit2D::ClusterRef());
+
+  hitOk = SiStripRecHit2D(LocalPoint(1, 1), LocalError(1, 1, 1), mdet, SiStripRecHit2D::ClusterRef());
 
   edm::TypeWithDict t(typeid(reco::Track));
-  o = edm::ObjectWithDict(t, & trk);
+  o = edm::ObjectWithDict(t, &trk);
 
   std::cerr << "Track pt: " << trk.pt() << std::endl;
   // note: pt = 3, charge = -1
-  check( "", true );
-  check( "  ", true );
+  check("", true);
+  check("  ", true);
   check("pt", true);
   check("px", false);
-  check( "pt > 2", true );
-  check( "charge < 0", true );
-  check( "pt < 2", false );
-  check( "pt >= 2", true );
-  check( "pt <= 2", false );
-  check( "pt = 3", true );
-  check( "pt == 3", true );
-  check( "pt != 3", false );
-  check( "! pt == 3", false );
-  check( "2.9 < pt < 3.1", true );
-  check( "pt > 2 & charge < 0", true );
-  check( "pt > 2 && charge < 0", true );
-  check( "pt < 2 & charge < 0", false );
-  check( "pt > 2 & charge > 0", false );
-  check( "pt < 2 & charge > 0", false );
-  check( "pt > 2 || charge > 0", true );
-  check( "pt > 2 | charge > 0", true );
-  check( "pt > 2 | charge < 0", true );
-  check( "pt < 2 | charge < 0", true );
-  check( "pt < 2 | charge > 0", false );
-  check( "pt > 2 | charge > 0 | pt < 2", true );
-  check( "pt > 2 | charge > 0 | (pt < 2 && charge < 0)", true );
-  check( "pt > 2 | charge < 0 | (pt < 2 && charge < 0)", true );
-  check( "pt > 2 | charge > 0 | (pt < 2 && charge > 0)", true );
-  check( "(pt) > 2", true );
-  check( "-pt < -2", true );
-  check( "3.9 < pt + 1 < 4.1", true );
-  check( "1.9 < pt - 1 < 2.1", true );
-  check( "5.9 < 2 * pt < 6.1", true );
-  check( "0.9 < pt / 3 < 1.1", true );
-  check( "8.9 < pt ^ 2 < 9.1", true );
-  check( "26.9 < 3 * pt ^ 2 < 27.1", true );
-  check( "27.9 < 3 * pt ^ 2 + 1 < 28.1", true );
-  check( " 0.99 < sin( phi ) < 1.01", true );
-  check( " -0.01 < cos( phi ) < 0.01", true );
-  check( " 8.9 < pow( pt, 2 ) < 9.1", true );
-  check( "( 0.99 < sin( phi ) < 1.01 ) & ( -0.01 < cos( phi ) < 0.01 )", true );
-  check( "( 3.9 < pt + 1 < 4.1 ) | ( pt < 2 )", true );
-  check( " pt = 3 &  pt > 2 | pt < 2", true );
-  check( "( ( pt = 3 &  pt > 2 ) | pt < 2 ) & 26.9 < 3 * pt ^ 2 < 27.1", true );
-  check( "! pt > 2", false );
-  check( "! pt < 2", true );
-  check( "! (( 0.99 < sin( phi ) < 1.01 ) & ( -0.01 < cos( phi ) < 0.01 ))", false );
-  check( "pt && pt > 1",true);
+  check("pt > 2", true);
+  check("charge < 0", true);
+  check("pt < 2", false);
+  check("pt >= 2", true);
+  check("pt <= 2", false);
+  check("pt = 3", true);
+  check("pt == 3", true);
+  check("pt != 3", false);
+  check("! pt == 3", false);
+  check("2.9 < pt < 3.1", true);
+  check("pt > 2 & charge < 0", true);
+  check("pt > 2 && charge < 0", true);
+  check("pt < 2 & charge < 0", false);
+  check("pt > 2 & charge > 0", false);
+  check("pt < 2 & charge > 0", false);
+  check("pt > 2 || charge > 0", true);
+  check("pt > 2 | charge > 0", true);
+  check("pt > 2 | charge < 0", true);
+  check("pt < 2 | charge < 0", true);
+  check("pt < 2 | charge > 0", false);
+  check("pt > 2 | charge > 0 | pt < 2", true);
+  check("pt > 2 | charge > 0 | (pt < 2 && charge < 0)", true);
+  check("pt > 2 | charge < 0 | (pt < 2 && charge < 0)", true);
+  check("pt > 2 | charge > 0 | (pt < 2 && charge > 0)", true);
+  check("(pt) > 2", true);
+  check("-pt < -2", true);
+  check("3.9 < pt + 1 < 4.1", true);
+  check("1.9 < pt - 1 < 2.1", true);
+  check("5.9 < 2 * pt < 6.1", true);
+  check("0.9 < pt / 3 < 1.1", true);
+  check("8.9 < pt ^ 2 < 9.1", true);
+  check("26.9 < 3 * pt ^ 2 < 27.1", true);
+  check("27.9 < 3 * pt ^ 2 + 1 < 28.1", true);
+  check(" 0.99 < sin( phi ) < 1.01", true);
+  check(" -0.01 < cos( phi ) < 0.01", true);
+  check(" 8.9 < pow( pt, 2 ) < 9.1", true);
+  check("( 0.99 < sin( phi ) < 1.01 ) & ( -0.01 < cos( phi ) < 0.01 )", true);
+  check("( 3.9 < pt + 1 < 4.1 ) | ( pt < 2 )", true);
+  check(" pt = 3 &  pt > 2 | pt < 2", true);
+  check("( ( pt = 3 &  pt > 2 ) | pt < 2 ) & 26.9 < 3 * pt ^ 2 < 27.1", true);
+  check("! pt > 2", false);
+  check("! pt < 2", true);
+  check("! (( 0.99 < sin( phi ) < 1.01 ) & ( -0.01 < cos( phi ) < 0.01 ))", false);
+  check("pt && pt > 1", true);
   // check trailing space
-  check( "pt > 2 ", true );
+  check("pt > 2 ", true);
 
   // check bit tests
-  check( "test_bit(7, 0)", true  );
-  check( "test_bit(7, 2)", true  );
-  check( "test_bit(7, 3)", false );
-  check( "test_bit(4, 0)", false );
-  check( "test_bit(4, 2)", true  );
-  check( "test_bit(4, 3)", false );
+  check("test_bit(7, 0)", true);
+  check("test_bit(7, 2)", true);
+  check("test_bit(7, 3)", false);
+  check("test_bit(4, 0)", false);
+  check("test_bit(4, 2)", true);
+  check("test_bit(4, 3)", false);
 
   // check quality
-  check("quality('highPurity')", true );
-  check("quality('loose')", false );
-  check("quality('tight')", false );
-  check("quality('confirmed')", false );
+  check("quality('highPurity')", true);
+  check("quality('loose')", false);
+  check("quality('tight')", false);
+  check("quality('confirmed')", false);
   check("quality('goodIterative')", true);
   check("quality('looseSetWithPV')", false);
   check("quality('highPuritySetWithPV')", false);
@@ -191,72 +176,73 @@ void testCutParser::checkAll() {
   check("quality( 'highPuritySetWithPV')", false);
   check("quality( 'highPuritySetWithPV' )", false);
 
-  // check handling of errors 
+  // check handling of errors
   //   first those who are the same in lazy and non lazy parsing
   for (int lazy = 0; lazy <= 1; ++lazy) {
-  sel.reset();
-  CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("1abc",sel, lazy));
-  sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("(pt < 1",sel, lazy), edm::Exception);
-  sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("pt < #",sel, lazy), edm::Exception);
-  sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("pt <> 5",sel, lazy), edm::Exception);
-  sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("cos( pt < .5",sel, lazy), edm::Exception);
-  sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>(" 2 * (pt + 1 < .5",sel, lazy), edm::Exception);
-  // These don't throw, but they return false.
-  sel.reset();
-  CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("pt() pt < .5",sel, lazy));
-  sel.reset();
-  CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("pt pt < .5",sel, lazy));
-  // This throws or return false depending on the parsing:
-  // without lazy parsing, it complains about non-existing method 'cos'
-  sel.reset();
-  if (lazy) CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("cos pt < .5",sel, lazy));
-  else      CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("cos pt < .5",sel, lazy), edm::Exception);
+    sel.reset();
+    CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("1abc", sel, lazy));
+    sel.reset();
+    CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("(pt < 1", sel, lazy), edm::Exception);
+    sel.reset();
+    CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("pt < #", sel, lazy), edm::Exception);
+    sel.reset();
+    CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("pt <> 5", sel, lazy), edm::Exception);
+    sel.reset();
+    CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("cos( pt < .5", sel, lazy), edm::Exception);
+    sel.reset();
+    CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>(" 2 * (pt + 1 < .5", sel, lazy), edm::Exception);
+    // These don't throw, but they return false.
+    sel.reset();
+    CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("pt() pt < .5", sel, lazy));
+    sel.reset();
+    CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("pt pt < .5", sel, lazy));
+    // This throws or return false depending on the parsing:
+    // without lazy parsing, it complains about non-existing method 'cos'
+    sel.reset();
+    if (lazy)
+      CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("cos pt < .5", sel, lazy));
+    else
+      CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("cos pt < .5", sel, lazy), edm::Exception);
   }
   // then those which are specific to non lazy parsing
   sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("doesNotExist < 1",sel), edm::Exception);
+  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("doesNotExist < 1", sel), edm::Exception);
   sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("pt.pt < 1",sel), edm::Exception);
+  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("pt.pt < 1", sel), edm::Exception);
   // and afterwards check that in lazy parsing they throw at runtime
   sel.reset();
-  CPPUNIT_ASSERT(reco::parser::cutParser<reco::Track>("doesNotExist < 1",sel,true)); // with lazy parsing this doesn't throw
-  CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                          // but it throws here!
+  CPPUNIT_ASSERT(
+      reco::parser::cutParser<reco::Track>("doesNotExist < 1", sel, true));  // with lazy parsing this doesn't throw
+  CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                  // but it throws here!
   sel.reset();
-  CPPUNIT_ASSERT(reco::parser::cutParser<reco::Track>("pt.pt < 1",sel, true));  // same for this
-  CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                     // it throws wen called
+  CPPUNIT_ASSERT(reco::parser::cutParser<reco::Track>("pt.pt < 1", sel, true));  // same for this
+  CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                      // it throws wen called
 
   sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')",sel, false), edm::Exception);
+  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')", sel, false), edm::Exception);
 
   // check hits (for re-implemented virtual functions and exception handling)
   CPPUNIT_ASSERT(hitOk.hasPositionAndError());
-  checkHit( "hasPositionAndError" , true, hitOk );
+  checkHit("hasPositionAndError", true, hitOk);
   CPPUNIT_ASSERT(!hitThrow.hasPositionAndError());
-  checkHit( "hasPositionAndError" , false, hitThrow );
+  checkHit("hasPositionAndError", false, hitThrow);
   CPPUNIT_ASSERT(hitOk.localPosition().x() == 1);
-  checkHit( ".99 < localPosition.x < 1.01", true, hitOk);
-  checkHit( ".99 < localPosition.x < 1.01", false, hitThrow);
+  checkHit(".99 < localPosition.x < 1.01", true, hitOk);
+  checkHit(".99 < localPosition.x < 1.01", false, hitThrow);
 
   // check underscores (would be better to build your own stub...)
-  checkHit("cluster.isNull()",true,hitOk);
-  checkHit("cluster_strip.isNull()",true,hitOk);
-  checkHit("cluster.isNonnull()",false,hitOk);  
-  checkHit("cluster_strip.isNonnull()",false,hitOk);
-
+  checkHit("cluster.isNull()", true, hitOk);
+  checkHit("cluster_strip.isNull()", true, hitOk);
+  checkHit("cluster.isNonnull()", false, hitOk);
+  checkHit("cluster_strip.isNonnull()", false, hitOk);
 
   // check short cirtcuit logics
-  CPPUNIT_ASSERT( hitOk.hasPositionAndError() && (hitOk.localPosition().x() == 1) );
-  CPPUNIT_ASSERT( !( hitThrow.hasPositionAndError() && (hitThrow.localPosition().x() == 1) ) );
-  checkHit( "hasPositionAndError && (localPosition.x = 1)", true,  hitOk    );
-  checkHit( "hasPositionAndError && (localPosition.x = 1)", false, hitThrow );
-  CPPUNIT_ASSERT( (!hitOk.hasPositionAndError()   ) || (hitOk.localPosition().x()    == 1) );
-  CPPUNIT_ASSERT( (!hitThrow.hasPositionAndError()) || (hitThrow.localPosition().x() == 1) );
-  checkHit( "!hasPositionAndError || (localPosition.x = 1)", true,  hitOk    );
-  checkHit( "!hasPositionAndError || (localPosition.x = 1)", true, hitThrow );
-
+  CPPUNIT_ASSERT(hitOk.hasPositionAndError() && (hitOk.localPosition().x() == 1));
+  CPPUNIT_ASSERT(!(hitThrow.hasPositionAndError() && (hitThrow.localPosition().x() == 1)));
+  checkHit("hasPositionAndError && (localPosition.x = 1)", true, hitOk);
+  checkHit("hasPositionAndError && (localPosition.x = 1)", false, hitThrow);
+  CPPUNIT_ASSERT((!hitOk.hasPositionAndError()) || (hitOk.localPosition().x() == 1));
+  CPPUNIT_ASSERT((!hitThrow.hasPositionAndError()) || (hitThrow.localPosition().x() == 1));
+  checkHit("!hasPositionAndError || (localPosition.x = 1)", true, hitOk);
+  checkHit("!hasPositionAndError || (localPosition.x = 1)", true, hitThrow);
 }

--- a/CommonTools/Utils/test/testCutParserThreaded.cc
+++ b/CommonTools/Utils/test/testCutParserThreaded.cc
@@ -15,24 +15,25 @@
 namespace {
   class Decrementer {
   public:
-    Decrementer(std::atomic<int>& iValue): value_(iValue), dec_(true) {}
+    Decrementer(std::atomic<int>& iValue) : value_(iValue), dec_(true) {}
     ~Decrementer() {
-      if(dec_) { --value_;}
+      if (dec_) {
+        --value_;
+      }
     }
 
     void decrement() {
       --value_;
-      dec_=false;
+      dec_ = false;
     }
 
   private:
     std::atomic<int>& value_;
     bool dec_;
   };
-}
+}  // namespace
 
 int main() {
-
   constexpr int kNThreads = 30;
   std::atomic<int> canStart{kNThreads};
   std::atomic<int> canStartEval{kNThreads};
@@ -42,53 +43,55 @@ int main() {
   TThread::Initialize();
   //When threading, also have to keep ROOT from logging all TObjects into a list
   TObject::SetObjectStat(false);
-  
+
   //Have to avoid having Streamers modify themselves after they have been used
   TVirtualStreamerInfo::Optimize(false);
 
+  for (int i = 0; i < kNThreads; ++i) {
+    threads.emplace_back([&canStart, &canStartEval, &failed]() {
+      try {
+        static thread_local TThread guard;
+        reco::Track trk(
+            20., 20., reco::Track::Point(), reco::Track::Vector(1., 1., 1.), +1, reco::Track::CovarianceMatrix{});
+        trk.setQuality(reco::Track::highPurity);
+        std::string const cut(" pt >= 1 & quality('highPurity') ");
+        //std::cout <<cut<<std::endl;
+        bool const lazy = true;
 
-  for(int i=0; i<kNThreads; ++i) {
-    threads.emplace_back([&canStart,&canStartEval,&failed]() {
-        try {
-          static thread_local TThread guard;
-          reco::Track trk(20., 20., reco::Track::Point(), reco::Track::Vector(1.,1.,1.), +1, reco::Track::CovarianceMatrix{});
-          trk.setQuality(reco::Track::highPurity);
-          std::string const cut( " pt >= 1 & quality('highPurity') ");
-          //std::cout <<cut<<std::endl;
-          bool const lazy = true;
-          
-          --canStart;
-          while( canStart > 0 ) {}
+        --canStart;
+        while (canStart > 0) {
+        }
 
-          //need to make sure canStartEval is decremented even if we have an exception
-          Decrementer decCanStartEval(canStartEval);
+        //need to make sure canStartEval is decremented even if we have an exception
+        Decrementer decCanStartEval(canStartEval);
 
-          StringCutObjectSelector<reco::Track> select(cut, lazy);
+        StringCutObjectSelector<reco::Track> select(cut, lazy);
 
-          decCanStartEval.decrement();
+        decCanStartEval.decrement();
 
-          while( canStartEval > 0 ) {}
-          if( not select(trk) ) {
-            std::cout <<"selection failed"<<std::endl;
-            failed = true;
-          }
-        } catch(cms::Exception const& exception) {
-          std::cout <<exception.what()<<std::endl;
+        while (canStartEval > 0) {
+        }
+        if (not select(trk)) {
+          std::cout << "selection failed" << std::endl;
           failed = true;
         }
-      });
+      } catch (cms::Exception const& exception) {
+        std::cout << exception.what() << std::endl;
+        failed = true;
+      }
+    });
   }
   canStart = true;
-  
-  for(auto& thread: threads) {
+
+  for (auto& thread : threads) {
     thread.join();
   }
-  
-  if(failed) {
-    std::cout <<"FAILED"<<std::endl;
+
+  if (failed) {
+    std::cout << "FAILED" << std::endl;
     return 1;
   }
 
-  std::cout <<"OK"<<std::endl;
+  std::cout << "OK" << std::endl;
   return 0;
 }

--- a/CommonTools/Utils/test/testDynArray.cpp
+++ b/CommonTools/Utils/test/testDynArray.cpp
@@ -1,88 +1,97 @@
 #include "CommonTools/Utils/interface/DynArray.h"
 
-
-
 struct A {
-A(){}
-A(int ii) : i(ii){}
-int i=-3;
-double k=0.1;
+  A() {}
+  A(int ii) : i(ii) {}
+  int i = -3;
+  double k = 0.1;
 
-virtual ~A(){}
-
+  virtual ~A() {}
 };
 
-
-#include<cassert>
-#include<iostream>
-#include<queue>
+#include <cassert>
+#include <iostream>
+#include <queue>
 
 int main(int s, char **) {
+  using T = A;
 
-  using T=A;
+  unsigned n = 4 * s;
 
-  unsigned n = 4*s;
+  //  alignas(alignof(T)) unsigned char a_storage[sizeof(T)*n];
+  //  DynArray<T> a(a_storage,n);
 
-//  alignas(alignof(T)) unsigned char a_storage[sizeof(T)*n];
-//  DynArray<T> a(a_storage,n);
-
-  declareDynArray(T,n,a);
+  declareDynArray(T, n, a);
 
   // T b[n];
-  declareDynArray(T,n,b);
+  declareDynArray(T, n, b);
 
-  b[0].i=42;
-  b[n-1].i=-42;
+  b[0].i = 42;
+  b[n - 1].i = -42;
 
-  auto pa = [&](auto i) { a[1].k=0.3; return a[i].k; };
-  auto pb = [&](auto i) { b[1].k=0.5; return b[i].k; };
+  auto pa = [&](auto i) {
+    a[1].k = 0.3;
+    return a[i].k;
+  };
+  auto pb = [&](auto i) {
+    b[1].k = 0.5;
+    return b[i].k;
+  };
 
-  auto loop = [&](auto k) { for(auto const & q : a) k = std::min(k,q.k); return k;};
+  auto loop = [&](auto k) {
+    for (auto const &q : a)
+      k = std::min(k, q.k);
+    return k;
+  };
 
-  std::cout << a[n-1].k << ' ' << pa(1) << ' ' << loop(2.3) << std::endl;
-  std::cout << b[n-1].k << ' ' << pb(1) << std::endl;
+  std::cout << a[n - 1].k << ' ' << pa(1) << ' ' << loop(2.3) << std::endl;
+  std::cout << b[n - 1].k << ' ' << pb(1) << std::endl;
 
-  assert(b.back().i==-42);
-  assert(b.front().i==42);
+  assert(b.back().i == -42);
+  assert(b.front().i == 42);
 
-  initDynArray(bool,n,q,true);
-  if (q[n-1]) std::cout << "ok" << std::endl;	
+  initDynArray(bool, n, q, true);
+  if (q[n - 1])
+    std::cout << "ok" << std::endl;
 
-  auto sn = 2*n;
-  unInitDynArray(T,sn+n,c);
-  assert(c.size()==0);
-  for(int i=0;i<int(sn);++i) c.push_back(i);
-  assert(c.size()==sn);
-  assert(c.front().i==0);
-  assert(c.back().i==int(sn-1));
-  c[1].k=3.14;
+  auto sn = 2 * n;
+  unInitDynArray(T, sn + n, c);
+  assert(c.size() == 0);
+  for (int i = 0; i < int(sn); ++i)
+    c.push_back(i);
+  assert(c.size() == sn);
+  assert(c.front().i == 0);
+  assert(c.back().i == int(sn - 1));
+  c[1].k = 3.14;
 
-  a = std::move(c);  
+  a = std::move(c);
 
-  assert(a.size()==sn);
+  assert(a.size() == sn);
   assert(c.empty());
-  assert(a[1].k==3.14);
+  assert(a[1].k == 3.14);
 
-  std::swap(a,b);
-  assert(b.size()==sn);
-  assert(a.size()==n);
+  std::swap(a, b);
+  assert(b.size() == sn);
+  assert(a.size() == n);
 
-
-  unInitDynArray(int,sn,qst); // queue storage
-  auto cmp = [](int i, int j){return i<j;};
-  std::priority_queue<int,DynArray<int>,decltype(cmp)> qq(cmp,std::move(qst));
+  unInitDynArray(int, sn, qst);  // queue storage
+  auto cmp = [](int i, int j) { return i < j; };
+  std::priority_queue<int, DynArray<int>, decltype(cmp)> qq(cmp, std::move(qst));
   assert(qq.empty());
-  for(int i=0;i<int(sn);++i) qq.push(i+1);
-  assert(qq.size()==sn);
-  for(int i=0;i<int(sn);++i) {
-   assert(qq.size()==sn-i);
-   assert(qq.top()==int(sn-i));
-   qq.pop();
+  for (int i = 0; i < int(sn); ++i)
+    qq.push(i + 1);
+  assert(qq.size() == sn);
+  for (int i = 0; i < int(sn); ++i) {
+    assert(qq.size() == sn - i);
+    assert(qq.top() == int(sn - i));
+    qq.pop();
   }
 
   assert(qq.empty());
-  qq.push(3); qq.push(7); qq.push(-3);
-  assert(qq.top()==7);
-  
+  qq.push(3);
+  qq.push(7);
+  qq.push(-3);
+  assert(qq.top() == 7);
+
   return 0;
 };

--- a/CommonTools/Utils/test/testExpressionEvaluator.cc
+++ b/CommonTools/Utils/test/testExpressionEvaluator.cc
@@ -10,127 +10,128 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-
 class testExpressionEvaluator : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testExpressionEvaluator);
   CPPUNIT_TEST(checkAll);
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  testExpressionEvaluator() {} // for crappy pats
-  ~testExpressionEvaluator(){}
-  void checkAll(); 
-
+  testExpressionEvaluator() {}  // for crappy pats
+  ~testExpressionEvaluator() {}
+  void checkAll();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( testExpressionEvaluator );
+CPPUNIT_TEST_SUITE_REGISTRATION(testExpressionEvaluator);
 
 #include <iostream>
 namespace {
-  void checkCandidate(reco::LeafCandidate const & cand, const std::string & expression, double x) {
+  void checkCandidate(reco::LeafCandidate const &cand, const std::string &expression, double x) {
     std::cerr << "testing " << expression << std::endl;
     try {
-     //provide definition of the virtual function as a string
-     std::string sexpr = "double eval(reco::LeafCandidate const& cand) const override { return ";
-     sexpr += expression + ";}";
-     // construct the expression evaluator (pkg where precompile.h resides, name of base class, declaration of overloaded member function)
-     reco::ExpressionEvaluator eval("CommonTools/CandUtils","reco::ValueOnObject<reco::LeafCandidate>",sexpr.c_str());
-     // obtain a pointer to the base class  (to be stored in Filter and Analyser at thier costruction time!)
-     reco::ValueOnObject<reco::LeafCandidate> const * expr = eval.expr<reco::ValueOnObject<reco::LeafCandidate>>();
-     CPPUNIT_ASSERT(expr);
-     // invoke
-     CPPUNIT_ASSERT(std::abs(expr->eval(cand) - x) < 1.e-6);
-    } catch(cms::Exception const & e) {
+      //provide definition of the virtual function as a string
+      std::string sexpr = "double eval(reco::LeafCandidate const& cand) const override { return ";
+      sexpr += expression + ";}";
+      // construct the expression evaluator (pkg where precompile.h resides, name of base class, declaration of overloaded member function)
+      reco::ExpressionEvaluator eval(
+          "CommonTools/CandUtils", "reco::ValueOnObject<reco::LeafCandidate>", sexpr.c_str());
+      // obtain a pointer to the base class  (to be stored in Filter and Analyser at thier costruction time!)
+      reco::ValueOnObject<reco::LeafCandidate> const *expr = eval.expr<reco::ValueOnObject<reco::LeafCandidate>>();
+      CPPUNIT_ASSERT(expr);
+      // invoke
+      CPPUNIT_ASSERT(std::abs(expr->eval(cand) - x) < 1.e-6);
+    } catch (cms::Exception const &e) {
       // if compilation fails, the compiler output is part of the exception message
-      std::cerr << e.what()  << std::endl;
-      CPPUNIT_ASSERT("ExpressionEvaluator threw"==0);
+      std::cerr << e.what() << std::endl;
+      CPPUNIT_ASSERT("ExpressionEvaluator threw" == 0);
     }
   }
 
-  std::vector<reco::LeafCandidate>  generate() {
-     reco::Candidate::LorentzVector p1(10, -10, -10, 15);
-     reco::Candidate::LorentzVector incr(0, 3, 3, 0);
+  std::vector<reco::LeafCandidate> generate() {
+    reco::Candidate::LorentzVector p1(10, -10, -10, 15);
+    reco::Candidate::LorentzVector incr(0, 3, 3, 0);
 
-     int sign=1;
-     std::vector<reco::LeafCandidate> ret;
-     for (int i=0; i<10; ++i) {
-       ret.emplace_back(sign,p1);
-       sign = -sign;
-       p1 += incr;
-     }
-     return ret;
-   }
-
+    int sign = 1;
+    std::vector<reco::LeafCandidate> ret;
+    for (int i = 0; i < 10; ++i) {
+      ret.emplace_back(sign, p1);
+      sign = -sign;
+      p1 += incr;
+    }
+    return ret;
+  }
 
   struct MyAnalyzer {
     using Selector = reco::MaskCollection<reco::LeafCandidate>;
-    explicit MyAnalyzer(std::string const & cut) {
+    explicit MyAnalyzer(std::string const &cut) {
       std::string sexpr = "void eval(Collection const & c, Mask & m) const override{";
-      sexpr += "\n auto cut = [](reco::LeafCandidate const & cand){ return "+cut+";};\n"; 
+      sexpr += "\n auto cut = [](reco::LeafCandidate const & cand){ return " + cut + ";};\n";
       sexpr += "mask(c,m,cut); }";
       std::cerr << "testing " << sexpr << std::endl;
       try {
-        reco::ExpressionEvaluator eval("CommonTools/CandUtils","reco::MaskCollection<reco::LeafCandidate>",sexpr.c_str());
+        reco::ExpressionEvaluator eval(
+            "CommonTools/CandUtils", "reco::MaskCollection<reco::LeafCandidate>", sexpr.c_str());
         m_selector = eval.expr<Selector>();
         CPPUNIT_ASSERT(m_selector);
-      } catch(cms::Exception const & e) {
-        std::cerr << e.what()  << std::endl;
-        CPPUNIT_ASSERT("ExpressionEvaluator threw"==0);
+      } catch (cms::Exception const &e) {
+        std::cerr << e.what() << std::endl;
+        CPPUNIT_ASSERT("ExpressionEvaluator threw" == 0);
       }
-
     }
 
     void analyze() const {
       auto inputColl = generate();
-      Selector::Collection cands; cands.reserve(inputColl.size());
-      for (auto const & c : inputColl) cands.push_back(&c);
+      Selector::Collection cands;
+      cands.reserve(inputColl.size());
+      for (auto const &c : inputColl)
+        cands.push_back(&c);
       Selector::Mask mask;
-      m_selector->eval(cands,mask);    
-      CPPUNIT_ASSERT(2==std::count(mask.begin(),mask.end(),true));
-      int ind=0;
-      cands.erase(std::remove_if(cands.begin(),cands.end(),[&](Selector::Collection::value_type const &){return !mask[ind++];}),cands.end());
-      CPPUNIT_ASSERT(2==cands.size());
-     }
+      m_selector->eval(cands, mask);
+      CPPUNIT_ASSERT(2 == std::count(mask.begin(), mask.end(), true));
+      int ind = 0;
+      cands.erase(
+          std::remove_if(
+              cands.begin(), cands.end(), [&](Selector::Collection::value_type const &) { return !mask[ind++]; }),
+          cands.end());
+      CPPUNIT_ASSERT(2 == cands.size());
+    }
 
-
-     Selector const * m_selector = nullptr;
+    Selector const *m_selector = nullptr;
   };
-
 
   struct MyAnalyzer2 {
     using Selector = reco::SelectInCollection<reco::LeafCandidate>;
-    explicit MyAnalyzer2(std::string const & cut) {
+    explicit MyAnalyzer2(std::string const &cut) {
       std::string sexpr = "void eval(Collection & c) const override{";
-      sexpr += "\n auto cut = [](reco::LeafCandidate const & cand){ return "+cut+";};\n";
+      sexpr += "\n auto cut = [](reco::LeafCandidate const & cand){ return " + cut + ";};\n";
       sexpr += "select(c,cut); }";
       std::cerr << "testing " << sexpr << std::endl;
       try {
-	reco::ExpressionEvaluator eval("CommonTools/CandUtils","reco::SelectInCollection<reco::LeafCandidate>",sexpr.c_str());
+        reco::ExpressionEvaluator eval(
+            "CommonTools/CandUtils", "reco::SelectInCollection<reco::LeafCandidate>", sexpr.c_str());
         m_selector = eval.expr<Selector>();
         CPPUNIT_ASSERT(m_selector);
-      } catch(cms::Exception const & e) {
-        std::cerr << e.what()  << std::endl;
-        CPPUNIT_ASSERT("ExpressionEvaluator threw"==0);
-      }                                                                                                     
+      } catch (cms::Exception const &e) {
+        std::cerr << e.what() << std::endl;
+        CPPUNIT_ASSERT("ExpressionEvaluator threw" == 0);
+      }
     }
 
     void analyze() const {
       auto inputColl = generate();
-      Selector::Collection cands; cands.reserve(inputColl.size());
-      for (auto const & c : inputColl) cands.push_back(&c);
+      Selector::Collection cands;
+      cands.reserve(inputColl.size());
+      for (auto const &c : inputColl)
+        cands.push_back(&c);
       m_selector->eval(cands);
-      CPPUNIT_ASSERT(2==cands.size());
+      CPPUNIT_ASSERT(2 == cands.size());
     }
 
-    Selector const * m_selector = nullptr;
+    Selector const *m_selector = nullptr;
   };
 
-
-
-}
+}  // namespace
 
 void testExpressionEvaluator::checkAll() {
-
   reco::CompositeCandidate cand;
 
   reco::Candidate::LorentzVector p1(1, 2, 3, 4);
@@ -139,22 +140,30 @@ void testExpressionEvaluator::checkAll() {
   reco::LeafCandidate c2(-1, p2);
   cand.addDaughter(c1);
   cand.addDaughter(c2);
-  CPPUNIT_ASSERT(cand.numberOfDaughters()==2);
-  CPPUNIT_ASSERT(cand.daughter(0)!=0);
-  CPPUNIT_ASSERT(cand.daughter(1)!=0);
+  CPPUNIT_ASSERT(cand.numberOfDaughters() == 2);
+  CPPUNIT_ASSERT(cand.daughter(0) != 0);
+  CPPUNIT_ASSERT(cand.daughter(1) != 0);
   {
-    checkCandidate(cand,"cand.numberOfDaughters()", cand.numberOfDaughters());
-    checkCandidate(cand,"cand.daughter(0)->isStandAloneMuon()", cand.daughter(0)->isStandAloneMuon());  
-    checkCandidate(cand,"cand.daughter(1)->isStandAloneMuon()", cand.daughter(1)->isStandAloneMuon());  
-    checkCandidate(cand,"cand.daughter(0)->pt()", cand.daughter(0)->pt());
-    checkCandidate(cand,"cand.daughter(1)->pt()", cand.daughter(1)->pt());
-    checkCandidate(cand,"std::min(cand.daughter(0)->pt(), cand.daughter(1)->pt())", std::min(cand.daughter(0)->pt(), cand.daughter(1)->pt()));
-    checkCandidate(cand,"std::max(cand.daughter(0)->pt(), cand.daughter(1)->pt())", std::max(cand.daughter(0)->pt(), cand.daughter(1)->pt()));
-    checkCandidate(cand,"reco::deltaPhi(cand.daughter(0)->phi(), cand.daughter(1)->phi())", reco::deltaPhi(cand.daughter(0)->phi(), cand.daughter(1)->phi()));
+    checkCandidate(cand, "cand.numberOfDaughters()", cand.numberOfDaughters());
+    checkCandidate(cand, "cand.daughter(0)->isStandAloneMuon()", cand.daughter(0)->isStandAloneMuon());
+    checkCandidate(cand, "cand.daughter(1)->isStandAloneMuon()", cand.daughter(1)->isStandAloneMuon());
+    checkCandidate(cand, "cand.daughter(0)->pt()", cand.daughter(0)->pt());
+    checkCandidate(cand, "cand.daughter(1)->pt()", cand.daughter(1)->pt());
+    checkCandidate(cand,
+                   "std::min(cand.daughter(0)->pt(), cand.daughter(1)->pt())",
+                   std::min(cand.daughter(0)->pt(), cand.daughter(1)->pt()));
+    checkCandidate(cand,
+                   "std::max(cand.daughter(0)->pt(), cand.daughter(1)->pt())",
+                   std::max(cand.daughter(0)->pt(), cand.daughter(1)->pt()));
+    checkCandidate(cand,
+                   "reco::deltaPhi(cand.daughter(0)->phi(), cand.daughter(1)->phi())",
+                   reco::deltaPhi(cand.daughter(0)->phi(), cand.daughter(1)->phi()));
     // check also opposite order, to see that the sign is correct
-    checkCandidate(cand,"reco::deltaPhi(cand.daughter(1)->phi(), cand.daughter(0)->phi())", reco::deltaPhi(cand.daughter(1)->phi(), cand.daughter(0)->phi())); 
-    checkCandidate(cand,"reco::deltaR(*cand.daughter(0), *cand.daughter(1))", reco::deltaR(*cand.daughter(0), *cand.daughter(1)));
-
+    checkCandidate(cand,
+                   "reco::deltaPhi(cand.daughter(1)->phi(), cand.daughter(0)->phi())",
+                   reco::deltaPhi(cand.daughter(1)->phi(), cand.daughter(0)->phi()));
+    checkCandidate(
+        cand, "reco::deltaR(*cand.daughter(0), *cand.daughter(1))", reco::deltaR(*cand.daughter(0), *cand.daughter(1)));
   }
 
   MyAnalyzer analyzer("cand.pt()>15 & std::abs(cand.eta())<2");
@@ -163,38 +172,41 @@ void testExpressionEvaluator::checkAll() {
   MyAnalyzer2 analyzer2("cand.pt()>15 & std::abs(cand.eta())<2");
   analyzer2.analyze();
 
-
   // pat
 
   std::vector<reco::LeafCandidate> cands;
-  cands.push_back(c1);  cands.push_back(c2); 
-  edm::TestHandle<std::vector<reco::LeafCandidate> > constituentsHandle(&cands, edm::ProductID(42));
+  cands.push_back(c1);
+  cands.push_back(c2);
+  edm::TestHandle<std::vector<reco::LeafCandidate>> constituentsHandle(&cands, edm::ProductID(42));
   reco::Jet::Constituents constituents;
-  constituents.push_back( reco::Jet::Constituent(constituentsHandle, 0) );
-  constituents.push_back( reco::Jet::Constituent(constituentsHandle, 1) );
-  reco::CaloJet::Specific caloSpecific; caloSpecific.mMaxEInEmTowers = 0.5;
-  pat::Jet jet(reco::CaloJet(p1+p2, reco::Jet::Point(), caloSpecific, constituents));
-  { 
-  std::string expression = "jet.userData<math::XYZVector>(\"my2int\")";
-  std::cerr << "testing " << expression << std::endl;
+  constituents.push_back(reco::Jet::Constituent(constituentsHandle, 0));
+  constituents.push_back(reco::Jet::Constituent(constituentsHandle, 1));
+  reco::CaloJet::Specific caloSpecific;
+  caloSpecific.mMaxEInEmTowers = 0.5;
+  pat::Jet jet(reco::CaloJet(p1 + p2, reco::Jet::Point(), caloSpecific, constituents));
+  {
+    std::string expression = "jet.userData<math::XYZVector>(\"my2int\")";
+    std::cerr << "testing " << expression << std::endl;
     try {
-     //provide definition of the virtual function as a string
-     std::string sexpr = "math::XYZVector const * operator()(pat::Jet const& jet) const override { return ";
-     sexpr += expression + ";}";
-     // obtain a pointer to the base class  (to be stored in Filter and Analyser at thier costruction time!)
-     auto const * expr = reco_expressionEvaluator("CommonTools/RecoUtils",SINGLE_ARG(reco::genericExpression<math::XYZVector const *, pat::Jet const &>),sexpr);
-     CPPUNIT_ASSERT(expr);
-     // invoke
-     CPPUNIT_ASSERT((*expr)(jet)==nullptr);
-     jet.addUserData("my2int",math::XYZVector(-2,-1,2));
-     CPPUNIT_ASSERT(jet.userData<math::XYZVector>("my2int")->z()==2);
-     std::cout << "now expr eval" << std::endl;
-     CPPUNIT_ASSERT((*expr)(jet)->z()==2);
-    } catch(cms::Exception const & e) {
+      //provide definition of the virtual function as a string
+      std::string sexpr = "math::XYZVector const * operator()(pat::Jet const& jet) const override { return ";
+      sexpr += expression + ";}";
+      // obtain a pointer to the base class  (to be stored in Filter and Analyser at thier costruction time!)
+      auto const *expr =
+          reco_expressionEvaluator("CommonTools/RecoUtils",
+                                   SINGLE_ARG(reco::genericExpression<math::XYZVector const *, pat::Jet const &>),
+                                   sexpr);
+      CPPUNIT_ASSERT(expr);
+      // invoke
+      CPPUNIT_ASSERT((*expr)(jet) == nullptr);
+      jet.addUserData("my2int", math::XYZVector(-2, -1, 2));
+      CPPUNIT_ASSERT(jet.userData<math::XYZVector>("my2int")->z() == 2);
+      std::cout << "now expr eval" << std::endl;
+      CPPUNIT_ASSERT((*expr)(jet)->z() == 2);
+    } catch (cms::Exception const &e) {
       // if compilation fails, the compiler output is part of the exception message
-      std::cerr << e.what()  << std::endl;
-      CPPUNIT_ASSERT("ExpressionEvaluator threw"==0);
+      std::cerr << e.what() << std::endl;
+      CPPUNIT_ASSERT("ExpressionEvaluator threw" == 0);
     }
   }
-
 }

--- a/CommonTools/Utils/test/testExpressionParser.cc
+++ b/CommonTools/Utils/test/testExpressionParser.cc
@@ -24,10 +24,10 @@ class testExpressionParser : public CppUnit::TestFixture {
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
   void testStringToEnum();
   void checkTrack(const std::string &, double);
-  void checkCandidate(const std::string &, double, bool lazy=false);
+  void checkCandidate(const std::string &, double, bool lazy = false);
   void checkJet(const std::string &, double);
   void checkMuon(const std::string &, double);
   reco::Track trk;
@@ -40,22 +40,22 @@ public:
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testExpressionParser);
 
-void testExpressionParser::checkTrack(const std::string & expression, double x) {
+void testExpressionParser::checkTrack(const std::string &expression, double x) {
   for (int lazyMode = 0; lazyMode <= 1; ++lazyMode) {
-  std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush; 
-  expr.reset();
-  CPPUNIT_ASSERT(reco::parser::expressionParser<reco::Track>(expression, expr, lazyMode));
-  CPPUNIT_ASSERT(expr.get() != 0);
-  double res = expr->value(o);
-  StringObjectFunction<reco::Track> f(expression, lazyMode);
-  CPPUNIT_ASSERT(fabs(f(trk) - res) < 1.e-6);
-  CPPUNIT_ASSERT(fabs(f(trk) - x) < 1.e-6);
-  std::cerr << " = " << res << std::endl;
+    std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush;
+    expr.reset();
+    CPPUNIT_ASSERT(reco::parser::expressionParser<reco::Track>(expression, expr, lazyMode));
+    CPPUNIT_ASSERT(expr.get() != 0);
+    double res = expr->value(o);
+    StringObjectFunction<reco::Track> f(expression, lazyMode);
+    CPPUNIT_ASSERT(fabs(f(trk) - res) < 1.e-6);
+    CPPUNIT_ASSERT(fabs(f(trk) - x) < 1.e-6);
+    std::cerr << " = " << res << std::endl;
   }
 }
 
-void testExpressionParser::checkCandidate(const std::string & expression, double x, bool lazyMode) {
-  std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush; 
+void testExpressionParser::checkCandidate(const std::string &expression, double x, bool lazyMode) {
+  std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush;
   expr.reset();
   CPPUNIT_ASSERT(reco::parser::expressionParser<reco::Candidate>(expression, expr, lazyMode));
   CPPUNIT_ASSERT(expr.get() != 0);
@@ -67,46 +67,47 @@ void testExpressionParser::checkCandidate(const std::string & expression, double
   std::cerr << " = " << res << std::endl;
 }
 
-void testExpressionParser::checkJet(const std::string & expression, double x) {
+void testExpressionParser::checkJet(const std::string &expression, double x) {
   for (int lazyMode = 0; lazyMode <= 1; ++lazyMode) {
-  std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush; 
-  expr.reset();
-  CPPUNIT_ASSERT(reco::parser::expressionParser<pat::Jet>(expression, expr, lazyMode));
-  CPPUNIT_ASSERT(expr.get() != 0);
-  double res = expr->value(o);
-  StringObjectFunction<pat::Jet> f(expression, lazyMode);
-  CPPUNIT_ASSERT(fabs(f(jet) - res) < 1.e-6);
-  CPPUNIT_ASSERT(fabs(f(jet) - x) < 1.e-6);
-  std::cerr << " = " << res << std::endl;
+    std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush;
+    expr.reset();
+    CPPUNIT_ASSERT(reco::parser::expressionParser<pat::Jet>(expression, expr, lazyMode));
+    CPPUNIT_ASSERT(expr.get() != 0);
+    double res = expr->value(o);
+    StringObjectFunction<pat::Jet> f(expression, lazyMode);
+    CPPUNIT_ASSERT(fabs(f(jet) - res) < 1.e-6);
+    CPPUNIT_ASSERT(fabs(f(jet) - x) < 1.e-6);
+    std::cerr << " = " << res << std::endl;
   }
 }
 
-void testExpressionParser::checkMuon(const std::string & expression, double x) {
+void testExpressionParser::checkMuon(const std::string &expression, double x) {
   for (int lazyMode = 0; lazyMode <= 1; ++lazyMode) {
-  std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush; 
-  expr.reset();
-  CPPUNIT_ASSERT(reco::parser::expressionParser<pat::Muon>(expression, expr, lazyMode));
-  CPPUNIT_ASSERT(expr.get() != 0);
-  double res = expr->value(o);
-  StringObjectFunction<pat::Muon> f(expression, lazyMode);
-  std::cerr << " = " << x << " (reference), " << res << " (bare), " << f(muon) << " (full)" << std::endl;
-  CPPUNIT_ASSERT(fabs(f(muon) - res) < 1.e-6);
-  CPPUNIT_ASSERT(fabs(f(muon) - x) < 1.e-6);
+    std::cerr << "checking " << (lazyMode ? "lazy " : "") << "expression: \"" << expression << "\"" << std::flush;
+    expr.reset();
+    CPPUNIT_ASSERT(reco::parser::expressionParser<pat::Muon>(expression, expr, lazyMode));
+    CPPUNIT_ASSERT(expr.get() != 0);
+    double res = expr->value(o);
+    StringObjectFunction<pat::Muon> f(expression, lazyMode);
+    std::cerr << " = " << x << " (reference), " << res << " (bare), " << f(muon) << " (full)" << std::endl;
+    CPPUNIT_ASSERT(fabs(f(muon) - res) < 1.e-6);
+    CPPUNIT_ASSERT(fabs(f(muon) - x) < 1.e-6);
   }
 }
 
 void testExpressionParser::testStringToEnum() {
-    std::cout << "Testing reco::Muon::ArbitrationType SegmentArbitration"  << std::endl;
-    CPPUNIT_ASSERT_EQUAL(StringToEnumValue<reco::Muon::ArbitrationType>("SegmentArbitration"),  int(reco::Muon::SegmentArbitration));
-    std::cout << "Testing reco::TrackBase::TrackQuality (tight, highPurity)"  << std::endl;
-    std::vector<std::string> algos;
-    algos.push_back("tight"); algos.push_back("highPurity");
-    std::vector<int> algoValues = StringToEnumValue<reco::TrackBase::TrackQuality>(algos);
-    CPPUNIT_ASSERT(algoValues.size() == 2);
-    CPPUNIT_ASSERT_EQUAL(algoValues[0], int(reco::TrackBase::tight));
-    CPPUNIT_ASSERT_EQUAL(algoValues[1], int(reco::TrackBase::highPurity));
+  std::cout << "Testing reco::Muon::ArbitrationType SegmentArbitration" << std::endl;
+  CPPUNIT_ASSERT_EQUAL(StringToEnumValue<reco::Muon::ArbitrationType>("SegmentArbitration"),
+                       int(reco::Muon::SegmentArbitration));
+  std::cout << "Testing reco::TrackBase::TrackQuality (tight, highPurity)" << std::endl;
+  std::vector<std::string> algos;
+  algos.push_back("tight");
+  algos.push_back("highPurity");
+  std::vector<int> algoValues = StringToEnumValue<reco::TrackBase::TrackQuality>(algos);
+  CPPUNIT_ASSERT(algoValues.size() == 2);
+  CPPUNIT_ASSERT_EQUAL(algoValues[0], int(reco::TrackBase::tight));
+  CPPUNIT_ASSERT_EQUAL(algoValues[1], int(reco::TrackBase::highPurity));
 }
-
 
 void testExpressionParser::checkAll() {
   using namespace reco;
@@ -114,11 +115,7 @@ void testExpressionParser::checkAll() {
   const int ndof = 10;
   reco::Track::Point v(1, 2, 3);
   reco::Track::Vector p(5, 3, 10);
-  double e[] = { 1.1,
-                 1.2, 2.2,
-                 1.3, 2.3, 3.3,
-                 1.4, 2.4, 3.4, 4.4,
-                 1.5, 2.5, 3.5, 4.5, 5.5 };
+  double e[] = {1.1, 1.2, 2.2, 1.3, 2.3, 3.3, 1.4, 2.4, 3.4, 4.4, 1.5, 2.5, 3.5, 4.5, 5.5};
   reco::TrackBase::CovarianceMatrix cov(e, e + 15);
   cov(0, 0) = 1.2345;
   cov(1, 0) = 123.456;
@@ -129,11 +126,9 @@ void testExpressionParser::checkAll() {
   reco::TrackExtraCollection trkExtras;
   reco::Track::Point outerV(100, 200, 300), innerV(v);
   reco::Track::Vector outerP(0.5, 3.5, 10.5), innerP(p);
-  reco::Track::CovarianceMatrix  outerC, innerC;
+  reco::Track::CovarianceMatrix outerC, innerC;
   unsigned int outerId = 123, innerId = 456;
-  reco::TrackExtra trkExtra(outerV, outerP, true, innerV, innerP, true,
-			    outerC, outerId, innerC, innerId,
-			    anyDirection);
+  reco::TrackExtra trkExtra(outerV, outerP, true, innerV, innerP, true, outerC, outerId, innerC, innerId, anyDirection);
   trkExtras.push_back(trkExtra);
   edm::TestHandle<reco::TrackExtraCollection> h(&trkExtras, pid);
   reco::TrackExtraRef trkExtraRef(h, 0);
@@ -141,10 +136,10 @@ void testExpressionParser::checkAll() {
   trk.setAlgorithm(reco::Track::pixelPairStep);
   {
     edm::TypeWithDict t(typeid(reco::Track));
-    o = edm::ObjectWithDict(t, & trk);
+    o = edm::ObjectWithDict(t, &trk);
     checkTrack("pt", trk.pt());
     checkTrack("charge", trk.charge());
-    checkTrack("pt/3", trk.pt()/3);
+    checkTrack("pt/3", trk.pt() / 3);
     checkTrack("covariance(0, 0)", trk.covariance(0, 0));
     checkTrack("covariance(1, 0)", trk.covariance(1, 0));
     checkTrack("covariance(1, 1)", trk.covariance(1, 1));
@@ -156,8 +151,8 @@ void testExpressionParser::checkAll() {
     checkTrack("quality('highPurity')", trk.quality(reco::TrackBase::highPurity));
     checkTrack("cosh(theta)", cosh(trk.theta()));
     checkTrack("hypot(px, py)", hypot(trk.px(), trk.py()));
-    checkTrack("?ndof<0?1:0", trk.ndof()<0?1:0);
-    checkTrack("?ndof=10?1:0", trk.ndof()==10?1:0);
+    checkTrack("?ndof<0?1:0", trk.ndof() < 0 ? 1 : 0);
+    checkTrack("?ndof=10?1:0", trk.ndof() == 10 ? 1 : 0);
   }
   reco::Candidate::LorentzVector p1(1, 2, 3, 4);
   reco::Candidate::LorentzVector p2(1.1, -2.5, 4.3, 13.7);
@@ -165,25 +160,30 @@ void testExpressionParser::checkAll() {
   reco::LeafCandidate c2(-1, p2);
   cand.addDaughter(c1);
   cand.addDaughter(c2);
-  CPPUNIT_ASSERT(cand.numberOfDaughters()==2);
-  CPPUNIT_ASSERT(cand.daughter(0)!=0);
-  CPPUNIT_ASSERT(cand.daughter(1)!=0);
+  CPPUNIT_ASSERT(cand.numberOfDaughters() == 2);
+  CPPUNIT_ASSERT(cand.daughter(0) != 0);
+  CPPUNIT_ASSERT(cand.daughter(1) != 0);
   {
     edm::TypeWithDict t(typeid(reco::Candidate));
-    o = edm::ObjectWithDict(t, & cand);  
+    o = edm::ObjectWithDict(t, &cand);
     // these can be checked in both modes
     for (int lazyMode = 0; lazyMode <= 1; ++lazyMode) {
-    checkCandidate("numberOfDaughters", cand.numberOfDaughters(), lazyMode);
-    checkCandidate("daughter(0).isStandAloneMuon", cand.daughter(0)->isStandAloneMuon(), lazyMode);  
-    checkCandidate("daughter(1).isStandAloneMuon", cand.daughter(1)->isStandAloneMuon(), lazyMode);  
-    checkCandidate("daughter(0).pt", cand.daughter(0)->pt(), lazyMode);
-    checkCandidate("daughter(1).pt", cand.daughter(1)->pt(), lazyMode);
-    checkCandidate("min(daughter(0).pt, daughter(1).pt)", std::min(cand.daughter(0)->pt(), cand.daughter(1)->pt()), lazyMode);
-    checkCandidate("max(daughter(0).pt, daughter(1).pt)", std::max(cand.daughter(0)->pt(), cand.daughter(1)->pt()), lazyMode);
-    checkCandidate("deltaPhi(daughter(0).phi, daughter(1).phi)", reco::deltaPhi(cand.daughter(0)->phi(), cand.daughter(1)->phi()));
-    // check also opposite order, to see that the sign is correct
-    checkCandidate("deltaPhi(daughter(1).phi, daughter(0).phi)", reco::deltaPhi(cand.daughter(1)->phi(), cand.daughter(0)->phi())); 
-    checkCandidate("deltaR(daughter(0).eta, daughter(0).phi, daughter(1).eta, daughter(1).phi)", reco::deltaR(*cand.daughter(0), *cand.daughter(1)));
+      checkCandidate("numberOfDaughters", cand.numberOfDaughters(), lazyMode);
+      checkCandidate("daughter(0).isStandAloneMuon", cand.daughter(0)->isStandAloneMuon(), lazyMode);
+      checkCandidate("daughter(1).isStandAloneMuon", cand.daughter(1)->isStandAloneMuon(), lazyMode);
+      checkCandidate("daughter(0).pt", cand.daughter(0)->pt(), lazyMode);
+      checkCandidate("daughter(1).pt", cand.daughter(1)->pt(), lazyMode);
+      checkCandidate(
+          "min(daughter(0).pt, daughter(1).pt)", std::min(cand.daughter(0)->pt(), cand.daughter(1)->pt()), lazyMode);
+      checkCandidate(
+          "max(daughter(0).pt, daughter(1).pt)", std::max(cand.daughter(0)->pt(), cand.daughter(1)->pt()), lazyMode);
+      checkCandidate("deltaPhi(daughter(0).phi, daughter(1).phi)",
+                     reco::deltaPhi(cand.daughter(0)->phi(), cand.daughter(1)->phi()));
+      // check also opposite order, to see that the sign is correct
+      checkCandidate("deltaPhi(daughter(1).phi, daughter(0).phi)",
+                     reco::deltaPhi(cand.daughter(1)->phi(), cand.daughter(0)->phi()));
+      checkCandidate("deltaR(daughter(0).eta, daughter(0).phi, daughter(1).eta, daughter(1).phi)",
+                     reco::deltaR(*cand.daughter(0), *cand.daughter(1)));
     }
     // these can be checked only in lazy mode
     checkCandidate("name.empty()", true, true);
@@ -191,52 +191,58 @@ void testExpressionParser::checkAll() {
   }
 
   std::vector<reco::LeafCandidate> cands;
-  cands.push_back(c1);  cands.push_back(c2); 
+  cands.push_back(c1);
+  cands.push_back(c2);
   edm::TestHandle<std::vector<reco::LeafCandidate> > constituentsHandle(&cands, edm::ProductID(42));
   reco::Jet::Constituents constituents;
-  constituents.push_back( reco::Jet::Constituent(constituentsHandle, 0) );
-  constituents.push_back( reco::Jet::Constituent(constituentsHandle, 1) );
-  reco::CaloJet::Specific caloSpecific; caloSpecific.mMaxEInEmTowers = 0.5;
-  jet = pat::Jet(reco::CaloJet(p1+p2, reco::Jet::Point(), caloSpecific, constituents));
+  constituents.push_back(reco::Jet::Constituent(constituentsHandle, 0));
+  constituents.push_back(reco::Jet::Constituent(constituentsHandle, 1));
+  reco::CaloJet::Specific caloSpecific;
+  caloSpecific.mMaxEInEmTowers = 0.5;
+  jet = pat::Jet(reco::CaloJet(p1 + p2, reco::Jet::Point(), caloSpecific, constituents));
   CPPUNIT_ASSERT(jet.nConstituents() == 2);
-  CPPUNIT_ASSERT(jet.nCarrying(1.0)  == 2);
-  CPPUNIT_ASSERT(jet.nCarrying(0.1)  == 1);
+  CPPUNIT_ASSERT(jet.nCarrying(1.0) == 2);
+  CPPUNIT_ASSERT(jet.nCarrying(0.1) == 1);
   {
     edm::TypeWithDict t(typeid(pat::Jet));
-    o = edm::ObjectWithDict(t, & jet);
+    o = edm::ObjectWithDict(t, &jet);
     checkJet("nCarrying(1.0)", jet.nCarrying(1.0));
     checkJet("nCarrying(0.1)", jet.nCarrying(0.1));
   }
   {
     // Check a method that starts with the same string as a predefined function
-    CPPUNIT_ASSERT(jet.maxEInEmTowers()== 0.5);
+    CPPUNIT_ASSERT(jet.maxEInEmTowers() == 0.5);
     checkJet("maxEInEmTowers", jet.maxEInEmTowers());
   }
 
-  std::pair<std::string,float> bp;
-  bp = std::pair<std::string,float>("aaa", 1.0); jet.addBDiscriminatorPair(bp); 
-  bp = std::pair<std::string,float>("b c", 2.0); jet.addBDiscriminatorPair(bp); 
-  bp = std::pair<std::string,float>("d " , 3.0); jet.addBDiscriminatorPair(bp); 
+  std::pair<std::string, float> bp;
+  bp = std::pair<std::string, float>("aaa", 1.0);
+  jet.addBDiscriminatorPair(bp);
+  bp = std::pair<std::string, float>("b c", 2.0);
+  jet.addBDiscriminatorPair(bp);
+  bp = std::pair<std::string, float>("d ", 3.0);
+  jet.addBDiscriminatorPair(bp);
   CPPUNIT_ASSERT(jet.bDiscriminator("aaa") == 1.0);
   CPPUNIT_ASSERT(jet.bDiscriminator("b c") == 2.0);
-  CPPUNIT_ASSERT(jet.bDiscriminator("d ")  == 3.0);
-  CPPUNIT_ASSERT(jet.getPairDiscri().size() == 3 );
+  CPPUNIT_ASSERT(jet.bDiscriminator("d ") == 3.0);
+  CPPUNIT_ASSERT(jet.getPairDiscri().size() == 3);
   {
     edm::TypeWithDict t(typeid(pat::Jet));
-    o = edm::ObjectWithDict(t, & jet);
+    o = edm::ObjectWithDict(t, &jet);
     checkJet("bDiscriminator(\"aaa\")", jet.bDiscriminator("aaa"));
-    checkJet("bDiscriminator('aaa')"  , jet.bDiscriminator("aaa"));
+    checkJet("bDiscriminator('aaa')", jet.bDiscriminator("aaa"));
     checkJet("bDiscriminator(\"b c\")", jet.bDiscriminator("b c"));
-    checkJet("bDiscriminator(\"d \")" , jet.bDiscriminator("d " ));
+    checkJet("bDiscriminator(\"d \")", jet.bDiscriminator("d "));
   }
 
-  muon = pat::Muon(reco::Muon(+1, p1+p2));
+  muon = pat::Muon(reco::Muon(+1, p1 + p2));
   muon.setUserIso(2.0);
   muon.setUserIso(42.0, 1);
-  CPPUNIT_ASSERT( muon.userIso()  == 2.0 );
-  CPPUNIT_ASSERT( muon.userIso(0) == 2.0 );
-  CPPUNIT_ASSERT( muon.userIso(1) == 42.0 );
-  reco::IsoDeposit dep; dep.addCandEnergy(2.0);
+  CPPUNIT_ASSERT(muon.userIso() == 2.0);
+  CPPUNIT_ASSERT(muon.userIso(0) == 2.0);
+  CPPUNIT_ASSERT(muon.userIso(1) == 42.0);
+  reco::IsoDeposit dep;
+  dep.addCandEnergy(2.0);
   CPPUNIT_ASSERT(dep.candEnergy() == 2.0);
   muon.setIsoDeposit(pat::TrackIso, dep);
   CPPUNIT_ASSERT(muon.trackIsoDeposit() != 0);
@@ -246,39 +252,39 @@ void testExpressionParser::checkAll() {
   muon.addTriggerObjectMatch(tosa);
   {
     edm::TypeWithDict t(typeid(pat::Muon));
-    o = edm::ObjectWithDict(t, & muon);
-    checkMuon("userIso"    , muon.userIso() );
-    checkMuon("userIso()"  , muon.userIso() );
-    checkMuon("userIso(0)" , muon.userIso(0));
-    checkMuon("userIso(1)" , muon.userIso(1));
+    o = edm::ObjectWithDict(t, &muon);
+    checkMuon("userIso", muon.userIso());
+    checkMuon("userIso()", muon.userIso());
+    checkMuon("userIso(0)", muon.userIso(0));
+    checkMuon("userIso(1)", muon.userIso(1));
     checkMuon("trackIsoDeposit.candEnergy", muon.trackIsoDeposit()->candEnergy());
     //checkMuon("isoDeposit('TrackIso').candEnergy", muon.isoDeposit(pat::TrackIso)->candEnergy());
-    checkMuon("triggerObjectMatchesByPath('HLT_Something').size()",1);
+    checkMuon("triggerObjectMatchesByPath('HLT_Something').size()", 1);
     for (int b = 0; b <= 1; ++b) {
-        std::cout << "Check for leaks in the " << (b ? "Lazy" : "standard") << " string parser" << std::endl;
-        expr.reset();
-        reco::parser::expressionParser<pat::Muon>("triggerObjectMatchesByPath('HLT_Something').size()", expr, b);
-        double res = 0;
-        for (size_t i = 0; i < 10*1000; ++i) {
-            for (size_t j = 0; j < 100; ++j) {
-                res += expr->value(o);
-                break;
-            }
-            break;
-            if (i % 1000 == 999) std::cout << "iter " << i << std::endl;
+      std::cout << "Check for leaks in the " << (b ? "Lazy" : "standard") << " string parser" << std::endl;
+      expr.reset();
+      reco::parser::expressionParser<pat::Muon>("triggerObjectMatchesByPath('HLT_Something').size()", expr, b);
+      double res = 0;
+      for (size_t i = 0; i < 10 * 1000; ++i) {
+        for (size_t j = 0; j < 100; ++j) {
+          res += expr->value(o);
+          break;
         }
+        break;
+        if (i % 1000 == 999)
+          std::cout << "iter " << i << std::endl;
+      }
     }
   }
   reco::CandidatePtrVector ptrOverlaps;
   ptrOverlaps.push_back(reco::CandidatePtr(constituentsHandle, 0));
-  muon.setOverlaps("test",ptrOverlaps); 
+  muon.setOverlaps("test", ptrOverlaps);
   CPPUNIT_ASSERT(muon.hasOverlaps("test"));
   CPPUNIT_ASSERT(muon.overlaps("test").size() == 1);
   CPPUNIT_ASSERT(muon.overlaps("test")[0]->pt() == c1.pt());
   {
     edm::TypeWithDict t(typeid(pat::Muon));
-    o = edm::ObjectWithDict(t, & muon);
+    o = edm::ObjectWithDict(t, &muon);
     checkMuon("overlaps('test')[0].pt", muon.overlaps("test")[0]->pt());
-
   }
 }

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -24,16 +24,16 @@ class testFormulaEvaluator : public CppUnit::TestFixture {
 public:
   void setUp() {}
   void tearDown() {}
-  void checkEvaluators(); 
+  void checkEvaluators();
   void checkFormulaEvaluator();
 };
 
 namespace {
   bool compare(double iLHS, double iRHS) {
-    return std::fabs(iLHS)!=0 ? (std::fabs(iLHS-iRHS)< 1E-6*std::fabs(iLHS)) : (std::fabs(iLHS) == std::fabs(iRHS));
+    return std::fabs(iLHS) != 0 ? (std::fabs(iLHS - iRHS) < 1E-6 * std::fabs(iLHS))
+                                : (std::fabs(iLHS) == std::fabs(iRHS));
   }
-}
-
+}  // namespace
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testFormulaEvaluator);
 
@@ -42,7 +42,7 @@ void testFormulaEvaluator::checkEvaluators() {
   {
     ConstantEvaluator c{4};
 
-    CPPUNIT_ASSERT( c.evaluate(nullptr,nullptr) == 4. );
+    CPPUNIT_ASSERT(c.evaluate(nullptr, nullptr) == 4.);
   }
 
   {
@@ -50,7 +50,7 @@ void testFormulaEvaluator::checkEvaluators() {
 
     double p = 5.;
 
-    CPPUNIT_ASSERT( pe.evaluate(nullptr, &p) == p);
+    CPPUNIT_ASSERT(pe.evaluate(nullptr, &p) == p);
   }
 
   {
@@ -58,118 +58,114 @@ void testFormulaEvaluator::checkEvaluators() {
 
     double v = 3.;
 
-    CPPUNIT_ASSERT( ve.evaluate(&v, nullptr) == v);
+    CPPUNIT_ASSERT(ve.evaluate(&v, nullptr) == v);
   }
 
   {
-    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
-    auto cr = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(3) );
+    auto cl = std::unique_ptr<ConstantEvaluator>(new ConstantEvaluator(4));
+    auto cr = std::unique_ptr<ConstantEvaluator>(new ConstantEvaluator(3));
 
-    BinaryOperatorEvaluator<std::minus<double>> be( std::move(cl), std::move(cr), EvaluatorBase::Precedence::kPlusMinus);
+    BinaryOperatorEvaluator<std::minus<double>> be(std::move(cl), std::move(cr), EvaluatorBase::Precedence::kPlusMinus);
 
-    CPPUNIT_ASSERT( be.evaluate(nullptr,nullptr) == 1. );
+    CPPUNIT_ASSERT(be.evaluate(nullptr, nullptr) == 1.);
   }
 
   {
-    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+    auto cl = std::unique_ptr<ConstantEvaluator>(new ConstantEvaluator(4));
 
-    FunctionOneArgEvaluator f( std::move(cl), [](double v) { return std::exp(v); } );
+    FunctionOneArgEvaluator f(std::move(cl), [](double v) { return std::exp(v); });
 
-    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == std::exp(4.) );
+    CPPUNIT_ASSERT(f.evaluate(nullptr, nullptr) == std::exp(4.));
   }
 
   {
-    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
-    auto cr = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(3) );
+    auto cl = std::unique_ptr<ConstantEvaluator>(new ConstantEvaluator(4));
+    auto cr = std::unique_ptr<ConstantEvaluator>(new ConstantEvaluator(3));
 
-    FunctionTwoArgsEvaluator f( std::move(cl), std::move(cr),
-                                [](double v1, double v2) { return std::max(v1,v2); });
+    FunctionTwoArgsEvaluator f(std::move(cl), std::move(cr), [](double v1, double v2) { return std::max(v1, v2); });
 
-    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == 4. );
+    CPPUNIT_ASSERT(f.evaluate(nullptr, nullptr) == 4.);
   }
 
   {
-    auto cl = std::unique_ptr<ConstantEvaluator>( new ConstantEvaluator(4) );
+    auto cl = std::unique_ptr<ConstantEvaluator>(new ConstantEvaluator(4));
 
-    UnaryMinusEvaluator f( std::move(cl) );
+    UnaryMinusEvaluator f(std::move(cl));
 
-    CPPUNIT_ASSERT( f.evaluate(nullptr,nullptr) == -4. );
+    CPPUNIT_ASSERT(f.evaluate(nullptr, nullptr) == -4.);
   }
-
 }
 
-void 
-testFormulaEvaluator::checkFormulaEvaluator() {
-
+void testFormulaEvaluator::checkFormulaEvaluator() {
   {
     reco::FormulaEvaluator f("5");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 5.);
   }
 
   {
     reco::FormulaEvaluator f("3+2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 5.);
   }
 
   {
     reco::FormulaEvaluator f(" 3 + 2 ");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 5.);
   }
 
   {
     reco::FormulaEvaluator f("3-2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
 
   {
     reco::FormulaEvaluator f("3*2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 6. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 6.);
   }
 
   {
     reco::FormulaEvaluator f("6/2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 3. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 3.);
   }
 
   {
     reco::FormulaEvaluator f("3^2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 9. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 9.);
   }
 
   {
     reco::FormulaEvaluator f("4*3^2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 36. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 36.);
   }
   {
     reco::FormulaEvaluator f("3^2*4");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 36. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 36.);
   }
 
   {
@@ -177,7 +173,7 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+2*(3*3*3*3)+5*2+6*2);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1 + 2 * (3 * 3 * 3 * 3) + 5 * 2 + 6 * 2);
   }
 
   {
@@ -185,453 +181,447 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+2*(3*3*3*3)+5*2+6*2);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1 + 2 * (3 * 3 * 3 * 3) + 5 * 2 + 6 * 2);
   }
 
   {
     reco::FormulaEvaluator f("3<=2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
   {
     reco::FormulaEvaluator f("2<=3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
   {
     reco::FormulaEvaluator f("3<=3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
 
   {
     reco::FormulaEvaluator f("3>=2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
   {
     reco::FormulaEvaluator f("2>=3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
   {
     reco::FormulaEvaluator f("3>=3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
-
 
   {
     reco::FormulaEvaluator f("3>2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
   {
     reco::FormulaEvaluator f("2>3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
   {
     reco::FormulaEvaluator f("3>3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
 
   {
     reco::FormulaEvaluator f("3<2");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
   {
     reco::FormulaEvaluator f("2<3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
   {
     reco::FormulaEvaluator f("3<3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
 
   {
     reco::FormulaEvaluator f("2==3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
   {
     reco::FormulaEvaluator f("3==3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
 
   {
     reco::FormulaEvaluator f("2!=3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1.);
   }
   {
     reco::FormulaEvaluator f("3!=3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 0. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 0.);
   }
 
   {
     reco::FormulaEvaluator f("1+2*3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 7. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 7.);
   }
 
   {
     reco::FormulaEvaluator f("(1+2)*3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 9. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 9.);
   }
 
   {
     reco::FormulaEvaluator f("2*3+1");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 7. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 7.);
   }
 
   {
     reco::FormulaEvaluator f("2*(3+1)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 8. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 8.);
   }
 
   {
     reco::FormulaEvaluator f("4/2*3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 6. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 6.);
   }
-
 
   {
     reco::FormulaEvaluator f("1-2+3");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2.);
   }
 
   {
     reco::FormulaEvaluator f("(1+2)-(3+4)");
     std::vector<double> emptyV;
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == -4. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == -4.);
   }
-
 
   {
     reco::FormulaEvaluator f("3/2*4+1");
 
     std::vector<double> emptyV;
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 3./2.*4.+1 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 3. / 2. * 4. + 1);
   }
 
   {
     reco::FormulaEvaluator f("1+3/2*4");
     std::vector<double> emptyV;
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+3./2.*4. );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1 + 3. / 2. * 4.);
   }
 
   {
     reco::FormulaEvaluator f("1+4*(3/2+5)");
     std::vector<double> emptyV;
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+4*(3./2.+5.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1 + 4 * (3. / 2. + 5.));
   }
 
   {
     reco::FormulaEvaluator f("1+2*3/4*5");
     std::vector<double> emptyV;
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+2.*3./4.*5 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1 + 2. * 3. / 4. * 5);
   }
-      
+
   {
     reco::FormulaEvaluator f("1+2*3/(4+5)+6");
     std::vector<double> emptyV;
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 1+2.*3./(4+5)+6 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 1 + 2. * 3. / (4 + 5) + 6);
   }
-
 
   {
     reco::FormulaEvaluator f("100./3.*2+1");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 100./3.*2.+1 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 100. / 3. * 2. + 1);
   }
 
   {
     reco::FormulaEvaluator f("100./3.*(4-2)+2*(3+1)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 100./3.*(4-2)+2*(3+1) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 100. / 3. * (4 - 2) + 2 * (3 + 1));
   }
 
   {
     reco::FormulaEvaluator f("2*(3*4*5)/6");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2*(3*4*5)/6 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2 * (3 * 4 * 5) / 6);
   }
 
   {
     reco::FormulaEvaluator f("2*(2.5*3*3.5)*(4*4.5*5)/6");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2*(2.5*3*3.5)*(4*4.5*5)/6 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2 * (2.5 * 3 * 3.5) * (4 * 4.5 * 5) / 6);
   }
 
   {
     reco::FormulaEvaluator f("x");
-    
-    std::vector<double> emptyV;
-    std::array<double,1> v ={{3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+    std::vector<double> emptyV;
+    std::array<double, 1> v = {{3.}};
+
+    CPPUNIT_ASSERT(f.evaluate(v, emptyV) == 3.);
   }
 
   {
     reco::FormulaEvaluator f("y");
-    
-    std::vector<double> emptyV;
-    std::array<double,2> v = {{0.,3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+    std::vector<double> emptyV;
+    std::array<double, 2> v = {{0., 3.}};
+
+    CPPUNIT_ASSERT(f.evaluate(v, emptyV) == 3.);
   }
 
   {
     reco::FormulaEvaluator f("z");
-    
-    std::vector<double> emptyV;
-    std::array<double,3> v = {{0.,0.,3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+    std::vector<double> emptyV;
+    std::array<double, 3> v = {{0., 0., 3.}};
+
+    CPPUNIT_ASSERT(f.evaluate(v, emptyV) == 3.);
   }
 
   {
     reco::FormulaEvaluator f("t");
-    
+
     std::vector<double> emptyV;
-    std::array<double,4> v = {{0.,0.,0.,3.}};
+    std::array<double, 4> v = {{0., 0., 0., 3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(v,emptyV) == 3. );
+    CPPUNIT_ASSERT(f.evaluate(v, emptyV) == 3.);
   }
-
 
   {
     reco::FormulaEvaluator f("[0]");
-    
-    std::vector<double> emptyV;
-    std::array<double,1> v = {{3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 3. );
+    std::vector<double> emptyV;
+    std::array<double, 1> v = {{3.}};
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, v) == 3.);
   }
 
   {
     reco::FormulaEvaluator f("[1]");
-    
-    std::vector<double> emptyV;
-    std::array<double,2> v = {{0.,3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 3. );
+    std::vector<double> emptyV;
+    std::array<double, 2> v = {{0., 3.}};
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, v) == 3.);
   }
 
   {
     reco::FormulaEvaluator f("[0]+[1]*3");
-    
-    std::vector<double> emptyV;
-    std::array<double,2> v = {{1.,3.}};
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,v) == 10. );
+    std::vector<double> emptyV;
+    std::array<double, 2> v = {{1., 3.}};
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, v) == 10.);
   }
 
   {
     reco::FormulaEvaluator f("log(2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::log(2.));
   }
   {
     reco::FormulaEvaluator f("TMath::Log(2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::log(2.));
   }
 
   {
     reco::FormulaEvaluator f("log10(2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::log(2.)/std::log(10.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::log(2.) / std::log(10.));
   }
 
   {
     reco::FormulaEvaluator f("exp(2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::exp(2.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::exp(2.));
   }
 
   {
     reco::FormulaEvaluator f("pow(2,0.3)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::pow(2.,0.3) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::pow(2., 0.3));
   }
 
   {
     reco::FormulaEvaluator f("TMath::Power(2,0.3)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::pow(2.,0.3) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::pow(2., 0.3));
   }
 
   {
     reco::FormulaEvaluator f("TMath::Erf(2.)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == TMath::Erf(2.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Erf(2.));
   }
 
   {
     reco::FormulaEvaluator f("erf(2.)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == std::erf(2.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::erf(2.));
   }
 
   {
     reco::FormulaEvaluator f("TMath::Landau(3.)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == TMath::Landau(3.) );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Landau(3.));
   }
 
   {
     reco::FormulaEvaluator f("max(2,1)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2);
   }
 
   {
     reco::FormulaEvaluator f("max(1,2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2);
   }
 
   {
     reco::FormulaEvaluator f("TMath::Max(2,1)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2);
   }
 
   {
     reco::FormulaEvaluator f("TMath::Max(1,2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 2 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 2);
   }
 
   {
     reco::FormulaEvaluator f("max(max(5,3),2)");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 5);
   }
 
   {
     reco::FormulaEvaluator f("max(2,max(5,3))");
-    
+
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == 5 );
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == 5);
   }
 
   {
     reco::FormulaEvaluator f("-(-2.36997+0.413917*TMath::Log(208))/208");
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT( f.evaluate(emptyV,emptyV) == -(-2.36997+0.413917*std::log(208.))/208.);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == -(-2.36997 + 0.413917 * std::log(208.)) / 208.);
   }
 
   {
     //For Jet energy corrections
     reco::FormulaEvaluator f("2*TMath::Erf(4*(x-1))");
 
-    std::vector<double> x ={1.};
-
+    std::vector<double> x = {1.};
 
     std::vector<double> xValues = {1., 2., 3.};
     std::vector<double> emptyV;
 
-    auto func = [](double x) { return 2*TMath::Erf(4*(x-1)); };
+    auto func = [](double x) { return 2 * TMath::Erf(4 * (x - 1)); };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, emptyV),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, emptyV), func(x[0])));
     }
   }
 
@@ -639,17 +629,16 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     //For Jet energy corrections
     reco::FormulaEvaluator f("2*TMath::Landau(2*(x-1))");
 
-    std::vector<double> x ={1.};
-
+    std::vector<double> x = {1.};
 
     std::vector<double> xValues = {1., 2., 3.};
     std::vector<double> emptyV;
 
-    auto func = [](double x) { return 2*TMath::Landau(2*(x-1)); };
+    auto func = [](double x) { return 2 * TMath::Landau(2 * (x - 1)); };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, emptyV),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, emptyV), func(x[0])));
     }
   }
 
@@ -657,17 +646,21 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     //From SimpleJetCorrector
     reco::FormulaEvaluator f("([0]+([1]/((log10(x)^2)+[2])))+([3]*exp(-([4]*((log10(x)-[5])*(log10(x)-[5])))))");
 
-    std::vector<double> x ={1.};
+    std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.,4.,2.,0.5,2.,1.};
+    std::vector<double> v = {1., 4., 2., 0.5, 2., 1.};
 
     std::vector<double> xValues = {1., 10., 100.};
 
-    auto func = [&v](double x) { return (v[0]+(v[1]/(( (std::log(x)/std::log(10))*(std::log(x)/std::log(10)) ) +v[2])))+(v[3]*std::exp(-1.*(v[4]*((std::log(x)/std::log(10.)-v[5])*(std::log(x)/std::log(10.)-v[5]))))); };
+    auto func = [&v](double x) {
+      return (v[0] + (v[1] / (((std::log(x) / std::log(10)) * (std::log(x) / std::log(10))) + v[2]))) +
+             (v[3] *
+              std::exp(-1. * (v[4] * ((std::log(x) / std::log(10.) - v[5]) * (std::log(x) / std::log(10.) - v[5])))));
+    };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
@@ -675,17 +668,17 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     //From SimpleJetCorrector
     reco::FormulaEvaluator f("[0]*([1]+[2]*TMath::Log(x))");
 
-    std::vector<double> x ={1.};
+    std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.3,4.,2.};
+    std::vector<double> v = {1.3, 4., 2.};
 
     std::vector<double> xValues = {1., 10., 100.};
 
-    auto func = [&v](double x) { return v[0]*(v[1]+v[2]*std::log(x)); };
+    auto func = [&v](double x) { return v[0] * (v[1] + v[2] * std::log(x)); };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
@@ -693,17 +686,17 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     //From SimpleJetCorrector
     reco::FormulaEvaluator f("[0]+([1]/((log10(x)^[2])+[3]))");
 
-    std::vector<double> x ={1.};
+    std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.3,4.,1.7,1.};
+    std::vector<double> v = {1.3, 4., 1.7, 1.};
 
     std::vector<double> xValues = {1., 10., 100.};
 
-    auto func = [&v](double x) { return v[0]+(v[1]/(( std::pow(log(x)/log(10.),v[2]) )+v[3])); };
+    auto func = [&v](double x) { return v[0] + (v[1] / ((std::pow(log(x) / log(10.), v[2])) + v[3])); };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
@@ -711,50 +704,57 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     //From SimpleJetCorrector
     reco::FormulaEvaluator f("max(0.0001,1-y*([0]+([1]*z)*(1+[2]*log(x)))/x)");
 
-    std::vector<double> v ={.1,1.,.5};
+    std::vector<double> v = {.1, 1., .5};
 
-    std::vector<double> p = {1.3,5.,10.};
+    std::vector<double> p = {1.3, 5., 10.};
 
     std::vector<double> xValues = {1., 10., 100.};
 
-    auto func = [&p](double x, double y, double z) { return std::max(0.0001, 1-y*(p[0]+(p[1]*z)*(1+p[2]*std::log(x)))/x); };
+    auto func = [&p](double x, double y, double z) {
+      return std::max(0.0001, 1 - y * (p[0] + (p[1] * z) * (1 + p[2] * std::log(x))) / x);
+    };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       v[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(v, p),func(v[0],v[1],v[2])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(v, p), func(v[0], v[1], v[2])));
     }
   }
   {
     reco::FormulaEvaluator f("(-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208");
 
-    std::vector<double> x ={1.};
+    std::vector<double> x = {1.};
 
     std::vector<double> v;
 
-    auto func = [](double x) {return (-2.36997+0.413917*std::log(x))/x-(-2.36997+0.413917*std::log(208))/208;};
+    auto func = [](double x) {
+      return (-2.36997 + 0.413917 * std::log(x)) / x - (-2.36997 + 0.413917 * std::log(208)) / 208;
+    };
 
     std::vector<double> xValues = {.1, 1., 10., 100.};
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
   {
-    reco::FormulaEvaluator f("TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227))");
-    std::vector<double> x ={1.};
+    reco::FormulaEvaluator f(
+        "TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)"
+        ")");
+    std::vector<double> x = {1.};
 
     std::vector<double> v;
 
-
     std::vector<double> xValues = {.1, 1., 10., 100.};
 
+    auto func = [](double x) {
+      return std::max(0., 1.03091 - 0.051154 * std::pow(x, -0.154227)) -
+             std::max(0., 1.03091 - 0.051154 * std::pow(208., -0.154227));
+    };
 
-    auto func = [](double x) { return std::max(0.,1.03091-0.051154*std::pow(x,-0.154227))-std::max(0.,1.03091-0.051154*std::pow(208.,-0.154227)); };
-
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
@@ -763,50 +763,58 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> v = {1., 4., 2., 0.5, 2., 1., 1., -1.};
     std::vector<double> xValues = {.1, 1., 10., 100.};
 
-    auto func =[&v](double x) { return v[2]*(v[3]+v[4]*std::log(std::max(v[0],std::min(v[1],x)))); };
-    for(auto const xv: xValues) {
+    auto func = [&v](double x) { return v[2] * (v[3] + v[4] * std::log(std::max(v[0], std::min(v[1], x)))); };
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
   {
     //From SimpleJetCorrector
-    reco::FormulaEvaluator f("((x>=[6])*(([0]+([1]/((log10(x)^2)+[2])))+([3]*exp(-([4]*((log10(x)-[5])*(log10(x)-[5])))))))+((x<[6])*[7])");
-
-    std::vector<double> x ={1.};
-
-    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
-
-
-    std::vector<double> xValues = {.1, 1., 10., 100.};
-
-    auto func = [&v](double x) { return ((x>=v[6])*((v[0]+(v[1]/(( (std::log(x)/std::log(10))*(std::log(x)/std::log(10)) ) +v[2])))+(v[3]*std::exp(-1.*(v[4]*((std::log(x)/std::log(10.)-v[5])*(std::log(x)/std::log(10.)-v[5])))))))+((x<v[6])*v[7]); };
-
-
-    for(auto const xv: xValues) {
-      x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
-    }
-  }
-
-
-  {
-    reco::FormulaEvaluator f("(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+[7]*((-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208)");
+    reco::FormulaEvaluator f(
+        "((x>=[6])*(([0]+([1]/((log10(x)^2)+[2])))+([3]*exp(-([4]*((log10(x)-[5])*(log10(x)-[5])))))))+((x<[6])*[7])");
 
     std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> v = {1., 4., 2., 0.5, 2., 1., 1., -1.};
+
     std::vector<double> xValues = {.1, 1., 10., 100.};
 
+    auto func = [&v](double x) {
+      return ((x >= v[6]) * ((v[0] + (v[1] / (((std::log(x) / std::log(10)) * (std::log(x) / std::log(10))) + v[2]))) +
+                             (v[3] * std::exp(-1. * (v[4] * ((std::log(x) / std::log(10.) - v[5]) *
+                                                             (std::log(x) / std::log(10.) - v[5]))))))) +
+             ((x < v[6]) * v[7]);
+    };
 
-    auto func =[&v](double x) { return (std::max(0.,1.03091-0.051154*std::pow(x,-0.154227))-std::max(0.,1.03091-0.051154*std::pow(208.,-0.154227)))+v[7]*((-2.36997+0.413917*std::log(x))/x-(-2.36997+0.413917*std::log(208))/208); };
-
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
+    }
+  }
+
+  {
+    reco::FormulaEvaluator f(
+        "(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227))"
+        ")+[7]*((-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208)");
+
+    std::vector<double> x = {1.};
+
+    std::vector<double> v = {1., 4., 2., 0.5, 2., 1., 1., -1.};
+    std::vector<double> xValues = {.1, 1., 10., 100.};
+
+    auto func = [&v](double x) {
+      return (std::max(0., 1.03091 - 0.051154 * std::pow(x, -0.154227)) -
+              std::max(0., 1.03091 - 0.051154 * std::pow(208., -0.154227))) +
+             v[7] * ((-2.36997 + 0.413917 * std::log(x)) / x - (-2.36997 + 0.413917 * std::log(208)) / 208);
+    };
+
+    for (auto const xv : xValues) {
+      x[0] = xv;
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
@@ -816,35 +824,41 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> v = {1., 4., 2., 0.5, 2., 1., 1., -1.};
     std::vector<double> xValues = {.1, 1., 10., 100.};
 
+    auto func = [](double x) { return 100. / 3. * 0.154227 + 2.36997; };
 
-    auto func =[](double x) {return 100./3.*0.154227+2.36997;
-    };
-
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
   {
     //From SimpleJetCorrector
-    reco::FormulaEvaluator f("[2]*([3]+[4]*TMath::Log(max([0],min([1],x))))*1./([5]+[6]*100./3.*(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+[7]*((-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208))");
+    reco::FormulaEvaluator f(
+        "[2]*([3]+[4]*TMath::Log(max([0],min([1],x))))*1./([5]+[6]*100./"
+        "3.*(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0."
+        "154227)))+[7]*((-2.36997+0.413917*TMath::Log(x))/x-(-2.36997+0.413917*TMath::Log(208))/208))");
 
     std::vector<double> x = {1.};
 
-    std::vector<double> v = {1.,4.,2.,0.5,2.,1.,1., -1.};
+    std::vector<double> v = {1., 4., 2., 0.5, 2., 1., 1., -1.};
     std::vector<double> xValues = {.1, 1., 10., 100.};
 
-
-    auto func =[&v](double x) {return v[2]*(v[3]+v[4]*std::log(std::max(v[0],std::min(v[1],x))))*1./(v[5]+v[6]*100./3.*(std::max(0.,1.03091-0.051154*std::pow(x,-0.154227))-std::max(0.,1.03091-0.051154*std::pow(208.,-0.154227)))+v[7]*((-2.36997+0.413917*std::log(x))/x-(-2.36997+0.413917*std::log(208))/208));
+    auto func = [&v](double x) {
+      return v[2] * (v[3] + v[4] * std::log(std::max(v[0], std::min(v[1], x)))) * 1. /
+             (v[5] +
+              v[6] * 100. / 3. *
+                  (std::max(0., 1.03091 - 0.051154 * std::pow(x, -0.154227)) -
+                   std::max(0., 1.03091 - 0.051154 * std::pow(208., -0.154227))) +
+              v[7] * ((-2.36997 + 0.413917 * std::log(x)) / x - (-2.36997 + 0.413917 * std::log(208)) / 208));
     };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-      CPPUNIT_ASSERT(compare(f.evaluate(x, v),func(x[0])) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
@@ -856,26 +870,33 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     std::vector<double> v = {0.88524, 28.4947, 4.89135, -19.0245, 0.0227809, -6.97308};
     std::vector<double> xValues = {10.};
 
-    auto func =[&v](double x) {return std::exp(v[4]*(std::log(x)/std::log(10)-v[5])*(std::log(x)/std::log(10)-v[5])); }; 
+    auto func = [&v](double x) {
+      return std::exp(v[4] * (std::log(x) / std::log(10) - v[5]) * (std::log(x) / std::log(10) - v[5]));
+    };
 
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
       CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
   {
-    reco::FormulaEvaluator f("max(0.0001,[0]+[1]/(pow(log10(x),2)+[2])+[3]*exp(-1*([4]*((log10(x)-[5])*(log10(x)-[5])))))");
+    reco::FormulaEvaluator f(
+        "max(0.0001,[0]+[1]/(pow(log10(x),2)+[2])+[3]*exp(-1*([4]*((log10(x)-[5])*(log10(x)-[5])))))");
 
     std::vector<double> x = {10.};
 
     std::vector<double> v = {0.88524, 28.4947, 4.89135, -19.0245, 0.0227809, -6.97308};
     std::vector<double> xValues = {10.};
 
+    auto func = [&v](double x) {
+      return std::max(
+          0.0001,
+          v[0] + v[1] / (std::pow(std::log(x) / std::log(10), 2) + v[2]) +
+              v[3] * std::exp(-1 * v[4] * (std::log(x) / std::log(10) - v[5]) * (std::log(x) / std::log(10) - v[5])));
+    };
 
-    auto func =[&v](double x) {return std::max(0.0001,v[0]+v[1]/(std::pow(std::log(x)/std::log(10), 2)+v[2])+v[3]*std::exp(-1*v[4]*(std::log(x)/std::log(10)-v[5])*(std::log(x)/std::log(10)-v[5]))); };
-
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
       CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
@@ -883,18 +904,16 @@ testFormulaEvaluator::checkFormulaEvaluator() {
 
   {
     std::vector<double> x = {425.92155818};
-    std::vector<double> v = {0.945459,2.78658,1.65054,-48.1061,0.0287239,-10.8759};
+    std::vector<double> v = {0.945459, 2.78658, 1.65054, -48.1061, 0.0287239, -10.8759};
     std::vector<double> xValues = {425.92155818};
 
-    reco::FormulaEvaluator f("-[4]*(log10(x)-[5])*(log10(x)-[5])"); 
-    auto func =[&v](double x) {return -v[4]*(std::log10(x)-v[5])*(std::log10(x)-v[5]); };
+    reco::FormulaEvaluator f("-[4]*(log10(x)-[5])*(log10(x)-[5])");
+    auto func = [&v](double x) { return -v[4] * (std::log10(x) - v[5]) * (std::log10(x) - v[5]); };
 
-
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
-       CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
-
   }
 
   {
@@ -905,50 +924,78 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     std::vector<double> v = {0.88524, 28.4947, 4.89135, -19.0245, 0.0227809, -6.97308};
     std::vector<double> xValues = {10.};
 
+    auto func = [&v](double x) {
+      return std::max(
+          0.0001,
+          v[0] + v[1] / (std::pow(std::log(x) / std::log(10), 2) + v[2]) +
+              v[3] * std::exp(-v[4] * (std::log(x) / std::log(10) - v[5]) * (std::log(x) / std::log(10) - v[5])));
+    };
 
-    auto func =[&v](double x) {return std::max(0.0001,v[0]+v[1]/(std::pow(std::log(x)/std::log(10), 2)+v[2])+v[3]*std::exp(-v[4]*(std::log(x)/std::log(10)-v[5])*(std::log(x)/std::log(10)-v[5]))); };
-
-    for(auto const xv: xValues) {
+    for (auto const xv : xValues) {
       x[0] = xv;
       CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
   {
-    reco::FormulaEvaluator f("[2]*([3]*([4]+[5]*TMath::Log(max([0],min([1],x))))*1./([6]+[7]*100./3.*(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+[8]*((1+0.04432-1.304*pow(max(30.,min(6500.,x)),-0.4624)+(0+1.724*TMath::Log(max(30.,min(6500.,x))))/max(30.,min(6500.,x)))-(1+0.04432-1.304*pow(208.,-0.4624)+(0+1.724*TMath::Log(208.))/208.))))");
+    reco::FormulaEvaluator f(
+        "[2]*([3]*([4]+[5]*TMath::Log(max([0],min([1],x))))*1./([6]+[7]*100./"
+        "3.*(TMath::Max(0.,1.03091-0.051154*pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0."
+        "154227)))+[8]*((1+0.04432-1.304*pow(max(30.,min(6500.,x)),-0.4624)+(0+1.724*TMath::Log(max(30.,min(6500.,x))))"
+        "/max(30.,min(6500.,x)))-(1+0.04432-1.304*pow(208.,-0.4624)+(0+1.724*TMath::Log(208.))/208.))))");
 
-    std::vector<double> v = {
-      55, 2510, 0.997756, 1.000155, 0.979016, 0.001834, 0.982, -0.048, 1.250
-    };
+    std::vector<double> v = {55, 2510, 0.997756, 1.000155, 0.979016, 0.001834, 0.982, -0.048, 1.250};
 
     std::vector<double> x = {100};
 
-    auto func = [&v](double x) { return v[2]*(v[3]*(v[4]+v[5]*TMath::Log(std::max(v[0],std::min(v[1],x))))*1./(v[6]+v[7]*100./3.*(TMath::Max(0.,1.03091-0.051154*std::pow(x,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+v[8]*((1+0.04432-1.304*std::pow(std::max(30.,std::min(6500.,x)),-0.4624)+(0+1.724*TMath::Log(std::max(30.,std::min(6500.,x))))/std::max(30.,std::min(6500.,x)))-(1+0.04432-1.304*std::pow(208.,-0.4624)+(0+1.724*TMath::Log(208.))/208.)))); };
+    auto func = [&v](double x) {
+      return v[2] *
+             (v[3] * (v[4] + v[5] * TMath::Log(std::max(v[0], std::min(v[1], x)))) * 1. /
+              (v[6] +
+               v[7] * 100. / 3. *
+                   (TMath::Max(0., 1.03091 - 0.051154 * std::pow(x, -0.154227)) -
+                    TMath::Max(0., 1.03091 - 0.051154 * TMath::Power(208., -0.154227))) +
+               v[8] *
+                   ((1 + 0.04432 - 1.304 * std::pow(std::max(30., std::min(6500., x)), -0.4624) +
+                     (0 + 1.724 * TMath::Log(std::max(30., std::min(6500., x)))) / std::max(30., std::min(6500., x))) -
+                    (1 + 0.04432 - 1.304 * std::pow(208., -0.4624) + (0 + 1.724 * TMath::Log(208.)) / 208.))));
+    };
 
-    CPPUNIT_ASSERT(compare(f.evaluate(x,v), func(x[0])) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
   }
 
   {
-    std::vector<std::pair<std::string,double> > formulas = { 
-      {"(1+0.04432+(1.724+100.))-1", 101.76832},
-      {"(1+(1.724+100.)+0.04432)-1", 101.76832},
-      {"((1.724+100.)+1+0.04432)-1", 101.76832},
-      {"(1+0.04432+1.724/100.)-1", .06156},
-      {"(1+1.724/100.+0.04432)-1", .06156},
-      {"(1.724/100.+1+0.04432)-1", .06156},
-      {"(1+0.04432+(1.724/100.))-1", (1+0.04432+(1.724/100.))-1 },
-      {"(1+(1.724/100.)+0.04432)-1", (1+0.04432+(1.724/100.))-1 },
-      {"((1.724/100.)+1+0.04432)-1", (1+0.04432+(1.724/100.))-1 },
-      {"0.997756*(1.000155*(0.979016+0.001834*TMath::Log(max(55.,min(2510.,100.))))*1./(0.982+-0.048*100./3.*(TMath::Max(0.,1.03091-0.051154*pow(100.,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+1.250*((1+0.04432-1.304*pow(max(30.,min(6500.,100.)),-0.4624)+(0+1.724*TMath::Log(max(30.,min(6500.,100.))))/max(30.,min(6500.,100.)))-(1+0.04432-1.304*pow(208.,-0.4624)+(0+1.724*TMath::Log(208.))/208.))))", 
-       0.997756*(1.000155*(0.979016+0.001834*TMath::Log(std::max(55.,std::min(2510.,100.))))*1./(0.982+-0.048*100./3.*(TMath::Max(0.,1.03091-0.051154*std::pow(100.,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0.154227)))+1.250*((1+0.04432-1.304*std::pow(std::max(30.,std::min(6500.,100.)),-0.4624)+(0+1.724*TMath::Log(std::max(30.,std::min(6500.,100.))))/std::max(30.,std::min(6500.,100.)))-(1+0.04432-1.304*std::pow(208.,-0.4624)+(0+1.724*TMath::Log(208.))/208.)))) }
-    };
+    std::vector<std::pair<std::string, double>> formulas = {
+        {"(1+0.04432+(1.724+100.))-1", 101.76832},
+        {"(1+(1.724+100.)+0.04432)-1", 101.76832},
+        {"((1.724+100.)+1+0.04432)-1", 101.76832},
+        {"(1+0.04432+1.724/100.)-1", .06156},
+        {"(1+1.724/100.+0.04432)-1", .06156},
+        {"(1.724/100.+1+0.04432)-1", .06156},
+        {"(1+0.04432+(1.724/100.))-1", (1 + 0.04432 + (1.724 / 100.)) - 1},
+        {"(1+(1.724/100.)+0.04432)-1", (1 + 0.04432 + (1.724 / 100.)) - 1},
+        {"((1.724/100.)+1+0.04432)-1", (1 + 0.04432 + (1.724 / 100.)) - 1},
+        {"0.997756*(1.000155*(0.979016+0.001834*TMath::Log(max(55.,min(2510.,100.))))*1./(0.982+-0.048*100./"
+         "3.*(TMath::Max(0.,1.03091-0.051154*pow(100.,-0.154227))-TMath::Max(0.,1.03091-0.051154*TMath::Power(208.,-0."
+         "154227)))+1.250*((1+0.04432-1.304*pow(max(30.,min(6500.,100.)),-0.4624)+(0+1.724*TMath::Log(max(30.,min(6500."
+         ",100.))))/max(30.,min(6500.,100.)))-(1+0.04432-1.304*pow(208.,-0.4624)+(0+1.724*TMath::Log(208.))/208.))))",
+         0.997756 *
+             (1.000155 * (0.979016 + 0.001834 * TMath::Log(std::max(55., std::min(2510., 100.)))) * 1. /
+              (0.982 +
+               -0.048 * 100. / 3. *
+                   (TMath::Max(0., 1.03091 - 0.051154 * std::pow(100., -0.154227)) -
+                    TMath::Max(0., 1.03091 - 0.051154 * TMath::Power(208., -0.154227))) +
+               1.250 * ((1 + 0.04432 - 1.304 * std::pow(std::max(30., std::min(6500., 100.)), -0.4624) +
+                         (0 + 1.724 * TMath::Log(std::max(30., std::min(6500., 100.)))) /
+                             std::max(30., std::min(6500., 100.))) -
+                        (1 + 0.04432 - 1.304 * std::pow(208., -0.4624) + (0 + 1.724 * TMath::Log(208.)) / 208.))))}};
 
     std::vector<double> x = {};
     std::vector<double> v = {};
-    for(auto const& form_val : formulas) {
+    for (auto const& form_val : formulas) {
       reco::FormulaEvaluator f(form_val.first);
 
-      CPPUNIT_ASSERT(compare( f.evaluate(x,v),form_val.second));
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), form_val.second));
     }
   }
 
@@ -956,150 +1003,149 @@ testFormulaEvaluator::checkFormulaEvaluator() {
   {
     reco::FormulaEvaluator f("[0]+[1]*exp(-x/[2])");
 
-    std::vector<double> v = {0.006467,0.02519,77.08};
+    std::vector<double> v = {0.006467, 0.02519, 77.08};
     std::vector<double> x = {100.};
 
-    auto func = [&v](double x) { return v[0]+v[1]*std::exp(-x/v[2]); };
+    auto func = [&v](double x) { return v[0] + v[1] * std::exp(-x / v[2]); };
 
-    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
   }
 
   {
     reco::FormulaEvaluator f("max(0.0001,1-y/x*([1]*(z-[0])*(1+[2]*log(x/30.))))");
 
-    std::vector<double> v = { 1.4, 0.453645, -0.015665 };
-    std::vector<double> x = { 157.2, 0.5, 23.2 };
+    std::vector<double> v = {1.4, 0.453645, -0.015665};
+    std::vector<double> x = {157.2, 0.5, 23.2};
 
-    auto func = [&v](double x, double y, double z ) { return std::max(0.0001,1-y/x*(v[1]*(z-v[0])*(1+v[2]*std::log(x/30.)))); };
+    auto func = [&v](double x, double y, double z) {
+      return std::max(0.0001, 1 - y / x * (v[1] * (z - v[0]) * (1 + v[2] * std::log(x / 30.))));
+    };
 
-    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0],x[1],x[2]) ) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0], x[1], x[2])));
   }
   {
     reco::FormulaEvaluator f("max(0.0001,1-y*[1]*(z-[0])*(1+[2]*log(x/30.))/x)");
 
-    std::vector<double> v = { 1.4, 0.453645, -0.015665 };
-    std::vector<double> x = { 157.2, 0.5, 23.2 };
+    std::vector<double> v = {1.4, 0.453645, -0.015665};
+    std::vector<double> x = {157.2, 0.5, 23.2};
 
-    auto func = [&v](double x, double y, double z ) { return std::max(0.0001,1-y/x*(v[1]*(z-v[0])*(1+v[2]*std::log(x/30.)))); };
+    auto func = [&v](double x, double y, double z) {
+      return std::max(0.0001, 1 - y / x * (v[1] * (z - v[0]) * (1 + v[2] * std::log(x / 30.))));
+    };
 
-    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0],x[1],x[2]) ) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0], x[1], x[2])));
   }
   {
     reco::FormulaEvaluator f("max(0.0001,1-y*([1]*(z-[0])*(1+[2]*log(x/30.)))/x)");
 
-    std::vector<double> v = { 1.4, 0.453645, -0.015665 };
-    std::vector<double> x = { 157.2, 0.5, 23.2 };
+    std::vector<double> v = {1.4, 0.453645, -0.015665};
+    std::vector<double> x = {157.2, 0.5, 23.2};
 
-    auto func = [&v](double x, double y, double z ) { return std::max(0.0001,1-y*(v[1]*(z-v[0])*(1+v[2]*std::log(x/30.)))/x); };
+    auto func = [&v](double x, double y, double z) {
+      return std::max(0.0001, 1 - y * (v[1] * (z - v[0]) * (1 + v[2] * std::log(x / 30.))) / x);
+    };
 
-    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0],x[1],x[2]) ) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0], x[1], x[2])));
   }
 
   {
     reco::FormulaEvaluator f("sqrt([0]*abs([0])/(x*x)+[1]*[1]*pow(x,[3])+[2]*[2])");
 
-    std::vector<double> v = {1.326,0.4209,0.02223,-0.6704};
+    std::vector<double> v = {1.326, 0.4209, 0.02223, -0.6704};
     std::vector<double> x = {100.};
 
-    auto func = [&v](double x) { return std::sqrt(v[0]*std::abs(v[0])/(x*x)+v[1]*v[1]*std::pow(x,v[3])+v[2]*v[2]); };
+    auto func = [&v](double x) {
+      return std::sqrt(v[0] * std::abs(v[0]) / (x * x) + v[1] * v[1] * std::pow(x, v[3]) + v[2] * v[2]);
+    };
 
-    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
   }
 
   {
     reco::FormulaEvaluator f("sqrt([0]*[0]/(x*x)+[1]*[1]/x+[2]*[2])");
 
-    std::vector<double> v = {2.3,0.20,0.009};
+    std::vector<double> v = {2.3, 0.20, 0.009};
     std::vector<double> x = {100.};
 
-    auto func = [&v](double x) { return std::sqrt(v[0]*v[0]/(x*x)+v[1]*v[1]/x+v[2]*v[2]); };
+    auto func = [&v](double x) { return std::sqrt(v[0] * v[0] / (x * x) + v[1] * v[1] / x + v[2] * v[2]); };
 
-    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+    CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
   }
 
   {
     //This was previously evaluated wrong
-    std::array<double,3> xs = {{224., 225., 226.}};
+    std::array<double, 3> xs = {{224., 225., 226.}};
     std::vector<double> x = {0.};
     std::vector<double> v = {-3., -3., -3., -3., -3., -3.};
 
-    reco::FormulaEvaluator f("([0]+[1]*x+[2]*x^2)*(x<225)+([0]+[1]*225+[2]*225^2+[3]*(x-225)+[4]*(x-225)^2+[5]*(x-225)^3)*(x>225)");
+    reco::FormulaEvaluator f(
+        "([0]+[1]*x+[2]*x^2)*(x<225)+([0]+[1]*225+[2]*225^2+[3]*(x-225)+[4]*(x-225)^2+[5]*(x-225)^3)*(x>225)");
 
-    auto func = [&v](double x) { 
-      return (v[0]+v[1]*x+v[2]*(x*x))*(x<225)+(v[0]+v[1]*225+v[2]*(225*225)+v[3]*(x-225)+v[4]*((x-225)*(x-225))+v[5]*((x-225)*(x-225)*(x-225)))*(x>225);
+    auto func = [&v](double x) {
+      return (v[0] + v[1] * x + v[2] * (x * x)) * (x < 225) +
+             (v[0] + v[1] * 225 + v[2] * (225 * 225) + v[3] * (x - 225) + v[4] * ((x - 225) * (x - 225)) +
+              v[5] * ((x - 225) * (x - 225) * (x - 225))) *
+                 (x > 225);
     };
 
-    for(auto x_i : xs) {
+    for (auto x_i : xs) {
       x[0] = x_i;
-      CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+      CPPUNIT_ASSERT(compare(f.evaluate(x, v), func(x[0])));
     }
   }
 
   {
-    auto t = [] () {
-      reco::FormulaEvaluator f("doesNotExist(2)");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("doesNotExist(2)"); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
-    auto t = [] () {
-      reco::FormulaEvaluator f("doesNotExist(2) + abs(-1)");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("doesNotExist(2) + abs(-1)"); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
-    auto t = [] () {
-      reco::FormulaEvaluator f("abs(-1) + doesNotExist(2)");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("abs(-1) + doesNotExist(2)"); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
-    auto t = [] () {
-      reco::FormulaEvaluator f("abs(-1) + ( 5 * doesNotExist(2))");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("abs(-1) + ( 5 * doesNotExist(2))"); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
-    auto t = [] () {
-      reco::FormulaEvaluator f("( 5 * doesNotExist(2)) + abs(-1)");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("( 5 * doesNotExist(2)) + abs(-1)"); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
-    auto t = [] () {
-      reco::FormulaEvaluator f("TMath::Exp(2)");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("TMath::Exp(2)"); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
     //this was previously causing a seg fault
-    auto t = [] () {
-      reco::FormulaEvaluator f("1 + 2 * 3 + 5 * doesNotExist(2) ");
-    };
-    
-    CPPUNIT_ASSERT_THROW( t(), cms::Exception );
+    auto t = []() { reco::FormulaEvaluator f("1 + 2 * 3 + 5 * doesNotExist(2) "); };
+
+    CPPUNIT_ASSERT_THROW(t(), cms::Exception);
   }
 
   {
     //Make sure spaces are shown in exception message
     try {
       reco::FormulaEvaluator f("1 + 2#");
-    } catch(cms::Exception const& e) {
-      auto r = "An exception of category 'FormulaEvaluatorParseError' occurred.\n"
-        "Exception Message:\n"
-        "While parsing '1 + 2#' could not parse beyond '1 + 2'\n";
+    } catch (cms::Exception const& e) {
+      auto r =
+          "An exception of category 'FormulaEvaluatorParseError' occurred.\n"
+          "Exception Message:\n"
+          "While parsing '1 + 2#' could not parse beyond '1 + 2'\n";
       CPPUNIT_ASSERT(std::string(r) == e.what());
     }
   }

--- a/CommonTools/Utils/test/testSelectIterator.cc
+++ b/CommonTools/Utils/test/testSelectIterator.cc
@@ -14,42 +14,41 @@ class testSelectIterator : public CppUnit::TestFixture {
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( testSelectIterator );
+CPPUNIT_TEST_SUITE_REGISTRATION(testSelectIterator);
 
 namespace test {
   struct A {
-    explicit A( double x ) : x_( x ) { }
+    explicit A(double x) : x_(x) {}
     double pt() const { return x_; }
+
   private:
     double x_;
   };
-}
+}  // namespace test
 
 void testSelectIterator::checkAll() {
   using namespace test;
   using namespace std;
   vector<A> v;
-  for( double x = 0; x < 10.1; ++ x )
+  for (double x = 0; x < 10.1; ++x)
     v.push_back(A(x));
-  CPPUNIT_ASSERT( v.size() == 11 );
-  PtMinSelector select( 3.5 );
-  Selection<vector<A>, PtMinSelector> sel( v, select );
-  CPPUNIT_ASSERT( sel.size() == 7 );
-  for( size_t i = 0; i < sel.size(); ++ i ) {
-    CPPUNIT_ASSERT( select( sel[i]) );
+  CPPUNIT_ASSERT(v.size() == 11);
+  PtMinSelector select(3.5);
+  Selection<vector<A>, PtMinSelector> sel(v, select);
+  CPPUNIT_ASSERT(sel.size() == 7);
+  for (size_t i = 0; i < sel.size(); ++i) {
+    CPPUNIT_ASSERT(select(sel[i]));
   }
-  for( Selection<vector<A>, PtMinSelector>::const_iterator i = sel.begin(); 
-       i != sel.end(); ++ i ) {
-    CPPUNIT_ASSERT( select( * i ) );
+  for (Selection<vector<A>, PtMinSelector>::const_iterator i = sel.begin(); i != sel.end(); ++i) {
+    CPPUNIT_ASSERT(select(*i));
   }
   vector<A> selected;
-  copy( sel.begin(), sel.end(), back_inserter( selected ) );
-  CPPUNIT_ASSERT( sel.size() == selected.size() );
-  for( size_t i = 0; i < selected.size(); ++ i ) {
-    CPPUNIT_ASSERT( select( selected[i]) );
+  copy(sel.begin(), sel.end(), back_inserter(selected));
+  CPPUNIT_ASSERT(sel.size() == selected.size());
+  for (size_t i = 0; i < selected.size(); ++i) {
+    CPPUNIT_ASSERT(select(selected[i]));
   }
-}  
-
+}

--- a/CommonTools/Utils/test/testSelectors.cc
+++ b/CommonTools/Utils/test/testSelectors.cc
@@ -17,51 +17,50 @@ class testSelectors : public CppUnit::TestFixture {
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( testSelectors );
+CPPUNIT_TEST_SUITE_REGISTRATION(testSelectors);
 
 namespace test {
   struct A {
-    explicit A( double x ) : x_( x ) { }
-    double x() const { return x_; } 
+    explicit A(double x) : x_(x) {}
+    double x() const { return x_; }
     double pt() const { return x_; }
     double et() const { return x_; }
+
   private:
     double x_;
   };
 
   struct Add {
-    double operator()( const A & a1, const A& a2 ) const {
-      return a1.x() + a2.x();
-    }
+    double operator()(const A& a1, const A& a2) const { return a1.x() + a2.x(); }
   };
-}
+}  // namespace test
 
 void testSelectors::checkAll() {
   using namespace test;
   {
-    A a( 1.0 );
-    MinFunctionSelector<A, & A::x> minSel( 0.9 );
-    MaxFunctionSelector<A, & A::x> maxSel( 1.1 );
-    RangeSelector<A, & A::x> rangeSel( 0.9, 1.1 );
-    PtMinSelector ptMinSel( 0.9 );
-    EtMinSelector etMinSel( 0.9 );
-    
-    CPPUNIT_ASSERT( minSel( a ) );
-    CPPUNIT_ASSERT( maxSel( a ) );
-    CPPUNIT_ASSERT( rangeSel( a ) );
-    CPPUNIT_ASSERT( ptMinSel( a ) );
-    CPPUNIT_ASSERT( etMinSel( a ) );
+    A a(1.0);
+    MinFunctionSelector<A, &A::x> minSel(0.9);
+    MaxFunctionSelector<A, &A::x> maxSel(1.1);
+    RangeSelector<A, &A::x> rangeSel(0.9, 1.1);
+    PtMinSelector ptMinSel(0.9);
+    EtMinSelector etMinSel(0.9);
+
+    CPPUNIT_ASSERT(minSel(a));
+    CPPUNIT_ASSERT(maxSel(a));
+    CPPUNIT_ASSERT(rangeSel(a));
+    CPPUNIT_ASSERT(ptMinSel(a));
+    CPPUNIT_ASSERT(etMinSel(a));
   }
   {
-    A a1( 3.0 ), a2( 5.0 );
-    MinObjectPairSelector<Add> minSel( 7.9 );
-    MaxObjectPairSelector<Add> maxSel( 8.1 );
-    RangeObjectPairSelector<Add> rangeSel( 7.9, 8.1 );
-    CPPUNIT_ASSERT( minSel( a1, a2 ) );
-    CPPUNIT_ASSERT( maxSel( a1, a2 ) );
-    CPPUNIT_ASSERT( rangeSel( a1, a2 ) );
+    A a1(3.0), a2(5.0);
+    MinObjectPairSelector<Add> minSel(7.9);
+    MaxObjectPairSelector<Add> maxSel(8.1);
+    RangeObjectPairSelector<Add> rangeSel(7.9, 8.1);
+    CPPUNIT_ASSERT(minSel(a1, a2));
+    CPPUNIT_ASSERT(maxSel(a1, a2));
+    CPPUNIT_ASSERT(rangeSel(a1, a2));
   }
 }


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/366//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


