### PR TITLE
Running code-format for geometry

### DIFF
--- a/Geometry/CaloTopology/interface/CaloDirection.h
+++ b/Geometry/CaloTopology/interface/CaloDirection.h
@@ -6,15 +6,38 @@
 
    \brief Codes the local directions in the cell lattice.
 */
-enum CaloDirection{NONE,SOUTH,SOUTHEAST,SOUTHWEST,EAST,WEST,
-		   NORTHEAST,NORTHWEST,NORTH,DOWN,
-		   DOWNSOUTH,DOWNSOUTHEAST,DOWNSOUTHWEST,DOWNEAST,DOWNWEST,
-		   DOWNNORTHEAST,DOWNNORTHWEST,DOWNNORTH,UP,
-		   UPSOUTH,UPSOUTHEAST,UPSOUTHWEST,UPEAST,UPWEST,
-		   UPNORTHEAST,UPNORTHWEST,UPNORTH};
+enum CaloDirection {
+  NONE,
+  SOUTH,
+  SOUTHEAST,
+  SOUTHWEST,
+  EAST,
+  WEST,
+  NORTHEAST,
+  NORTHWEST,
+  NORTH,
+  DOWN,
+  DOWNSOUTH,
+  DOWNSOUTHEAST,
+  DOWNSOUTHWEST,
+  DOWNEAST,
+  DOWNWEST,
+  DOWNNORTHEAST,
+  DOWNNORTHWEST,
+  DOWNNORTH,
+  UP,
+  UPSOUTH,
+  UPSOUTHEAST,
+  UPSOUTHWEST,
+  UPEAST,
+  UPWEST,
+  UPNORTHEAST,
+  UPNORTHWEST,
+  UPNORTH
+};
 
 //class ostream;
 #include <iosfwd>
-std::ostream & operator<<(std::ostream&,const CaloDirection&);
+std::ostream& operator<<(std::ostream&, const CaloDirection&);
 
 #endif

--- a/Geometry/CaloTopology/interface/CaloSubdetectorTopology.h
+++ b/Geometry/CaloTopology/interface/CaloSubdetectorTopology.h
@@ -1,7 +1,6 @@
 #ifndef TOPOLOGY_CALOTOPOLOGY_CALOSUBDETECTORTOPOLOGY_H
 #define TOPOLOGY_CALOTOPOLOGY_CALOSUBDETECTORTOPOLOGY_H 1
 
-
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CaloTopology/interface/CaloDirection.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -20,9 +19,9 @@ $Revision: 1.7 $
 class CaloSubdetectorTopology {
 public:
   /// standard constructor
-  CaloSubdetectorTopology() {};
+  CaloSubdetectorTopology(){};
   /// virtual destructor
-  virtual ~CaloSubdetectorTopology() { }
+  virtual ~CaloSubdetectorTopology() {}
   /// is this detid present in the Topology?
   virtual bool valid(const DetId& /*id*/) const { return false; };
   /// return a linear packed id
@@ -34,7 +33,7 @@ public:
   /// return a version which identifies the given topology
   virtual int topoVersion() const { return 0; }
   /// return whether this topology is consistent with the numbering in the given topology
-  virtual bool denseIdConsistent(int topoVer) const { return topoVer==topoVersion(); }
+  virtual bool denseIdConsistent(int topoVer) const { return topoVer == topoVersion(); }
 
   /** Get the neighbors of the given cell in east direction*/
   virtual std::vector<DetId> east(const DetId& id) const = 0;
@@ -53,103 +52,89 @@ public:
   // see for instance RecoCaloTools/Navigation/interface/CaloNavigator.h
   virtual DetId goEast(const DetId& id) const {
     std::vector<DetId> ids = east(id);
-    return ids.empty() ? DetId() : ids[0];    
+    return ids.empty() ? DetId() : ids[0];
   }
   virtual DetId goWest(const DetId& id) const {
     std::vector<DetId> ids = west(id);
-    return ids.empty() ? DetId() : ids[0];    
+    return ids.empty() ? DetId() : ids[0];
   }
   virtual DetId goNorth(const DetId& id) const {
     std::vector<DetId> ids = north(id);
-    return ids.empty() ? DetId() : ids[0];    
+    return ids.empty() ? DetId() : ids[0];
   }
   virtual DetId goSouth(const DetId& id) const {
     std::vector<DetId> ids = south(id);
-    return ids.empty() ? DetId() : ids[0];    
+    return ids.empty() ? DetId() : ids[0];
   }
   virtual DetId goUp(const DetId& id) const {
     std::vector<DetId> ids = up(id);
-    return ids.empty() ? DetId() : ids[0];    
+    return ids.empty() ? DetId() : ids[0];
   }
   virtual DetId goDown(const DetId& id) const {
     std::vector<DetId> ids = down(id);
-    return ids.empty() ? DetId() : ids[0];    
+    return ids.empty() ? DetId() : ids[0];
   }
 
-
   /** Get the neighbors of the given cell given direction*/
-  virtual std::vector<DetId> getNeighbours(const DetId& id, const CaloDirection& dir) const
-    {
-      std::vector<DetId> aNullVector;
-      switch(dir)
-	{
-	case NONE:
-	  return aNullVector;
-	  break;
-	case SOUTH:
-	  return south(id);
-	  break;
-	case NORTH:
-	  return north(id);
-	  break;
-	case EAST:
-	  return east(id);
-	  break;
-	case WEST:
-	  return west(id);
-	  break;
-        default:
-	  throw cms::Exception("getNeighboursError") << "Unsopported direction";
-	}
-      return aNullVector;
+  virtual std::vector<DetId> getNeighbours(const DetId& id, const CaloDirection& dir) const {
+    std::vector<DetId> aNullVector;
+    switch (dir) {
+      case NONE:
+        return aNullVector;
+        break;
+      case SOUTH:
+        return south(id);
+        break;
+      case NORTH:
+        return north(id);
+        break;
+      case EAST:
+        return east(id);
+        break;
+      case WEST:
+        return west(id);
+        break;
+      default:
+        throw cms::Exception("getNeighboursError") << "Unsopported direction";
     }
+    return aNullVector;
+  }
 
   /** Get the neighbors of the given cell in a window of given size*/
   virtual std::vector<DetId> getWindow(const DetId& id, const int& northSouthSize, const int& eastWestSize) const;
 
   /** Get all the neighbors of the given cell*/
-  virtual std::vector<DetId> getAllNeighbours(const DetId& id) const
-    {
-      return getWindow(id,3,3);
-    }
+  virtual std::vector<DetId> getAllNeighbours(const DetId& id) const { return getWindow(id, 3, 3); }
 
- protected:
-  typedef std::pair<int,int> Coordinate;
+protected:
+  typedef std::pair<int, int> Coordinate;
 
-  struct CellInfo
-  {
+  struct CellInfo {
     bool visited;
-    
+
     DetId cell;
-    
-    CellInfo() : 
-      visited(false)
-    {
-    }
-    
-    CellInfo(bool a_visited, const DetId &a_cell) : 
-      visited(a_visited),
-	 cell(a_cell)
-    {
-    }
+
+    CellInfo() : visited(false) {}
+
+    CellInfo(bool a_visited, const DetId& a_cell) : visited(a_visited), cell(a_cell) {}
   };
 
-  inline Coordinate getNeighbourIndex(const Coordinate &coord, const CaloDirection& dir) const
-    {
-      switch (dir)
-        {
-        case NORTH: return Coordinate(coord.first,coord.second + 1);
-        case SOUTH: return Coordinate(coord.first,coord.second - 1);
-	  
-        case EAST:  return Coordinate(coord.first + 1,coord.second);
-        case WEST:  return Coordinate(coord.first - 1,coord.second);
-	  
-        default:
-	  throw cms::Exception("getWindowError") << "Unsopported direction";
-        }
-    }
-  
-};
+  inline Coordinate getNeighbourIndex(const Coordinate& coord, const CaloDirection& dir) const {
+    switch (dir) {
+      case NORTH:
+        return Coordinate(coord.first, coord.second + 1);
+      case SOUTH:
+        return Coordinate(coord.first, coord.second - 1);
 
+      case EAST:
+        return Coordinate(coord.first + 1, coord.second);
+      case WEST:
+        return Coordinate(coord.first - 1, coord.second);
+
+      default:
+        throw cms::Exception("getWindowError") << "Unsopported direction";
+    }
+  }
+};
 
 #endif

--- a/Geometry/CaloTopology/interface/CaloTopology.h
+++ b/Geometry/CaloTopology/interface/CaloTopology.h
@@ -18,8 +18,7 @@ $Revision: 1.4 $
 
 class CaloTopology {
 public:
-
-  typedef std::map<int, std::unique_ptr<const CaloSubdetectorTopology>> TopMap ;
+  typedef std::map<int, std::unique_ptr<const CaloSubdetectorTopology>> TopMap;
 
   CaloTopology();
 
@@ -30,7 +29,7 @@ public:
   const CaloSubdetectorTopology* getSubdetectorTopology(const DetId& id) const;
   /// access the subdetector Topology for the given subdetector directly
   const CaloSubdetectorTopology* getSubdetectorTopology(DetId::Detector det, int subdet) const;
-  /// Is this a valid cell id? 
+  /// Is this a valid cell id?
   bool valid(const DetId& id) const;
 
   /// Get the neighbors of the given cell in east direction
@@ -56,7 +55,5 @@ private:
   TopMap theTopologies_;
   int makeIndex(DetId::Detector det, int subdet) const;
 };
-
-
 
 #endif

--- a/Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h
+++ b/Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h
@@ -19,7 +19,7 @@ class CaloTowerConstituentsMap {
 public:
   CaloTowerConstituentsMap() = delete;
   ~CaloTowerConstituentsMap();
-  CaloTowerConstituentsMap(const HcalTopology * hcaltopo, const CaloTowerTopology * cttopo);
+  CaloTowerConstituentsMap(const HcalTopology* hcaltopo, const CaloTowerTopology* cttopo);
 
   /// Get the tower id for this det id (or null if not known)
   CaloTowerDetId towerOf(const DetId& id) const;
@@ -34,20 +34,20 @@ public:
   void sort();
 
   /// add standard (hardcoded) HB items?
-  void useStandardHB(bool use=true);
+  void useStandardHB(bool use = true);
   /// add standard (hardcoded) HE items?
-  void useStandardHE(bool use=true);
+  void useStandardHE(bool use = true);
   /// add standard (hardcoded) HO items?
-  void useStandardHO(bool use=true);
+  void useStandardHO(bool use = true);
   /// add standard (hardcoded) HF items?
-  void useStandardHF(bool use=true);
+  void useStandardHF(bool use = true);
   /// add standard (hardcoded) EB items?
-  void useStandardEB(bool use=true);
+  void useStandardEB(bool use = true);
 
 private:
-  const HcalTopology * m_hcaltopo;
-  const CaloTowerTopology * m_cttopo;
-    
+  const HcalTopology* m_hcaltopo;
+  const CaloTowerTopology* m_cttopo;
+
   bool standardHB_;
   bool standardHE_;
   bool standardHF_;
@@ -56,14 +56,14 @@ private:
 
   struct MapItem {
     typedef DetId key_type;
-    MapItem(const DetId& acell, const CaloTowerDetId& atower) : cell(acell),tower(atower) { }
+    MapItem(const DetId& acell, const CaloTowerDetId& atower) : cell(acell), tower(atower) {}
     DetId cell;
     CaloTowerDetId tower;
     inline DetId id() const { return cell; }
   };
 
   edm::SortedCollection<MapItem> m_items;
-  mutable std::atomic<std::multimap<CaloTowerDetId,DetId>*> m_reverseItems;
+  mutable std::atomic<std::multimap<CaloTowerDetId, DetId>*> m_reverseItems;
 };
 
 #endif

--- a/Geometry/CaloTopology/interface/CaloTowerTopology.h
+++ b/Geometry/CaloTopology/interface/CaloTowerTopology.h
@@ -13,9 +13,9 @@
 class CaloTowerTopology final : public CaloSubdetectorTopology {
 public:
   /// standard constructor
-  CaloTowerTopology(const HcalTopology * topology);
+  CaloTowerTopology(const HcalTopology* topology);
   /// virtual destructor
-  ~CaloTowerTopology() override { }
+  ~CaloTowerTopology() override {}
   /// is this detid present in the Topology?
   bool valid(const DetId& id) const override;
   virtual bool validDetId(const CaloTowerDetId& id) const;
@@ -33,18 +33,18 @@ public:
   std::vector<DetId> down(const DetId& id) const override;
 
   //mimic accessors from HcalTopology, but with continuous ieta
-  int firstHBRing() const {return firstHBRing_;}
-  int lastHBRing()  const {return lastHBRing_;}
-  int firstHERing() const {return firstHERing_;}
-  int lastHERing()  const {return lastHERing_;}
-  int firstHFRing() const {return firstHFRing_;}
-  int lastHFRing()  const {return lastHFRing_;}
-  int firstHORing() const {return firstHORing_;}
-  int lastHORing()  const {return lastHORing_;}
-  int firstHEDoublePhiRing()   const {return firstHEDoublePhiRing_;} 
-  int firstHEQuadPhiRing()     const {return firstHEQuadPhiRing_;} 
-  int firstHFQuadPhiRing()     const {return firstHFQuadPhiRing_;}
-  
+  int firstHBRing() const { return firstHBRing_; }
+  int lastHBRing() const { return lastHBRing_; }
+  int firstHERing() const { return firstHERing_; }
+  int lastHERing() const { return lastHERing_; }
+  int firstHFRing() const { return firstHFRing_; }
+  int lastHFRing() const { return lastHFRing_; }
+  int firstHORing() const { return firstHORing_; }
+  int lastHORing() const { return lastHORing_; }
+  int firstHEDoublePhiRing() const { return firstHEDoublePhiRing_; }
+  int firstHEQuadPhiRing() const { return firstHEQuadPhiRing_; }
+  int firstHFQuadPhiRing() const { return firstHFQuadPhiRing_; }
+
   //conversion between CaloTowerTopology ieta and HcalTopology ieta
   int convertCTtoHcal(int ct_ieta) const;
   int convertHcaltoCT(int hcal_ieta, HcalSubdetector subdet) const;
@@ -52,12 +52,12 @@ public:
   //dense index functions moved from CaloTowerDetId
   uint32_t denseIndex(const DetId& id) const;
   CaloTowerDetId detIdFromDenseIndex(uint32_t din) const;
-  bool validDenseIndex(uint32_t din) const { return ( din < kSizeForDenseIndexing ); }
+  bool validDenseIndex(uint32_t din) const { return (din < kSizeForDenseIndexing); }
   uint32_t sizeForDenseIndexing() const { return kSizeForDenseIndexing; }
-  
+
 private:
   //member variables
-  const HcalTopology * hcaltopo;
+  const HcalTopology* hcaltopo;
   int firstHBRing_, lastHBRing_;
   int firstHERing_, lastHERing_;
   int firstHFRing_, lastHFRing_;
@@ -65,6 +65,5 @@ private:
   int firstHEDoublePhiRing_, firstHEQuadPhiRing_, firstHFQuadPhiRing_;
   int nSinglePhi_, nDoublePhi_, nQuadPhi_, nEtaHE_;
   uint32_t kSizeForDenseIndexing;
-
 };
 #endif

--- a/Geometry/CaloTopology/interface/EcalBarrelHardcodedTopology.h
+++ b/Geometry/CaloTopology/interface/EcalBarrelHardcodedTopology.h
@@ -6,95 +6,77 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 
-class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology
-{
-
- public:
+class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology {
+public:
   /// create a new Topology
-  EcalBarrelHardcodedTopology() {};
+  EcalBarrelHardcodedTopology(){};
 
-  ~EcalBarrelHardcodedTopology() override {};
-  
+  ~EcalBarrelHardcodedTopology() override{};
+
   /// move the Topology north (increment iphi)
-  DetId  goNorth(const DetId& id) const override {
-    return incrementIphi(EBDetId(id));
+  DetId goNorth(const DetId& id) const override { return incrementIphi(EBDetId(id)); }
+  std::vector<DetId> north(const DetId& id) const override {
+    EBDetId nextId = goNorth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> north(const DetId& id) const override
-    { 
-      EBDetId nextId=goNorth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology south (decrement iphi)
-  DetId goSouth(const DetId& id) const override {
-    return decrementIphi(EBDetId(id));
+  DetId goSouth(const DetId& id) const override { return decrementIphi(EBDetId(id)); }
+  std::vector<DetId> south(const DetId& id) const override {
+    EBDetId nextId = goSouth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> south(const DetId& id) const override
-    { 
-      EBDetId nextId=goSouth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology east (negative ieta)
-  DetId  goEast(const DetId& id) const override {
-    return decrementIeta(EBDetId(id));
+  DetId goEast(const DetId& id) const override { return decrementIeta(EBDetId(id)); }
+  std::vector<DetId> east(const DetId& id) const override {
+    EBDetId nextId = goEast(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> east(const DetId& id) const override
-    { 
-      EBDetId nextId=goEast(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology west (positive ieta)
-  DetId  goWest(const DetId& id) const override {
-    return incrementIeta(EBDetId(id));
+  DetId goWest(const DetId& id) const override { return incrementIeta(EBDetId(id)); }
+  std::vector<DetId> west(const DetId& id) const override {
+    EBDetId nextId = goWest(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> west(const DetId& id) const override
-    { 
-      EBDetId nextId=goWest(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
-  
-  std::vector<DetId> up(const DetId& /*id*/) const override
-    {
-      std::cout << "EcalBarrelHardcodedTopology::up() not yet implemented" << std::endl; 
-      std::vector<DetId> vNeighborsDetId;
-      return  vNeighborsDetId;
-    }
-  
-  std::vector<DetId> down(const DetId& /*id*/) const override
-    {
-      std::cout << "EcalBarrelHardcodedTopology::down() not yet implemented" << std::endl; 
-      std::vector<DetId> vNeighborsDetId;
-      return  vNeighborsDetId;
-    }
 
- private:
+  std::vector<DetId> up(const DetId& /*id*/) const override {
+    std::cout << "EcalBarrelHardcodedTopology::up() not yet implemented" << std::endl;
+    std::vector<DetId> vNeighborsDetId;
+    return vNeighborsDetId;
+  }
 
+  std::vector<DetId> down(const DetId& /*id*/) const override {
+    std::cout << "EcalBarrelHardcodedTopology::down() not yet implemented" << std::endl;
+    std::vector<DetId> vNeighborsDetId;
+    return vNeighborsDetId;
+  }
+
+private:
   /// move the nagivator to larger ieta (more positive z) (stops at end of barrel and returns null)
-  EBDetId incrementIeta(const EBDetId&) const ;
+  EBDetId incrementIeta(const EBDetId&) const;
 
   /// move the nagivator to smaller ieta (more negative z) (stops at end of barrel and returns null)
-  EBDetId decrementIeta(const EBDetId&) const ;
+  EBDetId decrementIeta(const EBDetId&) const;
 
-  /// move the nagivator to larger iphi (wraps around the barrel) 
-  EBDetId incrementIphi(const EBDetId&) const ;
+  /// move the nagivator to larger iphi (wraps around the barrel)
+  EBDetId incrementIphi(const EBDetId&) const;
 
   /// move the nagivator to smaller iphi (wraps around the barrel)
   EBDetId decrementIphi(const EBDetId&) const;
-
 };
 
 #endif

--- a/Geometry/CaloTopology/interface/EcalBarrelTopology.h
+++ b/Geometry/CaloTopology/interface/EcalBarrelTopology.h
@@ -9,98 +9,80 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 
-class EcalBarrelTopology final : public CaloSubdetectorTopology
-{
-
+class EcalBarrelTopology final : public CaloSubdetectorTopology {
 public:
   /// create a new Topology
- EcalBarrelTopology(): theGeom_(nullptr) {};
+  EcalBarrelTopology() : theGeom_(nullptr){};
 
   /// virtual destructor
-  ~EcalBarrelTopology() override { }  
+  ~EcalBarrelTopology() override {}
 
   /// create a new Topology from geometry
   EcalBarrelTopology(CaloGeometry const& theGeom) {
-    theGeom_ = theGeom.getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
+    theGeom_ = theGeom.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   }
-  
- /// move the Topology north (increment iphi)
-  DetId  goNorth(const DetId& id) const override {
-    return incrementIphi(EBDetId(id));
+
+  /// move the Topology north (increment iphi)
+  DetId goNorth(const DetId& id) const override { return incrementIphi(EBDetId(id)); }
+  std::vector<DetId> north(const DetId& id) const override {
+    EBDetId nextId = goNorth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> north(const DetId& id) const override
-    { 
-      EBDetId nextId=goNorth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology south (decrement iphi)
-  DetId goSouth(const DetId& id) const override {
-    return decrementIphi(EBDetId(id));
+  DetId goSouth(const DetId& id) const override { return decrementIphi(EBDetId(id)); }
+  std::vector<DetId> south(const DetId& id) const override {
+    EBDetId nextId = goSouth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> south(const DetId& id) const override
-    { 
-      EBDetId nextId=goSouth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology east (negative ieta)
-  DetId  goEast(const DetId& id) const override {
-    return decrementIeta(EBDetId(id));
+  DetId goEast(const DetId& id) const override { return decrementIeta(EBDetId(id)); }
+  std::vector<DetId> east(const DetId& id) const override {
+    EBDetId nextId = goEast(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> east(const DetId& id) const override
-    { 
-      EBDetId nextId=goEast(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology west (positive ieta)
-  DetId  goWest(const DetId& id) const override {
-    return incrementIeta(EBDetId(id));
+  DetId goWest(const DetId& id) const override { return incrementIeta(EBDetId(id)); }
+  std::vector<DetId> west(const DetId& id) const override {
+    EBDetId nextId = goWest(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EBDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> west(const DetId& id) const override
-    { 
-      EBDetId nextId=goWest(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EBDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
-  
-  
-  std::vector<DetId> up(const DetId& /*id*/) const override
-    {
-      std::cout << "EcalBarrelTopology::up() not yet implemented" << std::endl; 
-      std::vector<DetId> vNeighborsDetId;
-      return  vNeighborsDetId;
-    }
-  
-  std::vector<DetId> down(const DetId& /*id*/) const override
-    {
-      std::cout << "EcalBarrelTopology::down() not yet implemented" << std::endl; 
-      std::vector<DetId> vNeighborsDetId;
-      return  vNeighborsDetId;
-    }
 
- private:
+  std::vector<DetId> up(const DetId& /*id*/) const override {
+    std::cout << "EcalBarrelTopology::up() not yet implemented" << std::endl;
+    std::vector<DetId> vNeighborsDetId;
+    return vNeighborsDetId;
+  }
 
+  std::vector<DetId> down(const DetId& /*id*/) const override {
+    std::cout << "EcalBarrelTopology::down() not yet implemented" << std::endl;
+    std::vector<DetId> vNeighborsDetId;
+    return vNeighborsDetId;
+  }
+
+private:
   /// move the nagivator to larger ieta (more positive z) (stops at end of barrel and returns null)
-  EBDetId incrementIeta(const EBDetId&) const ;
+  EBDetId incrementIeta(const EBDetId&) const;
 
   /// move the nagivator to smaller ieta (more negative z) (stops at end of barrel and returns null)
-  EBDetId decrementIeta(const EBDetId&) const ;
+  EBDetId decrementIeta(const EBDetId&) const;
 
-  /// move the nagivator to larger iphi (wraps around the barrel) 
-  EBDetId incrementIphi(const EBDetId&) const ;
+  /// move the nagivator to larger iphi (wraps around the barrel)
+  EBDetId incrementIphi(const EBDetId&) const;
 
   /// move the nagivator to smaller iphi (wraps around the barrel)
   EBDetId decrementIphi(const EBDetId&) const;

--- a/Geometry/CaloTopology/interface/EcalEndcapHardcodedTopology.h
+++ b/Geometry/CaloTopology/interface/EcalEndcapHardcodedTopology.h
@@ -6,95 +6,77 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 
-class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology
-{
-
- public:
+class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology {
+public:
   /// create a new Topology
-  EcalEndcapHardcodedTopology() {};
+  EcalEndcapHardcodedTopology(){};
 
-  ~EcalEndcapHardcodedTopology() override {};
-  
-   /// move the Topology north (increment iy)  
-  DetId  goNorth(const DetId& id) const override {
-    return incrementIy(EEDetId(id));
-  }
-  std::vector<DetId> north(const DetId& id) const override
-  { 
-    EEDetId nextId= goNorth(id);
+  ~EcalEndcapHardcodedTopology() override{};
+
+  /// move the Topology north (increment iy)
+  DetId goNorth(const DetId& id) const override { return incrementIy(EEDetId(id)); }
+  std::vector<DetId> north(const DetId& id) const override {
+    EEDetId nextId = goNorth(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==EEDetId(0)))
+    if (!(nextId == EEDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
     return vNeighborsDetId;
   }
-  
+
   /// move the Topology south (decrement iy)
-  DetId goSouth(const DetId& id) const override {
-    return decrementIy(EEDetId(id));
-  }
-  std::vector<DetId> south(const DetId& id) const override
-  { 
-    EEDetId nextId= goSouth(id);
+  DetId goSouth(const DetId& id) const override { return decrementIy(EEDetId(id)); }
+  std::vector<DetId> south(const DetId& id) const override {
+    EEDetId nextId = goSouth(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==EEDetId(0)))
+    if (!(nextId == EEDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
     return vNeighborsDetId;
   }
-  
+
   /// move the Topology east (positive ix)
-  DetId  goEast(const DetId& id) const override {
-    return incrementIx(EEDetId(id));
-  }
-  std::vector<DetId> east(const DetId& id) const override
-  { 
-    EEDetId nextId=goEast(id);
+  DetId goEast(const DetId& id) const override { return incrementIx(EEDetId(id)); }
+  std::vector<DetId> east(const DetId& id) const override {
+    EEDetId nextId = goEast(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==EEDetId(0)))
+    if (!(nextId == EEDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
     return vNeighborsDetId;
   }
-  
+
   /// move the Topology west (negative ix)
-  DetId goWest(const DetId& id) const override {
-    return decrementIx(EEDetId(id));
-  }
-  std::vector<DetId> west(const DetId& id) const override
-  { 
-    EEDetId nextId=goWest(id);
+  DetId goWest(const DetId& id) const override { return decrementIx(EEDetId(id)); }
+  std::vector<DetId> west(const DetId& id) const override {
+    EEDetId nextId = goWest(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==EEDetId(0)))
+    if (!(nextId == EEDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
     return vNeighborsDetId;
   }
-  
-  std::vector<DetId> up(const DetId& /*id*/) const override
-  {
-    std::cout << "EcalEndcapHardcodedTopology::up() not yet implemented" << std::endl; 
+
+  std::vector<DetId> up(const DetId& /*id*/) const override {
+    std::cout << "EcalEndcapHardcodedTopology::up() not yet implemented" << std::endl;
     std::vector<DetId> vNeighborsDetId;
-    return  vNeighborsDetId;
+    return vNeighborsDetId;
   }
-  
-  std::vector<DetId> down(const DetId& /*id*/) const override
-  {
-    std::cout << "EcalEndcapHardcodedTopology::down() not yet implemented" << std::endl; 
+
+  std::vector<DetId> down(const DetId& /*id*/) const override {
+    std::cout << "EcalEndcapHardcodedTopology::down() not yet implemented" << std::endl;
     std::vector<DetId> vNeighborsDetId;
-    return  vNeighborsDetId;
+    return vNeighborsDetId;
   }
-  
- private:
-  
+
+private:
   /// move the nagivator to larger ix
-  EEDetId incrementIx(const EEDetId&) const ;
+  EEDetId incrementIx(const EEDetId&) const;
 
   /// move the nagivator to smaller ix
-  EEDetId decrementIx(const EEDetId&) const ;
+  EEDetId decrementIx(const EEDetId&) const;
 
   /// move the nagivator to larger iy
-  EEDetId incrementIy(const EEDetId&) const ;
+  EEDetId incrementIy(const EEDetId&) const;
 
   /// move the nagivator to smaller iy
   EEDetId decrementIy(const EEDetId&) const;
-
 };
 
 #endif

--- a/Geometry/CaloTopology/interface/EcalEndcapTopology.h
+++ b/Geometry/CaloTopology/interface/EcalEndcapTopology.h
@@ -11,95 +11,79 @@
 #include <iostream>
 
 class EcalEndcapTopology final : public CaloSubdetectorTopology {
-
 public:
   /// create a new Topology
-  EcalEndcapTopology() : theGeom_(nullptr) {};
+  EcalEndcapTopology() : theGeom_(nullptr){};
 
   /// virtual destructor
-  ~EcalEndcapTopology() override { }  
-  
+  ~EcalEndcapTopology() override {}
+
   /// create a new Topology from geometry
   EcalEndcapTopology(CaloGeometry const& theGeom) {
-    theGeom_ = theGeom.getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
+    theGeom_ = theGeom.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
   }
 
-  /// move the Topology north (increment iy)  
-  DetId  goNorth(const DetId& id) const override {
-    return incrementIy(EEDetId(id));
+  /// move the Topology north (increment iy)
+  DetId goNorth(const DetId& id) const override { return incrementIy(EEDetId(id)); }
+  std::vector<DetId> north(const DetId& id) const override {
+    EEDetId nextId = goNorth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EEDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> north(const DetId& id) const override
-    { 
-      EEDetId nextId= goNorth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EEDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology south (decrement iy)
-  DetId goSouth(const DetId& id) const override {
-    return decrementIy(EEDetId(id));
+  DetId goSouth(const DetId& id) const override { return decrementIy(EEDetId(id)); }
+  std::vector<DetId> south(const DetId& id) const override {
+    EEDetId nextId = goSouth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EEDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> south(const DetId& id) const override
-    { 
-      EEDetId nextId= goSouth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EEDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology east (positive ix)
-  DetId  goEast(const DetId& id) const override {
-    return incrementIx(EEDetId(id));
+  DetId goEast(const DetId& id) const override { return incrementIx(EEDetId(id)); }
+  std::vector<DetId> east(const DetId& id) const override {
+    EEDetId nextId = goEast(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EEDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> east(const DetId& id) const override
-    { 
-      EEDetId nextId=goEast(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EEDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology west (negative ix)
-  DetId goWest(const DetId& id) const override {
-    return decrementIx(EEDetId(id));
+  DetId goWest(const DetId& id) const override { return decrementIx(EEDetId(id)); }
+  std::vector<DetId> west(const DetId& id) const override {
+    EEDetId nextId = goWest(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == EEDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> west(const DetId& id) const override
-    { 
-      EEDetId nextId=goWest(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==EEDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
-  
-  std::vector<DetId> up(const DetId& /*id*/) const override
-    {
-      std::cout << "EcalBarrelTopology::up() not yet implemented" << std::endl; 
-      std::vector<DetId> vNeighborsDetId;
-      return  vNeighborsDetId;
-    }
-  
-  std::vector<DetId> down(const DetId& /*id*/) const override
-    {
-      std::cout << "EcalBarrelTopology::down() not yet implemented" << std::endl; 
-      std::vector<DetId> vNeighborsDetId;
-      return  vNeighborsDetId;
-    }
 
- private:
+  std::vector<DetId> up(const DetId& /*id*/) const override {
+    std::cout << "EcalBarrelTopology::up() not yet implemented" << std::endl;
+    std::vector<DetId> vNeighborsDetId;
+    return vNeighborsDetId;
+  }
 
+  std::vector<DetId> down(const DetId& /*id*/) const override {
+    std::cout << "EcalBarrelTopology::down() not yet implemented" << std::endl;
+    std::vector<DetId> vNeighborsDetId;
+    return vNeighborsDetId;
+  }
+
+private:
   /// move the nagivator to larger ix
-  EEDetId incrementIx(const EEDetId& id) const ;
+  EEDetId incrementIx(const EEDetId& id) const;
 
   /// move the nagivator to smaller ix
-  EEDetId decrementIx(const EEDetId& id) const ;
+  EEDetId decrementIx(const EEDetId& id) const;
 
   /// move the nagivator to larger iy
-  EEDetId incrementIy(const EEDetId& id) const ;
+  EEDetId incrementIy(const EEDetId& id) const;
 
   /// move the nagivator to smaller iy
   EEDetId decrementIy(const EEDetId& id) const;

--- a/Geometry/CaloTopology/interface/EcalPreshowerTopology.h
+++ b/Geometry/CaloTopology/interface/EcalPreshowerTopology.h
@@ -10,101 +10,80 @@
 #include <iostream>
 
 class EcalPreshowerTopology final : public CaloSubdetectorTopology {
-
- public:
+public:
   /// create a new Topology
   EcalPreshowerTopology() = default;
 
   /// virtual destructor
-  ~EcalPreshowerTopology() override { }  
-  
-  
-  /// move the Topology north (increment iy)  
-  DetId  goNorth(const DetId& id) const override {
-    return incrementIy(ESDetId(id));
+  ~EcalPreshowerTopology() override {}
+
+  /// move the Topology north (increment iy)
+  DetId goNorth(const DetId& id) const override { return incrementIy(ESDetId(id)); }
+  std::vector<DetId> north(const DetId& id) const override {
+    ESDetId nextId = goNorth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == ESDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> north(const DetId& id) const override
-    { 
-      ESDetId nextId= goNorth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==ESDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology south (decrement iy)
-  DetId goSouth(const DetId& id) const override {
-    return decrementIy(ESDetId(id));
+  DetId goSouth(const DetId& id) const override { return decrementIy(ESDetId(id)); }
+  std::vector<DetId> south(const DetId& id) const override {
+    ESDetId nextId = goSouth(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == ESDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
   }
-  std::vector<DetId> south(const DetId& id) const override
-    { 
-      ESDetId nextId= goSouth(id);
-      std::vector<DetId> vNeighborsDetId;
-      if (! (nextId==ESDetId(0)))
-	vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-      return vNeighborsDetId;
-    }
 
   /// move the Topology east (positive ix)
-  DetId  goEast(const DetId& id) const override {
-    return incrementIx(ESDetId(id));
-  }
-  std::vector<DetId> east(const DetId& id) const override
-  { 
-    ESDetId nextId=goEast(id);
+  DetId goEast(const DetId& id) const override { return incrementIx(ESDetId(id)); }
+  std::vector<DetId> east(const DetId& id) const override {
+    ESDetId nextId = goEast(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==ESDetId(0)))
+    if (!(nextId == ESDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
     return vNeighborsDetId;
   }
 
   /// move the Topology west (negative ix)
-  DetId goWest(const DetId& id) const override {
-    return decrementIx(ESDetId(id));
-  }
-  std::vector<DetId> west(const DetId& id) const override
-  { 
-    ESDetId nextId=goWest(id);
+  DetId goWest(const DetId& id) const override { return decrementIx(ESDetId(id)); }
+  std::vector<DetId> west(const DetId& id) const override {
+    ESDetId nextId = goWest(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==ESDetId(0)))
+    if (!(nextId == ESDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
     return vNeighborsDetId;
   }
-  
-  DetId goUp(const DetId& id) const override {
-    return incrementIz(ESDetId(id));
-  }
-  std::vector<DetId> up(const DetId& id) const override
-  {
-    ESDetId nextId=goUp(id);
+
+  DetId goUp(const DetId& id) const override { return incrementIz(ESDetId(id)); }
+  std::vector<DetId> up(const DetId& id) const override {
+    ESDetId nextId = goUp(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==ESDetId(0)))
+    if (!(nextId == ESDetId(0)))
       vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-    return  vNeighborsDetId;
-  }
-  
-  DetId goDown(const DetId& id) const override {
-    return decrementIz(ESDetId(id));
-  }
-  std::vector<DetId> down(const DetId& id) const override
-  {
-    ESDetId nextId=goDown(id);
-    std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==ESDetId(0)))
-      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
-    return  vNeighborsDetId;
+    return vNeighborsDetId;
   }
 
- private:
+  DetId goDown(const DetId& id) const override { return decrementIz(ESDetId(id)); }
+  std::vector<DetId> down(const DetId& id) const override {
+    ESDetId nextId = goDown(id);
+    std::vector<DetId> vNeighborsDetId;
+    if (!(nextId == ESDetId(0)))
+      vNeighborsDetId.emplace_back(DetId(nextId.rawId()));
+    return vNeighborsDetId;
+  }
 
+private:
   /// move the nagivator to larger ix
-  ESDetId incrementIx(const ESDetId& id) const ;
+  ESDetId incrementIx(const ESDetId& id) const;
 
   /// move the nagivator to smaller ix
-  ESDetId decrementIx(const ESDetId& id) const ;
+  ESDetId decrementIx(const ESDetId& id) const;
 
   /// move the nagivator to larger iy
-  ESDetId incrementIy(const ESDetId& id) const ;
+  ESDetId incrementIy(const ESDetId& id) const;
 
   /// move the nagivator to smaller iy
   ESDetId decrementIy(const ESDetId& id) const;
@@ -117,9 +96,3 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
 };
 
 #endif
-
-
-
-
-
-

--- a/Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h
+++ b/Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h
@@ -17,48 +17,45 @@
   */
 
 class EcalTrigTowerConstituentsMap {
-  
- public:
-  
+public:
   EcalTrigTowerConstituentsMap();
 
   /// Get the tower id for this det id (or null if not known)
   EcalTrigTowerDetId towerOf(const DetId& id) const;
 
-  /// Get the constituent detids for this tower id 
+  /// Get the constituent detids for this tower id
   std::vector<DetId> constituentsOf(const EcalTrigTowerDetId& id) const;
 
   /// set the association between a DetId and a tower
   void assign(const DetId& cell, const EcalTrigTowerDetId& tower);
 
- private:
-  /// Wrap a generic EEDetId to the equivalent one in z+ Quadrant 1 (from 0 < phi < pi/2) 
+private:
+  /// Wrap a generic EEDetId to the equivalent one in z+ Quadrant 1 (from 0 < phi < pi/2)
   DetId wrapEEDetId(const DetId& id) const;
-  /// Wrap a generic EcalTrigTowerDetId to the equivalent one in z+ Quadrant 1 (from 0 < phi < pi/2) 
+  /// Wrap a generic EcalTrigTowerDetId to the equivalent one in z+ Quadrant 1 (from 0 < phi < pi/2)
   DetId wrapEcalTrigTowerDetId(const DetId& id) const;
 
-  DetId changeEEDetIdQuadrantAndZ(const DetId& fromid, const int& toQuadrant,const int& tozside) const;
+  DetId changeEEDetIdQuadrantAndZ(const DetId& fromid, const int& toQuadrant, const int& tozside) const;
 
   int changeTowerQuadrant(int phiTower, int fromQuadrant, int toQuadrant) const;
 
   struct MapItem {
-    MapItem(const DetId& acell, const EcalTrigTowerDetId& atower) : cell(acell),tower(atower) { }
+    MapItem(const DetId& acell, const EcalTrigTowerDetId& atower) : cell(acell), tower(atower) {}
     DetId cell;
     EcalTrigTowerDetId tower;
-
   };
 
   typedef boost::multi_index_container<
-    MapItem,
-    boost::multi_index::indexed_by<
-    boost::multi_index::ordered_unique< boost::multi_index::member < MapItem,DetId,&MapItem::cell > >,
-    boost::multi_index::ordered_non_unique< boost::multi_index::member < MapItem,EcalTrigTowerDetId,&MapItem::tower> >
-    >
-    > EcalTowerMap;
-  
+      MapItem,
+      boost::multi_index::indexed_by<
+          boost::multi_index::ordered_unique<boost::multi_index::member<MapItem, DetId, &MapItem::cell> >,
+          boost::multi_index::ordered_non_unique<
+              boost::multi_index::member<MapItem, EcalTrigTowerDetId, &MapItem::tower> > > >
+      EcalTowerMap;
+
   typedef EcalTowerMap::nth_index<0>::type EcalTowerMap_by_DetId;
   typedef EcalTowerMap::nth_index<1>::type EcalTowerMap_by_towerDetId;
-  
+
   EcalTowerMap m_items;
 };
 

--- a/Geometry/CaloTopology/interface/FastTimeTopology.h
+++ b/Geometry/CaloTopology/interface/FastTimeTopology.h
@@ -9,68 +9,58 @@
 #include <iostream>
 
 class FastTimeTopology : public CaloSubdetectorTopology {
-
 public:
   /// create a new Topology
-  FastTimeTopology(const FastTimeDDDConstants& hdcons, 
-		   ForwardSubdetector subdet, int type);
+  FastTimeTopology(const FastTimeDDDConstants& hdcons, ForwardSubdetector subdet, int type);
 
   /// virtual destructor
-  ~FastTimeTopology() override { }  
+  ~FastTimeTopology() override {}
 
-  /// move the Topology north (increment iy)  
-  DetId  goNorth(const DetId& id) const override {
-    return offsetBy(id,0,+1);
-  }
-  std::vector<DetId> north(const DetId& id) const override { 
-    DetId nextId= goNorth(id);
+  /// move the Topology north (increment iy)
+  DetId goNorth(const DetId& id) const override { return offsetBy(id, 0, +1); }
+  std::vector<DetId> north(const DetId& id) const override {
+    DetId nextId = goNorth(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
 
   /// move the Topology south (decrement iy)
-  DetId goSouth(const DetId& id) const override {
-    return offsetBy(id,0,-1);
-  }
-  std::vector<DetId> south(const DetId& id) const override { 
-    DetId nextId= goSouth(id);
+  DetId goSouth(const DetId& id) const override { return offsetBy(id, 0, -1); }
+  std::vector<DetId> south(const DetId& id) const override {
+    DetId nextId = goSouth(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
 
   /// move the Topology east (positive ix)
-  DetId  goEast(const DetId& id) const override {
-    return offsetBy(id,+1,0);
-  }
-  std::vector<DetId> east(const DetId& id) const override { 
-    DetId nextId=goEast(id);
+  DetId goEast(const DetId& id) const override { return offsetBy(id, +1, 0); }
+  std::vector<DetId> east(const DetId& id) const override {
+    DetId nextId = goEast(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
 
   /// move the Topology west (negative ix)
-  DetId goWest(const DetId& id) const override {
-    return offsetBy(id,-1,0);
-  }
-  std::vector<DetId> west(const DetId& id) const override { 
-    DetId nextId=goWest(id);
+  DetId goWest(const DetId& id) const override { return offsetBy(id, -1, 0); }
+  std::vector<DetId> west(const DetId& id) const override {
+    DetId nextId = goWest(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
-  
+
   std::vector<DetId> up(const DetId& id) const override {
     std::vector<DetId> vNeighborsDetId;
     return vNeighborsDetId;
   }
-  
+
   std::vector<DetId> down(const DetId& id) const override {
     std::vector<DetId> vNeighborsDetId;
     return vNeighborsDetId;
@@ -78,42 +68,42 @@ public:
 
   ///Dense indexing
   uint32_t detId2denseId(const DetId& id) const override;
-  DetId    denseId2detId(uint32_t denseId) const override;
+  DetId denseId2detId(uint32_t denseId) const override;
   virtual uint32_t detId2denseGeomId(const DetId& id) const;
 
   ///Is this a valid cell id
   bool valid(const DetId& id) const override;
-  bool validHashIndex(uint32_t ix) const {return (ix < kSizeForDenseIndexing);}
+  bool validHashIndex(uint32_t ix) const { return (ix < kSizeForDenseIndexing); }
 
-  unsigned int totalModules() const {return kSizeForDenseIndexing;}
-  unsigned int totalGeomModules() const {return (unsigned int)(2*kHGeomHalf_);}
-  int          numberCells() const {return kHGeomHalf_;}
+  unsigned int totalModules() const { return kSizeForDenseIndexing; }
+  unsigned int totalGeomModules() const { return (unsigned int)(2 * kHGeomHalf_); }
+  int numberCells() const { return kHGeomHalf_; }
 
-  const FastTimeDDDConstants& dddConstants () const {return hdcons_;}
+  const FastTimeDDDConstants& dddConstants() const { return hdcons_; }
 
-  DetId offsetBy(const DetId startId, int nrStepsX, int nrStepsY ) const;
+  DetId offsetBy(const DetId startId, int nrStepsX, int nrStepsY) const;
   DetId switchZSide(const DetId startId) const;
 
   struct DecodedDetId {
     DecodedDetId() : iPhi(0), iEtaZ(0), zside(0), iType(0), subdet(0) {}
-    int                       iPhi, iEtaZ, zside, iType, subdet;
+    int iPhi, iEtaZ, zside, iType, subdet;
   };
 
   DecodedDetId geomDenseId2decId(const uint32_t& hi) const;
-  DecodedDetId decode(const DetId& id)  const ;
-  DetId encode(const DecodedDetId& id_) const ;
+  DecodedDetId decode(const DetId& id) const;
+  DetId encode(const DecodedDetId& id_) const;
 
-  ForwardSubdetector subDetector()  const { return subdet_;}
-  int                detectorType() const { return type_;}
+  ForwardSubdetector subDetector() const { return subdet_; }
+  int detectorType() const { return type_; }
+
 private:
-
   /// move the nagivator along x, y
-  DetId changeXY(const DetId& id, int nrStepsX, int nrStepsY) const ;
+  DetId changeXY(const DetId& id, int nrStepsX, int nrStepsY) const;
 
   const FastTimeDDDConstants& hdcons_;
-  ForwardSubdetector          subdet_;
-  int                         type_, nEtaZ_, nPhi_, kHGhalf_, kHGeomHalf_;
-  unsigned int                kSizeForDenseIndexing;
+  ForwardSubdetector subdet_;
+  int type_, nEtaZ_, nPhi_, kHGhalf_, kHGeomHalf_;
+  unsigned int kSizeForDenseIndexing;
 };
 
 #endif

--- a/Geometry/CaloTopology/interface/HGCalTopology.h
+++ b/Geometry/CaloTopology/interface/HGCalTopology.h
@@ -10,74 +10,65 @@
 #include <iostream>
 
 class HGCalTopology : public CaloSubdetectorTopology {
-
 public:
   /// create a new Topology
   HGCalTopology(const HGCalDDDConstants& hdcons, int subdet);
 
   /// virtual destructor
-  ~HGCalTopology() override { }  
+  ~HGCalTopology() override {}
 
-  /// move the Topology north (increment iy)  
-  DetId  goNorth(const DetId& id) const override {
-    return changeXY(id,0,+1);
-  }
-  std::vector<DetId> north(const DetId& id) const override { 
-    DetId nextId= goNorth(id);
+  /// move the Topology north (increment iy)
+  DetId goNorth(const DetId& id) const override { return changeXY(id, 0, +1); }
+  std::vector<DetId> north(const DetId& id) const override {
+    DetId nextId = goNorth(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
 
   /// move the Topology south (decrement iy)
-  DetId goSouth(const DetId& id) const override {
-    return changeXY(id,0,-1);
-  }
-  std::vector<DetId> south(const DetId& id) const override { 
-    DetId nextId= goSouth(id);
+  DetId goSouth(const DetId& id) const override { return changeXY(id, 0, -1); }
+  std::vector<DetId> south(const DetId& id) const override {
+    DetId nextId = goSouth(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
 
   /// move the Topology east (positive ix)
-  DetId  goEast(const DetId& id) const override {
-    return changeXY(id,+1,0);
-  }
-  std::vector<DetId> east(const DetId& id) const override { 
-    DetId nextId=goEast(id);
+  DetId goEast(const DetId& id) const override { return changeXY(id, +1, 0); }
+  std::vector<DetId> east(const DetId& id) const override {
+    DetId nextId = goEast(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
 
   /// move the Topology west (negative ix)
-  DetId goWest(const DetId& id) const override {
-    return changeXY(id,-1,0);
-  }
-  std::vector<DetId> west(const DetId& id) const override { 
-    DetId nextId=goWest(id);
+  DetId goWest(const DetId& id) const override { return changeXY(id, -1, 0); }
+  std::vector<DetId> west(const DetId& id) const override {
+    DetId nextId = goWest(id);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
-  
+
   std::vector<DetId> up(const DetId& id) const override {
-    DetId nextId=changeZ(id,+1);
+    DetId nextId = changeZ(id, +1);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
-  
+
   std::vector<DetId> down(const DetId& id) const override {
-    DetId nextId=changeZ(id,-1);
+    DetId nextId = changeZ(id, -1);
     std::vector<DetId> vNeighborsDetId;
-    if (! (nextId==DetId(0)))
+    if (!(nextId == DetId(0)))
       vNeighborsDetId.emplace_back(nextId);
     return vNeighborsDetId;
   }
@@ -85,7 +76,7 @@ public:
   std::vector<DetId> neighbors(const DetId& id) const;
 
   ///Geometry mode
-  HGCalGeometryMode::GeometryMode geomMode() const {return mode_;}
+  HGCalGeometryMode::GeometryMode geomMode() const { return mode_; }
 
   ///Dense indexing
   uint32_t detId2denseId(const DetId& id) const override;
@@ -94,18 +85,16 @@ public:
 
   ///Is this a valid cell id
   bool valid(const DetId& id) const override;
-  bool validHashIndex(uint32_t ix) const {return (ix < kSizeForDenseIndexing);}
+  bool validHashIndex(uint32_t ix) const { return (ix < kSizeForDenseIndexing); }
 
-  unsigned int totalModules() const {return kSizeForDenseIndexing;}
-  unsigned int totalGeomModules() const {return (unsigned int)(2*kHGeomHalf_);}
+  unsigned int totalModules() const { return kSizeForDenseIndexing; }
+  unsigned int totalGeomModules() const { return (unsigned int)(2 * kHGeomHalf_); }
   unsigned int allGeomModules() const;
 
-  bool maskCell(const DetId& id, int corners=3) const {
-    return dddConstants().maskCell(id, corners);
-  }
+  bool maskCell(const DetId& id, int corners = 3) const { return dddConstants().maskCell(id, corners); }
 
-  const HGCalDDDConstants& dddConstants () const {return hdcons_;}
-  
+  const HGCalDDDConstants& dddConstants() const { return hdcons_; }
+
   /** returns a new DetId offset by nrStepsX and nrStepsY (can be negative),
    * returns DetId(0) if invalid */
   DetId offsetBy(const DetId startId, int nrStepsX, int nrStepsY) const;
@@ -115,45 +104,43 @@ public:
   static const int subSectors_ = 2;
 
   struct DecodedDetId {
-    DecodedDetId() : iCell1(0), iCell2(0), iLay(0), iSec1(0), iSec2(0),
-                     iType(0), zSide(0), det(0) {}
-    int              iCell1, iCell2, iLay, iSec1, iSec2, iType, zSide, det;
+    DecodedDetId() : iCell1(0), iCell2(0), iLay(0), iSec1(0), iSec2(0), iType(0), zSide(0), det(0) {}
+    int iCell1, iCell2, iLay, iSec1, iSec2, iType, zSide, det;
   };
 
   DecodedDetId geomDenseId2decId(const uint32_t& hi) const;
-  DecodedDetId decode(const DetId& id)  const ;
-  DetId encode(const DecodedDetId& id_) const ;
+  DecodedDetId decode(const DetId& id) const;
+  DetId encode(const DecodedDetId& id_) const;
 
-  DetId::Detector    detector()  const { return det_;}
-  ForwardSubdetector subDetector()  const {return subdet_;}
-  bool               detectorType() const { return false;}
-  bool               isHFNose() const { 
-    return (((det_ == DetId::Forward) && 
-	     (subdet_ == ForwardSubdetector::HFNose)) ?  true : false);
+  DetId::Detector detector() const { return det_; }
+  ForwardSubdetector subDetector() const { return subdet_; }
+  bool detectorType() const { return false; }
+  bool isHFNose() const {
+    return (((det_ == DetId::Forward) && (subdet_ == ForwardSubdetector::HFNose)) ? true : false);
   }
+
 private:
   /// add DetId of Scintillator and Silicon type if valid
-  void addHGCSCintillatorId(std::vector<DetId>& ids, int zside, int type,
-			    int lay, int iradius, int iphi) const;
-  void addHGCSiliconId(std::vector<DetId>& ids, int det, int zside,
-		       int type,  int lay, int waferU, int waferV, 
-		       int cellU, int cellV) const;
+  void addHGCSCintillatorId(std::vector<DetId>& ids, int zside, int type, int lay, int iradius, int iphi) const;
+  void addHGCSiliconId(
+      std::vector<DetId>& ids, int det, int zside, int type, int lay, int waferU, int waferV, int cellU, int cellV)
+      const;
 
   /// move the nagivator along x, y
-  DetId changeXY(const DetId& id, int nrStepsX, int nrStepsY) const ;
+  DetId changeXY(const DetId& id, int nrStepsX, int nrStepsY) const;
 
   /// move the nagivator along z
-  DetId changeZ(const DetId& id, int nrStepsZ) const ;
+  DetId changeZ(const DetId& id, int nrStepsZ) const;
 
-  const HGCalDDDConstants&        hdcons_;
+  const HGCalDDDConstants& hdcons_;
   HGCalGeometryMode::GeometryMode mode_;
 
-  DetId::Detector                 det_;
-  ForwardSubdetector              subdet_;
-  int                             sectors_, layers_, cells_, types_;
-  int                             firstLay_, cellMax_, waferOff_, waferMax_;
-  int                             kHGhalf_, kHGeomHalf_;
-  unsigned int                    kSizeForDenseIndexing;
+  DetId::Detector det_;
+  ForwardSubdetector subdet_;
+  int sectors_, layers_, cells_, types_;
+  int firstLay_, cellMax_, waferOff_, waferMax_;
+  int kHGhalf_, kHGeomHalf_;
+  unsigned int kSizeForDenseIndexing;
 };
 
 #endif

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -25,20 +25,22 @@
 */
 class HcalTopology : public CaloSubdetectorTopology {
 public:
+  HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePosition = false);
+  HcalTopology(HcalTopologyMode::Mode mode,
+               int maxDepthHB,
+               int maxDepthHE,
+               HcalTopologyMode::TriggerMode tmode = HcalTopologyMode::TriggerMode_2009);
 
-  HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePosition=false);
-  HcalTopology(HcalTopologyMode::Mode mode, int maxDepthHB, int maxDepthHE, HcalTopologyMode::TriggerMode tmode=HcalTopologyMode::TriggerMode_2009);
-	
-  HcalTopologyMode::Mode mode() const {return mode_;}
+  HcalTopologyMode::Mode mode() const { return mode_; }
   HcalTopologyMode::TriggerMode triggerMode() const { return triggerMode_; }
   /** Add a cell to exclusion list */
   void exclude(const HcalDetId& id);
   /** Exclude an entire subdetector */
   void excludeSubdetector(HcalSubdetector subdet);
   /** Exclude an eta/phi/depth range for a given subdetector */
-  int exclude(HcalSubdetector subdet, int ieta1, int ieta2, int iphi1, int iphi2, int depth1=1, int depth2=4);
+  int exclude(HcalSubdetector subdet, int ieta1, int ieta2, int iphi1, int iphi2, int depth1 = 1, int depth2 = 4);
 
-  static std::string producerTag() { return "HCAL" ; }
+  static std::string producerTag() { return "HCAL"; }
 
   /// return a linear packed id
   unsigned int detId2denseId(const DetId& id) const override;
@@ -78,41 +80,36 @@ public:
   /** Get the neighbors of the given cell with lower (signed) ieta */
   int decIEta(const HcalDetId& id, HcalDetId neighbors[2]) const;
   /** Get the neighbor (if present) of the given cell with higher iphi */
-  bool incIPhi(const HcalDetId& id, HcalDetId &neighbor) const;
+  bool incIPhi(const HcalDetId& id, HcalDetId& neighbor) const;
   /** Get the neighbor (if present) of the given cell with lower iphi */
-  bool decIPhi(const HcalDetId& id, HcalDetId &neighbor) const;
+  bool decIPhi(const HcalDetId& id, HcalDetId& neighbor) const;
   /** Get the detector behind this one */
   bool incrementDepth(HcalDetId& id) const;
   /** Get the detector in front of this one */
   bool decrementDepth(HcalDetId& id) const;
 
-  int firstHBRing() const {return firstHBRing_;}
-  int lastHBRing()  const {return lastHBRing_;}
-  int firstHERing() const {return firstHERing_;}
-  int lastHERing()  const {return lastHERing_;}
-  int lastHBHERing() const {return std::max(lastHBRing_,lastHERing_);}
-  int firstHFRing() const {return firstHFRing_;}
-  int lastHFRing()  const {return lastHFRing_;}
-  int firstHORing() const {return firstHORing_;}
-  int lastHORing()  const {return lastHORing_;}
+  int firstHBRing() const { return firstHBRing_; }
+  int lastHBRing() const { return lastHBRing_; }
+  int firstHERing() const { return firstHERing_; }
+  int lastHERing() const { return lastHERing_; }
+  int lastHBHERing() const { return std::max(lastHBRing_, lastHERing_); }
+  int firstHFRing() const { return firstHFRing_; }
+  int lastHFRing() const { return lastHFRing_; }
+  int firstHORing() const { return firstHORing_; }
+  int lastHORing() const { return lastHORing_; }
 
-  int firstHEDoublePhiRing()   const {return firstHEDoublePhiRing_;} 
-  int firstHEQuadPhiRing()     const {return firstHEQuadPhiRing_;} 
-  int firstHFQuadPhiRing()     const {return firstHFQuadPhiRing_;}
-  int firstHETripleDepthRing() const {return firstHETripleDepthRing_;}
-  int singlePhiBins()          const {return singlePhiBins_;}
-  int doublePhiBins()          const {return doublePhiBins_;}
+  int firstHEDoublePhiRing() const { return firstHEDoublePhiRing_; }
+  int firstHEQuadPhiRing() const { return firstHEQuadPhiRing_; }
+  int firstHFQuadPhiRing() const { return firstHFQuadPhiRing_; }
+  int firstHETripleDepthRing() const { return firstHETripleDepthRing_; }
+  int singlePhiBins() const { return singlePhiBins_; }
+  int doublePhiBins() const { return doublePhiBins_; }
 
   /// finds the number of depth bins and which is the number to start with
-  void depthBinInformation(HcalSubdetector subdet, int etaRing,
-			   int iphi, int zside, int & nDepthBins,
-			   int & startingBin) const;
-  bool mergedDepth29(HcalDetId id) const {
-    return hcons_->mergedDepthList29(id.ieta(), id.iphi(), id.depth());
-  }
-  std::vector<int> mergedDepthList29(HcalDetId id) const {
-    return hcons_->mergedDepthList29(id.ieta(), id.iphi());
-  }
+  void depthBinInformation(
+      HcalSubdetector subdet, int etaRing, int iphi, int zside, int& nDepthBins, int& startingBin) const;
+  bool mergedDepth29(HcalDetId id) const { return hcons_->mergedDepthList29(id.ieta(), id.iphi(), id.depth()); }
+  std::vector<int> mergedDepthList29(HcalDetId id) const { return hcons_->mergedDepthList29(id.ieta(), id.iphi()); }
 
   /// how many phi segments in this ring
   int nPhiBins(int etaRing) const;
@@ -124,33 +121,27 @@ public:
 
   /// for each of the ~17 depth segments, specify which readout bin they belong to
   /// if the ring is not found, the first one with a lower ring will be returned.
-  void getDepthSegmentation(const unsigned ring, 
-			    std::vector<int> & readoutDepths,
-			    const bool flag=false) const;
-  void setDepthSegmentation(const unsigned ring, 
-			    const std::vector<int> & readoutDepths,
-			    const bool flag);
+  void getDepthSegmentation(const unsigned ring, std::vector<int>& readoutDepths, const bool flag = false) const;
+  void setDepthSegmentation(const unsigned ring, const std::vector<int>& readoutDepths, const bool flag);
   /// returns the boundaries of the depth segmentation, so that the first
   /// result is the first segment, and the second result is the first one
   /// of the next segment.  Used for calculating physical bounds.
-  std::pair<int, int> segmentBoundaries(const unsigned ring,
-					const unsigned depth,
-					const bool flag=false) const;
-  int getPhiZOne(std::vector<std::pair<int,int> >& phiz) const {return hcons_->getPhiZOne(phiz);}
+  std::pair<int, int> segmentBoundaries(const unsigned ring, const unsigned depth, const bool flag = false) const;
+  int getPhiZOne(std::vector<std::pair<int, int> >& phiz) const { return hcons_->getPhiZOne(phiz); }
 
-  unsigned int getHBSize() const {return HBSize_;}
-  unsigned int getHESize() const {return HESize_;}
-  unsigned int getHOSize() const {return HOSize_;}
-  unsigned int getHFSize() const {return HFSize_;}
-  unsigned int getHTSize() const {return HTSize_;}
-  unsigned int getCALIBSize() const {return CALIBSize_;}
+  unsigned int getHBSize() const { return HBSize_; }
+  unsigned int getHESize() const { return HESize_; }
+  unsigned int getHOSize() const { return HOSize_; }
+  unsigned int getHFSize() const { return HFSize_; }
+  unsigned int getHTSize() const { return HTSize_; }
+  unsigned int getCALIBSize() const { return CALIBSize_; }
 
-  int maxDepthHB() const { return maxDepthHB_;}
-  int maxDepthHE() const { return maxDepthHE_;}
-  int maxDepth( void ) const;
+  int maxDepthHB() const { return maxDepthHB_; }
+  int maxDepthHE() const { return maxDepthHE_; }
+  int maxDepth(void) const;
   int maxDepth(HcalSubdetector subdet) const;
   double etaMax(HcalSubdetector subdet) const;
-  std::pair<double,double> etaRange(HcalSubdetector subdet, int ieta) const;
+  std::pair<double, double> etaRange(HcalSubdetector subdet, int ieta) const;
 
   /// return a linear packed id from HB
   unsigned int detId2denseIdHB(const DetId& id) const;
@@ -170,17 +161,14 @@ public:
   unsigned int getNumberOfShapes() const { return numberOfShapes_; }
   bool isBH() const { return ((hcons_ == nullptr) ? false : hcons_->isBH()); }
 
-  const HcalDDDRecConstants* dddConstants () const {return hcons_;}
-  bool  withSpecialRBXHBHE() const {return hcons_->withSpecialRBXHBHE();}
-  HcalDetId mergedDepthDetId(const HcalDetId& id) const {return hcons_->mergedDepthDetId(id); }
-  bool  getMergePositionFlag() const {return mergePosition_;}
-  void  unmergeDepthDetId(const HcalDetId& id,
-			  std::vector<HcalDetId>& ids) const {
-    hcons_->unmergeDepthDetId(id, ids);
-  }
+  const HcalDDDRecConstants* dddConstants() const { return hcons_; }
+  bool withSpecialRBXHBHE() const { return hcons_->withSpecialRBXHBHE(); }
+  HcalDetId mergedDepthDetId(const HcalDetId& id) const { return hcons_->mergedDepthDetId(id); }
+  bool getMergePositionFlag() const { return mergePosition_; }
+  void unmergeDepthDetId(const HcalDetId& id, std::vector<HcalDetId>& ids) const { hcons_->unmergeDepthDetId(id, ids); }
   // Returns the DetId of the front Id if it is a merged RecHit in "Plan 1"
-  HcalDetId idFront(const HcalDetId& id) const {return hcons_->idFront(id);}
-  HcalDetId idBack (const HcalDetId& id) const {return hcons_->idBack(id);}
+  HcalDetId idFront(const HcalDetId& id) const { return hcons_->idFront(id); }
+  HcalDetId idBack(const HcalDetId& id) const { return hcons_->idBack(id); }
 
 private:
   /** Get the neighbors of the given cell with higher absolute ieta */
@@ -191,11 +179,11 @@ private:
   /** Is this a valid cell id, ignoring the exclusion list */
   bool validDetIdPreLS1(const HcalDetId& id) const;
   bool validRaw(const HcalDetId& id) const;
-  unsigned int detId2denseIdPreLS1 (const DetId& id) const;
+  unsigned int detId2denseIdPreLS1(const DetId& id) const;
   bool isExcluded(const HcalDetId& id) const;
 
-  const HcalDDDRecConstants *hcons_;
-  bool                       mergePosition_;
+  const HcalDDDRecConstants* hcons_;
+  bool mergePosition_;
   std::vector<HcalDetId> exclusionList_;
   bool excludeHB_, excludeHE_, excludeHO_, excludeHF_;
 
@@ -227,87 +215,87 @@ private:
 
   std::vector<double> etaTable, etaTableHF, dPhiTable, dPhiTableHF;
   std::vector<double> phioff;
-  std::vector<int>    unitPhi, unitPhiHF;
+  std::vector<int> unitPhi, unitPhiHF;
 
   int topoVersion_;
-    
+
   // index is ring;
   typedef std::map<unsigned, std::vector<int> > SegmentationMap;
   SegmentationMap depthSegmentation_;
   SegmentationMap depthSegmentationOne_;
 
-  enum { kHBhalf = 1296 ,
-	 kHEhalf = 1296 ,
-	 kHOhalf = 1080 ,
-	 kHFhalf = 864  ,
-	 kHThalf = 2088,
-	 kZDChalf = 11,
-	 kCASTORhalf = 224,
-	 kCALIBhalf = 693,
-         kHThalfPhase1 = 2520 ,
-	 kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf } ;
-  enum { kSizeForDenseIndexingPreLS1 = 2*kHcalhalf } ;
-  enum { kHBSizePreLS1 = 2*kHBhalf } ;
-  enum { kHESizePreLS1 = 2*kHEhalf } ;
-  enum { kHOSizePreLS1 = 2*kHOhalf } ;
-  enum { kHFSizePreLS1 = 2*kHFhalf } ;
-  enum { kHTSizePreLS1 = 2*kHThalf } ;
-  enum { kHTSizePhase1 = 2*kHThalfPhase1 } ;
-  enum { kCALIBSizePreLS1 = 2*kCALIBhalf };
+  enum {
+    kHBhalf = 1296,
+    kHEhalf = 1296,
+    kHOhalf = 1080,
+    kHFhalf = 864,
+    kHThalf = 2088,
+    kZDChalf = 11,
+    kCASTORhalf = 224,
+    kCALIBhalf = 693,
+    kHThalfPhase1 = 2520,
+    kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf
+  };
+  enum { kSizeForDenseIndexingPreLS1 = 2 * kHcalhalf };
+  enum { kHBSizePreLS1 = 2 * kHBhalf };
+  enum { kHESizePreLS1 = 2 * kHEhalf };
+  enum { kHOSizePreLS1 = 2 * kHOhalf };
+  enum { kHFSizePreLS1 = 2 * kHFhalf };
+  enum { kHTSizePreLS1 = 2 * kHThalf };
+  enum { kHTSizePhase1 = 2 * kHThalfPhase1 };
+  enum { kCALIBSizePreLS1 = 2 * kCALIBhalf };
   static const int minMaxDepth_ = 4;
-  static const unsigned int minPhi_=1, maxPhi_=72;
-  static const unsigned int nchanCalibHB_=3, nchanCalibHE_=6;
-  static const unsigned int nchanCalibHF_=3, nchanCalibHO_=2, chanCalibHOs_=7;
-  static constexpr int chanCalibHB_[nchanCalibHB_] = {0,1,2};
-  static constexpr int chanCalibHE_[nchanCalibHE_] = {0,1,3,4,5,6};
-  static constexpr int chanCalibHF_[nchanCalibHF_] = {0,1,8};
-  static constexpr int chanCalibHO_[nchanCalibHO_] = {0,1};
-  static const unsigned int nEtaCalibHBHEHF_=2, nEtaCalibHO_=5;
-  static constexpr int etaCalibHBHEHF_[nEtaCalibHBHEHF_] = {-1,1};
-  static constexpr int etaCalibHO_[nEtaCalibHO_] = {-2,-1,0,1,2};
-  static constexpr int phiCalibHO_[nEtaCalibHO_] = {59,47,53,47,47};
-  static const unsigned int mPhiCalibHBHE_=4, mPhiCalibHF_=18;
-  static const unsigned int mPhiCalibHO1_=12, mPhiCalibHO0_=mPhiCalibHO1_/2;
-  static const unsigned int kPhiCalibHBHE_=maxPhi_/mPhiCalibHBHE_;
-  static const unsigned int kchanCalibHB_=nchanCalibHB_*kPhiCalibHBHE_/2;
-  static const unsigned int kchanCalibHE_=nchanCalibHE_*kPhiCalibHBHE_/2;
-  static const unsigned int nCalibHB_=kPhiCalibHBHE_*nchanCalibHB_*nEtaCalibHBHEHF_;
-  static const unsigned int nCalibHE_=kPhiCalibHBHE_*nchanCalibHE_*nEtaCalibHBHEHF_;
-  static const unsigned int kPhiCalibHF_=maxPhi_/mPhiCalibHF_;
-  static const unsigned int kchanCalibHF_=nchanCalibHF_*kPhiCalibHF_/2;
-  static const unsigned int nCalibHF_=kPhiCalibHF_*nchanCalibHF_*nEtaCalibHBHEHF_;
-  static const unsigned int kPhiCalibHO0_=maxPhi_/mPhiCalibHO0_;
-  static const unsigned int kPhiCalibHO1_=maxPhi_/mPhiCalibHO1_;
-  static const unsigned int kPhiCalibHO2_=(3*kPhiCalibHO1_+kPhiCalibHO0_);
-  static const unsigned int kchanCalibHO_=nchanCalibHO_*kPhiCalibHO1_/2;
-  static const unsigned int kchanCalibHO1_=maxPhi_/2;
-  static const unsigned int kEtaPhiCalibHO_=kPhiCalibHO1_*(1+nEtaCalibHO_);
-  static const unsigned int nCalibHO0_=kEtaPhiCalibHO_*nchanCalibHO_;
-  static const unsigned int nCalibHO_=(nEtaCalibHO_+nCalibHO0_);
-  static const unsigned int kOffCalibHB_=0, kOffCalibHE_=(kOffCalibHB_+nCalibHB_);
-  static const unsigned int kOffCalibHF_=(kOffCalibHE_+nCalibHE_);
-  static const unsigned int kOffCalibHO0_=(kOffCalibHF_+nCalibHF_);
-  static const unsigned int kOffCalibHO_=(kOffCalibHO0_+nCalibHO0_);
-  static const unsigned int kOffCalibHOX_=(kOffCalibHO0_+nCalibHO_);
-  static const unsigned int nEtaCalibHOX_=2, ctypeHX_=-999;
-  static constexpr unsigned int etaCalibHOX_[nEtaCalibHOX_]={4,15};
-  static constexpr unsigned int mPhiCalibHOX_[nEtaCalibHOX_]={2,1};
-  static constexpr unsigned int nPhiCalibHOX_[nEtaCalibHOX_]={36,72};
-  static const int nCalibHOX_=(2*(nPhiCalibHOX_[0]+nPhiCalibHOX_[1]));
-  static constexpr int phiCalibHOX_[37]= {36, 1,38, 3,40,41, 6,43, 8,45,10,47,
-					  12,49,14,51,16,17,54,19,56,21,58,23,
-					  60,25,62,27,64,65,30,67,32,69,34,71,
-					  36};
-  static const unsigned int kOffCalibHBX_=(kOffCalibHOX_+nCalibHOX_);
-  static const unsigned int nEtaCalibHBX_=1,  etaCalibHBX_=16;
-  static const unsigned int mPhiCalibHBX_=1,  nPhiCalibHBX_=maxPhi_/mPhiCalibHBX_;
-  static const unsigned int nCalibHBX_=(2*nPhiCalibHBX_*nEtaCalibHBX_);
-  static const unsigned int kOffCalibHEX_=(kOffCalibHBX_+nCalibHBX_);
-  static const unsigned int nEtaCalibHEX_=2;
-  static constexpr int etaCalibHEX_[nEtaCalibHEX_]={25,27};
-  static const unsigned int mPhiCalibHEX_=2,  nPhiCalibHEX_=maxPhi_/mPhiCalibHEX_;
-  static const unsigned int nCalibHEX_=(2*nPhiCalibHEX_*nEtaCalibHEX_);
-  static const unsigned int kOffCalibHFX_=(kOffCalibHEX_+nCalibHEX_);
+  static const unsigned int minPhi_ = 1, maxPhi_ = 72;
+  static const unsigned int nchanCalibHB_ = 3, nchanCalibHE_ = 6;
+  static const unsigned int nchanCalibHF_ = 3, nchanCalibHO_ = 2, chanCalibHOs_ = 7;
+  static constexpr int chanCalibHB_[nchanCalibHB_] = {0, 1, 2};
+  static constexpr int chanCalibHE_[nchanCalibHE_] = {0, 1, 3, 4, 5, 6};
+  static constexpr int chanCalibHF_[nchanCalibHF_] = {0, 1, 8};
+  static constexpr int chanCalibHO_[nchanCalibHO_] = {0, 1};
+  static const unsigned int nEtaCalibHBHEHF_ = 2, nEtaCalibHO_ = 5;
+  static constexpr int etaCalibHBHEHF_[nEtaCalibHBHEHF_] = {-1, 1};
+  static constexpr int etaCalibHO_[nEtaCalibHO_] = {-2, -1, 0, 1, 2};
+  static constexpr int phiCalibHO_[nEtaCalibHO_] = {59, 47, 53, 47, 47};
+  static const unsigned int mPhiCalibHBHE_ = 4, mPhiCalibHF_ = 18;
+  static const unsigned int mPhiCalibHO1_ = 12, mPhiCalibHO0_ = mPhiCalibHO1_ / 2;
+  static const unsigned int kPhiCalibHBHE_ = maxPhi_ / mPhiCalibHBHE_;
+  static const unsigned int kchanCalibHB_ = nchanCalibHB_ * kPhiCalibHBHE_ / 2;
+  static const unsigned int kchanCalibHE_ = nchanCalibHE_ * kPhiCalibHBHE_ / 2;
+  static const unsigned int nCalibHB_ = kPhiCalibHBHE_ * nchanCalibHB_ * nEtaCalibHBHEHF_;
+  static const unsigned int nCalibHE_ = kPhiCalibHBHE_ * nchanCalibHE_ * nEtaCalibHBHEHF_;
+  static const unsigned int kPhiCalibHF_ = maxPhi_ / mPhiCalibHF_;
+  static const unsigned int kchanCalibHF_ = nchanCalibHF_ * kPhiCalibHF_ / 2;
+  static const unsigned int nCalibHF_ = kPhiCalibHF_ * nchanCalibHF_ * nEtaCalibHBHEHF_;
+  static const unsigned int kPhiCalibHO0_ = maxPhi_ / mPhiCalibHO0_;
+  static const unsigned int kPhiCalibHO1_ = maxPhi_ / mPhiCalibHO1_;
+  static const unsigned int kPhiCalibHO2_ = (3 * kPhiCalibHO1_ + kPhiCalibHO0_);
+  static const unsigned int kchanCalibHO_ = nchanCalibHO_ * kPhiCalibHO1_ / 2;
+  static const unsigned int kchanCalibHO1_ = maxPhi_ / 2;
+  static const unsigned int kEtaPhiCalibHO_ = kPhiCalibHO1_ * (1 + nEtaCalibHO_);
+  static const unsigned int nCalibHO0_ = kEtaPhiCalibHO_ * nchanCalibHO_;
+  static const unsigned int nCalibHO_ = (nEtaCalibHO_ + nCalibHO0_);
+  static const unsigned int kOffCalibHB_ = 0, kOffCalibHE_ = (kOffCalibHB_ + nCalibHB_);
+  static const unsigned int kOffCalibHF_ = (kOffCalibHE_ + nCalibHE_);
+  static const unsigned int kOffCalibHO0_ = (kOffCalibHF_ + nCalibHF_);
+  static const unsigned int kOffCalibHO_ = (kOffCalibHO0_ + nCalibHO0_);
+  static const unsigned int kOffCalibHOX_ = (kOffCalibHO0_ + nCalibHO_);
+  static const unsigned int nEtaCalibHOX_ = 2, ctypeHX_ = -999;
+  static constexpr unsigned int etaCalibHOX_[nEtaCalibHOX_] = {4, 15};
+  static constexpr unsigned int mPhiCalibHOX_[nEtaCalibHOX_] = {2, 1};
+  static constexpr unsigned int nPhiCalibHOX_[nEtaCalibHOX_] = {36, 72};
+  static const int nCalibHOX_ = (2 * (nPhiCalibHOX_[0] + nPhiCalibHOX_[1]));
+  static constexpr int phiCalibHOX_[37] = {36, 1,  38, 3,  40, 41, 6,  43, 8,  45, 10, 47, 12, 49, 14, 51, 16, 17, 54,
+                                           19, 56, 21, 58, 23, 60, 25, 62, 27, 64, 65, 30, 67, 32, 69, 34, 71, 36};
+  static const unsigned int kOffCalibHBX_ = (kOffCalibHOX_ + nCalibHOX_);
+  static const unsigned int nEtaCalibHBX_ = 1, etaCalibHBX_ = 16;
+  static const unsigned int mPhiCalibHBX_ = 1, nPhiCalibHBX_ = maxPhi_ / mPhiCalibHBX_;
+  static const unsigned int nCalibHBX_ = (2 * nPhiCalibHBX_ * nEtaCalibHBX_);
+  static const unsigned int kOffCalibHEX_ = (kOffCalibHBX_ + nCalibHBX_);
+  static const unsigned int nEtaCalibHEX_ = 2;
+  static constexpr int etaCalibHEX_[nEtaCalibHEX_] = {25, 27};
+  static const unsigned int mPhiCalibHEX_ = 2, nPhiCalibHEX_ = maxPhi_ / mPhiCalibHEX_;
+  static const unsigned int nCalibHEX_ = (2 * nPhiCalibHEX_ * nEtaCalibHEX_);
+  static const unsigned int kOffCalibHFX_ = (kOffCalibHEX_ + nCalibHEX_);
 };
 
 #endif

--- a/Geometry/CaloTopology/interface/HcalTopologyMode.h
+++ b/Geometry/CaloTopology/interface/HcalTopologyMode.h
@@ -6,33 +6,28 @@
 #include <string>
 #include <algorithm>
 
-template< typename T >
-class StringToEnumParser
-{
-    std::map< std::string, T > enumMap;
-public:
-    
-    StringToEnumParser( void );
+template <typename T>
+class StringToEnumParser {
+  std::map<std::string, T> enumMap;
 
-    T parseString( const std::string &value )
-	{ 
-	    typename std::map<std::string, T>::const_iterator iValue = enumMap.find( value );
-	    if( iValue  == enumMap.end())
-                throw cms::Exception( "Configuration" )
-		    << "the value " << value << " is not defined.";
-	    
-	    return iValue->second;
-	}
+public:
+  StringToEnumParser(void);
+
+  T parseString(const std::string &value) {
+    typename std::map<std::string, T>::const_iterator iValue = enumMap.find(value);
+    if (iValue == enumMap.end())
+      throw cms::Exception("Configuration") << "the value " << value << " is not defined.";
+
+    return iValue->second;
+  }
 };
 
 namespace HcalTopologyMode {
-    enum Mode {
-	LHC=0, H2=1, SLHC=2, H2HE=3 };
+  enum Mode { LHC = 0, H2 = 1, SLHC = 2, H2HE = 3 };
 
-    enum TriggerMode {
-      tm_LHC_PreLS1=0  // HF is summed in 3x2 regions
-    };
-}
+  enum TriggerMode {
+    tm_LHC_PreLS1 = 0  // HF is summed in 3x2 regions
+  };
+}  // namespace HcalTopologyMode
 
-
-#endif // CALO_TOPOLOGY_HCAL_TOPOLOGY_MODE_H
+#endif  // CALO_TOPOLOGY_HCAL_TOPOLOGY_MODE_H

--- a/Geometry/CaloTopology/interface/HcalTopologyRestrictionParser.h
+++ b/Geometry/CaloTopology/interface/HcalTopologyRestrictionParser.h
@@ -25,6 +25,7 @@ public:
       The line must be formated as described in the class description.
   */
   std::string parse(const std::string& line);
+
 private:
   HcalTopology& target_;
 };

--- a/Geometry/CaloTopology/src/CaloDirection.cc
+++ b/Geometry/CaloTopology/src/CaloDirection.cc
@@ -1,10 +1,8 @@
 #include "Geometry/CaloTopology/interface/CaloDirection.h"
 #include <iostream>
 
-std::ostream & operator<<(std::ostream& o,const CaloDirection& d)
-{
-  switch(d)
-    {
+std::ostream& operator<<(std::ostream& o, const CaloDirection& d) {
+  switch (d) {
     case NONE:
       o << "NONE";
       break;
@@ -89,7 +87,7 @@ std::ostream & operator<<(std::ostream& o,const CaloDirection& d)
     default:
       //o << static_cast<int>(d);
       break;
-    }
- 
+  }
+
   return o;
 }

--- a/Geometry/CaloTopology/src/CaloSubdetectorTopology.cc
+++ b/Geometry/CaloTopology/src/CaloSubdetectorTopology.cc
@@ -1,9 +1,9 @@
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include <cassert>
 
-std::vector<DetId> CaloSubdetectorTopology::getWindow(const DetId& id, const int& northSouthSize, const int& eastWestSize) const
-{
-  
+std::vector<DetId> CaloSubdetectorTopology::getWindow(const DetId& id,
+                                                      const int& northSouthSize,
+                                                      const int& eastWestSize) const {
   std::vector<DetId> cellsInWindow;
   // check pivot
   if (id.null())
@@ -11,66 +11,59 @@ std::vector<DetId> CaloSubdetectorTopology::getWindow(const DetId& id, const int
 
   //
   DetId myTmpId(id);
-  std::vector<std::pair<Coordinate,DetId> > fringe;
-  fringe.emplace_back(std::pair<Coordinate,DetId>(Coordinate(0,0),myTmpId));
-  
-  int halfWestEast = eastWestSize/2 ;
-  int halfNorthSouth = northSouthSize/2 ;
+  std::vector<std::pair<Coordinate, DetId> > fringe;
+  fringe.emplace_back(std::pair<Coordinate, DetId>(Coordinate(0, 0), myTmpId));
+
+  int halfWestEast = eastWestSize / 2;
+  int halfNorthSouth = northSouthSize / 2;
 
   std::vector<CellInfo> visited_cells;
   visited_cells.resize(northSouthSize * eastWestSize);
-  
-  while (!fringe.empty())
-    {
-      std::pair<Coordinate,DetId> cur = fringe.back();
-      fringe.pop_back();
-      
-      // check all four neighbours
-      const CaloDirection directions[4] = { NORTH, SOUTH, EAST, WEST };
-      
-      for (auto direction : directions)
-        {
-          Coordinate neighbour = getNeighbourIndex(cur.first,direction);
-	  //If outside the window range
-	  if ( neighbour.first < -halfWestEast ||
-	       neighbour.first > halfWestEast ||
-	       neighbour.second < -halfNorthSouth ||
-	       neighbour.second > halfNorthSouth )
-	    continue;
-	  
-	  
-	  //Found integer index in the matrix
-	  unsigned int_index =  neighbour.first + halfWestEast +  
-	    eastWestSize * (neighbour.second + halfNorthSouth );
-	  assert(int_index < visited_cells.size());
-	  
-          // check whether we have seen this neighbour already
-          if (visited_cells[int_index].visited)
-            // we have seen this one already
-            continue;
-              
-          // a new cell, get the DetId of the neighbour, mark it
-          // as visited and add it to the fringe
-          visited_cells[int_index].visited = true;
-	  std::vector<DetId> neighbourCells = getNeighbours(cur.second,direction);
 
-	  if ( neighbourCells.size() == 1 )
-	    visited_cells[int_index].cell = neighbourCells[0];
-	  else if ( neighbourCells.empty() )
-	    visited_cells[int_index].cell = DetId(0);
-	  else
-	    throw cms::Exception("getWindowError") << "Not supported subdetector for getWindow method";
-	  
-          if (!visited_cells[int_index].cell.null())
-            fringe.emplace_back(std::pair<Coordinate,DetId>(neighbour,visited_cells[int_index].cell));
-		  
-	} // loop over all possible directions
-    } // while some cells are left on the fringe
-  
-  
-  for (auto & visited_cell : visited_cells)
+  while (!fringe.empty()) {
+    std::pair<Coordinate, DetId> cur = fringe.back();
+    fringe.pop_back();
+
+    // check all four neighbours
+    const CaloDirection directions[4] = {NORTH, SOUTH, EAST, WEST};
+
+    for (auto direction : directions) {
+      Coordinate neighbour = getNeighbourIndex(cur.first, direction);
+      //If outside the window range
+      if (neighbour.first < -halfWestEast || neighbour.first > halfWestEast || neighbour.second < -halfNorthSouth ||
+          neighbour.second > halfNorthSouth)
+        continue;
+
+      //Found integer index in the matrix
+      unsigned int_index = neighbour.first + halfWestEast + eastWestSize * (neighbour.second + halfNorthSouth);
+      assert(int_index < visited_cells.size());
+
+      // check whether we have seen this neighbour already
+      if (visited_cells[int_index].visited)
+        // we have seen this one already
+        continue;
+
+      // a new cell, get the DetId of the neighbour, mark it
+      // as visited and add it to the fringe
+      visited_cells[int_index].visited = true;
+      std::vector<DetId> neighbourCells = getNeighbours(cur.second, direction);
+
+      if (neighbourCells.size() == 1)
+        visited_cells[int_index].cell = neighbourCells[0];
+      else if (neighbourCells.empty())
+        visited_cells[int_index].cell = DetId(0);
+      else
+        throw cms::Exception("getWindowError") << "Not supported subdetector for getWindow method";
+
+      if (!visited_cells[int_index].cell.null())
+        fringe.emplace_back(std::pair<Coordinate, DetId>(neighbour, visited_cells[int_index].cell));
+
+    }  // loop over all possible directions
+  }    // while some cells are left on the fringe
+
+  for (auto& visited_cell : visited_cells)
     if (!visited_cell.cell.null())
       cellsInWindow.emplace_back(visited_cell.cell);
-  
+
   return cellsInWindow;
 }

--- a/Geometry/CaloTopology/src/CaloTopology.cc
+++ b/Geometry/CaloTopology/src/CaloTopology.cc
@@ -1,81 +1,77 @@
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 
-
-CaloTopology::CaloTopology() {
-}
+CaloTopology::CaloTopology() {}
 
 CaloTopology::~CaloTopology() = default;
 
+int CaloTopology::makeIndex(DetId::Detector det, int subdet) const { return (int(det) << 4) | (subdet & 0xF); }
 
-int CaloTopology::makeIndex(DetId::Detector det, int subdet) const {
-  return (int(det)<<4) | (subdet&0xF);
-}
-
-void CaloTopology::setSubdetTopology(DetId::Detector det, int subdet, std::unique_ptr<const CaloSubdetectorTopology> geom) {
-  int index=makeIndex(det,subdet);
-  theTopologies_[index]=std::move(geom);
+void CaloTopology::setSubdetTopology(DetId::Detector det,
+                                     int subdet,
+                                     std::unique_ptr<const CaloSubdetectorTopology> geom) {
+  int index = makeIndex(det, subdet);
+  theTopologies_[index] = std::move(geom);
 }
 
 const CaloSubdetectorTopology* CaloTopology::getSubdetectorTopology(const DetId& id) const {
-  auto i=theTopologies_.find(makeIndex(id.det(),id.subdetId()));
-  return (i==theTopologies_.end())?(nullptr):(i->second.get());
+  auto i = theTopologies_.find(makeIndex(id.det(), id.subdetId()));
+  return (i == theTopologies_.end()) ? (nullptr) : (i->second.get());
 }
 
 const CaloSubdetectorTopology* CaloTopology::getSubdetectorTopology(DetId::Detector det, int subdet) const {
-    auto i=theTopologies_.find(makeIndex(det,subdet));
-    return (i==theTopologies_.end())?(nullptr):(i->second.get());
+  auto i = theTopologies_.find(makeIndex(det, subdet));
+  return (i == theTopologies_.end()) ? (nullptr) : (i->second.get());
 }
 
 static const std::vector<DetId> emptyDetIdVector;
 
 std::vector<DetId> CaloTopology::east(const DetId& id) const {
-  const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-  return (topology==nullptr) ? (emptyDetIdVector):(topology->east(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->east(id));
 }
 
 std::vector<DetId> CaloTopology::west(const DetId& id) const {
-  const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-  return (topology==nullptr) ? (emptyDetIdVector):(topology->west(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->west(id));
 }
 
 std::vector<DetId> CaloTopology::north(const DetId& id) const {
-  const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-  return (topology==nullptr) ? (emptyDetIdVector):(topology->north(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->north(id));
 }
 
 std::vector<DetId> CaloTopology::south(const DetId& id) const {
-  const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-  return (topology==nullptr) ? (emptyDetIdVector):(topology->south(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->south(id));
 }
 
 std::vector<DetId> CaloTopology::up(const DetId& id) const {
-  const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-  return (topology==nullptr) ? (emptyDetIdVector):(topology->up(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->up(id));
 }
 
 std::vector<DetId> CaloTopology::down(const DetId& id) const {
-    const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-    return (topology==nullptr) ? (emptyDetIdVector):(topology->down(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->down(id));
 }
 
-std::vector<DetId> CaloTopology::getNeighbours(const DetId& id,const CaloDirection& dir) const {
-    const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-    return (topology==nullptr) ? (emptyDetIdVector):(topology->getNeighbours(id,dir));
+std::vector<DetId> CaloTopology::getNeighbours(const DetId& id, const CaloDirection& dir) const {
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->getNeighbours(id, dir));
 }
 
 std::vector<DetId> CaloTopology::getWindow(const DetId& id, const int& northSouthSize, const int& eastWestSize) const {
-    const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-    return (topology==nullptr) ? (emptyDetIdVector):(topology->getWindow(id,northSouthSize, eastWestSize));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->getWindow(id, northSouthSize, eastWestSize));
 }
 
 std::vector<DetId> CaloTopology::getAllNeighbours(const DetId& id) const {
-    const CaloSubdetectorTopology* topology=getSubdetectorTopology(id);
-    return (topology==nullptr) ? (emptyDetIdVector):(topology->getAllNeighbours(id));
+  const CaloSubdetectorTopology* topology = getSubdetectorTopology(id);
+  return (topology == nullptr) ? (emptyDetIdVector) : (topology->getAllNeighbours(id));
 }
 
 bool CaloTopology::valid(const DetId& id) const {
-  const CaloSubdetectorTopology* geom=getSubdetectorTopology(id);
-  return (geom==nullptr)?(false):(geom->valid(id));
+  const CaloSubdetectorTopology* geom = getSubdetectorTopology(id);
+  return (geom == nullptr) ? (false) : (geom->valid(id));
 }
-

--- a/Geometry/CaloTopology/src/CaloTowerConstituentsMap.cc
+++ b/Geometry/CaloTopology/src/CaloTowerConstituentsMap.cc
@@ -13,39 +13,36 @@ CaloTowerConstituentsMap::~CaloTowerConstituentsMap() {
   delete m_reverseItems.load();
   m_reverseItems = nullptr;
 }
-CaloTowerConstituentsMap::CaloTowerConstituentsMap(const HcalTopology * hcaltopo, const CaloTowerTopology * cttopo) :
-  m_hcaltopo(hcaltopo),
-  m_cttopo(cttopo),
-  standardHB_(false),
-  standardHE_(false),
-  standardHF_(false),
-  standardHO_(false),
-  standardEB_(false),
-  m_reverseItems(nullptr)
-{
-}
+CaloTowerConstituentsMap::CaloTowerConstituentsMap(const HcalTopology* hcaltopo, const CaloTowerTopology* cttopo)
+    : m_hcaltopo(hcaltopo),
+      m_cttopo(cttopo),
+      standardHB_(false),
+      standardHE_(false),
+      standardHF_(false),
+      standardHO_(false),
+      standardEB_(false),
+      m_reverseItems(nullptr) {}
 
 CaloTowerDetId CaloTowerConstituentsMap::towerOf(const DetId& id) const {
-  CaloTowerDetId tid; // null to start with
+  CaloTowerDetId tid;  // null to start with
 
-  edm::SortedCollection<MapItem>::const_iterator i=m_items.find(id);
-  if (i!=m_items.end()) tid=i->tower;
+  edm::SortedCollection<MapItem>::const_iterator i = m_items.find(id);
+  if (i != m_items.end())
+    tid = i->tower;
 
   //use hcaltopo when dealing with hcal detids
   if (tid.null()) {
-    if (id.det()==DetId::Hcal) { 
+    if (id.det() == DetId::Hcal) {
       HcalDetId hid(id);
-      if ( (hid.subdet()==HcalBarrel && standardHB_ )  ||
-	   (hid.subdet()==HcalEndcap && standardHE_ )  ||
-	   (hid.subdet()==HcalOuter  && standardHO_ )  ||
-	   (hid.subdet()==HcalForward && standardHF_) ) {
-        tid = CaloTowerDetId(m_cttopo->convertHcaltoCT(hid.ietaAbs(),hid.subdet())*hid.zside(),hid.iphi());
-      }      
-    } else if (id.det()==DetId::Ecal) {
-      EcalSubdetector esd=(EcalSubdetector)id.subdetId();
-      if (esd==EcalBarrel && standardEB_) {
-	EBDetId ebid(id);
-	tid=CaloTowerDetId(ebid.tower_ieta(),ebid.tower_iphi());
+      if ((hid.subdet() == HcalBarrel && standardHB_) || (hid.subdet() == HcalEndcap && standardHE_) ||
+          (hid.subdet() == HcalOuter && standardHO_) || (hid.subdet() == HcalForward && standardHF_)) {
+        tid = CaloTowerDetId(m_cttopo->convertHcaltoCT(hid.ietaAbs(), hid.subdet()) * hid.zside(), hid.iphi());
+      }
+    } else if (id.det() == DetId::Ecal) {
+      EcalSubdetector esd = (EcalSubdetector)id.subdetId();
+      if (esd == EcalBarrel && standardEB_) {
+        EBDetId ebid(id);
+        tid = CaloTowerDetId(ebid.tower_ieta(), ebid.tower_iphi());
       }
     }
   }
@@ -54,132 +51,136 @@ CaloTowerDetId CaloTowerConstituentsMap::towerOf(const DetId& id) const {
 }
 
 void CaloTowerConstituentsMap::assign(const DetId& cell, const CaloTowerDetId& tower) {
-  if (m_items.find(cell)!=m_items.end()) {
-    throw cms::Exception("CaloTowers") << "Cell with id " << std::hex << cell.rawId() << std::dec << " is already mapped to a CaloTower " << m_items.find(cell)->tower << std::endl;
+  if (m_items.find(cell) != m_items.end()) {
+    throw cms::Exception("CaloTowers") << "Cell with id " << std::hex << cell.rawId() << std::dec
+                                       << " is already mapped to a CaloTower " << m_items.find(cell)->tower
+                                       << std::endl;
   }
-  m_items.emplace_back(MapItem(cell,tower));
+  m_items.emplace_back(MapItem(cell, tower));
 }
 
 void CaloTowerConstituentsMap::sort() {
   m_items.sort();
-  
-//  for (auto const & it : m_items)
-//    std::cout << std::hex << it.cell.rawId() << " " << it.tower.rawId() << std::dec << std::endl;
 
+  //  for (auto const & it : m_items)
+  //    std::cout << std::hex << it.cell.rawId() << " " << it.tower.rawId() << std::dec << std::endl;
 }
 
 std::vector<DetId> CaloTowerConstituentsMap::constituentsOf(const CaloTowerDetId& id) const {
 #ifdef EDM_ML_DEBUG
-  std::cout << "Get constituent of " << std::hex << id.rawId() << std::dec
-	    << " ID " << id << " ieta " << id.ieta() << std::endl;
+  std::cout << "Get constituent of " << std::hex << id.rawId() << std::dec << " ID " << id << " ieta " << id.ieta()
+            << std::endl;
 #endif
   std::vector<DetId> items;
-  if (id.ieta() == 0) return items;
+  if (id.ieta() == 0)
+    return items;
 
   // build reverse map if needed
-  if(!m_reverseItems.load(std::memory_order_acquire)) {
-      std::unique_ptr<std::multimap<CaloTowerDetId,DetId>> ptr{new std::multimap<CaloTowerDetId,DetId>};
-      for (auto m_item : m_items)
-          ptr->insert(std::pair<CaloTowerDetId,DetId>(m_item.tower,m_item.cell));
-      std::multimap<CaloTowerDetId,DetId>* expected = nullptr;
-      if(m_reverseItems.compare_exchange_strong(expected, ptr.get(), std::memory_order_acq_rel)) {
-          ptr.release();
-      }
+  if (!m_reverseItems.load(std::memory_order_acquire)) {
+    std::unique_ptr<std::multimap<CaloTowerDetId, DetId>> ptr{new std::multimap<CaloTowerDetId, DetId>};
+    for (auto m_item : m_items)
+      ptr->insert(std::pair<CaloTowerDetId, DetId>(m_item.tower, m_item.cell));
+    std::multimap<CaloTowerDetId, DetId>* expected = nullptr;
+    if (m_reverseItems.compare_exchange_strong(expected, ptr.get(), std::memory_order_acq_rel)) {
+      ptr.release();
+    }
   }
 
   /// copy from the items map
-  std::multimap<CaloTowerDetId,DetId>::const_iterator j;
-  auto range=(*m_reverseItems.load(std::memory_order_acquire)).equal_range(id);
-  for (j=range.first; j!=range.second; j++)
+  std::multimap<CaloTowerDetId, DetId>::const_iterator j;
+  auto range = (*m_reverseItems.load(std::memory_order_acquire)).equal_range(id);
+  for (j = range.first; j != range.second; j++)
     items.emplace_back(j->second);
 
   // dealing with topo dependency...
   //use cttopo when dealing with calotower detids
   int nd, sd;
   int hcal_ieta = m_cttopo->convertCTtoHcal(id.ietaAbs());
-  
+
   if (standardHB_) {
-    if (id.ietaAbs()<=m_cttopo->lastHBRing()) {
-      m_hcaltopo->depthBinInformation(HcalBarrel,hcal_ieta,id.iphi(),id.zside(),nd,sd);
-      for (int i=0; i<nd; i++) {
-	if (m_hcaltopo->getMergePositionFlag()) {
-	  HcalDetId hid = m_hcaltopo->mergedDepthDetId(HcalDetId(HcalBarrel,hcal_ieta*id.zside(),id.iphi(),i+sd));
-	  if (std::find(items.begin(),items.end(),hid) == items.end()) {
-	    items.emplace_back(hid);
+    if (id.ietaAbs() <= m_cttopo->lastHBRing()) {
+      m_hcaltopo->depthBinInformation(HcalBarrel, hcal_ieta, id.iphi(), id.zside(), nd, sd);
+      for (int i = 0; i < nd; i++) {
+        if (m_hcaltopo->getMergePositionFlag()) {
+          HcalDetId hid =
+              m_hcaltopo->mergedDepthDetId(HcalDetId(HcalBarrel, hcal_ieta * id.zside(), id.iphi(), i + sd));
+          if (std::find(items.begin(), items.end(), hid) == items.end()) {
+            items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	    std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+            std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
-	  }
-	} else {
-	  HcalDetId hid(HcalBarrel,hcal_ieta*id.zside(),id.iphi(),i+sd);
-	  items.emplace_back(hid);
+          }
+        } else {
+          HcalDetId hid(HcalBarrel, hcal_ieta * id.zside(), id.iphi(), i + sd);
+          items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	  std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+          std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
-	}
+        }
       }
     }
   }
   if (standardHO_) {
-    if (id.ietaAbs()<=m_cttopo->lastHORing()) {
-      m_hcaltopo->depthBinInformation(HcalOuter,hcal_ieta,id.iphi(),id.zside(),nd,sd);
-      for (int i=0; i<nd; i++) {
-	HcalDetId hid(HcalOuter,hcal_ieta*id.zside(),id.iphi(),i+sd);
+    if (id.ietaAbs() <= m_cttopo->lastHORing()) {
+      m_hcaltopo->depthBinInformation(HcalOuter, hcal_ieta, id.iphi(), id.zside(), nd, sd);
+      for (int i = 0; i < nd; i++) {
+        HcalDetId hid(HcalOuter, hcal_ieta * id.zside(), id.iphi(), i + sd);
         items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+        std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
       }
     }
   }
   if (standardHE_) {
-    if (id.ietaAbs()>=m_cttopo->firstHERing() && id.ietaAbs()<=m_cttopo->lastHERing()) {
-      m_hcaltopo->depthBinInformation(HcalEndcap,hcal_ieta,id.iphi(),id.zside(),nd,sd);
-      for (int i=0; i<nd; i++) {
-	if (m_hcaltopo->getMergePositionFlag()) {
-	  HcalDetId hid = m_hcaltopo->mergedDepthDetId(HcalDetId(HcalEndcap,hcal_ieta*id.zside(),id.iphi(),i+sd));
-	  if (std::find(items.begin(),items.end(),hid) == items.end()) {
-	    items.emplace_back(hid);
+    if (id.ietaAbs() >= m_cttopo->firstHERing() && id.ietaAbs() <= m_cttopo->lastHERing()) {
+      m_hcaltopo->depthBinInformation(HcalEndcap, hcal_ieta, id.iphi(), id.zside(), nd, sd);
+      for (int i = 0; i < nd; i++) {
+        if (m_hcaltopo->getMergePositionFlag()) {
+          HcalDetId hid =
+              m_hcaltopo->mergedDepthDetId(HcalDetId(HcalEndcap, hcal_ieta * id.zside(), id.iphi(), i + sd));
+          if (std::find(items.begin(), items.end(), hid) == items.end()) {
+            items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	    std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+            std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
-	  } 
-	} else {
-	  HcalDetId hid(HcalEndcap,hcal_ieta*id.zside(),id.iphi(),i+sd);
-	  items.emplace_back(hid);
+          }
+        } else {
+          HcalDetId hid(HcalEndcap, hcal_ieta * id.zside(), id.iphi(), i + sd);
+          items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	  std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+          std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
-	}
+        }
       }
     }
   }
   if (standardHF_) {
-    if (id.ietaAbs()>=m_cttopo->firstHFRing() && id.ietaAbs()<=m_cttopo->lastHFRing()) { 
-      m_hcaltopo->depthBinInformation(HcalForward,hcal_ieta,id.iphi(),id.zside(),nd,sd);
-      for (int i=0; i<nd; i++) {
-	HcalDetId hid(HcalForward,hcal_ieta*id.zside(),id.iphi(),i+sd);
+    if (id.ietaAbs() >= m_cttopo->firstHFRing() && id.ietaAbs() <= m_cttopo->lastHFRing()) {
+      m_hcaltopo->depthBinInformation(HcalForward, hcal_ieta, id.iphi(), id.zside(), nd, sd);
+      for (int i = 0; i < nd; i++) {
+        HcalDetId hid(HcalForward, hcal_ieta * id.zside(), id.iphi(), i + sd);
         items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+        std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
       }
       // special handling for first HF tower
       if (id.ietaAbs() == m_cttopo->firstHFRing()) {
-        int hcal_ieta2 = hcal_ieta-1;
-        m_hcaltopo->depthBinInformation(HcalForward,hcal_ieta2,id.iphi(),id.zside(),nd,sd);
-        for (int i=0; i<nd; i++) {
-	  HcalDetId hid(HcalForward,hcal_ieta2*id.zside(),id.iphi(),i+sd);
+        int hcal_ieta2 = hcal_ieta - 1;
+        m_hcaltopo->depthBinInformation(HcalForward, hcal_ieta2, id.iphi(), id.zside(), nd, sd);
+        for (int i = 0; i < nd; i++) {
+          HcalDetId hid(HcalForward, hcal_ieta2 * id.zside(), id.iphi(), i + sd);
           items.emplace_back(hid);
 #ifdef EDM_ML_DEBUG
-	  std::cout << id << " Depth " << i << ":" << i+sd << " " << hid <<"\n";
+          std::cout << id << " Depth " << i << ":" << i + sd << " " << hid << "\n";
 #endif
-	}
+        }
       }
     }
   }
-  if (standardEB_ && hcal_ieta<=EBDetId::MAX_IETA/5) {
-    HcalDetId hid(HcalBarrel,hcal_ieta*id.zside(),id.iphi(),1); // for the limits
+  if (standardEB_ && hcal_ieta <= EBDetId::MAX_IETA / 5) {
+    HcalDetId hid(HcalBarrel, hcal_ieta * id.zside(), id.iphi(), 1);  // for the limits
     int etaMin, etaMax;
     if (hid.zside() == -1) {
       etaMin = hid.crystal_ieta_high();
@@ -188,25 +189,15 @@ std::vector<DetId> CaloTowerConstituentsMap::constituentsOf(const CaloTowerDetId
       etaMin = hid.crystal_ieta_low();
       etaMax = hid.crystal_ieta_high();
     }
-    for (int ie=etaMin; ie<=etaMax; ie++)
-      for (int ip=hid.crystal_iphi_low(); ip<=hid.crystal_iphi_high(); ip++)
-        items.emplace_back(EBDetId(ie,ip));
+    for (int ie = etaMin; ie <= etaMax; ie++)
+      for (int ip = hid.crystal_iphi_low(); ip <= hid.crystal_iphi_high(); ip++)
+        items.emplace_back(EBDetId(ie, ip));
   }
   return items;
 }
 
-void CaloTowerConstituentsMap::useStandardHB(bool use) {
-  standardHB_=use;
-}
-void CaloTowerConstituentsMap::useStandardHE(bool use) {
-  standardHE_=use;
-}
-void CaloTowerConstituentsMap::useStandardHO(bool use) {
-  standardHO_=use;
-}
-void CaloTowerConstituentsMap::useStandardHF(bool use) {
-  standardHF_=use;
-}
-void CaloTowerConstituentsMap::useStandardEB(bool use) {
-  standardEB_=use;
-}
+void CaloTowerConstituentsMap::useStandardHB(bool use) { standardHB_ = use; }
+void CaloTowerConstituentsMap::useStandardHE(bool use) { standardHE_ = use; }
+void CaloTowerConstituentsMap::useStandardHO(bool use) { standardHO_ = use; }
+void CaloTowerConstituentsMap::useStandardHF(bool use) { standardHF_ = use; }
+void CaloTowerConstituentsMap::useStandardEB(bool use) { standardEB_ = use; }

--- a/Geometry/CaloTopology/src/CaloTowerTopology.cc
+++ b/Geometry/CaloTopology/src/CaloTowerTopology.cc
@@ -5,136 +5,145 @@
 
 //#define DebugLog
 
-CaloTowerTopology::CaloTowerTopology(const HcalTopology * topology) : hcaltopo(topology) {
-
+CaloTowerTopology::CaloTowerTopology(const HcalTopology* topology) : hcaltopo(topology) {
   //get number of towers in each hcal subdet from hcaltopo
   int nEtaHB, nEtaHO, nEtaHF;
   nEtaHB = hcaltopo->lastHBRing() - hcaltopo->firstHBRing() + 1;
-  nEtaHE_= hcaltopo->lastHERing() - hcaltopo->firstHERing() + 1;
+  nEtaHE_ = hcaltopo->lastHERing() - hcaltopo->firstHERing() + 1;
   nEtaHO = hcaltopo->lastHORing() - hcaltopo->firstHORing() + 1;
   nEtaHF = hcaltopo->lastHFRing() - hcaltopo->firstHFRing() + 1;
 #ifdef DebugLog
-  std::cout << "CaloTowerTopology:(1) " << nEtaHB << ":" << nEtaHE_ << ":"
-	    << nEtaHO << ":" << nEtaHF << ":" << hcaltopo->isBH() << std::endl;
+  std::cout << "CaloTowerTopology:(1) " << nEtaHB << ":" << nEtaHE_ << ":" << nEtaHO << ":" << nEtaHF << ":"
+            << hcaltopo->isBH() << std::endl;
 #endif
-  if (hcaltopo->isBH()) nEtaHE_ = 0;
+  if (hcaltopo->isBH())
+    nEtaHE_ = 0;
 
-  //setup continuous ieta  
+  //setup continuous ieta
   firstHBRing_ = 1;
   lastHBRing_ = firstHBRing_ + nEtaHB - 1;
-  firstHERing_ = lastHBRing_; //crossover
-  lastHERing_ = firstHERing_ + std::max(nEtaHE_ - 1,0); //max = protection for case with no HE
-  firstHFRing_ = lastHERing_ + 1; //no crossover for CaloTowers; HF crossover cells go in the subsequent non-crossover HF tower
-  lastHFRing_ = firstHFRing_ + (nEtaHF - 1) - 1; //nEtaHF - 1 to account for no crossover
+  firstHERing_ = lastHBRing_;                             //crossover
+  lastHERing_ = firstHERing_ + std::max(nEtaHE_ - 1, 0);  //max = protection for case with no HE
+  firstHFRing_ =
+      lastHERing_ + 1;  //no crossover for CaloTowers; HF crossover cells go in the subsequent non-crossover HF tower
+  lastHFRing_ = firstHFRing_ + (nEtaHF - 1) - 1;  //nEtaHF - 1 to account for no crossover
   firstHORing_ = 1;
   lastHORing_ = firstHORing_ + nEtaHO - 1;
 #ifdef DebugLog
-  std::cout << "CaloTowerTopology: (2) " << firstHBRing_ << ":" << lastHBRing_
-	    << ":" << firstHERing_ << ":" << lastHERing_ << ":" << firstHFRing_
-	    << ":" << lastHFRing_ << ":" << firstHORing_ << ":" << lastHORing_
-	    << std::endl;
+  std::cout << "CaloTowerTopology: (2) " << firstHBRing_ << ":" << lastHBRing_ << ":" << firstHERing_ << ":"
+            << lastHERing_ << ":" << firstHFRing_ << ":" << lastHFRing_ << ":" << firstHORing_ << ":" << lastHORing_
+            << std::endl;
 #endif
 
   //translate phi segmentation boundaries into continuous ieta
-  if(hcaltopo->firstHEDoublePhiRing()==999 || nEtaHE_ == 0) firstHEDoublePhiRing_ = firstHFRing_;
-  else firstHEDoublePhiRing_ = firstHERing_ + (hcaltopo->firstHEDoublePhiRing() - hcaltopo->firstHERing());
+  if (hcaltopo->firstHEDoublePhiRing() == 999 || nEtaHE_ == 0)
+    firstHEDoublePhiRing_ = firstHFRing_;
+  else
+    firstHEDoublePhiRing_ = firstHERing_ + (hcaltopo->firstHEDoublePhiRing() - hcaltopo->firstHERing());
   firstHEQuadPhiRing_ = firstHERing_ + (hcaltopo->firstHEQuadPhiRing() - hcaltopo->firstHERing());
   firstHFQuadPhiRing_ = firstHFRing_ - 1 + (hcaltopo->firstHFQuadPhiRing() - hcaltopo->firstHFRing());
-  
+
   //number of etas per phi segmentation type
   int nEtaSinglePhi_, nEtaDoublePhi_, nEtaQuadPhi_;
   nEtaSinglePhi_ = firstHEDoublePhiRing_ - firstHBRing_;
   nEtaDoublePhi_ = firstHFQuadPhiRing_ - firstHEDoublePhiRing_;
-  nEtaQuadPhi_ = lastHFRing_ - firstHFQuadPhiRing_ + 1; //include lastHFRing
-  
+  nEtaQuadPhi_ = lastHFRing_ - firstHFQuadPhiRing_ + 1;  //include lastHFRing
+
   //total number of towers per phi segmentation type
-  nSinglePhi_ = nEtaSinglePhi_*72;
-  nDoublePhi_ = nEtaDoublePhi_*36;
-  nQuadPhi_ = nEtaQuadPhi_*18;
+  nSinglePhi_ = nEtaSinglePhi_ * 72;
+  nDoublePhi_ = nEtaDoublePhi_ * 36;
+  nQuadPhi_ = nEtaQuadPhi_ * 18;
 
 #ifdef DebugLog
-  std::cout << "CaloTowerTopology: (3) " << nEtaSinglePhi_ << ":" 
-	    << nEtaDoublePhi_ << ":" << nEtaQuadPhi_ << ":" << nSinglePhi_
-	    << ":" << nDoublePhi_ << ":" << nQuadPhi_ << std::endl;
+  std::cout << "CaloTowerTopology: (3) " << nEtaSinglePhi_ << ":" << nEtaDoublePhi_ << ":" << nEtaQuadPhi_ << ":"
+            << nSinglePhi_ << ":" << nDoublePhi_ << ":" << nQuadPhi_ << std::endl;
 #endif
-  
-  //calculate maximum dense index size
-  kSizeForDenseIndexing = 2*(nSinglePhi_ + nDoublePhi_ + nQuadPhi_);
 
+  //calculate maximum dense index size
+  kSizeForDenseIndexing = 2 * (nSinglePhi_ + nDoublePhi_ + nQuadPhi_);
 }
 
 //convert CaloTowerTopology ieta to HcalTopology ieta
 int CaloTowerTopology::convertCTtoHcal(int ct_ieta) const {
-  if(ct_ieta <= lastHBRing_) return ct_ieta - firstHBRing_ + hcaltopo->firstHBRing();
-  else if(ct_ieta <= lastHERing_) return ct_ieta - firstHERing_ + hcaltopo->firstHERing();
-  else if(ct_ieta <= lastHFRing_) return ct_ieta - firstHFRing_ + hcaltopo->firstHFRing() + 1; //account for no HF crossover
-  else return 0; //if ct_ieta outside range
+  if (ct_ieta <= lastHBRing_)
+    return ct_ieta - firstHBRing_ + hcaltopo->firstHBRing();
+  else if (ct_ieta <= lastHERing_)
+    return ct_ieta - firstHERing_ + hcaltopo->firstHERing();
+  else if (ct_ieta <= lastHFRing_)
+    return ct_ieta - firstHFRing_ + hcaltopo->firstHFRing() + 1;  //account for no HF crossover
+  else
+    return 0;  //if ct_ieta outside range
 }
 
 //convert HcalTopology ieta to CaloTowerTopology ieta
 int CaloTowerTopology::convertHcaltoCT(int hcal_ieta, HcalSubdetector subdet) const {
-  if(subdet == HcalBarrel && hcal_ieta >= hcaltopo->firstHBRing() && hcal_ieta <= hcaltopo->lastHBRing()){
+  if (subdet == HcalBarrel && hcal_ieta >= hcaltopo->firstHBRing() && hcal_ieta <= hcaltopo->lastHBRing()) {
     return hcal_ieta - hcaltopo->firstHBRing() + firstHBRing_;
-  }
-  else if(subdet == HcalEndcap && hcal_ieta >= hcaltopo->firstHERing() && hcal_ieta <= hcaltopo->lastHERing()){
+  } else if (subdet == HcalEndcap && hcal_ieta >= hcaltopo->firstHERing() && hcal_ieta <= hcaltopo->lastHERing()) {
     return ((nEtaHE_ == 0) ? 0 : (hcal_ieta - hcaltopo->firstHERing() + firstHERing_));
-  }
-  else if(subdet == HcalForward && hcal_ieta >= hcaltopo->firstHFRing() && hcal_ieta <= hcaltopo->lastHFRing()) {
-  	if(hcal_ieta == hcaltopo->firstHFRing()) hcal_ieta++; //account for no HF crossover
-  	return hcal_ieta - hcaltopo->firstHFRing() + firstHFRing_ - 1;
-  }
-  else if(subdet == HcalOuter && hcal_ieta >= hcaltopo->firstHORing() && hcal_ieta <= hcaltopo->lastHORing()) {
+  } else if (subdet == HcalForward && hcal_ieta >= hcaltopo->firstHFRing() && hcal_ieta <= hcaltopo->lastHFRing()) {
+    if (hcal_ieta == hcaltopo->firstHFRing())
+      hcal_ieta++;  //account for no HF crossover
+    return hcal_ieta - hcaltopo->firstHFRing() + firstHFRing_ - 1;
+  } else if (subdet == HcalOuter && hcal_ieta >= hcaltopo->firstHORing() && hcal_ieta <= hcaltopo->lastHORing()) {
     return hcal_ieta - hcaltopo->firstHORing() + firstHORing_;
-  }
-  else return 0; //if hcal_ieta outside range, or unknown subdet
+  } else
+    return 0;  //if hcal_ieta outside range, or unknown subdet
 }
 
 bool CaloTowerTopology::valid(const DetId& id) const {
-  assert(id.det()==DetId::Calo && id.subdetId()==CaloTowerDetId::SubdetId);
+  assert(id.det() == DetId::Calo && id.subdetId() == CaloTowerDetId::SubdetId);
   return validDetId(id);
 }
 
 bool CaloTowerTopology::validDetId(const CaloTowerDetId& id) const {
   int ia = id.ietaAbs();
   int ip = id.iphi();
-  
-  return ( (ia >= firstHBRing_) && (ia <= lastHFRing_) //eta range
-           && (ip >= 1) && (ip <= 72) //phi range
-		   && (   (ia < firstHEDoublePhiRing_) //72 phi segments
-               || (ia < firstHFQuadPhiRing_ && (ip-1)%2 == 0) //36 phi segments, numbered 1,3,...,33,35
-               || (ia >= firstHFQuadPhiRing_ && (ip-3)%4 == 0)  ) //18 phi segments, numbered 71,3,7,11,...
-         );
+
+  return ((ia >= firstHBRing_) && (ia <= lastHFRing_)               //eta range
+          && (ip >= 1) && (ip <= 72)                                //phi range
+          && ((ia < firstHEDoublePhiRing_)                          //72 phi segments
+              || (ia < firstHFQuadPhiRing_ && (ip - 1) % 2 == 0)    //36 phi segments, numbered 1,3,...,33,35
+              || (ia >= firstHFQuadPhiRing_ && (ip - 3) % 4 == 0))  //18 phi segments, numbered 71,3,7,11,...
+  );
 }
 
 //decreasing ieta
 std::vector<DetId> CaloTowerTopology::east(const DetId& id) const {
   std::vector<DetId> dd;
   CaloTowerDetId tid(id);
-  int ieta=tid.ieta();
-  int iphi=tid.iphi();
-  
-  if (ieta==1) { //no ieta=0
-    ieta=-1;
-  } else if (ieta==firstHEDoublePhiRing_) { //currently double phi, going to single phi (positive eta) -> extra neighbor
+  int ieta = tid.ieta();
+  int iphi = tid.iphi();
+
+  if (ieta == 1) {  //no ieta=0
+    ieta = -1;
+  } else if (ieta ==
+             firstHEDoublePhiRing_) {  //currently double phi, going to single phi (positive eta) -> extra neighbor
     ieta--;
-    dd.emplace_back(CaloTowerDetId(ieta,iphi+1));    
-  } else if (ieta-1==-firstHEDoublePhiRing_) { //currently single phi, going to double phi (negative eta) -> change numbering
-    if ((iphi%2)==0) iphi--;
+    dd.emplace_back(CaloTowerDetId(ieta, iphi + 1));
+  } else if (ieta - 1 ==
+             -firstHEDoublePhiRing_) {  //currently single phi, going to double phi (negative eta) -> change numbering
+    if ((iphi % 2) == 0)
+      iphi--;
     ieta--;
-  } else if (ieta==firstHFQuadPhiRing_) { //currently quad phi, going to double phi (positive eta) -> extra neighbor
+  } else if (ieta == firstHFQuadPhiRing_) {  //currently quad phi, going to double phi (positive eta) -> extra neighbor
     ieta--;
-    dd.emplace_back(CaloTowerDetId(ieta,((iphi+1)%72)+1));    
-  } else if (ieta-1==-firstHFQuadPhiRing_) { //currently double phi, going to quad phi (negative eta) -> change numbering
-    if (((iphi-1)%4)==0) {
-      if (iphi==1) iphi=71;
-      else         iphi-=2;
+    dd.emplace_back(CaloTowerDetId(ieta, ((iphi + 1) % 72) + 1));
+  } else if (ieta - 1 ==
+             -firstHFQuadPhiRing_) {  //currently double phi, going to quad phi (negative eta) -> change numbering
+    if (((iphi - 1) % 4) == 0) {
+      if (iphi == 1)
+        iphi = 71;
+      else
+        iphi -= 2;
     }
     ieta--;
-  } else { //general case
+  } else {  //general case
     ieta--;
   }
 
-  if (ieta>=-lastHFRing_) dd.emplace_back(CaloTowerDetId(ieta,iphi));
+  if (ieta >= -lastHFRing_)
+    dd.emplace_back(CaloTowerDetId(ieta, iphi));
   return dd;
 }
 
@@ -143,31 +152,38 @@ std::vector<DetId> CaloTowerTopology::west(const DetId& id) const {
   std::vector<DetId> dd;
   CaloTowerDetId tid(id);
 
-  int ieta=tid.ieta();
-  int iphi=tid.iphi();
+  int ieta = tid.ieta();
+  int iphi = tid.iphi();
 
-  if (ieta==-1) { //no ieta=0
-    ieta=1;
-  } else if (ieta==-firstHEDoublePhiRing_) { //currently double phi, going to single phi (negative eta) -> extra neighbor
+  if (ieta == -1) {  //no ieta=0
+    ieta = 1;
+  } else if (ieta ==
+             -firstHEDoublePhiRing_) {  //currently double phi, going to single phi (negative eta) -> extra neighbor
     ieta++;
-    dd.emplace_back(CaloTowerDetId(ieta,iphi+1));    
-  } else if (ieta+1==firstHEDoublePhiRing_) { //currently single phi, going to double phi (positive eta) -> change numbering
-    if ((iphi%2)==0) iphi--;
+    dd.emplace_back(CaloTowerDetId(ieta, iphi + 1));
+  } else if (ieta + 1 ==
+             firstHEDoublePhiRing_) {  //currently single phi, going to double phi (positive eta) -> change numbering
+    if ((iphi % 2) == 0)
+      iphi--;
     ieta++;
-  } else if (ieta==-firstHFQuadPhiRing_) { //currently quad phi, going to double phi (negative eta) -> extra neighbor
+  } else if (ieta == -firstHFQuadPhiRing_) {  //currently quad phi, going to double phi (negative eta) -> extra neighbor
     ieta++;
-    dd.emplace_back(CaloTowerDetId(ieta,((iphi+1)%72)+1));
-  } else if (ieta+1==firstHFQuadPhiRing_) { //currently double phi, going to quad phi (positive eta) -> change numbering
-    if (((iphi-1)%4)==0) {
-      if (iphi==1) iphi=71;
-      else         iphi-=2;
+    dd.emplace_back(CaloTowerDetId(ieta, ((iphi + 1) % 72) + 1));
+  } else if (ieta + 1 ==
+             firstHFQuadPhiRing_) {  //currently double phi, going to quad phi (positive eta) -> change numbering
+    if (((iphi - 1) % 4) == 0) {
+      if (iphi == 1)
+        iphi = 71;
+      else
+        iphi -= 2;
     }
     ieta++;
   } else {
     ieta++;
   }
 
-  if (ieta<=lastHFRing_) dd.emplace_back(CaloTowerDetId(ieta,iphi));
+  if (ieta <= lastHFRing_)
+    dd.emplace_back(CaloTowerDetId(ieta, iphi));
 
   return dd;
 }
@@ -175,71 +191,69 @@ std::vector<DetId> CaloTowerTopology::west(const DetId& id) const {
 //increasing iphi
 std::vector<DetId> CaloTowerTopology::north(const DetId& id) const {
   CaloTowerDetId tid(id);
-  int iphi_n=tid.iphi()+1;
-  if (iphi_n>72) iphi_n=1;
-  if (tid.ietaAbs()>=firstHFQuadPhiRing_) { //18 phi segments, numbered 71,3,7,11,...
-    iphi_n+=3;
-    if (iphi_n>72) iphi_n-=72;
-  } else if (tid.ietaAbs()>=firstHEDoublePhiRing_ && (iphi_n%2)==0) { //36 phi segments, numbered 1,3,...,33,35
+  int iphi_n = tid.iphi() + 1;
+  if (iphi_n > 72)
+    iphi_n = 1;
+  if (tid.ietaAbs() >= firstHFQuadPhiRing_) {  //18 phi segments, numbered 71,3,7,11,...
+    iphi_n += 3;
+    if (iphi_n > 72)
+      iphi_n -= 72;
+  } else if (tid.ietaAbs() >= firstHEDoublePhiRing_ && (iphi_n % 2) == 0) {  //36 phi segments, numbered 1,3,...,33,35
     iphi_n++;
-    if (iphi_n>72) iphi_n-=72;
+    if (iphi_n > 72)
+      iphi_n -= 72;
   }
 
   std::vector<DetId> dd;
-  dd.emplace_back(CaloTowerDetId(tid.ieta(),iphi_n));
+  dd.emplace_back(CaloTowerDetId(tid.ieta(), iphi_n));
   return dd;
 }
 
 //decreasing iphi
 std::vector<DetId> CaloTowerTopology::south(const DetId& id) const {
   CaloTowerDetId tid(id);
-  int iphi_s=tid.iphi()-1;
-  if (iphi_s==0) iphi_s=72;
-  if (tid.ietaAbs()>=firstHFQuadPhiRing_) { //18 phi segments, numbered 71,3,7,11,...
-    iphi_s-=3;
-    if (iphi_s<=0) iphi_s+=72;
-  } else if (tid.ietaAbs()>=firstHEDoublePhiRing_ && (iphi_s%2)==0) { //36 phi segments, numbered 1,3,...,33,35
+  int iphi_s = tid.iphi() - 1;
+  if (iphi_s == 0)
+    iphi_s = 72;
+  if (tid.ietaAbs() >= firstHFQuadPhiRing_) {  //18 phi segments, numbered 71,3,7,11,...
+    iphi_s -= 3;
+    if (iphi_s <= 0)
+      iphi_s += 72;
+  } else if (tid.ietaAbs() >= firstHEDoublePhiRing_ && (iphi_s % 2) == 0) {  //36 phi segments, numbered 1,3,...,33,35
     iphi_s--;
   }
 
   std::vector<DetId> dd;
-  dd.emplace_back(CaloTowerDetId(tid.ieta(),iphi_s));
+  dd.emplace_back(CaloTowerDetId(tid.ieta(), iphi_s));
   return dd;
 }
 
-std::vector<DetId> CaloTowerTopology::up(const DetId& /*id*/) const {
-  return std::vector<DetId>();
-}
+std::vector<DetId> CaloTowerTopology::up(const DetId& /*id*/) const { return std::vector<DetId>(); }
 
-std::vector<DetId> CaloTowerTopology::down(const DetId& /*id*/) const {
-  return std::vector<DetId>();
-}
+std::vector<DetId> CaloTowerTopology::down(const DetId& /*id*/) const { return std::vector<DetId>(); }
 
 uint32_t CaloTowerTopology::denseIndex(const DetId& id) const {
   CaloTowerDetId tid(id);
-  const int ie ( tid.ietaAbs() );
-  const int ip ( tid.iphi() - 1 ) ;
-  
-  return ( ( 0 > tid.zside() ? 0 : kSizeForDenseIndexing/2 ) +
-           ( ( firstHEDoublePhiRing_ > ie ? ( ie - 1 )*72 + ip :
-	       ( firstHFQuadPhiRing_ > ie ?  nSinglePhi_ + ( ie - firstHEDoublePhiRing_ )*36 + ip/2 :
-		 nSinglePhi_ + nDoublePhi_ + ( ie - firstHFQuadPhiRing_ )*18 + ip/4 ) ) ) );
+  const int ie(tid.ietaAbs());
+  const int ip(tid.iphi() - 1);
+
+  return ((0 > tid.zside() ? 0 : kSizeForDenseIndexing / 2) +
+          ((firstHEDoublePhiRing_ > ie
+                ? (ie - 1) * 72 + ip
+                : (firstHFQuadPhiRing_ > ie ? nSinglePhi_ + (ie - firstHEDoublePhiRing_) * 36 + ip / 2
+                                            : nSinglePhi_ + nDoublePhi_ + (ie - firstHFQuadPhiRing_) * 18 + ip / 4))));
 }
 
-CaloTowerDetId CaloTowerTopology::detIdFromDenseIndex( uint32_t din ) const {
-  const int iz ( din < kSizeForDenseIndexing/2 ? -1 : 1 ) ;
-  din %= kSizeForDenseIndexing/2 ;
-  const int ie ( nSinglePhi_ + nDoublePhi_ - 1 < (int)(din) ?
-		 firstHFQuadPhiRing_ + (din - nSinglePhi_ - nDoublePhi_ )/18 :
-		 ( nSinglePhi_ - 1 < (int)din ?
-		   firstHEDoublePhiRing_ + ( din - nSinglePhi_ )/36 :
-		   din/72 + 1 ) ) ;
-  
-  const int ip ( nSinglePhi_ + nDoublePhi_ - 1 < (int)(din) ?
-		 ( ( din - nSinglePhi_ - nDoublePhi_ )%18 )*4 + 3 :
-		 ( nSinglePhi_ - 1 < (int)(din) ?
-		   ( ( din - nSinglePhi_ )%36 )*2 + 1 :
-		   din%72 + 1 ) ) ;
+CaloTowerDetId CaloTowerTopology::detIdFromDenseIndex(uint32_t din) const {
+  const int iz(din < kSizeForDenseIndexing / 2 ? -1 : 1);
+  din %= kSizeForDenseIndexing / 2;
+  const int ie(nSinglePhi_ + nDoublePhi_ - 1 < (int)(din)
+                   ? firstHFQuadPhiRing_ + (din - nSinglePhi_ - nDoublePhi_) / 18
+                   : (nSinglePhi_ - 1 < (int)din ? firstHEDoublePhiRing_ + (din - nSinglePhi_) / 36 : din / 72 + 1));
 
-  return ( validDenseIndex( din ) ? CaloTowerDetId( iz*ie, ip ) : CaloTowerDetId() ) ;
+  const int ip(nSinglePhi_ + nDoublePhi_ - 1 < (int)(din)
+                   ? ((din - nSinglePhi_ - nDoublePhi_) % 18) * 4 + 3
+                   : (nSinglePhi_ - 1 < (int)(din) ? ((din - nSinglePhi_) % 36) * 2 + 1 : din % 72 + 1));
+
+  return (validDenseIndex(din) ? CaloTowerDetId(iz * ie, ip) : CaloTowerDetId());
 }

--- a/Geometry/CaloTopology/src/ES_CaloSubdetectorTopology.cc
+++ b/Geometry/CaloTopology/src/ES_CaloSubdetectorTopology.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 
-
 TYPELOOKUP_DATA_REG(CaloSubdetectorTopology);

--- a/Geometry/CaloTopology/src/ES_CaloTopogy.cc
+++ b/Geometry/CaloTopology/src/ES_CaloTopogy.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 
-
 TYPELOOKUP_DATA_REG(CaloTopology);

--- a/Geometry/CaloTopology/src/EcalBarrelHardcodedTopology.cc
+++ b/Geometry/CaloTopology/src/EcalBarrelHardcodedTopology.cc
@@ -1,23 +1,33 @@
 #include "Geometry/CaloTopology/interface/EcalBarrelHardcodedTopology.h"
 
 EBDetId EcalBarrelHardcodedTopology::incrementIeta(const EBDetId& id) const {
-  if (id.ieta()==EBDetId::MAX_IETA) return EBDetId(0); // null det id
-  else if (id.ieta()==-1) return EBDetId(1,id.iphi());
-  else return EBDetId(id.ieta()+1,id.iphi());
+  if (id.ieta() == EBDetId::MAX_IETA)
+    return EBDetId(0);  // null det id
+  else if (id.ieta() == -1)
+    return EBDetId(1, id.iphi());
+  else
+    return EBDetId(id.ieta() + 1, id.iphi());
 }
 
 EBDetId EcalBarrelHardcodedTopology::decrementIeta(const EBDetId& id) const {
-  if (id.ieta()==-EBDetId::MAX_IETA) return EBDetId(0); // null det id
-  else if (id.ieta()==1) return EBDetId(-1,id.iphi());
-  else return EBDetId(id.ieta()-1,id.iphi());
+  if (id.ieta() == -EBDetId::MAX_IETA)
+    return EBDetId(0);  // null det id
+  else if (id.ieta() == 1)
+    return EBDetId(-1, id.iphi());
+  else
+    return EBDetId(id.ieta() - 1, id.iphi());
 }
 
 EBDetId EcalBarrelHardcodedTopology::incrementIphi(const EBDetId& id) const {
-  if (id.iphi()==EBDetId::MAX_IPHI) return EBDetId(id.ieta(),EBDetId::MIN_IPHI);
-  else return EBDetId(id.ieta(),id.iphi()+1);
+  if (id.iphi() == EBDetId::MAX_IPHI)
+    return EBDetId(id.ieta(), EBDetId::MIN_IPHI);
+  else
+    return EBDetId(id.ieta(), id.iphi() + 1);
 }
 
 EBDetId EcalBarrelHardcodedTopology::decrementIphi(const EBDetId& id) const {
-  if (id.iphi()==EBDetId::MIN_IPHI) return EBDetId(id.ieta(),EBDetId::MAX_IPHI);
-  else return EBDetId(id.ieta(),id.iphi()-1);
+  if (id.iphi() == EBDetId::MIN_IPHI)
+    return EBDetId(id.ieta(), EBDetId::MAX_IPHI);
+  else
+    return EBDetId(id.ieta(), id.iphi() - 1);
 }

--- a/Geometry/CaloTopology/src/EcalBarrelTopology.cc
+++ b/Geometry/CaloTopology/src/EcalBarrelTopology.cc
@@ -1,25 +1,21 @@
 #include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
 
-
 EBDetId EcalBarrelTopology::incrementIeta(const EBDetId& id) const {
   if (!(theGeom_->present(id)))
     return EBDetId(0);
-  
+
   EBDetId nextPoint;
-  if (id.ieta()==-1) 
-    {
-      if (EBDetId::validDetId(1,id.iphi()))
-	nextPoint=EBDetId (1,id.iphi());
-      else
-	return EBDetId(0);
-    }
-  else
-    {
-      if (EBDetId::validDetId(id.ieta()+1,id.iphi()))
-	nextPoint=EBDetId(id.ieta()+1,id.iphi());
-      else
-	return EBDetId(0);
-    }
+  if (id.ieta() == -1) {
+    if (EBDetId::validDetId(1, id.iphi()))
+      nextPoint = EBDetId(1, id.iphi());
+    else
+      return EBDetId(0);
+  } else {
+    if (EBDetId::validDetId(id.ieta() + 1, id.iphi()))
+      nextPoint = EBDetId(id.ieta() + 1, id.iphi());
+    else
+      return EBDetId(0);
+  }
   if (theGeom_->present(nextPoint))
     return nextPoint;
   else
@@ -27,85 +23,72 @@ EBDetId EcalBarrelTopology::incrementIeta(const EBDetId& id) const {
 }
 
 EBDetId EcalBarrelTopology::decrementIeta(const EBDetId& id) const {
-  
   if (!(theGeom_->present(id)))
     return EBDetId(0);
-  
+
   EBDetId nextPoint;
-  if (id.ieta()==1)
-    { 
-      if (EBDetId::validDetId(-1,id.iphi()))
-	nextPoint=EBDetId(-1,id.iphi());
-      else
-	return EBDetId(0);
-    }
-  else
-    { 
-      if (EBDetId::validDetId(id.ieta()-1,id.iphi()))
-	nextPoint=EBDetId(id.ieta()-1,id.iphi());
-      else
-	return EBDetId(0);
-    }
-  
+  if (id.ieta() == 1) {
+    if (EBDetId::validDetId(-1, id.iphi()))
+      nextPoint = EBDetId(-1, id.iphi());
+    else
+      return EBDetId(0);
+  } else {
+    if (EBDetId::validDetId(id.ieta() - 1, id.iphi()))
+      nextPoint = EBDetId(id.ieta() - 1, id.iphi());
+    else
+      return EBDetId(0);
+  }
+
   if (theGeom_->present(nextPoint))
     return nextPoint;
   else
     return EBDetId(0);
-} 
-
+}
 
 EBDetId EcalBarrelTopology::incrementIphi(const EBDetId& id) const {
   if (!(theGeom_->present(id)))
     return EBDetId(0);
-  
+
   EBDetId nextPoint;
-  
-  if (id.iphi()==EBDetId::MAX_IPHI) 
-    {
-      if (EBDetId::validDetId(id.ieta(),EBDetId::MIN_IPHI))
-	nextPoint=EBDetId(id.ieta(),EBDetId::MIN_IPHI);
-      else
-	return EBDetId(0);
-    }
-  else
-    {
-      if (EBDetId::validDetId(id.ieta(),id.iphi()+1)) 
-	nextPoint=EBDetId(id.ieta(),id.iphi()+1);
-      else
-	return EBDetId(0);
-    }
-  
+
+  if (id.iphi() == EBDetId::MAX_IPHI) {
+    if (EBDetId::validDetId(id.ieta(), EBDetId::MIN_IPHI))
+      nextPoint = EBDetId(id.ieta(), EBDetId::MIN_IPHI);
+    else
+      return EBDetId(0);
+  } else {
+    if (EBDetId::validDetId(id.ieta(), id.iphi() + 1))
+      nextPoint = EBDetId(id.ieta(), id.iphi() + 1);
+    else
+      return EBDetId(0);
+  }
+
   if (theGeom_->present(nextPoint))
     return nextPoint;
   else
     return EBDetId(0);
-} 
-
+}
 
 EBDetId EcalBarrelTopology::decrementIphi(const EBDetId& id) const {
   if (!(theGeom_->present(id)))
     return EBDetId(0);
-  
+
   EBDetId nextPoint;
-  
-  if (id.iphi()==EBDetId::MIN_IPHI)
-    { 
-      if (EBDetId::validDetId(id.ieta(),EBDetId::MAX_IPHI))
-	nextPoint=EBDetId(id.ieta(),EBDetId::MAX_IPHI);
-      else
-	return EBDetId(0);
-    }
-  else
-    {
-      if (EBDetId::validDetId(id.ieta(),id.iphi()-1))
-	nextPoint=EBDetId(id.ieta(),id.iphi()-1);
-      else
-        return EBDetId(0);
-    }  
-  
+
+  if (id.iphi() == EBDetId::MIN_IPHI) {
+    if (EBDetId::validDetId(id.ieta(), EBDetId::MAX_IPHI))
+      nextPoint = EBDetId(id.ieta(), EBDetId::MAX_IPHI);
+    else
+      return EBDetId(0);
+  } else {
+    if (EBDetId::validDetId(id.ieta(), id.iphi() - 1))
+      nextPoint = EBDetId(id.ieta(), id.iphi() - 1);
+    else
+      return EBDetId(0);
+  }
+
   if (theGeom_->present(nextPoint))
     return nextPoint;
   else
     return EBDetId(0);
-} 
-
+}

--- a/Geometry/CaloTopology/src/EcalEndcapHardcodedTopology.cc
+++ b/Geometry/CaloTopology/src/EcalEndcapHardcodedTopology.cc
@@ -1,21 +1,29 @@
 #include "Geometry/CaloTopology/interface/EcalEndcapHardcodedTopology.h"
 
 EEDetId EcalEndcapHardcodedTopology::incrementIx(const EEDetId& id) const {
-  if (! (EEDetId::validDetId(id.ix()+1,id.iy(),id.zside()) ) ) return EEDetId(0); // null det id
-  else return EEDetId(id.ix()+1,id.iy(),id.zside());	 
+  if (!(EEDetId::validDetId(id.ix() + 1, id.iy(), id.zside())))
+    return EEDetId(0);  // null det id
+  else
+    return EEDetId(id.ix() + 1, id.iy(), id.zside());
 }
 
 EEDetId EcalEndcapHardcodedTopology::decrementIx(const EEDetId& id) const {
-  if (! (EEDetId::validDetId(id.ix()-1,id.iy(),id.zside()) ) ) return EEDetId(0); // null det id
-  else return EEDetId(id.ix()-1,id.iy(),id.zside());	 
+  if (!(EEDetId::validDetId(id.ix() - 1, id.iy(), id.zside())))
+    return EEDetId(0);  // null det id
+  else
+    return EEDetId(id.ix() - 1, id.iy(), id.zside());
 }
 
 EEDetId EcalEndcapHardcodedTopology::incrementIy(const EEDetId& id) const {
-  if (! (EEDetId::validDetId(id.ix(),id.iy()+1,id.zside()) ) ) return EEDetId(0); // null det id
-  else return EEDetId(id.ix(),id.iy()+1,id.zside());	 
+  if (!(EEDetId::validDetId(id.ix(), id.iy() + 1, id.zside())))
+    return EEDetId(0);  // null det id
+  else
+    return EEDetId(id.ix(), id.iy() + 1, id.zside());
 }
 
 EEDetId EcalEndcapHardcodedTopology::decrementIy(const EEDetId& id) const {
-  if (! (EEDetId::validDetId(id.ix(),id.iy()-1,id.zside()) ) ) return EEDetId(0); // null det id
-  else return EEDetId(id.ix(),id.iy()-1,id.zside());	 
+  if (!(EEDetId::validDetId(id.ix(), id.iy() - 1, id.zside())))
+    return EEDetId(0);  // null det id
+  else
+    return EEDetId(id.ix(), id.iy() - 1, id.zside());
 }

--- a/Geometry/CaloTopology/src/EcalEndcapTopology.cc
+++ b/Geometry/CaloTopology/src/EcalEndcapTopology.cc
@@ -1,13 +1,12 @@
 #include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
 
-
 EEDetId EcalEndcapTopology::incrementIy(const EEDetId& id) const {
   if (!(theGeom_->present(id))) {
     return EEDetId(0);
   }
   EEDetId nextPoint;
-  if (EEDetId::validDetId(id.ix(),id.iy()+1,id.zside()))
-    nextPoint=EEDetId(id.ix(),id.iy()+1,id.zside());
+  if (EEDetId::validDetId(id.ix(), id.iy() + 1, id.zside()))
+    nextPoint = EEDetId(id.ix(), id.iy() + 1, id.zside());
   else
     return EEDetId(0);
 
@@ -15,17 +14,15 @@ EEDetId EcalEndcapTopology::incrementIy(const EEDetId& id) const {
     return nextPoint;
   else
     return EEDetId(0);
-} 
-
+}
 
 EEDetId EcalEndcapTopology::decrementIy(const EEDetId& id) const {
-
   if (!(theGeom_->present(id))) {
     return EEDetId(0);
   }
   EEDetId nextPoint;
-  if (EEDetId::validDetId(id.ix(),id.iy()-1,id.zside()))
-    nextPoint=EEDetId(id.ix(),id.iy()-1,id.zside());
+  if (EEDetId::validDetId(id.ix(), id.iy() - 1, id.zside()))
+    nextPoint = EEDetId(id.ix(), id.iy() - 1, id.zside());
   else
     return EEDetId(0);
 
@@ -33,18 +30,16 @@ EEDetId EcalEndcapTopology::decrementIy(const EEDetId& id) const {
     return nextPoint;
   else
     return EEDetId(0);
-} 
-
+}
 
 EEDetId EcalEndcapTopology::incrementIx(const EEDetId& id) const {
-  if (!(theGeom_->present(id)))  {
+  if (!(theGeom_->present(id))) {
     return EEDetId(0);
   }
-  
-  
+
   EEDetId nextPoint;
-  if (EEDetId::validDetId(id.ix()+1,id.iy(),id.zside()))
-    nextPoint=EEDetId(id.ix()+1,id.iy(),id.zside());
+  if (EEDetId::validDetId(id.ix() + 1, id.iy(), id.zside()))
+    nextPoint = EEDetId(id.ix() + 1, id.iy(), id.zside());
   else
     return EEDetId(0);
 
@@ -52,24 +47,22 @@ EEDetId EcalEndcapTopology::incrementIx(const EEDetId& id) const {
     return nextPoint;
   else
     return EEDetId(0);
-} 
-
+}
 
 EEDetId EcalEndcapTopology::decrementIx(const EEDetId& id) const {
   if (!(theGeom_->present(id))) {
     return EEDetId(0);
   }
-  
+
   EEDetId nextPoint;
 
-  if (EEDetId::validDetId(id.ix()-1,id.iy(),id.zside()))
-    nextPoint=EEDetId(id.ix()-1,id.iy(),id.zside());
+  if (EEDetId::validDetId(id.ix() - 1, id.iy(), id.zside()))
+    nextPoint = EEDetId(id.ix() - 1, id.iy(), id.zside());
   else
     return EEDetId(0);
-  
+
   if (theGeom_->present(nextPoint))
     return nextPoint;
   else
     return EEDetId(0);
-} 
-
+}

--- a/Geometry/CaloTopology/src/EcalPreshowerTopology.cc
+++ b/Geometry/CaloTopology/src/EcalPreshowerTopology.cc
@@ -4,155 +4,128 @@
 
 ESDetId EcalPreshowerTopology::incrementIy(const ESDetId& id) const {
   ESDetId nextPoint(0);
-  if (id==nextPoint) return nextPoint;
+  if (id == nextPoint)
+    return nextPoint;
 
   //Strips orientend along x direction for plane 2
-  if (id.plane() == 2)
-    {
-      if (id.strip() < 32 )
-	{
-	  //Incrementing just strip number
-	  if (ESDetId::validDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside()))
-	    nextPoint=ESDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside());
-	}
-      else
-	{
-	  //Changing wafer
-	  if (ESDetId::validDetId(1,id.six(),id.siy()+1,id.plane(),id.zside()))
-	    nextPoint=ESDetId(1,id.six(),id.siy()+1,id.plane(),id.zside());
-	}
-    }
-  //Strips orientend along y direction for plane 1
-  else if (id.plane() == 1)
-    {
+  if (id.plane() == 2) {
+    if (id.strip() < 32) {
+      //Incrementing just strip number
+      if (ESDetId::validDetId(id.strip() + 1, id.six(), id.siy(), id.plane(), id.zside()))
+        nextPoint = ESDetId(id.strip() + 1, id.six(), id.siy(), id.plane(), id.zside());
+    } else {
       //Changing wafer
-      if (ESDetId::validDetId(id.strip(),id.six(),id.siy()+1,id.plane(),id.zside()))
-	nextPoint=ESDetId(id.strip(),id.six(),id.siy()+1,id.plane(),id.zside());
+      if (ESDetId::validDetId(1, id.six(), id.siy() + 1, id.plane(), id.zside()))
+        nextPoint = ESDetId(1, id.six(), id.siy() + 1, id.plane(), id.zside());
     }
-  
-  return nextPoint;
-} 
+  }
+  //Strips orientend along y direction for plane 1
+  else if (id.plane() == 1) {
+    //Changing wafer
+    if (ESDetId::validDetId(id.strip(), id.six(), id.siy() + 1, id.plane(), id.zside()))
+      nextPoint = ESDetId(id.strip(), id.six(), id.siy() + 1, id.plane(), id.zside());
+  }
 
+  return nextPoint;
+}
 
 ESDetId EcalPreshowerTopology::decrementIy(const ESDetId& id) const {
   ESDetId nextPoint(0);
-  if (id==nextPoint) return nextPoint;
+  if (id == nextPoint)
+    return nextPoint;
 
   //Strips orientend along x direction for plane 2
-  if (id.plane() == 2)
-    {
-      if (id.strip() >1 )
-	{
-	  //Decrementing just strip number
-	  if (ESDetId::validDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside()))
-	    nextPoint=ESDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside());
-	}
-      else
-	{
-	  //Changing wafer
-	  if (ESDetId::validDetId(32,id.six(),id.siy()-1,id.plane(),id.zside()))
-	    nextPoint=ESDetId(32,id.six(),id.siy()-1,id.plane(),id.zside());
-	}
-    }
-  //Strips orientend along y direction for plane 1
-  else if (id.plane() == 1)
-    {
+  if (id.plane() == 2) {
+    if (id.strip() > 1) {
+      //Decrementing just strip number
+      if (ESDetId::validDetId(id.strip() - 1, id.six(), id.siy(), id.plane(), id.zside()))
+        nextPoint = ESDetId(id.strip() - 1, id.six(), id.siy(), id.plane(), id.zside());
+    } else {
       //Changing wafer
-      if (ESDetId::validDetId(id.strip(),id.six(),id.siy()-1,id.plane(),id.zside()))
-	nextPoint=ESDetId(id.strip(),id.six(),id.siy()-1,id.plane(),id.zside());
+      if (ESDetId::validDetId(32, id.six(), id.siy() - 1, id.plane(), id.zside()))
+        nextPoint = ESDetId(32, id.six(), id.siy() - 1, id.plane(), id.zside());
     }
-   return nextPoint;
-} 
-
+  }
+  //Strips orientend along y direction for plane 1
+  else if (id.plane() == 1) {
+    //Changing wafer
+    if (ESDetId::validDetId(id.strip(), id.six(), id.siy() - 1, id.plane(), id.zside()))
+      nextPoint = ESDetId(id.strip(), id.six(), id.siy() - 1, id.plane(), id.zside());
+  }
+  return nextPoint;
+}
 
 ESDetId EcalPreshowerTopology::incrementIx(const ESDetId& id) const {
   ESDetId nextPoint(0);
-  if (id==nextPoint) return nextPoint;
+  if (id == nextPoint)
+    return nextPoint;
 
   //Strips orientend along x direction for plane 2
-  if (id.plane() == 2)
-    {
-      //Changing wafer
-      if (ESDetId::validDetId(id.strip(),id.six()+1,id.siy(),id.plane(),id.zside()))
-	nextPoint=ESDetId(id.strip(),id.six()+1,id.siy(),id.plane(),id.zside());
-    }
+  if (id.plane() == 2) {
+    //Changing wafer
+    if (ESDetId::validDetId(id.strip(), id.six() + 1, id.siy(), id.plane(), id.zside()))
+      nextPoint = ESDetId(id.strip(), id.six() + 1, id.siy(), id.plane(), id.zside());
+  }
   //Strips orientend along y direction for plane 1
-  else if (id.plane() == 1)
-    {
-      if (id.strip() < 32 )
-	{
-	//Incrementing just strip number
-	  if (ESDetId::validDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside())) 
-	    nextPoint=ESDetId(id.strip()+1,id.six(),id.siy(),id.plane(),id.zside());
-	}
-      else
-	{
-	//Changing wafer
-	  if (ESDetId::validDetId(1,id.six()+1,id.siy(),id.plane(),id.zside()))
-	    nextPoint=ESDetId(1,id.six()+1,id.siy(),id.plane(),id.zside());
-	}
+  else if (id.plane() == 1) {
+    if (id.strip() < 32) {
+      //Incrementing just strip number
+      if (ESDetId::validDetId(id.strip() + 1, id.six(), id.siy(), id.plane(), id.zside()))
+        nextPoint = ESDetId(id.strip() + 1, id.six(), id.siy(), id.plane(), id.zside());
+    } else {
+      //Changing wafer
+      if (ESDetId::validDetId(1, id.six() + 1, id.siy(), id.plane(), id.zside()))
+        nextPoint = ESDetId(1, id.six() + 1, id.siy(), id.plane(), id.zside());
     }
+  }
 
-    return nextPoint;
-} 
-
+  return nextPoint;
+}
 
 ESDetId EcalPreshowerTopology::decrementIx(const ESDetId& id) const {
   ESDetId nextPoint(0);
-  if (id==nextPoint) return nextPoint;
+  if (id == nextPoint)
+    return nextPoint;
 
   //Strips orientend along x direction for plane 2
-  if (id.plane() == 2)
-    {
-      //Changing wafer
-      if (ESDetId::validDetId(id.strip(),id.six()-1,id.siy(),id.plane(),id.zside()))
-	nextPoint=ESDetId(id.strip(),id.six()-1,id.siy(),id.plane(),id.zside());
-    }
+  if (id.plane() == 2) {
+    //Changing wafer
+    if (ESDetId::validDetId(id.strip(), id.six() - 1, id.siy(), id.plane(), id.zside()))
+      nextPoint = ESDetId(id.strip(), id.six() - 1, id.siy(), id.plane(), id.zside());
+  }
   //Strips orientend along y direction for plane 1
-  else if (id.plane() == 1)
-    {
-      if (id.strip() > 1 )
-	{
-	  //Decrementing just strip number
-	  if (ESDetId::validDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside()))
-	    nextPoint=ESDetId(id.strip()-1,id.six(),id.siy(),id.plane(),id.zside());
-	}
-      else
-	{
-	  //Changing wafer
-	  if (ESDetId::validDetId(32,id.six()-1,id.siy(),id.plane(),id.zside()))
-	    nextPoint=ESDetId(32,id.six()-1,id.siy(),id.plane(),id.zside());
-	}
+  else if (id.plane() == 1) {
+    if (id.strip() > 1) {
+      //Decrementing just strip number
+      if (ESDetId::validDetId(id.strip() - 1, id.six(), id.siy(), id.plane(), id.zside()))
+        nextPoint = ESDetId(id.strip() - 1, id.six(), id.siy(), id.plane(), id.zside());
+    } else {
+      //Changing wafer
+      if (ESDetId::validDetId(32, id.six() - 1, id.siy(), id.plane(), id.zside()))
+        nextPoint = ESDetId(32, id.six() - 1, id.siy(), id.plane(), id.zside());
     }
-   return nextPoint;
-} 
-
+  }
+  return nextPoint;
+}
 
 ESDetId EcalPreshowerTopology::incrementIz(const ESDetId& id) const {
   ESDetId nextPoint(0);
-  if (id==nextPoint) return nextPoint;
+  if (id == nextPoint)
+    return nextPoint;
 
-  if (ESDetId::validDetId(id.strip(),id.six(),id.siy(),id.plane()+1,id.zside()))
-    nextPoint=ESDetId(id.strip(),id.six(),id.siy(),id.plane()+1,id.zside());
+  if (ESDetId::validDetId(id.strip(), id.six(), id.siy(), id.plane() + 1, id.zside()))
+    nextPoint = ESDetId(id.strip(), id.six(), id.siy(), id.plane() + 1, id.zside());
 
   return nextPoint;
-} 
-
-
+}
 
 ESDetId EcalPreshowerTopology::decrementIz(const ESDetId& id) const {
   ESDetId nextPoint(0);
-  if (id==nextPoint) return nextPoint;
+  if (id == nextPoint)
+    return nextPoint;
 
-  if (ESDetId::validDetId(id.strip(),id.six(),id.siy(),id.plane()-1,id.zside()))
-    nextPoint=ESDetId(id.strip(),id.six(),id.siy(),id.plane()-1,id.zside());
-  
+  if (ESDetId::validDetId(id.strip(), id.six(), id.siy(), id.plane() - 1, id.zside()))
+    nextPoint = ESDetId(id.strip(), id.six(), id.siy(), id.plane() - 1, id.zside());
+
   return nextPoint;
-} 
-
-
-
-
-
-
-
+}

--- a/Geometry/CaloTopology/src/EcalTrigTowerConstituentsMap.cc
+++ b/Geometry/CaloTopology/src/EcalTrigTowerConstituentsMap.cc
@@ -6,201 +6,193 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-EcalTrigTowerConstituentsMap::EcalTrigTowerConstituentsMap() 
-{
-}
+EcalTrigTowerConstituentsMap::EcalTrigTowerConstituentsMap() {}
 
 EcalTrigTowerDetId EcalTrigTowerConstituentsMap::towerOf(const DetId& id) const {
-  if (id.det() == DetId::Ecal && id.subdetId() == EcalBarrel)
-    {
-      //--------------------
-      // Ecal Barrel
-      //--------------------
-      EBDetId myId(id);
-      return myId.tower();
+  if (id.det() == DetId::Ecal && id.subdetId() == EcalBarrel) {
+    //--------------------
+    // Ecal Barrel
+    //--------------------
+    EBDetId myId(id);
+    return myId.tower();
+  } else if (id.det() == DetId::Ecal && id.subdetId() == EcalEndcap) {
+    //--------------------
+    // Ecal Endcap
+    //--------------------
+    EEDetId originalId(id);
+    // DetId wrappedId=wrapEEDetId(id);
+    DetId wrappedId(originalId);
+    EcalTowerMap::const_iterator i = m_items.find(wrappedId);
+    if (i != m_items.end()) {
+      int etaTower = i->tower.ietaAbs();
+      int phiTower = i->tower.iphi();
+      //trigger tower <-> crystal maping read
+      //..........from file and done only for 1 quadrant
+      //move from quadrant 1 to the actual one:
+      // phiTower = changeTowerQuadrant(phiTower, 1, originalId.iquadrant());
+      // std::cout << originalId.zside() <<  " " << etaTower << " " << phiTower << std::endl;
+      return EcalTrigTowerDetId(originalId.zside(), EcalEndcap, etaTower, phiTower);
     }
-  else if (id.det() == DetId::Ecal && id.subdetId() == EcalEndcap)
-    {
-      //--------------------
-      // Ecal Endcap
-      //--------------------
-      EEDetId originalId(id);
-      // DetId wrappedId=wrapEEDetId(id);
-      DetId wrappedId(originalId);
-      EcalTowerMap::const_iterator i=m_items.find(wrappedId);
-      if (i!=m_items.end()) 
-	{
-	  int etaTower=i->tower.ietaAbs();
-	  int phiTower=i->tower.iphi();
-	  //trigger tower <-> crystal maping read 
-	  //..........from file and done only for 1 quadrant
-	  //move from quadrant 1 to the actual one:
-	  // phiTower = changeTowerQuadrant(phiTower, 1, originalId.iquadrant());
-	  // std::cout << originalId.zside() <<  " " << etaTower << " " << phiTower << std::endl;
-	  return EcalTrigTowerDetId(originalId.zside(),EcalEndcap,etaTower,phiTower);
-	}
-    }
+  }
   return EcalTrigTowerDetId(0);
 }
 
-DetId EcalTrigTowerConstituentsMap::wrapEEDetId(const DetId& eeid) const
-{
-  if (! (eeid.det() == DetId::Ecal && eeid.subdetId() == EcalEndcap) )
+DetId EcalTrigTowerConstituentsMap::wrapEEDetId(const DetId& eeid) const {
+  if (!(eeid.det() == DetId::Ecal && eeid.subdetId() == EcalEndcap))
     return EEDetId(0);
-  
+
   EEDetId myId(eeid);
-  switch((myId.iquadrant()-1)%4)
-    {
+  switch ((myId.iquadrant() - 1) % 4) {
     case 0:
-      return DetId(EEDetId(myId.ix(),myId.iy(),1,EEDetId::XYMODE));
+      return DetId(EEDetId(myId.ix(), myId.iy(), 1, EEDetId::XYMODE));
       break;
     case 1:
-      return DetId(EEDetId(101-myId.ix(),myId.iy(),1,EEDetId::XYMODE));
+      return DetId(EEDetId(101 - myId.ix(), myId.iy(), 1, EEDetId::XYMODE));
       break;
     case 2:
-      return DetId(EEDetId(101-myId.ix(),101-myId.iy(),1,EEDetId::XYMODE));   
+      return DetId(EEDetId(101 - myId.ix(), 101 - myId.iy(), 1, EEDetId::XYMODE));
       break;
     case 3:
-      return DetId(EEDetId(myId.ix(),101-myId.iy(),1,EEDetId::XYMODE));   
+      return DetId(EEDetId(myId.ix(), 101 - myId.iy(), 1, EEDetId::XYMODE));
       break;
     default:
       /*should never be reached*/
-      edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";    
-    }
-  return EEDetId(0);
-}
-
-
-DetId EcalTrigTowerConstituentsMap::wrapEcalTrigTowerDetId(const DetId& id) const
-{
-  EcalTrigTowerDetId etid(id);
-
-  if (! (etid.det() == DetId::Ecal && etid.subdetId() == EcalTriggerTower && etid.subDet() == EcalEndcap) )
-    return EcalTrigTowerDetId(0);
-  
-  switch((etid.iquadrant()-1)%4)
-    {
-    case 0:
-      return DetId(EcalTrigTowerDetId(1,EcalEndcap,etid.ietaAbs(),etid.iphi()));
-      break;
-    case 1:
-      return DetId(EcalTrigTowerDetId(1,EcalEndcap,etid.ietaAbs(),EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2 - etid.iphi() + 1));
-      break;
-    case 2:
-      return DetId(EcalTrigTowerDetId(1,EcalEndcap,etid.ietaAbs(),etid.iphi() - EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2 ));
-      break;
-    case 3:
-      return DetId(EcalTrigTowerDetId(1,EcalEndcap,etid.ietaAbs(),EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 4 - etid.iphi() + 1));
-      break;
-    default:
-      /*should never be reached*/
-      edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";    
-    }
-  return EcalTrigTowerDetId(0);
-}
-
-DetId EcalTrigTowerConstituentsMap::changeEEDetIdQuadrantAndZ(const DetId& fromid, const int& toQuadrant,const int& tozside) const
-{
-  if (! (fromid.det() == DetId::Ecal && fromid.subdetId() == EcalEndcap) )
-    return EEDetId(0);
-  
-  EEDetId myId(fromid);
-  int dQuadrant = toQuadrant-myId.iquadrant(); 
-  switch(dQuadrant%4){
-  case 0:
-    return DetId(EEDetId(myId.ix(),myId.iy(),tozside,EEDetId::XYMODE));
-    break;
-  case 1:
-    /* adjacent tower: they are symetric*/
-    return DetId(EEDetId(101-myId.ix(),myId.iy(),tozside,EEDetId::XYMODE));
-    break;
-  case 2:
-    /* opposite quadrant: they are identical*/
-    return DetId(EEDetId(101-myId.ix(),101-myId.iy(),tozside,EEDetId::XYMODE));   
-    break;
-  case 3:
-    /* adjacent tower: they are symetric*/
-    return DetId(EEDetId(myId.ix(),101-myId.iy(),tozside,EEDetId::XYMODE));   
-    break;
-  default:
-    /*should never be reached*/
-    edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";    
+      edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";
   }
   return EEDetId(0);
 }
 
-int EcalTrigTowerConstituentsMap::changeTowerQuadrant(int phiTower, int fromQuadrant, int toQuadrant) const{
+DetId EcalTrigTowerConstituentsMap::wrapEcalTrigTowerDetId(const DetId& id) const {
+  EcalTrigTowerDetId etid(id);
+
+  if (!(etid.det() == DetId::Ecal && etid.subdetId() == EcalTriggerTower && etid.subDet() == EcalEndcap))
+    return EcalTrigTowerDetId(0);
+
+  switch ((etid.iquadrant() - 1) % 4) {
+    case 0:
+      return DetId(EcalTrigTowerDetId(1, EcalEndcap, etid.ietaAbs(), etid.iphi()));
+      break;
+    case 1:
+      return DetId(EcalTrigTowerDetId(
+          1, EcalEndcap, etid.ietaAbs(), EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2 - etid.iphi() + 1));
+      break;
+    case 2:
+      return DetId(EcalTrigTowerDetId(
+          1, EcalEndcap, etid.ietaAbs(), etid.iphi() - EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2));
+      break;
+    case 3:
+      return DetId(EcalTrigTowerDetId(
+          1, EcalEndcap, etid.ietaAbs(), EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 4 - etid.iphi() + 1));
+      break;
+    default:
+      /*should never be reached*/
+      edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";
+  }
+  return EcalTrigTowerDetId(0);
+}
+
+DetId EcalTrigTowerConstituentsMap::changeEEDetIdQuadrantAndZ(const DetId& fromid,
+                                                              const int& toQuadrant,
+                                                              const int& tozside) const {
+  if (!(fromid.det() == DetId::Ecal && fromid.subdetId() == EcalEndcap))
+    return EEDetId(0);
+
+  EEDetId myId(fromid);
+  int dQuadrant = toQuadrant - myId.iquadrant();
+  switch (dQuadrant % 4) {
+    case 0:
+      return DetId(EEDetId(myId.ix(), myId.iy(), tozside, EEDetId::XYMODE));
+      break;
+    case 1:
+      /* adjacent tower: they are symetric*/
+      return DetId(EEDetId(101 - myId.ix(), myId.iy(), tozside, EEDetId::XYMODE));
+      break;
+    case 2:
+      /* opposite quadrant: they are identical*/
+      return DetId(EEDetId(101 - myId.ix(), 101 - myId.iy(), tozside, EEDetId::XYMODE));
+      break;
+    case 3:
+      /* adjacent tower: they are symetric*/
+      return DetId(EEDetId(myId.ix(), 101 - myId.iy(), tozside, EEDetId::XYMODE));
+      break;
+    default:
+      /*should never be reached*/
+      edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";
+  }
+  return EEDetId(0);
+}
+
+int EcalTrigTowerConstituentsMap::changeTowerQuadrant(int phiTower, int fromQuadrant, int toQuadrant) const {
   int newPhiTower = phiTower;
-  int dQuadrant = toQuadrant-fromQuadrant; 
-  
-  switch(dQuadrant%4){
-  case 0:
-    newPhiTower = phiTower;
-    break;
-  case 1:
-    /* adjacent tower: they are symetric*/
-    newPhiTower = EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2 - phiTower + 1;
-    break;
-  case 2:
-    /* opposite quadrant: they are identical*/
-    newPhiTower = phiTower + EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2;
-    break;
-  case 3:
-    /* adjacent tower: they are symetric*/
-    newPhiTower = EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 4 - phiTower + 1;
-    break;
-  default:
-    /*should never be reached*/
-    edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";    
+  int dQuadrant = toQuadrant - fromQuadrant;
+
+  switch (dQuadrant % 4) {
+    case 0:
+      newPhiTower = phiTower;
+      break;
+    case 1:
+      /* adjacent tower: they are symetric*/
+      newPhiTower = EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2 - phiTower + 1;
+      break;
+    case 2:
+      /* opposite quadrant: they are identical*/
+      newPhiTower = phiTower + EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 2;
+      break;
+    case 3:
+      /* adjacent tower: they are symetric*/
+      newPhiTower = EcalTrigTowerDetId::kEETowersInPhiPerQuadrant * 4 - phiTower + 1;
+      break;
+    default:
+      /*should never be reached*/
+      edm::LogError("EcalTrigTowerConstituentsMapError") << "This should never be reached. Profound error!";
   }
   return newPhiTower;
 }
 
 void EcalTrigTowerConstituentsMap::assign(const DetId& cell, const EcalTrigTowerDetId& tower) {
-  if (m_items.find(cell)!=m_items.end()) {
-    throw cms::Exception("EcalTrigTowers") << "Cell with id " << std::hex << cell.rawId() << std::dec << " is already mapped to a EcalTrigTower " << m_items.find(cell)->tower << std::endl;
+  if (m_items.find(cell) != m_items.end()) {
+    throw cms::Exception("EcalTrigTowers")
+        << "Cell with id " << std::hex << cell.rawId() << std::dec << " is already mapped to a EcalTrigTower "
+        << m_items.find(cell)->tower << std::endl;
   }
-  
-  m_items.insert(MapItem(cell,tower));
+
+  m_items.insert(MapItem(cell, tower));
 }
 
 std::vector<DetId> EcalTrigTowerConstituentsMap::constituentsOf(const EcalTrigTowerDetId& id) const {
   std::vector<DetId> items;
-  
-  if ( id.det() == DetId::Ecal && id.subdetId() == EcalTriggerTower && id.subDet() == EcalBarrel ) 
-    {
-      //--------------------
-      // Ecal Barrel
-      //--------------------
-      // trigger towers are 5x5 crystals in the barrel
-      int etaxtalMin=(id.ietaAbs()-1)*5+1;
-      int phixtalMin=((id.iphi()-1)*5+11)%360;
-      if(phixtalMin<=0)phixtalMin+=360;
-      int etaxtalMax=id.ietaAbs()*5;
-      int phixtalMax=((id.iphi())*5+10)%360;
-      if(phixtalMax<=0) phixtalMax+=360;
-      for(int e=etaxtalMin;e<=etaxtalMax;e++) 
-	for(int p=phixtalMin;p<=phixtalMax;p++) 
-	  items.emplace_back(DetId(EBDetId(id.zside()*e,p,EBDetId::ETAPHIMODE)));
+
+  if (id.det() == DetId::Ecal && id.subdetId() == EcalTriggerTower && id.subDet() == EcalBarrel) {
+    //--------------------
+    // Ecal Barrel
+    //--------------------
+    // trigger towers are 5x5 crystals in the barrel
+    int etaxtalMin = (id.ietaAbs() - 1) * 5 + 1;
+    int phixtalMin = ((id.iphi() - 1) * 5 + 11) % 360;
+    if (phixtalMin <= 0)
+      phixtalMin += 360;
+    int etaxtalMax = id.ietaAbs() * 5;
+    int phixtalMax = ((id.iphi()) * 5 + 10) % 360;
+    if (phixtalMax <= 0)
+      phixtalMax += 360;
+    for (int e = etaxtalMin; e <= etaxtalMax; e++)
+      for (int p = phixtalMin; p <= phixtalMax; p++)
+        items.emplace_back(DetId(EBDetId(id.zside() * e, p, EBDetId::ETAPHIMODE)));
+  } else if (id.det() == DetId::Ecal && id.subdetId() == EcalTriggerTower && id.subDet() == EcalEndcap) {
+    //--------------------
+    // Ecal Endcap
+    //--------------------
+    //DetId myId=wrapEcalTrigTowerDetId(id);
+    EcalTowerMap_by_towerDetId::const_iterator lb, ub;
+    //boost::tuples::tie(lb,ub)=get<1>(m_items).equal_range(myId);
+    boost::tuples::tie(lb, ub) = boost::get<1>(m_items).equal_range(id);
+    while (lb != ub) {
+      //EEDetId mappedId((*lb).cell);
+      //items.emplace_back(changeEEDetIdQuadrantAndZ(mappedId,id.iquadrant(),id.zside()));
+      items.emplace_back((*lb).cell);
+      ++lb;
     }
-  else if (id.det() == DetId::Ecal && id.subdetId() == EcalTriggerTower && id.subDet() == EcalEndcap) 
-    {
-      //--------------------
-      // Ecal Endcap
-      //--------------------
-      //DetId myId=wrapEcalTrigTowerDetId(id);  
-      EcalTowerMap_by_towerDetId::const_iterator lb,ub;
-      //boost::tuples::tie(lb,ub)=get<1>(m_items).equal_range(myId);
-      boost::tuples::tie(lb,ub)=boost::get<1>(m_items).equal_range(id);
-      while (lb!=ub)
-	{
-	  //EEDetId mappedId((*lb).cell);
-	  //items.emplace_back(changeEEDetIdQuadrantAndZ(mappedId,id.iquadrant(),id.zside()));
-	  items.emplace_back((*lb).cell);
-	  ++lb;
-	}
-    }
-  
+  }
+
   return items;
 }
-

--- a/Geometry/CaloTopology/src/FastTimeTopology.cc
+++ b/Geometry/CaloTopology/src/FastTimeTopology.cc
@@ -3,42 +3,35 @@
 
 //#define EDM_ML_DEBUG
 
-FastTimeTopology::FastTimeTopology(const FastTimeDDDConstants& hdcons,
-				   ForwardSubdetector sub,
-				   int type) : hdcons_(hdcons), subdet_(sub),
-					       type_(type) {
-  nEtaZ_      = hdcons_.numberEtaZ(type_);
-  nPhi_       = hdcons_.numberPhi(type_);
-  kHGhalf_    = nEtaZ_*nPhi_;
+FastTimeTopology::FastTimeTopology(const FastTimeDDDConstants& hdcons, ForwardSubdetector sub, int type)
+    : hdcons_(hdcons), subdet_(sub), type_(type) {
+  nEtaZ_ = hdcons_.numberEtaZ(type_);
+  nPhi_ = hdcons_.numberPhi(type_);
+  kHGhalf_ = nEtaZ_ * nPhi_;
   kHGeomHalf_ = 1;
-  kSizeForDenseIndexing = (unsigned int)(2*kHGhalf_);
+  kSizeForDenseIndexing = (unsigned int)(2 * kHGhalf_);
 #ifdef EDM_ML_DEBUG
-  std::cout << "FastTimeTopology initialized for subDetetcor " << subdet_
-	    << " Type " << type_ << "  with " << nEtaZ_ 
-	    << " cells along Z|Eta and " << nPhi_
-	    << " cells along phi: total channels " << kSizeForDenseIndexing 
-	    << ":" << (2*kHGeomHalf_) << std::endl;
+  std::cout << "FastTimeTopology initialized for subDetetcor " << subdet_ << " Type " << type_ << "  with " << nEtaZ_
+            << " cells along Z|Eta and " << nPhi_ << " cells along phi: total channels " << kSizeForDenseIndexing << ":"
+            << (2 * kHGeomHalf_) << std::endl;
 #endif
 }
 
 uint32_t FastTimeTopology::detId2denseId(const DetId& id) const {
-
   FastTimeTopology::DecodedDetId id_ = decode(id);
-  uint32_t idx = (uint32_t)(((id_.zside > 0) ? kHGhalf_ : 0) +
-			    ((id_.iEtaZ-1)*nPhi_+id_.iPhi-1));
+  uint32_t idx = (uint32_t)(((id_.zside > 0) ? kHGhalf_ : 0) + ((id_.iEtaZ - 1) * nPhi_ + id_.iPhi - 1));
   return idx;
 }
 
 DetId FastTimeTopology::denseId2detId(uint32_t hi) const {
-
   if (validHashIndex(hi)) {
     FastTimeTopology::DecodedDetId id_;
-    id_.iType  = type_;
-    id_.zside  = ((int)(hi)<kHGhalf_ ? -1 : 1);
-    int di     = ((int)(hi)%kHGhalf_);
-    int iPhi   = (di%nPhi_);
-    id_.iPhi   = iPhi+1;
-    id_.iEtaZ  = (((di-iPhi)/nPhi_)+1);
+    id_.iType = type_;
+    id_.zside = ((int)(hi) < kHGhalf_ ? -1 : 1);
+    int di = ((int)(hi) % kHGhalf_);
+    int iPhi = (di % nPhi_);
+    id_.iPhi = iPhi + 1;
+    id_.iEtaZ = (((di - iPhi) / nPhi_) + 1);
     return encode(id_);
   } else {
     return DetId(0);
@@ -46,84 +39,80 @@ DetId FastTimeTopology::denseId2detId(uint32_t hi) const {
 }
 
 uint32_t FastTimeTopology::detId2denseGeomId(const DetId& id) const {
-
   FastTimeTopology::DecodedDetId id_ = decode(id);
   uint32_t idx = (uint32_t)((id_.zside > 0) ? kHGeomHalf_ : 0);
   return idx;
 }
 
 bool FastTimeTopology::valid(const DetId& id) const {
-
   FastTimeTopology::DecodedDetId id_ = decode(id);
-  bool flag = hdcons_.isValidXY(id_.iType,id_.iEtaZ,id_.iPhi);
+  bool flag = hdcons_.isValidXY(id_.iType, id_.iEtaZ, id_.iPhi);
   return flag;
 }
 
-DetId FastTimeTopology::offsetBy(const DetId startId, int nrStepsX,
-				 int nrStepsY ) const {
-
-  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)){
-    DetId id = changeXY(startId,nrStepsX,nrStepsY);
-    if (valid(id)) return id;
+DetId FastTimeTopology::offsetBy(const DetId startId, int nrStepsX, int nrStepsY) const {
+  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)) {
+    DetId id = changeXY(startId, nrStepsX, nrStepsY);
+    if (valid(id))
+      return id;
   }
   return DetId(0);
 }
 
 DetId FastTimeTopology::switchZSide(const DetId startId) const {
-
-  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)){
+  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)) {
     FastTimeTopology::DecodedDetId id_ = decode(startId);
-    id_.zside  =-id_.zside;
-    DetId id   = encode(id_);
-    if (valid(id)) return id;
+    id_.zside = -id_.zside;
+    DetId id = encode(id_);
+    if (valid(id))
+      return id;
   }
   return DetId(0);
 }
 
 FastTimeTopology::DecodedDetId FastTimeTopology::geomDenseId2decId(const uint32_t& hi) const {
-
   FastTimeTopology::DecodedDetId id_;
   if (hi < totalGeomModules()) {
-    id_.zside  = ((int)(hi)<kHGeomHalf_ ? -1 : 1);
+    id_.zside = ((int)(hi) < kHGeomHalf_ ? -1 : 1);
   }
   return id_;
 }
 
 FastTimeTopology::DecodedDetId FastTimeTopology::decode(const DetId& startId) const {
-
   FastTimeTopology::DecodedDetId id_;
   FastTimeDetId id(startId);
-  id_.iPhi   = id.iphi();
-  id_.iEtaZ  = id.ieta();
-  id_.iType  = id.type();
-  id_.zside  = id.zside();
+  id_.iPhi = id.iphi();
+  id_.iEtaZ = id.ieta();
+  id_.iType = id.type();
+  id_.zside = id.zside();
   id_.subdet = id.subdetId();
   return id_;
 }
 
 DetId FastTimeTopology::encode(const FastTimeTopology::DecodedDetId& id_) const {
-
-  DetId id = FastTimeDetId(id_.iType,id_.iEtaZ,id_.iPhi,id_.zside);
+  DetId id = FastTimeDetId(id_.iType, id_.iEtaZ, id_.iPhi, id_.zside);
   return id;
 }
 
-DetId FastTimeTopology::changeXY(const DetId& id, int nrStepsX,
-				 int nrStepsY ) const {
-
+DetId FastTimeTopology::changeXY(const DetId& id, int nrStepsX, int nrStepsY) const {
   FastTimeTopology::DecodedDetId id_ = decode(id);
   int iEtaZ = id_.iEtaZ + nrStepsX;
-  int iPhi  = id_.iPhi  + nrStepsY;
-  if      (iPhi < 1)     iPhi += nPhi_;
-  else if (iPhi > nPhi_) iPhi -= nPhi_;
+  int iPhi = id_.iPhi + nrStepsY;
+  if (iPhi < 1)
+    iPhi += nPhi_;
+  else if (iPhi > nPhi_)
+    iPhi -= nPhi_;
   if (id_.iType == 1 && iEtaZ < 0) {
     iEtaZ = -iEtaZ;
     id_.zside = -id_.zside;
   }
-  id_.iPhi   = iPhi;
-  id_.iEtaZ  = iEtaZ;
+  id_.iPhi = iPhi;
+  id_.iEtaZ = iEtaZ;
   DetId nextPoint = encode(id_);
-  if (valid(nextPoint)) return nextPoint;
-  else                  return DetId(0);
+  if (valid(nextPoint))
+    return nextPoint;
+  else
+    return DetId(0);
 }
 
 #include "FWCore/Utilities/interface/typelookup.h"

--- a/Geometry/CaloTopology/src/HGCalTopology.cc
+++ b/Geometry/CaloTopology/src/HGCalTopology.cc
@@ -8,509 +8,422 @@
 
 //#define EDM_ML_DEBUG
 
-HGCalTopology::HGCalTopology(const HGCalDDDConstants& hdcons, 
-			     int det) : hdcons_(hdcons) {
-
-  sectors_  = hdcons_.sectors();
-  layers_   = hdcons_.layers(true);
-  cells_    = hdcons_.maxCells(true);
-  mode_     = hdcons_.geomMode();
-  cellMax_  = hdcons_.maxCellUV();
+HGCalTopology::HGCalTopology(const HGCalDDDConstants& hdcons, int det) : hdcons_(hdcons) {
+  sectors_ = hdcons_.sectors();
+  layers_ = hdcons_.layers(true);
+  cells_ = hdcons_.maxCells(true);
+  mode_ = hdcons_.geomMode();
+  cellMax_ = hdcons_.maxCellUV();
   waferOff_ = hdcons_.waferUVMax();
-  waferMax_ = 2*waferOff_ + 1;
-  kHGhalf_  = sectors_*layers_*cells_ ;
+  waferMax_ = 2 * waferOff_ + 1;
+  kHGhalf_ = sectors_ * layers_ * cells_;
   firstLay_ = hdcons_.firstLayer();
-  if ((mode_ == HGCalGeometryMode::Hexagon) || 
-      (mode_ == HGCalGeometryMode::HexagonFull)) {
-    det_        = DetId::Forward;
-    subdet_     = (ForwardSubdetector)(det);
-    kHGeomHalf_ = sectors_*layers_;
-    types_      = 2;
+  if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
+    det_ = DetId::Forward;
+    subdet_ = (ForwardSubdetector)(det);
+    kHGeomHalf_ = sectors_ * layers_;
+    types_ = 2;
   } else if (det == (int)(DetId::Forward)) {
-    det_        = DetId::Forward;
-    subdet_     = HFNose;
-    kHGeomHalf_ = sectors_*layers_;
-    types_      = 3;
+    det_ = DetId::Forward;
+    subdet_ = HFNose;
+    kHGeomHalf_ = sectors_ * layers_;
+    types_ = 3;
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-    det_        = (DetId::Detector)(det);
-    subdet_     = ForwardEmpty;
-    kHGeomHalf_ = sectors_*layers_*cellMax_;
-    types_      = 2;
+    det_ = (DetId::Detector)(det);
+    subdet_ = ForwardEmpty;
+    kHGeomHalf_ = sectors_ * layers_ * cellMax_;
+    types_ = 2;
   } else {
-    det_        = (DetId::Detector)(det);
-    subdet_     = ForwardEmpty;
-    kHGeomHalf_ = sectors_*layers_;
-    types_      = 3;
+    det_ = (DetId::Detector)(det);
+    subdet_ = ForwardEmpty;
+    kHGeomHalf_ = sectors_ * layers_;
+    types_ = 3;
   }
-  kSizeForDenseIndexing = (unsigned int)(2*kHGhalf_);
+  kSizeForDenseIndexing = (unsigned int)(2 * kHGhalf_);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "HGCalTopology initialized for detector " 
-				<< det_ << ":" << subdet_ << " having " 
-				<< sectors_  << " Sectors, " << layers_ 
-				<< " Layers from " << firstLay_ << ", " 
-				<< cells_ << " cells and total channels " 
-				<< kSizeForDenseIndexing << ":"
-				<< (2*kHGeomHalf_) << std::endl;
+  edm::LogVerbatim("HGCalGeom") << "HGCalTopology initialized for detector " << det_ << ":" << subdet_ << " having "
+                                << sectors_ << " Sectors, " << layers_ << " Layers from " << firstLay_ << ", " << cells_
+                                << " cells and total channels " << kSizeForDenseIndexing << ":" << (2 * kHGeomHalf_)
+                                << std::endl;
 #endif
 }
 
 unsigned int HGCalTopology::allGeomModules() const {
-  return ((mode_ == HGCalGeometryMode::Trapezoid) ? 
-	  (unsigned int)(2*hdcons_.numberCells(true)) : 
-	  (unsigned int)(2*hdcons_.wafers()));
+  return ((mode_ == HGCalGeometryMode::Trapezoid) ? (unsigned int)(2 * hdcons_.numberCells(true))
+                                                  : (unsigned int)(2 * hdcons_.wafers()));
 }
 
 std::vector<DetId> HGCalTopology::neighbors(const DetId& idin) const {
   std::vector<DetId> ids;
   HGCalTopology::DecodedDetId id = decode(idin);
-  if ((mode_ == HGCalGeometryMode::Hexagon8) || 
-      (mode_ == HGCalGeometryMode::Hexagon8Full)) {
-    HGCalDDDConstants::CellType celltype = hdcons_.cellType(id.iType,id.iCell1,
-							    id.iCell2);
+  if ((mode_ == HGCalGeometryMode::Hexagon8) || (mode_ == HGCalGeometryMode::Hexagon8Full)) {
+    HGCalDDDConstants::CellType celltype = hdcons_.cellType(id.iType, id.iCell1, id.iCell2);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Type:WaferU:WaferV " << id.iType << ":"
-				  << id.iCell1 << ":" << id.iCell2 
-				  << " CellType " << static_cast<std::underlying_type<HGCalDDDConstants::CellType>::type>(celltype);
+    edm::LogVerbatim("HGCalGeom") << "Type:WaferU:WaferV " << id.iType << ":" << id.iCell1 << ":" << id.iCell2
+                                  << " CellType "
+                                  << static_cast<std::underlying_type<HGCalDDDConstants::CellType>::type>(celltype);
 #endif
     switch (celltype) {
-    case(HGCalDDDConstants::CellType::CentralType): {
-      // cell within the wafer
+      case (HGCalDDDConstants::CellType::CentralType): {
+        // cell within the wafer
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 0";
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 0";
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::BottomLeftEdge): {
-      // bottom left edge
-      int wu1(id.iSec1), wv1(id.iSec2-1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::BottomLeftEdge): {
+        // bottom left edge
+        int wu1(id.iSec1), wv1(id.iSec2 - 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 1 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 1 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,2*N1-1,v1+N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,2*N1-1,v1+N1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::LeftEdge): {
-      // left edege
-      int wu1(id.iSec1+1), wv1(id.iSec2);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int u1 = hdcons_.modifyUV(id.iCell1,id.iType,t1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 2 * N1 - 1, v1 + N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 2 * N1 - 1, v1 + N1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::LeftEdge): {
+        // left edege
+        int wu1(id.iSec1 + 1), wv1(id.iSec2);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int u1 = hdcons_.modifyUV(id.iCell1, id.iType, t1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 2 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << u1;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 2 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << u1;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1+N1,  2*N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1+N1-1,2*N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::TopLeftEdge): {
-      // top left edge
-      int wu1(id.iSec1+1), wv1(id.iSec2+1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 + N1, 2 * N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 + N1 - 1, 2 * N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::TopLeftEdge): {
+        // top left edge
+        int wu1(id.iSec1 + 1), wv1(id.iSec2 + 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 3 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 3 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,v1+1,v1+N1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,v1,v1+N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::TopRightEdge): {
-      // top right edge
-      int wu1(id.iSec1), wv1(id.iSec2+1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, v1 + 1, v1 + N1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, v1, v1 + N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::TopRightEdge): {
+        // top right edge
+        int wu1(id.iSec1), wv1(id.iSec2 + 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 4 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 4 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,0,v1-N1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,0,v1-N1+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::RightEdge): {
-      // right edge
-      int wu1(id.iSec1-1), wv1(id.iSec2);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int u1 = hdcons_.modifyUV(id.iCell1,id.iType,t1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 0, v1 - N1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 0, v1 - N1 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::RightEdge): {
+        // right edge
+        int wu1(id.iSec1 - 1), wv1(id.iSec2);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int u1 = hdcons_.modifyUV(id.iCell1, id.iType, t1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 5 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << u1;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 5 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << u1;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1-N1,0);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1-N1+1,0);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::BottomRightEdge): {
-      // bottom right edge
-      int wu1(id.iSec1-1), wv1(id.iSec2-1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int u1 = hdcons_.modifyUV(id.iCell1,id.iType,t1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 - N1, 0);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 - N1 + 1, 0);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::BottomRightEdge): {
+        // bottom right edge
+        int wu1(id.iSec1 - 1), wv1(id.iSec2 - 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int u1 = hdcons_.modifyUV(id.iCell1, id.iType, t1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 6 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << u1;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 6 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << u1;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1+N1-1,u1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1+N1,u1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::BottomCorner): {
-      // bottom corner
-      int wu1(id.iSec1), wv1(id.iSec2-1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
-      int wu2(id.iSec1-1), wv2(id.iSec2-1);
-      int t2 = hdcons_.getTypeHex(id.iLay,wu2,wv2);
-      int N2 = hdcons_.getUVMax(t2);
-      int u2 = hdcons_.modifyUV(id.iCell1,id.iType,t2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 + N1 - 1, u1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 + N1, u1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::BottomCorner): {
+        // bottom corner
+        int wu1(id.iSec1), wv1(id.iSec2 - 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
+        int wu2(id.iSec1 - 1), wv2(id.iSec2 - 1);
+        int t2 = hdcons_.getTypeHex(id.iLay, wu2, wv2);
+        int N2 = hdcons_.getUVMax(t2);
+        int u2 = hdcons_.modifyUV(id.iCell1, id.iType, t2);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 11 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1 << ":" << t2 << ":" << N2 << ":"
-				    << u2;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 11 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1 << ":" << t2
+                                      << ":" << N2 << ":" << u2;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,2*N1-1,v1+N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,2*N1-1,v1+N1);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,u2+N2,u2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::BottomLeftCorner): {
-      // bottom left corner
-      int wu1(id.iSec1+1), wv1(id.iSec2);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int u1 = hdcons_.modifyUV(id.iCell1,id.iType,t1);
-      int wu2(id.iSec1), wv2(id.iSec2-1);
-      int t2 = hdcons_.getTypeHex(id.iLay,wu2,wv2);
-      int N2 = hdcons_.getUVMax(t2);
-      int v2 = hdcons_.modifyUV(id.iCell2,id.iType,t2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 2 * N1 - 1, v1 + N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 2 * N1 - 1, v1 + N1);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, u2 + N2, u2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::BottomLeftCorner): {
+        // bottom left corner
+        int wu1(id.iSec1 + 1), wv1(id.iSec2);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int u1 = hdcons_.modifyUV(id.iCell1, id.iType, t1);
+        int wu2(id.iSec1), wv2(id.iSec2 - 1);
+        int t2 = hdcons_.getTypeHex(id.iLay, wu2, wv2);
+        int N2 = hdcons_.getUVMax(t2);
+        int v2 = hdcons_.modifyUV(id.iCell2, id.iType, t2);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 12 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << u1 << ":" << t2 << ":" << N2 << ":"
-				    << v2;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 12 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << u1 << ":" << t2
+                                      << ":" << N2 << ":" << v2;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1+N1,2*N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,2*N2-1,v2+N2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,2*N2-1,v2+N2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::TopLeftCorner): {
-      // top left corner
-      int wu1(id.iSec1+1), wv1(id.iSec2+1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
-      int wu2(id.iSec1+1), wv2(id.iSec2);
-      int t2 = hdcons_.getTypeHex(id.iLay,wu2,wv2);
-      int N2 = hdcons_.getUVMax(t2);
-      int u2 = hdcons_.modifyUV(id.iCell1,id.iType,t2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 + N1, 2 * N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, 2 * N2 - 1, v2 + N2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, 2 * N2 - 1, v2 + N2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::TopLeftCorner): {
+        // top left corner
+        int wu1(id.iSec1 + 1), wv1(id.iSec2 + 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
+        int wu2(id.iSec1 + 1), wv2(id.iSec2);
+        int t2 = hdcons_.getTypeHex(id.iLay, wu2, wv2);
+        int N2 = hdcons_.getUVMax(t2);
+        int u2 = hdcons_.modifyUV(id.iCell1, id.iType, t2);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 13 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1 << ":" << t2 << ":" << N2 << ":"
-				    << u2;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 13 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1 << ":" << t2
+                                      << ":" << N2 << ":" << u2;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,v1+1,N1+v1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,v1,N1+v1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,u2+N2-1,2*N2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::TopCorner): {
-      // top corner
-      int wu1(id.iSec1+1), wv1(id.iSec2+1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
-      int wu2(id.iSec1), wv2(id.iSec2+1);
-      int t2 = hdcons_.getTypeHex(id.iLay,wu2,wv2);
-      int N2 = hdcons_.getUVMax(t2);
-      int v2 = hdcons_.modifyUV(id.iCell2,id.iType,t2);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, v1 + 1, N1 + v1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, v1, N1 + v1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, u2 + N2 - 1, 2 * N2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::TopCorner): {
+        // top corner
+        int wu1(id.iSec1 + 1), wv1(id.iSec2 + 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
+        int wu2(id.iSec1), wv2(id.iSec2 + 1);
+        int t2 = hdcons_.getTypeHex(id.iLay, wu2, wv2);
+        int N2 = hdcons_.getUVMax(t2);
+        int v2 = hdcons_.modifyUV(id.iCell2, id.iType, t2);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 14 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1 << ":" << t2 << ":" << N2 << ":"
-				    << v2;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 14 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1 << ":" << t2
+                                      << ":" << N2 << ":" << v2;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,v1+1,v1+N1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,v1,v1+N1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2+1);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,0,v2-N2+1);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::TopRightCorner): {
-      // top right corner
-      int wu1(id.iSec1), wv1(id.iSec2+1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int v1 = hdcons_.modifyUV(id.iCell2,id.iType,t1);
-      int wu2(id.iSec1-1), wv2(id.iSec2);
-      int t2 = hdcons_.getTypeHex(id.iLay,wu2,wv2);
-      int N2 = hdcons_.getUVMax(t2);
-      int u2 = hdcons_.modifyUV(id.iCell1,id.iType,t2);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, v1 + 1, v1 + N1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, v1, v1 + N1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 + 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, 0, v2 - N2 + 1);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::TopRightCorner): {
+        // top right corner
+        int wu1(id.iSec1), wv1(id.iSec2 + 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int v1 = hdcons_.modifyUV(id.iCell2, id.iType, t1);
+        int wu2(id.iSec1 - 1), wv2(id.iSec2);
+        int t2 = hdcons_.getTypeHex(id.iLay, wu2, wv2);
+        int N2 = hdcons_.getUVMax(t2);
+        int u2 = hdcons_.modifyUV(id.iCell1, id.iType, t2);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 15 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << v1 << ":" << t2 << ":" << N2 << ":"
-				    << u2;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 15 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << v1 << ":" << t2
+                                      << ":" << N2 << ":" << u2;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,0,v1-N1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,u2-N2,0);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,u2-N2+1,0);
-      break;
-    }
-    case(HGCalDDDConstants::CellType::BottomRightCorner): {
-      // bottom right corner
-      int wu1(id.iSec1-1), wv1(id.iSec2-1);
-      int t1 = hdcons_.getTypeHex(id.iLay,wu1,wv1);
-      int N1 = hdcons_.getUVMax(t1);
-      int u1 = hdcons_.modifyUV(id.iCell1,id.iType,t1);
-      int wu2(id.iSec1-1), wv2(id.iSec2);
-      int t2 = hdcons_.getTypeHex(id.iLay,wu2,wv2);
-      int N2 = hdcons_.getUVMax(t2);
-      int u2 = hdcons_.modifyUV(id.iCell1,id.iType,t2);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, 0, v1 - N1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, u2 - N2, 0);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, u2 - N2 + 1, 0);
+        break;
+      }
+      case (HGCalDDDConstants::CellType::BottomRightCorner): {
+        // bottom right corner
+        int wu1(id.iSec1 - 1), wv1(id.iSec2 - 1);
+        int t1 = hdcons_.getTypeHex(id.iLay, wu1, wv1);
+        int N1 = hdcons_.getUVMax(t1);
+        int u1 = hdcons_.modifyUV(id.iCell1, id.iType, t1);
+        int wu2(id.iSec1 - 1), wv2(id.iSec2);
+        int t2 = hdcons_.getTypeHex(id.iLay, wu2, wv2);
+        int N2 = hdcons_.getUVMax(t2);
+        int u2 = hdcons_.modifyUV(id.iCell1, id.iType, t2);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Cell Type 16 " << ":" << wu1 << ":"
-				    << wv1 << ":" << t1 << ":" << N1 << ":" 
-				    << u1 << ":" << t2 << ":" << N2 << ":"
-				    << u2;
+        edm::LogVerbatim("HGCalGeom") << "Cell Type 16 "
+                                      << ":" << wu1 << ":" << wv1 << ":" << t1 << ":" << N1 << ":" << u1 << ":" << t2
+                                      << ":" << N2 << ":" << u2;
 #endif
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1+1,id.iCell2);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,id.iType,id.iLay,id.iSec1,id.iSec2,
-		      id.iCell1-1,id.iCell2-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t1,id.iLay,wu1,wv1,u1+N1-1,u1-1);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,u2-N2,0);
-      addHGCSiliconId(ids,id.det,id.zSide,t2,id.iLay,wu2,wv2,u2-N2+1,0);
-      break;
-    }
-    default:
-      // Not valid u, v
-      int N = hdcons_.getUVMax(id.iType);
-      edm::LogWarning("HGCalGeom") << "u:v " << id.iCell1 << ":" << id.iCell2 
-				   << " Tests " << (id.iCell1 > 2*N-1) << ":"
-				   << (id.iCell2 > 2*N-1) << ":" 
-				   << (id.iCell2 >= (id.iCell1+N)) << ":" 
-				   << (id.iCell1 > (id.iCell2+N)) << " ERROR";
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 + 1, id.iCell2);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, id.iType, id.iLay, id.iSec1, id.iSec2, id.iCell1 - 1, id.iCell2 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t1, id.iLay, wu1, wv1, u1 + N1 - 1, u1 - 1);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, u2 - N2, 0);
+        addHGCSiliconId(ids, id.det, id.zSide, t2, id.iLay, wu2, wv2, u2 - N2 + 1, 0);
+        break;
+      }
+      default:
+        // Not valid u, v
+        int N = hdcons_.getUVMax(id.iType);
+        edm::LogWarning("HGCalGeom") << "u:v " << id.iCell1 << ":" << id.iCell2 << " Tests " << (id.iCell1 > 2 * N - 1)
+                                     << ":" << (id.iCell2 > 2 * N - 1) << ":" << (id.iCell2 >= (id.iCell1 + N)) << ":"
+                                     << (id.iCell1 > (id.iCell2 + N)) << " ERROR";
     }
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-    int iphi1 = (id.iCell1 > 1) ? id.iCell1-1 : hdcons_.getUVMax(id.iType);
-    int iphi2 = (id.iCell1 < hdcons_.getUVMax(id.iType)) ? id.iCell1+1 : 1;
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1-1,id.iCell1);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1-1,iphi1);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1,iphi1);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1+1,iphi1);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1+1,id.iCell1);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1+1,iphi2);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1,iphi2);
-    addHGCSCintillatorId(ids,id.zSide,id.iType,id.iLay,id.iSec1-1,iphi2);
+    int iphi1 = (id.iCell1 > 1) ? id.iCell1 - 1 : hdcons_.getUVMax(id.iType);
+    int iphi2 = (id.iCell1 < hdcons_.getUVMax(id.iType)) ? id.iCell1 + 1 : 1;
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1 - 1, id.iCell1);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1 - 1, iphi1);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1, iphi1);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1 + 1, iphi1);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1 + 1, id.iCell1);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1 + 1, iphi2);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1, iphi2);
+    addHGCSCintillatorId(ids, id.zSide, id.iType, id.iLay, id.iSec1 - 1, iphi2);
   }
   return ids;
 }
- 
 
 uint32_t HGCalTopology::detId2denseId(const DetId& idin) const {
-
   HGCalTopology::DecodedDetId id = decode(idin);
   uint32_t idx;
-  if ((mode_ == HGCalGeometryMode::Hexagon) || 
-      (mode_ == HGCalGeometryMode::HexagonFull)) {
+  if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
     int type = (id.iType > 0) ? 1 : 0;
     idx = (uint32_t)(((id.zSide > 0) ? kHGhalf_ : 0) +
-		     ((((id.iCell1-1)*layers_+id.iLay-1)*sectors_+
-		       id.iSec1)*types_+type));
+                     ((((id.iCell1 - 1) * layers_ + id.iLay - 1) * sectors_ + id.iSec1) * types_ + type));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Input Hex " << id.zSide << ":" << id.iLay
-				  << ":" << id.iSec1 << ":" << id.iCell1
-				  << ":" << id.iType << " Constants " 
-				  << kHGeomHalf_ << ":" << layers_ << ":" 
-				  << sectors_ << ":" << types_<< " o/p " 
-				  << idx;
+    edm::LogVerbatim("HGCalGeom") << "Input Hex " << id.zSide << ":" << id.iLay << ":" << id.iSec1 << ":" << id.iCell1
+                                  << ":" << id.iType << " Constants " << kHGeomHalf_ << ":" << layers_ << ":"
+                                  << sectors_ << ":" << types_ << " o/p " << idx;
 #endif
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-    idx = (uint32_t)(((id.zSide > 0) ? kHGhalf_ : 0) +
-		     ((((id.iCell1-1)*layers_+id.iLay-firstLay_)*sectors_+
-		       id.iSec1-1)*types_+id.iType));
+    idx =
+        (uint32_t)(((id.zSide > 0) ? kHGhalf_ : 0) +
+                   ((((id.iCell1 - 1) * layers_ + id.iLay - firstLay_) * sectors_ + id.iSec1 - 1) * types_ + id.iType));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Input Trap " << id.zSide << ":" << id.iLay 
-				  << ":" << id.iSec1 << ":" << id.iCell1
-				  << ":" << id.iType << " Constants " 
-				  << kHGeomHalf_ << ":" << layers_ << ":" 
-				  << sectors_ << ":" << types_<< " o/p " 
-				  << idx;
+    edm::LogVerbatim("HGCalGeom") << "Input Trap " << id.zSide << ":" << id.iLay << ":" << id.iSec1 << ":" << id.iCell1
+                                  << ":" << id.iType << " Constants " << kHGeomHalf_ << ":" << layers_ << ":"
+                                  << sectors_ << ":" << types_ << " o/p " << idx;
 #endif
   } else {
-    idx = (uint32_t)(((id.zSide > 0) ? kHGhalf_ : 0) +
-		     (((((id.iCell1*cellMax_+id.iCell2)*layers_+
-			 id.iLay-1)*waferMax_+id.iSec1+waferOff_)*
-		       waferMax_+id.iSec2+waferOff_)*types_+id.iType));
+    idx =
+        (uint32_t)(((id.zSide > 0) ? kHGhalf_ : 0) +
+                   (((((id.iCell1 * cellMax_ + id.iCell2) * layers_ + id.iLay - 1) * waferMax_ + id.iSec1 + waferOff_) *
+                         waferMax_ +
+                     id.iSec2 + waferOff_) *
+                        types_ +
+                    id.iType));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Input Hex8 " << id.zSide << ":" << id.iLay 
-				  << ":" << id.iSec1 << ":" << id.iSec2 << ":"
-				  << id.iCell1 << ":" << id.iCell2 << ":"
-				  << id.iType << " Constants " << kHGeomHalf_ 
-				  << ":" << cellMax_ << ":" << layers_ << ":" 
-				  << waferMax_ << ":" << waferOff_ << ":" 
-				  << types_<< " o/p " << idx;
+    edm::LogVerbatim("HGCalGeom") << "Input Hex8 " << id.zSide << ":" << id.iLay << ":" << id.iSec1 << ":" << id.iSec2
+                                  << ":" << id.iCell1 << ":" << id.iCell2 << ":" << id.iType << " Constants "
+                                  << kHGeomHalf_ << ":" << cellMax_ << ":" << layers_ << ":" << waferMax_ << ":"
+                                  << waferOff_ << ":" << types_ << " o/p " << idx;
 #endif
   }
   return idx;
 }
 
 DetId HGCalTopology::denseId2detId(uint32_t hi) const {
-
   HGCalTopology::DecodedDetId id;
   if (validHashIndex(hi)) {
-    id.zSide  = ((int)(hi)<kHGhalf_ ? -1 : 1);
-    int di     = ((int)(hi)%kHGhalf_);
-    if ((mode_ == HGCalGeometryMode::Hexagon) || 
-	(mode_ == HGCalGeometryMode::HexagonFull)) {
-      int type  = (di%types_);
+    id.zSide = ((int)(hi) < kHGhalf_ ? -1 : 1);
+    int di = ((int)(hi) % kHGhalf_);
+    if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
+      int type = (di % types_);
       id.iType = (type == 0 ? -1 : 1);
-      id.iSec1 = (((di-type)/types_)%sectors_);
-      id.iLay  = (((((di-type)/types_)-id.iSec1+1)/sectors_)%layers_+1);
-      id.iCell1= (((((di-type)/types_)-id.iSec1+1)/sectors_-id.iLay+1)/layers_+1);
+      id.iSec1 = (((di - type) / types_) % sectors_);
+      id.iLay = (((((di - type) / types_) - id.iSec1 + 1) / sectors_) % layers_ + 1);
+      id.iCell1 = (((((di - type) / types_) - id.iSec1 + 1) / sectors_ - id.iLay + 1) / layers_ + 1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Input Hex " << hi << " o/p " << id.zSide 
-				    << ":" << id.iLay << ":" << id.iType
-				    << ":" << id.iSec1 << ":" << id.iCell1;
+      edm::LogVerbatim("HGCalGeom") << "Input Hex " << hi << " o/p " << id.zSide << ":" << id.iLay << ":" << id.iType
+                                    << ":" << id.iSec1 << ":" << id.iCell1;
 #endif
     } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-      int type  = (di%types_);
+      int type = (di % types_);
       id.iType = type;
-      id.iSec1 = (((di-type)/types_)%sectors_)+1;
-      id.iLay  = (((((di-type)/types_)-id.iSec1+1)/sectors_)%layers_+firstLay_);
-      id.iCell1= (((((di-type)/types_)-id.iSec1+1)/sectors_-id.iLay+firstLay_)/layers_+1);
+      id.iSec1 = (((di - type) / types_) % sectors_) + 1;
+      id.iLay = (((((di - type) / types_) - id.iSec1 + 1) / sectors_) % layers_ + firstLay_);
+      id.iCell1 = (((((di - type) / types_) - id.iSec1 + 1) / sectors_ - id.iLay + firstLay_) / layers_ + 1);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Input Trap " << hi << " o/p " << id.zSide 
-				    << ":" << id.iLay << ":" << id.iType
-				    << ":" << id.iSec1 << ":" << id.iCell1;
+      edm::LogVerbatim("HGCalGeom") << "Input Trap " << hi << " o/p " << id.zSide << ":" << id.iLay << ":" << id.iType
+                                    << ":" << id.iSec1 << ":" << id.iCell1;
 #endif
     } else {
-      int type  = (di%types_);
+      int type = (di % types_);
       id.iType = type;
-      di        = (di-type)/types_;
-      id.iSec2 = (di%waferMax_)-waferOff_;
-      di        = (di-id.iSec2-waferOff_)/waferMax_;
-      id.iSec1 = (di%waferMax_)-waferOff_;
-      di        = (di-id.iSec1-waferOff_)/waferMax_;
-      id.iLay  = (di%layers_)+1;
-      di        = (di-id.iLay+1)/layers_;
-      id.iCell2 = (di%cellMax_);
-      id.iCell1 = (di-id.iCell2)/cellMax_;
+      di = (di - type) / types_;
+      id.iSec2 = (di % waferMax_) - waferOff_;
+      di = (di - id.iSec2 - waferOff_) / waferMax_;
+      id.iSec1 = (di % waferMax_) - waferOff_;
+      di = (di - id.iSec1 - waferOff_) / waferMax_;
+      id.iLay = (di % layers_) + 1;
+      di = (di - id.iLay + 1) / layers_;
+      id.iCell2 = (di % cellMax_);
+      id.iCell1 = (di - id.iCell2) / cellMax_;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Input Hex8 " << hi << " o/p " << id.zSide 
-				    << ":" << id.iLay << ":" << id.iType
-				    << ":" << id.iSec1 << ":" << id.iSec2
-				    << ":" << id.iCell1 << ":" << id.iCell2;
+      edm::LogVerbatim("HGCalGeom") << "Input Hex8 " << hi << " o/p " << id.zSide << ":" << id.iLay << ":" << id.iType
+                                    << ":" << id.iSec1 << ":" << id.iSec2 << ":" << id.iCell1 << ":" << id.iCell2;
 #endif
     }
   }
@@ -518,243 +431,203 @@ DetId HGCalTopology::denseId2detId(uint32_t hi) const {
 }
 
 uint32_t HGCalTopology::detId2denseGeomId(const DetId& idin) const {
-
   HGCalTopology::DecodedDetId id = decode(idin);
   uint32_t idx;
-  if ((mode_ == HGCalGeometryMode::Hexagon) || 
-      (mode_ == HGCalGeometryMode::HexagonFull)) {
-    idx = (uint32_t)(((id.zSide > 0) ? kHGeomHalf_ : 0) +
-		     (id.iLay-1)*sectors_+id.iSec1);
+  if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
+    idx = (uint32_t)(((id.zSide > 0) ? kHGeomHalf_ : 0) + (id.iLay - 1) * sectors_ + id.iSec1);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Geom Hex I/P " << id.zSide << ":" 
-				  << id.iLay << ":" << id.iSec1 << ":" 
-				  << id.iType << " Constants " << kHGeomHalf_ 
-				  << ":" << layers_ << ":" << sectors_ 
-				  << " o/p " << idx;
+    edm::LogVerbatim("HGCalGeom") << "Geom Hex I/P " << id.zSide << ":" << id.iLay << ":" << id.iSec1 << ":" << id.iType
+                                  << " Constants " << kHGeomHalf_ << ":" << layers_ << ":" << sectors_ << " o/p "
+                                  << idx;
 #endif
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
     idx = (uint32_t)(((id.zSide > 0) ? kHGeomHalf_ : 0) +
-		     (((id.iLay-firstLay_)*sectors_+id.iSec1-1)*cellMax_+
-		      id.iCell1-1));
+                     (((id.iLay - firstLay_) * sectors_ + id.iSec1 - 1) * cellMax_ + id.iCell1 - 1));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Geom Trap I/P " << id.zSide << ":" 
-				  << id.iLay  << ":" << id.iSec1 << ":" 
-				  << id.iCell1 << ":" << id.iType 
-				  << " Constants " << kHGeomHalf_ << ":" 
-				  << layers_ << ":" << firstLay_ << ":" 
-				  << sectors_ << ":" << cellMax_ 
-				  << " o/p " << idx;
+    edm::LogVerbatim("HGCalGeom") << "Geom Trap I/P " << id.zSide << ":" << id.iLay << ":" << id.iSec1 << ":"
+                                  << id.iCell1 << ":" << id.iType << " Constants " << kHGeomHalf_ << ":" << layers_
+                                  << ":" << firstLay_ << ":" << sectors_ << ":" << cellMax_ << " o/p " << idx;
 #endif
   } else {
     idx = (uint32_t)(((id.zSide > 0) ? kHGeomHalf_ : 0) +
-		     (((id.iLay-1)*waferMax_+id.iSec1+waferOff_)*waferMax_+
-		      id.iSec2+waferOff_));
+                     (((id.iLay - 1) * waferMax_ + id.iSec1 + waferOff_) * waferMax_ + id.iSec2 + waferOff_));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Geom Hex8 I/P " << id.zSide << ":" 
-				  << id.iLay  << ":" << id.iSec1 << ":" 
-				  << id.iSec2 << ":" << id.iType 
-				  << " Constants " << kHGeomHalf_ << ":" 
-				  << layers_ << ":" << waferMax_ << ":"
-				  << waferOff_ << " o/p " << idx;
+    edm::LogVerbatim("HGCalGeom") << "Geom Hex8 I/P " << id.zSide << ":" << id.iLay << ":" << id.iSec1 << ":"
+                                  << id.iSec2 << ":" << id.iType << " Constants " << kHGeomHalf_ << ":" << layers_
+                                  << ":" << waferMax_ << ":" << waferOff_ << " o/p " << idx;
 #endif
   }
   return idx;
 }
 
 bool HGCalTopology::valid(const DetId& idin) const {
-
   HGCalTopology::DecodedDetId id = decode(idin);
   bool flag;
-  if ((mode_ == HGCalGeometryMode::Hexagon) || 
-	     (mode_ == HGCalGeometryMode::HexagonFull)) {
-    flag = (idin.det() == det_ && idin.subdetId() == (int)(subdet_) &&
-	    id.iCell1 >= 0 && id.iCell1 < cells_ && id.iLay > 0 && 
-	    id.iLay <= layers_ && id.iSec1 >= 0 && id.iSec1 <= sectors_);
-    if (flag) flag = hdcons_.isValidHex(id.iLay,id.iSec1,id.iCell1,true);
+  if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
+    flag = (idin.det() == det_ && idin.subdetId() == (int)(subdet_) && id.iCell1 >= 0 && id.iCell1 < cells_ &&
+            id.iLay > 0 && id.iLay <= layers_ && id.iSec1 >= 0 && id.iSec1 <= sectors_);
+    if (flag)
+      flag = hdcons_.isValidHex(id.iLay, id.iSec1, id.iCell1, true);
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-    flag = ((idin.det() == det_) && 
-	    hdcons_.isValidTrap(id.iLay,id.iSec1,id.iCell1));
+    flag = ((idin.det() == det_) && hdcons_.isValidTrap(id.iLay, id.iSec1, id.iCell1));
   } else {
-    flag = ((idin.det() == det_) && 
-	    hdcons_.isValidHex8(id.iLay,id.iSec1,id.iSec2,id.iCell1,id.iCell2));
+    flag = ((idin.det() == det_) && hdcons_.isValidHex8(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2));
   }
   return flag;
 }
 
-DetId HGCalTopology::offsetBy(const DetId startId, int nrStepsX,
-			      int nrStepsY ) const {
-
-  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)){
-    DetId id = changeXY(startId,nrStepsX,nrStepsY);
-    if (valid(id)) return id;
+DetId HGCalTopology::offsetBy(const DetId startId, int nrStepsX, int nrStepsY) const {
+  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)) {
+    DetId id = changeXY(startId, nrStepsX, nrStepsY);
+    if (valid(id))
+      return id;
   }
   return DetId(0);
 }
 
 DetId HGCalTopology::switchZSide(const DetId startId) const {
-
   HGCalTopology::DecodedDetId id_ = decode(startId);
-  id_.zSide  =-id_.zSide;
-  DetId id   = encode(id_);
-  if (valid(id)) return id;
-  else           return DetId(0);
+  id_.zSide = -id_.zSide;
+  DetId id = encode(id_);
+  if (valid(id))
+    return id;
+  else
+    return DetId(0);
 }
 
 HGCalTopology::DecodedDetId HGCalTopology::geomDenseId2decId(const uint32_t& hi) const {
-
   HGCalTopology::DecodedDetId id;
   if (hi < totalGeomModules()) {
-    id.zSide  = ((int)(hi)<kHGeomHalf_ ? -1 : 1);
-    int di    = ((int)(hi)%kHGeomHalf_);
-    if ((mode_ == HGCalGeometryMode::Hexagon) || 
-	(mode_ == HGCalGeometryMode::HexagonFull)) {
-      id.iSec1  = (di%sectors_);
-      di        = (di-id.iSec1)/sectors_;
-      id.iLay   = (di%layers_)+1;
-      id.iType  = ((di-id.iLay+1)/layers_ == 0) ? -1 : 1;
+    id.zSide = ((int)(hi) < kHGeomHalf_ ? -1 : 1);
+    int di = ((int)(hi) % kHGeomHalf_);
+    if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
+      id.iSec1 = (di % sectors_);
+      di = (di - id.iSec1) / sectors_;
+      id.iLay = (di % layers_) + 1;
+      id.iType = ((di - id.iLay + 1) / layers_ == 0) ? -1 : 1;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Geom Hex I/P " << hi << " O/P " 
-				    << id.zSide  << ":" << id.iType << ":" 
-				    << id.iLay << ":" << id.iSec1;
+      edm::LogVerbatim("HGCalGeom") << "Geom Hex I/P " << hi << " O/P " << id.zSide << ":" << id.iType << ":" << id.iLay
+                                    << ":" << id.iSec1;
 #endif
     } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-      id.iCell1 = (di%cellMax_)+1;
-      di        = (di-id.iCell1+1)/cellMax_;
-      id.iSec1  = (di%sectors_)+1;
-      di        = (di-id.iSec1+1)/sectors_;
-      id.iLay   = (di%layers_) + firstLay_;
-      id.iType  = (di-id.iLay+firstLay_)/layers_;
+      id.iCell1 = (di % cellMax_) + 1;
+      di = (di - id.iCell1 + 1) / cellMax_;
+      id.iSec1 = (di % sectors_) + 1;
+      di = (di - id.iSec1 + 1) / sectors_;
+      id.iLay = (di % layers_) + firstLay_;
+      id.iType = (di - id.iLay + firstLay_) / layers_;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Geom Trap I/P " << hi << " O/P " 
-				    << id.zSide << ":" << id.iType << ":" 
-				    << id.iLay << ":" << id.iSec1 << ":" 
-				    << id.iCell1;
+      edm::LogVerbatim("HGCalGeom") << "Geom Trap I/P " << hi << " O/P " << id.zSide << ":" << id.iType << ":"
+                                    << id.iLay << ":" << id.iSec1 << ":" << id.iCell1;
 #endif
     } else {
-      id.iSec2  = (di%waferMax_)-waferOff_;
-      di        = (di-id.iSec2-waferOff_)/waferMax_;
-      id.iSec1  = (di%waferMax_)-waferOff_;
-      di        = (di-id.iSec1-waferOff_)/waferMax_;
-      id.iLay   = (di%layers_)+1;
-      id.iType  = (di-id.iLay+1)/layers_;
+      id.iSec2 = (di % waferMax_) - waferOff_;
+      di = (di - id.iSec2 - waferOff_) / waferMax_;
+      id.iSec1 = (di % waferMax_) - waferOff_;
+      di = (di - id.iSec1 - waferOff_) / waferMax_;
+      id.iLay = (di % layers_) + 1;
+      id.iType = (di - id.iLay + 1) / layers_;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Geom Hex8 I/P " << hi << " O/P " 
-				    << id.zSide << ":" << id.iType << ":" 
-				    << id.iLay << ":" << id.iSec1 << ":" 
-				    << id.iSec2;
+      edm::LogVerbatim("HGCalGeom") << "Geom Hex8 I/P " << hi << " O/P " << id.zSide << ":" << id.iType << ":"
+                                    << id.iLay << ":" << id.iSec1 << ":" << id.iSec2;
 #endif
     }
   }
   return id;
 }
 
-void HGCalTopology::addHGCSCintillatorId(std::vector<DetId>& ids, int zside,
-					 int type, int lay, int iradius,
-					 int iphi) const {
+void HGCalTopology::addHGCSCintillatorId(
+    std::vector<DetId>& ids, int zside, int type, int lay, int iradius, int iphi) const {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "addHGCSCintillatorId " << zside << ":"
-				<< type << ":" << lay << ":" << iradius << ":"
-				<< iphi << " ==> Validity " 
-				<< hdcons_.isValidTrap(lay,iradius,iphi);
+  edm::LogVerbatim("HGCalGeom") << "addHGCSCintillatorId " << zside << ":" << type << ":" << lay << ":" << iradius
+                                << ":" << iphi << " ==> Validity " << hdcons_.isValidTrap(lay, iradius, iphi);
 #endif
-  if (hdcons_.isValidTrap(lay,iradius,iphi)) {
-    HGCScintillatorDetId id(type,lay,zside*iradius,iphi);
+  if (hdcons_.isValidTrap(lay, iradius, iphi)) {
+    HGCScintillatorDetId id(type, lay, zside * iradius, iphi);
     ids.emplace_back(DetId(id));
   }
 }
 
-void HGCalTopology::addHGCSiliconId(std::vector<DetId>& ids, int det,int zside,
-				   int type, int lay, int waferU, int waferV, 
-				   int cellU, int cellV) const {
+void HGCalTopology::addHGCSiliconId(
+    std::vector<DetId>& ids, int det, int zside, int type, int lay, int waferU, int waferV, int cellU, int cellV) const {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "addHGCSiliconId " << det << ":" << zside
-				<< ":" << type << ":" << lay << ":" << waferU
-				<< ":" << waferV << ":" << cellU << ":" 
-				<< cellV << " ==> Validity " 
-				<< hdcons_.isValidHex8(lay,waferU,waferV,cellU,cellV);
+  edm::LogVerbatim("HGCalGeom") << "addHGCSiliconId " << det << ":" << zside << ":" << type << ":" << lay << ":"
+                                << waferU << ":" << waferV << ":" << cellU << ":" << cellV << " ==> Validity "
+                                << hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV);
 #endif
-  if (hdcons_.isValidHex8(lay,waferU,waferV,cellU,cellV)) {
-    HGCSiliconDetId id((DetId::Detector)(det),zside,type,lay,waferU,waferV,
-		       cellU,cellV);
+  if (hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV)) {
+    HGCSiliconDetId id((DetId::Detector)(det), zside, type, lay, waferU, waferV, cellU, cellV);
     ids.emplace_back(DetId(id));
   }
 }
 
 HGCalTopology::DecodedDetId HGCalTopology::decode(const DetId& startId) const {
-
   HGCalTopology::DecodedDetId idx;
-  if ((mode_ == HGCalGeometryMode::Hexagon) || 
-      (mode_ == HGCalGeometryMode::HexagonFull)) {
+  if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
     HGCalDetId id(startId);
     idx.iCell1 = id.cell();
     idx.iCell2 = 0;
-    idx.iLay   = id.layer();
-    idx.iSec1  = id.wafer();
-    idx.iSec2  = 0;
-    idx.iType  = id.waferType();
-    idx.zSide  = id.zside();
-    idx.det    = id.subdetId();
+    idx.iLay = id.layer();
+    idx.iSec1 = id.wafer();
+    idx.iSec2 = 0;
+    idx.iType = id.waferType();
+    idx.zSide = id.zside();
+    idx.det = id.subdetId();
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
     HGCScintillatorDetId id(startId);
     idx.iCell1 = id.iphi();
     idx.iCell2 = 0;
-    idx.iLay   = id.layer();
-    idx.iSec1  = id.ietaAbs();
-    idx.iSec2  = 0;
-    idx.iType  = id.type();
-    idx.zSide  = id.zside();
-    idx.det    = (int)(id.subdet());
+    idx.iLay = id.layer();
+    idx.iSec1 = id.ietaAbs();
+    idx.iSec2 = 0;
+    idx.iType = id.type();
+    idx.zSide = id.zside();
+    idx.det = (int)(id.subdet());
   } else if (det_ == DetId::Forward && subdet_ == ForwardSubdetector::HFNose) {
     HFNoseDetId id(startId);
     idx.iCell1 = id.cellU();
     idx.iCell2 = id.cellV();
-    idx.iLay   = id.layer();
-    idx.iSec1  = id.waferU();
-    idx.iSec2  = id.waferV();
-    idx.iType  = id.type();
-    idx.zSide  = id.zside();
-    idx.det    = (int)(id.subdet());
+    idx.iLay = id.layer();
+    idx.iSec1 = id.waferU();
+    idx.iSec2 = id.waferV();
+    idx.iType = id.type();
+    idx.zSide = id.zside();
+    idx.det = (int)(id.subdet());
   } else {
     HGCSiliconDetId id(startId);
     idx.iCell1 = id.cellU();
     idx.iCell2 = id.cellV();
-    idx.iLay   = id.layer();
-    idx.iSec1  = id.waferU();
-    idx.iSec2  = id.waferV();
-    idx.iType  = id.type();
-    idx.zSide  = id.zside();
-    idx.det    = (int)(id.subdet());
+    idx.iLay = id.layer();
+    idx.iSec1 = id.waferU();
+    idx.iSec2 = id.waferV();
+    idx.iType = id.type();
+    idx.zSide = id.zside();
+    idx.det = (int)(id.subdet());
   }
   return idx;
 }
 
 DetId HGCalTopology::encode(const HGCalTopology::DecodedDetId& idx) const {
-
   DetId id;
-  if ((mode_ == HGCalGeometryMode::Hexagon) ||
-      (mode_ == HGCalGeometryMode::HexagonFull)) {
-    id = HGCalDetId((ForwardSubdetector)(idx.det),idx.zSide,idx.iLay,((idx.iType > 0) ? 1 : 0),idx.iSec1,idx.iCell1).rawId();
+  if ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull)) {
+    id =
+        HGCalDetId((ForwardSubdetector)(idx.det), idx.zSide, idx.iLay, ((idx.iType > 0) ? 1 : 0), idx.iSec1, idx.iCell1)
+            .rawId();
   } else if (mode_ == HGCalGeometryMode::Trapezoid) {
-    id = HGCScintillatorDetId(idx.iType,idx.iLay,idx.zSide*idx.iSec1,idx.iCell1).rawId();
+    id = HGCScintillatorDetId(idx.iType, idx.iLay, idx.zSide * idx.iSec1, idx.iCell1).rawId();
   } else if (det_ == DetId::Forward && subdet_ == ForwardSubdetector::HFNose) {
-    id = HFNoseDetId(idx.zSide,idx.iType,idx.iLay,idx.iSec1,idx.iSec2,idx.iCell1,idx.iCell2).rawId();
+    id = HFNoseDetId(idx.zSide, idx.iType, idx.iLay, idx.iSec1, idx.iSec2, idx.iCell1, idx.iCell2).rawId();
   } else {
-    id = HGCSiliconDetId((DetId::Detector)(idx.det),idx.zSide,idx.iType,idx.iLay,idx.iSec1,idx.iSec2,idx.iCell1,idx.iCell2).rawId();
+    id = HGCSiliconDetId(
+             (DetId::Detector)(idx.det), idx.zSide, idx.iType, idx.iLay, idx.iSec1, idx.iSec2, idx.iCell1, idx.iCell2)
+             .rawId();
   }
   return id;
 }
 
-DetId HGCalTopology::changeXY(const DetId& id, int nrStepsX,
-			      int nrStepsY ) const {
+DetId HGCalTopology::changeXY(const DetId& id, int nrStepsX, int nrStepsY) const { return DetId(); }
 
-  return DetId();
-}
-
-
-DetId HGCalTopology::changeZ(const DetId& id, int nrStepsZ) const {
-
-  return DetId();
-}
+DetId HGCalTopology::changeZ(const DetId& id, int nrStepsZ) const { return DetId(); }
 
 #include "FWCore/Utilities/interface/typelookup.h"
 

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -10,64 +10,75 @@
 using namespace geant_units;
 using namespace geant_units::operators;
 
-static const int IPHI_MAX=72;
+static const int IPHI_MAX = 72;
 
 //#define EDM_ML_DEBUG
 
-HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons,
-			   const bool mergePosition) :
-  hcons_(hcons), mergePosition_(mergePosition),
-  excludeHB_(false), excludeHE_(false), excludeHO_(false), excludeHF_(false),
-  firstHBRing_(1),
-  firstHERing_(999), lastHERing_(0),
-  firstHFRing_(29),  lastHFRing_(41),
-  firstHORing_(1),   lastHORing_(15),
-  firstHEDoublePhiRing_(999), firstHEQuadPhiRing_(999),
-  firstHFQuadPhiRing_(40), firstHETripleDepthRing_(999),
-  singlePhiBins_(IPHI_MAX), doublePhiBins_(36), maxPhiHE_(IPHI_MAX) {
-
-  mode_       = (HcalTopologyMode::Mode)(hcons_->getTopoMode());
-  triggerMode_= (HcalTopologyMode::TriggerMode)(hcons_->getTriggerMode());
+HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePosition)
+    : hcons_(hcons),
+      mergePosition_(mergePosition),
+      excludeHB_(false),
+      excludeHE_(false),
+      excludeHO_(false),
+      excludeHF_(false),
+      firstHBRing_(1),
+      firstHERing_(999),
+      lastHERing_(0),
+      firstHFRing_(29),
+      lastHFRing_(41),
+      firstHORing_(1),
+      lastHORing_(15),
+      firstHEDoublePhiRing_(999),
+      firstHEQuadPhiRing_(999),
+      firstHFQuadPhiRing_(40),
+      firstHETripleDepthRing_(999),
+      singlePhiBins_(IPHI_MAX),
+      doublePhiBins_(36),
+      maxPhiHE_(IPHI_MAX) {
+  mode_ = (HcalTopologyMode::Mode)(hcons_->getTopoMode());
+  triggerMode_ = (HcalTopologyMode::TriggerMode)(hcons_->getTriggerMode());
   maxDepthHB_ = hcons_->getMaxDepth(0);
   maxDepthHE_ = hcons_->getMaxDepth(1);
   maxDepthHF_ = hcons_->getMaxDepth(2);
-  etaBinsHB_  = hcons_->getEtaBins(0);
-  etaBinsHE_  = hcons_->getEtaBins(1);
-  nEtaHB_     = (hcons_->getEtaRange(0)).second-(hcons_->getEtaRange(0)).first+1;
-  lastHBRing_ = firstHBRing_+nEtaHB_-1;
-  if (hcons_->getNPhi(1) > maxPhiHE_) maxPhiHE_ = hcons_->getNPhi(1);
-  for (auto & i : etaBinsHE_) {
-    if (firstHERing_ > i.ieta) firstHERing_ = i.ieta;
-    if (lastHERing_  < i.ieta) lastHERing_  = i.ieta;
+  etaBinsHB_ = hcons_->getEtaBins(0);
+  etaBinsHE_ = hcons_->getEtaBins(1);
+  nEtaHB_ = (hcons_->getEtaRange(0)).second - (hcons_->getEtaRange(0)).first + 1;
+  lastHBRing_ = firstHBRing_ + nEtaHB_ - 1;
+  if (hcons_->getNPhi(1) > maxPhiHE_)
+    maxPhiHE_ = hcons_->getNPhi(1);
+  for (auto& i : etaBinsHE_) {
+    if (firstHERing_ > i.ieta)
+      firstHERing_ = i.ieta;
+    if (lastHERing_ < i.ieta)
+      lastHERing_ = i.ieta;
     int unit = static_cast<int>((i.dphi / 5.0_deg) + 0.01);
     if (unit == 2 && firstHEDoublePhiRing_ > i.ieta)
       firstHEDoublePhiRing_ = i.ieta;
     if (unit == 4 && firstHEQuadPhiRing_ > i.ieta)
       firstHEQuadPhiRing_ = i.ieta;
-    if (i.layer.size() > 2 && firstHETripleDepthRing_ > i.ieta) 
+    if (i.layer.size() > 2 && firstHETripleDepthRing_ > i.ieta)
       firstHETripleDepthRing_ = i.ieta;
   }
   if (firstHERing_ > lastHERing_) {
-    firstHERing_ = lastHERing_ = firstHEDoublePhiRing_ = firstHEQuadPhiRing_ =
-      firstHETripleDepthRing_ = nEtaHE_ = 0;
+    firstHERing_ = lastHERing_ = firstHEDoublePhiRing_ = firstHEQuadPhiRing_ = firstHETripleDepthRing_ = nEtaHE_ = 0;
   } else {
-    nEtaHE_     = (lastHERing_ - firstHERing_ + 1);
+    nEtaHE_ = (lastHERing_ - firstHERing_ + 1);
   }
-  if (mode_==HcalTopologyMode::LHC) {
-    topoVersion_=0; //DL
-    HBSize_     = kHBSizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
-    HESize_     = kHESizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
-    HOSize_     = kHOSizePreLS1; // ieta * iphi * 2
-    HFSize_     = kHFSizePreLS1;  // ieta * iphi * depth * 2
-    CALIBSize_  = kCALIBSizePreLS1;
+  if (mode_ == HcalTopologyMode::LHC) {
+    topoVersion_ = 0;         //DL
+    HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
+    HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
+    HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
+    HFSize_ = kHFSizePreLS1;  // ieta * iphi * depth * 2
+    CALIBSize_ = kCALIBSizePreLS1;
     numberOfShapes_ = 87;
-  } else if (mode_==HcalTopologyMode::SLHC) { // need to know more eventually
-    topoVersion_=10;
-    HBSize_     = nEtaHB_*IPHI_MAX*maxDepthHB_*2;
-    HESize_     = nEtaHE_*maxPhiHE_*maxDepthHE_*2;
-    HOSize_     = (lastHORing_-firstHORing_+1)*IPHI_MAX*2; // ieta * iphi * 2
-    HFSize_     = (lastHFRing_-firstHFRing_+1)*IPHI_MAX*maxDepthHF_*2;  // ieta * iphi * depth * 2
-    CALIBSize_  = kOffCalibHFX_;
+  } else if (mode_ == HcalTopologyMode::SLHC) {  // need to know more eventually
+    topoVersion_ = 10;
+    HBSize_ = nEtaHB_ * IPHI_MAX * maxDepthHB_ * 2;
+    HESize_ = nEtaHE_ * maxPhiHE_ * maxDepthHE_ * 2;
+    HOSize_ = (lastHORing_ - firstHORing_ + 1) * IPHI_MAX * 2;                // ieta * iphi * 2
+    HFSize_ = (lastHFRing_ - firstHFRing_ + 1) * IPHI_MAX * maxDepthHF_ * 2;  // ieta * iphi * depth * 2
+    CALIBSize_ = kOffCalibHFX_;
     numberOfShapes_ = (maxPhiHE_ > 72) ? 1200 : 500;
   }
   maxEta_ = (lastHERing_ > lastHFRing_) ? lastHERing_ : lastHFRing_;
@@ -78,128 +89,140 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons,
   }
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "Topo sizes " << HBSize_ << ":" << HESize_ << ":" << HOSize_
-	    << ":" << HFSize_ << ":" << HTSize_ << ":" << CALIBSize_ 
-	    << " for mode " << mode_ << ":" << triggerMode_ << std::endl;
+  std::cout << "Topo sizes " << HBSize_ << ":" << HESize_ << ":" << HOSize_ << ":" << HFSize_ << ":" << HTSize_ << ":"
+            << CALIBSize_ << " for mode " << mode_ << ":" << triggerMode_ << std::endl;
 #endif
 
   //The transition between HE/HF in eta
-  etaTableHF  = hcons_->getEtaTableHF();
-  etaTable    = hcons_->getEtaTable();
+  etaTableHF = hcons_->getEtaTableHF();
+  etaTable = hcons_->getEtaTable();
   dPhiTableHF = hcons_->getPhiTableHF();
-  dPhiTable   = hcons_->getPhiTable();
-  phioff      = hcons_->getPhiOffs();
-  std::pair<int,int>  ietaHF = hcons_->getEtaRange(2);
-  etaHE2HF_   = firstHFRing_;
-  etaHF2HE_   = lastHERing_;
+  dPhiTable = hcons_->getPhiTable();
+  phioff = hcons_->getPhiOffs();
+  std::pair<int, int> ietaHF = hcons_->getEtaRange(2);
+  etaHE2HF_ = firstHFRing_;
+  etaHF2HE_ = lastHERing_;
   if (etaBinsHE_.size() > 1) {
-    double eta  = etaBinsHE_[etaBinsHE_.size()-1].etaMax;
-    for (unsigned int i=1; i<etaTableHF.size(); ++i) {
+    double eta = etaBinsHE_[etaBinsHE_.size() - 1].etaMax;
+    for (unsigned int i = 1; i < etaTableHF.size(); ++i) {
       if (eta < etaTableHF[i]) {
-	etaHE2HF_ = ietaHF.first + i - 1;
-	break;
+        etaHE2HF_ = ietaHF.first + i - 1;
+        break;
       }
     }
-    eta         = etaTableHF[0];
-    for (auto & i : etaBinsHE_) {
+    eta = etaTableHF[0];
+    for (auto& i : etaBinsHE_) {
       if (eta < i.etaMax) {
-	etaHF2HE_ = i.ieta;
-	break;
+        etaHF2HE_ = i.ieta;
+        break;
       }
     }
   }
   const double fiveDegInRad = 5.0_deg;
   for (double k : dPhiTable) {
-    int units = (int)(k/fiveDegInRad+0.5);
+    int units = (int)(k / fiveDegInRad + 0.5);
     unitPhi.emplace_back(units);
   }
   for (double k : dPhiTableHF) {
-    int units = (int)(k/fiveDegInRad+0.5);
+    int units = (int)(k / fiveDegInRad + 0.5);
     unitPhiHF.emplace_back(units);
   }
   int nEta = hcons_->getNEta();
-  for (int ring=1; ring<=nEta; ++ring) {
-    std::vector<int> segmentation = hcons_->getDepth(ring-1,false);
-    setDepthSegmentation(ring,segmentation,false);
+  for (int ring = 1; ring <= nEta; ++ring) {
+    std::vector<int> segmentation = hcons_->getDepth(ring - 1, false);
+    setDepthSegmentation(ring, segmentation, false);
 #ifdef EDM_ML_DEBUG
-    std::cout << "Set segmentation for ring " << ring << " with " 
-              << segmentation.size() << " elements:";
-    for (unsigned int k=0; k<segmentation.size(); ++k) 
+    std::cout << "Set segmentation for ring " << ring << " with " << segmentation.size() << " elements:";
+    for (unsigned int k = 0; k < segmentation.size(); ++k)
       std::cout << " " << segmentation[k];
     std::cout << std::endl;
 #endif
-    segmentation = hcons_->getDepth(ring-1,true);
-    setDepthSegmentation(ring,segmentation,true);
+    segmentation = hcons_->getDepth(ring - 1, true);
+    setDepthSegmentation(ring, segmentation, true);
 #ifdef EDM_ML_DEBUG
-    std::cout << "Set Plan-1 segmentation for ring " << ring << " with " 
-              << segmentation.size() << " elements:";
-    for (unsigned int k=0; k<segmentation.size(); ++k) 
+    std::cout << "Set Plan-1 segmentation for ring " << ring << " with " << segmentation.size() << " elements:";
+    for (unsigned int k = 0; k < segmentation.size(); ++k)
       std::cout << " " << segmentation[k];
     std::cout << std::endl;
 #endif
   }
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "Constants in HcalTopology " << firstHBRing_ << ":" 
-            << lastHBRing_ << " " << firstHERing_ << ":" << lastHERing_ << ":" 
-            << firstHEDoublePhiRing_ << ":" << firstHEQuadPhiRing_ << ":" 
-            << firstHETripleDepthRing_ << " " << firstHFRing_ << ":" 
-            << lastHFRing_ << ":" << firstHFQuadPhiRing_ << " " << firstHORing_
-            << ":" << lastHORing_ << " " << maxDepthHB_ << ":" << maxDepthHE_ 
-            << " " << nEtaHB_ << ":" << nEtaHE_ << " " << etaHE2HF_ << ":" 
-            << etaHF2HE_ << " " << maxPhiHE_ << std::endl;
+  std::cout << "Constants in HcalTopology " << firstHBRing_ << ":" << lastHBRing_ << " " << firstHERing_ << ":"
+            << lastHERing_ << ":" << firstHEDoublePhiRing_ << ":" << firstHEQuadPhiRing_ << ":"
+            << firstHETripleDepthRing_ << " " << firstHFRing_ << ":" << lastHFRing_ << ":" << firstHFQuadPhiRing_ << " "
+            << firstHORing_ << ":" << lastHORing_ << " " << maxDepthHB_ << ":" << maxDepthHE_ << " " << nEtaHB_ << ":"
+            << nEtaHE_ << " " << etaHE2HF_ << ":" << etaHF2HE_ << " " << maxPhiHE_ << std::endl;
 #endif
 }
 
-HcalTopology::HcalTopology(HcalTopologyMode::Mode mode, int maxDepthHB, int maxDepthHE, HcalTopologyMode::TriggerMode tmode) :
-  hcons_(nullptr), mergePosition_(false),
-  excludeHB_(false), excludeHE_(false), excludeHO_(false), excludeHF_(false),
-  mode_(mode), triggerMode_(tmode),
-  firstHBRing_(1),   lastHBRing_(16),
-  firstHERing_(16),  lastHERing_(29),
-  firstHFRing_(29),  lastHFRing_(41),
-  firstHORing_(1),   lastHORing_(15),
-  firstHEDoublePhiRing_((mode==HcalTopologyMode::H2 || mode==HcalTopologyMode::H2HE)?(22):(21)),
-  firstHEQuadPhiRing_(999), firstHFQuadPhiRing_(40),
-  firstHETripleDepthRing_((mode==HcalTopologyMode::H2 || mode==HcalTopologyMode::H2HE)?(24):(27)),
-  singlePhiBins_(IPHI_MAX), doublePhiBins_(36),
-  maxDepthHB_(maxDepthHB), maxDepthHE_(maxDepthHE), maxDepthHF_(2),
-  etaHE2HF_(30), etaHF2HE_(29), maxPhiHE_(IPHI_MAX),
-  HBSize_(kHBSizePreLS1),
-  HESize_(kHESizePreLS1),
-  HOSize_(kHOSizePreLS1),
-  HFSize_(kHFSizePreLS1),
-  HTSize_(kHTSizePreLS1),
-  CALIBSize_(kCALIBSizePreLS1),
-  numberOfShapes_(( mode==HcalTopologyMode::SLHC ) ? 500 : 87 ) {
-
-  if (mode_==HcalTopologyMode::LHC) {
-    topoVersion_=0; //DL
-    HBSize_= kHBSizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
-    HESize_= kHESizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
-    HOSize_= kHOSizePreLS1; // ieta * iphi * 2
-    HFSize_= kHFSizePreLS1; // phi * eta * depth * pm
-  } else if (mode_==HcalTopologyMode::SLHC) { // need to know more eventually
-    HBSize_= maxDepthHB*16*IPHI_MAX*2;
-    HESize_= maxDepthHE*(29-16+1)*maxPhiHE_*2;
-    HOSize_= 15*IPHI_MAX*2; // ieta * iphi * 2
-    HFSize_= IPHI_MAX*13*maxDepthHF_*2; // phi * eta * depth * pm 
-    CALIBSize_= kOffCalibHFX_;
-    topoVersion_=10;
+HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
+                           int maxDepthHB,
+                           int maxDepthHE,
+                           HcalTopologyMode::TriggerMode tmode)
+    : hcons_(nullptr),
+      mergePosition_(false),
+      excludeHB_(false),
+      excludeHE_(false),
+      excludeHO_(false),
+      excludeHF_(false),
+      mode_(mode),
+      triggerMode_(tmode),
+      firstHBRing_(1),
+      lastHBRing_(16),
+      firstHERing_(16),
+      lastHERing_(29),
+      firstHFRing_(29),
+      lastHFRing_(41),
+      firstHORing_(1),
+      lastHORing_(15),
+      firstHEDoublePhiRing_((mode == HcalTopologyMode::H2 || mode == HcalTopologyMode::H2HE) ? (22) : (21)),
+      firstHEQuadPhiRing_(999),
+      firstHFQuadPhiRing_(40),
+      firstHETripleDepthRing_((mode == HcalTopologyMode::H2 || mode == HcalTopologyMode::H2HE) ? (24) : (27)),
+      singlePhiBins_(IPHI_MAX),
+      doublePhiBins_(36),
+      maxDepthHB_(maxDepthHB),
+      maxDepthHE_(maxDepthHE),
+      maxDepthHF_(2),
+      etaHE2HF_(30),
+      etaHF2HE_(29),
+      maxPhiHE_(IPHI_MAX),
+      HBSize_(kHBSizePreLS1),
+      HESize_(kHESizePreLS1),
+      HOSize_(kHOSizePreLS1),
+      HFSize_(kHFSizePreLS1),
+      HTSize_(kHTSizePreLS1),
+      CALIBSize_(kCALIBSizePreLS1),
+      numberOfShapes_((mode == HcalTopologyMode::SLHC) ? 500 : 87) {
+  if (mode_ == HcalTopologyMode::LHC) {
+    topoVersion_ = 0;                            //DL
+    HBSize_ = kHBSizePreLS1;                     // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
+    HESize_ = kHESizePreLS1;                     // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
+    HOSize_ = kHOSizePreLS1;                     // ieta * iphi * 2
+    HFSize_ = kHFSizePreLS1;                     // phi * eta * depth * pm
+  } else if (mode_ == HcalTopologyMode::SLHC) {  // need to know more eventually
+    HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
+    HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
+    HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2
+    HFSize_ = IPHI_MAX * 13 * maxDepthHF_ * 2;  // phi * eta * depth * pm
+    CALIBSize_ = kOffCalibHFX_;
+    topoVersion_ = 10;
   }
-  nEtaHB_ = (lastHBRing_-firstHBRing_+1);
-  nEtaHE_ = (lastHERing_-firstHERing_+1);
+  nEtaHB_ = (lastHBRing_ - firstHBRing_ + 1);
+  nEtaHE_ = (lastHERing_ - firstHERing_ + 1);
   if (triggerMode_ == HcalTopologyMode::TriggerMode_2009) {
     HTSize_ = kHTSizePreLS1;
   } else {
     HTSize_ = kHTSizePhase1;
   }
 
-  edm::LogWarning("CaloTopology") << "This is an incomplete constructor of HcalTopology - be warned that many functionalities will not be there - revert from this - get from EventSetup";
+  edm::LogWarning("CaloTopology") << "This is an incomplete constructor of HcalTopology - be warned that many "
+                                     "functionalities will not be there - revert from this - get from EventSetup";
 }
 
 bool HcalTopology::valid(const DetId& id) const {
-  assert(id.det()==DetId::Hcal);
+  assert(id.det() == DetId::Hcal);
   return validHcal(id);
 }
 
@@ -208,31 +231,40 @@ bool HcalTopology::validHcal(const HcalDetId& id) const {
   return validRaw(id) && !isExcluded(id);
 }
 
-bool HcalTopology::validDetId(HcalSubdetector subdet, int ieta, int iphi, 
-                              int depth) const {
-  return validHcal(HcalDetId(subdet,ieta,iphi,depth));
+bool HcalTopology::validDetId(HcalSubdetector subdet, int ieta, int iphi, int depth) const {
+  return validHcal(HcalDetId(subdet, ieta, iphi, depth));
 }
 
 bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
-
-  if (id.iphi()<1 || id.iphi()>IPHI_MAX || id.ieta()==0)  return false;
-  if (id.depth() != 0)                                    return false;
+  if (id.iphi() < 1 || id.iphi() > IPHI_MAX || id.ieta() == 0)
+    return false;
+  if (id.depth() != 0)
+    return false;
   if (maxDepthHE_ == 0) {
-    if (id.ietaAbs() > lastHBRing_ && id.ietaAbs() < firstHFRing_) return false;
+    if (id.ietaAbs() > lastHBRing_ && id.ietaAbs() < firstHFRing_)
+      return false;
   }
-  if (id.version()==0) {
+  if (id.version() == 0) {
     if (id.ietaAbs() > 28) {
-       if (triggerMode_ >= HcalTopologyMode::TriggerMode_2017) return false;
-       if (triggerMode_ == HcalTopologyMode::TriggerMode_2018legacy) return false;
-       if ((id.iphi() % 4) != 1)                               return false;
-       if (id.ietaAbs() > 32)                                  return false;
+      if (triggerMode_ >= HcalTopologyMode::TriggerMode_2017)
+        return false;
+      if (triggerMode_ == HcalTopologyMode::TriggerMode_2018legacy)
+        return false;
+      if ((id.iphi() % 4) != 1)
+        return false;
+      if (id.ietaAbs() > 32)
+        return false;
     }
-  } else if (id.version()==1) {
-    if (triggerMode_==HcalTopologyMode::TriggerMode_2009) return false;
-    if (id.ietaAbs()<30 || id.ietaAbs()>41)         return false;
-    if (id.ietaAbs()>29 && ((id.iphi()%2)==0))      return false;
-    if (id.ietaAbs()>39 && ((id.iphi()%4)!=3))      return false;
-  } else if (id.version()>1) {
+  } else if (id.version() == 1) {
+    if (triggerMode_ == HcalTopologyMode::TriggerMode_2009)
+      return false;
+    if (id.ietaAbs() < 30 || id.ietaAbs() > 41)
+      return false;
+    if (id.ietaAbs() > 29 && ((id.iphi() % 2) == 0))
+      return false;
+    if (id.ietaAbs() > 39 && ((id.iphi() % 4) != 3))
+      return false;
+  } else if (id.version() > 1) {
     // only versions 0 and 1 are supported
     return false;
   }
@@ -241,55 +273,59 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
 }
 
 bool HcalTopology::validCalib(const HcalCalibDetId& tid) const {
-
   bool ok(false);
-  if (tid.calibFlavor()==HcalCalibDetId::CalibrationBox) {
+  if (tid.calibFlavor() == HcalCalibDetId::CalibrationBox) {
     HcalSubdetector subdet = tid.hcalSubdet();
     int ieta = tid.ieta();
     int chan = tid.cboxChannel();
     unsigned int iphi = static_cast<unsigned int>(tid.iphi());
     if (subdet == HcalBarrel) {
-      if ((std::find(etaCalibHBHEHF_,etaCalibHBHEHF_+nEtaCalibHBHEHF_,ieta)
-	   !=etaCalibHBHEHF_+nEtaCalibHBHEHF_) && (iphi >= minPhi_) &&
-	  (std::find(chanCalibHB_,chanCalibHB_+nchanCalibHB_,chan)
-	   !=chanCalibHB_+nchanCalibHB_) && (iphi<= maxPhi_)) ok = true;
+      if ((std::find(etaCalibHBHEHF_, etaCalibHBHEHF_ + nEtaCalibHBHEHF_, ieta) !=
+           etaCalibHBHEHF_ + nEtaCalibHBHEHF_) &&
+          (iphi >= minPhi_) &&
+          (std::find(chanCalibHB_, chanCalibHB_ + nchanCalibHB_, chan) != chanCalibHB_ + nchanCalibHB_) &&
+          (iphi <= maxPhi_))
+        ok = true;
     } else if (subdet == HcalEndcap) {
-      if ((std::find(etaCalibHBHEHF_,etaCalibHBHEHF_+nEtaCalibHBHEHF_,ieta)
-	   !=etaCalibHBHEHF_+nEtaCalibHBHEHF_) && (iphi >= minPhi_) &&
-	  (std::find(chanCalibHE_,chanCalibHE_+nchanCalibHE_,chan)
-	   !=chanCalibHE_+nchanCalibHE_) && (iphi<= maxPhi_)) ok = true;
+      if ((std::find(etaCalibHBHEHF_, etaCalibHBHEHF_ + nEtaCalibHBHEHF_, ieta) !=
+           etaCalibHBHEHF_ + nEtaCalibHBHEHF_) &&
+          (iphi >= minPhi_) &&
+          (std::find(chanCalibHE_, chanCalibHE_ + nchanCalibHE_, chan) != chanCalibHE_ + nchanCalibHE_) &&
+          (iphi <= maxPhi_))
+        ok = true;
     } else if (subdet == HcalForward) {
-      if ((std::find(etaCalibHBHEHF_,etaCalibHBHEHF_+nEtaCalibHBHEHF_,ieta)
-	   !=etaCalibHBHEHF_+nEtaCalibHBHEHF_) && (iphi >= minPhi_) &&
-	  (std::find(chanCalibHF_,chanCalibHF_+nchanCalibHF_,chan)
-	   !=chanCalibHF_+nchanCalibHF_) && (iphi<= maxPhi_)) ok = true;
+      if ((std::find(etaCalibHBHEHF_, etaCalibHBHEHF_ + nEtaCalibHBHEHF_, ieta) !=
+           etaCalibHBHEHF_ + nEtaCalibHBHEHF_) &&
+          (iphi >= minPhi_) &&
+          (std::find(chanCalibHF_, chanCalibHF_ + nchanCalibHF_, chan) != chanCalibHF_ + nchanCalibHF_) &&
+          (iphi <= maxPhi_))
+        ok = true;
     } else if (subdet == HcalOuter) {
-      if ((std::find(etaCalibHO_,etaCalibHO_+nEtaCalibHO_,ieta)
-	   !=etaCalibHO_+nEtaCalibHO_) && ((chan==chanCalibHOs_) ||
-	  ((std::find(chanCalibHO_,chanCalibHO_+nchanCalibHO_,chan)
-	    !=chanCalibHO_+nchanCalibHO_) && (iphi >= minPhi_) && 
-	   (iphi<= maxPhi_)))) ok = true;
+      if ((std::find(etaCalibHO_, etaCalibHO_ + nEtaCalibHO_, ieta) != etaCalibHO_ + nEtaCalibHO_) &&
+          ((chan == chanCalibHOs_) ||
+           ((std::find(chanCalibHO_, chanCalibHO_ + nchanCalibHO_, chan) != chanCalibHO_ + nchanCalibHO_) &&
+            (iphi >= minPhi_) && (iphi <= maxPhi_))))
+        ok = true;
     }
-  } else if (tid.calibFlavor()==HcalCalibDetId::HOCrosstalk) {
+  } else if (tid.calibFlavor() == HcalCalibDetId::HOCrosstalk) {
     int ieta = std::abs(tid.ieta());
     unsigned int iphi = static_cast<unsigned int>(tid.iphi());
-    if ((std::find(etaCalibHOX_,etaCalibHOX_+nEtaCalibHOX_,ieta)
-	 !=etaCalibHOX_+nEtaCalibHOX_) && (iphi >= minPhi_) && 
-	(iphi<= maxPhi_)) ok = true;
-  } else if (tid.calibFlavor()==HcalCalibDetId::HBX) {
-    int ieta = std::abs(tid.ieta());
-    unsigned int iphi = static_cast<unsigned int>(tid.iphi());
-    if ((ieta == etaCalibHBX_) && (iphi >= minPhi_) && (iphi<= maxPhi_))
+    if ((std::find(etaCalibHOX_, etaCalibHOX_ + nEtaCalibHOX_, ieta) != etaCalibHOX_ + nEtaCalibHOX_) &&
+        (iphi >= minPhi_) && (iphi <= maxPhi_))
       ok = true;
-  } else if (tid.calibFlavor()==HcalCalibDetId::HEX) {
+  } else if (tid.calibFlavor() == HcalCalibDetId::HBX) {
     int ieta = std::abs(tid.ieta());
     unsigned int iphi = static_cast<unsigned int>(tid.iphi());
-    if ((std::find(etaCalibHEX_,etaCalibHEX_+nEtaCalibHEX_,ieta)
-	 !=etaCalibHEX_+nEtaCalibHEX_) && (iphi >= minPhi_) && 
-	(iphi<= maxPhi_)) ok = true;
-  } else if ((tid.calibFlavor()==HcalCalibDetId::uMNqie) ||
-	     (tid.calibFlavor()==HcalCalibDetId::LASERMON) ||
-	     (tid.calibFlavor()==HcalCalibDetId::CastorRadFacility)) {
+    if ((ieta == etaCalibHBX_) && (iphi >= minPhi_) && (iphi <= maxPhi_))
+      ok = true;
+  } else if (tid.calibFlavor() == HcalCalibDetId::HEX) {
+    int ieta = std::abs(tid.ieta());
+    unsigned int iphi = static_cast<unsigned int>(tid.iphi());
+    if ((std::find(etaCalibHEX_, etaCalibHEX_ + nEtaCalibHEX_, ieta) != etaCalibHEX_ + nEtaCalibHEX_) &&
+        (iphi >= minPhi_) && (iphi <= maxPhi_))
+      ok = true;
+  } else if ((tid.calibFlavor() == HcalCalibDetId::uMNqie) || (tid.calibFlavor() == HcalCalibDetId::LASERMON) ||
+             (tid.calibFlavor() == HcalCalibDetId::CastorRadFacility)) {
     ok = true;
   }
   return ok;
@@ -308,49 +344,70 @@ bool HcalTopology::validHcal(const HcalDetId& id, const unsigned int flag) const
   }
   return ok;
   */
-  return (flag>0 and hcons_->isPlan1MergedId(id)) or ((flag!=1 or !hcons_->isPlan1ToBeMergedId(id)) and validHcal(id));
+  return (flag > 0 and hcons_->isPlan1MergedId(id)) or
+         ((flag != 1 or !hcons_->isPlan1ToBeMergedId(id)) and validHcal(id));
 }
 
 bool HcalTopology::isExcluded(const HcalDetId& id) const {
-  bool exed=false;
+  bool exed = false;
   // first, check the full detector exclusions...  (fast)
   switch (id.subdet()) {
-  case(HcalBarrel):  exed=excludeHB_; break;
-  case(HcalEndcap):  exed=excludeHE_; break;
-  case(HcalOuter):   exed=excludeHO_; break;
-  case(HcalForward): exed=excludeHF_; break;
-  default: exed=false;
+    case (HcalBarrel):
+      exed = excludeHB_;
+      break;
+    case (HcalEndcap):
+      exed = excludeHE_;
+      break;
+    case (HcalOuter):
+      exed = excludeHO_;
+      break;
+    case (HcalForward):
+      exed = excludeHF_;
+      break;
+    default:
+      exed = false;
   }
   // next, check the list (slower)
   if (!exed && !exclusionList_.empty()) {
-    std::vector<HcalDetId>::const_iterator i=std::lower_bound(exclusionList_.begin(),exclusionList_.end(),id);
-    if (i!=exclusionList_.end() && *i==id) exed=true;
+    std::vector<HcalDetId>::const_iterator i = std::lower_bound(exclusionList_.begin(), exclusionList_.end(), id);
+    if (i != exclusionList_.end() && *i == id)
+      exed = true;
   }
   return exed;
 }
 
 void HcalTopology::exclude(const HcalDetId& id) {
-  std::vector<HcalDetId>::iterator i=std::lower_bound(exclusionList_.begin(),exclusionList_.end(),id);
-  if (i==exclusionList_.end() || *i!=id) {
-    exclusionList_.insert(i,id);
+  std::vector<HcalDetId>::iterator i = std::lower_bound(exclusionList_.begin(), exclusionList_.end(), id);
+  if (i == exclusionList_.end() || *i != id) {
+    exclusionList_.insert(i, id);
   }
 }
 
 void HcalTopology::excludeSubdetector(HcalSubdetector subdet) {
   switch (subdet) {
-  case(HcalBarrel):  excludeHB_=true; break;
-  case(HcalEndcap):  excludeHE_=true; break;
-  case(HcalOuter):   excludeHO_=true; break;
-  case(HcalForward): excludeHF_=true; break;
-  default: break;
+    case (HcalBarrel):
+      excludeHB_ = true;
+      break;
+    case (HcalEndcap):
+      excludeHE_ = true;
+      break;
+    case (HcalOuter):
+      excludeHO_ = true;
+      break;
+    case (HcalForward):
+      excludeHF_ = true;
+      break;
+    default:
+      break;
   }
 }
 
 std::vector<DetId> HcalTopology::east(const DetId& id) const {
   std::vector<DetId> vNeighborsDetId;
   HcalDetId neighbors[2];
-  for (int i=0;i<decIEta(HcalDetId(id),neighbors);i++) {
-    if (neighbors[i].oldFormat()) neighbors[i].changeForm();
+  for (int i = 0; i < decIEta(HcalDetId(id), neighbors); i++) {
+    if (neighbors[i].oldFormat())
+      neighbors[i].changeForm();
     vNeighborsDetId.emplace_back(DetId(neighbors[i].rawId()));
   }
   return vNeighborsDetId;
@@ -359,87 +416,101 @@ std::vector<DetId> HcalTopology::east(const DetId& id) const {
 std::vector<DetId> HcalTopology::west(const DetId& id) const {
   std::vector<DetId> vNeighborsDetId;
   HcalDetId neighbors[2];
-  for (int i=0;i<incIEta(HcalDetId(id),neighbors);i++) {
-    if (neighbors[i].oldFormat()) neighbors[i].changeForm();
+  for (int i = 0; i < incIEta(HcalDetId(id), neighbors); i++) {
+    if (neighbors[i].oldFormat())
+      neighbors[i].changeForm();
     vNeighborsDetId.emplace_back(DetId(neighbors[i].rawId()));
   }
-  return  vNeighborsDetId;
+  return vNeighborsDetId;
 }
 
 std::vector<DetId> HcalTopology::north(const DetId& id) const {
   std::vector<DetId> vNeighborsDetId;
   HcalDetId neighbor;
-  if (incIPhi(HcalDetId(id),neighbor)) {
-    if (neighbor.oldFormat()) neighbor.changeForm();
+  if (incIPhi(HcalDetId(id), neighbor)) {
+    if (neighbor.oldFormat())
+      neighbor.changeForm();
     vNeighborsDetId.emplace_back(DetId(neighbor.rawId()));
   }
-  return  vNeighborsDetId;
+  return vNeighborsDetId;
 }
 
 std::vector<DetId> HcalTopology::south(const DetId& id) const {
   std::vector<DetId> vNeighborsDetId;
   HcalDetId neighbor;
-  if (decIPhi(HcalDetId(id),neighbor)) {
-    if (neighbor.oldFormat()) neighbor.changeForm();
+  if (decIPhi(HcalDetId(id), neighbor)) {
+    if (neighbor.oldFormat())
+      neighbor.changeForm();
     vNeighborsDetId.emplace_back(DetId(neighbor.rawId()));
   }
-  return  vNeighborsDetId;
+  return vNeighborsDetId;
 }
 
 std::vector<DetId> HcalTopology::up(const DetId& id) const {
   HcalDetId neighbor = id;
   std::vector<DetId> vNeighborsDetId;
   if (incrementDepth(neighbor)) {
-    if (neighbor.oldFormat()) neighbor.changeForm();
+    if (neighbor.oldFormat())
+      neighbor.changeForm();
     vNeighborsDetId.emplace_back(neighbor);
   }
-  return  vNeighborsDetId;
+  return vNeighborsDetId;
 }
 
 std::vector<DetId> HcalTopology::down(const DetId& id) const {
   HcalDetId neighbor = id;
   std::vector<DetId> vNeighborsDetId;
   if (decrementDepth(neighbor)) {
-    if (neighbor.oldFormat()) neighbor.changeForm();
+    if (neighbor.oldFormat())
+      neighbor.changeForm();
     vNeighborsDetId.emplace_back(neighbor);
   }
-  return  vNeighborsDetId;
+  return vNeighborsDetId;
 }
 
 int HcalTopology::exclude(HcalSubdetector subdet, int ieta1, int ieta2, int iphi1, int iphi2, int depth1, int depth2) {
-
-  bool exed=false;
+  bool exed = false;
   // first, check the full detector exclusions...  (fast)
   switch (subdet) {
-  case(HcalBarrel):  exed=excludeHB_; break;
-  case(HcalEndcap):  exed=excludeHE_; break;
-  case(HcalOuter):   exed=excludeHO_; break;
-  case(HcalForward): exed=excludeHF_; break;
-  default: exed=false;
+    case (HcalBarrel):
+      exed = excludeHB_;
+      break;
+    case (HcalEndcap):
+      exed = excludeHE_;
+      break;
+    case (HcalOuter):
+      exed = excludeHO_;
+      break;
+    case (HcalForward):
+      exed = excludeHF_;
+      break;
+    default:
+      exed = false;
   }
-  if (exed) return 0; // if the whole detector is excluded...
+  if (exed)
+    return 0;  // if the whole detector is excluded...
 
-  int ieta_l=std::min(ieta1,ieta2);
-  int ieta_h=std::max(ieta1,ieta2);
-  int iphi_l=std::min(iphi1,iphi2);
-  int iphi_h=std::max(iphi1,iphi2);
-  int depth_l=std::min(depth1,depth2);
-  int depth_h=std::max(depth1,depth2);
+  int ieta_l = std::min(ieta1, ieta2);
+  int ieta_h = std::max(ieta1, ieta2);
+  int iphi_l = std::min(iphi1, iphi2);
+  int iphi_h = std::max(iphi1, iphi2);
+  int depth_l = std::min(depth1, depth2);
+  int depth_h = std::max(depth1, depth2);
 
-  int n=0;
-  for (int ieta=ieta_l; ieta<=ieta_h; ieta++) 
-    for (int iphi=iphi_l; iphi<=iphi_h; iphi++) 
-      for (int depth=depth_l; depth<=depth_h; depth++) {
-	HcalDetId id(subdet,ieta,iphi,depth);
-	if (validRaw(id)) { // use 'validRaw' to include check validity in "uncut" detector
-	  exclude(id);  
-	  n++;
-	}
+  int n = 0;
+  for (int ieta = ieta_l; ieta <= ieta_h; ieta++)
+    for (int iphi = iphi_l; iphi <= iphi_h; iphi++)
+      for (int depth = depth_l; depth <= depth_h; depth++) {
+        HcalDetId id(subdet, ieta, iphi, depth);
+        if (validRaw(id)) {  // use 'validRaw' to include check validity in "uncut" detector
+          exclude(id);
+          n++;
+        }
       }
   return n;
 }
 
-  /** Basic rules used to derive this code:
+/** Basic rules used to derive this code:
       
   HB has 72 towers in iphi.  Ieta 1-14 have depth=1, Ieta 15-16 have depth=1 or 2.
 
@@ -466,355 +537,367 @@ int HcalTopology::exclude(HcalSubdetector subdet, int ieta1, int ieta2, int iphi
   */
 
 bool HcalTopology::validDetIdPreLS1(const HcalDetId& id) const {
-  const HcalSubdetector sd (id.subdet());
-  const int             ie (id.ietaAbs());
-  const int             ip (id.iphi());
-  const int             dp (id.depth());
+  const HcalSubdetector sd(id.subdet());
+  const int ie(id.ietaAbs());
+  const int ip(id.iphi());
+  const int dp(id.depth());
 
-  return ( ( ip >=  1         ) &&
-	   ( ip <= IPHI_MAX   ) &&
-	   ( dp >=  1         ) &&
-	   ( ie >=  1         ) &&
-	   ( ( ( sd == HcalBarrel ) &&
-	       ( ( ( ie <= 14         ) &&
-		   ( dp ==  1         )    ) ||
-		 ( ( ( ie == 15 ) || ( ie == 16 ) ) && 
-		   ( dp <= 2          )                ) ) ) ||
-	     (  ( sd == HcalEndcap ) &&
-		( ( ( ie == firstHERing() ) &&
-		    ( dp ==  3 )          ) ||
-		  ( ( ie == 17 ) &&
-		    ( dp ==  1 )          ) ||
-		  ( ( ie >= 18 ) &&
-		    ( ie <= 20 ) &&
-		    ( dp <=  2 )          ) ||
-		  ( ( ie >= 21 ) &&
-		    ( ie <= 26 ) &&
-		    ( dp <=  2 ) &&
-		    ( ip%2 == 1 )         ) ||
-		  ( ( ie >= 27 ) &&
-		    ( ie <= 28 ) &&
-		    ( dp <=  3 ) &&
-		    ( ip%2 == 1 )         ) ||
-		  ( ( ie == 29 ) &&
-		    ( dp <=  2 ) &&
-		    ( ip%2 == 1 )         )          )      ) ||
-	     (  ( sd == HcalOuter ) &&
-		( ie <= 15 ) &&
-		( dp ==  4 )           ) ||
-	     (  ( sd == HcalForward ) &&
-		( dp <=  2 )          &&
-		( ( ( ie >= firstHFRing() ) &&
-		    ( ie <  firstHFQuadPhiRing() ) &&
-		    ( ip%2 == 1 )    ) ||
-		  ( ( ie >= firstHFQuadPhiRing() ) &&
-		    ( ie <= lastHFRing() ) &&
-		    ( ip%4 == 3 )         )  ) ) ) ) ;
+  return ((ip >= 1) && (ip <= IPHI_MAX) && (dp >= 1) && (ie >= 1) &&
+          (((sd == HcalBarrel) && (((ie <= 14) && (dp == 1)) || (((ie == 15) || (ie == 16)) && (dp <= 2)))) ||
+           ((sd == HcalEndcap) &&
+            (((ie == firstHERing()) && (dp == 3)) || ((ie == 17) && (dp == 1)) ||
+             ((ie >= 18) && (ie <= 20) && (dp <= 2)) || ((ie >= 21) && (ie <= 26) && (dp <= 2) && (ip % 2 == 1)) ||
+             ((ie >= 27) && (ie <= 28) && (dp <= 3) && (ip % 2 == 1)) || ((ie == 29) && (dp <= 2) && (ip % 2 == 1)))) ||
+           ((sd == HcalOuter) && (ie <= 15) && (dp == 4)) ||
+           ((sd == HcalForward) && (dp <= 2) &&
+            (((ie >= firstHFRing()) && (ie < firstHFQuadPhiRing()) && (ip % 2 == 1)) ||
+             ((ie >= firstHFQuadPhiRing()) && (ie <= lastHFRing()) && (ip % 4 == 3))))));
 }
 
-  /** Is this a valid cell id? */
+/** Is this a valid cell id? */
 bool HcalTopology::validRaw(const HcalDetId& id) const {
-  bool ok=true;
-  int ieta=id.ieta();
-  int aieta=id.ietaAbs();
-  int depth=id.depth();
-  int iphi=id.iphi();
-  int zside=id.zside();
-  HcalSubdetector subdet=id.subdet();
-  int maxPhi = (subdet==HcalEndcap) ? maxPhiHE_ : IPHI_MAX;
-  if ((ieta==0 || iphi<=0 || iphi>maxPhi) || aieta>maxEta_) ok = false; // outer limits
- 
+  bool ok = true;
+  int ieta = id.ieta();
+  int aieta = id.ietaAbs();
+  int depth = id.depth();
+  int iphi = id.iphi();
+  int zside = id.zside();
+  HcalSubdetector subdet = id.subdet();
+  int maxPhi = (subdet == HcalEndcap) ? maxPhiHE_ : IPHI_MAX;
+  if ((ieta == 0 || iphi <= 0 || iphi > maxPhi) || aieta > maxEta_)
+    ok = false;  // outer limits
+
   if (ok) {
-    if (subdet==HcalBarrel) {
-      if (mode_==HcalTopologyMode::SLHC || mode_==HcalTopologyMode::H2HE) {
-	if ((aieta>lastHBRing()) ||
-	    (depth>hcons_->getMaxDepth(0,aieta,iphi,zside)) ||
-	    (depth<hcons_->getMinDepth(0,aieta,iphi,zside))) ok=false;
+    if (subdet == HcalBarrel) {
+      if (mode_ == HcalTopologyMode::SLHC || mode_ == HcalTopologyMode::H2HE) {
+        if ((aieta > lastHBRing()) || (depth > hcons_->getMaxDepth(0, aieta, iphi, zside)) ||
+            (depth < hcons_->getMinDepth(0, aieta, iphi, zside)))
+          ok = false;
       } else {
-	if (aieta>lastHBRing() || depth>2 || (aieta<=14 && depth>1)) ok=false;
+        if (aieta > lastHBRing() || depth > 2 || (aieta <= 14 && depth > 1))
+          ok = false;
       }
-    } else if (subdet==HcalEndcap) {
-      if (mode_==HcalTopologyMode::SLHC || mode_==HcalTopologyMode::H2HE) {
-        if ((depth>hcons_->getMaxDepth(1,aieta,iphi,zside)) || 
-            (depth<hcons_->getMinDepth(1,aieta,iphi,zside)) ||
-	    (aieta<firstHERing()) || (aieta>lastHERing())) {
+    } else if (subdet == HcalEndcap) {
+      if (mode_ == HcalTopologyMode::SLHC || mode_ == HcalTopologyMode::H2HE) {
+        if ((depth > hcons_->getMaxDepth(1, aieta, iphi, zside)) ||
+            (depth < hcons_->getMinDepth(1, aieta, iphi, zside)) || (aieta < firstHERing()) || (aieta > lastHERing())) {
           ok = false;
         } else {
-          for (const auto & i : etaBinsHE_) {
+          for (const auto& i : etaBinsHE_) {
             if (aieta == i.ieta) {
-              if (aieta >= firstHEDoublePhiRing() && (iphi%2)==0) ok=false;
-              if (aieta >= firstHEQuadPhiRing()   && (iphi%4)!=3) ok=false;
-              if (aieta+1 == hcons_->getNoff(1)) {
-		if (depth < 1) ok = false;
-	      } else {
-		if (depth < i.depthStart) ok = false;
-	      }
+              if (aieta >= firstHEDoublePhiRing() && (iphi % 2) == 0)
+                ok = false;
+              if (aieta >= firstHEQuadPhiRing() && (iphi % 4) != 3)
+                ok = false;
+              if (aieta + 1 == hcons_->getNoff(1)) {
+                if (depth < 1)
+                  ok = false;
+              } else {
+                if (depth < i.depthStart)
+                  ok = false;
+              }
               break;
             }
           }
-	}
+        }
       } else {
-	if (depth>hcons_->getMaxDepth(1,aieta,iphi,zside) || 
-	    aieta<firstHERing() || aieta>lastHERing() || 
-	    (aieta==firstHERing() && depth!=hcons_->getDepthEta16(2,iphi,zside)) || 
-	    (aieta==17 && depth!=1 && mode_!=HcalTopologyMode::H2) || // special case at H2
-	    (((aieta>=17 && aieta<firstHETripleDepthRing()) || 
-	      aieta==lastHERing()) && depth>2) ||
-	    (aieta>=firstHEDoublePhiRing() && (iphi%2)==0)) ok=false;
+        if (depth > hcons_->getMaxDepth(1, aieta, iphi, zside) || aieta < firstHERing() || aieta > lastHERing() ||
+            (aieta == firstHERing() && depth != hcons_->getDepthEta16(2, iphi, zside)) ||
+            (aieta == 17 && depth != 1 && mode_ != HcalTopologyMode::H2) ||  // special case at H2
+            (((aieta >= 17 && aieta < firstHETripleDepthRing()) || aieta == lastHERing()) && depth > 2) ||
+            (aieta >= firstHEDoublePhiRing() && (iphi % 2) == 0))
+          ok = false;
       }
-    } else if (subdet==HcalOuter) {
-      if (aieta>lastHORing() || iphi>IPHI_MAX || depth!=4) ok=false;
-    } else if (subdet==HcalForward) {
-      if (aieta<firstHFRing() || aieta>lastHFRing() || ((iphi%2)==0) || 
-	  (depth>hcons_->maxHFDepth(ieta,iphi)) ||  
-	  (aieta>=firstHFQuadPhiRing() && ((iphi+1)%4)!=0)) ok=false;
-    } else if (subdet==HcalTriggerTower) {
-      ok=validHT(HcalTrigTowerDetId(id.rawId()));
-    } else if (subdet==HcalOther) {
-      ok=validCalib(HcalCalibDetId(id.rawId()));
+    } else if (subdet == HcalOuter) {
+      if (aieta > lastHORing() || iphi > IPHI_MAX || depth != 4)
+        ok = false;
+    } else if (subdet == HcalForward) {
+      if (aieta < firstHFRing() || aieta > lastHFRing() || ((iphi % 2) == 0) ||
+          (depth > hcons_->maxHFDepth(ieta, iphi)) || (aieta >= firstHFQuadPhiRing() && ((iphi + 1) % 4) != 0))
+        ok = false;
+    } else if (subdet == HcalTriggerTower) {
+      ok = validHT(HcalTrigTowerDetId(id.rawId()));
+    } else if (subdet == HcalOther) {
+      ok = validCalib(HcalCalibDetId(id.rawId()));
     } else {
-      ok=false;
+      ok = false;
     }
   }
   return ok;
 }
 
-bool HcalTopology::incIPhi(const HcalDetId& id, HcalDetId &neighbor) const {
-  bool ok=valid(id);
+bool HcalTopology::incIPhi(const HcalDetId& id, HcalDetId& neighbor) const {
+  bool ok = valid(id);
   if (ok) {
     switch (id.subdet()) {
-    case (HcalBarrel):
-    case (HcalOuter):
-      if (id.iphi()==IPHI_MAX) neighbor=HcalDetId(id.subdet(),id.ieta(),1,id.depth()); 
-      else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()+1,id.depth()); 
-      break;
-    case (HcalEndcap):
-      if (id.ietaAbs()>=firstHEQuadPhiRing()) {
-        if (id.iphi()==IPHI_MAX-1) neighbor=HcalDetId(id.subdet(),id.ieta(),3,id.depth()); 
-        else                       neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()+4,id.depth()); 
-      } else if (id.ietaAbs()>=firstHEDoublePhiRing()) {
- 	if (id.iphi()==IPHI_MAX-1) neighbor=HcalDetId(id.subdet(),id.ieta(),1,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()+2,id.depth()); 
-      } else {
-	if (id.iphi()==maxPhiHE_) neighbor=HcalDetId(id.subdet(),id.ieta(),1,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()+1,id.depth()); 
-      }	
-      break;
-    case (HcalForward):
-      if (id.ietaAbs()>=firstHFQuadPhiRing()) {
-	if (id.iphi()==IPHI_MAX-1) neighbor=HcalDetId(id.subdet(),id.ieta(),3,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()+4,id.depth()); 
-      } else {
-	if (id.iphi()==IPHI_MAX-1) neighbor=HcalDetId(id.subdet(),id.ieta(),1,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()+2,id.depth()); 
-      }
-      if (!validRaw(neighbor)) ok = false;
-      break;
-    default: ok=false;
+      case (HcalBarrel):
+      case (HcalOuter):
+        if (id.iphi() == IPHI_MAX)
+          neighbor = HcalDetId(id.subdet(), id.ieta(), 1, id.depth());
+        else
+          neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() + 1, id.depth());
+        break;
+      case (HcalEndcap):
+        if (id.ietaAbs() >= firstHEQuadPhiRing()) {
+          if (id.iphi() == IPHI_MAX - 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), 3, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() + 4, id.depth());
+        } else if (id.ietaAbs() >= firstHEDoublePhiRing()) {
+          if (id.iphi() == IPHI_MAX - 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() + 2, id.depth());
+        } else {
+          if (id.iphi() == maxPhiHE_)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() + 1, id.depth());
+        }
+        break;
+      case (HcalForward):
+        if (id.ietaAbs() >= firstHFQuadPhiRing()) {
+          if (id.iphi() == IPHI_MAX - 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), 3, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() + 4, id.depth());
+        } else {
+          if (id.iphi() == IPHI_MAX - 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() + 2, id.depth());
+        }
+        if (!validRaw(neighbor))
+          ok = false;
+        break;
+      default:
+        ok = false;
     }
-  } 
+  }
   return ok;
 }
 
 /** Get the neighbor (if present) of the given cell with lower iphi */
-bool HcalTopology::decIPhi(const HcalDetId& id, HcalDetId &neighbor) const {
-  bool ok=valid(id);
+bool HcalTopology::decIPhi(const HcalDetId& id, HcalDetId& neighbor) const {
+  bool ok = valid(id);
   if (ok) {
     switch (id.subdet()) {
-    case (HcalBarrel):
-    case (HcalOuter):
-      if (id.iphi()==1) neighbor=HcalDetId(id.subdet(),id.ieta(),IPHI_MAX,id.depth()); 
-      else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()-1,id.depth()); 
-      break;
-    case (HcalEndcap):
-      if (id.ietaAbs()>=firstHEQuadPhiRing()) {
-        if (id.iphi()==3) neighbor=HcalDetId(id.subdet(),id.ieta(),IPHI_MAX-1,id.depth()); 
-        else              neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()-4,id.depth()); 
-      } else if (id.ietaAbs()>=firstHEDoublePhiRing()) {
-	if (id.iphi()==1) neighbor=HcalDetId(id.subdet(),id.ieta(),IPHI_MAX-1,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()-2,id.depth()); 
-      } else {
-	if (id.iphi()==1) neighbor=HcalDetId(id.subdet(),id.ieta(),maxPhiHE_,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()-1,id.depth()); 
-      }
-      break;
-    case (HcalForward):
-      if (id.ietaAbs()>=firstHFQuadPhiRing()) {
-	if (id.iphi()==3) neighbor=HcalDetId(id.subdet(),id.ieta(),IPHI_MAX-1,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()-4,id.depth()); 
-      } else {
-	if (id.iphi()==1) neighbor=HcalDetId(id.subdet(),id.ieta(),IPHI_MAX-1,id.depth()); 
-	else neighbor=HcalDetId(id.subdet(),id.ieta(),id.iphi()-2,id.depth()); 
-      }
-      if (!validRaw(neighbor)) ok = false;
-      break;
-    default: ok=false;
+      case (HcalBarrel):
+      case (HcalOuter):
+        if (id.iphi() == 1)
+          neighbor = HcalDetId(id.subdet(), id.ieta(), IPHI_MAX, id.depth());
+        else
+          neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() - 1, id.depth());
+        break;
+      case (HcalEndcap):
+        if (id.ietaAbs() >= firstHEQuadPhiRing()) {
+          if (id.iphi() == 3)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), IPHI_MAX - 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() - 4, id.depth());
+        } else if (id.ietaAbs() >= firstHEDoublePhiRing()) {
+          if (id.iphi() == 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), IPHI_MAX - 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() - 2, id.depth());
+        } else {
+          if (id.iphi() == 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), maxPhiHE_, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() - 1, id.depth());
+        }
+        break;
+      case (HcalForward):
+        if (id.ietaAbs() >= firstHFQuadPhiRing()) {
+          if (id.iphi() == 3)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), IPHI_MAX - 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() - 4, id.depth());
+        } else {
+          if (id.iphi() == 1)
+            neighbor = HcalDetId(id.subdet(), id.ieta(), IPHI_MAX - 1, id.depth());
+          else
+            neighbor = HcalDetId(id.subdet(), id.ieta(), id.iphi() - 2, id.depth());
+        }
+        if (!validRaw(neighbor))
+          ok = false;
+        break;
+      default:
+        ok = false;
     }
-  } 
+  }
   return ok;
 }
 
 int HcalTopology::incIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
-  if (id.zside()==1) return incAIEta(id,neighbors);
-  else return decAIEta(id,neighbors);
+  if (id.zside() == 1)
+    return incAIEta(id, neighbors);
+  else
+    return decAIEta(id, neighbors);
 }
 
 int HcalTopology::decIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
-  if (id.zside()==1) return decAIEta(id,neighbors);
-  else return incAIEta(id,neighbors);
+  if (id.zside() == 1)
+    return decAIEta(id, neighbors);
+  else
+    return incAIEta(id, neighbors);
 }
 
 /** Increasing in |ieta|, there is always at most one neighbor */
 int HcalTopology::incAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
-  int n=1;
-  int aieta=id.ietaAbs();
+  int n = 1;
+  int aieta = id.ietaAbs();
 
-  if (aieta==firstHEDoublePhiRing()-1 && (id.iphi()%2)==0) 
-    neighbors[0]=HcalDetId(id.subdet(),(aieta+1)*id.zside(),id.iphi()-1,id.depth());
-  else if (aieta==firstHFQuadPhiRing()-1 && ((id.iphi()+1)%4)!=0) 
-    neighbors[0]=HcalDetId(id.subdet(),(aieta+1)*id.zside(),((id.iphi()==1)?(71):(id.iphi()-2)),id.depth());
-  else if (aieta==firstHEQuadPhiRing()-1 && ((id.iphi()+1)%4)!=0) 
-    neighbors[0]=HcalDetId(id.subdet(),(aieta+1)*id.zside(),((id.iphi()==1)?(71):(id.iphi()-2)),id.depth());
-  else if (aieta==lastHBRing()) 
-    neighbors[0]=HcalDetId(HcalEndcap,(aieta+1)*id.zside(),id.iphi(),1);
-  else if (aieta==lastHERing()) 
-    neighbors[0]=HcalDetId(HcalForward,etaHE2HF_*id.zside(),id.iphi(),1);
+  if (aieta == firstHEDoublePhiRing() - 1 && (id.iphi() % 2) == 0)
+    neighbors[0] = HcalDetId(id.subdet(), (aieta + 1) * id.zside(), id.iphi() - 1, id.depth());
+  else if (aieta == firstHFQuadPhiRing() - 1 && ((id.iphi() + 1) % 4) != 0)
+    neighbors[0] =
+        HcalDetId(id.subdet(), (aieta + 1) * id.zside(), ((id.iphi() == 1) ? (71) : (id.iphi() - 2)), id.depth());
+  else if (aieta == firstHEQuadPhiRing() - 1 && ((id.iphi() + 1) % 4) != 0)
+    neighbors[0] =
+        HcalDetId(id.subdet(), (aieta + 1) * id.zside(), ((id.iphi() == 1) ? (71) : (id.iphi() - 2)), id.depth());
+  else if (aieta == lastHBRing())
+    neighbors[0] = HcalDetId(HcalEndcap, (aieta + 1) * id.zside(), id.iphi(), 1);
+  else if (aieta == lastHERing())
+    neighbors[0] = HcalDetId(HcalForward, etaHE2HF_ * id.zside(), id.iphi(), 1);
   else
-    neighbors[0]=HcalDetId(id.subdet(),(aieta+1)*id.zside(),id.iphi(),id.depth());
-    
-  if (!valid(neighbors[0])) n=0;
+    neighbors[0] = HcalDetId(id.subdet(), (aieta + 1) * id.zside(), id.iphi(), id.depth());
+
+  if (!valid(neighbors[0]))
+    n = 0;
   return n;
 }
 
 /** Decreasing in |ieta|, there are be two neighbors of 40 and 21*/
 int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
-  int n=1;
-  int aieta=id.ietaAbs();
+  int n = 1;
+  int aieta = id.ietaAbs();
 
-  if (aieta==firstHEDoublePhiRing()) { 
-    n=2;
-    neighbors[0]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi(),id.depth());
-    neighbors[1]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi()+1,id.depth());
-  } else if (aieta==firstHFQuadPhiRing()) {
-    n=2;
-    neighbors[0]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi(),id.depth());
-    if (id.iphi()==IPHI_MAX-1) neighbors[1]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),1,id.depth());
-    else neighbors[1]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi()+2,id.depth());
-  } else if (aieta==firstHEQuadPhiRing()) {
-    n=2;
-    neighbors[0]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi(),id.depth());
-    if (id.iphi()==IPHI_MAX-1) neighbors[1]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),1,id.depth());
-    else                       neighbors[1]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi()+2,id.depth());
-  } else if (aieta==1) {
-    neighbors[0]=HcalDetId(id.subdet(),-aieta*id.zside(),id.iphi(),id.depth());
-  } else if (aieta==firstHERing()) {
-    neighbors[0]=HcalDetId(HcalBarrel,(aieta-1)*id.zside(),id.iphi(),1);
-  } else if (aieta==firstHFRing()) {
-    neighbors[0]=HcalDetId(HcalEndcap,etaHF2HE_*id.zside(),id.iphi(),1);
+  if (aieta == firstHEDoublePhiRing()) {
+    n = 2;
+    neighbors[0] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi(), id.depth());
+    neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi() + 1, id.depth());
+  } else if (aieta == firstHFQuadPhiRing()) {
+    n = 2;
+    neighbors[0] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi(), id.depth());
+    if (id.iphi() == IPHI_MAX - 1)
+      neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), 1, id.depth());
+    else
+      neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi() + 2, id.depth());
+  } else if (aieta == firstHEQuadPhiRing()) {
+    n = 2;
+    neighbors[0] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi(), id.depth());
+    if (id.iphi() == IPHI_MAX - 1)
+      neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), 1, id.depth());
+    else
+      neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi() + 2, id.depth());
+  } else if (aieta == 1) {
+    neighbors[0] = HcalDetId(id.subdet(), -aieta * id.zside(), id.iphi(), id.depth());
+  } else if (aieta == firstHERing()) {
+    neighbors[0] = HcalDetId(HcalBarrel, (aieta - 1) * id.zside(), id.iphi(), 1);
+  } else if (aieta == firstHFRing()) {
+    neighbors[0] = HcalDetId(HcalEndcap, etaHF2HE_ * id.zside(), id.iphi(), 1);
   } else
-    neighbors[0]=HcalDetId(id.subdet(),(aieta-1)*id.zside(),id.iphi(),id.depth());
-  
-  if (!valid(neighbors[0]) && n==2) {
-    if (!valid(neighbors[1])) n=0;
+    neighbors[0] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi(), id.depth());
+
+  if (!valid(neighbors[0]) && n == 2) {
+    if (!valid(neighbors[1]))
+      n = 0;
     else {
-      n=1;
-      neighbors[0]=neighbors[1];
+      n = 1;
+      neighbors[0] = neighbors[1];
     }
   }
-  if (n==2 && !valid(neighbors[1])) n=1;
-  if (n==1 && !valid(neighbors[0])) n=0;
+  if (n == 2 && !valid(neighbors[1]))
+    n = 1;
+  if (n == 1 && !valid(neighbors[0]))
+    n = 0;
 
   return n;
 }
 
-
-void HcalTopology::depthBinInformation(HcalSubdetector subdet, int etaRing,
-				       int iphi, int zside, int & nDepthBins,
-				       int & startingBin) const {
-
-  if(subdet == HcalBarrel) {
-    if (mode_==HcalTopologyMode::SLHC || mode_==HcalTopologyMode::H2HE) {
-      startingBin = hcons_->getMinDepth(0,etaRing,iphi,zside);
-      if (etaRing==lastHBRing()) {
-	nDepthBins = hcons_->getDepthEta16(1,iphi,zside)-startingBin+1;
+void HcalTopology::depthBinInformation(
+    HcalSubdetector subdet, int etaRing, int iphi, int zside, int& nDepthBins, int& startingBin) const {
+  if (subdet == HcalBarrel) {
+    if (mode_ == HcalTopologyMode::SLHC || mode_ == HcalTopologyMode::H2HE) {
+      startingBin = hcons_->getMinDepth(0, etaRing, iphi, zside);
+      if (etaRing == lastHBRing()) {
+        nDepthBins = hcons_->getDepthEta16(1, iphi, zside) - startingBin + 1;
       } else {
-	nDepthBins = hcons_->getMaxDepth(0,etaRing,iphi,zside)-startingBin+1;
+        nDepthBins = hcons_->getMaxDepth(0, etaRing, iphi, zside) - startingBin + 1;
       }
     } else {
-      if (etaRing<=14) {
-	nDepthBins  = 1;
-	startingBin = 1;
+      if (etaRing <= 14) {
+        nDepthBins = 1;
+        startingBin = 1;
       } else {
-	nDepthBins  = 2;
-	startingBin = 1;
+        nDepthBins = 2;
+        startingBin = 1;
       }
     }
-  } else if(subdet == HcalEndcap) {
-    if (mode_==HcalTopologyMode::SLHC || mode_==HcalTopologyMode::H2HE) {
-      if (etaRing==firstHERing()) {
-	startingBin = hcons_->getDepthEta16(2,iphi,zside);
+  } else if (subdet == HcalEndcap) {
+    if (mode_ == HcalTopologyMode::SLHC || mode_ == HcalTopologyMode::H2HE) {
+      if (etaRing == firstHERing()) {
+        startingBin = hcons_->getDepthEta16(2, iphi, zside);
       } else {
-	startingBin = hcons_->getMinDepth(1,etaRing,iphi,zside);
+        startingBin = hcons_->getMinDepth(1, etaRing, iphi, zside);
       }
-      nDepthBins  = hcons_->getMaxDepth(1,etaRing,iphi,zside)-startingBin+1;
+      nDepthBins = hcons_->getMaxDepth(1, etaRing, iphi, zside) - startingBin + 1;
     } else {
-      if (etaRing==firstHERing()) {
-	nDepthBins  = 1;
-	startingBin = 3;
-      } else if (etaRing==17) {
-	nDepthBins  = 1;
-	startingBin = 1;
-      } else if (etaRing==lastHERing()) {
-	nDepthBins  = 2;
-	startingBin = 1;
-      }	else {
-	nDepthBins = (etaRing >= firstHETripleDepthRing()) ? 3 : 2;
-	startingBin = 1;
+      if (etaRing == firstHERing()) {
+        nDepthBins = 1;
+        startingBin = 3;
+      } else if (etaRing == 17) {
+        nDepthBins = 1;
+        startingBin = 1;
+      } else if (etaRing == lastHERing()) {
+        nDepthBins = 2;
+        startingBin = 1;
+      } else {
+        nDepthBins = (etaRing >= firstHETripleDepthRing()) ? 3 : 2;
+        startingBin = 1;
       }
     }
-  } else if(subdet == HcalForward) {
-    nDepthBins  = maxDepthHF_;
+  } else if (subdet == HcalForward) {
+    nDepthBins = maxDepthHF_;
     startingBin = 1;
-  } else if(subdet == HcalOuter) {
-    nDepthBins  = 1;
+  } else if (subdet == HcalOuter) {
+    nDepthBins = 1;
     startingBin = 4;
   } else {
     std::cerr << "Bad HCAL subdetector " << subdet << std::endl;
   }
 }
 
-bool HcalTopology::incrementDepth(HcalDetId & detId) const {
-
+bool HcalTopology::incrementDepth(HcalDetId& detId) const {
   HcalSubdetector subdet = detId.subdet();
-  int ieta    = detId.ieta();
+  int ieta = detId.ieta();
   int etaRing = detId.ietaAbs();
-  int depth   = detId.depth();
-  int iphi    = detId.iphi();
-  int zside   = detId.zside();
+  int depth = detId.depth();
+  int iphi = detId.iphi();
+  int zside = detId.zside();
   int nDepthBins(0), startingBin(0);
   depthBinInformation(subdet, etaRing, iphi, zside, nDepthBins, startingBin);
 
   // see if the new depth bin exists
   ++depth;
-  if (depth >= (startingBin+nDepthBins)) {
+  if (depth >= (startingBin + nDepthBins)) {
     // handle on a case-by-case basis
-    if (subdet == HcalBarrel && etaRing < lastHORing())  {
+    if (subdet == HcalBarrel && etaRing < lastHORing()) {
       // HO
       subdet = HcalOuter;
-      depth  = 4;
+      depth = 4;
     } else if (subdet == HcalBarrel && etaRing == lastHBRing()) {
       // overlap
       subdet = HcalEndcap;
-      if (mode_==HcalTopologyMode::SLHC || mode_==HcalTopologyMode::H2HE) 
-	depth = hcons_->getDepthEta16(2,iphi,zside);
-    } else if (subdet == HcalEndcap && etaRing ==  lastHERing()-1 &&
-               mode_ != HcalTopologyMode::SLHC) {
+      if (mode_ == HcalTopologyMode::SLHC || mode_ == HcalTopologyMode::H2HE)
+        depth = hcons_->getDepthEta16(2, iphi, zside);
+    } else if (subdet == HcalEndcap && etaRing == lastHERing() - 1 && mode_ != HcalTopologyMode::SLHC) {
       // guard ring HF29 is behind HE 28
       subdet = HcalForward;
       (ieta > 0) ? ++ieta : --ieta;
       depth = 1;
-    } else if (subdet == HcalEndcap && etaRing ==  lastHERing() &&
-	       mode_ != HcalTopologyMode::SLHC) {
+    } else if (subdet == HcalEndcap && etaRing == lastHERing() && mode_ != HcalTopologyMode::SLHC) {
       // split cells go to bigger granularity.  Ring 29 -> 28
       (ieta > 0) ? --ieta : ++ieta;
     } else {
@@ -827,40 +910,38 @@ bool HcalTopology::incrementDepth(HcalDetId & detId) const {
   return validRaw(detId);
 }
 
-bool HcalTopology::decrementDepth(HcalDetId & detId) const {
+bool HcalTopology::decrementDepth(HcalDetId& detId) const {
   HcalSubdetector subdet = detId.subdet();
-  int ieta    = detId.ieta();
+  int ieta = detId.ieta();
   int etaRing = detId.ietaAbs();
-  int depth   = detId.depth();
-  int iphi    = detId.iphi();
-  int zside   = detId.zside();
+  int depth = detId.depth();
+  int iphi = detId.iphi();
+  int zside = detId.zside();
   int nDepthBins, startingBin;
   depthBinInformation(subdet, etaRing, iphi, zside, nDepthBins, startingBin);
 
   // see if the new depth bin exists
   --depth;
-  if ((subdet == HcalOuter) ||
-      (subdet == HcalEndcap && etaRing == firstHERing())) {
+  if ((subdet == HcalOuter) || (subdet == HcalEndcap && etaRing == firstHERing())) {
     subdet = HcalBarrel;
-    for (int i=0; i<nEtaHB_; ++i) {
+    for (int i = 0; i < nEtaHB_; ++i) {
       if (etaRing == etaBinsHB_[i].ieta) {
-        depth = etaBinsHB_[i].depthStart+etaBinsHB_[i].layer.size()-1;
+        depth = etaBinsHB_[i].depthStart + etaBinsHB_[i].layer.size() - 1;
         break;
       }
     }
-  } else if (subdet == HcalEndcap && etaRing ==  lastHERing() && 
-	     depth == hcons_->getDepthEta29(iphi,zside,0) &&
+  } else if (subdet == HcalEndcap && etaRing == lastHERing() && depth == hcons_->getDepthEta29(iphi, zside, 0) &&
              mode_ != HcalTopologyMode::SLHC) {
     (ieta > 0) ? --ieta : ++ieta;
   } else if (depth <= 0) {
-    if (subdet == HcalForward && etaRing ==  firstHFRing()) {
+    if (subdet == HcalForward && etaRing == firstHFRing()) {
       // overlap
       subdet = HcalEndcap;
-      etaRing= etaHF2HE_;
-      ieta   = (ieta > 0) ? etaRing : -etaRing;
-      for (const auto & i : etaBinsHE_) {
+      etaRing = etaHF2HE_;
+      ieta = (ieta > 0) ? etaRing : -etaRing;
+      for (const auto& i : etaBinsHE_) {
         if (etaRing == i.ieta) {
-          depth = i.depthStart+i.layer.size()-1;
+          depth = i.depthStart + i.layer.size() - 1;
           break;
         }
       }
@@ -875,12 +956,13 @@ bool HcalTopology::decrementDepth(HcalDetId & detId) const {
 }
 
 int HcalTopology::nPhiBins(int etaRing) const {
-  int lastPhiBin=singlePhiBins_;
-  if      (etaRing >= firstHFQuadPhiRing() || etaRing >= firstHEQuadPhiRing()) lastPhiBin=doublePhiBins_/2;
-  else if (etaRing >= firstHEDoublePhiRing())                                  lastPhiBin=doublePhiBins_;
-  if (hcons_ && etaRing >= hcons_->getEtaRange(1).first && 
-	etaRing <= hcons_->getEtaRange(1).second)  {
-		return nPhiBins(HcalBarrel, etaRing);
+  int lastPhiBin = singlePhiBins_;
+  if (etaRing >= firstHFQuadPhiRing() || etaRing >= firstHEQuadPhiRing())
+    lastPhiBin = doublePhiBins_ / 2;
+  else if (etaRing >= firstHEDoublePhiRing())
+    lastPhiBin = doublePhiBins_;
+  if (hcons_ && etaRing >= hcons_->getEtaRange(1).first && etaRing <= hcons_->getEtaRange(1).second) {
+    return nPhiBins(HcalBarrel, etaRing);
   }
   return lastPhiBin;
 }
@@ -888,9 +970,9 @@ int HcalTopology::nPhiBins(int etaRing) const {
 int HcalTopology::nPhiBins(HcalSubdetector bc, int etaRing) const {
   double phiTableVal;
   if (bc == HcalForward) {
-    phiTableVal = dPhiTableHF[etaRing-firstHFRing_];
+    phiTableVal = dPhiTableHF[etaRing - firstHFRing_];
   } else {
-    phiTableVal = dPhiTable[etaRing-firstHBRing_];
+    phiTableVal = dPhiTable[etaRing - firstHBRing_];
   }
   int lastPhiBin = 0;
   if (phiTableVal != 0.0)
@@ -899,36 +981,41 @@ int HcalTopology::nPhiBins(HcalSubdetector bc, int etaRing) const {
 }
 
 int HcalTopology::maxDepth() const {
-  int maxd1 = std::max(maxDepthHB_,maxDepthHE_);
-  int maxd2 = std::max(maxDepthHF_,minMaxDepth_);
-  return std::max(maxd1,maxd2);
+  int maxd1 = std::max(maxDepthHB_, maxDepthHE_);
+  int maxd2 = std::max(maxDepthHF_, minMaxDepth_);
+  return std::max(maxd1, maxd2);
 }
 
 int HcalTopology::maxDepth(HcalSubdetector bc) const {
-  if      (bc == HcalBarrel)  return maxDepthHB_;
-  else if (bc == HcalEndcap)  return maxDepthHE_;
-  else if (bc == HcalForward) return maxDepthHF_;
-  else                        return 4;
+  if (bc == HcalBarrel)
+    return maxDepthHB_;
+  else if (bc == HcalEndcap)
+    return maxDepthHE_;
+  else if (bc == HcalForward)
+    return maxDepthHF_;
+  else
+    return 4;
 }
 
 int HcalTopology::etaRing(HcalSubdetector bc, double abseta) const {
   int etaring = firstHBRing_;
   if (bc == HcalForward) {
     etaring = firstHFRing_;
-    for (unsigned int k=0; k<etaTableHF.size()-1; ++k) {
-      if (abseta < etaTableHF[k+1]) {
+    for (unsigned int k = 0; k < etaTableHF.size() - 1; ++k) {
+      if (abseta < etaTableHF[k + 1]) {
         etaring += k;
         break;
       }
     }
   } else {
-    for (unsigned int k=0; k<etaTable.size()-1; ++k) {
-      if (abseta < etaTable[k+1]) {
+    for (unsigned int k = 0; k < etaTable.size() - 1; ++k) {
+      if (abseta < etaTable[k + 1]) {
         etaring += k;
         break;
       }
     }
-    if (abseta >= etaTable[etaTable.size()-1]) etaring = lastHERing_;
+    if (abseta >= etaTable[etaTable.size() - 1])
+      etaring = lastHERing_;
   }
   return etaring;
 }
@@ -937,43 +1024,47 @@ int HcalTopology::phiBin(HcalSubdetector bc, int etaring, double phi) const {
   //put phi in correct range (0->2pi)
   int index(0);
   if (bc == HcalBarrel) {
-    index = (etaring-firstHBRing_);
-    phi  -= phioff[0];
+    index = (etaring - firstHBRing_);
+    phi -= phioff[0];
   } else if (bc == HcalEndcap) {
-    index = (etaring-firstHBRing_);
-    phi  -= phioff[1];
+    index = (etaring - firstHBRing_);
+    phi -= phioff[1];
   } else if (bc == HcalForward) {
-    index = (etaring-firstHFRing_);
+    index = (etaring - firstHFRing_);
     if (index < static_cast<int>(dPhiTableHF.size())) {
-      if (index >= 0 && unitPhiHF[index] > 2) phi -= phioff[4];
-      else                                    phi -= phioff[2];
+      if (index >= 0 && unitPhiHF[index] > 2)
+        phi -= phioff[4];
+      else
+        phi -= phioff[2];
     }
   }
-	if (index < 0)
-		index = 0;
-  if (phi < 0.0)   phi += 2._pi;
-  else if (phi > 2._pi) phi -= 2._pi;
+  if (index < 0)
+    index = 0;
+  if (phi < 0.0)
+    phi += 2._pi;
+  else if (phi > 2._pi)
+    phi -= 2._pi;
   int phibin(1), unit(1);
   if (bc == HcalForward) {
     if (index < (int)(dPhiTableHF.size())) {
-      unit    = unitPhiHF[index];
-      phibin  = static_cast<int>(phi/dPhiTableHF[index])+1;
+      unit = unitPhiHF[index];
+      phibin = static_cast<int>(phi / dPhiTableHF[index]) + 1;
     }
   } else {
     if (index < (int)(dPhiTable.size())) {
-      phibin  = static_cast<int>(phi/dPhiTable[index])+1;
-      unit    = unitPhi[index];
+      phibin = static_cast<int>(phi / dPhiTable[index]) + 1;
+      unit = unitPhi[index];
     }
   }
   int iphi(phibin);
-  if      (unit == 2) iphi = (phibin-1)*2+1;
-  else if (unit == 4) iphi = (phibin-1)*4+3;
+  if (unit == 2)
+    iphi = (phibin - 1) * 2 + 1;
+  else if (unit == 4)
+    iphi = (phibin - 1) * 4 + 3;
   return iphi;
 }
 
-void HcalTopology::getDepthSegmentation(const unsigned ring, 
-					std::vector<int> & readoutDepths,
-					const bool one) const {
+void HcalTopology::getDepthSegmentation(const unsigned ring, std::vector<int>& readoutDepths, const bool one) const {
   // if it doesn't exist, return the first entry with a lower index.  So if we only
   // have entries for 1 and 17, any input from 1-16 should return the entry for ring 1
   SegmentationMap::const_iterator pos;
@@ -993,9 +1084,7 @@ void HcalTopology::getDepthSegmentation(const unsigned ring,
   readoutDepths = pos->second;
 }
 
-void HcalTopology::setDepthSegmentation(const unsigned ring, 
-					const std::vector<int> & readoutDepths,
-					const bool one) {
+void HcalTopology::setDepthSegmentation(const unsigned ring, const std::vector<int>& readoutDepths, const bool one) {
   if (one) {
     depthSegmentationOne_[ring] = readoutDepths;
   } else {
@@ -1003,9 +1092,7 @@ void HcalTopology::setDepthSegmentation(const unsigned ring,
   }
 }
 
-std::pair<int, int> HcalTopology::segmentBoundaries(const unsigned ring, 
-						    const unsigned depth,
-						    const bool one) const {
+std::pair<int, int> HcalTopology::segmentBoundaries(const unsigned ring, const unsigned depth, const bool one) const {
   std::vector<int> readoutDepths;
   getDepthSegmentation(ring, readoutDepths, one);
   int d1 = std::lower_bound(readoutDepths.begin(), readoutDepths.end(), depth) - readoutDepths.begin();
@@ -1016,156 +1103,176 @@ std::pair<int, int> HcalTopology::segmentBoundaries(const unsigned ring,
 double HcalTopology::etaMax(HcalSubdetector subdet) const {
   double eta(0);
   switch (subdet) {
-  case(HcalBarrel):  
-    if (lastHBRing_ < (int)(etaTable.size())) eta=etaTable[lastHBRing_];
-    break;
-  case(HcalEndcap):  
-    if (lastHERing_ < (int)(etaTable.size()) && nEtaHE_ > 0) eta=etaTable[lastHERing_];
-    break;
-  case(HcalOuter): 
-    if (lastHORing_ < (int)(etaTable.size())) eta=etaTable[lastHORing_];
-    break;
-  case(HcalForward): 
-    if (!etaTableHF.empty()) eta=etaTableHF[etaTableHF.size()-1];
-    break;
-  default: eta=0;
+    case (HcalBarrel):
+      if (lastHBRing_ < (int)(etaTable.size()))
+        eta = etaTable[lastHBRing_];
+      break;
+    case (HcalEndcap):
+      if (lastHERing_ < (int)(etaTable.size()) && nEtaHE_ > 0)
+        eta = etaTable[lastHERing_];
+      break;
+    case (HcalOuter):
+      if (lastHORing_ < (int)(etaTable.size()))
+        eta = etaTable[lastHORing_];
+      break;
+    case (HcalForward):
+      if (!etaTableHF.empty())
+        eta = etaTableHF[etaTableHF.size() - 1];
+      break;
+    default:
+      eta = 0;
   }
   return eta;
 }
-std::pair<double,double> HcalTopology::etaRange(HcalSubdetector subdet, 
-                                                int keta) const {
+std::pair<double, double> HcalTopology::etaRange(HcalSubdetector subdet, int keta) const {
   int ieta = (keta > 0) ? keta : -keta;
   if (subdet == HcalForward) {
     if (ieta >= firstHFRing_) {
-      unsigned int ii = (unsigned int)(ieta-firstHFRing_);
-      if (ii+1 < etaTableHF.size()) 
-	return std::pair<double,double>(etaTableHF[ii],etaTableHF[ii+1]);
+      unsigned int ii = (unsigned int)(ieta - firstHFRing_);
+      if (ii + 1 < etaTableHF.size())
+        return std::pair<double, double>(etaTableHF[ii], etaTableHF[ii + 1]);
     }
   } else {
-    int ietal = (mode_==HcalTopologyMode::LHC && ieta == lastHERing_-1) ? (ieta+1) : ieta;
+    int ietal = (mode_ == HcalTopologyMode::LHC && ieta == lastHERing_ - 1) ? (ieta + 1) : ieta;
     if ((ietal < (int)(etaTable.size())) && (ieta > 0))
-      return std::pair<double,double>(etaTable[ieta-1],etaTable[ietal]);
+      return std::pair<double, double>(etaTable[ieta - 1], etaTable[ietal]);
   }
-  return std::pair<double,double>(0,0);
+  return std::pair<double, double>(0, 0);
 }
 
-unsigned int HcalTopology::detId2denseIdPreLS1 (const DetId& id) const {
-
+unsigned int HcalTopology::detId2denseIdPreLS1(const DetId& id) const {
   HcalDetId hid(id);
-  const HcalSubdetector sd (hid.subdet()  ) ;
-  const int             ip (hid.iphi()    ) ;
-  const int             ie (hid.ietaAbs() ) ;
-  const int             dp (hid.depth()   ) ;
-  const int             zn (hid.zside() < 0 ? 1 : 0 ) ;
-  unsigned int  retval = ( ( sd == HcalBarrel ) ?
-			   ( ip - 1 )*18 + dp - 1 + ie - ( ie<16 ? 1 : 0 ) + zn*kHBhalf :
-			   ( ( sd == HcalEndcap ) ?
-			     2*kHBhalf + ( ip - 1 )*8 + ( ip/2 )*20 +
-			     ( ( ie==16 || ie==17 ) ? ie - 16 :
-			       ( ( ie>=18 && ie<=20 ) ? 2 + 2*( ie - 18 ) + dp - 1 :
-				 ( ( ie>=21 && ie<=26 ) ? 8 + 2*( ie - 21 ) + dp - 1 :
-				   ( ( ie>=27 && ie<=28 ) ? 20 + 3*( ie - 27 ) + dp - 1 :
-				     26 + 2*( ie - 29 ) + dp - 1 ) ) ) ) + zn*kHEhalf :
-			     ( ( sd == HcalOuter ) ?
-			       2*kHBhalf + 2*kHEhalf + ( ip - 1 )*15 + ( ie - 1 ) + zn*kHOhalf :
-			       ( ( sd == HcalForward ) ?
-				 2*kHBhalf + 2*kHEhalf + 2*kHOhalf + 
-				 ( ( ip - 1 )/4 )*4 + ( ( ip - 1 )/2 )*22 + 
-				 2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalf : 0xFFFFFFFFu ) ) ) ) ; 
+  const HcalSubdetector sd(hid.subdet());
+  const int ip(hid.iphi());
+  const int ie(hid.ietaAbs());
+  const int dp(hid.depth());
+  const int zn(hid.zside() < 0 ? 1 : 0);
+  unsigned int retval =
+      ((sd == HcalBarrel)
+           ? (ip - 1) * 18 + dp - 1 + ie - (ie < 16 ? 1 : 0) + zn * kHBhalf
+           : ((sd == HcalEndcap)
+                  ? 2 * kHBhalf + (ip - 1) * 8 + (ip / 2) * 20 +
+                        ((ie == 16 || ie == 17)
+                             ? ie - 16
+                             : ((ie >= 18 && ie <= 20)
+                                    ? 2 + 2 * (ie - 18) + dp - 1
+                                    : ((ie >= 21 && ie <= 26)
+                                           ? 8 + 2 * (ie - 21) + dp - 1
+                                           : ((ie >= 27 && ie <= 28) ? 20 + 3 * (ie - 27) + dp - 1
+                                                                     : 26 + 2 * (ie - 29) + dp - 1)))) +
+                        zn * kHEhalf
+                  : ((sd == HcalOuter)
+                         ? 2 * kHBhalf + 2 * kHEhalf + (ip - 1) * 15 + (ie - 1) + zn * kHOhalf
+                         : ((sd == HcalForward) ? 2 * kHBhalf + 2 * kHEhalf + 2 * kHOhalf + ((ip - 1) / 4) * 4 +
+                                                      ((ip - 1) / 2) * 22 + 2 * (ie - 29) + (dp - 1) + zn * kHFhalf
+                                                : 0xFFFFFFFFu))));
   return retval;
 }
 
-
 unsigned int HcalTopology::detId2denseIdHB(const DetId& id) const {
   HcalDetId hid(id);
-  const int             ip (hid.iphi()    ) ;
-  const int             ie (hid.ietaAbs() ) ;
-  const int             dp (hid.depth()   ) ;
-  const int             zn (hid.zside() < 0 ? 1 : 0 ) ;
-  unsigned int  retval = 0xFFFFFFFFu;
-  if (topoVersion_==0) {
-    retval=( ip - 1 )*18 + dp - 1 + ie - ( ie<16 ? 1 : 0 ) + zn*kHBhalf;
-  } else if (topoVersion_==10) {
-    retval=(dp-1)+maxDepthHB_*(ip-1);
-    if (hid.ieta()>0) retval+=maxDepthHB_*IPHI_MAX*(hid.ieta()-firstHBRing());
-    else              retval+=maxDepthHB_*IPHI_MAX*(hid.ieta()+lastHBRing()+nEtaHB_);
+  const int ip(hid.iphi());
+  const int ie(hid.ietaAbs());
+  const int dp(hid.depth());
+  const int zn(hid.zside() < 0 ? 1 : 0);
+  unsigned int retval = 0xFFFFFFFFu;
+  if (topoVersion_ == 0) {
+    retval = (ip - 1) * 18 + dp - 1 + ie - (ie < 16 ? 1 : 0) + zn * kHBhalf;
+  } else if (topoVersion_ == 10) {
+    retval = (dp - 1) + maxDepthHB_ * (ip - 1);
+    if (hid.ieta() > 0)
+      retval += maxDepthHB_ * IPHI_MAX * (hid.ieta() - firstHBRing());
+    else
+      retval += maxDepthHB_ * IPHI_MAX * (hid.ieta() + lastHBRing() + nEtaHB_);
   }
   return retval;
 }
 
 unsigned int HcalTopology::detId2denseIdHE(const DetId& id) const {
   HcalDetId hid(id);
-  const int             ip (hid.iphi()    ) ;
-  const int             ie (hid.ietaAbs() ) ;
-  const int             dp (hid.depth()   ) ;
-  const int             zn (hid.zside() < 0 ? 1 : 0 ) ;
-  unsigned int  retval =  0xFFFFFFFFu;
-  if (topoVersion_==0) {
-    retval=( ip - 1 )*8 + ( ip/2 )*20 +
-      ( ( ie==16 || ie==17 ) ? ie - 16 :
-	( ( ie>=18 && ie<=20 ) ? 2 + 2*( ie - 18 ) + dp - 1 :
-	  ( ( ie>=21 && ie<=26 ) ? 8 + 2*( ie - 21 ) + dp - 1 :
-	    ( ( ie>=27 && ie<=28 ) ? 20 + 3*( ie - 27 ) + dp - 1 :
-	      26 + 2*( ie - 29 ) + dp - 1 ) ) ) ) + zn*kHEhalf;
-  } else if (topoVersion_==10) {
-    retval=(dp-1)+maxDepthHE_*(ip-1);
-    if (hid.ieta()>0) retval+=maxDepthHE_*maxPhiHE_*(hid.ieta()-firstHERing());
-    else              retval+=maxDepthHE_*maxPhiHE_*(hid.ieta()+lastHERing()+nEtaHE_);
+  const int ip(hid.iphi());
+  const int ie(hid.ietaAbs());
+  const int dp(hid.depth());
+  const int zn(hid.zside() < 0 ? 1 : 0);
+  unsigned int retval = 0xFFFFFFFFu;
+  if (topoVersion_ == 0) {
+    retval = (ip - 1) * 8 + (ip / 2) * 20 +
+             ((ie == 16 || ie == 17)
+                  ? ie - 16
+                  : ((ie >= 18 && ie <= 20)
+                         ? 2 + 2 * (ie - 18) + dp - 1
+                         : ((ie >= 21 && ie <= 26) ? 8 + 2 * (ie - 21) + dp - 1
+                                                   : ((ie >= 27 && ie <= 28) ? 20 + 3 * (ie - 27) + dp - 1
+                                                                             : 26 + 2 * (ie - 29) + dp - 1)))) +
+             zn * kHEhalf;
+  } else if (topoVersion_ == 10) {
+    retval = (dp - 1) + maxDepthHE_ * (ip - 1);
+    if (hid.ieta() > 0)
+      retval += maxDepthHE_ * maxPhiHE_ * (hid.ieta() - firstHERing());
+    else
+      retval += maxDepthHE_ * maxPhiHE_ * (hid.ieta() + lastHERing() + nEtaHE_);
   }
   return retval;
 }
 
 unsigned int HcalTopology::detId2denseIdHO(const DetId& id) const {
   HcalDetId hid(id);
-  const int             ip (hid.iphi()    ) ;
-  const int             ie (hid.ietaAbs() ) ;
-  const int             zn (hid.zside() < 0 ? 1 : 0 ) ;
+  const int ip(hid.iphi());
+  const int ie(hid.ietaAbs());
+  const int zn(hid.zside() < 0 ? 1 : 0);
 
-  unsigned int  retval = 0xFFFFFFFFu;
-  if (topoVersion_==0) {
-    retval=( ip - 1 )*15 + ( ie - 1 ) + zn*kHOhalf;
-  } else if (topoVersion_==10) {
-    if   (hid.ieta()>0) retval=(ip-1)+IPHI_MAX*(hid.ieta()-1);
-    else                retval=(ip-1)+IPHI_MAX*(30+hid.ieta());
+  unsigned int retval = 0xFFFFFFFFu;
+  if (topoVersion_ == 0) {
+    retval = (ip - 1) * 15 + (ie - 1) + zn * kHOhalf;
+  } else if (topoVersion_ == 10) {
+    if (hid.ieta() > 0)
+      retval = (ip - 1) + IPHI_MAX * (hid.ieta() - 1);
+    else
+      retval = (ip - 1) + IPHI_MAX * (30 + hid.ieta());
   }
   return retval;
 }
 
 unsigned int HcalTopology::detId2denseIdHF(const DetId& id) const {
   HcalDetId hid(id);
-  const int             ip (hid.iphi()    ) ;
-  const int             ie (hid.ietaAbs() ) ;
-  const int             dp (hid.depth()   ) ;
-  const int             zn (hid.zside() < 0 ? 1 : 0 ) ;
+  const int ip(hid.iphi());
+  const int ie(hid.ietaAbs());
+  const int dp(hid.depth());
+  const int zn(hid.zside() < 0 ? 1 : 0);
 
-  unsigned int  retval = 0xFFFFFFFFu;
-  if (topoVersion_==0) {
-    retval = ( ( ip - 1 )/4 )*4 + ( ( ip - 1 )/2 )*22 + 
-      2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalf;
-  } else if (topoVersion_==10) {
-    retval=dp-1+2*(ip-1);
-    if (hid.ieta()>0) retval+=maxDepthHF_*IPHI_MAX*(hid.ieta()-29);
-    else              retval+=maxDepthHF_*IPHI_MAX*((41+13)+hid.ieta());
+  unsigned int retval = 0xFFFFFFFFu;
+  if (topoVersion_ == 0) {
+    retval = ((ip - 1) / 4) * 4 + ((ip - 1) / 2) * 22 + 2 * (ie - 29) + (dp - 1) + zn * kHFhalf;
+  } else if (topoVersion_ == 10) {
+    retval = dp - 1 + 2 * (ip - 1);
+    if (hid.ieta() > 0)
+      retval += maxDepthHF_ * IPHI_MAX * (hid.ieta() - 29);
+    else
+      retval += maxDepthHF_ * IPHI_MAX * ((41 + 13) + hid.ieta());
   }
   return retval;
 }
 
 unsigned int HcalTopology::detId2denseIdHT(const DetId& id) const {
-  HcalTrigTowerDetId tid(id); 
+  HcalTrigTowerDetId tid(id);
   int zside = tid.zside();
   unsigned int ietaAbs = tid.ietaAbs();
-  unsigned int iphi  = tid.iphi();
+  unsigned int iphi = tid.iphi();
   unsigned int ivers = tid.version();
 
   unsigned int index;
-  if (ivers  == 0) {
-    if ((iphi-1)%4==0) index = (iphi-1)*32 + (ietaAbs-1) - (12*((iphi-1)/4));
-    else               index = (iphi-1)*28 + (ietaAbs-1) + (4*(((iphi-1)/4)+1));
-    if (zside == -1) index += kHThalf;
+  if (ivers == 0) {
+    if ((iphi - 1) % 4 == 0)
+      index = (iphi - 1) * 32 + (ietaAbs - 1) - (12 * ((iphi - 1) / 4));
+    else
+      index = (iphi - 1) * 28 + (ietaAbs - 1) + (4 * (((iphi - 1) / 4) + 1));
+    if (zside == -1)
+      index += kHThalf;
   } else {
     index = kHTSizePreLS1;
-    if (zside == -1) index += ((kHTSizePhase1-kHTSizePreLS1)/2);
-    index += (36 * (ietaAbs - 30) + ((iphi - 1)/2));
+    if (zside == -1)
+      index += ((kHTSizePhase1 - kHTSizePreLS1) / 2);
+    index += (36 * (ietaAbs - 30) + ((iphi - 1) / 2));
   }
 
   return index;
@@ -1177,184 +1284,179 @@ unsigned int HcalTopology::detId2denseIdCALIB(const DetId& id) const {
   int ieta = tid.ieta();
   int iphi = tid.iphi();
   int zside = tid.zside();
-  unsigned int index=0xFFFFFFFFu;
-      
-  if (tid.calibFlavor()==HcalCalibDetId::CalibrationBox) {
-        
+  unsigned int index = 0xFFFFFFFFu;
+
+  if (tid.calibFlavor() == HcalCalibDetId::CalibrationBox) {
     HcalSubdetector subDet = tid.hcalSubdet();
-        
-    if (subDet==HcalBarrel) {
+
+    if (subDet == HcalBarrel) {
       //std::cout<<"CALIB_HB:  ";
       //dphi = 4 (18 phi values), 3 channel types (0,1,2), eta = -1 or 1
       //total of 18*3*2=108 channels
-      index = ((iphi+1)/4-1) + 18*channel + 27*(ieta+1);
-    } else if (subDet==HcalEndcap) {
+      index = ((iphi + 1) / 4 - 1) + 18 * channel + 27 * (ieta + 1);
+    } else if (subDet == HcalEndcap) {
       //std::cout<<"CALIB_HE:  ";
       //dphi = 4 (18 phi values), 6 channel types (0,1,3,4,5,6), eta = -1 or 1
       //total of 18*6*2=216 channels
-      if (channel>2) channel-=1;
-      index = ((iphi+1)/4-1) + 18*channel + 54*(ieta+1) + 108;
-    } else if (subDet==HcalForward) {
+      if (channel > 2)
+        channel -= 1;
+      index = ((iphi + 1) / 4 - 1) + 18 * channel + 54 * (ieta + 1) + 108;
+    } else if (subDet == HcalForward) {
       //std::cout<<"CALIB_HF:  ";
       //dphi = 18 (4 phi values), 3 channel types (0,1,8), eta = -1 or 1
-      if (channel==8) channel = 2;
+      if (channel == 8)
+        channel = 2;
       //total channels 4*3*2=24
-      index = (iphi-1)/18 + 4*channel + 6*(ieta+1) + 324;
-    } else if (subDet==HcalOuter) {
+      index = (iphi - 1) / 18 + 4 * channel + 6 * (ieta + 1) + 324;
+    } else if (subDet == HcalOuter) {
       //std::cout<<"CALIB_HO:  ";
       //there are 5 special calib crosstalk channels, one in each ring
-      if (channel==7) {
-	index = (ieta+2) + 420;
-      //for HOM/HOP dphi = 6 (12 phi values),  2 channel types (0,1), eta = -2,-1 or 1,2
-      //for HO0/YB0 dphi = 12 (6 phi values),  2 channel types (0,1), eta = 0
-      } else{
-	if (ieta<0) index      = ((iphi+1)/12-1) + 36*channel + 6*(ieta+2) + 348;
-	else if (ieta>0) index = ((iphi+1)/12-1) + 36*channel + 6*(ieta+2) + 6 + 348;
-	else index             = ((iphi+1)/6-1)  + 36*channel + 6*(ieta+2) + 348;
+      if (channel == 7) {
+        index = (ieta + 2) + 420;
+        //for HOM/HOP dphi = 6 (12 phi values),  2 channel types (0,1), eta = -2,-1 or 1,2
+        //for HO0/YB0 dphi = 12 (6 phi values),  2 channel types (0,1), eta = 0
+      } else {
+        if (ieta < 0)
+          index = ((iphi + 1) / 12 - 1) + 36 * channel + 6 * (ieta + 2) + 348;
+        else if (ieta > 0)
+          index = ((iphi + 1) / 12 - 1) + 36 * channel + 6 * (ieta + 2) + 6 + 348;
+        else
+          index = ((iphi + 1) / 6 - 1) + 36 * channel + 6 * (ieta + 2) + 348;
       }
     } else {
       edm::LogWarning("CaloTopology") << "HCAL Det Id not valid!";
       index = 0;
     }
-        
-  } else if (tid.calibFlavor()==HcalCalibDetId::HOCrosstalk) {
+
+  } else if (tid.calibFlavor() == HcalCalibDetId::HOCrosstalk) {
     //std::cout<<"HX:  ";
     //for YB0/HO0 phi is grouped in 6 groups of 6 with dphi=2 but the transitions are 1 or 3
     // in such a way that the %36 operation yeilds unique values for every iphi
-    if (abs(ieta)==4)  index = ((iphi-1)%36) + (((zside+1)*36)/2) + 72 + 425;   //ieta = 1 YB0/HO0;
-    else               index = (iphi-1) + (36*(zside+1)*2) + 425;  //ieta = 0 for HO2M/HO1M ieta=2 for HO1P/HO2P;
-  } else if (tid.calibFlavor()==HcalCalibDetId::HBX) {
-    index = kOffCalibHBX_ + (iphi-1) + (zside+1)*nPhiCalibHBX_/2;
-  } else if (tid.calibFlavor()==HcalCalibDetId::HEX) {
+    if (abs(ieta) == 4)
+      index = ((iphi - 1) % 36) + (((zside + 1) * 36) / 2) + 72 + 425;  //ieta = 1 YB0/HO0;
+    else
+      index = (iphi - 1) + (36 * (zside + 1) * 2) + 425;  //ieta = 0 for HO2M/HO1M ieta=2 for HO1P/HO2P;
+  } else if (tid.calibFlavor() == HcalCalibDetId::HBX) {
+    index = kOffCalibHBX_ + (iphi - 1) + (zside + 1) * nPhiCalibHBX_ / 2;
+  } else if (tid.calibFlavor() == HcalCalibDetId::HEX) {
     if (std::abs(ieta) == etaCalibHEX_[0]) {
-      index = kOffCalibHEX_+(iphi-1)/mPhiCalibHEX_+(zside+1)*nPhiCalibHEX_/2;
+      index = kOffCalibHEX_ + (iphi - 1) / mPhiCalibHEX_ + (zside + 1) * nPhiCalibHEX_ / 2;
     } else if (std::abs(ieta) == etaCalibHEX_[1]) {
-      index =(kOffCalibHEX_+(iphi-1)/mPhiCalibHEX_+(zside+1)*nPhiCalibHEX_/2+
-	      2*nPhiCalibHEX_);
+      index = (kOffCalibHEX_ + (iphi - 1) / mPhiCalibHEX_ + (zside + 1) * nPhiCalibHEX_ / 2 + 2 * nPhiCalibHEX_);
     }
   }
   //std::cout << "  " << ieta << "  " << zside << "  " << iphi << "  " << depth << "  " << index << std::endl;
   return index;
 }
 
-
 HcalCalibDetId HcalTopology::denseId2detIdCALIB(const unsigned int& hid) const {
-
   HcalCalibDetId id;
   unsigned int hid0(hid);
   if (hid0 < kOffCalibHOX_) {
     HcalSubdetector subdet(HcalEmpty);
     int id0, ieta, iphi, ichan, ctype;
     if (hid0 < kOffCalibHE_) {
-      id0    = static_cast<int>(hid0);
+      id0 = static_cast<int>(hid0);
       subdet = HcalBarrel;
-      iphi   = hid0%kPhiCalibHBHE_;
-      ieta   = ((hid0 < nchanCalibHB_*kPhiCalibHBHE_) ? etaCalibHBHEHF_[0] :
-		etaCalibHBHEHF_[1]);
-      ichan  = (id0-iphi-(ieta+1)*kchanCalibHB_)/kPhiCalibHBHE_;
-      iphi   = mPhiCalibHBHE_*(iphi+1) - 1;
-      ctype  = chanCalibHB_[ichan];
+      iphi = hid0 % kPhiCalibHBHE_;
+      ieta = ((hid0 < nchanCalibHB_ * kPhiCalibHBHE_) ? etaCalibHBHEHF_[0] : etaCalibHBHEHF_[1]);
+      ichan = (id0 - iphi - (ieta + 1) * kchanCalibHB_) / kPhiCalibHBHE_;
+      iphi = mPhiCalibHBHE_ * (iphi + 1) - 1;
+      ctype = chanCalibHB_[ichan];
     } else if (hid0 < kOffCalibHF_) {
-      hid0  -= kOffCalibHE_;
-      id0    = static_cast<int>(hid0);
+      hid0 -= kOffCalibHE_;
+      id0 = static_cast<int>(hid0);
       subdet = HcalEndcap;
-      iphi   = hid0%kPhiCalibHBHE_;
-      ieta   = ((hid0 < nchanCalibHE_*kPhiCalibHBHE_) ? etaCalibHBHEHF_[0] :
-		etaCalibHBHEHF_[1]);
-      ichan  = (id0-iphi-(ieta+1)*kchanCalibHE_)/kPhiCalibHBHE_;
-      iphi   = mPhiCalibHBHE_*(iphi+1) - 1;
-      ctype  = chanCalibHE_[ichan];
+      iphi = hid0 % kPhiCalibHBHE_;
+      ieta = ((hid0 < nchanCalibHE_ * kPhiCalibHBHE_) ? etaCalibHBHEHF_[0] : etaCalibHBHEHF_[1]);
+      ichan = (id0 - iphi - (ieta + 1) * kchanCalibHE_) / kPhiCalibHBHE_;
+      iphi = mPhiCalibHBHE_ * (iphi + 1) - 1;
+      ctype = chanCalibHE_[ichan];
     } else if (hid0 < kOffCalibHO0_) {
-      hid0  -= kOffCalibHF_;
-      id0    = static_cast<int>(hid0);
+      hid0 -= kOffCalibHF_;
+      id0 = static_cast<int>(hid0);
       subdet = HcalForward;
-      iphi   = hid0%kPhiCalibHF_;
-      ieta   = ((hid0 < nchanCalibHF_*kPhiCalibHF_) ? etaCalibHBHEHF_[0] :
-		etaCalibHBHEHF_[1]);
-      ichan  = (id0-iphi-(ieta+1)*kchanCalibHF_)/kPhiCalibHF_;
-      iphi   = mPhiCalibHF_*iphi + 1;
-      ctype  = chanCalibHF_[ichan];
+      iphi = hid0 % kPhiCalibHF_;
+      ieta = ((hid0 < nchanCalibHF_ * kPhiCalibHF_) ? etaCalibHBHEHF_[0] : etaCalibHBHEHF_[1]);
+      ichan = (id0 - iphi - (ieta + 1) * kchanCalibHF_) / kPhiCalibHF_;
+      iphi = mPhiCalibHF_ * iphi + 1;
+      ctype = chanCalibHF_[ichan];
     } else if (hid0 < kOffCalibHO_) {
-      hid0  -= kOffCalibHO0_;
-      id0    = static_cast<int>(hid0);
+      hid0 -= kOffCalibHO0_;
+      id0 = static_cast<int>(hid0);
       subdet = HcalOuter;
-      unsigned int kphi = hid0%kEtaPhiCalibHO_;
-      if (kphi < 2*kPhiCalibHO1_) {
-	ieta  = (kphi >= kPhiCalibHO1_) ? etaCalibHO_[1] : etaCalibHO_[0];
-	iphi  = kphi%kPhiCalibHO1_;
-	ichan = (id0-iphi-(ieta+2)*kchanCalibHO_)/kchanCalibHO1_;
-	iphi = (iphi+1)*mPhiCalibHO1_-1;
-      } else if (kphi < (2*kPhiCalibHO1_+kPhiCalibHO0_)) {
-	ieta = etaCalibHO_[2];
-	iphi = kphi%kPhiCalibHO0_;
-	ichan = (id0-iphi-(ieta+2)*kchanCalibHO_)/kchanCalibHO1_;
-	iphi = (iphi+1)*mPhiCalibHO0_-1;
+      unsigned int kphi = hid0 % kEtaPhiCalibHO_;
+      if (kphi < 2 * kPhiCalibHO1_) {
+        ieta = (kphi >= kPhiCalibHO1_) ? etaCalibHO_[1] : etaCalibHO_[0];
+        iphi = kphi % kPhiCalibHO1_;
+        ichan = (id0 - iphi - (ieta + 2) * kchanCalibHO_) / kchanCalibHO1_;
+        iphi = (iphi + 1) * mPhiCalibHO1_ - 1;
+      } else if (kphi < (2 * kPhiCalibHO1_ + kPhiCalibHO0_)) {
+        ieta = etaCalibHO_[2];
+        iphi = kphi % kPhiCalibHO0_;
+        ichan = (id0 - iphi - (ieta + 2) * kchanCalibHO_) / kchanCalibHO1_;
+        iphi = (iphi + 1) * mPhiCalibHO0_ - 1;
       } else {
-	ieta = (kphi >= kPhiCalibHO2_) ? etaCalibHO_[4] : etaCalibHO_[3];
-	iphi = kphi%kPhiCalibHO1_;
-	ichan = (id0-iphi-(ieta+3)*kchanCalibHO_)/kchanCalibHO1_;
-	iphi = (iphi+1)*mPhiCalibHO1_-1;
+        ieta = (kphi >= kPhiCalibHO2_) ? etaCalibHO_[4] : etaCalibHO_[3];
+        iphi = kphi % kPhiCalibHO1_;
+        ichan = (id0 - iphi - (ieta + 3) * kchanCalibHO_) / kchanCalibHO1_;
+        iphi = (iphi + 1) * mPhiCalibHO1_ - 1;
       }
-      ctype  = chanCalibHO_[ichan];
+      ctype = chanCalibHO_[ichan];
     } else {
-      hid0  -= kOffCalibHO_;
+      hid0 -= kOffCalibHO_;
       subdet = HcalOuter;
-      iphi   = phiCalibHO_[hid0];
-      ctype  = static_cast<int>(chanCalibHOs_);
-      ieta   = etaCalibHO_[hid0];
+      iphi = phiCalibHO_[hid0];
+      ctype = static_cast<int>(chanCalibHOs_);
+      ieta = etaCalibHO_[hid0];
     }
-    id = HcalCalibDetId(subdet,ieta,iphi,ctype);
+    id = HcalCalibDetId(subdet, ieta, iphi, ctype);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CaloTopology")
-      << "CalibrationBox: " << hid << " o/p " << ieta << ":" << iphi << ":" 
-      << ichan << ":" << ctype << " " << id;
+    edm::LogVerbatim("CaloTopology") << "CalibrationBox: " << hid << " o/p " << ieta << ":" << iphi << ":" << ichan
+                                     << ":" << ctype << " " << id;
 #endif
   } else if (hid < kOffCalibHBX_) {
     hid0 -= kOffCalibHOX_;
     int iphi, ieta;
     if (hid0 < nPhiCalibHOX_[1]) {
-      iphi  = static_cast<int>(hid0) + 1;
-      ieta  =-etaCalibHOX_[1];
-    } else if (hid0 < (nPhiCalibHOX_[1]+nPhiCalibHOX_[0])) {
+      iphi = static_cast<int>(hid0) + 1;
+      ieta = -etaCalibHOX_[1];
+    } else if (hid0 < (nPhiCalibHOX_[1] + nPhiCalibHOX_[0])) {
       hid0 -= nPhiCalibHOX_[1];
-      iphi  = phiCalibHOX_[hid0+1];
-      ieta  =-etaCalibHOX_[0];
-    } else if (hid0 < (nPhiCalibHOX_[1]+2*nPhiCalibHOX_[0])) {
-      hid0 -= (nPhiCalibHOX_[1]+nPhiCalibHOX_[0]);
-      iphi  = phiCalibHOX_[hid0+1];
-      ieta  = etaCalibHOX_[0];
+      iphi = phiCalibHOX_[hid0 + 1];
+      ieta = -etaCalibHOX_[0];
+    } else if (hid0 < (nPhiCalibHOX_[1] + 2 * nPhiCalibHOX_[0])) {
+      hid0 -= (nPhiCalibHOX_[1] + nPhiCalibHOX_[0]);
+      iphi = phiCalibHOX_[hid0 + 1];
+      ieta = etaCalibHOX_[0];
     } else {
-      hid0 -= (nPhiCalibHOX_[1]+2*nPhiCalibHOX_[0]);
-      iphi  = static_cast<int>(hid0) + 1;
-      ieta  = etaCalibHOX_[1];
+      hid0 -= (nPhiCalibHOX_[1] + 2 * nPhiCalibHOX_[0]);
+      iphi = static_cast<int>(hid0) + 1;
+      ieta = etaCalibHOX_[1];
     }
-    id    = HcalCalibDetId(HcalCalibDetId::HOCrosstalk,ieta,iphi);
+    id = HcalCalibDetId(HcalCalibDetId::HOCrosstalk, ieta, iphi);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CaloTopology")
-      << "HOCrossTalk: " << hid << ":" << hid0 << " o/p "  << ieta << ":"
-      << iphi << " " << id;
+    edm::LogVerbatim("CaloTopology") << "HOCrossTalk: " << hid << ":" << hid0 << " o/p " << ieta << ":" << iphi << " "
+                                     << id;
 #endif
   } else if (hid < kOffCalibHEX_) {
     hid0 -= kOffCalibHBX_;
-    int ieta  = (hid0 >= nPhiCalibHBX_) ? etaCalibHBX_ : -etaCalibHBX_;
-    int iphi  = (hid0%nPhiCalibHBX_) + 1;
-    id    = HcalCalibDetId(HcalCalibDetId::HBX,ieta,iphi);
+    int ieta = (hid0 >= nPhiCalibHBX_) ? etaCalibHBX_ : -etaCalibHBX_;
+    int iphi = (hid0 % nPhiCalibHBX_) + 1;
+    id = HcalCalibDetId(HcalCalibDetId::HBX, ieta, iphi);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CaloTopology")
-      << "HBX: " << hid << ":" << hid0 << " o/p "  << ieta << ":" << iphi 
-      << " " << id;
+    edm::LogVerbatim("CaloTopology") << "HBX: " << hid << ":" << hid0 << " o/p " << ieta << ":" << iphi << " " << id;
 #endif
   } else if (hid < kOffCalibHFX_) {
     hid0 -= kOffCalibHEX_;
-    int iphi = 2*(hid0%nPhiCalibHEX_) + 1;
-    int ieta = ((hid0 < nPhiCalibHEX_) ? -etaCalibHEX_[0] :
-		((hid0 < 2*nPhiCalibHEX_) ? etaCalibHEX_[0] :
-		 ((hid0 < 3*nPhiCalibHEX_) ? -etaCalibHEX_[1] : etaCalibHEX_[1])));
-    id    = HcalCalibDetId(HcalCalibDetId::HEX,ieta,iphi);
+    int iphi = 2 * (hid0 % nPhiCalibHEX_) + 1;
+    int ieta = ((hid0 < nPhiCalibHEX_)
+                    ? -etaCalibHEX_[0]
+                    : ((hid0 < 2 * nPhiCalibHEX_) ? etaCalibHEX_[0]
+                                                  : ((hid0 < 3 * nPhiCalibHEX_) ? -etaCalibHEX_[1] : etaCalibHEX_[1])));
+    id = HcalCalibDetId(HcalCalibDetId::HEX, ieta, iphi);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CaloTopology")
-      << "HEX: " << hid << ":" << hid0 << " o/p "  << ieta << ":" << iphi 
-      << " " << id;
+    edm::LogVerbatim("CaloTopology") << "HEX: " << hid << ":" << hid0 << " o/p " << ieta << ":" << iphi << " " << id;
 #endif
   }
   return id;
@@ -1362,152 +1464,172 @@ HcalCalibDetId HcalTopology::denseId2detIdCALIB(const unsigned int& hid) const {
 
 unsigned int HcalTopology::detId2denseId(const DetId& id) const {
   unsigned int retval(0);
-  if (topoVersion_==0) { // pre-LS1
+  if (topoVersion_ == 0) {  // pre-LS1
     retval = detId2denseIdPreLS1(id);
-  } else if (topoVersion_==10) {
+  } else if (topoVersion_ == 10) {
     HcalDetId hid(id);
-    if (hid.subdet()==HcalBarrel) {
-      retval = (hid.depth()-1)+maxDepthHB_*(hid.iphi()-1);
-      if (hid.ieta()>0) retval+=maxDepthHB_*IPHI_MAX*(hid.ieta()-firstHBRing());
-      else              retval+=maxDepthHB_*IPHI_MAX*(hid.ieta()+lastHBRing()+nEtaHB_);
-    } else if (hid.subdet()==HcalEndcap) {
+    if (hid.subdet() == HcalBarrel) {
+      retval = (hid.depth() - 1) + maxDepthHB_ * (hid.iphi() - 1);
+      if (hid.ieta() > 0)
+        retval += maxDepthHB_ * IPHI_MAX * (hid.ieta() - firstHBRing());
+      else
+        retval += maxDepthHB_ * IPHI_MAX * (hid.ieta() + lastHBRing() + nEtaHB_);
+    } else if (hid.subdet() == HcalEndcap) {
       retval = HBSize_;
-      retval+= (hid.depth()-1)+maxDepthHE_*(hid.iphi()-1);
-      if (hid.ieta()>0) retval+=maxDepthHE_*maxPhiHE_*(hid.ieta()-firstHERing());
-      else              retval+=maxDepthHE_*maxPhiHE_*(hid.ieta()+lastHERing()+nEtaHE_);
-    } else if (hid.subdet()==HcalOuter) {
-      retval = HBSize_+HESize_;
-      if   (hid.ieta()>0) retval+=(hid.iphi()-1)+IPHI_MAX*(hid.ieta()-1);
-      else                retval+=(hid.iphi()-1)+IPHI_MAX*(30+hid.ieta());
-    } else if (hid.subdet()==HcalForward) { 
-      retval = HBSize_+HESize_+HOSize_;
-      retval+= (hid.depth()-1)+maxDepthHF_*(hid.iphi()-1);
-      if (hid.ieta()>0) retval+=maxDepthHF_*IPHI_MAX*(hid.ieta()-29);
-      else              retval+=maxDepthHF_*IPHI_MAX*((41+13)+hid.ieta());
+      retval += (hid.depth() - 1) + maxDepthHE_ * (hid.iphi() - 1);
+      if (hid.ieta() > 0)
+        retval += maxDepthHE_ * maxPhiHE_ * (hid.ieta() - firstHERing());
+      else
+        retval += maxDepthHE_ * maxPhiHE_ * (hid.ieta() + lastHERing() + nEtaHE_);
+    } else if (hid.subdet() == HcalOuter) {
+      retval = HBSize_ + HESize_;
+      if (hid.ieta() > 0)
+        retval += (hid.iphi() - 1) + IPHI_MAX * (hid.ieta() - 1);
+      else
+        retval += (hid.iphi() - 1) + IPHI_MAX * (30 + hid.ieta());
+    } else if (hid.subdet() == HcalForward) {
+      retval = HBSize_ + HESize_ + HOSize_;
+      retval += (hid.depth() - 1) + maxDepthHF_ * (hid.iphi() - 1);
+      if (hid.ieta() > 0)
+        retval += maxDepthHF_ * IPHI_MAX * (hid.ieta() - 29);
+      else
+        retval += maxDepthHF_ * IPHI_MAX * ((41 + 13) + hid.ieta());
     } else {
       retval = 0xFFFFFFFu;
     }
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "DetId2Dense " << topoVersion_ << " ID " << std::hex 
-	    << id.rawId() << std::dec << " | " << HcalDetId(id) << " : " 
-	    << std::hex << retval << std::dec << std::endl;
+  std::cout << "DetId2Dense " << topoVersion_ << " ID " << std::hex << id.rawId() << std::dec << " | " << HcalDetId(id)
+            << " : " << std::hex << retval << std::dec << std::endl;
 #endif
   return retval;
 }
 
 DetId HcalTopology::denseId2detId(unsigned int denseid) const {
-
-  HcalSubdetector sd ( HcalBarrel ) ;
-  int ie ( 0 ) ;
-  int ip ( 0 ) ;
-  int dp ( 0 ) ;
-  int in ( denseid ) ;
-  int iz ( 1 ) ;
-  if (topoVersion_==0) { //DL// pre-LS1
+  HcalSubdetector sd(HcalBarrel);
+  int ie(0);
+  int ip(0);
+  int dp(0);
+  int in(denseid);
+  int iz(1);
+  if (topoVersion_ == 0) {  //DL// pre-LS1
     if (denseid < kSizeForDenseIndexingPreLS1) {
-      if ( in > 2*( kHBhalf + kHEhalf + kHOhalf ) - 1 ) { // HF
-	sd  = HcalForward ;
-	in -= 2*( kHBhalf + kHEhalf + kHOhalf ) ; 
-	iz  = ( in<kHFhalf ? 1 : -1 ) ;
-	in %= kHFhalf ; 
-	ip  = 4*( in/48 ) ;
-	in %= 48 ;
-	ip += 1 + ( in>21 ? 2 : 0 ) ;
-	if( 3 == ip%4 ) in -= 22 ;
-	ie  = 29 + in/2 ;
-	dp  = 1 + in%2 ;
-      } else if ( in > 2*( kHBhalf + kHEhalf ) - 1 ) { // HO
-	sd  = HcalOuter ;
-	in -= 2*( kHBhalf + kHEhalf ) ; 
-	iz  = ( in<kHOhalf ? 1 : -1 ) ;
-	in %= kHOhalf ; 
-	dp  = 4 ;
-	ip  = 1 + in/15 ;
-	ie  = 1 + ( in - 15*( ip - 1 ) ) ;
-      } else if ( in > 2*kHBhalf - 1 ) { // Endcap
-	sd  = HcalEndcap ;
-	in -= 2*kHBhalf ;
-	iz  = ( in<kHEhalf ? 1 : -1 ) ;
-	in %= kHEhalf ; 
-	ip  = 2*( in/36 ) ;
-	in %= 36 ;
-	ip += 1 + in/28 ;
-	if( 0 == ip%2 ) in %= 28 ;
-	ie  = 15 + ( in<2 ? 1 + in : 2 + 
-		     ( in<20 ? 1 + ( in - 2 )/2 : 9 +
-		       ( in<26 ? 1 + ( in - 20 )/3 : 3 ) ) ) ;
-	dp  = ( in<1 ? 3 :
-		( in<2 ? 1 : 
-		  ( in<20 ? 1 + ( in - 2 )%2 : 
-		    ( in<26 ? 1 + ( in - 20 )%3 : 
-		      ( 1 + ( in - 26 )%2 ) ) ) ) ) ;
-      } else { // barrel
-	iz  = ( in<kHBhalf ? 1 : -1 ) ;
-	in %= kHBhalf ; 
-	ip = in/18 + 1 ;
-	in %= 18 ;
-	if ( in < 14 ) {
-	  dp = 1 ;
-	  ie = in + 1 ;
-	} else {
-	  in %= 14 ;
-	  dp =  1 + in%2 ;
-	  ie = 15 + in/2 ;
-	}
+      if (in > 2 * (kHBhalf + kHEhalf + kHOhalf) - 1) {  // HF
+        sd = HcalForward;
+        in -= 2 * (kHBhalf + kHEhalf + kHOhalf);
+        iz = (in < kHFhalf ? 1 : -1);
+        in %= kHFhalf;
+        ip = 4 * (in / 48);
+        in %= 48;
+        ip += 1 + (in > 21 ? 2 : 0);
+        if (3 == ip % 4)
+          in -= 22;
+        ie = 29 + in / 2;
+        dp = 1 + in % 2;
+      } else if (in > 2 * (kHBhalf + kHEhalf) - 1) {  // HO
+        sd = HcalOuter;
+        in -= 2 * (kHBhalf + kHEhalf);
+        iz = (in < kHOhalf ? 1 : -1);
+        in %= kHOhalf;
+        dp = 4;
+        ip = 1 + in / 15;
+        ie = 1 + (in - 15 * (ip - 1));
+      } else if (in > 2 * kHBhalf - 1) {  // Endcap
+        sd = HcalEndcap;
+        in -= 2 * kHBhalf;
+        iz = (in < kHEhalf ? 1 : -1);
+        in %= kHEhalf;
+        ip = 2 * (in / 36);
+        in %= 36;
+        ip += 1 + in / 28;
+        if (0 == ip % 2)
+          in %= 28;
+        ie = 15 + (in < 2 ? 1 + in : 2 + (in < 20 ? 1 + (in - 2) / 2 : 9 + (in < 26 ? 1 + (in - 20) / 3 : 3)));
+        dp = (in < 1
+                  ? 3
+                  : (in < 2 ? 1 : (in < 20 ? 1 + (in - 2) % 2 : (in < 26 ? 1 + (in - 20) % 3 : (1 + (in - 26) % 2)))));
+      } else {  // barrel
+        iz = (in < kHBhalf ? 1 : -1);
+        in %= kHBhalf;
+        ip = in / 18 + 1;
+        in %= 18;
+        if (in < 14) {
+          dp = 1;
+          ie = in + 1;
+        } else {
+          in %= 14;
+          dp = 1 + in % 2;
+          ie = 15 + in / 2;
+        }
       }
     }
-  } else if (topoVersion_==10) {
+  } else if (topoVersion_ == 10) {
     if (denseid < ncells()) {
-      if (denseid >= (HBSize_+HESize_+HOSize_)) {
-	sd  = HcalForward ;
-	in -= (HBSize_+HESize_+HOSize_);
-	dp  = (in%maxDepthHF_) + 1;
-	ip  = (in - dp + 1)%(maxDepthHF_*IPHI_MAX);
-	ip  = (ip/maxDepthHF_) + 1;
-	ie  = (in - dp + 1 - maxDepthHF_*(ip -1))/(IPHI_MAX*maxDepthHF_);
-	if (ie > 12) {ie  = 54 -ie; iz = -1;}
-	else         {ie += 29;     iz =  1;}
-      } else if (denseid >= (HBSize_+HESize_)) {
-	sd  = HcalOuter ;
-	in -= (HBSize_+HESize_);
-	dp  = 4;
-	ip  = (in%IPHI_MAX) + 1;
-	ie  = (in - ip + 1)/IPHI_MAX;
-	if (ie > 14) {ie  = 30 -ie; iz = -1;}
-	else         {ie += 1;      iz =  1;}
+      if (denseid >= (HBSize_ + HESize_ + HOSize_)) {
+        sd = HcalForward;
+        in -= (HBSize_ + HESize_ + HOSize_);
+        dp = (in % maxDepthHF_) + 1;
+        ip = (in - dp + 1) % (maxDepthHF_ * IPHI_MAX);
+        ip = (ip / maxDepthHF_) + 1;
+        ie = (in - dp + 1 - maxDepthHF_ * (ip - 1)) / (IPHI_MAX * maxDepthHF_);
+        if (ie > 12) {
+          ie = 54 - ie;
+          iz = -1;
+        } else {
+          ie += 29;
+          iz = 1;
+        }
+      } else if (denseid >= (HBSize_ + HESize_)) {
+        sd = HcalOuter;
+        in -= (HBSize_ + HESize_);
+        dp = 4;
+        ip = (in % IPHI_MAX) + 1;
+        ie = (in - ip + 1) / IPHI_MAX;
+        if (ie > 14) {
+          ie = 30 - ie;
+          iz = -1;
+        } else {
+          ie += 1;
+          iz = 1;
+        }
       } else if (denseid >= (HBSize_)) {
-	sd  = HcalEndcap ;
-	in -= (HBSize_);
-	dp  = (in%maxDepthHE_)+1;
-	ip  = (in - dp + 1)%(maxDepthHE_*maxPhiHE_);
-	ip  = (ip/maxDepthHE_) + 1;
-	ie  = (in - dp + 1 - maxDepthHE_*(ip-1))/(maxPhiHE_*maxDepthHE_);
-        if (ie >= nEtaHE_) {ie = lastHERing()+nEtaHE_ - ie; iz = -1;}
-        else               {ie = firstHERing() + ie;        iz =  1;}
+        sd = HcalEndcap;
+        in -= (HBSize_);
+        dp = (in % maxDepthHE_) + 1;
+        ip = (in - dp + 1) % (maxDepthHE_ * maxPhiHE_);
+        ip = (ip / maxDepthHE_) + 1;
+        ie = (in - dp + 1 - maxDepthHE_ * (ip - 1)) / (maxPhiHE_ * maxDepthHE_);
+        if (ie >= nEtaHE_) {
+          ie = lastHERing() + nEtaHE_ - ie;
+          iz = -1;
+        } else {
+          ie = firstHERing() + ie;
+          iz = 1;
+        }
       } else {
-	sd  = HcalBarrel ;
-	dp  = (in%maxDepthHB_)+1;
-	ip  = (in - dp + 1)%(maxDepthHB_*IPHI_MAX);
-	ip  = (ip/maxDepthHB_) + 1;
-	ie  = (in - dp + 1 - maxDepthHB_*(ip-1))/(IPHI_MAX*maxDepthHB_);
-        if (ie >= nEtaHB_) {ie = lastHBRing()+nEtaHB_ - ie; iz = -1;}
-        else               {ie = firstHBRing() + ie;        iz =  1;}
-      }	
+        sd = HcalBarrel;
+        dp = (in % maxDepthHB_) + 1;
+        ip = (in - dp + 1) % (maxDepthHB_ * IPHI_MAX);
+        ip = (ip / maxDepthHB_) + 1;
+        ie = (in - dp + 1 - maxDepthHB_ * (ip - 1)) / (IPHI_MAX * maxDepthHB_);
+        if (ie >= nEtaHB_) {
+          ie = lastHBRing() + nEtaHB_ - ie;
+          iz = -1;
+        } else {
+          ie = firstHBRing() + ie;
+          iz = 1;
+        }
+      }
     }
   }
-  HcalDetId hid(sd, iz*int(ie), ip, dp);
+  HcalDetId hid(sd, iz * int(ie), ip, dp);
 #ifdef EDM_ML_DEBUG
-  std::cout << "Dens2Det " << topoVersion_ << " i/p " << std::hex << denseid 
-	    << " : " << hid.rawId() << std::dec << " | " << hid << std::endl;
+  std::cout << "Dens2Det " << topoVersion_ << " i/p " << std::hex << denseid << " : " << hid.rawId() << std::dec
+            << " | " << hid << std::endl;
 #endif
   return hid;
 }
 
-unsigned int HcalTopology::ncells() const {
-  return HBSize_+HESize_+HOSize_+HFSize_;
-}
+unsigned int HcalTopology::ncells() const { return HBSize_ + HESize_ + HOSize_ + HFSize_; }
 
-int HcalTopology::topoVersion() const {
-  return topoVersion_;
-}
+int HcalTopology::topoVersion() const { return topoVersion_; }

--- a/Geometry/CaloTopology/src/HcalTopologyMode.cc
+++ b/Geometry/CaloTopology/src/HcalTopologyMode.cc
@@ -1,10 +1,9 @@
 #include "Geometry/CaloTopology/interface/HcalTopologyMode.h"
 
-template<>
-StringToEnumParser<HcalTopologyMode::Mode>::StringToEnumParser()
-{
-    enumMap["HcalTopologyMode::LHC"] = HcalTopologyMode::LHC;
-    enumMap["HcalTopologyMode::H2"] = HcalTopologyMode::H2;
-    enumMap["HcalTopologyMode::SLHC"] = HcalTopologyMode::SLHC;
-    enumMap["HcalTopologyMode::H2HE"] = HcalTopologyMode::H2HE;
+template <>
+StringToEnumParser<HcalTopologyMode::Mode>::StringToEnumParser() {
+  enumMap["HcalTopologyMode::LHC"] = HcalTopologyMode::LHC;
+  enumMap["HcalTopologyMode::H2"] = HcalTopologyMode::H2;
+  enumMap["HcalTopologyMode::SLHC"] = HcalTopologyMode::SLHC;
+  enumMap["HcalTopologyMode::H2HE"] = HcalTopologyMode::H2HE;
 }

--- a/Geometry/CaloTopology/src/HcalTopologyRestrictionParser.cc
+++ b/Geometry/CaloTopology/src/HcalTopologyRestrictionParser.cc
@@ -1,59 +1,78 @@
 #include "Geometry/CaloTopology/interface/HcalTopologyRestrictionParser.h"
-#include<boost/tokenizer.hpp>
-#include<sstream>
-#include<iostream>
-HcalTopologyRestrictionParser::HcalTopologyRestrictionParser(HcalTopology& target) : target_(target) {
-}
+#include <boost/tokenizer.hpp>
+#include <sstream>
+#include <iostream>
+HcalTopologyRestrictionParser::HcalTopologyRestrictionParser(HcalTopology& target) : target_(target) {}
 
 static HcalSubdetector determineSubdet(const std::string& item) {
-  if (item=="HB") return HcalBarrel;
-  if (item=="HE") return HcalEndcap;
-  if (item=="HF") return HcalForward;
-  if (item=="HO") return HcalOuter;
+  if (item == "HB")
+    return HcalBarrel;
+  if (item == "HE")
+    return HcalEndcap;
+  if (item == "HF")
+    return HcalForward;
+  if (item == "HO")
+    return HcalOuter;
   return (HcalSubdetector)0;
 }
 
 std::string HcalTopologyRestrictionParser::parse(const std::string& line) {
-
   std::ostringstream errors;
-  boost::char_separator<char> sep(" \t",";");
+  boost::char_separator<char> sep(" \t", ";");
   typedef boost::tokenizer<boost::char_separator<char> > myTokType;
 
-  std::string totaline(line); totaline+=';'; // terminate
+  std::string totaline(line);
+  totaline += ';';  // terminate
   myTokType tok(totaline, sep);
-  int ieta1=0, ieta2=0, iphi1=-1, iphi2=-1, depth1=1, depth2=4;
-  HcalSubdetector subdet=(HcalSubdetector)0;
+  int ieta1 = 0, ieta2 = 0, iphi1 = -1, iphi2 = -1, depth1 = 1, depth2 = 4;
+  HcalSubdetector subdet = (HcalSubdetector)0;
 
-  int phase=0; 
-  for (myTokType::iterator beg=tok.begin(); beg!=tok.end() && phase>=0; ++beg){
+  int phase = 0;
+  for (myTokType::iterator beg = tok.begin(); beg != tok.end() && phase >= 0; ++beg) {
     std::cout << phase << " : <" << *beg << ">\n";
-    if (*beg==";") {
-      if (phase==0) continue; // empty
-      if (phase!=1 && phase!=5 && phase!=7) { 
-	errors << "Expect 1, 5, or 7 arguments, got " << phase;
-	phase=-1;
+    if (*beg == ";") {
+      if (phase == 0)
+        continue;  // empty
+      if (phase != 1 && phase != 5 && phase != 7) {
+        errors << "Expect 1, 5, or 7 arguments, got " << phase;
+        phase = -1;
       } else {
-	if (phase==1) { // reject whole subdetector...
-	  target_.excludeSubdetector(subdet);
-	} else {
-	  target_.exclude(subdet,ieta1,ieta2,iphi1,iphi2,depth1,depth2);
-	}
-	phase=0;
+        if (phase == 1) {  // reject whole subdetector...
+          target_.excludeSubdetector(subdet);
+        } else {
+          target_.exclude(subdet, ieta1, ieta2, iphi1, iphi2, depth1, depth2);
+        }
+        phase = 0;
       }
     } else {
       switch (phase) {
-      case (0) : subdet=determineSubdet(*beg); break;
-      case (1) : ieta1=atoi(beg->c_str()); break;
-      case (2) : ieta2=atoi(beg->c_str()); break;
-      case (3) : iphi1=atoi(beg->c_str()); break;
-      case (4) : iphi2=atoi(beg->c_str()); depth1=1; depth2=4; break; // also set defaults...
-      case (5) : depth1=atoi(beg->c_str()); break;
-      case (6) : depth2=atoi(beg->c_str()); break;
+        case (0):
+          subdet = determineSubdet(*beg);
+          break;
+        case (1):
+          ieta1 = atoi(beg->c_str());
+          break;
+        case (2):
+          ieta2 = atoi(beg->c_str());
+          break;
+        case (3):
+          iphi1 = atoi(beg->c_str());
+          break;
+        case (4):
+          iphi2 = atoi(beg->c_str());
+          depth1 = 1;
+          depth2 = 4;
+          break;  // also set defaults...
+        case (5):
+          depth1 = atoi(beg->c_str());
+          break;
+        case (6):
+          depth2 = atoi(beg->c_str());
+          break;
       }
       phase++;
     }
   }
-  
-  return errors.str();
 
+  return errors.str();
 }

--- a/Geometry/CaloTopology/test/CaloTowerMapTester.cc
+++ b/Geometry/CaloTopology/test/CaloTowerMapTester.cc
@@ -25,10 +25,9 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 class CaloTowerMapTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
-  explicit CaloTowerMapTester(const edm::ParameterSet& );
-  
+  explicit CaloTowerMapTester(const edm::ParameterSet&);
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -42,53 +41,49 @@ private:
   // ----------member data ---------------------------
 };
 
-CaloTowerMapTester::CaloTowerMapTester(const edm::ParameterSet& ) {}
+CaloTowerMapTester::CaloTowerMapTester(const edm::ParameterSet&) {}
 
 void CaloTowerMapTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
 
-void CaloTowerMapTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
-  edm::ESHandle<CaloGeometry>             pG;
+void CaloTowerMapTester::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
+  edm::ESHandle<CaloGeometry> pG;
   iSetup.get<CaloGeometryRecord>().get(pG);
   edm::ESHandle<CaloTowerConstituentsMap> ct;
   iSetup.get<CaloGeometryRecord>().get(ct);
-  if (pG.isValid() && ct.isValid()) doTest(pG.product(),ct.product());
-  else std::cout << "CaloGeometry in EventSetup " << pG.isValid() 
-		 << " and CaloTowerConstituentsMap " << ct.isValid()
-		 << std::endl;
+  if (pG.isValid() && ct.isValid())
+    doTest(pG.product(), ct.product());
+  else
+    std::cout << "CaloGeometry in EventSetup " << pG.isValid() << " and CaloTowerConstituentsMap " << ct.isValid()
+              << std::endl;
 }
 
-void CaloTowerMapTester::doTest(const CaloGeometry* geo,
-				const CaloTowerConstituentsMap* ctmap) {
+void CaloTowerMapTester::doTest(const CaloGeometry* geo, const CaloTowerConstituentsMap* ctmap) {
+  HcalGeometry* hgeo = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
+  const std::vector<DetId>& dets = hgeo->getValidDetIds(DetId::Hcal, 0);
 
-  HcalGeometry* hgeo = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
-  const std::vector<DetId>& dets = hgeo->getValidDetIds(DetId::Hcal,0);
-
-  for (const auto& id: dets) {
+  for (const auto& id : dets) {
     CaloTowerDetId tower = ctmap->towerOf(id);
     std::vector<DetId> ids = ctmap->constituentsOf(tower);
-    std::cout << HcalDetId(id) << " belongs to " << tower << " which has "
-	      << ids.size() << " constituents\n";
-    for (unsigned int i=0; i<ids.size(); ++i) {
+    std::cout << HcalDetId(id) << " belongs to " << tower << " which has " << ids.size() << " constituents\n";
+    for (unsigned int i = 0; i < ids.size(); ++i) {
       std::cout << "[" << i << "] " << std::hex << ids[i].rawId() << std::dec;
-      if        (ids[i].det()==DetId::Ecal && ids[i].subdetId()==EcalBarrel) {
-	std::cout << " " << EBDetId(ids[i]) << std::endl;
-      } else if (ids[i].det()==DetId::Ecal && ids[i].subdetId()==EcalEndcap) {
-	std::cout << " " << EEDetId(ids[i]) << std::endl;
-      } else if (ids[i].det()==DetId::Ecal && ids[i].subdetId()==EcalPreshower) {
-	std::cout << " " << ESDetId(ids[i]) << std::endl;
-      } else if (ids[i].det()==DetId::Hcal) {
-	std::cout << " " << HcalDetId(ids[i]) << std::endl;
+      if (ids[i].det() == DetId::Ecal && ids[i].subdetId() == EcalBarrel) {
+        std::cout << " " << EBDetId(ids[i]) << std::endl;
+      } else if (ids[i].det() == DetId::Ecal && ids[i].subdetId() == EcalEndcap) {
+        std::cout << " " << EEDetId(ids[i]) << std::endl;
+      } else if (ids[i].det() == DetId::Ecal && ids[i].subdetId() == EcalPreshower) {
+        std::cout << " " << ESDetId(ids[i]) << std::endl;
+      } else if (ids[i].det() == DetId::Hcal) {
+        std::cout << " " << HcalDetId(ids[i]) << std::endl;
       } else {
-	std::cout << std::endl;
+        std::cout << std::endl;
       }
     }
   }
-
 }
 
 //define this as a plug-in

--- a/Geometry/CaloTopology/test/CaloTowerTopologyTester.cc
+++ b/Geometry/CaloTopology/test/CaloTowerTopologyTester.cc
@@ -21,9 +21,8 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
 class CaloTowerTopologyTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
-  explicit CaloTowerTopologyTester(const edm::ParameterSet& );
+  explicit CaloTowerTopologyTester(const edm::ParameterSet&);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -37,53 +36,52 @@ private:
   // ----------member data ---------------------------
 };
 
-CaloTowerTopologyTester::CaloTowerTopologyTester(const edm::ParameterSet& ) {}
+CaloTowerTopologyTester::CaloTowerTopologyTester(const edm::ParameterSet&) {}
 
 void CaloTowerTopologyTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
 
-void CaloTowerTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
+void CaloTowerTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
   edm::ESHandle<CaloTowerTopology> topo;
   iSetup.get<HcalRecNumberingRecord>().get(topo);
-  if (topo.isValid()) doTest(*topo);
-  else                std::cout << "Cannot get a valid CaloTowerTopology Object\n";
+  if (topo.isValid())
+    doTest(*topo);
+  else
+    std::cout << "Cannot get a valid CaloTowerTopology Object\n";
 }
 
 void CaloTowerTopologyTester::doTest(const CaloTowerTopology& topology) {
-
-  for (int ieta=-topology.lastHFRing(); ieta<=topology.lastHFRing(); ieta++) {
-    for (int iphi=1; iphi<=72; iphi++) {
-	  const CaloTowerDetId id(ieta,iphi);
-      if (topology.validDetId(id)) {  
+  for (int ieta = -topology.lastHFRing(); ieta <= topology.lastHFRing(); ieta++) {
+    for (int iphi = 1; iphi <= 72; iphi++) {
+      const CaloTowerDetId id(ieta, iphi);
+      if (topology.validDetId(id)) {
         std::vector<DetId> idE = topology.east(id);
         std::vector<DetId> idW = topology.west(id);
         std::vector<DetId> idN = topology.north(id);
         std::vector<DetId> idS = topology.south(id);
         std::cout << "Neighbours for : Tower " << id << std::endl;
         std::cout << "          " << idE.size() << " sets along East:";
-        for (auto & i : idE) 
+        for (auto& i : idE)
           std::cout << " " << (CaloTowerDetId)(i());
         std::cout << std::endl;
         std::cout << "          " << idW.size() << " sets along West:";
-        for (auto & i : idW) 
+        for (auto& i : idW)
           std::cout << " " << (CaloTowerDetId)(i());
         std::cout << std::endl;
         std::cout << "          " << idN.size() << " sets along North:";
-        for (auto & i : idN) 
+        for (auto& i : idN)
           std::cout << " " << (CaloTowerDetId)(i());
         std::cout << std::endl;
         std::cout << "          " << idS.size() << " sets along South:";
-        for (auto & i : idS) 
+        for (auto& i : idS)
           std::cout << " " << (CaloTowerDetId)(i());
         std::cout << std::endl;
       }
     }
   }
-
 }
 
 //define this as a plug-in

--- a/Geometry/CaloTopology/test/FastTimeTopologyTester.cc
+++ b/Geometry/CaloTopology/test/FastTimeTopologyTester.cc
@@ -19,10 +19,9 @@
 #include "Geometry/CaloTopology/interface/FastTimeTopology.h"
 
 class FastTimeTopologyTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
-  explicit FastTimeTopologyTester(const edm::ParameterSet& );
-  
+  explicit FastTimeTopologyTester(const edm::ParameterSet&);
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -35,59 +34,57 @@ private:
   // ----------member data ---------------------------
 };
 
-FastTimeTopologyTester::FastTimeTopologyTester(const edm::ParameterSet& ) {}
+FastTimeTopologyTester::FastTimeTopologyTester(const edm::ParameterSet&) {}
 
 void FastTimeTopologyTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
 
-void FastTimeTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
-
+void FastTimeTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
   edm::ESHandle<FastTimeTopology> topo;
-  iSetup.get<IdealGeometryRecord>().get("FastTimeBarrel",topo);
-  if (topo.isValid()) doTest(*topo);
-  else                std::cout << "Cannot get a valid FastTimeTopology Object for FastTimeBarrel\n";
+  iSetup.get<IdealGeometryRecord>().get("FastTimeBarrel", topo);
+  if (topo.isValid())
+    doTest(*topo);
+  else
+    std::cout << "Cannot get a valid FastTimeTopology Object for FastTimeBarrel\n";
 }
 
 void FastTimeTopologyTester::doTest(const FastTimeTopology& topology) {
-  
-  for (int izz=0; izz<=1; izz++) {
-    int iz = (2*izz-1);
-    for (int eta=1; eta<=265; ++eta) {
-      for (int phi=1; phi<=720; ++phi) {
-	const FastTimeDetId id(1,eta,phi,iz);
-	if (topology.valid(id)) {
-	  std::cout << "Neighbours for Tower "  << id << std::endl;
-	  std::vector<DetId> idE = topology.east(id);
-	  std::vector<DetId> idW = topology.west(id);
-	  std::vector<DetId> idN = topology.north(id);
-	  std::vector<DetId> idS = topology.south(id);
-	  std::cout << "          " << idE.size() << " sets along East:";
-	  for (auto & i : idE) 
-	    std::cout << " " << (FastTimeDetId)(i());
-	  std::cout << std::endl;
-	  std::cout << "          " << idW.size() << " sets along West:";
-	  for (auto & i : idW) 
-	    std::cout << " " << (FastTimeDetId)(i());
-	  std::cout << std::endl;
-	  std::cout << "          " << idN.size() << " sets along North:";
-	  for (auto & i : idN) 
-	    std::cout << " " << (FastTimeDetId)(i());
-	  std::cout << std::endl;
-	  std::cout << "          " << idS.size() << " sets along South:";
-	  for (auto & i : idS) 
-	    std::cout << " " << (FastTimeDetId)(i());
-	  std::cout << std::endl;
-	}
-	phi += 10;
+  for (int izz = 0; izz <= 1; izz++) {
+    int iz = (2 * izz - 1);
+    for (int eta = 1; eta <= 265; ++eta) {
+      for (int phi = 1; phi <= 720; ++phi) {
+        const FastTimeDetId id(1, eta, phi, iz);
+        if (topology.valid(id)) {
+          std::cout << "Neighbours for Tower " << id << std::endl;
+          std::vector<DetId> idE = topology.east(id);
+          std::vector<DetId> idW = topology.west(id);
+          std::vector<DetId> idN = topology.north(id);
+          std::vector<DetId> idS = topology.south(id);
+          std::cout << "          " << idE.size() << " sets along East:";
+          for (auto& i : idE)
+            std::cout << " " << (FastTimeDetId)(i());
+          std::cout << std::endl;
+          std::cout << "          " << idW.size() << " sets along West:";
+          for (auto& i : idW)
+            std::cout << " " << (FastTimeDetId)(i());
+          std::cout << std::endl;
+          std::cout << "          " << idN.size() << " sets along North:";
+          for (auto& i : idN)
+            std::cout << " " << (FastTimeDetId)(i());
+          std::cout << std::endl;
+          std::cout << "          " << idS.size() << " sets along South:";
+          for (auto& i : idS)
+            std::cout << " " << (FastTimeDetId)(i());
+          std::cout << std::endl;
+        }
+        phi += 10;
       }
       eta += 5;
     }
   }
-
 }
 
 //define this as a plug-in

--- a/Geometry/CaloTopology/test/HGCalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HGCalTopologyTester.cc
@@ -19,11 +19,10 @@
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 
-class HGCalTopologyTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> { 
-
+class HGCalTopologyTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
-  explicit HGCalTopologyTester(const edm::ParameterSet& );
-  
+  explicit HGCalTopologyTester(const edm::ParameterSet&);
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -34,85 +33,78 @@ private:
   void doTest(const HGCalTopology& topology);
 
   // ----------member data ---------------------------
-  const std::string      detectorName_;
+  const std::string detectorName_;
   const std::vector<int> type_, layer_, sec1_, sec2_, cell1_, cell2_;
 };
 
-HGCalTopologyTester::HGCalTopologyTester(const edm::ParameterSet& iC) :
-  detectorName_(iC.getParameter<std::string>("detectorName")),
-  type_(iC.getParameter<std::vector<int> >("types")),
-  layer_(iC.getParameter<std::vector<int> >("layers")),
-  sec1_(iC.getParameter<std::vector<int> >("sector1")),
-  sec2_(iC.getParameter<std::vector<int> >("sector2")),
-  cell1_(iC.getParameter<std::vector<int> >("cell1")),
-  cell2_(iC.getParameter<std::vector<int> >("cell2")) {}
+HGCalTopologyTester::HGCalTopologyTester(const edm::ParameterSet& iC)
+    : detectorName_(iC.getParameter<std::string>("detectorName")),
+      type_(iC.getParameter<std::vector<int> >("types")),
+      layer_(iC.getParameter<std::vector<int> >("layers")),
+      sec1_(iC.getParameter<std::vector<int> >("sector1")),
+      sec2_(iC.getParameter<std::vector<int> >("sector2")),
+      cell1_(iC.getParameter<std::vector<int> >("cell1")),
+      cell2_(iC.getParameter<std::vector<int> >("cell2")) {}
 
 void HGCalTopologyTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
-  std::vector<int> types = {0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2};
-  std::vector<int> layer = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18};
-  std::vector<int> sec1  = {1,1,2,2,3,3,5,5,6,6,7,7,8,8,9,9,10,10};
-  std::vector<int> sec2  = {3,3,3,3,2,2,6,6,6,6,3,3,8,8,9,9,3,3};
-  std::vector<int> cell1 = {0,4,12,14,18,23,1,4,7,10,13,16,0,3,6,9,12,15};
-  std::vector<int> cell2 = {0,4,0,2,23,18,1,4,7,10,13,16,0,3,6,9,12,15};
-  desc.add<std::string>("detectorName","HGCalEESensitive");
-  desc.add<std::vector<int> >("types",types);
-  desc.add<std::vector<int> >("layers",layer);
-  desc.add<std::vector<int> >("sector1",sec1);
-  desc.add<std::vector<int> >("sector2",sec2);
-  desc.add<std::vector<int> >("cell1",cell1);
-  desc.add<std::vector<int> >("cell2",cell2);
-  descriptions.add("hgcalTopologyTesterEE",desc);
+  std::vector<int> types = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};
+  std::vector<int> layer = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
+  std::vector<int> sec1 = {1, 1, 2, 2, 3, 3, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10};
+  std::vector<int> sec2 = {3, 3, 3, 3, 2, 2, 6, 6, 6, 6, 3, 3, 8, 8, 9, 9, 3, 3};
+  std::vector<int> cell1 = {0, 4, 12, 14, 18, 23, 1, 4, 7, 10, 13, 16, 0, 3, 6, 9, 12, 15};
+  std::vector<int> cell2 = {0, 4, 0, 2, 23, 18, 1, 4, 7, 10, 13, 16, 0, 3, 6, 9, 12, 15};
+  desc.add<std::string>("detectorName", "HGCalEESensitive");
+  desc.add<std::vector<int> >("types", types);
+  desc.add<std::vector<int> >("layers", layer);
+  desc.add<std::vector<int> >("sector1", sec1);
+  desc.add<std::vector<int> >("sector2", sec2);
+  desc.add<std::vector<int> >("cell1", cell1);
+  desc.add<std::vector<int> >("cell2", cell2);
+  descriptions.add("hgcalTopologyTesterEE", desc);
 }
 
-void HGCalTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
-
+void HGCalTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
   edm::ESHandle<HGCalTopology> topo;
-  iSetup.get<IdealGeometryRecord>().get(detectorName_,topo);
-  if (topo.isValid()) doTest(*topo);
-  else                std::cout << "Cannot get a valid Topology Object for "
-				<< detectorName_;
+  iSetup.get<IdealGeometryRecord>().get(detectorName_, topo);
+  if (topo.isValid())
+    doTest(*topo);
+  else
+    std::cout << "Cannot get a valid Topology Object for " << detectorName_;
 }
 
 void HGCalTopologyTester::doTest(const HGCalTopology& topology) {
-  
   if ((topology.geomMode() == HGCalGeometryMode::Hexagon8) ||
       (topology.geomMode() == HGCalGeometryMode::Hexagon8Full) ||
       (topology.geomMode() == HGCalGeometryMode::Trapezoid)) {
-    for (unsigned int i=0; i<type_.size(); ++i) {
+    for (unsigned int i = 0; i < type_.size(); ++i) {
       DetId id;
       if (detectorName_ == "HGCalEESensitive") {
-	id = HGCSiliconDetId(DetId::HGCalEE,1,type_[i],layer_[i],sec1_[i],
-			     sec2_[i],cell1_[i],cell2_[i]);
+        id = HGCSiliconDetId(DetId::HGCalEE, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalHESiliconSensitive") {
-	id = HGCSiliconDetId(DetId::HGCalHSi,1,type_[i],layer_[i],sec1_[i],
-			     sec2_[i],cell1_[i],cell2_[i]);
+        id = HGCSiliconDetId(DetId::HGCalHSi, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalHEScintillatorSensitive") {
-	id = HGCScintillatorDetId(type_[i],layer_[i],sec1_[i],cell1_[i]);
+        id = HGCScintillatorDetId(type_[i], layer_[i], sec1_[i], cell1_[i]);
       } else {
-	break;
+        break;
       }
       std::vector<DetId> ids = topology.neighbors(id);
       unsigned int k(0);
       if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
-	std::cout << (HGCSiliconDetId)(id) << " has " << ids.size()
-		  << " neighbours:" << std::endl;
-	for (const auto & idn : ids) {
-	  std::cout << "[" << k << "] " << (HGCSiliconDetId)(idn) << std::endl;
-	  ++k;
-	}
+        std::cout << (HGCSiliconDetId)(id) << " has " << ids.size() << " neighbours:" << std::endl;
+        for (const auto& idn : ids) {
+          std::cout << "[" << k << "] " << (HGCSiliconDetId)(idn) << std::endl;
+          ++k;
+        }
       } else {
-	std::cout << (HGCScintillatorDetId)(id) << " has " << ids.size()
-		  << " neighbours:" << std::endl;
-	for (const auto & idn : ids) {
-	  std::cout << "[" << k << "] " << (HGCScintillatorDetId)(idn) << "\n";
-	  ++k;
-	}
+        std::cout << (HGCScintillatorDetId)(id) << " has " << ids.size() << " neighbours:" << std::endl;
+        for (const auto& idn : ids) {
+          std::cout << "[" << k << "] " << (HGCScintillatorDetId)(idn) << "\n";
+          ++k;
+        }
       }
     }
   }
-
 }
 
 //define this as a plug-in

--- a/Geometry/CaloTopology/test/HcalDetId2DenseTester.cc
+++ b/Geometry/CaloTopology/test/HcalDetId2DenseTester.cc
@@ -23,9 +23,8 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 class HcalDetId2DenseTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
-  explicit HcalDetId2DenseTester(const edm::ParameterSet& );
+  explicit HcalDetId2DenseTester(const edm::ParameterSet&);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -37,22 +36,21 @@ private:
   void doTestFile(const HcalTopology& topology);
   void doTestHcalDetId(const HcalTopology& topology);
   void doTestHcalCalibDetId(const HcalTopology& topology);
-  std::vector<std::string> splitString (const std::string& fLine);
+  std::vector<std::string> splitString(const std::string& fLine);
   // ----------member data ---------------------------
-  const std::string     fileName_;
+  const std::string fileName_;
 };
 
-HcalDetId2DenseTester::HcalDetId2DenseTester(const edm::ParameterSet& iC) :
-  fileName_(iC.getUntrackedParameter<std::string>("fileName","")) {}
+HcalDetId2DenseTester::HcalDetId2DenseTester(const edm::ParameterSet& iC)
+    : fileName_(iC.getUntrackedParameter<std::string>("fileName", "")) {}
 
 void HcalDetId2DenseTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<std::string>("fileName","");
-  descriptions.add("hcalDetId2DenseTester",desc);
+  desc.addUntracked<std::string>("fileName", "");
+  descriptions.add("hcalDetId2DenseTester", desc);
 }
 
-void HcalDetId2DenseTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
-
+void HcalDetId2DenseTester::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
   edm::ESHandle<HcalTopology> topo;
   iSetup.get<HcalRecNumberingRecord>().get(topo);
   if (topo.isValid()) {
@@ -65,132 +63,126 @@ void HcalDetId2DenseTester::analyze(edm::Event const&, edm::EventSetup const& iS
 }
 
 void HcalDetId2DenseTester::doTestFile(const HcalTopology& topology) {
-
   if (!fileName_.empty()) {
     std::ifstream fInput(fileName_);
     if (!fInput.good()) {
       std::cout << "Cannot open file " << fileName_ << std::endl;
     } else {
-     char buffer [1024];
-     unsigned int all(0), total(0), good(0), ok(0), bad(0);
-     while (fInput.getline(buffer, 1024)) {
+      char buffer[1024];
+      unsigned int all(0), total(0), good(0), ok(0), bad(0);
+      while (fInput.getline(buffer, 1024)) {
         ++all;
-        if (buffer [0] == '#') continue; //ignore comment
-	std::vector <std::string> items = splitString (std::string(buffer));
-        if (items.size () != 4) {
-	  std::cout << "Ignore  line: " << buffer << std::endl;
+        if (buffer[0] == '#')
+          continue;  //ignore comment
+        std::vector<std::string> items = splitString(std::string(buffer));
+        if (items.size() != 4) {
+          std::cout << "Ignore  line: " << buffer << std::endl;
         } else {
           ++total;
-	  int ieta = std::atoi (items[1].c_str());;
-	  int iphi = std::atoi (items[2].c_str());;
-	  std::string error;
-	  if ((items[0]=="HB") || (items[0]=="HE") || (items[0]=="HF") ||
-	      (items[0]=="HO")) {
-	    HcalSubdetector sd(HcalBarrel);
-	    if (items[0] == "HE") {
-	      sd = HcalEndcap;
-	    } else if (items[0] == "HF") {
-	      sd = HcalForward;
-	    } else if (items[0] == "HO") {
-	      sd = HcalOuter;
-	    }
-	    int depth = std::atoi (items[3].c_str());
-	    HcalDetId cell(sd,ieta,iphi,depth);
-	    if (topology.valid(cell)) {
-	      ++ok;
-	      unsigned int dense = topology.detId2denseId(DetId(cell));
-	      DetId        id    = topology.denseId2detId(dense);
-	      if (cell == HcalDetId(id)) {
-		error = ""; ++good;
-	      } else {
-		error =  "***ERROR***"; ++bad;
-	      }
-	      std::cout << total << " " << cell << " Dense Index " << dense
-			<< " gives back " << HcalDetId(id) << " " << error 
-			<< std::endl;
-	    }
-	 
-	  } else if (items[0].find ("CALIB_") == 0) {
-	    HcalSubdetector sd = HcalOther;
-	    if      (items[0].find("HB")!=std::string::npos) sd=HcalBarrel;
-	    else if (items[0].find("HE")!=std::string::npos) sd=HcalEndcap;
-	    else if (items[0].find("HO")!=std::string::npos) sd=HcalOuter;
-	    else if (items[0].find("HF")!=std::string::npos) sd=HcalForward;
-	    int channel = std::atoi (items[3].c_str());
-	    HcalCalibDetId cell(sd, ieta,iphi,channel);
-	    if (topology.validCalib(cell)) {
-	      ++ok;
-	      unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
-	      DetId        id    = topology.denseId2detIdCALIB(dense);
-	      if (cell == HcalCalibDetId(id)) {
-		error = ""; ++good;
-	      } else {
-		error =  "***ERROR***"; ++bad;
-	      }
-	      std::cout << total << " " << cell << " Dense Index " << dense
-			<< " gives back "  << HcalCalibDetId(id) << " " 
-			<< error << std::endl;
-	    }
-	  } else if ((items[0]=="HOX") || (items[0]=="HBX") || 
-		     (items[0]=="HEX")) {
-	    HcalCalibDetId cell = ((items[0]=="HOX") ?
-				   (HcalCalibDetId(HcalCalibDetId::HOCrosstalk,ieta,iphi)) :
-				   ((items[0]=="HBX") ? (HcalCalibDetId(HcalCalibDetId::HBX,ieta,iphi)) :
-				    (HcalCalibDetId(HcalCalibDetId::HEX,ieta,iphi))));
-	    if (topology.validCalib(cell)) {
-	      ++ok;
-	      unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
-	      DetId        id    = topology.denseId2detIdCALIB(dense);
-	      if (cell == HcalCalibDetId(id)) {
-		error = ""; ++good;
-	      } else {
-		error =  "***ERROR***"; ++bad;
-	      }
-	      std::cout << good << " " << cell << " Dense Index " << dense 
-			<< " gives back " << HcalCalibDetId(id) << " " 
-			<< error << std::endl;
-	    }
-	  }
-	}
-     }
-     fInput.close();
-     std::cout << "Reads total of " << all << ":" << total << " records with "
-	       << good << ":" << ok << " good and " << bad << " bad DetId's" 
-	       << std::endl;
+          int ieta = std::atoi(items[1].c_str());
+          ;
+          int iphi = std::atoi(items[2].c_str());
+          ;
+          std::string error;
+          if ((items[0] == "HB") || (items[0] == "HE") || (items[0] == "HF") || (items[0] == "HO")) {
+            HcalSubdetector sd(HcalBarrel);
+            if (items[0] == "HE") {
+              sd = HcalEndcap;
+            } else if (items[0] == "HF") {
+              sd = HcalForward;
+            } else if (items[0] == "HO") {
+              sd = HcalOuter;
+            }
+            int depth = std::atoi(items[3].c_str());
+            HcalDetId cell(sd, ieta, iphi, depth);
+            if (topology.valid(cell)) {
+              ++ok;
+              unsigned int dense = topology.detId2denseId(DetId(cell));
+              DetId id = topology.denseId2detId(dense);
+              if (cell == HcalDetId(id)) {
+                error = "";
+                ++good;
+              } else {
+                error = "***ERROR***";
+                ++bad;
+              }
+              std::cout << total << " " << cell << " Dense Index " << dense << " gives back " << HcalDetId(id) << " "
+                        << error << std::endl;
+            }
+
+          } else if (items[0].find("CALIB_") == 0) {
+            HcalSubdetector sd = HcalOther;
+            if (items[0].find("HB") != std::string::npos)
+              sd = HcalBarrel;
+            else if (items[0].find("HE") != std::string::npos)
+              sd = HcalEndcap;
+            else if (items[0].find("HO") != std::string::npos)
+              sd = HcalOuter;
+            else if (items[0].find("HF") != std::string::npos)
+              sd = HcalForward;
+            int channel = std::atoi(items[3].c_str());
+            HcalCalibDetId cell(sd, ieta, iphi, channel);
+            if (topology.validCalib(cell)) {
+              ++ok;
+              unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
+              DetId id = topology.denseId2detIdCALIB(dense);
+              if (cell == HcalCalibDetId(id)) {
+                error = "";
+                ++good;
+              } else {
+                error = "***ERROR***";
+                ++bad;
+              }
+              std::cout << total << " " << cell << " Dense Index " << dense << " gives back " << HcalCalibDetId(id)
+                        << " " << error << std::endl;
+            }
+          } else if ((items[0] == "HOX") || (items[0] == "HBX") || (items[0] == "HEX")) {
+            HcalCalibDetId cell =
+                ((items[0] == "HOX") ? (HcalCalibDetId(HcalCalibDetId::HOCrosstalk, ieta, iphi))
+                                     : ((items[0] == "HBX") ? (HcalCalibDetId(HcalCalibDetId::HBX, ieta, iphi))
+                                                            : (HcalCalibDetId(HcalCalibDetId::HEX, ieta, iphi))));
+            if (topology.validCalib(cell)) {
+              ++ok;
+              unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
+              DetId id = topology.denseId2detIdCALIB(dense);
+              if (cell == HcalCalibDetId(id)) {
+                error = "";
+                ++good;
+              } else {
+                error = "***ERROR***";
+                ++bad;
+              }
+              std::cout << good << " " << cell << " Dense Index " << dense << " gives back " << HcalCalibDetId(id)
+                        << " " << error << std::endl;
+            }
+          }
+        }
+      }
+      fInput.close();
+      std::cout << "Reads total of " << all << ":" << total << " records with " << good << ":" << ok << " good and "
+                << bad << " bad DetId's" << std::endl;
     }
-  }    
+  }
 }
 
 void HcalDetId2DenseTester::doTestHcalDetId(const HcalTopology& topology) {
-  const int n=48;
-  HcalSubdetector sds[n] = {HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
-			    HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
-			    HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
-			    HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
-			    HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
-			    HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
-			    HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
-			    HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
-			    HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
-			    HcalForward,HcalForward,HcalForward,HcalForward,
-			    HcalForward,HcalForward,HcalForward,HcalForward,
-			    HcalForward,HcalForward,HcalForward,HcalForward};
-  int ietas[n] = {  1,  5,  9, 12, 14, 16, -2, -4, -8,-11,-13,-16,
-		   18, 21, 23, 25, 27, 29,-19,-20,-22,-24,-26,-28,
-		    1,  3,  5,  9, 11, 13, -2, -4, -6,-10,-12,-14,
-                   30, 32, 34, 36, 38, 40,-31,-33,-35,-37,-39,-41};
-  int iphis[n] = {11,21,31,41,51,61, 5,15,25,35,45,65,
-		  11,23,35,47,59,71, 3,15,27,39,51,63,
-		  11,21,31,41,51,61, 5,15,25,35,45,65,
-		  11,23,35,47,59,71, 3,15,27,39,51,63};
-  int depth[n] = {1,1,1,1,1,1,1,1,1,1,1,1,
-		  2,2,2,2,2,2,2,2,2,2,2,2,
-		  4,4,4,4,4,4,4,4,4,4,4,4,
-		  1,1,1,1,1,1,2,2,2,2,2,2};
+  const int n = 48;
+  HcalSubdetector sds[n] = {HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,
+                            HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalEndcap,  HcalEndcap,
+                            HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,
+                            HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,
+                            HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,
+                            HcalOuter,   HcalForward, HcalForward, HcalForward, HcalForward, HcalForward, HcalForward,
+                            HcalForward, HcalForward, HcalForward, HcalForward, HcalForward, HcalForward};
+  int ietas[n] = {1, 5, 9, 12, 14, 16, -2, -4, -8, -11, -13, -16, 18, 21, 23, 25, 27, 29, -19, -20, -22, -24, -26, -28,
+                  1, 3, 5, 9,  11, 13, -2, -4, -6, -10, -12, -14, 30, 32, 34, 36, 38, 40, -31, -33, -35, -37, -39, -41};
+  int iphis[n] = {11, 21, 31, 41, 51, 61, 5, 15, 25, 35, 45, 65, 11, 23, 35, 47, 59, 71, 3, 15, 27, 39, 51, 63,
+                  11, 21, 31, 41, 51, 61, 5, 15, 25, 35, 45, 65, 11, 23, 35, 47, 59, 71, 3, 15, 27, 39, 51, 63};
+  int depth[n] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};
 
   // Check on Dense Index
-  std::cout << "\nCheck on Dense Index for DetId's" << std::endl
-	    << "==================================" << std::endl;
+  std::cout << "\nCheck on Dense Index for DetId's" << std::endl << "==================================" << std::endl;
   int total(0), good(0), bad(0);
   std::string error;
   for (int i = 0; i < n; ++i) {
@@ -198,79 +190,91 @@ void HcalDetId2DenseTester::doTestHcalDetId(const HcalTopology& topology) {
     if (topology.valid(cell)) {
       ++total;
       unsigned int dense = topology.detId2denseId(DetId(cell));
-      DetId        id    = topology.denseId2detId(dense);
+      DetId id = topology.denseId2detId(dense);
       if (cell == HcalDetId(id)) {
-	++good; error = "";
+        ++good;
+        error = "";
       } else {
-	++bad; error = "**** ERROR *****"; 
+        ++bad;
+        error = "**** ERROR *****";
       }
-      std::cout << "[" << total << "] " << cell << " Dense " << dense 
-		<< " o/p " << HcalDetId(id) << " " << error << std::endl;
+      std::cout << "[" << total << "] " << cell << " Dense " << dense << " o/p " << HcalDetId(id) << " " << error
+                << std::endl;
     }
   }
 
-  std::cout << "Analyzes total of " << n << ":" << total <<" HcalDetIds with "
-	    << good << " good and " << bad << " bad DetId's" << std::endl;
+  std::cout << "Analyzes total of " << n << ":" << total << " HcalDetIds with " << good << " good and " << bad
+            << " bad DetId's" << std::endl;
 }
 
-
 void HcalDetId2DenseTester::doTestHcalCalibDetId(const HcalTopology& topology) {
-
-  const int n=48;
-  HcalCalibDetId::CalibDetType dets[n] =
-    {HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
-     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
-     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
-     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
-     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
-     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
-     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
-     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
-     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
-     HcalCalibDetId::HEX,           HcalCalibDetId::HEX,
-     HcalCalibDetId::HEX,           HcalCalibDetId::HEX,
-     HcalCalibDetId::HEX,           HcalCalibDetId::HEX,
-     HcalCalibDetId::HEX,           HcalCalibDetId::HEX};
-  HcalSubdetector sds[n] = 
-    {HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
-     HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
-     HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
-     HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
-     HcalOuter,  HcalOuter,  HcalForward,HcalForward,
-     HcalForward,HcalForward,HcalForward,HcalForward,
-     HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
-     HcalBarrel, HcalBarrel, HcalEndcap, HcalEndcap,
-     HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
-     HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
-     HcalOuter,  HcalOuter,  HcalForward,HcalForward,
-     HcalForward,HcalForward,HcalForward,HcalForward};
-  int ietas[n] = { 1,  1,  1, -1, -1, -1,  1,  1,  1, -1, -1, -1,
-		   1, -1,  0,  2, -1, -2,  1,  1, -1, -1,  1, -1,
-		   4,  4, -4, -4, 15, 15,-15,-15,-16,-16,-16,-16,
-                  16, 16, 16, 16, 25, 25, 27, 27,-25,-25,-27,-27};
-  int iphis[n] = {11,23,35,47,59,71, 3,15,27,39,51,65,
-		  22,11,35,71,47,59,19,37,55, 1,19,37,
-		  47,36,36,41,51,61, 5,15,25,35,45,65,
-		  11, 1,35,47,59,71, 3,15,27,39,51,63};
-  int depth[n] = {0,1,2,0,1,2,0,1,3,4,5,6,
-		  0,1,0,1,7,7,0,1,0,1,0,1,
-		  4,4,4,4,4,4,4,4,4,4,4,4,
-		  1,1,1,1,1,1,2,2,2,2,2,2};
+  const int n = 48;
+  HcalCalibDetId::CalibDetType dets[n] = {HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::CalibrationBox,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HOCrosstalk,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HBX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX,
+                                          HcalCalibDetId::HEX};
+  HcalSubdetector sds[n] = {HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,
+                            HcalBarrel,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalOuter,   HcalOuter,
+                            HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,   HcalForward, HcalForward, HcalForward,
+                            HcalForward, HcalForward, HcalForward, HcalBarrel,  HcalBarrel,  HcalBarrel,  HcalBarrel,
+                            HcalBarrel,  HcalBarrel,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,  HcalEndcap,
+                            HcalEndcap,  HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,   HcalOuter,
+                            HcalForward, HcalForward, HcalForward, HcalForward, HcalForward, HcalForward};
+  int ietas[n] = {1,   1,   1,   -1,  -1, -1, 1,  1,  1,  -1, -1, -1, 1,   -1,  0,   2,
+                  -1,  -2,  1,   1,   -1, -1, 1,  -1, 4,  4,  -4, -4, 15,  15,  -15, -15,
+                  -16, -16, -16, -16, 16, 16, 16, 16, 25, 25, 27, 27, -25, -25, -27, -27};
+  int iphis[n] = {11, 23, 35, 47, 59, 71, 3, 15, 27, 39, 51, 65, 22, 11, 35, 71, 47, 59, 19, 37, 55, 1,  19, 37,
+                  47, 36, 36, 41, 51, 61, 5, 15, 25, 35, 45, 65, 11, 1,  35, 47, 59, 71, 3,  15, 27, 39, 51, 63};
+  int depth[n] = {0, 1, 2, 0, 1, 2, 0, 1, 3, 4, 5, 6, 0, 1, 0, 1, 7, 7, 0, 1, 0, 1, 0, 1,
+                  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};
 
   // Check on Dense Index
   std::cout << "\nCheck on Dense Index for CalibDetId's" << std::endl
-	    << "=======================================" << std::endl;
+            << "=======================================" << std::endl;
   int total(0), good(0), bad(0);
   std::string error;
   for (int i = 0; i < n; ++i) {
@@ -283,34 +287,37 @@ void HcalDetId2DenseTester::doTestHcalCalibDetId(const HcalTopology& topology) {
     if (topology.validCalib(cell)) {
       ++total;
       unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
-      DetId        id    = topology.denseId2detIdCALIB(dense);
+      DetId id = topology.denseId2detIdCALIB(dense);
       if (cell == HcalCalibDetId(id)) {
-	++good; error = "";
+        ++good;
+        error = "";
       } else {
-	++bad; error = "**** ERROR *****"; 
+        ++bad;
+        error = "**** ERROR *****";
       }
-      std::cout << "[" << total << "] " << cell << " Dense " << dense 
-		<< " o/p " << HcalCalibDetId(id) << " " << error << std::endl;
+      std::cout << "[" << total << "] " << cell << " Dense " << dense << " o/p " << HcalCalibDetId(id) << " " << error
+                << std::endl;
     }
   }
-  std::cout << "Analyzes total of " << n << ":" << total << " CalibIds with "
-	    << good << " good and " << bad << " bad DetId's" << std::endl;
+  std::cout << "Analyzes total of " << n << ":" << total << " CalibIds with " << good << " good and " << bad
+            << " bad DetId's" << std::endl;
 }
 
-std::vector<std::string> HcalDetId2DenseTester::splitString (const std::string& fLine) {
-  std::vector <std::string> result;
+std::vector<std::string> HcalDetId2DenseTester::splitString(const std::string& fLine) {
+  std::vector<std::string> result;
   int start = 0;
   bool empty = true;
-  for (unsigned i = 0; i <= fLine.size (); i++) {
-    if (fLine [i] == ' ' || i == fLine.size ()) {
+  for (unsigned i = 0; i <= fLine.size(); i++) {
+    if (fLine[i] == ' ' || i == fLine.size()) {
       if (!empty) {
-	std::string item (fLine, start, i-start);
-        result.push_back (item);
+        std::string item(fLine, start, i - start);
+        result.push_back(item);
         empty = true;
       }
-      start = i+1;
+      start = i + 1;
     } else {
-      if (empty) empty = false;
+      if (empty)
+        empty = false;
     }
   }
   return result;

--- a/Geometry/CaloTopology/test/HcalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HcalTopologyTester.cc
@@ -22,9 +22,8 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 class HcalTopologyTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
-
 public:
-  explicit HcalTopologyTester(const edm::ParameterSet& );
+  explicit HcalTopologyTester(const edm::ParameterSet&);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -38,120 +37,115 @@ private:
   // ----------member data ---------------------------
 };
 
-HcalTopologyTester::HcalTopologyTester(const edm::ParameterSet& ) {}
+HcalTopologyTester::HcalTopologyTester(const edm::ParameterSet&) {}
 
 void HcalTopologyTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
 
-void HcalTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
-
-
+void HcalTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetup) {
   edm::ESTransientHandle<DDCompactView> pDD;
-  iSetup.get<IdealGeometryRecord>().get( pDD );
+  iSetup.get<IdealGeometryRecord>().get(pDD);
   std::cout << "Gets Compact View\n";
   edm::ESHandle<HcalDDDRecConstants> pHSNDC;
-  iSetup.get<HcalRecNumberingRecord>().get( pHSNDC );
+  iSetup.get<HcalRecNumberingRecord>().get(pHSNDC);
   std::cout << "Gets RecNumbering Record\n";
   edm::ESHandle<HcalTopology> topo;
   iSetup.get<HcalRecNumberingRecord>().get(topo);
-  if (topo.isValid()) doTest(*topo);
-  else                std::cout << "Cannot get a valid HcalTopology Object\n";
+  if (topo.isValid())
+    doTest(*topo);
+  else
+    std::cout << "Cannot get a valid HcalTopology Object\n";
 }
 
 void HcalTopologyTester::doTest(const HcalTopology& topology) {
-
   // First test on movements along eta/phi directions
   std::cout << "\nTest on movements along eta/phi directions" << std::endl
-	    << "==========================================" << std::endl;
-  for (int idet=0; idet<4; idet++) {
+            << "==========================================" << std::endl;
+  for (int idet = 0; idet < 4; idet++) {
     HcalSubdetector subdet = HcalBarrel;
-    if (idet == 1)      subdet = HcalOuter;
-    else if (idet == 2) subdet = HcalEndcap;
-    else if (idet == 3) subdet = HcalForward;
-    for (int depth=1; depth<4; ++depth) {
-      for (int ieta=-41; ieta<=41; ieta++) {
-	for (int iphi=1; iphi<=72; iphi++) {
-	  const HcalDetId id(subdet,ieta,iphi,depth);
-	  if (topology.valid(id)) {
-	    std::vector<DetId> idE = topology.east(id);
-	    std::vector<DetId> idW = topology.west(id);
-	    std::vector<DetId> idN = topology.north(id);
-	    std::vector<DetId> idS = topology.south(id);
-	    std::vector<DetId> idU = topology.up(id);
-	    std::cout << "Neighbours for : Tower " << id << std::endl;
-	    std::cout << "          " << idE.size() << " sets along East:";
-	    for (auto & i : idE) 
-	      std::cout << " " << (HcalDetId)(i());
-	    std::cout << std::endl;
-	    std::cout << "          " << idW.size() << " sets along West:";
-	    for (auto & i : idW) 
-	      std::cout << " " << (HcalDetId)(i());
-	    std::cout << std::endl;
-	    std::cout << "          " << idN.size() << " sets along North:";
-	    for (auto & i : idN) 
-	      std::cout << " " << (HcalDetId)(i());
-	    std::cout << std::endl;
-	    std::cout << "          " << idS.size() << " sets along South:";
-	    for (auto & i : idS) 
-	      std::cout << " " << (HcalDetId)(i());
-	    std::cout << std::endl;
-	    std::cout << "          " << idU.size() << " sets up in depth:";
-	    for (auto & i : idU) 
-	      std::cout << " " << (HcalDetId)(i());
-	    std::cout << std::endl;
-	  }
-	}
+    if (idet == 1)
+      subdet = HcalOuter;
+    else if (idet == 2)
+      subdet = HcalEndcap;
+    else if (idet == 3)
+      subdet = HcalForward;
+    for (int depth = 1; depth < 4; ++depth) {
+      for (int ieta = -41; ieta <= 41; ieta++) {
+        for (int iphi = 1; iphi <= 72; iphi++) {
+          const HcalDetId id(subdet, ieta, iphi, depth);
+          if (topology.valid(id)) {
+            std::vector<DetId> idE = topology.east(id);
+            std::vector<DetId> idW = topology.west(id);
+            std::vector<DetId> idN = topology.north(id);
+            std::vector<DetId> idS = topology.south(id);
+            std::vector<DetId> idU = topology.up(id);
+            std::cout << "Neighbours for : Tower " << id << std::endl;
+            std::cout << "          " << idE.size() << " sets along East:";
+            for (auto& i : idE)
+              std::cout << " " << (HcalDetId)(i());
+            std::cout << std::endl;
+            std::cout << "          " << idW.size() << " sets along West:";
+            for (auto& i : idW)
+              std::cout << " " << (HcalDetId)(i());
+            std::cout << std::endl;
+            std::cout << "          " << idN.size() << " sets along North:";
+            for (auto& i : idN)
+              std::cout << " " << (HcalDetId)(i());
+            std::cout << std::endl;
+            std::cout << "          " << idS.size() << " sets along South:";
+            for (auto& i : idS)
+              std::cout << " " << (HcalDetId)(i());
+            std::cout << std::endl;
+            std::cout << "          " << idU.size() << " sets up in depth:";
+            for (auto& i : idU)
+              std::cout << " " << (HcalDetId)(i());
+            std::cout << std::endl;
+          }
+        }
       }
     }
   }
 
   // Check on Dense Index
-  std::cout << "\nCheck on Dense Index" << std::endl
-	    << "=====================" << std::endl;
+  std::cout << "\nCheck on Dense Index" << std::endl << "=====================" << std::endl;
   int maxDepthHB = topology.maxDepthHB();
   int maxDepthHE = topology.maxDepthHE();
   for (int det = 1; det <= HcalForward; det++) {
-    for (int eta = -HcalDetId::kHcalEtaMask2; 
-	 eta <= (int)(HcalDetId::kHcalEtaMask2); eta++) {
+    for (int eta = -HcalDetId::kHcalEtaMask2; eta <= (int)(HcalDetId::kHcalEtaMask2); eta++) {
       for (unsigned int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
-	for (int depth = 1; depth < maxDepthHB + maxDepthHE; depth++) {
-	  HcalDetId cell ((HcalSubdetector) det, eta, phi, depth);
-	  if (topology.valid(cell)) {
-	    unsigned int dense = topology.detId2denseId(DetId(cell));
-	    DetId        id    = topology.denseId2detId(dense);
-	    if (cell == HcalDetId(id)) 
-	      std::cout << cell << " Dense " << std::hex << dense << std::dec
-			<< " o/p " << HcalDetId(id) << std::endl;
-	    else
-	      std::cout << cell << " Dense " << std::hex << dense << std::dec
-			<< " o/p " << HcalDetId(id) << " **** ERROR *****" 
-			<< std::endl;
-	  }
-	}
+        for (int depth = 1; depth < maxDepthHB + maxDepthHE; depth++) {
+          HcalDetId cell((HcalSubdetector)det, eta, phi, depth);
+          if (topology.valid(cell)) {
+            unsigned int dense = topology.detId2denseId(DetId(cell));
+            DetId id = topology.denseId2detId(dense);
+            if (cell == HcalDetId(id))
+              std::cout << cell << " Dense " << std::hex << dense << std::dec << " o/p " << HcalDetId(id) << std::endl;
+            else
+              std::cout << cell << " Dense " << std::hex << dense << std::dec << " o/p " << HcalDetId(id)
+                        << " **** ERROR *****" << std::endl;
+          }
+        }
       }
     }
   }
 
   // Check list of depths
-  std::cout << "\nCheck list of Depths" << std::endl
-	    << "====================" << std::endl;
-  for (int eta=topology.lastHERing()-2; eta<=topology.lastHERing(); ++eta) {
+  std::cout << "\nCheck list of Depths" << std::endl << "====================" << std::endl;
+  for (int eta = topology.lastHERing() - 2; eta <= topology.lastHERing(); ++eta) {
     for (unsigned int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
-      for (int depth = 1; depth <=  maxDepthHE; depth++) {
-	HcalDetId cell (HcalEndcap, eta, phi, depth);
-	if (topology.valid(cell)) {
-	  std::vector<int> depths = topology.mergedDepthList29(cell);
-	  std::cout << cell << " is with merge depth flag " 
-		    << topology.mergedDepth29(cell) << " having " << depths.size()
-		    << " merged depths:";
-	  for (unsigned int k=0; k<depths.size(); ++k) 
-	    std::cout << " [" << k << "]:" << depths[k];
-	  std::cout << std::endl;
-	}
+      for (int depth = 1; depth <= maxDepthHE; depth++) {
+        HcalDetId cell(HcalEndcap, eta, phi, depth);
+        if (topology.valid(cell)) {
+          std::vector<int> depths = topology.mergedDepthList29(cell);
+          std::cout << cell << " is with merge depth flag " << topology.mergedDepth29(cell) << " having "
+                    << depths.size() << " merged depths:";
+          for (unsigned int k = 0; k < depths.size(); ++k)
+            std::cout << " [" << k << "]:" << depths[k];
+          std::cout << std::endl;
+        }
       }
     }
   }


### PR DESCRIPTION

Applying code-format for CMSSW category geometry.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/375//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


