### PR TITLE
Running code-format for alca-reconstruction

### DIFF
--- a/RecoVertex/BeamSpotProducer/interface/BSFitter.h
+++ b/RecoVertex/BeamSpotProducer/interface/BSFitter.h
@@ -12,7 +12,6 @@
 
 ________________________________________________________________**/
 
-
 // CMS
 #include "RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h"
 #include "RecoVertex/BeamSpotProducer/interface/BSTrkParameters.h"
@@ -29,122 +28,103 @@ ________________________________________________________________**/
 #include <string>
 
 class BSFitter {
-  public:
+public:
+  //typedef std::vector <BSTrkParameters> BSTrkCollection;
 
-	//typedef std::vector <BSTrkParameters> BSTrkCollection;
-	
-	BSFitter();
-	BSFitter( const std::vector< BSTrkParameters > &BSvector);
-	
-	virtual ~BSFitter();
+  BSFitter();
+  BSFitter(const std::vector<BSTrkParameters> &BSvector);
 
-	void SetFitType(std::string type) {
-		ffit_type = type;
-	}
+  virtual ~BSFitter();
 
-	void SetFitVariable(std::string name) {
-		ffit_variable = name;
-	}
+  void SetFitType(std::string type) { ffit_type = type; }
 
-	reco::BeamSpot Fit();
-	
-	reco::BeamSpot Fit(double *inipar);
-		
-	// Fit Z distribution with a gaussian
-	reco::BeamSpot Fit_z(std::string type, double *inipar);
+  void SetFitVariable(std::string name) { ffit_variable = name; }
 
-	reco::BeamSpot Fit_z_chi2(double *inipar);
-	reco::BeamSpot Fit_z_likelihood(double *inipar);
-	
-	// Fit only d0-phi distribution with a chi2
-	reco::BeamSpot Fit_d0phi();
-	void SetMaximumZ(double z) { fMaxZ = z; }
-	void SetConvergence(double val) { fconvergence = val; }
-	void SetMinimumNTrks(int n) { fminNtrks = n; }
-	void Setd0Cut_d0phi(double d0cut);
-	void SetChi2Cut_d0phi(double chi2cut);
-	void SetInputBeamWidth(double val) { finputBeamWidth = val; }
-	int GetAcceptedTrks() { return ftmprow; }
-	void d0phi_Init() {
-		ftmprow = 0;
-		ftmp.ResizeTo(4,1);
-		ftmp.Zero();
-		fnthite=0;
-		goodfit=true;
-	}
-	std::vector < BSTrkParameters > GetData() { return fBSvector; }
-	
-	reco::BeamSpot Fit_ited0phi();
-		
-	reco::BeamSpot Fit_d_likelihood(double *inipar);
-	reco::BeamSpot Fit_d_z_likelihood(double *inipar, double *error_par);
-	reco::BeamSpot Fit_dres_z_likelihood(double *inipar);
+  reco::BeamSpot Fit();
 
-    double scanPDF(double *init_pars,int & tracksFailed,int option);
-    
-	double GetMinimum() {
-		return ff_minimum;
-	}
-	double GetResPar0() {
-		return fresolution_c0;
-	}
-	double GetResPar1() {
-		return fresolution_c1;
-	}
-	double GetResPar0Err() {
-		return fres_c0_err;
-	}
-	double GetResPar1Err() {
-		return fres_c1_err;
-	}
+  reco::BeamSpot Fit(double *inipar);
 
-	reco::BeamSpot::ResCovMatrix GetResMatrix() {
-		return fres_matrix;
-	}
+  // Fit Z distribution with a gaussian
+  reco::BeamSpot Fit_z(std::string type, double *inipar);
 
-	TH1F * GetVzHisto() { return h1z; }
-	
-  private:
+  reco::BeamSpot Fit_z_chi2(double *inipar);
+  reco::BeamSpot Fit_z_likelihood(double *inipar);
 
-	ROOT::Minuit2::ModularFunctionMinimizer* theFitter;
-	//BSzFcn* theGausszFcn;
-	BSpdfsFcn* thePDF;
-	
-	reco::BeamSpot::BeamType fbeamtype;
-	std::string ffit_type;
-	std::string ffit_variable;
+  // Fit only d0-phi distribution with a chi2
+  reco::BeamSpot Fit_d0phi();
+  void SetMaximumZ(double z) { fMaxZ = z; }
+  void SetConvergence(double val) { fconvergence = val; }
+  void SetMinimumNTrks(int n) { fminNtrks = n; }
+  void Setd0Cut_d0phi(double d0cut);
+  void SetChi2Cut_d0phi(double chi2cut);
+  void SetInputBeamWidth(double val) { finputBeamWidth = val; }
+  int GetAcceptedTrks() { return ftmprow; }
+  void d0phi_Init() {
+    ftmprow = 0;
+    ftmp.ResizeTo(4, 1);
+    ftmp.Zero();
+    fnthite = 0;
+    goodfit = true;
+  }
+  std::vector<BSTrkParameters> GetData() { return fBSvector; }
 
-	double ff_minimum;
-	
-	static const int fdim         = 7;
-	
-	std::string fpar_name[fdim];
+  reco::BeamSpot Fit_ited0phi();
 
-	Double_t fsqrt2pi;
-		
-	std::vector < BSTrkParameters > fBSvector;
-    std::vector < BSTrkParameters > fBSvectorBW;
-    
-	double fresolution_c0;
-	double fresolution_c1;
-	double fres_c0_err;
-	double fres_c1_err;
-	reco::BeamSpot::ResCovMatrix fres_matrix;
-	//reco::BeamSpot fBSforCuts;
-	TMatrixD ftmp;
-	bool fapplyd0cut;
-	bool fapplychi2cut;
-	double fd0cut;
-	double fchi2cut;
-	int ftmprow;
-	int fnthite;
-	bool goodfit;
-	double fMaxZ;
-	double fconvergence;
-	int fminNtrks;
-	double finputBeamWidth;
-	TH1F *h1z;
+  reco::BeamSpot Fit_d_likelihood(double *inipar);
+  reco::BeamSpot Fit_d_z_likelihood(double *inipar, double *error_par);
+  reco::BeamSpot Fit_dres_z_likelihood(double *inipar);
+
+  double scanPDF(double *init_pars, int &tracksFailed, int option);
+
+  double GetMinimum() { return ff_minimum; }
+  double GetResPar0() { return fresolution_c0; }
+  double GetResPar1() { return fresolution_c1; }
+  double GetResPar0Err() { return fres_c0_err; }
+  double GetResPar1Err() { return fres_c1_err; }
+
+  reco::BeamSpot::ResCovMatrix GetResMatrix() { return fres_matrix; }
+
+  TH1F *GetVzHisto() { return h1z; }
+
+private:
+  ROOT::Minuit2::ModularFunctionMinimizer *theFitter;
+  //BSzFcn* theGausszFcn;
+  BSpdfsFcn *thePDF;
+
+  reco::BeamSpot::BeamType fbeamtype;
+  std::string ffit_type;
+  std::string ffit_variable;
+
+  double ff_minimum;
+
+  static const int fdim = 7;
+
+  std::string fpar_name[fdim];
+
+  Double_t fsqrt2pi;
+
+  std::vector<BSTrkParameters> fBSvector;
+  std::vector<BSTrkParameters> fBSvectorBW;
+
+  double fresolution_c0;
+  double fresolution_c1;
+  double fres_c0_err;
+  double fres_c1_err;
+  reco::BeamSpot::ResCovMatrix fres_matrix;
+  //reco::BeamSpot fBSforCuts;
+  TMatrixD ftmp;
+  bool fapplyd0cut;
+  bool fapplychi2cut;
+  double fd0cut;
+  double fchi2cut;
+  int ftmprow;
+  int fnthite;
+  bool goodfit;
+  double fMaxZ;
+  double fconvergence;
+  int fminNtrks;
+  double finputBeamWidth;
+  TH1F *h1z;
 };
 
 #endif
-

--- a/RecoVertex/BeamSpotProducer/interface/BSTrkParameters.h
+++ b/RecoVertex/BeamSpotProducer/interface/BSTrkParameters.h
@@ -12,67 +12,68 @@
 
 ________________________________________________________________**/
 
-
 class BSTrkParameters {
+public:
+  // constructor
+  BSTrkParameters() {}
+  // constructor from values
+  //BSTrkParameters( double z0, double sigz0,
+  //				 double d0, double sigd0,
+  //				 double phi0, double pt) {
+  //	fz0 = z0;
+  //	fsigz0 = sigz0;
+  //	fd0 = d0;
+  //	fsigd0 = sigd0;
+  //	fphi0 = phi0;
+  //	fpt = pt;
+  //
+  //};
 
-  public:
+  BSTrkParameters(double z0,
+                  double sigz0,
+                  double d0,
+                  double sigd0,
+                  double phi0,
+                  double pt,
+                  double d0phi_d0 = 0.,
+                  double d0phi_chi2 = 0.) {
+    fz0 = z0;
+    fsigz0 = sigz0;
+    fd0 = d0;
+    fsigd0 = sigd0;
+    fphi0 = phi0;
+    fpt = pt;
+    fd0phi_d0 = d0phi_d0;
+    fd0phi_chi2 = d0phi_chi2;
+    fvx = 0.;
+    fvy = 0.;
+  };
 
-	// constructor
-	BSTrkParameters() {}
-	// constructor from values
-	//BSTrkParameters( double z0, double sigz0,
-	//				 double d0, double sigd0,
-	//				 double phi0, double pt) {
-	//	fz0 = z0;
-	//	fsigz0 = sigz0;
-	//	fd0 = d0;
-	//	fsigd0 = sigd0;
-	//	fphi0 = phi0;
-	//	fpt = pt;
-	//	
-	//};
-	
-	BSTrkParameters( double z0, double sigz0,
-					 double d0, double sigd0,
-					 double phi0, double pt,
-					 double d0phi_d0=0.,double d0phi_chi2=0.) {
-		fz0 = z0;
-		fsigz0 = sigz0;
-		fd0 = d0;
-		fsigd0 = sigd0;
-		fphi0 = phi0;
-		fpt = pt;
-		fd0phi_d0   = d0phi_d0;
-		fd0phi_chi2 = d0phi_chi2;
-		fvx = 0.;
-		fvy = 0.;
-	};
+  //
+  double z0() const { return fz0; }
+  double sigz0() const { return fsigz0; }
+  double d0() const { return fd0; }
+  double sigd0() const { return fsigd0; }
+  double phi0() const { return fphi0; }
+  double pt() const { return fpt; }
+  double d0phi_chi2() const { return fd0phi_chi2; }
+  double d0phi_d0() const { return fd0phi_d0; }
+  double vx() const { return fvx; }
+  double vy() const { return fvy; }
+  void setVx(double vx) { fvx = vx; }
+  void setVy(double vy) { fvy = vy; }
 
-    //
-	double z0() const { return fz0; }
-	double sigz0() const { return fsigz0; }
-	double d0() const { return fd0; }
-	double sigd0() const { return fsigd0; }
-	double phi0() const { return fphi0; }
-	double pt() const { return fpt; }
-	double d0phi_chi2() const { return fd0phi_chi2; }
-	double d0phi_d0() const { return fd0phi_d0; }
-	double vx() const { return fvx; }
-	double vy() const { return fvy; }
-	void setVx( double vx ) { fvx = vx; }
-	void setVy( double vy ) { fvy = vy; }
-	
-  private:
-	double fz0;
-	double fsigz0;
-	double fd0;
-	double fsigd0;
-	double fphi0;
-	double fpt;
-	double fd0phi_chi2;
-	double fd0phi_d0;
-	double fvx;
-	double fvy;
+private:
+  double fz0;
+  double fsigz0;
+  double fd0;
+  double fsigd0;
+  double fphi0;
+  double fpt;
+  double fd0phi_chi2;
+  double fd0phi_d0;
+  double fvx;
+  double fvy;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
+++ b/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
@@ -20,54 +20,43 @@ ________________________________________________________________**/
 #include <string>
 
 class BSpdfsFcn : public ROOT::Minuit2::FCNBase {
-	
-  public:
-	// cache the current data
-	void SetData(const std::vector < BSTrkParameters > &a_BSvector){
-		
-		fBSvector = a_BSvector;
-		
-	};
-	// define pdfs to use
-	void SetPDFs(std::string usepdfs) {
-		fusepdfs = usepdfs;
-	}
+public:
+  // cache the current data
+  void SetData(const std::vector<BSTrkParameters>& a_BSvector) { fBSvector = a_BSvector; };
+  // define pdfs to use
+  void SetPDFs(std::string usepdfs) { fusepdfs = usepdfs; }
 
-	double operator() (const std::vector<double>&) const override;
-	double Up() const override {return 1.;}
-	
-  private:
+  double operator()(const std::vector<double>&) const override;
+  double Up() const override { return 1.; }
 
-	double PDFGauss_d(double z, double d, double sigmad,
-					  double phi, const std::vector<double>& parms) const;
-	double PDFGauss_d_resolution(double z, double d,
-								 double phi, double pt, const std::vector<double>& parms) const;
+private:
+  double PDFGauss_d(double z, double d, double sigmad, double phi, const std::vector<double>& parms) const;
+  double PDFGauss_d_resolution(double z, double d, double phi, double pt, const std::vector<double>& parms) const;
 
-	double PDFGauss_z(double z, double sigmaz, const std::vector<double>& parms) const;
+  double PDFGauss_z(double z, double sigmaz, const std::vector<double>& parms) const;
 
-	std::string fusepdfs;
-	std::vector < BSTrkParameters > fBSvector;
+  std::string fusepdfs;
+  std::vector<BSTrkParameters> fBSvector;
 
-	static const int fPar_X0      = 0;  // 
-	static const int fPar_Y0      = 1;  //
-	static const int fPar_Z0      = 2;  // position of luminosity peak in z
-	static const int fPar_SigmaZ  = 3;  // sigma in z of the beam
-	static const int fPar_dxdz    = 4;  // 
-	static const int fPar_dydz    = 5;  //
-	static const int fPar_SigmaBeam = 6;  // 
-	static const int fPar_c0      = 7;  //
-	static const int fPar_c1      = 8;  //
-	
-	//static const int fPar_Z0      = 0;  // index of position of luminosity peak in z
-	//static const int fPar_SigmaZ  = 1;  // index of sigma in z of the beam
-	//static const int fPar_X0      = 2;  // 
-	//static const int fPar_Y0      = 3;  //
-	//static const int fPar_dxdz    = 4;  // 
-	//static const int fPar_dydz    = 5;  //
-	//static const int fPar_SigmaBeam = 6;  // 
-	//static const int fPar_c0      = 7;  //
-	//static const int fPar_c1      = 8;  //
-	
+  static const int fPar_X0 = 0;         //
+  static const int fPar_Y0 = 1;         //
+  static const int fPar_Z0 = 2;         // position of luminosity peak in z
+  static const int fPar_SigmaZ = 3;     // sigma in z of the beam
+  static const int fPar_dxdz = 4;       //
+  static const int fPar_dydz = 5;       //
+  static const int fPar_SigmaBeam = 6;  //
+  static const int fPar_c0 = 7;         //
+  static const int fPar_c1 = 8;         //
+
+  //static const int fPar_Z0      = 0;  // index of position of luminosity peak in z
+  //static const int fPar_SigmaZ  = 1;  // index of sigma in z of the beam
+  //static const int fPar_X0      = 2;  //
+  //static const int fPar_Y0      = 3;  //
+  //static const int fPar_dxdz    = 4;  //
+  //static const int fPar_dydz    = 5;  //
+  //static const int fPar_SigmaBeam = 6;  //
+  //static const int fPar_c0      = 7;  //
+  //static const int fPar_c1      = 8;  //
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamFitter.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamFitter.h
@@ -33,15 +33,17 @@
 
 #include <fstream>
 
-namespace edm {class ConsumesCollector;}
+namespace edm {
+  class ConsumesCollector;
+}
 
 class BeamFitter {
- public:
+public:
   BeamFitter() {}
-  BeamFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector &&iColl);
+  BeamFitter(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iColl);
   virtual ~BeamFitter();
 
-  void readEvent(const edm::Event& iEvent);
+  void readEvent(const edm::Event &iEvent);
 
   bool runFitter();
   bool runBeamWidthFitter();
@@ -51,8 +53,8 @@ class BeamFitter {
   reco::BeamSpot getBeamWidth() { return fbeamWidthFit; }
   void runAllFitter();
   void resetTrkVector() { fBSvector.clear(); }
-  void resetTotTrk() { ftotal_tracks=0; }
-  void resetLSRange() { fbeginLumiOfFit=fendLumiOfFit=-1; }
+  void resetTotTrk() { ftotal_tracks = 0; }
+  void resetLSRange() { fbeginLumiOfFit = fendLumiOfFit = -1; }
   void resetRefTime() { freftime[0] = freftime[1] = 0; }
   void setRefTime(time_t t0, time_t t1) {
     freftime[0] = t0;
@@ -62,84 +64,68 @@ class BeamFitter {
     updateBTime();
   }
 
-  std::pair<time_t,time_t> getRefTime(){
-    return std::make_pair(freftime[0], freftime[1]);
-  }
+  std::pair<time_t, time_t> getRefTime() { return std::make_pair(freftime[0], freftime[1]); }
 
   void resetPVFitter() { MyPVFitter->resetAll(); }
 
   //---these are added to fasciliate BeamMonitor stuff for DIP
-  std::size_t  getPVvectorSize() {return (MyPVFitter->getpvStore()).size(); }
+  std::size_t getPVvectorSize() { return (MyPVFitter->getpvStore()).size(); }
   //sc
-  void resizeBSvector(unsigned int nsize){
-    fBSvector.erase(fBSvector.begin(),fBSvector.begin()+nsize);
-   }
+  void resizeBSvector(unsigned int nsize) { fBSvector.erase(fBSvector.begin(), fBSvector.begin() + nsize); }
 
   //ssc
-  void resizePVvector(unsigned int npvsize){
-       MyPVFitter->resizepvStore(npvsize);
-   }
+  void resizePVvector(unsigned int npvsize) { MyPVFitter->resizepvStore(npvsize); }
 
- //ssc
-  void SetPVInfo(const std::vector<float> &v1_){
-     ForDIPPV_.clear();
-     ForDIPPV_.assign( v1_.begin(), v1_.end() );
-    }
+  //ssc
+  void SetPVInfo(const std::vector<float> &v1_) {
+    ForDIPPV_.clear();
+    ForDIPPV_.assign(v1_.begin(), v1_.end());
+  }
 
-//----------------
+  //----------------
 
-  void dumpTxtFile(std::string &,bool);
+  void dumpTxtFile(std::string &, bool);
   void dumpBWTxtFile(std::string &);
   void write2DB();
   reco::BeamSpot getBeamSpot() { return fbeamspot; }
   std::map<int, reco::BeamSpot> getBeamSpotMap() { return fbspotPVMap; }
   std::vector<BSTrkParameters> getBSvector() { return fBSvector; }
-  TH1F * getCutFlow() { return h1cutFlow; }
-  void subtractFromCutFlow(const TH1F* toSubtract) {
+  TH1F *getCutFlow() { return h1cutFlow; }
+  void subtractFromCutFlow(const TH1F *toSubtract) {
     h1cutFlow->Add(toSubtract, -1.0);
-    for (unsigned int i=0; i<sizeof(countPass)/sizeof(countPass[0]); i++){
-      countPass[i] = h1cutFlow->GetBinContent(i+1);
+    for (unsigned int i = 0; i < sizeof(countPass) / sizeof(countPass[0]); i++) {
+      countPass[i] = h1cutFlow->GetBinContent(i + 1);
     }
   }
 
   void resetCutFlow() {
     h1cutFlow->Reset();
     ftotal_tracks = 0;
-    for (unsigned int i=0; i<sizeof(countPass)/sizeof(countPass[0]); i++)
-      countPass[i]=0;
+    for (unsigned int i = 0; i < sizeof(countPass) / sizeof(countPass[0]); i++)
+      countPass[i] = 0;
   }
 
   //ssc
-  int getRunNumber() {
-    return frun;
-  }
+  int getRunNumber() { return frun; }
 
-  std::pair<int,int> getFitLSRange() {
-    return std::make_pair(fbeginLumiOfFit, fendLumiOfFit);
-  }
-  void setFitLSRange(int ls0,int ls1) {
+  std::pair<int, int> getFitLSRange() { return std::make_pair(fbeginLumiOfFit, fendLumiOfFit); }
+  void setFitLSRange(int ls0, int ls1) {
     fbeginLumiOfFit = ls0;
     fendLumiOfFit = ls1;
   }
-  void setRun( int run) { frun = run; }
+  void setRun(int run) { frun = run; }
 
-  int getNTracks() {
-    return fBSvector.size();
-  }
-  int getNPVs() {
-    return MyPVFitter->getNPVs();
-  }
-  const std::map<int, int> &getNPVsperBX() {
-    return MyPVFitter->getNPVsperBX();
-  }
- private:
+  int getNTracks() { return fBSvector.size(); }
+  int getNPVs() { return MyPVFitter->getNPVs(); }
+  const std::map<int, int> &getNPVsperBX() { return MyPVFitter->getNPVsperBX(); }
 
+private:
   // Update the fbeginTimeOfFit etc from the refTime
   void updateBTime();
   std::vector<BSTrkParameters> fBSvector;
   reco::BeamSpot fbeamspot;
   reco::BeamSpot fbeamWidthFit;
-  std::map< int, reco::BeamSpot> fbspotPVMap;
+  std::map<int, reco::BeamSpot> fbspotPVMap;
   //  BSFitter *fmyalgo;
   std::ofstream fasciiFile;
   std::ofstream fasciiDIP;
@@ -148,7 +134,7 @@ class BeamFitter {
   bool appendRunTxt_;
   edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
   edm::EDGetTokenT<edm::View<reco::Vertex> > vertexToken_;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_; //offlineBeamSpot
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;  //offlineBeamSpot
   bool writeTxt_;
   bool writeDIPTxt_;
   bool writeDIPBadFit_;
@@ -172,23 +158,22 @@ class BeamFitter {
   bool isMuon_;
   bool fitted_;
   bool ffilename_changed;
-   
+
   //ssc
-  std::vector<float> ForDIPPV_; 
-  
+  std::vector<float> ForDIPPV_;
 
   // ntuple
-  TH1F* h1z;
+  TH1F *h1z;
   bool saveNtuple_;
   bool saveBeamFit_;
   bool savePVVertices_;
   std::string outputfilename_;
-  TFile* file_;
-  TTree* ftree_;
+  TFile *file_;
+  TTree *ftree_;
   double ftheta;
   double fpt;
   double feta;
-  int    fcharge;
+  int fcharge;
   double fnormchi2;
   double fphi0;
   double fd0;
@@ -219,7 +204,7 @@ class BeamFitter {
   std::time_t freftime[2];
 
   //beam fit results
-  TTree* ftreeFit_;
+  TTree *ftreeFit_;
   int frunFit;
   int fbeginLumiOfFit;
   int fendLumiOfFit;
@@ -248,8 +233,7 @@ class BeamFitter {
   int countPass[9];
 
   PVFitter *MyPVFitter;
-  TTree* fPVTree_;
-
+  TTree *fPVTree_;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotAnalyzer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotAnalyzer.h
@@ -12,7 +12,6 @@
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -22,26 +21,23 @@ ________________________________________________________________**/
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
 
-
 class BeamSpotAnalyzer : public edm::EDAnalyzer {
- public:
+public:
   explicit BeamSpotAnalyzer(const edm::ParameterSet&);
   ~BeamSpotAnalyzer() override;
 
- private:
-  void beginJob() override ;
+private:
+  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-									const edm::EventSetup& context) override ;
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-								  const edm::EventSetup& c) override;
+  void endJob() override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) override;
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
 
-  int    ftotalevents;
+  int ftotalevents;
   int fitNLumi_;
   int resetFitNLumi_;
   // int countEvt_;       //counter
-  int countLumi_;      //counter
+  int countLumi_;  //counter
   int Org_resetFitNLumi_;
   int previousLumi_;
   int previousRun_;
@@ -55,7 +51,7 @@ class BeamSpotAnalyzer : public edm::EDAnalyzer {
   bool runallfitters_;
   //  double inputBeamWidth_;
 
-  BeamFitter * theBeamFitter;
+  BeamFitter* theBeamFitter;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotFitPVData.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotFitPVData.h
@@ -5,9 +5,9 @@
  *  \author WA, 9/3/2010
  */
 struct BeamSpotFitPVData {
-  float bunchCrossing; // bunch crossing
-  float position[3]; //< x, y, z position
-  float posError[3]; //< x, y, z error
-  float posCorr[3];  //< xy, xz, yz correlations
+  float bunchCrossing;  // bunch crossing
+  float position[3];    //< x, y, z position
+  float posError[3];    //< x, y, z error
+  float posCorr[3];     //< xy, xz, yz correlations
 };
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotFromDB.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotFromDB.h
@@ -12,7 +12,6 @@
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -21,18 +20,15 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 class BeamSpotFromDB : public edm::EDAnalyzer {
- public:
+public:
   explicit BeamSpotFromDB(const edm::ParameterSet&);
   ~BeamSpotFromDB() override;
 
- private:
-  void beginJob() override ;
+private:
+  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-
-
+  void endJob() override;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
@@ -20,29 +20,26 @@ ________________________________________________________________**/
 #include "DataFormats/Scalers/interface/BeamSpotOnline.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerEvmReadoutRecord.h"
 
+class BeamSpotOnlineProducer : public edm::stream::EDProducer<> {
+public:
+  typedef std::vector<edm::ParameterSet> Parameters;
 
-class BeamSpotOnlineProducer: public edm::stream::EDProducer<> {
+  /// constructor
+  explicit BeamSpotOnlineProducer(const edm::ParameterSet& iConf);
+  /// destructor
+  ~BeamSpotOnlineProducer() override;
 
-  public:
-	typedef std::vector<edm::ParameterSet> Parameters;
+  /// produce a beam spot class
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-	/// constructor
-	explicit BeamSpotOnlineProducer(const edm::ParameterSet& iConf);
-	/// destructor
-	~BeamSpotOnlineProducer() override;
-	
-	/// produce a beam spot class
-	void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+private:
+  const bool changeFrame_;
+  const double theMaxZ, theSetSigmaZ;
+  double theMaxR2;
+  const edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
+  const edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
 
-  private:
-
-	const bool changeFrame_;
-	const double theMaxZ,theSetSigmaZ;
-	double theMaxR2;
-	const edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
-	const edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
-
-	const unsigned int theBeamShoutMode;
+  const unsigned int theBeamShoutMode;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotProducer.h
@@ -18,22 +18,19 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
+class BeamSpotProducer : public edm::stream::EDProducer<> {
+public:
+  typedef std::vector<edm::ParameterSet> Parameters;
 
-class BeamSpotProducer: public edm::stream::EDProducer<> {
+  /// constructor
+  explicit BeamSpotProducer(const edm::ParameterSet& iConf);
+  /// destructor
+  ~BeamSpotProducer() override;
 
-  public:
-	typedef std::vector<edm::ParameterSet> Parameters;
+  /// produce a beam spot class
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-	/// constructor
-	explicit BeamSpotProducer(const edm::ParameterSet& iConf);
-	/// destructor
-	~BeamSpotProducer() override;
-	
-	/// produce a beam spot class
-	void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-
-  private:
-	
+private:
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotTreeData.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotTreeData.h
@@ -5,30 +5,29 @@
 
 class TTree;
 
-
-class BeamSpotTreeData{
- public:
+class BeamSpotTreeData {
+public:
   BeamSpotTreeData();
   ~BeamSpotTreeData();
   void branch(TTree* tree);
   void setBranchAddress(TTree* tree);
-  
+
   //Setters
-  void run          (unsigned int      run)          {run_=run;}
-  void lumi         (unsigned int      lumi)         {lumi_=lumi;}
-  void bunchCrossing(unsigned int      bunchCrossing){bunchCrossing_=bunchCrossing;}
-  void pvData       (const BeamSpotFitPVData &pvData)       {pvData_=pvData;}
+  void run(unsigned int run) { run_ = run; }
+  void lumi(unsigned int lumi) { lumi_ = lumi; }
+  void bunchCrossing(unsigned int bunchCrossing) { bunchCrossing_ = bunchCrossing; }
+  void pvData(const BeamSpotFitPVData& pvData) { pvData_ = pvData; }
 
   //Getters
-  const unsigned int&      getRun          (void){return run_;}
-  const unsigned int&      getLumi         (void){return lumi_;}
-  const unsigned int&      getBunchCrossing(void){return bunchCrossing_;}
-  const BeamSpotFitPVData& getPvData       (void){return pvData_;}
-  
- private:
-  unsigned int      run_;
-  unsigned int      lumi_;
-  unsigned int      bunchCrossing_;
+  const unsigned int& getRun(void) { return run_; }
+  const unsigned int& getLumi(void) { return lumi_; }
+  const unsigned int& getBunchCrossing(void) { return bunchCrossing_; }
+  const BeamSpotFitPVData& getPvData(void) { return pvData_; }
+
+private:
+  unsigned int run_;
+  unsigned int lumi_;
+  unsigned int bunchCrossing_;
   BeamSpotFitPVData pvData_;
 };
 

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2DB.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2DB.h
@@ -12,7 +12,6 @@
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -26,23 +25,20 @@ ________________________________________________________________**/
 #include "TFile.h"
 #include "TTree.h"
 
-#include<fstream>
+#include <fstream>
 
 class BeamSpotWrite2DB : public edm::EDAnalyzer {
- public:
+public:
   explicit BeamSpotWrite2DB(const edm::ParameterSet&);
   ~BeamSpotWrite2DB() override;
 
- private:
-  void beginJob() override ;
+private:
+  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
+  void endJob() override;
 
-  
   std::ifstream fasciiFile;
   std::string fasciiFileName;
-
-  
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
@@ -8,46 +8,43 @@
 namespace beamspot {
 
   struct BeamSpotContainer {
-      reco::BeamSpot beamspot          ;
-      int            run               ;
-      char           beginTimeOfFit[32];
-      char           endTimeOfFit  [32];
-      int            beginLumiOfFit    ;
-      int            endLumiOfFit      ;
-      std::time_t    reftime[2]        ;
+    reco::BeamSpot beamspot;
+    int run;
+    char beginTimeOfFit[32];
+    char endTimeOfFit[32];
+    int beginLumiOfFit;
+    int endLumiOfFit;
+    std::time_t reftime[2];
   };
- 
-  void dumpBeamSpotTxt(std::ofstream & outFile, BeamSpotContainer const& bsContainer){
 
-    outFile << "Runnumber "            << bsContainer.run                                                 << std::endl;
-    outFile << "BeginTimeOfFit "       << bsContainer.beginTimeOfFit << " "   << bsContainer.reftime[0]   << std::endl;
-    outFile << "EndTimeOfFit "         << bsContainer.endTimeOfFit   << " "   << bsContainer.reftime[1]   << std::endl;
-    outFile << "LumiRange "            << bsContainer.beginLumiOfFit << " - " << bsContainer.endLumiOfFit << std::endl;
-    outFile << "Type "                 << bsContainer.beamspot.type()                                     << std::endl;
-    outFile << "X0 "                   << bsContainer.beamspot.x0()                                       << std::endl;
-    outFile << "Y0 "                   << bsContainer.beamspot.y0()                                       << std::endl;
-    outFile << "Z0 "                   << bsContainer.beamspot.z0()                                       << std::endl;
-    outFile << "sigmaZ0 "              << bsContainer.beamspot.sigmaZ()                                   << std::endl;
-    outFile << "dxdz "                 << bsContainer.beamspot.dxdz()                                     << std::endl;
-    outFile << "dydz "                 << bsContainer.beamspot.dydz()                                     << std::endl;
-    outFile << "BeamWidthX "           << bsContainer.beamspot.BeamWidthX()                               << std::endl;
-    outFile << "BeamWidthY "           << bsContainer.beamspot.BeamWidthY()                               << std::endl;
-    for (int i = 0; i<6; ++i) {
-      outFile << "Cov("<<i<<",j) ";
-      for (int j=0; j<7; ++j) {
-        outFile << bsContainer.beamspot.covariance(i,j) << " ";
+  void dumpBeamSpotTxt(std::ofstream& outFile, BeamSpotContainer const& bsContainer) {
+    outFile << "Runnumber " << bsContainer.run << std::endl;
+    outFile << "BeginTimeOfFit " << bsContainer.beginTimeOfFit << " " << bsContainer.reftime[0] << std::endl;
+    outFile << "EndTimeOfFit " << bsContainer.endTimeOfFit << " " << bsContainer.reftime[1] << std::endl;
+    outFile << "LumiRange " << bsContainer.beginLumiOfFit << " - " << bsContainer.endLumiOfFit << std::endl;
+    outFile << "Type " << bsContainer.beamspot.type() << std::endl;
+    outFile << "X0 " << bsContainer.beamspot.x0() << std::endl;
+    outFile << "Y0 " << bsContainer.beamspot.y0() << std::endl;
+    outFile << "Z0 " << bsContainer.beamspot.z0() << std::endl;
+    outFile << "sigmaZ0 " << bsContainer.beamspot.sigmaZ() << std::endl;
+    outFile << "dxdz " << bsContainer.beamspot.dxdz() << std::endl;
+    outFile << "dydz " << bsContainer.beamspot.dydz() << std::endl;
+    outFile << "BeamWidthX " << bsContainer.beamspot.BeamWidthX() << std::endl;
+    outFile << "BeamWidthY " << bsContainer.beamspot.BeamWidthY() << std::endl;
+    for (int i = 0; i < 6; ++i) {
+      outFile << "Cov(" << i << ",j) ";
+      for (int j = 0; j < 7; ++j) {
+        outFile << bsContainer.beamspot.covariance(i, j) << " ";
       }
-        outFile << std::endl;
-      }
+      outFile << std::endl;
+    }
     // Uncertainties on sigmaX and sigmaY are set to be equal. Legacy from a distant past
-    outFile << "Cov(6,j) 0 0 0 0 0 0 " << bsContainer.beamspot.covariance(6,6)                            << std::endl;
-    outFile << "EmittanceX "           << bsContainer.beamspot.emittanceX()                               << std::endl;
-    outFile << "EmittanceY "           << bsContainer.beamspot.emittanceY()                               << std::endl;
-    outFile << "BetaStar "             << bsContainer.beamspot.betaStar()                                 << std::endl;
-
+    outFile << "Cov(6,j) 0 0 0 0 0 0 " << bsContainer.beamspot.covariance(6, 6) << std::endl;
+    outFile << "EmittanceX " << bsContainer.beamspot.emittanceX() << std::endl;
+    outFile << "EmittanceY " << bsContainer.beamspot.emittanceY() << std::endl;
+    outFile << "BetaStar " << bsContainer.beamspot.betaStar() << std::endl;
   }
 
-} // end namespace beamspot
-
+}  // end namespace beamspot
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
+++ b/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
@@ -17,28 +17,27 @@
 #include "RecoVertex/BeamSpotProducer/interface/BeamSpotFitPVData.h"
 #include "Minuit2/FCNBase.h"
 
-#include <vector> 
+#include <vector>
 
-class FcnBeamSpotFitPV : public ROOT::Minuit2::FCNBase { 
-public: 
+class FcnBeamSpotFitPV : public ROOT::Minuit2::FCNBase {
+public:
   // constructor from vertex data
   FcnBeamSpotFitPV(const std::vector<BeamSpotFitPVData>& data);
-  ~FcnBeamSpotFitPV() override {} 
+  ~FcnBeamSpotFitPV() override {}
   // additional vertex selection using limits in x, y, z
-  void setLimits (float xmin, float xmax,
-		  float ymin, float ymax,
-		  float zmin, float zmax);
+  void setLimits(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax);
   // deltaFcn for definition of the uncertainty
-  double Up() const override {return errorDef_;} 
+  double Up() const override { return errorDef_; }
   // -2lnL value based on vector of parameters
-  double operator() (const std::vector<double>&) const override; 
+  double operator()(const std::vector<double>&) const override;
   // vertex count used for the fit (after selection)
-  unsigned int nrOfVerticesUsed () const;
-private: 
-  const std::vector<BeamSpotFitPVData>& data_; //< vertex data
-  double errorDef_;                            //< error definition for Minuit
+  unsigned int nrOfVerticesUsed() const;
 
-  float lowerLimits_[3];                       //< lower limits for x,y,z
-  float upperLimits_[3];                       //< upper limits for x,y,z
-}; 
+private:
+  const std::vector<BeamSpotFitPVData>& data_;  //< vertex data
+  double errorDef_;                             //< error definition for Minuit
+
+  float lowerLimits_[3];  //< lower limits for x,y,z
+  float upperLimits_[3];  //< upper limits for x,y,z
+};
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/PVFitter.h
+++ b/RecoVertex/BeamSpotProducer/interface/PVFitter.h
@@ -26,7 +26,6 @@
 
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-
 // ROOT
 #include "TFile.h"
 #include "TTree.h"
@@ -34,23 +33,25 @@
 
 #include <fstream>
 
-namespace edm {class ConsumesCollector;}
+namespace edm {
+  class ConsumesCollector;
+}
 
 namespace reco {
   class Vertex;
 }
 
 class PVFitter {
- public:
+public:
   PVFitter() {}
-  PVFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector &&iColl);
-  PVFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector &iColl);
+  PVFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iColl);
+  PVFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iColl);
   virtual ~PVFitter();
 
-  void initialize(const edm::ParameterSet& iConfig, edm::ConsumesCollector &iColl);
+  void initialize(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iColl);
   void readEvent(const edm::Event& iEvent);
   void setTree(TTree* tree);
-  
+
   double getWidthX() { return fwidthX; }
   double getWidthY() { return fwidthY; }
   double getWidthZ() { return fwidthZ; }
@@ -58,23 +59,22 @@ class PVFitter {
   double getWidthYerr() { return fwidthYerr; }
   double getWidthZerr() { return fwidthZerr; }
   //ssc
-  std::vector<BeamSpotFitPVData> getpvStore() { return pvStore_; } 
- 
+  std::vector<BeamSpotFitPVData> getpvStore() { return pvStore_; }
+
   void FitPerBunchCrossing() { fFitPerBunchCrossing = true; }
   bool runBXFitter();
-  bool runFitter(); 
-  void resetLSRange() { fbeginLumiOfFit=fendLumiOfFit=-1; }
+  bool runFitter();
+  void resetLSRange() { fbeginLumiOfFit = fendLumiOfFit = -1; }
   void resetRefTime() { freftime[0] = freftime[1] = 0; }
   //ssc
-   void setRefTime(std::time_t t0,std::time_t t1) {
+  void setRefTime(std::time_t t0, std::time_t t1) {
     freftime[0] = t0;
     freftime[1] = t1;
   }
-   void setFitLSRange(int ls0,int ls1) {
+  void setFitLSRange(int ls0, int ls1) {
     fbeginLumiOfFit = ls0;
     fendLumiOfFit = ls1;
   }
-
 
   void dumpTxtFile();
   void resetAll() {
@@ -92,51 +92,45 @@ class PVFitter {
   std::map<int, reco::BeamSpot> getBeamSpotMap() { return fbspotMap; }
   bool IsFitPerBunchCrossing() { return fFitPerBunchCrossing; }
   int* getFitLSRange() {
-    int *tmp=new int[2];
+    int* tmp = new int[2];
     tmp[0] = fbeginLumiOfFit;
     tmp[1] = fendLumiOfFit;
     return tmp;
   }
- //ssc
- time_t* getRefTime(){
-   time_t *tmptime=new time_t[2];
-   tmptime[0]=freftime[0];
-   tmptime[1]=freftime[1];
-   return tmptime;
+  //ssc
+  time_t* getRefTime() {
+    time_t* tmptime = new time_t[2];
+    tmptime[0] = freftime[0];
+    tmptime[1] = freftime[1];
+    return tmptime;
   }
 
-//ssc
- void resizepvStore(unsigned int rmSize ){
-  pvStore_.erase(pvStore_.begin(), pvStore_.begin()+rmSize);
-  }
+  //ssc
+  void resizepvStore(unsigned int rmSize) { pvStore_.erase(pvStore_.begin(), pvStore_.begin() + rmSize); }
 
- 
   /// reduce size of primary vertex cache by increasing quality limit
-  void compressStore ();
+  void compressStore();
   /// vertex quality measure
-  double pvQuality (const reco::Vertex& pv) const;
+  double pvQuality(const reco::Vertex& pv) const;
   /// vertex quality measure
-  double pvQuality (const BeamSpotFitPVData& pv) const;
+  double pvQuality(const BeamSpotFitPVData& pv) const;
   int getNPVs() { return pvStore_.size(); }
-  
-  const std::map<int, int> &getNPVsperBX() {
-    
+
+  const std::map<int, int>& getNPVsperBX() {
     npvsmap_.clear();
 
-    for ( std::map<int,std::vector<BeamSpotFitPVData> >::const_iterator pvStore = bxMap_.begin(); 
-	  pvStore!=bxMap_.end(); ++pvStore) {
-
-      npvsmap_[ pvStore->first ] = (pvStore->second).size();
-
+    for (std::map<int, std::vector<BeamSpotFitPVData> >::const_iterator pvStore = bxMap_.begin();
+         pvStore != bxMap_.end();
+         ++pvStore) {
+      npvsmap_[pvStore->first] = (pvStore->second).size();
     }
     return npvsmap_;
   }
 
- private:
-
+private:
   std::map<int, int> npvsmap_;
   reco::BeamSpot fbeamspot;
-  std::map<int,reco::BeamSpot> fbspotMap;
+  std::map<int, reco::BeamSpot> fbspotMap;
   bool fFitPerBunchCrossing;
   bool useOnlyFirstPV_;
 
@@ -156,12 +150,13 @@ class PVFitter {
   double maxVtxR_;
   double maxVtxZ_;
   double errorScale_;
-  double sigmaCut_;         
-  double minSumPt_;         
-	
+  double sigmaCut_;
+  double minSumPt_;
+
   std::time_t freftime[2];
 
-  TH2F* hPVx; TH2F* hPVy; 
+  TH2F* hPVx;
+  TH2F* hPVy;
 
   TTree* ftree_;
 
@@ -175,10 +170,10 @@ class PVFitter {
   double fwidthYerr;
   double fwidthZerr;
 
-  std::vector<BeamSpotFitPVData> pvStore_; //< cache for PV data
-  std::map< int, std::vector<BeamSpotFitPVData> > bxMap_; // store PV data as a function of bunch crossings
-  double dynamicQualityCut_;               //< quality cut for vertices (dynamic adjustment)
-  std::vector<double> pvQualities_;        //< working space for PV store adjustement
+  std::vector<BeamSpotFitPVData> pvStore_;                //< cache for PV data
+  std::map<int, std::vector<BeamSpotFitPVData> > bxMap_;  // store PV data as a function of bunch crossings
+  double dynamicQualityCut_;                              //< quality cut for vertices (dynamic adjustment)
+  std::vector<double> pvQualities_;                       //< working space for PV store adjustement
 
   BeamSpotTreeData theBeamSpotTreeData_;
 };

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotAnalyzer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotAnalyzer.cc
@@ -10,7 +10,6 @@
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -25,14 +24,16 @@ ________________________________________________________________**/
 
 #include "TMath.h"
 
-BeamSpotAnalyzer::BeamSpotAnalyzer(const edm::ParameterSet& iConfig)
-{
+BeamSpotAnalyzer::BeamSpotAnalyzer(const edm::ParameterSet& iConfig) {
   // get parameter
-  write2DB_       = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getParameter<bool>("WriteToDB");
-  runallfitters_  = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getParameter<bool>("RunAllFitters");
-  fitNLumi_       = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getUntrackedParameter<int>("fitEveryNLumi",-1);
-  resetFitNLumi_  = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getUntrackedParameter<int>("resetEveryNLumi",-1);
-  runbeamwidthfit_  = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getParameter<bool>("RunBeamWidthFit");
+  write2DB_ = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getParameter<bool>("WriteToDB");
+  runallfitters_ = iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getParameter<bool>("RunAllFitters");
+  fitNLumi_ =
+      iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getUntrackedParameter<int>("fitEveryNLumi", -1);
+  resetFitNLumi_ =
+      iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getUntrackedParameter<int>("resetEveryNLumi", -1);
+  runbeamwidthfit_ =
+      iConfig.getParameter<edm::ParameterSet>("BSAnalyzerParameters").getParameter<bool>("RunBeamWidthFit");
 
   theBeamFitter = new BeamFitter(iConfig, consumesCollector());
   theBeamFitter->resetTrkVector();
@@ -49,159 +50,136 @@ BeamSpotAnalyzer::BeamSpotAnalyzer(const edm::ParameterSet& iConfig)
   Org_resetFitNLumi_ = resetFitNLumi_;
 }
 
+BeamSpotAnalyzer::~BeamSpotAnalyzer() { delete theBeamFitter; }
 
-BeamSpotAnalyzer::~BeamSpotAnalyzer()
-{
-  delete theBeamFitter;
+void BeamSpotAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  ftotalevents++;
+  theBeamFitter->readEvent(iEvent);
+  ftmprun = iEvent.id().run();
 }
 
+void BeamSpotAnalyzer::beginJob() {}
 
-void
-BeamSpotAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-	ftotalevents++;
-	theBeamFitter->readEvent(iEvent);
-	ftmprun = iEvent.id().run();
+//--------------------------------------------------------
+void BeamSpotAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) {
+  const edm::TimeValue_t fbegintimestamp = lumiSeg.beginTime().value();
+  const std::time_t ftmptime = fbegintimestamp >> 32;
 
-}
+  if (countLumi_ == 0 || (resetFitNLumi_ > 0 && countLumi_ % resetFitNLumi_ == 0)) {
+    ftmprun0 = lumiSeg.run();
+    ftmprun = ftmprun0;
+    beginLumiOfBSFit_ = lumiSeg.luminosityBlock();
+    refBStime[0] = ftmptime;
+  }
 
-
-
-void
-BeamSpotAnalyzer::beginJob()
-{
+  countLumi_++;
+  //std::cout << "Lumi # " << countLumi_ << std::endl;
+  if (ftmprun == previousRun_) {
+    if ((previousLumi_ + 1) != int(lumiSeg.luminosityBlock()))
+      edm::LogWarning("BeamSpotAnalyzer") << "LUMI SECTIONS ARE NOT SORTED!";
+  }
 }
 
 //--------------------------------------------------------
-void
-BeamSpotAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-									   const edm::EventSetup& context) {
-
-    const edm::TimeValue_t fbegintimestamp = lumiSeg.beginTime().value();
-    const std::time_t ftmptime = fbegintimestamp >> 32;
-
-    if ( countLumi_ == 0 || (resetFitNLumi_ > 0 && countLumi_%resetFitNLumi_ == 0) ) {
-        ftmprun0 = lumiSeg.run();
-        ftmprun = ftmprun0;
-        beginLumiOfBSFit_ = lumiSeg.luminosityBlock();
-        refBStime[0] = ftmptime;
-    }
-
-    countLumi_++;
-    //std::cout << "Lumi # " << countLumi_ << std::endl;
-    if ( ftmprun == previousRun_ ) {
-      if ( (previousLumi_ + 1) != int(lumiSeg.luminosityBlock()) )
-	edm::LogWarning("BeamSpotAnalyzer") << "LUMI SECTIONS ARE NOT SORTED!";
-    }
-}
-
-//--------------------------------------------------------
-void
-BeamSpotAnalyzer::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
-									 const edm::EventSetup& iSetup) {
-
+void BeamSpotAnalyzer::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
   //LogDebug("BeamSpotAnalyzer") <<
-  std::cout <<
-    "for lumis "<< beginLumiOfBSFit_ << " - " << endLumiOfBSFit_ << std::endl <<
-    "number of selected tracks = " << theBeamFitter->getNTracks() << std::endl;
+  std::cout << "for lumis " << beginLumiOfBSFit_ << " - " << endLumiOfBSFit_ << std::endl
+            << "number of selected tracks = " << theBeamFitter->getNTracks() << std::endl;
   std::cout << "number of selected PVs = " << theBeamFitter->getNPVs() << std::endl;
   //std::cout << "number of selected PVs per bx: " << std::endl;
   //theBeamFitter->getNPVsperBX();
 
-    const edm::TimeValue_t fendtimestamp = lumiSeg.endTime().value();
-    const std::time_t fendtime = fendtimestamp >> 32;
-    refBStime[1] = fendtime;
+  const edm::TimeValue_t fendtimestamp = lumiSeg.endTime().value();
+  const std::time_t fendtime = fendtimestamp >> 32;
+  refBStime[1] = fendtime;
 
-    endLumiOfBSFit_ = lumiSeg.luminosityBlock();
-    previousLumi_ = endLumiOfBSFit_;
+  endLumiOfBSFit_ = lumiSeg.luminosityBlock();
+  previousLumi_ = endLumiOfBSFit_;
 
-    if ( fitNLumi_ == -1 && resetFitNLumi_ == -1 ) return;
+  if (fitNLumi_ == -1 && resetFitNLumi_ == -1)
+    return;
 
-    if (fitNLumi_ > 0 && countLumi_%fitNLumi_!=0) return;
+  if (fitNLumi_ > 0 && countLumi_ % fitNLumi_ != 0)
+    return;
 
-    theBeamFitter->setFitLSRange(beginLumiOfBSFit_,endLumiOfBSFit_);
-    theBeamFitter->setRefTime(refBStime[0],refBStime[1]);
-    theBeamFitter->setRun(ftmprun0);
+  theBeamFitter->setFitLSRange(beginLumiOfBSFit_, endLumiOfBSFit_);
+  theBeamFitter->setRefTime(refBStime[0], refBStime[1]);
+  theBeamFitter->setRun(ftmprun0);
 
-    std::pair<int,int> LSRange = theBeamFitter->getFitLSRange();
+  std::pair<int, int> LSRange = theBeamFitter->getFitLSRange();
 
-    if (theBeamFitter->runPVandTrkFitter()){
-      reco::BeamSpot bs = theBeamFitter->getBeamSpot();
-      std::cout << "\n RESULTS OF DEFAULT FIT " << std::endl;
-      std::cout << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl;
-      std::cout << " for lumi blocks : " << LSRange.first << " - " << LSRange.second << std::endl;
-      std::cout << " lumi counter # " << countLumi_ << std::endl;
-      std::cout << bs << std::endl;
-      std::cout << "[BeamFitter] fit done. \n" << std::endl;
-    }
-    else { // Fill in empty beam spot if beamfit fails
-      reco::BeamSpot bs;
-      bs.setType(reco::BeamSpot::Fake);
-      std::cout << "\n Empty Beam spot fit" << std::endl;
-      std::cout << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl;
-      std::cout << " for lumi blocks : " << LSRange.first << " - " << LSRange.second << std::endl;
-      std::cout << " lumi counter # " << countLumi_ << std::endl;
-      std::cout << bs << std::endl;
-      std::cout << "[BeamFitter] fit failed \n" << std::endl;
-      //accumulate more events
-      // dissable this for the moment
-      //resetFitNLumi_ += 1;
-      //std::cout << "reset fitNLumi " << resetFitNLumi_ << std::endl;
-    }
+  if (theBeamFitter->runPVandTrkFitter()) {
+    reco::BeamSpot bs = theBeamFitter->getBeamSpot();
+    std::cout << "\n RESULTS OF DEFAULT FIT " << std::endl;
+    std::cout << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl;
+    std::cout << " for lumi blocks : " << LSRange.first << " - " << LSRange.second << std::endl;
+    std::cout << " lumi counter # " << countLumi_ << std::endl;
+    std::cout << bs << std::endl;
+    std::cout << "[BeamFitter] fit done. \n" << std::endl;
+  } else {  // Fill in empty beam spot if beamfit fails
+    reco::BeamSpot bs;
+    bs.setType(reco::BeamSpot::Fake);
+    std::cout << "\n Empty Beam spot fit" << std::endl;
+    std::cout << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl;
+    std::cout << " for lumi blocks : " << LSRange.first << " - " << LSRange.second << std::endl;
+    std::cout << " lumi counter # " << countLumi_ << std::endl;
+    std::cout << bs << std::endl;
+    std::cout << "[BeamFitter] fit failed \n" << std::endl;
+    //accumulate more events
+    // dissable this for the moment
+    //resetFitNLumi_ += 1;
+    //std::cout << "reset fitNLumi " << resetFitNLumi_ << std::endl;
+  }
 
-    if (resetFitNLumi_ > 0 && countLumi_%resetFitNLumi_ == 0) {
-      std::vector<BSTrkParameters> theBSvector = theBeamFitter->getBSvector();
-      std::cout << "Total number of tracks accumulated = " << theBSvector.size() << std::endl;
-      std::cout << "Reset track collection for beam fit" <<std::endl;
-      theBeamFitter->resetTrkVector();
-      theBeamFitter->resetLSRange();
-      theBeamFitter->resetCutFlow();
-      theBeamFitter->resetRefTime();
-      theBeamFitter->resetPVFitter();
-      countLumi_=0;
-      // reset counter to orginal
-      resetFitNLumi_ = Org_resetFitNLumi_;
-    }
-
+  if (resetFitNLumi_ > 0 && countLumi_ % resetFitNLumi_ == 0) {
+    std::vector<BSTrkParameters> theBSvector = theBeamFitter->getBSvector();
+    std::cout << "Total number of tracks accumulated = " << theBSvector.size() << std::endl;
+    std::cout << "Reset track collection for beam fit" << std::endl;
+    theBeamFitter->resetTrkVector();
+    theBeamFitter->resetLSRange();
+    theBeamFitter->resetCutFlow();
+    theBeamFitter->resetRefTime();
+    theBeamFitter->resetPVFitter();
+    countLumi_ = 0;
+    // reset counter to orginal
+    resetFitNLumi_ = Org_resetFitNLumi_;
+  }
 }
 
-
-void
-BeamSpotAnalyzer::endJob() {
+void BeamSpotAnalyzer::endJob() {
   std::cout << "\n-------------------------------------\n" << std::endl;
-  std::cout << "\n Total number of events processed: "<< ftotalevents << std::endl;
+  std::cout << "\n Total number of events processed: " << ftotalevents << std::endl;
   std::cout << "\n-------------------------------------\n\n" << std::endl;
 
-  if ( fitNLumi_ == -1 && resetFitNLumi_ == -1 ) {
+  if (fitNLumi_ == -1 && resetFitNLumi_ == -1) {
+    if (theBeamFitter->runPVandTrkFitter()) {
+      reco::BeamSpot beam_default = theBeamFitter->getBeamSpot();
+      std::pair<int, int> LSRange = theBeamFitter->getFitLSRange();
 
-	  if(theBeamFitter->runPVandTrkFitter()){
-		  reco::BeamSpot beam_default = theBeamFitter->getBeamSpot();
-                  std::pair<int,int> LSRange = theBeamFitter->getFitLSRange();
+      std::cout << "\n RESULTS OF DEFAULT FIT:" << std::endl;
+      std::cout << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl;
+      std::cout << " for lumi blocks : " << LSRange.first << " - " << LSRange.second << std::endl;
+      std::cout << " lumi counter # " << countLumi_ << std::endl;
+      std::cout << beam_default << std::endl;
 
-		  std::cout << "\n RESULTS OF DEFAULT FIT:" << std::endl;
-		  std::cout << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl;
-		  std::cout << " for lumi blocks : " << LSRange.first << " - " << LSRange.second << std::endl;
-		  std::cout << " lumi counter # " << countLumi_ << std::endl;
-		  std::cout << beam_default << std::endl;
-
-		  if (write2DB_) {
-			  std::cout << "\n-------------------------------------\n\n" << std::endl;
-			  std::cout << " write results to DB..." << std::endl;
-			  theBeamFitter->write2DB();
-		  }
-
-		  if (runallfitters_) {
-			  theBeamFitter->runAllFitter();
-		  }
-
-	  }
-      if ((runbeamwidthfit_)){
-                 theBeamFitter->runBeamWidthFitter();
-                 reco::BeamSpot beam_width = theBeamFitter->getBeamWidth();
-                 std::cout <<beam_width<< std::endl;
+      if (write2DB_) {
+        std::cout << "\n-------------------------------------\n\n" << std::endl;
+        std::cout << " write results to DB..." << std::endl;
+        theBeamFitter->write2DB();
       }
 
-	  else std::cout << "[BeamSpotAnalyzer] beamfit fails !!!" << std::endl;
+      if (runallfitters_) {
+        theBeamFitter->runAllFitter();
+      }
+    }
+    if ((runbeamwidthfit_)) {
+      theBeamFitter->runBeamWidthFitter();
+      reco::BeamSpot beam_width = theBeamFitter->getBeamWidth();
+      std::cout << beam_width << std::endl;
+    }
+
+    else
+      std::cout << "[BeamSpotAnalyzer] beamfit fails !!!" << std::endl;
   }
 
   std::cout << "[BeamSpotAnalyzer] endJob done \n" << std::endl;

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
@@ -24,120 +24,109 @@
 
 class BeamSpotFakeConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
-	typedef std::unique_ptr<BeamSpotObjects> ReturnType;
-	BeamSpotFakeConditions(const edm::ParameterSet &params);
-	~BeamSpotFakeConditions() override;
-	ReturnType produce(const BeamSpotObjectsRcd &record);
+  typedef std::unique_ptr<BeamSpotObjects> ReturnType;
+  BeamSpotFakeConditions(const edm::ParameterSet &params);
+  ~BeamSpotFakeConditions() override;
+  ReturnType produce(const BeamSpotObjectsRcd &record);
+
 private:
-	void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,const edm::IOVSyncValue &syncValue,edm::ValidityInterval &oValidity) override;
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
+                      const edm::IOVSyncValue &syncValue,
+                      edm::ValidityInterval &oValidity) override;
   edm::FileInPath inputFilename_;
   bool getDataFromFile_;
-  double x,y,z,sigmaZ,dxdz,dydz,beamWidthX,beamWidthY,emittanceX,emittanceY,betastar;
+  double x, y, z, sigmaZ, dxdz, dydz, beamWidthX, beamWidthY, emittanceX, emittanceY, betastar;
   std::string tag;
   double cov[7][7];
   int type;
-	
 };
 
-BeamSpotFakeConditions::BeamSpotFakeConditions(const edm::ParameterSet &params)
-{	
-		setWhatProduced(this);
-		findingRecord<BeamSpotObjectsRcd>();
-		getDataFromFile_ = params.getParameter<bool>("getDataFromFile");
-		if (getDataFromFile_) {
-		  inputFilename_   = params.getParameter<edm::FileInPath>("InputFilename");
-		  std::ifstream fasciiFile(inputFilename_.fullPath().c_str() );
-		  fasciiFile >> tag >> type;
-		  fasciiFile >> tag >> x;
-		  fasciiFile >> tag >> y;
-		  fasciiFile >> tag >> z;
-		  fasciiFile >> tag >> sigmaZ;
-		  fasciiFile >> tag >> dxdz;
-		  fasciiFile >> tag >> dydz;
-		  fasciiFile >> tag >> beamWidthX;
-		  fasciiFile >> tag >> beamWidthY;
-		  fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2]>> cov[0][3] >> cov[0][4]>> cov[0][5] >> cov[0][6]
-		    ;
-		  fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3]>> cov[1][4] >> cov[1][5]>> cov[1][6]
-		    ;
-		  fasciiFile >> tag >> cov[2][0]  >> cov[2][1] >> cov[2][2] >> cov[2][3]>> cov[2][4] >> cov[2][5]>> cov[2][6
-															   ];
-		  fasciiFile >> tag >> cov[3][0]  >> cov[3][1] >> cov[3][2] >> cov[3][3]>> cov[3][4] >> cov[3][5]>> cov[3][6
-															   ];
-		  fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3]>> cov[4][4] >> cov[4][5]>> cov[4][6]
-		    ;
-		  fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3]>> cov[5][4] >> cov[5][5]>> cov[5][6]
-		    ;
-		  fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3]>> cov[6][4] >> cov[6][5]>> cov[6][6]
-		    ;
-		  fasciiFile >> tag >> emittanceX;
-		  fasciiFile >> tag >> emittanceY;
-		  fasciiFile >> tag >> betastar;
+BeamSpotFakeConditions::BeamSpotFakeConditions(const edm::ParameterSet &params) {
+  setWhatProduced(this);
+  findingRecord<BeamSpotObjectsRcd>();
+  getDataFromFile_ = params.getParameter<bool>("getDataFromFile");
+  if (getDataFromFile_) {
+    inputFilename_ = params.getParameter<edm::FileInPath>("InputFilename");
+    std::ifstream fasciiFile(inputFilename_.fullPath().c_str());
+    fasciiFile >> tag >> type;
+    fasciiFile >> tag >> x;
+    fasciiFile >> tag >> y;
+    fasciiFile >> tag >> z;
+    fasciiFile >> tag >> sigmaZ;
+    fasciiFile >> tag >> dxdz;
+    fasciiFile >> tag >> dydz;
+    fasciiFile >> tag >> beamWidthX;
+    fasciiFile >> tag >> beamWidthY;
+    fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2] >> cov[0][3] >> cov[0][4] >> cov[0][5] >> cov[0][6];
+    fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3] >> cov[1][4] >> cov[1][5] >> cov[1][6];
+    fasciiFile >> tag >> cov[2][0] >> cov[2][1] >> cov[2][2] >> cov[2][3] >> cov[2][4] >> cov[2][5] >> cov[2][6];
+    fasciiFile >> tag >> cov[3][0] >> cov[3][1] >> cov[3][2] >> cov[3][3] >> cov[3][4] >> cov[3][5] >> cov[3][6];
+    fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3] >> cov[4][4] >> cov[4][5] >> cov[4][6];
+    fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3] >> cov[5][4] >> cov[5][5] >> cov[5][6];
+    fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3] >> cov[6][4] >> cov[6][5] >> cov[6][6];
+    fasciiFile >> tag >> emittanceX;
+    fasciiFile >> tag >> emittanceY;
+    fasciiFile >> tag >> betastar;
 
-		}
-		// input values by hand
-		else {
-		  x =              params.getParameter<double>(  "X0" );
-		  y =              params.getParameter<double>(  "Y0" );
-		  z =              params.getParameter<double>(  "Z0" );
-		  dxdz =           params.getParameter<double>(  "dxdz" );
-		  dydz =           params.getParameter<double>(  "dydz" );
-		  sigmaZ =         params.getParameter<double>(  "sigmaZ" );
-		  beamWidthX =     params.getParameter<double>(  "widthX" );
-		  beamWidthY =     params.getParameter<double>(  "widthY" );
-		  emittanceX =     params.getParameter<double>(  "emittanceX" );
-		  emittanceY =     params.getParameter<double>(  "emittanceY" );
-		  betastar =       params.getParameter<double>(  "betaStar"  );
+  }
+  // input values by hand
+  else {
+    x = params.getParameter<double>("X0");
+    y = params.getParameter<double>("Y0");
+    z = params.getParameter<double>("Z0");
+    dxdz = params.getParameter<double>("dxdz");
+    dydz = params.getParameter<double>("dydz");
+    sigmaZ = params.getParameter<double>("sigmaZ");
+    beamWidthX = params.getParameter<double>("widthX");
+    beamWidthY = params.getParameter<double>("widthY");
+    emittanceX = params.getParameter<double>("emittanceX");
+    emittanceY = params.getParameter<double>("emittanceY");
+    betastar = params.getParameter<double>("betaStar");
 
-		  // first set all elements (esp. off-diagonal elements to zero)
-		  for (int i=0; i<7; i++ ) {
-		    for (int j=0; j<7; j++) cov[i][j] = 0.0;
-		  }
+    // first set all elements (esp. off-diagonal elements to zero)
+    for (int i = 0; i < 7; i++) {
+      for (int j = 0; j < 7; j++)
+        cov[i][j] = 0.0;
+    }
 
-		  // we ignore correlations when values are given by hand
-		  cov[0][0] =       pow( params.getParameter<double>(  "errorX0" ), 2 );
-		  cov[1][1] =       pow(    params.getParameter<double>(  "errorY0" ), 2 );
-		  cov[2][2] =       pow(    params.getParameter<double>(  "errorZ0" ), 2 );
-		  cov[3][3] =       pow( params.getParameter<double>(  "errorSigmaZ" ), 2 );
-		  cov[4][4] =       pow( params.getParameter<double>(  "errordxdz" ), 2 );
-		  cov[5][5] =       pow( params.getParameter<double>(  "errordydz" ), 2 );
-		  cov[6][6] =       pow( params.getParameter<double>(  "errorWidth" ), 2 );
-		  
-		}
+    // we ignore correlations when values are given by hand
+    cov[0][0] = pow(params.getParameter<double>("errorX0"), 2);
+    cov[1][1] = pow(params.getParameter<double>("errorY0"), 2);
+    cov[2][2] = pow(params.getParameter<double>("errorZ0"), 2);
+    cov[3][3] = pow(params.getParameter<double>("errorSigmaZ"), 2);
+    cov[4][4] = pow(params.getParameter<double>("errordxdz"), 2);
+    cov[5][5] = pow(params.getParameter<double>("errordydz"), 2);
+    cov[6][6] = pow(params.getParameter<double>("errorWidth"), 2);
+  }
 }
 
-BeamSpotFakeConditions::~BeamSpotFakeConditions(){}
+BeamSpotFakeConditions::~BeamSpotFakeConditions() {}
 
-BeamSpotFakeConditions::ReturnType
-BeamSpotFakeConditions::produce(const BeamSpotObjectsRcd &record){
+BeamSpotFakeConditions::ReturnType BeamSpotFakeConditions::produce(const BeamSpotObjectsRcd &record) {
+  ReturnType adummy = std::make_unique<BeamSpotObjects>();
 
+  adummy->SetPosition(x, y, z);
+  adummy->SetSigmaZ(sigmaZ);
+  adummy->Setdxdz(dxdz);
+  adummy->Setdydz(dydz);
+  adummy->SetBeamWidthX(beamWidthX);
+  adummy->SetBeamWidthY(beamWidthY);
+  for (int i = 0; i < 7; i++) {
+    for (int j = 0; j < 7; j++) {
+      adummy->SetCovariance(i, j, cov[i][j]);
+    }
+  }
+  adummy->SetEmittanceX(emittanceX);
+  adummy->SetEmittanceY(emittanceY);
+  adummy->SetBetaStar(betastar);
 
-	ReturnType adummy = std::make_unique<BeamSpotObjects>();
-	
-	adummy->SetPosition( x, y , z );
-	adummy->SetSigmaZ( sigmaZ);
-	adummy->Setdxdz( dxdz );
-	adummy->Setdydz( dydz );
-	adummy->SetBeamWidthX( beamWidthX );
-	adummy->SetBeamWidthY( beamWidthY );
-	for (int i=0; i<7; i++ ) {
-	  for (int j=0; j<7; j++) {
-
-	    adummy->SetCovariance( i, j, cov[i][j] );
-	  } 
-	}
-	adummy->SetEmittanceX( emittanceX );
-	adummy->SetEmittanceY( emittanceY );
-	adummy->SetBetaStar( betastar);
-
-	return adummy;
+  return adummy;
 }
 
 void BeamSpotFakeConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
-						  const edm::IOVSyncValue &syncValue,
-						  edm::ValidityInterval &oValidity){
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-				    edm::IOVSyncValue::endOfTime());
+                                            const edm::IOVSyncValue &syncValue,
+                                            edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }
 
 DEFINE_FWK_EVENTSETUP_SOURCE(BeamSpotFakeConditions);

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotFromDB.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotFromDB.cc
@@ -9,7 +9,6 @@
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -27,42 +26,24 @@ ________________________________________________________________**/
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 
+BeamSpotFromDB::BeamSpotFromDB(const edm::ParameterSet& iConfig) {}
 
-BeamSpotFromDB::BeamSpotFromDB(const edm::ParameterSet& iConfig)
-{
-  
+BeamSpotFromDB::~BeamSpotFromDB() {}
+
+void BeamSpotFromDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::ESHandle<BeamSpotObjects> beamhandle;
+  iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
+  const BeamSpotObjects* mybeamspot = beamhandle.product();
+
+  std::cout << " for runs: " << iEvent.id().run() << " - " << iEvent.id().run() << std::endl;
+  //std::cout << iEvent.getRun().beginTime().value() << std::endl;
+  //std::cout << iEvent.time().value() << std::endl;
+  std::cout << *mybeamspot << std::endl;
 }
 
+void BeamSpotFromDB::beginJob() {}
 
-BeamSpotFromDB::~BeamSpotFromDB()
-{
-	
-}
-
-
-void
-BeamSpotFromDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-	
-	edm::ESHandle< BeamSpotObjects > beamhandle;
-	iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
-	const BeamSpotObjects *mybeamspot = beamhandle.product();
-
-	std::cout << " for runs: " << iEvent.id().run() << " - " << iEvent.id().run() << std::endl;
-	//std::cout << iEvent.getRun().beginTime().value() << std::endl;
-	//std::cout << iEvent.time().value() << std::endl;
-	std::cout << *mybeamspot << std::endl;
-
-}
-
-void
-BeamSpotFromDB::beginJob()
-{
-}
-
-void
-BeamSpotFromDB::endJob() {
-}
+void BeamSpotFromDB::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(BeamSpotFromDB);

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -10,152 +10,129 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 using namespace edm;
 
-
 BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
-  : changeFrame_ ( iconf.getParameter<bool>  ("changeToCMSCoordinates") )
-  , theMaxZ      ( iconf.getParameter<double>("maxZ")                   )
-  , theSetSigmaZ ( iconf.getParameter<double>("setSigmaZ")              )
-  , scalerToken_               ( consumes<BeamSpotOnlineCollection>       ( iconf.getParameter<InputTag>("src")       ) )
-  , l1GtEvmReadoutRecordToken_ ( consumes<L1GlobalTriggerEvmReadoutRecord>( iconf.getParameter<InputTag>("gtEvmLabel")) )
-  , theBeamShoutMode ( iconf.getUntrackedParameter<unsigned int> ("beamMode",11) )
-{
-
+    : changeFrame_(iconf.getParameter<bool>("changeToCMSCoordinates")),
+      theMaxZ(iconf.getParameter<double>("maxZ")),
+      theSetSigmaZ(iconf.getParameter<double>("setSigmaZ")),
+      scalerToken_(consumes<BeamSpotOnlineCollection>(iconf.getParameter<InputTag>("src"))),
+      l1GtEvmReadoutRecordToken_(consumes<L1GlobalTriggerEvmReadoutRecord>(iconf.getParameter<InputTag>("gtEvmLabel"))),
+      theBeamShoutMode(iconf.getUntrackedParameter<unsigned int>("beamMode", 11)) {
   theMaxR2 = iconf.getParameter<double>("maxRadius");
-  theMaxR2*=theMaxR2;
+  theMaxR2 *= theMaxR2;
 
   produces<reco::BeamSpot>();
-
-} 
+}
 
 BeamSpotOnlineProducer::~BeamSpotOnlineProducer() {}
 
-void
-BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
+void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //shout MODE only in stable beam
-  bool shoutMODE=false;
+  bool shoutMODE = false;
   edm::Handle<L1GlobalTriggerEvmReadoutRecord> gtEvmReadoutRecord;
-  if (iEvent.getByToken(l1GtEvmReadoutRecordToken_, gtEvmReadoutRecord)){
-    if (gtEvmReadoutRecord->gtfeWord().beamMode() == theBeamShoutMode) shoutMODE=true;
-  }
-  else{
-    shoutMODE=true;
+  if (iEvent.getByToken(l1GtEvmReadoutRecordToken_, gtEvmReadoutRecord)) {
+    if (gtEvmReadoutRecord->gtfeWord().beamMode() == theBeamShoutMode)
+      shoutMODE = true;
+  } else {
+    shoutMODE = true;
   }
 
   // get scalar collection
   Handle<BeamSpotOnlineCollection> handleScaler;
-  iEvent.getByToken( scalerToken_, handleScaler);
+  iEvent.getByToken(scalerToken_, handleScaler);
 
   // beam spot scalar object
   BeamSpotOnline spotOnline;
 
   // product is a reco::BeamSpot object
   auto result = std::make_unique<reco::BeamSpot>();
-  
+
   reco::BeamSpot aSpot;
 
-  bool fallBackToDB=false;
-  if (!handleScaler->empty()){
+  bool fallBackToDB = false;
+  if (!handleScaler->empty()) {
     // get one element
-    spotOnline = * ( handleScaler->begin() );
-    
+    spotOnline = *(handleScaler->begin());
+
     // in case we need to switch to LHC reference frame
     // ignore for the moment rotations, and translations
     double f = 1.;
-    if (changeFrame_) f = -1.;
-    
-    reco::BeamSpot::Point apoint( f* spotOnline.x(), spotOnline.y(), f* spotOnline.z() );
-    
+    if (changeFrame_)
+      f = -1.;
+
+    reco::BeamSpot::Point apoint(f * spotOnline.x(), spotOnline.y(), f * spotOnline.z());
+
     reco::BeamSpot::CovarianceMatrix matrix;
-    matrix(0,0) = spotOnline.err_x()*spotOnline.err_x();
-    matrix(1,1) = spotOnline.err_y()*spotOnline.err_y();
-    matrix(2,2) = spotOnline.err_z()*spotOnline.err_z();
-    matrix(3,3) = spotOnline.err_sigma_z()*spotOnline.err_sigma_z();
-    
+    matrix(0, 0) = spotOnline.err_x() * spotOnline.err_x();
+    matrix(1, 1) = spotOnline.err_y() * spotOnline.err_y();
+    matrix(2, 2) = spotOnline.err_z() * spotOnline.err_z();
+    matrix(3, 3) = spotOnline.err_sigma_z() * spotOnline.err_sigma_z();
+
     double sigmaZ = spotOnline.sigma_z();
-    if (theSetSigmaZ>0)
+    if (theSetSigmaZ > 0)
       sigmaZ = theSetSigmaZ;
-    
-    aSpot = reco::BeamSpot( apoint,
-			    sigmaZ,
-			    spotOnline.dxdz(),
-			    f* spotOnline.dydz(),
-			    spotOnline.width_x(),
-			    matrix);
-    
-    aSpot.setBeamWidthY( spotOnline.width_y() );
-    aSpot.setEmittanceX( 0. );
-    aSpot.setEmittanceY( 0. );
-    aSpot.setbetaStar( 0.) ;
-    aSpot.setType( reco::BeamSpot::LHC ); // flag value from scalars
-    
+
+    aSpot = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
+
+    aSpot.setBeamWidthY(spotOnline.width_y());
+    aSpot.setEmittanceX(0.);
+    aSpot.setEmittanceY(0.);
+    aSpot.setbetaStar(0.);
+    aSpot.setType(reco::BeamSpot::LHC);  // flag value from scalars
+
     // check if we have a valid beam spot fit result from online DQM
-    if ( spotOnline.x() == 0 &&
-	 spotOnline.y() == 0 &&
-	 spotOnline.z() == 0 &&
-	 spotOnline.width_x() == 0 &&
-	 spotOnline.width_y() == 0 ) 
-      {
-	if (shoutMODE){
-	  edm::LogWarning("BeamSpotFromDB") 
-	  << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
-	}
-	fallBackToDB=true;
+    if (spotOnline.x() == 0 && spotOnline.y() == 0 && spotOnline.z() == 0 && spotOnline.width_x() == 0 &&
+        spotOnline.width_y() == 0) {
+      if (shoutMODE) {
+        edm::LogWarning("BeamSpotFromDB")
+            << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
       }
-    double r2=spotOnline.x()*spotOnline.x() + spotOnline.y()*spotOnline.y();
-    if (fabs(spotOnline.z())>=theMaxZ || r2>=theMaxR2){
-      if (shoutMODE){
-	edm::LogError("BeamSpotFromDB") 
-	  << "Online Beam Spot producer falls back to DB value because the scaler values are too big to be true :"
-	  <<spotOnline.x()<<" "<<spotOnline.y()<<" "<<spotOnline.z();
-      }
-      fallBackToDB=true;
+      fallBackToDB = true;
     }
-  }
-  else{
+    double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
+    if (fabs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
+      if (shoutMODE) {
+        edm::LogError("BeamSpotFromDB")
+            << "Online Beam Spot producer falls back to DB value because the scaler values are too big to be true :"
+            << spotOnline.x() << " " << spotOnline.y() << " " << spotOnline.z();
+      }
+      fallBackToDB = true;
+    }
+  } else {
     //empty online beamspot collection: FED data was empty
     //the error should probably have been send at unpacker level
-    fallBackToDB=true;
+    fallBackToDB = true;
   }
-      
-  if (fallBackToDB){
 
-    edm::ESHandle< BeamSpotObjects > beamhandle;
+  if (fallBackToDB) {
+    edm::ESHandle<BeamSpotObjects> beamhandle;
     iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
-    const BeamSpotObjects *spotDB = beamhandle.product();
+    const BeamSpotObjects* spotDB = beamhandle.product();
 
     // translate from BeamSpotObjects to reco::BeamSpot
-    reco::BeamSpot::Point apoint( spotDB->GetX(), spotDB->GetY(), spotDB->GetZ() );
-  
+    reco::BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+
     reco::BeamSpot::CovarianceMatrix matrix;
-    for ( int i=0; i<7; ++i ) {
-      for ( int j=0; j<7; ++j ) {
-	matrix(i,j) = spotDB->GetCovariance(i,j);
+    for (int i = 0; i < 7; ++i) {
+      for (int j = 0; j < 7; ++j) {
+        matrix(i, j) = spotDB->GetCovariance(i, j);
       }
     }
-  
-    // this assume beam width same in x and y
-    aSpot = reco::BeamSpot( apoint,
-			    spotDB->GetSigmaZ(),
-			    spotDB->Getdxdz(),
-			    spotDB->Getdydz(),
-			    spotDB->GetBeamWidthX(),
-			    matrix );
-    aSpot.setBeamWidthY( spotDB->GetBeamWidthY() );
-    aSpot.setEmittanceX( spotDB->GetEmittanceX() );
-    aSpot.setEmittanceY( spotDB->GetEmittanceY() );
-    aSpot.setbetaStar( spotDB->GetBetaStar() );
-    aSpot.setType( reco::BeamSpot::Tracker );
 
+    // this assume beam width same in x and y
+    aSpot = reco::BeamSpot(
+        apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+    aSpot.setBeamWidthY(spotDB->GetBeamWidthY());
+    aSpot.setEmittanceX(spotDB->GetEmittanceX());
+    aSpot.setEmittanceY(spotDB->GetEmittanceY());
+    aSpot.setbetaStar(spotDB->GetBetaStar());
+    aSpot.setType(reco::BeamSpot::Tracker);
   }
-  
+
   *result = aSpot;
 
   iEvent.put(std::move(result));
-
 }
 
 DEFINE_FWK_MODULE(BeamSpotOnlineProducer);

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotProducer.cc
@@ -17,16 +17,13 @@
 // constructors and destructor
 //
 BeamSpotProducer::BeamSpotProducer(const edm::ParameterSet& iConf) {
-	
-	edm::LogInfo("RecoVertex/BeamSpotProducer") 
-		<< "Initializing Beam Spot producer " << "\n";
-  
-	//fVerbose=conf.getUntrackedParameter<bool>("verbose", false);
-	
-	produces<reco::BeamSpot>();
+  edm::LogInfo("RecoVertex/BeamSpotProducer") << "Initializing Beam Spot producer "
+                                              << "\n";
 
+  //fVerbose=conf.getUntrackedParameter<bool>("verbose", false);
+
+  produces<reco::BeamSpot>();
 }
-
 
 BeamSpotProducer::~BeamSpotProducer() {}
 
@@ -35,65 +32,54 @@ BeamSpotProducer::~BeamSpotProducer() {}
 //
 
 // ------------ method called to produce the data  ------------
-void
-BeamSpotProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-	
-	using namespace edm;
+void BeamSpotProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-	auto result = std::make_unique<reco::BeamSpot>();
+  auto result = std::make_unique<reco::BeamSpot>();
 
-	reco::BeamSpot aSpot;
+  reco::BeamSpot aSpot;
 
-	
-	//typedef math::XYZPoint Point;
-    //enum { dimension = 7 };
-    //typedef math::Error<dimension>::type CovarianceMatrix;
+  //typedef math::XYZPoint Point;
+  //enum { dimension = 7 };
+  //typedef math::Error<dimension>::type CovarianceMatrix;
 
-	
-	//try {
-	edm::LogInfo("RecoVertex/BeamSpotProducer") 
-	  << "Reconstructing event number: " << iEvent.id() << "\n";
+  //try {
+  edm::LogInfo("RecoVertex/BeamSpotProducer") << "Reconstructing event number: " << iEvent.id() << "\n";
 
-	edm::ESHandle< BeamSpotObjects > beamhandle;
-	iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
-	const BeamSpotObjects *spotDB = beamhandle.product();
+  edm::ESHandle<BeamSpotObjects> beamhandle;
+  iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
+  const BeamSpotObjects* spotDB = beamhandle.product();
 
-	// translate from BeamSpotObjects to reco::BeamSpot
-	reco::BeamSpot::Point apoint( spotDB->GetX(), spotDB->GetY(), spotDB->GetZ() );
-		
-	reco::BeamSpot::CovarianceMatrix matrix;
-	for ( int i=0; i<7; ++i ) {
-	  for ( int j=0; j<7; ++j ) {
-	    matrix(i,j) = spotDB->GetCovariance(i,j);
-	  }
-	}
-	
-	// this assume beam width same in x and y
-	aSpot = reco::BeamSpot( apoint,
-				spotDB->GetSigmaZ(),
-				spotDB->Getdxdz(),
-				spotDB->Getdydz(),
-				spotDB->GetBeamWidthX(),
-				matrix );
-	aSpot.setBeamWidthY( spotDB->GetBeamWidthY() );
-	aSpot.setEmittanceX( spotDB->GetEmittanceX() );
-	aSpot.setEmittanceY( spotDB->GetEmittanceY() );
-	aSpot.setbetaStar( spotDB->GetBetaStar() );
-		
-	//}
-	//
-	//catch (std::exception & err) {
-	//	edm::LogInfo("RecoVertex/BeamSpotProducer") 
-	//		<< "Exception during event number: " << iEvent.id() 
-	//		<< "\n" << err.what() << "\n";
-	//}
+  // translate from BeamSpotObjects to reco::BeamSpot
+  reco::BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
 
-	*result = aSpot;
-	
-	iEvent.put(std::move(result));
-	
+  reco::BeamSpot::CovarianceMatrix matrix;
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      matrix(i, j) = spotDB->GetCovariance(i, j);
+    }
+  }
+
+  // this assume beam width same in x and y
+  aSpot = reco::BeamSpot(
+      apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+  aSpot.setBeamWidthY(spotDB->GetBeamWidthY());
+  aSpot.setEmittanceX(spotDB->GetEmittanceX());
+  aSpot.setEmittanceY(spotDB->GetEmittanceY());
+  aSpot.setbetaStar(spotDB->GetBetaStar());
+
+  //}
+  //
+  //catch (std::exception & err) {
+  //	edm::LogInfo("RecoVertex/BeamSpotProducer")
+  //		<< "Exception during event number: " << iEvent.id()
+  //		<< "\n" << err.what() << "\n";
+  //}
+
+  *result = aSpot;
+
+  iEvent.put(std::move(result));
 }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(BeamSpotProducer);
-

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotWrite2DB.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotWrite2DB.cc
@@ -9,7 +9,6 @@
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -24,39 +23,22 @@ ________________________________________________________________**/
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 
-BeamSpotWrite2DB::BeamSpotWrite2DB(const edm::ParameterSet& iConfig)
-{
-
+BeamSpotWrite2DB::BeamSpotWrite2DB(const edm::ParameterSet& iConfig) {
   fasciiFileName = iConfig.getUntrackedParameter<std::string>("OutputFileName");
-  
+
   fasciiFile.open(fasciiFileName.c_str());
-  
 }
 
+BeamSpotWrite2DB::~BeamSpotWrite2DB() {}
 
-BeamSpotWrite2DB::~BeamSpotWrite2DB()
-{
-}
+void BeamSpotWrite2DB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}
 
+void BeamSpotWrite2DB::beginJob() {}
 
-void
-BeamSpotWrite2DB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-}
-
-
-
-void 
-BeamSpotWrite2DB::beginJob()
-{
-}
-
-void 
-BeamSpotWrite2DB::endJob() {
-
-	std::cout << " Read beam spot data from text file: " << fasciiFileName << std::endl;
-	std::cout << " please see plugins/BeamSpotWrite2DB.cc for format of text file." << std::endl;
-	/*
+void BeamSpotWrite2DB::endJob() {
+  std::cout << " Read beam spot data from text file: " << fasciiFileName << std::endl;
+  std::cout << " please see plugins/BeamSpotWrite2DB.cc for format of text file." << std::endl;
+  /*
 	std::cout << " Content of the file is expected to have this format with the first column as a keyword:" << std::endl;
 	std::cout << " x\n y\n z\n sigmaZ\n dxdz\n dydz\n beamWidthX\n beamWidthY" << std::endl;
 	for (int i =0; i<7; i++) {
@@ -66,71 +48,68 @@ BeamSpotWrite2DB::endJob() {
 		}
 	}
 	*/
-	
-	// extract from file
-	double x,y,z,sigmaZ,dxdz,dydz,beamWidthX,beamWidthY,emittanceX,emittanceY,betastar;
-	std::string tag;
-	double cov[7][7];
-	int type;
 
-	fasciiFile >> tag >> type;
-	fasciiFile >> tag >> x;
-	fasciiFile >> tag >> y;
-	fasciiFile >> tag >> z;
-	fasciiFile >> tag >> sigmaZ;
-	fasciiFile >> tag >> dxdz;
-	fasciiFile >> tag >> dydz;
-	fasciiFile >> tag >> beamWidthX;
-	fasciiFile >> tag >> beamWidthY;
-	fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2]>> cov[0][3] >> cov[0][4]>> cov[0][5] >> cov[0][6];
-	fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3]>> cov[1][4] >> cov[1][5]>> cov[1][6];
-	fasciiFile >> tag >> cov[2][0]  >> cov[2][1] >> cov[2][2] >> cov[2][3]>> cov[2][4] >> cov[2][5]>> cov[2][6];
-	fasciiFile >> tag >> cov[3][0]  >> cov[3][1] >> cov[3][2] >> cov[3][3]>> cov[3][4] >> cov[3][5]>> cov[3][6];
-	fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3]>> cov[4][4] >> cov[4][5]>> cov[4][6];
-	fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3]>> cov[5][4] >> cov[5][5]>> cov[5][6];
-	fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3]>> cov[6][4] >> cov[6][5]>> cov[6][6];
-	fasciiFile >> tag >> emittanceX;
-	fasciiFile >> tag >> emittanceY;
-	fasciiFile >> tag >> betastar;
-	
-	BeamSpotObjects *abeam = new BeamSpotObjects();
-	
-	abeam->SetType(type);
-	abeam->SetPosition(x,y,z);
-	abeam->SetSigmaZ(sigmaZ);
-	abeam->Setdxdz(dxdz);
-	abeam->Setdydz(dydz);
-	abeam->SetBeamWidthX(beamWidthX);
-	abeam->SetBeamWidthY(beamWidthY);
-	abeam->SetEmittanceX( emittanceX );
-	abeam->SetEmittanceY( emittanceY );
-	abeam->SetBetaStar( betastar );
-	
-	for (int i=0; i<7; ++i) {
-	  for (int j=0; j<7; ++j) {
-	    abeam->SetCovariance(i,j,cov[i][j]);
-	  }
-	}
+  // extract from file
+  double x, y, z, sigmaZ, dxdz, dydz, beamWidthX, beamWidthY, emittanceX, emittanceY, betastar;
+  std::string tag;
+  double cov[7][7];
+  int type;
 
-	std::cout << " write results to DB..." << std::endl;
+  fasciiFile >> tag >> type;
+  fasciiFile >> tag >> x;
+  fasciiFile >> tag >> y;
+  fasciiFile >> tag >> z;
+  fasciiFile >> tag >> sigmaZ;
+  fasciiFile >> tag >> dxdz;
+  fasciiFile >> tag >> dydz;
+  fasciiFile >> tag >> beamWidthX;
+  fasciiFile >> tag >> beamWidthY;
+  fasciiFile >> tag >> cov[0][0] >> cov[0][1] >> cov[0][2] >> cov[0][3] >> cov[0][4] >> cov[0][5] >> cov[0][6];
+  fasciiFile >> tag >> cov[1][0] >> cov[1][1] >> cov[1][2] >> cov[1][3] >> cov[1][4] >> cov[1][5] >> cov[1][6];
+  fasciiFile >> tag >> cov[2][0] >> cov[2][1] >> cov[2][2] >> cov[2][3] >> cov[2][4] >> cov[2][5] >> cov[2][6];
+  fasciiFile >> tag >> cov[3][0] >> cov[3][1] >> cov[3][2] >> cov[3][3] >> cov[3][4] >> cov[3][5] >> cov[3][6];
+  fasciiFile >> tag >> cov[4][0] >> cov[4][1] >> cov[4][2] >> cov[4][3] >> cov[4][4] >> cov[4][5] >> cov[4][6];
+  fasciiFile >> tag >> cov[5][0] >> cov[5][1] >> cov[5][2] >> cov[5][3] >> cov[5][4] >> cov[5][5] >> cov[5][6];
+  fasciiFile >> tag >> cov[6][0] >> cov[6][1] >> cov[6][2] >> cov[6][3] >> cov[6][4] >> cov[6][5] >> cov[6][6];
+  fasciiFile >> tag >> emittanceX;
+  fasciiFile >> tag >> emittanceY;
+  fasciiFile >> tag >> betastar;
 
-	edm::Service<cond::service::PoolDBOutputService> poolDbService;
-	if( poolDbService.isAvailable() ) {
-	  std::cout << "poolDBService available"<<std::endl;
-	  if ( poolDbService->isNewTagRequest( "BeamSpotObjectsRcd" ) ) {
-	    std::cout << "new tag requested" << std::endl;
-	    poolDbService->createNewIOV<BeamSpotObjects>( abeam, poolDbService->beginOfTime(),poolDbService->endOfTime(),
-								  "BeamSpotObjectsRcd"  );
-	  }
-	  else {
-	    std::cout << "no new tag requested" << std::endl;
-	    poolDbService->appendSinceTime<BeamSpotObjects>( abeam, poolDbService->currentTime(),
-							     "BeamSpotObjectsRcd" );
-	  }
-	  
-	}
+  BeamSpotObjects* abeam = new BeamSpotObjects();
 
-	std::cout << "[BeamSpotWrite2DB] endJob done \n" << std::endl;
+  abeam->SetType(type);
+  abeam->SetPosition(x, y, z);
+  abeam->SetSigmaZ(sigmaZ);
+  abeam->Setdxdz(dxdz);
+  abeam->Setdydz(dydz);
+  abeam->SetBeamWidthX(beamWidthX);
+  abeam->SetBeamWidthY(beamWidthY);
+  abeam->SetEmittanceX(emittanceX);
+  abeam->SetEmittanceY(emittanceY);
+  abeam->SetBetaStar(betastar);
+
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      abeam->SetCovariance(i, j, cov[i][j]);
+    }
+  }
+
+  std::cout << " write results to DB..." << std::endl;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    std::cout << "poolDBService available" << std::endl;
+    if (poolDbService->isNewTagRequest("BeamSpotObjectsRcd")) {
+      std::cout << "new tag requested" << std::endl;
+      poolDbService->createNewIOV<BeamSpotObjects>(
+          abeam, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotObjectsRcd");
+    } else {
+      std::cout << "no new tag requested" << std::endl;
+      poolDbService->appendSinceTime<BeamSpotObjects>(abeam, poolDbService->currentTime(), "BeamSpotObjectsRcd");
+    }
+  }
+
+  std::cout << "[BeamSpotWrite2DB] endJob done \n" << std::endl;
 }
 
 //define this as a plug-in

--- a/RecoVertex/BeamSpotProducer/src/BSFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSFitter.cc
@@ -10,7 +10,6 @@
 
 ________________________________________________________________**/
 
-
 #include "Minuit2/VariableMetricMinimizer.h"
 #include "Minuit2/FunctionMinimum.h"
 #include "Minuit2/MnPrint.h"
@@ -38,280 +37,255 @@ ________________________________________________________________**/
 
 using namespace ROOT::Minuit2;
 
-
 //_____________________________________________________________________
 BSFitter::BSFitter() {
-	fbeamtype = reco::BeamSpot::Unknown;
+  fbeamtype = reco::BeamSpot::Unknown;
 
- 	//In order to make fitting ROOT histograms thread safe
- 	// one must call this undocumented function
-	TMinuitMinimizer::UseStaticMinuit(false);
+  //In order to make fitting ROOT histograms thread safe
+  // one must call this undocumented function
+  TMinuitMinimizer::UseStaticMinuit(false);
 }
 
 //_____________________________________________________________________
-BSFitter::BSFitter( const std:: vector< BSTrkParameters > &BSvector ) {
- 	//In order to make fitting ROOT histograms thread safe
- 	// one must call this undocumented function
- 	TMinuitMinimizer::UseStaticMinuit(false);
+BSFitter::BSFitter(const std::vector<BSTrkParameters> &BSvector) {
+  //In order to make fitting ROOT histograms thread safe
+  // one must call this undocumented function
+  TMinuitMinimizer::UseStaticMinuit(false);
 
-	ffit_type = "default";
-	ffit_variable = "default";
+  ffit_type = "default";
+  ffit_variable = "default";
 
-	fBSvector = BSvector;
+  fBSvector = BSvector;
 
-	fsqrt2pi = sqrt(2.* TMath::Pi());
+  fsqrt2pi = sqrt(2. * TMath::Pi());
 
-	fpar_name[0] = "z0        ";
-	fpar_name[1] = "SigmaZ0   ";
-	fpar_name[2] = "X0        ";
-	fpar_name[3] = "Y0        ";
-	fpar_name[4] = "dxdz      ";
-	fpar_name[5] = "dydz      ";
-	fpar_name[6] = "SigmaBeam ";
+  fpar_name[0] = "z0        ";
+  fpar_name[1] = "SigmaZ0   ";
+  fpar_name[2] = "X0        ";
+  fpar_name[3] = "Y0        ";
+  fpar_name[4] = "dxdz      ";
+  fpar_name[5] = "dydz      ";
+  fpar_name[6] = "SigmaBeam ";
 
-	//if (theGausszFcn == 0 ) {
-	thePDF = new BSpdfsFcn();
+  //if (theGausszFcn == 0 ) {
+  thePDF = new BSpdfsFcn();
 
+  //}
+  //if (theFitter == 0 ) {
 
-//}
-		//if (theFitter == 0 ) {
+  theFitter = new VariableMetricMinimizer();
 
-	theFitter    = new VariableMetricMinimizer();
+  //}
 
-		//}
+  fapplyd0cut = false;
+  fapplychi2cut = false;
+  ftmprow = 0;
+  ftmp.ResizeTo(4, 1);
+  ftmp.Zero();
+  fnthite = 0;
+  fMaxZ = 50.;         //cm
+  fconvergence = 0.5;  // stop fit when 50% of the input collection has been removed.
+  fminNtrks = 100;
+  finputBeamWidth = -1;  // no input
 
-	fapplyd0cut = false;
-	fapplychi2cut = false;
-	ftmprow = 0;
-	ftmp.ResizeTo(4,1);
-	ftmp.Zero();
-	fnthite=0;
-	fMaxZ = 50.; //cm
-	fconvergence = 0.5; // stop fit when 50% of the input collection has been removed.
-	fminNtrks = 100;
-	finputBeamWidth = -1; // no input
-
-    h1z = new TH1F("h1z","z distribution",200,-fMaxZ, fMaxZ);
-
+  h1z = new TH1F("h1z", "z distribution", 200, -fMaxZ, fMaxZ);
 }
 
 //______________________________________________________________________
-BSFitter::~BSFitter()
-{
-	//delete fBSvector;
-	delete thePDF;
-	delete theFitter;
+BSFitter::~BSFitter() {
+  //delete fBSvector;
+  delete thePDF;
+  delete theFitter;
 }
-
 
 //______________________________________________________________________
-reco::BeamSpot BSFitter::Fit() {
-
-	return this->Fit(nullptr);
-
-}
+reco::BeamSpot BSFitter::Fit() { return this->Fit(nullptr); }
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit(double *inipar = nullptr) {
-	fbeamtype = reco::BeamSpot::Unknown;
-	if ( ffit_variable == "z" ) {
+  fbeamtype = reco::BeamSpot::Unknown;
+  if (ffit_variable == "z") {
+    if (ffit_type == "chi2") {
+      return Fit_z_chi2(inipar);
 
-		if ( ffit_type == "chi2" ) {
+    } else if (ffit_type == "likelihood") {
+      return Fit_z_likelihood(inipar);
 
-			return Fit_z_chi2(inipar);
+    } else if (ffit_type == "combined") {
+      reco::BeamSpot tmp_beamspot = Fit_z_chi2(inipar);
+      double tmp_par[2] = {tmp_beamspot.z0(), tmp_beamspot.sigmaZ()};
+      return Fit_z_likelihood(tmp_par);
 
-		} else if ( ffit_type == "likelihood" ) {
+    } else {
+      throw cms::Exception("LogicError")
+          << "Error in BeamSpotProducer/BSFitter: "
+          << "Illegal fit type, options are chi2,likelihood or combined(ie. first chi2 then likelihood)";
+    }
+  } else if (ffit_variable == "d") {
+    if (ffit_type == "d0phi") {
+      this->d0phi_Init();
+      return Fit_d0phi();
 
-			return Fit_z_likelihood(inipar);
+    } else if (ffit_type == "likelihood") {
+      return Fit_d_likelihood(inipar);
 
-		} else if ( ffit_type == "combined" ) {
+    } else if (ffit_type == "combined") {
+      this->d0phi_Init();
+      reco::BeamSpot tmp_beamspot = Fit_d0phi();
+      double tmp_par[4] = {tmp_beamspot.x0(), tmp_beamspot.y0(), tmp_beamspot.dxdz(), tmp_beamspot.dydz()};
+      return Fit_d_likelihood(tmp_par);
 
-			reco::BeamSpot tmp_beamspot = Fit_z_chi2(inipar);
-			double tmp_par[2] = {tmp_beamspot.z0(), tmp_beamspot.sigmaZ()};
-			return Fit_z_likelihood(tmp_par);
+    } else {
+      throw cms::Exception("LogicError") << "Error in BeamSpotProducer/BSFitter: "
+                                         << "Illegal fit type, options are d0phi, likelihood or combined";
+    }
+  } else if (ffit_variable == "d*z" || ffit_variable == "default") {
+    if (ffit_type == "likelihood" || ffit_type == "default") {
+      reco::BeamSpot::CovarianceMatrix matrix;
+      // we are now fitting Z inside d0phi fitter
+      // first fit z distribution using a chi2 fit
+      //reco::BeamSpot tmp_z = Fit_z_chi2(inipar);
+      //for (int j = 2 ; j < 4 ; ++j) {
+      //for(int k = j ; k < 4 ; ++k) {
+      //	matrix(j,k) = tmp_z.covariance()(j,k);
+      //}
+      //}
 
-		} else {
+      // use d0-phi algorithm to extract transverse position
+      this->d0phi_Init();
+      //reco::BeamSpot tmp_d0phi= Fit_d0phi(); // change to iterative procedure:
+      this->Setd0Cut_d0phi(4.0);
+      reco::BeamSpot tmp_d0phi = Fit_ited0phi();
 
-			throw cms::Exception("LogicError")
-			<< "Error in BeamSpotProducer/BSFitter: "
-			<< "Illegal fit type, options are chi2,likelihood or combined(ie. first chi2 then likelihood)";
+      //for (int j = 0 ; j < 2 ; ++j) {
+      //	for(int k = j ; k < 2 ; ++k) {
+      //		matrix(j,k) = tmp_d0phi.covariance()(j,k);
+      //}
+      //}
+      // slopes
+      //for (int j = 4 ; j < 6 ; ++j) {
+      // for(int k = j ; k < 6 ; ++k) {
+      //  matrix(j,k) = tmp_d0phi.covariance()(j,k);
+      //  }
+      //}
 
-		}
-	} else if ( ffit_variable == "d" ) {
+      // put everything into one object
+      reco::BeamSpot spot(reco::BeamSpot::Point(tmp_d0phi.x0(), tmp_d0phi.y0(), tmp_d0phi.z0()),
+                          tmp_d0phi.sigmaZ(),
+                          tmp_d0phi.dxdz(),
+                          tmp_d0phi.dydz(),
+                          0.,
+                          tmp_d0phi.covariance(),
+                          fbeamtype);
 
-		if ( ffit_type == "d0phi" ) {
-			this->d0phi_Init();
-			return Fit_d0phi();
+      //reco::BeamSpot tmp_z = Fit_z_chi2(inipar);
 
-		} else if ( ffit_type == "likelihood" ) {
+      //reco::BeamSpot tmp_d0phi = Fit_d0phi();
 
-			return Fit_d_likelihood(inipar);
+      // log-likelihood fit
+      if (ffit_type == "likelihood") {
+        double tmp_par[7] = {
+            tmp_d0phi.x0(), tmp_d0phi.y0(), tmp_d0phi.z0(), tmp_d0phi.sigmaZ(), tmp_d0phi.dxdz(), tmp_d0phi.dydz(), 0.0};
 
-		} else if ( ffit_type == "combined" ) {
+        double tmp_error_par[7];
+        for (int s = 0; s < 6; s++) {
+          tmp_error_par[s] = pow(tmp_d0phi.covariance()(s, s), 0.5);
+        }
+        tmp_error_par[6] = 0.0;
 
-			this->d0phi_Init();
-			reco::BeamSpot tmp_beamspot = Fit_d0phi();
-			double tmp_par[4] = {tmp_beamspot.x0(), tmp_beamspot.y0(), tmp_beamspot.dxdz(), tmp_beamspot.dydz()};
-			return Fit_d_likelihood(tmp_par);
+        reco::BeamSpot tmp_lh = Fit_d_z_likelihood(tmp_par, tmp_error_par);
 
-		} else {
-			throw cms::Exception("LogicError")
-				<< "Error in BeamSpotProducer/BSFitter: "
-				<< "Illegal fit type, options are d0phi, likelihood or combined";
-		}
-	} else if ( ffit_variable == "d*z" || ffit_variable == "default" ) {
+        if (edm::isNotFinite(ff_minimum)) {
+          edm::LogWarning("BSFitter")
+              << "BSFitter: Result is non physical. Log-Likelihood fit to extract beam width did not converge."
+              << std::endl;
+          tmp_lh.setType(reco::BeamSpot::Unknown);
+          return tmp_lh;
+        }
+        return tmp_lh;
 
-		if ( ffit_type == "likelihood" || ffit_type == "default" ) {
+      } else {
+        edm::LogInfo("BSFitter") << "default track-based fit does not extract beam width." << std::endl;
+        return spot;
+      }
 
-			reco::BeamSpot::CovarianceMatrix matrix;
-            // we are now fitting Z inside d0phi fitter
-			// first fit z distribution using a chi2 fit
-			//reco::BeamSpot tmp_z = Fit_z_chi2(inipar);
-			//for (int j = 2 ; j < 4 ; ++j) {
-            //for(int k = j ; k < 4 ; ++k) {
-            //	matrix(j,k) = tmp_z.covariance()(j,k);
-            //}
-			//}
+    } else if (ffit_type == "resolution") {
+      reco::BeamSpot tmp_z = Fit_z_chi2(inipar);
+      this->d0phi_Init();
+      reco::BeamSpot tmp_d0phi = Fit_d0phi();
 
-			// use d0-phi algorithm to extract transverse position
-			this->d0phi_Init();
-			//reco::BeamSpot tmp_d0phi= Fit_d0phi(); // change to iterative procedure:
-			this->Setd0Cut_d0phi(4.0);
-			reco::BeamSpot tmp_d0phi= Fit_ited0phi();
+      double tmp_par[7] = {
+          tmp_d0phi.x0(), tmp_d0phi.y0(), tmp_z.z0(), tmp_z.sigmaZ(), tmp_d0phi.dxdz(), tmp_d0phi.dydz(), 0.0};
+      double tmp_error_par[7];
+      for (int s = 0; s < 6; s++) {
+        tmp_error_par[s] = pow(tmp_par[s], 0.5);
+      }
+      tmp_error_par[6] = 0.0;
 
-			//for (int j = 0 ; j < 2 ; ++j) {
-			//	for(int k = j ; k < 2 ; ++k) {
-			//		matrix(j,k) = tmp_d0phi.covariance()(j,k);
-            //}
-			//}
-			// slopes
-			//for (int j = 4 ; j < 6 ; ++j) {
-            // for(int k = j ; k < 6 ; ++k) {
-            //  matrix(j,k) = tmp_d0phi.covariance()(j,k);
-			//  }
-			//}
+      reco::BeamSpot tmp_beam = Fit_d_z_likelihood(tmp_par, tmp_error_par);
 
+      double tmp_par2[7] = {tmp_beam.x0(),
+                            tmp_beam.y0(),
+                            tmp_beam.z0(),
+                            tmp_beam.sigmaZ(),
+                            tmp_beam.dxdz(),
+                            tmp_beam.dydz(),
+                            tmp_beam.BeamWidthX()};
 
-			// put everything into one object
-			reco::BeamSpot spot(reco::BeamSpot::Point(tmp_d0phi.x0(), tmp_d0phi.y0(), tmp_d0phi.z0()),
-								tmp_d0phi.sigmaZ(),
-								tmp_d0phi.dxdz(),
-								tmp_d0phi.dydz(),
-								0.,
-								tmp_d0phi.covariance(),
-								fbeamtype );
+      reco::BeamSpot tmp_lh = Fit_dres_z_likelihood(tmp_par2);
 
+      if (edm::isNotFinite(ff_minimum)) {
+        edm::LogWarning("BSFitter") << "Result is non physical. Log-Likelihood fit did not converge." << std::endl;
+        tmp_lh.setType(reco::BeamSpot::Unknown);
+        return tmp_lh;
+      }
+      return tmp_lh;
 
-
-			//reco::BeamSpot tmp_z = Fit_z_chi2(inipar);
-
-			//reco::BeamSpot tmp_d0phi = Fit_d0phi();
-
-            // log-likelihood fit
-			if (ffit_type == "likelihood") {
-                double tmp_par[7] = {tmp_d0phi.x0(), tmp_d0phi.y0(), tmp_d0phi.z0(),
-                                     tmp_d0phi.sigmaZ(), tmp_d0phi.dxdz(), tmp_d0phi.dydz(),0.0};
-
-                double tmp_error_par[7];
-                for(int s=0;s<6;s++){ tmp_error_par[s] = pow( tmp_d0phi.covariance()(s,s),0.5);}
-                tmp_error_par[6]=0.0;
-
-                reco::BeamSpot tmp_lh = Fit_d_z_likelihood(tmp_par,tmp_error_par);
-
-                if (edm::isNotFinite(ff_minimum)) {
-                    edm::LogWarning("BSFitter") << "BSFitter: Result is non physical. Log-Likelihood fit to extract beam width did not converge." << std::endl;
-                    tmp_lh.setType(reco::BeamSpot::Unknown);
-                    return tmp_lh;
-                }
-                return tmp_lh;
-
-			} else {
-
-                edm::LogInfo("BSFitter") << "default track-based fit does not extract beam width." << std::endl;
-				return spot;
-            }
-
-
-		} else if ( ffit_type == "resolution" ) {
-
-			reco::BeamSpot tmp_z = Fit_z_chi2(inipar);
-			this->d0phi_Init();
-			reco::BeamSpot tmp_d0phi = Fit_d0phi();
-
-			double tmp_par[7] = {tmp_d0phi.x0(), tmp_d0phi.y0(), tmp_z.z0(),
-								 tmp_z.sigmaZ(), tmp_d0phi.dxdz(), tmp_d0phi.dydz(),0.0};
-            double tmp_error_par[7];
-            for(int s=0;s<6;s++){ tmp_error_par[s] = pow(tmp_par[s],0.5);}
-            tmp_error_par[6]=0.0;
-
-			reco::BeamSpot tmp_beam = Fit_d_z_likelihood(tmp_par,tmp_error_par);
-
-			double tmp_par2[7] = {tmp_beam.x0(), tmp_beam.y0(), tmp_beam.z0(),
-								 tmp_beam.sigmaZ(), tmp_beam.dxdz(), tmp_beam.dydz(),
-								 tmp_beam.BeamWidthX()};
-
-			reco::BeamSpot tmp_lh = Fit_dres_z_likelihood(tmp_par2);
-
-			if (edm::isNotFinite(ff_minimum)) {
-
-                edm::LogWarning("BSFitter") << "Result is non physical. Log-Likelihood fit did not converge." << std::endl;
-				tmp_lh.setType(reco::BeamSpot::Unknown);
-				return tmp_lh;
-			}
-			return tmp_lh;
-
-		} else {
-
-			throw cms::Exception("LogicError")
-				<< "Error in BeamSpotProducer/BSFitter: "
-				<< "Illegal fit type, options are likelihood or resolution";
-		}
-	} else {
-
-		throw cms::Exception("LogicError")
-			<< "Error in BeamSpotProducer/BSFitter: "
-			<< "Illegal variable type, options are \"z\", \"d\", or \"d*z\"";
-	}
-
-
+    } else {
+      throw cms::Exception("LogicError") << "Error in BeamSpotProducer/BSFitter: "
+                                         << "Illegal fit type, options are likelihood or resolution";
+    }
+  } else {
+    throw cms::Exception("LogicError") << "Error in BeamSpotProducer/BSFitter: "
+                                       << "Illegal variable type, options are \"z\", \"d\", or \"d*z\"";
+  }
 }
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit_z_likelihood(double *inipar) {
+  //std::cout << "Fit_z(double *) called" << std::endl;
+  //std::cout << "inipar[0]= " << inipar[0] << std::endl;
+  //std::cout << "inipar[1]= " << inipar[1] << std::endl;
 
-	//std::cout << "Fit_z(double *) called" << std::endl;
-	//std::cout << "inipar[0]= " << inipar[0] << std::endl;
-	//std::cout << "inipar[1]= " << inipar[1] << std::endl;
+  std::vector<double> par(2, 0);
+  std::vector<double> err(2, 0);
 
-	std::vector<double> par(2,0);
-	std::vector<double> err(2,0);
+  par.push_back(0.0);
+  par.push_back(7.0);
+  err.push_back(0.0001);
+  err.push_back(0.0001);
+  //par[0] = 0.0; err[0] = 0.0;
+  //par[1] = 7.0; err[1] = 0.0;
 
-	par.push_back(0.0);
-	par.push_back(7.0);
-	err.push_back(0.0001);
-	err.push_back(0.0001);
-	//par[0] = 0.0; err[0] = 0.0;
-	//par[1] = 7.0; err[1] = 0.0;
+  thePDF->SetPDFs("PDFGauss_z");
+  thePDF->SetData(fBSvector);
+  //std::cout << "data loaded"<< std::endl;
 
-	thePDF->SetPDFs("PDFGauss_z");
-	thePDF->SetData(fBSvector);
-	//std::cout << "data loaded"<< std::endl;
+  //FunctionMinimum fmin = theFitter->Minimize(*theGausszFcn, par, err, 1, 500, 0.1);
+  MnUserParameters upar;
+  upar.Add("X0", 0., 0.);
+  upar.Add("Y0", 0., 0.);
+  upar.Add("Z0", inipar[0], 0.001);
+  upar.Add("sigmaZ", inipar[1], 0.001);
 
-	//FunctionMinimum fmin = theFitter->Minimize(*theGausszFcn, par, err, 1, 500, 0.1);
-	MnUserParameters upar;
-	upar.Add("X0",    0.,0.);
-	upar.Add("Y0",    0.,0.);
-	upar.Add("Z0",    inipar[0],0.001);
-	upar.Add("sigmaZ",inipar[1],0.001);
+  MnMigrad migrad(*thePDF, upar);
 
-	MnMigrad migrad(*thePDF, upar);
+  FunctionMinimum fmin = migrad();
+  ff_minimum = fmin.Fval();
+  //std::cout << " eval= " << ff_minimum
+  //		  << "/n params[0]= " << fmin.Parameters().Vec()(0) << std::endl;
 
-	FunctionMinimum fmin = migrad();
-	ff_minimum = fmin.Fval();
-	//std::cout << " eval= " << ff_minimum
-	//		  << "/n params[0]= " << fmin.Parameters().Vec()(0) << std::endl;
-
-	/*
+  /*
 	TMinuit *gmMinuit = new TMinuit(2);
 
 	//gmMinuit->SetFCN(z_fcn);
@@ -326,628 +300,566 @@ reco::BeamSpot BSFitter::Fit_z_likelihood(double *inipar) {
 	}
 	gmMinuit->Migrad();
 	*/
-	reco::BeamSpot::CovarianceMatrix matrix;
+  reco::BeamSpot::CovarianceMatrix matrix;
 
-	for (int j = 2 ; j < 4 ; ++j) {
-		for(int k = j ; k < 4 ; ++k) {
-		  matrix(j,k) = fmin.Error().Matrix()(j,k);
-		}
-	}
+  for (int j = 2; j < 4; ++j) {
+    for (int k = j; k < 4; ++k) {
+      matrix(j, k) = fmin.Error().Matrix()(j, k);
+    }
+  }
 
-	return reco::BeamSpot( reco::BeamSpot::Point(0.,
-						     0.,
-						     fmin.Parameters().Vec()(2)),
-			       fmin.Parameters().Vec()(3),
-			       0.,
-			       0.,
-			       0.,
-			       matrix,
-			       fbeamtype );
+  return reco::BeamSpot(reco::BeamSpot::Point(0., 0., fmin.Parameters().Vec()(2)),
+                        fmin.Parameters().Vec()(3),
+                        0.,
+                        0.,
+                        0.,
+                        matrix,
+                        fbeamtype);
 }
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit_z_chi2(double *inipar) {
+  // N.B. this fit is not performed anymore but now
+  // Z is fitted in the same track set used in the d0-phi fit after
+  // each iteration
 
-    // N.B. this fit is not performed anymore but now
-    // Z is fitted in the same track set used in the d0-phi fit after
-    // each iteration
+  //std::cout << "Fit_z_chi2() called" << std::endl;
+  // FIXME: include whole tracker z length for the time being
+  // ==> add protection and z0 cut
+  h1z = new TH1F("h1z", "z distribution", 200, -fMaxZ, fMaxZ);
 
+  std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin();
 
-	//std::cout << "Fit_z_chi2() called" << std::endl;
-        // FIXME: include whole tracker z length for the time being
-        // ==> add protection and z0 cut
-	h1z = new TH1F("h1z","z distribution",200,-fMaxZ, fMaxZ);
+  // HERE check size of track vector
 
-	std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin();
+  for (iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+    h1z->Fill(iparam->z0());
+    //std::cout<<"z0="<<iparam->z0()<<"; sigZ0="<<iparam->sigz0()<<std::endl;
+  }
 
-	// HERE check size of track vector
+  //Use our own copy for thread safety
+  // also do not add to global list of functions
+  TF1 fgaus("fgaus", "gaus", 0., 1., TF1::EAddToList::kNo);
+  h1z->Fit(&fgaus, "QLMN0 SERIAL");
+  //std::cout << "fitted "<< std::endl;
 
-	for( iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+  //std::cout << "got function" << std::endl;
+  double fpar[2] = {fgaus.GetParameter(1), fgaus.GetParameter(2)};
+  //std::cout<<"Debug fpar[2] = (" <<fpar[0]<<","<<fpar[1]<<")"<<std::endl;
+  reco::BeamSpot::CovarianceMatrix matrix;
+  // add matrix values.
+  matrix(2, 2) = fgaus.GetParError(1) * fgaus.GetParError(1);
+  matrix(3, 3) = fgaus.GetParError(2) * fgaus.GetParError(2);
 
-		 h1z->Fill( iparam->z0() );
-		 //std::cout<<"z0="<<iparam->z0()<<"; sigZ0="<<iparam->sigz0()<<std::endl;
-	}
+  //delete h1z;
 
-	//Use our own copy for thread safety
-        // also do not add to global list of functions
-	TF1 fgaus("fgaus","gaus",0.,1.,TF1::EAddToList::kNo);
-	h1z->Fit(&fgaus,"QLMN0 SERIAL");
-	//std::cout << "fitted "<< std::endl;
-
-	//std::cout << "got function" << std::endl;
-	double fpar[2] = {fgaus.GetParameter(1), fgaus.GetParameter(2) };
-	//std::cout<<"Debug fpar[2] = (" <<fpar[0]<<","<<fpar[1]<<")"<<std::endl;
-	reco::BeamSpot::CovarianceMatrix matrix;
-	// add matrix values.
-	matrix(2,2) = fgaus.GetParError(1) * fgaus.GetParError(1);
-	matrix(3,3) = fgaus.GetParError(2) * fgaus.GetParError(2);
-
-	//delete h1z;
-
-	return reco::BeamSpot( reco::BeamSpot::Point(0.,
-						     0.,
-						     fpar[0]),
-			       fpar[1],
-			       0.,
-			       0.,
-			       0.,
-			       matrix,
-			       fbeamtype );
-
-
+  return reco::BeamSpot(reco::BeamSpot::Point(0., 0., fpar[0]), fpar[1], 0., 0., 0., matrix, fbeamtype);
 }
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit_ited0phi() {
+  this->d0phi_Init();
+  edm::LogInfo("BSFitter") << "number of total input tracks: " << fBSvector.size() << std::endl;
 
-	this->d0phi_Init();
-    edm::LogInfo("BSFitter") << "number of total input tracks: " << fBSvector.size() << std::endl;
+  reco::BeamSpot theanswer;
 
-	reco::BeamSpot theanswer;
+  if ((int)fBSvector.size() <= fminNtrks) {
+    edm::LogWarning("BSFitter") << "need at least " << fminNtrks << " tracks to run beamline fitter." << std::endl;
+    fbeamtype = reco::BeamSpot::Fake;
+    theanswer.setType(fbeamtype);
+    return theanswer;
+  }
 
-	if ( (int)fBSvector.size() <= fminNtrks ) {
-        edm::LogWarning("BSFitter") << "need at least " << fminNtrks << " tracks to run beamline fitter." << std::endl;
-		fbeamtype = reco::BeamSpot::Fake;
-		theanswer.setType(fbeamtype);
-		return theanswer;
-	}
+  theanswer = Fit_d0phi();  //get initial ftmp and ftmprow
+  if (goodfit)
+    fnthite++;
+  //std::cout << "Initial tempanswer (iteration 0): " << theanswer << std::endl;
 
-	theanswer = Fit_d0phi(); //get initial ftmp and ftmprow
-	if ( goodfit ) fnthite++;
-	//std::cout << "Initial tempanswer (iteration 0): " << theanswer << std::endl;
+  reco::BeamSpot preanswer = theanswer;
 
-	reco::BeamSpot preanswer = theanswer;
-
-	while ( goodfit &&
-			ftmprow > fconvergence * fBSvector.size() &&
-			ftmprow > fminNtrks  ) {
-
-		theanswer = Fit_d0phi();
-		fd0cut /= 1.5;
-		fchi2cut /= 1.5;
-		if ( goodfit &&
-			ftmprow > fconvergence * fBSvector.size() &&
-			ftmprow > fminNtrks ) {
-			preanswer = theanswer;
-			//std::cout << "Iteration " << fnthite << ": " << preanswer << std::endl;
-			fnthite++;
-		}
-	}
-	// FIXME: return fit results from previous iteration for both bad fit and for >50% tracks thrown away
-	//std::cout << "The last iteration, theanswer: " << theanswer << std::endl;
-	theanswer = preanswer;
-	//std::cout << "Use previous results from iteration #" << ( fnthite > 0 ? fnthite-1 : 0 ) << std::endl;
-	//if ( fnthite > 1 ) std::cout << theanswer << std::endl;
-
-    edm::LogInfo("BSFitter") << "Total number of successful iterations = " << ( goodfit ? (fnthite+1) : fnthite ) << std::endl;
-    if (goodfit) {
-        fbeamtype = reco::BeamSpot::Tracker;
-        theanswer.setType(fbeamtype);
+  while (goodfit && ftmprow > fconvergence * fBSvector.size() && ftmprow > fminNtrks) {
+    theanswer = Fit_d0phi();
+    fd0cut /= 1.5;
+    fchi2cut /= 1.5;
+    if (goodfit && ftmprow > fconvergence * fBSvector.size() && ftmprow > fminNtrks) {
+      preanswer = theanswer;
+      //std::cout << "Iteration " << fnthite << ": " << preanswer << std::endl;
+      fnthite++;
     }
-    else {
-        edm::LogWarning("BSFitter") << "Fit doesn't converge!!!" << std::endl;
-        fbeamtype = reco::BeamSpot::Unknown;
-        theanswer.setType(fbeamtype);
-    }
-	return theanswer;
+  }
+  // FIXME: return fit results from previous iteration for both bad fit and for >50% tracks thrown away
+  //std::cout << "The last iteration, theanswer: " << theanswer << std::endl;
+  theanswer = preanswer;
+  //std::cout << "Use previous results from iteration #" << ( fnthite > 0 ? fnthite-1 : 0 ) << std::endl;
+  //if ( fnthite > 1 ) std::cout << theanswer << std::endl;
+
+  edm::LogInfo("BSFitter") << "Total number of successful iterations = " << (goodfit ? (fnthite + 1) : fnthite)
+                           << std::endl;
+  if (goodfit) {
+    fbeamtype = reco::BeamSpot::Tracker;
+    theanswer.setType(fbeamtype);
+  } else {
+    edm::LogWarning("BSFitter") << "Fit doesn't converge!!!" << std::endl;
+    fbeamtype = reco::BeamSpot::Unknown;
+    theanswer.setType(fbeamtype);
+  }
+  return theanswer;
 }
-
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit_d0phi() {
+  //LogDebug ("BSFitter") << " we will use " << fBSvector.size() << " tracks.";
+  if (fnthite > 0)
+    edm::LogInfo("BSFitter") << " number of tracks used: " << ftmprow << std::endl;
+  //std::cout << " ftmp = matrix("<<ftmp.GetNrows()<<","<<ftmp.GetNcols()<<")"<<std::endl;
+  //std::cout << " ftmp(0,0)="<<ftmp(0,0)<<std::endl;
+  //std::cout << " ftmp(1,0)="<<ftmp(1,0)<<std::endl;
+  //std::cout << " ftmp(2,0)="<<ftmp(2,0)<<std::endl;
+  //std::cout << " ftmp(3,0)="<<ftmp(3,0)<<std::endl;
 
-	//LogDebug ("BSFitter") << " we will use " << fBSvector.size() << " tracks.";
-    if (fnthite > 0) edm::LogInfo("BSFitter") << " number of tracks used: " << ftmprow << std::endl;
-	//std::cout << " ftmp = matrix("<<ftmp.GetNrows()<<","<<ftmp.GetNcols()<<")"<<std::endl;
-	//std::cout << " ftmp(0,0)="<<ftmp(0,0)<<std::endl;
-	//std::cout << " ftmp(1,0)="<<ftmp(1,0)<<std::endl;
-	//std::cout << " ftmp(2,0)="<<ftmp(2,0)<<std::endl;
-	//std::cout << " ftmp(3,0)="<<ftmp(3,0)<<std::endl;
+  h1z->Reset();
 
-        h1z->Reset();
+  TMatrixD x_result(4, 1);
+  TMatrixDSym V_result(4);
 
+  TMatrixDSym Vint(4);
+  TMatrixD b(4, 1);
 
-	TMatrixD x_result(4,1);
-	TMatrixDSym V_result(4);
+  //Double_t weightsum = 0;
 
-	TMatrixDSym Vint(4);
-	TMatrixD b(4,1);
+  Vint.Zero();
+  b.Zero();
 
-	//Double_t weightsum = 0;
+  TMatrixD g(4, 1);
+  TMatrixDSym temp(4);
 
-	Vint.Zero();
-	b.Zero();
+  std::vector<BSTrkParameters>::iterator iparam = fBSvector.begin();
+  ftmprow = 0;
 
-	TMatrixD g(4,1);
-	TMatrixDSym temp(4);
+  //edm::LogInfo ("BSFitter") << " test";
 
-	std::vector<BSTrkParameters>::iterator iparam = fBSvector.begin();
-	ftmprow=0;
+  //std::cout << "BSFitter: fit" << std::endl;
 
+  for (iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+    //if(i->weight2 == 0) continue;
 
-	//edm::LogInfo ("BSFitter") << " test";
+    //if (ftmprow==0) {
+    //std::cout << "d0=" << iparam->d0() << " sigd0=" << iparam->sigd0()
+    //<< " phi0="<< iparam->phi0() << " z0=" << iparam->z0() << std::endl;
+    //std::cout << "d0phi_d0=" << iparam->d0phi_d0() << " d0phi_chi2="<<iparam->d0phi_chi2() << std::endl;
+    //}
+    g(0, 0) = sin(iparam->phi0());
+    g(1, 0) = -cos(iparam->phi0());
+    g(2, 0) = iparam->z0() * g(0, 0);
+    g(3, 0) = iparam->z0() * g(1, 0);
 
-	//std::cout << "BSFitter: fit" << std::endl;
+    // average transverse beam width
+    double sigmabeam2 = 0.006 * 0.006;
+    if (finputBeamWidth > 0)
+      sigmabeam2 = finputBeamWidth * finputBeamWidth;
+    else {
+      //edm::LogWarning("BSFitter") << "using in fit beam width = " << sqrt(sigmabeam2) << std::endl;
+    }
 
-	for( iparam = fBSvector.begin() ;
-		iparam != fBSvector.end() ; ++iparam) {
+    //double sigma2 = sigmabeam2 +  (iparam->sigd0())* (iparam->sigd0()) / iparam->weight2;
+    // this should be 2*sigmabeam2?
+    double sigma2 = sigmabeam2 + (iparam->sigd0()) * (iparam->sigd0());
 
+    TMatrixD ftmptrans(1, 4);
+    ftmptrans = ftmptrans.Transpose(ftmp);
+    TMatrixD dcor = ftmptrans * g;
+    double chi2tmp = (iparam->d0() - dcor(0, 0)) * (iparam->d0() - dcor(0, 0)) / sigma2;
+    (*iparam) = BSTrkParameters(
+        iparam->z0(), iparam->sigz0(), iparam->d0(), iparam->sigd0(), iparam->phi0(), iparam->pt(), dcor(0, 0), chi2tmp);
 
-		//if(i->weight2 == 0) continue;
+    bool pass = true;
+    if (fapplyd0cut && fnthite > 0) {
+      if (std::abs(iparam->d0() - dcor(0, 0)) > fd0cut)
+        pass = false;
+    }
+    if (fapplychi2cut && fnthite > 0) {
+      if (chi2tmp > fchi2cut)
+        pass = false;
+    }
 
-		//if (ftmprow==0) {
-		//std::cout << "d0=" << iparam->d0() << " sigd0=" << iparam->sigd0()
-		//<< " phi0="<< iparam->phi0() << " z0=" << iparam->z0() << std::endl;
-		//std::cout << "d0phi_d0=" << iparam->d0phi_d0() << " d0phi_chi2="<<iparam->d0phi_chi2() << std::endl;
-		//}
-		g(0,0) = sin(iparam->phi0());
-		g(1,0) = -cos(iparam->phi0());
-		g(2,0) = iparam->z0() * g(0,0);
-		g(3,0) = iparam->z0() * g(1,0);
+    if (pass) {
+      temp.Zero();
+      for (int j = 0; j < 4; ++j) {
+        for (int k = j; k < 4; ++k) {
+          temp(j, k) += g(j, 0) * g(k, 0);
+        }
+      }
 
+      Vint += (temp * (1 / sigma2));
+      b += (iparam->d0() / sigma2 * g);
+      //weightsum += sqrt(i->weight2);
+      ftmprow++;
+      h1z->Fill(iparam->z0());
+    }
+  }
+  Double_t determinant;
+  TDecompBK bk(Vint);
+  bk.SetTol(1e-11);  //FIXME: find a better way to solve x_result
+  if (!bk.Decompose()) {
+    goodfit = false;
+    edm::LogWarning("BSFitter") << "Decomposition failed, matrix singular ?" << std::endl
+                                << "condition number = " << bk.Condition() << std::endl;
+  } else {
+    V_result = Vint.InvertFast(&determinant);
+    x_result = V_result * b;
+  }
+  //     	for(int j = 0 ; j < 4 ; ++j) {
+  // 	  for(int k = 0 ; k < 4 ; ++k) {
+  // 	    std::cout<<"V_result("<<j<<","<<k<<")="<<V_result(j,k)<<std::endl;
+  // 	  }
+  //     	}
+  //         for (int j=0;j<4;++j){
+  // 	  std::cout<<"x_result("<<j<<",0)="<<x_result(j,0)<<std::endl;
+  // 	}
+  //LogDebug ("BSFitter") << " d0-phi fit done.";
+  //std::cout<< " d0-phi fit done." << std::endl;
 
-		// average transverse beam width
-		double sigmabeam2 = 0.006 * 0.006;
-		if (finputBeamWidth > 0 ) sigmabeam2 = finputBeamWidth * finputBeamWidth;
-        else {
-	      //edm::LogWarning("BSFitter") << "using in fit beam width = " << sqrt(sigmabeam2) << std::endl;
-	     }
+  //Use our own copy for thread safety
+  // also do not add to global list of functions
+  TF1 fgaus("fgaus", "gaus", 0., 1., TF1::EAddToList::kNo);
+  //returns 0 if OK
+  //auto status = h1z->Fit(&fgaus,"QLM0","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
+  auto status =
+      h1z->Fit(&fgaus, "QLN0 SERIAL", "", h1z->GetMean() - 2. * h1z->GetRMS(), h1z->GetMean() + 2. * h1z->GetRMS());
 
-		//double sigma2 = sigmabeam2 +  (iparam->sigd0())* (iparam->sigd0()) / iparam->weight2;
-		// this should be 2*sigmabeam2?
-		double sigma2 = sigmabeam2 +  (iparam->sigd0())* (iparam->sigd0());
+  //std::cout << "fitted "<< std::endl;
 
-		TMatrixD ftmptrans(1,4);
-		ftmptrans = ftmptrans.Transpose(ftmp);
-		TMatrixD dcor = ftmptrans * g;
-		double chi2tmp = (iparam->d0() - dcor(0,0)) * (iparam->d0() - dcor(0,0))/sigma2;
-		(*iparam) = BSTrkParameters(iparam->z0(),iparam->sigz0(),iparam->d0(),iparam->sigd0(),
-					    iparam->phi0(), iparam->pt(),dcor(0,0),chi2tmp);
+  //std::cout << "got function" << std::endl;
+  if (status) {
+    //edm::LogError("NoBeamSpotFit")<<"gaussian fit failed. no BS d0 fit";
 
-		bool pass = true;
-		if (fapplyd0cut && fnthite>0 ) {
-	       		if ( std::abs(iparam->d0() - dcor(0,0)) > fd0cut ) pass = false;
+    goodfit = false;
+    return reco::BeamSpot();
+  }
+  double fpar[2] = {fgaus.GetParameter(1), fgaus.GetParameter(2)};
 
-		}
-		if (fapplychi2cut && fnthite>0 ) {
-			if ( chi2tmp > fchi2cut ) pass = false;
+  reco::BeamSpot::CovarianceMatrix matrix;
+  // first two parameters
+  for (int j = 0; j < 2; ++j) {
+    for (int k = j; k < 2; ++k) {
+      matrix(j, k) = V_result(j, k);
+    }
+  }
+  // slope parameters
+  for (int j = 4; j < 6; ++j) {
+    for (int k = j; k < 6; ++k) {
+      matrix(j, k) = V_result(j - 2, k - 2);
+    }
+  }
 
-		}
+  // Z0 and sigmaZ
+  matrix(2, 2) = fgaus.GetParError(1) * fgaus.GetParError(1);
+  matrix(3, 3) = fgaus.GetParError(2) * fgaus.GetParError(2);
 
-		if (pass) {
-			temp.Zero();
-			for(int j = 0 ; j < 4 ; ++j) {
-				for(int k = j ; k < 4 ; ++k) {
-					temp(j,k) += g(j,0) * g(k,0);
-				}
-			}
+  ftmp = x_result;
 
+  // x0 and y0 are *not* x,y at z=0, but actually at z=0
+  // to correct for this, we need to translate them to z=z0
+  // using the measured slopes
+  //
+  double x0tmp = x_result(0, 0);
+  double y0tmp = x_result(1, 0);
 
-			Vint += (temp * (1 / sigma2));
-			b += (iparam->d0() / sigma2 * g);
-			//weightsum += sqrt(i->weight2);
-			ftmprow++;
-            h1z->Fill( iparam->z0() );
-		}
+  x0tmp += x_result(2, 0) * fpar[0];
+  y0tmp += x_result(3, 0) * fpar[0];
 
-
-	}
-	Double_t determinant;
-	TDecompBK bk(Vint);
-	bk.SetTol(1e-11); //FIXME: find a better way to solve x_result
-	if (!bk.Decompose()) {
-	  goodfit = false;
-      edm::LogWarning("BSFitter")
-          << "Decomposition failed, matrix singular ?" << std::endl
-          << "condition number = " << bk.Condition() << std::endl;
-	}
-	else {
-	  V_result = Vint.InvertFast(&determinant);
-	  x_result = V_result  * b;
-	}
-	//     	for(int j = 0 ; j < 4 ; ++j) {
-	// 	  for(int k = 0 ; k < 4 ; ++k) {
-	// 	    std::cout<<"V_result("<<j<<","<<k<<")="<<V_result(j,k)<<std::endl;
-	// 	  }
-	//     	}
-	//         for (int j=0;j<4;++j){
-	// 	  std::cout<<"x_result("<<j<<",0)="<<x_result(j,0)<<std::endl;
-	// 	}
-	//LogDebug ("BSFitter") << " d0-phi fit done.";
-	//std::cout<< " d0-phi fit done." << std::endl;
-
-	//Use our own copy for thread safety
-        // also do not add to global list of functions
-	TF1 fgaus("fgaus","gaus",0.,1.,TF1::EAddToList::kNo);
-	//returns 0 if OK
-	//auto status = h1z->Fit(&fgaus,"QLM0","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
-	auto status = h1z->Fit(&fgaus,"QLN0 SERIAL","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
-
-	//std::cout << "fitted "<< std::endl;
-
-	//std::cout << "got function" << std::endl;
-	if (status){
-	  //edm::LogError("NoBeamSpotFit")<<"gaussian fit failed. no BS d0 fit";
-
-	  goodfit = false;
-	  return reco::BeamSpot();
-	}
-	double fpar[2] = {fgaus.GetParameter(1), fgaus.GetParameter(2) };
-
-	reco::BeamSpot::CovarianceMatrix matrix;
-	// first two parameters
-	for (int j = 0 ; j < 2 ; ++j) {
-		for(int k = j ; k < 2 ; ++k) {
-			matrix(j,k) = V_result(j,k);
-		}
-	}
-	// slope parameters
-	for (int j = 4 ; j < 6 ; ++j) {
-		for(int k = j ; k < 6 ; ++k) {
-			matrix(j,k) = V_result(j-2,k-2);
-		}
-	}
-
-    // Z0 and sigmaZ
-	matrix(2,2) = fgaus.GetParError(1) * fgaus.GetParError(1);
-	matrix(3,3) = fgaus.GetParError(2) * fgaus.GetParError(2);
-
-	ftmp = x_result;
-
-	// x0 and y0 are *not* x,y at z=0, but actually at z=0
-        // to correct for this, we need to translate them to z=z0
-        // using the measured slopes
-	//
-	double x0tmp = x_result(0,0);
-	double y0tmp = x_result(1,0);
-
-	x0tmp += x_result(2,0)*fpar[0];
-	y0tmp += x_result(3,0)*fpar[0];
-
-
-	return reco::BeamSpot( reco::BeamSpot::Point(x0tmp,
-						     y0tmp,
-						     fpar[0]),
-                           fpar[1],
-			       x_result(2,0),
-			       x_result(3,0),
-			       0.,
-			       matrix,
-			       fbeamtype );
-
+  return reco::BeamSpot(
+      reco::BeamSpot::Point(x0tmp, y0tmp, fpar[0]), fpar[1], x_result(2, 0), x_result(3, 0), 0., matrix, fbeamtype);
 }
-
 
 //______________________________________________________________________
 void BSFitter::Setd0Cut_d0phi(double d0cut) {
+  fapplyd0cut = true;
 
-	fapplyd0cut = true;
-
-	//fBSforCuts = BSfitted;
-	fd0cut = d0cut;
+  //fBSforCuts = BSfitted;
+  fd0cut = d0cut;
 }
 
 //______________________________________________________________________
 void BSFitter::SetChi2Cut_d0phi(double chi2cut) {
+  fapplychi2cut = true;
 
-	fapplychi2cut = true;
-
-	//fBSforCuts = BSfitted;
-	fchi2cut = chi2cut;
+  //fBSforCuts = BSfitted;
+  fchi2cut = chi2cut;
 }
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit_d_likelihood(double *inipar) {
+  thePDF->SetPDFs("PDFGauss_d");
+  thePDF->SetData(fBSvector);
 
+  MnUserParameters upar;
+  upar.Add("X0", inipar[0], 0.001);
+  upar.Add("Y0", inipar[1], 0.001);
+  upar.Add("Z0", 0., 0.001);
+  upar.Add("sigmaZ", 0., 0.001);
+  upar.Add("dxdz", inipar[2], 0.001);
+  upar.Add("dydz", inipar[3], 0.001);
 
-	thePDF->SetPDFs("PDFGauss_d");
-	thePDF->SetData(fBSvector);
+  MnMigrad migrad(*thePDF, upar);
 
-	MnUserParameters upar;
-	upar.Add("X0",  inipar[0],0.001);
-	upar.Add("Y0",  inipar[1],0.001);
-	upar.Add("Z0",    0.,0.001);
-	upar.Add("sigmaZ",0.,0.001);
-	upar.Add("dxdz",inipar[2],0.001);
-	upar.Add("dydz",inipar[3],0.001);
+  FunctionMinimum fmin = migrad();
+  ff_minimum = fmin.Fval();
 
+  reco::BeamSpot::CovarianceMatrix matrix;
+  for (int j = 0; j < 6; ++j) {
+    for (int k = j; k < 6; ++k) {
+      matrix(j, k) = fmin.Error().Matrix()(j, k);
+    }
+  }
 
-	MnMigrad migrad(*thePDF, upar);
-
-	FunctionMinimum fmin = migrad();
-	ff_minimum = fmin.Fval();
-
-	reco::BeamSpot::CovarianceMatrix matrix;
-	for (int j = 0 ; j < 6 ; ++j) {
-		for(int k = j ; k < 6 ; ++k) {
-			matrix(j,k) = fmin.Error().Matrix()(j,k);
-		}
-	}
-
-	return reco::BeamSpot( reco::BeamSpot::Point(fmin.Parameters().Vec()(0),
-						     fmin.Parameters().Vec()(1),
-						     0.),
-			       0.,
-			       fmin.Parameters().Vec()(4),
-			       fmin.Parameters().Vec()(5),
-			       0.,
-			       matrix,
-			       fbeamtype );
+  return reco::BeamSpot(reco::BeamSpot::Point(fmin.Parameters().Vec()(0), fmin.Parameters().Vec()(1), 0.),
+                        0.,
+                        fmin.Parameters().Vec()(4),
+                        fmin.Parameters().Vec()(5),
+                        0.,
+                        matrix,
+                        fbeamtype);
 }
 //______________________________________________________________________
-double BSFitter::scanPDF(double *init_pars, int & tracksfixed, int option){
+double BSFitter::scanPDF(double *init_pars, int &tracksfixed, int option) {
+  if (option == 1)
+    init_pars[6] = 0.0005;  //starting value for any given configuration
 
-   if(option==1)init_pars[6]=0.0005;  //starting value for any given configuration
-
-   //local vairables with initial values
-   double fsqrt2pi=0.0;
-   double d_sig=0.0;
-   double d_dprime=0.0;
-   double d_result=0.0;
-   double z_sig=0.0;
-   double z_result=0.0;
-   double function=0.0;
-   double tot_pdf=0.0;
-   double last_minvalue=1.0e+10;
-   double init_bw=-99.99;
-   int iters=0;
+  //local vairables with initial values
+  double fsqrt2pi = 0.0;
+  double d_sig = 0.0;
+  double d_dprime = 0.0;
+  double d_result = 0.0;
+  double z_sig = 0.0;
+  double z_result = 0.0;
+  double function = 0.0;
+  double tot_pdf = 0.0;
+  double last_minvalue = 1.0e+10;
+  double init_bw = -99.99;
+  int iters = 0;
 
   //used to remove tracks if far away from bs by this
-   double DeltadCut=0.1000;
-   if(init_pars[6]<0.0200){DeltadCut=0.0900; } //worked for high 2.36TeV
-   if(init_pars[6]<0.0100){DeltadCut=0.0700;}  //just a guesss for 7 TeV but one should scan for actual values
+  double DeltadCut = 0.1000;
+  if (init_pars[6] < 0.0200) {
+    DeltadCut = 0.0900;
+  }  //worked for high 2.36TeV
+  if (init_pars[6] < 0.0100) {
+    DeltadCut = 0.0700;
+  }  //just a guesss for 7 TeV but one should scan for actual values
 
+  std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin();
 
-std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin();
+  if (option == 1)
+    iters = 500;
+  if (option == 2)
+    iters = 1;
 
+  for (int p = 0; p < iters; p++) {
+    if (iters == 500)
+      init_pars[6] += 0.0002;
+    tracksfixed = 0;
 
-if(option==1)iters=500;
-if(option==2)iters=1;
+    for (iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+      fsqrt2pi = sqrt(2. * TMath::Pi());
+      d_sig = sqrt(init_pars[6] * init_pars[6] + (iparam->sigd0()) * (iparam->sigd0()));
+      d_dprime = iparam->d0() - (((init_pars[0] + iparam->z0() * (init_pars[4])) * sin(iparam->phi0())) -
+                                 ((init_pars[1] + iparam->z0() * (init_pars[5])) * cos(iparam->phi0())));
 
-for(int p=0;p<iters;p++){
-
-   if(iters==500)init_pars[6]+=0.0002;
-    tracksfixed=0;
-
-for( iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam)
-       {
-                    fsqrt2pi = sqrt(2.* TMath::Pi());
-                    d_sig = sqrt(init_pars[6]*init_pars[6] + (iparam->sigd0())*(iparam->sigd0()));
-                    d_dprime = iparam->d0() - (   (  (init_pars[0] + iparam->z0()*(init_pars[4]))*sin(iparam->phi0()) )
-                                               - (  (init_pars[1] + iparam->z0()*(init_pars[5]))*cos(iparam->phi0()) ) );
-
-                    //***Remove tracks before the fit which gives low pdf values to blow up the pdf
-                    if(std::abs(d_dprime)<DeltadCut && option==2){ fBSvectorBW.push_back(*iparam);}
-
-                    d_result = (exp(-(d_dprime*d_dprime)/(2.0*d_sig*d_sig)))/(d_sig*fsqrt2pi);
-                    z_sig = sqrt(iparam->sigz0() * iparam->sigz0() + init_pars[3]*init_pars[3]);
-                    z_result = (exp(-((iparam->z0() - init_pars[2])*(iparam->z0() - init_pars[2]))/(2.0*z_sig*z_sig)))/(z_sig*fsqrt2pi);
-                    tot_pdf=z_result*d_result;
-
-                    //for those trcks which gives problems due to very tiny pdf_d values.
-                    //Update: This protection will NOT be used with the dprime cut above but still kept here to get
-                    // the intial value of beam width reasonably
-                    //A warning will appear if there were any tracks with < 10^-5 for pdf_d so that (d-dprime) cut can be lowered
-                    if(d_result < 1.0e-05){ tot_pdf=z_result*1.0e-05;
-                                           //if(option==2)std::cout<<"last Iter  d-d'   =  "<<(std::abs(d_dprime))<<std::endl;
-                                           tracksfixed++; }
-
-                       function = function + log(tot_pdf);
-
-
-       }//loop over tracks
-
-
-       function= -2.0*function;
-       if(function<last_minvalue){init_bw=init_pars[6];
-                                  last_minvalue=function; }
-       function=0.0;
-   }//loop over beam width
-
-   if(init_bw>0) {
-    init_bw=init_bw+(0.20*init_bw); //start with 20 % more
-
-   }
-   else{
-
-       if(option==1){
-           edm::LogWarning("BSFitter")
-               <<"scanPDF:====>>>> WARNING***: The initial guess value of Beam width is negative!!!!!!"<<std::endl
-               <<"scanPDF:====>>>> Assigning beam width a starting value of "<<init_bw<<"  cm"<<std::endl;
-           init_bw=0.0200;
-
-       }
+      //***Remove tracks before the fit which gives low pdf values to blow up the pdf
+      if (std::abs(d_dprime) < DeltadCut && option == 2) {
+        fBSvectorBW.push_back(*iparam);
       }
 
+      d_result = (exp(-(d_dprime * d_dprime) / (2.0 * d_sig * d_sig))) / (d_sig * fsqrt2pi);
+      z_sig = sqrt(iparam->sigz0() * iparam->sigz0() + init_pars[3] * init_pars[3]);
+      z_result = (exp(-((iparam->z0() - init_pars[2]) * (iparam->z0() - init_pars[2])) / (2.0 * z_sig * z_sig))) /
+                 (z_sig * fsqrt2pi);
+      tot_pdf = z_result * d_result;
 
-    return init_bw;
+      //for those trcks which gives problems due to very tiny pdf_d values.
+      //Update: This protection will NOT be used with the dprime cut above but still kept here to get
+      // the intial value of beam width reasonably
+      //A warning will appear if there were any tracks with < 10^-5 for pdf_d so that (d-dprime) cut can be lowered
+      if (d_result < 1.0e-05) {
+        tot_pdf = z_result * 1.0e-05;
+        //if(option==2)std::cout<<"last Iter  d-d'   =  "<<(std::abs(d_dprime))<<std::endl;
+        tracksfixed++;
+      }
 
+      function = function + log(tot_pdf);
+
+    }  //loop over tracks
+
+    function = -2.0 * function;
+    if (function < last_minvalue) {
+      init_bw = init_pars[6];
+      last_minvalue = function;
+    }
+    function = 0.0;
+  }  //loop over beam width
+
+  if (init_bw > 0) {
+    init_bw = init_bw + (0.20 * init_bw);  //start with 20 % more
+
+  } else {
+    if (option == 1) {
+      edm::LogWarning("BSFitter")
+          << "scanPDF:====>>>> WARNING***: The initial guess value of Beam width is negative!!!!!!" << std::endl
+          << "scanPDF:====>>>> Assigning beam width a starting value of " << init_bw << "  cm" << std::endl;
+      init_bw = 0.0200;
+    }
+  }
+
+  return init_bw;
 }
 
 //________________________________________________________________________________
 reco::BeamSpot BSFitter::Fit_d_z_likelihood(double *inipar, double *error_par) {
+  int tracksFailed = 0;
 
-      int tracksFailed=0;
+  //estimate first guess of beam width and tame 20% extra of it to start
+  inipar[6] = scanPDF(inipar, tracksFailed, 1);
+  error_par[6] = (inipar[6]) * 0.20;
 
-      //estimate first guess of beam width and tame 20% extra of it to start
-      inipar[6]=scanPDF(inipar,tracksFailed,1);
-      error_par[6]=(inipar[6])*0.20;
+  //Here remove the tracks which give low pdf and fill into a new vector
+  //std::cout<<"Size of Old vector = "<<(fBSvector.size())<<std::endl;
+  /* double junk= */ scanPDF(inipar, tracksFailed, 2);
+  //std::cout<<"Size of New vector = "<<(fBSvectorBW.size())<<std::endl;
 
+  //Refill the fBSVector again with new sets of tracks
+  fBSvector.clear();
+  std::vector<BSTrkParameters>::const_iterator iparamBW = fBSvectorBW.begin();
+  for (iparamBW = fBSvectorBW.begin(); iparamBW != fBSvectorBW.end(); ++iparamBW) {
+    fBSvector.push_back(*iparamBW);
+  }
 
-     //Here remove the tracks which give low pdf and fill into a new vector
-     //std::cout<<"Size of Old vector = "<<(fBSvector.size())<<std::endl;
-     /* double junk= */ scanPDF(inipar,tracksFailed,2);
-     //std::cout<<"Size of New vector = "<<(fBSvectorBW.size())<<std::endl;
+  thePDF->SetPDFs("PDFGauss_d*PDFGauss_z");
+  thePDF->SetData(fBSvector);
+  MnUserParameters upar;
 
-     //Refill the fBSVector again with new sets of tracks
-     fBSvector.clear();
-     std::vector<BSTrkParameters>::const_iterator iparamBW = fBSvectorBW.begin();
-     for( iparamBW = fBSvectorBW.begin(); iparamBW != fBSvectorBW.end(); ++iparamBW)
-        {          fBSvector.push_back(*iparamBW);
-        }
+  upar.Add("X0", inipar[0], error_par[0]);
+  upar.Add("Y0", inipar[1], error_par[1]);
+  upar.Add("Z0", inipar[2], error_par[2]);
+  upar.Add("sigmaZ", inipar[3], error_par[3]);
+  upar.Add("dxdz", inipar[4], error_par[4]);
+  upar.Add("dydz", inipar[5], error_par[5]);
+  upar.Add("BeamWidthX", inipar[6], error_par[6]);
 
+  MnMigrad migrad(*thePDF, upar);
 
-        thePDF->SetPDFs("PDFGauss_d*PDFGauss_z");
-        thePDF->SetData(fBSvector);
-        MnUserParameters upar;
+  FunctionMinimum fmin = migrad();
 
-        upar.Add("X0",  inipar[0],error_par[0]);
-        upar.Add("Y0",  inipar[1],error_par[1]);
-        upar.Add("Z0",    inipar[2],error_par[2]);
-        upar.Add("sigmaZ",inipar[3],error_par[3]);
-        upar.Add("dxdz",inipar[4],error_par[4]);
-        upar.Add("dydz",inipar[5],error_par[5]);
-        upar.Add("BeamWidthX",inipar[6],error_par[6]);
+  // std::cout<<"-----how the fit evoves------"<<std::endl;
+  // std::cout<<fmin<<std::endl;
 
+  ff_minimum = fmin.Fval();
 
-        MnMigrad migrad(*thePDF, upar);
+  bool ff_nfcn = fmin.HasReachedCallLimit();
+  bool ff_cov = fmin.HasCovariance();
+  bool testing = fmin.IsValid();
 
-        FunctionMinimum fmin = migrad();
+  //Print WARNINGS if minimum did not converged
+  if (!testing) {
+    edm::LogWarning("BSFitter") << "===========>>>>>** WARNING: MINUIT DID NOT CONVERGES PROPERLY !!!!!!" << std::endl;
+    if (ff_nfcn)
+      edm::LogWarning("BSFitter") << "===========>>>>>** WARNING: No. of Calls Exhausted" << std::endl;
+    if (!ff_cov)
+      edm::LogWarning("BSFitter") << "===========>>>>>** WARNING: Covariance did not found" << std::endl;
+  }
 
-      // std::cout<<"-----how the fit evoves------"<<std::endl;
-      // std::cout<<fmin<<std::endl;
+  edm::LogInfo("BSFitter") << "The Total # Tracks used for beam width fit = " << (fBSvectorBW.size()) << std::endl;
 
-        ff_minimum = fmin.Fval();
+  //Checks after fit is performed
+  double lastIter_pars[7];
 
+  for (int ip = 0; ip < 7; ip++) {
+    lastIter_pars[ip] = fmin.Parameters().Vec()(ip);
+  }
 
-        bool ff_nfcn=fmin.HasReachedCallLimit();
-        bool ff_cov=fmin.HasCovariance();
-        bool testing=fmin.IsValid();
+  tracksFailed = 0;
+  /* double lastIter_scan= */ scanPDF(lastIter_pars, tracksFailed, 2);
 
+  edm::LogWarning("BSFitter") << "WARNING: # of tracks which have very low pdf value (pdf_d < 1.0e-05) are  = "
+                              << tracksFailed << std::endl;
 
-        //Print WARNINGS if minimum did not converged
-        if( ! testing )
-        {
-            edm::LogWarning("BSFitter") <<"===========>>>>>** WARNING: MINUIT DID NOT CONVERGES PROPERLY !!!!!!"<<std::endl;
-            if(ff_nfcn) edm::LogWarning("BSFitter") <<"===========>>>>>** WARNING: No. of Calls Exhausted"<<std::endl;
-            if(!ff_cov) edm::LogWarning("BSFitter") <<"===========>>>>>** WARNING: Covariance did not found"<<std::endl;
-        }
+  //std::cout << " eval= " << ff_minimum
+  //                << "/n params[0]= " << fmin.Parameters().Vec()(0) << std::endl;
 
-        edm::LogInfo("BSFitter") <<"The Total # Tracks used for beam width fit = "<<(fBSvectorBW.size())<<std::endl;
+  reco::BeamSpot::CovarianceMatrix matrix;
 
+  for (int j = 0; j < 7; ++j) {
+    for (int k = j; k < 7; ++k) {
+      matrix(j, k) = fmin.Error().Matrix()(j, k);
+    }
+  }
 
-    //Checks after fit is performed
-    double lastIter_pars[7];
+  return reco::BeamSpot(
+      reco::BeamSpot::Point(fmin.Parameters().Vec()(0), fmin.Parameters().Vec()(1), fmin.Parameters().Vec()(2)),
+      fmin.Parameters().Vec()(3),
+      fmin.Parameters().Vec()(4),
+      fmin.Parameters().Vec()(5),
+      fmin.Parameters().Vec()(6),
 
-   for(int ip=0;ip<7;ip++){ lastIter_pars[ip]=fmin.Parameters().Vec()(ip);
-                           }
-
-
-
-    tracksFailed=0;
-    /* double lastIter_scan= */ scanPDF(lastIter_pars,tracksFailed,2);
-
-
-    edm::LogWarning("BSFitter") <<"WARNING: # of tracks which have very low pdf value (pdf_d < 1.0e-05) are  = "<<tracksFailed<<std::endl;
-
-
-
-        //std::cout << " eval= " << ff_minimum
-        //                << "/n params[0]= " << fmin.Parameters().Vec()(0) << std::endl;
-
-        reco::BeamSpot::CovarianceMatrix matrix;
-
-        for (int j = 0 ; j < 7 ; ++j) {
-                for(int k = j ; k < 7 ; ++k) {
-                        matrix(j,k) = fmin.Error().Matrix()(j,k);
-                }
-        }
-
-
-        return reco::BeamSpot( reco::BeamSpot::Point(fmin.Parameters().Vec()(0),
-                                                     fmin.Parameters().Vec()(1),
-                                                     fmin.Parameters().Vec()(2)),
-                               fmin.Parameters().Vec()(3),
-                               fmin.Parameters().Vec()(4),
-                               fmin.Parameters().Vec()(5),
-                               fmin.Parameters().Vec()(6),
-
-                               matrix,
-                               fbeamtype );
+      matrix,
+      fbeamtype);
 }
-
 
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit_dres_z_likelihood(double *inipar) {
+  thePDF->SetPDFs("PDFGauss_d_resolution*PDFGauss_z");
+  thePDF->SetData(fBSvector);
 
+  MnUserParameters upar;
+  upar.Add("X0", inipar[0], 0.001);
+  upar.Add("Y0", inipar[1], 0.001);
+  upar.Add("Z0", inipar[2], 0.001);
+  upar.Add("sigmaZ", inipar[3], 0.001);
+  upar.Add("dxdz", inipar[4], 0.001);
+  upar.Add("dydz", inipar[5], 0.001);
+  upar.Add("BeamWidthX", inipar[6], 0.0001);
+  upar.Add("c0", 0.0010, 0.0001);
+  upar.Add("c1", 0.0090, 0.0001);
 
-	thePDF->SetPDFs("PDFGauss_d_resolution*PDFGauss_z");
-	thePDF->SetData(fBSvector);
+  // fix beam width
+  upar.Fix("BeamWidthX");
+  // number of parameters in fit are 9-1 = 8
 
-	MnUserParameters upar;
-	upar.Add("X0",  inipar[0],0.001);
-	upar.Add("Y0",  inipar[1],0.001);
-	upar.Add("Z0",    inipar[2],0.001);
-	upar.Add("sigmaZ",inipar[3],0.001);
-	upar.Add("dxdz",inipar[4],0.001);
-	upar.Add("dydz",inipar[5],0.001);
-	upar.Add("BeamWidthX",inipar[6],0.0001);
-	upar.Add("c0",0.0010,0.0001);
-	upar.Add("c1",0.0090,0.0001);
+  MnMigrad migrad(*thePDF, upar);
 
-	// fix beam width
-	upar.Fix("BeamWidthX");
-	// number of parameters in fit are 9-1 = 8
+  FunctionMinimum fmin = migrad();
+  ff_minimum = fmin.Fval();
 
-	MnMigrad migrad(*thePDF, upar);
+  reco::BeamSpot::CovarianceMatrix matrix;
 
-	FunctionMinimum fmin = migrad();
-	ff_minimum = fmin.Fval();
+  for (int j = 0; j < 6; ++j) {
+    for (int k = j; k < 6; ++k) {
+      matrix(j, k) = fmin.Error().Matrix()(j, k);
+    }
+  }
 
-	reco::BeamSpot::CovarianceMatrix matrix;
+  //std::cout << " fill resolution values" << std::endl;
+  //std::cout << " matrix size= " << fmin.Error().Matrix().size() << std::endl;
+  //std::cout << " vec(6)="<< fmin.Parameters().Vec()(6) << std::endl;
+  //std::cout << " vec(7)="<< fmin.Parameters().Vec()(7) << std::endl;
 
-	for (int j = 0 ; j < 6 ; ++j) {
-		for(int k = j ; k < 6 ; ++k) {
-			matrix(j,k) = fmin.Error().Matrix()(j,k);
-		}
-	}
+  fresolution_c0 = fmin.Parameters().Vec()(6);
+  fresolution_c1 = fmin.Parameters().Vec()(7);
+  fres_c0_err = sqrt(fmin.Error().Matrix()(6, 6));
+  fres_c1_err = sqrt(fmin.Error().Matrix()(7, 7));
 
-	//std::cout << " fill resolution values" << std::endl;
-	//std::cout << " matrix size= " << fmin.Error().Matrix().size() << std::endl;
-	//std::cout << " vec(6)="<< fmin.Parameters().Vec()(6) << std::endl;
-	//std::cout << " vec(7)="<< fmin.Parameters().Vec()(7) << std::endl;
+  for (int j = 6; j < 8; ++j) {
+    for (int k = 6; k < 8; ++k) {
+      fres_matrix(j - 6, k - 6) = fmin.Error().Matrix()(j, k);
+    }
+  }
 
-	fresolution_c0 = fmin.Parameters().Vec()(6);
-	fresolution_c1 = fmin.Parameters().Vec()(7);
-	fres_c0_err = sqrt( fmin.Error().Matrix()(6,6) );
-	fres_c1_err = sqrt( fmin.Error().Matrix()(7,7) );
-
-	for (int j = 6 ; j < 8 ; ++j) {
-		for(int k = 6 ; k < 8 ; ++k) {
-			fres_matrix(j-6,k-6) = fmin.Error().Matrix()(j,k);
-		}
-	}
-
-	return reco::BeamSpot( reco::BeamSpot::Point(fmin.Parameters().Vec()(0),
-									 fmin.Parameters().Vec()(1),
-									 fmin.Parameters().Vec()(2)),
-					 fmin.Parameters().Vec()(3),
-					 fmin.Parameters().Vec()(4),
-					 fmin.Parameters().Vec()(5),
-					 inipar[6],
-					 matrix,
-					 fbeamtype );
+  return reco::BeamSpot(
+      reco::BeamSpot::Point(fmin.Parameters().Vec()(0), fmin.Parameters().Vec()(1), fmin.Parameters().Vec()(2)),
+      fmin.Parameters().Vec()(3),
+      fmin.Parameters().Vec()(4),
+      fmin.Parameters().Vec()(5),
+      inipar[6],
+      matrix,
+      fbeamtype);
 }
-
-
-

--- a/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc
@@ -17,113 +17,90 @@ ________________________________________________________________**/
 #include <vector>
 
 //______________________________________________________________________
-double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad,
-							 double phi, const std::vector<double>& parms) const {
-
+double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, const std::vector<double>& parms) const {
   //---------------------------------------------------------------------------
   //  PDF for d0 distribution. This PDF is a simple gaussian in the
   //  beam reference frame.
   //---------------------------------------------------------------------------
-	double fsqrt2pi = sqrt(2.* TMath::Pi());
-	
-	double sig = sqrt(parms[fPar_SigmaBeam]*parms[fPar_SigmaBeam] +
-					  sigmad*sigmad);
+  double fsqrt2pi = sqrt(2. * TMath::Pi());
 
-	double dprime = d - ( ( parms[fPar_X0] + z*parms[fPar_dxdz] )*sin(phi)
-		- ( parms[fPar_Y0] + z*parms[fPar_dydz] )*cos(phi) );
-	
-	double result = (exp(-(dprime*dprime)/(2.0*sig*sig)))/(sig*fsqrt2pi);
-		
-	return result;
+  double sig = sqrt(parms[fPar_SigmaBeam] * parms[fPar_SigmaBeam] + sigmad * sigmad);
 
+  double dprime =
+      d - ((parms[fPar_X0] + z * parms[fPar_dxdz]) * sin(phi) - (parms[fPar_Y0] + z * parms[fPar_dydz]) * cos(phi));
+
+  double result = (exp(-(dprime * dprime) / (2.0 * sig * sig))) / (sig * fsqrt2pi);
+
+  return result;
 }
 
 //______________________________________________________________________
-double BSpdfsFcn::PDFGauss_d_resolution(double z, double d, double phi, double pt, const std::vector<double>& parms) const {
-
+double BSpdfsFcn::PDFGauss_d_resolution(
+    double z, double d, double phi, double pt, const std::vector<double>& parms) const {
   //---------------------------------------------------------------------------
   //  PDF for d0 distribution. This PDF is a simple gaussian in the
   //  beam reference frame. The IP resolution is parametrize by a linear
-  //  function as a function of 1/pt.	
+  //  function as a function of 1/pt.
   //---------------------------------------------------------------------------
-	double fsqrt2pi = sqrt(2.* TMath::Pi());
+  double fsqrt2pi = sqrt(2. * TMath::Pi());
 
-	double sigmad = parms[fPar_c0] + parms[fPar_c1]/pt;
-	
-	double sig = sqrt(parms[fPar_SigmaBeam]*parms[fPar_SigmaBeam] +
-					  sigmad*sigmad);
+  double sigmad = parms[fPar_c0] + parms[fPar_c1] / pt;
 
-	double dprime = d - ( ( parms[fPar_X0] + z*parms[fPar_dxdz] )*sin(phi)
-		- ( parms[fPar_Y0] + z*parms[fPar_dydz] )*cos(phi) );
-	
-	double result = (exp(-(dprime*dprime)/(2.0*sig*sig)))/(sig*fsqrt2pi);
-		
-	return result;
+  double sig = sqrt(parms[fPar_SigmaBeam] * parms[fPar_SigmaBeam] + sigmad * sigmad);
 
+  double dprime =
+      d - ((parms[fPar_X0] + z * parms[fPar_dxdz]) * sin(phi) - (parms[fPar_Y0] + z * parms[fPar_dydz]) * cos(phi));
+
+  double result = (exp(-(dprime * dprime) / (2.0 * sig * sig))) / (sig * fsqrt2pi);
+
+  return result;
 }
 
 //______________________________________________________________________
 double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, const std::vector<double>& parms) const {
-
   //---------------------------------------------------------------------------
   //  PDF for z-vertex distribution. This distribution
   // is parametrized by a simple normalized gaussian distribution.
   //---------------------------------------------------------------------------
-	double fsqrt2pi = sqrt(2.* TMath::Pi());
+  double fsqrt2pi = sqrt(2. * TMath::Pi());
 
-	double sig = sqrt(sigmaz*sigmaz+parms[fPar_SigmaZ]*parms[fPar_SigmaZ]);
-	//double sig = sqrt(sigmaz*sigmaz+parms[1]*parms[1]);
-	double result = (exp(-((z-parms[fPar_Z0])*(z-parms[fPar_Z0]))/(2.0*sig*sig)))/(sig*fsqrt2pi);
-	//double result = (exp(-((z-parms[0])*(z-parms[0]))/(2.0*sig*sig)))/(sig*fsqrt2pi);
-        
-	return result;
+  double sig = sqrt(sigmaz * sigmaz + parms[fPar_SigmaZ] * parms[fPar_SigmaZ]);
+  //double sig = sqrt(sigmaz*sigmaz+parms[1]*parms[1]);
+  double result = (exp(-((z - parms[fPar_Z0]) * (z - parms[fPar_Z0])) / (2.0 * sig * sig))) / (sig * fsqrt2pi);
+  //double result = (exp(-((z-parms[0])*(z-parms[0]))/(2.0*sig*sig)))/(sig*fsqrt2pi);
 
+  return result;
 }
 
-
-
-
 //______________________________________________________________________
-double BSpdfsFcn::operator() (const std::vector<double>& params) const {
-		
-	double f = 0.0;
+double BSpdfsFcn::operator()(const std::vector<double>& params) const {
+  double f = 0.0;
 
-	//std::cout << "fusepdfs=" << fusepdfs << " params.size="<<params.size() << std::endl;
-	
-	std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin();
+  //std::cout << "fusepdfs=" << fusepdfs << " params.size="<<params.size() << std::endl;
 
-	double pdf = 0;
-	
-	for( iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+  std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin();
 
-		
-		if (fusepdfs == "PDFGauss_z") {
-			pdf = PDFGauss_z( iparam->z0(), iparam->sigz0(),params);
-		}
-		else if (fusepdfs == "PDFGauss_d") {
-			pdf = PDFGauss_d( iparam->z0(), iparam->d0(),
-							  iparam->sigd0(), iparam->phi0(),params);
-		}
-		else if (fusepdfs == "PDFGauss_d_resolution") {
-			pdf = PDFGauss_d_resolution( iparam->z0(), iparam->d0(),
-							  iparam->phi0(), iparam->pt(),params);
-		}
-		else if (fusepdfs == "PDFGauss_d*PDFGauss_z") {
-			//std::cout << "pdf= " << pdf << std::endl;
-			pdf = PDFGauss_d( iparam->z0(), iparam->d0(),
-							  iparam->sigd0(), iparam->phi0(),params)*
-				PDFGauss_z( iparam->z0(), iparam->sigz0(),params);
-		}
-		else if (fusepdfs == "PDFGauss_d_resolution*PDFGauss_z") {
-			pdf = PDFGauss_d_resolution( iparam->z0(), iparam->d0(),
-										 iparam->phi0(), iparam->pt(),params)*
-				PDFGauss_z( iparam->z0(), iparam->sigz0(),params);
-		}
-		
-		f = log(pdf) + f;
+  double pdf = 0;
+
+  for (iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+    if (fusepdfs == "PDFGauss_z") {
+      pdf = PDFGauss_z(iparam->z0(), iparam->sigz0(), params);
+    } else if (fusepdfs == "PDFGauss_d") {
+      pdf = PDFGauss_d(iparam->z0(), iparam->d0(), iparam->sigd0(), iparam->phi0(), params);
+    } else if (fusepdfs == "PDFGauss_d_resolution") {
+      pdf = PDFGauss_d_resolution(iparam->z0(), iparam->d0(), iparam->phi0(), iparam->pt(), params);
+    } else if (fusepdfs == "PDFGauss_d*PDFGauss_z") {
+      //std::cout << "pdf= " << pdf << std::endl;
+      pdf = PDFGauss_d(iparam->z0(), iparam->d0(), iparam->sigd0(), iparam->phi0(), params) *
+            PDFGauss_z(iparam->z0(), iparam->sigz0(), params);
+    } else if (fusepdfs == "PDFGauss_d_resolution*PDFGauss_z") {
+      pdf = PDFGauss_d_resolution(iparam->z0(), iparam->d0(), iparam->phi0(), iparam->pt(), params) *
+            PDFGauss_z(iparam->z0(), iparam->sigz0(), params);
     }
 
-	f= -2.0*f;
-	return f;
+    f = log(pdf) + f;
+  }
 
+  f = -2.0 * f;
+  return f;
 }

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -28,120 +28,129 @@ ________________________________________________________________**/
 // Update the string representations of the time
 void BeamFitter::updateBTime() {
   char ts[] = "yyyy.mn.dd hh:mm:ss zzz ";
-  char* fbeginTime = ts;
-  strftime(fbeginTime,sizeof(ts),"%Y.%m.%d %H:%M:%S GMT",gmtime(&freftime[0]));
-  sprintf(fbeginTimeOfFit,"%s",fbeginTime);
-  char* fendTime = ts;
-  strftime(fendTime,sizeof(ts),"%Y.%m.%d %H:%M:%S GMT",gmtime(&freftime[1]));
-  sprintf(fendTimeOfFit,"%s",fendTime);
+  char *fbeginTime = ts;
+  strftime(fbeginTime, sizeof(ts), "%Y.%m.%d %H:%M:%S GMT", gmtime(&freftime[0]));
+  sprintf(fbeginTimeOfFit, "%s", fbeginTime);
+  char *fendTime = ts;
+  strftime(fendTime, sizeof(ts), "%Y.%m.%d %H:%M:%S GMT", gmtime(&freftime[1]));
+  sprintf(fendTimeOfFit, "%s", fendTime);
 }
 
-
-BeamFitter::BeamFitter(const edm::ParameterSet& iConfig,
-                       edm::ConsumesCollector &&iColl): fPVTree_(nullptr)
-{
-
-  debug_             = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("Debug");
-  tracksToken_       = iColl.consumes<reco::TrackCollection>(
+BeamFitter::BeamFitter(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iColl) : fPVTree_(nullptr) {
+  debug_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("Debug");
+  tracksToken_ = iColl.consumes<reco::TrackCollection>(
       iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<edm::InputTag>("TrackCollection"));
-  vertexToken_       = iColl.consumes<edm::View<reco::Vertex> >(
+  vertexToken_ = iColl.consumes<edm::View<reco::Vertex> >(
       iConfig.getUntrackedParameter<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices")));
-  beamSpotToken_     = iColl.consumes<reco::BeamSpot>(
+  beamSpotToken_ = iColl.consumes<reco::BeamSpot>(
       iConfig.getUntrackedParameter<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot")));
-  writeTxt_          = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("WriteAscii");
-  outputTxt_         = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::string>("AsciiFileName");
-  appendRunTxt_      = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("AppendRunToFileName");
-  writeDIPTxt_       = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("WriteDIPAscii");
+  writeTxt_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("WriteAscii");
+  outputTxt_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::string>("AsciiFileName");
+  appendRunTxt_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("AppendRunToFileName");
+  writeDIPTxt_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("WriteDIPAscii");
   // Specify whether we want to write the DIP file even if the fit is failed.
-  writeDIPBadFit_       = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("WriteDIPOnBadFit", true);
-  outputDIPTxt_      = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::string>("DIPFileName");
-  saveNtuple_        = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("SaveNtuple");
-  saveBeamFit_       = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("SaveFitResults");
-  savePVVertices_    = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("SavePVVertices");
-  isMuon_            = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("IsMuonCollection");
+  writeDIPBadFit_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("WriteDIPOnBadFit", true);
+  outputDIPTxt_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::string>("DIPFileName");
+  saveNtuple_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("SaveNtuple");
+  saveBeamFit_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("SaveFitResults");
+  savePVVertices_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("SavePVVertices");
+  isMuon_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("IsMuonCollection");
 
-  trk_MinpT_         = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MinimumPt");
-  trk_MaxEta_        = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumEta");
-  trk_MaxIP_         = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumImpactParameter");
-  trk_MaxZ_          = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumZ");
-  trk_MinNTotLayers_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<int>("MinimumTotalLayers");
-  trk_MinNPixLayers_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<int>("MinimumPixelLayers");
-  trk_MaxNormChi2_   = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumNormChi2");
-  trk_Algorithm_     = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::vector<std::string> >("TrackAlgorithm");
-  trk_Quality_       = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::vector<std::string> >("TrackQuality");
-  min_Ntrks_         = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<int>("MinimumInputTracks");
-  convergence_       = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("FractionOfFittedTrks");
-  inputBeamWidth_    = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("InputBeamWidth",-1.);
+  trk_MinpT_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MinimumPt");
+  trk_MaxEta_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumEta");
+  trk_MaxIP_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumImpactParameter");
+  trk_MaxZ_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumZ");
+  trk_MinNTotLayers_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<int>("MinimumTotalLayers");
+  trk_MinNPixLayers_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<int>("MinimumPixelLayers");
+  trk_MaxNormChi2_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("MaximumNormChi2");
+  trk_Algorithm_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter")
+                       .getUntrackedParameter<std::vector<std::string> >("TrackAlgorithm");
+  trk_Quality_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter")
+                     .getUntrackedParameter<std::vector<std::string> >("TrackQuality");
+  min_Ntrks_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<int>("MinimumInputTracks");
+  convergence_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("FractionOfFittedTrks");
+  inputBeamWidth_ =
+      iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<double>("InputBeamWidth", -1.);
 
-  for (unsigned int j=0;j<trk_Algorithm_.size();j++)
+  for (unsigned int j = 0; j < trk_Algorithm_.size(); j++)
     algorithm_.push_back(reco::TrackBase::algoByName(trk_Algorithm_[j]));
-  for (unsigned int j=0;j<trk_Quality_.size();j++)
+  for (unsigned int j = 0; j < trk_Quality_.size(); j++)
     quality_.push_back(reco::TrackBase::qualityByName(trk_Quality_[j]));
 
   if (saveNtuple_ || saveBeamFit_ || savePVVertices_) {
-    outputfilename_ = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::string>("OutputFileName");
-    file_ = TFile::Open(outputfilename_.c_str(),"RECREATE");
+    outputfilename_ =
+        iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<std::string>("OutputFileName");
+    file_ = TFile::Open(outputfilename_.c_str(), "RECREATE");
   }
   if (saveNtuple_) {
-    ftree_ = new TTree("mytree","mytree");
+    ftree_ = new TTree("mytree", "mytree");
     ftree_->AutoSave();
 
-    ftree_->Branch("pt",&fpt,"fpt/D");
-    ftree_->Branch("d0",&fd0,"fd0/D");
-    ftree_->Branch("d0bs",&fd0bs,"fd0bs/D");
-    ftree_->Branch("sigmad0",&fsigmad0,"fsigmad0/D");
-    ftree_->Branch("phi0",&fphi0,"fphi0/D");
-    ftree_->Branch("z0",&fz0,"fz0/D");
-    ftree_->Branch("sigmaz0",&fsigmaz0,"fsigmaz0/D");
-    ftree_->Branch("theta",&ftheta,"ftheta/D");
-    ftree_->Branch("eta",&feta,"feta/D");
-    ftree_->Branch("charge",&fcharge,"fcharge/I");
-    ftree_->Branch("normchi2",&fnormchi2,"fnormchi2/D");
-    ftree_->Branch("nTotLayerMeas",&fnTotLayerMeas,"fnTotLayerMeas/i");
-    ftree_->Branch("nStripLayerMeas",&fnStripLayerMeas,"fnStripLayerMeas/i");
-    ftree_->Branch("nPixelLayerMeas",&fnPixelLayerMeas,"fnPixelLayerMeas/i");
-    ftree_->Branch("nTIBLayerMeas",&fnTIBLayerMeas,"fnTIBLayerMeas/i");
-    ftree_->Branch("nTOBLayerMeas",&fnTOBLayerMeas,"fnTOBLayerMeas/i");
-    ftree_->Branch("nTIDLayerMeas",&fnTIDLayerMeas,"fnTIDLayerMeas/i");
-    ftree_->Branch("nTECLayerMeas",&fnTECLayerMeas,"fnTECLayerMeas/i");
-    ftree_->Branch("nPXBLayerMeas",&fnPXBLayerMeas,"fnPXBLayerMeas/i");
-    ftree_->Branch("nPXFLayerMeas",&fnPXFLayerMeas,"fnPXFLayerMeas/i");
-    ftree_->Branch("cov",&fcov,"fcov[7][7]/D");
-    ftree_->Branch("vx",&fvx,"fvx/D");
-    ftree_->Branch("vy",&fvy,"fvy/D");
-    ftree_->Branch("quality",&fquality,"fquality/O");
-    ftree_->Branch("algo",&falgo,"falgo/O");
-    ftree_->Branch("run",&frun,"frun/i");
-    ftree_->Branch("lumi",&flumi,"flumi/i");
-    ftree_->Branch("pvValid",&fpvValid,"fpvValid/O");
+    ftree_->Branch("pt", &fpt, "fpt/D");
+    ftree_->Branch("d0", &fd0, "fd0/D");
+    ftree_->Branch("d0bs", &fd0bs, "fd0bs/D");
+    ftree_->Branch("sigmad0", &fsigmad0, "fsigmad0/D");
+    ftree_->Branch("phi0", &fphi0, "fphi0/D");
+    ftree_->Branch("z0", &fz0, "fz0/D");
+    ftree_->Branch("sigmaz0", &fsigmaz0, "fsigmaz0/D");
+    ftree_->Branch("theta", &ftheta, "ftheta/D");
+    ftree_->Branch("eta", &feta, "feta/D");
+    ftree_->Branch("charge", &fcharge, "fcharge/I");
+    ftree_->Branch("normchi2", &fnormchi2, "fnormchi2/D");
+    ftree_->Branch("nTotLayerMeas", &fnTotLayerMeas, "fnTotLayerMeas/i");
+    ftree_->Branch("nStripLayerMeas", &fnStripLayerMeas, "fnStripLayerMeas/i");
+    ftree_->Branch("nPixelLayerMeas", &fnPixelLayerMeas, "fnPixelLayerMeas/i");
+    ftree_->Branch("nTIBLayerMeas", &fnTIBLayerMeas, "fnTIBLayerMeas/i");
+    ftree_->Branch("nTOBLayerMeas", &fnTOBLayerMeas, "fnTOBLayerMeas/i");
+    ftree_->Branch("nTIDLayerMeas", &fnTIDLayerMeas, "fnTIDLayerMeas/i");
+    ftree_->Branch("nTECLayerMeas", &fnTECLayerMeas, "fnTECLayerMeas/i");
+    ftree_->Branch("nPXBLayerMeas", &fnPXBLayerMeas, "fnPXBLayerMeas/i");
+    ftree_->Branch("nPXFLayerMeas", &fnPXFLayerMeas, "fnPXFLayerMeas/i");
+    ftree_->Branch("cov", &fcov, "fcov[7][7]/D");
+    ftree_->Branch("vx", &fvx, "fvx/D");
+    ftree_->Branch("vy", &fvy, "fvy/D");
+    ftree_->Branch("quality", &fquality, "fquality/O");
+    ftree_->Branch("algo", &falgo, "falgo/O");
+    ftree_->Branch("run", &frun, "frun/i");
+    ftree_->Branch("lumi", &flumi, "flumi/i");
+    ftree_->Branch("pvValid", &fpvValid, "fpvValid/O");
     ftree_->Branch("pvx", &fpvx, "fpvx/D");
     ftree_->Branch("pvy", &fpvy, "fpvy/D");
     ftree_->Branch("pvz", &fpvz, "fpvz/D");
   }
-  if (saveBeamFit_){
-    ftreeFit_ = new TTree("fitResults","fitResults");
+  if (saveBeamFit_) {
+    ftreeFit_ = new TTree("fitResults", "fitResults");
     ftreeFit_->AutoSave();
-    ftreeFit_->Branch("run",&frunFit,"frunFit/i");
-    ftreeFit_->Branch("beginLumi",&fbeginLumiOfFit,"fbeginLumiOfFit/i");
-    ftreeFit_->Branch("endLumi",&fendLumiOfFit,"fendLumiOfFit/i");
-    ftreeFit_->Branch("beginTime",fbeginTimeOfFit,"fbeginTimeOfFit/C");
-    ftreeFit_->Branch("endTime",fendTimeOfFit,"fendTimeOfFit/C");
-    ftreeFit_->Branch("x",&fx,"fx/D");
-    ftreeFit_->Branch("y",&fy,"fy/D");
-    ftreeFit_->Branch("z",&fz,"fz/D");
-    ftreeFit_->Branch("sigmaZ",&fsigmaZ,"fsigmaZ/D");
-    ftreeFit_->Branch("dxdz",&fdxdz,"fdxdz/D");
-    ftreeFit_->Branch("dydz",&fdydz,"fdydz/D");
-    ftreeFit_->Branch("xErr",&fxErr,"fxErr/D");
-    ftreeFit_->Branch("yErr",&fyErr,"fyErr/D");
-    ftreeFit_->Branch("zErr",&fzErr,"fzErr/D");
-    ftreeFit_->Branch("sigmaZErr",&fsigmaZErr,"fsigmaZErr/D");
-    ftreeFit_->Branch("dxdzErr",&fdxdzErr,"fdxdzErr/D");
-    ftreeFit_->Branch("dydzErr",&fdydzErr,"fdydzErr/D");
-    ftreeFit_->Branch("widthX",&fwidthX,"fwidthX/D");
-    ftreeFit_->Branch("widthY",&fwidthY,"fwidthY/D");
-    ftreeFit_->Branch("widthXErr",&fwidthXErr,"fwidthXErr/D");
-    ftreeFit_->Branch("widthYErr",&fwidthYErr,"fwidthYErr/D");
+    ftreeFit_->Branch("run", &frunFit, "frunFit/i");
+    ftreeFit_->Branch("beginLumi", &fbeginLumiOfFit, "fbeginLumiOfFit/i");
+    ftreeFit_->Branch("endLumi", &fendLumiOfFit, "fendLumiOfFit/i");
+    ftreeFit_->Branch("beginTime", fbeginTimeOfFit, "fbeginTimeOfFit/C");
+    ftreeFit_->Branch("endTime", fendTimeOfFit, "fendTimeOfFit/C");
+    ftreeFit_->Branch("x", &fx, "fx/D");
+    ftreeFit_->Branch("y", &fy, "fy/D");
+    ftreeFit_->Branch("z", &fz, "fz/D");
+    ftreeFit_->Branch("sigmaZ", &fsigmaZ, "fsigmaZ/D");
+    ftreeFit_->Branch("dxdz", &fdxdz, "fdxdz/D");
+    ftreeFit_->Branch("dydz", &fdydz, "fdydz/D");
+    ftreeFit_->Branch("xErr", &fxErr, "fxErr/D");
+    ftreeFit_->Branch("yErr", &fyErr, "fyErr/D");
+    ftreeFit_->Branch("zErr", &fzErr, "fzErr/D");
+    ftreeFit_->Branch("sigmaZErr", &fsigmaZErr, "fsigmaZErr/D");
+    ftreeFit_->Branch("dxdzErr", &fdxdzErr, "fdxdzErr/D");
+    ftreeFit_->Branch("dydzErr", &fdydzErr, "fdydzErr/D");
+    ftreeFit_->Branch("widthX", &fwidthX, "fwidthX/D");
+    ftreeFit_->Branch("widthY", &fwidthY, "fwidthY/D");
+    ftreeFit_->Branch("widthXErr", &fwidthXErr, "fwidthXErr/D");
+    ftreeFit_->Branch("widthYErr", &fwidthYErr, "fwidthYErr/D");
   }
 
   fBSvector.clear();
@@ -157,25 +166,25 @@ BeamFitter::BeamFitter(const edm::ParameterSet& iConfig,
   resetRefTime();
 
   //debug histograms
-  h1ntrks = new TH1F("h1ntrks","number of tracks per event",50,0,50);
-  h1vz_event = new TH1F("h1vz_event","track Vz", 50, -30, 30 );
-  h1cutFlow = new TH1F("h1cutFlow","Cut flow table of track selection", 9, 0, 9);
-  h1cutFlow->GetXaxis()->SetBinLabel(1,"No cut");
-  h1cutFlow->GetXaxis()->SetBinLabel(2,"Traker hits");
-  h1cutFlow->GetXaxis()->SetBinLabel(3,"Pixel hits");
-  h1cutFlow->GetXaxis()->SetBinLabel(4,"norm. #chi^{2}");
-  h1cutFlow->GetXaxis()->SetBinLabel(5,"algo");
-  h1cutFlow->GetXaxis()->SetBinLabel(6,"quality");
-  h1cutFlow->GetXaxis()->SetBinLabel(7,"d_{0}");
-  h1cutFlow->GetXaxis()->SetBinLabel(8,"z_{0}");
-  h1cutFlow->GetXaxis()->SetBinLabel(9,"p_{T}");
+  h1ntrks = new TH1F("h1ntrks", "number of tracks per event", 50, 0, 50);
+  h1vz_event = new TH1F("h1vz_event", "track Vz", 50, -30, 30);
+  h1cutFlow = new TH1F("h1cutFlow", "Cut flow table of track selection", 9, 0, 9);
+  h1cutFlow->GetXaxis()->SetBinLabel(1, "No cut");
+  h1cutFlow->GetXaxis()->SetBinLabel(2, "Traker hits");
+  h1cutFlow->GetXaxis()->SetBinLabel(3, "Pixel hits");
+  h1cutFlow->GetXaxis()->SetBinLabel(4, "norm. #chi^{2}");
+  h1cutFlow->GetXaxis()->SetBinLabel(5, "algo");
+  h1cutFlow->GetXaxis()->SetBinLabel(6, "quality");
+  h1cutFlow->GetXaxis()->SetBinLabel(7, "d_{0}");
+  h1cutFlow->GetXaxis()->SetBinLabel(8, "z_{0}");
+  h1cutFlow->GetXaxis()->SetBinLabel(9, "p_{T}");
   resetCutFlow();
 
   // Primary vertex fitter
   MyPVFitter = new PVFitter(iConfig, iColl);
   MyPVFitter->resetAll();
-  if (savePVVertices_){
-    fPVTree_ = new TTree("PrimaryVertices","PrimaryVertices");
+  if (savePVVertices_) {
+    fPVTree_ = new TTree("PrimaryVertices", "PrimaryVertices");
     MyPVFitter->setTree(fPVTree_);
   }
 
@@ -186,70 +195,71 @@ BeamFitter::BeamFitter(const edm::ParameterSet& iConfig,
 }
 
 BeamFitter::~BeamFitter() {
-
   if (saveNtuple_) {
     file_->cd();
-    if (fitted_ && h1z) h1z->Write();
+    if (fitted_ && h1z)
+      h1z->Write();
     h1ntrks->Write();
     h1vz_event->Write();
-    if (h1cutFlow) h1cutFlow->Write();
+    if (h1cutFlow)
+      h1cutFlow->Write();
     ftree_->Write();
   }
-  if (saveBeamFit_){
+  if (saveBeamFit_) {
     file_->cd();
     ftreeFit_->Write();
   }
-  if (savePVVertices_){
+  if (savePVVertices_) {
     file_->cd();
     fPVTree_->Write();
   }
 
-
-  if (saveNtuple_ || saveBeamFit_ || savePVVertices_){
+  if (saveNtuple_ || saveBeamFit_ || savePVVertices_) {
     file_->Close();
     delete file_;
   }
   delete MyPVFitter;
 }
 
-
-void BeamFitter::readEvent(const edm::Event& iEvent)
-{
-
-
+void BeamFitter::readEvent(const edm::Event &iEvent) {
   frun = iEvent.id().run();
   const edm::TimeValue_t ftimestamp = iEvent.time().value();
   const std::time_t ftmptime = ftimestamp >> 32;
 
-  if (fbeginLumiOfFit == -1) freftime[0] = freftime[1] = ftmptime;
-  if (freftime[0] == 0 || ftmptime < freftime[0]) freftime[0] = ftmptime;
-  if (freftime[1] == 0 || ftmptime > freftime[1]) freftime[1] = ftmptime;
+  if (fbeginLumiOfFit == -1)
+    freftime[0] = freftime[1] = ftmptime;
+  if (freftime[0] == 0 || ftmptime < freftime[0])
+    freftime[0] = ftmptime;
+  if (freftime[1] == 0 || ftmptime > freftime[1])
+    freftime[1] = ftmptime;
   // Update the human-readable string versions of the time
   updateBTime();
 
   flumi = iEvent.luminosityBlock();
   frunFit = frun;
-  if (fbeginLumiOfFit == -1 || fbeginLumiOfFit > flumi) fbeginLumiOfFit = flumi;
-  if (fendLumiOfFit == -1 || fendLumiOfFit < flumi) fendLumiOfFit = flumi;
+  if (fbeginLumiOfFit == -1 || fbeginLumiOfFit > flumi)
+    fbeginLumiOfFit = flumi;
+  if (fendLumiOfFit == -1 || fendLumiOfFit < flumi)
+    fendLumiOfFit = flumi;
 
   edm::Handle<reco::TrackCollection> TrackCollection;
   iEvent.getByToken(tracksToken_, TrackCollection);
 
   //------ Primary Vertices
-  edm::Handle< edm::View<reco::Vertex> > PVCollection;
+  edm::Handle<edm::View<reco::Vertex> > PVCollection;
   bool hasPVs = false;
   edm::View<reco::Vertex> pv;
-  if ( iEvent.getByToken(vertexToken_, PVCollection ) ) {
-      pv = *PVCollection;
-      hasPVs = true;
+  if (iEvent.getByToken(vertexToken_, PVCollection)) {
+    pv = *PVCollection;
+    hasPVs = true;
   }
   //------
 
   //------ Beam Spot in current event
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  const reco::BeamSpot *refBS =  nullptr;
-  if ( iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle) )
-      refBS = recoBeamSpotHandle.product();
+  const reco::BeamSpot *refBS = nullptr;
+  if (iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle))
+    refBS = recoBeamSpotHandle.product();
   //-------
 
   const reco::TrackCollection *tracks = TrackCollection.product();
@@ -257,9 +267,7 @@ void BeamFitter::readEvent(const edm::Event& iEvent)
   double eventZ = 0;
   double averageZ = 0;
 
-  for (reco::TrackCollection::const_iterator track = tracks->begin();
-          track != tracks->end(); ++track){
-
+  for (reco::TrackCollection::const_iterator track = tracks->begin(); track != tracks->end(); ++track) {
     if (!isMuon_) {
       const reco::HitPattern &trkHP = track->hitPattern();
 
@@ -282,8 +290,10 @@ void BeamFitter::readEvent(const edm::Event& iEvent)
     fcharge = track->charge();
     fnormchi2 = track->normalizedChi2();
     fd0 = track->d0();
-    if (refBS) fd0bs = -1*track->dxy(refBS->position());
-    else fd0bs = 0.;
+    if (refBS)
+      fd0bs = -1 * track->dxy(refBS->position());
+    else
+      fd0bs = 0.;
 
     fsigmad0 = track->d0Error();
     fz0 = track->dz();
@@ -292,355 +302,352 @@ void BeamFitter::readEvent(const edm::Event& iEvent)
     fvx = track->vx();
     fvy = track->vy();
 
-    for (int i=0; i<5; ++i) {
-      for (int j=0; j<5; ++j) {
-	fcov[i][j] = track->covariance(i,j);
+    for (int i = 0; i < 5; ++i) {
+      for (int j = 0; j < 5; ++j) {
+        fcov[i][j] = track->covariance(i, j);
       }
     }
 
     fquality = true;
     falgo = true;
 
-    if (! isMuon_ ) {
+    if (!isMuon_) {
       if (!quality_.empty()) {
-          fquality = false;
-          for (unsigned int i = 0; i<quality_.size();++i) {
-              if(debug_) edm::LogInfo("BeamFitter") << "quality_[" << i << "] = " << track->qualityName(quality_[i]) << std::endl;
-              if (track->quality(quality_[i])) {
-                  fquality = true;
-                  break;
-              }
+        fquality = false;
+        for (unsigned int i = 0; i < quality_.size(); ++i) {
+          if (debug_)
+            edm::LogInfo("BeamFitter") << "quality_[" << i << "] = " << track->qualityName(quality_[i]) << std::endl;
+          if (track->quality(quality_[i])) {
+            fquality = true;
+            break;
           }
+        }
       }
-
 
       // Track algorithm
 
       if (!algorithm_.empty()) {
-	if (std::find(algorithm_.begin(),algorithm_.end(),track->algo())==algorithm_.end())
-	  falgo = false;
+        if (std::find(algorithm_.begin(), algorithm_.end(), track->algo()) == algorithm_.end())
+          falgo = false;
       }
-
     }
 
     // check if we have a valid PV
     fpvValid = false;
 
-    if ( hasPVs ) {
+    if (hasPVs) {
+      for (size_t ipv = 0; ipv != pv.size(); ++ipv) {
+        if (!pv[ipv].isFake())
+          fpvValid = true;
 
-        for ( size_t ipv=0; ipv != pv.size(); ++ipv ) {
-
-            if (! pv[ipv].isFake() ) fpvValid = true;
-
-            if ( ipv==0 && !pv[0].isFake() ) { fpvx = pv[0].x(); fpvy = pv[0].y(); fpvz = pv[0].z(); } // fix this later
-
-
-        }
-
+        if (ipv == 0 && !pv[0].isFake()) {
+          fpvx = pv[0].x();
+          fpvy = pv[0].y();
+          fpvz = pv[0].z();
+        }  // fix this later
+      }
     }
 
-
-    if (saveNtuple_) ftree_->Fill();
+    if (saveNtuple_)
+      ftree_->Fill();
     ftotal_tracks++;
 
     countPass[0] = ftotal_tracks;
     // Track selection
-    if (fnTotLayerMeas >= trk_MinNTotLayers_) { countPass[1] += 1;
-      if (fnPixelLayerMeas >= trk_MinNPixLayers_) { countPass[2] += 1;
-	if (fnormchi2 < trk_MaxNormChi2_) { countPass[3] += 1;
-	  if (falgo) {countPass[4] += 1;
-	    if (fquality) { countPass[5] += 1;
-	      if (std::abs( fd0 ) < trk_MaxIP_) { countPass[6] += 1;
-		if (std::abs( fz0 ) < trk_MaxZ_){ countPass[7] += 1;
-		  if (fpt > trk_MinpT_) {
-		    countPass[8] += 1;
-		    if (std::abs( feta ) < trk_MaxEta_
-			//&& fpvValid
-			) {
-		      if (debug_) {
-                  edm::LogInfo("BeamFitter") << "Selected track quality = " << track->qualityMask()
-                                             << "; track algorithm = " << track->algoName() << "= TrackAlgorithm: " << track->algo() << std::endl;
-		      }
-		      BSTrkParameters BSTrk(fz0,fsigmaz0,fd0,fsigmad0,fphi0,fpt,0.,0.);
-		      BSTrk.setVx(fvx);
-		      BSTrk.setVy(fvy);
-		      fBSvector.push_back(BSTrk);
-		      averageZ += fz0;
-		    }
-		  }
-		}
-	      }
-	    }
-	  }
-	}
+    if (fnTotLayerMeas >= trk_MinNTotLayers_) {
+      countPass[1] += 1;
+      if (fnPixelLayerMeas >= trk_MinNPixLayers_) {
+        countPass[2] += 1;
+        if (fnormchi2 < trk_MaxNormChi2_) {
+          countPass[3] += 1;
+          if (falgo) {
+            countPass[4] += 1;
+            if (fquality) {
+              countPass[5] += 1;
+              if (std::abs(fd0) < trk_MaxIP_) {
+                countPass[6] += 1;
+                if (std::abs(fz0) < trk_MaxZ_) {
+                  countPass[7] += 1;
+                  if (fpt > trk_MinpT_) {
+                    countPass[8] += 1;
+                    if (std::abs(feta) < trk_MaxEta_
+                        //&& fpvValid
+                    ) {
+                      if (debug_) {
+                        edm::LogInfo("BeamFitter") << "Selected track quality = " << track->qualityMask()
+                                                   << "; track algorithm = " << track->algoName()
+                                                   << "= TrackAlgorithm: " << track->algo() << std::endl;
+                      }
+                      BSTrkParameters BSTrk(fz0, fsigmaz0, fd0, fsigmad0, fphi0, fpt, 0., 0.);
+                      BSTrk.setVx(fvx);
+                      BSTrk.setVy(fvy);
+                      fBSvector.push_back(BSTrk);
+                      averageZ += fz0;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
-    }// track selection
+    }  // track selection
 
-  }// tracks
+  }  // tracks
 
-  averageZ = averageZ/(float)(fBSvector.size());
+  averageZ = averageZ / (float)(fBSvector.size());
 
-  for( std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
-
-    eventZ += fabs( iparam->z0() - averageZ );
-
+  for (std::vector<BSTrkParameters>::const_iterator iparam = fBSvector.begin(); iparam != fBSvector.end(); ++iparam) {
+    eventZ += fabs(iparam->z0() - averageZ);
   }
 
-  h1ntrks->Fill( fBSvector.size() );
-  h1vz_event->Fill( eventZ/(float)(fBSvector.size() ) ) ;
-  for (unsigned int i=0; i < sizeof(countPass)/sizeof(countPass[0]); i++)
-    h1cutFlow->SetBinContent(i+1,countPass[i]);
+  h1ntrks->Fill(fBSvector.size());
+  h1vz_event->Fill(eventZ / (float)(fBSvector.size()));
+  for (unsigned int i = 0; i < sizeof(countPass) / sizeof(countPass[0]); i++)
+    h1cutFlow->SetBinContent(i + 1, countPass[i]);
 
   MyPVFitter->readEvent(iEvent);
-
 }
 
 bool BeamFitter::runPVandTrkFitter() {
-// run both PV and track fitters
-    bool fit_ok = false;
-    bool pv_fit_ok = false;
-    reco::BeamSpot bspotPV;
-    reco::BeamSpot bspotTrk;
+  // run both PV and track fitters
+  bool fit_ok = false;
+  bool pv_fit_ok = false;
+  reco::BeamSpot bspotPV;
+  reco::BeamSpot bspotTrk;
 
-    // First run PV fitter
-    if ( MyPVFitter->IsFitPerBunchCrossing() ){
-      edm::LogInfo("BeamFitter") << " [BeamFitterBxDebugTime] freftime[0] = " << freftime[0]
-				 << "; address =  " << &freftime[0]
-				 << " = " << fbeginTimeOfFit << std::endl;
-      edm::LogInfo("BeamFitter") << " [BeamFitterBxDebugTime] freftime[1] = " << freftime[1]
-				 << "; address =  " << &freftime[1]
-				 << " = " << fendTimeOfFit << std::endl;
+  // First run PV fitter
+  if (MyPVFitter->IsFitPerBunchCrossing()) {
+    edm::LogInfo("BeamFitter") << " [BeamFitterBxDebugTime] freftime[0] = " << freftime[0]
+                               << "; address =  " << &freftime[0] << " = " << fbeginTimeOfFit << std::endl;
+    edm::LogInfo("BeamFitter") << " [BeamFitterBxDebugTime] freftime[1] = " << freftime[1]
+                               << "; address =  " << &freftime[1] << " = " << fendTimeOfFit << std::endl;
 
-      if ( MyPVFitter->runBXFitter() ) {
-	fbspotPVMap = MyPVFitter->getBeamSpotMap();
-	pv_fit_ok = true;
-      }
-      if(writeTxt_ ) dumpTxtFile(outputTxt_,true); // all reaults
-      if(writeDIPTxt_ && (pv_fit_ok || writeDIPBadFit_)) {
-          dumpTxtFile(outputDIPTxt_,false); // for DQM/DIP
-      }
-      return pv_fit_ok;
+    if (MyPVFitter->runBXFitter()) {
+      fbspotPVMap = MyPVFitter->getBeamSpotMap();
+      pv_fit_ok = true;
     }
-
-    if ( MyPVFitter->runFitter() ) {
-
-        bspotPV = MyPVFitter->getBeamSpot();
-
-        // take beam width from PV fit and pass it to track fitter
-        // assume circular transverse beam width
-        inputBeamWidth_ = sqrt( pow(bspotPV.BeamWidthX(),2) + pow(bspotPV.BeamWidthY(),2) )/sqrt(2);
-        pv_fit_ok = true;
-
-    } else {
-        // problems with PV fit
-        bspotPV.setType(reco::BeamSpot::Unknown);
-        bspotTrk.setType(reco::BeamSpot::Unknown); //propagate error to trk beam spot
+    if (writeTxt_)
+      dumpTxtFile(outputTxt_, true);  // all reaults
+    if (writeDIPTxt_ && (pv_fit_ok || writeDIPBadFit_)) {
+      dumpTxtFile(outputDIPTxt_, false);  // for DQM/DIP
     }
+    return pv_fit_ok;
+  }
 
-    if ( runFitterNoTxt() ) {
+  if (MyPVFitter->runFitter()) {
+    bspotPV = MyPVFitter->getBeamSpot();
 
-        bspotTrk = fbeamspot;
-        fit_ok = true;
-    } else {
-      // beamfit failed, flagged as empty beam spot
-      bspotTrk.setType(reco::BeamSpot::Fake);
-      fit_ok = false;
-    }
+    // take beam width from PV fit and pass it to track fitter
+    // assume circular transverse beam width
+    inputBeamWidth_ = sqrt(pow(bspotPV.BeamWidthX(), 2) + pow(bspotPV.BeamWidthY(), 2)) / sqrt(2);
+    pv_fit_ok = true;
 
-    // combined results into one single beam spot
+  } else {
+    // problems with PV fit
+    bspotPV.setType(reco::BeamSpot::Unknown);
+    bspotTrk.setType(reco::BeamSpot::Unknown);  //propagate error to trk beam spot
+  }
 
-    // to pass errors I have to create another beam spot object
-    reco::BeamSpot::CovarianceMatrix matrix;
-    for (int j = 0 ; j < 7 ; ++j) {
-        for(int k = j ; k < 7 ; ++k) {
-            matrix(j,k) = bspotTrk.covariance(j,k);
-        }
-    }
-    // change beam width error to one from PV
-    if (pv_fit_ok && fit_ok ) {
-      matrix(6,6) = MyPVFitter->getWidthXerr() * MyPVFitter->getWidthXerr();
+  if (runFitterNoTxt()) {
+    bspotTrk = fbeamspot;
+    fit_ok = true;
+  } else {
+    // beamfit failed, flagged as empty beam spot
+    bspotTrk.setType(reco::BeamSpot::Fake);
+    fit_ok = false;
+  }
 
-      // get Z and sigmaZ from PV fit
-      matrix(2,2) = bspotPV.covariance(2,2);
-      matrix(3,3) = bspotPV.covariance(3,3);
-      reco::BeamSpot tmpbs(reco::BeamSpot::Point(bspotTrk.x0(), bspotTrk.y0(),
-						 bspotPV.z0() ),
-			   bspotPV.sigmaZ() ,
-			   bspotTrk.dxdz(),
-			   bspotTrk.dydz(),
-			   bspotPV.BeamWidthX(),
-			   matrix,
-			   bspotPV.type() );
-      tmpbs.setBeamWidthY( bspotPV.BeamWidthY() );
-      // overwrite beam spot result
-      fbeamspot = tmpbs;
-    }
-    if (pv_fit_ok && fit_ok) {
-      fbeamspot.setType(bspotPV.type());
-    }
-    else if(!pv_fit_ok && fit_ok){
-      fbeamspot.setType(reco::BeamSpot::Unknown);
-    }
-    else if(pv_fit_ok && !fit_ok){
-      fbeamspot.setType(reco::BeamSpot::Unknown);
-    }
-    else if(!pv_fit_ok && !fit_ok){
-      fbeamspot.setType(reco::BeamSpot::Fake);
-    }
+  // combined results into one single beam spot
 
-    if(writeTxt_ ) dumpTxtFile(outputTxt_,true); // all reaults
-    if(writeDIPTxt_ && ((fit_ok && pv_fit_ok) || writeDIPBadFit_)) {
-        dumpTxtFile(outputDIPTxt_,false); // for DQM/DIP
-        for(size_t i= 0; i < 7; i++)ForDIPPV_.push_back(0.0);
+  // to pass errors I have to create another beam spot object
+  reco::BeamSpot::CovarianceMatrix matrix;
+  for (int j = 0; j < 7; ++j) {
+    for (int k = j; k < 7; ++k) {
+      matrix(j, k) = bspotTrk.covariance(j, k);
     }
+  }
+  // change beam width error to one from PV
+  if (pv_fit_ok && fit_ok) {
+    matrix(6, 6) = MyPVFitter->getWidthXerr() * MyPVFitter->getWidthXerr();
 
-    return fit_ok && pv_fit_ok;
+    // get Z and sigmaZ from PV fit
+    matrix(2, 2) = bspotPV.covariance(2, 2);
+    matrix(3, 3) = bspotPV.covariance(3, 3);
+    reco::BeamSpot tmpbs(reco::BeamSpot::Point(bspotTrk.x0(), bspotTrk.y0(), bspotPV.z0()),
+                         bspotPV.sigmaZ(),
+                         bspotTrk.dxdz(),
+                         bspotTrk.dydz(),
+                         bspotPV.BeamWidthX(),
+                         matrix,
+                         bspotPV.type());
+    tmpbs.setBeamWidthY(bspotPV.BeamWidthY());
+    // overwrite beam spot result
+    fbeamspot = tmpbs;
+  }
+  if (pv_fit_ok && fit_ok) {
+    fbeamspot.setType(bspotPV.type());
+  } else if (!pv_fit_ok && fit_ok) {
+    fbeamspot.setType(reco::BeamSpot::Unknown);
+  } else if (pv_fit_ok && !fit_ok) {
+    fbeamspot.setType(reco::BeamSpot::Unknown);
+  } else if (!pv_fit_ok && !fit_ok) {
+    fbeamspot.setType(reco::BeamSpot::Fake);
+  }
+
+  if (writeTxt_)
+    dumpTxtFile(outputTxt_, true);  // all reaults
+  if (writeDIPTxt_ && ((fit_ok && pv_fit_ok) || writeDIPBadFit_)) {
+    dumpTxtFile(outputDIPTxt_, false);  // for DQM/DIP
+    for (size_t i = 0; i < 7; i++)
+      ForDIPPV_.push_back(0.0);
+  }
+
+  return fit_ok && pv_fit_ok;
 }
 
 bool BeamFitter::runFitterNoTxt() {
   edm::LogInfo("BeamFitter") << " [BeamFitterDebugTime] freftime[0] = " << freftime[0]
-			     << "; address =  " << &freftime[0]
-			     << " = " << fbeginTimeOfFit << std::endl;
+                             << "; address =  " << &freftime[0] << " = " << fbeginTimeOfFit << std::endl;
   edm::LogInfo("BeamFitter") << " [BeamFitterDebugTime] freftime[1] = " << freftime[1]
-			     << "; address =  " << &freftime[1]
-			     << " = " << fendTimeOfFit << std::endl;
+                             << "; address =  " << &freftime[1] << " = " << fendTimeOfFit << std::endl;
 
   if (fbeginLumiOfFit == -1 || fendLumiOfFit == -1) {
-      edm::LogWarning("BeamFitter") << "No event read! No Fitting!" << std::endl;
+    edm::LogWarning("BeamFitter") << "No event read! No Fitting!" << std::endl;
     return false;
   }
 
   bool fit_ok = false;
   // default fit to extract beam spot info
-  if(fBSvector.size() > 1 ){
+  if (fBSvector.size() > 1) {
+    edm::LogInfo("BeamFitter") << "Calculating beam spot..." << std::endl
+                               << "We will use " << fBSvector.size() << " good tracks out of " << ftotal_tracks
+                               << std::endl;
 
-      edm::LogInfo("BeamFitter") << "Calculating beam spot..." << std::endl
-                                 << "We will use " << fBSvector.size() << " good tracks out of " << ftotal_tracks << std::endl;
-
-    BSFitter *myalgo = new BSFitter( fBSvector );
-    myalgo->SetMaximumZ( trk_MaxZ_ );
-    myalgo->SetConvergence( convergence_ );
-    myalgo->SetMinimumNTrks( min_Ntrks_ );
-    if (inputBeamWidth_ > 0 ) myalgo->SetInputBeamWidth( inputBeamWidth_ );
+    BSFitter *myalgo = new BSFitter(fBSvector);
+    myalgo->SetMaximumZ(trk_MaxZ_);
+    myalgo->SetConvergence(convergence_);
+    myalgo->SetMinimumNTrks(min_Ntrks_);
+    if (inputBeamWidth_ > 0)
+      myalgo->SetInputBeamWidth(inputBeamWidth_);
 
     fbeamspot = myalgo->Fit();
 
-
     // retrieve histogram for Vz
-    h1z = (TH1F*) myalgo->GetVzHisto();
+    h1z = (TH1F *)myalgo->GetVzHisto();
 
     delete myalgo;
-    if ( fbeamspot.type() > 0 ) {// save all results except for Fake and Unknown (all 0.)
+    if (fbeamspot.type() > 0) {  // save all results except for Fake and Unknown (all 0.)
       fit_ok = true;
-      if (saveBeamFit_){
-	fx = fbeamspot.x0();
-	fy = fbeamspot.y0();
-	fz = fbeamspot.z0();
-	fsigmaZ = fbeamspot.sigmaZ();
-	fdxdz = fbeamspot.dxdz();
-	fdydz = fbeamspot.dydz();
-	fwidthX = fbeamspot.BeamWidthX();
-	fwidthY = fbeamspot.BeamWidthY();
-	fxErr = fbeamspot.x0Error();
-	fyErr = fbeamspot.y0Error();
-	fzErr = fbeamspot.z0Error();
-	fsigmaZErr = fbeamspot.sigmaZ0Error();
-	fdxdzErr = fbeamspot.dxdzError();
-	fdydzErr = fbeamspot.dydzError();
-	fwidthXErr = fbeamspot.BeamWidthXError();
-	fwidthYErr = fbeamspot.BeamWidthYError();
-	ftreeFit_->Fill();
+      if (saveBeamFit_) {
+        fx = fbeamspot.x0();
+        fy = fbeamspot.y0();
+        fz = fbeamspot.z0();
+        fsigmaZ = fbeamspot.sigmaZ();
+        fdxdz = fbeamspot.dxdz();
+        fdydz = fbeamspot.dydz();
+        fwidthX = fbeamspot.BeamWidthX();
+        fwidthY = fbeamspot.BeamWidthY();
+        fxErr = fbeamspot.x0Error();
+        fyErr = fbeamspot.y0Error();
+        fzErr = fbeamspot.z0Error();
+        fsigmaZErr = fbeamspot.sigmaZ0Error();
+        fdxdzErr = fbeamspot.dxdzError();
+        fdydzErr = fbeamspot.dydzError();
+        fwidthXErr = fbeamspot.BeamWidthXError();
+        fwidthYErr = fbeamspot.BeamWidthYError();
+        ftreeFit_->Fill();
       }
     }
-  }
-  else{ // tracks <= 1
+  } else {  // tracks <= 1
     reco::BeamSpot tmpbs;
     fbeamspot = tmpbs;
     fbeamspot.setType(reco::BeamSpot::Fake);
     edm::LogInfo("BeamFitter") << "Not enough good tracks selected! No beam fit!" << std::endl;
-
   }
   fitted_ = true;
   return fit_ok;
-
 }
 
 bool BeamFitter::runFitter() {
+  bool fit_ok = runFitterNoTxt();
 
-    bool fit_ok = runFitterNoTxt();
-
-    if(writeTxt_ ) dumpTxtFile(outputTxt_,true); // all reaults
-    if(writeDIPTxt_ && (fit_ok || writeDIPBadFit_)) {
-      dumpTxtFile(outputDIPTxt_,false); // for DQM/DIP
-    }
-    return fit_ok;
+  if (writeTxt_)
+    dumpTxtFile(outputTxt_, true);  // all reaults
+  if (writeDIPTxt_ && (fit_ok || writeDIPBadFit_)) {
+    dumpTxtFile(outputDIPTxt_, false);  // for DQM/DIP
+  }
+  return fit_ok;
 }
 
 bool BeamFitter::runBeamWidthFitter() {
   bool widthfit_ok = false;
   // default fit to extract beam spot info
-  if(fBSvector.size() > 1 ){
+  if (fBSvector.size() > 1) {
+    edm::LogInfo("BeamFitter") << "Calculating beam spot positions('d0-phi0' method) and width using llh Fit"
+                               << std::endl
+                               << "We will use " << fBSvector.size() << " good tracks out of " << ftotal_tracks
+                               << std::endl;
 
-      edm::LogInfo("BeamFitter") << "Calculating beam spot positions('d0-phi0' method) and width using llh Fit"<< std::endl
-                                 << "We will use " << fBSvector.size() << " good tracks out of " << ftotal_tracks << std::endl;
+    BSFitter *myalgo = new BSFitter(fBSvector);
+    myalgo->SetMaximumZ(trk_MaxZ_);
+    myalgo->SetConvergence(convergence_);
+    myalgo->SetMinimumNTrks(min_Ntrks_);
+    if (inputBeamWidth_ > 0)
+      myalgo->SetInputBeamWidth(inputBeamWidth_);
 
-        BSFitter *myalgo = new BSFitter( fBSvector );
-        myalgo->SetMaximumZ( trk_MaxZ_ );
-        myalgo->SetConvergence( convergence_ );
-        myalgo->SetMinimumNTrks(min_Ntrks_);
-        if (inputBeamWidth_ > 0 ) myalgo->SetInputBeamWidth( inputBeamWidth_ );
+    myalgo->SetFitVariable(std::string("d*z"));
+    myalgo->SetFitType(std::string("likelihood"));
+    fbeamWidthFit = myalgo->Fit();
 
+    //Add to .txt file
+    if (writeTxt_)
+      dumpBWTxtFile(outputTxt_);
 
-   myalgo->SetFitVariable(std::string("d*z"));
-   myalgo->SetFitType(std::string("likelihood"));
-   fbeamWidthFit = myalgo->Fit();
+    delete myalgo;
 
-   //Add to .txt file
-   if(writeTxt_   ) dumpBWTxtFile(outputTxt_);
-
-   delete myalgo;
-
-   // not fake
-   if ( fbeamspot.type() != 0 )
-       widthfit_ok = true;
-  }
-  else{
+    // not fake
+    if (fbeamspot.type() != 0)
+      widthfit_ok = true;
+  } else {
     fbeamspot.setType(reco::BeamSpot::Fake);
     edm::LogWarning("BeamFitter") << "Not enough good tracks selected! No beam fit!" << std::endl;
   }
   return widthfit_ok;
 }
 
-void BeamFitter::dumpBWTxtFile(std::string & fileName ){
-    std::ofstream outFile;
-    outFile.open(fileName.c_str(),std::ios::app);
-    outFile<<"-------------------------------------------------------------------------------------------------------------------------------------------------------------"<<std::endl;
-    outFile<<"Beam width(in cm) from Log-likelihood fit (Here we assume a symmetric beam(SigmaX=SigmaY)!)"<<std::endl;
-    outFile<<"   "<<std::endl;
-    outFile << "BeamWidth =  " <<fbeamWidthFit.BeamWidthX() <<" +/- "<<fbeamWidthFit.BeamWidthXError() << std::endl;
-    outFile.close();
+void BeamFitter::dumpBWTxtFile(std::string &fileName) {
+  std::ofstream outFile;
+  outFile.open(fileName.c_str(), std::ios::app);
+  outFile << "---------------------------------------------------------------------------------------------------------"
+             "----------------------------------------------------"
+          << std::endl;
+  outFile << "Beam width(in cm) from Log-likelihood fit (Here we assume a symmetric beam(SigmaX=SigmaY)!)" << std::endl;
+  outFile << "   " << std::endl;
+  outFile << "BeamWidth =  " << fbeamWidthFit.BeamWidthX() << " +/- " << fbeamWidthFit.BeamWidthXError() << std::endl;
+  outFile.close();
 }
 
-void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
+void BeamFitter::dumpTxtFile(std::string &fileName, bool append) {
   std::ofstream outFile;
 
   std::string tmpname = outputTxt_;
   char index[15];
-  if (appendRunTxt_ && writeTxt_ && !ffilename_changed ) {
-      sprintf(index,"%s%i","_Run", frun );
-      tmpname.insert(outputTxt_.length()-4,index);
-      fileName = tmpname;
-      ffilename_changed = true;
+  if (appendRunTxt_ && writeTxt_ && !ffilename_changed) {
+    sprintf(index, "%s%i", "_Run", frun);
+    tmpname.insert(outputTxt_.length() - 4, index);
+    fileName = tmpname;
+    ffilename_changed = true;
   }
 
   if (!append)
     outFile.open(fileName.c_str());
   else
-    outFile.open(fileName.c_str(),std::ios::app);
+    outFile.open(fileName.c_str(), std::ios::app);
 
-  if ( MyPVFitter->IsFitPerBunchCrossing() ) {
-
-    for (std::map<int,reco::BeamSpot>::const_iterator abspot = fbspotPVMap.begin(); abspot!= fbspotPVMap.end(); ++abspot) {
+  if (MyPVFitter->IsFitPerBunchCrossing()) {
+    for (std::map<int, reco::BeamSpot>::const_iterator abspot = fbspotPVMap.begin(); abspot != fbspotPVMap.end();
+         ++abspot) {
       reco::BeamSpot beamspottmp = abspot->second;
       int bx = abspot->first;
 
@@ -657,54 +664,52 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
       outFile << "dydz " << beamspottmp.dydz() << std::endl;
       outFile << "BeamWidthX " << beamspottmp.BeamWidthX() << std::endl;
       outFile << "BeamWidthY " << beamspottmp.BeamWidthY() << std::endl;
-      for (int i = 0; i<6; ++i) {
-	outFile << "Cov("<<i<<",j) ";
-	for (int j=0; j<7; ++j) {
-	  outFile << beamspottmp.covariance(i,j) << " ";
-	}
-	outFile << std::endl;
+      for (int i = 0; i < 6; ++i) {
+        outFile << "Cov(" << i << ",j) ";
+        for (int j = 0; j < 7; ++j) {
+          outFile << beamspottmp.covariance(i, j) << " ";
+        }
+        outFile << std::endl;
       }
-      outFile << "Cov(6,j) 0 0 0 0 0 0 " << beamspottmp.covariance(6,6) << std::endl;
+      outFile << "Cov(6,j) 0 0 0 0 0 0 " << beamspottmp.covariance(6, 6) << std::endl;
       //}
       outFile << "EmittanceX " << beamspottmp.emittanceX() << std::endl;
       outFile << "EmittanceY " << beamspottmp.emittanceY() << std::endl;
       outFile << "BetaStar " << beamspottmp.betaStar() << std::endl;
-
     }
-  }//if bx results needed
+  }  //if bx results needed
   else {
-  
     beamspot::BeamSpotContainer currentBS;
-    
-    currentBS.beamspot       = fbeamspot      ;
-    currentBS.run            = frun           ;
-    std::copy(fbeginTimeOfFit, fbeginTimeOfFit+32, currentBS.beginTimeOfFit);
-    std::copy(fendTimeOfFit  , fendTimeOfFit  +32, currentBS.endTimeOfFit  );
+
+    currentBS.beamspot = fbeamspot;
+    currentBS.run = frun;
+    std::copy(fbeginTimeOfFit, fbeginTimeOfFit + 32, currentBS.beginTimeOfFit);
+    std::copy(fendTimeOfFit, fendTimeOfFit + 32, currentBS.endTimeOfFit);
     currentBS.beginLumiOfFit = fbeginLumiOfFit;
-    currentBS.endLumiOfFit   = fendLumiOfFit  ;
-    std::copy(freftime, freftime+2, currentBS.reftime);
-          
+    currentBS.endLumiOfFit = fendLumiOfFit;
+    std::copy(freftime, freftime + 2, currentBS.reftime);
+
     beamspot::dumpBeamSpotTxt(outFile, currentBS);
-        
+
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
-  if(!append){
-    outFile << "events "<< (int)ForDIPPV_[0] << std::endl;
-    outFile << "meanPV "<< ForDIPPV_[1] << std::endl;
-    outFile << "meanErrPV "<< ForDIPPV_[2] << std::endl;
-    outFile << "rmsPV "<< ForDIPPV_[3] << std::endl;
-    outFile << "rmsErrPV "<< ForDIPPV_[4] << std::endl;
-    outFile << "maxPV "<< (int)ForDIPPV_[5] << std::endl;
-    outFile << "nPV "<< (int)ForDIPPV_[6] << std::endl;
-   }//writeDIPPVInfo_
-  }//else end  here
-  
+    if (!append) {
+      outFile << "events " << (int)ForDIPPV_[0] << std::endl;
+      outFile << "meanPV " << ForDIPPV_[1] << std::endl;
+      outFile << "meanErrPV " << ForDIPPV_[2] << std::endl;
+      outFile << "rmsPV " << ForDIPPV_[3] << std::endl;
+      outFile << "rmsErrPV " << ForDIPPV_[4] << std::endl;
+      outFile << "maxPV " << (int)ForDIPPV_[5] << std::endl;
+      outFile << "nPV " << (int)ForDIPPV_[6] << std::endl;
+    }  //writeDIPPVInfo_
+  }    //else end  here
+
   outFile.close();
 }
 
-void BeamFitter::write2DB(){
+void BeamFitter::write2DB() {
   BeamSpotObjects *pBSObjects = new BeamSpotObjects();
 
-  pBSObjects->SetPosition(fbeamspot.position().X(),fbeamspot.position().Y(),fbeamspot.position().Z());
+  pBSObjects->SetPosition(fbeamspot.position().X(), fbeamspot.position().Y(), fbeamspot.position().Z());
   //std::cout << " wrote: x= " << fbeamspot.position().X() << " y= "<< fbeamspot.position().Y() << " z= " << fbeamspot.position().Z() << std::endl;
   pBSObjects->SetSigmaZ(fbeamspot.sigmaZ());
   pBSObjects->Setdxdz(fbeamspot.dxdz());
@@ -714,45 +719,43 @@ void BeamFitter::write2DB(){
   //  pBSObjects->SetBeamWidthX(inputBeamWidth_);
   //  pBSObjects->SetBeamWidthY(inputBeamWidth_);
   //} else {
-    // need to fix this
-    //std::cout << " using default value, 15e-4, for beam width!!!"<<std::endl;
-  pBSObjects->SetBeamWidthX(fbeamspot.BeamWidthX() );
-  pBSObjects->SetBeamWidthY(fbeamspot.BeamWidthY() );
+  // need to fix this
+  //std::cout << " using default value, 15e-4, for beam width!!!"<<std::endl;
+  pBSObjects->SetBeamWidthX(fbeamspot.BeamWidthX());
+  pBSObjects->SetBeamWidthY(fbeamspot.BeamWidthY());
   //}
 
-  for (int i = 0; i<7; ++i) {
-    for (int j=0; j<7; ++j) {
-      pBSObjects->SetCovariance(i,j,fbeamspot.covariance(i,j));
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      pBSObjects->SetCovariance(i, j, fbeamspot.covariance(i, j));
     }
   }
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ) {
-    std::cout << "poolDBService available"<<std::endl;
-    if ( poolDbService->isNewTagRequest( "BeamSpotObjectsRcd" ) ) {
+  if (poolDbService.isAvailable()) {
+    std::cout << "poolDBService available" << std::endl;
+    if (poolDbService->isNewTagRequest("BeamSpotObjectsRcd")) {
       std::cout << "new tag requested" << std::endl;
-      poolDbService->createNewIOV<BeamSpotObjects>( pBSObjects, poolDbService->beginOfTime(),poolDbService->endOfTime(),
-						    "BeamSpotObjectsRcd"  );
-    }
-    else {
+      poolDbService->createNewIOV<BeamSpotObjects>(
+          pBSObjects, poolDbService->beginOfTime(), poolDbService->endOfTime(), "BeamSpotObjectsRcd");
+    } else {
       std::cout << "no new tag requested" << std::endl;
-      poolDbService->appendSinceTime<BeamSpotObjects>( pBSObjects, poolDbService->currentTime(),
-						       "BeamSpotObjectsRcd" );
+      poolDbService->appendSinceTime<BeamSpotObjects>(pBSObjects, poolDbService->currentTime(), "BeamSpotObjectsRcd");
     }
   }
 }
 
 void BeamFitter::runAllFitter() {
-  if(!fBSvector.empty()){
-    BSFitter *myalgo = new BSFitter( fBSvector );
+  if (!fBSvector.empty()) {
+    BSFitter *myalgo = new BSFitter(fBSvector);
     fbeamspot = myalgo->Fit_d0phi();
 
     // iterative
-    if(debug_)
+    if (debug_)
       std::cout << " d0-phi Iterative:" << std::endl;
-    BSFitter *myitealgo = new BSFitter( fBSvector );
+    BSFitter *myitealgo = new BSFitter(fBSvector);
     myitealgo->Setd0Cut_d0phi(4.0);
     reco::BeamSpot beam_ite = myitealgo->Fit_ited0phi();
-    if (debug_){
+    if (debug_) {
       std::cout << beam_ite << std::endl;
       std::cout << "\n Now run tests of the different fits\n";
     }
@@ -761,7 +764,7 @@ void BeamFitter::runAllFitter() {
     myalgo->SetFitVariable(std::string("z"));
     myalgo->SetFitType(std::string("chi2"));
     reco::BeamSpot beam_fit_z_chi2 = myalgo->Fit();
-    if (debug_){
+    if (debug_) {
       std::cout << " z Chi2 Fit ONLY:" << std::endl;
       std::cout << beam_fit_z_chi2 << std::endl;
     }
@@ -770,7 +773,7 @@ void BeamFitter::runAllFitter() {
     myalgo->SetFitVariable("z");
     myalgo->SetFitType("combined");
     reco::BeamSpot beam_fit_z_lh = myalgo->Fit();
-    if (debug_){
+    if (debug_) {
       std::cout << " z Log-Likelihood Fit ONLY:" << std::endl;
       std::cout << beam_fit_z_lh << std::endl;
     }
@@ -778,7 +781,7 @@ void BeamFitter::runAllFitter() {
     myalgo->SetFitVariable("d");
     myalgo->SetFitType("d0phi");
     reco::BeamSpot beam_fit_dphi = myalgo->Fit();
-    if (debug_){
+    if (debug_) {
       std::cout << " d0-phi0 Fit ONLY:" << std::endl;
       std::cout << beam_fit_dphi << std::endl;
     }
@@ -802,8 +805,6 @@ void BeamFitter::runAllFitter() {
       std::cout << "c1 = " << myalgo->GetResPar1() << " +- " << myalgo->GetResPar1Err() << std::endl;
     }
     */
-  }
-  else
-    if (debug_) std::cout << "No good track selected! No beam fit!" << std::endl;
+  } else if (debug_)
+    std::cout << "No good track selected! No beam fit!" << std::endl;
 }
-

--- a/RecoVertex/BeamSpotProducer/src/BeamSpotTreeData.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamSpotTreeData.cc
@@ -1,23 +1,21 @@
 #include "RecoVertex/BeamSpotProducer/interface/BeamSpotTreeData.h"
 #include <TTree.h>
 
-
-BeamSpotTreeData::BeamSpotTreeData(){}
-BeamSpotTreeData::~BeamSpotTreeData(){}
-
+BeamSpotTreeData::BeamSpotTreeData() {}
+BeamSpotTreeData::~BeamSpotTreeData() {}
 
 //--------------------------------------------------------------------------------------------------
-void BeamSpotTreeData::branch(TTree* tree){
-  tree->Branch("run"	      , &run_	       , "run/i");
-  tree->Branch("lumi"	      , &lumi_	       , "lumi/i");
+void BeamSpotTreeData::branch(TTree* tree) {
+  tree->Branch("run", &run_, "run/i");
+  tree->Branch("lumi", &lumi_, "lumi/i");
   tree->Branch("bunchCrossing", &bunchCrossing_, "bunchCrossing/i");
-  tree->Branch("pvData"	      , &pvData_       , "bunchCrossing:position[3]:posError[3]:posCorr[3]/F");
+  tree->Branch("pvData", &pvData_, "bunchCrossing:position[3]:posError[3]:posCorr[3]/F");
 }
 
 //--------------------------------------------------------------------------------------------------
-void BeamSpotTreeData::setBranchAddress(TTree* tree){
-  tree->SetBranchAddress("run"	        , &run_	         );
-  tree->SetBranchAddress("lumi"	        , &lumi_	 );
+void BeamSpotTreeData::setBranchAddress(TTree* tree) {
+  tree->SetBranchAddress("run", &run_);
+  tree->SetBranchAddress("lumi", &lumi_);
   tree->SetBranchAddress("bunchCrossing", &bunchCrossing_);
-  tree->SetBranchAddress("pvData"	, &pvData_       );
+  tree->SetBranchAddress("pvData", &pvData_);
 }

--- a/RecoVertex/BeamSpotProducer/src/FcnBeamSpotFitPV.cc
+++ b/RecoVertex/BeamSpotProducer/src/FcnBeamSpotFitPV.cc
@@ -9,20 +9,15 @@ using namespace std;
 //
 // constructor from vertex data
 //
-FcnBeamSpotFitPV::FcnBeamSpotFitPV(const vector<BeamSpotFitPVData>& data) : 
-  data_(data), errorDef_(1.) { 
+FcnBeamSpotFitPV::FcnBeamSpotFitPV(const vector<BeamSpotFitPVData>& data) : data_(data), errorDef_(1.) {
   //
   // default: no additional cuts
   //
   lowerLimits_[0] = lowerLimits_[1] = lowerLimits_[2] = -1.e30;
-  upperLimits_[0] = upperLimits_[1] = upperLimits_[2] =  1.e30;
+  upperLimits_[0] = upperLimits_[1] = upperLimits_[2] = 1.e30;
 }
 
-void 
-FcnBeamSpotFitPV::setLimits (float xmin, float xmax,
-			  float ymin, float ymax,
-			  float zmin, float zmax) 
-{
+void FcnBeamSpotFitPV::setLimits(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) {
   lowerLimits_[0] = xmin;
   lowerLimits_[1] = ymin;
   lowerLimits_[2] = zmin;
@@ -31,9 +26,7 @@ FcnBeamSpotFitPV::setLimits (float xmin, float xmax,
   upperLimits_[2] = zmax;
 }
 
-unsigned int
-FcnBeamSpotFitPV::nrOfVerticesUsed () const
-{
+unsigned int FcnBeamSpotFitPV::nrOfVerticesUsed() const {
   //
   // count vertices imposing the current limits
   //
@@ -41,14 +34,16 @@ FcnBeamSpotFitPV::nrOfVerticesUsed () const
   double v1(0);
   double v2(0);
   double v3(0);
-  for ( vector<BeamSpotFitPVData>::const_iterator ipv=data_.begin();
-	ipv!=data_.end(); ++ipv ) {
+  for (vector<BeamSpotFitPVData>::const_iterator ipv = data_.begin(); ipv != data_.end(); ++ipv) {
     v1 = (*ipv).position[0];
-    if ( v1<lowerLimits_[0] || v1>upperLimits_[0] )  continue;
+    if (v1 < lowerLimits_[0] || v1 > upperLimits_[0])
+      continue;
     v2 = (*ipv).position[1];
-    if ( v2<lowerLimits_[1] || v2>upperLimits_[1] )  continue;
+    if (v2 < lowerLimits_[1] || v2 > upperLimits_[1])
+      continue;
     v3 = (*ipv).position[2];
-    if ( v3<lowerLimits_[2] || v3>upperLimits_[2] )  continue;
+    if (v3 < lowerLimits_[2] || v3 > upperLimits_[2])
+      continue;
 
     ++nVtx;
   }
@@ -56,16 +51,14 @@ FcnBeamSpotFitPV::nrOfVerticesUsed () const
   return nVtx;
 }
 
-double
-FcnBeamSpotFitPV::operator() (const std::vector<double>& pars) const
-{
+double FcnBeamSpotFitPV::operator()(const std::vector<double>& pars) const {
   //
   // fit parameters
   //
   double vb1 = pars[0];
   double vb2 = pars[1];
   double vb3 = pars[2];
-  double sigb1 = pars[3]; 
+  double sigb1 = pars[3];
   double corrb12 = pars[4];
   double sigb2 = pars[5];
   double dxdz = pars[6];
@@ -75,19 +68,19 @@ FcnBeamSpotFitPV::operator() (const std::vector<double>& pars) const
   //
   // covariance matrix of the beamspot distribution
   //
-  typedef ROOT::Math::SVector<double,3> Vector3D;
-  typedef ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> > Matrix3D;
+  typedef ROOT::Math::SVector<double, 3> Vector3D;
+  typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > Matrix3D;
   Matrix3D covb;
-  double varb1 = sigb1*sigb1;
-  double varb2 = sigb2*sigb2;
-  double varb3 = sigb3*sigb3;
-// parametrisation: rotation (dx/dz, dy/dz); covxy
-  covb(0,0) = varb1;
-  covb(1,0) = covb(0,1) = corrb12*sigb1*sigb2;
-  covb(1,1) = varb2;
-  covb(2,0) = covb(0,2) = dxdz*(varb3-varb1)-dydz*covb(1,0);
-  covb(2,1) = covb(1,2) = dydz*(varb3-varb2)-dxdz*covb(1,0);
-  covb(2,2) = varb3;
+  double varb1 = sigb1 * sigb1;
+  double varb2 = sigb2 * sigb2;
+  double varb3 = sigb3 * sigb3;
+  // parametrisation: rotation (dx/dz, dy/dz); covxy
+  covb(0, 0) = varb1;
+  covb(1, 0) = covb(0, 1) = corrb12 * sigb1 * sigb2;
+  covb(1, 1) = varb2;
+  covb(2, 0) = covb(0, 2) = dxdz * (varb3 - varb1) - dydz * covb(1, 0);
+  covb(2, 1) = covb(1, 2) = dydz * (varb3 - varb2) - dxdz * covb(1, 0);
+  covb(2, 2) = varb3;
 
   //
   // calculation of the likelihood function
@@ -111,17 +104,19 @@ FcnBeamSpotFitPV::operator() (const std::vector<double>& pars) const
   //
   // iteration over vertices
   //
-  for ( vector<BeamSpotFitPVData>::const_iterator ipv=data_.begin();
-	ipv!=data_.end(); ++ipv ) {
+  for (vector<BeamSpotFitPVData>::const_iterator ipv = data_.begin(); ipv != data_.end(); ++ipv) {
     //
     // additional selection
     //
     v1 = (*ipv).position[0];
-    if ( v1<lowerLimits_[0] || v1>upperLimits_[0] )  continue;
+    if (v1 < lowerLimits_[0] || v1 > upperLimits_[0])
+      continue;
     v2 = (*ipv).position[1];
-    if ( v2<lowerLimits_[1] || v2>upperLimits_[1] )  continue;
+    if (v2 < lowerLimits_[1] || v2 > upperLimits_[1])
+      continue;
     v3 = (*ipv).position[2];
-    if ( v3<lowerLimits_[2] || v3>upperLimits_[2] )  continue;
+    if (v3 < lowerLimits_[2] || v3 > upperLimits_[2])
+      continue;
     //
     // vertex errors (after scaling) and correlations
     //
@@ -137,20 +132,20 @@ FcnBeamSpotFitPV::operator() (const std::vector<double>& pars) const
     //
     // vertex covariance matrix
     //
-    cov(0,0) = ev1*ev1;
-    cov(1,0) = cov(0,1) = ev1*ev2*corr12;
-    cov(1,1) = ev2*ev2;
-    cov(2,0) = cov(0,2) = ev1*ev3*corr13;
-    cov(2,1) = cov(1,2) = ev2*ev3*corr23;
-    cov(2,2) = ev3*ev3;
+    cov(0, 0) = ev1 * ev1;
+    cov(1, 0) = cov(0, 1) = ev1 * ev2 * corr12;
+    cov(1, 1) = ev2 * ev2;
+    cov(2, 0) = cov(0, 2) = ev1 * ev3 * corr13;
+    cov(2, 1) = cov(1, 2) = ev2 * ev3 * corr23;
+    cov(2, 2) = ev3 * ev3;
     //
     // total covariance and weight matrix
     //
     cov += covb;
     int ifail;
     wgt = cov.Inverse(ifail);
-    if ( ifail ) {
-      //edm::LogWarning("FcnBeamSpotFitPV") 
+    if (ifail) {
+      //edm::LogWarning("FcnBeamSpotFitPV")
       cout << "Inversion failed" << endl;
       return -1.e30;
     }
@@ -164,7 +159,7 @@ FcnBeamSpotFitPV::operator() (const std::vector<double>& pars) const
     // exponential term and normalization
     // (neglecting the additional cut)
     //
-    sumLL += ROOT::Math::Similarity(dv,wgt);
+    sumLL += ROOT::Math::Similarity(dv, wgt);
     double det;
     cov.Det2(det);
     sumLL += log(det);
@@ -172,4 +167,3 @@ FcnBeamSpotFitPV::operator() (const std::vector<double>& pars) const
 
   return sumLL;
 }
-

--- a/RecoVertex/BeamSpotProducer/src/PVFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/PVFitter.cc
@@ -39,136 +39,130 @@ ________________________________________________________________**/
 #include "TDirectory.h"
 #include "TMinuitMinimizer.h"
 
-#include <iostream>  
+#include <iostream>
 #include <sstream>
-using namespace std ;
+using namespace std;
 
-PVFitter::PVFitter(const edm::ParameterSet& iConfig,
-                   edm::ConsumesCollector &&iColl)
-  : ftree_(nullptr)
-{
+PVFitter::PVFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iColl) : ftree_(nullptr) {
   initialize(iConfig, iColl);
 }
 
-PVFitter::PVFitter(const edm::ParameterSet& iConfig,
-                   edm::ConsumesCollector &iColl)
-    :ftree_(nullptr)
-{
+PVFitter::PVFitter(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iColl) : ftree_(nullptr) {
   initialize(iConfig, iColl);
 }
 
-void PVFitter::initialize(const edm::ParameterSet& iConfig,
-                          edm::ConsumesCollector &iColl)
-{
+void PVFitter::initialize(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iColl) {
   //In order to make fitting ROOT histograms thread safe
   // one must call this undocumented function
   TMinuitMinimizer::UseStaticMinuit(false);
-  debug_             = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("Debug");
-  vertexToken_       = iColl.consumes<reco::VertexCollection>(
+  debug_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("Debug");
+  vertexToken_ = iColl.consumes<reco::VertexCollection>(
       iConfig.getParameter<edm::ParameterSet>("PVFitter")
-      .getUntrackedParameter<edm::InputTag>("VertexCollection", edm::InputTag("offlinePrimaryVertices")));
-  do3DFit_           = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("Apply3DFit");
+          .getUntrackedParameter<edm::InputTag>("VertexCollection", edm::InputTag("offlinePrimaryVertices")));
+  do3DFit_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("Apply3DFit");
   //writeTxt_          = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("WriteAscii");
   //outputTxt_         = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<std::string>("AsciiFileName");
-  maxNrVertices_     = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<unsigned int>("maxNrStoredVertices");
-  minNrVertices_     = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<unsigned int>("minNrVerticesForFit");
-  minVtxNdf_         = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("minVertexNdf");
-  maxVtxNormChi2_    = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("maxVertexNormChi2");
-  minVtxTracks_      = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<unsigned int>("minVertexNTracks");
-  minVtxWgt_         = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("minVertexMeanWeight");
-  maxVtxR_           = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("maxVertexR");
-  maxVtxZ_           = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("maxVertexZ");
-  errorScale_        = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("errorScale");
-  sigmaCut_          = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("nSigmaCut");
-  fFitPerBunchCrossing=iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("FitPerBunchCrossing");
-  useOnlyFirstPV_    = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("useOnlyFirstPV");
-  minSumPt_          = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("minSumPt");
-  
+  maxNrVertices_ =
+      iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<unsigned int>("maxNrStoredVertices");
+  minNrVertices_ =
+      iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<unsigned int>("minNrVerticesForFit");
+  minVtxNdf_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("minVertexNdf");
+  maxVtxNormChi2_ =
+      iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("maxVertexNormChi2");
+  minVtxTracks_ =
+      iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<unsigned int>("minVertexNTracks");
+  minVtxWgt_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("minVertexMeanWeight");
+  maxVtxR_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("maxVertexR");
+  maxVtxZ_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("maxVertexZ");
+  errorScale_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("errorScale");
+  sigmaCut_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("nSigmaCut");
+  fFitPerBunchCrossing =
+      iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("FitPerBunchCrossing");
+  useOnlyFirstPV_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<bool>("useOnlyFirstPV");
+  minSumPt_ = iConfig.getParameter<edm::ParameterSet>("PVFitter").getUntrackedParameter<double>("minSumPt");
+
   // preset quality cut to "infinite"
   dynamicQualityCut_ = 1.e30;
 
-  hPVx = new TH2F("hPVx","PVx vs PVz distribution",200,-maxVtxR_, maxVtxR_, 200, -maxVtxZ_, maxVtxZ_);
-  hPVy = new TH2F("hPVy","PVy vs PVz distribution",200,-maxVtxR_, maxVtxR_, 200, -maxVtxZ_, maxVtxZ_);
+  hPVx = new TH2F("hPVx", "PVx vs PVz distribution", 200, -maxVtxR_, maxVtxR_, 200, -maxVtxZ_, maxVtxZ_);
+  hPVy = new TH2F("hPVy", "PVy vs PVz distribution", 200, -maxVtxR_, maxVtxR_, 200, -maxVtxZ_, maxVtxZ_);
 }
 
-PVFitter::~PVFitter() {
+PVFitter::~PVFitter() {}
 
-}
-
-
-void PVFitter::readEvent(const edm::Event& iEvent)
-{
-
+void PVFitter::readEvent(const edm::Event& iEvent) {
   //------ Primary Vertices
-  edm::Handle< reco::VertexCollection > PVCollection;
+  edm::Handle<reco::VertexCollection> PVCollection;
   bool hasPVs = false;
 
-  if ( iEvent.getByToken(vertexToken_, PVCollection ) ) {
-      hasPVs = true;
+  if (iEvent.getByToken(vertexToken_, PVCollection)) {
+    hasPVs = true;
   }
   //------
 
-  if ( hasPVs ) {
+  if (hasPVs) {
+    for (reco::VertexCollection::const_iterator pv = PVCollection->begin(); pv != PVCollection->end(); ++pv) {
+      if (useOnlyFirstPV_) {
+        if (pv != PVCollection->begin())
+          break;
+      }
 
-      for (reco::VertexCollection::const_iterator pv = PVCollection->begin(); pv != PVCollection->end(); ++pv ) {
-          if (useOnlyFirstPV_){
-            if (pv != PVCollection->begin()) break;
-          }
+      //--- vertex selection
+      if (pv->isFake() || pv->tracksSize() == 0)
+        continue;
+      if (pv->ndof() < minVtxNdf_ || (pv->ndof() + 3.) / pv->tracksSize() < 2 * minVtxWgt_)
+        continue;
+      //---
 
-          //--- vertex selection
-          if ( pv->isFake() || pv->tracksSize()==0 )  continue;
-          if ( pv->ndof() < minVtxNdf_ || (pv->ndof()+3.)/pv->tracksSize()<2*minVtxWgt_ )  continue;
-          //---
+      if (pv->tracksSize() < minVtxTracks_)
+        continue;
 
-          if (pv->tracksSize() < minVtxTracks_ ) continue;
+      const auto& testTrack = pv->trackRefAt(0);
+      if (testTrack.isNull() || !testTrack.isAvailable()) {
+        edm::LogInfo("") << "Track collection not found. Skipping cut on sumPt.";
+      } else {
+        double sumPt = 0;
+        for (auto iTrack = pv->tracks_begin(); iTrack != pv->tracks_end(); ++iTrack) {
+          const auto pt = (*iTrack)->pt();
+          sumPt += pt;
+        }
+        if (sumPt < minSumPt_)
+          continue;
+      }
 
-          const auto& testTrack = pv->trackRefAt(0);
-          if(testTrack.isNull() || !testTrack.isAvailable())
-          {
-              edm::LogInfo("") << "Track collection not found. Skipping cut on sumPt.";
-          }
-          else
-          {
-              double sumPt=0;
-              for(auto iTrack = pv->tracks_begin(); iTrack != pv->tracks_end(); ++iTrack)
-              {
-                  const auto pt = (*iTrack)->pt();
-                  sumPt += pt;
-              }
-              if (sumPt < minSumPt_) continue;
-          }
+      hPVx->Fill(pv->x(), pv->z());
+      hPVy->Fill(pv->y(), pv->z());
 
-          hPVx->Fill( pv->x(), pv->z() );
-          hPVy->Fill( pv->y(), pv->z() );
+      //
+      // 3D fit section
+      //
+      // apply additional quality cut
+      if (pvQuality(*pv) > dynamicQualityCut_)
+        continue;
+      // if store exceeds max. size: reduce size and apply new quality cut
+      if (pvStore_.size() >= maxNrVertices_) {
+        compressStore();
+        if (pvQuality(*pv) > dynamicQualityCut_)
+          continue;
+      }
+      //
+      // copy PV to store
+      //
+      int bx = iEvent.bunchCrossing();
+      BeamSpotFitPVData pvData;
+      pvData.bunchCrossing = bx;
+      pvData.position[0] = pv->x();
+      pvData.position[1] = pv->y();
+      pvData.position[2] = pv->z();
+      pvData.posError[0] = pv->xError();
+      pvData.posError[1] = pv->yError();
+      pvData.posError[2] = pv->zError();
+      pvData.posCorr[0] = pv->covariance(0, 1) / pv->xError() / pv->yError();
+      pvData.posCorr[1] = pv->covariance(0, 2) / pv->xError() / pv->zError();
+      pvData.posCorr[2] = pv->covariance(1, 2) / pv->yError() / pv->zError();
+      pvStore_.push_back(pvData);
 
-          //
-          // 3D fit section
-          //
-          // apply additional quality cut
-          if ( pvQuality(*pv)>dynamicQualityCut_ )  continue;
-          // if store exceeds max. size: reduce size and apply new quality cut
-          if ( pvStore_.size()>=maxNrVertices_ ) {
-             compressStore();
-             if ( pvQuality(*pv)>dynamicQualityCut_ )  continue;
-          }
-          //
-          // copy PV to store
-          //
-          int bx = iEvent.bunchCrossing();
-          BeamSpotFitPVData pvData;
-          pvData.bunchCrossing = bx;
-          pvData.position[0] = pv->x();
-          pvData.position[1] = pv->y();
-          pvData.position[2] = pv->z();
-          pvData.posError[0] = pv->xError();
-          pvData.posError[1] = pv->yError();
-          pvData.posError[2] = pv->zError();
-          pvData.posCorr[0] = pv->covariance(0,1)/pv->xError()/pv->yError();
-          pvData.posCorr[1] = pv->covariance(0,2)/pv->xError()/pv->zError();
-          pvData.posCorr[2] = pv->covariance(1,2)/pv->yError()/pv->zError();
-          pvStore_.push_back(pvData);
-
-      if(ftree_ != nullptr){
+      if (ftree_ != nullptr) {
         theBeamSpotTreeData_.run(iEvent.id().run());
         theBeamSpotTreeData_.lumi(iEvent.luminosityBlock());
         theBeamSpotTreeData_.bunchCrossing(bx);
@@ -176,38 +170,35 @@ void PVFitter::readEvent(const edm::Event& iEvent)
         ftree_->Fill();
       }
 
-      if (fFitPerBunchCrossing) bxMap_[bx].push_back(pvData);
-
-      }
-
+      if (fFitPerBunchCrossing)
+        bxMap_[bx].push_back(pvData);
+    }
   }
-
 }
 
-void PVFitter::setTree(TTree* tree){
+void PVFitter::setTree(TTree* tree) {
   ftree_ = tree;
   theBeamSpotTreeData_.branch(ftree_);
 }
 
 bool PVFitter::runBXFitter() {
-
   using namespace ROOT::Minuit2;
   edm::LogInfo("PVFitter") << " Number of bunch crossings: " << bxMap_.size() << std::endl;
 
   bool fit_ok = true;
 
-  for ( std::map<int,std::vector<BeamSpotFitPVData> >::const_iterator pvStore = bxMap_.begin();
-	pvStore!=bxMap_.end(); ++pvStore) {
-
+  for (std::map<int, std::vector<BeamSpotFitPVData> >::const_iterator pvStore = bxMap_.begin(); pvStore != bxMap_.end();
+       ++pvStore) {
     // first set null beam spot in case
     // fit fails
     fbspotMap[pvStore->first] = reco::BeamSpot();
 
-    edm::LogInfo("PVFitter") << " Number of PVs collected for PVFitter: " << (pvStore->second).size() << " in bx: " << pvStore->first << std::endl;
+    edm::LogInfo("PVFitter") << " Number of PVs collected for PVFitter: " << (pvStore->second).size()
+                             << " in bx: " << pvStore->first << std::endl;
 
-    if ( (pvStore->second).size() <= minNrVertices_ ) {
-        edm::LogWarning("PVFitter") << " not enough PVs, continue" << std::endl;
-	fit_ok = false;
+    if ((pvStore->second).size() <= minNrVertices_) {
+      edm::LogWarning("PVFitter") << " not enough PVs, continue" << std::endl;
+      fit_ok = false;
       continue;
     }
 
@@ -221,17 +212,16 @@ bool PVFitter::runBXFitter() {
     // fit parameters: positions, widths, x-y correlations, tilts in xz and yz
     //
     MnUserParameters upar;
-    upar.Add("x"     , 0.   , 0.02  , -10., 10.);  // 0
-    upar.Add("y"     , 0.   , 0.02  , -10., 10.);  // 1
-    upar.Add("z"     , 0.   , 0.20  , -30., 30.);  // 2
-    upar.Add("ex"    , 0.015, 0.01  , 0.  , 10.);  // 3
-    upar.Add("corrxy", 0.   , 0.02  , -1. , 1. );  // 4
-    upar.Add("ey"    , 0.015, 0.01  , 0.  , 10.);  // 5
-    upar.Add("dxdz"  , 0.   , 0.0002, -0.1, 0.1);  // 6
-    upar.Add("dydz"  , 0.   , 0.0002, -0.1, 0.1);  // 7
-    upar.Add("ez"    , 1.   , 0.1   , 0.  , 30.);  // 8
-    upar.Add("scale", errorScale_   , errorScale_/10.,
-                      errorScale_/2., errorScale_*2.);      // 9
+    upar.Add("x", 0., 0.02, -10., 10.);                                                     // 0
+    upar.Add("y", 0., 0.02, -10., 10.);                                                     // 1
+    upar.Add("z", 0., 0.20, -30., 30.);                                                     // 2
+    upar.Add("ex", 0.015, 0.01, 0., 10.);                                                   // 3
+    upar.Add("corrxy", 0., 0.02, -1., 1.);                                                  // 4
+    upar.Add("ey", 0.015, 0.01, 0., 10.);                                                   // 5
+    upar.Add("dxdz", 0., 0.0002, -0.1, 0.1);                                                // 6
+    upar.Add("dydz", 0., 0.0002, -0.1, 0.1);                                                // 7
+    upar.Add("ez", 1., 0.1, 0., 30.);                                                       // 8
+    upar.Add("scale", errorScale_, errorScale_ / 10., errorScale_ / 2., errorScale_ * 2.);  // 9
     MnMigrad migrad(*fcn, upar);
 
     //
@@ -241,23 +231,23 @@ bool PVFitter::runBXFitter() {
     upar.Fix(6);
     upar.Fix(7);
     upar.Fix(9);
-    FunctionMinimum ierr = migrad(0,1.);
-    if ( !ierr.IsValid() ) {
-        edm::LogInfo("PVFitter") << "3D beam spot fit failed in 1st iteration" << std::endl;
-	fit_ok = false;
+    FunctionMinimum ierr = migrad(0, 1.);
+    if (!ierr.IsValid()) {
+      edm::LogInfo("PVFitter") << "3D beam spot fit failed in 1st iteration" << std::endl;
+      fit_ok = false;
       continue;
     }
     //
     // refit with harder selection on vertices
     //
-    fcn->setLimits(upar.Value(0)-sigmaCut_*upar.Value(3),
-		   upar.Value(0)+sigmaCut_*upar.Value(3),
-		   upar.Value(1)-sigmaCut_*upar.Value(5),
-		   upar.Value(1)+sigmaCut_*upar.Value(5),
-		   upar.Value(2)-sigmaCut_*upar.Value(8),
-		   upar.Value(2)+sigmaCut_*upar.Value(8));
-    ierr = migrad(0,1.);
-    if ( !ierr.IsValid() ) {
+    fcn->setLimits(upar.Value(0) - sigmaCut_ * upar.Value(3),
+                   upar.Value(0) + sigmaCut_ * upar.Value(3),
+                   upar.Value(1) - sigmaCut_ * upar.Value(5),
+                   upar.Value(1) + sigmaCut_ * upar.Value(5),
+                   upar.Value(2) - sigmaCut_ * upar.Value(8),
+                   upar.Value(2) + sigmaCut_ * upar.Value(8));
+    ierr = migrad(0, 1.);
+    if (!ierr.IsValid()) {
       edm::LogInfo("PVFitter") << "3D beam spot fit failed in 2nd iteration" << std::endl;
       fit_ok = false;
       continue;
@@ -268,10 +258,10 @@ bool PVFitter::runBXFitter() {
     upar.Release(4);
     upar.Release(6);
     upar.Release(7);
-    ierr = migrad(0,1.);
-    if ( !ierr.IsValid() ) {
-        edm::LogInfo("PVFitter") << "3D beam spot fit failed in 3rd iteration" << std::endl;
-	fit_ok = false;
+    ierr = migrad(0, 1.);
+    if (!ierr.IsValid()) {
+      edm::LogInfo("PVFitter") << "3D beam spot fit failed in 3rd iteration" << std::endl;
+      fit_ok = false;
       continue;
     }
 
@@ -284,27 +274,26 @@ bool PVFitter::runBXFitter() {
 
     reco::BeamSpot::CovarianceMatrix matrix;
     // need to get the full cov matrix
-    matrix(0,0) = pow( upar.Error(0), 2);
-    matrix(1,1) = pow( upar.Error(1), 2);
-    matrix(2,2) = pow( upar.Error(2), 2);
-    matrix(3,3) = fwidthZerr * fwidthZerr;
-    matrix(4,4) = pow( upar.Error(6), 2);
-    matrix(5,5) = pow( upar.Error(7), 2);
-    matrix(6,6) = fwidthXerr * fwidthXerr;
+    matrix(0, 0) = pow(upar.Error(0), 2);
+    matrix(1, 1) = pow(upar.Error(1), 2);
+    matrix(2, 2) = pow(upar.Error(2), 2);
+    matrix(3, 3) = fwidthZerr * fwidthZerr;
+    matrix(4, 4) = pow(upar.Error(6), 2);
+    matrix(5, 5) = pow(upar.Error(7), 2);
+    matrix(6, 6) = fwidthXerr * fwidthXerr;
 
-    fbeamspot = reco::BeamSpot( reco::BeamSpot::Point(upar.Value(0),
-						      upar.Value(1),
-						      upar.Value(2) ),
-				fwidthZ,
-				upar.Value(6), upar.Value(7),
-				fwidthX,
-				matrix );
-    fbeamspot.setBeamWidthX( fwidthX );
-    fbeamspot.setBeamWidthY( fwidthY );
-    fbeamspot.setType( reco::BeamSpot::Tracker );
+    fbeamspot = reco::BeamSpot(reco::BeamSpot::Point(upar.Value(0), upar.Value(1), upar.Value(2)),
+                               fwidthZ,
+                               upar.Value(6),
+                               upar.Value(7),
+                               fwidthX,
+                               matrix);
+    fbeamspot.setBeamWidthX(fwidthX);
+    fbeamspot.setBeamWidthY(fwidthY);
+    fbeamspot.setType(reco::BeamSpot::Tracker);
 
     fbspotMap[pvStore->first] = fbeamspot;
-    edm::LogInfo("PVFitter") << "3D PV fit done for this bunch crossing."<<std::endl;
+    edm::LogInfo("PVFitter") << "3D PV fit done for this bunch crossing." << std::endl;
     //delete fcn;
     fit_ok = fit_ok & true;
   }
@@ -312,226 +301,206 @@ bool PVFitter::runBXFitter() {
   return fit_ok;
 }
 
-
 bool PVFitter::runFitter() {
+  using namespace ROOT::Minuit2;
+  edm::LogInfo("PVFitter") << " Number of PVs collected for PVFitter: " << pvStore_.size() << std::endl;
 
-    using namespace ROOT::Minuit2;
-    edm::LogInfo("PVFitter") << " Number of PVs collected for PVFitter: " << pvStore_.size() << std::endl;
+  if (pvStore_.size() <= minNrVertices_)
+    return false;
 
-    if ( pvStore_.size() <= minNrVertices_ ) return false;
+  //need to create a unique histogram name to avoid ROOT trying to re-use one
+  // also tell ROOT to hide its global state
+  TDirectory::TContext guard{nullptr};
+  std::ostringstream str;
+  str << this;
+  std::unique_ptr<TH1D> h1PVx{hPVx->ProjectionX((std::string("h1PVx") + str.str()).c_str(), 0, -1, "e")};
+  std::unique_ptr<TH1D> h1PVy{hPVy->ProjectionX((std::string("h1PVy") + str.str()).c_str(), 0, -1, "e")};
+  std::unique_ptr<TH1D> h1PVz{hPVx->ProjectionY((std::string("h1PVz") + str.str()).c_str(), 0, -1, "e")};
 
-    //need to create a unique histogram name to avoid ROOT trying to re-use one
-    // also tell ROOT to hide its global state
-    TDirectory::TContext guard{nullptr};
-    std::ostringstream str;
-    str <<this;
-    std::unique_ptr<TH1D> h1PVx{ hPVx->ProjectionX( (std::string("h1PVx")+str.str()).c_str(), 0, -1, "e") };
-    std::unique_ptr<TH1D> h1PVy{ hPVy->ProjectionX( (std::string("h1PVy")+str.str()).c_str(), 0, -1, "e") };
-    std::unique_ptr<TH1D> h1PVz{ hPVx->ProjectionY( (std::string("h1PVz")+str.str()).c_str(), 0, -1, "e") };
+  //Use our own copy for thread safety
+  // also do not add to global list of functions
+  TF1 gausx("localGausX", "gaus", 0., 1., TF1::EAddToList::kNo);
+  TF1 gausy("localGausY", "gaus", 0., 1., TF1::EAddToList::kNo);
+  TF1 gausz("localGausZ", "gaus", 0., 1., TF1::EAddToList::kNo);
 
-    //Use our own copy for thread safety
-    // also do not add to global list of functions
-    TF1 gausx("localGausX","gaus",0.,1.,TF1::EAddToList::kNo);
-    TF1 gausy("localGausY","gaus",0.,1.,TF1::EAddToList::kNo);
-    TF1 gausz("localGausZ","gaus",0.,1.,TF1::EAddToList::kNo);
+  h1PVx->Fit(&gausx, "QLMN0 SERIAL");
+  h1PVy->Fit(&gausy, "QLMN0 SERIAL");
+  h1PVz->Fit(&gausz, "QLMN0 SERIAL");
 
-    h1PVx->Fit(&gausx,"QLMN0 SERIAL");
-    h1PVy->Fit(&gausy,"QLMN0 SERIAL");
-    h1PVz->Fit(&gausz,"QLMN0 SERIAL");
+  fwidthX = gausx.GetParameter(2);
+  fwidthY = gausy.GetParameter(2);
+  fwidthZ = gausz.GetParameter(2);
+  fwidthXerr = gausx.GetParError(2);
+  fwidthYerr = gausy.GetParError(2);
+  fwidthZerr = gausz.GetParError(2);
 
+  double estX = gausx.GetParameter(1);
+  double estY = gausy.GetParameter(1);
+  double estZ = gausz.GetParameter(1);
+  double errX = fwidthX * 3.;
+  double errY = fwidthY * 3.;
+  double errZ = fwidthZ * 3.;
 
-    fwidthX     = gausx.GetParameter(2);
-    fwidthY     = gausy.GetParameter(2);
-    fwidthZ     = gausz.GetParameter(2);
-    fwidthXerr  = gausx.GetParError(2);
-    fwidthYerr  = gausy.GetParError(2);
-    fwidthZerr  = gausz.GetParError(2);
-    
-    double estX = gausx.GetParameter(1);
-    double estY = gausy.GetParameter(1); 
-    double estZ = gausz.GetParameter(1);
-    double errX = fwidthX*3.;
-    double errY = fwidthY*3.; 
-    double errZ = fwidthZ*3.;
+  if (!do3DFit_) {
+    reco::BeamSpot::CovarianceMatrix matrix;
+    matrix(2, 2) = gausz.GetParError(1) * gausz.GetParError(1);
+    matrix(3, 3) = fwidthZerr * fwidthZerr;
+    matrix(6, 6) = fwidthXerr * fwidthXerr;
 
-    if ( ! do3DFit_ ) {
+    fbeamspot =
+        reco::BeamSpot(reco::BeamSpot::Point(gausx.GetParameter(1), gausy.GetParameter(1), gausz.GetParameter(1)),
+                       fwidthZ,
+                       0.,
+                       0.,
+                       fwidthX,
+                       matrix);
+    fbeamspot.setBeamWidthX(fwidthX);
+    fbeamspot.setBeamWidthY(fwidthY);
+    fbeamspot.setType(reco::BeamSpot::Tracker);
 
-      reco::BeamSpot::CovarianceMatrix matrix;
-      matrix(2,2) = gausz.GetParError(1) * gausz.GetParError(1);
-      matrix(3,3) = fwidthZerr * fwidthZerr;
-      matrix(6,6) = fwidthXerr * fwidthXerr;
-
-      fbeamspot = reco::BeamSpot( reco::BeamSpot::Point(gausx.GetParameter(1),
-                                                        gausy.GetParameter(1),
-                                                        gausz.GetParameter(1) ),
-                                  fwidthZ,
-                                  0., 0.,
-                                  fwidthX,
-                                  matrix );
-      fbeamspot.setBeamWidthX( fwidthX );
-      fbeamspot.setBeamWidthY( fwidthY );
-      fbeamspot.setType(reco::BeamSpot::Tracker);
-
+  } else {  // do 3D fit
+    //
+    // LL function and fitter
+    //
+    FcnBeamSpotFitPV* fcn = new FcnBeamSpotFitPV(pvStore_);
+    //
+    // fit parameters: positions, widths, x-y correlations, tilts in xz and yz
+    //
+    MnUserParameters upar;
+    upar.Add("x", estX, errX, -10., 10.);                                                   // 0
+    upar.Add("y", estY, errY, -10., 10.);                                                   // 1
+    upar.Add("z", estZ, errZ, -30., 30.);                                                   // 2
+    upar.Add("ex", 0.015, 0.01, 0., 10.);                                                   // 3
+    upar.Add("corrxy", 0., 0.02, -1., 1.);                                                  // 4
+    upar.Add("ey", 0.015, 0.01, 0., 10.);                                                   // 5
+    upar.Add("dxdz", 0., 0.0002, -0.1, 0.1);                                                // 6
+    upar.Add("dydz", 0., 0.0002, -0.1, 0.1);                                                // 7
+    upar.Add("ez", 1., 0.1, 0., 30.);                                                       // 8
+    upar.Add("scale", errorScale_, errorScale_ / 10., errorScale_ / 2., errorScale_ * 2.);  // 9
+    MnMigrad migrad(*fcn, upar);
+    //
+    // first iteration without correlations
+    //
+    migrad.Fix(4);
+    migrad.Fix(6);
+    migrad.Fix(7);
+    migrad.Fix(9);
+    FunctionMinimum ierr = migrad(0, 1.);
+    if (!ierr.IsValid()) {
+      edm::LogWarning("PVFitter") << "3D beam spot fit failed in 1st iteration" << std::endl;
+      return false;
     }
-    else { // do 3D fit
-      //
-      // LL function and fitter
-      //
-      FcnBeamSpotFitPV* fcn = new FcnBeamSpotFitPV(pvStore_);
-      //
-      // fit parameters: positions, widths, x-y correlations, tilts in xz and yz
-      //
-      MnUserParameters upar;
-      upar.Add("x"     , estX       , errX	     , -10.	    , 10.	    ); // 0
-      upar.Add("y"     , estY       , errY	     , -10.	    , 10.	    ); // 1
-      upar.Add("z"     , estZ       , errZ	     , -30.	    , 30.	    ); // 2
-      upar.Add("ex"    , 0.015	    , 0.01  	 , 0.   	, 10. 	    ); // 3
-      upar.Add("corrxy", 0.   	    , 0.02  	 , -1.  	, 1.  	    ); // 4
-      upar.Add("ey"    , 0.015	    , 0.01  	 , 0.   	, 10. 	    ); // 5
-      upar.Add("dxdz"  , 0.   	    , 0.0002	 , -0.1 	, 0.1 	    ); // 6
-      upar.Add("dydz"  , 0.   	    , 0.0002	 , -0.1 	, 0.1 	    ); // 7
-      upar.Add("ez"    , 1.   	    , 0.1   	 , 0.   	, 30. 	    ); // 8
-      upar.Add("scale" , errorScale_, errorScale_/10.,errorScale_/2., errorScale_*2.); // 9  
-      MnMigrad migrad(*fcn, upar);
-      //
-      // first iteration without correlations
-      //
-      migrad.Fix(4);
-      migrad.Fix(6);
-      migrad.Fix(7);
-      migrad.Fix(9);
-      FunctionMinimum ierr = migrad(0,1.);
-      if ( !ierr.IsValid() ) {
-          edm::LogWarning("PVFitter") << "3D beam spot fit failed in 1st iteration" << std::endl;
-          return false;
-      }
-      //
-      // refit with harder selection on vertices
-      //
+    //
+    // refit with harder selection on vertices
+    //
 
-      vector<double> results ;
-      vector<double> errors  ;
-      results = ierr.UserParameters().Params() ;					       \
-      errors  = ierr.UserParameters().Errors() ;					       \
+    vector<double> results;
+    vector<double> errors;
+    results = ierr.UserParameters().Params();
+    errors = ierr.UserParameters().Errors();
 
-      
-      fcn->setLimits(results[0]-sigmaCut_*results[3],
-                     results[0]+sigmaCut_*results[3],
-                     results[1]-sigmaCut_*results[5],
-                     results[1]+sigmaCut_*results[5],
-                     results[2]-sigmaCut_*results[8],
-                     results[2]+sigmaCut_*results[8]);
-      ierr = migrad(0,1.);
-      if ( !ierr.IsValid() ) {
-          edm::LogWarning("PVFitter") << "3D beam spot fit failed in 2nd iteration" << std::endl;
-          return false;
-      }
-      //
-      // refit with correlations
-      //
-      migrad.Release(4);
-      migrad.Release(6);
-      migrad.Release(7);
-      ierr = migrad(0,1.);
-      if ( !ierr.IsValid() ) {
-          edm::LogWarning("PVFitter") << "3D beam spot fit failed in 3rd iteration" << std::endl;
-          return false;
-      }
-
-      results = ierr.UserParameters().Params() ;					       \
-      errors  = ierr.UserParameters().Errors() ;					       \
-
-      fwidthX = results[3];
-      fwidthY = results[5];
-      fwidthZ = results[8];
-      fwidthXerr = errors[3];
-      fwidthYerr = errors[5];
-      fwidthZerr = errors[8];
-
-      // check errors on widths and sigmaZ for nan
-      if ( edm::isNotFinite(fwidthXerr) || edm::isNotFinite(fwidthYerr) || edm::isNotFinite(fwidthZerr) ) {
-          edm::LogWarning("PVFitter") << "3D beam spot fit returns nan in 3rd iteration" << std::endl;
-          return false;
-      }
-
-      reco::BeamSpot::CovarianceMatrix matrix;
-      // need to get the full cov matrix
-      matrix(0,0) = pow( errors[0], 2);
-      matrix(1,1) = pow( errors[1], 2);
-      matrix(2,2) = pow( errors[2], 2);
-      matrix(3,3) = fwidthZerr * fwidthZerr;
-      matrix(6,6) = fwidthXerr * fwidthXerr;
-
-      fbeamspot = reco::BeamSpot( reco::BeamSpot::Point(results[0],
-                                                        results[1],
-                                                        results[2] ),
-                                  fwidthZ,
-                                  results[6], results[7],
-                                  fwidthX,
-                                  matrix );
-      fbeamspot.setBeamWidthX( fwidthX );
-      fbeamspot.setBeamWidthY( fwidthY );
-      fbeamspot.setType(reco::BeamSpot::Tracker); 
+    fcn->setLimits(results[0] - sigmaCut_ * results[3],
+                   results[0] + sigmaCut_ * results[3],
+                   results[1] - sigmaCut_ * results[5],
+                   results[1] + sigmaCut_ * results[5],
+                   results[2] - sigmaCut_ * results[8],
+                   results[2] + sigmaCut_ * results[8]);
+    ierr = migrad(0, 1.);
+    if (!ierr.IsValid()) {
+      edm::LogWarning("PVFitter") << "3D beam spot fit failed in 2nd iteration" << std::endl;
+      return false;
+    }
+    //
+    // refit with correlations
+    //
+    migrad.Release(4);
+    migrad.Release(6);
+    migrad.Release(7);
+    ierr = migrad(0, 1.);
+    if (!ierr.IsValid()) {
+      edm::LogWarning("PVFitter") << "3D beam spot fit failed in 3rd iteration" << std::endl;
+      return false;
     }
 
-    return true;
+    results = ierr.UserParameters().Params();
+    errors = ierr.UserParameters().Errors();
+
+    fwidthX = results[3];
+    fwidthY = results[5];
+    fwidthZ = results[8];
+    fwidthXerr = errors[3];
+    fwidthYerr = errors[5];
+    fwidthZerr = errors[8];
+
+    // check errors on widths and sigmaZ for nan
+    if (edm::isNotFinite(fwidthXerr) || edm::isNotFinite(fwidthYerr) || edm::isNotFinite(fwidthZerr)) {
+      edm::LogWarning("PVFitter") << "3D beam spot fit returns nan in 3rd iteration" << std::endl;
+      return false;
+    }
+
+    reco::BeamSpot::CovarianceMatrix matrix;
+    // need to get the full cov matrix
+    matrix(0, 0) = pow(errors[0], 2);
+    matrix(1, 1) = pow(errors[1], 2);
+    matrix(2, 2) = pow(errors[2], 2);
+    matrix(3, 3) = fwidthZerr * fwidthZerr;
+    matrix(6, 6) = fwidthXerr * fwidthXerr;
+
+    fbeamspot = reco::BeamSpot(
+        reco::BeamSpot::Point(results[0], results[1], results[2]), fwidthZ, results[6], results[7], fwidthX, matrix);
+    fbeamspot.setBeamWidthX(fwidthX);
+    fbeamspot.setBeamWidthY(fwidthY);
+    fbeamspot.setType(reco::BeamSpot::Tracker);
+  }
+
+  return true;
 }
 
-void PVFitter::dumpTxtFile(){
+void PVFitter::dumpTxtFile() {}
 
-}
-
-
-void
-PVFitter::compressStore ()
-{
+void PVFitter::compressStore() {
   //
   // fill vertex qualities
   //
   pvQualities_.resize(pvStore_.size());
-  for ( unsigned int i=0; i<pvStore_.size(); ++i )  pvQualities_[i] = pvQuality(pvStore_[i]);
-  sort(pvQualities_.begin(),pvQualities_.end());
+  for (unsigned int i = 0; i < pvStore_.size(); ++i)
+    pvQualities_[i] = pvQuality(pvStore_[i]);
+  sort(pvQualities_.begin(), pvQualities_.end());
   //
   // Set new quality cut to median. This cut will be used to reduce the
   // number of vertices in the store and also apply to all new vertices
   // until the next reset
   //
-  dynamicQualityCut_ = pvQualities_[pvQualities_.size()/2];
+  dynamicQualityCut_ = pvQualities_[pvQualities_.size() / 2];
   //
   // remove all vertices failing the cut from the store
   //   (to be moved to a more efficient memory management!)
   //
   unsigned int iwrite(0);
-  for ( unsigned int i=0; i<pvStore_.size(); ++i ) {
-    if ( pvQuality(pvStore_[i])>dynamicQualityCut_ )  continue;
-    if ( i!=iwrite )  pvStore_[iwrite] = pvStore_[i];
+  for (unsigned int i = 0; i < pvStore_.size(); ++i) {
+    if (pvQuality(pvStore_[i]) > dynamicQualityCut_)
+      continue;
+    if (i != iwrite)
+      pvStore_[iwrite] = pvStore_[i];
     ++iwrite;
   }
   pvStore_.resize(iwrite);
-  edm::LogInfo("PVFitter") << "Reduced primary vertex store size to "
-                           << pvStore_.size() << " ; new dynamic quality cut = "
-                           << dynamicQualityCut_ << std::endl;
-
+  edm::LogInfo("PVFitter") << "Reduced primary vertex store size to " << pvStore_.size()
+                           << " ; new dynamic quality cut = " << dynamicQualityCut_ << std::endl;
 }
 
-double
-PVFitter::pvQuality (const reco::Vertex& pv) const
-{
+double PVFitter::pvQuality(const reco::Vertex& pv) const {
   //
   // determinant of the transverse part of the PV covariance matrix
   //
-  return
-    pv.covariance(0,0)*pv.covariance(1,1)-
-    pv.covariance(0,1)*pv.covariance(0,1);
+  return pv.covariance(0, 0) * pv.covariance(1, 1) - pv.covariance(0, 1) * pv.covariance(0, 1);
 }
 
-double
-PVFitter::pvQuality (const BeamSpotFitPVData& pv) const
-{
+double PVFitter::pvQuality(const BeamSpotFitPVData& pv) const {
   //
   // determinant of the transverse part of the PV covariance matrix
   //
   double ex = pv.posError[0];
   double ey = pv.posError[1];
-  return ex*ex*ey*ey*(1-pv.posCorr[0]*pv.posCorr[0]);
+  return ex * ex * ey * ey * (1 - pv.posCorr[0] * pv.posCorr[0]);
 }

--- a/RecoVertex/BeamSpotProducer/src/SealModules.cc
+++ b/RecoVertex/BeamSpotProducer/src/SealModules.cc
@@ -3,6 +3,5 @@
 //#include "RecoVertex/BeamSpotProducer/interface/BeamSpotAnalyzer.h"
 //#include "RecoVertex/BeamSpotProducer/interface/BeamSpotFromDB.h"
 
-
 //DEFINE_FWK_MODULE(BeamSpotAnalyzer);
 //DEFINE_FWK_MODULE(BeamSpotFromDB);

--- a/RecoVertex/BeamSpotProducer/test/BeamFit.cc
+++ b/RecoVertex/BeamSpotProducer/test/BeamFit.cc
@@ -18,26 +18,23 @@
 #include "global.h"
 //#include "beamfit_fcts.h"
 
-
-
-
 //const char par_name[dim][20]={"z0  ","sigma ","emmitance","beta*"};
-const char par_name[dim][20]={"z0  ","sigma ","x0 ", "y0 ", "dxdz ", "dydz ", "sigmaBeam ",
-							  "c0  ","c1    ","emittance ","betastar "};
+const char par_name[dim][20] = {
+    "z0  ", "sigma ", "x0 ", "y0 ", "dxdz ", "dydz ", "sigmaBeam ", "c0  ", "c1    ", "emittance ", "betastar "};
 
-Double_t params[dim],errparams[dim];
-Double_t sfpar[dim],errsfpar[dim]; 
+Double_t params[dim], errparams[dim];
+Double_t sfpar[dim], errsfpar[dim];
 
-constexpr Double_t step[dim] = {1.e-5,1.e-5,1.e-3,1.e-3,1.e-3,1.e-3,1.e-5,1.e-5,1.e-5,1.e-5,1.e-5};
-zData zdata;//!
+constexpr Double_t step[dim] = {1.e-5, 1.e-5, 1.e-3, 1.e-3, 1.e-3, 1.e-3, 1.e-5, 1.e-5, 1.e-5, 1.e-5, 1.e-5};
+zData zdata;  //!
 int tmpNtrks_ = 0;
 int fnthite = 0;
 TMatrixD ftmp;
 
 Double_t fd0cut = 4.0;
 
-int sequence[11] = {500,1000,2000,3000,4000,5000,6000,7000,8000,9000,10000};
-Double_t sequenceD[11] = {500,1000,2000,3000,4000,5000,6000,7000,8000,9000,10000};
+int sequence[11] = {500, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000};
+Double_t sequenceD[11] = {500, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000};
 Double_t zeros[11] = {0.};
 
 int iloop_ = 0;
@@ -70,228 +67,205 @@ TGraphErrors *g_sigmaZ;
 TGraphErrors *g_Z_lh;
 TGraphErrors *g_sigmaZ_lh;
 
-
-Double_t zdis(Double_t z, Double_t sigma, Double_t *parms)
-{ 
+Double_t zdis(Double_t z, Double_t sigma, Double_t *parms) {
   //---------------------------------------------------------------------------
-  //  This is a simple function to parameterize the z-vertex distribution. This 
-  // is parametrized by a simple normalized gaussian distribution. 
-  //---------------------------------------------------------------------------  
-		
-	Double_t sig = sqrt(sigma*sigma + parms[Par_Sigma]*parms[Par_Sigma]);	
-	Double_t result = (exp(-((z-parms[Par_Z0])*(z-parms[Par_Z0]))/(2.0*sig*sig)))/(sig*sqrt2pi);
-	return result;
-} 
+  //  This is a simple function to parameterize the z-vertex distribution. This
+  // is parametrized by a simple normalized gaussian distribution.
+  //---------------------------------------------------------------------------
 
+  Double_t sig = sqrt(sigma * sigma + parms[Par_Sigma] * parms[Par_Sigma]);
+  Double_t result = (exp(-((z - parms[Par_Z0]) * (z - parms[Par_Z0])) / (2.0 * sig * sig))) / (sig * sqrt2pi);
+  return result;
+}
 
-void zfcn(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag)
-{
+void zfcn(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag) {
   //----------------------------------------------------------------------------------
   // this is the function used by minuit to do the unbinned fit to the z distribution
   //----------------------------------------------------------------------------------
   f = 0.0;
-  for ( zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) 
-  {  
-      f = log(zdis(iter->Z,iter->SigZ,params))+f;
-    }
-  f= -2.0*f;
-  return ;
+  for (zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) {
+    f = log(zdis(iter->Z, iter->SigZ, params)) + f;
+  }
+  f = -2.0 * f;
+  return;
 }
 
-float betaf( float betastar,  float emmitance,float z,float z0)
-{
-  float x = sqrt(emmitance*(betastar+(((z-z0)*(z-z0))/betastar)));
+float betaf(float betastar, float emmitance, float z, float z0) {
+  float x = sqrt(emmitance * (betastar + (((z - z0) * (z - z0)) / betastar)));
   return x;
 }
 
-Double_t ddis(Double_t z, Double_t sigma,Double_t d, Double_t sigmad, Double_t *parms)
-{ 
+Double_t ddis(Double_t z, Double_t sigma, Double_t d, Double_t sigmad, Double_t *parms) {
   //---------------------------------------------------------------------------
-  // This is a simple function to parameterize the sigma of the beam at a given z.  
-  // This is parametrized by a simple normalized gaussian distribution. 
-  //---------------------------------------------------------------------------  
-  Double_t sig = betaf( parms[Par_beta],parms[Par_eps],z,parms[Par_Z0]);
-  sig          = sqrt(sig*sig+sigmad*sigmad);
-   Double_t result = (exp(-(d*d)/(2.0*sig*sig)))/(sig*sqrt2pi);
+  // This is a simple function to parameterize the sigma of the beam at a given z.
+  // This is parametrized by a simple normalized gaussian distribution.
+  //---------------------------------------------------------------------------
+  Double_t sig = betaf(parms[Par_beta], parms[Par_eps], z, parms[Par_Z0]);
+  sig = sqrt(sig * sig + sigmad * sigmad);
+  Double_t result = (exp(-(d * d) / (2.0 * sig * sig))) / (sig * sqrt2pi);
   return result;
 }
 
-Double_t allddis(Double_t z,Double_t d, Double_t sigmad,
-				 Double_t phi0, Double_t *parms)
-{ 
+Double_t allddis(Double_t z, Double_t d, Double_t sigmad, Double_t phi0, Double_t *parms) {
   //---------------------------------------------------------------------------
   // This is a simple function to parameterize the beam parameters
-  // This is parametrized by a simple normalized gaussian distribution. 
-  //---------------------------------------------------------------------------  
-	Double_t sig = sqrt( parms[Par_Sigbeam]*parms[Par_Sigbeam] + 10*sigmad*sigmad  ); //9 //2.5 factor for full simu data
-	Double_t dprime = d - (parms[Par_x0] + z*parms[Par_dxdz])*sin(phi0) +
-		(parms[Par_y0] + z*parms[Par_dydz])*cos(phi0);
-   Double_t result = (exp(-(dprime*dprime)/(2.0*sig*sig)))/(sig*sqrt2pi);
+  // This is parametrized by a simple normalized gaussian distribution.
+  //---------------------------------------------------------------------------
+  Double_t sig =
+      sqrt(parms[Par_Sigbeam] * parms[Par_Sigbeam] + 10 * sigmad * sigmad);  //9 //2.5 factor for full simu data
+  Double_t dprime =
+      d - (parms[Par_x0] + z * parms[Par_dxdz]) * sin(phi0) + (parms[Par_y0] + z * parms[Par_dydz]) * cos(phi0);
+  Double_t result = (exp(-(dprime * dprime) / (2.0 * sig * sig))) / (sig * sqrt2pi);
   return result;
 }
 
-Double_t allddisBeta(Double_t z, Double_t sigma,Double_t d, Double_t sigmad,
-				 Double_t phi0, Double_t *parms)
-{ 
+Double_t allddisBeta(Double_t z, Double_t sigma, Double_t d, Double_t sigmad, Double_t phi0, Double_t *parms) {
   //---------------------------------------------------------------------------
   // This is a simple function to parameterize the beam parameters
-  // This is parametrized by a simple normalized gaussian distribution. 
+  // This is parametrized by a simple normalized gaussian distribution.
   //---------------------------------------------------------------------------
-	Double_t sigmabeam = sqrt(parms[Par_eps]*(parms[Par_beta]+(((z-parms[Par_Z0])*(z-parms[Par_Z0]))/parms[Par_beta])));
-	
-	Double_t sig = sqrt( sigmabeam*sigmabeam + sigmad*sigmad  );
-	
-	Double_t dprime = d - (parms[Par_x0] + z*parms[Par_dxdz])*sin(phi0) +
-		(parms[Par_y0] + z*parms[Par_dydz])*cos(phi0);
-   Double_t result = (exp(-(dprime*dprime)/(2.0*sig*sig)))/(sig*sqrt2pi);
+  Double_t sigmabeam =
+      sqrt(parms[Par_eps] * (parms[Par_beta] + (((z - parms[Par_Z0]) * (z - parms[Par_Z0])) / parms[Par_beta])));
+
+  Double_t sig = sqrt(sigmabeam * sigmabeam + sigmad * sigmad);
+
+  Double_t dprime =
+      d - (parms[Par_x0] + z * parms[Par_dxdz]) * sin(phi0) + (parms[Par_y0] + z * parms[Par_dydz]) * cos(phi0);
+  Double_t result = (exp(-(dprime * dprime) / (2.0 * sig * sig))) / (sig * sqrt2pi);
   return result;
 }
 
-
-
-Double_t allddis2(Double_t z, Double_t sigma,Double_t d, Double_t pt,
-				  Double_t phi0, Double_t *parms)
-{ 
+Double_t allddis2(Double_t z, Double_t sigma, Double_t d, Double_t pt, Double_t phi0, Double_t *parms) {
   //---------------------------------------------------------------------------
   //
   //---------------------------------------------------------------------------
-	Double_t sigmad = parms[Par_c0] + parms[Par_c1]/pt;
-	Double_t sig = sqrt( parms[Par_Sigbeam]*parms[Par_Sigbeam] + sigmad*sigmad  );
-	Double_t dprime = d - (parms[Par_x0] + z*parms[Par_dxdz])*sin(phi0) + (parms[Par_y0] + z*parms[Par_dydz])*cos(phi0);
-   Double_t result = (exp(-(dprime*dprime)/(2.0*sig*sig)))/(sig*sqrt2pi);
+  Double_t sigmad = parms[Par_c0] + parms[Par_c1] / pt;
+  Double_t sig = sqrt(parms[Par_Sigbeam] * parms[Par_Sigbeam] + sigmad * sigmad);
+  Double_t dprime =
+      d - (parms[Par_x0] + z * parms[Par_dxdz]) * sin(phi0) + (parms[Par_y0] + z * parms[Par_dydz]) * cos(phi0);
+  Double_t result = (exp(-(dprime * dprime) / (2.0 * sig * sig))) / (sig * sqrt2pi);
   return result;
 }
 
-
-void dfcn(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag)
-{
+void dfcn(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag) {
   //----------------------------------------------------------------------------------
-  // this is the function used by minuit to do the unbinned fit to the IP distribution 
+  // this is the function used by minuit to do the unbinned fit to the IP distribution
   //----------------------------------------------------------------------------------
   f = 0.0;
-  for ( zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) 
-    {
-		//if(iter->weight2 == 0) continue;
-		
-      f = log(allddis(iter->Z,iter->D,iter->SigD,iter->Phi,params))+f;
-    }
-  f= -2.0*f;
-  return ;
+  for (zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) {
+    //if(iter->weight2 == 0) continue;
+
+    f = log(allddis(iter->Z, iter->D, iter->SigD, iter->Phi, params)) + f;
+  }
+  f = -2.0 * f;
+  return;
 }
 
-void dfcnbeta(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag)
-{
+void dfcnbeta(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag) {
   //----------------------------------------------------------------------------------
-  // this is the function used by minuit to do the unbinned fit to the IP distribution 
+  // this is the function used by minuit to do the unbinned fit to the IP distribution
   //----------------------------------------------------------------------------------
   f = 0.0;
-  for ( zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) 
-    {
-      f = log(allddisBeta(iter->Z,iter->SigZ,iter->D,iter->SigD,iter->Phi,params))+f;
-    }
-  f= -2.0*f;
-  return ;
+  for (zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) {
+    f = log(allddisBeta(iter->Z, iter->SigZ, iter->D, iter->SigD, iter->Phi, params)) + f;
+  }
+  f = -2.0 * f;
+  return;
 }
 
-void dfcn2(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag)
-{
+void dfcn2(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag) {
   //----------------------------------------------------------------------------------
-  // this is the function used by minuit to do the unbinned fit to the IP distribution 
+  // this is the function used by minuit to do the unbinned fit to the IP distribution
   //----------------------------------------------------------------------------------
   f = 0.0;
-  for ( zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) 
-    {
-      f = log(allddis2(iter->Z,iter->SigZ,iter->D,iter->Pt,iter->Phi,params)*zdis(iter->Z,iter->SigZ,params))+f;
-    }
-  f= -2.0*f;
-  return ;
+  for (zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) {
+    f = log(allddis2(iter->Z, iter->SigZ, iter->D, iter->Pt, iter->Phi, params) * zdis(iter->Z, iter->SigZ, params)) +
+        f;
+  }
+  f = -2.0 * f;
+  return;
 }
 
-void cfcn(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag)
-{
+void cfcn(Int_t &npar, Double_t *gin, Double_t &f, Double_t *params, Int_t iflag) {
   //-----------------------------------------------------------------------------------
   // this is the function used by minuit to do the unbinned finned combined in z an IP.
   //-----------------------------------------------------------------------------------
   f = 0.0;
-  for ( zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) 
-    {
-      f = log(allddis(iter->Z,iter->D,iter->SigD,iter->Phi,params)*zdis(iter->Z,iter->SigZ,params))+f;
-    }
-  f= -2.0*f;
-  return ;
+  for (zDataConstIter iter = zdata.begin(); iter != zdata.end(); ++iter) {
+    f = log(allddis(iter->Z, iter->D, iter->SigD, iter->Phi, params) * zdis(iter->Z, iter->SigZ, params)) + f;
+  }
+  f = -2.0 * f;
+  return;
 }
 
-void fit(TMatrixD &x, TMatrixDSym &V)
-{
-	TMatrixDSym Vint(4);
-	TMatrixD b(4,1);
-	Double_t weightsum = 0;
-	tmpNtrks_ = 0;
+void fit(TMatrixD &x, TMatrixDSym &V) {
+  TMatrixDSym Vint(4);
+  TMatrixD b(4, 1);
+  Double_t weightsum = 0;
+  tmpNtrks_ = 0;
 
-	Vint.Zero();
-	b.Zero();
-	TMatrixD g(4,1);
-	TMatrixDSym temp(4);
-	for(zDataConstIter i = zdata.begin() ; i != zdata.end() ; ++i) {
-		//std::cout << "weight  " << sqrt(i->weight2) << "\n";
-		if(i->weight2 == 0) continue;
+  Vint.Zero();
+  b.Zero();
+  TMatrixD g(4, 1);
+  TMatrixDSym temp(4);
+  for (zDataConstIter i = zdata.begin(); i != zdata.end(); ++i) {
+    //std::cout << "weight  " << sqrt(i->weight2) << "\n";
+    if (i->weight2 == 0)
+      continue;
 
-		g(0,0) = sin(i->Phi);
-		g(1,0) = -cos(i->Phi);
-		g(2,0) = i->Z * g(0,0);
-		g(3,0) = i->Z * g(1,0);
-    
-		temp.Zero();
-		for(int j = 0 ; j < 4 ; ++j) {
-			for(int k = j ; k < 4 ; ++k) {
-				temp(j,k) += g(j,0) * g(k,0);
-			}
-		}
-		double sigmabeam2 = 0.002 * 0.002;
-		//double sigma2 = sigmabeam2 +  (i->SigD)* (i->SigD) / i->weight2;
-		double sigma2 = sigmabeam2 +  (i->SigD)* (i->SigD);
- 
-		TMatrixD ftmptrans(1,4);
-		ftmptrans = ftmptrans.Transpose(ftmp);
-		TMatrixD dcor = ftmptrans * g;
+    g(0, 0) = sin(i->Phi);
+    g(1, 0) = -cos(i->Phi);
+    g(2, 0) = i->Z * g(0, 0);
+    g(3, 0) = i->Z * g(1, 0);
 
-		bool pass = true;
-		if ( (fnthite > 0) && ( std::abs( i->D - dcor(0,0) ) > fd0cut ) )
-			pass = false;
-		//if ( tmpNtrks_ < 10 && fnthite>0 ) {
-			//std::cout << " d0 = " << i->D << " dcor(0,0)= " << dcor(0,0) << " fd0cut=" << fd0cut << std::endl;
-		//}
-			
-		if (pass ) {
-			Vint += (temp * (1 / sigma2));
-			b += ((i->D / sigma2) * g);
-			weightsum += sqrt(i->weight2);
-			tmpNtrks_++;
-		}
-		
-	}
-	Double_t determinant;
-	V = Vint.InvertFast(&determinant);
-	x = V  * b;
-	ftmp = x;
+    temp.Zero();
+    for (int j = 0; j < 4; ++j) {
+      for (int k = j; k < 4; ++k) {
+        temp(j, k) += g(j, 0) * g(k, 0);
+      }
+    }
+    double sigmabeam2 = 0.002 * 0.002;
+    //double sigma2 = sigmabeam2 +  (i->SigD)* (i->SigD) / i->weight2;
+    double sigma2 = sigmabeam2 + (i->SigD) * (i->SigD);
 
-	std::cout << "number of tracks used in this iteration = " << tmpNtrks_ << std::endl;
-	std::cout << "Sum of all weights:" << weightsum << "\n";
-	std::cout << "x0                :" << x(0,0)    << " +- " << sqrt(V(0,0)) << " cm \n"; 
-	std::cout << "y0                :" << x(1,0)    << " +- " << sqrt(V(1,1)) << " cm \n"; 
-	std::cout << "x slope           :" << x(2,0)    << " +- " << sqrt(V(2,2)) << " cm \n";  
-	std::cout << "y slope           :" << x(3,0)    << " +- " << sqrt(V(3,3)) << " cm \n";
+    TMatrixD ftmptrans(1, 4);
+    ftmptrans = ftmptrans.Transpose(ftmp);
+    TMatrixD dcor = ftmptrans * g;
 
-	res_d0phi_X[iloop_] = x(0,0);
-	res_d0phi_Xerr[iloop_] = sqrt(V(0,0));
-	res_d0phi_Y[iloop_] = x(1,0);
-	res_d0phi_Yerr[iloop_] = sqrt(V(1,1));
-	res_d0phi_dXdz[iloop_] = x(2,0);
-	res_d0phi_dXdzerr[iloop_] = sqrt(V(2,2));
-	res_d0phi_dYdz[iloop_] = x(3,0);
-	res_d0phi_dYdzerr[iloop_] = sqrt(V(3,3));
-	
-	
+    bool pass = true;
+    if ((fnthite > 0) && (std::abs(i->D - dcor(0, 0)) > fd0cut))
+      pass = false;
+    //if ( tmpNtrks_ < 10 && fnthite>0 ) {
+    //std::cout << " d0 = " << i->D << " dcor(0,0)= " << dcor(0,0) << " fd0cut=" << fd0cut << std::endl;
+    //}
+
+    if (pass) {
+      Vint += (temp * (1 / sigma2));
+      b += ((i->D / sigma2) * g);
+      weightsum += sqrt(i->weight2);
+      tmpNtrks_++;
+    }
+  }
+  Double_t determinant;
+  V = Vint.InvertFast(&determinant);
+  x = V * b;
+  ftmp = x;
+
+  std::cout << "number of tracks used in this iteration = " << tmpNtrks_ << std::endl;
+  std::cout << "Sum of all weights:" << weightsum << "\n";
+  std::cout << "x0                :" << x(0, 0) << " +- " << sqrt(V(0, 0)) << " cm \n";
+  std::cout << "y0                :" << x(1, 0) << " +- " << sqrt(V(1, 1)) << " cm \n";
+  std::cout << "x slope           :" << x(2, 0) << " +- " << sqrt(V(2, 2)) << " cm \n";
+  std::cout << "y slope           :" << x(3, 0) << " +- " << sqrt(V(3, 3)) << " cm \n";
+
+  res_d0phi_X[iloop_] = x(0, 0);
+  res_d0phi_Xerr[iloop_] = sqrt(V(0, 0));
+  res_d0phi_Y[iloop_] = x(1, 0);
+  res_d0phi_Yerr[iloop_] = sqrt(V(1, 1));
+  res_d0phi_dXdz[iloop_] = x(2, 0);
+  res_d0phi_dXdzerr[iloop_] = sqrt(V(2, 2));
+  res_d0phi_dYdz[iloop_] = x(3, 0);
+  res_d0phi_dYdzerr[iloop_] = sqrt(V(3, 3));
 }
 
 //Double_t cutOnD(const TMatrixD& x, Double_t fd0cut)
@@ -306,31 +280,29 @@ void fit(TMatrixD &x, TMatrixDSym &V)
 //    TMatrixD dcor = g * x;
 //    //std::cout << dcor.GetNrows() << " , " << dcor.GetNcols() << "\n";
 //    if(std::abs(i->D -  dcor(0,0)) > fd0cut) {
-//      i->weight2 = 0; 
+//      i->weight2 = 0;
 //    } else {
 //      i->weight2 = 1;
 //      weightsum += 1;
 //    }
 //  }
 //  return weightsum;
-//} 
+//}
 
-Double_t cutOnChi2(const TMatrixD& x, Double_t chi2cut)
-{
-	double sigmabeam2 = 0.002 * 0.002;
-  TMatrixD g(1,4);
+Double_t cutOnChi2(const TMatrixD &x, Double_t chi2cut) {
+  double sigmabeam2 = 0.002 * 0.002;
+  TMatrixD g(1, 4);
   Double_t weightsum = 0;
-  for(zDataIter i = zdata.begin() ; i != zdata.end() ; ++i) {
-    g(0,0) = sin(i->Phi);
-    g(0,1) = - cos(i->Phi);
-    g(0,2) = i->Z * g(0,0);
-    g(0,3) = i->Z * g(0,1);
+  for (zDataIter i = zdata.begin(); i != zdata.end(); ++i) {
+    g(0, 0) = sin(i->Phi);
+    g(0, 1) = -cos(i->Phi);
+    g(0, 2) = i->Z * g(0, 0);
+    g(0, 3) = i->Z * g(0, 1);
     TMatrixD dcor = g * x;
     //std::cout << dcor.GetNrows() << " , " << dcor.GetNcols() << "\n";
-    Double_t chi2 = (i->D -  dcor(0,0))* (i->D -  dcor(0,0)) / 
-      (sigmabeam2 +  (i->SigD)*(i->SigD));
-    if(chi2 > chi2cut) {
-      i->weight2 = 0; 
+    Double_t chi2 = (i->D - dcor(0, 0)) * (i->D - dcor(0, 0)) / (sigmabeam2 + (i->SigD) * (i->SigD));
+    if (chi2 > chi2cut) {
+      i->weight2 = 0;
     } else {
       i->weight2 = 1;
       weightsum += 1;
@@ -340,113 +312,109 @@ Double_t cutOnChi2(const TMatrixD& x, Double_t chi2cut)
   return weightsum;
 }
 
+void fitAll() {
+  std::cout << "starting fits" << std::endl;
 
-void fitAll()
-{
+  // chi2 fit for Z
+  TH1F *h1z = new TH1F("h1z", "z distribution", 100, -50., 50.);
+  for (zDataConstIter i = zdata.begin(); i != zdata.end(); ++i) {
+    h1z->Fill(i->Z, i->SigZ);
+  }
+  h1z->Sumw2();
+  h1z->Fit("gaus");
+  //std::cout << "fitted "<< std::endl;
 
-	std::cout << "starting fits" << std::endl;
-	
-	// chi2 fit for Z
-	TH1F *h1z = new TH1F("h1z","z distribution",100,-50.,50.);
-	for(zDataConstIter i = zdata.begin() ; i != zdata.end() ; ++i) {
-		h1z->Fill(i->Z, i->SigZ );
+  TF1 *fgaus = h1z->GetFunction("gaus");
+  //std::cout << "got function" << std::endl;
+  res_Z[iloop_] = fgaus->GetParameter(1);
+  res_sigmaZ[iloop_] = fgaus->GetParameter(2);
+  res_Zerr[iloop_] = fgaus->GetParError(1);
+  res_sigmaZerr[iloop_] = fgaus->GetParError(2);
 
-	}
-	h1z->Sumw2();
-	h1z->Fit("gaus");
-	//std::cout << "fitted "<< std::endl;
-	
-	TF1 *fgaus = h1z->GetFunction("gaus");
-	//std::cout << "got function" << std::endl;
-	res_Z[iloop_] = fgaus->GetParameter(1);
-	res_sigmaZ[iloop_] = fgaus->GetParameter(2);
-    res_Zerr[iloop_] = fgaus->GetParError(1);
-    res_sigmaZerr[iloop_] = fgaus->GetParError(2);
-	
-	std::cout << "======== End of Chi2 Fit for Z ========\n" << std::endl;
+  std::cout << "======== End of Chi2 Fit for Z ========\n" << std::endl;
 
-	// LH fit for Z	
- TMinuit *gmMinuit = new TMinuit(2);
- gmMinuit->SetFCN(zfcn);
- std::cout << "SetFCN done" << std::endl;
- int ierflg = 0;
- sfpar[Par_Sigma] = 7.55;//mygaus->GetParameter(2);
- sfpar[Par_Z0]    = 0.;//r/mygaus->GetParameter(1);
- errsfpar[Par_Sigma] = 0.;//r/mygaus->GetParError(2);
- errsfpar[Par_Z0] = 0.;//r/mygaus->GetParError(1);
- 
- // UML Fit in z
- //Double_t zlimitUp[2] = { 0., 8. };
- //Double_t zlimitDown[2] = { 0., 7. };
+  // LH fit for Z
+  TMinuit *gmMinuit = new TMinuit(2);
+  gmMinuit->SetFCN(zfcn);
+  std::cout << "SetFCN done" << std::endl;
+  int ierflg = 0;
+  sfpar[Par_Sigma] = 7.55;   //mygaus->GetParameter(2);
+  sfpar[Par_Z0] = 0.;        //r/mygaus->GetParameter(1);
+  errsfpar[Par_Sigma] = 0.;  //r/mygaus->GetParError(2);
+  errsfpar[Par_Z0] = 0.;     //r/mygaus->GetParError(1);
 
- gmMinuit->SetFCN(zfcn);
- for (int i = 0; i<2; i++) {
-	 gmMinuit->mnparm(i,par_name[i],sfpar[i],step[i],0,0,ierflg);
-	 //gmMinuit->mnparm(i,par_name[i],sfpar[i],step[i],zlimitDown[i],zlimitUp[i],ierflg);
- }
+  // UML Fit in z
+  //Double_t zlimitUp[2] = { 0., 8. };
+  //Double_t zlimitDown[2] = { 0., 7. };
 
- //std::cout << "fit..." << std::endl;
- 
- gmMinuit->Migrad();
- // gmMinuit->mncuve();
- // gmMinuit->mnmnos();
- //gmMinuit->Migrad();
-for (int i = 0; i<2; i++) {
- gmMinuit->GetParameter(i,sfpar[i],errsfpar[i]);
-}
- 
- res_Z_lh[iloop_] = sfpar[Par_Z0];
- res_sigmaZ_lh[iloop_] = sfpar[Par_Sigma];
- res_Zerr_lh[iloop_] = errsfpar[Par_Z0];
- res_sigmaZerr_lh[iloop_] = errsfpar[Par_Sigma];
+  gmMinuit->SetFCN(zfcn);
+  for (int i = 0; i < 2; i++) {
+    gmMinuit->mnparm(i, par_name[i], sfpar[i], step[i], 0, 0, ierflg);
+    //gmMinuit->mnparm(i,par_name[i],sfpar[i],step[i],zlimitDown[i],zlimitUp[i],ierflg);
+  }
 
- // get 1 sigma contour of param 0 vs 1
- ///gmMinuit->SetErrorDef(1);
- ///TGraph *gra1_sig1 = (TGraph*)gMinuit->Contour(60,0,1);
- //gra1_sig1->Draw("alp");
- //gra1_sig1->SetName("gra1_sig1");
- ///gmMinuit->SetErrorDef(4); // two sigma
- ///TGraph *gra1_sig2 = (TGraph*)gMinuit->Contour(60,0,1);
- //gra1_sig2->Draw("alp");
- //gra1_sig2->SetName("gra1_sig2");
- // gr12->Draw("alp");
- 
- std::cout << "======== End of Maximum LH Fit for Z ========\n" << std::endl;
+  //std::cout << "fit..." << std::endl;
 
- //_______________ d0 phi fit _________________
+  gmMinuit->Migrad();
+  // gmMinuit->mncuve();
+  // gmMinuit->mnmnos();
+  //gmMinuit->Migrad();
+  for (int i = 0; i < 2; i++) {
+    gmMinuit->GetParameter(i, sfpar[i], errsfpar[i]);
+  }
 
- tmpNtrks_ = 0; // reset track counter
- 
- TMatrixD xmat(4,1);
- TMatrixDSym Verr(4);
- fit(xmat,Verr); // get initial values
- fnthite++;
+  res_Z_lh[iloop_] = sfpar[Par_Z0];
+  res_sigmaZ_lh[iloop_] = sfpar[Par_Sigma];
+  res_Zerr_lh[iloop_] = errsfpar[Par_Z0];
+  res_sigmaZerr_lh[iloop_] = errsfpar[Par_Sigma];
 
- Double_t chi2cut = 20;
+  // get 1 sigma contour of param 0 vs 1
+  ///gmMinuit->SetErrorDef(1);
+  ///TGraph *gra1_sig1 = (TGraph*)gMinuit->Contour(60,0,1);
+  //gra1_sig1->Draw("alp");
+  //gra1_sig1->SetName("gra1_sig1");
+  ///gmMinuit->SetErrorDef(4); // two sigma
+  ///TGraph *gra1_sig2 = (TGraph*)gMinuit->Contour(60,0,1);
+  //gra1_sig2->Draw("alp");
+  //gra1_sig2->SetName("gra1_sig2");
+  // gr12->Draw("alp");
 
- int fminNtrks = 100;
- double fconvergence = 0.9;
+  std::cout << "======== End of Maximum LH Fit for Z ========\n" << std::endl;
 
- while( tmpNtrks_ > fconvergence * zdata.size() ) {
- // below is a very artificial cut requesting that 50 % of the sample survive
- // we hould investigate if there are better criteria than that.
- //
- 
-// while( cutOnChi2(xmat,chi2cut) > 0.5 * zdata.size() ) {
-//	 tmpNtrks_ = 0;
+  //_______________ d0 phi fit _________________
 
-	 fit(xmat,Verr); 
-	 fd0cut /= 1.5;
-	 chi2cut /= 1.5;
-	 if ( tmpNtrks_ > fconvergence*zdata.size() && tmpNtrks_ > fminNtrks )
-	   fnthite++;
- }
- std::cout << " number of iterations: " << fnthite << std::endl;
- 
- std::cout << "======== End of d0-phi Fit ========\n" << std::endl;
+  tmpNtrks_ = 0;  // reset track counter
 
- //__________________ LH Fit for beam __________
- /*
+  TMatrixD xmat(4, 1);
+  TMatrixDSym Verr(4);
+  fit(xmat, Verr);  // get initial values
+  fnthite++;
+
+  Double_t chi2cut = 20;
+
+  int fminNtrks = 100;
+  double fconvergence = 0.9;
+
+  while (tmpNtrks_ > fconvergence * zdata.size()) {
+    // below is a very artificial cut requesting that 50 % of the sample survive
+    // we hould investigate if there are better criteria than that.
+    //
+
+    // while( cutOnChi2(xmat,chi2cut) > 0.5 * zdata.size() ) {
+    //	 tmpNtrks_ = 0;
+
+    fit(xmat, Verr);
+    fd0cut /= 1.5;
+    chi2cut /= 1.5;
+    if (tmpNtrks_ > fconvergence * zdata.size() && tmpNtrks_ > fminNtrks)
+      fnthite++;
+  }
+  std::cout << " number of iterations: " << fnthite << std::endl;
+
+  std::cout << "======== End of d0-phi Fit ========\n" << std::endl;
+
+  //__________________ LH Fit for beam __________
+  /*
    
  for (int i = 0; i<2; i++) { 
 	 gmMinuit->GetParameter(i,sfpar[i],errsfpar[i]);
@@ -550,125 +518,112 @@ for (int i = 0; i<2; i++) {
  std::cout << "======== End of Maximum LH Fit Product for Beam ========\n" << std::endl;
 
 */
-	 
- //outroot->cd();
- //r/h_z->Write(); //to draw only markers use "HISTPE1"
- //gra1_sig1->Write();
 
- //gra1_sig2->Write();
- 
- //app.Run();   
- // return 0;
+  //outroot->cd();
+  //r/h_z->Write(); //to draw only markers use "HISTPE1"
+  //gra1_sig1->Write();
+
+  //gra1_sig2->Write();
+
+  //app.Run();
+  // return 0;
 }
 
-int main(int argc, char **argv)
-{
-	
-	//gROOT->SetBatch(true);
- 
- //tnt *t = new tnt("PythiaGenerator/lhc_2008_aa_1001.root");
- std::cout << "name: " << argv[1] << std::endl;
+int main(int argc, char **argv) {
+  //gROOT->SetBatch(true);
 
- ftmp.ResizeTo(4,1);
-ftmp.Zero();
- 
- int cut_on_events=0;
- bool run_sequence = false;
- 
- 
- if (argc>=3) {
-	 TString tmpst(argv[2]);
-	 cut_on_events = tmpst.Atoi();
-	 if ( cut_on_events == -1 ) {
-		 run_sequence = true;
-		 std::cout << " run a sequence of fits for 0.5k, 1k, 2k, 5k, 10k" << std::endl;
-	 } else {
-		 std::cout << " maximum number of tracks = " << cut_on_events << std::endl;
-	 }
- }
+  //tnt *t = new tnt("PythiaGenerator/lhc_2008_aa_1001.root");
+  std::cout << "name: " << argv[1] << std::endl;
 
- 
- 
- TString in_filename(argv[1]);
- TString tmp_string = in_filename;
- TString out_filename = tmp_string.Replace(in_filename.Length()-5,in_filename.Length(),"_results.root");
- if (argc==4) {
-   out_filename = TString(argv[3]);
- }
+  ftmp.ResizeTo(4, 1);
+  ftmp.Zero();
 
- //static TROOT beamfit("beamfit","Beam fitting");
- //static TRint app("app",&argc,argv,NULL,0);
+  int cut_on_events = 0;
+  bool run_sequence = false;
 
- TFile *outroot = new TFile(out_filename,"RECREATE");
- 
- NtupleHelper *t = new NtupleHelper(in_filename);
- std::cout << " ntuple initialized" << std::endl;
-  
- //TH1F *h_z = (TH1F*) gDirectory->Get("z0");
- //h_z->SetDirectory(0);
-  
- 
- t->Book();
- std::cout << " ntuple booked" << std::endl;
+  if (argc >= 3) {
+    TString tmpst(argv[2]);
+    cut_on_events = tmpst.Atoi();
+    if (cut_on_events == -1) {
+      run_sequence = true;
+      std::cout << " run a sequence of fits for 0.5k, 1k, 2k, 5k, 10k" << std::endl;
+    } else {
+      std::cout << " maximum number of tracks = " << cut_on_events << std::endl;
+    }
+  }
 
- if ( run_sequence ) {
-	 for (int iloop=0; iloop < Nsequence_; iloop++ ) {
+  TString in_filename(argv[1]);
+  TString tmp_string = in_filename;
+  TString out_filename = tmp_string.Replace(in_filename.Length() - 5, in_filename.Length(), "_results.root");
+  if (argc == 4) {
+    out_filename = TString(argv[3]);
+  }
 
-		 std::cout << " loop over # " << sequence[iloop] << " tracks." << std::endl;
-		 zdata=t->Loop( sequence[iloop] );
-		 fitAll();
-		 std::cout << " loop has finished." << std::endl;
-		 iloop_++;
-	 }
+  //static TROOT beamfit("beamfit","Beam fitting");
+  //static TRint app("app",&argc,argv,NULL,0);
 
-	 outroot->cd();
-	 g_X = new TGraphErrors(Nsequence_,sequenceD,res_d0phi_X,zeros, res_d0phi_Xerr);
-	 g_Y = new TGraphErrors(Nsequence_,sequenceD,res_d0phi_Y,zeros, res_d0phi_Yerr);
-	 g_dXdz = new TGraphErrors(Nsequence_,sequenceD,res_d0phi_dXdz,zeros, res_d0phi_dXdzerr);
-	 g_dYdz = new TGraphErrors(Nsequence_,sequenceD,res_d0phi_dYdz,zeros, res_d0phi_dYdzerr);
+  TFile *outroot = new TFile(out_filename, "RECREATE");
 
-     g_Z = new TGraphErrors(Nsequence_,sequenceD,res_Z,zeros, res_Zerr);
-     g_sigmaZ = new TGraphErrors(Nsequence_,sequenceD,res_sigmaZ,zeros, res_sigmaZerr);
+  NtupleHelper *t = new NtupleHelper(in_filename);
+  std::cout << " ntuple initialized" << std::endl;
 
-	 g_Z_lh = new TGraphErrors(Nsequence_,sequenceD,res_Z_lh,zeros, res_Zerr_lh);
-     g_sigmaZ_lh = new TGraphErrors(Nsequence_,sequenceD,res_sigmaZ_lh,zeros, res_sigmaZerr_lh);
+  //TH1F *h_z = (TH1F*) gDirectory->Get("z0");
+  //h_z->SetDirectory(0);
 
-	 g_X->SetName("beamX");
-	 g_Y->SetName("beamY");
-	 g_dXdz->SetName("beamdXdz");
-	 g_dYdz->SetName("beamdYdz");
-	 g_Z->SetName("beamZ");
-	 g_sigmaZ->SetName("beamSigmaZ");
-	 g_Z_lh->SetName("beamZ_likelihood");
-	 g_sigmaZ_lh->SetName("beamSigmaZ_likelihood");
-	 
-	 
-	 //TCanvas *cv_x = new TCanvas("cv_x","beam_X",700,700);
-	 //g_X->Draw("AP");
+  t->Book();
+  std::cout << " ntuple booked" << std::endl;
 
-	 g_X->Write();
-	 g_Y->Write();
-	 g_dXdz->Write();
-	 g_dYdz->Write();
-	 g_Z->Write();
-	 g_sigmaZ->Write();
-	 g_Z_lh->Write();
-	 g_sigmaZ_lh->Write();
-	 
-	 outroot->Close();
-	 
- } else {
-	 zdata=t->Loop(cut_on_events);
-	 fitAll();
-	 std::cout << " finished loop over events" << std::endl;
- }
+  if (run_sequence) {
+    for (int iloop = 0; iloop < Nsequence_; iloop++) {
+      std::cout << " loop over # " << sequence[iloop] << " tracks." << std::endl;
+      zdata = t->Loop(sequence[iloop]);
+      fitAll();
+      std::cout << " loop has finished." << std::endl;
+      iloop_++;
+    }
 
+    outroot->cd();
+    g_X = new TGraphErrors(Nsequence_, sequenceD, res_d0phi_X, zeros, res_d0phi_Xerr);
+    g_Y = new TGraphErrors(Nsequence_, sequenceD, res_d0phi_Y, zeros, res_d0phi_Yerr);
+    g_dXdz = new TGraphErrors(Nsequence_, sequenceD, res_d0phi_dXdz, zeros, res_d0phi_dXdzerr);
+    g_dYdz = new TGraphErrors(Nsequence_, sequenceD, res_d0phi_dYdz, zeros, res_d0phi_dYdzerr);
 
+    g_Z = new TGraphErrors(Nsequence_, sequenceD, res_Z, zeros, res_Zerr);
+    g_sigmaZ = new TGraphErrors(Nsequence_, sequenceD, res_sigmaZ, zeros, res_sigmaZerr);
 
- 
- //cv_x->Print("beam_X.png");
- 
- 
- return 0;
+    g_Z_lh = new TGraphErrors(Nsequence_, sequenceD, res_Z_lh, zeros, res_Zerr_lh);
+    g_sigmaZ_lh = new TGraphErrors(Nsequence_, sequenceD, res_sigmaZ_lh, zeros, res_sigmaZerr_lh);
 
+    g_X->SetName("beamX");
+    g_Y->SetName("beamY");
+    g_dXdz->SetName("beamdXdz");
+    g_dYdz->SetName("beamdYdz");
+    g_Z->SetName("beamZ");
+    g_sigmaZ->SetName("beamSigmaZ");
+    g_Z_lh->SetName("beamZ_likelihood");
+    g_sigmaZ_lh->SetName("beamSigmaZ_likelihood");
+
+    //TCanvas *cv_x = new TCanvas("cv_x","beam_X",700,700);
+    //g_X->Draw("AP");
+
+    g_X->Write();
+    g_Y->Write();
+    g_dXdz->Write();
+    g_dYdz->Write();
+    g_Z->Write();
+    g_sigmaZ->Write();
+    g_Z_lh->Write();
+    g_sigmaZ_lh->Write();
+
+    outroot->Close();
+
+  } else {
+    zdata = t->Loop(cut_on_events);
+    fitAll();
+    std::cout << " finished loop over events" << std::endl;
+  }
+
+  //cv_x->Print("beam_X.png");
+
+  return 0;
 }

--- a/RecoVertex/BeamSpotProducer/test/NtupleHelper.cc
+++ b/RecoVertex/BeamSpotProducer/test/NtupleHelper.cc
@@ -7,110 +7,101 @@
 
 ClassImp(NtupleHelper);
 
-	
-void NtupleHelper::Book()
-{
-
-  hvxy = new TH2F("vxy" ,"x vers. y vertex",100,-0.01,0.01,100,-0.01,0.01);
-  hvxyz= new TH3F("vxyz" ,"x y z vertex"   ,100,-0.01,0.01,200,-40.,40.,100,-0.01,0.01);
-  hdphi= new TH2F("dphi","d vers phi",100,-0.,6.283,100,-0.2,0.2);
-  hd = new TH2F("d" ,"d vers. z ",100,-40.,40.,100,-0.01,0.01); 
-  hvxz = new TH2F("vxz" ,"x vers. z vertex",100,-40.,40.,100,-0.01,0.01);
-  hsigma  = new TH1F("sigma"  ,"sigma d "   ,100,0.,0.01);
-  hsx  = new TH1F("sx"  ,"sigma vers. z"   ,50,-40.,40.);
-  hpt  = new TH1F("pt"  ,"pt"   ,100,0.,20.);
-  hsx  -> Sumw2();
-  hsd  = new TH1F("sd"  ,"d0 vers. z"   ,50,-40.,40.);
-  hsd  -> Sumw2();
-  hsw  = new TH1F("sw"  ,"sigma weight vers. z"   ,50,-40.,40.);
-  hsw  -> Sumw2();
+void NtupleHelper::Book() {
+  hvxy = new TH2F("vxy", "x vers. y vertex", 100, -0.01, 0.01, 100, -0.01, 0.01);
+  hvxyz = new TH3F("vxyz", "x y z vertex", 100, -0.01, 0.01, 200, -40., 40., 100, -0.01, 0.01);
+  hdphi = new TH2F("dphi", "d vers phi", 100, -0., 6.283, 100, -0.2, 0.2);
+  hd = new TH2F("d", "d vers. z ", 100, -40., 40., 100, -0.01, 0.01);
+  hvxz = new TH2F("vxz", "x vers. z vertex", 100, -40., 40., 100, -0.01, 0.01);
+  hsigma = new TH1F("sigma", "sigma d ", 100, 0., 0.01);
+  hsx = new TH1F("sx", "sigma vers. z", 50, -40., 40.);
+  hpt = new TH1F("pt", "pt", 100, 0., 20.);
+  hsx->Sumw2();
+  hsd = new TH1F("sd", "d0 vers. z", 50, -40., 40.);
+  hsd->Sumw2();
+  hsw = new TH1F("sw", "sigma weight vers. z", 50, -40., 40.);
+  hsw->Sumw2();
 }
-zData  NtupleHelper::Loop(int maxEvents)
-{
-//   In a ROOT session, you can do:
-//      Root > .L NtupleHelper.C
-//      Root > NtupleHelper t
-//      Root > t.GetEntry(12); // Fill t data members with entry number 12
-//      Root > t.Show();       // Show values of entry 12
-//      Root > t.Show(16);     // Read and show values of entry 16
-//      Root > t.Loop();       // Loop on all entries
-//
+zData NtupleHelper::Loop(int maxEvents) {
+  //   In a ROOT session, you can do:
+  //      Root > .L NtupleHelper.C
+  //      Root > NtupleHelper t
+  //      Root > t.GetEntry(12); // Fill t data members with entry number 12
+  //      Root > t.Show();       // Show values of entry 12
+  //      Root > t.Show(16);     // Read and show values of entry 16
+  //      Root > t.Loop();       // Loop on all entries
+  //
 
-//     This is the loop skeleton where:
-//    jentry is the global entry number in the chain
-//    ientry is the entry number in the current Tree
-//  Note that the argument to GetEntry must be:
-//    jentry for TChain::GetEntry
-//    ientry for TTree::GetEntry and TBranch::GetEntry
-//
-//       To read only selected branches, Insert statements like:
-// METHOD1:
-//    fChain->SetBranchStatus("*",0);  // disable all branches
-//    fChain->SetBranchStatus("branchname",1);  // activate branchname
-// METHOD2: replace line
-//    fChain->GetEntry(jentry);       //read all branches
-//by  b_branchname->GetEntry(ientry); //read only this branch
-//   TH2F *hvxy = new TH2F("vxy","x vers. y vertex",100,-0.4,0.4,100,-0.4,0.4);
+  //     This is the loop skeleton where:
+  //    jentry is the global entry number in the chain
+  //    ientry is the entry number in the current Tree
+  //  Note that the argument to GetEntry must be:
+  //    jentry for TChain::GetEntry
+  //    ientry for TTree::GetEntry and TBranch::GetEntry
+  //
+  //       To read only selected branches, Insert statements like:
+  // METHOD1:
+  //    fChain->SetBranchStatus("*",0);  // disable all branches
+  //    fChain->SetBranchStatus("branchname",1);  // activate branchname
+  // METHOD2: replace line
+  //    fChain->GetEntry(jentry);       //read all branches
+  //by  b_branchname->GetEntry(ientry); //read only this branch
+  //   TH2F *hvxy = new TH2F("vxy","x vers. y vertex",100,-0.4,0.4,100,-0.4,0.4);
 
-  std::cout << "  loop over entries" <<std::endl;
+  std::cout << "  loop over entries" << std::endl;
   std::cout << "  maximum number of entries: " << maxEvents << std::endl;
   zData zvector;
-   if (fChain == 0) return zvector;
-   zvector.erase(zvector.begin(),zvector.end());
-   Long64_t nentries = fChain->GetEntriesFast();
+  if (fChain == 0)
+    return zvector;
+  zvector.erase(zvector.begin(), zvector.end());
+  Long64_t nentries = fChain->GetEntriesFast();
 
-   std::cout << " total number of entries: " << fChain->GetEntries() << std::endl;
-   
-   Int_t nbytes = 0, nb = 0;
-   int theevent = 0;
-   for (Long64_t jentry=0; jentry<nentries;jentry++) {
-     Long64_t ientry = LoadTree(jentry);
-     if (ientry < 0) break;
-     nb = fChain->GetEntry(jentry);   nbytes += nb;
-     //      if (sigmaD <0.05&&pt>4.0)
-     //	{
-      
-     //if (z0>-20. && z0<20. && pt>4 ) {
-     //if (pt>2 ) {
-     //if (pt>5 && sigmaD<0.02) { //it was pt>5
-     if (true) {
-       if (maxEvents>0 && maxEvents == theevent) {
-	 std::cout << " reached maximum number of tracks, continue" << std::endl;
-	 break;
-       }
-       hvxy->Fill(x,y);
-       hvxyz->Fill(x,z0,y);
-       hdphi->Fill(phi,d0);
-       hvxz->Fill(z0,x);
-       hsd->Fill(z0,fabs(d0));
-       hd->Fill(z0,d0);  
-       hsx->Fill(z0,fabs(x));
-       hpt->Fill(pt,1.0);
-       hsw->Fill(z0,1.0);   
-       hsigma->Fill(sigmaD);
+  std::cout << " total number of entries: " << fChain->GetEntries() << std::endl;
 
-       // for reco ntuples:
-       if (pt>1.2 &&
-		   TMath::Abs(eta)< 2.4 &&
-		   TMath::Abs(d0)<5 &&
-		   TMath::Abs(z0)<60 &&
-		   nPixelLayerMeas>=3 &&
-		   nTotLayerMeas >= 11 &&
-		   normchi2 < 2 &&
-	   quality &&
-	   algo ) { 
-		   //TMath::Abs(d0)<0.06 ) {
-		   //(chi2/ndof)<5 && TMath::Prob(chi2, (int)ndof)>0.02 && TMath::Abs(eta)<2.2 ) {
-		   zvector.push_back(data(z0,sigmaz0,d0,sigmaD,phi,pt,1.));
-		   theevent++;
-       }
-      
-     }
-  // if (Cut(ientry) < 0) continue;
-	  //	}
-   }
-   std::cout << zvector.size() << " selected tracks read in.\n";
-   hsx->Divide(hsw);
-   hsd->Divide(hsw);
-   return zvector;
+  Int_t nbytes = 0, nb = 0;
+  int theevent = 0;
+  for (Long64_t jentry = 0; jentry < nentries; jentry++) {
+    Long64_t ientry = LoadTree(jentry);
+    if (ientry < 0)
+      break;
+    nb = fChain->GetEntry(jentry);
+    nbytes += nb;
+    //      if (sigmaD <0.05&&pt>4.0)
+    //	{
+
+    //if (z0>-20. && z0<20. && pt>4 ) {
+    //if (pt>2 ) {
+    //if (pt>5 && sigmaD<0.02) { //it was pt>5
+    if (true) {
+      if (maxEvents > 0 && maxEvents == theevent) {
+        std::cout << " reached maximum number of tracks, continue" << std::endl;
+        break;
+      }
+      hvxy->Fill(x, y);
+      hvxyz->Fill(x, z0, y);
+      hdphi->Fill(phi, d0);
+      hvxz->Fill(z0, x);
+      hsd->Fill(z0, fabs(d0));
+      hd->Fill(z0, d0);
+      hsx->Fill(z0, fabs(x));
+      hpt->Fill(pt, 1.0);
+      hsw->Fill(z0, 1.0);
+      hsigma->Fill(sigmaD);
+
+      // for reco ntuples:
+      if (pt > 1.2 && TMath::Abs(eta) < 2.4 && TMath::Abs(d0) < 5 && TMath::Abs(z0) < 60 && nPixelLayerMeas >= 3 &&
+          nTotLayerMeas >= 11 && normchi2 < 2 && quality && algo) {
+        //TMath::Abs(d0)<0.06 ) {
+        //(chi2/ndof)<5 && TMath::Prob(chi2, (int)ndof)>0.02 && TMath::Abs(eta)<2.2 ) {
+        zvector.push_back(data(z0, sigmaz0, d0, sigmaD, phi, pt, 1.));
+        theevent++;
+      }
+    }
+    // if (Cut(ientry) < 0) continue;
+    //	}
+  }
+  std::cout << zvector.size() << " selected tracks read in.\n";
+  hsx->Divide(hsw);
+  hsd->Divide(hsw);
+  return zvector;
 }

--- a/RecoVertex/BeamSpotProducer/test/NtupleHelper.h
+++ b/RecoVertex/BeamSpotProducer/test/NtupleHelper.h
@@ -14,213 +14,208 @@
 #include "global.h"
 
 class NtupleHelper {
-public :
+public:
+  TH1F *hsx;
+  TH2F *hd;
+  TH1F *hsw;
+  TH1F *hsd;
+  TH1F *hsigma;
+  //  TH1F           *hsw;
+  TH2F *hvxy;
+  TH2F *hvxz;
+  TH2F *hdphi;
+  TH3F *hvxyz;
+  TH1F *hpt;
+  TTree *fChain;   //!pointer to the analyzed TTree or TChain
+  Int_t fCurrent;  //!current Tree number in a TChain
 
+  // Declaration of leave types
+  Float_t run;
+  Float_t event;
+  Double_t pt;
+  Double_t d0;
+  Double_t phi;
+  Double_t sigmaD;
+  Double_t z0;
+  Double_t sigmaz0;
+  Float_t x;
+  Float_t y;
+  //   UInt_t nPixelHit;
+  Double_t normchi2;
+  Double_t eta;
+  Double_t theta;
+  Int_t charge;
+  Int_t nTotLayerMeas;
+  Int_t nStripLayerMeas;
+  Int_t nPixelLayerMeas;
+  Bool_t quality;
+  Bool_t algo;
 
+  // List of branches
+  TBranch *b_run;      //!
+  TBranch *b_event;    //!
+  TBranch *b_pt;       //!
+  TBranch *b_d0;       //!
+  TBranch *b_phi;      //!
+  TBranch *b_sigmaD;   //!
+  TBranch *b_z0;       //!
+  TBranch *b_sigmaz0;  //!
+  TBranch *b_x;        //!
+  TBranch *b_y;        //!
+  TBranch *b_nTotLayerMeas;
+  TBranch *b_nStripLayerMeas;
+  TBranch *b_nPixelLayerMeas;
+  TBranch *b_normchi2;
+  TBranch *b_eta;
+  TBranch *b_theta;
+  TBranch *b_charge;
+  TBranch *b_quality;
+  TBranch *b_algo;
 
-  TH1F           *hsx; 
-  TH2F           *hd; 
-  TH1F           *hsw; 
-  TH1F           *hsd; 
-  TH1F           *hsigma; 
-  //  TH1F           *hsw; 
-  TH2F           *hvxy;
-  TH2F           *hvxz;
-  TH2F           *hdphi;
-  TH3F           *hvxyz;
-  TH1F           *hpt;   
-  TTree          *fChain;   //!pointer to the analyzed TTree or TChain
-  Int_t           fCurrent; //!current Tree number in a TChain
-
-   // Declaration of leave types
-   Float_t         run;
-   Float_t         event;
-   Double_t         pt;
-   Double_t         d0;
-   Double_t         phi;
-   Double_t         sigmaD;
-   Double_t         z0;
-   Double_t         sigmaz0;
-   Float_t         x;
-   Float_t         y;
-   //   UInt_t nPixelHit;
-   Double_t normchi2;
-   Double_t eta;
-   Double_t theta;
-   Int_t charge;
-   Int_t nTotLayerMeas;
-   Int_t nStripLayerMeas;
-   Int_t nPixelLayerMeas;
-   Bool_t quality;
-   Bool_t algo;
-
-   // List of branches
-   TBranch        *b_run;   //!
-   TBranch        *b_event;   //!
-   TBranch        *b_pt;   //!
-   TBranch        *b_d0;   //!
-   TBranch        *b_phi;   //!
-   TBranch        *b_sigmaD;   //!
-   TBranch        *b_z0;   //!
-   TBranch        *b_sigmaz0;   //!
-   TBranch        *b_x;   //!
-   TBranch        *b_y;   //!
-   TBranch *b_nTotLayerMeas;
-   TBranch *b_nStripLayerMeas;
-   TBranch *b_nPixelLayerMeas;
-   TBranch *b_normchi2;
-   TBranch *b_eta;
-   TBranch *b_theta;
-   TBranch *b_charge;
-   TBranch *b_quality;
-   TBranch *b_algo;
-
-   NtupleHelper(const char* fname ,TTree *tree=0);
-   virtual ~NtupleHelper();
-   virtual Int_t    Cut(Long64_t entry);
-   virtual Int_t    GetEntry(Long64_t entry);
-   virtual Long64_t LoadTree(Long64_t entry);
-   virtual void     Init(TTree *tree);
-   virtual zData    Loop(int maxEvents= 0);
-   virtual Bool_t   Notify();
-   virtual void     Show(Long64_t entry = -1);
-   virtual void     Book();
-  ClassDef(NtupleHelper,1) 
+  NtupleHelper(const char *fname, TTree *tree = 0);
+  virtual ~NtupleHelper();
+  virtual Int_t Cut(Long64_t entry);
+  virtual Int_t GetEntry(Long64_t entry);
+  virtual Long64_t LoadTree(Long64_t entry);
+  virtual void Init(TTree *tree);
+  virtual zData Loop(int maxEvents = 0);
+  virtual Bool_t Notify();
+  virtual void Show(Long64_t entry = -1);
+  virtual void Book();
+  ClassDef(NtupleHelper, 1)
 };
 
 #endif
 #ifdef NtupleHelper_cc
-NtupleHelper::NtupleHelper(const char* fname,TTree *tree)
-{
-// if parameter tree is not specified (or zero), connect the file
-// used to generate this class and read the Tree.
-   if (tree == 0) {
-      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject(fname);
-      if (!f) {
-         f = new TFile(fname);
-      }
-      tree = (TTree*)gDirectory->Get("mytree");
-	  std::cout << "[NtupleHelper] got tree " << std::endl;
-	  //tree = (TTree*)gDirectory->Get("mytree"); // for reco ntuple
-
-   }
-   Init(tree);
+NtupleHelper::NtupleHelper(const char *fname, TTree *tree) {
+  // if parameter tree is not specified (or zero), connect the file
+  // used to generate this class and read the Tree.
+  if (tree == 0) {
+    TFile *f = (TFile *)gROOT->GetListOfFiles()->FindObject(fname);
+    if (!f) {
+      f = new TFile(fname);
+    }
+    tree = (TTree *)gDirectory->Get("mytree");
+    std::cout << "[NtupleHelper] got tree " << std::endl;
+    //tree = (TTree*)gDirectory->Get("mytree"); // for reco ntuple
+  }
+  Init(tree);
 }
 
-NtupleHelper::~NtupleHelper()
-{
-   if (!fChain) return;
-   //delete fChain->GetCurrentFile();
+NtupleHelper::~NtupleHelper() {
+  if (!fChain)
+    return;
+  //delete fChain->GetCurrentFile();
 }
 
-Int_t NtupleHelper::GetEntry(Long64_t entry)
-{
-// Read contents of entry.
-   if (!fChain) return 0;
-   return fChain->GetEntry(entry);
+Int_t NtupleHelper::GetEntry(Long64_t entry) {
+  // Read contents of entry.
+  if (!fChain)
+    return 0;
+  return fChain->GetEntry(entry);
 }
-Long64_t NtupleHelper::LoadTree(Long64_t entry)
-{
-// Set the environment to read one entry
-   if (!fChain) return -5;
-   Long64_t centry = fChain->LoadTree(entry);
-   if (centry < 0) return centry;
-   if (fChain->IsA() != TChain::Class()) return centry;
-   TChain *chain = (TChain*)fChain;
-   if (chain->GetTreeNumber() != fCurrent) {
-      fCurrent = chain->GetTreeNumber();
-      Notify();
-   }
-   return centry;
-}
-
-void NtupleHelper::Init(TTree *tree)
-{
-   // The Init() function is called when the selector needs to initialize
-   // a new tree or chain. Typically here the branch addresses of the tree
-   // will be set. It is normaly not necessary to make changes to the
-   // generated code, but the routine can be extended by the user if needed.
-   // Init() will be called many times when running with PROOF.
-
-   // Set branch addresses
-   if (tree == 0) return;
-   fChain = tree;
-   fCurrent = -1;
-   fChain->SetMakeClass(1);
-
-   //fChain->SetBranchAddress("run",&run);
-   //fChain->SetBranchAddress("event",&event);
-   fChain->SetBranchAddress("pt",&pt);
-   fChain->SetBranchAddress("d0",&d0);
-   //fChain->SetBranchAddress("phi",&phi);
-   fChain->SetBranchAddress("phi0",&phi);// for reco ntuple
-   fChain->SetBranchAddress("sigmad0",&sigmaD);// for reco ntuple
-   fChain->SetBranchAddress("z0",&z0);
-   fChain->SetBranchAddress("sigmaz0",&sigmaz0);
-   //fChain->SetBranchAddress("x",&x);
-   //fChain->SetBranchAddress("y",&y);
-   fChain->SetBranchAddress("nTotLayerMeas",&nTotLayerMeas);
-   fChain->SetBranchAddress("nStripLayerMeas",&nStripLayerMeas);
-   fChain->SetBranchAddress("nPixelLayerMeas",&nPixelLayerMeas);
-   fChain->SetBranchAddress("normchi2",&normchi2);
-   fChain->SetBranchAddress("eta",&eta);
-   fChain->SetBranchAddress("theta",&theta);
-   fChain->SetBranchAddress("charge",&charge);
-   fChain->SetBranchAddress("quality",&quality);
-   fChain->SetBranchAddress("algo",&algo);
-
-   std::cout << "[NtupleHelper] tree initialized " << std::endl;
-   Notify();
+Long64_t NtupleHelper::LoadTree(Long64_t entry) {
+  // Set the environment to read one entry
+  if (!fChain)
+    return -5;
+  Long64_t centry = fChain->LoadTree(entry);
+  if (centry < 0)
+    return centry;
+  if (fChain->IsA() != TChain::Class())
+    return centry;
+  TChain *chain = (TChain *)fChain;
+  if (chain->GetTreeNumber() != fCurrent) {
+    fCurrent = chain->GetTreeNumber();
+    Notify();
+  }
+  return centry;
 }
 
-Bool_t NtupleHelper::Notify()
-{
-   // The Notify() function is called when a new file is opened. This
-   // can be either for a new TTree in a TChain or when when a new TTree
-   // is started when using PROOF. Typically here the branch pointers
-   // will be retrieved. It is normaly not necessary to make changes
-   // to the generated code, but the routine can be extended by the
-   // user if needed.
+void NtupleHelper::Init(TTree *tree) {
+  // The Init() function is called when the selector needs to initialize
+  // a new tree or chain. Typically here the branch addresses of the tree
+  // will be set. It is normaly not necessary to make changes to the
+  // generated code, but the routine can be extended by the user if needed.
+  // Init() will be called many times when running with PROOF.
 
-   // Get branch pointers
-   //b_run = fChain->GetBranch("run");
-   //b_event = fChain->GetBranch("event");
-   b_pt = fChain->GetBranch("pt");
-   b_d0 = fChain->GetBranch("d0");
-   //b_phi = fChain->GetBranch("phi");
-   //b_sigmaD = fChain->GetBranch("sigmaD");
-   b_phi = fChain->GetBranch("phi0");
-   b_sigmaD = fChain->GetBranch("sigmad0");
-   
-   b_z0 = fChain->GetBranch("z0");
-   b_sigmaz0 = fChain->GetBranch("sigmaz0");
-   //b_x = fChain->GetBranch("x");
-   //b_y = fChain->GetBranch("y");
+  // Set branch addresses
+  if (tree == 0)
+    return;
+  fChain = tree;
+  fCurrent = -1;
+  fChain->SetMakeClass(1);
 
-   b_nTotLayerMeas = fChain->GetBranch("nTotLayerMeas");
-   b_nPixelLayerMeas = fChain->GetBranch("nPixelLayerMeas");
-   b_nStripLayerMeas = fChain->GetBranch("nStripLayerMeas");
-   b_normchi2 = fChain->GetBranch("normchi2");
-   b_eta = fChain->GetBranch("eta");
-   b_quality = fChain->GetBranch("quality");
-   b_algo = fChain->GetBranch("algo");
+  //fChain->SetBranchAddress("run",&run);
+  //fChain->SetBranchAddress("event",&event);
+  fChain->SetBranchAddress("pt", &pt);
+  fChain->SetBranchAddress("d0", &d0);
+  //fChain->SetBranchAddress("phi",&phi);
+  fChain->SetBranchAddress("phi0", &phi);        // for reco ntuple
+  fChain->SetBranchAddress("sigmad0", &sigmaD);  // for reco ntuple
+  fChain->SetBranchAddress("z0", &z0);
+  fChain->SetBranchAddress("sigmaz0", &sigmaz0);
+  //fChain->SetBranchAddress("x",&x);
+  //fChain->SetBranchAddress("y",&y);
+  fChain->SetBranchAddress("nTotLayerMeas", &nTotLayerMeas);
+  fChain->SetBranchAddress("nStripLayerMeas", &nStripLayerMeas);
+  fChain->SetBranchAddress("nPixelLayerMeas", &nPixelLayerMeas);
+  fChain->SetBranchAddress("normchi2", &normchi2);
+  fChain->SetBranchAddress("eta", &eta);
+  fChain->SetBranchAddress("theta", &theta);
+  fChain->SetBranchAddress("charge", &charge);
+  fChain->SetBranchAddress("quality", &quality);
+  fChain->SetBranchAddress("algo", &algo);
 
-   std::cout << "[NtupleHelper] branches notified" << std::endl;
-   return kTRUE;
+  std::cout << "[NtupleHelper] tree initialized " << std::endl;
+  Notify();
 }
 
-void NtupleHelper::Show(Long64_t entry)
-{
-// Print contents of entry.
-// If entry is not specified, print current entry
-   if (!fChain) return;
-   fChain->Show(entry);
+Bool_t NtupleHelper::Notify() {
+  // The Notify() function is called when a new file is opened. This
+  // can be either for a new TTree in a TChain or when when a new TTree
+  // is started when using PROOF. Typically here the branch pointers
+  // will be retrieved. It is normaly not necessary to make changes
+  // to the generated code, but the routine can be extended by the
+  // user if needed.
+
+  // Get branch pointers
+  //b_run = fChain->GetBranch("run");
+  //b_event = fChain->GetBranch("event");
+  b_pt = fChain->GetBranch("pt");
+  b_d0 = fChain->GetBranch("d0");
+  //b_phi = fChain->GetBranch("phi");
+  //b_sigmaD = fChain->GetBranch("sigmaD");
+  b_phi = fChain->GetBranch("phi0");
+  b_sigmaD = fChain->GetBranch("sigmad0");
+
+  b_z0 = fChain->GetBranch("z0");
+  b_sigmaz0 = fChain->GetBranch("sigmaz0");
+  //b_x = fChain->GetBranch("x");
+  //b_y = fChain->GetBranch("y");
+
+  b_nTotLayerMeas = fChain->GetBranch("nTotLayerMeas");
+  b_nPixelLayerMeas = fChain->GetBranch("nPixelLayerMeas");
+  b_nStripLayerMeas = fChain->GetBranch("nStripLayerMeas");
+  b_normchi2 = fChain->GetBranch("normchi2");
+  b_eta = fChain->GetBranch("eta");
+  b_quality = fChain->GetBranch("quality");
+  b_algo = fChain->GetBranch("algo");
+
+  std::cout << "[NtupleHelper] branches notified" << std::endl;
+  return kTRUE;
 }
-Int_t NtupleHelper::Cut(Long64_t entry)
-{
-// This function may be called from Loop.
-// returns  1 if entry is accepted.
-// returns -1 otherwise.
-   return 1;
+
+void NtupleHelper::Show(Long64_t entry) {
+  // Print contents of entry.
+  // If entry is not specified, print current entry
+  if (!fChain)
+    return;
+  fChain->Show(entry);
 }
-#endif // #ifdef NtupleHelper_cc
+Int_t NtupleHelper::Cut(Long64_t entry) {
+  // This function may be called from Loop.
+  // returns  1 if entry is accepted.
+  // returns -1 otherwise.
+  return 1;
+}
+#endif  // #ifdef NtupleHelper_cc

--- a/RecoVertex/BeamSpotProducer/test/classes.h
+++ b/RecoVertex/BeamSpotProducer/test/classes.h
@@ -1,6 +1,5 @@
 #include "RecoVertex/BeamSpotProducer/test/NtupleHelper.h"
 
 namespace RecoVertex_BeamSpotProducer_test {
-  struct dictionary {
-  };
-}
+  struct dictionary {};
+}  // namespace RecoVertex_BeamSpotProducer_test

--- a/RecoVertex/BeamSpotProducer/test/global.h
+++ b/RecoVertex/BeamSpotProducer/test/global.h
@@ -5,35 +5,33 @@
 //
 // define some useful constants:
 //
-const Double_t sqrt2    = sqrt(2.0);
-const Double_t sqrt2pi  = 2.5066282746;
+const Double_t sqrt2 = sqrt(2.0);
+const Double_t sqrt2pi = 2.5066282746;
 
-const int dim    = 11;  // number of fit parameters
+const int dim = 11;  // number of fit parameters
 // 'pointers' to the parameters
-const int Par_Z0    = 0;  // index of position of luminosity peak in z  
+const int Par_Z0 = 0;     // index of position of luminosity peak in z
 const int Par_Sigma = 1;  // index of sigma in z of the beam
 
-const int Par_x0    = 2;  // beam spot x
-const int Par_y0    = 3;  // beam spot y
-const int Par_dxdz  = 4;  // beam slop dxdz
-const int Par_dydz  = 5;  // beam slop dydz
-const int Par_Sigbeam=6;  // beam spot width
+const int Par_x0 = 2;       // beam spot x
+const int Par_y0 = 3;       // beam spot y
+const int Par_dxdz = 4;     // beam slop dxdz
+const int Par_dydz = 5;     // beam slop dydz
+const int Par_Sigbeam = 6;  // beam spot width
 
-const int Par_c0    = 7;
-const int Par_c1    = 8;
+const int Par_c0 = 7;
+const int Par_c1 = 8;
 
-const int Par_eps   = 9;  // index of emittance 
-const int Par_beta  = 10;  // index of beta*
+const int Par_eps = 9;    // index of emittance
+const int Par_beta = 10;  // index of beta*
 
-struct data
- {
-   double Z,SigZ,D,SigD,Phi,Pt,weight2;
-   data(double z, double sigz,double d, double sigd,double phi,
-		double pt,double weight2)
-     : Z(z), SigZ(sigz),D(d),SigD(sigd),Phi(phi),Pt(pt),weight2(1){}
+struct data {
+  double Z, SigZ, D, SigD, Phi, Pt, weight2;
+  data(double z, double sigz, double d, double sigd, double phi, double pt, double weight2)
+      : Z(z), SigZ(sigz), D(d), SigD(sigd), Phi(phi), Pt(pt), weight2(1) {}
 };
-typedef std::vector<::data> zData;//!
-typedef zData::const_iterator zDataConstIter;//!
-typedef zData::iterator zDataIter;//!
+typedef std::vector<::data> zData;             //!
+typedef zData::const_iterator zDataConstIter;  //!
+typedef zData::iterator zDataIter;             //!
 //zData zdata;//!
-#endif //
+#endif  //


### PR DESCRIPTION

Applying code-format for CMSSW category alca,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/364//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


