### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/CommonTools/CandAlgos/interface/CandDecaySelector.h
+++ b/CommonTools/CandAlgos/interface/CandDecaySelector.h
@@ -12,43 +12,39 @@ namespace helper {
   class CandDecayStoreManager {
   public:
     typedef reco::CandidateCollection collection;
-    CandDecayStoreManager( const edm::Handle<reco::CandidateCollection> & ) :
-      selCands_( new reco::CandidateCollection ) {
-    }
-    template<typename I>
-    void cloneAndStore( const I & begin, const I & end, edm::Event & evt ) {
+    CandDecayStoreManager(const edm::Handle<reco::CandidateCollection>&) : selCands_(new reco::CandidateCollection) {}
+    template <typename I>
+    void cloneAndStore(const I& begin, const I& end, edm::Event& evt) {
       using namespace reco;
       CandidateRefProd cands = evt.getRefBeforePut<CandidateCollection>();
-      for( I i = begin; i != end; ++ i )
-	add( cands, * * i );
+      for (I i = begin; i != end; ++i)
+        add(cands, **i);
     }
-    edm::OrphanHandle<reco::CandidateCollection> put( edm::Event & evt ) {
-      return evt.put( std::move(selCands_) );
-    }
+    edm::OrphanHandle<reco::CandidateCollection> put(edm::Event& evt) { return evt.put(std::move(selCands_)); }
     size_t size() const { return selCands_->size(); }
-    
+
   private:
-    reco::CandidateRef add( reco::CandidateRefProd cands, const reco::Candidate & c ) {
+    reco::CandidateRef add(reco::CandidateRefProd cands, const reco::Candidate& c) {
       using namespace reco;
       using namespace std;
-      auto cmp = std::make_unique<CompositeRefCandidate>( c );
-      CompositeRefCandidate * p = cmp.get();
-      CandidateRef ref( cands, selCands_->size() );
-      selCands_->push_back( std::move(cmp) );
-      size_t n = c.numberOfDaughters(); 
-      for( size_t i = 0; i < n; ++ i )
-	p->addDaughter( add( cands, * c.daughter( i ) ) );
+      auto cmp = std::make_unique<CompositeRefCandidate>(c);
+      CompositeRefCandidate* p = cmp.get();
+      CandidateRef ref(cands, selCands_->size());
+      selCands_->push_back(std::move(cmp));
+      size_t n = c.numberOfDaughters();
+      for (size_t i = 0; i < n; ++i)
+        p->addDaughter(add(cands, *c.daughter(i)));
       return ref;
     }
     std::unique_ptr<reco::CandidateCollection> selCands_;
   };
-  
-  template<typename EdmFilter>
+
+  template <typename EdmFilter>
   struct StoreManagerTrait<reco::CandidateCollection, EdmFilter> {
     typedef CandDecayStoreManager type;
     typedef ObjectSelectorBase<reco::CandidateCollection, EdmFilter> base;
   };
 
-}
+}  // namespace helper
 
 #endif

--- a/CommonTools/CandAlgos/interface/CandMatcher.h
+++ b/CommonTools/CandAlgos/interface/CandMatcher.h
@@ -11,15 +11,15 @@
 
 namespace reco {
   namespace modules {
-    template<typename S, typename Collection = CandidateCollection, typename D = DeltaR<reco::Candidate> >
-    class CandMatcher : 
-      public Matcher<Collection, Collection, S, D, typename reco::helper::CandMapTrait<Collection>::type> {
-      public:
-        CandMatcher(  const edm::ParameterSet & cfg ) : 
-          Matcher<Collection, Collection, S, D, typename reco::helper::CandMapTrait<Collection>::type>( cfg ) { }
-      ~CandMatcher() override { }
+    template <typename S, typename Collection = CandidateCollection, typename D = DeltaR<reco::Candidate> >
+    class CandMatcher
+        : public Matcher<Collection, Collection, S, D, typename reco::helper::CandMapTrait<Collection>::type> {
+    public:
+      CandMatcher(const edm::ParameterSet& cfg)
+          : Matcher<Collection, Collection, S, D, typename reco::helper::CandMapTrait<Collection>::type>(cfg) {}
+      ~CandMatcher() override {}
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 #endif

--- a/CommonTools/CandAlgos/interface/CompositeCandSelector.h
+++ b/CommonTools/CandAlgos/interface/CompositeCandSelector.h
@@ -8,27 +8,27 @@
 namespace reco {
   namespace modules {
 
-    template<typename Selector, typename T1, typename T2, unsigned int nDau>
-      struct ParameterAdapter<CompositeCandSelector<Selector, T1, T2, nDau> > {
-	static CompositeCandSelector<Selector, T1, T2, nDau> make(const edm::ParameterSet & cfg) {
-	  return CompositeCandSelector<Selector, T1, T2, nDau>(modules::make<Selector>(cfg));
-	}
-      };
+    template <typename Selector, typename T1, typename T2, unsigned int nDau>
+    struct ParameterAdapter<CompositeCandSelector<Selector, T1, T2, nDau> > {
+      static CompositeCandSelector<Selector, T1, T2, nDau> make(const edm::ParameterSet& cfg) {
+        return CompositeCandSelector<Selector, T1, T2, nDau>(modules::make<Selector>(cfg));
+      }
+    };
 
-    template<template<typename, typename> class Combiner, typename T1, typename T2, unsigned int nDau>
-      struct ParameterAdapter<CompositeCandSelector<Combiner<StringCutObjectSelector<T1>,
-                                                             StringCutObjectSelector<T2> >, T1, T2, nDau> > {
-	typedef CompositeCandSelector<Combiner<StringCutObjectSelector<T1>,
-					       StringCutObjectSelector<T2> >, T1, T2, nDau> Selector;
-	  static Selector make(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC) {
-	    StringCutObjectSelector<T1> s1(cfg.getParameter<std::string>("daughter1cut"));
-	    StringCutObjectSelector<T2> s2(cfg.getParameter<std::string>("daughter2cut"));
-	    Combiner<StringCutObjectSelector<T1>, StringCutObjectSelector<T2> > c(s1, s2);
-	    return Selector(c);
-	  }
-      };
+    template <template <typename, typename> class Combiner, typename T1, typename T2, unsigned int nDau>
+    struct ParameterAdapter<
+        CompositeCandSelector<Combiner<StringCutObjectSelector<T1>, StringCutObjectSelector<T2> >, T1, T2, nDau> > {
+      typedef CompositeCandSelector<Combiner<StringCutObjectSelector<T1>, StringCutObjectSelector<T2> >, T1, T2, nDau>
+          Selector;
+      static Selector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        StringCutObjectSelector<T1> s1(cfg.getParameter<std::string>("daughter1cut"));
+        StringCutObjectSelector<T2> s2(cfg.getParameter<std::string>("daughter2cut"));
+        Combiner<StringCutObjectSelector<T1>, StringCutObjectSelector<T2> > c(s1, s2);
+        return Selector(c);
+      }
+    };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/CandAlgos/interface/GenJetParticleSelector.h
+++ b/CommonTools/CandAlgos/interface/GenJetParticleSelector.h
@@ -10,14 +10,22 @@
 #include "SimGeneral/HepPDTRecord/interface/PdtEntry.h"
 #include <set>
 
-namespace edm { class ParameterSet; class EventSetup; class Event; class ConsumesCollector; }
-namespace reco { class Candidate; }
+namespace edm {
+  class ParameterSet;
+  class EventSetup;
+  class Event;
+  class ConsumesCollector;
+}  // namespace edm
+namespace reco {
+  class Candidate;
+}
 
 class GenJetParticleSelector {
 public:
-  GenJetParticleSelector(const edm::ParameterSet&, edm::ConsumesCollector & iC);
+  GenJetParticleSelector(const edm::ParameterSet&, edm::ConsumesCollector& iC);
   bool operator()(const reco::Candidate&);
   void init(const edm::EventSetup&);
+
 private:
   typedef std::vector<PdtEntry> vpdt;
   bool stableOnly_;
@@ -32,18 +40,16 @@ private:
 namespace reco {
   namespace modules {
     struct GenJetParticleSelectorEventSetupInit {
-      static void init(GenJetParticleSelector & selector,
-		       const edm::Event & evt,
-		       const edm::EventSetup& es) {
-	selector.init(es);
+      static void init(GenJetParticleSelector& selector, const edm::Event& evt, const edm::EventSetup& es) {
+        selector.init(es);
       }
     };
 
-    template<>
+    template <>
     struct EventSetupInit<GenJetParticleSelectorEventSetupInit> {
       typedef GenJetParticleSelectorEventSetupInit type;
     };
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
+++ b/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
@@ -9,34 +9,41 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 class GenParticleCustomSelector {
-
 public:
-  GenParticleCustomSelector(){}
-  GenParticleCustomSelector ( double ptMin,double minRapidity,double maxRapidity,
-			double tip,double lip, bool chargedOnly, int status,
-			const std::vector<int>& pdgId = std::vector<int>()) :
-    ptMin_( ptMin ), minRapidity_( minRapidity ), maxRapidity_( maxRapidity ),
-    tip_( tip ), lip_( lip ), chargedOnly_(chargedOnly), status_(status), pdgId_( pdgId ) { }
+  GenParticleCustomSelector() {}
+  GenParticleCustomSelector(double ptMin,
+                            double minRapidity,
+                            double maxRapidity,
+                            double tip,
+                            double lip,
+                            bool chargedOnly,
+                            int status,
+                            const std::vector<int>& pdgId = std::vector<int>())
+      : ptMin_(ptMin),
+        minRapidity_(minRapidity),
+        maxRapidity_(maxRapidity),
+        tip_(tip),
+        lip_(lip),
+        chargedOnly_(chargedOnly),
+        status_(status),
+        pdgId_(pdgId) {}
 
   /// Operator() performs the selection: e.g. if (tPSelector(tp)) {...}
-  bool operator()( const reco::GenParticle & tp ) const {
-
-    if (chargedOnly_ && tp.charge()==0) return false;//select only if charge!=0
+  bool operator()(const reco::GenParticle& tp) const {
+    if (chargedOnly_ && tp.charge() == 0)
+      return false;  //select only if charge!=0
     bool testId = false;
     unsigned int idSize = pdgId_.size();
-    if (idSize==0) testId = true;
-    else for (unsigned int it=0;it!=idSize;++it){
-      if (tp.pdgId()==pdgId_[it]) testId = true;
-    }
+    if (idSize == 0)
+      testId = true;
+    else
+      for (unsigned int it = 0; it != idSize; ++it) {
+        if (tp.pdgId() == pdgId_[it])
+          testId = true;
+      }
 
-    return (
-	    tp.pt() >= ptMin_ &&
-	    tp.eta() >= minRapidity_ && tp.eta() <= maxRapidity_ &&
-	    sqrt(tp.vertex().perp2()) <= tip_ &&
-	    fabs(tp.vertex().z()) <= lip_ &&
-	    tp.status() == status_ &&
-	    testId
-	    );
+    return (tp.pt() >= ptMin_ && tp.eta() >= minRapidity_ && tp.eta() <= maxRapidity_ &&
+            sqrt(tp.vertex().perp2()) <= tip_ && fabs(tp.vertex().z()) <= lip_ && tp.status() == status_ && testId);
   }
 
 private:
@@ -48,7 +55,6 @@ private:
   bool chargedOnly_;
   int status_;
   std::vector<int> pdgId_;
-
 };
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -57,26 +63,25 @@ private:
 namespace reco {
   namespace modules {
 
-    template<>
+    template <>
     struct ParameterAdapter<GenParticleCustomSelector> {
-      static GenParticleCustomSelector make( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) {
+      static GenParticleCustomSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return make(cfg);
       }
 
-      static GenParticleCustomSelector make( const edm::ParameterSet & cfg) {
-	return GenParticleCustomSelector(
- 	  cfg.getParameter<double>( "ptMin" ),
-	  cfg.getParameter<double>( "minRapidity" ),
-	  cfg.getParameter<double>( "maxRapidity" ),
-	  cfg.getParameter<double>( "tip" ),
-	  cfg.getParameter<double>( "lip" ),
-	  cfg.getParameter<bool>( "chargedOnly" ),
-	  cfg.getParameter<int>( "status" ),
-	  cfg.getParameter<std::vector<int> >( "pdgId" ));
+      static GenParticleCustomSelector make(const edm::ParameterSet& cfg) {
+        return GenParticleCustomSelector(cfg.getParameter<double>("ptMin"),
+                                         cfg.getParameter<double>("minRapidity"),
+                                         cfg.getParameter<double>("maxRapidity"),
+                                         cfg.getParameter<double>("tip"),
+                                         cfg.getParameter<double>("lip"),
+                                         cfg.getParameter<bool>("chargedOnly"),
+                                         cfg.getParameter<int>("status"),
+                                         cfg.getParameter<std::vector<int> >("pdgId"));
       }
     };
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/CommonTools/CandAlgos/interface/ModifyObjectValueBase.h
+++ b/CommonTools/CandAlgos/interface/ModifyObjectValueBase.h
@@ -16,66 +16,56 @@
 #include <string>
 
 class ModifyObjectValueBase {
- public:
-  ModifyObjectValueBase(const edm::ParameterSet& conf) :
-  name_( conf.getParameter<std::string>("modifierName") ) {}
+public:
+  ModifyObjectValueBase(const edm::ParameterSet& conf) : name_(conf.getParameter<std::string>("modifierName")) {}
 
   virtual ~ModifyObjectValueBase() {}
 
   virtual void setEvent(const edm::Event&) {}
   virtual void setEventContent(const edm::EventSetup&) {}
-  
-  virtual void modifyObject(reco::GsfElectron&) const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle reco::GsfElectrons!"; 
+
+  virtual void modifyObject(reco::GsfElectron&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle reco::GsfElectrons!";
   }
-  virtual void modifyObject(reco::Photon&)   const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle reco::Photons!"; 
+  virtual void modifyObject(reco::Photon&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle reco::Photons!";
   }
-  virtual void modifyObject(reco::Muon&)     const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle reco::Muons!"; 
+  virtual void modifyObject(reco::Muon&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle reco::Muons!";
   }
-  virtual void modifyObject(reco::BaseTau&)      const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle reco::Taus!"; 
+  virtual void modifyObject(reco::BaseTau&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle reco::Taus!";
   }
-  virtual void modifyObject(reco::Jet&)      const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle reco::Jets!"; 
+  virtual void modifyObject(reco::Jet&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle reco::Jets!";
   }
   // pat modifiers
-  virtual void modifyObject(pat::Electron&) const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle pat::Electrons!"; 
+  virtual void modifyObject(pat::Electron&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle pat::Electrons!";
   }
-  virtual void modifyObject(pat::Photon&)   const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle pat::Photons!"; 
+  virtual void modifyObject(pat::Photon&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle pat::Photons!";
   }
-  virtual void modifyObject(pat::Muon&)     const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle pat::Muons!"; 
+  virtual void modifyObject(pat::Muon&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle pat::Muons!";
   }
-  virtual void modifyObject(pat::Tau&)      const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle pat::Taus!"; 
+  virtual void modifyObject(pat::Tau&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle pat::Taus!";
   }
-  virtual void modifyObject(pat::Jet&)      const { 
-    throw cms::Exception("InvalidConfiguration") 
-      << name_ << " is not configured to handle pat::Jets!"; 
+  virtual void modifyObject(pat::Jet&) const {
+    throw cms::Exception("InvalidConfiguration") << name_ << " is not configured to handle pat::Jets!";
   }
 
   const std::string& name() const { return name_; }
 
- private:
+private:
   const std::string name_;
 };
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< ModifyObjectValueBase* (const edm::ParameterSet&, edm::ConsumesCollector&) > ModifyObjectValueFactory;
+typedef edmplugin::PluginFactory<ModifyObjectValueBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    ModifyObjectValueFactory;
 #endif
 
 #endif

--- a/CommonTools/CandAlgos/interface/NewCandMatcher.h
+++ b/CommonTools/CandAlgos/interface/NewCandMatcher.h
@@ -10,13 +10,13 @@
 
 namespace reco {
   namespace modulesNew {
-    template<typename S, typename C1, typename C2, typename D = DeltaR<reco::Candidate> >
+    template <typename S, typename C1, typename C2, typename D = DeltaR<reco::Candidate> >
     class CandMatcher : public Matcher<C1, C2, S, D> {
     public:
-      CandMatcher(const edm::ParameterSet & cfg ) : Matcher<C1, C2, S, D>( cfg ) { }
-      ~CandMatcher() override { }
+      CandMatcher(const edm::ParameterSet& cfg) : Matcher<C1, C2, S, D>(cfg) {}
+      ~CandMatcher() override {}
     };
 
-  }
-}
+  }  // namespace modulesNew
+}  // namespace reco
 #endif

--- a/CommonTools/CandAlgos/interface/ObjectShallowCloneSelector.h
+++ b/CommonTools/CandAlgos/interface/ObjectShallowCloneSelector.h
@@ -9,13 +9,13 @@
 #include "DataFormats/Candidate/interface/ShallowCloneCandidate.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
-template<typename Selector, 
-	 typename SizeSelector = NonNullNumberSelector,
-         typename PostProcessor = helper::NullPostProcessor<reco::CandidateCollection> >
+template <typename Selector,
+          typename SizeSelector = NonNullNumberSelector,
+          typename PostProcessor = helper::NullPostProcessor<reco::CandidateCollection> >
 class ObjectShallowCloneSelector : public ObjectSelector<Selector, reco::CandidateCollection, SizeSelector> {
 public:
-  explicit ObjectShallowCloneSelector( const edm::ParameterSet & cfg ) :
-    ObjectSelector<Selector, reco::CandidateCollection, SizeSelector, PostProcessor>( cfg ) { }
+  explicit ObjectShallowCloneSelector(const edm::ParameterSet& cfg)
+      : ObjectSelector<Selector, reco::CandidateCollection, SizeSelector, PostProcessor>(cfg) {}
 };
 
 #endif

--- a/CommonTools/CandAlgos/interface/ShallowCloneProducer.h
+++ b/CommonTools/CandAlgos/interface/ShallowCloneProducer.h
@@ -19,39 +19,38 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Candidate/interface/ShallowCloneCandidate.h"
 
-template<typename C>
+template <typename C>
 class ShallowCloneProducer : public edm::EDProducer {
 public:
   /// constructor from parameter set
-  explicit ShallowCloneProducer( const edm::ParameterSet& );
+  explicit ShallowCloneProducer(const edm::ParameterSet&);
   /// destructor
   ~ShallowCloneProducer() override;
 
 private:
   /// process an event
-  void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   /// labels of the collection to be converted
   edm::EDGetTokenT<C> srcToken_;
 };
 
-template<typename C>
-ShallowCloneProducer<C>::ShallowCloneProducer( const edm::ParameterSet& par ) :
-  srcToken_( consumes<C>(par.template getParameter<edm::InputTag>( "src" ) ) ) {
+template <typename C>
+ShallowCloneProducer<C>::ShallowCloneProducer(const edm::ParameterSet& par)
+    : srcToken_(consumes<C>(par.template getParameter<edm::InputTag>("src"))) {
   produces<reco::CandidateCollection>();
 }
 
-template<typename C>
-ShallowCloneProducer<C>::~ShallowCloneProducer() {
-}
+template <typename C>
+ShallowCloneProducer<C>::~ShallowCloneProducer() {}
 
-template<typename C>
-void ShallowCloneProducer<C>::produce( edm::Event& evt, const edm::EventSetup& ) {
-  std::unique_ptr<reco::CandidateCollection> coll( new reco::CandidateCollection );
+template <typename C>
+void ShallowCloneProducer<C>::produce(edm::Event& evt, const edm::EventSetup&) {
+  std::unique_ptr<reco::CandidateCollection> coll(new reco::CandidateCollection);
   edm::Handle<C> masterCollection;
-  evt.getByToken( srcToken_, masterCollection );
-  for( size_t i = 0; i < masterCollection->size(); ++i ) {
-    reco::CandidateBaseRef masterClone( edm::Ref<C>( masterCollection, i ) );
-    coll->push_back( new reco::ShallowCloneCandidate( masterClone ) );
+  evt.getByToken(srcToken_, masterCollection);
+  for (size_t i = 0; i < masterCollection->size(); ++i) {
+    reco::CandidateBaseRef masterClone(edm::Ref<C>(masterCollection, i));
+    coll->push_back(new reco::ShallowCloneCandidate(masterClone));
   }
   evt.put(std::move(coll));
 }

--- a/CommonTools/CandAlgos/interface/SingleObjectShallowCloneSelector.h
+++ b/CommonTools/CandAlgos/interface/SingleObjectShallowCloneSelector.h
@@ -9,22 +9,25 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h"
 
-template<typename InputCollection, typename Selector, 
-	 typename StoreContainer = typename helper::StoreContainerTrait<reco::CandidateCollection>::type,
-	 typename PostProcessor = helper::NullPostProcessor<reco::CandidateCollection>,
-	 typename StoreManager = typename helper::StoreManagerTrait<reco::CandidateCollection>::type,
-	 typename Base = typename helper::StoreManagerTrait<reco::CandidateCollection>::base,
-	 typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
-class SingleObjectShallowCloneSelector : 
-  public ObjectShallowCloneSelector<SingleElementCollectionSelector<InputCollection, Selector, reco::CandidateCollection, 
-                                                                    StoreContainer, RefAdder>, 
-				    NonNullNumberSelector, PostProcessor> {
+template <typename InputCollection,
+          typename Selector,
+          typename StoreContainer = typename helper::StoreContainerTrait<reco::CandidateCollection>::type,
+          typename PostProcessor = helper::NullPostProcessor<reco::CandidateCollection>,
+          typename StoreManager = typename helper::StoreManagerTrait<reco::CandidateCollection>::type,
+          typename Base = typename helper::StoreManagerTrait<reco::CandidateCollection>::base,
+          typename RefAdder = typename helper::SelectionAdderTrait<InputCollection, StoreContainer>::type>
+class SingleObjectShallowCloneSelector
+    : public ObjectShallowCloneSelector<
+          SingleElementCollectionSelector<InputCollection, Selector, reco::CandidateCollection, StoreContainer, RefAdder>,
+          NonNullNumberSelector,
+          PostProcessor> {
 public:
-  explicit SingleObjectShallowCloneSelector( const edm::ParameterSet & cfg ) :
-    ObjectShallowCloneSelector<SingleElementCollectionSelector<InputCollection, Selector, reco::CandidateCollection, 
-							       StoreContainer, RefAdder>, 
-			       NonNullNumberSelector, PostProcessor>( cfg ) { }
-  ~SingleObjectShallowCloneSelector() override { }
+  explicit SingleObjectShallowCloneSelector(const edm::ParameterSet& cfg)
+      : ObjectShallowCloneSelector<
+            SingleElementCollectionSelector<InputCollection, Selector, reco::CandidateCollection, StoreContainer, RefAdder>,
+            NonNullNumberSelector,
+            PostProcessor>(cfg) {}
+  ~SingleObjectShallowCloneSelector() override {}
 };
 
 #endif

--- a/CommonTools/CandAlgos/interface/decayParser.h
+++ b/CommonTools/CandAlgos/interface/decayParser.h
@@ -4,7 +4,7 @@
 //
 // Package:     CandCombiner
 // Class  :     decayParser
-// 
+//
 /**\class decayParser decayParser.h CommonTools/CandCombiner/interface/decayParser.h
 
  Description: <one line class summary>
@@ -14,7 +14,7 @@
 
 */
 //
-// Original Author:  
+// Original Author:
 //         Created:  Sun Aug  7 20:26:36 EDT 2005
 // $Id: decayParser.h,v 1.2 2009/05/08 12:54:34 llista Exp $
 //
@@ -36,18 +36,19 @@ namespace cand {
     struct ConjInfo {
       enum Mode { kPrimary, kBar, kPlus, kMinus } mode_;
       edm::InputTag tag_;
-      ConjInfo( const std::string& tag ) : mode_( kPrimary ), tag_( tag ) { }
-      ConjInfo( const char* begin, const char* end ) : mode_( kPrimary ), tag_( std::string( begin, end ) ) { }
+      ConjInfo(const std::string& tag) : mode_(kPrimary), tag_(tag) {}
+      ConjInfo(const char* begin, const char* end) : mode_(kPrimary), tag_(std::string(begin, end)) {}
     };
-    
-    inline
-    std::ostream& operator<<(std::ostream& out, const ConjInfo& info ) {
-      return out << info.tag_ .encode() << " " 
-		 << ( 0 == info.mode_ ? "p" : ( info.mode_ == ConjInfo::kBar ? "b" : (info.mode_ == ConjInfo::kPlus ? "+" : "-" ) ) );
+
+    inline std::ostream& operator<<(std::ostream& out, const ConjInfo& info) {
+      return out << info.tag_.encode() << " "
+                 << (0 == info.mode_
+                         ? "p"
+                         : (info.mode_ == ConjInfo::kBar ? "b" : (info.mode_ == ConjInfo::kPlus ? "+" : "-")));
     }
-    
-    bool decayParser( const std::string& iValue, std::vector<ConjInfo>& oStrings );
-  }
-}
+
+    bool decayParser(const std::string& iValue, std::vector<ConjInfo>& oStrings);
+  }  // namespace parser
+}  // namespace cand
 
 #endif /* CANDCOMBINER_DECAYPARSER_H */

--- a/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandRefSelector.cc
+++ b/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandRefSelector.cc
@@ -24,13 +24,9 @@
 
 typedef double isolation;
 
-typedef SingleObjectSelector<
-          edm::AssociationVector<reco::CandidateRefProd, std::vector<isolation> >,
-          PairSelector<
-            RefSelector<AnySelector>,
-            MaxSelector<isolation>
-          >,
-          reco::CandidateRefVector
-        > AssociatedVariableMaxCutCandRefSelector;
+typedef SingleObjectSelector<edm::AssociationVector<reco::CandidateRefProd, std::vector<isolation> >,
+                             PairSelector<RefSelector<AnySelector>, MaxSelector<isolation> >,
+                             reco::CandidateRefVector>
+    AssociatedVariableMaxCutCandRefSelector;
 
-DEFINE_FWK_MODULE( AssociatedVariableMaxCutCandRefSelector );
+DEFINE_FWK_MODULE(AssociatedVariableMaxCutCandRefSelector);

--- a/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandSelector.cc
@@ -23,12 +23,8 @@
 
 typedef double isolation;
 
-typedef SingleObjectSelector<
-          edm::AssociationVector<reco::CandidateRefProd, std::vector<isolation> >,
-          PairSelector<
-            RefSelector<AnySelector>,
-            MaxSelector<isolation>
-          >
-        > AssociatedVariableMaxCutCandSelector;
+typedef SingleObjectSelector<edm::AssociationVector<reco::CandidateRefProd, std::vector<isolation> >,
+                             PairSelector<RefSelector<AnySelector>, MaxSelector<isolation> > >
+    AssociatedVariableMaxCutCandSelector;
 
-DEFINE_FWK_MODULE( AssociatedVariableMaxCutCandSelector );
+DEFINE_FWK_MODULE(AssociatedVariableMaxCutCandSelector);

--- a/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandSelectorNew.cc
+++ b/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandSelectorNew.cc
@@ -25,15 +25,9 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
+typedef ObjectSelector<AssociatedVariableCollectionSelector<reco::CandidateView,
+                                                            edm::ValueMap<float>,
+                                                            AndSelector<AnySelector, MaxSelector<float> > > >
+    AssociatedVariableMaxCutCandSelectorNew;
 
-typedef ObjectSelector<
-          AssociatedVariableCollectionSelector<
-            reco::CandidateView, edm::ValueMap<float>,
-            AndSelector<
-              AnySelector,
-              MaxSelector<float>
-            >
-          >
-        > AssociatedVariableMaxCutCandSelectorNew;
-
-DEFINE_FWK_MODULE( AssociatedVariableMaxCutCandSelectorNew );
+DEFINE_FWK_MODULE(AssociatedVariableMaxCutCandSelectorNew);

--- a/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/AssociatedVariableMaxCutCandViewSelector.cc
@@ -24,12 +24,8 @@
 #include "DataFormats/Candidate/interface/CandAssociation.h"
 typedef double isolation;
 
-typedef SingleObjectSelector<
-          reco::CandViewDoubleAssociations,
-          PairSelector<
-            RefSelector<AnySelector>,
-            MaxSelector<isolation>
-          >
-        > AssociatedVariableMaxCutCandViewSelector;
+typedef SingleObjectSelector<reco::CandViewDoubleAssociations,
+                             PairSelector<RefSelector<AnySelector>, MaxSelector<isolation> > >
+    AssociatedVariableMaxCutCandViewSelector;
 
-DEFINE_FWK_MODULE( AssociatedVariableMaxCutCandViewSelector );
+DEFINE_FWK_MODULE(AssociatedVariableMaxCutCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/CandCandAssociationMapOneToOne2Association.cc
+++ b/CommonTools/CandAlgos/plugins/CandCandAssociationMapOneToOne2Association.cc
@@ -9,9 +9,7 @@
 #include "CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef AssociationMapOneToOne2Association<
-          reco::CandidateCollection,
-          reco::CandidateCollection
-        > CandCandAssociationMapOneToOne2Association;
+typedef AssociationMapOneToOne2Association<reco::CandidateCollection, reco::CandidateCollection>
+    CandCandAssociationMapOneToOne2Association;
 
 DEFINE_FWK_MODULE(CandCandAssociationMapOneToOne2Association);

--- a/CommonTools/CandAlgos/plugins/CandCollectionExistFilter.cc
+++ b/CommonTools/CandAlgos/plugins/CandCollectionExistFilter.cc
@@ -9,14 +9,16 @@ using namespace reco;
 
 class CandCollectionExistFilter : public EDFilter {
 public:
-  CandCollectionExistFilter(const ParameterSet & cfg) :
-    srcToken_(consumes<CandidateView>(cfg.getParameter<InputTag>("src"))) { }
+  CandCollectionExistFilter(const ParameterSet& cfg)
+      : srcToken_(consumes<CandidateView>(cfg.getParameter<InputTag>("src"))) {}
+
 private:
   bool filter(Event& evt, const EventSetup&) override {
     Handle<CandidateView> src;
     bool exists = true;
     evt.getByToken(srcToken_, src);
-    if(!src.isValid()) exists = false;
+    if (!src.isValid())
+      exists = false;
     return exists;
   }
   EDGetTokenT<CandidateView> srcToken_;
@@ -25,4 +27,3 @@ private:
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(CandCollectionExistFilter);
-

--- a/CommonTools/CandAlgos/plugins/CandCountFilter.cc
+++ b/CommonTools/CandAlgos/plugins/CandCountFilter.cc
@@ -12,4 +12,4 @@
 
 typedef ObjectCountFilter<reco::CandidateCollection>::type CandCountFilter;
 
-DEFINE_FWK_MODULE( CandCountFilter );
+DEFINE_FWK_MODULE(CandCountFilter);

--- a/CommonTools/CandAlgos/plugins/CandDoubleAssociationVector2ValueMap.cc
+++ b/CommonTools/CandAlgos/plugins/CandDoubleAssociationVector2ValueMap.cc
@@ -9,9 +9,6 @@
 #include "CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef AssociationVector2ValueMap<
-          reco::CandidateRefProd,
-          std::vector<double>
-        > CandDoubleAssociationVector2ValueMap;
+typedef AssociationVector2ValueMap<reco::CandidateRefProd, std::vector<double> > CandDoubleAssociationVector2ValueMap;
 
 DEFINE_FWK_MODULE(CandDoubleAssociationVector2ValueMap);

--- a/CommonTools/CandAlgos/plugins/CandDoubleAssociationVectorSelector.cc
+++ b/CommonTools/CandAlgos/plugins/CandDoubleAssociationVectorSelector.cc
@@ -11,11 +11,10 @@
 #include "CommonTools/UtilAlgos/interface/MaxSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef AssociationVectorSelector<
-          reco::CandidateRefProd,
-          std::vector<double>,
-          StringCutObjectSelector<reco::Candidate>,
-          MaxSelector<double>
-        > CandDoubleAssociationVectorSelector;
+typedef AssociationVectorSelector<reco::CandidateRefProd,
+                                  std::vector<double>,
+                                  StringCutObjectSelector<reco::Candidate>,
+                                  MaxSelector<double> >
+    CandDoubleAssociationVectorSelector;
 
 DEFINE_FWK_MODULE(CandDoubleAssociationVectorSelector);

--- a/CommonTools/CandAlgos/plugins/CandHistoAnalyzer.cc
+++ b/CommonTools/CandAlgos/plugins/CandHistoAnalyzer.cc
@@ -11,5 +11,4 @@
 
 typedef HistoAnalyzer<reco::CandidateCollection> CandHistoAnalyzer;
 
-DEFINE_FWK_MODULE( CandHistoAnalyzer );
-
+DEFINE_FWK_MODULE(CandHistoAnalyzer);

--- a/CommonTools/CandAlgos/plugins/CandMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandMerger.cc
@@ -11,4 +11,4 @@
 
 typedef Merger<reco::CandidateCollection> CandMerger;
 
-DEFINE_FWK_MODULE( CandMerger );
+DEFINE_FWK_MODULE(CandMerger);

--- a/CommonTools/CandAlgos/plugins/CandMergerCleanOthersByDR.cc
+++ b/CommonTools/CandAlgos/plugins/CandMergerCleanOthersByDR.cc
@@ -31,7 +31,7 @@
 class CandMergerCleanOthersByDR : public edm::global::EDProducer<> {
 public:
   explicit CandMergerCleanOthersByDR(const edm::ParameterSet&);
-  ~CandMergerCleanOthersByDR(){}
+  ~CandMergerCleanOthersByDR() override{}
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   

--- a/CommonTools/CandAlgos/plugins/CandMergerCleanOthersByDR.cc
+++ b/CommonTools/CandAlgos/plugins/CandMergerCleanOthersByDR.cc
@@ -2,17 +2,16 @@
 //
 // A simple class to combine two candidate collections into a single
 // collection of ptrs to the candidates
-// note: it is a std::vector as the candidates are from different 
+// note: it is a std::vector as the candidates are from different
 // collections
 //
 // collection 1 is added fully while collection 2 is deltaR cross
 // cleaned against collection 2
 //
-// usecase: getting a unified list of e/gammas + jets for jet core 
+// usecase: getting a unified list of e/gammas + jets for jet core
 //          regional tracking
 //
 //****************************************************************
-
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -31,84 +30,79 @@
 class CandMergerCleanOthersByDR : public edm::global::EDProducer<> {
 public:
   explicit CandMergerCleanOthersByDR(const edm::ParameterSet&);
-  ~CandMergerCleanOthersByDR() override{}
-  
+  ~CandMergerCleanOthersByDR() override {}
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&)const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-private:  
-  const edm::EDGetTokenT<edm::View<reco::Candidate> > coll1Token_;
-  const edm::EDGetTokenT<edm::View<reco::Candidate> > coll2Token_;
+private:
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> coll1Token_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> coll2Token_;
   const float maxDR2ToClean_;
-
 };
 
-
 namespace {
-  double pow2(double val){return val*val;}
-}
+  double pow2(double val) { return val * val; }
+}  // namespace
 
-CandMergerCleanOthersByDR::CandMergerCleanOthersByDR(const edm::ParameterSet& iConfig) :
-  coll1Token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("coll1"))),
-  coll2Token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("coll2"))),
-  maxDR2ToClean_(pow2(iConfig.getParameter<double>("maxDRToClean")))
-{
-  produces<std::vector<edm::Ptr<reco::Candidate> > >();
+CandMergerCleanOthersByDR::CandMergerCleanOthersByDR(const edm::ParameterSet& iConfig)
+    : coll1Token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("coll1"))),
+      coll2Token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("coll2"))),
+      maxDR2ToClean_(pow2(iConfig.getParameter<double>("maxDRToClean"))) {
+  produces<std::vector<edm::Ptr<reco::Candidate>>>();
 }
 
 namespace {
-  template<typename T> edm::Handle<T> getHandle(const edm::Event& iEvent,
-						const edm::EDGetTokenT<T>& token)
-  {
+  template <typename T>
+  edm::Handle<T> getHandle(const edm::Event& iEvent, const edm::EDGetTokenT<T>& token) {
     edm::Handle<T> handle;
-    iEvent.getByToken(token,handle);
+    iEvent.getByToken(token, handle);
     return handle;
   }
-  
-  bool hasDRMatch(const reco::Candidate& cand,const std::vector<std::pair<float,float> >& etaPhisToMatch,const float maxDR2)
-  {
+
+  bool hasDRMatch(const reco::Candidate& cand,
+                  const std::vector<std::pair<float, float>>& etaPhisToMatch,
+                  const float maxDR2) {
     const float candEta = cand.eta();
     const float candPhi = cand.phi();
-    for(const auto& etaPhi : etaPhisToMatch){
-      if(reco::deltaR2(candEta,candPhi,etaPhi.first,etaPhi.second)<=maxDR2){
-	return true;
+    for (const auto& etaPhi : etaPhisToMatch) {
+      if (reco::deltaR2(candEta, candPhi, etaPhi.first, etaPhi.second) <= maxDR2) {
+        return true;
       }
     }
     return false;
   }
-}
+}  // namespace
 
 // ------------ method called to produce the data  ------------
-void
-CandMergerCleanOthersByDR::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup)const
-{
-  auto outColl = std::make_unique<std::vector<edm::Ptr<reco::Candidate> > >();
-  
-  auto coll1Handle = getHandle(iEvent,coll1Token_); 
-  auto coll2Handle = getHandle(iEvent,coll2Token_); 
-  
-  std::vector<std::pair<float,float> > coll1EtaPhis;
-  for(size_t objNr=0;objNr<coll1Handle->size();objNr++){
-    edm::Ptr<reco::Candidate> objPtr(coll1Handle,objNr);
-    coll1EtaPhis.push_back({objPtr->eta(),objPtr->phi()}); //just to speed up the DR match
+void CandMergerCleanOthersByDR::produce(edm::StreamID streamID,
+                                        edm::Event& iEvent,
+                                        const edm::EventSetup& iSetup) const {
+  auto outColl = std::make_unique<std::vector<edm::Ptr<reco::Candidate>>>();
+
+  auto coll1Handle = getHandle(iEvent, coll1Token_);
+  auto coll2Handle = getHandle(iEvent, coll2Token_);
+
+  std::vector<std::pair<float, float>> coll1EtaPhis;
+  for (size_t objNr = 0; objNr < coll1Handle->size(); objNr++) {
+    edm::Ptr<reco::Candidate> objPtr(coll1Handle, objNr);
+    coll1EtaPhis.push_back({objPtr->eta(), objPtr->phi()});  //just to speed up the DR match
     outColl->push_back(objPtr);
   }
-  for(size_t objNr=0;objNr<coll2Handle->size();objNr++){
-    edm::Ptr<reco::Candidate> objPtr(coll2Handle,objNr);
-    if(!hasDRMatch(*objPtr,coll1EtaPhis,maxDR2ToClean_)){
+  for (size_t objNr = 0; objNr < coll2Handle->size(); objNr++) {
+    edm::Ptr<reco::Candidate> objPtr(coll2Handle, objNr);
+    if (!hasDRMatch(*objPtr, coll1EtaPhis, maxDR2ToClean_)) {
       outColl->push_back(objPtr);
     }
   }
-    
+
   iEvent.put(std::move(outColl));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-CandMergerCleanOthersByDR::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  
+void CandMergerCleanOthersByDR::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("coll1", edm::InputTag("egammasForCoreTracking"));
   desc.add<edm::InputTag>("coll2", edm::InputTag("jetsForCoreTracking"));

--- a/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrProjector.cc
@@ -8,10 +8,8 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
-
 class CandPtrProjector : public edm::global::EDProducer<> {
 public:
-
   explicit CandPtrProjector(edm::ParameterSet const& iConfig);
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
@@ -20,16 +18,13 @@ private:
   edm::EDGetTokenT<edm::View<reco::Candidate>> vetoSrcToken_;
 };
 
-CandPtrProjector::CandPtrProjector(edm::ParameterSet const& iConfig):
-  candSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))},
-  vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))}
-{
+CandPtrProjector::CandPtrProjector(edm::ParameterSet const& iConfig)
+    : candSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))},
+      vetoSrcToken_{consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("veto"))} {
   produces<edm::PtrVector<reco::Candidate>>();
 }
 
-void
-CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const
-{
+void CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
   using namespace edm;
   Handle<View<reco::Candidate>> vetoes;
   iEvent.getByToken(vetoSrcToken_, vetoes);
@@ -38,16 +33,16 @@ CandPtrProjector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup con
   std::set<reco::CandidatePtr> vetoedPtrs;
   for (auto const& veto : *vetoes) {
     auto const n = veto.numberOfSourceCandidatePtrs();
-    for (size_t j {}; j<n; ++j) {
+    for (size_t j{}; j < n; ++j) {
       vetoedPtrs.insert(veto.sourceCandidatePtr(j));
     }
   }
 
   Handle<View<reco::Candidate>> cands;
   iEvent.getByToken(candSrcToken_, cands);
-  for (size_t i {}; i<cands->size(); ++i) {
+  for (size_t i{}; i < cands->size(); ++i) {
     auto const c = cands->ptrAt(i);
-    if (vetoedPtrs.find(c)==vetoedPtrs.cend()) {
+    if (vetoedPtrs.find(c) == vetoedPtrs.cend()) {
       result->push_back(c);
     }
   }

--- a/CommonTools/CandAlgos/plugins/CandPtrSelector.cc
+++ b/CommonTools/CandAlgos/plugins/CandPtrSelector.cc
@@ -12,10 +12,9 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::Candidate>,
-          StringCutObjectSelector<reco::Candidate, true>,
-          edm::PtrVector<reco::Candidate>
-       > CandPtrSelector;
+typedef SingleObjectSelector<edm::View<reco::Candidate>,
+                             StringCutObjectSelector<reco::Candidate, true>,
+                             edm::PtrVector<reco::Candidate> >
+    CandPtrSelector;
 
 DEFINE_FWK_MODULE(CandPtrSelector);

--- a/CommonTools/CandAlgos/plugins/CandReducer.cc
+++ b/CommonTools/CandAlgos/plugins/CandReducer.cc
@@ -23,12 +23,13 @@
 class CandReducer : public edm::EDProducer {
 public:
   /// constructor from parameter set
-  explicit CandReducer( const edm::ParameterSet& );
+  explicit CandReducer(const edm::ParameterSet&);
   /// destructor
   ~CandReducer() override;
+
 private:
   /// process one evevnt
-  void produce( edm::Event& evt, const edm::EventSetup& ) override;
+  void produce(edm::Event& evt, const edm::EventSetup&) override;
   /// label of source candidate collection
   edm::EDGetTokenT<reco::CandidateView> srcToken_;
 };
@@ -41,25 +42,24 @@ private:
 using namespace reco;
 using namespace edm;
 
-CandReducer::CandReducer( const edm::ParameterSet& cfg ) :
-  srcToken_( consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("src") ) ) {
+CandReducer::CandReducer(const edm::ParameterSet& cfg)
+    : srcToken_(consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("src"))) {
   produces<CandidateCollection>();
 }
 
-CandReducer::~CandReducer() {
-}
+CandReducer::~CandReducer() {}
 
-void CandReducer::produce( Event& evt, const EventSetup& ) {
+void CandReducer::produce(Event& evt, const EventSetup&) {
   Handle<reco::CandidateView> cands;
-  evt.getByToken( srcToken_, cands );
-  std::unique_ptr<CandidateCollection> comp( new CandidateCollection );
-  for( reco::CandidateView::const_iterator c = cands->begin(); c != cands->end(); ++c ) {
-    std::unique_ptr<Candidate> cand( new LeafCandidate( * c ) );
-    comp->push_back( cand.release() );
+  evt.getByToken(srcToken_, cands);
+  std::unique_ptr<CandidateCollection> comp(new CandidateCollection);
+  for (reco::CandidateView::const_iterator c = cands->begin(); c != cands->end(); ++c) {
+    std::unique_ptr<Candidate> cand(new LeafCandidate(*c));
+    comp->push_back(cand.release());
   }
   evt.put(std::move(comp));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( CandReducer );
+DEFINE_FWK_MODULE(CandReducer);

--- a/CommonTools/CandAlgos/plugins/CandRefMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandRefMerger.cc
@@ -11,4 +11,4 @@
 
 typedef Merger<reco::CandidateBaseRefVector> CandRefMerger;
 
-DEFINE_FWK_MODULE( CandRefMerger );
+DEFINE_FWK_MODULE(CandRefMerger);

--- a/CommonTools/CandAlgos/plugins/CandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/CandSelector.cc
@@ -12,12 +12,9 @@
 
 namespace reco {
   namespace modules {
-    typedef SingleObjectSelector<
-              reco::CandidateCollection,
-              StringCutObjectSelector<reco::Candidate>
-            > CandSelector;
+    typedef SingleObjectSelector<reco::CandidateCollection, StringCutObjectSelector<reco::Candidate> > CandSelector;
 
-DEFINE_FWK_MODULE( CandSelector );
+    DEFINE_FWK_MODULE(CandSelector);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/CandViewCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewCombiner.cc
@@ -10,8 +10,6 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "CommonTools/CandAlgos/interface/CandCombiner.h"
 
-typedef reco::modules::CandCombiner<
-                         StringCutObjectSelector<reco::Candidate, true>
-                       > CandViewCombiner;
-      
-DEFINE_FWK_MODULE( CandViewCombiner );
+typedef reco::modules::CandCombiner<StringCutObjectSelector<reco::Candidate, true> > CandViewCombiner;
+
+DEFINE_FWK_MODULE(CandViewCombiner);

--- a/CommonTools/CandAlgos/plugins/CandViewCountFilter.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewCountFilter.cc
@@ -13,4 +13,4 @@
 
 typedef ObjectCountFilter<reco::CandidateView>::type CandViewCountFilter;
 
-DEFINE_FWK_MODULE( CandViewCountFilter );
+DEFINE_FWK_MODULE(CandViewCountFilter);

--- a/CommonTools/CandAlgos/plugins/CandViewHistoAnalyzer.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewHistoAnalyzer.cc
@@ -11,5 +11,4 @@
 
 typedef HistoAnalyzer<reco::CandidateView> CandViewHistoAnalyzer;
 
-DEFINE_FWK_MODULE( CandViewHistoAnalyzer );
-
+DEFINE_FWK_MODULE(CandViewHistoAnalyzer);

--- a/CommonTools/CandAlgos/plugins/CandViewMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewMerger.cc
@@ -11,4 +11,4 @@
 
 typedef Merger<reco::CandidateView, reco::CandidateCollection> CandViewMerger;
 
-DEFINE_FWK_MODULE( CandViewMerger );
+DEFINE_FWK_MODULE(CandViewMerger);

--- a/CommonTools/CandAlgos/plugins/CandViewNtpProducer.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewNtpProducer.cc
@@ -11,5 +11,4 @@
 
 typedef NtpProducer<reco::CandidateView> CandViewNtpProducer;
 
-DEFINE_FWK_MODULE( CandViewNtpProducer );
-
+DEFINE_FWK_MODULE(CandViewNtpProducer);

--- a/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
@@ -16,18 +16,23 @@
 
 class CandViewRefMerger : public edm::EDProducer {
 public:
-  explicit CandViewRefMerger(const edm::ParameterSet& cfg) :
-    srcTokens_(edm::vector_transform(cfg.getParameter<std::vector<edm::InputTag> >("src"), [this](edm::InputTag const & tag){return consumes<reco::CandidateView>(tag);})) {
+  explicit CandViewRefMerger(const edm::ParameterSet& cfg)
+      : srcTokens_(
+            edm::vector_transform(cfg.getParameter<std::vector<edm::InputTag> >("src"),
+                                  [this](edm::InputTag const& tag) { return consumes<reco::CandidateView>(tag); })) {
     produces<std::vector<reco::CandidateBaseRef> >();
   }
+
 private:
-  void produce(edm::Event & evt, const edm::EventSetup &) override {
+  void produce(edm::Event& evt, const edm::EventSetup&) override {
     std::unique_ptr<std::vector<reco::CandidateBaseRef> > out(new std::vector<reco::CandidateBaseRef>);
-    for(std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator i = srcTokens_.begin(); i != srcTokens_.end(); ++i) {
+    for (std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator i = srcTokens_.begin();
+         i != srcTokens_.end();
+         ++i) {
       edm::Handle<reco::CandidateView> src;
       evt.getByToken(*i, src);
-      for(size_t j = 0; j < src->size(); ++j)
-	out->push_back(src->refAt(j));
+      for (size_t j = 0; j < src->size(); ++j)
+        out->push_back(src->refAt(j));
     }
     evt.put(std::move(out));
   }

--- a/CommonTools/CandAlgos/plugins/CandViewRefSelector.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewRefSelector.cc
@@ -18,9 +18,6 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::Candidate>,
-          StringCutObjectSelector<reco::Candidate>
-       > CandViewRefSelector;
+typedef SingleObjectSelector<edm::View<reco::Candidate>, StringCutObjectSelector<reco::Candidate> > CandViewRefSelector;
 
 DEFINE_FWK_MODULE(CandViewRefSelector);

--- a/CommonTools/CandAlgos/plugins/CandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewSelector.cc
@@ -18,10 +18,9 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::Candidate>,
-  StringCutObjectSelector<reco::Candidate, true>,
-          reco::CandidateCollection
-       > CandViewSelector;
+typedef SingleObjectSelector<edm::View<reco::Candidate>,
+                             StringCutObjectSelector<reco::Candidate, true>,
+                             reco::CandidateCollection>
+    CandViewSelector;
 
 DEFINE_FWK_MODULE(CandViewSelector);

--- a/CommonTools/CandAlgos/plugins/CandViewShallowCloneCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewShallowCloneCombiner.cc
@@ -9,13 +9,10 @@
 
 namespace reco {
   namespace modules {
-    typedef CandCombiner<
-              StringCutObjectSelector<reco::Candidate, true>,
-              AnyPairSelector,
-              combiner::helpers::ShallowClone
-            > CandViewShallowCloneCombiner;
+    typedef CandCombiner<StringCutObjectSelector<reco::Candidate, true>, AnyPairSelector, combiner::helpers::ShallowClone>
+        CandViewShallowCloneCombiner;
 
-DEFINE_FWK_MODULE( CandViewShallowCloneCombiner );
+    DEFINE_FWK_MODULE(CandViewShallowCloneCombiner);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/CandViewShallowCloneProducer.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewShallowCloneProducer.cc
@@ -12,8 +12,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 
-typedef SingleObjectShallowCloneSelector<edm::View<reco::Candidate>, StringCutObjectSelector<reco::Candidate> > CandViewShallowCloneProducer;
+typedef SingleObjectShallowCloneSelector<edm::View<reco::Candidate>, StringCutObjectSelector<reco::Candidate> >
+    CandViewShallowCloneProducer;
 
 DEFINE_FWK_MODULE(CandViewShallowCloneProducer);
-
-

--- a/CommonTools/CandAlgos/plugins/CandViewShallowClonePtrCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewShallowClonePtrCombiner.cc
@@ -9,13 +9,12 @@
 
 namespace reco {
   namespace modules {
-    typedef CandCombiner<
-              StringCutObjectSelector<reco::Candidate, true>,
-              AnyPairSelector,
-              combiner::helpers::ShallowClonePtr
-            > CandViewShallowClonePtrCombiner;
+    typedef CandCombiner<StringCutObjectSelector<reco::Candidate, true>,
+                         AnyPairSelector,
+                         combiner::helpers::ShallowClonePtr>
+        CandViewShallowClonePtrCombiner;
 
-DEFINE_FWK_MODULE( CandViewShallowClonePtrCombiner );
+    DEFINE_FWK_MODULE(CandViewShallowClonePtrCombiner);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/CompositeCandAndSelector.cc
+++ b/CommonTools/CandAlgos/plugins/CompositeCandAndSelector.cc
@@ -5,14 +5,9 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateView,
-          CompositeCandSelector<
-            AndPairSelector<
-              StringCutObjectSelector<reco::Candidate>,
-              StringCutObjectSelector<reco::Candidate> 
-            >
-          >
-        > CompositeCandAndSelector;
+typedef SingleObjectSelector<reco::CandidateView,
+                             CompositeCandSelector<AndPairSelector<StringCutObjectSelector<reco::Candidate>,
+                                                                   StringCutObjectSelector<reco::Candidate> > > >
+    CompositeCandAndSelector;
 
 DEFINE_FWK_MODULE(CompositeCandAndSelector);

--- a/CommonTools/CandAlgos/plugins/DeltaPhiMinCandCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/DeltaPhiMinCandCombiner.cc
@@ -10,9 +10,7 @@
 #include "CommonTools/UtilAlgos/interface/DeltaPhiMinPairSelector.h"
 #include "CommonTools/CandAlgos/interface/CandCombiner.h"
 
-typedef reco::modules::CandCombiner<
-          StringCutObjectSelector<reco::Candidate, true>,
-          DeltaPhiMinPairSelector
-        > DeltaPhiMinCandCombiner;
+typedef reco::modules::CandCombiner<StringCutObjectSelector<reco::Candidate, true>, DeltaPhiMinPairSelector>
+    DeltaPhiMinCandCombiner;
 
 DEFINE_FWK_MODULE(DeltaPhiMinCandCombiner);

--- a/CommonTools/CandAlgos/plugins/DeltaRMinCandCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/DeltaRMinCandCombiner.cc
@@ -10,9 +10,7 @@
 #include "CommonTools/UtilAlgos/interface/DeltaRMinPairSelector.h"
 #include "CommonTools/CandAlgos/interface/CandCombiner.h"
 
-typedef reco::modules::CandCombiner<
-          StringCutObjectSelector<reco::Candidate, true>,
-          DeltaRMinPairSelector
-        > DeltaRMinCandCombiner;
+typedef reco::modules::CandCombiner<StringCutObjectSelector<reco::Candidate, true>, DeltaRMinPairSelector>
+    DeltaRMinCandCombiner;
 
 DEFINE_FWK_MODULE(DeltaRMinCandCombiner);

--- a/CommonTools/CandAlgos/plugins/DummyCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/DummyCandSelector.cc
@@ -15,15 +15,10 @@
 #include "CommonTools/UtilAlgos/interface/FreeFunctionSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateView,
-          DummySelector
-        > DummyCandSelector;
+typedef SingleObjectSelector<reco::CandidateView, DummySelector> DummyCandSelector;
 
-typedef SingleObjectSelector<
-          reco::CandidateView,
-          FreeFunctionSelector<reco::Candidate, dummy::select>
-        > DummyFunCandSelector;
+typedef SingleObjectSelector<reco::CandidateView, FreeFunctionSelector<reco::Candidate, dummy::select> >
+    DummyFunCandSelector;
 
-DEFINE_FWK_MODULE( DummyCandSelector );
-DEFINE_FWK_MODULE( DummyFunCandSelector );
+DEFINE_FWK_MODULE(DummyCandSelector);
+DEFINE_FWK_MODULE(DummyFunCandSelector);

--- a/CommonTools/CandAlgos/plugins/EtaPtMinCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/EtaPtMinCandSelector.cc
@@ -21,12 +21,7 @@
 #include "CommonTools/UtilAlgos/interface/AndSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          AndSelector<
-            PtMinSelector,
-            EtaRangeSelector
-          >
-        > EtaPtMinCandSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, AndSelector<PtMinSelector, EtaRangeSelector> >
+    EtaPtMinCandSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinCandSelector );
+DEFINE_FWK_MODULE(EtaPtMinCandSelector);

--- a/CommonTools/CandAlgos/plugins/EtaPtMinCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/EtaPtMinCandViewSelector.cc
@@ -22,13 +22,9 @@
 #include "CommonTools/UtilAlgos/interface/AndSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::Candidate>,
-          AndSelector<
-            PtMinSelector,
-            EtaRangeSelector
-          >,
-          reco::CandidateCollection
-        > EtaPtMinCandViewSelector;
+typedef SingleObjectSelector<edm::View<reco::Candidate>,
+                             AndSelector<PtMinSelector, EtaRangeSelector>,
+                             reco::CandidateCollection>
+    EtaPtMinCandViewSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinCandViewSelector );
+DEFINE_FWK_MODULE(EtaPtMinCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/EtaPtMinPdgIdCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/EtaPtMinPdgIdCandSelector.cc
@@ -22,13 +22,7 @@
 #include "CommonTools/UtilAlgos/interface/AndSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          AndSelector<
-            PtMinSelector,
-            EtaRangeSelector,
-            PdgIdSelector
-          >
-        > EtaPtMinPdgIdCandSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, AndSelector<PtMinSelector, EtaRangeSelector, PdgIdSelector> >
+    EtaPtMinPdgIdCandSelector;
 
-DEFINE_FWK_MODULE( EtaPtMinPdgIdCandSelector );
+DEFINE_FWK_MODULE(EtaPtMinPdgIdCandSelector);

--- a/CommonTools/CandAlgos/plugins/GenJetParticleRefSelector.cc
+++ b/CommonTools/CandAlgos/plugins/GenJetParticleRefSelector.cc
@@ -5,13 +5,10 @@
 namespace reco {
   namespace modules {
 
-    typedef SingleObjectSelector<
-              reco::GenParticleCollection,
-              ::GenJetParticleSelector,
-              reco::GenParticleRefVector
-            > GenJetParticleRefSelector;
+    typedef SingleObjectSelector<reco::GenParticleCollection, ::GenJetParticleSelector, reco::GenParticleRefVector>
+        GenJetParticleRefSelector;
 
-   DEFINE_FWK_MODULE(GenJetParticleRefSelector);
+    DEFINE_FWK_MODULE(GenJetParticleRefSelector);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/GenParticleCustomSelector.cc
+++ b/CommonTools/CandAlgos/plugins/GenParticleCustomSelector.cc
@@ -12,9 +12,8 @@
 
 namespace reco {
   namespace modules {
-    typedef SingleObjectSelector<GenParticleCollection,::GenParticleCustomSelector> 
-    GenParticleCustomSelector ;
+    typedef SingleObjectSelector<GenParticleCollection, ::GenParticleCustomSelector> GenParticleCustomSelector;
 
-    DEFINE_FWK_MODULE( GenParticleCustomSelector );
-  }
-}
+    DEFINE_FWK_MODULE(GenParticleCustomSelector);
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/LargestPtCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/LargestPtCandSelector.cc
@@ -19,11 +19,7 @@
 #include "CommonTools/Utils/interface/PtComparator.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef ObjectSelector<
-          SortCollectionSelector<
-            reco::CandidateCollection,
-            GreaterByPt<reco::Candidate>
-          >
-        > LargestPtCandSelector;
+typedef ObjectSelector<SortCollectionSelector<reco::CandidateCollection, GreaterByPt<reco::Candidate> > >
+    LargestPtCandSelector;
 
-DEFINE_FWK_MODULE( LargestPtCandSelector );
+DEFINE_FWK_MODULE(LargestPtCandSelector);

--- a/CommonTools/CandAlgos/plugins/LargestPtCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/LargestPtCandViewSelector.cc
@@ -21,11 +21,7 @@
 #include "CommonTools/Utils/interface/PtComparator.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef ObjectSelector<
-          SortCollectionSelector<
-            reco::CandidateView,
-            GreaterByPt<reco::Candidate>
-          >
-        > LargestPtCandViewSelector;
+typedef ObjectSelector<SortCollectionSelector<reco::CandidateView, GreaterByPt<reco::Candidate> > >
+    LargestPtCandViewSelector;
 
-DEFINE_FWK_MODULE( LargestPtCandViewSelector );
+DEFINE_FWK_MODULE(LargestPtCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/NamedCandShallowCloneCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/NamedCandShallowCloneCombiner.cc
@@ -12,14 +12,13 @@
 
 namespace reco {
   namespace modules {
-    typedef CandCombiner<
-              StringCutObjectSelector<reco::Candidate, true>,
-              AnyPairSelector,
-              combiner::helpers::ShallowClone,
-              reco::NamedCompositeCandidateCollection
-            > NamedCandShallowCloneCombiner;
+    typedef CandCombiner<StringCutObjectSelector<reco::Candidate, true>,
+                         AnyPairSelector,
+                         combiner::helpers::ShallowClone,
+                         reco::NamedCompositeCandidateCollection>
+        NamedCandShallowCloneCombiner;
 
-DEFINE_FWK_MODULE( NamedCandShallowCloneCombiner );
+    DEFINE_FWK_MODULE(NamedCandShallowCloneCombiner);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/NamedCandViewCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/NamedCandViewCombiner.cc
@@ -13,11 +13,10 @@
 #include "DataFormats/Candidate/interface/NamedCompositeCandidate.h"
 #include "DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h"
 
-typedef reco::modules::CandCombiner<
-                         StringCutObjectSelector<reco::Candidate, true>,
-                         AnyPairSelector,
-                         combiner::helpers::NormalClone,
-                         reco::NamedCompositeCandidateCollection
-                       > NamedCandViewCombiner;
-      
+typedef reco::modules::CandCombiner<StringCutObjectSelector<reco::Candidate, true>,
+                                    AnyPairSelector,
+                                    combiner::helpers::NormalClone,
+                                    reco::NamedCompositeCandidateCollection>
+    NamedCandViewCombiner;
+
 DEFINE_FWK_MODULE(NamedCandViewCombiner);

--- a/CommonTools/CandAlgos/plugins/NamedCandViewShallowCloneCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/NamedCandViewShallowCloneCombiner.cc
@@ -12,14 +12,13 @@
 
 namespace reco {
   namespace modules {
-    typedef CandCombiner<
-              StringCutObjectSelector<reco::Candidate, true>,
-              AnyPairSelector,
-              combiner::helpers::ShallowClone,
-              reco::NamedCompositeCandidateCollection 
-            > NamedCandViewShallowCloneCombiner;
+    typedef CandCombiner<StringCutObjectSelector<reco::Candidate, true>,
+                         AnyPairSelector,
+                         combiner::helpers::ShallowClone,
+                         reco::NamedCompositeCandidateCollection>
+        NamedCandViewShallowCloneCombiner;
 
-DEFINE_FWK_MODULE( NamedCandViewShallowCloneCombiner );
+    DEFINE_FWK_MODULE(NamedCandViewShallowCloneCombiner);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/NamedCandViewShallowClonePtrCombiner.cc
+++ b/CommonTools/CandAlgos/plugins/NamedCandViewShallowClonePtrCombiner.cc
@@ -12,14 +12,13 @@
 
 namespace reco {
   namespace modules {
-    typedef CandCombiner<
-              StringCutObjectSelector<reco::Candidate, true>,
-              AnyPairSelector,
-              combiner::helpers::ShallowClonePtr,
-              reco::NamedCompositeCandidateCollection 
-            > NamedCandViewShallowClonePtrCombiner;
+    typedef CandCombiner<StringCutObjectSelector<reco::Candidate, true>,
+                         AnyPairSelector,
+                         combiner::helpers::ShallowClonePtr,
+                         reco::NamedCompositeCandidateCollection>
+        NamedCandViewShallowClonePtrCombiner;
 
-DEFINE_FWK_MODULE( NamedCandViewShallowClonePtrCombiner );
+    DEFINE_FWK_MODULE(NamedCandViewShallowClonePtrCombiner);
 
-  }
-}
+  }  // namespace modules
+}  // namespace reco

--- a/CommonTools/CandAlgos/plugins/ParticleDecayProducer.cc
+++ b/CommonTools/CandAlgos/plugins/ParticleDecayProducer.cc
@@ -13,11 +13,11 @@
 #include <vector>
 
 class ParticleDecayProducer : public edm::EDProducer {
- public:
+public:
   explicit ParticleDecayProducer(const edm::ParameterSet&);
   ~ParticleDecayProducer() override;
 
- private:
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
   edm::EDGetTokenT<reco::CandidateCollection> genCandidatesToken_;
   int motherPdgId_;
@@ -37,25 +37,24 @@ using namespace std;
 using namespace reco;
 
 // constructors
-ParticleDecayProducer::ParticleDecayProducer(const edm::ParameterSet& iConfig) :
-  genCandidatesToken_(consumes<CandidateCollection>(iConfig.getParameter<InputTag>("src"))),
-  motherPdgId_(iConfig.getParameter<int>("motherPdgId")),
-  daughtersPdgId_(iConfig.getParameter<vector<int> >("daughtersPdgId")),
-  decayChain_(iConfig.getParameter<std::string>("decayChain")) {
+ParticleDecayProducer::ParticleDecayProducer(const edm::ParameterSet& iConfig)
+    : genCandidatesToken_(consumes<CandidateCollection>(iConfig.getParameter<InputTag>("src"))),
+      motherPdgId_(iConfig.getParameter<int>("motherPdgId")),
+      daughtersPdgId_(iConfig.getParameter<vector<int> >("daughtersPdgId")),
+      decayChain_(iConfig.getParameter<std::string>("decayChain")) {
   string alias;
-  produces<CandidateCollection >(alias = decayChain_+ "Mother").setBranchAlias(alias);
-  for (unsigned int j = 0; j < daughtersPdgId_.size(); ++ j) {
-    ostringstream index,collection;
+  produces<CandidateCollection>(alias = decayChain_ + "Mother").setBranchAlias(alias);
+  for (unsigned int j = 0; j < daughtersPdgId_.size(); ++j) {
+    ostringstream index, collection;
     index << j;
     collection << decayChain_ << "Lepton" << index.str();
     valias.push_back(collection.str());
-    produces<CandidateCollection >(valias.at(j)).setBranchAlias( valias.at(j) );
+    produces<CandidateCollection>(valias.at(j)).setBranchAlias(valias.at(j));
   }
 }
 
 // destructor
-ParticleDecayProducer::~ParticleDecayProducer() {
-}
+ParticleDecayProducer::~ParticleDecayProducer() {}
 
 void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get gen particle candidates
@@ -65,16 +64,17 @@ void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   unique_ptr<CandidateCollection> mothercands(new CandidateCollection);
   unique_ptr<CandidateCollection> daughterscands(new CandidateCollection);
   size_t daughtersize = daughtersPdgId_.size();
-  for( CandidateCollection::const_iterator p = genCandidatesCollection->begin();p != genCandidatesCollection->end(); ++ p ) {
-    if (p->pdgId() == motherPdgId_  && p->status() == 3){
+  for (CandidateCollection::const_iterator p = genCandidatesCollection->begin(); p != genCandidatesCollection->end();
+       ++p) {
+    if (p->pdgId() == motherPdgId_ && p->status() == 3) {
       mothercands->push_back(p->clone());
       size_t ndau = p->numberOfDaughters();
-      for(size_t i = 0; i < ndau; ++ i){
-	for (size_t j = 0; j < daughtersize; ++j){
-	  if (p->daughter(i)->pdgId()==daughtersPdgId_[j] && p->daughter(i)->status()==3){
-	    daughterscands->push_back(p->daughter(i)->clone());
-	  }
-	}
+      for (size_t i = 0; i < ndau; ++i) {
+        for (size_t j = 0; j < daughtersize; ++j) {
+          if (p->daughter(i)->pdgId() == daughtersPdgId_[j] && p->daughter(i)->status() == 3) {
+            daughterscands->push_back(p->daughter(i)->clone());
+          }
+        }
       }
     }
   }
@@ -82,13 +82,13 @@ void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   iEvent.put(std::move(mothercands), decayChain_ + "Mother");
   daughterscands->sort(GreaterByPt<reco::Candidate>());
 
-  for (unsigned int row = 0; row < daughtersize; ++ row ){
+  for (unsigned int row = 0; row < daughtersize; ++row) {
     unique_ptr<CandidateCollection> leptonscands_(new CandidateCollection);
-    leptonscands_->push_back((daughterscands->begin()+row)->clone());
+    leptonscands_->push_back((daughterscands->begin() + row)->clone());
     iEvent.put(std::move(leptonscands_), valias.at(row));
   }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( ParticleDecayProducer );
+DEFINE_FWK_MODULE(ParticleDecayProducer);

--- a/CommonTools/CandAlgos/plugins/PdgIdAndStatusCandDecaySelector.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdAndStatusCandDecaySelector.cc
@@ -21,12 +21,7 @@
 #include "CommonTools/UtilAlgos/interface/StatusSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          AndSelector<
-            PdgIdSelector,
-            StatusSelector
-          >
-        > PdgIdAndStatusCandDecaySelector;
+typedef SingleObjectSelector<reco::CandidateCollection, AndSelector<PdgIdSelector, StatusSelector> >
+    PdgIdAndStatusCandDecaySelector;
 
-DEFINE_FWK_MODULE( PdgIdAndStatusCandDecaySelector );
+DEFINE_FWK_MODULE(PdgIdAndStatusCandDecaySelector);

--- a/CommonTools/CandAlgos/plugins/PdgIdAndStatusCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdAndStatusCandSelector.cc
@@ -20,12 +20,7 @@
 #include "CommonTools/UtilAlgos/interface/StatusSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          AndSelector<
-            PdgIdSelector,
-            StatusSelector
-          >
-        > PdgIdAndStatusCandSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, AndSelector<PdgIdSelector, StatusSelector> >
+    PdgIdAndStatusCandSelector;
 
-DEFINE_FWK_MODULE( PdgIdAndStatusCandSelector );
+DEFINE_FWK_MODULE(PdgIdAndStatusCandSelector);

--- a/CommonTools/CandAlgos/plugins/PdgIdAndStatusCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdAndStatusCandViewSelector.cc
@@ -22,12 +22,7 @@
 #include "CommonTools/UtilAlgos/interface/StatusSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateView,
-          AndSelector<
-            PdgIdSelector,
-            StatusSelector
-          >
-        > PdgIdAndStatusCandViewSelector;
+typedef SingleObjectSelector<reco::CandidateView, AndSelector<PdgIdSelector, StatusSelector> >
+    PdgIdAndStatusCandViewSelector;
 
-DEFINE_FWK_MODULE( PdgIdAndStatusCandViewSelector );
+DEFINE_FWK_MODULE(PdgIdAndStatusCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/PdgIdCandExcluder.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdCandExcluder.cc
@@ -16,9 +16,6 @@
 #include "CommonTools/UtilAlgos/interface/PdgIdExcluder.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-  reco::CandidateCollection,
-          PdgIdExcluder
-  > PdgIdCandExcluder;
+typedef SingleObjectSelector<reco::CandidateCollection, PdgIdExcluder> PdgIdCandExcluder;
 
-DEFINE_FWK_MODULE( PdgIdCandExcluder );
+DEFINE_FWK_MODULE(PdgIdCandExcluder);

--- a/CommonTools/CandAlgos/plugins/PdgIdCandRefSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdCandRefSelector.cc
@@ -17,10 +17,6 @@
 #include "CommonTools/UtilAlgos/interface/PdgIdSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector <
-          reco::CandidateCollection,
-          PdgIdSelector,
-          reco::CandidateRefVector
-        > PdgIdCandRefSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, PdgIdSelector, reco::CandidateRefVector> PdgIdCandRefSelector;
 
-DEFINE_FWK_MODULE( PdgIdCandRefSelector );
+DEFINE_FWK_MODULE(PdgIdCandRefSelector);

--- a/CommonTools/CandAlgos/plugins/PdgIdCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdCandSelector.cc
@@ -16,9 +16,6 @@
 #include "CommonTools/UtilAlgos/interface/PdgIdSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          PdgIdSelector
-        > PdgIdCandSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, PdgIdSelector> PdgIdCandSelector;
 
-DEFINE_FWK_MODULE( PdgIdCandSelector );
+DEFINE_FWK_MODULE(PdgIdCandSelector);

--- a/CommonTools/CandAlgos/plugins/PdgIdCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PdgIdCandViewSelector.cc
@@ -18,9 +18,6 @@
 #include "CommonTools/UtilAlgos/interface/PdgIdSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector <
-          reco::CandidateView,
-          PdgIdSelector
-        > PdgIdCandViewSelector;
+typedef SingleObjectSelector<reco::CandidateView, PdgIdSelector> PdgIdCandViewSelector;
 
-DEFINE_FWK_MODULE( PdgIdCandViewSelector );
+DEFINE_FWK_MODULE(PdgIdCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/PtMinAssociatedVariableMaxCutCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PtMinAssociatedVariableMaxCutCandSelector.cc
@@ -24,12 +24,8 @@
 
 typedef double isolation;
 
-typedef SingleObjectSelector<
-          edm::AssociationVector<reco::CandidateRefProd, std::vector<isolation> >,
-          PairSelector<
-            RefSelector<PtMinSelector>,
-            MaxSelector<isolation>
-          >
-        > PtMinAssociatedVariableMaxCutCandSelector;
+typedef SingleObjectSelector<edm::AssociationVector<reco::CandidateRefProd, std::vector<isolation> >,
+                             PairSelector<RefSelector<PtMinSelector>, MaxSelector<isolation> > >
+    PtMinAssociatedVariableMaxCutCandSelector;
 
-DEFINE_FWK_MODULE( PtMinAssociatedVariableMaxCutCandSelector );
+DEFINE_FWK_MODULE(PtMinAssociatedVariableMaxCutCandSelector);

--- a/CommonTools/CandAlgos/plugins/PtMinCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PtMinCandSelector.cc
@@ -16,9 +16,6 @@
 #include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          PtMinSelector
-        > PtMinCandSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, PtMinSelector> PtMinCandSelector;
 
-DEFINE_FWK_MODULE( PtMinCandSelector );
+DEFINE_FWK_MODULE(PtMinCandSelector);

--- a/CommonTools/CandAlgos/plugins/PtMinCandViewCloneSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PtMinCandViewCloneSelector.cc
@@ -19,10 +19,7 @@
 #include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::Candidate>,
-          PtMinSelector,
-          reco::CandidateCollection
-        > PtMinCandViewCloneSelector;
+typedef SingleObjectSelector<edm::View<reco::Candidate>, PtMinSelector, reco::CandidateCollection>
+    PtMinCandViewCloneSelector;
 
-DEFINE_FWK_MODULE( PtMinCandViewCloneSelector );
+DEFINE_FWK_MODULE(PtMinCandViewCloneSelector);

--- a/CommonTools/CandAlgos/plugins/PtMinCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/PtMinCandViewSelector.cc
@@ -18,9 +18,6 @@
 #include "CommonTools/UtilAlgos/interface/PtMinSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          edm::View<reco::Candidate>,
-          PtMinSelector
-        > PtMinCandViewSelector;
+typedef SingleObjectSelector<edm::View<reco::Candidate>, PtMinSelector> PtMinCandViewSelector;
 
-DEFINE_FWK_MODULE( PtMinCandViewSelector );
+DEFINE_FWK_MODULE(PtMinCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/StatusCandRefSelector.cc
+++ b/CommonTools/CandAlgos/plugins/StatusCandRefSelector.cc
@@ -17,10 +17,6 @@
 #include "CommonTools/UtilAlgos/interface/StatusSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          StatusSelector,
-          reco::CandidateRefVector
-        > StatusCandRefSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, StatusSelector, reco::CandidateRefVector> StatusCandRefSelector;
 
-DEFINE_FWK_MODULE( StatusCandRefSelector );
+DEFINE_FWK_MODULE(StatusCandRefSelector);

--- a/CommonTools/CandAlgos/plugins/StatusCandSelector.cc
+++ b/CommonTools/CandAlgos/plugins/StatusCandSelector.cc
@@ -16,9 +16,6 @@
 #include "CommonTools/UtilAlgos/interface/StatusSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateCollection,
-          StatusSelector
-        > StatusCandSelector;
+typedef SingleObjectSelector<reco::CandidateCollection, StatusSelector> StatusCandSelector;
 
-DEFINE_FWK_MODULE( StatusCandSelector );
+DEFINE_FWK_MODULE(StatusCandSelector);

--- a/CommonTools/CandAlgos/plugins/StatusCandViewSelector.cc
+++ b/CommonTools/CandAlgos/plugins/StatusCandViewSelector.cc
@@ -17,9 +17,6 @@
 #include "CommonTools/UtilAlgos/interface/StatusSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-typedef SingleObjectSelector<
-          reco::CandidateView,
-          StatusSelector
-        > StatusCandViewSelector;
+typedef SingleObjectSelector<reco::CandidateView, StatusSelector> StatusCandViewSelector;
 
-DEFINE_FWK_MODULE( StatusCandViewSelector );
+DEFINE_FWK_MODULE(StatusCandViewSelector);

--- a/CommonTools/CandAlgos/plugins/TrivialDeltaRMatcher.cc
+++ b/CommonTools/CandAlgos/plugins/TrivialDeltaRMatcher.cc
@@ -4,4 +4,4 @@
 
 typedef reco::modules::CandMatcher<AnyPairSelector> TrivialDeltaRMatcher;
 
-DEFINE_FWK_MODULE( TrivialDeltaRMatcher );
+DEFINE_FWK_MODULE(TrivialDeltaRMatcher);

--- a/CommonTools/CandAlgos/plugins/TrivialDeltaRViewMatcher.cc
+++ b/CommonTools/CandAlgos/plugins/TrivialDeltaRViewMatcher.cc
@@ -2,10 +2,6 @@
 #include "CommonTools/CandAlgos/interface/CandMatcher.h"
 #include "CommonTools/UtilAlgos/interface/AnyPairSelector.h"
 
-typedef 
-  reco::modules::CandMatcher<
-                   AnyPairSelector, 
-                   reco::CandidateView
-                 > TrivialDeltaRViewMatcher;
+typedef reco::modules::CandMatcher<AnyPairSelector, reco::CandidateView> TrivialDeltaRViewMatcher;
 
-DEFINE_FWK_MODULE( TrivialDeltaRViewMatcher );
+DEFINE_FWK_MODULE(TrivialDeltaRViewMatcher);

--- a/CommonTools/CandAlgos/src/GenJetParticleSelector.cc
+++ b/CommonTools/CandAlgos/src/GenJetParticleSelector.cc
@@ -7,35 +7,37 @@
 using namespace std;
 using namespace edm;
 
-GenJetParticleSelector::GenJetParticleSelector(const ParameterSet& cfg, edm::ConsumesCollector & iC) :
-  stableOnly_(cfg.getParameter<bool>("stableOnly")),
-  partons_(false), bInclude_(false) {
+GenJetParticleSelector::GenJetParticleSelector(const ParameterSet& cfg, edm::ConsumesCollector& iC)
+    : stableOnly_(cfg.getParameter<bool>("stableOnly")), partons_(false), bInclude_(false) {
   const string excludeString("excludeList");
   const string includeString("includeList");
   vpdt includeList, excludeList;
   vector<string> vPdtParams = cfg.getParameterNamesForType<vpdt>();
   bool found = std::find(vPdtParams.begin(), vPdtParams.end(), includeString) != vPdtParams.end();
-  if(found) includeList = cfg.getParameter<vpdt>(includeString);
+  if (found)
+    includeList = cfg.getParameter<vpdt>(includeString);
   found = find(vPdtParams.begin(), vPdtParams.end(), excludeString) != vPdtParams.end();
-  if(found) excludeList = cfg.getParameter<vpdt>(excludeString);
+  if (found)
+    excludeList = cfg.getParameter<vpdt>(excludeString);
   const string partonsString("partons");
   vector<string> vBoolParams = cfg.getParameterNamesForType<bool>();
   found = find(vBoolParams.begin(), vBoolParams.end(), partonsString) != vBoolParams.end();
-  if(found) partons_ = cfg.getParameter<bool>(partonsString);
+  if (found)
+    partons_ = cfg.getParameter<bool>(partonsString);
   bool bExclude = false;
-  if (!includeList.empty()) bInclude_ = true;
-  if (!excludeList.empty()) bExclude = true;
+  if (!includeList.empty())
+    bInclude_ = true;
+  if (!excludeList.empty())
+    bExclude = true;
 
   if (bInclude_ && bExclude) {
     throw cms::Exception("ConfigError", "not allowed to use both includeList and excludeList at the same time\n");
-  }
-  else if (bInclude_) {
+  } else if (bInclude_) {
     pdtList_ = includeList;
-  }
-  else {
+  } else {
     pdtList_ = excludeList;
   }
-  if(stableOnly_ && partons_) {
+  if (stableOnly_ && partons_) {
     throw cms::Exception("ConfigError", "not allowed to have both stableOnly and partons true at the same time\n");
   }
 }
@@ -43,19 +45,16 @@ GenJetParticleSelector::GenJetParticleSelector(const ParameterSet& cfg, edm::Con
 bool GenJetParticleSelector::operator()(const reco::Candidate& p) {
   int status = p.status();
   int id = abs(p.pdgId());
-  if((!stableOnly_ || status == 1) && !partons_ &&
-     ( (pIds_.find(id) == pIds_.end()) ^ bInclude_))
+  if ((!stableOnly_ || status == 1) && !partons_ && ((pIds_.find(id) == pIds_.end()) ^ bInclude_))
     return true;
-  else if(partons_ &&
-	  (p.numberOfDaughters() > 0 && (p.daughter(0)->pdgId() == 91 || p.daughter(0)->pdgId() == 92)) &&
-	  ( ((pIds_.find(id) == pIds_.end()) ^ bInclude_)))
+  else if (partons_ && (p.numberOfDaughters() > 0 && (p.daughter(0)->pdgId() == 91 || p.daughter(0)->pdgId() == 92)) &&
+           (((pIds_.find(id) == pIds_.end()) ^ bInclude_)))
     return true;
   else
     return false;
 }
 
 void GenJetParticleSelector::init(const edm::EventSetup& es) {
-  for(vpdt::iterator i = pdtList_.begin(); i != pdtList_.end(); ++i )
+  for (vpdt::iterator i = pdtList_.begin(); i != pdtList_.end(); ++i)
     i->setup(es);
 }
-

--- a/CommonTools/CandAlgos/src/ModifyObjectValueBase.cc
+++ b/CommonTools/CandAlgos/src/ModifyObjectValueBase.cc
@@ -1,4 +1,3 @@
 #include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
 
-EDM_REGISTER_PLUGINFACTORY(ModifyObjectValueFactory,"ModifyObjectValueFactory");
-
+EDM_REGISTER_PLUGINFACTORY(ModifyObjectValueFactory, "ModifyObjectValueFactory");

--- a/CommonTools/CandAlgos/src/decayParser.cc
+++ b/CommonTools/CandAlgos/src/decayParser.cc
@@ -2,11 +2,11 @@
 //
 // Package:     CandCombiner
 // Class  :     decayParser
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Original Author:  
+// Original Author:
 //         Created:  Sun Aug  7 20:26:31 EDT 2005
 // $Id: decayParser.cc,v 1.1 2009/03/03 13:50:55 llista Exp $
 //
@@ -18,40 +18,31 @@ using namespace std;
 using namespace boost::spirit::classic;
 namespace cand {
   namespace parser {
-    
+
     class ModeSetter {
     public:
-      ModeSetter( vector<ConjInfo>& iVect, ConjInfo::Mode iMode) : 
-	conjInfo_(iVect), mode_(iMode) {}
-      void operator()( const char ) const {
-	conjInfo_.back().mode_ = mode_;
-      }
+      ModeSetter(vector<ConjInfo>& iVect, ConjInfo::Mode iMode) : conjInfo_(iVect), mode_(iMode) {}
+      void operator()(const char) const { conjInfo_.back().mode_ = mode_; }
+
     private:
       vector<ConjInfo>& conjInfo_;
       ConjInfo::Mode mode_;
     };
-    
-    typedef scanner_policies<skip_parser_iteration_policy<nothing_parser, 
-							  iteration_policy>, 
-			     match_policy, action_policy> ScannerPolicy;
-    typedef scanner<const char*, ScannerPolicy > ScannerUsed_1;
+
+    typedef scanner_policies<skip_parser_iteration_policy<nothing_parser, iteration_policy>, match_policy, action_policy>
+        ScannerPolicy;
+    typedef scanner<const char*, ScannerPolicy> ScannerUsed_1;
     typedef rule<ScannerUsed_1> Rule_1;
-    
-    bool decayParser( const string& iValue, vector<ConjInfo>& oStrings ) {
+
+    bool decayParser(const string& iValue, vector<ConjInfo>& oStrings) {
       using namespace boost::spirit;
-      
-      Rule_1 label = ((+alnum_p) >> *ch_p(':') >> *ch_p('_') >>*alnum_p)[push_back_a(oStrings)];
-      Rule_1 conj =  (ch_p('@') >> !((ch_p('b')>>ch_p('a')>>ch_p('r')[ModeSetter(oStrings,ConjInfo::kBar)] )| 
-				     ch_p('+')[ModeSetter(oStrings,ConjInfo::kPlus)] | 
-				     ch_p('-')[ModeSetter(oStrings,ConjInfo::kMinus)]) );
-      
-      return parse( iValue.c_str(),
-		    (
-		     (label >> ! conj)
-		     % blank_p
-		     )
-		    ,
-		    nothing_p).full;
+
+      Rule_1 label = ((+alnum_p) >> *ch_p(':') >> *ch_p('_') >> *alnum_p)[push_back_a(oStrings)];
+      Rule_1 conj = (ch_p('@') >> !((ch_p('b') >> ch_p('a') >> ch_p('r')[ModeSetter(oStrings, ConjInfo::kBar)]) |
+                                    ch_p('+')[ModeSetter(oStrings, ConjInfo::kPlus)] |
+                                    ch_p('-')[ModeSetter(oStrings, ConjInfo::kMinus)]));
+
+      return parse(iValue.c_str(), ((label >> !conj) % blank_p), nothing_p).full;
     }
-  }
-}
+  }  // namespace parser
+}  // namespace cand

--- a/JetMETCorrections/Type1MET/interface/AddCorrectionsToGenericMET.h
+++ b/JetMETCorrections/Type1MET/interface/AddCorrectionsToGenericMET.h
@@ -25,24 +25,21 @@
 #include "DataFormats/METReco/interface/CorrMETData.h"
 
 class AddCorrectionsToGenericMET {
+public:
+  AddCorrectionsToGenericMET(){};
+  ~AddCorrectionsToGenericMET(){};
 
- public:
-  AddCorrectionsToGenericMET() {};
-  ~AddCorrectionsToGenericMET() {};
-  
   void setCorTokens(std::vector<edm::EDGetTokenT<CorrMETData> > const& corrTokens);
 
-  reco::MET getCorrectedMET(const reco::MET& srcMET,edm::Event& evt, const edm::EventSetup& es);
-  reco::PFMET getCorrectedPFMET(const reco::PFMET& srcMET,edm::Event& evt, const edm::EventSetup& es);
-  reco::CaloMET getCorrectedCaloMET(const reco::CaloMET& srcMET,edm::Event& evt, const edm::EventSetup& es);
+  reco::MET getCorrectedMET(const reco::MET& srcMET, edm::Event& evt, const edm::EventSetup& es);
+  reco::PFMET getCorrectedPFMET(const reco::PFMET& srcMET, edm::Event& evt, const edm::EventSetup& es);
+  reco::CaloMET getCorrectedCaloMET(const reco::CaloMET& srcMET, edm::Event& evt, const edm::EventSetup& es);
 
- private:
+private:
+  CorrMETData getCorrection(const reco::MET& srcMET, edm::Event& evt, const edm::EventSetup& es);
 
-  CorrMETData getCorrection(const reco::MET& srcMET,edm::Event& evt, const edm::EventSetup& es);
-  
   std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens_;
   reco::Candidate::LorentzVector constructP4From(const reco::MET& met, const CorrMETData& correction);
-
 };
 
 #endif

--- a/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
@@ -33,65 +33,52 @@
 #include <string>
 #include <type_traits>
 
-namespace CaloJetMETcorrInputProducer_namespace
-{
+namespace CaloJetMETcorrInputProducer_namespace {
   template <typename T>
-  class InputTypeCheckerT
-  {
-    public:
-     void operator()(const T&) const {} // no type-checking needed for reco::CaloJet input
-     bool isPatJet(const T&) const {
-       return std::is_base_of<class pat::Jet, T>::value;
-     }
+  class InputTypeCheckerT {
+  public:
+    void operator()(const T&) const {}  // no type-checking needed for reco::CaloJet input
+    bool isPatJet(const T&) const { return std::is_base_of<class pat::Jet, T>::value; }
   };
 
   template <typename T>
-  class RawJetExtractorT // this template is neccessary to support pat::Jets
-                         // (because pat::Jet->p4() returns the JES corrected, not the raw, jet momentum)
+  class RawJetExtractorT  // this template is neccessary to support pat::Jets
+                          // (because pat::Jet->p4() returns the JES corrected, not the raw, jet momentum)
   {
-    public:
-     RawJetExtractorT() {}
+  public:
+    RawJetExtractorT() {}
 
-     reco::Candidate::LorentzVector  operator()(const T& jet) const
-     {
-       return jet.p4();
-     }
+    reco::Candidate::LorentzVector operator()(const T& jet) const { return jet.p4(); }
   };
-}
+}  // namespace CaloJetMETcorrInputProducer_namespace
 
 template <typename T, typename Textractor>
-class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
-{
- public:
-
+class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<> {
+public:
   explicit CaloJetMETcorrInputProducerT(const edm::ParameterSet& cfg)
-    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-      offsetCorrLabel_("")
-  {
+      : moduleLabel_(cfg.getParameter<std::string>("@module_label")), offsetCorrLabel_("") {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
 
-    if ( cfg.exists("offsetCorrLabel") ) {
+    if (cfg.exists("offsetCorrLabel")) {
       offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
       offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
     }
     jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel");
     jetCorrToken_ = consumes<reco::JetCorrector>(jetCorrLabel_);
 
-    jetCorrEtaMax_ = ( cfg.exists("jetCorrEtaMax") ) ?
-      cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
+    jetCorrEtaMax_ = (cfg.exists("jetCorrEtaMax")) ? cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
 
     type1JetPtThreshold_ = cfg.getParameter<double>("type1JetPtThreshold");
 
     skipEM_ = cfg.getParameter<bool>("skipEM");
-    if ( skipEM_ ) {
+    if (skipEM_) {
       skipEMfractionThreshold_ = cfg.getParameter<double>("skipEMfractionThreshold");
     }
 
-    if(cfg.exists("srcMET"))
-      {
-	srcMET_ = cfg.getParameter<edm::InputTag>("srcMET");
-	metToken_ = consumes<edm::View<reco::MET> >(cfg.getParameter<edm::InputTag>("srcMET"));
-      }
+    if (cfg.exists("srcMET")) {
+      srcMET_ = cfg.getParameter<edm::InputTag>("srcMET");
+      metToken_ = consumes<edm::View<reco::MET> >(cfg.getParameter<edm::InputTag>("srcMET"));
+    }
 
     produces<CorrMETData>("type1");
     produces<CorrMETData>("type2");
@@ -99,10 +86,8 @@ class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
   }
   ~CaloJetMETcorrInputProducerT() override {}
 
- private:
-
-  void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const override
-  {
+private:
+  void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const override {
     std::unique_ptr<CorrMETData> type1Correction(new CorrMETData());
     std::unique_ptr<CorrMETData> unclEnergySum(new CorrMETData());
     std::unique_ptr<CorrMETData> offsetEnergySum(new CorrMETData());
@@ -116,27 +101,27 @@ class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
 
     typedef edm::View<reco::MET> METView;
     edm::Handle<METView> met;
-    if ( !srcMET_.label().empty() ) {
+    if (!srcMET_.label().empty()) {
       evt.getByToken(metToken_, met);
-      if ( met->size() != 1 )
-	throw cms::Exception("CaloJetMETcorrInputProducer::produce")
-	  << "Failed to find unique MET in the event, src = " << srcMET_.label() << " !!\n";
+      if (met->size() != 1)
+        throw cms::Exception("CaloJetMETcorrInputProducer::produce")
+            << "Failed to find unique MET in the event, src = " << srcMET_.label() << " !!\n";
 
-//--- compute "unclustered energy" by sutracting from the reconstructed MET
-//   (i.e. from the negative vectorial sum of all particles reconstructed in the event)
-//    the momenta of (high Pt) jets which enter Type 1 MET corrections
-//
-//    NOTE: MET = -(jets + muons + "unclustered energy"),
-//          so "unclustered energy" = -(MET + jets + muons),
-//          i.e. (high Pt) jets enter the sum of "unclustered energy" with negative sign.
-//
-      unclEnergySum->mex   = -met->front().px();
-      unclEnergySum->mey   = -met->front().py();
-      unclEnergySum->sumet =  met->front().sumEt();
+      //--- compute "unclustered energy" by sutracting from the reconstructed MET
+      //   (i.e. from the negative vectorial sum of all particles reconstructed in the event)
+      //    the momenta of (high Pt) jets which enter Type 1 MET corrections
+      //
+      //    NOTE: MET = -(jets + muons + "unclustered energy"),
+      //          so "unclustered energy" = -(MET + jets + muons),
+      //          i.e. (high Pt) jets enter the sum of "unclustered energy" with negative sign.
+      //
+      unclEnergySum->mex = -met->front().px();
+      unclEnergySum->mey = -met->front().py();
+      unclEnergySum->sumet = met->front().sumEt();
     }
 
     int numJets = jets->size();
-    for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
+    for (int jetIndex = 0; jetIndex < numJets; ++jetIndex) {
       const T& rawJet = jets->at(jetIndex);
 
       const CaloJetMETcorrInputProducer_namespace::InputTypeCheckerT<T> checkInputType{};
@@ -146,48 +131,48 @@ class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(rawJet);
 
       reco::Candidate::LorentzVector corrJetP4;
-      if ( checkInputType.isPatJet(rawJet) )
+      if (checkInputType.isPatJet(rawJet))
         corrJetP4 = jetCorrExtractor_(rawJet, jetCorrLabel_.label(), jetCorrEtaMax_);
       else
         corrJetP4 = jetCorrExtractor_(rawJet, jetCorr.product(), jetCorrEtaMax_);
 
-      if ( corrJetP4.pt() > type1JetPtThreshold_ ) {
+      if (corrJetP4.pt() > type1JetPtThreshold_) {
+        unclEnergySum->mex -= rawJetP4.px();
+        unclEnergySum->mey -= rawJetP4.py();
+        unclEnergySum->sumet -= rawJetP4.Et();
 
-	unclEnergySum->mex   -= rawJetP4.px();
-	unclEnergySum->mey   -= rawJetP4.py();
-	unclEnergySum->sumet -= rawJetP4.Et();
+        if (skipEM_ && rawJet.emEnergyFraction() > skipEMfractionThreshold_)
+          continue;
 
-	if ( skipEM_ && rawJet.emEnergyFraction() > skipEMfractionThreshold_ ) continue;
-
-	reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;
-	if ( !offsetCorrLabel_.label().empty() ) {
+        reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;
+        if (!offsetCorrLabel_.label().empty()) {
           edm::Handle<reco::JetCorrector> offsetCorr;
           evt.getByToken(offsetCorrToken_, offsetCorr);
-          if (  checkInputType.isPatJet(rawJet) )
+          if (checkInputType.isPatJet(rawJet))
             rawJetP4offsetCorr = jetCorrExtractor_(rawJet, offsetCorrLabel_.label(), jetCorrEtaMax_);
           else
-	    rawJetP4offsetCorr = jetCorrExtractor_(rawJet, offsetCorr.product(), jetCorrEtaMax_);
+            rawJetP4offsetCorr = jetCorrExtractor_(rawJet, offsetCorr.product(), jetCorrEtaMax_);
 
-	  offsetEnergySum->mex   += (rawJetP4.px() - rawJetP4offsetCorr.px());
-	  offsetEnergySum->mey   += (rawJetP4.py() - rawJetP4offsetCorr.py());
-	  offsetEnergySum->sumet += (rawJetP4.Et() - rawJetP4offsetCorr.Et());
-	}
+          offsetEnergySum->mex += (rawJetP4.px() - rawJetP4offsetCorr.px());
+          offsetEnergySum->mey += (rawJetP4.py() - rawJetP4offsetCorr.py());
+          offsetEnergySum->sumet += (rawJetP4.Et() - rawJetP4offsetCorr.Et());
+        }
 
-//--- MET balances momentum of reconstructed particles,
-//    hence correction to jets and corresponding Type 1 MET correction are of opposite sign
-	type1Correction->mex   -= (corrJetP4.px() - rawJetP4offsetCorr.px());
-	type1Correction->mey   -= (corrJetP4.py() - rawJetP4offsetCorr.py());
-	type1Correction->sumet += (corrJetP4.Et() - rawJetP4offsetCorr.Et());
+        //--- MET balances momentum of reconstructed particles,
+        //    hence correction to jets and corresponding Type 1 MET correction are of opposite sign
+        type1Correction->mex -= (corrJetP4.px() - rawJetP4offsetCorr.px());
+        type1Correction->mey -= (corrJetP4.py() - rawJetP4offsetCorr.py());
+        type1Correction->sumet += (corrJetP4.Et() - rawJetP4offsetCorr.Et());
       }
     }
 
-//--- add
-//     o Type 1 MET correction                (difference corrected-uncorrected jet energy for jets of (corrected) Pt > 20 GeV)
-//     o momentum sum of "unclustered energy" (jets of (corrected) Pt < 20 GeV)
-//     o momentum sum of "offset energy"      (sum of energy attributed to pile-up/underlying event)
-//    to the event
+    //--- add
+    //     o Type 1 MET correction                (difference corrected-uncorrected jet energy for jets of (corrected) Pt > 20 GeV)
+    //     o momentum sum of "unclustered energy" (jets of (corrected) Pt < 20 GeV)
+    //     o momentum sum of "offset energy"      (sum of energy attributed to pile-up/underlying event)
+    //    to the event
     evt.put(std::move(type1Correction), "type1");
-    evt.put(std::move(unclEnergySum),   "type2");
+    evt.put(std::move(unclEnergySum), "type2");
     evt.put(std::move(offsetEnergySum), "offset");
   }
 
@@ -196,33 +181,28 @@ class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
   edm::EDGetTokenT<std::vector<T> > token_;
 
   edm::InputTag offsetCorrLabel_;
-  edm::EDGetTokenT<reco::JetCorrector> offsetCorrToken_; // e.g. 'ak5CaloJetL1Fastjet'
+  edm::EDGetTokenT<reco::JetCorrector> offsetCorrToken_;  // e.g. 'ak5CaloJetL1Fastjet'
   edm::InputTag jetCorrLabel_;
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrToken_;    // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
+  edm::EDGetTokenT<reco::JetCorrector>
+      jetCorrToken_;  // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
   Textractor jetCorrExtractor_;
 
-  double jetCorrEtaMax_; // do not use JEC factors for |eta| above this threshold (recommended default = 4.7),
-                         // in order to work around problem with CMSSW_4_2_x JEC factors at high eta,
-                         // reported in
-                         //  https://hypernews.cern.ch/HyperNews/CMS/get/jes/270.html
-                         //  https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1259/1.html
+  double jetCorrEtaMax_;  // do not use JEC factors for |eta| above this threshold (recommended default = 4.7),
+                          // in order to work around problem with CMSSW_4_2_x JEC factors at high eta,
+                          // reported in
+                          //  https://hypernews.cern.ch/HyperNews/CMS/get/jes/270.html
+                          //  https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1259/1.html
 
-  double type1JetPtThreshold_; // threshold to distinguish between jets entering Type 1 MET correction
-                               // and jets entering "unclustered energy" sum
-                               // NOTE: threshold is applied on **corrected** jet energy (recommended default = 10 GeV)
+  double type1JetPtThreshold_;  // threshold to distinguish between jets entering Type 1 MET correction
+                                // and jets entering "unclustered energy" sum
+                                // NOTE: threshold is applied on **corrected** jet energy (recommended default = 10 GeV)
 
-  bool skipEM_; // flag to exclude jets with large fraction of electromagnetic energy (electrons/photons)
-                // from Type 1 + 2 MET corrections
+  bool skipEM_;  // flag to exclude jets with large fraction of electromagnetic energy (electrons/photons)
+                 // from Type 1 + 2 MET corrections
   double skipEMfractionThreshold_;
 
-  edm::InputTag srcMET_; // MET input, needed to compute "unclustered energy" sum for Type 2 MET correction
+  edm::InputTag srcMET_;  // MET input, needed to compute "unclustered energy" sum for Type 2 MET correction
   edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
-
 };
 
 #endif
-
-
-
-
-

--- a/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
@@ -116,7 +116,7 @@ class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
 
     typedef edm::View<reco::MET> METView;
     edm::Handle<METView> met;
-    if ( srcMET_.label() != "" ) {
+    if ( !srcMET_.label().empty() ) {
       evt.getByToken(metToken_, met);
       if ( met->size() != 1 )
 	throw cms::Exception("CaloJetMETcorrInputProducer::produce")

--- a/JetMETCorrections/Type1MET/interface/JetCleanerForType1METT.h
+++ b/JetMETCorrections/Type1MET/interface/JetCleanerForType1METT.h
@@ -39,102 +39,89 @@
 #include <string>
 #include <type_traits>
 
-
-namespace JetCleanerForType1MET_namespace
-{
+namespace JetCleanerForType1MET_namespace {
   template <typename T, typename Textractor>
-    class InputTypeCheckerT
-  {
+  class InputTypeCheckerT {
   public:
-
-    void operator()(const T&) const {} // no type-checking needed for reco::PFJet input
-    bool isPatJet(const T&) const {
-      return std::is_base_of<class pat::Jet, T>::value;
-    }
+    void operator()(const T&) const {}  // no type-checking needed for reco::PFJet input
+    bool isPatJet(const T&) const { return std::is_base_of<class pat::Jet, T>::value; }
   };
 
   template <typename T>
-    class RawJetExtractorT // this template is neccessary to support pat::Jets
-    // (because pat::Jet->p4() returns the JES corrected, not the raw, jet momentum)
-    // But it does not handle the muon removal!!!!! MM
-    {
-    public:
-
-      RawJetExtractorT(){}
-      reco::Candidate::LorentzVector operator()(const T& jet) const
-	{
-	  return jet.p4();
-	}
-    };
-}
-
+  class RawJetExtractorT  // this template is neccessary to support pat::Jets
+  // (because pat::Jet->p4() returns the JES corrected, not the raw, jet momentum)
+  // But it does not handle the muon removal!!!!! MM
+  {
+  public:
+    RawJetExtractorT() {}
+    reco::Candidate::LorentzVector operator()(const T& jet) const { return jet.p4(); }
+  };
+}  // namespace JetCleanerForType1MET_namespace
 
 template <typename T, typename Textractor>
-class JetCleanerForType1METT : public edm::stream::EDProducer<>
-{
- public:
+class JetCleanerForType1METT : public edm::stream::EDProducer<> {
+public:
+  explicit JetCleanerForType1METT(const edm::ParameterSet& cfg)
+      : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+        offsetCorrLabel_(""),
+        skipMuonSelection_(nullptr) {
+    token_ = consumes<std::vector<T>>(cfg.getParameter<edm::InputTag>("src"));
 
-  explicit JetCleanerForType1METT(const edm::ParameterSet& cfg):
-    moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    offsetCorrLabel_(""),
-    skipMuonSelection_(nullptr)
-      {
-       token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
+    offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
+    offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
 
-       offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
-       offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
+    jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel");        //for MC
+    jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes");  //for data
+    jetCorrToken_ = mayConsume<reco::JetCorrector>(jetCorrLabel_);
+    jetCorrResToken_ = mayConsume<reco::JetCorrector>(jetCorrLabelRes_);
 
-       jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel"); //for MC
-       jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes"); //for data
-       jetCorrToken_ = mayConsume<reco::JetCorrector>(jetCorrLabel_);
-       jetCorrResToken_ = mayConsume<reco::JetCorrector>(jetCorrLabelRes_);
-       
-       jetCorrEtaMax_ = cfg.getParameter<double>("jetCorrEtaMax");
-       
-       type1JetPtThreshold_ = cfg.getParameter<double>("type1JetPtThreshold");
+    jetCorrEtaMax_ = cfg.getParameter<double>("jetCorrEtaMax");
 
-       skipEM_ = cfg.getParameter<bool>("skipEM");
-       if ( skipEM_ ) {
-           skipEMfractionThreshold_ = cfg.getParameter<double>("skipEMfractionThreshold");
-       }
-       
-       skipMuons_ = cfg.getParameter<bool>("skipMuons");
-       if ( skipMuons_ ) {
-           std::string skipMuonSelection_string = cfg.getParameter<std::string>("skipMuonSelection");
-           skipMuonSelection_.reset( new StringCutObjectSelector<reco::Candidate>(skipMuonSelection_string,true) ) ;
-       }
+    type1JetPtThreshold_ = cfg.getParameter<double>("type1JetPtThreshold");
 
-       calcMuonSubtrRawPtAsValueMap_ = cfg.getParameter<bool>("calcMuonSubtrRawPtAsValueMap");
-
-       produces<std::vector<T> >();
-       if (calcMuonSubtrRawPtAsValueMap_) produces<edm::ValueMap<float>>("MuonSubtrRawPt");
-      }
-
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-        edm::ParameterSetDescription desc;
-        desc.add<std::string>("@module_label");
-        desc.add<edm::InputTag>("src");
-        desc.add<edm::InputTag>("offsetCorrLabel");
-        desc.add<edm::InputTag>("jetCorrLabel");
-        desc.add<edm::InputTag>("jetCorrLabelRes");
-        desc.add<double>("jetCorrEtaMax",9.9);
-        desc.add<double>("type1JetPtThreshold");
-        desc.add<bool>("skipEM");
-        desc.add<double>("skipEMfractionThreshold");
-        desc.add<bool>("skipMuons");
-        desc.add<std::string>("skipMuonSelection");
-	desc.add<bool>("calcMuonSubtrRawPtAsValueMap",false)->setComment("calculate muon-subtracted raw pt as a ValueMap for the input collection (only for selected jets, zero for others)");
-        descriptions.addDefault(desc);
+    skipEM_ = cfg.getParameter<bool>("skipEM");
+    if (skipEM_) {
+      skipEMfractionThreshold_ = cfg.getParameter<double>("skipEMfractionThreshold");
     }
 
- private:
+    skipMuons_ = cfg.getParameter<bool>("skipMuons");
+    if (skipMuons_) {
+      std::string skipMuonSelection_string = cfg.getParameter<std::string>("skipMuonSelection");
+      skipMuonSelection_.reset(new StringCutObjectSelector<reco::Candidate>(skipMuonSelection_string, true));
+    }
 
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
+    calcMuonSubtrRawPtAsValueMap_ = cfg.getParameter<bool>("calcMuonSubtrRawPtAsValueMap");
 
+    produces<std::vector<T>>();
+    if (calcMuonSubtrRawPtAsValueMap_)
+      produces<edm::ValueMap<float>>("MuonSubtrRawPt");
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("@module_label");
+    desc.add<edm::InputTag>("src");
+    desc.add<edm::InputTag>("offsetCorrLabel");
+    desc.add<edm::InputTag>("jetCorrLabel");
+    desc.add<edm::InputTag>("jetCorrLabelRes");
+    desc.add<double>("jetCorrEtaMax", 9.9);
+    desc.add<double>("type1JetPtThreshold");
+    desc.add<bool>("skipEM");
+    desc.add<double>("skipEMfractionThreshold");
+    desc.add<bool>("skipMuons");
+    desc.add<std::string>("skipMuonSelection");
+    desc.add<bool>("calcMuonSubtrRawPtAsValueMap", false)
+        ->setComment(
+            "calculate muon-subtracted raw pt as a ValueMap for the input collection (only for selected jets, zero for "
+            "others)");
+    descriptions.addDefault(desc);
+  }
+
+private:
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     edm::Handle<reco::JetCorrector> jetCorr;
     //automatic switch for residual corrections
-    if(evt.isRealData() ) {
+    if (evt.isRealData()) {
       jetCorrLabel_ = jetCorrLabelRes_;
       evt.getByToken(jetCorrResToken_, jetCorr);
     } else {
@@ -146,50 +133,52 @@ class JetCleanerForType1METT : public edm::stream::EDProducer<>
     evt.getByToken(token_, jets);
 
     //new collection
-    std::unique_ptr< std::vector<T> > cleanedJets( new std::vector<T>() );
+    std::unique_ptr<std::vector<T>> cleanedJets(new std::vector<T>());
 
     int numJets = jets->size();
-    std::vector<float> muonSubtrRawPt(numJets,0);
+    std::vector<float> muonSubtrRawPt(numJets, 0);
 
-    for(int jetIndex=0;jetIndex<numJets; ++jetIndex ) {
+    for (int jetIndex = 0; jetIndex < numJets; ++jetIndex) {
       const T& jet = jets->at(jetIndex);
-      
-      const static JetCleanerForType1MET_namespace::InputTypeCheckerT<T, Textractor> checkInputType {};
+
+      const static JetCleanerForType1MET_namespace::InputTypeCheckerT<T, Textractor> checkInputType{};
       checkInputType(jet);
 
       double emEnergyFraction = jet.chargedEmEnergyFraction() + jet.neutralEmEnergyFraction();
-      if(skipEM_&&emEnergyFraction>skipEMfractionThreshold_ ) continue;
+      if (skipEM_ && emEnergyFraction > skipEMfractionThreshold_)
+        continue;
 
-      const static JetCleanerForType1MET_namespace::RawJetExtractorT<T> rawJetExtractor {};
+      const static JetCleanerForType1MET_namespace::RawJetExtractorT<T> rawJetExtractor{};
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(jet);
 
-      if ( skipMuons_ ) {
-	const std::vector<reco::CandidatePtr> & cands = jet.daughterPtrVector();
-	for ( std::vector<reco::CandidatePtr>::const_iterator cand = cands.begin();
-	      cand != cands.end(); ++cand ) {
-	  const reco::PFCandidate *pfcand = dynamic_cast<const reco::PFCandidate *>(cand->get());
-	  const reco::Candidate *mu = (pfcand != nullptr ? ( pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : nullptr) : cand->get());
-	  if ( mu != nullptr && (*skipMuonSelection_)(*mu) ) {
-	    reco::Candidate::LorentzVector muonP4 = (*cand)->p4();
-	    rawJetP4 -= muonP4;
-	  }
-	}
+      if (skipMuons_) {
+        const std::vector<reco::CandidatePtr>& cands = jet.daughterPtrVector();
+        for (std::vector<reco::CandidatePtr>::const_iterator cand = cands.begin(); cand != cands.end(); ++cand) {
+          const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand->get());
+          const reco::Candidate* mu =
+              (pfcand != nullptr ? (pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : nullptr) : cand->get());
+          if (mu != nullptr && (*skipMuonSelection_)(*mu)) {
+            reco::Candidate::LorentzVector muonP4 = (*cand)->p4();
+            rawJetP4 -= muonP4;
+          }
+        }
       }
 
       reco::Candidate::LorentzVector corrJetP4;
-      if ( checkInputType.isPatJet(jet) ) {
-	corrJetP4 = jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4);
-      }
-      else {
-	corrJetP4 = jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
-	if(corrJetP4.pt()<type1JetPtThreshold_) continue;
+      if (checkInputType.isPatJet(jet)) {
+        corrJetP4 = jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4);
+      } else {
+        corrJetP4 = jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
+        if (corrJetP4.pt() < type1JetPtThreshold_)
+          continue;
       }
 
-      if(corrJetP4.pt()<type1JetPtThreshold_) continue;
+      if (corrJetP4.pt() < type1JetPtThreshold_)
+        continue;
 
       cleanedJets->push_back(jet);
-      if (calcMuonSubtrRawPtAsValueMap_) muonSubtrRawPt[jetIndex]=rawJetP4.Pt();
-
+      if (calcMuonSubtrRawPtAsValueMap_)
+        muonSubtrRawPt[jetIndex] = rawJetP4.Pt();
     }
 
     evt.put(std::move(cleanedJets));
@@ -197,43 +186,41 @@ class JetCleanerForType1METT : public edm::stream::EDProducer<>
     if (calcMuonSubtrRawPtAsValueMap_) {
       std::unique_ptr<edm::ValueMap<float>> muonSubtrRawPtV(new edm::ValueMap<float>());
       edm::ValueMap<float>::Filler fillerMuonSubtrRawPt(*muonSubtrRawPtV);
-      fillerMuonSubtrRawPt.insert(jets,muonSubtrRawPt.begin(),muonSubtrRawPt.end());
+      fillerMuonSubtrRawPt.insert(jets, muonSubtrRawPt.begin(), muonSubtrRawPt.end());
       fillerMuonSubtrRawPt.fill();
-      evt.put(std::move(muonSubtrRawPtV),"MuonSubtrRawPt");
+      evt.put(std::move(muonSubtrRawPtV), "MuonSubtrRawPt");
     }
-
   }
-
-
 
   std::string moduleLabel_;
 
-  edm::EDGetTokenT<std::vector<T> > token_;
+  edm::EDGetTokenT<std::vector<T>> token_;
 
   edm::InputTag offsetCorrLabel_;
-  edm::EDGetTokenT<reco::JetCorrector> offsetCorrToken_; // e.g. 'ak5CaloJetL1Fastjet'
+  edm::EDGetTokenT<reco::JetCorrector> offsetCorrToken_;  // e.g. 'ak5CaloJetL1Fastjet'
   edm::InputTag jetCorrLabel_;
   edm::InputTag jetCorrLabelRes_;
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrToken_;    // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrResToken_;    // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
+  edm::EDGetTokenT<reco::JetCorrector>
+      jetCorrToken_;  // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
+  edm::EDGetTokenT<reco::JetCorrector>
+      jetCorrResToken_;  // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
   Textractor jetCorrExtractor_;
 
-  double jetCorrEtaMax_; // do not use JEC factors for |eta| above this threshold
+  double jetCorrEtaMax_;  // do not use JEC factors for |eta| above this threshold
 
-  double type1JetPtThreshold_; // threshold to distinguish between jets entering Type 1 MET correction
+  double type1JetPtThreshold_;  // threshold to distinguish between jets entering Type 1 MET correction
   // and jets entering "unclustered energy" sum
   // NOTE: threshold is applied on **corrected** jet energy (recommended default = 10 GeV)
 
-  bool skipEM_; // flag to exclude jets with large fraction of electromagnetic energy (electrons/photons)
+  bool skipEM_;  // flag to exclude jets with large fraction of electromagnetic energy (electrons/photons)
   // from Type 1 + 2 MET corrections
   double skipEMfractionThreshold_;
 
-  bool skipMuons_; // flag to subtract momentum of muons (provided muons pass selection cuts) which are within jets
+  bool skipMuons_;  // flag to subtract momentum of muons (provided muons pass selection cuts) which are within jets
   // from jet energy before compute JECs/propagating JECs to Type 1 + 2 MET corrections
-  std::unique_ptr<StringCutObjectSelector< reco::Candidate> > skipMuonSelection_;
+  std::unique_ptr<StringCutObjectSelector<reco::Candidate>> skipMuonSelection_;
 
-  bool calcMuonSubtrRawPtAsValueMap_; // calculate muon-subtracted raw pt as a ValueMap for the input collection (only for selected jets, zero for others)
+  bool calcMuonSubtrRawPtAsValueMap_;  // calculate muon-subtracted raw pt as a ValueMap for the input collection (only for selected jets, zero for others)
 };
 
 #endif
-

--- a/JetMETCorrections/Type1MET/interface/JetCorrExtractorT.h
+++ b/JetMETCorrections/Type1MET/interface/JetCorrExtractorT.h
@@ -26,38 +26,36 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-namespace jetcorrextractor
-{
+namespace jetcorrextractor {
   // never heard of copysign?
-  inline double sign(double x)
-  {
-    if      ( x > 0. ) return +1.;
-    else if ( x < 0. ) return -1.;
-    else               return  0.;
+  inline double sign(double x) {
+    if (x > 0.)
+      return +1.;
+    else if (x < 0.)
+      return -1.;
+    else
+      return 0.;
   }
-}
+}  // namespace jetcorrextractor
 
 template <typename T>
-class JetCorrExtractorT
-{
- public:
-
-  reco::Candidate::LorentzVector operator()(const T& rawJet, const reco::JetCorrector* jetCorr,
-					    double jetCorrEtaMax = 9.9,
-					    const reco::Candidate::LorentzVector * const rawJetP4_specified = nullptr) const
-  {
-
+class JetCorrExtractorT {
+public:
+  reco::Candidate::LorentzVector operator()(
+      const T& rawJet,
+      const reco::JetCorrector* jetCorr,
+      double jetCorrEtaMax = 9.9,
+      const reco::Candidate::LorentzVector* const rawJetP4_specified = nullptr) const {
     // allow to specify four-vector to be used as "raw" (uncorrected) jet momentum,
     // call 'rawJet.p4()' in case four-vector not specified explicitely
-    reco::Candidate::LorentzVector rawJetP4 = ( rawJetP4_specified ) ?
-      (*rawJetP4_specified) : rawJet.p4();
+    reco::Candidate::LorentzVector rawJetP4 = (rawJetP4_specified) ? (*rawJetP4_specified) : rawJet.p4();
 
     double jetCorrFactor = 1.;
-    if ( fabs(rawJetP4.eta()) < jetCorrEtaMax ) {
+    if (fabs(rawJetP4.eta()) < jetCorrEtaMax) {
       jetCorrFactor = getCorrection(rawJet, jetCorr);
     } else {
       reco::Candidate::PolarLorentzVector modJetPolarP4(rawJetP4);
-      modJetPolarP4.SetEta(jetcorrextractor::sign(rawJetP4.eta())*jetCorrEtaMax);
+      modJetPolarP4.SetEta(jetcorrextractor::sign(rawJetP4.eta()) * jetCorrEtaMax);
 
       reco::Candidate::LorentzVector modJetP4(modJetPolarP4);
 
@@ -65,8 +63,9 @@ class JetCorrExtractorT
       modJet.setP4(modJetP4);
 
       jetCorrFactor = getCorrection(modJet, jetCorr);
-      if(jetCorrFactor<0) {
-	edm::LogWarning("JetCorrExtractor") << "Negative jet energy scale correction noticed" << ".\n";
+      if (jetCorrFactor < 0) {
+        edm::LogWarning("JetCorrExtractor") << "Negative jet energy scale correction noticed"
+                                            << ".\n";
       }
     }
 
@@ -76,26 +75,21 @@ class JetCorrExtractorT
     return corrJetP4;
   }
 
-  reco::Candidate::LorentzVector operator()(const T& rawJet, const std::string& jetCorrLabel,
-					    double jetCorrEtaMax = 9.9,
-					    const reco::Candidate::LorentzVector * const rawJetP4_specified = nullptr) const
-  {
-    edm::LogWarning("JetCorrExtractor") << "JetCorrExtractorT<T>::operator(const T&, const std::string&, ...) is deprecated.\n"
-      << "Please use JetCorrExtractorT<T>::operator(const T&, const reco::JetCorrector*, ...) instead.\n"
-      << "Jet remains uncorrected!";
-    reco::Candidate::LorentzVector rawJetP4 = ( rawJetP4_specified ) ?
-      (*rawJetP4_specified) : rawJet.p4();
+  reco::Candidate::LorentzVector operator()(
+      const T& rawJet,
+      const std::string& jetCorrLabel,
+      double jetCorrEtaMax = 9.9,
+      const reco::Candidate::LorentzVector* const rawJetP4_specified = nullptr) const {
+    edm::LogWarning("JetCorrExtractor")
+        << "JetCorrExtractorT<T>::operator(const T&, const std::string&, ...) is deprecated.\n"
+        << "Please use JetCorrExtractorT<T>::operator(const T&, const reco::JetCorrector*, ...) instead.\n"
+        << "Jet remains uncorrected!";
+    reco::Candidate::LorentzVector rawJetP4 = (rawJetP4_specified) ? (*rawJetP4_specified) : rawJet.p4();
     return rawJetP4;
   }
 
-    private:
-
-  static double getCorrection(const T& jet, const reco::JetCorrector* jetCorr)
-  {
-    return jetCorr->correction(jet);
-  }
-
-
+private:
+  static double getCorrection(const T& jet, const reco::JetCorrector* jetCorr) { return jetCorr->correction(jet); }
 };
 
 #endif

--- a/JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h
+++ b/JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h
@@ -29,17 +29,14 @@
 
 #include <vector>
 
-class METCorrectionAlgorithm 
-{
- public:
-
-  explicit METCorrectionAlgorithm(const edm::ParameterSet&, edm::ConsumesCollector && iConsumesCollector);
+class METCorrectionAlgorithm {
+public:
+  explicit METCorrectionAlgorithm(const edm::ParameterSet&, edm::ConsumesCollector&& iConsumesCollector);
   ~METCorrectionAlgorithm();
 
   CorrMETData compMETCorrection(edm::Event&, const edm::EventSetup&);
 
- private:
-
+private:
   typedef std::vector<edm::InputTag> vInputTag;
 
   std::vector<edm::EDGetTokenT<CorrMETData> > chsSumTokens_;
@@ -51,49 +48,49 @@ class METCorrectionAlgorithm
 
   double type0Rsoft_;
   double type0Cuncl_;
-  
+
   typedef std::vector<std::string> vstring;
-  struct type2BinningEntryType
-  {
-    type2BinningEntryType(const std::string& binCorrformula, const edm::ParameterSet& binCorrParameter, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector & iConsumesCollector)
-      : binLabel_(""),
-        binCorrFormula_(nullptr)
-    {
-      for (vInputTag::const_iterator inputTag = srcUnclEnergySums.begin(); inputTag != srcUnclEnergySums.end(); ++inputTag)
-	{
-	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
-	}
+  struct type2BinningEntryType {
+    type2BinningEntryType(const std::string& binCorrformula,
+                          const edm::ParameterSet& binCorrParameter,
+                          const vInputTag& srcUnclEnergySums,
+                          edm::ConsumesCollector& iConsumesCollector)
+        : binLabel_(""), binCorrFormula_(nullptr) {
+      for (vInputTag::const_iterator inputTag = srcUnclEnergySums.begin(); inputTag != srcUnclEnergySums.end();
+           ++inputTag) {
+        corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
+      }
 
       initialize(binCorrformula, binCorrParameter);
     }
-    type2BinningEntryType(const edm::ParameterSet& cfg, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector & iConsumesCollector)
-      : binLabel_(cfg.getParameter<std::string>("binLabel")),
-        binCorrFormula_(nullptr)
-    {
-      for ( vInputTag::const_iterator srcUnclEnergySum = srcUnclEnergySums.begin();
-	    srcUnclEnergySum != srcUnclEnergySums.end(); ++srcUnclEnergySum )
-	{
-	  std::string instanceLabel = srcUnclEnergySum->instance();
-	  if ( !instanceLabel.empty() && !binLabel_.empty() ) instanceLabel.append("#");
-	  instanceLabel.append(binLabel_);
-	  edm::InputTag inputTag(srcUnclEnergySum->label(), instanceLabel);
-	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));
-	}
-      
+    type2BinningEntryType(const edm::ParameterSet& cfg,
+                          const vInputTag& srcUnclEnergySums,
+                          edm::ConsumesCollector& iConsumesCollector)
+        : binLabel_(cfg.getParameter<std::string>("binLabel")), binCorrFormula_(nullptr) {
+      for (vInputTag::const_iterator srcUnclEnergySum = srcUnclEnergySums.begin();
+           srcUnclEnergySum != srcUnclEnergySums.end();
+           ++srcUnclEnergySum) {
+        std::string instanceLabel = srcUnclEnergySum->instance();
+        if (!instanceLabel.empty() && !binLabel_.empty())
+          instanceLabel.append("#");
+        instanceLabel.append(binLabel_);
+        edm::InputTag inputTag(srcUnclEnergySum->label(), instanceLabel);
+        corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));
+      }
+
       std::string binCorrFormula = cfg.getParameter<std::string>("binCorrFormula");
-    
+
       edm::ParameterSet binCorrParameter = cfg.getParameter<edm::ParameterSet>("binCorrParameter");
 
       initialize(binCorrFormula, binCorrParameter);
     }
-    void initialize(const std::string& binCorrFormula, const edm::ParameterSet& binCorrParameter)
-    {
+    void initialize(const std::string& binCorrFormula, const edm::ParameterSet& binCorrParameter) {
       TString formula = binCorrFormula;
-    
+
       vstring parNames = binCorrParameter.getParameterNamesForType<double>();
       int numParameter = parNames.size();
-      binCorrParameter_.resize(numParameter);    
-      for ( int parIndex = 0; parIndex < numParameter; ++parIndex ) {
+      binCorrParameter_.resize(numParameter);
+      for (int parIndex = 0; parIndex < numParameter; ++parIndex) {
         const std::string& parName = parNames[parIndex];
 
         double parValue = binCorrParameter.getParameter<double>(parName);
@@ -103,24 +100,21 @@ class METCorrectionAlgorithm
         formula = formula.ReplaceAll(parName.data(), parName_internal);
       }
 
-      std::string binCorrFormulaName = std::string("binCorrFormula").append("_").append(binLabel_); 
+      std::string binCorrFormulaName = std::string("binCorrFormula").append("_").append(binLabel_);
       binCorrFormula_ = new TFormula(binCorrFormulaName.data(), formula);
 
-//--- check that syntax of formula string is valid 
-//   (i.e. that TFormula "compiled" without errors)
-      if ( !(binCorrFormula_->GetNdim() <= 1 && binCorrFormula_->GetNpar() == numParameter) ) 
-	throw cms::Exception("METCorrectionAlgorithm") 
-	  << "Formula for Type 2 correction has invalid syntax = " << formula << " !!\n";
+      //--- check that syntax of formula string is valid
+      //   (i.e. that TFormula "compiled" without errors)
+      if (!(binCorrFormula_->GetNdim() <= 1 && binCorrFormula_->GetNpar() == numParameter))
+        throw cms::Exception("METCorrectionAlgorithm")
+            << "Formula for Type 2 correction has invalid syntax = " << formula << " !!\n";
 
-      for ( int parIndex = 0; parIndex < numParameter; ++parIndex ) {
-	binCorrFormula_->SetParameter(parIndex, binCorrParameter_[parIndex]);
-	binCorrFormula_->SetParName(parIndex, parNames[parIndex].data());
+      for (int parIndex = 0; parIndex < numParameter; ++parIndex) {
+        binCorrFormula_->SetParameter(parIndex, binCorrParameter_[parIndex]);
+        binCorrFormula_->SetParName(parIndex, parNames[parIndex].data());
       }
     }
-    ~type2BinningEntryType() 
-    {
-      delete binCorrFormula_;
-    }
+    ~type2BinningEntryType() { delete binCorrFormula_; }
     std::string binLabel_;
     std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens_;
     TFormula* binCorrFormula_;
@@ -130,7 +124,3 @@ class METCorrectionAlgorithm
 };
 
 #endif
-
-
- 
-

--- a/JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h
+++ b/JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h
@@ -74,7 +74,7 @@ class METCorrectionAlgorithm
 	    srcUnclEnergySum != srcUnclEnergySums.end(); ++srcUnclEnergySum )
 	{
 	  std::string instanceLabel = srcUnclEnergySum->instance();
-	  if ( instanceLabel != "" && binLabel_ != "" ) instanceLabel.append("#");
+	  if ( !instanceLabel.empty() && !binLabel_.empty() ) instanceLabel.append("#");
 	  instanceLabel.append(binLabel_);
 	  edm::InputTag inputTag(srcUnclEnergySum->label(), instanceLabel);
 	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -43,131 +43,117 @@
 #include <string>
 #include <type_traits>
 
-namespace PFJetMETcorrInputProducer_namespace
-{
+namespace PFJetMETcorrInputProducer_namespace {
   template <typename T, typename Textractor>
-  class InputTypeCheckerT
-  {
-    public:
-
-     void operator()(const T&) const {} // no type-checking needed for reco::PFJet input
-     bool isPatJet(const T&) const {
-       return std::is_base_of<class pat::Jet, T>::value;
-     }
+  class InputTypeCheckerT {
+  public:
+    void operator()(const T&) const {}  // no type-checking needed for reco::PFJet input
+    bool isPatJet(const T&) const { return std::is_base_of<class pat::Jet, T>::value; }
   };
 
   template <typename T>
-  class RawJetExtractorT // this template is neccessary to support pat::Jets
-                         // (because pat::Jet->p4() returns the JES corrected, not the raw, jet momentum)
-    // But it does not handle the muon removal!!!!! MM
+  class RawJetExtractorT  // this template is neccessary to support pat::Jets
+                          // (because pat::Jet->p4() returns the JES corrected, not the raw, jet momentum)
+  // But it does not handle the muon removal!!!!! MM
   {
-    public:
-
-     RawJetExtractorT(){}
-     reco::Candidate::LorentzVector operator()(const T& jet) const
-     {
-       return jet.p4();
-     }
+  public:
+    RawJetExtractorT() {}
+    reco::Candidate::LorentzVector operator()(const T& jet) const { return jet.p4(); }
   };
 
-}
+}  // namespace PFJetMETcorrInputProducer_namespace
 
 template <typename T, typename Textractor>
-class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
-{
- public:
-
+class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<> {
+public:
   explicit PFJetMETcorrInputProducerT(const edm::ParameterSet& cfg)
-    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-      offsetCorrLabel_(""),
-      skipMuonSelection_(nullptr)
-  {
+      : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+        offsetCorrLabel_(""),
+        skipMuonSelection_(nullptr) {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
 
-    if ( cfg.exists("offsetCorrLabel") ) {
+    if (cfg.exists("offsetCorrLabel")) {
       offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
       offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
     }
-    jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel"); //for MC
-    jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes"); //for data
+    jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel");        //for MC
+    jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes");  //for data
     jetCorrToken_ = mayConsume<reco::JetCorrector>(jetCorrLabel_);
     jetCorrResToken_ = mayConsume<reco::JetCorrector>(jetCorrLabelRes_);
 
-    jetCorrEtaMax_ = ( cfg.exists("jetCorrEtaMax") ) ?
-      cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
+    jetCorrEtaMax_ = (cfg.exists("jetCorrEtaMax")) ? cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
 
     type1JetPtThreshold_ = cfg.getParameter<double>("type1JetPtThreshold");
 
     skipEM_ = cfg.getParameter<bool>("skipEM");
-    if ( skipEM_ ) {
+    if (skipEM_) {
       skipEMfractionThreshold_ = cfg.getParameter<double>("skipEMfractionThreshold");
     }
 
     skipMuons_ = cfg.getParameter<bool>("skipMuons");
-    if ( skipMuons_ ) {
+    if (skipMuons_) {
       std::string skipMuonSelection_string = cfg.getParameter<std::string>("skipMuonSelection");
-      skipMuonSelection_ = new StringCutObjectSelector<reco::Candidate>(skipMuonSelection_string,true);
+      skipMuonSelection_ = new StringCutObjectSelector<reco::Candidate>(skipMuonSelection_string, true);
     }
 
-    if ( cfg.exists("type2Binning") ) {
+    if (cfg.exists("type2Binning")) {
       typedef std::vector<edm::ParameterSet> vParameterSet;
       vParameterSet cfgType2Binning = cfg.getParameter<vParameterSet>("type2Binning");
-      for ( vParameterSet::const_iterator cfgType2BinningEntry = cfgType2Binning.begin();
-	    cfgType2BinningEntry != cfgType2Binning.end(); ++cfgType2BinningEntry ) {
-	type2Binning_.push_back(new type2BinningEntryType(*cfgType2BinningEntry));
+      for (vParameterSet::const_iterator cfgType2BinningEntry = cfgType2Binning.begin();
+           cfgType2BinningEntry != cfgType2Binning.end();
+           ++cfgType2BinningEntry) {
+        type2Binning_.push_back(new type2BinningEntryType(*cfgType2BinningEntry));
       }
     } else {
       type2Binning_.push_back(new type2BinningEntryType());
     }
 
     produces<CorrMETData>("type1");
-    for ( typename std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
-	  type2BinningEntry != type2Binning_.end(); ++type2BinningEntry ) {
+    for (typename std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
+         type2BinningEntry != type2Binning_.end();
+         ++type2BinningEntry) {
       produces<CorrMETData>((*type2BinningEntry)->getInstanceLabel_full("type2"));
       produces<CorrMETData>((*type2BinningEntry)->getInstanceLabel_full("offset"));
     }
   }
-  ~PFJetMETcorrInputProducerT() override
-  {
+  ~PFJetMETcorrInputProducerT() override {
     delete skipMuonSelection_;
 
-    for ( typename std::vector<type2BinningEntryType*>::const_iterator it = type2Binning_.begin();
-	  it != type2Binning_.end(); ++it ) {
+    for (typename std::vector<type2BinningEntryType*>::const_iterator it = type2Binning_.begin();
+         it != type2Binning_.end();
+         ++it) {
       delete (*it);
     }
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src",edm::InputTag("ak4PFJetsCHS"));
-    desc.add<edm::InputTag>("offsetCorrLabel",edm::InputTag("ak4PFCHSL1FastjetCorrector"));
-    desc.add<edm::InputTag>("jetCorrLabel",edm::InputTag("ak4PFCHSL1FastL2L3Corrector"));
-    desc.add<edm::InputTag>("jetCorrLabelRes",edm::InputTag("ak4PFCHSL1FastL2L3ResidualCorrector"));
-    desc.add<double>("jetCorrEtaMax",9.9);
-    desc.add<double>("type1JetPtThreshold",15);
-    desc.add<bool>("skipEM",true);
-    desc.add<double>("skipEMfractionThreshold",0.90);
-    desc.add<bool>("skipMuons",true);
-    desc.add<std::string>("skipMuonSelection","isGlobalMuon | isStandAloneMuon");
-    descriptions.add(defaultModuleLabel< PFJetMETcorrInputProducerT<T, Textractor> >(), desc);
-    }
+    desc.add<edm::InputTag>("src", edm::InputTag("ak4PFJetsCHS"));
+    desc.add<edm::InputTag>("offsetCorrLabel", edm::InputTag("ak4PFCHSL1FastjetCorrector"));
+    desc.add<edm::InputTag>("jetCorrLabel", edm::InputTag("ak4PFCHSL1FastL2L3Corrector"));
+    desc.add<edm::InputTag>("jetCorrLabelRes", edm::InputTag("ak4PFCHSL1FastL2L3ResidualCorrector"));
+    desc.add<double>("jetCorrEtaMax", 9.9);
+    desc.add<double>("type1JetPtThreshold", 15);
+    desc.add<bool>("skipEM", true);
+    desc.add<double>("skipEMfractionThreshold", 0.90);
+    desc.add<bool>("skipMuons", true);
+    desc.add<std::string>("skipMuonSelection", "isGlobalMuon | isStandAloneMuon");
+    descriptions.add(defaultModuleLabel<PFJetMETcorrInputProducerT<T, Textractor> >(), desc);
+  }
 
-
- private:
-
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
-
+private:
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     std::unique_ptr<CorrMETData> type1Correction(new CorrMETData());
-    for ( typename std::vector<type2BinningEntryType*>::iterator type2BinningEntry = type2Binning_.begin();
-	  type2BinningEntry != type2Binning_.end(); ++type2BinningEntry ) {
-      (*type2BinningEntry)->binUnclEnergySum_   = CorrMETData();
+    for (typename std::vector<type2BinningEntryType*>::iterator type2BinningEntry = type2Binning_.begin();
+         type2BinningEntry != type2Binning_.end();
+         ++type2BinningEntry) {
+      (*type2BinningEntry)->binUnclEnergySum_ = CorrMETData();
       (*type2BinningEntry)->binOffsetEnergySum_ = CorrMETData();
     }
 
     edm::Handle<reco::JetCorrector> jetCorr;
     //automatic switch for residual corrections
-    if(evt.isRealData() ) {
+    if (evt.isRealData()) {
       jetCorrLabel_ = jetCorrLabelRes_;
       evt.getByToken(jetCorrResToken_, jetCorr);
     } else {
@@ -179,85 +165,90 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
     evt.getByToken(token_, jets);
 
     int numJets = jets->size();
-    for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
+    for (int jetIndex = 0; jetIndex < numJets; ++jetIndex) {
       const T& jet = jets->at(jetIndex);
 
-      const static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType {};
+      const static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType{};
       checkInputType(jet);
 
       double emEnergyFraction = jet.chargedEmEnergyFraction() + jet.neutralEmEnergyFraction();
-      if ( skipEM_ && emEnergyFraction > skipEMfractionThreshold_ ) continue;
+      if (skipEM_ && emEnergyFraction > skipEMfractionThreshold_)
+        continue;
 
-      const static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor {};
+      const static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor{};
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(jet);
 
-      if ( skipMuons_ ) {
-	const std::vector<reco::CandidatePtr> & cands = jet.daughterPtrVector();
-	for ( std::vector<reco::CandidatePtr>::const_iterator cand = cands.begin();
-	      cand != cands.end(); ++cand ) {
-          const reco::PFCandidate *pfcand = dynamic_cast<const reco::PFCandidate *>(cand->get());
-          const reco::Candidate *mu = (pfcand != nullptr ? ( pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : nullptr) : cand->get());
-	  if ( mu != nullptr && (*skipMuonSelection_)(*mu) ) {
-	    reco::Candidate::LorentzVector muonP4 = (*cand)->p4();
-	    rawJetP4 -= muonP4;
-	  }
-	}
+      if (skipMuons_) {
+        const std::vector<reco::CandidatePtr>& cands = jet.daughterPtrVector();
+        for (std::vector<reco::CandidatePtr>::const_iterator cand = cands.begin(); cand != cands.end(); ++cand) {
+          const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand->get());
+          const reco::Candidate* mu =
+              (pfcand != nullptr ? (pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : nullptr) : cand->get());
+          if (mu != nullptr && (*skipMuonSelection_)(*mu)) {
+            reco::Candidate::LorentzVector muonP4 = (*cand)->p4();
+            rawJetP4 -= muonP4;
+          }
+        }
       }
 
       reco::Candidate::LorentzVector corrJetP4;
-      if ( checkInputType.isPatJet(jet) )
+      if (checkInputType.isPatJet(jet))
         corrJetP4 = jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4);
       else
         corrJetP4 = jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
-      
-      if ( corrJetP4.pt() > type1JetPtThreshold_ ) {
 
-	reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;
-	if ( !offsetCorrLabel_.label().empty() ) {
+      if (corrJetP4.pt() > type1JetPtThreshold_) {
+        reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;
+        if (!offsetCorrLabel_.label().empty()) {
           edm::Handle<reco::JetCorrector> offsetCorr;
           evt.getByToken(offsetCorrToken_, offsetCorr);
-          if ( checkInputType.isPatJet(jet) )
+          if (checkInputType.isPatJet(jet))
             rawJetP4offsetCorr = jetCorrExtractor_(jet, offsetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4);
           else
-	    rawJetP4offsetCorr = jetCorrExtractor_(jet, offsetCorr.product(), jetCorrEtaMax_, &rawJetP4);
+            rawJetP4offsetCorr = jetCorrExtractor_(jet, offsetCorr.product(), jetCorrEtaMax_, &rawJetP4);
 
-	  for ( typename std::vector<type2BinningEntryType*>::iterator type2BinningEntry = type2Binning_.begin();
-		type2BinningEntry != type2Binning_.end(); ++type2BinningEntry ) {
-	    if ( !(*type2BinningEntry)->binSelection_ || (*(*type2BinningEntry)->binSelection_)(corrJetP4) ) {
-	      (*type2BinningEntry)->binOffsetEnergySum_.mex   += (rawJetP4.px() - rawJetP4offsetCorr.px());
-	      (*type2BinningEntry)->binOffsetEnergySum_.mey   += (rawJetP4.py() - rawJetP4offsetCorr.py());
-	      (*type2BinningEntry)->binOffsetEnergySum_.sumet += (rawJetP4.Et() - rawJetP4offsetCorr.Et());
-	    }
-	  }
-	}
+          for (typename std::vector<type2BinningEntryType*>::iterator type2BinningEntry = type2Binning_.begin();
+               type2BinningEntry != type2Binning_.end();
+               ++type2BinningEntry) {
+            if (!(*type2BinningEntry)->binSelection_ || (*(*type2BinningEntry)->binSelection_)(corrJetP4)) {
+              (*type2BinningEntry)->binOffsetEnergySum_.mex += (rawJetP4.px() - rawJetP4offsetCorr.px());
+              (*type2BinningEntry)->binOffsetEnergySum_.mey += (rawJetP4.py() - rawJetP4offsetCorr.py());
+              (*type2BinningEntry)->binOffsetEnergySum_.sumet += (rawJetP4.Et() - rawJetP4offsetCorr.Et());
+            }
+          }
+        }
 
-//--- MET balances momentum of reconstructed particles,
-//    hence correction to jets and corresponding Type 1 MET correction are of opposite sign
-	type1Correction->mex   -= (corrJetP4.px() - rawJetP4offsetCorr.px());
-	type1Correction->mey   -= (corrJetP4.py() - rawJetP4offsetCorr.py());
-	type1Correction->sumet += (corrJetP4.Et() - rawJetP4offsetCorr.Et());
+        //--- MET balances momentum of reconstructed particles,
+        //    hence correction to jets and corresponding Type 1 MET correction are of opposite sign
+        type1Correction->mex -= (corrJetP4.px() - rawJetP4offsetCorr.px());
+        type1Correction->mey -= (corrJetP4.py() - rawJetP4offsetCorr.py());
+        type1Correction->sumet += (corrJetP4.Et() - rawJetP4offsetCorr.Et());
       } else {
-	for ( typename std::vector<type2BinningEntryType*>::iterator type2BinningEntry = type2Binning_.begin();
-	      type2BinningEntry != type2Binning_.end(); ++type2BinningEntry ) {
-	  if ( !(*type2BinningEntry)->binSelection_ || (*(*type2BinningEntry)->binSelection_)(corrJetP4) ) {
-	    (*type2BinningEntry)->binUnclEnergySum_.mex   += rawJetP4.px();
-	    (*type2BinningEntry)->binUnclEnergySum_.mey   += rawJetP4.py();
-	    (*type2BinningEntry)->binUnclEnergySum_.sumet += rawJetP4.Et();
-	  }
-	}
+        for (typename std::vector<type2BinningEntryType*>::iterator type2BinningEntry = type2Binning_.begin();
+             type2BinningEntry != type2Binning_.end();
+             ++type2BinningEntry) {
+          if (!(*type2BinningEntry)->binSelection_ || (*(*type2BinningEntry)->binSelection_)(corrJetP4)) {
+            (*type2BinningEntry)->binUnclEnergySum_.mex += rawJetP4.px();
+            (*type2BinningEntry)->binUnclEnergySum_.mey += rawJetP4.py();
+            (*type2BinningEntry)->binUnclEnergySum_.sumet += rawJetP4.Et();
+          }
+        }
       }
     }
 
-//--- add
-//     o Type 1 MET correction                (difference corrected-uncorrected jet energy for jets of (corrected) Pt > 10 GeV)
-//     o momentum sum of "unclustered energy" (jets of (corrected) Pt < 10 GeV)
-//     o momentum sum of "offset energy"      (sum of energy attributed to pile-up/underlying event)
-//    to the event
+    //--- add
+    //     o Type 1 MET correction                (difference corrected-uncorrected jet energy for jets of (corrected) Pt > 10 GeV)
+    //     o momentum sum of "unclustered energy" (jets of (corrected) Pt < 10 GeV)
+    //     o momentum sum of "offset energy"      (sum of energy attributed to pile-up/underlying event)
+    //    to the event
     evt.put(std::move(type1Correction), "type1");
-    for ( typename std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
-	  type2BinningEntry != type2Binning_.end(); ++type2BinningEntry ) {
-      evt.put(std::unique_ptr<CorrMETData>(new CorrMETData((*type2BinningEntry)->binUnclEnergySum_)), (*type2BinningEntry)->getInstanceLabel_full("type2"));
-      evt.put(std::unique_ptr<CorrMETData>(new CorrMETData((*type2BinningEntry)->binOffsetEnergySum_)), (*type2BinningEntry)->getInstanceLabel_full("offset"));
+    for (typename std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
+         type2BinningEntry != type2Binning_.end();
+         ++type2BinningEntry) {
+      evt.put(std::unique_ptr<CorrMETData>(new CorrMETData((*type2BinningEntry)->binUnclEnergySum_)),
+              (*type2BinningEntry)->getInstanceLabel_full("type2"));
+      evt.put(std::unique_ptr<CorrMETData>(new CorrMETData((*type2BinningEntry)->binOffsetEnergySum_)),
+              (*type2BinningEntry)->getInstanceLabel_full("offset"));
     }
   }
 
@@ -266,45 +257,40 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
   edm::EDGetTokenT<std::vector<T> > token_;
 
   edm::InputTag offsetCorrLabel_;
-  edm::EDGetTokenT<reco::JetCorrector> offsetCorrToken_; // e.g. 'ak5CaloJetL1Fastjet'
+  edm::EDGetTokenT<reco::JetCorrector> offsetCorrToken_;  // e.g. 'ak5CaloJetL1Fastjet'
   edm::InputTag jetCorrLabel_;
   edm::InputTag jetCorrLabelRes_;
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrToken_;    // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrResToken_;    // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
+  edm::EDGetTokenT<reco::JetCorrector>
+      jetCorrToken_;  // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
+  edm::EDGetTokenT<reco::JetCorrector>
+      jetCorrResToken_;  // e.g. 'ak5CaloJetL1FastL2L3' (MC) / 'ak5CaloJetL1FastL2L3Residual' (Data)
   Textractor jetCorrExtractor_;
 
-  double jetCorrEtaMax_; // do not use JEC factors for |eta| above this threshold
+  double jetCorrEtaMax_;  // do not use JEC factors for |eta| above this threshold
 
-  double type1JetPtThreshold_; // threshold to distinguish between jets entering Type 1 MET correction
-                               // and jets entering "unclustered energy" sum
-                               // NOTE: threshold is applied on **corrected** jet energy (recommended default = 10 GeV)
+  double type1JetPtThreshold_;  // threshold to distinguish between jets entering Type 1 MET correction
+                                // and jets entering "unclustered energy" sum
+                                // NOTE: threshold is applied on **corrected** jet energy (recommended default = 10 GeV)
 
-  bool skipEM_; // flag to exclude jets with large fraction of electromagnetic energy (electrons/photons)
-                // from Type 1 + 2 MET corrections
+  bool skipEM_;  // flag to exclude jets with large fraction of electromagnetic energy (electrons/photons)
+                 // from Type 1 + 2 MET corrections
   double skipEMfractionThreshold_;
 
-  bool skipMuons_; // flag to subtract momentum of muons (provided muons pass selection cuts) which are within jets
-                   // from jet energy before compute JECs/propagating JECs to Type 1 + 2 MET corrections
+  bool skipMuons_;  // flag to subtract momentum of muons (provided muons pass selection cuts) which are within jets
+                    // from jet energy before compute JECs/propagating JECs to Type 1 + 2 MET corrections
   StringCutObjectSelector<reco::Candidate>* skipMuonSelection_;
 
-  struct type2BinningEntryType
-  {
-    type2BinningEntryType()
-      : binLabel_(""),
-        binSelection_(nullptr)
-    {}
+  struct type2BinningEntryType {
+    type2BinningEntryType() : binLabel_(""), binSelection_(nullptr) {}
     type2BinningEntryType(const edm::ParameterSet& cfg)
-      : binLabel_(cfg.getParameter<std::string>("binLabel")),
-        binSelection_(new StringCutObjectSelector<reco::Candidate::LorentzVector>(cfg.getParameter<std::string>("binSelection")))
-    {}
-    ~type2BinningEntryType()
-    {
-      delete binSelection_;
-    }
-    std::string getInstanceLabel_full(const std::string& instanceLabel)
-    {
+        : binLabel_(cfg.getParameter<std::string>("binLabel")),
+          binSelection_(new StringCutObjectSelector<reco::Candidate::LorentzVector>(
+              cfg.getParameter<std::string>("binSelection"))) {}
+    ~type2BinningEntryType() { delete binSelection_; }
+    std::string getInstanceLabel_full(const std::string& instanceLabel) {
       std::string retVal = instanceLabel;
-      if ( !instanceLabel.empty() && !binLabel_.empty() ) retVal.append("#");
+      if (!instanceLabel.empty() && !binLabel_.empty())
+        retVal.append("#");
       retVal.append(binLabel_);
       return retVal;
     }
@@ -317,7 +303,3 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
-
-

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -304,7 +304,7 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
     std::string getInstanceLabel_full(const std::string& instanceLabel)
     {
       std::string retVal = instanceLabel;
-      if ( instanceLabel != "" && binLabel_ != "" ) retVal.append("#");
+      if ( !instanceLabel.empty() && !binLabel_.empty() ) retVal.append("#");
       retVal.append(binLabel_);
       return retVal;
     }

--- a/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/BadPFCandidateJetsEEnoiseProducer.cc
@@ -7,7 +7,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/Event.h"
 
-#include "DataFormats/Common/interface/RefToPtr.h" 
+#include "DataFormats/Common/interface/RefToPtr.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
@@ -20,79 +20,74 @@
 #include "DataFormats/Math/interface/Point3D.h"
 
 namespace pat {
-  class BadPFCandidateJetsEEnoiseProducer : public edm::global::EDProducer<>{
+  class BadPFCandidateJetsEEnoiseProducer : public edm::global::EDProducer<> {
   public:
     explicit BadPFCandidateJetsEEnoiseProducer(const edm::ParameterSet&);
     ~BadPFCandidateJetsEEnoiseProducer() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
   private:
-    edm::EDGetTokenT<edm::View<pat::Jet> > jetsrc_;
+    edm::EDGetTokenT<edm::View<pat::Jet>> jetsrc_;
     double ptThreshold_;
     double minEtaThreshold_;
     double maxEtaThreshold_;
     bool userawPt_;
   };
-}
+}  // namespace pat
 
-
-pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const edm::ParameterSet& iConfig) :
-  jetsrc_(consumes<edm::View<pat::Jet> >(iConfig.getParameter<edm::InputTag>("jetsrc") )),
-  ptThreshold_(iConfig.getParameter<double>("ptThreshold")),
-  minEtaThreshold_(iConfig.getParameter<double>("minEtaThreshold")),
-  maxEtaThreshold_(iConfig.getParameter<double>("maxEtaThreshold")),
-  userawPt_(iConfig.getParameter<bool>("userawPt"))
-{
-  
+pat::BadPFCandidateJetsEEnoiseProducer::BadPFCandidateJetsEEnoiseProducer(const edm::ParameterSet& iConfig)
+    : jetsrc_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jetsrc"))),
+      ptThreshold_(iConfig.getParameter<double>("ptThreshold")),
+      minEtaThreshold_(iConfig.getParameter<double>("minEtaThreshold")),
+      maxEtaThreshold_(iConfig.getParameter<double>("maxEtaThreshold")),
+      userawPt_(iConfig.getParameter<bool>("userawPt")) {
   produces<std::vector<pat::Jet>>("good");
   produces<std::vector<pat::Jet>>("bad");
-  
 }
 
 pat::BadPFCandidateJetsEEnoiseProducer::~BadPFCandidateJetsEEnoiseProducer() {}
 
-void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  
+void pat::BadPFCandidateJetsEEnoiseProducer::produce(edm::StreamID,
+                                                     edm::Event& iEvent,
+                                                     const edm::EventSetup& iSetup) const {
   auto goodJets = std::make_unique<std::vector<pat::Jet>>();
   auto badJets = std::make_unique<std::vector<pat::Jet>>();
-  
-  edm::Handle<edm::View<pat::Jet> > jetcandidates;
+
+  edm::Handle<edm::View<pat::Jet>> jetcandidates;
   iEvent.getByToken(jetsrc_, jetcandidates);
-  
-  int njets   = jetcandidates->size();
- 
+
+  int njets = jetcandidates->size();
+
   // find the bad jets
-  for (int jetindex = 0; jetindex < njets; ++jetindex){
+  for (int jetindex = 0; jetindex < njets; ++jetindex) {
     edm::Ptr<pat::Jet> candjet = jetcandidates->ptrAt(jetindex);
 
     // Corrected Pt or Uncorrected Pt (It is defined from cfi file)
     double ptJet = userawPt_ ? candjet->correctedJet("Uncorrected").pt() : candjet->pt();
     double absEtaJet = std::abs(candjet->eta());
-    
-    if ( ptJet > ptThreshold_ || absEtaJet < minEtaThreshold_ || absEtaJet > maxEtaThreshold_) {
+
+    if (ptJet > ptThreshold_ || absEtaJet < minEtaThreshold_ || absEtaJet > maxEtaThreshold_) {
       // save good jets
       goodJets->emplace_back(candjet);
-    }
-    else {
+    } else {
       // save bad jets
       badJets->emplace_back(candjet);
     }
-    
   }
-  iEvent.put(std::move(goodJets),"good");
-  iEvent.put(std::move(badJets),"bad");
-  
+  iEvent.put(std::move(goodJets), "good");
+  iEvent.put(std::move(badJets), "bad");
 }
 
 void pat::BadPFCandidateJetsEEnoiseProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("jetsrc",edm::InputTag("slimmedJets"));
-  desc.add<bool>("userawPt",true);
-  desc.add<double>("ptThreshold",50.0);
-  desc.add<double>("minEtaThreshold",2.65);
-  desc.add<double>("maxEtaThreshold",3.139);
+  desc.add<edm::InputTag>("jetsrc", edm::InputTag("slimmedJets"));
+  desc.add<bool>("userawPt", true);
+  desc.add<double>("ptThreshold", 50.0);
+  desc.add<double>("minEtaThreshold", 2.65);
+  desc.add<double>("maxEtaThreshold", 3.139);
 
-  descriptions.add("BadPFCandidateJetsEEnoiseProducer",desc);
+  descriptions.add("BadPFCandidateJetsEEnoiseProducer", desc);
 }
 
 using pat::BadPFCandidateJetsEEnoiseProducer;

--- a/JetMETCorrections/Type1MET/plugins/CorrectedCaloMETProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/CorrectedCaloMETProducer.cc
@@ -18,51 +18,43 @@
 #include <vector>
 
 //____________________________________________________________________________||
-class CorrectedCaloMETProducer : public edm::stream::EDProducer<>
-{
-
+class CorrectedCaloMETProducer : public edm::stream::EDProducer<> {
 public:
-
   explicit CorrectedCaloMETProducer(const edm::ParameterSet& cfg)
-    : corrector(),
-      token_(consumes<METCollection>(cfg.getParameter<edm::InputTag>("src")))
-  {
+      : corrector(), token_(consumes<METCollection>(cfg.getParameter<edm::InputTag>("src"))) {
     std::vector<edm::InputTag> corrInputTags = cfg.getParameter<std::vector<edm::InputTag> >("srcCorrections");
     std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens;
-    for (std::vector<edm::InputTag>::const_iterator inputTag = corrInputTags.begin(); inputTag != corrInputTags.end(); ++inputTag) {
+    for (std::vector<edm::InputTag>::const_iterator inputTag = corrInputTags.begin(); inputTag != corrInputTags.end();
+         ++inputTag) {
       corrTokens.push_back(consumes<CorrMETData>(*inputTag));
     }
-    
+
     corrector.setCorTokens(corrTokens);
 
     produces<METCollection>("");
   }
 
-  ~CorrectedCaloMETProducer() override { }
+  ~CorrectedCaloMETProducer() override {}
 
 private:
-
   AddCorrectionsToGenericMET corrector;
 
   typedef std::vector<reco::CaloMET> METCollection;
 
   edm::EDGetTokenT<METCollection> token_;
- 
 
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     edm::Handle<METCollection> srcMETCollection;
     evt.getByToken(token_, srcMETCollection);
 
     const reco::CaloMET& srcMET = (*srcMETCollection)[0];
-    
+
     reco::CaloMET outMET = corrector.getCorrectedCaloMET(srcMET, evt, es);
 
     std::unique_ptr<METCollection> product(new METCollection);
     product->push_back(outMET);
     evt.put(std::move(product));
   }
-
 };
 
 //____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/plugins/CorrectedPFMETProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/CorrectedPFMETProducer.cc
@@ -22,60 +22,52 @@
 #include <vector>
 
 //____________________________________________________________________________||
-class CorrectedPFMETProducer : public edm::stream::EDProducer<>
-{
-
+class CorrectedPFMETProducer : public edm::stream::EDProducer<> {
 public:
-
   explicit CorrectedPFMETProducer(const edm::ParameterSet& cfg)
-    : corrector(),
-      token_(consumes<METCollection>(cfg.getParameter<edm::InputTag>("src")))
-  {
+      : corrector(), token_(consumes<METCollection>(cfg.getParameter<edm::InputTag>("src"))) {
     std::vector<edm::InputTag> corrInputTags = cfg.getParameter<std::vector<edm::InputTag> >("srcCorrections");
     std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens;
-    for (std::vector<edm::InputTag>::const_iterator inputTag = corrInputTags.begin(); inputTag != corrInputTags.end(); ++inputTag) {
+    for (std::vector<edm::InputTag>::const_iterator inputTag = corrInputTags.begin(); inputTag != corrInputTags.end();
+         ++inputTag) {
       corrTokens.push_back(consumes<CorrMETData>(*inputTag));
     }
-    
+
     corrector.setCorTokens(corrTokens);
 
     produces<METCollection>("");
   }
 
-  ~CorrectedPFMETProducer() override { }
+  ~CorrectedPFMETProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src",edm::InputTag("pfMet", ""));
+    desc.add<edm::InputTag>("src", edm::InputTag("pfMet", ""));
     std::vector<edm::InputTag> tmpv;
-    tmpv.push_back( edm::InputTag("corrPfMetType1", "type1") );
-    desc.add<std::vector<edm::InputTag> >("srcCorrections",tmpv);
-    descriptions.add(defaultModuleLabel<CorrectedPFMETProducer>(),desc);
+    tmpv.push_back(edm::InputTag("corrPfMetType1", "type1"));
+    desc.add<std::vector<edm::InputTag> >("srcCorrections", tmpv);
+    descriptions.add(defaultModuleLabel<CorrectedPFMETProducer>(), desc);
   }
 
 private:
-
   AddCorrectionsToGenericMET corrector;
 
   typedef std::vector<reco::PFMET> METCollection;
 
   edm::EDGetTokenT<METCollection> token_;
- 
 
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     edm::Handle<METCollection> srcMETCollection;
     evt.getByToken(token_, srcMETCollection);
 
     const reco::PFMET& srcMET = (*srcMETCollection)[0];
-        
-    reco::PFMET outMET= corrector.getCorrectedPFMET(srcMET, evt, es);
-    
+
+    reco::PFMET outMET = corrector.getCorrectedPFMET(srcMET, evt, es);
+
     std::unique_ptr<METCollection> product(new METCollection);
     product->push_back(outMET);
     evt.put(std::move(product));
   }
-
 };
 
 //____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/plugins/JetCleanerForType1MET.cc
+++ b/JetMETCorrections/Type1MET/plugins/JetCleanerForType1MET.cc
@@ -10,4 +10,3 @@ typedef JetCleanerForType1METT<reco::PFJet, JetCorrExtractorT<reco::PFJet> > PFJ
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(PFJetCleanerForType1MET);
-

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrDBInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrDBInputProducer.cc
@@ -13,127 +13,125 @@
 
 #include <TString.h>
 
-int MultShiftMETcorrDBInputProducer::translateTypeToAbsPdgId( reco::PFCandidate::ParticleType type ) {
-  switch( type ) {
-  case reco::PFCandidate::ParticleType::h: return 211; // pi+
-  case reco::PFCandidate::ParticleType::e: return 11;
-  case reco::PFCandidate::ParticleType::mu: return 13;
-  case reco::PFCandidate::ParticleType::gamma: return 22;
-  case reco::PFCandidate::ParticleType::h0: return 130; // K_L0
-  case reco::PFCandidate::ParticleType::h_HF: return 1; // dummy pdg code
-  case reco::PFCandidate::ParticleType::egamma_HF: return 2; // dummy pdg code
-  case reco::PFCandidate::ParticleType::X:
-  default: return 0;
+int MultShiftMETcorrDBInputProducer::translateTypeToAbsPdgId(reco::PFCandidate::ParticleType type) {
+  switch (type) {
+    case reco::PFCandidate::ParticleType::h:
+      return 211;  // pi+
+    case reco::PFCandidate::ParticleType::e:
+      return 11;
+    case reco::PFCandidate::ParticleType::mu:
+      return 13;
+    case reco::PFCandidate::ParticleType::gamma:
+      return 22;
+    case reco::PFCandidate::ParticleType::h0:
+      return 130;  // K_L0
+    case reco::PFCandidate::ParticleType::h_HF:
+      return 1;  // dummy pdg code
+    case reco::PFCandidate::ParticleType::egamma_HF:
+      return 2;  // dummy pdg code
+    case reco::PFCandidate::ParticleType::X:
+    default:
+      return 0;
   }
 }
 
+MultShiftMETcorrDBInputProducer::MultShiftMETcorrDBInputProducer(const edm::ParameterSet& cfg)
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
+  mPayloadName = cfg.getParameter<std::string>("payloadName");
+  mSampleType = (cfg.exists("sampleType")) ? cfg.getParameter<std::string>("sampleType") : "MC";
+  mIsData = cfg.getParameter<bool>("isData");
 
-MultShiftMETcorrDBInputProducer::MultShiftMETcorrDBInputProducer(const edm::ParameterSet& cfg):
-  moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
-  
-  mPayloadName    = cfg.getParameter<std::string>("payloadName");
-  mSampleType     = (cfg.exists("sampleType")) ? cfg.getParameter< std::string >("sampleType"): "MC";
-  mIsData         = cfg.getParameter< bool >("isData");
+  pflow_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("srcPFlow"));
+  vertices_ = consumes<edm::View<reco::Vertex> >(cfg.getParameter<edm::InputTag>("vertexCollection"));
 
-  pflow_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter< edm::InputTag >("srcPFlow") );
-  vertices_ = consumes<edm::View<reco::Vertex> >( cfg.getParameter< edm::InputTag >("vertexCollection") );
-
-  etaMin_.clear(); 
+  etaMin_.clear();
   etaMax_.clear();
 
   produces<CorrMETData>();
-
-
 }
 
-MultShiftMETcorrDBInputProducer::~MultShiftMETcorrDBInputProducer()
-{
-}
+MultShiftMETcorrDBInputProducer::~MultShiftMETcorrDBInputProducer() {}
 
-void MultShiftMETcorrDBInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void MultShiftMETcorrDBInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // Get para.s from DB
   edm::ESHandle<MEtXYcorrectParametersCollection> MEtXYcorParaColl;
-  es.get<MEtXYcorrectRecord>().get(mPayloadName,MEtXYcorParaColl);
+  es.get<MEtXYcorrectRecord>().get(mPayloadName, MEtXYcorParaColl);
 
   // get the sections from Collection (pair of section and METCorr.Par class)
   std::vector<MEtXYcorrectParametersCollection::key_type> keys;
   // save level to keys for each METParameter in METParameter collection
-  MEtXYcorParaColl->validKeys( keys );
-
+  MEtXYcorParaColl->validKeys(keys);
 
   //get primary vertices
   edm::Handle<edm::View<reco::Vertex> > hpv;
-  evt.getByToken( vertices_, hpv );
-  if(!hpv.isValid()) {
+  evt.getByToken(vertices_, hpv);
+  if (!hpv.isValid()) {
     edm::LogError("MultShiftMETcorrDBInputProducer::produce") << "could not find vertex collection ";
   }
   std::vector<reco::Vertex> goodVertices;
   for (unsigned i = 0; i < hpv->size(); i++) {
-    if ( (*hpv)[i].ndof() > 4 &&
-       ( fabs((*hpv)[i].z()) <= 24. ) &&
-       ( fabs((*hpv)[i].position().rho()) <= 2.0 ) )
-       goodVertices.push_back((*hpv)[i]);
+    if ((*hpv)[i].ndof() > 4 && (fabs((*hpv)[i].z()) <= 24.) && (fabs((*hpv)[i].position().rho()) <= 2.0))
+      goodVertices.push_back((*hpv)[i]);
   }
   int ngoodVertices = goodVertices.size();
 
   edm::Handle<edm::View<reco::Candidate> > particleFlow;
   evt.getByToken(pflow_, particleFlow);
 
-
   //loop over all constituent types and sum each correction
   //std::unique_ptr<CorrMETData> metCorr(new CorrMETData());
   std::unique_ptr<CorrMETData> metCorr(new CorrMETData());
-  
-  double corx=0.;
-  double cory=0.;
 
+  double corx = 0.;
+  double cory = 0.;
 
   // check DB
-  for ( std::vector<MEtXYcorrectParametersCollection::key_type>::const_iterator ikey = keys.begin();
-	   ikey != keys.end(); ++ikey ) {
-    if(mIsData)
-    {
-      if(!MEtXYcorParaColl->isShiftData(*ikey) )
-	throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
-	  << "DB is not for Data. Set proper option: \"corrPfMetXYMultDB.isData\" !!\n";
-    }else{
-      if( MEtXYcorParaColl->isShiftData(*ikey) )
-	throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
-	  << "DB is for Data. Set proper option: \"corrPfMetXYMultDB.isData\" !!\n";
+  for (std::vector<MEtXYcorrectParametersCollection::key_type>::const_iterator ikey = keys.begin(); ikey != keys.end();
+       ++ikey) {
+    if (mIsData) {
+      if (!MEtXYcorParaColl->isShiftData(*ikey))
+        throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
+            << "DB is not for Data. Set proper option: \"corrPfMetXYMultDB.isData\" !!\n";
+    } else {
+      if (MEtXYcorParaColl->isShiftData(*ikey))
+        throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
+            << "DB is for Data. Set proper option: \"corrPfMetXYMultDB.isData\" !!\n";
     }
   }
 
-  for ( std::vector<MEtXYcorrectParametersCollection::key_type>::const_iterator ikey = keys.begin();
-	   ikey != keys.end(); ++ikey ) {
-
-    if( !mIsData){
-
-      if(mSampleType == "MC"){
-        if(!MEtXYcorParaColl->isShiftMC(*ikey)) continue;
-      }else if(mSampleType == "DY"){
-        if(!MEtXYcorParaColl->isShiftDY(*ikey)) continue;
-      }else if(mSampleType == "TTJets"){
-        if(!MEtXYcorParaColl->isShiftTTJets(*ikey)) continue;
-      }else if(mSampleType == "WJets"){
-        if(!MEtXYcorParaColl->isShiftWJets(*ikey)) continue;
-      }else throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
-	<< "SampleType: "<<mSampleType<<" is not reserved !!!\n";
+  for (std::vector<MEtXYcorrectParametersCollection::key_type>::const_iterator ikey = keys.begin(); ikey != keys.end();
+       ++ikey) {
+    if (!mIsData) {
+      if (mSampleType == "MC") {
+        if (!MEtXYcorParaColl->isShiftMC(*ikey))
+          continue;
+      } else if (mSampleType == "DY") {
+        if (!MEtXYcorParaColl->isShiftDY(*ikey))
+          continue;
+      } else if (mSampleType == "TTJets") {
+        if (!MEtXYcorParaColl->isShiftTTJets(*ikey))
+          continue;
+      } else if (mSampleType == "WJets") {
+        if (!MEtXYcorParaColl->isShiftWJets(*ikey))
+          continue;
+      } else
+        throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
+            << "SampleType: " << mSampleType << " is not reserved !!!\n";
     }
 
-    std::string sectionName= MEtXYcorParaColl->findLabel(*ikey);
-    MEtXYcorrectParameters const & MEtXYcorParams = (*MEtXYcorParaColl)[*ikey];
+    std::string sectionName = MEtXYcorParaColl->findLabel(*ikey);
+    MEtXYcorrectParameters const& MEtXYcorParams = (*MEtXYcorParaColl)[*ikey];
 
     counts_ = 0;
-    sumPt_  = 0;
+    sumPt_ = 0;
 
     for (unsigned i = 0; i < particleFlow->size(); ++i) {
       const reco::Candidate& c = particleFlow->at(i);
-      if (abs(c.pdgId())== translateTypeToAbsPdgId(reco::PFCandidate::ParticleType( MEtXYcorParams.definitions().PtclType() ))) {
-        if ((c.eta()>MEtXYcorParams.record(0).xMin(0)) and (c.eta()<MEtXYcorParams.record(0).xMax(0))) {
-          counts_ +=1;
-          sumPt_  +=c.pt();
+      if (abs(c.pdgId()) ==
+          translateTypeToAbsPdgId(reco::PFCandidate::ParticleType(MEtXYcorParams.definitions().PtclType()))) {
+        if ((c.eta() > MEtXYcorParams.record(0).xMin(0)) and (c.eta() < MEtXYcorParams.record(0).xMax(0))) {
+          counts_ += 1;
+          sumPt_ += c.pt();
           continue;
         }
       }
@@ -141,42 +139,38 @@ void MultShiftMETcorrDBInputProducer::produce(edm::Event& evt, const edm::EventS
     double val(0.);
     unsigned parVar = MEtXYcorParams.definitions().parVar(0);
 
-    if ( parVar ==0) {
+    if (parVar == 0) {
       val = counts_;
 
-    }else if ( parVar ==1) { 
-      val = ngoodVertices; 
+    } else if (parVar == 1) {
+      val = ngoodVertices;
 
-    }else if ( parVar ==2) { 
+    } else if (parVar == 2) {
       val = sumPt_;
 
-    }else{
-	throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
-	  << "parVar: "<<parVar<<" is not reserved !!!\n";
+    } else {
+      throw cms::Exception("MultShiftMETcorrDBInputProducer::produce")
+          << "parVar: " << parVar << " is not reserved !!!\n";
     }
 
-    formula_x_.reset( new TF1("corrPx", MEtXYcorParams.definitions().formula().c_str()));
-    formula_y_.reset( new TF1("corrPy", MEtXYcorParams.definitions().formula().c_str()));
+    formula_x_.reset(new TF1("corrPx", MEtXYcorParams.definitions().formula().c_str()));
+    formula_y_.reset(new TF1("corrPy", MEtXYcorParams.definitions().formula().c_str()));
 
-    for( unsigned i(0); i<MEtXYcorParams.record(0).nParameters(); i++)
-    {
-      formula_x_->SetParameter(i,MEtXYcorParams.record(0).parameter(i));
+    for (unsigned i(0); i < MEtXYcorParams.record(0).nParameters(); i++) {
+      formula_x_->SetParameter(i, MEtXYcorParams.record(0).parameter(i));
     }
-    for( unsigned i(0); i<MEtXYcorParams.record(1).nParameters(); i++)
-    {
-      formula_y_->SetParameter(i,MEtXYcorParams.record(1).parameter(i));
+    for (unsigned i(0); i < MEtXYcorParams.record(1).nParameters(); i++) {
+      formula_y_->SetParameter(i, MEtXYcorParams.record(1).parameter(i));
     }
 
     corx -= formula_x_->Eval(val);
     cory -= formula_y_->Eval(val);
 
-  } //end loop over corrections
-
+  }  //end loop over corrections
 
   metCorr->mex = corx;
   metCorr->mey = cory;
   evt.put(std::move(metCorr), "");
-  
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrDBInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrDBInputProducer.h
@@ -29,20 +29,16 @@
 #include <string>
 #include <vector>
 
-class MultShiftMETcorrDBInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class MultShiftMETcorrDBInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit MultShiftMETcorrDBInputProducer(const edm::ParameterSet&);
   ~MultShiftMETcorrDBInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  static int translateTypeToAbsPdgId( reco::PFCandidate::ParticleType type );
+  static int translateTypeToAbsPdgId(reco::PFCandidate::ParticleType type);
 
-
-  edm::EDGetTokenT<edm::View<reco::Candidate> > pflow_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> pflow_;
   edm::EDGetTokenT<edm::View<reco::Vertex>> vertices_;
   std::string moduleLabel_;
   std::string mPayloadName;
@@ -54,12 +50,8 @@ class MultShiftMETcorrDBInputProducer : public edm::stream::EDProducer<>
   std::vector<double> etaMin_, etaMax_;
   int counts_;
   double sumPt_;
-  std::unique_ptr< TF1 > formula_x_;
-  std::unique_ptr< TF1 > formula_y_;
+  std::unique_ptr<TF1> formula_x_;
+  std::unique_ptr<TF1> formula_y_;
 };
 
 #endif
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.cc
@@ -9,47 +9,59 @@
 
 #include <TString.h>
 
-int MultShiftMETcorrInputProducer::translateTypeToAbsPdgId( reco::PFCandidate::ParticleType type ) {
-  switch( type ) {
-  case reco::PFCandidate::ParticleType::h: return 211; // pi+
-  case reco::PFCandidate::ParticleType::e: return 11;
-  case reco::PFCandidate::ParticleType::mu: return 13;
-  case reco::PFCandidate::ParticleType::gamma: return 22;
-  case reco::PFCandidate::ParticleType::h0: return 130; // K_L0
-  case reco::PFCandidate::ParticleType::h_HF: return 1; // dummy pdg code
-  case reco::PFCandidate::ParticleType::egamma_HF: return 2; // dummy pdg code
-  case reco::PFCandidate::ParticleType::X:
-  default: return 0;
+int MultShiftMETcorrInputProducer::translateTypeToAbsPdgId(reco::PFCandidate::ParticleType type) {
+  switch (type) {
+    case reco::PFCandidate::ParticleType::h:
+      return 211;  // pi+
+    case reco::PFCandidate::ParticleType::e:
+      return 11;
+    case reco::PFCandidate::ParticleType::mu:
+      return 13;
+    case reco::PFCandidate::ParticleType::gamma:
+      return 22;
+    case reco::PFCandidate::ParticleType::h0:
+      return 130;  // K_L0
+    case reco::PFCandidate::ParticleType::h_HF:
+      return 1;  // dummy pdg code
+    case reco::PFCandidate::ParticleType::egamma_HF:
+      return 2;  // dummy pdg code
+    case reco::PFCandidate::ParticleType::X:
+    default:
+      return 0;
   }
 }
 
-
-MultShiftMETcorrInputProducer::MultShiftMETcorrInputProducer(const edm::ParameterSet& cfg):
-  moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
-  
-  pflow_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter< edm::InputTag >("srcPFlow") );
-  vertices_ = consumes<edm::View<reco::Vertex> >( cfg.getParameter< edm::InputTag >("vertexCollection") );
+MultShiftMETcorrInputProducer::MultShiftMETcorrInputProducer(const edm::ParameterSet& cfg)
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
+  pflow_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("srcPFlow"));
+  vertices_ = consumes<edm::View<reco::Vertex> >(cfg.getParameter<edm::InputTag>("vertexCollection"));
 
   cfgCorrParameters_ = cfg.getParameter<std::vector<edm::ParameterSet> >("parameters");
-  etaMin_.clear(); 
+  etaMin_.clear();
   etaMax_.clear();
-  type_.clear(); 
-  varType_.clear(); 
+  type_.clear();
+  varType_.clear();
 
   produces<CorrMETData>();
 
-  for (std::vector<edm::ParameterSet>::const_iterator v = cfgCorrParameters_.begin(); v!=cfgCorrParameters_.end(); v++) {
+  for (std::vector<edm::ParameterSet>::const_iterator v = cfgCorrParameters_.begin(); v != cfgCorrParameters_.end();
+       v++) {
     TString corrPxFormula = v->getParameter<std::string>("fx");
     TString corrPyFormula = v->getParameter<std::string>("fy");
     std::vector<double> corrPxParams = v->getParameter<std::vector<double> >("px");
     std::vector<double> corrPyParams = v->getParameter<std::vector<double> >("py");
 
-    formula_x_.push_back( std::unique_ptr<TF1>(new TF1(std::string(moduleLabel_).append("_").append(v->getParameter<std::string>("name")).append("_corrPx").c_str(), v->getParameter<std::string>("fx").c_str()) ) );
-    formula_y_.push_back( std::unique_ptr<TF1>(new TF1(std::string(moduleLabel_).append("_").append(v->getParameter<std::string>("name")).append("_corrPy").c_str(), v->getParameter<std::string>("fy").c_str()) ) );
+    formula_x_.push_back(std::unique_ptr<TF1>(new TF1(
+        std::string(moduleLabel_).append("_").append(v->getParameter<std::string>("name")).append("_corrPx").c_str(),
+        v->getParameter<std::string>("fx").c_str())));
+    formula_y_.push_back(std::unique_ptr<TF1>(new TF1(
+        std::string(moduleLabel_).append("_").append(v->getParameter<std::string>("name")).append("_corrPy").c_str(),
+        v->getParameter<std::string>("fy").c_str())));
 
-    for (unsigned i=0; i<corrPxParams.size();i++) formula_x_.back()->SetParameter(i, corrPxParams[i]);
-    for (unsigned i=0; i<corrPyParams.size();i++) formula_y_.back()->SetParameter(i, corrPyParams[i]);
+    for (unsigned i = 0; i < corrPxParams.size(); i++)
+      formula_x_.back()->SetParameter(i, corrPxParams[i]);
+    for (unsigned i = 0; i < corrPyParams.size(); i++)
+      formula_y_.back()->SetParameter(i, corrPyParams[i]);
 
     counts_.push_back(0);
     sumPt_.push_back(0.);
@@ -60,75 +72,71 @@ MultShiftMETcorrInputProducer::MultShiftMETcorrInputProducer(const edm::Paramete
   }
 }
 
-MultShiftMETcorrInputProducer::~MultShiftMETcorrInputProducer()
-{
-}
+MultShiftMETcorrInputProducer::~MultShiftMETcorrInputProducer() {}
 
-void MultShiftMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void MultShiftMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   //get primary vertices
   edm::Handle<edm::View<reco::Vertex> > hpv;
-  evt.getByToken( vertices_, hpv );
-  if(!hpv.isValid()) {
+  evt.getByToken(vertices_, hpv);
+  if (!hpv.isValid()) {
     edm::LogError("MultShiftMETcorrInputProducer::produce") << "could not find vertex collection ";
   }
   std::vector<reco::Vertex> goodVertices;
   for (unsigned i = 0; i < hpv->size(); i++) {
-    if ( (*hpv)[i].ndof() > 4 &&
-       ( fabs((*hpv)[i].z()) <= 24. ) &&
-       ( fabs((*hpv)[i].position().rho()) <= 2.0 ) )
-       goodVertices.push_back((*hpv)[i]);
+    if ((*hpv)[i].ndof() > 4 && (fabs((*hpv)[i].z()) <= 24.) && (fabs((*hpv)[i].position().rho()) <= 2.0))
+      goodVertices.push_back((*hpv)[i]);
   }
   int ngoodVertices = goodVertices.size();
 
-  for (unsigned i=0;i<counts_.size();i++) counts_[i]=0;
-  for (unsigned i=0;i<sumPt_.size();i++) sumPt_[i]=0.;
+  for (unsigned i = 0; i < counts_.size(); i++)
+    counts_[i] = 0;
+  for (unsigned i = 0; i < sumPt_.size(); i++)
+    sumPt_[i] = 0.;
 
   edm::Handle<edm::View<reco::Candidate> > particleFlow;
   evt.getByToken(pflow_, particleFlow);
   for (unsigned i = 0; i < particleFlow->size(); ++i) {
     const reco::Candidate& c = particleFlow->at(i);
-    for (unsigned j=0; j<type_.size(); j++) {
-
-      if (abs(c.pdgId())== translateTypeToAbsPdgId(reco::PFCandidate::ParticleType(type_[j]))) {
-        if ((c.eta()>etaMin_[j]) and (c.eta()<etaMax_[j])) {
-          counts_[j]+=1;
-          sumPt_[j]+=c.pt();
+    for (unsigned j = 0; j < type_.size(); j++) {
+      if (abs(c.pdgId()) == translateTypeToAbsPdgId(reco::PFCandidate::ParticleType(type_[j]))) {
+        if ((c.eta() > etaMin_[j]) and (c.eta() < etaMax_[j])) {
+          counts_[j] += 1;
+          sumPt_[j] += c.pt();
           continue;
         }
       }
-    } 
+    }
   }
 
   //MM: loop over all constituent types and sum each correction
   std::unique_ptr<CorrMETData> metCorr(new CorrMETData());
-  
-  double corx=0.;
-  double cory=0.;
 
-  for (std::vector<edm::ParameterSet>::const_iterator v = cfgCorrParameters_.begin(); v!=cfgCorrParameters_.end(); v++) {
-    unsigned j=v-cfgCorrParameters_.begin();
- 
+  double corx = 0.;
+  double cory = 0.;
+
+  for (std::vector<edm::ParameterSet>::const_iterator v = cfgCorrParameters_.begin(); v != cfgCorrParameters_.end();
+       v++) {
+    unsigned j = v - cfgCorrParameters_.begin();
+
     double val(0.);
-    if (varType_[j]==0) {
+    if (varType_[j] == 0) {
       val = counts_[j];
-    } 
-    if (varType_[j]==1) {
-      val = ngoodVertices; 
-    } 
-    if (varType_[j]==2) {
+    }
+    if (varType_[j] == 1) {
+      val = ngoodVertices;
+    }
+    if (varType_[j] == 2) {
       val = sumPt_[j];
     }
 
     corx -= formula_x_[j]->Eval(val);
-    cory -= formula_y_[j]->Eval(val);  
+    cory -= formula_y_[j]->Eval(val);
 
-  } //end loop over corrections
+  }  //end loop over corrections
 
   metCorr->mex = corx;
   metCorr->mey = cory;
   evt.put(std::move(metCorr), "");
-  
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.h
@@ -28,20 +28,16 @@
 #include <string>
 #include <vector>
 
-class MultShiftMETcorrInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class MultShiftMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit MultShiftMETcorrInputProducer(const edm::ParameterSet&);
   ~MultShiftMETcorrInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  static int translateTypeToAbsPdgId( reco::PFCandidate::ParticleType type );
+  static int translateTypeToAbsPdgId(reco::PFCandidate::ParticleType type);
 
-
-  edm::EDGetTokenT<edm::View<reco::Candidate> > pflow_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> pflow_;
   edm::EDGetTokenT<edm::View<reco::Vertex>> vertices_;
   std::string moduleLabel_;
 
@@ -50,12 +46,8 @@ class MultShiftMETcorrInputProducer : public edm::stream::EDProducer<>
   std::vector<double> etaMin_, etaMax_;
   std::vector<int> type_, counts_, varType_;
   std::vector<double> sumPt_;
-  std::vector<std::unique_ptr<TF1> > formula_x_;
-  std::vector<std::unique_ptr<TF1> > formula_y_;
+  std::vector<std::unique_ptr<TF1>> formula_x_;
+  std::vector<std::unique_ptr<TF1>> formula_y_;
 };
 
 #endif
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.cc
@@ -5,21 +5,19 @@
 #include "DataFormats/METReco/interface/CorrMETData.h"
 
 MuonMETcorrInputProducer::MuonMETcorrInputProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   token_ = consumes<reco::MuonCollection>(cfg.getParameter<edm::InputTag>("src"));
-  muonCorrectionMapToken_ = consumes<edm::ValueMap<reco::MuonMETCorrectionData> >(cfg.getParameter<edm::InputTag>("srcMuonCorrections"));
+  muonCorrectionMapToken_ =
+      consumes<edm::ValueMap<reco::MuonMETCorrectionData> >(cfg.getParameter<edm::InputTag>("srcMuonCorrections"));
 
   produces<CorrMETData>();
 }
 
-MuonMETcorrInputProducer::~MuonMETcorrInputProducer()
-{
-// nothing to be done yet...
+MuonMETcorrInputProducer::~MuonMETcorrInputProducer() {
+  // nothing to be done yet...
 }
 
-void MuonMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void MuonMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   std::unique_ptr<CorrMETData> unclEnergySum(new CorrMETData());
 
   edm::Handle<reco::MuonCollection> muons;
@@ -29,27 +27,27 @@ void MuonMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& e
   edm::Handle<MuonMETCorrectionMap> muonCorrections;
   evt.getByToken(muonCorrectionMapToken_, muonCorrections);
 
-//--- sum muon corrections. 
-//
-//    NOTE: MET = -(jets + muon corrections + "unclustered energy"),
-//          so "unclustered energy" = -(MET + jets + muons),
-//          i.e. muon corrections enter the sum of "unclustered energy" with negative sign.
-//
+  //--- sum muon corrections.
+  //
+  //    NOTE: MET = -(jets + muon corrections + "unclustered energy"),
+  //          so "unclustered energy" = -(MET + jets + muons),
+  //          i.e. muon corrections enter the sum of "unclustered energy" with negative sign.
+  //
   int numMuons = muons->size();
-  for ( int muonIndex = 0; muonIndex < numMuons; ++muonIndex ) {
+  for (int muonIndex = 0; muonIndex < numMuons; ++muonIndex) {
     const reco::Muon& muon = muons->at(muonIndex);
-	
+
     reco::MuonRef muonRef(muons, muonIndex);
 
     reco::MuonMETCorrectionData muonCorrection = (*muonCorrections)[muonRef];
-    if ( muonCorrection.type() != reco::MuonMETCorrectionData::NotUsed ) {
-      unclEnergySum->mex   -= muon.px();
-      unclEnergySum->mey   -= muon.py();
+    if (muonCorrection.type() != reco::MuonMETCorrectionData::NotUsed) {
+      unclEnergySum->mex -= muon.px();
+      unclEnergySum->mey -= muon.py();
       unclEnergySum->sumet -= muon.pt();
     }
   }
 
-//--- add sum of muon corrections to the event
+  //--- add sum of muon corrections to the event
   evt.put(std::move(unclEnergySum));
 }
 

--- a/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.h
@@ -24,27 +24,18 @@
 
 #include <string>
 
-class MuonMETcorrInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class MuonMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit MuonMETcorrInputProducer(const edm::ParameterSet&);
   ~MuonMETcorrInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 
   edm::EDGetTokenT<reco::MuonCollection> token_;
   edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > muonCorrectionMapToken_;
-
 };
 
 #endif
-
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.cc
@@ -3,58 +3,50 @@
 #include "DataFormats/Common/interface/View.h"
 
 PFCandMETcorrInputProducer::PFCandMETcorrInputProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   token_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("src"));
 
-  if ( cfg.exists("binning") ) {
+  if (cfg.exists("binning")) {
     typedef std::vector<edm::ParameterSet> vParameterSet;
     vParameterSet cfgBinning = cfg.getParameter<vParameterSet>("binning");
-    for ( vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin();
-	  cfgBinningEntry != cfgBinning.end(); ++cfgBinningEntry ) {
+    for (vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin(); cfgBinningEntry != cfgBinning.end();
+         ++cfgBinningEntry) {
       binning_.emplace_back(new binningEntryType(*cfgBinningEntry));
     }
   } else {
     binning_.emplace_back(new binningEntryType());
   }
-  
-  for ( auto binningEntry = binning_.begin();
-	binningEntry != binning_.end(); ++binningEntry ) {
+
+  for (auto binningEntry = binning_.begin(); binningEntry != binning_.end(); ++binningEntry) {
     produces<CorrMETData>((*binningEntry)->binLabel_);
   }
 }
 
-PFCandMETcorrInputProducer::~PFCandMETcorrInputProducer()
-{  
-}
+PFCandMETcorrInputProducer::~PFCandMETcorrInputProducer() {}
 
-void PFCandMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  for ( auto binningEntry = binning_.begin();
-	binningEntry != binning_.end(); ++binningEntry ) {
+void PFCandMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  for (auto binningEntry = binning_.begin(); binningEntry != binning_.end(); ++binningEntry) {
     (*binningEntry)->binUnclEnergySum_ = CorrMETData();
   }
 
   typedef edm::View<reco::Candidate> CandidateView;
   edm::Handle<CandidateView> cands;
   evt.getByToken(token_, cands);
-  
-  for ( edm::View<reco::Candidate>::const_iterator cand = cands->begin();
-	cand != cands->end(); ++cand ) {
-    for ( auto binningEntry = binning_.begin();
-	  binningEntry != binning_.end(); ++binningEntry ) {
-      if ( !(*binningEntry)->binSelection_ || (*(*binningEntry)->binSelection_)(cand->p4()) ) {
-	(*binningEntry)->binUnclEnergySum_.mex   += cand->px();
-	(*binningEntry)->binUnclEnergySum_.mey   += cand->py();
-	(*binningEntry)->binUnclEnergySum_.sumet += cand->et();
+
+  for (edm::View<reco::Candidate>::const_iterator cand = cands->begin(); cand != cands->end(); ++cand) {
+    for (auto binningEntry = binning_.begin(); binningEntry != binning_.end(); ++binningEntry) {
+      if (!(*binningEntry)->binSelection_ || (*(*binningEntry)->binSelection_)(cand->p4())) {
+        (*binningEntry)->binUnclEnergySum_.mex += cand->px();
+        (*binningEntry)->binUnclEnergySum_.mey += cand->py();
+        (*binningEntry)->binUnclEnergySum_.sumet += cand->et();
       }
     }
   }
 
-//--- add momentum sum of PFCandidates not within jets ("unclustered energy") to the event
-  for ( auto binningEntry = binning_.cbegin();
-	binningEntry != binning_.cend(); ++binningEntry ) {
-    evt.put(std::unique_ptr<CorrMETData>(new CorrMETData((*binningEntry)->binUnclEnergySum_)), (*binningEntry)->binLabel_);
+  //--- add momentum sum of PFCandidates not within jets ("unclustered energy") to the event
+  for (auto binningEntry = binning_.cbegin(); binningEntry != binning_.cend(); ++binningEntry) {
+    evt.put(std::unique_ptr<CorrMETData>(new CorrMETData((*binningEntry)->binUnclEnergySum_)),
+            (*binningEntry)->binLabel_);
   }
 }
 

--- a/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
@@ -27,34 +27,25 @@
 
 #include <string>
 
-class PFCandMETcorrInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class PFCandMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit PFCandMETcorrInputProducer(const edm::ParameterSet&);
   ~PFCandMETcorrInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 
   edm::EDGetTokenT<edm::View<reco::Candidate> > token_;
 
-  struct binningEntryType
-  {
-    binningEntryType()
-      : binLabel_(""),
-        binSelection_(nullptr)
-    {}
+  struct binningEntryType {
+    binningEntryType() : binLabel_(""), binSelection_(nullptr) {}
     binningEntryType(const edm::ParameterSet& cfg)
-    : binLabel_(cfg.getParameter<std::string>("binLabel")),
-      binSelection_(new StringCutObjectSelector<reco::Candidate::LorentzVector>(cfg.getParameter<std::string>("binSelection")))
-    {}
-    ~binningEntryType() 
-    {      
-    }
+        : binLabel_(cfg.getParameter<std::string>("binLabel")),
+          binSelection_(new StringCutObjectSelector<reco::Candidate::LorentzVector>(
+              cfg.getParameter<std::string>("binSelection"))) {}
+    ~binningEntryType() {}
     const std::string binLabel_;
     std::unique_ptr<const StringCutObjectSelector<reco::Candidate::LorentzVector> > binSelection_;
     CorrMETData binUnclEnergySum_;
@@ -63,7 +54,3 @@ class PFCandMETcorrInputProducer : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/PFJetMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/PFJetMETcorrInputProducer.cc
@@ -10,4 +10,3 @@ typedef PFJetMETcorrInputProducerT<reco::PFJet, JetCorrExtractorT<reco::PFJet> >
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(PFJetMETcorrInputProducer);
-

--- a/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.cc
@@ -4,43 +4,38 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 PFchsMETcorrInputProducer::PFchsMETcorrInputProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    token_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("src"))),
-    goodVtxNdof_(cfg.getParameter<unsigned int>("goodVtxNdof")),
-    goodVtxZ_(cfg.getParameter<double>("goodVtxZ"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+      token_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("src"))),
+      goodVtxNdof_(cfg.getParameter<unsigned int>("goodVtxNdof")),
+      goodVtxZ_(cfg.getParameter<double>("goodVtxZ")) {
   produces<CorrMETData>("type0");
 }
 
-PFchsMETcorrInputProducer::~PFchsMETcorrInputProducer()
-{
+PFchsMETcorrInputProducer::~PFchsMETcorrInputProducer() {}
 
-}
-
-void PFchsMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void PFchsMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::VertexCollection> recVtxs;
   evt.getByToken(token_, recVtxs);
 
   std::unique_ptr<CorrMETData> chsSum(new CorrMETData());
 
-  for (unsigned i = 1; i < recVtxs->size(); ++i)
-    {
-      const reco::Vertex& v = recVtxs->at(i);
-      if (v.isFake()) continue;
-      if (v.ndof() < goodVtxNdof_) continue;
-      if (fabs(v.z()) > goodVtxZ_) continue;
+  for (unsigned i = 1; i < recVtxs->size(); ++i) {
+    const reco::Vertex& v = recVtxs->at(i);
+    if (v.isFake())
+      continue;
+    if (v.ndof() < goodVtxNdof_)
+      continue;
+    if (fabs(v.z()) > goodVtxZ_)
+      continue;
 
-      for (reco::Vertex::trackRef_iterator track = v.tracks_begin(); track != v.tracks_end(); ++track)
-	{
-	  if ((*track)->charge() != 0) 
-	    {
-	      chsSum->mex += (*track)->px();
-	      chsSum->mey += (*track)->py();
-	      chsSum->sumet += (*track)->pt();
-	    }
-	}
+    for (reco::Vertex::trackRef_iterator track = v.tracks_begin(); track != v.tracks_end(); ++track) {
+      if ((*track)->charge() != 0) {
+        chsSum->mex += (*track)->px();
+        chsSum->mey += (*track)->py();
+        chsSum->sumet += (*track)->pt();
+      }
     }
+  }
 
   evt.put(std::move(chsSum), "type0");
 }

--- a/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.h
@@ -29,15 +29,12 @@
 
 #include <string>
 
-class PFchsMETcorrInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class PFchsMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit PFchsMETcorrInputProducer(const edm::ParameterSet&);
   ~PFchsMETcorrInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
@@ -46,12 +43,6 @@ class PFchsMETcorrInputProducer : public edm::stream::EDProducer<>
 
   unsigned goodVtxNdof_;
   double goodVtxZ_;
- 
-
 };
 
 #endif
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/ScaleCorrMETData.cc
+++ b/JetMETCorrections/Type1MET/plugins/ScaleCorrMETData.cc
@@ -14,37 +14,33 @@
 #include <iostream>
 
 //____________________________________________________________________________||
-class ScaleCorrMETData : public edm::stream::EDProducer<>
-{
+class ScaleCorrMETData : public edm::stream::EDProducer<> {
 public:
   explicit ScaleCorrMETData(const edm::ParameterSet&);
-  ~ScaleCorrMETData() override { }
+  ~ScaleCorrMETData() override {}
 
 private:
-
   edm::EDGetTokenT<CorrMETData> token_;
   double scaleFactor_;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
-
 };
 
 //____________________________________________________________________________||
 ScaleCorrMETData::ScaleCorrMETData(const edm::ParameterSet& iConfig)
-  : token_(consumes<CorrMETData>(iConfig.getParameter<edm::InputTag>("src")))
-  , scaleFactor_(iConfig.getParameter<double>("scaleFactor"))
+    : token_(consumes<CorrMETData>(iConfig.getParameter<edm::InputTag>("src"))),
+      scaleFactor_(iConfig.getParameter<double>("scaleFactor"))
 
 {
   produces<CorrMETData>("");
 }
 
 //____________________________________________________________________________||
-void ScaleCorrMETData::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ScaleCorrMETData::produce(edm::Event& evt, const edm::EventSetup& es) {
   CorrMETData product;
   edm::Handle<CorrMETData> input;
   evt.getByToken(token_, input);
-  product += scaleFactor_*(*input);
+  product += scaleFactor_ * (*input);
 
   std::unique_ptr<CorrMETData> pprod(new CorrMETData(product));
   evt.put(std::move(pprod), "");
@@ -53,4 +49,3 @@ void ScaleCorrMETData::produce(edm::Event& evt, const edm::EventSetup& es)
 //____________________________________________________________________________||
 
 DEFINE_FWK_MODULE(ScaleCorrMETData);
-

--- a/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.cc
@@ -9,22 +9,16 @@
 #include <TString.h>
 
 SysShiftMETcorrInputProducer::SysShiftMETcorrInputProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    useNvtx(false),
-    corrPx_(nullptr),
-    corrPy_(nullptr)
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")), useNvtx(false), corrPx_(nullptr), corrPy_(nullptr) {
   token_ = consumes<edm::View<reco::MET> >(cfg.getParameter<edm::InputTag>("src"));
-  
+
   edm::ParameterSet cfgCorrParameter = cfg.getParameter<edm::ParameterSet>("parameter");
   TString corrPxFormula = cfgCorrParameter.getParameter<std::string>("px");
   TString corrPyFormula = cfgCorrParameter.getParameter<std::string>("py").data();
-  if ( corrPxFormula.Contains("Nvtx") || corrPyFormula.Contains("Nvtx") )
-    {
-      useNvtx = true,
-      verticesToken_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
-    }
-  
+  if (corrPxFormula.Contains("Nvtx") || corrPyFormula.Contains("Nvtx")) {
+    useNvtx = true, verticesToken_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
+  }
+
   corrPxFormula.ReplaceAll("sumEt", "x");
   corrPxFormula.ReplaceAll("Nvtx", "y");
   std::string corrPxName = std::string(moduleLabel_).append("_corrPx");
@@ -34,43 +28,39 @@ SysShiftMETcorrInputProducer::SysShiftMETcorrInputProducer(const edm::ParameterS
   corrPyFormula.ReplaceAll("Nvtx", "y");
   std::string corrPyName = std::string(moduleLabel_).append("_corrPy");
   corrPy_ = new TFormula(corrPyName.data(), corrPyFormula.Data());
-  
+
   produces<CorrMETData>();
 }
 
-SysShiftMETcorrInputProducer::~SysShiftMETcorrInputProducer()
-{
-// nothing to be done yet...
+SysShiftMETcorrInputProducer::~SysShiftMETcorrInputProducer() {
+  // nothing to be done yet...
 }
 
-void SysShiftMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void SysShiftMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   //std::cout << "<SysShiftMETcorrInputProducer::produce>:" << std::endl;
 
   typedef edm::View<reco::MET> METView;
   edm::Handle<METView> met;
   evt.getByToken(token_, met);
-  if ( met->size() != 1 ) 
-    throw cms::Exception("SysShiftMETcorrInputProducer::produce") 
-      << "Failed to find unique MET object !!\n";
+  if (met->size() != 1)
+    throw cms::Exception("SysShiftMETcorrInputProducer::produce") << "Failed to find unique MET object !!\n";
 
   double sumEt = met->front().sumEt();
   //std::cout << " sumEt = " << sumEt << std::endl;
 
   size_t Nvtx = 0;
-  if ( useNvtx )
-    {
-      edm::Handle<reco::VertexCollection> vertices;
-      evt.getByToken(verticesToken_, vertices);
-      Nvtx = vertices->size();
-    }
+  if (useNvtx) {
+    edm::Handle<reco::VertexCollection> vertices;
+    evt.getByToken(verticesToken_, vertices);
+    Nvtx = vertices->size();
+  }
   //std::cout << " Nvtx = " << Nvtx << std::endl;
 
   std::unique_ptr<CorrMETData> metCorr(new CorrMETData());
   metCorr->mex = -corrPx_->Eval(sumEt, Nvtx);
   metCorr->mey = -corrPy_->Eval(sumEt, Nvtx);
   //std::cout << "--> metCorr: Px = " << metCorr->mex << ", Py = " << metCorr->mey << std::endl;
-  
+
   evt.put(std::move(metCorr));
 }
 

--- a/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.h
@@ -25,15 +25,12 @@
 
 #include <string>
 
-class SysShiftMETcorrInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class SysShiftMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit SysShiftMETcorrInputProducer(const edm::ParameterSet&);
   ~SysShiftMETcorrInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
@@ -48,7 +45,3 @@ class SysShiftMETcorrInputProducer : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.h
@@ -26,15 +26,12 @@
 
 #include <string>
 
-class Type0PFMETcorrInputProducer : public edm::stream::EDProducer<>  
-{
- public:
-
+class Type0PFMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit Type0PFMETcorrInputProducer(const edm::ParameterSet&);
   ~Type0PFMETcorrInputProducer() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
@@ -48,8 +45,3 @@ class Type0PFMETcorrInputProducer : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
-
- 
-

--- a/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
@@ -51,7 +51,7 @@ private:
 	    srcUnclEnergySum != srcUnclEnergySums.end(); ++srcUnclEnergySum )
 	{
 	  std::string instanceLabel = srcUnclEnergySum->instance();
-	  if ( instanceLabel != "" && binLabel_ != "" ) instanceLabel.append("#");
+	  if ( !instanceLabel.empty() && !binLabel_.empty() ) instanceLabel.append("#");
 	  instanceLabel.append(binLabel_);
 	  edm::InputTag inputTag(srcUnclEnergySum->label(), instanceLabel);
 	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));

--- a/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
@@ -18,59 +18,56 @@
 #include <vector>
 
 //____________________________________________________________________________||
-class Type2CorrectionProducer : public edm::stream::EDProducer<>
-{
+class Type2CorrectionProducer : public edm::stream::EDProducer<> {
 public:
   explicit Type2CorrectionProducer(const edm::ParameterSet&);
-  ~Type2CorrectionProducer() override { }
+  ~Type2CorrectionProducer() override {}
 
 private:
-
   typedef std::vector<edm::InputTag> vInputTag;
 
   typedef std::vector<std::string> vstring;
-  struct type2BinningEntryType
-  {
-    type2BinningEntryType(const std::string& binCorrformula, const edm::ParameterSet& binCorrParameter, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector && iConsumesCollector)
-      : binLabel_(""),
-        binCorrFormula_(nullptr)
-    {
-      for (vInputTag::const_iterator inputTag = srcUnclEnergySums.begin(); inputTag != srcUnclEnergySums.end(); ++inputTag)
-	{
-	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
-	}
+  struct type2BinningEntryType {
+    type2BinningEntryType(const std::string& binCorrformula,
+                          const edm::ParameterSet& binCorrParameter,
+                          const vInputTag& srcUnclEnergySums,
+                          edm::ConsumesCollector&& iConsumesCollector)
+        : binLabel_(""), binCorrFormula_(nullptr) {
+      for (vInputTag::const_iterator inputTag = srcUnclEnergySums.begin(); inputTag != srcUnclEnergySums.end();
+           ++inputTag) {
+        corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
+      }
 
       initialize(binCorrformula, binCorrParameter);
     }
-    type2BinningEntryType(const edm::ParameterSet& cfg, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector && iConsumesCollector)
-      : binLabel_(cfg.getParameter<std::string>("binLabel")),
-        binCorrFormula_(nullptr)
-    {
+    type2BinningEntryType(const edm::ParameterSet& cfg,
+                          const vInputTag& srcUnclEnergySums,
+                          edm::ConsumesCollector&& iConsumesCollector)
+        : binLabel_(cfg.getParameter<std::string>("binLabel")), binCorrFormula_(nullptr) {
+      for (vInputTag::const_iterator srcUnclEnergySum = srcUnclEnergySums.begin();
+           srcUnclEnergySum != srcUnclEnergySums.end();
+           ++srcUnclEnergySum) {
+        std::string instanceLabel = srcUnclEnergySum->instance();
+        if (!instanceLabel.empty() && !binLabel_.empty())
+          instanceLabel.append("#");
+        instanceLabel.append(binLabel_);
+        edm::InputTag inputTag(srcUnclEnergySum->label(), instanceLabel);
+        corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));
+      }
 
-      for ( vInputTag::const_iterator srcUnclEnergySum = srcUnclEnergySums.begin();
-	    srcUnclEnergySum != srcUnclEnergySums.end(); ++srcUnclEnergySum )
-	{
-	  std::string instanceLabel = srcUnclEnergySum->instance();
-	  if ( !instanceLabel.empty() && !binLabel_.empty() ) instanceLabel.append("#");
-	  instanceLabel.append(binLabel_);
-	  edm::InputTag inputTag(srcUnclEnergySum->label(), instanceLabel);
-	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));
-	}
-      
       std::string binCorrFormula = cfg.getParameter<std::string>("binCorrFormula");
-    
+
       edm::ParameterSet binCorrParameter = cfg.getParameter<edm::ParameterSet>("binCorrParameter");
 
       initialize(binCorrFormula, binCorrParameter);
     }
-    void initialize(const std::string& binCorrFormula, const edm::ParameterSet& binCorrParameter)
-    {
+    void initialize(const std::string& binCorrFormula, const edm::ParameterSet& binCorrParameter) {
       TString formula = binCorrFormula;
-    
+
       vstring parNames = binCorrParameter.getParameterNamesForType<double>();
       int numParameter = parNames.size();
-      binCorrParameter_.resize(numParameter);    
-      for ( int parIndex = 0; parIndex < numParameter; ++parIndex ) {
+      binCorrParameter_.resize(numParameter);
+      for (int parIndex = 0; parIndex < numParameter; ++parIndex) {
         const std::string& parName = parNames[parIndex];
 
         double parValue = binCorrParameter.getParameter<double>(parName);
@@ -80,24 +77,21 @@ private:
         formula = formula.ReplaceAll(parName.data(), parName_internal);
       }
 
-      std::string binCorrFormulaName = std::string("binCorrFormula").append("_").append(binLabel_); 
+      std::string binCorrFormulaName = std::string("binCorrFormula").append("_").append(binLabel_);
       binCorrFormula_ = new TFormula(binCorrFormulaName.data(), formula);
 
-//--- check that syntax of formula string is valid 
-//   (i.e. that TFormula "compiled" without errors)
-      if ( !(binCorrFormula_->GetNdim() <= 1 && binCorrFormula_->GetNpar() == numParameter) ) 
-	throw cms::Exception("METCorrectionAlgorithm2") 
-	  << "Formula for Type 2 correction has invalid syntax = " << formula << " !!\n";
+      //--- check that syntax of formula string is valid
+      //   (i.e. that TFormula "compiled" without errors)
+      if (!(binCorrFormula_->GetNdim() <= 1 && binCorrFormula_->GetNpar() == numParameter))
+        throw cms::Exception("METCorrectionAlgorithm2")
+            << "Formula for Type 2 correction has invalid syntax = " << formula << " !!\n";
 
-      for ( int parIndex = 0; parIndex < numParameter; ++parIndex ) {
-	binCorrFormula_->SetParameter(parIndex, binCorrParameter_[parIndex]);
-	binCorrFormula_->SetParName(parIndex, parNames[parIndex].data());
+      for (int parIndex = 0; parIndex < numParameter; ++parIndex) {
+        binCorrFormula_->SetParameter(parIndex, binCorrParameter_[parIndex]);
+        binCorrFormula_->SetParName(parIndex, parNames[parIndex].data());
       }
     }
-    ~type2BinningEntryType() 
-    {
-      delete binCorrFormula_;
-    }
+    ~type2BinningEntryType() { delete binCorrFormula_; }
     std::string binLabel_;
     std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens_;
     TFormula* binCorrFormula_;
@@ -107,56 +101,54 @@ private:
   std::vector<type2BinningEntryType*> type2Binning_;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
-
 };
 
 //____________________________________________________________________________||
-Type2CorrectionProducer::Type2CorrectionProducer(const edm::ParameterSet& cfg)
-{
+Type2CorrectionProducer::Type2CorrectionProducer(const edm::ParameterSet& cfg) {
   vInputTag srcUnclEnergySums = cfg.getParameter<vInputTag>("srcUnclEnergySums");
 
-  if ( cfg.exists("type2Binning") )
-    {
-      typedef std::vector<edm::ParameterSet> vParameterSet;
-      vParameterSet cfgType2Binning = cfg.getParameter<vParameterSet>("type2Binning");
-      for ( vParameterSet::const_iterator cfgType2BinningEntry = cfgType2Binning.begin();
-	    cfgType2BinningEntry != cfgType2Binning.end(); ++cfgType2BinningEntry ) {
-	type2Binning_.push_back(new type2BinningEntryType(*cfgType2BinningEntry, srcUnclEnergySums, consumesCollector()));
-      }
+  if (cfg.exists("type2Binning")) {
+    typedef std::vector<edm::ParameterSet> vParameterSet;
+    vParameterSet cfgType2Binning = cfg.getParameter<vParameterSet>("type2Binning");
+    for (vParameterSet::const_iterator cfgType2BinningEntry = cfgType2Binning.begin();
+         cfgType2BinningEntry != cfgType2Binning.end();
+         ++cfgType2BinningEntry) {
+      type2Binning_.push_back(new type2BinningEntryType(*cfgType2BinningEntry, srcUnclEnergySums, consumesCollector()));
     }
-  else
-    {
-      std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
-      edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
-      type2Binning_.push_back(new type2BinningEntryType(type2CorrFormula, type2CorrParameter, srcUnclEnergySums, consumesCollector()));
-    }
+  } else {
+    std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
+    edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
+    type2Binning_.push_back(
+        new type2BinningEntryType(type2CorrFormula, type2CorrParameter, srcUnclEnergySums, consumesCollector()));
+  }
   produces<CorrMETData>("");
 }
 
 //____________________________________________________________________________||
-void Type2CorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void Type2CorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   CorrMETData product;
 
-  for ( std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
-	type2BinningEntry != type2Binning_.end(); ++type2BinningEntry )
-    {
-      CorrMETData unclEnergySum;
+  for (std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
+       type2BinningEntry != type2Binning_.end();
+       ++type2BinningEntry) {
+    CorrMETData unclEnergySum;
 
-      edm::Handle<CorrMETData> unclEnergySummand;
-      for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = (*type2BinningEntry)->corrTokens_.begin(); corrToken != (*type2BinningEntry)->corrTokens_.end(); ++corrToken)
-      {
-	evt.getByToken(*corrToken, unclEnergySummand);
-	unclEnergySum += (*unclEnergySummand);
-      }
+    edm::Handle<CorrMETData> unclEnergySummand;
+    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken =
+             (*type2BinningEntry)->corrTokens_.begin();
+         corrToken != (*type2BinningEntry)->corrTokens_.end();
+         ++corrToken) {
+      evt.getByToken(*corrToken, unclEnergySummand);
+      unclEnergySum += (*unclEnergySummand);
+    }
 
-      double unclEnergySumPt = sqrt(unclEnergySum.mex*unclEnergySum.mex + unclEnergySum.mey*unclEnergySum.mey);
-      double unclEnergyScaleFactor = (*type2BinningEntry)->binCorrFormula_->Eval(unclEnergySumPt);
+    double unclEnergySumPt = sqrt(unclEnergySum.mex * unclEnergySum.mex + unclEnergySum.mey * unclEnergySum.mey);
+    double unclEnergyScaleFactor = (*type2BinningEntry)->binCorrFormula_->Eval(unclEnergySumPt);
 
-      unclEnergySum.mex = -unclEnergySum.mex;
-      unclEnergySum.mey = -unclEnergySum.mey;
+    unclEnergySum.mex = -unclEnergySum.mex;
+    unclEnergySum.mey = -unclEnergySum.mey;
 
-      product += (unclEnergyScaleFactor - 1.)*unclEnergySum;
+    product += (unclEnergyScaleFactor - 1.) * unclEnergySum;
   }
 
   std::unique_ptr<CorrMETData> pprod(new CorrMETData(product));
@@ -166,4 +158,3 @@ void Type2CorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& es
 //____________________________________________________________________________||
 
 DEFINE_FWK_MODULE(Type2CorrectionProducer);
-

--- a/JetMETCorrections/Type1MET/plugins/UnclusteredBlobProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/UnclusteredBlobProducer.cc
@@ -7,57 +7,54 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/Event.h"
 
-#include "DataFormats/Common/interface/RefToPtr.h" 
+#include "DataFormats/Common/interface/RefToPtr.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 namespace pat {
-  class UnclusteredBlobProducer : public edm::global::EDProducer<>{
+  class UnclusteredBlobProducer : public edm::global::EDProducer<> {
   public:
     explicit UnclusteredBlobProducer(const edm::ParameterSet&);
     ~UnclusteredBlobProducer() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
   private:
-    edm::EDGetTokenT<edm::View<reco::Candidate> > candsrc_;
+    edm::EDGetTokenT<edm::View<reco::Candidate>> candsrc_;
   };
-}
+}  // namespace pat
 
-
-pat::UnclusteredBlobProducer::UnclusteredBlobProducer(const edm::ParameterSet& iConfig) :
-  candsrc_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("candsrc") ))
-{
+pat::UnclusteredBlobProducer::UnclusteredBlobProducer(const edm::ParameterSet& iConfig)
+    : candsrc_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("candsrc"))) {
   produces<std::vector<reco::VertexCompositePtrCandidate>>();
 }
 
 pat::UnclusteredBlobProducer::~UnclusteredBlobProducer() {}
 
 void pat::UnclusteredBlobProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  
   auto blob = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
-  
+
   edm::Handle<edm::View<reco::Candidate>> candidates;
   iEvent.getByToken(candsrc_, candidates);
-  
+
   blob->emplace_back();
 
   auto& c_blob = blob->back();
 
   // combine all candidates into composite so they can be accessed properly by CandPtrSelector
-  for(unsigned i = 0; i < candidates->size(); ++i){
+  for (unsigned i = 0; i < candidates->size(); ++i) {
     c_blob.addDaughter(candidates->ptrAt(i));
   }
 
   iEvent.put(std::move(blob));
-  
 }
 
 void pat::UnclusteredBlobProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("candsrc",edm::InputTag("badUnclustered"));
+  desc.add<edm::InputTag>("candsrc", edm::InputTag("badUnclustered"));
 
-  descriptions.add("UnclusteredBlobProducer",desc);
+  descriptions.add("UnclusteredBlobProducer", desc);
 }
 
 using pat::UnclusteredBlobProducer;

--- a/JetMETCorrections/Type1MET/src/AddCorrectionsToGenericMET.cc
+++ b/JetMETCorrections/Type1MET/src/AddCorrectionsToGenericMET.cc
@@ -1,58 +1,57 @@
 #include "JetMETCorrections/Type1MET/interface/AddCorrectionsToGenericMET.h"
 
-void
-AddCorrectionsToGenericMET::setCorTokens(std::vector<edm::EDGetTokenT<CorrMETData> > const& corrTokens){
-  corrTokens_=corrTokens;
+void AddCorrectionsToGenericMET::setCorTokens(std::vector<edm::EDGetTokenT<CorrMETData> > const& corrTokens) {
+  corrTokens_ = corrTokens;
 }
 
-reco::Candidate::LorentzVector 
-AddCorrectionsToGenericMET::constructP4From(const reco::MET& met,
-					    const CorrMETData& correction) {
+reco::Candidate::LorentzVector AddCorrectionsToGenericMET::constructP4From(const reco::MET& met,
+                                                                           const CorrMETData& correction) {
   double px = met.px() + correction.mex;
   double py = met.py() + correction.mey;
-  double pt = sqrt(px*px + py*py);
+  double pt = sqrt(px * px + py * py);
   return reco::Candidate::LorentzVector(px, py, 0., pt);
 }
 
-
-CorrMETData
-AddCorrectionsToGenericMET::getCorrection(const reco::MET& srcMET, edm::Event& evt, const edm::EventSetup& es) {
+CorrMETData AddCorrectionsToGenericMET::getCorrection(const reco::MET& srcMET,
+                                                      edm::Event& evt,
+                                                      const edm::EventSetup& es) {
   CorrMETData sumCor;
   edm::Handle<CorrMETData> corr;
-  for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = corrTokens_.begin(); corrToken != corrTokens_.end(); ++corrToken) {
+  for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = corrTokens_.begin();
+       corrToken != corrTokens_.end();
+       ++corrToken) {
     evt.getByToken(*corrToken, corr);
     sumCor += (*corr);
   }
 
   return sumCor;
 }
- 
 
-reco::MET
-AddCorrectionsToGenericMET::getCorrectedMET(const reco::MET& srcMET, edm::Event& evt, const edm::EventSetup& es) {
-  
+reco::MET AddCorrectionsToGenericMET::getCorrectedMET(const reco::MET& srcMET,
+                                                      edm::Event& evt,
+                                                      const edm::EventSetup& es) {
   CorrMETData corr = getCorrection(srcMET, evt, es);
-  reco::MET outMET(srcMET.sumEt()+corr.sumet, constructP4From(srcMET, corr), srcMET.vertex() );
-  
+  reco::MET outMET(srcMET.sumEt() + corr.sumet, constructP4From(srcMET, corr), srcMET.vertex());
+
   return outMET;
 }
 
 //specific flavors ================================
-reco::PFMET
-AddCorrectionsToGenericMET::getCorrectedPFMET(const reco::PFMET& srcMET, edm::Event& evt, const edm::EventSetup& es) {
-  
+reco::PFMET AddCorrectionsToGenericMET::getCorrectedPFMET(const reco::PFMET& srcMET,
+                                                          edm::Event& evt,
+                                                          const edm::EventSetup& es) {
   CorrMETData corr = getCorrection(srcMET, evt, es);
-  reco::PFMET outMET(srcMET.getSpecific(),srcMET.sumEt()+corr.sumet, constructP4From(srcMET, corr), srcMET.vertex() );
-  
+  reco::PFMET outMET(srcMET.getSpecific(), srcMET.sumEt() + corr.sumet, constructP4From(srcMET, corr), srcMET.vertex());
+
   return outMET;
 }
 
+reco::CaloMET AddCorrectionsToGenericMET::getCorrectedCaloMET(const reco::CaloMET& srcMET,
+                                                              edm::Event& evt,
+                                                              const edm::EventSetup& es) {
+  CorrMETData corr = getCorrection(srcMET, evt, es);
+  reco::CaloMET outMET(
+      srcMET.getSpecific(), srcMET.sumEt() + corr.sumet, constructP4From(srcMET, corr), srcMET.vertex());
 
-reco::CaloMET
-AddCorrectionsToGenericMET::getCorrectedCaloMET(const reco::CaloMET& srcMET, edm::Event& evt, const edm::EventSetup& es) {
-  
-   CorrMETData corr = getCorrection(srcMET, evt, es);
-   reco::CaloMET outMET(srcMET.getSpecific(),srcMET.sumEt()+corr.sumet, constructP4From(srcMET, corr), srcMET.vertex() );
-  
   return outMET;
 }

--- a/JetMETCorrections/Type1MET/src/METCorrectionAlgorithm.cc
+++ b/JetMETCorrections/Type1MET/src/METCorrectionAlgorithm.cc
@@ -6,136 +6,136 @@
 
 #include <string>
 
-METCorrectionAlgorithm::METCorrectionAlgorithm(const edm::ParameterSet& cfg, edm::ConsumesCollector && iConsumesCollector)
-{
+METCorrectionAlgorithm::METCorrectionAlgorithm(const edm::ParameterSet& cfg,
+                                               edm::ConsumesCollector&& iConsumesCollector) {
   applyType1Corrections_ = cfg.getParameter<bool>("applyType1Corrections");
-  if ( applyType1Corrections_ )
-    {
-      vInputTag srcType1Corrections = cfg.getParameter<vInputTag>("srcType1Corrections");
-      for (vInputTag::const_iterator inputTag = srcType1Corrections.begin(); inputTag != srcType1Corrections.end(); ++inputTag)
-	{
-	  type1Tokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
-	}
+  if (applyType1Corrections_) {
+    vInputTag srcType1Corrections = cfg.getParameter<vInputTag>("srcType1Corrections");
+    for (vInputTag::const_iterator inputTag = srcType1Corrections.begin(); inputTag != srcType1Corrections.end();
+         ++inputTag) {
+      type1Tokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
     }
-  
+  }
+
   applyType2Corrections_ = cfg.getParameter<bool>("applyType2Corrections");
-  if ( applyType2Corrections_ )
-    {
-      vInputTag srcUnclEnergySums = cfg.getParameter<vInputTag>("srcUnclEnergySums");
-    
-      if ( cfg.exists("type2Binning") ) 
-	{
-	  typedef std::vector<edm::ParameterSet> vParameterSet;
-	  vParameterSet cfgType2Binning = cfg.getParameter<vParameterSet>("type2Binning");
-	  for ( vParameterSet::const_iterator cfgType2BinningEntry = cfgType2Binning.begin();
-		cfgType2BinningEntry != cfgType2Binning.end(); ++cfgType2BinningEntry ) {
-	    type2Binning_.push_back(new type2BinningEntryType(*cfgType2BinningEntry, srcUnclEnergySums, iConsumesCollector));
-	  }
-	}
-      else
-	{
-	  std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
-	  edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
-	  type2Binning_.push_back(new type2BinningEntryType(type2CorrFormula, type2CorrParameter, srcUnclEnergySums, iConsumesCollector));
-	}
+  if (applyType2Corrections_) {
+    vInputTag srcUnclEnergySums = cfg.getParameter<vInputTag>("srcUnclEnergySums");
+
+    if (cfg.exists("type2Binning")) {
+      typedef std::vector<edm::ParameterSet> vParameterSet;
+      vParameterSet cfgType2Binning = cfg.getParameter<vParameterSet>("type2Binning");
+      for (vParameterSet::const_iterator cfgType2BinningEntry = cfgType2Binning.begin();
+           cfgType2BinningEntry != cfgType2Binning.end();
+           ++cfgType2BinningEntry) {
+        type2Binning_.push_back(
+            new type2BinningEntryType(*cfgType2BinningEntry, srcUnclEnergySums, iConsumesCollector));
+      }
+    } else {
+      std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
+      edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
+      type2Binning_.push_back(
+          new type2BinningEntryType(type2CorrFormula, type2CorrParameter, srcUnclEnergySums, iConsumesCollector));
+    }
+  }
+
+  applyType0Corrections_ =
+      cfg.exists("applyType0Corrections") ? cfg.getParameter<bool>("applyType0Corrections") : false;
+  if (applyType0Corrections_) {
+    vInputTag srcCHSSums = cfg.getParameter<vInputTag>("srcCHSSums");
+    for (vInputTag::const_iterator inputTag = srcCHSSums.begin(); inputTag != srcCHSSums.end(); ++inputTag) {
+      chsSumTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
     }
 
-  applyType0Corrections_ = cfg.exists("applyType0Corrections") ? cfg.getParameter<bool>("applyType0Corrections") : false;
-  if ( applyType0Corrections_ )
-    {
-      vInputTag srcCHSSums = cfg.getParameter<vInputTag>("srcCHSSums");
-      for (vInputTag::const_iterator inputTag = srcCHSSums.begin(); inputTag != srcCHSSums.end(); ++inputTag)
-	{
-	  chsSumTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(*inputTag));
-	}
-
-      type0Rsoft_ = cfg.getParameter<double>("type0Rsoft");
-      type0Cuncl_ = 1.0;
-      if (applyType2Corrections_)
-	{
-	  if (cfg.exists("type2Binning")) throw cms::Exception("Invalid Arg") << "Currently, applyType0Corrections and type2Binning cannot be used together!";
-	  std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
-	  if (!(type2CorrFormula == "A")) throw cms::Exception("Invalid Arg") << "type2CorrFormula must be \"A\" if applyType0Corrections!";
-	  edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
-	  type0Cuncl_ = type2CorrParameter.getParameter<double>("A");
-	}
+    type0Rsoft_ = cfg.getParameter<double>("type0Rsoft");
+    type0Cuncl_ = 1.0;
+    if (applyType2Corrections_) {
+      if (cfg.exists("type2Binning"))
+        throw cms::Exception("Invalid Arg")
+            << "Currently, applyType0Corrections and type2Binning cannot be used together!";
+      std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
+      if (!(type2CorrFormula == "A"))
+        throw cms::Exception("Invalid Arg") << "type2CorrFormula must be \"A\" if applyType0Corrections!";
+      edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
+      type0Cuncl_ = type2CorrParameter.getParameter<double>("A");
     }
+  }
 }
 
-METCorrectionAlgorithm::~METCorrectionAlgorithm()
-{
-  for ( std::vector<type2BinningEntryType*>::const_iterator it = type2Binning_.begin();
-	it != type2Binning_.end(); ++it ) {
+METCorrectionAlgorithm::~METCorrectionAlgorithm() {
+  for (std::vector<type2BinningEntryType*>::const_iterator it = type2Binning_.begin(); it != type2Binning_.end();
+       ++it) {
     delete (*it);
   }
 }
 
-CorrMETData METCorrectionAlgorithm::compMETCorrection(edm::Event& evt, const edm::EventSetup& es)
-{
+CorrMETData METCorrectionAlgorithm::compMETCorrection(edm::Event& evt, const edm::EventSetup& es) {
   CorrMETData metCorr;
-  metCorr.mex   = 0.;
-  metCorr.mey   = 0.;
+  metCorr.mex = 0.;
+  metCorr.mey = 0.;
   metCorr.sumet = 0.;
 
-  if ( applyType0Corrections_ ) {
-//--- sum all Type 0 MET correction terms
+  if (applyType0Corrections_) {
+    //--- sum all Type 0 MET correction terms
     edm::Handle<CorrMETData> chsSum;
-    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = chsSumTokens_.begin(); corrToken != chsSumTokens_.end(); ++corrToken)
-      {
-	evt.getByToken(*corrToken, chsSum);
+    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = chsSumTokens_.begin();
+         corrToken != chsSumTokens_.end();
+         ++corrToken) {
+      evt.getByToken(*corrToken, chsSum);
 
-	metCorr.mex   += type0Cuncl_*(1 - type0Rsoft_)*chsSum->mex;
-	metCorr.mey   += type0Cuncl_*(1 - type0Rsoft_)*chsSum->mey;
-	metCorr.sumet += type0Cuncl_*(1 - type0Rsoft_)*chsSum->sumet;
-      }
-  }
-
-  if ( applyType1Corrections_ ) {
-//--- sum all Type 1 MET correction terms
-    edm::Handle<CorrMETData> type1Correction;
-    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = type1Tokens_.begin(); corrToken != type1Tokens_.end(); ++corrToken)
-      {
-	evt.getByToken(*corrToken, type1Correction);
-
-	metCorr.mex   += type1Correction->mex;
-	metCorr.mey   += type1Correction->mey;
-	metCorr.sumet += type1Correction->sumet;
-      }
-  }
-
-  if ( applyType2Corrections_ )
-    {
-//--- compute momentum sum of all "unclustered energy" in the event
-//
-//    NOTE: calibration factors/formulas for Type 2 MET correction may depend on eta
-//         (like the jet energy correction factors do)
-//
-    
-      for ( std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
-	  type2BinningEntry != type2Binning_.end(); ++type2BinningEntry )
-	{
-	  CorrMETData unclEnergySum;
-	  edm::Handle<CorrMETData> unclEnergySummand;
-	  for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = (*type2BinningEntry)->corrTokens_.begin(); corrToken != (*type2BinningEntry)->corrTokens_.end(); ++corrToken)
-	    {
-	      evt.getByToken(*corrToken, unclEnergySummand);
-	
-	      unclEnergySum.mex   += unclEnergySummand->mex;
-	      unclEnergySum.mey   += unclEnergySummand->mey;
-	      unclEnergySum.sumet += unclEnergySummand->sumet;
-	    }
-
-//--- calibrate "unclustered energy"
-	  double unclEnergySumPt = sqrt(unclEnergySum.mex*unclEnergySum.mex + unclEnergySum.mey*unclEnergySum.mey);
-	  double unclEnergyScaleFactor = (*type2BinningEntry)->binCorrFormula_->Eval(unclEnergySumPt);
-
-//--- MET balances momentum of reconstructed particles,
-//    hence correction to "unclustered energy" and corresponding Type 2 MET correction are of opposite sign
-	  metCorr.mex   -= (unclEnergyScaleFactor - 1.)*unclEnergySum.mex;
-	  metCorr.mey   -= (unclEnergyScaleFactor - 1.)*unclEnergySum.mey;
-	  metCorr.sumet += (unclEnergyScaleFactor - 1.)*unclEnergySum.sumet;
-	}
+      metCorr.mex += type0Cuncl_ * (1 - type0Rsoft_) * chsSum->mex;
+      metCorr.mey += type0Cuncl_ * (1 - type0Rsoft_) * chsSum->mey;
+      metCorr.sumet += type0Cuncl_ * (1 - type0Rsoft_) * chsSum->sumet;
     }
+  }
+
+  if (applyType1Corrections_) {
+    //--- sum all Type 1 MET correction terms
+    edm::Handle<CorrMETData> type1Correction;
+    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = type1Tokens_.begin();
+         corrToken != type1Tokens_.end();
+         ++corrToken) {
+      evt.getByToken(*corrToken, type1Correction);
+
+      metCorr.mex += type1Correction->mex;
+      metCorr.mey += type1Correction->mey;
+      metCorr.sumet += type1Correction->sumet;
+    }
+  }
+
+  if (applyType2Corrections_) {
+    //--- compute momentum sum of all "unclustered energy" in the event
+    //
+    //    NOTE: calibration factors/formulas for Type 2 MET correction may depend on eta
+    //         (like the jet energy correction factors do)
+    //
+
+    for (std::vector<type2BinningEntryType*>::const_iterator type2BinningEntry = type2Binning_.begin();
+         type2BinningEntry != type2Binning_.end();
+         ++type2BinningEntry) {
+      CorrMETData unclEnergySum;
+      edm::Handle<CorrMETData> unclEnergySummand;
+      for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken =
+               (*type2BinningEntry)->corrTokens_.begin();
+           corrToken != (*type2BinningEntry)->corrTokens_.end();
+           ++corrToken) {
+        evt.getByToken(*corrToken, unclEnergySummand);
+
+        unclEnergySum.mex += unclEnergySummand->mex;
+        unclEnergySum.mey += unclEnergySummand->mey;
+        unclEnergySum.sumet += unclEnergySummand->sumet;
+      }
+
+      //--- calibrate "unclustered energy"
+      double unclEnergySumPt = sqrt(unclEnergySum.mex * unclEnergySum.mex + unclEnergySum.mey * unclEnergySum.mey);
+      double unclEnergyScaleFactor = (*type2BinningEntry)->binCorrFormula_->Eval(unclEnergySumPt);
+
+      //--- MET balances momentum of reconstructed particles,
+      //    hence correction to "unclustered energy" and corresponding Type 2 MET correction are of opposite sign
+      metCorr.mex -= (unclEnergyScaleFactor - 1.) * unclEnergySum.mex;
+      metCorr.mey -= (unclEnergyScaleFactor - 1.) * unclEnergySum.mey;
+      metCorr.sumet += (unclEnergyScaleFactor - 1.) * unclEnergySum.sumet;
+    }
+  }
 
   return metCorr;
 }

--- a/PhysicsTools/PatUtils/interface/BoostedJetMerger.h
+++ b/PhysicsTools/PatUtils/interface/BoostedJetMerger.h
@@ -2,7 +2,7 @@
 //
 // Package:    BoostedJetMerger
 // Class:      BoostedJetMerger
-// 
+//
 // \class BoostedJetMerger BoostedJetMerger.h PhysicsTools/PatUtils/interface/BoostedJetMerger.h
 // Description: Class to "deswizzle" information from various pat::Jet collections.
 //
@@ -11,7 +11,6 @@
 // $Id: BoostedJetMerger.cc,v 1.1 2013/03/07 20:13:55 srappocc Exp $
 //
 //
-
 
 // system include files
 #include <memory>
@@ -30,41 +29,39 @@
 // class decleration
 //
 
-
 /// Predicate to use for find_if.
 /// This checks whether a given edm::Ptr<reco::Candidate>
 /// (as you would get from the reco::BasicJet daughters)
 /// to see if it matches the original object ref of
 /// another pat::Jet (which is to find the corrected / btagged
-/// pat::Jet that corresponds to the subjet in question). 
+/// pat::Jet that corresponds to the subjet in question).
 struct FindCorrectedSubjet {
   // Input the daughter you're interested in checking
-  FindCorrectedSubjet( edm::Ptr<reco::Candidate> const & da ) : 
-    da_(da) {}
+  FindCorrectedSubjet(edm::Ptr<reco::Candidate> const& da) : da_(da) {}
 
-  // Predicate operator to compare an input pat::Jet to. 
-  bool operator()( pat::Jet const & subjet ) const {
+  // Predicate operator to compare an input pat::Jet to.
+  bool operator()(pat::Jet const& subjet) const {
     const edm::Ptr<reco::Candidate>& subjetOrigRef = subjet.originalObjectRef();
-    if ( da_ == subjetOrigRef ) {
+    if (da_ == subjetOrigRef) {
       return true;
-    }
-    else return false;
+    } else
+      return false;
   }
 
   edm::Ptr<reco::Candidate> da_;
 };
 
 class BoostedJetMerger : public edm::stream::EDProducer<> {
-   public:
-      explicit BoostedJetMerger(const edm::ParameterSet&);
-      ~BoostedJetMerger() override;
+public:
+  explicit BoostedJetMerger(const edm::ParameterSet&);
+  ~BoostedJetMerger() override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      // data labels
-      edm::EDGetTokenT<edm::View<pat::Jet> >  jetToken_;
-      edm::EDGetTokenT<edm::View<pat::Jet> >  subjetToken_;
+  // ----------member data ---------------------------
+
+  // data labels
+  edm::EDGetTokenT<edm::View<pat::Jet> > jetToken_;
+  edm::EDGetTokenT<edm::View<pat::Jet> > subjetToken_;
 };

--- a/PhysicsTools/PatUtils/interface/CaloIsolationEnergy.h
+++ b/PhysicsTools/PatUtils/interface/CaloIsolationEnergy.h
@@ -22,7 +22,7 @@ class TrackToEcalPropagator;
 class CaloTower;
 
 namespace reco {
-  class Track; 
+  class Track;
 }
 
 namespace pat {
@@ -30,18 +30,22 @@ namespace pat {
   class Electron;
 
   class CaloIsolationEnergy {
-    public:
-      CaloIsolationEnergy();
-      virtual ~CaloIsolationEnergy();
+  public:
+    CaloIsolationEnergy();
+    virtual ~CaloIsolationEnergy();
 
-      float calculate(const Electron & anElectron, const std::vector<CaloTower> & theTowers, float isoConeElectron = 0.3) const;
-      float calculate(const Muon & aMuon, const std::vector<CaloTower> & theTowers, float isoConeMuon = 0.3) const;
+    float calculate(const Electron& anElectron,
+                    const std::vector<CaloTower>& theTowers,
+                    float isoConeElectron = 0.3) const;
+    float calculate(const Muon& aMuon, const std::vector<CaloTower>& theTowers, float isoConeMuon = 0.3) const;
 
-    private:
-      float calculate(const reco::Track & track, const float leptonEnergy, const std::vector<CaloTower> & theTowers, float isoCone) const;
+  private:
+    float calculate(const reco::Track& track,
+                    const float leptonEnergy,
+                    const std::vector<CaloTower>& theTowers,
+                    float isoCone) const;
   };
 
-}
+}  // namespace pat
 
 #endif
-

--- a/PhysicsTools/PatUtils/interface/CaloJetSelector.h
+++ b/PhysicsTools/PatUtils/interface/CaloJetSelector.h
@@ -21,23 +21,19 @@
 namespace pat {
 
   class CaloJetSelector {
-
-
   public:
-    CaloJetSelector( const JetSelection& config ) : config_( config ) {}
+    CaloJetSelector(const JetSelection& config) : config_(config) {}
     ~CaloJetSelector() {}
 
     /// Returns 0 if Jet matches criteria, a flag otherwise.
     /// Criteria depend on the selector's configuration.
-    const ParticleStatus
-    filter( const reco::CaloJet& Jet ) const;
+    const ParticleStatus filter(const reco::CaloJet& Jet) const;
 
   private:
-
     JetSelection config_;
-    
-  }; // class
-  
-} // namespace
+
+  };  // class
+
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/DuplicatedElectronRemover.h
+++ b/PhysicsTools/PatUtils/interface/DuplicatedElectronRemover.h
@@ -10,55 +10,53 @@
 #include <memory>
 #include <vector>
 
+namespace pat {
 
-namespace pat { 
-    
-    /* --- Original comment from TQAF follows ----
+  /* --- Original comment from TQAF follows ----
      * it is possible that there are multiple electron objects in the collection that correspond to the same
      * real physics object - a supercluster with two tracks reconstructed to it, or a track that points to two different SC
      *  (i would guess the latter doesn't actually happen).
      * NB triplicates also appear in the electron collection provided by egamma group, it is necessary to handle those correctly   
      */
-    class DuplicatedElectronRemover {
-        public:
-            struct SameSuperclusterOrTrack {
-                template<typename T1, typename T2>
-                bool operator()(const T1 &t1, const T2 &t2) const { 
-                    return ((t1.superCluster() == t2.superCluster()) ||
-                            (t1.gsfTrack()     == t2.gsfTrack())); 
-                }
-            }; // struct
+  class DuplicatedElectronRemover {
+  public:
+    struct SameSuperclusterOrTrack {
+      template <typename T1, typename T2>
+      bool operator()(const T1 &t1, const T2 &t2) const {
+        return ((t1.superCluster() == t2.superCluster()) || (t1.gsfTrack() == t2.gsfTrack()));
+      }
+    };  // struct
 
-            struct BestEoverP {
-                template<typename T1, typename T2>
-                bool operator()(const T1 &t1, const T2 &t2) const { 
-                    float diff1 = fabs(t1.eSuperClusterOverP()-1);
-                    float diff2 = fabs(t2.eSuperClusterOverP()-1);
-                    return diff1 <= diff2;
-                }
-            }; //struct
+    struct BestEoverP {
+      template <typename T1, typename T2>
+      bool operator()(const T1 &t1, const T2 &t2) const {
+        float diff1 = fabs(t1.eSuperClusterOverP() - 1);
+        float diff2 = fabs(t2.eSuperClusterOverP() - 1);
+        return diff1 <= diff2;
+      }
+    };  //struct
 
-            // List of duplicate electrons to remove 
-            // Among those that share the same cluster or track, the one with E/P nearer to 1 is kept
-            std::unique_ptr< std::vector<size_t> > duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) const ;
+    // List of duplicate electrons to remove
+    // Among those that share the same cluster or track, the one with E/P nearer to 1 is kept
+    std::unique_ptr<std::vector<size_t> > duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) const;
 
-            // List of duplicate electrons to remove 
-            // Among those that share the same cluster or track, the one with E/P nearer to 1 is kept
-            std::unique_ptr< std::vector<size_t> > duplicatesToRemove(const edm::View<reco::GsfElectron>   &electrons) const ;
+    // List of duplicate electrons to remove
+    // Among those that share the same cluster or track, the one with E/P nearer to 1 is kept
+    std::unique_ptr<std::vector<size_t> > duplicatesToRemove(const edm::View<reco::GsfElectron> &electrons) const;
 
-            // Generic method. Collection can be vector, view or whatever you like
-            template<typename Collection>
-            std::unique_ptr< std::vector<size_t> > duplicatesToRemove(const Collection &electrons) const ;
-            
-        private:
-    }; // class
-} // namespace
+    // Generic method. Collection can be vector, view or whatever you like
+    template <typename Collection>
+    std::unique_ptr<std::vector<size_t> > duplicatesToRemove(const Collection &electrons) const;
+
+  private:
+  };  // class
+}  // namespace pat
 
 // implemented here because is templated
-template<typename Collection>
-std::unique_ptr< std::vector<size_t> >
-pat::DuplicatedElectronRemover::duplicatesToRemove(const Collection &electrons) const {
-    pat::GenericDuplicateRemover<SameSuperclusterOrTrack,BestEoverP> dups;
-    return dups.duplicates(electrons);
+template <typename Collection>
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedElectronRemover::duplicatesToRemove(
+    const Collection &electrons) const {
+  pat::GenericDuplicateRemover<SameSuperclusterOrTrack, BestEoverP> dups;
+  return dups.duplicates(electrons);
 }
 #endif

--- a/PhysicsTools/PatUtils/interface/DuplicatedPhotonRemover.h
+++ b/PhysicsTools/PatUtils/interface/DuplicatedPhotonRemover.h
@@ -13,103 +13,102 @@
 
 #include "CommonTools/Utils/interface/EtComparator.h"
 
-namespace pat { 
-    
-    class DuplicatedPhotonRemover {
+namespace pat {
 
-        public:
-            // Checks if two objects share the same supercluster seed
-            struct EqualBySuperClusterSeed {
-                template<typename T1, typename T2>
-                    bool operator()(const T1 &t1, const T2 &t2) const { 
-                        return (t1.superCluster()->seed() == t2.superCluster()->seed());
-                    }
-            };
-
-            // Checks if two objects share the same supercluster seed
-            struct EqualBySuperCluster {
-                template<typename T1, typename T2>
-                    bool operator()(const T1 &t1, const T2 &t2) const { 
-                        return (t1.superCluster() == t2.superCluster());
-                    }
-            };
-
-            /// Indices of duplicated photons (same supercluster) to remove. It keeps the photons with highest energy.
-            /// PhotonCollection can be anything that has a "begin()" and "end()", and that hold things which have a "superCluster()" method
-            /// notable examples are std::vector<Photon> and edm::View<Photon> (but GsfElectrons work too)
-            template <typename PhotonCollection> 
-            std::unique_ptr< std::vector<size_t> > duplicatesBySuperCluster(const PhotonCollection &photons) const ;
-            
-            /// Indices of duplicated photons (same supercluster) to remove. It keeps the photons with highest energy.
-            /// PhotonCollection can be anything that has a "begin()" and "end()", and that hold things which have a "superCluster()" method
-            /// notable examples are std::vector<Photon> and edm::View<Photon> (but GsfElectrons work too)
-            template <typename PhotonCollection> 
-            std::unique_ptr< std::vector<size_t> > duplicatesBySeed(const PhotonCollection &photons) const ;
-
-            /// Indices of photons which happen to be also electrons (that is, they share the same SC seed)
-            template <typename PhotonCollection, typename ElectronCollection> 
-            std::unique_ptr< pat::OverlapList > 
-            electronsBySeed(const PhotonCollection &photons, const ElectronCollection &electrons) const ;
-
-            /// Indices of photons which happen to be also electrons (that is, they share the same SC)
-            template <typename PhotonCollection, typename ElectronCollection> 
-            std::unique_ptr< pat::OverlapList > 
-            electronsBySuperCluster(const PhotonCollection &photons, const ElectronCollection &electrons) const ;
-
-            // ===== Concrete versions for users (and to get it compiled, so I can see if there are errors) ===
-            std::unique_ptr< std::vector<size_t> > duplicatesBySeed(const reco::PhotonCollection &photons) const ;
-            std::unique_ptr< std::vector<size_t> > duplicatesBySeed(const edm::View<reco::Photon> &photons) const ;
-            std::unique_ptr< std::vector<size_t> > duplicatesBySuperCluster(const edm::View<reco::Photon> &photons) const ;
-            std::unique_ptr< std::vector<size_t> > duplicatesBySuperCluster(const reco::PhotonCollection &photons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySeed(const reco::PhotonCollection &photons, 
-                    const reco::GsfElectronCollection& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySeed(const edm::View<reco::Photon> &photons, 
-                    const reco::GsfElectronCollection& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
-                    const reco::GsfElectronCollection& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const reco::PhotonCollection &photons, 
-                    const reco::GsfElectronCollection& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySeed(const reco::PhotonCollection &photons, 
-                    const edm::View<reco::GsfElectron>& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySeed(const edm::View<reco::Photon> &photons, 
-                    const edm::View<reco::GsfElectron>& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
-                    const edm::View<reco::GsfElectron>& electrons) const ;
-            std::unique_ptr< pat::OverlapList > electronsBySuperCluster(const reco::PhotonCollection &photons, 
-                    const edm::View<reco::GsfElectron>& electrons) const ;
+  class DuplicatedPhotonRemover {
+  public:
+    // Checks if two objects share the same supercluster seed
+    struct EqualBySuperClusterSeed {
+      template <typename T1, typename T2>
+      bool operator()(const T1 &t1, const T2 &t2) const {
+        return (t1.superCluster()->seed() == t2.superCluster()->seed());
+      }
     };
+
+    // Checks if two objects share the same supercluster seed
+    struct EqualBySuperCluster {
+      template <typename T1, typename T2>
+      bool operator()(const T1 &t1, const T2 &t2) const {
+        return (t1.superCluster() == t2.superCluster());
+      }
+    };
+
+    /// Indices of duplicated photons (same supercluster) to remove. It keeps the photons with highest energy.
+    /// PhotonCollection can be anything that has a "begin()" and "end()", and that hold things which have a "superCluster()" method
+    /// notable examples are std::vector<Photon> and edm::View<Photon> (but GsfElectrons work too)
+    template <typename PhotonCollection>
+    std::unique_ptr<std::vector<size_t> > duplicatesBySuperCluster(const PhotonCollection &photons) const;
+
+    /// Indices of duplicated photons (same supercluster) to remove. It keeps the photons with highest energy.
+    /// PhotonCollection can be anything that has a "begin()" and "end()", and that hold things which have a "superCluster()" method
+    /// notable examples are std::vector<Photon> and edm::View<Photon> (but GsfElectrons work too)
+    template <typename PhotonCollection>
+    std::unique_ptr<std::vector<size_t> > duplicatesBySeed(const PhotonCollection &photons) const;
+
+    /// Indices of photons which happen to be also electrons (that is, they share the same SC seed)
+    template <typename PhotonCollection, typename ElectronCollection>
+    std::unique_ptr<pat::OverlapList> electronsBySeed(const PhotonCollection &photons,
+                                                      const ElectronCollection &electrons) const;
+
+    /// Indices of photons which happen to be also electrons (that is, they share the same SC)
+    template <typename PhotonCollection, typename ElectronCollection>
+    std::unique_ptr<pat::OverlapList> electronsBySuperCluster(const PhotonCollection &photons,
+                                                              const ElectronCollection &electrons) const;
+
+    // ===== Concrete versions for users (and to get it compiled, so I can see if there are errors) ===
+    std::unique_ptr<std::vector<size_t> > duplicatesBySeed(const reco::PhotonCollection &photons) const;
+    std::unique_ptr<std::vector<size_t> > duplicatesBySeed(const edm::View<reco::Photon> &photons) const;
+    std::unique_ptr<std::vector<size_t> > duplicatesBySuperCluster(const edm::View<reco::Photon> &photons) const;
+    std::unique_ptr<std::vector<size_t> > duplicatesBySuperCluster(const reco::PhotonCollection &photons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySeed(const reco::PhotonCollection &photons,
+                                                      const reco::GsfElectronCollection &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySeed(const edm::View<reco::Photon> &photons,
+                                                      const reco::GsfElectronCollection &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySuperCluster(const edm::View<reco::Photon> &photons,
+                                                              const reco::GsfElectronCollection &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySuperCluster(const reco::PhotonCollection &photons,
+                                                              const reco::GsfElectronCollection &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySeed(const reco::PhotonCollection &photons,
+                                                      const edm::View<reco::GsfElectron> &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySeed(const edm::View<reco::Photon> &photons,
+                                                      const edm::View<reco::GsfElectron> &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySuperCluster(const edm::View<reco::Photon> &photons,
+                                                              const edm::View<reco::GsfElectron> &electrons) const;
+    std::unique_ptr<pat::OverlapList> electronsBySuperCluster(const reco::PhotonCollection &photons,
+                                                              const edm::View<reco::GsfElectron> &electrons) const;
+  };
+}  // namespace pat
+
+template <typename PhotonCollection>
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(
+    const PhotonCollection &photons) const {
+  typedef typename PhotonCollection::value_type PhotonType;
+  pat::GenericDuplicateRemover<EqualBySuperCluster, GreaterByEt<PhotonType> > dups;
+  return dups.duplicates(photons);
 }
 
-template<typename PhotonCollection>
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const PhotonCollection &photons) const {
-    typedef typename PhotonCollection::value_type PhotonType;
-    pat::GenericDuplicateRemover<EqualBySuperCluster, GreaterByEt<PhotonType> > dups;
-    return dups.duplicates(photons);
-}
-
-template<typename PhotonCollection>
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedPhotonRemover::duplicatesBySeed(const PhotonCollection &photons) const {
-    typedef typename PhotonCollection::value_type PhotonType;
-    pat::GenericDuplicateRemover<EqualBySuperClusterSeed, GreaterByEt<PhotonType> > dups;
-    return dups.duplicates(photons);
+template <typename PhotonCollection>
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedPhotonRemover::duplicatesBySeed(
+    const PhotonCollection &photons) const {
+  typedef typename PhotonCollection::value_type PhotonType;
+  pat::GenericDuplicateRemover<EqualBySuperClusterSeed, GreaterByEt<PhotonType> > dups;
+  return dups.duplicates(photons);
 }
 
 /// Indices of photons which happen to be also electrons (that is, they share the same SC)
-template <typename PhotonCollection, typename ElectronCollection> 
-std::unique_ptr< pat::OverlapList > 
-pat::DuplicatedPhotonRemover::electronsBySuperCluster(const PhotonCollection &photons, const ElectronCollection &electrons) const {
-    pat::GenericOverlapFinder< pat::OverlapDistance<EqualBySuperCluster> > ovl;
-    return ovl.find(photons, electrons);
+template <typename PhotonCollection, typename ElectronCollection>
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySuperCluster(
+    const PhotonCollection &photons, const ElectronCollection &electrons) const {
+  pat::GenericOverlapFinder<pat::OverlapDistance<EqualBySuperCluster> > ovl;
+  return ovl.find(photons, electrons);
 }
 
 /// Indices of photons which happen to be also electrons (that is, they share the same SC)
-template <typename PhotonCollection, typename ElectronCollection> 
-std::unique_ptr< pat::OverlapList > 
-pat::DuplicatedPhotonRemover::electronsBySeed(const PhotonCollection &photons, const ElectronCollection &electrons) const {
-    pat::GenericOverlapFinder< pat::OverlapDistance<EqualBySuperClusterSeed> > ovl;
-    return ovl.find(photons, electrons);
+template <typename PhotonCollection, typename ElectronCollection>
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySeed(
+    const PhotonCollection &photons, const ElectronCollection &electrons) const {
+  pat::GenericOverlapFinder<pat::OverlapDistance<EqualBySuperClusterSeed> > ovl;
+  return ovl.find(photons, electrons);
 }
 
 #endif

--- a/PhysicsTools/PatUtils/interface/EventHypothesisTools.h
+++ b/PhysicsTools/PatUtils/interface/EventHypothesisTools.h
@@ -5,54 +5,63 @@
 #include "DataFormats/PatCandidates/interface/EventHypothesis.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-namespace pat { namespace eventhypothesis {
+namespace pat {
+  namespace eventhypothesis {
 
-            /** Does the AND of some filters. OWNS the pointers to the filters */
-            class AndFilter : public ParticleFilter {
-                public:
-                    AndFilter() : filters_(2) {}
-                    AndFilter(ParticleFilter *f1, ParticleFilter *f2) ;
-                    ~AndFilter() override {}
-                    AndFilter & operator&=(ParticleFilter *filter) { filters_.push_back(filter); return *this; }
-                    bool operator()(const CandRefType &cand, const std::string &role) const override ;
-                private:
-                    boost::ptr_vector<ParticleFilter> filters_;
-            };
+    /** Does the AND of some filters. OWNS the pointers to the filters */
+    class AndFilter : public ParticleFilter {
+    public:
+      AndFilter() : filters_(2) {}
+      AndFilter(ParticleFilter *f1, ParticleFilter *f2);
+      ~AndFilter() override {}
+      AndFilter &operator&=(ParticleFilter *filter) {
+        filters_.push_back(filter);
+        return *this;
+      }
+      bool operator()(const CandRefType &cand, const std::string &role) const override;
 
-            /** Does the OR of some filters. OWNS the pointers to the filters */
-            class OrFilter : public ParticleFilter {
-                public:
-                    OrFilter() : filters_(2) {}
-                    OrFilter(ParticleFilter *f1, ParticleFilter *f2) ;
-                    ~OrFilter() override {}
-                    OrFilter & operator&=(ParticleFilter *filter) { filters_.push_back(filter); return *this; }
-                    bool operator()(const CandRefType &cand, const std::string &role) const override ;
-                private:
-                    boost::ptr_vector<ParticleFilter> filters_;
-            };
+    private:
+      boost::ptr_vector<ParticleFilter> filters_;
+    };
 
-            class ByPdgId : public ParticleFilter {
-                public:
-                    explicit ByPdgId(int32_t pdgCode, bool alsoAntiparticle=true) ;
-                    ~ByPdgId() override {}
-                    bool operator()(const CandRefType &cand, const std::string &role) const override ;
-                private:
-                    int32_t pdgCode_;
-                    bool    antiparticle_;
-            };
+    /** Does the OR of some filters. OWNS the pointers to the filters */
+    class OrFilter : public ParticleFilter {
+    public:
+      OrFilter() : filters_(2) {}
+      OrFilter(ParticleFilter *f1, ParticleFilter *f2);
+      ~OrFilter() override {}
+      OrFilter &operator&=(ParticleFilter *filter) {
+        filters_.push_back(filter);
+        return *this;
+      }
+      bool operator()(const CandRefType &cand, const std::string &role) const override;
 
-            class ByString : public ParticleFilter {
-                public:
-                    ByString(const std::string &cut) ; // not putting the explicit on purpose, I want to see what happens
-                    ~ByString() override {}
-                    bool operator()(const CandRefType &cand, const std::string &role) const override ;
-                private:
-                    StringCutObjectSelector<reco::Candidate> sel_;
-                    
-            };
+    private:
+      boost::ptr_vector<ParticleFilter> filters_;
+    };
 
+    class ByPdgId : public ParticleFilter {
+    public:
+      explicit ByPdgId(int32_t pdgCode, bool alsoAntiparticle = true);
+      ~ByPdgId() override {}
+      bool operator()(const CandRefType &cand, const std::string &role) const override;
 
+    private:
+      int32_t pdgCode_;
+      bool antiparticle_;
+    };
 
-} }
+    class ByString : public ParticleFilter {
+    public:
+      ByString(const std::string &cut);  // not putting the explicit on purpose, I want to see what happens
+      ~ByString() override {}
+      bool operator()(const CandRefType &cand, const std::string &role) const override;
+
+    private:
+      StringCutObjectSelector<reco::Candidate> sel_;
+    };
+
+  }  // namespace eventhypothesis
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/GenericDuplicateRemover.h
+++ b/PhysicsTools/PatUtils/interface/GenericDuplicateRemover.h
@@ -7,64 +7,61 @@
 
 namespace pat {
 
-    template <typename Comparator, typename Arbitrator>
-    class GenericDuplicateRemover {
+  template <typename Comparator, typename Arbitrator>
+  class GenericDuplicateRemover {
+  public:
+    GenericDuplicateRemover() {}
+    GenericDuplicateRemover(const Comparator &comp) : comparator_(comp) {}
+    GenericDuplicateRemover(const Comparator &comp, const Arbitrator &arbiter) : comparator_(comp), arbiter_(arbiter) {}
 
-        public:
+    ~GenericDuplicateRemover() {}
 
-           GenericDuplicateRemover() {}
-           GenericDuplicateRemover(const Comparator &comp) : comparator_(comp) {}
-           GenericDuplicateRemover(const Comparator &comp, const Arbitrator &arbiter) : comparator_(comp), arbiter_(arbiter) {}
-            
-           ~GenericDuplicateRemover() {}
+    /// Indices of duplicated items to remove
+    /// Comparator is used to check for duplication, Arbiter to pick the best one
+    /// e.g. comparator(x1, x2) should return true if they are duplicates
+    ///      arbitrator(x1, x2) should return true if x1 is better, that is we want to keep x1 and delete x2
+    /// Collection can be vector, View, or anything with the same interface
+    template <typename Collection>
+    std::unique_ptr<std::vector<size_t>> duplicates(const Collection &items) const;
 
-            /// Indices of duplicated items to remove
-            /// Comparator is used to check for duplication, Arbiter to pick the best one
-            /// e.g. comparator(x1, x2) should return true if they are duplicates
-            ///      arbitrator(x1, x2) should return true if x1 is better, that is we want to keep x1 and delete x2
-            /// Collection can be vector, View, or anything with the same interface
-            template <typename Collection>
-            std::unique_ptr< std::vector<size_t> >
-            duplicates(const Collection &items) const ;
+  private:
+    Comparator comparator_;
+    Arbitrator arbiter_;
 
-        private:
-            Comparator comparator_;
-            Arbitrator   arbiter_;
+  };  // class
+}  // namespace pat
 
-    }; // class
-}
+template <typename Comparator, typename Arbitrator>
+template <typename Collection>
+std::unique_ptr<std::vector<size_t>> pat::GenericDuplicateRemover<Comparator, Arbitrator>::duplicates(
+    const Collection &items) const {
+  size_t size = items.size();
 
-template<typename Comparator, typename Arbitrator>
-template<typename Collection>
-std::unique_ptr< std::vector<size_t> >
-pat::GenericDuplicateRemover<Comparator,Arbitrator>::duplicates(const Collection &items) const 
-{
-    size_t size = items.size();
+  std::vector<bool> bad(size, false);
 
-    std::vector<bool> bad(size, false);
+  for (size_t ie = 0; ie < size; ++ie) {
+    if (bad[ie])
+      continue;  // if already marked bad
 
-    for (size_t ie = 0; ie < size; ++ie) {
-        if (bad[ie]) continue; // if already marked bad
+    for (size_t je = ie + 1; je < size; ++je) {
+      if (bad[je])
+        continue;  // if already marked bad
 
-        for (size_t je = ie+1; je < size; ++je) {
-
-            if (bad[je]) continue; // if already marked bad
-
-            if ( comparator_(items[ie], items[je]) ) {
-                int toRemove = arbiter_(items[ie], items[je]) ? je : ie;
-                bad[toRemove] = true;
-            }
-        }
+      if (comparator_(items[ie], items[je])) {
+        int toRemove = arbiter_(items[ie], items[je]) ? je : ie;
+        bad[toRemove] = true;
+      }
     }
+  }
 
-    auto ret = std::make_unique<std::vector<size_t>>();
+  auto ret = std::make_unique<std::vector<size_t>>();
 
-    for (size_t i = 0; i < size; ++i) {
-        if (bad[i]) ret->push_back(i);
-    }
+  for (size_t i = 0; i < size; ++i) {
+    if (bad[i])
+      ret->push_back(i);
+  }
 
-    return ret;
+  return ret;
 }
-
 
 #endif

--- a/PhysicsTools/PatUtils/interface/GenericOverlapFinder.h
+++ b/PhysicsTools/PatUtils/interface/GenericOverlapFinder.h
@@ -9,90 +9,89 @@
 
 namespace pat {
 
-    /// A vector of pairs of indices <i1,i2>, for each i1 that overlaps, 
-    /// i2 is the "best" overlap match.
-    /// if an element of does not overlap with anyone, it will not end up in this list.
-    typedef std::vector< std::pair<size_t, size_t> > OverlapList;
+  /// A vector of pairs of indices <i1,i2>, for each i1 that overlaps,
+  /// i2 is the "best" overlap match.
+  /// if an element of does not overlap with anyone, it will not end up in this list.
+  typedef std::vector<std::pair<size_t, size_t> > OverlapList;
 
-    /// Turn a comparator in a distance for uses of overlap
-    ///    comparator(x,y) = true <-> x and y overlap
-    /// the associated distance would work as
-    ///     dist(x,y) = 1.0 - comparator(x,y)   [0 if overlap, 1 otherwise]
-    /// if the constructor of your Comparator does not need parameters, 
-    /// then the associated distance will not need parameters too.
-    template<typename Comparator>
-    struct OverlapDistance {
-        public:
-            OverlapDistance() {}
-            OverlapDistance(const Comparator &comp) : comp_(comp) {}
-            template<typename T1, typename T2>
-            double operator()(const T1 &t1, const T2 &t2) const {
-                return 1.0 - comp_(t1,t2);
-            }
-        private:
-            Comparator comp_;
-    }; //struct
-
-    /// Distance with deltaR metrics and a fixed maximum for the overlap deltaR
-    ///   dist(x,y) = deltaR2(x,y) / deltaR2cut;
-    struct OverlapByDeltaR {
-        public:
-            OverlapByDeltaR(double deltaR) :  scale_(1.0/(deltaR*deltaR)) {}
-            template<typename T1, typename T2>
-            double operator()(const T1 &t1, const T2 &t2) const {
-                return deltaR2(t1,t2) * scale_;
-            }
-        private:
-            double scale_;
-    }; //struct
-
-
-    template <typename Distance>
-    class GenericOverlapFinder {
-
-        public:
-
-           GenericOverlapFinder() {}
-           GenericOverlapFinder(const Distance &dist) : distance_(dist) {}
-            
-            /// Indices of overlapped items, and of the nearest item on they overlap with
-            /// Items are considered to overlap if distance(x1,x2) < 1
-            /// both Collections can be vectors, Views, or anything with the same interface
-            template <typename Collection, typename OtherCollection>
-            std::unique_ptr< OverlapList >
-            find(const Collection &items, const OtherCollection &other) const ;
-
-        private:
-            Distance distance_;
-
-    }; // class
-}
-
-template<typename Distance>
-template<typename Collection, typename OtherCollection>
-std::unique_ptr< pat::OverlapList >
-pat::GenericOverlapFinder<Distance>::find(const Collection &items, const OtherCollection &other) const 
-{
-    size_t size = items.size(), size2 = other.size();
-
-    auto ret = std::make_unique<OverlapList>();
-    
-    for (size_t ie = 0; ie < size; ++ie) {
-        double dmin   = 1.0;
-        size_t match = 0;
-
-        for (size_t je = 0; je < size2; ++je) {
-            double dist = distance_(items[ie], other[je]);
-            if (dist < dmin) { match = je; dmin = dist;  }
-        }
-        
-        if (dmin < 1.0) {
-            ret->push_back(std::make_pair(ie,match));
-        }
+  /// Turn a comparator in a distance for uses of overlap
+  ///    comparator(x,y) = true <-> x and y overlap
+  /// the associated distance would work as
+  ///     dist(x,y) = 1.0 - comparator(x,y)   [0 if overlap, 1 otherwise]
+  /// if the constructor of your Comparator does not need parameters,
+  /// then the associated distance will not need parameters too.
+  template <typename Comparator>
+  struct OverlapDistance {
+  public:
+    OverlapDistance() {}
+    OverlapDistance(const Comparator &comp) : comp_(comp) {}
+    template <typename T1, typename T2>
+    double operator()(const T1 &t1, const T2 &t2) const {
+      return 1.0 - comp_(t1, t2);
     }
 
-    return ret;
-}
+  private:
+    Comparator comp_;
+  };  //struct
 
+  /// Distance with deltaR metrics and a fixed maximum for the overlap deltaR
+  ///   dist(x,y) = deltaR2(x,y) / deltaR2cut;
+  struct OverlapByDeltaR {
+  public:
+    OverlapByDeltaR(double deltaR) : scale_(1.0 / (deltaR * deltaR)) {}
+    template <typename T1, typename T2>
+    double operator()(const T1 &t1, const T2 &t2) const {
+      return deltaR2(t1, t2) * scale_;
+    }
+
+  private:
+    double scale_;
+  };  //struct
+
+  template <typename Distance>
+  class GenericOverlapFinder {
+  public:
+    GenericOverlapFinder() {}
+    GenericOverlapFinder(const Distance &dist) : distance_(dist) {}
+
+    /// Indices of overlapped items, and of the nearest item on they overlap with
+    /// Items are considered to overlap if distance(x1,x2) < 1
+    /// both Collections can be vectors, Views, or anything with the same interface
+    template <typename Collection, typename OtherCollection>
+    std::unique_ptr<OverlapList> find(const Collection &items, const OtherCollection &other) const;
+
+  private:
+    Distance distance_;
+
+  };  // class
+}  // namespace pat
+
+template <typename Distance>
+template <typename Collection, typename OtherCollection>
+std::unique_ptr<pat::OverlapList> pat::GenericOverlapFinder<Distance>::find(const Collection &items,
+                                                                            const OtherCollection &other) const {
+  size_t size = items.size(), size2 = other.size();
+
+  auto ret = std::make_unique<OverlapList>();
+
+  for (size_t ie = 0; ie < size; ++ie) {
+    double dmin = 1.0;
+    size_t match = 0;
+
+    for (size_t je = 0; je < size2; ++je) {
+      double dist = distance_(items[ie], other[je]);
+      if (dist < dmin) {
+        match = je;
+        dmin = dist;
+      }
+    }
+
+    if (dmin < 1.0) {
+      ret->push_back(std::make_pair(ie, match));
+    }
+  }
+
+  return ret;
+}
 
 #endif

--- a/PhysicsTools/PatUtils/interface/JetSelection.h
+++ b/PhysicsTools/PatUtils/interface/JetSelection.h
@@ -8,27 +8,36 @@ namespace pat {
   /// Structure defining the jet selection.
   /// Used in the jet selectors.
   struct JetSelection {
-    std::string selectionType; ///< Choose selection type (see PATJetCleaner)
-    
-    double value;     ///< Cut value for likelihood-based selection
-    
+    std::string selectionType;  ///< Choose selection type (see PATJetCleaner)
+
+    double value;  ///< Cut value for likelihood-based selection
+
     /// @name Cuts for "custom" CaloJet selection:
-    //@{ 
+    //@{
     // From SusyAnalyzer
-    double EMFmin;                     double EMFmax;
+    double EMFmin;
+    double EMFmax;
     double Etamax;
     // From JetRejectorTool
     double Ptmin;
-    double EMvsHadFmin;               double EMvsHadFmax;
-    double HadFmin;                   double HadFmax;
-    double N90min;                    double N90max;
-    double NCaloTowersmin;            double NCaloTowersmax;
-    double HighestTowerOverJetmin;    double HighestTowerOverJetmax;
-    double RWidthmin;                 double RWidthmax;
-    double PtJetOverArea_min;         double PtJetOverArea_max;
-    double PtTowerOverArea_min;       double PtTowerOverArea_max;
+    double EMvsHadFmin;
+    double EMvsHadFmax;
+    double HadFmin;
+    double HadFmax;
+    double N90min;
+    double N90max;
+    double NCaloTowersmin;
+    double NCaloTowersmax;
+    double HighestTowerOverJetmin;
+    double HighestTowerOverJetmax;
+    double RWidthmin;
+    double RWidthmax;
+    double PtJetOverArea_min;
+    double PtJetOverArea_max;
+    double PtTowerOverArea_min;
+    double PtTowerOverArea_max;
     //@}
   };
-}
-  
+}  // namespace pat
+
 #endif

--- a/PhysicsTools/PatUtils/interface/JetSubstructurePacker.h
+++ b/PhysicsTools/PatUtils/interface/JetSubstructurePacker.h
@@ -2,7 +2,7 @@
 //
 // Package:    JetSubstructurePacker
 // Class:      JetSubstructurePacker
-// 
+//
 // \class JetSubstructurePacker JetSubstructurePacker.h PhysicsTools/PatUtils/interface/JetSubstructurePacker.h
 // Description: Class to pack subjet information from various pat::Jet collections into a single one.
 //
@@ -10,7 +10,6 @@
 // $Id: JetSubstructurePacker.cc,v 1.1 2013/03/07 20:13:55 srappocc Exp $
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,25 +31,23 @@
 // class decleration
 //
 
-
 class JetSubstructurePacker : public edm::stream::EDProducer<> {
-   public:
+public:
+  explicit JetSubstructurePacker(const edm::ParameterSet&);
+  ~JetSubstructurePacker() override;
 
-      explicit JetSubstructurePacker(const edm::ParameterSet&);
-      ~JetSubstructurePacker() override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
-      // data labels
-      float                                        distMax_;      
-      edm::EDGetTokenT<edm::View<pat::Jet> >       jetToken_;
-      std::vector<std::string>                     algoLabels_;
-      std::vector<edm::InputTag>                   algoTags_;
-      std::vector< edm::EDGetTokenT< edm::View<pat::Jet> > >   algoTokens_;
-      bool fixDaughters_;
-      edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
-      edm::EDGetTokenT<edm::Association<reco::PFCandidateCollection   >> pc2pf_;
+  // data labels
+  float distMax_;
+  edm::EDGetTokenT<edm::View<pat::Jet>> jetToken_;
+  std::vector<std::string> algoLabels_;
+  std::vector<edm::InputTag> algoTags_;
+  std::vector<edm::EDGetTokenT<edm::View<pat::Jet>>> algoTokens_;
+  bool fixDaughters_;
+  edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
+  edm::EDGetTokenT<edm::Association<reco::PFCandidateCollection>> pc2pf_;
 };

--- a/PhysicsTools/PatUtils/interface/LeptonJetIsolationAngle.h
+++ b/PhysicsTools/PatUtils/interface/LeptonJetIsolationAngle.h
@@ -15,7 +15,6 @@
   \author   Steven Lowette
 */
 
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -26,35 +25,32 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "PhysicsTools/PatUtils/interface/TrackerIsolationPt.h"
 
-
 namespace pat {
 
-
   class LeptonJetIsolationAngle {
+  public:
+    LeptonJetIsolationAngle(edm::ConsumesCollector&& iC);
+    ~LeptonJetIsolationAngle();
 
-    public:
+    float calculate(const Electron& anElectron,
+                    const edm::Handle<edm::View<reco::Track> >& trackHandle,
+                    const edm::Event& iEvent);
+    float calculate(const Muon& aMuon,
+                    const edm::Handle<edm::View<reco::Track> >& trackHandle,
+                    const edm::Event& iEvent);
 
-      LeptonJetIsolationAngle(edm::ConsumesCollector && iC);
-      ~LeptonJetIsolationAngle();
+  private:
+    float calculate(const CLHEP::HepLorentzVector& aLepton,
+                    const edm::Handle<edm::View<reco::Track> >& trackHandle,
+                    const edm::Event& iEvent);
+    float spaceAngle(const CLHEP::HepLorentzVector& aLepton, const reco::CaloJet& aJet);
 
-      float calculate(const Electron & anElectron, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent);
-      float calculate(const Muon & aMuon, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent);
-
-    private:
-
-      float calculate(const CLHEP::HepLorentzVector & aLepton, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent);
-      float spaceAngle(const CLHEP::HepLorentzVector & aLepton, const reco::CaloJet & aJet);
-
-    private:
-
-      TrackerIsolationPt trkIsolator_;
-      edm::EDGetTokenT<reco::CaloJetCollection>         jetToken_;
-      edm::EDGetTokenT<std::vector<reco::GsfElectron> > electronsToken_;
-
+  private:
+    TrackerIsolationPt trkIsolator_;
+    edm::EDGetTokenT<reco::CaloJetCollection> jetToken_;
+    edm::EDGetTokenT<std::vector<reco::GsfElectron> > electronsToken_;
   };
 
-
-}
+}  // namespace pat
 
 #endif
-

--- a/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
+++ b/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
@@ -14,7 +14,6 @@
   \author   Steven Lowette
 */
 
-
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -28,7 +27,7 @@ namespace reco {
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 namespace pat {
   class Electron;
@@ -37,19 +36,18 @@ namespace pat {
   class LeptonVertexSignificance {
   public:
     LeptonVertexSignificance();
-    LeptonVertexSignificance(const edm::EventSetup & iSetup, edm::ConsumesCollector && iC);
+    LeptonVertexSignificance(const edm::EventSetup& iSetup, edm::ConsumesCollector&& iC);
     ~LeptonVertexSignificance();
 
-    float calculate(const Electron & anElectron, const edm::Event & iEvent);
-    float calculate(const Muon & aMuon, const edm::Event & iEvent);
+    float calculate(const Electron& anElectron, const edm::Event& iEvent);
+    float calculate(const Muon& aMuon, const edm::Event& iEvent);
 
   private:
-    float calculate(const reco::Track & track, const edm::Event & iEvent);
-    TransientTrackBuilder * theTrackBuilder_;
+    float calculate(const reco::Track& track, const edm::Event& iEvent);
+    TransientTrackBuilder* theTrackBuilder_;
     edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
   };
 
-}
+}  // namespace pat
 
 #endif
-

--- a/PhysicsTools/PatUtils/interface/MiniIsolation.h
+++ b/PhysicsTools/PatUtils/interface/MiniIsolation.h
@@ -13,23 +13,28 @@
 #include "DataFormats/PatCandidates/interface/PFIsolation.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-namespace pat{
+namespace pat {
 
-  float miniIsoDr(const math::XYZTLorentzVector &p4, float mindr, float maxdr,
-		  float kt_scale);
+  float miniIsoDr(const math::XYZTLorentzVector& p4, float mindr, float maxdr, float kt_scale);
 
   // see src file for definitions of parameters
-  PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands, const math::XYZTLorentzVector& p4,
-                                   float mindr=0.05, float maxdr=0.2, float kt_scale=10.0,
-                                   float ptthresh=0.5, float deadcone_ch=0.0001,
-                                   float deadcone_pu=0.01, float deadcone_ph=0.01, float deadcone_nh=0.01,
-                                   float dZ_cut=0.0);
+  PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection* pfcands,
+                                 const math::XYZTLorentzVector& p4,
+                                 float mindr = 0.05,
+                                 float maxdr = 0.2,
+                                 float kt_scale = 10.0,
+                                 float ptthresh = 0.5,
+                                 float deadcone_ch = 0.0001,
+                                 float deadcone_pu = 0.01,
+                                 float deadcone_ph = 0.01,
+                                 float deadcone_nh = 0.01,
+                                 float dZ_cut = 0.0);
 
   double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-				   const math::XYZTLorentzVector& p4,
-				   double dr,
-				   double rho,
-                                   const std::vector<double> &area);
-}
+                                   const math::XYZTLorentzVector& p4,
+                                   double dr,
+                                   double rho,
+                                   const std::vector<double>& area);
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/MuonSelector.h
+++ b/PhysicsTools/PatUtils/interface/MuonSelector.h
@@ -28,52 +28,40 @@ namespace pat {
 
   /// Structure defining the muon selection
   struct MuonSelection {
-    std::string selectionType; ///< Choose selection type (see PATMuonCleaner)
-    
+    std::string selectionType;  ///< Choose selection type (see PATMuonCleaner)
+
     /// @name Cuts for "custom" selection type:
     //@{
     double dPbyPmax;
     double chi2max;
-    int    nHitsMin;
+    int nHitsMin;
     //@}
-	
-	/// @name Option for "muId" selection type:
+
+    /// @name Option for "muId" selection type:
     //@{
     muon::SelectionType flag;
-	double minCaloCompatibility;
-	double minSegmentCompatibility;
+    double minCaloCompatibility;
+    double minSegmentCompatibility;
     //@}
-	
   };
 
-
   class MuonSelector {
-
   public:
-    
-    MuonSelector( const MuonSelection& cfg ) : config_( cfg ) {}
+    MuonSelector(const MuonSelection& cfg) : config_(cfg) {}
     ~MuonSelector() {}
 
     /// Returns 0 if muon matches criteria, a flag otherwise.
     /// Criteria depend on the selector's configuration.
-    const pat::ParticleStatus
-    filter( const unsigned int& index,
-            const edm::View<reco::Muon>& muons ) const;
-    
+    const pat::ParticleStatus filter(const unsigned int& index, const edm::View<reco::Muon>& muons) const;
+
   private:
-    
     MuonSelection config_;
 
     /// Full-fledged selection based on SusyAnalyser
-    const pat::ParticleStatus
-    customSelection_( const unsigned int& index,
-                      const edm::View<reco::Muon>& muons  ) const;
-	const pat::ParticleStatus
-    muIdSelection_( const unsigned int& index,
-                      const edm::View<reco::Muon>& muons  ) const;
-    
+    const pat::ParticleStatus customSelection_(const unsigned int& index, const edm::View<reco::Muon>& muons) const;
+    const pat::ParticleStatus muIdSelection_(const unsigned int& index, const edm::View<reco::Muon>& muons) const;
 
-  }; // class
-} // namespace
+  };  // class
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/ObjectResolutionCalc.h
+++ b/PhysicsTools/PatUtils/interface/ObjectResolutionCalc.h
@@ -12,7 +12,6 @@
   \version  $Id: ObjectResolutionCalc.h,v 1.5 2008/10/08 19:19:25 gpetrucc Exp $
 */
 
-
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -31,43 +30,37 @@
 #include "TString.h"
 #include "TMultiLayerPerceptron.h"
 
-
 namespace pat {
 
-
   class ObjectResolutionCalc {
+  public:
+    ObjectResolutionCalc();
+    ObjectResolutionCalc(const TString& resopath, bool useNN);
+    ~ObjectResolutionCalc();
 
-    public:
-
-      ObjectResolutionCalc();
-      ObjectResolutionCalc(const TString& resopath, bool useNN);
-      ~ObjectResolutionCalc();
-
-      float obsRes(int obs, int eta, float eT);
-      int   etaBin(float eta);
+    float obsRes(int obs, int eta, float eT);
+    int etaBin(float eta);
 
 #ifdef OBSOLETE
-      void  operator()(Electron & obj);
-      void  operator()(Muon & obj);
-      void  operator()(Tau & obj);
-      void  operator()(Jet & obj);
-      void  operator()(MET & obj);
+    void operator()(Electron& obj);
+    void operator()(Muon& obj);
+    void operator()(Tau& obj);
+    void operator()(Jet& obj);
+    void operator()(MET& obj);
 #else
-      // WORKAROUND
-      template<typename T> void operator()(T &obj) { }
+    // WORKAROUND
+    template <typename T>
+    void operator()(T& obj) {}
 #endif
 
-    private:
-
-      TFile * resoFile_;
-      std::vector<float> etaBinVals_;
-      TF1 fResVsEt_[10][10];
-      TMultiLayerPerceptron * network_[10];
-      bool useNN_;
-
+  private:
+    TFile* resoFile_;
+    std::vector<float> etaBinVals_;
+    TF1 fResVsEt_[10][10];
+    TMultiLayerPerceptron* network_[10];
+    bool useNN_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/PATDiObjectProxy.h
+++ b/PhysicsTools/PatUtils/interface/PATDiObjectProxy.h
@@ -15,131 +15,131 @@
 
 namespace pat {
 
-/* Now we implement PATDiObjectProxy with typeid & static_casts on the fly. */
-class DiObjectProxy {
+  /* Now we implement PATDiObjectProxy with typeid & static_casts on the fly. */
+  class DiObjectProxy {
+  public:
+    /// Default constructor, requested by ROOT. NEVER use a default constructed item!
+    DiObjectProxy()
+        : cand1_(nullptr), cand2_(nullptr), type1_(nullptr), type2_(nullptr), totalP4ok_(false), totalP4_() {}
+    /// Constructor of the pair from two Candidates
+    /// Note: the Proxy MUST NOT outlive the Candidates, otherwise you get dangling pointers
+    DiObjectProxy(const reco::Candidate &c1, const reco::Candidate &c2)
+        : cand1_(&c1), cand2_(&c2), type1_(&typeid(c1)), type2_(&typeid(c2)), totalP4ok_(false), totalP4_() {}
 
-   public: 
-        /// Default constructor, requested by ROOT. NEVER use a default constructed item!
-        DiObjectProxy() : cand1_(nullptr), cand2_(nullptr), type1_(nullptr), type2_(nullptr), totalP4ok_(false), totalP4_()  {}
-        /// Constructor of the pair from two Candidates
-        /// Note: the Proxy MUST NOT outlive the Candidates, otherwise you get dangling pointers
-        DiObjectProxy(const reco::Candidate &c1, const reco::Candidate &c2) :
-            cand1_(&c1), cand2_(&c2), type1_(&typeid(c1)), type2_(&typeid(c2)), totalP4ok_(false), totalP4_() {}
-        
-        /// Gets the first Candidate
-        const reco::Candidate & cand1() const { return *cand1_; }
-        /// Gets the second Candidate
-        const reco::Candidate & cand2() const { return *cand2_; }
+    /// Gets the first Candidate
+    const reco::Candidate &cand1() const { return *cand1_; }
+    /// Gets the second Candidate
+    const reco::Candidate &cand2() const { return *cand2_; }
 
-        /// Get the angular separation
-        double deltaR() const { return ::deltaR(*cand1_, *cand2_); }
-        /// Get the phi separation
-        double deltaPhi() const { return ::deltaPhi(cand1_->phi(), cand2_->phi()); }
+    /// Get the angular separation
+    double deltaR() const { return ::deltaR(*cand1_, *cand2_); }
+    /// Get the phi separation
+    double deltaPhi() const { return ::deltaPhi(cand1_->phi(), cand2_->phi()); }
 
-        /// Get the total four momentum
-        // Implementation notice: return by const reference, not by value, 
-        // as it's easier for Reflex.
-        const reco::Candidate::LorentzVector & totalP4() const { 
-            if (!totalP4ok_) { 
-                totalP4_ = cand1_->p4() + cand2_->p4(); 
-                totalP4ok_ = true; 
-            }
-            return totalP4_;
+    /// Get the total four momentum
+    // Implementation notice: return by const reference, not by value,
+    // as it's easier for Reflex.
+    const reco::Candidate::LorentzVector &totalP4() const {
+      if (!totalP4ok_) {
+        totalP4_ = cand1_->p4() + cand2_->p4();
+        totalP4ok_ = true;
+      }
+      return totalP4_;
+    }
+
+    /// Get the PAT Electron, if the pair contains one and only one PAT Electron (throw exception otherwise)
+    const Electron &ele() const { return tryGetOne_<Electron>(); }
+    /// Get the PAT Muon, if the pair contains one and only one PAT Muon (throw exception otherwise)
+    const Muon &mu() const { return tryGetOne_<Muon>(); }
+    /// Get the PAT Tau, if the pair contains one and only one PAT Tau (throw exception otherwise)
+    const Tau &tau() const { return tryGetOne_<Tau>(); }
+    /// Get the PAT Photon, if the pair contains one and only one PAT Photon (throw exception otherwise)
+    const Photon &gam() const { return tryGetOne_<Photon>(); }
+    /// Get the PAT Jet, if the pair contains one and only one PAT Jet (throw exception otherwise)
+    const Jet &jet() const { return tryGetOne_<Jet>(); }
+    /// Get the PAT MET, if the pair contains one and only one PAT MET (throw exception otherwise)
+    const MET &met() const { return tryGetOne_<MET>(); }
+    /// Get the PAT GenericParticle, if the pair contains one and only one PAT GenericParticle (throw exception otherwise)
+    const GenericParticle &part() const { return tryGetOne_<GenericParticle>(); }
+    /// Get the PAT PFParticle, if the pair contains one and only one PAT PFParticle (throw exception otherwise)
+    const PFParticle &pf() const { return tryGetOne_<PFParticle>(); }
+
+    /// Get the first item, if it's a PAT Electron (throw exception otherwise)
+    const Electron &ele1() const { return tryGet_<Electron>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT Muon (throw exception otherwise)
+    const Muon &mu1() const { return tryGet_<Muon>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT Tau (throw exception otherwise)
+    const Tau &tau1() const { return tryGet_<Tau>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT Photon (throw exception otherwise)
+    const Photon &gam1() const { return tryGet_<Photon>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT Jet (throw exception otherwise)
+    const Jet &jet1() const { return tryGet_<Jet>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT MET (throw exception otherwise)
+    const MET &met1() const { return tryGet_<MET>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT GenericParticle (throw exception otherwise)
+    const GenericParticle &part1() const { return tryGet_<GenericParticle>(cand1_, type1_); }
+    /// Get the first item, if it's a PAT PFParticle (throw exception otherwise)
+    const PFParticle &pf1() const { return tryGet_<PFParticle>(cand1_, type1_); }
+
+    /// Get the second item, if it's a PAT Electron (throw exception otherwise)
+    const Electron &ele2() const { return tryGet_<Electron>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT Muon (throw exception otherwise)
+    const Muon &mu2() const { return tryGet_<Muon>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT Tau (throw exception otherwise)
+    const Tau &tau2() const { return tryGet_<Tau>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT Photon (throw exception otherwise)
+    const Photon &gam2() const { return tryGet_<Photon>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT Jet (throw exception otherwise)
+    const Jet &jet2() const { return tryGet_<Jet>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT MET (throw exception otherwise)
+    const MET &met2() const { return tryGet_<MET>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT GenericParticle (throw exception otherwise)
+    const GenericParticle &part2() const { return tryGet_<GenericParticle>(cand2_, type2_); }
+    /// Get the second item, if it's a PAT PFParticle (throw exception otherwise)
+    const PFParticle &pf2() const { return tryGet_<PFParticle>(cand2_, type2_); }
+
+  private:
+    template <typename T>
+    const T &tryGet_(const reco::Candidate *ptr, const std::type_info *type) const {
+      if (typeid(T) != *type) {
+        throw cms::Exception("Type Error")
+            << "pat::DiObjectProxy: the object of the pair is not of the type you request.\n"
+            << " Item Index in pair: " << (ptr == cand1_ ? "first" : "second") << "\n"
+            << " Requested TypeID  : " << ClassName<T>::name() << "\n"
+            << " Found TypeID      : " << className(*ptr) << "\n";
+      }
+      return static_cast<const T &>(*ptr);
+    }
+
+    template <typename T>
+    const T &tryGetOne_() const {
+      if (typeid(T) == *type1_) {
+        if (typeid(T) == *type2_) {
+          throw cms::Exception("Type Error")
+              << "pat::DiObjectProxy: "
+              << "you can't get use methods that get a particle by type if the two are of the same type!\n"
+              << " Requested Type:" << ClassName<T>::name() << "\n";
         }
-
-        /// Get the PAT Electron, if the pair contains one and only one PAT Electron (throw exception otherwise)
-        const Electron & ele()  const { return tryGetOne_<Electron>(); }
-        /// Get the PAT Muon, if the pair contains one and only one PAT Muon (throw exception otherwise)
-        const Muon & mu()  const { return tryGetOne_<Muon>(); }
-        /// Get the PAT Tau, if the pair contains one and only one PAT Tau (throw exception otherwise)
-        const Tau & tau()  const { return tryGetOne_<Tau>(); }
-        /// Get the PAT Photon, if the pair contains one and only one PAT Photon (throw exception otherwise)
-        const Photon & gam()  const { return tryGetOne_<Photon>(); }
-        /// Get the PAT Jet, if the pair contains one and only one PAT Jet (throw exception otherwise)
-        const Jet & jet()  const { return tryGetOne_<Jet>(); }
-        /// Get the PAT MET, if the pair contains one and only one PAT MET (throw exception otherwise)
-        const MET & met()  const { return tryGetOne_<MET>(); }
-        /// Get the PAT GenericParticle, if the pair contains one and only one PAT GenericParticle (throw exception otherwise)
-        const GenericParticle & part()  const { return tryGetOne_<GenericParticle>(); }
-        /// Get the PAT PFParticle, if the pair contains one and only one PAT PFParticle (throw exception otherwise)
-        const PFParticle & pf()  const { return tryGetOne_<PFParticle>(); }
-
-        /// Get the first item, if it's a PAT Electron (throw exception otherwise)
-        const Electron & ele1() const { return tryGet_<Electron>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT Muon (throw exception otherwise)
-        const Muon & mu1()  const { return tryGet_<Muon>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT Tau (throw exception otherwise)
-        const Tau & tau1()  const { return tryGet_<Tau>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT Photon (throw exception otherwise)
-        const Photon & gam1()  const { return tryGet_<Photon>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT Jet (throw exception otherwise)
-        const Jet & jet1()  const { return tryGet_<Jet>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT MET (throw exception otherwise)
-        const MET & met1()  const { return tryGet_<MET>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT GenericParticle (throw exception otherwise)
-        const GenericParticle & part1()  const { return tryGet_<GenericParticle>(cand1_, type1_); }
-        /// Get the first item, if it's a PAT PFParticle (throw exception otherwise)
-        const PFParticle & pf1()  const { return tryGet_<PFParticle>(cand1_, type1_); }
-
-        /// Get the second item, if it's a PAT Electron (throw exception otherwise)
-        const Electron & ele2() const { return tryGet_<Electron>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT Muon (throw exception otherwise)
-        const Muon & mu2()  const { return tryGet_<Muon>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT Tau (throw exception otherwise)
-        const Tau & tau2()  const { return tryGet_<Tau>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT Photon (throw exception otherwise)
-        const Photon & gam2()  const { return tryGet_<Photon>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT Jet (throw exception otherwise)
-        const Jet & jet2()  const { return tryGet_<Jet>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT MET (throw exception otherwise)
-        const MET & met2()  const { return tryGet_<MET>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT GenericParticle (throw exception otherwise)
-        const GenericParticle & part2()  const { return tryGet_<GenericParticle>(cand2_, type2_); }
-        /// Get the second item, if it's a PAT PFParticle (throw exception otherwise)
-        const PFParticle & pf2()  const { return tryGet_<PFParticle>(cand2_, type2_); }
-
-    private:
-
-        template<typename T>
-        const T & tryGet_(const reco::Candidate *ptr, const std::type_info *type) const {
-            if (typeid(T) != *type) {
-                throw cms::Exception("Type Error") << "pat::DiObjectProxy: the object of the pair is not of the type you request.\n" 
-                                                   << " Item Index in pair: " << (ptr == cand1_ ? "first" : "second") << "\n"
-                                                   << " Requested TypeID  : " << ClassName<T>::name() << "\n"
-                                                   << " Found TypeID      : " << className(*ptr) << "\n";
-            }
-            return static_cast<const T &>(*ptr);
+        return static_cast<const T &>(*cand1_);
+      } else {
+        if (typeid(T) != *type2_) {
+          throw cms::Exception("Type Error")
+              << "pat::DiObjectProxy: "
+              << "you can't get use methods that get a particle by type if neither of the two is of that type!\n"
+              << " Requested Type:" << ClassName<T>::name() << "\n"
+              << " Type of first :" << className(*cand1_) << "\n"
+              << " Type of second:" << className(*cand2_) << "\n";
         }
+        return static_cast<const T &>(*cand2_);
+      }
+    }
 
-        template<typename T> 
-        const T & tryGetOne_() const {
-            if (typeid(T) == *type1_) {
-                if (typeid(T) == *type2_) {
-                    throw cms::Exception("Type Error") << "pat::DiObjectProxy: " << 
-                        "you can't get use methods that get a particle by type if the two are of the same type!\n" <<
-                        " Requested Type:" << ClassName<T>::name() << "\n";
-                }
-                return static_cast<const T &>(*cand1_);
-            } else {
-                if (typeid(T) != *type2_) {
-                    throw cms::Exception("Type Error") << "pat::DiObjectProxy: " << 
-                        "you can't get use methods that get a particle by type if neither of the two is of that type!\n" <<
-                        " Requested Type:" << ClassName<T>::name() << "\n" <<
-                        " Type of first :" << className(*cand1_) << "\n" <<
-                        " Type of second:" << className(*cand2_) << "\n";
-                }
-                return static_cast<const T &>(*cand2_);
-            }
-        }
+    const reco::Candidate *cand1_, *cand2_;
+    const std::type_info *type1_, *type2_;
 
-       const reco::Candidate  *cand1_, *cand2_;
-       const std::type_info   *type1_, *type2_;
+    mutable bool totalP4ok_;
+    mutable reco::Candidate::LorentzVector totalP4_;
+  };
 
-       mutable bool totalP4ok_;
-       mutable reco::Candidate::LorentzVector totalP4_;
-       
-
-};
-
-}
+}  // namespace pat
 #endif

--- a/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
+++ b/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
@@ -29,61 +29,61 @@
 #include <string>
 #include <vector>
 
-namespace
-{
-  std::string format_vstring(const std::vector<std::string>& v)
-  {
+namespace {
+  std::string format_vstring(const std::vector<std::string>& v) {
     std::string retVal;
 
     retVal.append("{ ");
 
     unsigned numEntries = v.size();
-    for ( unsigned iEntry = 0; iEntry < numEntries; ++iEntry ) {
+    for (unsigned iEntry = 0; iEntry < numEntries; ++iEntry) {
       retVal.append(v[iEntry]);
-      if ( iEntry < (numEntries - 1) ) retVal.append(", ");
+      if (iEntry < (numEntries - 1))
+        retVal.append(", ");
     }
 
     retVal.append(" }");
 
     return retVal;
   }
-}
+}  // namespace
 
-class PATJetCorrExtractor
-{
- public:
-
-  reco::Candidate::LorentzVector operator()(const pat::Jet rawJet, const reco::JetCorrector* jetCorr,
-					    double jetCorrEtaMax = 9.9,
-					    const reco::Candidate::LorentzVector * const rawJetP4_specified = nullptr) const
-  {
-     JetCorrExtractorT<pat::Jet> jetCorrExtractor;
-     return jetCorrExtractor(rawJet, jetCorr, jetCorrEtaMax, rawJetP4_specified);
+class PATJetCorrExtractor {
+public:
+  reco::Candidate::LorentzVector operator()(
+      const pat::Jet rawJet,
+      const reco::JetCorrector* jetCorr,
+      double jetCorrEtaMax = 9.9,
+      const reco::Candidate::LorentzVector* const rawJetP4_specified = nullptr) const {
+    JetCorrExtractorT<pat::Jet> jetCorrExtractor;
+    return jetCorrExtractor(rawJet, jetCorr, jetCorrEtaMax, rawJetP4_specified);
   }
 
-  reco::Candidate::LorentzVector operator()(const pat::Jet& jet, const std::string& jetCorrLabel,
-					    double jetCorrEtaMax = 9.9,
-					    const reco::Candidate::LorentzVector* const rawJetP4_specified = nullptr) const
-  {
+  reco::Candidate::LorentzVector operator()(
+      const pat::Jet& jet,
+      const std::string& jetCorrLabel,
+      double jetCorrEtaMax = 9.9,
+      const reco::Candidate::LorentzVector* const rawJetP4_specified = nullptr) const {
     reco::Candidate::LorentzVector corrJetP4;
 
     try {
       corrJetP4 = jet.correctedP4(jetCorrLabel);
-      if(rawJetP4_specified != nullptr) {
-	//MM: compensate for potential removal of constituents (as muons)
-	//similar effect in JetMETCorrection/Type1MET/interface/JetCorrExtractor.h
-	reco::Candidate::LorentzVector rawJetP4 = jet.correctedP4("Uncorrected");
-	double corrFactor = corrJetP4.pt()/rawJetP4.pt();
-	corrJetP4 = (*rawJetP4_specified);
-	corrJetP4 *= corrFactor;
-	if(corrFactor<0) {
-	  edm::LogWarning("PATJetCorrExtractor") << "Negative jet energy scale correction noticed" << ".\n";
-	}
+      if (rawJetP4_specified != nullptr) {
+        //MM: compensate for potential removal of constituents (as muons)
+        //similar effect in JetMETCorrection/Type1MET/interface/JetCorrExtractor.h
+        reco::Candidate::LorentzVector rawJetP4 = jet.correctedP4("Uncorrected");
+        double corrFactor = corrJetP4.pt() / rawJetP4.pt();
+        corrJetP4 = (*rawJetP4_specified);
+        corrJetP4 *= corrFactor;
+        if (corrFactor < 0) {
+          edm::LogWarning("PATJetCorrExtractor") << "Negative jet energy scale correction noticed"
+                                                 << ".\n";
+        }
       }
-    } catch( cms::Exception const& ) {
+    } catch (cms::Exception const&) {
       throw cms::Exception("InvalidRequest")
-	<< "The JEC level " << jetCorrLabel << " does not exist !!\n"
-	<< "Available levels = " << format_vstring(jet.availableJECLevels()) << ".\n";
+          << "The JEC level " << jetCorrLabel << " does not exist !!\n"
+          << "Available levels = " << format_vstring(jet.availableJECLevels()) << ".\n";
     }
 
     return corrJetP4;
@@ -91,5 +91,3 @@ class PATJetCorrExtractor
 };
 
 #endif
-
-

--- a/PhysicsTools/PatUtils/interface/ParticleCode.h
+++ b/PhysicsTools/PatUtils/interface/ParticleCode.h
@@ -11,11 +11,10 @@
    \version $Id: $
 **/
 
-
 namespace pat {
 
   //! Definition of particle types
-  enum ParticleType { 
+  enum ParticleType {
     UNKNOWN = 0,  //!< 0: Unidentified isolated particle
     ELECTRON,     //!< 1:
     MUON,         //!< 2:
@@ -26,18 +25,16 @@ namespace pat {
     TOP,          //!< 7:
     INVISIBLE     //!< 8: Invisible particle (Monte Carlo only)
   };
-                      
 
   //! Definition of particle status after selection
-  enum ParticleStatus { 
-    GOOD = 0,    //!< 0: Passed selection
-    BAD,         //!< 1: Failed selection (without additional info)
-    HOVERE,      //!< 2: Bad H/E ratio
-    SHOWER,      //!< 3: Bad ECAL shower shape
-    MATCHING     //!< 4: Bad matching to track
+  enum ParticleStatus {
+    GOOD = 0,  //!< 0: Passed selection
+    BAD,       //!< 1: Failed selection (without additional info)
+    HOVERE,    //!< 2: Bad H/E ratio
+    SHOWER,    //!< 3: Bad ECAL shower shape
+    MATCHING   //!< 4: Bad matching to track
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/RawJetExtractorT.h
+++ b/PhysicsTools/PatUtils/interface/RawJetExtractorT.h
@@ -5,23 +5,23 @@
 
 namespace pat {
 
-    template <typename T>
-    class RawJetExtractorT  {
-        public:
-        RawJetExtractorT(){}
-            reco::Candidate::LorentzVector operator()(const T& jet) const {
-                return jet.p4();
-            }
-    };
+  template <typename T>
+  class RawJetExtractorT {
+  public:
+    RawJetExtractorT() {}
+    reco::Candidate::LorentzVector operator()(const T& jet) const { return jet.p4(); }
+  };
 
-    template <>
-    class RawJetExtractorT<pat::Jet> {
-        public:
-            reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const {
-                if ( jet.jecSetsAvailable() ) return jet.correctedP4("Uncorrected");
-                else return jet.p4();
-            }
-    };
-    
-}
+  template <>
+  class RawJetExtractorT<pat::Jet> {
+  public:
+    reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const {
+      if (jet.jecSetsAvailable())
+        return jet.correctedP4("Uncorrected");
+      else
+        return jet.p4();
+    }
+  };
+
+}  // namespace pat
 #endif

--- a/PhysicsTools/PatUtils/interface/RazorComputer.h
+++ b/PhysicsTools/PatUtils/interface/RazorComputer.h
@@ -4,30 +4,30 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-
 class RazorBox : public CachingVariable {
- public:
-  RazorBox(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) ;
-  ~RazorBox() override{}
-  
-  void compute(const edm::Event & iEvent) const;
- private:
+public:
+  RazorBox(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC);
+  ~RazorBox() override {}
+
+  void compute(const edm::Event& iEvent) const;
+
+private:
   double par_;
 };
 
 class RazorComputer : public VariableComputer {
- public:
-  RazorComputer(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) ;
+public:
+  RazorComputer(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC);
   ~RazorComputer() override{};
 
-  void compute(const edm::Event & iEvent) const override;
- private:
+  void compute(const edm::Event& iEvent) const override;
+
+private:
   edm::InputTag jet_;
   edm::InputTag met_;
   edm::EDGetTokenT<std::vector<pat::Jet>> jetToken_;
   edm::EDGetTokenT<std::vector<pat::MET>> metToken_;
-  float pt_,eta_;
-  
+  float pt_, eta_;
 };
 
 #endif

--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -109,7 +109,7 @@ template <typename T, typename Textractor>
     }
     auto shiftedJets = std::make_unique<JetCollection>();
 
-    if ( jetCorrPayloadName_ != "" ) {
+    if ( !jetCorrPayloadName_.empty() ) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
       es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
       const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];

--- a/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedJetProducerT.h
@@ -34,66 +34,59 @@
 #include <string>
 
 template <typename T, typename Textractor>
-  class ShiftedJetProducerT : public edm::stream::EDProducer<>
-{
+class ShiftedJetProducerT : public edm::stream::EDProducer<> {
   typedef std::vector<T> JetCollection;
 
- public:
-
+public:
   explicit ShiftedJetProducerT(const edm::ParameterSet& cfg)
-    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-      src_(cfg.getParameter<edm::InputTag>("src")),
-      srcToken_(consumes<JetCollection>(src_)),
-      jetCorrPayloadName_(""),
-      jetCorrParameters_(nullptr),
-      jecUncertainty_(nullptr),
-      jecUncertaintyValue_(-1.)
-  {
-    if ( cfg.exists("jecUncertaintyValue") ) {
+      : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+        src_(cfg.getParameter<edm::InputTag>("src")),
+        srcToken_(consumes<JetCollection>(src_)),
+        jetCorrPayloadName_(""),
+        jetCorrParameters_(nullptr),
+        jecUncertainty_(nullptr),
+        jecUncertaintyValue_(-1.) {
+    if (cfg.exists("jecUncertaintyValue")) {
       jecUncertaintyValue_ = cfg.getParameter<double>("jecUncertaintyValue");
     } else {
       jetCorrUncertaintyTag_ = cfg.getParameter<std::string>("jetCorrUncertaintyTag");
-      if ( cfg.exists("jetCorrInputFileName") ) {
-	jetCorrInputFileName_ = cfg.getParameter<edm::FileInPath>("jetCorrInputFileName");
-	if ( jetCorrInputFileName_.location() == edm::FileInPath::Unknown) throw cms::Exception("ShiftedJetProducerT")
-	  << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
-	jetCorrParameters_ = new JetCorrectorParameters(jetCorrInputFileName_.fullPath(), jetCorrUncertaintyTag_);
-	jecUncertainty_ = new JetCorrectionUncertainty(*jetCorrParameters_);
+      if (cfg.exists("jetCorrInputFileName")) {
+        jetCorrInputFileName_ = cfg.getParameter<edm::FileInPath>("jetCorrInputFileName");
+        if (jetCorrInputFileName_.location() == edm::FileInPath::Unknown)
+          throw cms::Exception("ShiftedJetProducerT")
+              << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
+        jetCorrParameters_ = new JetCorrectorParameters(jetCorrInputFileName_.fullPath(), jetCorrUncertaintyTag_);
+        jecUncertainty_ = new JetCorrectionUncertainty(*jetCorrParameters_);
       } else {
-	jetCorrPayloadName_ = cfg.getParameter<std::string>("jetCorrPayloadName");
+        jetCorrPayloadName_ = cfg.getParameter<std::string>("jetCorrPayloadName");
       }
     }
 
     addResidualJES_ = cfg.getParameter<bool>("addResidualJES");
-    if ( cfg.exists("jetCorrLabelUpToL3") ) {
+    if (cfg.exists("jetCorrLabelUpToL3")) {
       jetCorrLabelUpToL3_ = cfg.getParameter<edm::InputTag>("jetCorrLabelUpToL3");
       jetCorrTokenUpToL3_ = mayConsume<reco::JetCorrector>(jetCorrLabelUpToL3_);
-  }
-    if ( cfg.exists("jetCorrLabelUpToL3Res") && addResidualJES_ ) {
+    }
+    if (cfg.exists("jetCorrLabelUpToL3Res") && addResidualJES_) {
       jetCorrLabelUpToL3Res_ = cfg.getParameter<edm::InputTag>("jetCorrLabelUpToL3Res");
       jetCorrTokenUpToL3Res_ = mayConsume<reco::JetCorrector>(jetCorrLabelUpToL3Res_);
     }
-    jetCorrEtaMax_ = ( cfg.exists("jetCorrEtaMax") ) ?
-      cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
+    jetCorrEtaMax_ = (cfg.exists("jetCorrEtaMax")) ? cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
 
     shiftBy_ = cfg.getParameter<double>("shiftBy");
 
-    verbosity_ = ( cfg.exists("verbosity") ) ?
-      cfg.getParameter<int>("verbosity") : 0;
+    verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
 
     produces<JetCollection>();
   }
-  ~ShiftedJetProducerT() override
-  {
+  ~ShiftedJetProducerT() override {
     delete jetCorrParameters_;
     delete jecUncertainty_;
   }
 
- private:
-
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
-    if ( verbosity_ ) {
+private:
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
+    if (verbosity_) {
       std::cout << "<ShiftedJetProducerT::produce>:" << std::endl;
       std::cout << " moduleLabel = " << moduleLabel_ << std::endl;
       std::cout << " src = " << src_.label() << std::endl;
@@ -104,12 +97,12 @@ template <typename T, typename Textractor>
     edm::Handle<reco::JetCorrector> jetCorrUpToL3;
     evt.getByToken(jetCorrTokenUpToL3_, jetCorrUpToL3);
     edm::Handle<reco::JetCorrector> jetCorrUpToL3Res;
-    if ( evt.isRealData() && addResidualJES_ ) {
+    if (evt.isRealData() && addResidualJES_) {
       evt.getByToken(jetCorrTokenUpToL3Res_, jetCorrUpToL3Res);
     }
     auto shiftedJets = std::make_unique<JetCollection>();
 
-    if ( !jetCorrPayloadName_.empty() ) {
+    if (!jetCorrPayloadName_.empty()) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
       es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
       const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];
@@ -117,54 +110,56 @@ template <typename T, typename Textractor>
       jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
     }
 
-    for ( typename JetCollection::const_iterator originalJet = originalJets->begin();
-	  originalJet != originalJets->end(); ++originalJet ) {
+    for (typename JetCollection::const_iterator originalJet = originalJets->begin(); originalJet != originalJets->end();
+         ++originalJet) {
       reco::Candidate::LorentzVector originalJetP4 = originalJet->p4();
-      if ( verbosity_ ) {
-	std::cout << "originalJet: Pt = " << originalJetP4.pt() << ", eta = " << originalJetP4.eta() << ", phi = " << originalJetP4.phi() << std::endl;
+      if (verbosity_) {
+        std::cout << "originalJet: Pt = " << originalJetP4.pt() << ", eta = " << originalJetP4.eta()
+                  << ", phi = " << originalJetP4.phi() << std::endl;
       }
 
       double shift = 0.;
-      if ( jecUncertaintyValue_ != -1. ) {
-	shift = jecUncertaintyValue_;
+      if (jecUncertaintyValue_ != -1.) {
+        shift = jecUncertaintyValue_;
       } else {
-	jecUncertainty_->setJetEta(originalJetP4.eta());
-	jecUncertainty_->setJetPt(originalJetP4.pt());
+        jecUncertainty_->setJetEta(originalJetP4.eta());
+        jecUncertainty_->setJetPt(originalJetP4.pt());
 
-	shift = jecUncertainty_->getUncertainty(true);
+        shift = jecUncertainty_->getUncertainty(true);
       }
-      if ( verbosity_ ) {
-	std::cout << "shift = " << shift << std::endl;
+      if (verbosity_) {
+        std::cout << "shift = " << shift << std::endl;
       }
 
-      if ( evt.isRealData() && addResidualJES_ ) {
-    const static pat::RawJetExtractorT<T> rawJetExtractor{};
-	reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(*originalJet);
-	if ( rawJetP4.E() > 1.e-1 ) {
-	  reco::Candidate::LorentzVector corrJetP4upToL3 =
-	    std::is_base_of<class PATJetCorrExtractor, Textractor>::value ?
-	      jetCorrExtractor_(*originalJet, jetCorrLabelUpToL3_.label(), jetCorrEtaMax_, &rawJetP4) :
-	      jetCorrExtractor_(*originalJet, jetCorrUpToL3.product(), jetCorrEtaMax_, &rawJetP4);
-	  reco::Candidate::LorentzVector corrJetP4upToL3Res =
-	    std::is_base_of<class PATJetCorrExtractor, Textractor>::value ?
-	      jetCorrExtractor_(*originalJet, jetCorrLabelUpToL3Res_.label(), jetCorrEtaMax_, &rawJetP4) :
-	      jetCorrExtractor_(*originalJet, jetCorrUpToL3Res.product(), jetCorrEtaMax_, &rawJetP4);
-	  if ( corrJetP4upToL3.E() > 1.e-1 && corrJetP4upToL3Res.E() > 1.e-1 ) {
-	    double residualJES = (corrJetP4upToL3Res.E()/corrJetP4upToL3.E()) - 1.;
-	    shift = sqrt(shift*shift + residualJES*residualJES);
-	  }
-	}
+      if (evt.isRealData() && addResidualJES_) {
+        const static pat::RawJetExtractorT<T> rawJetExtractor{};
+        reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(*originalJet);
+        if (rawJetP4.E() > 1.e-1) {
+          reco::Candidate::LorentzVector corrJetP4upToL3 =
+              std::is_base_of<class PATJetCorrExtractor, Textractor>::value
+                  ? jetCorrExtractor_(*originalJet, jetCorrLabelUpToL3_.label(), jetCorrEtaMax_, &rawJetP4)
+                  : jetCorrExtractor_(*originalJet, jetCorrUpToL3.product(), jetCorrEtaMax_, &rawJetP4);
+          reco::Candidate::LorentzVector corrJetP4upToL3Res =
+              std::is_base_of<class PATJetCorrExtractor, Textractor>::value
+                  ? jetCorrExtractor_(*originalJet, jetCorrLabelUpToL3Res_.label(), jetCorrEtaMax_, &rawJetP4)
+                  : jetCorrExtractor_(*originalJet, jetCorrUpToL3Res.product(), jetCorrEtaMax_, &rawJetP4);
+          if (corrJetP4upToL3.E() > 1.e-1 && corrJetP4upToL3Res.E() > 1.e-1) {
+            double residualJES = (corrJetP4upToL3Res.E() / corrJetP4upToL3.E()) - 1.;
+            shift = sqrt(shift * shift + residualJES * residualJES);
+          }
+        }
       }
 
       shift *= shiftBy_;
-      if ( verbosity_ ) {
-	std::cout << "shift*shiftBy = " << shift << std::endl;
+      if (verbosity_) {
+        std::cout << "shift*shiftBy = " << shift << std::endl;
       }
 
       T shiftedJet(*originalJet);
-      shiftedJet.setP4((1. + shift)*originalJetP4);
-      if ( verbosity_ ) {
-	std::cout << "shiftedJet: Pt = " << shiftedJet.pt() << ", eta = " << shiftedJet.eta() << ", phi = " << shiftedJet.phi() << std::endl;
+      shiftedJet.setP4((1. + shift) * originalJetP4);
+      if (verbosity_) {
+        std::cout << "shiftedJet: Pt = " << shiftedJet.pt() << ", eta = " << shiftedJet.eta()
+                  << ", phi = " << shiftedJet.phi() << std::endl;
       }
 
       shiftedJets->push_back(shiftedJet);
@@ -185,25 +180,22 @@ template <typename T, typename Textractor>
   JetCorrectionUncertainty* jecUncertainty_;
 
   bool addResidualJES_;
-  edm::InputTag jetCorrLabelUpToL3_;    // L1+L2+L3 correction
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrTokenUpToL3_;    // L1+L2+L3 correction
-  edm::InputTag jetCorrLabelUpToL3Res_; // L1+L2+L3+Residual correction
-  edm::EDGetTokenT<reco::JetCorrector> jetCorrTokenUpToL3Res_; // L1+L2+L3+Residual correction
-  double jetCorrEtaMax_; // do not use JEC factors for |eta| above this threshold (recommended default = 4.7),
-                         // in order to work around problem with CMSSW_4_2_x JEC factors at high eta,
-                         // reported in
-                         //  https://hypernews.cern.ch/HyperNews/CMS/get/jes/270.html
-                         //  https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1259/1.html
+  edm::InputTag jetCorrLabelUpToL3_;                            // L1+L2+L3 correction
+  edm::EDGetTokenT<reco::JetCorrector> jetCorrTokenUpToL3_;     // L1+L2+L3 correction
+  edm::InputTag jetCorrLabelUpToL3Res_;                         // L1+L2+L3+Residual correction
+  edm::EDGetTokenT<reco::JetCorrector> jetCorrTokenUpToL3Res_;  // L1+L2+L3+Residual correction
+  double jetCorrEtaMax_;  // do not use JEC factors for |eta| above this threshold (recommended default = 4.7),
+                          // in order to work around problem with CMSSW_4_2_x JEC factors at high eta,
+                          // reported in
+                          //  https://hypernews.cern.ch/HyperNews/CMS/get/jes/270.html
+                          //  https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1259/1.html
   Textractor jetCorrExtractor_;
 
   double jecUncertaintyValue_;
 
-  double shiftBy_; // set to +1.0/-1.0 for up/down variation of energy scale
+  double shiftBy_;  // set to +1.0/-1.0 for up/down variation of energy scale
 
-  int verbosity_; // flag to enabled/disable debug output
+  int verbosity_;  // flag to enabled/disable debug output
 };
 
 #endif
-
-
-

--- a/PhysicsTools/PatUtils/interface/ShiftedParticleProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedParticleProducerT.h
@@ -28,25 +28,22 @@
 #include <vector>
 
 template <typename T>
-class ShiftedParticleProducerT : public edm::stream::EDProducer<>
-{
+class ShiftedParticleProducerT : public edm::stream::EDProducer<> {
   typedef std::vector<T> ParticleCollection;
 
- public:
-
+public:
   explicit ShiftedParticleProducerT(const edm::ParameterSet& cfg)
-    : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-  {
+      : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
     srcToken_ = consumes<ParticleCollection>(cfg.getParameter<edm::InputTag>("src"));
 
     shiftBy_ = cfg.getParameter<double>("shiftBy");
 
-    if ( cfg.exists("binning") ) {
+    if (cfg.exists("binning")) {
       typedef std::vector<edm::ParameterSet> vParameterSet;
       vParameterSet cfgBinning = cfg.getParameter<vParameterSet>("binning");
-      for ( vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin();
-	    cfgBinningEntry != cfgBinning.end(); ++cfgBinningEntry ) {
-	binning_.push_back(new binningEntryType(*cfgBinningEntry));
+      for (vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin(); cfgBinningEntry != cfgBinning.end();
+           ++cfgBinningEntry) {
+        binning_.push_back(new binningEntryType(*cfgBinningEntry));
       }
     } else {
       double uncertainty = cfg.getParameter<double>("uncertainty");
@@ -55,40 +52,38 @@ class ShiftedParticleProducerT : public edm::stream::EDProducer<>
 
     produces<ParticleCollection>();
   }
-  ~ShiftedParticleProducerT() override
-  {
-    for ( typename std::vector<binningEntryType*>::const_iterator it = binning_.begin();
-	  it != binning_.end(); ++it ) {
+  ~ShiftedParticleProducerT() override {
+    for (typename std::vector<binningEntryType*>::const_iterator it = binning_.begin(); it != binning_.end(); ++it) {
       delete (*it);
     }
   }
 
- private:
-
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
+private:
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     edm::Handle<ParticleCollection> originalParticles;
     evt.getByToken(srcToken_, originalParticles);
 
     auto shiftedParticles = std::make_unique<ParticleCollection>();
 
-    for ( typename ParticleCollection::const_iterator originalParticle = originalParticles->begin();
-	  originalParticle != originalParticles->end(); ++originalParticle ) {
-
+    for (typename ParticleCollection::const_iterator originalParticle = originalParticles->begin();
+         originalParticle != originalParticles->end();
+         ++originalParticle) {
       double uncertainty = 0.;
-      for ( typename std::vector<binningEntryType*>::iterator binningEntry = binning_.begin();
-	    binningEntry != binning_.end(); ++binningEntry ) {
-	if ( (!(*binningEntry)->binSelection_) || (*(*binningEntry)->binSelection_)(*originalParticle) ) {
-	  uncertainty = (*binningEntry)->binUncertainty_;
-	  break;
-	}
+      for (typename std::vector<binningEntryType*>::iterator binningEntry = binning_.begin();
+           binningEntry != binning_.end();
+           ++binningEntry) {
+        if ((!(*binningEntry)->binSelection_) || (*(*binningEntry)->binSelection_)(*originalParticle)) {
+          uncertainty = (*binningEntry)->binUncertainty_;
+          break;
+        }
       }
 
-      double shift = shiftBy_*uncertainty;
+      double shift = shiftBy_ * uncertainty;
 
       reco::Candidate::LorentzVector shiftedParticleP4 = originalParticle->p4();
-      //leave 0*nan = 0 
-      if (! (edm::isNotFinite(shift) && shiftedParticleP4.mag2()==0)) shiftedParticleP4 *= (1. + shift);
+      //leave 0*nan = 0
+      if (!(edm::isNotFinite(shift) && shiftedParticleP4.mag2() == 0))
+        shiftedParticleP4 *= (1. + shift);
 
       T shiftedParticle(*originalParticle);
       shiftedParticle.setP4(shiftedParticleP4);
@@ -103,30 +98,18 @@ class ShiftedParticleProducerT : public edm::stream::EDProducer<>
 
   edm::EDGetTokenT<ParticleCollection> srcToken_;
 
-  struct binningEntryType
-  {
-    binningEntryType(double uncertainty)
-      : binSelection_(nullptr),
-        binUncertainty_(uncertainty)
-    {}
+  struct binningEntryType {
+    binningEntryType(double uncertainty) : binSelection_(nullptr), binUncertainty_(uncertainty) {}
     binningEntryType(const edm::ParameterSet& cfg)
-    : binSelection_(new StringCutObjectSelector<T>(cfg.getParameter<std::string>("binSelection"))),
-      binUncertainty_(cfg.getParameter<double>("binUncertainty"))
-    {}
-    ~binningEntryType()
-    {
-      delete binSelection_;
-    }
+        : binSelection_(new StringCutObjectSelector<T>(cfg.getParameter<std::string>("binSelection"))),
+          binUncertainty_(cfg.getParameter<double>("binUncertainty")) {}
+    ~binningEntryType() { delete binSelection_; }
     StringCutObjectSelector<T>* binSelection_;
     double binUncertainty_;
   };
   std::vector<binningEntryType*> binning_;
 
-  double shiftBy_; // set to +1.0/-1.0 for up/down variation of energy scale
+  double shiftBy_;  // set to +1.0/-1.0 for up/down variation of energy scale
 };
 
 #endif
-
-
-
-

--- a/PhysicsTools/PatUtils/interface/SimpleJetTrackAssociator.h
+++ b/PhysicsTools/PatUtils/interface/SimpleJetTrackAssociator.h
@@ -3,22 +3,21 @@
 #include "DataFormats/Common/interface/View.h"
 
 namespace helper {
-class SimpleJetTrackAssociator {
-        public:
-                SimpleJetTrackAssociator() :
-                    deltaR2_(0), nHits_(0), chi2nMax_(0) { }
-                SimpleJetTrackAssociator(double deltaR, int32_t nHits, double chi2nMax) :
-                    deltaR2_(deltaR*deltaR), nHits_(nHits), chi2nMax_(chi2nMax) {}
-                
-                // 100% FWLite compatible (but will make up transient refs)
-                void associateTransient(const math::XYZVector &dir, const reco::TrackCollection  &in, reco::TrackRefVector &out) ;
+  class SimpleJetTrackAssociator {
+  public:
+    SimpleJetTrackAssociator() : deltaR2_(0), nHits_(0), chi2nMax_(0) {}
+    SimpleJetTrackAssociator(double deltaR, int32_t nHits, double chi2nMax)
+        : deltaR2_(deltaR * deltaR), nHits_(nHits), chi2nMax_(chi2nMax) {}
 
-                // more versatile, persistent refs, for when we're in full framework
-                void associate(const math::XYZVector &dir, const edm::View<reco::Track> &in, reco::TrackRefVector &out) ;
-        private:
-                double  deltaR2_;
-                int32_t nHits_;
-                double  chi2nMax_;
-};
-}
+    // 100% FWLite compatible (but will make up transient refs)
+    void associateTransient(const math::XYZVector &dir, const reco::TrackCollection &in, reco::TrackRefVector &out);
 
+    // more versatile, persistent refs, for when we're in full framework
+    void associate(const math::XYZVector &dir, const edm::View<reco::Track> &in, reco::TrackRefVector &out);
+
+  private:
+    double deltaR2_;
+    int32_t nHits_;
+    double chi2nMax_;
+  };
+}  // namespace helper

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -37,289 +37,288 @@
 #include <random>
 
 namespace pat {
-    class GenJetMatcher {
-        public:
-            GenJetMatcher(const edm::ParameterSet& cfg, edm::ConsumesCollector&& collector):
-                m_genJetsToken(collector.consumes<reco::GenJetCollection>(cfg.getParameter<edm::InputTag>("genJets"))),
-                m_dR_max(cfg.getParameter<double>("dRMax")),
-                m_dPt_max_factor(cfg.getParameter<double>("dPtMaxFactor")) {
-                // Empty
-            }
+  class GenJetMatcher {
+  public:
+    GenJetMatcher(const edm::ParameterSet& cfg, edm::ConsumesCollector&& collector)
+        : m_genJetsToken(collector.consumes<reco::GenJetCollection>(cfg.getParameter<edm::InputTag>("genJets"))),
+          m_dR_max(cfg.getParameter<double>("dRMax")),
+          m_dPt_max_factor(cfg.getParameter<double>("dPtMaxFactor")) {
+      // Empty
+    }
 
-            static void fillDescriptions(edm::ParameterSetDescription& desc) {
-                desc.add<edm::InputTag>("genJets");
-                desc.add<double>("dRMax");
-                desc.add<double>("dPtMaxFactor");
-            }
+    static void fillDescriptions(edm::ParameterSetDescription& desc) {
+      desc.add<edm::InputTag>("genJets");
+      desc.add<double>("dRMax");
+      desc.add<double>("dPtMaxFactor");
+    }
 
-            void getTokens(const edm::Event& event) {
-               event.getByToken(m_genJetsToken, m_genJets);
-            }
+    void getTokens(const edm::Event& event) { event.getByToken(m_genJetsToken, m_genJets); }
 
-            template<class T>
-            const reco::GenJet* match(const T& jet, double resolution) {
-                const reco::GenJetCollection& genJets = *m_genJets;
+    template <class T>
+    const reco::GenJet* match(const T& jet, double resolution) {
+      const reco::GenJetCollection& genJets = *m_genJets;
 
-                // Try to find a gen jet matching
-                // dR < m_dR_max
-                // dPt < m_dPt_max_factor * resolution
+      // Try to find a gen jet matching
+      // dR < m_dR_max
+      // dPt < m_dPt_max_factor * resolution
 
-                double min_dR = std::numeric_limits<double>::infinity();
-                const reco::GenJet* matched_genJet = nullptr;
+      double min_dR = std::numeric_limits<double>::infinity();
+      const reco::GenJet* matched_genJet = nullptr;
 
-                for (const auto& genJet: genJets) {
-                    double dR = deltaR(genJet, jet);
+      for (const auto& genJet : genJets) {
+        double dR = deltaR(genJet, jet);
 
-                    if (dR > min_dR)
-                        continue;
+        if (dR > min_dR)
+          continue;
 
-                    if (dR < m_dR_max) {
-                        double dPt = std::abs(genJet.pt() - jet.pt());
-                        if (dPt > m_dPt_max_factor * resolution)
-                            continue;
+        if (dR < m_dR_max) {
+          double dPt = std::abs(genJet.pt() - jet.pt());
+          if (dPt > m_dPt_max_factor * resolution)
+            continue;
 
-                        min_dR = dR;
-                        matched_genJet = &genJet;
-                    }
-                }
+          min_dR = dR;
+          matched_genJet = &genJet;
+        }
+      }
 
-                return matched_genJet;
-            }
+      return matched_genJet;
+    }
 
-        private:
-            edm::EDGetTokenT<reco::GenJetCollection> m_genJetsToken;
-            edm::Handle<reco::GenJetCollection> m_genJets;
+  private:
+    edm::EDGetTokenT<reco::GenJetCollection> m_genJetsToken;
+    edm::Handle<reco::GenJetCollection> m_genJets;
 
-            double m_dR_max;
-            double m_dPt_max_factor;
-    };
-};
+    double m_dR_max;
+    double m_dPt_max_factor;
+  };
+};  // namespace pat
 
 template <typename T>
 class SmearedJetProducerT : public edm::stream::EDProducer<> {
+  using JetCollection = std::vector<T>;
 
-    using JetCollection = std::vector<T>;
+public:
+  explicit SmearedJetProducerT(const edm::ParameterSet& cfg)
+      : m_enabled(cfg.getParameter<bool>("enabled")),
+        m_useDeterministicSeed(cfg.getParameter<bool>("useDeterministicSeed")),
+        m_debug(cfg.getUntrackedParameter<bool>("debug", false)) {
+    m_jets_token = consumes<JetCollection>(cfg.getParameter<edm::InputTag>("src"));
 
-    public:
-        explicit SmearedJetProducerT(const edm::ParameterSet& cfg):
-            m_enabled(cfg.getParameter<bool>("enabled")),
-            m_useDeterministicSeed(cfg.getParameter<bool>("useDeterministicSeed")),
-            m_debug(cfg.getUntrackedParameter<bool>("debug", false)) {
+    if (m_enabled) {
+      m_rho_token = consumes<double>(cfg.getParameter<edm::InputTag>("rho"));
 
-            m_jets_token = consumes<JetCollection>(cfg.getParameter<edm::InputTag>("src"));
+      m_use_txt_files = cfg.exists("resolutionFile") && cfg.exists("scaleFactorFile");
 
-            if (m_enabled) {
-                m_rho_token = consumes<double>(cfg.getParameter<edm::InputTag>("rho"));
+      if (m_use_txt_files) {
+        std::string resolutionFile = cfg.getParameter<edm::FileInPath>("resolutionFile").fullPath();
+        std::string scaleFactorFile = cfg.getParameter<edm::FileInPath>("scaleFactorFile").fullPath();
 
-                m_use_txt_files = cfg.exists("resolutionFile") && cfg.exists("scaleFactorFile");
+        m_resolution_from_file.reset(new JME::JetResolution(resolutionFile));
+        m_scale_factor_from_file.reset(new JME::JetResolutionScaleFactor(scaleFactorFile));
+      } else {
+        m_jets_algo = cfg.getParameter<std::string>("algo");
+        m_jets_algo_pt = cfg.getParameter<std::string>("algopt");
+      }
 
-                if (m_use_txt_files) {
-                    std::string resolutionFile = cfg.getParameter<edm::FileInPath>("resolutionFile").fullPath();
-                    std::string scaleFactorFile = cfg.getParameter<edm::FileInPath>("scaleFactorFile").fullPath();
+      std::uint32_t seed = cfg.getParameter<std::uint32_t>("seed");
+      m_random_generator = std::mt19937(seed);
 
-                    m_resolution_from_file.reset(new JME::JetResolution(resolutionFile));
-                    m_scale_factor_from_file.reset(new JME::JetResolutionScaleFactor(scaleFactorFile));
-                } else {
-                    m_jets_algo = cfg.getParameter<std::string>("algo");
-                    m_jets_algo_pt = cfg.getParameter<std::string>("algopt");
-                }
+      bool skipGenMatching = cfg.getParameter<bool>("skipGenMatching");
+      if (!skipGenMatching)
+        m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
 
-                std::uint32_t seed = cfg.getParameter<std::uint32_t>("seed");
-                m_random_generator = std::mt19937(seed);
+      std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
+      m_nomVar = 1;
+      if (variation == 0)
+        m_systematic_variation = Variation::NOMINAL;
+      else if (variation == 1)
+        m_systematic_variation = Variation::UP;
+      else if (variation == -1)
+        m_systematic_variation = Variation::DOWN;
+      else if (variation == 101) {
+        m_systematic_variation = Variation::NOMINAL;
+        m_nomVar = 1;
+      } else if (variation == -101) {
+        m_systematic_variation = Variation::NOMINAL;
+        m_nomVar = -1;
+      } else
+        throw edm::Exception(edm::errors::ConfigFileReadError,
+                             "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
+    }
 
-                bool skipGenMatching = cfg.getParameter<bool>("skipGenMatching");
-                if (! skipGenMatching)
-                    m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
+    produces<JetCollection>();
+  }
 
-                std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
-		m_nomVar=1;
-                if (variation == 0)
-                    m_systematic_variation = Variation::NOMINAL;
-                else if (variation == 1)
-                    m_systematic_variation = Variation::UP;
-                else if (variation == -1)
-                    m_systematic_variation = Variation::DOWN;
-		else if (variation == 101) {
-		  m_systematic_variation = Variation::NOMINAL;
-		  m_nomVar=1;
-		}
-		else if (variation == -101) {
-		  m_systematic_variation = Variation::NOMINAL;
-		  m_nomVar=-1;
-		}
-                else
-                    throw edm::Exception(edm::errors::ConfigFileReadError, "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
-            }
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
 
-            produces<JetCollection>();
-        }
+    desc.add<edm::InputTag>("src");
+    desc.add<bool>("enabled");
+    desc.add<edm::InputTag>("rho");
+    desc.add<std::int32_t>("variation", 0);
+    desc.add<std::uint32_t>("seed", 37428479);
+    desc.add<bool>("skipGenMatching", false);
+    desc.add<bool>("useDeterministicSeed", true);
+    desc.addUntracked<bool>("debug", false);
 
-        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-            edm::ParameterSetDescription desc;
+    auto source = (edm::ParameterDescription<std::string>("algo", true) and
+                   edm::ParameterDescription<std::string>("algopt", true)) xor
+                  (edm::ParameterDescription<edm::FileInPath>("resolutionFile", true) and
+                   edm::ParameterDescription<edm::FileInPath>("scaleFactorFile", true));
+    desc.addNode(std::move(source));
 
-            desc.add<edm::InputTag>("src");
-            desc.add<bool>("enabled");
-            desc.add<edm::InputTag>("rho");
-            desc.add<std::int32_t>("variation", 0);
-            desc.add<std::uint32_t>("seed", 37428479);
-            desc.add<bool>("skipGenMatching", false);
-            desc.add<bool>("useDeterministicSeed", true);
-            desc.addUntracked<bool>("debug", false);
+    pat::GenJetMatcher::fillDescriptions(desc);
 
-            auto source =
-	      (edm::ParameterDescription<std::string>("algo", true) and edm::ParameterDescription<std::string>("algopt", true)) xor
-	      (edm::ParameterDescription<edm::FileInPath>("resolutionFile", true) and edm::ParameterDescription<edm::FileInPath>("scaleFactorFile", true));
-            desc.addNode(std::move(source));
+    descriptions.addDefault(desc);
+  }
 
-            pat::GenJetMatcher::fillDescriptions(desc);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override {
+    edm::Handle<JetCollection> jets_collection;
+    event.getByToken(m_jets_token, jets_collection);
 
-            descriptions.addDefault(desc);
-        }
+    // Disable the module when running on real data
+    if (m_enabled && event.isRealData()) {
+      m_enabled = false;
+      m_genJetMatcher.reset();
+    }
 
-        void produce(edm::Event& event, const edm::EventSetup& setup) override {
+    edm::Handle<double> rho;
+    if (m_enabled)
+      event.getByToken(m_rho_token, rho);
 
-            edm::Handle<JetCollection> jets_collection;
-            event.getByToken(m_jets_token, jets_collection);
+    JME::JetResolution resolution;
+    JME::JetResolutionScaleFactor resolution_sf;
 
-            // Disable the module when running on real data
-            if (m_enabled && event.isRealData()) {
-                m_enabled = false;
-                m_genJetMatcher.reset();
-            }
+    const JetCollection& jets = *jets_collection;
 
-            edm::Handle<double> rho;
-            if (m_enabled)
-                event.getByToken(m_rho_token, rho);
+    if (m_enabled) {
+      if (m_use_txt_files) {
+        resolution = *m_resolution_from_file;
+        resolution_sf = *m_scale_factor_from_file;
+      } else {
+        resolution = JME::JetResolution::get(setup, m_jets_algo_pt);
+        resolution_sf = JME::JetResolutionScaleFactor::get(setup, m_jets_algo);
+      }
 
-            JME::JetResolution resolution;
-            JME::JetResolutionScaleFactor resolution_sf;
+      if (m_useDeterministicSeed) {
+        unsigned int runNum_uint = static_cast<unsigned int>(event.id().run());
+        unsigned int lumiNum_uint = static_cast<unsigned int>(event.id().luminosityBlock());
+        unsigned int evNum_uint = static_cast<unsigned int>(event.id().event());
+        unsigned int jet0eta = uint32_t(jets.empty() ? 0 : jets[0].eta() / 0.01);
+        std::uint32_t seed = jet0eta + m_nomVar + (lumiNum_uint << 10) + (runNum_uint << 20) + evNum_uint;
+        m_random_generator.seed(seed);
+      }
+    }
 
-            const JetCollection& jets = *jets_collection;
+    if (m_genJetMatcher)
+      m_genJetMatcher->getTokens(event);
 
-            if (m_enabled) {
-                if (m_use_txt_files) {
-                    resolution = *m_resolution_from_file;
-                    resolution_sf = *m_scale_factor_from_file;
-                } else {
-                    resolution = JME::JetResolution::get(setup, m_jets_algo_pt);
-                    resolution_sf = JME::JetResolutionScaleFactor::get(setup, m_jets_algo);
-                }
+    auto smearedJets = std::make_unique<JetCollection>();
 
-                if(m_useDeterministicSeed) {
-                    unsigned int runNum_uint = static_cast <unsigned int> (event.id().run());
-                    unsigned int lumiNum_uint = static_cast <unsigned int> (event.id().luminosityBlock());
-                    unsigned int evNum_uint = static_cast <unsigned int> (event.id().event());
-                    unsigned int jet0eta = uint32_t(jets.empty() ? 0 : jets[0].eta()/0.01);
-                    std::uint32_t seed = jet0eta + m_nomVar + (lumiNum_uint<<10) + (runNum_uint<<20) + evNum_uint;
-                    m_random_generator.seed(seed);
-                }
-            }
+    for (const auto& jet : jets) {
+      if ((!m_enabled) || (jet.pt() == 0)) {
+        // Module disabled or invalid p4. Simply copy the input jet.
+        smearedJets->push_back(jet);
 
-            if (m_genJetMatcher)
-                m_genJetMatcher->getTokens(event);
+        continue;
+      }
 
-            auto smearedJets = std::make_unique<JetCollection>();
+      double jet_resolution = resolution.getResolution(
+          {{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
+      double jer_sf = resolution_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, m_systematic_variation);
 
-            for (const auto& jet: jets) {
+      if (m_debug) {
+        std::cout << "jet:  pt: " << jet.pt() << "  eta: " << jet.eta() << "  phi: " << jet.phi()
+                  << "  e: " << jet.energy() << std::endl;
+        std::cout << "resolution: " << jet_resolution << std::endl;
+        std::cout << "resolution scale factor: " << jer_sf << std::endl;
+      }
 
-                if ((! m_enabled) || (jet.pt() == 0)) {
-                    // Module disabled or invalid p4. Simply copy the input jet.
-                    smearedJets->push_back(jet);
+      const reco::GenJet* genJet = nullptr;
+      if (m_genJetMatcher)
+        genJet = m_genJetMatcher->match(jet, jet.pt() * jet_resolution);
 
-                    continue;
-                }
+      double smearFactor = 1.;
 
-                double jet_resolution = resolution.getResolution({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
-                double jer_sf = resolution_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, m_systematic_variation);
-
-                if (m_debug) {
-                    std::cout << "jet:  pt: " << jet.pt() << "  eta: " << jet.eta() << "  phi: " << jet.phi() << "  e: " << jet.energy() << std::endl;
-                    std::cout << "resolution: " << jet_resolution << std::endl;
-                    std::cout << "resolution scale factor: " << jer_sf << std::endl;
-                }
-
-                const reco::GenJet* genJet = nullptr;
-                if (m_genJetMatcher)
-                    genJet = m_genJetMatcher->match(jet, jet.pt() * jet_resolution);
-
-                double smearFactor = 1.;
-
-                if (genJet) {
-                    /*
+      if (genJet) {
+        /*
                      * Case 1: we have a "good" gen jet matched to the reco jet
                      */
 
-                    if (m_debug) {
-                        std::cout << "gen jet:  pt: " << genJet->pt() << "  eta: " << genJet->eta() << "  phi: " << genJet->phi() << "  e: " << genJet->energy() << std::endl;
-                    }
+        if (m_debug) {
+          std::cout << "gen jet:  pt: " << genJet->pt() << "  eta: " << genJet->eta() << "  phi: " << genJet->phi()
+                    << "  e: " << genJet->energy() << std::endl;
+        }
 
-                    double dPt = jet.pt() - genJet->pt();
-                    smearFactor = 1 + m_nomVar*(jer_sf - 1.) * dPt / jet.pt();
+        double dPt = jet.pt() - genJet->pt();
+        smearFactor = 1 + m_nomVar * (jer_sf - 1.) * dPt / jet.pt();
 
-                } else if (jer_sf > 1) {
-                    /*
+      } else if (jer_sf > 1) {
+        /*
                      * Case 2: we don't have a gen jet. Smear jet pt using a random gaussian variation
                      */
 
-                    double sigma = jet_resolution * std::sqrt(jer_sf * jer_sf - 1);
-                    if (m_debug) {
-                        std::cout << "gaussian width: " << sigma << std::endl;
-                    }
-
-                    std::normal_distribution<> d(0, sigma);
-                    smearFactor = 1. + m_nomVar*d(m_random_generator);
-                } else if (m_debug) {
-                    std::cout << "Impossible to smear this jet" << std::endl;
-                }
-
-                if (jet.energy() * smearFactor < MIN_JET_ENERGY) {
-                    // Negative or too small smearFactor. We would change direction of the jet
-                    // and this is not what we want.
-                    // Recompute the smearing factor in order to have jet.energy() == MIN_JET_ENERGY
-                    double newSmearFactor = MIN_JET_ENERGY / jet.energy();
-                    if (m_debug) {
-                        std::cout << "The smearing factor (" << smearFactor << ") is either negative or too small. Fixing it to " << newSmearFactor << " to avoid change of direction." << std::endl;
-                    }
-                    smearFactor = newSmearFactor;
-                }
-
-                T smearedJet = jet;
-                smearedJet.scaleEnergy(smearFactor);
-
-                if (m_debug) {
-                    std::cout << "smeared jet (" << smearFactor << "):  pt: " << smearedJet.pt() << "  eta: " << smearedJet.eta() << "  phi: " << smearedJet.phi() << "  e: " << smearedJet.energy() << std::endl;
-                }
-
-                smearedJets->push_back(smearedJet);
-            }
-
-            // Sort jets by pt
-            std::sort(smearedJets->begin(), smearedJets->end(), jetPtComparator);
-
-            event.put(std::move(smearedJets));
+        double sigma = jet_resolution * std::sqrt(jer_sf * jer_sf - 1);
+        if (m_debug) {
+          std::cout << "gaussian width: " << sigma << std::endl;
         }
 
-    private:
-        static constexpr const double MIN_JET_ENERGY = 1e-2;
+        std::normal_distribution<> d(0, sigma);
+        smearFactor = 1. + m_nomVar * d(m_random_generator);
+      } else if (m_debug) {
+        std::cout << "Impossible to smear this jet" << std::endl;
+      }
 
-        edm::EDGetTokenT<JetCollection> m_jets_token;
-        edm::EDGetTokenT<double> m_rho_token;
-        bool m_enabled;
-        std::string m_jets_algo_pt;
-        std::string m_jets_algo;
-        Variation m_systematic_variation;
-        bool m_useDeterministicSeed;
-        bool m_debug;
-        std::shared_ptr<pat::GenJetMatcher> m_genJetMatcher;
+      if (jet.energy() * smearFactor < MIN_JET_ENERGY) {
+        // Negative or too small smearFactor. We would change direction of the jet
+        // and this is not what we want.
+        // Recompute the smearing factor in order to have jet.energy() == MIN_JET_ENERGY
+        double newSmearFactor = MIN_JET_ENERGY / jet.energy();
+        if (m_debug) {
+          std::cout << "The smearing factor (" << smearFactor << ") is either negative or too small. Fixing it to "
+                    << newSmearFactor << " to avoid change of direction." << std::endl;
+        }
+        smearFactor = newSmearFactor;
+      }
 
-        bool m_use_txt_files;
-        std::unique_ptr<JME::JetResolution> m_resolution_from_file;
-        std::unique_ptr<JME::JetResolutionScaleFactor> m_scale_factor_from_file;
+      T smearedJet = jet;
+      smearedJet.scaleEnergy(smearFactor);
 
-        std::mt19937 m_random_generator;
+      if (m_debug) {
+        std::cout << "smeared jet (" << smearFactor << "):  pt: " << smearedJet.pt() << "  eta: " << smearedJet.eta()
+                  << "  phi: " << smearedJet.phi() << "  e: " << smearedJet.energy() << std::endl;
+      }
 
-        GreaterByPt<T> jetPtComparator;
+      smearedJets->push_back(smearedJet);
+    }
 
-	int m_nomVar;
+    // Sort jets by pt
+    std::sort(smearedJets->begin(), smearedJets->end(), jetPtComparator);
+
+    event.put(std::move(smearedJets));
+  }
+
+private:
+  static constexpr const double MIN_JET_ENERGY = 1e-2;
+
+  edm::EDGetTokenT<JetCollection> m_jets_token;
+  edm::EDGetTokenT<double> m_rho_token;
+  bool m_enabled;
+  std::string m_jets_algo_pt;
+  std::string m_jets_algo;
+  Variation m_systematic_variation;
+  bool m_useDeterministicSeed;
+  bool m_debug;
+  std::shared_ptr<pat::GenJetMatcher> m_genJetMatcher;
+
+  bool m_use_txt_files;
+  std::unique_ptr<JME::JetResolution> m_resolution_from_file;
+  std::unique_ptr<JME::JetResolutionScaleFactor> m_scale_factor_from_file;
+
+  std::mt19937 m_random_generator;
+
+  GreaterByPt<T> jetPtComparator;
+
+  int m_nomVar;
 };
 #endif

--- a/PhysicsTools/PatUtils/interface/StringParserTools.h
+++ b/PhysicsTools/PatUtils/interface/StringParserTools.h
@@ -15,94 +15,89 @@
 #include "DataFormats/PatCandidates/interface/PFParticle.h"
 
 class PATStringObjectFunction {
-
 public:
-    PATStringObjectFunction() {}
-    PATStringObjectFunction(const std::string &string) ;
+  PATStringObjectFunction() {}
+  PATStringObjectFunction(const std::string &string);
 
-    double operator()(const reco::Candidate &c) const ;
+  double operator()(const reco::Candidate &c) const;
 
 private:
-    std::string expr_;
-    boost::shared_ptr<StringObjectFunction<reco::Candidate> > candFunc_; 
+  std::string expr_;
+  boost::shared_ptr<StringObjectFunction<reco::Candidate> > candFunc_;
 
-    boost::shared_ptr<StringObjectFunction<pat::Electron> >         eleFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::Muon> >              muFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::Tau> >              tauFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::Photon> >           gamFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::Jet> >              jetFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::MET> >              metFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::GenericParticle> >   gpFunc_;
-    boost::shared_ptr<StringObjectFunction<pat::PFParticle> >        pfFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::Electron> > eleFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::Muon> > muFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::Tau> > tauFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::Photon> > gamFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::Jet> > jetFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::MET> > metFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::GenericParticle> > gpFunc_;
+  boost::shared_ptr<StringObjectFunction<pat::PFParticle> > pfFunc_;
 
-    template<typename Obj> 
-    boost::shared_ptr<StringObjectFunction<Obj> > tryGet(const std::string &str) {
-        try {
-            return boost::shared_ptr<StringObjectFunction<Obj> >(new StringObjectFunction<Obj>(str));
-        } catch (cms::Exception const&) {
-            return boost::shared_ptr<StringObjectFunction<Obj> >();
-        }
+  template <typename Obj>
+  boost::shared_ptr<StringObjectFunction<Obj> > tryGet(const std::string &str) {
+    try {
+      return boost::shared_ptr<StringObjectFunction<Obj> >(new StringObjectFunction<Obj>(str));
+    } catch (cms::Exception const &) {
+      return boost::shared_ptr<StringObjectFunction<Obj> >();
     }
+  }
 
-    template<typename Obj>
-    double
-    tryEval(const reco::Candidate &c, const boost::shared_ptr<StringObjectFunction<Obj> > &func) const {
-        if (func.get()) return (*func)(static_cast<const Obj &>(c));
-        else throwBadType(typeid(c));
-        assert(false);
-        return 0; 
-    }
+  template <typename Obj>
+  double tryEval(const reco::Candidate &c, const boost::shared_ptr<StringObjectFunction<Obj> > &func) const {
+    if (func.get())
+      return (*func)(static_cast<const Obj &>(c));
+    else
+      throwBadType(typeid(c));
+    assert(false);
+    return 0;
+  }
 
-    // out of line throw exception
-    void throwBadType(const std::type_info &ty1) const ;
-    
+  // out of line throw exception
+  void throwBadType(const std::type_info &ty1) const;
 };
 
 class PATStringCutObjectSelector {
-
 public:
-    PATStringCutObjectSelector() {}
-    PATStringCutObjectSelector(const std::string &string) ;
+  PATStringCutObjectSelector() {}
+  PATStringCutObjectSelector(const std::string &string);
 
-    bool operator()(const reco::Candidate &c) const ;
+  bool operator()(const reco::Candidate &c) const;
 
 private:
-    std::string expr_;
-    boost::shared_ptr<StringCutObjectSelector<reco::Candidate> > candFunc_; 
+  std::string expr_;
+  boost::shared_ptr<StringCutObjectSelector<reco::Candidate> > candFunc_;
 
-    boost::shared_ptr<StringCutObjectSelector<pat::Electron> >         eleFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::Muon> >              muFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::Tau> >              tauFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::Photon> >           gamFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::Jet> >              jetFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::MET> >              metFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::GenericParticle> >   gpFunc_;
-    boost::shared_ptr<StringCutObjectSelector<pat::PFParticle> >        pfFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::Electron> > eleFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::Muon> > muFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::Tau> > tauFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::Photon> > gamFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::Jet> > jetFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::MET> > metFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::GenericParticle> > gpFunc_;
+  boost::shared_ptr<StringCutObjectSelector<pat::PFParticle> > pfFunc_;
 
-    template<typename Obj> 
-    boost::shared_ptr<StringCutObjectSelector<Obj> > tryGet(const std::string &str) {
-        try {
-            return boost::shared_ptr<StringCutObjectSelector<Obj> >(new StringCutObjectSelector<Obj>(str));
-        } catch (cms::Exception const&) {
-            return boost::shared_ptr<StringCutObjectSelector<Obj> >();
-        }
+  template <typename Obj>
+  boost::shared_ptr<StringCutObjectSelector<Obj> > tryGet(const std::string &str) {
+    try {
+      return boost::shared_ptr<StringCutObjectSelector<Obj> >(new StringCutObjectSelector<Obj>(str));
+    } catch (cms::Exception const &) {
+      return boost::shared_ptr<StringCutObjectSelector<Obj> >();
     }
+  }
 
-    template<typename Obj>
-    bool
-    tryEval(const reco::Candidate &c, const boost::shared_ptr<StringCutObjectSelector<Obj> > &func) const {
-        if (func.get()) return (*func)(static_cast<const Obj &>(c));
-        else throwBadType(typeid(c));
-        assert(false);
-        return false;
-    }
+  template <typename Obj>
+  bool tryEval(const reco::Candidate &c, const boost::shared_ptr<StringCutObjectSelector<Obj> > &func) const {
+    if (func.get())
+      return (*func)(static_cast<const Obj &>(c));
+    else
+      throwBadType(typeid(c));
+    assert(false);
+    return false;
+  }
 
-    // out of line throw exception
-    void throwBadType(const std::type_info &ty1) const ;
-
-    
-    
+  // out of line throw exception
+  void throwBadType(const std::type_info &ty1) const;
 };
-
 
 #endif

--- a/PhysicsTools/PatUtils/interface/TrackerIsolationPt.h
+++ b/PhysicsTools/PatUtils/interface/TrackerIsolationPt.h
@@ -20,9 +20,10 @@ namespace reco {
 }
 
 namespace edm {
-  template<typename T> class View;
+  template <typename T>
+  class View;
   class InputTag;
-}
+}  // namespace edm
 
 namespace pat {
   class Electron;
@@ -31,14 +32,16 @@ namespace pat {
   public:
     TrackerIsolationPt();
     virtual ~TrackerIsolationPt();
-    
-    float calculate(const Electron & theElectron, const edm::View<reco::Track> & theTracks, float isoConeElectron = 0.3) const;
-    float calculate(const Muon & theMuon, const edm::View<reco::Track> & theTracks, float isoConeMuon = 0.3) const;
-    
+
+    float calculate(const Electron& theElectron,
+                    const edm::View<reco::Track>& theTracks,
+                    float isoConeElectron = 0.3) const;
+    float calculate(const Muon& theMuon, const edm::View<reco::Track>& theTracks, float isoConeMuon = 0.3) const;
+
   private:
-    float calculate(const reco::Track & theTrack, const edm::View<reco::Track> & theTracks, float isoCone) const;
+    float calculate(const reco::Track& theTrack, const edm::View<reco::Track>& theTracks, float isoCone) const;
   };
 
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/TriggerHelper.h
+++ b/PhysicsTools/PatUtils/interface/TriggerHelper.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_PatUtils_TriggerHelper_h
 #define PhysicsTools_PatUtils_TriggerHelper_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatUtils
@@ -20,82 +19,124 @@
   \version  $Id: TriggerHelper.h,v 1.6 2010/12/20 11:55:48 vadler Exp $
 */
 
-
 #include <string>
 
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "FWCore/Framework/interface/Event.h"
 
-
 namespace pat {
 
   namespace helper {
 
     class TriggerMatchHelper {
+    public:
+      /// Constructors and Destructor
 
-      public:
+      /// Default constructor
+      TriggerMatchHelper(){};
 
-        /// Constructors and Destructor
+      /// Destructor
+      ~TriggerMatchHelper(){};
 
-        /// Default constructor
-        TriggerMatchHelper() {};
+      /// Methods
 
-        /// Destructor
-        ~TriggerMatchHelper() {};
-
-        /// Methods
-
-        /// Get a reference to the trigger objects matched to a certain physics object given by a reference for a certain matcher module
-        /// ... by resulting association
-        TriggerObjectRef triggerMatchObject( const reco::CandidateBaseRef & candRef, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// ... by matcher module label
-        TriggerObjectRef triggerMatchObject( const reco::CandidateBaseRef & candRef, const std::string & labelMatcher      , const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// Get a reference to the trigger objects matched to a certain physics object given by a collection and index for a certain matcher module
-        /// ... by resulting association
-        template< class C > TriggerObjectRef triggerMatchObject( const edm::Handle< C > & candCollHandle, const size_t iCand, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// ... by matcher module label
-        template< class C > TriggerObjectRef triggerMatchObject( const edm::Handle< C > & candCollHandle, const size_t iCand, const std::string & labelMatcher      , const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// Get a table of references to all trigger objects matched to a certain physics object given by a reference
-        TriggerObjectMatchMap triggerMatchObjects( const reco::CandidateBaseRef & candRef, const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// Get a table of references to all trigger objects matched to a certain physics object given by a collection and index
-        template< class C > TriggerObjectMatchMap triggerMatchObjects( const edm::Handle< C > & candCollHandle, const size_t iCand, const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// Get a vector of references to the phyics objects matched to a certain trigger object given by a reference for a certain matcher module
-        /// ... by resulting association
-        reco::CandidateBaseRefVector triggerMatchCandidates( const pat::TriggerObjectRef & objectRef, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// ... by matcher module label
-        reco::CandidateBaseRefVector triggerMatchCandidates( const pat::TriggerObjectRef & objectRef, const std::string & labelMatcher      , const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// Get a vector of references to the phyics objects matched to a certain trigger object given by a collection and index for a certain matcher module
-        /// ... by resulting association
-        reco::CandidateBaseRefVector triggerMatchCandidates( const edm::Handle< TriggerObjectCollection > & trigCollHandle, const size_t iTrig, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-        /// ... by matcher module label
-        reco::CandidateBaseRefVector triggerMatchCandidates( const edm::Handle< TriggerObjectCollection > & trigCollHandle, const size_t iTrig, const std::string & labelMatcher      , const edm::Event & event, const TriggerEvent & triggerEvent ) const;
-
+      /// Get a reference to the trigger objects matched to a certain physics object given by a reference for a certain matcher module
+      /// ... by resulting association
+      TriggerObjectRef triggerMatchObject(const reco::CandidateBaseRef& candRef,
+                                          const TriggerObjectMatch* matchResult,
+                                          const edm::Event& event,
+                                          const TriggerEvent& triggerEvent) const;
+      /// ... by matcher module label
+      TriggerObjectRef triggerMatchObject(const reco::CandidateBaseRef& candRef,
+                                          const std::string& labelMatcher,
+                                          const edm::Event& event,
+                                          const TriggerEvent& triggerEvent) const;
+      /// Get a reference to the trigger objects matched to a certain physics object given by a collection and index for a certain matcher module
+      /// ... by resulting association
+      template <class C>
+      TriggerObjectRef triggerMatchObject(const edm::Handle<C>& candCollHandle,
+                                          const size_t iCand,
+                                          const TriggerObjectMatch* matchResult,
+                                          const edm::Event& event,
+                                          const TriggerEvent& triggerEvent) const;
+      /// ... by matcher module label
+      template <class C>
+      TriggerObjectRef triggerMatchObject(const edm::Handle<C>& candCollHandle,
+                                          const size_t iCand,
+                                          const std::string& labelMatcher,
+                                          const edm::Event& event,
+                                          const TriggerEvent& triggerEvent) const;
+      /// Get a table of references to all trigger objects matched to a certain physics object given by a reference
+      TriggerObjectMatchMap triggerMatchObjects(const reco::CandidateBaseRef& candRef,
+                                                const edm::Event& event,
+                                                const TriggerEvent& triggerEvent) const;
+      /// Get a table of references to all trigger objects matched to a certain physics object given by a collection and index
+      template <class C>
+      TriggerObjectMatchMap triggerMatchObjects(const edm::Handle<C>& candCollHandle,
+                                                const size_t iCand,
+                                                const edm::Event& event,
+                                                const TriggerEvent& triggerEvent) const;
+      /// Get a vector of references to the phyics objects matched to a certain trigger object given by a reference for a certain matcher module
+      /// ... by resulting association
+      reco::CandidateBaseRefVector triggerMatchCandidates(const pat::TriggerObjectRef& objectRef,
+                                                          const TriggerObjectMatch* matchResult,
+                                                          const edm::Event& event,
+                                                          const TriggerEvent& triggerEvent) const;
+      /// ... by matcher module label
+      reco::CandidateBaseRefVector triggerMatchCandidates(const pat::TriggerObjectRef& objectRef,
+                                                          const std::string& labelMatcher,
+                                                          const edm::Event& event,
+                                                          const TriggerEvent& triggerEvent) const;
+      /// Get a vector of references to the phyics objects matched to a certain trigger object given by a collection and index for a certain matcher module
+      /// ... by resulting association
+      reco::CandidateBaseRefVector triggerMatchCandidates(const edm::Handle<TriggerObjectCollection>& trigCollHandle,
+                                                          const size_t iTrig,
+                                                          const TriggerObjectMatch* matchResult,
+                                                          const edm::Event& event,
+                                                          const TriggerEvent& triggerEvent) const;
+      /// ... by matcher module label
+      reco::CandidateBaseRefVector triggerMatchCandidates(const edm::Handle<TriggerObjectCollection>& trigCollHandle,
+                                                          const size_t iTrig,
+                                                          const std::string& labelMatcher,
+                                                          const edm::Event& event,
+                                                          const TriggerEvent& triggerEvent) const;
     };
 
     // Method Templates
 
     // Get a reference to the trigger objects matched to a certain physics object given by a collection and index for a certain matcher module
-    template< class C > TriggerObjectRef TriggerMatchHelper::triggerMatchObject( const edm::Handle< C > & candCollHandle, const size_t iCand, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-    {
-      const reco::CandidateBaseRef candRef( edm::Ref< C >( candCollHandle, iCand ) );
-      return triggerMatchObject( candRef, matchResult, event, triggerEvent );
+    template <class C>
+    TriggerObjectRef TriggerMatchHelper::triggerMatchObject(const edm::Handle<C>& candCollHandle,
+                                                            const size_t iCand,
+                                                            const TriggerObjectMatch* matchResult,
+                                                            const edm::Event& event,
+                                                            const TriggerEvent& triggerEvent) const {
+      const reco::CandidateBaseRef candRef(edm::Ref<C>(candCollHandle, iCand));
+      return triggerMatchObject(candRef, matchResult, event, triggerEvent);
     }
-    template< class C > TriggerObjectRef TriggerMatchHelper::triggerMatchObject( const edm::Handle< C > & candCollHandle, const size_t iCand, const std::string & labelMatcher, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-    {
-      return triggerMatchObject( candCollHandle, iCand, triggerEvent.triggerObjectMatchResult( labelMatcher ), event, triggerEvent );
+    template <class C>
+    TriggerObjectRef TriggerMatchHelper::triggerMatchObject(const edm::Handle<C>& candCollHandle,
+                                                            const size_t iCand,
+                                                            const std::string& labelMatcher,
+                                                            const edm::Event& event,
+                                                            const TriggerEvent& triggerEvent) const {
+      return triggerMatchObject(
+          candCollHandle, iCand, triggerEvent.triggerObjectMatchResult(labelMatcher), event, triggerEvent);
     }
 
     // Get a table of references to all trigger objects matched to a certain physics object given by a collection and index
-    template< class C > TriggerObjectMatchMap TriggerMatchHelper::triggerMatchObjects( const edm::Handle< C > & candCollHandle, const size_t iCand, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-    {
-      const reco::CandidateBaseRef candRef( edm::Ref< C >( candCollHandle, iCand ) );
-      return triggerMatchObjects( candRef, event, triggerEvent );
+    template <class C>
+    TriggerObjectMatchMap TriggerMatchHelper::triggerMatchObjects(const edm::Handle<C>& candCollHandle,
+                                                                  const size_t iCand,
+                                                                  const edm::Event& event,
+                                                                  const TriggerEvent& triggerEvent) const {
+      const reco::CandidateBaseRef candRef(edm::Ref<C>(candCollHandle, iCand));
+      return triggerMatchObjects(candRef, event, triggerEvent);
     }
 
-  }
+  }  // namespace helper
 
-}
-
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/VertexAssociationSelector.h
+++ b/PhysicsTools/PatUtils/interface/VertexAssociationSelector.h
@@ -6,16 +6,16 @@
 #include "DataFormats/PatCandidates/interface/Vertexing.h"
 
 namespace pat {
-    class VertexAssociationSelector {
-        public:
-            /// Structure to pack config for the constructor.
-            /// Note that even if no cuts are selected (all values set to 0),
-            /// this will still return 'false' for a null pat::VertexAssociation
-            struct Config {
-                Config() : dZ(0), dR(0), sigmasZ(0), sigmasR(0) {} //, sigmas3d(0) {}
-                /// cuts on Z and transverse distance from the vertex, absolute values or significances
-                float dZ, dR, sigmasZ, sigmasR; //, sigmas3d; 
-            };
+  class VertexAssociationSelector {
+  public:
+    /// Structure to pack config for the constructor.
+    /// Note that even if no cuts are selected (all values set to 0),
+    /// this will still return 'false' for a null pat::VertexAssociation
+    struct Config {
+      Config() : dZ(0), dR(0), sigmasZ(0), sigmasR(0) {}  //, sigmas3d(0) {}
+      /// cuts on Z and transverse distance from the vertex, absolute values or significances
+      float dZ, dR, sigmasZ, sigmasR;  //, sigmas3d;
+    };
 #if 0            
             /// Candidate selector made by a VertexAssociationSelector and a single vertex
             class SelectCandidates {
@@ -37,20 +37,20 @@ namespace pat {
             };
 #endif
 
-            /// an empty constructor is sometimes needed
-            VertexAssociationSelector() {} 
-            /// constructor from a configuration
-            VertexAssociationSelector(const Config & conf) ;
+    /// an empty constructor is sometimes needed
+    VertexAssociationSelector() {}
+    /// constructor from a configuration
+    VertexAssociationSelector(const Config &conf);
 
-            /// check if this VertexAssociation is ok
-            bool operator()(const pat::VertexAssociation & vass) const ;
+    /// check if this VertexAssociation is ok
+    bool operator()(const pat::VertexAssociation &vass) const;
 
-            /// check if this candidate and this vertex are compatible
-            /// this will just use the basic candidate vertex position,
-            /// without any fancy track extrapolation.
-            bool operator()(const reco::Candidate &c, const reco::Vertex &) const ;
+    /// check if this candidate and this vertex are compatible
+    /// this will just use the basic candidate vertex position,
+    /// without any fancy track extrapolation.
+    bool operator()(const reco::Candidate &c, const reco::Vertex &) const;
 
-            pat::VertexAssociation simpleAssociation(const reco::Candidate &c, const reco::VertexRef & vtx) const ;
+    pat::VertexAssociation simpleAssociation(const reco::Candidate &c, const reco::VertexRef &vtx) const;
 #if 0
             /// Make a Candidate selector from this association selector and a vertex
             SelectCandidates selectCandidates(const reco::Vertex    & vtx ) const { return SelectCandidates(*this, vtx  ); }
@@ -58,10 +58,10 @@ namespace pat {
             /// Make a Vertex selector from this association selector and a candidate
             SelectVertices   selectVertices(  const reco::Candidate & cand) const { return SelectVertices(  *this, cand ); }
 #endif
-        private:
-            Config conf_;
+  private:
+    Config conf_;
 
-    }; // class
-} // namespace
+  };  // class
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatUtils/interface/bJetSelector.h
+++ b/PhysicsTools/PatUtils/interface/bJetSelector.h
@@ -18,24 +18,19 @@
 
 class bJetSelector {
 public:
-
   bJetSelector(const edm::ParameterSet& cfg);
-  bool IsbTag(const pat::Jet& JetCand,
-              const std::string& operpoint,
-              const std::string& tagger) const;
-  bool IsbTag(const pat::Jet& JetCand,
-              const std::string& operpoint) const;
+  bool IsbTag(const pat::Jet& JetCand, const std::string& operpoint, const std::string& tagger) const;
+  bool IsbTag(const pat::Jet& JetCand, const std::string& operpoint) const;
   bool IsbTag(const pat::Jet& JetCand) const;
-//
+  //
 private:
-  std::map <std::string,std::map<std::string,double> > discCut;    //map to associate cuts and taggers
-  std::vector<double> discriminantCutsLoose_;                      //list of discriminant cut per tagger
-  std::vector<double> discriminantCutsMedium_;                     //list of discriminant cut per tagger
-  std::vector<double> discriminantCutsTight_;                      //list of discriminant cut per tagger
-  std::vector<std::string> BTagdiscriminator_;                     //list of taggers
-  std::string DefaultOp_;                                          //default operating point
-  std::string DefaultTg_;                                          //default taggers
+  std::map<std::string, std::map<std::string, double> > discCut;  //map to associate cuts and taggers
+  std::vector<double> discriminantCutsLoose_;                     //list of discriminant cut per tagger
+  std::vector<double> discriminantCutsMedium_;                    //list of discriminant cut per tagger
+  std::vector<double> discriminantCutsTight_;                     //list of discriminant cut per tagger
+  std::vector<std::string> BTagdiscriminator_;                    //list of taggers
+  std::string DefaultOp_;                                         //default operating point
+  std::string DefaultTg_;                                         //default taggers
 };
 
 #endif
-

--- a/PhysicsTools/PatUtils/plugins/BoostedJetMerger.cc
+++ b/PhysicsTools/PatUtils/plugins/BoostedJetMerger.cc
@@ -1,70 +1,57 @@
 #include "PhysicsTools/PatUtils/interface/BoostedJetMerger.h"
 
-
-BoostedJetMerger::BoostedJetMerger(const edm::ParameterSet& iConfig) :
-  jetToken_(consumes<edm::View<pat::Jet> >( iConfig.getParameter<edm::InputTag>("jetSrc") )),
-  subjetToken_(consumes<edm::View<pat::Jet> >( iConfig.getParameter<edm::InputTag>("subjetSrc") ))
-{
+BoostedJetMerger::BoostedJetMerger(const edm::ParameterSet& iConfig)
+    : jetToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
+      subjetToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("subjetSrc"))) {
   //register products
-  produces<std::vector<pat::Jet> > ();
-  produces<std::vector<pat::Jet> > ("SubJets");
+  produces<std::vector<pat::Jet>>();
+  produces<std::vector<pat::Jet>>("SubJets");
 }
 
-
-BoostedJetMerger::~BoostedJetMerger()
-{
-}
-
+BoostedJetMerger::~BoostedJetMerger() {}
 
 // ------------ method called to produce the data  ------------
-void
-BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup&)
-{  
-
+void BoostedJetMerger::produce(edm::Event& iEvent, const edm::EventSetup&) {
   auto outputs = std::make_unique<std::vector<pat::Jet>>();
   auto outputSubjets = std::make_unique<std::vector<pat::Jet>>();
 
-  edm::RefProd< std::vector<pat::Jet> > h_subJetsOut = iEvent.getRefBeforePut< std::vector<pat::Jet> >( "SubJets" );
- 
-  edm::Handle< edm::View<pat::Jet> > jetHandle;
-  edm::Handle< edm::View<pat::Jet> > subjetHandle;
+  edm::RefProd<std::vector<pat::Jet>> h_subJetsOut = iEvent.getRefBeforePut<std::vector<pat::Jet>>("SubJets");
 
-  iEvent.getByToken( jetToken_, jetHandle );
-  iEvent.getByToken( subjetToken_, subjetHandle ); 
+  edm::Handle<edm::View<pat::Jet>> jetHandle;
+  edm::Handle<edm::View<pat::Jet>> subjetHandle;
 
-  for ( edm::View<pat::Jet>::const_iterator ijetBegin = jetHandle->begin(),
-	  ijetEnd = jetHandle->end(), ijet = ijetBegin; ijet != ijetEnd; ++ijet ) {
-    
-    outputs->push_back( *ijet );
-    std::vector< edm::Ptr<reco::Candidate> > nextSubjets;
+  iEvent.getByToken(jetToken_, jetHandle);
+  iEvent.getByToken(subjetToken_, subjetHandle);
 
-    for ( unsigned int isubjet = 0; isubjet < ijet->numberOfDaughters(); ++isubjet ) {
-      edm::Ptr<reco::Candidate> const & subjet = ijet->daughterPtr(isubjet);
-      edm::View<pat::Jet>::const_iterator ifound = find_if( subjetHandle->begin(),
-							    subjetHandle->end(),
-							    FindCorrectedSubjet(subjet) );
-      if ( ifound != subjetHandle->end() ) {
+  for (edm::View<pat::Jet>::const_iterator ijetBegin = jetHandle->begin(), ijetEnd = jetHandle->end(), ijet = ijetBegin;
+       ijet != ijetEnd;
+       ++ijet) {
+    outputs->push_back(*ijet);
+    std::vector<edm::Ptr<reco::Candidate>> nextSubjets;
 
-	outputSubjets->push_back( *ifound );
+    for (unsigned int isubjet = 0; isubjet < ijet->numberOfDaughters(); ++isubjet) {
+      edm::Ptr<reco::Candidate> const& subjet = ijet->daughterPtr(isubjet);
+      edm::View<pat::Jet>::const_iterator ifound =
+          find_if(subjetHandle->begin(), subjetHandle->end(), FindCorrectedSubjet(subjet));
+      if (ifound != subjetHandle->end()) {
+        outputSubjets->push_back(*ifound);
 
-	edm::Ref<std::vector<pat::Jet> > subjetRef ( h_subJetsOut, outputSubjets->size() - 1);
-	edm::Ptr< pat::Jet > subjetPtr ( h_subJetsOut.id(), subjetRef.key(), h_subJetsOut.productGetter() );
-	nextSubjets.push_back( subjetPtr );
+        edm::Ref<std::vector<pat::Jet>> subjetRef(h_subJetsOut, outputSubjets->size() - 1);
+        edm::Ptr<pat::Jet> subjetPtr(h_subJetsOut.id(), subjetRef.key(), h_subJetsOut.productGetter());
+        nextSubjets.push_back(subjetPtr);
       }
     }
     outputs->back().clearDaughters();
-    for ( std::vector< edm::Ptr<reco::Candidate> >::const_iterator nextSubjet = nextSubjets.begin(),
-	    nextSubjetEnd = nextSubjets.end(); nextSubjet != nextSubjetEnd; ++nextSubjet ) {
-      outputs->back().addDaughter( *nextSubjet );
+    for (std::vector<edm::Ptr<reco::Candidate>>::const_iterator nextSubjet = nextSubjets.begin(),
+                                                                nextSubjetEnd = nextSubjets.end();
+         nextSubjet != nextSubjetEnd;
+         ++nextSubjet) {
+      outputs->back().addDaughter(*nextSubjet);
     }
-
-    
   }
 
-  
   iEvent.put(std::move(outputs));
   iEvent.put(std::move(outputSubjets), "SubJets");
-
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatUtils/plugins/CorrMETDataExtractor.cc
+++ b/PhysicsTools/PatUtils/plugins/CorrMETDataExtractor.cc
@@ -16,43 +16,38 @@
 
 //____________________________________________________________________________||
 class CorrMETDataExtractor : public edm::stream::EDProducer<> {
-
 public:
-
   explicit CorrMETDataExtractor(const edm::ParameterSet& cfg) {
     std::vector<edm::InputTag> corrInputTags = cfg.getParameter<std::vector<edm::InputTag> >("corrections");
     std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens;
-    for (std::vector<edm::InputTag>::const_iterator inputTag = corrInputTags.begin(); inputTag != corrInputTags.end(); ++inputTag) {
+    for (std::vector<edm::InputTag>::const_iterator inputTag = corrInputTags.begin(); inputTag != corrInputTags.end();
+         ++inputTag) {
       corrTokens_.push_back(consumes<CorrMETData>(*inputTag));
     }
 
     produces<float>("corX");
     produces<float>("corY");
     produces<float>("corSumEt");
-    
   }
 
-  ~CorrMETDataExtractor() override { }
+  ~CorrMETDataExtractor() override {}
 
 private:
-
   std::vector<edm::EDGetTokenT<CorrMETData> > corrTokens_;
-  
 
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
-  
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     CorrMETData sumCor;
     edm::Handle<CorrMETData> corr;
-    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = corrTokens_.begin(); corrToken != corrTokens_.end(); ++corrToken) {
-      
+    for (std::vector<edm::EDGetTokenT<CorrMETData> >::const_iterator corrToken = corrTokens_.begin();
+         corrToken != corrTokens_.end();
+         ++corrToken) {
       evt.getByToken(*corrToken, corr);
       sumCor += (*corr);
     }
 
-    float cX=(float)sumCor.mex;
-    float cY=(float)sumCor.mey;
-    float cSEt=(float)sumCor.sumet;
+    float cX = (float)sumCor.mex;
+    float cY = (float)sumCor.mey;
+    float cSEt = (float)sumCor.sumet;
 
     std::unique_ptr<float> corX(new float(0));
     std::unique_ptr<float> corY(new float(0));
@@ -62,11 +57,10 @@ private:
     *corY = cY;
     *corSumEt = cSEt;
 
-    evt.put(std::move(corX),"corX"); 
-    evt.put(std::move(corY),"corY");
-    evt.put(std::move(corSumEt),"corSumEt");
+    evt.put(std::move(corX), "corX");
+    evt.put(std::move(corY), "corY");
+    evt.put(std::move(corSumEt), "corSumEt");
   }
-
 };
 
 //____________________________________________________________________________||

--- a/PhysicsTools/PatUtils/plugins/JetCollectionReducer.cc
+++ b/PhysicsTools/PatUtils/plugins/JetCollectionReducer.cc
@@ -10,74 +10,65 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
-template<typename T>
+template <typename T>
 class JetCollectionReducerT : public edm::global::EDProducer<> {
-
 public:
-  explicit JetCollectionReducerT(const edm::ParameterSet & iConfig);
+  explicit JetCollectionReducerT(const edm::ParameterSet& iConfig);
   ~JetCollectionReducerT() override {}
 
-  void produce(edm::StreamID id, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
+  void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
 private:
-
-  edm::EDGetTokenT<std::vector<T>> jetColToken_;            
+  edm::EDGetTokenT<std::vector<T>> jetColToken_;
   bool writeEmptyCollection_;
-  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > collections_;
-  
+  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> collections_;
 };
 
-
-template<typename T>
-JetCollectionReducerT<T>::JetCollectionReducerT(const edm::ParameterSet& iConfig) :
-  jetColToken_(consumes<std::vector<T> >( iConfig.getParameter<edm::InputTag>("jetCollection") )),
-  writeEmptyCollection_(iConfig.getParameter<bool>("writeEmptyCollection"))
-{
-  
-  std::vector<edm::InputTag> filtersDecTags = iConfig.getParameter<std::vector<edm::InputTag> >("triggeringCollections");
-  for(std::vector<edm::InputTag>::const_iterator inputTag=filtersDecTags.begin();
-      inputTag!=filtersDecTags.end();++inputTag) {
-    collections_.push_back(consumes<edm::View<reco::Candidate> >(*inputTag));
+template <typename T>
+JetCollectionReducerT<T>::JetCollectionReducerT(const edm::ParameterSet& iConfig)
+    : jetColToken_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("jetCollection"))),
+      writeEmptyCollection_(iConfig.getParameter<bool>("writeEmptyCollection")) {
+  std::vector<edm::InputTag> filtersDecTags = iConfig.getParameter<std::vector<edm::InputTag>>("triggeringCollections");
+  for (std::vector<edm::InputTag>::const_iterator inputTag = filtersDecTags.begin(); inputTag != filtersDecTags.end();
+       ++inputTag) {
+    collections_.push_back(consumes<edm::View<reco::Candidate>>(*inputTag));
   }
-  
-  produces<std::vector<T> >();
 
+  produces<std::vector<T>>();
 }
 
 // ------------ method called to produce the data  ------------
-template<typename T>
-void
-JetCollectionReducerT<T>::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup&) const
-{  
+template <typename T>
+void JetCollectionReducerT<T>::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup&) const {
+  std::unique_ptr<std::vector<T>> outJets(new std::vector<T>());
 
-  std::unique_ptr<std::vector<T> > outJets(new std::vector<T>());
-  
-  bool filterDecision=false;
-  edm::Handle<edm::View<reco::Candidate> > tmpCol;
-  for(std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator filter=collections_.begin();
-      filter!=collections_.end();filter++) {
-    iEvent.getByToken(*filter,tmpCol);
-    if(!tmpCol->empty()) {
-      filterDecision=true;
+  bool filterDecision = false;
+  edm::Handle<edm::View<reco::Candidate>> tmpCol;
+  for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>>::const_iterator filter = collections_.begin();
+       filter != collections_.end();
+       filter++) {
+    iEvent.getByToken(*filter, tmpCol);
+    if (!tmpCol->empty()) {
+      filterDecision = true;
       break;
     }
   }
 
-  if(!filterDecision) {
-    if (writeEmptyCollection_) iEvent.put(std::move(outJets));
+  if (!filterDecision) {
+    if (writeEmptyCollection_)
+      iEvent.put(std::move(outJets));
     return;
   }
-  
-  edm::Handle< std::vector<T> > jetColHandle;
-  iEvent.getByToken( jetColToken_, jetColHandle );
-  
+
+  edm::Handle<std::vector<T>> jetColHandle;
+  iEvent.getByToken(jetColToken_, jetColHandle);
+
   //MM: probably a better way to do it...
-  for(size_t ij=0;ij<jetColHandle->size();ij++) {
-    outJets->push_back( (*jetColHandle)[ij] );
+  for (size_t ij = 0; ij < jetColHandle->size(); ij++) {
+    outJets->push_back((*jetColHandle)[ij]);
   }
 
   iEvent.put(std::move(outJets));
-
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatUtils/plugins/JetSubstructurePacker.cc
+++ b/PhysicsTools/PatUtils/plugins/JetSubstructurePacker.cc
@@ -2,123 +2,118 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 
-JetSubstructurePacker::JetSubstructurePacker(const edm::ParameterSet& iConfig) :
-  distMax_( iConfig.getParameter<double>("distMax") ),
-  jetToken_(consumes<edm::View<pat::Jet> >( iConfig.getParameter<edm::InputTag>("jetSrc") )),
-  algoLabels_( iConfig.getParameter< std::vector<std::string> > ("algoLabels") ),
-  algoTags_ (iConfig.getParameter<std::vector<edm::InputTag> > ( "algoTags" )),
-  fixDaughters_(iConfig.getParameter<bool>("fixDaughters"))
-{
-  algoTokens_ =edm::vector_transform(algoTags_, [this](edm::InputTag const & tag){return consumes< edm::View<pat::Jet> >(tag);});
+JetSubstructurePacker::JetSubstructurePacker(const edm::ParameterSet& iConfig)
+    : distMax_(iConfig.getParameter<double>("distMax")),
+      jetToken_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
+      algoLabels_(iConfig.getParameter<std::vector<std::string>>("algoLabels")),
+      algoTags_(iConfig.getParameter<std::vector<edm::InputTag>>("algoTags")),
+      fixDaughters_(iConfig.getParameter<bool>("fixDaughters")) {
+  algoTokens_ =
+      edm::vector_transform(algoTags_, [this](edm::InputTag const& tag) { return consumes<edm::View<pat::Jet>>(tag); });
   if (fixDaughters_) {
-    pf2pc_ = consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
-    pc2pf_ = consumes<edm::Association<reco::PFCandidateCollection   > >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
+    pf2pc_ = consumes<edm::Association<pat::PackedCandidateCollection>>(
+        iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
+    pc2pf_ = consumes<edm::Association<reco::PFCandidateCollection>>(
+        iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
   }
   //register products
-  produces<std::vector<pat::Jet> > ();
+  produces<std::vector<pat::Jet>>();
 }
 
-
-JetSubstructurePacker::~JetSubstructurePacker()
-{
-}
-
+JetSubstructurePacker::~JetSubstructurePacker() {}
 
 // ------------ method called to produce the data  ------------
-void
-JetSubstructurePacker::produce(edm::Event& iEvent, const edm::EventSetup&)
-{  
-
+void JetSubstructurePacker::produce(edm::Event& iEvent, const edm::EventSetup&) {
   auto outputs = std::make_unique<std::vector<pat::Jet>>();
- 
-  edm::Handle< edm::View<pat::Jet> > jetHandle;
-  std::vector< edm::Handle< edm::View<pat::Jet> > > algoHandles;
 
-  edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
-  edm::Handle<edm::Association<reco::PFCandidateCollection   > > pc2pf;
+  edm::Handle<edm::View<pat::Jet>> jetHandle;
+  std::vector<edm::Handle<edm::View<pat::Jet>>> algoHandles;
+
+  edm::Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  edm::Handle<edm::Association<reco::PFCandidateCollection>> pc2pf;
   if (fixDaughters_) {
-    iEvent.getByToken(pf2pc_,pf2pc);
-    iEvent.getByToken(pc2pf_,pc2pf);
+    iEvent.getByToken(pf2pc_, pf2pc);
+    iEvent.getByToken(pc2pf_, pc2pf);
   }
 
-  iEvent.getByToken( jetToken_, jetHandle );
-  algoHandles.resize( algoTags_.size() );
-  for ( size_t i = 0; i < algoTags_.size(); ++i ) {
-    iEvent.getByToken( algoTokens_[i], algoHandles[i] ); 
+  iEvent.getByToken(jetToken_, jetHandle);
+  algoHandles.resize(algoTags_.size());
+  for (size_t i = 0; i < algoTags_.size(); ++i) {
+    iEvent.getByToken(algoTokens_[i], algoHandles[i]);
   }
-  
+
   // Loop over the input jets that will be modified.
-  for ( auto const & ijet : *jetHandle  ) {
+  for (auto const& ijet : *jetHandle) {
     // Copy the jet.
-    outputs->push_back( ijet );
+    outputs->push_back(ijet);
     // Loop over the substructure collections
     unsigned int index = 0;
-    
-    for ( auto const & ialgoHandle : algoHandles ) {      
-      std::vector< edm::Ptr<pat::Jet> > nextSubjets;
+
+    for (auto const& ialgoHandle : algoHandles) {
+      std::vector<edm::Ptr<pat::Jet>> nextSubjets;
       float dRMin = distMax_;
-      for ( auto const & jjet : *ialgoHandle ) {       
-	if ( reco::deltaR( ijet, jjet ) < dRMin ) {
-	  for ( auto const & userfloatstr : jjet.userFloatNames() ) {
-	    outputs->back().addUserFloat( userfloatstr, jjet.userFloat(userfloatstr) );
-	  }
-	  for ( auto const & userintstr : jjet.userIntNames() ) {
-	    outputs->back().addUserInt( userintstr, jjet.userInt(userintstr) );
-	  }
-	  for ( auto const & usercandstr : jjet.userCandNames() ) {
-	    outputs->back().addUserCand( usercandstr, jjet.userCand(usercandstr) );
-	  }
-	  for ( size_t ida = 0; ida < jjet.numberOfDaughters(); ++ida ) {
-	    reco::CandidatePtr candPtr =  jjet.daughterPtr( ida);
-	    nextSubjets.push_back( edm::Ptr<pat::Jet> ( candPtr ) );
-	  }
-	  break;
-	}
+      for (auto const& jjet : *ialgoHandle) {
+        if (reco::deltaR(ijet, jjet) < dRMin) {
+          for (auto const& userfloatstr : jjet.userFloatNames()) {
+            outputs->back().addUserFloat(userfloatstr, jjet.userFloat(userfloatstr));
+          }
+          for (auto const& userintstr : jjet.userIntNames()) {
+            outputs->back().addUserInt(userintstr, jjet.userInt(userintstr));
+          }
+          for (auto const& usercandstr : jjet.userCandNames()) {
+            outputs->back().addUserCand(usercandstr, jjet.userCand(usercandstr));
+          }
+          for (size_t ida = 0; ida < jjet.numberOfDaughters(); ++ida) {
+            reco::CandidatePtr candPtr = jjet.daughterPtr(ida);
+            nextSubjets.push_back(edm::Ptr<pat::Jet>(candPtr));
+          }
+          break;
+        }
       }
-      outputs->back().addSubjets( nextSubjets, algoLabels_[index] );
-      ++index; 
+      outputs->back().addSubjets(nextSubjets, algoLabels_[index]);
+      ++index;
     }
 
     // fix daughters
     if (fixDaughters_) {
+      std::vector<reco::CandidatePtr> daughtersInSubjets;
+      std::vector<reco::CandidatePtr> daughtersNew;
+      const std::vector<reco::CandidatePtr>& jdausPF = outputs->back().daughterPtrVector();
+      std::vector<reco::CandidatePtr> jdaus;
+      jdaus.reserve(jdausPF.size());
+      // Convert the daughters to packed candidates. This is easier than ref-navigating through PUPPI or CHS to particleFlow.
+      for (auto const& jdau : jdausPF) {
+        jdaus.push_back(edm::refToPtr((*pf2pc)[jdau]));
+      }
 
-        std::vector<reco::CandidatePtr> daughtersInSubjets;
-        std::vector<reco::CandidatePtr> daughtersNew;
-        const std::vector<reco::CandidatePtr> & jdausPF = outputs->back().daughterPtrVector();
-	std::vector<reco::CandidatePtr> jdaus;
-	jdaus.reserve( jdausPF.size() );
-	// Convert the daughters to packed candidates. This is easier than ref-navigating through PUPPI or CHS to particleFlow.
-	for ( auto const & jdau : jdausPF ) {
-	  jdaus.push_back( edm::refToPtr((*pf2pc)[jdau]) );
-	}
-		
-        for ( const edm::Ptr<pat::Jet> & subjet : outputs->back().subjets()) {
-            const std::vector<reco::CandidatePtr> & sjdaus = subjet->daughterPtrVector();
-            // check that the subjet does not contain any extra constituents not contained in the jet
-            bool skipSubjet = false;
-            for (const reco::CandidatePtr & dau : sjdaus) {
-                if (std::find(jdaus.begin(), jdaus.end(), dau) == jdaus.end()) {
-                    skipSubjet = true;
-                    break;
-                }
-            }
-            if (skipSubjet) continue;
+      for (const edm::Ptr<pat::Jet>& subjet : outputs->back().subjets()) {
+        const std::vector<reco::CandidatePtr>& sjdaus = subjet->daughterPtrVector();
+        // check that the subjet does not contain any extra constituents not contained in the jet
+        bool skipSubjet = false;
+        for (const reco::CandidatePtr& dau : sjdaus) {
+          if (std::find(jdaus.begin(), jdaus.end(), dau) == jdaus.end()) {
+            skipSubjet = true;
+            break;
+          }
+        }
+        if (skipSubjet)
+          continue;
 
-            daughtersInSubjets.insert(daughtersInSubjets.end(), sjdaus.begin(), sjdaus.end());
-            daughtersNew.push_back( reco::CandidatePtr(subjet) );
+        daughtersInSubjets.insert(daughtersInSubjets.end(), sjdaus.begin(), sjdaus.end());
+        daughtersNew.push_back(reco::CandidatePtr(subjet));
+      }
+      for (const reco::CandidatePtr& dau : jdaus) {
+        if (std::find(daughtersInSubjets.begin(), daughtersInSubjets.end(), dau) == daughtersInSubjets.end()) {
+          daughtersNew.push_back(dau);
         }
-        for (const reco::CandidatePtr & dau : jdaus) {
-            if (std::find(daughtersInSubjets.begin(), daughtersInSubjets.end(), dau) == daughtersInSubjets.end()) {
-                daughtersNew.push_back( dau );
-            }
-        }
-        outputs->back().clearDaughters();
-        for (const auto & dau : daughtersNew) outputs->back().addDaughter(dau);
+      }
+      outputs->back().clearDaughters();
+      for (const auto& dau : daughtersNew)
+        outputs->back().addDaughter(dau);
     }
   }
 
   iEvent.put(std::move(outputs));
-
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    ProdTutorial/L1ECALPrefiringWeightProducer
 // Class:      L1ECALPrefiringWeightProducer
-// 
+//
 /**\class L1ECALPrefiringWeightProducer L1ECALPrefiringWeightProducer.cc ProdTutorial/L1ECALPrefiringWeightProducer/plugins/L1ECALPrefiringWeightProducer.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Thu, 08 Nov 2018 16:16:00 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -34,193 +33,195 @@
 #include "TH2.h"
 
 #include <iostream>
-enum fluctuations{central=0, up, down};
+enum fluctuations { central = 0, up, down };
 
 class L1ECALPrefiringWeightProducer : public edm::global::EDProducer<> {
 public:
   explicit L1ECALPrefiringWeightProducer(const edm::ParameterSet&);
   ~L1ECALPrefiringWeightProducer() override;
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  double getPrefiringRate( double eta, double pt, TH2F * h_prefmap, fluctuations fluctuation) const ;
-  
-  edm::EDGetTokenT<std::vector< pat::Photon> >  photons_token_; 
-  edm::EDGetTokenT<std::vector< pat::Jet> > jets_token_;
-  
-  TH2F * h_prefmap_photon; 
-  TH2F * h_prefmap_jet;
+  double getPrefiringRate(double eta, double pt, TH2F* h_prefmap, fluctuations fluctuation) const;
+
+  edm::EDGetTokenT<std::vector<pat::Photon> > photons_token_;
+  edm::EDGetTokenT<std::vector<pat::Jet> > jets_token_;
+
+  TH2F* h_prefmap_photon;
+  TH2F* h_prefmap_jet;
   std::string dataera_;
   bool useEMpt_;
   double prefiringRateSystUnc_;
   bool skipwarnings_;
 };
 
+L1ECALPrefiringWeightProducer::L1ECALPrefiringWeightProducer(const edm::ParameterSet& iConfig) {
+  photons_token_ = consumes<std::vector<pat::Photon> >(iConfig.getParameter<edm::InputTag>("ThePhotons"));
+  jets_token_ = consumes<std::vector<pat::Jet> >(iConfig.getParameter<edm::InputTag>("TheJets"));
 
-L1ECALPrefiringWeightProducer::L1ECALPrefiringWeightProducer(const edm::ParameterSet& iConfig)
-{
-  photons_token_  = consumes<std::vector<pat::Photon> >(  iConfig.getParameter<edm::InputTag>( "ThePhotons" )  );
-  jets_token_  = consumes<std::vector<pat::Jet> >(  iConfig.getParameter<edm::InputTag>( "TheJets" )  );
+  dataera_ = iConfig.getParameter<std::string>("DataEra");
+  useEMpt_ = iConfig.getParameter<bool>("UseJetEMPt");
+  prefiringRateSystUnc_ = iConfig.getParameter<double>("PrefiringRateSystematicUncty");
+  skipwarnings_ = iConfig.getParameter<bool>("SkipWarnings");
 
-  dataera_ =  iConfig.getParameter<std::string>( "DataEra" ) ;
-  useEMpt_  =  iConfig.getParameter<bool>( "UseJetEMPt" ) ; 
-  prefiringRateSystUnc_ =  iConfig.getParameter<double>( "PrefiringRateSystematicUncty" ) ;
-  skipwarnings_  =  iConfig.getParameter<bool>( "SkipWarnings" ) ;
+  TFile* file_prefiringmaps_;
+  std::string fname = iConfig.getParameter<std::string>("L1Maps");
+  edm::FileInPath mapsfilepath("PhysicsTools/PatUtils/data/" + fname);
+  file_prefiringmaps_ = new TFile(mapsfilepath.fullPath().c_str(), "read");
+  if (file_prefiringmaps_ == nullptr && !skipwarnings_)
+    std::cout << "File with maps not found. All prefiring weights set to 0. " << std::endl;
 
-  TFile *  file_prefiringmaps_;
-  std::string fname =  iConfig.getParameter<std::string>( "L1Maps" );
-  edm::FileInPath mapsfilepath("PhysicsTools/PatUtils/data/"+fname);
-  file_prefiringmaps_ = new TFile(mapsfilepath.fullPath().c_str(),"read" );
-  if(file_prefiringmaps_ == nullptr && !skipwarnings_) 
-    std::cout << "File with maps not found. All prefiring weights set to 0. " <<std::endl;
-  
-  TString mapphotonfullname= "L1prefiring_photonptvseta_"+ dataera_; 
-  if(!file_prefiringmaps_->Get(mapphotonfullname)&& !skipwarnings_) 
-    std::cout << "Photon map not found. All photons prefiring weights set to 0. " <<std::endl; 
-  h_prefmap_photon =(TH2F*) file_prefiringmaps_->Get(mapphotonfullname);
-  
-  TString mapjetfullname= (useEMpt_) ? "L1prefiring_jetemptvseta_"+ dataera_  :  "L1prefiring_jetptvseta_"+ dataera_ ; 
-  if(!file_prefiringmaps_->Get(mapjetfullname)&& !skipwarnings_) 
-    std::cout << "Jet map not found. All jets prefiring weights set to 0. "<< std::endl ; 
-  h_prefmap_jet =(TH2F*) file_prefiringmaps_->Get(mapjetfullname);
+  TString mapphotonfullname = "L1prefiring_photonptvseta_" + dataera_;
+  if (!file_prefiringmaps_->Get(mapphotonfullname) && !skipwarnings_)
+    std::cout << "Photon map not found. All photons prefiring weights set to 0. " << std::endl;
+  h_prefmap_photon = (TH2F*)file_prefiringmaps_->Get(mapphotonfullname);
+
+  TString mapjetfullname = (useEMpt_) ? "L1prefiring_jetemptvseta_" + dataera_ : "L1prefiring_jetptvseta_" + dataera_;
+  if (!file_prefiringmaps_->Get(mapjetfullname) && !skipwarnings_)
+    std::cout << "Jet map not found. All jets prefiring weights set to 0. " << std::endl;
+  h_prefmap_jet = (TH2F*)file_prefiringmaps_->Get(mapjetfullname);
   file_prefiringmaps_->Close();
   delete file_prefiringmaps_;
-  produces<double>( "nonPrefiringProb" ).setBranchAlias( "nonPrefiringProb");
-  produces<double>( "nonPrefiringProbUp" ).setBranchAlias( "nonPrefiringProbUp");
-  produces<double>( "nonPrefiringProbDown" ).setBranchAlias( "nonPrefiringProbDown");
-
+  produces<double>("nonPrefiringProb").setBranchAlias("nonPrefiringProb");
+  produces<double>("nonPrefiringProbUp").setBranchAlias("nonPrefiringProbUp");
+  produces<double>("nonPrefiringProbDown").setBranchAlias("nonPrefiringProbDown");
 }
 
-L1ECALPrefiringWeightProducer::~L1ECALPrefiringWeightProducer()
-{
+L1ECALPrefiringWeightProducer::~L1ECALPrefiringWeightProducer() {
   delete h_prefmap_photon;
   delete h_prefmap_jet;
 }
 
-void
-L1ECALPrefiringWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const 
-{
-   using namespace edm;
+void L1ECALPrefiringWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
 
-   //Photons
-   edm::Handle< std::vector<pat::Photon> > thePhotons;
-   iEvent.getByToken(photons_token_,thePhotons);
-   
-   //Jets
-   edm::Handle< std::vector< pat::Jet> > theJets;
-   iEvent.getByToken(jets_token_,theJets );
-   
-   //Probability for the event NOT to prefire, computed with the prefiring maps per object. 
-   //Up and down values correspond to the resulting value when shifting up/down all prefiring rates in prefiring maps. 
-   double nonPrefiringProba[3]={1.,1.,1.};//0: central, 1: up, 2: down
-   
-   for ( const auto fluct : { fluctuations::central,  fluctuations::up, fluctuations::down } ) {
-     for ( const auto & photon : *thePhotons ) {
-       double pt_gam= photon.pt();
-       double eta_gam=  photon.eta();
-       if( pt_gam < 20.) continue;
-       if( fabs(eta_gam) <2.) continue;
-       if( fabs(eta_gam) >3.) continue;
-       double prefiringprob_gam=  getPrefiringRate( eta_gam, pt_gam, h_prefmap_photon, fluct);  
-       nonPrefiringProba[fluct] *= (1.-prefiringprob_gam);
-     }
-     
-     //Now applying the prefiring maps to jets in the affected regions. 
-     for ( const auto &jet: *theJets ) {
-       
-       double pt_jet= jet.pt();
-       double eta_jet=  jet.eta();
-       double phi_jet=  jet.phi();
-       if( pt_jet < 20.) continue;
-       if( fabs(eta_jet) <2.) continue;
-       if( fabs(eta_jet) >3.) continue;
-       
-       //Loop over photons to remove overlap
-       double nonprefiringprobfromoverlappingphotons =1.;
-       for ( const auto & photon : *thePhotons ) {
-	 double pt_gam= photon.pt();
-	 double eta_gam=  photon.eta();
-	 double phi_gam=  photon.phi();
-	 if( pt_gam < 20.) continue;
-	 if( fabs(eta_gam) <2.) continue;
-	 if( fabs(eta_gam) >3.) continue;
-	 double dR = reco::deltaR( eta_jet,phi_jet,eta_gam,phi_gam );
-	 if(dR>0.4)continue;
-	 double prefiringprob_gam =  getPrefiringRate( eta_gam, pt_gam, h_prefmap_photon , fluct);
-	 nonprefiringprobfromoverlappingphotons  *= (1.-prefiringprob_gam) ;
-       }
-       //useEMpt =true if one wants to use maps parametrized vs Jet EM pt instead of pt.
-       if (useEMpt_) 
-	 pt_jet *= (jet.neutralEmEnergyFraction()+jet.chargedEmEnergyFraction());
-       double nonprefiringprobfromoverlappingjet  = 1. - getPrefiringRate( eta_jet, pt_jet , h_prefmap_jet , fluct);
-       
-       if(nonprefiringprobfromoverlappingphotons ==1.){ 
-	 nonPrefiringProba[fluct] *= nonprefiringprobfromoverlappingjet ; 
-       }
-       //If overlapping photons have a non prefiring rate larger than the jet, then replace these weights by the jet one
-       else if(nonprefiringprobfromoverlappingphotons > nonprefiringprobfromoverlappingjet ) {
-	 if(nonprefiringprobfromoverlappingphotons !=0.) {
-	   nonPrefiringProba[fluct] *= nonprefiringprobfromoverlappingjet / nonprefiringprobfromoverlappingphotons;
-	 }
-	 else{ 
-	   nonPrefiringProba[fluct] = 0.;
-	 }
-       }
-       //Last case: if overlapping photons have a non prefiring rate smaller than the jet, don't consider the jet in the event weight, and do nothing.
-     }
-   }
-   
-   auto nonPrefiringProb =std::make_unique <double> ( nonPrefiringProba[0]);
-   auto nonPrefiringProbUp =std::make_unique <double> ( nonPrefiringProba[1]);
-   auto nonPrefiringProbDown =std::make_unique <double> ( nonPrefiringProba[2]);
-   iEvent.put( std::move(nonPrefiringProb), "nonPrefiringProb" );        
-   iEvent.put( std::move(nonPrefiringProbUp), "nonPrefiringProbUp" );        
-   iEvent.put( std::move(nonPrefiringProbDown), "nonPrefiringProbDown" );    
-    
+  //Photons
+  edm::Handle<std::vector<pat::Photon> > thePhotons;
+  iEvent.getByToken(photons_token_, thePhotons);
+
+  //Jets
+  edm::Handle<std::vector<pat::Jet> > theJets;
+  iEvent.getByToken(jets_token_, theJets);
+
+  //Probability for the event NOT to prefire, computed with the prefiring maps per object.
+  //Up and down values correspond to the resulting value when shifting up/down all prefiring rates in prefiring maps.
+  double nonPrefiringProba[3] = {1., 1., 1.};  //0: central, 1: up, 2: down
+
+  for (const auto fluct : {fluctuations::central, fluctuations::up, fluctuations::down}) {
+    for (const auto& photon : *thePhotons) {
+      double pt_gam = photon.pt();
+      double eta_gam = photon.eta();
+      if (pt_gam < 20.)
+        continue;
+      if (fabs(eta_gam) < 2.)
+        continue;
+      if (fabs(eta_gam) > 3.)
+        continue;
+      double prefiringprob_gam = getPrefiringRate(eta_gam, pt_gam, h_prefmap_photon, fluct);
+      nonPrefiringProba[fluct] *= (1. - prefiringprob_gam);
+    }
+
+    //Now applying the prefiring maps to jets in the affected regions.
+    for (const auto& jet : *theJets) {
+      double pt_jet = jet.pt();
+      double eta_jet = jet.eta();
+      double phi_jet = jet.phi();
+      if (pt_jet < 20.)
+        continue;
+      if (fabs(eta_jet) < 2.)
+        continue;
+      if (fabs(eta_jet) > 3.)
+        continue;
+
+      //Loop over photons to remove overlap
+      double nonprefiringprobfromoverlappingphotons = 1.;
+      for (const auto& photon : *thePhotons) {
+        double pt_gam = photon.pt();
+        double eta_gam = photon.eta();
+        double phi_gam = photon.phi();
+        if (pt_gam < 20.)
+          continue;
+        if (fabs(eta_gam) < 2.)
+          continue;
+        if (fabs(eta_gam) > 3.)
+          continue;
+        double dR = reco::deltaR(eta_jet, phi_jet, eta_gam, phi_gam);
+        if (dR > 0.4)
+          continue;
+        double prefiringprob_gam = getPrefiringRate(eta_gam, pt_gam, h_prefmap_photon, fluct);
+        nonprefiringprobfromoverlappingphotons *= (1. - prefiringprob_gam);
+      }
+      //useEMpt =true if one wants to use maps parametrized vs Jet EM pt instead of pt.
+      if (useEMpt_)
+        pt_jet *= (jet.neutralEmEnergyFraction() + jet.chargedEmEnergyFraction());
+      double nonprefiringprobfromoverlappingjet = 1. - getPrefiringRate(eta_jet, pt_jet, h_prefmap_jet, fluct);
+
+      if (nonprefiringprobfromoverlappingphotons == 1.) {
+        nonPrefiringProba[fluct] *= nonprefiringprobfromoverlappingjet;
+      }
+      //If overlapping photons have a non prefiring rate larger than the jet, then replace these weights by the jet one
+      else if (nonprefiringprobfromoverlappingphotons > nonprefiringprobfromoverlappingjet) {
+        if (nonprefiringprobfromoverlappingphotons != 0.) {
+          nonPrefiringProba[fluct] *= nonprefiringprobfromoverlappingjet / nonprefiringprobfromoverlappingphotons;
+        } else {
+          nonPrefiringProba[fluct] = 0.;
+        }
+      }
+      //Last case: if overlapping photons have a non prefiring rate smaller than the jet, don't consider the jet in the event weight, and do nothing.
+    }
+  }
+
+  auto nonPrefiringProb = std::make_unique<double>(nonPrefiringProba[0]);
+  auto nonPrefiringProbUp = std::make_unique<double>(nonPrefiringProba[1]);
+  auto nonPrefiringProbDown = std::make_unique<double>(nonPrefiringProba[2]);
+  iEvent.put(std::move(nonPrefiringProb), "nonPrefiringProb");
+  iEvent.put(std::move(nonPrefiringProbUp), "nonPrefiringProbUp");
+  iEvent.put(std::move(nonPrefiringProbDown), "nonPrefiringProbDown");
 }
 
-
-double L1ECALPrefiringWeightProducer::getPrefiringRate( double eta, double pt, TH2F * h_prefmap, fluctuations fluctuation) const{
-
-  if(h_prefmap==nullptr&& !skipwarnings_)std::cout << "Prefiring map not found, setting prefiring rate to 0 " <<std::endl;
-  if(h_prefmap==nullptr ) return 0.;
+double L1ECALPrefiringWeightProducer::getPrefiringRate(double eta,
+                                                       double pt,
+                                                       TH2F* h_prefmap,
+                                                       fluctuations fluctuation) const {
+  if (h_prefmap == nullptr && !skipwarnings_)
+    std::cout << "Prefiring map not found, setting prefiring rate to 0 " << std::endl;
+  if (h_prefmap == nullptr)
+    return 0.;
   //Check pt is not above map overflow
   int nbinsy = h_prefmap->GetNbinsY();
-  double maxy= h_prefmap->GetYaxis()->GetBinLowEdge(nbinsy+1);
-  if(pt>=maxy) pt = maxy-0.01;
-  int thebin= h_prefmap->FindBin(eta,pt);
-  
+  double maxy = h_prefmap->GetYaxis()->GetBinLowEdge(nbinsy + 1);
+  if (pt >= maxy)
+    pt = maxy - 0.01;
+  int thebin = h_prefmap->FindBin(eta, pt);
+
   double prefrate = h_prefmap->GetBinContent(thebin);
-  
-  double statuncty = h_prefmap->GetBinError(thebin) ; 
-  double systuncty = prefiringRateSystUnc_*prefrate; 
-  
-  if(fluctuation == up) prefrate = std::min(1.,prefrate+sqrt(pow(statuncty,2)+pow(systuncty,2)));
-  if(fluctuation == down) prefrate = std::max(0.,prefrate-sqrt(pow(statuncty,2)+pow(systuncty,2)));
+
+  double statuncty = h_prefmap->GetBinError(thebin);
+  double systuncty = prefiringRateSystUnc_ * prefrate;
+
+  if (fluctuation == up)
+    prefrate = std::min(1., prefrate + sqrt(pow(statuncty, 2) + pow(systuncty, 2)));
+  if (fluctuation == down)
+    prefrate = std::max(0., prefrate - sqrt(pow(statuncty, 2) + pow(systuncty, 2)));
   return prefrate;
-    
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-L1ECALPrefiringWeightProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
+void L1ECALPrefiringWeightProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  
+
   desc.add<edm::InputTag>("ThePhotons", edm::InputTag("slimmedPhotons"));
   desc.add<edm::InputTag>("TheJets", edm::InputTag("slimmedJets"));
-  desc.add<std::string>("L1Maps","L1PrefiringMaps.root");
+  desc.add<std::string>("L1Maps", "L1PrefiringMaps.root");
   desc.add<std::string>("DataEra", "2017BtoF");
   desc.add<bool>("UseJetEMPt", false);
-  desc.add<double>("PrefiringRateSystematicUncty",0.2);
+  desc.add<double>("PrefiringRateSystematicUncty", 0.2);
   desc.add<bool>("SkipWarnings", true);
   descriptions.add("l1ECALPrefiringWeightProducer", desc);
-  
 }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(L1ECALPrefiringWeightProducer);
-

--- a/PhysicsTools/PatUtils/plugins/MinPatMETProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/MinPatMETProducer.cc
@@ -1,4 +1,4 @@
-#include "RecoMET/METProducers/interface/MinMETProducerT.h" 
+#include "RecoMET/METProducers/interface/MinMETProducerT.h"
 
 #include "DataFormats/PatCandidates/interface/MET.h"
 
@@ -7,6 +7,3 @@ typedef MinMETProducerT<pat::MET> MinPatMETProducer;
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(MinPatMETProducer);
-
-
-

--- a/PhysicsTools/PatUtils/plugins/PATCaloJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATCaloJetMETcorrInputProducer.cc
@@ -6,38 +6,31 @@
 
 #include "PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h"
 
-namespace CaloJetMETcorrInputProducer_namespace
-{
+namespace CaloJetMETcorrInputProducer_namespace {
   template <>
-  class InputTypeCheckerT<pat::Jet>
-  {
-    public:
-
-     void operator()(const pat::Jet& jet) const
-     {
-       // check that pat::Jet is of Calo-type
-       if ( !jet.isCaloJet() )
-	 throw cms::Exception("InvalidInput")
-	   << "Input pat::Jet is not of Calo-type !!\n";
-     }
-     bool isPatJet(const pat::Jet& jet) const {
-       return true;
-     }
+  class InputTypeCheckerT<pat::Jet> {
+  public:
+    void operator()(const pat::Jet& jet) const {
+      // check that pat::Jet is of Calo-type
+      if (!jet.isCaloJet())
+        throw cms::Exception("InvalidInput") << "Input pat::Jet is not of Calo-type !!\n";
+    }
+    bool isPatJet(const pat::Jet& jet) const { return true; }
   };
 
   template <>
-  class RawJetExtractorT<pat::Jet>
-  {
-    public:
-     RawJetExtractorT(){}
+  class RawJetExtractorT<pat::Jet> {
+  public:
+    RawJetExtractorT() {}
 
-     reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const
-     {
-       if ( jet.jecSetsAvailable() ) return jet.correctedP4("Uncorrected");
-       else return jet.p4();
-     }
+    reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const {
+      if (jet.jecSetsAvailable())
+        return jet.correctedP4("Uncorrected");
+      else
+        return jet.p4();
+    }
   };
-}
+}  // namespace CaloJetMETcorrInputProducer_namespace
 
 typedef CaloJetMETcorrInputProducerT<pat::Jet, PATJetCorrExtractor> PATCaloJetMETcorrInputProducer;
 

--- a/PhysicsTools/PatUtils/plugins/PATJetCleanerForType1MET.cc
+++ b/PhysicsTools/PatUtils/plugins/PATJetCleanerForType1MET.cc
@@ -4,43 +4,33 @@
 
 #include "PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h"
 
-namespace JetCleanerForType1MET_namespace
-{
+namespace JetCleanerForType1MET_namespace {
   template <>
-  class InputTypeCheckerT<pat::Jet, PATJetCorrExtractor>
-  {
-    public:
-
-     void operator()(const pat::Jet& jet) const
-     {
-       // check that pat::Jet is of PF-type
-       if ( !jet.isPFJet() )
-	 throw cms::Exception("InvalidInput")
-	   << "Input pat::Jet is not of PF-type !!\n";
-     }
-     bool isPatJet(const pat::Jet& jet) const {
-       return true;
-     }
+  class InputTypeCheckerT<pat::Jet, PATJetCorrExtractor> {
+  public:
+    void operator()(const pat::Jet& jet) const {
+      // check that pat::Jet is of PF-type
+      if (!jet.isPFJet())
+        throw cms::Exception("InvalidInput") << "Input pat::Jet is not of PF-type !!\n";
+    }
+    bool isPatJet(const pat::Jet& jet) const { return true; }
   };
 
   template <>
-  class RawJetExtractorT<pat::Jet>
-  {
-    public:
-
-     RawJetExtractorT(){}
-     reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const
-     {
-       if ( jet.jecSetsAvailable() ) return jet.correctedP4("Uncorrected");
-       else return jet.p4();
-     }
+  class RawJetExtractorT<pat::Jet> {
+  public:
+    RawJetExtractorT() {}
+    reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const {
+      if (jet.jecSetsAvailable())
+        return jet.correctedP4("Uncorrected");
+      else
+        return jet.p4();
+    }
   };
-}
+}  // namespace JetCleanerForType1MET_namespace
 
 typedef JetCleanerForType1METT<pat::Jet, PATJetCorrExtractor> PATJetCleanerForType1MET;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(PATJetCleanerForType1MET);
-
-

--- a/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
@@ -4,43 +4,33 @@
 
 #include "PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h"
 
-namespace PFJetMETcorrInputProducer_namespace
-{
+namespace PFJetMETcorrInputProducer_namespace {
   template <>
-  class InputTypeCheckerT<pat::Jet, PATJetCorrExtractor>
-  {
-    public:
-
-     void operator()(const pat::Jet& jet) const
-     {
-       // check that pat::Jet is of PF-type
-       if ( !jet.isPFJet() )
-	 throw cms::Exception("InvalidInput")
-	   << "Input pat::Jet is not of PF-type !!\n";
-     }
-     bool isPatJet(const pat::Jet& jet) const {
-       return true;
-     }
+  class InputTypeCheckerT<pat::Jet, PATJetCorrExtractor> {
+  public:
+    void operator()(const pat::Jet& jet) const {
+      // check that pat::Jet is of PF-type
+      if (!jet.isPFJet())
+        throw cms::Exception("InvalidInput") << "Input pat::Jet is not of PF-type !!\n";
+    }
+    bool isPatJet(const pat::Jet& jet) const { return true; }
   };
 
   template <>
-  class RawJetExtractorT<pat::Jet>
-  {
-    public:
-
-     RawJetExtractorT(){}
-     reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const
-     {
-       if ( jet.jecSetsAvailable() ) return jet.correctedP4("Uncorrected");
-       else return jet.p4();
-     }
+  class RawJetExtractorT<pat::Jet> {
+  public:
+    RawJetExtractorT() {}
+    reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const {
+      if (jet.jecSetsAvailable())
+        return jet.correctedP4("Uncorrected");
+      else
+        return jet.p4();
+    }
   };
-}
+}  // namespace PFJetMETcorrInputProducer_namespace
 
 typedef PFJetMETcorrInputProducerT<pat::Jet, PATJetCorrExtractor> PATPFJetMETcorrInputProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(PATPFJetMETcorrInputProducer);
-
-

--- a/PhysicsTools/PatUtils/plugins/PFMatchedCandidateRefExtractor.cc
+++ b/PhysicsTools/PatUtils/plugins/PFMatchedCandidateRefExtractor.cc
@@ -13,140 +13,124 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 class PFMatchedCandidateRefExtractor : public edm::global::EDProducer<> {
-
 public:
-  explicit PFMatchedCandidateRefExtractor(const edm::ParameterSet & iConfig);
+  explicit PFMatchedCandidateRefExtractor(const edm::ParameterSet& iConfig);
   ~PFMatchedCandidateRefExtractor() override;
 
-  void produce(edm::StreamID iID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
+  void produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
 private:
-
-  edm::EDGetTokenT<edm::View<reco::Candidate>> col1Token_;            
-  edm::EDGetTokenT<edm::View<reco::Candidate>> col2Token_;  
+  edm::EDGetTokenT<edm::View<reco::Candidate>> col1Token_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> col2Token_;
   std::string moduleLabel_;
-  edm::EDGetTokenT<edm::View<reco::PFCandidate> > pfCandToken_;
+  edm::EDGetTokenT<edm::View<reco::PFCandidate>> pfCandToken_;
 
   bool extractPFCands_;
-
 };
 
-
-PFMatchedCandidateRefExtractor::PFMatchedCandidateRefExtractor(const edm::ParameterSet& iConfig) :
-  col1Token_(consumes<edm::View<reco::Candidate> >( iConfig.getParameter<edm::InputTag>("col1") )),
-  col2Token_(consumes<edm::View<reco::Candidate> >( iConfig.getParameter<edm::InputTag>("col2") )),
-  moduleLabel_(iConfig.getParameter<std::string>("@module_label"))
-{
+PFMatchedCandidateRefExtractor::PFMatchedCandidateRefExtractor(const edm::ParameterSet& iConfig)
+    : col1Token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("col1"))),
+      col2Token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("col2"))),
+      moduleLabel_(iConfig.getParameter<std::string>("@module_label")) {
   //register products
-  
-  extractPFCands_=iConfig.getParameter<bool>("extractPFCandidates");
 
-  produces<edm::PtrVector<reco::Candidate> >("col1");
-  produces<edm::PtrVector<reco::Candidate> >("col2");
-  if(extractPFCands_) {
-    pfCandToken_=mayConsume<edm::View<reco::PFCandidate> >( iConfig.getParameter<edm::InputTag>("pfCandCollection") );
-    produces<edm::PtrVector<reco::PFCandidate> >("pfCandCol1");
-    produces<edm::PtrVector<reco::PFCandidate> >("pfCandCol2");
-  }  
+  extractPFCands_ = iConfig.getParameter<bool>("extractPFCandidates");
 
+  produces<edm::PtrVector<reco::Candidate>>("col1");
+  produces<edm::PtrVector<reco::Candidate>>("col2");
+  if (extractPFCands_) {
+    pfCandToken_ = mayConsume<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfCandCollection"));
+    produces<edm::PtrVector<reco::PFCandidate>>("pfCandCol1");
+    produces<edm::PtrVector<reco::PFCandidate>>("pfCandCol2");
+  }
 }
 
-
-PFMatchedCandidateRefExtractor::~PFMatchedCandidateRefExtractor() {
-}
-
+PFMatchedCandidateRefExtractor::~PFMatchedCandidateRefExtractor() {}
 
 // ------------ method called to produce the data  ------------
-void
-PFMatchedCandidateRefExtractor::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup&) const
-{  
+void PFMatchedCandidateRefExtractor::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup&) const {
+  std::unique_ptr<edm::PtrVector<reco::Candidate>> outcol1(new edm::PtrVector<reco::Candidate>());
+  std::unique_ptr<edm::PtrVector<reco::Candidate>> outcol2(new edm::PtrVector<reco::Candidate>());
 
+  std::unique_ptr<edm::PtrVector<reco::PFCandidate>> outPFCandCol1(new edm::PtrVector<reco::PFCandidate>());
+  std::unique_ptr<edm::PtrVector<reco::PFCandidate>> outPFCandCol2(new edm::PtrVector<reco::PFCandidate>());
 
-  std::unique_ptr<edm::PtrVector<reco::Candidate> > outcol1(new edm::PtrVector<reco::Candidate>());
-  std::unique_ptr<edm::PtrVector<reco::Candidate> > outcol2(new edm::PtrVector<reco::Candidate>());
-  
-  std::unique_ptr<edm::PtrVector<reco::PFCandidate> > outPFCandCol1(new edm::PtrVector<reco::PFCandidate>());
-  std::unique_ptr<edm::PtrVector<reco::PFCandidate> > outPFCandCol2(new edm::PtrVector<reco::PFCandidate>());
+  edm::Handle<edm::View<reco::Candidate>> col1Handle;
+  edm::Handle<edm::View<reco::Candidate>> col2Handle;
+  edm::Handle<edm::View<reco::PFCandidate>> pfCandHandle;
 
-  edm::Handle< edm::View<reco::Candidate> > col1Handle;
-  edm::Handle< edm::View<reco::Candidate> > col2Handle;
-  edm::Handle< edm::View<reco::PFCandidate> > pfCandHandle;
-
-  iEvent.getByToken( col1Token_, col1Handle );
-  iEvent.getByToken( col2Token_, col2Handle ); 
-   if(extractPFCands_) {
-     iEvent.getByToken( pfCandToken_, pfCandHandle ); 
-   }
-
-  for(size_t iC1=0;iC1<col1Handle->size();iC1++) {
-    for(size_t iC2=0;iC2<col2Handle->size();iC2++) {
-      
-      bool matched=(col1Handle->ptrAt(iC1)==col2Handle->ptrAt(iC2));
-      if(!matched &&
-	 deltaR2(col1Handle->ptrAt(iC1)->p4(), col2Handle->ptrAt(iC2)->p4() )< 0.000001) {
-	matched=true;
-      }
-   
-      if(matched) {
-	outcol1->push_back( col1Handle->ptrAt(iC1) );
-	outcol2->push_back( col2Handle->ptrAt(iC2) );
-	
-	if(!extractPFCands_) continue;
-	std::set<reco::CandidatePtr> sc1s;
-	std::set<reco::CandidatePtr> sc2s;
-	for(size_t ics1=0;ics1<col1Handle->ptrAt(iC1)->numberOfSourceCandidatePtrs();
-	    ics1++ ) {
-	  sc1s.insert( col1Handle->ptrAt(iC1)->sourceCandidatePtr(ics1));
-	}
-	for(size_t ics2=0;ics2<col2Handle->ptrAt(iC2)->numberOfSourceCandidatePtrs();
-	    ics2++ ) {
-	  sc2s.insert( col2Handle->ptrAt(iC2)->sourceCandidatePtr(ics2));
-	}
-
-	for(size_t ic=0;ic<pfCandHandle->size(); ++ic) {
-	  reco::PFCandidatePtr c = pfCandHandle->ptrAt(ic);
-
-	  bool match1=(sc1s.find(c)!=sc1s.end());
-	  bool match2=(sc2s.find(c)!=sc2s.end());
-	  
-	  if(!match1) {//recovery when pfcandidate sources are not equivalent
-	    for(size_t ics1=0;ics1<sc1s.size();ics1++) {
-	      if(deltaR2(c->p4(), 
-		 col1Handle->ptrAt(iC1)->sourceCandidatePtr(ics1)->p4())<0.0000001) { //tight dR, pfcandidates should be the same
-		match1=true;
-		break;
-	      }
-	    }
-	  }
-	  if(!match2) {//recovery when pfcandidate sources are not equivalent
-	    for(size_t ics2=0;ics2<sc2s.size();ics2++) {
-	      if(deltaR2(c->p4(), 
-		 col2Handle->ptrAt(iC2)->sourceCandidatePtr(ics2)->p4())<0.00001) { //tight dR
-		match2=true;
-		break;
-	      }
-	    }
-	  }
-
-	  if(match1) {
-	    outPFCandCol1->push_back(c);
-	  }
-	  if(match2) {
-	    outPFCandCol2->push_back(c);
-	  }
-	} //pfcand loop
-	
-      } //matching
-    } //col2
-  } //col1
-
-  iEvent.put(std::move(outcol1),"col1");
-  iEvent.put(std::move(outcol2),"col2");
-  if(extractPFCands_) {
-    iEvent.put(std::move(outPFCandCol1),"pfCandCol1");
-    iEvent.put(std::move(outPFCandCol2),"pfCandCol2");
+  iEvent.getByToken(col1Token_, col1Handle);
+  iEvent.getByToken(col2Token_, col2Handle);
+  if (extractPFCands_) {
+    iEvent.getByToken(pfCandToken_, pfCandHandle);
   }
 
+  for (size_t iC1 = 0; iC1 < col1Handle->size(); iC1++) {
+    for (size_t iC2 = 0; iC2 < col2Handle->size(); iC2++) {
+      bool matched = (col1Handle->ptrAt(iC1) == col2Handle->ptrAt(iC2));
+      if (!matched && deltaR2(col1Handle->ptrAt(iC1)->p4(), col2Handle->ptrAt(iC2)->p4()) < 0.000001) {
+        matched = true;
+      }
+
+      if (matched) {
+        outcol1->push_back(col1Handle->ptrAt(iC1));
+        outcol2->push_back(col2Handle->ptrAt(iC2));
+
+        if (!extractPFCands_)
+          continue;
+        std::set<reco::CandidatePtr> sc1s;
+        std::set<reco::CandidatePtr> sc2s;
+        for (size_t ics1 = 0; ics1 < col1Handle->ptrAt(iC1)->numberOfSourceCandidatePtrs(); ics1++) {
+          sc1s.insert(col1Handle->ptrAt(iC1)->sourceCandidatePtr(ics1));
+        }
+        for (size_t ics2 = 0; ics2 < col2Handle->ptrAt(iC2)->numberOfSourceCandidatePtrs(); ics2++) {
+          sc2s.insert(col2Handle->ptrAt(iC2)->sourceCandidatePtr(ics2));
+        }
+
+        for (size_t ic = 0; ic < pfCandHandle->size(); ++ic) {
+          reco::PFCandidatePtr c = pfCandHandle->ptrAt(ic);
+
+          bool match1 = (sc1s.find(c) != sc1s.end());
+          bool match2 = (sc2s.find(c) != sc2s.end());
+
+          if (!match1) {  //recovery when pfcandidate sources are not equivalent
+            for (size_t ics1 = 0; ics1 < sc1s.size(); ics1++) {
+              if (deltaR2(c->p4(),
+                          col1Handle->ptrAt(iC1)->sourceCandidatePtr(ics1)->p4()) <
+                  0.0000001) {  //tight dR, pfcandidates should be the same
+                match1 = true;
+                break;
+              }
+            }
+          }
+          if (!match2) {  //recovery when pfcandidate sources are not equivalent
+            for (size_t ics2 = 0; ics2 < sc2s.size(); ics2++) {
+              if (deltaR2(c->p4(),
+                          col2Handle->ptrAt(iC2)->sourceCandidatePtr(ics2)->p4()) < 0.00001) {  //tight dR
+                match2 = true;
+                break;
+              }
+            }
+          }
+
+          if (match1) {
+            outPFCandCol1->push_back(c);
+          }
+          if (match2) {
+            outPFCandCol2->push_back(c);
+          }
+        }  //pfcand loop
+
+      }  //matching
+    }    //col2
+  }      //col1
+
+  iEvent.put(std::move(outcol1), "col1");
+  iEvent.put(std::move(outcol2), "col2");
+  if (extractPFCands_) {
+    iEvent.put(std::move(outPFCandCol1), "pfCandCol1");
+    iEvent.put(std::move(outPFCandCol2), "pfCandCol2");
+  }
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatUtils/plugins/ShiftedJetProducerByMatchedObject.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedJetProducerByMatchedObject.cc
@@ -8,31 +8,27 @@
 
 template <typename T>
 ShiftedJetProducerByMatchedObjectT<T>::ShiftedJetProducerByMatchedObjectT(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   srcJets_ = consumes<JetCollection>(cfg.getParameter<edm::InputTag>("srcJets"));
   srcUnshiftedObjects_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("srcUnshiftedObjects"));
   srcShiftedObjects_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("srcShiftedObjects"));
 
   dRmatch_Jet_ = cfg.getParameter<double>("dRmatch_Jet");
-  dRmatch_Object_ = cfg.exists("dRmatch_Object") ?
-    cfg.getParameter<double>("dRmatch_Object") : 0.1;
+  dRmatch_Object_ = cfg.exists("dRmatch_Object") ? cfg.getParameter<double>("dRmatch_Object") : 0.1;
 
-  dR2match_Jet_ = dRmatch_Jet_*dRmatch_Jet_;
-  dR2match_Object_ = dRmatch_Object_*dRmatch_Object_;
+  dR2match_Jet_ = dRmatch_Jet_ * dRmatch_Jet_;
+  dR2match_Object_ = dRmatch_Object_ * dRmatch_Object_;
 
   produces<JetCollection>();
 }
 
 template <typename T>
-ShiftedJetProducerByMatchedObjectT<T>::~ShiftedJetProducerByMatchedObjectT()
-{
-// nothing to be done yet...
+ShiftedJetProducerByMatchedObjectT<T>::~ShiftedJetProducerByMatchedObjectT() {
+  // nothing to be done yet...
 }
 
 template <typename T>
-void ShiftedJetProducerByMatchedObjectT<T>::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedJetProducerByMatchedObjectT<T>::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<JetCollection> originalJets;
   evt.getByToken(srcJets_, originalJets);
 
@@ -43,84 +39,87 @@ void ShiftedJetProducerByMatchedObjectT<T>::produce(edm::Event& evt, const edm::
   evt.getByToken(srcShiftedObjects_, shiftedObjects);
 
   objects_.clear();
-  
+
   std::vector<bool> match(shiftedObjects->size(), false);
-  int prevMatch=-1;
+  int prevMatch = -1;
   int cnt = 0;
 
-  for ( reco::CandidateView::const_iterator unshiftedObject = unshiftedObjects->begin();
-	unshiftedObject != unshiftedObjects->end(); ++unshiftedObject ) {
+  for (reco::CandidateView::const_iterator unshiftedObject = unshiftedObjects->begin();
+       unshiftedObject != unshiftedObjects->end();
+       ++unshiftedObject) {
     bool isMatched_Object = false;
     double dR2bestMatch_Object = std::numeric_limits<double>::max();
-    prevMatch=-1;
+    prevMatch = -1;
     cnt = 0;
-    
+
     reco::Candidate::LorentzVector shiftedObjectP4_matched;
-    for ( reco::CandidateView::const_iterator shiftedObject = shiftedObjects->begin();
-	shiftedObject != shiftedObjects->end(); ++shiftedObject ) {
-      if( match[ cnt ] ) continue;
+    for (reco::CandidateView::const_iterator shiftedObject = shiftedObjects->begin();
+         shiftedObject != shiftedObjects->end();
+         ++shiftedObject) {
+      if (match[cnt])
+        continue;
 
       double dR2 = deltaR2(unshiftedObject->p4(), shiftedObject->p4());
-      if ( dR2 < dR2match_Object_ && dR2 < dR2bestMatch_Object ) {
-	shiftedObjectP4_matched = shiftedObject->p4();
-	isMatched_Object = true;
-	dR2bestMatch_Object = dR2;
-	
-	prevMatch = cnt;
+      if (dR2 < dR2match_Object_ && dR2 < dR2bestMatch_Object) {
+        shiftedObjectP4_matched = shiftedObject->p4();
+        isMatched_Object = true;
+        dR2bestMatch_Object = dR2;
+
+        prevMatch = cnt;
       }
       cnt++;
     }
-    if ( isMatched_Object ) {
+    if (isMatched_Object) {
       //Ambiguity removal
-      match[ prevMatch ] = true;
+      match[prevMatch] = true;
       objects_.push_back(objectEntryType(shiftedObjectP4_matched, unshiftedObject->p4(), sqrt(dR2bestMatch_Object)));
     }
   }
- 
-  
+
   match.assign(objects_.size(), false);
 
   auto shiftedJets = std::make_unique<JetCollection>();
-    
-  for ( typename JetCollection::const_iterator originalJet = originalJets->begin();
-	originalJet != originalJets->end(); ++originalJet ) {
-    
+
+  for (typename JetCollection::const_iterator originalJet = originalJets->begin(); originalJet != originalJets->end();
+       ++originalJet) {
     double shift = 0.;
     bool applyShift = false;
     double dR2bestMatch_Jet = std::numeric_limits<double>::max();
-    prevMatch=-1;
+    prevMatch = -1;
     cnt = 0;
-    
-    for ( typename std::vector<objectEntryType>::const_iterator object = objects_.begin();
-	  object != objects_.end(); ++object ) {
-      if ( !object->isValidMatch_ ) continue;
-      if( match[ cnt ] ) continue;
+
+    for (typename std::vector<objectEntryType>::const_iterator object = objects_.begin(); object != objects_.end();
+         ++object) {
+      if (!object->isValidMatch_)
+        continue;
+      if (match[cnt])
+        continue;
 
       double dR2 = deltaR2(originalJet->p4(), object->unshiftedObjectP4_);
-      if ( dR2 < dR2match_Jet_ && dR2 < dR2bestMatch_Jet ) {
-	shift = object->shift_;
-	applyShift = true;
-	dR2bestMatch_Jet = dR2;
+      if (dR2 < dR2match_Jet_ && dR2 < dR2bestMatch_Jet) {
+        shift = object->shift_;
+        applyShift = true;
+        dR2bestMatch_Jet = dR2;
 
-	prevMatch = cnt;
+        prevMatch = cnt;
       }
       cnt++;
     }
-    
+
     reco::Candidate::LorentzVector shiftedJetP4 = originalJet->p4();
-    if ( applyShift ) {
+    if (applyShift) {
       //Ambiguity removal
-      match[ prevMatch ] = true;
-      
+      match[prevMatch] = true;
+
       shiftedJetP4 *= (1. + shift);
     }
-    
-    T shiftedJet(*originalJet);      
+
+    T shiftedJet(*originalJet);
     shiftedJet.setP4(shiftedJetP4);
-    
+
     shiftedJets->push_back(shiftedJet);
   }
-  
+
   evt.put(std::move(shiftedJets));
 }
 
@@ -134,6 +133,3 @@ typedef ShiftedJetProducerByMatchedObjectT<reco::PFJet> ShiftedPFJetProducerByMa
 
 DEFINE_FWK_MODULE(ShiftedCaloJetProducerByMatchedObject);
 DEFINE_FWK_MODULE(ShiftedPFJetProducerByMatchedObject);
-
-
- 

--- a/PhysicsTools/PatUtils/plugins/ShiftedJetProducerByMatchedObject.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedJetProducerByMatchedObject.h
@@ -23,24 +23,21 @@
 #include <vector>
 
 template <typename T>
-class ShiftedJetProducerByMatchedObjectT : public edm::stream::EDProducer<>  
-{
+class ShiftedJetProducerByMatchedObjectT : public edm::stream::EDProducer<> {
   typedef std::vector<T> JetCollection;
 
- public:
-
+public:
   explicit ShiftedJetProducerByMatchedObjectT(const edm::ParameterSet&);
   ~ShiftedJetProducerByMatchedObjectT() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 
-  edm::EDGetTokenT<JetCollection> srcJets_; 
-  edm::EDGetTokenT<edm::View<reco::Candidate> > srcUnshiftedObjects_; 
-  edm::EDGetTokenT<edm::View<reco::Candidate> > srcShiftedObjects_; 
+  edm::EDGetTokenT<JetCollection> srcJets_;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > srcUnshiftedObjects_;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > srcShiftedObjects_;
 
   double dRmatch_Jet_;
   double dRmatch_Object_;
@@ -48,18 +45,17 @@ class ShiftedJetProducerByMatchedObjectT : public edm::stream::EDProducer<>
   double dR2match_Jet_;
   double dR2match_Object_;
 
-  struct objectEntryType
-  {
-    objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4, 
-		    const reco::Candidate::LorentzVector& unshiftedObjectP4, double dRmatch)
-      : shiftedObjectP4_(shiftedObjectP4),
-	unshiftedObjectP4_(unshiftedObjectP4),
-	dRmatch_(dRmatch),
-	isValidMatch_(false)
-    {
-      if ( unshiftedObjectP4.energy() > 0. ) {
-	shift_ = (shiftedObjectP4.energy()/unshiftedObjectP4.energy()) - 1.;
-	isValidMatch_ = true;
+  struct objectEntryType {
+    objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4,
+                    const reco::Candidate::LorentzVector& unshiftedObjectP4,
+                    double dRmatch)
+        : shiftedObjectP4_(shiftedObjectP4),
+          unshiftedObjectP4_(unshiftedObjectP4),
+          dRmatch_(dRmatch),
+          isValidMatch_(false) {
+      if (unshiftedObjectP4.energy() > 0.) {
+        shift_ = (shiftedObjectP4.energy() / unshiftedObjectP4.energy()) - 1.;
+        isValidMatch_ = true;
       }
     }
     ~objectEntryType() {}
@@ -74,7 +70,3 @@ class ShiftedJetProducerByMatchedObjectT : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
- 
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.cc
@@ -2,29 +2,26 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-ShiftedMETcorrInputProducer::ShiftedMETcorrInputProducer(const edm::ParameterSet& cfg)
-{
+ShiftedMETcorrInputProducer::ShiftedMETcorrInputProducer(const edm::ParameterSet& cfg) {
   src_ = cfg.getParameter<vInputTag>("src");
 
-//--- check that all InputTags refer to the same module label
-//   (i.e. differ by instance label only)
-  for ( vInputTag::const_iterator src_ref = src_.begin();
-	src_ref != src_.end(); ++src_ref ) {
-    for ( vInputTag::const_iterator src_test = src_ref;
-	  src_test != src_.end(); ++src_test ) {
-      if ( src_test->label() != src_ref->label() )
-	throw cms::Exception("ShiftedMETcorrInputProducer")
-	  << "InputTags specified by 'src' Configuration parameter must not refer to different module labels !!\n";
+  //--- check that all InputTags refer to the same module label
+  //   (i.e. differ by instance label only)
+  for (vInputTag::const_iterator src_ref = src_.begin(); src_ref != src_.end(); ++src_ref) {
+    for (vInputTag::const_iterator src_test = src_ref; src_test != src_.end(); ++src_test) {
+      if (src_test->label() != src_ref->label())
+        throw cms::Exception("ShiftedMETcorrInputProducer")
+            << "InputTags specified by 'src' Configuration parameter must not refer to different module labels !!\n";
     }
   }
 
   shiftBy_ = cfg.getParameter<double>("shiftBy");
 
-  if ( cfg.exists("binning") ) {
+  if (cfg.exists("binning")) {
     typedef std::vector<edm::ParameterSet> vParameterSet;
     vParameterSet cfgBinning = cfg.getParameter<vParameterSet>("binning");
-    for ( vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin();
-	  cfgBinningEntry != cfgBinning.end(); ++cfgBinningEntry ) {
+    for (vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin(); cfgBinningEntry != cfgBinning.end();
+         ++cfgBinningEntry) {
       binning_.push_back(new binningEntryType(*cfgBinningEntry));
     }
   } else {
@@ -32,43 +29,39 @@ ShiftedMETcorrInputProducer::ShiftedMETcorrInputProducer(const edm::ParameterSet
     binning_.push_back(new binningEntryType(uncertainty));
   }
 
-  for ( vInputTag::const_iterator src_i = src_.begin();
-	src_i != src_.end(); ++src_i ) {
-    for ( std::vector<binningEntryType*>::const_iterator binningEntry = binning_.begin();
-	  binningEntry != binning_.end(); ++binningEntry ) {
-      srcTokens_.push_back(consumes<CorrMETData>(edm::InputTag(src_i->label(), (*binningEntry)->getInstanceLabel_full(src_i->instance()))));
+  for (vInputTag::const_iterator src_i = src_.begin(); src_i != src_.end(); ++src_i) {
+    for (std::vector<binningEntryType*>::const_iterator binningEntry = binning_.begin(); binningEntry != binning_.end();
+         ++binningEntry) {
+      srcTokens_.push_back(consumes<CorrMETData>(
+          edm::InputTag(src_i->label(), (*binningEntry)->getInstanceLabel_full(src_i->instance()))));
       produces<CorrMETData>((*binningEntry)->getInstanceLabel_full(src_i->instance()));
     }
   }
 }
 
-ShiftedMETcorrInputProducer::~ShiftedMETcorrInputProducer()
-{
-  for ( std::vector<binningEntryType*>::const_iterator it = binning_.begin();
-	it != binning_.end(); ++it ) {
+ShiftedMETcorrInputProducer::~ShiftedMETcorrInputProducer() {
+  for (std::vector<binningEntryType*>::const_iterator it = binning_.begin(); it != binning_.end(); ++it) {
     delete (*it);
   }
 }
 
-void ShiftedMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   unsigned countToken(0);
-  for ( vInputTag::const_iterator src_i = src_.begin();
-	src_i != src_.end(); ++src_i ) {
-    for ( std::vector<binningEntryType*>::iterator binningEntry = binning_.begin();
-	  binningEntry != binning_.end(); ++binningEntry ) {
+  for (vInputTag::const_iterator src_i = src_.begin(); src_i != src_.end(); ++src_i) {
+    for (std::vector<binningEntryType*>::iterator binningEntry = binning_.begin(); binningEntry != binning_.end();
+         ++binningEntry) {
       edm::Handle<CorrMETData> originalObject;
       evt.getByToken(srcTokens_.at(countToken), originalObject);
       ++countToken;
 
-      double shift = shiftBy_*(*binningEntry)->binUncertainty_;
+      double shift = shiftBy_ * (*binningEntry)->binUncertainty_;
 
       auto shiftedObject = std::make_unique<CorrMETData>(*originalObject);
-//--- MET balances momentum of reconstructed particles,
-//    hence variations of "unclustered energy" and MET are opposite in sign
-      shiftedObject->mex   = -shift*originalObject->mex;
-      shiftedObject->mey   = -shift*originalObject->mey;
-      shiftedObject->sumet = shift*originalObject->sumet;
+      //--- MET balances momentum of reconstructed particles,
+      //    hence variations of "unclustered energy" and MET are opposite in sign
+      shiftedObject->mex = -shift * originalObject->mex;
+      shiftedObject->mey = -shift * originalObject->mey;
+      shiftedObject->sumet = shift * originalObject->sumet;
 
       evt.put(std::move(shiftedObject), (*binningEntry)->getInstanceLabel_full(src_i->instance()));
     }

--- a/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.h
@@ -22,35 +22,27 @@
 
 #include <string>
 
-class ShiftedMETcorrInputProducer : public edm::stream::EDProducer<>
-{
- public:
-
+class ShiftedMETcorrInputProducer : public edm::stream::EDProducer<> {
+public:
   explicit ShiftedMETcorrInputProducer(const edm::ParameterSet&);
   ~ShiftedMETcorrInputProducer() override;
 
- private:
-
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef std::vector<edm::InputTag> vInputTag;
   vInputTag src_;
   std::vector<edm::EDGetTokenT<CorrMETData> > srcTokens_;
 
-  struct binningEntryType
-  {
-    binningEntryType(double uncertainty)
-      : binLabel_(""),
-        binUncertainty_(uncertainty)
-    {}
+  struct binningEntryType {
+    binningEntryType(double uncertainty) : binLabel_(""), binUncertainty_(uncertainty) {}
     binningEntryType(const edm::ParameterSet& cfg)
-    : binLabel_(cfg.getParameter<std::string>("binLabel")),
-      binUncertainty_(cfg.getParameter<double>("binUncertainty"))
-    {}
-    std::string getInstanceLabel_full(const std::string& instanceLabel)
-    {
+        : binLabel_(cfg.getParameter<std::string>("binLabel")),
+          binUncertainty_(cfg.getParameter<double>("binUncertainty")) {}
+    std::string getInstanceLabel_full(const std::string& instanceLabel) {
       std::string retVal = instanceLabel;
-      if ( !instanceLabel.empty() && !binLabel_.empty() ) retVal.append("#");
+      if (!instanceLabel.empty() && !binLabel_.empty())
+        retVal.append("#");
       retVal.append(binLabel_);
       return retVal;
     }
@@ -64,7 +56,3 @@ class ShiftedMETcorrInputProducer : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.h
@@ -50,7 +50,7 @@ class ShiftedMETcorrInputProducer : public edm::stream::EDProducer<>
     std::string getInstanceLabel_full(const std::string& instanceLabel)
     {
       std::string retVal = instanceLabel;
-      if ( instanceLabel != "" && binLabel_ != "" ) retVal.append("#");
+      if ( !instanceLabel.empty() && !binLabel_.empty() ) retVal.append("#");
       retVal.append(binLabel_);
       return retVal;
     }

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducer.cc
@@ -7,4 +7,3 @@ typedef ShiftedParticleProducerT<reco::PFCandidate> ShiftedPFCandidateProducer;
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedPFCandidateProducer);
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerByMatchedObject.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerByMatchedObject.cc
@@ -2,27 +2,23 @@
 
 const double dRDefault = 1000;
 
-ShiftedPFCandidateProducerByMatchedObject::ShiftedPFCandidateProducerByMatchedObject(const edm::ParameterSet& cfg)
-{
+ShiftedPFCandidateProducerByMatchedObject::ShiftedPFCandidateProducerByMatchedObject(const edm::ParameterSet& cfg) {
   srcPFCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
   srcUnshiftedObjects_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("srcUnshiftedObjects"));
   srcShiftedObjects_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("srcShiftedObjects"));
 
   dRmatch_PFCandidate_ = cfg.getParameter<double>("dRmatch_PFCandidate");
-  dR2match_PFCandidate_ = dRmatch_PFCandidate_*dRmatch_PFCandidate_;
-  dRmatch_Object_ = cfg.exists("dRmatch_Object") ?
-    cfg.getParameter<double>("dRmatch_Object") : 0.1;
-  dR2match_Object_ = dRmatch_Object_*dRmatch_Object_;
+  dR2match_PFCandidate_ = dRmatch_PFCandidate_ * dRmatch_PFCandidate_;
+  dRmatch_Object_ = cfg.exists("dRmatch_Object") ? cfg.getParameter<double>("dRmatch_Object") : 0.1;
+  dR2match_Object_ = dRmatch_Object_ * dRmatch_Object_;
   produces<reco::PFCandidateCollection>();
 }
 
-ShiftedPFCandidateProducerByMatchedObject::~ShiftedPFCandidateProducerByMatchedObject()
-{
-// nothing to be done yet...
+ShiftedPFCandidateProducerByMatchedObject::~ShiftedPFCandidateProducerByMatchedObject() {
+  // nothing to be done yet...
 }
 
-void ShiftedPFCandidateProducerByMatchedObject::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedPFCandidateProducerByMatchedObject::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::PFCandidateCollection> originalPFCandidates;
   evt.getByToken(srcPFCandidates_, originalPFCandidates);
 
@@ -35,70 +31,69 @@ void ShiftedPFCandidateProducerByMatchedObject::produce(edm::Event& evt, const e
   evt.getByToken(srcShiftedObjects_, shiftedObjects);
 
   objects_.clear();
-  
+
   CandidateView::const_iterator shiftedObjectP4_matched;
   bool isMatched_Object = false;
   double dR2bestMatch_Object = dRDefault;
-  for ( CandidateView::const_iterator unshiftedObject = unshiftedObjects->begin();
-	unshiftedObject != unshiftedObjects->end(); ++unshiftedObject ) {
+  for (CandidateView::const_iterator unshiftedObject = unshiftedObjects->begin();
+       unshiftedObject != unshiftedObjects->end();
+       ++unshiftedObject) {
     isMatched_Object = false;
     dR2bestMatch_Object = dRDefault;
-   
-    for ( CandidateView::const_iterator shiftedObject = shiftedObjects->begin();
-	shiftedObject != shiftedObjects->end(); ++shiftedObject ) {
+
+    for (CandidateView::const_iterator shiftedObject = shiftedObjects->begin(); shiftedObject != shiftedObjects->end();
+         ++shiftedObject) {
       double dR2 = deltaR2(unshiftedObject->p4(), shiftedObject->p4());
-      if ( dR2 < dR2match_Object_ && dR2 < dR2bestMatch_Object ) {
-	shiftedObjectP4_matched = shiftedObject;
-	isMatched_Object = true;
-	dR2bestMatch_Object = dR2;
+      if (dR2 < dR2match_Object_ && dR2 < dR2bestMatch_Object) {
+        shiftedObjectP4_matched = shiftedObject;
+        isMatched_Object = true;
+        dR2bestMatch_Object = dR2;
       }
     }
-    if ( isMatched_Object ) {
-      objects_.push_back(objectEntryType(shiftedObjectP4_matched->p4(), unshiftedObject->p4(), sqrt(dR2bestMatch_Object) ));
+    if (isMatched_Object) {
+      objects_.push_back(
+          objectEntryType(shiftedObjectP4_matched->p4(), unshiftedObject->p4(), sqrt(dR2bestMatch_Object)));
     }
   }
- 
+
   auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
-    
-  for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
-	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
-    
+
+  for (reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
+       originalPFCandidate != originalPFCandidates->end();
+       ++originalPFCandidate) {
     double shift = 0.;
     bool applyShift = false;
     double dR2bestMatch_PFCandidate = dRDefault;
-    for ( std::vector<objectEntryType>::const_iterator object = objects_.begin();
-	  object != objects_.end(); ++object ) {
-      if ( !object->isValidMatch_ ) continue;
+    for (std::vector<objectEntryType>::const_iterator object = objects_.begin(); object != objects_.end(); ++object) {
+      if (!object->isValidMatch_)
+        continue;
       double dR2 = deltaR2(originalPFCandidate->p4(), object->unshiftedObjectP4_);
-      if ( dR2 < dR2match_PFCandidate_ && dR2 < dR2bestMatch_PFCandidate ) {
-	shift = object->shift_;
-	applyShift = true;
-	dR2bestMatch_PFCandidate = dR2;
+      if (dR2 < dR2match_PFCandidate_ && dR2 < dR2bestMatch_PFCandidate) {
+        shift = object->shift_;
+        applyShift = true;
+        dR2bestMatch_PFCandidate = dR2;
       }
     }
-    
+
     reco::Candidate::LorentzVector shiftedPFCandidateP4 = originalPFCandidate->p4();
-    if ( applyShift ) {
-      double shiftedPx = (1. + shift)*originalPFCandidate->px();
-      double shiftedPy = (1. + shift)*originalPFCandidate->py();
-      double shiftedPz = (1. + shift)*originalPFCandidate->pz();
+    if (applyShift) {
+      double shiftedPx = (1. + shift) * originalPFCandidate->px();
+      double shiftedPy = (1. + shift) * originalPFCandidate->py();
+      double shiftedPz = (1. + shift) * originalPFCandidate->pz();
       double mass = originalPFCandidate->mass();
-      double shiftedEn = sqrt(shiftedPx*shiftedPx + shiftedPy*shiftedPy + shiftedPz*shiftedPz + mass*mass);
+      double shiftedEn = sqrt(shiftedPx * shiftedPx + shiftedPy * shiftedPy + shiftedPz * shiftedPz + mass * mass);
       shiftedPFCandidateP4.SetPxPyPzE(shiftedPx, shiftedPy, shiftedPz, shiftedEn);
     }
-    
-    reco::PFCandidate shiftedPFCandidate(*originalPFCandidate);      
+
+    reco::PFCandidate shiftedPFCandidate(*originalPFCandidate);
     shiftedPFCandidate.setP4(shiftedPFCandidateP4);
-    
+
     shiftedPFCandidates->push_back(shiftedPFCandidate);
   }
-  
+
   evt.put(std::move(shiftedPFCandidates));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedPFCandidateProducerByMatchedObject);
-
-
- 

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerByMatchedObject.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerByMatchedObject.h
@@ -28,38 +28,34 @@
 #include <string>
 #include <vector>
 
-class ShiftedPFCandidateProducerByMatchedObject : public edm::stream::EDProducer<>  
-{
- public:
-
+class ShiftedPFCandidateProducerByMatchedObject : public edm::stream::EDProducer<> {
+public:
   explicit ShiftedPFCandidateProducerByMatchedObject(const edm::ParameterSet&);
   ~ShiftedPFCandidateProducerByMatchedObject() override;
-    
- private:
 
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  edm::EDGetTokenT<reco::PFCandidateCollection > srcPFCandidates_; 
-  edm::EDGetTokenT<edm::View<reco::Candidate> > srcUnshiftedObjects_; 
-  edm::EDGetTokenT<edm::View<reco::Candidate> > srcShiftedObjects_; 
+  edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidates_;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > srcUnshiftedObjects_;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > srcShiftedObjects_;
 
   double dRmatch_PFCandidate_;
   double dR2match_PFCandidate_;
   double dRmatch_Object_;
   double dR2match_Object_;
 
-  struct objectEntryType
-  {
-    objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4, 
-		    const reco::Candidate::LorentzVector& unshiftedObjectP4, double dRmatch)
-      : shiftedObjectP4_(shiftedObjectP4),
-	unshiftedObjectP4_(unshiftedObjectP4),
-	dRmatch_(dRmatch),
-	isValidMatch_(false)
-    {
-      if ( unshiftedObjectP4.energy() > 0. ) {
-	shift_ = (shiftedObjectP4.energy()/unshiftedObjectP4.energy()) - 1.;
-	isValidMatch_ = true;
+  struct objectEntryType {
+    objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4,
+                    const reco::Candidate::LorentzVector& unshiftedObjectP4,
+                    double dRmatch)
+        : shiftedObjectP4_(shiftedObjectP4),
+          unshiftedObjectP4_(unshiftedObjectP4),
+          dRmatch_(dRmatch),
+          isValidMatch_(false) {
+      if (unshiftedObjectP4.energy() > 0.) {
+        shift_ = (shiftedObjectP4.energy() / unshiftedObjectP4.energy()) - 1.;
+        isValidMatch_ = true;
       }
     }
     ~objectEntryType() {}
@@ -74,7 +70,3 @@ class ShiftedPFCandidateProducerByMatchedObject : public edm::stream::EDProducer
 };
 
 #endif
-
-
- 
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
@@ -6,15 +6,14 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 ShiftedPFCandidateProducerForNoPileUpPFMEt::ShiftedPFCandidateProducerForNoPileUpPFMEt(const edm::ParameterSet& cfg)
-  : srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates")))
-  , srcJetsToken_(consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets")))
-{
-
+    : srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates"))),
+      srcJetsToken_(consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets"))) {
   jetCorrUncertaintyTag_ = cfg.getParameter<std::string>("jetCorrUncertaintyTag");
-  if ( cfg.exists("jetCorrInputFileName") ) {
+  if (cfg.exists("jetCorrInputFileName")) {
     jetCorrInputFileName_ = cfg.getParameter<edm::FileInPath>("jetCorrInputFileName");
-    if ( jetCorrInputFileName_.location() == edm::FileInPath::Unknown) throw cms::Exception("ShiftedJetProducerT")
-      << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
+    if (jetCorrInputFileName_.location() == edm::FileInPath::Unknown)
+      throw cms::Exception("ShiftedJetProducerT")
+          << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
     jetCorrParameters_ = new JetCorrectorParameters(jetCorrInputFileName_.fullPath(), jetCorrUncertaintyTag_);
     jecUncertainty_ = new JetCorrectionUncertainty(*jetCorrParameters_);
   } else {
@@ -30,13 +29,11 @@ ShiftedPFCandidateProducerForNoPileUpPFMEt::ShiftedPFCandidateProducerForNoPileU
   produces<reco::PFCandidateCollection>();
 }
 
-ShiftedPFCandidateProducerForNoPileUpPFMEt::~ShiftedPFCandidateProducerForNoPileUpPFMEt()
-{
-// nothing to be done yet...
+ShiftedPFCandidateProducerForNoPileUpPFMEt::~ShiftedPFCandidateProducerForNoPileUpPFMEt() {
+  // nothing to be done yet...
 }
 
-void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::PFCandidateCollection> originalPFCandidates;
   evt.getByToken(srcPFCandidatesToken_, originalPFCandidates);
 
@@ -44,35 +41,36 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
   evt.getByToken(srcJetsToken_, jets);
 
   std::vector<const reco::PFJet*> selectedJets;
-  for ( reco::PFJetCollection::const_iterator jet = jets->begin();
-	jet != jets->end(); ++jet ) {
-    if ( jet->pt() > minJetPt_ ) selectedJets.push_back(&(*jet));
+  for (reco::PFJetCollection::const_iterator jet = jets->begin(); jet != jets->end(); ++jet) {
+    if (jet->pt() > minJetPt_)
+      selectedJets.push_back(&(*jet));
   }
 
-  if ( !jetCorrPayloadName_.empty() ) {
-      edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
-      es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
-      const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];
-      delete jecUncertainty_;
-      jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
-    }
+  if (!jetCorrPayloadName_.empty()) {
+    edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
+    es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
+    const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];
+    delete jecUncertainty_;
+    jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
+  }
 
   auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
-  for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
-	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
-
+  for (reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
+       originalPFCandidate != originalPFCandidates->end();
+       ++originalPFCandidate) {
     const reco::PFJet* jet_matched = nullptr;
-    for ( std::vector<const reco::PFJet*>::iterator jet = selectedJets.begin();
-	  jet != selectedJets.end(); ++jet ) {
+    for (std::vector<const reco::PFJet*>::iterator jet = selectedJets.begin(); jet != selectedJets.end(); ++jet) {
       std::vector<reco::PFCandidatePtr> jetConstituents = (*jet)->getPFConstituents();
-      for ( std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = jetConstituents.begin();
-	    jetConstituent != jetConstituents.end() && !jet_matched; ++jetConstituent ) {
-	if ( deltaR(originalPFCandidate->p4(), (*jetConstituent)->p4()) < 1.e-2 ) jet_matched = (*jet);
+      for (std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = jetConstituents.begin();
+           jetConstituent != jetConstituents.end() && !jet_matched;
+           ++jetConstituent) {
+        if (deltaR(originalPFCandidate->p4(), (*jetConstituent)->p4()) < 1.e-2)
+          jet_matched = (*jet);
       }
     }
 
     double shift = 0.;
-    if ( jet_matched ) {
+    if (jet_matched) {
       jecUncertainty_->setJetEta(jet_matched->eta());
       jecUncertainty_->setJetPt(jet_matched->pt());
 
@@ -98,6 +96,3 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedPFCandidateProducerForNoPileUpPFMEt);
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
@@ -49,7 +49,7 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
     if ( jet->pt() > minJetPt_ ) selectedJets.push_back(&(*jet));
   }
 
-  if ( jetCorrPayloadName_ != "" ) {
+  if ( !jetCorrPayloadName_.empty() ) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
       es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
       const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.h
@@ -39,19 +39,16 @@
 #include <string>
 #include <vector>
 
-class ShiftedPFCandidateProducerForNoPileUpPFMEt : public edm::stream::EDProducer<>
-{
- public:
-
+class ShiftedPFCandidateProducerForNoPileUpPFMEt : public edm::stream::EDProducer<> {
+public:
   explicit ShiftedPFCandidateProducerForNoPileUpPFMEt(const edm::ParameterSet&);
   ~ShiftedPFCandidateProducerForNoPileUpPFMEt() override;
 
- private:
-
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidatesToken_;
-  edm::EDGetTokenT<reco::PFJetCollection>       srcJetsToken_;
+  edm::EDGetTokenT<reco::PFJetCollection> srcJetsToken_;
 
   edm::FileInPath jetCorrInputFileName_;
   std::string jetCorrPayloadName_;
@@ -67,7 +64,3 @@ class ShiftedPFCandidateProducerForNoPileUpPFMEt : public edm::stream::EDProduce
 };
 
 #endif
-
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMVAMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMVAMEt.cc
@@ -5,28 +5,24 @@
 const double dRDefault = 1000;
 
 ShiftedPFCandidateProducerForPFMVAMEt::ShiftedPFCandidateProducerForPFMVAMEt(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-  , srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates")))
-  , srcUnshiftedObjectsToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcUnshiftedObjects")))
-  , srcShiftedObjectsToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcShiftedObjects")))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+      srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates"))),
+      srcUnshiftedObjectsToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcUnshiftedObjects"))),
+      srcShiftedObjectsToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcShiftedObjects"))) {
   dRmatch_PFCandidate_ = cfg.getParameter<double>("dRmatch_PFCandidate");
-  dRmatch_Object_ = cfg.exists("dRmatch_Object") ?
-    cfg.getParameter<double>("dRmatch_Object") : 0.1;
+  dRmatch_Object_ = cfg.exists("dRmatch_Object") ? cfg.getParameter<double>("dRmatch_Object") : 0.1;
 
-  dR2match_PFCandidate_ = dRmatch_PFCandidate_*dRmatch_PFCandidate_; 
-  dR2match_Object_ = dRmatch_Object_*dRmatch_Object_;
-  
+  dR2match_PFCandidate_ = dRmatch_PFCandidate_ * dRmatch_PFCandidate_;
+  dR2match_Object_ = dRmatch_Object_ * dRmatch_Object_;
+
   produces<reco::PFCandidateCollection>();
 }
 
-ShiftedPFCandidateProducerForPFMVAMEt::~ShiftedPFCandidateProducerForPFMVAMEt()
-{
-// nothing to be done yet...
+ShiftedPFCandidateProducerForPFMVAMEt::~ShiftedPFCandidateProducerForPFMVAMEt() {
+  // nothing to be done yet...
 }
 
-void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::PFCandidateCollection> originalPFCandidates;
   evt.getByToken(srcPFCandidatesToken_, originalPFCandidates);
 
@@ -39,33 +35,35 @@ void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::
   objects_.clear();
 
   std::vector<bool> match(shiftedObjects->size(), false);
-  int prevMatch=-1;
+  int prevMatch = -1;
   int cnt = 0;
 
-  for ( CandidateView::const_iterator unshiftedObject = unshiftedObjects->begin();
-	unshiftedObject != unshiftedObjects->end(); ++unshiftedObject ) {
+  for (CandidateView::const_iterator unshiftedObject = unshiftedObjects->begin();
+       unshiftedObject != unshiftedObjects->end();
+       ++unshiftedObject) {
     bool isMatched_Object = false;
     double dR2bestMatch_Object = dRDefault;
     reco::Candidate::LorentzVector shiftedObjectP4_matched;
-    prevMatch=-1;
-    
-    for ( CandidateView::const_iterator shiftedObject = shiftedObjects->begin();
-	shiftedObject != shiftedObjects->end(); ++shiftedObject ) {
-      if( match[ cnt ] ) continue;
+    prevMatch = -1;
+
+    for (CandidateView::const_iterator shiftedObject = shiftedObjects->begin(); shiftedObject != shiftedObjects->end();
+         ++shiftedObject) {
+      if (match[cnt])
+        continue;
 
       double dR2 = deltaR2(unshiftedObject->p4(), shiftedObject->p4());
-      if ( dR2 < dR2match_Object_ && dR2 < dR2bestMatch_Object ) {
-	shiftedObjectP4_matched = shiftedObject->p4();
-	isMatched_Object = true;
-	dR2bestMatch_Object = dR2;
+      if (dR2 < dR2match_Object_ && dR2 < dR2bestMatch_Object) {
+        shiftedObjectP4_matched = shiftedObject->p4();
+        isMatched_Object = true;
+        dR2bestMatch_Object = dR2;
 
-	prevMatch = cnt;
+        prevMatch = cnt;
       }
       cnt++;
     }
-    if ( isMatched_Object ) {
+    if (isMatched_Object) {
       //Ambiguity removal
-      match[ prevMatch ] = true;
+      match[prevMatch] = true;
       objects_.push_back(objectEntryType(shiftedObjectP4_matched, unshiftedObject->p4(), sqrt(dR2bestMatch_Object)));
     }
   }
@@ -74,36 +72,37 @@ void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::
 
   auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
 
-  for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
-	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
-
+  for (reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
+       originalPFCandidate != originalPFCandidates->end();
+       ++originalPFCandidate) {
     double shift = 0.;
     bool applyShift = false;
     double dR2bestMatch_PFCandidate = dRDefault;
-    prevMatch=-1;
+    prevMatch = -1;
     cnt = 0;
-    
-    for ( std::vector<objectEntryType>::const_iterator object = objects_.begin();
-	  object != objects_.end(); ++object ) {
-      if ( !object->isValidMatch_ ) continue;
-      if( match[ cnt ] ) continue;
+
+    for (std::vector<objectEntryType>::const_iterator object = objects_.begin(); object != objects_.end(); ++object) {
+      if (!object->isValidMatch_)
+        continue;
+      if (match[cnt])
+        continue;
 
       double dR2 = deltaR2(originalPFCandidate->p4(), object->unshiftedObjectP4_);
-      if ( dR2 < dR2match_PFCandidate_ && dR2 < dR2bestMatch_PFCandidate ) {
-	shift = object->shift_;
-	applyShift = true;
-	dR2bestMatch_PFCandidate = dR2;
+      if (dR2 < dR2match_PFCandidate_ && dR2 < dR2bestMatch_PFCandidate) {
+        shift = object->shift_;
+        applyShift = true;
+        dR2bestMatch_PFCandidate = dR2;
 
-	prevMatch = cnt;
+        prevMatch = cnt;
       }
       cnt++;
     }
 
     reco::Candidate::LorentzVector shiftedPFCandidateP4 = originalPFCandidate->p4();
-    if ( applyShift ) {
+    if (applyShift) {
       //Ambiguity removal
-      match[ prevMatch ] = true;
-     
+      match[prevMatch] = true;
+
       shiftedPFCandidateP4 *= (1. + shift);
     }
 
@@ -119,6 +118,3 @@ void ShiftedPFCandidateProducerForPFMVAMEt::produce(edm::Event& evt, const edm::
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedPFCandidateProducerForPFMVAMEt);
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMVAMEt.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMVAMEt.h
@@ -30,14 +30,12 @@
 #include <string>
 #include <vector>
 
-class ShiftedPFCandidateProducerForPFMVAMEt : public edm::stream::EDProducer<>
-{
- public:
-
+class ShiftedPFCandidateProducerForPFMVAMEt : public edm::stream::EDProducer<> {
+public:
   explicit ShiftedPFCandidateProducerForPFMVAMEt(const edm::ParameterSet&);
   ~ShiftedPFCandidateProducerForPFMVAMEt() override;
 
- private:
+private:
   typedef edm::View<reco::Candidate> CandidateView;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -45,8 +43,8 @@ class ShiftedPFCandidateProducerForPFMVAMEt : public edm::stream::EDProducer<>
   std::string moduleLabel_;
 
   edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidatesToken_;
-  edm::EDGetTokenT<CandidateView>               srcUnshiftedObjectsToken_;
-  edm::EDGetTokenT<CandidateView>               srcShiftedObjectsToken_;
+  edm::EDGetTokenT<CandidateView> srcUnshiftedObjectsToken_;
+  edm::EDGetTokenT<CandidateView> srcShiftedObjectsToken_;
 
   double dRmatch_PFCandidate_;
   double dRmatch_Object_;
@@ -54,19 +52,17 @@ class ShiftedPFCandidateProducerForPFMVAMEt : public edm::stream::EDProducer<>
   double dR2match_PFCandidate_;
   double dR2match_Object_;
 
-
-  struct objectEntryType
-  {
+  struct objectEntryType {
     objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4,
-		    const reco::Candidate::LorentzVector& unshiftedObjectP4, double dRmatch)
-      : shiftedObjectP4_(shiftedObjectP4),
-	unshiftedObjectP4_(unshiftedObjectP4),
-	dRmatch_(dRmatch),
-	isValidMatch_(false)
-    {
-      if ( unshiftedObjectP4.energy() > 0. ) {
-	shift_ = (shiftedObjectP4.energy()/unshiftedObjectP4.energy()) - 1.;
-	isValidMatch_ = true;
+                    const reco::Candidate::LorentzVector& unshiftedObjectP4,
+                    double dRmatch)
+        : shiftedObjectP4_(shiftedObjectP4),
+          unshiftedObjectP4_(unshiftedObjectP4),
+          dRmatch_(dRmatch),
+          isValidMatch_(false) {
+      if (unshiftedObjectP4.energy() > 0.) {
+        shift_ = (shiftedObjectP4.energy() / unshiftedObjectP4.energy()) - 1.;
+        isValidMatch_ = true;
       }
     }
     ~objectEntryType() {}
@@ -81,7 +77,3 @@ class ShiftedPFCandidateProducerForPFMVAMEt : public edm::stream::EDProducer<>
 };
 
 #endif
-
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
@@ -5,29 +5,27 @@
 
 #include "DataFormats/Math/interface/deltaR.h"
 
-const double dR2Match = 0.01*0.01;
+const double dR2Match = 0.01 * 0.01;
 
 ShiftedPFCandidateProducerForPFNoPUMEt::ShiftedPFCandidateProducerForPFNoPUMEt(const edm::ParameterSet& cfg)
-  : srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates")))
-  , srcJetsToken_(consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets")))
-{
-
+    : srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates"))),
+      srcJetsToken_(consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets"))) {
   jetCorrUncertaintyTag_ = cfg.getParameter<std::string>("jetCorrUncertaintyTag");
 
   jecValidFileName_ = cfg.exists("jetCorrInputFileName");
-  if ( jecValidFileName_ ) {
+  if (jecValidFileName_) {
     jetCorrInputFileName_ = cfg.getParameter<edm::FileInPath>("jetCorrInputFileName");
-    if ( jetCorrInputFileName_.location() == edm::FileInPath::Unknown) throw cms::Exception("ShiftedJetProducerT")
-      << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
+    if (jetCorrInputFileName_.location() == edm::FileInPath::Unknown)
+      throw cms::Exception("ShiftedJetProducerT")
+          << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
     edm::LogInfo("ShiftedPFCandidateProducerForPFNoPUMEt")
-      << "Reading JEC parameters = " << jetCorrUncertaintyTag_
-      << " from file = " << jetCorrInputFileName_.fullPath() << "." << std::endl;
+        << "Reading JEC parameters = " << jetCorrUncertaintyTag_ << " from file = " << jetCorrInputFileName_.fullPath()
+        << "." << std::endl;
     jetCorrParameters_ = new JetCorrectorParameters(jetCorrInputFileName_.fullPath(), jetCorrUncertaintyTag_);
     jecUncertainty_ = new JetCorrectionUncertainty(*jetCorrParameters_);
   } else {
     edm::LogInfo("ShiftedPFCandidateProducerForPFNoPUMEt")
-      << "Reading JEC parameters = " << jetCorrUncertaintyTag_
-      << " from DB/SQLlite file." << std::endl;
+        << "Reading JEC parameters = " << jetCorrUncertaintyTag_ << " from DB/SQLlite file." << std::endl;
     jetCorrPayloadName_ = cfg.getParameter<std::string>("jetCorrPayloadName");
   }
 
@@ -37,20 +35,17 @@ ShiftedPFCandidateProducerForPFNoPUMEt::ShiftedPFCandidateProducerForPFNoPUMEt(c
 
   unclEnUncertainty_ = cfg.getParameter<double>("unclEnUncertainty");
 
-
   produces<reco::PFCandidateCollection>();
 }
 
-ShiftedPFCandidateProducerForPFNoPUMEt::~ShiftedPFCandidateProducerForPFNoPUMEt()
-{
- if( jecValidFileName_ ) {
-  delete jetCorrParameters_;
-  delete jecUncertainty_;
- }
+ShiftedPFCandidateProducerForPFNoPUMEt::~ShiftedPFCandidateProducerForPFNoPUMEt() {
+  if (jecValidFileName_) {
+    delete jetCorrParameters_;
+    delete jecUncertainty_;
+  }
 }
 
-void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<reco::PFCandidateCollection> originalPFCandidates;
   evt.getByToken(srcPFCandidatesToken_, originalPFCandidates);
 
@@ -58,35 +53,36 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
   evt.getByToken(srcJetsToken_, jets);
 
   std::vector<const reco::PFJet*> selectedJets;
-  for ( reco::PFJetCollection::const_iterator jet = jets->begin();
-	jet != jets->end(); ++jet ) {
-    if ( jet->pt() > minJetPt_ ) selectedJets.push_back(&(*jet));
+  for (reco::PFJetCollection::const_iterator jet = jets->begin(); jet != jets->end(); ++jet) {
+    if (jet->pt() > minJetPt_)
+      selectedJets.push_back(&(*jet));
   }
 
-  if ( !jetCorrPayloadName_.empty() ) {
-      edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
-      es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
-      const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];
-      delete jecUncertainty_;
-      jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
-    }
+  if (!jetCorrPayloadName_.empty()) {
+    edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
+    es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
+    const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];
+    delete jecUncertainty_;
+    jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
+  }
 
   auto shiftedPFCandidates = std::make_unique<reco::PFCandidateCollection>();
 
-  for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
-	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
-
+  for (reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
+       originalPFCandidate != originalPFCandidates->end();
+       ++originalPFCandidate) {
     const reco::PFJet* jet_matched = nullptr;
-    for ( std::vector<const reco::PFJet*>::iterator jet = selectedJets.begin();
-	  jet != selectedJets.end(); ++jet ) {
-      for ( std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = (*jet)->getPFConstituents().begin();
-	    jetConstituent != (*jet)->getPFConstituents().end() && jet_matched==nullptr; ++jetConstituent ) {
-	if ( deltaR2(originalPFCandidate->p4(), (*jetConstituent)->p4()) < dR2Match ) jet_matched = (*jet);
+    for (std::vector<const reco::PFJet*>::iterator jet = selectedJets.begin(); jet != selectedJets.end(); ++jet) {
+      for (std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = (*jet)->getPFConstituents().begin();
+           jetConstituent != (*jet)->getPFConstituents().end() && jet_matched == nullptr;
+           ++jetConstituent) {
+        if (deltaR2(originalPFCandidate->p4(), (*jetConstituent)->p4()) < dR2Match)
+          jet_matched = (*jet);
       }
     }
 
     double shift = 0.;
-    if ( jet_matched!=nullptr ) {
+    if (jet_matched != nullptr) {
       jecUncertainty_->setJetEta(jet_matched->eta());
       jecUncertainty_->setJetPt(jet_matched->pt());
 
@@ -112,6 +108,3 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedPFCandidateProducerForPFNoPUMEt);
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.cc
@@ -63,7 +63,7 @@ void ShiftedPFCandidateProducerForPFNoPUMEt::produce(edm::Event& evt, const edm:
     if ( jet->pt() > minJetPt_ ) selectedJets.push_back(&(*jet));
   }
 
-  if ( jetCorrPayloadName_ != "" ) {
+  if ( !jetCorrPayloadName_.empty() ) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
       es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
       const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFNoPUMEt.h
@@ -39,21 +39,18 @@
 #include <string>
 #include <vector>
 
-class ShiftedPFCandidateProducerForPFNoPUMEt : public edm::EDProducer
-{
- public:
-
+class ShiftedPFCandidateProducerForPFNoPUMEt : public edm::EDProducer {
+public:
   explicit ShiftedPFCandidateProducerForPFNoPUMEt(const edm::ParameterSet&);
   ~ShiftedPFCandidateProducerForPFNoPUMEt() override;
 
- private:
-
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 
   edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidatesToken_;
-  edm::EDGetTokenT<reco::PFJetCollection>       srcJetsToken_;
+  edm::EDGetTokenT<reco::PFJetCollection> srcJetsToken_;
 
   edm::FileInPath jetCorrInputFileName_;
   std::string jetCorrPayloadName_;
@@ -68,11 +65,6 @@ class ShiftedPFCandidateProducerForPFNoPUMEt : public edm::EDProducer
   double shiftBy_;
 
   double unclEnUncertainty_;
-
 };
 
 #endif
-
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
@@ -1,19 +1,16 @@
 #include "PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h"
 
 ShiftedParticleMETcorrInputProducer::ShiftedParticleMETcorrInputProducer(const edm::ParameterSet& cfg)
-  : srcOriginalToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcOriginal")))
-  , srcShiftedToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcShifted")))
-{
+    : srcOriginalToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcOriginal"))),
+      srcShiftedToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcShifted"))) {
   produces<CorrMETData>();
 }
 
-ShiftedParticleMETcorrInputProducer::~ShiftedParticleMETcorrInputProducer()
-{
-// nothing to be done yet...
+ShiftedParticleMETcorrInputProducer::~ShiftedParticleMETcorrInputProducer() {
+  // nothing to be done yet...
 }
 
-void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
-{
+void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {
   edm::Handle<CandidateView> originalParticles;
   evt.getByToken(srcOriginalToken_, originalParticles);
 
@@ -22,17 +19,19 @@ void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt
 
   auto metCorrection = std::make_unique<CorrMETData>();
 
-  for ( CandidateView::const_iterator originalParticle = originalParticles->begin();
-	originalParticle != originalParticles->end(); ++originalParticle ) {
-    metCorrection->mex   += originalParticle->px();
-    metCorrection->mey   += originalParticle->py();
+  for (CandidateView::const_iterator originalParticle = originalParticles->begin();
+       originalParticle != originalParticles->end();
+       ++originalParticle) {
+    metCorrection->mex += originalParticle->px();
+    metCorrection->mey += originalParticle->py();
     metCorrection->sumet -= originalParticle->et();
   }
 
-  for ( CandidateView::const_iterator shiftedParticle = shiftedParticles->begin();
-	shiftedParticle != shiftedParticles->end(); ++shiftedParticle ) {
-    metCorrection->mex   -= shiftedParticle->px();
-    metCorrection->mey   -= shiftedParticle->py();
+  for (CandidateView::const_iterator shiftedParticle = shiftedParticles->begin();
+       shiftedParticle != shiftedParticles->end();
+       ++shiftedParticle) {
+    metCorrection->mex -= shiftedParticle->px();
+    metCorrection->mey -= shiftedParticle->py();
     metCorrection->sumet += shiftedParticle->et();
   }
 
@@ -42,5 +41,3 @@ void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedParticleMETcorrInputProducer);
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h
@@ -24,14 +24,12 @@
 #include <string>
 #include <vector>
 
-class ShiftedParticleMETcorrInputProducer : public edm::global::EDProducer<>
-{
- public:
-
+class ShiftedParticleMETcorrInputProducer : public edm::global::EDProducer<> {
+public:
   explicit ShiftedParticleMETcorrInputProducer(const edm::ParameterSet&);
   ~ShiftedParticleMETcorrInputProducer() override;
 
- private:
+private:
   typedef edm::View<reco::Candidate> CandidateView;
 
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
@@ -41,7 +39,3 @@ class ShiftedParticleMETcorrInputProducer : public edm::global::EDProducer<>
 };
 
 #endif
-
-
-
-

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.cc
@@ -1,18 +1,17 @@
 #include "PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-ShiftedParticleProducer::ShiftedParticleProducer(const edm::ParameterSet& cfg)
-{
-  moduleLabel_=cfg.getParameter<std::string>("@module_label");
+ShiftedParticleProducer::ShiftedParticleProducer(const edm::ParameterSet& cfg) {
+  moduleLabel_ = cfg.getParameter<std::string>("@module_label");
   srcToken_ = consumes<CandidateView>(cfg.getParameter<edm::InputTag>("src"));
   shiftBy_ = cfg.getParameter<double>("shiftBy");
 
-  if ( cfg.exists("binning") ) {
+  if (cfg.exists("binning")) {
     typedef std::vector<edm::ParameterSet> vParameterSet;
     vParameterSet cfgBinning = cfg.getParameter<vParameterSet>("binning");
-    for ( vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin();
-	  cfgBinningEntry != cfgBinning.end(); ++cfgBinningEntry ) {
-      binning_.push_back(new binningEntryType(*cfgBinningEntry,moduleLabel_));
+    for (vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin(); cfgBinningEntry != cfgBinning.end();
+         ++cfgBinningEntry) {
+      binning_.push_back(new binningEntryType(*cfgBinningEntry, moduleLabel_));
     }
   } else {
     std::string uncertainty = cfg.getParameter<std::string>("uncertainty");
@@ -22,53 +21,50 @@ ShiftedParticleProducer::ShiftedParticleProducer(const edm::ParameterSet& cfg)
   produces<reco::CandidateCollection>();
 }
 
-ShiftedParticleProducer::~ShiftedParticleProducer()
-{
-  for(std::vector<binningEntryType*>::const_iterator it = binning_.begin();
-	it != binning_.end(); ++it ) {
+ShiftedParticleProducer::~ShiftedParticleProducer() {
+  for (std::vector<binningEntryType*>::const_iterator it = binning_.begin(); it != binning_.end(); ++it) {
     delete (*it);
   }
 }
 
-void 
-ShiftedParticleProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void ShiftedParticleProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<CandidateView> originalParticles;
   evt.getByToken(srcToken_, originalParticles);
 
   auto shiftedParticles = std::make_unique<reco::CandidateCollection>();
 
-  for(CandidateView::const_iterator originalParticle = originalParticles->begin();
-      originalParticle != originalParticles->end(); ++originalParticle ) {
-
+  for (CandidateView::const_iterator originalParticle = originalParticles->begin();
+       originalParticle != originalParticles->end();
+       ++originalParticle) {
     double uncertainty = getUncShift(originalParticle);
-    double shift = shiftBy_*uncertainty;
+    double shift = shiftBy_ * uncertainty;
 
     reco::Candidate::LorentzVector shiftedParticleP4 = originalParticle->p4();
     //leave 0*nan = 0
-    if (! (edm::isNotFinite(shift) && shiftedParticleP4.mag2()==0)) shiftedParticleP4 *= (1. + shift);
+    if (!(edm::isNotFinite(shift) && shiftedParticleP4.mag2() == 0))
+      shiftedParticleP4 *= (1. + shift);
 
     std::unique_ptr<reco::Candidate> shiftedParticle = std::make_unique<reco::LeafCandidate>(*originalParticle);
     shiftedParticle->setP4(shiftedParticleP4);
-    
-    shiftedParticles->push_back( shiftedParticle.release() );
+
+    shiftedParticles->push_back(shiftedParticle.release());
   }
 
   evt.put(std::move(shiftedParticles));
 }
 
-double 
-ShiftedParticleProducer::getUncShift(const edm::View<reco::Candidate>::const_iterator& originalParticle) {
-  double valx=0;
-  double valy=0;
-  for(std::vector<binningEntryType*>::iterator binningEntry=binning_.begin();
-      binningEntry!=binning_.end(); ++binningEntry ) {
-    if( (!(*binningEntry)->binSelection_) || (*(*binningEntry)->binSelection_)(*originalParticle) ) {
+double ShiftedParticleProducer::getUncShift(const edm::View<reco::Candidate>::const_iterator& originalParticle) {
+  double valx = 0;
+  double valy = 0;
+  for (std::vector<binningEntryType*>::iterator binningEntry = binning_.begin(); binningEntry != binning_.end();
+       ++binningEntry) {
+    if ((!(*binningEntry)->binSelection_) || (*(*binningEntry)->binSelection_)(*originalParticle)) {
+      if ((*binningEntry)->energyDep_)
+        valx = originalParticle->energy();
+      else
+        valx = originalParticle->pt();
 
-      if( (*binningEntry)->energyDep_ ) valx=originalParticle->energy();
-      else valx=originalParticle->pt();
-
-      valy=originalParticle->eta();
+      valy = originalParticle->eta();
       return (*binningEntry)->binUncFormula_->Eval(valx, valy);
     }
   }

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleProducer.h
@@ -29,47 +29,39 @@
 
 #include <TF2.h>
 
-class ShiftedParticleProducer : public edm::stream::EDProducer<>
-{
+class ShiftedParticleProducer : public edm::stream::EDProducer<> {
   typedef edm::View<reco::Candidate> CandidateView;
 
- public:
-
+public:
   explicit ShiftedParticleProducer(const edm::ParameterSet& cfg);
   ~ShiftedParticleProducer() override;
-  
- private:
 
+private:
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
   double getUncShift(const CandidateView::const_iterator& originalParticle);
-
 
   std::string moduleLabel_;
 
   edm::EDGetTokenT<CandidateView> srcToken_;
 
-  struct binningEntryType
-  {
-  binningEntryType(std::string uncertainty, std::string moduleLabel)
-      : binSelection_(nullptr),
-      binUncertainty_(uncertainty),
-      energyDep_(false)
-    {
-      binUncFormula_ = std::make_unique<TF2>(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() );
+  struct binningEntryType {
+    binningEntryType(std::string uncertainty, std::string moduleLabel)
+        : binSelection_(nullptr), binUncertainty_(uncertainty), energyDep_(false) {
+      binUncFormula_ =
+          std::make_unique<TF2>(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str());
     }
-  binningEntryType(const edm::ParameterSet& cfg, std::string moduleLabel)
-  : binSelection_(new StringCutObjectSelector<reco::Candidate>(cfg.getParameter<std::string>("binSelection"))),
-      binUncertainty_(cfg.getParameter<std::string>("binUncertainty")),
-      energyDep_(false)
-    {
-      binUncFormula_ = std::make_unique<TF2>(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str() );
-      if(cfg.exists("energyDependency") ) {energyDep_=cfg.getParameter<bool>("energyDependency");
+    binningEntryType(const edm::ParameterSet& cfg, std::string moduleLabel)
+        : binSelection_(new StringCutObjectSelector<reco::Candidate>(cfg.getParameter<std::string>("binSelection"))),
+          binUncertainty_(cfg.getParameter<std::string>("binUncertainty")),
+          energyDep_(false) {
+      binUncFormula_ =
+          std::make_unique<TF2>(std::string(moduleLabel).append("_uncFormula").c_str(), binUncertainty_.c_str());
+      if (cfg.exists("energyDependency")) {
+        energyDep_ = cfg.getParameter<bool>("energyDependency");
       }
     }
-    ~binningEntryType()
-    {
-    }
+    ~binningEntryType() {}
     std::unique_ptr<StringCutObjectSelector<reco::Candidate> > binSelection_;
     //double binUncertainty_;
     std::string binUncertainty_;
@@ -78,7 +70,7 @@ class ShiftedParticleProducer : public edm::stream::EDProducer<>
   };
   std::vector<binningEntryType*> binning_;
 
-  double shiftBy_; // set to +1.0/-1.0 for up/down variation of energy scale
+  double shiftBy_;  // set to +1.0/-1.0 for up/down variation of energy scale
 };
 
 #endif

--- a/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/SmearedJetProducer.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 typedef SmearedJetProducerT<reco::CaloJet> SmearedCaloJetProducer;
-typedef SmearedJetProducerT<reco::PFJet>   SmearedPFJetProducer;
+typedef SmearedJetProducerT<reco::PFJet> SmearedPFJetProducer;
 typedef SmearedJetProducerT<pat::Jet> SmearedPATJetProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatUtils/plugins/modules.cc
+++ b/PhysicsTools/PatUtils/plugins/modules.cc
@@ -5,14 +5,14 @@
 
 #include "PhysicsTools/UtilAlgos/interface/CachingVariable.h"
 
-namespace configurableAnalysis{
-  constexpr char Jet[]="pat::Jet";
-  constexpr char Muon[]="pat::Muon";
-  constexpr char MET[]="pat::MET";
-  constexpr char Electron[]="pat::Electron";
-  constexpr char Tau[]="pat::Tau";
-  constexpr char Photon[]="pat::Photon";
-}
+namespace configurableAnalysis {
+  constexpr char Jet[] = "pat::Jet";
+  constexpr char Muon[] = "pat::Muon";
+  constexpr char MET[] = "pat::MET";
+  constexpr char Electron[] = "pat::Electron";
+  constexpr char Tau[] = "pat::Tau";
+  constexpr char Photon[] = "pat::Photon";
+}  // namespace configurableAnalysis
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
@@ -21,12 +21,12 @@ namespace configurableAnalysis{
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
-typedef ExpressionVariable<pat::Jet,configurableAnalysis::Jet> patJetExpressionVariable;
-typedef ExpressionVariable<pat::MET,configurableAnalysis::MET> patMETExpressionVariable;
-typedef ExpressionVariable<pat::Muon,configurableAnalysis::Muon> patMuonExpressionVariable;
-typedef ExpressionVariable<pat::Electron,configurableAnalysis::Electron> patElectronExpressionVariable;
-typedef ExpressionVariable<pat::Photon,configurableAnalysis::Photon> patPhotonExpressionVariable;
-typedef ExpressionVariable<pat::Tau,configurableAnalysis::Tau> patTauExpressionVariable;
+typedef ExpressionVariable<pat::Jet, configurableAnalysis::Jet> patJetExpressionVariable;
+typedef ExpressionVariable<pat::MET, configurableAnalysis::MET> patMETExpressionVariable;
+typedef ExpressionVariable<pat::Muon, configurableAnalysis::Muon> patMuonExpressionVariable;
+typedef ExpressionVariable<pat::Electron, configurableAnalysis::Electron> patElectronExpressionVariable;
+typedef ExpressionVariable<pat::Photon, configurableAnalysis::Photon> patPhotonExpressionVariable;
+typedef ExpressionVariable<pat::Tau, configurableAnalysis::Tau> patTauExpressionVariable;
 
 DEFINE_EDM_PLUGIN(CachingVariableFactory, patJetExpressionVariable, "patJetExpressionVariable");
 DEFINE_EDM_PLUGIN(CachingVariableFactory, patMETExpressionVariable, "patMETExpressionVariable");
@@ -36,7 +36,6 @@ DEFINE_EDM_PLUGIN(CachingVariableFactory, patPhotonExpressionVariable, "patPhoto
 DEFINE_EDM_PLUGIN(CachingVariableFactory, patTauExpressionVariable, "patTauExpressionVariable");
 
 #include "CommonTools/UtilAlgos/interface/StringCutEventSelector.h"
-
 
 //single cut object selector
 typedef StringCutEventSelector<pat::Jet> patJetEventSelector;
@@ -55,16 +54,16 @@ typedef StringCutsEventSelector<pat::Photon> patPhotonSEventSelector;
 typedef StringCutsEventSelector<pat::Tau> patTauSEventSelector;
 
 //vetoes
-typedef StringCutsEventSelector<pat::Jet,false> patJetSEventVetoSelector;
-typedef StringCutsEventSelector<pat::Muon,false> patMuonSEventVetoSelector;
-typedef StringCutsEventSelector<pat::MET,false> patMETSEventVetoSelector;
-typedef StringCutsEventSelector<pat::Electron,false> patElectronSEventVetoSelector;
-typedef StringCutsEventSelector<pat::Photon,false> patPhotonSEventVetoSelector;
-typedef StringCutsEventSelector<pat::Tau,false> patTauSEventVetoSelector;
+typedef StringCutsEventSelector<pat::Jet, false> patJetSEventVetoSelector;
+typedef StringCutsEventSelector<pat::Muon, false> patMuonSEventVetoSelector;
+typedef StringCutsEventSelector<pat::MET, false> patMETSEventVetoSelector;
+typedef StringCutsEventSelector<pat::Electron, false> patElectronSEventVetoSelector;
+typedef StringCutsEventSelector<pat::Photon, false> patPhotonSEventVetoSelector;
+typedef StringCutsEventSelector<pat::Tau, false> patTauSEventVetoSelector;
 //any selector
-typedef StringCutEventSelector<pat::Jet,true> patAnyJetEventSelector;
-typedef StringCutEventSelector<pat::Muon,true> patAnyMuonEventSelector;
-typedef StringCutEventSelector<pat::Electron,true> patAnyElectronEventSelector;
+typedef StringCutEventSelector<pat::Jet, true> patAnyJetEventSelector;
+typedef StringCutEventSelector<pat::Muon, true> patAnyMuonEventSelector;
+typedef StringCutEventSelector<pat::Electron, true> patAnyElectronEventSelector;
 
 DEFINE_EDM_PLUGIN(EventSelectorFactoryFromHelper, patJetEventSelector, "patJetEventSelector");
 DEFINE_EDM_PLUGIN(EventSelectorFactoryFromHelper, patAnyJetEventSelector, "patAnyJetEventSelector");
@@ -91,4 +90,3 @@ DEFINE_EDM_PLUGIN(EventSelectorFactoryFromHelper, patTauSEventVetoSelector, "pat
 #include "PhysicsTools/PatUtils/interface/RazorComputer.h"
 DEFINE_EDM_PLUGIN(CachingVariableFactory, RazorBox, "RazorBox");
 DEFINE_EDM_PLUGIN(VariableComputerFactory, RazorComputer, "RazorComputer");
-

--- a/PhysicsTools/PatUtils/src/CaloIsolationEnergy.cc
+++ b/PhysicsTools/PatUtils/src/CaloIsolationEnergy.cc
@@ -14,25 +14,29 @@
 using namespace pat;
 
 /// constructor
-CaloIsolationEnergy::CaloIsolationEnergy() {
-}
+CaloIsolationEnergy::CaloIsolationEnergy() {}
 
 /// destructor
-CaloIsolationEnergy::~CaloIsolationEnergy() {
-}
+CaloIsolationEnergy::~CaloIsolationEnergy() {}
 
 /// calculate the CalIsoE from the lepton object
-float CaloIsolationEnergy::calculate(const Electron & theElectron, const std::vector<CaloTower> & theTowers, float isoConeElectron) const {
+float CaloIsolationEnergy::calculate(const Electron& theElectron,
+                                     const std::vector<CaloTower>& theTowers,
+                                     float isoConeElectron) const {
   float isoE = this->calculate(*theElectron.gsfTrack(), theElectron.energy(), theTowers, isoConeElectron);
   return isoE - theElectron.caloEnergy();
 }
-float CaloIsolationEnergy::calculate(const Muon & theMuon, const std::vector<CaloTower> & theTowers, float isoConeMuon) const {
+float CaloIsolationEnergy::calculate(const Muon& theMuon,
+                                     const std::vector<CaloTower>& theTowers,
+                                     float isoConeMuon) const {
   return this->calculate(*theMuon.track(), theMuon.energy(), theTowers, isoConeMuon);
 }
 
-
 /// calculate the CalIsoE from the lepton's track
-float CaloIsolationEnergy::calculate(const reco::Track & theTrack, const float leptonEnergy, const std::vector<CaloTower> & theTowers, float isoCone) const {
+float CaloIsolationEnergy::calculate(const reco::Track& theTrack,
+                                     const float leptonEnergy,
+                                     const std::vector<CaloTower>& theTowers,
+                                     float isoCone) const {
   float isoELepton = 0;
   // calculate iso energy
   //const CaloTower * closestTower = 0;
@@ -40,10 +44,12 @@ float CaloIsolationEnergy::calculate(const reco::Track & theTrack, const float l
   for (std::vector<CaloTower>::const_iterator itTower = theTowers.begin(); itTower != theTowers.end(); itTower++) {
     // calculate dPhi with correct sign
     float dPhi = theTrack.phi() - itTower->phi();
-    if (dPhi > M_PI)  dPhi = -2*M_PI + dPhi;
-    if (dPhi < -M_PI) dPhi =  2*M_PI + dPhi;
+    if (dPhi > M_PI)
+      dPhi = -2 * M_PI + dPhi;
+    if (dPhi < -M_PI)
+      dPhi = 2 * M_PI + dPhi;
     // calculate dR
-    float dR = sqrt(std::pow(theTrack.eta()-itTower->eta(), 2) + std::pow(dPhi, 2));
+    float dR = sqrt(std::pow(theTrack.eta() - itTower->eta(), 2) + std::pow(dPhi, 2));
     // calculate energy in cone around direction at vertex of the track
     if (dR < isoCone) {
       isoELepton += itTower->energy();
@@ -54,7 +60,7 @@ float CaloIsolationEnergy::calculate(const reco::Track & theTrack, const float l
     }
   }
   // subtract track deposits from total energy in cone
-//  if (closestTower) isoELepton -= closestTower->energy();
+  //  if (closestTower) isoELepton -= closestTower->energy();
   // return the iso energy
   return isoELepton;
 }

--- a/PhysicsTools/PatUtils/src/CaloJetSelector.cc
+++ b/PhysicsTools/PatUtils/src/CaloJetSelector.cc
@@ -1,89 +1,91 @@
 
 #include "PhysicsTools/PatUtils/interface/CaloJetSelector.h"
 #include "DataFormats/Math/interface/deltaR.h"
- 
+
 using pat::CaloJetSelector;
 
 //______________________________________________________________________________
-const pat::ParticleStatus
-CaloJetSelector::filter( //const unsigned int&        index, 
-                         // const edm::View<reco::CaloJet>& Jets
-			  const reco::CaloJet& Jet
-                          ) const
-{
+const pat::ParticleStatus CaloJetSelector::filter(  //const unsigned int&        index,
+                                                    // const edm::View<reco::CaloJet>& Jets
+    const reco::CaloJet& Jet) const {
   ParticleStatus result = GOOD;
 
   ///Retrieve information
   ///Pt Jet
-  if (Jet.p4().Pt()<config_.Ptmin) result = BAD;
-  
+  if (Jet.p4().Pt() < config_.Ptmin)
+    result = BAD;
+
   ///eta region
   double eta = fabs(Jet.p4().Eta());
-  if (eta>config_.Etamax) result = BAD;
+  if (eta > config_.Etamax)
+    result = BAD;
 
   ///electromagnetic fraction
-  double EMF = Jet.emEnergyFraction();              
-  if (EMF<config_.EMFmin ||
-      EMF>config_.EMFmax    ) result = BAD;
+  double EMF = Jet.emEnergyFraction();
+  if (EMF < config_.EMFmin || EMF > config_.EMFmax)
+    result = BAD;
 
-  ///(EMCalEnergyFraction + HadCalEnergyFraction) / (EMCalEnergyFraction - HadCalEnergyFraction) 
-  double HadF = Jet.emEnergyFraction();              
+  ///(EMCalEnergyFraction + HadCalEnergyFraction) / (EMCalEnergyFraction - HadCalEnergyFraction)
+  double HadF = Jet.emEnergyFraction();
   double EMvsHadF = 0.;
-  if (EMF-HadF!=0.) EMvsHadF = (EMF+HadF)/(EMF-HadF);
-  if (EMvsHadF<config_.EMvsHadFmin ||
-      EMvsHadF>config_.EMvsHadFmax    ) result = BAD;
+  if (EMF - HadF != 0.)
+    EMvsHadF = (EMF + HadF) / (EMF - HadF);
+  if (EMvsHadF < config_.EMvsHadFmin || EMvsHadF > config_.EMvsHadFmax)
+    result = BAD;
 
   //ratio Energy over Momentum (both from calorimeter)
   //Useful? Both come from a lorentz-vector
   //double EoverP = 0.;
   //if (Jet.p4().P()!=0.) EoverP = Jet.energy() / Jet.p4().P();
   //if (EoverP > config_.EoverPmax) result = BAD;
-  
+
   ///n90: number of towers containing 90% of the jet's energy
   double n90 = Jet.n90();
-  if (n90<config_.N90min ||
-      n90>config_.N90max    ) result = BAD;
+  if (n90 < config_.N90min || n90 > config_.N90max)
+    result = BAD;
 
   ///Tower Number
   std::vector<CaloTowerPtr> jetTowers = Jet.getCaloConstituents();
-  if (jetTowers.size()<config_.NCaloTowersmin ||
-      jetTowers.size()>config_.NCaloTowersmax  ) result = BAD;
+  if (jetTowers.size() < config_.NCaloTowersmin || jetTowers.size() > config_.NCaloTowersmax)
+    result = BAD;
 
   //calculate tower related variables:
-  double MaxEnergyTower = 0., SumTowPt=0., SumTowPtR=0.;
-  for(std::vector<CaloTowerPtr>::const_iterator tow = jetTowers.begin(),
-      towend = jetTowers.end(); tow != towend; ++tow){
-
-    SumTowPt  += (*tow)->et();
-    SumTowPtR += (*tow)->et()*deltaR( Jet.p4().Eta(), Jet.p4().Phi(),
-                                      (*tow)->eta(),  (*tow)->phi()     );
-    if ( (*tow)->et() > MaxEnergyTower )
-       MaxEnergyTower = (*tow)->et();
+  double MaxEnergyTower = 0., SumTowPt = 0., SumTowPtR = 0.;
+  for (std::vector<CaloTowerPtr>::const_iterator tow = jetTowers.begin(), towend = jetTowers.end(); tow != towend;
+       ++tow) {
+    SumTowPt += (*tow)->et();
+    SumTowPtR += (*tow)->et() * deltaR(Jet.p4().Eta(), Jet.p4().Phi(), (*tow)->eta(), (*tow)->phi());
+    if ((*tow)->et() > MaxEnergyTower)
+      MaxEnergyTower = (*tow)->et();
   }
 
   ///Highest Et Tower / Et Jet
   double EtTowerMaxOverEtJet = 0.;
-  if (Jet.p4().Et()!=0.) EtTowerMaxOverEtJet = MaxEnergyTower /Jet.p4().Et();
-  if (EtTowerMaxOverEtJet < config_.HighestTowerOverJetmin ||
-      EtTowerMaxOverEtJet > config_.HighestTowerOverJetmax  ) result = BAD;
+  if (Jet.p4().Et() != 0.)
+    EtTowerMaxOverEtJet = MaxEnergyTower / Jet.p4().Et();
+  if (EtTowerMaxOverEtJet < config_.HighestTowerOverJetmin || EtTowerMaxOverEtJet > config_.HighestTowerOverJetmax)
+    result = BAD;
 
   ///Sum(E Twr * DeltaR(Twr-Jet)) / Sum(E Twr)
   double RWidth = 0.;
-  if (SumTowPt!=0.) RWidth = SumTowPtR /SumTowPt;
-  if (RWidth < config_.RWidthmin ||
-      RWidth > config_.RWidthmax  ) result = BAD;
-  
-  ///Pt Jet / Towers Area 		  
+  if (SumTowPt != 0.)
+    RWidth = SumTowPtR / SumTowPt;
+  if (RWidth < config_.RWidthmin || RWidth > config_.RWidthmax)
+    result = BAD;
+
+  ///Pt Jet / Towers Area
   double PtJetoverArea = 0.;
-  if (Jet.towersArea() !=0.) PtJetoverArea = Jet.p4().Pt() / Jet.towersArea();
-  if (PtJetoverArea < config_.PtJetOverArea_min ||
-      PtJetoverArea > config_.PtJetOverArea_max  ) result = BAD;
+  if (Jet.towersArea() != 0.)
+    PtJetoverArea = Jet.p4().Pt() / Jet.towersArea();
+  if (PtJetoverArea < config_.PtJetOverArea_min || PtJetoverArea > config_.PtJetOverArea_max)
+    result = BAD;
 
   ///Highest Et Tower / Towers Area
   double PtToweroverArea = 0.;
-  if (Jet.towersArea() !=0.) PtToweroverArea = MaxEnergyTower / Jet.towersArea();
-  if (PtToweroverArea < config_.PtTowerOverArea_min ||
-      PtToweroverArea > config_.PtTowerOverArea_max  ) result = BAD;
+  if (Jet.towersArea() != 0.)
+    PtToweroverArea = MaxEnergyTower / Jet.towersArea();
+  if (PtToweroverArea < config_.PtTowerOverArea_min || PtToweroverArea > config_.PtTowerOverArea_max)
+    result = BAD;
 
   return result;
 }

--- a/PhysicsTools/PatUtils/src/DuplicatedElectronRemover.cc
+++ b/PhysicsTools/PatUtils/src/DuplicatedElectronRemover.cc
@@ -2,19 +2,15 @@
 
 #include <algorithm>
 
-
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedElectronRemover::duplicatesToRemove(const std::vector<reco::GsfElectron> &electrons) const {
-    return duplicatesToRemove< std::vector<reco::GsfElectron> >(electrons);
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedElectronRemover::duplicatesToRemove(
+    const std::vector<reco::GsfElectron> &electrons) const {
+  return duplicatesToRemove<std::vector<reco::GsfElectron> >(electrons);
 }
 
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedElectronRemover::duplicatesToRemove(const edm::View<reco::GsfElectron>   &electrons) const {
-    return duplicatesToRemove< edm::View<reco::GsfElectron> >(electrons);
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedElectronRemover::duplicatesToRemove(
+    const edm::View<reco::GsfElectron> &electrons) const {
+  return duplicatesToRemove<edm::View<reco::GsfElectron> >(electrons);
 }
-
-
-
 
 /*
 std::unique_ptr< std::vector<size_t> >

--- a/PhysicsTools/PatUtils/src/DuplicatedPhotonRemover.cc
+++ b/PhysicsTools/PatUtils/src/DuplicatedPhotonRemover.cc
@@ -2,74 +2,65 @@
 
 #include <algorithm>
 
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedPhotonRemover::duplicatesBySeed(const reco::PhotonCollection &photons) const {
-    return duplicatesBySeed<reco::PhotonCollection>(photons);
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedPhotonRemover::duplicatesBySeed(
+    const reco::PhotonCollection &photons) const {
+  return duplicatesBySeed<reco::PhotonCollection>(photons);
 }
 
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedPhotonRemover::duplicatesBySeed(const edm::View<reco::Photon> &photons) const {
-    return duplicatesBySeed< edm::View<reco::Photon> >(photons);
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedPhotonRemover::duplicatesBySeed(
+    const edm::View<reco::Photon> &photons) const {
+  return duplicatesBySeed<edm::View<reco::Photon> >(photons);
 }
 
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const reco::PhotonCollection &photons) const {
-    return duplicatesBySuperCluster<reco::PhotonCollection>(photons);
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(
+    const reco::PhotonCollection &photons) const {
+  return duplicatesBySuperCluster<reco::PhotonCollection>(photons);
 }
 
-std::unique_ptr< std::vector<size_t> > 
-pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(const edm::View<reco::Photon> &photons) const {
-    return duplicatesBySuperCluster< edm::View<reco::Photon> >(photons);
+std::unique_ptr<std::vector<size_t> > pat::DuplicatedPhotonRemover::duplicatesBySuperCluster(
+    const edm::View<reco::Photon> &photons) const {
+  return duplicatesBySuperCluster<edm::View<reco::Photon> >(photons);
 }
 
 // ================ ELECTRONS  =============================
 // ---------------- against EleCollection  -----------------------------
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySeed(const reco::PhotonCollection &photons, 
-        const reco::GsfElectronCollection& electrons) const {
-    return electronsBySeed<reco::PhotonCollection, reco::GsfElectronCollection>(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySeed(
+    const reco::PhotonCollection &photons, const reco::GsfElectronCollection &electrons) const {
+  return electronsBySeed<reco::PhotonCollection, reco::GsfElectronCollection>(photons, electrons);
 }
 
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySeed(const edm::View<reco::Photon> &photons, 
-        const reco::GsfElectronCollection& electrons) const {
-    return electronsBySeed<edm::View<reco::Photon>, reco::GsfElectronCollection>(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySeed(
+    const edm::View<reco::Photon> &photons, const reco::GsfElectronCollection &electrons) const {
+  return electronsBySeed<edm::View<reco::Photon>, reco::GsfElectronCollection>(photons, electrons);
 }
 
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
-        const reco::GsfElectronCollection& electrons) const {
-    return electronsBySuperCluster<edm::View<reco::Photon>, reco::GsfElectronCollection>(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySuperCluster(
+    const edm::View<reco::Photon> &photons, const reco::GsfElectronCollection &electrons) const {
+  return electronsBySuperCluster<edm::View<reco::Photon>, reco::GsfElectronCollection>(photons, electrons);
 }
 
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySuperCluster(const reco::PhotonCollection &photons, 
-        const reco::GsfElectronCollection&  electrons) const {
-    return electronsBySuperCluster<reco::PhotonCollection, reco::GsfElectronCollection>(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySuperCluster(
+    const reco::PhotonCollection &photons, const reco::GsfElectronCollection &electrons) const {
+  return electronsBySuperCluster<reco::PhotonCollection, reco::GsfElectronCollection>(photons, electrons);
 }
 
 // ---------------- against EleView  -----------------------------
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySeed(const reco::PhotonCollection &photons, 
-        const edm::View<reco::GsfElectron>&  electrons) const {
-    return electronsBySeed<reco::PhotonCollection, edm::View<reco::GsfElectron> >(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySeed(
+    const reco::PhotonCollection &photons, const edm::View<reco::GsfElectron> &electrons) const {
+  return electronsBySeed<reco::PhotonCollection, edm::View<reco::GsfElectron> >(photons, electrons);
 }
 
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySeed(const edm::View<reco::Photon> &photons, 
-        const edm::View<reco::GsfElectron>&  electrons) const {
-    return electronsBySeed<edm::View<reco::Photon>, edm::View<reco::GsfElectron> >(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySeed(
+    const edm::View<reco::Photon> &photons, const edm::View<reco::GsfElectron> &electrons) const {
+  return electronsBySeed<edm::View<reco::Photon>, edm::View<reco::GsfElectron> >(photons, electrons);
 }
 
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySuperCluster(const edm::View<reco::Photon> &photons, 
-        const edm::View<reco::GsfElectron>&  electrons) const {
-    return electronsBySuperCluster<edm::View<reco::Photon>, edm::View<reco::GsfElectron> >(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySuperCluster(
+    const edm::View<reco::Photon> &photons, const edm::View<reco::GsfElectron> &electrons) const {
+  return electronsBySuperCluster<edm::View<reco::Photon>, edm::View<reco::GsfElectron> >(photons, electrons);
 }
 
-std::unique_ptr< pat::OverlapList >
-pat::DuplicatedPhotonRemover::electronsBySuperCluster(const reco::PhotonCollection &photons, 
-        const edm::View<reco::GsfElectron>&  electrons) const {
-    return electronsBySuperCluster<reco::PhotonCollection, edm::View<reco::GsfElectron> >(photons, electrons);
+std::unique_ptr<pat::OverlapList> pat::DuplicatedPhotonRemover::electronsBySuperCluster(
+    const reco::PhotonCollection &photons, const edm::View<reco::GsfElectron> &electrons) const {
+  return electronsBySuperCluster<reco::PhotonCollection, edm::View<reco::GsfElectron> >(photons, electrons);
 }
-

--- a/PhysicsTools/PatUtils/src/EventHypothesisTools.cc
+++ b/PhysicsTools/PatUtils/src/EventHypothesisTools.cc
@@ -2,49 +2,39 @@
 
 using namespace pat::eventhypothesis;
 
-AndFilter::AndFilter(ParticleFilter *f1, ParticleFilter *f2) :
-    filters_(2) 
-{
-    filters_.push_back(f1); filters_.push_back(f2);
+AndFilter::AndFilter(ParticleFilter *f1, ParticleFilter *f2) : filters_(2) {
+  filters_.push_back(f1);
+  filters_.push_back(f2);
 }
 
 bool AndFilter::operator()(const CandRefType &cand, const std::string &role) const {
-    for (boost::ptr_vector<ParticleFilter>::const_iterator it = filters_.begin(); it != filters_.end(); ++it) {
-        if (! (*it)(cand, role) ) return false;
-    }
-    return true;
+  for (boost::ptr_vector<ParticleFilter>::const_iterator it = filters_.begin(); it != filters_.end(); ++it) {
+    if (!(*it)(cand, role))
+      return false;
+  }
+  return true;
 }
 
-OrFilter::OrFilter(ParticleFilter *f1, ParticleFilter *f2) :
-    filters_(2) 
-{
-    filters_.push_back(f1); filters_.push_back(f2);
+OrFilter::OrFilter(ParticleFilter *f1, ParticleFilter *f2) : filters_(2) {
+  filters_.push_back(f1);
+  filters_.push_back(f2);
 }
 
 bool OrFilter::operator()(const CandRefType &cand, const std::string &role) const {
-    for (boost::ptr_vector<ParticleFilter>::const_iterator it = filters_.begin(); it != filters_.end(); ++it) {
-        if ( (*it)(cand, role) ) return true;
-    }
-    return false;
+  for (boost::ptr_vector<ParticleFilter>::const_iterator it = filters_.begin(); it != filters_.end(); ++it) {
+    if ((*it)(cand, role))
+      return true;
+  }
+  return false;
 }
 
-ByPdgId::ByPdgId(int32_t pdgCode, bool alsoAntiparticle) :
-    pdgCode_(alsoAntiparticle ? std::abs(pdgCode) : pdgCode),
-    antiparticle_(alsoAntiparticle)
-{
-}
+ByPdgId::ByPdgId(int32_t pdgCode, bool alsoAntiparticle)
+    : pdgCode_(alsoAntiparticle ? std::abs(pdgCode) : pdgCode), antiparticle_(alsoAntiparticle) {}
 
 bool ByPdgId::operator()(const CandRefType &cand, const std::string &role) const {
-    return antiparticle_ ? 
-              (std::abs(cand->pdgId()) == pdgCode_) :
-              (cand->pdgId() == pdgCode_);
+  return antiparticle_ ? (std::abs(cand->pdgId()) == pdgCode_) : (cand->pdgId() == pdgCode_);
 }
 
-ByString::ByString(const std::string &cut) : 
-    sel_(cut)
-{
-}
+ByString::ByString(const std::string &cut) : sel_(cut) {}
 
-bool ByString::operator()(const CandRefType &cand, const std::string &role) const {
-    return sel_(*cand);
-}
+bool ByString::operator()(const CandRefType &cand, const std::string &role) const { return sel_(*cand); }

--- a/PhysicsTools/PatUtils/src/LeptonJetIsolationAngle.cc
+++ b/PhysicsTools/PatUtils/src/LeptonJetIsolationAngle.cc
@@ -6,36 +6,34 @@
 
 #include <vector>
 
-
 using namespace pat;
 
-
 // constructor
-LeptonJetIsolationAngle::LeptonJetIsolationAngle(edm::ConsumesCollector && iC)
-: jetToken_( iC.consumes< reco::CaloJetCollection >( edm::InputTag( "iterativeCone5CaloJets" ) ) )
-, electronsToken_( iC.consumes< std::vector<reco::GsfElectron > >( edm::InputTag( "pixelMatchGsfElectrons" ) ) )
-{
-}
-
+LeptonJetIsolationAngle::LeptonJetIsolationAngle(edm::ConsumesCollector&& iC)
+    : jetToken_(iC.consumes<reco::CaloJetCollection>(edm::InputTag("iterativeCone5CaloJets"))),
+      electronsToken_(iC.consumes<std::vector<reco::GsfElectron> >(edm::InputTag("pixelMatchGsfElectrons"))) {}
 
 // destructor
-LeptonJetIsolationAngle::~LeptonJetIsolationAngle() {
-}
-
+LeptonJetIsolationAngle::~LeptonJetIsolationAngle() {}
 
 // calculate the JetIsoA for the lepton object
-float LeptonJetIsolationAngle::calculate(const Electron & theElectron, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent) {
+float LeptonJetIsolationAngle::calculate(const Electron& theElectron,
+                                         const edm::Handle<edm::View<reco::Track> >& trackHandle,
+                                         const edm::Event& iEvent) {
   CLHEP::HepLorentzVector theElectronHLV(theElectron.px(), theElectron.py(), theElectron.pz(), theElectron.energy());
   return this->calculate(theElectronHLV, trackHandle, iEvent);
 }
-float LeptonJetIsolationAngle::calculate(const Muon & theMuon, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent) {
+float LeptonJetIsolationAngle::calculate(const Muon& theMuon,
+                                         const edm::Handle<edm::View<reco::Track> >& trackHandle,
+                                         const edm::Event& iEvent) {
   CLHEP::HepLorentzVector theMuonHLV(theMuon.px(), theMuon.py(), theMuon.pz(), theMuon.energy());
   return this->calculate(theMuonHLV, trackHandle, iEvent);
 }
 
-
 // calculate the JetIsoA for the lepton's HLV
-float LeptonJetIsolationAngle::calculate(const CLHEP::HepLorentzVector & aLepton, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent) {
+float LeptonJetIsolationAngle::calculate(const CLHEP::HepLorentzVector& aLepton,
+                                         const edm::Handle<edm::View<reco::Track> >& trackHandle,
+                                         const edm::Event& iEvent) {
   // FIXME: this is an ugly temporary workaround, JetMET+egamma should come up with a better tool
   // retrieve the jets
   edm::Handle<reco::CaloJetCollection> jetHandle;
@@ -47,10 +45,9 @@ float LeptonJetIsolationAngle::calculate(const CLHEP::HepLorentzVector & aLepton
   std::vector<reco::GsfElectron> electrons = *electronsHandle;
   // determine the set of isolated electrons
   std::vector<Electron> isoElectrons;
-  for (size_t ie=0; ie<electrons.size(); ie++) {
+  for (size_t ie = 0; ie < electrons.size(); ie++) {
     Electron anElectron(electrons[ie]);
-    if (anElectron.pt() > 10 &&
-        trkIsolator_.calculate(anElectron, *trackHandle) < 3.0) {
+    if (anElectron.pt() > 10 && trkIsolator_.calculate(anElectron, *trackHandle) < 3.0) {
       isoElectrons.push_back(electrons[ie]);
     }
   }
@@ -60,25 +57,27 @@ float LeptonJetIsolationAngle::calculate(const CLHEP::HepLorentzVector & aLepton
     float mindr2 = 9999.;
     for (size_t ie = 0; ie < isoElectrons.size(); ie++) {
       float dr2 = ::deltaR2(*itJet, isoElectrons[ie]);
-      if (dr2 < mindr2) mindr2 = dr2;
+      if (dr2 < mindr2)
+        mindr2 = dr2;
     }
     float mindr = std::sqrt(mindr2);
     // yes, all cuts hardcoded buts, but it's a second-order effect
-    if (itJet->et() > 15 && mindr > 0.3) theJets.push_back(reco::CaloJet(*itJet));
+    if (itJet->et() > 15 && mindr > 0.3)
+      theJets.push_back(reco::CaloJet(*itJet));
   }
   // calculate finally the isolation angle
-  float isoAngle = 1000; // default to some craze impossible number to inhibit compiler warnings
+  float isoAngle = 1000;  // default to some craze impossible number to inhibit compiler warnings
   for (std::vector<reco::CaloJet>::const_iterator itJet = theJets.begin(); itJet != theJets.end(); itJet++) {
     float curDR = this->spaceAngle(aLepton, *itJet);
-    if (curDR < isoAngle) isoAngle = curDR;
+    if (curDR < isoAngle)
+      isoAngle = curDR;
   }
   return isoAngle;
 }
 
-
 // calculate the angle between two vectors in 3d eucledian space
-float LeptonJetIsolationAngle::spaceAngle(const CLHEP::HepLorentzVector & aLepton, const reco::CaloJet & aJet) {
-  return acos(sin(aJet.theta()) * cos(aJet.phi()) * sin(aLepton.theta()) * cos(aLepton.phi())
-            + sin(aJet.theta()) * sin(aJet.phi()) * sin(aLepton.theta()) * sin(aLepton.phi())
-            + cos(aJet.theta()) * cos(aLepton.theta()));
+float LeptonJetIsolationAngle::spaceAngle(const CLHEP::HepLorentzVector& aLepton, const reco::CaloJet& aJet) {
+  return acos(sin(aJet.theta()) * cos(aJet.phi()) * sin(aLepton.theta()) * cos(aLepton.phi()) +
+              sin(aJet.theta()) * sin(aJet.phi()) * sin(aLepton.theta()) * sin(aLepton.phi()) +
+              cos(aJet.theta()) * cos(aLepton.theta()));
 }

--- a/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
+++ b/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
@@ -16,9 +16,8 @@
 using namespace pat;
 
 // constructor
-LeptonVertexSignificance::LeptonVertexSignificance(const edm::EventSetup & iSetup, edm::ConsumesCollector && iC)
-: vertexToken_( iC.consumes< reco::VertexCollection >( edm::InputTag( "offlinePrimaryVerticesFromCTFTracks" ) ) )
-{
+LeptonVertexSignificance::LeptonVertexSignificance(const edm::EventSetup& iSetup, edm::ConsumesCollector&& iC)
+    : vertexToken_(iC.consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVerticesFromCTFTracks"))) {
   // instantiate the transient-track builder
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
@@ -26,32 +25,30 @@ LeptonVertexSignificance::LeptonVertexSignificance(const edm::EventSetup & iSetu
 }
 
 // destructor
-LeptonVertexSignificance::~LeptonVertexSignificance() {
-  delete theTrackBuilder_;
-}
+LeptonVertexSignificance::~LeptonVertexSignificance() { delete theTrackBuilder_; }
 
 // calculate the TrackIsoPt for the lepton object
-float LeptonVertexSignificance::calculate(const Electron & theElectron, const edm::Event & iEvent) {
+float LeptonVertexSignificance::calculate(const Electron& theElectron, const edm::Event& iEvent) {
   return this->calculate(*theElectron.gsfTrack(), iEvent);
 }
 
-float LeptonVertexSignificance::calculate(const Muon & theMuon, const edm::Event & iEvent) {
+float LeptonVertexSignificance::calculate(const Muon& theMuon, const edm::Event& iEvent) {
   return this->calculate(*theMuon.track(), iEvent);
 }
 
 // calculate the TrackIsoPt for the lepton's track
-float LeptonVertexSignificance::calculate(const reco::Track & theTrack, const edm::Event & iEvent) {
+float LeptonVertexSignificance::calculate(const reco::Track& theTrack, const edm::Event& iEvent) {
   // FIXME: think more about how to handle events without vertices
   // lepton LR calculation should have nothing to do with event selection
   edm::Handle<reco::VertexCollection> vertexHandle;
   iEvent.getByToken(vertexToken_, vertexHandle);
-  if (vertexHandle.product()->empty()) return 0;
+  if (vertexHandle.product()->empty())
+    return 0;
   reco::Vertex theVertex = vertexHandle.product()->front();
   // calculate the track-vertex association significance
   reco::TransientTrack theTrTrack = theTrackBuilder_->build(&theTrack);
   GlobalPoint theVertexPoint(theVertex.position().x(), theVertex.position().y(), theVertex.position().z());
   FreeTrajectoryState theLeptonNearVertex = theTrTrack.trajectoryStateClosestToPoint(theVertexPoint).theState();
-  return fabs(theVertex.position().z() - theLeptonNearVertex.position().z())
-    / sqrt(std::pow(theVertex.zError(), 2) + theLeptonNearVertex.cartesianError().position().czz());
+  return fabs(theVertex.position().z() - theLeptonNearVertex.position().z()) /
+         sqrt(std::pow(theVertex.zError(), 2) + theLeptonNearVertex.cartesianError().position().czz());
 }
-

--- a/PhysicsTools/PatUtils/src/MiniIsolation.cc
+++ b/PhysicsTools/PatUtils/src/MiniIsolation.cc
@@ -3,76 +3,81 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "PhysicsTools/PatUtils/interface/MiniIsolation.h"
 
-namespace pat{
+namespace pat {
 
-// Computes MiniIsolation given a 4-vector of the object in question
-// and a collection of packed PF cands. Computed as a sum of PFCand pT
-// inside a cone of radius dR = max(mindir, min(maxdr, kt_scale/pT))
-// Excludes PFCands inside of "deadcone" radius.
-// For nh, ph, pu, only include particles with pT > ptthresh
-// Some documentation can be found here: https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
+  // Computes MiniIsolation given a 4-vector of the object in question
+  // and a collection of packed PF cands. Computed as a sum of PFCand pT
+  // inside a cone of radius dR = max(mindir, min(maxdr, kt_scale/pT))
+  // Excludes PFCands inside of "deadcone" radius.
+  // For nh, ph, pu, only include particles with pT > ptthresh
+  // Some documentation can be found here: https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
 
-float miniIsoDr(const math::XYZTLorentzVector &p4, float mindr, float maxdr,
-		 float kt_scale){
-  return std::max(mindr, std::min(maxdr, float(kt_scale/p4.pt())));
-}
+  float miniIsoDr(const math::XYZTLorentzVector &p4, float mindr, float maxdr, float kt_scale) {
+    return std::max(mindr, std::min(maxdr, float(kt_scale / p4.pt())));
+  }
 
-PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
-                                 const math::XYZTLorentzVector &p4, float mindr, float maxdr,
-                                 float kt_scale, float ptthresh, float deadcone_ch,
-                                 float deadcone_pu, float deadcone_ph, float deadcone_nh,
-                                 float dZ_cut)
-{
-    
-    float chiso=0, nhiso=0, phiso=0, puiso=0;
-    float drcut = miniIsoDr(p4,mindr,maxdr,kt_scale);
-    for(auto const & pc : *pfcands){
-        float dr = deltaR(p4, pc.p4());
-        if(dr>drcut)
-            continue;
-        float pt = pc.p4().pt();
-        int id = pc.pdgId();
-        if(std::abs(id)==211){
-            bool fromPV = (pc.fromPV()>1 || fabs(pc.dz()) < dZ_cut);
-            if(fromPV && dr > deadcone_ch){
-                // if charged hadron and from primary vertex, add to charged hadron isolation
-                chiso += pt;
-            }else if(!fromPV && pt > ptthresh && dr > deadcone_pu){
-                // if charged hadron and NOT from primary vertex, add to pileup isolation
-                puiso += pt;
-            }
+  PFIsolation getMiniPFIsolation(const pat::PackedCandidateCollection *pfcands,
+                                 const math::XYZTLorentzVector &p4,
+                                 float mindr,
+                                 float maxdr,
+                                 float kt_scale,
+                                 float ptthresh,
+                                 float deadcone_ch,
+                                 float deadcone_pu,
+                                 float deadcone_ph,
+                                 float deadcone_nh,
+                                 float dZ_cut) {
+    float chiso = 0, nhiso = 0, phiso = 0, puiso = 0;
+    float drcut = miniIsoDr(p4, mindr, maxdr, kt_scale);
+    for (auto const &pc : *pfcands) {
+      float dr = deltaR(p4, pc.p4());
+      if (dr > drcut)
+        continue;
+      float pt = pc.p4().pt();
+      int id = pc.pdgId();
+      if (std::abs(id) == 211) {
+        bool fromPV = (pc.fromPV() > 1 || fabs(pc.dz()) < dZ_cut);
+        if (fromPV && dr > deadcone_ch) {
+          // if charged hadron and from primary vertex, add to charged hadron isolation
+          chiso += pt;
+        } else if (!fromPV && pt > ptthresh && dr > deadcone_pu) {
+          // if charged hadron and NOT from primary vertex, add to pileup isolation
+          puiso += pt;
         }
-        // if neutral hadron, add to neutral hadron isolation
-        if(std::abs(id)==130 && pt>ptthresh && dr>deadcone_nh)
-            nhiso += pt;
-        // if photon, add to photon isolation
-        if(std::abs(id)==22 && pt>ptthresh && dr>deadcone_ph)
-            phiso += pt;
-                
+      }
+      // if neutral hadron, add to neutral hadron isolation
+      if (std::abs(id) == 130 && pt > ptthresh && dr > deadcone_nh)
+        nhiso += pt;
+      // if photon, add to photon isolation
+      if (std::abs(id) == 22 && pt > ptthresh && dr > deadcone_ph)
+        phiso += pt;
     }
-                      
+
     return pat::PFIsolation(chiso, nhiso, phiso, puiso);
+  }
 
-}
-
-  double muonRelMiniIsoPUCorrected(const PFIsolation& iso,
-				   const math::XYZTLorentzVector& p4,
-				   double dr,
-				   double rho,
-                                   const std::vector<double> &area)
-  {
+  double muonRelMiniIsoPUCorrected(const PFIsolation &iso,
+                                   const math::XYZTLorentzVector &p4,
+                                   double dr,
+                                   double rho,
+                                   const std::vector<double> &area) {
     double absEta = std::abs(p4.eta());
     double ea = 0;
     //Eta dependent effective area
-    if      (absEta<0.800) ea = area.at(0);
-    else if (absEta<1.300) ea = area.at(1);
-    else if (absEta<2.000) ea = area.at(2);
-    else if (absEta<2.200) ea = area.at(3);
-    else if (absEta<2.500) ea = area.at(4);
+    if (absEta < 0.800)
+      ea = area.at(0);
+    else if (absEta < 1.300)
+      ea = area.at(1);
+    else if (absEta < 2.000)
+      ea = area.at(2);
+    else if (absEta < 2.200)
+      ea = area.at(3);
+    else if (absEta < 2.500)
+      ea = area.at(4);
 
-    double correction = rho * ea * (dr/0.3) * (dr/0.3);
-    double correctedIso = iso.chargedHadronIso() + std::max(0.0, iso.neutralHadronIso()+iso.photonIso() - correction);
-    return correctedIso/p4.pt();
+    double correction = rho * ea * (dr / 0.3) * (dr / 0.3);
+    double correctedIso = iso.chargedHadronIso() + std::max(0.0, iso.neutralHadronIso() + iso.photonIso() - correction);
+    return correctedIso / p4.pt();
   }
 
-}
+}  // namespace pat

--- a/PhysicsTools/PatUtils/src/MuonSelector.cc
+++ b/PhysicsTools/PatUtils/src/MuonSelector.cc
@@ -6,86 +6,67 @@
 using pat::MuonSelector;
 using namespace reco;
 
-
 //______________________________________________________________________________
-const pat::ParticleStatus
-MuonSelector::filter( const unsigned int&    index, 
-                      const edm::View<Muon>& muons ) const
-{
-
+const pat::ParticleStatus MuonSelector::filter(const unsigned int& index, const edm::View<Muon>& muons) const {
   // List of possible selections
-  if      ( config_.selectionType == "none"  ) 
-    {
+  if (config_.selectionType == "none") {
+    return GOOD;
+  } else if (config_.selectionType == "globalMuons") {
+    if (muons[index].isGlobalMuon())
       return GOOD;
-    }
-  else if ( config_.selectionType == "globalMuons" )
-    {
-      if ( muons[index].isGlobalMuon() ) return GOOD;
-      else return BAD;
-    }
-  else if ( config_.selectionType == "muonPOG"  )
-    {
-      return muIdSelection_( index, muons );
-    }
-  else if ( config_.selectionType == "custom"     ) 
-    {
-      return customSelection_( index, muons );
-    }
+    else
+      return BAD;
+  } else if (config_.selectionType == "muonPOG") {
+    return muIdSelection_(index, muons);
+  } else if (config_.selectionType == "custom") {
+    return customSelection_(index, muons);
+  }
 
   // Throw! unknown configuration
-  throw edm::Exception(edm::errors::Configuration) 
-    << "Unknown electron ID selection " << config_.selectionType;
-
+  throw edm::Exception(edm::errors::Configuration) << "Unknown electron ID selection " << config_.selectionType;
 }
 
 //______________________________________________________________________________
-const pat::ParticleStatus
-MuonSelector::customSelection_( const unsigned int&    index, 
-                                const edm::View<Muon>& muons ) const
-{
-
+const pat::ParticleStatus MuonSelector::customSelection_(const unsigned int& index,
+                                                         const edm::View<Muon>& muons) const {
   // Custom muon selection from SusyAnalyzer (TQAF has a subset of these cuts)
 
   // Use global muon if possible
   TrackRef muontrack;
-  if ( muons[index].isGlobalMuon() )
+  if (muons[index].isGlobalMuon())
     muontrack = muons[index].track();
   else
     muontrack = muons[index].combinedMuon();
 
-  float pt_track  = muontrack->pt();
-  float dpt_track = muontrack->error(0)/muontrack->qoverp()*muontrack->pt();
-  float chisq     = muontrack->normalizedChi2();
-  int nHitsValid  = muontrack->numberOfValidHits();
+  float pt_track = muontrack->pt();
+  float dpt_track = muontrack->error(0) / muontrack->qoverp() * muontrack->pt();
+  float chisq = muontrack->normalizedChi2();
+  int nHitsValid = muontrack->numberOfValidHits();
 
-  if ( dpt_track >= config_.dPbyPmax * pt_track ) return BAD;
-  
-  if ( chisq > config_.chi2max ) return BAD;
+  if (dpt_track >= config_.dPbyPmax * pt_track)
+    return BAD;
 
-  if ( nHitsValid < config_.nHitsMin ) return BAD;
+  if (chisq > config_.chi2max)
+    return BAD;
+
+  if (nHitsValid < config_.nHitsMin)
+    return BAD;
 
   return GOOD;
-
 }
 
-
 //______________________________________________________________________________
-const pat::ParticleStatus
-MuonSelector::muIdSelection_( const unsigned int&    index, 
-                              const edm::View<Muon>& muons ) const
-{
+const pat::ParticleStatus MuonSelector::muIdSelection_(const unsigned int& index, const edm::View<Muon>& muons) const {
   // MuonID algorithm
-  if ( muon::isGoodMuon((muons[index]),config_.flag) )
-    {
-      return BAD;
-    }
+  if (muon::isGoodMuon((muons[index]), config_.flag)) {
+    return BAD;
+  }
 
   // Direct cuts on compatibility
-  if (  muons[index].caloCompatibility()    <= config_.minCaloCompatibility
-     || muon::segmentCompatibility(muons[index]) <= config_.minSegmentCompatibility )
-    {
-      return BAD;
-    }
+  if (muons[index].caloCompatibility() <= config_.minCaloCompatibility ||
+      muon::segmentCompatibility(muons[index]) <= config_.minSegmentCompatibility) {
+    return BAD;
+  }
 
   return GOOD;
 }

--- a/PhysicsTools/PatUtils/src/ObjectResolutionCalc.cc
+++ b/PhysicsTools/PatUtils/src/ObjectResolutionCalc.cc
@@ -3,210 +3,206 @@
 
 #include "PhysicsTools/PatUtils/interface/ObjectResolutionCalc.h"
 
-
 using namespace pat;
 
-
 // constructor with path; default should not be used
-ObjectResolutionCalc::ObjectResolutionCalc(const TString& resopath, bool useNN = false): useNN_(useNN) {
-  edm::LogVerbatim("ObjectResolutionCalc") << ("ObjectResolutionCalc") << "=== Constructing a TopObjectResolutionCalc...";
+ObjectResolutionCalc::ObjectResolutionCalc(const TString& resopath, bool useNN = false) : useNN_(useNN) {
+  edm::LogVerbatim("ObjectResolutionCalc")
+      << ("ObjectResolutionCalc") << "=== Constructing a TopObjectResolutionCalc...";
   resoFile_ = new TFile(resopath);
-  if (!resoFile_) edm::LogError("ObjectResolutionCalc") << "No resolutions fits for this file available: "<<resopath<<"...";
-  TString  resObsName[8] = {"_ares","_bres","_cres","_dres","_thres","_phres","_etres","_etares"};
-  
+  if (!resoFile_)
+    edm::LogError("ObjectResolutionCalc") << "No resolutions fits for this file available: " << resopath << "...";
+  TString resObsName[8] = {"_ares", "_bres", "_cres", "_dres", "_thres", "_phres", "_etres", "_etares"};
+
   TList* keys = resoFile_->GetListOfKeys();
   TIter nextitem(keys);
   TKey* key = nullptr;
-  while((key = (TKey*)nextitem())) {
+  while ((key = (TKey*)nextitem())) {
     TString name = key->GetName();
-    if(useNN_) {
-      for(Int_t ro=0; ro<8; ro++) {
-        TString obsName = resObsName[ro]; obsName += "_NN";
-        if(name.Contains(obsName)){
-	  network_[ro] = (TMultiLayerPerceptron*) resoFile_->GetKey(name)->ReadObj();
-	}
+    if (useNN_) {
+      for (Int_t ro = 0; ro < 8; ro++) {
+        TString obsName = resObsName[ro];
+        obsName += "_NN";
+        if (name.Contains(obsName)) {
+          network_[ro] = (TMultiLayerPerceptron*)resoFile_->GetKey(name)->ReadObj();
+        }
       }
-    }
-    else 
-    { 
-      if(name.Contains("etabin") && (!name.Contains("etbin"))) {
-        for(int p=0; p<8; p++){
-          if(name.Contains(resObsName[p])){
-            TString etabin = name; etabin.Remove(0,etabin.Index("_")+1); etabin.Remove(0,etabin.Index("_")+7);
+    } else {
+      if (name.Contains("etabin") && (!name.Contains("etbin"))) {
+        for (int p = 0; p < 8; p++) {
+          if (name.Contains(resObsName[p])) {
+            TString etabin = name;
+            etabin.Remove(0, etabin.Index("_") + 1);
+            etabin.Remove(0, etabin.Index("_") + 7);
             int etaBin = etabin.Atoi();
-            TH1F *tmp = (TH1F*) (resoFile_->GetKey(name)->ReadObj());
-            fResVsEt_[p][etaBin] = (TF1)(*(tmp -> GetFunction("F_"+name)));
-	  }
+            TH1F* tmp = (TH1F*)(resoFile_->GetKey(name)->ReadObj());
+            fResVsEt_[p][etaBin] = (TF1)(*(tmp->GetFunction("F_" + name)));
+          }
         }
       }
     }
   }
   // find etabin values
-  TH1F *tmpEta = (TH1F*) (resoFile_->GetKey("hEtaBins")->ReadObj());
-  for(int b=1; b<=tmpEta->GetNbinsX(); b++) etaBinVals_.push_back(tmpEta->GetXaxis()->GetBinLowEdge(b));
+  TH1F* tmpEta = (TH1F*)(resoFile_->GetKey("hEtaBins")->ReadObj());
+  for (int b = 1; b <= tmpEta->GetNbinsX(); b++)
+    etaBinVals_.push_back(tmpEta->GetXaxis()->GetBinLowEdge(b));
   etaBinVals_.push_back(tmpEta->GetXaxis()->GetBinUpEdge(tmpEta->GetNbinsX()));
-  edm::LogVerbatim("ObjectResolutionCalc") << "Found "<<etaBinVals_.size()-1  << " eta-bins with edges: ( ";
-  for(size_t u=0; u<etaBinVals_.size(); u++) edm::LogVerbatim("ObjectResolutionCalc") << etaBinVals_[u]<<", ";
-  edm::LogVerbatim("ObjectResolutionCalc") << "\b\b )"<<std::endl;
-  
+  edm::LogVerbatim("ObjectResolutionCalc") << "Found " << etaBinVals_.size() - 1 << " eta-bins with edges: ( ";
+  for (size_t u = 0; u < etaBinVals_.size(); u++)
+    edm::LogVerbatim("ObjectResolutionCalc") << etaBinVals_[u] << ", ";
+  edm::LogVerbatim("ObjectResolutionCalc") << "\b\b )" << std::endl;
+
   edm::LogVerbatim("ObjectResolutionCalc") << "=== done." << std::endl;
 }
 
-
 // destructor
-ObjectResolutionCalc::~ObjectResolutionCalc() {
-  delete resoFile_;
-}
-
+ObjectResolutionCalc::~ObjectResolutionCalc() { delete resoFile_; }
 
 float ObjectResolutionCalc::obsRes(int obs, int eta, float eT) {
-  if (useNN_) throw edm::Exception( edm::errors::LogicError, 
-                                   "TopObjectResolutionCalc::obsRes should never be called when using a NN for resolutions." );
+  if (useNN_)
+    throw edm::Exception(edm::errors::LogicError,
+                         "TopObjectResolutionCalc::obsRes should never be called when using a NN for resolutions.");
   float res = fResVsEt_[obs][eta].Eval(eT);
   return res;
 }
 
-
 int ObjectResolutionCalc::etaBin(float eta) {
-  int nrEtaBins = etaBinVals_.size()-1;
-  int bin = nrEtaBins-1;
-  for(int i=0; i<nrEtaBins; i++) {
-    if(fabs(eta) > etaBinVals_[i] && fabs(eta) < etaBinVals_[i+1]) bin = i;
+  int nrEtaBins = etaBinVals_.size() - 1;
+  int bin = nrEtaBins - 1;
+  for (int i = 0; i < nrEtaBins; i++) {
+    if (fabs(eta) > etaBinVals_[i] && fabs(eta) < etaBinVals_[i + 1])
+      bin = i;
   }
   return bin;
 }
 
 #if OBSOLETE
-void ObjectResolutionCalc::operator()(Electron & obj) {
+void ObjectResolutionCalc::operator()(Electron& obj) {
   if (useNN_) {
     double v[2];
-    v[0]=obj.et();
-    v[1]=obj.eta();
-    obj.setResolutionA(     network_[0]->Evaluate(0,v ));
-    obj.setResolutionB(     network_[1]->Evaluate(0,v ));
-    obj.setResolutionC(     network_[2]->Evaluate(0,v ));
-    obj.setResolutionD(     network_[3]->Evaluate(0,v ));	
-    obj.setResolutionTheta( network_[4]->Evaluate(0,v ));	 
-    obj.setResolutionPhi(   network_[5]->Evaluate(0,v ));	
-    obj.setResolutionEt(    network_[6]->Evaluate(0,v ));	
-    obj.setResolutionEta(   network_[7]->Evaluate(0,v ));
+    v[0] = obj.et();
+    v[1] = obj.eta();
+    obj.setResolutionA(network_[0]->Evaluate(0, v));
+    obj.setResolutionB(network_[1]->Evaluate(0, v));
+    obj.setResolutionC(network_[2]->Evaluate(0, v));
+    obj.setResolutionD(network_[3]->Evaluate(0, v));
+    obj.setResolutionTheta(network_[4]->Evaluate(0, v));
+    obj.setResolutionPhi(network_[5]->Evaluate(0, v));
+    obj.setResolutionEt(network_[6]->Evaluate(0, v));
+    obj.setResolutionEta(network_[7]->Evaluate(0, v));
   } else {
     int bin = this->etaBin(obj.eta());
-    obj.setResolutionA(     this->obsRes(0,bin,obj.et()) );
-    obj.setResolutionB(     this->obsRes(1,bin,obj.et()) );
-    obj.setResolutionC(     this->obsRes(2,bin,obj.et()) ); 
-    obj.setResolutionD(     this->obsRes(3,bin,obj.et()) ); 
-    obj.setResolutionTheta( this->obsRes(4,bin,obj.et()) );  
-    obj.setResolutionPhi(   this->obsRes(5,bin,obj.et()) ); 
-    obj.setResolutionEt(    this->obsRes(6,bin,obj.et()) ); 
-    obj.setResolutionEta(   this->obsRes(7,bin,obj.et()) );
+    obj.setResolutionA(this->obsRes(0, bin, obj.et()));
+    obj.setResolutionB(this->obsRes(1, bin, obj.et()));
+    obj.setResolutionC(this->obsRes(2, bin, obj.et()));
+    obj.setResolutionD(this->obsRes(3, bin, obj.et()));
+    obj.setResolutionTheta(this->obsRes(4, bin, obj.et()));
+    obj.setResolutionPhi(this->obsRes(5, bin, obj.et()));
+    obj.setResolutionEt(this->obsRes(6, bin, obj.et()));
+    obj.setResolutionEta(this->obsRes(7, bin, obj.et()));
   }
 }
 
-
-void ObjectResolutionCalc::operator()(Muon & obj) {
+void ObjectResolutionCalc::operator()(Muon& obj) {
   if (useNN_) {
     double v[2];
-    v[0]=obj.et();
-    v[1]=obj.eta();
-    obj.setResolutionA(     network_[0]->Evaluate(0,v ));
-    obj.setResolutionB(     network_[1]->Evaluate(0,v ));
-    obj.setResolutionC(     network_[2]->Evaluate(0,v ));
-    obj.setResolutionD(     network_[3]->Evaluate(0,v ));	
-    obj.setResolutionTheta( network_[4]->Evaluate(0,v ));	 
-    obj.setResolutionPhi(   network_[5]->Evaluate(0,v ));	
-    obj.setResolutionEt(    network_[6]->Evaluate(0,v ));	
-    obj.setResolutionEta(   network_[7]->Evaluate(0,v ));
+    v[0] = obj.et();
+    v[1] = obj.eta();
+    obj.setResolutionA(network_[0]->Evaluate(0, v));
+    obj.setResolutionB(network_[1]->Evaluate(0, v));
+    obj.setResolutionC(network_[2]->Evaluate(0, v));
+    obj.setResolutionD(network_[3]->Evaluate(0, v));
+    obj.setResolutionTheta(network_[4]->Evaluate(0, v));
+    obj.setResolutionPhi(network_[5]->Evaluate(0, v));
+    obj.setResolutionEt(network_[6]->Evaluate(0, v));
+    obj.setResolutionEta(network_[7]->Evaluate(0, v));
   } else {
     int bin = this->etaBin(obj.eta());
-    obj.setResolutionA(     this->obsRes(0,bin,obj.et()) );
-    obj.setResolutionB(     this->obsRes(1,bin,obj.et()) );
-    obj.setResolutionC(     this->obsRes(2,bin,obj.et()) ); 
-    obj.setResolutionD(     this->obsRes(3,bin,obj.et()) ); 
-    obj.setResolutionTheta( this->obsRes(4,bin,obj.et()) );  
-    obj.setResolutionPhi(   this->obsRes(5,bin,obj.et()) ); 
-    obj.setResolutionEt(    this->obsRes(6,bin,obj.et()) ); 
-    obj.setResolutionEta(   this->obsRes(7,bin,obj.et()) );
+    obj.setResolutionA(this->obsRes(0, bin, obj.et()));
+    obj.setResolutionB(this->obsRes(1, bin, obj.et()));
+    obj.setResolutionC(this->obsRes(2, bin, obj.et()));
+    obj.setResolutionD(this->obsRes(3, bin, obj.et()));
+    obj.setResolutionTheta(this->obsRes(4, bin, obj.et()));
+    obj.setResolutionPhi(this->obsRes(5, bin, obj.et()));
+    obj.setResolutionEt(this->obsRes(6, bin, obj.et()));
+    obj.setResolutionEta(this->obsRes(7, bin, obj.et()));
   }
 }
 
-
-void ObjectResolutionCalc::operator()(Jet & obj) {
+void ObjectResolutionCalc::operator()(Jet& obj) {
   if (useNN_) {
     double v[2];
-    v[0]=obj.et();
-    v[1]=obj.eta();
-    obj.setResolutionA(     network_[0]->Evaluate(0,v ));
-    obj.setResolutionB(     network_[1]->Evaluate(0,v ));
-    obj.setResolutionC(     network_[2]->Evaluate(0,v ));
-    obj.setResolutionD(     network_[3]->Evaluate(0,v ));	
-    obj.setResolutionTheta( network_[4]->Evaluate(0,v ));	 
-    obj.setResolutionPhi(   network_[5]->Evaluate(0,v ));	
-    obj.setResolutionEt(    network_[6]->Evaluate(0,v ));	
-    obj.setResolutionEta(   network_[7]->Evaluate(0,v ));
+    v[0] = obj.et();
+    v[1] = obj.eta();
+    obj.setResolutionA(network_[0]->Evaluate(0, v));
+    obj.setResolutionB(network_[1]->Evaluate(0, v));
+    obj.setResolutionC(network_[2]->Evaluate(0, v));
+    obj.setResolutionD(network_[3]->Evaluate(0, v));
+    obj.setResolutionTheta(network_[4]->Evaluate(0, v));
+    obj.setResolutionPhi(network_[5]->Evaluate(0, v));
+    obj.setResolutionEt(network_[6]->Evaluate(0, v));
+    obj.setResolutionEta(network_[7]->Evaluate(0, v));
   } else {
     int bin = this->etaBin(obj.eta());
-    obj.setResolutionA(     this->obsRes(0,bin,obj.et()) );
-    obj.setResolutionB(     this->obsRes(1,bin,obj.et()) );
-    obj.setResolutionC(     this->obsRes(2,bin,obj.et()) ); 
-    obj.setResolutionD(     this->obsRes(3,bin,obj.et()) ); 
-    obj.setResolutionTheta( this->obsRes(4,bin,obj.et()) );  
-    obj.setResolutionPhi(   this->obsRes(5,bin,obj.et()) ); 
-    obj.setResolutionEt(    this->obsRes(6,bin,obj.et()) ); 
-    obj.setResolutionEta(   this->obsRes(7,bin,obj.et()) );
+    obj.setResolutionA(this->obsRes(0, bin, obj.et()));
+    obj.setResolutionB(this->obsRes(1, bin, obj.et()));
+    obj.setResolutionC(this->obsRes(2, bin, obj.et()));
+    obj.setResolutionD(this->obsRes(3, bin, obj.et()));
+    obj.setResolutionTheta(this->obsRes(4, bin, obj.et()));
+    obj.setResolutionPhi(this->obsRes(5, bin, obj.et()));
+    obj.setResolutionEt(this->obsRes(6, bin, obj.et()));
+    obj.setResolutionEta(this->obsRes(7, bin, obj.et()));
   }
 }
 
-
-void ObjectResolutionCalc::operator()(MET & obj) {
+void ObjectResolutionCalc::operator()(MET& obj) {
   if (useNN_) {
     double v[2];
-    v[0]=obj.et();
-    v[1]=obj.eta();
-    obj.setResolutionA(     network_[0]->Evaluate(0,v ));
-    obj.setResolutionB(     network_[1]->Evaluate(0,v ));
-    obj.setResolutionC(     network_[2]->Evaluate(0,v ));
-    obj.setResolutionD(     network_[3]->Evaluate(0,v ));
-    obj.setResolutionTheta( 1000000.  );   			// Total freedom	
-    obj.setResolutionPhi(   network_[5]->Evaluate(0,v ));	
-    obj.setResolutionEt(    network_[6]->Evaluate(0,v ));	
-    obj.setResolutionEta(   1000000.  );    			// Total freedom
+    v[0] = obj.et();
+    v[1] = obj.eta();
+    obj.setResolutionA(network_[0]->Evaluate(0, v));
+    obj.setResolutionB(network_[1]->Evaluate(0, v));
+    obj.setResolutionC(network_[2]->Evaluate(0, v));
+    obj.setResolutionD(network_[3]->Evaluate(0, v));
+    obj.setResolutionTheta(1000000.);  // Total freedom
+    obj.setResolutionPhi(network_[5]->Evaluate(0, v));
+    obj.setResolutionEt(network_[6]->Evaluate(0, v));
+    obj.setResolutionEta(1000000.);  // Total freedom
   } else {
-    obj.setResolutionA(     this->obsRes(0,0,obj.et())  );
-    obj.setResolutionC(     this->obsRes(1,0,obj.et())  );
-    obj.setResolutionB(     this->obsRes(2,0,obj.et())  );
-    obj.setResolutionD(     this->obsRes(3,0,obj.et())  );
-    obj.setResolutionTheta( 1000000.  );   			// Total freedom
-    obj.setResolutionPhi(   this->obsRes(5,0,obj.et())  );
-    obj.setResolutionEt(    this->obsRes(6,0,obj.et())  );
-    obj.setResolutionEta(   1000000.  );    			// Total freedom
+    obj.setResolutionA(this->obsRes(0, 0, obj.et()));
+    obj.setResolutionC(this->obsRes(1, 0, obj.et()));
+    obj.setResolutionB(this->obsRes(2, 0, obj.et()));
+    obj.setResolutionD(this->obsRes(3, 0, obj.et()));
+    obj.setResolutionTheta(1000000.);  // Total freedom
+    obj.setResolutionPhi(this->obsRes(5, 0, obj.et()));
+    obj.setResolutionEt(this->obsRes(6, 0, obj.et()));
+    obj.setResolutionEta(1000000.);  // Total freedom
   }
 }
 
-
-void ObjectResolutionCalc::operator()(Tau & obj) {
+void ObjectResolutionCalc::operator()(Tau& obj) {
   if (useNN_) {
     double v[2];
-    v[0]=obj.et();
-    v[1]=obj.eta();
-    obj.setResolutionA(     network_[0]->Evaluate(0,v ));
-    obj.setResolutionB(     network_[1]->Evaluate(0,v ));
-    obj.setResolutionC(     network_[2]->Evaluate(0,v ));
-    obj.setResolutionD(     network_[3]->Evaluate(0,v ));	
-    obj.setResolutionTheta( network_[4]->Evaluate(0,v ));	 
-    obj.setResolutionPhi(   network_[5]->Evaluate(0,v ));	
-    obj.setResolutionEt(    network_[6]->Evaluate(0,v ));	
-    obj.setResolutionEta(   network_[7]->Evaluate(0,v ));
+    v[0] = obj.et();
+    v[1] = obj.eta();
+    obj.setResolutionA(network_[0]->Evaluate(0, v));
+    obj.setResolutionB(network_[1]->Evaluate(0, v));
+    obj.setResolutionC(network_[2]->Evaluate(0, v));
+    obj.setResolutionD(network_[3]->Evaluate(0, v));
+    obj.setResolutionTheta(network_[4]->Evaluate(0, v));
+    obj.setResolutionPhi(network_[5]->Evaluate(0, v));
+    obj.setResolutionEt(network_[6]->Evaluate(0, v));
+    obj.setResolutionEta(network_[7]->Evaluate(0, v));
   } else {
     int bin = this->etaBin(obj.eta());
-    obj.setResolutionA(     this->obsRes(0,bin,obj.et()) );
-    obj.setResolutionB(     this->obsRes(1,bin,obj.et()) );
-    obj.setResolutionC(     this->obsRes(2,bin,obj.et()) ); 
-    obj.setResolutionD(     this->obsRes(3,bin,obj.et()) ); 
-    obj.setResolutionTheta( this->obsRes(4,bin,obj.et()) );  
-    obj.setResolutionPhi(   this->obsRes(5,bin,obj.et()) ); 
-    obj.setResolutionEt(    this->obsRes(6,bin,obj.et()) ); 
-    obj.setResolutionEta(   this->obsRes(7,bin,obj.et()) );
+    obj.setResolutionA(this->obsRes(0, bin, obj.et()));
+    obj.setResolutionB(this->obsRes(1, bin, obj.et()));
+    obj.setResolutionC(this->obsRes(2, bin, obj.et()));
+    obj.setResolutionD(this->obsRes(3, bin, obj.et()));
+    obj.setResolutionTheta(this->obsRes(4, bin, obj.et()));
+    obj.setResolutionPhi(this->obsRes(5, bin, obj.et()));
+    obj.setResolutionEt(this->obsRes(6, bin, obj.et()));
+    obj.setResolutionEta(this->obsRes(7, bin, obj.et()));
   }
 }
 #endif

--- a/PhysicsTools/PatUtils/src/RazorComputer.cc
+++ b/PhysicsTools/PatUtils/src/RazorComputer.cc
@@ -1,140 +1,128 @@
 #include "PhysicsTools/PatUtils/interface/RazorComputer.h"
 #include "TLorentzVector.h"
 
-RazorBox::RazorBox( const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) :
-  CachingVariable("RazorBox",arg.n,arg.iConfig,iC){
+RazorBox::RazorBox(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC)
+    : CachingVariable("RazorBox", arg.n, arg.iConfig, iC) {}
 
-}
+void RazorBox::compute(const edm::Event& iEvent) const {}
 
-void RazorBox::compute( const edm::Event & iEvent) const{
-  
-}
-
-RazorComputer::RazorComputer( const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC) : VariableComputer(arg,iC){
-  jet_ = edm::Service<InputTagDistributorService>()->retrieve("jet",arg.iConfig);
-  met_ = edm::Service<InputTagDistributorService>()->retrieve("met",arg.iConfig);
+RazorComputer::RazorComputer(const CachingVariable::CachingVariableFactoryArg& arg, edm::ConsumesCollector& iC)
+    : VariableComputer(arg, iC) {
+  jet_ = edm::Service<InputTagDistributorService>()->retrieve("jet", arg.iConfig);
+  met_ = edm::Service<InputTagDistributorService>()->retrieve("met", arg.iConfig);
   jetToken_ = iC.consumes<std::vector<pat::Jet>>(jet_);
   metToken_ = iC.consumes<std::vector<pat::MET>>(met_);
   pt_ = 40.;
-  eta_=2.4;
+  eta_ = 2.4;
 
-  declare("MRT",iC);
-  declare("MR",iC);
-  declare("R2",iC);
-  declare("R",iC);
-
+  declare("MRT", iC);
+  declare("MR", iC);
+  declare("R2", iC);
+  declare("R", iC);
 }
 
-namespace razor{
+namespace razor {
   typedef reco::Candidate::LorentzVector LorentzVector;
 
-  double CalcMR(const LorentzVector &ja, const LorentzVector &jb){
+  double CalcMR(const LorentzVector& ja, const LorentzVector& jb) {
     double A = ja.P();
     double B = jb.P();
     double az = ja.Pz();
     double bz = jb.Pz();
 
-    double temp = sqrt((A+B)*(A+B)-(az+bz)*(az+bz));
+    double temp = sqrt((A + B) * (A + B) - (az + bz) * (az + bz));
 
     return temp;
   }
-  double CalcMTR(const LorentzVector & j1, const LorentzVector & j2, const pat::MET & met){
-
-    double temp = met.et()*(j1.Pt()+j2.Pt()) - met.px()*(j1.X()+j2.X()) - met.py()*(j1.Y()+j2.Y());
+  double CalcMTR(const LorentzVector& j1, const LorentzVector& j2, const pat::MET& met) {
+    double temp = met.et() * (j1.Pt() + j2.Pt()) - met.px() * (j1.X() + j2.X()) - met.py() * (j1.Y() + j2.Y());
     temp /= 2.;
 
     temp = sqrt(temp);
 
     return temp;
   }
-};
+};  // namespace razor
 
-
-void RazorComputer::compute(const edm::Event & iEvent) const{
+void RazorComputer::compute(const edm::Event& iEvent) const {
   //std::cout<<"getting into computation"<<std::endl;
 
   edm::Handle<std::vector<pat::Jet>> jetH;
   edm::Handle<std::vector<pat::MET>> metH;
-  iEvent.getByToken( jetToken_, jetH);
-  iEvent.getByToken( metToken_, metH);
-  
+  iEvent.getByToken(jetToken_, jetH);
+  iEvent.getByToken(metToken_, metH);
+
   typedef reco::Candidate::LorentzVector LorentzVector;
 
-
   std::vector<LorentzVector> jets;
-  jets.reserve( jetH.product()->size() );
-  for (std::vector<pat::Jet>::const_iterator jetit = jetH.product()->begin();
-       jetit!= jetH.product()->end(); ++ jetit){
-    if (jetit->et() > pt_ && fabs(jetit->eta()) < eta_){
-      jets.push_back( jetit->p4());
+  jets.reserve(jetH.product()->size());
+  for (std::vector<pat::Jet>::const_iterator jetit = jetH.product()->begin(); jetit != jetH.product()->end(); ++jetit) {
+    if (jetit->et() > pt_ && fabs(jetit->eta()) < eta_) {
+      jets.push_back(jetit->p4());
     }
   }
 
-  reco::Candidate::LorentzVector HEM_1,HEM_2;
+  reco::Candidate::LorentzVector HEM_1, HEM_2;
 
-  HEM_1.SetPxPyPzE(0.0,0.0,0.0,0.0);
-  HEM_2.SetPxPyPzE(0.0,0.0,0.0,0.0);
-    
-  if(jets.size() < 2) {
-  }
-  else{
+  HEM_1.SetPxPyPzE(0.0, 0.0, 0.0, 0.0);
+  HEM_2.SetPxPyPzE(0.0, 0.0, 0.0, 0.0);
+
+  if (jets.size() < 2) {
+  } else {
     unsigned int N_comb = 1;
-    for(unsigned int i = 0; i < jets.size(); i++){
+    for (unsigned int i = 0; i < jets.size(); i++) {
       N_comb *= 2;
-    }   
-  
+    }
+
     double M_temp;
 
     double M_min = 9999999999.0;
     int j_count;
-    
-    for(unsigned int i = 1; i < N_comb-1; i++){
+
+    for (unsigned int i = 1; i < N_comb - 1; i++) {
       LorentzVector j_temp1, j_temp2;
       int itemp = i;
-      j_count = N_comb/2;
+      j_count = N_comb / 2;
       int count = 0;
-      while(j_count > 0){
-	if(itemp/j_count == 1){
-	  j_temp1 += jets[count];
-	} else {
-	  j_temp2 += jets[count];
-	}
-	itemp -= j_count*(itemp/j_count);
-	j_count /= 2;
-	count++;
+      while (j_count > 0) {
+        if (itemp / j_count == 1) {
+          j_temp1 += jets[count];
+        } else {
+          j_temp2 += jets[count];
+        }
+        itemp -= j_count * (itemp / j_count);
+        j_count /= 2;
+        count++;
       }
 
-      M_temp = j_temp1.M2()+j_temp2.M2();
+      M_temp = j_temp1.M2() + j_temp2.M2();
 
-      if(M_temp < M_min){
-	M_min = M_temp;
-	HEM_1 = j_temp1;
-	HEM_2 = j_temp2;
+      if (M_temp < M_min) {
+        M_min = M_temp;
+        HEM_1 = j_temp1;
+        HEM_2 = j_temp2;
       }
-      
     }
-    
-   
-    if(HEM_2.Pt() > HEM_1.Pt()){
+
+    if (HEM_2.Pt() > HEM_1.Pt()) {
       LorentzVector temp = HEM_1;
       HEM_1 = HEM_2;
       HEM_2 = temp;
     }
   }
 
-  double mrt=razor::CalcMTR( HEM_1, HEM_2, metH.product()->at(0));
-  double mr=razor::CalcMR( HEM_1, HEM_2);
-  
+  double mrt = razor::CalcMTR(HEM_1, HEM_2, metH.product()->at(0));
+  double mr = razor::CalcMR(HEM_1, HEM_2);
 
-  assign("MRT",mrt);
-  assign("MR",mr);
-  double r=-1,r2=-1;
-  if (mr!=0){
-    r=mrt/mr;
-    r2=r*r;
+  assign("MRT", mrt);
+  assign("MR", mr);
+  double r = -1, r2 = -1;
+  if (mr != 0) {
+    r = mrt / mr;
+    r2 = r * r;
   }
-  assign("R",r);
-  assign("R2",r2);
+  assign("R", r);
+  assign("R2", r2);
 
   //std::cout<<"MR,R2 "<<mr<<" , "<<r2<<std::endl;
 }

--- a/PhysicsTools/PatUtils/src/SimpleJetTrackAssociator.cc
+++ b/PhysicsTools/PatUtils/src/SimpleJetTrackAssociator.cc
@@ -2,28 +2,30 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-void
-helper::SimpleJetTrackAssociator::associateTransient(const math::XYZVector &dir, 
-                        const reco::TrackCollection &in, reco::TrackRefVector &out) {
-        for (size_t i = 0, n = in.size(); i < n; i++) {
-                const reco::Track & t = in[i];
-                if ((t.numberOfValidHits() < nHits_) || (t.normalizedChi2() > chi2nMax_)) continue;
-                if (deltaR2(dir, t) < deltaR2_) {
-                        reco::TrackRef tr(&in, i); // note: transient ref
-                        out.push_back(tr);
-                }
-        }
+void helper::SimpleJetTrackAssociator::associateTransient(const math::XYZVector &dir,
+                                                          const reco::TrackCollection &in,
+                                                          reco::TrackRefVector &out) {
+  for (size_t i = 0, n = in.size(); i < n; i++) {
+    const reco::Track &t = in[i];
+    if ((t.numberOfValidHits() < nHits_) || (t.normalizedChi2() > chi2nMax_))
+      continue;
+    if (deltaR2(dir, t) < deltaR2_) {
+      reco::TrackRef tr(&in, i);  // note: transient ref
+      out.push_back(tr);
+    }
+  }
 }
 
-void
-helper::SimpleJetTrackAssociator::associate(const math::XYZVector &dir, 
-                        const edm::View<reco::Track> &in, reco::TrackRefVector &out) {
-        for (size_t i = 0, n = in.size(); i < n; i++) {
-                const reco::Track & t = in[i];
-                if ((t.numberOfValidHits() < nHits_) || (t.normalizedChi2() > chi2nMax_)) continue;
-                if (deltaR2(dir, t) < deltaR2_) {
-                        reco::TrackRef tr = in.refAt(i).castTo<reco::TrackRef>();
-                        out.push_back(tr);
-                }
-        }
+void helper::SimpleJetTrackAssociator::associate(const math::XYZVector &dir,
+                                                 const edm::View<reco::Track> &in,
+                                                 reco::TrackRefVector &out) {
+  for (size_t i = 0, n = in.size(); i < n; i++) {
+    const reco::Track &t = in[i];
+    if ((t.numberOfValidHits() < nHits_) || (t.normalizedChi2() > chi2nMax_))
+      continue;
+    if (deltaR2(dir, t) < deltaR2_) {
+      reco::TrackRef tr = in.refAt(i).castTo<reco::TrackRef>();
+      out.push_back(tr);
+    }
+  }
 }

--- a/PhysicsTools/PatUtils/src/StringParserTools.cc
+++ b/PhysicsTools/PatUtils/src/StringParserTools.cc
@@ -1,74 +1,90 @@
 #include "PhysicsTools/PatUtils/interface/StringParserTools.h"
 #include <typeinfo>
 
-PATStringObjectFunction::PATStringObjectFunction(const std::string &string) :
-    expr_(string)
-{
-   candFunc_ = tryGet<reco::Candidate>(string);
-   if (!candFunc_.get()) {
-       eleFunc_ = tryGet<pat::Electron>(string);
-       muFunc_  = tryGet<pat::Muon>(string);
-       tauFunc_ = tryGet<pat::Tau>(string);
-       gamFunc_ = tryGet<pat::Photon>(string);
-       jetFunc_ = tryGet<pat::Jet>(string);
-       metFunc_ = tryGet<pat::MET>(string);
-       gpFunc_  = tryGet<pat::GenericParticle>(string);
-       pfFunc_  = tryGet<pat::PFParticle>(string);
-   } 
+PATStringObjectFunction::PATStringObjectFunction(const std::string &string) : expr_(string) {
+  candFunc_ = tryGet<reco::Candidate>(string);
+  if (!candFunc_.get()) {
+    eleFunc_ = tryGet<pat::Electron>(string);
+    muFunc_ = tryGet<pat::Muon>(string);
+    tauFunc_ = tryGet<pat::Tau>(string);
+    gamFunc_ = tryGet<pat::Photon>(string);
+    jetFunc_ = tryGet<pat::Jet>(string);
+    metFunc_ = tryGet<pat::MET>(string);
+    gpFunc_ = tryGet<pat::GenericParticle>(string);
+    pfFunc_ = tryGet<pat::PFParticle>(string);
+  }
 }
 
-double
-PATStringObjectFunction::operator()(const reco::Candidate &c) const  {
-    if (candFunc_.get()) return (*candFunc_)(c);
-    const std::type_info &type = typeid(c);
-    if      (type == typeid(pat::Electron       )) return tryEval<pat::Electron       >(c, eleFunc_);
-    else if (type == typeid(pat::Muon           )) return tryEval<pat::Muon           >(c,  muFunc_);
-    else if (type == typeid(pat::Tau            )) return tryEval<pat::Tau            >(c, tauFunc_);
-    else if (type == typeid(pat::Photon         )) return tryEval<pat::Photon         >(c, gamFunc_);
-    else if (type == typeid(pat::Jet            )) return tryEval<pat::Jet            >(c, jetFunc_);
-    else if (type == typeid(pat::MET            )) return tryEval<pat::MET            >(c, metFunc_);
-    else if (type == typeid(pat::GenericParticle)) return tryEval<pat::GenericParticle>(c,  gpFunc_);
-    else if (type == typeid(pat::PFParticle     )) return tryEval<pat::PFParticle     >(c,  pfFunc_);
-    else throw cms::Exception("Type Error") << "Cannot evaluate '" << expr_ << "' on an object of unsupported type " << type.name() << "\n"; 
+double PATStringObjectFunction::operator()(const reco::Candidate &c) const {
+  if (candFunc_.get())
+    return (*candFunc_)(c);
+  const std::type_info &type = typeid(c);
+  if (type == typeid(pat::Electron))
+    return tryEval<pat::Electron>(c, eleFunc_);
+  else if (type == typeid(pat::Muon))
+    return tryEval<pat::Muon>(c, muFunc_);
+  else if (type == typeid(pat::Tau))
+    return tryEval<pat::Tau>(c, tauFunc_);
+  else if (type == typeid(pat::Photon))
+    return tryEval<pat::Photon>(c, gamFunc_);
+  else if (type == typeid(pat::Jet))
+    return tryEval<pat::Jet>(c, jetFunc_);
+  else if (type == typeid(pat::MET))
+    return tryEval<pat::MET>(c, metFunc_);
+  else if (type == typeid(pat::GenericParticle))
+    return tryEval<pat::GenericParticle>(c, gpFunc_);
+  else if (type == typeid(pat::PFParticle))
+    return tryEval<pat::PFParticle>(c, pfFunc_);
+  else
+    throw cms::Exception("Type Error") << "Cannot evaluate '" << expr_ << "' on an object of unsupported type "
+                                       << type.name() << "\n";
 }
 
-void 
-PATStringObjectFunction::throwBadType(const std::type_info &ty) const  {
-    throw cms::Exception("Type Error")  << "Expression '" << expr_ << "' can't be evaluated on an object of type " << ty.name() << "\n(hint: use c++filt to demangle the type name)\n";
+void PATStringObjectFunction::throwBadType(const std::type_info &ty) const {
+  throw cms::Exception("Type Error") << "Expression '" << expr_ << "' can't be evaluated on an object of type "
+                                     << ty.name() << "\n(hint: use c++filt to demangle the type name)\n";
 }
 
-PATStringCutObjectSelector::PATStringCutObjectSelector(const std::string &string) :
-    expr_(string)
-{
-   candFunc_ = tryGet<reco::Candidate>(string);
-   if (!candFunc_.get()) {
-       eleFunc_ = tryGet<pat::Electron>(string);
-       muFunc_  = tryGet<pat::Muon>(string);
-       tauFunc_ = tryGet<pat::Tau>(string);
-       gamFunc_ = tryGet<pat::Photon>(string);
-       jetFunc_ = tryGet<pat::Jet>(string);
-       metFunc_ = tryGet<pat::MET>(string);
-       gpFunc_  = tryGet<pat::GenericParticle>(string);
-       pfFunc_  = tryGet<pat::PFParticle>(string);
-   } 
+PATStringCutObjectSelector::PATStringCutObjectSelector(const std::string &string) : expr_(string) {
+  candFunc_ = tryGet<reco::Candidate>(string);
+  if (!candFunc_.get()) {
+    eleFunc_ = tryGet<pat::Electron>(string);
+    muFunc_ = tryGet<pat::Muon>(string);
+    tauFunc_ = tryGet<pat::Tau>(string);
+    gamFunc_ = tryGet<pat::Photon>(string);
+    jetFunc_ = tryGet<pat::Jet>(string);
+    metFunc_ = tryGet<pat::MET>(string);
+    gpFunc_ = tryGet<pat::GenericParticle>(string);
+    pfFunc_ = tryGet<pat::PFParticle>(string);
+  }
 }
 
-bool
-PATStringCutObjectSelector::operator()(const reco::Candidate &c) const  {
-    if (candFunc_.get()) return (*candFunc_)(c);
-    const std::type_info &type = typeid(c);
-    if      (type == typeid(pat::Electron       )) return tryEval<pat::Electron       >(c, eleFunc_);
-    else if (type == typeid(pat::Muon           )) return tryEval<pat::Muon           >(c,  muFunc_);
-    else if (type == typeid(pat::Tau            )) return tryEval<pat::Tau            >(c, tauFunc_);
-    else if (type == typeid(pat::Photon         )) return tryEval<pat::Photon         >(c, gamFunc_);
-    else if (type == typeid(pat::Jet            )) return tryEval<pat::Jet            >(c, jetFunc_);
-    else if (type == typeid(pat::MET            )) return tryEval<pat::MET            >(c, metFunc_);
-    else if (type == typeid(pat::GenericParticle)) return tryEval<pat::GenericParticle>(c,  gpFunc_);
-    else if (type == typeid(pat::PFParticle     )) return tryEval<pat::PFParticle     >(c,  pfFunc_);
-    else throw cms::Exception("Type Error") << "Cannot evaluate '" << expr_ << "' on an object of unsupported type " << type.name() << "\n"; 
+bool PATStringCutObjectSelector::operator()(const reco::Candidate &c) const {
+  if (candFunc_.get())
+    return (*candFunc_)(c);
+  const std::type_info &type = typeid(c);
+  if (type == typeid(pat::Electron))
+    return tryEval<pat::Electron>(c, eleFunc_);
+  else if (type == typeid(pat::Muon))
+    return tryEval<pat::Muon>(c, muFunc_);
+  else if (type == typeid(pat::Tau))
+    return tryEval<pat::Tau>(c, tauFunc_);
+  else if (type == typeid(pat::Photon))
+    return tryEval<pat::Photon>(c, gamFunc_);
+  else if (type == typeid(pat::Jet))
+    return tryEval<pat::Jet>(c, jetFunc_);
+  else if (type == typeid(pat::MET))
+    return tryEval<pat::MET>(c, metFunc_);
+  else if (type == typeid(pat::GenericParticle))
+    return tryEval<pat::GenericParticle>(c, gpFunc_);
+  else if (type == typeid(pat::PFParticle))
+    return tryEval<pat::PFParticle>(c, pfFunc_);
+  else
+    throw cms::Exception("Type Error") << "Cannot evaluate '" << expr_ << "' on an object of unsupported type "
+                                       << type.name() << "\n";
 }
 
-void 
-PATStringCutObjectSelector::throwBadType(const std::type_info &ty) const  {
-    throw cms::Exception("Type Error")  << "Expression '" << expr_ << "' can't be evaluated on an object of type " << ty.name() << "\n(hint: use c++filt to demangle the type name)\n";
+void PATStringCutObjectSelector::throwBadType(const std::type_info &ty) const {
+  throw cms::Exception("Type Error") << "Expression '" << expr_ << "' can't be evaluated on an object of type "
+                                     << ty.name() << "\n(hint: use c++filt to demangle the type name)\n";
 }

--- a/PhysicsTools/PatUtils/src/TrackerIsolationPt.cc
+++ b/PhysicsTools/PatUtils/src/TrackerIsolationPt.cc
@@ -18,27 +18,31 @@
 using namespace pat;
 
 /// constructor
-TrackerIsolationPt::TrackerIsolationPt() {
-}
+TrackerIsolationPt::TrackerIsolationPt() {}
 
 /// destructor
-TrackerIsolationPt::~TrackerIsolationPt() {
-}
+TrackerIsolationPt::~TrackerIsolationPt() {}
 
 /// calculate the TrackIsoPt for the lepton object
-float TrackerIsolationPt::calculate(const Electron & theElectron, const edm::View<reco::Track> & theTracks, float isoConeElectron) const {
+float TrackerIsolationPt::calculate(const Electron& theElectron,
+                                    const edm::View<reco::Track>& theTracks,
+                                    float isoConeElectron) const {
   return this->calculate(*theElectron.gsfTrack(), theTracks, isoConeElectron);
 }
 
-float TrackerIsolationPt::calculate(const Muon & theMuon, const edm::View<reco::Track> & theTracks, float isoConeMuon) const {
+float TrackerIsolationPt::calculate(const Muon& theMuon,
+                                    const edm::View<reco::Track>& theTracks,
+                                    float isoConeMuon) const {
   return this->calculate(*theMuon.track(), theTracks, isoConeMuon);
 }
 
 /// calculate the TrackIsoPt for the lepton's track
-float TrackerIsolationPt::calculate(const reco::Track & theTrack, const edm::View<reco::Track> & theTracks, float isoCone) const {
+float TrackerIsolationPt::calculate(const reco::Track& theTrack,
+                                    const edm::View<reco::Track>& theTracks,
+                                    float isoCone) const {
   // initialize some variables
   float isoPtLepton = 0;
-  const reco::Track * closestTrackDRPt = nullptr, * closestTrackDR = nullptr;
+  const reco::Track *closestTrackDRPt = nullptr, *closestTrackDR = nullptr;
   float closestDRPt = 10000, closestDR = 10000;
   // use all these pointless vector conversions because the momenta from tracks
   // are completely unusable; bah, these math-vectors are worthless!
@@ -50,7 +54,7 @@ float TrackerIsolationPt::calculate(const reco::Track & theTrack, const edm::Vie
       isoPtLepton += track.perp();
       // find the closest matching track
       // FIXME: we could association by hits or chi2 to match
-      float pRatio = track.perp()/lepton.perp();
+      float pRatio = track.perp() / lepton.perp();
       if (dR < closestDRPt && pRatio > 0.5 && pRatio < 1.5) {
         closestDRPt = dR;
         closestTrackDRPt = &*itTrack;
@@ -69,8 +73,8 @@ float TrackerIsolationPt::calculate(const reco::Track & theTrack, const edm::Vie
     isoPtLepton -= closestTrackVector.perp();
   }
   // back to normal sum - S.L. 30/10/2007
-  if (isoPtLepton<0) isoPtLepton = 0;
+  if (isoPtLepton < 0)
+    isoPtLepton = 0;
   //  isoPtLepton <= 0.01 ? isoPtLepton = -1 : isoPtLepton = log(isoPtLepton);
   return isoPtLepton;
 }
-

--- a/PhysicsTools/PatUtils/src/TriggerHelper.cc
+++ b/PhysicsTools/PatUtils/src/TriggerHelper.cc
@@ -1,32 +1,29 @@
 //
 //
 
-
 #include "PhysicsTools/PatUtils/interface/TriggerHelper.h"
 
 #include "DataFormats/Common/interface/AssociativeIterator.h"
 
-
 using namespace pat;
 using namespace pat::helper;
 
-
-
 // Methods
-
 
 // Get a reference to the trigger objects matched to a certain physics object given by a reference for a certain matcher module
 
 // ... by resulting association
-TriggerObjectRef TriggerMatchHelper::triggerMatchObject( const reco::CandidateBaseRef & candRef, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
-  if ( matchResult ) {
-    auto it = edm::makeAssociativeIterator< reco::CandidateBaseRef>( *matchResult, event  );
-    auto itEnd =  it.end() ;
-    while ( it != itEnd ) {
-      if ( it->first.isNonnull() && it->second.isNonnull() && it->second.isAvailable() ) {
-        if ( it->first.id() == candRef.id() && it->first.key() == candRef.key() ) {
-          return TriggerObjectRef( it->second );
+TriggerObjectRef TriggerMatchHelper::triggerMatchObject(const reco::CandidateBaseRef& candRef,
+                                                        const TriggerObjectMatch* matchResult,
+                                                        const edm::Event& event,
+                                                        const TriggerEvent& triggerEvent) const {
+  if (matchResult) {
+    auto it = edm::makeAssociativeIterator<reco::CandidateBaseRef>(*matchResult, event);
+    auto itEnd = it.end();
+    while (it != itEnd) {
+      if (it->first.isNonnull() && it->second.isNonnull() && it->second.isAvailable()) {
+        if (it->first.id() == candRef.id() && it->first.key() == candRef.key()) {
+          return TriggerObjectRef(it->second);
         }
       }
       ++it;
@@ -36,37 +33,40 @@ TriggerObjectRef TriggerMatchHelper::triggerMatchObject( const reco::CandidateBa
 }
 
 // ... by matcher module label
-TriggerObjectRef TriggerMatchHelper::triggerMatchObject( const reco::CandidateBaseRef & candRef, const std::string & labelMatcher, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
-  return triggerMatchObject( candRef, triggerEvent.triggerObjectMatchResult( labelMatcher ), event, triggerEvent );
+TriggerObjectRef TriggerMatchHelper::triggerMatchObject(const reco::CandidateBaseRef& candRef,
+                                                        const std::string& labelMatcher,
+                                                        const edm::Event& event,
+                                                        const TriggerEvent& triggerEvent) const {
+  return triggerMatchObject(candRef, triggerEvent.triggerObjectMatchResult(labelMatcher), event, triggerEvent);
 }
 
-
 // Get a table of references to all trigger objects matched to a certain physics object given by a reference
-TriggerObjectMatchMap TriggerMatchHelper::triggerMatchObjects( const reco::CandidateBaseRef & candRef, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
+TriggerObjectMatchMap TriggerMatchHelper::triggerMatchObjects(const reco::CandidateBaseRef& candRef,
+                                                              const edm::Event& event,
+                                                              const TriggerEvent& triggerEvent) const {
   TriggerObjectMatchMap theContainer;
-  const std::vector< std::string > matchers( triggerEvent.triggerMatchers() );
-  for ( size_t iMatch = 0; iMatch < matchers.size(); ++iMatch ) {
-    theContainer[ matchers.at( iMatch ) ] = triggerMatchObject( candRef, matchers.at( iMatch ), event, triggerEvent );
+  const std::vector<std::string> matchers(triggerEvent.triggerMatchers());
+  for (size_t iMatch = 0; iMatch < matchers.size(); ++iMatch) {
+    theContainer[matchers.at(iMatch)] = triggerMatchObject(candRef, matchers.at(iMatch), event, triggerEvent);
   }
   return theContainer;
 }
 
-
 // Get a vector of references to the phyics objects matched to a certain trigger object given by a reference for a certain matcher module
 
 // ... by resulting association
-reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates( const TriggerObjectRef & objectRef, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
+reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates(const TriggerObjectRef& objectRef,
+                                                                        const TriggerObjectMatch* matchResult,
+                                                                        const edm::Event& event,
+                                                                        const TriggerEvent& triggerEvent) const {
   reco::CandidateBaseRefVector theCands;
-  if ( matchResult ) {
-    auto it = edm::makeAssociativeIterator< reco::CandidateBaseRef>( *matchResult, event );
-    auto itEnd = it.end() ;
-    while ( it != itEnd ) {
-      if ( it->first.isNonnull() && it->second.isNonnull() && it->second.isAvailable() ) {
-        if ( it->second == objectRef ) {
-          theCands.push_back( it->first );
+  if (matchResult) {
+    auto it = edm::makeAssociativeIterator<reco::CandidateBaseRef>(*matchResult, event);
+    auto itEnd = it.end();
+    while (it != itEnd) {
+      if (it->first.isNonnull() && it->second.isNonnull() && it->second.isAvailable()) {
+        if (it->second == objectRef) {
+          theCands.push_back(it->first);
         }
       }
       ++it;
@@ -76,22 +76,34 @@ reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates( const T
 }
 
 // ... by matcher module label
-reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates( const TriggerObjectRef & objectRef, const std::string & labelMatcher, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
-  return triggerMatchCandidates( objectRef, triggerEvent.triggerObjectMatchResult( labelMatcher ), event, triggerEvent );
+reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates(const TriggerObjectRef& objectRef,
+                                                                        const std::string& labelMatcher,
+                                                                        const edm::Event& event,
+                                                                        const TriggerEvent& triggerEvent) const {
+  return triggerMatchCandidates(objectRef, triggerEvent.triggerObjectMatchResult(labelMatcher), event, triggerEvent);
 }
-
 
 // Get a vector of references to the phyics objects matched to a certain trigger object given by a collection and index for a certain matcher module
 
 // ... by resulting association
-reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates( const edm::Handle< TriggerObjectCollection > & trigCollHandle, const size_t iTrig, const TriggerObjectMatch * matchResult, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
-  return triggerMatchCandidates( TriggerObjectRef( trigCollHandle, iTrig ), matchResult, event, triggerEvent );
+reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates(
+    const edm::Handle<TriggerObjectCollection>& trigCollHandle,
+    const size_t iTrig,
+    const TriggerObjectMatch* matchResult,
+    const edm::Event& event,
+    const TriggerEvent& triggerEvent) const {
+  return triggerMatchCandidates(TriggerObjectRef(trigCollHandle, iTrig), matchResult, event, triggerEvent);
 }
 
 // ... by matcher module label
-reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates( const edm::Handle< TriggerObjectCollection > & trigCollHandle, const size_t iTrig, const std::string & labelMatcher, const edm::Event & event, const TriggerEvent & triggerEvent ) const
-{
-  return triggerMatchCandidates( TriggerObjectRef( trigCollHandle, iTrig ), triggerEvent.triggerObjectMatchResult( labelMatcher ), event, triggerEvent );
+reco::CandidateBaseRefVector TriggerMatchHelper::triggerMatchCandidates(
+    const edm::Handle<TriggerObjectCollection>& trigCollHandle,
+    const size_t iTrig,
+    const std::string& labelMatcher,
+    const edm::Event& event,
+    const TriggerEvent& triggerEvent) const {
+  return triggerMatchCandidates(TriggerObjectRef(trigCollHandle, iTrig),
+                                triggerEvent.triggerObjectMatchResult(labelMatcher),
+                                event,
+                                triggerEvent);
 }

--- a/PhysicsTools/PatUtils/src/VertexAssociationSelector.cc
+++ b/PhysicsTools/PatUtils/src/VertexAssociationSelector.cc
@@ -3,37 +3,36 @@
 //#include "DataFormats/TrackReco/interface/Track.h"
 #include <cmath>
 
-pat::VertexAssociationSelector::VertexAssociationSelector(const Config & conf) : 
-    conf_(conf) 
-{
+pat::VertexAssociationSelector::VertexAssociationSelector(const Config &conf) : conf_(conf) {}
+
+pat::VertexAssociation pat::VertexAssociationSelector::simpleAssociation(const reco::Candidate &c,
+                                                                         const reco::VertexRef &vtx) const {
+  pat::VertexAssociation ret(vtx);
+  ret.setDistances(c.vertex(), vtx->position(), vtx->error());
+  return ret;
 }
 
-pat::VertexAssociation
-pat::VertexAssociationSelector::simpleAssociation(const reco::Candidate &c, const reco::VertexRef &vtx) const {    
-    pat::VertexAssociation ret(vtx);
-    ret.setDistances(c.vertex(), vtx->position(), vtx->error());
-    return ret;
-}
+bool pat::VertexAssociationSelector::operator()(const reco::Candidate &c, const reco::Vertex &vtx) const {
+  using std::abs;
+  using std::sqrt;
 
-
-bool
-pat::VertexAssociationSelector::operator()(const reco::Candidate &c, const reco::Vertex &vtx) const {    
-    using std::abs;
-    using std::sqrt;
-
-    if ((conf_.dZ > 0)      && !( std::abs(c.vz() - vtx.z())                > conf_.dZ    )) return false;
-    if ((conf_.sigmasZ > 0) && !( std::abs(c.vz() - vtx.z())                > conf_.sigmasZ * vtx.zError())) return false;
-    if ((conf_.dR > 0)      && !( (c.vertex() - vtx.position()).Rho() > conf_.dR    )) return false;
-    if ( conf_.sigmasR > 0) {
-        // D = sqrt( DZ^2 + DY^2) => sigma^2(D) = d D/d X_i * cov(X_i, X_j) * d D/d X_j =>
-        // d D / d X_i = DX_i / D
-        // D > sigmaR * sigma(D)   if and only if D^4 > sigmaR^2 * DX_i DX_j cov(X_i,X_j)
-        AlgebraicVector3 dist(c.vx() - vtx.x(), c.vy() - vtx.y(), 0);
-        double D2 = dist[0]*dist[0] + dist[1]*dist[1];
-        double DcovD = ROOT::Math::Similarity(dist, vtx.error());
-        if ( D2*D2 > DcovD * (conf_.sigmasR*conf_.sigmasR) ) return false;
-    }
-    /*
+  if ((conf_.dZ > 0) && !(std::abs(c.vz() - vtx.z()) > conf_.dZ))
+    return false;
+  if ((conf_.sigmasZ > 0) && !(std::abs(c.vz() - vtx.z()) > conf_.sigmasZ * vtx.zError()))
+    return false;
+  if ((conf_.dR > 0) && !((c.vertex() - vtx.position()).Rho() > conf_.dR))
+    return false;
+  if (conf_.sigmasR > 0) {
+    // D = sqrt( DZ^2 + DY^2) => sigma^2(D) = d D/d X_i * cov(X_i, X_j) * d D/d X_j =>
+    // d D / d X_i = DX_i / D
+    // D > sigmaR * sigma(D)   if and only if D^4 > sigmaR^2 * DX_i DX_j cov(X_i,X_j)
+    AlgebraicVector3 dist(c.vx() - vtx.x(), c.vy() - vtx.y(), 0);
+    double D2 = dist[0] * dist[0] + dist[1] * dist[1];
+    double DcovD = ROOT::Math::Similarity(dist, vtx.error());
+    if (D2 * D2 > DcovD * (conf_.sigmasR * conf_.sigmasR))
+      return false;
+  }
+  /*
     if (conf_.sigmas3d > 0) {
         // same as above, but 3D
          AlgebraicVector3 dist(c.vx() - vtx.x(), c.vy() - vtx.y(), c.vz() - vtx.z());
@@ -43,16 +42,20 @@ pat::VertexAssociationSelector::operator()(const reco::Candidate &c, const reco:
     }
     */
 
-    return true;
+  return true;
 }
 
-bool
-pat::VertexAssociationSelector::operator()(const pat::VertexAssociation &vass) const {    
-    if (vass.isNull()) return false;
-    if ((conf_.dZ > 0)       && ( vass.dz().value()         > conf_.dZ      )) return false;
-    if ((conf_.sigmasZ > 0)  && ( vass.dz().significance()  > conf_.sigmasZ )) return false;
-    if ((conf_.dZ > 0)       && ( vass.dr().value()         > conf_.dR      )) return false;
-    if ((conf_.sigmasZ > 0)  && ( vass.dr().significance()  > conf_.sigmasR )) return false;
-    // if ((conf_.sigmas3d > 0) && ( vass.signif3d()           > conf_.sigmas3d)) return false;
-    return true;
+bool pat::VertexAssociationSelector::operator()(const pat::VertexAssociation &vass) const {
+  if (vass.isNull())
+    return false;
+  if ((conf_.dZ > 0) && (vass.dz().value() > conf_.dZ))
+    return false;
+  if ((conf_.sigmasZ > 0) && (vass.dz().significance() > conf_.sigmasZ))
+    return false;
+  if ((conf_.dZ > 0) && (vass.dr().value() > conf_.dR))
+    return false;
+  if ((conf_.sigmasZ > 0) && (vass.dr().significance() > conf_.sigmasR))
+    return false;
+  // if ((conf_.sigmas3d > 0) && ( vass.signif3d()           > conf_.sigmas3d)) return false;
+  return true;
 }

--- a/PhysicsTools/PatUtils/src/bJetSelector.cc
+++ b/PhysicsTools/PatUtils/src/bJetSelector.cc
@@ -1,49 +1,37 @@
 //
-//  Implementacion of b Jet Selector for PAT 
+//  Implementacion of b Jet Selector for PAT
 //   By J.E. Ramirez Jun 18,2008
 //
 #include "PhysicsTools/PatUtils/interface/bJetSelector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-bJetSelector::bJetSelector(const edm::ParameterSet& cfg) :
-  discriminantCutsLoose_(cfg.getParameter<std::vector<double> >("discCutLoose")),
-  discriminantCutsMedium_(cfg.getParameter<std::vector<double> >("discCutMedium")),
-  discriminantCutsTight_(cfg.getParameter<std::vector<double> >("discCutTight")),
-  BTagdiscriminator_(cfg.getParameter<std::vector<std::string> >("bdiscriminators")), 
-  DefaultOp_(cfg.getParameter<std::string>("DefaultOp")),
-  DefaultTg_(cfg.getParameter<std::string>("DefaultBdisc"))
+bJetSelector::bJetSelector(const edm::ParameterSet& cfg)
+    : discriminantCutsLoose_(cfg.getParameter<std::vector<double> >("discCutLoose")),
+      discriminantCutsMedium_(cfg.getParameter<std::vector<double> >("discCutMedium")),
+      discriminantCutsTight_(cfg.getParameter<std::vector<double> >("discCutTight")),
+      BTagdiscriminator_(cfg.getParameter<std::vector<std::string> >("bdiscriminators")),
+      DefaultOp_(cfg.getParameter<std::string>("DefaultOp")),
+      DefaultTg_(cfg.getParameter<std::string>("DefaultBdisc"))
 
 {
-
-  for (unsigned int i=0; i<BTagdiscriminator_.size(); i++){
-     discCut["Loose"][BTagdiscriminator_[i]] = discriminantCutsLoose_[i];
-     discCut["Medium"][BTagdiscriminator_[i]] = discriminantCutsMedium_[i];
-     discCut["Tight"][BTagdiscriminator_[i]] = discriminantCutsTight_[i];
-  } 
+  for (unsigned int i = 0; i < BTagdiscriminator_.size(); i++) {
+    discCut["Loose"][BTagdiscriminator_[i]] = discriminantCutsLoose_[i];
+    discCut["Medium"][BTagdiscriminator_[i]] = discriminantCutsMedium_[i];
+    discCut["Tight"][BTagdiscriminator_[i]] = discriminantCutsTight_[i];
+  }
 }
 
-bool
-bJetSelector::IsbTag(const pat::Jet& JetCand, 
-                          const std::string& operpoint, 
-                          const std::string& tagger) const {
+bool bJetSelector::IsbTag(const pat::Jet& JetCand, const std::string& operpoint, const std::string& tagger) const {
+  std::map<std::string, std::map<std::string, double> >::const_iterator ioperpoint = discCut.find(operpoint);
+  if (ioperpoint == discCut.end())
+    throw cms::Exception("UnknownOperatingPoint") << "Unknown or undefined operative point" << std::endl;
+  std::map<std::string, double>::const_iterator itagger = ioperpoint->second.find(tagger);
+  if (itagger == ioperpoint->second.end())
+    throw cms::Exception("UnknownTagger") << "Unknown or undefined tagger" << std::endl;
 
-	std::map<std::string,std::map<std::string,double> >::const_iterator ioperpoint = discCut.find(operpoint);
-	if ( ioperpoint == discCut.end() ) throw cms::Exception("UnknownOperatingPoint") << "Unknown or undefined operative point" << std::endl;
-	std::map<std::string,double>::const_iterator itagger = ioperpoint->second.find(tagger);
-	if ( itagger == ioperpoint->second.end() ) throw cms::Exception("UnknownTagger") << "Unknown or undefined tagger" << std::endl;
-	
-	return JetCand.bDiscriminator(tagger) > itagger->second;
+  return JetCand.bDiscriminator(tagger) > itagger->second;
 }
-bool
-bJetSelector::IsbTag(const pat::Jet& JetCand, 
-					 const std::string& operpoint) const {
-
-	
-        return IsbTag(JetCand,operpoint,DefaultTg_);
+bool bJetSelector::IsbTag(const pat::Jet& JetCand, const std::string& operpoint) const {
+  return IsbTag(JetCand, operpoint, DefaultTg_);
 }
-bool
-bJetSelector::IsbTag(const pat::Jet& JetCand) const{ 
-        return IsbTag(JetCand,DefaultOp_,DefaultTg_);
-}
-
-
+bool bJetSelector::IsbTag(const pat::Jet& JetCand) const { return IsbTag(JetCand, DefaultOp_, DefaultTg_); }

--- a/PhysicsTools/PatUtils/src/classes.h
+++ b/PhysicsTools/PatUtils/src/classes.h
@@ -1,5 +1,7 @@
 #include "PhysicsTools/PatUtils/interface/PATDiObjectProxy.h"
 
-namespace PhysicsTools_PatUtils { struct dictionary { // apparenlty better than echo namespace PhysicsTools_PatUtils { echo namespace PhysicsTools_PatUtils {
-    pat::DiObjectProxy patDiObjectProxy; 
-}; }
+namespace PhysicsTools_PatUtils {
+  struct dictionary {  // apparenlty better than echo namespace PhysicsTools_PatUtils { echo namespace PhysicsTools_PatUtils {
+    pat::DiObjectProxy patDiObjectProxy;
+  };
+}  // namespace PhysicsTools_PatUtils

--- a/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
+++ b/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
@@ -11,46 +11,41 @@
 
 using namespace std;
 
-int main ( int argc, char ** argv )
-{
-
+int main(int argc, char** argv) {
   // load framework libraries
-  gSystem->Load( "libFWCoreFWLite" );
+  gSystem->Load("libFWCoreFWLite");
   FWLiteEnabler::enable();
 
-  if ( argc < 3 ) {
-    std::cout << "Usage : " << argv[0] 
-	      << " [your_cutflow_only.py] " 
-	      << "[cutflow_name] "<< std::endl;
+  if (argc < 3) {
+    std::cout << "Usage : " << argv[0] << " [your_cutflow_only.py] "
+              << "[cutflow_name] " << std::endl;
     return 0;
   }
 
-  if( !edm::readPSetsFrom(argv[1])->existsAs<edm::ParameterSet>(argv[2]) ){
-    std::cout << " ERROR: ParametersSet '"<< argv[2] 
-	      << "' is missing in your configuration file" 
-	      << std::endl; exit(0);
+  if (!edm::readPSetsFrom(argv[1])->existsAs<edm::ParameterSet>(argv[2])) {
+    std::cout << " ERROR: ParametersSet '" << argv[2] << "' is missing in your configuration file" << std::endl;
+    exit(0);
   }
-  
+
   edm::ParameterSet conf = edm::readPSetsFrom(argv[1])->getParameterSet(argv[2]);
   edm::ParameterSet trackedconf = conf.trackedPart();
-  
-  std::string tracked(trackedconf.dump()), untracked(conf.dump());  
 
-  if ( tracked != untracked ) {
-    throw cms::Exception("InvalidConfiguration")
-      << "IDs are not allowed to have untracked parameters"
-      << " in the configuration ParameterSet!";
+  std::string tracked(trackedconf.dump()), untracked(conf.dump());
+
+  if (tracked != untracked) {
+    throw cms::Exception("InvalidConfiguration") << "IDs are not allowed to have untracked parameters"
+                                                 << " in the configuration ParameterSet!";
   }
 
   // now setup the md5 and cute accessor functions
   unsigned char id_md5_[MD5_DIGEST_LENGTH];
-  memset(id_md5_,0,MD5_DIGEST_LENGTH*sizeof(unsigned char));
+  memset(id_md5_, 0, MD5_DIGEST_LENGTH * sizeof(unsigned char));
   MD5((const unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
-  printf("%s : ",argv[2]);
-  for( unsigned i=0; i<MD5_DIGEST_LENGTH; ++i ){
-    printf("%02x", id_md5_[i]);   
+  printf("%s : ", argv[2]);
+  for (unsigned i = 0; i < MD5_DIGEST_LENGTH; ++i) {
+    printf("%02x", id_md5_[i]);
   }
   printf("\n");
-  
+
   return 0;
 }

--- a/PhysicsTools/SelectorUtils/interface/CandidateCut.h
+++ b/PhysicsTools/SelectorUtils/interface/CandidateCut.h
@@ -8,16 +8,16 @@ namespace candidate_functions {
   class CandidateCut {
   public:
     using argument_type = reco::CandidatePtr;
-    using result_type   = bool;
+    using result_type = bool;
 
     CandidateCut() {}
     virtual result_type operator()(const argument_type&) const = 0;
     virtual ~CandidateCut() {}
-    
+
     virtual double value(const reco::CandidatePtr&) const = 0;
-    
+
     virtual const std::string& name() const = 0;
   };
-}
+}  // namespace candidate_functions
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
+++ b/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
@@ -59,7 +59,7 @@ class CutApplicatorBase : public candf::CandidateCut {
 #endif
     
   
-  result_type operator()(const argument_type&) const override
+  result_type operator()(const argument_type&) const 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     final
 #endif

--- a/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
+++ b/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
@@ -33,72 +33,66 @@ namespace reco {
   typedef edm::Ptr<reco::Photon> PhotonPtr;
   typedef edm::Ptr<reco::Muon> MuonPtr;
   typedef edm::Ptr<reco::PFTau> PFTauPtr;
-}
+}  // namespace reco
 
 namespace pat {
   typedef edm::Ptr<pat::Electron> ElectronPtr;
   typedef edm::Ptr<pat::Photon> PhotonPtr;
   typedef edm::Ptr<pat::Muon> MuonPtr;
   typedef edm::Ptr<pat::Tau> TauPtr;
-}
+}  // namespace pat
 
 class CutApplicatorBase : public candf::CandidateCut {
- public:
-  enum CandidateType{NONE,
-		     ELECTRON,MUON,PHOTON,TAU,
-		     PATELECTRON,PATMUON,PATPHOTON,PATTAU};
+public:
+  enum CandidateType { NONE, ELECTRON, MUON, PHOTON, TAU, PATELECTRON, PATMUON, PATPHOTON, PATTAU };
 
- CutApplicatorBase(): CandidateCut() {}
+  CutApplicatorBase() : CandidateCut() {}
 
- CutApplicatorBase(const edm::ParameterSet& c) :
-  _name(c.getParameter<std::string>("cutName")) {
-  }
+  CutApplicatorBase(const edm::ParameterSet& c) : _name(c.getParameter<std::string>("cutName")) {}
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   CutApplicatorBase(const CutApplicatorBase&) = delete;
   CutApplicatorBase& operator=(const CutApplicatorBase&) = delete;
 #endif
-    
-  
-  result_type operator()(const argument_type&) const 
+
+  result_type operator()(const argument_type&) const
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    final
+      final
 #endif
-    ;
-  
-  // electrons 
-  virtual result_type operator()(const reco::GsfElectronPtr&) const {return false;}
-  virtual result_type operator()(const pat::ElectronPtr&) const {return false;}
+      ;
+
+  // electrons
+  virtual result_type operator()(const reco::GsfElectronPtr&) const { return false; }
+  virtual result_type operator()(const pat::ElectronPtr&) const { return false; }
 
   // photons
-  virtual result_type operator()(const reco::PhotonPtr&) const {return false;}
-  virtual result_type operator()(const pat::PhotonPtr&) const {return false;}
-  
+  virtual result_type operator()(const reco::PhotonPtr&) const { return false; }
+  virtual result_type operator()(const pat::PhotonPtr&) const { return false; }
+
   // muons
-  virtual result_type operator()(const reco::MuonPtr&) const {return false;}
-  virtual result_type operator()(const pat::MuonPtr&) const {return false;}
+  virtual result_type operator()(const reco::MuonPtr&) const { return false; }
+  virtual result_type operator()(const pat::MuonPtr&) const { return false; }
 
   // taus
-  virtual result_type operator()(const reco::PFTauPtr&) const {return false;}
-  virtual result_type operator()(const pat::TauPtr&) const {return false;}
+  virtual result_type operator()(const reco::PFTauPtr&) const { return false; }
+  virtual result_type operator()(const pat::TauPtr&) const { return false; }
 
   // candidate operation
-  virtual result_type asCandidate(const argument_type&) const {return false;} 
-  
+  virtual result_type asCandidate(const argument_type&) const { return false; }
+
   virtual CandidateType candidateType() const { return NONE; }
 
   const std::string& name() const override { return _name; }
-  
+
   //! Destructor
   ~CutApplicatorBase() override{};
-  
- private:
+
+private:
   const std::string _name;
-  
 };
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< CutApplicatorBase* (const edm::ParameterSet&) > CutApplicatorFactory;
+typedef edmplugin::PluginFactory<CutApplicatorBase*(const edm::ParameterSet&)> CutApplicatorFactory;
 #endif
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
+++ b/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
@@ -54,11 +54,7 @@ public:
   CutApplicatorBase& operator=(const CutApplicatorBase&) = delete;
 #endif
 
-  result_type operator()(const argument_type&) const
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-      final
-#endif
-      ;
+  result_type operator()(const argument_type&) const final;
 
   // electrons
   virtual result_type operator()(const reco::GsfElectronPtr&) const { return false; }

--- a/PhysicsTools/SelectorUtils/interface/CutApplicatorWithEventContentBase.h
+++ b/PhysicsTools/SelectorUtils/interface/CutApplicatorWithEventContentBase.h
@@ -17,33 +17,29 @@
 #endif
 
 class CutApplicatorWithEventContentBase : public CutApplicatorBase {
- public:  
+public:
+  CutApplicatorWithEventContentBase() : CutApplicatorBase() {}
 
- CutApplicatorWithEventContentBase(): CutApplicatorBase() {}
-
- CutApplicatorWithEventContentBase(const edm::ParameterSet& c) :
-  CutApplicatorBase(c) {
-  }
+  CutApplicatorWithEventContentBase(const edm::ParameterSet& c) : CutApplicatorBase(c) {}
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   CutApplicatorWithEventContentBase(const CutApplicatorWithEventContentBase&) = delete;
   CutApplicatorWithEventContentBase& operator=(const CutApplicatorWithEventContentBase&) = delete;
 
-
   virtual void setConsumes(edm::ConsumesCollector&) = 0;
 #endif
 
   virtual void getEventContent(const edm::EventBase&) = 0;
-    
+
   //! Destructor
   ~CutApplicatorWithEventContentBase() override{};
-  
- protected:
+
+protected:
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-  std::unordered_map<std::string,edm::InputTag> contentTags_;
-  std::unordered_map<std::string,edm::EDGetToken> contentTokens_;
+  std::unordered_map<std::string, edm::InputTag> contentTags_;
+  std::unordered_map<std::string, edm::EDGetToken> contentTokens_;
 #else
-  std::map<std::string,edm::InputTag> contentTags_;
+  std::map<std::string, edm::InputTag> contentTags_;
 #endif
 };
 

--- a/PhysicsTools/SelectorUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h
@@ -10,65 +10,50 @@
 #include "PhysicsTools/SelectorUtils/interface/Selector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class ElectronVPlusJetsIDSelectionFunctor : public Selector<pat::Electron>  {
-
- public: // interface
-
+class ElectronVPlusJetsIDSelectionFunctor : public Selector<pat::Electron> {
+public:  // interface
   enum Version_t { SUMMER08, FIRSTDATA, N_VERSIONS };
 
   ElectronVPlusJetsIDSelectionFunctor() {}
 
 #ifndef __GCCXML__
-  ElectronVPlusJetsIDSelectionFunctor( edm::ParameterSet const & parameters, edm::ConsumesCollector& iC ) :
-    ElectronVPlusJetsIDSelectionFunctor(parameters)
-  {}
+  ElectronVPlusJetsIDSelectionFunctor(edm::ParameterSet const& parameters, edm::ConsumesCollector& iC)
+      : ElectronVPlusJetsIDSelectionFunctor(parameters) {}
 #endif
 
-  ElectronVPlusJetsIDSelectionFunctor( edm::ParameterSet const & parameters ){
-
+  ElectronVPlusJetsIDSelectionFunctor(edm::ParameterSet const& parameters) {
     std::string versionStr = parameters.getParameter<std::string>("version");
-    if ( versionStr != "FIRSTDATA") {
+    if (versionStr != "FIRSTDATA") {
       std::cout << "The version " << versionStr << " is deprecated. Setting to FIRSTDATA" << std::endl;
     }
 
     if (versionStr == "FIRSTDATA") {
-      initialize( FIRSTDATA,
-		  parameters.getParameter<double>("D0"),
-		  parameters.getParameter<double>("ED0"),
-		  parameters.getParameter<double>("SD0"),
-		  parameters.getParameter<double>("RelIso") );
-      if ( parameters.exists("cutsToIgnore") )
-	setIgnoredCuts( parameters.getParameter<std::vector<std::string> >("cutsToIgnore") );
+      initialize(FIRSTDATA,
+                 parameters.getParameter<double>("D0"),
+                 parameters.getParameter<double>("ED0"),
+                 parameters.getParameter<double>("SD0"),
+                 parameters.getParameter<double>("RelIso"));
+      if (parameters.exists("cutsToIgnore"))
+        setIgnoredCuts(parameters.getParameter<std::vector<std::string> >("cutsToIgnore"));
     } else {
       throw cms::Exception("InvalidInput") << "Expect version to be one of SUMMER08, FIRSTDATA," << std::endl;
     }
 
     retInternal_ = getBitTemplate();
-
   }
 
-
-  ElectronVPlusJetsIDSelectionFunctor( Version_t version,
-				       double d0 = 0.2,
-				       double ed0 = 999.0,
-				       double sd0 = 999.0,
-				       double reliso = 0.1) {
-    initialize( version, d0, ed0, sd0, reliso );
+  ElectronVPlusJetsIDSelectionFunctor(
+      Version_t version, double d0 = 0.2, double ed0 = 999.0, double sd0 = 999.0, double reliso = 0.1) {
+    initialize(version, d0, ed0, sd0, reliso);
   }
 
-
-  void initialize( Version_t version,
-		   double d0,
-		   double ed0,
-		   double sd0,
-		   double reliso)
-  {
+  void initialize(Version_t version, double d0, double ed0, double sd0, double reliso) {
     version_ = version;
 
-    push_back("D0",        d0);
-    push_back("ED0",       ed0);
-    push_back("SD0",       sd0);
-    push_back("RelIso",    reliso);
+    push_back("D0", d0);
+    push_back("ED0", ed0);
+    push_back("SD0", sd0);
+    push_back("RelIso", reliso);
 
     // all on by default
     set("D0");
@@ -76,18 +61,16 @@ class ElectronVPlusJetsIDSelectionFunctor : public Selector<pat::Electron>  {
     set("SD0");
     set("RelIso");
 
-
-    indexD0_            = index_type(&bits_, "D0"           );
-    indexED0_           = index_type(&bits_, "ED0"          );
-    indexSD0_           = index_type(&bits_, "SD0"          );
-    indexRelIso_        = index_type(&bits_, "RelIso"       );
-
+    indexD0_ = index_type(&bits_, "D0");
+    indexED0_ = index_type(&bits_, "ED0");
+    indexSD0_ = index_type(&bits_, "SD0");
+    indexRelIso_ = index_type(&bits_, "RelIso");
   }
 
   // Allow for multiple definitions of the cuts.
-  bool operator()( const pat::Electron & electron, pat::strbitset & ret ) override
-  {
-    if ( version_ == FIRSTDATA ) return firstDataCuts( electron, ret );
+  bool operator()(const pat::Electron& electron, pat::strbitset& ret) override {
+    if (version_ == FIRSTDATA)
+      return firstDataCuts(electron, ret);
     else {
       return false;
     }
@@ -96,40 +79,39 @@ class ElectronVPlusJetsIDSelectionFunctor : public Selector<pat::Electron>  {
   using Selector<pat::Electron>::operator();
 
   // cuts based on craft 08 analysis.
-  bool firstDataCuts( const pat::Electron & electron, pat::strbitset & ret)
-  {
-
+  bool firstDataCuts(const pat::Electron& electron, pat::strbitset& ret) {
     ret.set(false);
     double corr_d0 = electron.dB();
     double corr_ed0 = electron.edB();
-    double corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+    double corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
     double hcalIso = electron.dr03HcalTowerSumEt();
     double ecalIso = electron.dr03EcalRecHitSumEt();
-    double trkIso  = electron.dr03TkSumPt();
-    double et      = electron.et() ;
+    double trkIso = electron.dr03TkSumPt();
+    double et = electron.et();
 
     double relIso = (ecalIso + hcalIso + trkIso) / et;
 
-    if ( fabs(corr_d0) <  cut(indexD0_,     double()) || ignoreCut(indexD0_)      ) passCut(ret, indexD0_     );
-    if ( fabs(corr_ed0)<  cut(indexED0_,    double()) || ignoreCut(indexED0_)     ) passCut(ret, indexED0_    );
-    if ( fabs(corr_sd0)<  cut(indexSD0_,    double()) || ignoreCut(indexSD0_)     ) passCut(ret, indexSD0_    );
-    if ( relIso        <  cut(indexRelIso_, double()) || ignoreCut(indexRelIso_)  ) passCut(ret, indexRelIso_ );
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (fabs(corr_ed0) < cut(indexED0_, double()) || ignoreCut(indexED0_))
+      passCut(ret, indexED0_);
+    if (fabs(corr_sd0) < cut(indexSD0_, double()) || ignoreCut(indexSD0_))
+      passCut(ret, indexSD0_);
+    if (relIso < cut(indexRelIso_, double()) || ignoreCut(indexRelIso_))
+      passCut(ret, indexRelIso_);
 
     setIgnored(ret);
     return (bool)ret;
   }
 
-
- private: // member variables
-
+private:  // member variables
   Version_t version_;
 
   index_type indexD0_;
   index_type indexED0_;
   index_type indexSD0_;
   index_type indexRelIso_;
-
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/EventSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/EventSelector.h
@@ -11,11 +11,9 @@
   \version  $Id: EventSelector.h,v 1.1 2009/12/21 19:27:08 srappocc Exp $
 */
 
-
 #include "PhysicsTools/SelectorUtils/interface/Selector.h"
 #include <fstream>
 #include <functional>
-
 
 typedef Selector<edm::EventBase> EventSelector;
 

--- a/PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_PatUtils_interface_JetIDSelectionFunctor_h
 #define PhysicsTools_PatUtils_interface_JetIDSelectionFunctor_h
 
-
 /**
   \class    JetIDSelectionFunctor JetIDSelectionFunctor.h "PhysicsTools/Utilities/interface/JetIDSelectionFunctor.h"
   \brief    Jet selector for pat::Jets and for CaloJets
@@ -16,9 +15,6 @@
   \version  $Id: JetIDSelectionFunctor.h,v 1.15 2010/08/31 20:31:50 srappocc Exp $
 */
 
-
-
-
 #ifndef __GCCXML__
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #endif
@@ -29,56 +25,49 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <TMath.h>
-class JetIDSelectionFunctor : public Selector<pat::Jet>  {
-
- public: // interface
-
+class JetIDSelectionFunctor : public Selector<pat::Jet> {
+public:  // interface
   enum Version_t { CRAFT08, PURE09, DQM09, N_VERSIONS };
-  enum Quality_t { MINIMAL, LOOSE_AOD, LOOSE, TIGHT, N_QUALITY};
+  enum Quality_t { MINIMAL, LOOSE_AOD, LOOSE, TIGHT, N_QUALITY };
 
   JetIDSelectionFunctor() {}
 
 #ifndef __GCCXML__
-  JetIDSelectionFunctor( edm::ParameterSet const & parameters, edm::ConsumesCollector& iC ) :
-    JetIDSelectionFunctor(parameters)
-  {}
+  JetIDSelectionFunctor(edm::ParameterSet const& parameters, edm::ConsumesCollector& iC)
+      : JetIDSelectionFunctor(parameters) {}
 #endif
 
-
-  JetIDSelectionFunctor( edm::ParameterSet const & parameters ) {
+  JetIDSelectionFunctor(edm::ParameterSet const& parameters) {
     std::string versionStr = parameters.getParameter<std::string>("version");
     std::string qualityStr = parameters.getParameter<std::string>("quality");
     Quality_t quality = N_QUALITY;
 
-    if      ( qualityStr == "MINIMAL" )   quality = MINIMAL;
-    else if ( qualityStr == "LOOSE_AOD" ) quality = LOOSE_AOD;
-    else if ( qualityStr == "LOOSE" )     quality = LOOSE;
-    else if ( qualityStr == "TIGHT" )     quality = TIGHT;
+    if (qualityStr == "MINIMAL")
+      quality = MINIMAL;
+    else if (qualityStr == "LOOSE_AOD")
+      quality = LOOSE_AOD;
+    else if (qualityStr == "LOOSE")
+      quality = LOOSE;
+    else if (qualityStr == "TIGHT")
+      quality = TIGHT;
     else
-      throw cms::Exception("InvalidInput") << "Expect quality to be one of MINIMAL, LOOSE_AOD, LOOSE,TIGHT" << std::endl;
+      throw cms::Exception("InvalidInput")
+          << "Expect quality to be one of MINIMAL, LOOSE_AOD, LOOSE,TIGHT" << std::endl;
 
-
-    if ( versionStr == "CRAFT08" ) {
-      initialize( CRAFT08, quality );
-    }
-    else if ( versionStr == "PURE09" ) {
-      initialize( PURE09, quality );
-    }
-    else if ( versionStr == "DQM09" ) {
-      initialize( DQM09, quality );
-    }
-    else {
+    if (versionStr == "CRAFT08") {
+      initialize(CRAFT08, quality);
+    } else if (versionStr == "PURE09") {
+      initialize(PURE09, quality);
+    } else if (versionStr == "DQM09") {
+      initialize(DQM09, quality);
+    } else {
       throw cms::Exception("InvalidInput") << "Expect version to be one of CRAFT08, PURE09, DQM09" << std::endl;
     }
   }
 
-  JetIDSelectionFunctor( Version_t version, Quality_t quality ) {
-    initialize(version, quality);
-  }
+  JetIDSelectionFunctor(Version_t version, Quality_t quality) { initialize(version, quality); }
 
- void initialize( Version_t version, Quality_t quality )
-  {
-
+  void initialize(Version_t version, Quality_t quality) {
     version_ = version;
     quality_ = quality;
 
@@ -108,62 +97,58 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
     push_back("EF_N90Hits");
     push_back("EF_EMF");
 
-
-    bool use_09_fwd_id = version_ != CRAFT08; // CRAFT08 predates the 09 forward ID cuts
+    bool use_09_fwd_id = version_ != CRAFT08;  // CRAFT08 predates the 09 forward ID cuts
     bool use_dqm_09 = version_ == DQM09 && quality_ != LOOSE_AOD;
 
     // all appropriate for version and format (AOD complications) are on by default
-    set( "MINIMAL_EMF" );
-    set( "LOOSE_AOD_fHPD" );
-    set( "LOOSE_AOD_N90Hits" );
-    set( "LOOSE_AOD_EMF", ! use_09_fwd_id ); // except in CRAFT08, this devolves into MINIMAL_EMF
-    set( "LOOSE_fHPD" );
-    set( "LOOSE_N90Hits" );
-    set( "LOOSE_EMF", ! use_09_fwd_id ); // except in CRAFT08, this devolves into MINIMAL_EMF
-    set( "TIGHT_fHPD" );
-    set( "TIGHT_EMF" );
+    set("MINIMAL_EMF");
+    set("LOOSE_AOD_fHPD");
+    set("LOOSE_AOD_N90Hits");
+    set("LOOSE_AOD_EMF", !use_09_fwd_id);  // except in CRAFT08, this devolves into MINIMAL_EMF
+    set("LOOSE_fHPD");
+    set("LOOSE_N90Hits");
+    set("LOOSE_EMF", !use_09_fwd_id);  // except in CRAFT08, this devolves into MINIMAL_EMF
+    set("TIGHT_fHPD");
+    set("TIGHT_EMF");
 
-    set( "LOOSE_nHit", use_09_fwd_id );
-    set( "LOOSE_als", use_09_fwd_id );
-    set( "TIGHT_nHit", use_09_fwd_id );
-    set( "TIGHT_als", use_09_fwd_id );
-    set( "widths", use_09_fwd_id );
-    set( "EF_N90Hits", use_09_fwd_id );
-    set( "EF_EMF", use_09_fwd_id );
+    set("LOOSE_nHit", use_09_fwd_id);
+    set("LOOSE_als", use_09_fwd_id);
+    set("TIGHT_nHit", use_09_fwd_id);
+    set("TIGHT_als", use_09_fwd_id);
+    set("widths", use_09_fwd_id);
+    set("EF_N90Hits", use_09_fwd_id);
+    set("EF_EMF", use_09_fwd_id);
 
-    set( "LOOSE_fls", use_dqm_09 );
-    set( "LOOSE_foot", use_dqm_09 );
-    set( "TIGHT_fls", use_dqm_09 );
-    set( "TIGHT_foot", use_dqm_09 );
+    set("LOOSE_fls", use_dqm_09);
+    set("LOOSE_foot", use_dqm_09);
+    set("TIGHT_fls", use_dqm_09);
+    set("TIGHT_foot", use_dqm_09);
 
+    index_MINIMAL_EMF_ = index_type(&bits_, "MINIMAL_EMF");
 
-
-
-    index_MINIMAL_EMF_       = index_type(&bits_, "MINIMAL_EMF");
-
-    index_LOOSE_AOD_fHPD_    = index_type(&bits_, "LOOSE_AOD_fHPD");
+    index_LOOSE_AOD_fHPD_ = index_type(&bits_, "LOOSE_AOD_fHPD");
     index_LOOSE_AOD_N90Hits_ = index_type(&bits_, "LOOSE_AOD_N90Hits");
-    index_LOOSE_AOD_EMF_     = index_type(&bits_, "LOOSE_AOD_EMF");
+    index_LOOSE_AOD_EMF_ = index_type(&bits_, "LOOSE_AOD_EMF");
 
-    index_LOOSE_fHPD_        = index_type(&bits_, "LOOSE_fHPD");
-    index_LOOSE_N90Hits_     = index_type(&bits_, "LOOSE_N90Hits");
-    index_LOOSE_EMF_         = index_type(&bits_, "LOOSE_EMF");
+    index_LOOSE_fHPD_ = index_type(&bits_, "LOOSE_fHPD");
+    index_LOOSE_N90Hits_ = index_type(&bits_, "LOOSE_N90Hits");
+    index_LOOSE_EMF_ = index_type(&bits_, "LOOSE_EMF");
 
-    index_TIGHT_fHPD_        = index_type(&bits_, "TIGHT_fHPD");
-    index_TIGHT_EMF_         = index_type(&bits_, "TIGHT_EMF");
+    index_TIGHT_fHPD_ = index_type(&bits_, "TIGHT_fHPD");
+    index_TIGHT_EMF_ = index_type(&bits_, "TIGHT_EMF");
 
-    index_LOOSE_nHit_        = index_type(&bits_, "LOOSE_nHit");
-    index_LOOSE_als_         = index_type(&bits_, "LOOSE_als");
-    index_LOOSE_fls_         = index_type(&bits_, "LOOSE_fls");
-    index_LOOSE_foot_        = index_type(&bits_, "LOOSE_foot");
+    index_LOOSE_nHit_ = index_type(&bits_, "LOOSE_nHit");
+    index_LOOSE_als_ = index_type(&bits_, "LOOSE_als");
+    index_LOOSE_fls_ = index_type(&bits_, "LOOSE_fls");
+    index_LOOSE_foot_ = index_type(&bits_, "LOOSE_foot");
 
-    index_TIGHT_nHit_        = index_type(&bits_, "TIGHT_nHit");
-    index_TIGHT_als_         = index_type(&bits_, "TIGHT_als");
-    index_TIGHT_fls_         = index_type(&bits_, "TIGHT_fls");
-    index_TIGHT_foot_        = index_type(&bits_, "TIGHT_foot");
-    index_widths_            = index_type(&bits_, "widths");
-    index_EF_N90Hits_        = index_type(&bits_, "EF_N90Hits");
-    index_EF_EMF_            = index_type(&bits_, "EF_EMF");
+    index_TIGHT_nHit_ = index_type(&bits_, "TIGHT_nHit");
+    index_TIGHT_als_ = index_type(&bits_, "TIGHT_als");
+    index_TIGHT_fls_ = index_type(&bits_, "TIGHT_fls");
+    index_TIGHT_foot_ = index_type(&bits_, "TIGHT_foot");
+    index_widths_ = index_type(&bits_, "widths");
+    index_EF_N90Hits_ = index_type(&bits_, "EF_N90Hits");
+    index_EF_EMF_ = index_type(&bits_, "EF_EMF");
 
     // now set the return values for the ignored parts
     bool use_loose_aod = false;
@@ -172,65 +157,67 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
     bool use_tight_09_fwd_id = false;
     bool use_loose_09_fwd_id = false;
     // if ( quality_ == MINIMAL ) nothing to do...
-    if ( quality_ == LOOSE ) {
+    if (quality_ == LOOSE) {
       use_loose = true;
-      if( use_09_fwd_id ) use_loose_09_fwd_id = true;
+      if (use_09_fwd_id)
+        use_loose_09_fwd_id = true;
     }
-    if ( quality_ == LOOSE_AOD ) {
+    if (quality_ == LOOSE_AOD) {
       use_loose_aod = true;
-      if( use_09_fwd_id ) use_loose_09_fwd_id = true;
+      if (use_09_fwd_id)
+        use_loose_09_fwd_id = true;
     }
-    if ( quality_ == TIGHT ) {
+    if (quality_ == TIGHT) {
       use_tight = true;
-      if( use_09_fwd_id ) use_tight_09_fwd_id = true;
+      if (use_09_fwd_id)
+        use_tight_09_fwd_id = true;
     }
 
-    if( ! use_loose_aod ) {
-      set("LOOSE_AOD_fHPD", false );
-      set("LOOSE_AOD_N90Hits", false );
-      set("LOOSE_AOD_EMF", false );
+    if (!use_loose_aod) {
+      set("LOOSE_AOD_fHPD", false);
+      set("LOOSE_AOD_N90Hits", false);
+      set("LOOSE_AOD_EMF", false);
     }
 
-    if( ! ( use_loose || use_tight ) ) { // the CRAFT08 cuts are cumulative
-      set("LOOSE_N90Hits", false );
-      set("LOOSE_fHPD", false );
-      set("LOOSE_EMF", false );
+    if (!(use_loose || use_tight)) {  // the CRAFT08 cuts are cumulative
+      set("LOOSE_N90Hits", false);
+      set("LOOSE_fHPD", false);
+      set("LOOSE_EMF", false);
     }
 
-    if( ! use_tight ) {
-      set("TIGHT_fHPD", false );
-      set("TIGHT_EMF", false );
+    if (!use_tight) {
+      set("TIGHT_fHPD", false);
+      set("TIGHT_EMF", false);
     }
 
-    if( ! use_loose_09_fwd_id ) { // the FWD09 cuts are not
-      set( "LOOSE_nHit", false );
-      set( "LOOSE_als", false );
-      if( use_dqm_09 ) {
-	set( "LOOSE_fls", false );
-	set( "LOOSE_foot", false );
+    if (!use_loose_09_fwd_id) {  // the FWD09 cuts are not
+      set("LOOSE_nHit", false);
+      set("LOOSE_als", false);
+      if (use_dqm_09) {
+        set("LOOSE_fls", false);
+        set("LOOSE_foot", false);
       }
-    } // not using loose 09 fwd ID
+    }  // not using loose 09 fwd ID
 
-    if( ! use_tight_09_fwd_id ) {
-      set( "TIGHT_nHit", false );
-      set( "TIGHT_als", false );
-      set( "widths", false );
-      set( "EF_N90Hits", false );
-      set( "EF_EMF", false );
-      if( use_dqm_09 ) {
-	set( "TIGHT_fls", false );
-	set( "TIGHT_foot", false );
+    if (!use_tight_09_fwd_id) {
+      set("TIGHT_nHit", false);
+      set("TIGHT_als", false);
+      set("widths", false);
+      set("EF_N90Hits", false);
+      set("EF_EMF", false);
+      if (use_dqm_09) {
+        set("TIGHT_fls", false);
+        set("TIGHT_foot", false);
       }
-    } // not using tight 09 fwd ID
+    }  // not using tight 09 fwd ID
 
     retInternal_ = getBitTemplate();
   }
 
   // this functionality should be migrated into JetIDHelper in future releases
-  unsigned int count_hits( const std::vector<CaloTowerPtr> & towers )
-  {
+  unsigned int count_hits(const std::vector<CaloTowerPtr>& towers) {
     unsigned int nHit = 0;
-    for ( unsigned int iTower = 0; iTower < towers.size() ; ++iTower ) {
+    for (unsigned int iTower = 0; iTower < towers.size(); ++iTower) {
       const std::vector<DetId>& cellIDs = towers[iTower]->constituents();  // cell == recHit
       nHit += cellIDs.size();
     }
@@ -240,25 +227,29 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   // Accessor from PAT jets
   //
-  bool operator()( const pat::Jet & jet, pat::strbitset & ret ) override
-  {
-    if ( ! jet.isCaloJet() && !jet.isJPTJet() ) {
-      edm::LogWarning( "NYI" )<<"Criteria for pat::Jet-s other than CaloJets and JPTJets are not yet implemented";
+  bool operator()(const pat::Jet& jet, pat::strbitset& ret) override {
+    if (!jet.isCaloJet() && !jet.isJPTJet()) {
+      edm::LogWarning("NYI") << "Criteria for pat::Jet-s other than CaloJets and JPTJets are not yet implemented";
       return false;
     }
-    if ( version_ == CRAFT08 ) return craft08Cuts( jet.p4(), jet.emEnergyFraction(), jet.jetID(), ret );
-    if ( version_ == PURE09 || version_ == DQM09 ) {
-      unsigned int nHit = count_hits( jet.getCaloConstituents() );
-      if ( jet.currentJECLevel() == "Uncorrected" ) {
-	return fwd09Cuts( jet.p4(), jet.emEnergyFraction(), jet.etaetaMoment(), jet.phiphiMoment(), nHit,
-			  jet.jetID(), ret );
-      }
-      else {
-	return fwd09Cuts( jet.correctedP4("Uncorrected"), jet.emEnergyFraction(), jet.etaetaMoment(), jet.phiphiMoment(), nHit,
-			  jet.jetID(), ret );
+    if (version_ == CRAFT08)
+      return craft08Cuts(jet.p4(), jet.emEnergyFraction(), jet.jetID(), ret);
+    if (version_ == PURE09 || version_ == DQM09) {
+      unsigned int nHit = count_hits(jet.getCaloConstituents());
+      if (jet.currentJECLevel() == "Uncorrected") {
+        return fwd09Cuts(
+            jet.p4(), jet.emEnergyFraction(), jet.etaetaMoment(), jet.phiphiMoment(), nHit, jet.jetID(), ret);
+      } else {
+        return fwd09Cuts(jet.correctedP4("Uncorrected"),
+                         jet.emEnergyFraction(),
+                         jet.etaetaMoment(),
+                         jet.phiphiMoment(),
+                         nHit,
+                         jet.jetID(),
+                         ret);
       }
     }
-    edm::LogWarning( "BadInput | NYI" )<<"Requested version ("<<version_<<") is unknown";
+    edm::LogWarning("BadInput | NYI") << "Requested version (" << version_ << ") is unknown";
     return false;
   }
 
@@ -269,23 +260,22 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
   // Accessor from *CORRECTED* 4-vector, EMF, and Jet ID.
   // This can be used with reco quantities.
   //
-  bool operator()( reco::Candidate::LorentzVector const & correctedP4,
-		   double emEnergyFraction,
-		   reco::JetID const & jetID,
-		   pat::strbitset & ret )
-  {
-    if ( version_ == CRAFT08 ) return craft08Cuts( correctedP4, emEnergyFraction, jetID, ret );
-    edm::LogWarning( "BadInput | NYI" )<<"Requested version ("<<version_
-				       <<") is unknown or doesn't match the depreceated interface used";
+  bool operator()(reco::Candidate::LorentzVector const& correctedP4,
+                  double emEnergyFraction,
+                  reco::JetID const& jetID,
+                  pat::strbitset& ret) {
+    if (version_ == CRAFT08)
+      return craft08Cuts(correctedP4, emEnergyFraction, jetID, ret);
+    edm::LogWarning("BadInput | NYI") << "Requested version (" << version_
+                                      << ") is unknown or doesn't match the depreceated interface used";
     return false;
   }
   /// accessor like previous, without the ret
-  virtual bool operator()( reco::Candidate::LorentzVector const & correctedP4,
-			   double emEnergyFraction,
-			   reco::JetID const & jetID )
-  {
+  virtual bool operator()(reco::Candidate::LorentzVector const& correctedP4,
+                          double emEnergyFraction,
+                          reco::JetID const& jetID) {
     retInternal_.set(false);
-    operator()(correctedP4,emEnergyFraction, jetID, retInternal_);
+    operator()(correctedP4, emEnergyFraction, jetID, retInternal_);
     setIgnored(retInternal_);
     return (bool)retInternal_;
   }
@@ -294,24 +284,19 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
   // Accessor from CaloJet and Jet ID. Jets MUST BE corrected for craft08, but uncorrected for later cuts...
   // This can be used with reco quantities.
   //
-  bool operator()( reco::CaloJet const & jet,
-		   reco::JetID const & jetID,
-		   pat::strbitset & ret )
-  {
-    if ( version_ == CRAFT08 ) return craft08Cuts( jet.p4(), jet.emEnergyFraction(), jetID, ret );
-    if ( version_ == PURE09 || version_ == DQM09 ) {
-      unsigned int nHit = count_hits( jet.getCaloConstituents() );
-      return fwd09Cuts( jet.p4(), jet.emEnergyFraction(), jet.etaetaMoment(), jet.phiphiMoment(), nHit,
-			jetID, ret );
+  bool operator()(reco::CaloJet const& jet, reco::JetID const& jetID, pat::strbitset& ret) {
+    if (version_ == CRAFT08)
+      return craft08Cuts(jet.p4(), jet.emEnergyFraction(), jetID, ret);
+    if (version_ == PURE09 || version_ == DQM09) {
+      unsigned int nHit = count_hits(jet.getCaloConstituents());
+      return fwd09Cuts(jet.p4(), jet.emEnergyFraction(), jet.etaetaMoment(), jet.phiphiMoment(), nHit, jetID, ret);
     }
-    edm::LogWarning( "BadInput | NYI" )<<"Requested version ("<<version_<<") is unknown";
+    edm::LogWarning("BadInput | NYI") << "Requested version (" << version_ << ") is unknown";
     return false;
   }
 
   /// accessor like previous, without the ret
-  virtual bool operator()( reco::CaloJet const & jet,
-			   reco::JetID const & jetID )
-  {
+  virtual bool operator()(reco::CaloJet const& jet, reco::JetID const& jetID) {
     retInternal_.set(false);
     operator()(jet, jetID, retInternal_);
     setIgnored(retInternal_);
@@ -321,83 +306,106 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   // cuts based on craft 08 analysis.
   //
-  bool craft08Cuts( reco::Candidate::LorentzVector const & correctedP4,
-		    double emEnergyFraction,
-		    reco::JetID const & jetID,
-		    pat::strbitset & ret)
-  {
-
+  bool craft08Cuts(reco::Candidate::LorentzVector const& correctedP4,
+                   double emEnergyFraction,
+                   reco::JetID const& jetID,
+                   pat::strbitset& ret) {
     ret.set(false);
 
     // cache some variables
-    double abs_eta = TMath::Abs( correctedP4.eta() );
+    double abs_eta = TMath::Abs(correctedP4.eta());
     double corrPt = correctedP4.pt();
     double emf = emEnergyFraction;
 
-    if ( ignoreCut(index_MINIMAL_EMF_) || abs_eta > 2.6 || emf > 0.01 ) passCut( ret, index_MINIMAL_EMF_);
+    if (ignoreCut(index_MINIMAL_EMF_) || abs_eta > 2.6 || emf > 0.01)
+      passCut(ret, index_MINIMAL_EMF_);
 
-    if ( quality_ == LOOSE_AOD ) {
+    if (quality_ == LOOSE_AOD) {
       // loose fhpd cut from aod
-      if ( ignoreCut(index_LOOSE_AOD_fHPD_)    || jetID.approximatefHPD < 0.98 ) passCut( ret, index_LOOSE_AOD_fHPD_);
+      if (ignoreCut(index_LOOSE_AOD_fHPD_) || jetID.approximatefHPD < 0.98)
+        passCut(ret, index_LOOSE_AOD_fHPD_);
       // loose n90 hits cut
-      if ( ignoreCut(index_LOOSE_AOD_N90Hits_) || jetID.hitsInN90 > 1 ) passCut( ret, index_LOOSE_AOD_N90Hits_);
+      if (ignoreCut(index_LOOSE_AOD_N90Hits_) || jetID.hitsInN90 > 1)
+        passCut(ret, index_LOOSE_AOD_N90Hits_);
 
       // loose EMF Cut from aod
       bool emf_loose = true;
-      if( abs_eta <= 2.6 ) { // HBHE
-	if( emEnergyFraction <= 0.01 ) emf_loose = false;
-      } else {                // HF
-	if( emEnergyFraction <= -0.9 ) emf_loose = false;
-	if( corrPt > 80 && emEnergyFraction >= 1 ) emf_loose = false;
+      if (abs_eta <= 2.6) {  // HBHE
+        if (emEnergyFraction <= 0.01)
+          emf_loose = false;
+      } else {  // HF
+        if (emEnergyFraction <= -0.9)
+          emf_loose = false;
+        if (corrPt > 80 && emEnergyFraction >= 1)
+          emf_loose = false;
       }
-      if ( ignoreCut(index_LOOSE_AOD_EMF_) || emf_loose ) passCut(ret, index_LOOSE_AOD_EMF_);
+      if (ignoreCut(index_LOOSE_AOD_EMF_) || emf_loose)
+        passCut(ret, index_LOOSE_AOD_EMF_);
 
-    }
-    else if ( quality_ == LOOSE || quality_ == TIGHT ) {
+    } else if (quality_ == LOOSE || quality_ == TIGHT) {
       // loose fhpd cut
-      if ( ignoreCut(index_LOOSE_fHPD_)    || jetID.fHPD < 0.98 ) passCut( ret, index_LOOSE_fHPD_);
+      if (ignoreCut(index_LOOSE_fHPD_) || jetID.fHPD < 0.98)
+        passCut(ret, index_LOOSE_fHPD_);
       // loose n90 hits cut
-      if ( ignoreCut(index_LOOSE_N90Hits_) || jetID.n90Hits > 1 ) passCut( ret, index_LOOSE_N90Hits_);
+      if (ignoreCut(index_LOOSE_N90Hits_) || jetID.n90Hits > 1)
+        passCut(ret, index_LOOSE_N90Hits_);
 
       // loose EMF Cut
       bool emf_loose = true;
-      if( abs_eta <= 2.6 ) { // HBHE
-	if( emEnergyFraction <= 0.01 ) emf_loose = false;
-      } else {                // HF
-	if( emEnergyFraction <= -0.9 ) emf_loose = false;
-	if( corrPt > 80 && emEnergyFraction >= 1 ) emf_loose = false;
+      if (abs_eta <= 2.6) {  // HBHE
+        if (emEnergyFraction <= 0.01)
+          emf_loose = false;
+      } else {  // HF
+        if (emEnergyFraction <= -0.9)
+          emf_loose = false;
+        if (corrPt > 80 && emEnergyFraction >= 1)
+          emf_loose = false;
       }
-      if ( ignoreCut(index_LOOSE_EMF_) || emf_loose ) passCut(ret, index_LOOSE_EMF_);
+      if (ignoreCut(index_LOOSE_EMF_) || emf_loose)
+        passCut(ret, index_LOOSE_EMF_);
 
-      if ( quality_ == TIGHT ) {
-	// tight fhpd cut
-	bool tight_fhpd = true;
-	if ( corrPt >= 25 && jetID.fHPD >= 0.95 ) tight_fhpd = false; // this was supposed to use raw pT, see AN2009/087 :-(
-	if ( ignoreCut(index_TIGHT_fHPD_) || tight_fhpd ) passCut(ret, index_TIGHT_fHPD_);
+      if (quality_ == TIGHT) {
+        // tight fhpd cut
+        bool tight_fhpd = true;
+        if (corrPt >= 25 && jetID.fHPD >= 0.95)
+          tight_fhpd = false;  // this was supposed to use raw pT, see AN2009/087 :-(
+        if (ignoreCut(index_TIGHT_fHPD_) || tight_fhpd)
+          passCut(ret, index_TIGHT_fHPD_);
 
-	// tight emf cut
-	bool tight_emf = true;
-	if( abs_eta >= 1 && corrPt >= 80 && emEnergyFraction >= 1 ) tight_emf = false; // outside HB
-	if( abs_eta >= 2.6 ) { // outside HBHE
-	  if( emEnergyFraction <= -0.3 ) tight_emf = false;
-	  if( abs_eta < 3.25 ) { // HE-HF transition region
-	    if( corrPt >= 50 && emEnergyFraction <= -0.2 ) tight_emf = false;
-	    if( corrPt >= 80 && emEnergyFraction <= -0.1 ) tight_emf = false;
-	    if( corrPt >= 340 && emEnergyFraction >= 0.95 ) tight_emf = false;
-	  } else { // HF
-	    if( emEnergyFraction >= 0.9 ) tight_emf = false;
-	    if( corrPt >= 50 && emEnergyFraction <= -0.2 ) tight_emf = false;
-	    if( corrPt >= 50 && emEnergyFraction >= 0.8 ) tight_emf = false;
-	    if( corrPt >= 130 && emEnergyFraction <= -0.1 ) tight_emf = false;
-	    if( corrPt >= 130 && emEnergyFraction >= 0.7 ) tight_emf = false;
+        // tight emf cut
+        bool tight_emf = true;
+        if (abs_eta >= 1 && corrPt >= 80 && emEnergyFraction >= 1)
+          tight_emf = false;   // outside HB
+        if (abs_eta >= 2.6) {  // outside HBHE
+          if (emEnergyFraction <= -0.3)
+            tight_emf = false;
+          if (abs_eta < 3.25) {  // HE-HF transition region
+            if (corrPt >= 50 && emEnergyFraction <= -0.2)
+              tight_emf = false;
+            if (corrPt >= 80 && emEnergyFraction <= -0.1)
+              tight_emf = false;
+            if (corrPt >= 340 && emEnergyFraction >= 0.95)
+              tight_emf = false;
+          } else {  // HF
+            if (emEnergyFraction >= 0.9)
+              tight_emf = false;
+            if (corrPt >= 50 && emEnergyFraction <= -0.2)
+              tight_emf = false;
+            if (corrPt >= 50 && emEnergyFraction >= 0.8)
+              tight_emf = false;
+            if (corrPt >= 130 && emEnergyFraction <= -0.1)
+              tight_emf = false;
+            if (corrPt >= 130 && emEnergyFraction >= 0.7)
+              tight_emf = false;
 
-	  } // end if HF
-	}// end if outside HBHE
-	if ( ignoreCut(index_TIGHT_EMF_) || tight_emf ) passCut(ret, index_TIGHT_EMF_);
-      }// end if tight
-    }// end if loose or tight
+          }  // end if HF
+        }    // end if outside HBHE
+        if (ignoreCut(index_TIGHT_EMF_) || tight_emf)
+          passCut(ret, index_TIGHT_EMF_);
+      }  // end if tight
+    }    // end if loose or tight
 
-    setIgnored( ret );
+    setIgnored(ret);
 
     return (bool)ret;
   }
@@ -405,145 +413,145 @@ class JetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   // cuts based on craft 08 analysis + forward jet ID based on 09 data
   //
-  bool fwd09Cuts( reco::Candidate::LorentzVector const & rawP4,
-		  double emEnergyFraction, double etaWidth, double phiWidth, unsigned int nHit,
-		  reco::JetID const & jetID,
-		  pat::strbitset & ret)
-  {
+  bool fwd09Cuts(reco::Candidate::LorentzVector const& rawP4,
+                 double emEnergyFraction,
+                 double etaWidth,
+                 double phiWidth,
+                 unsigned int nHit,
+                 reco::JetID const& jetID,
+                 pat::strbitset& ret) {
     ret.set(false);
 
     // cache some variables
-    double abs_eta = TMath::Abs( rawP4.eta() );
+    double abs_eta = TMath::Abs(rawP4.eta());
     double rawPt = rawP4.pt();
     double emf = emEnergyFraction;
     double fhf = jetID.fLong + jetID.fShort;
-    double lnpt = ( rawPt > 0 ) ? TMath::Log( rawPt ) : -10;
-    double lnE = ( rawP4.energy() > 0 ) ? TMath::Log( rawP4.energy() ) : -10;
+    double lnpt = (rawPt > 0) ? TMath::Log(rawPt) : -10;
+    double lnE = (rawP4.energy() > 0) ? TMath::Log(rawP4.energy()) : -10;
 
     bool HB = abs_eta < 1.0;
     bool EF = 2.6 <= abs_eta && abs_eta < 3.4 && 0.1 <= fhf && fhf < 0.9;
-    bool HBHE = abs_eta < 2.6 || ( abs_eta < 3.4 && fhf < 0.1 );
-    bool HF = 3.4 <= abs_eta  || ( 2.6 <= abs_eta && 0.9 <= fhf );
+    bool HBHE = abs_eta < 2.6 || (abs_eta < 3.4 && fhf < 0.1);
+    bool HF = 3.4 <= abs_eta || (2.6 <= abs_eta && 0.9 <= fhf);
     bool HFa = HF && abs_eta < 3.8;
-    bool HFb = HF && ! HFa;
+    bool HFb = HF && !HFa;
 
     // HBHE cuts as in CRAFT08
     // - but using raw pTs
     // ========================
 
-    if ( (!HBHE) || ignoreCut(index_MINIMAL_EMF_) || emf > 0.01 ) passCut( ret, index_MINIMAL_EMF_);
+    if ((!HBHE) || ignoreCut(index_MINIMAL_EMF_) || emf > 0.01)
+      passCut(ret, index_MINIMAL_EMF_);
 
     // loose fhpd cut from AOD
-    if ( (!HBHE) || ignoreCut(index_LOOSE_AOD_fHPD_) || jetID.approximatefHPD < 0.98 ) passCut( ret, index_LOOSE_AOD_fHPD_);
+    if ((!HBHE) || ignoreCut(index_LOOSE_AOD_fHPD_) || jetID.approximatefHPD < 0.98)
+      passCut(ret, index_LOOSE_AOD_fHPD_);
     // loose n90 hits cut from AOD
-    if ( (!HBHE) || ignoreCut(index_LOOSE_AOD_N90Hits_) || jetID.hitsInN90 > 1 ) passCut( ret, index_LOOSE_AOD_N90Hits_);
+    if ((!HBHE) || ignoreCut(index_LOOSE_AOD_N90Hits_) || jetID.hitsInN90 > 1)
+      passCut(ret, index_LOOSE_AOD_N90Hits_);
 
     // loose fhpd cut
-    if ( (!HBHE) || ignoreCut(index_LOOSE_fHPD_) || jetID.fHPD < 0.98 ) passCut( ret, index_LOOSE_fHPD_);
+    if ((!HBHE) || ignoreCut(index_LOOSE_fHPD_) || jetID.fHPD < 0.98)
+      passCut(ret, index_LOOSE_fHPD_);
     // loose n90 hits cut
-    if ( (!HBHE) || ignoreCut(index_LOOSE_N90Hits_) || jetID.n90Hits > 1 ) passCut( ret, index_LOOSE_N90Hits_);
+    if ((!HBHE) || ignoreCut(index_LOOSE_N90Hits_) || jetID.n90Hits > 1)
+      passCut(ret, index_LOOSE_N90Hits_);
 
     // tight fhpd cut
-    if ( (!HBHE) || ignoreCut(index_TIGHT_fHPD_) || rawPt < 25 || jetID.fHPD < 0.95 ) passCut(ret, index_TIGHT_fHPD_);
+    if ((!HBHE) || ignoreCut(index_TIGHT_fHPD_) || rawPt < 25 || jetID.fHPD < 0.95)
+      passCut(ret, index_TIGHT_fHPD_);
 
     // tight emf cut
-    if ( (!HBHE) || ignoreCut(index_TIGHT_EMF_) || HB || rawPt < 55 || emf < 1 ) passCut(ret, index_TIGHT_EMF_);
-
+    if ((!HBHE) || ignoreCut(index_TIGHT_EMF_) || HB || rawPt < 55 || emf < 1)
+      passCut(ret, index_TIGHT_EMF_);
 
     // EF - these cuts are only used in "tight", but there's no need for this test here.
 
-    if( (!EF) || ignoreCut( index_EF_N90Hits_ )
-	|| jetID.n90Hits > 1 + 1.5 * TMath::Max( 0., lnpt - 1.5 ) )
-      passCut( ret, index_EF_N90Hits_ );
+    if ((!EF) || ignoreCut(index_EF_N90Hits_) || jetID.n90Hits > 1 + 1.5 * TMath::Max(0., lnpt - 1.5))
+      passCut(ret, index_EF_N90Hits_);
 
-    if( (!EF) || ignoreCut( index_EF_EMF_ )
-	|| emf > TMath::Max( -0.9, -0.1 - 0.05 * TMath::Power( TMath::Max( 0., 5 - lnpt ), 2. ) ) )
-      passCut( ret, index_EF_EMF_ );
+    if ((!EF) || ignoreCut(index_EF_EMF_) ||
+        emf > TMath::Max(-0.9, -0.1 - 0.05 * TMath::Power(TMath::Max(0., 5 - lnpt), 2.)))
+      passCut(ret, index_EF_EMF_);
 
     // both EF and HF
 
-    if( ( !( EF || HF ) ) || ignoreCut( index_TIGHT_fls_ )
-	|| ( EF && jetID.fLS < TMath::Min( 0.8, 0.1 + 0.016 * TMath::Power( TMath::Max( 0., 6 - lnpt ), 2.5 ) ) )
-	|| ( HFa && jetID.fLS < TMath::Min( 0.6, 0.05 + 0.045 * TMath::Power( TMath::Max( 0., 7.5 - lnE ), 2.2 ) ) )
-	|| ( HFb && jetID.fLS < TMath::Min( 0.1, 0.05 + 0.07 * TMath::Power( TMath::Max( 0., 7.8 - lnE ), 2. ) ) ) )
-      passCut( ret, index_TIGHT_fls_ );
+    if ((!(EF || HF)) || ignoreCut(index_TIGHT_fls_) ||
+        (EF && jetID.fLS < TMath::Min(0.8, 0.1 + 0.016 * TMath::Power(TMath::Max(0., 6 - lnpt), 2.5))) ||
+        (HFa && jetID.fLS < TMath::Min(0.6, 0.05 + 0.045 * TMath::Power(TMath::Max(0., 7.5 - lnE), 2.2))) ||
+        (HFb && jetID.fLS < TMath::Min(0.1, 0.05 + 0.07 * TMath::Power(TMath::Max(0., 7.8 - lnE), 2.))))
+      passCut(ret, index_TIGHT_fls_);
 
-    if( ( !( EF || HF ) ) || ignoreCut( index_widths_ )
-	|| ( 1E-10 < etaWidth && etaWidth < 0.12 &&
-	     1E-10 < phiWidth && phiWidth < 0.12 ) )
-      passCut( ret, index_widths_ );
+    if ((!(EF || HF)) || ignoreCut(index_widths_) ||
+        (1E-10 < etaWidth && etaWidth < 0.12 && 1E-10 < phiWidth && phiWidth < 0.12))
+      passCut(ret, index_widths_);
 
     // HF cuts
 
-    if( (!HF) || ignoreCut( index_LOOSE_nHit_ )
-	|| ( HFa && nHit > 1 + 2.4*( lnpt - 1. ) )
-	|| ( HFb && nHit > 1 + 3.*( lnpt - 1. ) ) )
-      passCut( ret, index_LOOSE_nHit_ );
+    if ((!HF) || ignoreCut(index_LOOSE_nHit_) || (HFa && nHit > 1 + 2.4 * (lnpt - 1.)) ||
+        (HFb && nHit > 1 + 3. * (lnpt - 1.)))
+      passCut(ret, index_LOOSE_nHit_);
 
-    if( (!HF) || ignoreCut( index_LOOSE_als_ )
-	|| ( emf < 0.6 + 0.05 * TMath::Power( TMath::Max( 0., 9 - lnE ), 1.5 ) &&
-	     emf > -0.2 - 0.041 * TMath::Power( TMath::Max( 0., 7.5 - lnE ), 2.2 ) ) )
-      passCut( ret, index_LOOSE_als_ );
+    if ((!HF) || ignoreCut(index_LOOSE_als_) ||
+        (emf < 0.6 + 0.05 * TMath::Power(TMath::Max(0., 9 - lnE), 1.5) &&
+         emf > -0.2 - 0.041 * TMath::Power(TMath::Max(0., 7.5 - lnE), 2.2)))
+      passCut(ret, index_LOOSE_als_);
 
-    if( (!HF) || ignoreCut( index_LOOSE_fls_ )
-	|| ( HFa && jetID.fLS < TMath::Min( 0.9, 0.1 + 0.05 * TMath::Power( TMath::Max( 0., 7.5 - lnE ), 2.2 ) ) )
-	|| ( HFb && jetID.fLS < TMath::Min( 0.6, 0.1 + 0.065 * TMath::Power( TMath::Max( 0., 7.5 - lnE ), 2.2 ) ) ) )
-      passCut( ret, index_LOOSE_fls_ );
+    if ((!HF) || ignoreCut(index_LOOSE_fls_) ||
+        (HFa && jetID.fLS < TMath::Min(0.9, 0.1 + 0.05 * TMath::Power(TMath::Max(0., 7.5 - lnE), 2.2))) ||
+        (HFb && jetID.fLS < TMath::Min(0.6, 0.1 + 0.065 * TMath::Power(TMath::Max(0., 7.5 - lnE), 2.2))))
+      passCut(ret, index_LOOSE_fls_);
 
-    if( (!HF) || ignoreCut( index_LOOSE_foot_ )
-	|| jetID.fHFOOT < 0.9 )
-      passCut( ret, index_LOOSE_foot_ );
+    if ((!HF) || ignoreCut(index_LOOSE_foot_) || jetID.fHFOOT < 0.9)
+      passCut(ret, index_LOOSE_foot_);
 
-    if( (!HF) || ignoreCut( index_TIGHT_nHit_ )
-	|| ( HFa && nHit > 1 + 2.7*( lnpt - 0.8 ) )
-	|| ( HFb && nHit > 1 + 3.5*( lnpt - 0.8 ) ) )
-      passCut( ret, index_TIGHT_nHit_ );
+    if ((!HF) || ignoreCut(index_TIGHT_nHit_) || (HFa && nHit > 1 + 2.7 * (lnpt - 0.8)) ||
+        (HFb && nHit > 1 + 3.5 * (lnpt - 0.8)))
+      passCut(ret, index_TIGHT_nHit_);
 
-    if( (!HF) || ignoreCut( index_TIGHT_als_ )
-	|| ( emf < 0.5 + 0.057 * TMath::Power( TMath::Max( 0., 9 - lnE ), 1.5 ) &&
-	     emf > TMath::Max( -0.6, -0.1 - 0.026 * TMath::Power( TMath::Max( 0., 8 - lnE ), 2.2 ) ) ) )
-      passCut( ret, index_TIGHT_als_ );
+    if ((!HF) || ignoreCut(index_TIGHT_als_) ||
+        (emf < 0.5 + 0.057 * TMath::Power(TMath::Max(0., 9 - lnE), 1.5) &&
+         emf > TMath::Max(-0.6, -0.1 - 0.026 * TMath::Power(TMath::Max(0., 8 - lnE), 2.2))))
+      passCut(ret, index_TIGHT_als_);
 
-    if( (!HF) || ignoreCut( index_TIGHT_foot_ )
-	|| jetID.fLS < 0.5 )
-      passCut( ret, index_TIGHT_foot_ );
+    if ((!HF) || ignoreCut(index_TIGHT_foot_) || jetID.fLS < 0.5)
+      passCut(ret, index_TIGHT_foot_);
 
-    setIgnored( ret );
+    setIgnored(ret);
 
     return (bool)ret;
   }
 
- private: // member variables
-
+private:  // member variables
   Version_t version_;
   Quality_t quality_;
 
-  index_type index_MINIMAL_EMF_       ;
+  index_type index_MINIMAL_EMF_;
 
-  index_type index_LOOSE_AOD_fHPD_    ;
-  index_type index_LOOSE_AOD_N90Hits_ ;
-  index_type index_LOOSE_AOD_EMF_     ;
+  index_type index_LOOSE_AOD_fHPD_;
+  index_type index_LOOSE_AOD_N90Hits_;
+  index_type index_LOOSE_AOD_EMF_;
 
-  index_type index_LOOSE_fHPD_        ;
-  index_type index_LOOSE_N90Hits_     ;
-  index_type index_LOOSE_EMF_         ;
+  index_type index_LOOSE_fHPD_;
+  index_type index_LOOSE_N90Hits_;
+  index_type index_LOOSE_EMF_;
 
-  index_type index_TIGHT_fHPD_        ;
-  index_type index_TIGHT_EMF_         ;
+  index_type index_TIGHT_fHPD_;
+  index_type index_TIGHT_EMF_;
 
-  index_type index_LOOSE_nHit_        ;
-  index_type index_LOOSE_als_         ;
-  index_type index_LOOSE_fls_         ;
-  index_type index_LOOSE_foot_        ;
+  index_type index_LOOSE_nHit_;
+  index_type index_LOOSE_als_;
+  index_type index_LOOSE_fls_;
+  index_type index_LOOSE_foot_;
 
-  index_type index_TIGHT_nHit_        ;
-  index_type index_TIGHT_als_         ;
-  index_type index_TIGHT_fls_         ;
-  index_type index_TIGHT_foot_        ;
-  index_type index_widths_            ;
-  index_type index_EF_N90Hits_        ;
-  index_type index_EF_EMF_            ;
-
+  index_type index_TIGHT_nHit_;
+  index_type index_TIGHT_als_;
+  index_type index_TIGHT_fls_;
+  index_type index_TIGHT_foot_;
+  index_type index_widths_;
+  index_type index_EF_N90Hits_;
+  index_type index_EF_EMF_;
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/MakePtrFromCollection.h
+++ b/PhysicsTools/SelectorUtils/interface/MakePtrFromCollection.h
@@ -3,10 +3,12 @@
 
 #include "DataFormats/Common/interface/Ptr.h"
 
-template<class Collection, class InPhysObj = typename Collection::value_type, class OutPhysObj = typename Collection::value_type>
-struct MakePtrFromCollection{
+template <class Collection,
+          class InPhysObj = typename Collection::value_type,
+          class OutPhysObj = typename Collection::value_type>
+struct MakePtrFromCollection {
   edm::Ptr<OutPhysObj> operator()(const Collection& coll, unsigned idx) {
-    edm::Ptr<InPhysObj> temp(&coll,idx);
+    edm::Ptr<InPhysObj> temp(&coll, idx);
     return edm::Ptr<OutPhysObj>(temp);
   }
 };

--- a/PhysicsTools/SelectorUtils/interface/MakePyVIDClassBuilder.h
+++ b/PhysicsTools/SelectorUtils/interface/MakePyVIDClassBuilder.h
@@ -4,23 +4,16 @@
 #include "PhysicsTools/SelectorUtils/interface/VersionedSelector.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 
-template<class PhysObj>
+template <class PhysObj>
 struct MakeVersionedSelector {
   MakeVersionedSelector() {}
-  
-  VersionedSelector<edm::Ptr<PhysObj> > 
-  operator()(const std::string& pset, 
-             const std::string& which_config) {
-    const edm::ParameterSet& temp = 
-      edm::readPSetsFrom(pset)->getParameter<edm::ParameterSet>(which_config);
+
+  VersionedSelector<edm::Ptr<PhysObj> > operator()(const std::string& pset, const std::string& which_config) {
+    const edm::ParameterSet& temp = edm::readPSetsFrom(pset)->getParameter<edm::ParameterSet>(which_config);
     return VersionedSelector<edm::Ptr<PhysObj> >(temp);
   }
 
-  VersionedSelector<edm::Ptr<PhysObj> > 
-  operator()() {
-    return VersionedSelector<edm::Ptr<PhysObj> >();
-  }
-  
+  VersionedSelector<edm::Ptr<PhysObj> > operator()() { return VersionedSelector<edm::Ptr<PhysObj> >(); }
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h
@@ -15,9 +15,7 @@
 #include <iostream>
 
 class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
-
- public: // interface
-
+public:  // interface
   bool verbose_;
 
   enum Version_t { SUMMER08, FIRSTDATA, SPRING10, FALL10, N_VERSIONS, KITQCD };
@@ -25,59 +23,54 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
   MuonVPlusJetsIDSelectionFunctor() {}
 
 #ifndef __GCCXML__
-  MuonVPlusJetsIDSelectionFunctor( edm::ParameterSet const & parameters, edm::ConsumesCollector& iC ) :
-    MuonVPlusJetsIDSelectionFunctor(parameters)
-  {
+  MuonVPlusJetsIDSelectionFunctor(edm::ParameterSet const& parameters, edm::ConsumesCollector& iC)
+      : MuonVPlusJetsIDSelectionFunctor(parameters) {
     beamLineSrcToken_ = iC.consumes<reco::BeamSpot>(beamLineSrc_);
     pvSrcToken_ = iC.consumes<std::vector<reco::Vertex> >(pvSrc_);
   }
 #endif
 
-  MuonVPlusJetsIDSelectionFunctor( edm::ParameterSet const & parameters ) {
-
+  MuonVPlusJetsIDSelectionFunctor(edm::ParameterSet const& parameters) {
     verbose_ = false;
 
     std::string versionStr = parameters.getParameter<std::string>("version");
 
     Version_t version = N_VERSIONS;
 
-    if ( versionStr == "SUMMER08" ) {
+    if (versionStr == "SUMMER08") {
       version = SUMMER08;
-    }
-    else if ( versionStr == "FIRSTDATA" ) {
+    } else if (versionStr == "FIRSTDATA") {
       version = FIRSTDATA;
-    }
-    else if ( versionStr == "SPRING10" ) {
+    } else if (versionStr == "SPRING10") {
       version = SPRING10;
-    }
-    else if ( versionStr == "FALL10" ) {
+    } else if (versionStr == "FALL10") {
       version = FALL10;
-      if (verbose_) std::cout << "\nMUON SELECTION - you are using FALL10 Selection" << std::endl;
-    }
-    else if (versionStr == "KITQCD") {
+      if (verbose_)
+        std::cout << "\nMUON SELECTION - you are using FALL10 Selection" << std::endl;
+    } else if (versionStr == "KITQCD") {
       version = KITQCD;
-      if (verbose_) std::cout << "\nMUON SELECTION - you are using KITQCD Selection" << std::endl;
-    }
-    else {
-      throw cms::Exception("InvalidInput") << "Expect version to be one of SUMMER08, FIRSTDATA, SPRING10, FALL10" << std::endl;
+      if (verbose_)
+        std::cout << "\nMUON SELECTION - you are using KITQCD Selection" << std::endl;
+    } else {
+      throw cms::Exception("InvalidInput")
+          << "Expect version to be one of SUMMER08, FIRSTDATA, SPRING10, FALL10" << std::endl;
     }
 
-    initialize( version,
-		parameters.getParameter<double>("Chi2"),
-		parameters.getParameter<double>("D0")  ,
-		parameters.getParameter<double>("ED0")  ,
-		parameters.getParameter<double>("SD0")  ,
-		parameters.getParameter<int>   ("NHits")   ,
-		parameters.getParameter<int>   ("NValMuHits"),
-		parameters.getParameter<double>("ECalVeto")   ,
-		parameters.getParameter<double>("HCalVeto")   ,
-		parameters.getParameter<double>("RelIso"),
-		parameters.getParameter<double>("LepZ"),
-		parameters.getParameter<int>("nPixelHits"),
-		parameters.getParameter<int>("nMatchedStations")
-		);
-    if ( parameters.exists("cutsToIgnore") )
-      setIgnoredCuts( parameters.getParameter<std::vector<std::string> >("cutsToIgnore") );
+    initialize(version,
+               parameters.getParameter<double>("Chi2"),
+               parameters.getParameter<double>("D0"),
+               parameters.getParameter<double>("ED0"),
+               parameters.getParameter<double>("SD0"),
+               parameters.getParameter<int>("NHits"),
+               parameters.getParameter<int>("NValMuHits"),
+               parameters.getParameter<double>("ECalVeto"),
+               parameters.getParameter<double>("HCalVeto"),
+               parameters.getParameter<double>("RelIso"),
+               parameters.getParameter<double>("LepZ"),
+               parameters.getParameter<int>("nPixelHits"),
+               parameters.getParameter<int>("nMatchedStations"));
+    if (parameters.exists("cutsToIgnore"))
+      setIgnoredCuts(parameters.getParameter<std::vector<std::string> >("cutsToIgnore"));
 
     retInternal_ = getBitTemplate();
 
@@ -85,57 +78,63 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
     pvSrc_ = parameters.getParameter<edm::InputTag>("pvSrc");
   }
 
-
-  MuonVPlusJetsIDSelectionFunctor( Version_t version,
-				   double chi2 = 10.0,
-				   double d0 = 0.2,
-				   double ed0 = 999.0,
-				   double sd0 = 999.0,
-				   int nhits = 11,
-				   int nValidMuonHits = 0,
-				   double ecalveto = 4.0,
-				   double hcalveto = 6.0,
-				   double reliso = 0.05,
-				   double maxLepZ = 1.0,
-				   int minPixelHits = 1,
-				   int minNMatches = 1
-				   ) : recalcDBFromBSp_(false) {
-    initialize( version, chi2, d0, ed0, sd0, nhits, nValidMuonHits, ecalveto, hcalveto, reliso,
-		maxLepZ, minPixelHits, minNMatches );
+  MuonVPlusJetsIDSelectionFunctor(Version_t version,
+                                  double chi2 = 10.0,
+                                  double d0 = 0.2,
+                                  double ed0 = 999.0,
+                                  double sd0 = 999.0,
+                                  int nhits = 11,
+                                  int nValidMuonHits = 0,
+                                  double ecalveto = 4.0,
+                                  double hcalveto = 6.0,
+                                  double reliso = 0.05,
+                                  double maxLepZ = 1.0,
+                                  int minPixelHits = 1,
+                                  int minNMatches = 1)
+      : recalcDBFromBSp_(false) {
+    initialize(version,
+               chi2,
+               d0,
+               ed0,
+               sd0,
+               nhits,
+               nValidMuonHits,
+               ecalveto,
+               hcalveto,
+               reliso,
+               maxLepZ,
+               minPixelHits,
+               minNMatches);
 
     retInternal_ = getBitTemplate();
   }
 
-
-
-
-  void initialize( Version_t version,
-		   double chi2 = 10.0,
-		   double d0 = 999.0,
-		   double ed0 = 999.0,
-		   double sd0 = 3.0,
-		   int nhits = 11,
-		   int nValidMuonHits = 0,
-		   double ecalveto = 4.0,
-		   double hcalveto = 6.0,
-		   double reliso = 0.05,
-		   double maxLepZ = 1.0,
-		   int minPixelHits = 1,
-		   int minNMatches = 1 )
-  {
+  void initialize(Version_t version,
+                  double chi2 = 10.0,
+                  double d0 = 999.0,
+                  double ed0 = 999.0,
+                  double sd0 = 3.0,
+                  int nhits = 11,
+                  int nValidMuonHits = 0,
+                  double ecalveto = 4.0,
+                  double hcalveto = 6.0,
+                  double reliso = 0.05,
+                  double maxLepZ = 1.0,
+                  int minPixelHits = 1,
+                  int minNMatches = 1) {
     version_ = version;
 
-    push_back("Chi2",      chi2   );
-    push_back("D0",        d0     );
-    push_back("ED0",       ed0    );
-    push_back("SD0",       sd0    );
-    push_back("NHits",     nhits  );
-    push_back("NValMuHits",     nValidMuonHits  );
-    push_back("ECalVeto",  ecalveto);
-    push_back("HCalVeto",  hcalveto);
-    push_back("RelIso",    reliso );
-    push_back("LepZ",      maxLepZ);
-    push_back("nPixelHits",minPixelHits);
+    push_back("Chi2", chi2);
+    push_back("D0", d0);
+    push_back("ED0", ed0);
+    push_back("SD0", sd0);
+    push_back("NHits", nhits);
+    push_back("NValMuHits", nValidMuonHits);
+    push_back("ECalVeto", ecalveto);
+    push_back("HCalVeto", hcalveto);
+    push_back("RelIso", reliso);
+    push_back("LepZ", maxLepZ);
+    push_back("nPixelHits", minPixelHits);
     push_back("nMatchedStations", minNMatches);
 
     set("Chi2");
@@ -151,149 +150,157 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
     set("nPixelHits");
     set("nMatchedStations");
 
-    indexChi2_          = index_type(&bits_, "Chi2"         );
-    indexD0_            = index_type(&bits_, "D0"           );
-    indexED0_           = index_type(&bits_, "ED0"          );
-    indexSD0_           = index_type(&bits_, "SD0"          );
-    indexNHits_         = index_type(&bits_, "NHits"        );
-    indexNValMuHits_    = index_type(&bits_, "NValMuHits"   );
-    indexECalVeto_      = index_type(&bits_, "ECalVeto"     );
-    indexHCalVeto_      = index_type(&bits_, "HCalVeto"     );
-    indexRelIso_        = index_type(&bits_, "RelIso"       );
-    indexLepZ_          = index_type( &bits_, "LepZ");
-    indexPixHits_       = index_type( &bits_, "nPixelHits");
-    indexStations_      = index_type( &bits_, "nMatchedStations");
+    indexChi2_ = index_type(&bits_, "Chi2");
+    indexD0_ = index_type(&bits_, "D0");
+    indexED0_ = index_type(&bits_, "ED0");
+    indexSD0_ = index_type(&bits_, "SD0");
+    indexNHits_ = index_type(&bits_, "NHits");
+    indexNValMuHits_ = index_type(&bits_, "NValMuHits");
+    indexECalVeto_ = index_type(&bits_, "ECalVeto");
+    indexHCalVeto_ = index_type(&bits_, "HCalVeto");
+    indexRelIso_ = index_type(&bits_, "RelIso");
+    indexLepZ_ = index_type(&bits_, "LepZ");
+    indexPixHits_ = index_type(&bits_, "nPixelHits");
+    indexStations_ = index_type(&bits_, "nMatchedStations");
 
-    if ( version == FALL10) {
-      set("ED0", false );
+    if (version == FALL10) {
+      set("ED0", false);
       set("SD0", false);
-      set("ECalVeto",false);
-      set("HCalVeto",false);
-    } else if ( version == SPRING10) {
-      set("ED0", false );
+      set("ECalVeto", false);
+      set("HCalVeto", false);
+    } else if (version == SPRING10) {
+      set("ED0", false);
       set("SD0", false);
-      set("ECalVeto",false);
-      set("HCalVeto",false);
+      set("ECalVeto", false);
+      set("HCalVeto", false);
       set("LepZ", false);
       set("nPixelHits", false);
       set("nMatchedStations", false);
-    } else if ( version_ == FIRSTDATA ) {
-      set("D0", false );
-      set("ED0", false );
-      set("NValMuHits",false);
+    } else if (version_ == FIRSTDATA) {
+      set("D0", false);
+      set("ED0", false);
+      set("NValMuHits", false);
       set("LepZ", false);
       set("nPixelHits", false);
       set("nMatchedStations", false);
-    } else if (version == SUMMER08 ) {
+    } else if (version == SUMMER08) {
       set("SD0", false);
-      set("NValMuHits",false);
+      set("NValMuHits", false);
       set("LepZ", false);
       set("nPixelHits", false);
       set("nMatchedStations", false);
-
     }
-
   }
 
   // Allow for multiple definitions of the cuts.
-  bool operator()( const pat::Muon & muon, edm::EventBase const & event, pat::strbitset & ret ) override
-  {
-
-    if (version_ == FALL10 ) return fall10Cuts(muon, event, ret);
-    else if (version_ == SPRING10 ) return spring10Cuts(muon, event, ret);
-    else if ( version_ == SUMMER08 ) return summer08Cuts( muon, ret );
-    else if ( version_ == FIRSTDATA ) return firstDataCuts( muon, ret );
-    else if ( version_ == KITQCD ) {
-      if (verbose_) std::cout << "Calling KIT selection method" << std::endl;
-      return kitQCDCuts (muon, event, ret);
-    }
-    else {
+  bool operator()(const pat::Muon& muon, edm::EventBase const& event, pat::strbitset& ret) override {
+    if (version_ == FALL10)
+      return fall10Cuts(muon, event, ret);
+    else if (version_ == SPRING10)
+      return spring10Cuts(muon, event, ret);
+    else if (version_ == SUMMER08)
+      return summer08Cuts(muon, ret);
+    else if (version_ == FIRSTDATA)
+      return firstDataCuts(muon, ret);
+    else if (version_ == KITQCD) {
+      if (verbose_)
+        std::cout << "Calling KIT selection method" << std::endl;
+      return kitQCDCuts(muon, event, ret);
+    } else {
       return false;
     }
   }
 
   // For compatibility with older versions.
-  bool operator()( const pat::Muon & muon, pat::strbitset & ret ) override
-  {
+  bool operator()(const pat::Muon& muon, pat::strbitset& ret) override {
+    if (version_ == SPRING10 || version_ == FALL10)
+      throw cms::Exception("LogicError") << "MuonVPlusJetsSelectionFunctor SPRING10 and FALL10 versions needs the "
+                                            "event! Call operator()(muon,event,ret)"
+                                         << std::endl;
 
-    if (version_ == SPRING10 || version_ == FALL10 ) throw cms::Exception("LogicError")
-      << "MuonVPlusJetsSelectionFunctor SPRING10 and FALL10 versions needs the event! Call operator()(muon,event,ret)"
-      <<std::endl;
-
-    else if ( version_ == SUMMER08 ) return summer08Cuts( muon, ret );
-    else if ( version_ == FIRSTDATA ) return firstDataCuts( muon, ret );
+    else if (version_ == SUMMER08)
+      return summer08Cuts(muon, ret);
+    else if (version_ == FIRSTDATA)
+      return firstDataCuts(muon, ret);
     else {
       return false;
     }
   }
 
-
   using Selector<pat::Muon>::operator();
 
   // cuts based on craft 08 analysis.
-  bool summer08Cuts( const pat::Muon & muon, pat::strbitset & ret)
-  {
-
+  bool summer08Cuts(const pat::Muon& muon, pat::strbitset& ret) {
     ret.set(false);
 
     double norm_chi2 = muon.normChi2();
     double corr_d0 = muon.dB();
-    int nhits = static_cast<int>( muon.numberOfValidHits() );
+    int nhits = static_cast<int>(muon.numberOfValidHits());
 
     double ecalVeto = muon.isolationR03().emVetoEt;
     double hcalVeto = muon.isolationR03().hadVetoEt;
 
     double hcalIso = muon.hcalIso();
     double ecalIso = muon.ecalIso();
-    double trkIso  = muon.trackIso();
-    double pt      = muon.pt() ;
+    double trkIso = muon.trackIso();
+    double pt = muon.pt();
 
     double relIso = (ecalIso + hcalIso + trkIso) / pt;
 
-    if ( norm_chi2     <  cut(indexChi2_,   double()) || ignoreCut(indexChi2_)    ) passCut(ret, indexChi2_   );
-    if ( fabs(corr_d0) <  cut(indexD0_,     double()) || ignoreCut(indexD0_)      ) passCut(ret, indexD0_     );
-    if ( nhits         >= cut(indexNHits_,  int()   ) || ignoreCut(indexNHits_)   ) passCut(ret, indexNHits_  );
-    if ( hcalVeto      <  cut(indexHCalVeto_,double())|| ignoreCut(indexHCalVeto_)) passCut(ret, indexHCalVeto_);
-    if ( ecalVeto      <  cut(indexECalVeto_,double())|| ignoreCut(indexECalVeto_)) passCut(ret, indexECalVeto_);
-    if ( relIso        <  cut(indexRelIso_, double()) || ignoreCut(indexRelIso_)  ) passCut(ret, indexRelIso_ );
+    if (norm_chi2 < cut(indexChi2_, double()) || ignoreCut(indexChi2_))
+      passCut(ret, indexChi2_);
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (nhits >= cut(indexNHits_, int()) || ignoreCut(indexNHits_))
+      passCut(ret, indexNHits_);
+    if (hcalVeto < cut(indexHCalVeto_, double()) || ignoreCut(indexHCalVeto_))
+      passCut(ret, indexHCalVeto_);
+    if (ecalVeto < cut(indexECalVeto_, double()) || ignoreCut(indexECalVeto_))
+      passCut(ret, indexECalVeto_);
+    if (relIso < cut(indexRelIso_, double()) || ignoreCut(indexRelIso_))
+      passCut(ret, indexRelIso_);
 
     setIgnored(ret);
 
     return (bool)ret;
   }
 
-
-
   // cuts based on craft 08 analysis.
-  bool firstDataCuts( const pat::Muon & muon, pat::strbitset & ret)
-  {
-
+  bool firstDataCuts(const pat::Muon& muon, pat::strbitset& ret) {
     ret.set(false);
 
     double norm_chi2 = muon.normChi2();
     double corr_d0 = muon.dB();
     double corr_ed0 = muon.edB();
-    double corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
-    int nhits = static_cast<int>( muon.numberOfValidHits() );
+    double corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
+    int nhits = static_cast<int>(muon.numberOfValidHits());
 
     double ecalVeto = muon.isolationR03().emVetoEt;
     double hcalVeto = muon.isolationR03().hadVetoEt;
 
     double hcalIso = muon.hcalIso();
     double ecalIso = muon.ecalIso();
-    double trkIso  = muon.trackIso();
-    double pt      = muon.pt() ;
+    double trkIso = muon.trackIso();
+    double pt = muon.pt();
 
     double relIso = (ecalIso + hcalIso + trkIso) / pt;
 
-    if ( norm_chi2     <  cut(indexChi2_,   double()) || ignoreCut(indexChi2_)    ) passCut(ret, indexChi2_   );
-    if ( fabs(corr_d0) <  cut(indexD0_,     double()) || ignoreCut(indexD0_)      ) passCut(ret, indexD0_     );
-    if ( fabs(corr_ed0)<  cut(indexED0_,    double()) || ignoreCut(indexED0_)     ) passCut(ret, indexED0_    );
-    if ( fabs(corr_sd0)<  cut(indexSD0_,    double()) || ignoreCut(indexSD0_)     ) passCut(ret, indexSD0_    );
-    if ( nhits         >= cut(indexNHits_,  int()   ) || ignoreCut(indexNHits_)   ) passCut(ret, indexNHits_  );
-    if ( hcalVeto      <  cut(indexHCalVeto_,double())|| ignoreCut(indexHCalVeto_)) passCut(ret, indexHCalVeto_);
-    if ( ecalVeto      <  cut(indexECalVeto_,double())|| ignoreCut(indexECalVeto_)) passCut(ret, indexECalVeto_);
-    if ( relIso        <  cut(indexRelIso_, double()) || ignoreCut(indexRelIso_)  ) passCut(ret, indexRelIso_ );
+    if (norm_chi2 < cut(indexChi2_, double()) || ignoreCut(indexChi2_))
+      passCut(ret, indexChi2_);
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (fabs(corr_ed0) < cut(indexED0_, double()) || ignoreCut(indexED0_))
+      passCut(ret, indexED0_);
+    if (fabs(corr_sd0) < cut(indexSD0_, double()) || ignoreCut(indexSD0_))
+      passCut(ret, indexSD0_);
+    if (nhits >= cut(indexNHits_, int()) || ignoreCut(indexNHits_))
+      passCut(ret, indexNHits_);
+    if (hcalVeto < cut(indexHCalVeto_, double()) || ignoreCut(indexHCalVeto_))
+      passCut(ret, indexHCalVeto_);
+    if (ecalVeto < cut(indexECalVeto_, double()) || ignoreCut(indexECalVeto_))
+      passCut(ret, indexECalVeto_);
+    if (relIso < cut(indexRelIso_, double()) || ignoreCut(indexRelIso_))
+      passCut(ret, indexRelIso_);
 
     setIgnored(ret);
 
@@ -301,146 +308,146 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
   }
 
   // cuts based on top group L+J synchronization exercise
-  bool spring10Cuts( const pat::Muon & muon, edm::EventBase const & event, pat::strbitset & ret)
-  {
-
+  bool spring10Cuts(const pat::Muon& muon, edm::EventBase const& event, pat::strbitset& ret) {
     ret.set(false);
 
     double norm_chi2 = muon.normChi2();
     double corr_d0 = muon.dB();
     double corr_ed0 = muon.edB();
-    double corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+    double corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
     //If required, recalculate the impact parameter using the beam spot
     if (recalcDBFromBSp_) {
-
       //Get the beam spot
-      reco::TrackBase::Point beamPoint(0,0,0);
+      reco::TrackBase::Point beamPoint(0, 0, 0);
       reco::BeamSpot beamSpot;
       edm::Handle<reco::BeamSpot> beamSpotHandle;
       event.getByLabel(beamLineSrc_, beamSpotHandle);
 
-      if( beamSpotHandle.isValid() ){
-	beamSpot = *beamSpotHandle;
-      } else{
-	edm::LogError("DataNotAvailable")
-	  << "No beam spot available from EventSetup, not adding high level selection \n";
+      if (beamSpotHandle.isValid()) {
+        beamSpot = *beamSpotHandle;
+      } else {
+        edm::LogError("DataNotAvailable")
+            << "No beam spot available from EventSetup, not adding high level selection \n";
       }
-      beamPoint = reco::TrackBase::Point ( beamSpot.x0(), beamSpot.y0(), beamSpot.z0() );
+      beamPoint = reco::TrackBase::Point(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
 
       //Use the beamspot to correct the impact parameter and uncertainty
       reco::TrackRef innerTrack = muon.innerTrack();
-      if ( innerTrack.isNonnull() && innerTrack.isAvailable() ) {
-	corr_d0 = -1.0 * innerTrack->dxy( beamPoint );
-	corr_ed0 = sqrt( innerTrack->d0Error() * innerTrack->d0Error()
-			 + 0.5* beamSpot.BeamWidthX()*beamSpot.BeamWidthX()
-			 + 0.5* beamSpot.BeamWidthY()*beamSpot.BeamWidthY() );
-	corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+      if (innerTrack.isNonnull() && innerTrack.isAvailable()) {
+        corr_d0 = -1.0 * innerTrack->dxy(beamPoint);
+        corr_ed0 =
+            sqrt(innerTrack->d0Error() * innerTrack->d0Error() + 0.5 * beamSpot.BeamWidthX() * beamSpot.BeamWidthX() +
+                 0.5 * beamSpot.BeamWidthY() * beamSpot.BeamWidthY());
+        corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
       } else {
-	corr_d0 =  999.;
-	corr_ed0 = 999.;
+        corr_d0 = 999.;
+        corr_ed0 = 999.;
       }
     }
 
-    int nhits = static_cast<int>( muon.numberOfValidHits() );
-    int nValidMuonHits = static_cast<int> (muon.globalTrack()->hitPattern().numberOfValidMuonHits());
+    int nhits = static_cast<int>(muon.numberOfValidHits());
+    int nValidMuonHits = static_cast<int>(muon.globalTrack()->hitPattern().numberOfValidMuonHits());
 
     double ecalVeto = muon.isolationR03().emVetoEt;
     double hcalVeto = muon.isolationR03().hadVetoEt;
 
     double hcalIso = muon.hcalIso();
     double ecalIso = muon.ecalIso();
-    double trkIso  = muon.trackIso();
-    double pt      = muon.pt() ;
+    double trkIso = muon.trackIso();
+    double pt = muon.pt();
 
     double relIso = (ecalIso + hcalIso + trkIso) / pt;
 
-    if ( norm_chi2     <  cut(indexChi2_,   double()) || ignoreCut(indexChi2_)    ) passCut(ret, indexChi2_   );
-    if ( fabs(corr_d0) <  cut(indexD0_,     double()) || ignoreCut(indexD0_)      ) passCut(ret, indexD0_     );
-    if ( fabs(corr_ed0)<  cut(indexED0_,    double()) || ignoreCut(indexED0_)     ) passCut(ret, indexED0_    );
-    if ( fabs(corr_sd0)<  cut(indexSD0_,    double()) || ignoreCut(indexSD0_)     ) passCut(ret, indexSD0_    );
-    if ( nhits         >= cut(indexNHits_,  int()   ) || ignoreCut(indexNHits_)   ) passCut(ret, indexNHits_  );
-    if ( nValidMuonHits> cut(indexNValMuHits_,int()) || ignoreCut(indexNValMuHits_)) passCut(ret, indexNValMuHits_  );
-    if ( hcalVeto      <  cut(indexHCalVeto_,double())|| ignoreCut(indexHCalVeto_)) passCut(ret, indexHCalVeto_);
-    if ( ecalVeto      <  cut(indexECalVeto_,double())|| ignoreCut(indexECalVeto_)) passCut(ret, indexECalVeto_);
-    if ( relIso        <  cut(indexRelIso_, double()) || ignoreCut(indexRelIso_)  ) passCut(ret, indexRelIso_ );
+    if (norm_chi2 < cut(indexChi2_, double()) || ignoreCut(indexChi2_))
+      passCut(ret, indexChi2_);
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (fabs(corr_ed0) < cut(indexED0_, double()) || ignoreCut(indexED0_))
+      passCut(ret, indexED0_);
+    if (fabs(corr_sd0) < cut(indexSD0_, double()) || ignoreCut(indexSD0_))
+      passCut(ret, indexSD0_);
+    if (nhits >= cut(indexNHits_, int()) || ignoreCut(indexNHits_))
+      passCut(ret, indexNHits_);
+    if (nValidMuonHits > cut(indexNValMuHits_, int()) || ignoreCut(indexNValMuHits_))
+      passCut(ret, indexNValMuHits_);
+    if (hcalVeto < cut(indexHCalVeto_, double()) || ignoreCut(indexHCalVeto_))
+      passCut(ret, indexHCalVeto_);
+    if (ecalVeto < cut(indexECalVeto_, double()) || ignoreCut(indexECalVeto_))
+      passCut(ret, indexECalVeto_);
+    if (relIso < cut(indexRelIso_, double()) || ignoreCut(indexRelIso_))
+      passCut(ret, indexRelIso_);
 
     setIgnored(ret);
 
     return (bool)ret;
   }
 
-
-
-
   // cuts based on top group L+J synchronization exercise
-  bool fall10Cuts( const pat::Muon & muon, edm::EventBase const & event, pat::strbitset & ret)
-  {
-
+  bool fall10Cuts(const pat::Muon& muon, edm::EventBase const& event, pat::strbitset& ret) {
     ret.set(false);
 
     double norm_chi2 = muon.normChi2();
     double corr_d0 = muon.dB();
     double corr_ed0 = muon.edB();
-    double corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+    double corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
     // Get the PV for the muon z requirement
     edm::Handle<std::vector<reco::Vertex> > pvtxHandle_;
-    event.getByLabel( pvSrc_, pvtxHandle_ );
+    event.getByLabel(pvSrc_, pvtxHandle_);
 
     double zvtx = -999;
-    if ( !pvtxHandle_->empty() ) {
+    if (!pvtxHandle_->empty()) {
       zvtx = pvtxHandle_->at(0).z();
     } else {
-      throw cms::Exception("InvalidInput") << " There needs to be at least one primary vertex in the event." << std::endl;
+      throw cms::Exception("InvalidInput")
+          << " There needs to be at least one primary vertex in the event." << std::endl;
     }
 
     //If required, recalculate the impact parameter using the beam spot
     if (recalcDBFromBSp_) {
-
       //Get the beam spot
-      reco::TrackBase::Point beamPoint(0,0,0);
+      reco::TrackBase::Point beamPoint(0, 0, 0);
       reco::BeamSpot beamSpot;
       edm::Handle<reco::BeamSpot> beamSpotHandle;
       event.getByLabel(beamLineSrc_, beamSpotHandle);
 
-      if( beamSpotHandle.isValid() ){
-	beamSpot = *beamSpotHandle;
-      } else{
-	edm::LogError("DataNotAvailable")
-	  << "No beam spot available from EventSetup, not adding high level selection \n";
+      if (beamSpotHandle.isValid()) {
+        beamSpot = *beamSpotHandle;
+      } else {
+        edm::LogError("DataNotAvailable")
+            << "No beam spot available from EventSetup, not adding high level selection \n";
       }
-      beamPoint = reco::TrackBase::Point ( beamSpot.x0(), beamSpot.y0(), beamSpot.z0() );
+      beamPoint = reco::TrackBase::Point(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
 
       //Use the beamspot to correct the impact parameter and uncertainty
       reco::TrackRef innerTrack = muon.innerTrack();
-      if ( innerTrack.isNonnull() && innerTrack.isAvailable() ) {
-	corr_d0 = -1.0 * innerTrack->dxy( beamPoint );
-	corr_ed0 = sqrt( innerTrack->d0Error() * innerTrack->d0Error()
-			 + 0.5* beamSpot.BeamWidthX()*beamSpot.BeamWidthX()
-			 + 0.5* beamSpot.BeamWidthY()*beamSpot.BeamWidthY() );
-	corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+      if (innerTrack.isNonnull() && innerTrack.isAvailable()) {
+        corr_d0 = -1.0 * innerTrack->dxy(beamPoint);
+        corr_ed0 =
+            sqrt(innerTrack->d0Error() * innerTrack->d0Error() + 0.5 * beamSpot.BeamWidthX() * beamSpot.BeamWidthX() +
+                 0.5 * beamSpot.BeamWidthY() * beamSpot.BeamWidthY());
+        corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
       } else {
-	corr_d0 =  999.;
-	corr_ed0 = 999.;
+        corr_d0 = 999.;
+        corr_ed0 = 999.;
       }
     }
 
-    int nhits = static_cast<int>( muon.numberOfValidHits() );
-    int nValidMuonHits = static_cast<int> (muon.globalTrack()->hitPattern().numberOfValidMuonHits());
+    int nhits = static_cast<int>(muon.numberOfValidHits());
+    int nValidMuonHits = static_cast<int>(muon.globalTrack()->hitPattern().numberOfValidMuonHits());
 
     double ecalVeto = muon.isolationR03().emVetoEt;
     double hcalVeto = muon.isolationR03().hadVetoEt;
 
     double hcalIso = muon.hcalIso();
     double ecalIso = muon.ecalIso();
-    double trkIso  = muon.trackIso();
-    double pt      = muon.pt() ;
+    double trkIso = muon.trackIso();
+    double pt = muon.pt();
 
     double relIso = (ecalIso + hcalIso + trkIso) / pt;
-
 
     double z_mu = muon.vertex().z();
 
@@ -448,95 +455,103 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
 
     int nMatchedStations = muon.numberOfMatches();
 
-    if ( norm_chi2     <  cut(indexChi2_,   double()) || ignoreCut(indexChi2_)    ) passCut(ret, indexChi2_   );
-    if ( fabs(corr_d0) <  cut(indexD0_,     double()) || ignoreCut(indexD0_)      ) passCut(ret, indexD0_     );
-    if ( fabs(corr_ed0)<  cut(indexED0_,    double()) || ignoreCut(indexED0_)     ) passCut(ret, indexED0_    );
-    if ( fabs(corr_sd0)<  cut(indexSD0_,    double()) || ignoreCut(indexSD0_)     ) passCut(ret, indexSD0_    );
-    if ( nhits         >= cut(indexNHits_,  int()   ) || ignoreCut(indexNHits_)   ) passCut(ret, indexNHits_  );
-    if ( nValidMuonHits> cut(indexNValMuHits_,int()) || ignoreCut(indexNValMuHits_)) passCut(ret, indexNValMuHits_  );
-    if ( hcalVeto      <  cut(indexHCalVeto_,double())|| ignoreCut(indexHCalVeto_)) passCut(ret, indexHCalVeto_);
-    if ( ecalVeto      <  cut(indexECalVeto_,double())|| ignoreCut(indexECalVeto_)) passCut(ret, indexECalVeto_);
-    if ( relIso        <  cut(indexRelIso_, double()) || ignoreCut(indexRelIso_)  ) passCut(ret, indexRelIso_ );
-    if ( fabs(z_mu-zvtx)<  cut(indexLepZ_, double()) || ignoreCut(indexLepZ_)  ) passCut(ret, indexLepZ_ );
-    if ( nPixelHits    >  cut(indexPixHits_,int())    || ignoreCut(indexPixHits_))  passCut(ret, indexPixHits_);
-    if ( nMatchedStations> cut(indexStations_,int())    || ignoreCut(indexStations_))  passCut(ret, indexStations_);
+    if (norm_chi2 < cut(indexChi2_, double()) || ignoreCut(indexChi2_))
+      passCut(ret, indexChi2_);
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (fabs(corr_ed0) < cut(indexED0_, double()) || ignoreCut(indexED0_))
+      passCut(ret, indexED0_);
+    if (fabs(corr_sd0) < cut(indexSD0_, double()) || ignoreCut(indexSD0_))
+      passCut(ret, indexSD0_);
+    if (nhits >= cut(indexNHits_, int()) || ignoreCut(indexNHits_))
+      passCut(ret, indexNHits_);
+    if (nValidMuonHits > cut(indexNValMuHits_, int()) || ignoreCut(indexNValMuHits_))
+      passCut(ret, indexNValMuHits_);
+    if (hcalVeto < cut(indexHCalVeto_, double()) || ignoreCut(indexHCalVeto_))
+      passCut(ret, indexHCalVeto_);
+    if (ecalVeto < cut(indexECalVeto_, double()) || ignoreCut(indexECalVeto_))
+      passCut(ret, indexECalVeto_);
+    if (relIso < cut(indexRelIso_, double()) || ignoreCut(indexRelIso_))
+      passCut(ret, indexRelIso_);
+    if (fabs(z_mu - zvtx) < cut(indexLepZ_, double()) || ignoreCut(indexLepZ_))
+      passCut(ret, indexLepZ_);
+    if (nPixelHits > cut(indexPixHits_, int()) || ignoreCut(indexPixHits_))
+      passCut(ret, indexPixHits_);
+    if (nMatchedStations > cut(indexStations_, int()) || ignoreCut(indexStations_))
+      passCut(ret, indexStations_);
 
     setIgnored(ret);
 
     return (bool)ret;
   }
-
 
   // cuts based on top group L+J synchronization exercise
   // this is a copy of fall 10 cuts
   // with a hack to include a double-sided reliso cut
 
-  bool kitQCDCuts( const pat::Muon & muon, edm::EventBase const & event, pat::strbitset & ret)
-  {
-
+  bool kitQCDCuts(const pat::Muon& muon, edm::EventBase const& event, pat::strbitset& ret) {
     ret.set(false);
 
     double norm_chi2 = muon.normChi2();
     double corr_d0 = muon.dB();
     double corr_ed0 = muon.edB();
-    double corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+    double corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
     // Get the PV for the muon z requirement
     edm::Handle<std::vector<reco::Vertex> > pvtxHandle_;
-    event.getByLabel( pvSrc_, pvtxHandle_ );
+    event.getByLabel(pvSrc_, pvtxHandle_);
 
     double zvtx = -999;
-    if ( !pvtxHandle_->empty() ) {
+    if (!pvtxHandle_->empty()) {
       zvtx = pvtxHandle_->at(0).z();
     } else {
-      throw cms::Exception("InvalidInput") << " There needs to be at least one primary vertex in the event." << std::endl;
+      throw cms::Exception("InvalidInput")
+          << " There needs to be at least one primary vertex in the event." << std::endl;
     }
 
     //If required, recalculate the impact parameter using the beam spot
     if (recalcDBFromBSp_) {
-
       //Get the beam spot
-      reco::TrackBase::Point beamPoint(0,0,0);
+      reco::TrackBase::Point beamPoint(0, 0, 0);
       reco::BeamSpot beamSpot;
       edm::Handle<reco::BeamSpot> beamSpotHandle;
       event.getByLabel(beamLineSrc_, beamSpotHandle);
 
-      if( beamSpotHandle.isValid() ){
-	beamSpot = *beamSpotHandle;
-      } else{
-	edm::LogError("DataNotAvailable")
-	  << "No beam spot available from EventSetup, not adding high level selection \n";
+      if (beamSpotHandle.isValid()) {
+        beamSpot = *beamSpotHandle;
+      } else {
+        edm::LogError("DataNotAvailable")
+            << "No beam spot available from EventSetup, not adding high level selection \n";
       }
-      beamPoint = reco::TrackBase::Point ( beamSpot.x0(), beamSpot.y0(), beamSpot.z0() );
+      beamPoint = reco::TrackBase::Point(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
 
       //Use the beamspot to correct the impact parameter and uncertainty
       reco::TrackRef innerTrack = muon.innerTrack();
-      if ( innerTrack.isNonnull() && innerTrack.isAvailable() ) {
-	corr_d0 = -1.0 * innerTrack->dxy( beamPoint );
-	corr_ed0 = sqrt( innerTrack->d0Error() * innerTrack->d0Error()
-			 + 0.5* beamSpot.BeamWidthX()*beamSpot.BeamWidthX()
-			 + 0.5* beamSpot.BeamWidthY()*beamSpot.BeamWidthY() );
-	corr_sd0 = ( corr_ed0 > 0.000000001 ) ? corr_d0 / corr_ed0 : 999.0;
+      if (innerTrack.isNonnull() && innerTrack.isAvailable()) {
+        corr_d0 = -1.0 * innerTrack->dxy(beamPoint);
+        corr_ed0 =
+            sqrt(innerTrack->d0Error() * innerTrack->d0Error() + 0.5 * beamSpot.BeamWidthX() * beamSpot.BeamWidthX() +
+                 0.5 * beamSpot.BeamWidthY() * beamSpot.BeamWidthY());
+        corr_sd0 = (corr_ed0 > 0.000000001) ? corr_d0 / corr_ed0 : 999.0;
 
       } else {
-	corr_d0 =  999.;
-	corr_ed0 = 999.;
+        corr_d0 = 999.;
+        corr_ed0 = 999.;
       }
     }
 
-    int nhits = static_cast<int>( muon.numberOfValidHits() );
-    int nValidMuonHits = static_cast<int> (muon.globalTrack()->hitPattern().numberOfValidMuonHits());
+    int nhits = static_cast<int>(muon.numberOfValidHits());
+    int nValidMuonHits = static_cast<int>(muon.globalTrack()->hitPattern().numberOfValidMuonHits());
 
     double ecalVeto = muon.isolationR03().emVetoEt;
     double hcalVeto = muon.isolationR03().hadVetoEt;
 
     double hcalIso = muon.hcalIso();
     double ecalIso = muon.ecalIso();
-    double trkIso  = muon.trackIso();
-    double pt      = muon.pt() ;
+    double trkIso = muon.trackIso();
+    double pt = muon.pt();
 
     double relIso = (ecalIso + hcalIso + trkIso) / pt;
-
 
     double z_mu = muon.vertex().z();
 
@@ -544,18 +559,28 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
 
     int nMatchedStations = muon.numberOfMatches();
 
-    if ( norm_chi2     <  cut(indexChi2_,   double()) || ignoreCut(indexChi2_)    ) passCut(ret, indexChi2_   );
-    if ( fabs(corr_d0) <  cut(indexD0_,     double()) || ignoreCut(indexD0_)      ) passCut(ret, indexD0_     );
-    if ( fabs(corr_ed0)<  cut(indexED0_,    double()) || ignoreCut(indexED0_)     ) passCut(ret, indexED0_    );
-    if ( fabs(corr_sd0)<  cut(indexSD0_,    double()) || ignoreCut(indexSD0_)     ) passCut(ret, indexSD0_    );
-    if ( nhits         >= cut(indexNHits_,  int()   ) || ignoreCut(indexNHits_)   ) passCut(ret, indexNHits_  );
-    if ( nValidMuonHits> cut(indexNValMuHits_,int()) || ignoreCut(indexNValMuHits_)) passCut(ret, indexNValMuHits_  );
-    if ( hcalVeto      <  cut(indexHCalVeto_,double())|| ignoreCut(indexHCalVeto_)) passCut(ret, indexHCalVeto_);
-    if ( ecalVeto      <  cut(indexECalVeto_,double())|| ignoreCut(indexECalVeto_)) passCut(ret, indexECalVeto_);
-    if ( fabs(z_mu-zvtx)<  cut(indexLepZ_, double()) || ignoreCut(indexLepZ_)  ) passCut(ret, indexLepZ_ );
-    if ( nPixelHits    >  cut(indexPixHits_,int())    || ignoreCut(indexPixHits_))  passCut(ret, indexPixHits_);
-    if ( nMatchedStations> cut(indexStations_,int())    || ignoreCut(indexStations_))  passCut(ret, indexStations_);
-
+    if (norm_chi2 < cut(indexChi2_, double()) || ignoreCut(indexChi2_))
+      passCut(ret, indexChi2_);
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (fabs(corr_ed0) < cut(indexED0_, double()) || ignoreCut(indexED0_))
+      passCut(ret, indexED0_);
+    if (fabs(corr_sd0) < cut(indexSD0_, double()) || ignoreCut(indexSD0_))
+      passCut(ret, indexSD0_);
+    if (nhits >= cut(indexNHits_, int()) || ignoreCut(indexNHits_))
+      passCut(ret, indexNHits_);
+    if (nValidMuonHits > cut(indexNValMuHits_, int()) || ignoreCut(indexNValMuHits_))
+      passCut(ret, indexNValMuHits_);
+    if (hcalVeto < cut(indexHCalVeto_, double()) || ignoreCut(indexHCalVeto_))
+      passCut(ret, indexHCalVeto_);
+    if (ecalVeto < cut(indexECalVeto_, double()) || ignoreCut(indexECalVeto_))
+      passCut(ret, indexECalVeto_);
+    if (fabs(z_mu - zvtx) < cut(indexLepZ_, double()) || ignoreCut(indexLepZ_))
+      passCut(ret, indexLepZ_);
+    if (nPixelHits > cut(indexPixHits_, int()) || ignoreCut(indexPixHits_))
+      passCut(ret, indexPixHits_);
+    if (nMatchedStations > cut(indexStations_, int()) || ignoreCut(indexStations_))
+      passCut(ret, indexStations_);
 
     ////////////////////////////////////////////////////////////////
     //
@@ -565,22 +590,15 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
     //
     //
     ///////////////////////////////////////////////////////////////
-    if ( ((relIso > 0.2) && (relIso < 0.75))
-         || ignoreCut(indexRelIso_)  ) passCut(ret, indexRelIso_ );
-
-
-
+    if (((relIso > 0.2) && (relIso < 0.75)) || ignoreCut(indexRelIso_))
+      passCut(ret, indexRelIso_);
 
     setIgnored(ret);
 
     return (bool)ret;
   }
 
-
-
-
- private: // member variables
-
+private:  // member variables
   Version_t version_;
   bool recalcDBFromBSp_;
   edm::InputTag beamLineSrc_;
@@ -604,8 +622,6 @@ class MuonVPlusJetsIDSelectionFunctor : public Selector<pat::Muon> {
   index_type indexLepZ_;
   index_type indexPixHits_;
   index_type indexStations_;
-
-
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
@@ -14,9 +14,7 @@
 #include <iostream>
 
 class PFElectronSelector : public Selector<pat::Electron> {
-
- public: // interface
-
+public:  // interface
   bool verbose_;
 
   enum Version_t { SPRING11, N_VERSIONS };
@@ -24,50 +22,43 @@ class PFElectronSelector : public Selector<pat::Electron> {
   PFElectronSelector() {}
 
 #ifndef __GCCXML__
-  PFElectronSelector( edm::ParameterSet const & parameters, edm::ConsumesCollector&& iC ) :
-    PFElectronSelector( parameters )
-  {}
+  PFElectronSelector(edm::ParameterSet const& parameters, edm::ConsumesCollector&& iC)
+      : PFElectronSelector(parameters) {}
 #endif
 
-  PFElectronSelector( edm::ParameterSet const & parameters ) {
-
+  PFElectronSelector(edm::ParameterSet const& parameters) {
     verbose_ = false;
 
     std::string versionStr = parameters.getParameter<std::string>("version");
 
     Version_t version = N_VERSIONS;
 
-    if ( versionStr == "SPRING11" ) {
+    if (versionStr == "SPRING11") {
       version = SPRING11;
-    }
-    else {
+    } else {
       throw cms::Exception("InvalidInput") << "Expect version to be one of SPRING11" << std::endl;
     }
 
-
-    initialize( version,
-		parameters.getParameter<double>("MVA"),
-		parameters.getParameter<double>("D0")  ,
-		parameters.getParameter<int>   ("MaxMissingHits"),
-		parameters.getParameter<std::string> ("electronIDused"),
-		parameters.getParameter<bool>  ("ConversionRejection"),
-		parameters.getParameter<double>("PFIso")
-		);
-    if ( parameters.exists("cutsToIgnore") )
-      setIgnoredCuts( parameters.getParameter<std::vector<std::string> >("cutsToIgnore") );
+    initialize(version,
+               parameters.getParameter<double>("MVA"),
+               parameters.getParameter<double>("D0"),
+               parameters.getParameter<int>("MaxMissingHits"),
+               parameters.getParameter<std::string>("electronIDused"),
+               parameters.getParameter<bool>("ConversionRejection"),
+               parameters.getParameter<double>("PFIso"));
+    if (parameters.exists("cutsToIgnore"))
+      setIgnoredCuts(parameters.getParameter<std::vector<std::string> >("cutsToIgnore"));
 
     retInternal_ = getBitTemplate();
-
   }
 
-  void initialize( Version_t version,
-		   double mva = 0.4,
-		   double d0 = 0.02,
-		   int nMissingHits = 1,
-		   std::string eidUsed = "eidTightMC",
-		   bool convRej = true,
-		   double pfiso = 0.15 )
-  {
+  void initialize(Version_t version,
+                  double mva = 0.4,
+                  double d0 = 0.02,
+                  int nMissingHits = 1,
+                  std::string eidUsed = "eidTightMC",
+                  bool convRej = true,
+                  double pfiso = 0.15) {
     version_ = version;
 
     //    size_t found;
@@ -75,12 +66,12 @@ class PFElectronSelector : public Selector<pat::Electron> {
     //  if ( found != string::npos)
     electronIDvalue_ = eidUsed;
 
-    push_back("D0",        d0     );
-    push_back("MaxMissingHits", nMissingHits  );
+    push_back("D0", d0);
+    push_back("MaxMissingHits", nMissingHits);
     push_back("electronID");
-    push_back("ConversionRejection" );
-    push_back("PFIso",    pfiso );
-    push_back("MVA",       mva   );
+    push_back("ConversionRejection");
+    push_back("PFIso", pfiso);
+    push_back("MVA", mva);
 
     set("D0");
     set("MaxMissingHits");
@@ -89,18 +80,18 @@ class PFElectronSelector : public Selector<pat::Electron> {
     set("PFIso");
     set("MVA");
 
-    indexD0_             = index_type(&bits_, "D0"           );
-    indexMaxMissingHits_ = index_type(&bits_, "MaxMissingHits" );
-    indexElectronId_     = index_type(&bits_, "electronID" );
-    indexConvRej_        = index_type(&bits_, "ConversionRejection" );
-    indexPFIso_          = index_type(&bits_, "PFIso"       );
-    indexMVA_            = index_type(&bits_, "MVA"         );
+    indexD0_ = index_type(&bits_, "D0");
+    indexMaxMissingHits_ = index_type(&bits_, "MaxMissingHits");
+    indexElectronId_ = index_type(&bits_, "electronID");
+    indexConvRej_ = index_type(&bits_, "ConversionRejection");
+    indexPFIso_ = index_type(&bits_, "PFIso");
+    indexMVA_ = index_type(&bits_, "MVA");
   }
 
   // Allow for multiple definitions of the cuts.
-  bool operator()( const pat::Electron & electron, pat::strbitset & ret ) override
-  {
-    if (version_ == SPRING11 ) return spring11Cuts(electron, ret);
+  bool operator()(const pat::Electron& electron, pat::strbitset& ret) override {
+    if (version_ == SPRING11)
+      return spring11Cuts(electron, ret);
     else {
       return false;
     }
@@ -109,9 +100,7 @@ class PFElectronSelector : public Selector<pat::Electron> {
   using Selector<pat::Electron>::operator();
 
   // cuts based on top group L+J synchronization exercise
-  bool spring11Cuts( const pat::Electron & electron, pat::strbitset & ret)
-  {
-
+  bool spring11Cuts(const pat::Electron& electron, pat::strbitset& ret) {
     ret.set(false);
 
     double mva = electron.mva_e_pi();
@@ -119,32 +108,37 @@ class PFElectronSelector : public Selector<pat::Electron> {
     double corr_d0 = electron.dB();
 
     // in >= 39x conversion rejection variables are accessible from Gsf electron
-    Double_t dist = electron.convDist(); // default value is -9999 if conversion partner not found
-    Double_t dcot = electron.convDcot(); // default value is -9999 if conversion partner not found
+    Double_t dist = electron.convDist();  // default value is -9999 if conversion partner not found
+    Double_t dcot = electron.convDcot();  // default value is -9999 if conversion partner not found
     bool isNotConv = !(fabs(dist) < 0.02 && fabs(dcot) < 0.02);
 
-    int bitWiseResults =  (int) electron.electronID( electronIDvalue_ );
-    bool electronIDboolean = ((bitWiseResults & 1) == 1 );
+    int bitWiseResults = (int)electron.electronID(electronIDvalue_);
+    bool electronIDboolean = ((bitWiseResults & 1) == 1);
 
     double chIso = electron.userIsolation(pat::PfChargedHadronIso);
     double nhIso = electron.userIsolation(pat::PfNeutralHadronIso);
-    double gIso  = electron.userIsolation(pat::PfGammaIso);
-    double et    = electron.et() ;
+    double gIso = electron.userIsolation(pat::PfGammaIso);
+    double et = electron.et();
 
     double pfIso = (chIso + nhIso + gIso) / et;
 
-    if ( missingHits   <= cut(indexMaxMissingHits_,  double()) || ignoreCut(indexMaxMissingHits_)   ) passCut(ret, indexMaxMissingHits_  );
-    if ( fabs(corr_d0) <  cut(indexD0_,              double()) || ignoreCut(indexD0_)               ) passCut(ret, indexD0_     );
-    if ( isNotConv                                             || ignoreCut(indexConvRej_)          ) passCut(ret, indexConvRej_     );
-    if ( pfIso         <  cut(indexPFIso_,           double()) || ignoreCut(indexPFIso_)            ) passCut(ret, indexPFIso_ );
-    if ( mva           >  cut(indexMVA_,             double()) || ignoreCut(indexMVA_)              ) passCut(ret, indexMVA_ );
-    if ( electronIDboolean                                     || ignoreCut(indexElectronId_)       ) passCut(ret, indexElectronId_);
+    if (missingHits <= cut(indexMaxMissingHits_, double()) || ignoreCut(indexMaxMissingHits_))
+      passCut(ret, indexMaxMissingHits_);
+    if (fabs(corr_d0) < cut(indexD0_, double()) || ignoreCut(indexD0_))
+      passCut(ret, indexD0_);
+    if (isNotConv || ignoreCut(indexConvRej_))
+      passCut(ret, indexConvRej_);
+    if (pfIso < cut(indexPFIso_, double()) || ignoreCut(indexPFIso_))
+      passCut(ret, indexPFIso_);
+    if (mva > cut(indexMVA_, double()) || ignoreCut(indexMVA_))
+      passCut(ret, indexMVA_);
+    if (electronIDboolean || ignoreCut(indexElectronId_))
+      passCut(ret, indexElectronId_);
     setIgnored(ret);
     return (bool)ret;
   }
 
- private: // member variables
-
+private:  // member variables
   Version_t version_;
 
   index_type indexID;

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -21,115 +21,142 @@
 #include "PhysicsTools/SelectorUtils/interface/Selector.h"
 
 #include <TMath.h>
-class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
-
- public: // interface
-
+class PFJetIDSelectionFunctor : public Selector<pat::Jet> {
+public:  // interface
   enum Version_t { FIRSTDATA, RUNIISTARTUP, WINTER16, WINTER17, WINTER17PUPPI, N_VERSIONS };
-  enum Quality_t { LOOSE, TIGHT, TIGHTLEPVETO, N_QUALITY};
+  enum Quality_t { LOOSE, TIGHT, TIGHTLEPVETO, N_QUALITY };
 
   PFJetIDSelectionFunctor() {}
 
 #ifndef __GCCXML__
-  PFJetIDSelectionFunctor( edm::ParameterSet const & params, edm::ConsumesCollector& iC ) :
-    PFJetIDSelectionFunctor(params)
-  {}
+  PFJetIDSelectionFunctor(edm::ParameterSet const &params, edm::ConsumesCollector &iC)
+      : PFJetIDSelectionFunctor(params) {}
 #endif
 
- PFJetIDSelectionFunctor( edm::ParameterSet const & params )
- {
-   std::string versionStr = params.getParameter<std::string>("version");
-   std::string qualityStr = params.getParameter<std::string>("quality");
+  PFJetIDSelectionFunctor(edm::ParameterSet const &params) {
+    std::string versionStr = params.getParameter<std::string>("version");
+    std::string qualityStr = params.getParameter<std::string>("quality");
 
-   if ( versionStr == "FIRSTDATA" )
-     version_ = FIRSTDATA;
-   else if( versionStr == "RUNIISTARTUP") 
-     version_ = RUNIISTARTUP;  
-   // WINTER16 implements most recent (as of Feb 2017) JetID criteria
-   // See: https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016
-   else if( versionStr == "WINTER16") 
-     version_ = WINTER16; 
-   else if( versionStr == "WINTER17") 
-     version_ = WINTER17;   
-   else if( versionStr == "WINTER17PUPPI")
-     version_ = WINTER17PUPPI;
-   else version_ = WINTER17;//set WINTER17 as default
-   
+    if (versionStr == "FIRSTDATA")
+      version_ = FIRSTDATA;
+    else if (versionStr == "RUNIISTARTUP")
+      version_ = RUNIISTARTUP;
+    // WINTER16 implements most recent (as of Feb 2017) JetID criteria
+    // See: https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016
+    else if (versionStr == "WINTER16")
+      version_ = WINTER16;
+    else if (versionStr == "WINTER17")
+      version_ = WINTER17;
+    else if (versionStr == "WINTER17PUPPI")
+      version_ = WINTER17PUPPI;
+    else
+      version_ = WINTER17;  //set WINTER17 as default
 
-   if      ( qualityStr == "LOOSE") quality_ = LOOSE;
-   else if ( qualityStr == "TIGHT") quality_ = TIGHT;
-   else if ( qualityStr == "TIGHTLEPVETO") quality_ = TIGHTLEPVETO;
-   else quality_ = TIGHT;
+    if (qualityStr == "LOOSE")
+      quality_ = LOOSE;
+    else if (qualityStr == "TIGHT")
+      quality_ = TIGHT;
+    else if (qualityStr == "TIGHTLEPVETO")
+      quality_ = TIGHTLEPVETO;
+    else
+      quality_ = TIGHT;
 
-   initCuts();
+    initCuts();
 
     // Now check the configuration to see if the user changed anything
-    if ( params.exists("CHF") ) set("CHF", params.getParameter<double>("CHF") );
-    if ( params.exists("NHF") ) set("NHF", params.getParameter<double>("NHF") );
-    if ((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) {if ( params.exists("CEF") ) set("CEF", params.getParameter<double>("CEF") );}
-    if ( params.exists("NEF") ) set("NEF", params.getParameter<double>("NEF") );
-    if ( params.exists("NCH") ) set("NCH", params.getParameter<int>   ("NCH") );
-    if ( params.exists("nConstituents") ) set("nConstituents", params.getParameter<int> ("nConstituents") );
-    if(version_ == RUNIISTARTUP){
-      if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
-      if ( params.exists("nNeutrals_FW") ) set("nNeutrals_FW", params.getParameter<int> ("nNeutrals_FW") );
+    if (params.exists("CHF"))
+      set("CHF", params.getParameter<double>("CHF"));
+    if (params.exists("NHF"))
+      set("NHF", params.getParameter<double>("NHF"));
+    if ((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT) {
+      if (params.exists("CEF"))
+        set("CEF", params.getParameter<double>("CEF"));
     }
-    if(version_ == WINTER16){
-      if ( params.exists("NHF_EC") ) set("NHF_EC", params.getParameter<double> ("NHF_EC") );
-      if ( params.exists("NEF_EC") ) set("NEF_EC", params.getParameter<double> ("NEF_EC") );
-      if ( params.exists("nNeutrals_EC") ) set("nNeutrals_EC", params.getParameter<int> ("nNeutrals_EC") );
-      if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
-      if ( params.exists("nNeutrals_FW") ) set("nNeutrals_FW", params.getParameter<int> ("nNeutrals_FW") );
-      if ( quality_ == TIGHTLEPVETO ) {if ( params.exists("MUF") ) set("MUF", params.getParameter<double> ("MUF") );}
+    if (params.exists("NEF"))
+      set("NEF", params.getParameter<double>("NEF"));
+    if (params.exists("NCH"))
+      set("NCH", params.getParameter<int>("NCH"));
+    if (params.exists("nConstituents"))
+      set("nConstituents", params.getParameter<int>("nConstituents"));
+    if (version_ == RUNIISTARTUP) {
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW"))
+        set("nNeutrals_FW", params.getParameter<int>("nNeutrals_FW"));
     }
-    if(version_ == WINTER17){
-      if ( params.exists("NEF_EC_L") ) set("NEF_EC_L", params.getParameter<double> ("NEF_EC_L") );
-      if ( params.exists("NEF_EC_U") ) set("NEF_EC_U", params.getParameter<double> ("NEF_EC_U") );
-      if ( params.exists("nNeutrals_EC") ) set("nNeutrals_EC", params.getParameter<int> ("nNeutrals_EC") );
-      if ( params.exists("NHF_FW") ) set("NHF_FW", params.getParameter<double> ("NHF_FW") );
-      if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
-      if ( params.exists("nNeutrals_FW") ) set("nNeutrals_FW", params.getParameter<int> ("nNeutrals_FW") );
-      if ( quality_ == TIGHTLEPVETO ) {if ( params.exists("MUF") ) set("MUF", params.getParameter<double> ("MUF") );}
+    if (version_ == WINTER16) {
+      if (params.exists("NHF_EC"))
+        set("NHF_EC", params.getParameter<double>("NHF_EC"));
+      if (params.exists("NEF_EC"))
+        set("NEF_EC", params.getParameter<double>("NEF_EC"));
+      if (params.exists("nNeutrals_EC"))
+        set("nNeutrals_EC", params.getParameter<int>("nNeutrals_EC"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW"))
+        set("nNeutrals_FW", params.getParameter<int>("nNeutrals_FW"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
     }
-    if(version_ == WINTER17PUPPI){
-      if ( params.exists("NHF_EC") ) set("NHF_EC", params.getParameter<double> ("NHF_EC") );
-      if ( params.exists("NHF_FW") ) set("NHF_FW", params.getParameter<double> ("NHF_FW") );
-      if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
-      if ( params.exists("nNeutrals_FW_L") ) set("nNeutrals_FW_L", params.getParameter<int> ("nNeutrals_FW_L") );
-      if ( params.exists("nNeutrals_FW_U") ) set("nNeutrals_FW_U", params.getParameter<int> ("nNeutrals_FW_U") );
-      if ( quality_ == TIGHTLEPVETO ) {if ( params.exists("MUF") ) set("MUF", params.getParameter<double> ("MUF") );}
+    if (version_ == WINTER17) {
+      if (params.exists("NEF_EC_L"))
+        set("NEF_EC_L", params.getParameter<double>("NEF_EC_L"));
+      if (params.exists("NEF_EC_U"))
+        set("NEF_EC_U", params.getParameter<double>("NEF_EC_U"));
+      if (params.exists("nNeutrals_EC"))
+        set("nNeutrals_EC", params.getParameter<int>("nNeutrals_EC"));
+      if (params.exists("NHF_FW"))
+        set("NHF_FW", params.getParameter<double>("NHF_FW"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW"))
+        set("nNeutrals_FW", params.getParameter<int>("nNeutrals_FW"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
+    }
+    if (version_ == WINTER17PUPPI) {
+      if (params.exists("NHF_EC"))
+        set("NHF_EC", params.getParameter<double>("NHF_EC"));
+      if (params.exists("NHF_FW"))
+        set("NHF_FW", params.getParameter<double>("NHF_FW"));
+      if (params.exists("NEF_FW"))
+        set("NEF_FW", params.getParameter<double>("NEF_FW"));
+      if (params.exists("nNeutrals_FW_L"))
+        set("nNeutrals_FW_L", params.getParameter<int>("nNeutrals_FW_L"));
+      if (params.exists("nNeutrals_FW_U"))
+        set("nNeutrals_FW_U", params.getParameter<int>("nNeutrals_FW_U"));
+      if (quality_ == TIGHTLEPVETO) {
+        if (params.exists("MUF"))
+          set("MUF", params.getParameter<double>("MUF"));
+      }
     }
 
-
-    if ( params.exists("cutsToIgnore") )
-      setIgnoredCuts( params.getParameter<std::vector<std::string> >("cutsToIgnore") );
+    if (params.exists("cutsToIgnore"))
+      setIgnoredCuts(params.getParameter<std::vector<std::string> >("cutsToIgnore"));
 
     initIndex();
-
   }
 
-
- PFJetIDSelectionFunctor( Version_t version,
-			  Quality_t quality ) :
-  version_(version), quality_(quality)
- {
-   initCuts();
-   initIndex();
- }
-
+  PFJetIDSelectionFunctor(Version_t version, Quality_t quality) : version_(version), quality_(quality) {
+    initCuts();
+    initIndex();
+  }
 
   //
   // Accessor from PAT jets
   //
-  bool operator()( const pat::Jet & jet, pat::strbitset & ret ) override
-  {
-    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 || version_ == WINTER17PUPPI) {
-      if ( jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable() )
-	return firstDataCuts( jet, ret, version_);
+  bool operator()(const pat::Jet &jet, pat::strbitset &ret) override {
+    if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
+        version_ == WINTER17PUPPI) {
+      if (jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable())
+        return firstDataCuts(jet, ret, version_);
       else
-	return firstDataCuts( jet.correctedJet("Uncorrected"), ret, version_ );
-    }
-    else {
+        return firstDataCuts(jet.correctedJet("Uncorrected"), ret, version_);
+    } else {
       return false;
     }
   }
@@ -139,17 +166,16 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   // Accessor from *CORRECTED* 4-vector, EMF, and Jet ID.
   // This can be used with reco quantities.
   //
-  bool operator()( const reco::PFJet & jet, pat::strbitset & ret )
-  {
-    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 || version_ == WINTER17PUPPI  ){ return firstDataCuts( jet, ret, version_);
-    }
-    else {
+  bool operator()(const reco::PFJet &jet, pat::strbitset &ret) {
+    if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
+        version_ == WINTER17PUPPI) {
+      return firstDataCuts(jet, ret, version_);
+    } else {
       return false;
     }
   }
 
-  bool operator()( const reco::PFJet & jet )
-  {
+  bool operator()(const reco::PFJet &jet) {
     retInternal_.set(false);
     operator()(jet, retInternal_);
     setIgnored(retInternal_);
@@ -159,9 +185,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   // cuts based on craft 08 analysis.
   //
-  bool firstDataCuts( reco::Jet const & jet,
-		      pat::strbitset & ret, Version_t version_)
-  {
+  bool firstDataCuts(reco::Jet const &jet, pat::strbitset &ret, Version_t version_) {
     ret.set(false);
 
     // cache some variables
@@ -170,86 +194,82 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     double cef = 0.0;
     double nef = 0.0;
     double muf = 0.0;
-    int    nch = 0;
-    int    nconstituents = 0;
-    int    nneutrals = 0;
+    int nch = 0;
+    int nconstituents = 0;
+    int nneutrals = 0;
 
     // Have to do this because pat::Jet inherits from reco::Jet but not reco::PFJet
-    reco::PFJet const * pfJet = dynamic_cast<reco::PFJet const *>(&jet);
-    pat::Jet const * patJet = dynamic_cast<pat::Jet const *>(&jet);
-    reco::BasicJet const * basicJet = dynamic_cast<reco::BasicJet const *>(&jet);
+    reco::PFJet const *pfJet = dynamic_cast<reco::PFJet const *>(&jet);
+    pat::Jet const *patJet = dynamic_cast<pat::Jet const *>(&jet);
+    reco::BasicJet const *basicJet = dynamic_cast<reco::BasicJet const *>(&jet);
 
-    if ( patJet != nullptr ) {
-      if ( patJet->isPFJet() ) {
-	chf = patJet->chargedHadronEnergyFraction();
-	nhf = patJet->neutralHadronEnergyFraction();
-	cef = patJet->chargedEmEnergyFraction();
-	nef = patJet->neutralEmEnergyFraction();
-	nch = patJet->chargedMultiplicity();
-	nconstituents = patJet->numberOfDaughters();
-	nneutrals = patJet->neutralMultiplicity();
+    if (patJet != nullptr) {
+      if (patJet->isPFJet()) {
+        chf = patJet->chargedHadronEnergyFraction();
+        nhf = patJet->neutralHadronEnergyFraction();
+        cef = patJet->chargedEmEnergyFraction();
+        nef = patJet->neutralEmEnergyFraction();
+        nch = patJet->chargedMultiplicity();
+        nconstituents = patJet->numberOfDaughters();
+        nneutrals = patJet->neutralMultiplicity();
         // Handle the special case of PUPPI jets with weighted multiplicities
         if (patJet->hasUserFloat("patPuppiJetSpecificProducer:puppiMultiplicity"))
-           nconstituents = patJet->userFloat("patPuppiJetSpecificProducer:puppiMultiplicity");
+          nconstituents = patJet->userFloat("patPuppiJetSpecificProducer:puppiMultiplicity");
         if (patJet->hasUserFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity"))
-           nneutrals = patJet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
+          nneutrals = patJet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
       }
       // Handle the special case where this is a composed jet for
       // subjet analyses
-      else if ( patJet->isBasicJet() ) {
-	double e_chf = 0.0;
-	double e_nhf = 0.0;
-	double e_cef = 0.0;
-	double e_nef = 0.0;
-	nch = 0;
-	nconstituents = 0;
-	nneutrals = 0;
+      else if (patJet->isBasicJet()) {
+        double e_chf = 0.0;
+        double e_nhf = 0.0;
+        double e_cef = 0.0;
+        double e_nef = 0.0;
+        nch = 0;
+        nconstituents = 0;
+        nneutrals = 0;
 
-	for ( reco::Jet::const_iterator ibegin = patJet->begin(),
-		iend = patJet->end(), isub = ibegin;
-	      isub != iend; ++isub ) {
-	  reco::PFJet const * pfsub = dynamic_cast<reco::PFJet const *>( &*isub );
-	  pat::Jet const * patsub = dynamic_cast<pat::Jet const *>( &*isub );
-	  if ( patsub ) {
-	    e_chf += patsub->chargedHadronEnergy();
-	    e_nhf += patsub->neutralHadronEnergy();
-	    e_cef += patsub->chargedEmEnergy();
-	    e_nef += patsub->neutralEmEnergy();
-	    nch += patsub->chargedMultiplicity();
+        for (reco::Jet::const_iterator ibegin = patJet->begin(), iend = patJet->end(), isub = ibegin; isub != iend;
+             ++isub) {
+          reco::PFJet const *pfsub = dynamic_cast<reco::PFJet const *>(&*isub);
+          pat::Jet const *patsub = dynamic_cast<pat::Jet const *>(&*isub);
+          if (patsub) {
+            e_chf += patsub->chargedHadronEnergy();
+            e_nhf += patsub->neutralHadronEnergy();
+            e_cef += patsub->chargedEmEnergy();
+            e_nef += patsub->neutralEmEnergy();
+            nch += patsub->chargedMultiplicity();
             nconstituents += patsub->numberOfDaughters();
-	    nneutrals += patsub->neutralMultiplicity();
-	  } else if ( pfsub ) {
+            nneutrals += patsub->neutralMultiplicity();
+          } else if (pfsub) {
             e_chf += pfsub->chargedHadronEnergy();
-	    e_nhf += pfsub->neutralHadronEnergy();
-	    e_cef += pfsub->chargedEmEnergy();
-	    e_nef += pfsub->neutralEmEnergy();
-	    nch += pfsub->chargedMultiplicity();
+            e_nhf += pfsub->neutralHadronEnergy();
+            e_cef += pfsub->chargedEmEnergy();
+            e_nef += pfsub->neutralEmEnergy();
+            nch += pfsub->chargedMultiplicity();
             nconstituents += pfsub->numberOfDaughters();
-	    nneutrals += pfsub->neutralMultiplicity();
-	  } else assert(0);
-	}
-	double e = patJet->energy();
-	if ( e > 0.000001 ) {
-	  chf = e_chf / e;
-	  nhf = e_nhf / e;
-	  cef = e_cef / e;
-	  nef = e_nef / e;
-	} else {
-	  chf = nhf = cef = nef = 0.0;
-	}
+            nneutrals += pfsub->neutralMultiplicity();
+          } else
+            assert(0);
+        }
+        double e = patJet->energy();
+        if (e > 0.000001) {
+          chf = e_chf / e;
+          nhf = e_nhf / e;
+          cef = e_cef / e;
+          nef = e_nef / e;
+        } else {
+          chf = nhf = cef = nef = 0.0;
+        }
       }
-    } // end if pat jet
-    else if ( pfJet != nullptr ) {
+    }  // end if pat jet
+    else if (pfJet != nullptr) {
       // CV: need to compute energy fractions in a way that works for corrected as well as for uncorrected PFJets
-      double jetEnergyUncorrected =
-	pfJet->chargedHadronEnergy()
-       + pfJet->neutralHadronEnergy()
-       + pfJet->photonEnergy()
-       + pfJet->electronEnergy()
-       + pfJet->muonEnergy()
-       + pfJet->HFEMEnergy();
-      if ( jetEnergyUncorrected > 0. ) {
-	chf = pfJet->chargedHadronEnergy() / jetEnergyUncorrected;
+      double jetEnergyUncorrected = pfJet->chargedHadronEnergy() + pfJet->neutralHadronEnergy() +
+                                    pfJet->photonEnergy() + pfJet->electronEnergy() + pfJet->muonEnergy() +
+                                    pfJet->HFEMEnergy();
+      if (jetEnergyUncorrected > 0.) {
+        chf = pfJet->chargedHadronEnergy() / jetEnergyUncorrected;
         nhf = pfJet->neutralHadronEnergy() / jetEnergyUncorrected;
         cef = pfJet->chargedEmEnergy() / jetEnergyUncorrected;
         nef = pfJet->neutralEmEnergy() / jetEnergyUncorrected;
@@ -258,297 +278,350 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       nch = pfJet->chargedMultiplicity();
       nconstituents = pfJet->numberOfDaughters();
       nneutrals = pfJet->neutralMultiplicity();
-    } // end if PF jet
+    }  // end if PF jet
     // Handle the special case where this is a composed jet for
     // subjet analyses
-    else if ( basicJet != nullptr ) {
+    else if (basicJet != nullptr) {
       double e_chf = 0.0;
       double e_nhf = 0.0;
       double e_cef = 0.0;
       double e_nef = 0.0;
       nch = 0;
       nconstituents = 0;
-      for ( reco::Jet::const_iterator ibegin = basicJet->begin(),
-	      iend = patJet->end(), isub = ibegin;
-	    isub != iend; ++isub ) {
-	reco::PFJet const * pfsub = dynamic_cast<reco::PFJet const *>( &*isub );
-	e_chf += pfsub->chargedHadronEnergy();
-	e_nhf += pfsub->neutralHadronEnergy();
-	e_cef += pfsub->chargedEmEnergy();
-	e_nef += pfsub->neutralEmEnergy();
-	nch += pfsub->chargedMultiplicity();
-	nconstituents += pfsub->numberOfDaughters();
-	nneutrals += pfsub->neutralMultiplicity();
+      for (reco::Jet::const_iterator ibegin = basicJet->begin(), iend = patJet->end(), isub = ibegin; isub != iend;
+           ++isub) {
+        reco::PFJet const *pfsub = dynamic_cast<reco::PFJet const *>(&*isub);
+        e_chf += pfsub->chargedHadronEnergy();
+        e_nhf += pfsub->neutralHadronEnergy();
+        e_cef += pfsub->chargedEmEnergy();
+        e_nef += pfsub->neutralEmEnergy();
+        nch += pfsub->chargedMultiplicity();
+        nconstituents += pfsub->numberOfDaughters();
+        nneutrals += pfsub->neutralMultiplicity();
       }
       double e = basicJet->energy();
-      if ( e > 0.000001 ) {
-	chf = e_chf / e;
-	nhf = e_nhf / e;
-	cef = e_cef / e;
-	nef = e_nef / e;
+      if (e > 0.000001) {
+        chf = e_chf / e;
+        nhf = e_nhf / e;
+        cef = e_cef / e;
+        nef = e_nef / e;
       }
-    } // end if basic jet
+    }  // end if basic jet
 
-
-
-   // Cuts for |eta| < 2.4 for FIRSTDATA, RUNIISTARTUP, WINTER16 and WINTER17
-    if((version_ != WINTER17 && version_ != WINTER17PUPPI) ||  quality_ != TIGHT ) {if ( ignoreCut(indexCEF_)           || ( cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCEF_);}
-
-    if ( ignoreCut(indexCHF_)           || ( chf > cut(indexCHF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCHF_);
-    if ( ignoreCut(indexNCH_)           || ( nch > cut(indexNCH_, int())    || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexNCH_);
-
-    if(version_ == FIRSTDATA){// Cuts for all eta for FIRSTDATA
-      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) ) ) passCut( ret, indexNConstituents_);
-      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double()) ) ) passCut( ret, indexNEF_);
-      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double()) ) ) passCut( ret, indexNHF_);
-    }else if(version_ == RUNIISTARTUP){
-      // Cuts for |eta| <= 3.0 for RUNIISTARTUP scenario
-      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 3.0 ) ) passCut( ret, indexNConstituents_);
-      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double())  || std::abs(jet.eta()) > 3.0 ) ) passCut( ret, indexNEF_);
-      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double())  || std::abs(jet.eta()) > 3.0 ) ) passCut( ret, indexNHF_);
-      // Cuts for |eta| > 3.0 for RUNIISTARTUP scenario
-      if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
-      if ( ignoreCut(indexNNeutrals_FW_) || ( nneutrals > cut(indexNNeutrals_FW_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_);
+    // Cuts for |eta| < 2.4 for FIRSTDATA, RUNIISTARTUP, WINTER16 and WINTER17
+    if ((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT) {
+      if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4))
+        passCut(ret, indexCEF_);
     }
-    else if(version_ == WINTER16){
+
+    if (ignoreCut(indexCHF_) || (chf > cut(indexCHF_, double()) || std::abs(jet.eta()) > 2.4))
+      passCut(ret, indexCHF_);
+    if (ignoreCut(indexNCH_) || (nch > cut(indexNCH_, int()) || std::abs(jet.eta()) > 2.4))
+      passCut(ret, indexNCH_);
+
+    if (version_ == FIRSTDATA) {  // Cuts for all eta for FIRSTDATA
+      if (ignoreCut(indexNConstituents_) || (nconstituents > cut(indexNConstituents_, int())))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double())))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double())))
+        passCut(ret, indexNHF_);
+    } else if (version_ == RUNIISTARTUP) {
+      // Cuts for |eta| <= 3.0 for RUNIISTARTUP scenario
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNHF_);
+      // Cuts for |eta| > 3.0 for RUNIISTARTUP scenario
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_) || (nneutrals > cut(indexNNeutrals_FW_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_);
+    } else if (version_ == WINTER16) {
       // Cuts for |eta| <= 2.7 for WINTER16 scenario
-      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNConstituents_);
-      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNEF_);
-      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNHF_);
-      if ( quality_ == TIGHTLEPVETO ) {if ( ignoreCut(indexMUF_)           || ( muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexMUF_);}
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7))
+          passCut(ret, indexMUF_);
+      }
 
       // Cuts for 2.7 < |eta| <= 3.0 for WINTER16 scenario
-      if ( ignoreCut(indexNHF_EC_)        || ( nhf < cut(indexNHF_EC_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNHF_EC_);
-      if ( ignoreCut(indexNEF_EC_)        || ( nef > cut(indexNEF_EC_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNEF_EC_);
-      if ( ignoreCut(indexNNeutrals_EC_)  || ( nneutrals > cut(indexNNeutrals_EC_, int())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNNeutrals_EC_);
+      if (ignoreCut(indexNHF_EC_) ||
+          (nhf < cut(indexNHF_EC_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNHF_EC_);
+      if (ignoreCut(indexNEF_EC_) ||
+          (nef > cut(indexNEF_EC_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_);
+      if (ignoreCut(indexNNeutrals_EC_) ||
+          (nneutrals > cut(indexNNeutrals_EC_, int()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNNeutrals_EC_);
 
       // Cuts for |eta| > 3.0 for WINTER16 scenario
-      if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
-      if ( ignoreCut(indexNNeutrals_FW_) || ( nneutrals > cut(indexNNeutrals_FW_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_);
-    }
-    else if(version_ == WINTER17){
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_) || (nneutrals > cut(indexNNeutrals_FW_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_);
+    } else if (version_ == WINTER17) {
       // Cuts for |eta| <= 2.7 for WINTER17 scenario
-      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNConstituents_);
-      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNEF_);
-      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNHF_);
-      if ( quality_ == TIGHTLEPVETO ) {if ( ignoreCut(indexMUF_)           || ( muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexMUF_);}
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7))
+          passCut(ret, indexMUF_);
+      }
 
       // Cuts for 2.7 < |eta| <= 3.0 for WINTER17 scenario
 
-      if ( ignoreCut(indexNEF_EC_L_)        || ( nef > cut(indexNEF_EC_L_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNEF_EC_L_);
-      if ( ignoreCut(indexNEF_EC_U_)        || ( nef < cut(indexNEF_EC_U_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNEF_EC_U_);  
-      if ( ignoreCut(indexNNeutrals_EC_)  || ( nneutrals > cut(indexNNeutrals_EC_, int())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNNeutrals_EC_);
+      if (ignoreCut(indexNEF_EC_L_) ||
+          (nef > cut(indexNEF_EC_L_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_L_);
+      if (ignoreCut(indexNEF_EC_U_) ||
+          (nef < cut(indexNEF_EC_U_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNEF_EC_U_);
+      if (ignoreCut(indexNNeutrals_EC_) ||
+          (nneutrals > cut(indexNNeutrals_EC_, int()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNNeutrals_EC_);
 
       // Cuts for |eta| > 3.0 for WINTER17 scenario
-      if ( ignoreCut(indexNHF_FW_)           || ( nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNHF_FW_);
-      if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
-      if ( ignoreCut(indexNNeutrals_FW_) || ( nneutrals > cut(indexNNeutrals_FW_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_);
+      if (ignoreCut(indexNHF_FW_) || (nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNHF_FW_);
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_) || (nneutrals > cut(indexNNeutrals_FW_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_);
 
-    }
-    else if(version_ == WINTER17PUPPI){
+    } else if (version_ == WINTER17PUPPI) {
       // Cuts for |eta| <= 2.7 for WINTER17 scenario
-      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNConstituents_);
-      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNEF_);
-      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNHF_);
-      if ( quality_ == TIGHTLEPVETO ) {if ( ignoreCut(indexMUF_)           || ( muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexMUF_);}
+      if (ignoreCut(indexNConstituents_) ||
+          (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNConstituents_);
+      if (ignoreCut(indexNEF_) || (nef < cut(indexNEF_, double()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNEF_);
+      if (ignoreCut(indexNHF_) || (nhf < cut(indexNHF_, double()) || std::abs(jet.eta()) > 2.7))
+        passCut(ret, indexNHF_);
+      if (quality_ == TIGHTLEPVETO) {
+        if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7))
+          passCut(ret, indexMUF_);
+      }
 
       // Cuts for 2.7 < |eta| <= 3.0 for WINTER17 scenario
 
-      if ( ignoreCut(indexNHF_EC_)        || ( nhf < cut(indexNHF_EC_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNHF_EC_);
+      if (ignoreCut(indexNHF_EC_) ||
+          (nhf < cut(indexNHF_EC_, double()) || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0))
+        passCut(ret, indexNHF_EC_);
 
       // Cuts for |eta| > 3.0 for WINTER17 scenario
-      if ( ignoreCut(indexNHF_FW_)           || ( nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNHF_FW_);
-      if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
-      if ( ignoreCut(indexNNeutrals_FW_L_) || ( nneutrals > cut(indexNNeutrals_FW_L_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_L_);
-      if ( ignoreCut(indexNNeutrals_FW_U_) || ( nneutrals < cut(indexNNeutrals_FW_U_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_U_);
-
+      if (ignoreCut(indexNHF_FW_) || (nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNHF_FW_);
+      if (ignoreCut(indexNEF_FW_) || (nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNEF_FW_);
+      if (ignoreCut(indexNNeutrals_FW_L_) ||
+          (nneutrals > cut(indexNNeutrals_FW_L_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_L_);
+      if (ignoreCut(indexNNeutrals_FW_U_) ||
+          (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
+        passCut(ret, indexNNeutrals_FW_U_);
     }
-
 
     //std::cout << "<PFJetIDSelectionFunctor::firstDataCuts>:" << std::endl;
     //std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
     //ret.print(std::cout);
 
-    setIgnored( ret );
+    setIgnored(ret);
     return (bool)ret;
   }
 
- private: // member variables
-
-  void initCuts()
-  {
-    push_back("CHF" );
-    push_back("NHF" );
-    if( (version_ != WINTER17 && version_!=WINTER17PUPPI) || quality_ != TIGHT ) push_back("CEF" );
-    push_back("NEF" );
-    push_back("NCH" );
+private:  // member variables
+  void initCuts() {
+    push_back("CHF");
+    push_back("NHF");
+    if ((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT)
+      push_back("CEF");
+    push_back("NEF");
+    push_back("NCH");
     push_back("nConstituents");
-    if(version_ == RUNIISTARTUP ){
+    if (version_ == RUNIISTARTUP) {
       push_back("NEF_FW");
       push_back("nNeutrals_FW");
     }
-    if(version_ == WINTER16 ){
+    if (version_ == WINTER16) {
       push_back("NHF_EC");
       push_back("NEF_EC");
       push_back("nNeutrals_EC");
       push_back("NEF_FW");
       push_back("nNeutrals_FW");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+      if (quality_ == TIGHTLEPVETO)
+        push_back("MUF");
     }
-    if(version_ == WINTER17 ){
+    if (version_ == WINTER17) {
       push_back("NEF_EC_L");
       push_back("NEF_EC_U");
       push_back("nNeutrals_EC");
       push_back("NEF_FW");
       push_back("NHF_FW");
       push_back("nNeutrals_FW");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+      if (quality_ == TIGHTLEPVETO)
+        push_back("MUF");
     }
-    if(version_ == WINTER17PUPPI ){
+    if (version_ == WINTER17PUPPI) {
       push_back("NHF_EC");
       push_back("NEF_FW");
       push_back("NHF_FW");
       push_back("nNeutrals_FW_L");
       push_back("nNeutrals_FW_U");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+      if (quality_ == TIGHTLEPVETO)
+        push_back("MUF");
     }
- 
 
-    if( (version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE ){
-      edm::LogWarning("BadJetIDVersion") << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
+    if ((version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE) {
+      edm::LogWarning("BadJetIDVersion")
+          << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
       quality_ = TIGHT;
-      }
+    }
 
     // Set some default cuts for LOOSE, TIGHT
-    if ( quality_ == LOOSE ) {
+    if (quality_ == LOOSE) {
       set("CHF", 0.0);
       set("NHF", 0.99);
       set("CEF", 0.99);
       set("NEF", 0.99);
       set("NCH", 0);
       set("nConstituents", 1);
-      if(version_ == RUNIISTARTUP){
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      else if(version_ == WINTER16){
-	set("NHF_EC",0.98);
-	set("NEF_EC",0.01);
-	set("nNeutrals_EC",2);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
+      if (version_ == RUNIISTARTUP) {
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == WINTER16) {
+        set("NHF_EC", 0.98);
+        set("NEF_EC", 0.01);
+        set("nNeutrals_EC", 2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
       }
 
-
-    } else if ( quality_ == TIGHT ) {
+    } else if (quality_ == TIGHT) {
       set("CHF", 0.0);
       set("NHF", 0.9);
-      if(version_ != WINTER17 && version_ != WINTER17PUPPI ) set("CEF", 0.99);
+      if (version_ != WINTER17 && version_ != WINTER17PUPPI)
+        set("CEF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
       set("nConstituents", 1);
-      if(version_ == RUNIISTARTUP){
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      else if(version_ == WINTER16){
-	set("NHF_EC",0.98);
-	set("NEF_EC",0.01);
-	set("nNeutrals_EC",2);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      else if(version_ == WINTER17){
-	set("NEF_EC_L",0.02);
-	set("NEF_EC_U",0.99);
-	set("nNeutrals_EC",2);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      else if(version_ == WINTER17PUPPI){
-	set("NHF_EC",0.99);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW_L",2);
-	set("nNeutrals_FW_U",15);
+      if (version_ == RUNIISTARTUP) {
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == WINTER16) {
+        set("NHF_EC", 0.98);
+        set("NEF_EC", 0.01);
+        set("nNeutrals_EC", 2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == WINTER17) {
+        set("NEF_EC_L", 0.02);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 2);
+        set("NHF_FW", 0.02);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == WINTER17PUPPI) {
+        set("NHF_EC", 0.99);
+        set("NHF_FW", 0.02);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 15);
       }
 
-    }else if ( quality_ == TIGHTLEPVETO ) {
+    } else if (quality_ == TIGHTLEPVETO) {
       set("CHF", 0.0);
       set("NHF", 0.9);
       set("NEF", 0.9);
       set("NCH", 0);
       set("nConstituents", 1);
-      if(version_ == WINTER17){
-	set("CEF", 0.8);
-	set("NEF_EC_L",0.02);
-	set("NEF_EC_U",0.99);
-	set("nNeutrals_EC",2);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-	set("MUF", 0.8);
+      if (version_ == WINTER17) {
+        set("CEF", 0.8);
+        set("NEF_EC_L", 0.02);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 2);
+        set("NHF_FW", 0.02);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+        set("MUF", 0.8);
+      } else if (version_ == WINTER17PUPPI) {
+        set("CEF", 0.8);
+        set("NHF_EC", 0.99);
+        set("NHF_FW", 0.02);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 15);
+        set("MUF", 0.8);
+      } else if (version_ == WINTER16) {
+        set("CEF", 0.9);
+        set("NEF_EC", 0.01);
+        set("NHF_EC", 0.98);
+        set("nNeutrals_EC", 2);
+        set("nNeutrals_FW", 10);
+        set("NEF_FW", 0.90);
+        set("MUF", 0.8);
       }
-      else if(version_ == WINTER17PUPPI){
-	set("CEF", 0.8);
-	set("NHF_EC",0.99);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW_L",2);
-	set("nNeutrals_FW_U",15);
-	set("MUF", 0.8);
-      }
-      else if(version_ == WINTER16){
-	set("CEF", 0.9);
-	set("NEF_EC",0.01);
-	set("NHF_EC",0.98);
-	set("nNeutrals_EC",2);
-	set("nNeutrals_FW",10);
-	set("NEF_FW",0.90);
-	set("MUF", 0.8);
-      }
-
     }
   }
 
-  void initIndex()
-  {
-    indexNConstituents_ = index_type (&bits_, "nConstituents");
-    indexNEF_ = index_type (&bits_, "NEF");
-    indexNHF_ = index_type (&bits_, "NHF");
-    if((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
+  void initIndex() {
+    indexNConstituents_ = index_type(&bits_, "nConstituents");
+    indexNEF_ = index_type(&bits_, "NEF");
+    indexNHF_ = index_type(&bits_, "NHF");
+    if ((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT)
+      indexCEF_ = index_type(&bits_, "CEF");
 
-    indexCHF_ = index_type (&bits_, "CHF");
-    indexNCH_ = index_type (&bits_, "NCH");
-    if(version_ == RUNIISTARTUP){
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
+    indexCHF_ = index_type(&bits_, "CHF");
+    indexNCH_ = index_type(&bits_, "NCH");
+    if (version_ == RUNIISTARTUP) {
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type(&bits_, "nNeutrals_FW");
     }
-    if(version_ == WINTER16){
-      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
-      indexNEF_EC_ = index_type (&bits_, "NEF_EC");
-      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
+    if (version_ == WINTER16) {
+      indexNHF_EC_ = index_type(&bits_, "NHF_EC");
+      indexNEF_EC_ = index_type(&bits_, "NEF_EC");
+      indexNNeutrals_EC_ = index_type(&bits_, "nNeutrals_EC");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type(&bits_, "nNeutrals_FW");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
+      }
     }
-    if(version_ == WINTER17){
-      indexNEF_EC_L_ = index_type (&bits_, "NEF_EC_L");
-      indexNEF_EC_U_ = index_type (&bits_, "NEF_EC_U");
-      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
-      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
+    if (version_ == WINTER17) {
+      indexNEF_EC_L_ = index_type(&bits_, "NEF_EC_L");
+      indexNEF_EC_U_ = index_type(&bits_, "NEF_EC_U");
+      indexNNeutrals_EC_ = index_type(&bits_, "nNeutrals_EC");
+      indexNHF_FW_ = index_type(&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type(&bits_, "nNeutrals_FW");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
+      }
     }
-    if(version_ == WINTER17PUPPI){
-      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
-      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_L_ = index_type (&bits_, "nNeutrals_FW_L");
-      indexNNeutrals_FW_U_ = index_type (&bits_, "nNeutrals_FW_U");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
+    if (version_ == WINTER17PUPPI) {
+      indexNHF_EC_ = index_type(&bits_, "NHF_EC");
+      indexNHF_FW_ = index_type(&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type(&bits_, "NEF_FW");
+      indexNNeutrals_FW_L_ = index_type(&bits_, "nNeutrals_FW_L");
+      indexNNeutrals_FW_U_ = index_type(&bits_, "nNeutrals_FW_U");
+      if (quality_ == TIGHTLEPVETO) {
+        indexMUF_ = index_type(&bits_, "MUF");
+      }
     }
 
     retInternal_ = getBitTemplate();
@@ -576,8 +649,6 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   index_type indexNEF_EC_L_;
   index_type indexNEF_EC_U_;
   index_type indexNNeutrals_EC_;
-
-
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/PFMuonSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFMuonSelector.h
@@ -14,9 +14,7 @@
 #include <iostream>
 
 class PFMuonSelector : public Selector<pat::Muon> {
-
- public: // interface
-
+public:  // interface
   bool verbose_;
 
   enum Version_t { TOPPAG12_LJETS, N_VERSIONS };
@@ -24,63 +22,55 @@ class PFMuonSelector : public Selector<pat::Muon> {
   PFMuonSelector() {}
 
 #ifndef __GCCXML__
-  PFMuonSelector( edm::ParameterSet const & parameters, edm::ConsumesCollector&& iC ) :
-    PFMuonSelector( parameters )
-  {}
+  PFMuonSelector(edm::ParameterSet const& parameters, edm::ConsumesCollector&& iC) : PFMuonSelector(parameters) {}
 #endif
 
-  PFMuonSelector( edm::ParameterSet const & parameters ) {
-
+  PFMuonSelector(edm::ParameterSet const& parameters) {
     verbose_ = false;
 
     std::string versionStr = parameters.getParameter<std::string>("version");
 
     Version_t version = N_VERSIONS;
 
-    if ( versionStr == "TOPPAG12_LJETS" ) {
+    if (versionStr == "TOPPAG12_LJETS") {
       version = TOPPAG12_LJETS;
-    }
-    else {
+    } else {
       throw cms::Exception("InvalidInput") << "Expect version to be one of SPRING11" << std::endl;
     }
 
-    initialize( version,
-                parameters.getParameter<double>("Chi2"),
-                parameters.getParameter<int>   ("minTrackerLayers"),
-                parameters.getParameter<int>   ("minValidMuHits"),
-                parameters.getParameter<double>("maxIp"),
-                parameters.getParameter<int>   ("minPixelHits"),
-                parameters.getParameter<int>   ("minMatchedStations"),
-                parameters.getParameter<double>("maxPfRelIso")
-		);
-    if ( parameters.exists("cutsToIgnore") )
-      setIgnoredCuts( parameters.getParameter<std::vector<std::string> >("cutsToIgnore") );
+    initialize(version,
+               parameters.getParameter<double>("Chi2"),
+               parameters.getParameter<int>("minTrackerLayers"),
+               parameters.getParameter<int>("minValidMuHits"),
+               parameters.getParameter<double>("maxIp"),
+               parameters.getParameter<int>("minPixelHits"),
+               parameters.getParameter<int>("minMatchedStations"),
+               parameters.getParameter<double>("maxPfRelIso"));
+    if (parameters.exists("cutsToIgnore"))
+      setIgnoredCuts(parameters.getParameter<std::vector<std::string> >("cutsToIgnore"));
 
     retInternal_ = getBitTemplate();
-
   }
 
-  void initialize( Version_t version,
-                   double    chi2             = 10.0,
-                   int       minTrackerLayers = 6,
-                   int       minValidMuonHits = 1,
-                   double    maxIp            = 0.2,
-                   int       minPixelHits     = 1,
-                   int       minNMatches      = 2,
-                   double    pfiso            = 0.12
-                   )
-  {
+  void initialize(Version_t version,
+                  double chi2 = 10.0,
+                  int minTrackerLayers = 6,
+                  int minValidMuonHits = 1,
+                  double maxIp = 0.2,
+                  int minPixelHits = 1,
+                  int minNMatches = 2,
+                  double pfiso = 0.12) {
     version_ = version;
 
-    push_back("GlobalMuon",         true);
-    push_back("TrackerMuon",        true);
-    push_back("Chi2",               chi2   );
-    push_back("minTrackerLayers",   minTrackerLayers);
-    push_back("minValidMuHits",     minValidMuonHits  );
-    push_back("maxIp",              maxIp );
-    push_back("minPixelHits",       minPixelHits);
+    push_back("GlobalMuon", true);
+    push_back("TrackerMuon", true);
+    push_back("Chi2", chi2);
+    push_back("minTrackerLayers", minTrackerLayers);
+    push_back("minValidMuHits", minValidMuonHits);
+    push_back("maxIp", maxIp);
+    push_back("minPixelHits", minPixelHits);
     push_back("minMatchedStations", minNMatches);
-    push_back("maxPfRelIso",        pfiso );
+    push_back("maxPfRelIso", pfiso);
 
     set("GlobalMuon");
     set("TrackerMuon");
@@ -92,25 +82,23 @@ class PFMuonSelector : public Selector<pat::Muon> {
     set("minMatchedStations");
     set("maxPfRelIso");
 
-    indexChi2_             = index_type(&bits_, "Chi2"            );
-    indexMinTrackerLayers_ = index_type(&bits_, "minTrackerLayers" );
-    indexminValidMuHits_   = index_type(&bits_, "minValidMuHits"      );
-    indexMaxIp_            = index_type(&bits_, "maxIp"      );
-    indexPixHits_          = index_type(&bits_, "minPixelHits"      );
-    indexStations_         = index_type(&bits_, "minMatchedStations");
-    indexmaxPfRelIso_      = index_type(&bits_, "maxPfRelIso"           );
+    indexChi2_ = index_type(&bits_, "Chi2");
+    indexMinTrackerLayers_ = index_type(&bits_, "minTrackerLayers");
+    indexminValidMuHits_ = index_type(&bits_, "minValidMuHits");
+    indexMaxIp_ = index_type(&bits_, "maxIp");
+    indexPixHits_ = index_type(&bits_, "minPixelHits");
+    indexStations_ = index_type(&bits_, "minMatchedStations");
+    indexmaxPfRelIso_ = index_type(&bits_, "maxPfRelIso");
 
-
-    if (version_ == TOPPAG12_LJETS ){
+    if (version_ == TOPPAG12_LJETS) {
       set("TrackerMuon", false);
     }
-
   }
 
   // Allow for multiple definitions of the cuts.
-  bool operator()( const pat::Muon & muon, pat::strbitset & ret ) override
-  {
-    if (version_ == TOPPAG12_LJETS ) return TopPag12LjetsCuts(muon, ret);
+  bool operator()(const pat::Muon& muon, pat::strbitset& ret) override {
+    if (version_ == TOPPAG12_LJETS)
+      return TopPag12LjetsCuts(muon, ret);
     else {
       return false;
     }
@@ -118,22 +106,21 @@ class PFMuonSelector : public Selector<pat::Muon> {
 
   using Selector<pat::Muon>::operator();
 
-  bool TopPag12LjetsCuts( const pat::Muon & muon, pat::strbitset & ret){
-
+  bool TopPag12LjetsCuts(const pat::Muon& muon, pat::strbitset& ret) {
     ret.set(false);
 
-    bool isGlobal  = muon.isGlobalMuon();
+    bool isGlobal = muon.isGlobalMuon();
     bool isTracker = muon.isTrackerMuon();
 
-    double norm_chi2     = 9999999.0;
+    double norm_chi2 = 9999999.0;
     int minTrackerLayers = 0;
     int minValidMuonHits = 0;
     int _ip = 0.0;
     int minPixelHits = 0;
-    if ( muon.globalTrack().isNonnull() && muon.globalTrack().isAvailable() ){
-      norm_chi2        = muon.normChi2();
-      minTrackerLayers = static_cast<int> (muon.track()->hitPattern().trackerLayersWithMeasurement());
-      minValidMuonHits = static_cast<int> (muon.globalTrack()->hitPattern().numberOfValidMuonHits());
+    if (muon.globalTrack().isNonnull() && muon.globalTrack().isAvailable()) {
+      norm_chi2 = muon.normChi2();
+      minTrackerLayers = static_cast<int>(muon.track()->hitPattern().trackerLayersWithMeasurement());
+      minValidMuonHits = static_cast<int>(muon.globalTrack()->hitPattern().numberOfValidMuonHits());
       _ip = muon.dB();
       minPixelHits = muon.innerTrack()->hitPattern().numberOfValidPixelHits();
     }
@@ -142,30 +129,36 @@ class PFMuonSelector : public Selector<pat::Muon> {
 
     double chIso = muon.userIsolation(pat::PfChargedHadronIso);
     double nhIso = muon.userIsolation(pat::PfNeutralHadronIso);
-    double gIso  = muon.userIsolation(pat::PfGammaIso);
-    double pt    = muon.pt() ;
+    double gIso = muon.userIsolation(pat::PfGammaIso);
+    double pt = muon.pt();
 
     double pfIso = (chIso + nhIso + gIso) / pt;
 
-    if ( isGlobal  || ignoreCut("GlobalMuon")  )  passCut(ret, "GlobalMuon" );
-    if ( isTracker || ignoreCut("TrackerMuon")  )  passCut(ret, "TrackerMuon" );
-    if ( norm_chi2          <  cut(indexChi2_,   double()) || ignoreCut(indexChi2_)    ) passCut(ret, indexChi2_   );
-    if ( minTrackerLayers   >= cut(indexMinTrackerLayers_,int()) || ignoreCut(indexMinTrackerLayers_)) passCut(ret, indexMinTrackerLayers_  );
-    if ( minValidMuonHits   >= cut(indexminValidMuHits_,int()) || ignoreCut(indexminValidMuHits_)) passCut(ret, indexminValidMuHits_  );
-    if ( _ip                <  cut(indexMaxIp_,double()) || ignoreCut(indexMaxIp_)) passCut(ret, indexMaxIp_  );
-    if ( minPixelHits       >= cut(indexPixHits_,int())    || ignoreCut(indexPixHits_))  passCut(ret, indexPixHits_);
-    if ( minMatchedStations >= cut(indexStations_,int())  || ignoreCut(indexStations_))  passCut(ret, indexStations_);
-    if ( pfIso              <  cut(indexmaxPfRelIso_, double())  || ignoreCut(indexmaxPfRelIso_)  ) passCut(ret, indexmaxPfRelIso_ );
+    if (isGlobal || ignoreCut("GlobalMuon"))
+      passCut(ret, "GlobalMuon");
+    if (isTracker || ignoreCut("TrackerMuon"))
+      passCut(ret, "TrackerMuon");
+    if (norm_chi2 < cut(indexChi2_, double()) || ignoreCut(indexChi2_))
+      passCut(ret, indexChi2_);
+    if (minTrackerLayers >= cut(indexMinTrackerLayers_, int()) || ignoreCut(indexMinTrackerLayers_))
+      passCut(ret, indexMinTrackerLayers_);
+    if (minValidMuonHits >= cut(indexminValidMuHits_, int()) || ignoreCut(indexminValidMuHits_))
+      passCut(ret, indexminValidMuHits_);
+    if (_ip < cut(indexMaxIp_, double()) || ignoreCut(indexMaxIp_))
+      passCut(ret, indexMaxIp_);
+    if (minPixelHits >= cut(indexPixHits_, int()) || ignoreCut(indexPixHits_))
+      passCut(ret, indexPixHits_);
+    if (minMatchedStations >= cut(indexStations_, int()) || ignoreCut(indexStations_))
+      passCut(ret, indexStations_);
+    if (pfIso < cut(indexmaxPfRelIso_, double()) || ignoreCut(indexmaxPfRelIso_))
+      passCut(ret, indexmaxPfRelIso_);
 
     setIgnored(ret);
 
     return (bool)ret;
   }
 
-
-
- private: // member variables
-
+private:  // member variables
   Version_t version_;
 
   index_type indexChi2_;
@@ -175,8 +168,6 @@ class PFMuonSelector : public Selector<pat::Muon> {
   index_type indexPixHits_;
   index_type indexStations_;
   index_type indexmaxPfRelIso_;
-
-
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/PVObjectSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PVObjectSelector.h
@@ -16,46 +16,41 @@
 // make a selector for this selection
 class PVObjectSelector : public Selector<reco::Vertex> {
 public:
-
   PVObjectSelector() {}
 
 #ifndef __GCCXML__
-  PVObjectSelector( edm::ParameterSet const & params, edm::ConsumesCollector&& iC ) :
-    PVObjectSelector( params )
-  {}
+  PVObjectSelector(edm::ParameterSet const& params, edm::ConsumesCollector&& iC) : PVObjectSelector(params) {}
 #endif
 
- PVObjectSelector( edm::ParameterSet const & params )  {
-    push_back("PV NDOF", params.getParameter<double>("minNdof") );
-    push_back("PV Z", params.getParameter<double>("maxZ") );
-    push_back("PV RHO", params.getParameter<double>("maxRho") );
+  PVObjectSelector(edm::ParameterSet const& params) {
+    push_back("PV NDOF", params.getParameter<double>("minNdof"));
+    push_back("PV Z", params.getParameter<double>("maxZ"));
+    push_back("PV RHO", params.getParameter<double>("maxRho"));
     set("PV NDOF");
     set("PV Z");
     set("PV RHO");
 
-    indexNDOF_ = index_type (&bits_, "PV NDOF");
-    indexZ_    = index_type (&bits_, "PV Z");
-    indexRho_  = index_type (&bits_, "PV RHO");
+    indexNDOF_ = index_type(&bits_, "PV NDOF");
+    indexZ_ = index_type(&bits_, "PV Z");
+    indexRho_ = index_type(&bits_, "PV RHO");
 
-    if ( params.exists("cutsToIgnore") )
-      setIgnoredCuts( params.getParameter<std::vector<std::string> >("cutsToIgnore") );
+    if (params.exists("cutsToIgnore"))
+      setIgnoredCuts(params.getParameter<std::vector<std::string> >("cutsToIgnore"));
 
     retInternal_ = getBitTemplate();
   }
 
- bool operator() ( reco::Vertex const & pv,  pat::strbitset & ret ) override {
-    if ( pv.isFake() ) return false;
+  bool operator()(reco::Vertex const& pv, pat::strbitset& ret) override {
+    if (pv.isFake())
+      return false;
 
-    if ( pv.ndof() >= cut(indexNDOF_, double() )
-	 || ignoreCut(indexNDOF_)    ) {
-      passCut(ret, indexNDOF_ );
-      if ( fabs(pv.z()) <= cut(indexZ_, double())
-	   || ignoreCut(indexZ_)    ) {
-	passCut(ret, indexZ_ );
-	if ( fabs(pv.position().Rho()) <= cut(indexRho_, double() )
-	     || ignoreCut(indexRho_) ) {
-	  passCut( ret, indexRho_);
-	}
+    if (pv.ndof() >= cut(indexNDOF_, double()) || ignoreCut(indexNDOF_)) {
+      passCut(ret, indexNDOF_);
+      if (fabs(pv.z()) <= cut(indexZ_, double()) || ignoreCut(indexZ_)) {
+        passCut(ret, indexZ_);
+        if (fabs(pv.position().Rho()) <= cut(indexRho_, double()) || ignoreCut(indexRho_)) {
+          passCut(ret, indexRho_);
+        }
       }
     }
 
@@ -64,7 +59,7 @@ public:
     return (bool)ret;
   }
 
- using Selector<reco::Vertex>::operator();
+  using Selector<reco::Vertex>::operator();
 
 private:
   index_type indexNDOF_;

--- a/PhysicsTools/SelectorUtils/interface/PVSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PVSelector.h
@@ -10,50 +10,45 @@
 #include "PhysicsTools/SelectorUtils/interface/EventSelector.h"
 #include "PhysicsTools/SelectorUtils/interface/PVObjectSelector.h"
 
-
 // make a selector for this selection
 class PVSelector : public Selector<edm::EventBase> {
 public:
-
   PVSelector() {}
 
-  PVSelector( edm::ParameterSet const & params ) :
-    pvSrc_ (params.getParameter<edm::InputTag>("pvSrc") ),
-    pvSel_ (params)
-  {
-    push_back("NPV", params.getParameter<int>("NPV") );
+  PVSelector(edm::ParameterSet const& params) : pvSrc_(params.getParameter<edm::InputTag>("pvSrc")), pvSel_(params) {
+    push_back("NPV", params.getParameter<int>("NPV"));
     set("NPV");
     retInternal_ = getBitTemplate();
     indexNPV_ = index_type(&bits_, "NPV");
   }
 
 #ifndef __GCCXML__
-  PVSelector( edm::ParameterSet const & params, edm::ConsumesCollector&& iC ) :
-    PVSelector(params)
-  {
+  PVSelector(edm::ParameterSet const& params, edm::ConsumesCollector&& iC) : PVSelector(params) {
     pvSrcToken_ = iC.consumes<std::vector<reco::Vertex> >(pvSrc_);
   }
 #endif
 
-  bool operator() ( edm::EventBase const & event,  pat::strbitset & ret ) override {
+  bool operator()(edm::EventBase const& event, pat::strbitset& ret) override {
     ret.set(false);
     event.getByLabel(pvSrc_, h_primVtx);
 
     // check if there is a good primary vertex
 
-    if ( h_primVtx->empty() ) return false;
+    if (h_primVtx->empty())
+      return false;
 
     // Loop over PV's and count those that pass
     int npv = 0;
     int _ntotal = 0;
     mvSelPvs.clear();
-    for ( std::vector<reco::Vertex>::const_iterator ibegin = h_primVtx->begin(),
-          iend = h_primVtx->end(), i = ibegin; i != iend; ++i ) {
-      reco::Vertex const & pv = *i;
+    for (std::vector<reco::Vertex>::const_iterator ibegin = h_primVtx->begin(), iend = h_primVtx->end(), i = ibegin;
+         i != iend;
+         ++i) {
+      reco::Vertex const& pv = *i;
       bool ipass = pvSel_(pv);
-      if ( ipass ) {
+      if (ipass) {
         ++npv;
-        mvSelPvs.push_back(edm::Ptr<reco::Vertex>(h_primVtx,_ntotal));
+        mvSelPvs.push_back(edm::Ptr<reco::Vertex>(h_primVtx, _ntotal));
       }
       ++_ntotal;
     }
@@ -62,7 +57,7 @@ public:
     mNpv = npv;
 
     // Set the strbitset
-    if ( npv >= cut(indexNPV_, int() ) || ignoreCut(indexNPV_) ) {
+    if (npv >= cut(indexNPV_, int()) || ignoreCut(indexNPV_)) {
       passCut(ret, indexNPV_);
     }
 
@@ -76,30 +71,23 @@ public:
 
   using EventSelector::operator();
 
-  edm::Handle<std::vector<reco::Vertex> > const & vertices() const { return h_primVtx; }
-
-
+  edm::Handle<std::vector<reco::Vertex> > const& vertices() const { return h_primVtx; }
 
   // get NPV from the last check
-  int GetNpv(void){return mNpv;}
+  int GetNpv(void) { return mNpv; }
 
-
-
-  std::vector<edm::Ptr<reco::Vertex> >  const &
-    GetSelectedPvs() const { return mvSelPvs; }
-
-
+  std::vector<edm::Ptr<reco::Vertex> > const& GetSelectedPvs() const { return mvSelPvs; }
 
 private:
-  edm::InputTag                           pvSrc_;
+  edm::InputTag pvSrc_;
 #ifndef __GCCXML__
-  edm::EDGetTokenT<std::vector<reco::Vertex> >                           pvSrcToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex> > pvSrcToken_;
 #endif
-  PVObjectSelector                        pvSel_;
+  PVObjectSelector pvSel_;
   edm::Handle<std::vector<reco::Vertex> > h_primVtx;
-  std::vector<edm::Ptr<reco::Vertex> >    mvSelPvs; // selected vertices
-  index_type                              indexNPV_;
-  int                                     mNpv; // cache number of PVs
+  std::vector<edm::Ptr<reco::Vertex> > mvSelPvs;  // selected vertices
+  index_type indexNPV_;
+  int mNpv;  // cache number of PVs
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/PrintVIDToString.h
+++ b/PhysicsTools/SelectorUtils/interface/PrintVIDToString.h
@@ -7,8 +7,8 @@
 #include <sstream>
 #include <string>
 
-template<typename T>
-struct PrintVIDToString{  
+template <typename T>
+struct PrintVIDToString {
   std::string operator()(const VersionedSelector<edm::Ptr<T> >& select) {
     std::stringstream out;
     select.print(out);

--- a/PhysicsTools/SelectorUtils/interface/RunLumiSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/RunLumiSelector.h
@@ -19,20 +19,16 @@ public:
   RunLumiSelector() {}
 
 #ifndef __GCCXML__
-  RunLumiSelector( edm::ParameterSet const & params, edm::ConsumesCollector&& iC ) :
-    RunLumiSelector( params )
-  {}
+  RunLumiSelector(edm::ParameterSet const& params, edm::ConsumesCollector&& iC) : RunLumiSelector(params) {}
 #endif
 
-  RunLumiSelector( edm::ParameterSet const & params ) {
-
+  RunLumiSelector(edm::ParameterSet const& params) {
     push_back("RunLumi");
 
-    if ( params.exists("lumisToProcess") ) {
-      lumis_ = params.getUntrackedParameter<std::vector<edm::LuminosityBlockRange> > ("lumisToProcess");
-      set("RunLumi" );
-    }
-    else {
+    if (params.exists("lumisToProcess")) {
+      lumis_ = params.getUntrackedParameter<std::vector<edm::LuminosityBlockRange> >("lumisToProcess");
+      set("RunLumi");
+    } else {
       lumis_.clear();
       set("RunLumi", false);
     }
@@ -40,20 +36,22 @@ public:
     retInternal_ = getBitTemplate();
   }
 
-  bool operator() ( edm::EventBase const & ev,  pat::strbitset & ret ) override {
-
-    if ( !ignoreCut("RunLumi") ) {
+  bool operator()(edm::EventBase const& ev, pat::strbitset& ret) override {
+    if (!ignoreCut("RunLumi")) {
       bool goodLumi = false;
-      for ( std::vector<edm::LuminosityBlockRange>::const_iterator lumisBegin = lumis_.begin(),
-	      lumisEnd = lumis_.end(), ilumi = lumisBegin;
-	    ilumi != lumisEnd; ++ilumi ) {
-	if ( ev.id().run() >= ilumi->startRun() && ev.id().run() <= ilumi->endRun()  &&
-	     ev.id().luminosityBlock() >= ilumi->startLumi() && ev.id().luminosityBlock() <= ilumi->endLumi() )  {
-	  goodLumi = true;
-	  break;
-	}
+      for (std::vector<edm::LuminosityBlockRange>::const_iterator lumisBegin = lumis_.begin(),
+                                                                  lumisEnd = lumis_.end(),
+                                                                  ilumi = lumisBegin;
+           ilumi != lumisEnd;
+           ++ilumi) {
+        if (ev.id().run() >= ilumi->startRun() && ev.id().run() <= ilumi->endRun() &&
+            ev.id().luminosityBlock() >= ilumi->startLumi() && ev.id().luminosityBlock() <= ilumi->endLumi()) {
+          goodLumi = true;
+          break;
+        }
       }
-      if ( goodLumi ) passCut(ret, "RunLumi" );
+      if (goodLumi)
+        passCut(ret, "RunLumi");
     } else {
       passCut(ret, "RunLumi");
     }
@@ -65,9 +63,7 @@ public:
   using EventSelector::operator();
 
 private:
-
   std::vector<edm::LuminosityBlockRange> lumis_;
-
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/Selector.h
+++ b/PhysicsTools/SelectorUtils/interface/Selector.h
@@ -12,26 +12,24 @@
   \author Salvatore Rappoccio
 */
 
-
 #include "PhysicsTools/SelectorUtils/interface/strbitset.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Common/interface/EventBase.h"
 #include <fstream>
 
 /// Functor that operates on <T>
-template<class T>
+template <class T>
 class Selector {
-
- public:
-  typedef T                                            data_type;
-  typedef pat::strbitset::index_type                   index_type;
-  typedef std::pair<index_type, size_t>                cut_flow_item;
-  typedef std::vector<cut_flow_item>                   cut_flow_map;
-  typedef std::map<index_type, int>                    int_map;
-  typedef std::map<index_type, double>                 double_map;
+public:
+  typedef T data_type;
+  typedef pat::strbitset::index_type index_type;
+  typedef std::pair<index_type, size_t> cut_flow_item;
+  typedef std::vector<cut_flow_item> cut_flow_map;
+  typedef std::map<index_type, int> int_map;
+  typedef std::map<index_type, double> double_map;
 
   /// Constructor clears the bits
-  Selector( ) {
+  Selector() {
     bits_.clear();
     intCuts_.clear();
     doubleCuts_.clear();
@@ -41,251 +39,210 @@ class Selector {
   virtual ~Selector() {}
 
   /// This is the registration of an individual cut string
-  virtual void push_back( std::string const & s) {
+  virtual void push_back(std::string const &s) {
     bits_.push_back(s);
-    index_type i(&bits_,s);
+    index_type i(&bits_, s);
     // don't need to check to see if the key is already there,
     // bits_ does that.
-    cutFlow_.push_back( cut_flow_item(i, 0) );
+    cutFlow_.push_back(cut_flow_item(i, 0));
   }
 
-
   /// This is the registration of an individual cut string, with an int cut value
-  virtual void push_back( std::string const & s, int cut) {
+  virtual void push_back(std::string const &s, int cut) {
     bits_.push_back(s);
-    index_type i(&bits_,s);
+    index_type i(&bits_, s);
     intCuts_[i] = cut;
     // don't need to check to see if the key is already there,
     // bits_ does that.
-    cutFlow_.push_back( cut_flow_item(i,0) );
+    cutFlow_.push_back(cut_flow_item(i, 0));
   }
 
   /// This is the registration of an individual cut string, with a double cut value
-  virtual void push_back( std::string const & s, double cut) {
+  virtual void push_back(std::string const &s, double cut) {
     bits_.push_back(s);
-    index_type i(&bits_,s);
+    index_type i(&bits_, s);
     doubleCuts_[i] = cut;
     // don't need to check to see if the key is already there,
     // bits_ does that.
-    cutFlow_.push_back( cut_flow_item(i,0) );
+    cutFlow_.push_back(cut_flow_item(i, 0));
   }
 
   /// This provides the interface for base classes to select objects
-  virtual bool operator()( T const & t, pat::strbitset & ret ) = 0;
+  virtual bool operator()(T const &t, pat::strbitset &ret) = 0;
 
   /// This provides an alternative signature without the second ret
-  virtual bool operator()( T const & t )
-  {
+  virtual bool operator()(T const &t) {
     retInternal_.set(false);
     operator()(t, retInternal_);
     setIgnored(retInternal_);
     return (bool)retInternal_;
   }
 
+  /// This provides an alternative signature that includes extra information
+  virtual bool operator()(T const &t, edm::EventBase const &e, pat::strbitset &ret) { return operator()(t, ret); }
 
   /// This provides an alternative signature that includes extra information
-  virtual bool operator()( T const & t, edm::EventBase const & e, pat::strbitset & ret)
-  {
-    return operator()(t, ret);
-  }
-
-  /// This provides an alternative signature that includes extra information
-  virtual bool operator()( T const & t, edm::EventBase const & e)
-  {
+  virtual bool operator()(T const &t, edm::EventBase const &e) {
     retInternal_.set(false);
     operator()(t, e, retInternal_);
     setIgnored(retInternal_);
     return (bool)retInternal_;
   }
 
-
   /// Set a given selection cut, on or off
-  void set(std::string const & s, bool val = true) {
-    set( index_type(&bits_,s), val);
-  }
-  void set(index_type const & i, bool val = true) {
-    bits_[i] = val;
-  }
+  void set(std::string const &s, bool val = true) { set(index_type(&bits_, s), val); }
+  void set(index_type const &i, bool val = true) { bits_[i] = val; }
 
   /// Set a given selection cut, on or off, and reset int cut value
-  void set(std::string const & s, int cut, bool val = true) {
-    set( index_type(&bits_,s), cut);
-  }
-  void set(index_type const & i, int cut, bool val = true) {
+  void set(std::string const &s, int cut, bool val = true) { set(index_type(&bits_, s), cut); }
+  void set(index_type const &i, int cut, bool val = true) {
     bits_[i] = val;
     intCuts_[i] = cut;
   }
 
   /// Set a given selection cut, on or off, and reset int cut value
-  void set(std::string const & s, double cut, bool val = true) {
-    set( index_type(&bits_,s), cut);
-  }
-  void set(index_type const & i, double cut, bool val = true) {
+  void set(std::string const &s, double cut, bool val = true) { set(index_type(&bits_, s), cut); }
+  void set(index_type const &i, double cut, bool val = true) {
     bits_[i] = val;
     doubleCuts_[i] = cut;
   }
 
   /// Turn off a given selection cut.
-  void clear(std::string const & s) {
-    clear(index_type(&bits_,s));
-  }
+  void clear(std::string const &s) { clear(index_type(&bits_, s)); }
 
-  void clear(index_type const & i) {
-    bits_[i] = false;
-  }
+  void clear(index_type const &i) { bits_[i] = false; }
 
   /// Access the selector cut at index "s".
   /// "true" means to consider the cut.
   /// "false" means to ignore the cut.
-  bool operator[] ( std::string const & s ) const {
-    return bits_[s];
-  }
+  bool operator[](std::string const &s) const { return bits_[s]; }
 
-  bool operator[] ( index_type const & i ) const {
-    return bits_[i];
-  }
+  bool operator[](index_type const &i) const { return bits_[i]; }
 
   /// consider the cut at index "s"
-  bool considerCut( std::string const & s ) const {
-    return bits_[s] == true;
-  }
-  bool considerCut( index_type const & i  ) const {
-    return bits_[i] == true;
-  }
+  bool considerCut(std::string const &s) const { return bits_[s] == true; }
+  bool considerCut(index_type const &i) const { return bits_[i] == true; }
 
   /// ignore the cut at index "s"
-  bool ignoreCut( std::string const & s ) const {
-    return bits_[s] == false;
-  }
-  bool ignoreCut( index_type const & i ) const {
-    return bits_[i] == false;
-  }
+  bool ignoreCut(std::string const &s) const { return bits_[s] == false; }
+  bool ignoreCut(index_type const &i) const { return bits_[i] == false; }
 
   /// set the bits to ignore from a vector
-  void setIgnoredCuts( std::vector<std::string> const & bitsToIgnore ) {
-    for ( std::vector<std::string>::const_iterator ignoreBegin = bitsToIgnore.begin(),
-	    ignoreEnd = bitsToIgnore.end(), ibit = ignoreBegin;
-	  ibit != ignoreEnd; ++ibit ) {
-      set(*ibit, false );
+  void setIgnoredCuts(std::vector<std::string> const &bitsToIgnore) {
+    for (std::vector<std::string>::const_iterator ignoreBegin = bitsToIgnore.begin(),
+                                                  ignoreEnd = bitsToIgnore.end(),
+                                                  ibit = ignoreBegin;
+         ibit != ignoreEnd;
+         ++ibit) {
+      set(*ibit, false);
     }
   }
 
   /// Passing cuts
-  void passCut( pat::strbitset & ret, std::string const & s ) {
-    passCut( ret, index_type(&bits_,s));
-  }
+  void passCut(pat::strbitset &ret, std::string const &s) { passCut(ret, index_type(&bits_, s)); }
 
-  void passCut( pat::strbitset & ret, index_type const & i ) {
+  void passCut(pat::strbitset &ret, index_type const &i) {
     ret[i] = true;
     cut_flow_map::iterator found = cutFlow_.end();
-    for ( cut_flow_map::iterator cutsBegin = cutFlow_.begin(),
-	    cutsEnd = cutFlow_.end(), icut = cutsBegin;
-	  icut != cutsEnd && found == cutsEnd; ++icut ) {
-      if ( icut->first == i ) {
-	found = icut;
+    for (cut_flow_map::iterator cutsBegin = cutFlow_.begin(), cutsEnd = cutFlow_.end(), icut = cutsBegin;
+         icut != cutsEnd && found == cutsEnd;
+         ++icut) {
+      if (icut->first == i) {
+        found = icut;
       }
-    }    
+    }
     ++(found->second);
   }
 
   /// Access the int cut values at index "s"
-  int cut( index_type const & i, int val ) const {
-    return intCuts_.find( i )->second;
-  };
+  int cut(index_type const &i, int val) const { return intCuts_.find(i)->second; };
   /// Access the double cut values at index "s"
-  double cut( index_type const & i, double val ) const {
-    return doubleCuts_.find( i )->second;
-  };
+  double cut(index_type const &i, double val) const { return doubleCuts_.find(i)->second; };
 
   /// Access the int cut values at index "s"
-  int cut( std::string s, int val ) const {
-    return cut( index_type(&bits_,s), val);
-  };
+  int cut(std::string s, int val) const { return cut(index_type(&bits_, s), val); };
   /// Access the double cut values at index "s"
-  double cut( std::string s, double val ) const {
-    return cut( index_type(&bits_,s), val);
-  };
+  double cut(std::string s, double val) const { return cut(index_type(&bits_, s), val); };
 
   /// Get an empty bitset with the proper names
   pat::strbitset getBitTemplate() const {
     pat::strbitset ret = bits_;
     ret.set(false);
-    for ( cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(),
-	    cutsEnd = cutFlow_.end(), icut = cutsBegin;
-	  icut != cutsEnd; ++icut ) {
-      if ( ignoreCut(icut->first) ) ret[icut->first] = true;
+    for (cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(), cutsEnd = cutFlow_.end(), icut = cutsBegin;
+         icut != cutsEnd;
+         ++icut) {
+      if (ignoreCut(icut->first))
+        ret[icut->first] = true;
     }
     return ret;
   }
 
   /// set ignored bits
-  void setIgnored( pat::strbitset & ret ) {
-    for ( cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(),
-	    cutsEnd = cutFlow_.end(), icut = cutsBegin;
-	  icut != cutsEnd; ++icut ) {
-      if ( ignoreCut(icut->first) ) ret[icut->first] = true;
+  void setIgnored(pat::strbitset &ret) {
+    for (cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(), cutsEnd = cutFlow_.end(), icut = cutsBegin;
+         icut != cutsEnd;
+         ++icut) {
+      if (ignoreCut(icut->first))
+        ret[icut->first] = true;
     }
   }
 
   /// Print the cut flow
-  void print(std::ostream & out) const {
-    for ( cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(),
-	    cutsEnd = cutFlow_.end(), icut = cutsBegin;
-	  icut != cutsEnd; ++icut ) {
+  void print(std::ostream &out) const {
+    for (cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(), cutsEnd = cutFlow_.end(), icut = cutsBegin;
+         icut != cutsEnd;
+         ++icut) {
       char buff[1000];
-      if ( considerCut( icut->first ) ) {
-	sprintf(buff, "%6lu : %20s %10lu",
-		static_cast<unsigned long>(icut - cutsBegin),
-		icut->first.str().c_str(),
-		static_cast<unsigned long>(icut->second) );
+      if (considerCut(icut->first)) {
+        sprintf(buff,
+                "%6lu : %20s %10lu",
+                static_cast<unsigned long>(icut - cutsBegin),
+                icut->first.str().c_str(),
+                static_cast<unsigned long>(icut->second));
       } else {
-	sprintf(buff, "%6lu : %20s %10s",
-		static_cast<unsigned long>(icut - cutsBegin),
-		icut->first.str().c_str(),
-		"off" );
+        sprintf(
+            buff, "%6lu : %20s %10s", static_cast<unsigned long>(icut - cutsBegin), icut->first.str().c_str(), "off");
       }
       out << buff << std::endl;
     }
   }
 
   /// Print the cuts being considered
-  void printActiveCuts(std::ostream & out) const {
+  void printActiveCuts(std::ostream &out) const {
     bool already_printed_one = false;
-    for ( cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(),
-	    cutsEnd = cutFlow_.end(), icut = cutsBegin;
-	  icut != cutsEnd; ++icut ) {
-      if ( considerCut( icut->first ) ) {
-	if( already_printed_one ) out << ", ";
-	out << icut->first;
-	already_printed_one = true;
+    for (cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(), cutsEnd = cutFlow_.end(), icut = cutsBegin;
+         icut != cutsEnd;
+         ++icut) {
+      if (considerCut(icut->first)) {
+        if (already_printed_one)
+          out << ", ";
+        out << icut->first;
+        already_printed_one = true;
       }
     }
     out << std::endl;
   }
 
   /// Return the number of passing cases
-  double getPasses( std::string const & s ) const {
-    return getPasses( index_type(&bits_,s) );
-  }
-  double getPasses( index_type const &i ) const {
+  double getPasses(std::string const &s) const { return getPasses(index_type(&bits_, s)); }
+  double getPasses(index_type const &i) const {
     cut_flow_map::const_iterator found = cutFlow_.end();
-    for ( cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(),
-            cutsEnd = cutFlow_.end(), icut = cutsBegin;
-          icut != cutsEnd && found == cutsEnd; ++icut ) {
-      if ( icut->first == i ) {
-	found = icut;
+    for (cut_flow_map::const_iterator cutsBegin = cutFlow_.begin(), cutsEnd = cutFlow_.end(), icut = cutsBegin;
+         icut != cutsEnd && found == cutsEnd;
+         ++icut) {
+      if (icut->first == i) {
+        found = icut;
       }
     }
     return found->second;
   }
 
-
- protected:
-  pat::strbitset bits_;        //!< the bitset indexed by strings
-  pat::strbitset retInternal_; //!< internal ret if users don't care about return bits
-  int_map        intCuts_;     //!< the int-value cut map
-  double_map     doubleCuts_;  //!< the double-value cut map
-  cut_flow_map   cutFlow_;     //!< map of cut flows in "human" order
+protected:
+  pat::strbitset bits_;         //!< the bitset indexed by strings
+  pat::strbitset retInternal_;  //!< internal ret if users don't care about return bits
+  int_map intCuts_;             //!< the int-value cut map
+  double_map doubleCuts_;       //!< the double-value cut map
+  cut_flow_map cutFlow_;        //!< map of cut flows in "human" order
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/SimpleCutBasedElectronIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/SimpleCutBasedElectronIDSelectionFunctor.h
@@ -57,493 +57,503 @@ ________________________________________________________________________________
 
 */
 
+class SimpleCutBasedElectronIDSelectionFunctor : public Selector<pat::Electron> {
+public:  // interface
+  enum Version_t {
+    relIso95 = 0,
+    cIso95,
+    relIso90,
+    cIso90,
+    relIso85,
+    cIso85,
+    relIso80,
+    cIso80,
+    relIso70,
+    cIso70,
+    relIso60,
+    cIso60,
+    NONE
+  };
 
-class SimpleCutBasedElectronIDSelectionFunctor : public Selector<pat::Electron>  {
-
- public: // interface  
-  
-  enum Version_t { relIso95=0, cIso95,  relIso90, cIso90, relIso85, cIso85, 
-		   relIso80, cIso80,  relIso70, cIso70, relIso60, cIso60, NONE };
-  
   SimpleCutBasedElectronIDSelectionFunctor() {}
-  
-  // initialize it by inserting directly the cut values in a parameter set
-  SimpleCutBasedElectronIDSelectionFunctor(edm::ParameterSet const & parameters)
-    {
-      // get the cuts from the PS
-      initialize( parameters.getParameter<Double_t>("trackIso_EB"), 
-		  parameters.getParameter<Double_t>("ecalIso_EB"), 
-		  parameters.getParameter<Double_t>("hcalIso_EB"), 
-		  parameters.getParameter<Double_t>("sihih_EB"), 
-		  parameters.getParameter<Double_t>("dphi_EB"), 
-		  parameters.getParameter<Double_t>("deta_EB"), 
-		  parameters.getParameter<Double_t>("hoe_EB"), 
-		  parameters.getParameter<Double_t>("cIso_EB"), 
-		  parameters.getParameter<Double_t>("trackIso_EE"), 
-		  parameters.getParameter<Double_t>("ecalIso_EE"), 
-		  parameters.getParameter<Double_t>("hcalIso_EE"), 
-		  parameters.getParameter<Double_t>("sihih_EE"), 
-		  parameters.getParameter<Double_t>("dphi_EE"), 
-		  parameters.getParameter<Double_t>("deta_EE"), 
-		  parameters.getParameter<Double_t>("hoe_EE"), 
-		  parameters.getParameter<Double_t>("cIso_EE"), 
-		  parameters.getParameter<Int_t>("conversionRejection"), 
-		  parameters.getParameter<Int_t>("maxNumberOfExpectedMissingHits"));
-      retInternal_ = getBitTemplate();
-    }
-  // initialize it by using only the version name
-  SimpleCutBasedElectronIDSelectionFunctor(Version_t  version)
-    {
-      if (version == NONE) {
-	std::cout << "SimpleCutBasedElectronIDSelectionFunctor: If you want to use version NONE "
-		  << "then you have also to provide the selection cuts by yourself " << std::endl;
-	std::cout << "SimpleCutBasedElectronIDSelectionFunctor: ID Version is changed to 80cIso "
-		  << std::endl;
-	version = cIso80;
-      }
-      initialize(version);
-      retInternal_ = getBitTemplate();
-    }
 
-  void initialize( Version_t version ) 
-  {
+  // initialize it by inserting directly the cut values in a parameter set
+  SimpleCutBasedElectronIDSelectionFunctor(edm::ParameterSet const& parameters) {
+    // get the cuts from the PS
+    initialize(parameters.getParameter<Double_t>("trackIso_EB"),
+               parameters.getParameter<Double_t>("ecalIso_EB"),
+               parameters.getParameter<Double_t>("hcalIso_EB"),
+               parameters.getParameter<Double_t>("sihih_EB"),
+               parameters.getParameter<Double_t>("dphi_EB"),
+               parameters.getParameter<Double_t>("deta_EB"),
+               parameters.getParameter<Double_t>("hoe_EB"),
+               parameters.getParameter<Double_t>("cIso_EB"),
+               parameters.getParameter<Double_t>("trackIso_EE"),
+               parameters.getParameter<Double_t>("ecalIso_EE"),
+               parameters.getParameter<Double_t>("hcalIso_EE"),
+               parameters.getParameter<Double_t>("sihih_EE"),
+               parameters.getParameter<Double_t>("dphi_EE"),
+               parameters.getParameter<Double_t>("deta_EE"),
+               parameters.getParameter<Double_t>("hoe_EE"),
+               parameters.getParameter<Double_t>("cIso_EE"),
+               parameters.getParameter<Int_t>("conversionRejection"),
+               parameters.getParameter<Int_t>("maxNumberOfExpectedMissingHits"));
+    retInternal_ = getBitTemplate();
+  }
+  // initialize it by using only the version name
+  SimpleCutBasedElectronIDSelectionFunctor(Version_t version) {
+    if (version == NONE) {
+      std::cout << "SimpleCutBasedElectronIDSelectionFunctor: If you want to use version NONE "
+                << "then you have also to provide the selection cuts by yourself " << std::endl;
+      std::cout << "SimpleCutBasedElectronIDSelectionFunctor: ID Version is changed to 80cIso " << std::endl;
+      version = cIso80;
+    }
+    initialize(version);
+    retInternal_ = getBitTemplate();
+  }
+
+  void initialize(Version_t version) {
     version_ = version;
     // push back the variables
     push_back("trackIso_EB");
-    push_back("ecalIso_EB" );
-    push_back("hcalIso_EB" );
-    push_back("sihih_EB"   );
-    push_back("dphi_EB"    );
-    push_back("deta_EB"    );
-    push_back("hoe_EB"     );
-    push_back("cIso_EB"    );
-    
+    push_back("ecalIso_EB");
+    push_back("hcalIso_EB");
+    push_back("sihih_EB");
+    push_back("dphi_EB");
+    push_back("deta_EB");
+    push_back("hoe_EB");
+    push_back("cIso_EB");
+
     push_back("trackIso_EE");
-    push_back("ecalIso_EE" );
-    push_back("hcalIso_EE" );
-    push_back("sihih_EE"   );
-    push_back("dphi_EE"    );
-    push_back("deta_EE"    );
-    push_back("hoe_EE"     );
-    push_back("cIso_EE"    );
-    
-    push_back("conversionRejection"            );
-    push_back("maxNumberOfExpectedMissingHits" );
-    
-    
-    
-    
+    push_back("ecalIso_EE");
+    push_back("hcalIso_EE");
+    push_back("sihih_EE");
+    push_back("dphi_EE");
+    push_back("deta_EE");
+    push_back("hoe_EE");
+    push_back("cIso_EE");
+
+    push_back("conversionRejection");
+    push_back("maxNumberOfExpectedMissingHits");
+
     if (version_ == relIso95) {
       set("trackIso_EB", 1.5e-01);
-      set("ecalIso_EB",  2.0e+00);
-      set("hcalIso_EB",  1.2e-01);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     8.0e-01);
-      set("deta_EB",     7.0e-03);
-      set("hoe_EB",      1.5e-01);
-      set("cIso_EB",     10000. );
-      
+      set("ecalIso_EB", 2.0e+00);
+      set("hcalIso_EB", 1.2e-01);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 8.0e-01);
+      set("deta_EB", 7.0e-03);
+      set("hoe_EB", 1.5e-01);
+      set("cIso_EB", 10000.);
+
       set("trackIso_EE", 8.0e-02);
-      set("ecalIso_EE",  6.0e-02);
-      set("hcalIso_EE",  5.0e-02);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     7.0e-01);
-      set("deta_EE",     1.0e-02);
-      set("hoe_EE",      7.0e-02);
-      set("cIso_EE",     10000. );
-      
-      set("conversionRejection",            0);
+      set("ecalIso_EE", 6.0e-02);
+      set("hcalIso_EE", 5.0e-02);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 7.0e-01);
+      set("deta_EE", 1.0e-02);
+      set("hoe_EE", 7.0e-02);
+      set("cIso_EE", 10000.);
+
+      set("conversionRejection", 0);
       set("maxNumberOfExpectedMissingHits", 1);
 
-    }
-    else if (version_ == cIso95) {
+    } else if (version_ == cIso95) {
       set("trackIso_EB", 100000.);
-      set("ecalIso_EB",  100000.);
-      set("hcalIso_EB",  100000.);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     8.0e-01);
-      set("deta_EB",     7.0e-03);
-      set("hoe_EB",      1.5e-01);
-      set("cIso_EB",     1.5e-01);
-      			       					      
+      set("ecalIso_EB", 100000.);
+      set("hcalIso_EB", 100000.);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 8.0e-01);
+      set("deta_EB", 7.0e-03);
+      set("hoe_EB", 1.5e-01);
+      set("cIso_EB", 1.5e-01);
+
       set("trackIso_EE", 100000.);
-      set("ecalIso_EE",  100000.);
-      set("hcalIso_EE",  100000.);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     7.0e-01);
-      set("deta_EE",     1.0e-02);
-      set("hoe_EE",      7.0e-02);
-      set("cIso_EE",     1.0e-01);
-      
-      set("conversionRejection",            0);
+      set("ecalIso_EE", 100000.);
+      set("hcalIso_EE", 100000.);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 7.0e-01);
+      set("deta_EE", 1.0e-02);
+      set("hoe_EE", 7.0e-02);
+      set("cIso_EE", 1.0e-01);
+
+      set("conversionRejection", 0);
       set("maxNumberOfExpectedMissingHits", 1);
-      
-    }
-    else if (version_ == relIso90) {
+
+    } else if (version_ == relIso90) {
       set("trackIso_EB", 1.2e-01);
-      set("ecalIso_EB",  9.0e-02);
-      set("hcalIso_EB",  1.0e-01);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     8.0e-01);
-      set("deta_EB",     7.0e-03);
-      set("hoe_EB",      1.2e-01);
-      set("cIso_EB",     10000. );
+      set("ecalIso_EB", 9.0e-02);
+      set("hcalIso_EB", 1.0e-01);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 8.0e-01);
+      set("deta_EB", 7.0e-03);
+      set("hoe_EB", 1.2e-01);
+      set("cIso_EB", 10000.);
 
       set("trackIso_EE", 5.0e-02);
-      set("ecalIso_EE",  6.0e-02);
-      set("hcalIso_EE",  3.0e-02);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     7.0e-01);
-      set("deta_EE",     9.0e-03);
-      set("hoe_EE",      5.0e-02);
-      set("cIso_EE",     10000. );
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 6.0e-02);
+      set("hcalIso_EE", 3.0e-02);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 7.0e-01);
+      set("deta_EE", 9.0e-03);
+      set("hoe_EE", 5.0e-02);
+      set("cIso_EE", 10000.);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 1);
-    }
-    else if (version_ == cIso90) {
+    } else if (version_ == cIso90) {
       set("trackIso_EB", 100000.);
-      set("ecalIso_EB",  100000.);
-      set("hcalIso_EB",  100000.);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     8.0e-01);
-      set("deta_EB",     7.0e-03);
-      set("hoe_EB",      1.2e-01);
-      set("cIso_EB",     1.0e-01);
+      set("ecalIso_EB", 100000.);
+      set("hcalIso_EB", 100000.);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 8.0e-01);
+      set("deta_EB", 7.0e-03);
+      set("hoe_EB", 1.2e-01);
+      set("cIso_EB", 1.0e-01);
 
       set("trackIso_EE", 100000.);
-      set("ecalIso_EE",  100000.);
-      set("hcalIso_EE",  100000.);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     7.0e-01);
-      set("deta_EE",     9.0e-03);
-      set("hoe_EE",      5.0e-02);
-      set("cIso_EE",     7.0e-02);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 100000.);
+      set("hcalIso_EE", 100000.);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 7.0e-01);
+      set("deta_EE", 9.0e-03);
+      set("hoe_EE", 5.0e-02);
+      set("cIso_EE", 7.0e-02);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 1);
-    }
-    else if (version_ == relIso85) {
+    } else if (version_ == relIso85) {
       set("trackIso_EB", 9.0e-02);
-      set("ecalIso_EB",  8.0e-02);
-      set("hcalIso_EB",  1.0e-01);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     6.0e-02);
-      set("deta_EB",     6.0e-03);
-      set("hoe_EB",      4.0e-02);
-      set("cIso_EB",     10000. );
+      set("ecalIso_EB", 8.0e-02);
+      set("hcalIso_EB", 1.0e-01);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 6.0e-02);
+      set("deta_EB", 6.0e-03);
+      set("hoe_EB", 4.0e-02);
+      set("cIso_EB", 10000.);
 
       set("trackIso_EE", 5.0e-02);
-      set("ecalIso_EE",  5.0e-02);
-      set("hcalIso_EE",  2.5e-02);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     4.0e-02);
-      set("deta_EE",     7.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     10000. );
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 5.0e-02);
+      set("hcalIso_EE", 2.5e-02);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 4.0e-02);
+      set("deta_EE", 7.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 10000.);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 1);
-    }
-    else if (version_ == cIso85) {
+    } else if (version_ == cIso85) {
       set("trackIso_EB", 100000.);
-      set("ecalIso_EB",  100000.);
-      set("hcalIso_EB",  100000.);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     6.0e-02);
-      set("deta_EB",     6.0e-03);
-      set("hoe_EB",      4.0e-02);
-      set("cIso_EB",     9.0e-02);
+      set("ecalIso_EB", 100000.);
+      set("hcalIso_EB", 100000.);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 6.0e-02);
+      set("deta_EB", 6.0e-03);
+      set("hoe_EB", 4.0e-02);
+      set("cIso_EB", 9.0e-02);
 
       set("trackIso_EE", 100000.);
-      set("ecalIso_EE",  100000.);
-      set("hcalIso_EE",  100000.);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     4.0e-02);
-      set("deta_EE",     7.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     6.0e-02);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 100000.);
+      set("hcalIso_EE", 100000.);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 4.0e-02);
+      set("deta_EE", 7.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 6.0e-02);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 1);
-    }
-    else if (version_ == relIso80) {
+    } else if (version_ == relIso80) {
       set("trackIso_EB", 9.0e-02);
-      set("ecalIso_EB",  7.0e-02);
-      set("hcalIso_EB",  1.0e-01);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     6.0e-02);
-      set("deta_EB",     4.0e-03);
-      set("hoe_EB",      4.0e-02);
-      set("cIso_EB",     100000.);
+      set("ecalIso_EB", 7.0e-02);
+      set("hcalIso_EB", 1.0e-01);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 6.0e-02);
+      set("deta_EB", 4.0e-03);
+      set("hoe_EB", 4.0e-02);
+      set("cIso_EB", 100000.);
 
       set("trackIso_EE", 4.0e-02);
-      set("ecalIso_EE",  5.0e-02);
-      set("hcalIso_EE",  2.5e-02);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     3.0e-02);
-      set("deta_EE",     7.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     100000.);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 5.0e-02);
+      set("hcalIso_EE", 2.5e-02);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 3.0e-02);
+      set("deta_EE", 7.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 100000.);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 0);
-    }
-    else if (version_ == cIso80) {
+    } else if (version_ == cIso80) {
       set("trackIso_EB", 100000.);
-      set("ecalIso_EB",  100000.);
-      set("hcalIso_EB",  100000.);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     6.0e-02);
-      set("deta_EB",     4.0e-03);
-      set("hoe_EB",      4.0e-02);
-      set("cIso_EB",     7.0e-02);
+      set("ecalIso_EB", 100000.);
+      set("hcalIso_EB", 100000.);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 6.0e-02);
+      set("deta_EB", 4.0e-03);
+      set("hoe_EB", 4.0e-02);
+      set("cIso_EB", 7.0e-02);
 
       set("trackIso_EE", 100000.);
-      set("ecalIso_EE",  100000.);
-      set("hcalIso_EE",  100000.);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     3.0e-02);
-      set("deta_EE",     7.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     6.0e-02);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 100000.);
+      set("hcalIso_EE", 100000.);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 3.0e-02);
+      set("deta_EE", 7.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 6.0e-02);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 0);
-    }
-    else if (version_ == relIso70) {
+    } else if (version_ == relIso70) {
       set("trackIso_EB", 5.0e-02);
-      set("ecalIso_EB",  6.0e-02);
-      set("hcalIso_EB",  3.0e-02);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     3.0e-02);
-      set("deta_EB",     4.0e-03);
-      set("hoe_EB",      2.5e-02);
-      set("cIso_EB",     100000.);
+      set("ecalIso_EB", 6.0e-02);
+      set("hcalIso_EB", 3.0e-02);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 3.0e-02);
+      set("deta_EB", 4.0e-03);
+      set("hoe_EB", 2.5e-02);
+      set("cIso_EB", 100000.);
 
       set("trackIso_EE", 2.5e-02);
-      set("ecalIso_EE",  2.5e-02);
-      set("hcalIso_EE",  2.0e-02);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     2.0e-02);
-      set("deta_EE",     5.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     100000.);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 2.5e-02);
+      set("hcalIso_EE", 2.0e-02);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 2.0e-02);
+      set("deta_EE", 5.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 100000.);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 0);
-    }
-    else if (version_ == cIso70) {
+    } else if (version_ == cIso70) {
       set("trackIso_EB", 100000.);
-      set("ecalIso_EB",  100000.);
-      set("hcalIso_EB",  100000.);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     3.0e-02);
-      set("deta_EB",     4.0e-03);
-      set("hoe_EB",      2.5e-02);
-      set("cIso_EB",     4.0e-02);
+      set("ecalIso_EB", 100000.);
+      set("hcalIso_EB", 100000.);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 3.0e-02);
+      set("deta_EB", 4.0e-03);
+      set("hoe_EB", 2.5e-02);
+      set("cIso_EB", 4.0e-02);
 
       set("trackIso_EE", 100000.);
-      set("ecalIso_EE",  100000.);
-      set("hcalIso_EE",  100000.);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     2.0e-02);
-      set("deta_EE",     5.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     3.0e-02);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 100000.);
+      set("hcalIso_EE", 100000.);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 2.0e-02);
+      set("deta_EE", 5.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 3.0e-02);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 0);
-    }
-    else if (version_ == relIso60) {
+    } else if (version_ == relIso60) {
       set("trackIso_EB", 4.0e-02);
-      set("ecalIso_EB",  4.0e-02);
-      set("hcalIso_EB",  3.0e-02);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     2.5e-02);
-      set("deta_EB",     4.0e-03);
-      set("hoe_EB",      2.5e-02);
-      set("cIso_EB",     100000.);
+      set("ecalIso_EB", 4.0e-02);
+      set("hcalIso_EB", 3.0e-02);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 2.5e-02);
+      set("deta_EB", 4.0e-03);
+      set("hoe_EB", 2.5e-02);
+      set("cIso_EB", 100000.);
 
       set("trackIso_EE", 2.5e-02);
-      set("ecalIso_EE",  2.0e-02);
-      set("hcalIso_EE",  2.0e-02);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     2.0e-02);
-      set("deta_EE",     5.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     100000.);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 2.0e-02);
+      set("hcalIso_EE", 2.0e-02);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 2.0e-02);
+      set("deta_EE", 5.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 100000.);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 0);
-    }
-    else if (version_ == cIso60) {
+    } else if (version_ == cIso60) {
       set("trackIso_EB", 100000.);
-      set("ecalIso_EB",  100000.);
-      set("hcalIso_EB",  100000.);
-      set("sihih_EB",    1.0e-02);
-      set("dphi_EB",     2.5e-02);
-      set("deta_EB",     4.0e-03);
-      set("hoe_EB",      2.5e-02);
-      set("cIso_EB",     3.0e-02);
+      set("ecalIso_EB", 100000.);
+      set("hcalIso_EB", 100000.);
+      set("sihih_EB", 1.0e-02);
+      set("dphi_EB", 2.5e-02);
+      set("deta_EB", 4.0e-03);
+      set("hoe_EB", 2.5e-02);
+      set("cIso_EB", 3.0e-02);
 
       set("trackIso_EE", 100000.);
-      set("ecalIso_EE",  100000.);
-      set("hcalIso_EE",  100000.);
-      set("sihih_EE",    3.0e-02);
-      set("dphi_EE",     2.0e-02);
-      set("deta_EE",     5.0e-03);
-      set("hoe_EE",      2.5e-02);
-      set("cIso_EE",     2.0e-02);
-      
-      set("conversionRejection",            1);
+      set("ecalIso_EE", 100000.);
+      set("hcalIso_EE", 100000.);
+      set("sihih_EE", 3.0e-02);
+      set("dphi_EE", 2.0e-02);
+      set("deta_EE", 5.0e-03);
+      set("hoe_EE", 2.5e-02);
+      set("cIso_EE", 2.0e-02);
+
+      set("conversionRejection", 1);
       set("maxNumberOfExpectedMissingHits", 0);
     }
   }
 
-  void initialize(Double_t trackIso_EB, Double_t ecalIso_EB, Double_t hcalIso_EB,
-		  Double_t sihih_EB, Double_t  dphi_EB, Double_t deta_EB, Double_t hoe_EB,
-		  Double_t cIso_EB,
-		  Double_t trackIso_EE, Double_t ecalIso_EE, Double_t hcalIso_EE,
-		  Double_t sihih_EE, Double_t  dphi_EE, Double_t deta_EE, Double_t hoe_EE,
-		  Double_t cIso_EE, Int_t conversionRejection, 
-		  Int_t maxNumberOfExpectedMissingHits)
-  {
+  void initialize(Double_t trackIso_EB,
+                  Double_t ecalIso_EB,
+                  Double_t hcalIso_EB,
+                  Double_t sihih_EB,
+                  Double_t dphi_EB,
+                  Double_t deta_EB,
+                  Double_t hoe_EB,
+                  Double_t cIso_EB,
+                  Double_t trackIso_EE,
+                  Double_t ecalIso_EE,
+                  Double_t hcalIso_EE,
+                  Double_t sihih_EE,
+                  Double_t dphi_EE,
+                  Double_t deta_EE,
+                  Double_t hoe_EE,
+                  Double_t cIso_EE,
+                  Int_t conversionRejection,
+                  Int_t maxNumberOfExpectedMissingHits) {
     version_ = NONE;
     push_back("trackIso_EB");
-    push_back("ecalIso_EB" );
-    push_back("hcalIso_EB" );
-    push_back("sihih_EB"   );
-    push_back("dphi_EB"    );
-    push_back("deta_EB"    );
-    push_back("hoe_EB"     );
-    push_back("cIso_EB"    );
-    
+    push_back("ecalIso_EB");
+    push_back("hcalIso_EB");
+    push_back("sihih_EB");
+    push_back("dphi_EB");
+    push_back("deta_EB");
+    push_back("hoe_EB");
+    push_back("cIso_EB");
+
     push_back("trackIso_EE");
-    push_back("ecalIso_EE" );
-    push_back("hcalIso_EE" );
-    push_back("sihih_EE"   );
-    push_back("dphi_EE"    );
-    push_back("deta_EE"    );
-    push_back("hoe_EE"     );
-    push_back("cIso_EE"    );
-    
-    push_back("conversionRejection"            );
-    push_back("maxNumberOfExpectedMissingHits" );
-    
-   
+    push_back("ecalIso_EE");
+    push_back("hcalIso_EE");
+    push_back("sihih_EE");
+    push_back("dphi_EE");
+    push_back("deta_EE");
+    push_back("hoe_EE");
+    push_back("cIso_EE");
+
+    push_back("conversionRejection");
+    push_back("maxNumberOfExpectedMissingHits");
+
     set("trackIso_EB", trackIso_EB);
-    set("ecalIso_EB",  ecalIso_EB);
-    set("hcalIso_EB",  hcalIso_EB);
-    set("sihih_EB",    sihih_EB);
-    set("dphi_EB",     dphi_EB);
-    set("deta_EB",     deta_EB);
-    set("hoe_EB",      hoe_EB);
-    set("cIso_EB",     cIso_EB);
-    
+    set("ecalIso_EB", ecalIso_EB);
+    set("hcalIso_EB", hcalIso_EB);
+    set("sihih_EB", sihih_EB);
+    set("dphi_EB", dphi_EB);
+    set("deta_EB", deta_EB);
+    set("hoe_EB", hoe_EB);
+    set("cIso_EB", cIso_EB);
+
     set("trackIso_EE", trackIso_EE);
-    set("ecalIso_EE",  ecalIso_EE);
-    set("hcalIso_EE",  hcalIso_EE);
-    set("sihih_EE",    sihih_EE);
-    set("dphi_EE",     dphi_EE);
-    set("deta_EE",     deta_EE);
-    set("hoe_EE",      hoe_EE);
-    set("cIso_EE",     cIso_EE);
-    
-    set("conversionRejection",            conversionRejection);
+    set("ecalIso_EE", ecalIso_EE);
+    set("hcalIso_EE", hcalIso_EE);
+    set("sihih_EE", sihih_EE);
+    set("dphi_EE", dphi_EE);
+    set("deta_EE", deta_EE);
+    set("hoe_EE", hoe_EE);
+    set("cIso_EE", cIso_EE);
+
+    set("conversionRejection", conversionRejection);
     set("maxNumberOfExpectedMissingHits", maxNumberOfExpectedMissingHits);
-    
   }
 
-  bool operator()( const pat::Electron & electron, pat::strbitset & ret ) override 
-  {
+  bool operator()(const pat::Electron& electron, pat::strbitset& ret) override {
     // for the time being only Spring10 variable definition
     return spring10Variables(electron, ret);
   }
   using Selector<pat::Electron>::operator();
   // function with the Spring10 variable definitions
-  bool spring10Variables( const pat::Electron & electron, pat::strbitset & ret) 
-  {
+  bool spring10Variables(const pat::Electron& electron, pat::strbitset& ret) {
     ret.set(false);
     //
     Double_t eleET = electron.p4().Pt();
-    Double_t trackIso = electron.dr03TkSumPt()/eleET;
-    Double_t ecalIso = electron.dr03EcalRecHitSumEt()/eleET;
-    Double_t hcalIso = electron.dr03HcalTowerSumEt()/eleET;
-    Double_t sihih   = electron.sigmaIetaIeta();
-    Double_t Dphi    = electron.deltaPhiSuperClusterTrackAtVtx();
-    Double_t Deta    = electron.deltaEtaSuperClusterTrackAtVtx();
-    Double_t HoE     = electron.hadronicOverEm();
-    Double_t cIso    = 0;
-    if (electron.isEB()) { cIso = 
-	( electron.dr03TkSumPt() + std::max(0.,electron.dr03EcalRecHitSumEt() -1.) 
-	  + electron.dr03HcalTowerSumEt() ) / eleET;
-    }
-    else {
-      cIso = ( electron.dr03TkSumPt()+electron.dr03EcalRecHitSumEt()+
-	       electron.dr03HcalTowerSumEt()  ) / eleET;
+    Double_t trackIso = electron.dr03TkSumPt() / eleET;
+    Double_t ecalIso = electron.dr03EcalRecHitSumEt() / eleET;
+    Double_t hcalIso = electron.dr03HcalTowerSumEt() / eleET;
+    Double_t sihih = electron.sigmaIetaIeta();
+    Double_t Dphi = electron.deltaPhiSuperClusterTrackAtVtx();
+    Double_t Deta = electron.deltaEtaSuperClusterTrackAtVtx();
+    Double_t HoE = electron.hadronicOverEm();
+    Double_t cIso = 0;
+    if (electron.isEB()) {
+      cIso =
+          (electron.dr03TkSumPt() + std::max(0., electron.dr03EcalRecHitSumEt() - 1.) + electron.dr03HcalTowerSumEt()) /
+          eleET;
+    } else {
+      cIso = (electron.dr03TkSumPt() + electron.dr03EcalRecHitSumEt() + electron.dr03HcalTowerSumEt()) / eleET;
     }
     Int_t innerHits = electron.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
     // in 39 conversion rejection variables are accessible from Gsf electron
-    Double_t dist = electron.convDist(); // default value is -9999 if conversion partner not found
-    Double_t dcot = electron.convDcot(); // default value is -9999 if conversion partner not found
+    Double_t dist = electron.convDist();  // default value is -9999 if conversion partner not found
+    Double_t dcot = electron.convDcot();  // default value is -9999 if conversion partner not found
     Bool_t isConv = fabs(dist) < 0.02 && fabs(dcot) < 0.02;
     // now apply the cuts
-    if (electron.isEB()) { // BARREL case
+    if (electron.isEB()) {  // BARREL case
       // check the EB cuts
-      if ( trackIso   <  cut("trackIso_EB", double()) || ignoreCut("trackIso_EB")) passCut(ret, "trackIso_EB");
-      if ( ecalIso    <  cut("ecalIso_EB",  double()) || ignoreCut("ecalIso_EB") ) passCut(ret, "ecalIso_EB");
-      if ( hcalIso    <  cut("hcalIso_EB",  double()) || ignoreCut("hcalIso_EB") ) passCut(ret, "hcalIso_EB");
-      if ( sihih      <  cut("sihih_EB",    double()) || ignoreCut("sihih_EB")   ) passCut(ret, "sihih_EB");
-      if ( fabs(Dphi) <  cut("dphi_EB",     double()) || ignoreCut("dphi_EB")    ) passCut(ret, "dphi_EB");
-      if ( fabs(Deta) <  cut("deta_EB",     double()) || ignoreCut("deta_EB")    ) passCut(ret, "deta_EB");
-      if ( HoE        <  cut("hoe_EB",      double()) || ignoreCut("hoe_EB")     ) passCut(ret, "hoe_EB");
-      if ( cIso       <  cut("cIso_EB",     double()) || ignoreCut("cIso_EB")    ) passCut(ret, "cIso_EB");
+      if (trackIso < cut("trackIso_EB", double()) || ignoreCut("trackIso_EB"))
+        passCut(ret, "trackIso_EB");
+      if (ecalIso < cut("ecalIso_EB", double()) || ignoreCut("ecalIso_EB"))
+        passCut(ret, "ecalIso_EB");
+      if (hcalIso < cut("hcalIso_EB", double()) || ignoreCut("hcalIso_EB"))
+        passCut(ret, "hcalIso_EB");
+      if (sihih < cut("sihih_EB", double()) || ignoreCut("sihih_EB"))
+        passCut(ret, "sihih_EB");
+      if (fabs(Dphi) < cut("dphi_EB", double()) || ignoreCut("dphi_EB"))
+        passCut(ret, "dphi_EB");
+      if (fabs(Deta) < cut("deta_EB", double()) || ignoreCut("deta_EB"))
+        passCut(ret, "deta_EB");
+      if (HoE < cut("hoe_EB", double()) || ignoreCut("hoe_EB"))
+        passCut(ret, "hoe_EB");
+      if (cIso < cut("cIso_EB", double()) || ignoreCut("cIso_EB"))
+        passCut(ret, "cIso_EB");
       // pass all the EE cuts
-      passCut(ret, "trackIso_EE");	
-      passCut(ret, "ecalIso_EE");	
-      passCut(ret, "hcalIso_EE");	
-      passCut(ret, "sihih_EE");	
-      passCut(ret, "dphi_EE");	
-      passCut(ret, "deta_EE");	
-      passCut(ret, "hoe_EE");	
-      passCut(ret, "cIso_EE");     
+      passCut(ret, "trackIso_EE");
+      passCut(ret, "ecalIso_EE");
+      passCut(ret, "hcalIso_EE");
+      passCut(ret, "sihih_EE");
+      passCut(ret, "dphi_EE");
+      passCut(ret, "deta_EE");
+      passCut(ret, "hoe_EE");
+      passCut(ret, "cIso_EE");
     } else {  // ENDCAPS case
       // check the EE cuts
-      if ( trackIso   <  cut("trackIso_EE", double()) || ignoreCut("trackIso_EE")) passCut(ret, "trackIso_EE");
-      if ( ecalIso    <  cut("ecalIso_EE",  double()) || ignoreCut("ecalIso_EE") ) passCut(ret, "ecalIso_EE");
-      if ( hcalIso    <  cut("hcalIso_EE",  double()) || ignoreCut("hcalIso_EE") ) passCut(ret, "hcalIso_EE");
-      if ( sihih      <  cut("sihih_EE",    double()) || ignoreCut("sihih_EE")   ) passCut(ret, "sihih_EE");
-      if ( fabs(Dphi) <  cut("dphi_EE",     double()) || ignoreCut("dphi_EE")    ) passCut(ret, "dphi_EE");
-      if ( fabs(Deta) <  cut("deta_EE",     double()) || ignoreCut("deta_EE")    ) passCut(ret, "deta_EE");
-      if ( HoE        <  cut("hoe_EE",      double()) || ignoreCut("hoe_EE")     ) passCut(ret, "hoe_EE");
-      if ( cIso       <  cut("cIso_EE",     double()) || ignoreCut("cIso_EE")    ) passCut(ret, "cIso_EE");     
+      if (trackIso < cut("trackIso_EE", double()) || ignoreCut("trackIso_EE"))
+        passCut(ret, "trackIso_EE");
+      if (ecalIso < cut("ecalIso_EE", double()) || ignoreCut("ecalIso_EE"))
+        passCut(ret, "ecalIso_EE");
+      if (hcalIso < cut("hcalIso_EE", double()) || ignoreCut("hcalIso_EE"))
+        passCut(ret, "hcalIso_EE");
+      if (sihih < cut("sihih_EE", double()) || ignoreCut("sihih_EE"))
+        passCut(ret, "sihih_EE");
+      if (fabs(Dphi) < cut("dphi_EE", double()) || ignoreCut("dphi_EE"))
+        passCut(ret, "dphi_EE");
+      if (fabs(Deta) < cut("deta_EE", double()) || ignoreCut("deta_EE"))
+        passCut(ret, "deta_EE");
+      if (HoE < cut("hoe_EE", double()) || ignoreCut("hoe_EE"))
+        passCut(ret, "hoe_EE");
+      if (cIso < cut("cIso_EE", double()) || ignoreCut("cIso_EE"))
+        passCut(ret, "cIso_EE");
       // pass all the EB cuts
-      passCut(ret, "trackIso_EB");	
-      passCut(ret, "ecalIso_EB");	
-      passCut(ret, "hcalIso_EB");	
-      passCut(ret, "sihih_EB");	
-      passCut(ret, "dphi_EB");	
-      passCut(ret, "deta_EB");	
-      passCut(ret, "hoe_EB");	
-      passCut(ret, "cIso_EB");     
+      passCut(ret, "trackIso_EB");
+      passCut(ret, "ecalIso_EB");
+      passCut(ret, "hcalIso_EB");
+      passCut(ret, "sihih_EB");
+      passCut(ret, "dphi_EB");
+      passCut(ret, "deta_EB");
+      passCut(ret, "hoe_EB");
+      passCut(ret, "cIso_EB");
     }
 
     // conversion rejection common for EB and EE
-    if ( innerHits  <=  cut("maxNumberOfExpectedMissingHits", int())) 
-      passCut(ret, "maxNumberOfExpectedMissingHits");    
-    if ( 0==cut("conversionRejection", int()) || isConv==false)
+    if (innerHits <= cut("maxNumberOfExpectedMissingHits", int()))
+      passCut(ret, "maxNumberOfExpectedMissingHits");
+    if (0 == cut("conversionRejection", int()) || isConv == false)
       passCut(ret, "conversionRejection");
-    setIgnored(ret);   
+    setIgnored(ret);
     return (bool)ret;
   }
 
-
-
- private: // member variables
-  // version of the cuts  
+private:  // member variables
+  // version of the cuts
   Version_t version_;
 };
-
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h
@@ -23,26 +23,25 @@
 #include <memory>
 #include <sstream>
 
-template< class PhysicsObjectPtr , class SelectorType=VersionedSelector<PhysicsObjectPtr> >
+template <class PhysicsObjectPtr, class SelectorType = VersionedSelector<PhysicsObjectPtr>>
 class VersionedIdProducer : public edm::stream::EDProducer<> {
 public:
-  using PhysicsObjectType =  typename PhysicsObjectPtr::value_type;
+  using PhysicsObjectType = typename PhysicsObjectPtr::value_type;
 
-  using Collection =  edm::View<PhysicsObjectType>;
+  using Collection = edm::View<PhysicsObjectType>;
   using TokenType = edm::EDGetTokenT<Collection>;
 
   explicit VersionedIdProducer(const edm::ParameterSet&);
   ~VersionedIdProducer() override {}
-  
+
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-private:  
+private:
   // ----------member data ---------------------------
   bool verbose_;
   TokenType physicsObjectSrc_;
-    
-  std::vector<std::unique_ptr<SelectorType> > ids_;
 
+  std::vector<std::unique_ptr<SelectorType>> ids_;
 };
 
 //
@@ -56,153 +55,139 @@ private:
 //
 // constructors and destructor
 //
-template< class PhysicsObjectPtr , class SelectorType >
-VersionedIdProducer<PhysicsObjectPtr,SelectorType>::
-VersionedIdProducer(const edm::ParameterSet& iConfig) {
+template <class PhysicsObjectPtr, class SelectorType>
+VersionedIdProducer<PhysicsObjectPtr, SelectorType>::VersionedIdProducer(const edm::ParameterSet& iConfig) {
   constexpr char bitmap_label[] = "Bitmap";
-  
+
   verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
-  
-  physicsObjectSrc_ = 
-    consumes<Collection>(iConfig.getParameter<edm::InputTag>("physicsObjectSrc"));
-  
-  const std::vector<edm::ParameterSet>& ids = 
-    iConfig.getParameterSetVector("physicsObjectIDs");
-  for(const auto& id : ids ) {    
-    const std::string& idMD5 = 
-      id.getParameter<std::string>("idMD5");
-    const edm::ParameterSet& the_id = 
-      id.getParameterSet("idDefinition");
-    const std::string& idname =
-      the_id.getParameter<std::string>("idName");
+
+  physicsObjectSrc_ = consumes<Collection>(iConfig.getParameter<edm::InputTag>("physicsObjectSrc"));
+
+  const std::vector<edm::ParameterSet>& ids = iConfig.getParameterSetVector("physicsObjectIDs");
+  for (const auto& id : ids) {
+    const std::string& idMD5 = id.getParameter<std::string>("idMD5");
+    const edm::ParameterSet& the_id = id.getParameterSet("idDefinition");
+    const std::string& idname = the_id.getParameter<std::string>("idName");
     std::string calculated_md5;
-    ids_.emplace_back( new SelectorType(the_id) );
+    ids_.emplace_back(new SelectorType(the_id));
     calculated_md5 = ids_.back()->md5String();
     ids_.back()->setConsumes(consumesCollector());
-    if( ids_.back()->cutFlowSize() == 0 ) {
-      throw cms::Exception("InvalidCutFlow")
-	<< "Post-processing cutflow size is zero! You may have configured"
-	<< " the python incorrectly!";
+    if (ids_.back()->cutFlowSize() == 0) {
+      throw cms::Exception("InvalidCutFlow") << "Post-processing cutflow size is zero! You may have configured"
+                                             << " the python incorrectly!";
     }
 
-    if( idMD5 != calculated_md5 ) {
-      edm::LogInfo("IdConfigurationNotValidated")
-        << "ID: " << ids_.back()->name() << "\n"
-	<< "The expected md5: " << idMD5 << " does not match the md5\n"
-	<< "calculated by the ID: " << calculated_md5 << " please\n"
-	<< "update your python configuration or determine the source\n"
-	<< "of transcription error!";
+    if (idMD5 != calculated_md5) {
+      edm::LogInfo("IdConfigurationNotValidated") << "ID: " << ids_.back()->name() << "\n"
+                                                  << "The expected md5: " << idMD5 << " does not match the md5\n"
+                                                  << "calculated by the ID: " << calculated_md5 << " please\n"
+                                                  << "update your python configuration or determine the source\n"
+                                                  << "of transcription error!";
     }
 
     std::stringstream idmsg;
 
-    // dump whatever information about the ID we have     
-    idmsg << "Instantiated ID: " << idname << std::endl
-	  << "with MD5 hash: " << idMD5 << std::endl;
-    const bool isPOGApproved = 
-      id.getUntrackedParameter<bool>("isPOGApproved",false);
-    if( isPOGApproved ) {
+    // dump whatever information about the ID we have
+    idmsg << "Instantiated ID: " << idname << std::endl << "with MD5 hash: " << idMD5 << std::endl;
+    const bool isPOGApproved = id.getUntrackedParameter<bool>("isPOGApproved", false);
+    if (isPOGApproved) {
       idmsg << "This ID is POG approved!" << std::endl;
     } else {
       idmsg << "This ID is not POG approved and likely under development!!!\n"
-	    << "Please make sure to report your progress with this ID "
-	    << "at the next relevant POG meeting." << std::endl;
+            << "Please make sure to report your progress with this ID "
+            << "at the next relevant POG meeting." << std::endl;
     }
 
-    if( !isPOGApproved ) {
-      edm::LogWarning("IdInformation")
-        << idmsg.str();
+    if (!isPOGApproved) {
+      edm::LogWarning("IdInformation") << idmsg.str();
     } else {
-      edm::LogInfo("IdInformation")
-        << idmsg.str();
-    }    
+      edm::LogInfo("IdInformation") << idmsg.str();
+    }
 
     produces<std::string>(idname);
-    produces<edm::ValueMap<bool> >(idname);
-    produces<edm::ValueMap<float> >(idname); // for PAT
-    produces<edm::ValueMap<unsigned> >(idname);  
-    produces<edm::ValueMap<unsigned> >(idname+std::string(bitmap_label));
-    produces<edm::ValueMap<vid::CutFlowResult> >(idname);
+    produces<edm::ValueMap<bool>>(idname);
+    produces<edm::ValueMap<float>>(idname);  // for PAT
+    produces<edm::ValueMap<unsigned>>(idname);
+    produces<edm::ValueMap<unsigned>>(idname + std::string(bitmap_label));
+    produces<edm::ValueMap<vid::CutFlowResult>>(idname);
     produces<pat::UserDataCollection>(idname);
-    produces<edm::ValueMap<edm::Ptr<pat::UserData> > >(idname);
+    produces<edm::ValueMap<edm::Ptr<pat::UserData>>>(idname);
   }
 }
 
-template< class PhysicsObjectPtr , class SelectorType >
-void VersionedIdProducer<PhysicsObjectPtr,SelectorType>::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+template <class PhysicsObjectPtr, class SelectorType>
+void VersionedIdProducer<PhysicsObjectPtr, SelectorType>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   constexpr char bitmap_label[] = "Bitmap";
-  
+
   edm::Handle<Collection> physicsObjectsHandle;
-  iEvent.getByToken(physicsObjectSrc_,physicsObjectsHandle);
+  iEvent.getByToken(physicsObjectSrc_, physicsObjectsHandle);
 
   const Collection& physicsobjects = *physicsObjectsHandle;
 
-  for( const auto& id : ids_ ) {
+  for (const auto& id : ids_) {
     auto outPass = std::make_unique<edm::ValueMap<bool>>();
     auto outPassf = std::make_unique<edm::ValueMap<float>>();
     auto outHowFar = std::make_unique<edm::ValueMap<unsigned>>();
     auto outBitmap = std::make_unique<edm::ValueMap<unsigned>>();
     auto out_cfrs = std::make_unique<edm::ValueMap<vid::CutFlowResult>>();
     auto out_usrd = std::make_unique<pat::UserDataCollection>();
-        
+
     std::vector<bool> passfail;
     std::vector<float> passfailf;
     std::vector<unsigned> howfar;
     std::vector<unsigned> bitmap;
     std::vector<vid::CutFlowResult> cfrs;
-    
-    for(size_t i = 0; i < physicsobjects.size(); ++i) {
+
+    for (size_t i = 0; i < physicsobjects.size(); ++i) {
       auto po = physicsobjects.ptrAt(i);
-      passfail.push_back((*id)(po,iEvent));
+      passfail.push_back((*id)(po, iEvent));
       passfailf.push_back(passfail.back());
       howfar.push_back(id->howFarInCutFlow());
       bitmap.push_back(id->bitMap());
       cfrs.push_back(id->cutFlowResult());
-      out_usrd->push_back(pat::UserData::make(cfrs.back(),false));
+      out_usrd->push_back(pat::UserData::make(cfrs.back(), false));
     }
-    
+
     edm::ValueMap<bool>::Filler fillerpassfail(*outPass);
     fillerpassfail.insert(physicsObjectsHandle, passfail.begin(), passfail.end());
     fillerpassfail.fill();
-    
+
     edm::ValueMap<float>::Filler fillerpassfailf(*outPassf);
     fillerpassfailf.insert(physicsObjectsHandle, passfailf.begin(), passfailf.end());
     fillerpassfailf.fill();
 
     edm::ValueMap<unsigned>::Filler fillerhowfar(*outHowFar);
-    fillerhowfar.insert(physicsObjectsHandle, howfar.begin(), howfar.end() );
-    fillerhowfar.fill();  
-    
+    fillerhowfar.insert(physicsObjectsHandle, howfar.begin(), howfar.end());
+    fillerhowfar.fill();
+
     edm::ValueMap<unsigned>::Filler fillerbitmap(*outBitmap);
-    fillerbitmap.insert(physicsObjectsHandle, bitmap.begin(), bitmap.end() );
-    fillerbitmap.fill(); 
+    fillerbitmap.insert(physicsObjectsHandle, bitmap.begin(), bitmap.end());
+    fillerbitmap.fill();
 
     edm::ValueMap<vid::CutFlowResult>::Filler fillercfr(*out_cfrs);
-    fillercfr.insert(physicsObjectsHandle, cfrs.begin(), cfrs.end() );
-    fillercfr.fill(); 
+    fillercfr.insert(physicsObjectsHandle, cfrs.begin(), cfrs.end());
+    fillercfr.fill();
 
-    iEvent.put(std::move(outPass),id->name());
-    iEvent.put(std::move(outPassf),id->name());
-    iEvent.put(std::move(outHowFar),id->name());
-    iEvent.put(std::move(outBitmap),id->name()+std::string(bitmap_label));
-    iEvent.put(std::move(out_cfrs),id->name());
-    iEvent.put(std::make_unique<std::string>(id->md5String()),
-	       id->name());
-    auto usrd_handle = iEvent.put(std::move(out_usrd),id->name());
+    iEvent.put(std::move(outPass), id->name());
+    iEvent.put(std::move(outPassf), id->name());
+    iEvent.put(std::move(outHowFar), id->name());
+    iEvent.put(std::move(outBitmap), id->name() + std::string(bitmap_label));
+    iEvent.put(std::move(out_cfrs), id->name());
+    iEvent.put(std::make_unique<std::string>(id->md5String()), id->name());
+    auto usrd_handle = iEvent.put(std::move(out_usrd), id->name());
     //now add the value map of ptrs to user datas
     auto out_usrdptrs = std::make_unique<edm::ValueMap<edm::Ptr<pat::UserData>>>();
-    std::vector<edm::Ptr<pat::UserData> > usrdptrs;
-    for( unsigned i = 0; i < usrd_handle->size(); ++i ){
-      usrdptrs.push_back(edm::Ptr<pat::UserData>(usrd_handle,i));
+    std::vector<edm::Ptr<pat::UserData>> usrdptrs;
+    for (unsigned i = 0; i < usrd_handle->size(); ++i) {
+      usrdptrs.push_back(edm::Ptr<pat::UserData>(usrd_handle, i));
     }
 
-    edm::ValueMap<edm::Ptr<pat::UserData> >::Filler fillerusrdptrs(*out_usrdptrs);
+    edm::ValueMap<edm::Ptr<pat::UserData>>::Filler fillerusrdptrs(*out_usrdptrs);
     fillerusrdptrs.insert(physicsObjectsHandle, usrdptrs.begin(), usrdptrs.end());
     fillerusrdptrs.fill();
 
-    iEvent.put(std::move(out_usrdptrs),id->name());        
-  }   
+    iEvent.put(std::move(out_usrdptrs), id->name());
+  }
 }
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -11,7 +11,7 @@
   \author Lindsey Gray
 */
 
-#if ( !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__) && !defined(__CLING__) )
+#if (!defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__) && !defined(__CLING__))
 
 #define REGULAR_CPLUSPLUS 1
 #define CINT_GUARD(CODE) CODE
@@ -42,15 +42,12 @@ namespace vid {
   class CutFlowResult;
 }
 
-template<class T>
+template <class T>
 class VersionedSelector : public Selector<T> {
- public:
- VersionedSelector() : Selector<T>(), initialized_(false) {}
+public:
+  VersionedSelector() : Selector<T>(), initialized_(false) {}
 
- VersionedSelector(const edm::ParameterSet& conf) : 
-  Selector<T>(),
-  initialized_(false) { 
-
+  VersionedSelector(const edm::ParameterSet& conf) : Selector<T>(), initialized_(false) {
     validateParamsAreTracked(conf);
 
     name_ = conf.getParameter<std::string>("idName");
@@ -58,96 +55,95 @@ class VersionedSelector : public Selector<T> {
     // now setup the md5 and cute accessor functions
     constexpr unsigned length = MD5_DIGEST_LENGTH;
     std::string tracked(conf.trackedPart().dump());
-    memset(id_md5_,0,length*sizeof(unsigned char));
+    memset(id_md5_, 0, length * sizeof(unsigned char));
     MD5((unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
     char buf[32];
-    for( unsigned i=0; i<MD5_DIGEST_LENGTH; ++i ){
+    for (unsigned i = 0; i < MD5_DIGEST_LENGTH; ++i) {
       sprintf(buf, "%02x", id_md5_[i]);
-      md5_string_.append( buf );
+      md5_string_.append(buf);
     }
     initialize(conf);
-    this->retInternal_  = this->getBitTemplate();
+    this->retInternal_ = this->getBitTemplate();
   }
-  
-  bool operator()( const T& ref, pat::strbitset& ret ) CINT_GUARD(final) {
+
+  bool operator()(const T& ref, pat::strbitset& ret) CINT_GUARD(final) {
     howfar_ = 0;
     bitmap_ = 0;
     values_.clear();
     bool failed = false;
-    if( !initialized_ ) {
-      throw cms::Exception("CutNotInitialized")
-	<< "VersionedGsfElectronSelector not initialized!" << std::endl;
-    }  
-    for( unsigned i = 0; i < cuts_.size(); ++i ) {
+    if (!initialized_) {
+      throw cms::Exception("CutNotInitialized") << "VersionedGsfElectronSelector not initialized!" << std::endl;
+    }
+    for (unsigned i = 0; i < cuts_.size(); ++i) {
       reco::CandidatePtr temp(ref);
       const bool result = (*cuts_[i])(temp);
       values_.push_back(cuts_[i]->value(temp));
-      if( result || this->ignoreCut(cut_indices_[i]) ) {
-	this->passCut(ret,cut_indices_[i]);
-        bitmap_ |= 1<<i;
-	if( !failed ) ++howfar_;
+      if (result || this->ignoreCut(cut_indices_[i])) {
+        this->passCut(ret, cut_indices_[i]);
+        bitmap_ |= 1 << i;
+        if (!failed)
+          ++howfar_;
       } else {
-	failed = true;
+        failed = true;
       }
     }
     this->setIgnored(ret);
     return (bool)ret;
   }
-  
+
   bool operator()(const T& ref, edm::EventBase const& e, pat::strbitset& ret) CINT_GUARD(final) {
     // setup isolation needs
-    for( size_t i = 0, cutssize = cuts_.size(); i < cutssize; ++i ) {
-      if( needs_event_content_[i] ) {
-	CutApplicatorWithEventContentBase* needsEvent = 
-	  static_cast<CutApplicatorWithEventContentBase*>(cuts_[i].get());
-	needsEvent->getEventContent(e); 
+    for (size_t i = 0, cutssize = cuts_.size(); i < cutssize; ++i) {
+      if (needs_event_content_[i]) {
+        CutApplicatorWithEventContentBase* needsEvent = static_cast<CutApplicatorWithEventContentBase*>(cuts_[i].get());
+        needsEvent->getEventContent(e);
       }
     }
     return this->operator()(ref, ret);
   }
-  
+
   //repeat the other operator() we left out here
   //in the base class here so they are exposed to ROOT
 
   /* VID BY VALUE */
-  bool operator()( typename T::value_type const & t ) {
-    const T temp(&t,0); // assuming T is edm::Ptr
+  bool operator()(typename T::value_type const& t) {
+    const T temp(&t, 0);  // assuming T is edm::Ptr
     return this->operator()(temp);
   }
 
-  bool operator()( typename T::value_type const & t, edm::EventBase const & e) {
-    const T temp(&t,0);
-    return this->operator()(temp,e);
+  bool operator()(typename T::value_type const& t, edm::EventBase const& e) {
+    const T temp(&t, 0);
+    return this->operator()(temp, e);
   }
-  
-  bool operator()( T const & t ) CINT_GUARD(final) {
+
+  bool operator()(T const& t) CINT_GUARD(final) {
     this->retInternal_.set(false);
     this->operator()(t, this->retInternal_);
     this->setIgnored(this->retInternal_);
     return (bool)this->retInternal_;
   }
-  
-  bool operator()( T const & t, edm::EventBase const & e) CINT_GUARD(final) {
+
+  bool operator()(T const& t, edm::EventBase const& e) CINT_GUARD(final) {
     this->retInternal_.set(false);
     this->operator()(t, e, this->retInternal_);
     this->setIgnored(this->retInternal_);
     return (bool)this->retInternal_;
   }
 
-  const unsigned char* md55Raw() const { return id_md5_; } 
+  const unsigned char* md55Raw() const { return id_md5_; }
   bool operator==(const VersionedSelector& other) const {
     constexpr unsigned length = MD5_DIGEST_LENGTH;
-    return ( 0 == memcmp(id_md5_,other.id_md5_,length*sizeof(unsigned char)) );
+    return (0 == memcmp(id_md5_, other.id_md5_, length * sizeof(unsigned char)));
   }
   const std::string& md5String() const { return md5_string_; }
 
   const std::string& name() const { return name_; }
 
   const unsigned howFarInCutFlow() const { return howfar_; }
-  
+
   const unsigned bitMap() const { return bitmap_; }
 
-  const size_t cutFlowSize() const { return cuts_.size(); } 
+  const size_t cutFlowSize() const { return cuts_.size(); }
 
   vid::CutFlowResult cutFlowResult() const;
 
@@ -155,132 +151,126 @@ class VersionedSelector : public Selector<T> {
 
   CINT_GUARD(void setConsumes(edm::ConsumesCollector));
 
- private:
+private:
   //here we check that the parameters of the VID cuts are tracked
   //we allow exactly one parameter to be untracked "isPOGApproved"
   //as if its tracked, its a pain for the md5Sums
-  //due to the mechanics of PSets, it was demined easier just to 
+  //due to the mechanics of PSets, it was demined easier just to
   //create a new config which doesnt have an untracked isPOGApproved
   //if isPOGApproved is tracked (if we decide to do that in the future), it keeps it
   //see https://github.com/cms-sw/cmssw/issues/19799 for the discussion
-  static void validateParamsAreTracked(const edm::ParameterSet& conf){
+  static void validateParamsAreTracked(const edm::ParameterSet& conf) {
     edm::ParameterSet trackedPart = conf.trackedPart();
     edm::ParameterSet confWithoutIsPOGApproved;
-    for(auto& paraName : conf.getParameterNames()){
-      if(paraName != "isPOGApproved") confWithoutIsPOGApproved.copyFrom(conf,paraName);
-      else if(conf.existsAs<bool>(paraName,true)) confWithoutIsPOGApproved.copyFrom(conf,paraName); //adding isPOGApproved if its a tracked bool
+    for (auto& paraName : conf.getParameterNames()) {
+      if (paraName != "isPOGApproved")
+        confWithoutIsPOGApproved.copyFrom(conf, paraName);
+      else if (conf.existsAs<bool>(paraName, true))
+        confWithoutIsPOGApproved.copyFrom(conf, paraName);  //adding isPOGApproved if its a tracked bool
     }
-    std::string tracked(conf.trackedPart().dump()), untracked(confWithoutIsPOGApproved.dump());   
-    if ( tracked != untracked ) {
-      throw cms::Exception("InvalidConfiguration")
-	<< "VersionedSelector does not allow untracked parameters"
-	<< " in the cutflow ParameterSet!";
+    std::string tracked(conf.trackedPart().dump()), untracked(confWithoutIsPOGApproved.dump());
+    if (tracked != untracked) {
+      throw cms::Exception("InvalidConfiguration") << "VersionedSelector does not allow untracked parameters"
+                                                   << " in the cutflow ParameterSet!";
     }
   }
 
-   
- protected:
+protected:
   bool initialized_;
-  std::vector<SHARED_PTR(candf::CandidateCut) > cuts_;
+  std::vector<SHARED_PTR(candf::CandidateCut)> cuts_;
   std::vector<bool> needs_event_content_;
   std::vector<typename Selector<T>::index_type> cut_indices_;
   unsigned howfar_, bitmap_;
   std::vector<double> values_;
 
- private:  
+private:
   unsigned char id_md5_[MD5_DIGEST_LENGTH];
-  std::string md5_string_,name_;  
+  std::string md5_string_, name_;
 };
 
-template<class T>
-void VersionedSelector<T>::
-initialize( const edm::ParameterSet& conf ) {
-  if(initialized_) {
-    edm::LogWarning("VersionedPatElectronSelector")
-      << "ID was already initialized!";
+template <class T>
+void VersionedSelector<T>::initialize(const edm::ParameterSet& conf) {
+  if (initialized_) {
+    edm::LogWarning("VersionedPatElectronSelector") << "ID was already initialized!";
     return;
-  }  
-  const std::vector<edm::ParameterSet>& cutflow =
-    conf.getParameterSetVector("cutFlow");  
-  if( cutflow.empty() ) {
-    throw cms::Exception("InvalidCutFlow")
-      << "You have supplied a null/empty cutflow to VersionedIDSelector,"
-      << " please add content to the cuflow and try again.";
   }
-  
+  const std::vector<edm::ParameterSet>& cutflow = conf.getParameterSetVector("cutFlow");
+  if (cutflow.empty()) {
+    throw cms::Exception("InvalidCutFlow") << "You have supplied a null/empty cutflow to VersionedIDSelector,"
+                                           << " please add content to the cuflow and try again.";
+  }
+
   // this lets us keep track of cuts without knowing what they are :D
-  std::vector<edm::ParameterSet>::const_iterator cbegin(cutflow.begin()),
-    cend(cutflow.end());
+  std::vector<edm::ParameterSet>::const_iterator cbegin(cutflow.begin()), cend(cutflow.end());
   std::vector<edm::ParameterSet>::const_iterator icut = cbegin;
-  std::map<std::string,unsigned> cut_counter;
+  std::map<std::string, unsigned> cut_counter;
   std::vector<std::string> ignored_cuts;
-  for( ; icut != cend; ++icut ) {  
-    std::stringstream realname;    
+  for (; icut != cend; ++icut) {
+    std::stringstream realname;
     const std::string& name = icut->getParameter<std::string>("cutName");
-    if( !cut_counter.count(name) ) cut_counter[name] = 0;      
+    if (!cut_counter.count(name))
+      cut_counter[name] = 0;
     realname << name << "_" << cut_counter[name];
-    const bool needsContent = 
-      icut->getParameter<bool>("needsAdditionalProducts");     
+    const bool needsContent = icut->getParameter<bool>("needsAdditionalProducts");
     const bool ignored = icut->getParameter<bool>("isIgnored");
-    CINT_GUARD(cuts_.emplace_back(CutApplicatorFactory::get()->create(name,*icut)));
+    CINT_GUARD(cuts_.emplace_back(CutApplicatorFactory::get()->create(name, *icut)));
     needs_event_content_.push_back(needsContent);
     const std::string therealname = realname.str();
     this->push_back(therealname);
     this->set(therealname);
-    if(ignored) ignored_cuts.push_back(therealname);
+    if (ignored)
+      ignored_cuts.push_back(therealname);
     cut_counter[name]++;
-  }    
+  }
   this->setIgnoredCuts(ignored_cuts);
 
   //have to loop again to set cut indices after all are filled
   icut = cbegin;
   cut_counter.clear();
-  for( ; icut != cend; ++icut ) {
+  for (; icut != cend; ++icut) {
     std::stringstream realname;
-    const std::string& name = cuts_[std::distance(cbegin,icut)]->name();    
-    if( !cut_counter.count(name) ) cut_counter[name] = 0;      
+    const std::string& name = cuts_[std::distance(cbegin, icut)]->name();
+    if (!cut_counter.count(name))
+      cut_counter[name] = 0;
     realname << name << "_" << cut_counter[name];
-    cut_indices_.push_back(typename Selector<T>::index_type(&(this->bits_),realname.str()));    
+    cut_indices_.push_back(typename Selector<T>::index_type(&(this->bits_), realname.str()));
     cut_counter[name]++;
   }
-  
+
   initialized_ = true;
 }
 
-
-
 #ifdef REGULAR_CPLUSPLUS
 #include "DataFormats/PatCandidates/interface/VIDCutFlowResult.h"
-template<class T> 
+template <class T>
 vid::CutFlowResult VersionedSelector<T>::cutFlowResult() const {
-  std::map<std::string,unsigned> names_to_index;
-  std::map<std::string,unsigned> cut_counter;
-  for( unsigned idx = 0; idx < cuts_.size(); ++idx ) {
+  std::map<std::string, unsigned> names_to_index;
+  std::map<std::string, unsigned> cut_counter;
+  for (unsigned idx = 0; idx < cuts_.size(); ++idx) {
     const std::string& name = cuts_[idx]->name();
-    if( !cut_counter.count(name) ) cut_counter[name] = 0;  
+    if (!cut_counter.count(name))
+      cut_counter[name] = 0;
     std::stringstream realname;
     realname << name << "_" << cut_counter[name];
-    names_to_index.emplace(realname.str(),idx);
+    names_to_index.emplace(realname.str(), idx);
     cut_counter[name]++;
   }
-  return vid::CutFlowResult(name_,md5_string_,names_to_index,values_,bitmap_);
+  return vid::CutFlowResult(name_, md5_string_, names_to_index, values_, bitmap_);
 }
 
 #include "PhysicsTools/SelectorUtils/interface/CutApplicatorWithEventContentBase.h"
-template<class T>
+template <class T>
 void VersionedSelector<T>::setConsumes(edm::ConsumesCollector cc) {
-  for( size_t i = 0, cutssize = cuts_.size(); i < cutssize; ++i ) {
-    if( needs_event_content_[i] ) {
-      CutApplicatorWithEventContentBase* needsEvent = 
-	dynamic_cast<CutApplicatorWithEventContentBase*>(cuts_[i].get());
-      if( nullptr != needsEvent ) {
+  for (size_t i = 0, cutssize = cuts_.size(); i < cutssize; ++i) {
+    if (needs_event_content_[i]) {
+      CutApplicatorWithEventContentBase* needsEvent = dynamic_cast<CutApplicatorWithEventContentBase*>(cuts_[i].get());
+      if (nullptr != needsEvent) {
         needsEvent->setConsumes(cc);
       } else {
-        throw cms::Exception("InvalidCutConfiguration")
-          << "Cut: " << ((CutApplicatorBase*)cuts_[i].get())->name() 
-          << " configured to consume event products but does not "
-          << " inherit from CutApplicatorWithEventContenBase "
-          << " please correct either your python or C++!";
+        throw cms::Exception("InvalidCutConfiguration") << "Cut: " << ((CutApplicatorBase*)cuts_[i].get())->name()
+                                                        << " configured to consume event products but does not "
+                                                        << " inherit from CutApplicatorWithEventContenBase "
+                                                        << " please correct either your python or C++!";
       }
     }
   }

--- a/PhysicsTools/SelectorUtils/interface/WPlusJetsEventSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/WPlusJetsEventSelector.h
@@ -20,39 +20,40 @@
 #include "DataFormats/Candidate/interface/ShallowClonePtrCandidate.h"
 
 class WPlusJetsEventSelector : public EventSelector {
- public:
+public:
   WPlusJetsEventSelector() {}
 #ifndef __GCCXML__
-  WPlusJetsEventSelector( edm::ParameterSet const & params, edm::ConsumesCollector&& iC ) :
-    WPlusJetsEventSelector(params)
-  {
-    muonToken_ = iC.mayConsume< std::vector< pat::Muon > >(muonTag_);
-    electronToken_ = iC.mayConsume< std::vector< pat::Electron > >(electronTag_);
-    jetToken_ = iC.mayConsume< std::vector< pat::Jet > >(jetTag_);
-    metToken_ = iC.mayConsume< std::vector< pat::MET > >(metTag_);
+  WPlusJetsEventSelector(edm::ParameterSet const& params, edm::ConsumesCollector&& iC)
+      : WPlusJetsEventSelector(params) {
+    muonToken_ = iC.mayConsume<std::vector<pat::Muon> >(muonTag_);
+    electronToken_ = iC.mayConsume<std::vector<pat::Electron> >(electronTag_);
+    jetToken_ = iC.mayConsume<std::vector<pat::Jet> >(jetTag_);
+    metToken_ = iC.mayConsume<std::vector<pat::MET> >(metTag_);
     trigToken_ = iC.mayConsume<pat::TriggerEvent>(trigTag_);
-    muonIdTight_ = MuonVPlusJetsIDSelectionFunctor( params.getParameter<edm::ParameterSet>("muonIdTight"), iC );
-    electronIdTight_ = ElectronVPlusJetsIDSelectionFunctor(params.getParameter<edm::ParameterSet>("electronIdTight"), iC );
-    muonIdLoose_ = MuonVPlusJetsIDSelectionFunctor( params.getParameter<edm::ParameterSet>("muonIdLoose"), iC );
-    electronIdLoose_ = ElectronVPlusJetsIDSelectionFunctor(params.getParameter<edm::ParameterSet>("electronIdLoose"), iC );
-    jetIdLoose_      = JetIDSelectionFunctor(params.getParameter<edm::ParameterSet>("jetIdLoose"), iC );
-    pfjetIdLoose_    = PFJetIDSelectionFunctor(params.getParameter<edm::ParameterSet>("pfjetIdLoose"), iC );
+    muonIdTight_ = MuonVPlusJetsIDSelectionFunctor(params.getParameter<edm::ParameterSet>("muonIdTight"), iC);
+    electronIdTight_ =
+        ElectronVPlusJetsIDSelectionFunctor(params.getParameter<edm::ParameterSet>("electronIdTight"), iC);
+    muonIdLoose_ = MuonVPlusJetsIDSelectionFunctor(params.getParameter<edm::ParameterSet>("muonIdLoose"), iC);
+    electronIdLoose_ =
+        ElectronVPlusJetsIDSelectionFunctor(params.getParameter<edm::ParameterSet>("electronIdLoose"), iC);
+    jetIdLoose_ = JetIDSelectionFunctor(params.getParameter<edm::ParameterSet>("jetIdLoose"), iC);
+    pfjetIdLoose_ = PFJetIDSelectionFunctor(params.getParameter<edm::ParameterSet>("pfjetIdLoose"), iC);
   }
 #endif
-  WPlusJetsEventSelector( edm::ParameterSet const & params );
+  WPlusJetsEventSelector(edm::ParameterSet const& params);
 
-  virtual void scaleJets(double scale) {jetScale_ = scale;}
+  virtual void scaleJets(double scale) { jetScale_ = scale; }
 
-  bool operator()( edm::EventBase const & t, pat::strbitset & ret) override;
+  bool operator()(edm::EventBase const& t, pat::strbitset& ret) override;
   using EventSelector::operator();
 
-  std::vector<reco::ShallowClonePtrCandidate> const & selectedJets     () const { return selectedJets_;     }
-  std::vector<reco::ShallowClonePtrCandidate> const & cleanedJets      () const { return cleanedJets_;      }
-  std::vector<reco::ShallowClonePtrCandidate> const & selectedElectrons() const { return selectedElectrons_;}
-  std::vector<reco::ShallowClonePtrCandidate> const & selectedMuons    () const { return selectedMuons_;    }
-  reco::ShallowClonePtrCandidate const &              selectedMET      () const { return met_; }
+  std::vector<reco::ShallowClonePtrCandidate> const& selectedJets() const { return selectedJets_; }
+  std::vector<reco::ShallowClonePtrCandidate> const& cleanedJets() const { return cleanedJets_; }
+  std::vector<reco::ShallowClonePtrCandidate> const& selectedElectrons() const { return selectedElectrons_; }
+  std::vector<reco::ShallowClonePtrCandidate> const& selectedMuons() const { return selectedMuons_; }
+  reco::ShallowClonePtrCandidate const& selectedMET() const { return met_; }
 
-  void printSelectors(std::ostream & out) const {
+  void printSelectors(std::ostream& out) const {
     out << "PV Selector: " << std::endl;
     pvSelector_.print(out);
     out << "Muon ID Tight Selector: " << std::endl;
@@ -69,31 +70,30 @@ class WPlusJetsEventSelector : public EventSelector {
     pfjetIdLoose_.print(out);
   }
 
- protected:
-
-  edm::InputTag               muonTag_;
+protected:
+  edm::InputTag muonTag_;
 #ifndef __GCCXML__
-  edm::EDGetTokenT< std::vector< pat::Muon > > muonToken_;
+  edm::EDGetTokenT<std::vector<pat::Muon> > muonToken_;
 #endif
-  edm::InputTag               electronTag_;
+  edm::InputTag electronTag_;
 #ifndef __GCCXML__
-  edm::EDGetTokenT< std::vector< pat::Electron > > electronToken_;
+  edm::EDGetTokenT<std::vector<pat::Electron> > electronToken_;
 #endif
-  edm::InputTag               jetTag_;
+  edm::InputTag jetTag_;
 #ifndef __GCCXML__
-  edm::EDGetTokenT< std::vector< pat::Jet > > jetToken_;
+  edm::EDGetTokenT<std::vector<pat::Jet> > jetToken_;
 #endif
-  edm::InputTag               metTag_;
+  edm::InputTag metTag_;
 #ifndef __GCCXML__
-  edm::EDGetTokenT< std::vector< pat::MET > > metToken_;
+  edm::EDGetTokenT<std::vector<pat::MET> > metToken_;
 #endif
-  edm::InputTag               trigTag_;
+  edm::InputTag trigTag_;
 #ifndef __GCCXML__
   edm::EDGetTokenT<pat::TriggerEvent> trigToken_;
 #endif
 
-  std::string                 muTrig_;
-  std::string                 eleTrig_;
+  std::string muTrig_;
+  std::string eleTrig_;
 
   std::vector<reco::ShallowClonePtrCandidate> selectedJets_;
   std::vector<reco::ShallowClonePtrCandidate> selectedMuons_;
@@ -103,15 +103,15 @@ class WPlusJetsEventSelector : public EventSelector {
   std::vector<reco::ShallowClonePtrCandidate> selectedMETs_;
   std::vector<reco::ShallowClonePtrCandidate> cleanedJets_;
   std::vector<reco::ShallowClonePtrCandidate> selectedElectrons2_;
-  reco::ShallowClonePtrCandidate              met_;
+  reco::ShallowClonePtrCandidate met_;
 
-  PVSelector                           pvSelector_;
-  MuonVPlusJetsIDSelectionFunctor      muonIdTight_;
-  ElectronVPlusJetsIDSelectionFunctor  electronIdTight_;
-  MuonVPlusJetsIDSelectionFunctor      muonIdLoose_;
-  ElectronVPlusJetsIDSelectionFunctor  electronIdLoose_;
-  JetIDSelectionFunctor                jetIdLoose_;
-  PFJetIDSelectionFunctor              pfjetIdLoose_;
+  PVSelector pvSelector_;
+  MuonVPlusJetsIDSelectionFunctor muonIdTight_;
+  ElectronVPlusJetsIDSelectionFunctor electronIdTight_;
+  MuonVPlusJetsIDSelectionFunctor muonIdLoose_;
+  ElectronVPlusJetsIDSelectionFunctor electronIdLoose_;
+  JetIDSelectionFunctor jetIdLoose_;
+  PFJetIDSelectionFunctor pfjetIdLoose_;
 
   int minJets_;
 
@@ -121,41 +121,39 @@ class WPlusJetsEventSelector : public EventSelector {
   bool muPlusJets_;
   bool ePlusJets_;
 
-  double muPtMin_  ;
-  double muEtaMax_ ;
-  double eleEtMin_ ;
+  double muPtMin_;
+  double muEtaMax_;
+  double eleEtMin_;
   double eleEtaMax_;
 
-  double muPtMinLoose_  ;
-  double muEtaMaxLoose_ ;
-  double eleEtMinLoose_ ;
+  double muPtMinLoose_;
+  double muEtaMaxLoose_;
+  double eleEtMinLoose_;
   double eleEtaMaxLoose_;
 
-  double jetPtMin_ ;
+  double jetPtMin_;
   double jetEtaMax_;
 
   double jetScale_;
 
   double metMin_;
 
-  index_type   inclusiveIndex_;
-  index_type   triggerIndex_;
-  index_type   pvIndex_;
-  index_type   lep1Index_;
-  index_type   lep2Index_;
-  index_type   lep3Index_;
-  index_type   lep4Index_;
-  index_type   metIndex_;
-  index_type   zvetoIndex_;
-  index_type   conversionIndex_;
-  index_type   cosmicIndex_;
-  index_type   jet1Index_;
-  index_type   jet2Index_;
-  index_type   jet3Index_;
-  index_type   jet4Index_;
-  index_type   jet5Index_;
-
+  index_type inclusiveIndex_;
+  index_type triggerIndex_;
+  index_type pvIndex_;
+  index_type lep1Index_;
+  index_type lep2Index_;
+  index_type lep3Index_;
+  index_type lep4Index_;
+  index_type metIndex_;
+  index_type zvetoIndex_;
+  index_type conversionIndex_;
+  index_type cosmicIndex_;
+  index_type jet1Index_;
+  index_type jet2Index_;
+  index_type jet3Index_;
+  index_type jet4Index_;
+  index_type jet5Index_;
 };
-
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/strbitset.h
+++ b/PhysicsTools/SelectorUtils/interface/strbitset.h
@@ -12,7 +12,6 @@
   \version  $Id: strbitset.h,v 1.7 2010/07/23 01:25:22 srappocc Exp $
 */
 
-
 #include <string>
 #include <map>
 #include <vector>
@@ -21,383 +20,323 @@
 
 namespace pat {
 
-class strbitset {
- public:
-
-
-  class index_type {
+  class strbitset {
   public:
-    typedef unsigned int   size_t;
-    
-    friend class strbitset;
+    class index_type {
+    public:
+      typedef unsigned int size_t;
 
-  index_type() :bitset_(nullptr), i_(0) {}
-    
-  index_type( strbitset const * b, std::string const & s) :
-    bitset_(b) 
-    {
-      if ( bitset_ ) {
-	i_ = bitset_->index(s);
+      friend class strbitset;
+
+      index_type() : bitset_(nullptr), i_(0) {}
+
+      index_type(strbitset const* b, std::string const& s) : bitset_(b) {
+        if (bitset_) {
+          i_ = bitset_->index(s);
+        } else {
+          i_ = 0;
+        }
+      }
+
+      std::string const& str() const { return bitset_->index(i_); }
+
+      bool operator<(index_type const& r) const { return i_ < r.i_; }
+      bool operator>(index_type const& r) const { return i_ > r.i_; }
+      bool operator<=(index_type const& r) const { return i_ <= r.i_; }
+      bool operator>=(index_type const& r) const { return i_ >= r.i_; }
+      bool operator==(index_type const& r) const { return i_ == r.i_; }
+
+      friend std::ostream& operator<<(std::ostream& out, const index_type& r);
+
+    protected:
+      strbitset const* bitset_;
+      size_t i_;
+    };
+
+    friend class index_type;
+
+    // Add typedefs
+    typedef unsigned int size_t;
+    typedef std::map<std::string, size_t> str_index_map;
+    typedef std::vector<bool> bit_vector;
+
+    //! constructor: just clears the bitset and map
+    strbitset() { clear(); }
+
+    //! clear the bitset and map
+    void clear() {
+      map_.clear();
+      bits_.clear();
+    }
+
+    ///! cast to bool
+    operator bool() const {
+      bool b = true;
+      for (bit_vector::const_iterator bitsBegin = bits_.begin(), bitsEnd = bits_.end(), ibit = bitsBegin;
+           ibit != bitsEnd;
+           ++ibit) {
+        if (*ibit == false)
+          b = false;
+      }
+      return b;
+    }
+
+    ///! Logical negation of bool()
+    bool operator!() const { return !(operator bool()); }
+
+    /// adds an item that is indexed by the string. this
+    /// can then be sorted, cut, whatever, and the
+    /// index mapping is kept
+    void push_back(std::string s) {
+      if (map_.find(s) == map_.end()) {
+        map_[s] = bits_.size();
+        bits_.resize(bits_.size() + 1);
+        *(bits_.rbegin()) = false;
       } else {
-	i_ = 0;
+        std::cout << "Duplicate entry " << s << ", not added to registry" << std::endl;
       }
     }
 
-    std::string const & str() const { return bitset_->index(i_);}
+    //! print method
+    void print(std::ostream& out) const {
+      for (str_index_map::const_iterator mbegin = map_.begin(), mend = map_.end(), mit = mbegin; mit != mend; ++mit) {
+        char buff[100];
+        sprintf(buff, "%10s = %6i", mit->first.c_str(), (int)(bits_.at(mit->second)));
+        out << buff << std::endl;
+      }
+    }
 
-    bool operator< ( index_type const & r) const { return i_ < r.i_;}
-    bool operator> ( index_type const & r) const { return i_ > r.i_;}
-    bool operator<=( index_type const & r) const { return i_ <= r.i_;}
-    bool operator>=( index_type const & r) const { return i_ >= r.i_;}
-    bool operator==( index_type const & r) const { return i_ == r.i_;}    
+    //! access method const
+    bit_vector::const_reference operator[](const std::string s) const {
+      size_t index = this->index(s);
+      return bits_.operator[](index);
+    }
 
-    friend std::ostream & operator<<(std::ostream & out, const index_type & r);
-      
-  protected:
-    strbitset const *   bitset_;
-    size_t              i_;
+    bit_vector::const_reference operator[](index_type const& i) const { return bits_.operator[](i.i_); }
+
+    //! access method non-const
+    bit_vector::reference operator[](const std::string s) {
+      size_t index = this->index(s);
+      return bits_.operator[](index);
+    }
+
+    bit_vector::reference operator[](index_type const& i) { return bits_.operator[](i.i_); }
+
+    //! set method of all bits
+    strbitset& set(bool val = true) {
+      for (bit_vector::iterator ibegin = bits_.begin(), iend = bits_.end(), i = ibegin; i != iend; ++i) {
+        *i = val;
+      }
+      return *this;
+    }
+
+    //! flip method of all bits
+    strbitset& flip() {
+      for (bit_vector::iterator ibegin = bits_.begin(), iend = bits_.end(), i = ibegin; i != iend; ++i) {
+        *i = !(*i);
+      }
+      return *this;
+    }
+
+    //! set method of one bit
+    strbitset& set(std::string s, bool val = true) {
+      (*this)[s] = val;
+      return *this;
+    }
+
+    strbitset& set(index_type const& i, bool val = true) {
+      (*this)[i] = val;
+      return *this;
+    }
+
+    //! flip method of one bit
+    strbitset& flip(std::string s) {
+      (*this)[s] = !((*this)[s]);
+      return *this;
+    }
+
+    strbitset& flip(index_type const& i) {
+      (*this)[i] = !((*this)[i]);
+      return *this;
+    }
+
+    //! logical negation
+    strbitset operator~() {
+      strbitset ret(*this);
+      for (bit_vector::iterator ibegin = ret.bits_.begin(), iend = ret.bits_.end(), i = ibegin; i != iend; ++i) {
+        *i = !(*i);
+      }
+      return ret;
+    }
+
+    //! bitwise and
+    strbitset& operator&=(const strbitset& r) {
+      if (map_.size() != r.map_.size()) {
+        std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
+      } else {
+        str_index_map::iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
+        for (; i != iend; ++i) {
+          std::string key = i->first;
+          str_index_map::const_iterator j = r.map_.find(key);
+          if (j == r.map_.end()) {
+            std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
+          } else {
+            (*this)[key] = (*this)[key] && r[key];
+          }
+        }
+      }
+      return *this;
+    }
+
+    //! bitwise or
+    strbitset& operator|=(const strbitset& r) {
+      if (map_.size() != r.map_.size()) {
+        std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
+      } else {
+        str_index_map::iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
+        for (; i != iend; ++i) {
+          std::string key = i->first;
+          str_index_map::const_iterator j = r.map_.find(key);
+          if (j == r.map_.end()) {
+            std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
+          } else {
+            (*this)[key] = (*this)[key] || r[key];
+          }
+        }
+      }
+      return *this;
+    }
+
+    //! bitwise xor
+    strbitset& operator^=(const strbitset& r) {
+      if (map_.size() != r.map_.size()) {
+        std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
+      } else {
+        str_index_map::iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
+        for (; i != iend; ++i) {
+          std::string key = i->first;
+          str_index_map::const_iterator j = r.map_.find(key);
+          if (j == r.map_.end()) {
+            std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
+          } else {
+            (*this)[key] = ((*this)[key] || r[key]) && !((*this)[key] && r[key]);
+          }
+        }
+      }
+      return *this;
+    }
+
+    //! equality operator
+    bool operator==(const strbitset& r) const {
+      if (map_.size() != r.map_.size()) {
+        std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
+      } else {
+        str_index_map::const_iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
+        for (; i != iend; ++i) {
+          std::string key = i->first;
+          str_index_map::const_iterator j = r.map_.find(key);
+          if (j == r.map_.end()) {
+            std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
+          } else {
+            if ((*this)[key] != r[key])
+              return false;
+          }
+        }
+      }
+      return true;
+    }
+
+    //! equality operator to bool
+    bool operator==(bool b) const {
+      bool result = true;
+      for (bit_vector::const_iterator iBegin = bits_.begin(), iEnd = bits_.end(), ibit = iBegin; ibit != iEnd; ++ibit) {
+        result &= (*ibit == b);
+      }
+      return result;
+    }
+
+    //! inequality operator
+    bool operator!=(const strbitset& r) const { return !(operator==(r)); }
+
+    //! inequality operator to bool
+    bool operator!=(bool b) const { return !(operator==(b)); }
+
+    //! returns number of bits set
+    size_t count() const {
+      size_t ret = 0;
+      for (bit_vector::const_iterator ibegin = bits_.begin(), iend = bits_.end(), i = ibegin; i != iend; ++i) {
+        if (*i)
+          ++ret;
+      }
+      return ret;
+    }
+
+    //! returns true if any are set
+    size_t any() const {
+      for (bit_vector::const_iterator ibegin = bits_.begin(), iend = bits_.end(), i = ibegin; i != iend; ++i) {
+        if (*i)
+          return true;
+      }
+      return true;
+    }
+
+    //! returns true if none are set
+    size_t none() const { return !any(); }
+
+    //! test
+    bool test(std::string s) const { return (*this)[s] == true; }
+
+    bool test(index_type const& i) const { return (*this)[i] == true; }
+
+    //! give access to the ordered bits
+    const bit_vector& bits() const { return bits_; }
+
+    //! give access to the ordered strings
+    const std::vector<std::string> strings() const {
+      std::vector<std::string> strings;
+      strings.resize(bits_.size());
+      for (str_index_map::const_iterator it = map_.begin(), end = map_.end(); it != end; ++it) {
+        strings[it->second] = it->first;
+      }
+      return strings;
+    }
+
+    friend strbitset operator&(const strbitset& l, const strbitset& r);
+    friend strbitset operator|(const strbitset& l, const strbitset& r);
+    friend strbitset operator^(const strbitset& l, const strbitset& r);
+
+  private:
+    /// workhorse: this gets the index of "bits" that is pointed to by
+    /// the string "s"
+    size_t index(std::string s) const {
+      str_index_map::const_iterator f = map_.find(s);
+      if (f == map_.end()) {
+        std::cout << "Cannot find " << s << ", returning size()" << std::endl;
+        return map_.size();
+      } else {
+        return f->second;
+      }
+    }
+
+    std::string const& index(size_t i) const {
+      for (str_index_map::const_iterator f = map_.begin(), fEnd = map_.end(); f != fEnd; ++f) {
+        if (f->second == i)
+          return f->first;
+      }
+      std::cout << "Cannot find " << i << ", returning dummy" << std::endl;
+      return dummy_;
+    }
+
+    static const std::string dummy_;
+    str_index_map map_;  //!< map that holds the string-->index map
+    bit_vector bits_;    //!< the actual bits, indexed by the index in "map_"
   };
 
+  strbitset operator&(const strbitset& l, const strbitset& r);
 
-  friend class index_type;
+  strbitset operator|(const strbitset& l, const strbitset& r);
+  strbitset operator^(const strbitset& l, const strbitset& r);
 
-  // Add typedefs
-  typedef unsigned int                    size_t;
-  typedef std::map<std::string, size_t>   str_index_map;
-  typedef std::vector<bool>               bit_vector;
-
-  //! constructor: just clears the bitset and map
- strbitset() {
-    clear();
-  }
-
-  //! clear the bitset and map
-  void clear() {
-    map_.clear();
-    bits_.clear();
-  }
-
-  ///! cast to bool
-  operator bool() const {
-    bool b = true;
-    for ( bit_vector::const_iterator bitsBegin = bits_.begin(),
-	    bitsEnd = bits_.end(), ibit = bitsBegin;
-	  ibit != bitsEnd; ++ibit ) {
-      if ( *ibit == false ) b = false;
-    }
-    return b;
-  }
-
-  ///! Logical negation of bool()
-  bool operator!() const {
-    return ! ( operator bool() );
-  }
-  
-  /// adds an item that is indexed by the string. this
-  /// can then be sorted, cut, whatever, and the
-  /// index mapping is kept
-  void push_back( std::string s ) {
-    if ( map_.find(s) == map_.end() ) {
-      map_[s] = bits_.size();
-      bits_.resize( bits_.size() + 1 );
-      *(bits_.rbegin()) = false;
-    } else {
-      std::cout << "Duplicate entry " << s << ", not added to registry" << std::endl;
-    }
-  }
-
-
-  //! print method
-  void print(std::ostream & out) const {
-    for( str_index_map::const_iterator mbegin = map_.begin(),
-	   mend = map_.end(),
-	   mit = mbegin;
-	 mit != mend; ++mit ) {
-      char buff[100];
-      sprintf(buff, "%10s = %6i", mit->first.c_str(), (int)(bits_.at(mit->second)));
-      out << buff << std::endl;
-    }
-  }
-
-  //! access method const
-  bit_vector::const_reference operator[] ( const std::string s) const {
-    size_t index = this->index(s);
-    return bits_.operator[](index);
-  }
-
-  bit_vector::const_reference operator[] ( index_type const & i) const {
-    return bits_.operator[](i.i_);
-  }
-
-  //! access method non-const
-  bit_vector::reference operator[] ( const std::string s) {
-    size_t index = this->index(s);
-    return bits_.operator[](index);
-  }
-
-  bit_vector::reference operator[] ( index_type const & i ) {
-    return bits_.operator[](i.i_);
-  }
-
-
-  //! set method of all bits
-  strbitset & set( bool val = true) {
-    for ( bit_vector::iterator ibegin = bits_.begin(),
-	    iend = bits_.end(), i = ibegin;
-	  i != iend; ++i ) {
-      *i = val;
-    }
-    return *this;
-  }
-
-  //! flip method of all bits
-  strbitset & flip() {
-    for ( bit_vector::iterator ibegin = bits_.begin(),
-	    iend = bits_.end(), i = ibegin;
-	  i != iend; ++i ) {
-      *i = ! (*i);
-    }
-    return *this;
-  }
-
-  //! set method of one bit
-  strbitset & set( std::string s, bool val = true) {
-    (*this)[s] = val;
-    return *this;
-  }
-
-  strbitset & set( index_type const & i, bool val = true) {
-    (*this)[i] = val;
-    return *this;
-  }
-
-
-  //! flip method of one bit
-  strbitset & flip( std::string s) {
-    (*this)[s] = !( (*this)[s] );
-    return *this;
-  }
-
-  strbitset & flip( index_type const & i ) {
-    (*this)[i] = !( (*this)[i] );
-    return *this;
-  }
-
-  //! logical negation
-  strbitset operator~() {
-    strbitset ret(*this);
-    for ( bit_vector::iterator ibegin = ret.bits_.begin(),
-	    iend = ret.bits_.end(), i = ibegin;
-	  i != iend; ++i ) {
-      *i = !(*i);
-    }
-    return ret;
-  }
-
-  //! bitwise and
-  strbitset & operator&=( const strbitset & r) {
-    if ( map_.size() != r.map_.size() ) { 
-      std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
-    } else {
-      str_index_map::iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
-      for ( ; i != iend; ++i ) {
-	std::string key = i->first;
-	str_index_map::const_iterator j = r.map_.find( key );
-	if ( j == r.map_.end() ) {
-	  std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
-	} else {
-	  (*this)[key] = (*this)[key] && r[key];
-	}
-      }
-    }
-    return *this;
-  }
-
-
-  //! bitwise or
-  strbitset & operator|=( const strbitset & r) {
-    if ( map_.size() != r.map_.size() ) { 
-      std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
-    } else {
-      str_index_map::iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
-      for ( ; i != iend; ++i ) {
-	std::string key = i->first;
-	str_index_map::const_iterator j = r.map_.find( key );
-	if ( j == r.map_.end() ) {
-	  std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
-	} else {
-	  (*this)[key] = (*this)[key] || r[key];
-	}
-      }
-    }
-    return *this;
-  }
-
-
-
-  //! bitwise xor
-  strbitset & operator^=( const strbitset & r) {
-    if ( map_.size() != r.map_.size() ) { 
-      std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
-    } else {
-      str_index_map::iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
-      for ( ; i != iend; ++i ) {
-	std::string key = i->first;
-	str_index_map::const_iterator j = r.map_.find( key );
-	if ( j == r.map_.end() ) {
-	  std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
-	} else {
-	  (*this)[key] = ( (*this)[key] || r[key]) && ! ((*this)[key] && r[key]);
-	}
-      }
-    }
-    return *this;
-  }
-
-
-
-
-
-  //! equality operator
-  bool operator==( const strbitset & r) const {
-    if ( map_.size() != r.map_.size() ) { 
-      std::cout << "strbitset operator&= : bitsets not the same size" << std::endl;
-    } else {
-      str_index_map::const_iterator ibegin = map_.begin(), iend = map_.end(), i = ibegin;
-      for ( ; i != iend; ++i ) {
-	std::string key = i->first;
-	str_index_map::const_iterator j = r.map_.find( key );
-	if ( j == r.map_.end() ) {
-	  std::cout << "strbitset operator&= : cannot find key " << key << std::endl;
-	} else {
-	  if ( (*this)[key] != r[key] ) return false;
-	}
-      }
-    }
-    return true;
-  }
-
-  //! equality operator to bool
-  bool operator==( bool b ) const {
-    bool result = true;
-    for ( bit_vector::const_iterator iBegin = bits_.begin(),
-	    iEnd = bits_.end(), ibit = iBegin;
-	  ibit != iEnd; ++ibit ) {
-      result &= ( *ibit == b );
-    }
-    return result;
-  }
-
-
-  //! inequality operator
-  bool operator!=( const strbitset & r) const {
-    return ! (operator==(r));
-  }
-
-  //! inequality operator to bool
-  bool operator!=( bool b ) const {
-    return ! ( operator==(b));
-  }
-
-  //! returns number of bits set
-  size_t count() const {
-    size_t ret = 0;
-    for ( bit_vector::const_iterator ibegin = bits_.begin(),
-	    iend = bits_.end(), i = ibegin;
-	  i != iend; ++i ) {
-      if ( *i ) ++ret;
-    }    
-    return ret;
-  }
-
-
-
-  //! returns true if any are set
-  size_t any() const {
-    for ( bit_vector::const_iterator ibegin = bits_.begin(),
-	    iend = bits_.end(), i = ibegin;
-	  i != iend; ++i ) {
-      if ( *i ) return true;
-    }
-    return true;
-  }
-
-  //! returns true if none are set
-  size_t none () const {
-    return !any();
-  }
-
-  //! test
-  bool test(std::string s) const {
-    return (*this)[s] == true;
-  }
-
-  bool test(index_type const &i) const {
-    return (*this)[i] == true;
-  }
-
-  //! give access to the ordered bits
-  const bit_vector& bits() const {
-    return bits_;
-  }
-
-
-  //! give access to the ordered strings
-  const std::vector<std::string> strings() const {
-    std::vector<std::string> strings;
-    strings.resize(bits_.size());
-    for (str_index_map::const_iterator it = map_.begin(), 
-         end = map_.end(); it != end; ++it){
-      strings[it->second] = it->first;
-    }
-    return strings;
-  }
-
-
-
-  friend strbitset operator&(const strbitset& l, const strbitset& r);
-  friend strbitset operator|(const strbitset& l, const strbitset& r);
-  friend strbitset operator^(const strbitset& l, const strbitset& r);
-
-
- private:
-
-
-  /// workhorse: this gets the index of "bits" that is pointed to by
-  /// the string "s"
-  size_t  index(std::string s) const {
-    str_index_map::const_iterator f = map_.find(s);
-    if ( f == map_.end() ) {
-      std::cout << "Cannot find " << s << ", returning size()" << std::endl;
-      return map_.size();
-    } else {
-      return f->second;
-    }
-  }
-  
-  std::string const & index( size_t i ) const {
-    for ( str_index_map::const_iterator f = map_.begin(),
-	    fEnd = map_.end();
-	  f != fEnd; ++f ) {
-      if ( f->second == i ) return f->first;
-    }
-    std::cout << "Cannot find " << i << ", returning dummy" << std::endl;
-    return dummy_;
-
-  }
-
-  static const std::string       dummy_;
-  str_index_map     map_;   //!< map that holds the string-->index map 
-  bit_vector        bits_;  //!< the actual bits, indexed by the index in "map_"
-};
-
- strbitset operator&(const strbitset& l, const strbitset& r);
-
- strbitset operator|(const strbitset& l, const strbitset& r);
- strbitset operator^(const strbitset& l, const strbitset& r);
-
-
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/SelectorUtils/plugins/EtaMultiRangeCut.cc
+++ b/PhysicsTools/SelectorUtils/plugins/EtaMultiRangeCut.cc
@@ -2,39 +2,33 @@
 
 class EtaMultiRangeCut : public CutApplicatorBase {
 public:
-  EtaMultiRangeCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _absEta(c.getParameter<bool>("useAbsEta")) {
-    const std::vector<edm::ParameterSet>& ranges =
-      c.getParameterSetVector("allowedEtaRanges");
-    for( const auto& range : ranges ) {
+  EtaMultiRangeCut(const edm::ParameterSet& c) : CutApplicatorBase(c), _absEta(c.getParameter<bool>("useAbsEta")) {
+    const std::vector<edm::ParameterSet>& ranges = c.getParameterSetVector("allowedEtaRanges");
+    for (const auto& range : ranges) {
       const double min = range.getParameter<double>("minEta");
       const double max = range.getParameter<double>("maxEta");
-      _ranges.emplace_back(min,max);
+      _ranges.emplace_back(min, max);
     }
   }
-  
-  double value(const reco::CandidatePtr& cand) const final { 
-    return ( _absEta ? std::abs(cand->eta()) : cand->eta() );
-  }
+
+  double value(const reco::CandidatePtr& cand) const final { return (_absEta ? std::abs(cand->eta()) : cand->eta()); }
 
   result_type asCandidate(const argument_type&) const final;
 
 private:
   const bool _absEta;
-  std::vector<std::pair<double,double> > _ranges; 
+  std::vector<std::pair<double, double> > _ranges;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,EtaMultiRangeCut,"EtaMultiRangeCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, EtaMultiRangeCut, "EtaMultiRangeCut");
 
-CutApplicatorBase::result_type 
-EtaMultiRangeCut::
-asCandidate(const argument_type& cand) const {
-  const double the_eta = ( _absEta ? std::abs(cand->eta()) : cand->eta() );
+CutApplicatorBase::result_type EtaMultiRangeCut::asCandidate(const argument_type& cand) const {
+  const double the_eta = (_absEta ? std::abs(cand->eta()) : cand->eta());
   bool result = false;
-  for(const auto& range : _ranges ) {
-    if( the_eta >= range.first && the_eta < range.second ) {
-      result = true; break;
+  for (const auto& range : _ranges) {
+    if (the_eta >= range.first && the_eta < range.second) {
+      result = true;
+      break;
     }
   }
   return result;

--- a/PhysicsTools/SelectorUtils/plugins/ExpressionEvaluatorCut.cc
+++ b/PhysicsTools/SelectorUtils/plugins/ExpressionEvaluatorCut.cc
@@ -7,14 +7,10 @@ class ExpressionEvaluatorCut : public CutApplicatorBase {
 public:
   ExpressionEvaluatorCut(const edm::ParameterSet& c);
   ~ExpressionEvaluatorCut() override{};
-  
-  result_type asCandidate(const argument_type& cand) const final {
-    return (*cut_)(cand);
-  }
 
-  double value(const reco::CandidatePtr& cand) const final {
-    return cut_->value(cand);
-  }
+  result_type asCandidate(const argument_type& cand) const final { return (*cut_)(cand); }
+
+  double value(const reco::CandidatePtr& cand) const final { return cut_->value(cand); }
 
   const std::string& name() const final { return realname_; }
 
@@ -23,35 +19,26 @@ private:
   CutApplicatorBase* cut_;
 };
 
-ExpressionEvaluatorCut::
-ExpressionEvaluatorCut(const edm::ParameterSet& c) : 
-  CutApplicatorBase(c),
-  realname_(c.getParameter<std::string>("realCutName"))
-{
+ExpressionEvaluatorCut::ExpressionEvaluatorCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c), realname_(c.getParameter<std::string>("realCutName")) {
   const std::string newline("\n");
   const std::string close_function("; };");
   const std::string candTypePreamble("CandidateType candidateType() const override final { return ");
-  
+
   //construct the overload of candidateType()
   const std::string& candType = c.getParameter<std::string>("candidateType");
   const std::string candTypeExpr = candTypePreamble + candType + close_function;
-  
+
   // read in the overload of operator()
   const std::string& oprExpr = c.getParameter<std::string>("functionDef");
-  
+
   // read in the overload of value()
   const std::string& valExpr = c.getParameter<std::string>("valueDef");
 
   // concatenate and evaluate the expression
-  const std::string total_expr = ( candTypeExpr + newline + 
-                                   oprExpr      + newline +
-                                   valExpr                  );
-  reco::ExpressionEvaluator eval("PhysicsTools/SelectorUtils",
-                                 "CutApplicatorBase",
-                                 total_expr);
+  const std::string total_expr = (candTypeExpr + newline + oprExpr + newline + valExpr);
+  reco::ExpressionEvaluator eval("PhysicsTools/SelectorUtils", "CutApplicatorBase", total_expr);
   cut_ = eval.expr<CutApplicatorBase>();
 }
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  ExpressionEvaluatorCut,
-                  "ExpressionEvaluatorCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, ExpressionEvaluatorCut, "ExpressionEvaluatorCut");

--- a/PhysicsTools/SelectorUtils/plugins/ExpressionEvaluatorCutWithEventContent.cc
+++ b/PhysicsTools/SelectorUtils/plugins/ExpressionEvaluatorCutWithEventContent.cc
@@ -6,23 +6,15 @@
 class ExpressionEvaluatorCutWithEventContent : public CutApplicatorWithEventContentBase {
 public:
   ExpressionEvaluatorCutWithEventContent(const edm::ParameterSet& c);
-  ~ExpressionEvaluatorCutWithEventContent() override {};
+  ~ExpressionEvaluatorCutWithEventContent() override{};
 
-  result_type asCandidate(const argument_type& cand) const final {
-    return (*cut_)(cand);
-  }
+  result_type asCandidate(const argument_type& cand) const final { return (*cut_)(cand); }
 
-  void setConsumes(edm::ConsumesCollector& sumes) final { 
-    cut_->setConsumes(sumes);
-  }
+  void setConsumes(edm::ConsumesCollector& sumes) final { cut_->setConsumes(sumes); }
 
-  void getEventContent(const edm::EventBase& event) final { 
-    cut_->getEventContent(event);
-  }
+  void getEventContent(const edm::EventBase& event) final { cut_->getEventContent(event); }
 
-  double value(const reco::CandidatePtr& cand) const final {
-    return cut_->value(cand);
-  }
+  double value(const reco::CandidatePtr& cand) const final { return cut_->value(cand); }
 
   const std::string& name() const final { return realname_; }
 
@@ -31,47 +23,34 @@ private:
   CutApplicatorWithEventContentBase* cut_;
 };
 
-ExpressionEvaluatorCutWithEventContent::
-ExpressionEvaluatorCutWithEventContent(const edm::ParameterSet& c) : 
-  CutApplicatorWithEventContentBase(c),
-  realname_(c.getParameter<std::string>("realCutName")) 
-{ 
+ExpressionEvaluatorCutWithEventContent::ExpressionEvaluatorCutWithEventContent(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c), realname_(c.getParameter<std::string>("realCutName")) {
   const std::string newline("\n");
   const std::string close_function("; };");
   const std::string candTypePreamble("CandidateType candidateType() const override final { return ");
-  
+
   //construct the overload of candidateType()
   const std::string& candType = c.getParameter<std::string>("candidateType");
   const std::string candTypeExpr = candTypePreamble + candType + close_function;
-  
+
   // read in the overload of operator()
   const std::string& oprExpr = c.getParameter<std::string>("functionDef");
-  
+
   // read in the overload of value()
   const std::string& valExpr = c.getParameter<std::string>("valueDef");
 
   // read in the overload of setConsumes()
-  const std::string& setConsumesExpr = 
-    c.getParameter<std::string>("setConsumesDef");
+  const std::string& setConsumesExpr = c.getParameter<std::string>("setConsumesDef");
 
   // read in the overload of getEventContent()
-  const std::string& getEventContentExpr = 
-    c.getParameter<std::string>("getEventContentDef");
-  
+  const std::string& getEventContentExpr = c.getParameter<std::string>("getEventContentDef");
 
   // concatenate and evaluate the expression
-  const std::string total_expr = ( candTypeExpr        + newline + 
-                                   oprExpr             + newline +
-                                   valExpr             + newline +
-                                   setConsumesExpr     + newline +
-                                   getEventContentExpr             );
-  reco::ExpressionEvaluator eval("PhysicsTools/SelectorUtils",
-                                 "CutApplicatorWithEventContentBase",
-                                 total_expr);
+  const std::string total_expr = (candTypeExpr + newline + oprExpr + newline + valExpr + newline + setConsumesExpr +
+                                  newline + getEventContentExpr);
+  reco::ExpressionEvaluator eval("PhysicsTools/SelectorUtils", "CutApplicatorWithEventContentBase", total_expr);
   cut_ = eval.expr<CutApplicatorWithEventContentBase>();
-
 }
-
 
 DEFINE_EDM_PLUGIN(CutApplicatorFactory,
                   ExpressionEvaluatorCutWithEventContent,

--- a/PhysicsTools/SelectorUtils/plugins/MaxAbsEtaCut.cc
+++ b/PhysicsTools/SelectorUtils/plugins/MaxAbsEtaCut.cc
@@ -2,21 +2,14 @@
 
 class MaxAbsEtaCut : public CutApplicatorBase {
 public:
-  MaxAbsEtaCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _maxEta(c.getParameter<double>("maxEta")) { }
-  
-  double value(const reco::CandidatePtr& cand) const final {
-    return std::abs(cand->eta());
-  }
+  MaxAbsEtaCut(const edm::ParameterSet& c) : CutApplicatorBase(c), _maxEta(c.getParameter<double>("maxEta")) {}
 
-  result_type asCandidate(const argument_type& cand) const final {
-    return std::abs(cand->eta()) < _maxEta;
-  }
+  double value(const reco::CandidatePtr& cand) const final { return std::abs(cand->eta()); }
+
+  result_type asCandidate(const argument_type& cand) const final { return std::abs(cand->eta()) < _maxEta; }
 
 private:
   const double _maxEta;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,MaxAbsEtaCut,"MaxAbsEtaCut");
-
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MaxAbsEtaCut, "MaxAbsEtaCut");

--- a/PhysicsTools/SelectorUtils/plugins/MinPtCut.cc
+++ b/PhysicsTools/SelectorUtils/plugins/MinPtCut.cc
@@ -2,21 +2,14 @@
 
 class MinPtCut : public CutApplicatorBase {
 public:
-  MinPtCut(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _minPt(c.getParameter<double>("minPt")) { }
-  
-  double value(const reco::CandidatePtr& cand) const final {
-    return cand->pt();
-  }
+  MinPtCut(const edm::ParameterSet& c) : CutApplicatorBase(c), _minPt(c.getParameter<double>("minPt")) {}
 
-  result_type asCandidate(const argument_type& cand) const final {
-    return cand->pt() > _minPt;
-  }
+  double value(const reco::CandidatePtr& cand) const final { return cand->pt(); }
+
+  result_type asCandidate(const argument_type& cand) const final { return cand->pt() > _minPt; }
 
 private:
   const double _minPt;
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,MinPtCut,"MinPtCut");
-
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MinPtCut, "MinPtCut");

--- a/PhysicsTools/SelectorUtils/plugins/MinPtCutInEtaRanges.cc
+++ b/PhysicsTools/SelectorUtils/plugins/MinPtCutInEtaRanges.cc
@@ -2,45 +2,37 @@
 
 class MinPtCutInEtaRanges : public CutApplicatorBase {
 public:
-  MinPtCutInEtaRanges(const edm::ParameterSet& c) :
-    CutApplicatorBase(c),
-    _absEta(c.getParameter<bool>("useAbsEta")) {
-    const std::vector<edm::ParameterSet>& ranges =
-      c.getParameterSetVector("allowedEtaRanges");
-    for( const auto& range : ranges ) {
+  MinPtCutInEtaRanges(const edm::ParameterSet& c) : CutApplicatorBase(c), _absEta(c.getParameter<bool>("useAbsEta")) {
+    const std::vector<edm::ParameterSet>& ranges = c.getParameterSetVector("allowedEtaRanges");
+    for (const auto& range : ranges) {
       const double minEta = range.getParameter<double>("minEta");
       const double maxEta = range.getParameter<double>("maxEta");
       const double minPt = range.getParameter<double>("minPt");
-      _ranges.emplace_back(minEta,maxEta);
+      _ranges.emplace_back(minEta, maxEta);
       _minPt.push_back(minPt);
     }
   }
 
-  double value(const reco::CandidatePtr& cand) const final {
-    return cand->pt();
-  }
+  double value(const reco::CandidatePtr& cand) const final { return cand->pt(); }
 
   result_type asCandidate(const argument_type&) const final;
 
 private:
   const bool _absEta;
-  std::vector<std::pair<double,double> > _ranges; 
-  std::vector<double> _minPt; // indexed as above
+  std::vector<std::pair<double, double> > _ranges;
+  std::vector<double> _minPt;  // indexed as above
 };
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,MinPtCutInEtaRanges,
-		  "MinPtCutInEtaRanges");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MinPtCutInEtaRanges, "MinPtCutInEtaRanges");
 
-CutApplicatorBase::result_type 
-MinPtCutInEtaRanges::
-asCandidate(const argument_type& cand) const{
-  const double the_eta = ( _absEta ? std::abs(cand->eta()) : cand->eta() );
+CutApplicatorBase::result_type MinPtCutInEtaRanges::asCandidate(const argument_type& cand) const {
+  const double the_eta = (_absEta ? std::abs(cand->eta()) : cand->eta());
   bool result = false;
-  for( unsigned i = 0; i < _ranges.size(); ++i ) {
+  for (unsigned i = 0; i < _ranges.size(); ++i) {
     const auto& range = _ranges[i];
-    if( the_eta >= range.first && the_eta < range.second && 
-	cand->pt() > _minPt[i] ) {
-      result = true; break;
+    if (the_eta >= range.first && the_eta < range.second && cand->pt() > _minPt[i]) {
+      result = true;
+      break;
     }
   }
   return result;

--- a/PhysicsTools/SelectorUtils/src/CutApplicatorBase.cc
+++ b/PhysicsTools/SelectorUtils/src/CutApplicatorBase.cc
@@ -1,71 +1,50 @@
 #include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
 
-EDM_REGISTER_PLUGINFACTORY(CutApplicatorFactory,"CutApplicatorFactory");
+EDM_REGISTER_PLUGINFACTORY(CutApplicatorFactory, "CutApplicatorFactory");
 
-CutApplicatorBase::result_type 
-CutApplicatorBase::
-operator()(const CutApplicatorBase::argument_type& arg) const {
-  if( arg.isNull() ) { 
-    throw cms::Exception("BadProductPtr")
-      << _name << "received a bad product ref to process!" << std::endl;
+CutApplicatorBase::result_type CutApplicatorBase::operator()(const CutApplicatorBase::argument_type& arg) const {
+  if (arg.isNull()) {
+    throw cms::Exception("BadProductPtr") << _name << "received a bad product ref to process!" << std::endl;
   }
-  
-  switch(candidateType()) {
-  case ELECTRON:
-    {      
+
+  switch (candidateType()) {
+    case ELECTRON: {
       const reco::GsfElectronPtr ele(arg);
       return this->operator()(ele);
-    }
-    break;
-  case MUON:
-    {
+    } break;
+    case MUON: {
       const reco::MuonPtr mu(arg);
       return this->operator()(mu);
-    }
-    break;
-  case PHOTON:
-    {
+    } break;
+    case PHOTON: {
       const reco::PhotonPtr pho(arg);
       return this->operator()(pho);
-    }
-    break;
-  case TAU:
-    {
+    } break;
+    case TAU: {
       const reco::PFTauPtr tau(arg);
       return this->operator()(tau);
-    }
-    break;
-  case PATELECTRON:
-    {
+    } break;
+    case PATELECTRON: {
       const pat::ElectronPtr ele(arg);
       return this->operator()(ele);
-    }
-    break;
-  case PATMUON:
-    {
+    } break;
+    case PATMUON: {
       const pat::MuonPtr mu(arg);
       return this->operator()(mu);
-    }
-    break;
-  case PATPHOTON:
-    {
+    } break;
+    case PATPHOTON: {
       const pat::PhotonPtr pho(arg);
       return this->operator()(pho);
-    }
-    break;
-  case PATTAU:
-    {
+    } break;
+    case PATTAU: {
       const pat::TauPtr tau(arg);
       return this->operator()(tau);
-    }
-    break;
-  case NONE:
-    {
+    } break;
+    case NONE: {
       return asCandidate(arg);
       break;
     }
-  default:
-    throw cms::Exception("BadCandidateType")
-      << "Unknown candidate type";
+    default:
+      throw cms::Exception("BadCandidateType") << "Unknown candidate type";
   }
 }

--- a/PhysicsTools/SelectorUtils/src/EventSelector.cc
+++ b/PhysicsTools/SelectorUtils/src/EventSelector.cc
@@ -1,2 +1,1 @@
 #include "PhysicsTools/SelectorUtils/interface/EventSelector.h"
-

--- a/PhysicsTools/SelectorUtils/src/PFMuonSelector.cc
+++ b/PhysicsTools/SelectorUtils/src/PFMuonSelector.cc
@@ -1,2 +1,1 @@
 #include "PhysicsTools/SelectorUtils/interface/PFMuonSelector.h"
-

--- a/PhysicsTools/SelectorUtils/src/WPlusJetsEventSelector.cc
+++ b/PhysicsTools/SelectorUtils/src/WPlusJetsEventSelector.cc
@@ -6,105 +6,99 @@
 
 using namespace std;
 
-WPlusJetsEventSelector::WPlusJetsEventSelector( edm::ParameterSet const & params ) :
-  EventSelector(),
-  muonTag_         (params.getParameter<edm::InputTag>("muonSrc") ),
-  electronTag_     (params.getParameter<edm::InputTag>("electronSrc") ),
-  jetTag_          (params.getParameter<edm::InputTag>("jetSrc") ),
-  metTag_          (params.getParameter<edm::InputTag>("metSrc") ),
-  trigTag_         (params.getParameter<edm::InputTag>("trigSrc") ),
-  muTrig_          (params.getParameter<std::string>("muTrig")),
-  eleTrig_         (params.getParameter<std::string>("eleTrig")),
-  pvSelector_      (params.getParameter<edm::ParameterSet>("pvSelector") ),
-  muonIdTight_     (params.getParameter<edm::ParameterSet>("muonIdTight") ),
-  electronIdTight_ (params.getParameter<edm::ParameterSet>("electronIdTight") ),
-  muonIdLoose_     (params.getParameter<edm::ParameterSet>("muonIdLoose") ),
-  electronIdLoose_ (params.getParameter<edm::ParameterSet>("electronIdLoose") ),
-  jetIdLoose_      (params.getParameter<edm::ParameterSet>("jetIdLoose") ),
-  pfjetIdLoose_    (params.getParameter<edm::ParameterSet>("pfjetIdLoose") ),
-  minJets_         (params.getParameter<int> ("minJets") ),
-  muJetDR_         (params.getParameter<double>("muJetDR")),
-  eleJetDR_        (params.getParameter<double>("eleJetDR")),
-  muPlusJets_      (params.getParameter<bool>("muPlusJets") ),
-  ePlusJets_       (params.getParameter<bool>("ePlusJets") ),
-  muPtMin_         (params.getParameter<double>("muPtMin")),
-  muEtaMax_        (params.getParameter<double>("muEtaMax")),
-  eleEtMin_        (params.getParameter<double>("eleEtMin")),
-  eleEtaMax_       (params.getParameter<double>("eleEtaMax")),
-  muPtMinLoose_    (params.getParameter<double>("muPtMinLoose")),
-  muEtaMaxLoose_   (params.getParameter<double>("muEtaMaxLoose")),
-  eleEtMinLoose_   (params.getParameter<double>("eleEtMinLoose")),
-  eleEtaMaxLoose_  (params.getParameter<double>("eleEtaMaxLoose")),
-  jetPtMin_        (params.getParameter<double>("jetPtMin")),
-  jetEtaMax_       (params.getParameter<double>("jetEtaMax")),
-  jetScale_        (params.getParameter<double>("jetScale")),
-  metMin_          (params.getParameter<double>("metMin"))
-{
+WPlusJetsEventSelector::WPlusJetsEventSelector(edm::ParameterSet const& params)
+    : EventSelector(),
+      muonTag_(params.getParameter<edm::InputTag>("muonSrc")),
+      electronTag_(params.getParameter<edm::InputTag>("electronSrc")),
+      jetTag_(params.getParameter<edm::InputTag>("jetSrc")),
+      metTag_(params.getParameter<edm::InputTag>("metSrc")),
+      trigTag_(params.getParameter<edm::InputTag>("trigSrc")),
+      muTrig_(params.getParameter<std::string>("muTrig")),
+      eleTrig_(params.getParameter<std::string>("eleTrig")),
+      pvSelector_(params.getParameter<edm::ParameterSet>("pvSelector")),
+      muonIdTight_(params.getParameter<edm::ParameterSet>("muonIdTight")),
+      electronIdTight_(params.getParameter<edm::ParameterSet>("electronIdTight")),
+      muonIdLoose_(params.getParameter<edm::ParameterSet>("muonIdLoose")),
+      electronIdLoose_(params.getParameter<edm::ParameterSet>("electronIdLoose")),
+      jetIdLoose_(params.getParameter<edm::ParameterSet>("jetIdLoose")),
+      pfjetIdLoose_(params.getParameter<edm::ParameterSet>("pfjetIdLoose")),
+      minJets_(params.getParameter<int>("minJets")),
+      muJetDR_(params.getParameter<double>("muJetDR")),
+      eleJetDR_(params.getParameter<double>("eleJetDR")),
+      muPlusJets_(params.getParameter<bool>("muPlusJets")),
+      ePlusJets_(params.getParameter<bool>("ePlusJets")),
+      muPtMin_(params.getParameter<double>("muPtMin")),
+      muEtaMax_(params.getParameter<double>("muEtaMax")),
+      eleEtMin_(params.getParameter<double>("eleEtMin")),
+      eleEtaMax_(params.getParameter<double>("eleEtaMax")),
+      muPtMinLoose_(params.getParameter<double>("muPtMinLoose")),
+      muEtaMaxLoose_(params.getParameter<double>("muEtaMaxLoose")),
+      eleEtMinLoose_(params.getParameter<double>("eleEtMinLoose")),
+      eleEtaMaxLoose_(params.getParameter<double>("eleEtaMaxLoose")),
+      jetPtMin_(params.getParameter<double>("jetPtMin")),
+      jetEtaMax_(params.getParameter<double>("jetEtaMax")),
+      jetScale_(params.getParameter<double>("jetScale")),
+      metMin_(params.getParameter<double>("metMin")) {
   // make the bitset
-  push_back( "Inclusive"      );
-  push_back( "Trigger"        );
-  push_back( "PV"             );
-  push_back( ">= 1 Lepton"    );
-  push_back( "== 1 Tight Lepton"    );
-  push_back( "== 1 Tight Lepton, Mu Veto");
-  push_back( "== 1 Lepton"    );
-  push_back( "MET Cut"        );
-  push_back( "Z Veto"         );
-  push_back( "Conversion Veto");
-  push_back( "Cosmic Veto"    );
-  push_back( ">=1 Jets"       );
-  push_back( ">=2 Jets"       );
-  push_back( ">=3 Jets"       );
-  push_back( ">=4 Jets"       );
-  push_back( ">=5 Jets"       );
-
+  push_back("Inclusive");
+  push_back("Trigger");
+  push_back("PV");
+  push_back(">= 1 Lepton");
+  push_back("== 1 Tight Lepton");
+  push_back("== 1 Tight Lepton, Mu Veto");
+  push_back("== 1 Lepton");
+  push_back("MET Cut");
+  push_back("Z Veto");
+  push_back("Conversion Veto");
+  push_back("Cosmic Veto");
+  push_back(">=1 Jets");
+  push_back(">=2 Jets");
+  push_back(">=3 Jets");
+  push_back(">=4 Jets");
+  push_back(">=5 Jets");
 
   // turn (almost) everything on by default
-  set( "Inclusive"      );
-  set( "Trigger"        );
-  set( "PV"             );
-  set( ">= 1 Lepton"    );
-  set( "== 1 Tight Lepton"    );
-  set( "== 1 Tight Lepton, Mu Veto");
-  set( "== 1 Lepton"    );
-  set( "MET Cut"        );
-  set( "Z Veto"         );
-  set( "Conversion Veto");
-  set( "Cosmic Veto"    );
-  set( ">=1 Jets", minJets_ >= 1);
-  set( ">=2 Jets", minJets_ >= 2);
-  set( ">=3 Jets", minJets_ >= 3);
-  set( ">=4 Jets", minJets_ >= 4);
-  set( ">=5 Jets", minJets_ >= 5);
+  set("Inclusive");
+  set("Trigger");
+  set("PV");
+  set(">= 1 Lepton");
+  set("== 1 Tight Lepton");
+  set("== 1 Tight Lepton, Mu Veto");
+  set("== 1 Lepton");
+  set("MET Cut");
+  set("Z Veto");
+  set("Conversion Veto");
+  set("Cosmic Veto");
+  set(">=1 Jets", minJets_ >= 1);
+  set(">=2 Jets", minJets_ >= 2);
+  set(">=3 Jets", minJets_ >= 3);
+  set(">=4 Jets", minJets_ >= 4);
+  set(">=5 Jets", minJets_ >= 5);
 
-
-  inclusiveIndex_ = index_type(&bits_, std::string("Inclusive"      ));
-  triggerIndex_ = index_type(&bits_, std::string("Trigger"        ));
-  pvIndex_ = index_type(&bits_, std::string("PV"             ));
-  lep1Index_ = index_type(&bits_, std::string(">= 1 Lepton"    ));
-  lep2Index_ = index_type(&bits_, std::string("== 1 Tight Lepton"    ));
+  inclusiveIndex_ = index_type(&bits_, std::string("Inclusive"));
+  triggerIndex_ = index_type(&bits_, std::string("Trigger"));
+  pvIndex_ = index_type(&bits_, std::string("PV"));
+  lep1Index_ = index_type(&bits_, std::string(">= 1 Lepton"));
+  lep2Index_ = index_type(&bits_, std::string("== 1 Tight Lepton"));
   lep3Index_ = index_type(&bits_, std::string("== 1 Tight Lepton, Mu Veto"));
-  lep4Index_ = index_type(&bits_, std::string("== 1 Lepton"    ));
-  metIndex_ = index_type(&bits_, std::string("MET Cut"        ));
-  zvetoIndex_ = index_type(&bits_, std::string("Z Veto"         ));
+  lep4Index_ = index_type(&bits_, std::string("== 1 Lepton"));
+  metIndex_ = index_type(&bits_, std::string("MET Cut"));
+  zvetoIndex_ = index_type(&bits_, std::string("Z Veto"));
   conversionIndex_ = index_type(&bits_, std::string("Conversion Veto"));
-  cosmicIndex_ = index_type(&bits_, std::string("Cosmic Veto"    ));
+  cosmicIndex_ = index_type(&bits_, std::string("Cosmic Veto"));
   jet1Index_ = index_type(&bits_, std::string(">=1 Jets"));
   jet2Index_ = index_type(&bits_, std::string(">=2 Jets"));
   jet3Index_ = index_type(&bits_, std::string(">=3 Jets"));
   jet4Index_ = index_type(&bits_, std::string(">=4 Jets"));
   jet5Index_ = index_type(&bits_, std::string(">=5 Jets"));
 
-  if ( params.exists("cutsToIgnore") )
-    setIgnoredCuts( params.getParameter<std::vector<std::string> >("cutsToIgnore") );
-
+  if (params.exists("cutsToIgnore"))
+    setIgnoredCuts(params.getParameter<std::vector<std::string> >("cutsToIgnore"));
 
   retInternal_ = getBitTemplate();
 }
 
-bool WPlusJetsEventSelector::operator() ( edm::EventBase const & event, pat::strbitset & ret)
-{
-
+bool WPlusJetsEventSelector::operator()(edm::EventBase const& event, pat::strbitset& ret) {
   ret.set(false);
 
   selectedJets_.clear();
@@ -115,272 +109,234 @@ bool WPlusJetsEventSelector::operator() ( edm::EventBase const & event, pat::str
   looseElectrons_.clear();
   selectedMETs_.clear();
 
-
-  passCut( ret, inclusiveIndex_);
-
+  passCut(ret, inclusiveIndex_);
 
   bool passTrig = false;
-  if (!ignoreCut(triggerIndex_) ) {
-
-
+  if (!ignoreCut(triggerIndex_)) {
     edm::Handle<pat::TriggerEvent> triggerEvent;
     event.getByLabel(trigTag_, triggerEvent);
 
-    pat::TriggerEvent const * trig = &*triggerEvent;
+    pat::TriggerEvent const* trig = &*triggerEvent;
 
-    if ( trig->wasRun() && trig->wasAccept() ) {
+    if (trig->wasRun() && trig->wasAccept()) {
+      pat::TriggerPath const* muPath = trig->path(muTrig_);
 
-      pat::TriggerPath const * muPath = trig->path(muTrig_);
+      pat::TriggerPath const* elePath = trig->path(eleTrig_);
 
-      pat::TriggerPath const * elePath = trig->path(eleTrig_);
-
-      if ( muPlusJets_ && muPath != nullptr && muPath->wasAccept() ) {
-	passTrig = true;
+      if (muPlusJets_ && muPath != nullptr && muPath->wasAccept()) {
+        passTrig = true;
       }
 
-      if ( ePlusJets_ && elePath != nullptr && elePath->wasAccept() ) {
-	passTrig = true;
+      if (ePlusJets_ && elePath != nullptr && elePath->wasAccept()) {
+        passTrig = true;
       }
     }
   }
 
-
-
-
-  if ( ignoreCut(triggerIndex_) ||
-       passTrig ) {
+  if (ignoreCut(triggerIndex_) || passTrig) {
     passCut(ret, triggerIndex_);
-
 
     bool passPV = false;
 
-    passPV = pvSelector_( event );
-    if ( ignoreCut(pvIndex_) || passPV ) {
+    passPV = pvSelector_(event);
+    if (ignoreCut(pvIndex_) || passPV) {
       passCut(ret, pvIndex_);
 
-      edm::Handle< vector< pat::Electron > > electronHandle;
-      event.getByLabel (electronTag_, electronHandle);
+      edm::Handle<vector<pat::Electron> > electronHandle;
+      event.getByLabel(electronTag_, electronHandle);
 
-      edm::Handle< vector< pat::Muon > > muonHandle;
-      event.getByLabel (muonTag_, muonHandle);
+      edm::Handle<vector<pat::Muon> > muonHandle;
+      event.getByLabel(muonTag_, muonHandle);
 
-      edm::Handle< vector< pat::Jet > > jetHandle;
+      edm::Handle<vector<pat::Jet> > jetHandle;
 
-      edm::Handle< edm::OwnVector<reco::Candidate> > jetClonesHandle ;
+      edm::Handle<edm::OwnVector<reco::Candidate> > jetClonesHandle;
 
-      edm::Handle< vector< pat::MET > > metHandle;
-      event.getByLabel (metTag_, metHandle);
+      edm::Handle<vector<pat::MET> > metHandle;
+      event.getByLabel(metTag_, metHandle);
 
       int nElectrons = 0;
-      for ( std::vector<pat::Electron>::const_iterator electronBegin = electronHandle->begin(),
-	      electronEnd = electronHandle->end(), ielectron = electronBegin;
-	    ielectron != electronEnd; ++ielectron ) {
-	++nElectrons;
-	// Tight cuts
-	if ( ielectron->et() > eleEtMin_ && fabs(ielectron->eta()) < eleEtaMax_ &&
-	     electronIdTight_(*ielectron) &&
-	     ielectron->electronID( "eidRobustTight" ) > 0  ) {
-	  selectedElectrons_.push_back( reco::ShallowClonePtrCandidate( edm::Ptr<pat::Electron>( electronHandle, ielectron - electronBegin ) ) );
-	} else {
-	  // Loose cuts
-	  if ( ielectron->et() > eleEtMinLoose_ && fabs(ielectron->eta()) < eleEtaMaxLoose_ &&
-	       electronIdLoose_(*ielectron) ) {
-	    looseElectrons_.push_back( reco::ShallowClonePtrCandidate( edm::Ptr<pat::Electron>( electronHandle, ielectron - electronBegin ) ) );
-	  }
-	}
+      for (std::vector<pat::Electron>::const_iterator electronBegin = electronHandle->begin(),
+                                                      electronEnd = electronHandle->end(),
+                                                      ielectron = electronBegin;
+           ielectron != electronEnd;
+           ++ielectron) {
+        ++nElectrons;
+        // Tight cuts
+        if (ielectron->et() > eleEtMin_ && fabs(ielectron->eta()) < eleEtaMax_ && electronIdTight_(*ielectron) &&
+            ielectron->electronID("eidRobustTight") > 0) {
+          selectedElectrons_.push_back(
+              reco::ShallowClonePtrCandidate(edm::Ptr<pat::Electron>(electronHandle, ielectron - electronBegin)));
+        } else {
+          // Loose cuts
+          if (ielectron->et() > eleEtMinLoose_ && fabs(ielectron->eta()) < eleEtaMaxLoose_ &&
+              electronIdLoose_(*ielectron)) {
+            looseElectrons_.push_back(
+                reco::ShallowClonePtrCandidate(edm::Ptr<pat::Electron>(electronHandle, ielectron - electronBegin)));
+          }
+        }
       }
 
+      for (std::vector<pat::Muon>::const_iterator muonBegin = muonHandle->begin(),
+                                                  muonEnd = muonHandle->end(),
+                                                  imuon = muonBegin;
+           imuon != muonEnd;
+           ++imuon) {
+        if (!imuon->isGlobalMuon())
+          continue;
 
-      for ( std::vector<pat::Muon>::const_iterator muonBegin = muonHandle->begin(),
-	      muonEnd = muonHandle->end(), imuon = muonBegin;
-	    imuon != muonEnd; ++imuon ) {
-	if ( !imuon->isGlobalMuon() ) continue;
-
-	// Tight cuts
-	bool passTight = muonIdTight_(*imuon,event) && imuon->isTrackerMuon() ;
-	if (  imuon->pt() > muPtMin_ && fabs(imuon->eta()) < muEtaMax_ &&
-	     passTight ) {
-
-	  selectedMuons_.push_back( reco::ShallowClonePtrCandidate( edm::Ptr<pat::Muon>( muonHandle, imuon - muonBegin ) ) );
-	} else {
-	  // Loose cuts
-	  if ( imuon->pt() > muPtMinLoose_ && fabs(imuon->eta()) < muEtaMaxLoose_ &&
-	       muonIdLoose_(*imuon,event) ) {
-	    looseMuons_.push_back( reco::ShallowClonePtrCandidate( edm::Ptr<pat::Muon>( muonHandle, imuon - muonBegin ) ) );
-	  }
-	}
+        // Tight cuts
+        bool passTight = muonIdTight_(*imuon, event) && imuon->isTrackerMuon();
+        if (imuon->pt() > muPtMin_ && fabs(imuon->eta()) < muEtaMax_ && passTight) {
+          selectedMuons_.push_back(reco::ShallowClonePtrCandidate(edm::Ptr<pat::Muon>(muonHandle, imuon - muonBegin)));
+        } else {
+          // Loose cuts
+          if (imuon->pt() > muPtMinLoose_ && fabs(imuon->eta()) < muEtaMaxLoose_ && muonIdLoose_(*imuon, event)) {
+            looseMuons_.push_back(reco::ShallowClonePtrCandidate(edm::Ptr<pat::Muon>(muonHandle, imuon - muonBegin)));
+          }
+        }
       }
 
+      met_ = reco::ShallowClonePtrCandidate(
+          edm::Ptr<pat::MET>(metHandle, 0), metHandle->at(0).charge(), metHandle->at(0).p4());
 
-      met_ = reco::ShallowClonePtrCandidate( edm::Ptr<pat::MET>( metHandle, 0),
-					     metHandle->at(0).charge(),
-					     metHandle->at(0).p4() );
-
-
-
-      event.getByLabel (jetTag_, jetHandle);
+      event.getByLabel(jetTag_, jetHandle);
       pat::strbitset ret1 = jetIdLoose_.getBitTemplate();
       pat::strbitset ret2 = pfjetIdLoose_.getBitTemplate();
-      for ( std::vector<pat::Jet>::const_iterator jetBegin = jetHandle->begin(),
-	      jetEnd = jetHandle->end(), ijet = jetBegin;
-	    ijet != jetEnd; ++ijet ) {
-	reco::ShallowClonePtrCandidate scaledJet ( reco::ShallowClonePtrCandidate( edm::Ptr<pat::Jet>( jetHandle, ijet - jetBegin ),
-										   ijet->charge(),
-										   ijet->p4() * jetScale_ ) );
-	bool passJetID = false;
-	if ( ijet->isCaloJet() || ijet->isJPTJet() ) passJetID = jetIdLoose_(*ijet, ret1);
-	else passJetID = pfjetIdLoose_(*ijet, ret2);
-	if ( scaledJet.pt() > jetPtMin_ && fabs(scaledJet.eta()) < jetEtaMax_ && passJetID ) {
-	  selectedJets_.push_back( scaledJet );
+      for (std::vector<pat::Jet>::const_iterator jetBegin = jetHandle->begin(),
+                                                 jetEnd = jetHandle->end(),
+                                                 ijet = jetBegin;
+           ijet != jetEnd;
+           ++ijet) {
+        reco::ShallowClonePtrCandidate scaledJet(reco::ShallowClonePtrCandidate(
+            edm::Ptr<pat::Jet>(jetHandle, ijet - jetBegin), ijet->charge(), ijet->p4() * jetScale_));
+        bool passJetID = false;
+        if (ijet->isCaloJet() || ijet->isJPTJet())
+          passJetID = jetIdLoose_(*ijet, ret1);
+        else
+          passJetID = pfjetIdLoose_(*ijet, ret2);
+        if (scaledJet.pt() > jetPtMin_ && fabs(scaledJet.eta()) < jetEtaMax_ && passJetID) {
+          selectedJets_.push_back(scaledJet);
 
-	  if ( muPlusJets_ ) {
-
-	    //Remove some jets
-	    bool indeltaR = false;
-	    for( std::vector<reco::ShallowClonePtrCandidate>::const_iterator muonBegin = selectedMuons_.begin(),
-		   muonEnd = selectedMuons_.end(), imuon = muonBegin;
-		 imuon != muonEnd; ++imuon ) {
-	      if( reco::deltaR( imuon->eta(), imuon->phi(), scaledJet.eta(), scaledJet.phi() ) < muJetDR_ )
-		{  indeltaR = true; }
-	    }
-	    if( !indeltaR ) {
-	      cleanedJets_.push_back( scaledJet );
-	    }// end if jet is not within dR of a muon
-	  }// end if mu+jets
-	  else {
-	    //Remove some jets
-	    bool indeltaR = false;
-	    for( std::vector<reco::ShallowClonePtrCandidate>::const_iterator electronBegin = selectedElectrons_.begin(),
-		   electronEnd = selectedElectrons_.end(), ielectron = electronBegin;
-		 ielectron != electronEnd; ++ielectron ) {
-	      if( reco::deltaR( ielectron->eta(), ielectron->phi(), scaledJet.eta(), scaledJet.phi() ) < eleJetDR_ )
-		{  indeltaR = true; }
-	    }
-	    if( !indeltaR ) {
-	      cleanedJets_.push_back( scaledJet );
-	    }// end if jet is not within dR of an electron
-	  }// end if e+jets
-	}// end if pass id and kin cuts
-      }// end loop over jets
-
-
+          if (muPlusJets_) {
+            //Remove some jets
+            bool indeltaR = false;
+            for (std::vector<reco::ShallowClonePtrCandidate>::const_iterator muonBegin = selectedMuons_.begin(),
+                                                                             muonEnd = selectedMuons_.end(),
+                                                                             imuon = muonBegin;
+                 imuon != muonEnd;
+                 ++imuon) {
+              if (reco::deltaR(imuon->eta(), imuon->phi(), scaledJet.eta(), scaledJet.phi()) < muJetDR_) {
+                indeltaR = true;
+              }
+            }
+            if (!indeltaR) {
+              cleanedJets_.push_back(scaledJet);
+            }  // end if jet is not within dR of a muon
+          }    // end if mu+jets
+          else {
+            //Remove some jets
+            bool indeltaR = false;
+            for (std::vector<reco::ShallowClonePtrCandidate>::const_iterator electronBegin = selectedElectrons_.begin(),
+                                                                             electronEnd = selectedElectrons_.end(),
+                                                                             ielectron = electronBegin;
+                 ielectron != electronEnd;
+                 ++ielectron) {
+              if (reco::deltaR(ielectron->eta(), ielectron->phi(), scaledJet.eta(), scaledJet.phi()) < eleJetDR_) {
+                indeltaR = true;
+              }
+            }
+            if (!indeltaR) {
+              cleanedJets_.push_back(scaledJet);
+            }  // end if jet is not within dR of an electron
+          }    // end if e+jets
+        }      // end if pass id and kin cuts
+      }        // end loop over jets
 
       int nleptons = 0;
-      if ( muPlusJets_ )
-	nleptons += selectedMuons_.size();
+      if (muPlusJets_)
+        nleptons += selectedMuons_.size();
 
-      if ( ePlusJets_ )
-	nleptons += selectedElectrons_.size();
+      if (ePlusJets_)
+        nleptons += selectedElectrons_.size();
 
-      if ( ignoreCut(lep1Index_) ||
-	   ( nleptons > 0 ) ){
-	passCut( ret, lep1Index_);
+      if (ignoreCut(lep1Index_) || (nleptons > 0)) {
+        passCut(ret, lep1Index_);
 
-	if ( ignoreCut(lep2Index_) ||
-	     ( nleptons == 1 ) ){
-	  passCut( ret, lep2Index_);
+        if (ignoreCut(lep2Index_) || (nleptons == 1)) {
+          passCut(ret, lep2Index_);
 
-	  bool oneMuon =
-	    ( selectedMuons_.size() == 1 &&
-	      looseMuons_.size() + selectedElectrons_.size() + looseElectrons_.size() == 0
-	      );
-	  bool oneElectron =
-	    ( selectedElectrons_.size() == 1 &&
-	      selectedMuons_.empty()
-	      );
+          bool oneMuon = (selectedMuons_.size() == 1 &&
+                          looseMuons_.size() + selectedElectrons_.size() + looseElectrons_.size() == 0);
+          bool oneElectron = (selectedElectrons_.size() == 1 && selectedMuons_.empty());
 
-	  bool oneMuonMuVeto =
-	    ( selectedMuons_.size() == 1 &&
-	      looseMuons_.empty()
-	      );
+          bool oneMuonMuVeto = (selectedMuons_.size() == 1 && looseMuons_.empty());
 
+          if (ignoreCut(lep3Index_) || ePlusJets_ || (muPlusJets_ && oneMuonMuVeto)) {
+            passCut(ret, lep3Index_);
 
-	  if ( ignoreCut(lep3Index_) ||
-	       ePlusJets_ ||
-	       (muPlusJets_ && oneMuonMuVeto)
-	       ) {
-	    passCut(ret, lep3Index_);
+            if (ignoreCut(lep4Index_) || ((muPlusJets_ && oneMuon) ^ (ePlusJets_ && oneElectron))) {
+              passCut(ret, lep4Index_);
 
-	    if ( ignoreCut(lep4Index_) ||
-		 ( (muPlusJets_ && oneMuon) ^ (ePlusJets_ && oneElectron )  )
-		 ) {
-	      passCut(ret, lep4Index_);
+              bool metCut = met_.pt() > metMin_;
+              if (ignoreCut(metIndex_) || metCut) {
+                passCut(ret, metIndex_);
 
-	      bool metCut = met_.pt() > metMin_;
-	      if ( ignoreCut(metIndex_) ||
-		   metCut ) {
-		passCut( ret, metIndex_ );
+                bool zVeto = true;
+                if (selectedMuons_.size() == 2) {
+                }
+                if (selectedElectrons_.size() == 2) {
+                }
+                if (ignoreCut(zvetoIndex_) || zVeto) {
+                  passCut(ret, zvetoIndex_);
 
+                  bool conversionVeto = true;
+                  if (ignoreCut(conversionIndex_) || conversionVeto) {
+                    passCut(ret, conversionIndex_);
 
-		bool zVeto = true;
-		if ( selectedMuons_.size() == 2 ) {
-		}
-		if ( selectedElectrons_.size() == 2 ) {
-		}
-		if ( ignoreCut(zvetoIndex_) ||
-		     zVeto ){
-		  passCut(ret, zvetoIndex_);
+                    bool cosmicVeto = true;
+                    if (ignoreCut(cosmicIndex_) || cosmicVeto) {
+                      passCut(ret, cosmicIndex_);
 
+                      if (ignoreCut(jet1Index_) || static_cast<int>(cleanedJets_.size()) >= 1) {
+                        passCut(ret, jet1Index_);
+                      }  // end if >=1 tight jets
 
-		  bool conversionVeto = true;
-		  if ( ignoreCut(conversionIndex_) ||
-		       conversionVeto ) {
-		    passCut(ret,conversionIndex_);
+                      if (ignoreCut(jet2Index_) || static_cast<int>(cleanedJets_.size()) >= 2) {
+                        passCut(ret, jet2Index_);
+                      }  // end if >=2 tight jets
 
+                      if (ignoreCut(jet3Index_) || static_cast<int>(cleanedJets_.size()) >= 3) {
+                        passCut(ret, jet3Index_);
+                      }  // end if >=3 tight jets
 
+                      if (ignoreCut(jet4Index_) || static_cast<int>(cleanedJets_.size()) >= 4) {
+                        passCut(ret, jet4Index_);
+                      }  // end if >=4 tight jets
 
-		    bool cosmicVeto = true;
-		    if ( ignoreCut(cosmicIndex_) ||
-			 cosmicVeto ) {
-		      passCut(ret,cosmicIndex_);
+                      if (ignoreCut(jet5Index_) || static_cast<int>(cleanedJets_.size()) >= 5) {
+                        passCut(ret, jet5Index_);
+                      }  // end if >=5 tight jets
 
-		      if ( ignoreCut(jet1Index_) ||
-			   static_cast<int>(cleanedJets_.size()) >=  1 ){
-			passCut(ret,jet1Index_);
-		      } // end if >=1 tight jets
+                    }  // end if cosmic veto
 
-		      if ( ignoreCut(jet2Index_) ||
-			   static_cast<int>(cleanedJets_.size()) >=  2 ){
-			passCut(ret,jet2Index_);
-		      } // end if >=2 tight jets
+                  }  // end if conversion veto
 
-		      if ( ignoreCut(jet3Index_) ||
-			   static_cast<int>(cleanedJets_.size()) >=  3 ){
-			passCut(ret,jet3Index_);
-		      } // end if >=3 tight jets
+                }  // end if z veto
 
-		      if ( ignoreCut(jet4Index_) ||
-			   static_cast<int>(cleanedJets_.size()) >=  4 ){
-			passCut(ret,jet4Index_);
-		      } // end if >=4 tight jets
+              }  // end if met cut
 
-		      if ( ignoreCut(jet5Index_) ||
-			   static_cast<int>(cleanedJets_.size()) >=  5 ){
-			passCut(ret,jet5Index_);
-		      } // end if >=5 tight jets
+            }  // end if == 1 lepton
 
+          }  // end if == 1 tight lepton with a muon veto separately
 
+        }  // end if == 1 tight lepton
 
-		    } // end if cosmic veto
+      }  // end if >= 1 lepton
 
-		  } // end if conversion veto
+    }  // end if PV
 
-		} // end if z veto
-
-	      } // end if met cut
-
-	    } // end if == 1 lepton
-
-	  } // end if == 1 tight lepton with a muon veto separately
-
-	} // end if == 1 tight lepton
-
-      } // end if >= 1 lepton
-
-    } // end if PV
-
-  } // end if trigger
-
+  }  // end if trigger
 
   setIgnored(ret);
 

--- a/PhysicsTools/SelectorUtils/src/classes.h
+++ b/PhysicsTools/SelectorUtils/src/classes.h
@@ -12,15 +12,12 @@
 #include "PhysicsTools/SelectorUtils/interface/RunLumiSelector.h"
 #include "PhysicsTools/SelectorUtils/interface/MakePyVIDClassBuilder.h"
 
-
 namespace PhysicsTools_SelectorUtils {
   struct dictionary {
-
     pat::strbitset strbitset;
     edm::Wrapper<pat::strbitset> wstrbitset;
-    std::vector< pat::strbitset> vstrbitset;
-    edm::Wrapper< std::vector< pat::strbitset> > wvstrbitset;
-    
+    std::vector<pat::strbitset> vstrbitset;
+    edm::Wrapper<std::vector<pat::strbitset> > wvstrbitset;
   };
 
-}
+}  // namespace PhysicsTools_SelectorUtils

--- a/PhysicsTools/SelectorUtils/src/strbitset.cc
+++ b/PhysicsTools/SelectorUtils/src/strbitset.cc
@@ -2,9 +2,7 @@
 
 namespace pat {
 
-
- const std::string strbitset::dummy_ = std::string("");
-
+  const std::string strbitset::dummy_ = std::string("");
 
   strbitset operator&(const strbitset& l, const strbitset& r) {
     strbitset ret = r;
@@ -18,15 +16,15 @@ namespace pat {
     return ret;
   }
 
-  strbitset operator^(const strbitset& l, const strbitset& r){
+  strbitset operator^(const strbitset& l, const strbitset& r) {
     strbitset ret = r;
     ret ^= l;
     return ret;
   }
 
-  std::ostream & operator<<(std::ostream & out, const strbitset::index_type & r) {
+  std::ostream& operator<<(std::ostream& out, const strbitset::index_type& r) {
     out << r.i_;
     return out;
   }
 
-}
+}  // namespace pat


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/365//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


