### PR TITLE
Running code-format for reconstruction-upgrade

### DIFF
--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
@@ -24,87 +24,82 @@
 #include <iostream>
 #include <sstream>
 
-
-
 /**
  *  Constructor
  */
-GEMCSCSegAlgoRR::GEMCSCSegAlgoRR(const edm::ParameterSet& ps) : GEMCSCSegmentAlgorithm(ps), myName("GEMCSCSegAlgoRR"), sfit_(nullptr) 
-{	 
-  debug                     = ps.getUntrackedParameter<bool>("GEMCSCDebug");
-  minHitsPerSegment         = ps.getParameter<unsigned int>("minHitsPerSegment");
-  preClustering             = ps.getParameter<bool>("preClustering");
-  dXclusBoxMax              = ps.getParameter<double>("dXclusBoxMax");
-  dYclusBoxMax              = ps.getParameter<double>("dYclusBoxMax");
+GEMCSCSegAlgoRR::GEMCSCSegAlgoRR(const edm::ParameterSet& ps)
+    : GEMCSCSegmentAlgorithm(ps), myName("GEMCSCSegAlgoRR"), sfit_(nullptr) {
+  debug = ps.getUntrackedParameter<bool>("GEMCSCDebug");
+  minHitsPerSegment = ps.getParameter<unsigned int>("minHitsPerSegment");
+  preClustering = ps.getParameter<bool>("preClustering");
+  dXclusBoxMax = ps.getParameter<double>("dXclusBoxMax");
+  dYclusBoxMax = ps.getParameter<double>("dYclusBoxMax");
   preClustering_useChaining = ps.getParameter<bool>("preClusteringUseChaining");
-  dPhiChainBoxMax           = ps.getParameter<double>("dPhiChainBoxMax");
-  dThetaChainBoxMax         = ps.getParameter<double>("dThetaChainBoxMax");
-  dRChainBoxMax             = ps.getParameter<double>("dRChainBoxMax");
-  maxRecHitsInCluster       = ps.getParameter<int>("maxRecHitsInCluster");
+  dPhiChainBoxMax = ps.getParameter<double>("dPhiChainBoxMax");
+  dThetaChainBoxMax = ps.getParameter<double>("dThetaChainBoxMax");
+  dRChainBoxMax = ps.getParameter<double>("dRChainBoxMax");
+  maxRecHitsInCluster = ps.getParameter<int>("maxRecHitsInCluster");
 }
-
-
 
 /** 
  * Destructor
  */
 GEMCSCSegAlgoRR::~GEMCSCSegAlgoRR() {}
 
-
-
 /**
  * Run the algorithm
  */
-std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::run( const std::map<uint32_t, const CSCLayer*>& csclayermap, const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap, 
-						 const std::vector<const CSCSegment*>& cscsegments, const std::vector<const GEMRecHit*>& gemrechits) 
-{
-
+std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::run(const std::map<uint32_t, const CSCLayer*>& csclayermap,
+                                                const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap,
+                                                const std::vector<const CSCSegment*>& cscsegments,
+                                                const std::vector<const GEMRecHit*>& gemrechits) {
   // This function is called for each CSC Chamber (ME1/1) associated with a GEM chamber in which GEM Rechits were found
   // This means that the csc segment vector can contain more than one segment and that all combinations with the gemrechits have to be tried
 
-
   // assign the maps < detid, geometry object > to the class variables
-  theCSCLayers_   = csclayermap;
+  theCSCLayers_ = csclayermap;
   theGEMEtaParts_ = gemrollmap;
-
 
   // LogDebug info about reading of CSC Chamber map and GEM Eta Partition map
   edm::LogVerbatim("GEMCSCSegAlgoRR") << "[GEMCSCSegAlgoRR::run] cached the csclayermap and the gemrollmap";
 
   // --- LogDebug for CSC Layer map -----------------------------------------
-  std::stringstream csclayermapss; csclayermapss<<"[GEMCSCSegAlgoRR::run] :: csclayermap :: elements ["<<std::endl;
-  for(std::map<uint32_t, const CSCLayer*>::const_iterator mapIt = theCSCLayers_.begin(); mapIt != theCSCLayers_.end(); ++mapIt) 
-    {
-      csclayermapss<<"[CSC DetId "<<mapIt->first<<" ="<<CSCDetId(mapIt->first)<<", CSC Layer "<<mapIt->second<<" ="<<(mapIt->second)->id()<<"],"<<std::endl;
-    }
-  csclayermapss<<"]"<<std::endl; 
+  std::stringstream csclayermapss;
+  csclayermapss << "[GEMCSCSegAlgoRR::run] :: csclayermap :: elements [" << std::endl;
+  for (std::map<uint32_t, const CSCLayer*>::const_iterator mapIt = theCSCLayers_.begin(); mapIt != theCSCLayers_.end();
+       ++mapIt) {
+    csclayermapss << "[CSC DetId " << mapIt->first << " =" << CSCDetId(mapIt->first) << ", CSC Layer " << mapIt->second
+                  << " =" << (mapIt->second)->id() << "]," << std::endl;
+  }
+  csclayermapss << "]" << std::endl;
   std::string csclayermapstr = csclayermapss.str();
   edm::LogVerbatim("GEMCSCSegAlgoRR") << csclayermapstr;
   // --- End LogDebug -------------------------------------------------------
 
   // --- LogDebug for GEM Eta Partition map ---------------------------------
-  std::stringstream gemetapartmapss; gemetapartmapss<<"[GEMCSCSegAlgoRR::run] :: gemetapartmap :: elements ["<<std::endl;
-  for(std::map<uint32_t, const GEMEtaPartition*>::const_iterator mapIt = theGEMEtaParts_.begin(); mapIt != theGEMEtaParts_.end(); ++mapIt) 
-    {
-      gemetapartmapss<<"[GEM DetId "<<mapIt->first<<" ="<<GEMDetId(mapIt->first)<<", GEM EtaPart "<<mapIt->second<<"],"<<std::endl;
-    }
-  gemetapartmapss<<"]"<<std::endl; 
+  std::stringstream gemetapartmapss;
+  gemetapartmapss << "[GEMCSCSegAlgoRR::run] :: gemetapartmap :: elements [" << std::endl;
+  for (std::map<uint32_t, const GEMEtaPartition*>::const_iterator mapIt = theGEMEtaParts_.begin();
+       mapIt != theGEMEtaParts_.end();
+       ++mapIt) {
+    gemetapartmapss << "[GEM DetId " << mapIt->first << " =" << GEMDetId(mapIt->first) << ", GEM EtaPart "
+                    << mapIt->second << "]," << std::endl;
+  }
+  gemetapartmapss << "]" << std::endl;
   std::string gemetapartmapstr = gemetapartmapss.str();
   edm::LogVerbatim("GEMCSCSegAlgoRR") << gemetapartmapstr;
   // --- End LogDebug -------------------------------------------------------
 
+  std::vector<GEMCSCSegment> segmentvectorfinal;
+  std::vector<GEMCSCSegment> segmentvectorchamber;
+  std::vector<GEMCSCSegment> segmentvectorfromfit;
+  std::vector<const TrackingRecHit*> chainedRecHits;
 
-  std::vector<GEMCSCSegment>                        segmentvectorfinal;
-  std::vector<GEMCSCSegment>                        segmentvectorchamber;
-  std::vector<GEMCSCSegment>                        segmentvectorfromfit;
-  std::vector<const TrackingRecHit*>                chainedRecHits;
-  
-
-  // From the GEMCSCSegmentBuilder we get 
+  // From the GEMCSCSegmentBuilder we get
   // - a collection of CSC Segments belonging all to the same chamber
   // - a collection of GEM RecHits belonging to GEM Eta-Partitions close to this CSC
   //
-  // Now we have to loop over all CSC Segments 
+  // Now we have to loop over all CSC Segments
   // and see to which CSC segments we can match the GEM rechits
   // if matching fails we will still keep those segments in the GEMCSC segment collection
   // but we will assign -1 to the matched parameter --> 2B implemented in the DataFormat
@@ -113,39 +108,41 @@ std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::run( const std::map<uint32_t, const 
   // empty the temporary gemcsc segments vector
   // segmentvectortmp.clear();
 
-  for(std::vector<const CSCSegment*>::const_iterator cscSegIt = cscsegments.begin(); cscSegIt != cscsegments.end(); ++cscSegIt)
-    {
+  for (std::vector<const CSCSegment*>::const_iterator cscSegIt = cscsegments.begin(); cscSegIt != cscsegments.end();
+       ++cscSegIt) {
+    // chain hits :: make a vector of TrackingRecHits
+    //               that contains the CSC and GEM rechits
+    //               and that can be given to the fitter
+    chainedRecHits = this->chainHitsToSegm(*cscSegIt, gemrechits);
 
-      // chain hits :: make a vector of TrackingRecHits
-      //               that contains the CSC and GEM rechits
-      //               and that can be given to the fitter
-      chainedRecHits = this->chainHitsToSegm(*cscSegIt, gemrechits);
-  
-      // if gemrechits are associated, run the buildSegments step
-      if(chainedRecHits.size() > (*cscSegIt)->specificRecHits().size()) 
-	{
-	  segmentvectorfromfit = this->buildSegments(*cscSegIt, chainedRecHits);
-	}
-  
-      // if no gemrechits are associated, wrap the existing CSCSegment in a GEMCSCSegment class
-      else 
-	{
-	  std::vector<const GEMRecHit*> gemRecHits_noGEMrh; // empty GEMRecHit vector
-	  GEMCSCSegment tmp(*cscSegIt, gemRecHits_noGEMrh, (*cscSegIt)->localPosition(), (*cscSegIt)->localDirection(), (*cscSegIt)->parametersError(), (*cscSegIt)->chi2());
-	  segmentvectorfromfit.push_back(tmp);
-	}
-
-      segmentvectorchamber.insert( segmentvectorchamber.end(), segmentvectorfromfit.begin(), segmentvectorfromfit.end() );
-      segmentvectorfromfit.clear();
+    // if gemrechits are associated, run the buildSegments step
+    if (chainedRecHits.size() > (*cscSegIt)->specificRecHits().size()) {
+      segmentvectorfromfit = this->buildSegments(*cscSegIt, chainedRecHits);
     }
 
+    // if no gemrechits are associated, wrap the existing CSCSegment in a GEMCSCSegment class
+    else {
+      std::vector<const GEMRecHit*> gemRecHits_noGEMrh;  // empty GEMRecHit vector
+      GEMCSCSegment tmp(*cscSegIt,
+                        gemRecHits_noGEMrh,
+                        (*cscSegIt)->localPosition(),
+                        (*cscSegIt)->localDirection(),
+                        (*cscSegIt)->parametersError(),
+                        (*cscSegIt)->chi2());
+      segmentvectorfromfit.push_back(tmp);
+    }
+
+    segmentvectorchamber.insert(segmentvectorchamber.end(), segmentvectorfromfit.begin(), segmentvectorfromfit.end());
+    segmentvectorfromfit.clear();
+  }
+
   // add the found gemcsc segments to the collection of all gemcsc segments and return
-  segmentvectorfinal.insert( segmentvectorfinal.end(), segmentvectorchamber.begin(), segmentvectorchamber.end() );  
+  segmentvectorfinal.insert(segmentvectorfinal.end(), segmentvectorchamber.begin(), segmentvectorchamber.end());
   segmentvectorchamber.clear();
-  edm::LogVerbatim("GEMCSCSegAlgoRR") << "[GEMCSCSegAlgoRR::run] GEMCSC Segments fitted or wrapped, size of vector = "<<segmentvectorfinal.size();
+  edm::LogVerbatim("GEMCSCSegAlgoRR") << "[GEMCSCSegAlgoRR::run] GEMCSC Segments fitted or wrapped, size of vector = "
+                                      << segmentvectorfinal.size();
   return segmentvectorfinal;
 }
-
 
 /**
  * Chain hits :: make a TrackingRecHit vector containing both CSC and GEM rechits 
@@ -154,159 +151,147 @@ std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::run( const std::map<uint32_t, const 
  *               check whether they are compatible with the CSC segment extrapolation
  *               to the GEM plane. If they are compatible, add these GEM rechits
  */
-std::vector<const TrackingRecHit*> GEMCSCSegAlgoRR::chainHitsToSegm(const CSCSegment* cscsegment, const std::vector<const GEMRecHit*>& gemrechits) 
-{
-
+std::vector<const TrackingRecHit*> GEMCSCSegAlgoRR::chainHitsToSegm(const CSCSegment* cscsegment,
+                                                                    const std::vector<const GEMRecHit*>& gemrechits) {
   std::vector<const TrackingRecHit*> chainedRecHits;
 
   // working with layers makes it here a bit more difficult:
   // the CSC segment points to the chamber, which we cannot ask from the map
   // the CSC rechits point to the layers, from which we can ask the chamber
 
-  auto segLP                   = cscsegment->localPosition();
-  auto segLD                   = cscsegment->localDirection();
-  auto cscrhs                  = cscsegment->specificRecHits();
+  auto segLP = cscsegment->localPosition();
+  auto segLD = cscsegment->localDirection();
+  auto cscrhs = cscsegment->specificRecHits();
 
-  // Loop over the CSC Segment rechits 
+  // Loop over the CSC Segment rechits
   // and save a copy in the chainedRecHits vector
-  for (auto crh = cscrhs.begin(); crh!= cscrhs.end(); crh++)
-    {
-      chainedRecHits.push_back(crh->clone());
-    }
+  for (auto crh = cscrhs.begin(); crh != cscrhs.end(); crh++) {
+    chainedRecHits.push_back(crh->clone());
+  }
 
   // now ask the layer id of the first CSC rechit
   std::vector<const TrackingRecHit*>::const_iterator trhIt = chainedRecHits.begin();
-  // make sure pointer is valid 
-  if(trhIt == chainedRecHits.end()) {
-    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::chainHitsToSegm] CSC segment has zero rechits ... end function here";
+  // make sure pointer is valid
+  if (trhIt == chainedRecHits.end()) {
+    edm::LogVerbatim("GEMCSCSegFit")
+        << "[GEMCSCSegFit::chainHitsToSegm] CSC segment has zero rechits ... end function here";
     return chainedRecHits;
   }
-  const CSCLayer * cscLayer = theCSCLayers_.find((*trhIt)->rawId())->second;
+  const CSCLayer* cscLayer = theCSCLayers_.find((*trhIt)->rawId())->second;
   // now ask the chamber id of the first CSC rechit
-  if(!cscLayer) {
-    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::chainHitsToSegm] CSC rechit ID was not found back in the CSCLayerMap ... end function here";
+  if (!cscLayer) {
+    edm::LogVerbatim("GEMCSCSegFit")
+        << "[GEMCSCSegFit::chainHitsToSegm] CSC rechit ID was not found back in the CSCLayerMap ... end function here";
     return chainedRecHits;
   }
   const CSCChamber* cscChamber = cscLayer->chamber();
 
   // For non-empty GEM rechit vector
-  if(!gemrechits.empty())
-    {
-      float Dphi_min_l1 = 999;
-      float Dphi_min_l2 = 999;
-      float Dtheta_min_l1 = 999;
-      float Dtheta_min_l2 = 999;
-     
-      std::vector<const GEMRecHit*>::const_iterator grhIt = gemrechits.begin();
+  if (!gemrechits.empty()) {
+    float Dphi_min_l1 = 999;
+    float Dphi_min_l2 = 999;
+    float Dtheta_min_l1 = 999;
+    float Dtheta_min_l2 = 999;
 
-      const GEMRecHit* gemrh_min_l1= *grhIt;
-      const GEMRecHit* gemrh_min_l2= *grhIt;
-      
-      // Loop over GEM rechits from the EnsembleGEMHitContainer
-      for(grhIt = gemrechits.begin(); grhIt != gemrechits.end(); ++grhIt) 
-	{
-	  // get GEM Rechit Local & Global Position
-	  auto rhLP = (*grhIt)->localPosition();
-	  const GEMEtaPartition* rhRef  = theGEMEtaParts_.find((*grhIt)->gemId())->second;
-	  auto rhGP = rhRef->toGlobal(rhLP);
-	  // get GEM Rechit Local position w.r.t. the CSC Chamber
-	  // --> we are interessed in the z-coordinate
-	  auto rhLP_inSegmRef = cscChamber->toLocal(rhGP);
-	  // calculate the extrapolation of the CSC segment to the GEM plane (z-coord)
-	  // to get x- and y- coordinate 
-	  float xe = 0.0, ye = 0.0, ze = 0.0;
-	  if(segLD.z() != 0)
-	    {
-	      xe = segLP.x()+segLD.x()*rhLP_inSegmRef.z()/segLD.z();
-	      ye = segLP.y()+segLD.y()*rhLP_inSegmRef.z()/segLD.z();
-	      ze = rhLP_inSegmRef.z();
-	    }
-	  // 3D extrapolated point in the GEM plane
-	  LocalPoint extrPoint(xe,ye,ze);
-	  
-	  // get GEM Rechit Global Position, but obtained from CSC Chamber
-	  // --> this should be the same as rhGP = rhRef->toGlobal(rhLP);
-	  auto rhGP_fromSegmRef = cscChamber->toGlobal(rhLP_inSegmRef);
-	  float phi_rh          = rhGP_fromSegmRef.phi();
-	  float theta_rh        = rhGP_fromSegmRef.theta();
-	  // get Extrapolat Global Position, also obtained from CSC Chamber
-	  auto extrPoinGP_fromSegmRef = cscChamber->toGlobal(extrPoint);
-	  float phi_ext               = extrPoinGP_fromSegmRef.phi();
-	  float theta_ext             = extrPoinGP_fromSegmRef.theta();
-	  
-	  // GEM 1st Layer :: Search for GEM Rechit with smallest Delta Eta and Delta Phi
-	  //                  and save it inside gemrh_min_l1 
-	  if ((*grhIt)->gemId().layer()==1) 
-	    {
-	      float Dphi_l1 = fabs(phi_ext-phi_rh);
-	      float Dtheta_l1 = fabs(theta_ext-theta_rh);
-	      if (Dphi_l1 <= Dphi_min_l1) 
-		{
-		  Dphi_min_l1   = Dphi_l1;
-		  Dtheta_min_l1 = Dtheta_l1;
-		  gemrh_min_l1  = *grhIt;
-		}	  
-	    }
-	  // GEM 2nd Layer :: Search for GEM Rechit with smallest Delta Eta and Delta Phi
-	  //                  and save it inside gemrh_min_l2 
-	  if ((*grhIt)->gemId().layer()==2) 
-	    {
-	      float Dphi_l2 = fabs(phi_ext-phi_rh);
-	      float Dtheta_l2 = fabs(theta_ext-theta_rh);
-	      if (Dphi_l2 <= Dphi_min_l2)
-		{
-		  Dphi_min_l2   = Dphi_l2;
-		  Dtheta_min_l2 = Dtheta_l2;
-		  gemrh_min_l2  = *grhIt;
-		}
-	    }
-	  
-	} // end loop over GEM Rechits
-      
-      // Check whether GEM rechit with smallest delta eta and delta phi 
-      // w.r.t. the extrapolation of the CSC segment is within the 
-      // maxima given by the configuration of the algorithm
-      bool phiRequirementOK_l1 = Dphi_min_l1 < dPhiChainBoxMax;
-      bool thetaRequirementOK_l1 = Dtheta_min_l1 < dThetaChainBoxMax;
-      if(phiRequirementOK_l1 && thetaRequirementOK_l1 && gemrh_min_l1!=nullptr) 
-	{
-	  chainedRecHits.push_back(gemrh_min_l1->clone());  
-	}
-      bool phiRequirementOK_l2 = Dphi_min_l2 < dPhiChainBoxMax;
-      bool thetaRequirementOK_l2 = Dtheta_min_l2 < dThetaChainBoxMax;
-      if(phiRequirementOK_l2 && thetaRequirementOK_l2 && gemrh_min_l2!=nullptr) 
-	{
-	  chainedRecHits.push_back(gemrh_min_l2->clone());
-	}
-    } // End check > 0 GEM rechits
+    std::vector<const GEMRecHit*>::const_iterator grhIt = gemrechits.begin();
+
+    const GEMRecHit* gemrh_min_l1 = *grhIt;
+    const GEMRecHit* gemrh_min_l2 = *grhIt;
+
+    // Loop over GEM rechits from the EnsembleGEMHitContainer
+    for (grhIt = gemrechits.begin(); grhIt != gemrechits.end(); ++grhIt) {
+      // get GEM Rechit Local & Global Position
+      auto rhLP = (*grhIt)->localPosition();
+      const GEMEtaPartition* rhRef = theGEMEtaParts_.find((*grhIt)->gemId())->second;
+      auto rhGP = rhRef->toGlobal(rhLP);
+      // get GEM Rechit Local position w.r.t. the CSC Chamber
+      // --> we are interessed in the z-coordinate
+      auto rhLP_inSegmRef = cscChamber->toLocal(rhGP);
+      // calculate the extrapolation of the CSC segment to the GEM plane (z-coord)
+      // to get x- and y- coordinate
+      float xe = 0.0, ye = 0.0, ze = 0.0;
+      if (segLD.z() != 0) {
+        xe = segLP.x() + segLD.x() * rhLP_inSegmRef.z() / segLD.z();
+        ye = segLP.y() + segLD.y() * rhLP_inSegmRef.z() / segLD.z();
+        ze = rhLP_inSegmRef.z();
+      }
+      // 3D extrapolated point in the GEM plane
+      LocalPoint extrPoint(xe, ye, ze);
+
+      // get GEM Rechit Global Position, but obtained from CSC Chamber
+      // --> this should be the same as rhGP = rhRef->toGlobal(rhLP);
+      auto rhGP_fromSegmRef = cscChamber->toGlobal(rhLP_inSegmRef);
+      float phi_rh = rhGP_fromSegmRef.phi();
+      float theta_rh = rhGP_fromSegmRef.theta();
+      // get Extrapolat Global Position, also obtained from CSC Chamber
+      auto extrPoinGP_fromSegmRef = cscChamber->toGlobal(extrPoint);
+      float phi_ext = extrPoinGP_fromSegmRef.phi();
+      float theta_ext = extrPoinGP_fromSegmRef.theta();
+
+      // GEM 1st Layer :: Search for GEM Rechit with smallest Delta Eta and Delta Phi
+      //                  and save it inside gemrh_min_l1
+      if ((*grhIt)->gemId().layer() == 1) {
+        float Dphi_l1 = fabs(phi_ext - phi_rh);
+        float Dtheta_l1 = fabs(theta_ext - theta_rh);
+        if (Dphi_l1 <= Dphi_min_l1) {
+          Dphi_min_l1 = Dphi_l1;
+          Dtheta_min_l1 = Dtheta_l1;
+          gemrh_min_l1 = *grhIt;
+        }
+      }
+      // GEM 2nd Layer :: Search for GEM Rechit with smallest Delta Eta and Delta Phi
+      //                  and save it inside gemrh_min_l2
+      if ((*grhIt)->gemId().layer() == 2) {
+        float Dphi_l2 = fabs(phi_ext - phi_rh);
+        float Dtheta_l2 = fabs(theta_ext - theta_rh);
+        if (Dphi_l2 <= Dphi_min_l2) {
+          Dphi_min_l2 = Dphi_l2;
+          Dtheta_min_l2 = Dtheta_l2;
+          gemrh_min_l2 = *grhIt;
+        }
+      }
+
+    }  // end loop over GEM Rechits
+
+    // Check whether GEM rechit with smallest delta eta and delta phi
+    // w.r.t. the extrapolation of the CSC segment is within the
+    // maxima given by the configuration of the algorithm
+    bool phiRequirementOK_l1 = Dphi_min_l1 < dPhiChainBoxMax;
+    bool thetaRequirementOK_l1 = Dtheta_min_l1 < dThetaChainBoxMax;
+    if (phiRequirementOK_l1 && thetaRequirementOK_l1 && gemrh_min_l1 != nullptr) {
+      chainedRecHits.push_back(gemrh_min_l1->clone());
+    }
+    bool phiRequirementOK_l2 = Dphi_min_l2 < dPhiChainBoxMax;
+    bool thetaRequirementOK_l2 = Dtheta_min_l2 < dThetaChainBoxMax;
+    if (phiRequirementOK_l2 && thetaRequirementOK_l2 && gemrh_min_l2 != nullptr) {
+      chainedRecHits.push_back(gemrh_min_l2->clone());
+    }
+  }  // End check > 0 GEM rechits
 
   return chainedRecHits;
 }
-
-
 
 /** 
  * This algorithm uses a Minimum Spanning Tree (ST) approach to build
  * endcap muon track segments from the rechits in the 6 layers of a CSC
  * and the 2 layers inside a GE1/1 GEM. Fit is implemented in GEMCSCSegFit.cc
  */
-std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::buildSegments(const CSCSegment* cscsegment, const std::vector<const TrackingRecHit*>& rechits) 
-{
-
-  std::vector<GEMCSCSegment>    gemcscsegmentvector;
+std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::buildSegments(const CSCSegment* cscsegment,
+                                                          const std::vector<const TrackingRecHit*>& rechits) {
+  std::vector<GEMCSCSegment> gemcscsegmentvector;
   std::vector<const GEMRecHit*> gemrechits;
 
   // Leave the function if the amount of rechits in the EnsembleHitContainer < min required
-  if (rechits.size() < minHitsPerSegment) 
-    {
-      return gemcscsegmentvector;
-    }
+  if (rechits.size() < minHitsPerSegment) {
+    return gemcscsegmentvector;
+  }
 
   // Extract the GEMRecHits from the TrackingRecHit vector
-  for(std::vector<const TrackingRecHit*>::const_iterator trhIt = rechits.begin(); trhIt!=rechits.end(); ++trhIt) 
-    {
-      if (DetId((*trhIt)->rawId()).subdetId() == MuonSubdetId::GEM) { gemrechits.push_back( ((const GEMRecHit*)*trhIt) ); }
+  for (std::vector<const TrackingRecHit*>::const_iterator trhIt = rechits.begin(); trhIt != rechits.end(); ++trhIt) {
+    if (DetId((*trhIt)->rawId()).subdetId() == MuonSubdetId::GEM) {
+      gemrechits.push_back(((const GEMRecHit*)*trhIt));
     }
+  }
 
   // The actual fit on all hits of the vector of the selected Tracking RecHits:
   delete sfit_;
@@ -314,18 +299,20 @@ std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::buildSegments(const CSCSegment* cscs
   sfit_->fit();
 
   // obtain all information necessary to make the segment:
-  LocalPoint protoIntercept      = sfit_->intercept();
-  LocalVector protoDirection     = sfit_->localdir();
-  AlgebraicSymMatrix protoErrors = sfit_->covarianceMatrix(); 
-  double protoChi2               = sfit_->chi2();
+  LocalPoint protoIntercept = sfit_->intercept();
+  LocalVector protoDirection = sfit_->localdir();
+  AlgebraicSymMatrix protoErrors = sfit_->covarianceMatrix();
+  double protoChi2 = sfit_->chi2();
 
-  edm::LogVerbatim("GEMCSCSegAlgoRR") << "[GEMCSCSegAlgoRR::buildSegments] fit done, will now try to make GEMCSC Segment from CSC Segment in "<<cscsegment->cscDetId()
-				      << " made of "<<cscsegment->specificRecHits().size()<<" rechits and with chi2 = "<<cscsegment->chi2()<<" and with "<<gemrechits.size()<<" GEM RecHits";
+  edm::LogVerbatim("GEMCSCSegAlgoRR")
+      << "[GEMCSCSegAlgoRR::buildSegments] fit done, will now try to make GEMCSC Segment from CSC Segment in "
+      << cscsegment->cscDetId() << " made of " << cscsegment->specificRecHits().size()
+      << " rechits and with chi2 = " << cscsegment->chi2() << " and with " << gemrechits.size() << " GEM RecHits";
 
   // save all information inside GEMCSCSegment
   GEMCSCSegment tmp(cscsegment, gemrechits, protoIntercept, protoDirection, protoErrors, protoChi2);
 
   edm::LogVerbatim("GEMCSCSegAlgoRR") << "[GEMCSCSegAlgoRR::buildSegments] GEMCSC Segment made";
-  gemcscsegmentvector.push_back(tmp);    
+  gemcscsegmentvector.push_back(tmp);
   return gemcscsegmentvector;
 }

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.h
@@ -20,14 +20,10 @@
 #include <deque>
 #include <vector>
 
-
 class GEMCSCSegFit;
 
 class GEMCSCSegAlgoRR : public GEMCSCSegmentAlgorithm {
-
-
 public:
-
   /// Constructor
   explicit GEMCSCSegAlgoRR(const edm::ParameterSet& ps);
 
@@ -37,41 +33,43 @@ public:
   /**
    * Build segments for all desired groups of hits
    */
-  std::vector<GEMCSCSegment> run( const std::map<uint32_t, const CSCLayer*>& csclayermap, const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap,
-				  const std::vector<const CSCSegment*>& cscsegments, const std::vector<const GEMRecHit*>& gemrechits) override;
-private:
+  std::vector<GEMCSCSegment> run(const std::map<uint32_t, const CSCLayer*>& csclayermap,
+                                 const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap,
+                                 const std::vector<const CSCSegment*>& cscsegments,
+                                 const std::vector<const GEMRecHit*>& gemrechits) override;
 
-  /// Utility functions 
+private:
+  /// Utility functions
   /**
    * Search for GEMHits inside a Box around the position extrapolated from the CSC segment.
    */
-  std::vector<const TrackingRecHit*> chainHitsToSegm(const CSCSegment* cscsegment, const std::vector<const GEMRecHit*>& gemrechits);
+  std::vector<const TrackingRecHit*> chainHitsToSegm(const CSCSegment* cscsegment,
+                                                     const std::vector<const GEMRecHit*>& gemrechits);
 
-    
   /**
    * Build the GEMCSCSegment.
    */
-  std::vector<GEMCSCSegment> buildSegments(const CSCSegment* cscsegment, const std::vector<const TrackingRecHit*>& rechits);
-
+  std::vector<GEMCSCSegment> buildSegments(const CSCSegment* cscsegment,
+                                           const std::vector<const TrackingRecHit*>& rechits);
 
   /// Configuration parameters
-  bool         debug;
+  bool debug;
   unsigned int minHitsPerSegment;
-  bool         preClustering;
-  double       dXclusBoxMax;
-  double       dYclusBoxMax;
-  bool         preClustering_useChaining;
-  double       dPhiChainBoxMax;
-  double       dThetaChainBoxMax;
-  double       dRChainBoxMax;
-  int          maxRecHitsInCluster;
-  
-  /// Member variables
-  const std::string myName; // name of the algorithm, here: GEMCSCSegAlgoRR
+  bool preClustering;
+  double dXclusBoxMax;
+  double dYclusBoxMax;
+  bool preClustering_useChaining;
+  double dPhiChainBoxMax;
+  double dThetaChainBoxMax;
+  double dRChainBoxMax;
+  int maxRecHitsInCluster;
 
-  std::map<uint32_t, const CSCLayer*>        theCSCLayers_;
+  /// Member variables
+  const std::string myName;  // name of the algorithm, here: GEMCSCSegAlgoRR
+
+  std::map<uint32_t, const CSCLayer*> theCSCLayers_;
   std::map<uint32_t, const GEMEtaPartition*> theGEMEtaParts_;
-  GEMCSCSegFit*                              sfit_;
+  GEMCSCSegFit* sfit_;
 };
 
 #endif

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegFit.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegFit.cc
@@ -1,7 +1,7 @@
 // ------------------------- //
-// --> GEMCSCSegFit.cc 
+// --> GEMCSCSegFit.cc
 // Created:  21.04.2015
-// --> Based on CSCSegFit.cc 
+// --> Based on CSCSegFit.cc
 // with last mod: 03.02.2015
 // as found in 750pre2 rel
 // ------------------------- //
@@ -16,40 +16,38 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 void GEMCSCSegFit::fit(void) {
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] - start the fitting fun :: nhits = "<<nhits();
-  if ( fitdone() ) return; // don't redo fit unnecessarily
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] - start the fitting fun :: nhits = " << nhits();
+  if (fitdone())
+    return;  // don't redo fit unnecessarily
   short n = nhits();
-  switch ( n ) {
-  case 1:
-    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] - cannot fit just 1 hit!!";
-    break;
-  case 2:
-    fit2();
-    break;
-  case 3:
-  case 4:
-  case 5:
-  case 6:
-  case 7:
-  case 8:
-    fitlsq();
-    break;
-  default:
-    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] - cannot fit more than 8 hits!!";
-  }  
+  switch (n) {
+    case 1:
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] - cannot fit just 1 hit!!";
+      break;
+    case 2:
+      fit2();
+      break;
+    case 3:
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+    case 8:
+      fitlsq();
+      break;
+    default:
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] - cannot fit more than 8 hits!!";
+  }
 }
 
 void GEMCSCSegFit::fit2(void) {
-
   edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit2] - start fit2()";
   // Just join the two points
   // Equation of straight line between (x1, y1) and (x2, y2) in xy-plane is
   //       y = mx + c
   // with m = (y2-y1)/(x2-x1)
   // and  c = (y1*x2-x2*y1)/(x2-x1)
-
 
   // 1) Check whether hits are on the same layer
   // -------------------------------------------
@@ -60,22 +58,22 @@ void GEMCSCSegFit::fit2(void) {
   // check whether first hit is GEM or CSC
   if (d1.subdetId() == MuonSubdetId::GEM) {
     il1 = GEMDetId(d1).layer();
-  }
-  else if (d1.subdetId() == MuonSubdetId::CSC) {
+  } else if (d1.subdetId() == MuonSubdetId::CSC) {
     il1 = CSCDetId(d1).layer() + 2;
+  } else {
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
   }
-  else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
   const TrackingRecHit& h1 = (**ih);
   ++ih;
   DetId d2 = DetId((*ih)->rawId());
   // check whether second hit is GEM or CSC
   if (d2.subdetId() == MuonSubdetId::GEM) {
     il2 = GEMDetId(d2).layer();
-  }
-  else if (d2.subdetId() == MuonSubdetId::CSC) {
+  } else if (d2.subdetId() == MuonSubdetId::CSC) {
     il2 = GEMDetId(d2).layer() + 2;
+  } else {
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
   }
-  else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
   const TrackingRecHit& h2 = (**ih);
   // Skip if on same layer, but should be impossible :)
   if (il1 == il2) {
@@ -83,47 +81,45 @@ void GEMCSCSegFit::fit2(void) {
     return;
   }
 
-
   // 2) Global Positions of hit 1 and 2 and
-  //    Local  Positions of hit 1 and 2 w.r.t. reference CSC Chamber Frame 
+  //    Local  Positions of hit 1 and 2 w.r.t. reference CSC Chamber Frame
   // ---------------------------------------------------------------------
   GlobalPoint h1glopos, h2glopos;
   // global position hit 1
-  if(d1.subdetId() == MuonSubdetId::GEM) {
+  if (d1.subdetId() == MuonSubdetId::GEM) {
     const GEMEtaPartition* roll1 = gemetapartition(GEMDetId(d1));
     h1glopos = roll1->toGlobal(h1.localPosition());
-  }
-  else if(d1.subdetId() == MuonSubdetId::CSC) {
+  } else if (d1.subdetId() == MuonSubdetId::CSC) {
     const CSCLayer* layer1 = cscchamber(CSCDetId(d1))->layer(CSCDetId(d1).layer());
     h1glopos = layer1->toGlobal(h1.localPosition());
+  } else {
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
   }
-  else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
   // global position hit 2
-  if(d2.subdetId() == MuonSubdetId::GEM) {
+  if (d2.subdetId() == MuonSubdetId::GEM) {
     const GEMEtaPartition* roll2 = gemetapartition(GEMDetId(d2));
     h2glopos = roll2->toGlobal(h2.localPosition());
-  }
-  else if(d2.subdetId() == MuonSubdetId::CSC) {
+  } else if (d2.subdetId() == MuonSubdetId::CSC) {
     const CSCLayer* layer2 = cscchamber(CSCDetId(d2))->layer(CSCDetId(d2).layer());
     h2glopos = layer2->toGlobal(h2.localPosition());
+  } else {
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
   }
-  else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
   // local positions hit 1 and 2 w.r.t. ref CSC Chamber Frame
   // We want hit wrt chamber (and local z will be != 0)
-  LocalPoint h1pos = refcscchamber()->toLocal(h1glopos);  
-  LocalPoint h2pos = refcscchamber()->toLocal(h2glopos);  
-
+  LocalPoint h1pos = refcscchamber()->toLocal(h1glopos);
+  LocalPoint h2pos = refcscchamber()->toLocal(h2glopos);
 
   // 3) Now make straight line between the two points in local coords
-  // ----------------------------------------------------------------    
-  float dz = h2pos.z()-h1pos.z();
-  if(dz != 0) {
-    uslope_ = ( h2pos.x() - h1pos.x() ) / dz ;
-    vslope_ = ( h2pos.y() - h1pos.y() ) / dz ;
+  // ----------------------------------------------------------------
+  float dz = h2pos.z() - h1pos.z();
+  if (dz != 0) {
+    uslope_ = (h2pos.x() - h1pos.x()) / dz;
+    vslope_ = (h2pos.y() - h1pos.y()) / dz;
   }
-  float uintercept = ( h1pos.x()*h2pos.z() - h2pos.x()*h1pos.z() ) / dz;
-  float vintercept = ( h1pos.y()*h2pos.z() - h2pos.y()*h1pos.z() ) / dz;
-  intercept_ = LocalPoint( uintercept, vintercept, 0.);
+  float uintercept = (h1pos.x() * h2pos.z() - h2pos.x() * h1pos.z()) / dz;
+  float vintercept = (h1pos.y() * h2pos.z() - h2pos.y() * h1pos.z()) / dz;
+  intercept_ = LocalPoint(uintercept, vintercept, 0.);
 
   setOutFromIP();
 
@@ -134,9 +130,7 @@ void GEMCSCSegFit::fit2(void) {
   fitdone_ = true;
 }
 
-
 void GEMCSCSegFit::fitlsq(void) {
-  
   edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - start fitlsq";
   // Linear least-squares fit to up to 6 CSC rechits, one per layer in a CSC
   // and up to 2 GEM rechits in a GEM superchamber
@@ -146,40 +140,40 @@ void GEMCSCSegFit::fitlsq(void) {
 
   // Comments below taken from CSCSegFit algorithm.
   // Comments adapted from original  CSCSegAlgoSK algorithm.
-  
+
   // Fit to the local x, y rechit coordinates in z projection
   // The CSC & GEM strip measurement controls the precision of x
-  // The CSC wire measurement & GEM eta-partition controls the precision of y. 
+  // The CSC wire measurement & GEM eta-partition controls the precision of y.
   // Typical precision CSC: u (strip, sigma~200um), v (wire, sigma~1cm)
   // Typical precision GEM: u (strip, sigma~250um), v (eta-part, sigma~10-20cm)
-  
+
   // Set up the normal equations for the least-squares fit as a matrix equation
-  
+
   // We have a vector of measurements m, which is a 2n x 1 dim matrix
   // The transpose mT is (u1, v1, u2, v2, ..., un, vn) where
-  // ui is the strip-associated measurement and 
-  // vi is the wire-associated measurement 
+  // ui is the strip-associated measurement and
+  // vi is the wire-associated measurement
   // for a given rechit i.
-  
+
   // The fit is to
   // u = u0 + uz * z
   // v = v0 + vz * z
   // where u0, uz, v0, vz are the parameters to be obtained from the fit.
-  
+
   // These are contained in a vector p which is a 4x1 dim matrix, and
   // its transpose pT is (u0, v0, uz, vz). Note the ordering!
-  
+
   // The covariance matrix for each pair of measurements is 2 x 2 and
   // the inverse of this is the error matrix E.
   // The error matrix for the whole set of n measurements is a diagonal
   // matrix with diagonal elements the individual 2 x 2 error matrices
   // (because the inverse of a diagonal matrix is a diagonal matrix
   // with each element the inverse of the original.)
-  
+
   // In function 'weightMatrix()', the variable 'matrix' is filled with this
-  // block-diagonal overall covariance matrix. Then 'matrix' is inverted to the 
+  // block-diagonal overall covariance matrix. Then 'matrix' is inverted to the
   // block-diagonal error matrix, and returned.
-  
+
   // Define the matrix A as
   //    1   0   z1  0
   //    0   1   0   z1
@@ -188,303 +182,295 @@ void GEMCSCSegFit::fitlsq(void) {
   //    ..  ..  ..  ..
   //    1   0   zn  0
   //    0   1   0   zn
-  
+
   // This matrix A is set up and returned by function 'derivativeMatrix()'.
-  
+
   // Then the normal equations are described by the matrix equation
   //
   //    (AT E A)p = (AT E)m
   //
   // where AT is the transpose of A.
-  
+
   // Call the combined matrix on the LHS, M, and that on the RHS, B:
   //     M p = B
-  
+
   // We solve this for the parameter vector, p.
   // The elements of M and B then involve sums over the hits
-  
-  // The covariance matrix of the parameters is obtained by 
+
+  // The covariance matrix of the parameters is obtained by
   // (AT E A)^-1 calculated in 'covarianceMatrix()'.
-  
 
   // NOTE
   // We need local position of a RecHit w.r.t. the CHAMBER
   // and the RecHit itself only knows its local position w.r.t.
   // the LAYER, so we must explicitly transform global position.
-  
 
-  SMatrix4 M; // 4x4, init to 0
-  SVector4 B; // 4x1, init to 0; 
+  SMatrix4 M;  // 4x4, init to 0
+  SVector4 B;  // 4x1, init to 0;
 
   std::vector<const TrackingRecHit*>::const_iterator ih = hits_.begin();
 
-  // LogDebug :: Loop over the TrackingRecHits and print the GEM and CSC Hits  
-  for (ih = hits_.begin(); ih != hits_.end(); ++ih) 
-    {
-      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - looping over TrackingRecHits";
-      const TrackingRecHit& hit = (**ih);
-      DetId d = DetId(hit.rawId());
-      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit in detid ("<<d.rawId()<<")";
-      if(d.subdetId() == MuonSubdetId::GEM) {
-	edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit is a GEM Hit in detid ("<<d.rawId()<<")";
-	edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - GEM DetId ("<<GEMDetId(d.rawId())<<")";
-      }
-      else if(d.subdetId() == MuonSubdetId::CSC) {
-	edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit is a CSC Hit in detid ("<<d.rawId()<<")";
-	edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - CSC DetId ("<<CSCDetId(d.rawId())<<")";
-      }
-      else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
+  // LogDebug :: Loop over the TrackingRecHits and print the GEM and CSC Hits
+  for (ih = hits_.begin(); ih != hits_.end(); ++ih) {
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - looping over TrackingRecHits";
+    const TrackingRecHit& hit = (**ih);
+    DetId d = DetId(hit.rawId());
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit in detid (" << d.rawId() << ")";
+    if (d.subdetId() == MuonSubdetId::GEM) {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit is a GEM Hit in detid ("
+                                       << d.rawId() << ")";
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - GEM DetId (" << GEMDetId(d.rawId()) << ")";
+    } else if (d.subdetId() == MuonSubdetId::CSC) {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit is a CSC Hit in detid ("
+                                       << d.rawId() << ")";
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - CSC DetId (" << CSCDetId(d.rawId()) << ")";
+    } else {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
     }
+  }
 
   // Loop over the TrackingRecHits and make small (2x2) matrices used to fill the blockdiagonal covariance matrix E^-1
-  for (ih = hits_.begin(); ih != hits_.end(); ++ih) 
-    {
-      const TrackingRecHit& hit = (**ih);
-      GlobalPoint gp;
-      DetId d = DetId(hit.rawId());
-      if(d.subdetId() == MuonSubdetId::GEM) 
-	{
-	  const GEMEtaPartition* roll = gemetapartition(GEMDetId(d));
-	  gp = roll->toGlobal(hit.localPosition());
-	}
-      else if(d.subdetId() == MuonSubdetId::CSC) 
-	{
-	  const CSCLayer* layer = cscchamber(CSCDetId(d))->layer(CSCDetId(d).layer());
-	  gp = layer->toGlobal(hit.localPosition());
-	}
-      else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
-      LocalPoint lp = refcscchamber()->toLocal(gp); 
+  for (ih = hits_.begin(); ih != hits_.end(); ++ih) {
+    const TrackingRecHit& hit = (**ih);
+    GlobalPoint gp;
+    DetId d = DetId(hit.rawId());
+    if (d.subdetId() == MuonSubdetId::GEM) {
+      const GEMEtaPartition* roll = gemetapartition(GEMDetId(d));
+      gp = roll->toGlobal(hit.localPosition());
+    } else if (d.subdetId() == MuonSubdetId::CSC) {
+      const CSCLayer* layer = cscchamber(CSCDetId(d))->layer(CSCDetId(d).layer());
+      gp = layer->toGlobal(hit.localPosition());
+    } else {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
+    }
+    LocalPoint lp = refcscchamber()->toLocal(gp);
 
-      // LogDebug
-      std::stringstream lpss; lpss<<lp; std::string lps = lpss.str();
-      std::stringstream gpss; gpss<<gp; std::string gps = gpss.str();
-      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit global position "<<std::setw(30)<<gps<<" and local position "<<std::setw(30)<<lps
-				       <<" wrt reference csc chamber "<<refcscchamber()->id().rawId()<<" = "<<refcscchamber()->id();
-      
-      // Local position of hit w.r.t. chamber
-      double u = lp.x();
-      double v = lp.y();
-      double z = lp.z();
-      
-      // Covariance matrix of local errors 
-      SMatrixSym2 IC; // 2x2, init to 0
-      
-      IC(0,0) = hit.localPositionError().xx();
-      IC(1,1) = hit.localPositionError().yy();
-      //@@ NOT SURE WHICH OFF-DIAGONAL ELEMENT MUST BE DEFINED BUT (1,0) WORKS
-      //@@ (and SMatrix enforces symmetry)
-      IC(1,0) = hit.localPositionError().xy();
-      // IC(0,1) = IC(1,0);
+    // LogDebug
+    std::stringstream lpss;
+    lpss << lp;
+    std::string lps = lpss.str();
+    std::stringstream gpss;
+    gpss << gp;
+    std::string gps = gpss.str();
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fitlsq] - Tracking RecHit global position " << std::setw(30)
+                                     << gps << " and local position " << std::setw(30) << lps
+                                     << " wrt reference csc chamber " << refcscchamber()->id().rawId() << " = "
+                                     << refcscchamber()->id();
 
-      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] 2x2 covariance matrix for this Tracking RecHit :: [[" << IC(0,0) <<", "<< IC(0,1) <<"]["<< IC(1,0) <<","<<IC(1,1)<<"]]";
-      
-      // Invert covariance matrix (and trap if it fails!)
-      bool ok = IC.Invert();
-      if ( !ok ) 
-	{
-	  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] Failed to invert covariance matrix: \n" << IC;      
-	  return; // MATRIX INVERSION FAILED ... QUIT VOID FUNCTION
-	}
+    // Local position of hit w.r.t. chamber
+    double u = lp.x();
+    double v = lp.y();
+    double z = lp.z();
 
-      // M = (AT E A)
-      // B = (AT E m)
-      // for now fill only with sum of blockdiagonal 
-      // elements of (E^-1)_i = IC_i for hit i
-      M(0,0) += IC(0,0);
-      M(0,1) += IC(0,1);
-      M(0,2) += IC(0,0) * z;
-      M(0,3) += IC(0,1) * z;
-      B(0)   += u * IC(0,0) + v * IC(0,1);
-      
-      M(1,0) += IC(1,0);
-      M(1,1) += IC(1,1);
-      M(1,2) += IC(1,0) * z;
-      M(1,3) += IC(1,1) * z;
-      B(1)   += u * IC(1,0) + v * IC(1,1);
-      
-      M(2,0) += IC(0,0) * z;
-      M(2,1) += IC(0,1) * z;
-      M(2,2) += IC(0,0) * z * z;
-      M(2,3) += IC(0,1) * z * z;
-      B(2)   += ( u * IC(0,0) + v * IC(0,1) ) * z;
-      
-      M(3,0) += IC(1,0) * z;
-      M(3,1) += IC(1,1) * z;
-      M(3,2) += IC(1,0) * z * z;
-      M(3,3) += IC(1,1) * z * z;
-      B(3)   += ( u * IC(1,0) + v * IC(1,1) ) * z;
-      
-    } // End Loop over the TrackingRecHits to make the block matrices to be filled in M and B
-  
+    // Covariance matrix of local errors
+    SMatrixSym2 IC;  // 2x2, init to 0
+
+    IC(0, 0) = hit.localPositionError().xx();
+    IC(1, 1) = hit.localPositionError().yy();
+    //@@ NOT SURE WHICH OFF-DIAGONAL ELEMENT MUST BE DEFINED BUT (1,0) WORKS
+    //@@ (and SMatrix enforces symmetry)
+    IC(1, 0) = hit.localPositionError().xy();
+    // IC(0,1) = IC(1,0);
+
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] 2x2 covariance matrix for this Tracking RecHit :: [["
+                                     << IC(0, 0) << ", " << IC(0, 1) << "][" << IC(1, 0) << "," << IC(1, 1) << "]]";
+
+    // Invert covariance matrix (and trap if it fails!)
+    bool ok = IC.Invert();
+    if (!ok) {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] Failed to invert covariance matrix: \n" << IC;
+      return;  // MATRIX INVERSION FAILED ... QUIT VOID FUNCTION
+    }
+
+    // M = (AT E A)
+    // B = (AT E m)
+    // for now fill only with sum of blockdiagonal
+    // elements of (E^-1)_i = IC_i for hit i
+    M(0, 0) += IC(0, 0);
+    M(0, 1) += IC(0, 1);
+    M(0, 2) += IC(0, 0) * z;
+    M(0, 3) += IC(0, 1) * z;
+    B(0) += u * IC(0, 0) + v * IC(0, 1);
+
+    M(1, 0) += IC(1, 0);
+    M(1, 1) += IC(1, 1);
+    M(1, 2) += IC(1, 0) * z;
+    M(1, 3) += IC(1, 1) * z;
+    B(1) += u * IC(1, 0) + v * IC(1, 1);
+
+    M(2, 0) += IC(0, 0) * z;
+    M(2, 1) += IC(0, 1) * z;
+    M(2, 2) += IC(0, 0) * z * z;
+    M(2, 3) += IC(0, 1) * z * z;
+    B(2) += (u * IC(0, 0) + v * IC(0, 1)) * z;
+
+    M(3, 0) += IC(1, 0) * z;
+    M(3, 1) += IC(1, 1) * z;
+    M(3, 2) += IC(1, 0) * z * z;
+    M(3, 3) += IC(1, 1) * z * z;
+    B(3) += (u * IC(1, 0) + v * IC(1, 1)) * z;
+
+  }  // End Loop over the TrackingRecHits to make the block matrices to be filled in M and B
+
   SVector4 p;
   bool ok = M.Invert();
-  if (!ok )
-    {
-      edm::LogVerbatim("GEMCSCSegment|GEMCSCSegFit") << "[GEMCSCSegFit::fit] Failed to invert matrix: \n" << M;
-      return; // MATRIX INVERSION FAILED ... QUIT VOID FUNCTION 
-    }
-  else 
-    {
-      p = M * B;
-    }
+  if (!ok) {
+    edm::LogVerbatim("GEMCSCSegment|GEMCSCSegFit") << "[GEMCSCSegFit::fit] Failed to invert matrix: \n" << M;
+    return;  // MATRIX INVERSION FAILED ... QUIT VOID FUNCTION
+  } else {
+    p = M * B;
+  }
 
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] p = " 
-          << p(0) << ", " << p(1) << ", " << p(2) << ", " << p(3);
-  
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::fit] p = " << p(0) << ", " << p(1) << ", " << p(2) << ", "
+                                   << p(3);
+
   // fill member variables  (note origin has local z = 0)
   //  intercept_
   intercept_ = LocalPoint(p(0), p(1), 0.);
-  
+
   // localdir_ - set so segment points outwards from IP
   uslope_ = p(2);
   vslope_ = p(3);
   setOutFromIP();
-  
+
   // calculate chi2 of fit
-  setChi2( );
+  setChi2();
 
   // flag fit has been done
   fitdone_ = true;
-
 }
 
-
-
 void GEMCSCSegFit::setChi2(void) {
-  
   double chsq = 0.;
   bool gem = false;
 
   std::vector<const TrackingRecHit*>::const_iterator ih;
   for (ih = hits_.begin(); ih != hits_.end(); ++ih) {
-
     const TrackingRecHit& hit = (**ih);
     GlobalPoint gp;
     DetId d = DetId(hit.rawId());
-    if(d.subdetId() == MuonSubdetId::GEM) {
+    if (d.subdetId() == MuonSubdetId::GEM) {
       const GEMEtaPartition* roll = gemetapartition(GEMDetId(d));
       gp = roll->toGlobal(hit.localPosition());
       gem = true;
-    }
-    else if(d.subdetId() == MuonSubdetId::CSC) {
+    } else if (d.subdetId() == MuonSubdetId::CSC) {
       const CSCLayer* layer = cscchamber(CSCDetId(d))->layer(CSCDetId(d).layer());
       gp = layer->toGlobal(hit.localPosition());
       gem = false;
+    } else {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
     }
-    else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
     LocalPoint lp = refcscchamber()->toLocal(gp);
 
     // LogDebug
-    std::stringstream lpss; lpss<<lp; std::string lps = lpss.str();
-    std::stringstream gpss; gpss<<gp; std::string gps = gpss.str();
-    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] - Tracking RecHit in "<<(gem? "GEM":"CSC")<<" global position "<<std::setw(30)<<gps<<" and local position "<<std::setw(30)<<lps
-				       <<" wrt reference csc chamber "<<refcscchamber()->id().rawId()<<" = "<<refcscchamber()->id();
-    
+    std::stringstream lpss;
+    lpss << lp;
+    std::string lps = lpss.str();
+    std::stringstream gpss;
+    gpss << gp;
+    std::string gps = gpss.str();
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] - Tracking RecHit in " << (gem ? "GEM" : "CSC")
+                                     << " global position " << std::setw(30) << gps << " and local position "
+                                     << std::setw(30) << lps << " wrt reference csc chamber "
+                                     << refcscchamber()->id().rawId() << " = " << refcscchamber()->id();
+
     double u = lp.x();
     double v = lp.y();
     double z = lp.z();
-    
+
     double du = intercept_.x() + uslope_ * z - u;
     double dv = intercept_.y() + vslope_ * z - v;
-    
+
     edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] u, v, z = " << u << ", " << v << ", " << z;
 
-    SMatrixSym2 IC; // 2x2, init to 0
+    SMatrixSym2 IC;  // 2x2, init to 0
 
-    IC(0,0) = hit.localPositionError().xx();
+    IC(0, 0) = hit.localPositionError().xx();
     //    IC(0,1) = hit.localPositionError().xy();
-    IC(1,0) = hit.localPositionError().xy();
-    IC(1,1) = hit.localPositionError().yy();
+    IC(1, 0) = hit.localPositionError().xy();
+    IC(1, 1) = hit.localPositionError().yy();
     //    IC(1,0) = IC(0,1);
 
     edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] IC before = \n" << IC;
 
     // Invert covariance matrix
     bool ok = IC.Invert();
-    if (!ok ){
+    if (!ok) {
       edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Failed to invert covariance matrix: \n" << IC;
-      return; // MATRIX INVERSION FAILED ... QUIT VOID FUNCTION
+      return;  // MATRIX INVERSION FAILED ... QUIT VOID FUNCTION
     }
     edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] IC after = \n" << IC;
-    chsq += du*du*IC(0,0) + 2.*du*dv*IC(0,1) + dv*dv*IC(1,1);
+    chsq += du * du * IC(0, 0) + 2. * du * dv * IC(0, 1) + dv * dv * IC(1, 1);
     // LogDebug
-    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Contribution of this Tracking RecHit to Chi2: du^2*D(1,1) + 2*du*dv*D(1,2) + dv^2*D(2,2) = " 
-				       << du*du <<"*"<<IC(0,0)<<" + 2.*"<<du<<"*"<<dv<<"*"<<IC(0,1)<<" + "<<dv*dv<<"*"<<IC(1,1)<<" = "<<du*du*IC(0,0) + 2.*du*dv*IC(0,1) + dv*dv*IC(1,1);
+    edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Contribution of this Tracking RecHit to Chi2: "
+                                        "du^2*D(1,1) + 2*du*dv*D(1,2) + dv^2*D(2,2) = "
+                                     << du * du << "*" << IC(0, 0) << " + 2.*" << du << "*" << dv << "*" << IC(0, 1)
+                                     << " + " << dv * dv << "*" << IC(1, 1) << " = "
+                                     << du * du * IC(0, 0) + 2. * du * dv * IC(0, 1) + dv * dv * IC(1, 1);
   }
   // LogDebug
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Total Chi2 = "<<chsq;
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Total NDof = "<<2.*hits_.size() - 4;
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Total Chi2/NDof = "<<((hits_.size()>2)?(chsq/(2.*hits_.size() - 4)):(0.0));
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Total Chi2 = " << chsq;
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Total NDof = " << 2. * hits_.size() - 4;
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] Total Chi2/NDof = "
+                                   << ((hits_.size() > 2) ? (chsq / (2. * hits_.size() - 4)) : (0.0));
 
   // fill member variables
   chi2_ = chsq;
-  ndof_ = 2.*hits_.size() - 4;
+  ndof_ = 2. * hits_.size() - 4;
 
   edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::setChi2] chi2 = " << chi2_ << "/" << ndof_ << " dof";
-
 }
 
-
-
-
 GEMCSCSegFit::SMatrixSym16 GEMCSCSegFit::weightMatrix() {
-  
   bool ok = true;
 
-  SMatrixSym16 matrix = ROOT::Math::SMatrixIdentity(); 
-  // for CSC segment ::     max 6 rechits => 12x12, 
+  SMatrixSym16 matrix = ROOT::Math::SMatrixIdentity();
+  // for CSC segment ::     max 6 rechits => 12x12,
   // for GEM-CSC segment :: max 8 rechits => 16x16
   // for all :: init to 1's on diag
 
   int row = 0;
-  
-  for (std::vector<const TrackingRecHit*>::const_iterator it = hits_.begin(); it != hits_.end(); ++it) 
-    {
-   
-      const TrackingRecHit& hit = (**it);
 
-      // Note scaleXError allows rescaling the x error if necessary
+  for (std::vector<const TrackingRecHit*>::const_iterator it = hits_.begin(); it != hits_.end(); ++it) {
+    const TrackingRecHit& hit = (**it);
 
-      matrix(row, row)   = scaleXError()*hit.localPositionError().xx();
-      matrix(row, row+1) = hit.localPositionError().xy();
-      ++row;
-      matrix(row, row-1) = hit.localPositionError().xy();
-      matrix(row, row)   = hit.localPositionError().yy();
-      ++row;
-    }
+    // Note scaleXError allows rescaling the x error if necessary
 
-  ok = matrix.Invert(); // invert in place
-  if ( !ok ) 
-    {
-      edm::LogVerbatim("GEMCSCSegment|GEMCSCSegFit") << "[GEMCSCSegFit::weightMatrix] Failed to invert matrix: \n" << matrix;      
-      SMatrixSym16 emptymatrix = ROOT::Math::SMatrixIdentity();
-      return emptymatrix; // return (empty) identity matrix if matrix inversion failed 
-    }
+    matrix(row, row) = scaleXError() * hit.localPositionError().xx();
+    matrix(row, row + 1) = hit.localPositionError().xy();
+    ++row;
+    matrix(row, row - 1) = hit.localPositionError().xy();
+    matrix(row, row) = hit.localPositionError().yy();
+    ++row;
+  }
+
+  ok = matrix.Invert();  // invert in place
+  if (!ok) {
+    edm::LogVerbatim("GEMCSCSegment|GEMCSCSegFit") << "[GEMCSCSegFit::weightMatrix] Failed to invert matrix: \n"
+                                                   << matrix;
+    SMatrixSym16 emptymatrix = ROOT::Math::SMatrixIdentity();
+    return emptymatrix;  // return (empty) identity matrix if matrix inversion failed
+  }
   return matrix;
 }
 
-
-
-
 GEMCSCSegFit::SMatrix16by4 GEMCSCSegFit::derivativeMatrix() {
-  
-  SMatrix16by4 matrix; // 16x4, init to 0
+  SMatrix16by4 matrix;  // 16x4, init to 0
   int row = 0;
-  
-  for(std::vector<const TrackingRecHit*>::const_iterator it = hits_.begin(); it != hits_.end(); ++it) {
-    
+
+  for (std::vector<const TrackingRecHit*>::const_iterator it = hits_.begin(); it != hits_.end(); ++it) {
     const TrackingRecHit& hit = (**it);
     GlobalPoint gp;
     DetId d = DetId(hit.rawId());
-    if(d.subdetId() == MuonSubdetId::GEM) {
+    if (d.subdetId() == MuonSubdetId::GEM) {
       const GEMEtaPartition* roll = gemetapartition(GEMDetId(d));
       gp = roll->toGlobal(hit.localPosition());
-    }
-    else if(d.subdetId() == MuonSubdetId::CSC) {
+    } else if (d.subdetId() == MuonSubdetId::CSC) {
       const CSCLayer* layer = cscchamber(CSCDetId(d))->layer(CSCDetId(d).layer());
       gp = layer->toGlobal(hit.localPosition());
+    } else {
+      edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector";
     }
-    else { edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit:fit2] - TrackingRecHit is not in GEM or CSC subdetector"; }
     LocalPoint lp = refcscchamber()->toLocal(gp);
     float z = lp.z();
 
@@ -498,72 +484,67 @@ GEMCSCSegFit::SMatrix16by4 GEMCSCSegFit::derivativeMatrix() {
   return matrix;
 }
 
-
 void GEMCSCSegFit::setOutFromIP() {
   // Set direction of segment to point from IP outwards
   // (Incorrect for particles not coming from IP, of course.)
-  
+
   double dxdz = uslope_;
   double dydz = vslope_;
-  double dz   = 1./sqrt(1. + dxdz*dxdz + dydz*dydz);
-  double dx   = dz*dxdz;
-  double dy   = dz*dydz;
-  LocalVector localDir(dx,dy,dz);
+  double dz = 1. / sqrt(1. + dxdz * dxdz + dydz * dydz);
+  double dx = dz * dxdz;
+  double dy = dz * dydz;
+  LocalVector localDir(dx, dy, dz);
 
-  // localDir sometimes needs a sign flip 
+  // localDir sometimes needs a sign flip
   // Examine its direction and origin in global z: to point outward
   // the localDir should always have same sign as global z...
-  
-  double globalZpos    = ( refcscchamber()->toGlobal( intercept_ ) ).z();
-  double globalZdir    = ( refcscchamber()->toGlobal( localDir  ) ).z();
+
+  double globalZpos = (refcscchamber()->toGlobal(intercept_)).z();
+  double globalZdir = (refcscchamber()->toGlobal(localDir)).z();
   double directionSign = globalZpos * globalZdir;
-  localdir_ = (directionSign * localDir ).unit();
+  localdir_ = (directionSign * localDir).unit();
 }
 
-
-
 AlgebraicSymMatrix GEMCSCSegFit::covarianceMatrix() {
-  
   SMatrixSym16 weights = weightMatrix();
   SMatrix16by4 A = derivativeMatrix();
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] weights matrix W: \n" << weights;      
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] derivatives matrix A: \n" << A;      
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] weights matrix W: \n" << weights;
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] derivatives matrix A: \n" << A;
 
   // (AT W A)^-1
   // e.g. See http://www.phys.ufl.edu/~avery/fitting.html, part I
 
   bool ok;
-  SMatrixSym4 result =  ROOT::Math::SimilarityT(A, weights);
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] (AT W A): \n" << result;      
-  ok = result.Invert(); // inverts in place
-  if ( !ok ) {
-    edm::LogVerbatim("GEMCSCSegment|GEMCSCSegFit") << "[GEMCSCSegFit::calculateError] Failed to invert matrix: \n" << result;
-    AlgebraicSymMatrix emptymatrix(4, 0. );
-    return emptymatrix; // return empty matrix if matrix inversion failed
+  SMatrixSym4 result = ROOT::Math::SimilarityT(A, weights);
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] (AT W A): \n" << result;
+  ok = result.Invert();  // inverts in place
+  if (!ok) {
+    edm::LogVerbatim("GEMCSCSegment|GEMCSCSegFit") << "[GEMCSCSegFit::calculateError] Failed to invert matrix: \n"
+                                                   << result;
+    AlgebraicSymMatrix emptymatrix(4, 0.);
+    return emptymatrix;  // return empty matrix if matrix inversion failed
   }
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] (AT W A)^-1: \n" << result;      
-  
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::covarianceMatrix] (AT W A)^-1: \n" << result;
+
   // reorder components to match TrackingRecHit interface (GEMCSCSegment isa TrackingRecHit)
-  // i.e. slopes first, then positions 
-  AlgebraicSymMatrix flipped = flipErrors( result );
-    
+  // i.e. slopes first, then positions
+  AlgebraicSymMatrix flipped = flipErrors(result);
+
   return flipped;
 }
 
-
-AlgebraicSymMatrix GEMCSCSegFit::flipErrors( const SMatrixSym4& a ) { 
-    
+AlgebraicSymMatrix GEMCSCSegFit::flipErrors(const SMatrixSym4& a) {
   // The GEMCSCSegment needs the error matrix re-arranged to match
-  // parameters in order (uz, vz, u0, v0) 
+  // parameters in order (uz, vz, u0, v0)
   // where uz, vz = slopes, u0, v0 = intercepts
-    
-  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::flipErrors] input: \n" << a;      
 
-  AlgebraicSymMatrix hold(4, 0. ); 
-      
-  for ( short j=0; j!=4; ++j) {
-    for (short i=0; i!=4; ++i) {
-      hold(i+1,j+1) = a(i,j); // SMatrix counts from 0, AlgebraicMatrix from 1
+  edm::LogVerbatim("GEMCSCSegFit") << "[GEMCSCSegFit::flipErrors] input: \n" << a;
+
+  AlgebraicSymMatrix hold(4, 0.);
+
+  for (short j = 0; j != 4; ++j) {
+    for (short i = 0; i != 4; ++i) {
+      hold(i + 1, j + 1) = a(i, j);  // SMatrix counts from 0, AlgebraicMatrix from 1
     }
   }
 
@@ -573,23 +554,23 @@ AlgebraicSymMatrix GEMCSCSegFit::flipErrors( const SMatrixSym4& a ) {
   //  LogTrace("GEMCSCSegFit") << " " << hold(3,1) << "  " << hold(3,2) << "  " << hold(3,3) << "  " << hold(3,4);
   //  LogTrace("GEMCSCSegFit") << " " << hold(4,1) << "  " << hold(4,2) << "  " << hold(4,3) << "  " << hold(4,4) << ")";
 
-  // errors on slopes into upper left 
-  hold(1,1) = a(2,2); 
-  hold(1,2) = a(2,3); 
-  hold(2,1) = a(3,2); 
-  hold(2,2) = a(3,3); 
-    
-  // errors on positions into lower right 
-  hold(3,3) = a(0,0); 
-  hold(3,4) = a(0,1); 
-  hold(4,3) = a(1,0); 
-  hold(4,4) = a(1,1); 
-    
+  // errors on slopes into upper left
+  hold(1, 1) = a(2, 2);
+  hold(1, 2) = a(2, 3);
+  hold(2, 1) = a(3, 2);
+  hold(2, 2) = a(3, 3);
+
+  // errors on positions into lower right
+  hold(3, 3) = a(0, 0);
+  hold(3, 4) = a(0, 1);
+  hold(4, 3) = a(1, 0);
+  hold(4, 4) = a(1, 1);
+
   // must also interchange off-diagonal elements of off-diagonal 2x2 submatrices
-  hold(4,1) = a(1,2);
-  hold(3,2) = a(0,3);
-  hold(2,3) = a(3,0); // = a(0,3)
-  hold(1,4) = a(2,1); // = a(1,2)
+  hold(4, 1) = a(1, 2);
+  hold(3, 2) = a(0, 3);
+  hold(2, 3) = a(3, 0);  // = a(0,3)
+  hold(1, 4) = a(2, 1);  // = a(1,2)
 
   //  LogTrace("GEMCSCSegFit") << "[GEMCSCSegFit::flipErrors] after flip:";
   //  LogTrace("GEMCSCSegFit") << "(" << hold(1,1) << "  " << hold(1,2) << "  " << hold(1,3) << "  " << hold(1,4);
@@ -599,26 +580,19 @@ AlgebraicSymMatrix GEMCSCSegFit::flipErrors( const SMatrixSym4& a ) {
 
   return hold;
 }
- 
-float GEMCSCSegFit::xfit( float z ) const {
+
+float GEMCSCSegFit::xfit(float z) const {
   //@@ ADD THIS TO EACH ACCESSOR OF FIT RESULTS?
   //  if ( !fitdone() ) fit();
   return intercept_.x() + uslope_ * z;
 }
 
-float GEMCSCSegFit::yfit( float z ) const {
-  return intercept_.y() + vslope_ * z;
-}
+float GEMCSCSegFit::yfit(float z) const { return intercept_.y() + vslope_ * z; }
 
-float GEMCSCSegFit::xdev( float x, float z ) const {
-  return intercept_.x() + uslope_ * z - x;
-}
+float GEMCSCSegFit::xdev(float x, float z) const { return intercept_.x() + uslope_ * z - x; }
 
-float GEMCSCSegFit::ydev( float y, float z ) const {
-  return intercept_.y() + vslope_ * z - y;
-}
+float GEMCSCSegFit::ydev(float y, float z) const { return intercept_.y() + vslope_ * z - y; }
 
 float GEMCSCSegFit::Rdev(float x, float y, float z) const {
-  return sqrt ( xdev(x,z)*xdev(x,z) + ydev(y,z)*ydev(y,z) );
+  return sqrt(xdev(x, z) * xdev(x, z) + ydev(y, z) * ydev(y, z));
 }
-

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentAlgorithm.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentAlgorithm.h
@@ -25,17 +25,18 @@
 #include <map>
 
 class GEMCSCSegmentAlgorithm {
+public:
+  /// Constructor
+  explicit GEMCSCSegmentAlgorithm(const edm::ParameterSet&){};
+  /// Destructor
+  virtual ~GEMCSCSegmentAlgorithm(){};
+  /// Run the algorithm = build segments
+  virtual std::vector<GEMCSCSegment> run(const std::map<uint32_t, const CSCLayer*>& csclayermap,
+                                         const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap,
+                                         const std::vector<const CSCSegment*>& cscsegments,
+                                         const std::vector<const GEMRecHit*>& gemrechits) = 0;
 
-    public:
-
-    /// Constructor
-    explicit GEMCSCSegmentAlgorithm(const edm::ParameterSet&) {};
-    /// Destructor
-    virtual ~GEMCSCSegmentAlgorithm() {};
-    /// Run the algorithm = build segments 
-    virtual std::vector<GEMCSCSegment> run(const std::map<uint32_t, const CSCLayer*>& csclayermap, const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap,
-					   const std::vector<const CSCSegment*>& cscsegments, const std::vector<const GEMRecHit*>& gemrechits) = 0;
-    private:
+private:
 };
 
 #endif

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.h
@@ -16,7 +16,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
- 
+
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
 #include <Geometry/GEMGeometry/interface/GEMGeometry.h>
 
@@ -25,39 +25,38 @@
 #include <Geometry/GEMGeometry/interface/GEMEtaPartition.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
-#include <DataFormats/GEMRecHit/interface/GEMRecHit.h>           
+#include <DataFormats/GEMRecHit/interface/GEMRecHit.h>
 #include <DataFormats/GEMRecHit/interface/GEMRecHitCollection.h>
 #include <DataFormats/GEMRecHit/interface/GEMCSCSegmentCollection.h>
 
+class CSCStationIndex {
+public:
+  CSCStationIndex() : _region(0), _station(0), _ring(0), _chamber(0), _layer(0){};
+  CSCStationIndex(int region, int station, int ring, int chamber, int layer)
+      : _region(region), _station(station), _ring(ring), _chamber(chamber), _layer(layer) {}
+  ~CSCStationIndex() {}
 
-class CSCStationIndex{
- public:
- CSCStationIndex():_region(0),_station(0),_ring(0),_chamber(0),_layer(0){};
- CSCStationIndex(int region, int station, int ring, int chamber, int layer):
-  _region(region), _station(station), _ring(ring),_chamber(chamber),_layer(layer){}
-  ~CSCStationIndex(){}
+  int region() const { return _region; }
+  int station() const { return _station; }
+  int ring() const { return _ring; }
+  int chamber() const { return _chamber; }
+  int layer() const { return _layer; }
 
-  int region()  const {return _region;}
-  int station() const {return _station;}
-  int ring()    const {return _ring;}
-  int chamber() const {return _chamber;}
-  int layer()   const {return _layer;}
-
-  bool operator<(const CSCStationIndex& cscind) const{
-    if(cscind.region()!=this->region())
-      return cscind.region()<this->region();
-    else if(cscind.station()!=this->station())
-      return cscind.station()<this->station();
-    else if(cscind.ring()!=this->ring())
-      return cscind.ring()<this->ring();
-    else if(cscind.chamber()!=this->chamber())
-      return cscind.chamber()<this->chamber();
-    else if(cscind.layer()!=this->layer())
-      return cscind.layer()<this->layer();
+  bool operator<(const CSCStationIndex& cscind) const {
+    if (cscind.region() != this->region())
+      return cscind.region() < this->region();
+    else if (cscind.station() != this->station())
+      return cscind.station() < this->station();
+    else if (cscind.ring() != this->ring())
+      return cscind.ring() < this->ring();
+    else if (cscind.chamber() != this->chamber())
+      return cscind.chamber() < this->chamber();
+    else if (cscind.layer() != this->layer())
+      return cscind.layer() < this->layer();
     return false;
   }
-  
- private:
+
+private:
   int _region;
   int _station;
   int _ring;
@@ -65,26 +64,24 @@ class CSCStationIndex{
   int _layer;
 };
 
-
 class GEMCSCSegmentAlgorithm;
 
 class GEMCSCSegmentBuilder {
- public:
+public:
   explicit GEMCSCSegmentBuilder(const edm::ParameterSet&);
   ~GEMCSCSegmentBuilder();
-  void build(const GEMRecHitCollection* rechits,const CSCSegmentCollection* cscsegments, GEMCSCSegmentCollection& oc); 
+  void build(const GEMRecHitCollection* rechits, const CSCSegmentCollection* cscsegments, GEMCSCSegmentCollection& oc);
 
-  void setGeometry(const GEMGeometry* gemgeom, const CSCGeometry* cscgeom); 
-  void LinkGEMRollsToCSCChamberIndex(const GEMGeometry* gemgeom, const CSCGeometry* cscgeom);  
-   
- protected:
-  std::map<CSCStationIndex,std::set<GEMDetId> > rollstoreCSC;
+  void setGeometry(const GEMGeometry* gemgeom, const CSCGeometry* cscgeom);
+  void LinkGEMRollsToCSCChamberIndex(const GEMGeometry* gemgeom, const CSCGeometry* cscgeom);
 
- private:
+protected:
+  std::map<CSCStationIndex, std::set<GEMDetId> > rollstoreCSC;
+
+private:
   std::unique_ptr<GEMCSCSegmentAlgorithm> algo;
   const GEMGeometry* gemgeom_;
   const CSCGeometry* cscgeom_;
-  
 };
 
 #endif

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilderPluginFactory.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilderPluginFactory.cc
@@ -8,5 +8,4 @@
 
 #include <RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilderPluginFactory.h>
 
-EDM_REGISTER_PLUGINFACTORY(GEMCSCSegmentBuilderPluginFactory,"GEMCSCSegmentBuilderPluginFactory");
-
+EDM_REGISTER_PLUGINFACTORY(GEMCSCSegmentBuilderPluginFactory, "GEMCSCSegmentBuilderPluginFactory");

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilderPluginFactory.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilderPluginFactory.h
@@ -13,6 +13,6 @@
 #include <FWCore/PluginManager/interface/PluginFactory.h>
 #include <RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentAlgorithm.h>
 
-typedef edmplugin::PluginFactory<GEMCSCSegmentAlgorithm *(const edm::ParameterSet&)> GEMCSCSegmentBuilderPluginFactory;
+typedef edmplugin::PluginFactory<GEMCSCSegmentAlgorithm *(const edm::ParameterSet &)> GEMCSCSegmentBuilderPluginFactory;
 
 #endif

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
@@ -7,7 +7,7 @@
 
 #include <DataFormats/Common/interface/Handle.h>
 #include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/MessageLogger/interface/MessageLogger.h> 
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
@@ -20,53 +20,49 @@
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
 
 GEMCSCSegmentProducer::GEMCSCSegmentProducer(const edm::ParameterSet& pas) : iev(0) {
-	
-  csc_token = consumes<CSCSegmentCollection>( pas.getParameter<edm::InputTag>("inputObjectsCSC"));
-  gem_token = consumes<GEMRecHitCollection> ( pas.getParameter<edm::InputTag>("inputObjectsGEM"));
-  segmentBuilder_  = new GEMCSCSegmentBuilder(pas); // pass on the parameterset
-  
+  csc_token = consumes<CSCSegmentCollection>(pas.getParameter<edm::InputTag>("inputObjectsCSC"));
+  gem_token = consumes<GEMRecHitCollection>(pas.getParameter<edm::InputTag>("inputObjectsGEM"));
+  segmentBuilder_ = new GEMCSCSegmentBuilder(pas);  // pass on the parameterset
+
   // register what this produces
   produces<GEMCSCSegmentCollection>();
 }
 
-
 GEMCSCSegmentProducer::~GEMCSCSegmentProducer() {
-
-    LogDebug("GEMCSCSegment") << "deleting GEMCSCSegmentBuilder after " << iev << " events w/ gem and csc data.";
-    delete segmentBuilder_;
+  LogDebug("GEMCSCSegment") << "deleting GEMCSCSegmentBuilder after " << iev << " events w/ gem and csc data.";
+  delete segmentBuilder_;
 }
 
-
 void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
-    LogDebug("GEMCSCSegment") << "start producing segments for " << ++iev << "th event w/ gem and csc data";
-	
-    // find the geometry (& conditions?) for this event & cache it in the builder
-    edm::ESHandle<CSCGeometry> cscg;
-    setup.get<MuonGeometryRecord>().get(cscg);
-    const CSCGeometry* cgeom = &*cscg;
-    
-    edm::ESHandle<GEMGeometry> gemg;
-    setup.get<MuonGeometryRecord>().get(gemg);
-    const GEMGeometry* ggeom = &*gemg;
-    
-    // cache the geometry in the builder
-    segmentBuilder_->setGeometry(ggeom,cgeom);
+  LogDebug("GEMCSCSegment") << "start producing segments for " << ++iev << "th event w/ gem and csc data";
 
-    // fill the map with matches between GEM and CSC chambers
-    segmentBuilder_->LinkGEMRollsToCSCChamberIndex(ggeom,cgeom);
+  // find the geometry (& conditions?) for this event & cache it in the builder
+  edm::ESHandle<CSCGeometry> cscg;
+  setup.get<MuonGeometryRecord>().get(cscg);
+  const CSCGeometry* cgeom = &*cscg;
 
-    // get the collection of CSCSegment and GEMRecHits
-    edm::Handle<CSCSegmentCollection> cscSegment;
-    ev.getByToken(csc_token, cscSegment);
-    edm::Handle<GEMRecHitCollection> gemRecHits;
-    ev.getByToken(gem_token, gemRecHits);    
+  edm::ESHandle<GEMGeometry> gemg;
+  setup.get<MuonGeometryRecord>().get(gemg);
+  const GEMGeometry* ggeom = &*gemg;
 
-    // create empty collection of GEMCSC Segments
-    auto oc = std::make_unique<GEMCSCSegmentCollection>();
+  // cache the geometry in the builder
+  segmentBuilder_->setGeometry(ggeom, cgeom);
 
-    // pass the empty collection of GEMCSC Segments and fill it
-    segmentBuilder_->build(gemRecHits.product(), cscSegment.product(), *oc); //@@ FILL oc
-    
-    // put the filled collection in event
-    ev.put(std::move(oc));
+  // fill the map with matches between GEM and CSC chambers
+  segmentBuilder_->LinkGEMRollsToCSCChamberIndex(ggeom, cgeom);
+
+  // get the collection of CSCSegment and GEMRecHits
+  edm::Handle<CSCSegmentCollection> cscSegment;
+  ev.getByToken(csc_token, cscSegment);
+  edm::Handle<GEMRecHitCollection> gemRecHits;
+  ev.getByToken(gem_token, gemRecHits);
+
+  // create empty collection of GEMCSC Segments
+  auto oc = std::make_unique<GEMCSCSegmentCollection>();
+
+  // pass the empty collection of GEMCSC Segments and fill it
+  segmentBuilder_->build(gemRecHits.product(), cscSegment.product(), *oc);  //@@ FILL oc
+
+  // put the filled collection in event
+  ev.put(std::move(oc));
 }

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
@@ -18,22 +18,22 @@
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 
-class GEMCSCSegmentBuilder; 
+class GEMCSCSegmentBuilder;
 
 class GEMCSCSegmentProducer : public edm::stream::EDProducer<> {
 public:
-    /// Constructor
-    explicit GEMCSCSegmentProducer(const edm::ParameterSet&);
-    /// Destructor
-    ~GEMCSCSegmentProducer() override;
-    /// Produce the GEM-CSCSegment collection
-    void produce(edm::Event&, const edm::EventSetup&) override;
+  /// Constructor
+  explicit GEMCSCSegmentProducer(const edm::ParameterSet&);
+  /// Destructor
+  ~GEMCSCSegmentProducer() override;
+  /// Produce the GEM-CSCSegment collection
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-    int iev; // events through
-    GEMCSCSegmentBuilder* segmentBuilder_;
-    edm::EDGetTokenT<CSCSegmentCollection> csc_token;
-    edm::EDGetTokenT<GEMRecHitCollection>  gem_token;
+  int iev;  // events through
+  GEMCSCSegmentBuilder* segmentBuilder_;
+  edm::EDGetTokenT<CSCSegmentCollection> csc_token;
+  edm::EDGetTokenT<GEMRecHitCollection> gem_token;
 };
 
 #endif

--- a/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TestGEMCSCSegmentAnalyzer
 // Class:      TestGEMCSCSegmentAnalyzer
-// 
+//
 /**\class TestGEMCSCSegmentAnalyzer TestGEMCSCSegmentAnalyzer.cc MyAnalyzers/TestGEMCSCSegmentAnalyzer/src/TestGEMCSCSegmentAnalyzer.cc
 
  Description: [one line class summary]
@@ -42,9 +42,9 @@
 #include <DataFormats/GEMRecHit/interface/GEMRecHit.h>
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 
-#include <Geometry/CSCGeometry/interface/CSCChamberSpecs.h>//?
-#include <Geometry/CSCGeometry/interface/CSCChamber.h>//?
-#include <Geometry/CSCGeometry/interface/CSCLayer.h>//?
+#include <Geometry/CSCGeometry/interface/CSCChamberSpecs.h>  //?
+#include <Geometry/CSCGeometry/interface/CSCChamber.h>       //?
+#include <Geometry/CSCGeometry/interface/CSCLayer.h>         //?
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
 #include <Geometry/GEMGeometry/interface/GEMGeometry.h>
 #include <Geometry/GEMGeometry/interface/GEMEtaPartition.h>
@@ -64,36 +64,36 @@
 using namespace std;
 using namespace edm;
 
-
 class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit TestGEMCSCSegmentAnalyzer(const edm::ParameterSet&);
-      ~TestGEMCSCSegmentAnalyzer();
+public:
+  explicit TestGEMCSCSegmentAnalyzer(const edm::ParameterSet&);
+  ~TestGEMCSCSegmentAnalyzer();
 
-   private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+private:
+  virtual void beginJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob();
 
-      virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&);
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
-      edm::PSimHitContainer SimHitMatched(std::vector<GEMRecHit>::const_iterator, edm::ESHandle<GEMGeometry>, const edm::Event&);
+  edm::PSimHitContainer SimHitMatched(std::vector<GEMRecHit>::const_iterator,
+                                      edm::ESHandle<GEMGeometry>,
+                                      const edm::Event&);
 
-      // ----------member data ---------------------------
-    edm::ESHandle<GEMGeometry> gemGeom;
-    edm::ESHandle<CSCGeometry> cscGeom;
-    
+  // ----------member data ---------------------------
+  edm::ESHandle<GEMGeometry> gemGeom;
+  edm::ESHandle<CSCGeometry> cscGeom;
+
   bool debug;
   std::string rootFileName;
 
-  edm::EDGetTokenT<edm::SimTrackContainer>  SimTrack_Token;
-  edm::EDGetTokenT<CSCSegmentCollection>    CSCSegment_Token;
+  edm::EDGetTokenT<edm::SimTrackContainer> SimTrack_Token;
+  edm::EDGetTokenT<CSCSegmentCollection> CSCSegment_Token;
   edm::EDGetTokenT<GEMCSCSegmentCollection> GEMCSCSegment_Token;
-  edm::EDGetTokenT<edm::PSimHitContainer>   GEMSimHit_Token;
-
+  edm::EDGetTokenT<edm::PSimHitContainer> GEMSimHit_Token;
 
   std::unique_ptr<TFile> outputfile;
 
@@ -106,33 +106,32 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_NumGEMCSCRH;
   std::unique_ptr<TH1F> GEMCSC_NumGEMCSCSeg;
 
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LPx;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LPy;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LPEx;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LPEy;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LDx;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LDy;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LDEx;
-  std::unique_ptr<TH1F>  GEMCSC_SSegm_LDEy;
-  std::unique_ptr<TH2F>  GEMCSC_SSegm_LDEy_vs_ndof;
-  std::unique_ptr<TH2F>  GEMCSC_SSegm_LPEy_vs_ndof;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LPx;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LPy;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LPEx;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LPEy;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LDx;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LDy;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LDEx;
-  std::unique_ptr<TH1F>  GEMCSC_CSCSegm_LDEy;
-  std::unique_ptr<TH2F>  GEMCSC_CSCSegm_LDEy_vs_ndof;
-  std::unique_ptr<TH2F>  GEMCSC_CSCSegm_LPEy_vs_ndof;
-    
-  std::unique_ptr<TH1F>  SIMGEMCSC_SSegm_LDx;
-  std::unique_ptr<TH1F>  SIMGEMCSC_SSegm_LDy;
-  std::unique_ptr<TH1F>  SIMGEMCSC_SSegm_LDEx;
-  std::unique_ptr<TH1F>  SIMGEMCSC_SSegm_LDEy;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LPx;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LPy;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LPEx;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LPEy;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LDx;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LDy;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LDEx;
+  std::unique_ptr<TH1F> GEMCSC_SSegm_LDEy;
+  std::unique_ptr<TH2F> GEMCSC_SSegm_LDEy_vs_ndof;
+  std::unique_ptr<TH2F> GEMCSC_SSegm_LPEy_vs_ndof;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LPx;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LPy;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LPEx;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LPEy;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LDx;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LDy;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LDEx;
+  std::unique_ptr<TH1F> GEMCSC_CSCSegm_LDEy;
+  std::unique_ptr<TH2F> GEMCSC_CSCSegm_LDEy_vs_ndof;
+  std::unique_ptr<TH2F> GEMCSC_CSCSegm_LPEy_vs_ndof;
 
-    
+  std::unique_ptr<TH1F> SIMGEMCSC_SSegm_LDx;
+  std::unique_ptr<TH1F> SIMGEMCSC_SSegm_LDy;
+  std::unique_ptr<TH1F> SIMGEMCSC_SSegm_LDEx;
+  std::unique_ptr<TH1F> SIMGEMCSC_SSegm_LDEy;
+
   std::unique_ptr<TH1F> GEMCSC_Residuals_x;
   std::unique_ptr<TH1F> GEMCSC_Residuals_gem_x;
   std::unique_ptr<TH1F> GEMCSC_Residuals_csc_x;
@@ -193,7 +192,7 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_Pool_cscl6_y;
   std::unique_ptr<TH1F> GEMCSC_Pool_geml1_y;
   std::unique_ptr<TH1F> GEMCSC_Pool_geml2_y;
-    
+
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_x_newE;
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_y_newE;
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_odd_x_newE;
@@ -202,11 +201,11 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_y_newE_mp;
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_odd_x_newE_mp;
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_odd_y_newE_mp;
-  std::unique_ptr<TH1F> GEMCSC_Pool_gem_x_newE_mm ;
-  std::unique_ptr<TH1F> GEMCSC_Pool_gem_y_newE_mm ;
+  std::unique_ptr<TH1F> GEMCSC_Pool_gem_x_newE_mm;
+  std::unique_ptr<TH1F> GEMCSC_Pool_gem_y_newE_mm;
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_odd_x_newE_mm;
   std::unique_ptr<TH1F> GEMCSC_Pool_gem_odd_y_newE_mm;
-  
+
   std::unique_ptr<TH1F> GEMCSC_Dphi_min_afterCut;
   std::unique_ptr<TH1F> GEMCSC_Dtheta_min_afterCut;
   std::unique_ptr<TH1F> GEMCSC_DR_min_afterCut;
@@ -230,7 +229,7 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_l2;
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_l2_odd;
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_l2_even;
-    
+
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_odd;
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_even;
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_odd_r1;
@@ -241,8 +240,7 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_odd_r6;
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_odd_r7;
   std::unique_ptr<TH1F> GEMCSC_Dphi_cscS_min_afterCut_odd_r8;
-  
-  
+
   std::unique_ptr<TH1F> GEMCSC_SSegm_xe_l1;
   std::unique_ptr<TH1F> GEMCSC_SSegm_ye_l1;
   std::unique_ptr<TH1F> GEMCSC_SSegm_ze_l1;
@@ -258,7 +256,7 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_SSegm_ze_l1_even;
   std::unique_ptr<TH1F> GEMCSC_SSegm_sigmaxe_l1_even;
   std::unique_ptr<TH1F> GEMCSC_SSegm_sigmaye_l1_even;
-  
+
   std::unique_ptr<TH1F> GEMCSC_SSegm_xe_l2;
   std::unique_ptr<TH1F> GEMCSC_SSegm_ye_l2;
   std::unique_ptr<TH1F> GEMCSC_SSegm_ze_l2;
@@ -274,8 +272,7 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_SSegm_ze_l2_even;
   std::unique_ptr<TH1F> GEMCSC_SSegm_sigmaxe_l2_even;
   std::unique_ptr<TH1F> GEMCSC_SSegm_sigmaye_l2_even;
-    
-    
+
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_xe_l1;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_ye_l1;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_ze_l1;
@@ -291,7 +288,7 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_ze_l1_even;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_sigmaxe_l1_even;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_sigmaye_l1_even;
-    
+
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_xe_l2;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_ye_l2;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_ze_l2;
@@ -307,19 +304,19 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_ze_l2_even;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_sigmaxe_l2_even;
   std::unique_ptr<TH1F> GEMCSC_CSCSegm_sigmaye_l2_even;
-    
+
   std::unique_ptr<TH2F> SIM_etaVScharge;
   std::unique_ptr<TH2F> SIM_etaVStype;
   std::unique_ptr<TH2F> SIMGEMCSC_theta_cscSsh_vs_ndof_odd;
   std::unique_ptr<TH2F> SIMGEMCSC_theta_cscSsh_vs_ndof_even;
-  
+
   std::unique_ptr<TH1F> SIMGEMCSC_Dphi_SS_min_afterCut;
   std::unique_ptr<TH1F> SIMGEMCSC_Dtheta_SS_min_afterCut;
   std::unique_ptr<TH1F> SIMGEMCSC_Dtheta_SS_min_afterCut_odd;
   std::unique_ptr<TH1F> SIMGEMCSC_Dtheta_SS_min_afterCut_even;
   std::unique_ptr<TH1F> SIMGEMCSC_Dphi_SS_min_afterCut_odd;
   std::unique_ptr<TH1F> SIMGEMCSC_Dphi_SS_min_afterCut_even;
-  
+
   std::unique_ptr<TH1F> SIMGEMCSC_Dphi_cscS_min_afterCut;
   std::unique_ptr<TH1F> SIMGEMCSC_Dtheta_cscS_min_afterCut;
   std::unique_ptr<TH1F> SIMGEMCSC_Dtheta_cscS_min_afterCut_odd;
@@ -351,277 +348,385 @@ class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
 TestGEMCSCSegmentAnalyzer::TestGEMCSCSegmentAnalyzer(const edm::ParameterSet& iConfig)
 
 {
-   //now do what ever initialization is needed
-  debug         = iConfig.getUntrackedParameter<bool>("Debug");
-  rootFileName  = iConfig.getUntrackedParameter<std::string>("RootFileName");
+  //now do what ever initialization is needed
+  debug = iConfig.getUntrackedParameter<bool>("Debug");
+  rootFileName = iConfig.getUntrackedParameter<std::string>("RootFileName");
 
   // outputfile = new TFile(rootFileName.c_str(), "RECREATE" );
   outputfile.reset(TFile::Open(rootFileName.c_str()));
 
-
-  SimTrack_Token      = consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
-  CSCSegment_Token    = consumes<CSCSegmentCollection>(edm::InputTag("cscSegments"));
+  SimTrack_Token = consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
+  CSCSegment_Token = consumes<CSCSegmentCollection>(edm::InputTag("cscSegments"));
   GEMCSCSegment_Token = consumes<GEMCSCSegmentCollection>(edm::InputTag("gemcscSegments"));
-  GEMSimHit_Token     = consumes<edm::PSimHitContainer>(edm::InputTag("g4SimHits","MuonGEMHits"));
-  
-  SIM_etaVScharge     = std::unique_ptr<TH2F>(new TH2F("SimTrack_etaVScharge","SimTrack_etaVScharge",500,-2.5,2.5,6,-3,3));
-  SIM_etaVStype       = std::unique_ptr<TH2F>(new TH2F("SimTrack_etaVStype","SimTrack_etaVStype",500,-2.5,2.5,30,-15,15));
-  CSC_fitchi2         = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_csc","ReducedChi2_csc",160,0.,4.));
-    
-  GEMCSC_fitchi2      = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_gemcsc","ReducedChi2_gemcsc",160,0.,4.));
-  GEMCSC_fitchi2_odd  = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_odd_gemcsc","ReducedChi2_odd_gemcsc",160,0.,4.));
-  GEMCSC_fitchi2_even = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_even_gemcsc","ReducedChi2_even_gemcsc",160,0.,4.));
-  GEMCSC_NumGEMRH     = std::unique_ptr<TH1F>(new TH1F("NumGEMRH","NumGEMRH",20,0.,20));
-  GEMCSC_NumCSCRH     = std::unique_ptr<TH1F>(new TH1F("NumCSCRH","NumCSCRH",20,0.,20));
-  GEMCSC_NumGEMCSCRH  = std::unique_ptr<TH1F>(new TH1F("NumGEMCSCRH","NumGEMCSCRH",20,0.,20));
-  GEMCSC_NumGEMCSCSeg = std::unique_ptr<TH1F>(new TH1F("NumGMCSCSeg","NumGEMCSCSeg",20,0.,20));
-  GEMCSC_SSegm_LPx    = std::unique_ptr<TH1F>(new TH1F("SuperS_LPx","SuperS_LPx",1200,-60.,60));
-  GEMCSC_SSegm_LPy    = std::unique_ptr<TH1F>(new TH1F("SuperS_LPy","SuperS_LPy",4000,-200.,200));
-  GEMCSC_SSegm_LPEx   = std::unique_ptr<TH1F>(new TH1F("SuperS_LPEx","SuperS_LPEx",10000,0.,0.5));
-  GEMCSC_SSegm_LPEy   = std::unique_ptr<TH1F>(new TH1F("SuperS_LPEy","SuperS_LPEy",10000,0.,5));
+  GEMSimHit_Token = consumes<edm::PSimHitContainer>(edm::InputTag("g4SimHits", "MuonGEMHits"));
+
+  SIM_etaVScharge =
+      std::unique_ptr<TH2F>(new TH2F("SimTrack_etaVScharge", "SimTrack_etaVScharge", 500, -2.5, 2.5, 6, -3, 3));
+  SIM_etaVStype =
+      std::unique_ptr<TH2F>(new TH2F("SimTrack_etaVStype", "SimTrack_etaVStype", 500, -2.5, 2.5, 30, -15, 15));
+  CSC_fitchi2 = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_csc", "ReducedChi2_csc", 160, 0., 4.));
+
+  GEMCSC_fitchi2 = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_gemcsc", "ReducedChi2_gemcsc", 160, 0., 4.));
+  GEMCSC_fitchi2_odd = std::unique_ptr<TH1F>(new TH1F("ReducedChi2_odd_gemcsc", "ReducedChi2_odd_gemcsc", 160, 0., 4.));
+  GEMCSC_fitchi2_even =
+      std::unique_ptr<TH1F>(new TH1F("ReducedChi2_even_gemcsc", "ReducedChi2_even_gemcsc", 160, 0., 4.));
+  GEMCSC_NumGEMRH = std::unique_ptr<TH1F>(new TH1F("NumGEMRH", "NumGEMRH", 20, 0., 20));
+  GEMCSC_NumCSCRH = std::unique_ptr<TH1F>(new TH1F("NumCSCRH", "NumCSCRH", 20, 0., 20));
+  GEMCSC_NumGEMCSCRH = std::unique_ptr<TH1F>(new TH1F("NumGEMCSCRH", "NumGEMCSCRH", 20, 0., 20));
+  GEMCSC_NumGEMCSCSeg = std::unique_ptr<TH1F>(new TH1F("NumGMCSCSeg", "NumGEMCSCSeg", 20, 0., 20));
+  GEMCSC_SSegm_LPx = std::unique_ptr<TH1F>(new TH1F("SuperS_LPx", "SuperS_LPx", 1200, -60., 60));
+  GEMCSC_SSegm_LPy = std::unique_ptr<TH1F>(new TH1F("SuperS_LPy", "SuperS_LPy", 4000, -200., 200));
+  GEMCSC_SSegm_LPEx = std::unique_ptr<TH1F>(new TH1F("SuperS_LPEx", "SuperS_LPEx", 10000, 0., 0.5));
+  GEMCSC_SSegm_LPEy = std::unique_ptr<TH1F>(new TH1F("SuperS_LPEy", "SuperS_LPEy", 10000, 0., 5));
   //GEMCSC_SSegm_LPEz = std::unique_ptr<TH1F>(new TH1F("SuperS_LPEz","SuperS_LPEz",1000,0.,0.5));
-  GEMCSC_SSegm_LDx    = std::unique_ptr<TH1F>(new TH1F("SuperS_LDx","SuperS_LDx",1000,-2.,2));
-  GEMCSC_SSegm_LDy    = std::unique_ptr<TH1F>(new TH1F("SuperS_LDy","SuperS_LDy",1000,-2.,2));
-  GEMCSC_SSegm_LDEx   = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEx","SuperS_LDEx",10000,0.,0.05));
-  GEMCSC_SSegm_LDEy   = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEy","SuperS_LDEy",10000,0.,0.5));
-  GEMCSC_SSegm_LDEy_vs_ndof    = std::unique_ptr<TH2F>(new TH2F("SSegm_LDEy_vs_ndof","SSegm_LDEy vs ndof",1000,0.,0.05,15,-0.5,14.5));
-  GEMCSC_SSegm_LPEy_vs_ndof    = std::unique_ptr<TH2F>(new TH2F("SSegm_LPEy_vs_ndof","SSegm_LPEy vs ndof",1000,0.,0.5,15,-0.5,14.5));
+  GEMCSC_SSegm_LDx = std::unique_ptr<TH1F>(new TH1F("SuperS_LDx", "SuperS_LDx", 1000, -2., 2));
+  GEMCSC_SSegm_LDy = std::unique_ptr<TH1F>(new TH1F("SuperS_LDy", "SuperS_LDy", 1000, -2., 2));
+  GEMCSC_SSegm_LDEx = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEx", "SuperS_LDEx", 10000, 0., 0.05));
+  GEMCSC_SSegm_LDEy = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEy", "SuperS_LDEy", 10000, 0., 0.5));
+  GEMCSC_SSegm_LDEy_vs_ndof =
+      std::unique_ptr<TH2F>(new TH2F("SSegm_LDEy_vs_ndof", "SSegm_LDEy vs ndof", 1000, 0., 0.05, 15, -0.5, 14.5));
+  GEMCSC_SSegm_LPEy_vs_ndof =
+      std::unique_ptr<TH2F>(new TH2F("SSegm_LPEy_vs_ndof", "SSegm_LPEy vs ndof", 1000, 0., 0.5, 15, -0.5, 14.5));
   //GEMCSC_SSegm_LDEz = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEz","SuperS_LDEz",1000,0.,0.05));
-  GEMCSC_CSCSegm_LPx  = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPx","CSCSegm_LPx",1200,-60.,60));
-  GEMCSC_CSCSegm_LPy  = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPy","CSCSegm_LPy",4000,-200.,200));
-  GEMCSC_CSCSegm_LPEx = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPEx","CSCSegm_LPEx",10000,0.,0.5));
-  GEMCSC_CSCSegm_LPEy = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPEy","CSCSegm_LPEy",10000,0.,5));
+  GEMCSC_CSCSegm_LPx = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPx", "CSCSegm_LPx", 1200, -60., 60));
+  GEMCSC_CSCSegm_LPy = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPy", "CSCSegm_LPy", 4000, -200., 200));
+  GEMCSC_CSCSegm_LPEx = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPEx", "CSCSegm_LPEx", 10000, 0., 0.5));
+  GEMCSC_CSCSegm_LPEy = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPEy", "CSCSegm_LPEy", 10000, 0., 5));
   //GEMCSC_CSCSegm_LPEz = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LPEz","CSCSegm_LPEz",1000,0.,0.5));
-  GEMCSC_CSCSegm_LDx  = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDx","CSCSegm_LDx",1000,-2.,2));
-  GEMCSC_CSCSegm_LDy  = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDy","CSCSegm_LDy",1000,-2.,2));
-  GEMCSC_CSCSegm_LDEx = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDEx","CSCSegm_LDEx",10000,0.,0.05));
-  GEMCSC_CSCSegm_LDEy = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDEy","CSCSegm_LDEy",10000,0.,0.5));
+  GEMCSC_CSCSegm_LDx = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDx", "CSCSegm_LDx", 1000, -2., 2));
+  GEMCSC_CSCSegm_LDy = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDy", "CSCSegm_LDy", 1000, -2., 2));
+  GEMCSC_CSCSegm_LDEx = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDEx", "CSCSegm_LDEx", 10000, 0., 0.05));
+  GEMCSC_CSCSegm_LDEy = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDEy", "CSCSegm_LDEy", 10000, 0., 0.5));
   //GEMCSC_CSCSegm_LDEz = std::unique_ptr<TH1F>(new TH1F("CSCSegm_LDEz","CSCSegm_LDEz",1000,0.,0.05));
-  GEMCSC_CSCSegm_LDEy_vs_ndof    = std::unique_ptr<TH2F>(new TH2F("CSCSegm_LDEy_vs_ndof","CSCSegm_LDEy vs ndof",1000,0.,0.05,15,-0.5,14.5));
-  GEMCSC_CSCSegm_LPEy_vs_ndof    = std::unique_ptr<TH2F>(new TH2F("CSCSegm_LPEy_vs_ndof","CSCSegm_LPEy vs ndof",1000,0.,0.5,15,-0.5,14.5));
-  SIMGEMCSC_SSegm_LDx = std::unique_ptr<TH1F>(new TH1F("SSegm_LDx_expected","SSegm_LDx",1000,-2.,2));
-  SIMGEMCSC_SSegm_LDy = std::unique_ptr<TH1F>(new TH1F("SSegm_LDy_expected","SSegm_LDy",1000,-2.,2));
-  SIMGEMCSC_SSegm_LDEx    = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEx_expected","SuperS_LDEx",10000,0.,0.005));
-  SIMGEMCSC_SSegm_LDEy    = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEy_expected","SuperS_LDEy",1000,0.,0.05));
+  GEMCSC_CSCSegm_LDEy_vs_ndof =
+      std::unique_ptr<TH2F>(new TH2F("CSCSegm_LDEy_vs_ndof", "CSCSegm_LDEy vs ndof", 1000, 0., 0.05, 15, -0.5, 14.5));
+  GEMCSC_CSCSegm_LPEy_vs_ndof =
+      std::unique_ptr<TH2F>(new TH2F("CSCSegm_LPEy_vs_ndof", "CSCSegm_LPEy vs ndof", 1000, 0., 0.5, 15, -0.5, 14.5));
+  SIMGEMCSC_SSegm_LDx = std::unique_ptr<TH1F>(new TH1F("SSegm_LDx_expected", "SSegm_LDx", 1000, -2., 2));
+  SIMGEMCSC_SSegm_LDy = std::unique_ptr<TH1F>(new TH1F("SSegm_LDy_expected", "SSegm_LDy", 1000, -2., 2));
+  SIMGEMCSC_SSegm_LDEx = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEx_expected", "SuperS_LDEx", 10000, 0., 0.005));
+  SIMGEMCSC_SSegm_LDEy = std::unique_ptr<TH1F>(new TH1F("SuperS_LDEy_expected", "SuperS_LDEy", 1000, 0., 0.05));
 
+  GEMCSC_SSegm_xe_l1 = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l1", "GEMCSC_SSegm_xe_l1", 1200, -60., 60));
+  GEMCSC_SSegm_ye_l1 = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l1", "GEMCSC_SSegm_ye_l1", 4000, -200., 200));
+  GEMCSC_SSegm_ze_l1 = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l1", "GEMCSC_SSegm_ze_l1", 12000, -600., 600));
+  GEMCSC_SSegm_xe_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l1_odd", "GEMCSC_SSegm_xe_l1_odd", 1200, -60., 60));
+  GEMCSC_SSegm_ye_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l1_odd", "GEMCSC_SSegm_ye_l1_odd", 4000, -200., 200));
+  GEMCSC_SSegm_ze_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l1_odd", "GEMCSC_SSegm_ze_l1_odd", 12000, -600., 600));
+  GEMCSC_SSegm_xe_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l1_even", "GEMCSC_SSegm_xe_l1_even", 1200, -60., 60));
+  GEMCSC_SSegm_ye_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l1_even", "GEMCSC_SSegm_ye_l1_even", 4000, -200., 200));
+  GEMCSC_SSegm_ze_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l1_even", "GEMCSC_SSegm_ze_l1_even", 12000, -600., 600));
+  GEMCSC_SSegm_xe_l2 = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l2", "GEMCSC_SSegm_xe_l2", 1200, -60., 60));
+  GEMCSC_SSegm_ye_l2 = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l2", "GEMCSC_SSegm_ye_l2", 4000, -200., 200));
+  GEMCSC_SSegm_ze_l2 = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l2", "GEMCSC_SSegm_ze_l2", 12000, -600., 600));
+  GEMCSC_SSegm_xe_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l2_odd", "GEMCSC_SSegm_xe_l2_odd", 1200, -60., 60));
+  GEMCSC_SSegm_ye_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l2_odd", "GEMCSC_SSegm_ye_l2_odd", 4000, -200., 200));
+  GEMCSC_SSegm_ze_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l2_odd", "GEMCSC_SSegm_ze_l2_odd", 12000, -600., 600));
+  GEMCSC_SSegm_xe_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l2_even", "GEMCSC_SSegm_xe_l2_even", 1200, -60., 60));
+  GEMCSC_SSegm_ye_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l2_even", "GEMCSC_SSegm_ye_l2_even", 4000, -200., 200));
+  GEMCSC_SSegm_ze_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l2_even", "GEMCSC_SSegm_ze_l2_even", 12000, -600., 600));
 
-  GEMCSC_SSegm_xe_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l1","GEMCSC_SSegm_xe_l1",1200,-60.,60));
-  GEMCSC_SSegm_ye_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l1","GEMCSC_SSegm_ye_l1",4000,-200.,200));
-  GEMCSC_SSegm_ze_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l1","GEMCSC_SSegm_ze_l1",12000,-600.,600));
-  GEMCSC_SSegm_xe_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l1_odd","GEMCSC_SSegm_xe_l1_odd",1200,-60.,60));
-  GEMCSC_SSegm_ye_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l1_odd","GEMCSC_SSegm_ye_l1_odd",4000,-200.,200));
-  GEMCSC_SSegm_ze_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l1_odd","GEMCSC_SSegm_ze_l1_odd",12000,-600.,600));
-  GEMCSC_SSegm_xe_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l1_even","GEMCSC_SSegm_xe_l1_even",1200,-60.,60));
-  GEMCSC_SSegm_ye_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l1_even","GEMCSC_SSegm_ye_l1_even",4000,-200.,200));
-  GEMCSC_SSegm_ze_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l1_even","GEMCSC_SSegm_ze_l1_even",12000,-600.,600));
-  GEMCSC_SSegm_xe_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l2","GEMCSC_SSegm_xe_l2",1200,-60.,60));
-  GEMCSC_SSegm_ye_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l2","GEMCSC_SSegm_ye_l2",4000,-200.,200));
-  GEMCSC_SSegm_ze_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l2","GEMCSC_SSegm_ze_l2",12000,-600.,600));
-  GEMCSC_SSegm_xe_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l2_odd","GEMCSC_SSegm_xe_l2_odd",1200,-60.,60));
-  GEMCSC_SSegm_ye_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l2_odd","GEMCSC_SSegm_ye_l2_odd",4000,-200.,200));
-  GEMCSC_SSegm_ze_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l2_odd","GEMCSC_SSegm_ze_l2_odd",12000,-600.,600));
-  GEMCSC_SSegm_xe_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_xe_l2_even","GEMCSC_SSegm_xe_l2_even",1200,-60.,60));
-  GEMCSC_SSegm_ye_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ye_l2_even","GEMCSC_SSegm_ye_l2_even",4000,-200.,200));
-  GEMCSC_SSegm_ze_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_ze_l2_even","GEMCSC_SSegm_ze_l2_even",12000,-600.,600));
-    
-  GEMCSC_CSCSegm_xe_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l1","GEMCSC_CSCSegm_xe_l1",1200,-60.,60));
-  GEMCSC_CSCSegm_ye_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l1","GEMCSC_CSCSegm_ye_l1",4000,-200.,200));
-  GEMCSC_CSCSegm_ze_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l1","GEMCSC_CSCSegm_ze_l1",12000,-600.,600));
-  GEMCSC_CSCSegm_xe_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l1_odd","GEMCSC_CSCSegm_xe_l1_odd",1200,-60.,60));
-  GEMCSC_CSCSegm_ye_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l1_odd","GEMCSC_CSCSegm_ye_l1_odd",4000,-200.,200));
-  GEMCSC_CSCSegm_ze_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l1_odd","GEMCSC_CSCSegm_ze_l1_odd",12000,-600.,600));
-  GEMCSC_CSCSegm_xe_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l1_even","GEMCSC_CSCSegm_xe_l1_even",1200,-60.,60));
-  GEMCSC_CSCSegm_ye_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l1_even","GEMCSC_CSCSegm_ye_l1_even",4000,-200.,200));
-  GEMCSC_CSCSegm_ze_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l1_even","GEMCSC_CSCSegm_ze_l1_even",12000,-600.,600));
-  GEMCSC_CSCSegm_xe_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l2","GEMCSC_CSCSegm_xe_l2",1200,-60.,60));
-  GEMCSC_CSCSegm_ye_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l2","GEMCSC_CSCSegm_ye_l2",4000,-200.,200));
-  GEMCSC_CSCSegm_ze_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l2","GEMCSC_CSCSegm_ze_l2",12000,-600.,600));
-  GEMCSC_CSCSegm_xe_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l2_odd","GEMCSC_CSCSegm_xe_l2_odd",1200,-60.,60));
-  GEMCSC_CSCSegm_ye_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l2_odd","GEMCSC_CSCSegm_ye_l2_odd",4000,-200.,200));
-  GEMCSC_CSCSegm_ze_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l2_odd","GEMCSC_CSCSegm_ze_l2_odd",12000,-600.,600));
-  GEMCSC_CSCSegm_xe_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l2_even","GEMCSC_CSCSegm_xe_l2_even",1200,-60.,60));
-  GEMCSC_CSCSegm_ye_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l2_even","GEMCSC_CSCSegm_ye_l2_even",4000,-200.,200));
-  GEMCSC_CSCSegm_ze_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l2_even","GEMCSC_CSCSegm_ze_l2_even",12000,-600.,600));
-  
-  GEMCSC_SSegm_sigmaxe_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l1","GEMCSC_SSegm_sigmaxe_l1",1000,0.,0.5));
-  GEMCSC_SSegm_sigmaye_l1        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l1","GEMCSC_SSegm_sigmaye_l1",1000,0.,10));
-  GEMCSC_SSegm_sigmaxe_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l1_odd","GEMCSC_SSegm_sigmaxe_l1_odd",1000,0.,0.5));
-  GEMCSC_SSegm_sigmaye_l1_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l1_odd","GEMCSC_SSegm_sigmaye_l1_odd",1000,0.,10));
-  GEMCSC_SSegm_sigmaxe_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l1_even","GEMCSC_SSegm_sigmaxe_l1_even",1000,0.,0.5));
-  GEMCSC_SSegm_sigmaye_l1_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l1_even","GEMCSC_SSegm_sigmaye_l1_even",1000,0.,10));
-  GEMCSC_SSegm_sigmaxe_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l2","GEMCSC_SSegm_sigmaxe_l2",1000,0.,0.5));
-  GEMCSC_SSegm_sigmaye_l2        = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l2","GEMCSC_SSegm_sigmaye_l2",1000,0.,10));
-  GEMCSC_SSegm_sigmaxe_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l2_odd","GEMCSC_SSegm_sigmaxe_l2_odd",1000,0.,0.5));
-  GEMCSC_SSegm_sigmaye_l2_odd    = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l2_odd","GEMCSC_SSegm_sigmaye_l2_odd",1000,0.,10));
-  GEMCSC_SSegm_sigmaxe_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l2_even","GEMCSC_SSegm_sigmaxe_l2_even",1000,0.,0.5));
-  GEMCSC_SSegm_sigmaye_l2_even   = std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l2_even","GEMCSC_SSegm_sigmaye_l2_even",1000,0.,10));
-  GEMCSC_CSCSegm_sigmaxe_l1      = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l1","GEMCSC_CSCSegm_sigmaxe_l1",1000,0.,0.5));
-  GEMCSC_CSCSegm_sigmaye_l1      = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l1","GEMCSC_CSCSegm_sigmaye_l1",1000,0.,10));
-  GEMCSC_CSCSegm_sigmaxe_l1_odd  = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l1_odd","GEMCSC_CSCSegm_sigmaxe_l1_odd",1000,0.,0.5));
-  GEMCSC_CSCSegm_sigmaye_l1_odd  = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l1_odd","GEMCSC_CSCSegm_sigmaye_l1_odd",1000,0.,10));
-  GEMCSC_CSCSegm_sigmaxe_l1_even = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l1_even","GEMCSC_CSCSegm_sigmaxe_l1_even",1000,0.,0.5));
-  GEMCSC_CSCSegm_sigmaye_l1_even = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l1_even","GEMCSC_CSCSegm_sigmaye_l1_even",1000,0.,10));
-  GEMCSC_CSCSegm_sigmaxe_l2      = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l2","GEMCSC_CSCSegm_sigmaxe_l2",1000,0.,0.5));
-  GEMCSC_CSCSegm_sigmaye_l2      = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l2","GEMCSC_CSCSegm_sigmaye_l2",1000,0.,10));
-  GEMCSC_CSCSegm_sigmaxe_l2_odd  = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l2_odd","GEMCSC_CSCSegm_sigmaxe_l2_odd",1000,0.,0.5));
-  GEMCSC_CSCSegm_sigmaye_l2_odd  = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l2_odd","GEMCSC_CSCSegm_sigmaye_l2_odd",1000,0.,10));
-  GEMCSC_CSCSegm_sigmaxe_l2_even = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l2_even","GEMCSC_CSCSegm_sigmaxe_l2_even",1000,0.,0.5));
-  GEMCSC_CSCSegm_sigmaye_l2_even = std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l2_even","GEMCSC_CSCSegm_sigmaye_l2_even",1000,0.,10));
-  
-  GEMCSC_Residuals_x            = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes","xGEMCSCRes",100,-0.5,0.5));
-  GEMCSC_Residuals_gem_x        = std::unique_ptr<TH1F>(new TH1F("xGEMRes","xGEMRes",100,-0.5,0.5));
-  GEMCSC_Residuals_csc_x        = std::unique_ptr<TH1F>(new TH1F("xCSCRes","xCSCRes",100,-0.5,0.5));
-  GEMCSC_Residuals_gem_even_x   = std::unique_ptr<TH1F>(new TH1F("xGEMRes_even","xGEMRes even",100,-0.5,0.5));
-  GEMCSC_Residuals_csc_even_x   = std::unique_ptr<TH1F>(new TH1F("xCSCRes_even","xCSCRes even",100,-0.5,0.5));
-  GEMCSC_Residuals_gem_odd_x    = std::unique_ptr<TH1F>(new TH1F("xGEMRes_odd","xGEMRes odd",100,-0.5,0.5));
-  GEMCSC_Residuals_csc_odd_x    = std::unique_ptr<TH1F>(new TH1F("xCSCRes_odd","xCSCRes odd",100,-0.5,0.5));
-  GEMCSC_Residuals_cscl1_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl1","xGEMCSCRes_cscl1",100,-0.5,0.5));
-  GEMCSC_Residuals_cscl2_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl2","xGEMCSCRes_cscl2",100,-0.5,0.5));
-  GEMCSC_Residuals_cscl3_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl3","xGEMCSCRes_cscl3",100,-0.5,0.5));
-  GEMCSC_Residuals_cscl4_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl4","xGEMCSCRes_cscl4",100,-0.5,0.5));
-  GEMCSC_Residuals_cscl5_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl5","xGEMCSCRes_cscl5",100,-0.5,0.5));
-  GEMCSC_Residuals_cscl6_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl6","xGEMCSCRes_cscl6",100,-0.5,0.5));
-  GEMCSC_Residuals_geml1_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_geml1","xGEMCSCRes_geml1",100,-0.5,0.5));
-  GEMCSC_Residuals_geml2_x      = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_geml2","xGEMCSCRes_geml2",100,-0.5,0.5));
-  GEMCSC_Pool_x                 = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool","xGEMCSCPool",100,-5.,5.));
-  GEMCSC_Pool_gem_x             = std::unique_ptr<TH1F>(new TH1F("xGEMPool","xGEMPool",100,-5.,5.));
-  GEMCSC_Pool_csc_x             = std::unique_ptr<TH1F>(new TH1F("xCSCPool","xCSCPool",100,-5.,5.));
-  GEMCSC_Pool_gem_even_x        = std::unique_ptr<TH1F>(new TH1F("xGEMPool_even","xGEMPool even",100,-5.,5.));
-  GEMCSC_Pool_csc_even_x        = std::unique_ptr<TH1F>(new TH1F("xCSCPool_even","xCSCPool even",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_x         = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd","xGEMPool odd",100,-5.,5.));
-  GEMCSC_Pool_csc_odd_x         = std::unique_ptr<TH1F>(new TH1F("xCSCPool_odd","xCSCPool odd",100,-5.,5.));
-  GEMCSC_Pool_cscl1_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl1","xGEMCSCPool_cscl1",100,-5.,5.));
-  GEMCSC_Pool_cscl2_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl2","xGEMCSCPool_cscl2",100,-5.,5.));
-  GEMCSC_Pool_cscl3_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl3","xGEMCSCPool_cscl3",100,-5.,5.));
-  GEMCSC_Pool_cscl4_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl4","xGEMCSCPool_cscl4",100,-5.,5.));
-  GEMCSC_Pool_cscl5_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl5","xGEMCSCPool_cscl5",100,-5.,5.));
-  GEMCSC_Pool_cscl6_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl6","xGEMCSCPool_cscl6",100,-5.,5.));
-  GEMCSC_Pool_geml1_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_geml1","xGEMCSCPool_geml1",100,-5.,5.));
-  GEMCSC_Pool_geml2_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_geml2","xGEMCSCPool_geml2",100,-5.,5.));
-  GEMCSC_Residuals_y        = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes","yGEMCSCRes",100,-10.,10.));
-  GEMCSC_Residuals_gem_y    = std::unique_ptr<TH1F>(new TH1F("yGEMRes","yGEMRes",100,-10.,10.));
-  GEMCSC_Residuals_csc_y    = std::unique_ptr<TH1F>(new TH1F("yCSCRes","yCSCRes",100,-5.,5.));
-  GEMCSC_Residuals_gem_even_y   = std::unique_ptr<TH1F>(new TH1F("yGEMRes_even","yGEMRes even",100,-10.,10.));
-  GEMCSC_Residuals_csc_even_y   = std::unique_ptr<TH1F>(new TH1F("yCSCRes_even","yCSCRes even",100,-5.,5.));
-  GEMCSC_Residuals_gem_odd_y    = std::unique_ptr<TH1F>(new TH1F("yGEMRes_odd","yGEMRes odd",100,-10.,10.));
-  GEMCSC_Residuals_csc_odd_y    = std::unique_ptr<TH1F>(new TH1F("yCSCRes_odd","yCSCRes odd",100,-5.,5.));
-  GEMCSC_Residuals_cscl1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl1","yGEMCSCRes_cscl1",100,-5.,5.));
-  GEMCSC_Residuals_cscl2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl2","yGEMCSCRes_cscl2",100,-5.,5.));
-  GEMCSC_Residuals_cscl3_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl3","yGEMCSCRes_cscl3",100,-5.,5.));
-  GEMCSC_Residuals_cscl4_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl4","yGEMCSCRes_cscl4",100,-5.,5.));
-  GEMCSC_Residuals_cscl5_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl5","yGEMCSCRes_cscl5",100,-5.,5.));
-  GEMCSC_Residuals_cscl6_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl6","yGEMCSCRes_cscl6",100,-5.,5.));
-  GEMCSC_Residuals_geml1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_geml1","yGEMCSCRes_geml1",100,-5.,5.));
-  GEMCSC_Residuals_geml2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_geml2","yGEMCSCRes_geml2",100,-5.,5.));
-  GEMCSC_Pool_y            = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool","yGEMCSCPool",100,-5.,5.));
-  GEMCSC_Pool_gem_y        = std::unique_ptr<TH1F>(new TH1F("yGEMPool","yGEMPool",100,-5.,5.));
-  GEMCSC_Pool_csc_y        = std::unique_ptr<TH1F>(new TH1F("yCSCPool","yCSCPool",100,-5.,5.));
-  GEMCSC_Pool_gem_even_y   = std::unique_ptr<TH1F>(new TH1F("yGEMPool_even","yGEMPool even",100,-5.,5.));
-  GEMCSC_Pool_csc_even_y   = std::unique_ptr<TH1F>(new TH1F("yCSCPool_even","yCSCPool even",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_y    = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd","yGEMPool odd",100,-5.,5.));
-  GEMCSC_Pool_csc_odd_y    = std::unique_ptr<TH1F>(new TH1F("yCSCPool_odd","yCSCPool odd",100,-5.,5.));
-  GEMCSC_Pool_cscl1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl1","yGEMCSCPool_cscl1",100,-5.,5.));
-  GEMCSC_Pool_cscl2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl2","yGEMCSCPool_cscl2",100,-5.,5.));
-  GEMCSC_Pool_cscl3_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl3","yGEMCSCPool_cscl3",100,-5.,5.));
-  GEMCSC_Pool_cscl4_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl4","yGEMCSCPool_cscl4",100,-5.,5.));
-  GEMCSC_Pool_cscl5_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl5","yGEMCSCPool_cscl5",100,-5.,5.));
-  GEMCSC_Pool_cscl6_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl6","yGEMCSCPool_cscl6",100,-5.,5.));
-  GEMCSC_Pool_geml1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_geml1","yGEMCSCPool_geml1",100,-5.,5.));
-  GEMCSC_Pool_geml2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_geml2","yGEMCSCPool_geml2",100,-5.,5.));
-    
+  GEMCSC_CSCSegm_xe_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l1", "GEMCSC_CSCSegm_xe_l1", 1200, -60., 60));
+  GEMCSC_CSCSegm_ye_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l1", "GEMCSC_CSCSegm_ye_l1", 4000, -200., 200));
+  GEMCSC_CSCSegm_ze_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l1", "GEMCSC_CSCSegm_ze_l1", 12000, -600., 600));
+  GEMCSC_CSCSegm_xe_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l1_odd", "GEMCSC_CSCSegm_xe_l1_odd", 1200, -60., 60));
+  GEMCSC_CSCSegm_ye_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l1_odd", "GEMCSC_CSCSegm_ye_l1_odd", 4000, -200., 200));
+  GEMCSC_CSCSegm_ze_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l1_odd", "GEMCSC_CSCSegm_ze_l1_odd", 12000, -600., 600));
+  GEMCSC_CSCSegm_xe_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l1_even", "GEMCSC_CSCSegm_xe_l1_even", 1200, -60., 60));
+  GEMCSC_CSCSegm_ye_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l1_even", "GEMCSC_CSCSegm_ye_l1_even", 4000, -200., 200));
+  GEMCSC_CSCSegm_ze_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l1_even", "GEMCSC_CSCSegm_ze_l1_even", 12000, -600., 600));
+  GEMCSC_CSCSegm_xe_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l2", "GEMCSC_CSCSegm_xe_l2", 1200, -60., 60));
+  GEMCSC_CSCSegm_ye_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l2", "GEMCSC_CSCSegm_ye_l2", 4000, -200., 200));
+  GEMCSC_CSCSegm_ze_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l2", "GEMCSC_CSCSegm_ze_l2", 12000, -600., 600));
+  GEMCSC_CSCSegm_xe_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l2_odd", "GEMCSC_CSCSegm_xe_l2_odd", 1200, -60., 60));
+  GEMCSC_CSCSegm_ye_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l2_odd", "GEMCSC_CSCSegm_ye_l2_odd", 4000, -200., 200));
+  GEMCSC_CSCSegm_ze_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l2_odd", "GEMCSC_CSCSegm_ze_l2_odd", 12000, -600., 600));
+  GEMCSC_CSCSegm_xe_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_xe_l2_even", "GEMCSC_CSCSegm_xe_l2_even", 1200, -60., 60));
+  GEMCSC_CSCSegm_ye_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ye_l2_even", "GEMCSC_CSCSegm_ye_l2_even", 4000, -200., 200));
+  GEMCSC_CSCSegm_ze_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_ze_l2_even", "GEMCSC_CSCSegm_ze_l2_even", 12000, -600., 600));
 
-  GEMCSC_Pool_gem_x_newE           = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE","xGEMPool_newE",100,-5.,5.));
-  GEMCSC_Pool_gem_y_newE           = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE","yGEMPool_newE",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_x_newE       = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE","xGEMPool odd newE",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_y_newE       = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE","yGEMPool odd newE",100,-5.,5.));
-  GEMCSC_Pool_gem_x_newE_mp        = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE_mp","xGEMPool_newE muon+",100,-5.,5.));
-  GEMCSC_Pool_gem_y_newE_mp        = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE_mp","yGEMPool_newE muon+",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_x_newE_mp    = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE_mp","xGEMPool odd newE muon+",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_y_newE_mp    = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE_mp","yGEMPool odd newE muon+",100,-5.,5.));
-  GEMCSC_Pool_gem_x_newE_mm        = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE_mm","xGEMPool_newE muon-",100,-5.,5.));
-  GEMCSC_Pool_gem_y_newE_mm        = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE_mm","yGEMPool_newE muon-",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_x_newE_mm    = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE_mm","xGEMPool odd newE muon-",100,-5.,5.));
-  GEMCSC_Pool_gem_odd_y_newE_mm    = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE_mm","yGEMPool odd newE muon-",100,-5.,5.));
-  
-  GEMCSC_Dphi_min_afterCut              = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut","Dphi_gemRHgemcscS_min_afterCut",800000,-4.,4.));
-  GEMCSC_Dtheta_min_afterCut            = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemRHgemcscS_min_afterCut","Dtheta_gemRHgemcscS_min_afterCut",60000,-3.,3.));
-  GEMCSC_DR_min_afterCut                = std::unique_ptr<TH1F>(new TH1F("DR_gemRHgemcscS_min_afterCut","DR_gemRHgemcscS_min_afterCut",60000,-3.,3.));
-  GEMCSC_Dphi_min_afterCut_odd          = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_odd","Dphi_gemRHgemcscS_min_afterCut_odd",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_even         = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_even","Dphi_gemRHgemcscS_min_afterCut_even",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_l1           = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_l1","Dphi_gemRHgemcscS_min_afterCut_l1",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_l1_odd       = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_l1_odd","Dphi_gemRHgemcscS_min_afterCut_l1_odd",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_l1_even      = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_l1_even","Dphi_gemRHgemcscS_min_afterCut_l1_even",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_l2           = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_l2","Dphi_gemRHgemcscS_min_afterCut_l2",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_l2_odd       = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_l2_odd","Dphi_gemRHgemcscS_min_afterCut_l2_odd",800000,-4.,4.));
-  GEMCSC_Dphi_min_afterCut_l2_even      = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHgemcscS_min_afterCut_l2_even","Dphi_gemRHgemcscS_min_afterCut_l2_even",800000,-4.,4.));
-  
-  GEMCSC_Dphi_cscS_min_afterCut         = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut","Dphi_gemRHcscS_min_afterCut",800000,-4.,4.));
-  GEMCSC_Dtheta_cscS_min_afterCut       = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemRHcscS_min_afterCut","Dtheta_gemRHcscS_min_afterCut",60000,-3.,3.));
-  GEMCSC_DR_cscS_min_afterCut           = std::unique_ptr<TH1F>(new TH1F("DR_gemRHcscS_min_afterCut","DR_gemRHcscS_min_afterCut",60000,-3.,3.));
-  GEMCSC_Dphi_cscS_min_afterCut_l1      = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_l1","Dphi_gemRHcscS_min_afterCut_l1",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_l1_odd  = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_l1_odd","Dphi_gemRHcscS_min_afterCut_l1_odd",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_l1_even = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_l1_even","Dphi_gemRHcscS_min_afterCut_l1_even",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_l2      = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_l2","Dphi_gemRHcscS_min_afterCut_l2",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_l2_odd  = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_l2_odd","Dphi_gemRHcscS_min_afterCut_l2_odd",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_l2_even = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_l2_even","Dphi_gemRHcscS_min_afterCut_l2_even",800000,-4.,4.));
-  
-  GEMCSC_Dphi_cscS_min_afterCut_odd    = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd","Dphi_gemRHcscS_min_afterCut_odd",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_even   = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_even","Dphi_gemRHcscS_min_afterCut_even",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r1 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r1","Dphi_gemRHcscS_min_afterCut_odd_r1",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r2 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r2","Dphi_gemRHcscS_min_afterCut_odd_r2",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r3 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r3","Dphi_gemRHcscS_min_afterCut_odd_r3",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r4 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r4","Dphi_gemRHcscS_min_afterCut_odd_r4",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r5 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r5","Dphi_gemRHcscS_min_afterCut_odd_r5",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r6 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r6","Dphi_gemRHcscS_min_afterCut_odd_r6",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r7 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r7","Dphi_gemRHcscS_min_afterCut_odd_r7",800000,-4.,4.));
-  GEMCSC_Dphi_cscS_min_afterCut_odd_r8 = std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r8","Dphi_gemRHcscS_min_afterCut_odd_r8",800000,-4.,4.));
-  GEMCSC_Dtheta_cscS_min_afterCut_odd  = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemRHcscS_min_afterCut_odd","Dtheta_gemRHcscS_min_afterCut_odd",60000,-3.,3.));
-  GEMCSC_Dtheta_cscS_min_afterCut_even = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemRHcscS_min_afterCut_even","Dtheta_gemRHcscS_min_afterCut_even",60000,-3.,3.));
-  
-  
-  SIMGEMCSC_Dphi_cscS_min_afterCut        = std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHcscS_min_afterCut","Dphi_gemSHcscS_min_afterCut",800000,-4.,4.));
-  SIMGEMCSC_Dtheta_cscS_min_afterCut      = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHcscS_min_afterCut","Dtheta_gemSHcscS_min_afterCut",60000,-3.,3.));
-  SIMGEMCSC_Dphi_cscS_min_afterCut_odd    = std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHcscS_min_afterCut_odd","Dphi_gemSHcscS_min_afterCut_odd",800000,-4.,4.));
-  SIMGEMCSC_Dphi_cscS_min_afterCut_even   = std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHcscS_min_afterCut_even","Dphi_gemSHcscS_min_afterCut_even",800000,-4.,4.));
-  SIMGEMCSC_Dtheta_cscS_min_afterCut_odd  = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHcscS_min_afterCut_odd","Dtheta_gemSHcscS_min_afterCut_odd",60000,-3.,3.));
-  SIMGEMCSC_Dtheta_cscS_min_afterCut_even = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHcscS_min_afterCut_even","Dtheta_gemSHcscS_min_afterCut_even",60000,-3.,3.));
-  
-  SIMGEMCSC_Dphi_SS_min_afterCut        = std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHSS_min_afterCut","Dphi_gemSHSS_min_afterCut",800000,-4.,4.));
-  SIMGEMCSC_Dtheta_SS_min_afterCut      = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHSS_min_afterCut","Dtheta_gemSHSS_min_afterCut",60000,-3.,3.));
-  SIMGEMCSC_Dphi_SS_min_afterCut_odd    = std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHSS_min_afterCut_odd","Dphi_gemSHSS_min_afterCut_odd",800000,-4.,4.));
-  SIMGEMCSC_Dphi_SS_min_afterCut_even   = std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHSS_min_afterCut_even","Dphi_gemSHSS_min_afterCut_even",800000,-4.,4.));
-  SIMGEMCSC_Dtheta_SS_min_afterCut_odd  = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHSS_min_afterCut_odd","Dtheta_gemSHSS_min_afterCut_odd",60000,-3.,3.));
-  SIMGEMCSC_Dtheta_SS_min_afterCut_even = std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHSS_min_afterCut_even","Dtheta_gemSHSS_min_afterCut_even",60000,-3.,3.));
-  
-  SIMGEMCSC_theta_cscSsh_vs_ndof_odd    = std::unique_ptr<TH2F>(new TH2F("SIMGEMCSCSegm_theta_cscSsh_vs_ndof_odd","theta_cscSsh vs ndof odd",30000,0.,3.,15,-0.5,14.5));
-  SIMGEMCSC_theta_cscSsh_vs_ndof_even   = std::unique_ptr<TH2F>(new TH2F("SIMGEMCSCSegm_theta_cscSsh_vs_ndof_even","theta_cscSsh vs ndof even",30000,0.,3.,15,-0.5,14.5));
-  
-  SIMGEMCSC_Residuals_gem_x      = std::unique_ptr<TH1F>(new TH1F("xGEMRes_simhit","xGEMRes",100,-0.5,0.5));
-  SIMGEMCSC_Residuals_gem_y      = std::unique_ptr<TH1F>(new TH1F("yGEMRes_simhit","yGEMRes",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_x_newE      = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE_simhit","xGEMPool newE",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_y_newE      = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE_simhit","yGEMPool newE",100,-10.,10.));
-  SIMGEMCSC_Residuals_gem_odd_x  = std::unique_ptr<TH1F>(new TH1F("xGEMRes_odd_simhit","xGEMRes",100,-0.5,0.5));
-  SIMGEMCSC_Residuals_gem_odd_y  = std::unique_ptr<TH1F>(new TH1F("yGEMRes_odd_simhit","yGEMRes",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_x_newE_odd  = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE_simhit","xGEMPool newE",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_y_newE_odd  = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE_simhit","yGEMPool newE",100,-10.,10.));
-  SIMGEMCSC_Residuals_gem_even_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_even_simhit","xGEMRes",100,-0.5,0.5));
-  SIMGEMCSC_Residuals_gem_even_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_even_simhit","yGEMRes",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_x_newE_even = std::unique_ptr<TH1F>(new TH1F("xGEMPool_even_newE_simhit","xGEMPool newE",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_y_newE_even = std::unique_ptr<TH1F>(new TH1F("yGEMPool_even_newE_simhit","yGEMPool newE",100,-10.,10.));
-  
-  SIMGEMCSC_Residuals_gem_rhsh_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_shrh","xGEMRes",100,-0.5,0.5));
-  SIMGEMCSC_Residuals_gem_rhsh_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_shrh","yGEMRes",100,-10.,10.));
-  SIMGEMCSC_Pool_gem_rhsh_x_newE = std::unique_ptr<TH1F>(new TH1F("xGEMPool_shrh","xGEMPool sh rh",100,-5.,5.));
-  SIMGEMCSC_Pool_gem_rhsh_y_newE = std::unique_ptr<TH1F>(new TH1F("yGEMPool_shrh","yGEMPool sh rh",100,-5.,5.));
-  
+  GEMCSC_SSegm_sigmaxe_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l1", "GEMCSC_SSegm_sigmaxe_l1", 1000, 0., 0.5));
+  GEMCSC_SSegm_sigmaye_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l1", "GEMCSC_SSegm_sigmaye_l1", 1000, 0., 10));
+  GEMCSC_SSegm_sigmaxe_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l1_odd", "GEMCSC_SSegm_sigmaxe_l1_odd", 1000, 0., 0.5));
+  GEMCSC_SSegm_sigmaye_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l1_odd", "GEMCSC_SSegm_sigmaye_l1_odd", 1000, 0., 10));
+  GEMCSC_SSegm_sigmaxe_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l1_even", "GEMCSC_SSegm_sigmaxe_l1_even", 1000, 0., 0.5));
+  GEMCSC_SSegm_sigmaye_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l1_even", "GEMCSC_SSegm_sigmaye_l1_even", 1000, 0., 10));
+  GEMCSC_SSegm_sigmaxe_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l2", "GEMCSC_SSegm_sigmaxe_l2", 1000, 0., 0.5));
+  GEMCSC_SSegm_sigmaye_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l2", "GEMCSC_SSegm_sigmaye_l2", 1000, 0., 10));
+  GEMCSC_SSegm_sigmaxe_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l2_odd", "GEMCSC_SSegm_sigmaxe_l2_odd", 1000, 0., 0.5));
+  GEMCSC_SSegm_sigmaye_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l2_odd", "GEMCSC_SSegm_sigmaye_l2_odd", 1000, 0., 10));
+  GEMCSC_SSegm_sigmaxe_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaxe_l2_even", "GEMCSC_SSegm_sigmaxe_l2_even", 1000, 0., 0.5));
+  GEMCSC_SSegm_sigmaye_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_SSegm_sigmaye_l2_even", "GEMCSC_SSegm_sigmaye_l2_even", 1000, 0., 10));
+  GEMCSC_CSCSegm_sigmaxe_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l1", "GEMCSC_CSCSegm_sigmaxe_l1", 1000, 0., 0.5));
+  GEMCSC_CSCSegm_sigmaye_l1 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l1", "GEMCSC_CSCSegm_sigmaye_l1", 1000, 0., 10));
+  GEMCSC_CSCSegm_sigmaxe_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l1_odd", "GEMCSC_CSCSegm_sigmaxe_l1_odd", 1000, 0., 0.5));
+  GEMCSC_CSCSegm_sigmaye_l1_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l1_odd", "GEMCSC_CSCSegm_sigmaye_l1_odd", 1000, 0., 10));
+  GEMCSC_CSCSegm_sigmaxe_l1_even = std::unique_ptr<TH1F>(
+      new TH1F("GEMCSC_CSCSegm_sigmaxe_l1_even", "GEMCSC_CSCSegm_sigmaxe_l1_even", 1000, 0., 0.5));
+  GEMCSC_CSCSegm_sigmaye_l1_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l1_even", "GEMCSC_CSCSegm_sigmaye_l1_even", 1000, 0., 10));
+  GEMCSC_CSCSegm_sigmaxe_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l2", "GEMCSC_CSCSegm_sigmaxe_l2", 1000, 0., 0.5));
+  GEMCSC_CSCSegm_sigmaye_l2 =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l2", "GEMCSC_CSCSegm_sigmaye_l2", 1000, 0., 10));
+  GEMCSC_CSCSegm_sigmaxe_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaxe_l2_odd", "GEMCSC_CSCSegm_sigmaxe_l2_odd", 1000, 0., 0.5));
+  GEMCSC_CSCSegm_sigmaye_l2_odd =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l2_odd", "GEMCSC_CSCSegm_sigmaye_l2_odd", 1000, 0., 10));
+  GEMCSC_CSCSegm_sigmaxe_l2_even = std::unique_ptr<TH1F>(
+      new TH1F("GEMCSC_CSCSegm_sigmaxe_l2_even", "GEMCSC_CSCSegm_sigmaxe_l2_even", 1000, 0., 0.5));
+  GEMCSC_CSCSegm_sigmaye_l2_even =
+      std::unique_ptr<TH1F>(new TH1F("GEMCSC_CSCSegm_sigmaye_l2_even", "GEMCSC_CSCSegm_sigmaye_l2_even", 1000, 0., 10));
+
+  GEMCSC_Residuals_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes", "xGEMCSCRes", 100, -0.5, 0.5));
+  GEMCSC_Residuals_gem_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes", "xGEMRes", 100, -0.5, 0.5));
+  GEMCSC_Residuals_csc_x = std::unique_ptr<TH1F>(new TH1F("xCSCRes", "xCSCRes", 100, -0.5, 0.5));
+  GEMCSC_Residuals_gem_even_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_even", "xGEMRes even", 100, -0.5, 0.5));
+  GEMCSC_Residuals_csc_even_x = std::unique_ptr<TH1F>(new TH1F("xCSCRes_even", "xCSCRes even", 100, -0.5, 0.5));
+  GEMCSC_Residuals_gem_odd_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_odd", "xGEMRes odd", 100, -0.5, 0.5));
+  GEMCSC_Residuals_csc_odd_x = std::unique_ptr<TH1F>(new TH1F("xCSCRes_odd", "xCSCRes odd", 100, -0.5, 0.5));
+  GEMCSC_Residuals_cscl1_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl1", "xGEMCSCRes_cscl1", 100, -0.5, 0.5));
+  GEMCSC_Residuals_cscl2_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl2", "xGEMCSCRes_cscl2", 100, -0.5, 0.5));
+  GEMCSC_Residuals_cscl3_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl3", "xGEMCSCRes_cscl3", 100, -0.5, 0.5));
+  GEMCSC_Residuals_cscl4_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl4", "xGEMCSCRes_cscl4", 100, -0.5, 0.5));
+  GEMCSC_Residuals_cscl5_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl5", "xGEMCSCRes_cscl5", 100, -0.5, 0.5));
+  GEMCSC_Residuals_cscl6_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_cscl6", "xGEMCSCRes_cscl6", 100, -0.5, 0.5));
+  GEMCSC_Residuals_geml1_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_geml1", "xGEMCSCRes_geml1", 100, -0.5, 0.5));
+  GEMCSC_Residuals_geml2_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCRes_geml2", "xGEMCSCRes_geml2", 100, -0.5, 0.5));
+  GEMCSC_Pool_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool", "xGEMCSCPool", 100, -5., 5.));
+  GEMCSC_Pool_gem_x = std::unique_ptr<TH1F>(new TH1F("xGEMPool", "xGEMPool", 100, -5., 5.));
+  GEMCSC_Pool_csc_x = std::unique_ptr<TH1F>(new TH1F("xCSCPool", "xCSCPool", 100, -5., 5.));
+  GEMCSC_Pool_gem_even_x = std::unique_ptr<TH1F>(new TH1F("xGEMPool_even", "xGEMPool even", 100, -5., 5.));
+  GEMCSC_Pool_csc_even_x = std::unique_ptr<TH1F>(new TH1F("xCSCPool_even", "xCSCPool even", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_x = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd", "xGEMPool odd", 100, -5., 5.));
+  GEMCSC_Pool_csc_odd_x = std::unique_ptr<TH1F>(new TH1F("xCSCPool_odd", "xCSCPool odd", 100, -5., 5.));
+  GEMCSC_Pool_cscl1_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl1", "xGEMCSCPool_cscl1", 100, -5., 5.));
+  GEMCSC_Pool_cscl2_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl2", "xGEMCSCPool_cscl2", 100, -5., 5.));
+  GEMCSC_Pool_cscl3_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl3", "xGEMCSCPool_cscl3", 100, -5., 5.));
+  GEMCSC_Pool_cscl4_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl4", "xGEMCSCPool_cscl4", 100, -5., 5.));
+  GEMCSC_Pool_cscl5_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl5", "xGEMCSCPool_cscl5", 100, -5., 5.));
+  GEMCSC_Pool_cscl6_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_cscl6", "xGEMCSCPool_cscl6", 100, -5., 5.));
+  GEMCSC_Pool_geml1_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_geml1", "xGEMCSCPool_geml1", 100, -5., 5.));
+  GEMCSC_Pool_geml2_x = std::unique_ptr<TH1F>(new TH1F("xGEMCSCPool_geml2", "xGEMCSCPool_geml2", 100, -5., 5.));
+  GEMCSC_Residuals_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes", "yGEMCSCRes", 100, -10., 10.));
+  GEMCSC_Residuals_gem_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes", "yGEMRes", 100, -10., 10.));
+  GEMCSC_Residuals_csc_y = std::unique_ptr<TH1F>(new TH1F("yCSCRes", "yCSCRes", 100, -5., 5.));
+  GEMCSC_Residuals_gem_even_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_even", "yGEMRes even", 100, -10., 10.));
+  GEMCSC_Residuals_csc_even_y = std::unique_ptr<TH1F>(new TH1F("yCSCRes_even", "yCSCRes even", 100, -5., 5.));
+  GEMCSC_Residuals_gem_odd_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_odd", "yGEMRes odd", 100, -10., 10.));
+  GEMCSC_Residuals_csc_odd_y = std::unique_ptr<TH1F>(new TH1F("yCSCRes_odd", "yCSCRes odd", 100, -5., 5.));
+  GEMCSC_Residuals_cscl1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl1", "yGEMCSCRes_cscl1", 100, -5., 5.));
+  GEMCSC_Residuals_cscl2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl2", "yGEMCSCRes_cscl2", 100, -5., 5.));
+  GEMCSC_Residuals_cscl3_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl3", "yGEMCSCRes_cscl3", 100, -5., 5.));
+  GEMCSC_Residuals_cscl4_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl4", "yGEMCSCRes_cscl4", 100, -5., 5.));
+  GEMCSC_Residuals_cscl5_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl5", "yGEMCSCRes_cscl5", 100, -5., 5.));
+  GEMCSC_Residuals_cscl6_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_cscl6", "yGEMCSCRes_cscl6", 100, -5., 5.));
+  GEMCSC_Residuals_geml1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_geml1", "yGEMCSCRes_geml1", 100, -5., 5.));
+  GEMCSC_Residuals_geml2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCRes_geml2", "yGEMCSCRes_geml2", 100, -5., 5.));
+  GEMCSC_Pool_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool", "yGEMCSCPool", 100, -5., 5.));
+  GEMCSC_Pool_gem_y = std::unique_ptr<TH1F>(new TH1F("yGEMPool", "yGEMPool", 100, -5., 5.));
+  GEMCSC_Pool_csc_y = std::unique_ptr<TH1F>(new TH1F("yCSCPool", "yCSCPool", 100, -5., 5.));
+  GEMCSC_Pool_gem_even_y = std::unique_ptr<TH1F>(new TH1F("yGEMPool_even", "yGEMPool even", 100, -5., 5.));
+  GEMCSC_Pool_csc_even_y = std::unique_ptr<TH1F>(new TH1F("yCSCPool_even", "yCSCPool even", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_y = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd", "yGEMPool odd", 100, -5., 5.));
+  GEMCSC_Pool_csc_odd_y = std::unique_ptr<TH1F>(new TH1F("yCSCPool_odd", "yCSCPool odd", 100, -5., 5.));
+  GEMCSC_Pool_cscl1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl1", "yGEMCSCPool_cscl1", 100, -5., 5.));
+  GEMCSC_Pool_cscl2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl2", "yGEMCSCPool_cscl2", 100, -5., 5.));
+  GEMCSC_Pool_cscl3_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl3", "yGEMCSCPool_cscl3", 100, -5., 5.));
+  GEMCSC_Pool_cscl4_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl4", "yGEMCSCPool_cscl4", 100, -5., 5.));
+  GEMCSC_Pool_cscl5_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl5", "yGEMCSCPool_cscl5", 100, -5., 5.));
+  GEMCSC_Pool_cscl6_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_cscl6", "yGEMCSCPool_cscl6", 100, -5., 5.));
+  GEMCSC_Pool_geml1_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_geml1", "yGEMCSCPool_geml1", 100, -5., 5.));
+  GEMCSC_Pool_geml2_y = std::unique_ptr<TH1F>(new TH1F("yGEMCSCPool_geml2", "yGEMCSCPool_geml2", 100, -5., 5.));
+
+  GEMCSC_Pool_gem_x_newE = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE", "xGEMPool_newE", 100, -5., 5.));
+  GEMCSC_Pool_gem_y_newE = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE", "yGEMPool_newE", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_x_newE = std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE", "xGEMPool odd newE", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_y_newE = std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE", "yGEMPool odd newE", 100, -5., 5.));
+  GEMCSC_Pool_gem_x_newE_mp = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE_mp", "xGEMPool_newE muon+", 100, -5., 5.));
+  GEMCSC_Pool_gem_y_newE_mp = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE_mp", "yGEMPool_newE muon+", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_x_newE_mp =
+      std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE_mp", "xGEMPool odd newE muon+", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_y_newE_mp =
+      std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE_mp", "yGEMPool odd newE muon+", 100, -5., 5.));
+  GEMCSC_Pool_gem_x_newE_mm = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE_mm", "xGEMPool_newE muon-", 100, -5., 5.));
+  GEMCSC_Pool_gem_y_newE_mm = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE_mm", "yGEMPool_newE muon-", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_x_newE_mm =
+      std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE_mm", "xGEMPool odd newE muon-", 100, -5., 5.));
+  GEMCSC_Pool_gem_odd_y_newE_mm =
+      std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE_mm", "yGEMPool odd newE muon-", 100, -5., 5.));
+
+  GEMCSC_Dphi_min_afterCut = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut", "Dphi_gemRHgemcscS_min_afterCut", 800000, -4., 4.));
+  GEMCSC_Dtheta_min_afterCut = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemRHgemcscS_min_afterCut", "Dtheta_gemRHgemcscS_min_afterCut", 60000, -3., 3.));
+  GEMCSC_DR_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("DR_gemRHgemcscS_min_afterCut", "DR_gemRHgemcscS_min_afterCut", 60000, -3., 3.));
+  GEMCSC_Dphi_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_odd", "Dphi_gemRHgemcscS_min_afterCut_odd", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_even", "Dphi_gemRHgemcscS_min_afterCut_even", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_l1 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_l1", "Dphi_gemRHgemcscS_min_afterCut_l1", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_l1_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_l1_odd", "Dphi_gemRHgemcscS_min_afterCut_l1_odd", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_l1_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_l1_even", "Dphi_gemRHgemcscS_min_afterCut_l1_even", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_l2 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_l2", "Dphi_gemRHgemcscS_min_afterCut_l2", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_l2_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_l2_odd", "Dphi_gemRHgemcscS_min_afterCut_l2_odd", 800000, -4., 4.));
+  GEMCSC_Dphi_min_afterCut_l2_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHgemcscS_min_afterCut_l2_even", "Dphi_gemRHgemcscS_min_afterCut_l2_even", 800000, -4., 4.));
+
+  GEMCSC_Dphi_cscS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("Dphi_gemRHcscS_min_afterCut", "Dphi_gemRHcscS_min_afterCut", 800000, -4., 4.));
+  GEMCSC_Dtheta_cscS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("Dtheta_gemRHcscS_min_afterCut", "Dtheta_gemRHcscS_min_afterCut", 60000, -3., 3.));
+  GEMCSC_DR_cscS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("DR_gemRHcscS_min_afterCut", "DR_gemRHcscS_min_afterCut", 60000, -3., 3.));
+  GEMCSC_Dphi_cscS_min_afterCut_l1 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_l1", "Dphi_gemRHcscS_min_afterCut_l1", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_l1_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_l1_odd", "Dphi_gemRHcscS_min_afterCut_l1_odd", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_l1_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_l1_even", "Dphi_gemRHcscS_min_afterCut_l1_even", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_l2 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_l2", "Dphi_gemRHcscS_min_afterCut_l2", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_l2_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_l2_odd", "Dphi_gemRHcscS_min_afterCut_l2_odd", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_l2_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_l2_even", "Dphi_gemRHcscS_min_afterCut_l2_even", 800000, -4., 4.));
+
+  GEMCSC_Dphi_cscS_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd", "Dphi_gemRHcscS_min_afterCut_odd", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_even", "Dphi_gemRHcscS_min_afterCut_even", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r1 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r1", "Dphi_gemRHcscS_min_afterCut_odd_r1", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r2 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r2", "Dphi_gemRHcscS_min_afterCut_odd_r2", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r3 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r3", "Dphi_gemRHcscS_min_afterCut_odd_r3", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r4 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r4", "Dphi_gemRHcscS_min_afterCut_odd_r4", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r5 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r5", "Dphi_gemRHcscS_min_afterCut_odd_r5", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r6 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r6", "Dphi_gemRHcscS_min_afterCut_odd_r6", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r7 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r7", "Dphi_gemRHcscS_min_afterCut_odd_r7", 800000, -4., 4.));
+  GEMCSC_Dphi_cscS_min_afterCut_odd_r8 = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemRHcscS_min_afterCut_odd_r8", "Dphi_gemRHcscS_min_afterCut_odd_r8", 800000, -4., 4.));
+  GEMCSC_Dtheta_cscS_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemRHcscS_min_afterCut_odd", "Dtheta_gemRHcscS_min_afterCut_odd", 60000, -3., 3.));
+  GEMCSC_Dtheta_cscS_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemRHcscS_min_afterCut_even", "Dtheta_gemRHcscS_min_afterCut_even", 60000, -3., 3.));
+
+  SIMGEMCSC_Dphi_cscS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHcscS_min_afterCut", "Dphi_gemSHcscS_min_afterCut", 800000, -4., 4.));
+  SIMGEMCSC_Dtheta_cscS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHcscS_min_afterCut", "Dtheta_gemSHcscS_min_afterCut", 60000, -3., 3.));
+  SIMGEMCSC_Dphi_cscS_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemSHcscS_min_afterCut_odd", "Dphi_gemSHcscS_min_afterCut_odd", 800000, -4., 4.));
+  SIMGEMCSC_Dphi_cscS_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemSHcscS_min_afterCut_even", "Dphi_gemSHcscS_min_afterCut_even", 800000, -4., 4.));
+  SIMGEMCSC_Dtheta_cscS_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemSHcscS_min_afterCut_odd", "Dtheta_gemSHcscS_min_afterCut_odd", 60000, -3., 3.));
+  SIMGEMCSC_Dtheta_cscS_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemSHcscS_min_afterCut_even", "Dtheta_gemSHcscS_min_afterCut_even", 60000, -3., 3.));
+
+  SIMGEMCSC_Dphi_SS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("Dphi_gemSHSS_min_afterCut", "Dphi_gemSHSS_min_afterCut", 800000, -4., 4.));
+  SIMGEMCSC_Dtheta_SS_min_afterCut =
+      std::unique_ptr<TH1F>(new TH1F("Dtheta_gemSHSS_min_afterCut", "Dtheta_gemSHSS_min_afterCut", 60000, -3., 3.));
+  SIMGEMCSC_Dphi_SS_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemSHSS_min_afterCut_odd", "Dphi_gemSHSS_min_afterCut_odd", 800000, -4., 4.));
+  SIMGEMCSC_Dphi_SS_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dphi_gemSHSS_min_afterCut_even", "Dphi_gemSHSS_min_afterCut_even", 800000, -4., 4.));
+  SIMGEMCSC_Dtheta_SS_min_afterCut_odd = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemSHSS_min_afterCut_odd", "Dtheta_gemSHSS_min_afterCut_odd", 60000, -3., 3.));
+  SIMGEMCSC_Dtheta_SS_min_afterCut_even = std::unique_ptr<TH1F>(
+      new TH1F("Dtheta_gemSHSS_min_afterCut_even", "Dtheta_gemSHSS_min_afterCut_even", 60000, -3., 3.));
+
+  SIMGEMCSC_theta_cscSsh_vs_ndof_odd = std::unique_ptr<TH2F>(
+      new TH2F("SIMGEMCSCSegm_theta_cscSsh_vs_ndof_odd", "theta_cscSsh vs ndof odd", 30000, 0., 3., 15, -0.5, 14.5));
+  SIMGEMCSC_theta_cscSsh_vs_ndof_even = std::unique_ptr<TH2F>(
+      new TH2F("SIMGEMCSCSegm_theta_cscSsh_vs_ndof_even", "theta_cscSsh vs ndof even", 30000, 0., 3., 15, -0.5, 14.5));
+
+  SIMGEMCSC_Residuals_gem_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_simhit", "xGEMRes", 100, -0.5, 0.5));
+  SIMGEMCSC_Residuals_gem_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_simhit", "yGEMRes", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_x_newE = std::unique_ptr<TH1F>(new TH1F("xGEMPool_newE_simhit", "xGEMPool newE", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_y_newE = std::unique_ptr<TH1F>(new TH1F("yGEMPool_newE_simhit", "yGEMPool newE", 100, -10., 10.));
+  SIMGEMCSC_Residuals_gem_odd_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_odd_simhit", "xGEMRes", 100, -0.5, 0.5));
+  SIMGEMCSC_Residuals_gem_odd_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_odd_simhit", "yGEMRes", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_x_newE_odd =
+      std::unique_ptr<TH1F>(new TH1F("xGEMPool_odd_newE_simhit", "xGEMPool newE", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_y_newE_odd =
+      std::unique_ptr<TH1F>(new TH1F("yGEMPool_odd_newE_simhit", "yGEMPool newE", 100, -10., 10.));
+  SIMGEMCSC_Residuals_gem_even_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_even_simhit", "xGEMRes", 100, -0.5, 0.5));
+  SIMGEMCSC_Residuals_gem_even_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_even_simhit", "yGEMRes", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_x_newE_even =
+      std::unique_ptr<TH1F>(new TH1F("xGEMPool_even_newE_simhit", "xGEMPool newE", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_y_newE_even =
+      std::unique_ptr<TH1F>(new TH1F("yGEMPool_even_newE_simhit", "yGEMPool newE", 100, -10., 10.));
+
+  SIMGEMCSC_Residuals_gem_rhsh_x = std::unique_ptr<TH1F>(new TH1F("xGEMRes_shrh", "xGEMRes", 100, -0.5, 0.5));
+  SIMGEMCSC_Residuals_gem_rhsh_y = std::unique_ptr<TH1F>(new TH1F("yGEMRes_shrh", "yGEMRes", 100, -10., 10.));
+  SIMGEMCSC_Pool_gem_rhsh_x_newE = std::unique_ptr<TH1F>(new TH1F("xGEMPool_shrh", "xGEMPool sh rh", 100, -5., 5.));
+  SIMGEMCSC_Pool_gem_rhsh_y_newE = std::unique_ptr<TH1F>(new TH1F("yGEMPool_shrh", "yGEMPool sh rh", 100, -5., 5.));
 }
 
-
-TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
-{
+TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer() {
   SIM_etaVScharge->Write();
   SIM_etaVStype->Write();
-  
+
   CSC_fitchi2->Write();
   GEMCSC_fitchi2->Write();
   GEMCSC_fitchi2_odd->Write();
@@ -730,7 +835,7 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_Pool_gem_y_newE_mm->Write();
   GEMCSC_Pool_gem_odd_x_newE_mm->Write();
   GEMCSC_Pool_gem_odd_y_newE_mm->Write();
-  
+
   GEMCSC_SSegm_xe_l1->Write();
   GEMCSC_SSegm_ye_l1->Write();
   GEMCSC_SSegm_ze_l1->Write();
@@ -746,7 +851,7 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_SSegm_ze_l1_even->Write();
   GEMCSC_SSegm_sigmaxe_l1_even->Write();
   GEMCSC_SSegm_sigmaye_l1_even->Write();
-  
+
   GEMCSC_SSegm_xe_l2->Write();
   GEMCSC_SSegm_ye_l2->Write();
   GEMCSC_SSegm_ze_l2->Write();
@@ -762,8 +867,7 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_SSegm_ze_l2_even->Write();
   GEMCSC_SSegm_sigmaxe_l2_even->Write();
   GEMCSC_SSegm_sigmaye_l2_even->Write();
-  
-    
+
   GEMCSC_CSCSegm_xe_l1->Write();
   GEMCSC_CSCSegm_ye_l1->Write();
   GEMCSC_CSCSegm_ze_l1->Write();
@@ -779,7 +883,7 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_CSCSegm_ze_l1_even->Write();
   GEMCSC_CSCSegm_sigmaxe_l1_even->Write();
   GEMCSC_CSCSegm_sigmaye_l1_even->Write();
-  
+
   GEMCSC_CSCSegm_xe_l2->Write();
   GEMCSC_CSCSegm_ye_l2->Write();
   GEMCSC_CSCSegm_ze_l2->Write();
@@ -795,8 +899,7 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_CSCSegm_ze_l2_even->Write();
   GEMCSC_CSCSegm_sigmaxe_l2_even->Write();
   GEMCSC_CSCSegm_sigmaye_l2_even->Write();
-  
-  
+
   GEMCSC_Dphi_min_afterCut->Write();
   GEMCSC_Dtheta_min_afterCut->Write();
   GEMCSC_Dphi_min_afterCut_odd->Write();
@@ -808,20 +911,20 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_Dphi_min_afterCut_l2->Write();
   GEMCSC_Dphi_min_afterCut_l2_odd->Write();
   GEMCSC_Dphi_min_afterCut_l2_even->Write();
-  
+
   GEMCSC_Dphi_cscS_min_afterCut->Write();
   GEMCSC_Dtheta_cscS_min_afterCut->Write();
   GEMCSC_Dtheta_cscS_min_afterCut_odd->Write();
   GEMCSC_Dtheta_cscS_min_afterCut_even->Write();
   GEMCSC_DR_cscS_min_afterCut->Write();
-  
+
   GEMCSC_Dphi_cscS_min_afterCut_l1->Write();
   GEMCSC_Dphi_cscS_min_afterCut_l1_odd->Write();
   GEMCSC_Dphi_cscS_min_afterCut_l1_even->Write();
   GEMCSC_Dphi_cscS_min_afterCut_l2->Write();
   GEMCSC_Dphi_cscS_min_afterCut_l2_odd->Write();
   GEMCSC_Dphi_cscS_min_afterCut_l2_even->Write();
-  
+
   GEMCSC_Dphi_cscS_min_afterCut_odd->Write();
   GEMCSC_Dphi_cscS_min_afterCut_even->Write();
   GEMCSC_Dphi_cscS_min_afterCut_odd_r1->Write();
@@ -832,15 +935,14 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   GEMCSC_Dphi_cscS_min_afterCut_odd_r6->Write();
   GEMCSC_Dphi_cscS_min_afterCut_odd_r7->Write();
   GEMCSC_Dphi_cscS_min_afterCut_odd_r8->Write();
-  
-  
+
   SIMGEMCSC_Dphi_SS_min_afterCut->Write();
   SIMGEMCSC_Dtheta_SS_min_afterCut->Write();
   SIMGEMCSC_Dtheta_SS_min_afterCut_odd->Write();
   SIMGEMCSC_Dtheta_SS_min_afterCut_even->Write();
   SIMGEMCSC_Dphi_SS_min_afterCut_odd->Write();
   SIMGEMCSC_Dphi_SS_min_afterCut_even->Write();
-  
+
   SIMGEMCSC_Dphi_cscS_min_afterCut->Write();
   SIMGEMCSC_Dtheta_cscS_min_afterCut->Write();
   SIMGEMCSC_Dtheta_cscS_min_afterCut_odd->Write();
@@ -859,46 +961,42 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer()
   SIMGEMCSC_Residuals_gem_even_y->Write();
   SIMGEMCSC_Pool_gem_x_newE_even->Write();
   SIMGEMCSC_Pool_gem_y_newE_even->Write();
-  
+
   SIMGEMCSC_Residuals_gem_rhsh_x->Write();
   SIMGEMCSC_Residuals_gem_rhsh_y->Write();
   SIMGEMCSC_Pool_gem_rhsh_x_newE->Write();
   SIMGEMCSC_Pool_gem_rhsh_y_newE->Write();
-  
+
   SIMGEMCSC_theta_cscSsh_vs_ndof_odd->Write();
   SIMGEMCSC_theta_cscSsh_vs_ndof_even->Write();
-    
 }
 
 // ------------ method called for each event  ------------
-void
-TestGEMCSCSegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    iSetup.get<MuonGeometryRecord>().get(gemGeom);
-    iSetup.get<MuonGeometryRecord>().get(cscGeom);
-    const CSCGeometry* cscGeom_ = &*cscGeom;
- 
- // ================
- // Sim Tracks
- // ================
-    edm::Handle<edm::SimTrackContainer> simTracks;
-    iEvent.getByToken(SimTrack_Token, simTracks);
-    // edm::Handle<edm::SimTrackContainer> simTracks;
-    // iEvent.getByLabel("g4SimHits",simTracks);
+void TestGEMCSCSegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  iSetup.get<MuonGeometryRecord>().get(gemGeom);
+  iSetup.get<MuonGeometryRecord>().get(cscGeom);
+  const CSCGeometry* cscGeom_ = &*cscGeom;
 
+  // ================
+  // Sim Tracks
+  // ================
+  edm::Handle<edm::SimTrackContainer> simTracks;
+  iEvent.getByToken(SimTrack_Token, simTracks);
+  // edm::Handle<edm::SimTrackContainer> simTracks;
+  // iEvent.getByLabel("g4SimHits",simTracks);
 
+  edm::SimTrackContainer::const_iterator simTrack;
 
-    edm::SimTrackContainer::const_iterator simTrack;
+  for (simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack) {
+    if (!(abs((*simTrack).type()) == 13))
+      continue;
+    double simEta = (*simTrack).momentum().eta();
+    //double simPhi = (*simTrack).momentum().phi();
+    int qGen = simTrack->charge();
+    SIM_etaVScharge->Fill(simEta, qGen);
+    SIM_etaVStype->Fill(simEta, (*simTrack).type());
+  }
 
-    for (simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack){
-      if (!(abs((*simTrack).type()) == 13)) continue;
-      double simEta = (*simTrack).momentum().eta();
-      //double simPhi = (*simTrack).momentum().phi();
-      int qGen = simTrack->charge();
-      SIM_etaVScharge->Fill(simEta,qGen);
-      SIM_etaVStype->Fill(simEta,(*simTrack).type());
-    }
-    
   // ================
   // CSC Segments
   // ================
@@ -909,11 +1007,11 @@ TestGEMCSCSegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
 
   for (auto cscs = cscSegment->begin(); cscs != cscSegment->end(); cscs++) {
     CSCDetId CSCId = cscs->cscDetId();
-    if(!(CSCId.station() == 1 && (CSCId.ring() == 1 || CSCId.ring() == 4))) continue;
+    if (!(CSCId.station() == 1 && (CSCId.ring() == 1 || CSCId.ring() == 4)))
+      continue;
 
     auto cscrhs = cscs->specificRecHits();
   }
-
 
   // ================
   // GEMCSC Segments
@@ -925,671 +1023,663 @@ TestGEMCSCSegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
   // iEvent.getByLabel("gemcscSegments","", "RECO", gemcscSegment);
   // iEvent.getByLabel("gemcscSegments", "", "GEMCSCREC", gemcscSegment);
 
-  if(gemcscSegment->size()!=0)GEMCSC_NumGEMCSCSeg->Fill(gemcscSegment->size());
+  if (gemcscSegment->size() != 0)
+    GEMCSC_NumGEMCSCSeg->Fill(gemcscSegment->size());
 
-    for (auto gemcscs = gemcscSegment->begin(); gemcscs != gemcscSegment->end(); gemcscs++) {
+  for (auto gemcscs = gemcscSegment->begin(); gemcscs != gemcscSegment->end(); gemcscs++) {
+    auto gemrhs_if = gemcscs->gemRecHits();
+    if (debug) {
+      std::cout << "GEM-CSC Segment with " << gemcscs->gemRecHits().size() << " GEM rechits and "
+                << gemcscs->cscSegment().specificRecHits().size() << " CSC rechits" << std::endl;
+    }
+    if (gemrhs_if.size() == 0)
+      continue;
+    // if(gemrhs_if.size()!=0) continue;
 
-      auto gemrhs_if = gemcscs->gemRecHits();
-      if(debug) 
-	{ 	
-	  std::cout<<"GEM-CSC Segment with "<<gemcscs->gemRecHits().size()<<" GEM rechits and "<<gemcscs->cscSegment().specificRecHits().size()<<" CSC rechits"<<std::endl;
-	}
-      if(gemrhs_if.size()==0) continue;
-      // if(gemrhs_if.size()!=0) continue;
-
-      // --- some printout for debug -----------------------------------------------------------------------------------------------------------------------------------
-      if(debug) {
-	std::cout<<"GEM-CSC Segment with "<<gemcscs->gemRecHits().size()<<" GEM rechits and "<<gemcscs->cscSegment().specificRecHits().size()<<" CSC rechits"<<std::endl;
-	auto gemrhs = gemcscs->gemRecHits();
-	for (auto rh = gemrhs.begin(); rh!= gemrhs.end(); rh++){
-	  GEMDetId gemId((*rh).geographicalId());
-	  const GEMEtaPartition* id_etapart = gemGeom->etaPartition(gemId);
-	  const BoundPlane & GEMSurface = id_etapart->surface();
-	  GlobalPoint GEMGlobalPoint = GEMSurface.toGlobal((*rh).localPosition());
-	  std::cout<<"GEM Rechit in "<<gemId<<" = "<<gemId.rawId()<<" at X = "<<GEMGlobalPoint.x()<<" Y = "<<GEMGlobalPoint.y()<<" Z = "<<GEMGlobalPoint.z()<<std::endl;
-	}
-	CSCSegment cscSeg = gemcscs->cscSegment();
-	auto cscrhs = cscSeg.specificRecHits();
-	for (auto rh = cscrhs.begin(); rh!= cscrhs.end(); rh++){
-	  CSCDetId cscId = (CSCDetId)(*rh).cscDetId();
-	  GlobalPoint CSCGlobalPoint = cscGeom->idToDet(cscId)->toGlobal((*rh).localPosition());
-	  std::cout<<"CSC Rechit in "<<cscId<<" = "<<cscId.rawId()<<" at X = "<<CSCGlobalPoint.x()<<" Y = "<<CSCGlobalPoint.y()<<" Z = "<<CSCGlobalPoint.z()<<std::endl;
-	}
+    // --- some printout for debug -----------------------------------------------------------------------------------------------------------------------------------
+    if (debug) {
+      std::cout << "GEM-CSC Segment with " << gemcscs->gemRecHits().size() << " GEM rechits and "
+                << gemcscs->cscSegment().specificRecHits().size() << " CSC rechits" << std::endl;
+      auto gemrhs = gemcscs->gemRecHits();
+      for (auto rh = gemrhs.begin(); rh != gemrhs.end(); rh++) {
+        GEMDetId gemId((*rh).geographicalId());
+        const GEMEtaPartition* id_etapart = gemGeom->etaPartition(gemId);
+        const BoundPlane& GEMSurface = id_etapart->surface();
+        GlobalPoint GEMGlobalPoint = GEMSurface.toGlobal((*rh).localPosition());
+        std::cout << "GEM Rechit in " << gemId << " = " << gemId.rawId() << " at X = " << GEMGlobalPoint.x()
+                  << " Y = " << GEMGlobalPoint.y() << " Z = " << GEMGlobalPoint.z() << std::endl;
       }
-      // --- some printout for debug -----------------------------------------------------------------------------------------------------------------------------------
+      CSCSegment cscSeg = gemcscs->cscSegment();
+      auto cscrhs = cscSeg.specificRecHits();
+      for (auto rh = cscrhs.begin(); rh != cscrhs.end(); rh++) {
+        CSCDetId cscId = (CSCDetId)(*rh).cscDetId();
+        GlobalPoint CSCGlobalPoint = cscGeom->idToDet(cscId)->toGlobal((*rh).localPosition());
+        std::cout << "CSC Rechit in " << cscId << " = " << cscId.rawId() << " at X = " << CSCGlobalPoint.x()
+                  << " Y = " << CSCGlobalPoint.y() << " Z = " << CSCGlobalPoint.z() << std::endl;
+      }
+    }
+    // --- some printout for debug -----------------------------------------------------------------------------------------------------------------------------------
 
+    ///////// GEMCSC seg //////////////////////////////////////
+    CSCDetId gemcscId = gemcscs->cscDetId();
+    const CSCChamber* cscChamber = cscGeom_->chamber(gemcscId);
 
+    auto gemcscsegLP = gemcscs->localPosition();
+    auto gemcscsegLD = gemcscs->localDirection();
+    auto gemcscsegLEP = gemcscs->localPositionError();
+    auto gemcscsegLED = gemcscs->localDirectionError();
+    GEMCSC_SSegm_LPx->Fill(gemcscsegLP.x());
+    GEMCSC_SSegm_LPy->Fill(gemcscsegLP.y());
+    GEMCSC_SSegm_LPEx->Fill(sqrt(gemcscsegLEP.xx()));
+    GEMCSC_SSegm_LPEy->Fill(sqrt(gemcscsegLEP.yy()));
+    //GEMCSC_SSegm_LPEz->Fill(gemcscsegLEP.zz());
+    GEMCSC_SSegm_LDx->Fill(gemcscsegLD.x());
+    GEMCSC_SSegm_LDy->Fill(gemcscsegLD.y());
+    GEMCSC_SSegm_LDEx->Fill(sqrt(gemcscsegLED.xx()));
+    GEMCSC_SSegm_LDEy->Fill(sqrt(gemcscsegLED.yy()));
+    //GEMCSC_SSegm_LDEz->Fill(gemcscsegLED.zz());
+    GEMCSC_SSegm_LPEy_vs_ndof->Fill(gemcscsegLEP.yy(), gemcscs->degreesOfFreedom());
+    GEMCSC_SSegm_LDEy_vs_ndof->Fill(gemcscsegLED.yy(), gemcscs->degreesOfFreedom());
 
-        
-        ///////// GEMCSC seg //////////////////////////////////////
-        CSCDetId gemcscId = gemcscs->cscDetId();
-        const CSCChamber* cscChamber = cscGeom_->chamber(gemcscId);
+    GEMCSC_fitchi2->Fill(gemcscs->chi2() / gemcscs->degreesOfFreedom());
 
-        auto gemcscsegLP = gemcscs->localPosition();
-        auto gemcscsegLD = gemcscs->localDirection();
-        auto gemcscsegLEP = gemcscs->localPositionError();
-        auto gemcscsegLED = gemcscs->localDirectionError();
-        GEMCSC_SSegm_LPx->Fill(gemcscsegLP.x());
-        GEMCSC_SSegm_LPy->Fill(gemcscsegLP.y());
-        GEMCSC_SSegm_LPEx->Fill(sqrt(gemcscsegLEP.xx()));
-        GEMCSC_SSegm_LPEy->Fill(sqrt(gemcscsegLEP.yy()));
-        //GEMCSC_SSegm_LPEz->Fill(gemcscsegLEP.zz());
-        GEMCSC_SSegm_LDx->Fill(gemcscsegLD.x());
-        GEMCSC_SSegm_LDy->Fill(gemcscsegLD.y());
-        GEMCSC_SSegm_LDEx->Fill(sqrt(gemcscsegLED.xx()));
-        GEMCSC_SSegm_LDEy->Fill(sqrt(gemcscsegLED.yy()));
-        //GEMCSC_SSegm_LDEz->Fill(gemcscsegLED.zz());
-        GEMCSC_SSegm_LPEy_vs_ndof->Fill(gemcscsegLEP.yy(),gemcscs->degreesOfFreedom());
-        GEMCSC_SSegm_LDEy_vs_ndof->Fill(gemcscsegLED.yy(),gemcscs->degreesOfFreedom());
-        
-        GEMCSC_fitchi2->Fill(gemcscs->chi2()/gemcscs->degreesOfFreedom());
-        
-        CSCDetId id((*gemcscs).geographicalId());
-        int chamber = id.chamber();
-        if(chamber%2!=0){
-        GEMCSC_fitchi2_odd->Fill(gemcscs->chi2()/gemcscs->degreesOfFreedom());}
-        else{GEMCSC_fitchi2_even->Fill(gemcscs->chi2()/gemcscs->degreesOfFreedom());}
-      
-        GEMCSC_NumGEMCSCRH->Fill(gemcscs->cscSegment().specificRecHits().size()+gemcscs->gemRecHits().size());
-      
-        ///////// CSC seg /////////////////////////////////////
-        CSCSegment cscSeg = gemcscs->cscSegment();
-        //CSCDetId CSCId_new = cscSeg.cscDetId();
-        //if(!(CSCId_new.station() == 1 && CSCId_new.ring() == 1)) continue;
-        auto cscrhs = cscSeg.specificRecHits();
-        GEMCSC_NumCSCRH->Fill(cscrhs.size());
-        
-        auto cscsegLP = cscSeg.localPosition();
-        auto cscsegLD = cscSeg.localDirection();
-        auto cscsegLEP = cscSeg.localPositionError();
-        auto cscsegLED = cscSeg.localDirectionError();
-        
-        GEMCSC_CSCSegm_LPx->Fill(cscsegLP.x());
-        GEMCSC_CSCSegm_LPy->Fill(cscsegLP.y());
-        GEMCSC_CSCSegm_LPEx->Fill(sqrt(cscsegLEP.xx()));
-        GEMCSC_CSCSegm_LPEy->Fill(sqrt(cscsegLEP.yy()));
-        //GEMCSC_CSCSegm_LPEz->Fill(cscsegLEP.zz());
-        GEMCSC_CSCSegm_LDx->Fill(cscsegLD.x());
-        GEMCSC_CSCSegm_LDy->Fill(cscsegLD.y());
-        GEMCSC_CSCSegm_LDEx->Fill(sqrt(cscsegLED.xx()));
-        GEMCSC_CSCSegm_LDEy->Fill(sqrt(cscsegLED.yy()));
-        //GEMCSC_CSCSegm_LDEz->Fill(cscsegLED.zz());
-        GEMCSC_CSCSegm_LPEy_vs_ndof->Fill(cscsegLEP.yy(),cscSeg.degreesOfFreedom());
-        GEMCSC_CSCSegm_LDEy_vs_ndof->Fill(cscsegLED.yy(),cscSeg.degreesOfFreedom());
-        
-        CSC_fitchi2->Fill(cscSeg.chi2()/cscSeg.degreesOfFreedom());
-      
-        //////////////////////// CSC RH
-        for (auto rh = cscrhs.begin(); rh!= cscrhs.end(); rh++){
-            //CSCDetId cscrhId = rh.cscDetId();
-            CSCDetId cscrhId = (CSCDetId)(*rh).cscDetId();
-            const CSCLayer* cscrhRef = cscGeom_->layer( cscrhId );
-          
-            auto cscrhLP = rh->localPosition();
-            auto cscrhLEP = rh->localPositionError();
-            auto cscrhGP = cscrhRef->toGlobal(cscrhLP);
-            auto cscrhLP_inSegmRef = cscChamber->toLocal(cscrhGP);
-            float xe  = gemcscsegLP.x()+gemcscsegLD.x()*cscrhLP_inSegmRef.z()/gemcscsegLD.z();
-            float ye  = gemcscsegLP.y()+gemcscsegLD.y()*cscrhLP_inSegmRef.z()/gemcscsegLD.z();
-            float ze = cscrhLP_inSegmRef.z();
-            LocalPoint extrPoint(xe,ye,ze); // in segment rest frame
-            //float sigma_xe = gemcscsegLEP.xx()+gemcscsegLED.xx()*cscrhLP_inSegmRef.z()*cscrhLP_inSegmRef.z();
-            //float sigma_ye = gemcscsegLEP.yy()+gemcscsegLED.yy()*cscrhLP_inSegmRef.z()*cscrhLP_inSegmRef.z();
-            auto extSegm = cscrhRef->toLocal(cscChamber->toGlobal(extrPoint)); // in layer restframe
-          
-            GEMCSC_Residuals_x->Fill(cscrhLP.x()-extSegm.x());
-            GEMCSC_Residuals_y->Fill(cscrhLP.y()-extSegm.y());
-            GEMCSC_Pool_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-            GEMCSC_Pool_y->Fill((cscrhLP.y()-extSegm.y())/sqrt(cscrhLEP.yy()));
-            GEMCSC_Residuals_csc_x->Fill(cscrhLP.x()-extSegm.x());
-            GEMCSC_Residuals_csc_y->Fill(cscrhLP.y()-extSegm.y());
-            GEMCSC_Pool_csc_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-            GEMCSC_Pool_csc_y->Fill((cscrhLP.y()-extSegm.y())/sqrt(cscrhLEP.yy()));
+    CSCDetId id((*gemcscs).geographicalId());
+    int chamber = id.chamber();
+    if (chamber % 2 != 0) {
+      GEMCSC_fitchi2_odd->Fill(gemcscs->chi2() / gemcscs->degreesOfFreedom());
+    } else {
+      GEMCSC_fitchi2_even->Fill(gemcscs->chi2() / gemcscs->degreesOfFreedom());
+    }
 
-            CSCDetId id((*rh).geographicalId());
-            int chamber = id.chamber();
-            if(chamber%2!=0){
-              //std::cout<<"camera dispari"<<chamber<<std::endl;
-              GEMCSC_Residuals_csc_odd_x->Fill(cscrhLP.x()-extSegm.x());
-              GEMCSC_Residuals_csc_odd_y->Fill(cscrhLP.y()-extSegm.y());
-              GEMCSC_Pool_csc_odd_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-              GEMCSC_Pool_csc_odd_y->Fill((cscrhLP.y()-extSegm.y())/sqrt(cscrhLEP.yy()));
-            }
-            else {
-              GEMCSC_Residuals_csc_even_x->Fill(cscrhLP.x()-extSegm.x());
-              GEMCSC_Residuals_csc_even_y->Fill(cscrhLP.y()-extSegm.y());
-              GEMCSC_Pool_csc_even_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-              GEMCSC_Pool_csc_even_y->Fill((cscrhLP.y()-extSegm.y())/sqrt(cscrhLEP.yy()));
+    GEMCSC_NumGEMCSCRH->Fill(gemcscs->cscSegment().specificRecHits().size() + gemcscs->gemRecHits().size());
 
-            }
-          
-            switch (cscrhId.layer()){
-              case 1:
-                  GEMCSC_Residuals_cscl1_x->Fill(cscrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_cscl1_y->Fill(cscrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_cscl1_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-                  GEMCSC_Pool_cscl1_y->Fill((cscrhLP.x()-extSegm.y())/sqrt(cscrhLEP.yy()));
-                  break;
-              case 2:
-                  GEMCSC_Residuals_cscl2_x->Fill(cscrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_cscl2_y->Fill(cscrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_cscl2_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-                  GEMCSC_Pool_cscl2_y->Fill((cscrhLP.x()-extSegm.y())/sqrt(cscrhLEP.yy()));
-                  break;
-                  
-              case 3:
-                  GEMCSC_Residuals_cscl3_x->Fill(cscrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_cscl3_y->Fill(cscrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_cscl3_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-                  GEMCSC_Pool_cscl3_y->Fill((cscrhLP.x()-extSegm.y())/sqrt(cscrhLEP.yy()));
-                  break;
-              case 4:
-                  GEMCSC_Residuals_cscl4_x->Fill(cscrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_cscl4_y->Fill(cscrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_cscl4_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-                  GEMCSC_Pool_cscl4_y->Fill((cscrhLP.x()-extSegm.y())/sqrt(cscrhLEP.yy()));
-                  break;
-              case 5:
-                  GEMCSC_Residuals_cscl5_x->Fill(cscrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_cscl5_y->Fill(cscrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_cscl5_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-                  GEMCSC_Pool_cscl5_y->Fill((cscrhLP.x()-extSegm.y())/sqrt(cscrhLEP.yy()));
-                  break;
-              case 6:
-                  GEMCSC_Residuals_cscl6_x->Fill(cscrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_cscl6_y->Fill(cscrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_cscl6_x->Fill((cscrhLP.x()-extSegm.x())/sqrt(cscrhLEP.xx()));
-                  GEMCSC_Pool_cscl6_y->Fill((cscrhLP.x()-extSegm.y())/sqrt(cscrhLEP.yy()));
-                  break;
-              default:
-                  std::cout <<" Unphysical GEMCSC layer "<<cscrhId<<std::endl;
+    ///////// CSC seg /////////////////////////////////////
+    CSCSegment cscSeg = gemcscs->cscSegment();
+    //CSCDetId CSCId_new = cscSeg.cscDetId();
+    //if(!(CSCId_new.station() == 1 && CSCId_new.ring() == 1)) continue;
+    auto cscrhs = cscSeg.specificRecHits();
+    GEMCSC_NumCSCRH->Fill(cscrhs.size());
+
+    auto cscsegLP = cscSeg.localPosition();
+    auto cscsegLD = cscSeg.localDirection();
+    auto cscsegLEP = cscSeg.localPositionError();
+    auto cscsegLED = cscSeg.localDirectionError();
+
+    GEMCSC_CSCSegm_LPx->Fill(cscsegLP.x());
+    GEMCSC_CSCSegm_LPy->Fill(cscsegLP.y());
+    GEMCSC_CSCSegm_LPEx->Fill(sqrt(cscsegLEP.xx()));
+    GEMCSC_CSCSegm_LPEy->Fill(sqrt(cscsegLEP.yy()));
+    //GEMCSC_CSCSegm_LPEz->Fill(cscsegLEP.zz());
+    GEMCSC_CSCSegm_LDx->Fill(cscsegLD.x());
+    GEMCSC_CSCSegm_LDy->Fill(cscsegLD.y());
+    GEMCSC_CSCSegm_LDEx->Fill(sqrt(cscsegLED.xx()));
+    GEMCSC_CSCSegm_LDEy->Fill(sqrt(cscsegLED.yy()));
+    //GEMCSC_CSCSegm_LDEz->Fill(cscsegLED.zz());
+    GEMCSC_CSCSegm_LPEy_vs_ndof->Fill(cscsegLEP.yy(), cscSeg.degreesOfFreedom());
+    GEMCSC_CSCSegm_LDEy_vs_ndof->Fill(cscsegLED.yy(), cscSeg.degreesOfFreedom());
+
+    CSC_fitchi2->Fill(cscSeg.chi2() / cscSeg.degreesOfFreedom());
+
+    //////////////////////// CSC RH
+    for (auto rh = cscrhs.begin(); rh != cscrhs.end(); rh++) {
+      //CSCDetId cscrhId = rh.cscDetId();
+      CSCDetId cscrhId = (CSCDetId)(*rh).cscDetId();
+      const CSCLayer* cscrhRef = cscGeom_->layer(cscrhId);
+
+      auto cscrhLP = rh->localPosition();
+      auto cscrhLEP = rh->localPositionError();
+      auto cscrhGP = cscrhRef->toGlobal(cscrhLP);
+      auto cscrhLP_inSegmRef = cscChamber->toLocal(cscrhGP);
+      float xe = gemcscsegLP.x() + gemcscsegLD.x() * cscrhLP_inSegmRef.z() / gemcscsegLD.z();
+      float ye = gemcscsegLP.y() + gemcscsegLD.y() * cscrhLP_inSegmRef.z() / gemcscsegLD.z();
+      float ze = cscrhLP_inSegmRef.z();
+      LocalPoint extrPoint(xe, ye, ze);  // in segment rest frame
+      //float sigma_xe = gemcscsegLEP.xx()+gemcscsegLED.xx()*cscrhLP_inSegmRef.z()*cscrhLP_inSegmRef.z();
+      //float sigma_ye = gemcscsegLEP.yy()+gemcscsegLED.yy()*cscrhLP_inSegmRef.z()*cscrhLP_inSegmRef.z();
+      auto extSegm = cscrhRef->toLocal(cscChamber->toGlobal(extrPoint));  // in layer restframe
+
+      GEMCSC_Residuals_x->Fill(cscrhLP.x() - extSegm.x());
+      GEMCSC_Residuals_y->Fill(cscrhLP.y() - extSegm.y());
+      GEMCSC_Pool_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+      GEMCSC_Pool_y->Fill((cscrhLP.y() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+      GEMCSC_Residuals_csc_x->Fill(cscrhLP.x() - extSegm.x());
+      GEMCSC_Residuals_csc_y->Fill(cscrhLP.y() - extSegm.y());
+      GEMCSC_Pool_csc_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+      GEMCSC_Pool_csc_y->Fill((cscrhLP.y() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+
+      CSCDetId id((*rh).geographicalId());
+      int chamber = id.chamber();
+      if (chamber % 2 != 0) {
+        //std::cout<<"camera dispari"<<chamber<<std::endl;
+        GEMCSC_Residuals_csc_odd_x->Fill(cscrhLP.x() - extSegm.x());
+        GEMCSC_Residuals_csc_odd_y->Fill(cscrhLP.y() - extSegm.y());
+        GEMCSC_Pool_csc_odd_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+        GEMCSC_Pool_csc_odd_y->Fill((cscrhLP.y() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+      } else {
+        GEMCSC_Residuals_csc_even_x->Fill(cscrhLP.x() - extSegm.x());
+        GEMCSC_Residuals_csc_even_y->Fill(cscrhLP.y() - extSegm.y());
+        GEMCSC_Pool_csc_even_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+        GEMCSC_Pool_csc_even_y->Fill((cscrhLP.y() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+      }
+
+      switch (cscrhId.layer()) {
+        case 1:
+          GEMCSC_Residuals_cscl1_x->Fill(cscrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_cscl1_y->Fill(cscrhLP.y() - extSegm.y());
+          GEMCSC_Pool_cscl1_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+          GEMCSC_Pool_cscl1_y->Fill((cscrhLP.x() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+          break;
+        case 2:
+          GEMCSC_Residuals_cscl2_x->Fill(cscrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_cscl2_y->Fill(cscrhLP.y() - extSegm.y());
+          GEMCSC_Pool_cscl2_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+          GEMCSC_Pool_cscl2_y->Fill((cscrhLP.x() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+          break;
+
+        case 3:
+          GEMCSC_Residuals_cscl3_x->Fill(cscrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_cscl3_y->Fill(cscrhLP.y() - extSegm.y());
+          GEMCSC_Pool_cscl3_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+          GEMCSC_Pool_cscl3_y->Fill((cscrhLP.x() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+          break;
+        case 4:
+          GEMCSC_Residuals_cscl4_x->Fill(cscrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_cscl4_y->Fill(cscrhLP.y() - extSegm.y());
+          GEMCSC_Pool_cscl4_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+          GEMCSC_Pool_cscl4_y->Fill((cscrhLP.x() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+          break;
+        case 5:
+          GEMCSC_Residuals_cscl5_x->Fill(cscrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_cscl5_y->Fill(cscrhLP.y() - extSegm.y());
+          GEMCSC_Pool_cscl5_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+          GEMCSC_Pool_cscl5_y->Fill((cscrhLP.x() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+          break;
+        case 6:
+          GEMCSC_Residuals_cscl6_x->Fill(cscrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_cscl6_y->Fill(cscrhLP.y() - extSegm.y());
+          GEMCSC_Pool_cscl6_x->Fill((cscrhLP.x() - extSegm.x()) / sqrt(cscrhLEP.xx()));
+          GEMCSC_Pool_cscl6_y->Fill((cscrhLP.x() - extSegm.y()) / sqrt(cscrhLEP.yy()));
+          break;
+        default:
+          std::cout << " Unphysical GEMCSC layer " << cscrhId << std::endl;
+      }
+    }
+    //////////////////
+
+    //////// GEM recHits ////////////////////
+    auto gemrhs = gemcscs->gemRecHits();
+    GEMCSC_NumGEMRH->Fill(gemrhs.size());
+    for (auto rh = gemrhs.begin(); rh != gemrhs.end(); rh++) {
+      GEMDetId id((*rh).geographicalId());
+      int chamber = id.chamber();
+
+      //GEMDetId gemid(rh->geographicalId());
+      auto gemrhId = rh->gemId();
+      const GEMEtaPartition* gemrhRef = gemGeom->etaPartition(gemrhId);
+      auto gemrhLP = rh->localPosition();
+      auto gemrhLEP = rh->localPositionError();
+      auto gemrhGP = gemrhRef->toGlobal(gemrhLP);
+      auto gemrhLP_inSegmRef = cscChamber->toLocal(gemrhGP);
+      float phi_rh = gemrhGP.phi();
+      float theta_rh = gemrhGP.theta();
+      float eta_rh = gemrhGP.eta();
+      float xe = gemcscsegLP.x() + gemcscsegLD.x() * gemrhLP_inSegmRef.z() / gemcscsegLD.z();
+      float ye = gemcscsegLP.y() + gemcscsegLD.y() * gemrhLP_inSegmRef.z() / gemcscsegLD.z();
+      float ze = gemrhLP_inSegmRef.z();
+      LocalPoint extrPoint(xe, ye, ze);  // in segment rest frame
+      float sigma_xe = sqrt(gemcscsegLEP.xx() + gemcscsegLED.xx() * gemrhLP_inSegmRef.z() * gemrhLP_inSegmRef.z());
+      float sigma_ye = sqrt(gemcscsegLEP.yy() + gemcscsegLED.yy() * gemrhLP_inSegmRef.z() * gemrhLP_inSegmRef.z());
+      auto extrPoinGP_fromSegmRef = cscChamber->toGlobal(extrPoint);
+      float phi_ext = extrPoinGP_fromSegmRef.phi();
+      float theta_ext = extrPoinGP_fromSegmRef.theta();
+
+      auto extSegm = gemrhRef->toLocal(cscChamber->toGlobal(extrPoint));  // in layer restframe
+
+      GEMCSC_Dphi_min_afterCut->Fill(phi_ext - phi_rh);
+      GEMCSC_Dtheta_min_afterCut->Fill((theta_ext - theta_rh));
+      GEMCSC_DR_min_afterCut->Fill((theta_ext - theta_rh) * (theta_ext - theta_rh) +
+                                   (phi_ext - phi_rh) * (phi_ext - phi_rh));
+
+      switch (gemrhId.layer()) {
+        case 1:
+          GEMCSC_SSegm_xe_l1->Fill(xe);
+          GEMCSC_SSegm_ye_l1->Fill(ye);
+          GEMCSC_SSegm_ze_l1->Fill(ze);
+          GEMCSC_SSegm_sigmaxe_l1->Fill(sigma_xe);
+          GEMCSC_SSegm_sigmaye_l1->Fill(sigma_ye);
+          GEMCSC_Dphi_min_afterCut_l1->Fill((phi_ext - phi_rh));
+          if (chamber % 2 != 0) {
+            GEMCSC_Dphi_min_afterCut_l1_odd->Fill((phi_ext - phi_rh));
+            GEMCSC_Dphi_min_afterCut_odd->Fill((phi_ext - phi_rh));
+            GEMCSC_SSegm_xe_l1_odd->Fill(xe);
+            GEMCSC_SSegm_ye_l1_odd->Fill(ye);
+            GEMCSC_SSegm_ze_l1_odd->Fill(ze);
+            GEMCSC_SSegm_sigmaxe_l1_odd->Fill(sigma_xe);
+            GEMCSC_SSegm_sigmaye_l1_odd->Fill(sigma_ye);
+          } else {
+            GEMCSC_Dphi_min_afterCut_l1_even->Fill((phi_ext - phi_rh));
+            GEMCSC_Dphi_min_afterCut_even->Fill((phi_ext - phi_rh));
+            GEMCSC_SSegm_xe_l1_even->Fill(xe);
+            GEMCSC_SSegm_ye_l1_even->Fill(ye);
+            GEMCSC_SSegm_ze_l1_even->Fill(ze);
+            GEMCSC_SSegm_sigmaxe_l1_even->Fill(sigma_xe);
+            GEMCSC_SSegm_sigmaye_l1_even->Fill(sigma_ye);
           }
+
+          break;
+        case 2:
+          GEMCSC_SSegm_xe_l2->Fill(xe);
+          GEMCSC_SSegm_ye_l2->Fill(ye);
+          GEMCSC_SSegm_ze_l2->Fill(ze);
+          GEMCSC_SSegm_sigmaxe_l2->Fill(sigma_xe);
+          GEMCSC_SSegm_sigmaye_l2->Fill(sigma_ye);
+          GEMCSC_Dphi_min_afterCut_l2->Fill((phi_ext - phi_rh));
+          if (chamber % 2 != 0) {
+            GEMCSC_Dphi_min_afterCut_l2_odd->Fill((phi_ext - phi_rh));
+            GEMCSC_Dphi_min_afterCut_odd->Fill((phi_ext - phi_rh));
+            GEMCSC_SSegm_xe_l2_odd->Fill(xe);
+            GEMCSC_SSegm_ye_l2_odd->Fill(ye);
+            GEMCSC_SSegm_ze_l2_odd->Fill(ze);
+            GEMCSC_SSegm_sigmaxe_l2_odd->Fill(sigma_xe);
+            GEMCSC_SSegm_sigmaye_l2_odd->Fill(sigma_ye);
+          } else {
+            GEMCSC_Dphi_min_afterCut_l2_even->Fill((phi_ext - phi_rh));
+            GEMCSC_Dphi_min_afterCut_even->Fill((phi_ext - phi_rh));
+            GEMCSC_SSegm_xe_l2_even->Fill(xe);
+            GEMCSC_SSegm_ye_l2_even->Fill(ye);
+            GEMCSC_SSegm_ze_l2_even->Fill(ze);
+            GEMCSC_SSegm_sigmaxe_l2_even->Fill(sigma_xe);
+            GEMCSC_SSegm_sigmaye_l2_even->Fill(sigma_ye);
+          }
+
+          break;
+        default:
+          std::cout << " Unphysical GEMCSC layer " << gemrhId << std::endl;
       }
-        //////////////////
-      
-        //////// GEM recHits ////////////////////
-        auto gemrhs = gemcscs->gemRecHits();
-        GEMCSC_NumGEMRH->Fill(gemrhs.size());
-        for (auto rh = gemrhs.begin(); rh!= gemrhs.end(); rh++){
-            GEMDetId id((*rh).geographicalId());
-            int chamber = id.chamber();
-            
-            //GEMDetId gemid(rh->geographicalId());
-            auto gemrhId = rh->gemId();
-            const GEMEtaPartition* gemrhRef  = gemGeom->etaPartition(gemrhId);
-            auto gemrhLP = rh->localPosition();
-            auto gemrhLEP = rh->localPositionError();
-            auto gemrhGP = gemrhRef->toGlobal(gemrhLP);
-            auto gemrhLP_inSegmRef = cscChamber->toLocal(gemrhGP);
-            float phi_rh = gemrhGP.phi();
-            float theta_rh = gemrhGP.theta();
-            float eta_rh = gemrhGP.eta();
-            float xe  = gemcscsegLP.x()+gemcscsegLD.x()*gemrhLP_inSegmRef.z()/gemcscsegLD.z();
-            float ye  = gemcscsegLP.y()+gemcscsegLD.y()*gemrhLP_inSegmRef.z()/gemcscsegLD.z();
-            float ze = gemrhLP_inSegmRef.z();
-            LocalPoint extrPoint(xe,ye,ze); // in segment rest frame
-            float sigma_xe = sqrt (gemcscsegLEP.xx()+gemcscsegLED.xx()*gemrhLP_inSegmRef.z()*gemrhLP_inSegmRef.z());
-            float sigma_ye = sqrt (gemcscsegLEP.yy()+gemcscsegLED.yy()*gemrhLP_inSegmRef.z()*gemrhLP_inSegmRef.z());
-            auto extrPoinGP_fromSegmRef = cscChamber->toGlobal(extrPoint);
-            float phi_ext = extrPoinGP_fromSegmRef.phi();
-            float theta_ext = extrPoinGP_fromSegmRef.theta();
-            
-            auto extSegm = gemrhRef->toLocal(cscChamber->toGlobal(extrPoint)); // in layer restframe
 
-            GEMCSC_Dphi_min_afterCut->Fill(phi_ext-phi_rh);
-            GEMCSC_Dtheta_min_afterCut->Fill((theta_ext-theta_rh));
-            GEMCSC_DR_min_afterCut->Fill((theta_ext-theta_rh)*(theta_ext-theta_rh)+(phi_ext-phi_rh)*(phi_ext-phi_rh));
-            
-            switch (gemrhId.layer()){
-                case 1:
-                    GEMCSC_SSegm_xe_l1->Fill(xe);
-                    GEMCSC_SSegm_ye_l1->Fill(ye);
-                    GEMCSC_SSegm_ze_l1->Fill(ze);
-                    GEMCSC_SSegm_sigmaxe_l1->Fill(sigma_xe);
-                    GEMCSC_SSegm_sigmaye_l1->Fill(sigma_ye);
-                    GEMCSC_Dphi_min_afterCut_l1->Fill((phi_ext-phi_rh));
-                    if(chamber%2!=0){GEMCSC_Dphi_min_afterCut_l1_odd->Fill((phi_ext-phi_rh));
-                        GEMCSC_Dphi_min_afterCut_odd->Fill((phi_ext-phi_rh));
-                        GEMCSC_SSegm_xe_l1_odd->Fill(xe);
-                        GEMCSC_SSegm_ye_l1_odd->Fill(ye);
-                        GEMCSC_SSegm_ze_l1_odd->Fill(ze);
-                        GEMCSC_SSegm_sigmaxe_l1_odd->Fill(sigma_xe);
-                        GEMCSC_SSegm_sigmaye_l1_odd->Fill(sigma_ye);
-                    }
-                    else{GEMCSC_Dphi_min_afterCut_l1_even->Fill((phi_ext-phi_rh));
-                        GEMCSC_Dphi_min_afterCut_even->Fill((phi_ext-phi_rh));
-                        GEMCSC_SSegm_xe_l1_even->Fill(xe);
-                        GEMCSC_SSegm_ye_l1_even->Fill(ye);
-                        GEMCSC_SSegm_ze_l1_even->Fill(ze);
-                        GEMCSC_SSegm_sigmaxe_l1_even->Fill(sigma_xe);
-                        GEMCSC_SSegm_sigmaye_l1_even->Fill(sigma_ye);
-                    }
-                    
-                    break;
-                 case 2:
-                    GEMCSC_SSegm_xe_l2->Fill(xe);
-                    GEMCSC_SSegm_ye_l2->Fill(ye);
-                    GEMCSC_SSegm_ze_l2->Fill(ze);
-                    GEMCSC_SSegm_sigmaxe_l2->Fill(sigma_xe);
-                    GEMCSC_SSegm_sigmaye_l2->Fill(sigma_ye);
-                    GEMCSC_Dphi_min_afterCut_l2->Fill((phi_ext-phi_rh));
-                    if(chamber%2!=0){GEMCSC_Dphi_min_afterCut_l2_odd->Fill((phi_ext-phi_rh));
-                        GEMCSC_Dphi_min_afterCut_odd->Fill((phi_ext-phi_rh));
-                        GEMCSC_SSegm_xe_l2_odd->Fill(xe);
-                        GEMCSC_SSegm_ye_l2_odd->Fill(ye);
-                        GEMCSC_SSegm_ze_l2_odd->Fill(ze);
-                        GEMCSC_SSegm_sigmaxe_l2_odd->Fill(sigma_xe);
-                        GEMCSC_SSegm_sigmaye_l2_odd->Fill(sigma_ye);
-                    }
-                    else{GEMCSC_Dphi_min_afterCut_l2_even->Fill((phi_ext-phi_rh));
-                        GEMCSC_Dphi_min_afterCut_even->Fill((phi_ext-phi_rh));
-                        GEMCSC_SSegm_xe_l2_even->Fill(xe);
-                        GEMCSC_SSegm_ye_l2_even->Fill(ye);
-                        GEMCSC_SSegm_ze_l2_even->Fill(ze);
-                        GEMCSC_SSegm_sigmaxe_l2_even->Fill(sigma_xe);
-                        GEMCSC_SSegm_sigmaye_l2_even->Fill(sigma_ye);
-                    }
-                    
-                    break;
-                default:
-                    std::cout <<" Unphysical GEMCSC layer "<<gemrhId<<std::endl;
-            }
+      GEMCSC_Residuals_x->Fill(gemrhLP.x() - extSegm.x());
+      GEMCSC_Residuals_y->Fill(gemrhLP.y() - extSegm.y());
+      GEMCSC_Pool_x->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx()));
+      GEMCSC_Pool_y->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy()));
+      GEMCSC_Residuals_gem_x->Fill(gemrhLP.x() - extSegm.x());
+      GEMCSC_Residuals_gem_y->Fill(gemrhLP.y() - extSegm.y());
+      GEMCSC_Pool_gem_x->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx()));
+      GEMCSC_Pool_gem_y->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy()));
+      GEMCSC_Pool_gem_x_newE->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx() + sigma_xe * sigma_xe));
+      GEMCSC_Pool_gem_y_newE->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy() + sigma_ye * sigma_ye));
 
-            GEMCSC_Residuals_x->Fill(gemrhLP.x()-extSegm.x());
-            GEMCSC_Residuals_y->Fill(gemrhLP.y()-extSegm.y());
-            GEMCSC_Pool_x->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()));
-            GEMCSC_Pool_y->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()));
-            GEMCSC_Residuals_gem_x->Fill(gemrhLP.x()-extSegm.x());
-            GEMCSC_Residuals_gem_y->Fill(gemrhLP.y()-extSegm.y());
-            GEMCSC_Pool_gem_x->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()));
-            GEMCSC_Pool_gem_y->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()));
-            GEMCSC_Pool_gem_x_newE->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()+ sigma_xe*sigma_xe ));
-            GEMCSC_Pool_gem_y_newE->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()+ sigma_ye*sigma_ye));
-            
-            if (eta_rh>0){
-                GEMCSC_Pool_gem_x_newE_mp->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()+ sigma_xe*sigma_xe ));
-                GEMCSC_Pool_gem_y_newE_mp->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()+ sigma_ye*sigma_ye));
-            }
-            if (eta_rh<0){
-                GEMCSC_Pool_gem_x_newE_mm->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()+ sigma_xe*sigma_xe ));
-                GEMCSC_Pool_gem_y_newE_mm->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()+ sigma_ye*sigma_ye));
-            }
+      if (eta_rh > 0) {
+        GEMCSC_Pool_gem_x_newE_mp->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx() + sigma_xe * sigma_xe));
+        GEMCSC_Pool_gem_y_newE_mp->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy() + sigma_ye * sigma_ye));
+      }
+      if (eta_rh < 0) {
+        GEMCSC_Pool_gem_x_newE_mm->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx() + sigma_xe * sigma_xe));
+        GEMCSC_Pool_gem_y_newE_mm->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy() + sigma_ye * sigma_ye));
+      }
 
- 
-            
-            if(chamber%2!=0){
-              GEMCSC_Residuals_gem_odd_x->Fill(gemrhLP.x()-extSegm.x());
-              GEMCSC_Residuals_gem_odd_y->Fill(gemrhLP.y()-extSegm.y());
-              GEMCSC_Pool_gem_odd_x->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()));
-              GEMCSC_Pool_gem_odd_y->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()));
-                GEMCSC_Pool_gem_odd_x_newE->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()+ sigma_xe*sigma_xe ));
-                GEMCSC_Pool_gem_odd_y_newE->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()+ sigma_ye*sigma_ye));
-                if (eta_rh>0){
-                    GEMCSC_Pool_gem_odd_x_newE_mp->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()+ sigma_xe*sigma_xe ));
-                    GEMCSC_Pool_gem_odd_y_newE_mp->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()+ sigma_ye*sigma_ye));
-                }
-                if (eta_rh<0){
-                    GEMCSC_Pool_gem_odd_x_newE_mm->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()+ sigma_xe*sigma_xe ));
-                    GEMCSC_Pool_gem_odd_y_newE_mm->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()+ sigma_ye*sigma_ye));
-                }
-            }
-            else {
-              GEMCSC_Residuals_gem_even_x->Fill(gemrhLP.x()-extSegm.x());
-              GEMCSC_Residuals_gem_even_y->Fill(gemrhLP.y()-extSegm.y());
-              GEMCSC_Pool_gem_even_x->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()));
-              GEMCSC_Pool_gem_even_y->Fill((gemrhLP.y()-extSegm.y())/sqrt(gemrhLEP.yy()));
-              
-            }
+      if (chamber % 2 != 0) {
+        GEMCSC_Residuals_gem_odd_x->Fill(gemrhLP.x() - extSegm.x());
+        GEMCSC_Residuals_gem_odd_y->Fill(gemrhLP.y() - extSegm.y());
+        GEMCSC_Pool_gem_odd_x->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx()));
+        GEMCSC_Pool_gem_odd_y->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy()));
+        GEMCSC_Pool_gem_odd_x_newE->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx() + sigma_xe * sigma_xe));
+        GEMCSC_Pool_gem_odd_y_newE->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy() + sigma_ye * sigma_ye));
+        if (eta_rh > 0) {
+          GEMCSC_Pool_gem_odd_x_newE_mp->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx() + sigma_xe * sigma_xe));
+          GEMCSC_Pool_gem_odd_y_newE_mp->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy() + sigma_ye * sigma_ye));
+        }
+        if (eta_rh < 0) {
+          GEMCSC_Pool_gem_odd_x_newE_mm->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx() + sigma_xe * sigma_xe));
+          GEMCSC_Pool_gem_odd_y_newE_mm->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy() + sigma_ye * sigma_ye));
+        }
+      } else {
+        GEMCSC_Residuals_gem_even_x->Fill(gemrhLP.x() - extSegm.x());
+        GEMCSC_Residuals_gem_even_y->Fill(gemrhLP.y() - extSegm.y());
+        GEMCSC_Pool_gem_even_x->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx()));
+        GEMCSC_Pool_gem_even_y->Fill((gemrhLP.y() - extSegm.y()) / sqrt(gemrhLEP.yy()));
+      }
 
-            switch (gemrhId.layer()){
-              case 1:
-                  GEMCSC_Residuals_geml1_x->Fill(gemrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_geml1_y->Fill(gemrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_geml1_x->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()));
-                  GEMCSC_Pool_geml1_y->Fill((gemrhLP.x()-extSegm.y())/sqrt(gemrhLEP.yy()));
-                  break;
-              case 2:
-                  GEMCSC_Residuals_geml2_x->Fill(gemrhLP.x()-extSegm.x());
-                  GEMCSC_Residuals_geml2_y->Fill(gemrhLP.y()-extSegm.y());
-                  GEMCSC_Pool_geml2_x->Fill((gemrhLP.x()-extSegm.x())/sqrt(gemrhLEP.xx()));
-                  GEMCSC_Pool_geml2_y->Fill((gemrhLP.x()-extSegm.y())/sqrt(gemrhLEP.yy()));
-                  break;
-              default:
-                  std::cout <<" Unphysical GEMCSC layer "<<gemrhId<<std::endl;
-                }
-            
-                    float xe_csc  = cscsegLP.x()+cscsegLD.x()*gemrhLP_inSegmRef.z()/cscsegLD.z();
-                    float ye_csc  = cscsegLP.y()+cscsegLD.y()*gemrhLP_inSegmRef.z()/cscsegLD.z();
-                    float ze_csc = gemrhLP_inSegmRef.z();
-                    LocalPoint extrPoint_csc(xe_csc,ye_csc,ze_csc); // in segment rest frame
-                    float sigma_xe_csc = sqrt(cscsegLEP.xx()+cscsegLED.xx()*gemrhLP_inSegmRef.z()*gemrhLP_inSegmRef.z());
-                    float sigma_ye_csc = sqrt(cscsegLEP.yy()+cscsegLED.yy()*gemrhLP_inSegmRef.z()*gemrhLP_inSegmRef.z());
-                    auto extrPoinGP_csc_fromSegmRef = cscChamber->toGlobal(extrPoint_csc);
-                    float phi_ext_csc = extrPoinGP_csc_fromSegmRef.phi();
-                    float theta_ext_csc = extrPoinGP_csc_fromSegmRef.theta();
-            
-                    //auto extSegm_csc = gemrhRef->toLocal(cscChamber->toGlobal(extrPoint_csc)); // in layer restframe
-                    
-                    GEMCSC_Dphi_cscS_min_afterCut->Fill((phi_ext_csc-phi_rh));
-                    GEMCSC_Dtheta_cscS_min_afterCut->Fill((theta_ext_csc-theta_rh));
-                    GEMCSC_DR_cscS_min_afterCut->Fill((theta_ext_csc-theta_rh)*(theta_ext_csc-theta_rh)+(phi_ext_csc-phi_rh)*(phi_ext_csc-phi_rh));
-            if(chamber%2!=0){GEMCSC_Dphi_cscS_min_afterCut_odd->Fill((phi_ext_csc-phi_rh));
-                GEMCSC_Dtheta_cscS_min_afterCut_odd->Fill((theta_ext_csc-theta_rh));
-                switch (gemrhId.roll()){
-                    case 1: GEMCSC_Dphi_cscS_min_afterCut_odd_r1->Fill((phi_ext_csc-phi_rh)); break;
-                    case 2: GEMCSC_Dphi_cscS_min_afterCut_odd_r2->Fill((phi_ext_csc-phi_rh)); break;
-                    case 3: GEMCSC_Dphi_cscS_min_afterCut_odd_r3->Fill((phi_ext_csc-phi_rh)); break;
-                    case 4: GEMCSC_Dphi_cscS_min_afterCut_odd_r4->Fill((phi_ext_csc-phi_rh)); break;
-                    case 5: GEMCSC_Dphi_cscS_min_afterCut_odd_r5->Fill((phi_ext_csc-phi_rh)); break;
-                    case 6: GEMCSC_Dphi_cscS_min_afterCut_odd_r6->Fill((phi_ext_csc-phi_rh)); break;
-                    case 7: GEMCSC_Dphi_cscS_min_afterCut_odd_r7->Fill((phi_ext_csc-phi_rh)); break;
-                    case 8: GEMCSC_Dphi_cscS_min_afterCut_odd_r8->Fill((phi_ext_csc-phi_rh)); break;
-                    default:
-                    std::cout <<" Unphysical GEM roll "<<gemrhId<<std::endl;
-                }
-            }
-            else {
-                GEMCSC_Dtheta_cscS_min_afterCut_even->Fill((theta_ext_csc-theta_rh));
-                GEMCSC_Dphi_cscS_min_afterCut_even->Fill((phi_ext_csc-phi_rh));}
-            
-                    switch (gemrhId.layer()){
-                        case 1:
-                            GEMCSC_CSCSegm_xe_l1->Fill(xe_csc);
-                            GEMCSC_CSCSegm_ye_l1->Fill(ye_csc);
-                            GEMCSC_CSCSegm_ze_l1->Fill(ze_csc);
-                            GEMCSC_CSCSegm_sigmaxe_l1->Fill(sigma_xe_csc);
-                            GEMCSC_CSCSegm_sigmaye_l1->Fill(sigma_ye_csc);
-                            GEMCSC_Dphi_cscS_min_afterCut_l1->Fill((phi_ext_csc-phi_rh));
-                            if(chamber%2!=0){GEMCSC_Dphi_cscS_min_afterCut_l1_odd->Fill((phi_ext_csc-phi_rh));
-                                GEMCSC_CSCSegm_xe_l1_odd->Fill(xe_csc);
-                                GEMCSC_CSCSegm_ye_l1_odd->Fill(ye_csc);
-                                GEMCSC_CSCSegm_ze_l1_odd->Fill(ze_csc);
-                                GEMCSC_CSCSegm_sigmaxe_l1_odd->Fill(sigma_xe_csc);
-                                GEMCSC_CSCSegm_sigmaye_l1_odd->Fill(sigma_ye_csc);
-                            }
-                            else{GEMCSC_Dphi_cscS_min_afterCut_l1_even->Fill((phi_ext_csc-phi_rh));
-                                GEMCSC_CSCSegm_xe_l1_even->Fill(xe_csc);
-                                GEMCSC_CSCSegm_ye_l1_even->Fill(ye_csc);
-                                GEMCSC_CSCSegm_ze_l1_even->Fill(ze_csc);
-                                GEMCSC_CSCSegm_sigmaxe_l1_even->Fill(sigma_xe_csc);
-                                GEMCSC_CSCSegm_sigmaye_l1_even->Fill(sigma_ye_csc);
-                            }
-                            
-                            break;
-                        case 2:
-                            GEMCSC_CSCSegm_xe_l2->Fill(xe_csc);
-                            GEMCSC_CSCSegm_ye_l2->Fill(ye_csc);
-                            GEMCSC_CSCSegm_ze_l2->Fill(ze_csc);
-                            GEMCSC_CSCSegm_sigmaxe_l2->Fill(sigma_xe_csc);
-                            GEMCSC_CSCSegm_sigmaye_l2->Fill(sigma_ye_csc);
+      switch (gemrhId.layer()) {
+        case 1:
+          GEMCSC_Residuals_geml1_x->Fill(gemrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_geml1_y->Fill(gemrhLP.y() - extSegm.y());
+          GEMCSC_Pool_geml1_x->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx()));
+          GEMCSC_Pool_geml1_y->Fill((gemrhLP.x() - extSegm.y()) / sqrt(gemrhLEP.yy()));
+          break;
+        case 2:
+          GEMCSC_Residuals_geml2_x->Fill(gemrhLP.x() - extSegm.x());
+          GEMCSC_Residuals_geml2_y->Fill(gemrhLP.y() - extSegm.y());
+          GEMCSC_Pool_geml2_x->Fill((gemrhLP.x() - extSegm.x()) / sqrt(gemrhLEP.xx()));
+          GEMCSC_Pool_geml2_y->Fill((gemrhLP.x() - extSegm.y()) / sqrt(gemrhLEP.yy()));
+          break;
+        default:
+          std::cout << " Unphysical GEMCSC layer " << gemrhId << std::endl;
+      }
 
-                            GEMCSC_Dphi_cscS_min_afterCut_l2->Fill((phi_ext_csc-phi_rh));
-                            if(chamber%2!=0){GEMCSC_Dphi_cscS_min_afterCut_l2_odd->Fill((phi_ext_csc-phi_rh));
-                                GEMCSC_CSCSegm_xe_l2_odd->Fill(xe_csc);
-                                GEMCSC_CSCSegm_ye_l2_odd->Fill(ye_csc);
-                                GEMCSC_CSCSegm_ze_l2_odd->Fill(ze_csc);
-                                GEMCSC_CSCSegm_sigmaxe_l2_odd->Fill(sigma_xe_csc);
-                                GEMCSC_CSCSegm_sigmaye_l2_odd->Fill(sigma_ye_csc);
-                            }
-                            else{GEMCSC_Dphi_cscS_min_afterCut_l2_even->Fill((phi_ext_csc-phi_rh));
-                                GEMCSC_CSCSegm_xe_l2_even->Fill(xe_csc);
-                                GEMCSC_CSCSegm_ye_l2_even->Fill(ye_csc);
-                                GEMCSC_CSCSegm_ze_l2_even->Fill(ze_csc);
-                                GEMCSC_CSCSegm_sigmaxe_l2_even->Fill(sigma_xe_csc);
-                                GEMCSC_CSCSegm_sigmaye_l2_even->Fill(sigma_ye_csc);
-                            }
+      float xe_csc = cscsegLP.x() + cscsegLD.x() * gemrhLP_inSegmRef.z() / cscsegLD.z();
+      float ye_csc = cscsegLP.y() + cscsegLD.y() * gemrhLP_inSegmRef.z() / cscsegLD.z();
+      float ze_csc = gemrhLP_inSegmRef.z();
+      LocalPoint extrPoint_csc(xe_csc, ye_csc, ze_csc);  // in segment rest frame
+      float sigma_xe_csc = sqrt(cscsegLEP.xx() + cscsegLED.xx() * gemrhLP_inSegmRef.z() * gemrhLP_inSegmRef.z());
+      float sigma_ye_csc = sqrt(cscsegLEP.yy() + cscsegLED.yy() * gemrhLP_inSegmRef.z() * gemrhLP_inSegmRef.z());
+      auto extrPoinGP_csc_fromSegmRef = cscChamber->toGlobal(extrPoint_csc);
+      float phi_ext_csc = extrPoinGP_csc_fromSegmRef.phi();
+      float theta_ext_csc = extrPoinGP_csc_fromSegmRef.theta();
 
-                            break;
-                        default:
-                            std::cout <<" Unphysical GEMCSC layer "<<gemrhId<<std::endl;
-                    }
+      //auto extSegm_csc = gemrhRef->toLocal(cscChamber->toGlobal(extrPoint_csc)); // in layer restframe
 
-            int Nsimhit=0;
-            edm::PSimHitContainer selGEMSimHit = SimHitMatched(rh, gemGeom, iEvent);
-            
-            for(edm::PSimHitContainer::const_iterator itHit = selGEMSimHit.begin(); itHit != selGEMSimHit.end(); ++itHit){
-                    Nsimhit++;
-                    if(Nsimhit>1)continue;
-                
-                
-                
-                //const GEMEtaPartition* gemshRef  = gemGeom->etaPartition(gemshId);
-                LocalPoint gemshLP = itHit->localPosition();
-                GlobalPoint gemshGP(gemGeom->idToDet(itHit->detUnitId())->surface().toGlobal(gemshLP));
-                //auto gemrhGP = gemrhRef->toGlobal(gemrhLP);
-                auto gemshLP_inSegmRef = cscChamber->toLocal(gemshGP);
-                //auto gemshLEP = itHit->localPositionError();
-                //LocalPoint lp = itHit->entryPoint();
-                //std::cout <<" entry Position x = "<<lp.x()<<" y= "<<lp.y()<<" z= "<<lp.z()<<std::endl;
-                //auto gemshLP_inSegmRef = cscChamber->toLocal(gemshGP);
-                //GlobalPoint hitGP_sim(gemGeom->idToDet(itHit->detUnitId())->surface().toGlobal(lp));
-                float phi_sh = gemshGP.phi();
-                float theta_sh = gemshGP.theta();
-                //float eta_sh = gemshGP.eta();
-                
-                float xe_sh  = gemcscsegLP.x()+gemcscsegLD.x()*gemshLP_inSegmRef.z()/gemcscsegLD.z();
-                float ye_sh  = gemcscsegLP.y()+gemcscsegLD.y()*gemshLP_inSegmRef.z()/gemcscsegLD.z();
-                float ze_sh = gemshLP_inSegmRef.z();
-                LocalPoint extrPoint_sh(xe_sh,ye_sh,ze_sh); // in segment rest frame
-                //float sigma_xe_sh = sqrt (gemcscsegLEP.xx());
-                //float sigma_ye_sh = sqrt (gemcscsegLEP.yy());
-                float sigma_xe_sh = sqrt (gemcscsegLEP.xx()+gemcscsegLED.xx()*gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
-                float sigma_ye_sh = sqrt (gemcscsegLEP.yy()+gemcscsegLED.yy()*gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
-                auto extSegm_sh = gemrhRef->toLocal(cscChamber->toGlobal(extrPoint_sh));
-                auto extrPoinGP_fromSegmRef_sh = cscChamber->toGlobal(extrPoint_sh);
-                float phi_ext_sh = extrPoinGP_fromSegmRef_sh.phi();
-                float theta_ext_sh = extrPoinGP_fromSegmRef_sh.theta();
-                
-                float dxdz=(gemshLP_inSegmRef.x()-cscsegLP.x())/gemshLP_inSegmRef.z();
-                float dydz=(gemshLP_inSegmRef.y()-cscsegLP.y())/gemshLP_inSegmRef.z();
-                float sigma_dxdz=cscsegLEP.xx()/(gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
-                float sigma_dydz=cscsegLEP.yy()/(gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
-                SIMGEMCSC_SSegm_LDx->Fill(dxdz);
-                SIMGEMCSC_SSegm_LDy->Fill(dydz);
-                SIMGEMCSC_SSegm_LDEx->Fill(sigma_dxdz);
-                SIMGEMCSC_SSegm_LDEy->Fill(sigma_dydz);
-                
-                float xe_csc_sh  = cscsegLP.x()+cscsegLD.x()*gemshLP_inSegmRef.z()/cscsegLD.z();
-                float ye_csc_sh  = cscsegLP.y()+cscsegLD.y()*gemshLP_inSegmRef.z()/cscsegLD.z();
-                float ze_csc_sh = gemshLP_inSegmRef.z();
-                LocalPoint extrPoint_csc_sh(xe_csc_sh,ye_csc_sh,ze_csc_sh); // in segment rest frame
-                //float sigma_xe_csc_sh = sqrt(cscsegLEP.xx()+cscsegLED.xx()*gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
-                //float sigma_ye_csc_sh = sqrt(cscsegLEP.yy()+cscsegLED.yy()*gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
-                auto extrPoinGP_csc_fromSegmRef_sh = cscChamber->toGlobal(extrPoint_csc_sh);
-                float phi_ext_csc_sh = extrPoinGP_csc_fromSegmRef_sh.phi();
-                float theta_ext_csc_sh = extrPoinGP_csc_fromSegmRef_sh.theta();
+      GEMCSC_Dphi_cscS_min_afterCut->Fill((phi_ext_csc - phi_rh));
+      GEMCSC_Dtheta_cscS_min_afterCut->Fill((theta_ext_csc - theta_rh));
+      GEMCSC_DR_cscS_min_afterCut->Fill((theta_ext_csc - theta_rh) * (theta_ext_csc - theta_rh) +
+                                        (phi_ext_csc - phi_rh) * (phi_ext_csc - phi_rh));
+      if (chamber % 2 != 0) {
+        GEMCSC_Dphi_cscS_min_afterCut_odd->Fill((phi_ext_csc - phi_rh));
+        GEMCSC_Dtheta_cscS_min_afterCut_odd->Fill((theta_ext_csc - theta_rh));
+        switch (gemrhId.roll()) {
+          case 1:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r1->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 2:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r2->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 3:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r3->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 4:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r4->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 5:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r5->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 6:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r6->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 7:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r7->Fill((phi_ext_csc - phi_rh));
+            break;
+          case 8:
+            GEMCSC_Dphi_cscS_min_afterCut_odd_r8->Fill((phi_ext_csc - phi_rh));
+            break;
+          default:
+            std::cout << " Unphysical GEM roll " << gemrhId << std::endl;
+        }
+      } else {
+        GEMCSC_Dtheta_cscS_min_afterCut_even->Fill((theta_ext_csc - theta_rh));
+        GEMCSC_Dphi_cscS_min_afterCut_even->Fill((phi_ext_csc - phi_rh));
+      }
 
-                SIMGEMCSC_Dphi_cscS_min_afterCut->Fill((phi_ext_csc_sh-phi_sh));
-                SIMGEMCSC_Dtheta_cscS_min_afterCut->Fill((theta_ext_csc_sh-theta_sh));
-                SIMGEMCSC_Dphi_SS_min_afterCut->Fill((phi_ext_sh-phi_sh));
-                SIMGEMCSC_Dtheta_SS_min_afterCut->Fill((theta_ext_sh-theta_sh));
-                
-                SIMGEMCSC_Residuals_gem_x->Fill(gemshLP.x()-extSegm_sh.x());
-                SIMGEMCSC_Residuals_gem_y->Fill(gemshLP.y()-extSegm_sh.y());
-                SIMGEMCSC_Pool_gem_x_newE->Fill((gemshLP.x()-extSegm_sh.x())/sqrt(sigma_xe_sh*sigma_xe_sh ));
-                SIMGEMCSC_Pool_gem_y_newE->Fill((gemshLP.y()-extSegm_sh.y())/sqrt(sigma_ye_sh*sigma_ye_sh));
-                
-                SIMGEMCSC_Residuals_gem_rhsh_x->Fill(gemshLP.x()-gemrhLP.x());
-                SIMGEMCSC_Residuals_gem_rhsh_y->Fill(gemshLP.y()-gemrhLP.y());
-                SIMGEMCSC_Pool_gem_rhsh_x_newE->Fill((gemshLP.x()-gemrhLP.x())/sqrt(gemrhLEP.xx()));
-                SIMGEMCSC_Pool_gem_rhsh_y_newE->Fill((gemshLP.y()-gemrhLP.y())/sqrt(gemrhLEP.yy()));
-                
-                if(chamber%2!=0){
-                    SIMGEMCSC_Residuals_gem_odd_x->Fill(gemshLP.x()-extSegm_sh.x());
-                    SIMGEMCSC_Residuals_gem_odd_y->Fill(gemshLP.y()-extSegm_sh.y());
-                    SIMGEMCSC_Pool_gem_x_newE_odd->Fill((gemshLP.x()-extSegm_sh.x())/sqrt(sigma_xe_sh*sigma_xe_sh ));
-                    SIMGEMCSC_Pool_gem_y_newE_odd->Fill((gemshLP.y()-extSegm_sh.y())/sqrt(sigma_ye_sh*sigma_ye_sh));
-                    SIMGEMCSC_Dphi_cscS_min_afterCut_odd->Fill((phi_ext_csc_sh-phi_sh));
-                    SIMGEMCSC_Dtheta_cscS_min_afterCut_odd->Fill((theta_ext_csc_sh-theta_sh));
-                    SIMGEMCSC_Dphi_SS_min_afterCut_odd->Fill((phi_ext_sh-phi_sh));
-                    SIMGEMCSC_Dtheta_SS_min_afterCut_odd->Fill((theta_ext_sh-theta_sh));
-                    SIMGEMCSC_theta_cscSsh_vs_ndof_odd->Fill((theta_ext_csc_sh-theta_sh),cscSeg.degreesOfFreedom());
-                    
-                }
-                else{
-                    SIMGEMCSC_Residuals_gem_even_x->Fill(gemshLP.x()-extSegm_sh.x());
-                    SIMGEMCSC_Residuals_gem_even_y->Fill(gemshLP.y()-extSegm_sh.y());
-                    SIMGEMCSC_Pool_gem_x_newE_even->Fill((gemshLP.x()-extSegm_sh.x())/sqrt(sigma_xe_sh*sigma_xe_sh ));
-                    SIMGEMCSC_Pool_gem_y_newE_even->Fill((gemshLP.y()-extSegm_sh.y())/sqrt(sigma_ye_sh*sigma_ye_sh));
-                    SIMGEMCSC_Dphi_cscS_min_afterCut_even->Fill((phi_ext_csc_sh-phi_sh));
-                    SIMGEMCSC_Dtheta_cscS_min_afterCut_even->Fill((theta_ext_csc_sh-theta_sh));
-                    SIMGEMCSC_Dphi_SS_min_afterCut_even->Fill((phi_ext_sh-phi_sh));
-                    SIMGEMCSC_Dtheta_SS_min_afterCut_even->Fill((theta_ext_sh-theta_sh));
-                    SIMGEMCSC_theta_cscSsh_vs_ndof_even->Fill((theta_ext_csc_sh-theta_sh),cscSeg.degreesOfFreedom());
-                }
-                
-            }// fine loop sim hit compatibili
+      switch (gemrhId.layer()) {
+        case 1:
+          GEMCSC_CSCSegm_xe_l1->Fill(xe_csc);
+          GEMCSC_CSCSegm_ye_l1->Fill(ye_csc);
+          GEMCSC_CSCSegm_ze_l1->Fill(ze_csc);
+          GEMCSC_CSCSegm_sigmaxe_l1->Fill(sigma_xe_csc);
+          GEMCSC_CSCSegm_sigmaye_l1->Fill(sigma_ye_csc);
+          GEMCSC_Dphi_cscS_min_afterCut_l1->Fill((phi_ext_csc - phi_rh));
+          if (chamber % 2 != 0) {
+            GEMCSC_Dphi_cscS_min_afterCut_l1_odd->Fill((phi_ext_csc - phi_rh));
+            GEMCSC_CSCSegm_xe_l1_odd->Fill(xe_csc);
+            GEMCSC_CSCSegm_ye_l1_odd->Fill(ye_csc);
+            GEMCSC_CSCSegm_ze_l1_odd->Fill(ze_csc);
+            GEMCSC_CSCSegm_sigmaxe_l1_odd->Fill(sigma_xe_csc);
+            GEMCSC_CSCSegm_sigmaye_l1_odd->Fill(sigma_ye_csc);
+          } else {
+            GEMCSC_Dphi_cscS_min_afterCut_l1_even->Fill((phi_ext_csc - phi_rh));
+            GEMCSC_CSCSegm_xe_l1_even->Fill(xe_csc);
+            GEMCSC_CSCSegm_ye_l1_even->Fill(ye_csc);
+            GEMCSC_CSCSegm_ze_l1_even->Fill(ze_csc);
+            GEMCSC_CSCSegm_sigmaxe_l1_even->Fill(sigma_xe_csc);
+            GEMCSC_CSCSegm_sigmaye_l1_even->Fill(sigma_ye_csc);
+          }
 
-        }// fine loop gem rh
-        
-    
-        
-        
-        
-        
-        
-        
-        
-        
-        /////////////////////////////////////////////
-        auto gemcscrhs = gemcscs->recHits();
-        for (auto rh = gemcscrhs.begin(); rh!= gemcscrhs.end(); rh++){
-	  
-	  // if (rh->geographicalId().subdetId() == MuonSubdetId::CSC){
-	  DetId d = DetId((*rh)->rawId());
-	  if (d.subdetId() == MuonSubdetId::CSC) {
-	    
-	    std::cout<<"CSC found"<<std::endl;
-	    
-	    // CSCDetId id(rh->geographicalId());
-	    CSCDetId id(d);
-	    
-	    //int layer = id.layer();
-	    int station = id.station();
-	    int ring = id.ring();
-	    //int chamber = id.chamber();
-	    //int roll = id.roll();
-	    
-	    std::cout<<"CSC Region"<<" Station "<<station<<" ring "<<ring<<std::endl;
-	    
-	  }
-	  // else if (rh->geographicalId().subdetId() == MuonSubdetId::GEM){
-	  else if (d.subdetId() == MuonSubdetId::GEM) {
-	    // std::cout<<"GEM found"<<std::endl;
-	    
-	    // GEMDetId id(rh->geographicalId());
-	    GEMDetId id(d);
-	    int region = id.region();
-	    int layer = id.layer();
-	    int station = id.station();
-	    int ring = id.ring();
-	    int chamber = id.chamber();
-	    int roll = id.roll();
-	    
-	    std::cout<<"GEM Region"<<region<<" Station "<<station<<" ring "<<ring<<" layer "<<layer<<" chamber "<<chamber<<" roll "<<roll<<std::endl;
-	  }
-	  
-	  
+          break;
+        case 2:
+          GEMCSC_CSCSegm_xe_l2->Fill(xe_csc);
+          GEMCSC_CSCSegm_ye_l2->Fill(ye_csc);
+          GEMCSC_CSCSegm_ze_l2->Fill(ze_csc);
+          GEMCSC_CSCSegm_sigmaxe_l2->Fill(sigma_xe_csc);
+          GEMCSC_CSCSegm_sigmaye_l2->Fill(sigma_ye_csc);
+
+          GEMCSC_Dphi_cscS_min_afterCut_l2->Fill((phi_ext_csc - phi_rh));
+          if (chamber % 2 != 0) {
+            GEMCSC_Dphi_cscS_min_afterCut_l2_odd->Fill((phi_ext_csc - phi_rh));
+            GEMCSC_CSCSegm_xe_l2_odd->Fill(xe_csc);
+            GEMCSC_CSCSegm_ye_l2_odd->Fill(ye_csc);
+            GEMCSC_CSCSegm_ze_l2_odd->Fill(ze_csc);
+            GEMCSC_CSCSegm_sigmaxe_l2_odd->Fill(sigma_xe_csc);
+            GEMCSC_CSCSegm_sigmaye_l2_odd->Fill(sigma_ye_csc);
+          } else {
+            GEMCSC_Dphi_cscS_min_afterCut_l2_even->Fill((phi_ext_csc - phi_rh));
+            GEMCSC_CSCSegm_xe_l2_even->Fill(xe_csc);
+            GEMCSC_CSCSegm_ye_l2_even->Fill(ye_csc);
+            GEMCSC_CSCSegm_ze_l2_even->Fill(ze_csc);
+            GEMCSC_CSCSegm_sigmaxe_l2_even->Fill(sigma_xe_csc);
+            GEMCSC_CSCSegm_sigmaye_l2_even->Fill(sigma_ye_csc);
+          }
+
+          break;
+        default:
+          std::cout << " Unphysical GEMCSC layer " << gemrhId << std::endl;
+      }
+
+      int Nsimhit = 0;
+      edm::PSimHitContainer selGEMSimHit = SimHitMatched(rh, gemGeom, iEvent);
+
+      for (edm::PSimHitContainer::const_iterator itHit = selGEMSimHit.begin(); itHit != selGEMSimHit.end(); ++itHit) {
+        Nsimhit++;
+        if (Nsimhit > 1)
+          continue;
+
+        //const GEMEtaPartition* gemshRef  = gemGeom->etaPartition(gemshId);
+        LocalPoint gemshLP = itHit->localPosition();
+        GlobalPoint gemshGP(gemGeom->idToDet(itHit->detUnitId())->surface().toGlobal(gemshLP));
+        //auto gemrhGP = gemrhRef->toGlobal(gemrhLP);
+        auto gemshLP_inSegmRef = cscChamber->toLocal(gemshGP);
+        //auto gemshLEP = itHit->localPositionError();
+        //LocalPoint lp = itHit->entryPoint();
+        //std::cout <<" entry Position x = "<<lp.x()<<" y= "<<lp.y()<<" z= "<<lp.z()<<std::endl;
+        //auto gemshLP_inSegmRef = cscChamber->toLocal(gemshGP);
+        //GlobalPoint hitGP_sim(gemGeom->idToDet(itHit->detUnitId())->surface().toGlobal(lp));
+        float phi_sh = gemshGP.phi();
+        float theta_sh = gemshGP.theta();
+        //float eta_sh = gemshGP.eta();
+
+        float xe_sh = gemcscsegLP.x() + gemcscsegLD.x() * gemshLP_inSegmRef.z() / gemcscsegLD.z();
+        float ye_sh = gemcscsegLP.y() + gemcscsegLD.y() * gemshLP_inSegmRef.z() / gemcscsegLD.z();
+        float ze_sh = gemshLP_inSegmRef.z();
+        LocalPoint extrPoint_sh(xe_sh, ye_sh, ze_sh);  // in segment rest frame
+        //float sigma_xe_sh = sqrt (gemcscsegLEP.xx());
+        //float sigma_ye_sh = sqrt (gemcscsegLEP.yy());
+        float sigma_xe_sh = sqrt(gemcscsegLEP.xx() + gemcscsegLED.xx() * gemshLP_inSegmRef.z() * gemshLP_inSegmRef.z());
+        float sigma_ye_sh = sqrt(gemcscsegLEP.yy() + gemcscsegLED.yy() * gemshLP_inSegmRef.z() * gemshLP_inSegmRef.z());
+        auto extSegm_sh = gemrhRef->toLocal(cscChamber->toGlobal(extrPoint_sh));
+        auto extrPoinGP_fromSegmRef_sh = cscChamber->toGlobal(extrPoint_sh);
+        float phi_ext_sh = extrPoinGP_fromSegmRef_sh.phi();
+        float theta_ext_sh = extrPoinGP_fromSegmRef_sh.theta();
+
+        float dxdz = (gemshLP_inSegmRef.x() - cscsegLP.x()) / gemshLP_inSegmRef.z();
+        float dydz = (gemshLP_inSegmRef.y() - cscsegLP.y()) / gemshLP_inSegmRef.z();
+        float sigma_dxdz = cscsegLEP.xx() / (gemshLP_inSegmRef.z() * gemshLP_inSegmRef.z());
+        float sigma_dydz = cscsegLEP.yy() / (gemshLP_inSegmRef.z() * gemshLP_inSegmRef.z());
+        SIMGEMCSC_SSegm_LDx->Fill(dxdz);
+        SIMGEMCSC_SSegm_LDy->Fill(dydz);
+        SIMGEMCSC_SSegm_LDEx->Fill(sigma_dxdz);
+        SIMGEMCSC_SSegm_LDEy->Fill(sigma_dydz);
+
+        float xe_csc_sh = cscsegLP.x() + cscsegLD.x() * gemshLP_inSegmRef.z() / cscsegLD.z();
+        float ye_csc_sh = cscsegLP.y() + cscsegLD.y() * gemshLP_inSegmRef.z() / cscsegLD.z();
+        float ze_csc_sh = gemshLP_inSegmRef.z();
+        LocalPoint extrPoint_csc_sh(xe_csc_sh, ye_csc_sh, ze_csc_sh);  // in segment rest frame
+        //float sigma_xe_csc_sh = sqrt(cscsegLEP.xx()+cscsegLED.xx()*gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
+        //float sigma_ye_csc_sh = sqrt(cscsegLEP.yy()+cscsegLED.yy()*gemshLP_inSegmRef.z()*gemshLP_inSegmRef.z());
+        auto extrPoinGP_csc_fromSegmRef_sh = cscChamber->toGlobal(extrPoint_csc_sh);
+        float phi_ext_csc_sh = extrPoinGP_csc_fromSegmRef_sh.phi();
+        float theta_ext_csc_sh = extrPoinGP_csc_fromSegmRef_sh.theta();
+
+        SIMGEMCSC_Dphi_cscS_min_afterCut->Fill((phi_ext_csc_sh - phi_sh));
+        SIMGEMCSC_Dtheta_cscS_min_afterCut->Fill((theta_ext_csc_sh - theta_sh));
+        SIMGEMCSC_Dphi_SS_min_afterCut->Fill((phi_ext_sh - phi_sh));
+        SIMGEMCSC_Dtheta_SS_min_afterCut->Fill((theta_ext_sh - theta_sh));
+
+        SIMGEMCSC_Residuals_gem_x->Fill(gemshLP.x() - extSegm_sh.x());
+        SIMGEMCSC_Residuals_gem_y->Fill(gemshLP.y() - extSegm_sh.y());
+        SIMGEMCSC_Pool_gem_x_newE->Fill((gemshLP.x() - extSegm_sh.x()) / sqrt(sigma_xe_sh * sigma_xe_sh));
+        SIMGEMCSC_Pool_gem_y_newE->Fill((gemshLP.y() - extSegm_sh.y()) / sqrt(sigma_ye_sh * sigma_ye_sh));
+
+        SIMGEMCSC_Residuals_gem_rhsh_x->Fill(gemshLP.x() - gemrhLP.x());
+        SIMGEMCSC_Residuals_gem_rhsh_y->Fill(gemshLP.y() - gemrhLP.y());
+        SIMGEMCSC_Pool_gem_rhsh_x_newE->Fill((gemshLP.x() - gemrhLP.x()) / sqrt(gemrhLEP.xx()));
+        SIMGEMCSC_Pool_gem_rhsh_y_newE->Fill((gemshLP.y() - gemrhLP.y()) / sqrt(gemrhLEP.yy()));
+
+        if (chamber % 2 != 0) {
+          SIMGEMCSC_Residuals_gem_odd_x->Fill(gemshLP.x() - extSegm_sh.x());
+          SIMGEMCSC_Residuals_gem_odd_y->Fill(gemshLP.y() - extSegm_sh.y());
+          SIMGEMCSC_Pool_gem_x_newE_odd->Fill((gemshLP.x() - extSegm_sh.x()) / sqrt(sigma_xe_sh * sigma_xe_sh));
+          SIMGEMCSC_Pool_gem_y_newE_odd->Fill((gemshLP.y() - extSegm_sh.y()) / sqrt(sigma_ye_sh * sigma_ye_sh));
+          SIMGEMCSC_Dphi_cscS_min_afterCut_odd->Fill((phi_ext_csc_sh - phi_sh));
+          SIMGEMCSC_Dtheta_cscS_min_afterCut_odd->Fill((theta_ext_csc_sh - theta_sh));
+          SIMGEMCSC_Dphi_SS_min_afterCut_odd->Fill((phi_ext_sh - phi_sh));
+          SIMGEMCSC_Dtheta_SS_min_afterCut_odd->Fill((theta_ext_sh - theta_sh));
+          SIMGEMCSC_theta_cscSsh_vs_ndof_odd->Fill((theta_ext_csc_sh - theta_sh), cscSeg.degreesOfFreedom());
+
+        } else {
+          SIMGEMCSC_Residuals_gem_even_x->Fill(gemshLP.x() - extSegm_sh.x());
+          SIMGEMCSC_Residuals_gem_even_y->Fill(gemshLP.y() - extSegm_sh.y());
+          SIMGEMCSC_Pool_gem_x_newE_even->Fill((gemshLP.x() - extSegm_sh.x()) / sqrt(sigma_xe_sh * sigma_xe_sh));
+          SIMGEMCSC_Pool_gem_y_newE_even->Fill((gemshLP.y() - extSegm_sh.y()) / sqrt(sigma_ye_sh * sigma_ye_sh));
+          SIMGEMCSC_Dphi_cscS_min_afterCut_even->Fill((phi_ext_csc_sh - phi_sh));
+          SIMGEMCSC_Dtheta_cscS_min_afterCut_even->Fill((theta_ext_csc_sh - theta_sh));
+          SIMGEMCSC_Dphi_SS_min_afterCut_even->Fill((phi_ext_sh - phi_sh));
+          SIMGEMCSC_Dtheta_SS_min_afterCut_even->Fill((theta_ext_sh - theta_sh));
+          SIMGEMCSC_theta_cscSsh_vs_ndof_even->Fill((theta_ext_csc_sh - theta_sh), cscSeg.degreesOfFreedom());
         }
 
-      
-        auto gemcscsegGD = cscChamber->toGlobal(gemcscs->localPosition());
-        for (simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack){
-            double simEta = (*simTrack).momentum().eta();
-            double simPhi = (*simTrack).momentum().phi();
-            double dR = sqrt(pow((simEta-gemcscsegGD.eta()),2) + pow((simPhi-gemcscsegGD.phi()),2));
-            if(dR > 0.1) continue;
-  
-        
-        }
-  
-  
-  }// loop gemcsc segments
+      }  // fine loop sim hit compatibili
 
-  std::cout <<"------------------------------------------------------------------------------"<<std::endl;
-  std::cout <<"------------------------------------------------------------------------------"<<std::endl;
-       
+    }  // fine loop gem rh
+
+    /////////////////////////////////////////////
+    auto gemcscrhs = gemcscs->recHits();
+    for (auto rh = gemcscrhs.begin(); rh != gemcscrhs.end(); rh++) {
+      // if (rh->geographicalId().subdetId() == MuonSubdetId::CSC){
+      DetId d = DetId((*rh)->rawId());
+      if (d.subdetId() == MuonSubdetId::CSC) {
+        std::cout << "CSC found" << std::endl;
+
+        // CSCDetId id(rh->geographicalId());
+        CSCDetId id(d);
+
+        //int layer = id.layer();
+        int station = id.station();
+        int ring = id.ring();
+        //int chamber = id.chamber();
+        //int roll = id.roll();
+
+        std::cout << "CSC Region"
+                  << " Station " << station << " ring " << ring << std::endl;
+
+      }
+      // else if (rh->geographicalId().subdetId() == MuonSubdetId::GEM){
+      else if (d.subdetId() == MuonSubdetId::GEM) {
+        // std::cout<<"GEM found"<<std::endl;
+
+        // GEMDetId id(rh->geographicalId());
+        GEMDetId id(d);
+        int region = id.region();
+        int layer = id.layer();
+        int station = id.station();
+        int ring = id.ring();
+        int chamber = id.chamber();
+        int roll = id.roll();
+
+        std::cout << "GEM Region" << region << " Station " << station << " ring " << ring << " layer " << layer
+                  << " chamber " << chamber << " roll " << roll << std::endl;
+      }
+    }
+
+    auto gemcscsegGD = cscChamber->toGlobal(gemcscs->localPosition());
+    for (simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack) {
+      double simEta = (*simTrack).momentum().eta();
+      double simPhi = (*simTrack).momentum().phi();
+      double dR = sqrt(pow((simEta - gemcscsegGD.eta()), 2) + pow((simPhi - gemcscsegGD.phi()), 2));
+      if (dR > 0.1)
+        continue;
+    }
+
+  }  // loop gemcsc segments
+
+  std::cout << "------------------------------------------------------------------------------" << std::endl;
+  std::cout << "------------------------------------------------------------------------------" << std::endl;
 }
 
 //
 // member functions
 //
 
+edm::PSimHitContainer TestGEMCSCSegmentAnalyzer::SimHitMatched(std::vector<GEMRecHit>::const_iterator recHit,
+                                                               edm::ESHandle<GEMGeometry> gemGeom,
+                                                               const Event& iEvent) {
+  edm::PSimHitContainer selectedGEMHits;
 
-edm::PSimHitContainer TestGEMCSCSegmentAnalyzer::SimHitMatched(std::vector<GEMRecHit>::const_iterator recHit, edm::ESHandle<GEMGeometry> gemGeom, const Event & iEvent)
-{
-    
+  GEMDetId id((*recHit).geographicalId());
 
-    edm::PSimHitContainer selectedGEMHits;
+  int region = id.region();
+  int layer = id.layer();
+  int station = id.station();
+  int chamber = id.chamber();
+  int roll = id.roll();
 
-    GEMDetId id((*recHit).geographicalId());
+  int cls = recHit->clusterSize();
+  int firstStrip = recHit->firstClusterStrip();
 
-    
-    int region = id.region();
-    int layer = id.layer();
-    int station = id.station();
-    int chamber = id.chamber();
-    int roll = id.roll();
+  edm::Handle<edm::PSimHitContainer> GEMHits;
+  iEvent.getByToken(GEMSimHit_Token, GEMHits);
+  // edm::Handle<edm::PSimHitContainer> GEMHits;
+  // iEvent.getByLabel(edm::InputTag("g4SimHits","MuonGEMHits"), GEMHits);
 
-    int cls = recHit->clusterSize();
-    int firstStrip = recHit->firstClusterStrip();
+  for (edm::PSimHitContainer::const_iterator itHit = GEMHits->begin(); itHit != GEMHits->end(); ++itHit) {
+    if (!(abs(itHit->particleType()) == 13))
+      continue;
+    GEMDetId idGem = GEMDetId(itHit->detUnitId());
+    int region_sim = idGem.region();
+    int layer_sim = idGem.layer();
+    int station_sim = idGem.station();
+    int chamber_sim = idGem.chamber();
+    int roll_sim = idGem.roll();
 
-    edm::Handle<edm::PSimHitContainer> GEMHits;
-    iEvent.getByToken(GEMSimHit_Token, GEMHits);
-    // edm::Handle<edm::PSimHitContainer> GEMHits;
-    // iEvent.getByLabel(edm::InputTag("g4SimHits","MuonGEMHits"), GEMHits);
-
-    for(edm::PSimHitContainer::const_iterator itHit = GEMHits->begin(); itHit != GEMHits->end(); ++itHit){
-        if (!(abs(itHit->particleType()) == 13)) continue;
-      	GEMDetId idGem = GEMDetId(itHit->detUnitId());
-      	int region_sim = idGem.region();
-      	int layer_sim = idGem.layer();
-      	int station_sim = idGem.station();
-      	int chamber_sim = idGem.chamber();
-      	int roll_sim = idGem.roll();
-        
-      	LocalPoint lp = itHit->entryPoint();
-        // GlobalPoint hitGP_sim(gemGeom->idToDet(itHit->detUnitId())->surface().toGlobal(lp));
-      	float strip_sim = gemGeom->etaPartition(idGem)->strip(lp);
-      	if(region != region_sim) continue;
-      	if(layer != layer_sim) continue;
-      	if(station != station_sim) continue;
-      	if(chamber != chamber_sim) continue;
-      	if(roll != roll_sim) continue;
-        for(int i = firstStrip; i < (firstStrip + cls); i++ ){
-            if(abs(strip_sim-i)<1) {selectedGEMHits.push_back(*itHit);}
-        }
-
-        
+    LocalPoint lp = itHit->entryPoint();
+    // GlobalPoint hitGP_sim(gemGeom->idToDet(itHit->detUnitId())->surface().toGlobal(lp));
+    float strip_sim = gemGeom->etaPartition(idGem)->strip(lp);
+    if (region != region_sim)
+      continue;
+    if (layer != layer_sim)
+      continue;
+    if (station != station_sim)
+      continue;
+    if (chamber != chamber_sim)
+      continue;
+    if (roll != roll_sim)
+      continue;
+    for (int i = firstStrip; i < (firstStrip + cls); i++) {
+      if (abs(strip_sim - i) < 1) {
+        selectedGEMHits.push_back(*itHit);
+      }
     }
- 
+  }
 
-    return selectedGEMHits;
-    
+  return selectedGEMHits;
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-TestGEMCSCSegmentAnalyzer::beginJob()
-{
-}
+void TestGEMCSCSegmentAnalyzer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-TestGEMCSCSegmentAnalyzer::endJob() 
-{
-}
+void TestGEMCSCSegmentAnalyzer::endJob() {}
 
 // ------------ method called when starting to processes a run  ------------
-void 
-TestGEMCSCSegmentAnalyzer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
-{
+void TestGEMCSCSegmentAnalyzer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
   //iSetup.get<MuonGeometryRecord>().get(gemGeom);
   //iSetup.get<MuonGeometryRecord>().get(cscGeom);
-
-
-
 }
 
 //define this as a plug-in


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction,upgrade.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/378//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


