### PR TITLE
Extend and fix RecHitTools

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
@@ -30,90 +30,86 @@ class HGCalRecHit;
 
 namespace hgcal {
 
-  class EGammaPCAHelper
-  {
-    public:
-      typedef ROOT::Math::Transform3D Transform3D;
-      typedef ROOT::Math::Transform3D::Point Point;
+  class EGammaPCAHelper {
+  public:
+    typedef ROOT::Math::Transform3D Transform3D;
+    typedef ROOT::Math::Transform3D::Point Point;
 
-      EGammaPCAHelper();
-      ~EGammaPCAHelper();
+    EGammaPCAHelper();
+    ~EGammaPCAHelper();
 
-      // for the GsfElectrons
-      void storeRecHits(const reco::CaloCluster & theCluster );
-      void storeRecHits(const reco::HGCalMultiCluster &cluster );
+    // for the GsfElectrons
+    void storeRecHits(const reco::CaloCluster &theCluster);
+    void storeRecHits(const reco::HGCalMultiCluster &cluster);
 
-      const TPrincipal & pcaResult();
-      /// to set from outside - once per event
-      void setHitMap( std::map<DetId,const HGCRecHit *> * hitMap) ;
-      /// to compute from inside - once per event
-      void fillHitMap(const HGCRecHitCollection & HGCEERecHits,
-                      const HGCRecHitCollection & HGCFHRecHits,
-                      const HGCRecHitCollection & HGCBHRecHits);
+    const TPrincipal &pcaResult();
+    /// to set from outside - once per event
+    void setHitMap(std::map<DetId, const HGCRecHit *> *hitMap);
+    /// to compute from inside - once per event
+    void fillHitMap(const HGCRecHitCollection &HGCEERecHits,
+                    const HGCRecHitCollection &HGCFHRecHits,
+                    const HGCRecHitCollection &HGCBHRecHits);
 
-      std::map<DetId,const HGCRecHit *> * getHitMap(){return hitMap_;}
+    std::map<DetId, const HGCRecHit *> *getHitMap() { return hitMap_; }
 
-      void setRecHitTools(const hgcal::RecHitTools * recHitTools );
+    void setRecHitTools(const hgcal::RecHitTools *recHitTools);
 
-      inline void setdEdXWeights(const std::vector<double> & dEdX){ dEdXWeights_ = dEdX;}
+    inline void setdEdXWeights(const std::vector<double> &dEdX) { dEdXWeights_ = dEdX; }
 
-      void pcaInitialComputation() {
-          computePCA(-1.,false);
-      }
+    void pcaInitialComputation() { computePCA(-1., false); }
 
-      void computePCA(float radius, bool withHalo=true);
-      const math::XYZPoint  & barycenter() const {return barycenter_;}
-      const math::XYZVector & axis() const {return axis_;}
+    void computePCA(float radius, bool withHalo = true);
+    const math::XYZPoint &barycenter() const { return barycenter_; }
+    const math::XYZVector &axis() const { return axis_; }
 
-      void computeShowerWidth(float radius, bool withHalo=true);
+    void computeShowerWidth(float radius, bool withHalo = true);
 
-      inline double sigmaUU() const { return checkIteration()? sigu_ : -1. ;}
-      inline double sigmaVV() const { return checkIteration()? sigv_ : -1. ;}
-      inline double sigmaEE() const { return checkIteration()? sige_ : -1. ;}
-      inline double sigmaPP() const { return checkIteration()? sigp_ : -1. ;}
+    inline double sigmaUU() const { return checkIteration() ? sigu_ : -1.; }
+    inline double sigmaVV() const { return checkIteration() ? sigv_ : -1.; }
+    inline double sigmaEE() const { return checkIteration() ? sige_ : -1.; }
+    inline double sigmaPP() const { return checkIteration() ? sigp_ : -1.; }
 
-      inline const TVectorD& eigenValues () const {return *pca_->GetEigenValues();}
-      inline const TVectorD& sigmas() const {return *pca_->GetSigmas();}
-      // contains maxlayer+1 values, first layer is [1]
-      LongDeps  energyPerLayer(float radius, bool withHalo=true) ;
+    inline const TVectorD &eigenValues() const { return *pca_->GetEigenValues(); }
+    inline const TVectorD &sigmas() const { return *pca_->GetSigmas(); }
+    // contains maxlayer+1 values, first layer is [1]
+    LongDeps energyPerLayer(float radius, bool withHalo = true);
 
-      float clusterDepthCompatibility(const LongDeps &, float & measuredDepth, float& expectedDepth, float& expectedSigma );
-      void printHits( float radius) const;
-      void clear();
+    float clusterDepthCompatibility(const LongDeps &, float &measuredDepth, float &expectedDepth, float &expectedSigma);
+    void printHits(float radius) const;
+    void clear();
 
-    private:
-      bool checkIteration() const ;
-      void storeRecHits(const std::vector<std::pair<DetId, float>> &hf);
-      float findZFirstLayer(const LongDeps&) const;
+  private:
+    bool checkIteration() const;
+    void storeRecHits(const std::vector<std::pair<DetId, float>> &hf);
+    float findZFirstLayer(const LongDeps &) const;
 
-      bool recHitsStored_;
-      bool debug_;
+    bool recHitsStored_;
+    bool debug_;
 
-      //parameters
-      std::vector<double> dEdXWeights_;
-      std::vector<double> invThicknessCorrection_;
+    //parameters
+    std::vector<double> dEdXWeights_;
+    std::vector<double> invThicknessCorrection_;
 
-      int hitMapOrigin_; // 0 not initialized; 1 set from outside ; 2 set from inside
-      const reco::CaloCluster * theCluster_;
-      std::map<DetId, const HGCRecHit *> * hitMap_;
-      std::vector<Spot> theSpots_;
-      int pcaIteration_;
-      unsigned int maxlayer_;
+    int hitMapOrigin_;  // 0 not initialized; 1 set from outside ; 2 set from inside
+    const reco::CaloCluster *theCluster_;
+    std::map<DetId, const HGCRecHit *> *hitMap_;
+    std::vector<Spot> theSpots_;
+    int pcaIteration_;
+    unsigned int maxlayer_;
 
-      // output quantities
-      math::XYZPoint barycenter_;
-      math::XYZVector axis_;
+    // output quantities
+    math::XYZPoint barycenter_;
+    math::XYZVector axis_;
 
-      Transform3D trans_;
-      double sigu_,sigv_,sige_,sigp_;
+    Transform3D trans_;
+    double sigu_, sigv_, sige_, sigp_;
 
-      // helper
-      std::unique_ptr<TPrincipal> pca_;
-      const hgcal::RecHitTools * recHitTools_;
-      ShowerDepth showerDepth_;
-
+    // helper
+    std::unique_ptr<TPrincipal> pca_;
+    const hgcal::RecHitTools *recHitTools_;
+    ShowerDepth showerDepth_;
   };
 
-}
+}  // namespace hgcal
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
@@ -98,6 +98,7 @@ namespace hgcal {
       std::map<DetId, const HGCRecHit *> * hitMap_;
       std::vector<Spot> theSpots_;
       int pcaIteration_;
+      unsigned int maxlayer;
 
       // output quantities
       math::XYZPoint barycenter_;

--- a/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
@@ -98,7 +98,7 @@ namespace hgcal {
       std::map<DetId, const HGCRecHit *> * hitMap_;
       std::vector<Spot> theSpots_;
       int pcaIteration_;
-      unsigned int maxlayer;
+      unsigned int maxlayer_;
 
       // output quantities
       math::XYZPoint barycenter_;

--- a/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
@@ -36,7 +36,7 @@ void EGammaPCAHelper::setHitMap( std::map<DetId,const HGCRecHit *> * hitMap) {
 
 void EGammaPCAHelper::setRecHitTools(const hgcal::RecHitTools * recHitTools ) {
     recHitTools_ = recHitTools;
-    maxlayer = recHitTools_->lastLayerBH();
+    maxlayer_ = recHitTools_->lastLayerBH();
 }
 
 void EGammaPCAHelper::fillHitMap(const HGCRecHitCollection & rechitsEE,
@@ -257,7 +257,7 @@ LongDeps  EGammaPCAHelper::energyPerLayer(float radius, bool withHalo) {
     if (debug_) checkIteration();
     std::set<int> layers;
     float radius2 = radius*radius;
-    std::vector<float> energyPerLayer(maxlayer+1, 0.f);
+    std::vector<float> energyPerLayer(maxlayer_+1, 0.f);
     math::XYZVector mainAxis(axis_);
     mainAxis.unit();
     math::XYZVector phiAxis(barycenter_.x(), barycenter_.y(), 0);
@@ -299,7 +299,7 @@ void EGammaPCAHelper::printHits(float radius) const {
 
 float EGammaPCAHelper::findZFirstLayer(const LongDeps & ld) const {
     unsigned int firstLayer = 0;
-    for(unsigned il=1;il<=maxlayer;++il) {
+    for(unsigned il=1;il<=maxlayer_;++il) {
         if (ld.energyPerLayer()[il] > 0.) {
             firstLayer = il;
             break;

--- a/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
@@ -13,206 +13,217 @@
 
 using namespace hgcal;
 
-EGammaPCAHelper::EGammaPCAHelper():
-  // Thickness correction to dEdx weights
-  // (100um, 200um, 300um silicon)
-  // See RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi
-  invThicknessCorrection_({1. / 1.132, 1. / 1.092, 1. / 1.084}),
-  pca_(new TPrincipal(3, "D")) {
-    hitMapOrigin_ = 0;
-    hitMap_ = new std::map<DetId, const HGCRecHit *>();
-    debug_ = false;
+EGammaPCAHelper::EGammaPCAHelper()
+    :  // Thickness correction to dEdx weights
+      // (100um, 200um, 300um silicon)
+      // See RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi
+      invThicknessCorrection_({1. / 1.132, 1. / 1.092, 1. / 1.084}),
+      pca_(new TPrincipal(3, "D")) {
+  hitMapOrigin_ = 0;
+  hitMap_ = new std::map<DetId, const HGCRecHit*>();
+  debug_ = false;
 }
 
 EGammaPCAHelper::~EGammaPCAHelper() {
-    if (hitMapOrigin_ == 2) delete hitMap_;
+  if (hitMapOrigin_ == 2)
+    delete hitMap_;
 }
 
-void EGammaPCAHelper::setHitMap( std::map<DetId,const HGCRecHit *> * hitMap) {
-    hitMapOrigin_ = 1;
-    hitMap_ = hitMap ;
-    pcaIteration_ = 0;
+void EGammaPCAHelper::setHitMap(std::map<DetId, const HGCRecHit*>* hitMap) {
+  hitMapOrigin_ = 1;
+  hitMap_ = hitMap;
+  pcaIteration_ = 0;
 }
 
-void EGammaPCAHelper::setRecHitTools(const hgcal::RecHitTools * recHitTools ) {
-    recHitTools_ = recHitTools;
-    maxlayer_ = recHitTools_->lastLayerBH();
+void EGammaPCAHelper::setRecHitTools(const hgcal::RecHitTools* recHitTools) {
+  recHitTools_ = recHitTools;
+  maxlayer_ = recHitTools_->lastLayerBH();
 }
 
-void EGammaPCAHelper::fillHitMap(const HGCRecHitCollection & rechitsEE,
-                                 const HGCRecHitCollection & rechitsFH,
-                                 const HGCRecHitCollection & rechitsBH) {
-    hitMap_->clear();
-    for (const auto& hit : rechitsEE) {
-        hitMap_->emplace_hint(hitMap_->end(), hit.detid(), &hit);
-    }
+void EGammaPCAHelper::fillHitMap(const HGCRecHitCollection& rechitsEE,
+                                 const HGCRecHitCollection& rechitsFH,
+                                 const HGCRecHitCollection& rechitsBH) {
+  hitMap_->clear();
+  for (const auto& hit : rechitsEE) {
+    hitMap_->emplace_hint(hitMap_->end(), hit.detid(), &hit);
+  }
 
-    for (const auto& hit : rechitsFH) {
-        hitMap_->emplace_hint(hitMap_->end(), hit.detid(), &hit);
-    }
+  for (const auto& hit : rechitsFH) {
+    hitMap_->emplace_hint(hitMap_->end(), hit.detid(), &hit);
+  }
 
-    for (const auto& hit : rechitsBH) {
-        hitMap_->emplace_hint(hitMap_->end(), hit.detid(), &hit);
-    }
+  for (const auto& hit : rechitsBH) {
+    hitMap_->emplace_hint(hitMap_->end(), hit.detid(), &hit);
+  }
 
-    pcaIteration_ = 0;
-    hitMapOrigin_ = 2;
+  pcaIteration_ = 0;
+  hitMapOrigin_ = 2;
 }
 
-void EGammaPCAHelper::storeRecHits(const reco::HGCalMultiCluster &cluster ){
-    theCluster_ = &cluster;
-    std::vector<std::pair<DetId, float>> result;
-    for (reco::HGCalMultiCluster::component_iterator it = cluster.begin(); it != cluster.end();
-    it++) {
-        const std::vector<std::pair<DetId, float>> &hf = (*it)->hitsAndFractions();
-        result.insert(result.end(),hf.begin(),hf.end());
-    }
-    storeRecHits(result);
+void EGammaPCAHelper::storeRecHits(const reco::HGCalMultiCluster& cluster) {
+  theCluster_ = &cluster;
+  std::vector<std::pair<DetId, float>> result;
+  for (reco::HGCalMultiCluster::component_iterator it = cluster.begin(); it != cluster.end(); it++) {
+    const std::vector<std::pair<DetId, float>>& hf = (*it)->hitsAndFractions();
+    result.insert(result.end(), hf.begin(), hf.end());
+  }
+  storeRecHits(result);
 }
 
-void EGammaPCAHelper::storeRecHits(const reco::CaloCluster & cluster) {
-    theCluster_ = &cluster;
-    storeRecHits(cluster.hitsAndFractions());
+void EGammaPCAHelper::storeRecHits(const reco::CaloCluster& cluster) {
+  theCluster_ = &cluster;
+  storeRecHits(cluster.hitsAndFractions());
 }
 
-void EGammaPCAHelper::storeRecHits(const std::vector<std::pair<DetId, float>> &hf) {
-    std::vector<double> pcavars;
-    pcavars.resize(3,0.);
-    theSpots_.clear();
-    pcaIteration_ = 0;
+void EGammaPCAHelper::storeRecHits(const std::vector<std::pair<DetId, float>>& hf) {
+  std::vector<double> pcavars;
+  pcavars.resize(3, 0.);
+  theSpots_.clear();
+  pcaIteration_ = 0;
 
-    sigu_ = 0.;
-    sigv_ = 0.;
-    sigp_ = 0.;
-    sige_ = 0.;
+  sigu_ = 0.;
+  sigv_ = 0.;
+  sigp_ = 0.;
+  sige_ = 0.;
 
-    unsigned hfsize = hf.size();
-    if (debug_)
-        std::cout << "The seed cluster constains " << hfsize << " hits " << std::endl;
+  unsigned hfsize = hf.size();
+  if (debug_)
+    std::cout << "The seed cluster constains " << hfsize << " hits " << std::endl;
 
-    if (hfsize == 0) return;
+  if (hfsize == 0)
+    return;
 
+  for (unsigned int j = 0; j < hfsize; j++) {
+    unsigned int layer = recHitTools_->getLayerWithOffset(hf[j].first);
 
-    for (unsigned int j = 0; j < hfsize; j++) {
-        unsigned int layer = recHitTools_->getLayerWithOffset(hf[j].first);
-
-        const DetId rh_detid = hf[j].first;
-        std::map<DetId,const HGCRecHit *>::const_iterator itcheck= hitMap_->find(rh_detid);
-        if (itcheck == hitMap_->end()) {
-            edm::LogWarning("EgammaPCAHelper") << " Big problem, unable to find a hit " << rh_detid.rawId() << " " << rh_detid.det() << " " << HGCalDetId(rh_detid) << std::endl;
-            continue;
-        }
-        if (debug_) {
-            std::cout << "DetId " << rh_detid.rawId() << " " << layer << " " <<  itcheck->second->energy() <<std::endl;
-            std::cout << " Hit " << itcheck->second << " " << itcheck->second->energy() << std::endl;
-        }
-        float fraction = hf[j].second;
-
-        int thickIndex = recHitTools_->getSiThickIndex(rh_detid);
-        double mip = dEdXWeights_[layer] * 0.001;  // convert in GeV
-        if(thickIndex>-1 and thickIndex<3) mip *= invThicknessCorrection_[thickIndex];
-
-        pcavars[0] = recHitTools_->getPosition(rh_detid).x();
-        pcavars[1] = recHitTools_->getPosition(rh_detid).y();
-        pcavars[2] = recHitTools_->getPosition(rh_detid).z();
-        if (pcavars[2] == 0.)
-            edm::LogWarning("EgammaPCAHelper") << " Problem, hit with z =0 ";
-        else  {
-            Spot mySpot(rh_detid,itcheck->second->energy(),pcavars,layer,fraction,mip);
-            theSpots_.push_back(mySpot);
-        }
+    const DetId rh_detid = hf[j].first;
+    std::map<DetId, const HGCRecHit*>::const_iterator itcheck = hitMap_->find(rh_detid);
+    if (itcheck == hitMap_->end()) {
+      edm::LogWarning("EgammaPCAHelper") << " Big problem, unable to find a hit " << rh_detid.rawId() << " "
+                                         << rh_detid.det() << " " << HGCalDetId(rh_detid) << std::endl;
+      continue;
     }
     if (debug_) {
-        std::cout << " Stored " << theSpots_.size() << " hits " << std::endl;
+      std::cout << "DetId " << rh_detid.rawId() << " " << layer << " " << itcheck->second->energy() << std::endl;
+      std::cout << " Hit " << itcheck->second << " " << itcheck->second->energy() << std::endl;
     }
+    float fraction = hf[j].second;
+
+    int thickIndex = recHitTools_->getSiThickIndex(rh_detid);
+    double mip = dEdXWeights_[layer] * 0.001;  // convert in GeV
+    if (thickIndex > -1 and thickIndex < 3)
+      mip *= invThicknessCorrection_[thickIndex];
+
+    pcavars[0] = recHitTools_->getPosition(rh_detid).x();
+    pcavars[1] = recHitTools_->getPosition(rh_detid).y();
+    pcavars[2] = recHitTools_->getPosition(rh_detid).z();
+    if (pcavars[2] == 0.)
+      edm::LogWarning("EgammaPCAHelper") << " Problem, hit with z =0 ";
+    else {
+      Spot mySpot(rh_detid, itcheck->second->energy(), pcavars, layer, fraction, mip);
+      theSpots_.push_back(mySpot);
+    }
+  }
+  if (debug_) {
+    std::cout << " Stored " << theSpots_.size() << " hits " << std::endl;
+  }
 }
 
-void EGammaPCAHelper::computePCA(float radius , bool withHalo) {
-    // very important - to reset
-    pca_.reset(new TPrincipal(3, "D"));
-    bool initialCalculation = radius < 0;
-    if (debug_)
-        std::cout << " Initial calculation " << initialCalculation << std::endl;
-    if (initialCalculation && withHalo) {
-        edm::LogWarning("EGammaPCAHelper") << "Warning - in the first iteration, the halo hits are excluded " << std::endl;
-        withHalo=false;
-    }
+void EGammaPCAHelper::computePCA(float radius, bool withHalo) {
+  // very important - to reset
+  pca_.reset(new TPrincipal(3, "D"));
+  bool initialCalculation = radius < 0;
+  if (debug_)
+    std::cout << " Initial calculation " << initialCalculation << std::endl;
+  if (initialCalculation && withHalo) {
+    edm::LogWarning("EGammaPCAHelper") << "Warning - in the first iteration, the halo hits are excluded " << std::endl;
+    withHalo = false;
+  }
 
-    float radius2 = radius*radius;
-    if (! initialCalculation)     {
-        math::XYZVector mainAxis(axis_);
-        mainAxis.unit();
-        math::XYZVector phiAxis(barycenter_.x(), barycenter_.y(), 0);
-        math::XYZVector udir(mainAxis.Cross(phiAxis));
-        udir = udir.unit();
-        trans_ = Transform3D(Point(barycenter_), Point(barycenter_ + axis_), Point(barycenter_ + udir), Point(0, 0, 0),
-        Point(0., 0., 1.), Point(1., 0., 0.));
-    }
+  float radius2 = radius * radius;
+  if (!initialCalculation) {
+    math::XYZVector mainAxis(axis_);
+    mainAxis.unit();
+    math::XYZVector phiAxis(barycenter_.x(), barycenter_.y(), 0);
+    math::XYZVector udir(mainAxis.Cross(phiAxis));
+    udir = udir.unit();
+    trans_ = Transform3D(Point(barycenter_),
+                         Point(barycenter_ + axis_),
+                         Point(barycenter_ + udir),
+                         Point(0, 0, 0),
+                         Point(0., 0., 1.),
+                         Point(1., 0., 0.));
+  }
 
-    std::set<int> layers;
-    for (const auto& spot : theSpots_) {
-        if (spot.layer() > recHitTools_->lastLayerEE()) continue;
-        if (!withHalo && (! spot.isCore() ))
-            continue;
-        if (initialCalculation) {
-            // initial calculation, take only core hits
-            if ( ! spot.isCore() ) continue;
-            layers.insert(spot.layer());
-            for (int i = 0; i < spot.multiplicity(); ++i)
-                pca_->AddRow(spot.row());
-        }
-        else {
-            // use a cylinder, include all hits
-            math::XYZPoint local = trans_(Point( spot.row()[0],spot.row()[1],spot.row()[2]));
-            if (local.Perp2() > radius2) continue;
-            layers.insert(spot.layer());
-            for (int i = 0; i < spot.multiplicity(); ++i)
-                pca_->AddRow(spot.row());
-        }
+  std::set<int> layers;
+  for (const auto& spot : theSpots_) {
+    if (spot.layer() > recHitTools_->lastLayerEE())
+      continue;
+    if (!withHalo && (!spot.isCore()))
+      continue;
+    if (initialCalculation) {
+      // initial calculation, take only core hits
+      if (!spot.isCore())
+        continue;
+      layers.insert(spot.layer());
+      for (int i = 0; i < spot.multiplicity(); ++i)
+        pca_->AddRow(spot.row());
+    } else {
+      // use a cylinder, include all hits
+      math::XYZPoint local = trans_(Point(spot.row()[0], spot.row()[1], spot.row()[2]));
+      if (local.Perp2() > radius2)
+        continue;
+      layers.insert(spot.layer());
+      for (int i = 0; i < spot.multiplicity(); ++i)
+        pca_->AddRow(spot.row());
     }
-    if (debug_)
-        std::cout << " Nlayers " << layers.size() << std::endl;
-    if (layers.size() < 3) {
-        pcaIteration_ = -1;
-        return;
-    }
-    pca_->MakePrincipals();
-    ++pcaIteration_;
-    const TVectorD& means = *(pca_->GetMeanValues());
-    const TMatrixD& eigens = *(pca_->GetEigenVectors());
+  }
+  if (debug_)
+    std::cout << " Nlayers " << layers.size() << std::endl;
+  if (layers.size() < 3) {
+    pcaIteration_ = -1;
+    return;
+  }
+  pca_->MakePrincipals();
+  ++pcaIteration_;
+  const TVectorD& means = *(pca_->GetMeanValues());
+  const TMatrixD& eigens = *(pca_->GetEigenVectors());
 
-    barycenter_ = math::XYZPoint(means[0], means[1], means[2]);
-    axis_ = math::XYZVector(eigens(0, 0), eigens(1, 0), eigens(2, 0));
-    if (axis_.z() * barycenter_.z() < 0.0) {
-        axis_ = -1. * axis_;
-    }
+  barycenter_ = math::XYZPoint(means[0], means[1], means[2]);
+  axis_ = math::XYZVector(eigens(0, 0), eigens(1, 0), eigens(2, 0));
+  if (axis_.z() * barycenter_.z() < 0.0) {
+    axis_ = -1. * axis_;
+  }
 }
 
- void EGammaPCAHelper::computeShowerWidth(float radius, bool withHalo){
-    sigu_ = 0.;
-    sigv_ = 0.;
-    sigp_ = 0.;
-    sige_ = 0.;
-    double cyl_ene = 0.;
+void EGammaPCAHelper::computeShowerWidth(float radius, bool withHalo) {
+  sigu_ = 0.;
+  sigv_ = 0.;
+  sigp_ = 0.;
+  sige_ = 0.;
+  double cyl_ene = 0.;
 
-    float radius2 = radius * radius;
-    for (const auto& spot : theSpots_) {
-        Point globalPoint(spot.row()[0],spot.row()[1],spot.row()[2]);
-        math::XYZPoint local = trans_(globalPoint);
-        if (local.Perp2() > radius2) continue;
+  float radius2 = radius * radius;
+  for (const auto& spot : theSpots_) {
+    Point globalPoint(spot.row()[0], spot.row()[1], spot.row()[2]);
+    math::XYZPoint local = trans_(globalPoint);
+    if (local.Perp2() > radius2)
+      continue;
 
-        // Select halo hits or not
-        if (withHalo && spot.fraction() < 0) continue;
-        if (!withHalo && !(spot.isCore())) continue;
+    // Select halo hits or not
+    if (withHalo && spot.fraction() < 0)
+      continue;
+    if (!withHalo && !(spot.isCore()))
+      continue;
 
-        sige_ += (globalPoint.eta() - theCluster_->eta()) * (globalPoint.eta() - theCluster_->eta()) * spot.energy();
-        sigp_ += deltaPhi(globalPoint.phi(), theCluster_->phi()) * deltaPhi(globalPoint.phi(), theCluster_->phi()) *
-              spot.energy();
+    sige_ += (globalPoint.eta() - theCluster_->eta()) * (globalPoint.eta() - theCluster_->eta()) * spot.energy();
+    sigp_ += deltaPhi(globalPoint.phi(), theCluster_->phi()) * deltaPhi(globalPoint.phi(), theCluster_->phi()) *
+             spot.energy();
 
-        sigu_ += local.x() * local.x() * spot.energy();
-        sigv_ += local.y() * local.y() * spot.energy();
-        cyl_ene += spot.energy();
-    }
+    sigu_ += local.x() * local.x() * spot.energy();
+    sigv_ += local.y() * local.y() * spot.energy();
+    cyl_ene += spot.energy();
+  }
 
   if (cyl_ene > 0.) {
     const double inv_cyl_ene = 1. / cyl_ene;
@@ -228,95 +239,109 @@ void EGammaPCAHelper::computePCA(float radius , bool withHalo) {
 }
 
 bool EGammaPCAHelper::checkIteration() const {
-    if (pcaIteration_ == 0) {
-        if(debug_)
-            std::cout << " The PCA has not been run yet " << std::endl;
-        return false;
-    }   else if (pcaIteration_ == 1) {
-        if (debug_)
-            std::cout << " The PCA has been run only once - careful " << std::endl;
-        return false;
-    }   else if (pcaIteration_ == -1){
-        if (debug_)
-            std::cout << " Not enough layers to perform PCA " << std::endl;
-        return false;
-    }
-    return true;
+  if (pcaIteration_ == 0) {
+    if (debug_)
+      std::cout << " The PCA has not been run yet " << std::endl;
+    return false;
+  } else if (pcaIteration_ == 1) {
+    if (debug_)
+      std::cout << " The PCA has been run only once - careful " << std::endl;
+    return false;
+  } else if (pcaIteration_ == -1) {
+    if (debug_)
+      std::cout << " Not enough layers to perform PCA " << std::endl;
+    return false;
+  }
+  return true;
 }
 
 void EGammaPCAHelper::clear() {
-    theSpots_.clear();
-    pcaIteration_ = 0;
-    sigu_ = 0.;
-    sigv_ = 0.;
-    sigp_ = 0.;
-    sige_ = 0.;
+  theSpots_.clear();
+  pcaIteration_ = 0;
+  sigu_ = 0.;
+  sigv_ = 0.;
+  sigp_ = 0.;
+  sige_ = 0.;
 }
 
-LongDeps  EGammaPCAHelper::energyPerLayer(float radius, bool withHalo) {
-    if (debug_) checkIteration();
-    std::set<int> layers;
-    float radius2 = radius*radius;
-    std::vector<float> energyPerLayer(maxlayer_+1, 0.f);
-    math::XYZVector mainAxis(axis_);
-    mainAxis.unit();
-    math::XYZVector phiAxis(barycenter_.x(), barycenter_.y(), 0);
-    math::XYZVector udir(mainAxis.Cross(phiAxis));
-    udir = udir.unit();
-    trans_ = Transform3D(Point(barycenter_), Point(barycenter_ + axis_), Point(barycenter_ + udir), Point(0, 0, 0),
-    Point(0., 0., 1.), Point(1., 0., 0.));
-    float energyEE = 0.;
-    float energyFH = 0.;
-    float energyBH = 0.;
+LongDeps EGammaPCAHelper::energyPerLayer(float radius, bool withHalo) {
+  if (debug_)
+    checkIteration();
+  std::set<int> layers;
+  float radius2 = radius * radius;
+  std::vector<float> energyPerLayer(maxlayer_ + 1, 0.f);
+  math::XYZVector mainAxis(axis_);
+  mainAxis.unit();
+  math::XYZVector phiAxis(barycenter_.x(), barycenter_.y(), 0);
+  math::XYZVector udir(mainAxis.Cross(phiAxis));
+  udir = udir.unit();
+  trans_ = Transform3D(Point(barycenter_),
+                       Point(barycenter_ + axis_),
+                       Point(barycenter_ + udir),
+                       Point(0, 0, 0),
+                       Point(0., 0., 1.),
+                       Point(1., 0., 0.));
+  float energyEE = 0.;
+  float energyFH = 0.;
+  float energyBH = 0.;
 
-    for (const auto& spot : theSpots_) {
-        if (!withHalo && ! spot.isCore())
-            continue;
-        math::XYZPoint local = trans_(Point( spot.row()[0],spot.row()[1],spot.row()[2]));
-        if (local.Perp2() > radius2) continue;
-        energyPerLayer[spot.layer()] += spot.energy();
-        layers.insert(spot.layer());
-        if (spot.detId().det() == DetId::HGCalEE or spot.subdet() == HGCEE) { energyEE += spot.energy();}
-        else if (spot.detId().det() == DetId::HGCalHSi or spot.subdet() == HGCHEF) { energyFH += spot.energy();}
-        else if (spot.detId().det() == DetId::HGCalHSc or spot.subdet() == HGCHEB) { energyBH += spot.energy();}
-
+  for (const auto& spot : theSpots_) {
+    if (!withHalo && !spot.isCore())
+      continue;
+    math::XYZPoint local = trans_(Point(spot.row()[0], spot.row()[1], spot.row()[2]));
+    if (local.Perp2() > radius2)
+      continue;
+    energyPerLayer[spot.layer()] += spot.energy();
+    layers.insert(spot.layer());
+    if (spot.detId().det() == DetId::HGCalEE or spot.subdet() == HGCEE) {
+      energyEE += spot.energy();
+    } else if (spot.detId().det() == DetId::HGCalHSi or spot.subdet() == HGCHEF) {
+      energyFH += spot.energy();
+    } else if (spot.detId().det() == DetId::HGCalHSc or spot.subdet() == HGCHEB) {
+      energyBH += spot.energy();
     }
-    return LongDeps(radius,energyPerLayer,energyEE,energyFH,energyBH,layers);
+  }
+  return LongDeps(radius, energyPerLayer, energyEE, energyFH, energyBH, layers);
 }
 
 void EGammaPCAHelper::printHits(float radius) const {
-    unsigned nSpots = theSpots_.size();
-    float radius2=radius*radius;
-    for ( unsigned i =0; i< nSpots ; ++i) {
-        Spot spot(theSpots_[i]);
-        math::XYZPoint local = trans_(Point( spot.row()[0],spot.row()[1],spot.row()[2]));
-        if (local.Perp2() < radius2 ) {
-            std::cout << i << "  " << theSpots_[i].detId().rawId() << " " << theSpots_[i].layer() << " " << theSpots_[i].energy() << " " <<theSpots_[i].isCore() ;
-            std::cout << " " << std::sqrt(local.Perp2()) << std::endl;
-        }
+  unsigned nSpots = theSpots_.size();
+  float radius2 = radius * radius;
+  for (unsigned i = 0; i < nSpots; ++i) {
+    Spot spot(theSpots_[i]);
+    math::XYZPoint local = trans_(Point(spot.row()[0], spot.row()[1], spot.row()[2]));
+    if (local.Perp2() < radius2) {
+      std::cout << i << "  " << theSpots_[i].detId().rawId() << " " << theSpots_[i].layer() << " "
+                << theSpots_[i].energy() << " " << theSpots_[i].isCore();
+      std::cout << " " << std::sqrt(local.Perp2()) << std::endl;
     }
+  }
 }
 
-float EGammaPCAHelper::findZFirstLayer(const LongDeps & ld) const {
-    unsigned int firstLayer = 0;
-    for(unsigned il=1;il<=maxlayer_;++il) {
-        if (ld.energyPerLayer()[il] > 0.) {
-            firstLayer = il;
-            break;
-        }
+float EGammaPCAHelper::findZFirstLayer(const LongDeps& ld) const {
+  unsigned int firstLayer = 0;
+  for (unsigned il = 1; il <= maxlayer_; ++il) {
+    if (ld.energyPerLayer()[il] > 0.) {
+      firstLayer = il;
+      break;
     }
-    // Make dummy DetId to get abs(z) for layer
-    return recHitTools_->getPositionLayer(firstLayer).z();
+  }
+  // Make dummy DetId to get abs(z) for layer
+  return recHitTools_->getPositionLayer(firstLayer).z();
 }
 
-float EGammaPCAHelper::clusterDepthCompatibility(const LongDeps & ld, float & measuredDepth, float& expectedDepth, float&expectedSigma) {
-    expectedDepth = -999.;
-    expectedSigma = -999.;
-    measuredDepth = -999.;
-    if (!checkIteration()) return -999.;
+float EGammaPCAHelper::clusterDepthCompatibility(const LongDeps& ld,
+                                                 float& measuredDepth,
+                                                 float& expectedDepth,
+                                                 float& expectedSigma) {
+  expectedDepth = -999.;
+  expectedSigma = -999.;
+  measuredDepth = -999.;
+  if (!checkIteration())
+    return -999.;
 
-    float z = findZFirstLayer(ld);
-    math::XYZVector dir=axis_.unit();
-    measuredDepth = std::abs((z-std::abs(barycenter_.z()))/dir.z());
-    return showerDepth_.getClusterDepthCompatibility(measuredDepth,ld.energyEE(), expectedDepth,expectedSigma);
+  float z = findZFirstLayer(ld);
+  math::XYZVector dir = axis_.unit();
+  measuredDepth = std::abs((z - std::abs(barycenter_.z())) / dir.z());
+  return showerDepth_.getClusterDepthCompatibility(measuredDepth, ld.energyEE(), expectedDepth, expectedSigma);
 }

--- a/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
@@ -8,10 +8,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// To retrieve HGCalImagingAlgo::maxlayer
-// Also available as HGCal3DClustering::lastLayerBH and HGCalDepthPreClusterer::lastLayerBH
-#include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
-
 #include <algorithm>
 #include <iostream>
 
@@ -40,6 +36,7 @@ void EGammaPCAHelper::setHitMap( std::map<DetId,const HGCRecHit *> * hitMap) {
 
 void EGammaPCAHelper::setRecHitTools(const hgcal::RecHitTools * recHitTools ) {
     recHitTools_ = recHitTools;
+    maxlayer = recHitTools_->lastLayerBH();
 }
 
 void EGammaPCAHelper::fillHitMap(const HGCRecHitCollection & rechitsEE,
@@ -260,7 +257,7 @@ LongDeps  EGammaPCAHelper::energyPerLayer(float radius, bool withHalo) {
     if (debug_) checkIteration();
     std::set<int> layers;
     float radius2 = radius*radius;
-    std::vector<float> energyPerLayer(HGCalClusteringAlgoBase::maxlayer+1, 0.f);
+    std::vector<float> energyPerLayer(maxlayer+1, 0.f);
     math::XYZVector mainAxis(axis_);
     mainAxis.unit();
     math::XYZVector phiAxis(barycenter_.x(), barycenter_.y(), 0);
@@ -302,7 +299,7 @@ void EGammaPCAHelper::printHits(float radius) const {
 
 float EGammaPCAHelper::findZFirstLayer(const LongDeps & ld) const {
     unsigned int firstLayer = 0;
-    for(unsigned il=1;il<=HGCalClusteringAlgoBase::maxlayer;++il) {
+    for(unsigned il=1;il<=maxlayer;++il) {
         if (ld.energyPerLayer()[il] > 0.) {
             firstLayer = il;
             break;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -1,7 +1,6 @@
 #ifndef RecoLocalCalo_HGCalRecAlgos_HGCal3DClustering
 #define RecoLocalCalo_HGCalRecAlgos_HGCal3DClustering
 
-
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h"
@@ -15,30 +14,27 @@
 
 #include "CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h"
 
-class HGCal3DClustering
-{
+class HGCal3DClustering {
 public:
+  HGCal3DClustering() : radii({0., 0., 0.}), minClusters(0), clusterTools(nullptr) {}
 
- HGCal3DClustering() : radii({0.,0.,0.}), minClusters(0), clusterTools(nullptr)
-  {
-  }
+  HGCal3DClustering(const edm::ParameterSet& conf,
+                    edm::ConsumesCollector& sumes,
+                    const std::vector<double>& radii_in,
+                    uint32_t min_clusters)
+      : radii(radii_in),
+        minClusters(min_clusters),
+        es(0),
+        clusterTools(std::make_unique<hgcal::ClusterTools>(conf, sumes)) {}
 
-  HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes, const std::vector<double>& radii_in, uint32_t min_clusters) :
-   radii(radii_in),
-   minClusters(min_clusters),
-   es(0),
-   clusterTools(std::make_unique<hgcal::ClusterTools>(conf,sumes))
-   {
-   }
-
-
-   HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes) :
-     HGCal3DClustering(conf, sumes, conf.getParameter<std::vector<double>>("multiclusterRadii"),
-         conf.getParameter<unsigned>("minClusters")) {}
+  HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : HGCal3DClustering(conf,
+                          sumes,
+                          conf.getParameter<std::vector<double>>("multiclusterRadii"),
+                          conf.getParameter<unsigned>("minClusters")) {}
 
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
-  void getEventSetup(const edm::EventSetup& es)
-  {
+  void getEventSetup(const edm::EventSetup& es) {
     clusterTools->getEventSetup(es);
     rhtools_.getEventSetup(es);
     maxlayer = rhtools_.lastLayerBH();
@@ -46,33 +42,32 @@ public:
     minpos.clear();
     maxpos.clear();
     zees.clear();
-    points.resize(2*(maxlayer+1));
-    minpos.resize(2*(maxlayer+1),{ {0.0f,0.0f} });
-    maxpos.resize(2*(maxlayer+1),{ {0.0f,0.0f} });
-    zees.resize(2*(maxlayer+1),0.);
+    points.resize(2 * (maxlayer + 1));
+    minpos.resize(2 * (maxlayer + 1), {{0.0f, 0.0f}});
+    maxpos.resize(2 * (maxlayer + 1), {{0.0f, 0.0f}});
+    zees.resize(2 * (maxlayer + 1), 0.);
   }
 
   typedef std::vector<reco::BasicCluster> ClusterCollection;
 
-  std::vector<reco::HGCalMultiCluster> makeClusters(const reco::HGCalMultiCluster::ClusterCollection &);
+  std::vector<reco::HGCalMultiCluster> makeClusters(const reco::HGCalMultiCluster::ClusterCollection&);
 
 private:
-
-  void organizeByLayer(const reco::HGCalMultiCluster::ClusterCollection &);
-  void reset(){
-    for( auto& it: points)
-      {
-        it.clear();
-        std::vector<KDNode>().swap(it);
-      }
+  void organizeByLayer(const reco::HGCalMultiCluster::ClusterCollection&);
+  void reset() {
+    for (auto& it : points) {
+      it.clear();
+      std::vector<KDNode>().swap(it);
+    }
     std::fill(zees.begin(), zees.end(), 0.);
-    for(unsigned int i = 0; i < minpos.size(); i++)
-      {
-	minpos[i][0]=0.;minpos[i][1]=0.;
-	maxpos[i][0]=0.;maxpos[i][1]=0.;
-      }
+    for (unsigned int i = 0; i < minpos.size(); i++) {
+      minpos[i][0] = 0.;
+      minpos[i][1] = 0.;
+      maxpos[i][0] = 0.;
+      maxpos[i][1] = 0.;
+    }
   }
-  void layerIntersection(std::array<double,3> &to, const std::array<double,3> &from) const;
+  void layerIntersection(std::array<double, 3>& to, const std::array<double, 3>& from) const;
 
   //max number of layers
   unsigned int maxlayer;
@@ -82,20 +77,19 @@ private:
   struct ClusterRef {
     int ind;
     float z;
-    ClusterRef(int ind_i, float z_i): ind(ind_i),z(z_i){}
-    ClusterRef(): ind(-1),z(0.){}
+    ClusterRef(int ind_i, float z_i) : ind(ind_i), z(z_i) {}
+    ClusterRef() : ind(-1), z(0.) {}
   };
 
   typedef KDTreeLinkerAlgo<ClusterRef> KDTree;
   typedef KDTreeNodeInfo<ClusterRef> KDNode;
-  std::vector< std::vector<KDNode> > points;
-  std::vector<std::array<float,2> > minpos;
-  std::vector<std::array<float,2> > maxpos;
-  std::vector<size_t> es; /*!< vector to contain sorted indices of all clusters. */
-  std::vector<float> zees; /*!< vector to contain z position of each layer. */
+  std::vector<std::vector<KDNode>> points;
+  std::vector<std::array<float, 2>> minpos;
+  std::vector<std::array<float, 2>> maxpos;
+  std::vector<size_t> es;                            /*!< vector to contain sorted indices of all clusters. */
+  std::vector<float> zees;                           /*!< vector to contain z position of each layer. */
   std::unique_ptr<hgcal::ClusterTools> clusterTools; /*!< instance of tools to simplify cluster access. */
-  hgcal::RecHitTools rhtools_; /*!< instance of tools to access RecHit information. */
-
+  hgcal::RecHitTools rhtools_;                       /*!< instance of tools to access RecHit information. */
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -45,6 +45,7 @@ public:
   {
     clusterTools->getEventSetup(es);
     rhtools_.getEventSetup(es);
+    maxlayer = rhtools_.lastLayerBH();
   }
 
   typedef std::vector<reco::BasicCluster> ClusterCollection;
@@ -70,7 +71,7 @@ private:
   void layerIntersection(std::array<double,3> &to, const std::array<double,3> &from) const;
 
   //max number of layers
-  static const unsigned int maxlayer = HGCalClusteringAlgoBase::maxlayer;
+  unsigned int maxlayer;
 
   std::vector<double> radii;
   uint32_t minClusters;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -26,11 +26,7 @@ public:
   HGCal3DClustering(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes, const std::vector<double>& radii_in, uint32_t min_clusters) :
    radii(radii_in),
    minClusters(min_clusters),
-   points(2*(maxlayer+1)),
-   minpos(2*(maxlayer+1),{ {0.0f,0.0f} }),
-   maxpos(2*(maxlayer+1),{ {0.0f,0.0f} }),
    es(0),
-   zees(2*(maxlayer+1),0.),
    clusterTools(std::make_unique<hgcal::ClusterTools>(conf,sumes))
    {
    }
@@ -46,6 +42,14 @@ public:
     clusterTools->getEventSetup(es);
     rhtools_.getEventSetup(es);
     maxlayer = rhtools_.lastLayerBH();
+    points.clear();
+    minpos.clear();
+    maxpos.clear();
+    zees.clear();
+    points.resize(2*(maxlayer+1));
+    minpos.resize(2*(maxlayer+1),{ {0.0f,0.0f} });
+    maxpos.resize(2*(maxlayer+1),{ {0.0f,0.0f} });
+    zees.resize(2*(maxlayer+1),0.);
   }
 
   typedef std::vector<reco::BasicCluster> ClusterCollection;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
@@ -22,7 +22,7 @@ public:
   /// Destructor
   virtual ~HGCalRecHitAbsAlgo(){};
 
-  inline void getEventSetup(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
+  inline void set(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
 
   /// make rechits from dataframes
   virtual void setLayerWeights(const std::vector<float>& weights){};

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h
@@ -12,22 +12,25 @@
 #include <vector>
 #include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
 #include "DataFormats/HGCRecHit/interface/HGCUncalibratedRecHit.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
-class HGCalRecHitAbsAlgo
-{
- public:
-
+class HGCalRecHitAbsAlgo {
+public:
   /// Constructor
   //HGCalRecHitAbsAlgo() { };
 
   /// Destructor
-  virtual ~HGCalRecHitAbsAlgo() { };
+  virtual ~HGCalRecHitAbsAlgo(){};
+
+  inline void getEventSetup(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
 
   /// make rechits from dataframes
-  virtual void setLayerWeights(const std::vector<float>& weights) {};
+  virtual void setLayerWeights(const std::vector<float>& weights){};
 
   virtual void setADCToGeVConstant(const float value) = 0;
-  virtual HGCRecHit makeRecHit(const HGCUncalibratedRecHit& uncalibRH, const uint32_t &flags) const = 0;
+  virtual HGCRecHit makeRecHit(const HGCUncalibratedRecHit& uncalibRH, const uint32_t& flags) const = 0;
 
+protected:
+  hgcal::RecHitTools rhtools_;
 };
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
@@ -26,13 +26,9 @@ public:
     adcToGeVConstantIsSet_ = false;
   }
 
-  void setLayerWeights(const std::vector<float>& weights) override {
-    weights_ = weights;
-  }
+  void setLayerWeights(const std::vector<float>& weights) override { weights_ = weights; }
 
-  void setNoseLayerWeights(const std::vector<float>& weights) {
-    weightsNose_ = weights;
-  }
+  void setNoseLayerWeights(const std::vector<float>& weights) { weightsNose_ = weights; }
 
   void setADCToGeVConstant(const float value) override {
     adcToGeVConstant_ = value;
@@ -53,13 +49,13 @@ public:
     unsigned layer = rhtools_.getLayerWithOffset(baseid);
     bool hfnose(false);
 
-    if ( DetId::Forward == baseid.det() && HFNose == baseid.subdetId() )
+    if (DetId::Forward == baseid.det() && HFNose == baseid.subdetId())
       hfnose = true;
 
     //    float clockToNsConstant = 25;
-    float energy = (hfnose ? (uncalibRH.amplitude() * weightsNose_[layer] * 0.001f) :
-                    (uncalibRH.amplitude() * weights_[layer] * 0.001f));
-    float time   = uncalibRH.jitter();
+    float energy = (hfnose ? (uncalibRH.amplitude() * weightsNose_[layer] * 0.001f)
+                           : (uncalibRH.amplitude() * weights_[layer] * 0.001f));
+    float time = uncalibRH.jitter();
 
     //if(time<0) time   = 0; // fast-track digi conversion
 
@@ -74,7 +70,7 @@ public:
 
 private:
   float adcToGeVConstant_;
-  bool  adcToGeVConstantIsSet_;
+  bool adcToGeVConstantIsSet_;
   std::vector<float> weights_, weightsNose_;
 };
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
@@ -47,10 +47,7 @@ public:
 
     DetId baseid = uncalibRH.id();
     unsigned layer = rhtools_.getLayerWithOffset(baseid);
-    bool hfnose(false);
-
-    if (DetId::Forward == baseid.det() && HFNose == baseid.subdetId())
-      hfnose = true;
+    bool hfnose = DetId::Forward == baseid.det() && HFNose == baseid.subdetId();
 
     //    float clockToNsConstant = 25;
     float energy = (hfnose ? (uncalibRH.amplitude() * weightsNose_[layer] * 0.001f)

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
@@ -19,7 +19,7 @@
 #include <iostream>
 
 class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
- public:
+public:
   // default ctor
   HGCalRecHitSimpleAlgo() {
     adcToGeVConstant_ = -1;
@@ -33,56 +33,38 @@ class HGCalRecHitSimpleAlgo : public HGCalRecHitAbsAlgo {
   void setNoseLayerWeights(const std::vector<float>& weights) {
     weightsNose_ = weights;
   }
-  
+
   void setADCToGeVConstant(const float value) override {
     adcToGeVConstant_ = value;
     adcToGeVConstantIsSet_ = true;
   }
-  
-  
+
   // destructor
-  ~HGCalRecHitSimpleAlgo() override { };
-  
+  ~HGCalRecHitSimpleAlgo() override{};
+
   /// Compute parameters
-  HGCRecHit makeRecHit(const HGCUncalibratedRecHit& uncalibRH,
-                               const uint32_t& flags = 0) const override {
-    
-    if(!adcToGeVConstantIsSet_) {
-      throw cms::Exception("HGCalRecHitSimpleAlgoBadConfig") 
-        << "makeRecHit: adcToGeVConstant_ not set before calling this method!";
-    }
-    
-    DetId baseid = uncalibRH.id();
-    unsigned layer = 0;
-    bool hfnose(false);
-    if ( DetId::HGCalEE == baseid.det() ) {
-      layer = HGCSiliconDetId(baseid).layer();
-    } else if ( DetId::HGCalHSi == baseid.det() ) {
-      layer = HGCSiliconDetId(baseid).layer() + 28;
-    } else if ( DetId::HGCalHSc == baseid.det() ) {
-      layer = HGCScintillatorDetId(baseid).layer() + 28;
-    } else if ( DetId::Forward == baseid.det() && HFNose == baseid.subdetId() ) {
-	layer = HFNoseDetId(baseid).layer(); hfnose = true;
-    } else if( DetId::Hcal == baseid.det() && HcalEndcap == baseid.subdetId() ) {
-      layer =  HcalDetId(baseid).depth() + 40;
-    } else if ( DetId::Forward == baseid.det() && HGCEE == baseid.subdetId() ) {
-      layer = HGCalDetId(baseid).layer();
-    } else if ( DetId::Forward == baseid.det() && HGCHEF == baseid.subdetId() ) {
-      layer = HGCalDetId(baseid).layer() + 28;
-    } else {
-      throw cms::Exception("InvalidRecHit")
-	<< "HGCalRecHitSimpleAlgo encountered a non-HGCal det id: " << baseid.det() << ' ' << baseid.subdetId() << ' ' << baseid.rawId();
+  HGCRecHit makeRecHit(const HGCUncalibratedRecHit& uncalibRH, const uint32_t& flags = 0) const override {
+    if (!adcToGeVConstantIsSet_) {
+      throw cms::Exception("HGCalRecHitSimpleAlgoBadConfig")
+          << "makeRecHit: adcToGeVConstant_ not set before calling this method!";
     }
 
-    //    float clockToNsConstant = 25;    
+    DetId baseid = uncalibRH.id();
+    unsigned layer = rhtools_.getLayerWithOffset(baseid);
+    bool hfnose(false);
+
+    if ( DetId::Forward == baseid.det() && HFNose == baseid.subdetId() )
+      hfnose = true;
+
+    //    float clockToNsConstant = 25;
     float energy = (hfnose ? (uncalibRH.amplitude() * weightsNose_[layer] * 0.001f) :
                     (uncalibRH.amplitude() * weights_[layer] * 0.001f));
     float time   = uncalibRH.jitter();
 
     //if(time<0) time   = 0; // fast-track digi conversion
-    
-    HGCRecHit rh( uncalibRH.id(), energy, time );
-    
+
+    HGCRecHit rh(uncalibRH.id(), energy, time);
+
     // Now fill flags
     // all rechits from the digitizer are "good" at present
     rh.setFlag(HGCRecHit::kGood);

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -14,7 +14,7 @@ class DetId;
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 namespace hgcal {
   class RecHitTools {
@@ -24,10 +24,10 @@ namespace hgcal {
 
     void getEvent(const edm::Event&);
     void getEventSetup(const edm::EventSetup&);
-    const CaloSubdetectorGeometry* getSubdetectorGeometry( const DetId& id ) const;
+    const CaloSubdetectorGeometry* getSubdetectorGeometry(const DetId& id) const;
 
     GlobalPoint getPosition(const DetId& id) const;
-    GlobalPoint getPositionLayer(int layer, bool nose=false) const;
+    GlobalPoint getPositionLayer(int layer, bool nose = false) const;
     // zside returns +/- 1
     int zside(const DetId& id) const;
 
@@ -35,12 +35,12 @@ namespace hgcal {
     std::float_t getRadiusToSide(const DetId&) const;
     int getSiThickIndex(const DetId&) const;
 
-    unsigned int getLayer(DetId::Detector type, bool nose=false) const;
+    unsigned int getLayer(DetId::Detector type, bool nose = false) const;
     unsigned int getLayer(ForwardSubdetector type) const;
     unsigned int getLayer(const DetId&) const;
     unsigned int getLayerWithOffset(const DetId&) const;
-    std::pair<int,int> getWafer(const DetId&) const;
-    std::pair<int,int> getCell(const DetId&) const;
+    std::pair<int, int> getWafer(const DetId&) const;
+    std::pair<int, int> getCell(const DetId&) const;
 
     bool isHalfCell(const DetId&) const;
 
@@ -54,21 +54,23 @@ namespace hgcal {
     float getPhi(const DetId& id) const;
     float getPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
 
-    inline const CaloGeometry * getGeometry() const {return geom_;};
-    unsigned int lastLayerEE() const {return fhOffset_;}
-    unsigned int lastLayerFH() const {return fhLastLayer_;}
-    unsigned int firstLayerBH() const {return bhOffset_+1;}
-    unsigned int lastLayerBH() const {return bhLastLayer_;}
-    unsigned int maxNumberOfWafersPerLayer(bool nose=false) const
-    {return (nose ? maxNumberOfWafersNose_ : maxNumberOfWafersPerLayer_);}
-    inline int getGeometryType() const {return geometryType_;}
-    bool maskCell(const DetId& id, int corners=3) const;
+    inline const CaloGeometry* getGeometry() const { return geom_; };
+    unsigned int lastLayerEE() const { return fhOffset_; }
+    unsigned int lastLayerFH() const { return fhLastLayer_; }
+    unsigned int firstLayerBH() const { return bhOffset_ + 1; }
+    unsigned int lastLayerBH() const { return bhLastLayer_; }
+    unsigned int maxNumberOfWafersPerLayer(bool nose = false) const {
+      return (nose ? maxNumberOfWafersNose_ : maxNumberOfWafersPerLayer_);
+    }
+    inline int getGeometryType() const { return geometryType_; }
+    bool maskCell(const DetId& id, int corners = 3) const;
+
   private:
     const CaloGeometry* geom_;
-    unsigned int        fhOffset_, bhOffset_, bhLastLayer_, fhLastLayer_;
-    unsigned int        maxNumberOfWafersPerLayer_, maxNumberOfWafersNose_;
-    int                 geometryType_;
+    unsigned int fhOffset_, bhOffset_, bhLastLayer_, fhLastLayer_;
+    unsigned int maxNumberOfWafersPerLayer_, maxNumberOfWafersNose_;
+    int geometryType_;
   };
-}
+}  // namespace hgcal
 
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -57,13 +57,15 @@ namespace hgcal {
     inline const CaloGeometry * getGeometry() const {return geom_;};
     unsigned int lastLayerEE() const {return fhOffset_;}
     unsigned int lastLayerFH() const {return fhLastLayer_;}
-    unsigned int maxNumberOfWafersPerLayer(bool nose=false) const 
+    unsigned int firstLayerBH() const {return bhOffset_+1;}
+    unsigned int lastLayerBH() const {return bhLastLayer_;}
+    unsigned int maxNumberOfWafersPerLayer(bool nose=false) const
     {return (nose ? maxNumberOfWafersNose_ : maxNumberOfWafersPerLayer_);}
     inline int getGeometryType() const {return geometryType_;}
     bool maskCell(const DetId& id, int corners=3) const;
   private:
     const CaloGeometry* geom_;
-    unsigned int        fhOffset_, bhOffset_, fhLastLayer_;
+    unsigned int        fhOffset_, bhOffset_, bhLastLayer_, fhLastLayer_;
     unsigned int        maxNumberOfWafersPerLayer_, maxNumberOfWafersNose_;
     int                 geometryType_;
   };

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
@@ -1,133 +1,127 @@
 #include "RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-
 namespace {
-  std::vector<size_t> sorted_indices(const reco::HGCalMultiCluster::ClusterCollection& v) {
-
+  std::vector<size_t> sorted_indices(const reco::HGCalMultiCluster::ClusterCollection &v) {
     // initialize original index locations
     std::vector<size_t> idx(v.size());
-    std::iota (std::begin(idx), std::end(idx), 0);
+    std::iota(std::begin(idx), std::end(idx), 0);
 
     // sort indices based on comparing values in v
-    std::sort(idx.begin(), idx.end(),
-         [&v](size_t i1, size_t i2) {return (*v[i1]) > (*v[i2]);});
+    std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return (*v[i1]) > (*v[i2]); });
 
     return idx;
   }
 
-  float distReal2(const edm::Ptr<reco::BasicCluster> &a,
-		  const std::array<double,3> &to) {
-    return (a->x()-to[0])*(a->x()-to[0]) + (a->y()-to[1])*(a->y()-to[1]);
+  float distReal2(const edm::Ptr<reco::BasicCluster> &a, const std::array<double, 3> &to) {
+    return (a->x() - to[0]) * (a->x() - to[0]) + (a->y() - to[1]) * (a->y() - to[1]);
   }
-}
+}  // namespace
 
 void HGCal3DClustering::organizeByLayer(const reco::HGCalMultiCluster::ClusterCollection &thecls) {
   es = sorted_indices(thecls);
   unsigned int es_size = es.size();
-  for(unsigned int i = 0; i < es_size; ++i) {
-     int layer = rhtools_.getLayerWithOffset(thecls[es[i]]->hitsAndFractions()[0].first);
-    layer += int(thecls[es[i]]->z()>0)*(maxlayer+1);
+  for (unsigned int i = 0; i < es_size; ++i) {
+    int layer = rhtools_.getLayerWithOffset(thecls[es[i]]->hitsAndFractions()[0].first);
+    layer += int(thecls[es[i]]->z() > 0) * (maxlayer + 1);
     float x = thecls[es[i]]->x();
     float y = thecls[es[i]]->y();
     float z = thecls[es[i]]->z();
-    points[layer].emplace_back(ClusterRef(i,z),x,y);
-    if(zees[layer]==0.) {
+    points[layer].emplace_back(ClusterRef(i, z), x, y);
+    if (zees[layer] == 0.) {
       // At least one cluster for layer at z
       zees[layer] = z;
     }
-    if(points[layer].empty()){
-      minpos[layer][0] = x; minpos[layer][1] = y;
-      maxpos[layer][0] = x; maxpos[layer][1] = y;
-    }else{
-      minpos[layer][0] = std::min(x,minpos[layer][0]);
-      minpos[layer][1] = std::min(y,minpos[layer][1]);
-      maxpos[layer][0] = std::max(x,maxpos[layer][0]);
-      maxpos[layer][1] = std::max(y,maxpos[layer][1]);
+    if (points[layer].empty()) {
+      minpos[layer][0] = x;
+      minpos[layer][1] = y;
+      maxpos[layer][0] = x;
+      maxpos[layer][1] = y;
+    } else {
+      minpos[layer][0] = std::min(x, minpos[layer][0]);
+      minpos[layer][1] = std::min(y, minpos[layer][1]);
+      maxpos[layer][0] = std::max(x, maxpos[layer][0]);
+      maxpos[layer][1] = std::max(y, maxpos[layer][1]);
     }
   }
 }
-std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(const reco::HGCalMultiCluster::ClusterCollection &thecls) {
+std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(
+    const reco::HGCalMultiCluster::ClusterCollection &thecls) {
   reset();
   organizeByLayer(thecls);
   std::vector<reco::HGCalMultiCluster> thePreClusters;
 
-  std::vector<KDTree> hit_kdtree(2*(maxlayer+1));
-  for (unsigned int i = 0; i <= 2*maxlayer+1; ++i) {
-    KDTreeBox bounds(minpos[i][0],maxpos[i][0],
-		     minpos[i][1],maxpos[i][1]);
-    hit_kdtree[i].build(points[i],bounds);
+  std::vector<KDTree> hit_kdtree(2 * (maxlayer + 1));
+  for (unsigned int i = 0; i <= 2 * maxlayer + 1; ++i) {
+    KDTreeBox bounds(minpos[i][0], maxpos[i][0], minpos[i][1], maxpos[i][1]);
+    hit_kdtree[i].build(points[i], bounds);
   }
-  std::vector<int> vused(es.size(),0);
+  std::vector<int> vused(es.size(), 0);
   unsigned int used = 0;
 
   unsigned int es_size = es.size();
-  for(unsigned int i = 0; i < es_size; ++i) {
-    if(vused[i]==0) {
+  for (unsigned int i = 0; i < es_size; ++i) {
+    if (vused[i] == 0) {
       reco::HGCalMultiCluster temp;
       temp.push_back(thecls[es[i]]);
-      vused[i]=(thecls[es[i]]->z()>0)? 1 : -1;
+      vused[i] = (thecls[es[i]]->z() > 0) ? 1 : -1;
       ++used;
       // Starting from cluster es[i] at from[0] - from[1] - from[2]
-      std::array<double,3> from{ {thecls[es[i]]->x(),thecls[es[i]]->y(),thecls[es[i]]->z()} };
-      unsigned int firstlayer = int(thecls[es[i]]->z()>0)*(maxlayer+1);
-      unsigned int lastlayer = firstlayer+maxlayer+1;
-      for(unsigned int j = firstlayer; j < lastlayer; ++j) {
-	if(zees[j]==0.){
-	  // layer j not yet ever reached?
-	  continue;
-	}
-	std::array<double,3> to{ {0.,0.,zees[j]} };
-	layerIntersection(to,from);
-        unsigned int layer = j > maxlayer ? (j-(maxlayer+1)) : j; //maps back from index used for KD trees to actual layer
+      std::array<double, 3> from{{thecls[es[i]]->x(), thecls[es[i]]->y(), thecls[es[i]]->z()}};
+      unsigned int firstlayer = int(thecls[es[i]]->z() > 0) * (maxlayer + 1);
+      unsigned int lastlayer = firstlayer + maxlayer + 1;
+      for (unsigned int j = firstlayer; j < lastlayer; ++j) {
+        if (zees[j] == 0.) {
+          // layer j not yet ever reached?
+          continue;
+        }
+        std::array<double, 3> to{{0., 0., zees[j]}};
+        layerIntersection(to, from);
+        unsigned int layer =
+            j > maxlayer ? (j - (maxlayer + 1)) : j;  //maps back from index used for KD trees to actual layer
         float radius = radii[2];
-        if(layer <= rhtools_.lastLayerEE()) radius = radii[0];
-        else if(layer < rhtools_.firstLayerBH()) radius = radii[1];
-        float radius2 = radius*radius;
-	KDTreeBox search_box(float(to[0])-radius,float(to[0])+radius,
-			     float(to[1])-radius,float(to[1])+radius);
-	std::vector<ClusterRef> found;
-	// at layer j in box float(to[0])+/-radius - float(to[1])+/-radius
-	hit_kdtree[j].search(search_box,found);
-	// found found.size() clusters within box
-	for(unsigned int k = 0; k < found.size(); k++){
-	  if(vused[found[k].ind]==0 && distReal2(thecls[es[found[k].ind]],to)<radius2){
-	    temp.push_back(thecls[es[found[k].ind]]);
-	    vused[found[k].ind]=vused[i];
-	    ++used;
-	  }
-	}
-
+        if (layer <= rhtools_.lastLayerEE())
+          radius = radii[0];
+        else if (layer < rhtools_.firstLayerBH())
+          radius = radii[1];
+        float radius2 = radius * radius;
+        KDTreeBox search_box(
+            float(to[0]) - radius, float(to[0]) + radius, float(to[1]) - radius, float(to[1]) + radius);
+        std::vector<ClusterRef> found;
+        // at layer j in box float(to[0])+/-radius - float(to[1])+/-radius
+        hit_kdtree[j].search(search_box, found);
+        // found found.size() clusters within box
+        for (unsigned int k = 0; k < found.size(); k++) {
+          if (vused[found[k].ind] == 0 && distReal2(thecls[es[found[k].ind]], to) < radius2) {
+            temp.push_back(thecls[es[found[k].ind]]);
+            vused[found[k].ind] = vused[i];
+            ++used;
+          }
+        }
       }
-      if( temp.size() > minClusters ) {
-	math::XYZPoint position = clusterTools->getMultiClusterPosition(temp);
-	if (std::abs(position.z()) <= 0.) continue;
-	// only store multiclusters that pass the energy threshold in getMultiClusterPosition
-	// giving them a position inside the HGCal
-	thePreClusters.push_back(temp);
-	auto& back = thePreClusters.back();
-	back.setPosition(position);
-	back.setEnergy(clusterTools->getMultiClusterEnergy(back));
+      if (temp.size() > minClusters) {
+        math::XYZPoint position = clusterTools->getMultiClusterPosition(temp);
+        if (std::abs(position.z()) <= 0.)
+          continue;
+        // only store multiclusters that pass the energy threshold in getMultiClusterPosition
+        // giving them a position inside the HGCal
+        thePreClusters.push_back(temp);
+        auto &back = thePreClusters.back();
+        back.setPosition(position);
+        back.setEnergy(clusterTools->getMultiClusterEnergy(back));
       }
-
     }
-
   }
 
   return thePreClusters;
-
 }
 
-void HGCal3DClustering::layerIntersection(std::array<double,3> &to,
-					  const std::array<double,3> &from)
-  const
-{
+void HGCal3DClustering::layerIntersection(std::array<double, 3> &to, const std::array<double, 3> &from) const {
   if (from[2] != 0) {
-      to[0]=from[0]/from[2]*to[2];
-      to[1]=from[1]/from[2]*to[2];
-  }
-  else {
-      to[0] = 0;
-      to[1] = 0;
+    to[0] = from[0] / from[2] * to[2];
+    to[1] = from[1] / from[2] * to[2];
+  } else {
+    to[0] = 0;
+    to[1] = 0;
   }
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
@@ -82,7 +82,7 @@ std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(const reco:
         unsigned int layer = j > maxlayer ? (j-(maxlayer+1)) : j; //maps back from index used for KD trees to actual layer
         float radius = radii[2];
         if(layer <= rhtools_.lastLayerEE()) radius = radii[0];
-        else if(layer <= rhtools_.lastLayerFH()) radius = radii[1];
+        else if(layer < rhtools_.firstLayerBH()) radius = radii[1];
         float radius2 = radius*radius;
 	KDTreeBox search_box(float(to[0])-radius,float(to[0])+radius,
 			     float(to[1])-radius,float(to[1])+radius);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
@@ -55,7 +55,7 @@ std::vector<reco::HGCalMultiCluster> HGCalDepthPreClusterer::makePreClusters(con
           unsigned int layer = clusterTools->getLayer(detid);
           float radius = radii[2];
           if(layer <= rhtools_.lastLayerEE()) radius = radii[0];
-          else if(layer <= rhtools_.lastLayerFH()) radius = radii[1];
+          else if(layer < rhtools_.firstLayerBH()) radius = radii[1];
           float radius2 = radius*radius;
 	  if( distanceCheck<radius2 && int(thecls[es[j]]->z()*vused[i])>0 ) {
 	    temp.push_back(thecls[es[j]]);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
@@ -4,76 +4,75 @@
 #include <list>
 
 namespace {
-  std::vector<size_t> sorted_indices(const reco::HGCalMultiCluster::ClusterCollection& v) {
-
+  std::vector<size_t> sorted_indices(const reco::HGCalMultiCluster::ClusterCollection &v) {
     // initialize original index locations
     std::vector<size_t> idx(v.size());
-    for (size_t i = 0; i != idx.size(); ++i) idx[i] = i;
+    for (size_t i = 0; i != idx.size(); ++i)
+      idx[i] = i;
 
     // sort indices based on comparing values in v
-    std::sort(idx.begin(), idx.end(),
-         [&v](size_t i1, size_t i2) {return (*v[i1]) > (*v[i2]);});
+    std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return (*v[i1]) > (*v[i2]); });
 
     return idx;
   }
 
-  float dist2(const edm::Ptr<reco::BasicCluster> &a,
-	      const edm::Ptr<reco::BasicCluster> &b) {
-    return reco::deltaR2(*a,*b);
+  float dist2(const edm::Ptr<reco::BasicCluster> &a, const edm::Ptr<reco::BasicCluster> &b) {
+    return reco::deltaR2(*a, *b);
   }
 
   //get distance between cluster and multicluster axis (defined by remaning cluster with highest energy)
   // N.B. the order of the clusters matters
-  float distAxisCluster2(const edm::Ptr<reco::BasicCluster> &a,
-             const edm::Ptr<reco::BasicCluster> &b) {
-    float tanTheta = tan(2*atan(exp(-1*a->eta())));
-    float ax = b->z()*tanTheta*cos(a->phi());
-    float ay = b->z()*tanTheta*sin(a->phi());
-    return (ax-b->x())*(ax-b->x()) + (ay-b->y())*(ay-b->y());
+  float distAxisCluster2(const edm::Ptr<reco::BasicCluster> &a, const edm::Ptr<reco::BasicCluster> &b) {
+    float tanTheta = tan(2 * atan(exp(-1 * a->eta())));
+    float ax = b->z() * tanTheta * cos(a->phi());
+    float ay = b->z() * tanTheta * sin(a->phi());
+    return (ax - b->x()) * (ax - b->x()) + (ay - b->y()) * (ay - b->y());
   }
-}
+}  // namespace
 
-std::vector<reco::HGCalMultiCluster> HGCalDepthPreClusterer::makePreClusters(const reco::HGCalMultiCluster::ClusterCollection &thecls) const {
-
+std::vector<reco::HGCalMultiCluster> HGCalDepthPreClusterer::makePreClusters(
+    const reco::HGCalMultiCluster::ClusterCollection &thecls) const {
   std::vector<reco::HGCalMultiCluster> thePreClusters;
   std::vector<size_t> es = sorted_indices(thecls);
-  std::vector<int> vused(es.size(),0);
+  std::vector<int> vused(es.size(), 0);
   unsigned int used = 0;
 
-  for(unsigned int i = 0; i < es.size(); ++i) {
-    if(vused[i]==0) {
+  for (unsigned int i = 0; i < es.size(); ++i) {
+    if (vused[i] == 0) {
       reco::HGCalMultiCluster temp;
       temp.push_back(thecls[es[i]]);
-      vused[i]=(thecls[es[i]]->z()>0)? 1 : -1;
+      vused[i] = (thecls[es[i]]->z() > 0) ? 1 : -1;
       ++used;
-      for(unsigned int j = i+1; j < es.size(); ++j) {
-	if(vused[j]==0) {
+      for (unsigned int j = i + 1; j < es.size(); ++j) {
+        if (vused[j] == 0) {
           float distanceCheck = 9999.;
-          if( realSpaceCone ) distanceCheck = distAxisCluster2(thecls[es[i]],thecls[es[j]]);
-          else distanceCheck = dist2(thecls[es[i]],thecls[es[j]]);
+          if (realSpaceCone)
+            distanceCheck = distAxisCluster2(thecls[es[i]], thecls[es[j]]);
+          else
+            distanceCheck = dist2(thecls[es[i]], thecls[es[j]]);
           DetId detid = thecls[es[j]]->hitsAndFractions()[0].first();
           unsigned int layer = clusterTools->getLayer(detid);
           float radius = radii[2];
-          if(layer <= rhtools_.lastLayerEE()) radius = radii[0];
-          else if(layer < rhtools_.firstLayerBH()) radius = radii[1];
-          float radius2 = radius*radius;
-	  if( distanceCheck<radius2 && int(thecls[es[j]]->z()*vused[i])>0 ) {
-	    temp.push_back(thecls[es[j]]);
-	    vused[j]=vused[i];
-	    ++used;
-	  }
-	}
+          if (layer <= rhtools_.lastLayerEE())
+            radius = radii[0];
+          else if (layer < rhtools_.firstLayerBH())
+            radius = radii[1];
+          float radius2 = radius * radius;
+          if (distanceCheck<radius2 &&int(thecls[es[j]]->z() * vused[i])> 0) {
+            temp.push_back(thecls[es[j]]);
+            vused[j] = vused[i];
+            ++used;
+          }
+        }
       }
-      if( temp.size() > minClusters ) {
+      if (temp.size() > minClusters) {
         thePreClusters.push_back(temp);
-        auto& back = thePreClusters.back();
+        auto &back = thePreClusters.back();
         back.setPosition(clusterTools->getMultiClusterPosition(back));
         back.setEnergy(clusterTools->getMultiClusterEnergy(back));
       }
     }
   }
-
-
 
   return thePreClusters;
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -18,101 +18,96 @@
 using namespace hgcal;
 
 namespace {
-  template<typename DDD>
+  template <typename DDD>
   inline void check_ddd(const DDD* ddd) {
-    if( nullptr == ddd ) {
-      throw cms::Exception("hgcal::RecHitTools")
-        << "DDDConstants not accessibl to hgcal::RecHitTools!";
+    if (nullptr == ddd) {
+      throw cms::Exception("hgcal::RecHitTools") << "DDDConstants not accessibl to hgcal::RecHitTools!";
     }
   }
 
-  template<typename GEOM>
+  template <typename GEOM>
   inline void check_geom(const GEOM* geom) {
-    if( nullptr == geom ) {
-      throw cms::Exception("hgcal::RecHitTools")
-        << "Geometry not provided yet to hgcal::RecHitTools!";
+    if (nullptr == geom) {
+      throw cms::Exception("hgcal::RecHitTools") << "Geometry not provided yet to hgcal::RecHitTools!";
     }
   }
 
-  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
-					  const HGCalDetId& detid) {
+  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom, const HGCalDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
     check_ddd(ddd);
     return ddd;
   }
 
-  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
-					  const HGCSiliconDetId& detid) {
+  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom, const HGCSiliconDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
     check_ddd(ddd);
     return ddd;
   }
 
-  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom,
-					  const HFNoseDetId& detid) {
+  inline const HGCalDDDConstants* get_ddd(const CaloSubdetectorGeometry* geom, const HFNoseDetId& detid) {
     const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
     check_ddd(ddd);
     return ddd;
   }
 
-  inline const HGCalDDDConstants* get_ddd(const CaloGeometry* geom,
-					  int type, int maxLayerEE,
-					  int layer) {
-    DetId::Detector det = ((type == 0) ? DetId::Forward :
-			   ((layer > maxLayerEE) ? DetId::HGCalHSi :
-			    DetId::HGCalEE));
-    int subdet = ((type != 0) ? ForwardSubdetector::ForwardEmpty :
-		  ((layer > maxLayerEE) ? ForwardSubdetector::HGCEE :
-		   ForwardSubdetector::HGCHEF));
-    const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(det,subdet));
+  inline const HGCalDDDConstants* get_ddd(const CaloGeometry* geom, int type, int maxLayerEE, int layer) {
+    DetId::Detector det = ((type == 0) ? DetId::Forward : ((layer > maxLayerEE) ? DetId::HGCalHSi : DetId::HGCalEE));
+    int subdet = ((type != 0) ? ForwardSubdetector::ForwardEmpty
+                              : ((layer > maxLayerEE) ? ForwardSubdetector::HGCEE : ForwardSubdetector::HGCHEF));
+    const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(det, subdet));
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
     check_ddd(ddd);
     return ddd;
   }
 
-}
+}  // namespace
 
-void RecHitTools::getEvent(const edm::Event& ev) {
-}
+void RecHitTools::getEvent(const edm::Event& ev) {}
 
 void RecHitTools::getEventSetup(const edm::EventSetup& es) {
-
   edm::ESHandle<CaloGeometry> geom;
   es.get<CaloGeometryRecord>().get(geom);
 
   geom_ = geom.product();
   unsigned int wmaxEE(0), wmaxFH(0);
-  auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
+  auto geomEE = static_cast<const HGCalGeometry*>(
+      geom_->getSubdetectorGeometry(DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));
   //check if it's the new geometry
-  if(geomEE) {
+  if (geomEE) {
     geometryType_ = 1;
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
-    wmaxEE    = (geomEE->topology().dddConstants()).waferCount(0);
-    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
-    wmaxFH    = (geomFH->topology().dddConstants()).waferCount(0);
+    wmaxEE = (geomEE->topology().dddConstants()).waferCount(0);
+    auto geomFH = static_cast<const HGCalGeometry*>(
+        geom_->getSubdetectorGeometry(DetId::HGCalHSi, ForwardSubdetector::ForwardEmpty));
+    wmaxFH = (geomFH->topology().dddConstants()).waferCount(0);
     fhLastLayer_ = fhOffset_ + (geomFH->topology().dddConstants()).layers(true);
-    auto geomBH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
-    bhOffset_ = fhOffset_ + (geomBH->topology().dddConstants()).firstLayer() - (geomEE->topology().dddConstants()).firstLayer();
+    auto geomBH = static_cast<const HGCalGeometry*>(
+        geom_->getSubdetectorGeometry(DetId::HGCalHSc, ForwardSubdetector::ForwardEmpty));
+    bhOffset_ =
+        fhOffset_ + (geomBH->topology().dddConstants()).firstLayer() - (geomEE->topology().dddConstants()).firstLayer();
     bhLastLayer_ = bhOffset_ + (geomBH->topology().dddConstants()).layers(true);
-  }
-  else {
+  } else {
     geometryType_ = 0;
-    geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+    geomEE =
+        static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCEE));
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
-    wmaxEE    = 1 + (geomEE->topology().dddConstants()).waferMax();
-    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+    wmaxEE = 1 + (geomEE->topology().dddConstants()).waferMax();
+    auto geomFH =
+        static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCHEF));
     bhOffset_ = fhOffset_ + (geomFH->topology().dddConstants()).layers(true);
-    wmaxFH    = 1 + (geomFH->topology().dddConstants()).waferMax();
+    wmaxFH = 1 + (geomFH->topology().dddConstants()).waferMax();
     fhLastLayer_ = bhOffset_;
-    auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+    auto geomBH =
+        static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal, HcalSubdetector::HcalEndcap));
     bhLastLayer_ = bhOffset_ + (geomBH->topology().dddConstants())->getMaxDepth(1);
   }
-  maxNumberOfWafersPerLayer_ = std::max(wmaxEE,wmaxFH);
+  maxNumberOfWafersPerLayer_ = std::max(wmaxEE, wmaxFH);
   // For nose geometry
-  auto geomNose = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HFNose));
+  auto geomNose =
+      static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HFNose));
   if (geomNose) {
     maxNumberOfWafersNose_ = (geomNose->topology().dddConstants()).waferCount(0);
   } else {
@@ -120,10 +115,12 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
   }
 }
 
-const CaloSubdetectorGeometry* RecHitTools::getSubdetectorGeometry( const DetId& id ) const {
+const CaloSubdetectorGeometry* RecHitTools::getSubdetectorGeometry(const DetId& id) const {
   DetId::Detector det = id.det();
-  int subdet = (det == DetId::HGCalEE || det == DetId::HGCalHSi || det == DetId::HGCalHSc) ? ForwardSubdetector::ForwardEmpty : id.subdetId();
-  auto geom = geom_->getSubdetectorGeometry(det,subdet);
+  int subdet = (det == DetId::HGCalEE || det == DetId::HGCalHSi || det == DetId::HGCalHSc)
+                   ? ForwardSubdetector::ForwardEmpty
+                   : id.subdetId();
+  auto geom = geom_->getSubdetectorGeometry(det, subdet);
   check_geom(geom);
   return geom;
 }
@@ -144,17 +141,18 @@ GlobalPoint RecHitTools::getPositionLayer(int layer, bool nose) const {
   int lay = std::abs(layer);
   double z(0);
   if (nose) {
-    auto geomNose = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HFNose));
+    auto geomNose =
+        static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HFNose));
     if (geomNose) {
       const HGCalDDDConstants* ddd = &(geomNose->topology().dddConstants());
       if (ddd)
-	z = (layer > 0) ? ddd->waferZ(lay,true) : -ddd->waferZ(lay,true);
+        z = (layer > 0) ? ddd->waferZ(lay, true) : -ddd->waferZ(lay, true);
     }
   } else {
     const HGCalDDDConstants* ddd = get_ddd(geom_, geometryType_, fhOffset_, lay);
-    z = (layer > 0) ? ddd->waferZ(lay,true) : -ddd->waferZ(lay,true);
+    z = (layer > 0) ? ddd->waferZ(lay, true) : -ddd->waferZ(lay, true);
   }
-  return GlobalPoint(0,0,z);
+  return GlobalPoint(0, 0, z);
 }
 
 int RecHitTools::zside(const DetId& id) const {
@@ -167,7 +165,7 @@ int RecHitTools::zside(const DetId& id) const {
     zside = HFNoseDetId(id).zside();
   } else if (id.det() == DetId::Forward) {
     zside = HGCalDetId(id).zside();
-  } else if( id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+  } else if (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
     zside = HcalDetId(id).zside();
   }
   return zside;
@@ -178,20 +176,19 @@ std::float_t RecHitTools::getSiThickness(const DetId& id) const {
   std::float_t thick(0.37);
   if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
     const HGCSiliconDetId hid(id);
-    auto ddd = get_ddd(geom,hid);
-    thick    = ddd->cellThickness(hid.layer(),hid.waferU(),hid.waferV());
+    auto ddd = get_ddd(geom, hid);
+    thick = ddd->cellThickness(hid.layer(), hid.waferU(), hid.waferV());
   } else if (id.det() == DetId::Forward && id.subdetId() == static_cast<int>(HFNose)) {
     const HFNoseDetId hid(id);
-    auto ddd = get_ddd(geom,hid);
-    thick    = ddd->cellThickness(hid.layer(),hid.waferU(),hid.waferV());
+    auto ddd = get_ddd(geom, hid);
+    thick = ddd->cellThickness(hid.layer(), hid.waferU(), hid.waferV());
   } else if (id.det() == DetId::Forward) {
     const HGCalDetId hid(id);
-    auto ddd = get_ddd(geom,hid);
-    thick    = ddd->cellThickness(hid.layer(),hid.wafer(),0);
+    auto ddd = get_ddd(geom, hid);
+    thick = ddd->cellThickness(hid.layer(), hid.wafer(), 0);
   } else {
     LogDebug("getSiThickness::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":"
-      << id.det() << " is not HGCal silicon!";
+        << "det id: " << std::hex << id.rawId() << std::dec << ":" << id.det() << " is not HGCal silicon!";
     // It does not make any sense to return 0.37 as thickness for a detector
     // that is not Silicon(does it?). Mark it as 0. to be able to distinguish
     // the case.
@@ -225,98 +222,111 @@ std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
   std::float_t size(std::numeric_limits<std::float_t>::max());
   if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
     const HGCSiliconDetId hid(id);
-    auto  ddd = get_ddd(geom,hid);
-    size     = ddd->cellSizeHex(hid.type());
+    auto ddd = get_ddd(geom, hid);
+    size = ddd->cellSizeHex(hid.type());
   } else if (id.det() == DetId::Forward && id.subdetId() == static_cast<int>(HFNose)) {
     const HFNoseDetId hid(id);
-    auto  ddd = get_ddd(geom,hid);
-    size     = ddd->cellSizeHex(hid.type());
+    auto ddd = get_ddd(geom, hid);
+    size = ddd->cellSizeHex(hid.type());
   } else if (id.det() == DetId::Forward) {
     const HGCalDetId hid(id);
-    auto  ddd = get_ddd(geom,hid);
-    size     = ddd->cellSizeHex(hid.waferType());
+    auto ddd = get_ddd(geom, hid);
+    size = ddd->cellSizeHex(hid.waferType());
   } else {
     edm::LogError("getRadiusToSide::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":"
-      << id.det() << " is not HGCal silicon!";
+        << "det id: " << std::hex << id.rawId() << std::dec << ":" << id.det() << " is not HGCal silicon!";
   }
   return size;
 }
 
 unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
-
   int layer(0);
   switch (type) {
-    case(ForwardSubdetector::HGCEE): {
-      auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-      layer       = (geomEE->topology().dddConstants()).layers(true);
+    case (ForwardSubdetector::HGCEE): {
+      auto geomEE =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCEE));
+      layer = (geomEE->topology().dddConstants()).layers(true);
       break;
     }
     case (ForwardSubdetector::HGCHEF): {
-      auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-      layer       = (geomFH->topology().dddConstants()).layers(true);
+      auto geomFH =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCHEF));
+      layer = (geomFH->topology().dddConstants()).layers(true);
       break;
     }
     case (ForwardSubdetector::HGCHEB): {
-      auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
-      layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
+      auto geomBH =
+          static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal, HcalSubdetector::HcalEndcap));
+      layer = (geomBH->topology().dddConstants())->getMaxDepth(1);
       break;
     }
     case (ForwardSubdetector::ForwardEmpty): {
-      auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-      layer       = (geomEE->topology().dddConstants()).layers(true);
-      auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-      layer      += (geomFH->topology().dddConstants()).layers(true);
-      auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+      auto geomEE =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCEE));
+      layer = (geomEE->topology().dddConstants()).layers(true);
+      auto geomFH =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCHEF));
+      layer += (geomFH->topology().dddConstants()).layers(true);
+      auto geomBH =
+          static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal, HcalSubdetector::HcalEndcap));
       if (geomBH)
-	layer    += (geomBH->topology().dddConstants())->getMaxDepth(1);
-      auto geomBH2= static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEB));
+        layer += (geomBH->topology().dddConstants())->getMaxDepth(1);
+      auto geomBH2 =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HGCHEB));
       if (geomBH2)
-	layer    += (geomBH2->topology().dddConstants()).layers(true);
+        layer += (geomBH2->topology().dddConstants()).layers(true);
       break;
     }
-    case(ForwardSubdetector::HFNose): {
-      auto geomHFN = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HFNose));
-      layer       = (geomHFN->topology().dddConstants()).layers(true);
+    case (ForwardSubdetector::HFNose): {
+      auto geomHFN =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HFNose));
+      layer = (geomHFN->topology().dddConstants()).layers(true);
       break;
     }
-    default: layer = 0;
+    default:
+      layer = 0;
   }
   return (unsigned int)(layer);
 }
 
 unsigned int RecHitTools::getLayer(const DetId::Detector type, bool nose) const {
-
   int layer;
   switch (type) {
-  case(DetId::HGCalEE): {
-    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(type,ForwardSubdetector::ForwardEmpty));
-    layer       = (geomEE->topology().dddConstants()).layers(true);
-    break;
-  }
-  case (DetId::HGCalHSi): {
-    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(type,ForwardSubdetector::ForwardEmpty));
-    layer       = (geomFH->topology().dddConstants()).layers(true);
-    break;
-  }
-  case (DetId::HGCalHSc): {
-    auto geomBH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(type,ForwardSubdetector::ForwardEmpty));
-    layer       = (geomBH->topology().dddConstants()).layers(true);
-    break;
+    case (DetId::HGCalEE): {
+      auto geomEE =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(type, ForwardSubdetector::ForwardEmpty));
+      layer = (geomEE->topology().dddConstants()).layers(true);
+      break;
     }
-  case (DetId::Forward): {
-    if (nose) {
-      auto geomHFN = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HFNose));
-      layer       = (geomHFN->topology().dddConstants()).layers(true);
-    } else {
-      auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
-      layer       = (geomEE->topology().dddConstants()).layers(true);
-      auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
-      layer      += (geomFH->topology().dddConstants()).layers(true);
+    case (DetId::HGCalHSi): {
+      auto geomFH =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(type, ForwardSubdetector::ForwardEmpty));
+      layer = (geomFH->topology().dddConstants()).layers(true);
+      break;
     }
-    break;
-  }
-  default: layer = 0;
+    case (DetId::HGCalHSc): {
+      auto geomBH =
+          static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(type, ForwardSubdetector::ForwardEmpty));
+      layer = (geomBH->topology().dddConstants()).layers(true);
+      break;
+    }
+    case (DetId::Forward): {
+      if (nose) {
+        auto geomHFN = static_cast<const HGCalGeometry*>(
+            geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HFNose));
+        layer = (geomHFN->topology().dddConstants()).layers(true);
+      } else {
+        auto geomEE = static_cast<const HGCalGeometry*>(
+            geom_->getSubdetectorGeometry(DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));
+        layer = (geomEE->topology().dddConstants()).layers(true);
+        auto geomFH = static_cast<const HGCalGeometry*>(
+            geom_->getSubdetectorGeometry(DetId::HGCalHSi, ForwardSubdetector::ForwardEmpty));
+        layer += (geomFH->topology().dddConstants()).layers(true);
+      }
+      break;
+    }
+    default:
+      layer = 0;
   }
   return (unsigned int)(layer);
 }
@@ -339,7 +349,7 @@ unsigned int RecHitTools::getLayer(const DetId& id) const {
 
 unsigned int RecHitTools::getLayerWithOffset(const DetId& id) const {
   unsigned int layer = getLayer(id);
-  if (id.det() == DetId::Forward && id.subdetId() == HGCHEF ) {
+  if (id.det() == DetId::Forward && id.subdetId() == HGCHEF) {
     layer += fhOffset_;
   } else if (id.det() == DetId::HGCalHSi || id.det() == DetId::HGCalHSc) {
     // DetId::HGCalHSc hits include the offset w.r.t. EE already
@@ -350,7 +360,7 @@ unsigned int RecHitTools::getLayerWithOffset(const DetId& id) const {
   return layer;
 }
 
-std::pair<int,int> RecHitTools::getWafer(const DetId& id) const {
+std::pair<int, int> RecHitTools::getWafer(const DetId& id) const {
   int waferU = std::numeric_limits<int>::max();
   int waferV = 0;
   if ((id.det() == DetId::HGCalEE) || (id.det() == DetId::HGCalHSi)) {
@@ -363,13 +373,12 @@ std::pair<int,int> RecHitTools::getWafer(const DetId& id) const {
     waferU = HGCalDetId(id).wafer();
   } else {
     edm::LogError("getWafer::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":"
-      << id.det() << " is not HGCal silicon!";
+        << "det id: " << std::hex << id.rawId() << std::dec << ":" << id.det() << " is not HGCal silicon!";
   }
-  return std::pair<int,int>(waferU,waferV);
+  return std::pair<int, int>(waferU, waferV);
 }
 
-std::pair<int,int> RecHitTools::getCell(const DetId& id) const {
+std::pair<int, int> RecHitTools::getCell(const DetId& id) const {
   int cellU = std::numeric_limits<int>::max();
   int cellV = 0;
   if ((id.det() == DetId::HGCalEE) || (id.det() == DetId::HGCalHSi)) {
@@ -382,10 +391,9 @@ std::pair<int,int> RecHitTools::getCell(const DetId& id) const {
     cellU = HGCalDetId(id).cell();
   } else {
     edm::LogError("getCell::InvalidSiliconDetid")
-      << "det id: " << std::hex << id.rawId() << std::dec << ":"
-      << id.det() << " is not HGCal silicon!";
+        << "det id: " << std::hex << id.rawId() << std::dec << ":" << id.det() << " is not HGCal silicon!";
   }
-  return std::pair<int,int>(cellU,cellV);
+  return std::pair<int, int>(cellU, cellV);
 }
 
 bool RecHitTools::isHalfCell(const DetId& id) const {
@@ -393,16 +401,16 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
   if (id.det() == DetId::Forward) {
     HGCalDetId hid(id);
     auto geom = getSubdetectorGeometry(hid);
-    auto ddd = get_ddd(geom,hid);
+    auto ddd = get_ddd(geom, hid);
     const int waferType = ddd->waferTypeT(hid.waferType());
-    return ddd->isHalfCell(waferType,hid.cell());
+    return ddd->isHalfCell(waferType, hid.cell());
   }
   //new geometry is always false
   return ishalf;
 }
 
 float RecHitTools::getEta(const GlobalPoint& position, const float& vertex_z) const {
-  GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z()-vertex_z);
+  GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z() - vertex_z);
   return corrected_position.eta();
 }
 
@@ -413,13 +421,13 @@ float RecHitTools::getEta(const DetId& id, const float& vertex_z) const {
 }
 
 float RecHitTools::getPhi(const GlobalPoint& position) const {
-  float phi = atan2(position.y(),position.x());
+  float phi = atan2(position.y(), position.x());
   return phi;
 }
 
 float RecHitTools::getPhi(const DetId& id) const {
   GlobalPoint position = getPosition(id);
-  float phi = atan2(position.y(),position.x());
+  float phi = atan2(position.y(), position.x());
   return phi;
 }
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -71,7 +71,7 @@ namespace {
     const HGCalDDDConstants* ddd = &(hg->topology().dddConstants());
     check_ddd(ddd);
     return ddd;
-  }						
+  }
 
 }
 
@@ -92,9 +92,11 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
     wmaxEE    = (geomEE->topology().dddConstants()).waferCount(0);
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
-    bhOffset_ = fhOffset_;
     wmaxFH    = (geomFH->topology().dddConstants()).waferCount(0);
     fhLastLayer_ = fhOffset_ + (geomFH->topology().dddConstants()).layers(true);
+    auto geomBH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
+    bhOffset_ = fhOffset_ + (geomBH->topology().dddConstants()).firstLayer() - (geomEE->topology().dddConstants()).firstLayer();
+    bhLastLayer_ = bhOffset_ + (geomBH->topology().dddConstants()).layers(true);
   }
   else {
     geometryType_ = 0;
@@ -105,6 +107,8 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
     bhOffset_ = fhOffset_ + (geomFH->topology().dddConstants()).layers(true);
     wmaxFH    = 1 + (geomFH->topology().dddConstants()).waferMax();
     fhLastLayer_ = bhOffset_;
+    auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+    bhLastLayer_ = bhOffset_ + (geomBH->topology().dddConstants())->getMaxDepth(1);
   }
   maxNumberOfWafersPerLayer_ = std::max(wmaxEE,wmaxFH);
   // For nose geometry
@@ -337,9 +341,9 @@ unsigned int RecHitTools::getLayerWithOffset(const DetId& id) const {
   unsigned int layer = getLayer(id);
   if (id.det() == DetId::Forward && id.subdetId() == HGCHEF ) {
     layer += fhOffset_;
-  } else if (id.det() == DetId::HGCalHSi || id.det() == DetId::HGCalHSc) {
+  } else if (id.det() == DetId::HGCalHSi) {
     layer += fhOffset_;
-  } else if (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
+  } else if ((id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) || id.det() == DetId::HGCalHSc) {
     layer += bhOffset_;
   }
   return layer;

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -341,9 +341,10 @@ unsigned int RecHitTools::getLayerWithOffset(const DetId& id) const {
   unsigned int layer = getLayer(id);
   if (id.det() == DetId::Forward && id.subdetId() == HGCHEF ) {
     layer += fhOffset_;
-  } else if (id.det() == DetId::HGCalHSi) {
+  } else if (id.det() == DetId::HGCalHSi || id.det() == DetId::HGCalHSc) {
+    // DetId::HGCalHSc hits include the offset w.r.t. EE already
     layer += fhOffset_;
-  } else if ((id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) || id.det() == DetId::HGCalHSc) {
+  } else if (id.det() == DetId::Hcal && id.subdetId() == HcalEndcap) {
     layer += bhOffset_;
   }
   return layer;

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -23,34 +23,32 @@
 #include <string>
 #include <vector>
 
-using Density=hgcal_clustering::Density;
+using Density = hgcal_clustering::Density;
 
 class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
- public:
-
- HGCalCLUEAlgo(const edm::ParameterSet& ps)
-  : HGCalClusteringAlgoBase(
-      (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity",3),
-      reco::CaloCluster::undefined),
-     thresholdW0_(ps.getParameter<std::vector<double> >("thresholdW0")),
-     vecDeltas_(ps.getParameter<std::vector<double> >("deltac")),
-     kappa_(ps.getParameter<double>("kappa")),
-     ecut_(ps.getParameter<double>("ecut")),
-     dependSensor_(ps.getParameter<bool>("dependSensor")),
-     dEdXweights_(ps.getParameter<std::vector<double> >("dEdXweights")),
-     thicknessCorrection_(ps.getParameter<std::vector<double> >("thicknessCorrection")),
-     fcPerMip_(ps.getParameter<std::vector<double> >("fcPerMip")),
-     fcPerEle_(ps.getParameter<double>("fcPerEle")),
-     nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double> >("values")),
-     noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
-     initialized_(false)
-     {}
+public:
+  HGCalCLUEAlgo(const edm::ParameterSet& ps)
+      : HGCalClusteringAlgoBase(
+            (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
+            reco::CaloCluster::undefined),
+        thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
+        vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),
+        kappa_(ps.getParameter<double>("kappa")),
+        ecut_(ps.getParameter<double>("ecut")),
+        dependSensor_(ps.getParameter<bool>("dependSensor")),
+        dEdXweights_(ps.getParameter<std::vector<double>>("dEdXweights")),
+        thicknessCorrection_(ps.getParameter<std::vector<double>>("thicknessCorrection")),
+        fcPerMip_(ps.getParameter<std::vector<double>>("fcPerMip")),
+        fcPerEle_(ps.getParameter<double>("fcPerEle")),
+        nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
+        noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
+        initialized_(false) {}
 
   ~HGCalCLUEAlgo() override {}
 
   void getEventSetupPerAlgorithm(const edm::EventSetup& es) override;
 
-  void populate(const HGCRecHitCollection &hits) override;
+  void populate(const HGCRecHitCollection& hits) override;
 
   // this is the method that will start the clusterisation (it is possible to invoke this method
   // more than once - but make sure it is with different hit collections (or else use reset)
@@ -62,14 +60,12 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
   void reset() override {
     clusters_v_.clear();
-    for(auto& cl: numberOfClustersPerLayer_)
-    {
+    for (auto& cl : numberOfClustersPerLayer_) {
       cl = 0;
     }
 
-    for(auto& cells : cells_)
+    for (auto& cells : cells_)
       cells.clear();
-
   }
 
   Density getDensity() override;
@@ -77,40 +73,37 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
   void computeThreshold();
 
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
-    iDesc.add<std::vector<double>>("thresholdW0", {
-        2.9,
-        2.9,
-        2.9
-        });
-    iDesc.add<std::vector<double>>("deltac", {
-        1.3,
-        1.3,
-        5.0,
-        });
+    iDesc.add<std::vector<double>>("thresholdW0", {2.9, 2.9, 2.9});
+    iDesc.add<std::vector<double>>("deltac",
+                                   {
+                                       1.3,
+                                       1.3,
+                                       5.0,
+                                   });
     iDesc.add<bool>("dependSensor", true);
     iDesc.add<double>("ecut", 3.0);
     iDesc.add<double>("kappa", 9.0);
     iDesc.addUntracked<unsigned int>("verbosity", 3);
-    iDesc.add<std::vector<double>>("dEdXweights",{});
-    iDesc.add<std::vector<double>>("thicknessCorrection",{});
-    iDesc.add<std::vector<double>>("fcPerMip",{});
-    iDesc.add<double>("fcPerEle",0.0);
+    iDesc.add<std::vector<double>>("dEdXweights", {});
+    iDesc.add<std::vector<double>>("thicknessCorrection", {});
+    iDesc.add<std::vector<double>>("fcPerMip", {});
+    iDesc.add<double>("fcPerEle", 0.0);
     edm::ParameterSetDescription descNestedNoises;
-    descNestedNoises.add<std::vector<double> >("values", {});
+    descNestedNoises.add<std::vector<double>>("values", {});
     iDesc.add<edm::ParameterSetDescription>("noises", descNestedNoises);
     edm::ParameterSetDescription descNestedNoiseMIP;
-    descNestedNoiseMIP.add<bool>("scaleByDose", false );
+    descNestedNoiseMIP.add<bool>("scaleByDose", false);
     iDesc.add<edm::ParameterSetDescription>("scaleByDose", descNestedNoiseMIP);
-    descNestedNoiseMIP.add<std::string>("doseMap", "" );
+    descNestedNoiseMIP.add<std::string>("doseMap", "");
     iDesc.add<edm::ParameterSetDescription>("doseMap", descNestedNoiseMIP);
-    descNestedNoiseMIP.add<double>("noise_MIP", 1./100. );
+    descNestedNoiseMIP.add<double>("noise_MIP", 1. / 100.);
     iDesc.add<edm::ParameterSetDescription>("noiseMip", descNestedNoiseMIP);
   }
 
   /// point in the space
   typedef math::XYZPoint Point;
 
- private:
+private:
   // To compute the cluster position
   std::vector<double> thresholdW0_;
 
@@ -133,8 +126,8 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
   double fcPerEle_;
   std::vector<double> nonAgedNoises_;
   double noiseMip_;
-  std::vector<std::vector<double> > thresholds_;
-  std::vector<std::vector<double> > v_sigmaNoise_;
+  std::vector<std::vector<double>> thresholds_;
+  std::vector<std::vector<double>> v_sigmaNoise_;
 
   // initialization bool
   bool initialized_;
@@ -153,11 +146,10 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
     std::vector<int> nearestHigher;
     std::vector<int> clusterIndex;
     std::vector<float> sigmaNoise;
-    std::vector< std::vector <int> > followers;
+    std::vector<std::vector<int>> followers;
     std::vector<bool> isSeed;
 
-    void clear()
-    {
+    void clear() {
       detid.clear();
       x.clear();
       y.clear();
@@ -182,16 +174,17 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
     return (dx * dx + dy * dy);
   }
 
-  inline float distance(int cell1,
-                         int cell2, int layerId) const {  // 2-d distance on the layer (x-y)
+  inline float distance(int cell1, int cell2, int layerId) const {  // 2-d distance on the layer (x-y)
     return std::sqrt(distance2(cell1, cell2, layerId));
   }
 
   void prepareDataStructures(const unsigned int layerId);
-  void calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);  // return max density
+  void calculateLocalDensity(const HGCalLayerTiles& lt,
+                             const unsigned int layerId,
+                             float delta_c);  // return max density
   void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);
   int findAndAssignClusters(const unsigned int layerId, float delta_c);
-  math::XYZPoint calculatePosition(const std::vector<int> &v, const unsigned int layerId) const;
+  math::XYZPoint calculatePosition(const std::vector<int>& v, const unsigned int layerId) const;
   void setDensity(const unsigned int layerId);
 };
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -43,12 +43,12 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
      fcPerEle_(ps.getParameter<double>("fcPerEle")),
      nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double> >("values")),
      noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
-     initialized_(false),
-     cells_(2*(maxlayer+1)),
-     numberOfClustersPerLayer_(2*(maxlayer+1),0)
+     initialized_(false)
      {}
 
   ~HGCalCLUEAlgo() override {}
+
+  void getEventSetupPerAlgorithm(const edm::EventSetup& es) override;
 
   void populate(const HGCRecHitCollection &hits) override;
 
@@ -69,7 +69,7 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
     for(auto& cells : cells_)
       cells.clear();
-    
+
   }
 
   Density getDensity() override;
@@ -143,10 +143,10 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
   struct CellsOnLayer {
     std::vector<DetId> detid;
-    std::vector<float> x; 
+    std::vector<float> x;
     std::vector<float> y;
 
-    std::vector<float> weight; 
+    std::vector<float> weight;
     std::vector<float> rho;
 
     std::vector<float> delta;
@@ -171,22 +171,22 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
       isSeed.clear();
     }
   };
-  
+
   std::vector<CellsOnLayer> cells_;
-  
+
   std::vector<int> numberOfClustersPerLayer_;
 
   inline float distance2(int cell1, int cell2, int layerId) const {  // distance squared
     const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
     const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
     return (dx * dx + dy * dy);
-  }  
+  }
 
   inline float distance(int cell1,
                          int cell2, int layerId) const {  // 2-d distance on the layer (x-y)
     return std::sqrt(distance2(cell1, cell2, layerId));
   }
-  
+
   void prepareDataStructures(const unsigned int layerId);
   void calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);  // return max density
   void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -14,91 +14,79 @@
 #include <numeric>
 
 namespace hgcal_clustering {
-template <typename T>
-std::vector<size_t> sorted_indices(const std::vector<T> &v) {
+  template <typename T>
+  std::vector<size_t> sorted_indices(const std::vector<T> &v) {
+    // initialize original index locations
+    std::vector<size_t> idx(v.size());
+    std::iota(std::begin(idx), std::end(idx), 0);
 
-        // initialize original index locations
-        std::vector<size_t> idx(v.size());
-        std::iota (std::begin(idx), std::end(idx), 0);
+    // sort indices based on comparing values in v
+    std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return v[i1] > v[i2]; });
 
-        // sort indices based on comparing values in v
-        std::sort(idx.begin(), idx.end(),
-                  [&v](size_t i1, size_t i2) {
-                return v[i1] > v[i2];
-        });
+    return idx;
+  }
 
-        return idx;
-}
+  template <typename T>
+  size_t max_index(const std::vector<T> &v) {
+    // initialize original index locations
+    std::vector<size_t> idx(v.size(), 0);
+    std::iota(std::begin(idx), std::end(idx), 0);
 
-template <typename T>
-size_t max_index(const std::vector<T> &v) {
+    // take the max index based on comparing values in v
+    auto maxidx = std::max_element(
+        idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return v[i1].data.rho < v[i2].data.rho; });
 
-        // initialize original index locations
-        std::vector<size_t> idx(v.size(),0);
-        std::iota (std::begin(idx), std::end(idx), 0);
+    return (*maxidx);
+  }
 
-        // take the max index based on comparing values in v
-        auto maxidx = std::max_element(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) {return v[i1].data.rho < v[i2].data.rho;});
+  //Density collection
+  typedef std::map<DetId, float> Density;
 
-        return (*maxidx);
-}
+};  // namespace hgcal_clustering
 
-//Density collection
-typedef std::map< DetId, float > Density;
-
-};
-
-class HGCalClusteringAlgoBase
-{
-
+class HGCalClusteringAlgoBase {
 public:
+  enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
-enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
+  HGCalClusteringAlgoBase(VerbosityLevel v, reco::CaloCluster::AlgoId algo) : verbosity_(v), algoId_(algo){};
+  virtual ~HGCalClusteringAlgoBase() {}
 
- HGCalClusteringAlgoBase(VerbosityLevel v,
-     reco::CaloCluster::AlgoId algo)
-   : verbosity_(v), algoId_(algo) {};
- virtual ~HGCalClusteringAlgoBase() {}
+  virtual void populate(const HGCRecHitCollection &hits) = 0;
+  virtual void makeClusters() = 0;
+  virtual std::vector<reco::BasicCluster> getClusters(bool) = 0;
+  virtual void reset() = 0;
+  virtual hgcal_clustering::Density getDensity() = 0;
+  virtual void getEventSetupPerAlgorithm(const edm::EventSetup &es) {}
 
- virtual void populate(const HGCRecHitCollection &hits) = 0;
- virtual void makeClusters() = 0;
- virtual std::vector<reco::BasicCluster> getClusters(bool) = 0;
- virtual void reset() = 0;
- virtual hgcal_clustering::Density getDensity() = 0;
- virtual void getEventSetupPerAlgorithm(const edm::EventSetup& es){}
+  inline void getEventSetup(const edm::EventSetup &es) {
+    rhtools_.getEventSetup(es);
+    maxlayer_ = rhtools_.lastLayerBH();
+    lastLayerEE_ = rhtools_.lastLayerEE();
+    lastLayerFH_ = rhtools_.lastLayerFH();
+    firstLayerBH_ = rhtools_.firstLayerBH();
+    getEventSetupPerAlgorithm(es);
+  }
+  inline void setVerbosity(VerbosityLevel the_verbosity) { verbosity_ = the_verbosity; }
+  inline void setAlgoId(reco::CaloCluster::AlgoId algo) { algoId_ = algo; }
 
- inline void getEventSetup(const edm::EventSetup& es){
-   rhtools_.getEventSetup(es);
-   maxlayer_ = rhtools_.lastLayerBH();
-   lastLayerEE_ = rhtools_.lastLayerEE();
-   lastLayerFH_ = rhtools_.lastLayerFH();
-   firstLayerBH_ = rhtools_.firstLayerBH();
-   getEventSetupPerAlgorithm(es);
- }
- inline void setVerbosity(VerbosityLevel the_verbosity) {
-   verbosity_ = the_verbosity;
- }
- inline void setAlgoId(reco::CaloCluster::AlgoId algo) {algoId_ = algo;}
-
- //max number of layers
- unsigned int maxlayer_;
- // last layer per subdetector
- unsigned int lastLayerEE_;
- unsigned int lastLayerFH_;
- unsigned int firstLayerBH_;
+  //max number of layers
+  unsigned int maxlayer_;
+  // last layer per subdetector
+  unsigned int lastLayerEE_;
+  unsigned int lastLayerFH_;
+  unsigned int firstLayerBH_;
 
 protected:
- // The verbosity level
- VerbosityLevel verbosity_;
+  // The verbosity level
+  VerbosityLevel verbosity_;
 
- // The vector of clusters
- std::vector<reco::BasicCluster> clusters_v_;
+  // The vector of clusters
+  std::vector<reco::BasicCluster> clusters_v_;
 
- hgcal::RecHitTools rhtools_;
+  hgcal::RecHitTools rhtools_;
 
- // The algo id
- reco::CaloCluster::AlgoId algoId_;
-
+  // The algo id
+  reco::CaloCluster::AlgoId algoId_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -65,9 +65,14 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
  virtual std::vector<reco::BasicCluster> getClusters(bool) = 0;
  virtual void reset() = 0;
  virtual hgcal_clustering::Density getDensity() = 0;
+ virtual void getEventSetupPerAlgorithm(const edm::EventSetup& es){}
 
  inline void getEventSetup(const edm::EventSetup& es){
    rhtools_.getEventSetup(es);
+   maxlayer = rhtools_.lastLayerBH();
+   lastLayerEE = rhtools_.lastLayerEE();
+   lastLayerFH = rhtools_.lastLayerFH();
+   getEventSetupPerAlgorithm(es);
  }
  inline void setVerbosity(VerbosityLevel the_verbosity) {
    verbosity_ = the_verbosity;
@@ -75,10 +80,10 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
  inline void setAlgoId(reco::CaloCluster::AlgoId algo) {algoId_ = algo;}
 
  //max number of layers
- static const unsigned int maxlayer = 52;
+ unsigned int maxlayer;
  // last layer per subdetector
- static const unsigned int lastLayerEE = 28;
- static const unsigned int lastLayerFH = 40;
+ unsigned int lastLayerEE;
+ unsigned int lastLayerFH;
 
 protected:
  // The verbosity level

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -69,9 +69,9 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
  inline void getEventSetup(const edm::EventSetup& es){
    rhtools_.getEventSetup(es);
-   maxlayer = rhtools_.lastLayerBH();
-   lastLayerEE = rhtools_.lastLayerEE();
-   lastLayerFH = rhtools_.lastLayerFH();
+   maxlayer_ = rhtools_.lastLayerBH();
+   lastLayerEE_ = rhtools_.lastLayerEE();
+   lastLayerFH_ = rhtools_.lastLayerFH();
    getEventSetupPerAlgorithm(es);
  }
  inline void setVerbosity(VerbosityLevel the_verbosity) {
@@ -80,10 +80,10 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
  inline void setAlgoId(reco::CaloCluster::AlgoId algo) {algoId_ = algo;}
 
  //max number of layers
- unsigned int maxlayer;
+ unsigned int maxlayer_;
  // last layer per subdetector
- unsigned int lastLayerEE;
- unsigned int lastLayerFH;
+ unsigned int lastLayerEE_;
+ unsigned int lastLayerFH_;
 
 protected:
  // The verbosity level

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -72,6 +72,7 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
    maxlayer_ = rhtools_.lastLayerBH();
    lastLayerEE_ = rhtools_.lastLayerEE();
    lastLayerFH_ = rhtools_.lastLayerFH();
+   firstLayerBH_ = rhtools_.firstLayerBH();
    getEventSetupPerAlgorithm(es);
  }
  inline void setVerbosity(VerbosityLevel the_verbosity) {
@@ -84,6 +85,7 @@ enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
  // last layer per subdetector
  unsigned int lastLayerEE_;
  unsigned int lastLayerFH_;
+ unsigned int firstLayerBH_;
 
 protected:
  // The verbosity level

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
@@ -49,13 +49,11 @@ public:
      fcPerEle_(ps.getParameter<double>("fcPerEle")),
      nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double> >("values")),
      noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
-     initialized_(false),
-     points_(2*(maxlayer+1)),
-     minpos_(2*(maxlayer+1),{ {0.0f,0.0f} }),
-     maxpos_(2*(maxlayer+1),{ {0.0f,0.0f} }) {}
+     initialized_(false) {}
 
 ~HGCalImagingAlgo() override {}
 
+void getEventSetupPerAlgorithm(const edm::EventSetup& es) override;
 
 void populate(const HGCRecHitCollection &hits) override;
 // this is the method that will start the clusterisation (it is possible to invoke this method more than once - but make sure it is with

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalImagingAlgo.h
@@ -28,233 +28,236 @@
 
 using Density = hgcal_clustering::Density;
 
-class HGCalImagingAlgo : public HGCalClusteringAlgoBase
-{
+class HGCalImagingAlgo : public HGCalClusteringAlgoBase {
 public:
+  HGCalImagingAlgo(const edm::ParameterSet &ps)
+      : HGCalClusteringAlgoBase(
+            (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
+            reco::CaloCluster::undefined),
+        thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
+        positionDeltaRho_c_(ps.getParameter<std::vector<double>>("positionDeltaRho_c")),
+        vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),
+        kappa_(ps.getParameter<double>("kappa")),
+        ecut_(ps.getParameter<double>("ecut")),
+        sigma2_(1.0),
+        dependSensor_(ps.getParameter<bool>("dependSensor")),
+        dEdXweights_(ps.getParameter<std::vector<double>>("dEdXweights")),
+        thicknessCorrection_(ps.getParameter<std::vector<double>>("thicknessCorrection")),
+        fcPerMip_(ps.getParameter<std::vector<double>>("fcPerMip")),
+        fcPerEle_(ps.getParameter<double>("fcPerEle")),
+        nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
+        noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
+        initialized_(false) {}
 
- HGCalImagingAlgo(const edm::ParameterSet& ps)
-  : HGCalClusteringAlgoBase(
-      (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity",3),
-      reco::CaloCluster::undefined),
-     thresholdW0_(ps.getParameter<std::vector<double> >("thresholdW0")),
-     positionDeltaRho_c_(ps.getParameter<std::vector<double> >("positionDeltaRho_c")),
-     vecDeltas_(ps.getParameter<std::vector<double> >("deltac")),
-     kappa_(ps.getParameter<double>("kappa")),
-     ecut_(ps.getParameter<double>("ecut")),
-     sigma2_(1.0),
-     dependSensor_(ps.getParameter<bool>("dependSensor")),
-     dEdXweights_(ps.getParameter<std::vector<double> >("dEdXweights")),
-     thicknessCorrection_(ps.getParameter<std::vector<double> >("thicknessCorrection")),
-     fcPerMip_(ps.getParameter<std::vector<double> >("fcPerMip")),
-     fcPerEle_(ps.getParameter<double>("fcPerEle")),
-     nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double> >("values")),
-     noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
-     initialized_(false) {}
+  ~HGCalImagingAlgo() override {}
 
-~HGCalImagingAlgo() override {}
+  void getEventSetupPerAlgorithm(const edm::EventSetup &es) override;
 
-void getEventSetupPerAlgorithm(const edm::EventSetup& es) override;
+  void populate(const HGCRecHitCollection &hits) override;
+  // this is the method that will start the clusterisation (it is possible to invoke this method more than once - but make sure it is with
+  // different hit collections (or else use reset)
 
-void populate(const HGCRecHitCollection &hits) override;
-// this is the method that will start the clusterisation (it is possible to invoke this method more than once - but make sure it is with
-// different hit collections (or else use reset)
+  void makeClusters() override;
 
-void makeClusters() override;
+  // this is the method to get the cluster collection out
+  std::vector<reco::BasicCluster> getClusters(bool) override;
 
-// this is the method to get the cluster collection out
-std::vector<reco::BasicCluster> getClusters(bool) override;
+  // use this if you want to reuse the same cluster object but don't want to accumulate clusters (hardly useful?)
+  void reset() override {
+    clusters_v_.clear();
+    layerClustersPerLayer_.clear();
+    for (auto &it : points_) {
+      it.clear();
+      std::vector<KDNode>().swap(it);
+    }
+    for (unsigned int i = 0; i < minpos_.size(); i++) {
+      minpos_[i][0] = 0.;
+      minpos_[i][1] = 0.;
+      maxpos_[i][0] = 0.;
+      maxpos_[i][1] = 0.;
+    }
+  }
+  void computeThreshold();
 
-// use this if you want to reuse the same cluster object but don't want to accumulate clusters (hardly useful?)
-void reset() override {
-        clusters_v_.clear();
-        layerClustersPerLayer_.clear();
-        for( auto& it: points_)
-        {
-                it.clear();
-                std::vector<KDNode>().swap(it);
-        }
-        for(unsigned int i = 0; i < minpos_.size(); i++)
-        {
-                minpos_[i][0]=0.; minpos_[i][1]=0.;
-                maxpos_[i][0]=0.; maxpos_[i][1]=0.;
-        }
-}
-void computeThreshold();
+  //getDensity
+  Density getDensity() override;
 
-//getDensity
- Density getDensity() override;
+  static void fillPSetDescription(edm::ParameterSetDescription &iDesc) {
+    iDesc.add<std::vector<double>>("thresholdW0", {2.9, 2.9, 2.9});
+    iDesc.add<std::vector<double>>("positionDeltaRho_c", {1.3, 1.3, 1.3});
+    iDesc.add<std::vector<double>>("deltac",
+                                   {
+                                       2.0,
+                                       2.0,
+                                       5.0,
+                                   });
+    iDesc.add<bool>("dependSensor", true);
+    iDesc.add<double>("ecut", 3.0);
+    iDesc.add<double>("kappa", 9.0);
+    iDesc.addUntracked<unsigned int>("verbosity", 3);
+    iDesc.add<std::vector<double>>("dEdXweights", {});
+    iDesc.add<std::vector<double>>("thicknessCorrection", {});
+    iDesc.add<std::vector<double>>("fcPerMip", {});
+    iDesc.add<double>("fcPerEle", 0.0);
+    edm::ParameterSetDescription descNestedNoises;
+    descNestedNoises.add<std::vector<double>>("values", {});
+    iDesc.add<edm::ParameterSetDescription>("noises", descNestedNoises);
+    edm::ParameterSetDescription descNestedNoiseMIP;
+    descNestedNoiseMIP.add<bool>("scaleByDose", false);
+    iDesc.add<edm::ParameterSetDescription>("scaleByDose", descNestedNoiseMIP);
+    descNestedNoiseMIP.add<std::string>("doseMap", "");
+    iDesc.add<edm::ParameterSetDescription>("doseMap", descNestedNoiseMIP);
+    descNestedNoiseMIP.add<double>("noise_MIP", 1. / 100.);
+    iDesc.add<edm::ParameterSetDescription>("noiseMip", descNestedNoiseMIP);
+  }
 
-static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
-  iDesc.add<std::vector<double>>("thresholdW0", {
-    2.9,
-    2.9,
-    2.9
-  });
-  iDesc.add<std::vector<double>>("positionDeltaRho_c", {
-    1.3,
-    1.3,
-    1.3
-  });
-  iDesc.add<std::vector<double>>("deltac", {
-    2.0,
-    2.0,
-    5.0,
-  });
-  iDesc.add<bool>("dependSensor", true);
-  iDesc.add<double>("ecut", 3.0);
-  iDesc.add<double>("kappa", 9.0);
-  iDesc.addUntracked<unsigned int>("verbosity", 3);
-  iDesc.add<std::vector<double>>("dEdXweights",{});
-  iDesc.add<std::vector<double>>("thicknessCorrection",{});
-  iDesc.add<std::vector<double>>("fcPerMip",{});
-  iDesc.add<double>("fcPerEle",0.0);
-  edm::ParameterSetDescription descNestedNoises;
-  descNestedNoises.add<std::vector<double> >("values", {});
-  iDesc.add<edm::ParameterSetDescription>("noises", descNestedNoises);
-  edm::ParameterSetDescription descNestedNoiseMIP;
-  descNestedNoiseMIP.add<bool>("scaleByDose", false );
-  iDesc.add<edm::ParameterSetDescription>("scaleByDose", descNestedNoiseMIP);
-  descNestedNoiseMIP.add<std::string>("doseMap", "" );
-  iDesc.add<edm::ParameterSetDescription>("doseMap", descNestedNoiseMIP);
-  descNestedNoiseMIP.add<double>("noise_MIP", 1./100. );
-  iDesc.add<edm::ParameterSetDescription>("noiseMip", descNestedNoiseMIP);
-}
-
-/// point in the space
-typedef math::XYZPoint Point;
+  /// point in the space
+  typedef math::XYZPoint Point;
 
 private:
+  // To compute the cluster position
+  std::vector<double> thresholdW0_;
+  std::vector<double> positionDeltaRho_c_;
 
-// To compute the cluster position
-std::vector<double> thresholdW0_;
-std::vector<double> positionDeltaRho_c_;
+  // The two parameters used to identify clusters
+  std::vector<double> vecDeltas_;
+  double kappa_;
 
-// The two parameters used to identify clusters
-std::vector<double> vecDeltas_;
-double kappa_;
+  // The hit energy cutoff
+  double ecut_;
 
-// The hit energy cutoff
-double ecut_;
+  // for energy sharing
+  double sigma2_;  // transverse shower size
 
-// for energy sharing
-double sigma2_;   // transverse shower size
+  // The vector of clusters
+  std::vector<reco::BasicCluster> clusters_v_;
 
-// The vector of clusters
-std::vector<reco::BasicCluster> clusters_v_;
+  // For keeping the density per hit
+  Density density_;
 
-// For keeping the density per hit
- Density density_;
+  // various parameters used for calculating the noise levels for a given sensor (and whether to use them)
+  bool dependSensor_;
+  std::vector<double> dEdXweights_;
+  std::vector<double> thicknessCorrection_;
+  std::vector<double> fcPerMip_;
+  double fcPerEle_;
+  std::vector<double> nonAgedNoises_;
+  double noiseMip_;
+  std::vector<std::vector<double>> thresholds_;
+  std::vector<std::vector<double>> sigmaNoise_;
 
-// various parameters used for calculating the noise levels for a given sensor (and whether to use them)
-bool dependSensor_;
-std::vector<double> dEdXweights_;
-std::vector<double> thicknessCorrection_;
-std::vector<double> fcPerMip_;
-double fcPerEle_;
-std::vector<double> nonAgedNoises_;
-double noiseMip_;
-std::vector<std::vector<double> > thresholds_;
-std::vector<std::vector<double> > sigmaNoise_;
+  // initialization bool
+  bool initialized_;
 
-// initialization bool
-bool initialized_;
+  struct Hexel {
+    double x;
+    double y;
+    double z;
+    bool isHalfCell;
+    double weight;
+    double fraction;
+    DetId detid;
+    double rho;
+    double delta;
+    int nearestHigher;
+    bool isBorder;
+    bool isHalo;
+    int clusterIndex;
+    float sigmaNoise;
+    float thickness;
+    const hgcal::RecHitTools *tools;
 
-struct Hexel {
+    Hexel(const HGCRecHit &hit,
+          DetId id_in,
+          bool isHalf,
+          float sigmaNoise_in,
+          float thickness_in,
+          const hgcal::RecHitTools *tools_in)
+        : isHalfCell(isHalf),
+          weight(0.),
+          fraction(1.0),
+          detid(id_in),
+          rho(0.),
+          delta(0.),
+          nearestHigher(-1),
+          isBorder(false),
+          isHalo(false),
+          clusterIndex(-1),
+          sigmaNoise(sigmaNoise_in),
+          thickness(thickness_in),
+          tools(tools_in) {
+      const GlobalPoint position(tools->getPosition(detid));
+      weight = hit.energy();
+      x = position.x();
+      y = position.y();
+      z = position.z();
+    }
+    Hexel()
+        : x(0.),
+          y(0.),
+          z(0.),
+          isHalfCell(false),
+          weight(0.),
+          fraction(1.0),
+          detid(),
+          rho(0.),
+          delta(0.),
+          nearestHigher(-1),
+          isBorder(false),
+          isHalo(false),
+          clusterIndex(-1),
+          sigmaNoise(0.),
+          thickness(0.),
+          tools(nullptr) {}
+    bool operator>(const Hexel &rhs) const { return (rho > rhs.rho); }
+  };
 
-        double x;
-        double y;
-        double z;
-        bool isHalfCell;
-        double weight;
-        double fraction;
-        DetId detid;
-        double rho;
-        double delta;
-        int nearestHigher;
-        bool isBorder;
-        bool isHalo;
-        int clusterIndex;
-        float sigmaNoise;
-        float thickness;
-        const hgcal::RecHitTools *tools;
+  typedef KDTreeLinkerAlgo<Hexel> KDTree;
+  typedef KDTreeNodeInfo<Hexel> KDNode;
 
-        Hexel(const HGCRecHit &hit, DetId id_in, bool isHalf, float sigmaNoise_in, float thickness_in, const hgcal::RecHitTools *tools_in) :
-                isHalfCell(isHalf),
-                weight(0.), fraction(1.0), detid(id_in), rho(0.), delta(0.),
-                nearestHigher(-1), isBorder(false), isHalo(false),
-                clusterIndex(-1), sigmaNoise(sigmaNoise_in), thickness(thickness_in),
-                tools(tools_in)
-        {
-                const GlobalPoint position( tools->getPosition( detid ) );
-                weight = hit.energy();
-                x = position.x();
-                y = position.y();
-                z = position.z();
-        }
-        Hexel() :
-                x(0.),y(0.),z(0.),isHalfCell(false),
-                weight(0.), fraction(1.0), detid(), rho(0.), delta(0.),
-                nearestHigher(-1), isBorder(false), isHalo(false),
-                clusterIndex(-1),
-                sigmaNoise(0.),
-                thickness(0.),
-                tools(nullptr)
-        {
-        }
-        bool operator > (const Hexel& rhs) const {
-                return (rho > rhs.rho);
-        }
+  std::vector<std::vector<std::vector<KDNode>>> layerClustersPerLayer_;
 
-};
+  std::vector<size_t> sort_by_delta(const std::vector<KDNode> &v) const {
+    std::vector<size_t> idx(v.size());
+    std::iota(std::begin(idx), std::end(idx), 0);
+    sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return v[i1].data.delta > v[i2].data.delta; });
+    return idx;
+  }
 
-typedef KDTreeLinkerAlgo<Hexel> KDTree;
-typedef KDTreeNodeInfo<Hexel> KDNode;
+  std::vector<std::vector<KDNode>> points_;  //a vector of vectors of hexels, one for each layer
+  //@@EM todo: the number of layers should be obtained programmatically - the range is 1-n instead of 0-n-1...
 
+  std::vector<std::array<float, 2>> minpos_;
+  std::vector<std::array<float, 2>> maxpos_;
 
-std::vector<std::vector<std::vector< KDNode> > > layerClustersPerLayer_;
+  //these functions should be in a helper class.
+  inline double distance2(const Hexel &pt1, const Hexel &pt2) const {  //distance squared
+    const double dx = pt1.x - pt2.x;
+    const double dy = pt1.y - pt2.y;
+    return (dx * dx + dy * dy);
+  }                                                                   //distance squaredq
+  inline double distance(const Hexel &pt1, const Hexel &pt2) const {  //2-d distance on the layer (x-y)
+    return std::sqrt(distance2(pt1, pt2));
+  }
+  double calculateLocalDensity(std::vector<KDNode> &, KDTree &, const unsigned int) const;  //return max density
+  double calculateDistanceToHigher(std::vector<KDNode> &) const;
+  int findAndAssignClusters(std::vector<KDNode> &,
+                            KDTree &,
+                            double,
+                            KDTreeBox<2> &,
+                            const unsigned int,
+                            std::vector<std::vector<KDNode>> &) const;
+  math::XYZPoint calculatePosition(std::vector<KDNode> &) const;
 
-std::vector<size_t> sort_by_delta(const std::vector<KDNode> &v) const {
-        std::vector<size_t> idx(v.size());
-        std::iota (std::begin(idx), std::end(idx), 0);
-        sort(idx.begin(), idx.end(),
-             [&v](size_t i1, size_t i2) {
-                        return v[i1].data.delta > v[i2].data.delta;
-                });
-        return idx;
-}
+  //For keeping the density information
+  void setDensity(const std::vector<KDNode> &nd);
 
-std::vector<std::vector<KDNode> > points_;   //a vector of vectors of hexels, one for each layer
-//@@EM todo: the number of layers should be obtained programmatically - the range is 1-n instead of 0-n-1...
-
-std::vector<std::array<float,2> > minpos_;
-std::vector<std::array<float,2> > maxpos_;
-
-
-//these functions should be in a helper class.
-inline double distance2(const Hexel &pt1, const Hexel &pt2) const{   //distance squared
-        const double dx = pt1.x - pt2.x;
-        const double dy = pt1.y - pt2.y;
-        return (dx*dx + dy*dy);
-}   //distance squaredq
-inline double distance(const Hexel &pt1, const Hexel &pt2) const{   //2-d distance on the layer (x-y)
-        return std::sqrt(distance2(pt1,pt2));
-}
-double calculateLocalDensity(std::vector<KDNode> &, KDTree &, const unsigned int) const;   //return max density
-double calculateDistanceToHigher(std::vector<KDNode> &) const;
-int findAndAssignClusters(std::vector<KDNode> &, KDTree &, double, KDTreeBox<2> &, const unsigned int, std::vector<std::vector<KDNode> >&) const;
-math::XYZPoint calculatePosition(std::vector<KDNode> &) const;
-
-//For keeping the density information
- void setDensity(const std::vector<KDNode> &nd);
-
-// attempt to find subclusters within a given set of hexels
-std::vector<unsigned> findLocalMaximaInCluster(const std::vector<KDNode>&);
-math::XYZPoint calculatePositionWithFraction(const std::vector<KDNode>&, const std::vector<double>&);
-double calculateEnergyWithFraction(const std::vector<KDNode>&, const std::vector<double>&);
-// outputs
-void shareEnergy(const std::vector<KDNode>&,
-                 const std::vector<unsigned>&,
-                 std::vector<std::vector<double> >&);
+  // attempt to find subclusters within a given set of hexels
+  std::vector<unsigned> findLocalMaximaInCluster(const std::vector<KDNode> &);
+  math::XYZPoint calculatePositionWithFraction(const std::vector<KDNode> &, const std::vector<double> &);
+  double calculateEnergyWithFraction(const std::vector<KDNode> &, const std::vector<double> &);
+  // outputs
+  void shareEnergy(const std::vector<KDNode> &, const std::vector<unsigned> &, std::vector<std::vector<double>> &);
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h
@@ -5,33 +5,35 @@
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 
 namespace edm {
-        class Event;
-        class EventSetup;
-        class ParameterSet;
-}
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
-
-// this worker class structure is not well thought out and needs to 
+// this worker class structure is not well thought out and needs to
 // change in the future.
 class HGCalUncalibRecHitWorkerBaseClass {
-        public:
-                HGCalUncalibRecHitWorkerBaseClass(const edm::ParameterSet&){}
-                virtual ~HGCalUncalibRecHitWorkerBaseClass(){}
+public:
+  HGCalUncalibRecHitWorkerBaseClass(const edm::ParameterSet&) {}
+  virtual ~HGCalUncalibRecHitWorkerBaseClass() {}
 
-                // do event setup things
-                virtual void set(const edm::EventSetup& es) = 0;
+  // do event setup things
+  virtual void set(const edm::EventSetup& es) = 0;
 
-                // run HGC-EE things
-                virtual bool runHGCEE(const HGCalDigiCollection::const_iterator & digi, HGCeeUncalibratedRecHitCollection & result) = 0;
+  // run HGC-EE things
+  virtual bool runHGCEE(const HGCalDigiCollection::const_iterator& digi, HGCeeUncalibratedRecHitCollection& result) = 0;
 
-                // run HGC-FH things
-                virtual bool runHGCHEsil(const HGCalDigiCollection::const_iterator & digi, HGChefUncalibratedRecHitCollection & result) = 0;
+  // run HGC-FH things
+  virtual bool runHGCHEsil(const HGCalDigiCollection::const_iterator& digi,
+                           HGChefUncalibratedRecHitCollection& result) = 0;
 
-                // run HGC-BH things
-                virtual bool runHGCHEscint(const HGCalDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) = 0;
+  // run HGC-BH things
+  virtual bool runHGCHEscint(const HGCalDigiCollection::const_iterator& digi,
+                             HGChebUncalibratedRecHitCollection& result) = 0;
 
-                // run HFNose things
-                virtual bool runHGCHFNose(const HGCalDigiCollection::const_iterator & digi, HGChfnoseUncalibratedRecHitCollection & result) = 0;
+  // run HFNose things
+  virtual bool runHGCHFNose(const HGCalDigiCollection::const_iterator& digi,
+                            HGChfnoseUncalibratedRecHitCollection& result) = 0;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -90,7 +90,7 @@ void HGCalCLUEAlgo::makeClusters() {
                   // density calculation
       if (i%maxlayer_ < lastLayerEE_)
         delta_c = vecDeltas_[0];
-      else if (i%maxlayer_ < lastLayerFH_)
+      else if (i%maxlayer_ < (firstLayerBH_-1))
         delta_c = vecDeltas_[1];
       else
         delta_c = vecDeltas_[2];

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalImagingAlgo.cc
@@ -14,6 +14,15 @@
 
 using namespace hgcal_clustering;
 
+void HGCalImagingAlgo::getEventSetupPerAlgorithm(const edm::EventSetup& es) {
+  points_.clear();
+  minpos_.clear();
+  maxpos_.clear();
+  points_.resize(2*(maxlayer+1));
+  minpos_.resize(2*(maxlayer+1), { {0.0f,0.0f} });
+  maxpos_.resize(2*(maxlayer+1), { {0.0f,0.0f} });
+}
+
 void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
   // loop over all hits and create the Hexel structure, skip energies below ecut
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalImagingAlgo.cc
@@ -281,7 +281,7 @@ double HGCalImagingAlgo::calculateLocalDensity(std::vector<KDNode> &nd,
                  // density calculation
   if (layer <= lastLayerEE_)
     delta_c = vecDeltas_[0];
-  else if (layer <= lastLayerFH_)
+  else if (layer < firstLayerBH_)
     delta_c = vecDeltas_[1];
   else
     delta_c = vecDeltas_[2];
@@ -373,7 +373,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
   float delta_c; // critical distance
   if (layer <= lastLayerEE_)
     delta_c = vecDeltas_[0];
-  else if (layer <= lastLayerFH_)
+  else if (layer < firstLayerBH_)
     delta_c = vecDeltas_[1];
   else
     delta_c = vecDeltas_[2];

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalImagingAlgo.cc
@@ -14,13 +14,13 @@
 
 using namespace hgcal_clustering;
 
-void HGCalImagingAlgo::getEventSetupPerAlgorithm(const edm::EventSetup& es) {
+void HGCalImagingAlgo::getEventSetupPerAlgorithm(const edm::EventSetup &es) {
   points_.clear();
   minpos_.clear();
   maxpos_.clear();
-  points_.resize(2*(maxlayer_+1));
-  minpos_.resize(2*(maxlayer_+1), { {0.0f,0.0f} });
-  maxpos_.resize(2*(maxlayer_+1), { {0.0f,0.0f} });
+  points_.resize(2 * (maxlayer_ + 1));
+  minpos_.resize(2 * (maxlayer_ + 1), {{0.0f, 0.0f}});
+  maxpos_.resize(2 * (maxlayer_ + 1), {{0.0f, 0.0f}});
 }
 
 void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
@@ -34,7 +34,6 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
 
   std::vector<bool> firstHit(2 * (maxlayer_ + 1), true);
   for (unsigned int i = 0; i < hits.size(); ++i) {
-
     const HGCRecHit &hgrh = hits[i];
     DetId detid = hgrh.detid();
     unsigned int layer = rhtools_.getLayerWithOffset(detid);
@@ -51,8 +50,8 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
       sigmaNoise = sigmaNoise_[layer - 1][thickness_index];
 
       if (hgrh.energy() < storedThreshold)
-        continue; // this sets the ZS threshold at ecut times the sigma noise
-                  // for the sensor
+        continue;  // this sets the ZS threshold at ecut times the sigma noise
+                   // for the sensor
     }
     if (!dependSensor_ && hgrh.energy() < ecut_)
       continue;
@@ -68,8 +67,7 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
     // here's were the KDNode is passed its dims arguments - note that these are
     // *copied* from the Hexel
     points_[layer].emplace_back(
-        Hexel(hgrh, detid, isHalf, sigmaNoise, thickness, &rhtools_),
-        position.x(), position.y());
+        Hexel(hgrh, detid, isHalf, sigmaNoise, thickness, &rhtools_), position.x(), position.y());
 
     // for each layer, store the minimum and maximum x and y coordinates for the
     // KDTreeBox boundaries
@@ -86,7 +84,7 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
       maxpos_[layer][1] = std::max((float)position.y(), maxpos_[layer][1]);
     }
 
-  } // end loop hits
+  }  // end loop hits
 }
 // Create a vector of Hexels associated to one cluster from a collection of
 // HGCalRecHits - this can be used directly to make the final cluster list -
@@ -102,26 +100,23 @@ void HGCalImagingAlgo::makeClusters() {
       hit_kdtree.build(points_[i], bounds);
 
       unsigned int actualLayer =
-          i > maxlayer_
-              ? (i - (maxlayer_ + 1))
-              : i; // maps back from index used for KD trees to actual layer
+          i > maxlayer_ ? (i - (maxlayer_ + 1)) : i;  // maps back from index used for KD trees to actual layer
 
-      double maxdensity = calculateLocalDensity(
-          points_[i], hit_kdtree, actualLayer); // also stores rho (energy
-                                               // density) for each point (node)
+      double maxdensity = calculateLocalDensity(points_[i], hit_kdtree, actualLayer);  // also stores rho (energy
+                                                                                       // density) for each point (node)
       // calculate distance to nearest point with higher density storing
       // distance (delta) and point's index
       calculateDistanceToHigher(points_[i]);
-      findAndAssignClusters(points_[i], hit_kdtree, maxdensity, bounds,
-                            actualLayer, layerClustersPerLayer_[i]);
+      findAndAssignClusters(points_[i], hit_kdtree, maxdensity, bounds, actualLayer, layerClustersPerLayer_[i]);
     });
   });
   //Now that we have the density per point we can store it
-for(auto const& p: points_) { setDensity(p); }
+  for (auto const &p : points_) {
+    setDensity(p);
+  }
 }
 
 std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
-
   reco::CaloID caloID = reco::CaloID::DET_HGCAL_ENDCAP;
   std::vector<std::pair<DetId, float>> thisCluster;
   for (auto &clsOnLayer : layerClustersPerLayer_) {
@@ -133,7 +128,6 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
       size_t rsmax = max_index(clsOnLayer[i]);
 
       if (doSharing) {
-
         std::vector<unsigned> seeds = findLocalMaximaInCluster(clsOnLayer[i]);
         // sharing found seeds.size() sub-cluster seeds in cluster i
 
@@ -146,39 +140,33 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
 
         for (unsigned isub = 0; isub < fractions.size(); ++isub) {
           double effective_hits = 0.0;
-          double energy =
-              calculateEnergyWithFraction(clsOnLayer[i], fractions[isub]);
-          Point position =
-              calculatePositionWithFraction(clsOnLayer[i], fractions[isub]);
+          double energy = calculateEnergyWithFraction(clsOnLayer[i], fractions[isub]);
+          Point position = calculatePositionWithFraction(clsOnLayer[i], fractions[isub]);
 
           for (unsigned ihit = 0; ihit < fractions[isub].size(); ++ihit) {
             const double fraction = fractions[isub][ihit];
             if (fraction > 1e-7) {
               effective_hits += fraction;
-              thisCluster.emplace_back(clsOnLayer[i][ihit].data.detid,
-                                       fraction);
+              thisCluster.emplace_back(clsOnLayer[i][ihit].data.detid, fraction);
             }
           }
 
           if (verbosity_ < pINFO) {
-            std::cout << "\t******** NEW CLUSTER (SHARING) ********"
-                      << std::endl;
-            std::cout << "\tEff. No. of cells = " << effective_hits
-                      << std::endl;
+            std::cout << "\t******** NEW CLUSTER (SHARING) ********" << std::endl;
+            std::cout << "\tEff. No. of cells = " << effective_hits << std::endl;
             std::cout << "\t     Energy       = " << energy << std::endl;
-            std::cout << "\t     Phi          = " << position.phi()
-                      << std::endl;
-            std::cout << "\t     Eta          = " << position.eta()
-                      << std::endl;
+            std::cout << "\t     Phi          = " << position.phi() << std::endl;
+            std::cout << "\t     Eta          = " << position.eta() << std::endl;
             std::cout << "\t*****************************" << std::endl;
           }
-          clusters_v_.emplace_back(energy, position, caloID, thisCluster,
-                                  algoId_);
-	  if (!clusters_v_.empty()){ clusters_v_.back().setSeed( clsOnLayer[i][rsmax].data.detid); }
-	  thisCluster.clear();
+          clusters_v_.emplace_back(energy, position, caloID, thisCluster, algoId_);
+          if (!clusters_v_.empty()) {
+            clusters_v_.back().setSeed(clsOnLayer[i][rsmax].data.detid);
+          }
+          thisCluster.clear();
         }
       } else {
-        position = calculatePosition(clsOnLayer[i]); // energy-weighted position
+        position = calculatePosition(clsOnLayer[i]);  // energy-weighted position
         //   std::vector< KDNode >::iterator it;
         for (auto &it : clsOnLayer[i]) {
           energy += it.data.isHalo ? 0. : it.data.weight;
@@ -195,7 +183,9 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
           std::cout << "*****************************" << std::endl;
         }
         clusters_v_.emplace_back(energy, position, caloID, thisCluster, algoId_);
-	if (!clusters_v_.empty()){ clusters_v_.back().setSeed( clsOnLayer[i][rsmax].data.detid); }
+        if (!clusters_v_.empty()) {
+          clusters_v_.back().setSeed(clsOnLayer[i][rsmax].data.detid);
+        }
         thisCluster.clear();
       }
     }
@@ -203,8 +193,7 @@ std::vector<reco::BasicCluster> HGCalImagingAlgo::getClusters(bool doSharing) {
   return clusters_v_;
 }
 
-math::XYZPoint
-HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
+math::XYZPoint HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
   float total_weight = 0.f;
   float x = 0.f;
   float y = 0.f;
@@ -217,8 +206,8 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
   // determining the maximum energy hit
   for (unsigned int i = 0; i < v_size; i++) {
     if (v[i].data.weight > maxEnergyValue) {
-        maxEnergyValue = v[i].data.weight;
-        maxEnergyIndex = i;
+      maxEnergyValue = v[i].data.weight;
+      maxEnergyIndex = i;
     }
   }
 
@@ -230,15 +219,14 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
   // and save corresponding hits indices
   std::vector<unsigned int> innerIndices;
   for (unsigned int i = 0; i < v_size; i++) {
-    if (thick == -1 ||
-        distance2(v[i].data, v[maxEnergyIndex].data) < positionDeltaRho_c_[thick]){
+    if (thick == -1 || distance2(v[i].data, v[maxEnergyIndex].data) < positionDeltaRho_c_[thick]) {
       innerIndices.push_back(i);
 
       float rhEnergy = v[i].data.weight;
       total_weight += rhEnergy;
       // just fill x, y for scintillator
       // for Si it is overwritten later anyway
-      if(thick == -1){
+      if (thick == -1) {
         x += v[i].data.x * rhEnergy;
         y += v[i].data.y * rhEnergy;
       }
@@ -246,14 +234,15 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
   }
   // just loop on reduced vector of interesting indices
   // to compute log weighting
-  if(thick != -1 && total_weight != 0.){ // Silicon case
+  if (thick != -1 && total_weight != 0.) {  // Silicon case
     float total_weight_log = 0.f;
     float x_log = 0.f;
     float y_log = 0.f;
     for (auto idx : innerIndices) {
       float rhEnergy = v[idx].data.weight;
-      if(rhEnergy == 0.) continue;
-      float Wi = std::max(thresholdW0_[thick] + log(rhEnergy/total_weight), 0.);
+      if (rhEnergy == 0.)
+        continue;
+      float Wi = std::max(thresholdW0_[thick] + log(rhEnergy / total_weight), 0.);
       x_log += v[idx].data.x * Wi;
       y_log += v[idx].data.y * Wi;
       total_weight_log += Wi;
@@ -265,20 +254,15 @@ HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v) const {
 
   if (total_weight != 0.) {
     auto inv_tot_weight = 1. / total_weight;
-    return math::XYZPoint(x * inv_tot_weight,
-                          y * inv_tot_weight,
-                          v[maxEnergyIndex].data.z);
+    return math::XYZPoint(x * inv_tot_weight, y * inv_tot_weight, v[maxEnergyIndex].data.z);
   }
   return math::XYZPoint(0, 0, 0);
 }
 
-double HGCalImagingAlgo::calculateLocalDensity(std::vector<KDNode> &nd,
-                                               KDTree &lp,
-                                               const unsigned int layer) const {
-
+double HGCalImagingAlgo::calculateLocalDensity(std::vector<KDNode> &nd, KDTree &lp, const unsigned int layer) const {
   double maxdensity = 0.;
-  float delta_c; // maximum search distance (critical distance) for local
-                 // density calculation
+  float delta_c;  // maximum search distance (critical distance) for local
+                  // density calculation
   if (layer <= lastLayerEE_)
     delta_c = vecDeltas_[0];
   else if (layer < firstLayerBH_)
@@ -289,8 +273,8 @@ double HGCalImagingAlgo::calculateLocalDensity(std::vector<KDNode> &nd,
   // for each node calculate local density rho and store it
   for (unsigned int i = 0; i < nd.size(); ++i) {
     // speec up search by looking within +/- delta_c window only
-    KDTreeBox search_box(nd[i].dims[0] - delta_c, nd[i].dims[0] + delta_c,
-                         nd[i].dims[1] - delta_c, nd[i].dims[1] + delta_c);
+    KDTreeBox search_box(
+        nd[i].dims[0] - delta_c, nd[i].dims[0] + delta_c, nd[i].dims[1] - delta_c, nd[i].dims[1] + delta_c);
     std::vector<Hexel> found;
     lp.search(search_box, found);
     const unsigned int found_size = found.size();
@@ -299,14 +283,12 @@ double HGCalImagingAlgo::calculateLocalDensity(std::vector<KDNode> &nd,
         nd[i].data.rho += found[j].weight;
         maxdensity = std::max(maxdensity, nd[i].data.rho);
       }
-    } // end loop found
-  }   // end loop nodes
+    }  // end loop found
+  }    // end loop nodes
   return maxdensity;
 }
 
-double
-HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd) const {
-
+double HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd) const {
   // sort vector of Hexels by decreasing local density
   std::vector<size_t> rs = sorted_indices(nd);
 
@@ -316,7 +298,7 @@ HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd) const {
   if (!rs.empty())
     maxdensity = nd[rs[0]].data.rho;
   else
-    return maxdensity; // there are no hits
+    return maxdensity;  // there are no hits
   double dist2 = 0.;
   // start by setting delta for the highest density hit to
   // the most distant hit - this is a convention
@@ -333,8 +315,7 @@ HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd) const {
   const double max_dist2 = dist2;
   const unsigned int nd_size = nd.size();
 
-  for (unsigned int oi = 1; oi < nd_size;
-       ++oi) { // start from second-highest density
+  for (unsigned int oi = 1; oi < nd_size; ++oi) {  // start from second-highest density
     dist2 = max_dist2;
     unsigned int i = rs[oi];
     // we only need to check up to oi since hits
@@ -344,33 +325,35 @@ HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd) const {
     for (unsigned int oj = 0; oj < oi; ++oj) {
       unsigned int j = rs[oj];
       // Limit the search box
-      if ((nd[i].data.x - nd[j].data.x)*(nd[i].data.x - nd[j].data.x) > dist2) continue;
-      if ((nd[i].data.y - nd[j].data.y)*(nd[i].data.y - nd[j].data.y) > dist2) continue;
+      if ((nd[i].data.x - nd[j].data.x) * (nd[i].data.x - nd[j].data.x) > dist2)
+        continue;
+      if ((nd[i].data.y - nd[j].data.y) * (nd[i].data.y - nd[j].data.y) > dist2)
+        continue;
       double tmp = distance2(nd[i].data, nd[j].data);
-      if (tmp <= dist2) { // this "<=" instead of "<" addresses the (rare) case
-                          // when there are only two hits
+      if (tmp <= dist2) {  // this "<=" instead of "<" addresses the (rare) case
+                           // when there are only two hits
         dist2 = tmp;
         nearestHigher = j;
       }
     }
     nd[i].data.delta = std::sqrt(dist2);
-    nd[i].data.nearestHigher =
-        nearestHigher; // this uses the original unsorted hitlist
+    nd[i].data.nearestHigher = nearestHigher;  // this uses the original unsorted hitlist
   }
   return maxdensity;
 }
-int HGCalImagingAlgo::findAndAssignClusters(
-    std::vector<KDNode> &nd, KDTree &lp, double maxdensity, KDTreeBox<2> &bounds,
-    const unsigned int layer,
-    std::vector<std::vector<KDNode>> &clustersOnLayer) const {
-
+int HGCalImagingAlgo::findAndAssignClusters(std::vector<KDNode> &nd,
+                                            KDTree &lp,
+                                            double maxdensity,
+                                            KDTreeBox<2> &bounds,
+                                            const unsigned int layer,
+                                            std::vector<std::vector<KDNode>> &clustersOnLayer) const {
   // this is called once per layer and endcap...
   // so when filling the cluster temporary vector of Hexels we resize each time
   // by the number  of clusters found. This is always equal to the number of
   // cluster centers...
 
   unsigned int nClustersOnLayer = 0;
-  float delta_c; // critical distance
+  float delta_c;  // critical distance
   if (layer <= lastLayerEE_)
     delta_c = vecDeltas_[0];
   else if (layer < firstLayerBH_)
@@ -378,29 +361,24 @@ int HGCalImagingAlgo::findAndAssignClusters(
   else
     delta_c = vecDeltas_[2];
 
-  std::vector<size_t> rs =
-      sorted_indices(nd); // indices sorted by decreasing rho
-  std::vector<size_t> ds =
-      sort_by_delta(nd); // sort in decreasing distance to higher
+  std::vector<size_t> rs = sorted_indices(nd);  // indices sorted by decreasing rho
+  std::vector<size_t> ds = sort_by_delta(nd);   // sort in decreasing distance to higher
 
   const unsigned int nd_size = nd.size();
   for (unsigned int i = 0; i < nd_size; ++i) {
-
     if (nd[ds[i]].data.delta < delta_c)
-      break; // no more cluster centers to be looked at
+      break;  // no more cluster centers to be looked at
     if (dependSensor_) {
-
       float rho_c = kappa_ * nd[ds[i]].data.sigmaNoise;
       if (nd[ds[i]].data.rho < rho_c)
-        continue; // set equal to kappa times noise threshold
+        continue;  // set equal to kappa times noise threshold
 
     } else if (nd[ds[i]].data.rho * kappa_ < maxdensity)
       continue;
 
     nd[ds[i]].data.clusterIndex = nClustersOnLayer;
     if (verbosity_ < pINFO) {
-      std::cout << "Adding new cluster with index " << nClustersOnLayer
-                << std::endl;
+      std::cout << "Adding new cluster with index " << nClustersOnLayer << std::endl;
       std::cout << "Cluster center is hit " << ds[i] << std::endl;
     }
     nClustersOnLayer++;
@@ -417,8 +395,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
   for (unsigned int oi = 1; oi < nd_size; ++oi) {
     unsigned int i = rs[oi];
     int ci = nd[i].data.clusterIndex;
-    if (ci ==
-        -1) { // clusterIndex is initialised with -1 if not yet used in cluster
+    if (ci == -1) {  // clusterIndex is initialised with -1 if not yet used in cluster
       nd[i].data.clusterIndex = nd[nd[i].data.nearestHigher].data.clusterIndex;
     }
   }
@@ -442,14 +419,13 @@ int HGCalImagingAlgo::findAndAssignClusters(
     int ci = nd[i].data.clusterIndex;
     bool flag_isolated = true;
     if (ci != -1) {
-      KDTreeBox search_box(nd[i].dims[0] - delta_c, nd[i].dims[0] + delta_c,
-                           nd[i].dims[1] - delta_c, nd[i].dims[1] + delta_c);
+      KDTreeBox search_box(
+          nd[i].dims[0] - delta_c, nd[i].dims[0] + delta_c, nd[i].dims[1] - delta_c, nd[i].dims[1] + delta_c);
       std::vector<Hexel> found;
       lp.search(search_box, found);
 
       const unsigned int found_size = found.size();
-      for (unsigned int j = 0; j < found_size;
-           j++) { // start from 0 here instead of 1
+      for (unsigned int j = 0; j < found_size; j++) {  // start from 0 here instead of 1
         // check if the hit is not within d_c of another cluster
         if (found[j].clusterIndex != -1) {
           float dist = distance(found[j], nd[i].data);
@@ -461,8 +437,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
           // because we are using two different containers, we have to make sure
           // that we don't unflag the
           // hit when it finds *itself* closer than delta_c
-          if (dist < delta_c && dist != 0. &&
-              found[j].clusterIndex == ci) {
+          if (dist < delta_c && dist != 0. && found[j].clusterIndex == ci) {
             // in this case it is not an isolated hit
             // the dist!=0 is because the hit being looked at is also inside the
             // search box and at dist==0
@@ -471,14 +446,13 @@ int HGCalImagingAlgo::findAndAssignClusters(
         }
       }
       if (flag_isolated)
-        nd[i].data.isBorder =
-            true; // the hit is more than delta_c from any of its brethren
+        nd[i].data.isBorder = true;  // the hit is more than delta_c from any of its brethren
     }
     // check if this border hit has density larger than the current rho_b and
     // update
     if (nd[i].data.isBorder && rho_b[ci] < nd[i].data.rho)
       rho_b[ci] = nd[i].data.rho;
-  } // end loop all hits
+  }  // end loop all hits
 
   // flag points in cluster with density < rho_b as halo points, then fill the
   // cluster vector
@@ -489,8 +463,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
         nd[i].data.isHalo = true;
       clustersOnLayer[ci].push_back(nd[i]);
       if (verbosity_ < pINFO) {
-        std::cout << "Pushing hit " << i << " into cluster with index " << ci
-                  << std::endl;
+        std::cout << "Pushing hit " << i << " into cluster with index " << ci << std::endl;
       }
     }
   }
@@ -503,8 +476,7 @@ int HGCalImagingAlgo::findAndAssignClusters(
 }
 
 // find local maxima within delta_c, marking the indices in the cluster
-std::vector<unsigned>
-HGCalImagingAlgo::findLocalMaximaInCluster(const std::vector<KDNode> &cluster) {
+std::vector<unsigned> HGCalImagingAlgo::findLocalMaximaInCluster(const std::vector<KDNode> &cluster) {
   std::vector<unsigned> result;
   std::vector<bool> seed(cluster.size(), true);
   float delta_c = 2.;
@@ -532,8 +504,8 @@ HGCalImagingAlgo::findLocalMaximaInCluster(const std::vector<KDNode> &cluster) {
   return result;
 }
 
-math::XYZPoint HGCalImagingAlgo::calculatePositionWithFraction(
-    const std::vector<KDNode> &hits, const std::vector<double> &fractions) {
+math::XYZPoint HGCalImagingAlgo::calculatePositionWithFraction(const std::vector<KDNode> &hits,
+                                                               const std::vector<double> &fractions) {
   double norm(0.0), x(0.0), y(0.0), z(0.0);
   for (unsigned i = 0; i < hits.size(); ++i) {
     const double weight = fractions[i] * hits[i].data.weight;
@@ -547,8 +519,8 @@ math::XYZPoint HGCalImagingAlgo::calculatePositionWithFraction(
   return result;
 }
 
-double HGCalImagingAlgo::calculateEnergyWithFraction(
-    const std::vector<KDNode> &hits, const std::vector<double> &fractions) {
+double HGCalImagingAlgo::calculateEnergyWithFraction(const std::vector<KDNode> &hits,
+                                                     const std::vector<double> &fractions) {
   double result = 0.0;
   for (unsigned i = 0; i < hits.size(); ++i) {
     result += fractions[i] * hits[i].data.weight;
@@ -556,16 +528,16 @@ double HGCalImagingAlgo::calculateEnergyWithFraction(
   return result;
 }
 
-void HGCalImagingAlgo::shareEnergy(
-    const std::vector<KDNode> &incluster, const std::vector<unsigned> &seeds,
-    std::vector<std::vector<double>> &outclusters) {
+void HGCalImagingAlgo::shareEnergy(const std::vector<KDNode> &incluster,
+                                   const std::vector<unsigned> &seeds,
+                                   std::vector<std::vector<double>> &outclusters) {
   std::vector<bool> isaseed(incluster.size(), false);
   outclusters.clear();
   outclusters.resize(seeds.size());
   std::vector<Point> centroids(seeds.size());
   std::vector<double> energies(seeds.size());
 
-  if (seeds.size() == 1) { // short circuit the case of a lone cluster
+  if (seeds.size() == 1) {  // short circuit the case of a lone cluster
     outclusters[0].clear();
     outclusters[0].resize(incluster.size(), 1.0);
     return;
@@ -587,8 +559,7 @@ void HGCalImagingAlgo::shareEnergy(
     for (unsigned j = 0; j < incluster.size(); ++j) {
       if (j == seeds[i]) {
         outclusters[i][j] = 1.0;
-        centroids[i] = math::XYZPoint(incluster[j].data.x, incluster[j].data.y,
-                                      incluster[j].data.z);
+        centroids[i] = math::XYZPoint(incluster[j].data.x, incluster[j].data.y, incluster[j].data.z);
         energies[i] = incluster[j].data.weight;
       }
     }
@@ -602,8 +573,7 @@ void HGCalImagingAlgo::shareEnergy(
   double diff = std::numeric_limits<double>::max();
   const double stoppingTolerance = 1e-8;
   const auto numberOfSeeds = seeds.size();
-  auto toleranceScaling =
-      numberOfSeeds > 2 ? (numberOfSeeds - 1) * (numberOfSeeds - 1) : 1;
+  auto toleranceScaling = numberOfSeeds > 2 ? (numberOfSeeds - 1) * (numberOfSeeds - 1) : 1;
   std::vector<Point> prevCentroids;
   std::vector<double> frac(numberOfSeeds), dist2(numberOfSeeds);
   while (iter++ < iterMax && diff > stoppingTolerance * toleranceScaling) {
@@ -612,13 +582,12 @@ void HGCalImagingAlgo::shareEnergy(
       double fracTot(0.0);
       for (unsigned j = 0; j < numberOfSeeds; ++j) {
         double fraction = 0.0;
-        double d2 = (std::pow(ihit.x - centroids[j].x(), 2.0) +
-                     std::pow(ihit.y - centroids[j].y(), 2.0) +
+        double d2 = (std::pow(ihit.x - centroids[j].x(), 2.0) + std::pow(ihit.y - centroids[j].y(), 2.0) +
                      std::pow(ihit.z - centroids[j].z(), 2.0)) /
                     sigma2_;
         dist2[j] = d2;
         // now we set the fractions up based on hit type
-        if (i == seeds[j]) { // this cluster's seed
+        if (i == seeds[j]) {  // this cluster's seed
           fraction = 1.0;
         } else if (isaseed[i]) {
           fraction = 0.0;
@@ -665,41 +634,35 @@ void HGCalImagingAlgo::computeThreshold() {
   // geometries at the same time.
 
   if (initialized_)
-    return; // only need to calculate thresholds once
+    return;  // only need to calculate thresholds once
 
   initialized_ = true;
 
   std::vector<double> dummy;
   const unsigned maxNumberOfThickIndices = 3;
-  dummy.resize(maxNumberOfThickIndices + 1, 0); // +1 to accomodate for the Scintillators
+  dummy.resize(maxNumberOfThickIndices + 1, 0);  // +1 to accomodate for the Scintillators
   thresholds_.resize(maxlayer_, dummy);
   sigmaNoise_.resize(maxlayer_, dummy);
 
   for (unsigned ilayer = 1; ilayer <= maxlayer_; ++ilayer) {
     for (unsigned ithick = 0; ithick < maxNumberOfThickIndices; ++ithick) {
-      float sigmaNoise =
-          0.001f * fcPerEle_ * nonAgedNoises_[ithick] * dEdXweights_[ilayer] /
-          (fcPerMip_[ithick] * thicknessCorrection_[ithick]);
+      float sigmaNoise = 0.001f * fcPerEle_ * nonAgedNoises_[ithick] * dEdXweights_[ilayer] /
+                         (fcPerMip_[ithick] * thicknessCorrection_[ithick]);
       thresholds_[ilayer - 1][ithick] = sigmaNoise * ecut_;
       sigmaNoise_[ilayer - 1][ithick] = sigmaNoise;
     }
     float scintillators_sigmaNoise = 0.001f * noiseMip_ * dEdXweights_[ilayer];
     thresholds_[ilayer - 1][maxNumberOfThickIndices] = ecut_ * scintillators_sigmaNoise;
-    sigmaNoise_[ilayer -1][maxNumberOfThickIndices] = scintillators_sigmaNoise;
+    sigmaNoise_[ilayer - 1][maxNumberOfThickIndices] = scintillators_sigmaNoise;
   }
-
 }
 
-void HGCalImagingAlgo::setDensity(const std::vector<KDNode> &nd){
-
+void HGCalImagingAlgo::setDensity(const std::vector<KDNode> &nd) {
   // for each node calculate local density rho and store it
-  for (auto &i : nd){
-    density_[ i.data.detid ] =  i.data.rho ;
-  }   // end loop nodes
+  for (auto &i : nd) {
+    density_[i.data.detid] = i.data.rho;
+  }  // end loop nodes
 }
 
 //Density
-Density HGCalImagingAlgo::getDensity(){
-  return density_;
-}
-
+Density HGCalImagingAlgo::getDensity() { return density_; }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitProducer.cc
@@ -24,106 +24,105 @@
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalRecHitWorkerBaseClass.h"
 
 class HGCalRecHitProducer : public edm::stream::EDProducer<> {
-  
- public:
+public:
   explicit HGCalRecHitProducer(const edm::ParameterSet& ps);
   ~HGCalRecHitProducer() override;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
-  
- private:
-  
+
+private:
   const edm::EDGetTokenT<HGCeeUncalibratedRecHitCollection> eeUncalibRecHitCollection_;
-  const edm::EDGetTokenT<HGChefUncalibratedRecHitCollection>  hefUncalibRecHitCollection_;
+  const edm::EDGetTokenT<HGChefUncalibratedRecHitCollection> hefUncalibRecHitCollection_;
   const edm::EDGetTokenT<HGChebUncalibratedRecHitCollection> hebUncalibRecHitCollection_;
   const edm::EDGetTokenT<HGChfnoseUncalibratedRecHitCollection> hfnoseUncalibRecHitCollection_;
-  const std::string eeRechitCollection_; // instance name for HGCEE
-  const std::string hefRechitCollection_; // instance name for HGCHEF
-  const std::string hebRechitCollection_; // instance name for HGCHEB 
-  const std::string hfnoseRechitCollection_; // instance name for HFNose
-  
-  std::unique_ptr<HGCalRecHitWorkerBaseClass> worker_;  
+  const std::string eeRechitCollection_;      // instance name for HGCEE
+  const std::string hefRechitCollection_;     // instance name for HGCHEF
+  const std::string hebRechitCollection_;     // instance name for HGCHEB
+  const std::string hfnoseRechitCollection_;  // instance name for HFNose
+
+  std::unique_ptr<HGCalRecHitWorkerBaseClass> worker_;
 };
 
-HGCalRecHitProducer::HGCalRecHitProducer(const edm::ParameterSet& ps) :
-  eeUncalibRecHitCollection_( consumes<HGCeeUncalibratedRecHitCollection>( ps.getParameter<edm::InputTag>("HGCEEuncalibRecHitCollection") ) ),
-  hefUncalibRecHitCollection_( consumes<HGChefUncalibratedRecHitCollection>( ps.getParameter<edm::InputTag>("HGCHEFuncalibRecHitCollection") ) ),
-  hebUncalibRecHitCollection_( consumes<HGChebUncalibratedRecHitCollection>( ps.getParameter<edm::InputTag>("HGCHEBuncalibRecHitCollection") ) ),
-  hfnoseUncalibRecHitCollection_( consumes<HGChfnoseUncalibratedRecHitCollection>( ps.getParameter<edm::InputTag>("HGCHFNoseuncalibRecHitCollection") ) ),
-  eeRechitCollection_( ps.getParameter<std::string>("HGCEErechitCollection") ),
-  hefRechitCollection_( ps.getParameter<std::string>("HGCHEFrechitCollection") ),
-  hebRechitCollection_( ps.getParameter<std::string>("HGCHEBrechitCollection") ),
-  hfnoseRechitCollection_( ps.getParameter<std::string>("HGCHFNoserechitCollection") ),
-  worker_{ HGCalRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps) }
-{
-  produces< HGCeeRecHitCollection >(eeRechitCollection_);
-  produces< HGChefRecHitCollection >(hefRechitCollection_);
-  produces< HGChebRecHitCollection >(hebRechitCollection_);
-  produces< HGChfnoseRecHitCollection >(hfnoseRechitCollection_);
+HGCalRecHitProducer::HGCalRecHitProducer(const edm::ParameterSet& ps)
+    : eeUncalibRecHitCollection_(
+          consumes<HGCeeUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("HGCEEuncalibRecHitCollection"))),
+      hefUncalibRecHitCollection_(consumes<HGChefUncalibratedRecHitCollection>(
+          ps.getParameter<edm::InputTag>("HGCHEFuncalibRecHitCollection"))),
+      hebUncalibRecHitCollection_(consumes<HGChebUncalibratedRecHitCollection>(
+          ps.getParameter<edm::InputTag>("HGCHEBuncalibRecHitCollection"))),
+      hfnoseUncalibRecHitCollection_(consumes<HGChfnoseUncalibratedRecHitCollection>(
+          ps.getParameter<edm::InputTag>("HGCHFNoseuncalibRecHitCollection"))),
+      eeRechitCollection_(ps.getParameter<std::string>("HGCEErechitCollection")),
+      hefRechitCollection_(ps.getParameter<std::string>("HGCHEFrechitCollection")),
+      hebRechitCollection_(ps.getParameter<std::string>("HGCHEBrechitCollection")),
+      hfnoseRechitCollection_(ps.getParameter<std::string>("HGCHFNoserechitCollection")),
+      worker_{HGCalRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps)} {
+  produces<HGCeeRecHitCollection>(eeRechitCollection_);
+  produces<HGChefRecHitCollection>(hefRechitCollection_);
+  produces<HGChebRecHitCollection>(hebRechitCollection_);
+  produces<HGChfnoseRecHitCollection>(hfnoseRechitCollection_);
 }
 
-HGCalRecHitProducer::~HGCalRecHitProducer() {
-}
+HGCalRecHitProducer::~HGCalRecHitProducer() {}
 
-void
-HGCalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+void HGCalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   using namespace edm;
 
-  Handle< HGCeeUncalibratedRecHitCollection > pHGCeeUncalibRecHits;
-  Handle< HGChefUncalibratedRecHitCollection > pHGChefUncalibRecHits;
-  Handle< HGChebUncalibratedRecHitCollection > pHGChebUncalibRecHits;
-  Handle< HGChfnoseUncalibratedRecHitCollection > pHGChfnoseUncalibRecHits;
-  
-  const HGCeeUncalibratedRecHitCollection*  eeUncalibRecHits = nullptr;
-  const HGChefUncalibratedRecHitCollection*  hefUncalibRecHits = nullptr; 
-  const HGChebUncalibratedRecHitCollection*  hebUncalibRecHits = nullptr; 
+  Handle<HGCeeUncalibratedRecHitCollection> pHGCeeUncalibRecHits;
+  Handle<HGChefUncalibratedRecHitCollection> pHGChefUncalibRecHits;
+  Handle<HGChebUncalibratedRecHitCollection> pHGChebUncalibRecHits;
+  Handle<HGChfnoseUncalibratedRecHitCollection> pHGChfnoseUncalibRecHits;
+
+  const HGCeeUncalibratedRecHitCollection* eeUncalibRecHits = nullptr;
+  const HGChefUncalibratedRecHitCollection* hefUncalibRecHits = nullptr;
+  const HGChebUncalibratedRecHitCollection* hebUncalibRecHits = nullptr;
   const HGChfnoseUncalibratedRecHitCollection* hfnoseUncalibRecHits = nullptr;
 
   // get the HGC uncalib rechit collection
-  evt.getByToken( eeUncalibRecHitCollection_, pHGCeeUncalibRecHits);
+  evt.getByToken(eeUncalibRecHitCollection_, pHGCeeUncalibRecHits);
   eeUncalibRecHits = pHGCeeUncalibRecHits.product();
-    
-  evt.getByToken( hefUncalibRecHitCollection_, pHGChefUncalibRecHits);
+
+  evt.getByToken(hefUncalibRecHitCollection_, pHGChefUncalibRecHits);
   hefUncalibRecHits = pHGChefUncalibRecHits.product();
-  
-  evt.getByToken( hebUncalibRecHitCollection_, pHGChebUncalibRecHits);
+
+  evt.getByToken(hebUncalibRecHitCollection_, pHGChebUncalibRecHits);
   hebUncalibRecHits = pHGChebUncalibRecHits.product();
-  
-  evt.getByToken( hfnoseUncalibRecHitCollection_, pHGChfnoseUncalibRecHits);
+
+  evt.getByToken(hfnoseUncalibRecHitCollection_, pHGChfnoseUncalibRecHits);
   if (pHGChfnoseUncalibRecHits.isValid())
     hfnoseUncalibRecHits = pHGChfnoseUncalibRecHits.product();
-    
+
   // collection of rechits to put in the event
   auto eeRecHits = std::make_unique<HGCeeRecHitCollection>();
   auto hefRecHits = std::make_unique<HGChefRecHitCollection>();
   auto hebRecHits = std::make_unique<HGChebRecHitCollection>();
-    
+
   worker_->set(es);
-  
+
   // loop over uncalibrated rechits to make calibrated ones
-  for(auto it  = eeUncalibRecHits->begin(); it != eeUncalibRecHits->end(); ++it) {
+  for (auto it = eeUncalibRecHits->begin(); it != eeUncalibRecHits->end(); ++it) {
     worker_->run(evt, *it, *eeRecHits);
   }
-  
+
   // loop over uncalibrated rechits to make calibrated ones
-  for(auto it  = hefUncalibRecHits->begin(); it != hefUncalibRecHits->end(); ++it) {
+  for (auto it = hefUncalibRecHits->begin(); it != hefUncalibRecHits->end(); ++it) {
     worker_->run(evt, *it, *hefRecHits);
   }
-  
+
   // loop over uncalibrated rechits to make calibrated ones
-  for(auto it  = hebUncalibRecHits->begin(); it != hebUncalibRecHits->end(); ++it) {
+  for (auto it = hebUncalibRecHits->begin(); it != hebUncalibRecHits->end(); ++it) {
     worker_->run(evt, *it, *hebRecHits);
   }
-    
+
   // sort collections before attempting recovery, to avoid insertion of double recHits
   eeRecHits->sort();
   hefRecHits->sort();
   hebRecHits->sort();
-    
-  // put the collection of recunstructed hits in the event   
+
+  // put the collection of recunstructed hits in the event
   LogInfo("HGCalRecHitInfo") << "total # HGCee calibrated rechits: " << eeRecHits->size();
   LogInfo("HGCalRecHitInfo") << "total # HGChef calibrated rechits: " << hefRecHits->size();
   LogInfo("HGCalRecHitInfo") << "total # HGCheb calibrated rechits: " << hebRecHits->size();
-  
+
   evt.put(std::move(eeRecHits), eeRechitCollection_);
   evt.put(std::move(hefRecHits), hefRechitCollection_);
   evt.put(std::move(hebRecHits), hebRechitCollection_);
@@ -131,7 +130,7 @@ HGCalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // do the same for HFNose hits
   if (pHGChfnoseUncalibRecHits.isValid()) {
     auto hfnoseRecHits = std::make_unique<HGChfnoseRecHitCollection>();
-    for(auto it  = hfnoseUncalibRecHits->begin(); it != hfnoseUncalibRecHits->end(); ++it) {
+    for (auto it = hfnoseUncalibRecHits->begin(); it != hfnoseUncalibRecHits->end(); ++it) {
       worker_->run(evt, *it, *hfnoseRecHits);
     }
     hfnoseRecHits->sort();
@@ -141,4 +140,4 @@ HGCalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE( HGCalRecHitProducer );
+DEFINE_FWK_MODULE(HGCalRecHitProducer);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -70,6 +70,7 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : 
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
   tools_->getEventSetup(es);
+  rechitMaker_->set(es);
   if (hgcEE_isSiFE_) {
     edm::ESHandle<HGCalGeometry> hgceeGeoHandle;
     es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -7,104 +7,91 @@
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet&ps) :
-        HGCalRecHitWorkerBaseClass(ps)
-{
-    rechitMaker_.reset(new HGCalRecHitSimpleAlgo());
-    tools_.reset(new hgcal::RecHitTools());
-    constexpr float keV2GeV = 1e-6;
-    // HGCee constants
-    hgcEE_keV2DIGI_ = ps.getParameter<double>("HGCEE_keV2DIGI");
-    hgcEE_fCPerMIP_ = ps.getParameter < std::vector<double> > ("HGCEE_fCPerMIP");
-    hgcEE_isSiFE_ = ps.getParameter<bool>("HGCEE_isSiFE");
-    hgceeUncalib2GeV_ = keV2GeV / hgcEE_keV2DIGI_;
+HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : HGCalRecHitWorkerBaseClass(ps) {
+  rechitMaker_.reset(new HGCalRecHitSimpleAlgo());
+  tools_.reset(new hgcal::RecHitTools());
+  constexpr float keV2GeV = 1e-6;
+  // HGCee constants
+  hgcEE_keV2DIGI_ = ps.getParameter<double>("HGCEE_keV2DIGI");
+  hgcEE_fCPerMIP_ = ps.getParameter<std::vector<double> >("HGCEE_fCPerMIP");
+  hgcEE_isSiFE_ = ps.getParameter<bool>("HGCEE_isSiFE");
+  hgceeUncalib2GeV_ = keV2GeV / hgcEE_keV2DIGI_;
 
-    // HGChef constants
-    hgcHEF_keV2DIGI_ = ps.getParameter<double>("HGCHEF_keV2DIGI");
-    hgcHEF_fCPerMIP_ = ps.getParameter < std::vector<double> > ("HGCHEF_fCPerMIP");
-    hgcHEF_isSiFE_ = ps.getParameter<bool>("HGCHEF_isSiFE");
-    hgchefUncalib2GeV_ = keV2GeV / hgcHEF_keV2DIGI_;
+  // HGChef constants
+  hgcHEF_keV2DIGI_ = ps.getParameter<double>("HGCHEF_keV2DIGI");
+  hgcHEF_fCPerMIP_ = ps.getParameter<std::vector<double> >("HGCHEF_fCPerMIP");
+  hgcHEF_isSiFE_ = ps.getParameter<bool>("HGCHEF_isSiFE");
+  hgchefUncalib2GeV_ = keV2GeV / hgcHEF_keV2DIGI_;
 
-    // HGCheb constants
-    hgcHEB_keV2DIGI_ = ps.getParameter<double>("HGCHEB_keV2DIGI");
-    hgcHEB_isSiFE_ = ps.getParameter<bool>("HGCHEB_isSiFE");
-    hgchebUncalib2GeV_ = keV2GeV / hgcHEB_keV2DIGI_;
+  // HGCheb constants
+  hgcHEB_keV2DIGI_ = ps.getParameter<double>("HGCHEB_keV2DIGI");
+  hgcHEB_isSiFE_ = ps.getParameter<bool>("HGCHEB_isSiFE");
+  hgchebUncalib2GeV_ = keV2GeV / hgcHEB_keV2DIGI_;
 
-    // HGChfnose constants
-    hgcHFNose_keV2DIGI_ = ps.getParameter<double>("HGCHFNose_keV2DIGI");
-    hgcHFNose_fCPerMIP_ = ps.getParameter < std::vector<double> > ("HGCHFNose_fCPerMIP");
-    hgcHFNose_isSiFE_ = ps.getParameter<bool>("HGCHFNose_isSiFE");
-    hgchfnoseUncalib2GeV_ = keV2GeV / hgcHFNose_keV2DIGI_;
+  // HGChfnose constants
+  hgcHFNose_keV2DIGI_ = ps.getParameter<double>("HGCHFNose_keV2DIGI");
+  hgcHFNose_fCPerMIP_ = ps.getParameter<std::vector<double> >("HGCHFNose_fCPerMIP");
+  hgcHFNose_isSiFE_ = ps.getParameter<bool>("HGCHFNose_isSiFE");
+  hgchfnoseUncalib2GeV_ = keV2GeV / hgcHFNose_keV2DIGI_;
 
-    // layer weights (from Valeri/Arabella)
-    const auto& dweights = ps.getParameter < std::vector<double> > ("layerWeights");
-    for (auto weight : dweights)
-    {
-        weights_.push_back(weight);
-    }
-    const auto& weightnose = ps.getParameter < std::vector<double> > ("layerNoseWeights");
-    for (auto const& weight : weightnose) weightsNose_.emplace_back(weight);
+  // layer weights (from Valeri/Arabella)
+  const auto& dweights = ps.getParameter<std::vector<double> >("layerWeights");
+  for (auto weight : dweights) {
+    weights_.push_back(weight);
+  }
+  const auto& weightnose = ps.getParameter<std::vector<double> >("layerNoseWeights");
+  for (auto const& weight : weightnose)
+    weightsNose_.emplace_back(weight);
 
-    rechitMaker_->setLayerWeights(weights_);
-    rechitMaker_->setNoseLayerWeights(weightsNose_);
+  rechitMaker_->setLayerWeights(weights_);
+  rechitMaker_->setNoseLayerWeights(weightsNose_);
 
-    // residual correction for cell thickness
-    const auto& rcorr = ps.getParameter < std::vector<double> > ("thicknessCorrection");
-    rcorr_.clear();
-    rcorr_.push_back(1.f);
-    for (auto corr : rcorr)
-    {
-        rcorr_.push_back(1.0 / corr);
-    }
+  // residual correction for cell thickness
+  const auto& rcorr = ps.getParameter<std::vector<double> >("thicknessCorrection");
+  rcorr_.clear();
+  rcorr_.push_back(1.f);
+  for (auto corr : rcorr) {
+    rcorr_.push_back(1.0 / corr);
+  }
 
+  hgcEE_noise_fC_ = ps.getParameter<edm::ParameterSet>("HGCEE_noise_fC").getParameter<std::vector<double> >("values");
+  hgcEE_cce_ = ps.getParameter<edm::ParameterSet>("HGCEE_cce").getParameter<std::vector<double> >("values");
+  hgcHEF_noise_fC_ = ps.getParameter<edm::ParameterSet>("HGCHEF_noise_fC").getParameter<std::vector<double> >("values");
+  hgcHEF_cce_ = ps.getParameter<edm::ParameterSet>("HGCHEF_cce").getParameter<std::vector<double> >("values");
+  hgcHEB_noise_MIP_ = ps.getParameter<edm::ParameterSet>("HGCHEB_noise_MIP").getParameter<double>("noise_MIP");
+  hgcHFNose_noise_fC_ =
+      ps.getParameter<edm::ParameterSet>("HGCHFNose_noise_fC").getParameter<std::vector<double> >("values");
+  hgcHFNose_cce_ = ps.getParameter<edm::ParameterSet>("HGCHFNose_cce").getParameter<std::vector<double> >("values");
 
-    hgcEE_noise_fC_ = ps.getParameter<edm::ParameterSet>("HGCEE_noise_fC").getParameter < std::vector<double> > ("values");
-    hgcEE_cce_ = ps.getParameter<edm::ParameterSet>("HGCEE_cce").getParameter< std::vector<double> > ("values");
-    hgcHEF_noise_fC_ = ps.getParameter<edm::ParameterSet>("HGCHEF_noise_fC").getParameter < std::vector<double> > ("values");
-    hgcHEF_cce_ = ps.getParameter<edm::ParameterSet>("HGCHEF_cce").getParameter< std::vector<double> > ("values");
-    hgcHEB_noise_MIP_ = ps.getParameter<edm::ParameterSet>("HGCHEB_noise_MIP").getParameter<double>("noise_MIP");
-    hgcHFNose_noise_fC_ = ps.getParameter<edm::ParameterSet>("HGCHFNose_noise_fC").getParameter < std::vector<double> > ("values");
-    hgcHFNose_cce_ = ps.getParameter<edm::ParameterSet>("HGCHFNose_cce").getParameter< std::vector<double> > ("values");
-
-    // don't produce rechit if detid is a ghost one
-    rangeMatch_ = ps.getParameter<uint32_t>("rangeMatch");
-    rangeMask_  = ps.getParameter<uint32_t>("rangeMask");
+  // don't produce rechit if detid is a ghost one
+  rangeMatch_ = ps.getParameter<uint32_t>("rangeMatch");
+  rangeMask_ = ps.getParameter<uint32_t>("rangeMask");
 }
 
-void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es)
-{
-    tools_->getEventSetup(es);
-    if (hgcEE_isSiFE_)
-    {
-        edm::ESHandle < HGCalGeometry > hgceeGeoHandle;
-        es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);
-        ddds_[0] = &(hgceeGeoHandle->topology().dddConstants());
-    }
-    else
-    {
-        ddds_[0] = nullptr;
-    }
-    if (hgcHEF_isSiFE_)
-    {
-        edm::ESHandle < HGCalGeometry > hgchefGeoHandle;
-        es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hgchefGeoHandle);
-        ddds_[1] = &(hgchefGeoHandle->topology().dddConstants());
-    }
-    else
-    {
-        ddds_[1] = nullptr;
-    }
-    ddds_[2] = nullptr;
-    if (hgcHFNose_isSiFE_)
-    {
-        edm::ESHandle < HGCalGeometry > hgchfnoseGeoHandle;
-        es.get<IdealGeometryRecord>().get("HGCalHFNoseSensitive", hgchfnoseGeoHandle);
-        ddds_[3] = &(hgchfnoseGeoHandle->topology().dddConstants());
-    }
-    else
-    {
-        ddds_[3] = nullptr;
-    }
+void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es) {
+  tools_->getEventSetup(es);
+  if (hgcEE_isSiFE_) {
+    edm::ESHandle<HGCalGeometry> hgceeGeoHandle;
+    es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);
+    ddds_[0] = &(hgceeGeoHandle->topology().dddConstants());
+  } else {
+    ddds_[0] = nullptr;
+  }
+  if (hgcHEF_isSiFE_) {
+    edm::ESHandle<HGCalGeometry> hgchefGeoHandle;
+    es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hgchefGeoHandle);
+    ddds_[1] = &(hgchefGeoHandle->topology().dddConstants());
+  } else {
+    ddds_[1] = nullptr;
+  }
+  ddds_[2] = nullptr;
+  if (hgcHFNose_isSiFE_) {
+    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle;
+    es.get<IdealGeometryRecord>().get("HGCalHFNoseSensitive", hgchfnoseGeoHandle);
+    ddds_[3] = &(hgchfnoseGeoHandle->topology().dddConstants());
+  } else {
+    ddds_[3] = nullptr;
+  }
 }
 
 bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
@@ -137,25 +124,25 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
       idtype = hgcbh;
       break;
     default:
-      switch (detid.subdetId())  {
-      case HGCEE:
-	idtype = hgcee;
-	thickness = ddds_[detid.subdetId()-3]->waferTypeL(HGCalDetId(detid).wafer());
-        break;
-      case HGCHEF:
-	idtype = hgcfh;
-	thickness = ddds_[detid.subdetId()-3]->waferTypeL(HGCalDetId(detid).wafer());
-        break;
-      case HcalEndcap:
-      case HGCHEB:
-	idtype = hgcbh;
-	break;
-      case HFNose:
-	idtype = hgchfnose;
-	thickness = 1 + HFNoseDetId(detid).type();
-	break;
-      default:
-	break;
+      switch (detid.subdetId()) {
+        case HGCEE:
+          idtype = hgcee;
+          thickness = ddds_[detid.subdetId() - 3]->waferTypeL(HGCalDetId(detid).wafer());
+          break;
+        case HGCHEF:
+          idtype = hgcfh;
+          thickness = ddds_[detid.subdetId() - 3]->waferTypeL(HGCalDetId(detid).wafer());
+          break;
+        case HcalEndcap:
+        case HGCHEB:
+          idtype = hgcbh;
+          break;
+        case HFNose:
+          idtype = hgchfnose;
+          thickness = 1 + HFNoseDetId(detid).type();
+          break;
+        default:
+          break;
       }
   }
   switch (idtype) {
@@ -178,8 +165,8 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
     case hgchfnose:
       rechitMaker_->setADCToGeVConstant(float(hgchfnoseUncalib2GeV_));
       cce_correction = hgcHFNose_cce_[thickness - 1];
-      sigmaNoiseGeV = 1e-3 * weightsNose_[layer] * rcorr_[thickness]
-	* hgcHFNose_noise_fC_[thickness - 1] / hgcHFNose_fCPerMIP_[thickness - 1];
+      sigmaNoiseGeV = 1e-3 * weightsNose_[layer] * rcorr_[thickness] * hgcHFNose_noise_fC_[thickness - 1] /
+                      hgcHFNose_fCPerMIP_[thickness - 1];
       break;
     default:
       throw cms::Exception("NonHGCRecHit") << "Rechit with detid = " << detid.rawId() << " is not HGC!";

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -17,41 +17,37 @@
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 class HGCalRecHitWorkerSimple : public HGCalRecHitWorkerBaseClass {
- public:
+public:
   HGCalRecHitWorkerSimple(const edm::ParameterSet&);
-  ~HGCalRecHitWorkerSimple() override;                       
-  
+  ~HGCalRecHitWorkerSimple() override;
+
   void set(const edm::EventSetup& es) override;
-  bool run(const edm::Event& evt, const HGCUncalibratedRecHit& uncalibRH, HGCRecHitCollection & result) override;
-  
- protected:
+  bool run(const edm::Event& evt, const HGCUncalibratedRecHit& uncalibRH, HGCRecHitCollection& result) override;
 
-  enum detectortype { hgcee=1, hgcfh=2, hgcbh=3, hgchfnose=4};
+protected:
+  enum detectortype { hgcee = 1, hgcfh = 2, hgcbh = 3, hgchfnose = 4 };
 
-  double hgcEE_keV2DIGI_,  hgceeUncalib2GeV_;
+  double hgcEE_keV2DIGI_, hgceeUncalib2GeV_;
   std::vector<double> hgcEE_fCPerMIP_;
   std::vector<double> hgcEE_cce_;
   double hgcHEF_keV2DIGI_, hgchefUncalib2GeV_;
   std::vector<double> hgcHEF_fCPerMIP_;
   std::vector<double> hgcHEF_cce_;
   double hgcHEB_keV2DIGI_, hgchebUncalib2GeV_;
-  double hgcHFNose_keV2DIGI_,  hgchfnoseUncalib2GeV_;
+  double hgcHFNose_keV2DIGI_, hgchfnoseUncalib2GeV_;
   std::vector<double> hgcHFNose_fCPerMIP_;
   std::vector<double> hgcHFNose_cce_;
   bool hgcEE_isSiFE_, hgcHEF_isSiFE_, hgcHEB_isSiFE_, hgcHFNose_isSiFE_;
-  
-
 
   std::vector<double> hgcEE_noise_fC_;
   std::vector<double> hgcHEF_noise_fC_;
   std::vector<double> hgcHFNose_noise_fC_;
   double hgcHEB_noise_MIP_;
 
-
   std::array<const HGCalDDDConstants*, 4> ddds_;
-  
+
   std::vector<int> v_chstatus_;
-  
+
   std::vector<int> v_DB_reco_flags_;
   bool killDeadChannels_;
 
@@ -62,7 +58,6 @@ class HGCalRecHitWorkerSimple : public HGCalRecHitWorkerBaseClass {
   std::vector<float> weights_, weightsNose_;
   std::unique_ptr<HGCalRecHitSimpleAlgo> rechitMaker_;
   std::unique_ptr<hgcal::RecHitTools> tools_;
-
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.cc
@@ -9,93 +9,83 @@
 
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 
-HGCalUncalibRecHitProducer::HGCalUncalibRecHitProducer(const edm::ParameterSet& ps) :
-  eeDigiCollection_( consumes<HGCalDigiCollection>( ps.getParameter<edm::InputTag>("HGCEEdigiCollection") ) ),
-  hefDigiCollection_( consumes<HGCalDigiCollection>( ps.getParameter<edm::InputTag>("HGCHEFdigiCollection") ) ),
-  hebDigiCollection_( consumes<HGCalDigiCollection>( ps.getParameter<edm::InputTag>("HGCHEBdigiCollection") ) ),
-  hfnoseDigiCollection_( consumes<HGCalDigiCollection>( ps.getParameter<edm::InputTag>("HGCHFNosedigiCollection") ) ),
-  eeHitCollection_( ps.getParameter<std::string>("HGCEEhitCollection") ),
-  hefHitCollection_( ps.getParameter<std::string>("HGCHEFhitCollection") ),
-  hebHitCollection_( ps.getParameter<std::string>("HGCHEBhitCollection") ),
-  hfnoseHitCollection_( ps.getParameter<std::string>("HGCHFNosehitCollection") ),
-  worker_{ HGCalUncalibRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps) }
-{
-  produces< HGCeeUncalibratedRecHitCollection >(eeHitCollection_);
-  produces< HGChefUncalibratedRecHitCollection >(hefHitCollection_);
-  produces< HGChebUncalibratedRecHitCollection >(hebHitCollection_);
-  produces< HGChfnoseUncalibratedRecHitCollection >(hfnoseHitCollection_);
-
+HGCalUncalibRecHitProducer::HGCalUncalibRecHitProducer(const edm::ParameterSet& ps)
+    : eeDigiCollection_(consumes<HGCalDigiCollection>(ps.getParameter<edm::InputTag>("HGCEEdigiCollection"))),
+      hefDigiCollection_(consumes<HGCalDigiCollection>(ps.getParameter<edm::InputTag>("HGCHEFdigiCollection"))),
+      hebDigiCollection_(consumes<HGCalDigiCollection>(ps.getParameter<edm::InputTag>("HGCHEBdigiCollection"))),
+      hfnoseDigiCollection_(consumes<HGCalDigiCollection>(ps.getParameter<edm::InputTag>("HGCHFNosedigiCollection"))),
+      eeHitCollection_(ps.getParameter<std::string>("HGCEEhitCollection")),
+      hefHitCollection_(ps.getParameter<std::string>("HGCHEFhitCollection")),
+      hebHitCollection_(ps.getParameter<std::string>("HGCHEBhitCollection")),
+      hfnoseHitCollection_(ps.getParameter<std::string>("HGCHFNosehitCollection")),
+      worker_{HGCalUncalibRecHitWorkerFactory::get()->create(ps.getParameter<std::string>("algo"), ps)} {
+  produces<HGCeeUncalibratedRecHitCollection>(eeHitCollection_);
+  produces<HGChefUncalibratedRecHitCollection>(hefHitCollection_);
+  produces<HGChebUncalibratedRecHitCollection>(hebHitCollection_);
+  produces<HGChfnoseUncalibratedRecHitCollection>(hfnoseHitCollection_);
 }
 
-HGCalUncalibRecHitProducer::~HGCalUncalibRecHitProducer() {
-}
+HGCalUncalibRecHitProducer::~HGCalUncalibRecHitProducer() {}
 
-void
-HGCalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+void HGCalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   using namespace edm;
-  
-  
- 
+
   // tranparently get things from event setup
   worker_->set(es);
-  
+
   // prepare output
   auto eeUncalibRechits = std::make_unique<HGCeeUncalibratedRecHitCollection>();
   auto hefUncalibRechits = std::make_unique<HGChefUncalibratedRecHitCollection>();
   auto hebUncalibRechits = std::make_unique<HGChebUncalibratedRecHitCollection>();
   auto hfnoseUncalibRechits = std::make_unique<HGChfnoseUncalibratedRecHitCollection>();
-  
+
   // loop over HGCEE digis
-  edm::Handle< HGCalDigiCollection > pHGCEEDigis;
-  evt.getByToken( eeDigiCollection_, pHGCEEDigis);
-  const HGCalDigiCollection* eeDigis = 
-    pHGCEEDigis.product();
+  edm::Handle<HGCalDigiCollection> pHGCEEDigis;
+  evt.getByToken(eeDigiCollection_, pHGCEEDigis);
+  const HGCalDigiCollection* eeDigis = pHGCEEDigis.product();
   eeUncalibRechits->reserve(eeDigis->size());
-  for(auto itdg = eeDigis->begin(); itdg != eeDigis->end(); ++itdg) {
+  for (auto itdg = eeDigis->begin(); itdg != eeDigis->end(); ++itdg) {
     worker_->runHGCEE(itdg, *eeUncalibRechits);
   }
-  
+
   // loop over HGCHEsil digis
-  edm::Handle< HGCalDigiCollection > pHGCHEFDigis;
-  evt.getByToken( hefDigiCollection_, pHGCHEFDigis);
-  const HGCalDigiCollection* hefDigis = 
-    pHGCHEFDigis.product();
+  edm::Handle<HGCalDigiCollection> pHGCHEFDigis;
+  evt.getByToken(hefDigiCollection_, pHGCHEFDigis);
+  const HGCalDigiCollection* hefDigis = pHGCHEFDigis.product();
   hefUncalibRechits->reserve(hefDigis->size());
-  for(auto itdg = hefDigis->begin(); itdg != hefDigis->end(); ++itdg) {
+  for (auto itdg = hefDigis->begin(); itdg != hefDigis->end(); ++itdg) {
     worker_->runHGCHEsil(itdg, *hefUncalibRechits);
   }
 
   // loop over HGCHEscint digis
-  edm::Handle< HGCalDigiCollection > pHGCHEBDigis;
-  evt.getByToken( hebDigiCollection_, pHGCHEBDigis);
-  const HGCalDigiCollection* hebDigis = 
-    pHGCHEBDigis.product();
+  edm::Handle<HGCalDigiCollection> pHGCHEBDigis;
+  evt.getByToken(hebDigiCollection_, pHGCHEBDigis);
+  const HGCalDigiCollection* hebDigis = pHGCHEBDigis.product();
   hebUncalibRechits->reserve(hebDigis->size());
-  for(auto itdg = hebDigis->begin(); itdg != hebDigis->end(); ++itdg) {
+  for (auto itdg = hebDigis->begin(); itdg != hebDigis->end(); ++itdg) {
     worker_->runHGCHEscint(itdg, *hebUncalibRechits);
   }
-  
+
   // loop over HFNose digis
-  edm::Handle< HGCalDigiCollection > pHGCHFNoseDigis;
-  evt.getByToken( hfnoseDigiCollection_, pHGCHFNoseDigis);
+  edm::Handle<HGCalDigiCollection> pHGCHFNoseDigis;
+  evt.getByToken(hfnoseDigiCollection_, pHGCHFNoseDigis);
   if (pHGCHFNoseDigis.isValid()) {
-    const HGCalDigiCollection* hfnoseDigis = 
-      pHGCHFNoseDigis.product();
+    const HGCalDigiCollection* hfnoseDigis = pHGCHFNoseDigis.product();
     if (!(hfnoseDigis->empty())) {
       hfnoseUncalibRechits->reserve(hfnoseDigis->size());
-      for(auto itdg = hfnoseDigis->begin(); itdg != hfnoseDigis->end(); ++itdg)
-	worker_->runHGCHFNose(itdg, *hfnoseUncalibRechits);
+      for (auto itdg = hfnoseDigis->begin(); itdg != hfnoseDigis->end(); ++itdg)
+        worker_->runHGCHFNose(itdg, *hfnoseUncalibRechits);
     }
   }
-  
+
   // put the collection of recunstructed hits in the event
   evt.put(std::move(eeUncalibRechits), eeHitCollection_);
   evt.put(std::move(hefUncalibRechits), hefHitCollection_);
   evt.put(std::move(hebUncalibRechits), hebHitCollection_);
-  if (pHGCHFNoseDigis.isValid()) 
+  if (pHGCHFNoseDigis.isValid())
     evt.put(std::move(hfnoseUncalibRechits), hfnoseHitCollection_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( HGCalUncalibRecHitProducer );
+DEFINE_FWK_MODULE(HGCalUncalibRecHitProducer);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.h
@@ -10,25 +10,22 @@
 
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h"
 
-
 class HGCalUncalibRecHitProducer : public edm::stream::EDProducer<> {
-  
- public:
+public:
   explicit HGCalUncalibRecHitProducer(const edm::ParameterSet& ps);
   ~HGCalUncalibRecHitProducer() override;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
-  
- private:
-  
-  const edm::EDGetTokenT<HGCalDigiCollection> eeDigiCollection_; // collection of HGCEE digis
-  const edm::EDGetTokenT<HGCalDigiCollection> hefDigiCollection_; // collection of HGCHEF digis
-  edm::EDGetTokenT<HGCalDigiCollection> hebDigiCollection_; // collection of HGCHEB digis
-  edm::EDGetTokenT<HGCalDigiCollection> hfnoseDigiCollection_; // collection of HGCHFNose digis
-  
-  const std::string eeHitCollection_; // instance name of HGCEE collection of hits
-  const std::string hefHitCollection_; // instance name of HGCHEF collection of hits
-  const std::string hebHitCollection_; // instance name of HGCHEB collection of hits
-  const std::string hfnoseHitCollection_; // instance name of HGCHFnose collection of hits
+
+private:
+  const edm::EDGetTokenT<HGCalDigiCollection> eeDigiCollection_;   // collection of HGCEE digis
+  const edm::EDGetTokenT<HGCalDigiCollection> hefDigiCollection_;  // collection of HGCHEF digis
+  edm::EDGetTokenT<HGCalDigiCollection> hebDigiCollection_;        // collection of HGCHEB digis
+  edm::EDGetTokenT<HGCalDigiCollection> hfnoseDigiCollection_;     // collection of HGCHFNose digis
+
+  const std::string eeHitCollection_;      // instance name of HGCEE collection of hits
+  const std::string hefHitCollection_;     // instance name of HGCHEF collection of hits
+  const std::string hebHitCollection_;     // instance name of HGCHEB collection of hits
+  const std::string hfnoseHitCollection_;  // instance name of HGCHFnose collection of hits
 
   std::unique_ptr<HGCalUncalibRecHitWorkerBaseClass> worker_;
 };

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -6,125 +6,111 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-void configureIt(const edm::ParameterSet& conf, 
-                 HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame>& maker) {
-  constexpr char isSiFE[]           = "isSiFE";
-  constexpr char adcNbits[]         = "adcNbits";
-  constexpr char adcSaturation[]    = "adcSaturation";
-  constexpr char tdcNbits[]         = "tdcNbits";
-  constexpr char tdcSaturation[]    = "tdcSaturation";
-  constexpr char tdcOnset[]         = "tdcOnset";
-  constexpr char toaLSB_ns[]        = "toaLSB_ns";
-  constexpr char fCPerMIP[]         = "fCPerMIP";
-  
-  if( conf.exists(isSiFE) ) {
+void configureIt(const edm::ParameterSet& conf, HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame>& maker) {
+  constexpr char isSiFE[] = "isSiFE";
+  constexpr char adcNbits[] = "adcNbits";
+  constexpr char adcSaturation[] = "adcSaturation";
+  constexpr char tdcNbits[] = "tdcNbits";
+  constexpr char tdcSaturation[] = "tdcSaturation";
+  constexpr char tdcOnset[] = "tdcOnset";
+  constexpr char toaLSB_ns[] = "toaLSB_ns";
+  constexpr char fCPerMIP[] = "fCPerMIP";
+
+  if (conf.exists(isSiFE)) {
     maker.set_isSiFESim(conf.getParameter<bool>(isSiFE));
   } else {
     maker.set_isSiFESim(false);
   }
 
-  if( conf.exists(adcNbits) ) {
-    uint32_t nBits     = conf.getParameter<uint32_t>(adcNbits);
-    double saturation  = conf.getParameter<double>(adcSaturation);
-    float adcLSB       = saturation/pow(2.,nBits);    
+  if (conf.exists(adcNbits)) {
+    uint32_t nBits = conf.getParameter<uint32_t>(adcNbits);
+    double saturation = conf.getParameter<double>(adcSaturation);
+    float adcLSB = saturation / pow(2., nBits);
     maker.set_ADCLSB(adcLSB);
   } else {
     maker.set_ADCLSB(-1.);
   }
-  
-  if( conf.exists(tdcNbits) ) {
-    uint32_t nBits    = conf.getParameter<uint32_t>(tdcNbits);
+
+  if (conf.exists(tdcNbits)) {
+    uint32_t nBits = conf.getParameter<uint32_t>(tdcNbits);
     double saturation = conf.getParameter<double>(tdcSaturation);
-    double onset      = conf.getParameter<double>(tdcOnset); // in fC
-    float tdcLSB      = saturation/pow(2.,nBits); 
+    double onset = conf.getParameter<double>(tdcOnset);  // in fC
+    float tdcLSB = saturation / pow(2., nBits);
     maker.set_TDCLSB(tdcLSB);
     maker.set_tdcOnsetfC(onset);
   } else {
     maker.set_TDCLSB(-1.);
     maker.set_tdcOnsetfC(-1.);
-  } 
+  }
 
-  if( conf.exists(toaLSB_ns) ) {
+  if (conf.exists(toaLSB_ns)) {
     maker.set_toaLSBToNS(conf.getParameter<double>(toaLSB_ns));
   } else {
     maker.set_toaLSBToNS(-1.);
   }
 
-  if( conf.exists(fCPerMIP) ) {
+  if (conf.exists(fCPerMIP)) {
     maker.set_fCPerMIP(conf.getParameter<std::vector<double> >(fCPerMIP));
   } else {
     maker.set_fCPerMIP(std::vector<double>({1.0}));
   }
-  
 }
 
-HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet&ps) :
-  HGCalUncalibRecHitWorkerBaseClass(ps)
-{
+HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet& ps)
+    : HGCalUncalibRecHitWorkerBaseClass(ps) {
   const edm::ParameterSet& ee_cfg = ps.getParameterSet("HGCEEConfig");
   const edm::ParameterSet& hef_cfg = ps.getParameterSet("HGCHEFConfig");
   const edm::ParameterSet& heb_cfg = ps.getParameterSet("HGCHEBConfig");
   const edm::ParameterSet& hfnose_cfg = ps.getParameterSet("HGCHFNoseConfig");
-  configureIt(ee_cfg,uncalibMaker_ee_);
-  configureIt(hef_cfg,uncalibMaker_hef_);
-  configureIt(heb_cfg,uncalibMaker_heb_);
-  configureIt(hfnose_cfg,uncalibMaker_hfnose_);
+  configureIt(ee_cfg, uncalibMaker_ee_);
+  configureIt(hef_cfg, uncalibMaker_hef_);
+  configureIt(heb_cfg, uncalibMaker_heb_);
+  configureIt(hfnose_cfg, uncalibMaker_hfnose_);
 }
 
-void
-HGCalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es)
-{
+void HGCalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es) {
   if (uncalibMaker_ee_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgceeGeoHandle; 
-    es.get<IdealGeometryRecord>().get("HGCalEESensitive",hgceeGeoHandle) ; 
+    edm::ESHandle<HGCalGeometry> hgceeGeoHandle;
+    es.get<IdealGeometryRecord>().get("HGCalEESensitive", hgceeGeoHandle);
     uncalibMaker_ee_.setGeometry(hgceeGeoHandle.product());
   }
   if (uncalibMaker_hef_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgchefGeoHandle; 
-    es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive",hgchefGeoHandle) ; 
+    edm::ESHandle<HGCalGeometry> hgchefGeoHandle;
+    es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive", hgchefGeoHandle);
     uncalibMaker_hef_.setGeometry(hgchefGeoHandle.product());
-  }  
-  uncalibMaker_heb_.setGeometry(nullptr);  
+  }
+  uncalibMaker_heb_.setGeometry(nullptr);
   if (uncalibMaker_hfnose_.isSiFESim()) {
-    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle; 
-    es.get<IdealGeometryRecord>().get("HGCalHFNoseSensitive",hgchfnoseGeoHandle) ; 
+    edm::ESHandle<HGCalGeometry> hgchfnoseGeoHandle;
+    es.get<IdealGeometryRecord>().get("HGCalHFNoseSensitive", hgchfnoseGeoHandle);
     uncalibMaker_hfnose_.setGeometry(hgchfnoseGeoHandle.product());
   }
 }
 
-
-bool
-HGCalUncalibRecHitWorkerWeights::runHGCEE( const HGCalDigiCollection::const_iterator & itdg,
-					   HGCeeUncalibratedRecHitCollection & result )
-{
-  result.push_back(uncalibMaker_ee_.makeRecHit(*itdg));  
+bool HGCalUncalibRecHitWorkerWeights::runHGCEE(const HGCalDigiCollection::const_iterator& itdg,
+                                               HGCeeUncalibratedRecHitCollection& result) {
+  result.push_back(uncalibMaker_ee_.makeRecHit(*itdg));
   return true;
 }
 
-bool
-HGCalUncalibRecHitWorkerWeights::runHGCHEsil( const HGCalDigiCollection::const_iterator & itdg,
-					      HGChefUncalibratedRecHitCollection & result )
-{
+bool HGCalUncalibRecHitWorkerWeights::runHGCHEsil(const HGCalDigiCollection::const_iterator& itdg,
+                                                  HGChefUncalibratedRecHitCollection& result) {
   result.push_back(uncalibMaker_hef_.makeRecHit(*itdg));
   return true;
 }
 
-bool
-HGCalUncalibRecHitWorkerWeights::runHGCHEscint(	const HGCalDigiCollection::const_iterator & itdg,
-						HGChebUncalibratedRecHitCollection & result )
-{
+bool HGCalUncalibRecHitWorkerWeights::runHGCHEscint(const HGCalDigiCollection::const_iterator& itdg,
+                                                    HGChebUncalibratedRecHitCollection& result) {
   result.push_back(uncalibMaker_heb_.makeRecHit(*itdg));
   return true;
 }
 
-bool
-HGCalUncalibRecHitWorkerWeights::runHGCHFNose( const HGCalDigiCollection::const_iterator & itdg,
-					       HGChfnoseUncalibratedRecHitCollection & result )
-{
-  result.push_back(uncalibMaker_hfnose_.makeRecHit(*itdg));  
+bool HGCalUncalibRecHitWorkerWeights::runHGCHFNose(const HGCalDigiCollection::const_iterator& itdg,
+                                                   HGChfnoseUncalibratedRecHitCollection& result) {
+  result.push_back(uncalibMaker_hfnose_.makeRecHit(*itdg));
   return true;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerFactory.h"
-DEFINE_EDM_PLUGIN( HGCalUncalibRecHitWorkerFactory, HGCalUncalibRecHitWorkerWeights, "HGCalUncalibRecHitWorkerWeights" );
+DEFINE_EDM_PLUGIN(HGCalUncalibRecHitWorkerFactory, HGCalUncalibRecHitWorkerWeights, "HGCalUncalibRecHitWorkerWeights");

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
@@ -15,32 +15,31 @@
 #include "DataFormats/HGCDigi/interface/HGCSample.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
 namespace edm {
   class Event;
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class HGCalUncalibRecHitWorkerWeights : public HGCalUncalibRecHitWorkerBaseClass {
-  
- public:
+public:
   HGCalUncalibRecHitWorkerWeights(const edm::ParameterSet&);
-  ~HGCalUncalibRecHitWorkerWeights() override {};
-  
-  void set(const edm::EventSetup& es) override;
-  bool runHGCEE(const HGCalDigiCollection::const_iterator & digi, HGCeeUncalibratedRecHitCollection & result) override;
-  bool runHGCHEsil(const HGCalDigiCollection::const_iterator & digi, HGChefUncalibratedRecHitCollection & result) override;
-  bool runHGCHEscint(const HGCalDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) override;
-  bool runHGCHFNose(const HGCalDigiCollection::const_iterator & digi, HGChfnoseUncalibratedRecHitCollection & result) override;
+  ~HGCalUncalibRecHitWorkerWeights() override{};
 
- protected:
-    
+  void set(const edm::EventSetup& es) override;
+  bool runHGCEE(const HGCalDigiCollection::const_iterator& digi, HGCeeUncalibratedRecHitCollection& result) override;
+  bool runHGCHEsil(const HGCalDigiCollection::const_iterator& digi,
+                   HGChefUncalibratedRecHitCollection& result) override;
+  bool runHGCHEscint(const HGCalDigiCollection::const_iterator& digi,
+                     HGChebUncalibratedRecHitCollection& result) override;
+  bool runHGCHFNose(const HGCalDigiCollection::const_iterator& digi,
+                    HGChfnoseUncalibratedRecHitCollection& result) override;
+
+protected:
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_ee_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_hef_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_heb_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCalDataFrame> uncalibMaker_hfnose_;
-
 };
 
 #endif


### PR DESCRIPTION
- add bhOffset_,
- fix getLayerWithOffset for new geometry,
- add firstLayerBH(), lastLayerBH()

#### PR description:

This PR introduces some important functionality and fixes in/to the RecHitTools required to eventually remove magic numbers in other places of the HGCal reconstruction code.
Related to https://github.com/cms-sw/cmssw/issues/26225

#### PR validation:

Ran some test code with D41 geometry and got the following output:

```text
bhOffset_: 36
EE layers: 28
FH layers: 22
BH layers: 14
first EE layer: 1
first FH layer: 1
first BH layer: 9
EE layer at z = 10000: 28
FH layer at z = 10000: 24
BH layer at z = 10000: 24
lastLayerEE: 28
lastLayerFH: 50
lastLayerBH: 50
firstLayerBH: 37
```

There are some discrepancies that need to be understood, which, however, seem to be in the geometry, underlining the importance of this PR for geometry validation.
For example: D41 should have 50 HGCal layers only, 22 FH layers, 14 BH layers.
After talking to @bsunanda , the error might also be in my setup and there are no issues in D41 geoemtry. We will investigate, but that's independent of the PR.