### PR TITLE
Running code-format for simulation

### DIFF
--- a/SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h
+++ b/SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h
@@ -9,24 +9,23 @@ namespace cms {
 }
 
 namespace cms {
-class DDDWorld {
+  class DDDWorld {
+  public:
+    DDDWorld(const cms::DDDetector*, dd4hep::sim::Geant4GeometryMaps::VolumeMap&);
+    ~DDDWorld();
+    static void workerSetAsWorld(G4VPhysicalVolume* pv);
+    const G4VPhysicalVolume* getWorldVolume() const { return m_world; }
 
- public:
-  DDDWorld(const cms::DDDetector*, dd4hep::sim::Geant4GeometryMaps::VolumeMap&);
-  ~DDDWorld();
-  static void workerSetAsWorld(G4VPhysicalVolume* pv);
-  const G4VPhysicalVolume* getWorldVolume() const { return m_world; }
-  
-  // In order to share the world volume with the worker threads, we
-  // need a non-const pointer. Thread-safety is handled inside Geant4
-  // with TLS. Should we consider a friend declaration here in order
-  // to avoid misuse?
-  G4VPhysicalVolume* getWorldVolumeForWorker() const { return m_world; }
-  
- private:
-  void setAsWorld(G4VPhysicalVolume* pv);
-  G4VPhysicalVolume* m_world;
-};
-}
+    // In order to share the world volume with the worker threads, we
+    // need a non-const pointer. Thread-safety is handled inside Geant4
+    // with TLS. Should we consider a friend declaration here in order
+    // to avoid misuse?
+    G4VPhysicalVolume* getWorldVolumeForWorker() const { return m_world; }
+
+  private:
+    void setAsWorld(G4VPhysicalVolume* pv);
+    G4VPhysicalVolume* m_world;
+  };
+}  // namespace cms
 
 #endif

--- a/SimG4Core/DD4hepGeometry/src/DD4hep_DDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/src/DD4hep_DDDWorld.cc
@@ -10,58 +10,51 @@
 #include "G4RunManagerKernel.hh"
 #include "G4PVPlacement.hh"
 #include "G4TransportationManager.hh"
- 
+
 using namespace edm;
 using namespace cms;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 
 DDDWorld::DDDWorld(const DDDetector* ddd, dd4hep::sim::Geant4GeometryMaps::VolumeMap& map) {
+  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of DDDWorld...";
 
-  LogVerbatim("SimG4CoreApplication") 
-    << "DD4hep_DDDWorld: initialization of DDDWorld...";
-  
   DetElement world = ddd->description()->world();
-  printout(INFO,"SimDD4CMS",
-	   "+++ DDDWorld::DDDWorld start... %s",
-	   world.name());
+  printout(INFO, "SimDD4CMS", "+++ DDDWorld::DDDWorld start... %s", world.name());
   const Detector& detector = *ddd->description();
   Geant4Converter g4Geo(detector);
   Geant4GeometryInfo* geometry = g4Geo.create(world).detach();
   map = geometry->g4Volumes;
-  
+
   auto it = geometry->g4Volumes.find(detector.worldVolume().ptr());
   LogVerbatim("Geometry") << "The world is " << it->first.name();
-  
+
   if (geometry) {
     LogVerbatim("Geometry").log([&](auto& log) {
-      for(auto iter = map.begin(); iter != map.end(); ++iter) {
+      for (auto iter = map.begin(); iter != map.end(); ++iter) {
         log << iter->first.name() << " = ";
-        if(iter->second)
-	  log << iter->second->GetName() << "; ";
+        if (iter->second)
+          log << iter->second->GetName() << "; ";
         else
-	  log << "***none***; ";
+          log << "***none***; ";
       }
-      log << "\n"; 
+      log << "\n";
     });
   }
   m_world = geometry->world();
 
   setAsWorld(m_world);
-  printout(INFO,"SimDD4CMS",
-	   "+++ DDDWorld::DDDWorld done!");
+  printout(INFO, "SimDD4CMS", "+++ DDDWorld::DDDWorld done!");
 
-  LogVerbatim("SimG4CoreApplication") 
-    << "DD4hep_DDDWorld: initialization of DDDWorld done.";
+  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of DDDWorld done.";
 }
 
 DDDWorld::~DDDWorld() {}
 
-void
-DDDWorld::setAsWorld(G4VPhysicalVolume * pv) {
+void DDDWorld::setAsWorld(G4VPhysicalVolume* pv) {
   G4RunManagerKernel* kernel = G4RunManagerKernel::GetRunManagerKernel();
 
-  if(kernel)
+  if (kernel)
     kernel->DefineWorldVolume(pv);
   else
     edm::LogError("SimG4CoreGeometry") << "cms::DDDWorld::setAsWorld: No G4RunManagerKernel?";
@@ -69,17 +62,15 @@ DDDWorld::setAsWorld(G4VPhysicalVolume * pv) {
   edm::LogInfo("SimG4CoreGeometry") << " World volume defined ";
 }
 
-void
-DDDWorld::workerSetAsWorld(G4VPhysicalVolume * pv) {
+void DDDWorld::workerSetAsWorld(G4VPhysicalVolume* pv) {
   G4RunManagerKernel* kernel = G4RunManagerKernel::GetRunManagerKernel();
-  if(kernel) {
+  if (kernel) {
     kernel->WorkerDefineWorldVolume(pv);
     // The following does not get done in WorkerDefineWorldVolume()
     // because we don't use G4MTRunManager
     G4TransportationManager* transM = G4TransportationManager::GetTransportationManager();
     transM->SetWorldForTracking(pv);
-  }
-  else
+  } else
     edm::LogError("SimG4CoreGeometry") << "cms::DDDWorld::workerSetAsWorld: No G4RunManagerKernel?";
 
   edm::LogInfo("SimG4CoreGeometry") << " World volume defined (for worker) ";

--- a/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
@@ -32,19 +32,19 @@ namespace {
   string_view noNamespace(string_view input) {
     string_view v = input;
     auto first = v.find_first_of(":");
-    v.remove_prefix(min(first+1, v.size()));
+    v.remove_prefix(min(first + 1, v.size()));
     return v;
   }
 
   bool sortByName(const std::pair<G4LogicalVolume*, const DDSpecPar*>& p1,
-		  const std::pair<G4LogicalVolume*, const DDSpecPar*>& p2) {
+                  const std::pair<G4LogicalVolume*, const DDSpecPar*>& p2) {
     bool result = false;
     if (p1.first->GetName() > p2.first->GetName()) {
       result = true;
     }
     return result;
   }
-}
+}  // namespace
 
 class DD4hepTestDDDWorld : public one::EDAnalyzer<> {
 public:
@@ -58,7 +58,7 @@ private:
   void update();
   void initialize(const dd4hep::sim::Geant4GeometryMaps::VolumeMap&);
   G4ProductionCuts* getProductionCuts(G4Region* region);
-  
+
   const ESInputTag tag_;
   const DDSpecParRegistry* specPars_;
   G4MTRunManagerKernel* kernel_;
@@ -71,17 +71,14 @@ private:
 };
 
 DD4hepTestDDDWorld::DD4hepTestDDDWorld(const ParameterSet& iConfig)
-  : tag_(iConfig.getParameter<ESInputTag>("DDDetector"))
-{
+    : tag_(iConfig.getParameter<ESInputTag>("DDDetector")) {
   keywordRegion_ = "CMSCutsRegion";
   protonCut_ = iConfig.getUntrackedParameter<bool>("CutsOnProton", true);
   verbosity_ = iConfig.getUntrackedParameter<int>("Verbosity", 1);
   kernel_ = new G4MTRunManagerKernel();
 }
 
-void
-DD4hepTestDDDWorld::analyze(const Event&, const EventSetup& iEventSetup)
-{
+void DD4hepTestDDDWorld::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "\nDD4hepTestDDDWorld::analyze: " << tag_;
 
   const DDVectorRegistryRcd& regRecord = iEventSetup.get<DDVectorRegistryRcd>();
@@ -105,7 +102,7 @@ DD4hepTestDDDWorld::analyze(const Event&, const EventSetup& iEventSetup)
   g4Geo.debugVolumes = true;
   g4Geo.debugPlacements = true;
   g4Geo.create(detector.world());
-    
+
   dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
   world_.reset(new DDDWorld(ddd.product(), lvMap));
   initialize(lvMap);
@@ -117,29 +114,29 @@ void DD4hepTestDDDWorld::initialize(const dd4hep::sim::Geant4GeometryMaps::Volum
   specPars_->filter(specs_, keywordRegion_);
 
   LogVerbatim("Geometry").log([&](auto& log) {
-    for(auto const& it : vmap) {
-      for(auto const& fit : specs_) {
-        for(auto const& sit : fit->spars) {
-	  log << sit.first << " =  " << sit.second[0] << "\n";
-	}
-	for(auto const& pit : fit->paths) {
-	  log << cms::dd::realTopName(pit) << "\n";
-	  log << "   compare equal to " << noNamespace(it.first.name()) << " ... ";
-	  if(cms::dd::compareEqual(noNamespace(it.first.name()), cms::dd::realTopName(pit))) {
-	    vec_.emplace_back(std::make_pair<G4LogicalVolume*, const cms::DDSpecPar*>(&*it.second, &*fit));
-	    log << "   are equal!\n";
-	  } else
-	    log << "   nope.\n";	
+    for (auto const& it : vmap) {
+      for (auto const& fit : specs_) {
+        for (auto const& sit : fit->spars) {
+          log << sit.first << " =  " << sit.second[0] << "\n";
+        }
+        for (auto const& pit : fit->paths) {
+          log << cms::dd::realTopName(pit) << "\n";
+          log << "   compare equal to " << noNamespace(it.first.name()) << " ... ";
+          if (cms::dd::compareEqual(noNamespace(it.first.name()), cms::dd::realTopName(pit))) {
+            vec_.emplace_back(std::make_pair<G4LogicalVolume*, const cms::DDSpecPar*>(&*it.second, &*fit));
+            log << "   are equal!\n";
+          } else
+            log << "   nope.\n";
         }
       }
     }
   });
-  
+
   // sort all root volumes - to get the same sequence at every run of the application.
   sort(begin(vec_), end(vec_), &sortByName);
-  
+
   // Now generate all the regions
-  for(auto const& it : vec_) {
+  for (auto const& it : vec_) {
     auto regName = it.second->strValue(keywordRegion_.data());
     G4Region* region = G4RegionStore::GetInstance()->FindOrCreateRegion({regName.data(), regName.size()});
     region->AddRootLogicalVolume(it.first);
@@ -151,12 +148,12 @@ void DD4hepTestDDDWorld::initialize(const dd4hep::sim::Geant4GeometryMaps::Volum
 void DD4hepTestDDDWorld::update() {
   LogVerbatim("Geometry").log([&](auto& log) {
     log << "DD4hepTestDDDWorld::update()\n";
-    for(const auto& t: vec_) {
+    for (const auto& t : vec_) {
       log << t.first->GetName() << ":\n";
-      for(const auto& kl : t.second->spars) {
-        log << kl.first << " = "; 
-        for(const auto& kil : kl.second) {
-	  log << kil << ", ";
+      for (const auto& kl : t.second->spars) {
+        log << kl.first << " = ";
+        for (const auto& kil : kl.second) {
+          log << kil << ", ";
         }
       }
       log << "\n";
@@ -164,7 +161,7 @@ void DD4hepTestDDDWorld::update() {
     log << "DD4hepTestDDDWorld::update() done!\n";
   });
   // Loop over all DDLP and provide the cuts for each region
-  for(auto const& it : vec_) {
+  for (auto const& it : vec_) {
     auto regName = it.second->strValue(keywordRegion_.data());
     G4Region* region = G4RegionStore::GetInstance()->FindOrCreateRegion({regName.data(), regName.size()});
 
@@ -174,10 +171,10 @@ void DD4hepTestDDDWorld::update() {
     //
     auto gammacutStr = it.second->strValue("ProdCutsForGamma");
     double gammacut = dd4hep::_toDouble({gammacutStr.data(), gammacutStr.size()});
-    
+
     auto electroncutStr = it.second->strValue("ProdCutsForElectrons");
     double electroncut = dd4hep::_toDouble({electroncutStr.data(), electroncutStr.size()});
-    
+
     auto positroncutStr = it.second->strValue("ProdCutsForPositrons");
     double positroncut = dd4hep::_toDouble({positroncutStr.data(), positroncutStr.size()});
     double protoncut = 0.0;
@@ -196,10 +193,10 @@ void DD4hepTestDDDWorld::update() {
     }
     prodCuts->SetProductionCut(protoncut, idxG4ProtonCut);
     if (verbosity_ > 0) {
-      LogVerbatim("Geometry") << "DDG4ProductionCuts : Setting cuts for " << regName << "\n    Electrons: "
-			      << electroncutStr << " (" << electroncut << ")\n    Positrons: " << positroncutStr
-			      << " (" << positroncut << ")\n    Gamma    : "
-			      << gammacutStr << " (" << gammacut << ")\n";
+      LogVerbatim("Geometry") << "DDG4ProductionCuts : Setting cuts for " << regName
+                              << "\n    Electrons: " << electroncutStr << " (" << electroncut
+                              << ")\n    Positrons: " << positroncutStr << " (" << positroncut
+                              << ")\n    Gamma    : " << gammacutStr << " (" << gammacut << ")\n";
     }
   }
 }

--- a/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestG4Geometry.cc
+++ b/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestG4Geometry.cc
@@ -26,20 +26,16 @@ public:
   void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
 
-private:  
+private:
   const ESInputTag m_tag;
   const string m_detElementPath;
   const string m_placedVolPath;
-
 };
 
 DD4hepTestG4Geometry::DD4hepTestG4Geometry(const ParameterSet& iConfig)
-  : m_tag(iConfig.getParameter<ESInputTag>("DDDetector"))
-{}
+    : m_tag(iConfig.getParameter<ESInputTag>("DDDetector")) {}
 
-void
-DD4hepTestG4Geometry::analyze(const Event&, const EventSetup& iEventSetup)
-{
+void DD4hepTestG4Geometry::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "\nDD4hepTestG4Geometry::analyze: " << m_tag;
 
   const DDVectorRegistryRcd& regRecord = iEventSetup.get<DDVectorRegistryRcd>();
@@ -49,7 +45,7 @@ DD4hepTestG4Geometry::analyze(const Event&, const EventSetup& iEventSetup)
   const GeometryFileRcd& ddRecord = iEventSetup.get<GeometryFileRcd>();
   ESTransientHandle<DDDetector> ddd;
   ddRecord.get(m_tag.module(), ddd);
-    
+
   const dd4hep::Detector& detector = *ddd->description();
   dd4hep::sim::Geant4Converter g4Geo = dd4hep::sim::Geant4Converter(detector);
   g4Geo.debugMaterials = true;
@@ -58,7 +54,7 @@ DD4hepTestG4Geometry::analyze(const Event&, const EventSetup& iEventSetup)
   g4Geo.debugVolumes = true;
   g4Geo.debugPlacements = true;
   g4Geo.create(detector.world());
-  
+
   LogVerbatim("Geometry") << "Done.";
 }
 


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/379//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


