### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
@@ -22,41 +22,46 @@
 namespace pf2pat {
 
   struct ElectronIDPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
-
-    ElectronIDPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      electronsToken_( iC.consumes<reco::GsfElectronCollection>( cfg.getParameter< edm::InputTag >( "recoGsfElectrons" ) ) ),
-      electronIdToken_( iC.consumes<edm::ValueMap<float> >( cfg.getParameter< edm::InputTag >( "electronIdMap" ) ) )
-    {
-        if (cfg.exists("bitsToCheck")) {
-            isBitMap_ = true;
-            mask_ = 0;
-            if (cfg.existsAs<std::vector<std::string> >("bitsToCheck")) {
-                std::vector<std::string> strbits = cfg.getParameter<std::vector<std::string> >("bitsToCheck");
-                for (std::vector<std::string>::const_iterator istrbit = strbits.begin(), estrbit = strbits.end();
-                        istrbit != estrbit; ++istrbit) {
-                    if      (*istrbit == "id" )  { mask_ |= 1; }
-                    else if (*istrbit == "iso")  { mask_ |= 2; }
-                    else if (*istrbit == "conv") { mask_ |= 4; }
-                    else if (*istrbit == "ip")   { mask_ |= 8; }
-                    else throw cms::Exception("Configuration") << "ElectronIDPFCandidateSelector: " <<
-                        "bitsToCheck allowed string values are only id(0), iso(1), conv(2), ip(3).\n" <<
-                            "Otherwise, use uint32_t bitmask).\n";
-                }
-            } else if (cfg.existsAs<uint32_t>("bitsToCheck")) {
-                mask_ = cfg.getParameter<uint32_t>("bitsToCheck");
-            } else {
-                throw cms::Exception("Configuration") << "ElectronIDPFCandidateSelector: " <<
-                        "bitsToCheck must be either a vector of strings, or a uint32 bitmask.\n";
-            }
+    ElectronIDPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : electronsToken_(
+              iC.consumes<reco::GsfElectronCollection>(cfg.getParameter<edm::InputTag>("recoGsfElectrons"))),
+          electronIdToken_(iC.consumes<edm::ValueMap<float> >(cfg.getParameter<edm::InputTag>("electronIdMap"))) {
+      if (cfg.exists("bitsToCheck")) {
+        isBitMap_ = true;
+        mask_ = 0;
+        if (cfg.existsAs<std::vector<std::string> >("bitsToCheck")) {
+          std::vector<std::string> strbits = cfg.getParameter<std::vector<std::string> >("bitsToCheck");
+          for (std::vector<std::string>::const_iterator istrbit = strbits.begin(), estrbit = strbits.end();
+               istrbit != estrbit;
+               ++istrbit) {
+            if (*istrbit == "id") {
+              mask_ |= 1;
+            } else if (*istrbit == "iso") {
+              mask_ |= 2;
+            } else if (*istrbit == "conv") {
+              mask_ |= 4;
+            } else if (*istrbit == "ip") {
+              mask_ |= 8;
+            } else
+              throw cms::Exception("Configuration")
+                  << "ElectronIDPFCandidateSelector: "
+                  << "bitsToCheck allowed string values are only id(0), iso(1), conv(2), ip(3).\n"
+                  << "Otherwise, use uint32_t bitmask).\n";
+          }
+        } else if (cfg.existsAs<uint32_t>("bitsToCheck")) {
+          mask_ = cfg.getParameter<uint32_t>("bitsToCheck");
         } else {
-            isBitMap_ = false;
-            value_ = cfg.getParameter<double>("electronIdCut");
+          throw cms::Exception("Configuration")
+              << "ElectronIDPFCandidateSelector: "
+              << "bitsToCheck must be either a vector of strings, or a uint32 bitmask.\n";
         }
+      } else {
+        isBitMap_ = false;
+        value_ = cfg.getParameter<double>("electronIdCut");
+      }
     }
 
-    void select( const HandleToCollection & hc,
-		 const edm::Event & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();
 
       edm::Handle<reco::GsfElectronCollection> electrons;
@@ -65,56 +70,61 @@ namespace pf2pat {
       edm::Handle<edm::ValueMap<float> > electronId;
       e.getByToken(electronIdToken_, electronId);
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
         // Get GsfTrack for matching with reco::GsfElectron objects
         reco::GsfTrackRef PfTk = pfc->gsfTrackRef();
 
         // skip ones without GsfTrack: they won't be matched anyway
-        if (PfTk.isNull()) continue;
+        if (PfTk.isNull())
+          continue;
 
         int match = -1;
         // try first the non-ambiguous tracks
-        for (reco::GsfElectronCollection::const_iterator it = electrons->begin(), ed = electrons->end(); it != ed; ++it) {
-            if (it->gsfTrack() == PfTk) { match = it - electrons->begin(); break; }
+        for (reco::GsfElectronCollection::const_iterator it = electrons->begin(), ed = electrons->end(); it != ed;
+             ++it) {
+          if (it->gsfTrack() == PfTk) {
+            match = it - electrons->begin();
+            break;
+          }
         }
         // then the ambiguous ones
         if (match == -1) {
-            for (reco::GsfElectronCollection::const_iterator it = electrons->begin(), ed = electrons->end(); it != ed; ++it) {
-                if (std::count(it->ambiguousGsfTracksBegin(), it->ambiguousGsfTracksEnd(), PfTk) > 0) {
-                    match = it - electrons->begin(); break;
-                }
+          for (reco::GsfElectronCollection::const_iterator it = electrons->begin(), ed = electrons->end(); it != ed;
+               ++it) {
+            if (std::count(it->ambiguousGsfTracksBegin(), it->ambiguousGsfTracksEnd(), PfTk) > 0) {
+              match = it - electrons->begin();
+              break;
             }
+          }
         }
         // if found, make a GsfElectronRef and read electron id
         if (match != -1) {
-            reco::GsfElectronRef ref(electrons,match);
-            float eleId = (*electronId)[ref];
-            bool pass = false;
-            if (isBitMap_) {
-                uint32_t thisval = eleId;
-                pass = ((thisval & mask_) == mask_);
-            } else {
-                pass = (eleId > value_);
-            }
-            if (pass) {
-                selected_.push_back( reco::PFCandidate(*pfc) );
-                reco::PFCandidatePtr ptrToMother( hc, key );
-                selected_.back().setSourceCandidatePtr( ptrToMother );
-            }
+          reco::GsfElectronRef ref(electrons, match);
+          float eleId = (*electronId)[ref];
+          bool pass = false;
+          if (isBitMap_) {
+            uint32_t thisval = eleId;
+            pass = ((thisval & mask_) == mask_);
+          } else {
+            pass = (eleId > value_);
+          }
+          if (pass) {
+            selected_.push_back(reco::PFCandidate(*pfc));
+            reco::PFCandidatePtr ptrToMother(hc, key);
+            selected_.back().setSourceCandidatePtr(ptrToMother);
+          }
         }
       }
     }
 
-    private:
-        edm::EDGetTokenT<reco::GsfElectronCollection>  electronsToken_;
-        edm::EDGetTokenT<edm::ValueMap<float> >  electronIdToken_;
-        bool isBitMap_;
-        uint32_t mask_;
-        double   value_;
+  private:
+    edm::EDGetTokenT<reco::GsfElectronCollection> electronsToken_;
+    edm::EDGetTokenT<edm::ValueMap<float> > electronIdToken_;
+    bool isBitMap_;
+    uint32_t mask_;
+    double value_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/EventHypothesis.h
+++ b/CommonTools/ParticleFlow/interface/EventHypothesis.h
@@ -1,42 +1,37 @@
 #ifndef __CommonTools_ParticleFlow_interface_EventHypothesis__
 #define __CommonTools_ParticleFlow_interface_EventHypothesis__
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <map>
 #include <string>
 
-
 namespace pf2pat {
-  
-  class EventHypothesis {
 
+  class EventHypothesis {
   public:
     /// the name of the parameter set is given to the event hypothesis
     /// the parameter set must contain a vstring named "sequence"
-    /// and at least a parameter set named after each string in the 
-    /// sequence. 
-    EventHypothesis( const edm::ParameterSet& ps);
-    
+    /// and at least a parameter set named after each string in the
+    /// sequence.
+    EventHypothesis(const edm::ParameterSet& ps);
 
   private:
     // need a base class for all algorithms/producers
     typedef std::string Producer;
-    typedef std::map< std::string, Producer >  Producers;
-    typedef std::vector< std::string > Sequence; 
-    
-    /// unique name
-    std::string   name_;
-    
-    /// map of producers, indexed by producer name
-    Producers     producers_;
+    typedef std::map<std::string, Producer> Producers;
+    typedef std::vector<std::string> Sequence;
 
-    /// sequence of producers 
-    Sequence      sequence_;
-    
+    /// unique name
+    std::string name_;
+
+    /// map of producers, indexed by producer name
+    Producers producers_;
+
+    /// sequence of producers
+    Sequence sequence_;
   };
 
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/GenericPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/GenericPFCandidateSelectorDefinition.h
@@ -20,31 +20,25 @@
 namespace pf2pat {
 
   struct GenericPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
+    GenericPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : selector_(cfg.getParameter<std::string>("cut")) {}
 
-    GenericPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      selector_( cfg.getParameter< std::string >( "cut" ) ) { }
-
-    void select( const HandleToCollection & hc,
-		 const edm::Event & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-
-	if( selector_(*pfc) ) {
-	  selected_.push_back( reco::PFCandidate(*pfc) );
-	  reco::PFCandidatePtr ptrToMother( hc, key );
-	  selected_.back().setSourceCandidatePtr( ptrToMother );
-
-	}
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
+        if (selector_(*pfc)) {
+          selected_.push_back(reco::PFCandidate(*pfc));
+          reco::PFCandidatePtr ptrToMother(hc, key);
+          selected_.back().setSourceCandidatePtr(ptrToMother);
+        }
       }
     }
 
-    private:
+  private:
     StringCutObjectSelector<reco::PFCandidate> selector_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h
@@ -1,7 +1,6 @@
 #ifndef CommonTools_ParticleFlow_GenericPFJetSelectorDefinition
 #define CommonTools_ParticleFlow_GenericPFJetSelectorDefinition
 
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -13,31 +12,25 @@
 namespace pf2pat {
 
   struct GenericPFJetSelectorDefinition : public PFJetSelectorDefinition {
+    GenericPFJetSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : selector_(cfg.getParameter<std::string>("cut")) {}
 
-    GenericPFJetSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      selector_( cfg.getParameter< std::string >( "cut" ) ) { }
-
-    void select( const HandleToCollection & hc,
-		 const edm::Event & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-
-	if( selector_(*pfc) ) {
-	  selected_.push_back( reco::PFJet(*pfc) );
-	  reco::CandidatePtr ptrToMother( hc, key );
-	  selected_.back().setSourceCandidatePtr( ptrToMother );
-
-	}
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
+        if (selector_(*pfc)) {
+          selected_.push_back(reco::PFJet(*pfc));
+          reco::CandidatePtr ptrToMother(hc, key);
+          selected_.back().setSourceCandidatePtr(ptrToMother);
+        }
       }
     }
 
-    private:
+  private:
     StringCutObjectSelector<reco::PFJet> selector_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
@@ -22,66 +22,66 @@
 namespace pf2pat {
 
   struct IPCutPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
+    IPCutPFCandidateSelectorDefinition(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC)
+        : verticesToken_(iC.consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
+          d0Cut_(cfg.getParameter<double>("d0Cut")),
+          dzCut_(cfg.getParameter<double>("dzCut")),
+          d0SigCut_(cfg.getParameter<double>("d0SigCut")),
+          dzSigCut_(cfg.getParameter<double>("dzSigCut")) {}
 
-    IPCutPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      verticesToken_( iC.consumes<reco::VertexCollection>( cfg.getParameter<edm::InputTag> ( "vertices" ) ) ),
-      d0Cut_( cfg.getParameter<double>("d0Cut") ),
-      dzCut_( cfg.getParameter<double>("dzCut") ),
-      d0SigCut_( cfg.getParameter<double>("d0SigCut") ),
-      dzSigCut_( cfg.getParameter<double>("dzSigCut") ) {}
-
-    void select( const HandleToCollection & hc,
-		 const edm::Event & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection &hc, const edm::Event &e, const edm::EventSetup &s) {
       selected_.clear();
 
       edm::Handle<reco::VertexCollection> vertices;
       e.getByToken(verticesToken_, vertices);
-      if (vertices->empty()) return;
+      if (vertices->empty())
+        return;
       const reco::Vertex &vtx = (*vertices)[0];
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
+        bool passing = true;
+        const reco::Track *tk = nullptr;
+        if (pfc->gsfTrackRef().isNonnull())
+          tk = pfc->gsfTrackRef().get();
+        else if (pfc->trackRef().isNonnull())
+          tk = pfc->trackRef().get();
 
-	bool passing = true;
-	const reco::Track *tk = nullptr;
-	if (pfc->gsfTrackRef().isNonnull())   tk = pfc->gsfTrackRef().get();
-	else if (pfc->trackRef().isNonnull()) tk = pfc->trackRef().get();
+        if (tk != nullptr) {
+          double d0 = fabs(tk->dxy(vtx.position()));
+          double dz = fabs(tk->dz(vtx.position()));
+          double d0e = hypot(tk->dxyError(), hypot(vtx.xError(), vtx.yError()));
+          double dze = hypot(tk->dzError(), vtx.zError());
+          if (d0Cut_ > 0 && d0 > d0Cut_)
+            passing = false;
+          if (dzCut_ > 0 && dz > dzCut_)
+            passing = false;
+          if (d0SigCut_ > 0 && d0e > 0 && d0 / d0e > d0SigCut_)
+            passing = false;
+          if (dzSigCut_ > 0 && dze > 0 && dz / dze > dzSigCut_)
+            passing = false;
+        }
 
-	if (tk != nullptr) {
-	  double d0 =  fabs(tk->dxy(vtx.position()));
-	  double dz =  fabs(tk->dz(vtx.position()));
-	  double d0e = hypot(tk->dxyError(), hypot(vtx.xError(), vtx.yError()));
-	  double dze = hypot(tk->dzError(),  vtx.zError());
-	  if (d0Cut_ > 0 && d0 > d0Cut_) passing = false;
-	  if (dzCut_ > 0 && dz > dzCut_) passing = false;
-	  if (d0SigCut_ > 0 && d0e > 0 && d0/d0e > d0SigCut_) passing = false;
-	  if (dzSigCut_ > 0 && dze > 0 && dz/dze > dzSigCut_) passing = false;
-	}
+        if (passing) {
+          selected_.push_back(reco::PFCandidate(*pfc));
+          reco::PFCandidatePtr ptrToMother(hc, key);
 
-	if( passing ) {
-	  selected_.push_back( reco::PFCandidate(*pfc) );
-	  reco::PFCandidatePtr ptrToMother( hc, key );
-
-	  if ( pfc->numberOfSourceCandidatePtrs() > 0 ) {
-	    selected_.back().setSourceCandidatePtr( edm::Ptr<reco::PFCandidate>(  pfc->sourceCandidatePtr(0)
-										  ) );
-	  }
-	  else {
-	    selected_.back().setSourceCandidatePtr( ptrToMother );
-	  }
-	}
+          if (pfc->numberOfSourceCandidatePtrs() > 0) {
+            selected_.back().setSourceCandidatePtr(edm::Ptr<reco::PFCandidate>(pfc->sourceCandidatePtr(0)));
+          } else {
+            selected_.back().setSourceCandidatePtr(ptrToMother);
+          }
+        }
       }
     }
 
-    private:
+  private:
     edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
     double d0Cut_;
     double dzCut_;
     double d0SigCut_;
     double dzSigCut_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/IsolatedPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IsolatedPFCandidateSelectorDefinition.h
@@ -14,106 +14,99 @@
 namespace pf2pat {
 
   class IsolatedPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
-
   public:
     typedef edm::ValueMap<double> IsoMap;
 
-    IsolatedPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      isolationValueMapChargedTokens_(edm::vector_transform(cfg.getParameter< std::vector<edm::InputTag> >("isolationValueMapsCharged"), [&](edm::InputTag const & tag){return iC.consumes<IsoMap>(tag);}) ),
-      isolationValueMapNeutralTokens_(edm::vector_transform(cfg.getParameter< std::vector<edm::InputTag> >("isolationValueMapsNeutral"), [&](edm::InputTag const & tag){return iC.consumes<IsoMap>(tag);}) ),
-      doDeltaBetaCorrection_(cfg.getParameter<bool>("doDeltaBetaCorrection")),
-      deltaBetaIsolationValueMapToken_(iC.mayConsume<IsoMap>(cfg.getParameter< edm::InputTag >("deltaBetaIsolationValueMap") ) ),
-      deltaBetaFactor_(cfg.getParameter<double>("deltaBetaFactor")),
-      isRelative_(cfg.getParameter<bool>("isRelative")),
-      isolationCut_(cfg.getParameter<double>("isolationCut")) {}
+    IsolatedPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : isolationValueMapChargedTokens_(
+              edm::vector_transform(cfg.getParameter<std::vector<edm::InputTag> >("isolationValueMapsCharged"),
+                                    [&](edm::InputTag const& tag) { return iC.consumes<IsoMap>(tag); })),
+          isolationValueMapNeutralTokens_(
+              edm::vector_transform(cfg.getParameter<std::vector<edm::InputTag> >("isolationValueMapsNeutral"),
+                                    [&](edm::InputTag const& tag) { return iC.consumes<IsoMap>(tag); })),
+          doDeltaBetaCorrection_(cfg.getParameter<bool>("doDeltaBetaCorrection")),
+          deltaBetaIsolationValueMapToken_(
+              iC.mayConsume<IsoMap>(cfg.getParameter<edm::InputTag>("deltaBetaIsolationValueMap"))),
+          deltaBetaFactor_(cfg.getParameter<double>("deltaBetaFactor")),
+          isRelative_(cfg.getParameter<bool>("isRelative")),
+          isolationCut_(cfg.getParameter<double>("isolationCut")) {}
 
-
-
-    void select( const HandleToCollection & hc,
-		 const edm::Event & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();
 
-
       // read all charged isolation value maps
-      std::vector< edm::Handle<IsoMap> >
-	isoMapsCharged(isolationValueMapChargedTokens_.size());
-      for(unsigned iMap = 0; iMap<isolationValueMapChargedTokens_.size(); ++iMap) {
-	e.getByToken(isolationValueMapChargedTokens_[iMap], isoMapsCharged[iMap]);
+      std::vector<edm::Handle<IsoMap> > isoMapsCharged(isolationValueMapChargedTokens_.size());
+      for (unsigned iMap = 0; iMap < isolationValueMapChargedTokens_.size(); ++iMap) {
+        e.getByToken(isolationValueMapChargedTokens_[iMap], isoMapsCharged[iMap]);
       }
 
-
       // read all neutral isolation value maps
-      std::vector< edm::Handle<IsoMap> >
-	isoMapsNeutral(isolationValueMapNeutralTokens_.size());
-      for(unsigned iMap = 0; iMap<isolationValueMapNeutralTokens_.size(); ++iMap) {
-	e.getByToken(isolationValueMapNeutralTokens_[iMap], isoMapsNeutral[iMap]);
+      std::vector<edm::Handle<IsoMap> > isoMapsNeutral(isolationValueMapNeutralTokens_.size());
+      for (unsigned iMap = 0; iMap < isolationValueMapNeutralTokens_.size(); ++iMap) {
+        e.getByToken(isolationValueMapNeutralTokens_[iMap], isoMapsNeutral[iMap]);
       }
 
       edm::Handle<IsoMap> dBetaH;
-      if(doDeltaBetaCorrection_) {
-	e.getByToken(deltaBetaIsolationValueMapToken_, dBetaH);
+      if (doDeltaBetaCorrection_) {
+        e.getByToken(deltaBetaIsolationValueMapToken_, dBetaH);
       }
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-	reco::PFCandidateRef candidate(hc,key);
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
+        reco::PFCandidateRef candidate(hc, key);
 
-	bool passed = true;
-	double isoSumCharged=0.0;
-	double isoSumNeutral=0.0;
+        bool passed = true;
+        double isoSumCharged = 0.0;
+        double isoSumNeutral = 0.0;
 
-	for(unsigned iMap = 0; iMap<isoMapsCharged.size(); ++iMap) {
-	  const IsoMap & isoMap = *(isoMapsCharged[iMap]);
-	  double val = isoMap[candidate];
-	  isoSumCharged+=val;
-	}
+        for (unsigned iMap = 0; iMap < isoMapsCharged.size(); ++iMap) {
+          const IsoMap& isoMap = *(isoMapsCharged[iMap]);
+          double val = isoMap[candidate];
+          isoSumCharged += val;
+        }
 
-	for(unsigned iMap = 0; iMap<isoMapsNeutral.size(); ++iMap) {
-	  const IsoMap & isoMap = *(isoMapsNeutral[iMap]);
-	  double val = isoMap[candidate];
-	  isoSumNeutral+=val;
-	}
+        for (unsigned iMap = 0; iMap < isoMapsNeutral.size(); ++iMap) {
+          const IsoMap& isoMap = *(isoMapsNeutral[iMap]);
+          double val = isoMap[candidate];
+          isoSumNeutral += val;
+        }
 
+        if (doDeltaBetaCorrection_) {
+          const IsoMap& isoMap = *dBetaH;
+          double dBetaVal = isoMap[candidate];
+          double dBetaCorIsoSumNeutral = isoSumNeutral + deltaBetaFactor_ * dBetaVal;
+          isoSumNeutral = dBetaCorIsoSumNeutral > 0 ? dBetaCorIsoSumNeutral : 0;  //follow muon POG definition in 2012
+        }
 
-	if ( doDeltaBetaCorrection_ ) {
-	  const IsoMap& isoMap = *dBetaH;
-	  double dBetaVal = isoMap[candidate];
-	  double dBetaCorIsoSumNeutral = isoSumNeutral + deltaBetaFactor_*dBetaVal;
-	  isoSumNeutral = dBetaCorIsoSumNeutral>0 ? dBetaCorIsoSumNeutral : 0; //follow muon POG definition in 2012
-	}
+        double isoSum = isoSumCharged + isoSumNeutral;
 
-	double isoSum=isoSumCharged+isoSumNeutral;
+        if (isRelative_) {
+          isoSum /= candidate->pt();
+        }
 
-	if( isRelative_ ) {
-	  isoSum /= candidate->pt();
-	}
+        if (isoSum > isolationCut_) {
+          passed = false;
+        }
 
-	if ( isoSum>isolationCut_ ) {
-	  passed = false;
-	}
-
-	if(passed) {
-	  // passed all cuts, selected
-	  selected_.push_back( reco::PFCandidate(*pfc) );
-	  reco::PFCandidatePtr ptrToMother( hc, key );
-	  selected_.back().setSourceCandidatePtr( ptrToMother );
-	}
+        if (passed) {
+          // passed all cuts, selected
+          selected_.push_back(reco::PFCandidate(*pfc));
+          reco::PFCandidatePtr ptrToMother(hc, key);
+          selected_.back().setSourceCandidatePtr(ptrToMother);
+        }
       }
     }
-
 
   private:
     std::vector<edm::EDGetTokenT<IsoMap> > isolationValueMapChargedTokens_;
     std::vector<edm::EDGetTokenT<IsoMap> > isolationValueMapNeutralTokens_;
-    bool                       doDeltaBetaCorrection_;
-    edm::EDGetTokenT<IsoMap>              deltaBetaIsolationValueMapToken_;
-    double                     deltaBetaFactor_;
-    bool                       isRelative_;
-    double                     isolationCut_;
+    bool doDeltaBetaCorrection_;
+    edm::EDGetTokenT<IsoMap> deltaBetaIsolationValueMapToken_;
+    double deltaBetaFactor_;
+    bool isRelative_;
+    double isolationCut_;
   };
 
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/MuonIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/MuonIDPFCandidateSelectorDefinition.h
@@ -9,7 +9,6 @@
    \version  $Id: MuonIDPFCandidateSelectorDefinition.h,v 1.1 2011/01/28 20:56:44 srappocc Exp $
 */
 
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,41 +22,35 @@
 namespace pf2pat {
 
   struct MuonIDPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
+    MuonIDPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : muonCut_(cfg.getParameter<std::string>("cut")) {}
 
-    MuonIDPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      muonCut_( cfg.getParameter< std::string >( "cut" ) )
-    {
-    }
-
-    void select( const HandleToCollection & hc,
-		 const edm::Event & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
         reco::MuonRef muR = pfc->muonRef();
 
         // skip ones without a ref to a reco::Muon: they won't be matched anyway
-        if (muR.isNull()) continue;
+        if (muR.isNull())
+          continue;
 
         // convert into a pat::Muon, so that the 'muonID' method is available
         pat::Muon patMu(*muR);
 
         // apply muon id
         if (muonCut_(patMu)) {
-            selected_.push_back( reco::PFCandidate(*pfc) );
-            reco::PFCandidatePtr ptrToMother( hc, key );
-            selected_.back().setSourceCandidatePtr( ptrToMother );
+          selected_.push_back(reco::PFCandidate(*pfc));
+          reco::PFCandidatePtr ptrToMother(hc, key);
+          selected_.back().setSourceCandidatePtr(ptrToMother);
         }
       }
     }
 
-    private:
-        StringCutObjectSelector<pat::Muon> muonCut_;
+  private:
+    StringCutObjectSelector<pat::Muon> muonCut_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFCandidateFwdPtrFactory.h
+++ b/CommonTools/ParticleFlow/interface/PFCandidateFwdPtrFactory.h
@@ -15,18 +15,17 @@
 
 namespace reco {
   struct PFCandidateFwdPtrFactory {
-    edm::FwdPtr<reco::PFCandidate> operator() (edm::View<reco::PFCandidate> const & view, unsigned int i)  const  { 
+    edm::FwdPtr<reco::PFCandidate> operator()(edm::View<reco::PFCandidate> const& view, unsigned int i) const {
       edm::Ptr<reco::PFCandidate> ptr = view.ptrAt(i);
       edm::Ptr<reco::PFCandidate> backPtr = ptr;
-      if ( ptr.isNonnull() && ptr.isAvailable() && ptr->numberOfSourceCandidatePtrs() > 0 ) {
+      if (ptr.isNonnull() && ptr.isAvailable() && ptr->numberOfSourceCandidatePtrs() > 0) {
         edm::Ptr<reco::Candidate> basePtr = ptr->sourceCandidatePtr(0);
         if (basePtr.isNonnull() && basePtr.isAvailable())
-          backPtr = edm::Ptr<reco::PFCandidate>( basePtr );//this cast works only for available stuff
+          backPtr = edm::Ptr<reco::PFCandidate>(basePtr);  //this cast works only for available stuff
       }
-      return edm::FwdPtr<reco::PFCandidate>(ptr,backPtr); 
+      return edm::FwdPtr<reco::PFCandidate>(ptr, backPtr);
     }
-
   };
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h
@@ -8,19 +8,18 @@
 namespace pf2pat {
 
   class PFCandidateSelectorDefinition {
-
   public:
     typedef reco::PFCandidateCollection collection;
-    typedef edm::Handle< collection > HandleToCollection;
-    typedef std::vector<reco::PFCandidate>  container;
+    typedef edm::Handle<collection> HandleToCollection;
+    typedef std::vector<reco::PFCandidate> container;
 
     struct Pointer {
-      const reco::PFCandidate * operator()(const reco::PFCandidate &c) const { return &c; }
+      const reco::PFCandidate* operator()(const reco::PFCandidate& c) const { return &c; }
     };
 
-    typedef boost::transform_iterator<Pointer,container::const_iterator> const_iterator;
+    typedef boost::transform_iterator<Pointer, container::const_iterator> const_iterator;
 
-    PFCandidateSelectorDefinition () {}
+    PFCandidateSelectorDefinition() {}
 
     const_iterator begin() const { return const_iterator(selected_.begin()); }
 
@@ -28,11 +27,11 @@ namespace pf2pat {
 
     size_t size() const { return selected_.size(); }
 
-    const container& selected() const {return selected_;}
+    const container& selected() const { return selected_; }
 
   protected:
     container selected_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFCandidateWithSrcPtrFactory.h
+++ b/CommonTools/ParticleFlow/interface/PFCandidateWithSrcPtrFactory.h
@@ -14,9 +14,9 @@
 
 namespace reco {
   class PFCandidateWithSrcPtrFactory {
-  public :
-    reco::PFCandidate operator()( edm::FwdPtr<reco::PFCandidate> const & input ) const {
-      reco::PFCandidate output( *input );
+  public:
+    reco::PFCandidate operator()(edm::FwdPtr<reco::PFCandidate> const& input) const {
+      reco::PFCandidate output(*input);
       /* really, what's the point in this ? The one below should be enough
       //and the one loop here is a torture of converting Ptr<PFCandidate> to Ptr<Candidate> and back
       for ( unsigned int isource = 0; isource < input->numberOfSourceCandidatePtrs(); ++isource ) {
@@ -24,10 +24,10 @@ namespace reco {
 	output.setSourceCandidatePtr( ptr );
       }
       */
-      output.setSourceCandidatePtr( input.backPtr() );
-      return output; 
+      output.setSourceCandidatePtr(input.backPtr());
+      return output;
     }
   };
-}
+}  // namespace reco
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFIsoDepositAlgo.h
+++ b/CommonTools/ParticleFlow/interface/PFIsoDepositAlgo.h
@@ -22,44 +22,38 @@
 */
 
 namespace pf2pat {
-  
+
   class PFIsoDepositAlgo {
   public:
-    
     // can be a template parameter (IsoDeposits from GenParticles? )
-    typedef reco::PFCandidate   Particle;
-    typedef std::vector< Particle > ParticleCollection;
-    
+    typedef reco::PFCandidate Particle;
+    typedef std::vector<Particle> ParticleCollection;
+
     // random access to the IsoDeposit corresponding to a given particle
-    typedef std::vector< reco::IsoDeposit > IsoDeposits;
+    typedef std::vector<reco::IsoDeposit> IsoDeposits;
 
     explicit PFIsoDepositAlgo(const edm::ParameterSet&);
 
     ~PFIsoDepositAlgo();
-    
+
     /// all the filtering is done before
-    /// could gain in performance by having a single loop, and 
+    /// could gain in performance by having a single loop, and
     /// by producing all isodeposits at the same time?
     /// however, would not gain in ease of maintenance, and in flexibility.
-    const IsoDeposits&  produce(const ParticleCollection& toBeIsolated,
-				const ParticleCollection& forIsolation );
-    
-  private:    
-    
-    /// build the IsoDeposit for "particle"
-    reco::IsoDeposit buildIsoDeposit( const Particle& particle, 
-				      const ParticleCollection& forIsolation ) const; 
-    
-    /// checks if the 2 particles are in fact the same
-    bool sameParticle( const Particle& particle1,
-		       const Particle& particle2 ) const;
+    const IsoDeposits& produce(const ParticleCollection& toBeIsolated, const ParticleCollection& forIsolation);
 
-    
+  private:
+    /// build the IsoDeposit for "particle"
+    reco::IsoDeposit buildIsoDeposit(const Particle& particle, const ParticleCollection& forIsolation) const;
+
+    /// checks if the 2 particles are in fact the same
+    bool sameParticle(const Particle& particle1, const Particle& particle2) const;
+
     /// IsoDeposits computed in the produce function
-    IsoDeposits  isoDeposits_;
+    IsoDeposits isoDeposits_;
 
     bool verbose_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFJetSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PFJetSelectorDefinition.h
@@ -8,31 +8,30 @@
 namespace pf2pat {
 
   class PFJetSelectorDefinition {
-
   public:
     typedef reco::PFJetCollection collection;
-    typedef edm::Handle< collection > HandleToCollection;
-    typedef std::vector<reco::PFJet>  container;
+    typedef edm::Handle<collection> HandleToCollection;
+    typedef std::vector<reco::PFJet> container;
 
     struct Pointer {
-      const reco::PFJet * operator()(const reco::PFJet &c) const { return &c; }
+      const reco::PFJet* operator()(const reco::PFJet& c) const { return &c; }
     };
-    
-    typedef boost::transform_iterator<Pointer,container::const_iterator> const_iterator;
-    
-    PFJetSelectorDefinition () {}
-    
+
+    typedef boost::transform_iterator<Pointer, container::const_iterator> const_iterator;
+
+    PFJetSelectorDefinition() {}
+
     const_iterator begin() const { return const_iterator(selected_.begin()); }
-    
+
     const_iterator end() const { return const_iterator(selected_.end()); }
-    
+
     size_t size() const { return selected_.size(); }
-    
-    const container& selected() const {return selected_;}
-    
+
+    const container& selected() const { return selected_; }
+
   protected:
     container selected_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFMETAlgo.h
+++ b/CommonTools/ParticleFlow/interface/PFMETAlgo.h
@@ -25,27 +25,23 @@
 \date   february 2008
 */
 
-
 namespace pf2pat {
-  
+
   class PFMETAlgo {
   public:
-
     explicit PFMETAlgo(const edm::ParameterSet&);
 
     ~PFMETAlgo();
-    
+
     reco::MET produce(const reco::PFCandidateCollection& pfCandidates);
 
   private:
-    
     /// HF calibration factor (in 31X applied by PFProducer)
     double hfCalibFactor_;
-    
-    /// verbose ?
-    bool   verbose_;
 
+    /// verbose ?
+    bool verbose_;
   };
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PFPileUpAlgo.h
+++ b/CommonTools/ParticleFlow/interface/PFPileUpAlgo.h
@@ -10,46 +10,40 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class PFPileUpAlgo {
- public:
+public:
+  typedef std::vector<edm::FwdPtr<reco::PFCandidate> > PFCollection;
 
+  PFPileUpAlgo() : checkClosestZVertex_(true), verbose_(false) { ; }
 
-  typedef std::vector< edm::FwdPtr<reco::PFCandidate> >  PFCollection;
+  PFPileUpAlgo(bool checkClosestZVertex, bool verbose = false)
+      : checkClosestZVertex_(checkClosestZVertex), verbose_(verbose) {
+    ;
+  }
 
-  PFPileUpAlgo():checkClosestZVertex_(true), verbose_(false) {;}
-    
-  PFPileUpAlgo( bool checkClosestZVertex, bool verbose=false):
-    checkClosestZVertex_(checkClosestZVertex), verbose_(verbose) {;}
-
-  ~PFPileUpAlgo(){;}
+  ~PFPileUpAlgo() { ; }
 
   // the last parameter is needed if you want to use the sourceCandidatePtr
-  void process(const PFCollection & pfCandidates, 
-	       const reco::VertexCollection & vertices)  ;
+  void process(const PFCollection& pfCandidates, const reco::VertexCollection& vertices);
 
   inline void setVerbose(bool verbose) { verbose_ = verbose; }
 
-  inline void setCheckClosestZVertex(bool val) { checkClosestZVertex_ = val;}
+  inline void setCheckClosestZVertex(bool val) { checkClosestZVertex_ = val; }
 
-  const PFCollection & getPFCandidatesFromPU() const {return pfCandidatesFromPU_;}
-  
-  const PFCollection & getPFCandidatesFromVtx() const {return pfCandidatesFromVtx_;}
+  const PFCollection& getPFCandidatesFromPU() const { return pfCandidatesFromPU_; }
 
-  int chargedHadronVertex(const reco::VertexCollection& vertices, 
-			const reco::PFCandidate& pfcand ) const;
+  const PFCollection& getPFCandidatesFromVtx() const { return pfCandidatesFromVtx_; }
 
+  int chargedHadronVertex(const reco::VertexCollection& vertices, const reco::PFCandidate& pfcand) const;
 
- private  :
-
+private:
   /// use the closest z vertex if a track is not in a vertex
-  bool   checkClosestZVertex_;
-  
-  
+  bool checkClosestZVertex_;
+
   /// verbose ?
-  bool   verbose_;
+  bool verbose_;
 
   PFCollection pfCandidatesFromVtx_;
   PFCollection pfCandidatesFromPU_;
-  
 };
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PdgIdPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PdgIdPFCandidateSelectorDefinition.h
@@ -12,35 +12,30 @@
 namespace pf2pat {
 
   class PdgIdPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
-
   public:
-    PdgIdPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      pdgIds_( cfg.getParameter< std::vector<int> >( "pdgId" ) ) { }
+    PdgIdPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : pdgIds_(cfg.getParameter<std::vector<int> >("pdgId")) {}
 
-    void select( const HandleToCollection & hc,
-		 const edm::EventBase & e,
-		 const edm::EventSetup& s) {
+    void select(const HandleToCollection& hc, const edm::EventBase& e, const edm::EventSetup& s) {
       selected_.clear();
 
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-
-	for(unsigned iId=0; iId<pdgIds_.size(); iId++) {
-	  if ( pfc->pdgId() == pdgIds_[iId] ) {
-	    selected_.push_back( reco::PFCandidate(*pfc) );
-	    reco::PFCandidatePtr ptrToMother( hc, key );
-	    selected_.back().setSourceCandidatePtr( ptrToMother );
-	    break;
-	  }
-	}
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
+        for (unsigned iId = 0; iId < pdgIds_.size(); iId++) {
+          if (pfc->pdgId() == pdgIds_[iId]) {
+            selected_.push_back(reco::PFCandidate(*pfc));
+            reco::PFCandidatePtr ptrToMother(hc, key);
+            selected_.back().setSourceCandidatePtr(ptrToMother);
+            break;
+          }
+        }
       }
     }
 
-    private:
+  private:
     std::vector<int> pdgIds_;
   };
 
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h
@@ -11,40 +11,31 @@
 namespace pf2pat {
 
   class PtMinPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
-
   public:
-    PtMinPFCandidateSelectorDefinition ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-      ptMin_( cfg.getParameter< double >( "ptMin" ) ) { }
+    PtMinPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : ptMin_(cfg.getParameter<double>("ptMin")) {}
 
-
-    void select( const HandleToCollection & hc,
-		 const edm::EventBase & e,
-		 const edm::EventSetup& s
-		 ) {
+    void select(const HandleToCollection& hc, const edm::EventBase& e, const edm::EventSetup& s) {
       selected_.clear();
 
-      assert( hc.isValid() );
+      assert(hc.isValid());
 
-
-      unsigned key=0;
-      for( collection::const_iterator pfc = hc->begin();
-	   pfc != hc->end(); ++pfc, ++key) {
-
- 	if( pfc->pt() > ptMin_ ) {
-	  selected_.push_back( reco::PFCandidate(*pfc) );
-	  reco::PFCandidatePtr ptrToMother( hc, key );
-	  selected_.back().setSourceCandidatePtr( ptrToMother );
-
-	}
+      unsigned key = 0;
+      for (collection::const_iterator pfc = hc->begin(); pfc != hc->end(); ++pfc, ++key) {
+        if (pfc->pt() > ptMin_) {
+          selected_.push_back(reco::PFCandidate(*pfc));
+          reco::PFCandidatePtr ptrToMother(hc, key);
+          selected_.back().setSourceCandidatePtr(ptrToMother);
+        }
       }
     }
 
-/*     const container& selected() const {return selected_;} */
+    /*     const container& selected() const {return selected_;} */
 
-    private:
-      double ptMin_;
+  private:
+    double ptMin_;
   };
 
-}
+}  // namespace pf2pat
 
 #endif

--- a/CommonTools/ParticleFlow/plugins/DeltaBetaWeights.cc
+++ b/CommonTools/ParticleFlow/plugins/DeltaBetaWeights.cc
@@ -1,10 +1,9 @@
 #include "CommonTools/ParticleFlow/plugins/DeltaBetaWeights.h"
 
-DeltaBetaWeights::DeltaBetaWeights(const edm::ParameterSet& iConfig):
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  pfCharged_(iConfig.getParameter<edm::InputTag>("chargedFromPV")),
-  pfPU_(iConfig.getParameter<edm::InputTag>("chargedFromPU"))
-{
+DeltaBetaWeights::DeltaBetaWeights(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      pfCharged_(iConfig.getParameter<edm::InputTag>("chargedFromPV")),
+      pfPU_(iConfig.getParameter<edm::InputTag>("chargedFromPU")) {
   produces<reco::PFCandidateCollection>();
 
   pfCharged_token = consumes<edm::View<reco::Candidate> >(pfCharged_);
@@ -14,77 +13,68 @@ DeltaBetaWeights::DeltaBetaWeights(const edm::ParameterSet& iConfig):
   // pfCharged_token = consumes<reco::PFCandidateCollection>(pfCharged_);
   // pfPU_token = consumes<reco::PFCandidateCollection>(pfPU_);
   // src_token = consumes<reco::PFCandidateCollection>(src_);
-
 }
 
-
-DeltaBetaWeights::~DeltaBetaWeights()
-{
- 
+DeltaBetaWeights::~DeltaBetaWeights() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-DeltaBetaWeights::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void DeltaBetaWeights::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   edm::Handle<edm::View<reco::Candidate> > pfCharged;
   edm::Handle<edm::View<reco::Candidate> > pfPU;
   edm::Handle<edm::View<reco::Candidate> > src;
-  
 
-  iEvent.getByToken(src_token,src);
-  iEvent.getByToken(pfCharged_token,pfCharged);
-  iEvent.getByToken(pfPU_token,pfPU);
+  iEvent.getByToken(src_token, src);
+  iEvent.getByToken(pfCharged_token, pfCharged);
+  iEvent.getByToken(pfPU_token, pfPU);
 
   double sumNPU = .0;
-  double sumPU =  .0;
+  double sumPU = .0;
 
   std::unique_ptr<reco::PFCandidateCollection> out(new reco::PFCandidateCollection);
 
-
-  for (const reco::Candidate & cand : *src) {
-    if (cand.charge() !=0) {
+  for (const reco::Candidate& cand : *src) {
+    if (cand.charge() != 0) {
       // this part of code should be executed only if input collection is not entirely composed of neutral candidates, i.e. never by default
-      edm::LogWarning("DeltaBetaWeights") << "Trying to reweight charged particle... saving it to output collection without any change";
-      out->emplace_back(cand.charge(),cand.p4(),reco::PFCandidate::ParticleType::X);
+      edm::LogWarning("DeltaBetaWeights")
+          << "Trying to reweight charged particle... saving it to output collection without any change";
+      out->emplace_back(cand.charge(), cand.p4(), reco::PFCandidate::ParticleType::X);
       (out->back()).setParticleType((out->back()).translatePdgIdToType(cand.pdgId()));
       continue;
     }
 
-    sumNPU=1.0;
-    sumPU=1.0;
-    double eta=cand.eta();
-    double phi=cand.phi();
-    for (const reco::Candidate &chCand : *pfCharged ) {
-      double sum = (chCand.pt()*chCand.pt())/(deltaR2(eta,phi,chCand.eta(),chCand.phi()));
-      if(sum > 1.0) sumNPU *= sum;
+    sumNPU = 1.0;
+    sumPU = 1.0;
+    double eta = cand.eta();
+    double phi = cand.phi();
+    for (const reco::Candidate& chCand : *pfCharged) {
+      double sum = (chCand.pt() * chCand.pt()) / (deltaR2(eta, phi, chCand.eta(), chCand.phi()));
+      if (sum > 1.0)
+        sumNPU *= sum;
     }
-    sumNPU=0.5*log(sumNPU);
+    sumNPU = 0.5 * log(sumNPU);
 
-    for (const reco::Candidate &puCand : *pfPU ) {
-      double sum = (puCand.pt()*puCand.pt())/(deltaR2(eta,phi,puCand.eta(),puCand.phi()));
-      if(sum > 1.0) sumPU *= sum;
+    for (const reco::Candidate& puCand : *pfPU) {
+      double sum = (puCand.pt() * puCand.pt()) / (deltaR2(eta, phi, puCand.eta(), puCand.phi()));
+      if (sum > 1.0)
+        sumPU *= sum;
     }
-    sumPU=0.5*log(sumPU);
+    sumPU = 0.5 * log(sumPU);
 
-    reco::PFCandidate neutral = reco::PFCandidate(cand.charge(),cand.p4(),reco::PFCandidate::ParticleType::X);
+    reco::PFCandidate neutral = reco::PFCandidate(cand.charge(), cand.p4(), reco::PFCandidate::ParticleType::X);
     neutral.setParticleType(neutral.translatePdgIdToType(cand.pdgId()));
-    if (sumNPU+sumPU>0)
-      neutral.setP4(((sumNPU)/(sumNPU+sumPU))*neutral.p4());
+    if (sumNPU + sumPU > 0)
+      neutral.setP4(((sumNPU) / (sumNPU + sumPU)) * neutral.p4());
     out->push_back(neutral);
-
   }
 
   iEvent.put(std::move(out));
- 
 }

--- a/CommonTools/ParticleFlow/plugins/DeltaBetaWeights.h
+++ b/CommonTools/ParticleFlow/plugins/DeltaBetaWeights.h
@@ -1,12 +1,11 @@
 
 // Weight for neutral particles based on distance with charged
-// 
+//
 // Original Author:  Michail Bachtis,40 1-B08,+41227678176,
 //         Created:  Mon Dec  9 13:18:05 CET 2013
 //
 // edited by Pavel Jez
 //
-
 
 // system include files
 #include <memory>
@@ -25,22 +24,18 @@
 //
 
 class DeltaBetaWeights : public edm::EDProducer {
- public:
+public:
   explicit DeltaBetaWeights(const edm::ParameterSet&);
   ~DeltaBetaWeights() override;
 
- private:
-
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
   // ----------member data ---------------------------
   edm::InputTag src_;
   edm::InputTag pfCharged_;
   edm::InputTag pfPU_;
-  
+
   edm::EDGetTokenT<edm::View<reco::Candidate> > pfCharged_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > pfPU_token;
   edm::EDGetTokenT<edm::View<reco::Candidate> > src_token;
-
-
-
 };

--- a/CommonTools/ParticleFlow/plugins/GenericPFJetSelector.cc
+++ b/CommonTools/ParticleFlow/plugins/GenericPFJetSelector.cc
@@ -6,6 +6,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h"
 
-typedef ObjectSelector< pf2pat::GenericPFJetSelectorDefinition ,  reco::PFJetCollection > GenericPFJetSelector;
+typedef ObjectSelector<pf2pat::GenericPFJetSelectorDefinition, reco::PFJetCollection> GenericPFJetSelector;
 
 DEFINE_FWK_MODULE(GenericPFJetSelector);

--- a/CommonTools/ParticleFlow/plugins/IsolatedPFCandidateSelector.cc
+++ b/CommonTools/ParticleFlow/plugins/IsolatedPFCandidateSelector.cc
@@ -1,7 +1,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 

--- a/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.cc
@@ -30,64 +30,70 @@ using namespace reco;
 using namespace reco::isodeposit;
 
 bool PFCandIsolatorFromDeposits::SingleDeposit::isNumber(const std::string &str) const {
-   static const std::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
-   return regex_match(str.c_str(), re);
+  static const std::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
+  return regex_match(str.c_str(), re);
 }
-double PFCandIsolatorFromDeposits::SingleDeposit::toNumber(const std::string &str) const {
-    return atof(str.c_str());
-}
+double PFCandIsolatorFromDeposits::SingleDeposit::toNumber(const std::string &str) const { return atof(str.c_str()); }
 
-PFCandIsolatorFromDeposits::SingleDeposit::SingleDeposit(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) :
-  srcToken_(iC.consumes<reco::IsoDepositMap>(iConfig.getParameter<edm::InputTag>("src"))),
-  deltaR_(iConfig.getParameter<double>("deltaR")),
-  weightExpr_(iConfig.getParameter<std::string>("weight")),
-  skipDefaultVeto_(iConfig.getParameter<bool>("skipDefaultVeto")),
-  usePivotForBarrelEndcaps_(iConfig.getParameter<bool>("PivotCoordinatesForEBEE"))
-						      //,vetos_(new AbsVetos())
+PFCandIsolatorFromDeposits::SingleDeposit::SingleDeposit(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC)
+    : srcToken_(iC.consumes<reco::IsoDepositMap>(iConfig.getParameter<edm::InputTag>("src"))),
+      deltaR_(iConfig.getParameter<double>("deltaR")),
+      weightExpr_(iConfig.getParameter<std::string>("weight")),
+      skipDefaultVeto_(iConfig.getParameter<bool>("skipDefaultVeto")),
+      usePivotForBarrelEndcaps_(iConfig.getParameter<bool>("PivotCoordinatesForEBEE"))
+//,vetos_(new AbsVetos())
 {
   std::string mode = iConfig.getParameter<std::string>("mode");
-  if (mode == "sum") mode_ = Sum;
-  else if (mode == "sumRelative") mode_ = SumRelative;
-  else if (mode == "sum2") mode_ = Sum2;
-  else if (mode == "sum2Relative") mode_ = Sum2Relative;
-  else if (mode == "max") mode_ = Max;
-  else if (mode == "maxRelative") mode_ = MaxRelative;
-  else if (mode == "nearestDR") mode_ = NearestDR;
-  else if (mode == "count") mode_ = Count;
-  else throw cms::Exception("Not Implemented") << "Mode '" << mode << "' not implemented. " <<
-    "Supported modes are 'sum', 'sumRelative', 'count'." <<
-    //"Supported modes are 'sum', 'sumRelative', 'max', 'maxRelative', 'count'." << // TODO: on request only
-    "New methods can be easily implemented if requested.";
+  if (mode == "sum")
+    mode_ = Sum;
+  else if (mode == "sumRelative")
+    mode_ = SumRelative;
+  else if (mode == "sum2")
+    mode_ = Sum2;
+  else if (mode == "sum2Relative")
+    mode_ = Sum2Relative;
+  else if (mode == "max")
+    mode_ = Max;
+  else if (mode == "maxRelative")
+    mode_ = MaxRelative;
+  else if (mode == "nearestDR")
+    mode_ = NearestDR;
+  else if (mode == "count")
+    mode_ = Count;
+  else
+    throw cms::Exception("Not Implemented") << "Mode '" << mode << "' not implemented. "
+                                            << "Supported modes are 'sum', 'sumRelative', 'count'." <<
+        //"Supported modes are 'sum', 'sumRelative', 'max', 'maxRelative', 'count'." << // TODO: on request only
+        "New methods can be easily implemented if requested.";
   typedef std::vector<std::string> vstring;
-  vstring vetos = iConfig.getParameter< vstring >("vetos");
-  reco::isodeposit::EventDependentAbsVeto *evdep=nullptr;
+  vstring vetos = iConfig.getParameter<vstring>("vetos");
+  reco::isodeposit::EventDependentAbsVeto *evdep = nullptr;
   static const std::regex ecalSwitch("^Ecal(Barrel|Endcaps):(.*)");
 
   for (vstring::const_iterator it = vetos.begin(), ed = vetos.end(); it != ed; ++it) {
     std::cmatch match;
     // in that case, make two series of vetoes
-    if( usePivotForBarrelEndcaps_) {
-      if (regex_match(it->c_str(), match, ecalSwitch))
-	{
-	  if(match[1] == "Barrel") {
-	    //	    std::cout << " Adding Barrel veto " << std::string(match[2]) << std::endl;
-	    barrelVetos_.push_back(IsoDepositVetoFactory::make(std::string(match[2]).c_str(), evdep, iC)); // I don't know a better syntax
-	  }
-	  if(match[1] == "Endcaps") {
-	    //	    std::cout << " Adding Endcap veto " << std::string(match[2]) << std::endl;
-	    endcapVetos_.push_back(IsoDepositVetoFactory::make(std::string(match[2]).c_str(), evdep, iC));
-	  }
-	}
-      else
-	{
-	  barrelVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
-	  endcapVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
-	}
+    if (usePivotForBarrelEndcaps_) {
+      if (regex_match(it->c_str(), match, ecalSwitch)) {
+        if (match[1] == "Barrel") {
+          //	    std::cout << " Adding Barrel veto " << std::string(match[2]) << std::endl;
+          barrelVetos_.push_back(
+              IsoDepositVetoFactory::make(std::string(match[2]).c_str(), evdep, iC));  // I don't know a better syntax
+        }
+        if (match[1] == "Endcaps") {
+          //	    std::cout << " Adding Endcap veto " << std::string(match[2]) << std::endl;
+          endcapVetos_.push_back(IsoDepositVetoFactory::make(std::string(match[2]).c_str(), evdep, iC));
+        }
+      } else {
+        barrelVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+        endcapVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+      }
     } else {
       //only one serie of vetoes, just barrel
       barrelVetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
     }
-    if (evdep) evdepVetos_.push_back(evdep);
+    if (evdep)
+      evdepVetos_.push_back(evdep);
   }
 
   std::string weight = iConfig.getParameter<std::string>("weight");
@@ -102,91 +108,101 @@ PFCandIsolatorFromDeposits::SingleDeposit::SingleDeposit(const edm::ParameterSet
   //std::cout << "PFCandIsolatorFromDeposits::SingleDeposit::SingleDeposit: Total of " << vetos_.size() << " vetos" << std::endl;
 }
 void PFCandIsolatorFromDeposits::SingleDeposit::cleanup() {
-    for (AbsVetos::iterator it = barrelVetos_.begin(), ed = barrelVetos_.end(); it != ed; ++it) {
-        delete *it;
-    }
-    for (AbsVetos::iterator it = endcapVetos_.begin(), ed = endcapVetos_.end(); it != ed; ++it) {
-        delete *it;
-    }
-    barrelVetos_.clear();
-    endcapVetos_.clear();
-    // NOTE: we DON'T have to delete the evdepVetos_, they have already been deleted above. We just clear the vectors
-    evdepVetos_.clear();
+  for (AbsVetos::iterator it = barrelVetos_.begin(), ed = barrelVetos_.end(); it != ed; ++it) {
+    delete *it;
+  }
+  for (AbsVetos::iterator it = endcapVetos_.begin(), ed = endcapVetos_.end(); it != ed; ++it) {
+    delete *it;
+  }
+  barrelVetos_.clear();
+  endcapVetos_.clear();
+  // NOTE: we DON'T have to delete the evdepVetos_, they have already been deleted above. We just clear the vectors
+  evdepVetos_.clear();
 }
 void PFCandIsolatorFromDeposits::SingleDeposit::open(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-    iEvent.getByToken(srcToken_, hDeps_);
-    for (EventDependentAbsVetos::iterator it = evdepVetos_.begin(), ed = evdepVetos_.end(); it != ed; ++it) {
-        (*it)->setEvent(iEvent,iSetup);
-    }
+  iEvent.getByToken(srcToken_, hDeps_);
+  for (EventDependentAbsVetos::iterator it = evdepVetos_.begin(), ed = evdepVetos_.end(); it != ed; ++it) {
+    (*it)->setEvent(iEvent, iSetup);
+  }
 }
 
 double PFCandIsolatorFromDeposits::SingleDeposit::compute(const reco::CandidateBaseRef &cand) {
-    const IsoDeposit &dep = (*hDeps_)[cand];
-    double eta = dep.eta(), phi = dep.phi(); // better to center on the deposit direction
-                                             // that could be, e.g., the impact point at calo
-    bool barrel=true;
-    if( usePivotForBarrelEndcaps_) {
-      const reco::PFCandidate * myPFCand = dynamic_cast<const reco::PFCandidate*>(&(*cand));
-      if(myPFCand)  {
-	// exact barrel boundary
-	barrel = fabs(myPFCand->positionAtECALEntrance().eta())<1.479;
-      }
-      else {
-	const reco::RecoCandidate * myRecoCand = dynamic_cast<const reco::RecoCandidate*>(&(*cand));
-	if(myRecoCand) {
-	  // not optimal. isEB should be used.
-	  barrel = ( fabs(myRecoCand->superCluster()->eta())<1.479 );
-	}
+  const IsoDeposit &dep = (*hDeps_)[cand];
+  double eta = dep.eta(), phi = dep.phi();  // better to center on the deposit direction
+                                            // that could be, e.g., the impact point at calo
+  bool barrel = true;
+  if (usePivotForBarrelEndcaps_) {
+    const reco::PFCandidate *myPFCand = dynamic_cast<const reco::PFCandidate *>(&(*cand));
+    if (myPFCand) {
+      // exact barrel boundary
+      barrel = fabs(myPFCand->positionAtECALEntrance().eta()) < 1.479;
+    } else {
+      const reco::RecoCandidate *myRecoCand = dynamic_cast<const reco::RecoCandidate *>(&(*cand));
+      if (myRecoCand) {
+        // not optimal. isEB should be used.
+        barrel = (fabs(myRecoCand->superCluster()->eta()) < 1.479);
       }
     }
-    // if ! usePivotForBarrelEndcaps_ only the barrel series is used, which does not prevent the vetoes do be different in barrel & endcaps
-    reco::isodeposit::AbsVetos * vetos = (barrel) ? &barrelVetos_ : &endcapVetos_;
+  }
+  // if ! usePivotForBarrelEndcaps_ only the barrel series is used, which does not prevent the vetoes do be different in barrel & endcaps
+  reco::isodeposit::AbsVetos *vetos = (barrel) ? &barrelVetos_ : &endcapVetos_;
 
-    for (AbsVetos::iterator it = vetos->begin(), ed = vetos->end(); it != ed; ++it) {
-        (*it)->centerOn(eta, phi);
-    }
-    double weight = (usesFunction_ ? weightExpr_(*cand) : weight_);
-    switch (mode_) {
-        case Count:        return weight * dep.countWithin(deltaR_, *vetos, skipDefaultVeto_);
-        case Sum:          return weight * dep.sumWithin(deltaR_, *vetos, skipDefaultVeto_);
-        case SumRelative:  return weight * dep.sumWithin(deltaR_, *vetos, skipDefaultVeto_) / dep.candEnergy() ;
-        case Sum2:         return weight * dep.sum2Within(deltaR_, *vetos, skipDefaultVeto_);
-        case Sum2Relative: return weight * dep.sum2Within(deltaR_, *vetos, skipDefaultVeto_) / (dep.candEnergy() * dep.candEnergy()) ;
-        case Max:          return weight * dep.maxWithin(deltaR_, *vetos, skipDefaultVeto_);
-        case NearestDR:    return weight * dep.nearestDR(deltaR_, *vetos, skipDefaultVeto_);
-        case MaxRelative:  return weight * dep.maxWithin(deltaR_, *vetos, skipDefaultVeto_) / dep.candEnergy() ;
-    }
-    throw cms::Exception("Logic error") << "Should not happen at " << __FILE__ << ", line " << __LINE__; // avoid gcc warning
+  for (AbsVetos::iterator it = vetos->begin(), ed = vetos->end(); it != ed; ++it) {
+    (*it)->centerOn(eta, phi);
+  }
+  double weight = (usesFunction_ ? weightExpr_(*cand) : weight_);
+  switch (mode_) {
+    case Count:
+      return weight * dep.countWithin(deltaR_, *vetos, skipDefaultVeto_);
+    case Sum:
+      return weight * dep.sumWithin(deltaR_, *vetos, skipDefaultVeto_);
+    case SumRelative:
+      return weight * dep.sumWithin(deltaR_, *vetos, skipDefaultVeto_) / dep.candEnergy();
+    case Sum2:
+      return weight * dep.sum2Within(deltaR_, *vetos, skipDefaultVeto_);
+    case Sum2Relative:
+      return weight * dep.sum2Within(deltaR_, *vetos, skipDefaultVeto_) / (dep.candEnergy() * dep.candEnergy());
+    case Max:
+      return weight * dep.maxWithin(deltaR_, *vetos, skipDefaultVeto_);
+    case NearestDR:
+      return weight * dep.nearestDR(deltaR_, *vetos, skipDefaultVeto_);
+    case MaxRelative:
+      return weight * dep.maxWithin(deltaR_, *vetos, skipDefaultVeto_) / dep.candEnergy();
+  }
+  throw cms::Exception("Logic error") << "Should not happen at " << __FILE__ << ", line "
+                                      << __LINE__;  // avoid gcc warning
 }
 
 /// constructor with config
-PFCandIsolatorFromDeposits::PFCandIsolatorFromDeposits(const ParameterSet& par) {
+PFCandIsolatorFromDeposits::PFCandIsolatorFromDeposits(const ParameterSet &par) {
   typedef std::vector<edm::ParameterSet> VPSet;
   VPSet depPSets = par.getParameter<VPSet>("deposits");
   for (VPSet::const_iterator it = depPSets.begin(), ed = depPSets.end(); it != ed; ++it) {
     sources_.push_back(SingleDeposit(*it, consumesCollector()));
   }
-  if (sources_.empty()) throw cms::Exception("Configuration Error") << "Please specify at least one deposit!";
+  if (sources_.empty())
+    throw cms::Exception("Configuration Error") << "Please specify at least one deposit!";
   produces<CandDoubleMap>();
 }
 
 /// destructor
 PFCandIsolatorFromDeposits::~PFCandIsolatorFromDeposits() {
   std::vector<SingleDeposit>::iterator it, begin = sources_.begin(), end = sources_.end();
-  for (it = begin; it != end; ++it) it->cleanup();
+  for (it = begin; it != end; ++it)
+    it->cleanup();
 }
 
 /// build deposits
-void PFCandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSetup){
-
+void PFCandIsolatorFromDeposits::produce(Event &event, const EventSetup &eventSetup) {
   std::vector<SingleDeposit>::iterator it, begin = sources_.begin(), end = sources_.end();
-  for (it = begin; it != end; ++it) it->open(event, eventSetup);
+  for (it = begin; it != end; ++it)
+    it->open(event, eventSetup);
 
-  const IsoDepositMap & map = begin->map();
+  const IsoDepositMap &map = begin->map();
 
-  if (map.empty()) { // !!???
-        event.put(std::unique_ptr<CandDoubleMap>(new CandDoubleMap()));
-        return;
+  if (map.empty()) {  // !!???
+    event.put(std::unique_ptr<CandDoubleMap>(new CandDoubleMap()));
+    return;
   }
   std::unique_ptr<CandDoubleMap> ret(new CandDoubleMap());
   CandDoubleMap::Filler filler(*ret);
@@ -195,18 +211,19 @@ void PFCandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSe
   typedef reco::IsoDepositMap::container::const_iterator iterator_ii;
   iterator_i depI = map.begin();
   iterator_i depIEnd = map.end();
-  for (; depI != depIEnd; ++depI){
-    std::vector<double> retV(depI.size(),0);
+  for (; depI != depIEnd; ++depI) {
+    std::vector<double> retV(depI.size(), 0);
     edm::Handle<edm::View<reco::Candidate> > candH;
     event.get(depI.id(), candH);
-    const edm::View<reco::Candidate>& candV = *candH;
+    const edm::View<reco::Candidate> &candV = *candH;
 
     iterator_ii depII = depI.begin();
     iterator_ii depIIEnd = depI.end();
     size_t iRet = 0;
-    for (; depII != depIIEnd; ++depII,++iRet){
-      double sum=0;
-      for (it = begin; it != end; ++it) sum += it->compute(candV.refAt(iRet));
+    for (; depII != depIIEnd; ++depII, ++iRet) {
+      double sum = 0;
+      for (it = begin; it != end; ++it)
+        sum += it->compute(candV.refAt(iRet));
       retV[iRet] = sum;
     }
     filler.insert(candH, retV.begin(), retV.end());
@@ -215,4 +232,4 @@ void PFCandIsolatorFromDeposits::produce(Event& event, const EventSetup& eventSe
   event.put(std::move(ret));
 }
 
-DEFINE_FWK_MODULE( PFCandIsolatorFromDeposits );
+DEFINE_FWK_MODULE(PFCandIsolatorFromDeposits);

--- a/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.h
+++ b/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.h
@@ -17,51 +17,52 @@
 
 #include <string>
 
-namespace edm { class Event; }
-namespace edm { class EventSetup; }
+namespace edm {
+  class Event;
+}
+namespace edm {
+  class EventSetup;
+}
 
 class PFCandIsolatorFromDeposits : public edm::stream::EDProducer<> {
-
 public:
   typedef edm::ValueMap<double> CandDoubleMap;
 
   enum Mode { Sum, SumRelative, Sum2, Sum2Relative, Max, MaxRelative, Count, NearestDR };
-  PFCandIsolatorFromDeposits(const edm::ParameterSet&);
+  PFCandIsolatorFromDeposits(const edm::ParameterSet &);
 
   ~PFCandIsolatorFromDeposits() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
   class SingleDeposit {
-    public:
-        SingleDeposit(const edm::ParameterSet &, edm::ConsumesCollector && iC) ;
-        void cleanup() ;
-        void open(const edm::Event &iEvent, const edm::EventSetup &iSetup) ;
-        double compute(const reco::CandidateBaseRef &cand) ;
-        const reco::IsoDepositMap & map() { return *hDeps_; }
-    private:
-        Mode mode_;
-        edm::EDGetTokenT<reco::IsoDepositMap> srcToken_;
-        double deltaR_;
-        bool   usesFunction_;
-        double weight_;
+  public:
+    SingleDeposit(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
+    void cleanup();
+    void open(const edm::Event &iEvent, const edm::EventSetup &iSetup);
+    double compute(const reco::CandidateBaseRef &cand);
+    const reco::IsoDepositMap &map() { return *hDeps_; }
 
-        StringObjectFunction<reco::Candidate> weightExpr_;
-        reco::isodeposit::AbsVetos barrelVetos_;
-        reco::isodeposit::AbsVetos endcapVetos_;
-        reco::isodeposit::EventDependentAbsVetos evdepVetos_; // note: these are a subset of the above. Don't delete twice!
-        bool   skipDefaultVeto_;
-	bool usePivotForBarrelEndcaps_;
-        edm::Handle<reco::IsoDepositMap> hDeps_; // transient
+  private:
+    Mode mode_;
+    edm::EDGetTokenT<reco::IsoDepositMap> srcToken_;
+    double deltaR_;
+    bool usesFunction_;
+    double weight_;
 
-	bool isNumber(const std::string &str) const ;
-	double toNumber(const std::string &str) const ;
+    StringObjectFunction<reco::Candidate> weightExpr_;
+    reco::isodeposit::AbsVetos barrelVetos_;
+    reco::isodeposit::AbsVetos endcapVetos_;
+    reco::isodeposit::EventDependentAbsVetos evdepVetos_;  // note: these are a subset of the above. Don't delete twice!
+    bool skipDefaultVeto_;
+    bool usePivotForBarrelEndcaps_;
+    edm::Handle<reco::IsoDepositMap> hDeps_;  // transient
+
+    bool isNumber(const std::string &str) const;
+    double toNumber(const std::string &str) const;
   };
   // datamembers
   std::vector<SingleDeposit> sources_;
-
-
-
 };
 #endif

--- a/CommonTools/ParticleFlow/plugins/PFCandWithSuperClusterExtractor.h
+++ b/CommonTools/ParticleFlow/plugins/PFCandWithSuperClusterExtractor.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
@@ -18,65 +17,64 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h"
 
-
 class PFCandWithSuperClusterExtractor : public reco::isodeposit::IsoDepositExtractor {
-
 public:
-
   PFCandWithSuperClusterExtractor(){};
-  PFCandWithSuperClusterExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC);
+  PFCandWithSuperClusterExtractor(const edm::ParameterSet &par, edm::ConsumesCollector &&iC);
 
-  ~PFCandWithSuperClusterExtractor() override{}
+  ~PFCandWithSuperClusterExtractor() override {}
 
-  void fillVetos (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::TrackCollection & cand) override { }
+  void fillVetos(const edm::Event &ev, const edm::EventSetup &evSetup, const reco::TrackCollection &cand) override {}
 
-
-  reco::IsoDeposit deposit (const edm::Event & ev,
-				    const edm::EventSetup & evSetup, const reco::Track & muon) const override {
+  reco::IsoDeposit deposit(const edm::Event &ev,
+                           const edm::EventSetup &evSetup,
+                           const reco::Track &muon) const override {
     return depositFromObject(ev, evSetup, muon);
   }
 
-  reco::IsoDeposit deposit (const edm::Event & ev,
-				    const edm::EventSetup & evSetup, const reco::Candidate & cand) const override {
+  reco::IsoDeposit deposit(const edm::Event &ev,
+                           const edm::EventSetup &evSetup,
+                           const reco::Candidate &cand) const override {
+    const reco::Photon *myPhoton = dynamic_cast<const reco::Photon *>(&cand);
+    if (myPhoton)
+      return depositFromObject(ev, evSetup, *myPhoton);
 
-    const reco::Photon * myPhoton= dynamic_cast<const reco::Photon*>(&cand);
-    if(myPhoton)
-      return depositFromObject(ev, evSetup,*myPhoton);
+    const reco::GsfElectron *myElectron = dynamic_cast<const reco::GsfElectron *>(&cand);
+    if (myElectron)
+      return depositFromObject(ev, evSetup, *myElectron);
 
-    const reco::GsfElectron * myElectron = dynamic_cast<const reco::GsfElectron*>(&cand);
-    if(myElectron)
-      return depositFromObject(ev,evSetup,*myElectron);
-
-    const reco::PFCandidate * myPFCand = dynamic_cast<const reco::PFCandidate*>(&cand);
-    return depositFromObject(ev, evSetup,*myPFCand);
+    const reco::PFCandidate *myPFCand = dynamic_cast<const reco::PFCandidate *>(&cand);
+    return depositFromObject(ev, evSetup, *myPFCand);
   }
 
 private:
-  reco::IsoDeposit::Veto veto( const reco::IsoDeposit::Direction & dir) const;
+  reco::IsoDeposit::Veto veto(const reco::IsoDeposit::Direction &dir) const;
 
-  reco::IsoDeposit depositFromObject( const edm::Event & ev,
-				      const edm::EventSetup & evSetup, const reco::Photon &cand) const ;
+  reco::IsoDeposit depositFromObject(const edm::Event &ev,
+                                     const edm::EventSetup &evSetup,
+                                     const reco::Photon &cand) const;
 
-  reco::IsoDeposit depositFromObject( const edm::Event & ev,
-				      const edm::EventSetup & evSetup, const reco::GsfElectron &cand) const ;
+  reco::IsoDeposit depositFromObject(const edm::Event &ev,
+                                     const edm::EventSetup &evSetup,
+                                     const reco::GsfElectron &cand) const;
 
-  reco::IsoDeposit depositFromObject( const edm::Event & ev,
-				      const edm::EventSetup & evSetup, const reco::Track &cand) const ;
+  reco::IsoDeposit depositFromObject(const edm::Event &ev,
+                                     const edm::EventSetup &evSetup,
+                                     const reco::Track &cand) const;
 
-  reco::IsoDeposit depositFromObject( const edm::Event & ev,
-				      const edm::EventSetup & evSetup, const reco::PFCandidate &cand) const ;
+  reco::IsoDeposit depositFromObject(const edm::Event &ev,
+                                     const edm::EventSetup &evSetup,
+                                     const reco::PFCandidate &cand) const;
 
   // Parameter set
-  edm::EDGetTokenT<reco::PFCandidateCollection> thePFCandToken; // Track Collection Label
-  std::string theDepositLabel;         // name for deposit
-  bool theVetoSuperClusterMatch;         //SuperClusterRef Check
-  bool theMissHitVetoSuperClusterMatch;   // veto PF photons sharing SC with supercluster if misshits >0
-  double theDiff_r;                    // transverse distance to vertex
-  double theDiff_z;                    // z distance to vertex
-  double theDR_Max;                    // Maximum cone angle for deposits
-  double theDR_Veto;                   // Veto cone angle
+  edm::EDGetTokenT<reco::PFCandidateCollection> thePFCandToken;  // Track Collection Label
+  std::string theDepositLabel;                                   // name for deposit
+  bool theVetoSuperClusterMatch;                                 //SuperClusterRef Check
+  bool theMissHitVetoSuperClusterMatch;  // veto PF photons sharing SC with supercluster if misshits >0
+  double theDiff_r;                      // transverse distance to vertex
+  double theDiff_z;                      // z distance to vertex
+  double theDR_Max;                      // Maximum cone angle for deposits
+  double theDR_Veto;                     // Veto cone angle
 };
-
 
 #endif

--- a/CommonTools/ParticleFlow/plugins/PFCandidateFromFwdPtrProducer.h
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateFromFwdPtrProducer.h
@@ -3,6 +3,5 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateWithSrcPtrFactory.h"
 
-typedef edm::ProductFromFwdPtrProducer< reco::PFCandidate, 
-                                        reco::PFCandidateWithSrcPtrFactory >  PFCandidateFromFwdPtrProducer;
-
+typedef edm::ProductFromFwdPtrProducer<reco::PFCandidate, reco::PFCandidateWithSrcPtrFactory>
+    PFCandidateFromFwdPtrProducer;

--- a/CommonTools/ParticleFlow/plugins/PFCandidateFwdPtrCollectionFilter.h
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateFwdPtrCollectionFilter.h
@@ -5,9 +5,9 @@
 #include "CommonTools/UtilAlgos/interface/PdgIdSelector.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateWithSrcPtrFactory.h"
 
-typedef edm::FwdPtrCollectionFilter< reco::PFCandidate, 
-                                     reco::StringCutObjectSelectorHandler<reco::PFCandidate,false>, 
-                                     reco::PFCandidateWithSrcPtrFactory >  PFCandidateFwdPtrCollectionStringFilter;
-typedef edm::FwdPtrCollectionFilter< reco::PFCandidate, reco::PdgIdSelectorHandler, 
-                                     reco::PFCandidateWithSrcPtrFactory >  PFCandidateFwdPtrCollectionPdgIdFilter;
-
+typedef edm::FwdPtrCollectionFilter<reco::PFCandidate,
+                                    reco::StringCutObjectSelectorHandler<reco::PFCandidate, false>,
+                                    reco::PFCandidateWithSrcPtrFactory>
+    PFCandidateFwdPtrCollectionStringFilter;
+typedef edm::FwdPtrCollectionFilter<reco::PFCandidate, reco::PdgIdSelectorHandler, reco::PFCandidateWithSrcPtrFactory>
+    PFCandidateFwdPtrCollectionPdgIdFilter;

--- a/CommonTools/ParticleFlow/plugins/PFCandidateMuonUntagger.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateMuonUntagger.cc
@@ -1,6 +1,6 @@
 /// Take:
 //    - a PF candidate collection (which uses the old muons)
-//    - a map from the old muons to the new muons (in which some muons have been un-tagged and so are no longer PF muons) 
+//    - a map from the old muons to the new muons (in which some muons have been un-tagged and so are no longer PF muons)
 //      format: edm::Association<std::vector<reco::Muon>>
 //  Produce:
 //    - a new PFCandidate collection using the new muons, and in which the muons that have been un-tagged are removed
@@ -22,106 +22,105 @@
 #include <iostream>
 
 class PFCandidateMuonUntagger : public edm::global::EDProducer<> {
-    public:
-        PFCandidateMuonUntagger(const edm::ParameterSet&);
-        ~PFCandidateMuonUntagger() override {};
+public:
+  PFCandidateMuonUntagger(const edm::ParameterSet &);
+  ~PFCandidateMuonUntagger() override{};
 
-        void produce(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID iID, edm::Event &, const edm::EventSetup &) const override;
 
-    private:
-        edm::EDGetTokenT<std::vector<reco::PFCandidate> > pfcandidates_;
-        edm::EDGetTokenT<edm::Association<std::vector<reco::Muon>>> oldToNewMuons_;
+private:
+  edm::EDGetTokenT<std::vector<reco::PFCandidate>> pfcandidates_;
+  edm::EDGetTokenT<edm::Association<std::vector<reco::Muon>>> oldToNewMuons_;
 
-        template<typename H1>
-        void writeValueMap(edm::Event &out, const H1 &from, const std::vector<int> values, const std::string &name) {
-            typedef edm::ValueMap<int> IntMap;
-            std::unique_ptr<IntMap> intmap(new IntMap());
-            typename IntMap::Filler filler(*intmap);
-            filler.insert(from, values.begin(), values.end());
-            filler.fill();
-            out.put(std::move(intmap), name);
-        }
-
+  template <typename H1>
+  void writeValueMap(edm::Event &out, const H1 &from, const std::vector<int> values, const std::string &name) {
+    typedef edm::ValueMap<int> IntMap;
+    std::unique_ptr<IntMap> intmap(new IntMap());
+    typename IntMap::Filler filler(*intmap);
+    filler.insert(from, values.begin(), values.end());
+    filler.fill();
+    out.put(std::move(intmap), name);
+  }
 };
 
-PFCandidateMuonUntagger::PFCandidateMuonUntagger(const edm::ParameterSet &iConfig) :
-    pfcandidates_(consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfcandidates"))),
-    oldToNewMuons_(consumes<edm::Association<std::vector<reco::Muon>>>(iConfig.getParameter<edm::InputTag>("oldToNewMuons")))
-{
-    produces<std::vector<reco::PFCandidate>>();
-    produces<std::vector<reco::PFCandidate>>("discarded");
-    produces<edm::ValueMap<reco::PFCandidateRef>>();
+PFCandidateMuonUntagger::PFCandidateMuonUntagger(const edm::ParameterSet &iConfig)
+    : pfcandidates_(consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfcandidates"))),
+      oldToNewMuons_(
+          consumes<edm::Association<std::vector<reco::Muon>>>(iConfig.getParameter<edm::InputTag>("oldToNewMuons"))) {
+  produces<std::vector<reco::PFCandidate>>();
+  produces<std::vector<reco::PFCandidate>>("discarded");
+  produces<edm::ValueMap<reco::PFCandidateRef>>();
 }
 
-void PFCandidateMuonUntagger::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup&) const
-{
-    edm::Handle<edm::Association<std::vector<reco::Muon>>> oldToNewMuons;
-    iEvent.getByToken(oldToNewMuons_, oldToNewMuons);
+void PFCandidateMuonUntagger::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &) const {
+  edm::Handle<edm::Association<std::vector<reco::Muon>>> oldToNewMuons;
+  iEvent.getByToken(oldToNewMuons_, oldToNewMuons);
 
-    edm::Handle<std::vector<reco::PFCandidate>> pfcandidates;
-    iEvent.getByToken(pfcandidates_, pfcandidates);
+  edm::Handle<std::vector<reco::PFCandidate>> pfcandidates;
+  iEvent.getByToken(pfcandidates_, pfcandidates);
 
-    int n = pfcandidates->size();
-    std::unique_ptr<std::vector<reco::PFCandidate>> copy(new std::vector<reco::PFCandidate>());
-    std::unique_ptr<std::vector<reco::PFCandidate>> discarded(new std::vector<reco::PFCandidate>());
-    copy->reserve(n); 
-    std::vector<int> oldToNew(n), newToOld, badToOld; 
-    newToOld.reserve(n);
+  int n = pfcandidates->size();
+  std::unique_ptr<std::vector<reco::PFCandidate>> copy(new std::vector<reco::PFCandidate>());
+  std::unique_ptr<std::vector<reco::PFCandidate>> discarded(new std::vector<reco::PFCandidate>());
+  copy->reserve(n);
+  std::vector<int> oldToNew(n), newToOld, badToOld;
+  newToOld.reserve(n);
 
-    int i = -1;
-    for (const reco::PFCandidate &pf : *pfcandidates) {
-        ++i;
-        if (pf.muonRef().isNonnull()) {
-            reco::MuonRef newRef = (*oldToNewMuons)[pf.muonRef()];
-            if (abs(pf.pdgId()) == 13 && !newRef->isPFMuon()) { // was untagging
-                discarded->push_back(pf);
-                oldToNew[i] = (-discarded->size());
-                badToOld.push_back(i);
-                discarded->back().setMuonRef(newRef);
-            } else {
-                copy->push_back(pf);
-                oldToNew[i] = (copy->size());
-                newToOld.push_back(i);
-                copy->back().setMuonRef(newRef);
-            }
-        } else {
-            copy->push_back(pf);
-            oldToNew[i] = (copy->size());
-            newToOld.push_back(i);
-        } 
+  int i = -1;
+  for (const reco::PFCandidate &pf : *pfcandidates) {
+    ++i;
+    if (pf.muonRef().isNonnull()) {
+      reco::MuonRef newRef = (*oldToNewMuons)[pf.muonRef()];
+      if (abs(pf.pdgId()) == 13 && !newRef->isPFMuon()) {  // was untagging
+        discarded->push_back(pf);
+        oldToNew[i] = (-discarded->size());
+        badToOld.push_back(i);
+        discarded->back().setMuonRef(newRef);
+      } else {
+        copy->push_back(pf);
+        oldToNew[i] = (copy->size());
+        newToOld.push_back(i);
+        copy->back().setMuonRef(newRef);
+      }
+    } else {
+      copy->push_back(pf);
+      oldToNew[i] = (copy->size());
+      newToOld.push_back(i);
     }
+  }
 
-    // Now we put things in the event
-    edm::OrphanHandle<std::vector<reco::PFCandidate>> newpf = iEvent.put(std::move(copy));
-    edm::OrphanHandle<std::vector<reco::PFCandidate>> badpf = iEvent.put(std::move(discarded), "discarded");
+  // Now we put things in the event
+  edm::OrphanHandle<std::vector<reco::PFCandidate>> newpf = iEvent.put(std::move(copy));
+  edm::OrphanHandle<std::vector<reco::PFCandidate>> badpf = iEvent.put(std::move(discarded), "discarded");
 
-    std::unique_ptr<edm::ValueMap<reco::PFCandidateRef>> pf2pf(new edm::ValueMap<reco::PFCandidateRef>());
-    edm::ValueMap<reco::PFCandidateRef>::Filler filler(*pf2pf);
-    std::vector<reco::PFCandidateRef> refs; refs.reserve(n);
-    // old to new
-    for (i = 0; i < n; ++i) {
-        if (oldToNew[i] > 0) {
-            refs.push_back(reco::PFCandidateRef(newpf, oldToNew[i]-1));
-        } else {
-            refs.push_back(reco::PFCandidateRef(badpf,-oldToNew[i]-1));
-        }
+  std::unique_ptr<edm::ValueMap<reco::PFCandidateRef>> pf2pf(new edm::ValueMap<reco::PFCandidateRef>());
+  edm::ValueMap<reco::PFCandidateRef>::Filler filler(*pf2pf);
+  std::vector<reco::PFCandidateRef> refs;
+  refs.reserve(n);
+  // old to new
+  for (i = 0; i < n; ++i) {
+    if (oldToNew[i] > 0) {
+      refs.push_back(reco::PFCandidateRef(newpf, oldToNew[i] - 1));
+    } else {
+      refs.push_back(reco::PFCandidateRef(badpf, -oldToNew[i] - 1));
     }
-    filler.insert(pfcandidates, refs.begin(), refs.end());
-    // new good to old
-    refs.clear();
-    for (int i : newToOld) {
-        refs.push_back(reco::PFCandidateRef(pfcandidates,i));
-    }
-    filler.insert(newpf, refs.begin(), refs.end());
-    // new bad to old
-    refs.clear();
-    for (int i : badToOld) {
-        refs.push_back(reco::PFCandidateRef(pfcandidates,i));
-    }
-    filler.insert(badpf, refs.begin(), refs.end());
-    // done
-    filler.fill();
-    iEvent.put(std::move(pf2pf));
+  }
+  filler.insert(pfcandidates, refs.begin(), refs.end());
+  // new good to old
+  refs.clear();
+  for (int i : newToOld) {
+    refs.push_back(reco::PFCandidateRef(pfcandidates, i));
+  }
+  filler.insert(newpf, refs.begin(), refs.end());
+  // new bad to old
+  refs.clear();
+  for (int i : badToOld) {
+    refs.push_back(reco::PFCandidateRef(pfcandidates, i));
+  }
+  filler.insert(badpf, refs.begin(), refs.end());
+  // done
+  filler.fill();
+  iEvent.put(std::move(pf2pf));
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PFCandidateMuonUntagger);

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -31,315 +31,280 @@
 #include "DataFormats/Common/interface/Association.h"
 #include <iostream>
 
-
-struct HEChannel { 
-  float eta; float phi; float ratio;
-  HEChannel(float eta, float phi, float ratio): 
-    eta(eta),
-    phi(phi),
-    ratio(ratio)
-  {}
+struct HEChannel {
+  float eta;
+  float phi;
+  float ratio;
+  HEChannel(float eta, float phi, float ratio) : eta(eta), phi(phi), ratio(ratio) {}
 };
-struct HFChannel { 
-  int ieta; int iphi; int depth; float ratio;
-  HFChannel(int ieta, int iphi, int depth, float ratio): 
-    ieta(ieta),
-    iphi(iphi),
-    depth(depth),
-    ratio(ratio)
-  {}  
+struct HFChannel {
+  int ieta;
+  int iphi;
+  int depth;
+  float ratio;
+  HFChannel(int ieta, int iphi, int depth, float ratio) : ieta(ieta), iphi(iphi), depth(depth), ratio(ratio) {}
 };
-
 
 class PFCandidateRecalibrator : public edm::stream::EDProducer<> {
-    public:
-        PFCandidateRecalibrator(const edm::ParameterSet&);
-        ~PFCandidateRecalibrator() override {};
+public:
+  PFCandidateRecalibrator(const edm::ParameterSet&);
+  ~PFCandidateRecalibrator() override{};
 
-        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    private:
-        void beginRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
-        void endRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
-        void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void beginRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
+  void endRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-        edm::ESWatcher<HcalRecNumberingRecord> hcalDbWatcher_;
-        edm::ESWatcher<HcalRespCorrsRcd> hcalRCWatcher_;
-  
-        edm::EDGetTokenT<reco::PFCandidateCollection> pfcandidates_;
+  edm::ESWatcher<HcalRecNumberingRecord> hcalDbWatcher_;
+  edm::ESWatcher<HcalRespCorrsRcd> hcalRCWatcher_;
 
-        std::vector<HEChannel> badChHE_;
-        std::vector<HFChannel> badChHF_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfcandidates_;
 
-        float shortFibreThr_;
-        float longFibreThr_;
+  std::vector<HEChannel> badChHE_;
+  std::vector<HFChannel> badChHF_;
+
+  float shortFibreThr_;
+  float longFibreThr_;
 };
 
-PFCandidateRecalibrator::PFCandidateRecalibrator(const edm::ParameterSet &iConfig) :
-  pfcandidates_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfcandidates"))),
-  shortFibreThr_(iConfig.getParameter<double>("shortFibreThr")),
-  longFibreThr_(iConfig.getParameter<double>("longFibreThr"))
-{
-    produces<reco::PFCandidateCollection>();
-    produces<reco::PFCandidateCollection>("discarded");
-    produces<edm::ValueMap<reco::PFCandidateRef>>();
+PFCandidateRecalibrator::PFCandidateRecalibrator(const edm::ParameterSet& iConfig)
+    : pfcandidates_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfcandidates"))),
+      shortFibreThr_(iConfig.getParameter<double>("shortFibreThr")),
+      longFibreThr_(iConfig.getParameter<double>("longFibreThr")) {
+  produces<reco::PFCandidateCollection>();
+  produces<reco::PFCandidateCollection>("discarded");
+  produces<edm::ValueMap<reco::PFCandidateRef>>();
 }
 
-void PFCandidateRecalibrator::beginRun(const edm::Run &iRun, const edm::EventSetup &iSetup)
-{
-    if (hcalDbWatcher_.check(iSetup) || hcalRCWatcher_.check(iSetup))
-      {
-	//Get Calib Constants from current GT
-	edm::ESHandle<HcalDbService> gtCond;
-	iSetup.get<HcalDbRecord>().get(gtCond);
-	
-	//Get Calib Constants from bugged tag
-	edm::ESHandle<HcalTopology> htopo;
-	iSetup.get<HcalRecNumberingRecord>().get(htopo);
-	const HcalTopology* theHBHETopology = htopo.product();
-	
-	edm::ESHandle<HcalRespCorrs> buggedCond;
-	iSetup.get<HcalRespCorrsRcd>().get("bugged", buggedCond);
-	HcalRespCorrs buggedRespCorrs(*buggedCond.product());
-	buggedRespCorrs.setTopo(theHBHETopology);
-	
-	//access calogeometry
-	edm::ESHandle<CaloGeometry> calogeom;
-	iSetup.get<CaloGeometryRecord>().get(calogeom);
-	const CaloGeometry* cgeo = calogeom.product();
-	const HcalGeometry* hgeom = static_cast<const HcalGeometry*>(cgeo->getSubdetectorGeometry(DetId::Hcal,HcalForward));
+void PFCandidateRecalibrator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  if (hcalDbWatcher_.check(iSetup) || hcalRCWatcher_.check(iSetup)) {
+    //Get Calib Constants from current GT
+    edm::ESHandle<HcalDbService> gtCond;
+    iSetup.get<HcalDbRecord>().get(gtCond);
 
-	//reset the bad channel containers
-	badChHE_.clear();
-	badChHF_.clear();
-	
-	//fill bad cells HE (use eta, phi)
-	const std::vector<DetId>& cellsHE = hgeom->getValidDetIds(DetId::Detector::Hcal, HcalEndcap);
-	for( auto id : cellsHE)
-	  {
-	    float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
-	    float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
-	    if (buggedRespCorr == 0.)
-	      continue;
+    //Get Calib Constants from bugged tag
+    edm::ESHandle<HcalTopology> htopo;
+    iSetup.get<HcalRecNumberingRecord>().get(htopo);
+    const HcalTopology* theHBHETopology = htopo.product();
 
-	    float ratio = currentRespCorr/buggedRespCorr;
-	    if( std::abs(ratio - 1.f) > 0.001 )
-	      {
-		GlobalPoint pos = hgeom->getPosition(id);
-		badChHE_.push_back(HEChannel(pos.eta(),pos.phi(),ratio));
-	      }
-	  }
-	
-	//fill bad cells HF (use ieta, iphi)
-	auto const& cellsHF = hgeom->getValidDetIds(DetId::Detector::Hcal, HcalForward);
-	for( auto id : cellsHF)
-	  {
-	    float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
-	    float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
-	    if (buggedRespCorr == 0.)
-	      continue;
+    edm::ESHandle<HcalRespCorrs> buggedCond;
+    iSetup.get<HcalRespCorrsRcd>().get("bugged", buggedCond);
+    HcalRespCorrs buggedRespCorrs(*buggedCond.product());
+    buggedRespCorrs.setTopo(theHBHETopology);
 
-	    float ratio = currentRespCorr/buggedRespCorr;
-	    if( std::abs(ratio - 1.f) > 0.001 )
-	      {
-		HcalDetId dummyId(id);
-		badChHF_.push_back(HFChannel(dummyId.ieta(), dummyId.iphi(), dummyId.depth(), ratio));
-	      }
-	  }
-      }
-}
-
-void PFCandidateRecalibrator::endRun(const edm::Run &iRun, const edm::EventSetup &iSetup)
-{
-}
-
-void PFCandidateRecalibrator::produce(edm::Event &iEvent, const edm::EventSetup &iSetup)
-{
     //access calogeometry
     edm::ESHandle<CaloGeometry> calogeom;
     iSetup.get<CaloGeometryRecord>().get(calogeom);
     const CaloGeometry* cgeo = calogeom.product();
-    const HcalGeometry* hgeom = static_cast<const HcalGeometry*>(cgeo->getSubdetectorGeometry(DetId::Hcal,HcalForward));
- 
-    //access PFCandidates
-    edm::Handle<reco::PFCandidateCollection> pfcandidates;
-    iEvent.getByToken(pfcandidates_, pfcandidates);
+    const HcalGeometry* hgeom =
+        static_cast<const HcalGeometry*>(cgeo->getSubdetectorGeometry(DetId::Hcal, HcalForward));
 
-    int nPfCand = pfcandidates->size();
-    std::unique_ptr<reco::PFCandidateCollection> copy(new reco::PFCandidateCollection());
-    std::unique_ptr<reco::PFCandidateCollection> discarded(new reco::PFCandidateCollection());
-    copy->reserve(nPfCand);
-    std::vector<int> oldToNew(nPfCand), newToOld, badToOld; 
-    newToOld.reserve(nPfCand);
+    //reset the bad channel containers
+    badChHE_.clear();
+    badChHF_.clear();
 
-    LogDebug("PFCandidateRecalibrator") << "NEW EV:";
+    //fill bad cells HE (use eta, phi)
+    const std::vector<DetId>& cellsHE = hgeom->getValidDetIds(DetId::Detector::Hcal, HcalEndcap);
+    for (auto id : cellsHE) {
+      float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
+      float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
+      if (buggedRespCorr == 0.)
+        continue;
 
-    //loop over PFCandidates
-    int i = -1;
-    for (const reco::PFCandidate &pf : *pfcandidates) 
-      {
-	++i;
-	float absEta = std::abs(pf.eta());
-
-	//deal with HE
-	if( pf.particleId() == reco::PFCandidate::ParticleType::h0 && 
-	    !badChHE_.empty() &&  //don't touch if no miscalibration is found
-	    absEta > 1.4  && absEta < 3.)
-	  {
-	    bool toKill = false;
-	    for(auto const& badIt: badChHE_)
-	      if( reco::deltaR2(pf.eta(), pf.phi(), badIt.eta, badIt.phi) < 0.07 )
-		toKill = true;
-	    
-	    
-	    if(toKill)
-	      {
-		discarded->push_back(pf);
-		oldToNew[i] = (-discarded->size());
-		badToOld.push_back(i);
-		continue;
-	      }
-	    else
-	      {
-		copy->push_back(pf);
-		oldToNew[i] = (copy->size());
-		newToOld.push_back(i);
-	      }
-	  }
-	//deal with HF
-	else if( (pf.particleId() == reco::PFCandidate::ParticleType::h_HF || pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF) &&
-		 !badChHF_.empty() &&  //don't touch if no miscalibration is found
-		 absEta >= 3.)
-	  {
-	    const math::XYZPointF& ecalPoint = pf.positionAtECALEntrance();
-	    GlobalPoint ecalGPoint(ecalPoint.X(),ecalPoint.Y(),ecalPoint.Z());
-	    HcalDetId closestDetId(hgeom->getClosestCell(ecalGPoint));
-	    
-	    if(closestDetId.subdet() == HcalForward)
-	      {
-		HcalDetId hDetId(closestDetId.subdet(),closestDetId.ieta(),closestDetId.iphi(),1); //depth1
-		
-		//raw*calEnergy() is the same as *calEnergy() - no corrections are done for HF
-		float longE  = pf.rawEcalEnergy() + pf.rawHcalEnergy()/2.;  //depth1
-		float shortE = pf.rawHcalEnergy()/2.;                       //depth2
-		
-		float ecalEnergy = pf.rawEcalEnergy();
-		float hcalEnergy = pf.rawHcalEnergy();
-		float totEnergy = ecalEnergy + hcalEnergy;
-		float totEnergyOrig = totEnergy;
-		
-		bool toKill = false;
-			
-		for(auto const& badIt: badChHF_)
-		  {
-		    if ( hDetId.ieta() == badIt.ieta &&
-			 hDetId.iphi() == badIt.iphi )
-		      {
-			LogDebug("PFCandidateRecalibrator") << "==> orig en (tot,H,E): " 
-							    << pf.energy() << " " << pf.rawHcalEnergy() << " " << pf.rawEcalEnergy();
-			if(badIt.depth == 1) //depth1
-			  {
-			    longE *= badIt.ratio;
-			    ecalEnergy = ((longE - shortE) > 0.) ? (longE - shortE) : 0.;
-			    totEnergy = ecalEnergy + hcalEnergy;
-			  }
-			else //depth2
-			  {
-			    shortE *= badIt.ratio;
-			    hcalEnergy = 2*shortE;
-			    ecalEnergy = ((longE - shortE) > 0.) ? (longE - shortE) : 0.;
-			    totEnergy = ecalEnergy + hcalEnergy;
-			  }
-			//kill candidate if goes below thr
-			if((pf.particleId() == reco::PFCandidate::ParticleType::h_HF && shortE < shortFibreThr_) ||
-			   (pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF && longE < longFibreThr_))
-			  toKill = true;
-
-			LogDebug("PFCandidateRecalibrator") << "====> ieta,iphi,depth: " 
-							    << badIt.ieta << " " << badIt.iphi << " " << badIt.depth << " corr: " << badIt.ratio;
-			LogDebug("PFCandidateRecalibrator") << "====> recal en (tot,H,E): " 
-							    << totEnergy << " " << hcalEnergy << " " << ecalEnergy;
-
-		      }
-		  }
-		
-		if(toKill)
-		  {
-		    discarded->push_back(pf);
-		    oldToNew[i] = (-discarded->size());
-		    badToOld.push_back(i);
-
-		    LogDebug("PFCandidateRecalibrator") << "==> KILLED ";
-		  }
-		else
-		  {
-		    copy->push_back(pf);
-		    oldToNew[i] = (copy->size());
-		    newToOld.push_back(i);
-		    
-		    copy->back().setHcalEnergy(hcalEnergy, hcalEnergy);
-		    copy->back().setEcalEnergy(ecalEnergy, ecalEnergy);
-
-		    float scalingFactor = totEnergy/totEnergyOrig;
-		    math::XYZTLorentzVector recalibP4 = pf.p4() * scalingFactor;
-		    copy->back().setP4( recalibP4 );
-
-		    LogDebug("PFCandidateRecalibrator") << "====> stored en (tot,H,E): " 
-							<< copy->back().energy() << " " << copy->back().hcalEnergy() << " " << copy->back().ecalEnergy();
-		  }
-	      }
-	    else
-	      {
-		copy->push_back(pf);
-		oldToNew[i] = (copy->size());
-		newToOld.push_back(i);
-	      }
-	  }
-	else
-	  {
-	    copy->push_back(pf);
-	    oldToNew[i] = (copy->size());
-	    newToOld.push_back(i);
-	  }
-      }
-
-    // Now we put things in the event
-    edm::OrphanHandle<reco::PFCandidateCollection> newpf = iEvent.put(std::move(copy));
-    edm::OrphanHandle<reco::PFCandidateCollection> badpf = iEvent.put(std::move(discarded), "discarded");
-
-    std::unique_ptr<edm::ValueMap<reco::PFCandidateRef>> pf2pf(new edm::ValueMap<reco::PFCandidateRef>());
-    edm::ValueMap<reco::PFCandidateRef>::Filler filler(*pf2pf);
-    std::vector<reco::PFCandidateRef> refs; refs.reserve(nPfCand);
-
-    // old to new
-    for (auto iOldToNew : oldToNew){
-      if (iOldToNew > 0) {
-	refs.push_back(reco::PFCandidateRef(newpf, iOldToNew-1));
-      } else {
-	refs.push_back(reco::PFCandidateRef(badpf,-iOldToNew-1));
+      float ratio = currentRespCorr / buggedRespCorr;
+      if (std::abs(ratio - 1.f) > 0.001) {
+        GlobalPoint pos = hgeom->getPosition(id);
+        badChHE_.push_back(HEChannel(pos.eta(), pos.phi(), ratio));
       }
     }
-    filler.insert(pfcandidates, refs.begin(), refs.end());
-    // new good to old
-    refs.clear();
-    for (int i : newToOld) {
-      refs.push_back(reco::PFCandidateRef(pfcandidates,i));
+
+    //fill bad cells HF (use ieta, iphi)
+    auto const& cellsHF = hgeom->getValidDetIds(DetId::Detector::Hcal, HcalForward);
+    for (auto id : cellsHF) {
+      float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
+      float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
+      if (buggedRespCorr == 0.)
+        continue;
+
+      float ratio = currentRespCorr / buggedRespCorr;
+      if (std::abs(ratio - 1.f) > 0.001) {
+        HcalDetId dummyId(id);
+        badChHF_.push_back(HFChannel(dummyId.ieta(), dummyId.iphi(), dummyId.depth(), ratio));
+      }
     }
-    filler.insert(newpf, refs.begin(), refs.end());
-    // new bad to old
-    refs.clear();
-    for (int i : badToOld) {
-      refs.push_back(reco::PFCandidateRef(pfcandidates,i));
-    }
-    filler.insert(badpf, refs.begin(), refs.end());
-    // done
-    filler.fill();
-    iEvent.put(std::move(pf2pf));
+  }
 }
 
-void
-PFCandidateRecalibrator::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+void PFCandidateRecalibrator::endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
+
+void PFCandidateRecalibrator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //access calogeometry
+  edm::ESHandle<CaloGeometry> calogeom;
+  iSetup.get<CaloGeometryRecord>().get(calogeom);
+  const CaloGeometry* cgeo = calogeom.product();
+  const HcalGeometry* hgeom = static_cast<const HcalGeometry*>(cgeo->getSubdetectorGeometry(DetId::Hcal, HcalForward));
+
+  //access PFCandidates
+  edm::Handle<reco::PFCandidateCollection> pfcandidates;
+  iEvent.getByToken(pfcandidates_, pfcandidates);
+
+  int nPfCand = pfcandidates->size();
+  std::unique_ptr<reco::PFCandidateCollection> copy(new reco::PFCandidateCollection());
+  std::unique_ptr<reco::PFCandidateCollection> discarded(new reco::PFCandidateCollection());
+  copy->reserve(nPfCand);
+  std::vector<int> oldToNew(nPfCand), newToOld, badToOld;
+  newToOld.reserve(nPfCand);
+
+  LogDebug("PFCandidateRecalibrator") << "NEW EV:";
+
+  //loop over PFCandidates
+  int i = -1;
+  for (const reco::PFCandidate& pf : *pfcandidates) {
+    ++i;
+    float absEta = std::abs(pf.eta());
+
+    //deal with HE
+    if (pf.particleId() == reco::PFCandidate::ParticleType::h0 &&
+        !badChHE_.empty() &&  //don't touch if no miscalibration is found
+        absEta > 1.4 && absEta < 3.) {
+      bool toKill = false;
+      for (auto const& badIt : badChHE_)
+        if (reco::deltaR2(pf.eta(), pf.phi(), badIt.eta, badIt.phi) < 0.07)
+          toKill = true;
+
+      if (toKill) {
+        discarded->push_back(pf);
+        oldToNew[i] = (-discarded->size());
+        badToOld.push_back(i);
+        continue;
+      } else {
+        copy->push_back(pf);
+        oldToNew[i] = (copy->size());
+        newToOld.push_back(i);
+      }
+    }
+    //deal with HF
+    else if ((pf.particleId() == reco::PFCandidate::ParticleType::h_HF ||
+              pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF) &&
+             !badChHF_.empty() &&  //don't touch if no miscalibration is found
+             absEta >= 3.) {
+      const math::XYZPointF& ecalPoint = pf.positionAtECALEntrance();
+      GlobalPoint ecalGPoint(ecalPoint.X(), ecalPoint.Y(), ecalPoint.Z());
+      HcalDetId closestDetId(hgeom->getClosestCell(ecalGPoint));
+
+      if (closestDetId.subdet() == HcalForward) {
+        HcalDetId hDetId(closestDetId.subdet(), closestDetId.ieta(), closestDetId.iphi(), 1);  //depth1
+
+        //raw*calEnergy() is the same as *calEnergy() - no corrections are done for HF
+        float longE = pf.rawEcalEnergy() + pf.rawHcalEnergy() / 2.;  //depth1
+        float shortE = pf.rawHcalEnergy() / 2.;                      //depth2
+
+        float ecalEnergy = pf.rawEcalEnergy();
+        float hcalEnergy = pf.rawHcalEnergy();
+        float totEnergy = ecalEnergy + hcalEnergy;
+        float totEnergyOrig = totEnergy;
+
+        bool toKill = false;
+
+        for (auto const& badIt : badChHF_) {
+          if (hDetId.ieta() == badIt.ieta && hDetId.iphi() == badIt.iphi) {
+            LogDebug("PFCandidateRecalibrator")
+                << "==> orig en (tot,H,E): " << pf.energy() << " " << pf.rawHcalEnergy() << " " << pf.rawEcalEnergy();
+            if (badIt.depth == 1)  //depth1
+            {
+              longE *= badIt.ratio;
+              ecalEnergy = ((longE - shortE) > 0.) ? (longE - shortE) : 0.;
+              totEnergy = ecalEnergy + hcalEnergy;
+            } else  //depth2
+            {
+              shortE *= badIt.ratio;
+              hcalEnergy = 2 * shortE;
+              ecalEnergy = ((longE - shortE) > 0.) ? (longE - shortE) : 0.;
+              totEnergy = ecalEnergy + hcalEnergy;
+            }
+            //kill candidate if goes below thr
+            if ((pf.particleId() == reco::PFCandidate::ParticleType::h_HF && shortE < shortFibreThr_) ||
+                (pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF && longE < longFibreThr_))
+              toKill = true;
+
+            LogDebug("PFCandidateRecalibrator") << "====> ieta,iphi,depth: " << badIt.ieta << " " << badIt.iphi << " "
+                                                << badIt.depth << " corr: " << badIt.ratio;
+            LogDebug("PFCandidateRecalibrator")
+                << "====> recal en (tot,H,E): " << totEnergy << " " << hcalEnergy << " " << ecalEnergy;
+          }
+        }
+
+        if (toKill) {
+          discarded->push_back(pf);
+          oldToNew[i] = (-discarded->size());
+          badToOld.push_back(i);
+
+          LogDebug("PFCandidateRecalibrator") << "==> KILLED ";
+        } else {
+          copy->push_back(pf);
+          oldToNew[i] = (copy->size());
+          newToOld.push_back(i);
+
+          copy->back().setHcalEnergy(hcalEnergy, hcalEnergy);
+          copy->back().setEcalEnergy(ecalEnergy, ecalEnergy);
+
+          float scalingFactor = totEnergy / totEnergyOrig;
+          math::XYZTLorentzVector recalibP4 = pf.p4() * scalingFactor;
+          copy->back().setP4(recalibP4);
+
+          LogDebug("PFCandidateRecalibrator") << "====> stored en (tot,H,E): " << copy->back().energy() << " "
+                                              << copy->back().hcalEnergy() << " " << copy->back().ecalEnergy();
+        }
+      } else {
+        copy->push_back(pf);
+        oldToNew[i] = (copy->size());
+        newToOld.push_back(i);
+      }
+    } else {
+      copy->push_back(pf);
+      oldToNew[i] = (copy->size());
+      newToOld.push_back(i);
+    }
+  }
+
+  // Now we put things in the event
+  edm::OrphanHandle<reco::PFCandidateCollection> newpf = iEvent.put(std::move(copy));
+  edm::OrphanHandle<reco::PFCandidateCollection> badpf = iEvent.put(std::move(discarded), "discarded");
+
+  std::unique_ptr<edm::ValueMap<reco::PFCandidateRef>> pf2pf(new edm::ValueMap<reco::PFCandidateRef>());
+  edm::ValueMap<reco::PFCandidateRef>::Filler filler(*pf2pf);
+  std::vector<reco::PFCandidateRef> refs;
+  refs.reserve(nPfCand);
+
+  // old to new
+  for (auto iOldToNew : oldToNew) {
+    if (iOldToNew > 0) {
+      refs.push_back(reco::PFCandidateRef(newpf, iOldToNew - 1));
+    } else {
+      refs.push_back(reco::PFCandidateRef(badpf, -iOldToNew - 1));
+    }
+  }
+  filler.insert(pfcandidates, refs.begin(), refs.end());
+  // new good to old
+  refs.clear();
+  for (int i : newToOld) {
+    refs.push_back(reco::PFCandidateRef(pfcandidates, i));
+  }
+  filler.insert(newpf, refs.begin(), refs.end());
+  // new bad to old
+  refs.clear();
+  for (int i : badToOld) {
+    refs.push_back(reco::PFCandidateRef(pfcandidates, i));
+  }
+  filler.insert(badpf, refs.begin(), refs.end());
+  // done
+  filler.fill();
+  iEvent.put(std::move(pf2pf));
+}
+
+void PFCandidateRecalibrator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
   desc.add<edm::InputTag>("pfcandidates", edm::InputTag("particleFlow"));
@@ -347,7 +312,6 @@ PFCandidateRecalibrator::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<double>("longFibreThr", 1.4);
 
   descriptions.add("pfCandidateRecalibrator", desc);
-
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CommonTools/ParticleFlow/plugins/PFEGammaToCandidateRemapper.cc
+++ b/CommonTools/ParticleFlow/plugins/PFEGammaToCandidateRemapper.cc
@@ -17,65 +17,64 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 class PFEGammaToCandidateRemapper : public edm::global::EDProducer<> {
-    public:
-        explicit PFEGammaToCandidateRemapper(const edm::ParameterSet & iConfig);
-        ~PFEGammaToCandidateRemapper() override { }
+public:
+  explicit PFEGammaToCandidateRemapper(const edm::ParameterSet &iConfig);
+  ~PFEGammaToCandidateRemapper() override {}
 
-        void produce(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
+  void produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
 
-    private:
-        edm::EDGetTokenT<std::vector<reco::Photon>> photons_;
-        edm::EDGetTokenT<std::vector<reco::GsfElectron>> electrons_;
-        edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
-        edm::EDGetTokenT<edm::ValueMap<reco::PFCandidateRef>> pf2pf_;
+private:
+  edm::EDGetTokenT<std::vector<reco::Photon>> photons_;
+  edm::EDGetTokenT<std::vector<reco::GsfElectron>> electrons_;
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> photon2pf_, electron2pf_;
+  edm::EDGetTokenT<edm::ValueMap<reco::PFCandidateRef>> pf2pf_;
 
-        template<typename T>
-        void run(edm::Event & iEvent, 
-                const edm::EDGetTokenT<std::vector<T>> &colltoken, 
-                const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> &oldmaptoken, 
-                const edm::ValueMap<reco::PFCandidateRef> & pf2pf, 
-                const std::string &name) const {
-            edm::Handle<std::vector<T>> handle;
-            iEvent.getByToken(colltoken, handle);
+  template <typename T>
+  void run(edm::Event &iEvent,
+           const edm::EDGetTokenT<std::vector<T>> &colltoken,
+           const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> &oldmaptoken,
+           const edm::ValueMap<reco::PFCandidateRef> &pf2pf,
+           const std::string &name) const {
+    edm::Handle<std::vector<T>> handle;
+    iEvent.getByToken(colltoken, handle);
 
-            edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> oldmap;
-            iEvent.getByToken(oldmaptoken, oldmap);
+    edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> oldmap;
+    iEvent.getByToken(oldmaptoken, oldmap);
 
-            std::vector<std::vector<reco::PFCandidateRef>> refs(handle->size());
-            for (unsigned int i = 0, n = handle->size(); i < n; ++i) {
-                edm::Ref<std::vector<T>> egRef(handle,i);
-                for (reco::PFCandidateRef pfRef : (*oldmap)[egRef]) {
-                    refs[i].push_back(pf2pf[pfRef]);
-                }
-            }
+    std::vector<std::vector<reco::PFCandidateRef>> refs(handle->size());
+    for (unsigned int i = 0, n = handle->size(); i < n; ++i) {
+      edm::Ref<std::vector<T>> egRef(handle, i);
+      for (reco::PFCandidateRef pfRef : (*oldmap)[egRef]) {
+        refs[i].push_back(pf2pf[pfRef]);
+      }
+    }
 
-            std::unique_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef>>> out(new edm::ValueMap<std::vector<reco::PFCandidateRef>>());
-            edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler filler(*out);
-            filler.insert(handle, refs.begin(), refs.end());
-            filler.fill();
-            iEvent.put(std::move(out), name);
-        }
+    std::unique_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef>>> out(
+        new edm::ValueMap<std::vector<reco::PFCandidateRef>>());
+    edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler filler(*out);
+    filler.insert(handle, refs.begin(), refs.end());
+    filler.fill();
+    iEvent.put(std::move(out), name);
+  }
 };
 
-
-PFEGammaToCandidateRemapper::PFEGammaToCandidateRemapper(const edm::ParameterSet & iConfig):
-    photons_(consumes<std::vector<reco::Photon>>(iConfig.getParameter<edm::InputTag>("photons"))),
-    electrons_(consumes<std::vector<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
-    photon2pf_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("photon2pf"))),
-    electron2pf_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("electron2pf"))),
-    pf2pf_(consumes<edm::ValueMap<reco::PFCandidateRef>>(iConfig.getParameter<edm::InputTag>("pf2pf")))
-{
-    produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>("photons");
-    produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>("electrons");
+PFEGammaToCandidateRemapper::PFEGammaToCandidateRemapper(const edm::ParameterSet &iConfig)
+    : photons_(consumes<std::vector<reco::Photon>>(iConfig.getParameter<edm::InputTag>("photons"))),
+      electrons_(consumes<std::vector<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      photon2pf_(
+          consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("photon2pf"))),
+      electron2pf_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+          iConfig.getParameter<edm::InputTag>("electron2pf"))),
+      pf2pf_(consumes<edm::ValueMap<reco::PFCandidateRef>>(iConfig.getParameter<edm::InputTag>("pf2pf"))) {
+  produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>("photons");
+  produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>("electrons");
 }
 
-
-void 
-PFEGammaToCandidateRemapper::produce(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
-    edm::Handle<edm::ValueMap<reco::PFCandidateRef>> pf2pf;
-    iEvent.getByToken(pf2pf_, pf2pf);
-    run<reco::Photon>(iEvent, photons_, photon2pf_, *pf2pf, "photons");
-    run<reco::GsfElectron>(iEvent, electrons_, electron2pf_, *pf2pf, "electrons");
+void PFEGammaToCandidateRemapper::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  edm::Handle<edm::ValueMap<reco::PFCandidateRef>> pf2pf;
+  iEvent.getByToken(pf2pf_, pf2pf);
+  run<reco::Photon>(iEvent, photons_, photon2pf_, *pf2pf, "photons");
+  run<reco::GsfElectron>(iEvent, electrons_, electron2pf_, *pf2pf, "electrons");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CommonTools/ParticleFlow/plugins/PFJetFwdPtrProducer.h
+++ b/CommonTools/ParticleFlow/plugins/PFJetFwdPtrProducer.h
@@ -2,4 +2,4 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 
-typedef edm::FwdPtrProducer< reco::PFJet >  PFJetFwdPtrProducer;
+typedef edm::FwdPtrProducer<reco::PFJet> PFJetFwdPtrProducer;

--- a/CommonTools/ParticleFlow/plugins/PFMET.cc
+++ b/CommonTools/ParticleFlow/plugins/PFMET.cc
@@ -12,59 +12,36 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace reco;
 using namespace math;
 
 PFMET::PFMET(const edm::ParameterSet& iConfig) : pfMETAlgo_(iConfig) {
-
-
-
-  inputTagPFCandidates_
-    = iConfig.getParameter<InputTag>("PFCandidates");
+  inputTagPFCandidates_ = iConfig.getParameter<InputTag>("PFCandidates");
   tokenPFCandidates_ = consumes<PFCandidateCollection>(inputTagPFCandidates_);
 
   produces<METCollection>();
 
-  LogDebug("PFMET")
-    <<" input collection : "<<inputTagPFCandidates_ ;
-
+  LogDebug("PFMET") << " input collection : " << inputTagPFCandidates_;
 }
 
+PFMET::~PFMET() {}
 
+void PFMET::beginJob() {}
 
-PFMET::~PFMET() { }
-
-
-
-void PFMET::beginJob() { }
-
-
-void PFMET::produce(Event& iEvent,
-			  const EventSetup& iSetup) {
-
-  LogDebug("PFMET")<<"START event: "<<iEvent.id().event()
-		   <<" in run "<<iEvent.id().run()<<endl;
-
-
+void PFMET::produce(Event& iEvent, const EventSetup& iSetup) {
+  LogDebug("PFMET") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;
 
   // get PFCandidates
 
   Handle<PFCandidateCollection> pfCandidates;
-  iEvent.getByToken( tokenPFCandidates_, pfCandidates);
+  iEvent.getByToken(tokenPFCandidates_, pfCandidates);
 
-  unique_ptr< METCollection >
-    pOutput( new METCollection() );
+  unique_ptr<METCollection> pOutput(new METCollection());
 
-
-
-  pOutput->push_back( pfMETAlgo_.produce( *pfCandidates ) );
+  pOutput->push_back(pfMETAlgo_.produce(*pfCandidates));
   iEvent.put(std::move(pOutput));
 
-  LogDebug("PFMET")<<"STOP event: "<<iEvent.id().event()
-		   <<" in run "<<iEvent.id().run()<<endl;
+  LogDebug("PFMET") << "STOP event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;
 }
-
-

--- a/CommonTools/ParticleFlow/plugins/PFMET.h
+++ b/CommonTools/ParticleFlow/plugins/PFMET.h
@@ -24,12 +24,8 @@
 \date   february 2008
 */
 
-
-
-
 class PFMET : public edm::EDProducer {
- public:
-
+public:
   explicit PFMET(const edm::ParameterSet&);
 
   ~PFMET() override;
@@ -38,13 +34,12 @@ class PFMET : public edm::EDProducer {
 
   void beginJob() override;
 
- private:
-
+private:
   /// Input PFCandidates
-  edm::InputTag       inputTagPFCandidates_;
+  edm::InputTag inputTagPFCandidates_;
   edm::EDGetTokenT<reco::PFCandidateCollection> tokenPFCandidates_;
 
-  pf2pat::PFMETAlgo   pfMETAlgo_;
+  pf2pat::PFMETAlgo pfMETAlgo_;
 };
 
 #endif

--- a/CommonTools/ParticleFlow/plugins/PFPileUp.h
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.h
@@ -28,15 +28,11 @@ produces the corresponding collection of PileUpCandidates.
 
 */
 
-
-
-
 class PFPileUp : public edm::stream::EDProducer<> {
- public:
-
-  typedef std::vector< edm::FwdPtr<reco::PFCandidate> >  PFCollection;
-  typedef edm::View<reco::PFCandidate>                   PFView;
-  typedef std::vector<reco::PFCandidate>                 PFCollectionByValue;
+public:
+  typedef std::vector<edm::FwdPtr<reco::PFCandidate> > PFCollection;
+  typedef edm::View<reco::PFCandidate> PFView;
+  typedef std::vector<reco::PFCandidate> PFCollectionByValue;
 
   explicit PFPileUp(const edm::ParameterSet&);
 
@@ -44,27 +40,25 @@ class PFPileUp : public edm::stream::EDProducer<> {
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
-
-  PFPileUpAlgo    pileUpAlgo_;
+private:
+  PFPileUpAlgo pileUpAlgo_;
 
   /// PFCandidates to be analyzed
-  edm::EDGetTokenT<PFCollection>   tokenPFCandidates_;
+  edm::EDGetTokenT<PFCollection> tokenPFCandidates_;
   /// fall-back token
-  edm::EDGetTokenT<PFView>   tokenPFCandidatesView_;
+  edm::EDGetTokenT<PFView> tokenPFCandidatesView_;
 
   /// vertices
-  edm::EDGetTokenT<reco::VertexCollection>   tokenVertices_;
+  edm::EDGetTokenT<reco::VertexCollection> tokenVertices_;
 
   /// enable PFPileUp selection
-  bool   enable_;
+  bool enable_;
 
   /// verbose ?
-  bool   verbose_;
+  bool verbose_;
 
   /// use the closest z vertex if a track is not in a vertex
-  bool   checkClosestZVertex_;
-
+  bool checkClosestZVertex_;
 };
 
 #endif

--- a/CommonTools/ParticleFlow/plugins/PFTauFwdPtrProducer.h
+++ b/CommonTools/ParticleFlow/plugins/PFTauFwdPtrProducer.h
@@ -2,4 +2,4 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 
-typedef edm::FwdPtrProducer< reco::PFTau >  PFTauFwdPtrProducer;
+typedef edm::FwdPtrProducer<reco::PFTau> PFTauFwdPtrProducer;

--- a/CommonTools/ParticleFlow/plugins/PdgIdPFCandidateSelector.cc
+++ b/CommonTools/ParticleFlow/plugins/PdgIdPFCandidateSelector.cc
@@ -1,7 +1,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 

--- a/CommonTools/ParticleFlow/plugins/PtMinPFCandidateSelector.cc
+++ b/CommonTools/ParticleFlow/plugins/PtMinPFCandidateSelector.cc
@@ -1,15 +1,12 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h"
 
-
 typedef ObjectSelector<pf2pat::PtMinPFCandidateSelectorDefinition> PtMinPFCandidateSelector;
 
 DEFINE_FWK_MODULE(PtMinPFCandidateSelector);
-

--- a/CommonTools/ParticleFlow/plugins/SealModule.cc
+++ b/CommonTools/ParticleFlow/plugins/SealModule.cc
@@ -19,7 +19,7 @@ DEFINE_FWK_MODULE(PFJetFwdPtrProducer);
 DEFINE_FWK_MODULE(PFTauFwdPtrProducer);
 DEFINE_FWK_MODULE(PFCandidateFromFwdPtrProducer);
 
-typedef edm::ProductFromFwdPtrProducer< reco::PFJet >  PFJetFromFwdPtrProducer;
+typedef edm::ProductFromFwdPtrProducer<reco::PFJet> PFJetFromFwdPtrProducer;
 DEFINE_FWK_MODULE(PFJetFromFwdPtrProducer);
 
 DEFINE_FWK_MODULE(DeltaBetaWeights);

--- a/CommonTools/ParticleFlow/plugins/TopProjector.cc
+++ b/CommonTools/ParticleFlow/plugins/TopProjector.cc
@@ -1,6 +1,5 @@
 #include "CommonTools/ParticleFlow/plugins/TopProjector.h"
 
-
 #include "DataFormats/ParticleFlowCandidate/interface/PileUpPFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PileUpPFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h"
@@ -23,19 +22,18 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace reco;
 
-typedef TopProjector<PFJet,               PFCandidate> TPPFJetsOnPFCandidates;
-typedef TopProjector<PFCandidate,         PFCandidate> TPPFCandidatesOnPFCandidates;
-typedef TopProjector<PileUpPFCandidate,   PFCandidate> TPPileUpPFCandidatesOnPFCandidates;
+typedef TopProjector<PFJet, PFCandidate> TPPFJetsOnPFCandidates;
+typedef TopProjector<PFCandidate, PFCandidate> TPPFCandidatesOnPFCandidates;
+typedef TopProjector<PileUpPFCandidate, PFCandidate> TPPileUpPFCandidatesOnPFCandidates;
 typedef TopProjector<IsolatedPFCandidate, PFCandidate> TPIsolatedPFCandidatesOnPFCandidates;
 
 typedef TopProjector<PFCandidate, PileUpPFCandidate> TPPFCandidatesOnPileUpPFCandidates;
 typedef TopProjector<PFTau, PFJet> TPPFTausOnPFJets;
-typedef TopProjector<PFTau, PFJet, TopProjectorDeltaROverlap<PFTau,PFJet> > TPPFTausOnPFJetsDeltaR;
+typedef TopProjector<PFTau, PFJet, TopProjectorDeltaROverlap<PFTau, PFJet> > TPPFTausOnPFJetsDeltaR;
 
 DEFINE_FWK_MODULE(TPPFJetsOnPFCandidates);
 DEFINE_FWK_MODULE(TPPFCandidatesOnPFCandidates);
@@ -44,5 +42,3 @@ DEFINE_FWK_MODULE(TPIsolatedPFCandidatesOnPFCandidates);
 DEFINE_FWK_MODULE(TPPFCandidatesOnPileUpPFCandidates);
 DEFINE_FWK_MODULE(TPPFTausOnPFJets);
 DEFINE_FWK_MODULE(TPPFTausOnPFJetsDeltaR);
-
-

--- a/CommonTools/ParticleFlow/plugins/TopProjector.h
+++ b/CommonTools/ParticleFlow/plugins/TopProjector.h
@@ -36,157 +36,152 @@
 
 #include <iostream>
 
-
 /// This checks a slew of possible overlaps for FwdPtr<Candidate> and derivatives.
-template < class Top, class Bottom>
-  class TopProjectorFwdPtrOverlap {
+template <class Top, class Bottom>
+class TopProjectorFwdPtrOverlap {
+public:
+  typedef edm::FwdPtr<Top> TopFwdPtr;
+  typedef edm::FwdPtr<Bottom> BottomFwdPtr;
 
-  public:
-    typedef edm::FwdPtr<Top> TopFwdPtr;
-    typedef edm::FwdPtr<Bottom> BottomFwdPtr;
+  explicit TopProjectorFwdPtrOverlap() { bottom_ = 0; }
 
+  explicit TopProjectorFwdPtrOverlap(edm::ParameterSet const& iConfig) { bottom_ = nullptr; }
 
-    explicit TopProjectorFwdPtrOverlap( ){bottom_ = 0;}
+  inline void setBottom(BottomFwdPtr const& bottom) { bottom_ = &bottom; }
 
-    explicit TopProjectorFwdPtrOverlap(edm::ParameterSet const & iConfig ){ bottom_ = nullptr;}
+  bool operator()(TopFwdPtr const& top) const {
+    bool topFwdGood = top.ptr().isNonnull() && top.ptr().isAvailable();
+    bool topBckGood = top.backPtr().isNonnull() && top.backPtr().isAvailable();
+    bool bottomFwdGood = bottom_->ptr().isNonnull() && bottom_->ptr().isAvailable();
+    bool bottomBckGood = bottom_->backPtr().isNonnull() && bottom_->backPtr().isAvailable();
 
-    inline void setBottom(BottomFwdPtr const & bottom ) { bottom_ = &bottom; }
-
-    bool operator() ( TopFwdPtr const & top ) const{
-      bool topFwdGood = top.ptr().isNonnull() && top.ptr().isAvailable();
-      bool topBckGood = top.backPtr().isNonnull() && top.backPtr().isAvailable();
-      bool bottomFwdGood = bottom_->ptr().isNonnull() && bottom_->ptr().isAvailable();
-      bool bottomBckGood = bottom_->backPtr().isNonnull() && bottom_->backPtr().isAvailable();
-
-      bool matched =
-	(topFwdGood && bottomFwdGood && top.ptr().refCore() == bottom_->ptr().refCore() && top.ptr().key() == bottom_->ptr().key()) ||
-	(topFwdGood && bottomBckGood && top.ptr().refCore() == bottom_->backPtr().refCore() && top.ptr().key() == bottom_->backPtr().key()) ||
-	(topBckGood && bottomFwdGood && top.backPtr().refCore() == bottom_->ptr().refCore() && top.backPtr().key() == bottom_->ptr().key()) ||
-	(topBckGood && bottomBckGood && top.backPtr().refCore() == bottom_->backPtr().refCore() && top.backPtr().key() == bottom_->backPtr().key())
-	;
-      if ( !matched ) {
-	for ( unsigned isource = 0; isource < top->numberOfSourceCandidatePtrs(); ++isource ) {
-	  reco::CandidatePtr const & topSrcPtr = top->sourceCandidatePtr(isource);
-	  bool topSrcGood = topSrcPtr.isNonnull() && topSrcPtr.isAvailable();
-	  if ( (topSrcGood && bottomFwdGood && topSrcPtr.refCore() == bottom_->ptr().refCore() && topSrcPtr.key() == bottom_->ptr().key())||
-	       (topSrcGood && bottomBckGood && topSrcPtr.refCore() == bottom_->backPtr().refCore() && topSrcPtr.key() == bottom_->backPtr().key())
-	       ) {
-	    matched = true;
-	    break;
-	  }
-	}
+    bool matched = (topFwdGood && bottomFwdGood && top.ptr().refCore() == bottom_->ptr().refCore() &&
+                    top.ptr().key() == bottom_->ptr().key()) ||
+                   (topFwdGood && bottomBckGood && top.ptr().refCore() == bottom_->backPtr().refCore() &&
+                    top.ptr().key() == bottom_->backPtr().key()) ||
+                   (topBckGood && bottomFwdGood && top.backPtr().refCore() == bottom_->ptr().refCore() &&
+                    top.backPtr().key() == bottom_->ptr().key()) ||
+                   (topBckGood && bottomBckGood && top.backPtr().refCore() == bottom_->backPtr().refCore() &&
+                    top.backPtr().key() == bottom_->backPtr().key());
+    if (!matched) {
+      for (unsigned isource = 0; isource < top->numberOfSourceCandidatePtrs(); ++isource) {
+        reco::CandidatePtr const& topSrcPtr = top->sourceCandidatePtr(isource);
+        bool topSrcGood = topSrcPtr.isNonnull() && topSrcPtr.isAvailable();
+        if ((topSrcGood && bottomFwdGood && topSrcPtr.refCore() == bottom_->ptr().refCore() &&
+             topSrcPtr.key() == bottom_->ptr().key()) ||
+            (topSrcGood && bottomBckGood && topSrcPtr.refCore() == bottom_->backPtr().refCore() &&
+             topSrcPtr.key() == bottom_->backPtr().key())) {
+          matched = true;
+          break;
+        }
       }
-      if ( !matched ) {
-	for ( unsigned isource = 0; isource < (*bottom_)->numberOfSourceCandidatePtrs(); ++isource ) {
-	  reco::CandidatePtr const & bottomSrcPtr = (*bottom_)->sourceCandidatePtr(isource);
-	  bool bottomSrcGood = bottomSrcPtr.isNonnull() && bottomSrcPtr.isAvailable();
-	  if ( (topFwdGood && bottomSrcGood && bottomSrcPtr.refCore() == top.ptr().refCore() && bottomSrcPtr.key() == top.ptr().key() )||
-	       (topBckGood && bottomSrcGood && bottomSrcPtr.refCore() == top.backPtr().refCore() && bottomSrcPtr.key() == top.backPtr().key() )
-	       ) {
-	    matched = true;
-	    break;
-	  }
-	}
+    }
+    if (!matched) {
+      for (unsigned isource = 0; isource < (*bottom_)->numberOfSourceCandidatePtrs(); ++isource) {
+        reco::CandidatePtr const& bottomSrcPtr = (*bottom_)->sourceCandidatePtr(isource);
+        bool bottomSrcGood = bottomSrcPtr.isNonnull() && bottomSrcPtr.isAvailable();
+        if ((topFwdGood && bottomSrcGood && bottomSrcPtr.refCore() == top.ptr().refCore() &&
+             bottomSrcPtr.key() == top.ptr().key()) ||
+            (topBckGood && bottomSrcGood && bottomSrcPtr.refCore() == top.backPtr().refCore() &&
+             bottomSrcPtr.key() == top.backPtr().key())) {
+          matched = true;
+          break;
+        }
       }
-
-      return matched;
-
     }
 
- protected :
-    BottomFwdPtr const * bottom_;
+    return matched;
+  }
 
+protected:
+  BottomFwdPtr const* bottom_;
 };
-
 
 /// This checks matching based on delta R
-template < class Top, class Bottom>
-  class TopProjectorDeltaROverlap {
+template <class Top, class Bottom>
+class TopProjectorDeltaROverlap {
+public:
+  typedef edm::FwdPtr<Top> TopFwdPtr;
+  typedef edm::FwdPtr<Bottom> BottomFwdPtr;
 
-  public:
-    typedef edm::FwdPtr<Top> TopFwdPtr;
-    typedef edm::FwdPtr<Bottom> BottomFwdPtr;
+  explicit TopProjectorDeltaROverlap() { bottom_ = 0; }
+  explicit TopProjectorDeltaROverlap(edm::ParameterSet const& config)
+      : deltaR2_(config.getParameter<double>("deltaR")),
+        bottom_(nullptr),
+        bottomCPtr_(nullptr),
+        botEta_(-999.f),
+        botPhi_(0.f) {
+    deltaR2_ *= deltaR2_;
+  }
 
-    explicit TopProjectorDeltaROverlap() {bottom_ = 0;}
-    explicit TopProjectorDeltaROverlap(edm::ParameterSet const & config ) :
-    deltaR2_( config.getParameter<double>("deltaR") ),
-      bottom_(nullptr),bottomCPtr_(nullptr),botEta_(-999.f),botPhi_(0.f)
-      {deltaR2_*=deltaR2_;}
+  inline void setBottom(BottomFwdPtr const& bottom) {
+    bottom_ = &bottom;
+    bottomCPtr_ = &**bottom_;
+    botEta_ = bottomCPtr_->eta();
+    botPhi_ = bottomCPtr_->phi();
+  }
 
+  bool operator()(TopFwdPtr const& top) const {
+    const Top& oTop = *top;
+    float topEta = oTop.eta();
+    float topPhi = oTop.phi();
+    bool matched = reco::deltaR2(topEta, topPhi, botEta_, botPhi_) < deltaR2_;
+    return matched;
+  }
 
-      inline void setBottom(BottomFwdPtr const & bottom ) {
-	bottom_ = &bottom; bottomCPtr_=&**bottom_;
-	botEta_ = bottomCPtr_->eta();
-	botPhi_ = bottomCPtr_->phi();
-      }
-
-    bool operator() ( TopFwdPtr const & top ) const{
-      const Top& oTop = *top; float topEta = oTop.eta(); float topPhi = oTop.phi();
-      bool matched = reco::deltaR2( topEta, topPhi, botEta_, botPhi_) < deltaR2_;
-      return matched;
-    }
-
- protected :
-    double deltaR2_;
-    BottomFwdPtr const * bottom_;
-    const Bottom* bottomCPtr_;
-    float botEta_,botPhi_;
+protected:
+  double deltaR2_;
+  BottomFwdPtr const* bottom_;
+  const Bottom* bottomCPtr_;
+  float botEta_, botPhi_;
 };
 
-template< class Top, class Bottom, class Matcher = TopProjectorFwdPtrOverlap<Top,Bottom> >
+template <class Top, class Bottom, class Matcher = TopProjectorFwdPtrOverlap<Top, Bottom> >
 class TopProjector : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   typedef std::vector<Top> TopCollection;
-  typedef edm::Handle< std::vector<Top> > TopHandle;
+  typedef edm::Handle<std::vector<Top> > TopHandle;
   typedef edm::FwdPtr<Top> TopFwdPtr;
   typedef std::vector<TopFwdPtr> TopFwdPtrCollection;
-  typedef edm::Handle< TopFwdPtrCollection > TopFwdPtrHandle;
+  typedef edm::Handle<TopFwdPtrCollection> TopFwdPtrHandle;
 
   typedef std::vector<Bottom> BottomCollection;
-  typedef edm::Handle< std::vector<Bottom> > BottomHandle;
+  typedef edm::Handle<std::vector<Bottom> > BottomHandle;
   typedef edm::Ptr<Bottom> BottomPtr;
   typedef edm::Ref<BottomCollection> BottomRef;
   typedef edm::FwdPtr<Bottom> BottomFwdPtr;
   typedef std::vector<BottomFwdPtr> BottomFwdPtrCollection;
-  typedef edm::Handle< BottomFwdPtrCollection > BottomFwdPtrHandle;
+  typedef edm::Handle<BottomFwdPtrCollection> BottomFwdPtrHandle;
 
   TopProjector(const edm::ParameterSet&);
 
-  ~TopProjector() override {};
-
+  ~TopProjector() override{};
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-
- private:
+private:
   /// Matching method.
-  Matcher         match_;
+  Matcher match_;
 
   /// enable? if not, all candidates in the bottom collection are copied to the output collection
-  bool            enable_;
+  bool enable_;
 
   /// name of the top projection
-  std::string     name_;
+  std::string name_;
 
   /// input tag for the top (masking) collection
-  edm::InputTag   inputTagTop_;
-  edm::EDGetTokenT<TopFwdPtrCollection>   tokenTop_;
+  edm::InputTag inputTagTop_;
+  edm::EDGetTokenT<TopFwdPtrCollection> tokenTop_;
 
   /// input tag for the masked collection.
-  edm::InputTag   inputTagBottom_;
-  edm::EDGetTokenT<BottomFwdPtrCollection>   tokenBottom_;
+  edm::InputTag inputTagBottom_;
+  edm::EDGetTokenT<BottomFwdPtrCollection> tokenBottom_;
 };
 
-
-
-
-template< class Top, class Bottom, class Matcher >
-TopProjector< Top, Bottom, Matcher>::TopProjector(const edm::ParameterSet& iConfig) :
-  match_(iConfig),
-  enable_(iConfig.getParameter<bool>("enable")) {
-  name_ = iConfig.getUntrackedParameter<std::string>("name","No Name");
+template <class Top, class Bottom, class Matcher>
+TopProjector<Top, Bottom, Matcher>::TopProjector(const edm::ParameterSet& iConfig)
+    : match_(iConfig), enable_(iConfig.getParameter<bool>("enable")) {
+  name_ = iConfig.getUntrackedParameter<std::string>("name", "No Name");
   inputTagTop_ = iConfig.getParameter<edm::InputTag>("topCollection");
   tokenTop_ = consumes<TopFwdPtrCollection>(inputTagTop_);
   inputTagBottom_ = iConfig.getParameter<edm::InputTag>("bottomCollection");
@@ -194,50 +189,43 @@ TopProjector< Top, Bottom, Matcher>::TopProjector(const edm::ParameterSet& iConf
 
   // will produce a collection of the unmasked candidates in the
   // bottom collection
-  produces< BottomFwdPtrCollection > ();
+  produces<BottomFwdPtrCollection>();
 }
 
-
-template< class Top, class Bottom, class Matcher >
-void TopProjector< Top, Bottom, Matcher >::produce( edm::Event& iEvent,
-                                                    const edm::EventSetup& iSetup) {
+template <class Top, class Bottom, class Matcher>
+void TopProjector<Top, Bottom, Matcher>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get the various collections
 
   // Access the masking collection
   TopFwdPtrHandle tops;
-  iEvent.getByToken(  tokenTop_, tops );
-  std::list<  TopFwdPtr > topsList;
+  iEvent.getByToken(tokenTop_, tops);
+  std::list<TopFwdPtr> topsList;
 
-  for ( typename TopFwdPtrCollection::const_iterator ibegin = tops->begin(),
-	  iend = tops->end(), i = ibegin; i != iend; ++i ) {
-    topsList.push_back( *i );
+  for (typename TopFwdPtrCollection::const_iterator ibegin = tops->begin(), iend = tops->end(), i = ibegin; i != iend;
+       ++i) {
+    topsList.push_back(*i);
   }
 
-
-/*   if( !tops.isValid() ) { */
-/*     std::ostringstream  err; */
-/*     err<<"The top collection must be supplied."<<std::endl */
-/*        <<"It is now set to : "<<inputTagTop_<<std::endl; */
-/*     edm::LogError("PFPAT")<<err.str(); */
-/*     throw cms::Exception( "MissingProduct", err.str()); */
-/*   } */
-
-
-
+  /*   if( !tops.isValid() ) { */
+  /*     std::ostringstream  err; */
+  /*     err<<"The top collection must be supplied."<<std::endl */
+  /*        <<"It is now set to : "<<inputTagTop_<<std::endl; */
+  /*     edm::LogError("PFPAT")<<err.str(); */
+  /*     throw cms::Exception( "MissingProduct", err.str()); */
+  /*   } */
 
   // Access the collection to
   // be masked by the other ones
   BottomFwdPtrHandle bottoms;
-  iEvent.getByToken(  tokenBottom_, bottoms );
+  iEvent.getByToken(tokenBottom_, bottoms);
 
-/*   if( !bottoms.isValid() ) { */
-/*     std::ostringstream  err; */
-/*     err<<"The bottom collection must be supplied."<<std::endl */
-/*        <<"It is now set to : "<<inputTagBottom_<<std::endl; */
-/*     edm::LogError("PFPAT")<<err.str(); */
-/*     throw cms::Exception( "MissingProduct", err.str()); */
-/*   } */
-
+  /*   if( !bottoms.isValid() ) { */
+  /*     std::ostringstream  err; */
+  /*     err<<"The bottom collection must be supplied."<<std::endl */
+  /*        <<"It is now set to : "<<inputTagBottom_<<std::endl; */
+  /*     edm::LogError("PFPAT")<<err.str(); */
+  /*     throw cms::Exception( "MissingProduct", err.str()); */
+  /*   } */
 
   /* if(verbose_) { */
   /*   const edm::Provenance& topProv = iEvent.getProvenance(tops.id()); */
@@ -254,7 +242,6 @@ void TopProjector< Top, Bottom, Matcher >::produce( edm::Event& iEvent,
   /*     edm::LogDebug("TopProjection") << "< " << i << " " << top.key() << " : " << *top << std::endl; */
   /*   } */
 
-
   /*   edm::LogDebug("TopProjection")<<"Bottom   :  " */
   /* 	     <<bottoms.id()<<"\t"<<bottoms->size()<<std::endl */
   /* 	     <<bottomProv.branchDescription()<<std::endl; */
@@ -266,39 +253,36 @@ void TopProjector< Top, Bottom, Matcher >::produce( edm::Event& iEvent,
 
   /* } */
 
-
   // output collection of FwdPtrs to objects,
   // selected from the Bottom collection
-  std::unique_ptr< BottomFwdPtrCollection >
-    pBottomFwdPtrOutput( new BottomFwdPtrCollection );
+  std::unique_ptr<BottomFwdPtrCollection> pBottomFwdPtrOutput(new BottomFwdPtrCollection);
 
-  LogDebug("TopProjection")<<" Remaining candidates in the bottom collection ------ ";
+  LogDebug("TopProjection") << " Remaining candidates in the bottom collection ------ ";
 
-  for(typename BottomFwdPtrCollection::const_iterator i=bottoms->begin(),
-	iend = bottoms->end(), ibegin = i; i != iend; ++i) {
-
-    BottomFwdPtr const & bottom = *i;
+  for (typename BottomFwdPtrCollection::const_iterator i = bottoms->begin(), iend = bottoms->end(), ibegin = i;
+       i != iend;
+       ++i) {
+    BottomFwdPtr const& bottom = *i;
     match_.setBottom(bottom);
-    typename std::list< TopFwdPtr >::iterator found = topsList.end();
-    if ( enable_ ) {
-      found = std::find_if( topsList.begin(), topsList.end(), match_ );
+    typename std::list<TopFwdPtr>::iterator found = topsList.end();
+    if (enable_) {
+      found = std::find_if(topsList.begin(), topsList.end(), match_);
     }
 
     // If this is masked in the top projection, we remove it.
-    if( found != topsList.end() ) {
-      LogDebug("TopProjection")<<"X "<<i-ibegin << **i;
+    if (found != topsList.end()) {
+      LogDebug("TopProjection") << "X " << i - ibegin << **i;
       topsList.erase(found);
       continue;
     }
     // otherwise, we keep it.
     else {
-      LogDebug("TopProjection")<<"O "<<i-ibegin << **i;
-      pBottomFwdPtrOutput->push_back( bottom );
+      LogDebug("TopProjection") << "O " << i - ibegin << **i;
+      pBottomFwdPtrOutput->push_back(bottom);
     }
   }
 
   iEvent.put(std::move(pBottomFwdPtrOutput));
 }
-
 
 #endif

--- a/CommonTools/ParticleFlow/plugins/Type1PFMET.cc
+++ b/CommonTools/ParticleFlow/plugins/Type1PFMET.cc
@@ -11,46 +11,47 @@
 using namespace reco;
 
 // PRODUCER CONSTRUCTORS ------------------------------------------
-Type1PFMET::Type1PFMET( const edm::ParameterSet& iConfig )
-{
-  tokenUncorMet  = consumes<METCollection>(iConfig.getParameter<edm::InputTag>("inputUncorMetLabel"));
+Type1PFMET::Type1PFMET(const edm::ParameterSet& iConfig) {
+  tokenUncorMet = consumes<METCollection>(iConfig.getParameter<edm::InputTag>("inputUncorMetLabel"));
   tokenUncorJets = consumes<PFJetCollection>(iConfig.getParameter<edm::InputTag>("inputUncorJetsTag"));
   correctorToken = consumes<JetCorrector>(iConfig.getParameter<edm::InputTag>("corrector"));
-  jetPTthreshold      = iConfig.getParameter<double>("jetPTthreshold");
-  jetEMfracLimit      = iConfig.getParameter<double>("jetEMfracLimit");
-  jetMufracLimit      = iConfig.getParameter<double>("jetMufracLimit");
+  jetPTthreshold = iConfig.getParameter<double>("jetPTthreshold");
+  jetEMfracLimit = iConfig.getParameter<double>("jetEMfracLimit");
+  jetMufracLimit = iConfig.getParameter<double>("jetMufracLimit");
   produces<METCollection>();
 }
-Type1PFMET::Type1PFMET()  {}
+Type1PFMET::Type1PFMET() {}
 
 // PRODUCER DESTRUCTORS -------------------------------------------
 Type1PFMET::~Type1PFMET() {}
 
 // PRODUCER METHODS -----------------------------------------------
-  void Type1PFMET::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void Type1PFMET::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   Handle<PFJetCollection> inputUncorJets;
-  iEvent.getByToken( tokenUncorJets, inputUncorJets );
+  iEvent.getByToken(tokenUncorJets, inputUncorJets);
   Handle<JetCorrector> corrector;
-  iEvent.getByToken( correctorToken, corrector );
-  Handle<METCollection> inputUncorMet;                     //Define Inputs
-  iEvent.getByToken( tokenUncorMet,  inputUncorMet );     //Get Inputs
-  std::unique_ptr<METCollection> output( new METCollection() );  //Create empty output
-  run( *(inputUncorMet.product()), *(corrector.product()), *(inputUncorJets.product()),
-       jetPTthreshold, jetEMfracLimit, jetMufracLimit,
-       &*output );                                         //Invoke the algorithm
-  iEvent.put(std::move(output));                                        //Put output into Event
+  iEvent.getByToken(correctorToken, corrector);
+  Handle<METCollection> inputUncorMet;                         //Define Inputs
+  iEvent.getByToken(tokenUncorMet, inputUncorMet);             //Get Inputs
+  std::unique_ptr<METCollection> output(new METCollection());  //Create empty output
+  run(*(inputUncorMet.product()),
+      *(corrector.product()),
+      *(inputUncorJets.product()),
+      jetPTthreshold,
+      jetEMfracLimit,
+      jetMufracLimit,
+      &*output);                  //Invoke the algorithm
+  iEvent.put(std::move(output));  //Put output into Event
 }
 
 void Type1PFMET::run(const METCollection& uncorMET,
-		     const reco::JetCorrector& corrector,
-		     const PFJetCollection& uncorJet,
-		     double jetPTthreshold,
-		     double jetEMfracLimit,
-		     double jetMufracLimit,
-		     METCollection* corMET)
-{
+                     const reco::JetCorrector& corrector,
+                     const PFJetCollection& uncorJet,
+                     double jetPTthreshold,
+                     double jetEMfracLimit,
+                     double jetMufracLimit,
+                     METCollection* corMET) {
   if (!corMET) {
     std::cerr << "Type1METAlgo_run-> undefined output MET collection. Stop. " << std::endl;
     return;
@@ -62,45 +63,36 @@ void Type1PFMET::run(const METCollection& uncorMET,
   // ---------------- Calculate jet corrections, but only for those uncorrected jets
   // ---------------- which are above the given threshold.  This requires that the
   // ---------------- uncorrected jets be matched with the corrected jets.
-  for( PFJetCollection::const_iterator jet = uncorJet.begin(); jet != uncorJet.end(); ++jet) {
-    if( jet->pt() > jetPTthreshold ) {
-      double emEFrac =
-	jet->chargedEmEnergyFraction() + jet->neutralEmEnergyFraction();
+  for (PFJetCollection::const_iterator jet = uncorJet.begin(); jet != uncorJet.end(); ++jet) {
+    if (jet->pt() > jetPTthreshold) {
+      double emEFrac = jet->chargedEmEnergyFraction() + jet->neutralEmEnergyFraction();
       double muEFrac = jet->chargedMuEnergyFraction();
-      if( emEFrac < jetEMfracLimit
-	  && muEFrac < jetMufracLimit ) {
-	double corr = corrector.correction (*jet) - 1.; // correction itself
-	DeltaPx +=  jet->px() * corr;
-	DeltaPy +=  jet->py() * corr;
-	DeltaSumET += jet->et() * corr;
+      if (emEFrac < jetEMfracLimit && muEFrac < jetMufracLimit) {
+        double corr = corrector.correction(*jet) - 1.;  // correction itself
+        DeltaPx += jet->px() * corr;
+        DeltaPy += jet->py() * corr;
+        DeltaSumET += jet->et() * corr;
       }
     }
   }
   //----------------- Calculate and set deltas for new MET correction
   CorrMETData delta;
-  delta.mex   =  - DeltaPx;    //correction to MET (from Jets) is negative,
-  delta.mey   =  - DeltaPy;    //since MET points in direction opposite of jets
-  delta.sumet =  DeltaSumET;
+  delta.mex = -DeltaPx;  //correction to MET (from Jets) is negative,
+  delta.mey = -DeltaPy;  //since MET points in direction opposite of jets
+  delta.sumet = DeltaSumET;
   //----------------- Fill holder with corrected MET (= uncorrected + delta) values
   const MET* u = &(uncorMET.front());
-  double corrMetPx = u->px()+delta.mex;
-  double corrMetPy = u->py()+delta.mey;
-  MET::LorentzVector correctedMET4vector( corrMetPx, corrMetPy, 0.,
-					  sqrt (corrMetPx*corrMetPx + corrMetPy*corrMetPy)
-					  );
+  double corrMetPx = u->px() + delta.mex;
+  double corrMetPy = u->py() + delta.mey;
+  MET::LorentzVector correctedMET4vector(corrMetPx, corrMetPy, 0., sqrt(corrMetPx * corrMetPx + corrMetPy * corrMetPy));
   //----------------- get previous corrections and push into new corrections
   std::vector<CorrMETData> corrections = u->mEtCorr();
-  corrections.push_back( delta );
+  corrections.push_back(delta);
   //----------------- Push onto MET Collection
-  MET result = MET(u->sumEt()+delta.sumet,
-		   corrections,
-		   correctedMET4vector,
-		   u->vertex() );
+  MET result = MET(u->sumEt() + delta.sumet, corrections, correctedMET4vector, u->vertex());
   corMET->push_back(result);
 
   return;
 }
 
 //  DEFINE_FWK_MODULE(Type1PFMET);  //define this as a plug-in
-
-

--- a/CommonTools/ParticleFlow/plugins/Type1PFMET.h
+++ b/CommonTools/ParticleFlow/plugins/Type1PFMET.h
@@ -25,17 +25,15 @@
 #include "DataFormats/METReco/interface/METFwd.h"
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 
-
-
 // PRODUCER CLASS DEFINITION -------------------------------------
-class Type1PFMET : public edm::EDProducer
-{
- public:
-  explicit Type1PFMET( const edm::ParameterSet& );
+class Type1PFMET : public edm::EDProducer {
+public:
+  explicit Type1PFMET(const edm::ParameterSet&);
   explicit Type1PFMET();
   ~Type1PFMET() override;
-  void produce( edm::Event&, const edm::EventSetup& ) override;
- private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
   edm::EDGetTokenT<reco::METCollection> tokenUncorMet;
   edm::EDGetTokenT<reco::PFJetCollection> tokenUncorJets;
   edm::EDGetTokenT<reco::JetCorrector> correctorToken;
@@ -43,12 +41,12 @@ class Type1PFMET : public edm::EDProducer
   double jetEMfracLimit;
   double jetMufracLimit;
   void run(const reco::METCollection& uncorMET,
-	   const reco::JetCorrector& corrector,
-	   const reco::PFJetCollection& uncorJet,
-	   double jetPTthreshold,
-	   double jetEMfracLimit,
-	   double jetMufracLimit,
-	   reco::METCollection* corMET);
+           const reco::JetCorrector& corrector,
+           const reco::PFJetCollection& uncorJet,
+           double jetPTthreshold,
+           double jetEMfracLimit,
+           double jetMufracLimit,
+           reco::METCollection* corMET);
 };
 
 #endif

--- a/CommonTools/ParticleFlow/src/EventHypothesis.cc
+++ b/CommonTools/ParticleFlow/src/EventHypothesis.cc
@@ -2,11 +2,6 @@
 
 #include <iostream>
 
-using pf2pat::EventHypothesis; 
+using pf2pat::EventHypothesis;
 
-
-EventHypothesis::EventHypothesis( const edm::ParameterSet& ps) {
-  
-  std::cout<<ps.dump()<<std::endl;
-}
-
+EventHypothesis::EventHypothesis(const edm::ParameterSet& ps) { std::cout << ps.dump() << std::endl; }

--- a/CommonTools/ParticleFlow/src/PFIsoDepositAlgo.cc
+++ b/CommonTools/ParticleFlow/src/PFIsoDepositAlgo.cc
@@ -6,69 +6,55 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace reco;
 using namespace math;
 using namespace pf2pat;
 
-PFIsoDepositAlgo::PFIsoDepositAlgo(const edm::ParameterSet& iConfig): 
-  verbose_ ( iConfig.getUntrackedParameter<bool>("verbose",false) )
+PFIsoDepositAlgo::PFIsoDepositAlgo(const edm::ParameterSet& iConfig)
+    : verbose_(iConfig.getUntrackedParameter<bool>("verbose", false))
 
 {}
 
+PFIsoDepositAlgo::~PFIsoDepositAlgo() {}
 
-
-PFIsoDepositAlgo::~PFIsoDepositAlgo() { }
-
-
-const PFIsoDepositAlgo::IsoDeposits&  
-PFIsoDepositAlgo::produce( const ParticleCollection& toBeIsolated,
-			   const ParticleCollection& forIsolation) {
-  
-
+const PFIsoDepositAlgo::IsoDeposits& PFIsoDepositAlgo::produce(const ParticleCollection& toBeIsolated,
+                                                               const ParticleCollection& forIsolation) {
   isoDeposits_.clear();
-  isoDeposits_.reserve( toBeIsolated.size() );
+  isoDeposits_.reserve(toBeIsolated.size());
 
-  for( unsigned i=0; i<toBeIsolated.size(); i++ ) {
+  for (unsigned i = 0; i < toBeIsolated.size(); i++) {
     const reco::PFCandidate& toBeIso = toBeIsolated[i];
 
-    if(verbose_ ) 
-      cout<<"to be isolated: "<<toBeIso<<endl;
+    if (verbose_)
+      cout << "to be isolated: " << toBeIso << endl;
 
-    isoDeposits_.push_back( buildIsoDeposit( toBeIso, forIsolation ) ); 
+    isoDeposits_.push_back(buildIsoDeposit(toBeIso, forIsolation));
   }
-  
 
-  if(verbose_) {
-    cout<<"PFIsoDepositAlgo "<<endl;
+  if (verbose_) {
+    cout << "PFIsoDepositAlgo " << endl;
   }
 
   return isoDeposits_;
 }
 
+IsoDeposit PFIsoDepositAlgo::buildIsoDeposit(const Particle& particle, const ParticleCollection& forIsolation) const {
+  reco::isodeposit::Direction pfDir(particle.eta(), particle.phi());
+  //   reco::IsoDeposit::Veto veto;
+  //   veto.vetoDir = pfDir;
+  //   veto.dR = 0.05;
 
-IsoDeposit PFIsoDepositAlgo::buildIsoDeposit( const Particle& particle, 
-					      const ParticleCollection& forIsolation ) const {
-  
+  IsoDeposit isoDep(pfDir);
 
-  reco::isodeposit::Direction pfDir(particle.eta(), 
-				    particle.phi());
-//   reco::IsoDeposit::Veto veto;
-//   veto.vetoDir = pfDir;
-//   veto.dR = 0.05; 
-
-  IsoDeposit isoDep( pfDir );
-  
-  for( unsigned i=0; i<forIsolation.size(); i++ ) {
-    
+  for (unsigned i = 0; i < forIsolation.size(); i++) {
     const reco::PFCandidate& pfc = forIsolation[i];
 
     // need to remove "particle"!
 
-    if( sameParticle( particle, pfc ) ) continue; 
-
+    if (sameParticle(particle, pfc))
+      continue;
 
     const XYZTLorentzVector& pvi(pfc.p4());
     reco::isodeposit::Direction dirPfc(pfc.eta(), pfc.phi());
@@ -76,32 +62,33 @@ IsoDeposit PFIsoDepositAlgo::buildIsoDeposit( const Particle& particle,
 
     //COLIN make a parameter
     double maxDeltaRForIsoDep_ = 1;
-    if(dR > maxDeltaRForIsoDep_) {
+    if (dR > maxDeltaRForIsoDep_) {
       //      if( verbose_ ) cout<<"OUT OF CONE"<<endl;
       continue;
     }
     //    else if(verbose_) cout<<endl;
 
-    if(verbose_ ) 
-      cout<<"\t"<<pfc<<endl;
+    if (verbose_)
+      cout << "\t" << pfc << endl;
 
     double pt = pvi.Pt();
-    isoDep.addDeposit(dirPfc, pt); 
+    isoDep.addDeposit(dirPfc, pt);
   }
 
   return isoDep;
 }
 
-
-bool PFIsoDepositAlgo::sameParticle( const Particle& particle1,
-				     const Particle& particle2 ) const {
-
+bool PFIsoDepositAlgo::sameParticle(const Particle& particle1, const Particle& particle2) const {
   double smallNumber = 1e-15;
-  
-  if( particle1.particleId() != particle2.particleId() ) return false;
-  else if( fabs( particle1.energy() - particle2.energy() ) > smallNumber ) return false;
-  else if( fabs( particle1.eta() - particle2.eta() ) > smallNumber ) return false;
-  else if( fabs( particle1.eta() - particle2.eta() ) > smallNumber ) return false;
-  else return true; 
-  
+
+  if (particle1.particleId() != particle2.particleId())
+    return false;
+  else if (fabs(particle1.energy() - particle2.energy()) > smallNumber)
+    return false;
+  else if (fabs(particle1.eta() - particle2.eta()) > smallNumber)
+    return false;
+  else if (fabs(particle1.eta() - particle2.eta()) > smallNumber)
+    return false;
+  else
+    return true;
 }

--- a/CommonTools/ParticleFlow/src/PFMETAlgo.cc
+++ b/CommonTools/ParticleFlow/src/PFMETAlgo.cc
@@ -8,7 +8,6 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace reco;
@@ -16,35 +15,25 @@ using namespace math;
 using namespace pf2pat;
 
 PFMETAlgo::PFMETAlgo(const edm::ParameterSet& iConfig) {
-  
+  verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 
-  verbose_ = 
-    iConfig.getUntrackedParameter<bool>("verbose",false);
-
-  hfCalibFactor_ = 
-    iConfig.getParameter<double>("hfCalibFactor");
-
+  hfCalibFactor_ = iConfig.getParameter<double>("hfCalibFactor");
 }
 
+PFMETAlgo::~PFMETAlgo() {}
 
-
-PFMETAlgo::~PFMETAlgo() { }
-
-reco::MET  PFMETAlgo::produce( const reco::PFCandidateCollection& pfCandidates) {
-  
+reco::MET PFMETAlgo::produce(const reco::PFCandidateCollection& pfCandidates) {
   double sumEx = 0;
   double sumEy = 0;
   double sumEt = 0;
 
-  for( unsigned i=0; i<pfCandidates.size(); i++ ) {
-
+  for (unsigned i = 0; i < pfCandidates.size(); i++) {
     const reco::PFCandidate& cand = pfCandidates[i];
-    
+
     double E = cand.energy();
 
     /// HF calibration factor (in 31X applied by PFProducer)
-    if( cand.particleId()==PFCandidate::h_HF || 
-	cand.particleId()==PFCandidate::egamma_HF ) 
+    if (cand.particleId() == PFCandidate::h_HF || cand.particleId() == PFCandidate::egamma_HF)
       E *= hfCalibFactor_;
 
     double phi = cand.phi();
@@ -53,30 +42,23 @@ reco::MET  PFMETAlgo::produce( const reco::PFCandidateCollection& pfCandidates) 
 
     double theta = cand.theta();
     double sintheta = sin(theta);
-    
-    double et = E*sintheta;
-    double ex = et*cosphi;
-    double ey = et*sinphi;
-    
+
+    double et = E * sintheta;
+    double ex = et * cosphi;
+    double ey = et * sinphi;
+
     sumEx += ex;
     sumEy += ey;
     sumEt += et;
   }
-  
-  double Et = sqrt( sumEx*sumEx + sumEy*sumEy);
-  XYZTLorentzVector missingEt( -sumEx, -sumEy, 0, Et);
-  
-  if(verbose_) {
-    cout<<"PFMETAlgo: mEx, mEy, mEt = "
-	<< missingEt.X() <<", "
-	<< missingEt.Y() <<", "
-	<< missingEt.T() <<endl;
+
+  double Et = sqrt(sumEx * sumEx + sumEy * sumEy);
+  XYZTLorentzVector missingEt(-sumEx, -sumEy, 0, Et);
+
+  if (verbose_) {
+    cout << "PFMETAlgo: mEx, mEy, mEt = " << missingEt.X() << ", " << missingEt.Y() << ", " << missingEt.T() << endl;
   }
 
-  XYZPoint vertex; // dummy vertex
+  XYZPoint vertex;  // dummy vertex
   return MET(sumEt, missingEt, vertex);
-
- 
 }
-
-

--- a/CommonTools/ParticleFlow/src/PFPileUpAlgo.cc
+++ b/CommonTools/ParticleFlow/src/PFPileUpAlgo.cc
@@ -2,92 +2,80 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-void PFPileUpAlgo::process(const PFCollection & pfCandidates, 
-			   const reco::VertexCollection & vertices)  {
-
+void PFPileUpAlgo::process(const PFCollection& pfCandidates, const reco::VertexCollection& vertices) {
   pfCandidatesFromVtx_.clear();
   pfCandidatesFromPU_.clear();
 
-  for( unsigned i=0; i<pfCandidates.size(); i++ ) {
-    
-    const reco::PFCandidate& cand = * ( pfCandidates[i] );
-    
+  for (unsigned i = 0; i < pfCandidates.size(); i++) {
+    const reco::PFCandidate& cand = *(pfCandidates[i]);
+
     int ivertex;
 
-    switch( cand.particleId() ) {
-    case reco::PFCandidate::h:
-      ivertex = chargedHadronVertex( vertices, cand );
-      break;
-    default:
-      continue;
-    } 
-    
+    switch (cand.particleId()) {
+      case reco::PFCandidate::h:
+        ivertex = chargedHadronVertex(vertices, cand);
+        break;
+      default:
+        continue;
+    }
+
     // no associated vertex, or primary vertex
     // not pile-up
-    if( ivertex == -1  || 
-	ivertex == 0 ) {
-      if(verbose_)
-	std::cout<<"VTX "<<i<<" "<< *(pfCandidates[i])<<std::endl;
-      pfCandidatesFromVtx_.push_back( pfCandidates[i] );
+    if (ivertex == -1 || ivertex == 0) {
+      if (verbose_)
+        std::cout << "VTX " << i << " " << *(pfCandidates[i]) << std::endl;
+      pfCandidatesFromVtx_.push_back(pfCandidates[i]);
     } else {
-      if(verbose_)
-	std::cout<<"PU  "<<i<<" "<< *(pfCandidates[i])<<std::endl;
+      if (verbose_)
+        std::cout << "PU  " << i << " " << *(pfCandidates[i]) << std::endl;
       // associated to a vertex
-      pfCandidatesFromPU_.push_back( pfCandidates[i] );
+      pfCandidatesFromPU_.push_back(pfCandidates[i]);
     }
   }
 }
 
-
-int 
-PFPileUpAlgo::chargedHadronVertex( const reco::VertexCollection& vertices, const reco::PFCandidate& pfcand ) const {
-
-  auto const & track = pfcand.trackRef();  
-  size_t  iVertex = 0;
-  unsigned int index=0;
+int PFPileUpAlgo::chargedHadronVertex(const reco::VertexCollection& vertices, const reco::PFCandidate& pfcand) const {
+  auto const& track = pfcand.trackRef();
+  size_t iVertex = 0;
+  unsigned int index = 0;
   unsigned int nFoundVertex = 0;
-  float bestweight=0;
-  for( auto const & vtx : vertices) {
-      float w = vtx.trackWeight(track);
-     //select the vertex for which the track has the highest weight
- 	if (w > bestweight){
-	  bestweight=w;
-	  iVertex=index;
-	  nFoundVertex++;
-	}
-     ++index;
+  float bestweight = 0;
+  for (auto const& vtx : vertices) {
+    float w = vtx.trackWeight(track);
+    //select the vertex for which the track has the highest weight
+    if (w > bestweight) {
+      bestweight = w;
+      iVertex = index;
+      nFoundVertex++;
+    }
+    ++index;
   }
 
-  if (nFoundVertex>0){
-    if (nFoundVertex!=1)
-      edm::LogWarning("TrackOnTwoVertex")<<"a track is shared by at least two verteces. Used to be an assert";
+  if (nFoundVertex > 0) {
+    if (nFoundVertex != 1)
+      edm::LogWarning("TrackOnTwoVertex") << "a track is shared by at least two verteces. Used to be an assert";
     return iVertex;
   }
-  // no vertex found with this track. 
+  // no vertex found with this track.
 
   // optional: as a secondary solution, associate the closest vertex in z
-  if ( checkClosestZVertex_ ) {
-
+  if (checkClosestZVertex_) {
     double dzmin = 10000;
     double ztrack = pfcand.vertex().z();
     bool foundVertex = false;
     index = 0;
-    for(auto iv=vertices.begin(); iv!=vertices.end(); ++iv, ++index) {
-
+    for (auto iv = vertices.begin(); iv != vertices.end(); ++iv, ++index) {
       double dz = fabs(ztrack - iv->z());
-      if(dz<dzmin) {
-	dzmin = dz; 
-	iVertex = index;
-	foundVertex = true;
+      if (dz < dzmin) {
+        dzmin = dz;
+        iVertex = index;
+        foundVertex = true;
       }
     }
 
-    if( foundVertex ) 
-      return iVertex;  
-
+    if (foundVertex)
+      return iVertex;
   }
 
-
-  return -1 ;
+  return -1;
 }
-

--- a/CommonTools/ParticleFlow/test/PFIsoReaderDemo.cc
+++ b/CommonTools/ParticleFlow/test/PFIsoReaderDemo.cc
@@ -12,180 +12,180 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
-PFIsoReaderDemo::PFIsoReaderDemo(const edm::ParameterSet& iConfig)
-{
+PFIsoReaderDemo::PFIsoReaderDemo(const edm::ParameterSet& iConfig) {
   inputTagGsfElectrons_ = iConfig.getParameter<edm::InputTag>("Electrons");
   tokenGsfElectrons_ = consumes<reco::GsfElectronCollection>(inputTagGsfElectrons_);
   inputTagPhotons_ = iConfig.getParameter<edm::InputTag>("Photons");
   tokenPhotons_ = consumes<reco::PhotonCollection>(inputTagPhotons_);
 
-//   // not needed at the moment
-//   inputTagPFCandidateMap_ = iConfig.getParameter< edm::InputTag>("PFCandidateMap");
+  //   // not needed at the moment
+  //   inputTagPFCandidateMap_ = iConfig.getParameter< edm::InputTag>("PFCandidateMap");
 
-//   inputTagIsoDepElectrons_ = iConfig.getParameter< std::vector<edm::InputTag> >("IsoDepElectron");
-  tokensIsoDepElectrons_ = edm::vector_transform(iConfig.getParameter< std::vector<edm::InputTag> >("IsoDepElectron"), [this](edm::InputTag const & tag){return consumes<edm::ValueMap<reco::IsoDeposit> >(tag);});
-//   inputTagIsoDepPhotons_ = iConfig.getParameter< std::vector<edm::InputTag> >("IsoDepPhoton");
-  tokensIsoDepPhotons_ = edm::vector_transform(iConfig.getParameter< std::vector<edm::InputTag> >("IsoDepPhoton"), [this](edm::InputTag const & tag){return consumes<edm::ValueMap<reco::IsoDeposit> >(tag);});
+  //   inputTagIsoDepElectrons_ = iConfig.getParameter< std::vector<edm::InputTag> >("IsoDepElectron");
+  tokensIsoDepElectrons_ = edm::vector_transform(
+      iConfig.getParameter<std::vector<edm::InputTag> >("IsoDepElectron"),
+      [this](edm::InputTag const& tag) { return consumes<edm::ValueMap<reco::IsoDeposit> >(tag); });
+  //   inputTagIsoDepPhotons_ = iConfig.getParameter< std::vector<edm::InputTag> >("IsoDepPhoton");
+  tokensIsoDepPhotons_ = edm::vector_transform(
+      iConfig.getParameter<std::vector<edm::InputTag> >("IsoDepPhoton"),
+      [this](edm::InputTag const& tag) { return consumes<edm::ValueMap<reco::IsoDeposit> >(tag); });
   // No longer needed. e/g recommendation (04/04/12)
   //  inputTagIsoValElectronsNoPFId_ = iConfig.getParameter< std::vector<edm::InputTag> >("IsoValElectronNoPF");
-//   inputTagIsoValElectronsPFId_   = iConfig.getParameter< std::vector<edm::InputTag> >("IsoValElectronPF");
-  tokensIsoValElectronsPFId_ = edm::vector_transform(iConfig.getParameter< std::vector<edm::InputTag> >("IsoValElectronPF"), [this](edm::InputTag const & tag){return consumes<edm::ValueMap<double> >(tag);});
-//   inputTagIsoValPhotonsPFId_   = iConfig.getParameter< std::vector<edm::InputTag> >("IsoValPhoton");
-  tokensIsoValPhotonsPFId_ = edm::vector_transform(iConfig.getParameter< std::vector<edm::InputTag> >("IsoValPhoton"), [this](edm::InputTag const & tag){return consumes<edm::ValueMap<double> >(tag);});
+  //   inputTagIsoValElectronsPFId_   = iConfig.getParameter< std::vector<edm::InputTag> >("IsoValElectronPF");
+  tokensIsoValElectronsPFId_ =
+      edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >("IsoValElectronPF"),
+                            [this](edm::InputTag const& tag) { return consumes<edm::ValueMap<double> >(tag); });
+  //   inputTagIsoValPhotonsPFId_   = iConfig.getParameter< std::vector<edm::InputTag> >("IsoValPhoton");
+  tokensIsoValPhotonsPFId_ =
+      edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >("IsoValPhoton"),
+                            [this](edm::InputTag const& tag) { return consumes<edm::ValueMap<double> >(tag); });
 
   printElectrons_ = iConfig.getParameter<bool>("PrintElectrons");
   printPhotons_ = iConfig.getParameter<bool>("PrintPhotons");
 
   // Control plots
   TFileDirectory dir = fileservice_->mkdir("PF ISO");
-  chargedBarrelElectrons_    = dir.make<TH1F>("chargedBarrelElectrons",";Sum pT/pT" ,100,0,4);
-  photonBarrelElectrons_     = dir.make<TH1F>("photonBarrelElectrons",";Sum pT/pT", 100,0,4);
-  neutralBarrelElectrons_    = dir.make<TH1F>("neutralBarrelElectrons",";Sum pT/pT", 100,0,4);
+  chargedBarrelElectrons_ = dir.make<TH1F>("chargedBarrelElectrons", ";Sum pT/pT", 100, 0, 4);
+  photonBarrelElectrons_ = dir.make<TH1F>("photonBarrelElectrons", ";Sum pT/pT", 100, 0, 4);
+  neutralBarrelElectrons_ = dir.make<TH1F>("neutralBarrelElectrons", ";Sum pT/pT", 100, 0, 4);
 
-  chargedEndcapsElectrons_   = dir.make<TH1F>("chargedEndcapsElectrons",";Sum pT/pT",100,0,4);
-  photonEndcapsElectrons_    = dir.make<TH1F>("photonEndcapsElectrons",";Sum pT/pT",100,0,4);
-  neutralEndcapsElectrons_   = dir.make<TH1F>("neutralEndcapsElectrons",";Sum pT/pT",100,0,4);
+  chargedEndcapsElectrons_ = dir.make<TH1F>("chargedEndcapsElectrons", ";Sum pT/pT", 100, 0, 4);
+  photonEndcapsElectrons_ = dir.make<TH1F>("photonEndcapsElectrons", ";Sum pT/pT", 100, 0, 4);
+  neutralEndcapsElectrons_ = dir.make<TH1F>("neutralEndcapsElectrons", ";Sum pT/pT", 100, 0, 4);
 
-  sumBarrelElectrons_        = dir.make<TH1F>("allbarrelElectrons",";Sum pT/pT",100,0,4);
-  sumEndcapsElectrons_       = dir.make<TH1F>("allendcapsElectrons",";Sum pT/pT",100,0,4);
+  sumBarrelElectrons_ = dir.make<TH1F>("allbarrelElectrons", ";Sum pT/pT", 100, 0, 4);
+  sumEndcapsElectrons_ = dir.make<TH1F>("allendcapsElectrons", ";Sum pT/pT", 100, 0, 4);
 
-  chargedBarrelPhotons_    = dir.make<TH1F>("chargedBarrelPhotons",";Sum pT/pT" ,100,0,4);
-  photonBarrelPhotons_     = dir.make<TH1F>("photonBarrelPhotons",";Sum pT/pT", 100,0,4);
-  neutralBarrelPhotons_    = dir.make<TH1F>("neutralBarrelPhotons",";Sum pT/pT", 100,0,4);
+  chargedBarrelPhotons_ = dir.make<TH1F>("chargedBarrelPhotons", ";Sum pT/pT", 100, 0, 4);
+  photonBarrelPhotons_ = dir.make<TH1F>("photonBarrelPhotons", ";Sum pT/pT", 100, 0, 4);
+  neutralBarrelPhotons_ = dir.make<TH1F>("neutralBarrelPhotons", ";Sum pT/pT", 100, 0, 4);
 
-  chargedEndcapsPhotons_   = dir.make<TH1F>("chargedEndcapsPhotons",";Sum pT/pT",100,0,4);
-  photonEndcapsPhotons_    = dir.make<TH1F>("photonEndcapsPhotons",";Sum pT/pT",100,0,4);
-  neutralEndcapsPhotons_   = dir.make<TH1F>("neutralEndcapsPhotons",";Sum pT/pT",100,0,4);
+  chargedEndcapsPhotons_ = dir.make<TH1F>("chargedEndcapsPhotons", ";Sum pT/pT", 100, 0, 4);
+  photonEndcapsPhotons_ = dir.make<TH1F>("photonEndcapsPhotons", ";Sum pT/pT", 100, 0, 4);
+  neutralEndcapsPhotons_ = dir.make<TH1F>("neutralEndcapsPhotons", ";Sum pT/pT", 100, 0, 4);
 
-  sumBarrelPhotons_        = dir.make<TH1F>("allbarrelPhotons",";Sum pT/pT",100,0,4);
-  sumEndcapsPhotons_       = dir.make<TH1F>("allendcapsPhotons",";Sum pT/pT",100,0,4);
-
+  sumBarrelPhotons_ = dir.make<TH1F>("allbarrelPhotons", ";Sum pT/pT", 100, 0, 4);
+  sumEndcapsPhotons_ = dir.make<TH1F>("allendcapsPhotons", ";Sum pT/pT", 100, 0, 4);
 }
 
-PFIsoReaderDemo::~PFIsoReaderDemo(){;}
+PFIsoReaderDemo::~PFIsoReaderDemo() { ; }
 
-void
-PFIsoReaderDemo::beginRun(edm::Run const&, edm::EventSetup const& ){;}
+void PFIsoReaderDemo::beginRun(edm::Run const&, edm::EventSetup const&) { ; }
 
-void PFIsoReaderDemo::analyze(const edm::Event & iEvent,const edm::EventSetup & c)
-{
+void PFIsoReaderDemo::analyze(const edm::Event& iEvent, const edm::EventSetup& c) {
   edm::Handle<reco::GsfElectronCollection> gsfElectronH;
-  bool found = iEvent.getByToken(tokenGsfElectrons_,gsfElectronH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get GsfElectrons: "
-       <<inputTagGsfElectrons_<<std::endl;
-    edm::LogError("PFIsoReaderDemo")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
+  bool found = iEvent.getByToken(tokenGsfElectrons_, gsfElectronH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get GsfElectrons: " << inputTagGsfElectrons_ << std::endl;
+    edm::LogError("PFIsoReaderDemo") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
   }
 
   edm::Handle<reco::PhotonCollection> photonH;
-  found = iEvent.getByToken(tokenPhotons_,photonH);
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get Photons: "
-       <<inputTagPhotons_<<std::endl;
-    edm::LogError("PFIsoReaderDemo")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
+  found = iEvent.getByToken(tokenPhotons_, photonH);
+  if (!found) {
+    std::ostringstream err;
+    err << " cannot get Photons: " << inputTagPhotons_ << std::endl;
+    edm::LogError("PFIsoReaderDemo") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
   }
 
-
   // get the iso deposits. 3 (charged hadrons, photons, neutral hadrons)
-  unsigned nTypes=3;
+  unsigned nTypes = 3;
   IsoDepositMaps electronIsoDep(nTypes);
 
-  for (size_t j = 0; j<tokensIsoDepElectrons_.size(); ++j) {
+  for (size_t j = 0; j < tokensIsoDepElectrons_.size(); ++j) {
     iEvent.getByToken(tokensIsoDepElectrons_[j], electronIsoDep[j]);
   }
 
-
   IsoDepositMaps photonIsoDep(nTypes);
-  for (size_t j = 0; j<tokensIsoDepPhotons_.size(); ++j) {
+  for (size_t j = 0; j < tokensIsoDepPhotons_.size(); ++j) {
     iEvent.getByToken(tokensIsoDepPhotons_[j], photonIsoDep[j]);
   }
 
   IsoDepositVals electronIsoValPFId(nTypes);
   IsoDepositVals photonIsoValPFId(nTypes);
   // just renaming
-  const IsoDepositVals * electronIsoVals = &electronIsoValPFId;
+  const IsoDepositVals* electronIsoVals = &electronIsoValPFId;
 
-  for (size_t j = 0; j<tokensIsoValElectronsPFId_.size(); ++j) {
+  for (size_t j = 0; j < tokensIsoValElectronsPFId_.size(); ++j) {
     iEvent.getByToken(tokensIsoValElectronsPFId_[j], electronIsoValPFId[j]);
   }
 
-  for (size_t j = 0; j<tokensIsoValPhotonsPFId_.size(); ++j) {
+  for (size_t j = 0; j < tokensIsoValPhotonsPFId_.size(); ++j) {
     iEvent.getByToken(tokensIsoValPhotonsPFId_[j], photonIsoValPFId[j]);
   }
 
-
   // Electrons - from reco
-  if(printElectrons_) {
-    unsigned nele=gsfElectronH->size();
+  if (printElectrons_) {
+    unsigned nele = gsfElectronH->size();
 
-    for(unsigned iele=0; iele<nele;++iele) {
-      reco::GsfElectronRef myElectronRef(gsfElectronH,iele);
+    for (unsigned iele = 0; iele < nele; ++iele) {
+      reco::GsfElectronRef myElectronRef(gsfElectronH, iele);
 
-      double charged =  (*(*electronIsoVals)[0])[myElectronRef];
+      double charged = (*(*electronIsoVals)[0])[myElectronRef];
       double photon = (*(*electronIsoVals)[1])[myElectronRef];
       double neutral = (*(*electronIsoVals)[2])[myElectronRef];
 
-      std::cout << "Electron: " << " run " << iEvent.id().run() << " lumi " << iEvent.id().luminosityBlock() << " event " << iEvent.id().event();
-      std::cout << " pt " <<  myElectronRef->pt() << " eta " << myElectronRef->eta() << " phi " << myElectronRef->phi() << " charge " << myElectronRef->charge()<< " : ";
-      std::cout << " ChargedIso " << charged ;
-      std::cout << " PhotonIso " <<  photon ;
+      std::cout << "Electron: "
+                << " run " << iEvent.id().run() << " lumi " << iEvent.id().luminosityBlock() << " event "
+                << iEvent.id().event();
+      std::cout << " pt " << myElectronRef->pt() << " eta " << myElectronRef->eta() << " phi " << myElectronRef->phi()
+                << " charge " << myElectronRef->charge() << " : ";
+      std::cout << " ChargedIso " << charged;
+      std::cout << " PhotonIso " << photon;
       std::cout << " NeutralHadron Iso " << neutral << std::endl;
 
-      if(myElectronRef->isEB()) {
-	chargedBarrelElectrons_ ->Fill(charged/myElectronRef->pt());
-	photonBarrelElectrons_->Fill(photon/myElectronRef->pt());
-	neutralBarrelElectrons_->Fill(neutral/myElectronRef->pt());
-	sumBarrelElectrons_->Fill((charged+photon+neutral)/myElectronRef->pt());
+      if (myElectronRef->isEB()) {
+        chargedBarrelElectrons_->Fill(charged / myElectronRef->pt());
+        photonBarrelElectrons_->Fill(photon / myElectronRef->pt());
+        neutralBarrelElectrons_->Fill(neutral / myElectronRef->pt());
+        sumBarrelElectrons_->Fill((charged + photon + neutral) / myElectronRef->pt());
       } else {
-	chargedEndcapsElectrons_ ->Fill(charged/myElectronRef->pt());
-	photonEndcapsElectrons_->Fill(photon/myElectronRef->pt());
-	neutralEndcapsElectrons_->Fill(neutral/myElectronRef->pt());
-	sumEndcapsElectrons_->Fill((charged+photon+neutral)/myElectronRef->pt());
+        chargedEndcapsElectrons_->Fill(charged / myElectronRef->pt());
+        photonEndcapsElectrons_->Fill(photon / myElectronRef->pt());
+        neutralEndcapsElectrons_->Fill(neutral / myElectronRef->pt());
+        sumEndcapsElectrons_->Fill((charged + photon + neutral) / myElectronRef->pt());
       }
     }
   }
 
- // Photons - from reco
-  const IsoDepositVals * photonIsoVals = &photonIsoValPFId;
+  // Photons - from reco
+  const IsoDepositVals* photonIsoVals = &photonIsoValPFId;
 
-  if(printPhotons_) {
-    unsigned npho=photonH->size();
+  if (printPhotons_) {
+    unsigned npho = photonH->size();
 
-    for(unsigned ipho=0; ipho<npho;++ipho) {
-      reco::PhotonRef myPhotonRef(photonH,ipho);
+    for (unsigned ipho = 0; ipho < npho; ++ipho) {
+      reco::PhotonRef myPhotonRef(photonH, ipho);
 
-      double charged =  (*(*photonIsoVals)[0])[myPhotonRef];
+      double charged = (*(*photonIsoVals)[0])[myPhotonRef];
       double photon = (*(*photonIsoVals)[1])[myPhotonRef];
       double neutral = (*(*photonIsoVals)[2])[myPhotonRef];
 
-      std::cout << "Photon: " << " run " << iEvent.id().run() << " lumi " << iEvent.id().luminosityBlock() << " event " << iEvent.id().event();
-      std::cout << " pt " <<  myPhotonRef->pt() << " eta " << myPhotonRef->eta() << " phi " << myPhotonRef->phi() << " charge " << myPhotonRef->charge()<< " : ";
-      std::cout << " ChargedIso " << charged ;
-      std::cout << " PhotonIso " <<  photon ;
+      std::cout << "Photon: "
+                << " run " << iEvent.id().run() << " lumi " << iEvent.id().luminosityBlock() << " event "
+                << iEvent.id().event();
+      std::cout << " pt " << myPhotonRef->pt() << " eta " << myPhotonRef->eta() << " phi " << myPhotonRef->phi()
+                << " charge " << myPhotonRef->charge() << " : ";
+      std::cout << " ChargedIso " << charged;
+      std::cout << " PhotonIso " << photon;
       std::cout << " NeutralHadron Iso " << neutral << std::endl;
 
-      if(myPhotonRef->isEB()) {
-	chargedBarrelPhotons_ ->Fill(charged/myPhotonRef->pt());
-	photonBarrelPhotons_->Fill(photon/myPhotonRef->pt());
-	neutralBarrelPhotons_->Fill(neutral/myPhotonRef->pt());
-	sumBarrelPhotons_->Fill((charged+photon+neutral)/myPhotonRef->pt());
+      if (myPhotonRef->isEB()) {
+        chargedBarrelPhotons_->Fill(charged / myPhotonRef->pt());
+        photonBarrelPhotons_->Fill(photon / myPhotonRef->pt());
+        neutralBarrelPhotons_->Fill(neutral / myPhotonRef->pt());
+        sumBarrelPhotons_->Fill((charged + photon + neutral) / myPhotonRef->pt());
       } else {
-	chargedEndcapsPhotons_ ->Fill(charged/myPhotonRef->pt());
-	photonEndcapsPhotons_->Fill(photon/myPhotonRef->pt());
-	neutralEndcapsPhotons_->Fill(neutral/myPhotonRef->pt());
-	sumEndcapsPhotons_->Fill((charged+photon+neutral)/myPhotonRef->pt());
+        chargedEndcapsPhotons_->Fill(charged / myPhotonRef->pt());
+        photonEndcapsPhotons_->Fill(photon / myPhotonRef->pt());
+        neutralEndcapsPhotons_->Fill(neutral / myPhotonRef->pt());
+        sumEndcapsPhotons_->Fill((charged + photon + neutral) / myPhotonRef->pt());
       }
     }
   }
-
-
 }
 
-
 DEFINE_FWK_MODULE(PFIsoReaderDemo);
-
-

--- a/CommonTools/ParticleFlow/test/PFIsoReaderDemo.h
+++ b/CommonTools/ParticleFlow/test/PFIsoReaderDemo.h
@@ -13,65 +13,61 @@
 
 #include "TH2F.h"
 
-
-class PFIsoReaderDemo : public edm::EDAnalyzer
-{
- public:
+class PFIsoReaderDemo : public edm::EDAnalyzer {
+public:
   explicit PFIsoReaderDemo(const edm::ParameterSet&);
   ~PFIsoReaderDemo();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const& );
-  virtual void analyze(const edm::Event & iEvent,const edm::EventSetup & c);
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
 
-  typedef std::vector< edm::Handle< edm::ValueMap<reco::IsoDeposit> > > IsoDepositMaps;
-  typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsoDepositVals;
+  typedef std::vector<edm::Handle<edm::ValueMap<reco::IsoDeposit> > > IsoDepositMaps;
+  typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsoDepositVals;
 
- private:
-
+private:
   bool printPhotons_;
   bool printElectrons_;
 
-  void plotIsoDeposits(const IsoDepositMaps & depmap, const reco::GsfElectronRef & ref,
-		       double&, double&, double&) ;
+  void plotIsoDeposits(const IsoDepositMaps& depmap, const reco::GsfElectronRef& ref, double&, double&, double&);
 
- //This analyzer produces a file with a tree so we need,
+  //This analyzer produces a file with a tree so we need,
   edm::Service<TFileService> fileservice_;
 
   edm::InputTag inputTagGsfElectrons_;
   edm::EDGetTokenT<reco::GsfElectronCollection> tokenGsfElectrons_;
   edm::InputTag inputTagPhotons_;
   edm::EDGetTokenT<reco::PhotonCollection> tokenPhotons_;
-//   edm::InputTag inputTagPFCandidateMap_;
-//   std::vector<edm::InputTag> inputTagIsoDepElectrons_;
+  //   edm::InputTag inputTagPFCandidateMap_;
+  //   std::vector<edm::InputTag> inputTagIsoDepElectrons_;
   std::vector<edm::EDGetTokenT<edm::ValueMap<reco::IsoDeposit> > > tokensIsoDepElectrons_;
-//   std::vector<edm::InputTag> inputTagIsoDepPhotons_;
+  //   std::vector<edm::InputTag> inputTagIsoDepPhotons_;
   std::vector<edm::EDGetTokenT<edm::ValueMap<reco::IsoDeposit> > > tokensIsoDepPhotons_;
   //  std::vector<edm::InputTag> inputTagIsoValElectronsNoPFId_;
-//   std::vector<edm::InputTag> inputTagIsoValElectronsPFId_;
+  //   std::vector<edm::InputTag> inputTagIsoValElectronsPFId_;
   std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > tokensIsoValElectronsPFId_;
-//   std::vector<edm::InputTag> inputTagIsoValPhotonsPFId_;
+  //   std::vector<edm::InputTag> inputTagIsoValPhotonsPFId_;
   std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > tokensIsoValPhotonsPFId_;
 
   // Control histos
-  TH1F* chargedBarrelElectrons_   ;
-  TH1F* photonBarrelElectrons_    ;
-  TH1F* neutralBarrelElectrons_   ;
+  TH1F* chargedBarrelElectrons_;
+  TH1F* photonBarrelElectrons_;
+  TH1F* neutralBarrelElectrons_;
 
-  TH1F* chargedEndcapsElectrons_  ;
-  TH1F* photonEndcapsElectrons_   ;
-  TH1F* neutralEndcapsElectrons_  ;
+  TH1F* chargedEndcapsElectrons_;
+  TH1F* photonEndcapsElectrons_;
+  TH1F* neutralEndcapsElectrons_;
 
-  TH1F* sumBarrelElectrons_       ;
-  TH1F* sumEndcapsElectrons_      ;
+  TH1F* sumBarrelElectrons_;
+  TH1F* sumEndcapsElectrons_;
 
-  TH1F* chargedBarrelPhotons_   ;
-  TH1F* photonBarrelPhotons_    ;
-  TH1F* neutralBarrelPhotons_   ;
+  TH1F* chargedBarrelPhotons_;
+  TH1F* photonBarrelPhotons_;
+  TH1F* neutralBarrelPhotons_;
 
-  TH1F* chargedEndcapsPhotons_  ;
-  TH1F* photonEndcapsPhotons_   ;
-  TH1F* neutralEndcapsPhotons_  ;
+  TH1F* chargedEndcapsPhotons_;
+  TH1F* photonEndcapsPhotons_;
+  TH1F* neutralEndcapsPhotons_;
 
-  TH1F* sumBarrelPhotons_       ;
-  TH1F* sumEndcapsPhotons_      ;
+  TH1F* sumBarrelPhotons_;
+  TH1F* sumEndcapsPhotons_;
 };
 #endif

--- a/DataFormats/Candidate/interface/CandAssociation.h
+++ b/DataFormats/Candidate/interface/CandAssociation.h
@@ -11,19 +11,21 @@
 namespace edm {
   namespace helper {
     struct CandMasterKeyReference {
-      template<typename CandRef>
-      static const CandRef & get( const CandRef & t, edm::ProductID id ) { 
-	if ( id == t.id() ) return t;
-	else return t->masterClone().template castTo<CandRef>(); 
+      template <typename CandRef>
+      static const CandRef& get(const CandRef& t, edm::ProductID id) {
+        if (id == t.id())
+          return t;
+        else
+          return t->masterClone().template castTo<CandRef>();
       }
     };
 
-    template<>
+    template <>
     struct AssociationKeyReferenceTrait<reco::CandidateCollection> {
       typedef CandMasterKeyReference type;
     };
-  }
-}
+  }  // namespace helper
+}  // namespace edm
 
 namespace reco {
   typedef edm::AssociationVector<CandidateRefProd, std::vector<float> > CandFloatAssociations;
@@ -35,6 +37,6 @@ namespace reco {
   typedef edm::AssociationVector<CandidateBaseRefProd, std::vector<int> > CandViewIntAssociations;
   typedef edm::AssociationVector<CandidateBaseRefProd, std::vector<unsigned int> > CandViewUIntAssociations;
   typedef edm::ValueMap<CandidateBaseRef> CandRefValueMap;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CandMatchMap.h
+++ b/DataFormats/Candidate/interface/CandMatchMap.h
@@ -12,17 +12,9 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 namespace reco {
-  typedef edm::AssociationMap<
-            edm::OneToOne<reco::CandidateCollection, 
-                          reco::CandidateCollection
-            > 
-          > CandMatchMap;
+  typedef edm::AssociationMap<edm::OneToOne<reco::CandidateCollection, reco::CandidateCollection> > CandMatchMap;
 
-  typedef edm::AssociationMap<
-            edm::OneToOneGeneric<reco::CandidateView, 
-                                 reco::CandidateView
-            > 
-          > CandViewMatchMap;
-}
+  typedef edm::AssociationMap<edm::OneToOneGeneric<reco::CandidateView, reco::CandidateView> > CandViewMatchMap;
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CandMatchMapMany.h
+++ b/DataFormats/Candidate/interface/CandMatchMapMany.h
@@ -11,12 +11,8 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 namespace reco {
-  typedef edm::AssociationMap<
-            edm::OneToManyWithQuality<reco::CandidateCollection, 
-                                      reco::CandidateCollection,
-                                      double
-                                     > 
-                             > CandMatchMapMany;
+  typedef edm::AssociationMap<edm::OneToManyWithQuality<reco::CandidateCollection, reco::CandidateCollection, double> >
+      CandMatchMapMany;
 }
 
 #endif

--- a/DataFormats/Candidate/interface/Candidate.h
+++ b/DataFormats/Candidate/interface/Candidate.h
@@ -30,7 +30,7 @@ namespace reco {
     typedef size_t size_type;
     typedef candidate::const_iterator const_iterator;
     typedef candidate::iterator iterator;
- 
+
     /// electric charge type
     typedef int Charge;
     /// Lorentz vector
@@ -46,38 +46,38 @@ namespace reco {
     /// covariance error matrix (3x3)
     typedef math::Error<dimension>::type CovarianceMatrix;
     /// matix size
-    enum { size = dimension * (dimension + 1)/2 };
+    enum { size = dimension * (dimension + 1) / 2 };
     /// index type
     typedef unsigned int index;
 
     /// default constructor
-    Candidate() {};
+    Candidate(){};
     /// destructor
     virtual ~Candidate();
     /// electric charge
     virtual int charge() const = 0;
     /// set electric charge
-    virtual void setCharge( Charge q ) = 0;
+    virtual void setCharge(Charge q) = 0;
     /// electric charge
     virtual int threeCharge() const = 0;
     /// set electric charge
-    virtual void setThreeCharge( Charge qx3 ) = 0;
+    virtual void setThreeCharge(Charge qx3) = 0;
     /// four-momentum Lorentz vector
-    virtual const LorentzVector & p4() const = 0;
+    virtual const LorentzVector& p4() const = 0;
     /// four-momentum Lorentz vector
-    virtual const PolarLorentzVector & polarP4() const = 0;
+    virtual const PolarLorentzVector& polarP4() const = 0;
     /// spatial momentum vector
     virtual Vector momentum() const = 0;
-    /// boost vector to boost a Lorentz vector 
+    /// boost vector to boost a Lorentz vector
     /// to the particle center of mass system
     virtual Vector boostToCM() const = 0;
     /// magnitude of momentum vector
     virtual double p() const = 0;
     /// energy
     virtual double energy() const = 0;
-    /// transverse energy 
+    /// transverse energy
     virtual double et() const = 0;
-    /// transverse energy squared (use this for cut!)                                                                 
+    /// transverse energy squared (use this for cut!)
     virtual double et2() const = 0;
     /// mass
     virtual double mass() const = 0;
@@ -106,80 +106,78 @@ namespace reco {
     /// rapidity
     virtual double y() const = 0;
     /// set 4-momentum
-    virtual void setP4( const LorentzVector & p4 ) = 0;
+    virtual void setP4(const LorentzVector& p4) = 0;
     /// set 4-momentum
-    virtual void setP4( const PolarLorentzVector & p4 )  = 0;
+    virtual void setP4(const PolarLorentzVector& p4) = 0;
     /// set particle mass
-    virtual void setMass( double m )  = 0;
-    virtual void setPz( double pz )  = 0;
+    virtual void setMass(double m) = 0;
+    virtual void setPz(double pz) = 0;
     /// vertex position
-    virtual const Point & vertex() const  = 0;
+    virtual const Point& vertex() const = 0;
     /// x coordinate of vertex position
-    virtual double vx() const  = 0;
+    virtual double vx() const = 0;
     /// y coordinate of vertex position
-    virtual double vy() const  = 0;
+    virtual double vy() const = 0;
     /// z coordinate of vertex position
-    virtual double vz() const  = 0;
+    virtual double vz() const = 0;
     /// set vertex
-    virtual void setVertex( const Point & vertex )  = 0;
+    virtual void setVertex(const Point& vertex) = 0;
     /// PDG identifier
-    virtual int pdgId() const  = 0;
+    virtual int pdgId() const = 0;
     // set PDG identifier
-    virtual void setPdgId( int pdgId )  = 0;
+    virtual void setPdgId(int pdgId) = 0;
     /// status word
-    virtual int status() const  = 0;
+    virtual int status() const = 0;
     /// set status word
-    virtual void setStatus( int status )  = 0;
+    virtual void setStatus(int status) = 0;
     /// set long lived flag
-    virtual void setLongLived()  = 0;
+    virtual void setLongLived() = 0;
     /// is long lived?
-    virtual bool longLived() const  = 0;
+    virtual bool longLived() const = 0;
     /// set mass constraint flag
     virtual void setMassConstraint() = 0;
     /// do mass constraint?
     virtual bool massConstraint() const = 0;
     /// returns a clone of the Candidate object
-    virtual Candidate * clone() const = 0;
+    virtual Candidate* clone() const = 0;
     /// first daughter const_iterator
-    const_iterator begin() const { return const_iterator(this,0);} 
+    const_iterator begin() const { return const_iterator(this, 0); }
     /// last daughter const_iterator
-    const_iterator end() const  { return const_iterator(this,numberOfDaughters());}
+    const_iterator end() const { return const_iterator(this, numberOfDaughters()); }
     /// first daughter iterator
-    iterator begin()  { return iterator(this,0);}  
+    iterator begin() { return iterator(this, 0); }
     /// last daughter iterator
-    iterator end()  { return iterator(this,numberOfDaughters());}
+    iterator end() { return iterator(this, numberOfDaughters()); }
     /// number of daughters
     virtual size_type numberOfDaughters() const = 0;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate * daughter( size_type i ) const = 0;
+    virtual const Candidate* daughter(size_type i) const = 0;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate * daughter( size_type i ) = 0;
+    virtual Candidate* daughter(size_type i) = 0;
     /// return daughter with a specified role name
-    virtual Candidate * daughter(const std::string& s ) = 0;
+    virtual Candidate* daughter(const std::string& s) = 0;
     /// return daughter with a specified role name
-    virtual const Candidate * daughter(const std::string& s ) const = 0;
+    virtual const Candidate* daughter(const std::string& s) const = 0;
     /// number of mothers (zero or one in most of but not all the cases)
     virtual size_type numberOfMothers() const = 0;
     /// return pointer to mother
-    virtual const Candidate * mother( size_type i = 0 ) const = 0;
-    /// return the number of source Candidates 
+    virtual const Candidate* mother(size_type i = 0) const = 0;
+    /// return the number of source Candidates
     /// ( the candidates used to construct this Candidate)
-    virtual size_t numberOfSourceCandidatePtrs() const  = 0;
-    /// return a Ptr to one of the source Candidates 
+    virtual size_t numberOfSourceCandidatePtrs() const = 0;
+    /// return a Ptr to one of the source Candidates
     /// ( the candidates used to construct this Candidate)
-    virtual CandidatePtr sourceCandidatePtr( size_type i ) const {
-      return CandidatePtr();
-    }
-    /// \brief Set the ptr to the source Candidate. 
-    /// 
-    /// necessary, to allow a parallel treatment of all candidates 
-    /// in PF2PAT. Does nothing for most Candidate classes, including 
+    virtual CandidatePtr sourceCandidatePtr(size_type i) const { return CandidatePtr(); }
+    /// \brief Set the ptr to the source Candidate.
+    ///
+    /// necessary, to allow a parallel treatment of all candidates
+    /// in PF2PAT. Does nothing for most Candidate classes, including
     /// CompositePtrCandidates, where the source information is in fact
-    /// the collection of ptrs to daughters. For non-Composite Candidates, 
-    /// this function can be used to set the ptr to the source of the 
-    /// Candidate, which will allow to keep track 
-    /// of the reconstruction history. 
-    virtual void setSourceCandidatePtr( const CandidatePtr& ptr ) {};
+    /// the collection of ptrs to daughters. For non-Composite Candidates,
+    /// this function can be used to set the ptr to the source of the
+    /// Candidate, which will allow to keep track
+    /// of the reconstruction history.
+    virtual void setSourceCandidatePtr(const CandidatePtr& ptr){};
 
     /// chi-squares
     virtual double vertexChi2() const = 0;
@@ -195,61 +193,89 @@ namespace reco {
     /// (i, j)-th element of error matrix, i, j = 0, ... 2
     virtual double vertexCovariance(int i, int j) const = 0;
     /// fill SMatrix
-    virtual CovarianceMatrix vertexCovariance() const { CovarianceMatrix m; fillVertexCovariance(m); return m; }  //TODO
-    virtual void fillVertexCovariance(CovarianceMatrix & v) const = 0;
+    virtual CovarianceMatrix vertexCovariance() const {
+      CovarianceMatrix m;
+      fillVertexCovariance(m);
+      return m;
+    }  //TODO
+    virtual void fillVertexCovariance(CovarianceMatrix& v) const = 0;
     /// returns true if this candidate has a reference to a master clone.
     /// This only happens if the concrete Candidate type is ShallowCloneCandidate
     virtual bool hasMasterClone() const = 0;
     /// returns ptr to master clone, if existing.
     /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
-    virtual const CandidateBaseRef & masterClone() const = 0;
+    virtual const CandidateBaseRef& masterClone() const = 0;
     /// returns true if this candidate has a ptr to a master clone.
     /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
     virtual bool hasMasterClonePtr() const = 0;
     /// returns ptr to master clone, if existing.
     /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
-    virtual const CandidatePtr & masterClonePtr() const = 0;
+    virtual const CandidatePtr& masterClonePtr() const = 0;
     /// cast master clone reference to a concrete type
-    template<typename Ref>
-    Ref masterRef() const { return masterClone().template castTo<Ref>(); }
+    template <typename Ref>
+    Ref masterRef() const {
+      return masterClone().template castTo<Ref>();
+    }
     /// get a component
 
-    template<typename T> T get() const { 
-      if ( hasMasterClone() ) return masterClone()->get<T>();
-      else return reco::get<T>( * this ); 
+    template <typename T>
+    T get() const {
+      if (hasMasterClone())
+        return masterClone()->get<T>();
+      else
+        return reco::get<T>(*this);
     }
     /// get a component
-    template<typename T, typename Tag> T get() const { 
-      if ( hasMasterClone() ) return masterClone()->get<T, Tag>();
-      else return reco::get<T, Tag>( * this ); 
+    template <typename T, typename Tag>
+    T get() const {
+      if (hasMasterClone())
+        return masterClone()->get<T, Tag>();
+      else
+        return reco::get<T, Tag>(*this);
     }
     /// get a component
-    template<typename T> T get( size_type i ) const { 
-      if ( hasMasterClone() ) return masterClone()->get<T>( i );
-      else return reco::get<T>( * this, i ); 
+    template <typename T>
+    T get(size_type i) const {
+      if (hasMasterClone())
+        return masterClone()->get<T>(i);
+      else
+        return reco::get<T>(*this, i);
     }
     /// get a component
-    template<typename T, typename Tag> T get( size_type i ) const { 
-      if ( hasMasterClone() ) return masterClone()->get<T, Tag>( i );
-      else return reco::get<T, Tag>( * this, i ); 
+    template <typename T, typename Tag>
+    T get(size_type i) const {
+      if (hasMasterClone())
+        return masterClone()->get<T, Tag>(i);
+      else
+        return reco::get<T, Tag>(*this, i);
     }
     /// number of components
-    template<typename T> size_type numberOf() const { 
-      if ( hasMasterClone() ) return masterClone()->numberOf<T>();
-      else return reco::numberOf<T>( * this ); 
+    template <typename T>
+    size_type numberOf() const {
+      if (hasMasterClone())
+        return masterClone()->numberOf<T>();
+      else
+        return reco::numberOf<T>(*this);
     }
     /// number of components
-    template<typename T, typename Tag> size_type numberOf() const { 
-      if ( hasMasterClone() ) return masterClone()->numberOf<T, Tag>();
-      else return reco::numberOf<T, Tag>( * this ); 
+    template <typename T, typename Tag>
+    size_type numberOf() const {
+      if (hasMasterClone())
+        return masterClone()->numberOf<T, Tag>();
+      else
+        return reco::numberOf<T, Tag>(*this);
     }
 
-    virtual const Track * bestTrack() const {return nullptr;}	
- 
-    /// uncertainty on dz 
-    virtual float dzError() const {return 0;} // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    virtual const Track* bestTrack() const { return nullptr; }
+
+    /// uncertainty on dz
+    virtual float dzError() const {
+      return 0;
+    }  // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
     /// uncertainty on dxy
-    virtual float dxyError() const {return 0;} // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
+    virtual float dxyError() const {
+      return 0;
+    }  // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
 
     virtual bool isElectron() const = 0;
     virtual bool isMuon() const = 0;
@@ -263,22 +289,21 @@ namespace reco {
 
   protected:
     /// check overlap with another Candidate
-    virtual bool overlap( const Candidate & ) const = 0;
-    template<typename, typename, typename> friend struct component; 
+    virtual bool overlap(const Candidate&) const = 0;
+    template <typename, typename, typename>
+    friend struct component;
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;
     friend class ShallowClonePtrCandidate;
-
   };
 
-namespace candidate {
+  namespace candidate {
 
-const_iterator::reference const_iterator::operator*() const { return *(me->daughter(i));}
-iterator::reference iterator::operator*() const { return *(me->daughter(i));}
+    const_iterator::reference const_iterator::operator*() const { return *(me->daughter(i)); }
+    iterator::reference iterator::operator*() const { return *(me->daughter(i)); }
 
+  }  // namespace candidate
 
-}
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CandidateFwd.h
+++ b/DataFormats/Candidate/interface/CandidateFwd.h
@@ -37,6 +37,6 @@ namespace reco {
   typedef edm::RefProd<CandidateCollection> CandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type
   typedef edm::RefToBaseProd<Candidate> CandidateBaseRefProd;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CandidateWithRef.h
+++ b/DataFormats/Candidate/interface/CandidateWithRef.h
@@ -14,29 +14,29 @@
 
 namespace reco {
 
-  template<typename Ref>
+  template <typename Ref>
   class CandidateWithRef : public LeafCandidate {
   public:
     typedef Ref reference;
     /// default constructor
-    CandidateWithRef() : LeafCandidate() { }
+    CandidateWithRef() : LeafCandidate() {}
     /// constructor from values
-    CandidateWithRef( const LorentzVector & p4, Charge q = 0, const Point & vtx = Point( 0, 0, 0 ) ) :
-      LeafCandidate( q, p4, vtx ) { }
+    CandidateWithRef(const LorentzVector &p4, Charge q = 0, const Point &vtx = Point(0, 0, 0))
+        : LeafCandidate(q, p4, vtx) {}
     /// destructor
     ~CandidateWithRef() override;
     /// returns a clone of the candidate
-    CandidateWithRef * clone() const override;
+    CandidateWithRef *clone() const override;
     /// set reference
-    void setRef( const Ref & r ) { ref_ = r; }
-    /// reference 
+    void setRef(const Ref &r) { ref_ = r; }
+    /// reference
     reference ref() const { return ref_; }
 
     CMS_CLASS_VERSION(13)
 
   private:
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate &) const override;
     /// reference to a CaloRecHit
     reference ref_;
   };
@@ -44,24 +44,26 @@ namespace reco {
   // the following has to be added for any single Ref type
   // GET_DEFAULT_CANDIDATE_COMPONENT( CandidateWithRef<Ref>, CandidateWithRef<Ref>::reference, ref )
 
-  template<typename Ref>
-    CandidateWithRef<Ref>::~CandidateWithRef() { 
+  template <typename Ref>
+  CandidateWithRef<Ref>::~CandidateWithRef() {}
+
+  template <typename Ref>
+  CandidateWithRef<Ref> *CandidateWithRef<Ref>::clone() const {
+    return new CandidateWithRef<Ref>(*this);
   }
-  
-  template<typename Ref>
-    CandidateWithRef<Ref> * CandidateWithRef<Ref>::clone() const {
-    return new CandidateWithRef<Ref>( * this );
+
+  template <typename Ref>
+  bool CandidateWithRef<Ref>::overlap(const Candidate &c) const {
+    const CandidateWithRef *o = dynamic_cast<const CandidateWithRef *>(&c);
+    if (o == 0)
+      return false;
+    if (ref().isNull())
+      return false;
+    if (o->ref().isNull())
+      return false;
+    return (ref() != o->ref());
   }
-  
-  template<typename Ref>
-    bool CandidateWithRef<Ref>::overlap( const Candidate & c ) const {
-    const CandidateWithRef * o = dynamic_cast<const CandidateWithRef *>( & c );
-    if ( o == 0 ) return false;
-    if ( ref().isNull() ) return false;
-    if ( o->ref().isNull() ) return false;
-    return ( ref() != o->ref() );
-  }
-  
-}
+
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CompositeCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeCandidate.h
@@ -14,7 +14,7 @@
 
 #include "DataFormats/Candidate/interface/CompositeCandidateFwd.h"
 #include <string>
-#include <vector> 
+#include <vector>
 
 namespace reco {
 
@@ -22,44 +22,51 @@ namespace reco {
   public:
     /// collection of daughters
     typedef CandidateCollection daughters;
-    typedef std::vector<std::string> role_collection; 
+    typedef std::vector<std::string> role_collection;
     /// default constructor
-    CompositeCandidate(std::string name="") : LeafCandidate(), name_(name) { }
+    CompositeCandidate(std::string name = "") : LeafCandidate(), name_(name) {}
     /// constructor from values
-    template<typename P4>
-    CompositeCandidate( Charge q, const P4 & p4, const Point & vtx = Point( 0, 0, 0 ),
-			int pdgId = 0, int status = 0, bool integerCharge = true,
-			std::string name="") :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ), name_(name) { }
-   /// constructor from values
-    explicit CompositeCandidate( const Candidate & p, const std::string& name="" );
+    template <typename P4>
+    CompositeCandidate(Charge q,
+                       const P4& p4,
+                       const Point& vtx = Point(0, 0, 0),
+                       int pdgId = 0,
+                       int status = 0,
+                       bool integerCharge = true,
+                       std::string name = "")
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge), name_(name) {}
     /// constructor from values
-    explicit CompositeCandidate( const Candidate & p, const std::string& name, role_collection const & roles );
+    explicit CompositeCandidate(const Candidate& p, const std::string& name = "");
+    /// constructor from values
+    explicit CompositeCandidate(const Candidate& p, const std::string& name, role_collection const& roles);
     /// destructor
     ~CompositeCandidate() override;
     /// get the name of the candidate
-    std::string name() const { return name_;}
+    std::string name() const { return name_; }
     /// set the name of the candidate
-    void        setName(std::string name) { name_ = name;}
+    void setName(std::string name) { name_ = name; }
     /// get the roles
-    role_collection const & roles() const { return roles_; }
-    /// set the roles    
-    void                    setRoles( const role_collection & roles ) { roles_.clear(); roles_ = roles; }
+    role_collection const& roles() const { return roles_; }
+    /// set the roles
+    void setRoles(const role_collection& roles) {
+      roles_.clear();
+      roles_ = roles;
+    }
     /// returns a clone of the candidate
-    CompositeCandidate * clone() const override;
+    CompositeCandidate* clone() const override;
     /// number of daughters
     size_type numberOfDaughters() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate * daughter( size_type ) const override;
+    const Candidate* daughter(size_type) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate * daughter( size_type ) override;
+    Candidate* daughter(size_type) override;
     // Get candidate based on role
-    Candidate *       daughter(const std::string& s ) override;
-    const Candidate * daughter(const std::string& s ) const override;
-    /// add a clone of the passed candidate as daughter 
-    void addDaughter( const Candidate &, const std::string& s="" );
-    /// add a clone of the passed candidate as daughter 
-    void addDaughter( std::unique_ptr<Candidate>, const std::string& s="" );
+    Candidate* daughter(const std::string& s) override;
+    const Candidate* daughter(const std::string& s) const override;
+    /// add a clone of the passed candidate as daughter
+    void addDaughter(const Candidate&, const std::string& s = "");
+    /// add a clone of the passed candidate as daughter
+    void addDaughter(std::unique_ptr<Candidate>, const std::string& s = "");
     /// clear daughters
     void clearDaughters() { dau.clear(); }
     // clear roles
@@ -69,19 +76,19 @@ namespace reco {
     /// number of mothers (zero or one in most of but not all the cases)
     size_type numberOfMothers() const override;
     /// return pointer to mother
-    const Candidate * mother( size_type i = 0 ) const override;
+    const Candidate* mother(size_type i = 0) const override;
 
   private:
     /// collection of daughters
     daughters dau;
     /// check overlap with another daughter
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
     /// candidate name
     std::string name_;
     /// candidate roles
     role_collection roles_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/CompositeCandidateFwd.h
@@ -31,6 +31,6 @@ namespace reco {
   typedef edm::RefProd<CompositeCandidateCollection> CompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type
   typedef edm::RefToBaseProd<CompositeCandidate> CompositeCandidateBaseRefProd;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/CompositePtrCandidate.h
@@ -21,62 +21,68 @@ namespace reco {
     /// collection of references to daughters
     typedef std::vector<CandidatePtr> mothers;
     /// default constructor
-    CompositePtrCandidate() : LeafCandidate() { }
+    CompositePtrCandidate() : LeafCandidate() {}
     /// constructor from values
-    CompositePtrCandidate( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			   int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositePtrCandidate(Charge q,
+                          const LorentzVector& p4,
+                          const Point& vtx = Point(0, 0, 0),
+                          int pdgId = 0,
+                          int status = 0,
+                          bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from values
-    CompositePtrCandidate( Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			   int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositePtrCandidate(Charge q,
+                          const PolarLorentzVector& p4,
+                          const Point& vtx = Point(0, 0, 0),
+                          int pdgId = 0,
+                          int status = 0,
+                          bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from a Candidate
-    explicit CompositePtrCandidate( const Candidate & p ) : LeafCandidate( p ) { }
+    explicit CompositePtrCandidate(const Candidate& p) : LeafCandidate(p) {}
     /// destructor
     ~CompositePtrCandidate() override;
     /// returns a clone of the candidate
-    CompositePtrCandidate * clone() const override;
+    CompositePtrCandidate* clone() const override;
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// number of mothers
     size_t numberOfMothers() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate * daughter( size_type ) const override;
-    using reco::LeafCandidate::daughter; // avoid hiding the base
+    const Candidate* daughter(size_type) const override;
+    using reco::LeafCandidate::daughter;  // avoid hiding the base
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate * daughter( size_type ) override;
+    Candidate* daughter(size_type) override;
     /// add a daughter via a reference
-    void addDaughter( const CandidatePtr & );    
+    void addDaughter(const CandidatePtr&);
     /// clear daughter references
     virtual void clearDaughters() { dau.clear(); }
     /// reference to daughter at given position
-    virtual CandidatePtr daughterPtr( size_type i ) const { return dau[ i ]; }
+    virtual CandidatePtr daughterPtr(size_type i) const { return dau[i]; }
     /// references to daughtes
-    virtual const daughters & daughterPtrVector() const { return dau; }
+    virtual const daughters& daughterPtrVector() const { return dau; }
     /// return pointer to mother
-    const Candidate * mother( size_t i = 0 ) const override;
-    /// number of source candidates 
-    /// ( the candidates used to construct this Candidate). 
-    /// for CompositeRefBaseCandidates, the source candidates 
-    /// are the daughters. 
-    size_type numberOfSourceCandidatePtrs() const override ;
-    /// return a RefToBase to one of the source Candidates 
-    /// ( the candidates used to construct this Candidate). 
-    /// for CompositeRefBaseCandidates, the source candidates 
-    /// are the daughters. 
-    CandidatePtr sourceCandidatePtr( size_type i ) const override;
+    const Candidate* mother(size_t i = 0) const override;
+    /// number of source candidates
+    /// ( the candidates used to construct this Candidate).
+    /// for CompositeRefBaseCandidates, the source candidates
+    /// are the daughters.
+    size_type numberOfSourceCandidatePtrs() const override;
+    /// return a RefToBase to one of the source Candidates
+    /// ( the candidates used to construct this Candidate).
+    /// for CompositeRefBaseCandidates, the source candidates
+    /// are the daughters.
+    CandidatePtr sourceCandidatePtr(size_type i) const override;
 
   private:
     /// collection of references to daughters
     daughters dau;
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
   };
 
-  inline void CompositePtrCandidate::addDaughter( const CandidatePtr & cand ) { 
-    dau.push_back( cand ); 
-  }
+  inline void CompositePtrCandidate::addDaughter(const CandidatePtr& cand) { dau.push_back(cand); }
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CompositeRefBaseCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeRefBaseCandidate.h
@@ -19,49 +19,55 @@ namespace reco {
     /// collection of references to daughters
     typedef std::vector<CandidateBaseRef> daughters;
     /// default constructor
-    CompositeRefBaseCandidate() : LeafCandidate() { }
+    CompositeRefBaseCandidate() : LeafCandidate() {}
     /// constructor from values
-    CompositeRefBaseCandidate( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			       int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositeRefBaseCandidate(Charge q,
+                              const LorentzVector& p4,
+                              const Point& vtx = Point(0, 0, 0),
+                              int pdgId = 0,
+                              int status = 0,
+                              bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from values
-    CompositeRefBaseCandidate( Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			       int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositeRefBaseCandidate(Charge q,
+                              const PolarLorentzVector& p4,
+                              const Point& vtx = Point(0, 0, 0),
+                              int pdgId = 0,
+                              int status = 0,
+                              bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from a particle
-    explicit CompositeRefBaseCandidate( const Candidate & c ) : LeafCandidate( c ) { }
+    explicit CompositeRefBaseCandidate(const Candidate& c) : LeafCandidate(c) {}
     /// destructor
     ~CompositeRefBaseCandidate() override;
     /// returns a clone of the candidate
-    CompositeRefBaseCandidate * clone() const override;
+    CompositeRefBaseCandidate* clone() const override;
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// number of mothers
     size_t numberOfMothers() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate * daughter( size_type ) const override;
+    const Candidate* daughter(size_type) const override;
     /// return mother at a given position, i = 0, ... numberOfMothers() - 1 (read only mode)
-    const Candidate * mother( size_type ) const override;
+    const Candidate* mother(size_type) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate * daughter( size_type ) override;
-    using reco::LeafCandidate::daughter; // avoid hiding the base
+    Candidate* daughter(size_type) override;
+    using reco::LeafCandidate::daughter;  // avoid hiding the base
     /// add a daughter via a reference
-    void addDaughter( const CandidateBaseRef & );    
+    void addDaughter(const CandidateBaseRef&);
     /// clear daughter references
     void clearDaughters() { dau.clear(); }
     /// reference to daughter at given position
-    CandidateBaseRef daughterRef( size_type i ) const { return dau[ i ]; }
+    CandidateBaseRef daughterRef(size_type i) const { return dau[i]; }
 
   private:
     /// collection of references to daughters
     daughters dau;
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
   };
 
-  inline void CompositeRefBaseCandidate::addDaughter( const CandidateBaseRef & cand ) { 
-    dau.push_back( cand ); 
-  }
-}
+  inline void CompositeRefBaseCandidate::addDaughter(const CandidateBaseRef& cand) { dau.push_back(cand); }
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CompositeRefCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeRefCandidate.h
@@ -21,48 +21,56 @@ namespace reco {
     /// collection of references to daughters
     typedef CandidateRefVector mothers;
     /// default constructor
-    CompositeRefCandidate() : LeafCandidate() { }
+    CompositeRefCandidate() : LeafCandidate() {}
     /// constructor from values
-    CompositeRefCandidate( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			   int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositeRefCandidate(Charge q,
+                          const LorentzVector& p4,
+                          const Point& vtx = Point(0, 0, 0),
+                          int pdgId = 0,
+                          int status = 0,
+                          bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from values
-    CompositeRefCandidate( Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			   int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositeRefCandidate(Charge q,
+                          const PolarLorentzVector& p4,
+                          const Point& vtx = Point(0, 0, 0),
+                          int pdgId = 0,
+                          int status = 0,
+                          bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from a candidate
-    explicit CompositeRefCandidate( const Candidate & p ) : LeafCandidate( p ) { }
+    explicit CompositeRefCandidate(const Candidate& p) : LeafCandidate(p) {}
     /// destructor
     ~CompositeRefCandidate() override;
     /// returns a clone of the candidate
-    CompositeRefCandidate * clone() const override;
+    CompositeRefCandidate* clone() const override;
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate * daughter( size_type ) const override;
+    const Candidate* daughter(size_type) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate * daughter( size_type ) override;
-    using reco::LeafCandidate::daughter; // avoid hiding the base
+    Candidate* daughter(size_type) override;
+    using reco::LeafCandidate::daughter;  // avoid hiding the base
     /// add a daughter via a reference
-    void addDaughter( const CandidateRef & );    
+    void addDaughter(const CandidateRef&);
     /// add a daughter via a reference
-    void addMother( const CandidateRef & );    
+    void addMother(const CandidateRef&);
     /// clear daughter references
     void clearDaughters() { dau.clear(); }
     /// reference to daughter at given position
-    CandidateRef daughterRef( size_type i ) const { return dau[ i ]; }
+    CandidateRef daughterRef(size_type i) const { return dau[i]; }
     /// references to daughtes
-    const daughters & daughterRefVector() const { return dau; }
+    const daughters& daughterRefVector() const { return dau; }
     /// reference to mother at given position
-    CandidateRef motherRef( size_type i = 0 ) const { return mom[ i ]; }
+    CandidateRef motherRef(size_type i = 0) const { return mom[i]; }
     /// references to mothers
-    const mothers & motherRefVector() const { return mom; }
+    const mothers& motherRefVector() const { return mom; }
     /// set daughters product ID
-    void resetDaughters( const edm::ProductID & id ) { dau = daughters( id ); }
+    void resetDaughters(const edm::ProductID& id) { dau = daughters(id); }
     /// number of mothers (zero or one in most of but not all the cases)
     size_t numberOfMothers() const override;
     /// return pointer to mother
-    const Candidate * mother( size_t i = 0 ) const override;
+    const Candidate* mother(size_t i = 0) const override;
 
   private:
     /// collection of references to daughters
@@ -70,16 +78,12 @@ namespace reco {
     /// collection of references to mothers
     daughters mom;
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
   };
 
-  inline void CompositeRefCandidate::addDaughter( const CandidateRef & cand ) { 
-    dau.push_back( cand ); 
-  }
+  inline void CompositeRefCandidate::addDaughter(const CandidateRef& cand) { dau.push_back(cand); }
 
-  inline void CompositeRefCandidate::addMother( const CandidateRef & cand ) { 
-    mom.push_back( cand ); 
-  }
-}
+  inline void CompositeRefCandidate::addMother(const CandidateRef& cand) { mom.push_back(cand); }
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/CompositeRefCandidateT.h
+++ b/DataFormats/Candidate/interface/CompositeRefCandidateT.h
@@ -15,7 +15,7 @@
 
 namespace reco {
 
-  template<typename D>
+  template <typename D>
   class CompositeRefCandidateT : public LeafCandidate {
   public:
     /// collection of references to daughters
@@ -23,52 +23,60 @@ namespace reco {
     /// collection of references to daughters
     typedef D mothers;
     /// default constructor
-    CompositeRefCandidateT() : LeafCandidate() { }
+    CompositeRefCandidateT() : LeafCandidate() {}
     /// constructor from values
-    CompositeRefCandidateT( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			    int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositeRefCandidateT(Charge q,
+                           const LorentzVector& p4,
+                           const Point& vtx = Point(0, 0, 0),
+                           int pdgId = 0,
+                           int status = 0,
+                           bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from values
-    CompositeRefCandidateT( Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			    int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      LeafCandidate( q, p4, vtx, pdgId, status, integerCharge ) { }
+    CompositeRefCandidateT(Charge q,
+                           const PolarLorentzVector& p4,
+                           const Point& vtx = Point(0, 0, 0),
+                           int pdgId = 0,
+                           int status = 0,
+                           bool integerCharge = true)
+        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
     /// constructor from a particle
-    explicit CompositeRefCandidateT( const LeafCandidate& c ) : LeafCandidate( c ) { }
+    explicit CompositeRefCandidateT(const LeafCandidate& c) : LeafCandidate(c) {}
     /// destructor
     ~CompositeRefCandidateT() override;
     /// returns a clone of the candidate
-    CompositeRefCandidateT<D> * clone() const override;
+    CompositeRefCandidateT<D>* clone() const override;
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// number of mothers
     size_t numberOfMothers() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate * daughter(size_type) const override;
-    using ::reco::LeafCandidate::daughter; // avoid hiding the base
+    const Candidate* daughter(size_type) const override;
+    using ::reco::LeafCandidate::daughter;  // avoid hiding the base
     /// return mother at a given position, i = 0, ... numberOfMothers() - 1 (read only mode)
-    const Candidate * mother(size_type = 0) const override;
+    const Candidate* mother(size_type = 0) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate * daughter(size_type) override;
+    Candidate* daughter(size_type) override;
     /// add a daughter via a reference
-    void addDaughter( const typename daughters::value_type & );    
+    void addDaughter(const typename daughters::value_type&);
     /// add a daughter via a reference
-    void addMother( const typename mothers::value_type & );    
+    void addMother(const typename mothers::value_type&);
     /// clear daughter references
     void clearDaughters() { dau.clear(); }
     /// clear mother references
     void clearMothers() { mom.clear(); }
-    /// reference to daughter at given position       
-    typename daughters::value_type daughterRef( size_type i ) const { return dau[ i ]; }
+    /// reference to daughter at given position
+    typename daughters::value_type daughterRef(size_type i) const { return dau[i]; }
     /// references to daughtes
-    const daughters & daughterRefVector() const { return dau; }
+    const daughters& daughterRefVector() const { return dau; }
     /// reference to mother at given position
-    typename daughters::value_type motherRef( size_type i = 0 ) const { return mom[ i ]; }
+    typename daughters::value_type motherRef(size_type i = 0) const { return mom[i]; }
     /// references to mothers
-    const mothers & motherRefVector() const { return mom; }
+    const mothers& motherRefVector() const { return mom; }
     /// set daughters product ID
-    void resetDaughters( const edm::ProductID & id ) { dau = daughters( id ); }
+    void resetDaughters(const edm::ProductID& id) { dau = daughters(id); }
     /// set mother product ID
-    void resetMothers( const edm::ProductID & id ) { mom = mothers( id ); }
+    void resetMothers(const edm::ProductID& id) { mom = mothers(id); }
 
     CMS_CLASS_VERSION(13)
 
@@ -78,57 +86,56 @@ namespace reco {
     /// collection of references to mothers
     daughters mom;
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
   };
 
-  template<typename D>
-  inline void CompositeRefCandidateT<D>::addDaughter( const typename daughters::value_type & cand ) { 
-    dau.push_back( cand ); 
+  template <typename D>
+  inline void CompositeRefCandidateT<D>::addDaughter(const typename daughters::value_type& cand) {
+    dau.push_back(cand);
   }
 
-  template<typename D>
-  inline void CompositeRefCandidateT<D>::addMother( const typename daughters::value_type & cand ) { 
-    mom.push_back( cand ); 
+  template <typename D>
+  inline void CompositeRefCandidateT<D>::addMother(const typename daughters::value_type& cand) {
+    mom.push_back(cand);
   }
 
-  template<typename D>
-  CompositeRefCandidateT<D>::~CompositeRefCandidateT() { 
+  template <typename D>
+  CompositeRefCandidateT<D>::~CompositeRefCandidateT() {}
+
+  template <typename D>
+  CompositeRefCandidateT<D>* CompositeRefCandidateT<D>::clone() const {
+    return new CompositeRefCandidateT(*this);
   }
-  
-  template<typename D>
-  CompositeRefCandidateT<D> * CompositeRefCandidateT<D>::clone() const { 
-    return new CompositeRefCandidateT( * this ); 
+
+  template <typename D>
+  const Candidate* CompositeRefCandidateT<D>::daughter(size_type i) const {
+    return (i < numberOfDaughters()) ? &*dau[i] : nullptr;
   }
-  
-  template<typename D>
-  const Candidate * CompositeRefCandidateT<D>::daughter( size_type i ) const { 
-    return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr;
+
+  template <typename D>
+  const Candidate* CompositeRefCandidateT<D>::mother(size_type i) const {
+    return (i < numberOfMothers()) ? &*mom[i] : nullptr;
   }
-  
-  template<typename D>
-  const Candidate * CompositeRefCandidateT<D>::mother( size_type i ) const { 
-    return ( i < numberOfMothers() ) ? & * mom[ i ] : nullptr;
-  }
-  
-  template<typename D>
-  Candidate * CompositeRefCandidateT<D>::daughter( size_type i ) { 
+
+  template <typename D>
+  Candidate* CompositeRefCandidateT<D>::daughter(size_type i) {
     return nullptr;
   }
-  
-  template<typename D>
-  size_t CompositeRefCandidateT<D>::numberOfDaughters() const { 
-    return dau.size(); 
+
+  template <typename D>
+  size_t CompositeRefCandidateT<D>::numberOfDaughters() const {
+    return dau.size();
   }
-  
-  template<typename D>
-  size_t CompositeRefCandidateT<D>::numberOfMothers() const { 
-    return mom.size(); 
+
+  template <typename D>
+  size_t CompositeRefCandidateT<D>::numberOfMothers() const {
+    return mom.size();
   }
-  
-  template<typename D>
-  bool CompositeRefCandidateT<D>::overlap( const Candidate & c2 ) const {
-    throw cms::Exception( "Error" ) << "can't check overlap internally for CompositeRefCanddate";
+
+  template <typename D>
+  bool CompositeRefCandidateT<D>::overlap(const Candidate& c2) const {
+    throw cms::Exception("Error") << "can't check overlap internally for CompositeRefCanddate";
   }
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/LeafCandidate.h
+++ b/DataFormats/Candidate/interface/LeafCandidate.h
@@ -12,54 +12,71 @@
 #include "ParticleState.h"
 
 namespace reco {
-  
+
   class LeafCandidate : public Candidate {
   public:
-    /// collection of daughter candidates                                                 
+    /// collection of daughter candidates
     typedef CandidateCollection daughters;
-    /// electric charge type                                                              
+    /// electric charge type
     typedef int Charge;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::XYZTLorentzVector LorentzVector;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZPoint Point;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZVector Vector;
 
     typedef unsigned int index;
 
     LeafCandidate() {}
 
-    // constructor from candidate 
-    explicit LeafCandidate( const Candidate & c) : m_state(c.charge(),c.polarP4(), c.vertex(), c.pdgId(), c.status() ){}
+    // constructor from candidate
+    explicit LeafCandidate(const Candidate& c) : m_state(c.charge(), c.polarP4(), c.vertex(), c.pdgId(), c.status()) {}
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    template<typename... Args>
-    explicit   LeafCandidate(Args && ...args) : 
-    m_state(std::forward<Args>(args)...) {}
+    template <typename... Args>
+    explicit LeafCandidate(Args&&... args) : m_state(std::forward<Args>(args)...) {}
 
-    LeafCandidate(LeafCandidate& rh): m_state(rh.m_state){}
+    LeafCandidate(LeafCandidate& rh) : m_state(rh.m_state) {}
 
-    LeafCandidate(LeafCandidate&&)=default;
-    LeafCandidate(LeafCandidate const&)=default;
-    LeafCandidate& operator=(LeafCandidate&&)=default;
-    LeafCandidate& operator=(LeafCandidate const&)=default;
+    LeafCandidate(LeafCandidate&&) = default;
+    LeafCandidate(LeafCandidate const&) = default;
+    LeafCandidate& operator=(LeafCandidate&&) = default;
+    LeafCandidate& operator=(LeafCandidate const&) = default;
 #else
     // for Reflex to parse...  (compilation will use the above)
-    LeafCandidate( Charge q, const PtEtaPhiMass & p4, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
-    LeafCandidate( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
-    LeafCandidate( Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
-    LeafCandidate( Charge q, const GlobalVector & p3, float iEnergy, float imass, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
+    LeafCandidate(Charge q,
+                  const PtEtaPhiMass& p4,
+                  const Point& vtx = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true);
+    LeafCandidate(Charge q,
+                  const LorentzVector& p4,
+                  const Point& vtx = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true);
+    LeafCandidate(Charge q,
+                  const PolarLorentzVector& p4,
+                  const Point& vtx = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true);
+    LeafCandidate(Charge q,
+                  const GlobalVector& p3,
+                  float iEnergy,
+                  float imass,
+                  const Point& vtx = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true);
 #endif
 
-    void construct(int qx3,  float pt, float eta, float phi, float mass, const Point & vtx, int pdgId, int status) {
-      m_state = ParticleState(qx3, PolarLorentzVector(pt,eta,phi,mass), vtx, pdgId, status, false);
+    void construct(int qx3, float pt, float eta, float phi, float mass, const Point& vtx, int pdgId, int status) {
+      m_state = ParticleState(qx3, PolarLorentzVector(pt, eta, phi, mass), vtx, pdgId, status, false);
     }
 
     /// destructor
@@ -67,121 +84,117 @@ namespace reco {
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// return daughter at a given position (throws an exception)
-    const Candidate * daughter( size_type ) const override;
+    const Candidate* daughter(size_type) const override;
     /// number of mothers
     size_t numberOfMothers() const override;
     /// return mother at a given position (throws an exception)
-    const Candidate * mother( size_type ) const override;
+    const Candidate* mother(size_type) const override;
     /// return daughter at a given position (throws an exception)
-    Candidate * daughter( size_type ) override;
+    Candidate* daughter(size_type) override;
     /// return daughter with a specified role name
-    Candidate * daughter(const std::string& s ) override;
-    /// return daughter with a specified role name                                        
-    const Candidate * daughter(const std::string& s ) const override;
-    /// return the number of source Candidates                                            
-    /// ( the candidates used to construct this Candidate)                                
-    size_t numberOfSourceCandidatePtrs() const override { return 0;}
-    /// return a Ptr to one of the source Candidates                                      
-    /// ( the candidates used to construct this Candidate)                                
-    CandidatePtr sourceCandidatePtr( size_type i ) const override {
-      return CandidatePtr();
-    }
+    Candidate* daughter(const std::string& s) override;
+    /// return daughter with a specified role name
+    const Candidate* daughter(const std::string& s) const override;
+    /// return the number of source Candidates
+    /// ( the candidates used to construct this Candidate)
+    size_t numberOfSourceCandidatePtrs() const override { return 0; }
+    /// return a Ptr to one of the source Candidates
+    /// ( the candidates used to construct this Candidate)
+    CandidatePtr sourceCandidatePtr(size_type i) const override { return CandidatePtr(); }
 
     /// electric charge
     int charge() const final { return m_state.charge(); }
-    /// set electric charge                                                               
-    void setCharge( Charge q ) final { m_state.setCharge(q); }
-    /// electric charge                                                                   
+    /// set electric charge
+    void setCharge(Charge q) final { m_state.setCharge(q); }
+    /// electric charge
     int threeCharge() const final { return m_state.threeCharge(); }
-    /// set electric charge                                                               
-    void setThreeCharge( Charge qx3 ) final {m_state.setThreeCharge(qx3); }
-    /// four-momentum Lorentz vector                                                      
-    const LorentzVector & p4() const final { return m_state.p4(); }
-    /// four-momentum Lorentz vector                                                      
-    const PolarLorentzVector & polarP4() const final { return m_state.polarP4(); }
-    /// spatial momentum vector                                                           
+    /// set electric charge
+    void setThreeCharge(Charge qx3) final { m_state.setThreeCharge(qx3); }
+    /// four-momentum Lorentz vector
+    const LorentzVector& p4() const final { return m_state.p4(); }
+    /// four-momentum Lorentz vector
+    const PolarLorentzVector& polarP4() const final { return m_state.polarP4(); }
+    /// spatial momentum vector
     Vector momentum() const final { return m_state.momentum(); }
-    /// boost vector to boost a Lorentz vector                                            
-    /// to the particle center of mass system                                             
+    /// boost vector to boost a Lorentz vector
+    /// to the particle center of mass system
     Vector boostToCM() const final { return m_state.boostToCM(); }
-    /// magnitude of momentum vector                                                      
+    /// magnitude of momentum vector
     double p() const final { return m_state.p(); }
-    /// energy                                                                            
+    /// energy
     double energy() const final { return m_state.energy(); }
-    /// transverse energy                                                                 
+    /// transverse energy
     double et() const final { return m_state.et(); }
-    /// transverse energy squared (use this for cut!)                                                                 
+    /// transverse energy squared (use this for cut!)
     double et2() const final { return m_state.et2(); }
-    /// mass                                                                              
+    /// mass
     double mass() const final { return m_state.mass(); }
-    /// mass squared                                                                      
+    /// mass squared
     double massSqr() const final { return mass() * mass(); }
 
-    /// transverse mass                                                                   
-    double mt() const final  { return m_state.mt(); }
-    /// transverse mass squared                                                           
-    double mtSqr() const final  { return m_state.mtSqr(); }
-    /// x coordinate of momentum vector                                                   
-    double px() const final  {  return m_state.px(); }
-    /// y coordinate of momentum vector                                                   
-    double py() const final  { return m_state.py(); }
-    /// z coordinate of momentum vector                                                   
-    double pz() const final  {  return m_state.pz(); }
-    /// transverse momentum                                                               
-    double pt() const final  { return m_state.pt();}
-    /// momentum azimuthal angle                                                          
-    double phi() const final  { return m_state.phi(); }
-    /// momentum polar angle                                                              
-    double theta() const final  {  return m_state.theta(); }
-    /// momentum pseudorapidity                                                           
-     double eta() const final  { return m_state.eta(); }
-    /// rapidity                                                                          
-    double rapidity() const final  {  return m_state.rapidity(); }
-    /// rapidity                                                                          
-    double y() const final  { return rapidity(); }
-    /// set 4-momentum                                                                    
-    void setP4( const LorentzVector & p4 ) final  { m_state.setP4(p4);}
-    /// set 4-momentum                                                                    
-    void setP4( const PolarLorentzVector & p4 ) final  {m_state.setP4(p4); }
-    /// set particle mass                                                                 
-    void setMass( double m ) final  {m_state.setMass(m);}
-    void setPz( double pz ) final  { m_state.setPz(pz);}
-    /// vertex position                 (overwritten by PF...)                                                  
-    const Point & vertex() const override { return m_state.vertex(); }
-    /// x coordinate of vertex position                                                   
-    double vx() const override  { return m_state.vx(); }
-    /// y coordinate of vertex position                                                   
-    double vy() const override  { return m_state.vy(); }
-    /// z coordinate of vertex position                                                   
-    double vz() const override  { return m_state.vz(); }
-    /// set vertex                                                                        
-    void setVertex( const Point & vertex ) override   { m_state.setVertex(vertex); }
+    /// transverse mass
+    double mt() const final { return m_state.mt(); }
+    /// transverse mass squared
+    double mtSqr() const final { return m_state.mtSqr(); }
+    /// x coordinate of momentum vector
+    double px() const final { return m_state.px(); }
+    /// y coordinate of momentum vector
+    double py() const final { return m_state.py(); }
+    /// z coordinate of momentum vector
+    double pz() const final { return m_state.pz(); }
+    /// transverse momentum
+    double pt() const final { return m_state.pt(); }
+    /// momentum azimuthal angle
+    double phi() const final { return m_state.phi(); }
+    /// momentum polar angle
+    double theta() const final { return m_state.theta(); }
+    /// momentum pseudorapidity
+    double eta() const final { return m_state.eta(); }
+    /// rapidity
+    double rapidity() const final { return m_state.rapidity(); }
+    /// rapidity
+    double y() const final { return rapidity(); }
+    /// set 4-momentum
+    void setP4(const LorentzVector& p4) final { m_state.setP4(p4); }
+    /// set 4-momentum
+    void setP4(const PolarLorentzVector& p4) final { m_state.setP4(p4); }
+    /// set particle mass
+    void setMass(double m) final { m_state.setMass(m); }
+    void setPz(double pz) final { m_state.setPz(pz); }
+    /// vertex position                 (overwritten by PF...)
+    const Point& vertex() const override { return m_state.vertex(); }
+    /// x coordinate of vertex position
+    double vx() const override { return m_state.vx(); }
+    /// y coordinate of vertex position
+    double vy() const override { return m_state.vy(); }
+    /// z coordinate of vertex position
+    double vz() const override { return m_state.vz(); }
+    /// set vertex
+    void setVertex(const Point& vertex) override { m_state.setVertex(vertex); }
 
-    /// PDG identifier                                                                    
-    int pdgId() const final  { return m_state.pdgId(); }
-    // set PDG identifier                                                                 
-    void setPdgId( int pdgId ) final  { m_state.setPdgId(pdgId); }
-    /// status word                                                                       
-    int status() const final  { return m_state.status(); }
-    /// set status word                                                                   
-    void setStatus( int status ) final  { m_state.setStatus(status); }
-    /// long lived flag                                                                   
-    /// set long lived flag                                                               
-    void setLongLived() final  { m_state.setLongLived(); }
-    /// is long lived?                                                                    
-    bool longLived() const final  { return m_state.longLived(); }
+    /// PDG identifier
+    int pdgId() const final { return m_state.pdgId(); }
+    // set PDG identifier
+    void setPdgId(int pdgId) final { m_state.setPdgId(pdgId); }
+    /// status word
+    int status() const final { return m_state.status(); }
+    /// set status word
+    void setStatus(int status) final { m_state.setStatus(status); }
+    /// long lived flag
+    /// set long lived flag
+    void setLongLived() final { m_state.setLongLived(); }
+    /// is long lived?
+    bool longLived() const final { return m_state.longLived(); }
     /// do mass constraint flag
     /// set mass constraint flag
-    void setMassConstraint() final  { m_state.setMassConstraint();}
+    void setMassConstraint() final { m_state.setMassConstraint(); }
     /// do mass constraint?
-    bool massConstraint() const final  { return m_state.massConstraint(); }
+    bool massConstraint() const final { return m_state.massConstraint(); }
 
-    /// returns a clone of the Candidate object                                           
-    LeafCandidate * clone() const override  {
-      return new LeafCandidate( *this );
-    }
+    /// returns a clone of the Candidate object
+    LeafCandidate* clone() const override { return new LeafCandidate(*this); }
 
-    /// chi-squares                                                                                                    
+    /// chi-squares
     double vertexChi2() const override;
     /** Number of degrees of freedom                                                                                   
      *  Meant to be Double32_t for soft-assignment fitters:                                                            
@@ -190,63 +203,85 @@ namespace reco {
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002                                                                  
      */
     double vertexNdof() const override;
-    /// chi-squared divided by n.d.o.f.                                                                                
+    /// chi-squared divided by n.d.o.f.
     double vertexNormalizedChi2() const override;
-    /// (i, j)-th element of error matrix, i, j = 0, ... 2                                                             
+    /// (i, j)-th element of error matrix, i, j = 0, ... 2
     double vertexCovariance(int i, int j) const override;
-    /// return SMatrix                                                                                                 
-    CovarianceMatrix vertexCovariance() const final  { CovarianceMatrix m; fillVertexCovariance(m); return m; }
-    /// fill SMatrix                                                                                                   
-    void fillVertexCovariance(CovarianceMatrix & v) const override;
-    /// returns true if this candidate has a reference to a master clone.                                              
-    /// This only happens if the concrete Candidate type is ShallowCloneCandidate                                      
+    /// return SMatrix
+    CovarianceMatrix vertexCovariance() const final {
+      CovarianceMatrix m;
+      fillVertexCovariance(m);
+      return m;
+    }
+    /// fill SMatrix
+    void fillVertexCovariance(CovarianceMatrix& v) const override;
+    /// returns true if this candidate has a reference to a master clone.
+    /// This only happens if the concrete Candidate type is ShallowCloneCandidate
     bool hasMasterClone() const override;
-    /// returns ptr to master clone, if existing.                                                                      
-    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate                                
-    const CandidateBaseRef & masterClone() const override;
-    /// returns true if this candidate has a ptr to a master clone.                                                    
-    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate                                   
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
+    const CandidateBaseRef& masterClone() const override;
+    /// returns true if this candidate has a ptr to a master clone.
+    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
     bool hasMasterClonePtr() const override;
-    /// returns ptr to master clone, if existing.                                                                      
-    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate                             
-    const CandidatePtr & masterClonePtr() const override;
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
+    const CandidatePtr& masterClonePtr() const override;
 
-    /// cast master clone reference to a concrete type                                                                 
-    template<typename Ref>
-      Ref masterRef() const { return masterClone().template castTo<Ref>(); }
-    /// get a component                                                                                                
+    /// cast master clone reference to a concrete type
+    template <typename Ref>
+    Ref masterRef() const {
+      return masterClone().template castTo<Ref>();
+    }
+    /// get a component
 
-    template<typename T> T get() const {
-      if ( hasMasterClone() ) return masterClone()->get<T>();
-      else return reco::get<T>( * this );
+    template <typename T>
+    T get() const {
+      if (hasMasterClone())
+        return masterClone()->get<T>();
+      else
+        return reco::get<T>(*this);
     }
-    /// get a component                                                                                                
-    template<typename T, typename Tag> T get() const {
-      if ( hasMasterClone() ) return masterClone()->get<T, Tag>();
-      else return reco::get<T, Tag>( * this );
+    /// get a component
+    template <typename T, typename Tag>
+    T get() const {
+      if (hasMasterClone())
+        return masterClone()->get<T, Tag>();
+      else
+        return reco::get<T, Tag>(*this);
     }
-    /// get a component                                                                                                
-    template<typename T> T get( size_type i ) const {
-      if ( hasMasterClone() ) return masterClone()->get<T>( i );
-      else return reco::get<T>( * this, i );
+    /// get a component
+    template <typename T>
+    T get(size_type i) const {
+      if (hasMasterClone())
+        return masterClone()->get<T>(i);
+      else
+        return reco::get<T>(*this, i);
     }
-    /// get a component                                                                                                
-    template<typename T, typename Tag> T get( size_type i ) const {
-      if ( hasMasterClone() ) return masterClone()->get<T, Tag>( i );
-      else return reco::get<T, Tag>( * this, i );
+    /// get a component
+    template <typename T, typename Tag>
+    T get(size_type i) const {
+      if (hasMasterClone())
+        return masterClone()->get<T, Tag>(i);
+      else
+        return reco::get<T, Tag>(*this, i);
     }
-    /// number of components                                                                                           
-    template<typename T> size_type numberOf() const {
-      if ( hasMasterClone() ) return masterClone()->numberOf<T>();
-      else return reco::numberOf<T>( * this );
+    /// number of components
+    template <typename T>
+    size_type numberOf() const {
+      if (hasMasterClone())
+        return masterClone()->numberOf<T>();
+      else
+        return reco::numberOf<T>(*this);
     }
-    /// number of components                                                                                           
-    template<typename T, typename Tag> size_type numberOf() const {
-      if ( hasMasterClone() ) return masterClone()->numberOf<T, Tag>();
-      else return reco::numberOf<T, Tag>( * this );
+    /// number of components
+    template <typename T, typename Tag>
+    size_type numberOf() const {
+      if (hasMasterClone())
+        return masterClone()->numberOf<T, Tag>();
+      else
+        return reco::numberOf<T, Tag>(*this);
     }
-
-
 
     bool isElectron() const override;
     bool isMuon() const override;
@@ -261,16 +296,16 @@ namespace reco {
   private:
     ParticleState m_state;
 
-    private:
-    /// check overlap with another Candidate                                              
-    bool overlap( const Candidate & ) const override;
-    template<typename, typename, typename> friend struct component;
+  private:
+    /// check overlap with another Candidate
+    bool overlap(const Candidate&) const override;
+    template <typename, typename, typename>
+    friend struct component;
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;
     friend class ShallowClonePtrCandidate;
-
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/LeafRefCandidateT.h
+++ b/DataFormats/Candidate/interface/LeafRefCandidateT.h
@@ -12,146 +12,167 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"
 
-
 namespace reco {
-  
+
   class LeafRefCandidateT : public LeafCandidate {
   public:
-    /// collection of daughter candidates                                                 
+    /// collection of daughter candidates
     typedef CandidateCollection daughters;
-    /// electric charge type                                                              
+    /// electric charge type
     typedef int Charge;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::XYZTLorentzVector LorentzVector;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZPoint Point;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZVector Vector;
 
     typedef unsigned int index;
 
-    /// default constructor                                                               
-    LeafRefCandidateT() { }
-    // constructor from T                                                        
-    template < class REF >
-    LeafRefCandidateT( const REF & c, float m) :  
-      LeafCandidate(c->charge(),PolarLorentzVector(c->pt(), c->eta(), c->phi(), m ),c->vertex()),
-      ref_(c.refCore(), c.key()){}
+    /// default constructor
+    LeafRefCandidateT() {}
+    // constructor from T
+    template <class REF>
+    LeafRefCandidateT(const REF& c, float m)
+        : LeafCandidate(c->charge(), PolarLorentzVector(c->pt(), c->eta(), c->phi(), m), c->vertex()),
+          ref_(c.refCore(), c.key()) {}
     /// destructor
     ~LeafRefCandidateT() override {}
 
-protected:
+  protected:
     // get the ref (better be the correct ref!)
-    template<typename REF>   
-    REF getRef() const { return REF(ref_.toRefCore(),ref_.index()); }
+    template <typename REF>
+    REF getRef() const {
+      return REF(ref_.toRefCore(), ref_.index());
+    }
 
-public:
+  public:
     /// number of daughters
-    size_t numberOfDaughters() const final  { return 0; }
+    size_t numberOfDaughters() const final { return 0; }
     /// return daughter at a given position (throws an exception)
-    const Candidate * daughter( size_type ) const final  { return nullptr; }
+    const Candidate* daughter(size_type) const final { return nullptr; }
     /// number of mothers
-    size_t numberOfMothers() const final  { return 0; }
+    size_t numberOfMothers() const final { return 0; }
     /// return mother at a given position (throws an exception)
-    const Candidate * mother( size_type ) const final  { return nullptr; }
+    const Candidate* mother(size_type) const final { return nullptr; }
     /// return daughter at a given position (throws an exception)
-    Candidate * daughter( size_type ) final  { return nullptr; }
+    Candidate* daughter(size_type) final { return nullptr; }
     /// return daughter with a specified role name
-    Candidate * daughter(const std::string& s ) final  { return nullptr; }
-    /// return daughter with a specified role name                                        
-    const Candidate * daughter(const std::string& s ) const final  { return nullptr; }
-    /// return the number of source Candidates                                            
-    /// ( the candidates used to construct this Candidate)                                
-    size_t numberOfSourceCandidatePtrs() const final  { return 0;}
-    /// return a Ptr to one of the source Candidates                                      
-    /// ( the candidates used to construct this Candidate)                                
-    CandidatePtr sourceCandidatePtr( size_type i ) const final  {
+    Candidate* daughter(const std::string& s) final { return nullptr; }
+    /// return daughter with a specified role name
+    const Candidate* daughter(const std::string& s) const final { return nullptr; }
+    /// return the number of source Candidates
+    /// ( the candidates used to construct this Candidate)
+    size_t numberOfSourceCandidatePtrs() const final { return 0; }
+    /// return a Ptr to one of the source Candidates
+    /// ( the candidates used to construct this Candidate)
+    CandidatePtr sourceCandidatePtr(size_type i) const final {
       static const CandidatePtr dummyPtr;
       return dummyPtr;
     }
 
-
-                     
-    /// This only happens if the concrete Candidate type is ShallowCloneCandidate                                      
-    bool hasMasterClone() const final  { return false; }
-    /// returns ptr to master clone, if existing.                                                                      
-    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate                                
-    const CandidateBaseRef & masterClone() const final  { 
-      static const CandidateBaseRef dummyRef; return dummyRef; 
+    /// This only happens if the concrete Candidate type is ShallowCloneCandidate
+    bool hasMasterClone() const final { return false; }
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
+    const CandidateBaseRef& masterClone() const final {
+      static const CandidateBaseRef dummyRef;
+      return dummyRef;
     }
-    /// returns true if this candidate has a ptr to a master clone.                                                    
-    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate                                   
-    bool hasMasterClonePtr() const final  { return false; }
-    /// returns ptr to master clone, if existing.                                                                      
-    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate                             
-    const CandidatePtr & masterClonePtr() const final  { 
-      static const CandidatePtr dummyPtr; return dummyPtr; 
-    }
-
-    /// cast master clone reference to a concrete type                                                                 
-    template<typename Ref>
-      Ref masterRef() const { Ref dummyRef; return dummyRef; }
-    /// get a component                                                                                                
-
-    template<typename C> C get() const {
-      if ( hasMasterClone() ) return masterClone()->template get<C>();
-      else return reco::get<C>( * this );
-    }
-    /// get a component                                                                                                
-    template<typename C, typename Tag> C get() const {
-      if ( hasMasterClone() ) return masterClone()->template get<C, Tag>();
-      else return reco::get<C, Tag>( * this );
-    }
-    /// get a component                                                                                                
-    template<typename C> C get( size_type i ) const {
-      if ( hasMasterClone() ) return masterClone()->template get<C>( i );
-      else return reco::get<C>( * this, i );
-    }
-    /// get a component                                                                                                
-    template<typename C, typename Tag> C get( size_type i ) const {
-      if ( hasMasterClone() ) return masterClone()->template get<C, Tag>( i );
-      else return reco::get<C, Tag>( * this, i );
-    }
-    /// number of components                                                                                           
-    template<typename C> size_type numberOf() const {
-      if ( hasMasterClone() ) return masterClone()->template numberOf<C>();
-      else return reco::numberOf<C>( * this );
-    }
-    /// number of components                                                                                           
-    template<typename C, typename Tag> size_type numberOf() const {
-      if ( hasMasterClone() ) return masterClone()->template numberOf<C, Tag>();
-      else return reco::numberOf<C, Tag>( * this );
+    /// returns true if this candidate has a ptr to a master clone.
+    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
+    bool hasMasterClonePtr() const final { return false; }
+    /// returns ptr to master clone, if existing.
+    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
+    const CandidatePtr& masterClonePtr() const final {
+      static const CandidatePtr dummyPtr;
+      return dummyPtr;
     }
 
+    /// cast master clone reference to a concrete type
+    template <typename Ref>
+    Ref masterRef() const {
+      Ref dummyRef;
+      return dummyRef;
+    }
+    /// get a component
 
-    bool isElectron() const final  { return false; }
-    bool isMuon() const final  { return false; }
-    bool isStandAloneMuon() const final  { return false; }
-    bool isGlobalMuon() const final  { return false; }
-    bool isTrackerMuon() const final  { return false; }
-    bool isCaloMuon() const final  { return false; }
-    bool isPhoton() const final  { return false; }
-    bool isConvertedPhoton() const final  { return false; }
-    bool isJet() const final  { return false; }
+    template <typename C>
+    C get() const {
+      if (hasMasterClone())
+        return masterClone()->template get<C>();
+      else
+        return reco::get<C>(*this);
+    }
+    /// get a component
+    template <typename C, typename Tag>
+    C get() const {
+      if (hasMasterClone())
+        return masterClone()->template get<C, Tag>();
+      else
+        return reco::get<C, Tag>(*this);
+    }
+    /// get a component
+    template <typename C>
+    C get(size_type i) const {
+      if (hasMasterClone())
+        return masterClone()->template get<C>(i);
+      else
+        return reco::get<C>(*this, i);
+    }
+    /// get a component
+    template <typename C, typename Tag>
+    C get(size_type i) const {
+      if (hasMasterClone())
+        return masterClone()->template get<C, Tag>(i);
+      else
+        return reco::get<C, Tag>(*this, i);
+    }
+    /// number of components
+    template <typename C>
+    size_type numberOf() const {
+      if (hasMasterClone())
+        return masterClone()->template numberOf<C>();
+      else
+        return reco::numberOf<C>(*this);
+    }
+    /// number of components
+    template <typename C, typename Tag>
+    size_type numberOf() const {
+      if (hasMasterClone())
+        return masterClone()->template numberOf<C, Tag>();
+      else
+        return reco::numberOf<C, Tag>(*this);
+    }
+
+    bool isElectron() const final { return false; }
+    bool isMuon() const final { return false; }
+    bool isStandAloneMuon() const final { return false; }
+    bool isGlobalMuon() const final { return false; }
+    bool isTrackerMuon() const final { return false; }
+    bool isCaloMuon() const final { return false; }
+    bool isPhoton() const final { return false; }
+    bool isConvertedPhoton() const final { return false; }
+    bool isJet() const final { return false; }
 
     CMS_CLASS_VERSION(13)
 
   protected:
- 
-    /// check overlap with another Candidate                                              
-    bool overlap( const Candidate & ) const override;
-    virtual bool overlap( const LeafRefCandidateT & ) const;
-    template<typename, typename, typename> friend struct component;
+    /// check overlap with another Candidate
+    bool overlap(const Candidate&) const override;
+    virtual bool overlap(const LeafRefCandidateT&) const;
+    template <typename, typename, typename>
+    friend struct component;
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;
     friend class ShallowClonePtrCandidate;
 
   protected:
     edm::RefCoreWithIndex ref_;
-  private:
 
+  private:
     ///
     /// Hide these from all users:
     ///
@@ -175,20 +196,14 @@ public:
     */
   };
 
-
-
-  inline
-  bool LeafRefCandidateT::overlap( const Candidate & o ) const  { 
-    return  p4() == o.p4() && vertex() == o.vertex() && charge() == o.charge();
-  }
-  
-  inline
-  bool LeafRefCandidateT::overlap( const LeafRefCandidateT & o ) const   { 
-    return  (ref_.id() == o.ref_.id()) & (ref_.index() == o.ref_.index());
+  inline bool LeafRefCandidateT::overlap(const Candidate& o) const {
+    return p4() == o.p4() && vertex() == o.vertex() && charge() == o.charge();
   }
 
+  inline bool LeafRefCandidateT::overlap(const LeafRefCandidateT& o) const {
+    return (ref_.id() == o.ref_.id()) & (ref_.index() == o.ref_.index());
+  }
 
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/NamedCompositeCandidate.h
+++ b/DataFormats/Candidate/interface/NamedCompositeCandidate.h
@@ -20,56 +20,60 @@ namespace reco {
 
   class NamedCompositeCandidate : public CompositeCandidate {
   public:
-    typedef std::vector<std::string>                   role_collection;
+    typedef std::vector<std::string> role_collection;
 
     /// default constructor
-    NamedCompositeCandidate(std::string name="") : CompositeCandidate(), name_(name) { }
+    NamedCompositeCandidate(std::string name = "") : CompositeCandidate(), name_(name) {}
+    NamedCompositeCandidate(std::string name, const role_collection& roles)
+        : CompositeCandidate(), name_(name), roles_(roles) {}
+    /// constructor from values
     NamedCompositeCandidate(std::string name,
-			    const role_collection & roles  ) : 
-      CompositeCandidate(), name_(name), roles_(roles) { }
+                            const role_collection& roles,
+                            Charge q,
+                            const LorentzVector& p4,
+                            const Point& vtx = Point(0, 0, 0),
+                            int pdgId = 0,
+                            int status = 0,
+                            bool integerCharge = true)
+        : CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge), name_(name), roles_(roles) {}
     /// constructor from values
-    NamedCompositeCandidate( std::string name, 
-			     const role_collection & roles,
-			     Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-			     int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      CompositeCandidate( q, p4, vtx, pdgId, status, integerCharge ), 
-      name_ (name), roles_(roles) { }
-    /// constructor from values
-    NamedCompositeCandidate( std::string name, 
-			     const role_collection & roles, 
-			     const Candidate & p );
- 
+    NamedCompositeCandidate(std::string name, const role_collection& roles, const Candidate& p);
+
     /// destructor
     ~NamedCompositeCandidate() override;
     /// returns a clone of the candidate
-    NamedCompositeCandidate * clone() const override;
+    NamedCompositeCandidate* clone() const override;
     // get name
-    std::string             name() const { return name_; }
+    std::string name() const { return name_; }
     // set name
-    void                    setName( std::string n ) { name_ = n; }
+    void setName(std::string n) { name_ = n; }
     // get roles
-    const NamedCompositeCandidate::role_collection & roles() const { return roles_;}
+    const NamedCompositeCandidate::role_collection& roles() const { return roles_; }
     // set roles
-    void                    setRoles( const NamedCompositeCandidate::role_collection & roles ) { roles_.clear(); roles_ = roles; }
+    void setRoles(const NamedCompositeCandidate::role_collection& roles) {
+      roles_.clear();
+      roles_ = roles;
+    }
     // Get candidate based on role
-    Candidate *       daughter(const std::string& s ) override;
-    const Candidate * daughter(const std::string& s ) const override;
+    Candidate* daughter(const std::string& s) override;
+    const Candidate* daughter(const std::string& s) const override;
     // Get candidate based on index
-    Candidate *       daughter( size_type i ) override { return CompositeCandidate::daughter(i); }
-    const Candidate * daughter( size_type i ) const override  { return CompositeCandidate::daughter(i); }
+    Candidate* daughter(size_type i) override { return CompositeCandidate::daughter(i); }
+    const Candidate* daughter(size_type i) const override { return CompositeCandidate::daughter(i); }
     // Add daughters
-    void                    addDaughter( const Candidate &, const std::string&s );
-    void                    addDaughter( std::unique_ptr<Candidate>, const std::string& s );
+    void addDaughter(const Candidate&, const std::string& s);
+    void addDaughter(std::unique_ptr<Candidate>, const std::string& s);
     // Clear daughters and roles
-    void                    clearDaughters() { CompositeCandidate::clearDaughters(); }
-    void                    clearRoles() { roles_.clear(); }
+    void clearDaughters() { CompositeCandidate::clearDaughters(); }
+    void clearRoles() { roles_.clear(); }
     // Apply the roles to the objects
-    void                    applyRoles();
+    void applyRoles();
+
   private:
-    std::string      name_;
-    role_collection  roles_;
+    std::string name_;
+    role_collection roles_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h
@@ -31,6 +31,6 @@ namespace reco {
   typedef edm::RefProd<NamedCompositeCandidateCollection> NamedCompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type
   typedef edm::RefToBaseProd<NamedCompositeCandidate> NamedCompositeCandidateBaseRefProd;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/OverlapChecker.h
+++ b/DataFormats/Candidate/interface/OverlapChecker.h
@@ -11,13 +11,13 @@
  */
 
 namespace reco {
-  class Candidate; 
+  class Candidate;
 }
 
 class OverlapChecker {
 public:
   /// return true if two candidates overlap
-  bool operator()( const reco::Candidate &, const reco::Candidate & ) const;
+  bool operator()(const reco::Candidate &, const reco::Candidate &) const;
 };
 
 #endif

--- a/DataFormats/Candidate/interface/Particle.h
+++ b/DataFormats/Candidate/interface/Particle.h
@@ -12,149 +12,163 @@
 
 #include "ParticleState.h"
 namespace reco {
-  
+
   class Particle {
   public:
-    /// electric charge type                                                              
+    /// electric charge type
     typedef int Charge;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::XYZTLorentzVector LorentzVector;
-    /// Lorentz vector                                                                    
+    /// Lorentz vector
     typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZPoint Point;
-    /// point in the space                                                                
+    /// point in the space
     typedef math::XYZVector Vector;
 
     typedef unsigned int index;
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    template<typename... Args>
-    explicit   Particle(Args && ...args) : 
-    m_state(std::forward<Args>(args)...) {}
+    template <typename... Args>
+    explicit Particle(Args&&... args) : m_state(std::forward<Args>(args)...) {}
 
-    Particle(Particle& rh): m_state(rh.m_state){}
+    Particle(Particle& rh) : m_state(rh.m_state) {}
 
-    Particle(Particle&&)=default;
-    Particle(Particle const&)=default;
-    Particle& operator=(Particle&&)=default;
-    Particle& operator=(Particle const&)=default;
+    Particle(Particle&&) = default;
+    Particle(Particle const&) = default;
+    Particle& operator=(Particle&&) = default;
+    Particle& operator=(Particle const&) = default;
 #else
     // for Reflex to parse...  (compilation will use the above)
     Particle();
-    Particle( Charge q, const PtEtaPhiMass & p4, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
-    Particle( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
-    Particle( Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
-    Particle( Charge q, const GlobalVector & p3, float iEnergy, float imass, const Point & vtx = Point( 0, 0, 0 ),
-		   int pdgId = 0, int status = 0, bool integerCharge = true );
+    Particle(Charge q,
+             const PtEtaPhiMass& p4,
+             const Point& vtx = Point(0, 0, 0),
+             int pdgId = 0,
+             int status = 0,
+             bool integerCharge = true);
+    Particle(Charge q,
+             const LorentzVector& p4,
+             const Point& vtx = Point(0, 0, 0),
+             int pdgId = 0,
+             int status = 0,
+             bool integerCharge = true);
+    Particle(Charge q,
+             const PolarLorentzVector& p4,
+             const Point& vtx = Point(0, 0, 0),
+             int pdgId = 0,
+             int status = 0,
+             bool integerCharge = true);
+    Particle(Charge q,
+             const GlobalVector& p3,
+             float iEnergy,
+             float imass,
+             const Point& vtx = Point(0, 0, 0),
+             int pdgId = 0,
+             int status = 0,
+             bool integerCharge = true);
 #endif
 
-    void construct(int qx3,  float pt, float eta, float phi, float mass, const Point & vtx, int pdgId, int status) {
-      m_state = ParticleState(qx3, PolarLorentzVector(pt,eta,phi,mass), vtx, pdgId, status, false);
+    void construct(int qx3, float pt, float eta, float phi, float mass, const Point& vtx, int pdgId, int status) {
+      m_state = ParticleState(qx3, PolarLorentzVector(pt, eta, phi, mass), vtx, pdgId, status, false);
     }
 
     /// destructor
-    virtual ~Particle(){}
-
+    virtual ~Particle() {}
 
     /// electric charge
     int charge() const { return m_state.charge(); }
-    /// set electric charge                                                               
-    void setCharge( Charge q ) { m_state.setCharge(q); }
-    /// electric charge                                                                   
+    /// set electric charge
+    void setCharge(Charge q) { m_state.setCharge(q); }
+    /// electric charge
     int threeCharge() const { return m_state.threeCharge(); }
-    /// set electric charge                                                               
-    void setThreeCharge( Charge qx3 ) {m_state.setThreeCharge(qx3); }
-    /// four-momentum Lorentz vector                                                      
-    const LorentzVector & p4() const { return m_state.p4(); }
-    /// four-momentum Lorentz vector                                                      
-    const PolarLorentzVector & polarP4() const { return m_state.polarP4(); }
-    /// spatial momentum vector                                                           
+    /// set electric charge
+    void setThreeCharge(Charge qx3) { m_state.setThreeCharge(qx3); }
+    /// four-momentum Lorentz vector
+    const LorentzVector& p4() const { return m_state.p4(); }
+    /// four-momentum Lorentz vector
+    const PolarLorentzVector& polarP4() const { return m_state.polarP4(); }
+    /// spatial momentum vector
     Vector momentum() const { return m_state.momentum(); }
-    /// boost vector to boost a Lorentz vector                                            
-    /// to the particle center of mass system                                             
+    /// boost vector to boost a Lorentz vector
+    /// to the particle center of mass system
     Vector boostToCM() const { return m_state.boostToCM(); }
-    /// magnitude of momentum vector                                                      
+    /// magnitude of momentum vector
     double p() const { return m_state.p(); }
-    /// energy                                                                            
+    /// energy
     double energy() const { return m_state.energy(); }
-    /// transverse energy                                                                 
+    /// transverse energy
     double et() const { return m_state.et(); }
-    /// transverse energy squared (use this for cut!)                                                                 
+    /// transverse energy squared (use this for cut!)
     double et2() const { return m_state.et2(); }
-    /// mass                                                                              
+    /// mass
     double mass() const { return m_state.mass(); }
-    /// mass squared                                                                      
+    /// mass squared
     double massSqr() const { return mass() * mass(); }
 
-    /// transverse mass                                                                   
-    double mt() const  { return m_state.mt(); }
-    /// transverse mass squared                                                           
-    double mtSqr() const  { return m_state.mtSqr(); }
-    /// x coordinate of momentum vector                                                   
-    double px() const  {  return m_state.px(); }
-    /// y coordinate of momentum vector                                                   
-    double py() const  { return m_state.py(); }
-    /// z coordinate of momentum vector                                                   
-    double pz() const  {  return m_state.pz(); }
-    /// transverse momentum                                                               
-    double pt() const  { return m_state.pt();}
-    /// momentum azimuthal angle                                                          
-    double phi() const  { return m_state.phi(); }
-    /// momentum polar angle                                                              
-    double theta() const  {  return m_state.theta(); }
-    /// momentum pseudorapidity                                                           
-     double eta() const  { return m_state.eta(); }
-    /// rapidity                                                                          
-    double rapidity() const  {  return m_state.rapidity(); }
-    /// rapidity                                                                          
-    double y() const  { return rapidity(); }
-    /// set 4-momentum                                                                    
-    void setP4( const LorentzVector & p4 )  { m_state.setP4(p4);}
-    /// set 4-momentum                                                                    
-    void setP4( const PolarLorentzVector & p4 )  {m_state.setP4(p4); }
-    /// set particle mass                                                                 
-    void setMass( double m )  {m_state.setMass(m);}
-    void setPz( double pz )  { m_state.setPz(pz);}
-    /// vertex position                 (overwritten by PF...)                                                  
-    const Point & vertex() const { return m_state.vertex(); }
-    /// x coordinate of vertex position                                                   
-    double vx() const  { return m_state.vx(); }
-    /// y coordinate of vertex position                                                   
-    double vy() const  { return m_state.vy(); }
-    /// z coordinate of vertex position                                                   
-    double vz() const  { return m_state.vz(); }
-    /// set vertex                                                                        
-    void setVertex( const Point & vertex )   { m_state.setVertex(vertex); }
+    /// transverse mass
+    double mt() const { return m_state.mt(); }
+    /// transverse mass squared
+    double mtSqr() const { return m_state.mtSqr(); }
+    /// x coordinate of momentum vector
+    double px() const { return m_state.px(); }
+    /// y coordinate of momentum vector
+    double py() const { return m_state.py(); }
+    /// z coordinate of momentum vector
+    double pz() const { return m_state.pz(); }
+    /// transverse momentum
+    double pt() const { return m_state.pt(); }
+    /// momentum azimuthal angle
+    double phi() const { return m_state.phi(); }
+    /// momentum polar angle
+    double theta() const { return m_state.theta(); }
+    /// momentum pseudorapidity
+    double eta() const { return m_state.eta(); }
+    /// rapidity
+    double rapidity() const { return m_state.rapidity(); }
+    /// rapidity
+    double y() const { return rapidity(); }
+    /// set 4-momentum
+    void setP4(const LorentzVector& p4) { m_state.setP4(p4); }
+    /// set 4-momentum
+    void setP4(const PolarLorentzVector& p4) { m_state.setP4(p4); }
+    /// set particle mass
+    void setMass(double m) { m_state.setMass(m); }
+    void setPz(double pz) { m_state.setPz(pz); }
+    /// vertex position                 (overwritten by PF...)
+    const Point& vertex() const { return m_state.vertex(); }
+    /// x coordinate of vertex position
+    double vx() const { return m_state.vx(); }
+    /// y coordinate of vertex position
+    double vy() const { return m_state.vy(); }
+    /// z coordinate of vertex position
+    double vz() const { return m_state.vz(); }
+    /// set vertex
+    void setVertex(const Point& vertex) { m_state.setVertex(vertex); }
 
-    /// PDG identifier                                                                    
-    int pdgId() const  { return m_state.pdgId(); }
-    // set PDG identifier                                                                 
-    void setPdgId( int pdgId )  { m_state.setPdgId(pdgId); }
-    /// status word                                                                       
-    int status() const  { return m_state.status(); }
-    /// set status word                                                                   
-    void setStatus( int status )  { m_state.setStatus(status); }
-    /// long lived flag                                                                   
-    /// set long lived flag                                                               
-    void setLongLived()  { m_state.setLongLived(); }
-    /// is long lived?                                                                    
-    bool longLived() const  { return m_state.longLived(); }
+    /// PDG identifier
+    int pdgId() const { return m_state.pdgId(); }
+    // set PDG identifier
+    void setPdgId(int pdgId) { m_state.setPdgId(pdgId); }
+    /// status word
+    int status() const { return m_state.status(); }
+    /// set status word
+    void setStatus(int status) { m_state.setStatus(status); }
+    /// long lived flag
+    /// set long lived flag
+    void setLongLived() { m_state.setLongLived(); }
+    /// is long lived?
+    bool longLived() const { return m_state.longLived(); }
     /// do mass constraint flag
     /// set mass constraint flag
-    void setMassConstraint()  { m_state.setMassConstraint();}
+    void setMassConstraint() { m_state.setMassConstraint(); }
     /// do mass constraint?
-    bool massConstraint() const  { return m_state.massConstraint(); }
+    bool massConstraint() const { return m_state.massConstraint(); }
 
   private:
     ParticleState m_state;
-
-
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/ParticleState.h
+++ b/DataFormats/Candidate/interface/ParticleState.h
@@ -18,7 +18,7 @@
 #include "Rtypes.h"
 
 namespace reco {
-  
+
   class ParticleState {
   public:
     /// electric charge type
@@ -32,117 +32,140 @@ namespace reco {
     /// point in the space
     typedef math::XYZVector Vector;
     /// default constructor
-    ParticleState() : vertex_(0, 0, 0),
-		 qx3_(0), pdgId_(0), status_(0){}
-    
-    /// constructor from values
-    ParticleState( Charge q, const PtEtaPhiMass  & p4, const Point & vertex= Point( 0, 0, 0 ),
-	      int pdgId=0, int status=0, bool integerCharge=true)
-      : vertex_( vertex ),  p4Polar_( p4.pt(), p4.eta(), p4.phi(), p4.mass() ),
-	p4Cartesian_(p4Polar_),
-	qx3_( integerCharge ? q*3 : q ),pdgId_( pdgId ), status_( status ){}
-    
-    /// constructor from values
-    ParticleState( Charge q, const LorentzVector & p4, const Point & vertex = Point( 0, 0, 0 ),
-	      int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      vertex_( vertex ), 
-      p4Polar_(p4), p4Cartesian_(p4),
-      qx3_( integerCharge ? q*3 : q ),pdgId_( pdgId ), status_( status ){}
+    ParticleState() : vertex_(0, 0, 0), qx3_(0), pdgId_(0), status_(0) {}
 
-    
     /// constructor from values
-    ParticleState( Charge q, const PolarLorentzVector & p4, const Point & vertex = Point( 0, 0, 0 ),
-	      int pdgId = 0, int status = 0, bool integerCharge = true ):
-      vertex_( vertex ), 
-      p4Polar_(p4), p4Cartesian_(p4),
-      qx3_( integerCharge ? q*3 : q ),pdgId_( pdgId ), status_( status ){}
-    
-    ParticleState( Charge q, const GlobalVector & p3, float iEnergy, float imass, const Point & vertex = Point( 0, 0, 0 ),
-                   int pdgId = 0, int status = 0, bool integerCharge = true ) :
-      vertex_( vertex ), 
-      p4Polar_(p3.perp(),p3.eta(),p3.phi(),imass),  p4Cartesian_(p3.x(),p3.y(),p3.z(), iEnergy),
-      qx3_( integerCharge ? q*3 : q ), pdgId_( pdgId ), status_( status ){}
+    ParticleState(Charge q,
+                  const PtEtaPhiMass& p4,
+                  const Point& vertex = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true)
+        : vertex_(vertex),
+          p4Polar_(p4.pt(), p4.eta(), p4.phi(), p4.mass()),
+          p4Cartesian_(p4Polar_),
+          qx3_(integerCharge ? q * 3 : q),
+          pdgId_(pdgId),
+          status_(status) {}
+
+    /// constructor from values
+    ParticleState(Charge q,
+                  const LorentzVector& p4,
+                  const Point& vertex = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true)
+        : vertex_(vertex),
+          p4Polar_(p4),
+          p4Cartesian_(p4),
+          qx3_(integerCharge ? q * 3 : q),
+          pdgId_(pdgId),
+          status_(status) {}
+
+    /// constructor from values
+    ParticleState(Charge q,
+                  const PolarLorentzVector& p4,
+                  const Point& vertex = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true)
+        : vertex_(vertex),
+          p4Polar_(p4),
+          p4Cartesian_(p4),
+          qx3_(integerCharge ? q * 3 : q),
+          pdgId_(pdgId),
+          status_(status) {}
+
+    ParticleState(Charge q,
+                  const GlobalVector& p3,
+                  float iEnergy,
+                  float imass,
+                  const Point& vertex = Point(0, 0, 0),
+                  int pdgId = 0,
+                  int status = 0,
+                  bool integerCharge = true)
+        : vertex_(vertex),
+          p4Polar_(p3.perp(), p3.eta(), p3.phi(), imass),
+          p4Cartesian_(p3.x(), p3.y(), p3.z(), iEnergy),
+          qx3_(integerCharge ? q * 3 : q),
+          pdgId_(pdgId),
+          status_(status) {}
 
     /// set internal cache
-    inline void setCartesian()  { 
-      p4Cartesian_ = p4Polar_;
-    }
- 
+    inline void setCartesian() { p4Cartesian_ = p4Polar_; }
+
     /// electric charge
     int charge() const { return qx3_ / 3; }
     /// set electric charge
-    void setCharge( Charge q ) { qx3_ = q * 3; }
+    void setCharge(Charge q) { qx3_ = q * 3; }
     /// electric charge
     int threeCharge() const { return qx3_; }
     /// set electric charge
-    void setThreeCharge( Charge qx3 ) { qx3_ = qx3; }
+    void setThreeCharge(Charge qx3) { qx3_ = qx3; }
     /// four-momentum Lorentz vector
-    const LorentzVector & p4() const {  return p4Cartesian_; }
+    const LorentzVector& p4() const { return p4Cartesian_; }
     /// four-momentum Lorentz vector
-    const PolarLorentzVector & polarP4() const { return p4Polar_; }
+    const PolarLorentzVector& polarP4() const { return p4Polar_; }
     /// spatial momentum vector
-    Vector momentum() const {  return p4Cartesian_.Vect(); }
-    /// boost vector to boost a Lorentz vector 
+    Vector momentum() const { return p4Cartesian_.Vect(); }
+    /// boost vector to boost a Lorentz vector
     /// to the particle center of mass system
-    Vector boostToCM() const {  return p4Cartesian_.BoostToCM(); }
+    Vector boostToCM() const { return p4Cartesian_.BoostToCM(); }
     /// magnitude of momentum vector
-    double p() const {  return p4Cartesian_.P(); }
+    double p() const { return p4Cartesian_.P(); }
     /// energy
-    double energy() const {  return p4Cartesian_.E(); }  
-    /// transverse energy 
-    double et() const { return (pt()<=0) ? 0 : p4Cartesian_.Et(); }  
+    double energy() const { return p4Cartesian_.E(); }
+    /// transverse energy
+    double et() const { return (pt() <= 0) ? 0 : p4Cartesian_.Et(); }
     /// transverse energy squared (use this for cuts)!
-    double et2() const { return (pt()<=0) ? 0 : p4Cartesian_.Et2(); }  
+    double et2() const { return (pt() <= 0) ? 0 : p4Cartesian_.Et2(); }
     /// mass
-    double mass() const { return  p4Polar_.mass(); }
+    double mass() const { return p4Polar_.mass(); }
     /// mass squared
-    double massSqr() const { return mass()*mass(); }
+    double massSqr() const { return mass() * mass(); }
     /// transverse mass
     double mt() const { return p4Polar_.Mt(); }
     /// transverse mass squared
     double mtSqr() const { return p4Polar_.Mt2(); }
     /// x coordinate of momentum vector
-    double px() const {  return p4Cartesian_.Px(); }
+    double px() const { return p4Cartesian_.Px(); }
     /// y coordinate of momentum vector
-    double py() const {  return p4Cartesian_.Py(); }
+    double py() const { return p4Cartesian_.Py(); }
     /// z coordinate of momentum vector
-    double pz() const {  return p4Cartesian_.Pz(); }
+    double pz() const { return p4Cartesian_.Pz(); }
     /// transverse momentum
     double pt() const { return p4Polar_.pt(); }
     /// momentum azimuthal angle
     double phi() const { return p4Polar_.phi(); }
     /// momentum polar angle
-    double theta() const {  return p4Cartesian_.Theta(); }
+    double theta() const { return p4Cartesian_.Theta(); }
     /// momentum pseudorapidity
     double eta() const { return p4Polar_.eta(); }
     /// repidity
-    double rapidity() const {  return p4Polar_.Rapidity(); }
+    double rapidity() const { return p4Polar_.Rapidity(); }
     /// repidity
     double y() const { return rapidity(); }
     /// set 4-momentum
-    void setP4( const LorentzVector & p4 ) { 
+    void setP4(const LorentzVector& p4) {
       p4Cartesian_ = p4;
       p4Polar_ = p4;
-
     }
     /// set 4-momentum
-    void setP4( const PolarLorentzVector & p4 ) { 
+    void setP4(const PolarLorentzVector& p4) {
       p4Polar_ = p4;
       p4Cartesian_ = p4;
     }
     /// set particle mass
-    void setMass( double m ) { 
+    void setMass(double m) {
       p4Polar_.SetM(m);
       setCartesian();
-      
     }
-    void setPz( double pz ) {
+    void setPz(double pz) {
       p4Cartesian_.SetPz(pz);
       p4Polar_ = p4Cartesian_;
-
     }
     /// vertex position
-    const Point & vertex() const { return vertex_; }
+    const Point& vertex() const { return vertex_; }
     /// x coordinate of vertex position
     double vx() const { return vertex_.X(); }
     /// y coordinate of vertex position
@@ -150,48 +173,46 @@ namespace reco {
     /// z coordinate of vertex position
     double vz() const { return vertex_.Z(); }
     /// set vertex
-    void setVertex( const Point & vertex ) { vertex_ = vertex; }
+    void setVertex(const Point& vertex) { vertex_ = vertex; }
     /// PDG identifier
     int pdgId() const { return pdgId_; }
     // set PDG identifier
-    void setPdgId( int pdgId ) { pdgId_ = pdgId; }
+    void setPdgId(int pdgId) { pdgId_ = pdgId; }
     /// status word
     int status() const { return status_; }
     /// set status word
-    void setStatus( int status ) { status_ = status; }
+    void setStatus(int status) { status_ = status; }
     /// set long lived flag
     void setLongLived() { status_ |= longLivedTag; }
     /// is long lived?
     bool longLived() const { return status_ & longLivedTag; }
     /// set mass constraint flag
-    void setMassConstraint() { status_ |= massConstraintTag;}
+    void setMassConstraint() { status_ |= massConstraintTag; }
     /// do mass constraint?
-    bool massConstraint() const  { return status_ & massConstraintTag; }
-
+    bool massConstraint() const { return status_ & massConstraintTag; }
 
   private:
     static const unsigned int longLivedTag = 65536;
     static const unsigned int massConstraintTag = 131072;
-    
+
   private:
     /// vertex position
     Point vertex_;
-    
+
     /// four-momentum Lorentz vector
     PolarLorentzVector p4Polar_;
     /// internal cache for p4
     LorentzVector p4Cartesian_;
 
     /// electric charge
-    Charge qx3_;   
+    Charge qx3_;
 
     /// PDG identifier
     int pdgId_;
     /// status word
     int status_;
-    
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/ShallowCloneCandidate.h
+++ b/DataFormats/Candidate/interface/ShallowCloneCandidate.h
@@ -17,41 +17,42 @@ namespace reco {
     /// collection of daughter candidates
     typedef CandidateCollection daughters;
     /// default constructor
-    ShallowCloneCandidate() : LeafCandidate() {  }
+    ShallowCloneCandidate() : LeafCandidate() {}
     /// constructor from Particle
-    explicit ShallowCloneCandidate( const CandidateBaseRef & masterClone ) : 
-      LeafCandidate( * masterClone ), 
-      masterClone_( masterClone->hasMasterClone() ? 
-		    masterClone->masterClone() : 
-		    masterClone ) { 
-    }
+    explicit ShallowCloneCandidate(const CandidateBaseRef& masterClone)
+        : LeafCandidate(*masterClone),
+          masterClone_(masterClone->hasMasterClone() ? masterClone->masterClone() : masterClone) {}
     /// constructor from values
-    ShallowCloneCandidate( const CandidateBaseRef & masterClone, 
-			   Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
-      LeafCandidate( q, p4, vtx ), masterClone_( masterClone ) { }
+    ShallowCloneCandidate(const CandidateBaseRef& masterClone,
+                          Charge q,
+                          const LorentzVector& p4,
+                          const Point& vtx = Point(0, 0, 0))
+        : LeafCandidate(q, p4, vtx), masterClone_(masterClone) {}
     /// constructor from values
-    ShallowCloneCandidate( const CandidateBaseRef & masterClone, 
-			   Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
-      LeafCandidate( q, p4, vtx ), masterClone_( masterClone ) { }
+    ShallowCloneCandidate(const CandidateBaseRef& masterClone,
+                          Charge q,
+                          const PolarLorentzVector& p4,
+                          const Point& vtx = Point(0, 0, 0))
+        : LeafCandidate(q, p4, vtx), masterClone_(masterClone) {}
     /// destructor
     ~ShallowCloneCandidate() override;
     /// returns a clone of the Candidate object
-    ShallowCloneCandidate * clone() const override;
+    ShallowCloneCandidate* clone() const override;
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// number of daughters
     size_t numberOfMothers() const override;
     /// return daughter at a given position (throws an exception)
-    const Candidate * daughter( size_type i ) const override;
+    const Candidate* daughter(size_type i) const override;
     /// return daughter at a given position (throws an exception)
-    const Candidate * mother( size_type i ) const override;
+    const Candidate* mother(size_type i) const override;
     /// return daughter at a given position (throws an exception)
-    Candidate * daughter( size_type i ) override;
-    using reco::LeafCandidate::daughter; // avoid hiding the base
+    Candidate* daughter(size_type i) override;
+    using reco::LeafCandidate::daughter;  // avoid hiding the base
     /// has master clone
     bool hasMasterClone() const override;
     /// returns reference to master clone
-    const CandidateBaseRef & masterClone() const override;
+    const CandidateBaseRef& masterClone() const override;
 
     bool isElectron() const override;
     bool isMuon() const override;
@@ -62,13 +63,14 @@ namespace reco {
     bool isPhoton() const override;
     bool isConvertedPhoton() const override;
     bool isJet() const override;
+
   private:
     /// check overlap with another Candidate
-    bool overlap( const Candidate & c ) const override { return masterClone_->overlap( c ); }
+    bool overlap(const Candidate& c) const override { return masterClone_->overlap(c); }
     /// CandidateBaseReference to master clone
     CandidateBaseRef masterClone_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/ShallowClonePtrCandidate.h
+++ b/DataFormats/Candidate/interface/ShallowClonePtrCandidate.h
@@ -17,40 +17,41 @@ namespace reco {
     /// collection of daughter candidates
     typedef CandidateCollection daughters;
     /// default constructor
-    ShallowClonePtrCandidate() : LeafCandidate() {  }
+    ShallowClonePtrCandidate() : LeafCandidate() {}
     /// constructor from Particle
-    explicit ShallowClonePtrCandidate( const CandidatePtr & masterClone ) : 
-      LeafCandidate( * masterClone ), 
-      masterClone_( masterClone ) { 
-    }
+    explicit ShallowClonePtrCandidate(const CandidatePtr& masterClone)
+        : LeafCandidate(*masterClone), masterClone_(masterClone) {}
     /// constructor from values
-    ShallowClonePtrCandidate( const CandidatePtr & masterClone, 
-			   Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
-      LeafCandidate( q, p4, vtx ), masterClone_( masterClone ) { }
+    ShallowClonePtrCandidate(const CandidatePtr& masterClone,
+                             Charge q,
+                             const LorentzVector& p4,
+                             const Point& vtx = Point(0, 0, 0))
+        : LeafCandidate(q, p4, vtx), masterClone_(masterClone) {}
     /// constructor from values
-    ShallowClonePtrCandidate( const CandidatePtr & masterClone, 
-			   Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
-      LeafCandidate( q, p4, vtx ), masterClone_( masterClone ) { }
+    ShallowClonePtrCandidate(const CandidatePtr& masterClone,
+                             Charge q,
+                             const PolarLorentzVector& p4,
+                             const Point& vtx = Point(0, 0, 0))
+        : LeafCandidate(q, p4, vtx), masterClone_(masterClone) {}
     /// destructor
     ~ShallowClonePtrCandidate() override;
     /// returns a clone of the Candidate object
-    ShallowClonePtrCandidate * clone() const override;
+    ShallowClonePtrCandidate* clone() const override;
     /// number of daughters
     size_t numberOfDaughters() const override;
     /// number of mothers
     size_t numberOfMothers() const override;
     /// return daughter at a given position (throws an exception)
-    const Candidate * daughter( size_type i ) const override;
+    const Candidate* daughter(size_type i) const override;
     /// return mother at a given position (throws an exception)
-    const Candidate * mother( size_type i ) const override;
+    const Candidate* mother(size_type i) const override;
     /// return daughter at a given position (throws an exception)
-    Candidate * daughter( size_type i ) override;
-    using reco::LeafCandidate::daughter; // avoid hiding the base
+    Candidate* daughter(size_type i) override;
+    using reco::LeafCandidate::daughter;  // avoid hiding the base
     /// has master clone pointer
     bool hasMasterClonePtr() const override;
     /// returns reference to master clone pointer
-    const CandidatePtr & masterClonePtr() const override;
-
+    const CandidatePtr& masterClonePtr() const override;
 
     bool isElectron() const override;
     bool isMuon() const override;
@@ -61,13 +62,14 @@ namespace reco {
     bool isPhoton() const override;
     bool isConvertedPhoton() const override;
     bool isJet() const override;
+
   private:
     /// check overlap with another Candidate
-    bool overlap( const Candidate & c ) const override { return masterClone_->overlap( c ); }
+    bool overlap(const Candidate& c) const override { return masterClone_->overlap(c); }
     /// CandidatePtrerence to master clone
     CandidatePtr masterClone_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositeCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidate.h
@@ -15,26 +15,29 @@
 namespace reco {
   class VertexCompositeCandidate : public CompositeCandidate {
   public:
-    VertexCompositeCandidate() : CompositeCandidate() { }
+    VertexCompositeCandidate() : CompositeCandidate() {}
     /// constructor from values
-    VertexCompositeCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-			     int pdgId = 0, int status = 0, bool integerCharge = true) :
-      CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge),
-      chi2_(0), ndof_(0) { }
+    VertexCompositeCandidate(
+        Charge q, const LorentzVector &p4, const Point &vtx, int pdgId = 0, int status = 0, bool integerCharge = true)
+        : CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0) {}
     /// constructor from values
-    VertexCompositeCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-			     const CovarianceMatrix & err, double chi2, double ndof,
-			     int pdgId = 0, int status = 0, bool integerCharge = true);
-     /// constructor from values
-    explicit VertexCompositeCandidate(const Candidate & p) :
-      CompositeCandidate(p), chi2_(0), ndof_(0) { }
-     /// constructor from values
-    explicit VertexCompositeCandidate(const CompositeCandidate & p) :
-      CompositeCandidate(p), chi2_(0), ndof_(0) { }
+    VertexCompositeCandidate(Charge q,
+                             const LorentzVector &p4,
+                             const Point &vtx,
+                             const CovarianceMatrix &err,
+                             double chi2,
+                             double ndof,
+                             int pdgId = 0,
+                             int status = 0,
+                             bool integerCharge = true);
+    /// constructor from values
+    explicit VertexCompositeCandidate(const Candidate &p) : CompositeCandidate(p), chi2_(0), ndof_(0) {}
+    /// constructor from values
+    explicit VertexCompositeCandidate(const CompositeCandidate &p) : CompositeCandidate(p), chi2_(0), ndof_(0) {}
     /// destructor
     ~VertexCompositeCandidate() override;
     /// returns a clone of the candidate
-    VertexCompositeCandidate * clone() const override;
+    VertexCompositeCandidate *clone() const override;
     /// chi-squares
     double vertexChi2() const override { return chi2_; }
     /** Number of degrees of freedom
@@ -47,18 +50,18 @@ namespace reco {
     /// chi-squared divided by n.d.o.f.
     double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
     /// (i, j)-th element of error matrix, i, j = 0, ... 2
-    double vertexCovariance(int i, int j) const override { 
-      return covariance_[idx(i, j)]; 
-    }
-    using reco::LeafCandidate::vertexCovariance; // avoid hiding the
+    double vertexCovariance(int i, int j) const override { return covariance_[idx(i, j)]; }
+    using reco::LeafCandidate::vertexCovariance;  // avoid hiding the
     /// fill SMatrix
-    void fillVertexCovariance(CovarianceMatrix & v) const override;
+    void fillVertexCovariance(CovarianceMatrix &v) const override;
     /// set chi2 and ndof
     void setChi2AndNdof(double chi2, double ndof) {
-      chi2_ = chi2; ndof_ = ndof;
+      chi2_ = chi2;
+      ndof_ = ndof;
     }
     /// set covariance matrix
     void setCovariance(const CovarianceMatrix &m);
+
   private:
     /// chi-sqared
     Double32_t chi2_;
@@ -69,10 +72,10 @@ namespace reco {
     /// position index
     index idx(index i, index j) const {
       int a = (i <= j ? i : j), b = (i <= j ? j : i);
-      return b * (b + 1)/2 + a;
+      return b * (b + 1) / 2 + a;
     }
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
@@ -31,6 +31,6 @@ namespace reco {
   typedef edm::RefProd<VertexCompositeCandidateCollection> VertexCompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type
   typedef edm::RefToBaseProd<VertexCompositeCandidate> VertexCompositeCandidateBaseRefProd;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
@@ -19,37 +19,50 @@ namespace reco {
     /// covariance error matrix (3x3)
     typedef math::Error<dimension4D>::type CovarianceMatrix4D;
     /// matix size
-    enum { size4D = dimension4D * (dimension4D + 1)/2 };
+    enum { size4D = dimension4D * (dimension4D + 1) / 2 };
 
-    VertexCompositePtrCandidate() : CompositePtrCandidate(), chi2_(0), ndof_(0), time_(0) { }
+    VertexCompositePtrCandidate() : CompositePtrCandidate(), chi2_(0), ndof_(0), time_(0) {}
     /// constructor from values
-    VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-				int pdgId = 0, int status = 0, bool integerCharge = true) :
-      CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-	chi2_(0), ndof_(0), time_(0) { }
-    VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-				double time, int pdgId = 0, int status = 0, 
-				bool integerCharge = true) :
-      CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-	chi2_(0), ndof_(0), time_(time) { }
+    VertexCompositePtrCandidate(
+        Charge q, const LorentzVector &p4, const Point &vtx, int pdgId = 0, int status = 0, bool integerCharge = true)
+        : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0), time_(0) {}
+    VertexCompositePtrCandidate(Charge q,
+                                const LorentzVector &p4,
+                                const Point &vtx,
+                                double time,
+                                int pdgId = 0,
+                                int status = 0,
+                                bool integerCharge = true)
+        : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(0), ndof_(0), time_(time) {}
     /// constructor from values
-    VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-				const CovarianceMatrix & err, double chi2, double ndof,
-				int pdgId = 0, int status = 0, bool integerCharge = true);
-    VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-				double time, const CovarianceMatrix4D & err, double chi2, 
-				double ndof, int pdgId = 0, int status = 0, 
-				bool integerCharge = true);
-     /// constructor from values
-    explicit VertexCompositePtrCandidate(const Candidate & p) :
-      CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) { }
-     /// constructor from values
-    explicit VertexCompositePtrCandidate(const CompositePtrCandidate & p) :
-      CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) { }
+    VertexCompositePtrCandidate(Charge q,
+                                const LorentzVector &p4,
+                                const Point &vtx,
+                                const CovarianceMatrix &err,
+                                double chi2,
+                                double ndof,
+                                int pdgId = 0,
+                                int status = 0,
+                                bool integerCharge = true);
+    VertexCompositePtrCandidate(Charge q,
+                                const LorentzVector &p4,
+                                const Point &vtx,
+                                double time,
+                                const CovarianceMatrix4D &err,
+                                double chi2,
+                                double ndof,
+                                int pdgId = 0,
+                                int status = 0,
+                                bool integerCharge = true);
+    /// constructor from values
+    explicit VertexCompositePtrCandidate(const Candidate &p) : CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) {}
+    /// constructor from values
+    explicit VertexCompositePtrCandidate(const CompositePtrCandidate &p)
+        : CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) {}
     /// destructor
     ~VertexCompositePtrCandidate() override;
     /// returns a clone of the candidate
-    VertexCompositePtrCandidate * clone() const override;
+    VertexCompositePtrCandidate *clone() const override;
 
     /// chi-squares
     double vertexChi2() const override { return chi2_; }
@@ -63,21 +76,24 @@ namespace reco {
     /// chi-squared divided by n.d.o.f.
     double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
     /// (i, j)-th element of error matrix, i, j = 0, ... 3
-    double vertexCovariance(int i, int j) const override { 
-      return covariance_[idx(i, j)]; 
-    }
-    using reco::LeafCandidate::vertexCovariance; // avoid hiding the
+    double vertexCovariance(int i, int j) const override { return covariance_[idx(i, j)]; }
+    using reco::LeafCandidate::vertexCovariance;  // avoid hiding the
     /// return SMatrix 4D
-    CovarianceMatrix4D vertexCovariance4D() const { CovarianceMatrix4D m; fillVertexCovariance( m ); return m; }
+    CovarianceMatrix4D vertexCovariance4D() const {
+      CovarianceMatrix4D m;
+      fillVertexCovariance(m);
+      return m;
+    }
 
     /// fill SMatrix
-    void fillVertexCovariance(CovarianceMatrix & v) const override;
+    void fillVertexCovariance(CovarianceMatrix &v) const override;
     /// 4D version
-    void fillVertexCovariance( CovarianceMatrix4D & v ) const;
+    void fillVertexCovariance(CovarianceMatrix4D &v) const;
 
     /// set chi2 and ndof
     void setChi2AndNdof(double chi2, double ndof) {
-      chi2_ = chi2; ndof_ = ndof;
+      chi2_ = chi2;
+      ndof_ = ndof;
     }
     /// set covariance matrix
     void setCovariance(const CovarianceMatrix &m);
@@ -90,12 +106,20 @@ namespace reco {
     /// the following functions are implemented to have a more consistent interface with the one of reco::Vertex
     typedef math::Error<dimension>::type Error;
     typedef math::Error<dimension4D>::type Error4D;
-    const Point & position() const {return vertex();} 	
+    const Point &position() const { return vertex(); }
     double t() const { return time_; }
-    double tError() const { return std::sqrt( vertexCovariance(3,3) ); }
-    Error  error() const { Error m; fillVertexCovariance( m ); return m; }
+    double tError() const { return std::sqrt(vertexCovariance(3, 3)); }
+    Error error() const {
+      Error m;
+      fillVertexCovariance(m);
+      return m;
+    }
     /// return SMatrix 4D
-    Error4D error4D() const { Error4D m; fillVertexCovariance( m ); return m; }
+    Error4D error4D() const {
+      Error4D m;
+      fillVertexCovariance(m);
+      return m;
+    }
 
   private:
     /// chi-sqared
@@ -109,10 +133,10 @@ namespace reco {
     /// position index
     index idx(index i, index j) const {
       int a = (i <= j ? i : j), b = (i <= j ? j : i);
-      return b * (b + 1)/2 + a;
+      return b * (b + 1) / 2 + a;
     }
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
@@ -31,6 +31,6 @@ namespace reco {
   typedef edm::RefProd<VertexCompositePtrCandidateCollection> VertexCompositePtrCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type
   typedef edm::RefToBaseProd<VertexCompositePtrCandidate> VertexCompositePtrCandidateBaseRefProd;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/const_iterator.h
+++ b/DataFormats/Candidate/interface/const_iterator.h
@@ -13,40 +13,67 @@ namespace reco {
   namespace candidate {
     struct const_iterator {
       typedef const Candidate value_type;
-      typedef const Candidate * pointer;
-      typedef const Candidate & reference;
+      typedef const Candidate* pointer;
+      typedef const Candidate& reference;
       typedef ptrdiff_t difference_type;
       typedef std::vector<int>::const_iterator::iterator_category iterator_category;
-      const_iterator() : me(nullptr), i( 0 ) { }
-      const_iterator(pointer ime, difference_type ii ) : me(ime), i(ii) { }
-      const_iterator(const iterator & it) : me(it.me), i(it.i) { }
-      const_iterator & operator=( const iterator & it ) { me = it.me; i=it.i;  return *this; }
-      const_iterator& operator++() { ++i; return *this; }
-      const_iterator operator++( int ) { const_iterator ci = *this; ++i; return ci; }
-      const_iterator& operator--() { --i; return *this; }
-      const_iterator operator--( int ) { const_iterator ci = *this; --i; return ci; }
-      difference_type operator-( const const_iterator & o ) const { return i-o.i; }
-      const_iterator operator+( difference_type n ) const { 
-	const_iterator ci = *this; ci.i+=n;
-	return ci; 
+      const_iterator() : me(nullptr), i(0) {}
+      const_iterator(pointer ime, difference_type ii) : me(ime), i(ii) {}
+      const_iterator(const iterator& it) : me(it.me), i(it.i) {}
+      const_iterator& operator=(const iterator& it) {
+        me = it.me;
+        i = it.i;
+        return *this;
       }
-      const_iterator operator-( difference_type n ) const {
-        const_iterator ci = *this; ci.i-=n;  
+      const_iterator& operator++() {
+        ++i;
+        return *this;
+      }
+      const_iterator operator++(int) {
+        const_iterator ci = *this;
+        ++i;
         return ci;
       }
-      bool operator<( const const_iterator & o ) { return i<o.i; }
-      bool operator==( const const_iterator& ci ) const { return i==ci.i; }
-      bool operator!=( const const_iterator& ci ) const { return i!=ci.i; }
-      inline reference operator * () const;
-      pointer operator->() const { return & ( operator*() ); }
-      const_iterator & operator +=( difference_type d ) { i+=d; return *this; }
-      const_iterator & operator -=( difference_type d ) { i-=d; return *this; }
+      const_iterator& operator--() {
+        --i;
+        return *this;
+      }
+      const_iterator operator--(int) {
+        const_iterator ci = *this;
+        --i;
+        return ci;
+      }
+      difference_type operator-(const const_iterator& o) const { return i - o.i; }
+      const_iterator operator+(difference_type n) const {
+        const_iterator ci = *this;
+        ci.i += n;
+        return ci;
+      }
+      const_iterator operator-(difference_type n) const {
+        const_iterator ci = *this;
+        ci.i -= n;
+        return ci;
+      }
+      bool operator<(const const_iterator& o) { return i < o.i; }
+      bool operator==(const const_iterator& ci) const { return i == ci.i; }
+      bool operator!=(const const_iterator& ci) const { return i != ci.i; }
+      inline reference operator*() const;
+      pointer operator->() const { return &(operator*()); }
+      const_iterator& operator+=(difference_type d) {
+        i += d;
+        return *this;
+      }
+      const_iterator& operator-=(difference_type d) {
+        i -= d;
+        return *this;
+      }
+
     private:
-       pointer me;
-       difference_type i;
+      pointer me;
+      difference_type i;
     };
 
-  }
-}
+  }  // namespace candidate
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/interface/iterator.h
+++ b/DataFormats/Candidate/interface/iterator.h
@@ -13,40 +13,63 @@ namespace reco {
     struct const_iterator;
     struct iterator {
       typedef Candidate value_type;
-      typedef Candidate * pointer;
-      typedef Candidate & reference;
+      typedef Candidate* pointer;
+      typedef Candidate& reference;
       typedef ptrdiff_t difference_type;
       typedef std::vector<int>::iterator::iterator_category iterator_category;
-      iterator() : me(nullptr), i( 0 ) { }
-      iterator(pointer ime, difference_type ii ) : me(ime), i(ii) { }
-      iterator& operator++() { ++i; return *this; }
-      iterator operator++( int ) { iterator ci = *this; ++i; return ci; }
-      iterator& operator--() { --i; return *this; }
-      iterator operator--( int ) { iterator ci = *this; --i; return ci; }
-      difference_type operator-( const iterator & o ) const { return i-o.i; }
-      iterator operator+( difference_type n ) const { 
-	iterator ci = *this; ci.i+=n;
-	return ci; 
+      iterator() : me(nullptr), i(0) {}
+      iterator(pointer ime, difference_type ii) : me(ime), i(ii) {}
+      iterator& operator++() {
+        ++i;
+        return *this;
       }
-      iterator operator-( difference_type n ) const {
-        iterator ci = *this; ci.i-=n;  
+      iterator operator++(int) {
+        iterator ci = *this;
+        ++i;
         return ci;
       }
-      bool operator<( const iterator & o ) { return i<o.i; }
-      bool operator==( const iterator& ci ) const { return i==ci.i; }
-      bool operator!=( const iterator& ci ) const { return i!=ci.i; }
+      iterator& operator--() {
+        --i;
+        return *this;
+      }
+      iterator operator--(int) {
+        iterator ci = *this;
+        --i;
+        return ci;
+      }
+      difference_type operator-(const iterator& o) const { return i - o.i; }
+      iterator operator+(difference_type n) const {
+        iterator ci = *this;
+        ci.i += n;
+        return ci;
+      }
+      iterator operator-(difference_type n) const {
+        iterator ci = *this;
+        ci.i -= n;
+        return ci;
+      }
+      bool operator<(const iterator& o) { return i < o.i; }
+      bool operator==(const iterator& ci) const { return i == ci.i; }
+      bool operator!=(const iterator& ci) const { return i != ci.i; }
 
-      inline reference operator * () const;
-      pointer operator->() const { return & ( operator*() ); }
-      iterator & operator +=( difference_type d ) { i+=d; return *this; }
-      iterator & operator -=( difference_type d ) { i-=d; return *this; }
+      inline reference operator*() const;
+      pointer operator->() const { return &(operator*()); }
+      iterator& operator+=(difference_type d) {
+        i += d;
+        return *this;
+      }
+      iterator& operator-=(difference_type d) {
+        i -= d;
+        return *this;
+      }
+
     private:
-       pointer me;
-       difference_type i;
-       friend struct const_iterator;
+      pointer me;
+      difference_type i;
+      friend struct const_iterator;
     };
 
-  }
-}
+  }  // namespace candidate
+}  // namespace reco
 
 #endif

--- a/DataFormats/Candidate/src/Candidate.cc
+++ b/DataFormats/Candidate/src/Candidate.cc
@@ -2,4 +2,4 @@
 
 using namespace reco;
 
-Candidate::~Candidate() { }
+Candidate::~Candidate() {}

--- a/DataFormats/Candidate/src/CompositeCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeCandidate.cc
@@ -116,7 +116,7 @@ const Candidate * CompositeCandidate::daughter(const std::string& s) const  {
 
 void CompositeCandidate::addDaughter(const Candidate & cand, const std::string& s) {
   Candidate * c = cand.clone();
-  if (s != "") {
+  if (!s.empty()) {
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
     bool isFound = (find(begin, end, s) != end);
     if (isFound) {
@@ -134,7 +134,7 @@ void CompositeCandidate::addDaughter(const Candidate & cand, const std::string& 
 }
 
 void CompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std::string& s) {
-  if (s != "") {
+  if (!s.empty()) {
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
     bool isFound = (find(begin, end, s) != end);
     if (isFound) {

--- a/DataFormats/Candidate/src/CompositeCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeCandidate.cc
@@ -3,57 +3,50 @@
 
 using namespace reco;
 
-CompositeCandidate::CompositeCandidate(const Candidate & c,
-				       const std::string& name) :
-  LeafCandidate(c), name_(name) {
+CompositeCandidate::CompositeCandidate(const Candidate& c, const std::string& name) : LeafCandidate(c), name_(name) {
   size_t n = c.numberOfDaughters();
-  for(size_t i = 0; i != n; ++i) {
-      addDaughter(*c.daughter(i));
+  for (size_t i = 0; i != n; ++i) {
+    addDaughter(*c.daughter(i));
   }
 }
 
-CompositeCandidate::CompositeCandidate(const Candidate & c,
-				       const std::string& name,
-				       role_collection const & roles) :
-  LeafCandidate(c), name_(name), roles_(roles) {
+CompositeCandidate::CompositeCandidate(const Candidate& c, const std::string& name, role_collection const& roles)
+    : LeafCandidate(c), name_(name), roles_(roles) {
   size_t n = c.numberOfDaughters();
   size_t r = roles_.size();
   bool sameSize = (n == r);
-  for(size_t i = 0; i != n; ++i) {
-    if (sameSize && r > 0) 
+  for (size_t i = 0; i != n; ++i) {
+    if (sameSize && r > 0)
       addDaughter(*c.daughter(i), roles_[i]);
     else
       addDaughter(*c.daughter(i));
   }
 }
 
-CompositeCandidate::~CompositeCandidate() { }
+CompositeCandidate::~CompositeCandidate() {}
 
-CompositeCandidate * CompositeCandidate::clone() const { return new CompositeCandidate(* this); }
+CompositeCandidate* CompositeCandidate::clone() const { return new CompositeCandidate(*this); }
 
-const Candidate * CompositeCandidate::daughter(size_type i) const { 
-  return (i < numberOfDaughters()) ? & dau[ i ] : nullptr; // i >= 0, since i is unsigned
+const Candidate* CompositeCandidate::daughter(size_type i) const {
+  return (i < numberOfDaughters()) ? &dau[i] : nullptr;  // i >= 0, since i is unsigned
 }
 
-Candidate * CompositeCandidate::daughter(size_type i) { 
-  Candidate * d = (i < numberOfDaughters()) ? & dau[ i ] : nullptr; // i >= 0, since i is unsigned
+Candidate* CompositeCandidate::daughter(size_type i) {
+  Candidate* d = (i < numberOfDaughters()) ? &dau[i] : nullptr;  // i >= 0, since i is unsigned
   return d;
 }
 
-const Candidate * CompositeCandidate::mother(size_type i) const { 
-  return nullptr;
-}
+const Candidate* CompositeCandidate::mother(size_type i) const { return nullptr; }
 
 size_t CompositeCandidate::numberOfDaughters() const { return dau.size(); }
 
 size_t CompositeCandidate::numberOfMothers() const { return 0; }
 
-bool CompositeCandidate::overlap(const Candidate & c2) const {
+bool CompositeCandidate::overlap(const Candidate& c2) const {
   throw cms::Exception("Error") << "can't check overlap internally for CompositeCanddate";
 }
 
 void CompositeCandidate::applyRoles() {
-
   if (roles_.empty())
     return;
 
@@ -62,21 +55,21 @@ void CompositeCandidate::applyRoles() {
   int N2 = numberOfDaughters();
   if (N1 != N2) {
     throw cms::Exception("InvalidReference")
-      << "CompositeCandidate::applyRoles : Number of roles and daughters differ, this is an error.\n";
+        << "CompositeCandidate::applyRoles : Number of roles and daughters differ, this is an error.\n";
   }
   // Set up the daughter roles
-  for (int i = 0 ; i < N1; ++i) {
+  for (int i = 0; i < N1; ++i) {
     std::string role = roles_[i];
-    Candidate * c = CompositeCandidate::daughter(i);
+    Candidate* c = CompositeCandidate::daughter(i);
 
-    CompositeCandidate * c1 = dynamic_cast<CompositeCandidate *>(c);
+    CompositeCandidate* c1 = dynamic_cast<CompositeCandidate*>(c);
     if (c1 != nullptr) {
       c1->setName(role);
     }
   }
 }
 
-Candidate * CompositeCandidate::daughter(const std::string& s) {
+Candidate* CompositeCandidate::daughter(const std::string& s) {
   int ret = -1;
   int i = 0, N = roles_.size();
   bool found = false;
@@ -88,14 +81,13 @@ Candidate * CompositeCandidate::daughter(const std::string& s) {
   }
 
   if (ret < 0) {
-    throw cms::Exception("InvalidReference")
-      << "CompositeCandidate::daughter: Cannot find role " << s << "\n";
+    throw cms::Exception("InvalidReference") << "CompositeCandidate::daughter: Cannot find role " << s << "\n";
   }
-  
+
   return daughter(ret);
 }
 
-const Candidate * CompositeCandidate::daughter(const std::string& s) const  {
+const Candidate* CompositeCandidate::daughter(const std::string& s) const {
   int ret = -1;
   int i = 0, N = roles_.size();
   bool found = false;
@@ -107,25 +99,23 @@ const Candidate * CompositeCandidate::daughter(const std::string& s) const  {
   }
 
   if (ret < 0) {
-    throw cms::Exception("InvalidReference")
-      << "CompositeCandidate::daughter: Cannot find role " << s << "\n";
+    throw cms::Exception("InvalidReference") << "CompositeCandidate::daughter: Cannot find role " << s << "\n";
   }
-  
+
   return daughter(ret);
 }
 
-void CompositeCandidate::addDaughter(const Candidate & cand, const std::string& s) {
-  Candidate * c = cand.clone();
+void CompositeCandidate::addDaughter(const Candidate& cand, const std::string& s) {
+  Candidate* c = cand.clone();
   if (!s.empty()) {
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
     bool isFound = (find(begin, end, s) != end);
     if (isFound) {
-      throw cms::Exception("InvalidReference")
-	<< "CompositeCandidate::addDaughter: Already have role with name \"" << s 
-	<< "\", please clearDaughters, or use a new name\n";
+      throw cms::Exception("InvalidReference") << "CompositeCandidate::addDaughter: Already have role with name \"" << s
+                                               << "\", please clearDaughters, or use a new name\n";
     }
     roles_.push_back(s);
-    CompositeCandidate * c1 = dynamic_cast<CompositeCandidate*>(&*c);
+    CompositeCandidate* c1 = dynamic_cast<CompositeCandidate*>(&*c);
     if (c1 != nullptr) {
       c1->setName(s);
     }
@@ -138,17 +128,14 @@ void CompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std:
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
     bool isFound = (find(begin, end, s) != end);
     if (isFound) {
-      throw cms::Exception("InvalidReference")
-	<< "CompositeCandidate::addDaughter: Already have role with name \"" << s 
-	<< "\", please clearDaughters, or use a new name\n";
+      throw cms::Exception("InvalidReference") << "CompositeCandidate::addDaughter: Already have role with name \"" << s
+                                               << "\", please clearDaughters, or use a new name\n";
     }
-    roles_.push_back(s);  
-    CompositeCandidate * c1 = dynamic_cast<CompositeCandidate*>(&*cand);
+    roles_.push_back(s);
+    CompositeCandidate* c1 = dynamic_cast<CompositeCandidate*>(&*cand);
     if (c1 != nullptr) {
       c1->setName(s);
     }
   }
   dau.push_back(std::move(cand));
 }
-
-

--- a/DataFormats/Candidate/src/CompositePtrCandidate.cc
+++ b/DataFormats/Candidate/src/CompositePtrCandidate.cc
@@ -3,41 +3,26 @@
 
 using namespace reco;
 
-CompositePtrCandidate::~CompositePtrCandidate() { 
+CompositePtrCandidate::~CompositePtrCandidate() {}
+
+CompositePtrCandidate* CompositePtrCandidate::clone() const { return new CompositePtrCandidate(*this); }
+
+const Candidate* CompositePtrCandidate::daughter(size_type i) const {
+  return (i < numberOfDaughters()) ? &*dau[i] : nullptr;  // i >= 0, since i is unsigned
 }
 
-CompositePtrCandidate * CompositePtrCandidate::clone() const { 
-  return new CompositePtrCandidate( * this ); 
-}
+const Candidate* CompositePtrCandidate::mother(size_type i) const { return nullptr; }
 
-const Candidate * CompositePtrCandidate::daughter( size_type i ) const { 
-  return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr; // i >= 0, since i is unsigned
-}
+Candidate* CompositePtrCandidate::daughter(size_type i) { return nullptr; }
 
-const Candidate * CompositePtrCandidate::mother( size_type i ) const { 
-  return nullptr;
-}
+size_t CompositePtrCandidate::numberOfDaughters() const { return dau.size(); }
 
-Candidate * CompositePtrCandidate::daughter( size_type i ) { 
-  return nullptr;
-}
+size_t CompositePtrCandidate::numberOfMothers() const { return 0; }
 
-size_t CompositePtrCandidate::numberOfDaughters() const { 
-  return dau.size(); 
-}
+size_t CompositePtrCandidate::numberOfSourceCandidatePtrs() const { return numberOfDaughters(); }
 
-size_t CompositePtrCandidate::numberOfMothers() const { 
-  return 0;
-}
+CandidatePtr CompositePtrCandidate::sourceCandidatePtr(size_type i) const { return daughterPtr(i); }
 
-size_t CompositePtrCandidate::numberOfSourceCandidatePtrs() const { 
-  return numberOfDaughters(); 
-}
-
-CandidatePtr CompositePtrCandidate::sourceCandidatePtr( size_type i ) const {
-  return daughterPtr(i);
-}
-
-bool CompositePtrCandidate::overlap( const Candidate & c2 ) const {
-  throw cms::Exception( "Error" ) << "can't check overlap internally for CompositePtrCanddate";
+bool CompositePtrCandidate::overlap(const Candidate& c2) const {
+  throw cms::Exception("Error") << "can't check overlap internally for CompositePtrCanddate";
 }

--- a/DataFormats/Candidate/src/CompositeRefBaseCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeRefBaseCandidate.cc
@@ -3,34 +3,22 @@
 
 using namespace reco;
 
-CompositeRefBaseCandidate::~CompositeRefBaseCandidate() { 
+CompositeRefBaseCandidate::~CompositeRefBaseCandidate() {}
+
+CompositeRefBaseCandidate* CompositeRefBaseCandidate::clone() const { return new CompositeRefBaseCandidate(*this); }
+
+const Candidate* CompositeRefBaseCandidate::daughter(size_type i) const {
+  return (i < numberOfDaughters()) ? &*dau[i] : nullptr;  // i >= 0, since i is unsigned
 }
 
-CompositeRefBaseCandidate * CompositeRefBaseCandidate::clone() const { 
-  return new CompositeRefBaseCandidate( * this ); 
-}
+const Candidate* CompositeRefBaseCandidate::mother(size_type i) const { return nullptr; }
 
-const Candidate * CompositeRefBaseCandidate::daughter( size_type i ) const { 
-  return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr; // i >= 0, since i is unsigned
-}
+Candidate* CompositeRefBaseCandidate::daughter(size_type i) { return nullptr; }
 
-const Candidate * CompositeRefBaseCandidate::mother( size_type i ) const { 
- return nullptr;
-}
+size_t CompositeRefBaseCandidate::numberOfDaughters() const { return dau.size(); }
 
-Candidate * CompositeRefBaseCandidate::daughter( size_type i ) { 
-  return nullptr;
-}
+size_t CompositeRefBaseCandidate::numberOfMothers() const { return 0; }
 
-size_t CompositeRefBaseCandidate::numberOfDaughters() const { 
-  return dau.size(); 
+bool CompositeRefBaseCandidate::overlap(const Candidate& c2) const {
+  throw cms::Exception("Error") << "can't check overlap internally for CompositeRefBaseCanddate";
 }
-
-size_t CompositeRefBaseCandidate::numberOfMothers() const { 
-  return 0;
-}
-
-bool CompositeRefBaseCandidate::overlap( const Candidate & c2 ) const {
-  throw cms::Exception( "Error" ) << "can't check overlap internally for CompositeRefBaseCanddate";
-}
-

--- a/DataFormats/Candidate/src/CompositeRefCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeRefCandidate.cc
@@ -3,33 +3,24 @@
 
 using namespace reco;
 
-CompositeRefCandidate::~CompositeRefCandidate() { 
+CompositeRefCandidate::~CompositeRefCandidate() {}
+
+CompositeRefCandidate* CompositeRefCandidate::clone() const { return new CompositeRefCandidate(*this); }
+
+const Candidate* CompositeRefCandidate::daughter(size_type i) const {
+  return (i < numberOfDaughters()) ? &*dau[i] : nullptr;  // i >= 0, since i is unsigned
 }
 
-CompositeRefCandidate * CompositeRefCandidate::clone() const { 
-  return new CompositeRefCandidate( * this ); 
+const Candidate* CompositeRefCandidate::mother(size_type i) const {
+  return (i < numberOfMothers()) ? &*mom[i] : nullptr;  // i >= 0, since i is unsigned
 }
 
-const Candidate * CompositeRefCandidate::daughter( size_type i ) const { 
-  return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr; // i >= 0, since i is unsigned
-}
+Candidate* CompositeRefCandidate::daughter(size_type i) { return nullptr; }
 
-const Candidate * CompositeRefCandidate::mother( size_type i ) const { 
-  return ( i < numberOfMothers() ) ? & * mom[ i ] : nullptr; // i >= 0, since i is unsigned
-}
+size_t CompositeRefCandidate::numberOfDaughters() const { return dau.size(); }
 
-Candidate * CompositeRefCandidate::daughter( size_type i ) { 
-  return nullptr;
-}
+size_t CompositeRefCandidate::numberOfMothers() const { return mom.size(); }
 
-size_t CompositeRefCandidate::numberOfDaughters() const { 
-  return dau.size(); 
-}
-
-size_t CompositeRefCandidate::numberOfMothers() const { 
-  return mom.size();
-}
-
-bool CompositeRefCandidate::overlap( const Candidate & c2 ) const {
-  throw cms::Exception( "Error" ) << "can't check overlap internally for CompositeRefCanddate";
+bool CompositeRefCandidate::overlap(const Candidate& c2) const {
+  throw cms::Exception("Error") << "can't check overlap internally for CompositeRefCanddate";
 }

--- a/DataFormats/Candidate/src/LeafCandidate.cc
+++ b/DataFormats/Candidate/src/LeafCandidate.cc
@@ -2,87 +2,62 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 using namespace reco;
 
-LeafCandidate::~LeafCandidate() { }
+LeafCandidate::~LeafCandidate() {}
 
-const CandidateBaseRef & LeafCandidate::masterClone() const {
-  throw cms::Exception("Invalid Reference")
-    << "this Candidate has no master clone reference."
-    << "Can't call masterClone() method.\n";
+const CandidateBaseRef& LeafCandidate::masterClone() const {
+  throw cms::Exception("Invalid Reference") << "this Candidate has no master clone reference."
+                                            << "Can't call masterClone() method.\n";
 }
 
-bool LeafCandidate::hasMasterClone() const {
-  return false;
+bool LeafCandidate::hasMasterClone() const { return false; }
+
+bool LeafCandidate::hasMasterClonePtr() const { return false; }
+
+const CandidatePtr& LeafCandidate::masterClonePtr() const {
+  throw cms::Exception("Invalid Reference") << "this Candidate has no master clone ptr."
+                                            << "Can't call masterClonePtr() method.\n";
 }
 
-bool LeafCandidate::hasMasterClonePtr() const {
-  return false;
+size_t LeafCandidate::numberOfDaughters() const { return 0; }
+
+size_t LeafCandidate::numberOfMothers() const { return 0; }
+
+bool LeafCandidate::overlap(const Candidate& o) const {
+  return p4() == o.p4() && vertex() == o.vertex() && charge() == o.charge();
 }
 
+const Candidate* LeafCandidate::daughter(size_type) const { return nullptr; }
 
-const CandidatePtr & LeafCandidate::masterClonePtr() const {
-  throw cms::Exception("Invalid Reference")
-    << "this Candidate has no master clone ptr."
-    << "Can't call masterClonePtr() method.\n";
-}
+const Candidate* LeafCandidate::mother(size_type) const { return nullptr; }
 
-size_t LeafCandidate::numberOfDaughters() const { 
-  return 0; 
-}
-
-size_t LeafCandidate::numberOfMothers() const { 
-  return 0; 
-}
-
-bool LeafCandidate::overlap( const Candidate & o ) const { 
-  return  p4() == o.p4() && vertex() == o.vertex() && charge() == o.charge();
-}
-
-const Candidate * LeafCandidate::daughter( size_type ) const {
-  return nullptr;
-}
-
-const Candidate * LeafCandidate::mother( size_type ) const {
-  return nullptr;
-}
-
-const Candidate * LeafCandidate::daughter(const std::string&) const {
+const Candidate* LeafCandidate::daughter(const std::string&) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "This Candidate type does not implement daughter(std::string). "
-    << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
+      << "This Candidate type does not implement daughter(std::string). "
+      << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
 }
 
-Candidate * LeafCandidate::daughter(const std::string&) {
+Candidate* LeafCandidate::daughter(const std::string&) {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "This Candidate type does not implement daughter(std::string). "
-    << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
+      << "This Candidate type does not implement daughter(std::string). "
+      << "Please use CompositeCandidate or NamedCompositeCandidate.\n";
 }
 
+Candidate* LeafCandidate::daughter(size_type) { return nullptr; }
 
+double LeafCandidate::vertexChi2() const { return 0; }
 
-Candidate * LeafCandidate::daughter( size_type ) {
-  return nullptr;
-}
+double LeafCandidate::vertexNdof() const { return 0; }
 
-double LeafCandidate::vertexChi2() const {
-  return 0;
-}
-
-double LeafCandidate::vertexNdof() const {
-  return 0;
-}
-
-double LeafCandidate::vertexNormalizedChi2() const {
-  return 0;
-}
+double LeafCandidate::vertexNormalizedChi2() const { return 0; }
 
 double LeafCandidate::vertexCovariance(int i, int j) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
+      << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
 }
 
-void LeafCandidate::fillVertexCovariance(CovarianceMatrix & err) const {
+void LeafCandidate::fillVertexCovariance(CovarianceMatrix& err) const {
   throw edm::Exception(edm::errors::UnimplementedFeature)
-    << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
+      << "reco::ConcreteCandidate does not implement vertex covariant matrix.\n";
 }
 
 bool LeafCandidate::isElectron() const { return false; }

--- a/DataFormats/Candidate/src/NamedCompositeCandidate.cc
+++ b/DataFormats/Candidate/src/NamedCompositeCandidate.cc
@@ -1,130 +1,117 @@
 #include "DataFormats/Candidate/interface/NamedCompositeCandidate.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <iostream> 
+#include <iostream>
 
 using namespace reco;
 
-NamedCompositeCandidate::NamedCompositeCandidate(std::string name, 
-						 const NamedCompositeCandidate::role_collection & roles,
-						 const Candidate & c) :
-  CompositeCandidate(c),
-  name_(name),
-  roles_(roles)
-{
-
+NamedCompositeCandidate::NamedCompositeCandidate(std::string name,
+                                                 const NamedCompositeCandidate::role_collection& roles,
+                                                 const Candidate& c)
+    : CompositeCandidate(c), name_(name), roles_(roles) {
   // Check if there are the same number of daughters and roles
   int N1 = roles_.size();
   int N2 = numberOfDaughters();
 
-  if ( N1 != N2 ) {
+  if (N1 != N2) {
     throw cms::Exception("InvalidReference")
-      << "NamedCompositeCandidate constructor: Number of roles and daughters differ, this is an error. Name = " << name << "\n";
+        << "NamedCompositeCandidate constructor: Number of roles and daughters differ, this is an error. Name = "
+        << name << "\n";
   }
 }
 
-NamedCompositeCandidate::~NamedCompositeCandidate() { clearDaughters(); clearRoles(); }
+NamedCompositeCandidate::~NamedCompositeCandidate() {
+  clearDaughters();
+  clearRoles();
+}
 
-NamedCompositeCandidate * NamedCompositeCandidate::clone() const { return new NamedCompositeCandidate( * this ); }
+NamedCompositeCandidate* NamedCompositeCandidate::clone() const { return new NamedCompositeCandidate(*this); }
 
-void NamedCompositeCandidate::applyRoles()
-{
-
+void NamedCompositeCandidate::applyRoles() {
   // Check if there are the same number of daughters and roles
   int N1 = roles_.size();
   int N2 = numberOfDaughters();
-  if ( N1 != N2 ) {
+  if (N1 != N2) {
     throw cms::Exception("InvalidReference")
-      << "NamedCompositeCandidate::applyRoles : Number of roles and daughters differ, this is an error.\n";
+        << "NamedCompositeCandidate::applyRoles : Number of roles and daughters differ, this is an error.\n";
   }
   // Set up the daughter roles
-  for ( int i = 0 ; i < N1; ++i ) {
+  for (int i = 0; i < N1; ++i) {
     std::string role = roles_[i];
-    Candidate * c = CompositeCandidate::daughter( i );
+    Candidate* c = CompositeCandidate::daughter(i);
 
-    NamedCompositeCandidate * c1 = dynamic_cast<NamedCompositeCandidate *>(c);
-    if ( c1 != nullptr ) {
-      c1->setName( role );
+    NamedCompositeCandidate* c1 = dynamic_cast<NamedCompositeCandidate*>(c);
+    if (c1 != nullptr) {
+      c1->setName(role);
     }
   }
 }
 
-Candidate * NamedCompositeCandidate::daughter(const std::string& s ) 
-{
+Candidate* NamedCompositeCandidate::daughter(const std::string& s) {
   int ret = -1;
   int i = 0, N = roles_.size();
   bool found = false;
-  for ( ; i < N && !found; ++i ) {
-    if ( s == roles_[i] ) {
+  for (; i < N && !found; ++i) {
+    if (s == roles_[i]) {
       found = true;
       ret = i;
     }
   }
 
-  if ( ret < 0 ) {
-    throw cms::Exception("InvalidReference")
-      << "NamedCompositeCandidate::daughter: Cannot find role " << s << "\n";
+  if (ret < 0) {
+    throw cms::Exception("InvalidReference") << "NamedCompositeCandidate::daughter: Cannot find role " << s << "\n";
   }
-  
+
   return daughter(ret);
 }
 
-const Candidate * NamedCompositeCandidate::daughter(const std::string& s ) const 
-{
+const Candidate* NamedCompositeCandidate::daughter(const std::string& s) const {
   int ret = -1;
   int i = 0, N = roles_.size();
   bool found = false;
-  for ( ; i < N && !found; ++i ) {
-    if ( s == roles_[i] ) {
+  for (; i < N && !found; ++i) {
+    if (s == roles_[i]) {
       found = true;
       ret = i;
     }
   }
 
-  if ( ret < 0 ) {
-    throw cms::Exception("InvalidReference")
-      << "NamedCompositeCandidate::daughter: Cannot find role " << s << "\n";
+  if (ret < 0) {
+    throw cms::Exception("InvalidReference") << "NamedCompositeCandidate::daughter: Cannot find role " << s << "\n";
   }
-  
+
   return daughter(ret);
 }
 
-void NamedCompositeCandidate::addDaughter( const Candidate & cand, const std::string& s )
-{
-
+void NamedCompositeCandidate::addDaughter(const Candidate& cand, const std::string& s) {
   role_collection::iterator begin = roles_.begin(), end = roles_.end();
-  bool isFound = ( find( begin, end, s) != end );
-  if ( isFound ) {
-    throw cms::Exception("InvalidReference")
-      << "NamedCompositeCandidate::addDaughter: Already have role with name " << s 
-      << ", please clearDaughters, or use a new name\n";
+  bool isFound = (find(begin, end, s) != end);
+  if (isFound) {
+    throw cms::Exception("InvalidReference") << "NamedCompositeCandidate::addDaughter: Already have role with name "
+                                             << s << ", please clearDaughters, or use a new name\n";
   }
 
-  roles_.push_back( s );
-  std::unique_ptr<Candidate> c( cand.clone() );
-  NamedCompositeCandidate * c1 =  dynamic_cast<NamedCompositeCandidate*>(&*c);
-  if ( c1 != nullptr ) {
-    c1->setName( s );
+  roles_.push_back(s);
+  std::unique_ptr<Candidate> c(cand.clone());
+  NamedCompositeCandidate* c1 = dynamic_cast<NamedCompositeCandidate*>(&*c);
+  if (c1 != nullptr) {
+    c1->setName(s);
   }
-  CompositeCandidate::addDaughter( std::move(c) );
+  CompositeCandidate::addDaughter(std::move(c));
 }
 
-void NamedCompositeCandidate::addDaughter( std::unique_ptr<Candidate> cand, const std::string& s )
-{
+void NamedCompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std::string& s) {
   role_collection::iterator begin = roles_.begin(), end = roles_.end();
-  bool isFound = ( find( begin, end, s) != end );
-  if ( isFound ) {
-    throw cms::Exception("InvalidReference")
-      << "NamedCompositeCandidate::addDaughter: Already have role with name " << s 
-      << ", please clearDaughters, or use a new name\n";
+  bool isFound = (find(begin, end, s) != end);
+  if (isFound) {
+    throw cms::Exception("InvalidReference") << "NamedCompositeCandidate::addDaughter: Already have role with name "
+                                             << s << ", please clearDaughters, or use a new name\n";
   }
 
-  roles_.push_back( s );
-  NamedCompositeCandidate * c1 = dynamic_cast<NamedCompositeCandidate*>(&*cand);
-  if ( c1 != nullptr ) {
-    c1->setName( s );
+  roles_.push_back(s);
+  NamedCompositeCandidate* c1 = dynamic_cast<NamedCompositeCandidate*>(&*cand);
+  if (c1 != nullptr) {
+    c1->setName(s);
   }
-  CompositeCandidate::addDaughter( std::move(cand) );
+  CompositeCandidate::addDaughter(std::move(cand));
 }
-
-

--- a/DataFormats/Candidate/src/OverlapChecker.cc
+++ b/DataFormats/Candidate/src/OverlapChecker.cc
@@ -1,30 +1,29 @@
-#include "DataFormats/Candidate/interface/OverlapChecker.h"  
+#include "DataFormats/Candidate/interface/OverlapChecker.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 using namespace reco;
-  
-bool OverlapChecker::operator()( const Candidate & c1, const Candidate & c2 ) const {
+
+bool OverlapChecker::operator()(const Candidate& c1, const Candidate& c2) const {
   typedef Candidate::const_iterator iterator;
-  if( c1.numberOfDaughters() == 0 ) {
-    if ( c2.numberOfDaughters() == 0 ) {
-      if( c2.hasMasterClone() )
-	return c1.overlap( *(c2.masterClone()) );
+  if (c1.numberOfDaughters() == 0) {
+    if (c2.numberOfDaughters() == 0) {
+      if (c2.hasMasterClone())
+        return c1.overlap(*(c2.masterClone()));
       else
-	return c1.overlap( c2 );
+        return c1.overlap(c2);
     }
     iterator b2 = c2.begin(), e2 = c2.end();
-    for( iterator i2 = b2; i2 != e2; ++ i2 ) {
-      if( operator()( c1, * i2 ) ) { 
-	return true;
+    for (iterator i2 = b2; i2 != e2; ++i2) {
+      if (operator()(c1, *i2)) {
+        return true;
       }
     }
     return false;
   }
   iterator b1 = c1.begin(), e1 = c1.end();
-  for( iterator i1 = b1; i1 != e1; ++ i1 ) {
-    if( operator()( * i1, c2 ) ) { 
+  for (iterator i1 = b1; i1 != e1; ++i1) {
+    if (operator()(*i1, c2)) {
       return true;
     }
   }
   return false;
 }
-

--- a/DataFormats/Candidate/src/ShallowCloneCandidate.cc
+++ b/DataFormats/Candidate/src/ShallowCloneCandidate.cc
@@ -1,73 +1,38 @@
 #include "DataFormats/Candidate/interface/ShallowCloneCandidate.h"
 using namespace reco;
 
-ShallowCloneCandidate::~ShallowCloneCandidate() { 
-}
+ShallowCloneCandidate::~ShallowCloneCandidate() {}
 
-ShallowCloneCandidate * ShallowCloneCandidate::clone() const { 
-  return new ShallowCloneCandidate( *this ); 
-}
+ShallowCloneCandidate* ShallowCloneCandidate::clone() const { return new ShallowCloneCandidate(*this); }
 
-size_t ShallowCloneCandidate::numberOfDaughters() const { 
-  return masterClone_->numberOfDaughters(); 
-}
+size_t ShallowCloneCandidate::numberOfDaughters() const { return masterClone_->numberOfDaughters(); }
 
-size_t ShallowCloneCandidate::numberOfMothers() const { 
-  return masterClone_->numberOfMothers(); 
-}
+size_t ShallowCloneCandidate::numberOfMothers() const { return masterClone_->numberOfMothers(); }
 
-const Candidate * ShallowCloneCandidate::daughter( size_type i ) const { 
-  return masterClone_->daughter( i ); 
-}
+const Candidate* ShallowCloneCandidate::daughter(size_type i) const { return masterClone_->daughter(i); }
 
-const Candidate * ShallowCloneCandidate::mother( size_type i ) const { 
-  return masterClone_->mother( i ); 
-}
+const Candidate* ShallowCloneCandidate::mother(size_type i) const { return masterClone_->mother(i); }
 
-Candidate * ShallowCloneCandidate::daughter( size_type i ) { 
-  return nullptr;
-}
+Candidate* ShallowCloneCandidate::daughter(size_type i) { return nullptr; }
 
-bool ShallowCloneCandidate::hasMasterClone() const {
-  return true;
-}
+bool ShallowCloneCandidate::hasMasterClone() const { return true; }
 
-const CandidateBaseRef & ShallowCloneCandidate::masterClone() const {
-  return masterClone_;
-}
+const CandidateBaseRef& ShallowCloneCandidate::masterClone() const { return masterClone_; }
 
-bool ShallowCloneCandidate::isElectron() const { 
-  return masterClone_->isElectron(); 
-}
+bool ShallowCloneCandidate::isElectron() const { return masterClone_->isElectron(); }
 
-bool ShallowCloneCandidate::isMuon() const { 
-  return masterClone_->isMuon(); 
-}
+bool ShallowCloneCandidate::isMuon() const { return masterClone_->isMuon(); }
 
-bool ShallowCloneCandidate::isGlobalMuon() const { 
-  return masterClone_->isGlobalMuon(); 
-}
+bool ShallowCloneCandidate::isGlobalMuon() const { return masterClone_->isGlobalMuon(); }
 
-bool ShallowCloneCandidate::isStandAloneMuon() const { 
-  return masterClone_->isStandAloneMuon(); 
-}
+bool ShallowCloneCandidate::isStandAloneMuon() const { return masterClone_->isStandAloneMuon(); }
 
-bool ShallowCloneCandidate::isTrackerMuon() const { 
-  return masterClone_->isTrackerMuon(); 
-}
+bool ShallowCloneCandidate::isTrackerMuon() const { return masterClone_->isTrackerMuon(); }
 
-bool ShallowCloneCandidate::isCaloMuon() const { 
-  return masterClone_->isCaloMuon(); 
-}
+bool ShallowCloneCandidate::isCaloMuon() const { return masterClone_->isCaloMuon(); }
 
-bool ShallowCloneCandidate::isPhoton() const { 
-  return masterClone_->isPhoton(); 
-}
+bool ShallowCloneCandidate::isPhoton() const { return masterClone_->isPhoton(); }
 
-bool ShallowCloneCandidate::isConvertedPhoton() const { 
-  return masterClone_->isConvertedPhoton(); 
-}
+bool ShallowCloneCandidate::isConvertedPhoton() const { return masterClone_->isConvertedPhoton(); }
 
-bool ShallowCloneCandidate::isJet() const { 
-  return masterClone_->isJet(); 
-}
+bool ShallowCloneCandidate::isJet() const { return masterClone_->isJet(); }

--- a/DataFormats/Candidate/src/ShallowClonePtrCandidate.cc
+++ b/DataFormats/Candidate/src/ShallowClonePtrCandidate.cc
@@ -1,73 +1,38 @@
 #include "DataFormats/Candidate/interface/ShallowClonePtrCandidate.h"
 using namespace reco;
 
-ShallowClonePtrCandidate::~ShallowClonePtrCandidate() { 
-}
+ShallowClonePtrCandidate::~ShallowClonePtrCandidate() {}
 
-ShallowClonePtrCandidate * ShallowClonePtrCandidate::clone() const { 
-  return new ShallowClonePtrCandidate( *this ); 
-}
+ShallowClonePtrCandidate* ShallowClonePtrCandidate::clone() const { return new ShallowClonePtrCandidate(*this); }
 
-size_t ShallowClonePtrCandidate::numberOfDaughters() const { 
-  return masterClone_->numberOfDaughters(); 
-}
+size_t ShallowClonePtrCandidate::numberOfDaughters() const { return masterClone_->numberOfDaughters(); }
 
-size_t ShallowClonePtrCandidate::numberOfMothers() const { 
-  return masterClone_->numberOfMothers(); 
-}
+size_t ShallowClonePtrCandidate::numberOfMothers() const { return masterClone_->numberOfMothers(); }
 
-const Candidate * ShallowClonePtrCandidate::daughter( size_type i ) const { 
-  return masterClone_->daughter( i ); 
-}
+const Candidate* ShallowClonePtrCandidate::daughter(size_type i) const { return masterClone_->daughter(i); }
 
-const Candidate * ShallowClonePtrCandidate::mother( size_type i ) const { 
-  return masterClone_->mother( i ); 
-}
+const Candidate* ShallowClonePtrCandidate::mother(size_type i) const { return masterClone_->mother(i); }
 
-Candidate * ShallowClonePtrCandidate::daughter( size_type i ) { 
-  return nullptr;
-}
+Candidate* ShallowClonePtrCandidate::daughter(size_type i) { return nullptr; }
 
-bool ShallowClonePtrCandidate::hasMasterClonePtr() const {
-  return true;
-}
+bool ShallowClonePtrCandidate::hasMasterClonePtr() const { return true; }
 
-const CandidatePtr & ShallowClonePtrCandidate::masterClonePtr() const {
-  return masterClone_;
-}
+const CandidatePtr& ShallowClonePtrCandidate::masterClonePtr() const { return masterClone_; }
 
-bool ShallowClonePtrCandidate::isElectron() const { 
-  return masterClone_->isElectron(); 
-}
+bool ShallowClonePtrCandidate::isElectron() const { return masterClone_->isElectron(); }
 
-bool ShallowClonePtrCandidate::isMuon() const { 
-  return masterClone_->isMuon(); 
-}
+bool ShallowClonePtrCandidate::isMuon() const { return masterClone_->isMuon(); }
 
-bool ShallowClonePtrCandidate::isGlobalMuon() const { 
-  return masterClone_->isGlobalMuon(); 
-}
+bool ShallowClonePtrCandidate::isGlobalMuon() const { return masterClone_->isGlobalMuon(); }
 
-bool ShallowClonePtrCandidate::isStandAloneMuon() const { 
-  return masterClone_->isStandAloneMuon(); 
-}
+bool ShallowClonePtrCandidate::isStandAloneMuon() const { return masterClone_->isStandAloneMuon(); }
 
-bool ShallowClonePtrCandidate::isTrackerMuon() const { 
-  return masterClone_->isTrackerMuon(); 
-}
+bool ShallowClonePtrCandidate::isTrackerMuon() const { return masterClone_->isTrackerMuon(); }
 
-bool ShallowClonePtrCandidate::isCaloMuon() const { 
-  return masterClone_->isCaloMuon(); 
-}
+bool ShallowClonePtrCandidate::isCaloMuon() const { return masterClone_->isCaloMuon(); }
 
-bool ShallowClonePtrCandidate::isPhoton() const { 
-  return masterClone_->isPhoton(); 
-}
+bool ShallowClonePtrCandidate::isPhoton() const { return masterClone_->isPhoton(); }
 
-bool ShallowClonePtrCandidate::isConvertedPhoton() const { 
-  return masterClone_->isConvertedPhoton(); 
-}
+bool ShallowClonePtrCandidate::isConvertedPhoton() const { return masterClone_->isConvertedPhoton(); }
 
-bool ShallowClonePtrCandidate::isJet() const { 
-  return masterClone_->isJet(); 
-}
+bool ShallowClonePtrCandidate::isJet() const { return masterClone_->isJet(); }

--- a/DataFormats/Candidate/src/VertexCompositeCandidate.cc
+++ b/DataFormats/Candidate/src/VertexCompositeCandidate.cc
@@ -2,30 +2,33 @@
 
 using namespace reco;
 
-VertexCompositeCandidate::VertexCompositeCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-						   const CovarianceMatrix & err, double chi2, double ndof,
-						   int pdgId, int status, bool integerCharge) :
-  CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge),
-  chi2_(chi2), ndof_(ndof) { 
+VertexCompositeCandidate::VertexCompositeCandidate(Charge q,
+                                                   const LorentzVector& p4,
+                                                   const Point& vtx,
+                                                   const CovarianceMatrix& err,
+                                                   double chi2,
+                                                   double ndof,
+                                                   int pdgId,
+                                                   int status,
+                                                   bool integerCharge)
+    : CompositeCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(chi2), ndof_(ndof) {
   setCovariance(err);
 }
 
-VertexCompositeCandidate::~VertexCompositeCandidate() { }
+VertexCompositeCandidate::~VertexCompositeCandidate() {}
 
-VertexCompositeCandidate * VertexCompositeCandidate::clone() const { 
-  return new VertexCompositeCandidate(*this); 
-}
+VertexCompositeCandidate* VertexCompositeCandidate::clone() const { return new VertexCompositeCandidate(*this); }
 
 void VertexCompositeCandidate::fillVertexCovariance(CovarianceMatrix& err) const {
   index idx = 0;
-  for(index i = 0; i < dimension; ++i) 
-    for(index j = 0; j <= i; ++ j)
+  for (index i = 0; i < dimension; ++i)
+    for (index j = 0; j <= i; ++j)
       err(i, j) = covariance_[idx++];
 }
 
-void VertexCompositeCandidate::setCovariance(const CovarianceMatrix & err) {
+void VertexCompositeCandidate::setCovariance(const CovarianceMatrix& err) {
   index idx = 0;
-  for(index i = 0; i < dimension; ++i) 
-    for(index j = 0; j <= i; ++j)
+  for (index i = 0; i < dimension; ++i)
+    for (index j = 0; j <= i; ++j)
       covariance_[idx++] = err(i, j);
 }

--- a/DataFormats/Candidate/src/VertexCompositePtrCandidate.cc
+++ b/DataFormats/Candidate/src/VertexCompositePtrCandidate.cc
@@ -2,58 +2,68 @@
 
 using namespace reco;
 
-VertexCompositePtrCandidate::VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-						   const CovarianceMatrix & err, double chi2, double ndof,
-						   int pdgId, int status, bool integerCharge) :
-  CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-  chi2_(chi2), ndof_(ndof), time_(0.) { 
+VertexCompositePtrCandidate::VertexCompositePtrCandidate(Charge q,
+                                                         const LorentzVector& p4,
+                                                         const Point& vtx,
+                                                         const CovarianceMatrix& err,
+                                                         double chi2,
+                                                         double ndof,
+                                                         int pdgId,
+                                                         int status,
+                                                         bool integerCharge)
+    : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(chi2), ndof_(ndof), time_(0.) {
   setCovariance(err);
 }
 
-VertexCompositePtrCandidate::VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-						   double time, const CovarianceMatrix4D & err, double chi2, 
-						   double ndof, int pdgId, int status, bool integerCharge) :
-  CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-  chi2_(chi2), ndof_(ndof), time_(time) { 
+VertexCompositePtrCandidate::VertexCompositePtrCandidate(Charge q,
+                                                         const LorentzVector& p4,
+                                                         const Point& vtx,
+                                                         double time,
+                                                         const CovarianceMatrix4D& err,
+                                                         double chi2,
+                                                         double ndof,
+                                                         int pdgId,
+                                                         int status,
+                                                         bool integerCharge)
+    : CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge), chi2_(chi2), ndof_(ndof), time_(time) {
   setCovariance(err);
 }
 
-VertexCompositePtrCandidate::~VertexCompositePtrCandidate() { }
+VertexCompositePtrCandidate::~VertexCompositePtrCandidate() {}
 
-VertexCompositePtrCandidate * VertexCompositePtrCandidate::clone() const { 
-  return new VertexCompositePtrCandidate(*this); 
+VertexCompositePtrCandidate* VertexCompositePtrCandidate::clone() const {
+  return new VertexCompositePtrCandidate(*this);
 }
 
 void VertexCompositePtrCandidate::fillVertexCovariance(CovarianceMatrix& err) const {
   Error4D temp;
   fillVertexCovariance(temp);
-  err = temp.Sub<Error>(0,0);  
+  err = temp.Sub<Error>(0, 0);
 }
 
 void VertexCompositePtrCandidate::fillVertexCovariance(CovarianceMatrix4D& err) const {
   index idx = 0;
-  for(index i = 0; i < dimension4D; ++i) 
-    for(index j = 0; j <= i; ++ j) 
+  for (index i = 0; i < dimension4D; ++i)
+    for (index j = 0; j <= i; ++j)
       err(i, j) = covariance_[idx++];
 }
 
-void VertexCompositePtrCandidate::setCovariance(const CovarianceMatrix & err) {
+void VertexCompositePtrCandidate::setCovariance(const CovarianceMatrix& err) {
   index idx = 0;
-  for(index i = 0; i < dimension4D; ++i) { 
-    for(index j = 0; j <= i; ++j) {
-      if( i == dimension || j == dimension ) {
-        covariance_[ idx ++ ] = 0.0;
+  for (index i = 0; i < dimension4D; ++i) {
+    for (index j = 0; j <= i; ++j) {
+      if (i == dimension || j == dimension) {
+        covariance_[idx++] = 0.0;
       } else {
-        covariance_[ idx ++ ] = err( i, j );
+        covariance_[idx++] = err(i, j);
       }
     }
   }
 }
 
-void VertexCompositePtrCandidate::setCovariance(const CovarianceMatrix4D & err) {
+void VertexCompositePtrCandidate::setCovariance(const CovarianceMatrix4D& err) {
   index idx = 0;
-  for(index i = 0; i < dimension4D; ++i) 
-    for(index j = 0; j <= i; ++j)
+  for (index i = 0; i < dimension4D; ++i)
+    for (index j = 0; j <= i; ++j)
       covariance_[idx++] = err(i, j);
 }
-

--- a/DataFormats/Candidate/src/classes.h
+++ b/DataFormats/Candidate/src/classes.h
@@ -1,11 +1,11 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
-#include "Rtypes.h" 
-#include "Math/Cartesian3D.h" 
-#include "Math/Polar3D.h" 
-#include "Math/CylindricalEta3D.h" 
-#include "Math/PxPyPzE4D.h" 
+#include "Rtypes.h"
+#include "Math/Cartesian3D.h"
+#include "Math/Polar3D.h"
+#include "Math/CylindricalEta3D.h"
+#include "Math/PxPyPzE4D.h"
 #include "DataFormats/Candidate/interface/LeafRefCandidateT.h"
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
@@ -38,6 +38,6 @@
 #include <vector>
 
 namespace reco {
-   typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<CandidateView,CandidateView,bool> > CandViewCandViewAssociation;
+  typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<CandidateView, CandidateView, bool> >
+      CandViewCandViewAssociation;
 }
-

--- a/DataFormats/Candidate/test/testCandidate.cc
+++ b/DataFormats/Candidate/test/testCandidate.cc
@@ -9,16 +9,17 @@ class testCandidate : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testCandidate);
   CPPUNIT_TEST(checkAll);
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testCandidate);
 
 namespace test {
-  
+
   struct DummyComponent {
     int x;
   };
@@ -29,15 +30,14 @@ namespace test {
 
   class DummyCandidate1 : public reco::LeafCandidate {
   public:
-    DummyCandidate1( const LorentzVector & p, Charge q, int x, 
-		     int y1, int y2) : reco::LeafCandidate( q, p ) { 
+    DummyCandidate1(const LorentzVector& p, Charge q, int x, int y1, int y2) : reco::LeafCandidate(q, p) {
       c.x = x;
       cc[0].x = y1;
       cc[1].x = y2;
     }
-    virtual DummyCandidate1 * clone() const { return new DummyCandidate1( * this ); }
+    virtual DummyCandidate1* clone() const { return new DummyCandidate1(*this); }
     DummyComponent cmp() const { return c; }
-    DummyComponent2 cmp2( size_t i ) const { return cc[i]; }
+    DummyComponent2 cmp2(size_t i) const { return cc[i]; }
     size_t cmpSize2() const { return 2; }
 
   private:
@@ -46,77 +46,81 @@ namespace test {
   };
 
   struct DummyRef {
-    bool isNull() const    { return true; }
+    bool isNull() const { return true; }
     bool isNonnull() const { return false; }
-    bool operator==( const DummyRef & ref ) const { return true; }
-    bool operator!=( const DummyRef & ref ) const { return false; }
+    bool operator==(const DummyRef& ref) const { return true; }
+    bool operator!=(const DummyRef& ref) const { return false; }
   };
 
-}
+}  // namespace test
 
 namespace reco {
-  GET_DEFAULT_CANDIDATE_COMPONENT( test::DummyCandidate1, test::DummyComponent, cmp );
-  GET_CANDIDATE_MULTIPLECOMPONENTS( test::DummyCandidate1, test::DummyComponent2, cmp2, cmpSize2, DefaultComponentTag );
-}
+  GET_DEFAULT_CANDIDATE_COMPONENT(test::DummyCandidate1, test::DummyComponent, cmp);
+  GET_CANDIDATE_MULTIPLECOMPONENTS(test::DummyCandidate1, test::DummyComponent2, cmp2, cmpSize2, DefaultComponentTag);
+}  // namespace reco
 
 void testCandidate::checkAll() {
-  reco::Particle::LorentzVector p( 1.0, 2.0, 3.0, 5.0 );
+  reco::Particle::LorentzVector p(1.0, 2.0, 3.0, 5.0);
   GlobalVector v(1.0, 2.0, 3.0);
-  reco::LeafCandidate::PolarLorentzVector pl(p);  
+  reco::LeafCandidate::PolarLorentzVector pl(p);
 
-  reco::Particle::Charge q( 1 );
+  reco::Particle::Charge q(1);
   int x = 123, y0 = 111, y1 = 222;
-  std::unique_ptr<reco::Candidate> c( new test::DummyCandidate1( p, q, x, y0, y1 ) );
-  CPPUNIT_ASSERT( c->charge() == q );
-  CPPUNIT_ASSERT( (c->p4() - p).M2() < 1.e-4 );
-  CPPUNIT_ASSERT( c->numberOfDaughters() == 0 );
-  CPPUNIT_ASSERT( c->get<test::DummyComponent>().x == x );
-  CPPUNIT_ASSERT( c->numberOf<test::DummyComponent2>() == 2 );
-  CPPUNIT_ASSERT( c->get<test::DummyComponent2>( 0 ).x == y0 );
-  CPPUNIT_ASSERT( c->get<test::DummyComponent2>( 1 ).x == y1 );
+  std::unique_ptr<reco::Candidate> c(new test::DummyCandidate1(p, q, x, y0, y1));
+  CPPUNIT_ASSERT(c->charge() == q);
+  CPPUNIT_ASSERT((c->p4() - p).M2() < 1.e-4);
+  CPPUNIT_ASSERT(c->numberOfDaughters() == 0);
+  CPPUNIT_ASSERT(c->get<test::DummyComponent>().x == x);
+  CPPUNIT_ASSERT(c->numberOf<test::DummyComponent2>() == 2);
+  CPPUNIT_ASSERT(c->get<test::DummyComponent2>(0).x == y0);
+  CPPUNIT_ASSERT(c->get<test::DummyComponent2>(1).x == y1);
 
   reco::CandidateWithRef<test::DummyRef> cwr;
   test::DummyRef dr;
-  cwr.setRef( dr );
+  cwr.setRef(dr);
 
   reco::Candidate::const_iterator b = c->begin(), e = c->end();
-  CPPUNIT_ASSERT( b == e );
-  CPPUNIT_ASSERT( e - b == 0 );
+  CPPUNIT_ASSERT(b == e);
+  CPPUNIT_ASSERT(e - b == 0);
 
   // test constructors
 
-  reco::LeafCandidate c1(q,p);
-  reco::LeafCandidate c2(q,pl);
-  reco::LeafCandidate c3(q,v,5.f,c1.mass());
+  reco::LeafCandidate c1(q, p);
+  reco::LeafCandidate c2(q, pl);
+  reco::LeafCandidate c3(q, v, 5.f, c1.mass());
 
-  auto ftoi = [](float x)->int { int i; memcpy(&i,&x,4); return i;};
-  auto print = [](float a, float b)->bool { std::cout << "\nwhat? " << a <<' ' << b << std::endl; return false;};
-  auto ok = [&](float a, float b)->bool { return std::abs(ftoi(a)-ftoi(b))<10 ? true : print(a,b); };
+  auto ftoi = [](float x) -> int {
+    int i;
+    memcpy(&i, &x, 4);
+    return i;
+  };
+  auto print = [](float a, float b) -> bool {
+    std::cout << "\nwhat? " << a << ' ' << b << std::endl;
+    return false;
+  };
+  auto ok = [&](float a, float b) -> bool { return std::abs(ftoi(a) - ftoi(b)) < 10 ? true : print(a, b); };
 
-  CPPUNIT_ASSERT(ok(c1.pt(),c2.pt()));
-  CPPUNIT_ASSERT(ok(c1.eta(),c2.eta()));
-  CPPUNIT_ASSERT(ok(c1.phi(),c2.phi()));
-  CPPUNIT_ASSERT(ok(c1.mass(),c2.mass()));
+  CPPUNIT_ASSERT(ok(c1.pt(), c2.pt()));
+  CPPUNIT_ASSERT(ok(c1.eta(), c2.eta()));
+  CPPUNIT_ASSERT(ok(c1.phi(), c2.phi()));
+  CPPUNIT_ASSERT(ok(c1.mass(), c2.mass()));
 
-  CPPUNIT_ASSERT(ok(c1.y(),c2.y()));
- 
-  CPPUNIT_ASSERT(ok(c1.pt(),c3.pt()));
-  CPPUNIT_ASSERT(ok(c1.eta(),c3.eta()));
-  CPPUNIT_ASSERT(ok(c1.phi(),c3.phi()));
-  CPPUNIT_ASSERT(ok(c1.mass(),c3.mass()));
+  CPPUNIT_ASSERT(ok(c1.y(), c2.y()));
 
-  CPPUNIT_ASSERT(ok(c1.y(),c3.y()));
+  CPPUNIT_ASSERT(ok(c1.pt(), c3.pt()));
+  CPPUNIT_ASSERT(ok(c1.eta(), c3.eta()));
+  CPPUNIT_ASSERT(ok(c1.phi(), c3.phi()));
+  CPPUNIT_ASSERT(ok(c1.mass(), c3.mass()));
 
-  CPPUNIT_ASSERT(ok(c1.px(),c2.px()));
-  CPPUNIT_ASSERT(ok(c1.py(),c2.py()));
-  CPPUNIT_ASSERT(ok(c1.pz(),c2.pz()));
-  CPPUNIT_ASSERT(ok(c1.energy(),c2.energy()));
+  CPPUNIT_ASSERT(ok(c1.y(), c3.y()));
 
-  CPPUNIT_ASSERT(ok(c1.px(),c3.px()));
-  CPPUNIT_ASSERT(ok(c1.py(),c3.py()));
-  CPPUNIT_ASSERT(ok(c1.pz(),c3.pz()));
-  CPPUNIT_ASSERT(ok(c1.energy(),c3.energy()));
+  CPPUNIT_ASSERT(ok(c1.px(), c2.px()));
+  CPPUNIT_ASSERT(ok(c1.py(), c2.py()));
+  CPPUNIT_ASSERT(ok(c1.pz(), c2.pz()));
+  CPPUNIT_ASSERT(ok(c1.energy(), c2.energy()));
 
-
-
+  CPPUNIT_ASSERT(ok(c1.px(), c3.px()));
+  CPPUNIT_ASSERT(ok(c1.py(), c3.py()));
+  CPPUNIT_ASSERT(ok(c1.pz(), c3.pz()));
+  CPPUNIT_ASSERT(ok(c1.energy(), c3.energy()));
 }

--- a/DataFormats/Candidate/test/testCompositeCandidate.cc
+++ b/DataFormats/Candidate/test/testCompositeCandidate.cc
@@ -6,10 +6,11 @@ class testCompositeCandidate : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testCompositeCandidate);
   CPPUNIT_TEST(checkAll);
   CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp() {}
   void tearDown() {}
-  void checkAll(); 
+  void checkAll();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testCompositeCandidate);
@@ -17,53 +18,52 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testCompositeCandidate);
 namespace test {
   class DummyCandidate : public reco::LeafCandidate {
   public:
-    DummyCandidate( const LorentzVector & p, Charge q = 0, int x = 0 ) : 
-      reco::LeafCandidate(q, p), x_(x) { }
-    virtual DummyCandidate * clone() const { return new DummyCandidate( * this ); }
+    DummyCandidate(const LorentzVector& p, Charge q = 0, int x = 0) : reco::LeafCandidate(q, p), x_(x) {}
+    virtual DummyCandidate* clone() const { return new DummyCandidate(*this); }
     int x() const { return x_; }
+
   private:
     int x_;
   };
-}
+}  // namespace test
 
 namespace reco {
-  GET_DEFAULT_CANDIDATE_COMPONENT( test::DummyCandidate, int, x );
+  GET_DEFAULT_CANDIDATE_COMPONENT(test::DummyCandidate, int, x);
 }
 
 namespace test {
   struct DummyCandSelector {
-    DummyCandSelector( int x ): x_(x) { }
-    bool operator()( const reco::Candidate & c ) const {
-      return c.get<int>() == x_;
-    }
+    DummyCandSelector(int x) : x_(x) {}
+    bool operator()(const reco::Candidate& c) const { return c.get<int>() == x_; }
+
   private:
     int x_;
   };
-}
+}  // namespace test
 
 void testCompositeCandidate::checkAll() {
-  reco::Particle::LorentzVector p1( 1.0, 2.0, 3.0, 4.0 ), p2( 1.5, 2.5, 3.5, 4.5 );
-  reco::Particle::Charge q1( 1 ), q2( -1 );
+  reco::Particle::LorentzVector p1(1.0, 2.0, 3.0, 4.0), p2(1.5, 2.5, 3.5, 4.5);
+  reco::Particle::Charge q1(1), q2(-1);
   {
-    test::DummyCandidate t1( p1, q1 );
-    test::DummyCandidate t2( p2, q2 );
+    test::DummyCandidate t1(p1, q1);
+    test::DummyCandidate t2(p2, q2);
     reco::CompositeCandidate c;
-    CPPUNIT_ASSERT( c.numberOfDaughters() == 0 );
-    c.addDaughter( t1 );
-    CPPUNIT_ASSERT( c.numberOfDaughters() == 1 );
-    c.addDaughter( t2 );
-    CPPUNIT_ASSERT( c.numberOfDaughters() == 2 );
-    
-    const reco::Candidate * d[ 2 ];
+    CPPUNIT_ASSERT(c.numberOfDaughters() == 0);
+    c.addDaughter(t1);
+    CPPUNIT_ASSERT(c.numberOfDaughters() == 1);
+    c.addDaughter(t2);
+    CPPUNIT_ASSERT(c.numberOfDaughters() == 2);
+
+    const reco::Candidate* d[2];
     int idx = 0;
-    const reco::CompositeCandidate & cand = c;
-    CPPUNIT_ASSERT(c.numberOfDaughters()==2);
-    for( reco::Candidate::const_iterator i = cand.begin(); i != cand.end(); ++ i ) {
-      d[ idx ++ ] = & * i;
+    const reco::CompositeCandidate& cand = c;
+    CPPUNIT_ASSERT(c.numberOfDaughters() == 2);
+    for (reco::Candidate::const_iterator i = cand.begin(); i != cand.end(); ++i) {
+      d[idx++] = &*i;
     }
-    CPPUNIT_ASSERT( d[ 0 ]->charge() == q1 );
-    CPPUNIT_ASSERT( (d[ 0 ]->p4() - p1).M2() < 1.e-4 );
-    CPPUNIT_ASSERT( d[ 1 ]->charge() == q2 );
-    CPPUNIT_ASSERT( (d[ 1 ]->p4() - p2).M2() < 1.e-4 );
+    CPPUNIT_ASSERT(d[0]->charge() == q1);
+    CPPUNIT_ASSERT((d[0]->p4() - p1).M2() < 1.e-4);
+    CPPUNIT_ASSERT(d[1]->charge() == q2);
+    CPPUNIT_ASSERT((d[1]->p4() - p2).M2() < 1.e-4);
   }
 }

--- a/DataFormats/Candidate/test/testParticle.cc
+++ b/DataFormats/Candidate/test/testParticle.cc
@@ -13,9 +13,9 @@ class testParticle : public CppUnit::TestFixture {
   CPPUNIT_TEST(checkPolarLarge);
   CPPUNIT_TEST(checkFloatLarge);
   CPPUNIT_TEST_SUITE_END();
+
 public:
-  void setUp() {
-  }
+  void setUp() {}
   void tearDown() {}
   void checkXYZ();
   void checkPolar();
@@ -23,277 +23,283 @@ public:
   void checkXYZLarge();
   void checkPolarLarge();
   void checkFloatLarge();
- 
-  void testAbs( const reco::Particle & t, 
-	     reco::Particle::Charge q, const reco::Particle::Point &,
-	     const reco::Particle::LorentzVector & p,
-	     const reco::Particle::PolarLorentzVector & pp );
-  void testRel( const reco::Particle & t, 
-	     reco::Particle::Charge q, const reco::Particle::Point &,
-	     const reco::Particle::LorentzVector & p,
-	     const reco::Particle::PolarLorentzVector & pp );
+
+  void testAbs(const reco::Particle &t,
+               reco::Particle::Charge q,
+               const reco::Particle::Point &,
+               const reco::Particle::LorentzVector &p,
+               const reco::Particle::PolarLorentzVector &pp);
+  void testRel(const reco::Particle &t,
+               reco::Particle::Charge q,
+               const reco::Particle::Point &,
+               const reco::Particle::LorentzVector &p,
+               const reco::Particle::PolarLorentzVector &pp);
 
   const double mass = 123.456;
   const double pz = 100.000;
-  const reco::Particle::Point vtx = reco::Particle::Point( 6, 7, 8 );
-  const reco::Particle::Point vtx1 = reco::Particle::Point( 8, 7, 6 );
-  const reco::Particle::Charge q= 1;
-  const reco::Particle::Charge q1=9;
-
-
+  const reco::Particle::Point vtx = reco::Particle::Point(6, 7, 8);
+  const reco::Particle::Point vtx1 = reco::Particle::Point(8, 7, 6);
+  const reco::Particle::Charge q = 1;
+  const reco::Particle::Charge q1 = 9;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testParticle);
 
-void testParticle::testAbs( const reco::Particle & t, 
-			 reco::Particle::Charge q, const reco::Particle::Point & vtx,
-			 const reco::Particle::LorentzVector & p,
-			 const reco::Particle::PolarLorentzVector & pp ) {
+void testParticle::testAbs(const reco::Particle &t,
+                           reco::Particle::Charge q,
+                           const reco::Particle::Point &vtx,
+                           const reco::Particle::LorentzVector &p,
+                           const reco::Particle::PolarLorentzVector &pp) {
   const double epsilon = 1.e-5;
   const double epsilon2 = 5.e-4;
-  CPPUNIT_ASSERT( t.charge() == q );
-  CPPUNIT_ASSERT( t.threeCharge() == q*3 );
-  CPPUNIT_ASSERT( (t.polarP4() - pp).M2() < epsilon );
-  CPPUNIT_ASSERT( (t.p4() - p).M2() < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.p() - p.P()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.energy() - p.E()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.px() - p.Px()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.py() - p.Py()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.pz() - p.Pz()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.phi() - p.Phi()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.theta() - p.Theta()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.eta() - p.Eta()) < epsilon  );
-  CPPUNIT_ASSERT( std::abs(t.mass() - p.M()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.massSqr() - p.M2()) < epsilon2 );
-  CPPUNIT_ASSERT( std::abs(t.mt() - p.Mt()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.mtSqr() - p.Mt2()) < epsilon2 );  
-  CPPUNIT_ASSERT( std::abs(t.rapidity() - p.Rapidity()) < epsilon );  
-  CPPUNIT_ASSERT( std::abs(t.vx() - vtx.x()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.vy() - vtx.y()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.vz() - vtx.z()) < epsilon );
+  CPPUNIT_ASSERT(t.charge() == q);
+  CPPUNIT_ASSERT(t.threeCharge() == q * 3);
+  CPPUNIT_ASSERT((t.polarP4() - pp).M2() < epsilon);
+  CPPUNIT_ASSERT((t.p4() - p).M2() < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.p() - p.P()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.energy() - p.E()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.px() - p.Px()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.py() - p.Py()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.pz() - p.Pz()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.phi() - p.Phi()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.theta() - p.Theta()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.eta() - p.Eta()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.mass() - p.M()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.massSqr() - p.M2()) < epsilon2);
+  CPPUNIT_ASSERT(std::abs(t.mt() - p.Mt()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.mtSqr() - p.Mt2()) < epsilon2);
+  CPPUNIT_ASSERT(std::abs(t.rapidity() - p.Rapidity()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.vx() - vtx.x()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.vy() - vtx.y()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.vz() - vtx.z()) < epsilon);
 }
 
-void testParticle::testRel( const reco::Particle & t, 
-			 reco::Particle::Charge q, const reco::Particle::Point & vtx,
-			 const reco::Particle::LorentzVector & p,
-			 const reco::Particle::PolarLorentzVector & pp ) {
+void testParticle::testRel(const reco::Particle &t,
+                           reco::Particle::Charge q,
+                           const reco::Particle::Point &vtx,
+                           const reco::Particle::LorentzVector &p,
+                           const reco::Particle::PolarLorentzVector &pp) {
   const double epsilon = 1.e-5;
   const double epsilon2 = 5.e-4;
-  CPPUNIT_ASSERT( t.charge() == q );
-  CPPUNIT_ASSERT( t.threeCharge() == q*3 );
+  CPPUNIT_ASSERT(t.charge() == q);
+  CPPUNIT_ASSERT(t.threeCharge() == q * 3);
   // these should be zero
-  CPPUNIT_ASSERT( (t.polarP4() - pp).M2() < epsilon );
-  CPPUNIT_ASSERT( (t.p4() - p).M2() < epsilon );
+  CPPUNIT_ASSERT((t.polarP4() - pp).M2() < epsilon);
+  CPPUNIT_ASSERT((t.p4() - p).M2() < epsilon);
 
-  CPPUNIT_ASSERT( std::abs(t.p() - p.P())/p.P() < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.energy() - p.E())/p.E() < epsilon );
+  CPPUNIT_ASSERT(std::abs(t.p() - p.P()) / p.P() < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.energy() - p.E()) / p.E() < epsilon);
 
-  CPPUNIT_ASSERT( std::abs((t.px() - p.px())/p.px()) < epsilon );
-  CPPUNIT_ASSERT( std::abs((t.py() - p.py())/p.py()) < epsilon );
-  CPPUNIT_ASSERT( std::abs((t.pz() - p.pz())/p.pz()) < epsilon );
+  CPPUNIT_ASSERT(std::abs((t.px() - p.px()) / p.px()) < epsilon);
+  CPPUNIT_ASSERT(std::abs((t.py() - p.py()) / p.py()) < epsilon);
+  CPPUNIT_ASSERT(std::abs((t.pz() - p.pz()) / p.pz()) < epsilon);
   // here resolution should be absolute no matter what
-  CPPUNIT_ASSERT( std::abs(t.phi() - p.Phi()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.theta() - p.Theta()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.eta() - p.Eta()) < epsilon  );
-  CPPUNIT_ASSERT( std::abs(t.rapidity() - p.Rapidity()) < epsilon );  
+  CPPUNIT_ASSERT(std::abs(t.phi() - p.Phi()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.theta() - p.Theta()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.eta() - p.Eta()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.rapidity() - p.Rapidity()) < epsilon);
 
-  CPPUNIT_ASSERT( std::abs((t.mass() - p.M())/p.M()) < epsilon );
-  CPPUNIT_ASSERT( std::abs((t.massSqr() - p.M2())/p.M2()) < epsilon2 );
-  CPPUNIT_ASSERT( std::abs((t.mt() - p.Mt())/p.Mt()) < epsilon );
-  CPPUNIT_ASSERT( std::abs((t.mtSqr() - p.Mt2())/p.Mt2()) < epsilon2 );  
+  CPPUNIT_ASSERT(std::abs((t.mass() - p.M()) / p.M()) < epsilon);
+  CPPUNIT_ASSERT(std::abs((t.massSqr() - p.M2()) / p.M2()) < epsilon2);
+  CPPUNIT_ASSERT(std::abs((t.mt() - p.Mt()) / p.Mt()) < epsilon);
+  CPPUNIT_ASSERT(std::abs((t.mtSqr() - p.Mt2()) / p.Mt2()) < epsilon2);
 
   // not really tested....  absolute makes sense
-  CPPUNIT_ASSERT( std::abs(t.vx() - vtx.x()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.vy() - vtx.y()) < epsilon );
-  CPPUNIT_ASSERT( std::abs(t.vz() - vtx.z()) < epsilon );
+  CPPUNIT_ASSERT(std::abs(t.vx() - vtx.x()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.vy() - vtx.y()) < epsilon);
+  CPPUNIT_ASSERT(std::abs(t.vz() - vtx.z()) < epsilon);
 }
 
-
-
-reco::Particle stream(reco::Particle & t) {
+reco::Particle stream(reco::Particle &t) {
   auto m_class = TClass::GetClass(typeid(reco::Particle));
   TBufferFile wbuffer(TBufferFile::kWrite);
   wbuffer.InitMap();
-  wbuffer.StreamObject((&t),m_class);
-  
-  TBufferFile rbuffer(TBufferFile::kRead, wbuffer.Length(),
-		      (wbuffer.Buffer()), kFALSE);
-  
+  wbuffer.StreamObject((&t), m_class);
+
+  TBufferFile rbuffer(TBufferFile::kRead, wbuffer.Length(), (wbuffer.Buffer()), kFALSE);
+
   rbuffer.InitMap();
 
   reco::Particle t2;
   rbuffer.StreamObject(&t2, m_class);
   return t2;
-  
-
 }
 
 void testParticle::checkXYZ() {
-  reco::Particle::LorentzVector p( 1.0, 2.0, 3.0, 4.0 );
+  reco::Particle::LorentzVector p(1.0, 2.0, 3.0, 4.0);
   reco::Particle::PolarLorentzVector pp(p);
-  reco::Particle t( q, p, vtx );
+  reco::Particle t(q, p, vtx);
   testAbs(t, q, vtx, p, pp);
-  
+
   auto t2 = stream(t);
   testAbs(t2, q, vtx, p, pp);
- 
 
-  reco::Particle::LorentzVector p1( 1.1, 2.2, 3.3, 4.4 );
+  reco::Particle::LorentzVector p1(1.1, 2.2, 3.3, 4.4);
   reco::Particle::PolarLorentzVector pp1(p1);
   t.setP4(p1);
   testAbs(t, q, vtx, p1, pp1);
-  t.setMass(mass); pp1.SetM(mass); p1 =  reco::Particle::LorentzVector(pp1);
-  testAbs(t, q, vtx, p1, pp1);   
-  t.setPz(pz); p1.SetPz(pz); pp1 = reco::Particle::PolarLorentzVector(p1);
+  t.setMass(mass);
+  pp1.SetM(mass);
+  p1 = reco::Particle::LorentzVector(pp1);
   testAbs(t, q, vtx, p1, pp1);
-  t.setVertex( vtx1 );
+  t.setPz(pz);
+  p1.SetPz(pz);
+  pp1 = reco::Particle::PolarLorentzVector(p1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setVertex(vtx1);
   testAbs(t, q, vtx1, p1, pp1);
-  t.setCharge( q1 );
+  t.setCharge(q1);
   testAbs(t, q1, vtx1, p1, pp1);
-  t.setThreeCharge( q1 );
-  testAbs(t, q1/3, vtx1, p1, pp1);
-
- 
+  t.setThreeCharge(q1);
+  testAbs(t, q1 / 3, vtx1, p1, pp1);
 }
 
-  void testParticle::checkPolar(){
-    reco::Particle::PolarLorentzVector pp( 1.0, 2.0, 3.0, 4.0 );
-    reco::Particle::LorentzVector p(pp);
-    reco::Particle t( q, pp, vtx );
-    testAbs(t, q, vtx, p, pp);
+void testParticle::checkPolar() {
+  reco::Particle::PolarLorentzVector pp(1.0, 2.0, 3.0, 4.0);
+  reco::Particle::LorentzVector p(pp);
+  reco::Particle t(q, pp, vtx);
+  testAbs(t, q, vtx, p, pp);
 
-    auto t2 = stream(t);
-    testAbs(t2, q, vtx, p, pp);
+  auto t2 = stream(t);
+  testAbs(t2, q, vtx, p, pp);
 
+  reco::Particle::PolarLorentzVector pp1(1.1, 2.2, 3.3, 4.4);
+  reco::Particle::LorentzVector p1(pp1);
+  t.setP4(pp1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setMass(mass);
+  pp1.SetM(mass);
+  p1 = reco::Particle::LorentzVector(pp1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setPz(pz);
+  p1.SetPz(pz);
+  pp1 = reco::Particle::PolarLorentzVector(p1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setVertex(vtx1);
+  testAbs(t, q, vtx1, p1, pp1);
+  t.setCharge(q1);
+  testAbs(t, q1, vtx1, p1, pp1);
+  t.setThreeCharge(q1);
+  testAbs(t, q1 / 3, vtx1, p1, pp1);
+}
 
-    reco::Particle::PolarLorentzVector pp1( 1.1, 2.2, 3.3, 4.4 );
-    reco::Particle::LorentzVector p1(pp1);
-    t.setP4(pp1);
-    testAbs(t, q, vtx, p1, pp1);
-    t.setMass(mass); pp1.SetM(mass); p1 =  reco::Particle::LorentzVector(pp1);
-    testAbs(t, q, vtx, p1, pp1);    
-    t.setPz(pz); p1.SetPz(pz); pp1 = reco::Particle::PolarLorentzVector(p1);
-    testAbs(t, q, vtx, p1, pp1);   
-    t.setVertex( vtx1 );
-    testAbs(t, q, vtx1, p1, pp1);
-    t.setCharge( q1 );
-    testAbs(t, q1, vtx1, p1, pp1);
-    t.setThreeCharge( q1 );
-    testAbs(t, q1/3, vtx1, p1, pp1);
- }
+void testParticle::checkFloat() {
+  reco::Particle::PolarLorentzVector pp(1.0, 2.0, 3.0, 4.0);
+  PtEtaPhiMass pepm(1.0f, 2.0f, 3.0f, 4.0f);
+  reco::Particle::LorentzVector p(pp);
+  reco::Particle t(q, pepm, vtx);
 
-  void testParticle::checkFloat(){
-    reco::Particle::PolarLorentzVector pp( 1.0, 2.0, 3.0, 4.0 );
-    PtEtaPhiMass pepm(1.0f, 2.0f, 3.0f, 4.0f );
-    reco::Particle::LorentzVector p(pp);
-    reco::Particle t( q, pepm, vtx );
-    
-    testAbs(t, q, vtx, p, pp);    
+  testAbs(t, q, vtx, p, pp);
 
-    auto t2 = stream(t);
-    testAbs(t2, q, vtx, p, pp);
+  auto t2 = stream(t);
+  testAbs(t2, q, vtx, p, pp);
 
+  reco::Particle::PolarLorentzVector pp1(1.1, 2.2, 3.3, 4.4);
+  reco::Particle::LorentzVector p1(pp1);
+  t.setP4(pp1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setMass(mass);
+  pp1.SetM(mass);
+  p1 = reco::Particle::LorentzVector(pp1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setPz(pz);
+  p1.SetPz(pz);
+  pp1 = reco::Particle::PolarLorentzVector(p1);
+  testAbs(t, q, vtx, p1, pp1);
+  t.setVertex(vtx1);
+  testAbs(t, q, vtx1, p1, pp1);
+  t.setCharge(q1);
+  testAbs(t, q1, vtx1, p1, pp1);
+  t.setThreeCharge(q1);
+  testAbs(t, q1 / 3, vtx1, p1, pp1);
+}
 
-    reco::Particle::PolarLorentzVector pp1( 1.1, 2.2, 3.3, 4.4 );
-    reco::Particle::LorentzVector p1(pp1);
-    t.setP4(pp1);
-    testAbs(t, q, vtx, p1, pp1);
-    t.setMass(mass); pp1.SetM(mass); p1 =  reco::Particle::LorentzVector(pp1);
-    testAbs(t, q, vtx, p1, pp1);    
-    t.setPz(pz); p1.SetPz(pz); pp1 = reco::Particle::PolarLorentzVector(p1);
-    testAbs(t, q, vtx, p1, pp1);   
-    t.setVertex( vtx1 );
-    testAbs(t, q, vtx1, p1, pp1);
-    t.setCharge( q1 );
-    testAbs(t, q1, vtx1, p1, pp1);
-    t.setThreeCharge( q1 );
-    testAbs(t, q1/3, vtx1, p1, pp1);
-   
- }
+void testParticle::checkXYZLarge() {
+  auto E = std::sqrt(321. * 321. + 163. * 163. + 678 * 678. + 11.21 * 11.21);
+  reco::Particle::LorentzVector p(321., 163., 678., E);
+  reco::Particle::PolarLorentzVector pp(p);
+  reco::Particle t(q, p, vtx);
+  testRel(t, q, vtx, p, pp);
 
-  void testParticle::checkXYZLarge() {
-    auto E = std::sqrt(321.*321. + 163.*163. + 678*678. + 11.21*11.21);
-    reco::Particle::LorentzVector p( 321., 163., 678.,E );
-    reco::Particle::PolarLorentzVector pp(p);
-    reco::Particle t( q, p, vtx );
-    testRel(t, q, vtx, p, pp);
+  auto t2 = stream(t);
+  testRel(t2, q, vtx, p, pp);
 
-    auto t2 = stream(t);
-    testRel(t2, q, vtx, p, pp);
+  reco::Particle::LorentzVector p1(321.1, 163.1, 678.1, E + 0.5);
+  reco::Particle::PolarLorentzVector pp1(p1);
+  t.setP4(p1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setMass(mass);
+  pp1.SetM(mass);
+  p1 = reco::Particle::LorentzVector(pp1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setPz(pz);
+  p1.SetPz(pz);
+  pp1 = reco::Particle::PolarLorentzVector(p1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setVertex(vtx1);
+  testRel(t, q, vtx1, p1, pp1);
+  t.setCharge(q1);
+  testRel(t, q1, vtx1, p1, pp1);
+  t.setThreeCharge(q1);
+  testRel(t, q1 / 3, vtx1, p1, pp1);
+}
 
+void testParticle::checkPolarLarge() {
+  reco::Particle::PolarLorentzVector pp(1234.56, 1.96, 2.45, 11.21);
+  reco::Particle::LorentzVector p(pp);
+  reco::Particle t(q, pp, vtx);
+  testRel(t, q, vtx, p, pp);
 
-    reco::Particle::LorentzVector p1 (321.1, 163.1, 678.1, E+0.5 );
-    reco::Particle::PolarLorentzVector pp1(p1);
-    t.setP4(p1);
-    testRel(t, q, vtx, p1, pp1);
-    t.setMass(mass); pp1.SetM(mass); p1 =  reco::Particle::LorentzVector(pp1);
-    testRel(t, q, vtx, p1, pp1);   
-    t.setPz(pz); p1.SetPz(pz); pp1 = reco::Particle::PolarLorentzVector(p1);
-    testRel(t, q, vtx, p1, pp1);
-    t.setVertex( vtx1 );
-    testRel(t, q, vtx1, p1, pp1);
-    t.setCharge( q1 );
-    testRel(t, q1, vtx1, p1, pp1);
-    t.setThreeCharge( q1 );
-    testRel(t, q1/3, vtx1, p1, pp1);
+  auto t2 = stream(t);
+  testRel(t2, q, vtx, p, pp);
 
+  reco::Particle::PolarLorentzVector pp1(1234.76, 1.86, 2.75, 11.11);
+  reco::Particle::LorentzVector p1(pp1);
+  t.setP4(pp1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setMass(mass);
+  pp1.SetM(mass);
+  p1 = reco::Particle::LorentzVector(pp1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setPz(pz);
+  p1.SetPz(pz);
+  pp1 = reco::Particle::PolarLorentzVector(p1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setVertex(vtx1);
+  testRel(t, q, vtx1, p1, pp1);
+  t.setCharge(q1);
+  testRel(t, q1, vtx1, p1, pp1);
+  t.setThreeCharge(q1);
+  testRel(t, q1 / 3, vtx1, p1, pp1);
+}
 
+void testParticle::checkFloatLarge() {
+  reco::Particle::PolarLorentzVector pp(1234.56, 1.96, 2.45, 11.21);
+  PtEtaPhiMass pepm(1234.56f, 1.96f, 2.45f, 11.21f);
+  reco::Particle::LorentzVector p(pp);
+  reco::Particle t(q, pepm, vtx);
 
+  testRel(t, q, vtx, p, pp);
 
-  }
+  auto t2 = stream(t);
+  testRel(t2, q, vtx, p, pp);
 
-  void testParticle::checkPolarLarge(){
-    reco::Particle::PolarLorentzVector pp( 1234.56, 1.96, 2.45, 11.21 );
-    reco::Particle::LorentzVector p(pp);
-    reco::Particle t( q, pp, vtx );
-    testRel(t, q, vtx, p, pp);
-
-    auto t2 = stream(t);
-    testRel(t2, q, vtx, p, pp);
-
-
-    reco::Particle::PolarLorentzVector pp1( 1234.76, 1.86, 2.75, 11.11 );
-    reco::Particle::LorentzVector p1(pp1);
-    t.setP4(pp1);
-    testRel(t, q, vtx, p1, pp1);
-    t.setMass(mass); pp1.SetM(mass); p1 =  reco::Particle::LorentzVector(pp1);
-    testRel(t, q, vtx, p1, pp1);    
-    t.setPz(pz); p1.SetPz(pz); pp1 = reco::Particle::PolarLorentzVector(p1);
-    testRel(t, q, vtx, p1, pp1);   
-    t.setVertex( vtx1 );
-    testRel(t, q, vtx1, p1, pp1);
-    t.setCharge( q1 );
-    testRel(t, q1, vtx1, p1, pp1);
-    t.setThreeCharge( q1 );
-    testRel(t, q1/3, vtx1, p1, pp1);
- }
-
-  void testParticle::checkFloatLarge(){
-    reco::Particle::PolarLorentzVector pp( 1234.56, 1.96, 2.45, 11.21 );
-    PtEtaPhiMass pepm(1234.56f, 1.96f, 2.45f, 11.21f );
-    reco::Particle::LorentzVector p(pp);
-    reco::Particle t( q, pepm, vtx );
-    
-    testRel(t, q, vtx, p, pp);
-
-    auto t2 = stream(t);
-    testRel(t2, q, vtx, p, pp);
-
-    
-    reco::Particle::PolarLorentzVector pp1( 1.1, 2.2, 3.3, 4.4 );
-    reco::Particle::LorentzVector p1(pp1);
-    t.setP4(pp1);
-    testRel(t, q, vtx, p1, pp1);
-    t.setMass(mass); pp1.SetM(mass); p1 =  reco::Particle::LorentzVector(pp1);
-    testRel(t, q, vtx, p1, pp1);    
-    t.setPz(pz); p1.SetPz(pz); pp1 = reco::Particle::PolarLorentzVector(p1);
-    testRel(t, q, vtx, p1, pp1);   
-    t.setVertex( vtx1 );
-    testRel(t, q, vtx1, p1, pp1);
-    t.setCharge( q1 );
-    testRel(t, q1, vtx1, p1, pp1);
-    t.setThreeCharge( q1 );
-    testRel(t, q1/3, vtx1, p1, pp1);
-    
- }
-
+  reco::Particle::PolarLorentzVector pp1(1.1, 2.2, 3.3, 4.4);
+  reco::Particle::LorentzVector p1(pp1);
+  t.setP4(pp1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setMass(mass);
+  pp1.SetM(mass);
+  p1 = reco::Particle::LorentzVector(pp1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setPz(pz);
+  p1.SetPz(pz);
+  pp1 = reco::Particle::PolarLorentzVector(p1);
+  testRel(t, q, vtx, p1, pp1);
+  t.setVertex(vtx1);
+  testRel(t, q, vtx1, p1, pp1);
+  t.setCharge(q1);
+  testRel(t, q1, vtx1, p1, pp1);
+  t.setThreeCharge(q1);
+  testRel(t, q1 / 3, vtx1, p1, pp1);
+}


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/367//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


