### PR TITLE
Fix use-after-move in CITKPFIsolationSumProducer(ForPUPPI)

### DIFF
--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
@@ -86,11 +86,11 @@ namespace citk {
         throw cms::Exception("InvalidIsolationType") << "Isolation type: " << isotype << " is not available in the "
                                                      << "list of allowed isolations!.";
       }
-      _isolation_types[thetype->second].emplace_back(std::move(theisolator));
       const std::string dash("-");
       std::string pname = isotype + dash + coneName + dash + theisolator->additionalCode();
       _product_names[thetype->second].emplace_back(pname);
       produces<edm::ValueMap<float>>(pname);
+      _isolation_types[thetype->second].emplace_back(std::move(theisolator));
     }
   }
 

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -89,11 +89,11 @@ namespace citk {
         throw cms::Exception("InvalidIsolationType") << "Isolation type: " << isotype << " is not available in the "
                                                      << "list of allowed isolations!.";
       }
-      _isolation_types[thetype->second].emplace_back(std::move(theisolator));
       const std::string dash("-");
       std::string pname = isotype + dash + coneName + dash + theisolator->additionalCode();
       _product_names[thetype->second].emplace_back(pname);
       produces<edm::ValueMap<float>>(pname);
+      _isolation_types[thetype->second].emplace_back(std::move(theisolator));
     }
   }
 


### PR DESCRIPTION
#### PR description:

This PR fixes use-after-move in  CITKPFIsolationSumProducer and CITKPFIsolationSumProducerForPUPPI introduced accidentally in #25914 that leads to segfault when PluginFactory returns a unique_ptr (in #27097).

#### PR validation:

Code compiles.