### PR TITLE
[HGCal] Material budget from vertex up to in front of muon stations

### DIFF
--- a/Validation/Geometry/interface/MaterialBudgetHGCalHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetHGCalHistos.h
@@ -9,6 +9,15 @@ public:
   MaterialBudgetHGCalHistos(std::shared_ptr<MaterialBudgetData> data,
                             std::shared_ptr<TestHistoMgr> mgr,
                             const std::string& fileName);
+  MaterialBudgetHGCalHistos(std::shared_ptr<MaterialBudgetData> data,
+                            std::shared_ptr<TestHistoMgr> mgr,
+                            const std::string& fileName, 
+			    double minZ, double maxZ, int nintZ,
+			    double rMin, double rMax, int nrbin,
+			    double etaMin, double etaMax, int netabin,
+			    double phiMin, double phiMax, int nphibin,
+			    double RMin, double RMax, int nRbin
+			    );
   ~MaterialBudgetHGCalHistos() override {}
   void fillStartTrack() override;
   void fillPerStep() override;
@@ -25,6 +34,13 @@ private:
   double* theMateId;
 
   std::shared_ptr<TestHistoMgr> hmgr;
+
+  double zMin_, zMax_; int nzbin_;
+  double rMin_, rMax_; int nrbin_;
+  double etaMin_, etaMax_; int netabin_;
+  double phiMin_, phiMax_; int nphibin_;
+  double RMin_, RMax_; int nRbin_;
+
 };
 
 #endif

--- a/Validation/Geometry/python/plot_hgcal_utils.py
+++ b/Validation/Geometry/python/plot_hgcal_utils.py
@@ -12,10 +12,10 @@ from array import array
 from Validation.Geometry.plot_utils import Plot_params
 
 plots = {}
-plots.setdefault('x_vs_eta', Plot_params(10, '#eta', 'x/X_{0}', 0.0, 2.575, -4.0, 4.0, '', 0, 0., 0., 0, 1))
+plots.setdefault('x_vs_eta', Plot_params(10, '#eta', 'x/X_{0}', 0.0, 145., -4.0, 4.0, '', 0, 0., 0., 0, 1))
 plots.setdefault('x_vs_phi', Plot_params(20, '#varphi [rad]', 'x/X_{0}', 0.0, 6.2, -4.0, 4.0, '', 0, 0., 0., 0, 1))
 plots.setdefault('x_vs_R',   Plot_params(40, 'R [cm]', 'x/X_{0}', 0.0, 70.0, 0.0, 1200.0, '', 0, 0., 0., 0, 1))
-plots.setdefault('l_vs_eta', Plot_params(10010, '#eta', 'x/#lambda_{I}', 0.0, 0.73, -4.0, 4.0, '', 0, 0., 0., 0, 1))
+plots.setdefault('l_vs_eta', Plot_params(10010, '#eta', 'x/#lambda_{I}', 0.0, 22.8, -4.0, 4.0, '', 0, 0., 0., 0, 1))
 plots.setdefault('l_vs_phi', Plot_params(10020, '#varphi [rad]', 'x/#lambda_{I}', 0.0, 1.2, -4.0, 4.0, '', 0, 0., 0., 0, 1))
 plots.setdefault('l_vs_R',   Plot_params(10040, 'R [cm]', 'x/#lambda_{I}', 0.0, 7.5, 0.0, 1200.0, '', 0, 0., 0., 0, 1))
 plots.setdefault('x_vs_eta_vs_phi', Plot_params(30, '#eta', '#varphi', 0., 0., 0., 0., 'x/X_{0}', 0, -1., -1., 0, 1))
@@ -60,14 +60,29 @@ COMPOUNDS = OrderedDict()
 COMPOUNDS["HGCal"] = ["HGCal"]
 COMPOUNDS["HGCalEE"] = ["HGCalEE"]
 COMPOUNDS["HGCalHE"] = ["HGCalHEsil", "HGCalHEmix"]
-
+COMPOUNDS["FromVertexToBackOfHGCal"] = ["BeamPipe","Tracker","ECAL","HCal","EndcapTimingLayer + Thermal Screen","Neutron Moderator + Thermal Screen","HGCal + HGCal Service + Thermal Screen","Solenoid Magnet","Muon Wheels and Cables"]
 
 # The DETECTORS must be the single component of the HGCal for which
 # the user can ask for the corresponding material description.
+# BE CAREFUL: When running on a single detector and not through all 
+# only uncomment that one below. e.g. when running on HGCal only you should 
+# have only: 
+# DETECTORS["HGCal"] = kAzure-5
+# and others should be commented out.
 DETECTORS = OrderedDict()
-DETECTORS["HGCal"] = kAzure-5
-DETECTORS["HGCalEE"] = kAzure-9
-DETECTORS["HGCalHE"] = kOrange-2
+DETECTORS["BeamPipe"] = kGray+2
+DETECTORS["Tracker"]  = 9 #kAzure-5
+DETECTORS["ECAL"] = 2 #kOrange+10
+DETECTORS["HCal"] = 6  #kMagenta-2
+DETECTORS["EndcapTimingLayer + Thermal Screen"] = 7#kAzure-9 
+DETECTORS["Neutron Moderator + Thermal Screen"] = 46#kOrange+5
+DETECTORS["HGCal + HGCal Service + Thermal Screen"] = 5#kOrange-2
+DETECTORS["Solenoid Magnet"] = 4#kGray+5
+DETECTORS["Muon Wheels and Cables"] = 28
+#When running to get the R vs z sum of all subdetectors comment out above and 
+#uncomment the next line
+#DETECTORS["FromVertexToBackOfHGCal"] = 30
+
 
 # sDETS are the label of the HGCal elements in the Reconstruction
 # geometry. They are all used to derive the reconstruction material
@@ -78,9 +93,11 @@ DETECTORS["HGCalHE"] = kOrange-2
 # made as inclusive as possible with respect to the many
 # reconstruction geometries in CMSSW.
 sDETS = OrderedDict()
-sDETS["HGCalEE"] = kRed
-sDETS["HGCalHEsil"] = kBlue
-sDETS["HGCalHEmix"] = kGreen
+#sDETS["HGCalEE"] = kRed
+#sDETS["HGCalHEsil"] = kBlue
+#sDETS["HGCalHEmix"] = kGreen
+sDETS["ECAL"] = kBlue
+sDETS["HCal"] = kOrange
 #sDETS[""] = kYellow
 #sDETS[""] = kOrange
 #sDETS[""] = kPink
@@ -244,3 +261,62 @@ MatXo['Lead'] = 5.6118
 MatXo['Epoxy'] = 315.901
 MatXo['Kapton'] = 365.309
 
+def drawHalfEtaValues():
+    """Function to draw the eta.
+    Function to draw the eta references on top of an already existing
+    TCanvas. The lines and labels drawn are collected inside a list and
+    the list is returned to the user to extend the live of the objects
+    contained, otherwise no lines and labels will be drawn, since they
+    will be garbage-collected as soon as this function returns.
+    """
+
+    # Add eta labels
+    keep_alive = []
+    etas = [ 0.2*i for i in range(0,18) ]
+
+    etax = 2850.#6850.
+    etay = 1240.#5200.
+    lineL = 110#8600.
+    offT = 10.
+
+    for ieta in etas:
+        th = 2*atan(exp(-ieta))
+        talign = 21
+
+        #IP
+        lineh = TLine(-20.,0.,20.,0.)
+        lineh.Draw()
+        linev = TLine(0.,-10.,0.,10.)
+        linev.Draw()
+        keep_alive.append(lineh)
+        keep_alive.append(linev)
+
+        x1 = 0
+        y1 = 0
+        if ieta>-1.6 and ieta<1.6:
+            x1 = etay/tan(th)
+            y1 = etay
+        elif ieta <=-1.6:
+            x1 = -etax
+            y1 = -etax*tan(th)
+            talign = 11
+        elif ieta>=1.6:
+            x1 = etax
+            y1 = etax*tan(th)
+            talign = 31
+        x2 = x1+lineL*cos(th)
+        y2 = y1+lineL*sin(th)
+        xt = x2
+        yt = y2+offT
+
+        line1 = TLine(x1,y1,x2,y2)
+        line1.Draw()
+        keep_alive.append(line1)
+
+        text = "%3.1f" % ieta
+        t1 = TLatex(xt, yt, '%s' % ('#eta = 0' if ieta == 0 else text))
+        t1.SetTextSize(0.03)
+        t1.SetTextAlign(talign)
+        t1.Draw()
+        keep_alive.append(t1)
+    return keep_alive

--- a/Validation/Geometry/python/plot_hgcal_utils.py
+++ b/Validation/Geometry/python/plot_hgcal_utils.py
@@ -34,7 +34,17 @@ plots.setdefault('x_over_l_vs_eta', Plot_params(10, '#eta', '(x/X_{0})/(x/#lambd
 plots.setdefault('x_over_l_vs_phi', Plot_params(20, '#varphi [rad]', '(x/X_{0})/(x/#lambda_{I})', 0., 0., 0., 0., '', 0, -1, -1, 0, 0))
 
 # Conversion name from the label (key) to the components in CMSSW/Geometry
-_LABELS2COMPS = {'HGCal': 'HGCal',
+_LABELS2COMPS = {'BeamPipe': 'BEAM',
+                 'Tracker': 'Tracker', 
+                 'EndcapTimingLayer + Thermal Screen': 'CALOECTSFront',
+                 'Neutron Moderator + Thermal Screen' : 'CALOECTSMiddle',
+                 'HGCal + HGCal Service + Thermal Screen' : 'CALOECTSRear',
+                 'Solenoid Magnet' : 'MGNT',
+                 'Muon Wheels and Cables' : 'MB',
+                 'ECAL': 'ECAL',
+                 'HCal': 'HCal',
+                 'FromVertexToBackOfHGCal' : ['BEAM','Tracker','ECAL','HCal','CALOECTSFront','CALOECTSMiddle','CALOECTSRear','MGNT','MB'],
+                 'HGCal': 'HGCal',
                  'HGCalEE': 'HGCalEE',
                  'HGCalHE': ['HGCalHEsil', 'HGCalHEmix']
                  }

--- a/Validation/Geometry/src/MaterialBudgetAction.cc
+++ b/Validation/Geometry/src/MaterialBudgetAction.cc
@@ -77,7 +77,14 @@ MaterialBudgetAction::MaterialBudgetAction(const edm::ParameterSet& iPSet) {
       theHistos = std::make_shared<MaterialBudgetMtdHistos>(theData, theHistoMgr, saveToHistosFile);
       theData->setMtdmode(true);
     } else if (theHistoList == "HGCal") {
-      theHistos = std::make_shared<MaterialBudgetHGCalHistos>(theData, theHistoMgr, saveToHistosFile);
+      theHistos = std::make_shared<MaterialBudgetHGCalHistos>
+	(theData, theHistoMgr, saveToHistosFile, 
+	 m_Anal.getParameter<double>("minZ"), m_Anal.getParameter<double>("maxZ"), m_Anal.getParameter<int>("nintZ"), 
+	 m_Anal.getParameter<double>("rMin"), m_Anal.getParameter<double>("rMax"), m_Anal.getParameter<int>("nrbin"), 
+	 m_Anal.getParameter<double>("etaMin"), m_Anal.getParameter<double>("etaMax"), m_Anal.getParameter<int>("netabin"), 
+	 m_Anal.getParameter<double>("phiMin"), m_Anal.getParameter<double>("phiMax"), m_Anal.getParameter<int>("nphibin"), 
+	 m_Anal.getParameter<double>("RMin"), m_Anal.getParameter<double>("RMax"), m_Anal.getParameter<int>("nRbin")
+	 );
       //In HGCal mode, so tell data class
       theData->setHGCalmode(true);
     } else {

--- a/Validation/Geometry/src/MaterialBudgetHGCalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHGCalHistos.cc
@@ -8,8 +8,31 @@ const T& max(const T& a, const T& b) {
 
 MaterialBudgetHGCalHistos::MaterialBudgetHGCalHistos(std::shared_ptr<MaterialBudgetData> data,
                                                      std::shared_ptr<TestHistoMgr> mgr,
-                                                     const std::string& fileName)
-    : MaterialBudgetFormat(data), hmgr(mgr) {
+                                                     const std::string& fileName, 
+						     double minZ, double maxZ, int nintZ,
+						     double rMin, double rMax, int nrbin,
+						     double etaMin, double etaMax, int netabin,
+						     double phiMin, double phiMax, int nphibin,
+						     double RMin, double RMax, int nRbin)
+  : MaterialBudgetFormat(data), 
+  hmgr(mgr), 
+  zMin_(minZ),
+  zMax_(maxZ), 
+  nzbin_(nintZ),
+  rMin_(rMin), 
+  rMax_(rMax),
+  nrbin_(nrbin),
+  etaMin_(etaMin),
+  etaMax_(etaMax),
+  netabin_(netabin),
+  phiMin_(phiMin),
+  phiMax_(phiMax),
+  nphibin_(nphibin),
+  RMin_(RMin),
+  RMax_(RMax),
+  nRbin_(nRbin)
+
+{
   theFileName = fileName;
   book();
 }
@@ -17,608 +40,521 @@ MaterialBudgetHGCalHistos::MaterialBudgetHGCalHistos(std::shared_ptr<MaterialBud
 void MaterialBudgetHGCalHistos::book() {
   std::cout << "=== booking user histos ===" << std::endl;
 
-  // Parameters for 2D histograms
-  // Make z 1mm per bin
-  int nzbin = 11000;
-  float zMax = 5500.;   //
-  float zMin = -5500.;  //
-  // Make r 1cm per bin
-  int nrbin = 345;
-  float rMin = -50.;
-  float rMax = 3400.;
-  // eta
-  int netabin = 250;
-  float etaMin = -5.;
-  float etaMax = 5.;
-  // phi
-  int nphibin = 180;
-  float phiMin = -3.2;
-  float phiMax = 3.2;
-  // R for profile histos
-  int nRbin = 300;
-  float RMin = 0.;
-  float RMax = 3000.;
-
   // total X0
-  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta;#eta;x/X_{0} ", netabin, etaMin, etaMax));
-  hmgr->addHisto1(new TH1F("11", "Eta ", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi;#varphi [rad];x/X_{0} ", nphibin, phiMin, phiMax));
-  hmgr->addHisto1(new TH1F("21", "Phi ", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta;#eta;x/X_{0} ", netabin_, etaMin_, etaMax_));
+  hmgr->addHisto1(new TH1F("11", "Eta ", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi;#varphi [rad];x/X_{0} ", nphibin_, phiMin_, phiMax_));
+  hmgr->addHisto1(new TH1F("21", "Phi ", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("30", "MB prof Eta  Phi;#eta;#varphi;x/X_{0} ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("40", "MB prof R;R [mm];x/X_{0} ", nRbin, RMin, RMax));
-  hmgr->addHisto1(new TH1F("41", "R ", nRbin, RMin, RMax));
+      new TProfile2D("30", "MB prof Eta  Phi;#eta;#varphi;x/X_{0} ", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("40", "MB prof R;R [mm];x/X_{0} ", nRbin_, RMin_, RMax_));
+  hmgr->addHisto1(new TH1F("41", "R ", nRbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("50", "MB prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
-  hmgr->addHisto2(new TH2F("999", "Tot track length for MB", nzbin, zMin, zMax, nrbin, rMin, rMax));
-  hmgr->addHisto2(new TH2F("51", "R vs z ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("50", "MB prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
+  hmgr->addHisto2(new TH2F("999", "Tot track length for MB", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
+  hmgr->addHisto2(new TH2F("51", "R vs z ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("52", "MB ortho prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
-  hmgr->addHisto2(new TH2F("60", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("52", "MB ortho prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
+  hmgr->addHisto2(new TH2F("60", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("70", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("70", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("72", "MB ortho prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("72", "MB ortho prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Copper
-  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Copper];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Copper];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Copper];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Copper];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "130", "MB prof Eta  Phi [Copper];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("140", "MB prof R [Copper];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "130", "MB prof Eta  Phi [Copper];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("140", "MB prof R [Copper];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("150", "MB prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("150", "MB prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "152", "MB ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "152", "MB ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("160", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("160", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "170", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "170", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "172", "MB ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "172", "MB ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // H_Scintillator
-  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Scintillator];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Scintillator];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Scintillator];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Scintillator];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "230", "MB prof Eta  Phi [Scintillator];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("240", "MB prof R [Scintillator];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "230", "MB prof Eta  Phi [Scintillator];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("240", "MB prof R [Scintillator];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "250", "MB prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "250", "MB prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "252", "MB ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "252", "MB ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(new TH2F(
-      "260", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "260", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "270", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "270", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "272", "MB ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "272", "MB ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Cables
-  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("340", "MB prof R [Cables];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("340", "MB prof R [Cables];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "352", "MB ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "352", "MB ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "370", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "370", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "372", "MB ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "372", "MB ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // HGC_G10_FR4
-  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [HGC_G10_FR4];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [HGC_G10_FR4];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [HGC_G10_FR4];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [HGC_G10_FR4];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "430", "MB prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("440", "MB prof R [HGC_G10_FR4];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "430", "MB prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("440", "MB prof R [HGC_G10_FR4];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "450", "MB prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "450", "MB prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "452", "MB ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "452", "MB ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("460", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("460", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "470", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "470", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "472", "MB ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "472", "MB ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Silicon
-  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Silicon];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Silicon];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Silicon];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Silicon];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "530", "MB prof Eta  Phi [Silicon];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("540", "MB prof R [Silicon];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "530", "MB prof Eta  Phi [Silicon];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("540", "MB prof R [Silicon];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("550", "MB prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("550", "MB prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "552", "MB ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "552", "MB ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("560", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("560", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "570", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "570", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "572", "MB ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "572", "MB ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Other
-  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("640", "MB prof R [Other];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("640", "MB prof R [Other];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "652", "MB ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "652", "MB ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("670", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("670", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "672", "MB ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "672", "MB ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Air
-  hmgr->addHistoProf1(new TProfile("710", "MB prof Eta [Air];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("720", "MB prof Phi [Air];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("710", "MB prof Eta [Air];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("720", "MB prof Phi [Air];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "730", "MB prof Eta  Phi [Air];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("740", "MB prof R [Air];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "730", "MB prof Eta  Phi [Air];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("740", "MB prof R [Air];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "752", "MB ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "752", "MB ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("770", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("770", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "772", "MB ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "772", "MB ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   //StainlessSteel
-  hmgr->addHistoProf1(new TProfile("810", "MB prof Eta [StainlessSteel];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("810", "MB prof Eta [StainlessSteel];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("820", "MB prof Phi [StainlessSteel];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+      new TProfile("820", "MB prof Phi [StainlessSteel];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "830", "MB prof Eta  Phi [StainlessSteel];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("840", "MB prof R [StainlessSteel];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "830", "MB prof Eta  Phi [StainlessSteel];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("840", "MB prof R [StainlessSteel];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "850", "MB prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "850", "MB prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "852", "MB ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "852", "MB ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(new TH2F(
-      "860", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "860", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "870", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "870", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "872", "MB ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "872", "MB ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   //WCu
-  hmgr->addHistoProf1(new TProfile("910", "MB prof Eta [WCu];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("920", "MB prof Phi [WCu];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("910", "MB prof Eta [WCu];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("920", "MB prof Phi [WCu];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "930", "MB prof Eta  Phi [WCu];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("940", "MB prof R [WCu];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "930", "MB prof Eta  Phi [WCu];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("940", "MB prof R [WCu];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("950", "MB prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("950", "MB prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "952", "MB ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "952", "MB ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("960", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("960", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("970", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("970", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "972", "MB ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "972", "MB ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Lead
-  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Lead];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("1020", "MB prof Phi [Lead];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Lead];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("1020", "MB prof Phi [Lead];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1030", "MB prof Eta  Phi [Lead];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("1040", "MB prof R [Lead];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "1030", "MB prof Eta  Phi [Lead];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("1040", "MB prof R [Lead];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("1050", "MB prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("1050", "MB prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1052", "MB ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1052", "MB ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("1060", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("1060", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("1070", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("1070", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1072", "MB ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1072", "MB ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Epoxy
-  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Epoxy];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("1120", "MB prof Phi [Epoxy];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Epoxy];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("1120", "MB prof Phi [Epoxy];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1130", "MB prof Eta  Phi [Epoxy];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("1140", "MB prof R [Epoxy];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "1130", "MB prof Eta  Phi [Epoxy];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("1140", "MB prof R [Epoxy];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("1150", "MB prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("1150", "MB prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1152", "MB ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1152", "MB ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("1160", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("1160", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1170", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1170", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1172", "MB ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1172", "MB ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Kapton
-  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Kapton];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("1220", "MB prof Phi [Kapton];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Kapton];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("1220", "MB prof Phi [Kapton];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1230", "MB prof Eta  Phi [Kapton];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("1240", "MB prof R [Kapton];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "1230", "MB prof Eta  Phi [Kapton];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("1240", "MB prof R [Kapton];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("1250", "MB prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("1250", "MB prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1252", "MB ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1252", "MB ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("1260", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("1260", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1270", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1270", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1272", "MB ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1272", "MB ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Aluminium
-  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Aluminium];#eta;x/X_{0}", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("1320", "MB prof Phi [Aluminium];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Aluminium];#eta;x/X_{0}", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("1320", "MB prof Phi [Aluminium];#varphi [rad];x/X_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1330", "MB prof Eta  Phi [Aluminium];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
-  hmgr->addHistoProf1(new TProfile("1340", "MB prof R [Aluminium];R [mm];x/X_{0}", nRbin, RMin, RMax));
+      "1330", "MB prof Eta  Phi [Aluminium];#eta;#varphi;x/X_{0}", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("1340", "MB prof R [Aluminium];R [mm];x/X_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1350", "MB prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1350", "MB prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1352", "MB ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1352", "MB ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("1360", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("1360", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1370", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1370", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "1372", "MB ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "1372", "MB ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   //=========================================================================================================
   // total Lambda0
-  hmgr->addHistoProf1(new TProfile("10010", "IL prof Eta;#eta;#lambda/#lambda_{0} ", netabin, etaMin, etaMax));
-  hmgr->addHistoProf1(new TProfile("10020", "IL prof Phi;#varphi [rad];#lambda/#lambda_{0} ", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("10010", "IL prof Eta;#eta;#lambda/#lambda_{0} ", netabin_, etaMin_, etaMax_));
+  hmgr->addHistoProf1(new TProfile("10020", "IL prof Phi;#varphi [rad];#lambda/#lambda_{0} ", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10030", "IL prof Eta  Phi;#eta;#varphi;#lambda/#lambda_{0} ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+      "10030", "IL prof Eta  Phi;#eta;#varphi;#lambda/#lambda_{0} ", netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
 
   // rr
-  hmgr->addHistoProf1(new TProfile("10040", "IL prof R;R [mm];#lambda/#lambda_{0} ", nRbin, RMin, RMax));
+  hmgr->addHistoProf1(new TProfile("10040", "IL prof R;R [mm];#lambda/#lambda_{0} ", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10050", "IL prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10050", "IL prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10052", "IL ortho prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
-  hmgr->addHisto2(new TH2F("1999", "Tot track length for l0", nzbin, zMin, zMax, nrbin, rMin, rMax));
-  hmgr->addHisto2(new TH2F("10060", "IL prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10052", "IL ortho prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
+  hmgr->addHisto2(new TH2F("1999", "Tot track length for l0", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
+  hmgr->addHisto2(new TH2F("10060", "IL prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10070", "IL prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10070", "IL prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10072", "IL ortho prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10072", "IL ortho prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Copper
-  hmgr->addHistoProf1(new TProfile("10110", "IL prof Eta [Copper];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10110", "IL prof Eta [Copper];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10120", "IL prof Phi [Copper];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10120", "IL prof Phi [Copper];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10130",
                                      "IL prof Eta  Phi [Copper];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10140", "IL prof R [Copper];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10140", "IL prof R [Copper];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10150", "IL prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10150", "IL prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10152", "IL ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10152", "IL ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("10160", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("10160", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10170", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10170", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10172", "IL ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10172", "IL ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // H_Scintillator
   hmgr->addHistoProf1(
-      new TProfile("10210", "IL prof Eta [Scintillator];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+      new TProfile("10210", "IL prof Eta [Scintillator];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10220", "IL prof Phi [Scintillator];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10220", "IL prof Phi [Scintillator];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10230",
                                      "IL prof Eta  Phi [Scintillator];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10240", "IL prof R [Scintillator];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10240", "IL prof R [Scintillator];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10250", "IL prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10250", "IL prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10252", "IL ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10252", "IL ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(new TH2F(
-      "10260", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10260", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10270", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10270", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10272", "IL ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10272", "IL ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Cables
-  hmgr->addHistoProf1(new TProfile("10310", "IL prof Eta [Cables];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10310", "IL prof Eta [Cables];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10320", "IL prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10320", "IL prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10330",
                                      "IL prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10340", "IL prof R [Cables];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10340", "IL prof R [Cables];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10350", "IL prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10350", "IL prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10352", "IL ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10352", "IL ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("10360", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("10360", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10370", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10370", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10372", "IL ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10372", "IL ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // HGC_G10_FR4
   hmgr->addHistoProf1(
-      new TProfile("10410", "IL prof Eta [HGC_G10_FR4];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+      new TProfile("10410", "IL prof Eta [HGC_G10_FR4];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10420", "IL prof Phi [HGC_G10_FR4];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10420", "IL prof Phi [HGC_G10_FR4];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10430",
                                      "IL prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10440", "IL prof R [HGC_G10_FR4];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10440", "IL prof R [HGC_G10_FR4];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10450", "IL prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10450", "IL prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10452", "IL ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10452", "IL ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(new TH2F(
-      "10460", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10460", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10470", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10470", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10472", "IL ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10472", "IL ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Silicon
-  hmgr->addHistoProf1(new TProfile("10510", "IL prof Eta [Silicon];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10510", "IL prof Eta [Silicon];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10520", "IL prof Phi [Silicon];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10520", "IL prof Phi [Silicon];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10530",
                                      "IL prof Eta  Phi [Silicon];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10540", "IL prof R [Silicon];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10540", "IL prof R [Silicon];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10550", "IL prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10550", "IL prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10552", "IL ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10552", "IL ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("10560", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("10560", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10570", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10570", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10572", "IL ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10572", "IL ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Other
-  hmgr->addHistoProf1(new TProfile("10610", "IL prof Eta [Other];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10610", "IL prof Eta [Other];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10620", "IL prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10620", "IL prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10630",
                                      "IL prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10640", "IL prof R [Other];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10640", "IL prof R [Other];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("10650", "IL prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("10650", "IL prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10652", "IL ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10652", "IL ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("10660", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("10660", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10670", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10670", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10672", "IL ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10672", "IL ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Air
-  hmgr->addHistoProf1(new TProfile("10710", "IL prof Eta [Air];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10710", "IL prof Eta [Air];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10720", "IL prof Phi [Air];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10720", "IL prof Phi [Air];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10730",
                                      "IL prof Eta  Phi [Air];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10740", "IL prof R [Air];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10740", "IL prof R [Air];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("10750", "IL prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("10750", "IL prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10752", "IL ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10752", "IL ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("10760", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("10760", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("10770", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("10770", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10772", "IL ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10772", "IL ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   //StainlessSteel
   hmgr->addHistoProf1(
-      new TProfile("10810", "IL prof Eta [StainlessSteel];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+      new TProfile("10810", "IL prof Eta [StainlessSteel];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10820", "IL prof Phi [StainlessSteel];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10820", "IL prof Phi [StainlessSteel];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10830",
                                      "IL prof Eta  Phi [StainlessSteel];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf1(
-      new TProfile("10840", "IL prof R [StainlessSteel];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+      new TProfile("10840", "IL prof R [StainlessSteel];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10850", "IL prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10850", "IL prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10852", "IL ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10852", "IL ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(new TH2F(
-      "10860", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10860", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10870", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10870", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10872", "IL ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10872", "IL ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   //WCu
-  hmgr->addHistoProf1(new TProfile("10910", "IL prof Eta [WCu];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10910", "IL prof Eta [WCu];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("10920", "IL prof Phi [WCu];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("10920", "IL prof Phi [WCu];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("10930",
                                      "IL prof Eta  Phi [WCu];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("10940", "IL prof R [WCu];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("10940", "IL prof R [WCu];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("10950", "IL prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("10950", "IL prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10952", "IL ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10952", "IL ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("10960", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("10960", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("10970", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("10970", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "10972", "IL ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "10972", "IL ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Lead
-  hmgr->addHistoProf1(new TProfile("11010", "IL prof Eta [Lead];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("11010", "IL prof Eta [Lead];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("11020", "IL prof Phi [Lead];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("11020", "IL prof Phi [Lead];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("11030",
                                      "IL prof Eta  Phi [Lead];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("11040", "IL prof R [Lead];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("11040", "IL prof R [Lead];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("11050", "IL prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("11050", "IL prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11052", "IL ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11052", "IL ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("11060", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("11060", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11070", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11070", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11072", "IL ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11072", "IL ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Epoxy
-  hmgr->addHistoProf1(new TProfile("11110", "IL prof Eta [Epoxy];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("11110", "IL prof Eta [Epoxy];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("11120", "IL prof Phi [Epoxy];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("11120", "IL prof Phi [Epoxy];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("11130",
                                      "IL prof Eta  Phi [Epoxy];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("11140", "IL prof R [Epoxy];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("11140", "IL prof R [Epoxy];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(
-      new TProfile2D("11150", "IL prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TProfile2D("11150", "IL prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11152", "IL ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11152", "IL ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("11160", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("11160", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11170", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11170", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11172", "IL ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11172", "IL ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Kapton
-  hmgr->addHistoProf1(new TProfile("11210", "IL prof Eta [Kapton];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("11210", "IL prof Eta [Kapton];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("11220", "IL prof Phi [Kapton];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("11220", "IL prof Phi [Kapton];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("11230",
                                      "IL prof Eta  Phi [Kapton];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("11240", "IL prof R [Kapton];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("11240", "IL prof R [Kapton];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11250", "IL prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11250", "IL prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11252", "IL ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11252", "IL ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("11260", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("11260", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11270", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11270", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11272", "IL ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11272", "IL ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   // Aluminium
   hmgr->addHistoProf1(
-      new TProfile("11310", "IL prof Eta [Aluminium];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+      new TProfile("11310", "IL prof Eta [Aluminium];#eta;#lambda/#lambda_{0}", netabin_, etaMin_, etaMax_));
   hmgr->addHistoProf1(
-      new TProfile("11320", "IL prof Phi [Aluminium];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+      new TProfile("11320", "IL prof Phi [Aluminium];#varphi [rad];#lambda/#lambda_{0}", nphibin_, phiMin_, phiMax_));
   hmgr->addHistoProf2(new TProfile2D("11330",
                                      "IL prof Eta  Phi [Aluminium];#eta;#varphi;#lambda/#lambda_{0}",
-                                     netabin,
-                                     etaMin,
-                                     etaMax,
-                                     nphibin,
-                                     phiMin,
-                                     phiMax));
-  hmgr->addHistoProf1(new TProfile("11340", "IL prof R [Aluminium];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+                                     netabin_, etaMin_, etaMax_, nphibin_, phiMin_, phiMax_));
+  hmgr->addHistoProf1(new TProfile("11340", "IL prof R [Aluminium];R [mm];#lambda/#lambda_{0}", nrbin_, RMin_, RMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11350", "IL prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+				     "11350", "IL prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11352", "IL ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+				     "11352", "IL ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHisto2(
-      new TH2F("11360", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      new TH2F("11360", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11370", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11370", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
   hmgr->addHistoProf2(new TProfile2D(
-      "11372", "IL ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+      "11372", "IL ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin_, zMin_, zMax_, nrbin_, rMin_, rMax_));
 
   std::cout << "=== booking user histos done ===" << std::endl;
 }

--- a/Validation/Geometry/test/MaterialBudgetHGCal.py
+++ b/Validation/Geometry/test/MaterialBudgetHGCal.py
@@ -11,7 +11,7 @@ from array import array
 oldargv = sys.argv[:]
 sys.argv = [ '-b-' ]
 from ROOT import TCanvas, TLegend, TPaveText, THStack, TFile, TLatex, TPaveLabel
-from ROOT import TProfile, TProfile2D, TH1D, TH2F, TPaletteAxis, TH1, TH1F, TColor, TExec
+from ROOT import TProfile, TProfile2D, TH1D, TH2D, TH2F, TPaletteAxis, TH1, TH1F, TColor, TExec, TLine
 from ROOT import kBlack, kWhite, kOrange, kAzure, kBlue
 from ROOT import gROOT, gStyle
 gROOT.SetBatch(True)
@@ -19,7 +19,7 @@ sys.argv = oldargv
 
 from Validation.Geometry.plot_utils import setTDRStyle, Plot_params, drawEtaValues
  
-from Validation.Geometry.plot_hgcal_utils import plots, COMPOUNDS, DETECTORS, sDETS, hist_label_to_num, TwikiPrintout, acustompalette, dEdx, MatXo
+from Validation.Geometry.plot_hgcal_utils import plots, COMPOUNDS, DETECTORS, sDETS, hist_label_to_num, TwikiPrintout, acustompalette, dEdx, MatXo, drawHalfEtaValues
 from collections import namedtuple, OrderedDict
 import sys, os
 import argparse
@@ -76,7 +76,7 @@ def assignOrAddIfExists_(h, p):
         h.Add(p.ProjectionX("B_%s" % h.GetName()), +1.000)
     return h
 
-def createPlots_(plot):
+def createPlots_(plot, compounddetectorname):
     """Cumulative material budget from simulation.
     
        Internal function that will produce a cumulative profile of the
@@ -88,7 +88,6 @@ def createPlots_(plot):
 
     """
 
-    IBs = ["InnerServices", "Phase2PixelBarrel", "TIB", "TIDF", "TIDB"]
     theDirname = "Figures"
 
     hist_X0_detectors = OrderedDict()
@@ -96,7 +95,6 @@ def createPlots_(plot):
         print("Error: chosen plot name not known %s" % plot)
         return
 
-    hist_X0_IB = None
     # We need to keep the file content alive for the lifetime of the
     # full function....
     subDetectorFiles = []
@@ -114,10 +112,6 @@ def createPlots_(plot):
         print ("Opening file: %s" % subDetectorFilename)
         prof_X0_XXX = subDetectorFile.Get("%d" % plots[plot].plotNumber)
 
-        # Merge together the "inner barrel detectors".
-        if subDetector in IBs:
-            hist_X0_IB = assignOrAddIfExists_(hist_X0_IB, prof_X0_XXX)
-
         hist_X0_detectors[subDetector] = prof_X0_XXX.ProjectionX()
 
         # category profiles
@@ -128,9 +122,9 @@ def createPlots_(plot):
 
     cumulative_matbdg = TH1D("CumulativeSimulMatBdg",
                              "CumulativeSimulMatBdg",
-                             hist_X0_IB.GetNbinsX(),
-                             hist_X0_IB.GetXaxis().GetXmin(),
-                             hist_X0_IB.GetXaxis().GetXmax())
+                             hist_X0_detectors["BeamPipe"].GetNbinsX(),
+                             hist_X0_detectors["BeamPipe"].GetXaxis().GetXmin(),
+                             hist_X0_detectors["BeamPipe"].GetXaxis().GetXmax())
     cumulative_matbdg.SetDirectory(0)
 
     # colors
@@ -140,9 +134,9 @@ def createPlots_(plot):
     for label, [num, color, leg] in hist_label_to_num.iteritems():
         hist_X0_elements[label].SetFillColor(color)
 
-    # First Plot: BeamPipe + Pixel + TIB/TID + TOB + TEC + Outside
+    # First Plot: BeamPipe + Tracker + ECAL + HCal + HGCal + MB + MGNT
     # stack
-    stackTitle_SubDetectors = "Tracker Material Budget;%s;%s" % (
+    stackTitle_SubDetectors = "Material Budget;%s;%s" % (
         plots[plot].abscissa,plots[plot].ordinate)
     stack_X0_SubDetectors = THStack("stack_X0",stackTitle_SubDetectors)
     for det, histo in hist_X0_detectors.iteritems():
@@ -151,19 +145,19 @@ def createPlots_(plot):
 
     # canvas
     can_SubDetectors = TCanvas("can_SubDetectors","can_SubDetectors",800,800)
-    can_SubDetectors.Range(0,0,25,25)
+    #can_SubDetectors.Range(0,0,25,25)
     can_SubDetectors.SetFillColor(kWhite)
 
     # Draw
     stack_X0_SubDetectors.SetMinimum(plots[plot].ymin)
     stack_X0_SubDetectors.SetMaximum(plots[plot].ymax)
     stack_X0_SubDetectors.Draw("HIST")
-    stack_X0_SubDetectors.GetXaxis().SetLimits(plots[plot].xmin, plots[plot].xmax)
+    #stack_X0_SubDetectors.GetXaxis().SetLimits(plots[plot].xmin, plots[plot].xmax)
 
 
     # Legenda
-    theLegend_SubDetectors = TLegend(0.180,0.8,0.98,0.92)
-    theLegend_SubDetectors.SetNColumns(3)
+    theLegend_SubDetectors = TLegend(0.130,0.7,0.93,0.90) #(0.180,0.8,0.98,0.90)
+    theLegend_SubDetectors.SetNColumns(2)
     theLegend_SubDetectors.SetFillColor(0)
     theLegend_SubDetectors.SetFillStyle(0)
     theLegend_SubDetectors.SetBorderSize(0)
@@ -174,7 +168,7 @@ def createPlots_(plot):
     theLegend_SubDetectors.Draw()
 
     # text
-    text_SubDetectors = TPaveText(0.180,0.727,0.402,0.787,"NDC")
+    text_SubDetectors = TPaveText(0.130,0.627,0.352,0.687,"NDC") #(0.180,0.727,0.402,0.787,"NDC")
     text_SubDetectors.SetFillColor(0)
     text_SubDetectors.SetBorderSize(0)
     text_SubDetectors.AddText("CMS Simulation")
@@ -185,55 +179,201 @@ def createPlots_(plot):
     can_SubDetectors.Update()
     if not checkFile_(theDirname):
         os.mkdir(theDirname)
-    #can_SubDetectors.SaveAs("%s/Tracker_SubDetectors_%s.pdf" % (theDirname, plot))
-    #can_SubDetectors.SaveAs("%s/Tracker_SubDetectors_%s.root" % (theDirname, plot))
+    can_SubDetectors.SaveAs("%s/MaterialBdg_%s_%s.pdf" % (theDirname, compounddetectorname,plot))
+    can_SubDetectors.SaveAs("%s/MaterialBdg_%s_%s.png" % (theDirname, compounddetectorname,plot))
+    can_SubDetectors.SaveAs("%s/MaterialBdg_%s_%s.root" % (theDirname, compounddetectorname,plot))
 
+    if plot == "x_vs_eta" or plot == "l_vs_eta":
+        canname = "MBCan_1D_%s_%s_total"  % (compounddetectorname, plot)
+        can2 = TCanvas(canname, canname, 800, 800)
+        can2.Range(0,0,25,25)
+        can2.SetFillColor(kWhite)
+        gStyle.SetOptStat(0)
+        gStyle.SetOptTitle(0);
+        #title = TPaveLabel(.11,.95,.35,.99,"Total accumulated material budget","brndc")
+        stack_X0_SubDetectors.GetStack().Last().SetMarkerStyle(34)
+        stack_X0_SubDetectors.GetStack().Last().GetXaxis().SetRangeUser( 1.0, 3.5)
+        stack_X0_SubDetectors.GetStack().Last().Draw();
+        stack_X0_SubDetectors.GetYaxis().SetTitleOffset(1.15);
+        can2.Update()
+        can2.Modified()
+        can2.SaveAs("%s/%s_%s_total_Zplus.pdf" % (theDirname, compounddetectorname, plot))
+        can2.SaveAs("%s/%s_%s_total_Zplus.png" % (theDirname, compounddetectorname, plot))
+        stack_X0_SubDetectors.GetStack().Last().GetXaxis().SetRangeUser( -3.5, -1.0)
+        stack_X0_SubDetectors.GetStack().Last().Draw();
+        stack_X0_SubDetectors.GetYaxis().SetTitleOffset(1.15);
+        can2.Update()
+        can2.Modified()
+        can2.SaveAs("%s/%s_%s_total_Zminus.pdf" % (theDirname, compounddetectorname, plot))
+        can2.SaveAs("%s/%s_%s_total_Zminus.png" % (theDirname, compounddetectorname, plot))
 
-    # Second Plot: BeamPipe + SEN + ELE + CAB + COL + SUP + OTH/AIR +
-    # Outside stack
-    stackTitle_Materials = "Tracker Material Budget;%s;%s" % (plots[plot].abscissa,
-                                                              plots[plot].ordinate)
-    stack_X0_Materials = THStack("stack_X0",stackTitle_Materials)
-    stack_X0_Materials.Add(hist_X0_detectors["BeamPipe"])
-    for label, [num, color, leg] in hist_label_to_num.iteritems():
-        stack_X0_Materials.Add(hist_X0_elements[label])
-
-    # canvas
-    can_Materials = TCanvas("can_Materials","can_Materials",800,800)
-    can_Materials.Range(0,0,25,25)
-    can_Materials.SetFillColor(kWhite)
-
-    # Draw
-    stack_X0_Materials.SetMinimum(plots[plot].ymin)
-    stack_X0_Materials.SetMaximum(plots[plot].ymax)
-    stack_X0_Materials.Draw("HIST")
-    stack_X0_Materials.GetXaxis().SetLimits(plots[plot].xmin, plots[plot].xmax)
-
-    # Legenda
-    theLegend_Materials = TLegend(0.180,0.8,0.95,0.92)
-    theLegend_Materials.SetNColumns(3)
-    theLegend_Materials.SetFillColor(0)
-    theLegend_Materials.SetBorderSize(0)
-
-    theLegend_Materials.AddEntry(hist_X0_detectors["BeamPipe"],  "Beam Pipe", "f")
-    for label, [num, color, leg] in hist_label_to_num.iteritems():
-        theLegend_Materials.AddEntry(hist_X0_elements[label], leg, "f")
-    theLegend_Materials.Draw()
-
-    # text
-    text_Materials = TPaveText(0.180,0.727,0.402,0.787,"NDC")
-    text_Materials.SetFillColor(0)
-    text_Materials.SetBorderSize(0)
-    text_Materials.AddText("CMS Simulation")
-    text_Materials.SetTextAlign(11)
-    text_Materials.Draw()
-
-    # Store
-    can_Materials.Update()
-    #can_Materials.SaveAs("%s/Tracker_Materials_%s.pdf" % (theDirname, plot))
-    #can_Materials.SaveAs("%s/Tracker_Materials_%s.root" % (theDirname, plot))
+        #Also print them to give them exact numbers
+        etavalues = []
+        matbudginX0 = []
+        matbudginIntLen = []
+        for binx in range(0,stack_X0_SubDetectors.GetStack().Last().GetXaxis().GetNbins()):
+            bincontent = stack_X0_SubDetectors.GetStack().Last().GetBinContent(binx) 
+            if bincontent == 0: continue
+            etavalues.append( stack_X0_SubDetectors.GetStack().Last().GetBinCenter(binx)  )
+            if plot == "x_vs_eta": 
+                matbudginX0.append( bincontent  )
+                d1 = {'Eta': etavalues, 'MatBudInX0': matbudginX0}
+                df1 = pd.DataFrame(data=d1).round(2)
+                df1.to_csv(r'/afs/cern.ch/work/a/apsallid/CMS/PFCalStudies/CMS-HGCAL/matbudV10fromVertexToBackofHGCal/CMSSW_11_0_X_2019-06-04-2300/src/Validation/Geometry/test/EtavsMatBudinXo.txt',sep=' ', index=False, header=False)
+                #print df1
+            if plot == "l_vs_eta": 
+                matbudginIntLen.append( bincontent )
+                d2 = {'Eta': etavalues, 'MatBudInIntLen': matbudginIntLen}
+                df2 = pd.DataFrame(data=d2).round(2)
+                df2.to_csv(r'/afs/cern.ch/work/a/apsallid/CMS/PFCalStudies/CMS-HGCAL/matbudV10fromVertexToBackofHGCal/CMSSW_11_0_X_2019-06-04-2300/src/Validation/Geometry/test/EtavsMatBudInIntLen.txt',sep=' ', index=False, header=False)
+                #print df2
 
     return cumulative_matbdg
+
+def createPlots2D_(plot, compounddetectorname):
+    """2D material budget map to know exactly what we are adding.
+    """
+
+    #IBs = ["InnerServices", "Phase2PixelBarrel", "TIB", "TIDF", "TIDB"]
+    theDirname = "Figures"
+
+    hist_X0_detectors = OrderedDict()
+    if plot not in plots.keys():
+        print("Error: chosen plot name not known %s" % plot)
+        return
+
+    # We need to keep the file content alive for the lifetime of the
+    # full function....
+    subDetectorFiles = []
+
+    hist_X0_elements = OrderedDict()
+    prof_X0_elements = OrderedDict()
+
+    for subDetector,color in DETECTORS.iteritems():
+        subDetectorFilename = "matbdg_%s.root" % subDetector
+        if not checkFile_(subDetectorFilename):
+            print("Error opening file: %s" % subDetectorFilename)
+            continue
+
+        subDetectorFiles.append(TFile(subDetectorFilename))
+        subDetectorFile = subDetectorFiles[-1]
+        print ("Opening file: %s" % subDetectorFilename)
+        prof_X0_XXX = subDetectorFile.Get("%d" % plots[plot].plotNumber)
+
+        #hist_X0_detectors[subDetector] = prof_X0_XXX
+        hist_X0_detectors[subDetector] = prof_X0_XXX.ProjectionXY("_pxy","B")
+        print subDetector
+
+    # First Plot: BeamPipe + Tracker + ECAL + HCal + HGCal + MB + MGNT
+ 
+    # Create "null" histo
+    minX = 1.03*hist_X0_detectors["BeamPipe"].GetXaxis().GetXmin()
+    maxX = 1.03*hist_X0_detectors["BeamPipe"].GetXaxis().GetXmax()
+    minY = 1.03*hist_X0_detectors["BeamPipe"].GetYaxis().GetXmin()
+    maxY = 1.03*hist_X0_detectors["BeamPipe"].GetYaxis().GetXmax()
+
+    frame = TH2F("frame", "", 10, minX, maxX, 10, minY, maxY);
+    frame.SetMinimum(0.1)
+    frame.SetMaximum(10.)
+    frame.GetXaxis().SetTickLength(frame.GetXaxis().GetTickLength()*0.50)
+    frame.GetYaxis().SetTickLength(frame.GetXaxis().GetTickLength()/4.)
+
+    hist2d_X0_total = hist_X0_detectors["BeamPipe"]
+
+    # stack
+    hist2dTitle = ('%s %s;%s;%s;%s' % (plots[plot].quotaName,
+                                       "All detectors",
+                                       plots[plot].abscissa,
+                                       plots[plot].ordinate,
+                                       plots[plot].quotaName))
+
+    hist2d_X0_total.SetTitle(hist2dTitle)
+    frame.SetTitle(hist2dTitle)
+    frame.SetTitleOffset(0.5,"Y")
+
+    #If here you put different histomin,histomaxin plot_utils you won't see anything 
+    #for the material plots. 
+    if plots[plot].histoMin != -1.:
+        hist2d_X0_total.SetMinimum(plots[plot].histoMin)
+    if plots[plot].histoMax != -1.:
+        hist2d_X0_total.SetMaximum(plots[plot].histoMax)
+
+    #
+    # canvas
+    can_SubDetectors = TCanvas("can_SubDetectors","can_SubDetectors",2480+248, 580+58+58)
+    can_SubDetectors.SetTopMargin(0.1)
+    can_SubDetectors.SetBottomMargin(0.1)
+    can_SubDetectors.SetLeftMargin(0.04)
+    can_SubDetectors.SetRightMargin(0.06)
+    can_SubDetectors.SetFillColor(kWhite)
+    gStyle.SetOptStat(0)
+    gStyle.SetTitleFillColor(0)
+    gStyle.SetTitleBorderSize(0)
+    gStyle.SetOptTitle(0)
+
+    hist2d_X0_total.GetYaxis().SetTickLength(hist2d_X0_total.GetXaxis().GetTickLength()/4.)
+    hist2d_X0_total.GetYaxis().SetTickLength(hist2d_X0_total.GetXaxis().GetTickLength()/4.)
+    hist2d_X0_total.SetTitleOffset(0.5,"Y")
+    hist2d_X0_total.GetYaxis().SetTitleOffset(0.50);
+    #hist2d_X0_total.GetXaxis().SetTitleOffset(1.15);
+    #hist2d_X0_total.GetXaxis().SetNoExponent(True)
+    #hist2d_X0_total.GetYaxis().SetNoExponent(True)
+
+
+    # colors
+    for det, color in DETECTORS.iteritems():
+        hist_X0_detectors[det].SetMarkerColor(color)
+        hist_X0_detectors[det].SetFillColor(color)
+
+    for det, histo in hist_X0_detectors.iteritems():
+        print det
+        histo.Draw("same")
+
+    # Legenda
+    theLegend_SubDetectors = TLegend(0.100,0.7,0.90,0.90)#(0.180,0.8,0.98,0.90)
+    theLegend_SubDetectors.SetNColumns(3)
+    theLegend_SubDetectors.SetFillColor(0)
+    theLegend_SubDetectors.SetFillStyle(0)
+    theLegend_SubDetectors.SetBorderSize(0)
+
+    for det, histo in hist_X0_detectors.iteritems():
+        theLegend_SubDetectors.AddEntry(histo, det,  "f")
+    #theLegend_SubDetectors.AddEntry(hgbound1, "HGCal Eta Boundaries [1.3, 3.0]",  "l") 
+
+    theLegend_SubDetectors.Draw()
+
+    
+    # text
+    text_SubDetectors = TPaveText(0.100,0.627,0.322,0.687,"NDC")#(0.180,0.727,0.402,0.787,"NDC")
+    text_SubDetectors.SetFillColor(0)
+    text_SubDetectors.SetBorderSize(0)
+    text_SubDetectors.AddText("CMS Simulation")
+    text_SubDetectors.SetTextAlign(11)
+    text_SubDetectors.Draw()
+    
+
+    #Add eta labels
+    keep_alive = []
+    if plots[plot].iDrawEta:
+        keep_alive.extend(drawEtaValues())
+    
+    # Store
+    can_SubDetectors.Update()
+    if not checkFile_(theDirname):
+        os.mkdir(theDirname)
+    can_SubDetectors.SaveAs("%s/MaterialBdg_%s_%s.png" % (theDirname, compounddetectorname, plot))
+    #It seems that it is too heavy to create .pdf and .root
+    #can_SubDetectors.SaveAs("%s/MaterialBdg_FromVertexToEndofHGCal_%s.pdf" % (theDirname, plot))
+    #can_SubDetectors.SaveAs("%s/MaterialBdg_FromVertexToEndofHGCal_%s.root" % (theDirname, plot))
+
+    hist2d_X0_total.GetXaxis().SetRangeUser( 0., 7000.)
+    #Draw eta values in the zoom case
+    keep_alive = []
+    keep_alive.extend(drawHalfEtaValues())
+    #hist2d_X0_total.Draw("COLZ") 
+    can_SubDetectors.Update()
+    can_SubDetectors.Modified()
+    can_SubDetectors.SaveAs("%s/MaterialBdg_%s_%s_Zpluszoom.png" % (theDirname, compounddetectorname, plot))
 
 def createPlotsReco_(reco_file, label, debug=False):
     """Cumulative material budget from reconstruction.
@@ -452,14 +592,13 @@ def createCompoundPlots(detector, plot):
         can2.SaveAs("%s/%s_%s_total_Zminus.png" % (theDirname, detector, plot))
  
 
-def create2DPlots(detector, plot, plotnum, plotmat):
+def create2DPlots(detector, plot, plotnum, plotmat, dosingledetector = True):
     """Produce the requested plot for the specified detector.
 
        Function that will plot the requested 2D-@plot for the
        specified @detector. The specified detector could either be a
        real detector or a compound one. The list of available plots
-       are the keys of plots dictionary (imported from plot_utils.
-
+       are the keys of plots dictionary imported from plot_utils.
     """
 
     #gStyle.Reset()
@@ -496,12 +635,17 @@ def create2DPlots(detector, plot, plotnum, plotmat):
 
     # histos
     prof2d_X0_det_total.__class__ = TProfile2D
-    #hist_X0_total = prof2d_X0_det_total.ProjectionXY()
+    hist_X0_total = prof2d_X0_det_total.ProjectionXY()
 
     # keep files live forever
     files = []
-    if detector in COMPOUNDS.keys():
-        for subDetector in COMPOUNDS[detector][1:]:
+    if detector in COMPOUNDS.keys() and not dosingledetector:
+        #When the loop was:
+        #for subDetector in COMPOUNDS[detector][1:]:
+        #and the detector was single it never went in the loop and read the single file 
+        #from above. I alter this to COMPOUNDS[detector] to do the multi material budget plot.
+        #This won't effect the single detector due to the alter in the if above
+        for subDetector in COMPOUNDS[detector]:
             # filenames of single components
             subDetectorFilename = "matbdg_%s.root" % subDetector
  
@@ -549,7 +693,10 @@ def create2DPlots(detector, plot, plotnum, plotmat):
                                        plots[plot].ordinate,
                                        plots[plot].quotaName))
 
-    hist2d_X0_total = prof2d_X0_det_total
+    if dosingledetector: 
+        hist2d_X0_total = prof2d_X0_det_total
+    else : 
+        hist2d_X0_total = hist_X0_total
     hist2d_X0_total.SetTitle(hist2dTitle)
     frame.SetTitle(hist2dTitle)
     frame.SetTitleOffset(0.5,"Y")
@@ -640,7 +787,8 @@ def create2DPlots(detector, plot, plotnum, plotmat):
     if plot == "x_vs_z_vs_Rsum" or plot == "l_vs_z_vs_Rsum" or plot == "x_vs_z_vs_Rsumcos" or plot == "l_vs_z_vs_Rsumcos" or plot == "x_vs_z_vs_Rloc" or plot == "l_vs_z_vs_Rloc" or  plot == "x_vs_z_vs_Rloccos" or plot == "l_vs_z_vs_Rloccos":
         #Z+
         #hist2d_X0_total.GetXaxis().SetLimits( 3100., 5200.)
-        hist2d_X0_total.GetXaxis().SetRangeUser( 3100., 5400.)
+        if dosingledetector: hist2d_X0_total.GetXaxis().SetRangeUser( 3100., 5400.)
+        else : hist2d_X0_total.GetXaxis().SetRangeUser( 0., 7000.)
         #Do not draw eta values in the zoom case
         keep_alive = []
         #hist2d_X0_total.Draw("COLZ") 
@@ -650,7 +798,8 @@ def create2DPlots(detector, plot, plotnum, plotmat):
         can2.SaveAs( "%s/%s/%s_%s%s_ZplusZoom.png" % (theDirname, "ZPlusZoom", detector, plot, plotmat))
         #Z-
         #hist2d_X0_total.GetXaxis().SetLimits( 3100., 5200.)
-        hist2d_X0_total.GetXaxis().SetRangeUser( -5400., -3100.)
+        if dosingledetector: hist2d_X0_total.GetXaxis().SetRangeUser( -5400., -3100.)
+        else : hist2d_X0_total.GetXaxis().SetRangeUser( 0., -7000.)
         #Do not draw eta values in the zoom case
         keep_alive = []
         #hist2d_X0_total.Draw("COLZ") 
@@ -770,6 +919,10 @@ if __name__ == '__main__':
                         help='Compare simulation and reco materials',
                         action='store_true',
                         default=False)
+    parser.add_argument('-m', '--multi',
+                        help='Combining multiple detectors',
+                        action='store_true',
+                        default=False)
     parser.add_argument('-s', '--single',
                         help='Material budget for single detector from simulation',
                         action='store_true',
@@ -791,6 +944,23 @@ if __name__ == '__main__':
             print("Error, missing label")
             raise RuntimeError
         materialBudget_Simul_vs_Reco(args.reco, args.label, debug=False)
+
+    if args.multi: 
+        #Material Budget plot from Vertex to end of HGCal
+        cumulative_matbdg_sim = createPlots_("x_vs_eta",args.detector)
+        cumulative_matbdg_sim = createPlots_("l_vs_eta",args.detector)
+        cumulative_matbdg_sim = createPlots2D_("x_vs_z_vs_Rsum",args.detector)
+        cumulative_matbdg_sim = createPlots2D_("l_vs_z_vs_Rsum",args.detector)
+
+        required_2DplotsForalldetectors = ["x_vs_z_vs_Rsum", "l_vs_z_vs_Rsum"]
+
+        for p in required_2DplotsForalldetectors:
+            #First the total
+            create2DPlots(args.detector, p, plots[p].plotNumber, "", not args.multi)
+            #Then, the rest
+            #for label, [num, color, leg] in hist_label_to_num.iteritems():
+                #print label, num, color, leg
+                #create2DPlots(args.detector, p, num + plots[p].plotNumber, leg)
 
     if args.single:
         if args.detector is None:

--- a/Validation/Geometry/test/runP_FromVertexUpToInFrontOfMuonStations_cfg.py
+++ b/Validation/Geometry/test/runP_FromVertexUpToInFrontOfMuonStations_cfg.py
@@ -1,0 +1,134 @@
+# In order to produce what you need (or in a loop)
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=BeamPipe
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=Tracker
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=ECAL
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=HCal
+##EndcapTimingLayer + Thermal Screen (Barrel Timing Layer is included in the Tracker)
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='EndcapTimingLayer + Thermal Screen'
+##Neutron Moderator + Thermal Screen
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Neutron Moderator + Thermal Screen'
+##HGCal + HGCal Service + Thermal Screen
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='HGCal + HGCal Service + Thermal Screen'
+##Solenoid Magnet
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Solenoid Magnet'
+##Muon Wheels and Cables
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Muon Wheels and Cables'
+
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+import sys, re
+
+process = cms.Process("PROD")
+
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+
+# The default geometry is Extended2023D41. If a different geoemtry
+# is needed, the appropriate flag has to be passed at command line,
+# e.g.: cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom="XYZ"
+
+# The default component to be monitored is the HGCal. If other
+# components need to be studied, they must be supplied, one at a time,
+# at the command line, e.g.: cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py
+# label="XYZ"
+
+from Validation.Geometry.plot_hgcal_utils import _LABELS2COMPS
+
+_ALLOWED_LABELS = _LABELS2COMPS.keys()
+
+options = VarParsing('analysis')
+options.register('geom',             #name
+                 'Extended2023D41',      #default value
+                 VarParsing.multiplicity.singleton,   # kind of options
+                 VarParsing.varType.string,           # type of option
+                 "Select the geometry to be studied"  # help message
+                )
+
+options.register('label',         #name
+                 'HGCal',              #default value
+                 VarParsing.multiplicity.singleton,   # kind of options
+                 VarParsing.varType.string,           # type of option
+                 "Select the label to be used to create output files. Default to HGCal. If multiple components are selected, it defaults to the join of all components, with '_' as separator."  # help message
+                )
+
+options.setDefault('inputFiles', ['file:single_neutrino_random.root'])
+
+options.parseArguments()
+# Option validation
+
+if options.label not in _ALLOWED_LABELS:
+    print "\n*** Error, '%s' not registered as a valid components to monitor." % options.label
+    print "Allowed components:", _ALLOWED_LABELS
+    print
+    raise RuntimeError("Unknown label")
+
+_components = _LABELS2COMPS[options.label]
+
+# Load geometry either from the Database of from files
+process.load("Configuration.Geometry.Geometry%s_cff" % options.geom)
+
+#
+#Magnetic Field
+#
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+
+# Output of events, etc...
+#
+# Explicit note : since some histos/tree might be dumped directly,
+#                 better NOT use PoolOutputModule !
+# Detector simulation (Geant4-based)
+#
+process.load("SimG4Core.Application.g4SimHits_cfi")
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(options.inputFiles)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.p1 = cms.Path(process.g4SimHits)
+process.g4SimHits.StackingAction.TrackNeutrino = cms.bool(True)
+process.g4SimHits.UseMagneticField = False
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/DummyPhysics'
+process.g4SimHits.Physics.DummyEMPhysics = True
+process.g4SimHits.Physics.CutsPerRegion = False
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    type = cms.string('MaterialBudgetAction'),
+    MaterialBudgetAction = cms.PSet(
+        HistosFile = cms.string('matbdg_%s.root' % options.label),
+        AllStepsToTree = cms.bool(True),
+        HistogramList = cms.string('HGCal'),
+        SelectedVolumes = cms.vstring(_components),
+        TreeFile = cms.string('None'), ## is NOT requested
+
+        StopAfterProcess = cms.string('None'),
+        #        TextFile = cms.string("matbdg_HGCal.txt")
+        TextFile = cms.string('None'), 
+        #Setting ranges for histos
+        #Make z 2mm per bin. Be careful this could lead to memory crashes if too low. 
+        minZ = cms.double(-7000.),
+        maxZ = cms.double(7000.),
+        nintZ = cms.int32(7000), 
+        # Make r 1cm per bin
+        rMin = cms.double(-50.), 
+        rMax = cms.double(8000.),
+        nrbin = cms.int32(805),
+        # eta
+        etaMin = cms.double(-5.), 
+        etaMax = cms.double(5.),
+        netabin = cms.int32(250),
+        # phi
+        phiMin = cms.double(-3.2), 
+        phiMax = cms.double(3.2),
+        nphibin = cms.int32(180),
+        # R for profile histos
+        RMin =  cms.double(0.), 
+        RMax =  cms.double(8000.), 
+        nRbin = cms.int32(800)
+
+     )
+))

--- a/Validation/Geometry/test/runP_FromVertexUpToInFrontOfMuonStations_cfg.py
+++ b/Validation/Geometry/test/runP_FromVertexUpToInFrontOfMuonStations_cfg.py
@@ -13,6 +13,8 @@
 #time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Solenoid Magnet'
 ##Muon Wheels and Cables
 #time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label='Muon Wheels and Cables'
+##Finally, all together 
+#time cmsRun runP_FromVertexUpToInFrontOfMuonStations_cfg.py geom=Extended2023D41 label=FromVertexToBackOfHGCal
 
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing

--- a/Validation/Geometry/test/runP_HGCal_cfg.py
+++ b/Validation/Geometry/test/runP_HGCal_cfg.py
@@ -95,7 +95,29 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
         TreeFile = cms.string('None'), ## is NOT requested
 
         StopAfterProcess = cms.string('None'),
-#        TextFile = cms.string("matbdg_HGCal.txt")
-        TextFile = cms.string('None')
-    )
+        #        TextFile = cms.string("matbdg_HGCal.txt")
+        TextFile = cms.string('None'), 
+        #Setting ranges for histos
+        #Make z 1mm per bin. Be careful this could lead to memory crashes if too low. 
+        minZ = cms.double(-5500.),
+        maxZ = cms.double(5500.),
+        nintZ = cms.int32(11000), 
+        # Make r 1cm per bin
+        rMin = cms.double(-50.), 
+        rMax = cms.double(3400.),
+        nrbin = cms.int32(345),
+        # eta
+        etaMin = cms.double(-5.), 
+        etaMax = cms.double(5.),
+        netabin = cms.int32(250),
+        # phi
+        phiMin = cms.double(-3.2), 
+        phiMax = cms.double(3.2),
+        nphibin = cms.int32(180),
+        # R for profile histos
+        RMin =  cms.double(0.), 
+        RMax =  cms.double(3000.), 
+        nRbin = cms.int32(300)
+
+     )
 ))


### PR DESCRIPTION
#### PR description:

The new V10 HGCal geometry in D41 scenario introduces significant reduction of material budget from V9 (~1.5λ). Motivated by the strong interest in how is this change effecting the Muon system, we estimated (@felicepantaleo , @rovere ) the total thickness, in nuclear interaction lengths, in front of Muon Stations versus eta, starting from the vertex. 

In this PR, we add the relevant changes that are necessary to perform the above study. Special care was taken so that the existing HGCal material budget study is not effected, so that someone can easily run both tasks without any conflict. 

#### PR validation:

The results of this work has been presented in the HGCal DPG [1] and we have checked that the standard HGCal material budget study presented previously [2] is not effected and the two can be run side by side. 

Detailed instructions on running the standard HGCal material budget study has been written in the HGCal webpage [3] while more instructions on the current study will be added in the same place. 

#### if this PR is a backport please specify the original PR:

This is not a backport. 

[1] https://indico.cern.ch/event/820095/contributions/3428509/attachments/1844946/3026574/MatBudInFrontofMuonStations_15May19.pdf

[2] https://indico.cern.ch/event/813555/contributions/3400815/attachments/1831509/2999507/Psallidas-MaterialBudgetV10.pdf

[3] http://hgcal.web.cern.ch/hgcal/MaterialBudget/MaterialBudget/
