### PR TITLE
Running code-format for alca

### DIFF
--- a/Alignment/TrackerAlignment/interface/AlignableSiStripDet.h
+++ b/Alignment/TrackerAlignment/interface/AlignableSiStripDet.h
@@ -10,7 +10,7 @@
  *  $Date: 2008/07/13 12:26:41 $
  *  $Revision: 1.4 $
  */
- 
+
 #include "Alignment/CommonAlignment/interface/AlignableDet.h"
 
 #include <vector>
@@ -20,21 +20,21 @@ class AlignTransformErrorExtended;
 class Bounds;
 class StripGeomDetType;
 
-class AlignableSiStripDet: public AlignableDet {
- public:
+class AlignableSiStripDet : public AlignableDet {
+public:
   /// Constructor
   AlignableSiStripDet(const GluedGeomDet *geomDet);
   /// reduntantly make destructor virtual
   ~AlignableSiStripDet() override;
 
   /// first consistify with component detunits, then call method from AlignableDet
-  Alignments* alignments() const override;
+  Alignments *alignments() const override;
 
- private:
+private:
   /// make alignments consistent with daughters
   void consistifyAlignments();
 
-//   void dumpCompareEuler(const RotationType &oldRot, const RotationType &newRot) const;
+  //   void dumpCompareEuler(const RotationType &oldRot, const RotationType &newRot) const;
 
   /// The following four members are needed to recalculate the surface in consistifyAlignments,
   /// to get rid of a GluedDet* which is disregarded since it could become an invalid pointer
@@ -42,8 +42,8 @@ class AlignableSiStripDet: public AlignableDet {
   /// types would become invalid together with the GeomDets they are taken from.
   /// StripGeomDetType has neither clone() and nor a decent copy constructor, so I cannot go the
   /// the same way as for the bounds. Sigh!
-  const Bounds     *theMonoBounds;
-  const Bounds     *theStereoBounds;
+  const Bounds *theMonoBounds;
+  const Bounds *theStereoBounds;
   const StripGeomDetType &theMonoType;
   const StripGeomDetType &theStereoType;
 };

--- a/Alignment/TrackerAlignment/interface/AlignableTracker.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTracker.h
@@ -14,146 +14,85 @@
 class TrackerGeometry;
 class TrackerTopology;
 
-
-
 class AlignableTracker : public AlignableComposite {
-
   /// grant access for the tracker-alignables builder
   friend class AlignableTrackerBuilder;
 
 public:
-
   AlignableTracker(const TrackerGeometry*, const TrackerTopology*);
-  ~AlignableTracker() override { /* TODO: delete all tracker-alignables? */ };
+  ~AlignableTracker() override{/* TODO: delete all tracker-alignables? */};
 
   /// Return alignables of subdet and hierarchy level determined by name
   /// as defined in tracker part of Alignment/CommonAlignment/StructureType.h
-  Alignables& subStructures(const std::string &subStructName) {
-    return alignableMap_.find(subStructName);
-  }
+  Alignables& subStructures(const std::string& subStructName) { return alignableMap_.find(subStructName); }
 
   /// Updater using TrackerGeometry and TrackerTopology.
   /// The given geometry and topology have to match the current ones.
   void update(const TrackerGeometry*, const TrackerTopology*);
 
   /// Return TOB half barrels
-  Alignables& outerHalfBarrels() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TOBHalfBarrel));
-  }
+  Alignables& outerHalfBarrels() { return this->subStructures(alignableObjectId_.typeToName(align::TOBHalfBarrel)); }
   /// Return TIB half barrels
-  Alignables& innerHalfBarrels() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIBHalfBarrel));
-  }
+  Alignables& innerHalfBarrels() { return this->subStructures(alignableObjectId_.typeToName(align::TIBHalfBarrel)); }
   /// Return Pixel half barrels
-  Alignables& pixelHalfBarrels() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPBHalfBarrel));
-  }
+  Alignables& pixelHalfBarrels() { return this->subStructures(alignableObjectId_.typeToName(align::TPBHalfBarrel)); }
   /// Return TECs
-  Alignables& endCaps() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TECEndcap));
-  }
+  Alignables& endCaps() { return this->subStructures(alignableObjectId_.typeToName(align::TECEndcap)); }
   /// Return TPEs
-  Alignables& pixelEndCaps() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPEEndcap));
-  }
+  Alignables& pixelEndCaps() { return this->subStructures(alignableObjectId_.typeToName(align::TPEEndcap)); }
   /// Return TIDs
-  Alignables& TIDs() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIDEndcap));
-  }
+  Alignables& TIDs() { return this->subStructures(alignableObjectId_.typeToName(align::TIDEndcap)); }
   /// Return pixel endcap half cylinders
   Alignables& pixelEndcapHalfCylinders() {
     return this->subStructures(alignableObjectId_.typeToName(align::TPEHalfCylinder));
   }
 
-  /// Return inner and outer barrel GeomDets together 
-  Alignables barrelGeomDets() { return this->merge(this->innerBarrelGeomDets(),
-						   this->outerBarrelGeomDets());}
-  /// Return inner barrel and TID GeomDets together 
-  Alignables TIBTIDGeomDets() { return this->merge(this->innerBarrelGeomDets(),
-						   this->TIDGeomDets());
-  }
-  /// Return inner barrel GeomDets 
-  Alignables& innerBarrelGeomDets() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIBModule));
-  }
+  /// Return inner and outer barrel GeomDets together
+  Alignables barrelGeomDets() { return this->merge(this->innerBarrelGeomDets(), this->outerBarrelGeomDets()); }
+  /// Return inner barrel and TID GeomDets together
+  Alignables TIBTIDGeomDets() { return this->merge(this->innerBarrelGeomDets(), this->TIDGeomDets()); }
+  /// Return inner barrel GeomDets
+  Alignables& innerBarrelGeomDets() { return this->subStructures(alignableObjectId_.typeToName(align::TIBModule)); }
   /// Return outer barrel GeomDets
-  Alignables& outerBarrelGeomDets() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TOBModule));
-  }
+  Alignables& outerBarrelGeomDets() { return this->subStructures(alignableObjectId_.typeToName(align::TOBModule)); }
   /// Return pixel barrel GeomDets
-  Alignables& pixelHalfBarrelGeomDets() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPBModule));
-  }
+  Alignables& pixelHalfBarrelGeomDets() { return this->subStructures(alignableObjectId_.typeToName(align::TPBModule)); }
   /// Return endcap  GeomDets
-  Alignables& endcapGeomDets() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TECModule));
-  }
-  /// Return TID  GeomDets  
-  Alignables& TIDGeomDets() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIDModule));
-  }
+  Alignables& endcapGeomDets() { return this->subStructures(alignableObjectId_.typeToName(align::TECModule)); }
+  /// Return TID  GeomDets
+  Alignables& TIDGeomDets() { return this->subStructures(alignableObjectId_.typeToName(align::TIDModule)); }
   /// Return pixel endcap GeomDets
-  Alignables& pixelEndcapGeomDets() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPEModule));
-  }
-  
+  Alignables& pixelEndcapGeomDets() { return this->subStructures(alignableObjectId_.typeToName(align::TPEModule)); }
+
   /// Return inner and outer barrel rods
-  Alignables barrelRods() { return this->merge(this->innerBarrelRods(), this->outerBarrelRods());}
+  Alignables barrelRods() { return this->merge(this->innerBarrelRods(), this->outerBarrelRods()); }
   /// Return inner barrel rods
-  Alignables& innerBarrelRods() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIBString));
-  }
+  Alignables& innerBarrelRods() { return this->subStructures(alignableObjectId_.typeToName(align::TIBString)); }
   /// Return outer barrel rods
-  Alignables& outerBarrelRods() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TOBRod));
-  }
+  Alignables& outerBarrelRods() { return this->subStructures(alignableObjectId_.typeToName(align::TOBRod)); }
   /// Return pixel half barrel ladders (implemented as AlignableRods)
-  Alignables& pixelHalfBarrelLadders() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPBLadder));
-  }
+  Alignables& pixelHalfBarrelLadders() { return this->subStructures(alignableObjectId_.typeToName(align::TPBLadder)); }
   /// Return encap petals
-  Alignables& endcapPetals() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TECPetal));
-  }
+  Alignables& endcapPetals() { return this->subStructures(alignableObjectId_.typeToName(align::TECPetal)); }
   /// Return TID rings
-  Alignables& TIDRings() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIDRing));
-  }
+  Alignables& TIDRings() { return this->subStructures(alignableObjectId_.typeToName(align::TIDRing)); }
   /// Return pixel endcap petals
-  Alignables& pixelEndcapPetals() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPEPanel));
-  }
-		     
+  Alignables& pixelEndcapPetals() { return this->subStructures(alignableObjectId_.typeToName(align::TPEPanel)); }
+
   /// Return inner and outer barrel layers
-  Alignables barrelLayers() { return this->merge(this->innerBarrelLayers(),
-						 this->outerBarrelLayers() );
-  }
+  Alignables barrelLayers() { return this->merge(this->innerBarrelLayers(), this->outerBarrelLayers()); }
   /// Return inner barrel layers
-  Alignables& innerBarrelLayers() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIBLayer));
-  }
+  Alignables& innerBarrelLayers() { return this->subStructures(alignableObjectId_.typeToName(align::TIBLayer)); }
   /// Return outer barrel layers
-  Alignables& outerBarrelLayers() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TOBLayer));
-  }
+  Alignables& outerBarrelLayers() { return this->subStructures(alignableObjectId_.typeToName(align::TOBLayer)); }
   /// Return pixel half barrel layers
-  Alignables& pixelHalfBarrelLayers() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPBLayer));
-  }
+  Alignables& pixelHalfBarrelLayers() { return this->subStructures(alignableObjectId_.typeToName(align::TPBLayer)); }
   /// Return endcap layers
-  Alignables& endcapLayers() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TECDisk));
-  }
+  Alignables& endcapLayers() { return this->subStructures(alignableObjectId_.typeToName(align::TECDisk)); }
   /// Return TID layers
-  Alignables& TIDLayers() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TIDDisk));
-  }
+  Alignables& TIDLayers() { return this->subStructures(alignableObjectId_.typeToName(align::TIDDisk)); }
   /// Return pixel endcap layers
-  Alignables& pixelEndcapLayers() {
-    return this->subStructures(alignableObjectId_.typeToName(align::TPEHalfDisk));
-  }
-
-
+  Alignables& pixelEndcapLayers() { return this->subStructures(alignableObjectId_.typeToName(align::TPEHalfDisk)); }
 
   /// Return alignments, sorted by DetId
   Alignments* alignments() const override;
@@ -162,21 +101,21 @@ public:
   AlignmentErrorsExtended* alignmentErrors() const override;
 
   /// Return tracker topology used to build AlignableTracker
-  const TrackerTopology* trackerTopology() const { return tTopo_;}
+  const TrackerTopology* trackerTopology() const { return tTopo_; }
 
   /// Return tracker name space derived from the tracker's topology
   const align::TrackerNameSpace& trackerNameSpace() const { return trackerNameSpace_; }
 
   /// Return tracker alignable object ID provider derived from the tracker's geometry
   const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
+
 private:
-  Alignables merge( const Alignables& list1, const Alignables& list2 ) const;
+  Alignables merge(const Alignables& list1, const Alignables& list2) const;
 
   const TrackerTopology* tTopo_;
   align::TrackerNameSpace trackerNameSpace_;
   AlignableObjectId alignableObjectId_;
   AlignableMap alignableMap_;
-
 };
 
-#endif //AlignableTracker_H
+#endif  //AlignableTracker_H

--- a/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
@@ -14,70 +14,61 @@
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h"
 
-
-
 class AlignableTrackerBuilder {
   using Alignables = align::Alignables;
 
   //========================== PUBLIC METHODS =================================
-  public: //===================================================================
+public:  //===================================================================
+  AlignableTrackerBuilder(const TrackerGeometry*, const TrackerTopology*);
+  virtual ~AlignableTrackerBuilder() = default;
 
-    AlignableTrackerBuilder(const TrackerGeometry*, const TrackerTopology*);
-    virtual ~AlignableTrackerBuilder() = default;
+  /// Builds all Alignables (units and composites) of the tracker, based on
+  /// the given TrackerGeometry.
+  void buildAlignables(AlignableTracker*, bool update = false);
 
-    /// Builds all Alignables (units and composites) of the tracker, based on
-    /// the given TrackerGeometry.
-    void buildAlignables(AlignableTracker*, bool update = false);
+  /// Return tracker name space derived from the tracker's topology
+  const align::TrackerNameSpace& trackerNameSpace() const { return trackerAlignmentLevelBuilder_.trackerNameSpace(); }
 
-    /// Return tracker name space derived from the tracker's topology
-    const align::TrackerNameSpace& trackerNameSpace() const {
-      return trackerAlignmentLevelBuilder_.trackerNameSpace(); }
-
-
-    /// Return tracker alignable object ID provider  derived from the tracker's geometry
-    const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
+  /// Return tracker alignable object ID provider  derived from the tracker's geometry
+  const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
 
   //========================= PRIVATE METHODS =================================
-  private: //==================================================================
+private:  //==================================================================
+  /// Builds Alignables on module-level for each part of the tracker.
+  void buildAlignableDetUnits(bool update = false);
+  /// Decides whether a GeomDet is from Pixel- or Strip-Detector and calls
+  /// the according method to build the Alignable.
+  void convertGeomDetsToAlignables(const TrackingGeometry::DetContainer&,
+                                   const std::string& moduleName,
+                                   bool update = false);
+  /// Converts GeomDetUnits of PXB and PXE to AlignableDetUnits.
+  void buildPixelDetectorAlignable(
+      const GeomDet*, int subdetId, Alignables& aliDets, Alignables& aliDetUnits, bool update = false);
+  /// Converts GeomDets of TIB, TID, TOB and TEC either to AlignableDetUnits
+  /// or AlignableSiStripDet, depending on the module-type (2D or 1D).
+  void buildStripDetectorAlignable(
+      const GeomDet*, int subdetId, Alignables& aliDets, Alignables& aliDetUnits, bool update = false);
 
-    /// Builds Alignables on module-level for each part of the tracker.
-    void buildAlignableDetUnits(bool update = false);
-    /// Decides whether a GeomDet is from Pixel- or Strip-Detector and calls
-    /// the according method to build the Alignable.
-    void convertGeomDetsToAlignables(const TrackingGeometry::DetContainer&,
-                                     const std::string& moduleName,
-                                     bool update = false);
-    /// Converts GeomDetUnits of PXB and PXE to AlignableDetUnits.
-    void buildPixelDetectorAlignable(const GeomDet*, int subdetId,
-                                     Alignables& aliDets, Alignables& aliDetUnits,
-                                     bool update = false);
-    /// Converts GeomDets of TIB, TID, TOB and TEC either to AlignableDetUnits
-    /// or AlignableSiStripDet, depending on the module-type (2D or 1D).
-    void buildStripDetectorAlignable(const GeomDet*, int subdetId,
-                                     Alignables& aliDets, Alignables& aliDetUnits,
-                                     bool update = false);
-
-    /// Builds all composite Alignables for the tracker. The hierarchy and
-    /// numbers of components are determined in TrackerAlignmentLevelBuilder.
-    void buildAlignableComposites(bool update = false);
-    /// Builds the PixelDetector by hand.
-    void buildPixelDetector(AlignableTracker*);
-    /// Builds the StripDetector by hand.
-    void buildStripDetector(AlignableTracker*);
+  /// Builds all composite Alignables for the tracker. The hierarchy and
+  /// numbers of components are determined in TrackerAlignmentLevelBuilder.
+  void buildAlignableComposites(bool update = false);
+  /// Builds the PixelDetector by hand.
+  void buildPixelDetector(AlignableTracker*);
+  /// Builds the StripDetector by hand.
+  void buildStripDetector(AlignableTracker*);
 
   //========================== PRIVATE DATA ===================================
   //===========================================================================
 
-    const TrackerGeometry* trackerGeometry_;
-    const TrackerTopology* trackerTopology_;
-    const AlignableObjectId alignableObjectId_;
+  const TrackerGeometry* trackerGeometry_;
+  const TrackerTopology* trackerTopology_;
+  const AlignableObjectId alignableObjectId_;
 
-    AlignableMap* alignableMap_;
+  AlignableMap* alignableMap_;
 
-    TrackerAlignmentLevelBuilder trackerAlignmentLevelBuilder_;
+  TrackerAlignmentLevelBuilder trackerAlignmentLevelBuilder_;
 
-    int numDetUnits = 0;
-
+  int numDetUnits = 0;
 };
 
 #endif /* ALIGNMENT_TRACKERALIGNMENT_INTERFACE_ALIGNABLETRACKERBUILDER_H_ */

--- a/Alignment/TrackerAlignment/interface/TrackerAlignableId.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignableId.h
@@ -3,7 +3,7 @@
 
 /// \class TrackerAlignableId
 ///
-/// Helper class to provide unique numerical ID's for Alignables. 
+/// Helper class to provide unique numerical ID's for Alignables.
 /// The unique ID is formed from:
 ///  - the AlignableObjectId (DetUnit, Det, Rod, Layer, etc.)
 ///  - the geographical ID of the first GeomDet in the composite.
@@ -19,19 +19,15 @@
 class DetId;
 class TrackerTopology;
 
-class TrackerAlignableId
-{
-
+class TrackerAlignableId {
 public:
-  
   TrackerAlignableId() {}
 
   /// Return type and layer of DetId
   /// Keep this for now.
   /// Concept of a "layer" in Alignment is obsolete.
   /// Will be replaced by a more generic function.
-  std::pair<int,int> typeAndLayerFromDetId( const DetId& detId, const TrackerTopology* tTopo ) const;
-
+  std::pair<int, int> typeAndLayerFromDetId(const DetId& detId, const TrackerTopology* tTopo) const;
 };
 
 #endif

--- a/Alignment/TrackerAlignment/interface/TrackerAlignableIndexer.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignableIndexer.h
@@ -21,9 +21,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableIndexer.h"
 #include "Alignment/TrackerAlignment/interface/TrackerNameSpace.h"
 
-
-class TrackerAlignableIndexer : public AlignableIndexer
-{
+class TrackerAlignableIndexer : public AlignableIndexer {
 public:
   /// Build the counters map.
   TrackerAlignableIndexer(const align::TrackerNameSpace&);

--- a/Alignment/TrackerAlignment/interface/TrackerAlignment.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignment.h
@@ -12,31 +12,39 @@
 
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 
-class TrackerAlignment
-{
-
+class TrackerAlignment {
 public:
-  TrackerAlignment( const edm::EventSetup& setup );
+  TrackerAlignment(const edm::EventSetup& setup);
 
   ~TrackerAlignment();
-  
+
   AlignableTracker* getAlignableTracker() { return theAlignableTracker; }
-   
-  void moveAlignablePixelEndCaps( int rawId, const align::Scalars& localDisplacements, 
-                                  const align::Scalars& localRotations  );
-  void moveAlignableEndCaps( int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations  );
-  void moveAlignablePixelHalfBarrels( int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations  );
-  void moveAlignableInnerHalfBarrels( int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations  );
-  void moveAlignableOuterHalfBarrels( int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations  );	
-  void moveAlignableTIDs( int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations  );
-  void moveAlignableTIBTIDs( int rawId, const align::Scalars& globalDisplacements, const align::RotationType& backwardRotation, const align::RotationType& forwardRotation, bool toAndFro);
-  
+
+  void moveAlignablePixelEndCaps(int rawId,
+                                 const align::Scalars& localDisplacements,
+                                 const align::Scalars& localRotations);
+  void moveAlignableEndCaps(int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations);
+  void moveAlignablePixelHalfBarrels(int rawId,
+                                     const align::Scalars& localDisplacements,
+                                     const align::Scalars& localRotations);
+  void moveAlignableInnerHalfBarrels(int rawId,
+                                     const align::Scalars& localDisplacements,
+                                     const align::Scalars& localRotations);
+  void moveAlignableOuterHalfBarrels(int rawId,
+                                     const align::Scalars& localDisplacements,
+                                     const align::Scalars& localRotations);
+  void moveAlignableTIDs(int rawId, const align::Scalars& localDisplacements, const align::Scalars& localRotations);
+  void moveAlignableTIBTIDs(int rawId,
+                            const align::Scalars& globalDisplacements,
+                            const align::RotationType& backwardRotation,
+                            const align::RotationType& forwardRotation,
+                            bool toAndFro);
+
   void saveToDB();
-  
-private:  
+
+private:
   AlignableTracker* theAlignableTracker;
 
   std::string theAlignRecordName, theErrorRecordName;
-  
 };
-#endif //TrackerAlignment_H
+#endif  //TrackerAlignment_H

--- a/Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h
@@ -22,85 +22,80 @@ class TrackerTopology;
 class TrackerGeometry;
 
 class TrackerAlignmentLevelBuilder {
-
   //========================== PUBLIC METHODS =================================
-  public: //===================================================================
+public:  //===================================================================
+  TrackerAlignmentLevelBuilder(const TrackerTopology*, const TrackerGeometry*);
+  virtual ~TrackerAlignmentLevelBuilder();
 
-    TrackerAlignmentLevelBuilder(const TrackerTopology*,
-                                 const TrackerGeometry*);
-    virtual ~TrackerAlignmentLevelBuilder();
-
-    void addDetUnitInfo(const DetId& detId);
-    std::vector<align::AlignmentLevels> build();
-    const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
-    const align::TrackerNameSpace& trackerNameSpace() const;
+  void addDetUnitInfo(const DetId& detId);
+  std::vector<align::AlignmentLevels> build();
+  const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
+  const align::TrackerNameSpace& trackerNameSpace() const;
 
   //========================= PRIVATE METHODS =================================
-  private: //==================================================================
+private:  //==================================================================
+  void addPXBDetUnitInfo(const DetId& detId);
+  void addPXEDetUnitInfo(const DetId& detId);
+  void addTIBDetUnitInfo(const DetId& detId);
+  void addTIDDetUnitInfo(const DetId& detId);
+  void addTOBDetUnitInfo(const DetId& detId);
+  void addTECDetUnitInfo(const DetId& detId);
 
-    void addPXBDetUnitInfo(const DetId& detId);
-    void addPXEDetUnitInfo(const DetId& detId);
-    void addTIBDetUnitInfo(const DetId& detId);
-    void addTIDDetUnitInfo(const DetId& detId);
-    void addTOBDetUnitInfo(const DetId& detId);
-    void addTECDetUnitInfo(const DetId& detId);
-
-    align::AlignmentLevels buildPXBAlignmentLevels();
-    align::AlignmentLevels buildPXEAlignmentLevels();
-    align::AlignmentLevels buildTIBAlignmentLevels();
-    align::AlignmentLevels buildTIDAlignmentLevels();
-    align::AlignmentLevels buildTOBAlignmentLevels();
-    align::AlignmentLevels buildTECAlignmentLevels();
+  align::AlignmentLevels buildPXBAlignmentLevels();
+  align::AlignmentLevels buildPXEAlignmentLevels();
+  align::AlignmentLevels buildTIBAlignmentLevels();
+  align::AlignmentLevels buildTIDAlignmentLevels();
+  align::AlignmentLevels buildTOBAlignmentLevels();
+  align::AlignmentLevels buildTECAlignmentLevels();
 
   //========================== PRIVATE DATA ===================================
   //===========================================================================
 
-    const TrackerTopology* trackerTopology_;
-    const AlignableObjectId alignableObjectId_;
-    align::TrackerNameSpace trackerNameSpace_;
-    bool levelsBuilt_{false};
+  const TrackerTopology* trackerTopology_;
+  const AlignableObjectId alignableObjectId_;
+  align::TrackerNameSpace trackerNameSpace_;
+  bool levelsBuilt_{false};
 
-    // PixelBarrel
-    std::set<unsigned int> pxbLayerIDs_;
-    std::set<unsigned int> pxbLadderIDs_;
-    std::set<unsigned int> pxbModuleIDs_;
-    std::map<unsigned int, unsigned int> pxbLaddersPerLayer_;
+  // PixelBarrel
+  std::set<unsigned int> pxbLayerIDs_;
+  std::set<unsigned int> pxbLadderIDs_;
+  std::set<unsigned int> pxbModuleIDs_;
+  std::map<unsigned int, unsigned int> pxbLaddersPerLayer_;
 
-    // PixelEndcap
-    std::set<unsigned int> pxeSideIDs_;
-    std::set<unsigned int> pxeDiskIDs_;
-    std::set<unsigned int> pxeBladeIDs_;
-    std::set<unsigned int> pxePanelIDs_;
-    std::set<unsigned int> pxeModuleIDs_;
+  // PixelEndcap
+  std::set<unsigned int> pxeSideIDs_;
+  std::set<unsigned int> pxeDiskIDs_;
+  std::set<unsigned int> pxeBladeIDs_;
+  std::set<unsigned int> pxePanelIDs_;
+  std::set<unsigned int> pxeModuleIDs_;
 
-    // TIB
-    std::set<unsigned int> tibSideIDs_;
-    std::set<unsigned int> tibLayerIDs_;
-    std::set<unsigned int> tibStringIDs_;
-    std::set<unsigned int> tibModuleIDs_;
-    std::map<unsigned int, unsigned int> pxbStringsPerHalfShell_;
+  // TIB
+  std::set<unsigned int> tibSideIDs_;
+  std::set<unsigned int> tibLayerIDs_;
+  std::set<unsigned int> tibStringIDs_;
+  std::set<unsigned int> tibModuleIDs_;
+  std::map<unsigned int, unsigned int> pxbStringsPerHalfShell_;
 
-    // TID
-    std::set<unsigned int> tidSideIDs_;
-    std::set<unsigned int> tidWheelIDs_;
-    std::set<unsigned int> tidRingIDs_;
-    std::set<unsigned int> tidModuleIDs_;
-    std::map<unsigned int, unsigned int> tidStringsInnerLayer_;
-    std::map<unsigned int, unsigned int> tidStringsOuterLayer_;
+  // TID
+  std::set<unsigned int> tidSideIDs_;
+  std::set<unsigned int> tidWheelIDs_;
+  std::set<unsigned int> tidRingIDs_;
+  std::set<unsigned int> tidModuleIDs_;
+  std::map<unsigned int, unsigned int> tidStringsInnerLayer_;
+  std::map<unsigned int, unsigned int> tidStringsOuterLayer_;
 
-    // TOB
-    std::set<unsigned int> tobLayerIDs_;
-    std::set<unsigned int> tobSideIDs_;
-    std::set<unsigned int> tobRodIDs_;
-    std::set<unsigned int> tobModuleIDs_;
+  // TOB
+  std::set<unsigned int> tobLayerIDs_;
+  std::set<unsigned int> tobSideIDs_;
+  std::set<unsigned int> tobRodIDs_;
+  std::set<unsigned int> tobModuleIDs_;
 
-    // TEC
-    std::set<unsigned int> tecSideIDs_;
-    std::set<unsigned int> tecWheelIDs_;
-    std::set<unsigned int> tecPetalIDs_;
-    std::set<unsigned int> tecRingIDs_;
-    std::set<unsigned int> tecModuleIDs_;
-
+  // TEC
+  std::set<unsigned int> tecSideIDs_;
+  std::set<unsigned int> tecWheelIDs_;
+  std::set<unsigned int> tecPetalIDs_;
+  std::set<unsigned int> tecRingIDs_;
+  std::set<unsigned int> tecModuleIDs_;
 };
 
 #endif /* ALIGNMENT_TRACKERALIGNMENT_INTERFACE_TRACKERALIGNMENTLEVELBUILDER_H_ */

--- a/Alignment/TrackerAlignment/interface/TrackerNameSpace.h
+++ b/Alignment/TrackerAlignment/interface/TrackerNameSpace.h
@@ -3,13 +3,11 @@
 
 #include "CondFormats/Alignment/interface/Definitions.h"
 
-
 class TrackerTopology;
 class TrackerAlignmentLevelBuilder;
 
 namespace align {
   class TrackerNameSpace {
-
     /// grant access for the TrackerAlignmentLevelBuilder (in global namespace)
     friend class ::TrackerAlignmentLevelBuilder;
 
@@ -144,7 +142,6 @@ namespace align {
 
       /// Number of strings for each surface of a half shell.
       std::vector<unsigned int> sphs_;
-
     };
 
     class TOB {
@@ -210,6 +207,7 @@ namespace align {
 
       /// Endcap number is 1 at -z side and 2 at +z side.
       unsigned int endcapNumber(align::ID) const;
+
     private:
       const TrackerTopology* trackerTopology_;
     };
@@ -251,7 +249,6 @@ namespace align {
       const TrackerTopology* trackerTopology_;
     };
 
-
     const TrackerTopology* trackerTopology() const { return trackerTopology_; }
     const TPB& tpb() const { return tpb_; }
     const TPE& tpe() const { return tpe_; }
@@ -269,5 +266,5 @@ namespace align {
     TID tid_;
     TEC tec_;
   };
-};
+};     // namespace align
 #endif /* Alignment_TrackerAlignment_TrackerNameSpace_H */

--- a/Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h
+++ b/Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h
@@ -21,35 +21,30 @@ class AlignableTracker;
 
 /// Builds a scenario from configuration and applies it to the alignable tracker.
 
-class TrackerScenarioBuilder : public MisalignmentScenarioBuilder
-{
-
+class TrackerScenarioBuilder : public MisalignmentScenarioBuilder {
 public:
- 
   /// Constructor
-  explicit TrackerScenarioBuilder( AlignableTracker* alignable );
+  explicit TrackerScenarioBuilder(AlignableTracker* alignable);
 
   /// Destructor
-  ~TrackerScenarioBuilder() override {};
+  ~TrackerScenarioBuilder() override{};
 
   /// Apply misalignment scenario to the tracker
-  void applyScenario( const edm::ParameterSet& scenario ) override;
+  void applyScenario(const edm::ParameterSet& scenario) override;
   /// does this still make sense?
   bool isTopLevel_(const std::string& parameterSetName) const override;
   /// True if hierarchy level 'sub' could be part of hierarchy level 'large'.
-  bool possiblyPartOf(const std::string &sub, const std::string &large) const override;
+  bool possiblyPartOf(const std::string& sub, const std::string& large) const override;
 
 private:
   std::string stripOffModule(const align::StructureType& type) const;
 
- // Members
+  // Members
 
-  AlignableTracker* theAlignableTracker;   ///< Pointer to mother alignable object
+  AlignableTracker* theAlignableTracker;  ///< Pointer to mother alignable object
   /// following things are needed in possiblyPartOf:
-  std::vector<std::string> theSubdets; ///< sub-detector acronyms appearing in StructureType.h (TPE)
-  unsigned int theFirstStripIndex;     ///< index of first strip subdet in 'theSubdets' (pixel<strip)  
-
+  std::vector<std::string> theSubdets;  ///< sub-detector acronyms appearing in StructureType.h (TPE)
+  unsigned int theFirstStripIndex;      ///< index of first strip subdet in 'theSubdets' (pixel<strip)
 };
-
 
 #endif

--- a/Alignment/TrackerAlignment/interface/TrackerTreeVariables.h
+++ b/Alignment/TrackerAlignment/interface/TrackerTreeVariables.h
@@ -1,30 +1,24 @@
 #ifndef TrackerTreeVariables_h
 #define TrackerTreeVariables_h
 
-
 // For ROOT types with '_t':
 #include <Rtypes.h>
 
-
 // container to hold all static module parameters, determined with ideal geometry
-struct TrackerTreeVariables{
-  
-  TrackerTreeVariables(){
-    this->clear();
-  }
-  
-  void clear(){
+struct TrackerTreeVariables {
+  TrackerTreeVariables() { this->clear(); }
+
+  void clear() {
     rawId = subdetId = layer = side = half = rod = ring = petal = blade = panel = outerInner = module = nStrips = 0;
     isDoubleSide = isRPhi = isStereo = false;
     uDirection = vDirection = wDirection = 0;
     posR = posPhi = posEta = posX = posY = posZ = -999.F;
   }
-  
+
   UInt_t rawId, subdetId, layer, side, half, rod, ring, petal, blade, panel, outerInner, module, nStrips;
   Bool_t isDoubleSide, isRPhi, isStereo;
   Int_t uDirection, vDirection, wDirection;
   Float_t posR, posPhi, posEta, posX, posY, posZ;
 };
-
 
 #endif

--- a/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.h
+++ b/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.h
@@ -2,7 +2,7 @@
 #define TrackerAlignment_AlignmentPrescaler_H
 
 #include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EventPrincipal.h" 
+#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -20,28 +20,26 @@
 
 class TrackerTopology;
 
-class AlignmentPrescaler : public edm::EDProducer{
-
- public:
+class AlignmentPrescaler : public edm::EDProducer {
+public:
   AlignmentPrescaler(const edm::ParameterSet &iConfig);
   ~AlignmentPrescaler() override;
   void beginJob() override;
   void endJob() override;
-  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
+  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
- private:
-  edm::InputTag src_;//tracks in input
-  edm::InputTag srcQualityMap_;//Hit-quality association map
+private:
+  edm::InputTag src_;            //tracks in input
+  edm::InputTag srcQualityMap_;  //Hit-quality association map
 
-  std::string prescfilename_;//name of the file containing the TTree with the prescaling factors
-  std::string presctreename_;//name of the  TTree with the prescaling factors
+  std::string prescfilename_;  //name of the file containing the TTree with the prescaling factors
+  std::string presctreename_;  //name of the  TTree with the prescaling factors
 
   TFile *fpresc_;
   TTree *tpresc_;
   TRandom3 *myrand_;
- 
 
-  int layerFromId (const DetId& id, const TrackerTopology* tTopo) const;
+  int layerFromId(const DetId &id, const TrackerTopology *tTopo) const;
 
   unsigned int detid_;
   float hitPrescFactor_, overlapPrescFactor_;

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CosmicTrackTool/CosmicRateAnalyzer
 // Class:      CosmicRateAnalyzer
-// 
+//
 /**\class CosmicRateAnalyzer CosmicRateAnalyzer.cc CosmicTrackTool/CosmicRateAnalyzer/plugins/CosmicRateAnalyzer.cc
 
  Description :
@@ -20,8 +20,6 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 //
 //         Created:  Sat, 30 May 2015 20:14:35 GMT
 //
-
-
 
 // system include files
 #include <memory>
@@ -47,7 +45,7 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "CondFormats/SiStripObjects/interface/SiStripLatency.h"                
+#include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
@@ -72,89 +70,84 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include <iomanip>
 #include <TTree.h>
 
-
 //
 // class declaration
 //
-class CosmicRateAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::SharedResources> {
-   public:
-      explicit CosmicRateAnalyzer(const edm::ParameterSet&);
-      ~CosmicRateAnalyzer() override;
+class CosmicRateAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
+public:
+  explicit CosmicRateAnalyzer(const edm::ParameterSet&);
+  ~CosmicRateAnalyzer() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
 
-      void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      void endRun(edm::Run const&, edm::EventSetup const&) override;
+  static double stampToReal(edm::Timestamp time) { return time.unixTime() + time.microsecondOffset() * 1e-6; }
+  void ClearInEventLoop();
+  void ClearInEndRun();
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<reco::TrackCollection> trackTags_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clustercollectionToken_;
+  edm::EDGetTokenT<reco::MuonCollection> muonTags_;
+  edm::RunNumber_t lastrunnum;
+  double lastruntime;
+  edm::Service<TFileService> fs;
 
-      static double stampToReal(edm::Timestamp time) {
-	return time.unixTime() + time.microsecondOffset()*1e-6;
-      }
-      void ClearInEventLoop();
-      void ClearInEndRun();
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<reco::TrackCollection> trackTags_;
-      edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clustercollectionToken_;
-      edm::EDGetTokenT<reco::MuonCollection> muonTags_;
-      edm::RunNumber_t lastrunnum;
-      double lastruntime;
-      edm::Service<TFileService> fs;
-   
-      unsigned int DetectorID; 
-      TTree* treeEvent;
-      TTree* treeRun;
-      TTree* treeCluster;
+  unsigned int DetectorID;
+  TTree* treeEvent;
+  TTree* treeRun;
+  TTree* treeCluster;
 
-      int			events;
-      int       		track_BPIX  ; 	
-      int       		track_FPIX  ; 	
-      int       		track_PIXEL ; 	
-      int       		track_TEC   ; 	
-      int       		track_TECM  ; 	
-      int       		track_TECP  ; 	
-      int       		track_TOB   ; 	
-      int       		track_TIB   ;     
-      int       		track_TID   ;     
-      int       		track_TIDM  ;     
-      int       		track_TIDP  ; 	
-      
-      std::vector<int>		v_ntrk;
-      int 			ntrk;
-      int			ntrk_runnum;
-   
-      int			number_of_tracks;
-      int			number_of_tracks_PIX;
-      int			number_of_tracks_FPIX;
-      int			number_of_tracks_BPIX;
-      int			number_of_tracks_TEC;
-      int			number_of_tracks_TECP;
-      int			number_of_tracks_TECM;
-      int			number_of_tracks_TOB;
-      int			number_of_tracks_TIB;
-      int			number_of_tracks_TID;
-      int			number_of_tracks_TIDP;
-      int			number_of_tracks_TIDM;
-      int			number_of_events;
-      edm::RunNumber_t		runnum;
-      double                    run_time ;
-      std::vector<double>	pt;
-      std::vector<double>	charge;
-      std::vector<double>	chi2;
-      std::vector<double>	chi2_ndof;
-      std::vector<double>	eta;
-      std::vector<double>	theta;
-      std::vector<double>	phi;
-      std::vector<double>	p;
-      std::vector<double>	d0;
-      std::vector<double>	dz;
-      std::vector<double>	nvh;
-      std::vector<double>	DTtime;
+  int events;
+  int track_BPIX;
+  int track_FPIX;
+  int track_PIXEL;
+  int track_TEC;
+  int track_TECM;
+  int track_TECP;
+  int track_TOB;
+  int track_TIB;
+  int track_TID;
+  int track_TIDM;
+  int track_TIDP;
 
+  std::vector<int> v_ntrk;
+  int ntrk;
+  int ntrk_runnum;
+
+  int number_of_tracks;
+  int number_of_tracks_PIX;
+  int number_of_tracks_FPIX;
+  int number_of_tracks_BPIX;
+  int number_of_tracks_TEC;
+  int number_of_tracks_TECP;
+  int number_of_tracks_TECM;
+  int number_of_tracks_TOB;
+  int number_of_tracks_TIB;
+  int number_of_tracks_TID;
+  int number_of_tracks_TIDP;
+  int number_of_tracks_TIDM;
+  int number_of_events;
+  edm::RunNumber_t runnum;
+  double run_time;
+  std::vector<double> pt;
+  std::vector<double> charge;
+  std::vector<double> chi2;
+  std::vector<double> chi2_ndof;
+  std::vector<double> eta;
+  std::vector<double> theta;
+  std::vector<double> phi;
+  std::vector<double> p;
+  std::vector<double> d0;
+  std::vector<double> dz;
+  std::vector<double> nvh;
+  std::vector<double> DTtime;
 };
 
 //
@@ -168,318 +161,304 @@ class CosmicRateAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::
 //
 // constructors and destructor
 //
-CosmicRateAnalyzer::CosmicRateAnalyzer(const edm::ParameterSet& iConfig):
-  trackTags_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksInputTag"))),
-  clustercollectionToken_(consumes<edmNew::DetSetVector<SiStripCluster> >(iConfig.getParameter<edm::InputTag>("tracksInputTag"))),
-  muonTags_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muonsInputTag")))
-{
-   //now do what ever initialization is needed
-   //
-    usesResource(TFileService::kSharedResource);
-    treeEvent = fs->make<TTree>("Event","");
-    treeRun = fs->make<TTree>("Run","");
-    treeCluster = fs->make<TTree>("Cluster","");
-
+CosmicRateAnalyzer::CosmicRateAnalyzer(const edm::ParameterSet& iConfig)
+    : trackTags_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksInputTag"))),
+      clustercollectionToken_(
+          consumes<edmNew::DetSetVector<SiStripCluster> >(iConfig.getParameter<edm::InputTag>("tracksInputTag"))),
+      muonTags_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muonsInputTag"))) {
+  //now do what ever initialization is needed
+  //
+  usesResource(TFileService::kSharedResource);
+  treeEvent = fs->make<TTree>("Event", "");
+  treeRun = fs->make<TTree>("Run", "");
+  treeCluster = fs->make<TTree>("Cluster", "");
 }
 
-
-CosmicRateAnalyzer::~CosmicRateAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+CosmicRateAnalyzer::~CosmicRateAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 void CosmicRateAnalyzer::ClearInEventLoop() {
-
-      pt	.clear();
-      charge	.clear(); 
-      chi2	.clear();
-      chi2_ndof	.clear();
-      eta	.clear();
-      theta	.clear();
-      phi	.clear();
-      p		.clear();
-      d0	.clear();
-      dz	.clear();
-      nvh	.clear();
-      DTtime	.clear();
-
+  pt.clear();
+  charge.clear();
+  chi2.clear();
+  chi2_ndof.clear();
+  eta.clear();
+  theta.clear();
+  phi.clear();
+  p.clear();
+  d0.clear();
+  dz.clear();
+  nvh.clear();
+  DTtime.clear();
 }
 
 // ------------ method called for each event  ------------
-void
-CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   using reco::TrackCollection;
-   edm::Handle<reco::TrackCollection> tracks;
-   iEvent.getByToken(trackTags_, tracks);
+  using reco::TrackCollection;
+  edm::Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken(trackTags_, tracks);
 
-   edm::ESHandle<MagneticField> magfield;
-   iSetup.get<IdealMagneticFieldRecord>().get(magfield);
+  edm::ESHandle<MagneticField> magfield;
+  iSetup.get<IdealMagneticFieldRecord>().get(magfield);
 
-   edm::ESHandle<TrackerTopology> tTopo;
-   iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo);
 
-   edm::Timestamp ts_begin = iEvent.getRun().beginTime();
-   double t_begin = stampToReal(ts_begin);
-   edm::Timestamp ts_end = iEvent.getRun().endTime();
-   double t_end = stampToReal(ts_end);
+  edm::Timestamp ts_begin = iEvent.getRun().beginTime();
+  double t_begin = stampToReal(ts_begin);
+  edm::Timestamp ts_end = iEvent.getRun().endTime();
+  double t_end = stampToReal(ts_end);
 
-   lastruntime = t_end - t_begin;
-   lastrunnum = iEvent.getRun().run();
+  lastruntime = t_end - t_begin;
+  lastrunnum = iEvent.getRun().run();
 
-   edm::ESHandle<SiStripLatency> apvlat;
-   iSetup.get<SiStripLatencyRcd>().get(apvlat);
+  edm::ESHandle<SiStripLatency> apvlat;
+  iSetup.get<SiStripLatencyRcd>().get(apvlat);
 
-   if (!tracks->empty()) v_ntrk.push_back(tracks->size());
+  if (!tracks->empty())
+    v_ntrk.push_back(tracks->size());
 
-   ntrk	= 0;
-   for(TrackCollection::const_iterator itTrack1 = tracks->begin(); itTrack1 != tracks->end(); ++itTrack1)
-   {
-      pt	.push_back(itTrack1->pt());
-      charge	.push_back(itTrack1->charge());
-      chi2	.push_back(itTrack1->chi2());
-      chi2_ndof	.push_back(itTrack1->normalizedChi2());
-      eta	.push_back(itTrack1->eta());
-      theta	.push_back(itTrack1->theta());
-      phi	.push_back(itTrack1->phi());
-      p		.push_back(itTrack1->p());
-      d0	.push_back(itTrack1->d0());
-      dz	.push_back(itTrack1->dz());
-      nvh	.push_back(itTrack1->numberOfValidHits());
+  ntrk = 0;
+  for (TrackCollection::const_iterator itTrack1 = tracks->begin(); itTrack1 != tracks->end(); ++itTrack1) {
+    pt.push_back(itTrack1->pt());
+    charge.push_back(itTrack1->charge());
+    chi2.push_back(itTrack1->chi2());
+    chi2_ndof.push_back(itTrack1->normalizedChi2());
+    eta.push_back(itTrack1->eta());
+    theta.push_back(itTrack1->theta());
+    phi.push_back(itTrack1->phi());
+    p.push_back(itTrack1->p());
+    d0.push_back(itTrack1->d0());
+    dz.push_back(itTrack1->dz());
+    nvh.push_back(itTrack1->numberOfValidHits());
 
-      int nhitinBPIX  	= 0;
-      int nhitinFPIX  	= 0;
-      int nhitinPIXEL 	= 0;
-      int nhitinTEC 	= 0;
-      int nhitinTOB 	= 0;
-      int nhitinTIB 	= 0;
-      int nhitinTID 	= 0;
-      int nhitinTECminus= 0;
-      int nhitinTECplus = 0;
-      int nhitinTIDminus= 0;
-      int nhitinTIDplus = 0;
-      int countHit 	= 0;
+    int nhitinBPIX = 0;
+    int nhitinFPIX = 0;
+    int nhitinPIXEL = 0;
+    int nhitinTEC = 0;
+    int nhitinTOB = 0;
+    int nhitinTIB = 0;
+    int nhitinTID = 0;
+    int nhitinTECminus = 0;
+    int nhitinTECplus = 0;
+    int nhitinTIDminus = 0;
+    int nhitinTIDplus = 0;
+    int countHit = 0;
 
-      for(auto const& hit1 : itTrack1->recHits())
-      {
+    for (auto const& hit1 : itTrack1->recHits()) {
+      const DetId detId1(hit1->geographicalId());
+      const int subdetId1 = detId1.subdetId();
+      if (!hit1->isValid())
+        continue;  // only real hits count as in itTrack1->numberOfValidHits()
 
-         const DetId detId1(hit1->geographicalId());
-         const int subdetId1 = detId1.subdetId();
-         if (!hit1->isValid()) continue; // only real hits count as in itTrack1->numberOfValidHits()
+      ///////////////////////////////////////////////////////////////////////////////////////////////////
+      // 			 Hit information in PixelBarrel                          		 //
+      ///////////////////////////////////////////////////////////////////////////////////////////////////
+      if (PixelSubdetector::PixelBarrel == subdetId1) {
+        ++nhitinBPIX;
+        ++nhitinPIXEL;
+        PixelBarrelName pxbId1(detId1);
+      }
+      ///////////////////////////////////////////////////////////////////////////////////////////////////
+      //			Hit information in PixelEndcap                                  	//
+      //////////////////////////////////////////////////////////////////////////////////////////////////
+      else if (PixelSubdetector::PixelEndcap == subdetId1) {
+        ++nhitinFPIX;
+        ++nhitinPIXEL;
+      }
+      //////////////////////////////////////////////////////////////////////////////////////////////////
+      //			Hit information in TEC							//
+      //////////////////////////////////////////////////////////////////////////////////////////////////
+      else if (SiStripDetId::TEC == subdetId1) {
+        ++nhitinTEC;
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// 			 Hit information in PixelBarrel                          		 //
-///////////////////////////////////////////////////////////////////////////////////////////////////
-         if (PixelSubdetector::PixelBarrel == subdetId1) 
-         { 
-            ++nhitinBPIX; ++nhitinPIXEL;
-            PixelBarrelName pxbId1(detId1);
-         }
-///////////////////////////////////////////////////////////////////////////////////////////////////
-//			Hit information in PixelEndcap                                  	//
-//////////////////////////////////////////////////////////////////////////////////////////////////
-          else if (PixelSubdetector::PixelEndcap == subdetId1) 
-          { 
-             ++nhitinFPIX; ++nhitinPIXEL;
-          } 
-//////////////////////////////////////////////////////////////////////////////////////////////////
-//			Hit information in TEC							//
-//////////////////////////////////////////////////////////////////////////////////////////////////
-          else if (SiStripDetId::TEC == subdetId1)
-          { 
-             ++nhitinTEC;
- 
-             if (tTopo->tecIsZMinusSide(detId1))
-             {
-                ++nhitinTECminus;
-             }
-             else 
-             {
-                ++nhitinTECplus;
-             }
-          } 
-//////////////////////////////////////////////////////////////////////////////////////////////////
-//			Hit information in TOB		   		                        //
-/////////////////////////////////////////////////////////////////////////////////////////////////
-          else if (SiStripDetId::TOB == subdetId1)
-          {
-             ++nhitinTOB;
-          }
-//////////////////////////////////////////////////////////////////////////////////////////////////
-//			Hit information in TIB		                                	//
-/////////////////////////////////////////////////////////////////////////////////////////////////
-          else if (SiStripDetId::TIB == subdetId1)
-          { 
-             ++nhitinTIB;
-          }
-//////////////////////////////////////////////////////////////////////////////////////////////////
-//			Hit information in TID		                                	//
-/////////////////////////////////////////////////////////////////////////////////////////////////
-          else if (SiStripDetId::TID == subdetId1)
-          { 
-             ++nhitinTID;
+        if (tTopo->tecIsZMinusSide(detId1)) {
+          ++nhitinTECminus;
+        } else {
+          ++nhitinTECplus;
+        }
+      }
+      //////////////////////////////////////////////////////////////////////////////////////////////////
+      //			Hit information in TOB		   		                        //
+      /////////////////////////////////////////////////////////////////////////////////////////////////
+      else if (SiStripDetId::TOB == subdetId1) {
+        ++nhitinTOB;
+      }
+      //////////////////////////////////////////////////////////////////////////////////////////////////
+      //			Hit information in TIB		                                	//
+      /////////////////////////////////////////////////////////////////////////////////////////////////
+      else if (SiStripDetId::TIB == subdetId1) {
+        ++nhitinTIB;
+      }
+      //////////////////////////////////////////////////////////////////////////////////////////////////
+      //			Hit information in TID		                                	//
+      /////////////////////////////////////////////////////////////////////////////////////////////////
+      else if (SiStripDetId::TID == subdetId1) {
+        ++nhitinTID;
 
-             if (tTopo->tidIsZMinusSide(detId1))
-             {
-                ++nhitinTIDminus;
-             }
-             else
-             {
-                ++nhitinTIDplus;
-             }
-          }
+        if (tTopo->tidIsZMinusSide(detId1)) {
+          ++nhitinTIDminus;
+        } else {
+          ++nhitinTIDplus;
+        }
+      }
 
-          countHit++;
-      } // for Loop over Hits
+      countHit++;
+    }  // for Loop over Hits
 
-      if (nhitinBPIX	 > 0 )    	{track_BPIX++	;}     
-      if (nhitinFPIX  	 > 0 )    	{track_FPIX++	;} 
-      if (nhitinPIXEL 	 > 0 )   	{track_PIXEL++	;} 
-      if (nhitinTEC 	 > 0 )    	{track_TEC++	;}
-      if (nhitinTECminus > 0 ) 		{track_TECM++	;} 
-      if (nhitinTECplus	 > 0 )  	{track_TECP++	;}
-      if (nhitinTOB	 > 0 )    	{track_TOB++	;}
-      if (nhitinTIB	 > 0 )    	{track_TIB++	;}
-      if (nhitinTID	 > 0 )    	{track_TID++	;}
-      if (nhitinTIDminus > 0 ) 		{track_TIDM++	;}
-      if (nhitinTIDplus	 > 0 )  	{track_TIDP++	;}
-		
-      ntrk++;
-      ntrk_runnum++;
-   }  // for Loop over TrackCollection
-   events++;		
+    if (nhitinBPIX > 0) {
+      track_BPIX++;
+    }
+    if (nhitinFPIX > 0) {
+      track_FPIX++;
+    }
+    if (nhitinPIXEL > 0) {
+      track_PIXEL++;
+    }
+    if (nhitinTEC > 0) {
+      track_TEC++;
+    }
+    if (nhitinTECminus > 0) {
+      track_TECM++;
+    }
+    if (nhitinTECplus > 0) {
+      track_TECP++;
+    }
+    if (nhitinTOB > 0) {
+      track_TOB++;
+    }
+    if (nhitinTIB > 0) {
+      track_TIB++;
+    }
+    if (nhitinTID > 0) {
+      track_TID++;
+    }
+    if (nhitinTIDminus > 0) {
+      track_TIDM++;
+    }
+    if (nhitinTIDplus > 0) {
+      track_TIDP++;
+    }
 
-   Handle<edmNew::DetSetVector<SiStripCluster> > cluster;
-   iEvent.getByToken(clustercollectionToken_,cluster);
+    ntrk++;
+    ntrk_runnum++;
+  }  // for Loop over TrackCollection
+  events++;
 
-   for(edmNew::DetSetVector<SiStripCluster>::const_iterator det = cluster->begin();det!=cluster->end();++det) 
-   {
-      DetectorID = (det->detId());
-      treeCluster->Fill();
-   }
+  Handle<edmNew::DetSetVector<SiStripCluster> > cluster;
+  iEvent.getByToken(clustercollectionToken_, cluster);
 
-   edm::Handle<reco::MuonCollection> muH;
-   iEvent.getByToken(muonTags_, muH);
-   const reco::MuonCollection& muonsT0 = *(muH.product()); 
-   float time = -9999.;
-   for (unsigned int i=0; i<muonsT0.size(); i++) 
-   {
-      //DT time
-      reco::MuonTime mt0 = muonsT0[i].time();
-      time = mt0.timeAtIpInOut;
-      DTtime.push_back(time);
-   }
-   treeEvent ->Fill();
-   ClearInEventLoop();
+  for (edmNew::DetSetVector<SiStripCluster>::const_iterator det = cluster->begin(); det != cluster->end(); ++det) {
+    DetectorID = (det->detId());
+    treeCluster->Fill();
+  }
 
-}   //Event Loop
+  edm::Handle<reco::MuonCollection> muH;
+  iEvent.getByToken(muonTags_, muH);
+  const reco::MuonCollection& muonsT0 = *(muH.product());
+  float time = -9999.;
+  for (unsigned int i = 0; i < muonsT0.size(); i++) {
+    //DT time
+    reco::MuonTime mt0 = muonsT0[i].time();
+    time = mt0.timeAtIpInOut;
+    DTtime.push_back(time);
+  }
+  treeEvent->Fill();
+  ClearInEventLoop();
+
+}  //Event Loop
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-CosmicRateAnalyzer::beginJob()
-{
-   treeEvent 	->Branch("pt",&pt);
-   treeEvent 	->Branch("charge",&charge);
-   treeEvent 	->Branch("chi2",&chi2);
-   treeEvent 	->Branch("chi2_ndof",&chi2_ndof);
-   treeEvent 	->Branch("eta",&eta);
-   treeEvent 	->Branch("theta",&theta);
-   treeEvent 	->Branch("phi",&phi);
-   treeEvent 	->Branch("p",&p);
-   treeEvent 	->Branch("d0",&d0);
-   treeEvent 	->Branch("dz",&dz);
-   treeEvent 	->Branch("nvh",&nvh);
-   treeEvent	->Branch("ntrk",&ntrk);
-   treeEvent	->Branch("DTtime",&DTtime);
-   treeRun	->Branch("run_time",&run_time);   
-   treeRun	->Branch("runnum",&runnum);   
-   treeRun	->Branch("number_of_events",&number_of_events);
-   treeRun	->Branch("number_of_tracks",&number_of_tracks);
-   treeRun	->Branch("number_of_tracks_PIX",&number_of_tracks_PIX);
-   treeRun	->Branch("number_of_tracks_FPIX",&number_of_tracks_FPIX);
-   treeRun	->Branch("number_of_tracks_BPIX",&number_of_tracks_BPIX);
-   treeRun	->Branch("number_of_tracks_TID",&number_of_tracks_TID);
-   treeRun	->Branch("number_of_tracks_TIDM",&number_of_tracks_TIDM);
-   treeRun	->Branch("number_of_tracks_TIDP",&number_of_tracks_TIDP);
-   treeRun	->Branch("number_of_tracks_TIB",&number_of_tracks_TIB);
-   treeRun	->Branch("number_of_tracks_TEC",&number_of_tracks_TEC);
-   treeRun	->Branch("number_of_tracks_TECP",&number_of_tracks_TECP);
-   treeRun	->Branch("number_of_tracks_TECM",&number_of_tracks_TECM);
-   treeRun	->Branch("number_of_tracks_TOB",&number_of_tracks_TOB);
-   treeCluster	->Branch("DetID",&DetectorID);
-
+void CosmicRateAnalyzer::beginJob() {
+  treeEvent->Branch("pt", &pt);
+  treeEvent->Branch("charge", &charge);
+  treeEvent->Branch("chi2", &chi2);
+  treeEvent->Branch("chi2_ndof", &chi2_ndof);
+  treeEvent->Branch("eta", &eta);
+  treeEvent->Branch("theta", &theta);
+  treeEvent->Branch("phi", &phi);
+  treeEvent->Branch("p", &p);
+  treeEvent->Branch("d0", &d0);
+  treeEvent->Branch("dz", &dz);
+  treeEvent->Branch("nvh", &nvh);
+  treeEvent->Branch("ntrk", &ntrk);
+  treeEvent->Branch("DTtime", &DTtime);
+  treeRun->Branch("run_time", &run_time);
+  treeRun->Branch("runnum", &runnum);
+  treeRun->Branch("number_of_events", &number_of_events);
+  treeRun->Branch("number_of_tracks", &number_of_tracks);
+  treeRun->Branch("number_of_tracks_PIX", &number_of_tracks_PIX);
+  treeRun->Branch("number_of_tracks_FPIX", &number_of_tracks_FPIX);
+  treeRun->Branch("number_of_tracks_BPIX", &number_of_tracks_BPIX);
+  treeRun->Branch("number_of_tracks_TID", &number_of_tracks_TID);
+  treeRun->Branch("number_of_tracks_TIDM", &number_of_tracks_TIDM);
+  treeRun->Branch("number_of_tracks_TIDP", &number_of_tracks_TIDP);
+  treeRun->Branch("number_of_tracks_TIB", &number_of_tracks_TIB);
+  treeRun->Branch("number_of_tracks_TEC", &number_of_tracks_TEC);
+  treeRun->Branch("number_of_tracks_TECP", &number_of_tracks_TECP);
+  treeRun->Branch("number_of_tracks_TECM", &number_of_tracks_TECM);
+  treeRun->Branch("number_of_tracks_TOB", &number_of_tracks_TOB);
+  treeCluster->Branch("DetID", &DetectorID);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-CosmicRateAnalyzer::endJob() 
-{
-}
+void CosmicRateAnalyzer::endJob() {}
 
 // ------------ method called when starting to processes a run  ------------
-void 
-CosmicRateAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-   lastruntime		= 0.0;
-   lastrunnum		= 0.0;
-   ntrk_runnum 		= 0.0;
-   events		= 0.0;
-   track_BPIX           = 0.0;  
-   track_FPIX           = 0.0;
-   track_PIXEL          = 0.0;
-   track_TEC            = 0.0;
-   track_TECM           = 0.0;
-   track_TECP           = 0.0;
-   track_TOB            = 0.0;
-   track_TIB            = 0.0;
-   track_TID            = 0.0;
-   track_TIDM           = 0.0;
-   track_TIDP           = 0.0;
+void CosmicRateAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&) {
+  lastruntime = 0.0;
+  lastrunnum = 0.0;
+  ntrk_runnum = 0.0;
+  events = 0.0;
+  track_BPIX = 0.0;
+  track_FPIX = 0.0;
+  track_PIXEL = 0.0;
+  track_TEC = 0.0;
+  track_TECM = 0.0;
+  track_TECP = 0.0;
+  track_TOB = 0.0;
+  track_TIB = 0.0;
+  track_TID = 0.0;
+  track_TIDM = 0.0;
+  track_TIDP = 0.0;
 }
-
 
 // ------------ method called when ending the processing of a run  ------------
 
-void 
-CosmicRateAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
-{
-   number_of_tracks	=ntrk_runnum;
-   run_time		= lastruntime;
-   runnum		= lastrunnum;
-   number_of_tracks_PIX	= track_PIXEL ; 
-   number_of_tracks_FPIX= track_FPIX ; 
-   number_of_tracks_BPIX= track_BPIX; 
-   number_of_tracks_TEC	= track_TEC  ; 
-   number_of_tracks_TECM= track_TECM ; 
-   number_of_tracks_TECP= track_TECP ; 
-   number_of_tracks_TOB	= track_TOB  ; 
-   number_of_tracks_TIB	= track_TIB  ; 
-   number_of_tracks_TID	= track_TID  ; 
-   number_of_tracks_TIDM= track_TIDM ; 
-   number_of_tracks_TIDP= track_TIDP ; 
-   number_of_events	= events;
-   treeRun  ->Fill();
+void CosmicRateAnalyzer::endRun(edm::Run const&, edm::EventSetup const&) {
+  number_of_tracks = ntrk_runnum;
+  run_time = lastruntime;
+  runnum = lastrunnum;
+  number_of_tracks_PIX = track_PIXEL;
+  number_of_tracks_FPIX = track_FPIX;
+  number_of_tracks_BPIX = track_BPIX;
+  number_of_tracks_TEC = track_TEC;
+  number_of_tracks_TECM = track_TECM;
+  number_of_tracks_TECP = track_TECP;
+  number_of_tracks_TOB = track_TOB;
+  number_of_tracks_TIB = track_TIB;
+  number_of_tracks_TID = track_TID;
+  number_of_tracks_TIDM = track_TIDM;
+  number_of_tracks_TIDP = track_TIDP;
+  number_of_events = events;
+  treeRun->Fill();
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-CosmicRateAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void CosmicRateAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Create tuple with all variables required to calculate cosmic event and track rates.");
-  desc.add<edm::InputTag> ("tracksInputTag",edm::InputTag("ALCARECOTkAlCosmicsCTF0T"));
-  desc.add<edm::InputTag> ("muonsInputTag",edm::InputTag("muons1Leg"));
+  desc.add<edm::InputTag>("tracksInputTag", edm::InputTag("ALCARECOTkAlCosmicsCTF0T"));
+  desc.add<edm::InputTag>("muonsInputTag", edm::InputTag("muons1Leg"));
   descriptions.add("cosmicRateAnalyzer", desc);
 }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CosmicRateAnalyzer);
-

--- a/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
+++ b/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
@@ -25,7 +25,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <iostream>
@@ -67,7 +66,7 @@
 // class declaration
 //
 
-class CreateIdealTkAlRecords : public edm::one::EDAnalyzer<>  {
+class CreateIdealTkAlRecords : public edm::one::EDAnalyzer<> {
 public:
   explicit CreateIdealTkAlRecords(const edm::ParameterSet&);
   ~CreateIdealTkAlRecords() override;
@@ -75,8 +74,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static std::string toString(const GeomDetEnumerators::SubDetector&);
   static GeomDetEnumerators::SubDetector toSubDetector(const std::string& sub);
-  static std::vector<GeomDetEnumerators::SubDetector>
-  toSubDetectors(const std::vector<std::string>& subs);
+  static std::vector<GeomDetEnumerators::SubDetector> toSubDetectors(const std::vector<std::string>& subs);
 
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -98,126 +96,145 @@ private:
   std::vector<GeomDetEnumerators::SubDetector> subDets_;
 };
 
-
 //
 // constructors and destructor
 //
-CreateIdealTkAlRecords::CreateIdealTkAlRecords(const edm::ParameterSet& iConfig) :
-  skipSubDetectors_(toSubDetectors(iConfig.getUntrackedParameter<std::vector<std::string> >("skipSubDetectors"))),
-  alignToGlobalTag_(iConfig.getUntrackedParameter<bool>("alignToGlobalTag")),
-  createReferenceRcd_(iConfig.getUntrackedParameter<bool>("createReferenceRcd")),
-  firstEvent_(true)
-{
-}
+CreateIdealTkAlRecords::CreateIdealTkAlRecords(const edm::ParameterSet& iConfig)
+    : skipSubDetectors_(toSubDetectors(iConfig.getUntrackedParameter<std::vector<std::string> >("skipSubDetectors"))),
+      alignToGlobalTag_(iConfig.getUntrackedParameter<bool>("alignToGlobalTag")),
+      createReferenceRcd_(iConfig.getUntrackedParameter<bool>("createReferenceRcd")),
+      firstEvent_(true) {}
 
-
-CreateIdealTkAlRecords::~CreateIdealTkAlRecords()
-{
-}
-
+CreateIdealTkAlRecords::~CreateIdealTkAlRecords() {}
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-CreateIdealTkAlRecords::analyze(const edm::Event&, const edm::EventSetup& iSetup)
-{
+void CreateIdealTkAlRecords::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
   if (firstEvent_) {
     clearAlignmentInfos();
     const auto tracker = retrieveGeometry(iSetup);
 
     auto dets = tracker->dets();
-    std::sort(dets.begin(), dets.end(),
-              [](const auto& a, const auto& b) {
-                return a->geographicalId().rawId() < b->geographicalId().rawId();});
+    std::sort(dets.begin(), dets.end(), [](const auto& a, const auto& b) {
+      return a->geographicalId().rawId() < b->geographicalId().rawId();
+    });
 
-    for (const auto& det: dets) addAlignmentInfo(*det);
-    if (alignToGlobalTag_ && !createReferenceRcd_) alignToGT(iSetup);
+    for (const auto& det : dets)
+      addAlignmentInfo(*det);
+    if (alignToGlobalTag_ && !createReferenceRcd_)
+      alignToGT(iSetup);
     writeToDB();
     firstEvent_ = false;
   }
 }
 
-
-std::string
-CreateIdealTkAlRecords::toString(const GeomDetEnumerators::SubDetector& sub)
-{
+std::string CreateIdealTkAlRecords::toString(const GeomDetEnumerators::SubDetector& sub) {
   switch (sub) {
-  case GeomDetEnumerators::PixelBarrel: return "PixelBarrel";
-  case GeomDetEnumerators::PixelEndcap: return "PixelEndcap";
-  case GeomDetEnumerators::TIB:         return "TIB";
-  case GeomDetEnumerators::TOB:         return "TOB";
-  case GeomDetEnumerators::TID:         return "TID";
-  case GeomDetEnumerators::TEC:         return "TEC";
-  case GeomDetEnumerators::CSC:         return "CSC";
-  case GeomDetEnumerators::DT:          return "DT";
-  case GeomDetEnumerators::RPCBarrel:   return "RPCBarrel";
-  case GeomDetEnumerators::RPCEndcap:   return "RPCEndcap";
-  case GeomDetEnumerators::GEM:         return "GEM";
-  case GeomDetEnumerators::ME0:         return "ME0";
-  case GeomDetEnumerators::P2OTB:       return "P2OTB";
-  case GeomDetEnumerators::P2OTEC:      return "P2OTEC";
-  case GeomDetEnumerators::P1PXB:       return "P1PXB";
-  case GeomDetEnumerators::P1PXEC:      return "P1PXEC";
-  case GeomDetEnumerators::P2PXB:       return "P2PXB";
-  case GeomDetEnumerators::P2PXEC:      return "P2PXEC";
-  case GeomDetEnumerators::invalidDet:  return "invalidDet";
-  default:
-    throw cms::Exception("UnknownSubdetector");
+    case GeomDetEnumerators::PixelBarrel:
+      return "PixelBarrel";
+    case GeomDetEnumerators::PixelEndcap:
+      return "PixelEndcap";
+    case GeomDetEnumerators::TIB:
+      return "TIB";
+    case GeomDetEnumerators::TOB:
+      return "TOB";
+    case GeomDetEnumerators::TID:
+      return "TID";
+    case GeomDetEnumerators::TEC:
+      return "TEC";
+    case GeomDetEnumerators::CSC:
+      return "CSC";
+    case GeomDetEnumerators::DT:
+      return "DT";
+    case GeomDetEnumerators::RPCBarrel:
+      return "RPCBarrel";
+    case GeomDetEnumerators::RPCEndcap:
+      return "RPCEndcap";
+    case GeomDetEnumerators::GEM:
+      return "GEM";
+    case GeomDetEnumerators::ME0:
+      return "ME0";
+    case GeomDetEnumerators::P2OTB:
+      return "P2OTB";
+    case GeomDetEnumerators::P2OTEC:
+      return "P2OTEC";
+    case GeomDetEnumerators::P1PXB:
+      return "P1PXB";
+    case GeomDetEnumerators::P1PXEC:
+      return "P1PXEC";
+    case GeomDetEnumerators::P2PXB:
+      return "P2PXB";
+    case GeomDetEnumerators::P2PXEC:
+      return "P2PXEC";
+    case GeomDetEnumerators::invalidDet:
+      return "invalidDet";
+    default:
+      throw cms::Exception("UnknownSubdetector");
   }
 }
 
-
-GeomDetEnumerators::SubDetector
-CreateIdealTkAlRecords::toSubDetector(const std::string& sub)
-{
-  if (sub == "PixelBarrel")      return GeomDetEnumerators::PixelBarrel;
-  else if (sub == "PixelEndcap") return GeomDetEnumerators::PixelEndcap;
-  else if (sub == "TIB")         return GeomDetEnumerators::TIB;
-  else if (sub == "TOB")         return GeomDetEnumerators::TOB;
-  else if (sub == "TID")         return GeomDetEnumerators::TID;
-  else if (sub == "TEC")         return GeomDetEnumerators::TEC;
-  else if (sub == "CSC")         return GeomDetEnumerators::CSC;
-  else if (sub == "DT")          return GeomDetEnumerators::DT;
-  else if (sub == "RPCBarrel")   return GeomDetEnumerators::RPCBarrel;
-  else if (sub == "RPCEndcap")   return GeomDetEnumerators::RPCEndcap;
-  else if (sub == "GEM")         return GeomDetEnumerators::GEM;
-  else if (sub == "ME0")         return GeomDetEnumerators::ME0;
-  else if (sub == "P2OTB")       return GeomDetEnumerators::P2OTB;
-  else if (sub == "P2OTEC")      return GeomDetEnumerators::P2OTEC;
-  else if (sub == "P1PXB")       return GeomDetEnumerators::P1PXB;
-  else if (sub == "P1PXEC")      return GeomDetEnumerators::P1PXEC;
-  else if (sub == "P2PXB")       return GeomDetEnumerators::P2PXB;
-  else if (sub == "P2PXEC")      return GeomDetEnumerators::P2PXEC;
-  else if (sub == "invalidDet")  return GeomDetEnumerators::invalidDet;
-  else throw cms::Exception("UnknownSubdetector") << sub;
+GeomDetEnumerators::SubDetector CreateIdealTkAlRecords::toSubDetector(const std::string& sub) {
+  if (sub == "PixelBarrel")
+    return GeomDetEnumerators::PixelBarrel;
+  else if (sub == "PixelEndcap")
+    return GeomDetEnumerators::PixelEndcap;
+  else if (sub == "TIB")
+    return GeomDetEnumerators::TIB;
+  else if (sub == "TOB")
+    return GeomDetEnumerators::TOB;
+  else if (sub == "TID")
+    return GeomDetEnumerators::TID;
+  else if (sub == "TEC")
+    return GeomDetEnumerators::TEC;
+  else if (sub == "CSC")
+    return GeomDetEnumerators::CSC;
+  else if (sub == "DT")
+    return GeomDetEnumerators::DT;
+  else if (sub == "RPCBarrel")
+    return GeomDetEnumerators::RPCBarrel;
+  else if (sub == "RPCEndcap")
+    return GeomDetEnumerators::RPCEndcap;
+  else if (sub == "GEM")
+    return GeomDetEnumerators::GEM;
+  else if (sub == "ME0")
+    return GeomDetEnumerators::ME0;
+  else if (sub == "P2OTB")
+    return GeomDetEnumerators::P2OTB;
+  else if (sub == "P2OTEC")
+    return GeomDetEnumerators::P2OTEC;
+  else if (sub == "P1PXB")
+    return GeomDetEnumerators::P1PXB;
+  else if (sub == "P1PXEC")
+    return GeomDetEnumerators::P1PXEC;
+  else if (sub == "P2PXB")
+    return GeomDetEnumerators::P2PXB;
+  else if (sub == "P2PXEC")
+    return GeomDetEnumerators::P2PXEC;
+  else if (sub == "invalidDet")
+    return GeomDetEnumerators::invalidDet;
+  else
+    throw cms::Exception("UnknownSubdetector") << sub;
 }
 
-
-std::vector<GeomDetEnumerators::SubDetector>
-CreateIdealTkAlRecords::toSubDetectors(const std::vector<std::string>& subs)
-{
+std::vector<GeomDetEnumerators::SubDetector> CreateIdealTkAlRecords::toSubDetectors(
+    const std::vector<std::string>& subs) {
   std::vector<GeomDetEnumerators::SubDetector> result;
-  for (const auto& sub: subs) result.emplace_back(toSubDetector(sub));
+  for (const auto& sub : subs)
+    result.emplace_back(toSubDetector(sub));
   return result;
 }
 
-
-void
-CreateIdealTkAlRecords::clearAlignmentInfos()
-{
+void CreateIdealTkAlRecords::clearAlignmentInfos() {
   alignments_.clear();
   alignmentErrors_.clear();
   alignmentSurfaceDeformations_ = AlignmentSurfaceDeformations{};
   rawIDs_.clear();
 }
 
-
-std::unique_ptr<TrackerGeometry>
-CreateIdealTkAlRecords::retrieveGeometry(const edm::EventSetup& iSetup)
-{
+std::unique_ptr<TrackerGeometry> CreateIdealTkAlRecords::retrieveGeometry(const edm::EventSetup& iSetup) {
   edm::ESHandle<GeometricDet> geometricDet;
   iSetup.get<IdealGeometryRecord>().get(geometricDet);
 
@@ -230,14 +247,10 @@ CreateIdealTkAlRecords::retrieveGeometry(const edm::EventSetup& iSetup)
 
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
 
-  return std::unique_ptr<TrackerGeometry> {
-    trackerBuilder.build(&(*geometricDet), *ptp, tTopo )};
+  return std::unique_ptr<TrackerGeometry>{trackerBuilder.build(&(*geometricDet), *ptp, tTopo)};
 }
 
-
-void
-CreateIdealTkAlRecords::addAlignmentInfo(const GeomDet& det)
-{
+void CreateIdealTkAlRecords::addAlignmentInfo(const GeomDet& det) {
   const auto subDetector = toString(det.subDetector());
   const auto& detId = det.geographicalId().rawId();
   const auto& pos = det.position();
@@ -247,28 +260,23 @@ CreateIdealTkAlRecords::addAlignmentInfo(const GeomDet& det)
 
   // TrackerAlignmentRcd entry
   if (createReferenceRcd_) {
-    alignments_.m_align.emplace_back(AlignTransform(AlignTransform::Translation(),
-                                                    AlignTransform::Rotation(),
-                                                    detId));
+    alignments_.m_align.emplace_back(AlignTransform(AlignTransform::Translation(), AlignTransform::Rotation(), detId));
   } else {
     const AlignTransform::Translation translation(pos.x(), pos.y(), pos.z());
     const AlignTransform::Rotation rotation(
-        CLHEP::HepRep3x3(rot.xx(),rot.xy(),rot.xz(),
-                         rot.yx(),rot.yy(),rot.yz(),
-                         rot.zx(),rot.zy(),rot.zz()));
+        CLHEP::HepRep3x3(rot.xx(), rot.xy(), rot.xz(), rot.yx(), rot.yy(), rot.yz(), rot.zx(), rot.zy(), rot.zz()));
     const auto& eulerAngles = rotation.eulerAngles();
-    LogDebug("Alignment")
-      << "============================================================\n"
-      << "subdetector: " << subDetector << "\n"
-      << "detId:       " << detId << "\n"
-      << "------------------------------------------------------------\n"
-      << "     x: " << pos.x() << "\n"
-      << "     y: " << pos.y() << "\n"
-      << "     z: " << pos.z() << "\n"
-      << "   phi: " << eulerAngles.phi() << "\n"
-      << " theta: " << eulerAngles.theta() << "\n"
-      << "   psi: " << eulerAngles.psi() << "\n"
-      << "============================================================\n";
+    LogDebug("Alignment") << "============================================================\n"
+                          << "subdetector: " << subDetector << "\n"
+                          << "detId:       " << detId << "\n"
+                          << "------------------------------------------------------------\n"
+                          << "     x: " << pos.x() << "\n"
+                          << "     y: " << pos.y() << "\n"
+                          << "     z: " << pos.z() << "\n"
+                          << "   phi: " << eulerAngles.phi() << "\n"
+                          << " theta: " << eulerAngles.theta() << "\n"
+                          << "   psi: " << eulerAngles.psi() << "\n"
+                          << "============================================================\n";
     alignments_.m_align.emplace_back(AlignTransform(translation, rotation, detId));
   }
 
@@ -277,10 +285,7 @@ CreateIdealTkAlRecords::addAlignmentInfo(const GeomDet& det)
   alignmentErrors_.m_alignError.emplace_back(AlignTransformErrorExtended(zeroAPEs, detId));
 }
 
-
-void
-CreateIdealTkAlRecords::alignToGT(const edm::EventSetup& iSetup)
-{
+void CreateIdealTkAlRecords::alignToGT(const edm::EventSetup& iSetup) {
   LogDebug("Alignment") << "Aligning to global tag\n";
 
   edm::ESHandle<Alignments> alignments;
@@ -292,61 +297,51 @@ CreateIdealTkAlRecords::alignToGT(const edm::EventSetup& iSetup)
 
   if (alignments->m_align.size() != alignmentErrors->m_alignError.size())
     throw cms::Exception("GeometryMismatch")
-      << "Size mismatch between alignments (size=" << alignments->m_align.size()
-      << ") and alignment errors (size=" << alignmentErrors->m_alignError.size()
-      << ")";
+        << "Size mismatch between alignments (size=" << alignments->m_align.size()
+        << ") and alignment errors (size=" << alignmentErrors->m_alignError.size() << ")";
 
   std::vector<uint32_t> commonIDs;
   auto itAlignErr = alignmentErrors->m_alignError.cbegin();
-  for (auto itAlign = alignments->m_align.cbegin();
-       itAlign != alignments->m_align.cend();
-       ++itAlign, ++itAlignErr) {
+  for (auto itAlign = alignments->m_align.cbegin(); itAlign != alignments->m_align.cend(); ++itAlign, ++itAlignErr) {
     const auto id = itAlign->rawId();
     auto found = std::find(rawIDs_.cbegin(), rawIDs_.cend(), id);
     if (found != rawIDs_.cend()) {
       if (id != itAlignErr->rawId())
-        throw cms::Exception("GeometryMismatch")
-          << "DetId mismatch between alignments (rawId=" << id
-          << ") and alignment errors (rawId=" << itAlignErr->rawId() << ")";
+        throw cms::Exception("GeometryMismatch") << "DetId mismatch between alignments (rawId=" << id
+                                                 << ") and alignment errors (rawId=" << itAlignErr->rawId() << ")";
 
       const auto index = std::distance(rawIDs_.cbegin(), found);
-      if (std::find(skipSubDetectors_.begin(),
-                    skipSubDetectors_.end(),
-                    subDets_[index]) != skipSubDetectors_.end()) continue;
+      if (std::find(skipSubDetectors_.begin(), skipSubDetectors_.end(), subDets_[index]) != skipSubDetectors_.end())
+        continue;
 
-      if (alignments_.m_align[index].rawId()
-          != alignmentErrors_.m_alignError[index].rawId())
+      if (alignments_.m_align[index].rawId() != alignmentErrors_.m_alignError[index].rawId())
         throw cms::Exception("GeometryMismatch")
-          << "DetId mismatch between alignments (rawId="
-          << alignments_.m_align[index].rawId()
-          << ") and alignment errors (rawId="
-          << alignmentErrors_.m_alignError[index].rawId() << ")";
+            << "DetId mismatch between alignments (rawId=" << alignments_.m_align[index].rawId()
+            << ") and alignment errors (rawId=" << alignmentErrors_.m_alignError[index].rawId() << ")";
 
-      LogDebug("Alignment")
-	<< "============================================================\n"
-	<< "\nGeometry content (" << toString(subDets_[index]) << ", "
-	<< alignments_.m_align[index].rawId() << "):\n"
-	<< "\tx: " << alignments_.m_align[index].translation().x()
-	<< "\ty: " << alignments_.m_align[index].translation().y()
-	<< "\tz: " << alignments_.m_align[index].translation().z()
-	<< "\tphi: " << alignments_.m_align[index].rotation().phi()
-	<< "\ttheta: " << alignments_.m_align[index].rotation().theta()
-	<< "\tpsi: " << alignments_.m_align[index].rotation().psi()
-	<< "============================================================\n";
+      LogDebug("Alignment") << "============================================================\n"
+                            << "\nGeometry content (" << toString(subDets_[index]) << ", "
+                            << alignments_.m_align[index].rawId() << "):\n"
+                            << "\tx: " << alignments_.m_align[index].translation().x()
+                            << "\ty: " << alignments_.m_align[index].translation().y()
+                            << "\tz: " << alignments_.m_align[index].translation().z()
+                            << "\tphi: " << alignments_.m_align[index].rotation().phi()
+                            << "\ttheta: " << alignments_.m_align[index].rotation().theta()
+                            << "\tpsi: " << alignments_.m_align[index].rotation().psi()
+                            << "============================================================\n";
       alignments_.m_align[index] = *itAlign;
       alignmentErrors_.m_alignError[index] = *itAlignErr;
       commonIDs.push_back(id);
-      LogDebug("Alignment")
-	<< "============================================================\n"
-	<< "Global tag content (" << toString(subDets_[index]) << ", "
-	<< alignments_.m_align[index].rawId() << "):\n"
-	<< "\tx: " << alignments_.m_align[index].translation().x()
-	<< "\ty: " << alignments_.m_align[index].translation().y()
-	<< "\tz: " << alignments_.m_align[index].translation().z()
-	<< "\tphi: " << alignments_.m_align[index].rotation().phi()
-	<< "\ttheta: " << alignments_.m_align[index].rotation().theta()
-	<< "\tpsi: " << alignments_.m_align[index].rotation().psi()
-	<< "============================================================\n";
+      LogDebug("Alignment") << "============================================================\n"
+                            << "Global tag content (" << toString(subDets_[index]) << ", "
+                            << alignments_.m_align[index].rawId() << "):\n"
+                            << "\tx: " << alignments_.m_align[index].translation().x()
+                            << "\ty: " << alignments_.m_align[index].translation().y()
+                            << "\tz: " << alignments_.m_align[index].translation().z()
+                            << "\tphi: " << alignments_.m_align[index].rotation().phi()
+                            << "\ttheta: " << alignments_.m_align[index].rotation().theta()
+                            << "\tpsi: " << alignments_.m_align[index].rotation().psi()
+                            << "============================================================\n";
     }
   }
 
@@ -356,27 +351,23 @@ CreateIdealTkAlRecords::alignToGT(const edm::EventSetup& iSetup)
   // - no entry is created for ideal surfaces
   //   -> size of surface deformation payload does not necessarily match the
   //      size of the other tracker alignment payload
-  for (const auto& id: commonIDs) {
+  for (const auto& id : commonIDs) {
     // search for common raw ID in surface deformation items
     auto item = std::find_if(surfaceDeformations->items().cbegin(),
                              surfaceDeformations->items().cend(),
                              [&id](const auto& i) { return i.m_rawId == id; });
-    if (item == surfaceDeformations->items().cend()) continue; // not found
+    if (item == surfaceDeformations->items().cend())
+      continue;  // not found
 
     // copy surface deformation item
     const auto index = std::distance(surfaceDeformations->items().cbegin(), item);
     const auto beginEndPair = surfaceDeformations->parameters(index);
     std::vector<align::Scalar> params(beginEndPair.first, beginEndPair.second);
-    alignmentSurfaceDeformations_.add(item->m_rawId,
-                                      item->m_parametrizationType,
-                                      params);
+    alignmentSurfaceDeformations_.add(item->m_rawId, item->m_parametrizationType, params);
   }
 }
 
-
-void
-CreateIdealTkAlRecords::writeToDB()
-{
+void CreateIdealTkAlRecords::writeToDB() {
   const auto& since = cond::timeTypeSpecs[cond::runnumber].beginValue;
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
@@ -384,29 +375,24 @@ CreateIdealTkAlRecords::writeToDB()
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   }
 
-  edm::LogInfo("Alignment")
-    << "Writing ideal tracker-alignment records.";
+  edm::LogInfo("Alignment") << "Writing ideal tracker-alignment records.";
   poolDb->writeOne(&alignments_, since, "TrackerAlignmentRcd");
   poolDb->writeOne(&alignmentErrors_, since, "TrackerAlignmentErrorExtendedRcd");
   poolDb->writeOne(&alignmentSurfaceDeformations_, since, "TrackerSurfaceDeformationRcd");
 }
 
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-CreateIdealTkAlRecords::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+void CreateIdealTkAlRecords::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setComment("Creates ideal TrackerAlignmentRcd and TrackerAlignmentErrorExtendedRcd "
-                  "from the loaded tracker geometry. "
-                  "PoolDBOutputService must be set up for these records.");
+  desc.setComment(
+      "Creates ideal TrackerAlignmentRcd and TrackerAlignmentErrorExtendedRcd "
+      "from the loaded tracker geometry. "
+      "PoolDBOutputService must be set up for these records.");
   desc.addUntracked<bool>("alignToGlobalTag", false);
-  desc.addUntracked<std::vector<std::string> >("skipSubDetectors",
-                                               std::vector<std::string>{});
+  desc.addUntracked<std::vector<std::string> >("skipSubDetectors", std::vector<std::string>{});
   desc.addUntracked<bool>("createReferenceRcd", false);
   descriptions.add("createIdealTkAlRecords", desc);
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CreateIdealTkAlRecords);

--- a/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
+++ b/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
@@ -19,7 +19,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <unordered_map>
@@ -58,7 +57,7 @@
 // class declaration
 //
 
-class MCMisalignmentScaler : public edm::one::EDAnalyzer<>  {
+class MCMisalignmentScaler : public edm::one::EDAnalyzer<> {
 public:
   explicit MCMisalignmentScaler(const edm::ParameterSet&);
   ~MCMisalignmentScaler() override = default;
@@ -81,24 +80,19 @@ private:
 //
 // constructors and destructor
 //
-MCMisalignmentScaler::MCMisalignmentScaler(const edm::ParameterSet& iConfig) :
-  scalers_{decodeSubDetectors(iConfig.getParameter<edm::VParameterSet>("scalers"))},
-  pullBadModulesToIdeal_{iConfig.getUntrackedParameter<bool>("pullBadModulesToIdeal")},
-  outlierPullToIdealCut_{iConfig.getUntrackedParameter<double>("outlierPullToIdealCut")}
-{
-}
-
-
+MCMisalignmentScaler::MCMisalignmentScaler(const edm::ParameterSet& iConfig)
+    : scalers_{decodeSubDetectors(iConfig.getParameter<edm::VParameterSet>("scalers"))},
+      pullBadModulesToIdeal_{iConfig.getUntrackedParameter<bool>("pullBadModulesToIdeal")},
+      outlierPullToIdealCut_{iConfig.getUntrackedParameter<double>("outlierPullToIdealCut")} {}
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSetup)
-{
-  if (!firstEvent_) return;
+void MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
+  if (!firstEvent_)
+    return;
   firstEvent_ = false;
 
   // get handle on bad modules
@@ -116,22 +110,20 @@ MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSetup)
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const auto* const topology = tTopoHandle.product();
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
-  auto tracker = std::unique_ptr<TrackerGeometry> {
-    trackerBuilder.build(&(*geometricDet), *ptp, topology)};
+  auto tracker = std::unique_ptr<TrackerGeometry>{trackerBuilder.build(&(*geometricDet), *ptp, topology)};
 
   auto dets = tracker->dets();
-  std::sort(dets.begin(), dets.end(),
-            [](const auto& a, const auto& b) {
-              return a->geographicalId().rawId() < b->geographicalId().rawId();});
+  std::sort(dets.begin(), dets.end(), [](const auto& a, const auto& b) {
+    return a->geographicalId().rawId() < b->geographicalId().rawId();
+  });
 
   // get the input alignment
   edm::ESHandle<Alignments> alignments;
   iSetup.get<TrackerAlignmentRcd>().get(alignments);
 
   if (dets.size() != alignments->m_align.size()) {
-    throw cms::Exception("GeometryMismatch")
-      << "Size mismatch between alignments (size=" << alignments->m_align.size()
-      << ") and ideal geometry (size=" << dets.size() << ")";
+    throw cms::Exception("GeometryMismatch") << "Size mismatch between alignments (size=" << alignments->m_align.size()
+                                             << ") and ideal geometry (size=" << dets.size() << ")";
   }
 
   Alignments rescaledAlignments{};
@@ -142,32 +134,31 @@ MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSetup)
     auto misaligned = alignments->m_align.cbegin();
     for (; ideal != ideal_end; ++ideal, ++misaligned) {
       if ((*ideal)->geographicalId().rawId() != misaligned->rawId()) {
-        throw cms::Exception("GeometryMismatch")
-          << "Order differs between Dets in alignments ideal geometry.";
+        throw cms::Exception("GeometryMismatch") << "Order differs between Dets in alignments ideal geometry.";
       }
 
       // determine scale factor
       const auto& subDetId = (*ideal)->geographicalId().subdetId();
       auto side = topology->side((*ideal)->geographicalId());
       if (side == 0) {
-        switch(subDetId) {
-        case PixelSubdetector::PixelBarrel:
-          side = 1;      // both sides are treated identical -> pick one of them
-          break;
-        case StripSubdetector::TIB:
-          side = topology->tibSide((*ideal)->geographicalId());
-          break;
-        case StripSubdetector::TOB:
-          side = topology->tobSide((*ideal)->geographicalId());
-          break;
-        default: break;
+        switch (subDetId) {
+          case PixelSubdetector::PixelBarrel:
+            side = 1;  // both sides are treated identical -> pick one of them
+            break;
+          case StripSubdetector::TIB:
+            side = topology->tibSide((*ideal)->geographicalId());
+            break;
+          case StripSubdetector::TOB:
+            side = topology->tobSide((*ideal)->geographicalId());
+            break;
+          default:
+            break;
         }
       }
       auto scaleFactor = scalers_.find(subDetId)->second.find(side)->second;
 
       if (pullBadModulesToIdeal_ &&
-          (pixelModules->IsModuleBad(misaligned->rawId()) ||
-           stripModules->IsModuleBad(misaligned->rawId()))) {
+          (pixelModules->IsModuleBad(misaligned->rawId()) || stripModules->IsModuleBad(misaligned->rawId()))) {
         scaleFactor = 0.0;
       }
 
@@ -186,50 +177,34 @@ MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSetup)
       auto zz_diff = misaligned->rotation().zz() - (*ideal)->rotation().zz();
 
       if (outlierPullToIdealCut_ > 0.0 &&
-          (x_diff*x_diff + y_diff*y_diff + z_diff*z_diff)
-          > outlierPullToIdealCut_*outlierPullToIdealCut_) {
+          (x_diff * x_diff + y_diff * y_diff + z_diff * z_diff) > outlierPullToIdealCut_ * outlierPullToIdealCut_) {
         ++outlierCounter;
-        edm::LogInfo("Alignment")
-          << outlierCounter << ") Outlier found in subdetector " << subDetId
-          << ":  delta x: " << x_diff
-          << ",  delta y: " << y_diff
-          << ",  delta z: " << z_diff
-          << ",  delta xx: " << xx_diff
-          << ",  delta xy: " << xy_diff
-          << ",  delta xz: " << xz_diff
-          << ",  delta yx: " << yx_diff
-          << ",  delta yx: " << yy_diff
-          << ",  delta yy: " << yz_diff
-          << ",  delta zz: " << zx_diff
-          << ",  delta zy: " << zy_diff
-          << ",  delta zz: " << zz_diff
-          << "\n";
+        edm::LogInfo("Alignment") << outlierCounter << ") Outlier found in subdetector " << subDetId
+                                  << ":  delta x: " << x_diff << ",  delta y: " << y_diff << ",  delta z: " << z_diff
+                                  << ",  delta xx: " << xx_diff << ",  delta xy: " << xy_diff
+                                  << ",  delta xz: " << xz_diff << ",  delta yx: " << yx_diff
+                                  << ",  delta yx: " << yy_diff << ",  delta yy: " << yz_diff
+                                  << ",  delta zz: " << zx_diff << ",  delta zy: " << zy_diff
+                                  << ",  delta zz: " << zz_diff << "\n";
         scaleFactor = 0.0;
       }
 
-      const AlignTransform::Translation rescaledTranslation{
-        (*ideal)->position().x() + scaleFactor*x_diff,
-        (*ideal)->position().y() + scaleFactor*y_diff,
-        (*ideal)->position().z() + scaleFactor*z_diff
-          };
+      const AlignTransform::Translation rescaledTranslation{(*ideal)->position().x() + scaleFactor * x_diff,
+                                                            (*ideal)->position().y() + scaleFactor * y_diff,
+                                                            (*ideal)->position().z() + scaleFactor * z_diff};
 
       const AlignTransform::Rotation rescaledRotation{
-        CLHEP::HepRep3x3{
-            (*ideal)->rotation().xx() + scaleFactor*xx_diff,
-            (*ideal)->rotation().xy() + scaleFactor*xy_diff,
-            (*ideal)->rotation().xz() + scaleFactor*xz_diff,
-            (*ideal)->rotation().yx() + scaleFactor*yx_diff,
-            (*ideal)->rotation().yy() + scaleFactor*yy_diff,
-            (*ideal)->rotation().yz() + scaleFactor*yz_diff,
-            (*ideal)->rotation().zx() + scaleFactor*zx_diff,
-            (*ideal)->rotation().zy() + scaleFactor*zy_diff,
-            (*ideal)->rotation().zz() + scaleFactor*zz_diff
-            }
-          };
+          CLHEP::HepRep3x3{(*ideal)->rotation().xx() + scaleFactor * xx_diff,
+                           (*ideal)->rotation().xy() + scaleFactor * xy_diff,
+                           (*ideal)->rotation().xz() + scaleFactor * xz_diff,
+                           (*ideal)->rotation().yx() + scaleFactor * yx_diff,
+                           (*ideal)->rotation().yy() + scaleFactor * yy_diff,
+                           (*ideal)->rotation().yz() + scaleFactor * yz_diff,
+                           (*ideal)->rotation().zx() + scaleFactor * zx_diff,
+                           (*ideal)->rotation().zy() + scaleFactor * zy_diff,
+                           (*ideal)->rotation().zz() + scaleFactor * zz_diff}};
 
-      const AlignTransform rescaledTransform{rescaledTranslation,
-                                             rescaledRotation,
-                                             misaligned->rawId()};
+      const AlignTransform rescaledTransform{rescaledTranslation, rescaledRotation, misaligned->rawId()};
       rescaledAlignments.m_align.emplace_back(std::move(rescaledTransform));
     }
   }
@@ -238,17 +213,12 @@ MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSetup)
   if (!poolDb.isAvailable()) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   }
-  edm::LogInfo("Alignment")
-    << "Writing rescaled tracker-alignment record.";
+  edm::LogInfo("Alignment") << "Writing rescaled tracker-alignment record.";
   const auto& since = cond::timeTypeSpecs[cond::runnumber].beginValue;
   poolDb->writeOne(&rescaledAlignments, since, "TrackerAlignmentRcd");
-
 }
 
-
-MCMisalignmentScaler::ScalerMap
-MCMisalignmentScaler::decodeSubDetectors(const edm::VParameterSet& psets)
-{
+MCMisalignmentScaler::ScalerMap MCMisalignmentScaler::decodeSubDetectors(const edm::VParameterSet& psets) {
   // initialize scaler map
   ScalerMap subDetMap;
   for (unsigned int subDetId = 1; subDetId <= 6; ++subDetId) {
@@ -257,21 +227,24 @@ MCMisalignmentScaler::decodeSubDetectors(const edm::VParameterSet& psets)
   }
 
   // apply scale factors from configuration
-  for (const auto& pset: psets) {
+  for (const auto& pset : psets) {
     const auto& name = pset.getUntrackedParameter<std::string>("subDetector");
     const auto& factor = pset.getUntrackedParameter<double>("factor");
 
     std::vector<int> sides;
-    if (name.find("-") != std::string::npos) sides.push_back(1);
-    if (name.find("+") != std::string::npos) sides.push_back(2);
-    if (sides.empty()) {        // -> use both sides
+    if (name.find("-") != std::string::npos)
+      sides.push_back(1);
+    if (name.find("+") != std::string::npos)
+      sides.push_back(2);
+    if (sides.empty()) {  // -> use both sides
       sides.push_back(1);
       sides.push_back(2);
     }
 
     if (name.find("Tracker") != std::string::npos) {
       for (unsigned int subDetId = 1; subDetId <= 6; ++subDetId) {
-        for (const auto& side: sides) subDetMap[subDetId][side] *= factor;
+        for (const auto& side : sides)
+          subDetMap[subDetId][side] *= factor;
       }
       if (sides.size() == 1) {
         // if only one side to be scaled
@@ -283,29 +256,33 @@ MCMisalignmentScaler::decodeSubDetectors(const edm::VParameterSet& psets)
       subDetMap[PixelSubdetector::PixelBarrel][1] *= factor;
       subDetMap[PixelSubdetector::PixelBarrel][2] *= factor;
     } else if (name.find("PXF") != std::string::npos) {
-      for (const auto& side: sides) subDetMap[PixelSubdetector::PixelEndcap][side] *= factor;
+      for (const auto& side : sides)
+        subDetMap[PixelSubdetector::PixelEndcap][side] *= factor;
     } else if (name.find("TIB") != std::string::npos) {
-      for (const auto& side: sides) subDetMap[StripSubdetector::TIB][side] *= factor;
+      for (const auto& side : sides)
+        subDetMap[StripSubdetector::TIB][side] *= factor;
     } else if (name.find("TOB") != std::string::npos) {
-      for (const auto& side: sides) subDetMap[StripSubdetector::TOB][side] *= factor;
+      for (const auto& side : sides)
+        subDetMap[StripSubdetector::TOB][side] *= factor;
     } else if (name.find("TID") != std::string::npos) {
-      for (const auto& side: sides) subDetMap[StripSubdetector::TID][side] *= factor;
+      for (const auto& side : sides)
+        subDetMap[StripSubdetector::TID][side] *= factor;
     } else if (name.find("TEC") != std::string::npos) {
-      for (const auto& side: sides) subDetMap[StripSubdetector::TEC][side] *= factor;
+      for (const auto& side : sides)
+        subDetMap[StripSubdetector::TEC][side] *= factor;
     } else {
-      throw cms::Exception("BadConfig")
-        << "@SUB=MCMisalignmentScaler::decodeSubDetectors\n"
-        << "Unknown tracker subdetector: " << name
-        << "\nSupported options: Tracker, PXB, PXF, TIB, TOB, TID, TEC "
-        << "(possibly decorated with '+' or '-')";
+      throw cms::Exception("BadConfig") << "@SUB=MCMisalignmentScaler::decodeSubDetectors\n"
+                                        << "Unknown tracker subdetector: " << name
+                                        << "\nSupported options: Tracker, PXB, PXF, TIB, TOB, TID, TEC "
+                                        << "(possibly decorated with '+' or '-')";
     }
   }
 
   std::stringstream logInfo;
   logInfo << "MC misalignment scale factors:\n";
-  for (const auto& subdet: subDetMap) {
+  for (const auto& subdet : subDetMap) {
     logInfo << "  Subdet " << subdet.first << "\n";
-    for (const auto& side: subdet.second) {
+    for (const auto& side : subdet.second) {
       logInfo << "    side " << side.first << ": " << side.second << "\n";
     }
     logInfo << "\n";
@@ -315,17 +292,16 @@ MCMisalignmentScaler::decodeSubDetectors(const edm::VParameterSet& psets)
   return subDetMap;
 }
 
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-MCMisalignmentScaler::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+void MCMisalignmentScaler::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setComment("Creates rescaled MC misalignment scenario. "
-                  "PoolDBOutputService must be set up for 'TrackerAlignmentRcd'.");
+  desc.setComment(
+      "Creates rescaled MC misalignment scenario. "
+      "PoolDBOutputService must be set up for 'TrackerAlignmentRcd'.");
   edm::ParameterSetDescription descScaler;
-  descScaler.setComment("ParameterSet specifying the tracker part to be scaled "
-                        "by a given factor.");
+  descScaler.setComment(
+      "ParameterSet specifying the tracker part to be scaled "
+      "by a given factor.");
   descScaler.addUntracked<std::string>("subDetector", "Tracker");
   descScaler.addUntracked<double>("factor", 1.0);
   desc.addVPSet("scalers", descScaler, std::vector<edm::ParameterSet>(1));

--- a/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EventPrincipal.h" 
+#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -29,244 +29,241 @@
 //#include <boost/regex.hpp>
 
 class TkAlCaOverlapTagger : public edm::EDProducer {
- public:
-  TkAlCaOverlapTagger(const edm::ParameterSet &iConfig);
+public:
+  TkAlCaOverlapTagger(const edm::ParameterSet& iConfig);
   ~TkAlCaOverlapTagger() override;
-  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
- private:
+private:
   edm::InputTag src_;
   edm::InputTag srcClust_;
   bool rejectBadMods_;
   std::vector<unsigned int> BadModsList_;
 
-
-  int layerFromId (const DetId& id, const TrackerTopology* tTopo) const;
+  int layerFromId(const DetId& id, const TrackerTopology* tTopo) const;
 };
 
-TkAlCaOverlapTagger::TkAlCaOverlapTagger(const edm::ParameterSet& iConfig):
-  src_( iConfig.getParameter<edm::InputTag>("src") ),
-  srcClust_( iConfig.getParameter<edm::InputTag>("Clustersrc") ),
-  rejectBadMods_(  iConfig.getParameter<bool>("rejectBadMods")),
-  BadModsList_(  iConfig.getParameter<std::vector<uint32_t> >("BadMods"))
-{
-
-  produces<AliClusterValueMap>(); //produces the ValueMap (VM) to be stored in the Event at the end
+TkAlCaOverlapTagger::TkAlCaOverlapTagger(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      srcClust_(iConfig.getParameter<edm::InputTag>("Clustersrc")),
+      rejectBadMods_(iConfig.getParameter<bool>("rejectBadMods")),
+      BadModsList_(iConfig.getParameter<std::vector<uint32_t> >("BadMods")) {
+  produces<AliClusterValueMap>();  //produces the ValueMap (VM) to be stored in the Event at the end
 }
 
-TkAlCaOverlapTagger::~TkAlCaOverlapTagger(){}
+TkAlCaOverlapTagger::~TkAlCaOverlapTagger() {}
 
-
-void TkAlCaOverlapTagger::produce(edm::Event &iEvent, const edm::EventSetup &iSetup){
+void TkAlCaOverlapTagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   edm::Handle<TrajTrackAssociationCollection> assoMap;
-  iEvent.getByLabel(src_,  assoMap);
+  iEvent.getByLabel(src_, assoMap);
   // cout<<"\n\n############################\n###  Starting a new TkAlCaOverlapTagger - Ev "<<iEvent.id().run()<<", "<<iEvent.id().event()<<endl;
 
   AlignmentClusterFlag iniflag;
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelclusters;
-  iEvent.getByLabel(srcClust_,  pixelclusters);//same label as tracks
-  std::vector<AlignmentClusterFlag> pixelvalues(pixelclusters->dataSize(), iniflag);//vector where to store value to be fileld in the VM
+  iEvent.getByLabel(srcClust_, pixelclusters);  //same label as tracks
+  std::vector<AlignmentClusterFlag> pixelvalues(pixelclusters->dataSize(),
+                                                iniflag);  //vector where to store value to be fileld in the VM
 
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripclusters;
-  iEvent.getByLabel(srcClust_,  stripclusters);//same label as tracks
-  std::vector<AlignmentClusterFlag> stripvalues(stripclusters->dataSize(), iniflag);//vector where to store value to be fileld in the VM
-
-
+  iEvent.getByLabel(srcClust_, stripclusters);  //same label as tracks
+  std::vector<AlignmentClusterFlag> stripvalues(stripclusters->dataSize(),
+                                                iniflag);  //vector where to store value to be fileld in the VM
 
   //start doing the thing!
 
   //loop over trajectories
-  for (TrajTrackAssociationCollection::const_iterator itass = assoMap->begin();  itass != assoMap->end(); ++itass){
-    
-    int nOverlaps=0;
-    const edm::Ref<std::vector<Trajectory> >traj = itass->key;//trajectory in the collection
-    const Trajectory * myTrajectory= &(*traj);
-    std::vector<TrajectoryMeasurement> tmColl =myTrajectory->measurements();
+  for (TrajTrackAssociationCollection::const_iterator itass = assoMap->begin(); itass != assoMap->end(); ++itass) {
+    int nOverlaps = 0;
+    const edm::Ref<std::vector<Trajectory> > traj = itass->key;  //trajectory in the collection
+    const Trajectory* myTrajectory = &(*traj);
+    std::vector<TrajectoryMeasurement> tmColl = myTrajectory->measurements();
 
-    const reco::TrackRef tkref = itass->val;//associated track track in the collection
+    const reco::TrackRef tkref = itass->val;  //associated track track in the collection
     // const Track * trk = &(*tkref);
-    int hitcnt=-1;
+    int hitcnt = -1;
 
     //loop over traj meas
     const TrajectoryMeasurement* previousTM(nullptr);
     DetId previousId(0);
 
-    for(std::vector<TrajectoryMeasurement>::const_iterator itTrajMeas = tmColl.begin(); itTrajMeas!=tmColl.end(); ++itTrajMeas){
+    for (std::vector<TrajectoryMeasurement>::const_iterator itTrajMeas = tmColl.begin(); itTrajMeas != tmColl.end();
+         ++itTrajMeas) {
       hitcnt++;
 
-      if ( previousTM!=nullptr ) {
-	//	std::cout<<"Checking TrajMeas ("<<hitcnt+1<<"):"<<std::endl;
-	if(!previousTM->recHit()->isValid()){
-	  //std::cout<<"Previous RecHit invalid !"<<std::endl; 
-	continue;}
-	//else std::cout<<"\nDetId: "<<std::flush<<previousTM->recHit()->geographicalId().rawId()<<"\t Local x of hit: "<<previousTM->recHit()->localPosition().x()<<std::endl;
+      if (previousTM != nullptr) {
+        //	std::cout<<"Checking TrajMeas ("<<hitcnt+1<<"):"<<std::endl;
+        if (!previousTM->recHit()->isValid()) {
+          //std::cout<<"Previous RecHit invalid !"<<std::endl;
+          continue;
+        }
+        //else std::cout<<"\nDetId: "<<std::flush<<previousTM->recHit()->geographicalId().rawId()<<"\t Local x of hit: "<<previousTM->recHit()->localPosition().x()<<std::endl;
+      } else {
+        //std::cout<<"This is the first Traj Meas of the Trajectory! The Trajectory contains "<< tmColl.size()<<" TrajMeas"<<std::endl;
       }
-      else{
-	//std::cout<<"This is the first Traj Meas of the Trajectory! The Trajectory contains "<< tmColl.size()<<" TrajMeas"<<std::endl;
-      }
-      
-      
+
       TrackingRecHit::ConstRecHitPointer hitpointer = itTrajMeas->recHit();
-      const TrackingRecHit *hit=&(* hitpointer);
-      if(!hit->isValid())continue;
+      const TrackingRecHit* hit = &(*hitpointer);
+      if (!hit->isValid())
+        continue;
 
       //std::cout << "         hit number " << (ith - itt->recHits().begin()) << std::endl;
       DetId detid = hit->geographicalId();
-      int layer(layerFromId(detid, tTopo));//layer 1-4=TIB, layer 5-10=TOB
+      int layer(layerFromId(detid, tTopo));  //layer 1-4=TIB, layer 5-10=TOB
       int subDet = detid.subdetId();
 
-      if ( ( previousTM!=nullptr )&& (layer!=-1 )) {
-	for (std::vector<TrajectoryMeasurement>::const_iterator itmCompare =itTrajMeas-1;itmCompare >= tmColl.begin() &&  itmCompare > itTrajMeas - 4;--itmCompare){
-	  DetId compareId = itmCompare->recHit()->geographicalId();
-	  if ( subDet != compareId.subdetId() || layer  != layerFromId(compareId, tTopo)) break;
-	  if (!itmCompare->recHit()->isValid()) continue;
-	  if ( (subDet<=2) || (subDet > 2 && SiStripDetId(detid).stereo()==SiStripDetId(compareId).stereo())){//if either pixel or strip stereo module
-	    
-	    //
-	    //WOW, we have an overlap!!!!!!
-	    //
-	    AlignmentClusterFlag hitflag(hit->geographicalId());
-	    hitflag.SetOverlapFlag();
-	    // cout<<"Overlap found in SubDet "<<subDet<<"!!!"<<flush;
+      if ((previousTM != nullptr) && (layer != -1)) {
+        for (std::vector<TrajectoryMeasurement>::const_iterator itmCompare = itTrajMeas - 1;
+             itmCompare >= tmColl.begin() && itmCompare > itTrajMeas - 4;
+             --itmCompare) {
+          DetId compareId = itmCompare->recHit()->geographicalId();
+          if (subDet != compareId.subdetId() || layer != layerFromId(compareId, tTopo))
+            break;
+          if (!itmCompare->recHit()->isValid())
+            continue;
+          if ((subDet <= 2) ||
+              (subDet > 2 && SiStripDetId(detid).stereo() ==
+                                 SiStripDetId(compareId).stereo())) {  //if either pixel or strip stereo module
 
-	    bool hitInStrip=(subDet==SiStripDetId::TIB) || (subDet==SiStripDetId::TID) ||(subDet==SiStripDetId::TOB) ||(subDet==SiStripDetId::TEC);
-	    if (hitInStrip){
-	      //cout<<"  TypeId of the RecHit: "<<className(*hit)<<endl;
-	      // const std::type_info &type = typeid(*hit);
-	      const SiStripRecHit2D* transstriphit2D = dynamic_cast<const  SiStripRecHit2D*>(hit);
-	      const SiStripRecHit1D* transstriphit1D = dynamic_cast<const  SiStripRecHit1D*>(hit);
-	   
-	      //   if (type == typeid(SiStripRecHit1D)) {
-	      if(transstriphit1D!=nullptr){
-		//	const SiStripRecHit1D* striphit=dynamic_cast<const  SiStripRecHit1D*>(hit);
-		const SiStripRecHit1D* striphit=transstriphit1D;
-		if(striphit!=nullptr){
-		  SiStripRecHit1D::ClusterRef stripclust(striphit->cluster());
-		  
-		  if(stripclust.id()==stripclusters.id()){//ensure that the stripclust is really present in the original cluster collection!!!
-		    stripvalues[stripclust.key()]=hitflag;
-		  }
-		  else{
-		    edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: ProdId of Strip clusters mismatched: "<<stripclust.id()<<" vs "<<stripclusters.id();
-		  }
-		}
-		else{
-		  edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: Dynamic cast of Strip RecHit failed!   TypeId of the RecHit: "<<className(*hit);
-		}
-	      }//end if sistriprechit1D
-	      else if(transstriphit2D!=nullptr){
-	      //else if (type == typeid(SiStripRecHit2D)) {
-		//		const SiStripRecHit2D* striphit=dynamic_cast<const  SiStripRecHit2D*>(hit);
-		const SiStripRecHit2D* striphit=transstriphit2D;   
-		if(striphit!=nullptr){
-		  SiStripRecHit2D::ClusterRef stripclust(striphit->cluster());
-		  
-		  if(stripclust.id()==stripclusters.id()){//ensure that the stripclust is really present in the original cluster collection!!!
-		    stripvalues[stripclust.key()]=hitflag;
-	      
-		    //cout<<">>> Storing in the ValueMap a StripClusterRef with Cluster.Key: "<<stripclust.key()<<" ("<<striphit->cluster().key() <<"), Cluster.Id: "<<stripclust.id()<<"  (DetId is "<<hit->geographicalId().rawId()<<")"<<endl;
-		  }
-		  else{
-		    edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: ProdId of Strip clusters mismatched: "<<stripclust.id()<<" vs "<<stripclusters.id();
-		  }
-		  
-		  // cout<<"Cluster baricentre: "<<stripclust->barycenter()<<endl;
-		}
-		else{
-		  edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: Dynamic cast of Strip RecHit failed!   TypeId of the RecHit: "<<className(*hit);
-		}
-	      }//end if Sistriprechit2D
-	      else{
-		edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: Impossible to determine the type of SiStripRecHit.  TypeId of the RecHit: "<<className(*hit);
-	      }	  
-	 
-	    }//end if hit in Strips
-	    else {//pixel hit
-	      const SiPixelRecHit* transpixelhit = dynamic_cast<const SiPixelRecHit*>(hit);
-	      if(transpixelhit!=nullptr){
-		const SiPixelRecHit* pixelhit=transpixelhit;
-		SiPixelClusterRefNew pixclust(pixelhit->cluster());
-		
-		if(pixclust.id()==pixelclusters.id()){
-		  pixelvalues[pixclust.key()]=hitflag;
-		  //cout<<">>> Storing in the ValueMap a PixelClusterRef with ProdID: "<<pixclust.id()<<"  (DetId is "<<hit->geographicalId().rawId()<<")" <<endl;//"  and  a Val with ID: "<<flag.id()<<endl;
-		}
-		else{
-		  edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: ProdId of Pixel clusters mismatched: "<<pixclust.id()<<" vs "<<pixelclusters.id();
-		}
-	      }
-	      else{
-		edm::LogError("TkAlCaOverlapTagger")<<"ERROR in <TkAlCaOverlapTagger::produce>: Dynamic cast of Pixel RecHit failed!   TypeId of the RecHit: "<<className(*hit);
-	      }
-	    }//end 'else' it is a pixel hit
+            //
+            //WOW, we have an overlap!!!!!!
+            //
+            AlignmentClusterFlag hitflag(hit->geographicalId());
+            hitflag.SetOverlapFlag();
+            // cout<<"Overlap found in SubDet "<<subDet<<"!!!"<<flush;
 
-	    nOverlaps++;
-	    break;
-	  }
-	}//end second loop on TM
-      }//end if a previous TM exists
+            bool hitInStrip = (subDet == SiStripDetId::TIB) || (subDet == SiStripDetId::TID) ||
+                              (subDet == SiStripDetId::TOB) || (subDet == SiStripDetId::TEC);
+            if (hitInStrip) {
+              //cout<<"  TypeId of the RecHit: "<<className(*hit)<<endl;
+              // const std::type_info &type = typeid(*hit);
+              const SiStripRecHit2D* transstriphit2D = dynamic_cast<const SiStripRecHit2D*>(hit);
+              const SiStripRecHit1D* transstriphit1D = dynamic_cast<const SiStripRecHit1D*>(hit);
 
-      previousTM = &(* itTrajMeas);
+              //   if (type == typeid(SiStripRecHit1D)) {
+              if (transstriphit1D != nullptr) {
+                //	const SiStripRecHit1D* striphit=dynamic_cast<const  SiStripRecHit1D*>(hit);
+                const SiStripRecHit1D* striphit = transstriphit1D;
+                if (striphit != nullptr) {
+                  SiStripRecHit1D::ClusterRef stripclust(striphit->cluster());
+
+                  if (stripclust.id() ==
+                      stripclusters
+                          .id()) {  //ensure that the stripclust is really present in the original cluster collection!!!
+                    stripvalues[stripclust.key()] = hitflag;
+                  } else {
+                    edm::LogError("TkAlCaOverlapTagger")
+                        << "ERROR in <TkAlCaOverlapTagger::produce>: ProdId of Strip clusters mismatched: "
+                        << stripclust.id() << " vs " << stripclusters.id();
+                  }
+                } else {
+                  edm::LogError("TkAlCaOverlapTagger") << "ERROR in <TkAlCaOverlapTagger::produce>: Dynamic cast of "
+                                                          "Strip RecHit failed!   TypeId of the RecHit: "
+                                                       << className(*hit);
+                }
+              }  //end if sistriprechit1D
+              else if (transstriphit2D != nullptr) {
+                //else if (type == typeid(SiStripRecHit2D)) {
+                //		const SiStripRecHit2D* striphit=dynamic_cast<const  SiStripRecHit2D*>(hit);
+                const SiStripRecHit2D* striphit = transstriphit2D;
+                if (striphit != nullptr) {
+                  SiStripRecHit2D::ClusterRef stripclust(striphit->cluster());
+
+                  if (stripclust.id() ==
+                      stripclusters
+                          .id()) {  //ensure that the stripclust is really present in the original cluster collection!!!
+                    stripvalues[stripclust.key()] = hitflag;
+
+                    //cout<<">>> Storing in the ValueMap a StripClusterRef with Cluster.Key: "<<stripclust.key()<<" ("<<striphit->cluster().key() <<"), Cluster.Id: "<<stripclust.id()<<"  (DetId is "<<hit->geographicalId().rawId()<<")"<<endl;
+                  } else {
+                    edm::LogError("TkAlCaOverlapTagger")
+                        << "ERROR in <TkAlCaOverlapTagger::produce>: ProdId of Strip clusters mismatched: "
+                        << stripclust.id() << " vs " << stripclusters.id();
+                  }
+
+                  // cout<<"Cluster baricentre: "<<stripclust->barycenter()<<endl;
+                } else {
+                  edm::LogError("TkAlCaOverlapTagger") << "ERROR in <TkAlCaOverlapTagger::produce>: Dynamic cast of "
+                                                          "Strip RecHit failed!   TypeId of the RecHit: "
+                                                       << className(*hit);
+                }
+              }  //end if Sistriprechit2D
+              else {
+                edm::LogError("TkAlCaOverlapTagger") << "ERROR in <TkAlCaOverlapTagger::produce>: Impossible to "
+                                                        "determine the type of SiStripRecHit.  TypeId of the RecHit: "
+                                                     << className(*hit);
+              }
+
+            }       //end if hit in Strips
+            else {  //pixel hit
+              const SiPixelRecHit* transpixelhit = dynamic_cast<const SiPixelRecHit*>(hit);
+              if (transpixelhit != nullptr) {
+                const SiPixelRecHit* pixelhit = transpixelhit;
+                SiPixelClusterRefNew pixclust(pixelhit->cluster());
+
+                if (pixclust.id() == pixelclusters.id()) {
+                  pixelvalues[pixclust.key()] = hitflag;
+                  //cout<<">>> Storing in the ValueMap a PixelClusterRef with ProdID: "<<pixclust.id()<<"  (DetId is "<<hit->geographicalId().rawId()<<")" <<endl;//"  and  a Val with ID: "<<flag.id()<<endl;
+                } else {
+                  edm::LogError("TkAlCaOverlapTagger")
+                      << "ERROR in <TkAlCaOverlapTagger::produce>: ProdId of Pixel clusters mismatched: "
+                      << pixclust.id() << " vs " << pixelclusters.id();
+                }
+              } else {
+                edm::LogError("TkAlCaOverlapTagger") << "ERROR in <TkAlCaOverlapTagger::produce>: Dynamic cast of "
+                                                        "Pixel RecHit failed!   TypeId of the RecHit: "
+                                                     << className(*hit);
+              }
+            }  //end 'else' it is a pixel hit
+
+            nOverlaps++;
+            break;
+          }
+        }  //end second loop on TM
+      }    //end if a previous TM exists
+
+      previousTM = &(*itTrajMeas);
       previousId = detid;
-    }//end loop over traj meas
-    //std::cout<<"Found "<<nOverlaps<<" overlaps in this trajectory"<<std::endl; 
+    }  //end loop over traj meas
+    //std::cout<<"Found "<<nOverlaps<<" overlaps in this trajectory"<<std::endl;
 
-  }//end loop over trajectories
+  }  //end loop over trajectories
 
-
-
-  // prepare output 
+  // prepare output
   auto hitvalmap = std::make_unique<AliClusterValueMap>();
-  AliClusterValueMap::Filler mapfiller(*hitvalmap); 
+  AliClusterValueMap::Filler mapfiller(*hitvalmap);
 
-  edm::TestHandle<std::vector<AlignmentClusterFlag> > fakePixelHandle( &pixelvalues,pixelclusters.id());
+  edm::TestHandle<std::vector<AlignmentClusterFlag> > fakePixelHandle(&pixelvalues, pixelclusters.id());
   mapfiller.insert(fakePixelHandle, pixelvalues.begin(), pixelvalues.end());
 
-  edm::TestHandle<std::vector<AlignmentClusterFlag> > fakeStripHandle( &stripvalues,stripclusters.id());
+  edm::TestHandle<std::vector<AlignmentClusterFlag> > fakeStripHandle(&stripvalues, stripclusters.id());
   mapfiller.insert(fakeStripHandle, stripvalues.begin(), stripvalues.end());
   mapfiller.fill();
 
-
-
-
-
   // iEvent.put(std::move(stripmap));
   iEvent.put(std::move(hitvalmap));
-}//end  TkAlCaOverlapTagger::produce
-int TkAlCaOverlapTagger::layerFromId (const DetId& id, const TrackerTopology* tTopo) const
-{
- if ( uint32_t(id.subdetId())==PixelSubdetector::PixelBarrel ) {
-    
+}  //end  TkAlCaOverlapTagger::produce
+int TkAlCaOverlapTagger::layerFromId(const DetId& id, const TrackerTopology* tTopo) const {
+  if (uint32_t(id.subdetId()) == PixelSubdetector::PixelBarrel) {
     return tTopo->pxbLayer(id);
-  }
-  else if ( uint32_t(id.subdetId())==PixelSubdetector::PixelEndcap ) {
-    
-    return tTopo->pxfDisk(id) + (3*(tTopo->pxfSide(id)-1));
-  }
-  else if ( id.subdetId()==StripSubdetector::TIB ) {
-    
+  } else if (uint32_t(id.subdetId()) == PixelSubdetector::PixelEndcap) {
+    return tTopo->pxfDisk(id) + (3 * (tTopo->pxfSide(id) - 1));
+  } else if (id.subdetId() == StripSubdetector::TIB) {
     return tTopo->tibLayer(id);
-  }
-  else if ( id.subdetId()==StripSubdetector::TOB ) {
-    
+  } else if (id.subdetId() == StripSubdetector::TOB) {
     return tTopo->tobLayer(id);
-  }
-  else if ( id.subdetId()==StripSubdetector::TEC ) {
-    
-    return tTopo->tecWheel(id) + (9*(tTopo->tecSide(id)-1));
-  }
-  else if ( id.subdetId()==StripSubdetector::TID ) {
-    
-    return tTopo->tidWheel(id) + (3*(tTopo->tidSide(id)-1));
+  } else if (id.subdetId() == StripSubdetector::TEC) {
+    return tTopo->tecWheel(id) + (9 * (tTopo->tecSide(id) - 1));
+  } else if (id.subdetId() == StripSubdetector::TID) {
+    return tTopo->tidWheel(id) + (3 * (tTopo->tidSide(id) - 1));
   }
   return -1;
 
-}//end layerfromId
+}  //end layerfromId
 
 // ========= MODULE DEF ==============
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/Alignment/TrackerAlignment/plugins/TkAlCaSkimTreeMerger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaSkimTreeMerger.cc
@@ -8,7 +8,7 @@
 #include <map>
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/EventPrincipal.h" 
+#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -16,307 +16,287 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
 #include "TFile.h"
 #include "TString.h"
 #include "TChain.h"
 #include "TStopwatch.h"
 
-class TkAlCaSkimTreeMerger : public edm::EDAnalyzer{
-
- public:
+class TkAlCaSkimTreeMerger : public edm::EDAnalyzer {
+public:
   TkAlCaSkimTreeMerger(const edm::ParameterSet &iConfig);
   ~TkAlCaSkimTreeMerger() override;
   void beginJob() override;
   void endJob() override;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
- private:
-  TTree *out_;//TTree containing the merged result
-  TTree *firsttree_;//first tree of the list; this gives the structure to all the others 
-  TChain *ch_;//chain containing all the tree you want to merge
-  std::string filelist_;//text file containing the list of input files
+private:
+  TTree *out_;            //TTree containing the merged result
+  TTree *firsttree_;      //first tree of the list; this gives the structure to all the others
+  TChain *ch_;            //chain containing all the tree you want to merge
+  std::string filelist_;  //text file containing the list of input files
   std::string firstfilename_;
-  std::string treename_;//name of the tree you want to merge (contained in the file)
-  std::string outfilename_;//name of the file where you want to save the output
- 
+  std::string treename_;     //name of the tree you want to merge (contained in the file)
+  std::string outfilename_;  //name of the file where you want to save the output
+
   //Hit Population
-  typedef std::map<uint32_t,uint32_t>DetHitMap;
+  typedef std::map<uint32_t, uint32_t> DetHitMap;
   DetHitMap hitmap_;
   DetHitMap overlapmap_;
-  int maxhits_;//above this number, the hit population is prescaled. Configurable for each subdet 
+  int maxhits_;  //above this number, the hit population is prescaled. Configurable for each subdet
   edm::ParameterSet maxhitsSet_;
   int maxPXBhits_, maxPXFhits_, maxTIBhits_, maxTIDhits_, maxTOBhits_, maxTEChits_;
- 
 
   TStopwatch myclock;
-
 };
-
-
-
 
 #endif
 
-
-TkAlCaSkimTreeMerger::TkAlCaSkimTreeMerger(const edm::ParameterSet &iConfig) :
-    filelist_(iConfig.getParameter<std::string>("FileList")), 
-    treename_(iConfig.getParameter<std::string>("TreeName")),
-    outfilename_(iConfig.getParameter<std::string>("OutputFile")),
-    // maxhits_(iConfig.getParameter<vint>("NhitsMaxLimit"))
-    maxhits_(iConfig.getParameter<int32_t>("NhitsMaxLimit")),
-    maxhitsSet_(iConfig.getParameter<edm::ParameterSet>("NhitsMaxSet"))
-{
-  maxPXBhits_=maxhitsSet_.getParameter<int32_t>("PXBmaxhits");
-  maxPXFhits_=maxhitsSet_.getParameter<int32_t>("PXFmaxhits");
-  maxTIBhits_=maxhitsSet_.getParameter<int32_t>("TIBmaxhits");
-  maxTIDhits_=maxhitsSet_.getParameter<int32_t>("TIDmaxhits");
-  maxTOBhits_=maxhitsSet_.getParameter<int32_t>("TOBmaxhits");
-  maxTEChits_=maxhitsSet_.getParameter<int32_t>("TECmaxhits");
+TkAlCaSkimTreeMerger::TkAlCaSkimTreeMerger(const edm::ParameterSet &iConfig)
+    : filelist_(iConfig.getParameter<std::string>("FileList")),
+      treename_(iConfig.getParameter<std::string>("TreeName")),
+      outfilename_(iConfig.getParameter<std::string>("OutputFile")),
+      // maxhits_(iConfig.getParameter<vint>("NhitsMaxLimit"))
+      maxhits_(iConfig.getParameter<int32_t>("NhitsMaxLimit")),
+      maxhitsSet_(iConfig.getParameter<edm::ParameterSet>("NhitsMaxSet")) {
+  maxPXBhits_ = maxhitsSet_.getParameter<int32_t>("PXBmaxhits");
+  maxPXFhits_ = maxhitsSet_.getParameter<int32_t>("PXFmaxhits");
+  maxTIBhits_ = maxhitsSet_.getParameter<int32_t>("TIBmaxhits");
+  maxTIDhits_ = maxhitsSet_.getParameter<int32_t>("TIDmaxhits");
+  maxTOBhits_ = maxhitsSet_.getParameter<int32_t>("TOBmaxhits");
+  maxTEChits_ = maxhitsSet_.getParameter<int32_t>("TECmaxhits");
   //anything you want to do for initializing
-  std::cout<<"\n\n*** MAX N HITS = "<<maxhits_<<std::endl<<std::endl;
-  out_=nullptr;
-  firsttree_=nullptr;
-  ch_=nullptr;
+  std::cout << "\n\n*** MAX N HITS = " << maxhits_ << std::endl << std::endl;
+  out_ = nullptr;
+  firsttree_ = nullptr;
+  ch_ = nullptr;
 }
 
-
-TkAlCaSkimTreeMerger::~TkAlCaSkimTreeMerger(){
+TkAlCaSkimTreeMerger::~TkAlCaSkimTreeMerger() {
   //default destructor
   // delete out_;
   // delete firsttree_;
 
   delete ch_;
-  std::cout<<"finished."<<std::endl;
+  std::cout << "finished." << std::endl;
 }
 
 // ------------ method called before analyzing the first event  ------------
-void TkAlCaSkimTreeMerger::beginJob(){
- 
+void TkAlCaSkimTreeMerger::beginJob() {
   myclock.Start();
 
   //prepare the chain
-  ch_=new TChain(treename_.c_str());
-  std::cout<<"The chain contains "<<ch_->GetNtrees()<<" trees"<<std::endl;
-  
+  ch_ = new TChain(treename_.c_str());
+  std::cout << "The chain contains " << ch_->GetNtrees() << " trees" << std::endl;
+
   //load the trees into the chain
-  std::ifstream flist(filelist_.c_str(),std::ios::in);
+  std::ifstream flist(filelist_.c_str(), std::ios::in);
   std::string filename;
   std::string firstfilename;
-  bool first=true;
-  while(!flist.eof()){
-    filename="";
-    flist>>filename;
-    if(filename.empty())continue;
+  bool first = true;
+  while (!flist.eof()) {
+    filename = "";
+    flist >> filename;
+    if (filename.empty())
+      continue;
     //std::cout<<"Adding "<<filename<<std::endl;
     ch_->Add(filename.c_str());
-    if(first){
-      firstfilename_=filename;
-      first=false;
+    if (first) {
+      firstfilename_ = filename;
+      first = false;
     }
-   
   }
-  std::cout<<"Now the chain contains "<<ch_->GetNtrees()<<" trees ("<<ch_->GetEntries()<<" entries)"<<std::endl;
+  std::cout << "Now the chain contains " << ch_->GetNtrees() << " trees (" << ch_->GetEntries() << " entries)"
+            << std::endl;
 
- 
-  unsigned int id_ch=0;
-  uint32_t nhits_ch=0,noverlaps_ch=0;
-  ch_->SetBranchAddress("DetId",    &id_ch);
-  ch_->SetBranchAddress("Nhits",    &nhits_ch);
-  ch_->SetBranchAddress("Noverlaps",&noverlaps_ch);
+  unsigned int id_ch = 0;
+  uint32_t nhits_ch = 0, noverlaps_ch = 0;
+  ch_->SetBranchAddress("DetId", &id_ch);
+  ch_->SetBranchAddress("Nhits", &nhits_ch);
+  ch_->SetBranchAddress("Noverlaps", &noverlaps_ch);
 
-  ch_->SetBranchStatus("SubDet",false);
-  ch_->SetBranchStatus("Layer",false);
-  ch_->SetBranchStatus("is2D",false);
-  ch_->SetBranchStatus("isStereo",false);
-  ch_->SetBranchStatus("posX",false);
-  ch_->SetBranchStatus("posY",false);
-  ch_->SetBranchStatus("posZ",false);
-  ch_->SetBranchStatus("posR",false);
-  ch_->SetBranchStatus("posEta",false);
-  ch_->SetBranchStatus("posPhi",false);//now only id, nhits and noverlaps are on...
+  ch_->SetBranchStatus("SubDet", false);
+  ch_->SetBranchStatus("Layer", false);
+  ch_->SetBranchStatus("is2D", false);
+  ch_->SetBranchStatus("isStereo", false);
+  ch_->SetBranchStatus("posX", false);
+  ch_->SetBranchStatus("posY", false);
+  ch_->SetBranchStatus("posZ", false);
+  ch_->SetBranchStatus("posR", false);
+  ch_->SetBranchStatus("posEta", false);
+  ch_->SetBranchStatus("posPhi", false);  //now only id, nhits and noverlaps are on...
 
-
-  int totnhits(0),totnoverlaps(0);
-
+  int totnhits(0), totnoverlaps(0);
 
   //look if you find this detid in the map
   DetHitMap::iterator mapiter;
   DetHitMap::iterator overlapiter;
-  
-  for(int ent=0;ent<ch_->GetEntries();++ent){
-  //  for(int ent=0;ent<100;++ent){
-    ch_->GetEntry(ent);
-    totnhits+=nhits_ch;
-    totnoverlaps+=noverlaps_ch;
 
-    mapiter= hitmap_.find(id_ch);
-    if(mapiter!=hitmap_.end() ){//present, increase its value
-      hitmap_[id_ch]=hitmap_[id_ch]+nhits_ch;
-    }
-    else{//not present, let's add this key to the map with value=1
+  for (int ent = 0; ent < ch_->GetEntries(); ++ent) {
+    //  for(int ent=0;ent<100;++ent){
+    ch_->GetEntry(ent);
+    totnhits += nhits_ch;
+    totnoverlaps += noverlaps_ch;
+
+    mapiter = hitmap_.find(id_ch);
+    if (mapiter != hitmap_.end()) {  //present, increase its value
+      hitmap_[id_ch] = hitmap_[id_ch] + nhits_ch;
+    } else {  //not present, let's add this key to the map with value=1
       hitmap_.insert(std::pair<uint32_t, uint32_t>(id_ch, nhits_ch));
     }
     //do the same for overlaps
-    overlapiter= overlapmap_.find(id_ch);
-    if(overlapiter!=overlapmap_.end() ){
-      overlapmap_[id_ch]=overlapmap_[id_ch]+noverlaps_ch;
-    }
-    else{
+    overlapiter = overlapmap_.find(id_ch);
+    if (overlapiter != overlapmap_.end()) {
+      overlapmap_[id_ch] = overlapmap_[id_ch] + noverlaps_ch;
+    } else {
       overlapmap_.insert(std::pair<uint32_t, uint32_t>(id_ch, noverlaps_ch));
     }
-    
-  }//end loop on ent - entries in the chain
 
+  }  //end loop on ent - entries in the chain
 
-  std::cout<<"Nhits in the chain: "<<totnhits<<std::endl;
-  std::cout<<"NOverlaps in the chain: "<<totnoverlaps<<std::endl;
-
+  std::cout << "Nhits in the chain: " << totnhits << std::endl;
+  std::cout << "NOverlaps in the chain: " << totnoverlaps << std::endl;
 
   myclock.Stop();
-  std::cout<<"Finished beginJob after "<<myclock.RealTime()<<" s (real time) / "<<myclock.CpuTime()<<" s (cpu time)"<<std::endl;
+  std::cout << "Finished beginJob after " << myclock.RealTime() << " s (real time) / " << myclock.CpuTime()
+            << " s (cpu time)" << std::endl;
   myclock.Continue();
-}//end beginJob
-
+}  //end beginJob
 
 // ------------ method called to for each event  ------------
-void TkAlCaSkimTreeMerger::analyze(const edm::Event&, const edm::EventSetup&){
-    // std::cout<<firsttree_->GetEntries()<<std::endl;
-}//end analyze
+void TkAlCaSkimTreeMerger::analyze(const edm::Event &, const edm::EventSetup &) {
+  // std::cout<<firsttree_->GetEntries()<<std::endl;
+}  //end analyze
 
 // ------------ method called after having analyzed all the events  ------------
-void TkAlCaSkimTreeMerger::endJob(){
-
-
+void TkAlCaSkimTreeMerger::endJob() {
   //address variables in the first tree and in the chain
-  TFile *firstfile=new TFile(firstfilename_.c_str(),"READ");
-  firsttree_=(TTree*)firstfile->Get(treename_.c_str());
-  std::cout<<"the first tree has "<<firsttree_->GetEntries() <<" entries"<<std::endl; 
-  unsigned int id=0;
-  uint32_t nhits=0,noverlaps=0;
-  float posX(-99999.0),posY(-77777.0),posZ(-88888.0);
-  float posEta(-6666.0),posPhi(-5555.0),posR(-4444.0);
-  int subdet=0;
-  unsigned int layer=0; 
+  TFile *firstfile = new TFile(firstfilename_.c_str(), "READ");
+  firsttree_ = (TTree *)firstfile->Get(treename_.c_str());
+  std::cout << "the first tree has " << firsttree_->GetEntries() << " entries" << std::endl;
+  unsigned int id = 0;
+  uint32_t nhits = 0, noverlaps = 0;
+  float posX(-99999.0), posY(-77777.0), posZ(-88888.0);
+  float posEta(-6666.0), posPhi(-5555.0), posR(-4444.0);
+  int subdet = 0;
+  unsigned int layer = 0;
   // bool is2D=false,isStereo=false;
-  firsttree_->SetBranchAddress("DetId",    &id);
-  firsttree_->SetBranchAddress("Nhits",    &nhits);
-  firsttree_->SetBranchAddress("Noverlaps",&noverlaps);
-  firsttree_->SetBranchAddress("SubDet",   &subdet);
-  firsttree_->SetBranchAddress("Layer",    &layer);
+  firsttree_->SetBranchAddress("DetId", &id);
+  firsttree_->SetBranchAddress("Nhits", &nhits);
+  firsttree_->SetBranchAddress("Noverlaps", &noverlaps);
+  firsttree_->SetBranchAddress("SubDet", &subdet);
+  firsttree_->SetBranchAddress("Layer", &layer);
   //  firsttree_->SetBranchAddress("is2D" ,    &is2D);
   // firsttree_->SetBranchAddress("isStereo", &isStereo);
-  firsttree_->SetBranchAddress("posX",     &posX);
-  firsttree_->SetBranchAddress("posY",     &posY);
-  firsttree_->SetBranchAddress("posZ",     &posZ);
-  firsttree_->SetBranchAddress("posR",     &posR);
-  firsttree_->SetBranchAddress("posEta",   &posEta);
-  firsttree_->SetBranchAddress("posPhi",   &posPhi);
-
+  firsttree_->SetBranchAddress("posX", &posX);
+  firsttree_->SetBranchAddress("posY", &posY);
+  firsttree_->SetBranchAddress("posZ", &posZ);
+  firsttree_->SetBranchAddress("posR", &posR);
+  firsttree_->SetBranchAddress("posEta", &posEta);
+  firsttree_->SetBranchAddress("posPhi", &posPhi);
 
   //create and book the output
- 
- 
-  TFile *outfile=new TFile(outfilename_.c_str(),"RECREATE");
-  out_=new TTree(treename_.c_str(),"AlignmentHitMapsTOTAL");
-  unsigned int id_out=0;
-  uint32_t nhits_out=0,noverlaps_out=0;
-  float posX_out(-99999.0),posY_out(-77777.0),posZ_out(-88888.0);
-  float posEta_out(-6666.0),posPhi_out(-5555.0),posR_out(-4444.0);
-  int subdet_out=0;
-  unsigned int layer_out=0; 
-  bool is2D_out=false,isStereo_out=false;
-  float prescfact_out=1.0;
-  float prescfact_overlap_out=1.0;
 
-  out_->Branch("DetId",    &id_out ,      "DetId/i");
-  out_->Branch("Nhits",    &nhits_out ,   "Nhits/i");
-  out_->Branch("Noverlaps",&noverlaps_out,"Noverlaps/i");
-  out_->Branch("SubDet",   &subdet_out,   "SubDet/I");
-  out_->Branch("Layer",    &layer_out,    "Layer/i");
-  out_->Branch("is2D" ,    &is2D_out,     "is2D/B");
+  TFile *outfile = new TFile(outfilename_.c_str(), "RECREATE");
+  out_ = new TTree(treename_.c_str(), "AlignmentHitMapsTOTAL");
+  unsigned int id_out = 0;
+  uint32_t nhits_out = 0, noverlaps_out = 0;
+  float posX_out(-99999.0), posY_out(-77777.0), posZ_out(-88888.0);
+  float posEta_out(-6666.0), posPhi_out(-5555.0), posR_out(-4444.0);
+  int subdet_out = 0;
+  unsigned int layer_out = 0;
+  bool is2D_out = false, isStereo_out = false;
+  float prescfact_out = 1.0;
+  float prescfact_overlap_out = 1.0;
+
+  out_->Branch("DetId", &id_out, "DetId/i");
+  out_->Branch("Nhits", &nhits_out, "Nhits/i");
+  out_->Branch("Noverlaps", &noverlaps_out, "Noverlaps/i");
+  out_->Branch("SubDet", &subdet_out, "SubDet/I");
+  out_->Branch("Layer", &layer_out, "Layer/i");
+  out_->Branch("is2D", &is2D_out, "is2D/B");
   out_->Branch("isStereo", &isStereo_out, "isStereo/B");
-  out_->Branch("posX",     &posX_out,     "posX/F");
-  out_->Branch("posY",     &posY_out,     "posY/F");
-  out_->Branch("posZ",     &posZ_out,     "posZ/F");
-  out_->Branch("posR",     &posR_out,     "posR/F");
-  out_->Branch("posEta",   &posEta_out,   "posEta/F");
-  out_->Branch("posPhi",   &posPhi_out,   "posPhi/F");
-  out_->Branch("PrescaleFactor",&prescfact_out,"PrescaleFact/F");  
-  out_->Branch("PrescaleFactorOverlap",&prescfact_overlap_out,"PrescaleFactOverlap/F"); 
-
+  out_->Branch("posX", &posX_out, "posX/F");
+  out_->Branch("posY", &posY_out, "posY/F");
+  out_->Branch("posZ", &posZ_out, "posZ/F");
+  out_->Branch("posR", &posR_out, "posR/F");
+  out_->Branch("posEta", &posEta_out, "posEta/F");
+  out_->Branch("posPhi", &posPhi_out, "posPhi/F");
+  out_->Branch("PrescaleFactor", &prescfact_out, "PrescaleFact/F");
+  out_->Branch("PrescaleFactorOverlap", &prescfact_overlap_out, "PrescaleFactOverlap/F");
 
   //look if you find this detid in the map
   DetHitMap::iterator mapiter;
-  
-   for(int mod=0;mod<firsttree_->GetEntries();mod++){
-     //for(int mod=0;mod<100;++mod){
+
+  for (int mod = 0; mod < firsttree_->GetEntries(); mod++) {
+    //for(int mod=0;mod<100;++mod){
     //   nhits_out=0;
     // noverlaps_out=0;
- 
+
     firsttree_->GetEntry(mod);
-    nhits_out=hitmap_[id];
-    noverlaps_out=overlapmap_[id];
+    nhits_out = hitmap_[id];
+    noverlaps_out = overlapmap_[id];
     // if(mod<25)std::cout<<"Nhits 1st tree: "<<nhits<<"\tTotal nhits chain: "<<nhits_out<<std::endl;
-    id_out=id;
-    subdet_out=subdet;
-    layer_out=layer;
-    posX_out=posX;
-    posY_out=posY;
-    posZ_out=posZ;
-    posR_out=posR;
-    posEta_out=posEta;
-    posPhi_out=posPhi;
+    id_out = id;
+    subdet_out = subdet;
+    layer_out = layer;
+    posX_out = posX;
+    posY_out = posY;
+    posZ_out = posZ;
+    posR_out = posR;
+    posEta_out = posEta;
+    posPhi_out = posPhi;
 
     //calculate prescaling factor
-    int subdetmax=-1;
-    if(subdet_out==1)subdetmax=maxPXBhits_;
-    else if(subdet_out==2)subdetmax=maxPXFhits_;
-    else if(subdet_out==3)subdetmax=maxTIBhits_;
-    else if(subdet_out==4)subdetmax=maxTIDhits_;
-    else if(subdet_out==5)subdetmax=maxTOBhits_;
-    else if(subdet_out==6)subdetmax=maxTEChits_;
-    else subdetmax=-9999;
+    int subdetmax = -1;
+    if (subdet_out == 1)
+      subdetmax = maxPXBhits_;
+    else if (subdet_out == 2)
+      subdetmax = maxPXFhits_;
+    else if (subdet_out == 3)
+      subdetmax = maxTIBhits_;
+    else if (subdet_out == 4)
+      subdetmax = maxTIDhits_;
+    else if (subdet_out == 5)
+      subdetmax = maxTOBhits_;
+    else if (subdet_out == 6)
+      subdetmax = maxTEChits_;
+    else
+      subdetmax = -9999;
 
-    if(maxhits_>-1){
-      if(int(nhits_out)>maxhits_){
-	prescfact_out=float(maxhits_)/float(nhits_out);
+    if (maxhits_ > -1) {
+      if (int(nhits_out) > maxhits_) {
+        prescfact_out = float(maxhits_) / float(nhits_out);
       }
-      if(int(noverlaps_out)>maxhits_){
-	prescfact_overlap_out=float(maxhits_)/float(noverlaps_out);
+      if (int(noverlaps_out) > maxhits_) {
+        prescfact_overlap_out = float(maxhits_) / float(noverlaps_out);
       }
-    }
-    else if(subdetmax>0){//calculate different prescaling factors for each subdet
-      if(int(nhits_out)>subdetmax){
-	prescfact_out=float(subdetmax/nhits_out);
+    } else if (subdetmax > 0) {  //calculate different prescaling factors for each subdet
+      if (int(nhits_out) > subdetmax) {
+        prescfact_out = float(subdetmax / nhits_out);
       }
-     if(int(noverlaps_out)>subdetmax){
-	prescfact_overlap_out=float(subdetmax)/float(noverlaps_out);
+      if (int(noverlaps_out) > subdetmax) {
+        prescfact_overlap_out = float(subdetmax) / float(noverlaps_out);
       }
-    }
-    else{
-      prescfact_out=1.0;
-      prescfact_overlap_out=1.0;
+    } else {
+      prescfact_out = 1.0;
+      prescfact_overlap_out = 1.0;
     }
     out_->Fill();
 
-  }//end loop on mod - first tree modules
-
+  }  //end loop on mod - first tree modules
 
   myclock.Stop();
-  std::cout<<"Finished endJob after "<<myclock.RealTime()<<" s (real time) / "<<myclock.CpuTime()<<" s (cpu time)"<<std::endl;
-  std::cout<<"Ending the tree merging."<<std::endl;
+  std::cout << "Finished endJob after " << myclock.RealTime() << " s (real time) / " << myclock.CpuTime()
+            << " s (cpu time)" << std::endl;
+  std::cout << "Ending the tree merging." << std::endl;
   out_->Write();
-  std::cout<<"Deleting..."<<std::flush;
+  std::cout << "Deleting..." << std::flush;
   delete firstfile;
   delete outfile;
- 
-  
-}//end endJob
 
+}  //end endJob
 
 // ========= MODULE DEF ==============
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TkAlCaSkimTreeMerger);
-

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
@@ -39,238 +39,230 @@
 // made some variables constant, removed obviously dead code and comments
 
 TrackerSystematicMisalignments::TrackerSystematicMisalignments(const edm::ParameterSet& cfg)
-  : theAlignableTracker(nullptr)
-{
-	// use existing geometry
-	m_fromDBGeom = cfg.getUntrackedParameter< bool > ("fromDBGeom");
+    : theAlignableTracker(nullptr) {
+  // use existing geometry
+  m_fromDBGeom = cfg.getUntrackedParameter<bool>("fromDBGeom");
 
-	// constants
-	m_radialEpsilon = cfg.getUntrackedParameter< double > ("radialEpsilon");
-	m_telescopeEpsilon = cfg.getUntrackedParameter< double > ("telescopeEpsilon");
-	m_layerRotEpsilon = cfg.getUntrackedParameter< double > ("layerRotEpsilon");
-	m_bowingEpsilon = cfg.getUntrackedParameter< double > ("bowingEpsilon");
-	m_zExpEpsilon = cfg.getUntrackedParameter< double > ("zExpEpsilon");
-	m_twistEpsilon = cfg.getUntrackedParameter< double > ("twistEpsilon");
-	m_ellipticalEpsilon = cfg.getUntrackedParameter< double > ("ellipticalEpsilon");
-	m_skewEpsilon = cfg.getUntrackedParameter< double > ("skewEpsilon");
-	m_sagittaEpsilon = cfg.getUntrackedParameter< double > ("sagittaEpsilon");
+  // constants
+  m_radialEpsilon = cfg.getUntrackedParameter<double>("radialEpsilon");
+  m_telescopeEpsilon = cfg.getUntrackedParameter<double>("telescopeEpsilon");
+  m_layerRotEpsilon = cfg.getUntrackedParameter<double>("layerRotEpsilon");
+  m_bowingEpsilon = cfg.getUntrackedParameter<double>("bowingEpsilon");
+  m_zExpEpsilon = cfg.getUntrackedParameter<double>("zExpEpsilon");
+  m_twistEpsilon = cfg.getUntrackedParameter<double>("twistEpsilon");
+  m_ellipticalEpsilon = cfg.getUntrackedParameter<double>("ellipticalEpsilon");
+  m_skewEpsilon = cfg.getUntrackedParameter<double>("skewEpsilon");
+  m_sagittaEpsilon = cfg.getUntrackedParameter<double>("sagittaEpsilon");
 
-	m_ellipticalDelta = cfg.getUntrackedParameter< double > ("ellipticalDelta");
-	m_skewDelta = cfg.getUntrackedParameter< double > ("skewDelta");
-	m_sagittaDelta = cfg.getUntrackedParameter< double > ("sagittaDelta");
+  m_ellipticalDelta = cfg.getUntrackedParameter<double>("ellipticalDelta");
+  m_skewDelta = cfg.getUntrackedParameter<double>("skewDelta");
+  m_sagittaDelta = cfg.getUntrackedParameter<double>("sagittaDelta");
 
-	if (m_radialEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying radial ...";
-	}
-	if (m_telescopeEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying telescope ...";
-	}
-	if (m_layerRotEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying layer rotation ...";
-	}
-	if (m_bowingEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying bowing ...";
-	}
-	if (m_zExpEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying z-expansion ...";
-	}
-	if (m_twistEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying twist ...";
-	}
-	if (m_ellipticalEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying elliptical ...";
-	}
-	if (m_skewEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying skew ...";
-	}
-	if (m_sagittaEpsilon > -990.0){
-		edm::LogWarning("MisalignedTracker") << "Applying sagitta ...";
-	}
+  if (m_radialEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying radial ...";
+  }
+  if (m_telescopeEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying telescope ...";
+  }
+  if (m_layerRotEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying layer rotation ...";
+  }
+  if (m_bowingEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying bowing ...";
+  }
+  if (m_zExpEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying z-expansion ...";
+  }
+  if (m_twistEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying twist ...";
+  }
+  if (m_ellipticalEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying elliptical ...";
+  }
+  if (m_skewEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying skew ...";
+  }
+  if (m_sagittaEpsilon > -990.0) {
+    edm::LogWarning("MisalignedTracker") << "Applying sagitta ...";
+  }
 
-	// get flag for suppression of blind movements
-	suppressBlindMvmts = cfg.getUntrackedParameter< bool > ("suppressBlindMvmts");
-	if (suppressBlindMvmts)
-	{
-		edm::LogWarning("MisalignedTracker") << "Blind movements suppressed (TIB/TOB in z, TID/TEC in r)";
-	}
+  // get flag for suppression of blind movements
+  suppressBlindMvmts = cfg.getUntrackedParameter<bool>("suppressBlindMvmts");
+  if (suppressBlindMvmts) {
+    edm::LogWarning("MisalignedTracker") << "Blind movements suppressed (TIB/TOB in z, TID/TEC in r)";
+  }
 
-	// compatibility with old (weird) z convention
-	oldMinusZconvention = cfg.getUntrackedParameter< bool > ("oldMinusZconvention");
-	if (oldMinusZconvention)
-	{
-		edm::LogWarning("MisalignedTracker") << "Old z convention: dz --> -dz";
-	}
-	else
-	{
-		edm::LogWarning("MisalignedTracker") << "New z convention: dz --> dz";
-	}
-
+  // compatibility with old (weird) z convention
+  oldMinusZconvention = cfg.getUntrackedParameter<bool>("oldMinusZconvention");
+  if (oldMinusZconvention) {
+    edm::LogWarning("MisalignedTracker") << "Old z convention: dz --> -dz";
+  } else {
+    edm::LogWarning("MisalignedTracker") << "New z convention: dz --> dz";
+  }
 }
 
-void TrackerSystematicMisalignments::beginJob()
-{
+void TrackerSystematicMisalignments::beginJob() {}
 
+void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm::EventSetup& setup) {
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  const TrackerTopology* const tTopo = tTopoHandle.product();
+
+  edm::ESHandle<GeometricDet> geom;
+  setup.get<IdealGeometryRecord>().get(geom);
+  edm::ESHandle<PTrackerParameters> ptp;
+  setup.get<PTrackerParametersRcd>().get(ptp);
+  TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo);
+
+  //take geometry from DB or randomly generate geometry
+  if (m_fromDBGeom) {
+    //build the tracker
+    edm::ESHandle<Alignments> alignments;
+    edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
+
+    setup.get<TrackerAlignmentRcd>().get(alignments);
+    setup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+
+    edm::ESHandle<Alignments> globalPositionRcd;
+    setup.get<TrackerDigiGeometryRecord>().getRecord<GlobalPositionRcd>().get(globalPositionRcd);
+
+    //apply the latest alignments
+    GeometryAligner aligner;
+    aligner.applyAlignments<TrackerGeometry>(&(*tracker),
+                                             &(*alignments),
+                                             &(*alignmentErrors),
+                                             align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Tracker)));
+  }
+
+  theAlignableTracker = new AlignableTracker(&(*tracker), tTopo);
+
+  applySystematicMisalignment(&(*theAlignableTracker));
+
+  // -------------- writing out to alignment record --------------
+  Alignments* myAlignments = theAlignableTracker->alignments();
+  AlignmentErrorsExtended* myAlignmentErrorsExtended = theAlignableTracker->alignmentErrors();
+
+  // Store alignment[Error]s to DB
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  std::string theAlignRecordName = "TrackerAlignmentRcd";
+  std::string theErrorRecordName = "TrackerAlignmentErrorExtendedRcd";
+
+  // Call service
+  if (!poolDbService.isAvailable())  // Die if not available
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
+
+  poolDbService->writeOne<Alignments>(&(*myAlignments), poolDbService->beginOfTime(), theAlignRecordName);
+  poolDbService->writeOne<AlignmentErrorsExtended>(
+      &(*myAlignmentErrorsExtended), poolDbService->beginOfTime(), theErrorRecordName);
 }
 
+void TrackerSystematicMisalignments::applySystematicMisalignment(Alignable* ali) {
+  const align::Alignables& comp = ali->components();
+  unsigned int nComp = comp.size();
+  //move then do for lower level object
+  //for issue of det vs detunit
+  bool usecomps = true;
+  if ((ali->alignableObjectId() == 2) && (nComp >= 1))
+    usecomps = false;
+  for (unsigned int i = 0; i < nComp; ++i) {
+    if (usecomps)
+      applySystematicMisalignment(comp[i]);
+  }
 
-void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm::EventSetup& setup){
+  // if suppression of blind mvmts: check if subdet is blind to a certain mode
+  bool blindToZ(false), blindToR(false);
+  if (suppressBlindMvmts) {
+    const int subdetid = ali->geomDetId().subdetId();
+    switch (subdetid) {
+      // TIB/TON blind to z
+      case SiStripDetId::TIB:
+      case SiStripDetId::TOB:
+        blindToZ = true;
+        break;
+      // TID/TEC blind to R
+      case SiStripDetId::TID:
+      case SiStripDetId::TEC:
+        blindToR = true;
+        break;
+      default:
+        break;
+    }
+  }
 
-	//Retrieve tracker topology from geometry
-	edm::ESHandle<TrackerTopology> tTopoHandle;
-	setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-	const TrackerTopology* const tTopo = tTopoHandle.product();
-
-	edm::ESHandle<GeometricDet> geom;
-	setup.get<IdealGeometryRecord>().get(geom);
-	edm::ESHandle<PTrackerParameters> ptp;
-	setup.get<PTrackerParametersRcd>().get( ptp );
-	TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo );
-
-	//take geometry from DB or randomly generate geometry
-	if (m_fromDBGeom){
-		//build the tracker
-		edm::ESHandle<Alignments> alignments;
-		edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-
-		setup.get<TrackerAlignmentRcd>().get(alignments);
-		setup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
-
-		edm::ESHandle<Alignments> globalPositionRcd;
-		setup.get<TrackerDigiGeometryRecord>().getRecord<GlobalPositionRcd>().get(globalPositionRcd);
-
-		//apply the latest alignments
-		GeometryAligner aligner;
-		aligner.applyAlignments<TrackerGeometry>( &(*tracker), &(*alignments), &(*alignmentErrors),
-							  align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Tracker)));
-
-	}
-
-	theAlignableTracker = new AlignableTracker(&(*tracker), tTopo);
-
-	applySystematicMisalignment( &(*theAlignableTracker) );
-
-	// -------------- writing out to alignment record --------------
-	Alignments* myAlignments = theAlignableTracker->alignments() ;
-	AlignmentErrorsExtended* myAlignmentErrorsExtended = theAlignableTracker->alignmentErrors() ;
-
-	// Store alignment[Error]s to DB
-	edm::Service<cond::service::PoolDBOutputService> poolDbService;
-	std::string theAlignRecordName = "TrackerAlignmentRcd";
-	std::string theErrorRecordName = "TrackerAlignmentErrorExtendedRcd";
-
-	// Call service
-	if( !poolDbService.isAvailable() ) // Die if not available
-		throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
-
-	poolDbService->writeOne<Alignments>(&(*myAlignments), poolDbService->beginOfTime(), theAlignRecordName);
-	poolDbService->writeOne<AlignmentErrorsExtended>(&(*myAlignmentErrorsExtended), poolDbService->beginOfTime(), theErrorRecordName);
+  const int level = ali->alignableObjectId();
+  if ((level == 1) || (level == 2)) {
+    const align::PositionType gP = ali->globalPosition();
+    const align::GlobalVector gVec = findSystematicMis(gP, blindToZ, blindToR);
+    ali->move(gVec);
+  }
 }
 
-void TrackerSystematicMisalignments::applySystematicMisalignment(Alignable* ali)
-{
+align::GlobalVector TrackerSystematicMisalignments::findSystematicMis(const align::PositionType& globalPos,
+                                                                      const bool blindToZ,
+                                                                      const bool blindToR) {
+  //align::GlobalVector TrackerSystematicMisalignments::findSystematicMis( align::PositionType globalPos ){
+  // calculates shift for the current alignable
+  // all corrections are calculated w.r.t. the original geometry
+  double deltaX = 0.0;
+  double deltaY = 0.0;
+  double deltaZ = 0.0;
+  const double oldX = globalPos.x();
+  const double oldY = globalPos.y();
+  const double oldZ = globalPos.z();
+  const double oldPhi = globalPos.phi();
+  const double oldR = sqrt(globalPos.x() * globalPos.x() + globalPos.y() * globalPos.y());
 
-	const align::Alignables& comp = ali->components();
-	unsigned int nComp = comp.size();
-	//move then do for lower level object
-	//for issue of det vs detunit
-	bool usecomps = true;
-	if ((ali->alignableObjectId()==2)&&(nComp>=1)) usecomps = false;
-	for (unsigned int i = 0; i < nComp; ++i){
-		if (usecomps) applySystematicMisalignment(comp[i]);
-	}
+  if (m_radialEpsilon > -990.0 && !blindToR) {
+    deltaX += m_radialEpsilon * oldX;
+    deltaY += m_radialEpsilon * oldY;
+  }
+  if (m_telescopeEpsilon > -990.0 && !blindToZ) {
+    deltaZ += m_telescopeEpsilon * oldR;
+  }
+  if (m_layerRotEpsilon > -990.0) {
+    // The following number was chosen such that the Layer Rotation systematic
+    // misalignment would not cause an overall rotation of the tracker.
+    const double Roffset = 57.0;
+    const double xP = oldR * cos(oldPhi + m_layerRotEpsilon * (oldR - Roffset));
+    const double yP = oldR * sin(oldPhi + m_layerRotEpsilon * (oldR - Roffset));
+    deltaX += (xP - oldX);
+    deltaY += (yP - oldY);
+  }
+  if (m_bowingEpsilon > -990.0 && !blindToR) {
+    const double trackeredgePlusZ = 271.846;
+    const double bowfactor = m_bowingEpsilon * (trackeredgePlusZ * trackeredgePlusZ - oldZ * oldZ);
+    deltaX += oldX * bowfactor;
+    deltaY += oldY * bowfactor;
+  }
+  if (m_zExpEpsilon > -990.0 && !blindToZ) {
+    deltaZ += oldZ * m_zExpEpsilon;
+  }
+  if (m_twistEpsilon > -990.0) {
+    const double xP = oldR * cos(oldPhi + m_twistEpsilon * oldZ);
+    const double yP = oldR * sin(oldPhi + m_twistEpsilon * oldZ);
+    deltaX += (xP - oldX);
+    deltaY += (yP - oldY);
+  }
+  if (m_ellipticalEpsilon > -990.0 && !blindToR) {
+    deltaX += oldX * m_ellipticalEpsilon * cos(2.0 * oldPhi + m_ellipticalDelta);
+    deltaY += oldY * m_ellipticalEpsilon * cos(2.0 * oldPhi + m_ellipticalDelta);
+  }
+  if (m_skewEpsilon > -990.0 && !blindToZ) {
+    deltaZ += m_skewEpsilon * cos(oldPhi + m_skewDelta);
+  }
+  if (m_sagittaEpsilon > -990.0) {
+    // deltaX += oldX/fabs(oldX)*m_sagittaEpsilon; // old one...
+    deltaX += oldR * m_sagittaEpsilon * sin(m_sagittaDelta);
+    deltaY += oldR * m_sagittaEpsilon * cos(m_sagittaDelta);  //Delta y is cos so that delta=0 reflects the old behavior
+  }
 
-	// if suppression of blind mvmts: check if subdet is blind to a certain mode
-	bool blindToZ(false), blindToR(false);
-	if (suppressBlindMvmts)
-	{
-		const int subdetid = ali->geomDetId().subdetId();
-		switch(subdetid)
-		{
-			// TIB/TON blind to z
-			case SiStripDetId::TIB:
-			case SiStripDetId::TOB:
-				blindToZ = true;
-				break;
-			// TID/TEC blind to R
-			case SiStripDetId::TID:
-			case SiStripDetId::TEC:
-				blindToR = true;
-				break;
-			default:
-				break;
-		}
-	}
+  // Compatibility with old version <= 1.5
+  if (oldMinusZconvention)
+    deltaZ = -deltaZ;
 
-	const int level = ali->alignableObjectId();
-	if ((level == 1)||(level == 2)){
-		const align::PositionType gP = ali->globalPosition();
-		const align::GlobalVector gVec = findSystematicMis( gP, blindToZ, blindToR);
-		ali->move( gVec );
-	}
-}
-
-align::GlobalVector TrackerSystematicMisalignments::findSystematicMis( const align::PositionType& globalPos, const bool blindToZ, const bool blindToR ){
-//align::GlobalVector TrackerSystematicMisalignments::findSystematicMis( align::PositionType globalPos ){
-	// calculates shift for the current alignable
-	// all corrections are calculated w.r.t. the original geometry
-	double deltaX = 0.0;
-	double deltaY = 0.0;
-	double deltaZ = 0.0;
-	const double oldX = globalPos.x();
-	const double oldY = globalPos.y();
-	const double oldZ = globalPos.z();
-	const double oldPhi = globalPos.phi();
-	const double oldR = sqrt(globalPos.x()*globalPos.x() + globalPos.y()*globalPos.y());
-
-	if (m_radialEpsilon > -990.0 && !blindToR){
-		deltaX += m_radialEpsilon*oldX;
-		deltaY += m_radialEpsilon*oldY;
-	}
-	if (m_telescopeEpsilon > -990.0 && !blindToZ){
-		deltaZ += m_telescopeEpsilon*oldR;
-	}
-	if (m_layerRotEpsilon > -990.0){
-		// The following number was chosen such that the Layer Rotation systematic
-		// misalignment would not cause an overall rotation of the tracker.
-		const double Roffset = 57.0;
-		const double xP = oldR*cos(oldPhi+m_layerRotEpsilon*(oldR-Roffset));
-		const double yP = oldR*sin(oldPhi+m_layerRotEpsilon*(oldR-Roffset));
-		deltaX += (xP - oldX);
-		deltaY += (yP - oldY);
-	}
-	if (m_bowingEpsilon > -990.0 && !blindToR){
-		const double trackeredgePlusZ=271.846;
-		const double bowfactor=m_bowingEpsilon*(trackeredgePlusZ*trackeredgePlusZ-oldZ*oldZ);
-		deltaX += oldX*bowfactor;
-		deltaY += oldY*bowfactor;
-	}
-	if (m_zExpEpsilon > -990.0 && !blindToZ){
-		deltaZ += oldZ*m_zExpEpsilon;
-	}
-	if (m_twistEpsilon > -990.0){
-		const double xP = oldR*cos(oldPhi+m_twistEpsilon*oldZ);
-		const double yP = oldR*sin(oldPhi+m_twistEpsilon*oldZ);
-		deltaX += (xP - oldX);
-		deltaY += (yP - oldY);
-	}
-	if (m_ellipticalEpsilon > -990.0 && !blindToR){
-		deltaX += oldX*m_ellipticalEpsilon*cos(2.0*oldPhi + m_ellipticalDelta);
-		deltaY += oldY*m_ellipticalEpsilon*cos(2.0*oldPhi + m_ellipticalDelta);
-	}
-	if (m_skewEpsilon > -990.0 && !blindToZ){
-		deltaZ += m_skewEpsilon*cos(oldPhi + m_skewDelta);
-	}
-	if (m_sagittaEpsilon > -990.0){
-		// deltaX += oldX/fabs(oldX)*m_sagittaEpsilon; // old one...
-		deltaX += oldR*m_sagittaEpsilon*sin(m_sagittaDelta);
-		deltaY += oldR*m_sagittaEpsilon*cos(m_sagittaDelta);    //Delta y is cos so that delta=0 reflects the old behavior
-	}
-
-	// Compatibility with old version <= 1.5
-	if (oldMinusZconvention) deltaZ = -deltaZ;
-
-	align::GlobalVector gV( deltaX, deltaY, deltaZ );
-	return gV;
+  align::GlobalVector gV(deltaX, deltaY, deltaZ);
+  return gV;
 }
 
 // Plug in to framework

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.h
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.h
@@ -23,53 +23,45 @@ namespace edm {
   class ParameterSet;
 }
 
-class TrackerSystematicMisalignments:
-public edm::EDAnalyzer
-{
+class TrackerSystematicMisalignments : public edm::EDAnalyzer {
 public:
-	
-	TrackerSystematicMisalignments(
-								   const edm::ParameterSet&
-								   );
-	
-	/// Read ideal tracker geometry from DB
-	void beginJob() override;
-	
-	void analyze(const edm::Event&, const edm::EventSetup&) override;
-	
+  TrackerSystematicMisalignments(const edm::ParameterSet&);
+
+  /// Read ideal tracker geometry from DB
+  void beginJob() override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
 private:
-	
-	void applySystematicMisalignment( Alignable* ); 
-	//align::GlobalVector findSystematicMis( align::PositionType );
-	align::GlobalVector findSystematicMis( const align::PositionType&, const bool blindToZ, const bool blindToR );
-	
-	AlignableTracker* theAlignableTracker;
-	
-	
-	
-	// configurables needed for the systematic misalignment
-	bool m_fromDBGeom;
-	
-	double m_radialEpsilon;
-	double m_telescopeEpsilon;
-	double m_layerRotEpsilon;
-	double m_bowingEpsilon;
-	double m_zExpEpsilon;
-	double m_twistEpsilon;
-	double m_ellipticalEpsilon;
-	double m_skewEpsilon;
-	double m_sagittaEpsilon;
+  void applySystematicMisalignment(Alignable*);
+  //align::GlobalVector findSystematicMis( align::PositionType );
+  align::GlobalVector findSystematicMis(const align::PositionType&, const bool blindToZ, const bool blindToR);
 
-        //misalignment phases
-        double m_ellipticalDelta;
-        double m_skewDelta;
-        double m_sagittaDelta;
+  AlignableTracker* theAlignableTracker;
 
-	// flag to steer suppression of blind movements
-	bool suppressBlindMvmts;
+  // configurables needed for the systematic misalignment
+  bool m_fromDBGeom;
 
-	// flag for old z behaviour, version <= 1.5
-	bool oldMinusZconvention;
+  double m_radialEpsilon;
+  double m_telescopeEpsilon;
+  double m_layerRotEpsilon;
+  double m_bowingEpsilon;
+  double m_zExpEpsilon;
+  double m_twistEpsilon;
+  double m_ellipticalEpsilon;
+  double m_skewEpsilon;
+  double m_sagittaEpsilon;
+
+  //misalignment phases
+  double m_ellipticalDelta;
+  double m_skewDelta;
+  double m_sagittaDelta;
+
+  // flag to steer suppression of blind movements
+  bool suppressBlindMvmts;
+
+  // flag for old z behaviour, version <= 1.5
+  bool oldMinusZconvention;
 };
 
 #endif

--- a/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -90,22 +89,17 @@ private:
 //
 // constructors and destructor
 //
-TrackerTreeGenerator::TrackerTreeGenerator(const edm::ParameterSet& config):
-  createEntryForDoubleSidedModule_(config.getParameter<bool>("createEntryForDoubleSidedModule")),
-  config_(config)
-{
+TrackerTreeGenerator::TrackerTreeGenerator(const edm::ParameterSet& config)
+    : createEntryForDoubleSidedModule_(config.getParameter<bool>("createEntryForDoubleSidedModule")), config_(config) {
   usesResource(TFileService::kSharedResource);
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-TrackerTreeGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void TrackerTreeGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //iSetup.get<TrackerDigiGeometryRecord>().get(tkGeom);
   // now try to take directly the ideal geometry independent of used geometry in Global Tag
   edm::ESHandle<GeometricDet> geometricDet;
@@ -123,197 +117,174 @@ TrackerTreeGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   AlignableTracker alignableTracker{tkGeom, tTopo};
   const auto& ns = alignableTracker.trackerNameSpace();
 
-  edm::LogInfo("TrackerTreeGenerator")
-    << "@SUB=TrackerTreeGenerator::analyze"
-    << "There are " << tkGeom->detIds().size()
-    << " dets and "<<tkGeom->detUnitIds().size()
-    <<" detUnits in the Geometry Record";
+  edm::LogInfo("TrackerTreeGenerator") << "@SUB=TrackerTreeGenerator::analyze"
+                                       << "There are " << tkGeom->detIds().size() << " dets and "
+                                       << tkGeom->detUnitIds().size() << " detUnits in the Geometry Record";
 
   if (createEntryForDoubleSidedModule_) {
-    edm::LogInfo("TrackerTreeGenerator")
-      << "@SUB=TrackerTreeGenerator::analyze"
-      << "Create entry for each module AND one entry for virtual "
-      << "double-sided module in addition";
+    edm::LogInfo("TrackerTreeGenerator") << "@SUB=TrackerTreeGenerator::analyze"
+                                         << "Create entry for each module AND one entry for virtual "
+                                         << "double-sided module in addition";
   } else {
-    edm::LogInfo("TrackerTreeGenerator")
-      << "@SUB=TrackerTreeGenerator::analyze"
-      << "Create one entry for each physical module, do NOT create additional "
-      << "entry for virtual double-sided module";
+    edm::LogInfo("TrackerTreeGenerator") << "@SUB=TrackerTreeGenerator::analyze"
+                                         << "Create one entry for each physical module, do NOT create additional "
+                                         << "entry for virtual double-sided module";
   }
 
-  for (const auto& detId: tkGeom->detIds()){
-
+  for (const auto& detId : tkGeom->detIds()) {
     const GeomDet& geomDet = *tkGeom->idToDet(detId);
     const Surface& surface = geomDet.surface();
 
     TrackerTreeVariables tkTreeVar;
     const auto rawId = detId.rawId();
-    tkTreeVar.rawId    = rawId;
+    tkTreeVar.rawId = rawId;
     tkTreeVar.subdetId = detId.subdetId();
 
     switch (tkTreeVar.subdetId) {
-    case PixelSubdetector::PixelBarrel:
-      tkTreeVar.layer  = tTopo->pxbLayer(detId);
-      tkTreeVar.half   = ns.tpb().halfBarrelNumber(rawId);
-      tkTreeVar.rod    = tTopo->pxbLadder(detId);     // ... so, ladder is not per halfBarrel-Layer, but per barrel-layer!
-      tkTreeVar.module = tTopo->pxbModule(detId);
-      break;
-    case PixelSubdetector::PixelEndcap:
-      tkTreeVar.layer  = tTopo->pxfDisk(detId);
-      tkTreeVar.side   = tTopo->pxfSide(detId);
-      tkTreeVar.half   = ns.tpe().halfCylinderNumber(rawId);
-      tkTreeVar.blade  = tTopo->pxfBlade(detId);
-      tkTreeVar.panel  = tTopo->pxfPanel(detId);
-      tkTreeVar.module = tTopo->pxfModule(detId);
-      break;
-    case StripSubdetector::TIB:
-      tkTreeVar.layer        = tTopo->tibLayer(detId);
-      tkTreeVar.side         = tTopo->tibStringInfo(detId)[0];
-      tkTreeVar.half         = ns.tib().halfShellNumber(rawId);
-      tkTreeVar.rod          = tTopo->tibStringInfo(detId)[2];
-      tkTreeVar.outerInner   = tTopo->tibStringInfo(detId)[1];
-      tkTreeVar.module       = tTopo->tibModule(detId);
-      tkTreeVar.isDoubleSide = tTopo->tibIsDoubleSide(detId);
-      tkTreeVar.isRPhi       = tTopo->tibIsRPhi(detId);
-      tkTreeVar.isStereo     = tTopo->tibIsStereo(detId);
-      break;
-    case StripSubdetector::TID:
-      tkTreeVar.layer        = tTopo->tidWheel(detId);
-      tkTreeVar.side         = tTopo->tidSide(detId);
-      tkTreeVar.ring         = tTopo->tidRing(detId);
-      tkTreeVar.outerInner   = tTopo->tidModuleInfo(detId)[0];
-      tkTreeVar.module       = tTopo->tidModuleInfo(detId)[1];
-      tkTreeVar.isDoubleSide = tTopo->tidIsDoubleSide(detId);
-      tkTreeVar.isRPhi       = tTopo->tidIsRPhi(detId);
-      tkTreeVar.isStereo     = tTopo->tidIsStereo(detId);
-      break;
-    case StripSubdetector::TOB:
-      tkTreeVar.layer        = tTopo->tobLayer(detId);
-      tkTreeVar.side         = tTopo->tobRodInfo(detId)[0];
-      tkTreeVar.rod          = tTopo->tobRodInfo(detId)[1];
-      tkTreeVar.module       = tTopo->tobModule(detId);
-      tkTreeVar.isDoubleSide = tTopo->tobIsDoubleSide(detId);
-      tkTreeVar.isRPhi       = tTopo->tobIsRPhi(detId);
-      tkTreeVar.isStereo     = tTopo->tobIsStereo(detId);
-      break;
-    case StripSubdetector::TEC:
-      tkTreeVar.layer        = tTopo->tecWheel(detId);
-      tkTreeVar.side         = tTopo->tecSide(detId);
-      tkTreeVar.ring         = tTopo->tecRing(detId);
-      tkTreeVar.petal        = tTopo->tecPetalInfo(detId)[1];
-      tkTreeVar.outerInner   = tTopo->tecPetalInfo(detId)[0];
-      tkTreeVar.module       = tTopo->tecModule(detId);
-      tkTreeVar.isDoubleSide = tTopo->tecIsDoubleSide(detId);
-      tkTreeVar.isRPhi       = tTopo->tecIsRPhi(detId);
-      tkTreeVar.isStereo     = tTopo->tecIsStereo(detId);
-      break;
+      case PixelSubdetector::PixelBarrel:
+        tkTreeVar.layer = tTopo->pxbLayer(detId);
+        tkTreeVar.half = ns.tpb().halfBarrelNumber(rawId);
+        tkTreeVar.rod = tTopo->pxbLadder(detId);  // ... so, ladder is not per halfBarrel-Layer, but per barrel-layer!
+        tkTreeVar.module = tTopo->pxbModule(detId);
+        break;
+      case PixelSubdetector::PixelEndcap:
+        tkTreeVar.layer = tTopo->pxfDisk(detId);
+        tkTreeVar.side = tTopo->pxfSide(detId);
+        tkTreeVar.half = ns.tpe().halfCylinderNumber(rawId);
+        tkTreeVar.blade = tTopo->pxfBlade(detId);
+        tkTreeVar.panel = tTopo->pxfPanel(detId);
+        tkTreeVar.module = tTopo->pxfModule(detId);
+        break;
+      case StripSubdetector::TIB:
+        tkTreeVar.layer = tTopo->tibLayer(detId);
+        tkTreeVar.side = tTopo->tibStringInfo(detId)[0];
+        tkTreeVar.half = ns.tib().halfShellNumber(rawId);
+        tkTreeVar.rod = tTopo->tibStringInfo(detId)[2];
+        tkTreeVar.outerInner = tTopo->tibStringInfo(detId)[1];
+        tkTreeVar.module = tTopo->tibModule(detId);
+        tkTreeVar.isDoubleSide = tTopo->tibIsDoubleSide(detId);
+        tkTreeVar.isRPhi = tTopo->tibIsRPhi(detId);
+        tkTreeVar.isStereo = tTopo->tibIsStereo(detId);
+        break;
+      case StripSubdetector::TID:
+        tkTreeVar.layer = tTopo->tidWheel(detId);
+        tkTreeVar.side = tTopo->tidSide(detId);
+        tkTreeVar.ring = tTopo->tidRing(detId);
+        tkTreeVar.outerInner = tTopo->tidModuleInfo(detId)[0];
+        tkTreeVar.module = tTopo->tidModuleInfo(detId)[1];
+        tkTreeVar.isDoubleSide = tTopo->tidIsDoubleSide(detId);
+        tkTreeVar.isRPhi = tTopo->tidIsRPhi(detId);
+        tkTreeVar.isStereo = tTopo->tidIsStereo(detId);
+        break;
+      case StripSubdetector::TOB:
+        tkTreeVar.layer = tTopo->tobLayer(detId);
+        tkTreeVar.side = tTopo->tobRodInfo(detId)[0];
+        tkTreeVar.rod = tTopo->tobRodInfo(detId)[1];
+        tkTreeVar.module = tTopo->tobModule(detId);
+        tkTreeVar.isDoubleSide = tTopo->tobIsDoubleSide(detId);
+        tkTreeVar.isRPhi = tTopo->tobIsRPhi(detId);
+        tkTreeVar.isStereo = tTopo->tobIsStereo(detId);
+        break;
+      case StripSubdetector::TEC:
+        tkTreeVar.layer = tTopo->tecWheel(detId);
+        tkTreeVar.side = tTopo->tecSide(detId);
+        tkTreeVar.ring = tTopo->tecRing(detId);
+        tkTreeVar.petal = tTopo->tecPetalInfo(detId)[1];
+        tkTreeVar.outerInner = tTopo->tecPetalInfo(detId)[0];
+        tkTreeVar.module = tTopo->tecModule(detId);
+        tkTreeVar.isDoubleSide = tTopo->tecIsDoubleSide(detId);
+        tkTreeVar.isRPhi = tTopo->tecIsRPhi(detId);
+        tkTreeVar.isStereo = tTopo->tecIsStereo(detId);
+        break;
     }
 
-
-    LocalPoint lPModule(0.,0.,0.),
-               lUDirection(1.,0.,0.),
-               lVDirection(0.,1.,0.),
-               lWDirection(0.,0.,1.);
-    GlobalPoint gPModule    = surface.toGlobal(lPModule),
-                gUDirection = surface.toGlobal(lUDirection),
-                gVDirection = surface.toGlobal(lVDirection),
-                gWDirection = surface.toGlobal(lWDirection);
+    LocalPoint lPModule(0., 0., 0.), lUDirection(1., 0., 0.), lVDirection(0., 1., 0.), lWDirection(0., 0., 1.);
+    GlobalPoint gPModule = surface.toGlobal(lPModule), gUDirection = surface.toGlobal(lUDirection),
+                gVDirection = surface.toGlobal(lVDirection), gWDirection = surface.toGlobal(lWDirection);
     double dR(999.), dPhi(999.), dZ(999.);
     switch (tkTreeVar.subdetId) {
-    case PixelSubdetector::PixelBarrel:
-    case StripSubdetector::TIB:
-    case StripSubdetector::TOB:
-      dR   = gWDirection.perp() - gPModule.perp();
-      dPhi = deltaPhi(gUDirection.barePhi(),gPModule.barePhi());
-      dZ   = gVDirection.z() - gPModule.z();
-      tkTreeVar.uDirection = dPhi>0. ? 1 : -1;
-      tkTreeVar.vDirection = dZ>0.   ? 1 : -1;
-      tkTreeVar.wDirection = dR>0.   ? 1 : -1;
-      break;
-    case PixelSubdetector::PixelEndcap:
-      dR   = gUDirection.perp() - gPModule.perp();
-      dPhi = deltaPhi(gVDirection.barePhi(),gPModule.barePhi());
-      dZ   = gWDirection.z() - gPModule.z();
-      tkTreeVar.uDirection = dR>0.   ? 1 : -1;
-      tkTreeVar.vDirection = dPhi>0. ? 1 : -1;
-      tkTreeVar.wDirection = dZ>0.   ? 1 : -1;
-      break;
-    case StripSubdetector::TID:
-    case StripSubdetector::TEC:
-      dR = gVDirection.perp() - gPModule.perp();
-      dPhi = deltaPhi(gUDirection.barePhi(),gPModule.barePhi());
-      dZ = gWDirection.z() - gPModule.z();
-      tkTreeVar.uDirection = dPhi>0. ? 1 : -1;
-      tkTreeVar.vDirection = dR>0.   ? 1 : -1;
-      tkTreeVar.wDirection = dZ>0.   ? 1 : -1;
-      break;
-    }
-    tkTreeVar.posR         = gPModule.perp();
-    tkTreeVar.posPhi       = gPModule.barePhi();     // = gPModule.barePhi().degrees();
-    tkTreeVar.posEta       = gPModule.eta();
-    tkTreeVar.posX         = gPModule.x();
-    tkTreeVar.posY         = gPModule.y();
-    tkTreeVar.posZ         = gPModule.z();
-
-
-    if(auto stripGeomDetUnit = dynamic_cast<const StripGeomDetUnit*>(&geomDet)){  //is it a single physical module?
-      switch (tkTreeVar.subdetId) {
+      case PixelSubdetector::PixelBarrel:
       case StripSubdetector::TIB:
       case StripSubdetector::TOB:
+        dR = gWDirection.perp() - gPModule.perp();
+        dPhi = deltaPhi(gUDirection.barePhi(), gPModule.barePhi());
+        dZ = gVDirection.z() - gPModule.z();
+        tkTreeVar.uDirection = dPhi > 0. ? 1 : -1;
+        tkTreeVar.vDirection = dZ > 0. ? 1 : -1;
+        tkTreeVar.wDirection = dR > 0. ? 1 : -1;
+        break;
+      case PixelSubdetector::PixelEndcap:
+        dR = gUDirection.perp() - gPModule.perp();
+        dPhi = deltaPhi(gVDirection.barePhi(), gPModule.barePhi());
+        dZ = gWDirection.z() - gPModule.z();
+        tkTreeVar.uDirection = dR > 0. ? 1 : -1;
+        tkTreeVar.vDirection = dPhi > 0. ? 1 : -1;
+        tkTreeVar.wDirection = dZ > 0. ? 1 : -1;
+        break;
       case StripSubdetector::TID:
       case StripSubdetector::TEC:
-        auto& topol =
-          dynamic_cast<const StripTopology&>(stripGeomDetUnit->specificTopology());
-        tkTreeVar.nStrips = topol.nstrips();
+        dR = gVDirection.perp() - gPModule.perp();
+        dPhi = deltaPhi(gUDirection.barePhi(), gPModule.barePhi());
+        dZ = gWDirection.z() - gPModule.z();
+        tkTreeVar.uDirection = dPhi > 0. ? 1 : -1;
+        tkTreeVar.vDirection = dR > 0. ? 1 : -1;
+        tkTreeVar.wDirection = dZ > 0. ? 1 : -1;
         break;
+    }
+    tkTreeVar.posR = gPModule.perp();
+    tkTreeVar.posPhi = gPModule.barePhi();  // = gPModule.barePhi().degrees();
+    tkTreeVar.posEta = gPModule.eta();
+    tkTreeVar.posX = gPModule.x();
+    tkTreeVar.posY = gPModule.y();
+    tkTreeVar.posZ = gPModule.z();
+
+    if (auto stripGeomDetUnit = dynamic_cast<const StripGeomDetUnit*>(&geomDet)) {  //is it a single physical module?
+      switch (tkTreeVar.subdetId) {
+        case StripSubdetector::TIB:
+        case StripSubdetector::TOB:
+        case StripSubdetector::TID:
+        case StripSubdetector::TEC:
+          auto& topol = dynamic_cast<const StripTopology&>(stripGeomDetUnit->specificTopology());
+          tkTreeVar.nStrips = topol.nstrips();
+          break;
       }
     }
 
-
-    if(!createEntryForDoubleSidedModule_){
+    if (!createEntryForDoubleSidedModule_) {
       // do so only for individual modules and not also one entry for the combined doubleSided Module
-      if (tkTreeVar.isDoubleSide) continue;
+      if (tkTreeVar.isDoubleSide)
+        continue;
     }
     vTkTreeVar_.push_back(tkTreeVar);
   }
-
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-TrackerTreeGenerator::beginJob()
-{
-}
-
+void TrackerTreeGenerator::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-TrackerTreeGenerator::endJob() {
-  UInt_t rawId(999), subdetId(999), layer(999), side(999), half(999), rod(999),
-    ring(999), petal(999), blade(999), panel(999), outerInner(999),
-    module(999), nStrips(999);
+void TrackerTreeGenerator::endJob() {
+  UInt_t rawId(999), subdetId(999), layer(999), side(999), half(999), rod(999), ring(999), petal(999), blade(999),
+      panel(999), outerInner(999), module(999), nStrips(999);
   Bool_t isDoubleSide(false), isRPhi(false), isStereo(false);
   Int_t uDirection(999), vDirection(999), wDirection(999);
-  Float_t posR(999.F), posPhi(999.F), posEta(999.F),
-    posX(999.F), posY(999.F), posZ(999.F);
+  Float_t posR(999.F), posPhi(999.F), posEta(999.F), posX(999.F), posY(999.F), posZ(999.F);
 
   edm::Service<TFileService> fileService;
   TFileDirectory treeDir = fileService->mkdir("TrackerTree");
-  auto trackerTree{treeDir.make<TTree>("TrackerTree",
-                                       "IDs of all modules (ideal geometry)")};
+  auto trackerTree{treeDir.make<TTree>("TrackerTree", "IDs of all modules (ideal geometry)")};
   trackerTree->Branch("RawId", &rawId, "RawId/i");
   trackerTree->Branch("SubdetId", &subdetId, "SubdetId/i");
-  trackerTree->Branch("Layer", &layer, "Layer/i");                // Barrel: Layer, Forward: Disk
-  trackerTree->Branch("Side", &side, "Side/i");                   // Rod/Ring in +z or -z
-  trackerTree->Branch("Half", &half, "Half/i");                   // PXB: HalfBarrel, PXF: HalfCylinder, TIB: HalfShell
-  trackerTree->Branch("Rod", &rod, "Rod/i");                      // Barrel (Ladder or String or Rod)
-  trackerTree->Branch("Ring", &ring, "Ring/i");                   // Forward
-  trackerTree->Branch("Petal", &petal, "Petal/i");                // TEC
-  trackerTree->Branch("Blade", &blade, "Blade/i");                // PXF
-  trackerTree->Branch("Panel", &panel, "Panel/i");                // PXF
-  trackerTree->Branch("OuterInner", &outerInner, "OuterInner/i"); // front/back String,Ring,Petal
-  trackerTree->Branch("Module", &module, "Module/i");             // Module ID
+  trackerTree->Branch("Layer", &layer, "Layer/i");                 // Barrel: Layer, Forward: Disk
+  trackerTree->Branch("Side", &side, "Side/i");                    // Rod/Ring in +z or -z
+  trackerTree->Branch("Half", &half, "Half/i");                    // PXB: HalfBarrel, PXF: HalfCylinder, TIB: HalfShell
+  trackerTree->Branch("Rod", &rod, "Rod/i");                       // Barrel (Ladder or String or Rod)
+  trackerTree->Branch("Ring", &ring, "Ring/i");                    // Forward
+  trackerTree->Branch("Petal", &petal, "Petal/i");                 // TEC
+  trackerTree->Branch("Blade", &blade, "Blade/i");                 // PXF
+  trackerTree->Branch("Panel", &panel, "Panel/i");                 // PXF
+  trackerTree->Branch("OuterInner", &outerInner, "OuterInner/i");  // front/back String,Ring,Petal
+  trackerTree->Branch("Module", &module, "Module/i");              // Module ID
   trackerTree->Branch("NStrips", &nStrips, "NStrips/i");
   trackerTree->Branch("IsDoubleSide", &isDoubleSide, "IsDoubleSide/O");
   trackerTree->Branch("IsRPhi", &isRPhi, "IsRPhi/O");
@@ -328,40 +299,38 @@ TrackerTreeGenerator::endJob() {
   trackerTree->Branch("PosY", &posY, "PosY/F");
   trackerTree->Branch("PosZ", &posZ, "PosZ/F");
 
-  for(const auto& iTree: vTkTreeVar_){
-    rawId        = iTree.rawId;
-    subdetId     = iTree.subdetId;
-    layer        = iTree.layer;
-    side         = iTree.side;
-    half         = iTree.half;
-    rod          = iTree.rod;
-    ring         = iTree.ring;
-    petal        = iTree.petal;
-    blade        = iTree.blade;
-    panel        = iTree.panel;
-    outerInner   = iTree.outerInner;
-    module       = iTree.module;
-    nStrips      = iTree.nStrips;
+  for (const auto& iTree : vTkTreeVar_) {
+    rawId = iTree.rawId;
+    subdetId = iTree.subdetId;
+    layer = iTree.layer;
+    side = iTree.side;
+    half = iTree.half;
+    rod = iTree.rod;
+    ring = iTree.ring;
+    petal = iTree.petal;
+    blade = iTree.blade;
+    panel = iTree.panel;
+    outerInner = iTree.outerInner;
+    module = iTree.module;
+    nStrips = iTree.nStrips;
     isDoubleSide = iTree.isDoubleSide;
-    isRPhi       = iTree.isRPhi;
-    isStereo     = iTree.isStereo;
-    uDirection   = iTree.uDirection;
-    vDirection   = iTree.vDirection;
-    wDirection   = iTree.wDirection;
-    posR         = iTree.posR;
-    posPhi       = iTree.posPhi;
-    posEta       = iTree.posEta;
-    posX         = iTree.posX;
-    posY         = iTree.posY;
-    posZ         = iTree.posZ;
+    isRPhi = iTree.isRPhi;
+    isStereo = iTree.isStereo;
+    uDirection = iTree.uDirection;
+    vDirection = iTree.vDirection;
+    wDirection = iTree.wDirection;
+    posR = iTree.posR;
+    posPhi = iTree.posPhi;
+    posEta = iTree.posEta;
+    posX = iTree.posX;
+    posY = iTree.posY;
+    posZ = iTree.posZ;
 
     trackerTree->Fill();
   }
-  edm::LogInfo("TrackerTreeGenerator")
-    << "@SUB=TrackerTreeGenerator::endJob"
-    << "TrackerTree contains "<< vTkTreeVar_.size() <<" entries overall";
+  edm::LogInfo("TrackerTreeGenerator") << "@SUB=TrackerTreeGenerator::endJob"
+                                       << "TrackerTree contains " << vTkTreeVar_.size() << " entries overall";
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(TrackerTreeGenerator);

--- a/Alignment/TrackerAlignment/src/AlignableSiStripDet.cc
+++ b/Alignment/TrackerAlignment/src/AlignableSiStripDet.cc
@@ -4,7 +4,7 @@
  */
 
 #include "Alignment/TrackerAlignment/interface/AlignableSiStripDet.h"
- 
+
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
@@ -23,80 +23,73 @@
 
 #include <cmath>
 
-AlignableSiStripDet::AlignableSiStripDet(const GluedGeomDet *gluedDet) 
-  : AlignableDet(gluedDet, true), // true: adding DetUnits
-    theMonoBounds  (gluedDet->monoDet()  ->surface().bounds().clone()),
-    theStereoBounds(gluedDet->stereoDet()->surface().bounds().clone()),
-    theMonoType  (static_cast<const StripGeomDetUnit*>(gluedDet->monoDet())  ->specificType()),
-    theStereoType(static_cast<const StripGeomDetUnit*>(gluedDet->stereoDet())->specificType())
-{
+AlignableSiStripDet::AlignableSiStripDet(const GluedGeomDet* gluedDet)
+    : AlignableDet(gluedDet, true),  // true: adding DetUnits
+      theMonoBounds(gluedDet->monoDet()->surface().bounds().clone()),
+      theStereoBounds(gluedDet->stereoDet()->surface().bounds().clone()),
+      theMonoType(static_cast<const StripGeomDetUnit*>(gluedDet->monoDet())->specificType()),
+      theStereoType(static_cast<const StripGeomDetUnit*>(gluedDet->stereoDet())->specificType()) {
   // It is not allowed to store a pointer to GeomDet within objects with a life time
-  // longer than an Event: 
+  // longer than an Event:
   // GeomDet comes from TrackerGeometry that is created from GeometricDet that depends on
   // IdealGeometryRecord from EventSetup, so it could change in next event!
-  //  ==> Need to store directly what I need from it. 
+  //  ==> Need to store directly what I need from it.
   // Unfortunately the current way with references for the type does not solve that,
   // either. But currently no way out, see header file.
 
   // check order mono/stereo
   const Alignables units(this->components());
-  if (units.size() != 2
-      || gluedDet->monoDet()->geographicalId() != units[0]->geomDetId()
-      || gluedDet->stereoDet()->geographicalId() != units[1]->geomDetId()) {
-    throw cms::Exception("LogicError")
-      << "[AlignableSiStripDet] " << "Either != 2 components or "
-      << "mono/stereo in wrong order for consistifyAlignments.";
+  if (units.size() != 2 || gluedDet->monoDet()->geographicalId() != units[0]->geomDetId() ||
+      gluedDet->stereoDet()->geographicalId() != units[1]->geomDetId()) {
+    throw cms::Exception("LogicError") << "[AlignableSiStripDet] "
+                                       << "Either != 2 components or "
+                                       << "mono/stereo in wrong order for consistifyAlignments.";
   }
 }
 
 //__________________________________________________________________________________________________
-AlignableSiStripDet::~AlignableSiStripDet()
-{
+AlignableSiStripDet::~AlignableSiStripDet() {
   delete theMonoBounds;
   delete theStereoBounds;
 }
 
 //__________________________________________________________________________________________________
-Alignments* AlignableSiStripDet::alignments() const
-{
+Alignments* AlignableSiStripDet::alignments() const {
   const_cast<AlignableSiStripDet*>(this)->consistifyAlignments();
 
   return this->AlignableDet::alignments();
 }
 
 //__________________________________________________________________________________________________
-void AlignableSiStripDet::consistifyAlignments()
-{
+void AlignableSiStripDet::consistifyAlignments() {
   // make alignments consistent with daughters, calling method from geometry
 
   // The aim of all this gymnastics is to have the alignments calculated by
   // PlaneBuilderForGluedDet::plane(const std::vector<const GeomDetUnit*> &detComps);
-  // 
+  //
   // So we take the (new) position and orientation from the AligableDetUnits,
   // but bounds and GeomDetType from original GeomDetUnits to create new GeomDetUnits
   // that are passed to that routine.
 
-  const Alignables aliUnits(this->components()); // order mono==0, stereo==1 checked in ctr.
+  const Alignables aliUnits(this->components());  // order mono==0, stereo==1 checked in ctr.
 
-  BoundPlane::BoundPlanePointer monoPlane
-    = BoundPlane::build(aliUnits[0]->globalPosition(), aliUnits[0]->globalRotation(),
-			theMonoBounds->clone());
+  BoundPlane::BoundPlanePointer monoPlane =
+      BoundPlane::build(aliUnits[0]->globalPosition(), aliUnits[0]->globalRotation(), theMonoBounds->clone());
   // Fortunately we do not seem to need a GeometricDet pointer and can use 0:
   const StripGeomDetUnit monoDet(&(*monoPlane), &theMonoType, 0);
 
-  BoundPlane::BoundPlanePointer stereoPlane
-    = BoundPlane::build(aliUnits[1]->globalPosition(), aliUnits[1]->globalRotation(),
-			theStereoBounds->clone());
+  BoundPlane::BoundPlanePointer stereoPlane =
+      BoundPlane::build(aliUnits[1]->globalPosition(), aliUnits[1]->globalRotation(), theStereoBounds->clone());
   // Fortunately we do not seem to need a GeometricDet pointer and can use 0:
   const StripGeomDetUnit stereoDet(&(*stereoPlane), &theStereoType, 0);
 
   std::vector<const GeomDetUnit*> detComps;
-  detComps.push_back(&monoDet);   // order mono first, stereo second should be as in...
-  detComps.push_back(&stereoDet); // ...TrackerGeomBuilderFromGeometricDet::buildGeomDet
+  detComps.push_back(&monoDet);    // order mono first, stereo second should be as in...
+  detComps.push_back(&stereoDet);  // ...TrackerGeomBuilderFromGeometricDet::buildGeomDet
 
   // Now we have all to calculate new position and rotation via PlaneBuilderForGluedDet.
-  const PositionType oldPos(theSurface.position()); // From old surface for keeping...
-  const RotationType oldRot(theSurface.rotation()); // ...track of changes.
+  const PositionType oldPos(theSurface.position());  // From old surface for keeping...
+  const RotationType oldRot(theSurface.rotation());  // ...track of changes.
 
   PlaneBuilderForGluedDet planeBuilder;
   theSurface = AlignableSurface(*planeBuilder.plane(detComps));
@@ -108,14 +101,13 @@ void AlignableSiStripDet::consistifyAlignments()
   this->addDisplacement(movement);
   this->addRotation(rotation);
 
-//   this->dumpCompareEuler(oldRot, theSurface.rotation());
+  //   this->dumpCompareEuler(oldRot, theSurface.rotation());
 
-//   if (movement.mag2()) { // > 1.e-10) { 
-//     edm::LogWarning("Alignment") << "@SUB=consistifyAlignments" 
-//                                  << "Delta: " << movement.x() << " " << movement.y() << " " << movement.z()
-//                                  << "\nPos: " << oldPos.perp() << " " << oldPos.phi() << " " << oldPos.z();
-//   }
-
+  //   if (movement.mag2()) { // > 1.e-10) {
+  //     edm::LogWarning("Alignment") << "@SUB=consistifyAlignments"
+  //                                  << "Delta: " << movement.x() << " " << movement.y() << " " << movement.z()
+  //                                  << "\nPos: " << oldPos.perp() << " " << oldPos.phi() << " " << oldPos.z();
+  //   }
 }
 
 // #include "CLHEP/Vector/EulerAngles.h"
@@ -124,7 +116,7 @@ void AlignableSiStripDet::consistifyAlignments()
 // void AlignableSiStripDet::dumpCompareEuler(const RotationType &oldRot,
 // 					   const RotationType &newRot) const
 // {
-//   // 
+//   //
 //   const HepRotation oldClhep(HepRep3x3(oldRot.xx(), oldRot.xy(), oldRot.xz(),
 // 				       oldRot.yx(), oldRot.yy(), oldRot.yz(),
 // 				       oldRot.zx(), oldRot.zy(), oldRot.zz()));
@@ -139,10 +131,10 @@ void AlignableSiStripDet::consistifyAlignments()
 // 				       rotation.yx(), rotation.yy(), rotation.yz(),
 // 				       rotation.zx(), rotation.zy(), rotation.zz()));
 //
-//   edm::LogWarning("Alignment") << "@SUB=dumpCompareEuler" 
+//   edm::LogWarning("Alignment") << "@SUB=dumpCompareEuler"
 //  			       << "oldEuler " << oldClhep.eulerAngles()
 //  			       << "\nnewEuler " << newClhep.eulerAngles()
 // 			       << "\n diff_euler " << diff.eulerAngles()
-// 			       << "\n diff_diag (" << diff.xx() << ", " << diff.yy() 
+// 			       << "\n diff_diag (" << diff.xx() << ", " << diff.yy()
 // 			       <<         ", " << diff.zz() << ")";
 // }

--- a/Alignment/TrackerAlignment/src/AlignableTracker.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTracker.cc
@@ -10,18 +10,13 @@
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 
-
-
 //_____________________________________________________________________________
-AlignableTracker
-::AlignableTracker(const TrackerGeometry* trackerGeometry,
-                   const TrackerTopology* trackerTopology) :
-  // id not yet known, will be set by builder
-  AlignableComposite(0, align::Tracker, RotationType()),
-  tTopo_(trackerTopology),
-  trackerNameSpace_(trackerTopology),
-  alignableObjectId_(trackerGeometry, nullptr, nullptr)
-{
+AlignableTracker ::AlignableTracker(const TrackerGeometry* trackerGeometry, const TrackerTopology* trackerTopology)
+    :  // id not yet known, will be set by builder
+      AlignableComposite(0, align::Tracker, RotationType()),
+      tTopo_(trackerTopology),
+      trackerNameSpace_(trackerTopology),
+      alignableObjectId_(trackerGeometry, nullptr, nullptr) {
   AlignableTrackerBuilder builder(trackerGeometry, trackerTopology);
   builder.buildAlignables(this);
   trackerNameSpace_ = builder.trackerNameSpace();
@@ -29,65 +24,53 @@ AlignableTracker
 }
 
 //_____________________________________________________________________________
-void AlignableTracker::update(const TrackerGeometry* trackerGeometry,
-                              const TrackerTopology* trackerTopology)
-{
+void AlignableTracker::update(const TrackerGeometry* trackerGeometry, const TrackerTopology* trackerTopology) {
   AlignableTrackerBuilder builder(trackerGeometry, trackerTopology);
   builder.buildAlignables(this, /* update = */ true);
 }
 
 //_____________________________________________________________________________
-align::Alignables AlignableTracker::merge( const Alignables& list1,
-                                           const Alignables& list2 ) const
-{
+align::Alignables AlignableTracker::merge(const Alignables& list1, const Alignables& list2) const {
   Alignables all = list1;
 
-  all.insert( all.end(), list2.begin(), list2.end() );
+  all.insert(all.end(), list2.begin(), list2.end());
 
   return all;
 }
 
 //_____________________________________________________________________________
-Alignments* AlignableTracker::alignments( void ) const
-{
-
+Alignments* AlignableTracker::alignments(void) const {
   align::Alignables comp = this->components();
   Alignments* m_alignments = new Alignments();
   // Add components recursively
-  for ( align::Alignables::iterator i=comp.begin(); i!=comp.end(); i++ )
-    {
-      Alignments* tmpAlignments = (*i)->alignments();
-      std::copy( tmpAlignments->m_align.begin(), tmpAlignments->m_align.end(), 
-				 std::back_inserter(m_alignments->m_align) );
-	  delete tmpAlignments;
-    }
+  for (align::Alignables::iterator i = comp.begin(); i != comp.end(); i++) {
+    Alignments* tmpAlignments = (*i)->alignments();
+    std::copy(tmpAlignments->m_align.begin(), tmpAlignments->m_align.end(), std::back_inserter(m_alignments->m_align));
+    delete tmpAlignments;
+  }
 
   // sort by rawId
-  std::sort( m_alignments->m_align.begin(), m_alignments->m_align.end());
+  std::sort(m_alignments->m_align.begin(), m_alignments->m_align.end());
 
   return m_alignments;
-
 }
 
 //_____________________________________________________________________________
-AlignmentErrorsExtended* AlignableTracker::alignmentErrors( void ) const
-{
-
+AlignmentErrorsExtended* AlignableTracker::alignmentErrors(void) const {
   align::Alignables comp = this->components();
   AlignmentErrorsExtended* m_alignmentErrors = new AlignmentErrorsExtended();
 
   // Add components recursively
-  for ( align::Alignables::iterator i=comp.begin(); i!=comp.end(); i++ )
-    {
-	  AlignmentErrorsExtended* tmpAlignmentErrorsExtended = (*i)->alignmentErrors();
-      std::copy( tmpAlignmentErrorsExtended->m_alignError.begin(), tmpAlignmentErrorsExtended->m_alignError.end(), 
-				 std::back_inserter(m_alignmentErrors->m_alignError) );
-	  delete tmpAlignmentErrorsExtended;
-    }
+  for (align::Alignables::iterator i = comp.begin(); i != comp.end(); i++) {
+    AlignmentErrorsExtended* tmpAlignmentErrorsExtended = (*i)->alignmentErrors();
+    std::copy(tmpAlignmentErrorsExtended->m_alignError.begin(),
+              tmpAlignmentErrorsExtended->m_alignError.end(),
+              std::back_inserter(m_alignmentErrors->m_alignError));
+    delete tmpAlignmentErrorsExtended;
+  }
 
   // sort by rawId
-  std::sort( m_alignmentErrors->m_alignError.begin(), m_alignmentErrors->m_alignError.end());
+  std::sort(m_alignmentErrors->m_alignError.begin(), m_alignmentErrors->m_alignError.end());
 
   return m_alignmentErrors;
-
 }

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -16,41 +16,40 @@
 
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
-
 //=============================================================================
 //===   PUBLIC METHOD IMPLEMENTATION                                        ===
 //=============================================================================
 
 //_____________________________________________________________________________
-AlignableTrackerBuilder
-::AlignableTrackerBuilder(const TrackerGeometry* trackerGeometry,
-                          const TrackerTopology* trackerTopology) :
-  trackerGeometry_(trackerGeometry),
-  trackerTopology_(trackerTopology),
-  alignableObjectId_(trackerGeometry, nullptr, nullptr),
-  alignableMap_(nullptr),
-  trackerAlignmentLevelBuilder_(trackerTopology, trackerGeometry)
-{
+AlignableTrackerBuilder ::AlignableTrackerBuilder(const TrackerGeometry* trackerGeometry,
+                                                  const TrackerTopology* trackerTopology)
+    : trackerGeometry_(trackerGeometry),
+      trackerTopology_(trackerTopology),
+      alignableObjectId_(trackerGeometry, nullptr, nullptr),
+      alignableMap_(nullptr),
+      trackerAlignmentLevelBuilder_(trackerTopology, trackerGeometry) {
   std::ostringstream ss;
 
   switch (alignableObjectId_.geometry()) {
-  case AlignableObjectId::Geometry::RunI:    ss << "RunI geometry";    break;
-  case AlignableObjectId::Geometry::PhaseI:  ss << "PhaseI geometry";  break;
-  case AlignableObjectId::Geometry::PhaseII: ss << "PhaseII geometry"; break;
-  default:
-    throw cms::Exception("LogicError")
-      << "[AlignableTrackerBuilder] unknown version of TrackerGeometry";
+    case AlignableObjectId::Geometry::RunI:
+      ss << "RunI geometry";
+      break;
+    case AlignableObjectId::Geometry::PhaseI:
+      ss << "PhaseI geometry";
+      break;
+    case AlignableObjectId::Geometry::PhaseII:
+      ss << "PhaseII geometry";
+      break;
+    default:
+      throw cms::Exception("LogicError") << "[AlignableTrackerBuilder] unknown version of TrackerGeometry";
   }
 
-  edm::LogInfo("AlignableBuildProcess")
-    << "@SUB=AlignableTrackerBuilder::AlignableTrackerBuilder"
-    << "GeometryVersion: " << ss.str();
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=AlignableTrackerBuilder::AlignableTrackerBuilder"
+                                        << "GeometryVersion: " << ss.str();
 }
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildAlignables(AlignableTracker* trackerAlignables, bool update)
-{
+void AlignableTrackerBuilder ::buildAlignables(AlignableTracker* trackerAlignables, bool update) {
   alignableMap_ = &trackerAlignables->alignableMap_;
 
   // first, build Alignables on module-level (AlignableDetUnits)
@@ -59,7 +58,8 @@ void AlignableTrackerBuilder
   // now build the composite Alignables (Ladders, Layers etc.)
   buildAlignableComposites(update);
 
-  if (update) return;           // everything else not needed for the update
+  if (update)
+    return;  // everything else not needed for the update
 
   // create pixel-detector
   buildPixelDetector(trackerAlignables);
@@ -72,86 +72,61 @@ void AlignableTrackerBuilder
   trackerAlignables->theId = trackerAlignables->components()[0]->id();
 }
 
-
-
 //=============================================================================
 //===   PRIVATE METHOD IMPLEMENTATION                                       ===
 //=============================================================================
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildAlignableDetUnits(bool update)
-{
+void AlignableTrackerBuilder ::buildAlignableDetUnits(bool update) {
   // PixelBarrel
-  convertGeomDetsToAlignables(
-    trackerGeometry_->detsPXB(), alignableObjectId_.idToString(align::TPBModule),
-    update
-  );
+  convertGeomDetsToAlignables(trackerGeometry_->detsPXB(), alignableObjectId_.idToString(align::TPBModule), update);
 
   // PixelEndcap
-  convertGeomDetsToAlignables(
-    trackerGeometry_->detsPXF(), alignableObjectId_.idToString(align::TPEModule),
-    update
-  );
+  convertGeomDetsToAlignables(trackerGeometry_->detsPXF(), alignableObjectId_.idToString(align::TPEModule), update);
 
   // TIB
-  convertGeomDetsToAlignables(
-    trackerGeometry_->detsTIB(), alignableObjectId_.idToString(align::TIBModule),
-    update
-  );
+  convertGeomDetsToAlignables(trackerGeometry_->detsTIB(), alignableObjectId_.idToString(align::TIBModule), update);
 
   // TID
-  convertGeomDetsToAlignables(
-    trackerGeometry_->detsTID(), alignableObjectId_.idToString(align::TIDModule),
-    update
-  );
+  convertGeomDetsToAlignables(trackerGeometry_->detsTID(), alignableObjectId_.idToString(align::TIDModule), update);
 
   // TOB
-  convertGeomDetsToAlignables(
-    trackerGeometry_->detsTOB(), alignableObjectId_.idToString(align::TOBModule),
-    update
-  );
+  convertGeomDetsToAlignables(trackerGeometry_->detsTOB(), alignableObjectId_.idToString(align::TOBModule), update);
 
   // TEC
-  convertGeomDetsToAlignables(
-    trackerGeometry_->detsTEC(), alignableObjectId_.idToString(align::TECModule),
-    update
-  );
+  convertGeomDetsToAlignables(trackerGeometry_->detsTEC(), alignableObjectId_.idToString(align::TECModule), update);
 }
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::convertGeomDetsToAlignables(const TrackingGeometry::DetContainer& geomDets,
-                              const std::string& moduleName, bool update)
-{
+void AlignableTrackerBuilder ::convertGeomDetsToAlignables(const TrackingGeometry::DetContainer& geomDets,
+                                                           const std::string& moduleName,
+                                                           bool update) {
   numDetUnits = 0;
 
   auto& alignables = alignableMap_->get(moduleName);
-  if (!update) alignables.reserve(geomDets.size());
+  if (!update)
+    alignables.reserve(geomDets.size());
 
   // units are added for each moduleName, which are at moduleName + "Unit"
   // in the pixel Module and ModuleUnit are equivalent
-  auto & aliUnits = alignableMap_->get(moduleName+"Unit");
-  if (!update) aliUnits.reserve(geomDets.size()); // minimal number space needed
+  auto& aliUnits = alignableMap_->get(moduleName + "Unit");
+  if (!update)
+    aliUnits.reserve(geomDets.size());  // minimal number space needed
 
   for (auto& geomDet : geomDets) {
-    int subdetId = geomDet->geographicalId().subdetId(); //don't check det()==Tracker
+    int subdetId = geomDet->geographicalId().subdetId();  //don't check det()==Tracker
 
-    if (subdetId == PixelSubdetector::PixelBarrel ||
-        subdetId == PixelSubdetector::PixelEndcap) {
+    if (subdetId == PixelSubdetector::PixelBarrel || subdetId == PixelSubdetector::PixelEndcap) {
       buildPixelDetectorAlignable(geomDet, subdetId, alignables, aliUnits, update);
 
-    } else if (subdetId == SiStripDetId::TIB ||
-               subdetId == SiStripDetId::TID ||
-               subdetId == SiStripDetId::TOB ||
+    } else if (subdetId == SiStripDetId::TIB || subdetId == SiStripDetId::TID || subdetId == SiStripDetId::TOB ||
                subdetId == SiStripDetId::TEC) {
       // for strip we create also <TIB/TID/TOB/TEC>ModuleUnit list
       // for 1D components of 2D layers
       buildStripDetectorAlignable(geomDet, subdetId, alignables, aliUnits, update);
 
     } else {
-      throw cms::Exception("LogicError")
-        << "[AlignableTrackerBuilder] GeomDet of unknown subdetector";
+      throw cms::Exception("LogicError") << "[AlignableTrackerBuilder] GeomDet of unknown subdetector";
     }
 
     trackerAlignmentLevelBuilder_.addDetUnitInfo(geomDet->geographicalId());
@@ -162,46 +137,38 @@ void AlignableTrackerBuilder
   // we also create AlignableSiStripDets, which consist of multiple
   // AlignableDetUnits, hence alignables.size() and numDetUnits are not equal.
 
-  edm::LogInfo("AlignableBuildProcess")
-    << "@SUB=AlignableTrackerBuilder::convertGeomDetsToAlignables"
-    << "converted GeomDets to Alignables for " << moduleName << "\n"
-    << "   GeomDets:             " << geomDets.size()         << "\n"
-    << "   AlignableDetUnits:    " << numDetUnits;
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=AlignableTrackerBuilder::convertGeomDetsToAlignables"
+                                        << "converted GeomDets to Alignables for " << moduleName << "\n"
+                                        << "   GeomDets:             " << geomDets.size() << "\n"
+                                        << "   AlignableDetUnits:    " << numDetUnits;
 }
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildPixelDetectorAlignable(const GeomDet* geomDetUnit, int subdetId,
-                              Alignables& aliDets, Alignables& aliDetUnits,
-                              bool update)
-{
+void AlignableTrackerBuilder ::buildPixelDetectorAlignable(
+    const GeomDet* geomDetUnit, int subdetId, Alignables& aliDets, Alignables& aliDetUnits, bool update) {
   // treat all pixel dets in same way with one AlignableDetUnit
   if (!geomDetUnit->isLeaf()) {
-    throw cms::Exception("BadHierarchy")
-      << "[AlignableTrackerBuilder] Pixel GeomDet (subdetector " << subdetId
-      << ") is not a GeomDetUnit.";
+    throw cms::Exception("BadHierarchy") << "[AlignableTrackerBuilder] Pixel GeomDet (subdetector " << subdetId
+                                         << ") is not a GeomDetUnit.";
   }
 
   if (update) {
-    auto ali =
-      std::find_if(aliDets.cbegin(), aliDets.cend(),
-                   [&geomDetUnit](const auto& i) {
-                     return i->id() == geomDetUnit->geographicalId().rawId(); });
+    auto ali = std::find_if(aliDets.cbegin(), aliDets.cend(), [&geomDetUnit](const auto& i) {
+      return i->id() == geomDetUnit->geographicalId().rawId();
+    });
     if (ali != aliDets.end()) {
       // add dynamic cast here to get AlignableDetUnit!
       auto aliDetUnit = dynamic_cast<AlignableDetUnit*>(*ali);
       if (aliDetUnit) {
         aliDetUnit->update(geomDetUnit);
       } else {
-        throw cms::Exception("LogicError")
-          << "[AlignableTrackerBuilder::buildPixelDetectorAlignable] "
-          << "cast to 'AlignableDetUnit*' failed while it should not\n";
+        throw cms::Exception("LogicError") << "[AlignableTrackerBuilder::buildPixelDetectorAlignable] "
+                                           << "cast to 'AlignableDetUnit*' failed while it should not\n";
       }
     } else {
       throw cms::Exception("GeometryMismatch")
-        << "[AlignableTrackerBuilder::buildPixelDetectorAlignable] "
-        << "GeomDet with DetId " << geomDetUnit->geographicalId().rawId()
-        << " not found in current geometry.\n";
+          << "[AlignableTrackerBuilder::buildPixelDetectorAlignable] "
+          << "GeomDet with DetId " << geomDetUnit->geographicalId().rawId() << " not found in current geometry.\n";
     }
   } else {
     aliDets.push_back(new AlignableDetUnit(geomDetUnit));
@@ -211,11 +178,8 @@ void AlignableTrackerBuilder
 }
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildStripDetectorAlignable(const GeomDet* geomDet, int subdetId,
-                              Alignables& aliDets, Alignables& aliDetUnits,
-                              bool update)
-{
+void AlignableTrackerBuilder ::buildStripDetectorAlignable(
+    const GeomDet* geomDet, int subdetId, Alignables& aliDets, Alignables& aliDetUnits, bool update) {
   // In strip we have:
   // 1) 'Pure' 1D-modules like TOB layers 3-6 (not glued): AlignableDetUnit
   // 2) Composite 2D-modules like TOB layers 1&2 (not glued): AlignableDet
@@ -229,31 +193,27 @@ void AlignableTrackerBuilder
       // 2D-module, convert it to GluedGeomDet
       const GluedGeomDet* gluedGeomDet = dynamic_cast<const GluedGeomDet*>(geomDet);
       if (!gluedGeomDet) {
-        throw cms::Exception("LogicError")
-          << "[AlignableTrackerBuilder] dynamic_cast<const GluedGeomDet*> "
-          << "failed.";
+        throw cms::Exception("LogicError") << "[AlignableTrackerBuilder] dynamic_cast<const GluedGeomDet*> "
+                                           << "failed.";
       }
 
       // components (AlignableDetUnits) constructed within
       if (update) {
-        auto ali =
-          std::find_if(aliDets.cbegin(), aliDets.cend(),
-                       [&gluedGeomDet](const auto& i) {
-                         return i->id() == gluedGeomDet->geographicalId().rawId(); });
+        auto ali = std::find_if(aliDets.cbegin(), aliDets.cend(), [&gluedGeomDet](const auto& i) {
+          return i->id() == gluedGeomDet->geographicalId().rawId();
+        });
         if (ali != aliDets.end()) {
           auto aliSiStripDet = dynamic_cast<AlignableSiStripDet*>(*ali);
           if (aliSiStripDet) {
             aliSiStripDet->update(gluedGeomDet);
           } else {
-            throw cms::Exception("LogicError")
-              << "[AlignableTrackerBuilder::buildStripDetectorAlignable] "
-              << "cast to 'AlignableSiStripDet*' failed while it should not\n";
+            throw cms::Exception("LogicError") << "[AlignableTrackerBuilder::buildStripDetectorAlignable] "
+                                               << "cast to 'AlignableSiStripDet*' failed while it should not\n";
           }
         } else {
           throw cms::Exception("GeometryMismatch")
-            << "[AlignableTrackerBuilder::buildStripDetectorAlignable] "
-            << "GeomDet with DetId " << gluedGeomDet->geographicalId().rawId()
-            << " not found in current geometry.\n";
+              << "[AlignableTrackerBuilder::buildStripDetectorAlignable] "
+              << "GeomDet with DetId " << gluedGeomDet->geographicalId().rawId() << " not found in current geometry.\n";
         }
       } else {
         aliDets.push_back(new AlignableSiStripDet(gluedGeomDet));
@@ -263,7 +223,7 @@ void AlignableTrackerBuilder
 
       if (!update) {
         // reserve space for the additional units:
-        aliDetUnits.reserve(aliDetUnits.size() + nAddedUnits -1);
+        aliDetUnits.reserve(aliDetUnits.size() + nAddedUnits - 1);
         aliDetUnits.insert(aliDetUnits.end(), addAliDetUnits.begin(), addAliDetUnits.end());
       }
       numDetUnits += nAddedUnits;
@@ -272,16 +232,12 @@ void AlignableTrackerBuilder
       // no components: pure 1D-module
       buildPixelDetectorAlignable(geomDet, subdetId, aliDets, aliDetUnits, update);
     }
-  } // no else: glued components of AlignableDet constructed within
-    // AlignableSiStripDet -> AlignableDet, see above
+  }  // no else: glued components of AlignableDet constructed within
+     // AlignableSiStripDet -> AlignableDet, see above
 }
 
-
-
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildAlignableComposites(bool update)
-{
+void AlignableTrackerBuilder ::buildAlignableComposites(bool update) {
   unsigned int numCompositeAlignables = 0;
 
   // tracker levels must be built before the indexer is created in order to pass
@@ -291,9 +247,9 @@ void AlignableTrackerBuilder
   TrackerAlignableIndexer trackerIndexer{trackerAlignmentLevelBuilder_.trackerNameSpace()};
   AlignableCompositeBuilder compositeBuilder{trackerTopology_, trackerGeometry_, trackerIndexer};
 
-  for (auto& trackerSubLevels: trackerLevels) {
+  for (auto& trackerSubLevels : trackerLevels) {
     // first add all levels of the current subdetector to the builder
-    for (auto& level: trackerSubLevels) {
+    for (auto& level : trackerSubLevels) {
       compositeBuilder.addAlignmentLevel(std::move(level));
     }
     // now build this tracker-level
@@ -302,27 +258,22 @@ void AlignableTrackerBuilder
     compositeBuilder.clearAlignmentLevels();
   }
 
-  edm::LogInfo("AlignableBuildProcess")
-    << "@SUB=AlignableTrackerBuilder::buildAlignableComposites"
-    << "AlignableComposites built for Tracker: " << numCompositeAlignables
-    << " (note: without Pixel- and Strip-Alignable)";
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=AlignableTrackerBuilder::buildAlignableComposites"
+                                        << "AlignableComposites built for Tracker: " << numCompositeAlignables
+                                        << " (note: without Pixel- and Strip-Alignable)";
 }
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildPixelDetector(AlignableTracker* trackerAlignables)
-{
-  const std::string& pxbName   = alignableObjectId_.idToString(align::TPBBarrel);
-  const std::string& pxeName   = alignableObjectId_.idToString(align::TPEEndcap);
+void AlignableTrackerBuilder ::buildPixelDetector(AlignableTracker* trackerAlignables) {
+  const std::string& pxbName = alignableObjectId_.idToString(align::TPBBarrel);
+  const std::string& pxeName = alignableObjectId_.idToString(align::TPEEndcap);
   const std::string& pixelName = alignableObjectId_.idToString(align::Pixel);
 
-  auto& pxbAlignables   = alignableMap_->find(pxbName);
-  auto& pxeAlignables   = alignableMap_->find(pxeName);
-  auto& pixelAlignables = alignableMap_->get (pixelName);
+  auto& pxbAlignables = alignableMap_->find(pxbName);
+  auto& pxeAlignables = alignableMap_->find(pxeName);
+  auto& pixelAlignables = alignableMap_->get(pixelName);
 
-  pixelAlignables.push_back(
-    new AlignableComposite(pxbAlignables[0]->id(), align::Pixel, align::RotationType())
-  );
+  pixelAlignables.push_back(new AlignableComposite(pxbAlignables[0]->id(), align::Pixel, align::RotationType()));
 
   pixelAlignables[0]->addComponent(pxbAlignables[0]);
   pixelAlignables[0]->addComponent(pxeAlignables[0]);
@@ -330,31 +281,26 @@ void AlignableTrackerBuilder
 
   trackerAlignables->addComponent(pixelAlignables[0]);
 
-  edm::LogInfo("AlignableBuildProcess")
-    << "@SUB=AlignableTrackerBuilder::buildPixelDetector"
-    << "Built " << pixelName << "-detector Alignable, consisting of Alignables"
-    << " of " << pxbName << " and " << pxeName;
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=AlignableTrackerBuilder::buildPixelDetector"
+                                        << "Built " << pixelName << "-detector Alignable, consisting of Alignables"
+                                        << " of " << pxbName << " and " << pxeName;
 }
 
 //_____________________________________________________________________________
-void AlignableTrackerBuilder
-::buildStripDetector(AlignableTracker* trackerAlignables)
-{
-  const std::string& tibName   = alignableObjectId_.idToString(align::TIBBarrel);
-  const std::string& tidName   = alignableObjectId_.idToString(align::TIDEndcap);
-  const std::string& tobName   = alignableObjectId_.idToString(align::TOBBarrel);
-  const std::string& tecName   = alignableObjectId_.idToString(align::TECEndcap);
+void AlignableTrackerBuilder ::buildStripDetector(AlignableTracker* trackerAlignables) {
+  const std::string& tibName = alignableObjectId_.idToString(align::TIBBarrel);
+  const std::string& tidName = alignableObjectId_.idToString(align::TIDEndcap);
+  const std::string& tobName = alignableObjectId_.idToString(align::TOBBarrel);
+  const std::string& tecName = alignableObjectId_.idToString(align::TECEndcap);
   const std::string& stripName = alignableObjectId_.idToString(align::Strip);
 
-  auto& tibAlignables   = alignableMap_->find(tibName);
-  auto& tidAlignables   = alignableMap_->find(tidName);
-  auto& tobAlignables   = alignableMap_->find(tobName);
-  auto& tecAlignables   = alignableMap_->find(tecName);
-  auto& stripAlignables = alignableMap_->get (stripName);
+  auto& tibAlignables = alignableMap_->find(tibName);
+  auto& tidAlignables = alignableMap_->find(tidName);
+  auto& tobAlignables = alignableMap_->find(tobName);
+  auto& tecAlignables = alignableMap_->find(tecName);
+  auto& stripAlignables = alignableMap_->get(stripName);
 
-  stripAlignables.push_back(
-    new AlignableComposite(tibAlignables[0]->id(), align::Strip, align::RotationType())
-  );
+  stripAlignables.push_back(new AlignableComposite(tibAlignables[0]->id(), align::Strip, align::RotationType()));
 
   stripAlignables[0]->addComponent(tibAlignables[0]);
   stripAlignables[0]->addComponent(tidAlignables[0]);
@@ -365,9 +311,8 @@ void AlignableTrackerBuilder
 
   trackerAlignables->addComponent(stripAlignables[0]);
 
-  edm::LogInfo("AlignableBuildProcess")
-    << "@SUB=AlignableTrackerBuilder::buildStripDetector"
-    << "Built " << stripName << "-detector Alignable, consisting of Alignables"
-    << " of " << tibName << ", " << tidName
-    << ", " << tobName << " and " << tecName;
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=AlignableTrackerBuilder::buildStripDetector"
+                                        << "Built " << stripName << "-detector Alignable, consisting of Alignables"
+                                        << " of " << tibName << ", " << tidName << ", " << tobName << " and "
+                                        << tecName;
 }

--- a/Alignment/TrackerAlignment/src/TrackerAlignableId.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignableId.cc
@@ -12,50 +12,27 @@
 
 #include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
 
-
 //__________________________________________________________________________________________________
 // Returns alignable object id and layer (or wheel, or disk) number from a DetId
-std::pair<int,int> TrackerAlignableId::typeAndLayerFromDetId( const DetId& detId , const TrackerTopology* tTopo) const
-{
-
+std::pair<int, int> TrackerAlignableId::typeAndLayerFromDetId(const DetId& detId, const TrackerTopology* tTopo) const {
   int layerNumber = 0;
 
   unsigned int subdetId = static_cast<unsigned int>(detId.subdetId());
 
-  if ( subdetId == StripSubdetector::TIB) 
-	{ 
-	   
-	  layerNumber = tTopo->tibLayer(detId.rawId());
-	}
-  else if ( subdetId ==  StripSubdetector::TOB )
-	{ 
-	   
-	  layerNumber = tTopo->tobLayer(detId.rawId());
-	}
-  else if ( subdetId ==  StripSubdetector::TID) 
-	{ 
-	  
-	  layerNumber = tTopo->tidWheel(detId.rawId());
-	}
-  else if ( subdetId ==  StripSubdetector::TEC )
-	{ 
-	   
-	  layerNumber = tTopo->tecWheel(detId.rawId()); 
-	}
-  else if ( subdetId ==  PixelSubdetector::PixelBarrel ) 
-	{ 
-	   
-	  layerNumber = tTopo->pxbLayer(detId.rawId());  
-	}
-  else if ( subdetId ==  PixelSubdetector::PixelEndcap ) 
-	{ 
-	   
-	  layerNumber = tTopo->pxfDisk(detId.rawId());  
-	}
-  else
-	edm::LogWarning("LogicError") << "Unknown subdetid: " <<  subdetId;
+  if (subdetId == StripSubdetector::TIB) {
+    layerNumber = tTopo->tibLayer(detId.rawId());
+  } else if (subdetId == StripSubdetector::TOB) {
+    layerNumber = tTopo->tobLayer(detId.rawId());
+  } else if (subdetId == StripSubdetector::TID) {
+    layerNumber = tTopo->tidWheel(detId.rawId());
+  } else if (subdetId == StripSubdetector::TEC) {
+    layerNumber = tTopo->tecWheel(detId.rawId());
+  } else if (subdetId == PixelSubdetector::PixelBarrel) {
+    layerNumber = tTopo->pxbLayer(detId.rawId());
+  } else if (subdetId == PixelSubdetector::PixelEndcap) {
+    layerNumber = tTopo->pxfDisk(detId.rawId());
+  } else
+    edm::LogWarning("LogicError") << "Unknown subdetid: " << subdetId;
 
-
-  return std::make_pair( subdetId, layerNumber );
-
+  return std::make_pair(subdetId, layerNumber);
 }

--- a/Alignment/TrackerAlignment/src/TrackerAlignableIndexer.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignableIndexer.cc
@@ -1,58 +1,54 @@
 #include "Alignment/TrackerAlignment/interface/TrackerAlignableIndexer.h"
 
-
 //______________________________________________________________________________
-TrackerAlignableIndexer
-::TrackerAlignableIndexer(const align::TrackerNameSpace& tns) :
-  tns_(tns)
-{
+TrackerAlignableIndexer ::TrackerAlignableIndexer(const align::TrackerNameSpace& tns) : tns_(tns) {
   using namespace std::placeholders;
   using namespace align;
   theCounters.clear();
 
   // Barrel Pixel
-  theCounters[TPBModule]     = std::bind(&TrackerNameSpace::TPB::moduleNumber,     &(tns_.tpb()), _1);
-  theCounters[TPBLadder]     = std::bind(&TrackerNameSpace::TPB::ladderNumber,     &(tns_.tpb()), _1);
-  theCounters[TPBLayer]      = std::bind(&TrackerNameSpace::TPB::layerNumber,      &(tns_.tpb()), _1);
+  theCounters[TPBModule] = std::bind(&TrackerNameSpace::TPB::moduleNumber, &(tns_.tpb()), _1);
+  theCounters[TPBLadder] = std::bind(&TrackerNameSpace::TPB::ladderNumber, &(tns_.tpb()), _1);
+  theCounters[TPBLayer] = std::bind(&TrackerNameSpace::TPB::layerNumber, &(tns_.tpb()), _1);
   theCounters[TPBHalfBarrel] = std::bind(&TrackerNameSpace::TPB::halfBarrelNumber, &(tns_.tpb()), _1);
-  theCounters[TPBBarrel]     = std::bind(&TrackerNameSpace::TPB::barrelNumber,     &(tns_.tpb()), _1);
+  theCounters[TPBBarrel] = std::bind(&TrackerNameSpace::TPB::barrelNumber, &(tns_.tpb()), _1);
 
   // Forward Pixel
-  theCounters[TPEModule]       = std::bind(&TrackerNameSpace::TPE::moduleNumber,       &(tns_.tpe()), _1);
-  theCounters[TPEPanel]        = std::bind(&TrackerNameSpace::TPE::panelNumber,        &(tns_.tpe()), _1);
-  theCounters[TPEBlade]        = std::bind(&TrackerNameSpace::TPE::bladeNumber,        &(tns_.tpe()), _1);
-  theCounters[TPEHalfDisk]     = std::bind(&TrackerNameSpace::TPE::halfDiskNumber,     &(tns_.tpe()), _1);
+  theCounters[TPEModule] = std::bind(&TrackerNameSpace::TPE::moduleNumber, &(tns_.tpe()), _1);
+  theCounters[TPEPanel] = std::bind(&TrackerNameSpace::TPE::panelNumber, &(tns_.tpe()), _1);
+  theCounters[TPEBlade] = std::bind(&TrackerNameSpace::TPE::bladeNumber, &(tns_.tpe()), _1);
+  theCounters[TPEHalfDisk] = std::bind(&TrackerNameSpace::TPE::halfDiskNumber, &(tns_.tpe()), _1);
   theCounters[TPEHalfCylinder] = std::bind(&TrackerNameSpace::TPE::halfCylinderNumber, &(tns_.tpe()), _1);
-  theCounters[TPEEndcap]       = std::bind(&TrackerNameSpace::TPE::endcapNumber,       &(tns_.tpe()), _1);
+  theCounters[TPEEndcap] = std::bind(&TrackerNameSpace::TPE::endcapNumber, &(tns_.tpe()), _1);
 
   // Tracker Inner Barrel
-  theCounters[TIBModule]     = std::bind(&TrackerNameSpace::TIB::moduleNumber,     &(tns_.tib()), _1);
-  theCounters[TIBString]     = std::bind(&TrackerNameSpace::TIB::stringNumber,     &(tns_.tib()), _1);
-  theCounters[TIBSurface]    = std::bind(&TrackerNameSpace::TIB::surfaceNumber,    &(tns_.tib()), _1);
-  theCounters[TIBHalfShell]  = std::bind(&TrackerNameSpace::TIB::halfShellNumber,  &(tns_.tib()), _1);
-  theCounters[TIBLayer]      = std::bind(&TrackerNameSpace::TIB::layerNumber,      &(tns_.tib()), _1);
+  theCounters[TIBModule] = std::bind(&TrackerNameSpace::TIB::moduleNumber, &(tns_.tib()), _1);
+  theCounters[TIBString] = std::bind(&TrackerNameSpace::TIB::stringNumber, &(tns_.tib()), _1);
+  theCounters[TIBSurface] = std::bind(&TrackerNameSpace::TIB::surfaceNumber, &(tns_.tib()), _1);
+  theCounters[TIBHalfShell] = std::bind(&TrackerNameSpace::TIB::halfShellNumber, &(tns_.tib()), _1);
+  theCounters[TIBLayer] = std::bind(&TrackerNameSpace::TIB::layerNumber, &(tns_.tib()), _1);
   theCounters[TIBHalfBarrel] = std::bind(&TrackerNameSpace::TIB::halfBarrelNumber, &(tns_.tib()), _1);
-  theCounters[TIBBarrel]     = std::bind(&TrackerNameSpace::TIB::barrelNumber,     &(tns_.tib()), _1);
+  theCounters[TIBBarrel] = std::bind(&TrackerNameSpace::TIB::barrelNumber, &(tns_.tib()), _1);
 
   // Tracker Inner Disk
   theCounters[TIDModule] = std::bind(&TrackerNameSpace::TID::moduleNumber, &(tns_.tid()), _1);
-  theCounters[TIDSide]   = std::bind(&TrackerNameSpace::TID::sideNumber,   &(tns_.tid()), _1);
-  theCounters[TIDRing]   = std::bind(&TrackerNameSpace::TID::ringNumber,   &(tns_.tid()), _1);
-  theCounters[TIDDisk]   = std::bind(&TrackerNameSpace::TID::diskNumber,   &(tns_.tid()), _1);
+  theCounters[TIDSide] = std::bind(&TrackerNameSpace::TID::sideNumber, &(tns_.tid()), _1);
+  theCounters[TIDRing] = std::bind(&TrackerNameSpace::TID::ringNumber, &(tns_.tid()), _1);
+  theCounters[TIDDisk] = std::bind(&TrackerNameSpace::TID::diskNumber, &(tns_.tid()), _1);
   theCounters[TIDEndcap] = std::bind(&TrackerNameSpace::TID::endcapNumber, &(tns_.tid()), _1);
 
   // Tracker Outer Barrel
-  theCounters[TOBModule]     = std::bind(&TrackerNameSpace::TOB::moduleNumber,     &(tns_.tob()), _1);
-  theCounters[TOBRod]        = std::bind(&TrackerNameSpace::TOB::rodNumber,        &(tns_.tob()), _1);
-  theCounters[TOBLayer]      = std::bind(&TrackerNameSpace::TOB::layerNumber,      &(tns_.tob()), _1);
+  theCounters[TOBModule] = std::bind(&TrackerNameSpace::TOB::moduleNumber, &(tns_.tob()), _1);
+  theCounters[TOBRod] = std::bind(&TrackerNameSpace::TOB::rodNumber, &(tns_.tob()), _1);
+  theCounters[TOBLayer] = std::bind(&TrackerNameSpace::TOB::layerNumber, &(tns_.tob()), _1);
   theCounters[TOBHalfBarrel] = std::bind(&TrackerNameSpace::TOB::halfBarrelNumber, &(tns_.tob()), _1);
-  theCounters[TOBBarrel]     = std::bind(&TrackerNameSpace::TOB::barrelNumber,     &(tns_.tob()), _1);
+  theCounters[TOBBarrel] = std::bind(&TrackerNameSpace::TOB::barrelNumber, &(tns_.tob()), _1);
 
   // Tracker Endcaps
   theCounters[TECModule] = std::bind(&TrackerNameSpace::TEC::moduleNumber, &(tns_.tec()), _1);
-  theCounters[TECRing]   = std::bind(&TrackerNameSpace::TEC::ringNumber,   &(tns_.tec()), _1);
-  theCounters[TECPetal]  = std::bind(&TrackerNameSpace::TEC::petalNumber,  &(tns_.tec()), _1);
-  theCounters[TECSide]   = std::bind(&TrackerNameSpace::TEC::sideNumber,   &(tns_.tec()), _1);
-  theCounters[TECDisk]   = std::bind(&TrackerNameSpace::TEC::diskNumber,   &(tns_.tec()), _1);
+  theCounters[TECRing] = std::bind(&TrackerNameSpace::TEC::ringNumber, &(tns_.tec()), _1);
+  theCounters[TECPetal] = std::bind(&TrackerNameSpace::TEC::petalNumber, &(tns_.tec()), _1);
+  theCounters[TECSide] = std::bind(&TrackerNameSpace::TEC::sideNumber, &(tns_.tec()), _1);
+  theCounters[TECDisk] = std::bind(&TrackerNameSpace::TEC::diskNumber, &(tns_.tec()), _1);
   theCounters[TECEndcap] = std::bind(&TrackerNameSpace::TEC::endcapNumber, &(tns_.tec()), _1);
 }

--- a/Alignment/TrackerAlignment/src/TrackerAlignment.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignment.cc
@@ -17,280 +17,251 @@
 
 //__________________________________________________________________
 //
-TrackerAlignment::TrackerAlignment( const edm::EventSetup& setup ):
-  theAlignRecordName( "TrackerAlignmentRcd" ),
-  theErrorRecordName( "TrackerAlignmentErrorExtendedRcd" )
-{
-
+TrackerAlignment::TrackerAlignment(const edm::EventSetup& setup)
+    : theAlignRecordName("TrackerAlignmentRcd"), theErrorRecordName("TrackerAlignmentErrorExtendedRcd") {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   setup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   edm::ESHandle<TrackerGeometry> trackerGeometry;
-  setup.get<TrackerDigiGeometryRecord>().get( trackerGeometry );
-  theAlignableTracker = new AlignableTracker( &(*trackerGeometry), tTopo );
-
+  setup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
+  theAlignableTracker = new AlignableTracker(&(*trackerGeometry), tTopo);
 }
-
 
 //__________________________________________________________________
 //
-TrackerAlignment::~TrackerAlignment( void )
-{
-
-  delete theAlignableTracker;
-
-}
-
+TrackerAlignment::~TrackerAlignment(void) { delete theAlignableTracker; }
 
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignablePixelEndCaps( int rawid , 
-                                                  const align::Scalars& local_displacements,  
-                                                  const align::Scalars& local_rotations  )
-{
-	
+void TrackerAlignment::moveAlignablePixelEndCaps(int rawid,
+                                                 const align::Scalars& local_displacements,
+                                                 const align::Scalars& local_rotations) {
   // Displace and rotate pixelEndCaps
   const align::Alignables& thePixelEndCapsAlignables = theAlignableTracker->pixelEndcapGeomDets();
-  for ( align::Alignables::const_iterator iter = thePixelEndCapsAlignables.begin(); 
-        iter != thePixelEndCapsAlignables.end(); ++iter )
-    { 
-        
-      // Get the raw ID of the associated GeomDet
-      int id = (*iter)->geomDetId().rawId();
-		
-      // Select the given module
-      if ( id == rawid ){
-          
-        // Convert local to global diplacements
-        align::LocalVector lvector( local_displacements.at(0), local_displacements.at(1), local_displacements.at(2)); 
-        align::GlobalVector gvector = ((*iter)->surface()).toGlobal( lvector );
-          
-        // global displacement 
-        (*iter)->move( gvector );
-          
-        // local rotation 
-        (*iter)->rotateAroundLocalX( local_rotations.at(0) ); // Local X axis rotation
-        (*iter)->rotateAroundLocalY( local_rotations.at(1) ); // Local Y axis rotation
-        (*iter)->rotateAroundLocalZ( local_rotations.at(2) ); // Local Z axis rotation
-          
-      }
+  for (align::Alignables::const_iterator iter = thePixelEndCapsAlignables.begin();
+       iter != thePixelEndCapsAlignables.end();
+       ++iter) {
+    // Get the raw ID of the associated GeomDet
+    int id = (*iter)->geomDetId().rawId();
+
+    // Select the given module
+    if (id == rawid) {
+      // Convert local to global diplacements
+      align::LocalVector lvector(local_displacements.at(0), local_displacements.at(1), local_displacements.at(2));
+      align::GlobalVector gvector = ((*iter)->surface()).toGlobal(lvector);
+
+      // global displacement
+      (*iter)->move(gvector);
+
+      // local rotation
+      (*iter)->rotateAroundLocalX(local_rotations.at(0));  // Local X axis rotation
+      (*iter)->rotateAroundLocalY(local_rotations.at(1));  // Local Y axis rotation
+      (*iter)->rotateAroundLocalZ(local_rotations.at(2));  // Local Z axis rotation
     }
+  }
 }
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignableEndCaps( int rawid , const align::Scalars& local_displacements,  const align::Scalars& local_rotations  ){
-	
+void TrackerAlignment::moveAlignableEndCaps(int rawid,
+                                            const align::Scalars& local_displacements,
+                                            const align::Scalars& local_rotations) {
   // Displace and rotate EndCaps
   const align::Alignables& theEndCapsAlignables = theAlignableTracker->endcapGeomDets();
-  for ( align::Alignables::const_iterator iter = theEndCapsAlignables.begin(); 
-        iter != theEndCapsAlignables.end(); ++iter ){ 
-		
+  for (align::Alignables::const_iterator iter = theEndCapsAlignables.begin(); iter != theEndCapsAlignables.end();
+       ++iter) {
     // Get the raw ID of the associated GeomDet
     int id = (*iter)->geomDetId().rawId();
-		
+
     // Select the given module
-    if ( id == rawid ){
-			
+    if (id == rawid) {
       // Convert local to global diplacements
-      align::LocalVector lvector( local_displacements.at(0), local_displacements.at(1), local_displacements.at(2)); 
-      align::GlobalVector gvector = ((*iter)->surface()).toGlobal( lvector );
-			
-      // global displacement 
-      (*iter)->move( gvector );
-			
-      // local rotation 
-      (*iter)->rotateAroundLocalX( local_rotations.at(0) ); // Local X axis rotation
-      (*iter)->rotateAroundLocalY( local_rotations.at(1) ); // Local Y axis rotation
-      (*iter)->rotateAroundLocalZ( local_rotations.at(2) ); // Local Z axis rotation
-			
+      align::LocalVector lvector(local_displacements.at(0), local_displacements.at(1), local_displacements.at(2));
+      align::GlobalVector gvector = ((*iter)->surface()).toGlobal(lvector);
+
+      // global displacement
+      (*iter)->move(gvector);
+
+      // local rotation
+      (*iter)->rotateAroundLocalX(local_rotations.at(0));  // Local X axis rotation
+      (*iter)->rotateAroundLocalY(local_rotations.at(1));  // Local Y axis rotation
+      (*iter)->rotateAroundLocalZ(local_rotations.at(2));  // Local Z axis rotation
     }
   }
 }
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignablePixelHalfBarrels( int rawid , const align::Scalars& local_displacements,  const align::Scalars& local_rotations  ){
-	
+void TrackerAlignment::moveAlignablePixelHalfBarrels(int rawid,
+                                                     const align::Scalars& local_displacements,
+                                                     const align::Scalars& local_rotations) {
   // Displace and rotate PixelHalfBarrels
   const align::Alignables& thePixelHalfBarrelsAlignables = theAlignableTracker->pixelHalfBarrelGeomDets();
-  for ( align::Alignables::const_iterator iter = thePixelHalfBarrelsAlignables.begin(); 
-        iter != thePixelHalfBarrelsAlignables.end(); ++iter ){ 
-		
+  for (align::Alignables::const_iterator iter = thePixelHalfBarrelsAlignables.begin();
+       iter != thePixelHalfBarrelsAlignables.end();
+       ++iter) {
     // Get the raw ID of the associated GeomDet
     int id = (*iter)->geomDetId().rawId();
-		
+
     // Select the given module
-    if ( id == rawid ){
-			
+    if (id == rawid) {
       // Convert local to global diplacements
-      align::LocalVector lvector( local_displacements.at(0), local_displacements.at(1), local_displacements.at(2)); 
-      align::GlobalVector gvector = ((*iter)->surface()).toGlobal( lvector );
-			
-      // global displacement 
-      (*iter)->move( gvector );
-			
-      // local rotation 
-      (*iter)->rotateAroundLocalX( local_rotations.at(0) ); // Local X axis rotation
-      (*iter)->rotateAroundLocalY( local_rotations.at(1) ); // Local Y axis rotation
-      (*iter)->rotateAroundLocalZ( local_rotations.at(2) ); // Local Z axis rotation
-			
+      align::LocalVector lvector(local_displacements.at(0), local_displacements.at(1), local_displacements.at(2));
+      align::GlobalVector gvector = ((*iter)->surface()).toGlobal(lvector);
+
+      // global displacement
+      (*iter)->move(gvector);
+
+      // local rotation
+      (*iter)->rotateAroundLocalX(local_rotations.at(0));  // Local X axis rotation
+      (*iter)->rotateAroundLocalY(local_rotations.at(1));  // Local Y axis rotation
+      (*iter)->rotateAroundLocalZ(local_rotations.at(2));  // Local Z axis rotation
     }
   }
 }
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignableOuterHalfBarrels( int rawid , const align::Scalars& local_displacements,  const align::Scalars& local_rotations  ){
-	
+void TrackerAlignment::moveAlignableOuterHalfBarrels(int rawid,
+                                                     const align::Scalars& local_displacements,
+                                                     const align::Scalars& local_rotations) {
   // Displace and rotate OuterHalfBarrels
   const align::Alignables& theOuterHalfBarrelsAlignables = theAlignableTracker->outerBarrelGeomDets();
-  for ( align::Alignables::const_iterator iter = theOuterHalfBarrelsAlignables.begin(); 
-        iter != theOuterHalfBarrelsAlignables.end(); ++iter ){ 
-		
+  for (align::Alignables::const_iterator iter = theOuterHalfBarrelsAlignables.begin();
+       iter != theOuterHalfBarrelsAlignables.end();
+       ++iter) {
     // Get the raw ID of the associated GeomDet
     int id = (*iter)->geomDetId().rawId();
-		
+
     // Select the given module
-    if ( id == rawid ){
-			
+    if (id == rawid) {
       // Convert local to global diplacements
-      align::LocalVector lvector( local_displacements.at(0), local_displacements.at(1), local_displacements.at(2)); 
-      align::GlobalVector gvector = ((*iter)->surface()).toGlobal( lvector );
-			
-      // global displacement 
-      (*iter)->move( gvector );
-			
-      // local rotation 
-      (*iter)->rotateAroundLocalX( local_rotations.at(0) ); // Local X axis rotation
-      (*iter)->rotateAroundLocalY( local_rotations.at(1) ); // Local Y axis rotation
-      (*iter)->rotateAroundLocalZ( local_rotations.at(2) ); // Local Z axis rotation
-			
+      align::LocalVector lvector(local_displacements.at(0), local_displacements.at(1), local_displacements.at(2));
+      align::GlobalVector gvector = ((*iter)->surface()).toGlobal(lvector);
+
+      // global displacement
+      (*iter)->move(gvector);
+
+      // local rotation
+      (*iter)->rotateAroundLocalX(local_rotations.at(0));  // Local X axis rotation
+      (*iter)->rotateAroundLocalY(local_rotations.at(1));  // Local Y axis rotation
+      (*iter)->rotateAroundLocalZ(local_rotations.at(2));  // Local Z axis rotation
     }
   }
 }
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignableInnerHalfBarrels( int rawid , const align::Scalars& local_displacements,  const align::Scalars& local_rotations  ){
-	
+void TrackerAlignment::moveAlignableInnerHalfBarrels(int rawid,
+                                                     const align::Scalars& local_displacements,
+                                                     const align::Scalars& local_rotations) {
   // Displace and rotate InnerHalfBarrels
   const align::Alignables& theInnerHalfBarrelsAlignables = theAlignableTracker->innerBarrelGeomDets();
-  for ( align::Alignables::const_iterator iter = theInnerHalfBarrelsAlignables.begin(); 
-        iter != theInnerHalfBarrelsAlignables.end(); ++iter ){ 
-		
+  for (align::Alignables::const_iterator iter = theInnerHalfBarrelsAlignables.begin();
+       iter != theInnerHalfBarrelsAlignables.end();
+       ++iter) {
     // Get the raw ID of the associated GeomDet
     int id = (*iter)->geomDetId().rawId();
-		
+
     // Select the given module
-    if ( id == rawid ){
-			
+    if (id == rawid) {
       // Convert local to global diplacements
-      align::LocalVector lvector( local_displacements.at(0), local_displacements.at(1), local_displacements.at(2)); 
-      align::GlobalVector gvector = ((*iter)->surface()).toGlobal( lvector );
-			
-      // global displacement 
-      (*iter)->move( gvector );
-			
-      // local rotation 
-      (*iter)->rotateAroundLocalX( local_rotations.at(0) ); // Local X axis rotation
-      (*iter)->rotateAroundLocalY( local_rotations.at(1) ); // Local Y axis rotation
-      (*iter)->rotateAroundLocalZ( local_rotations.at(2) ); // Local Z axis rotation
-			
+      align::LocalVector lvector(local_displacements.at(0), local_displacements.at(1), local_displacements.at(2));
+      align::GlobalVector gvector = ((*iter)->surface()).toGlobal(lvector);
+
+      // global displacement
+      (*iter)->move(gvector);
+
+      // local rotation
+      (*iter)->rotateAroundLocalX(local_rotations.at(0));  // Local X axis rotation
+      (*iter)->rotateAroundLocalY(local_rotations.at(1));  // Local Y axis rotation
+      (*iter)->rotateAroundLocalZ(local_rotations.at(2));  // Local Z axis rotation
     }
   }
 }
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignableTIDs( int rawid , const align::Scalars& local_displacements,  const align::Scalars& local_rotations  ){
-	
+void TrackerAlignment::moveAlignableTIDs(int rawid,
+                                         const align::Scalars& local_displacements,
+                                         const align::Scalars& local_rotations) {
   // Displace and rotate TIDs
   const align::Alignables& theTIDsAlignables = theAlignableTracker->TIDGeomDets();
-  for ( align::Alignables::const_iterator iter = theTIDsAlignables.begin(); 
-        iter != theTIDsAlignables.end(); ++iter ){ 
-		
+  for (align::Alignables::const_iterator iter = theTIDsAlignables.begin(); iter != theTIDsAlignables.end(); ++iter) {
     // Get the raw ID of the associated GeomDet
     int id = (*iter)->geomDetId().rawId();
-		
+
     // Select the given module
-    if ( id == rawid ){
-			
+    if (id == rawid) {
       // Convert local to global diplacements
-      align::LocalVector lvector( local_displacements.at(0), local_displacements.at(1), local_displacements.at(2)); 
-      align::GlobalVector gvector = ((*iter)->surface()).toGlobal( lvector );
-			
-      // global displacement 
-      (*iter)->move( gvector );
-			
-      // local rotation 
-      (*iter)->rotateAroundLocalX( local_rotations.at(0) ); // Local X axis rotation
-      (*iter)->rotateAroundLocalY( local_rotations.at(1) ); // Local Y axis rotation
-      (*iter)->rotateAroundLocalZ( local_rotations.at(2) ); // Local Z axis rotation
-			
+      align::LocalVector lvector(local_displacements.at(0), local_displacements.at(1), local_displacements.at(2));
+      align::GlobalVector gvector = ((*iter)->surface()).toGlobal(lvector);
+
+      // global displacement
+      (*iter)->move(gvector);
+
+      // local rotation
+      (*iter)->rotateAroundLocalX(local_rotations.at(0));  // Local X axis rotation
+      (*iter)->rotateAroundLocalY(local_rotations.at(1));  // Local Y axis rotation
+      (*iter)->rotateAroundLocalZ(local_rotations.at(2));  // Local Z axis rotation
     }
   }
 }
 
 //__________________________________________________________________
 //
-void TrackerAlignment::moveAlignableTIBTIDs( int rawId, const align::Scalars& globalDisplacements, const align::RotationType& backwardRotation, const align::RotationType& forwardRotation, bool toAndFro ){
-
+void TrackerAlignment::moveAlignableTIBTIDs(int rawId,
+                                            const align::Scalars& globalDisplacements,
+                                            const align::RotationType& backwardRotation,
+                                            const align::RotationType& forwardRotation,
+                                            bool toAndFro) {
   // Displace and rotate TIB and TID
   const align::Alignables& theTIBTIDAlignables = theAlignableTracker->TIBTIDGeomDets();
-  for ( align::Alignables::const_iterator iter = theTIBTIDAlignables.begin(); 
-        iter != theTIBTIDAlignables.end(); ++iter )
-    { 
-	    
-      // Get the raw ID of the associated GeomDet
-      int id = (*iter)->geomDetId().rawId();
-	    
-      // Select the given module
-      if ( id == rawId ){
-	      
-        // global displacement 
-        align::GlobalVector gvector (globalDisplacements.at(0), globalDisplacements.at(1), globalDisplacements.at(2));
-        (*iter)->move( gvector );
-	      
-        // global rotation
-        if (toAndFro) { 
-          align::RotationType theResultRotation = backwardRotation*forwardRotation.transposed();
-          (*iter)->rotateInGlobalFrame( theResultRotation ); 
-        } else {
-          (*iter)->rotateInGlobalFrame( backwardRotation );
-        }
+  for (align::Alignables::const_iterator iter = theTIBTIDAlignables.begin(); iter != theTIBTIDAlignables.end();
+       ++iter) {
+    // Get the raw ID of the associated GeomDet
+    int id = (*iter)->geomDetId().rawId();
+
+    // Select the given module
+    if (id == rawId) {
+      // global displacement
+      align::GlobalVector gvector(globalDisplacements.at(0), globalDisplacements.at(1), globalDisplacements.at(2));
+      (*iter)->move(gvector);
+
+      // global rotation
+      if (toAndFro) {
+        align::RotationType theResultRotation = backwardRotation * forwardRotation.transposed();
+        (*iter)->rotateInGlobalFrame(theResultRotation);
+      } else {
+        (*iter)->rotateInGlobalFrame(backwardRotation);
       }
     }
+  }
 }
-
 
 //__________________________________________________________________
 //
-void TrackerAlignment::saveToDB(void){
-	
+void TrackerAlignment::saveToDB(void) {
   // Output POOL-ORA objects
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( !poolDbService.isAvailable() ) // Die if not available
-	throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
+  if (!poolDbService.isAvailable())  // Die if not available
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Retrieve and store
   Alignments* alignments = theAlignableTracker->alignments();
   AlignmentErrorsExtended* alignmentErrors = theAlignableTracker->alignmentErrors();
 
-//   if ( poolDbService->isNewTagRequest(theAlignRecordName) )
-//     poolDbService->createNewIOV<Alignments>( alignments, poolDbService->endOfTime(), 
-//                                              theAlignRecordName );
-//   else
-//     poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(), 
-//                                                 theAlignRecordName );
-  poolDbService->writeOne<Alignments>(alignments, poolDbService->currentTime(),
-                                      theAlignRecordName);
-//   if ( poolDbService->isNewTagRequest(theErrorRecordName) )
-//     poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors,
-//                                                   poolDbService->endOfTime(), 
-//                                                   theErrorRecordName );
-//   else
-//     poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors,
-//                                                      poolDbService->currentTime(), 
-//                                                      theErrorRecordName );
-  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->currentTime(),
-                                           theErrorRecordName);
+  //   if ( poolDbService->isNewTagRequest(theAlignRecordName) )
+  //     poolDbService->createNewIOV<Alignments>( alignments, poolDbService->endOfTime(),
+  //                                              theAlignRecordName );
+  //   else
+  //     poolDbService->appendSinceTime<Alignments>( alignments, poolDbService->currentTime(),
+  //                                                 theAlignRecordName );
+  poolDbService->writeOne<Alignments>(alignments, poolDbService->currentTime(), theAlignRecordName);
+  //   if ( poolDbService->isNewTagRequest(theErrorRecordName) )
+  //     poolDbService->createNewIOV<AlignmentErrorsExtended>( alignmentErrors,
+  //                                                   poolDbService->endOfTime(),
+  //                                                   theErrorRecordName );
+  //   else
+  //     poolDbService->appendSinceTime<AlignmentErrorsExtended>( alignmentErrors,
+  //                                                      poolDbService->currentTime(),
+  //                                                      theErrorRecordName );
+  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->currentTime(), theErrorRecordName);
 }
-

--- a/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
@@ -9,48 +9,48 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
-
-
 //=============================================================================
 //===   PUBLIC METHOD IMPLEMENTATION                                        ===
 //=============================================================================
 
 //_____________________________________________________________________________
-TrackerAlignmentLevelBuilder
-::TrackerAlignmentLevelBuilder(const TrackerTopology* trackerTopology,
-			       const TrackerGeometry* trackerGeometry) :
-  trackerTopology_(trackerTopology),
-  alignableObjectId_(trackerGeometry, nullptr, nullptr),
-  trackerNameSpace_(trackerTopology)
-{
-}
+TrackerAlignmentLevelBuilder ::TrackerAlignmentLevelBuilder(const TrackerTopology* trackerTopology,
+                                                            const TrackerGeometry* trackerGeometry)
+    : trackerTopology_(trackerTopology),
+      alignableObjectId_(trackerGeometry, nullptr, nullptr),
+      trackerNameSpace_(trackerTopology) {}
 
 //_____________________________________________________________________________
-TrackerAlignmentLevelBuilder::
-~TrackerAlignmentLevelBuilder()
-{
-}
+TrackerAlignmentLevelBuilder::~TrackerAlignmentLevelBuilder() {}
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addDetUnitInfo(const DetId& detId)
-{
+void TrackerAlignmentLevelBuilder ::addDetUnitInfo(const DetId& detId) {
   int subdetId = detId.subdetId();
 
   switch (subdetId) {
-    case PixelSubdetector::PixelBarrel: addPXBDetUnitInfo(detId); break;
-    case PixelSubdetector::PixelEndcap: addPXEDetUnitInfo(detId); break;
-    case StripSubdetector::TIB:         addTIBDetUnitInfo(detId); break;
-    case StripSubdetector::TID:         addTIDDetUnitInfo(detId); break;
-    case StripSubdetector::TOB:         addTOBDetUnitInfo(detId); break;
-    case StripSubdetector::TEC:         addTECDetUnitInfo(detId); break;
+    case PixelSubdetector::PixelBarrel:
+      addPXBDetUnitInfo(detId);
+      break;
+    case PixelSubdetector::PixelEndcap:
+      addPXEDetUnitInfo(detId);
+      break;
+    case StripSubdetector::TIB:
+      addTIBDetUnitInfo(detId);
+      break;
+    case StripSubdetector::TID:
+      addTIDDetUnitInfo(detId);
+      break;
+    case StripSubdetector::TOB:
+      addTOBDetUnitInfo(detId);
+      break;
+    case StripSubdetector::TEC:
+      addTECDetUnitInfo(detId);
+      break;
   }
 }
 
 //_____________________________________________________________________________
-std::vector<align::AlignmentLevels> TrackerAlignmentLevelBuilder
-::build()
-{
+std::vector<align::AlignmentLevels> TrackerAlignmentLevelBuilder ::build() {
   std::vector<align::AlignmentLevels> levels;
   levels.push_back(buildPXBAlignmentLevels());
   levels.push_back(buildPXEAlignmentLevels());
@@ -62,333 +62,293 @@ std::vector<align::AlignmentLevels> TrackerAlignmentLevelBuilder
   return levels;
 }
 
-
 //______________________________________________________________________________
-const align::TrackerNameSpace& TrackerAlignmentLevelBuilder
-::trackerNameSpace() const {
+const align::TrackerNameSpace& TrackerAlignmentLevelBuilder ::trackerNameSpace() const {
   if (levelsBuilt_) {
     return trackerNameSpace_;
   } else {
-    throw cms::Exception("LogicError")
-      << "@SUB=TrackerAlignmentLevelBuilder::trackerNameSpace\n"
-      << "trying to get the name space before it has been properly initialized;"
-      << " please call TrackerAlignmentLevelBuilder::build() first";
+    throw cms::Exception("LogicError") << "@SUB=TrackerAlignmentLevelBuilder::trackerNameSpace\n"
+                                       << "trying to get the name space before it has been properly initialized;"
+                                       << " please call TrackerAlignmentLevelBuilder::build() first";
   }
 }
-
-
 
 //=============================================================================
 //===   PRIVATE METHOD IMPLEMENTATION                                       ===
 //=============================================================================
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addPXBDetUnitInfo(const DetId& detId)
-{
-  auto layerID  = trackerTopology_->pxbLayer(detId);
+void TrackerAlignmentLevelBuilder ::addPXBDetUnitInfo(const DetId& detId) {
+  auto layerID = trackerTopology_->pxbLayer(detId);
   auto ladderID = trackerTopology_->pxbLadder(detId);
   auto moduleID = trackerTopology_->module(detId);
 
-  if (pxbLaddersPerLayer_[layerID-1] < ladderID) {
-    pxbLaddersPerLayer_[layerID-1] = ladderID;
+  if (pxbLaddersPerLayer_[layerID - 1] < ladderID) {
+    pxbLaddersPerLayer_[layerID - 1] = ladderID;
   }
 
-  pxbLayerIDs_. insert(layerID);
+  pxbLayerIDs_.insert(layerID);
   pxbLadderIDs_.insert(ladderID);
   pxbModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addPXEDetUnitInfo(const DetId& detId)
-{
-  auto sideID   = trackerTopology_->pxfSide(detId);
-  auto diskID   = trackerTopology_->pxfDisk(detId);
-  auto bladeID  = trackerTopology_->pxfBlade(detId);
-  auto panelID  = trackerTopology_->pxfPanel(detId);
+void TrackerAlignmentLevelBuilder ::addPXEDetUnitInfo(const DetId& detId) {
+  auto sideID = trackerTopology_->pxfSide(detId);
+  auto diskID = trackerTopology_->pxfDisk(detId);
+  auto bladeID = trackerTopology_->pxfBlade(detId);
+  auto panelID = trackerTopology_->pxfPanel(detId);
   auto moduleID = trackerTopology_->module(detId);
 
-  pxeSideIDs_.  insert(sideID);
-  pxeDiskIDs_.  insert(diskID);
-  pxeBladeIDs_. insert(bladeID);
-  pxePanelIDs_. insert(panelID);
+  pxeSideIDs_.insert(sideID);
+  pxeDiskIDs_.insert(diskID);
+  pxeBladeIDs_.insert(bladeID);
+  pxePanelIDs_.insert(panelID);
   pxeModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addTIBDetUnitInfo(const DetId& detId)
-{
-  auto sideID    = trackerTopology_->tibSide(detId);
-  auto layerID   = trackerTopology_->tibLayer(detId);
+void TrackerAlignmentLevelBuilder ::addTIBDetUnitInfo(const DetId& detId) {
+  auto sideID = trackerTopology_->tibSide(detId);
+  auto layerID = trackerTopology_->tibLayer(detId);
   auto layerSide = trackerTopology_->tibOrder(detId);
-  auto stringID  = trackerTopology_->tibString(detId);
-  auto moduleID  = trackerTopology_->module(detId);
+  auto stringID = trackerTopology_->tibString(detId);
+  auto moduleID = trackerTopology_->module(detId);
 
   if (layerSide == 1) {
-    if (tidStringsInnerLayer_[layerID-1] < stringID) {
-      tidStringsInnerLayer_[layerID-1] = stringID;
+    if (tidStringsInnerLayer_[layerID - 1] < stringID) {
+      tidStringsInnerLayer_[layerID - 1] = stringID;
     }
   } else {
-    if (tidStringsOuterLayer_[layerID-1] < stringID) {
-      tidStringsOuterLayer_[layerID-1] = stringID;
+    if (tidStringsOuterLayer_[layerID - 1] < stringID) {
+      tidStringsOuterLayer_[layerID - 1] = stringID;
     }
   }
 
-  tibSideIDs_.  insert(sideID);
-  tibLayerIDs_. insert(layerID);
+  tibSideIDs_.insert(sideID);
+  tibLayerIDs_.insert(layerID);
   tibStringIDs_.insert(stringID);
   tibModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addTIDDetUnitInfo(const DetId& detId)
-{
-  auto sideID   = trackerTopology_->tidSide(detId);
-  auto wheelID  = trackerTopology_->tidWheel(detId);
-  auto ringID   = trackerTopology_->tidRing(detId);
+void TrackerAlignmentLevelBuilder ::addTIDDetUnitInfo(const DetId& detId) {
+  auto sideID = trackerTopology_->tidSide(detId);
+  auto wheelID = trackerTopology_->tidWheel(detId);
+  auto ringID = trackerTopology_->tidRing(detId);
   auto moduleID = trackerTopology_->module(detId);
 
   // tidOrder
-  tidSideIDs_.  insert(sideID);
-  tidWheelIDs_. insert(wheelID);
-  tidRingIDs_.  insert(ringID);
+  tidSideIDs_.insert(sideID);
+  tidWheelIDs_.insert(wheelID);
+  tidRingIDs_.insert(ringID);
   tidModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addTOBDetUnitInfo(const DetId& detId)
-{
-  auto layerID  = trackerTopology_->tobLayer(detId);
-  auto sideID   = trackerTopology_->tobSide(detId);
-  auto rodID    = trackerTopology_->tobRod(detId);
+void TrackerAlignmentLevelBuilder ::addTOBDetUnitInfo(const DetId& detId) {
+  auto layerID = trackerTopology_->tobLayer(detId);
+  auto sideID = trackerTopology_->tobSide(detId);
+  auto rodID = trackerTopology_->tobRod(detId);
   auto moduleID = trackerTopology_->module(detId);
 
-  tobLayerIDs_. insert(layerID);
-  tobSideIDs_.  insert(sideID);
-  tobRodIDs_.   insert(rodID);
+  tobLayerIDs_.insert(layerID);
+  tobSideIDs_.insert(sideID);
+  tobRodIDs_.insert(rodID);
   tobModuleIDs_.insert(moduleID);
 }
 
 //_____________________________________________________________________________
-void TrackerAlignmentLevelBuilder
-::addTECDetUnitInfo(const DetId& detId)
-{
-  auto sideID   = trackerTopology_->tecSide(detId);
-  auto wheelID  = trackerTopology_->tecWheel(detId);
-  auto petalID  = trackerTopology_->tecPetalNumber(detId);
-  auto ringID   = trackerTopology_->tecRing(detId);
+void TrackerAlignmentLevelBuilder ::addTECDetUnitInfo(const DetId& detId) {
+  auto sideID = trackerTopology_->tecSide(detId);
+  auto wheelID = trackerTopology_->tecWheel(detId);
+  auto petalID = trackerTopology_->tecPetalNumber(detId);
+  auto ringID = trackerTopology_->tecRing(detId);
   auto moduleID = trackerTopology_->module(detId);
 
-  tecSideIDs_.  insert(sideID);
-  tecWheelIDs_. insert(wheelID);
-  tecPetalIDs_. insert(petalID);
-  tecRingIDs_.  insert(ringID);
+  tecSideIDs_.insert(sideID);
+  tecWheelIDs_.insert(wheelID);
+  tecPetalIDs_.insert(petalID);
+  tecRingIDs_.insert(ringID);
   tecModuleIDs_.insert(moduleID);
 }
 
-
-
 //_____________________________________________________________________________
-align::AlignmentLevels TrackerAlignmentLevelBuilder
-::buildPXBAlignmentLevels()
-{
+align::AlignmentLevels TrackerAlignmentLevelBuilder ::buildPXBAlignmentLevels() {
   int maxNumModules = pxbModuleIDs_.size();
-  int maxNumLadders = pxbLadderIDs_.size() / 2; // divide by 2 since we have
-                                               // HalfBarrels
-  int maxNumLayers  = pxbLayerIDs_.size();
+  int maxNumLadders = pxbLadderIDs_.size() / 2;  // divide by 2 since we have
+                                                 // HalfBarrels
+  int maxNumLayers = pxbLayerIDs_.size();
 
   std::ostringstream ss;
-  ss << "determined following numbers for "
-     << alignableObjectId_.idToString(align::TPBBarrel) << " geometry:" << "\n"
-     << "   max. number of modules: " << maxNumModules                  << "\n"
-     << "   max. number of ladders: " << maxNumLadders                  << "\n";
+  ss << "determined following numbers for " << alignableObjectId_.idToString(align::TPBBarrel) << " geometry:"
+     << "\n"
+     << "   max. number of modules: " << maxNumModules << "\n"
+     << "   max. number of ladders: " << maxNumLadders << "\n";
 
   for (size_t layer = 0; layer < pxbLaddersPerLayer_.size(); ++layer) {
     // divide by 4, because we need the ladders per quarter cylinder
     trackerNameSpace_.tpb_.lpqc_.push_back(pxbLaddersPerLayer_[layer] / 4);
-    ss << "      ladders in layer-" << layer << ": "
-       << pxbLaddersPerLayer_[layer] << "\n";
+    ss << "      ladders in layer-" << layer << ": " << pxbLaddersPerLayer_[layer] << "\n";
   }
 
   ss << "   max. number of layers:  " << maxNumLayers;
-  edm::LogInfo("AlignableBuildProcess")
-     << "@SUB=TrackerAlignmentLevelBuilder::buildPXBAlignmentLevels"
-     << ss.str();
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=TrackerAlignmentLevelBuilder::buildPXBAlignmentLevels" << ss.str();
 
   align::AlignmentLevels pxb;
-  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBModule,     maxNumModules, false));
-  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBLadder,     maxNumLadders, true));
-  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBLayer,      maxNumLayers,  false));
-  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBHalfBarrel, 2,             false));
-  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBBarrel,     1,             false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBModule, maxNumModules, false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBLadder, maxNumLadders, true));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBLayer, maxNumLayers, false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBHalfBarrel, 2, false));
+  pxb.push_back(std::make_unique<AlignmentLevel>(align::TPBBarrel, 1, false));
   return pxb;
 }
 
 //_____________________________________________________________________________
-align::AlignmentLevels TrackerAlignmentLevelBuilder
-::buildPXEAlignmentLevels()
-{
+align::AlignmentLevels TrackerAlignmentLevelBuilder ::buildPXEAlignmentLevels() {
   int maxNumModules = pxeModuleIDs_.size();
-  int maxNumPanels  = pxePanelIDs_.size();
-  int maxNumBlades  = pxeBladeIDs_.size() / 2;
-  int maxNumDisks   = pxeDiskIDs_.size();
-  int maxNumSides   = pxeSideIDs_.size();
+  int maxNumPanels = pxePanelIDs_.size();
+  int maxNumBlades = pxeBladeIDs_.size() / 2;
+  int maxNumDisks = pxeDiskIDs_.size();
+  int maxNumSides = pxeSideIDs_.size();
 
   std::ostringstream ss;
-  ss << "determined following numbers for "
-     << alignableObjectId_.idToString(align::TPEEndcap) << " geometry:" << "\n"
-     << "   max. number of modules: " << maxNumModules                  << "\n"
-     << "   max. number of panels:  " << maxNumPanels                   << "\n"
-     << "   max. number of blades:  " << maxNumBlades                   << "\n";
+  ss << "determined following numbers for " << alignableObjectId_.idToString(align::TPEEndcap) << " geometry:"
+     << "\n"
+     << "   max. number of modules: " << maxNumModules << "\n"
+     << "   max. number of panels:  " << maxNumPanels << "\n"
+     << "   max. number of blades:  " << maxNumBlades << "\n";
 
   trackerNameSpace_.tpe_.bpqd_ = maxNumBlades / 2;
 
   ss << "      blades per quarter disk: " << trackerNameSpace_.tpe_.bpqd_ << "\n"
-     << "   max. number of disks:   " << maxNumDisks                    << "\n"
+     << "   max. number of disks:   " << maxNumDisks << "\n"
      << "   max. number of sides:   " << maxNumSides;
-  edm::LogInfo("AlignableBuildProcess")
-     << "@SUB=TrackerAlignmentLevelBuilder::buildPXEAlignmentLevels"
-     << ss.str();
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=TrackerAlignmentLevelBuilder::buildPXEAlignmentLevels" << ss.str();
 
   align::AlignmentLevels pxe;
-  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEModule,       maxNumModules, false));
-  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEPanel,        maxNumPanels,  true));
-  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEBlade,        maxNumBlades,  true));
-  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEHalfDisk,     maxNumDisks,   false));
-  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEHalfCylinder, 2,             false));
-  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEEndcap,       maxNumSides,   false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEModule, maxNumModules, false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEPanel, maxNumPanels, true));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEBlade, maxNumBlades, true));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEHalfDisk, maxNumDisks, false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEHalfCylinder, 2, false));
+  pxe.push_back(std::make_unique<AlignmentLevel>(align::TPEEndcap, maxNumSides, false));
   return pxe;
 }
 
 //_____________________________________________________________________________
-align::AlignmentLevels TrackerAlignmentLevelBuilder
-::buildTIBAlignmentLevels()
-{
+align::AlignmentLevels TrackerAlignmentLevelBuilder ::buildTIBAlignmentLevels() {
   int maxNumModules = tibModuleIDs_.size();
   int maxNumStrings = tibStringIDs_.size();
-  int maxNumLayers  = tibLayerIDs_.size();
-  int maxNumSides   = tibSideIDs_.size();
+  int maxNumLayers = tibLayerIDs_.size();
+  int maxNumSides = tibSideIDs_.size();
 
   std::ostringstream ss;
-  ss << "determined following numbers for "
-     << alignableObjectId_.idToString(align::TIBBarrel) << " geometry:" << "\n"
-     << "   max. number of modules: " << maxNumModules                  << "\n"
-     << "   max. number of strings: " << maxNumStrings                  << "\n";
+  ss << "determined following numbers for " << alignableObjectId_.idToString(align::TIBBarrel) << " geometry:"
+     << "\n"
+     << "   max. number of modules: " << maxNumModules << "\n"
+     << "   max. number of strings: " << maxNumStrings << "\n";
 
   for (size_t layer = 0; layer < tidStringsInnerLayer_.size(); ++layer) {
     // divide by 2, because we have HalfShells
     trackerNameSpace_.tib_.sphs_.push_back(tidStringsInnerLayer_[layer] / 2);
     trackerNameSpace_.tib_.sphs_.push_back(tidStringsOuterLayer_[layer] / 2);
 
-    ss << "      strings in layer-" << layer << " (inside):  "
-       << tidStringsInnerLayer_[layer] << "\n"
-       << "      strings in layer-" << layer << " (outside): "
-       << tidStringsOuterLayer_[layer] << "\n";
+    ss << "      strings in layer-" << layer << " (inside):  " << tidStringsInnerLayer_[layer] << "\n"
+       << "      strings in layer-" << layer << " (outside): " << tidStringsOuterLayer_[layer] << "\n";
   }
 
-  ss << "   max. number of layers:  " << maxNumLayers                   << "\n"
+  ss << "   max. number of layers:  " << maxNumLayers << "\n"
      << "   max. number of sides:   " << maxNumSides;
-  edm::LogInfo("AlignableBuildProcess")
-       << "@SUB=TrackerAlignmentLevelBuilder::buildTIBAlignmentLevels"
-       << ss.str();
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=TrackerAlignmentLevelBuilder::buildTIBAlignmentLevels" << ss.str();
 
   align::AlignmentLevels tib;
-  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBModule,     maxNumModules, false));
-  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBString,     maxNumStrings, true));
-  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBSurface,    2, false)); // 2 surfaces per half shell
-  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBHalfShell,  2, false)); // 2 half shells per layer
-  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBLayer,      maxNumLayers, false));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBModule, maxNumModules, false));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBString, maxNumStrings, true));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBSurface, 2, false));    // 2 surfaces per half shell
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBHalfShell, 2, false));  // 2 half shells per layer
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBLayer, maxNumLayers, false));
   tib.push_back(std::make_unique<AlignmentLevel>(align::TIBHalfBarrel, 2, false));
-  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBBarrel,     1, false));
+  tib.push_back(std::make_unique<AlignmentLevel>(align::TIBBarrel, 1, false));
   return tib;
 }
 
 //_____________________________________________________________________________
-align::AlignmentLevels TrackerAlignmentLevelBuilder
-::buildTIDAlignmentLevels()
-{
+align::AlignmentLevels TrackerAlignmentLevelBuilder ::buildTIDAlignmentLevels() {
   int maxNumModules = tidModuleIDs_.size();
-  int maxNumRings   = tidRingIDs_.size();
+  int maxNumRings = tidRingIDs_.size();
   // TODO: for PhaseII geometry the method name for tidWheel changes:
   //       -> trackerTopology->tidDisk(detId);
-  int maxNumWheels  = tidWheelIDs_.size();
-  int maxNumSides   = tidSideIDs_.size();
+  int maxNumWheels = tidWheelIDs_.size();
+  int maxNumSides = tidSideIDs_.size();
 
-  edm::LogInfo("AlignableBuildProcess")
-     << "@SUB=TrackerAlignmentLevelBuilder::buildTIDAlignmentLevels"
-     << "determined following numbers for "
-     << alignableObjectId_.idToString(align::TIDEndcap) << " geometry:" << "\n"
-     << "   max. number of modules: " << maxNumModules                  << "\n"
-     << "   max. number of rings:   " << maxNumRings                    << "\n"
-     << "   max. number of wheels:  " << maxNumWheels                   << "\n"
-     << "   max. number of sides:   " << maxNumSides;
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=TrackerAlignmentLevelBuilder::buildTIDAlignmentLevels"
+                                        << "determined following numbers for "
+                                        << alignableObjectId_.idToString(align::TIDEndcap) << " geometry:"
+                                        << "\n"
+                                        << "   max. number of modules: " << maxNumModules << "\n"
+                                        << "   max. number of rings:   " << maxNumRings << "\n"
+                                        << "   max. number of wheels:  " << maxNumWheels << "\n"
+                                        << "   max. number of sides:   " << maxNumSides;
 
   align::AlignmentLevels tid;
   tid.push_back(std::make_unique<AlignmentLevel>(align::TIDModule, maxNumModules, false));
-  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDSide,   2,             false)); // 2 sides per ring
-  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDRing,   maxNumRings,   false));
-  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDDisk,   maxNumWheels,  false));
-  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDEndcap, 2,             false)); // 2 endcaps in TID
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDSide, 2, false));  // 2 sides per ring
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDRing, maxNumRings, false));
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDDisk, maxNumWheels, false));
+  tid.push_back(std::make_unique<AlignmentLevel>(align::TIDEndcap, 2, false));  // 2 endcaps in TID
   return tid;
 }
 
 //_____________________________________________________________________________
-align::AlignmentLevels TrackerAlignmentLevelBuilder
-::buildTOBAlignmentLevels()
-{
+align::AlignmentLevels TrackerAlignmentLevelBuilder ::buildTOBAlignmentLevels() {
   int maxNumModules = tobModuleIDs_.size();
-  int maxNumRods    = tobRodIDs_.size();
-  int maxNumSides   = tobSideIDs_.size();
-  int maxNumLayers  = tobLayerIDs_.size();
+  int maxNumRods = tobRodIDs_.size();
+  int maxNumSides = tobSideIDs_.size();
+  int maxNumLayers = tobLayerIDs_.size();
 
-  edm::LogInfo("AlignableBuildProcess")
-     << "@SUB=TrackerAlignmentLevelBuilder::buildTOBAlignmentLevels"
-     << "determined following numbers for "
-     << alignableObjectId_.idToString(align::TOBBarrel) << " geometry:" << "\n"
-     << "   max. number of modules: " << maxNumModules                  << "\n"
-     << "   max. number of rods:    " << maxNumRods                     << "\n"
-     << "   max. number of sides:   " << maxNumSides                    << "\n"
-     << "   max. number of layers:  " << maxNumLayers;
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=TrackerAlignmentLevelBuilder::buildTOBAlignmentLevels"
+                                        << "determined following numbers for "
+                                        << alignableObjectId_.idToString(align::TOBBarrel) << " geometry:"
+                                        << "\n"
+                                        << "   max. number of modules: " << maxNumModules << "\n"
+                                        << "   max. number of rods:    " << maxNumRods << "\n"
+                                        << "   max. number of sides:   " << maxNumSides << "\n"
+                                        << "   max. number of layers:  " << maxNumLayers;
 
   align::AlignmentLevels tob;
-  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBModule,     maxNumModules, false));
-  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBRod,        maxNumRods,    true));
-  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBLayer,      maxNumLayers,  false));
-  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBHalfBarrel, maxNumSides,   false));
-  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBBarrel,     1,             false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBModule, maxNumModules, false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBRod, maxNumRods, true));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBLayer, maxNumLayers, false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBHalfBarrel, maxNumSides, false));
+  tob.push_back(std::make_unique<AlignmentLevel>(align::TOBBarrel, 1, false));
   return tob;
 }
 
 //_____________________________________________________________________________
-align::AlignmentLevels TrackerAlignmentLevelBuilder
-::buildTECAlignmentLevels()
-{
+align::AlignmentLevels TrackerAlignmentLevelBuilder ::buildTECAlignmentLevels() {
   int maxNumModules = tecModuleIDs_.size();
-  int maxNumRings   = tecRingIDs_.size();
-  int maxNumPetals  = tecPetalIDs_.size();
-  int maxNumDisks   = tecWheelIDs_.size();
-  int maxNumSides   = tecSideIDs_.size();
+  int maxNumRings = tecRingIDs_.size();
+  int maxNumPetals = tecPetalIDs_.size();
+  int maxNumDisks = tecWheelIDs_.size();
+  int maxNumSides = tecSideIDs_.size();
 
-  edm::LogInfo("AlignableBuildProcess")
-     << "@SUB=TrackerAlignmentLevelBuilder::buildTECAlignmentLevels"
-     << "determined following numbers for "
-     << alignableObjectId_.idToString(align::TECEndcap) << " geometry:" << "\n"
-     << "   max. number of modules: " << maxNumModules                  << "\n"
-     << "   max. number of rings:   " << maxNumRings                    << "\n"
-     << "   max. number of petals:  " << maxNumPetals                   << "\n"
-     << "   max. number of wheels:  " << maxNumDisks                    << "\n"
-     << "   max. number of sides:   " << maxNumSides;
+  edm::LogInfo("AlignableBuildProcess") << "@SUB=TrackerAlignmentLevelBuilder::buildTECAlignmentLevels"
+                                        << "determined following numbers for "
+                                        << alignableObjectId_.idToString(align::TECEndcap) << " geometry:"
+                                        << "\n"
+                                        << "   max. number of modules: " << maxNumModules << "\n"
+                                        << "   max. number of rings:   " << maxNumRings << "\n"
+                                        << "   max. number of petals:  " << maxNumPetals << "\n"
+                                        << "   max. number of wheels:  " << maxNumDisks << "\n"
+                                        << "   max. number of sides:   " << maxNumSides;
 
   align::AlignmentLevels tec;
   tec.push_back(std::make_unique<AlignmentLevel>(align::TECModule, maxNumModules, false));
-  tec.push_back(std::make_unique<AlignmentLevel>(align::TECRing,   maxNumRings,   true));
-  tec.push_back(std::make_unique<AlignmentLevel>(align::TECPetal,  maxNumPetals,  true));
-  tec.push_back(std::make_unique<AlignmentLevel>(align::TECSide,   2,             false)); // 2 sides per disk
-  tec.push_back(std::make_unique<AlignmentLevel>(align::TECDisk,   maxNumDisks,   false));
-  tec.push_back(std::make_unique<AlignmentLevel>(align::TECEndcap, 2,             false));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECRing, maxNumRings, true));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECPetal, maxNumPetals, true));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECSide, 2, false));  // 2 sides per disk
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECDisk, maxNumDisks, false));
+  tec.push_back(std::make_unique<AlignmentLevel>(align::TECEndcap, 2, false));
   return tec;
 }

--- a/Alignment/TrackerAlignment/src/TrackerNameSpace.cc
+++ b/Alignment/TrackerAlignment/src/TrackerNameSpace.cc
@@ -2,42 +2,25 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+//______________________________________________________________________________
+align::TrackerNameSpace ::TrackerNameSpace(const TrackerTopology* topology)
+    : trackerTopology_(topology),
+      tpb_(topology),
+      tpe_(topology),
+      tib_(topology),
+      tob_(topology),
+      tid_(topology),
+      tec_(topology) {}
 
 //______________________________________________________________________________
-align::TrackerNameSpace
-::TrackerNameSpace(const TrackerTopology* topology) :
-  trackerTopology_(topology),
-  tpb_(topology),
-  tpe_(topology),
-  tib_(topology),
-  tob_(topology),
-  tid_(topology),
-  tec_(topology)
-{
-}
-
+align::TrackerNameSpace::TPB ::TPB(const TrackerTopology* topology) : trackerTopology_(topology) {}
 
 //______________________________________________________________________________
-align::TrackerNameSpace::TPB
-::TPB(const TrackerTopology* topology) :
-  trackerTopology_(topology)
-{
-}
-
+unsigned int align::TrackerNameSpace::TPB ::moduleNumber(align::ID id) const { return trackerTopology_->pxbModule(id); }
 
 //______________________________________________________________________________
-unsigned int align::TrackerNameSpace::TPB
-::moduleNumber(align::ID id) const
-{
-  return trackerTopology_->pxbModule(id);
-}
-
-
-//______________________________________________________________________________
-unsigned int align::TrackerNameSpace::TPB
-::ladderNumber(align::ID id) const
-{
-  unsigned int l = trackerTopology_->pxbLadder(id); // increases with phi
+unsigned int align::TrackerNameSpace::TPB ::ladderNumber(align::ID id) const {
+  unsigned int l = trackerTopology_->pxbLadder(id);  // increases with phi
   unsigned int c = trackerTopology_->pxbLayer(id) - 1;
 
   // Ladder in 1st quadrant: number = lpqc_ + 1 - l     (1 to lpqc_)
@@ -46,110 +29,61 @@ unsigned int align::TrackerNameSpace::TPB
   // Ladder in 4th quadrant: number = 5 * lpqc_ + 1 - l (lpqc_ + 1 to 2 * lpqc_)
 
   return l > 3 * lpqc_[c] ? 5 * lpqc_[c] + 1 - l :  // ladder in 4th quadrant
-           (l > lpqc_[c] ? l - lpqc_[c] :           // ladder not in 1st quadrant
-             lpqc_[c] + 1 - l);
+             (l > lpqc_[c] ? l - lpqc_[c] :         // ladder not in 1st quadrant
+                  lpqc_[c] + 1 - l);
 }
 
+//______________________________________________________________________________
+unsigned int align::TrackerNameSpace::TPB ::layerNumber(align::ID id) const { return trackerTopology_->pxbLayer(id); }
 
 //______________________________________________________________________________
-unsigned int align::TrackerNameSpace::TPB
-::layerNumber(align::ID id) const
-{
-  return trackerTopology_->pxbLayer(id);
-}
-
-
-//______________________________________________________________________________
-unsigned int align::TrackerNameSpace::TPB
-::halfBarrelNumber(align::ID id) const
-{
-  unsigned int l = trackerTopology_->pxbLadder(id); // increases with phi
+unsigned int align::TrackerNameSpace::TPB ::halfBarrelNumber(align::ID id) const {
+  unsigned int l = trackerTopology_->pxbLadder(id);  // increases with phi
   unsigned int c = trackerTopology_->pxbLayer(id) - 1;
 
   return l > lpqc_[c] && l <= 3 * lpqc_[c] ? 1 : 2;
 }
 
+//______________________________________________________________________________
+unsigned int align::TrackerNameSpace::TPB ::barrelNumber(align::ID) const { return 1; }
 
 //______________________________________________________________________________
-unsigned int align::TrackerNameSpace::TPB
-::barrelNumber(align::ID) const
-{
-  return 1;
-}
+align::TrackerNameSpace::TPE ::TPE(const TrackerTopology* topology) : trackerTopology_(topology) {}
 
+unsigned int align::TrackerNameSpace::TPE ::moduleNumber(align::ID id) const { return trackerTopology_->pxfModule(id); }
 
-//______________________________________________________________________________
-align::TrackerNameSpace::TPE
-::TPE(const TrackerTopology* topology) :
-  trackerTopology_(topology)
-{
-}
+unsigned int align::TrackerNameSpace::TPE ::panelNumber(align::ID id) const { return trackerTopology_->pxfPanel(id); }
 
-
-unsigned int align::TrackerNameSpace::TPE
-::moduleNumber(align::ID id) const
-{
-  return trackerTopology_->pxfModule(id);
-}
-
-unsigned int align::TrackerNameSpace::TPE
-::panelNumber(align::ID id) const
-{
-  return trackerTopology_->pxfPanel(id);
-}
-
-unsigned int align::TrackerNameSpace::TPE
-::bladeNumber(align::ID id) const
-{
-  unsigned int b = trackerTopology_->pxfBlade(id); // 1 to 24 in increasing phi
+unsigned int align::TrackerNameSpace::TPE ::bladeNumber(align::ID id) const {
+  unsigned int b = trackerTopology_->pxfBlade(id);  // 1 to 24 in increasing phi
 
   // Blade in 1st quadrant: number = bpqd_ + 1 - b     (1 to bpqd_)
   // Blade in 2nd quadrant: number = b - bpqd_         (1 to bpqd_)
   // Blade in 3rd quadrant: number = b - bpqd_         (bpqd_ + 1 to 2 * bpqd_)
   // Blade in 4th quadrant: number = 5 * bpqd_ + 1 - b (bpqd_ + 1 to 2 * bpqd_)
 
-  return b > 3 * bpqd_ ? // blade in 4th quadrant
-    5 * bpqd_ + 1 - b :
-    (b > bpqd_ ? // blade not in 1st quadrant
-     b - bpqd_ : bpqd_ + 1 - b);
+  return b > 3 * bpqd_ ?  // blade in 4th quadrant
+             5 * bpqd_ + 1 - b
+                       : (b > bpqd_ ?  // blade not in 1st quadrant
+                              b - bpqd_
+                                    : bpqd_ + 1 - b);
 }
 
-unsigned int align::TrackerNameSpace::TPE
-::halfDiskNumber(align::ID id) const
-{
-  return trackerTopology_->pxfDisk(id);
-}
+unsigned int align::TrackerNameSpace::TPE ::halfDiskNumber(align::ID id) const { return trackerTopology_->pxfDisk(id); }
 
-unsigned int align::TrackerNameSpace::TPE
-::halfCylinderNumber(align::ID id) const
-{
-  unsigned int b = trackerTopology_->pxfBlade(id); // 1 to 24 in increasing phi
+unsigned int align::TrackerNameSpace::TPE ::halfCylinderNumber(align::ID id) const {
+  unsigned int b = trackerTopology_->pxfBlade(id);  // 1 to 24 in increasing phi
 
   return b > bpqd_ && b <= 3 * bpqd_ ? 1 : 2;
 }
 
-unsigned int align::TrackerNameSpace::TPE
-::endcapNumber(align::ID id) const
-{
-  return trackerTopology_->pxfSide(id);
-}
+unsigned int align::TrackerNameSpace::TPE ::endcapNumber(align::ID id) const { return trackerTopology_->pxfSide(id); }
 
+align::TrackerNameSpace::TIB ::TIB(const TrackerTopology* topology) : trackerTopology_(topology) {}
 
-align::TrackerNameSpace::TIB
-::TIB(const TrackerTopology* topology) :
-  trackerTopology_(topology)
-{
-}
+unsigned int align::TrackerNameSpace::TIB ::moduleNumber(align::ID id) const { return trackerTopology_->tibModule(id); }
 
-unsigned int align::TrackerNameSpace::TIB
-::moduleNumber(align::ID id) const
-{
-  return trackerTopology_->tibModule(id);
-}
-
-unsigned int align::TrackerNameSpace::TIB
-::stringNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TIB ::stringNumber(align::ID id) const {
   std::vector<unsigned int> s = trackerTopology_->tibStringInfo(id);
   // s[1]: surface lower = 1, upper = 2
   // s[2]: string no. increases with phi
@@ -162,15 +96,11 @@ unsigned int align::TrackerNameSpace::TIB
   return s[2] > sphs_[l] ? 2 * sphs_[l] + 1 - s[2] : s[2];
 }
 
-unsigned int align::TrackerNameSpace::TIB
-::surfaceNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TIB ::surfaceNumber(align::ID id) const {
   return trackerTopology_->tibStringInfo(id)[1];
 }
 
-unsigned int align::TrackerNameSpace::TIB
-::halfShellNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TIB ::halfShellNumber(align::ID id) const {
   std::vector<unsigned int> s = trackerTopology_->tibStringInfo(id);
   // s[1]: surface lower = 1, upper = 2
   // s[2]: string no. increases with phi
@@ -180,134 +110,60 @@ unsigned int align::TrackerNameSpace::TIB
   return s[2] > sphs_[l] ? 1 : 2;
 }
 
-unsigned int align::TrackerNameSpace::TIB
-::layerNumber(align::ID id) const
-{
-  return trackerTopology_->tibLayer(id);
-}
+unsigned int align::TrackerNameSpace::TIB ::layerNumber(align::ID id) const { return trackerTopology_->tibLayer(id); }
 
-unsigned int align::TrackerNameSpace::TIB
-::halfBarrelNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TIB ::halfBarrelNumber(align::ID id) const {
   return trackerTopology_->tibStringInfo(id)[0];
 }
 
-unsigned int align::TrackerNameSpace::TIB
-::barrelNumber(align::ID) const
-{
-  return 1;
-}
+unsigned int align::TrackerNameSpace::TIB ::barrelNumber(align::ID) const { return 1; }
 
-align::TrackerNameSpace::TOB
-::TOB(const TrackerTopology* topology) :
-  trackerTopology_(topology)
-{
-}
+align::TrackerNameSpace::TOB ::TOB(const TrackerTopology* topology) : trackerTopology_(topology) {}
 
-unsigned int align::TrackerNameSpace::TOB
-::moduleNumber(align::ID id) const
-{
-  return trackerTopology_->tobModule(id);
-}
+unsigned int align::TrackerNameSpace::TOB ::moduleNumber(align::ID id) const { return trackerTopology_->tobModule(id); }
 
-unsigned int align::TrackerNameSpace::TOB
-::rodNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TOB ::rodNumber(align::ID id) const {
   return trackerTopology_->tobRodInfo(id)[1];
 }
 
-unsigned int align::TrackerNameSpace::TOB
-::layerNumber(align::ID id) const
-{
-  return trackerTopology_->tobLayer(id);
-}
+unsigned int align::TrackerNameSpace::TOB ::layerNumber(align::ID id) const { return trackerTopology_->tobLayer(id); }
 
-unsigned int align::TrackerNameSpace::TOB
-::halfBarrelNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TOB ::halfBarrelNumber(align::ID id) const {
   return trackerTopology_->tobRodInfo(id)[0];
 }
 
-unsigned int align::TrackerNameSpace::TOB
-::barrelNumber(align::ID) const
-{
-  return 1;
-}
+unsigned int align::TrackerNameSpace::TOB ::barrelNumber(align::ID) const { return 1; }
 
-align::TrackerNameSpace::TID
-::TID(const TrackerTopology* topology) :
-  trackerTopology_(topology)
-{
-}
+align::TrackerNameSpace::TID ::TID(const TrackerTopology* topology) : trackerTopology_(topology) {}
 
-unsigned int align::TrackerNameSpace::TID
-::moduleNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TID ::moduleNumber(align::ID id) const {
   return trackerTopology_->tidModuleInfo(id)[1];
 }
 
-unsigned int align::TrackerNameSpace::TID
-::sideNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TID ::sideNumber(align::ID id) const {
   return trackerTopology_->tidModuleInfo(id)[0];
 }
 
-unsigned int align::TrackerNameSpace::TID
-::ringNumber(align::ID id) const
-{
-  return trackerTopology_->tidRing(id);
-}
+unsigned int align::TrackerNameSpace::TID ::ringNumber(align::ID id) const { return trackerTopology_->tidRing(id); }
 
-unsigned int align::TrackerNameSpace::TID
-::diskNumber(align::ID id) const
-{
-  return trackerTopology_->tidWheel(id);
-}
+unsigned int align::TrackerNameSpace::TID ::diskNumber(align::ID id) const { return trackerTopology_->tidWheel(id); }
 
-unsigned int align::TrackerNameSpace::TID
-::endcapNumber(align::ID id) const
-{
-  return trackerTopology_->tidSide(id);
-}
+unsigned int align::TrackerNameSpace::TID ::endcapNumber(align::ID id) const { return trackerTopology_->tidSide(id); }
 
-align::TrackerNameSpace::TEC
-::TEC(const TrackerTopology* topology) :
-  trackerTopology_(topology)
-{
-}
+align::TrackerNameSpace::TEC ::TEC(const TrackerTopology* topology) : trackerTopology_(topology) {}
 
-unsigned int align::TrackerNameSpace::TEC
-::moduleNumber(align::ID id) const
-{
-  return trackerTopology_->tecModule(id);
-}
+unsigned int align::TrackerNameSpace::TEC ::moduleNumber(align::ID id) const { return trackerTopology_->tecModule(id); }
 
-unsigned int align::TrackerNameSpace::TEC
-::ringNumber(align::ID id) const
-{
-  return trackerTopology_->tecRing(id);
-}
+unsigned int align::TrackerNameSpace::TEC ::ringNumber(align::ID id) const { return trackerTopology_->tecRing(id); }
 
-unsigned int align::TrackerNameSpace::TEC
-::petalNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TEC ::petalNumber(align::ID id) const {
   return trackerTopology_->tecPetalInfo(id)[1];
 }
 
-unsigned int align::TrackerNameSpace::TEC
-::sideNumber(align::ID id) const
-{
+unsigned int align::TrackerNameSpace::TEC ::sideNumber(align::ID id) const {
   return trackerTopology_->tecPetalInfo(id)[0];
 }
 
-unsigned int align::TrackerNameSpace::TEC
-::diskNumber(align::ID id) const
-{
-  return trackerTopology_->tecWheel(id);
-}
+unsigned int align::TrackerNameSpace::TEC ::diskNumber(align::ID id) const { return trackerTopology_->tecWheel(id); }
 
-unsigned int align::TrackerNameSpace::TEC
-::endcapNumber(align::ID id) const
-{
-  return trackerTopology_->tecSide(id);
-}
+unsigned int align::TrackerNameSpace::TEC ::endcapNumber(align::ID id) const { return trackerTopology_->tecSide(id); }

--- a/Alignment/TrackerAlignment/src/TrackerScenarioBuilder.cc
+++ b/Alignment/TrackerAlignment/src/TrackerScenarioBuilder.cc
@@ -18,19 +18,15 @@
 #include "Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 
-
 //__________________________________________________________________________________________________
-TrackerScenarioBuilder::TrackerScenarioBuilder(AlignableTracker* alignable) :
-  MisalignmentScenarioBuilder(alignable->objectIdProvider().geometry()),
-  theAlignableTracker(alignable)
-{
-
+TrackerScenarioBuilder::TrackerScenarioBuilder(AlignableTracker* alignable)
+    : MisalignmentScenarioBuilder(alignable->objectIdProvider().geometry()), theAlignableTracker(alignable) {
   if (!theAlignableTracker) {
     throw cms::Exception("TypeMismatch") << "Pointer to AlignableTracker is empty.\n";
   }
 
   // Fill what is needed for possiblyPartOf(..):
-  theSubdets.push_back(stripOffModule(align::TPBModule)); // Take care, order matters: 1st pixel, 2nd strip.
+  theSubdets.push_back(stripOffModule(align::TPBModule));  // Take care, order matters: 1st pixel, 2nd strip.
   theSubdets.push_back(stripOffModule(align::TPEModule));
   theFirstStripIndex = theSubdets.size();
   theSubdets.push_back(stripOffModule(align::TIBModule));
@@ -39,74 +35,72 @@ TrackerScenarioBuilder::TrackerScenarioBuilder(AlignableTracker* alignable) :
   theSubdets.push_back(stripOffModule(align::TECModule));
 }
 
-
 //__________________________________________________________________________________________________
-void TrackerScenarioBuilder::applyScenario( const edm::ParameterSet& scenario )
-{
-
+void TrackerScenarioBuilder::applyScenario(const edm::ParameterSet& scenario) {
   // Apply the scenario to all main components of tracker.
   theModifierCounter = 0;
 
   // Seed is set at top-level, and is mandatory
-  if ( this->hasParameter_( "seed", scenario) )
-	theModifier.setSeed( static_cast<long>(scenario.getParameter<int>("seed")) );
+  if (this->hasParameter_("seed", scenario))
+    theModifier.setSeed(static_cast<long>(scenario.getParameter<int>("seed")));
   else
-	throw cms::Exception("BadConfig") << "No generator seed defined!";  
+    throw cms::Exception("BadConfig") << "No generator seed defined!";
 
   // misalignment applied recursively ('subStructures("Tracker")' contains only tracker itself)
   this->decodeMovements_(scenario, theAlignableTracker->subStructures("Tracker"));
 
-  edm::LogInfo("TrackerScenarioBuilder") 
-	<< "Applied modifications to " << theModifierCounter << " alignables";
-
+  edm::LogInfo("TrackerScenarioBuilder") << "Applied modifications to " << theModifierCounter << " alignables";
 }
 
-
 //__________________________________________________________________________________________________
-bool TrackerScenarioBuilder::isTopLevel_(const std::string &parameterSetName) const
-{
+bool TrackerScenarioBuilder::isTopLevel_(const std::string& parameterSetName) const {
   // Get root name (strip last character [s])
   std::string root = this->rootName_(parameterSetName);
 
-  if (root == "Tracker") return true;
+  if (root == "Tracker")
+    return true;
 
   return false;
 }
 
 //__________________________________________________________________________________________________
-bool TrackerScenarioBuilder::possiblyPartOf(const std::string &subStruct, const std::string &largeStr) const
-{
+bool TrackerScenarioBuilder::possiblyPartOf(const std::string& subStruct, const std::string& largeStr) const {
   // string::find(s) != nPos => 's' is contained in string!
-  const std::string::size_type nPos = std::string::npos; 
+  const std::string::size_type nPos = std::string::npos;
 
   // First check whether anything from pixel in strip.
   if (largeStr.find("Strip") != nPos) {
-    if (subStruct.find("Pixel") != nPos) return false;
+    if (subStruct.find("Pixel") != nPos)
+      return false;
     for (unsigned int iPix = 0; iPix < theFirstStripIndex; ++iPix) {
-      if (subStruct.find(theSubdets[iPix]) != nPos) return false;
+      if (subStruct.find(theSubdets[iPix]) != nPos)
+        return false;
     }
   }
 
   // Now check whether anything from strip in pixel.
   if (largeStr.find("Pixel") != nPos) {
-    if (subStruct.find("Strip") != nPos) return false;
+    if (subStruct.find("Strip") != nPos)
+      return false;
     for (unsigned int iStrip = theFirstStripIndex; iStrip < theSubdets.size(); ++iStrip) {
-      if (subStruct.find(theSubdets[iStrip]) != nPos) return false;
+      if (subStruct.find(theSubdets[iStrip]) != nPos)
+        return false;
     }
   }
 
   // Finally check for any different detector parts, e.g. TIDEndcap/TIBString gives false.
   for (unsigned int iSub = 0; iSub < theSubdets.size(); ++iSub) {
     for (unsigned int iLarge = 0; iLarge < theSubdets.size(); ++iLarge) {
-      if (iLarge == iSub) continue;
+      if (iLarge == iSub)
+        continue;
       if (largeStr.find(theSubdets[iLarge]) != nPos && subStruct.find(theSubdets[iSub]) != nPos) {
-	return false;
+        return false;
       }
     }
   }
 
   // It seems like a possible combination:
-  return true; 
+  return true;
 }
 
 //__________________________________________________________________________________________________
@@ -115,8 +109,7 @@ std::string TrackerScenarioBuilder::stripOffModule(const align::StructureType& t
   std::string name{theAlignableTracker->objectIdProvider().typeToName(type)};
   auto start = name.find(module);
   if (start == std::string::npos) {
-    throw cms::Exception("LogicError")
-      << "[TrackerScenarioBuilder] '" << name << "' is not a module type";
+    throw cms::Exception("LogicError") << "[TrackerScenarioBuilder] '" << name << "' is not a module type";
   }
   name.replace(start, module.length(), "");
   return name;

--- a/Alignment/TrackerAlignment/test/ApeAdder.cpp
+++ b/Alignment/TrackerAlignment/test/ApeAdder.cpp
@@ -8,7 +8,6 @@
 //         Created:  December 5, 2006
 //
 
-
 // system include files
 
 // user include files
@@ -33,41 +32,33 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
-
 // Class declaration
 class ApeAdder : public edm::EDAnalyzer {
 public:
-  explicit ApeAdder( const edm::ParameterSet& );
-  ~ApeAdder() {};
-  
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  explicit ApeAdder(const edm::ParameterSet&);
+  ~ApeAdder(){};
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
-    // methods
+  // methods
   void addApe(const align::Alignables& alignables);
-    
+
 private:
-    // members
+  // members
   std::string theErrorRecordName;
-    std::vector<double> theApe; // Amount of APE to add (from config.)
-  
+  std::vector<double> theApe;  // Amount of APE to add (from config.)
 };
 
-ApeAdder::ApeAdder( const edm::ParameterSet& iConfig )  :
-  theErrorRecordName( "TrackerAlignmentErrorExtendedRcd" )
-{ 
-
+ApeAdder::ApeAdder(const edm::ParameterSet& iConfig) : theErrorRecordName("TrackerAlignmentErrorExtendedRcd") {
   // The APE to set to all GeomDets
-  theApe = iConfig.getUntrackedParameter< std::vector<double> >("apeVector");
-  
+  theApe = iConfig.getUntrackedParameter<std::vector<double> >("apeVector");
 }
 
 //__________________________________________________________________________________________________
-void ApeAdder::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+void ApeAdder::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 {
-
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -75,46 +66,41 @@ void ApeAdder::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
   // Get geometry from ES
   edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get( trackerGeometry );
-    
+  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
+
   // Create the alignable hierarchy
-  AlignableTracker* theAlignableTracker = new AlignableTracker( &(*trackerGeometry), tTopo );
-  
+  AlignableTracker* theAlignableTracker = new AlignableTracker(&(*trackerGeometry), tTopo);
+
   // Now loop on alignable dets and add alignment error
-  if ( theAlignableTracker->barrelGeomDets().size() ) 
+  if (theAlignableTracker->barrelGeomDets().size())
     this->addApe(theAlignableTracker->barrelGeomDets());
-  if ( theAlignableTracker->pixelHalfBarrelGeomDets().size() ) 
+  if (theAlignableTracker->pixelHalfBarrelGeomDets().size())
     this->addApe(theAlignableTracker->pixelHalfBarrelGeomDets());
-  if ( theAlignableTracker->endcapGeomDets().size() ) 
+  if (theAlignableTracker->endcapGeomDets().size())
     this->addApe(theAlignableTracker->endcapGeomDets());
-  if ( theAlignableTracker->TIDGeomDets().size() ) 
+  if (theAlignableTracker->TIDGeomDets().size())
     this->addApe(theAlignableTracker->TIDGeomDets());
-  if ( theAlignableTracker->pixelEndcapGeomDets().size() ) 
+  if (theAlignableTracker->pixelEndcapGeomDets().size())
     this->addApe(theAlignableTracker->pixelEndcapGeomDets());
-  
+
   // Store to DB
   AlignmentErrorsExtended* alignmentErrors = theAlignableTracker->alignmentErrors();
 
   // Call service
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( !poolDbService.isAvailable() ) // Die if not available
+  if (!poolDbService.isAvailable())  // Die if not available
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
   // Save to DB
-  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->beginOfTime(),
-                                           theErrorRecordName);
-
+  poolDbService->writeOne<AlignmentErrorsExtended>(alignmentErrors, poolDbService->beginOfTime(), theErrorRecordName);
 
   delete theAlignableTracker;
-
 }
 
-void ApeAdder::addApe(const align::Alignables& alignables)
-{
-  
-  AlignmentPositionError ape( theApe[0], theApe[1], theApe[2] );
-  for (const auto& iDet: alignables) {
-    iDet->setAlignmentPositionError(ape, true); // true: propagate to components
+void ApeAdder::addApe(const align::Alignables& alignables) {
+  AlignmentPositionError ape(theApe[0], theApe[1], theApe[2]);
+  for (const auto& iDet : alignables) {
+    iDet->setAlignmentPositionError(ape, true);  // true: propagate to components
   }
 }
 

--- a/Alignment/TrackerAlignment/test/TestAnalyzer.cpp
+++ b/Alignment/TrackerAlignment/test/TestAnalyzer.cpp
@@ -2,7 +2,7 @@
 //
 // Package:    TestAnalyzer
 // Class:      TestAnalyzer
-// 
+//
 //
 // Description: Module to test the Alignment software
 //
@@ -10,7 +10,6 @@
 // Original Author:  Frederic Ronga
 //         Created:  March 16, 2006
 //
-
 
 // system include files
 #include <string>
@@ -40,103 +39,83 @@
 
 class TestAnalyzer : public edm::EDAnalyzer {
 public:
-  explicit TestAnalyzer( const edm::ParameterSet& );
+  explicit TestAnalyzer(const edm::ParameterSet&);
   ~TestAnalyzer();
-  
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
   TTree* theTree;
   TFile* theFile;
-  float x_,y_,z_,phi_,theta_,length_,thick_,width_;
+  float x_, y_, z_, phi_, theta_, length_, thick_, width_;
   int Id_;
   TRotMatrix* rot_;
-
 };
 
 //
 // constructors and destructor
 //
-TestAnalyzer::TestAnalyzer( const edm::ParameterSet& iConfig ) 
-{ 
-
+TestAnalyzer::TestAnalyzer(const edm::ParameterSet& iConfig) {
   // Open root file and define tree
-  std::string fileName = iConfig.getUntrackedParameter<std::string>("fileName","test.root");
-  theFile = new TFile( fileName.c_str(), "RECREATE" );
-  theTree = new TTree( "theTree", "Detector units positions" );
-  
-  theTree->Branch("Id",     &Id_,     "Id/I"     );
-  theTree->Branch("x",      &x_,      "x/F"      );
-  theTree->Branch("y",      &y_,      "y/F"      );
-  theTree->Branch("z",      &z_,      "z/F"      );
-  theTree->Branch("phi",    &phi_,    "phi/F"    );
-  theTree->Branch("theta",  &theta_,  "theta/F"  );
-  theTree->Branch("length", &length_, "length/F" );
-  theTree->Branch("width",  &width_,  "width/F"  );
-  theTree->Branch("thick",  &thick_,  "thick/F"  );
-  rot_ = 0;
-  theTree->Branch("rot",    "TRotMatrix", &rot_  );
+  std::string fileName = iConfig.getUntrackedParameter<std::string>("fileName", "test.root");
+  theFile = new TFile(fileName.c_str(), "RECREATE");
+  theTree = new TTree("theTree", "Detector units positions");
 
+  theTree->Branch("Id", &Id_, "Id/I");
+  theTree->Branch("x", &x_, "x/F");
+  theTree->Branch("y", &y_, "y/F");
+  theTree->Branch("z", &z_, "z/F");
+  theTree->Branch("phi", &phi_, "phi/F");
+  theTree->Branch("theta", &theta_, "theta/F");
+  theTree->Branch("length", &length_, "length/F");
+  theTree->Branch("width", &width_, "width/F");
+  theTree->Branch("thick", &thick_, "thick/F");
+  rot_ = 0;
+  theTree->Branch("rot", "TRotMatrix", &rot_);
 }
 
-
-TestAnalyzer::~TestAnalyzer()
-{ 
-  
+TestAnalyzer::~TestAnalyzer() {
   theTree->Write();
   theFile->Close();
-  
 }
 
-
-void
-TestAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-
-   
+void TestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::LogInfo("TrackerAlignment") << "Starting!";
 
   //
   // Retrieve tracker geometry from event setup
   //
   edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get( trackerGeometry );
+  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
 
   // Now loop on detector units, and store position and orientation
-  for ( auto iGeomDet = trackerGeometry->dets().begin();
-		iGeomDet != trackerGeometry->dets().end(); iGeomDet++ )
-	{
-	  
-	  Id_     = (*iGeomDet)->geographicalId().rawId();
-	  x_      = (*iGeomDet)->position().x();
-	  y_      = (*iGeomDet)->position().y();
-	  z_      = (*iGeomDet)->position().z();
-	  phi_    = (*iGeomDet)->surface().normalVector().phi();
-	  theta_  = (*iGeomDet)->surface().normalVector().theta();
-	  length_ = (*iGeomDet)->surface().bounds().length();
-	  width_  = (*iGeomDet)->surface().bounds().width();
-	  thick_  = (*iGeomDet)->surface().bounds().thickness();
+  for (auto iGeomDet = trackerGeometry->dets().begin(); iGeomDet != trackerGeometry->dets().end(); iGeomDet++) {
+    Id_ = (*iGeomDet)->geographicalId().rawId();
+    x_ = (*iGeomDet)->position().x();
+    y_ = (*iGeomDet)->position().y();
+    z_ = (*iGeomDet)->position().z();
+    phi_ = (*iGeomDet)->surface().normalVector().phi();
+    theta_ = (*iGeomDet)->surface().normalVector().theta();
+    length_ = (*iGeomDet)->surface().bounds().length();
+    width_ = (*iGeomDet)->surface().bounds().width();
+    thick_ = (*iGeomDet)->surface().bounds().thickness();
 
-	  double matrix[9] = { 
-		(*iGeomDet)->rotation().xx(),
-		(*iGeomDet)->rotation().xy(),
-		(*iGeomDet)->rotation().xz(),
-		(*iGeomDet)->rotation().yx(),
-		(*iGeomDet)->rotation().yy(),
-		(*iGeomDet)->rotation().yz(),
-		(*iGeomDet)->rotation().zx(),
-		(*iGeomDet)->rotation().zy(),
-		(*iGeomDet)->rotation().zz()
-	  };
-	  rot_ = new TRotMatrix( "rot", "rot", matrix );
+    double matrix[9] = {(*iGeomDet)->rotation().xx(),
+                        (*iGeomDet)->rotation().xy(),
+                        (*iGeomDet)->rotation().xz(),
+                        (*iGeomDet)->rotation().yx(),
+                        (*iGeomDet)->rotation().yy(),
+                        (*iGeomDet)->rotation().yz(),
+                        (*iGeomDet)->rotation().zx(),
+                        (*iGeomDet)->rotation().zy(),
+                        (*iGeomDet)->rotation().zz()};
+    rot_ = new TRotMatrix("rot", "rot", matrix);
 
-	  theTree->Fill();
+    theTree->Fill();
+  }
 
-	}
-  
   edm::LogInfo("TrackerAlignment") << "Done!";
-
 }
 
 //define this as a plug-in

--- a/Alignment/TrackerAlignment/test/TestReader.cpp
+++ b/Alignment/TrackerAlignment/test/TestReader.cpp
@@ -8,7 +8,6 @@
 //         Created:  March 16, 2006
 //
 
-
 // system include files
 #include <TRotMatrix.h>
 
@@ -19,7 +18,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
@@ -33,63 +31,49 @@
 
 class TestTrackerReader : public edm::EDAnalyzer {
 public:
-  explicit TestTrackerReader( const edm::ParameterSet& )
-    : rot(0) {}
-  
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  explicit TestTrackerReader(const edm::ParameterSet&) : rot(0) {}
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
-  float x,y,z,phi,theta,length,thick,width;
+  float x, y, z, phi, theta, length, thick, width;
   TRotMatrix* rot;
-
 };
 
-
-void
-TestTrackerReader::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-
-   
+void TestTrackerReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::LogInfo("TrackerAlignment") << "Starting!";
 
   // Retrieve alignment[Error]s from DBase
   edm::ESHandle<Alignments> alignments;
-  iSetup.get<TrackerAlignmentRcd>().get( alignments );
+  iSetup.get<TrackerAlignmentRcd>().get(alignments);
   edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get( alignmentErrors );
+  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
 
-  edm::LogVerbatim("DumpAlignments")  << "\n----------------------\n";
-  for ( std::vector<AlignTransform>::const_iterator it = alignments->m_align.begin();
-		it != alignments->m_align.end(); it++ )
-	{
-	  CLHEP::HepRotation rot( (*it).rotation() );
-	  align::RotationType rotation( rot.xx(), rot.xy(), rot.xz(),
-					rot.yx(), rot.yy(), rot.yz(),
-					rot.zx(), rot.zy(), rot.zz() );
+  edm::LogVerbatim("DumpAlignments") << "\n----------------------\n";
+  for (std::vector<AlignTransform>::const_iterator it = alignments->m_align.begin(); it != alignments->m_align.end();
+       it++) {
+    CLHEP::HepRotation rot((*it).rotation());
+    align::RotationType rotation(
+        rot.xx(), rot.xy(), rot.xz(), rot.yx(), rot.yy(), rot.yz(), rot.zx(), rot.zy(), rot.zz());
 
-	  edm::LogVerbatim("DumpAlignments") << (*it).rawId()
-				<< "  " << (*it).translation().x()
-				<< " " << (*it).translation().y()
-				<< " " << (*it).translation().z()
-				<< "  " << rotation.xx() << " " << rotation.xy() << " " << rotation.xz()
-				<< " " << rotation.yx() << " " << rotation.yy() << " " << rotation.yz()
-				<< " " << rotation.zx() << " " << rotation.zy() << " " << rotation.zz();
-
-	}
-  edm::LogVerbatim("DumpAlignments")  << "\n----------------------\n";
-  edm::LogVerbatim("DumpAlignmentErrorsExtended")  << "\n----------------------\n";
+    edm::LogVerbatim("DumpAlignments") << (*it).rawId() << "  " << (*it).translation().x() << " "
+                                       << (*it).translation().y() << " " << (*it).translation().z() << "  "
+                                       << rotation.xx() << " " << rotation.xy() << " " << rotation.xz() << " "
+                                       << rotation.yx() << " " << rotation.yy() << " " << rotation.yz() << " "
+                                       << rotation.zx() << " " << rotation.zy() << " " << rotation.zz();
+  }
+  edm::LogVerbatim("DumpAlignments") << "\n----------------------\n";
+  edm::LogVerbatim("DumpAlignmentErrorsExtended") << "\n----------------------\n";
 
   std::vector<AlignTransformErrorExtended> alignErrors = alignmentErrors->m_alignError;
-  for ( std::vector<AlignTransformErrorExtended>::const_iterator it = alignErrors.begin();
-		it != alignErrors.end(); it++ )
-	{
-	  edm::LogVerbatim("DumpAlignments") << (*it).rawId() << (*it).matrix();
-	}
-  edm::LogVerbatim("DumpAlignmentErrorsExtended")  << "\n----------------------\n";
+  for (std::vector<AlignTransformErrorExtended>::const_iterator it = alignErrors.begin(); it != alignErrors.end();
+       it++) {
+    edm::LogVerbatim("DumpAlignments") << (*it).rawId() << (*it).matrix();
+  }
+  edm::LogVerbatim("DumpAlignmentErrorsExtended") << "\n----------------------\n";
 
   edm::LogInfo("TrackerAlignment") << "Done!";
-
 }
 
 //define this as a plug-in

--- a/Alignment/TrackerAlignment/test/TestTrackerHierarchy.cpp
+++ b/Alignment/TrackerAlignment/test/TestTrackerHierarchy.cpp
@@ -2,7 +2,7 @@
 //
 // Package:    TestTrackerHierarchy
 // Class:      TestTrackerHierarchy
-// 
+//
 //
 // Description: Module to test the Alignment software
 //
@@ -10,7 +10,6 @@
 // Original Author:  Frederic Ronga
 //         Created:  March 16, 2006
 //         $Id: TestTrackerHierarchy.cpp,v 1.6 2012/06/30 08:59:35 eulisse Exp $
-
 
 // system include files
 #include <sstream>
@@ -20,7 +19,7 @@
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EventSetup.h"	 
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -29,13 +28,11 @@
 #include "CondFormats/Alignment/interface/AlignTransform.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 
-
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/CommonAlignment/interface/AlignableNavigator.h"
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 
-
-static const int kLEAD_WIDTH = 40; // First field width
+static const int kLEAD_WIDTH = 40;  // First field width
 
 //
 //
@@ -44,15 +41,16 @@ static const int kLEAD_WIDTH = 40; // First field width
 
 class TestTrackerHierarchy : public edm::EDAnalyzer {
 public:
-  explicit TestTrackerHierarchy( const edm::ParameterSet& pSet) 
-    : dumpAlignments_(pSet.getUntrackedParameter<bool>("dumpAlignments")) {}
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  explicit TestTrackerHierarchy(const edm::ParameterSet& pSet)
+      : dumpAlignments_(pSet.getUntrackedParameter<bool>("dumpAlignments")) {}
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
-  void dumpAlignable( const Alignable*, unsigned int, unsigned int );
-  void printInfo( const Alignable*, unsigned int );
-  void dumpAlignments(const edm::EventSetup& setup, AlignableTracker *aliTracker) const;
+  void dumpAlignable(const Alignable*, unsigned int, unsigned int);
+  void printInfo(const Alignable*, unsigned int);
+  void dumpAlignments(const edm::EventSetup& setup, AlignableTracker* aliTracker) const;
 
   std::string leaders_, blank_, filled_;
 
@@ -60,137 +58,120 @@ private:
   std::unique_ptr<AlignableTracker> alignableTracker_;
 };
 
-
-void
-TestTrackerHierarchy::analyze( const edm::Event&, const edm::EventSetup& setup )
-{
+void TestTrackerHierarchy::analyze(const edm::Event&, const edm::EventSetup& setup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   setup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   edm::LogInfo("TrackerHierarchy") << "Starting!";
-  edm::ESHandle<TrackerGeometry> trackerGeometry;	 
-  setup.get<TrackerDigiGeometryRecord>().get( trackerGeometry );
+  edm::ESHandle<TrackerGeometry> trackerGeometry;
+  setup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
   alignableTracker_ = std::make_unique<AlignableTracker>(&(*trackerGeometry), tTopo);
 
   leaders_ = "";
-  blank_ = "   ";  // These two...
-  filled_ = "|  "; // ... must have the same length
+  blank_ = "   ";   // These two...
+  filled_ = "|  ";  // ... must have the same length
 
   // Now dump mother of each alignable
   //const Alignable* alignable = (&(*theAlignableTracker))->pixelHalfBarrels()[0];
   this->dumpAlignable(alignableTracker_.get(), 1, 1);
-  
-  
+
   edm::LogInfo("TrackerHierarchy") << "Done!";
 
   if (dumpAlignments_) {
     this->dumpAlignments(setup, alignableTracker_.get());
   }
-
 }
-
 
 //__________________________________________________________________________________________________
 // Recursive loop on alignable hierarchy
-void TestTrackerHierarchy::dumpAlignable( const Alignable* alignable,
-                                          unsigned int idau, unsigned int ndau )
-{
+void TestTrackerHierarchy::dumpAlignable(const Alignable* alignable, unsigned int idau, unsigned int ndau) {
+  printInfo(alignable, idau);
 
-  printInfo( alignable, idau );
-
-  if ( ndau != idau ) leaders_ += filled_;
-  else leaders_ += blank_;
+  if (ndau != idau)
+    leaders_ += filled_;
+  else
+    leaders_ += blank_;
 
   const align::Alignables& comps = alignable->components();
-  if ( unsigned int ndau = comps.size() ) {
+  if (unsigned int ndau = comps.size()) {
     unsigned int idau = 0;
-    for ( align::Alignables::const_iterator iter = comps.begin(); iter != comps.end(); ++iter )
-      dumpAlignable( *iter, ++idau, ndau );
+    for (align::Alignables::const_iterator iter = comps.begin(); iter != comps.end(); ++iter)
+      dumpAlignable(*iter, ++idau, ndau);
   }
 
-  leaders_ = leaders_.substr( 0, leaders_.length()-blank_.length() );
-
+  leaders_ = leaders_.substr(0, leaders_.length() - blank_.length());
 }
-
 
 //__________________________________________________________________________________________________
 // Do the actual printout
-void TestTrackerHierarchy::printInfo( const Alignable* alignable,
-                                      unsigned int idau )
-{
-  int width = kLEAD_WIDTH-leaders_.length();
+void TestTrackerHierarchy::printInfo(const Alignable* alignable, unsigned int idau) {
+  int width = kLEAD_WIDTH - leaders_.length();
 
-  std::ostringstream name,pos,rot;
+  std::ostringstream name, pos, rot;
 
   name << alignableTracker_->objectIdProvider().idToString(alignable->alignableObjectId()) << idau;
 
   // Position
   pos.setf(std::ios::fixed);
-  pos << "(" << std::right 
-      << std::setw(8)  << std::setprecision(4) << alignable->globalPosition().x() << ","
-      << std::setw(8)  << std::setprecision(4) << alignable->globalPosition().y() << ","
-      << std::setw(8)  << std::setprecision(4) << alignable->globalPosition().z() << ")";
+  pos << "(" << std::right << std::setw(8) << std::setprecision(4) << alignable->globalPosition().x() << ","
+      << std::setw(8) << std::setprecision(4) << alignable->globalPosition().y() << "," << std::setw(8)
+      << std::setprecision(4) << alignable->globalPosition().z() << ")";
 
-  edm::LogVerbatim("DumpAlignable") 
-    << leaders_ << "+-> "
-    << std::setw(width) << std::left << name.str()
-    << " | " << std::setw(3)  << std::left << alignable->components().size()
-    << " | " << std::setw(11) << std::left << alignable->id()
-    << " | " << pos.str();
-
+  edm::LogVerbatim("DumpAlignable") << leaders_ << "+-> " << std::setw(width) << std::left << name.str() << " | "
+                                    << std::setw(3) << std::left << alignable->components().size() << " | "
+                                    << std::setw(11) << std::left << alignable->id() << " | " << pos.str();
 }
 
 //__________________________________________________________________________________________________
-void TestTrackerHierarchy::dumpAlignments(const edm::EventSetup& setup,
-					  AlignableTracker *aliTracker) const
-{
+void TestTrackerHierarchy::dumpAlignments(const edm::EventSetup& setup, AlignableTracker* aliTracker) const {
   edm::ESHandle<Alignments> alignments;
   setup.get<TrackerAlignmentRcd>().get(alignments);
   if (alignments->empty()) {
     edm::LogWarning("TrackerAlignment") << "@SUB=dumpAlignments"
-					<< "No TrackerAlignmentRcd.";
+                                        << "No TrackerAlignmentRcd.";
   } else {
     AlignableNavigator navi(aliTracker);
     edm::LogInfo("TrackerAlignment") << "@SUB=dumpAlignments"
-				     << "Start dumping alignments.";
+                                     << "Start dumping alignments.";
     unsigned int nProblems = 0;
     for (std::vector<AlignTransform>::const_iterator iAlign = alignments->m_align.begin(),
-	   iEnd = alignments->m_align.end(); iAlign != iEnd; ++iAlign) {
+                                                     iEnd = alignments->m_align.end();
+         iAlign != iEnd;
+         ++iAlign) {
       const align::ID id = (*iAlign).rawId();
       const AlignTransform::Translation pos((*iAlign).translation());
       edm::LogVerbatim("DumpAlignable") << (*iAlign).rawId() << "  |  " << pos;
 
       AlignableDetOrUnitPtr aliPtr = navi.alignableFromDetId(id);
       if (!aliPtr.isNull()) {
-	const Alignable::PositionType &aliPos = aliPtr->globalPosition();
-	double dR = aliPos.perp() - pos.perp();
-	double dRphi = (aliPos.phi() - pos.phi()) * pos.perp();
-	double dZ = aliPos.z() - pos.z();
-	if (dR*dR + dRphi*dRphi + dZ*dZ) { 
-	  ++nProblems;
-	  edm::LogWarning("Alignment") 
-	    << "@SUB=analyze" << "Delta r,rphi,z: " << dR << " " << dRphi << " " << dZ
-	    << "\nPos r,phi,z: " << pos.perp() << " " << pos.phi() << " " << pos.z();
-	}
+        const Alignable::PositionType& aliPos = aliPtr->globalPosition();
+        double dR = aliPos.perp() - pos.perp();
+        double dRphi = (aliPos.phi() - pos.phi()) * pos.perp();
+        double dZ = aliPos.z() - pos.z();
+        if (dR * dR + dRphi * dRphi + dZ * dZ) {
+          ++nProblems;
+          edm::LogWarning("Alignment") << "@SUB=analyze"
+                                       << "Delta r,rphi,z: " << dR << " " << dRphi << " " << dZ
+                                       << "\nPos r,phi,z: " << pos.perp() << " " << pos.phi() << " " << pos.z();
+        }
       } else {
-	++nProblems;
-	edm::LogWarning("Alignment") << "@SUB=dumpAlignments" << "No Alignable for Id " << id;
+        ++nProblems;
+        edm::LogWarning("Alignment") << "@SUB=dumpAlignments"
+                                     << "No Alignable for Id " << id;
       }
-    } // ending loop
+    }  // ending loop
 
     if (nProblems) {
-      edm::LogWarning("TrackerAlignment") 
-	<< "@SUB=dumpAlignments" << "Ending: " << nProblems << " Alignments with problems.";
+      edm::LogWarning("TrackerAlignment") << "@SUB=dumpAlignments"
+                                          << "Ending: " << nProblems << " Alignments with problems.";
     } else {
-      edm::LogInfo("TrackerAlignment") << "@SUB=dumpAlignments" << "Ending without problem.";
+      edm::LogInfo("TrackerAlignment") << "@SUB=dumpAlignments"
+                                       << "Ending without problem.";
     }
   }
 }
 
-
 //define this as a plug-in
 DEFINE_FWK_MODULE(TestTrackerHierarchy);
-
-

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
@@ -19,59 +19,49 @@
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/TrackerAlignment/interface/AlignableSiStripDet.h"
 
-
-
 //=============================================================================
 //===   PUBLIC METHOD IMPLEMENTATION                                        ===
 //=============================================================================
 
 //_____________________________________________________________________________
-TrackerGeometryAnalyzer
-::TrackerGeometryAnalyzer(const edm::ParameterSet& config) :
-  analyzeAlignables_    (config.getParameter<bool>("analyzeAlignables")),
-  printTrackerStructure_(config.getParameter<bool>("printTrackerStructure")),
-  maxPrintDepth_        (config.getParameter<int> ("maxPrintDepth")),
+TrackerGeometryAnalyzer ::TrackerGeometryAnalyzer(const edm::ParameterSet& config)
+    : analyzeAlignables_(config.getParameter<bool>("analyzeAlignables")),
+      printTrackerStructure_(config.getParameter<bool>("printTrackerStructure")),
+      maxPrintDepth_(config.getParameter<int>("maxPrintDepth")),
 
-  analyzeGeometry_(config.getParameter<bool>("analyzeGeometry")),
-  analyzePXB_     (config.getParameter<bool>("analyzePXB")),
-  analyzePXE_     (config.getParameter<bool>("analyzePXE")),
-  analyzeTIB_     (config.getParameter<bool>("analyzeTIB")),
-  analyzeTID_     (config.getParameter<bool>("analyzeTID")),
-  analyzeTOB_     (config.getParameter<bool>("analyzeTOB")),
-  analyzeTEC_     (config.getParameter<bool>("analyzeTEC")),
+      analyzeGeometry_(config.getParameter<bool>("analyzeGeometry")),
+      analyzePXB_(config.getParameter<bool>("analyzePXB")),
+      analyzePXE_(config.getParameter<bool>("analyzePXE")),
+      analyzeTIB_(config.getParameter<bool>("analyzeTIB")),
+      analyzeTID_(config.getParameter<bool>("analyzeTID")),
+      analyzeTOB_(config.getParameter<bool>("analyzeTOB")),
+      analyzeTEC_(config.getParameter<bool>("analyzeTEC")),
 
-  trackerTopology(0),
-  trackerGeometry(0),
-  // will be reset once the geometry is known:
-  alignableObjectId_{AlignableObjectId::Geometry::General}
-{
-}
+      trackerTopology(0),
+      trackerGeometry(0),
+      // will be reset once the geometry is known:
+      alignableObjectId_{AlignableObjectId::Geometry::General} {}
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::beginRun(const edm::Run& /* run */, const edm::EventSetup& setup)
-{
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::beginRun"
-    << "Initializing TrackerGeometryAnalyzer";
+void TrackerGeometryAnalyzer ::beginRun(const edm::Run& /* run */, const edm::EventSetup& setup) {
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::beginRun"
+                                          << "Initializing TrackerGeometryAnalyzer";
 
   setTrackerTopology(setup);
   setTrackerGeometry(setup);
 
-  if (analyzeAlignables_) analyzeTrackerAlignables();
-  if (analyzeGeometry_)   analyzeTrackerGeometry();
+  if (analyzeAlignables_)
+    analyzeTrackerAlignables();
+  if (analyzeGeometry_)
+    analyzeTrackerGeometry();
 }
-
-
 
 //=============================================================================
 //===   PRIVATE METHOD IMPLEMENTATION                                       ===
 //=============================================================================
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::setTrackerTopology(const edm::EventSetup& setup)
-{
+void TrackerGeometryAnalyzer ::setTrackerTopology(const edm::EventSetup& setup) {
   edm::ESHandle<TrackerTopology> trackerTopologyHandle;
   setup.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
 
@@ -79,9 +69,7 @@ void TrackerGeometryAnalyzer
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::setTrackerGeometry(const edm::EventSetup& setup)
-{
+void TrackerGeometryAnalyzer ::setTrackerGeometry(const edm::EventSetup& setup) {
   edm::ESHandle<GeometricDet> geometricDet;
   setup.get<IdealGeometryRecord>().get(geometricDet);
 
@@ -89,31 +77,19 @@ void TrackerGeometryAnalyzer
   setup.get<PTrackerParametersRcd>().get(trackerParams);
 
   TrackerGeomBuilderFromGeometricDet trackerGeometryBuilder;
-  trackerGeometry = trackerGeometryBuilder.build(
-                      &(*geometricDet),
-                      *trackerParams,
-                      trackerTopology
-                    );
+  trackerGeometry = trackerGeometryBuilder.build(&(*geometricDet), *trackerParams, trackerTopology);
   alignableObjectId_ = AlignableObjectId{trackerGeometry, nullptr, nullptr};
 }
 
-
-
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTrackerAlignables()
-{
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerAlignables"
-    << "Building and analyzing TrackerAlignables aka AlignableTracker";
+void TrackerGeometryAnalyzer ::analyzeTrackerAlignables() {
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerAlignables"
+                                          << "Building and analyzing TrackerAlignables aka AlignableTracker";
 
-  AlignableTracker* trackerAlignables = new AlignableTracker(
-                                          trackerGeometry,
-                                          trackerTopology
-                                        );
+  AlignableTracker* trackerAlignables = new AlignableTracker(trackerGeometry, trackerTopology);
 
   if (trackerAlignables) {
-    analyzeAlignableDetUnits  (trackerAlignables);
+    analyzeAlignableDetUnits(trackerAlignables);
     analyzeCompositeAlignables(trackerAlignables);
 
     if (printTrackerStructure_) {
@@ -124,25 +100,20 @@ void TrackerGeometryAnalyzer
       printAlignableStructure(trackerAlignables, ss, 0);
       ss << "\n===========================================================\n\n";
 
-      edm::LogInfo("TrackerGeometryAnalyzer")
-        << "@SUB=TrackerGeometryAnalyzer::printAlignableStructure" << ss.str();
+      edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::printAlignableStructure" << ss.str();
     }
 
   } else {
-    edm::LogError("TrackerGeometryAnalyzer")
-      << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerAlignables"
-      << "Failed to built AlignableTracker";
+    edm::LogError("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerAlignables"
+                                             << "Failed to built AlignableTracker";
   }
 
   delete trackerAlignables;
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeAlignableDetUnits(Alignable* trackerAlignables)
-{
-  int numPXB = 0, numPXE = 0,
-      numTIB = 0, numTID = 0, numTOB = 0, numTEC = 0;
+void TrackerGeometryAnalyzer ::analyzeAlignableDetUnits(Alignable* trackerAlignables) {
+  int numPXB = 0, numPXE = 0, numTIB = 0, numTID = 0, numTOB = 0, numTEC = 0;
 
   auto allAlignableDetUnits = trackerAlignables->deepComponents();
 
@@ -151,97 +122,107 @@ void TrackerGeometryAnalyzer
 
     int subdetId = alignable->geomDetId().subdetId();
     switch (subdetId) {
-      case PixelSubdetector::PixelBarrel: numPXB += num; break;
-      case PixelSubdetector::PixelEndcap: numPXE += num; break;
-      case StripSubdetector::TIB:         numTIB += num; break;
-      case StripSubdetector::TID:         numTID += num; break;
-      case StripSubdetector::TOB:         numTOB += num; break;
-      case StripSubdetector::TEC:         numTEC += num; break;
+      case PixelSubdetector::PixelBarrel:
+        numPXB += num;
+        break;
+      case PixelSubdetector::PixelEndcap:
+        numPXE += num;
+        break;
+      case StripSubdetector::TIB:
+        numTIB += num;
+        break;
+      case StripSubdetector::TID:
+        numTID += num;
+        break;
+      case StripSubdetector::TOB:
+        numTOB += num;
+        break;
+      case StripSubdetector::TEC:
+        numTEC += num;
+        break;
     }
   }
 
-  int numDetUnits = numPXB + numPXE +
-                    numTIB + numTID + numTOB + numTEC;
+  int numDetUnits = numPXB + numPXE + numTIB + numTID + numTOB + numTEC;
 
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzeAlignableDetUnits"
-    << "AlignableDetUnits: " << allAlignableDetUnits.size() << "\n"
-    << "   PXB AlignableDetUnits: " << numPXB << "\n"
-    << "   PXE AlignableDetUnits: " << numPXE << "\n"
-    << "   TIB AlignableDetUnits: " << numTIB << "\n"
-    << "   TID AlignableDetUnits: " << numTID << "\n"
-    << "   TID AlignableDetUnits: " << numTOB << "\n"
-    << "   TEC AlignableDetUnits: " << numTEC << "\n"
-    << "                        ========"     << "\n"
-    << "                          " << numDetUnits;
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzeAlignableDetUnits"
+                                          << "AlignableDetUnits: " << allAlignableDetUnits.size() << "\n"
+                                          << "   PXB AlignableDetUnits: " << numPXB << "\n"
+                                          << "   PXE AlignableDetUnits: " << numPXE << "\n"
+                                          << "   TIB AlignableDetUnits: " << numTIB << "\n"
+                                          << "   TID AlignableDetUnits: " << numTID << "\n"
+                                          << "   TID AlignableDetUnits: " << numTOB << "\n"
+                                          << "   TEC AlignableDetUnits: " << numTEC << "\n"
+                                          << "                        ========"
+                                          << "\n"
+                                          << "                          " << numDetUnits;
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeCompositeAlignables(Alignable* trackerAlignables)
-{
+void TrackerGeometryAnalyzer ::analyzeCompositeAlignables(Alignable* trackerAlignables) {
   int numPXBComposites = countCompositeAlignables(
-                           // PixelBarrel Alignables
-                           trackerAlignables->components()[0]->components()[0]
-                         ) + 1; // + 1 for the Barrel itself
+                             // PixelBarrel Alignables
+                             trackerAlignables->components()[0]->components()[0]) +
+                         1;  // + 1 for the Barrel itself
   int numPXEComposites = countCompositeAlignables(
-                           // PixelEndcap+ Alignables
-                           trackerAlignables->components()[0]->components()[1]
-                         ) + 1 +
+                             // PixelEndcap+ Alignables
+                             trackerAlignables->components()[0]->components()[1]) +
+                         1 +
                          countCompositeAlignables(
-                           // PixelEndcap- Alignables
-                           trackerAlignables->components()[0]->components()[2]
-                         ) + 1;
+                             // PixelEndcap- Alignables
+                             trackerAlignables->components()[0]->components()[2]) +
+                         1;
   int numTIBComposites = countCompositeAlignables(
-                           // TIB Alignables
-                           trackerAlignables->components()[1]->components()[0]
-                         ) + 1;
+                             // TIB Alignables
+                             trackerAlignables->components()[1]->components()[0]) +
+                         1;
   int numTIDComposites = countCompositeAlignables(
-                           // TID+ Alignables
-                           trackerAlignables->components()[1]->components()[1]
-                         ) + 1 +
+                             // TID+ Alignables
+                             trackerAlignables->components()[1]->components()[1]) +
+                         1 +
                          countCompositeAlignables(
-                           // TID- Alignables
-                           trackerAlignables->components()[1]->components()[2]
-                         ) + 1;
+                             // TID- Alignables
+                             trackerAlignables->components()[1]->components()[2]) +
+                         1;
   int numTOBComposites = countCompositeAlignables(
-                           // TOB Alignables
-                           trackerAlignables->components()[1]->components()[3]
-                         ) + 1;
+                             // TOB Alignables
+                             trackerAlignables->components()[1]->components()[3]) +
+                         1;
   int numTECComposites = countCompositeAlignables(
-                           // TEC+ Alignables
-                           trackerAlignables->components()[1]->components()[4]
-                         ) + 1 +
+                             // TEC+ Alignables
+                             trackerAlignables->components()[1]->components()[4]) +
+                         1 +
                          countCompositeAlignables(
-                           // TEC- Alignables
-                           trackerAlignables->components()[1]->components()[5]
-                         ) + 1;
+                             // TEC- Alignables
+                             trackerAlignables->components()[1]->components()[5]) +
+                         1;
 
-  int numComposites = numPXBComposites + numPXEComposites + numTIBComposites +
-                      numTIDComposites + numTOBComposites + numTECComposites;
+  int numComposites =
+      numPXBComposites + numPXEComposites + numTIBComposites + numTIDComposites + numTOBComposites + numTECComposites;
 
   edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzeCompositeAlignables"
-    << "AlignableComposites: " << countCompositeAlignables(trackerAlignables)
-    << "\n"
-    << "   CompositeAlignable in PXB: " << numPXBComposites << "\n"
-    << "   CompositeAlignable in PXE: " << numPXEComposites << "\n"
-    << "   CompositeAlignable in TIB: " << numTIBComposites << "\n"
-    << "   CompositeAlignable in TID: " << numTIDComposites << "\n"
-    << "   CompositeAlignable in TOB: " << numTOBComposites << "\n"
-    << "   CompositeAlignable in TEC: " << numTECComposites << "\n"
-    << "                            ========"               << "\n"
-    << "                              " << numComposites    << "\n"
-    << "     + 1 Alignable for Pixel: 1"                    << "\n"
-    << "     + 1 Alignable for Strip: 1"                    << "\n"
-    << "                            ========"               << "\n"
-    << "                              " << numComposites + 2;
+      << "@SUB=TrackerGeometryAnalyzer::analyzeCompositeAlignables"
+      << "AlignableComposites: " << countCompositeAlignables(trackerAlignables) << "\n"
+      << "   CompositeAlignable in PXB: " << numPXBComposites << "\n"
+      << "   CompositeAlignable in PXE: " << numPXEComposites << "\n"
+      << "   CompositeAlignable in TIB: " << numTIBComposites << "\n"
+      << "   CompositeAlignable in TID: " << numTIDComposites << "\n"
+      << "   CompositeAlignable in TOB: " << numTOBComposites << "\n"
+      << "   CompositeAlignable in TEC: " << numTECComposites << "\n"
+      << "                            ========"
+      << "\n"
+      << "                              " << numComposites << "\n"
+      << "     + 1 Alignable for Pixel: 1"
+      << "\n"
+      << "     + 1 Alignable for Strip: 1"
+      << "\n"
+      << "                            ========"
+      << "\n"
+      << "                              " << numComposites + 2;
 }
 
 //_____________________________________________________________________________
-int TrackerGeometryAnalyzer
-::countCompositeAlignables(Alignable* compositeAlignable)
-{
+int TrackerGeometryAnalyzer ::countCompositeAlignables(Alignable* compositeAlignable) {
   int num = 0;
 
   for (auto* alignable : compositeAlignable->components()) {
@@ -249,8 +230,7 @@ int TrackerGeometryAnalyzer
     // consist of (usually 2) multiple AlignableDetUnits, hence alignable->
     // components().size() is > 0. To check if we have an AlignableSiStripDet
     // we simple cast it and see if the cast fails or not.
-    AlignableSiStripDet* isSiStripDet
-                           = dynamic_cast<AlignableSiStripDet*>(alignable);
+    AlignableSiStripDet* isSiStripDet = dynamic_cast<AlignableSiStripDet*>(alignable);
     if (!isSiStripDet) {
       if (alignable->components().size()) {
         ++num;
@@ -263,39 +243,36 @@ int TrackerGeometryAnalyzer
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::printAlignableStructure(Alignable* compositeAlignable,
-                          std::ostringstream& ss, int indent)
-{
-  if (indent == maxPrintDepth_) return;
+void TrackerGeometryAnalyzer ::printAlignableStructure(Alignable* compositeAlignable,
+                                                       std::ostringstream& ss,
+                                                       int indent) {
+  if (indent == maxPrintDepth_)
+    return;
 
   for (auto* alignable : compositeAlignable->components()) {
     if (alignable->components().size()) {
-      for (int i = 0; i < (3*indent); ++i) ss << " ";
+      for (int i = 0; i < (3 * indent); ++i)
+        ss << " ";
 
       auto type = alignableObjectId_.idToString(alignable->alignableObjectId());
       ss << type;
 
       int len = (6 * maxPrintDepth_) - (3 * indent) - strlen(type);
-      for (int i = 0; i < len; ++i) ss << " ";
+      for (int i = 0; i < len; ++i)
+        ss << " ";
 
-      ss << " >> consists of " << alignable->components().size()
-         << " Alignable(s)" << "\n";
+      ss << " >> consists of " << alignable->components().size() << " Alignable(s)"
+         << "\n";
 
       printAlignableStructure(alignable, ss, indent + 1);
     }
   }
 }
 
-
-
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTrackerGeometry()
-{
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerGeometry"
-    << "Analyzing TrackerGeometry";
+void TrackerGeometryAnalyzer ::analyzeTrackerGeometry() {
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerGeometry"
+                                          << "Analyzing TrackerGeometry";
   std::ostringstream ss;
 
   analyzeTrackerGeometryVersion(ss);
@@ -306,144 +283,164 @@ void TrackerGeometryAnalyzer
     if (detId.det() == DetId::Tracker) {
       switch (detId.subdetId()) {
         case PixelSubdetector::PixelBarrel:
-          if (analyzePXB_) analyzePXBDetUnit(detId, ss);
+          if (analyzePXB_)
+            analyzePXBDetUnit(detId, ss);
           break;
         case PixelSubdetector::PixelEndcap:
-          if (analyzePXE_) analyzePXEDetUnit(detId, ss);
+          if (analyzePXE_)
+            analyzePXEDetUnit(detId, ss);
           break;
         case StripSubdetector::TIB:
-          if (analyzeTIB_) analyzeTIBDetUnit(detId, ss);
+          if (analyzeTIB_)
+            analyzeTIBDetUnit(detId, ss);
           break;
         case StripSubdetector::TID:
-          if (analyzeTID_) analyzeTIDDetUnit(detId, ss);
+          if (analyzeTID_)
+            analyzeTIDDetUnit(detId, ss);
           break;
         case StripSubdetector::TOB:
-          if (analyzeTOB_) analyzeTOBDetUnit(detId, ss);
+          if (analyzeTOB_)
+            analyzeTOBDetUnit(detId, ss);
           break;
         case StripSubdetector::TEC:
-          if (analyzeTEC_) analyzeTECDetUnit(detId, ss);
+          if (analyzeTEC_)
+            analyzeTECDetUnit(detId, ss);
           break;
       }
     }
   }
 
-  edm::LogInfo("TrackerGeometryAnalyzer")
-      << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerGeometry" << ss.str();
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzeTrackerGeometry" << ss.str();
 
-  if (analyzePXB_) analyzePXB();
-  if (analyzePXE_) analyzePXE();
-  if (analyzeTIB_) analyzeTIB();
-  if (analyzeTID_) analyzeTID();
-  if (analyzeTOB_) analyzeTOB();
-  if (analyzeTEC_) analyzeTEC();
+  if (analyzePXB_)
+    analyzePXB();
+  if (analyzePXE_)
+    analyzePXE();
+  if (analyzeTIB_)
+    analyzeTIB();
+  if (analyzeTID_)
+    analyzeTID();
+  if (analyzeTOB_)
+    analyzeTOB();
+  if (analyzeTEC_)
+    analyzeTEC();
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTrackerGeometryVersion(std::ostringstream& ss) {
+void TrackerGeometryAnalyzer ::analyzeTrackerGeometryVersion(std::ostringstream& ss) {
   // PixelBarrel
   if (trackerGeometry->isThere(GeomDetEnumerators::PixelBarrel)) {
-    ss << "(PXB) PixelBarrel geometry from Run I" << "\n";
+    ss << "(PXB) PixelBarrel geometry from Run I"
+       << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::P1PXB)) {
     ss << "(PXB) P1PXB geometry from Phase-I "
        << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::P2PXB)) {
-    ss << "(PXB) P2PXB geometry from Phase-II" << "\n";
+    ss << "(PXB) P2PXB geometry from Phase-II"
+       << "\n";
   } else {
-    ss << "(PXB) Geometry is unknown" << "\n";
+    ss << "(PXB) Geometry is unknown"
+       << "\n";
   }
 
   // PixelEndcap
   if (trackerGeometry->isThere(GeomDetEnumerators::PixelEndcap)) {
-    ss << "(PXE) PixelEndcap geometry from Run I" << "\n";
+    ss << "(PXE) PixelEndcap geometry from Run I"
+       << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::P1PXEC)) {
-    ss << "(PXE) P1PXEC geometry from Phase-I" << "\n";
+    ss << "(PXE) P1PXEC geometry from Phase-I"
+       << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::P2PXEC)) {
-    ss << "(PXE) P2PXEC geometry from Phase-II" << "\n";
+    ss << "(PXE) P2PXEC geometry from Phase-II"
+       << "\n";
   } else {
-    ss << "(PXE) Geometry is unknown" << "\n";
+    ss << "(PXE) Geometry is unknown"
+       << "\n";
   }
 
   // TIB
   if (trackerGeometry->isThere(GeomDetEnumerators::TIB)) {
-    ss << "(TIB) TIB geometry from Run I and Phase-I" << "\n";
+    ss << "(TIB) TIB geometry from Run I and Phase-I"
+       << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::invalidDet)) {
-    ss << "(TIB) No TIB geometry since Phase-II" << "\n";
+    ss << "(TIB) No TIB geometry since Phase-II"
+       << "\n";
   } else {
-    ss << "(TIB) Geometry is unknown" << "\n";
+    ss << "(TIB) Geometry is unknown"
+       << "\n";
   }
 
   // TID
   if (trackerGeometry->isThere(GeomDetEnumerators::TID)) {
-    ss << "(TID) TID geometry from Run I and Phase-I" << "\n";
+    ss << "(TID) TID geometry from Run I and Phase-I"
+       << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::P2OTEC)) {
-    ss << "(TID) P2OTEC geometry from Phase-II" << "\n";
+    ss << "(TID) P2OTEC geometry from Phase-II"
+       << "\n";
   } else {
-    ss << "(TID) Geometry is unknown" << "\n";
+    ss << "(TID) Geometry is unknown"
+       << "\n";
   }
 
   // TOB
   if (trackerGeometry->isThere(GeomDetEnumerators::TOB)) {
-    ss << "(TOB) TOB geometry from Run I and Phase-I" << "\n";
+    ss << "(TOB) TOB geometry from Run I and Phase-I"
+       << "\n";
   } else if (trackerGeometry->isThere(GeomDetEnumerators::P2OTB)) {
-    ss << "(TOB) P2OTB geometry from Phase-II" << "\n";
+    ss << "(TOB) P2OTB geometry from Phase-II"
+       << "\n";
   } else {
-    ss << "(TOB) Geometry is unknown" << "\n";
+    ss << "(TOB) Geometry is unknown"
+       << "\n";
   }
 
   // TEC
   if (trackerGeometry->isThere(GeomDetEnumerators::TEC)) {
-    ss << "(TEC) TEC geometry from Run I and Phase-I" << "\n";
-  }  else if (trackerGeometry->isThere(GeomDetEnumerators::invalidDet)) {
-    ss << "(TEC) No TEC geometry since Phase-II" << "\n";
+    ss << "(TEC) TEC geometry from Run I and Phase-I"
+       << "\n";
+  } else if (trackerGeometry->isThere(GeomDetEnumerators::invalidDet)) {
+    ss << "(TEC) No TEC geometry since Phase-II"
+       << "\n";
   } else {
-    ss << "(TEC) Geometry is unknown" << "\n";
+    ss << "(TEC) Geometry is unknown"
+       << "\n";
   }
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzePXBDetUnit(DetId& detId, std::ostringstream& ss)
-{
-  auto layerID  = trackerTopology->pxbLayer(detId);
+void TrackerGeometryAnalyzer ::analyzePXBDetUnit(DetId& detId, std::ostringstream& ss) {
+  auto layerID = trackerTopology->pxbLayer(detId);
   auto ladderID = trackerTopology->pxbLadder(detId);
   auto moduleID = trackerTopology->module(detId);
 
   ss << "Topology info for - TPBModule - with DetId " << detId.rawId() << ": "
-     << "   layerID: "   << layerID
-     << "   ladderID: "  << ladderID
-     << "   moduleID: "  << moduleID
-     << "\n";
+     << "   layerID: " << layerID << "   ladderID: " << ladderID << "   moduleID: " << moduleID << "\n";
 
-  pxbLayerIDs. insert(layerID);
+  pxbLayerIDs.insert(layerID);
   pxbLadderIDs.insert(ladderID);
   pxbModuleIDs.insert(moduleID);
 
   ++numPXBDetUnits;
 }
 
-void TrackerGeometryAnalyzer
-::analyzePXB()
-{
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzePXB"
-    << "   number of PXBModules:              " << numPXBDetUnits      << "\n"
-    << "   max. number of modules per ladder: " << pxbModuleIDs.size() << "\n"
-    << "   max. number of ladders per layer:  " << pxbLadderIDs.size() << "\n"
-    << "   max. number of layers  in PXB:     " << pxbLayerIDs.size();
+void TrackerGeometryAnalyzer ::analyzePXB() {
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzePXB"
+                                          << "   number of PXBModules:              " << numPXBDetUnits << "\n"
+                                          << "   max. number of modules per ladder: " << pxbModuleIDs.size() << "\n"
+                                          << "   max. number of ladders per layer:  " << pxbLadderIDs.size() << "\n"
+                                          << "   max. number of layers  in PXB:     " << pxbLayerIDs.size();
 
-  std::vector<std::vector<int> >
-    numPXBModules(pxbLayerIDs.size(), std::vector<int>(pxbLadderIDs.size(), 0));
+  std::vector<std::vector<int> > numPXBModules(pxbLayerIDs.size(), std::vector<int>(pxbLadderIDs.size(), 0));
 
   for (auto& det : trackerGeometry->dets()) {
     auto detId = det->geographicalId();
 
     if (detId.det() == DetId::Tracker) {
       if (detId.subdetId() == PixelSubdetector::PixelBarrel) {
-        auto layerID  = trackerTopology->pxbLayer(detId);
+        auto layerID = trackerTopology->pxbLayer(detId);
         auto ladderID = trackerTopology->pxbLadder(detId);
 
-        numPXBModules[layerID-1][ladderID-1]++;
+        numPXBModules[layerID - 1][ladderID - 1]++;
       }
     }
   }
@@ -454,79 +451,65 @@ void TrackerGeometryAnalyzer
   for (unsigned int i = 0; i < pxbLayerIDs.size(); ++i) {
     for (unsigned int j = 0; j < pxbLadderIDs.size(); ++j) {
       if (numPXBModules[i][j] > 0) {
-        ss << "   number of modules in layer-"  << i+1
-                                  << " ladder-" << j+1
-                                  << ": " << numPXBModules[i][j]
-                                  << "\n";
+        ss << "   number of modules in layer-" << i + 1 << " ladder-" << j + 1 << ": " << numPXBModules[i][j] << "\n";
       }
     }
   }
 
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzePXB" << ss.str();
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzePXB" << ss.str();
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzePXEDetUnit(DetId& detId, std::ostringstream& ss)
-{
-  auto sideID   = trackerTopology->pxfSide(detId);
-  auto diskID   = trackerTopology->pxfDisk(detId);
-  auto bladeID  = trackerTopology->pxfBlade(detId);
-  auto panelID  = trackerTopology->pxfPanel(detId);
+void TrackerGeometryAnalyzer ::analyzePXEDetUnit(DetId& detId, std::ostringstream& ss) {
+  auto sideID = trackerTopology->pxfSide(detId);
+  auto diskID = trackerTopology->pxfDisk(detId);
+  auto bladeID = trackerTopology->pxfBlade(detId);
+  auto panelID = trackerTopology->pxfPanel(detId);
   auto moduleID = trackerTopology->module(detId);
 
   ss << "Topology info for - TPEModule - with DetId " << detId.rawId() << ": "
-     << "   sideID: "   << sideID
-     << "   diskID: "   << diskID
-     << "   bladeID: "  << bladeID
-     << "   panelID: "  << panelID
-     << "   moduleID: " << moduleID
-     << "\n";
+     << "   sideID: " << sideID << "   diskID: " << diskID << "   bladeID: " << bladeID << "   panelID: " << panelID
+     << "   moduleID: " << moduleID << "\n";
 
-  pxeSideIDs.  insert(sideID);
-  pxeDiskIDs.  insert(diskID);
-  pxeBladeIDs. insert(bladeID);
-  pxePanelIDs. insert(panelID);
+  pxeSideIDs.insert(sideID);
+  pxeDiskIDs.insert(diskID);
+  pxeBladeIDs.insert(bladeID);
+  pxePanelIDs.insert(panelID);
   pxeModuleIDs.insert(moduleID);
 
   numPXEDetUnits++;
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzePXE() {
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzePXE"
-    << "   number of PXEModules:             " << numPXEDetUnits      << "\n"
-    << "   max. number of modules per panel: " << pxeModuleIDs.size() << "\n"
-    << "   max. number of panels  per blade: " << pxePanelIDs.size()  << "\n"
-    << "   max. number of blades  per disk:  " << pxeBladeIDs.size()  << "\n"
-    << "   max. number of disks   per side:  " << pxeDiskIDs.size()   << "\n"
-    << "   max. number of sides in PXE:      " << pxeSideIDs.size();
+void TrackerGeometryAnalyzer ::analyzePXE() {
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzePXE"
+                                          << "   number of PXEModules:             " << numPXEDetUnits << "\n"
+                                          << "   max. number of modules per panel: " << pxeModuleIDs.size() << "\n"
+                                          << "   max. number of panels  per blade: " << pxePanelIDs.size() << "\n"
+                                          << "   max. number of blades  per disk:  " << pxeBladeIDs.size() << "\n"
+                                          << "   max. number of disks   per side:  " << pxeDiskIDs.size() << "\n"
+                                          << "   max. number of sides in PXE:      " << pxeSideIDs.size();
 
-  std::vector<std::vector<std::vector<std::vector<int> > > >
-    numAlignablesPXE
-    (pxeSideIDs.size(), std::vector<std::vector<std::vector<int> > >
-     (pxeDiskIDs.size(), std::vector<std::vector<int> >
-      (pxeBladeIDs.size(), std::vector<int>
-       (pxePanelIDs.size(), 0)  // initialize everything with 0
-       )
-      )
-     );
+  std::vector<std::vector<std::vector<std::vector<int> > > > numAlignablesPXE(
+      pxeSideIDs.size(),
+      std::vector<std::vector<std::vector<int> > >(
+          pxeDiskIDs.size(),
+          std::vector<std::vector<int> >(
+              pxeBladeIDs.size(), std::vector<int>(pxePanelIDs.size(), 0)  // initialize everything with 0
+              )));
 
   for (auto& det : trackerGeometry->dets()) {
     auto detId = det->geographicalId();
 
     if (detId.det() == DetId::Tracker) {
       if (detId.subdetId() == PixelSubdetector::PixelEndcap) {
-        auto sideID   = trackerTopology->pxfSide(detId);
-        auto diskID   = trackerTopology->pxfDisk(detId);
-        auto bladeID  = trackerTopology->pxfBlade(detId);
-        auto panelID  = trackerTopology->pxfPanel(detId);
+        auto sideID = trackerTopology->pxfSide(detId);
+        auto diskID = trackerTopology->pxfDisk(detId);
+        auto bladeID = trackerTopology->pxfBlade(detId);
+        auto panelID = trackerTopology->pxfPanel(detId);
         //auto moduleID = trackerTopology->module(detId);
 
-        numAlignablesPXE[sideID-1][diskID-1][bladeID-1][panelID-1]++;
+        numAlignablesPXE[sideID - 1][diskID - 1][bladeID - 1][panelID - 1]++;
       }
     }
   }
@@ -539,40 +522,30 @@ void TrackerGeometryAnalyzer
       for (unsigned int k = 0; k < pxeBladeIDs.size(); ++k) {
         for (unsigned int l = 0; l < pxePanelIDs.size(); ++l) {
           if (numAlignablesPXE[i][j][k][l] > 0) {
-            ss << "   number of modules in side-"  << i+1
-                                      << " disk-"  << j+1
-                                      << " blade-" << k+1
-                                      << " panel-" << l+1
-                                      << ": " << numAlignablesPXE[i][j][k][l]
-                                      << "\n";
+            ss << "   number of modules in side-" << i + 1 << " disk-" << j + 1 << " blade-" << k + 1 << " panel-"
+               << l + 1 << ": " << numAlignablesPXE[i][j][k][l] << "\n";
           }
         }
       }
     }
   }
 
-  edm::LogInfo("TrackerGeometryAnalyzer")
-    << "@SUB=TrackerGeometryAnalyzer::analyzePXE" << ss.str();
+  edm::LogInfo("TrackerGeometryAnalyzer") << "@SUB=TrackerGeometryAnalyzer::analyzePXE" << ss.str();
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTIBDetUnit(DetId& detId, std::ostringstream& ss)
-{
-  auto sideID   = trackerTopology->tibSide(detId);
-  auto layerID  = trackerTopology->tibLayer(detId);
+void TrackerGeometryAnalyzer ::analyzeTIBDetUnit(DetId& detId, std::ostringstream& ss) {
+  auto sideID = trackerTopology->tibSide(detId);
+  auto layerID = trackerTopology->tibLayer(detId);
   auto stringID = trackerTopology->tibString(detId);
   auto moduleID = trackerTopology->module(detId);
 
   ss << "Topology info for - TIBModule - with DetId " << detId.rawId() << ": "
-     << "   sideID: "   << sideID
-     << "   layerID: "  << layerID
-     << "   stringID: " << stringID
-     << "   moduleID: " << moduleID
-     << "\n";
+     << "   sideID: " << sideID << "   layerID: " << layerID << "   stringID: " << stringID
+     << "   moduleID: " << moduleID << "\n";
 
-  tibSideIDs.  insert(sideID);
-  tibLayerIDs. insert(layerID);
+  tibSideIDs.insert(sideID);
+  tibLayerIDs.insert(layerID);
   tibStringIDs.insert(stringID);
   tibModuleIDs.insert(moduleID);
 
@@ -580,104 +553,80 @@ void TrackerGeometryAnalyzer
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTIB()
-{
+void TrackerGeometryAnalyzer ::analyzeTIB() {
   // TODO: not yet implemented
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTIDDetUnit(DetId& detId, std::ostringstream& ss)
-{
-  auto sideID   = trackerTopology->tidSide(detId);
-  auto wheelID  = trackerTopology->tidWheel(detId);
-  auto ringID   = trackerTopology->tidRing(detId);
+void TrackerGeometryAnalyzer ::analyzeTIDDetUnit(DetId& detId, std::ostringstream& ss) {
+  auto sideID = trackerTopology->tidSide(detId);
+  auto wheelID = trackerTopology->tidWheel(detId);
+  auto ringID = trackerTopology->tidRing(detId);
   auto moduleID = trackerTopology->module(detId);
 
   ss << "Topology info for - TIDModule - with DetId " << detId.rawId() << ": "
-     << "   sideID: "   << sideID
-     << "   wheelID: "  << wheelID
-     << "   ringID: "   << ringID
-     << "   moduleID: " << moduleID
+     << "   sideID: " << sideID << "   wheelID: " << wheelID << "   ringID: " << ringID << "   moduleID: " << moduleID
      << "\n";
 
-  tidSideIDs.  insert(sideID);
-  tidWheelIDs. insert(wheelID);
-  tidRingIDs.  insert(ringID);
+  tidSideIDs.insert(sideID);
+  tidWheelIDs.insert(wheelID);
+  tidRingIDs.insert(ringID);
   tidModuleIDs.insert(moduleID);
 
   ++numTIDDetUnits;
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTID()
-{
+void TrackerGeometryAnalyzer ::analyzeTID() {
   // TODO: not yet implemented
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTOBDetUnit(DetId& detId, std::ostringstream& ss)
-{
-  auto layerID  = trackerTopology->tobLayer(detId);
-  auto sideID   = trackerTopology->tobSide(detId);
-  auto rodID    = trackerTopology->tobRod(detId);
+void TrackerGeometryAnalyzer ::analyzeTOBDetUnit(DetId& detId, std::ostringstream& ss) {
+  auto layerID = trackerTopology->tobLayer(detId);
+  auto sideID = trackerTopology->tobSide(detId);
+  auto rodID = trackerTopology->tobRod(detId);
   auto moduleID = trackerTopology->module(detId);
 
   ss << "Topology info for - TOBModule - with DetId " << detId.rawId() << ": "
-     << "   layerID: "  << layerID
-     << "   sideID: "   << sideID
-     << "   rodID: "    << rodID
-     << "   moduleID: " << moduleID
+     << "   layerID: " << layerID << "   sideID: " << sideID << "   rodID: " << rodID << "   moduleID: " << moduleID
      << "\n";
 
-  tobLayerIDs. insert(layerID);
-  tobSideIDs.  insert(sideID);
-  tobRodIDs.   insert(rodID);
+  tobLayerIDs.insert(layerID);
+  tobSideIDs.insert(sideID);
+  tobRodIDs.insert(rodID);
   tobModuleIDs.insert(moduleID);
 
   ++numTOBDetUnits;
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTOB()
-{
+void TrackerGeometryAnalyzer ::analyzeTOB() {
   // TODO: not yet implemented
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTECDetUnit(DetId& detId, std::ostringstream& ss)
-{
-  auto sideID   = trackerTopology->tecSide(detId);
-  auto wheelID  = trackerTopology->tecWheel(detId);
-  auto petalID  = trackerTopology->tecPetalNumber(detId);
-  auto ringID   = trackerTopology->tecRing(detId);
+void TrackerGeometryAnalyzer ::analyzeTECDetUnit(DetId& detId, std::ostringstream& ss) {
+  auto sideID = trackerTopology->tecSide(detId);
+  auto wheelID = trackerTopology->tecWheel(detId);
+  auto petalID = trackerTopology->tecPetalNumber(detId);
+  auto ringID = trackerTopology->tecRing(detId);
   auto moduleID = trackerTopology->module(detId);
 
   ss << "Topology info for - TECModule - with DetId " << detId.rawId() << ": "
-     << "   sideID: "   << sideID
-     << "   wheelID: "  << wheelID
-     << "   petalID: "  << petalID
-     << "   ringID: "   << ringID
-     << "   moduleID: " << moduleID
-     << "\n";
+     << "   sideID: " << sideID << "   wheelID: " << wheelID << "   petalID: " << petalID << "   ringID: " << ringID
+     << "   moduleID: " << moduleID << "\n";
 
-  tecSideIDs.  insert(sideID);
-  tecWheelIDs. insert(wheelID);
-  tecPetalIDs. insert(petalID);
-  tecRingIDs.  insert(ringID);
+  tecSideIDs.insert(sideID);
+  tecWheelIDs.insert(wheelID);
+  tecPetalIDs.insert(petalID);
+  tecRingIDs.insert(ringID);
   tecModuleIDs.insert(moduleID);
 
   ++numTECDetUnits;
 }
 
 //_____________________________________________________________________________
-void TrackerGeometryAnalyzer
-::analyzeTEC()
-{
+void TrackerGeometryAnalyzer ::analyzeTEC() {
   // TODO: not yet implemented
 }

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.h
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.h
@@ -24,113 +24,107 @@
 
 class Alignable;
 
-
-
 class TrackerGeometryAnalyzer : public edm::EDAnalyzer {
-
   //========================== PUBLIC METHODS =================================
-  public: //===================================================================
+public:  //===================================================================
+  TrackerGeometryAnalyzer(const edm::ParameterSet&);
+  virtual ~TrackerGeometryAnalyzer(){};
 
-    TrackerGeometryAnalyzer(const edm::ParameterSet&);
-    virtual ~TrackerGeometryAnalyzer() {};
-
-    virtual void beginRun(const edm::Run&,   const edm::EventSetup&) override;
-    virtual void analyze (const edm::Event&, const edm::EventSetup&) override {};
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override{};
 
   //========================= PRIVATE METHODS =================================
-  private: //==================================================================
+private:  //==================================================================
+  void setTrackerTopology(const edm::EventSetup&);
+  void setTrackerGeometry(const edm::EventSetup&);
 
-    void setTrackerTopology(const edm::EventSetup&);
-    void setTrackerGeometry(const edm::EventSetup&);
+  void analyzeTrackerAlignables();
+  void analyzeAlignableDetUnits(Alignable*);
+  void analyzeCompositeAlignables(Alignable*);
+  int countCompositeAlignables(Alignable*);
+  void printAlignableStructure(Alignable*, std::ostringstream&, int indent);
 
-    void analyzeTrackerAlignables();
-    void analyzeAlignableDetUnits  (Alignable*);
-    void analyzeCompositeAlignables(Alignable*);
-    int countCompositeAlignables(Alignable*);
-    void printAlignableStructure(Alignable*, std::ostringstream&, int indent);
-
-    void analyzeTrackerGeometry();
-    void analyzeTrackerGeometryVersion(std::ostringstream&);
-    void analyzePXBDetUnit(DetId& detId, std::ostringstream&);
-    void analyzePXB();
-    void analyzePXEDetUnit(DetId& detId, std::ostringstream&);
-    void analyzePXE();
-    void analyzeTIBDetUnit(DetId& detId, std::ostringstream&);
-    void analyzeTIB();
-    void analyzeTIDDetUnit(DetId& detId, std::ostringstream&);
-    void analyzeTID();
-    void analyzeTOBDetUnit(DetId& detId, std::ostringstream&);
-    void analyzeTOB();
-    void analyzeTECDetUnit(DetId& detId, std::ostringstream&);
-    void analyzeTEC();
+  void analyzeTrackerGeometry();
+  void analyzeTrackerGeometryVersion(std::ostringstream&);
+  void analyzePXBDetUnit(DetId& detId, std::ostringstream&);
+  void analyzePXB();
+  void analyzePXEDetUnit(DetId& detId, std::ostringstream&);
+  void analyzePXE();
+  void analyzeTIBDetUnit(DetId& detId, std::ostringstream&);
+  void analyzeTIB();
+  void analyzeTIDDetUnit(DetId& detId, std::ostringstream&);
+  void analyzeTID();
+  void analyzeTOBDetUnit(DetId& detId, std::ostringstream&);
+  void analyzeTOB();
+  void analyzeTECDetUnit(DetId& detId, std::ostringstream&);
+  void analyzeTEC();
 
   //========================== PRIVATE DATA ===================================
   //===========================================================================
 
-    // config-file parameters
-    const bool analyzeAlignables_;
-    const bool printTrackerStructure_;
-    const int  maxPrintDepth_;
-    const bool analyzeGeometry_;
-    const bool analyzePXB_;
-    const bool analyzePXE_;
-    const bool analyzeTIB_;
-    const bool analyzeTID_;
-    const bool analyzeTOB_;
-    const bool analyzeTEC_;
+  // config-file parameters
+  const bool analyzeAlignables_;
+  const bool printTrackerStructure_;
+  const int maxPrintDepth_;
+  const bool analyzeGeometry_;
+  const bool analyzePXB_;
+  const bool analyzePXE_;
+  const bool analyzeTIB_;
+  const bool analyzeTID_;
+  const bool analyzeTOB_;
+  const bool analyzeTEC_;
 
-    // topology and geometry
-    const TrackerTopology* trackerTopology;
-    const TrackerGeometry* trackerGeometry;
+  // topology and geometry
+  const TrackerTopology* trackerTopology;
+  const TrackerGeometry* trackerGeometry;
 
-    // alignable object ID provider
-    AlignableObjectId alignableObjectId_;
+  // alignable object ID provider
+  AlignableObjectId alignableObjectId_;
 
-    // counter for detUnits
-    int numPXBDetUnits = 0;
-    int numPXEDetUnits = 0;
-    int numTIBDetUnits = 0;
-    int numTIDDetUnits = 0;
-    int numTOBDetUnits = 0;
-    int numTECDetUnits = 0;
+  // counter for detUnits
+  int numPXBDetUnits = 0;
+  int numPXEDetUnits = 0;
+  int numTIBDetUnits = 0;
+  int numTIDDetUnits = 0;
+  int numTOBDetUnits = 0;
+  int numTECDetUnits = 0;
 
-    // PixelBarrel counters
-    std::set<unsigned int> pxbLayerIDs;
-    std::set<unsigned int> pxbLadderIDs;
-    std::set<unsigned int> pxbModuleIDs;
+  // PixelBarrel counters
+  std::set<unsigned int> pxbLayerIDs;
+  std::set<unsigned int> pxbLadderIDs;
+  std::set<unsigned int> pxbModuleIDs;
 
-    // PixelEndcap counters
-    std::set<unsigned int> pxeSideIDs;
-    std::set<unsigned int> pxeDiskIDs;
-    std::set<unsigned int> pxeBladeIDs;
-    std::set<unsigned int> pxePanelIDs;
-    std::set<unsigned int> pxeModuleIDs;
+  // PixelEndcap counters
+  std::set<unsigned int> pxeSideIDs;
+  std::set<unsigned int> pxeDiskIDs;
+  std::set<unsigned int> pxeBladeIDs;
+  std::set<unsigned int> pxePanelIDs;
+  std::set<unsigned int> pxeModuleIDs;
 
-    // TIB counters
-    std::set<unsigned int> tibSideIDs;
-    std::set<unsigned int> tibLayerIDs;
-    std::set<unsigned int> tibStringIDs;
-    std::set<unsigned int> tibModuleIDs;
+  // TIB counters
+  std::set<unsigned int> tibSideIDs;
+  std::set<unsigned int> tibLayerIDs;
+  std::set<unsigned int> tibStringIDs;
+  std::set<unsigned int> tibModuleIDs;
 
-    // TID counters
-    std::set<unsigned int> tidSideIDs;
-    std::set<unsigned int> tidWheelIDs;
-    std::set<unsigned int> tidRingIDs;
-    std::set<unsigned int> tidModuleIDs;
+  // TID counters
+  std::set<unsigned int> tidSideIDs;
+  std::set<unsigned int> tidWheelIDs;
+  std::set<unsigned int> tidRingIDs;
+  std::set<unsigned int> tidModuleIDs;
 
-    // TOB counters
-    std::set<unsigned int> tobLayerIDs;
-    std::set<unsigned int> tobSideIDs;
-    std::set<unsigned int> tobRodIDs;
-    std::set<unsigned int> tobModuleIDs;
+  // TOB counters
+  std::set<unsigned int> tobLayerIDs;
+  std::set<unsigned int> tobSideIDs;
+  std::set<unsigned int> tobRodIDs;
+  std::set<unsigned int> tobModuleIDs;
 
-    // TEC counters
-    std::set<unsigned int> tecSideIDs;
-    std::set<unsigned int> tecWheelIDs;
-    std::set<unsigned int> tecPetalIDs;
-    std::set<unsigned int> tecRingIDs;
-    std::set<unsigned int> tecModuleIDs;
-
+  // TEC counters
+  std::set<unsigned int> tecSideIDs;
+  std::set<unsigned int> tecWheelIDs;
+  std::set<unsigned int> tecPetalIDs;
+  std::set<unsigned int> tecRingIDs;
+  std::set<unsigned int> tecModuleIDs;
 };
 
 // define this as a plug-in

--- a/CalibTracker/SiStripCommon/interface/Book.h
+++ b/CalibTracker/SiStripCommon/interface/Book.h
@@ -14,104 +14,185 @@
 #include <boost/iterator/filter_iterator.hpp>
 
 class Book {
-  
-  typedef   const double             double_t;
-  typedef   const unsigned long        uint_t;
-  typedef   const std::string        string_t;
-  typedef std::map<std::string, TH1*>  book_t;
+  typedef const double double_t;
+  typedef const unsigned long uint_t;
+  typedef const std::string string_t;
+  typedef std::map<std::string, TH1*> book_t;
 
   book_t book_;
   std::string title_;
   TDirectory* directory;
-  
+
   struct match_name {
     match_name(string_t re) : expression(re) {}
-    bool operator()(const book_t::const_iterator::value_type& p) { return regex_match( p.first, expression); }
-    private:  boost::regex expression;
+    bool operator()(const book_t::const_iterator::value_type& p) { return regex_match(p.first, expression); }
+
+  private:
+    boost::regex expression;
   };
-  
- public:
-  
+
+public:
   Book() : title_(""), directory(nullptr) {}
-  Book(string_t t) : title_(t), directory(new TDirectory(t.c_str(),t.c_str())) {}
+  Book(string_t t) : title_(t), directory(new TDirectory(t.c_str(), t.c_str())) {}
 
-  string_t& title() const { return title_;}
-  bool empty()   const { return book_.empty(); }
-  long size ()   const { return book_.size(); }
+  string_t& title() const { return title_; }
+  bool empty() const { return book_.empty(); }
+  long size() const { return book_.size(); }
 
-  TH1* book(string_t name, TH1*const hist)   { book_[name]=hist; hist->SetDirectory(directory); if(!hist->GetSumw2N()) hist->Sumw2(); return hist;}
-  TH1*& operator[](string_t name)       { return book_[name]; }
-  const TH1*  operator[](string_t name) const { book_t::const_iterator it = book_.find(name); return it==book_.end() ? nullptr : it->second;}
-
-  typedef boost::filter_iterator<match_name,book_t::iterator> iterator;
-  typedef boost::filter_iterator<match_name,book_t::const_iterator> const_iterator;
-  iterator       begin(string_t re = ".*")       {book_t::iterator       b(book_.begin()), e(book_.end()); return boost::make_filter_iterator(match_name(re),b,e);}
-  const_iterator begin(string_t re = ".*") const {book_t::const_iterator b(book_.begin()), e(book_.end()); return boost::make_filter_iterator(match_name(re),b,e);}
-  iterator       end(  string_t re = ".*")       {book_t::iterator       e(book_.end()); return boost::make_filter_iterator(match_name(re),e,e);}
-  const_iterator end(  string_t re = ".*") const {book_t::const_iterator e(book_.end()); return boost::make_filter_iterator(match_name(re),e,e);}
-  iterator       find (string_t name, string_t re = ".*")       { return boost::make_filter_iterator(match_name(re),book_.find(name),book_.end()); }
-  const_iterator find (string_t name, string_t re = ".*") const { return boost::make_filter_iterator(match_name(re),book_.find(name),book_.end()); }
-  std::pair<iterator,iterator>             filter_range(string_t re = ".*")       { return std::make_pair(begin(re), end(re) ); }
-  std::pair<const_iterator,const_iterator> filter_range(string_t re = ".*") const { return std::make_pair(begin(re), end(re) ); }
-
-  void erase(string_t name) { book_t::iterator it = book_.find(name); if(it!=book_.end()) {delete it->second; book_.erase(it); } }
-  void erase(iterator it) { delete it->second; book_.erase(it.base()); }
-
-  void fill( double_t X, const char* name, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup, double_t W=1 ) { fill(X,std::string(name),NbinsX,Xlow,Xup,W);}
-  void fill( double_t X, const poly<std::string>& names, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup, double_t W=1 ) 
-  { 
-    for(auto const& name : names) {
-      book_t::const_iterator current = book_.find(name);
-      if( current == book_.end() )
-	book(name, new TH1D(name.c_str(), "", NbinsX, Xlow, Xup))->Fill(X,W);
-      else current->second->Fill(X,W);
-    }
+  TH1* book(string_t name, TH1* const hist) {
+    book_[name] = hist;
+    hist->SetDirectory(directory);
+    if (!hist->GetSumw2N())
+      hist->Sumw2();
+    return hist;
   }
-  void fill( double_t X, double_t Y, const char* name, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup, double_t W=1 ) {fill(X,Y,std::string(name),NbinsX,Xlow,Xup,W);}
-  void fill( double_t X, double_t Y, const poly<std::string>& names, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup, double_t W=1 )
-  { 
-    for(auto const& name : names) {
-      book_t::const_iterator current = book_.find(name);
-      if( current == book_.end() )
-	static_cast<TProfile*>(book(name, new TProfile(name.c_str(), "", NbinsX, Xlow, Xup)))->Fill(X,Y,W);
-      else static_cast<TProfile*>(current->second)->Fill(X,Y,W);
-    }
-  }
-  void fill( double_t X, double_t Y, const char* name, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup,
-	     uint_t NbinsY, double_t Ylow, double_t Yup, double_t W=1 ) { fill(X,Y,std::string(name),NbinsX,Xlow,Xup,NbinsY,Ylow,Yup,W);}
-  void fill( double_t X, double_t Y, const poly<std::string>& names, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup,
-	     uint_t NbinsY, double_t Ylow, double_t Yup, double_t W=1 )
-  { 
-    for(auto const& name : names) {
-      book_t::const_iterator current = book_.find(name);
-      if( current == book_.end() )
-	static_cast<TH2*>(book(name, new TH2D(name.c_str(), "", NbinsX, Xlow, Xup, NbinsY, Ylow, Yup)))->Fill(X,Y,W);
-      else static_cast<TH2*>(current->second)->Fill(X,Y,W);
-    }
-  }
-  void fill( double_t X, double_t Y, double_t Z,  const char* name, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup,
-	     uint_t NbinsY, double_t Ylow, double_t Yup,
-	     uint_t NbinsZ, double_t Zlow, double_t Zup, double_t W=1 ) {fill(X,Y,Z,std::string(name),NbinsX,Xlow,Xup,NbinsY,Ylow,Yup,NbinsZ,Zlow,Zup);}
-  void fill( double_t X, double_t Y, double_t Z,  const poly<std::string>& names, 
-	     uint_t NbinsX, double_t Xlow, double_t Xup,
-	     uint_t NbinsY, double_t Ylow, double_t Yup,
-	     uint_t NbinsZ, double_t Zlow, double_t Zup, double_t W=1 )
-  { 
-    for(auto const& name : names) {
-      book_t::const_iterator current = book_.find(name);
-      if( current == book_.end() )
-	static_cast<TH3*>(book(name, new TH3D(name.c_str(), "", NbinsX, Xlow, Xup, NbinsY, Ylow, Yup, NbinsZ, Zlow, Zup)))->Fill(X,Y,Z,W);
-      else static_cast<TH3*>(current->second)->Fill(X,Y,Z,W);
-    }
+  TH1*& operator[](string_t name) { return book_[name]; }
+  const TH1* operator[](string_t name) const {
+    book_t::const_iterator it = book_.find(name);
+    return it == book_.end() ? nullptr : it->second;
   }
 
+  typedef boost::filter_iterator<match_name, book_t::iterator> iterator;
+  typedef boost::filter_iterator<match_name, book_t::const_iterator> const_iterator;
+  iterator begin(string_t re = ".*") {
+    book_t::iterator b(book_.begin()), e(book_.end());
+    return boost::make_filter_iterator(match_name(re), b, e);
+  }
+  const_iterator begin(string_t re = ".*") const {
+    book_t::const_iterator b(book_.begin()), e(book_.end());
+    return boost::make_filter_iterator(match_name(re), b, e);
+  }
+  iterator end(string_t re = ".*") {
+    book_t::iterator e(book_.end());
+    return boost::make_filter_iterator(match_name(re), e, e);
+  }
+  const_iterator end(string_t re = ".*") const {
+    book_t::const_iterator e(book_.end());
+    return boost::make_filter_iterator(match_name(re), e, e);
+  }
+  iterator find(string_t name, string_t re = ".*") {
+    return boost::make_filter_iterator(match_name(re), book_.find(name), book_.end());
+  }
+  const_iterator find(string_t name, string_t re = ".*") const {
+    return boost::make_filter_iterator(match_name(re), book_.find(name), book_.end());
+  }
+  std::pair<iterator, iterator> filter_range(string_t re = ".*") { return std::make_pair(begin(re), end(re)); }
+  std::pair<const_iterator, const_iterator> filter_range(string_t re = ".*") const {
+    return std::make_pair(begin(re), end(re));
+  }
+
+  void erase(string_t name) {
+    book_t::iterator it = book_.find(name);
+    if (it != book_.end()) {
+      delete it->second;
+      book_.erase(it);
+    }
+  }
+  void erase(iterator it) {
+    delete it->second;
+    book_.erase(it.base());
+  }
+
+  void fill(double_t X, const char* name, uint_t NbinsX, double_t Xlow, double_t Xup, double_t W = 1) {
+    fill(X, std::string(name), NbinsX, Xlow, Xup, W);
+  }
+  void fill(double_t X, const poly<std::string>& names, uint_t NbinsX, double_t Xlow, double_t Xup, double_t W = 1) {
+    for (auto const& name : names) {
+      book_t::const_iterator current = book_.find(name);
+      if (current == book_.end())
+        book(name, new TH1D(name.c_str(), "", NbinsX, Xlow, Xup))->Fill(X, W);
+      else
+        current->second->Fill(X, W);
+    }
+  }
+  void fill(double_t X, double_t Y, const char* name, uint_t NbinsX, double_t Xlow, double_t Xup, double_t W = 1) {
+    fill(X, Y, std::string(name), NbinsX, Xlow, Xup, W);
+  }
+  void fill(double_t X,
+            double_t Y,
+            const poly<std::string>& names,
+            uint_t NbinsX,
+            double_t Xlow,
+            double_t Xup,
+            double_t W = 1) {
+    for (auto const& name : names) {
+      book_t::const_iterator current = book_.find(name);
+      if (current == book_.end())
+        static_cast<TProfile*>(book(name, new TProfile(name.c_str(), "", NbinsX, Xlow, Xup)))->Fill(X, Y, W);
+      else
+        static_cast<TProfile*>(current->second)->Fill(X, Y, W);
+    }
+  }
+  void fill(double_t X,
+            double_t Y,
+            const char* name,
+            uint_t NbinsX,
+            double_t Xlow,
+            double_t Xup,
+            uint_t NbinsY,
+            double_t Ylow,
+            double_t Yup,
+            double_t W = 1) {
+    fill(X, Y, std::string(name), NbinsX, Xlow, Xup, NbinsY, Ylow, Yup, W);
+  }
+  void fill(double_t X,
+            double_t Y,
+            const poly<std::string>& names,
+            uint_t NbinsX,
+            double_t Xlow,
+            double_t Xup,
+            uint_t NbinsY,
+            double_t Ylow,
+            double_t Yup,
+            double_t W = 1) {
+    for (auto const& name : names) {
+      book_t::const_iterator current = book_.find(name);
+      if (current == book_.end())
+        static_cast<TH2*>(book(name, new TH2D(name.c_str(), "", NbinsX, Xlow, Xup, NbinsY, Ylow, Yup)))->Fill(X, Y, W);
+      else
+        static_cast<TH2*>(current->second)->Fill(X, Y, W);
+    }
+  }
+  void fill(double_t X,
+            double_t Y,
+            double_t Z,
+            const char* name,
+            uint_t NbinsX,
+            double_t Xlow,
+            double_t Xup,
+            uint_t NbinsY,
+            double_t Ylow,
+            double_t Yup,
+            uint_t NbinsZ,
+            double_t Zlow,
+            double_t Zup,
+            double_t W = 1) {
+    fill(X, Y, Z, std::string(name), NbinsX, Xlow, Xup, NbinsY, Ylow, Yup, NbinsZ, Zlow, Zup);
+  }
+  void fill(double_t X,
+            double_t Y,
+            double_t Z,
+            const poly<std::string>& names,
+            uint_t NbinsX,
+            double_t Xlow,
+            double_t Xup,
+            uint_t NbinsY,
+            double_t Ylow,
+            double_t Yup,
+            uint_t NbinsZ,
+            double_t Zlow,
+            double_t Zup,
+            double_t W = 1) {
+    for (auto const& name : names) {
+      book_t::const_iterator current = book_.find(name);
+      if (current == book_.end())
+        static_cast<TH3*>(
+            book(name, new TH3D(name.c_str(), "", NbinsX, Xlow, Xup, NbinsY, Ylow, Yup, NbinsZ, Zlow, Zup)))
+            ->Fill(X, Y, Z, W);
+      else
+        static_cast<TH3*>(current->second)->Fill(X, Y, Z, W);
+    }
+  }
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
@@ -15,36 +15,32 @@ class SiStripProcessedRawDigi;
 class TrackerTopology;
 
 class ShallowClustersProducer : public edm::EDProducer {
-  
- public:
+public:
+  explicit ShallowClustersProducer(const edm::ParameterSet &);
 
-  explicit ShallowClustersProducer(const edm::ParameterSet&);
-
- private:
-
+private:
   edm::InputTag theClustersLabel;
   std::string Prefix;
-  void produce( edm::Event &, const edm::EventSetup & ) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
   struct moduleVars {
-    moduleVars(uint32_t, const TrackerTopology*);
+    moduleVars(uint32_t, const TrackerTopology *);
     int subdetid, side, layerwheel, stringringrod, petal, stereo;
     uint32_t module;
   };
 
-  struct NearDigis { 
-    NearDigis(const SiStripClusterInfo&);
-    NearDigis(const SiStripClusterInfo&, const edm::DetSetVector<SiStripProcessedRawDigi>&);
-    float max, left, right, first, last, Lleft, Rright; 
-    float etaX() const {return ((left+right)/max)/2.;}
-    float eta()  const {return right>left ? max/(max+right) : left/(left+max);}
-    float etaasymm() const {return right>left ? (right-max)/(right+max) : (max-left)/(max+left);}
-    float outsideasymm() const {return (last-first)/(last+first);}
+  struct NearDigis {
+    NearDigis(const SiStripClusterInfo &);
+    NearDigis(const SiStripClusterInfo &, const edm::DetSetVector<SiStripProcessedRawDigi> &);
+    float max, left, right, first, last, Lleft, Rright;
+    float etaX() const { return ((left + right) / max) / 2.; }
+    float eta() const { return right > left ? max / (max + right) : left / (left + max); }
+    float etaasymm() const { return right > left ? (right - max) / (right + max) : (max - left) / (max + left); }
+    float outsideasymm() const { return (last - first) / (last + first); }
   };
 
-  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> >          theClustersToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > theClustersToken_;
   edm::EDGetTokenT<edm::DetSetVector<SiStripProcessedRawDigi> > theDigisToken_;
-  
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowDigisProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowDigisProducer.h
@@ -8,33 +8,32 @@
 class SiStripNoises;
 
 class ShallowDigisProducer : public edm::EDProducer {
+public:
+  explicit ShallowDigisProducer(const edm::ParameterSet &);
 
- public:
-
-  explicit ShallowDigisProducer(const edm::ParameterSet&);
-
- private:  
+private:
   struct products {
     std::unique_ptr<std::vector<unsigned> > id;
     std::unique_ptr<std::vector<unsigned> > subdet;
     std::unique_ptr<std::vector<unsigned> > strip;
     std::unique_ptr<std::vector<unsigned> > adc;
     std::unique_ptr<std::vector<float> > noise;
-    products() 
-      : id(new std::vector<unsigned>()), 
-	subdet(new std::vector<unsigned>()), 
-	strip(new std::vector<unsigned>()), 
-	adc(new std::vector<unsigned>()), 
-	noise(new std::vector<float>()) {}
+    products()
+        : id(new std::vector<unsigned>()),
+          subdet(new std::vector<unsigned>()),
+          strip(new std::vector<unsigned>()),
+          adc(new std::vector<unsigned>()),
+          noise(new std::vector<float>()) {}
   };
   std::vector<edm::InputTag> inputTags;
   edm::ESHandle<SiStripNoises> noiseHandle;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  template<class T> bool findInput(edm::Handle<T>&, const edm::Event&);
-  template<class T> void recordDigis(const T &, products&);
-  void insert(products&, edm::Event&);  
-  
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  template <class T>
+  bool findInput(edm::Handle<T> &, const edm::Event &);
+  template <class T>
+  void recordDigis(const T &, products &);
+  void insert(products &, edm::Event &);
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
@@ -8,12 +8,13 @@
 #include <string>
 
 class ShallowEventDataProducer : public edm::EDProducer {
- public: 
-  explicit ShallowEventDataProducer(const edm::ParameterSet&);
- private: 
-  void produce( edm::Event &, const edm::EventSetup & ) override;
-	edm::EDGetTokenT< L1GlobalTriggerReadoutRecord > trig_token_;
-	edm::EDGetTokenT< LumiScalersCollection > scalerToken_; 
+public:
+  explicit ShallowEventDataProducer(const edm::ParameterSet &);
+
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> trig_token_;
+  edm::EDGetTokenT<LumiScalersCollection> scalerToken_;
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
@@ -23,7 +23,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 
-
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 
@@ -38,8 +37,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 
-
-
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -51,30 +48,29 @@
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 #include "DataFormats/TrackReco/interface/TrackDeDxHits.h"
 
-
 #include <ext/hash_map>
-
 
 class ShallowGainCalibration : public edm::EDProducer {
 public:
   explicit ShallowGainCalibration(const edm::ParameterSet&);
+
 private:
-	const edm::EDGetTokenT< edm::View<reco::Track> > tracks_token_;
-	const edm::EDGetTokenT< TrajTrackAssociationCollection > association_token_;
-	
+  const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
+  const edm::EDGetTokenT<TrajTrackAssociationCollection> association_token_;
+
   std::string Suffix;
   std::string Prefix;
 
-  void   produce( edm::Event &, const edm::EventSetup & ) override;
-//  virtual void beginJob(EventSetup const&);
-//  virtual void beginRun(Run&, EventSetup const&);
-  bool   IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup);
-  double thickness    (DetId id);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  //  virtual void beginJob(EventSetup const&);
+  //  virtual void beginRun(Run&, EventSetup const&);
+  bool IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup);
+  double thickness(DetId id);
 
   const TrackerGeometry* m_tracker;
-  std::map<DetId,double> m_thicknessMap;
+  std::map<DetId, double> m_thicknessMap;
 
-/*
+  /*
   struct stAPVGain{int DetId; int APVId; double PreviousGain;};
   class isEqual{
       public:
@@ -85,6 +81,3 @@ private:
 */
 };
 #endif
-
-
-

--- a/CalibTracker/SiStripCommon/interface/ShallowRechitClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowRechitClustersProducer.h
@@ -10,14 +10,15 @@
 
 class ShallowRechitClustersProducer : public edm::EDProducer {
 public:
-  explicit ShallowRechitClustersProducer(const edm::ParameterSet&);
+  explicit ShallowRechitClustersProducer(const edm::ParameterSet &);
+
 private:
   std::string Suffix;
   std::string Prefix;
-  const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;
-	std::vector< edm::EDGetTokenT<SiStripRecHit2DCollection> > rec_hits_tokens_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
+  std::vector<edm::EDGetTokenT<SiStripRecHit2DCollection> > rec_hits_tokens_;
   //std::vector<edm::InputTag> inputTags;
-  void produce( edm::Event &, const edm::EventSetup & ) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowSimhitClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowSimhitClustersProducer.h
@@ -10,19 +10,20 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 class ShallowSimhitClustersProducer : public edm::EDProducer {
- public:
+public:
   explicit ShallowSimhitClustersProducer(const edm::ParameterSet&);
- private:
-  //std::vector<edm::InputTag> inputTags;
-	std::vector< edm::EDGetTokenT< std::vector<PSimHit> > > simhits_tokens_;
-  const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;
-  std::string Prefix;
-	std::string runningmode_;
 
-  void produce( edm::Event &, const edm::EventSetup & ) override;
-  shallow::CLUSTERMAP::const_iterator match_cluster(const unsigned&, 
-						    const float&, 
-						    const shallow::CLUSTERMAP&, 
-						    const edmNew::DetSetVector<SiStripCluster>& ) const;
+private:
+  //std::vector<edm::InputTag> inputTags;
+  std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simhits_tokens_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
+  std::string Prefix;
+  std::string runningmode_;
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  shallow::CLUSTERMAP::const_iterator match_cluster(const unsigned&,
+                                                    const float&,
+                                                    const shallow::CLUSTERMAP&,
+                                                    const edmNew::DetSetVector<SiStripCluster>&) const;
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowTools.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTools.h
@@ -12,16 +12,18 @@ class StripGeomDetUnit;
 class MagneticField;
 class SiStripLorentzAngle;
 class Event;
-namespace edm {class InputTag;}
+namespace edm {
+  class InputTag;
+}
 
 namespace shallow {
-  
-typedef std::map<std::pair<uint32_t, uint16_t>, unsigned int> CLUSTERMAP;  
 
-CLUSTERMAP make_cluster_map( const edm::Event& , const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > & );
-LocalVector drift( const StripGeomDetUnit*, const MagneticField&, const SiStripLorentzAngle&);
-int findTrackIndex(const edm::Handle<edm::View<reco::Track> >& h,   const reco::Track* t);
+  typedef std::map<std::pair<uint32_t, uint16_t>, unsigned int> CLUSTERMAP;
 
-}
+  CLUSTERMAP make_cluster_map(const edm::Event&, const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> >&);
+  LocalVector drift(const StripGeomDetUnit*, const MagneticField&, const SiStripLorentzAngle&);
+  int findTrackIndex(const edm::Handle<edm::View<reco::Track> >& h, const reco::Track* t);
+
+}  // namespace shallow
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowTrackClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTrackClustersProducer.h
@@ -11,14 +11,15 @@
 
 class ShallowTrackClustersProducer : public edm::EDProducer {
 public:
-  explicit ShallowTrackClustersProducer(const edm::ParameterSet&);
+  explicit ShallowTrackClustersProducer(const edm::ParameterSet &);
+
 private:
-	const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
-	const edm::EDGetTokenT<TrajTrackAssociationCollection> association_token_;
-	const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;
+  const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
+  const edm::EDGetTokenT<TrajTrackAssociationCollection> association_token_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
   std::string Suffix;
   std::string Prefix;
 
-  void produce( edm::Event &, const edm::EventSetup & ) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowTracksProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTracksProducer.h
@@ -8,12 +8,13 @@
 
 class ShallowTracksProducer : public edm::EDProducer {
 public:
-  explicit ShallowTracksProducer(const edm::ParameterSet&);
+  explicit ShallowTracksProducer(const edm::ParameterSet &);
+
 private:
-	const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
+  const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
   edm::InputTag theTracksLabel;
   std::string Prefix;
   std::string Suffix;
-  void produce( edm::Event &, const edm::EventSetup & ) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowTree.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTree.h
@@ -31,47 +31,66 @@
 #include <TTree.h>
 
 class ShallowTree : public edm::EDAnalyzer {
-private:    
+private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override{}
+  void endJob() override {}
 
-	template <class T> 
-	void eat(edm::BranchDescription const* desc) {
-		consumes<T>(edm::InputTag(desc->moduleLabel(), desc->productInstanceName()));
-	}
+  template <class T>
+  void eat(edm::BranchDescription const* desc) {
+    consumes<T>(edm::InputTag(desc->moduleLabel(), desc->productInstanceName()));
+  }
 
   class BranchConnector {
   public:
-    virtual ~BranchConnector() {};
+    virtual ~BranchConnector(){};
     virtual void connect(const edm::Event&) = 0;
   };
-  
+
   template <class T>
   class TypedBranchConnector : public BranchConnector {
   private:
-    std::string ml;  //module label
+    std::string ml;   //module label
     std::string pin;  //product instance name
     T object_;
     T* object_ptr_;
+
   public:
     TypedBranchConnector(edm::BranchDescription const*, std::string, TTree*);
     void connect(const edm::Event&) override;
   };
 
   edm::Service<TFileService> fs_;
-  TTree * tree_;
+  TTree* tree_;
   std::vector<BranchConnector*> connectors_;
 
 public:
-  explicit ShallowTree(const edm::ParameterSet& iConfig);// : pset(iConfig) {}
-  
-  enum LEAFTYPE {BOOL=1,  BOOL_V,          
-		 SHORT,   SHORT_V,           U_SHORT, U_SHORT_V,       
-		 INT,     INT_V,             U_INT,   U_INT_V,
-		 FLOAT,   FLOAT_V,           DOUBLE,  DOUBLE_V,
-		 LONG,    LONG_V,	     U_LONG,  U_LONG_V, 
-		 CHAR,    CHAR_V,            U_CHAR,  U_CHAR_V};
+  explicit ShallowTree(const edm::ParameterSet& iConfig);  // : pset(iConfig) {}
+
+  enum LEAFTYPE {
+    BOOL = 1,
+    BOOL_V,
+    SHORT,
+    SHORT_V,
+    U_SHORT,
+    U_SHORT_V,
+    INT,
+    INT_V,
+    U_INT,
+    U_INT_V,
+    FLOAT,
+    FLOAT_V,
+    DOUBLE,
+    DOUBLE_V,
+    LONG,
+    LONG_V,
+    U_LONG,
+    U_LONG_V,
+    CHAR,
+    CHAR_V,
+    U_CHAR,
+    U_CHAR_V
+  };
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
@@ -9,17 +9,15 @@
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
- 
 class SiStripDCSStatus {
- public:
-  SiStripDCSStatus(edm::ConsumesCollector && iC) : SiStripDCSStatus( iC ) {};
-  SiStripDCSStatus(edm::ConsumesCollector & iC);
- ~SiStripDCSStatus();
+public:
+  SiStripDCSStatus(edm::ConsumesCollector&& iC) : SiStripDCSStatus(iC){};
+  SiStripDCSStatus(edm::ConsumesCollector& iC);
+  ~SiStripDCSStatus();
 
   bool getStatus(edm::Event const& e, edm::EventSetup const& eSetup);
 
- private: 
-
+private:
   void initialise(edm::Event const& e, edm::EventSetup const& eSetup);
 
   bool TIBTIDinDAQ, TOBinDAQ, TECFinDAQ, TECBinDAQ;
@@ -28,9 +26,8 @@ class SiStripDCSStatus {
   bool rawdataAbsent;
   bool initialised;
 
-  edm::EDGetTokenT<DcsStatusCollection>  dcsStatusToken_;
+  edm::EDGetTokenT<DcsStatusCollection> dcsStatusToken_;
   edm::EDGetTokenT<FEDRawDataCollection> rawDataToken_;
-
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiStripDetInfoFileReader
 // Class:      SiStripDetInfoFileReader
-// 
+//
 /**\class SiStripDetInfoFileReader SiStripDetInfoFileReader.cc CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
 
  Description: <one line class summary>
@@ -27,15 +27,12 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class SiStripDetInfoFileReader  {
-
+class SiStripDetInfoFileReader {
 public:
-
-  struct DetInfo{
-    
+  struct DetInfo {
     DetInfo(){};
-    DetInfo(unsigned short _nApvs, double _stripLength, float _thickness):
-    nApvs(_nApvs),stripLength(_stripLength),thickness(_thickness){};
+    DetInfo(unsigned short _nApvs, double _stripLength, float _thickness)
+        : nApvs(_nApvs), stripLength(_stripLength), thickness(_thickness){};
 
     unsigned short nApvs;
     double stripLength;
@@ -43,36 +40,32 @@ public:
   };
 
   explicit SiStripDetInfoFileReader(){};
-  explicit SiStripDetInfoFileReader(const edm::ParameterSet&,
-				    const edm::ActivityRegistry&);
+  explicit SiStripDetInfoFileReader(const edm::ParameterSet&, const edm::ActivityRegistry&);
 
   explicit SiStripDetInfoFileReader(std::string filePath);
   explicit SiStripDetInfoFileReader(const SiStripDetInfoFileReader&);
 
   ~SiStripDetInfoFileReader();
 
-  SiStripDetInfoFileReader& operator=(const SiStripDetInfoFileReader &copy);
+  SiStripDetInfoFileReader& operator=(const SiStripDetInfoFileReader& copy);
 
-  const std::vector<uint32_t> & getAllDetIds() const {return detIds_;}
+  const std::vector<uint32_t>& getAllDetIds() const { return detIds_; }
 
-  const std::pair<unsigned short, double>  getNumberOfApvsAndStripLength(uint32_t detId) const;
+  const std::pair<unsigned short, double> getNumberOfApvsAndStripLength(uint32_t detId) const;
 
-  const float & getThickness(uint32_t detId) const;
+  const float& getThickness(uint32_t detId) const;
 
-  const std::map<uint32_t, DetInfo > & getAllData() const {return detData_;}
-
+  const std::map<uint32_t, DetInfo>& getAllData() const { return detData_; }
 
 private:
-
   void reader(std::string filePath);
 
-  std::ifstream inputFile_; 
+  std::ifstream inputFile_;
   //  std::string filePath_;
 
   std::map<uint32_t, DetInfo> detData_;
   //  std::map<uint32_t, std::pair<unsigned short, double> > detData_;
   //std::map<uint32_t, float > detThickness_;
   std::vector<uint32_t> detIds_;
-
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/SiStripFedIdListReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripFedIdListReader.h
@@ -9,42 +9,38 @@
 class SiStripFedIdListReader;
 
 /** */
-std::ostream& operator<< ( std::ostream&, const SiStripFedIdListReader& );
+std::ostream& operator<<(std::ostream&, const SiStripFedIdListReader&);
 
 /**
    @class SiStripFedIdListReader
    @author R.Bainbridge
 */
-class SiStripFedIdListReader  {
-  
- public:
-  
+class SiStripFedIdListReader {
+public:
   /** */
-  explicit SiStripFedIdListReader( std::string filePath );
+  explicit SiStripFedIdListReader(std::string filePath);
 
   /** */
-  explicit SiStripFedIdListReader( const SiStripFedIdListReader& );
-  
+  explicit SiStripFedIdListReader(const SiStripFedIdListReader&);
+
   /** */
-  SiStripFedIdListReader& operator=( const SiStripFedIdListReader& );
+  SiStripFedIdListReader& operator=(const SiStripFedIdListReader&);
 
   /** */
   ~SiStripFedIdListReader();
-  
+
   /** */
-  inline const std::vector<uint16_t> & fedIds() const;
-  
- private:
-  
+  inline const std::vector<uint16_t>& fedIds() const;
+
+private:
   /** */
-  explicit SiStripFedIdListReader() {;}
-  
-  std::ifstream inputFile_; 
-  
+  explicit SiStripFedIdListReader() { ; }
+
+  std::ifstream inputFile_;
+
   std::vector<uint16_t> fedIds_;
-  
 };
 
-const std::vector<uint16_t> & SiStripFedIdListReader::fedIds() const { return fedIds_; }
+const std::vector<uint16_t>& SiStripFedIdListReader::fedIds() const { return fedIds_; }
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/TTREE_FOREACH_ENTRY.hh
+++ b/CalibTracker/SiStripCommon/interface/TTREE_FOREACH_ENTRY.hh
@@ -7,58 +7,68 @@
 #include <iomanip>
 #include "TTree.h"
 
-#define LEAF(leaf, tree)						\
-  leaf = 0;								\
-  { TBranch* branch = tree->GetBranch( #leaf ); assert(branch);		\
-    branch->SetAddress( &(leaf) );					\
-    branch->GetEntry( TFE_local_index,1); }				\
+#define LEAF(leaf, tree)                      \
+  leaf = 0;                                   \
+  {                                           \
+    TBranch* branch = tree->GetBranch(#leaf); \
+    assert(branch);                           \
+    branch->SetAddress(&(leaf));              \
+    branch->GetEntry(TFE_local_index, 1);     \
+  }
 
-#define PLEAF(leaf, tree)						\
-  leaf;									\
-  { TBranch* branch = tree->GetBranch( #leaf ); assert(branch);		\
-    void* pt = &(leaf);							\
-    branch->SetAddress( &pt );						\
-    branch->GetEntry( TFE_local_index,1); }				\
+#define PLEAF(leaf, tree)                     \
+  leaf;                                       \
+  {                                           \
+    TBranch* branch = tree->GetBranch(#leaf); \
+    assert(branch);                           \
+    void* pt = &(leaf);                       \
+    branch->SetAddress(&pt);                  \
+    branch->GetEntry(TFE_local_index, 1);     \
+  }
 
-#define RENAMED_LEAF(var,leafname, tree)				\
-  var = 0;								\
-  { std::string n=leafname;						\
-    TBranch* branch = tree->GetBranch( n.c_str() ); assert(branch);	\
-    branch->SetAddress( &(var) );					\
-    branch->GetEntry( TFE_local_index,1); }				\
+#define RENAMED_LEAF(var, leafname, tree)         \
+  var = 0;                                        \
+  {                                               \
+    std::string n = leafname;                     \
+    TBranch* branch = tree->GetBranch(n.c_str()); \
+    assert(branch);                               \
+    branch->SetAddress(&(var));                   \
+    branch->GetEntry(TFE_local_index, 1);         \
+  }
 
-#define RENAMED_PLEAF(var,leafname, tree)				\
-  var;									\
-  { std::string n=leafname;						\
-    TBranch* branch = tree->GetBranch( n.c_str() ); assert(branch);	\
-    void* pt = &(var);							\
-    branch->SetAddress( &pt );						\
-    branch->GetEntry( TFE_local_index,1); }				\
+#define RENAMED_PLEAF(var, leafname, tree)        \
+  var;                                            \
+  {                                               \
+    std::string n = leafname;                     \
+    TBranch* branch = tree->GetBranch(n.c_str()); \
+    assert(branch);                               \
+    void* pt = &(var);                            \
+    branch->SetAddress(&pt);                      \
+    branch->GetEntry(TFE_local_index, 1);         \
+  }
 
-  
-#define TTREE_FOREACH_ENTRY(tree)					\
-  for ( Long64_t							\
-	  TFE_index=0,							\
-	  TFE_total=tree->GetEntries(),					\
-	  TFE_local_index=0,						\
-	  TFE_local_total=0,						\
-	  TFE_freq=TFE_total/100;					\
-	TFE_index < TFE_total &&					\
-	  ( TFE_local_index < TFE_local_total ||			\
-	    (-1 < tree->LoadTree(TFE_index) &&				\
-	     -1 < ( TFE_local_index = 0) &&				\
-	     -1 < ( TFE_local_total = tree->GetTree()->GetEntries())	\
-	     ));							\
-	TFE_index++, TFE_local_index++ )				\
+#define TTREE_FOREACH_ENTRY(tree)                                                                             \
+  for (Long64_t TFE_index = 0,                                                                                \
+                TFE_total = tree->GetEntries(),                                                               \
+                TFE_local_index = 0,                                                                          \
+                TFE_local_total = 0,                                                                          \
+                TFE_freq = TFE_total / 100;                                                                   \
+       TFE_index < TFE_total &&                                                                               \
+       (TFE_local_index < TFE_local_total || (-1 < tree->LoadTree(TFE_index) && -1 < (TFE_local_index = 0) && \
+                                              -1 < (TFE_local_total = tree->GetTree()->GetEntries())));       \
+       TFE_index++, TFE_local_index++)
 
-    
-#define TFE_MAX(max) if(TFE_index && max) { TFE_total = std::min(Long64_t(max),TFE_total); TFE_freq=TFE_total/100;}
+#define TFE_MAX(max)                                \
+  if (TFE_index && max) {                           \
+    TFE_total = std::min(Long64_t(max), TFE_total); \
+    TFE_freq = TFE_total / 100;                     \
+  }
 
-#define TFE_PRINTSTATUS	{						\
-    if ( TFE_freq && !(TFE_index%TFE_freq) ) {				\
-      std::cout << "\b\b\b\b\b" << std::setw(3) << std::fixed		\
-		<< (100*TFE_index)/TFE_total << "% " << std::flush;	\
-    }									\
-  }									\
-    
+#define TFE_PRINTSTATUS                                                                                               \
+  {                                                                                                                   \
+    if (TFE_freq && !(TFE_index % TFE_freq)) {                                                                        \
+      std::cout << "\b\b\b\b\b" << std::setw(3) << std::fixed << (100 * TFE_index) / TFE_total << "% " << std::flush; \
+    }                                                                                                                 \
+  }
+
 #endif

--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -7,81 +7,131 @@
 
 class TrackerTopology;
 
-class TkLayerMap
-{
+class TkLayerMap {
 public:
-  struct XYbin{
-    XYbin(int16_t _ix=-999, int16_t _iy=-999, float _x=-999., float _y=-999.)
-      : ix(_ix), iy(_iy), x(_x), y(_y) {}
-    int16_t ix,iy;
-    float x,y;
+  struct XYbin {
+    XYbin(int16_t _ix = -999, int16_t _iy = -999, float _x = -999., float _y = -999.)
+        : ix(_ix), iy(_iy), x(_x), y(_y) {}
+    int16_t ix, iy;
+    float x, y;
   };
 
-  enum TkLayerEnum { INVALID=0,
-                     TIB_L1, TIB_L2, TIB_L3, TIB_L4, //1-4
-                     TIDM_D1, TIDM_D2, TIDM_D3, //5-7
-                     TIDP_D1, TIDP_D2, TIDP_D3, //8-10
-                     TOB_L1, TOB_L2, TOB_L3, TOB_L4, TOB_L5, TOB_L6, //11-16
-                     TECM_W1, TECM_W2, TECM_W3, TECM_W4, TECM_W5, TECM_W6, TECM_W7, TECM_W8, TECM_W9, //17-25
-                     TECP_W1, TECP_W2, TECP_W3, TECP_W4, TECP_W5, TECP_W6, TECP_W7, TECP_W8, TECP_W9, //26-34
-                     NUMLAYERS }; //35
+  enum TkLayerEnum {
+    INVALID = 0,
+    TIB_L1,
+    TIB_L2,
+    TIB_L3,
+    TIB_L4,  //1-4
+    TIDM_D1,
+    TIDM_D2,
+    TIDM_D3,  //5-7
+    TIDP_D1,
+    TIDP_D2,
+    TIDP_D3,  //8-10
+    TOB_L1,
+    TOB_L2,
+    TOB_L3,
+    TOB_L4,
+    TOB_L5,
+    TOB_L6,  //11-16
+    TECM_W1,
+    TECM_W2,
+    TECM_W3,
+    TECM_W4,
+    TECM_W5,
+    TECM_W6,
+    TECM_W7,
+    TECM_W8,
+    TECM_W9,  //17-25
+    TECP_W1,
+    TECP_W2,
+    TECP_W3,
+    TECP_W4,
+    TECP_W5,
+    TECP_W6,
+    TECP_W7,
+    TECP_W8,
+    TECP_W9,  //26-34
+    NUMLAYERS
+  };  //35
 
   TkLayerMap() {}
 
-  TkLayerMap( int layer
-            , std::size_t nchX, double lowX, double highX
-            , std::size_t nchY, double lowY, double highY
-            , const TrackerTopology* tTopo, const std::vector<uint32_t>& tkDetIdList
-            , const std::vector<uint32_t>& singleExtString = {}
-            , const std::vector<uint32_t>& modulesInRingFront = {}
-            , const std::vector<uint32_t>& modulesInRingBack = {}
-            , const std::vector<uint32_t>& binForRing = {}
-            , uint32_t nstring_ext = 0, uint32_t nrod = 0
-            )
-    : layer_(layer)
-    , nchX_(nchX), lowX_(lowX), highX_(highX)
-    , nchY_(nchY), lowY_(lowY), highY_(highY)
-    , tTopo_(tTopo)
-    , singleExtStr_(singleExtString)
-    , modulesInRingFront_(modulesInRingFront), modulesInRingBack_(modulesInRingBack)
-    , binForRing_(binForRing)
-    , nStringExt_(nstring_ext), nRod_(nrod)
-    , binToDet_(std::vector<DetId>(std::size_t(nchX*nchY), 0))
-  {
+  TkLayerMap(int layer,
+             std::size_t nchX,
+             double lowX,
+             double highX,
+             std::size_t nchY,
+             double lowY,
+             double highY,
+             const TrackerTopology* tTopo,
+             const std::vector<uint32_t>& tkDetIdList,
+             const std::vector<uint32_t>& singleExtString = {},
+             const std::vector<uint32_t>& modulesInRingFront = {},
+             const std::vector<uint32_t>& modulesInRingBack = {},
+             const std::vector<uint32_t>& binForRing = {},
+             uint32_t nstring_ext = 0,
+             uint32_t nrod = 0)
+      : layer_(layer),
+        nchX_(nchX),
+        lowX_(lowX),
+        highX_(highX),
+        nchY_(nchY),
+        lowY_(lowY),
+        highY_(highY),
+        tTopo_(tTopo),
+        singleExtStr_(singleExtString),
+        modulesInRingFront_(modulesInRingFront),
+        modulesInRingBack_(modulesInRingBack),
+        binForRing_(binForRing),
+        nStringExt_(nstring_ext),
+        nRod_(nrod),
+        binToDet_(std::vector<DetId>(std::size_t(nchX * nchY), 0)) {
     initMap(tkDetIdList);
   }
 
-  TkLayerMap( int layer
-            , std::size_t nchX, double lowX, double highX
-            , std::size_t nchY, double lowY, double highY
-            , const TrackerTopology* tTopo, const std::vector<uint32_t>& tkDetIdList
-            , std::vector<uint32_t>&& singleExtString = {}
-            , std::vector<uint32_t>&& modulesInRingFront = {}
-            , std::vector<uint32_t>&& modulesInRingBack = {}
-            , std::vector<uint32_t>&& binForRing = {}
-            , uint32_t nstring_ext = 0, uint32_t nrod = 0
-            )
-    : layer_(layer)
-    , nchX_(nchX), lowX_(lowX), highX_(highX)
-    , nchY_(nchY), lowY_(lowY), highY_(highY)
-    , tTopo_(tTopo)
-    , singleExtStr_(singleExtString)
-    , modulesInRingFront_(modulesInRingFront), modulesInRingBack_(modulesInRingBack)
-    , binForRing_(binForRing)
-    , nStringExt_(nstring_ext), nRod_(nrod)
-    , binToDet_(std::vector<DetId>(std::size_t(nchX*nchY), 0))
-  {
+  TkLayerMap(int layer,
+             std::size_t nchX,
+             double lowX,
+             double highX,
+             std::size_t nchY,
+             double lowY,
+             double highY,
+             const TrackerTopology* tTopo,
+             const std::vector<uint32_t>& tkDetIdList,
+             std::vector<uint32_t>&& singleExtString = {},
+             std::vector<uint32_t>&& modulesInRingFront = {},
+             std::vector<uint32_t>&& modulesInRingBack = {},
+             std::vector<uint32_t>&& binForRing = {},
+             uint32_t nstring_ext = 0,
+             uint32_t nrod = 0)
+      : layer_(layer),
+        nchX_(nchX),
+        lowX_(lowX),
+        highX_(highX),
+        nchY_(nchY),
+        lowY_(lowY),
+        highY_(highY),
+        tTopo_(tTopo),
+        singleExtStr_(singleExtString),
+        modulesInRingFront_(modulesInRingFront),
+        modulesInRingBack_(modulesInRingBack),
+        binForRing_(binForRing),
+        nStringExt_(nstring_ext),
+        nRod_(nrod),
+        binToDet_(std::vector<DetId>(std::size_t(nchX * nchY), 0)) {
     initMap(tkDetIdList);
   }
 
   void initMap(const std::vector<uint32_t>& tkDetIdList);
+
 private:
   void initMap_TIB(const std::vector<uint32_t>& tkDetIdList);
   void initMap_TOB(const std::vector<uint32_t>& tkDetIdList);
   void initMap_TID(const std::vector<uint32_t>& tkDetIdList);
   void initMap_TEC(const std::vector<uint32_t>& tkDetIdList);
 
-  std::size_t bin(std::size_t ix, std::size_t iy) const { return (ix-1)+nchX_*(iy-1); }
+  std::size_t bin(std::size_t ix, std::size_t iy) const { return (ix - 1) + nchX_ * (iy - 1); }
 
 public:
   static const int16_t layerSearch(DetId detid, const TrackerTopology* tTopo);
@@ -96,10 +146,11 @@ public:
 
   DetId getDetFromBin(int ix, int iy) const {
     const auto idx = bin(ix, iy);
-    return ( idx < nchX_*nchY_ ) ? binToDet_[idx] : DetId(0);
+    return (idx < nchX_ * nchY_) ? binToDet_[idx] : DetId(0);
   }
 
   const XYbin getXY(DetId detid, int layerEnumNb = TkLayerMap::INVALID) const;
+
 private:
   XYbin getXY_TIB(DetId detid) const;
   XYbin getXY_TOB(DetId detid) const;
@@ -107,28 +158,29 @@ private:
   XYbin getXY_TEC(DetId detid) const;
 
 private:
-  int layer_; //In the enumerator sequence
+  int layer_;  //In the enumerator sequence
   std::size_t nchX_;
   double lowX_, highX_;
   std::size_t nchY_;
   double lowY_, highY_;
   const TrackerTopology* tTopo_;
 
-  std::vector<uint32_t> singleExtStr_; // for TIB
-  std::vector<uint32_t> modulesInRingFront_, modulesInRingBack_, binForRing_; // for TEC
+  std::vector<uint32_t> singleExtStr_;                                         // for TIB
+  std::vector<uint32_t> modulesInRingFront_, modulesInRingBack_, binForRing_;  // for TEC
   uint32_t nStringExt_, nRod_;
 
   std::vector<DetId> binToDet_;
 };
 
-class TkDetMap
-{
+class TkDetMap {
 public:
-  TkDetMap(const TrackerTopology* tTopo) : tTopo_(tTopo) { TkMap.resize(TkLayerMap::NUMLAYERS); } // maximal number of layers
+  TkDetMap(const TrackerTopology* tTopo) : tTopo_(tTopo) {
+    TkMap.resize(TkLayerMap::NUMLAYERS);
+  }  // maximal number of layers
 
   // modifiers
-  void setLayerMap(int layer, const TkLayerMap& lyrMap ) { TkMap[layer] = lyrMap; }
-  void setLayerMap(int layer, TkLayerMap&& lyrMap ) { TkMap[layer] = lyrMap; }
+  void setLayerMap(int layer, const TkLayerMap& lyrMap) { TkMap[layer] = lyrMap; }
+  void setLayerMap(int layer, TkLayerMap&& lyrMap) { TkMap[layer] = lyrMap; }
 
   // conversion
   static std::string getLayerName(int in);
@@ -136,24 +188,24 @@ public:
 
   static void getSubDetLayerSide(int in, SiStripDetId::SubDetector&, uint32_t& layer, uint32_t& side);
 
-  DetId getDetFromBin(int layer, int ix, int iy) const
-  { return TkMap[layer].getDetFromBin(ix, iy); }
-  DetId getDetFromBin(const std::string& layerName, int ix, int iy) const
-  { return getDetFromBin(getLayerNum(layerName), ix, iy); }
+  DetId getDetFromBin(int layer, int ix, int iy) const { return TkMap[layer].getDetFromBin(ix, iy); }
+  DetId getDetFromBin(const std::string& layerName, int ix, int iy) const {
+    return getDetFromBin(getLayerNum(layerName), ix, iy);
+  }
 
-  std::vector<DetId> getDetsForLayer(int layer) const
-  { return TkMap[layer].getBinToDet(); } // const vector& -> vector conversion will copy
+  std::vector<DetId> getDetsForLayer(int layer) const {
+    return TkMap[layer].getBinToDet();
+  }  // const vector& -> vector conversion will copy
 
   // getXY and findLayer with caching, getComponents (for TkHistoMap)
   const TkLayerMap::XYbin& getXY(DetId detid,
-      DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const;
-  int16_t findLayer(DetId detid,
-      DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const;
-  void getComponents(int layer,
-		     int& nchX, double& lowX, double& highX,
-		     int& nchY, double& lowY, double& highY) const;
+                                 DetId& cached_detid,
+                                 int16_t& cached_layer,
+                                 TkLayerMap::XYbin& cached_XYbin) const;
+  int16_t findLayer(DetId detid, DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const;
+  void getComponents(int layer, int& nchX, double& lowX, double& highX, int& nchY, double& lowY, double& highY) const;
 
- private:
+private:
   std::vector<TkLayerMap> TkMap;
   const TrackerTopology* tTopo_;
 };

--- a/CalibTracker/SiStripCommon/interface/poly.h
+++ b/CalibTracker/SiStripCommon/interface/poly.h
@@ -7,109 +7,157 @@
 #include <list>
 #include <set>
 
-template<class T> class poly;
-template<class T> poly<T> operator+ (const poly<T>&, const char* ); 
-template<class T> poly<T> operator+ (const char*, const poly<T>& ); 
+template <class T>
+class poly;
+template <class T>
+poly<T> operator+(const poly<T>&, const char*);
+template <class T>
+poly<T> operator+(const char*, const poly<T>&);
 
-template<class T>
-class poly :
-  boost::incrementable< poly<T>,
-  boost::addable< poly<T>,
-  boost::multipliable< poly<T>,
-  boost::multipliable2< poly<T>, T,
-  boost::less_than_comparable< poly<T> > > > > > {    
-    
-    std::list<std::set<T> > columns;
-    
-  public:
+template <class T>
+class poly
+    : boost::incrementable<
+          poly<T>,
+          boost::addable<
+              poly<T>,
+              boost::multipliable<poly<T>, boost::multipliable2<poly<T>, T, boost::less_than_comparable<poly<T> > > > > > {
+  std::list<std::set<T> > columns;
 
-    class const_iterator;
-    typedef T value_type;
-    typedef typename std::list<std::set<T> >::iterator                column_iterator;
-    typedef typename std::list<std::set<T> >::const_iterator    const_column_iterator;
-    poly() {}
-    poly(const T& t) {operator+=(t);}
+public:
+  class const_iterator;
+  typedef T value_type;
+  typedef typename std::list<std::set<T> >::iterator column_iterator;
+  typedef typename std::list<std::set<T> >::const_iterator const_column_iterator;
+  poly() {}
+  poly(const T& t) { operator+=(t); }
 
-    bool operator<(const poly& R) const { 
-      const_column_iterator column(columns.begin()), Rcolumn(R.columns.begin());
-      while( column!=columns.end() && Rcolumn!=R.columns.end() && *column==*Rcolumn) { ++column; ++Rcolumn; }
-      return column!=columns.end() && Rcolumn!=R.columns.end() && *column < *Rcolumn;
-    }  
-    poly operator++() {columns.push_back(std::set<T>()); return *this;}                    
-    poly operator+=(const poly& R) { columns.insert(columns.end(),R.columns.begin(),R.columns.end()); return *this;}
-    poly operator+=(const T& r) { operator++(); return operator*=(r);}
-    poly operator*=(const T& r) { columns.back().insert(r); return *this;}    
-    poly operator*=(const poly& R) { columns.back().insert(R.begin(),R.end()); return *this;}    
-    friend poly<T> operator+ <> (const poly<T>&, const char*);
-    friend poly<T> operator+ <> (const char*, const poly<T>&);
+  bool operator<(const poly& R) const {
+    const_column_iterator column(columns.begin()), Rcolumn(R.columns.begin());
+    while (column != columns.end() && Rcolumn != R.columns.end() && *column == *Rcolumn) {
+      ++column;
+      ++Rcolumn;
+    }
+    return column != columns.end() && Rcolumn != R.columns.end() && *column < *Rcolumn;
+  }
+  poly operator++() {
+    columns.push_back(std::set<T>());
+    return *this;
+  }
+  poly operator+=(const poly& R) {
+    columns.insert(columns.end(), R.columns.begin(), R.columns.end());
+    return *this;
+  }
+  poly operator+=(const T& r) {
+    operator++();
+    return operator*=(r);
+  }
+  poly operator*=(const T& r) {
+    columns.back().insert(r);
+    return *this;
+  }
+  poly operator*=(const poly& R) {
+    columns.back().insert(R.begin(), R.end());
+    return *this;
+  }
+  friend poly<T> operator+<>(const poly<T>&, const char*);
+  friend poly<T> operator+<>(const char*, const poly<T>&);
 
-    const_iterator begin() const { return const_iterator(*this);}
-    const_iterator end()   const { return const_iterator::end_of(*this);} 
+  const_iterator begin() const { return const_iterator(*this); }
+  const_iterator end() const { return const_iterator::end_of(*this); }
 
-    auto const& getColumns() const { return columns; }
-    auto& getColumns() { return columns; }
+  auto const& getColumns() const { return columns; }
+  auto& getColumns() { return columns; }
 
-    size_t size() const { 
-      if(columns.empty()) return 0;
-      size_t size=1;
-      for( const_column_iterator column = columns.begin(); column != columns.end(); ++column) 
-	size *= column->size(); 
-      return size;
+  size_t size() const {
+    if (columns.empty())
+      return 0;
+    size_t size = 1;
+    for (const_column_iterator column = columns.begin(); column != columns.end(); ++column)
+      size *= column->size();
+    return size;
+  }
+
+  class const_iterator : public boost::iterator_facade<const_iterator, T const, boost::bidirectional_traversal_tag, T> {
+    friend class boost::iterator_core_access;
+
+    std::list<typename std::set<T>::const_iterator> state;
+    typename std::list<std::set<T> >::const_iterator begin, end;
+
+    typedef typename std::list<typename std::set<T>::const_iterator>::iterator state_iterator;
+    typedef typename std::list<typename std::set<T>::const_iterator>::const_iterator const_state_iterator;
+
+    bool equal(const_iterator const& rhs) const { return std::equal(state.begin(), state.end(), rhs.state.begin()); }
+    T dereference() const {
+      T s;
+      for (const_state_iterator istate = state.begin(); istate != state.end(); ++istate)
+        s += **istate;
+      return s;
+    }
+    void increment() {
+      state_iterator istate = state.begin();
+      const_column_iterator column = begin;
+      while (column != end && ++*istate == column->end()) {
+        ++istate;
+        ++column;
+      }
+      if (column == end) {
+        --column;
+        --istate;
+      }
+      while (istate != state.begin()) {
+        --istate;
+        *istate = (--column)->begin();
+      }
+    }
+    void decrement() {
+      state_iterator istate = state.begin();
+      const_column_iterator column = begin;
+      while (column != end && *istate == column->begin()) {
+        ++istate;
+        ++column;
+      }
+      if (column != end)
+        --*istate;
+      while (istate != state.begin()) {
+        --istate;
+        *istate = --((--column)->end());
+      }
     }
 
-    class const_iterator 
-      : public boost::iterator_facade< const_iterator, T const, boost::bidirectional_traversal_tag, T >  {
-      friend class boost::iterator_core_access;
-
-      std::list<typename std::set<T>::const_iterator>    state;
-      typename std::list<std::set<T> >::const_iterator   begin, end;
-
-      typedef typename std::list<typename std::set<T>::const_iterator>::iterator                state_iterator;
-      typedef typename std::list<typename std::set<T>::const_iterator>::const_iterator    const_state_iterator;
-
-      bool equal(const_iterator const& rhs) const { return std::equal( state.begin(), state.end(), rhs.state.begin() ); }
-      T dereference() const { T s; for(const_state_iterator istate=state.begin(); istate!=state.end(); ++istate)  s+= **istate; return s; }
-      void increment() { 
-	state_iterator istate = state.begin();
-	const_column_iterator column = begin;
-	while( column != end && ++*istate == column->end() ) { ++istate; ++column;} 
-	if( column == end ) {--column; --istate;}
-	while( istate != state.begin() ) {--istate; *istate = (--column)->begin();}
-      }
-      void decrement() {  
-	state_iterator istate = state.begin();
-	const_column_iterator column = begin;
-	while( column != end && *istate == column->begin())  { ++istate; ++column;}
-	if( column != end) --*istate;
-	while( istate != state.begin() ) {--istate; *istate = --((--column)->end());} 
-      }
-      
-    public:
-      
-      const_iterator() {}
-      const_iterator(const poly& p) : begin(p.getColumns().begin()), end(p.getColumns().end()) {
-	const_column_iterator column = begin; 
-	while(column!=end) state.push_back((column++)->begin()); 
-      }
-      static const_iterator end_of(const poly& p) {
-	const_iterator it(p);
-	if(p.size()!=0) *--(it.state.end()) = (--p.getColumns().end())->end();
-	return it;
-      }
-      
-  };    
-
+  public:
+    const_iterator() {}
+    const_iterator(const poly& p) : begin(p.getColumns().begin()), end(p.getColumns().end()) {
+      const_column_iterator column = begin;
+      while (column != end)
+        state.push_back((column++)->begin());
+    }
+    static const_iterator end_of(const poly& p) {
+      const_iterator it(p);
+      if (p.size() != 0)
+        *--(it.state.end()) = (--p.getColumns().end())->end();
+      return it;
+    }
+  };
 };
 
-template<class T> poly<T> operator+ (const poly<T>& lhs, const char* rhs ) { return lhs + poly<T>(rhs);} 
-template<class T> poly<T> operator+ (const char* lhs, const poly<T>& rhs ) { return poly<T>(lhs) + rhs;}
+template <class T>
+poly<T> operator+(const poly<T>& lhs, const char* rhs) {
+  return lhs + poly<T>(rhs);
+}
+template <class T>
+poly<T> operator+(const char* lhs, const poly<T>& rhs) {
+  return poly<T>(lhs) + rhs;
+}
 
-template <class charT, class traits, class T> 
-inline
-std::basic_ostream<charT,traits>& operator<<(std::basic_ostream<charT,traits>& strm, const poly<T>& f) { 
-  for(auto const& column : f.getColumns()) 
-    { strm << "( "; for(auto const& entry : column) strm << entry << ", "; strm << " )" << std::endl; }
-  return strm; 
+template <class charT, class traits, class T>
+inline std::basic_ostream<charT, traits>& operator<<(std::basic_ostream<charT, traits>& strm, const poly<T>& f) {
+  for (auto const& column : f.getColumns()) {
+    strm << "( ";
+    for (auto const& entry : column)
+      strm << entry << ", ";
+    strm << " )" << std::endl;
+  }
+  return strm;
 }
 
 #endif

--- a/CalibTracker/SiStripCommon/plugins/PrescaleEventFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/PrescaleEventFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CalibTracker/SiStripCommon
 // Class:      PrescaleEventFilter
-// 
+//
 /**\class PrescaleEventFilter PrescaleEventFilter.cc CalibTracker/SiStripCommon/plugins/PrescaleEventFilter.cc
 
  Description: Simple class to prescale events entering the Strip Tracker Calibration Tree
@@ -15,7 +15,6 @@
 //         Created:  Wed, 29 Nov 2017 15:27:07 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,142 +31,120 @@
 
 namespace prescale {
   struct Efficiency {
-    Efficiency(): eventCount_(0),acceptCount_(0) { }
+    Efficiency() : eventCount_(0), acceptCount_(0) {}
     mutable std::atomic<unsigned int> eventCount_;
     mutable std::atomic<unsigned int> acceptCount_;
   };
-}
+}  // namespace prescale
 
 //
 // class declaration
 //
 
 class PrescaleEventFilter : public edm::stream::EDFilter<edm::GlobalCache<prescale::Efficiency> > {
-   public:
-      explicit PrescaleEventFilter(edm::ParameterSet const& iConfig, const prescale::Efficiency* efficiency);
-      ~PrescaleEventFilter() override;
+public:
+  explicit PrescaleEventFilter(edm::ParameterSet const& iConfig, const prescale::Efficiency* efficiency);
+  ~PrescaleEventFilter() override;
 
-      static std::unique_ptr<prescale::Efficiency> initializeGlobalCache(edm::ParameterSet const&) {
- return std::unique_ptr<prescale::Efficiency>(new prescale::Efficiency());
-      };
+  static std::unique_ptr<prescale::Efficiency> initializeGlobalCache(edm::ParameterSet const&) {
+    return std::unique_ptr<prescale::Efficiency>(new prescale::Efficiency());
+  };
 
-  
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-      static void globalEndJob(const prescale::Efficiency* efficiency);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void globalEndJob(const prescale::Efficiency* efficiency);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      bool filter(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
-      /// accept one in prescaleFactor_; 0 means never to accept an event
-      unsigned int prescaleFactor_;
+  /// accept one in prescaleFactor_; 0 means never to accept an event
+  unsigned int prescaleFactor_;
 
-      /// event counter
-      unsigned int eventCount_;
+  /// event counter
+  unsigned int eventCount_;
 
-      /// accept counter
-      unsigned int acceptCount_;
+  /// accept counter
+  unsigned int acceptCount_;
 
-      /// initial offset
-      unsigned int offsetCount_;
-      unsigned int offsetPhase_;
-  
-      /// check for (re)initialization of the prescale
-      bool newLumi_;
+  /// initial offset
+  unsigned int offsetCount_;
+  unsigned int offsetPhase_;
 
-      /// "seed" used to initialize the prescale counter
-      static const unsigned int prescaleSeed_ = 65537;
+  /// check for (re)initialization of the prescale
+  bool newLumi_;
 
+  /// "seed" used to initialize the prescale counter
+  static const unsigned int prescaleSeed_ = 65537;
 };
 
 //
 // constructors and destructor
 //
-PrescaleEventFilter::PrescaleEventFilter(const edm::ParameterSet& iConfig,const prescale::Efficiency* efficiency):
-  prescaleFactor_(iConfig.getParameter<unsigned int>("prescale")),
-  eventCount_(0),
-  acceptCount_(0),
-  offsetCount_(0),
-  offsetPhase_(iConfig.getParameter<unsigned int>("offset"))
-{
-   //now do what ever initialization is needed
-
+PrescaleEventFilter::PrescaleEventFilter(const edm::ParameterSet& iConfig, const prescale::Efficiency* efficiency)
+    : prescaleFactor_(iConfig.getParameter<unsigned int>("prescale")),
+      eventCount_(0),
+      acceptCount_(0),
+      offsetCount_(0),
+      offsetPhase_(iConfig.getParameter<unsigned int>("offset")) {
+  //now do what ever initialization is needed
 }
 
-
-PrescaleEventFilter::~PrescaleEventFilter()
-{
-}
+PrescaleEventFilter::~PrescaleEventFilter() {}
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool
-PrescaleEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+bool PrescaleEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   bool needsInit (eventCount_==0);
+  bool needsInit(eventCount_ == 0);
 
-   if (needsInit && (prescaleFactor_ != 0)) {
-     // initialize the prescale counter to the first event number multiplied by a big "seed"
-      offsetCount_ = ((uint64_t) (iEvent.id().event() + offsetPhase_) * prescaleSeed_) % prescaleFactor_;
-   }
+  if (needsInit && (prescaleFactor_ != 0)) {
+    // initialize the prescale counter to the first event number multiplied by a big "seed"
+    offsetCount_ = ((uint64_t)(iEvent.id().event() + offsetPhase_) * prescaleSeed_) % prescaleFactor_;
+  }
 
-   const bool result ( (prescaleFactor_ == 0) ? 
-          false : ((eventCount_ + offsetCount_) % prescaleFactor_ == 0) );
+  const bool result((prescaleFactor_ == 0) ? false : ((eventCount_ + offsetCount_) % prescaleFactor_ == 0));
 
-   ++eventCount_;
-   if (result) ++acceptCount_;
-   return result;
-   
+  ++eventCount_;
+  if (result)
+    ++acceptCount_;
+  return result;
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-PrescaleEventFilter::beginStream(edm::StreamID)
-{
-}
+void PrescaleEventFilter::beginStream(edm::StreamID) {}
 
 //_____________________________________________________________________________
-void 
-PrescaleEventFilter::endStream()
-{
+void PrescaleEventFilter::endStream() {
   //since these are std::atomic, it is safe to increment them
   // even if multiple endStreams are being called.
   globalCache()->eventCount_ += eventCount_;
-  globalCache()->acceptCount_ += acceptCount_; 
+  globalCache()->acceptCount_ += acceptCount_;
   return;
 }
 
 //_____________________________________________________________________________
-void 
-PrescaleEventFilter::globalEndJob(const prescale::Efficiency* efficiency)
-{
+void PrescaleEventFilter::globalEndJob(const prescale::Efficiency* efficiency) {
   unsigned int accept(efficiency->acceptCount_);
-  unsigned int event (efficiency->eventCount_);
-  edm::LogInfo("PrescaleSummary")
-    << accept << "/" << event
-    << " ("
-    << 100.*accept/static_cast<double>(std::max(1u,event))
-    << "% of events accepted).";
+  unsigned int event(efficiency->eventCount_);
+  edm::LogInfo("PrescaleSummary") << accept << "/" << event << " ("
+                                  << 100. * accept / static_cast<double>(std::max(1u, event))
+                                  << "% of events accepted).";
   return;
 }
- 
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-PrescaleEventFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
+void PrescaleEventFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<unsigned int>("prescale",1);
-  desc.add<unsigned int>("offset",0);
+  desc.add<unsigned int>("prescale", 1);
+  desc.add<unsigned int>("offset", 0);
   descriptions.add("prescaleEvent", desc);
-
 }
 //define this as a plug-in
-DEFINE_FWK_MODULE(PrescaleEventFilter); 
+DEFINE_FWK_MODULE(PrescaleEventFilter);

--- a/CalibTracker/SiStripCommon/plugins/SealModules.cc
+++ b/CalibTracker/SiStripCommon/plugins/SealModules.cc
@@ -3,13 +3,11 @@
 
 #include "CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.h"
 
-
 DEFINE_FWK_MODULE(SiStripDetInfoFileWriter);
 
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 DEFINE_FWK_SERVICE(SiStripDetInfoFileReader);
-
 
 #include "CalibTracker/SiStripCommon/interface/ShallowTree.h"
 #include "CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h"

--- a/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
@@ -10,257 +10,245 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
-ShallowClustersProducer::ShallowClustersProducer(const edm::ParameterSet& iConfig) 
-  : Prefix(iConfig.getParameter<std::string>("Prefix") )
-{
-  produces <std::vector<unsigned> >    ( Prefix + "number"       );
-  produces <std::vector<unsigned> >    ( Prefix + "width"        );
-  produces <std::vector<float> >       ( Prefix + "variance"     );
-  produces <std::vector<float> >       ( Prefix + "barystrip"    );
-  produces <std::vector<float> >       ( Prefix + "middlestrip"  );
-  produces <std::vector<unsigned> >    ( Prefix + "charge"       );
-  produces <std::vector<float> >       ( Prefix + "noise"        );
-  produces <std::vector<float> >       ( Prefix + "ston"         );
-  produces <std::vector<unsigned> >    ( Prefix + "seedstrip"    );
-  produces <std::vector<unsigned> >    ( Prefix + "seedindex"    );
-  produces <std::vector<unsigned> >    ( Prefix + "seedcharge"   );
-  produces <std::vector<float> >       ( Prefix + "seednoise"    );
-  produces <std::vector<float> >       ( Prefix + "seedgain"     );
-  produces <std::vector<unsigned> >    ( Prefix + "qualityisbad" );
+ShallowClustersProducer::ShallowClustersProducer(const edm::ParameterSet& iConfig)
+    : Prefix(iConfig.getParameter<std::string>("Prefix")) {
+  produces<std::vector<unsigned>>(Prefix + "number");
+  produces<std::vector<unsigned>>(Prefix + "width");
+  produces<std::vector<float>>(Prefix + "variance");
+  produces<std::vector<float>>(Prefix + "barystrip");
+  produces<std::vector<float>>(Prefix + "middlestrip");
+  produces<std::vector<unsigned>>(Prefix + "charge");
+  produces<std::vector<float>>(Prefix + "noise");
+  produces<std::vector<float>>(Prefix + "ston");
+  produces<std::vector<unsigned>>(Prefix + "seedstrip");
+  produces<std::vector<unsigned>>(Prefix + "seedindex");
+  produces<std::vector<unsigned>>(Prefix + "seedcharge");
+  produces<std::vector<float>>(Prefix + "seednoise");
+  produces<std::vector<float>>(Prefix + "seedgain");
+  produces<std::vector<unsigned>>(Prefix + "qualityisbad");
 
-  produces <std::vector<float> >       ( Prefix + "rawchargeC"   );
-  produces <std::vector<float> >       ( Prefix + "rawchargeL"   );
-  produces <std::vector<float> >       ( Prefix + "rawchargeR"   );
-  produces <std::vector<float> >       ( Prefix + "rawchargeLL"   );
-  produces <std::vector<float> >       ( Prefix + "rawchargeRR"   );
-  produces <std::vector<float> >       ( Prefix + "eta"          );
-  produces <std::vector<float> >       ( Prefix + "foldedeta"    );
-  produces <std::vector<float> >       ( Prefix + "etaX"         );
-  produces <std::vector<float> >       ( Prefix + "etaasymm"     );
-  produces <std::vector<float> >       ( Prefix + "outsideasymm");
-  produces <std::vector<float> >       ( Prefix + "neweta");
-  produces <std::vector<float> >       ( Prefix + "newetaerr");
-  
-  produces <std::vector<unsigned> >    ( Prefix + "detid"         );
-  produces <std::vector<int> >         ( Prefix + "subdetid"      );
-  produces <std::vector<int> >         ( Prefix + "module"        );
-  produces <std::vector<int> >         ( Prefix + "side"          );
-  produces <std::vector<int> >         ( Prefix + "layerwheel"    );
-  produces <std::vector<int> >         ( Prefix + "stringringrod" );
-  produces <std::vector<int> >         ( Prefix + "petal"         );
-  produces <std::vector<int> >         ( Prefix + "stereo"        );
+  produces<std::vector<float>>(Prefix + "rawchargeC");
+  produces<std::vector<float>>(Prefix + "rawchargeL");
+  produces<std::vector<float>>(Prefix + "rawchargeR");
+  produces<std::vector<float>>(Prefix + "rawchargeLL");
+  produces<std::vector<float>>(Prefix + "rawchargeRR");
+  produces<std::vector<float>>(Prefix + "eta");
+  produces<std::vector<float>>(Prefix + "foldedeta");
+  produces<std::vector<float>>(Prefix + "etaX");
+  produces<std::vector<float>>(Prefix + "etaasymm");
+  produces<std::vector<float>>(Prefix + "outsideasymm");
+  produces<std::vector<float>>(Prefix + "neweta");
+  produces<std::vector<float>>(Prefix + "newetaerr");
 
-  theClustersToken_ = consumes<edmNew::DetSetVector<SiStripCluster> >          (iConfig.getParameter<edm::InputTag>("Clusters"));
-  theDigisToken_    = consumes<edm::DetSetVector<SiStripProcessedRawDigi> > (edm::InputTag("siStripProcessedRawDigis", ""));
+  produces<std::vector<unsigned>>(Prefix + "detid");
+  produces<std::vector<int>>(Prefix + "subdetid");
+  produces<std::vector<int>>(Prefix + "module");
+  produces<std::vector<int>>(Prefix + "side");
+  produces<std::vector<int>>(Prefix + "layerwheel");
+  produces<std::vector<int>>(Prefix + "stringringrod");
+  produces<std::vector<int>>(Prefix + "petal");
+  produces<std::vector<int>>(Prefix + "stereo");
+
+  theClustersToken_ = consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"));
+  theDigisToken_ = consumes<edm::DetSetVector<SiStripProcessedRawDigi>>(edm::InputTag("siStripProcessedRawDigis", ""));
 }
 
-void ShallowClustersProducer::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ShallowClustersProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
- 
-  auto       number        = std::make_unique<std::vector<unsigned>>(7,0);
-  auto       width         = std::make_unique<std::vector<unsigned>>();
-  auto       variance      = std::make_unique<std::vector<float>>();
-  auto       barystrip     = std::make_unique<std::vector<float>>();
-  auto       middlestrip   = std::make_unique<std::vector<float>>();
-  auto       charge        = std::make_unique<std::vector<unsigned>>();
-  auto       noise         = std::make_unique<std::vector<float>>();
-  auto       ston          = std::make_unique<std::vector<float>>();
-  auto       seedstrip     = std::make_unique<std::vector<unsigned>>();
-  auto       seedindex     = std::make_unique<std::vector<unsigned>>();
-  auto       seedcharge    = std::make_unique<std::vector<unsigned>>();
-  auto       seednoise     = std::make_unique<std::vector<float>>();
-  auto       seedgain      = std::make_unique<std::vector<float>>();
-  auto       qualityisbad  = std::make_unique<std::vector<unsigned>>();
 
-  auto       rawchargeC    = std::make_unique<std::vector<float>>();
-  auto       rawchargeL    = std::make_unique<std::vector<float>>();
-  auto       rawchargeR    = std::make_unique<std::vector<float>>();
-  auto       rawchargeLL   = std::make_unique<std::vector<float>>();
-  auto       rawchargeRR   = std::make_unique<std::vector<float>>();
-  auto       etaX          = std::make_unique<std::vector<float>>();
-  auto       eta           = std::make_unique<std::vector<float>>();
-  auto       foldedeta     = std::make_unique<std::vector<float>>();
-  auto       etaasymm      = std::make_unique<std::vector<float>>();
-  auto       outsideasymm  = std::make_unique<std::vector<float>>();
-  auto       neweta        = std::make_unique<std::vector<float>>();
-  auto       newetaerr     = std::make_unique<std::vector<float>>();
-  
-  auto       detid         = std::make_unique<std::vector<unsigned>>();
-  auto       subdetid      = std::make_unique<std::vector<int>>();
-  auto       side          = std::make_unique<std::vector<int>>();
-  auto       module        = std::make_unique<std::vector<int>>();
-  auto       layerwheel    = std::make_unique<std::vector<int>>();
-  auto       stringringrod = std::make_unique<std::vector<int>>();
-  auto       petal         = std::make_unique<std::vector<int>>();
-  auto       stereo        = std::make_unique<std::vector<int>>();
+  auto number = std::make_unique<std::vector<unsigned>>(7, 0);
+  auto width = std::make_unique<std::vector<unsigned>>();
+  auto variance = std::make_unique<std::vector<float>>();
+  auto barystrip = std::make_unique<std::vector<float>>();
+  auto middlestrip = std::make_unique<std::vector<float>>();
+  auto charge = std::make_unique<std::vector<unsigned>>();
+  auto noise = std::make_unique<std::vector<float>>();
+  auto ston = std::make_unique<std::vector<float>>();
+  auto seedstrip = std::make_unique<std::vector<unsigned>>();
+  auto seedindex = std::make_unique<std::vector<unsigned>>();
+  auto seedcharge = std::make_unique<std::vector<unsigned>>();
+  auto seednoise = std::make_unique<std::vector<float>>();
+  auto seedgain = std::make_unique<std::vector<float>>();
+  auto qualityisbad = std::make_unique<std::vector<unsigned>>();
 
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusters;
+  auto rawchargeC = std::make_unique<std::vector<float>>();
+  auto rawchargeL = std::make_unique<std::vector<float>>();
+  auto rawchargeR = std::make_unique<std::vector<float>>();
+  auto rawchargeLL = std::make_unique<std::vector<float>>();
+  auto rawchargeRR = std::make_unique<std::vector<float>>();
+  auto etaX = std::make_unique<std::vector<float>>();
+  auto eta = std::make_unique<std::vector<float>>();
+  auto foldedeta = std::make_unique<std::vector<float>>();
+  auto etaasymm = std::make_unique<std::vector<float>>();
+  auto outsideasymm = std::make_unique<std::vector<float>>();
+  auto neweta = std::make_unique<std::vector<float>>();
+  auto newetaerr = std::make_unique<std::vector<float>>();
+
+  auto detid = std::make_unique<std::vector<unsigned>>();
+  auto subdetid = std::make_unique<std::vector<int>>();
+  auto side = std::make_unique<std::vector<int>>();
+  auto module = std::make_unique<std::vector<int>>();
+  auto layerwheel = std::make_unique<std::vector<int>>();
+  auto stringringrod = std::make_unique<std::vector<int>>();
+  auto petal = std::make_unique<std::vector<int>>();
+  auto stereo = std::make_unique<std::vector<int>>();
+
+  edm::Handle<edmNew::DetSetVector<SiStripCluster>> clusters;
   //  iEvent.getByLabel(theClustersLabel, clusters);
   iEvent.getByToken(theClustersToken_, clusters);
-  
-  edm::Handle<edm::DetSetVector<SiStripProcessedRawDigi> > rawProcessedDigis;
+
+  edm::Handle<edm::DetSetVector<SiStripProcessedRawDigi>> rawProcessedDigis;
   //  iEvent.getByLabel("siStripProcessedRawDigis", "", rawProcessedDigis);
-  iEvent.getByToken(theDigisToken_,rawProcessedDigis);
- 
-  edmNew::DetSetVector<SiStripCluster>::const_iterator itClusters=clusters->begin();
-  for(;itClusters!=clusters->end();++itClusters){
+  iEvent.getByToken(theDigisToken_, rawProcessedDigis);
+
+  edmNew::DetSetVector<SiStripCluster>::const_iterator itClusters = clusters->begin();
+  for (; itClusters != clusters->end(); ++itClusters) {
     uint32_t id = itClusters->id();
     const moduleVars moduleV(id, tTopo);
-    for(edmNew::DetSet<SiStripCluster>::const_iterator cluster=itClusters->begin(); cluster!=itClusters->end();++cluster){
-      
+    for (edmNew::DetSet<SiStripCluster>::const_iterator cluster = itClusters->begin(); cluster != itClusters->end();
+         ++cluster) {
       const SiStripClusterInfo info(*cluster, iSetup, id);
       const NearDigis digis = rawProcessedDigis.isValid() ? NearDigis(info, *rawProcessedDigis) : NearDigis(info);
 
       (number->at(0))++;
       (number->at(moduleV.subdetid))++;
-      width->push_back(        cluster->amplitudes().size()                              );
-      barystrip->push_back(    cluster->barycenter()                                     );
-      variance->push_back(     info.variance()                                         );
-      middlestrip->push_back(  info.firstStrip() + info.width()/2.0                    );
-      charge->push_back(       info.charge()                                           );
-      noise->push_back(        info.noiseRescaledByGain()                              );
-      ston->push_back(         info.signalOverNoise()                                  );
-      seedstrip->push_back(    info.maxStrip()                                         );
-      seedindex->push_back(    info.maxIndex()                                         );
-      seedcharge->push_back(   info.maxCharge()                                        );
-      seednoise->push_back(    info.stripNoisesRescaledByGain().at(info.maxIndex())   );
-      seedgain->push_back(     info.stripGains().at(info.maxIndex())                  );
-      qualityisbad->push_back( info.IsAnythingBad()                                    );
+      width->push_back(cluster->amplitudes().size());
+      barystrip->push_back(cluster->barycenter());
+      variance->push_back(info.variance());
+      middlestrip->push_back(info.firstStrip() + info.width() / 2.0);
+      charge->push_back(info.charge());
+      noise->push_back(info.noiseRescaledByGain());
+      ston->push_back(info.signalOverNoise());
+      seedstrip->push_back(info.maxStrip());
+      seedindex->push_back(info.maxIndex());
+      seedcharge->push_back(info.maxCharge());
+      seednoise->push_back(info.stripNoisesRescaledByGain().at(info.maxIndex()));
+      seedgain->push_back(info.stripGains().at(info.maxIndex()));
+      qualityisbad->push_back(info.IsAnythingBad());
 
-      rawchargeC->push_back(   digis.max            );
-      rawchargeL->push_back(   digis.left           );
-      rawchargeR->push_back(   digis.right          );
-      rawchargeLL->push_back(  digis.Lleft          );
-      rawchargeRR->push_back(  digis.Rright         );
-      etaX->push_back(         digis.etaX()         );
-      eta->push_back(          digis.eta()          );
-      etaasymm->push_back(     digis.etaasymm()     );
-      outsideasymm->push_back( digis.outsideasymm() );
-      neweta->push_back(       (digis.last-digis.first)/info.charge() );
-      newetaerr->push_back(    (sqrt(digis.last+digis.first))/pow(info.charge(),1.5) );
+      rawchargeC->push_back(digis.max);
+      rawchargeL->push_back(digis.left);
+      rawchargeR->push_back(digis.right);
+      rawchargeLL->push_back(digis.Lleft);
+      rawchargeRR->push_back(digis.Rright);
+      etaX->push_back(digis.etaX());
+      eta->push_back(digis.eta());
+      etaasymm->push_back(digis.etaasymm());
+      outsideasymm->push_back(digis.outsideasymm());
+      neweta->push_back((digis.last - digis.first) / info.charge());
+      newetaerr->push_back((sqrt(digis.last + digis.first)) / pow(info.charge(), 1.5));
 
-      detid->push_back(            id                 );                
-      subdetid->push_back(         moduleV.subdetid      );          
-      side->push_back(             moduleV.side          );                  
-      module->push_back(           moduleV.module        );              
-      layerwheel->push_back(       moduleV.layerwheel    );      
-      stringringrod->push_back(    moduleV.stringringrod );
-      petal->push_back(            moduleV.petal         );                
-      stereo->push_back(           moduleV.stereo        );              
+      detid->push_back(id);
+      subdetid->push_back(moduleV.subdetid);
+      side->push_back(moduleV.side);
+      module->push_back(moduleV.module);
+      layerwheel->push_back(moduleV.layerwheel);
+      stringringrod->push_back(moduleV.stringringrod);
+      petal->push_back(moduleV.petal);
+      stereo->push_back(moduleV.stereo);
     }
   }
 
-  iEvent.put(std::move(number),      Prefix + "number"       );
-  iEvent.put(std::move(width),       Prefix + "width"        );
-  iEvent.put(std::move(variance),    Prefix + "variance"     );
-  iEvent.put(std::move(barystrip),   Prefix + "barystrip"    );
-  iEvent.put(std::move(middlestrip), Prefix + "middlestrip"  );
-  iEvent.put(std::move(charge),      Prefix + "charge"       );
-  iEvent.put(std::move(noise),       Prefix + "noise"        );
-  iEvent.put(std::move(ston),        Prefix + "ston"         );
-  iEvent.put(std::move(seedstrip),   Prefix + "seedstrip"    );
-  iEvent.put(std::move(seedindex),   Prefix + "seedindex"    );
-  iEvent.put(std::move(seedcharge),  Prefix + "seedcharge"   );
-  iEvent.put(std::move(seednoise),   Prefix + "seednoise"    );
-  iEvent.put(std::move(seedgain),    Prefix + "seedgain"     );
-  iEvent.put(std::move(qualityisbad),Prefix + "qualityisbad" );
+  iEvent.put(std::move(number), Prefix + "number");
+  iEvent.put(std::move(width), Prefix + "width");
+  iEvent.put(std::move(variance), Prefix + "variance");
+  iEvent.put(std::move(barystrip), Prefix + "barystrip");
+  iEvent.put(std::move(middlestrip), Prefix + "middlestrip");
+  iEvent.put(std::move(charge), Prefix + "charge");
+  iEvent.put(std::move(noise), Prefix + "noise");
+  iEvent.put(std::move(ston), Prefix + "ston");
+  iEvent.put(std::move(seedstrip), Prefix + "seedstrip");
+  iEvent.put(std::move(seedindex), Prefix + "seedindex");
+  iEvent.put(std::move(seedcharge), Prefix + "seedcharge");
+  iEvent.put(std::move(seednoise), Prefix + "seednoise");
+  iEvent.put(std::move(seedgain), Prefix + "seedgain");
+  iEvent.put(std::move(qualityisbad), Prefix + "qualityisbad");
 
-  iEvent.put(std::move(rawchargeC),  Prefix + "rawchargeC"   );
-  iEvent.put(std::move(rawchargeL),  Prefix + "rawchargeL"   );
-  iEvent.put(std::move(rawchargeR),  Prefix + "rawchargeR"   );
-  iEvent.put(std::move(rawchargeLL), Prefix + "rawchargeLL"  );
-  iEvent.put(std::move(rawchargeRR), Prefix + "rawchargeRR"  );
-  iEvent.put(std::move(etaX),        Prefix + "etaX"         );
-  iEvent.put(std::move(eta),         Prefix + "eta"          );
-  iEvent.put(std::move(foldedeta),   Prefix + "foldedeta"    );
-  iEvent.put(std::move(etaasymm),    Prefix + "etaasymm"     );
-  iEvent.put(std::move(outsideasymm),Prefix + "outsideasymm" );
-  iEvent.put(std::move(neweta),      Prefix + "neweta"       );
-  iEvent.put(std::move(newetaerr),   Prefix + "newetaerr"    );
+  iEvent.put(std::move(rawchargeC), Prefix + "rawchargeC");
+  iEvent.put(std::move(rawchargeL), Prefix + "rawchargeL");
+  iEvent.put(std::move(rawchargeR), Prefix + "rawchargeR");
+  iEvent.put(std::move(rawchargeLL), Prefix + "rawchargeLL");
+  iEvent.put(std::move(rawchargeRR), Prefix + "rawchargeRR");
+  iEvent.put(std::move(etaX), Prefix + "etaX");
+  iEvent.put(std::move(eta), Prefix + "eta");
+  iEvent.put(std::move(foldedeta), Prefix + "foldedeta");
+  iEvent.put(std::move(etaasymm), Prefix + "etaasymm");
+  iEvent.put(std::move(outsideasymm), Prefix + "outsideasymm");
+  iEvent.put(std::move(neweta), Prefix + "neweta");
+  iEvent.put(std::move(newetaerr), Prefix + "newetaerr");
 
-  iEvent.put(std::move(detid),        Prefix + "detid"         );
-  iEvent.put(std::move(subdetid),     Prefix + "subdetid"      );
-  iEvent.put(std::move(module),       Prefix + "module"        );
-  iEvent.put(std::move(side),         Prefix + "side"          );
-  iEvent.put(std::move(layerwheel),   Prefix + "layerwheel"    );
-  iEvent.put(std::move(stringringrod),Prefix + "stringringrod" );
-  iEvent.put(std::move(petal),        Prefix + "petal"         );
-  iEvent.put(std::move(stereo),       Prefix + "stereo"        );
-
+  iEvent.put(std::move(detid), Prefix + "detid");
+  iEvent.put(std::move(subdetid), Prefix + "subdetid");
+  iEvent.put(std::move(module), Prefix + "module");
+  iEvent.put(std::move(side), Prefix + "side");
+  iEvent.put(std::move(layerwheel), Prefix + "layerwheel");
+  iEvent.put(std::move(stringringrod), Prefix + "stringringrod");
+  iEvent.put(std::move(petal), Prefix + "petal");
+  iEvent.put(std::move(stereo), Prefix + "stereo");
 }
 
-ShallowClustersProducer::NearDigis::
-NearDigis(const SiStripClusterInfo& info) {
-  max =  info.maxCharge();
-  left =           info.maxIndex()    > uint16_t(0)                ? info.stripCharges()[info.maxIndex()-1]      : 0 ;
-  Lleft =          info.maxIndex()    > uint16_t(1)                ? info.stripCharges()[info.maxIndex()-2]      : 0 ;
-  right=  unsigned(info.maxIndex()+1) < info.stripCharges().size() ? info.stripCharges()[info.maxIndex()+1]      : 0 ;
-  Rright= unsigned(info.maxIndex()+2) < info.stripCharges().size() ? info.stripCharges()[info.maxIndex()+2]      : 0 ;
+ShallowClustersProducer::NearDigis::NearDigis(const SiStripClusterInfo& info) {
+  max = info.maxCharge();
+  left = info.maxIndex() > uint16_t(0) ? info.stripCharges()[info.maxIndex() - 1] : 0;
+  Lleft = info.maxIndex() > uint16_t(1) ? info.stripCharges()[info.maxIndex() - 2] : 0;
+  right = unsigned(info.maxIndex() + 1) < info.stripCharges().size() ? info.stripCharges()[info.maxIndex() + 1] : 0;
+  Rright = unsigned(info.maxIndex() + 2) < info.stripCharges().size() ? info.stripCharges()[info.maxIndex() + 2] : 0;
   first = info.stripCharges()[0];
-  last =  info.stripCharges()[info.width()-1];
+  last = info.stripCharges()[info.width() - 1];
 }
 
-ShallowClustersProducer::NearDigis::
-NearDigis(const SiStripClusterInfo& info, const edm::DetSetVector<SiStripProcessedRawDigi>& rawProcessedDigis) {
+ShallowClustersProducer::NearDigis::NearDigis(const SiStripClusterInfo& info,
+                                              const edm::DetSetVector<SiStripProcessedRawDigi>& rawProcessedDigis) {
   edm::DetSetVector<SiStripProcessedRawDigi>::const_iterator digiframe = rawProcessedDigis.find(info.detId());
-  if( digiframe != rawProcessedDigis.end()) {
-    max =                                                            digiframe->data.at(info.maxStrip()).adc()       ;
-    left =            info.maxStrip()    > uint16_t(0)             ? digiframe->data.at(info.maxStrip()-1).adc() : 0 ;
-    Lleft =           info.maxStrip()    > uint16_t(1)             ? digiframe->data.at(info.maxStrip()-2).adc() : 0 ;
-    right =  unsigned(info.maxStrip()+1) < digiframe->data.size()  ? digiframe->data.at(info.maxStrip()+1).adc() : 0 ;
-    Rright = unsigned(info.maxStrip()+2) < digiframe->data.size()  ? digiframe->data.at(info.maxStrip()+2).adc() : 0 ;
+  if (digiframe != rawProcessedDigis.end()) {
+    max = digiframe->data.at(info.maxStrip()).adc();
+    left = info.maxStrip() > uint16_t(0) ? digiframe->data.at(info.maxStrip() - 1).adc() : 0;
+    Lleft = info.maxStrip() > uint16_t(1) ? digiframe->data.at(info.maxStrip() - 2).adc() : 0;
+    right = unsigned(info.maxStrip() + 1) < digiframe->data.size() ? digiframe->data.at(info.maxStrip() + 1).adc() : 0;
+    Rright = unsigned(info.maxStrip() + 2) < digiframe->data.size() ? digiframe->data.at(info.maxStrip() + 2).adc() : 0;
     first = digiframe->data.at(info.firstStrip()).adc();
-    last = digiframe->data.at(info.firstStrip()+info.width() - 1).adc();
+    last = digiframe->data.at(info.firstStrip() + info.width() - 1).adc();
   } else {
     *this = NearDigis(info);
   }
 }
 
-ShallowClustersProducer::moduleVars::
-moduleVars(uint32_t detid, const TrackerTopology* tTopo) {
+ShallowClustersProducer::moduleVars::moduleVars(uint32_t detid, const TrackerTopology* tTopo) {
   SiStripDetId subdet(detid);
   subdetid = subdet.subDetector();
-  if( SiStripDetId::TIB == subdetid ) {
-    
-    module        = tTopo->tibModule(detid); 
-    side          = tTopo->tibIsZMinusSide(detid)?-1:1;  
-    layerwheel    = tTopo->tibLayer(detid); 
-    stringringrod = tTopo->tibString(detid); 
-    stereo        = tTopo->tibIsStereo(detid) ? 1 : 0;
-  } else
-  if( SiStripDetId::TID == subdetid ) {
-    
-    module        = tTopo->tidModule(detid); 
-    side          = tTopo->tidIsZMinusSide(detid)?-1:1;  
-    layerwheel    = tTopo->tidWheel(detid); 
-    stringringrod = tTopo->tidRing(detid); 
-    stereo        = tTopo->tidIsStereo(detid) ? 1 : 0;
-  } else
-  if( SiStripDetId::TOB == subdetid ) {
-    
-    module        = tTopo->tobModule(detid); 
-    side          = tTopo->tobIsZMinusSide(detid)?-1:1;  
-    layerwheel    = tTopo->tobLayer(detid); 
-    stringringrod = tTopo->tobRod(detid); 
-    stereo        = tTopo->tobIsStereo(detid) ? 1 : 0;
-  } else
-  if( SiStripDetId::TEC == subdetid ) {
-    
-    module        = tTopo->tecModule(detid); 
-    side          = tTopo->tecIsZMinusSide(detid)?-1:1;  
-    layerwheel    = tTopo->tecWheel(detid); 
-    stringringrod = tTopo->tecRing(detid); 
-    petal         = tTopo->tecPetalNumber(detid); 
-    stereo        = tTopo->tecIsStereo(detid) ? 1 : 0;
+  if (SiStripDetId::TIB == subdetid) {
+    module = tTopo->tibModule(detid);
+    side = tTopo->tibIsZMinusSide(detid) ? -1 : 1;
+    layerwheel = tTopo->tibLayer(detid);
+    stringringrod = tTopo->tibString(detid);
+    stereo = tTopo->tibIsStereo(detid) ? 1 : 0;
+  } else if (SiStripDetId::TID == subdetid) {
+    module = tTopo->tidModule(detid);
+    side = tTopo->tidIsZMinusSide(detid) ? -1 : 1;
+    layerwheel = tTopo->tidWheel(detid);
+    stringringrod = tTopo->tidRing(detid);
+    stereo = tTopo->tidIsStereo(detid) ? 1 : 0;
+  } else if (SiStripDetId::TOB == subdetid) {
+    module = tTopo->tobModule(detid);
+    side = tTopo->tobIsZMinusSide(detid) ? -1 : 1;
+    layerwheel = tTopo->tobLayer(detid);
+    stringringrod = tTopo->tobRod(detid);
+    stereo = tTopo->tobIsStereo(detid) ? 1 : 0;
+  } else if (SiStripDetId::TEC == subdetid) {
+    module = tTopo->tecModule(detid);
+    side = tTopo->tecIsZMinusSide(detid) ? -1 : 1;
+    layerwheel = tTopo->tecWheel(detid);
+    stringringrod = tTopo->tecRing(detid);
+    petal = tTopo->tecPetalNumber(detid);
+    stereo = tTopo->tecIsStereo(detid) ? 1 : 0;
   } else {
     module = 0;
     side = 0;
-    layerwheel=-1;
+    layerwheel = -1;
     stringringrod = -1;
-    petal=-1;
+    petal = -1;
   }
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowDigisProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowDigisProducer.cc
@@ -11,59 +11,55 @@
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 
 ShallowDigisProducer::ShallowDigisProducer(const edm::ParameterSet& conf)
-  : inputTags(conf.getParameter<std::vector<edm::InputTag> >("DigiProducersList")) 
-{
+    : inputTags(conf.getParameter<std::vector<edm::InputTag> >("DigiProducersList")) {
   produces<std::vector<unsigned> >("id");
   produces<std::vector<unsigned> >("subdet");
   produces<std::vector<unsigned> >("strip");
   produces<std::vector<unsigned> >("adc");
   produces<std::vector<float> >("noise");
-}  
-
-void ShallowDigisProducer::
-insert(products& p, edm::Event& e) {
-  e.put(std::move(p.id),     "id");
-  e.put(std::move(p.subdet), "subdet");
-  e.put(std::move(p.strip),  "strip");
-  e.put(std::move(p.adc),    "adc");
-  e.put(std::move(p.noise),  "noise");
 }
 
-template<class T>
-inline
-void ShallowDigisProducer::
-recordDigis(const T& digiCollection, products& p) {
-  for(auto const& set : digiCollection) {
+void ShallowDigisProducer::insert(products& p, edm::Event& e) {
+  e.put(std::move(p.id), "id");
+  e.put(std::move(p.subdet), "subdet");
+  e.put(std::move(p.strip), "strip");
+  e.put(std::move(p.adc), "adc");
+  e.put(std::move(p.noise), "noise");
+}
+
+template <class T>
+inline void ShallowDigisProducer::recordDigis(const T& digiCollection, products& p) {
+  for (auto const& set : digiCollection) {
     SiStripNoises::Range detNoiseRange = noiseHandle->getRange(set.detId());
-    for(auto const& digi : set) {
+    for (auto const& digi : set) {
       p.id->push_back(set.detId());
-      p.subdet->push_back((set.detId()>>25)&0x7);
+      p.subdet->push_back((set.detId() >> 25) & 0x7);
       p.strip->push_back(digi.strip());
       p.adc->push_back(digi.adc());
-      p.noise->push_back(noiseHandle->getNoise( digi.strip(), detNoiseRange));
+      p.noise->push_back(noiseHandle->getNoise(digi.strip(), detNoiseRange));
     }
   }
 }
 
-void ShallowDigisProducer::
-produce(edm::Event& e, const edm::EventSetup& es) {  
+void ShallowDigisProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   products p;
-  edm::Handle< edm::DetSetVector<SiStripDigi> >     inputOld;  
-  edm::Handle< edmNew::DetSetVector<SiStripDigi> >  inputNew;  
+  edm::Handle<edm::DetSetVector<SiStripDigi> > inputOld;
+  edm::Handle<edmNew::DetSetVector<SiStripDigi> > inputNew;
   es.get<SiStripNoisesRcd>().get(noiseHandle);
-  if( findInput(inputOld, e) ) recordDigis(*inputOld, p); else 
-    if( findInput(inputNew, e) ) recordDigis(*inputNew, p); else
-      edm::LogWarning("Input Not Found");
-  insert(p,e);
+  if (findInput(inputOld, e))
+    recordDigis(*inputOld, p);
+  else if (findInput(inputNew, e))
+    recordDigis(*inputNew, p);
+  else
+    edm::LogWarning("Input Not Found");
+  insert(p, e);
 }
 
-template<class T>
-inline
-bool ShallowDigisProducer::
-findInput(edm::Handle<T>& handle, const edm::Event& e) {
-  for(auto const& inputTag : inputTags) {
+template <class T>
+inline bool ShallowDigisProducer::findInput(edm::Handle<T>& handle, const edm::Event& e) {
+  for (auto const& inputTag : inputTags) {
     e.getByLabel(inputTag, handle);
-    if( handle.isValid() && !handle->empty() ) {
+    if (handle.isValid() && !handle->empty()) {
       LogDebug("Input") << inputTag;
       return true;
     }

--- a/CalibTracker/SiStripCommon/plugins/ShallowEventDataProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowEventDataProducer.cc
@@ -6,86 +6,83 @@
 // #include <bitset>
 
 ShallowEventDataProducer::ShallowEventDataProducer(const edm::ParameterSet& iConfig) {
-  produces <unsigned int> ( "run"      );
-  produces <unsigned int> ( "event"    );
-  produces <unsigned int> ( "bx"       );
-  produces <unsigned int> ( "lumi"     );
-  produces <float>        ( "instLumi" );
-  produces <float>        ( "PU"       );
-  #ifdef ExtendedCALIBTree
-  produces <std::vector<bool> > ( "TrigTech" );
-  produces <std::vector<bool> > ( "TrigPh" );
-  #endif
+  produces<unsigned int>("run");
+  produces<unsigned int>("event");
+  produces<unsigned int>("bx");
+  produces<unsigned int>("lumi");
+  produces<float>("instLumi");
+  produces<float>("PU");
+#ifdef ExtendedCALIBTree
+  produces<std::vector<bool>>("TrigTech");
+  produces<std::vector<bool>>("TrigPh");
+#endif
 
-  trig_token_   = consumes<L1GlobalTriggerReadoutRecord>(iConfig.getParameter<edm::InputTag>("trigRecord"));
-  scalerToken_  = consumes< LumiScalersCollection >(iConfig.getParameter<edm::InputTag>("lumiScalers"));
-
+  trig_token_ = consumes<L1GlobalTriggerReadoutRecord>(iConfig.getParameter<edm::InputTag>("trigRecord"));
+  scalerToken_ = consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("lumiScalers"));
 }
 
-void ShallowEventDataProducer::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ShallowEventDataProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto run = std::make_unique<unsigned int>(iEvent.id().run());
+  auto event = std::make_unique<unsigned int>(iEvent.id().event());
+  auto bx = std::make_unique<unsigned int>(iEvent.bunchCrossing());
+  auto lumi = std::make_unique<unsigned int>(iEvent.luminosityBlock());
 
-
-  auto run   = std::make_unique<unsigned int>(iEvent.id().run()   );
-  auto event = std::make_unique<unsigned int>(iEvent.id().event() );
-  auto bx    = std::make_unique<unsigned int>(iEvent.bunchCrossing() );
-  auto lumi  = std::make_unique<unsigned int>(iEvent.luminosityBlock() );
-
-  edm::Handle< L1GlobalTriggerReadoutRecord > gtRecord;
+  edm::Handle<L1GlobalTriggerReadoutRecord> gtRecord;
   iEvent.getByToken(trig_token_, gtRecord);
 
-  #ifdef ExtendedCALIBTree
-  std::vector<bool> TrigTech_(64,false);
-  std::vector<bool> TrigPh_(128,false);
-  #endif
+#ifdef ExtendedCALIBTree
+  std::vector<bool> TrigTech_(64, false);
+  std::vector<bool> TrigPh_(128, false);
+#endif
 
-  #ifdef ExtendedCALIBTree
+#ifdef ExtendedCALIBTree
   // Get dWord after masking disabled bits
   DecisionWord dWord = gtRecord->decisionWord();
-  if ( ! dWord.empty() ) { // if board not there this is zero
+  if (!dWord.empty()) {  // if board not there this is zero
     // loop over dec. bit to get total rate (no overlap)
-    for ( int i = 0; i < 64; ++i ) {
-      TrigPh_[i]= dWord[i];
+    for (int i = 0; i < 64; ++i) {
+      TrigPh_[i] = dWord[i];
     }
   }
 
   TechnicalTriggerWord tw = gtRecord->technicalTriggerWord();
-  if ( ! tw.empty() ) {
+  if (!tw.empty()) {
     // loop over dec. bit to get total rate (no overlap)
-    for ( int i = 0; i < 64; ++i ) {
-      TrigTech_[i]=tw[i];
+    for (int i = 0; i < 64; ++i) {
+      TrigTech_[i] = tw[i];
     }
   }
 
   auto TrigTech = std::make_unique<std::vector<bool>>(TrigTech_);
   auto TrigPh = std::make_unique<std::vector<bool>>(TrigPh_);
-  #endif
+#endif
 
   // Luminosity informations
-  edm::Handle< LumiScalersCollection > lumiScalers;
-  float instLumi_=0; float PU_=0;
+  edm::Handle<LumiScalersCollection> lumiScalers;
+  float instLumi_ = 0;
+  float PU_ = 0;
   iEvent.getByToken(scalerToken_, lumiScalers);
-  if(lumiScalers.isValid()){
+  if (lumiScalers.isValid()) {
     if (lumiScalers->begin() != lumiScalers->end()) {
       instLumi_ = lumiScalers->begin()->instantLumi();
-      PU_       = lumiScalers->begin()->pileup();
+      PU_ = lumiScalers->begin()->pileup();
     }
   } else {
     edm::LogInfo("ShallowEventDataProducer")
-      << "LumiScalers collection not found in the event; will write dummy values";
+        << "LumiScalers collection not found in the event; will write dummy values";
   }
 
   auto instLumi = std::make_unique<float>(instLumi_);
-  auto PU       = std::make_unique<float>(PU_);
+  auto PU = std::make_unique<float>(PU_);
 
-  iEvent.put(std::move(run),      "run"   );
-  iEvent.put(std::move(event),    "event" );
-  iEvent.put(std::move(bx),       "bx" );
-  iEvent.put(std::move(lumi),     "lumi" );
-  #ifdef ExtendedCALIBTree
-  iEvent.put(std::move(TrigTech), "TrigTech" );
-  iEvent.put(std::move(TrigPh),   "TrigPh" );
-  #endif
+  iEvent.put(std::move(run), "run");
+  iEvent.put(std::move(event), "event");
+  iEvent.put(std::move(bx), "bx");
+  iEvent.put(std::move(lumi), "lumi");
+#ifdef ExtendedCALIBTree
+  iEvent.put(std::move(TrigTech), "TrigTech");
+  iEvent.put(std::move(TrigPh), "TrigPh");
+#endif
   iEvent.put(std::move(instLumi), "instLumi");
-  iEvent.put(std::move(PU),       "PU");
+  iEvent.put(std::move(PU), "PU");
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowGainCalibration.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowGainCalibration.cc
@@ -1,210 +1,236 @@
 #include "CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripGain.h" 
-#include "CalibTracker/Records/interface/SiStripGainRcd.h"  
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
 
 using namespace edm;
 using namespace reco;
 using namespace std;
 
 ShallowGainCalibration::ShallowGainCalibration(const edm::ParameterSet& iConfig)
-  :  tracks_token_( consumes< edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("Tracks")) ),
-		 association_token_( consumes< TrajTrackAssociationCollection >(iConfig.getParameter<edm::InputTag>("Tracks")) ),
-     Suffix       ( iConfig.getParameter<std::string>("Suffix")    ),
-     Prefix       ( iConfig.getParameter<std::string>("Prefix") )
-{
-  produces <std::vector<int> >            ( Prefix + "trackindex"     + Suffix );
-  produces <std::vector<unsigned int> >   ( Prefix + "rawid"          + Suffix );
-  produces <std::vector<double> >         ( Prefix + "localdirx"      + Suffix );
-  produces <std::vector<double> >         ( Prefix + "localdiry"      + Suffix );
-  produces <std::vector<double> >         ( Prefix + "localdirz"      + Suffix );
-  produces <std::vector<unsigned short> > ( Prefix + "firststrip"     + Suffix );
-  produces <std::vector<unsigned short> > ( Prefix + "nstrips"        + Suffix );
-  produces <std::vector<bool> >           ( Prefix + "saturation"     + Suffix );
-  produces <std::vector<bool> >           ( Prefix + "overlapping"    + Suffix );
-  produces <std::vector<bool> >           ( Prefix + "farfromedge"    + Suffix );
-  produces <std::vector<unsigned int> >   ( Prefix + "charge"         + Suffix );
-  produces <std::vector<double> >         ( Prefix + "path"           + Suffix );
-  #ifdef ExtendedCALIBTree
-  produces <std::vector<double> >         ( Prefix + "chargeoverpath" + Suffix );
-  #endif
-  produces <std::vector<unsigned char> >  ( Prefix + "amplitude"      + Suffix );
-  produces <std::vector<double> >         ( Prefix + "gainused"       + Suffix );
-  produces <std::vector<double> >         ( Prefix + "gainusedTick"   + Suffix );
+    : tracks_token_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("Tracks"))),
+      association_token_(consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("Tracks"))),
+      Suffix(iConfig.getParameter<std::string>("Suffix")),
+      Prefix(iConfig.getParameter<std::string>("Prefix")) {
+  produces<std::vector<int>>(Prefix + "trackindex" + Suffix);
+  produces<std::vector<unsigned int>>(Prefix + "rawid" + Suffix);
+  produces<std::vector<double>>(Prefix + "localdirx" + Suffix);
+  produces<std::vector<double>>(Prefix + "localdiry" + Suffix);
+  produces<std::vector<double>>(Prefix + "localdirz" + Suffix);
+  produces<std::vector<unsigned short>>(Prefix + "firststrip" + Suffix);
+  produces<std::vector<unsigned short>>(Prefix + "nstrips" + Suffix);
+  produces<std::vector<bool>>(Prefix + "saturation" + Suffix);
+  produces<std::vector<bool>>(Prefix + "overlapping" + Suffix);
+  produces<std::vector<bool>>(Prefix + "farfromedge" + Suffix);
+  produces<std::vector<unsigned int>>(Prefix + "charge" + Suffix);
+  produces<std::vector<double>>(Prefix + "path" + Suffix);
+#ifdef ExtendedCALIBTree
+  produces<std::vector<double>>(Prefix + "chargeoverpath" + Suffix);
+#endif
+  produces<std::vector<unsigned char>>(Prefix + "amplitude" + Suffix);
+  produces<std::vector<double>>(Prefix + "gainused" + Suffix);
+  produces<std::vector<double>>(Prefix + "gainusedTick" + Suffix);
 }
 
-void ShallowGainCalibration::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  auto         trackindex    = std::make_unique<std::vector<int>>            ();
-  auto         rawid         = std::make_unique<std::vector<unsigned int>>   ();
-  auto         localdirx     = std::make_unique<std::vector<double>>         ();
-  auto         localdiry     = std::make_unique<std::vector<double>>         ();
-  auto         localdirz     = std::make_unique<std::vector<double>>         ();
-  auto         firststrip    = std::make_unique<std::vector<unsigned short>> ();
-  auto         nstrips       = std::make_unique<std::vector<unsigned short>> ();
-  auto         saturation    = std::make_unique<std::vector<bool>>           ();
-  auto         overlapping   = std::make_unique<std::vector<bool>>           ();
-  auto         farfromedge   = std::make_unique<std::vector<bool>>           ();
-  auto         charge        = std::make_unique<std::vector<unsigned int>>   ();
-  auto         path          = std::make_unique<std::vector<double>>         ();
-  #ifdef ExtendedCALIBTree
-  auto         chargeoverpath= std::make_unique<std::vector<double>>         ();
-  #endif
-  auto         amplitude     = std::make_unique<std::vector<unsigned char>>  ();
-  auto         gainused      = std::make_unique<std::vector<double>>         ();
-  auto         gainusedTick  = std::make_unique<std::vector<double>>         ();
+void ShallowGainCalibration::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto trackindex = std::make_unique<std::vector<int>>();
+  auto rawid = std::make_unique<std::vector<unsigned int>>();
+  auto localdirx = std::make_unique<std::vector<double>>();
+  auto localdiry = std::make_unique<std::vector<double>>();
+  auto localdirz = std::make_unique<std::vector<double>>();
+  auto firststrip = std::make_unique<std::vector<unsigned short>>();
+  auto nstrips = std::make_unique<std::vector<unsigned short>>();
+  auto saturation = std::make_unique<std::vector<bool>>();
+  auto overlapping = std::make_unique<std::vector<bool>>();
+  auto farfromedge = std::make_unique<std::vector<bool>>();
+  auto charge = std::make_unique<std::vector<unsigned int>>();
+  auto path = std::make_unique<std::vector<double>>();
+#ifdef ExtendedCALIBTree
+  auto chargeoverpath = std::make_unique<std::vector<double>>();
+#endif
+  auto amplitude = std::make_unique<std::vector<unsigned char>>();
+  auto gainused = std::make_unique<std::vector<double>>();
+  auto gainusedTick = std::make_unique<std::vector<double>>();
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;         iSetup.get<TrackerDigiGeometryRecord>().get( theTrackerGeometry );  
-  m_tracker=&(* theTrackerGeometry );
-  edm::ESHandle<SiStripGain> gainHandle;                     iSetup.get<SiStripGainRcd>().get(gainHandle);
-  edm::Handle<edm::View<reco::Track> > tracks;	             iEvent.getByToken(tracks_token_, tracks);	  
-  edm::Handle<TrajTrackAssociationCollection> associations;  iEvent.getByToken(association_token_, associations);
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  m_tracker = &(*theTrackerGeometry);
+  edm::ESHandle<SiStripGain> gainHandle;
+  iSetup.get<SiStripGainRcd>().get(gainHandle);
+  edm::Handle<edm::View<reco::Track>> tracks;
+  iEvent.getByToken(tracks_token_, tracks);
+  edm::Handle<TrajTrackAssociationCollection> associations;
+  iEvent.getByToken(association_token_, associations);
 
-  for( TrajTrackAssociationCollection::const_iterator association = associations->begin(); association != associations->end(); association++) {
-       const Trajectory*  traj  = association->key.get();
-       const reco::Track* track = association->val.get();
+  for (TrajTrackAssociationCollection::const_iterator association = associations->begin();
+       association != associations->end();
+       association++) {
+    const Trajectory* traj = association->key.get();
+    const reco::Track* track = association->val.get();
 
-       vector<TrajectoryMeasurement> measurements = traj->measurements();
-       for(vector<TrajectoryMeasurement>::const_iterator measurement_it = measurements.begin(); measurement_it!=measurements.end(); measurement_it++){
-          TrajectoryStateOnSurface trajState = measurement_it->updatedState();
-          if( !trajState.isValid() ) continue;     
+    vector<TrajectoryMeasurement> measurements = traj->measurements();
+    for (vector<TrajectoryMeasurement>::const_iterator measurement_it = measurements.begin();
+         measurement_it != measurements.end();
+         measurement_it++) {
+      TrajectoryStateOnSurface trajState = measurement_it->updatedState();
+      if (!trajState.isValid())
+        continue;
 
-          const TrackingRecHit*         hit                 = (*measurement_it->recHit()).hit();
-          const SiStripRecHit1D*        sistripsimple1dhit  = dynamic_cast<const SiStripRecHit1D*>(hit);
-          const SiStripRecHit2D*        sistripsimplehit    = dynamic_cast<const SiStripRecHit2D*>(hit);
-          const SiStripMatchedRecHit2D* sistripmatchedhit   = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
-          const SiPixelRecHit*          sipixelhit          = dynamic_cast<const SiPixelRecHit*>(hit);
+      const TrackingRecHit* hit = (*measurement_it->recHit()).hit();
+      const SiStripRecHit1D* sistripsimple1dhit = dynamic_cast<const SiStripRecHit1D*>(hit);
+      const SiStripRecHit2D* sistripsimplehit = dynamic_cast<const SiStripRecHit2D*>(hit);
+      const SiStripMatchedRecHit2D* sistripmatchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
+      const SiPixelRecHit* sipixelhit = dynamic_cast<const SiPixelRecHit*>(hit);
 
-          const SiPixelCluster*   PixelCluster = nullptr;
-          const SiStripCluster*   StripCluster = nullptr;
-          uint32_t                DetId = 0;
+      const SiPixelCluster* PixelCluster = nullptr;
+      const SiStripCluster* StripCluster = nullptr;
+      uint32_t DetId = 0;
 
-          for(unsigned int h=0;h<2;h++){
-            if(!sistripmatchedhit && h==1){
-	       continue;
-            }else if(sistripmatchedhit  && h==0){
-               StripCluster = &sistripmatchedhit->monoCluster();
-	       DetId = sistripmatchedhit->monoId();
-            }else if(sistripmatchedhit  && h==1){
-               StripCluster = &sistripmatchedhit->stereoCluster();;
-	       DetId = sistripmatchedhit->stereoId();
-            }else if(sistripsimplehit){
-               StripCluster = (sistripsimplehit->cluster()).get();
-	       DetId = sistripsimplehit->geographicalId().rawId();
-            }else if(sistripsimple1dhit){
-               StripCluster = (sistripsimple1dhit->cluster()).get();
-	       DetId = sistripsimple1dhit->geographicalId().rawId();
-            }else if(sipixelhit){
-               PixelCluster = (sipixelhit->cluster()).get();
-               DetId = sipixelhit->geographicalId().rawId();
-            }else{
-               continue;
-            }
+      for (unsigned int h = 0; h < 2; h++) {
+        if (!sistripmatchedhit && h == 1) {
+          continue;
+        } else if (sistripmatchedhit && h == 0) {
+          StripCluster = &sistripmatchedhit->monoCluster();
+          DetId = sistripmatchedhit->monoId();
+        } else if (sistripmatchedhit && h == 1) {
+          StripCluster = &sistripmatchedhit->stereoCluster();
+          ;
+          DetId = sistripmatchedhit->stereoId();
+        } else if (sistripsimplehit) {
+          StripCluster = (sistripsimplehit->cluster()).get();
+          DetId = sistripsimplehit->geographicalId().rawId();
+        } else if (sistripsimple1dhit) {
+          StripCluster = (sistripsimple1dhit->cluster()).get();
+          DetId = sistripsimple1dhit->geographicalId().rawId();
+        } else if (sipixelhit) {
+          PixelCluster = (sipixelhit->cluster()).get();
+          DetId = sipixelhit->geographicalId().rawId();
+        } else {
+          continue;
+        }
 
-            LocalVector             trackDirection = trajState.localDirection();
-            double                  cosine         = trackDirection.z()/trackDirection.mag();
-            bool                    Saturation     = false;
-            bool                    Overlapping    = false;
-            unsigned int            Charge         = 0;
-            double                  Path           = (10.0*thickness(DetId))/fabs(cosine);
-            double                  PrevGain       = -1;
-            double                  PrevGainTick   = -1;
-            int                     FirstStrip     = 0;
-            int                     NStrips        = 0;
+        LocalVector trackDirection = trajState.localDirection();
+        double cosine = trackDirection.z() / trackDirection.mag();
+        bool Saturation = false;
+        bool Overlapping = false;
+        unsigned int Charge = 0;
+        double Path = (10.0 * thickness(DetId)) / fabs(cosine);
+        double PrevGain = -1;
+        double PrevGainTick = -1;
+        int FirstStrip = 0;
+        int NStrips = 0;
 
-            if(StripCluster){
-               const auto           &  Ampls          = StripCluster->amplitudes();
-   	                               FirstStrip     = StripCluster->firstStrip();
-                                       NStrips        = Ampls.size();
-               int                     APVId          = FirstStrip/128;
+        if (StripCluster) {
+          const auto& Ampls = StripCluster->amplitudes();
+          FirstStrip = StripCluster->firstStrip();
+          NStrips = Ampls.size();
+          int APVId = FirstStrip / 128;
 
-
-               if(gainHandle.isValid()){ 
-                  PrevGain     =  gainHandle->getApvGain(APVId,gainHandle->getRange(DetId, 1),1); 
-                  PrevGainTick =  gainHandle->getApvGain(APVId,gainHandle->getRange(DetId, 0),1);           
-               }
-
-               for(unsigned int a=0;a<Ampls.size();a++){               
-                  Charge+=Ampls[a];
-                  if(Ampls[a] >=254)Saturation =true;
-                  amplitude->push_back( Ampls[a] );
-               }
-
-               if(FirstStrip==0                                  )Overlapping=true;
-               if(FirstStrip==128                                )Overlapping=true;
-               if(FirstStrip==256                                )Overlapping=true;
-               if(FirstStrip==384                                )Overlapping=true;
-               if(FirstStrip==512                                )Overlapping=true;
-               if(FirstStrip==640                                )Overlapping=true;
-
-               if(FirstStrip<=127 && FirstStrip+Ampls.size()>127)Overlapping=true;
-               if(FirstStrip<=255 && FirstStrip+Ampls.size()>255)Overlapping=true;
-               if(FirstStrip<=383 && FirstStrip+Ampls.size()>383)Overlapping=true;
-               if(FirstStrip<=511 && FirstStrip+Ampls.size()>511)Overlapping=true;
-               if(FirstStrip<=639 && FirstStrip+Ampls.size()>639)Overlapping=true;
-
-               if(FirstStrip+Ampls.size()==127                   )Overlapping=true;
-               if(FirstStrip+Ampls.size()==255                   )Overlapping=true;
-               if(FirstStrip+Ampls.size()==383                   )Overlapping=true;
-               if(FirstStrip+Ampls.size()==511                   )Overlapping=true;
-               if(FirstStrip+Ampls.size()==639                   )Overlapping=true;
-               if(FirstStrip+Ampls.size()==767                   )Overlapping=true;
-            }else if(PixelCluster){
-               const auto&             Ampls          = PixelCluster->pixelADC();
-               int                     FirstRow       = PixelCluster->minPixelRow();
-               int                     FirstCol       = PixelCluster->minPixelCol();
-               FirstStrip                             = ((FirstRow/80)<<3 | (FirstCol/52)) * 128; //Hack to save the APVId
-               NStrips                                = 0;
-               Saturation                             = false;
-               Overlapping                            = false;
-
-               for(unsigned int a=0;a<Ampls.size();a++){
-                  Charge+=Ampls[a];
-                  if(Ampls[a] >=254)Saturation =true;
-               }
-            }
-	    #ifdef ExtendedCALIBTree
-	    double ChargeOverPath = (double)Charge / Path ;
-	    #endif
-
-            trackindex    ->push_back( shallow::findTrackIndex(tracks, track) ); 
-            rawid         ->push_back( DetId );         
-            localdirx     ->push_back( trackDirection.x() );
-            localdiry     ->push_back( trackDirection.y() );
-            localdirz     ->push_back( trackDirection.z() );
-            firststrip    ->push_back( FirstStrip );
-            nstrips       ->push_back( NStrips );
-            saturation    ->push_back( Saturation );
-            overlapping   ->push_back( Overlapping );
-            farfromedge   ->push_back( StripCluster ? IsFarFromBorder(&trajState,DetId, &iSetup) : true );
-            charge        ->push_back( Charge );
-            path          ->push_back( Path );
-            #ifdef ExtendedCALIBTree
-            chargeoverpath->push_back( ChargeOverPath );
-            #endif
-            gainused      ->push_back( PrevGain );  
-            gainusedTick  ->push_back( PrevGainTick );  
+          if (gainHandle.isValid()) {
+            PrevGain = gainHandle->getApvGain(APVId, gainHandle->getRange(DetId, 1), 1);
+            PrevGainTick = gainHandle->getApvGain(APVId, gainHandle->getRange(DetId, 0), 1);
           }
-       }
+
+          for (unsigned int a = 0; a < Ampls.size(); a++) {
+            Charge += Ampls[a];
+            if (Ampls[a] >= 254)
+              Saturation = true;
+            amplitude->push_back(Ampls[a]);
+          }
+
+          if (FirstStrip == 0)
+            Overlapping = true;
+          if (FirstStrip == 128)
+            Overlapping = true;
+          if (FirstStrip == 256)
+            Overlapping = true;
+          if (FirstStrip == 384)
+            Overlapping = true;
+          if (FirstStrip == 512)
+            Overlapping = true;
+          if (FirstStrip == 640)
+            Overlapping = true;
+
+          if (FirstStrip <= 127 && FirstStrip + Ampls.size() > 127)
+            Overlapping = true;
+          if (FirstStrip <= 255 && FirstStrip + Ampls.size() > 255)
+            Overlapping = true;
+          if (FirstStrip <= 383 && FirstStrip + Ampls.size() > 383)
+            Overlapping = true;
+          if (FirstStrip <= 511 && FirstStrip + Ampls.size() > 511)
+            Overlapping = true;
+          if (FirstStrip <= 639 && FirstStrip + Ampls.size() > 639)
+            Overlapping = true;
+
+          if (FirstStrip + Ampls.size() == 127)
+            Overlapping = true;
+          if (FirstStrip + Ampls.size() == 255)
+            Overlapping = true;
+          if (FirstStrip + Ampls.size() == 383)
+            Overlapping = true;
+          if (FirstStrip + Ampls.size() == 511)
+            Overlapping = true;
+          if (FirstStrip + Ampls.size() == 639)
+            Overlapping = true;
+          if (FirstStrip + Ampls.size() == 767)
+            Overlapping = true;
+        } else if (PixelCluster) {
+          const auto& Ampls = PixelCluster->pixelADC();
+          int FirstRow = PixelCluster->minPixelRow();
+          int FirstCol = PixelCluster->minPixelCol();
+          FirstStrip = ((FirstRow / 80) << 3 | (FirstCol / 52)) * 128;  //Hack to save the APVId
+          NStrips = 0;
+          Saturation = false;
+          Overlapping = false;
+
+          for (unsigned int a = 0; a < Ampls.size(); a++) {
+            Charge += Ampls[a];
+            if (Ampls[a] >= 254)
+              Saturation = true;
+          }
+        }
+#ifdef ExtendedCALIBTree
+        double ChargeOverPath = (double)Charge / Path;
+#endif
+
+        trackindex->push_back(shallow::findTrackIndex(tracks, track));
+        rawid->push_back(DetId);
+        localdirx->push_back(trackDirection.x());
+        localdiry->push_back(trackDirection.y());
+        localdirz->push_back(trackDirection.z());
+        firststrip->push_back(FirstStrip);
+        nstrips->push_back(NStrips);
+        saturation->push_back(Saturation);
+        overlapping->push_back(Overlapping);
+        farfromedge->push_back(StripCluster ? IsFarFromBorder(&trajState, DetId, &iSetup) : true);
+        charge->push_back(Charge);
+        path->push_back(Path);
+#ifdef ExtendedCALIBTree
+        chargeoverpath->push_back(ChargeOverPath);
+#endif
+        gainused->push_back(PrevGain);
+        gainusedTick->push_back(PrevGainTick);
+      }
+    }
   }
 
-  iEvent.put(std::move(trackindex),    Prefix + "trackindex"    + Suffix );
-  iEvent.put(std::move(rawid     ),    Prefix + "rawid"         + Suffix );
-  iEvent.put(std::move(localdirx ),    Prefix + "localdirx"     + Suffix );
-  iEvent.put(std::move(localdiry ),    Prefix + "localdiry"     + Suffix );
-  iEvent.put(std::move(localdirz ),    Prefix + "localdirz"     + Suffix );
-  iEvent.put(std::move(firststrip),    Prefix + "firststrip"    + Suffix );
-  iEvent.put(std::move(nstrips),       Prefix + "nstrips"       + Suffix );
-  iEvent.put(std::move(saturation),    Prefix + "saturation"    + Suffix );
-  iEvent.put(std::move(overlapping),   Prefix + "overlapping"   + Suffix );
-  iEvent.put(std::move(farfromedge),   Prefix + "farfromedge"   + Suffix );
-  iEvent.put(std::move(charge),        Prefix + "charge"        + Suffix );
-  iEvent.put(std::move(path),          Prefix + "path"          + Suffix );
-  #ifdef ExtendedCALIBTree
-  iEvent.put(std::move(chargeoverpath),Prefix + "chargeoverpath"+ Suffix );
-  #endif
-  iEvent.put(std::move(amplitude),     Prefix + "amplitude"     + Suffix );
-  iEvent.put(std::move(gainused),      Prefix + "gainused"      + Suffix );
-  iEvent.put(std::move(gainusedTick),  Prefix + "gainusedTick"  + Suffix );
+  iEvent.put(std::move(trackindex), Prefix + "trackindex" + Suffix);
+  iEvent.put(std::move(rawid), Prefix + "rawid" + Suffix);
+  iEvent.put(std::move(localdirx), Prefix + "localdirx" + Suffix);
+  iEvent.put(std::move(localdiry), Prefix + "localdiry" + Suffix);
+  iEvent.put(std::move(localdirz), Prefix + "localdirz" + Suffix);
+  iEvent.put(std::move(firststrip), Prefix + "firststrip" + Suffix);
+  iEvent.put(std::move(nstrips), Prefix + "nstrips" + Suffix);
+  iEvent.put(std::move(saturation), Prefix + "saturation" + Suffix);
+  iEvent.put(std::move(overlapping), Prefix + "overlapping" + Suffix);
+  iEvent.put(std::move(farfromedge), Prefix + "farfromedge" + Suffix);
+  iEvent.put(std::move(charge), Prefix + "charge" + Suffix);
+  iEvent.put(std::move(path), Prefix + "path" + Suffix);
+#ifdef ExtendedCALIBTree
+  iEvent.put(std::move(chargeoverpath), Prefix + "chargeoverpath" + Suffix);
+#endif
+  iEvent.put(std::move(amplitude), Prefix + "amplitude" + Suffix);
+  iEvent.put(std::move(gainused), Prefix + "gainused" + Suffix);
+  iEvent.put(std::move(gainusedTick), Prefix + "gainusedTick" + Suffix);
 }
 
 /*
@@ -262,62 +288,62 @@ void ShallowGainCalibration::beginRun(edm::Run &, const edm::EventSetup &iSetup)
 }
 */
 
-bool ShallowGainCalibration::IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup)
-{ 
-  edm::ESHandle<TrackerGeometry> tkGeom; iSetup->get<TrackerDigiGeometryRecord>().get( tkGeom );
+bool ShallowGainCalibration::IsFarFromBorder(TrajectoryStateOnSurface* trajState,
+                                             const uint32_t detid,
+                                             const edm::EventSetup* iSetup) {
+  edm::ESHandle<TrackerGeometry> tkGeom;
+  iSetup->get<TrackerDigiGeometryRecord>().get(tkGeom);
 
-  LocalPoint  HitLocalPos   = trajState->localPosition();
-  LocalError  HitLocalError = trajState->localError().positionError() ;
+  LocalPoint HitLocalPos = trajState->localPosition();
+  LocalError HitLocalError = trajState->localError().positionError();
 
   const GeomDetUnit* it = tkGeom->idToDetUnit(DetId(detid));
-  if (dynamic_cast<const StripGeomDetUnit*>(it)==nullptr && dynamic_cast<const PixelGeomDetUnit*>(it)==nullptr) {
-     std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
-     return false;
+  if (dynamic_cast<const StripGeomDetUnit*>(it) == nullptr && dynamic_cast<const PixelGeomDetUnit*>(it) == nullptr) {
+    std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
+    return false;
   }
 
   const BoundPlane plane = it->surface();
-  const TrapezoidalPlaneBounds* trapezoidalBounds( dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
-  const RectangularPlaneBounds* rectangularBounds( dynamic_cast<const RectangularPlaneBounds*>(&(plane.bounds())));
+  const TrapezoidalPlaneBounds* trapezoidalBounds(dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
+  const RectangularPlaneBounds* rectangularBounds(dynamic_cast<const RectangularPlaneBounds*>(&(plane.bounds())));
 
-  double DistFromBorder = 1.0;    
-  double HalfLength     = it->surface().bounds().length() /2.0;
+  double DistFromBorder = 1.0;
+  double HalfLength = it->surface().bounds().length() / 2.0;
 
-  if(trapezoidalBounds)
-  {
-      std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters();
-     HalfLength     = parameters[3];
-  }else if(rectangularBounds){
-     HalfLength     = it->surface().bounds().length() /2.0;
-  }else{return false;}
+  if (trapezoidalBounds) {
+    std::array<const float, 4> const& parameters = (*trapezoidalBounds).parameters();
+    HalfLength = parameters[3];
+  } else if (rectangularBounds) {
+    HalfLength = it->surface().bounds().length() / 2.0;
+  } else {
+    return false;
+  }
 
-  if (fabs(HitLocalPos.y())+HitLocalError.yy() >= (HalfLength - DistFromBorder) ) return false;
+  if (fabs(HitLocalPos.y()) + HitLocalError.yy() >= (HalfLength - DistFromBorder))
+    return false;
 
   return true;
 }
 
-
-double ShallowGainCalibration::thickness(DetId id)
-{
- map<DetId,double>::iterator th=m_thicknessMap.find(id);
- if(th!=m_thicknessMap.end())
-   return (*th).second;
- else {
-   double detThickness=1.;
-   //compute thickness normalization
-   const GeomDetUnit* it = m_tracker->idToDetUnit(DetId(id));
-   bool isPixel = dynamic_cast<const PixelGeomDetUnit*>(it)!=nullptr;
-   bool isStrip = dynamic_cast<const StripGeomDetUnit*>(it)!=nullptr;
-   if (!isPixel && ! isStrip) {
-   //FIXME throw exception
+double ShallowGainCalibration::thickness(DetId id) {
+  map<DetId, double>::iterator th = m_thicknessMap.find(id);
+  if (th != m_thicknessMap.end())
+    return (*th).second;
+  else {
+    double detThickness = 1.;
+    //compute thickness normalization
+    const GeomDetUnit* it = m_tracker->idToDetUnit(DetId(id));
+    bool isPixel = dynamic_cast<const PixelGeomDetUnit*>(it) != nullptr;
+    bool isStrip = dynamic_cast<const StripGeomDetUnit*>(it) != nullptr;
+    if (!isPixel && !isStrip) {
+      //FIXME throw exception
       edm::LogWarning("DeDxHitsProducer") << "\t\t this detID doesn't seem to belong to the Tracker";
       detThickness = 1.;
-  }else{
+    } else {
       detThickness = it->surface().bounds().thickness();
+    }
+
+    m_thicknessMap[id] = detThickness;  //computed value
+    return detThickness;
   }
-
-   m_thicknessMap[id]=detThickness;//computed value
-   return detThickness;
- }
-
 }
-

--- a/CalibTracker/SiStripCommon/plugins/ShallowRechitClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowRechitClustersProducer.cc
@@ -11,77 +11,77 @@
 #include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
 
 ShallowRechitClustersProducer::ShallowRechitClustersProducer(const edm::ParameterSet& iConfig)
-  :  Suffix       ( iConfig.getParameter<std::string>("Suffix") ),
-     Prefix       ( iConfig.getParameter<std::string>("Prefix") ),
-     clusters_token_( consumes< edmNew::DetSetVector<SiStripCluster> >(iConfig.getParameter<edm::InputTag>("Clusters")))
-{
-	std::vector<edm::InputTag> rec_hits_tags = iConfig.getParameter<std::vector<edm::InputTag> >("InputTags");
-	for(auto itag : rec_hits_tags) {
-		rec_hits_tokens_.push_back(
-			consumes< SiStripRecHit2DCollection >(itag)
-			);
-	}
+    : Suffix(iConfig.getParameter<std::string>("Suffix")),
+      Prefix(iConfig.getParameter<std::string>("Prefix")),
+      clusters_token_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"))) {
+  std::vector<edm::InputTag> rec_hits_tags = iConfig.getParameter<std::vector<edm::InputTag>>("InputTags");
+  for (auto itag : rec_hits_tags) {
+    rec_hits_tokens_.push_back(consumes<SiStripRecHit2DCollection>(itag));
+  }
 
-  produces <std::vector<float> >        ( Prefix + "strip"      + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "merr"       + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "localx"     + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "localy"     + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "localxerr"  + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "localyerr"  + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "globalx"    + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "globaly"    + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "globalz"    + Suffix );   
+  produces<std::vector<float>>(Prefix + "strip" + Suffix);
+  produces<std::vector<float>>(Prefix + "merr" + Suffix);
+  produces<std::vector<float>>(Prefix + "localx" + Suffix);
+  produces<std::vector<float>>(Prefix + "localy" + Suffix);
+  produces<std::vector<float>>(Prefix + "localxerr" + Suffix);
+  produces<std::vector<float>>(Prefix + "localyerr" + Suffix);
+  produces<std::vector<float>>(Prefix + "globalx" + Suffix);
+  produces<std::vector<float>>(Prefix + "globaly" + Suffix);
+  produces<std::vector<float>>(Prefix + "globalz" + Suffix);
 }
 
-void ShallowRechitClustersProducer::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  shallow::CLUSTERMAP clustermap = shallow::make_cluster_map(iEvent, clusters_token_); 
+void ShallowRechitClustersProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  shallow::CLUSTERMAP clustermap = shallow::make_cluster_map(iEvent, clusters_token_);
 
   int size = clustermap.size();
-  auto  strip       = std::make_unique <std::vector<float>>(size,  -10000  );   
-  auto  merr        = std::make_unique <std::vector<float>>(size,  -10000  );   
-  auto  localx      = std::make_unique <std::vector<float>>(size,  -10000  );   
-  auto  localy      = std::make_unique <std::vector<float>>(size,  -10000  );   
-  auto  localxerr   = std::make_unique <std::vector<float>>(size,  -1  );   
-  auto  localyerr   = std::make_unique <std::vector<float>>(size,  -1  );     
-  auto  globalx     = std::make_unique <std::vector<float>>(size,  -10000  );   
-  auto  globaly     = std::make_unique <std::vector<float>>(size,  -10000  );   
-  auto  globalz     = std::make_unique <std::vector<float>>(size,  -10000  );   
+  auto strip = std::make_unique<std::vector<float>>(size, -10000);
+  auto merr = std::make_unique<std::vector<float>>(size, -10000);
+  auto localx = std::make_unique<std::vector<float>>(size, -10000);
+  auto localy = std::make_unique<std::vector<float>>(size, -10000);
+  auto localxerr = std::make_unique<std::vector<float>>(size, -1);
+  auto localyerr = std::make_unique<std::vector<float>>(size, -1);
+  auto globalx = std::make_unique<std::vector<float>>(size, -10000);
+  auto globaly = std::make_unique<std::vector<float>>(size, -10000);
+  auto globalz = std::make_unique<std::vector<float>>(size, -10000);
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry; iSetup.get<TrackerDigiGeometryRecord>().get( theTrackerGeometry );
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
 
-	for(auto recHit_token : rec_hits_tokens_) {
-		edm::Handle<SiStripRecHit2DCollection> recHits; 
-		iEvent.getByToken(recHit_token, recHits);
-    for(auto const& ds : *recHits) {
-      for(auto const& hit : ds) {
-	
-				shallow::CLUSTERMAP::iterator cluster = clustermap.find( std::make_pair(hit.geographicalId().rawId(), hit.cluster()->firstStrip()   ) );
-				if(cluster != clustermap.end() ) {
-					const StripGeomDetUnit* theStripDet = dynamic_cast<const StripGeomDetUnit*>( theTrackerGeometry->idToDet( hit.geographicalId() ) );
-					unsigned int i = cluster->second;
-					strip->at(i)  =    theStripDet->specificTopology().strip(hit.localPosition());
-					merr->at(i)   =    sqrt(theStripDet->specificTopology().measurementError(hit.localPosition(), hit.localPositionError()).uu());
-					localx->at(i) =    hit.localPosition().x();
-					localy->at(i) =    hit.localPosition().y();
-					localxerr->at(i) = sqrt(hit.localPositionError().xx());
-					localyerr->at(i) = sqrt(hit.localPositionError().yy());
-					globalx->at(i) =   theStripDet->toGlobal(hit.localPosition()).x();
-					globaly->at(i) =   theStripDet->toGlobal(hit.localPosition()).y();
-					globalz->at(i) =   theStripDet->toGlobal(hit.localPosition()).z();
-				}
-				else {throw cms::Exception("cluster not found");}
+  for (auto recHit_token : rec_hits_tokens_) {
+    edm::Handle<SiStripRecHit2DCollection> recHits;
+    iEvent.getByToken(recHit_token, recHits);
+    for (auto const& ds : *recHits) {
+      for (auto const& hit : ds) {
+        shallow::CLUSTERMAP::iterator cluster =
+            clustermap.find(std::make_pair(hit.geographicalId().rawId(), hit.cluster()->firstStrip()));
+        if (cluster != clustermap.end()) {
+          const StripGeomDetUnit* theStripDet =
+              dynamic_cast<const StripGeomDetUnit*>(theTrackerGeometry->idToDet(hit.geographicalId()));
+          unsigned int i = cluster->second;
+          strip->at(i) = theStripDet->specificTopology().strip(hit.localPosition());
+          merr->at(i) = sqrt(
+              theStripDet->specificTopology().measurementError(hit.localPosition(), hit.localPositionError()).uu());
+          localx->at(i) = hit.localPosition().x();
+          localy->at(i) = hit.localPosition().y();
+          localxerr->at(i) = sqrt(hit.localPositionError().xx());
+          localyerr->at(i) = sqrt(hit.localPositionError().yy());
+          globalx->at(i) = theStripDet->toGlobal(hit.localPosition()).x();
+          globaly->at(i) = theStripDet->toGlobal(hit.localPosition()).y();
+          globalz->at(i) = theStripDet->toGlobal(hit.localPosition()).z();
+        } else {
+          throw cms::Exception("cluster not found");
+        }
       }
     }
   }
-  
-  iEvent.put(std::move(strip),      Prefix + "strip"      + Suffix );   
-  iEvent.put(std::move(merr),       Prefix + "merr"       + Suffix );   
-  iEvent.put(std::move(localx),     Prefix + "localx"     + Suffix );   
-  iEvent.put(std::move(localy),     Prefix + "localy"     + Suffix );   
-  iEvent.put(std::move(localxerr),  Prefix + "localxerr"  + Suffix );   
-  iEvent.put(std::move(localyerr),  Prefix + "localyerr"  + Suffix );   
-  iEvent.put(std::move(globalx),    Prefix + "globalx"    + Suffix );   
-  iEvent.put(std::move(globaly),    Prefix + "globaly"    + Suffix );   
-  iEvent.put(std::move(globalz),    Prefix + "globalz"    + Suffix );   
+
+  iEvent.put(std::move(strip), Prefix + "strip" + Suffix);
+  iEvent.put(std::move(merr), Prefix + "merr" + Suffix);
+  iEvent.put(std::move(localx), Prefix + "localx" + Suffix);
+  iEvent.put(std::move(localy), Prefix + "localy" + Suffix);
+  iEvent.put(std::move(localxerr), Prefix + "localxerr" + Suffix);
+  iEvent.put(std::move(localyerr), Prefix + "localyerr" + Suffix);
+  iEvent.put(std::move(globalx), Prefix + "globalx" + Suffix);
+  iEvent.put(std::move(globaly), Prefix + "globaly" + Suffix);
+  iEvent.put(std::move(globalz), Prefix + "globalz" + Suffix);
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.cc
@@ -8,71 +8,71 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-ShallowSimTracksProducer::ShallowSimTracksProducer(const edm::ParameterSet& conf) 
-  : Prefix( conf.getParameter<std::string>("Prefix") ),
-    Suffix( conf.getParameter<std::string>("Suffix") ),
-    trackingParticles_token_(consumes<TrackingParticleCollection>(conf.getParameter<edm::InputTag>("TrackingParticles"))),
-    associator_token_( consumes<reco::TrackToTrackingParticleAssociator>(conf.getParameter<edm::InputTag>("Associator"))),
-    tracks_token_(consumes<edm::View<reco::Track> >(conf.getParameter<edm::InputTag>("Tracks")))
-{
-  produces <std::vector<unsigned> >     ( Prefix + "multi"      + Suffix );
-  produces <std::vector<int> >          ( Prefix + "type"      + Suffix );
-  produces <std::vector<float> >        ( Prefix + "charge"    + Suffix );
-  produces <std::vector<float> >        ( Prefix + "momentum"  + Suffix );
-  produces <std::vector<float> >        ( Prefix + "pt"        + Suffix );
-  produces <std::vector<double> >       ( Prefix + "theta"     + Suffix );
-  produces <std::vector<double> >       ( Prefix + "phi"       + Suffix );
-  produces <std::vector<double> >       ( Prefix + "eta"       + Suffix );
-  produces <std::vector<double> >       ( Prefix + "qoverp"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "vx"        + Suffix );
-  produces <std::vector<double> >       ( Prefix + "vy"        + Suffix );
-  produces <std::vector<double> >       ( Prefix + "vz"        + Suffix );
+ShallowSimTracksProducer::ShallowSimTracksProducer(const edm::ParameterSet& conf)
+    : Prefix(conf.getParameter<std::string>("Prefix")),
+      Suffix(conf.getParameter<std::string>("Suffix")),
+      trackingParticles_token_(
+          consumes<TrackingParticleCollection>(conf.getParameter<edm::InputTag>("TrackingParticles"))),
+      associator_token_(
+          consumes<reco::TrackToTrackingParticleAssociator>(conf.getParameter<edm::InputTag>("Associator"))),
+      tracks_token_(consumes<edm::View<reco::Track>>(conf.getParameter<edm::InputTag>("Tracks"))) {
+  produces<std::vector<unsigned>>(Prefix + "multi" + Suffix);
+  produces<std::vector<int>>(Prefix + "type" + Suffix);
+  produces<std::vector<float>>(Prefix + "charge" + Suffix);
+  produces<std::vector<float>>(Prefix + "momentum" + Suffix);
+  produces<std::vector<float>>(Prefix + "pt" + Suffix);
+  produces<std::vector<double>>(Prefix + "theta" + Suffix);
+  produces<std::vector<double>>(Prefix + "phi" + Suffix);
+  produces<std::vector<double>>(Prefix + "eta" + Suffix);
+  produces<std::vector<double>>(Prefix + "qoverp" + Suffix);
+  produces<std::vector<double>>(Prefix + "vx" + Suffix);
+  produces<std::vector<double>>(Prefix + "vy" + Suffix);
+  produces<std::vector<double>>(Prefix + "vz" + Suffix);
 }
 
-
-void ShallowSimTracksProducer::
-produce(edm::Event& event, const edm::EventSetup& setup) {
-
-  edm::Handle<edm::View<reco::Track> >                     tracks ;   event.getByToken(tracks_token_, tracks);
-  edm::Handle<TrackingParticleCollection>       trackingParticles ;   event.getByToken(trackingParticles_token_, trackingParticles );  
-  edm::Handle<reco::TrackToTrackingParticleAssociator> associator ;   event.getByToken(associator_token_, associator);
+void ShallowSimTracksProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  edm::Handle<edm::View<reco::Track>> tracks;
+  event.getByToken(tracks_token_, tracks);
+  edm::Handle<TrackingParticleCollection> trackingParticles;
+  event.getByToken(trackingParticles_token_, trackingParticles);
+  edm::Handle<reco::TrackToTrackingParticleAssociator> associator;
+  event.getByToken(associator_token_, associator);
 
   unsigned size = tracks->size();
-  auto   multi        = std::make_unique<std::vector<unsigned>>(size,    0);
-  auto   type         = std::make_unique<std::vector<int>>     (size,    0);
-  auto   charge       = std::make_unique<std::vector<float>>   (size,    0);
-  auto   momentum     = std::make_unique<std::vector<float>>   (size,   -1);
-  auto   pt           = std::make_unique<std::vector<float>>   (size,   -1);
-  auto   theta        = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   phi          = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   eta          = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   dxy          = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   dsz          = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   qoverp       = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   vx           = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   vy           = std::make_unique<std::vector<double>>  (size,-1000);
-  auto   vz           = std::make_unique<std::vector<double>>  (size,-1000);
+  auto multi = std::make_unique<std::vector<unsigned>>(size, 0);
+  auto type = std::make_unique<std::vector<int>>(size, 0);
+  auto charge = std::make_unique<std::vector<float>>(size, 0);
+  auto momentum = std::make_unique<std::vector<float>>(size, -1);
+  auto pt = std::make_unique<std::vector<float>>(size, -1);
+  auto theta = std::make_unique<std::vector<double>>(size, -1000);
+  auto phi = std::make_unique<std::vector<double>>(size, -1000);
+  auto eta = std::make_unique<std::vector<double>>(size, -1000);
+  auto dxy = std::make_unique<std::vector<double>>(size, -1000);
+  auto dsz = std::make_unique<std::vector<double>>(size, -1000);
+  auto qoverp = std::make_unique<std::vector<double>>(size, -1000);
+  auto vx = std::make_unique<std::vector<double>>(size, -1000);
+  auto vy = std::make_unique<std::vector<double>>(size, -1000);
+  auto vz = std::make_unique<std::vector<double>>(size, -1000);
 
-  reco::RecoToSimCollection associations = associator->associateRecoToSim( tracks, trackingParticles);
-  
-  for( reco::RecoToSimCollection::const_iterator association = associations.begin(); 
-       association != associations.end(); association++) {
+  reco::RecoToSimCollection associations = associator->associateRecoToSim(tracks, trackingParticles);
 
+  for (reco::RecoToSimCollection::const_iterator association = associations.begin(); association != associations.end();
+       association++) {
     const reco::Track* track = association->key.get();
-    const int matches        = association->val.size();
-    if(matches>0) {
+    const int matches = association->val.size();
+    if (matches > 0) {
       const TrackingParticle* tparticle = association->val[0].first.get();
       unsigned i = shallow::findTrackIndex(tracks, track);
 
       multi->at(i) = matches;
-      type->at(i)  = tparticle->pdgId();
-      charge->at(i)= tparticle->charge();
-      momentum->at(i)=tparticle->p() ;
-      pt->at(i) = tparticle->pt()    ;
-      theta->at(i) = tparticle->theta() ;
-      phi->at(i)   = tparticle->phi()   ;
-      eta->at(i)   = tparticle->eta()   ;
-      qoverp->at(i)= tparticle->charge()/tparticle->p();
+      type->at(i) = tparticle->pdgId();
+      charge->at(i) = tparticle->charge();
+      momentum->at(i) = tparticle->p();
+      pt->at(i) = tparticle->pt();
+      theta->at(i) = tparticle->theta();
+      phi->at(i) = tparticle->phi();
+      eta->at(i) = tparticle->eta();
+      qoverp->at(i) = tparticle->charge() / tparticle->p();
 
       const TrackingVertex* tvertex = tparticle->parentVertex().get();
       vx->at(i) = tvertex->position().x();
@@ -80,18 +80,17 @@ produce(edm::Event& event, const edm::EventSetup& setup) {
       vz->at(i) = tvertex->position().z();
     }
   }
-  
-  event.put(std::move(multi   ), Prefix + "multi"     + Suffix );
-  event.put(std::move(type    ), Prefix + "type"      + Suffix );
-  event.put(std::move(charge  ), Prefix + "charge"    + Suffix );
-  event.put(std::move(momentum), Prefix + "momentum"  + Suffix );
-  event.put(std::move(pt      ), Prefix + "pt"        + Suffix );
-  event.put(std::move(theta   ), Prefix + "theta"     + Suffix );
-  event.put(std::move(phi     ), Prefix + "phi"       + Suffix );
-  event.put(std::move(eta     ), Prefix + "eta"       + Suffix );
-  event.put(std::move(qoverp  ), Prefix + "qoverp"    + Suffix );
-  event.put(std::move(vx      ), Prefix + "vx"        + Suffix );
-  event.put(std::move(vy      ), Prefix + "vy"        + Suffix );
-  event.put(std::move(vz      ), Prefix + "vz"        + Suffix );
-  
+
+  event.put(std::move(multi), Prefix + "multi" + Suffix);
+  event.put(std::move(type), Prefix + "type" + Suffix);
+  event.put(std::move(charge), Prefix + "charge" + Suffix);
+  event.put(std::move(momentum), Prefix + "momentum" + Suffix);
+  event.put(std::move(pt), Prefix + "pt" + Suffix);
+  event.put(std::move(theta), Prefix + "theta" + Suffix);
+  event.put(std::move(phi), Prefix + "phi" + Suffix);
+  event.put(std::move(eta), Prefix + "eta" + Suffix);
+  event.put(std::move(qoverp), Prefix + "qoverp" + Suffix);
+  event.put(std::move(vx), Prefix + "vx" + Suffix);
+  event.put(std::move(vy), Prefix + "vy" + Suffix);
+  event.put(std::move(vz), Prefix + "vz" + Suffix);
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimTracksProducer.h
@@ -10,19 +10,15 @@
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
 class ShallowSimTracksProducer : public edm::EDProducer {
+public:
+  explicit ShallowSimTracksProducer(const edm::ParameterSet &);
 
- public:
-
-  explicit ShallowSimTracksProducer(const edm::ParameterSet&);
-
- private:
-
+private:
   const std::string Prefix;
   const std::string Suffix;
   const edm::EDGetTokenT<TrackingParticleCollection> trackingParticles_token_;
   const edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> associator_token_;
-	const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
-  void produce( edm::Event &, const edm::EventSetup & ) override;
-
+  const edm::EDGetTokenT<edm::View<reco::Track> > tracks_token_;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 };
 #endif

--- a/CalibTracker/SiStripCommon/plugins/ShallowSimhitClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowSimhitClustersProducer.cc
@@ -16,119 +16,120 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 ShallowSimhitClustersProducer::ShallowSimhitClustersProducer(const edm::ParameterSet& iConfig)
-  : clusters_token_( consumes< edmNew::DetSetVector<SiStripCluster> >(iConfig.getParameter<edm::InputTag>("Clusters"))),
-    Prefix( iConfig.getParameter<std::string>("Prefix") ),
-		runningmode_( iConfig.getParameter<std::string>("runningMode") )
-{
-	std::vector<edm::InputTag> simhits_tags = iConfig.getParameter<std::vector<edm::InputTag> >("InputTags");
-	for(auto itag : simhits_tags) {
-		simhits_tokens_.push_back(
-			consumes< std::vector<PSimHit> >(itag)
-			);
-	}
-
-  produces <std::vector<unsigned> >      ( Prefix + "hits"       );
-  produces <std::vector<float> >         ( Prefix + "strip"      );
-  produces <std::vector<float> >         ( Prefix + "localtheta" );
-  produces <std::vector<float> >         ( Prefix + "localphi"   );
-  produces <std::vector<float> >         ( Prefix + "localx"     );
-  produces <std::vector<float> >         ( Prefix + "localy"     );
-  produces <std::vector<float> >         ( Prefix + "localz"     );
-  produces <std::vector<float> >         ( Prefix + "momentum"   );
-  produces <std::vector<float> >         ( Prefix + "energyloss" );
-  produces <std::vector<float> >         ( Prefix + "time"       );
-  produces <std::vector<int> >            ( Prefix + "particle"   );
-  produces <std::vector<unsigned short> > ( Prefix + "process"    );
-}	      
-
-void ShallowSimhitClustersProducer::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  shallow::CLUSTERMAP clustermap = shallow::make_cluster_map(iEvent,clusters_token_);
-
-  int size = clustermap.size();
-  auto          hits         = std::make_unique <std::vector<unsigned>>       (size, 0);
-  auto          strip        = std::make_unique <std::vector<float>>          (size, -100);
-  auto          localtheta   = std::make_unique <std::vector<float>>          (size, -100);
-  auto          localphi     = std::make_unique <std::vector<float>>          (size, -100);
-  auto          localx       = std::make_unique <std::vector<float>>          (size, -100);
-  auto          localy       = std::make_unique <std::vector<float>>          (size, -100);
-  auto          localz       = std::make_unique <std::vector<float>>          (size, -100);
-  auto          momentum     = std::make_unique <std::vector<float>>          (size, 0);
-  auto          energyloss   = std::make_unique <std::vector<float>>          (size, -1);
-  auto          time         = std::make_unique <std::vector<float>>          (size, -1);
-  auto          particle     = std::make_unique <std::vector<int>>            (size, -500);
-  auto          process      = std::make_unique <std::vector<unsigned short>> (size, 0);
-
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;         iSetup.get<TrackerDigiGeometryRecord>().get( theTrackerGeometry );  
-  edm::ESHandle<MagneticField> magfield;		     iSetup.get<IdealMagneticFieldRecord>().get(magfield);		      
-  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle;    iSetup.get<SiStripLorentzAngleRcd>().get(runningmode_, SiStripLorentzAngle);      
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusters;  iEvent.getByLabel("siStripClusters", "", clusters);
-
-	for(auto& simhit_token : simhits_tokens_) {
-		edm::Handle< std::vector<PSimHit> > simhits; 
-		iEvent.getByToken(simhit_token, simhits);
-    for(auto const& hit : *simhits ) {
-      
-      const uint32_t id = hit.detUnitId();
-      const StripGeomDetUnit* theStripDet = dynamic_cast<const StripGeomDetUnit*>( theTrackerGeometry->idToDet( id ) );
-      const LocalVector drift = shallow::drift(theStripDet, *magfield, *SiStripLorentzAngle);
-
-      const float driftedstrip_ = theStripDet->specificTopology().strip( hit.localPosition()+0.5*drift );
-      const float     hitstrip_ = theStripDet->specificTopology().strip( hit.localPosition()           );
-
-      shallow::CLUSTERMAP::const_iterator cluster = match_cluster( id, driftedstrip_, clustermap, *clusters); 
-      if(cluster != clustermap.end()) {
-				unsigned i = cluster->second;
-				hits->at(i)+=1;
-				if(hits->at(i) == 1) {
-					strip->at(i) = hitstrip_;
-					localtheta->at(i) = hit.thetaAtEntry();
-					localphi->at(i) = hit.phiAtEntry();
-					localx->at(i) = hit.localPosition().x();
-					localy->at(i) = hit.localPosition().y();
-					localz->at(i) = hit.localPosition().z();
-					momentum->at(i) = hit.pabs();
-					energyloss->at(i) = hit.energyLoss();
-					time->at(i) = hit.timeOfFlight();
-					particle->at(i) = hit.particleType();
-					process->at(i) = hit.processType();
-				}
-      }    
-    } 
+    : clusters_token_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"))),
+      Prefix(iConfig.getParameter<std::string>("Prefix")),
+      runningmode_(iConfig.getParameter<std::string>("runningMode")) {
+  std::vector<edm::InputTag> simhits_tags = iConfig.getParameter<std::vector<edm::InputTag>>("InputTags");
+  for (auto itag : simhits_tags) {
+    simhits_tokens_.push_back(consumes<std::vector<PSimHit>>(itag));
   }
 
-  iEvent.put(std::move(hits),        Prefix + "hits"      );
-  iEvent.put(std::move(strip),       Prefix + "strip"      );
-  iEvent.put(std::move(localtheta),  Prefix + "localtheta" );
-  iEvent.put(std::move(localphi),    Prefix + "localphi" );
-  iEvent.put(std::move(localx),      Prefix + "localx" );
-  iEvent.put(std::move(localy),      Prefix + "localy" );
-  iEvent.put(std::move(localz),      Prefix + "localz" );
-  iEvent.put(std::move(momentum),    Prefix + "momentum" );
-  iEvent.put(std::move(energyloss),  Prefix + "energyloss" );
-  iEvent.put(std::move(time),        Prefix + "time" );
-  iEvent.put(std::move(particle),    Prefix + "particle" );
-  iEvent.put(std::move(process),     Prefix + "process" );
+  produces<std::vector<unsigned>>(Prefix + "hits");
+  produces<std::vector<float>>(Prefix + "strip");
+  produces<std::vector<float>>(Prefix + "localtheta");
+  produces<std::vector<float>>(Prefix + "localphi");
+  produces<std::vector<float>>(Prefix + "localx");
+  produces<std::vector<float>>(Prefix + "localy");
+  produces<std::vector<float>>(Prefix + "localz");
+  produces<std::vector<float>>(Prefix + "momentum");
+  produces<std::vector<float>>(Prefix + "energyloss");
+  produces<std::vector<float>>(Prefix + "time");
+  produces<std::vector<int>>(Prefix + "particle");
+  produces<std::vector<unsigned short>>(Prefix + "process");
 }
 
-shallow::CLUSTERMAP::const_iterator ShallowSimhitClustersProducer::
-match_cluster( const unsigned& id, const float& strip_, const shallow::CLUSTERMAP& clustermap, const edmNew::DetSetVector<SiStripCluster>& clusters) const {
+void ShallowSimhitClustersProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  shallow::CLUSTERMAP clustermap = shallow::make_cluster_map(iEvent, clusters_token_);
+
+  int size = clustermap.size();
+  auto hits = std::make_unique<std::vector<unsigned>>(size, 0);
+  auto strip = std::make_unique<std::vector<float>>(size, -100);
+  auto localtheta = std::make_unique<std::vector<float>>(size, -100);
+  auto localphi = std::make_unique<std::vector<float>>(size, -100);
+  auto localx = std::make_unique<std::vector<float>>(size, -100);
+  auto localy = std::make_unique<std::vector<float>>(size, -100);
+  auto localz = std::make_unique<std::vector<float>>(size, -100);
+  auto momentum = std::make_unique<std::vector<float>>(size, 0);
+  auto energyloss = std::make_unique<std::vector<float>>(size, -1);
+  auto time = std::make_unique<std::vector<float>>(size, -1);
+  auto particle = std::make_unique<std::vector<int>>(size, -500);
+  auto process = std::make_unique<std::vector<unsigned short>>(size, 0);
+
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  edm::ESHandle<MagneticField> magfield;
+  iSetup.get<IdealMagneticFieldRecord>().get(magfield);
+  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle;
+  iSetup.get<SiStripLorentzAngleRcd>().get(runningmode_, SiStripLorentzAngle);
+  edm::Handle<edmNew::DetSetVector<SiStripCluster>> clusters;
+  iEvent.getByLabel("siStripClusters", "", clusters);
+
+  for (auto& simhit_token : simhits_tokens_) {
+    edm::Handle<std::vector<PSimHit>> simhits;
+    iEvent.getByToken(simhit_token, simhits);
+    for (auto const& hit : *simhits) {
+      const uint32_t id = hit.detUnitId();
+      const StripGeomDetUnit* theStripDet = dynamic_cast<const StripGeomDetUnit*>(theTrackerGeometry->idToDet(id));
+      const LocalVector drift = shallow::drift(theStripDet, *magfield, *SiStripLorentzAngle);
+
+      const float driftedstrip_ = theStripDet->specificTopology().strip(hit.localPosition() + 0.5 * drift);
+      const float hitstrip_ = theStripDet->specificTopology().strip(hit.localPosition());
+
+      shallow::CLUSTERMAP::const_iterator cluster = match_cluster(id, driftedstrip_, clustermap, *clusters);
+      if (cluster != clustermap.end()) {
+        unsigned i = cluster->second;
+        hits->at(i) += 1;
+        if (hits->at(i) == 1) {
+          strip->at(i) = hitstrip_;
+          localtheta->at(i) = hit.thetaAtEntry();
+          localphi->at(i) = hit.phiAtEntry();
+          localx->at(i) = hit.localPosition().x();
+          localy->at(i) = hit.localPosition().y();
+          localz->at(i) = hit.localPosition().z();
+          momentum->at(i) = hit.pabs();
+          energyloss->at(i) = hit.energyLoss();
+          time->at(i) = hit.timeOfFlight();
+          particle->at(i) = hit.particleType();
+          process->at(i) = hit.processType();
+        }
+      }
+    }
+  }
+
+  iEvent.put(std::move(hits), Prefix + "hits");
+  iEvent.put(std::move(strip), Prefix + "strip");
+  iEvent.put(std::move(localtheta), Prefix + "localtheta");
+  iEvent.put(std::move(localphi), Prefix + "localphi");
+  iEvent.put(std::move(localx), Prefix + "localx");
+  iEvent.put(std::move(localy), Prefix + "localy");
+  iEvent.put(std::move(localz), Prefix + "localz");
+  iEvent.put(std::move(momentum), Prefix + "momentum");
+  iEvent.put(std::move(energyloss), Prefix + "energyloss");
+  iEvent.put(std::move(time), Prefix + "time");
+  iEvent.put(std::move(particle), Prefix + "particle");
+  iEvent.put(std::move(process), Prefix + "process");
+}
+
+shallow::CLUSTERMAP::const_iterator ShallowSimhitClustersProducer::match_cluster(
+    const unsigned& id,
+    const float& strip_,
+    const shallow::CLUSTERMAP& clustermap,
+    const edmNew::DetSetVector<SiStripCluster>& clusters) const {
   shallow::CLUSTERMAP::const_iterator cluster = clustermap.end();
   edmNew::DetSetVector<SiStripCluster>::const_iterator clustersDetSet = clusters.find(id);
-  if( clustersDetSet != clusters.end() ) {
-    edmNew::DetSet<SiStripCluster>::const_iterator left, right=clustersDetSet->begin();
-    while( right != clustersDetSet->end() && strip_ > right->barycenter() ) 
+  if (clustersDetSet != clusters.end()) {
+    edmNew::DetSet<SiStripCluster>::const_iterator left, right = clustersDetSet->begin();
+    while (right != clustersDetSet->end() && strip_ > right->barycenter())
       right++;
-    left = right-1;
-    if(right!=clustersDetSet->end() && right!=clustersDetSet->begin()) { 
-      unsigned firstStrip = (right->barycenter()-strip_) < (strip_-left->barycenter()) ? right->firstStrip() : left->firstStrip();
-      cluster = clustermap.find( std::make_pair( id, firstStrip));
-    }
-    else if(right != clustersDetSet->begin())
-      cluster = clustermap.find( std::make_pair( id, left->firstStrip()));
-    else 
-      cluster = clustermap.find( std::make_pair( id, right->firstStrip()));
+    left = right - 1;
+    if (right != clustersDetSet->end() && right != clustersDetSet->begin()) {
+      unsigned firstStrip =
+          (right->barycenter() - strip_) < (strip_ - left->barycenter()) ? right->firstStrip() : left->firstStrip();
+      cluster = clustermap.find(std::make_pair(id, firstStrip));
+    } else if (right != clustersDetSet->begin())
+      cluster = clustermap.find(std::make_pair(id, left->firstStrip()));
+    else
+      cluster = clustermap.find(std::make_pair(id, right->firstStrip()));
   }
   return cluster;
 }
-

--- a/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.cc
@@ -24,244 +24,296 @@
 #include <map>
 
 ShallowTrackClustersProducer::ShallowTrackClustersProducer(const edm::ParameterSet& iConfig)
-  :  tracks_token_(consumes<edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("Tracks"))),
-		 association_token_(consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("Tracks"))),
-     clusters_token_( consumes< edmNew::DetSetVector<SiStripCluster> >( iConfig.getParameter<edm::InputTag>("Clusters") ) ),
-     Suffix       ( iConfig.getParameter<std::string>("Suffix")    ),
-     Prefix       ( iConfig.getParameter<std::string>("Prefix") )
-{
-  produces<std::vector<int> > ( Prefix + "clusterIdx"      + Suffix ); //link: on trk cluster --> general cluster info 
-  produces<std::vector<int> > ( Prefix + "onTrkClusterIdx" + Suffix ); //link: general cluster info --> on track cluster
-	produces <std::vector<int> > ( Prefix + "onTrkClustersBegin" + Suffix ); //link: track --> onTrkInfo (range)
-	produces <std::vector<int> > ( Prefix + "onTrkClustersEnd" + Suffix ); //link: track --> onTrkInfo (range)
-  produces <std::vector<int> > ( Prefix + "trackindex"  + Suffix ); //link: on trk cluster --> track index
+    : tracks_token_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("Tracks"))),
+      association_token_(consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("Tracks"))),
+      clusters_token_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("Clusters"))),
+      Suffix(iConfig.getParameter<std::string>("Suffix")),
+      Prefix(iConfig.getParameter<std::string>("Prefix")) {
+  produces<std::vector<int>>(Prefix + "clusterIdx" + Suffix);          //link: on trk cluster --> general cluster info
+  produces<std::vector<int>>(Prefix + "onTrkClusterIdx" + Suffix);     //link: general cluster info --> on track cluster
+  produces<std::vector<int>>(Prefix + "onTrkClustersBegin" + Suffix);  //link: track --> onTrkInfo (range)
+  produces<std::vector<int>>(Prefix + "onTrkClustersEnd" + Suffix);    //link: track --> onTrkInfo (range)
+  produces<std::vector<int>>(Prefix + "trackindex" + Suffix);          //link: on trk cluster --> track index
 
-  produces <std::vector<unsigned int> > ( Prefix + "trackmulti"  + Suffix );
-  produces <std::vector<float> >        ( Prefix + "localtheta"  + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "localphi"    + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "localpitch"  + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "localx"      + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "localy"      + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "localz"      + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "strip"       + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "globaltheta" + Suffix );  
-  produces <std::vector<float> >        ( Prefix + "globalphi"   + Suffix );
-  produces <std::vector<float> >        ( Prefix + "globalx"     + Suffix );
-  produces <std::vector<float> >        ( Prefix + "globaly"     + Suffix );
-  produces <std::vector<float> >        ( Prefix + "globalz"     + Suffix );
-  produces <std::vector<float> >        ( Prefix + "insidistance"+ Suffix );
-  produces <std::vector<float> >        ( Prefix + "covered"     + Suffix );
-  produces <std::vector<float> >        ( Prefix + "projwidth"   + Suffix );
-  produces <std::vector<float> >        ( Prefix + "BdotY"       + Suffix );
+  produces<std::vector<unsigned int>>(Prefix + "trackmulti" + Suffix);
+  produces<std::vector<float>>(Prefix + "localtheta" + Suffix);
+  produces<std::vector<float>>(Prefix + "localphi" + Suffix);
+  produces<std::vector<float>>(Prefix + "localpitch" + Suffix);
+  produces<std::vector<float>>(Prefix + "localx" + Suffix);
+  produces<std::vector<float>>(Prefix + "localy" + Suffix);
+  produces<std::vector<float>>(Prefix + "localz" + Suffix);
+  produces<std::vector<float>>(Prefix + "strip" + Suffix);
+  produces<std::vector<float>>(Prefix + "globaltheta" + Suffix);
+  produces<std::vector<float>>(Prefix + "globalphi" + Suffix);
+  produces<std::vector<float>>(Prefix + "globalx" + Suffix);
+  produces<std::vector<float>>(Prefix + "globaly" + Suffix);
+  produces<std::vector<float>>(Prefix + "globalz" + Suffix);
+  produces<std::vector<float>>(Prefix + "insidistance" + Suffix);
+  produces<std::vector<float>>(Prefix + "covered" + Suffix);
+  produces<std::vector<float>>(Prefix + "projwidth" + Suffix);
+  produces<std::vector<float>>(Prefix + "BdotY" + Suffix);
 
-  produces <std::vector<float> >        ( Prefix + "rhlocalx"     + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhlocaly"     + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhlocalxerr"  + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhlocalyerr"  + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhglobalx"    + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhglobaly"    + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhglobalz"    + Suffix );
-  produces <std::vector<float> >        ( Prefix + "rhstrip"      + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "rhmerr"       + Suffix );   
+  produces<std::vector<float>>(Prefix + "rhlocalx" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhlocaly" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhlocalxerr" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhlocalyerr" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhglobalx" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhglobaly" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhglobalz" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhstrip" + Suffix);
+  produces<std::vector<float>>(Prefix + "rhmerr" + Suffix);
 
-  produces <std::vector<float> >        ( Prefix + "ubstrip"      + Suffix );   
-  produces <std::vector<float> >        ( Prefix + "ubmerr"       + Suffix );   
+  produces<std::vector<float>>(Prefix + "ubstrip" + Suffix);
+  produces<std::vector<float>>(Prefix + "ubmerr" + Suffix);
 
-  produces <std::vector<float> >       ( Prefix + "driftx"        + Suffix );
-  produces <std::vector<float> >       ( Prefix + "drifty"        + Suffix );
-  produces <std::vector<float> >       ( Prefix + "driftz"        + Suffix );
-  produces <std::vector<float> >       ( Prefix + "globalZofunitlocalY" + Suffix );            
+  produces<std::vector<float>>(Prefix + "driftx" + Suffix);
+  produces<std::vector<float>>(Prefix + "drifty" + Suffix);
+  produces<std::vector<float>>(Prefix + "driftz" + Suffix);
+  produces<std::vector<float>>(Prefix + "globalZofunitlocalY" + Suffix);
 }
 
-void ShallowTrackClustersProducer::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ShallowTrackClustersProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   shallow::CLUSTERMAP clustermap = shallow::make_cluster_map(iEvent, clusters_token_);
-  edm::Handle<edm::View<reco::Track> > tracks;	             iEvent.getByToken(tracks_token_, tracks);	  
+  edm::Handle<edm::View<reco::Track>> tracks;
+  iEvent.getByToken(tracks_token_, tracks);
 
   int size = clustermap.size();
 
-	//links
-  auto clusterIdx        = std::make_unique<std::vector<int>>(); //link: on trk cluster --> general cluster info 
-  auto onTrkClusterIdx   = std::make_unique<std::vector<int>>(size,   -1); //link: general cluster info --> on track cluster
-  auto onTrkClustersBegin = std::make_unique<std::vector<int>>( tracks->size(), -1 ); //link: track --> on trk cluster
-  auto onTrkClustersEnd   = std::make_unique<std::vector<int>>( tracks->size(), -1 ); //link: track --> on trk cluster
-  auto trackindex    = std::make_unique<std::vector<int>>(); //link: on track cluster --> track
-	clusterIdx->reserve(size);
-	trackindex->reserve(size);
-	
-  auto  trackmulti   = std::make_unique<std::vector<unsigned int>>(); trackmulti  ->reserve(size);
-  auto  localtheta   = std::make_unique<std::vector<float>>(); localtheta  ->reserve(size);
-  auto  localphi     = std::make_unique<std::vector<float>>(); localphi    ->reserve(size);
-  auto  localpitch   = std::make_unique<std::vector<float>>(); localpitch  ->reserve(size);
-  auto  localx       = std::make_unique<std::vector<float>>(); localx      ->reserve(size);
-  auto  localy       = std::make_unique<std::vector<float>>(); localy      ->reserve(size);
-  auto  localz       = std::make_unique<std::vector<float>>(); localz      ->reserve(size);
-  auto  strip        = std::make_unique<std::vector<float>>(); strip       ->reserve(size);
-  auto  globaltheta  = std::make_unique<std::vector<float>>(); globaltheta ->reserve(size);
-  auto  globalphi    = std::make_unique<std::vector<float>>(); globalphi   ->reserve(size);
-  auto  globalx      = std::make_unique<std::vector<float>>(); globalx     ->reserve(size);
-  auto  globaly      = std::make_unique<std::vector<float>>(); globaly     ->reserve(size);
-  auto  globalz      = std::make_unique<std::vector<float>>(); globalz     ->reserve(size);
-  auto  insidistance = std::make_unique<std::vector<float>>(); insidistance->reserve(size);
-  auto  projwidth    = std::make_unique<std::vector<float>>(); projwidth   ->reserve(size);
-  auto  BdotY        = std::make_unique<std::vector<float>>(); BdotY       ->reserve(size);
-  auto  covered      = std::make_unique<std::vector<float>>(); covered     ->reserve(size);
-  auto  rhlocalx     = std::make_unique<std::vector<float>>(); rhlocalx   ->reserve(size);
-  auto  rhlocaly     = std::make_unique<std::vector<float>>(); rhlocaly   ->reserve(size);  
-  auto  rhlocalxerr  = std::make_unique<std::vector<float>>(); rhlocalxerr->reserve(size);  
-  auto  rhlocalyerr  = std::make_unique<std::vector<float>>(); rhlocalyerr->reserve(size);    
-  auto  rhglobalx    = std::make_unique<std::vector<float>>(); rhglobalx  ->reserve(size);  
-  auto  rhglobaly    = std::make_unique<std::vector<float>>(); rhglobaly  ->reserve(size);  
-  auto  rhglobalz    = std::make_unique<std::vector<float>>(); rhglobalz  ->reserve(size);  
-  auto  rhstrip      = std::make_unique<std::vector<float>>(); rhstrip    ->reserve(size);  
-  auto  rhmerr       = std::make_unique<std::vector<float>>(); rhmerr     ->reserve(size);  
-  auto  ubstrip      = std::make_unique<std::vector<float>>(); ubstrip    ->reserve(size);  
-  auto  ubmerr       = std::make_unique<std::vector<float>>(); ubmerr     ->reserve(size);  
-  auto  driftx       = std::make_unique<std::vector<float>>(); driftx     ->reserve(size);
-  auto  drifty       = std::make_unique<std::vector<float>>(); drifty     ->reserve(size);
-  auto  driftz       = std::make_unique<std::vector<float>>(); driftz     ->reserve(size);
-  auto  globalZofunitlocalY = std::make_unique<std::vector<float>>(); globalZofunitlocalY->reserve(size);
+  //links
+  auto clusterIdx = std::make_unique<std::vector<int>>();  //link: on trk cluster --> general cluster info
+  auto onTrkClusterIdx =
+      std::make_unique<std::vector<int>>(size, -1);  //link: general cluster info --> on track cluster
+  auto onTrkClustersBegin = std::make_unique<std::vector<int>>(tracks->size(), -1);  //link: track --> on trk cluster
+  auto onTrkClustersEnd = std::make_unique<std::vector<int>>(tracks->size(), -1);    //link: track --> on trk cluster
+  auto trackindex = std::make_unique<std::vector<int>>();                            //link: on track cluster --> track
+  clusterIdx->reserve(size);
+  trackindex->reserve(size);
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;         iSetup.get<TrackerDigiGeometryRecord>().get( theTrackerGeometry );  
-  edm::ESHandle<MagneticField> magfield;		     iSetup.get<IdealMagneticFieldRecord>().get(magfield);		      
-  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle;    iSetup.get<SiStripLorentzAngleDepRcd>().get(SiStripLorentzAngle);      
+  auto trackmulti = std::make_unique<std::vector<unsigned int>>();
+  trackmulti->reserve(size);
+  auto localtheta = std::make_unique<std::vector<float>>();
+  localtheta->reserve(size);
+  auto localphi = std::make_unique<std::vector<float>>();
+  localphi->reserve(size);
+  auto localpitch = std::make_unique<std::vector<float>>();
+  localpitch->reserve(size);
+  auto localx = std::make_unique<std::vector<float>>();
+  localx->reserve(size);
+  auto localy = std::make_unique<std::vector<float>>();
+  localy->reserve(size);
+  auto localz = std::make_unique<std::vector<float>>();
+  localz->reserve(size);
+  auto strip = std::make_unique<std::vector<float>>();
+  strip->reserve(size);
+  auto globaltheta = std::make_unique<std::vector<float>>();
+  globaltheta->reserve(size);
+  auto globalphi = std::make_unique<std::vector<float>>();
+  globalphi->reserve(size);
+  auto globalx = std::make_unique<std::vector<float>>();
+  globalx->reserve(size);
+  auto globaly = std::make_unique<std::vector<float>>();
+  globaly->reserve(size);
+  auto globalz = std::make_unique<std::vector<float>>();
+  globalz->reserve(size);
+  auto insidistance = std::make_unique<std::vector<float>>();
+  insidistance->reserve(size);
+  auto projwidth = std::make_unique<std::vector<float>>();
+  projwidth->reserve(size);
+  auto BdotY = std::make_unique<std::vector<float>>();
+  BdotY->reserve(size);
+  auto covered = std::make_unique<std::vector<float>>();
+  covered->reserve(size);
+  auto rhlocalx = std::make_unique<std::vector<float>>();
+  rhlocalx->reserve(size);
+  auto rhlocaly = std::make_unique<std::vector<float>>();
+  rhlocaly->reserve(size);
+  auto rhlocalxerr = std::make_unique<std::vector<float>>();
+  rhlocalxerr->reserve(size);
+  auto rhlocalyerr = std::make_unique<std::vector<float>>();
+  rhlocalyerr->reserve(size);
+  auto rhglobalx = std::make_unique<std::vector<float>>();
+  rhglobalx->reserve(size);
+  auto rhglobaly = std::make_unique<std::vector<float>>();
+  rhglobaly->reserve(size);
+  auto rhglobalz = std::make_unique<std::vector<float>>();
+  rhglobalz->reserve(size);
+  auto rhstrip = std::make_unique<std::vector<float>>();
+  rhstrip->reserve(size);
+  auto rhmerr = std::make_unique<std::vector<float>>();
+  rhmerr->reserve(size);
+  auto ubstrip = std::make_unique<std::vector<float>>();
+  ubstrip->reserve(size);
+  auto ubmerr = std::make_unique<std::vector<float>>();
+  ubmerr->reserve(size);
+  auto driftx = std::make_unique<std::vector<float>>();
+  driftx->reserve(size);
+  auto drifty = std::make_unique<std::vector<float>>();
+  drifty->reserve(size);
+  auto driftz = std::make_unique<std::vector<float>>();
+  driftz->reserve(size);
+  auto globalZofunitlocalY = std::make_unique<std::vector<float>>();
+  globalZofunitlocalY->reserve(size);
 
-  edm::Handle<TrajTrackAssociationCollection> associations;  iEvent.getByToken(association_token_, associations);
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  edm::ESHandle<MagneticField> magfield;
+  iSetup.get<IdealMagneticFieldRecord>().get(magfield);
+  edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle;
+  iSetup.get<SiStripLorentzAngleDepRcd>().get(SiStripLorentzAngle);
+
+  edm::Handle<TrajTrackAssociationCollection> associations;
+  iEvent.getByToken(association_token_, associations);
 
   TrajectoryStateCombiner combiner;
 
-	size_t ontrk_cluster_idx=0;
-  std::map<size_t, std::vector<size_t> > mapping; //cluster idx --> on trk cluster idx (multiple)
+  size_t ontrk_cluster_idx = 0;
+  std::map<size_t, std::vector<size_t>> mapping;  //cluster idx --> on trk cluster idx (multiple)
 
-  for( TrajTrackAssociationCollection::const_iterator association = associations->begin(); 
-       association != associations->end(); association++) {
-    const Trajectory*  traj  = association->key.get();
+  for (TrajTrackAssociationCollection::const_iterator association = associations->begin();
+       association != associations->end();
+       association++) {
+    const Trajectory* traj = association->key.get();
     const reco::Track* track = association->val.get();
-		int trk_idx = shallow::findTrackIndex(tracks, track); 
-		size_t trk_strt_idx = ontrk_cluster_idx;
+    int trk_idx = shallow::findTrackIndex(tracks, track);
+    size_t trk_strt_idx = ontrk_cluster_idx;
 
-    for(auto const& measurement : traj->measurements() ) {
+    for (auto const& measurement : traj->measurements()) {
       const TrajectoryStateOnSurface& tsos = measurement.updatedState();
-      const TrajectoryStateOnSurface unbiased = combiner(measurement.forwardPredictedState(), measurement.backwardPredictedState());
+      const TrajectoryStateOnSurface unbiased =
+          combiner(measurement.forwardPredictedState(), measurement.backwardPredictedState());
 
-      const TrackingRecHit*         hit        = measurement.recHit()->hit();
-      const SiStripRecHit1D*        hit1D      = dynamic_cast<const SiStripRecHit1D*>(hit);
-      const SiStripRecHit2D*        hit2D      = dynamic_cast<const SiStripRecHit2D*>(hit);
+      const TrackingRecHit* hit = measurement.recHit()->hit();
+      const SiStripRecHit1D* hit1D = dynamic_cast<const SiStripRecHit1D*>(hit);
+      const SiStripRecHit2D* hit2D = dynamic_cast<const SiStripRecHit2D*>(hit);
       const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
 
-      for(unsigned h=0; h<2; h++) { //loop over possible Hit options (1D, 2D)
-				const SiStripCluster* cluster_ptr;
-				if(!matchedhit && h==1) continue; 
-				else if( matchedhit && h==0) cluster_ptr = &matchedhit->monoCluster(); 
-				else if( matchedhit && h==1) cluster_ptr = &matchedhit->stereoCluster(); 
-				else if(hit2D) cluster_ptr = (hit2D->cluster()).get(); 
-				else if(hit1D) cluster_ptr = (hit1D->cluster()).get(); 
-				else continue;
+      for (unsigned h = 0; h < 2; h++) {  //loop over possible Hit options (1D, 2D)
+        const SiStripCluster* cluster_ptr;
+        if (!matchedhit && h == 1)
+          continue;
+        else if (matchedhit && h == 0)
+          cluster_ptr = &matchedhit->monoCluster();
+        else if (matchedhit && h == 1)
+          cluster_ptr = &matchedhit->stereoCluster();
+        else if (hit2D)
+          cluster_ptr = (hit2D->cluster()).get();
+        else if (hit1D)
+          cluster_ptr = (hit1D->cluster()).get();
+        else
+          continue;
 
-				shallow::CLUSTERMAP::const_iterator cluster = clustermap.find( std::make_pair( hit->geographicalId().rawId(), cluster_ptr->firstStrip() ));
-				if(cluster == clustermap.end() ) throw cms::Exception("Logic Error") << "Cluster not found: this could be a configuration error" << std::endl;
-	
-				unsigned i = cluster->second;
+        shallow::CLUSTERMAP::const_iterator cluster =
+            clustermap.find(std::make_pair(hit->geographicalId().rawId(), cluster_ptr->firstStrip()));
+        if (cluster == clustermap.end())
+          throw cms::Exception("Logic Error") << "Cluster not found: this could be a configuration error" << std::endl;
 
-				//find if cluster was already assigned to a previous track
-				auto already_visited = mapping.find(i);
-				int nassociations = 1;
-				if(already_visited != mapping.end()) {
-					nassociations += already_visited->second.size();
-					for(size_t idx : already_visited->second) {
-						trackmulti->at(idx)++;
-					}
-					already_visited->second.push_back(ontrk_cluster_idx);
-				}
-				else { //otherwise store this 
-					std::vector<size_t> single = {ontrk_cluster_idx};
-					mapping.insert( std::make_pair(i, single) );
-				}
+        unsigned i = cluster->second;
 
-				const StripGeomDetUnit* theStripDet = dynamic_cast<const StripGeomDetUnit*>( theTrackerGeometry->idToDet( hit->geographicalId() ) );
-				LocalVector drift = shallow::drift( theStripDet, *magfield, *SiStripLorentzAngle);
-				
-				if(nassociations == 1) onTrkClusterIdx->at(i) = ontrk_cluster_idx; //link: general cluster info --> on track cluster
-				clusterIdx->push_back(  i );  //link: on trk cluster --> general cluster info 
-				trackmulti->push_back(  nassociations );
-				trackindex->push_back(  trk_idx );
-				localtheta->push_back(  (theStripDet->toLocal(tsos.globalDirection())).theta() ); 
-				localphi->push_back(    (theStripDet->toLocal(tsos.globalDirection())).phi() );   
-				localpitch->push_back(  (theStripDet->specificTopology()).localPitch(theStripDet->toLocal(tsos.globalPosition())) ); 
-				localx->push_back(      (theStripDet->toLocal(tsos.globalPosition())).x() );    
-				localy->push_back(      (theStripDet->toLocal(tsos.globalPosition())).y() );    
-				localz->push_back(      (theStripDet->toLocal(tsos.globalPosition())).z() );    
-				strip->push_back(       (theStripDet->specificTopology()).strip(theStripDet->toLocal(tsos.globalPosition())) );
-				globaltheta->push_back( tsos.globalDirection().theta() );                       
-				globalphi->push_back(   tsos.globalDirection().phi() );                         
-				globalx->push_back(     tsos.globalPosition().x() );                            
-				globaly->push_back(     tsos.globalPosition().y() );                            
-				globalz->push_back(     tsos.globalPosition().z() );                            
-				insidistance->push_back(1./fabs(cos(localtheta->at(ontrk_cluster_idx))) );                      
-				projwidth->push_back(   tan(localtheta->at(ontrk_cluster_idx))*cos(localphi->at(ontrk_cluster_idx)) );         
-				BdotY->push_back(       (theStripDet->surface()).toLocal( magfield->inTesla(theStripDet->surface().position())).y() );
-				covered->push_back(     drift.z()/localpitch->at(ontrk_cluster_idx) * fabs(projwidth->at(ontrk_cluster_idx) - drift.x()/drift.z()) );
-				rhlocalx->push_back(    hit->localPosition().x() );
-				rhlocaly->push_back(    hit->localPosition().y() );
-				rhlocalxerr->push_back( sqrt(hit->localPositionError().xx()) );
-				rhlocalyerr->push_back( sqrt(hit->localPositionError().yy()) );
-				rhglobalx->push_back(   theStripDet->toGlobal(hit->localPosition()).x() );
-				rhglobaly->push_back(   theStripDet->toGlobal(hit->localPosition()).y() );
-				rhglobalz->push_back(   theStripDet->toGlobal(hit->localPosition()).z() );
-				rhstrip->push_back(     theStripDet->specificTopology().strip(hit->localPosition()) );
-				rhmerr->push_back(      sqrt(theStripDet->specificTopology().measurementError(hit->localPosition(), hit->localPositionError()).uu()) );
-				ubstrip->push_back(     theStripDet->specificTopology().strip(unbiased.localPosition()) );
-				ubmerr->push_back(      sqrt(theStripDet->specificTopology().measurementError(unbiased.localPosition(), unbiased.localError().positionError()).uu()) );
-				driftx->push_back(      drift.x() );
-				drifty->push_back(      drift.y() );
-				driftz->push_back(      drift.z() );
-				globalZofunitlocalY->push_back( (theStripDet->toGlobal(LocalVector(0,1,0))).z() );
-				
-				ontrk_cluster_idx++;
-      } //for(unsigned h=0; h<2; h++) { //loop over possible Hit options (1D, 2D)
-    } //for(auto const& measurement : traj->measurements() )
+        //find if cluster was already assigned to a previous track
+        auto already_visited = mapping.find(i);
+        int nassociations = 1;
+        if (already_visited != mapping.end()) {
+          nassociations += already_visited->second.size();
+          for (size_t idx : already_visited->second) {
+            trackmulti->at(idx)++;
+          }
+          already_visited->second.push_back(ontrk_cluster_idx);
+        } else {  //otherwise store this
+          std::vector<size_t> single = {ontrk_cluster_idx};
+          mapping.insert(std::make_pair(i, single));
+        }
 
-		onTrkClustersBegin->at(trk_idx) = trk_strt_idx;
-		onTrkClustersEnd->at(trk_idx)   = ontrk_cluster_idx;
+        const StripGeomDetUnit* theStripDet =
+            dynamic_cast<const StripGeomDetUnit*>(theTrackerGeometry->idToDet(hit->geographicalId()));
+        LocalVector drift = shallow::drift(theStripDet, *magfield, *SiStripLorentzAngle);
 
-  } //for(TrajTrackAssociationCollection::const_iterator association = associations->begin();
+        if (nassociations == 1)
+          onTrkClusterIdx->at(i) = ontrk_cluster_idx;  //link: general cluster info --> on track cluster
+        clusterIdx->push_back(i);                      //link: on trk cluster --> general cluster info
+        trackmulti->push_back(nassociations);
+        trackindex->push_back(trk_idx);
+        localtheta->push_back((theStripDet->toLocal(tsos.globalDirection())).theta());
+        localphi->push_back((theStripDet->toLocal(tsos.globalDirection())).phi());
+        localpitch->push_back(
+            (theStripDet->specificTopology()).localPitch(theStripDet->toLocal(tsos.globalPosition())));
+        localx->push_back((theStripDet->toLocal(tsos.globalPosition())).x());
+        localy->push_back((theStripDet->toLocal(tsos.globalPosition())).y());
+        localz->push_back((theStripDet->toLocal(tsos.globalPosition())).z());
+        strip->push_back((theStripDet->specificTopology()).strip(theStripDet->toLocal(tsos.globalPosition())));
+        globaltheta->push_back(tsos.globalDirection().theta());
+        globalphi->push_back(tsos.globalDirection().phi());
+        globalx->push_back(tsos.globalPosition().x());
+        globaly->push_back(tsos.globalPosition().y());
+        globalz->push_back(tsos.globalPosition().z());
+        insidistance->push_back(1. / fabs(cos(localtheta->at(ontrk_cluster_idx))));
+        projwidth->push_back(tan(localtheta->at(ontrk_cluster_idx)) * cos(localphi->at(ontrk_cluster_idx)));
+        BdotY->push_back((theStripDet->surface()).toLocal(magfield->inTesla(theStripDet->surface().position())).y());
+        covered->push_back(drift.z() / localpitch->at(ontrk_cluster_idx) *
+                           fabs(projwidth->at(ontrk_cluster_idx) - drift.x() / drift.z()));
+        rhlocalx->push_back(hit->localPosition().x());
+        rhlocaly->push_back(hit->localPosition().y());
+        rhlocalxerr->push_back(sqrt(hit->localPositionError().xx()));
+        rhlocalyerr->push_back(sqrt(hit->localPositionError().yy()));
+        rhglobalx->push_back(theStripDet->toGlobal(hit->localPosition()).x());
+        rhglobaly->push_back(theStripDet->toGlobal(hit->localPosition()).y());
+        rhglobalz->push_back(theStripDet->toGlobal(hit->localPosition()).z());
+        rhstrip->push_back(theStripDet->specificTopology().strip(hit->localPosition()));
+        rhmerr->push_back(sqrt(
+            theStripDet->specificTopology().measurementError(hit->localPosition(), hit->localPositionError()).uu()));
+        ubstrip->push_back(theStripDet->specificTopology().strip(unbiased.localPosition()));
+        ubmerr->push_back(sqrt(theStripDet->specificTopology()
+                                   .measurementError(unbiased.localPosition(), unbiased.localError().positionError())
+                                   .uu()));
+        driftx->push_back(drift.x());
+        drifty->push_back(drift.y());
+        driftz->push_back(drift.z());
+        globalZofunitlocalY->push_back((theStripDet->toGlobal(LocalVector(0, 1, 0))).z());
 
-  iEvent.put(std::move(clusterIdx        ), Prefix + "clusterIdx" + Suffix );
-  iEvent.put(std::move(onTrkClusterIdx   ), Prefix + "onTrkClusterIdx" + Suffix );
-  iEvent.put(std::move(onTrkClustersBegin), Prefix + "onTrkClustersBegin" + Suffix );
-  iEvent.put(std::move(onTrkClustersEnd  ), Prefix + "onTrkClustersEnd" + Suffix );
-  iEvent.put(std::move(trackindex),  Prefix + "trackindex"  + Suffix );
+        ontrk_cluster_idx++;
+      }  //for(unsigned h=0; h<2; h++) { //loop over possible Hit options (1D, 2D)
+    }    //for(auto const& measurement : traj->measurements() )
 
-  iEvent.put(std::move(trackmulti),  Prefix + "trackmulti"  + Suffix );
-  iEvent.put(std::move(localtheta),  Prefix + "localtheta"  + Suffix );
-  iEvent.put(std::move(localphi),    Prefix + "localphi"    + Suffix );
-  iEvent.put(std::move(localpitch),  Prefix + "localpitch"  + Suffix );
-  iEvent.put(std::move(localx),      Prefix + "localx"      + Suffix );
-  iEvent.put(std::move(localy),      Prefix + "localy"      + Suffix );
-  iEvent.put(std::move(localz),      Prefix + "localz"      + Suffix );
-  iEvent.put(std::move(strip),       Prefix + "strip"       + Suffix );
-  iEvent.put(std::move(globaltheta), Prefix + "globaltheta" + Suffix );
-  iEvent.put(std::move(globalphi),   Prefix + "globalphi"   + Suffix );
-  iEvent.put(std::move(globalx),     Prefix + "globalx"     + Suffix );
-  iEvent.put(std::move(globaly),     Prefix + "globaly"     + Suffix );
-  iEvent.put(std::move(globalz),     Prefix + "globalz"     + Suffix );  
-  iEvent.put(std::move(insidistance),Prefix + "insidistance"+ Suffix );
-  iEvent.put(std::move(covered),     Prefix + "covered"     + Suffix );
-  iEvent.put(std::move(projwidth),   Prefix + "projwidth"   + Suffix );
-  iEvent.put(std::move(BdotY),       Prefix + "BdotY"       + Suffix );
-  iEvent.put(std::move(rhlocalx),    Prefix + "rhlocalx"    + Suffix );   
-  iEvent.put(std::move(rhlocaly),    Prefix + "rhlocaly"    + Suffix );   
-  iEvent.put(std::move(rhlocalxerr), Prefix + "rhlocalxerr" + Suffix );   
-  iEvent.put(std::move(rhlocalyerr), Prefix + "rhlocalyerr" + Suffix );   
-  iEvent.put(std::move(rhglobalx),   Prefix + "rhglobalx"   + Suffix );   
-  iEvent.put(std::move(rhglobaly),   Prefix + "rhglobaly"   + Suffix );   
-  iEvent.put(std::move(rhglobalz),   Prefix + "rhglobalz"   + Suffix );   
-  iEvent.put(std::move(rhstrip),     Prefix + "rhstrip"     + Suffix );   
-  iEvent.put(std::move(rhmerr),      Prefix + "rhmerr"      + Suffix );   
-  iEvent.put(std::move(ubstrip),     Prefix + "ubstrip"     + Suffix );   
-  iEvent.put(std::move(ubmerr),      Prefix + "ubmerr"      + Suffix );   
-  iEvent.put(std::move(driftx),      Prefix + "driftx"      + Suffix );
-  iEvent.put(std::move(drifty),      Prefix + "drifty"      + Suffix );
-  iEvent.put(std::move(driftz),      Prefix + "driftz"      + Suffix );
-  iEvent.put(std::move(globalZofunitlocalY), Prefix + "globalZofunitlocalY" + Suffix );
+    onTrkClustersBegin->at(trk_idx) = trk_strt_idx;
+    onTrkClustersEnd->at(trk_idx) = ontrk_cluster_idx;
+
+  }  //for(TrajTrackAssociationCollection::const_iterator association = associations->begin();
+
+  iEvent.put(std::move(clusterIdx), Prefix + "clusterIdx" + Suffix);
+  iEvent.put(std::move(onTrkClusterIdx), Prefix + "onTrkClusterIdx" + Suffix);
+  iEvent.put(std::move(onTrkClustersBegin), Prefix + "onTrkClustersBegin" + Suffix);
+  iEvent.put(std::move(onTrkClustersEnd), Prefix + "onTrkClustersEnd" + Suffix);
+  iEvent.put(std::move(trackindex), Prefix + "trackindex" + Suffix);
+
+  iEvent.put(std::move(trackmulti), Prefix + "trackmulti" + Suffix);
+  iEvent.put(std::move(localtheta), Prefix + "localtheta" + Suffix);
+  iEvent.put(std::move(localphi), Prefix + "localphi" + Suffix);
+  iEvent.put(std::move(localpitch), Prefix + "localpitch" + Suffix);
+  iEvent.put(std::move(localx), Prefix + "localx" + Suffix);
+  iEvent.put(std::move(localy), Prefix + "localy" + Suffix);
+  iEvent.put(std::move(localz), Prefix + "localz" + Suffix);
+  iEvent.put(std::move(strip), Prefix + "strip" + Suffix);
+  iEvent.put(std::move(globaltheta), Prefix + "globaltheta" + Suffix);
+  iEvent.put(std::move(globalphi), Prefix + "globalphi" + Suffix);
+  iEvent.put(std::move(globalx), Prefix + "globalx" + Suffix);
+  iEvent.put(std::move(globaly), Prefix + "globaly" + Suffix);
+  iEvent.put(std::move(globalz), Prefix + "globalz" + Suffix);
+  iEvent.put(std::move(insidistance), Prefix + "insidistance" + Suffix);
+  iEvent.put(std::move(covered), Prefix + "covered" + Suffix);
+  iEvent.put(std::move(projwidth), Prefix + "projwidth" + Suffix);
+  iEvent.put(std::move(BdotY), Prefix + "BdotY" + Suffix);
+  iEvent.put(std::move(rhlocalx), Prefix + "rhlocalx" + Suffix);
+  iEvent.put(std::move(rhlocaly), Prefix + "rhlocaly" + Suffix);
+  iEvent.put(std::move(rhlocalxerr), Prefix + "rhlocalxerr" + Suffix);
+  iEvent.put(std::move(rhlocalyerr), Prefix + "rhlocalyerr" + Suffix);
+  iEvent.put(std::move(rhglobalx), Prefix + "rhglobalx" + Suffix);
+  iEvent.put(std::move(rhglobaly), Prefix + "rhglobaly" + Suffix);
+  iEvent.put(std::move(rhglobalz), Prefix + "rhglobalz" + Suffix);
+  iEvent.put(std::move(rhstrip), Prefix + "rhstrip" + Suffix);
+  iEvent.put(std::move(rhmerr), Prefix + "rhmerr" + Suffix);
+  iEvent.put(std::move(ubstrip), Prefix + "ubstrip" + Suffix);
+  iEvent.put(std::move(ubmerr), Prefix + "ubmerr" + Suffix);
+  iEvent.put(std::move(driftx), Prefix + "driftx" + Suffix);
+  iEvent.put(std::move(drifty), Prefix + "drifty" + Suffix);
+  iEvent.put(std::move(driftz), Prefix + "driftz" + Suffix);
+  iEvent.put(std::move(globalZofunitlocalY), Prefix + "globalZofunitlocalY" + Suffix);
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowTracksProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTracksProducer.cc
@@ -7,123 +7,121 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
 ShallowTracksProducer::ShallowTracksProducer(const edm::ParameterSet& iConfig)
-  :  tracks_token_( consumes<edm::View<reco::Track> >( iConfig.getParameter<edm::InputTag>("Tracks") )),
-     Prefix       ( iConfig.getParameter<std::string>("Prefix")    ),
-     Suffix       ( iConfig.getParameter<std::string>("Suffix")    )
-{
-  produces <unsigned int>               ( Prefix + "number"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "chi2"      + Suffix );
-  produces <std::vector<double> >       ( Prefix + "ndof"      + Suffix );
-  produces <std::vector<double> >       ( Prefix + "chi2ndof"  + Suffix );
-  produces <std::vector<float> >        ( Prefix + "charge"    + Suffix );
-  produces <std::vector<float> >        ( Prefix + "momentum"  + Suffix );
-  produces <std::vector<float> >        ( Prefix + "pt"        + Suffix );
-  produces <std::vector<float> >        ( Prefix + "pterr"     + Suffix );
-  produces <std::vector<unsigned int> > ( Prefix + "hitsvalid" + Suffix );
-  produces <std::vector<unsigned int> > ( Prefix + "hitslost"  + Suffix );
-  produces <std::vector<double> >       ( Prefix + "theta"     + Suffix );
-  produces <std::vector<double> >       ( Prefix + "thetaerr"  + Suffix );
-  produces <std::vector<double> >       ( Prefix + "phi"       + Suffix );
-  produces <std::vector<double> >       ( Prefix + "phierr"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "eta"       + Suffix );
-  produces <std::vector<double> >       ( Prefix + "etaerr"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "dxy"       + Suffix );
-  produces <std::vector<double> >       ( Prefix + "dxyerr"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "dsz"       + Suffix );
-  produces <std::vector<double> >       ( Prefix + "dszerr"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "qoverp"    + Suffix );
-  produces <std::vector<double> >       ( Prefix + "qoverperr" + Suffix );
-  produces <std::vector<double> >       ( Prefix + "vx"        + Suffix );
-  produces <std::vector<double> >       ( Prefix + "vy"        + Suffix );
-  produces <std::vector<double> >       ( Prefix + "vz"        + Suffix );
-  produces <std::vector<int> >          ( Prefix + "algo"        + Suffix );
+    : tracks_token_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("Tracks"))),
+      Prefix(iConfig.getParameter<std::string>("Prefix")),
+      Suffix(iConfig.getParameter<std::string>("Suffix")) {
+  produces<unsigned int>(Prefix + "number" + Suffix);
+  produces<std::vector<double>>(Prefix + "chi2" + Suffix);
+  produces<std::vector<double>>(Prefix + "ndof" + Suffix);
+  produces<std::vector<double>>(Prefix + "chi2ndof" + Suffix);
+  produces<std::vector<float>>(Prefix + "charge" + Suffix);
+  produces<std::vector<float>>(Prefix + "momentum" + Suffix);
+  produces<std::vector<float>>(Prefix + "pt" + Suffix);
+  produces<std::vector<float>>(Prefix + "pterr" + Suffix);
+  produces<std::vector<unsigned int>>(Prefix + "hitsvalid" + Suffix);
+  produces<std::vector<unsigned int>>(Prefix + "hitslost" + Suffix);
+  produces<std::vector<double>>(Prefix + "theta" + Suffix);
+  produces<std::vector<double>>(Prefix + "thetaerr" + Suffix);
+  produces<std::vector<double>>(Prefix + "phi" + Suffix);
+  produces<std::vector<double>>(Prefix + "phierr" + Suffix);
+  produces<std::vector<double>>(Prefix + "eta" + Suffix);
+  produces<std::vector<double>>(Prefix + "etaerr" + Suffix);
+  produces<std::vector<double>>(Prefix + "dxy" + Suffix);
+  produces<std::vector<double>>(Prefix + "dxyerr" + Suffix);
+  produces<std::vector<double>>(Prefix + "dsz" + Suffix);
+  produces<std::vector<double>>(Prefix + "dszerr" + Suffix);
+  produces<std::vector<double>>(Prefix + "qoverp" + Suffix);
+  produces<std::vector<double>>(Prefix + "qoverperr" + Suffix);
+  produces<std::vector<double>>(Prefix + "vx" + Suffix);
+  produces<std::vector<double>>(Prefix + "vy" + Suffix);
+  produces<std::vector<double>>(Prefix + "vz" + Suffix);
+  produces<std::vector<int>>(Prefix + "algo" + Suffix);
 }
 
-void ShallowTracksProducer::
-produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  auto       number      = std::make_unique<unsigned int>(0);
-  auto       chi2        = std::make_unique<std::vector<double>>();
-  auto       ndof        = std::make_unique<std::vector<double>>();
-  auto       chi2ndof    = std::make_unique<std::vector<double>>();
-  auto       charge      = std::make_unique<std::vector<float>>();
-  auto       momentum    = std::make_unique<std::vector<float>>();
-  auto       pt          = std::make_unique<std::vector<float>>();
-  auto       pterr       = std::make_unique<std::vector<float>>();
-  auto       hitsvalid   = std::make_unique<std::vector<unsigned int>>();
-  auto       hitslost    = std::make_unique<std::vector<unsigned int>>();
-  auto       theta       = std::make_unique<std::vector<double>>();
-  auto       thetaerr    = std::make_unique<std::vector<double>>();
-  auto       phi         = std::make_unique<std::vector<double>>();
-  auto       phierr      = std::make_unique<std::vector<double>>();
-  auto       eta         = std::make_unique<std::vector<double>>();
-  auto       etaerr      = std::make_unique<std::vector<double>>();
-  auto       dxy         = std::make_unique<std::vector<double>>();
-  auto       dxyerr      = std::make_unique<std::vector<double>>();
-  auto       dsz         = std::make_unique<std::vector<double>>();
-  auto       dszerr      = std::make_unique<std::vector<double>>();
-  auto       qoverp      = std::make_unique<std::vector<double>>();
-  auto       qoverperr   = std::make_unique<std::vector<double>>();
-  auto       vx          = std::make_unique<std::vector<double>>();
-  auto       vy          = std::make_unique<std::vector<double>>();
-  auto       vz          = std::make_unique<std::vector<double>>();
-  auto       algo        = std::make_unique<std::vector<int>>();
+void ShallowTracksProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto number = std::make_unique<unsigned int>(0);
+  auto chi2 = std::make_unique<std::vector<double>>();
+  auto ndof = std::make_unique<std::vector<double>>();
+  auto chi2ndof = std::make_unique<std::vector<double>>();
+  auto charge = std::make_unique<std::vector<float>>();
+  auto momentum = std::make_unique<std::vector<float>>();
+  auto pt = std::make_unique<std::vector<float>>();
+  auto pterr = std::make_unique<std::vector<float>>();
+  auto hitsvalid = std::make_unique<std::vector<unsigned int>>();
+  auto hitslost = std::make_unique<std::vector<unsigned int>>();
+  auto theta = std::make_unique<std::vector<double>>();
+  auto thetaerr = std::make_unique<std::vector<double>>();
+  auto phi = std::make_unique<std::vector<double>>();
+  auto phierr = std::make_unique<std::vector<double>>();
+  auto eta = std::make_unique<std::vector<double>>();
+  auto etaerr = std::make_unique<std::vector<double>>();
+  auto dxy = std::make_unique<std::vector<double>>();
+  auto dxyerr = std::make_unique<std::vector<double>>();
+  auto dsz = std::make_unique<std::vector<double>>();
+  auto dszerr = std::make_unique<std::vector<double>>();
+  auto qoverp = std::make_unique<std::vector<double>>();
+  auto qoverperr = std::make_unique<std::vector<double>>();
+  auto vx = std::make_unique<std::vector<double>>();
+  auto vy = std::make_unique<std::vector<double>>();
+  auto vz = std::make_unique<std::vector<double>>();
+  auto algo = std::make_unique<std::vector<int>>();
 
-  edm::Handle<edm::View<reco::Track> > tracks;  iEvent.getByToken(tracks_token_, tracks);
+  edm::Handle<edm::View<reco::Track>> tracks;
+  iEvent.getByToken(tracks_token_, tracks);
 
   *number = tracks->size();
-  for(auto const& track : *tracks) {
-    chi2->push_back(      track.chi2()              );
-    ndof->push_back(      track.ndof()              );
-    chi2ndof->push_back(  track.chi2()/track.ndof() );
-    charge->push_back(    track.charge()            );
-    momentum->push_back(  track.p()                 );
-    pt->push_back(        track.pt()                );
-    pterr->push_back(     track.ptError()           );
-    hitsvalid->push_back( track.numberOfValidHits() );
-    hitslost->push_back(  track.numberOfLostHits()  );
-    theta->push_back(     track.theta()             );
-    thetaerr->push_back(  track.thetaError()        );
-    phi->push_back(       track.phi()               );
-    phierr->push_back(    track.phiError()          );
-    eta->push_back(       track.eta()               );
-    etaerr->push_back(    track.etaError()          );
-    dxy->push_back(       track.dxy()               );
-    dxyerr->push_back(    track.dxyError()          );
-    dsz->push_back(       track.dsz()               );
-    dszerr->push_back(    track.dszError()          );
-    qoverp->push_back(    track.qoverp()            );
-    qoverperr->push_back( track.qoverpError()       );
-    vx->push_back(        track.vx()                );
-    vy->push_back(        track.vy()                );
-    vz->push_back(        track.vz()                );
-    algo->push_back(      (int) track.algo()              );
+  for (auto const& track : *tracks) {
+    chi2->push_back(track.chi2());
+    ndof->push_back(track.ndof());
+    chi2ndof->push_back(track.chi2() / track.ndof());
+    charge->push_back(track.charge());
+    momentum->push_back(track.p());
+    pt->push_back(track.pt());
+    pterr->push_back(track.ptError());
+    hitsvalid->push_back(track.numberOfValidHits());
+    hitslost->push_back(track.numberOfLostHits());
+    theta->push_back(track.theta());
+    thetaerr->push_back(track.thetaError());
+    phi->push_back(track.phi());
+    phierr->push_back(track.phiError());
+    eta->push_back(track.eta());
+    etaerr->push_back(track.etaError());
+    dxy->push_back(track.dxy());
+    dxyerr->push_back(track.dxyError());
+    dsz->push_back(track.dsz());
+    dszerr->push_back(track.dszError());
+    qoverp->push_back(track.qoverp());
+    qoverperr->push_back(track.qoverpError());
+    vx->push_back(track.vx());
+    vy->push_back(track.vy());
+    vz->push_back(track.vz());
+    algo->push_back((int)track.algo());
   }
 
-  iEvent.put(std::move(number),       Prefix + "number"     + Suffix );
-  iEvent.put(std::move(chi2),         Prefix + "chi2"       + Suffix );
-  iEvent.put(std::move(ndof),         Prefix + "ndof"       + Suffix );
-  iEvent.put(std::move(chi2ndof),     Prefix + "chi2ndof"   + Suffix );
-  iEvent.put(std::move(charge),       Prefix + "charge"     + Suffix );
-  iEvent.put(std::move(momentum),     Prefix + "momentum"   + Suffix );
-  iEvent.put(std::move(pt),           Prefix + "pt"         + Suffix );
-  iEvent.put(std::move(pterr),        Prefix + "pterr"      + Suffix );
-  iEvent.put(std::move(hitsvalid),    Prefix + "hitsvalid"  + Suffix );
-  iEvent.put(std::move(hitslost),     Prefix + "hitslost"   + Suffix );
-  iEvent.put(std::move(theta),        Prefix + "theta"      + Suffix );
-  iEvent.put(std::move(thetaerr),     Prefix + "thetaerr"   + Suffix );
-  iEvent.put(std::move(phi),          Prefix + "phi"        + Suffix );
-  iEvent.put(std::move(phierr),       Prefix + "phierr"     + Suffix );
-  iEvent.put(std::move(eta),          Prefix + "eta"        + Suffix );
-  iEvent.put(std::move(etaerr),       Prefix + "etaerr"     + Suffix );
-  iEvent.put(std::move(dxy),          Prefix + "dxy"        + Suffix );
-  iEvent.put(std::move(dxyerr),       Prefix + "dxyerr"     + Suffix );
-  iEvent.put(std::move(dsz),          Prefix + "dsz"        + Suffix );
-  iEvent.put(std::move(dszerr),       Prefix + "dszerr"     + Suffix );
-  iEvent.put(std::move(qoverp),       Prefix + "qoverp"     + Suffix );
-  iEvent.put(std::move(qoverperr),    Prefix + "qoverperr"  + Suffix );
-  iEvent.put(std::move(vx),           Prefix + "vx"         + Suffix );
-  iEvent.put(std::move(vy),           Prefix + "vy"         + Suffix );
-  iEvent.put(std::move(vz),           Prefix + "vz"         + Suffix );
-  iEvent.put(std::move(algo),         Prefix + "algo"       + Suffix );
-
+  iEvent.put(std::move(number), Prefix + "number" + Suffix);
+  iEvent.put(std::move(chi2), Prefix + "chi2" + Suffix);
+  iEvent.put(std::move(ndof), Prefix + "ndof" + Suffix);
+  iEvent.put(std::move(chi2ndof), Prefix + "chi2ndof" + Suffix);
+  iEvent.put(std::move(charge), Prefix + "charge" + Suffix);
+  iEvent.put(std::move(momentum), Prefix + "momentum" + Suffix);
+  iEvent.put(std::move(pt), Prefix + "pt" + Suffix);
+  iEvent.put(std::move(pterr), Prefix + "pterr" + Suffix);
+  iEvent.put(std::move(hitsvalid), Prefix + "hitsvalid" + Suffix);
+  iEvent.put(std::move(hitslost), Prefix + "hitslost" + Suffix);
+  iEvent.put(std::move(theta), Prefix + "theta" + Suffix);
+  iEvent.put(std::move(thetaerr), Prefix + "thetaerr" + Suffix);
+  iEvent.put(std::move(phi), Prefix + "phi" + Suffix);
+  iEvent.put(std::move(phierr), Prefix + "phierr" + Suffix);
+  iEvent.put(std::move(eta), Prefix + "eta" + Suffix);
+  iEvent.put(std::move(etaerr), Prefix + "etaerr" + Suffix);
+  iEvent.put(std::move(dxy), Prefix + "dxy" + Suffix);
+  iEvent.put(std::move(dxyerr), Prefix + "dxyerr" + Suffix);
+  iEvent.put(std::move(dsz), Prefix + "dsz" + Suffix);
+  iEvent.put(std::move(dszerr), Prefix + "dszerr" + Suffix);
+  iEvent.put(std::move(qoverp), Prefix + "qoverp" + Suffix);
+  iEvent.put(std::move(qoverperr), Prefix + "qoverperr" + Suffix);
+  iEvent.put(std::move(vx), Prefix + "vx" + Suffix);
+  iEvent.put(std::move(vy), Prefix + "vy" + Suffix);
+  iEvent.put(std::move(vz), Prefix + "vz" + Suffix);
+  iEvent.put(std::move(algo), Prefix + "algo" + Suffix);
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
@@ -1,6 +1,6 @@
 #include "CalibTracker/SiStripCommon/interface/ShallowTree.h"
 
-#include "FWCore/Framework/interface/ConstProductRegistry.h" 
+#include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 
@@ -9,24 +9,34 @@
 
 ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
   //int compSettings= iConfig.getParameter<int>("CompressionSettings",-1);
-  int compSettings= iConfig.getUntrackedParameter<int>("CompressionSettings",-1);
-  if(compSettings>0)
-  	fs_->file().SetCompressionSettings(compSettings);
-  tree_ = fs_->make<TTree>("tree", ""); 
+  int compSettings = iConfig.getUntrackedParameter<int>("CompressionSettings", -1);
+  if (compSettings > 0)
+    fs_->file().SetCompressionSettings(compSettings);
+  tree_ = fs_->make<TTree>("tree", "");
 
   std::map<std::string, LEAFTYPE> leafmap;
-  leafmap["bool"]      = BOOL;       leafmap["bools"]     = BOOL_V;
-  leafmap["short int"] = SHORT;      leafmap["shorts"]    = SHORT_V;
-  leafmap["ushort int"]= U_SHORT;    leafmap["ushorts"]   = U_SHORT_V;
-  leafmap["int"]       = INT;        leafmap["ints"]      = INT_V;
-  leafmap["uint"]      = U_INT;      leafmap["uints"]     = U_INT_V;
-  leafmap["float"]     = FLOAT;      leafmap["floats"]    = FLOAT_V;
-  leafmap["double"]    = DOUBLE;     leafmap["doubles"]   = DOUBLE_V;
-  leafmap["lint"]      = LONG;       leafmap["longs"]     = LONG_V;
-  leafmap["ulint"]     = U_LONG;     leafmap["ulongs"]    = U_LONG_V;
-  leafmap["char"]      = CHAR;       leafmap["chars"]     = CHAR_V;
-  leafmap["uchar"]     = U_CHAR;     leafmap["uchars"]    = U_CHAR_V;
-
+  leafmap["bool"] = BOOL;
+  leafmap["bools"] = BOOL_V;
+  leafmap["short int"] = SHORT;
+  leafmap["shorts"] = SHORT_V;
+  leafmap["ushort int"] = U_SHORT;
+  leafmap["ushorts"] = U_SHORT_V;
+  leafmap["int"] = INT;
+  leafmap["ints"] = INT_V;
+  leafmap["uint"] = U_INT;
+  leafmap["uints"] = U_INT_V;
+  leafmap["float"] = FLOAT;
+  leafmap["floats"] = FLOAT_V;
+  leafmap["double"] = DOUBLE;
+  leafmap["doubles"] = DOUBLE_V;
+  leafmap["lint"] = LONG;
+  leafmap["longs"] = LONG_V;
+  leafmap["ulint"] = U_LONG;
+  leafmap["ulongs"] = U_LONG_V;
+  leafmap["char"] = CHAR;
+  leafmap["chars"] = CHAR_V;
+  leafmap["uchar"] = U_CHAR;
+  leafmap["uchars"] = U_CHAR_V;
 
   edm::Service<edm::ConstProductRegistry> reg;
   auto allBranches = reg->allBranchDescriptions();
@@ -36,99 +46,153 @@ ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
 
   std::set<std::string> branchnames;
 
-  for( auto const& selection : allBranches) {
-    if(productSelector_.selected(*selection)) {
-
+  for (auto const& selection : allBranches) {
+    if (productSelector_.selected(*selection)) {
       //Check for duplicate branch names
-      if (branchnames.find( selection->productInstanceName()) != branchnames.end() ) {
-				throw edm::Exception(edm::errors::Configuration)
-					<< "More than one branch named: "
-					<< selection->productInstanceName() << std::endl
-					<< "Exception thrown from ShallowTree::ShallowTree" << std::endl;
-      }
-      else {
-				branchnames.insert( selection->productInstanceName() );
+      if (branchnames.find(selection->productInstanceName()) != branchnames.end()) {
+        throw edm::Exception(edm::errors::Configuration)
+            << "More than one branch named: " << selection->productInstanceName() << std::endl
+            << "Exception thrown from ShallowTree::ShallowTree" << std::endl;
+      } else {
+        branchnames.insert(selection->productInstanceName());
       }
 
       //Create ShallowTree branch
-      switch(leafmap.find( selection->friendlyClassName() )->second) {
-      case BOOL     :  connectors_.push_back( new TypedBranchConnector                      <bool>  (selection, "/O", tree_) ); eat                      <bool>  (selection); break;
-      case BOOL_V   :  connectors_.push_back( new TypedBranchConnector<std::vector          <bool> >(selection,   "", tree_) ); eat<std::vector          <bool> >(selection); break;
-      case INT      :  connectors_.push_back( new TypedBranchConnector                       <int>  (selection, "/I", tree_) ); eat                       <int>  (selection); break;
-      case INT_V    :  connectors_.push_back( new TypedBranchConnector<std::vector           <int> >(selection,   "", tree_) ); eat<std::vector           <int> >(selection); break;
-      case U_INT    :  connectors_.push_back( new TypedBranchConnector              <unsigned int>  (selection, "/i", tree_) ); eat              <unsigned int>  (selection); break;
-      case U_INT_V  :  connectors_.push_back( new TypedBranchConnector<std::vector  <unsigned int> >(selection,   "", tree_) ); eat<std::vector  <unsigned int> >(selection); break;
-      case SHORT    :  connectors_.push_back( new TypedBranchConnector                     <short>  (selection, "/S", tree_) ); eat                     <short>  (selection); break;
-      case SHORT_V  :  connectors_.push_back( new TypedBranchConnector<std::vector         <short> >(selection,   "", tree_) ); eat<std::vector         <short> >(selection); break;
-      case U_SHORT  :  connectors_.push_back( new TypedBranchConnector            <unsigned short>  (selection, "/s", tree_) ); eat            <unsigned short>  (selection); break;
-      case U_SHORT_V:  connectors_.push_back( new TypedBranchConnector<std::vector<unsigned short> >(selection,   "", tree_) ); eat<std::vector<unsigned short> >(selection); break;
-      case FLOAT    :  connectors_.push_back( new TypedBranchConnector                     <float>  (selection, "/F", tree_) ); eat                     <float>  (selection); break;
-      case FLOAT_V  :  connectors_.push_back( new TypedBranchConnector<std::vector         <float> >(selection,   "", tree_) ); eat<std::vector         <float> >(selection); break;
-      case DOUBLE   :  connectors_.push_back( new TypedBranchConnector                    <double>  (selection, "/D", tree_) ); eat                    <double>  (selection); break;
-      case DOUBLE_V :  connectors_.push_back( new TypedBranchConnector<std::vector        <double> >(selection,   "", tree_) ); eat<std::vector        <double> >(selection); break;
-      case LONG     :  connectors_.push_back( new TypedBranchConnector                      <long>  (selection, "/L", tree_) ); eat                      <long>  (selection); break;
-      case LONG_V   :  connectors_.push_back( new TypedBranchConnector<std::vector          <long> >(selection,   "", tree_) ); eat<std::vector          <long> >(selection); break;
-      case U_LONG   :  connectors_.push_back( new TypedBranchConnector             <unsigned long>  (selection, "/l", tree_) ); eat             <unsigned long>  (selection); break;
-      case U_LONG_V :  connectors_.push_back( new TypedBranchConnector<std::vector <unsigned long> >(selection,   "", tree_) ); eat<std::vector <unsigned long> >(selection); break;
-      case CHAR     :  connectors_.push_back( new TypedBranchConnector                      <char>  (selection, "/B", tree_) ); eat                      <char>  (selection); break;
-      case CHAR_V   :  connectors_.push_back( new TypedBranchConnector<std::vector          <char> >(selection,   "", tree_) ); eat<std::vector          <char> >(selection); break;
-      case U_CHAR   :  connectors_.push_back( new TypedBranchConnector             <unsigned char>  (selection, "/b", tree_) ); eat             <unsigned char>  (selection); break;
-      case U_CHAR_V :  connectors_.push_back( new TypedBranchConnector<std::vector <unsigned char> >(selection,   "", tree_) ); eat<std::vector <unsigned char> >(selection); break;
-      default: 
-			{
-				std::string leafstring = "";
-				typedef std::pair<std::string, LEAFTYPE> pair_t;
-				for( const pair_t& leaf: leafmap) { 
-					leafstring+= "\t" + leaf.first + "\n";
-				}
+      switch (leafmap.find(selection->friendlyClassName())->second) {
+        case BOOL:
+          connectors_.push_back(new TypedBranchConnector<bool>(selection, "/O", tree_));
+          eat<bool>(selection);
+          break;
+        case BOOL_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<bool> >(selection, "", tree_));
+          eat<std::vector<bool> >(selection);
+          break;
+        case INT:
+          connectors_.push_back(new TypedBranchConnector<int>(selection, "/I", tree_));
+          eat<int>(selection);
+          break;
+        case INT_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<int> >(selection, "", tree_));
+          eat<std::vector<int> >(selection);
+          break;
+        case U_INT:
+          connectors_.push_back(new TypedBranchConnector<unsigned int>(selection, "/i", tree_));
+          eat<unsigned int>(selection);
+          break;
+        case U_INT_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned int> >(selection, "", tree_));
+          eat<std::vector<unsigned int> >(selection);
+          break;
+        case SHORT:
+          connectors_.push_back(new TypedBranchConnector<short>(selection, "/S", tree_));
+          eat<short>(selection);
+          break;
+        case SHORT_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<short> >(selection, "", tree_));
+          eat<std::vector<short> >(selection);
+          break;
+        case U_SHORT:
+          connectors_.push_back(new TypedBranchConnector<unsigned short>(selection, "/s", tree_));
+          eat<unsigned short>(selection);
+          break;
+        case U_SHORT_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned short> >(selection, "", tree_));
+          eat<std::vector<unsigned short> >(selection);
+          break;
+        case FLOAT:
+          connectors_.push_back(new TypedBranchConnector<float>(selection, "/F", tree_));
+          eat<float>(selection);
+          break;
+        case FLOAT_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<float> >(selection, "", tree_));
+          eat<std::vector<float> >(selection);
+          break;
+        case DOUBLE:
+          connectors_.push_back(new TypedBranchConnector<double>(selection, "/D", tree_));
+          eat<double>(selection);
+          break;
+        case DOUBLE_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<double> >(selection, "", tree_));
+          eat<std::vector<double> >(selection);
+          break;
+        case LONG:
+          connectors_.push_back(new TypedBranchConnector<long>(selection, "/L", tree_));
+          eat<long>(selection);
+          break;
+        case LONG_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<long> >(selection, "", tree_));
+          eat<std::vector<long> >(selection);
+          break;
+        case U_LONG:
+          connectors_.push_back(new TypedBranchConnector<unsigned long>(selection, "/l", tree_));
+          eat<unsigned long>(selection);
+          break;
+        case U_LONG_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned long> >(selection, "", tree_));
+          eat<std::vector<unsigned long> >(selection);
+          break;
+        case CHAR:
+          connectors_.push_back(new TypedBranchConnector<char>(selection, "/B", tree_));
+          eat<char>(selection);
+          break;
+        case CHAR_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<char> >(selection, "", tree_));
+          eat<std::vector<char> >(selection);
+          break;
+        case U_CHAR:
+          connectors_.push_back(new TypedBranchConnector<unsigned char>(selection, "/b", tree_));
+          eat<unsigned char>(selection);
+          break;
+        case U_CHAR_V:
+          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned char> >(selection, "", tree_));
+          eat<std::vector<unsigned char> >(selection);
+          break;
+        default: {
+          std::string leafstring = "";
+          typedef std::pair<std::string, LEAFTYPE> pair_t;
+          for (const pair_t& leaf : leafmap) {
+            leafstring += "\t" + leaf.first + "\n";
+          }
 
-				throw edm::Exception(edm::errors::Configuration)
-					<< "class ShallowTree does not handle leaves of type " << selection->className() << " like\n"
-					<<   selection->friendlyClassName()   << "_" 
-					<<   selection->moduleLabel()         << "_" 
-					<<   selection->productInstanceName() << "_"  
-					<<   selection->processName()         << std::endl
-					<< "Valid leaf types are (friendlyClassName):\n"
-					<<   leafstring
-					<< "Exception thrown from ShallowTree::ShallowTree\n";
-			}
+          throw edm::Exception(edm::errors::Configuration)
+              << "class ShallowTree does not handle leaves of type " << selection->className() << " like\n"
+              << selection->friendlyClassName() << "_" << selection->moduleLabel() << "_"
+              << selection->productInstanceName() << "_" << selection->processName() << std::endl
+              << "Valid leaf types are (friendlyClassName):\n"
+              << leafstring << "Exception thrown from ShallowTree::ShallowTree\n";
+        }
       }
     }
   }
 }
 
-
-void ShallowTree::
-analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  for( BranchConnector* connector: connectors_) {
+void ShallowTree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  for (BranchConnector* connector : connectors_) {
     connector->connect(iEvent);
- }
+  }
   tree_->Fill();
 }
 
 template <class T>
-void ShallowTree::TypedBranchConnector<T>::
-connect(const edm::Event& iEvent) {
+void ShallowTree::TypedBranchConnector<T>::connect(const edm::Event& iEvent) {
   edm::Handle<T> handle_;
   iEvent.getByLabel(ml, pin, handle_);
   object_ = *handle_;
 }
 
-template <class T> 
-ShallowTree::TypedBranchConnector<T>::
-TypedBranchConnector(edm::BranchDescription const* desc, 
-		     std::string t, 
-		     TTree * tree)
-  :  ml( desc->moduleLabel() ),  
-     pin( desc->productInstanceName() )
-{
-  object_ptr_ = &object_;  
-  std::string s=pin+t;  
-  if(!t.empty())  { tree->Branch(pin.c_str(),  object_ptr_, s.c_str() );}  //raw type
-  else       { tree->Branch(pin.c_str(), &object_ptr_            );}  //vector<type>
+template <class T>
+ShallowTree::TypedBranchConnector<T>::TypedBranchConnector(edm::BranchDescription const* desc,
+                                                           std::string t,
+                                                           TTree* tree)
+    : ml(desc->moduleLabel()), pin(desc->productInstanceName()) {
+  object_ptr_ = &object_;
+  std::string s = pin + t;
+  if (!t.empty()) {
+    tree->Branch(pin.c_str(), object_ptr_, s.c_str());
+  }  //raw type
+  else {
+    tree->Branch(pin.c_str(), &object_ptr_);
+  }  //vector<type>
 }
 
-void ShallowTree::
-beginJob() {
-}
-
+void ShallowTree::beginJob() {}

--- a/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
@@ -12,39 +12,37 @@
 //
 
 class SiStripBFieldFilter : public edm::EDFilter {
-  public:
-  SiStripBFieldFilter( const edm::ParameterSet & );
+public:
+  SiStripBFieldFilter(const edm::ParameterSet&);
   ~SiStripBFieldFilter() override;
 
-  private:
-  double MagFieldCurrentTh_;   /*!<  Threshold for the Magnet current. */
-  bool   HIpassFilter_;        /*!<  Swith for HI/Low filter. */
+private:
+  double MagFieldCurrentTh_; /*!<  Threshold for the Magnet current. */
+  bool HIpassFilter_;        /*!<  Swith for HI/Low filter. */
 
-  bool filter( edm::Event &, edm::EventSetup const& ) override;
+  bool filter(edm::Event&, edm::EventSetup const&) override;
 };
 
 //
 // -- Constructor
 //
-SiStripBFieldFilter::SiStripBFieldFilter( const edm::ParameterSet & pset ) {
-    MagFieldCurrentTh_ = pset.getUntrackedParameter<double>  ("MagFieldCurrentTh",  2000.);
-    HIpassFilter_      = pset.getUntrackedParameter<bool>    ("HIpassFilter"   ,  true);
+SiStripBFieldFilter::SiStripBFieldFilter(const edm::ParameterSet& pset) {
+  MagFieldCurrentTh_ = pset.getUntrackedParameter<double>("MagFieldCurrentTh", 2000.);
+  HIpassFilter_ = pset.getUntrackedParameter<bool>("HIpassFilter", true);
 }
 
 //
 // -- Destructor
 //
-SiStripBFieldFilter::~SiStripBFieldFilter() {
-}
+SiStripBFieldFilter::~SiStripBFieldFilter() {}
 
-bool SiStripBFieldFilter::filter( edm::Event & evt, edm::EventSetup const& es) {
-
+bool SiStripBFieldFilter::filter(edm::Event& evt, edm::EventSetup const& es) {
   edm::ESHandle<RunInfo> runInfo;
   es.get<RunInfoRcd>().get(runInfo);
 
   double average_current = runInfo.product()->m_avg_current;
 
-  return ( (HIpassFilter_)? average_current > MagFieldCurrentTh_ : average_current < MagFieldCurrentTh_);
+  return ((HIpassFilter_) ? average_current > MagFieldCurrentTh_ : average_current < MagFieldCurrentTh_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
@@ -7,36 +7,32 @@
 //
 // -- Class Deleration
 //
- 
-class SiStripDCSFilter : public edm::EDFilter {
- public:
- SiStripDCSFilter( const edm::ParameterSet & );
- ~SiStripDCSFilter() override;
 
-  private:
-  bool filter( edm::Event &, edm::EventSetup const& ) override;
-  SiStripDCSStatus* dcsStatus_;  
+class SiStripDCSFilter : public edm::EDFilter {
+public:
+  SiStripDCSFilter(const edm::ParameterSet&);
+  ~SiStripDCSFilter() override;
+
+private:
+  bool filter(edm::Event&, edm::EventSetup const&) override;
+  SiStripDCSStatus* dcsStatus_;
 };
- 
+
 //
 // -- Constructor
 //
-SiStripDCSFilter::SiStripDCSFilter( const edm::ParameterSet & pset ) {
-  dcsStatus_ = new SiStripDCSStatus(consumesCollector()); 
+SiStripDCSFilter::SiStripDCSFilter(const edm::ParameterSet& pset) {
+  dcsStatus_ = new SiStripDCSStatus(consumesCollector());
 }
 //
 // -- Destructor
 //
 SiStripDCSFilter::~SiStripDCSFilter() {
-  if (dcsStatus_) delete dcsStatus_;
+  if (dcsStatus_)
+    delete dcsStatus_;
 }
- 
-bool SiStripDCSFilter::filter( edm::Event & evt, edm::EventSetup const& es) {
 
-  return (dcsStatus_->getStatus(evt, es));   
-}
+bool SiStripDCSFilter::filter(edm::Event& evt, edm::EventSetup const& es) { return (dcsStatus_->getStatus(evt, es)); }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiStripDCSFilter);
-
- 

--- a/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.h
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiStripDetInfoFileWriter
 // Class:      SiStripDetInfoFileWriter
-// 
+//
 /**\class SiStripDetInfoFileWriter SiStripDetInfoFileWriter.cc CalibTracker/SiStripCommon/src/SiStripDetInfoFileWriter.cc
 
  Description: <one line class summary>
@@ -24,24 +24,17 @@
 #include <fstream>
 
 class SiStripDetInfoFileWriter : public edm::EDAnalyzer {
-
 public:
-
   explicit SiStripDetInfoFileWriter(const edm::ParameterSet&);
   ~SiStripDetInfoFileWriter() override;
 
 private:
+  void beginRun(const edm::Run&, const edm::EventSetup& iSetup) override;
 
-  void beginRun(const edm::Run& , const edm::EventSetup& iSetup) override;
-
-  void analyze(const edm::Event &, const edm::EventSetup &) override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override{};
 
 private:
-
-
-  std::ofstream outputFile_; 
+  std::ofstream outputFile_;
   std::string filePath_;
-
-
 };
 #endif

--- a/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
@@ -11,8 +11,7 @@ class TrackerTopology;
 
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 
-class TkDetMapESProducer : public edm::ESProducer
-{
+class TkDetMapESProducer : public edm::ESProducer {
 public:
   TkDetMapESProducer(const edm::ParameterSet&);
   ~TkDetMapESProducer() override {}
@@ -23,51 +22,71 @@ private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
 };
 
-TkDetMapESProducer::TkDetMapESProducer(const edm::ParameterSet&)
-{
-  setWhatProduced(this).setConsumes(tTopoToken_);
-}
+TkDetMapESProducer::TkDetMapESProducer(const edm::ParameterSet&) { setWhatProduced(this).setConsumes(tTopoToken_); }
 
 namespace {
-  TkLayerMap makeTkLayerMap(int layer, const TrackerTopology* tTopo, const std::vector<uint32_t> tkDetIdList)
-  {
-    LogTrace("TkLayerMap") <<" TkLayerMap::constructor for layer " << layer;
+  TkLayerMap makeTkLayerMap(int layer, const TrackerTopology* tTopo, const std::vector<uint32_t> tkDetIdList) {
+    LogTrace("TkLayerMap") << " TkLayerMap::constructor for layer " << layer;
     uint32_t nStringExt, nRod;
     std::vector<uint32_t> SingleExtString;
     switch (layer) {
-      case TkLayerMap::TIB_L1: //TIBL1
+      case TkLayerMap::TIB_L1:  //TIBL1
         nStringExt = 30;
-        SingleExtString.insert(SingleExtString.begin(),8,0);
-        SingleExtString.insert(SingleExtString.begin()+8,7,1);
-        SingleExtString.insert(SingleExtString.begin()+15,8,2);
-        SingleExtString.insert(SingleExtString.begin()+23,7,3);
-        return TkLayerMap(layer, 12, -6., 6., 2*(nStringExt+1), -1.*(nStringExt+1.), (nStringExt+1), tTopo, tkDetIdList,
-            SingleExtString, {}, {}, {}, nStringExt);
+        SingleExtString.insert(SingleExtString.begin(), 8, 0);
+        SingleExtString.insert(SingleExtString.begin() + 8, 7, 1);
+        SingleExtString.insert(SingleExtString.begin() + 15, 8, 2);
+        SingleExtString.insert(SingleExtString.begin() + 23, 7, 3);
+        return TkLayerMap(layer,
+                          12,
+                          -6.,
+                          6.,
+                          2 * (nStringExt + 1),
+                          -1. * (nStringExt + 1.),
+                          (nStringExt + 1),
+                          tTopo,
+                          tkDetIdList,
+                          SingleExtString,
+                          {},
+                          {},
+                          {},
+                          nStringExt);
         break;
       case TkLayerMap::TIB_L2:
         nStringExt = 38;
-        SingleExtString.insert(SingleExtString.begin(),10,0);
-        SingleExtString.insert(SingleExtString.begin()+10,9,1);
-        SingleExtString.insert(SingleExtString.begin()+19,10,2);
-        SingleExtString.insert(SingleExtString.begin()+29,9,3);
-        return TkLayerMap(layer, 12, -6., 6., 2*(nStringExt+1), -1.*(nStringExt+1.), (nStringExt+1), tTopo, tkDetIdList,
-            SingleExtString, {}, {}, {}, nStringExt);
+        SingleExtString.insert(SingleExtString.begin(), 10, 0);
+        SingleExtString.insert(SingleExtString.begin() + 10, 9, 1);
+        SingleExtString.insert(SingleExtString.begin() + 19, 10, 2);
+        SingleExtString.insert(SingleExtString.begin() + 29, 9, 3);
+        return TkLayerMap(layer,
+                          12,
+                          -6.,
+                          6.,
+                          2 * (nStringExt + 1),
+                          -1. * (nStringExt + 1.),
+                          (nStringExt + 1),
+                          tTopo,
+                          tkDetIdList,
+                          SingleExtString,
+                          {},
+                          {},
+                          {},
+                          nStringExt);
         break;
       case TkLayerMap::TIB_L3:
         nStringExt = 46;
-        SingleExtString.insert(SingleExtString.begin(),23,0);
-        SingleExtString.insert(SingleExtString.begin()+23,23,1);
-        return TkLayerMap(layer, 12, -6., 6., nStringExt, 0, nStringExt, tTopo, tkDetIdList,
-            SingleExtString, {}, {}, {}, nStringExt);
+        SingleExtString.insert(SingleExtString.begin(), 23, 0);
+        SingleExtString.insert(SingleExtString.begin() + 23, 23, 1);
+        return TkLayerMap(
+            layer, 12, -6., 6., nStringExt, 0, nStringExt, tTopo, tkDetIdList, SingleExtString, {}, {}, {}, nStringExt);
         break;
       case TkLayerMap::TIB_L4:
         nStringExt = 56;
-        SingleExtString.insert(SingleExtString.begin(),14,0);
-        SingleExtString.insert(SingleExtString.begin()+14,14,1);
-        SingleExtString.insert(SingleExtString.begin()+28,14,2);
-        SingleExtString.insert(SingleExtString.begin()+42,14,3);
-        return TkLayerMap(layer, 12, -6., 6., nStringExt, 0, nStringExt, tTopo, tkDetIdList,
-            SingleExtString, {}, {}, {}, nStringExt);
+        SingleExtString.insert(SingleExtString.begin(), 14, 0);
+        SingleExtString.insert(SingleExtString.begin() + 14, 14, 1);
+        SingleExtString.insert(SingleExtString.begin() + 28, 14, 2);
+        SingleExtString.insert(SingleExtString.begin() + 42, 14, 3);
+        return TkLayerMap(
+            layer, 12, -6., 6., nStringExt, 0, nStringExt, tTopo, tkDetIdList, SingleExtString, {}, {}, {}, nStringExt);
         break;
       case TkLayerMap::TIDM_D1:  //TID
       case TkLayerMap::TIDM_D2:  //TID
@@ -81,93 +100,202 @@ namespace {
         break;
       case TkLayerMap::TOB_L1:  //TOBL1
         nRod = 42;
-        return TkLayerMap(layer, 12, -6., 6., 2*(nRod+1), -1.*(nRod+1.), (nRod+1.), tTopo, tkDetIdList,
-            {}, {}, {}, {}, 0, nRod);
+        return TkLayerMap(layer,
+                          12,
+                          -6.,
+                          6.,
+                          2 * (nRod + 1),
+                          -1. * (nRod + 1.),
+                          (nRod + 1.),
+                          tTopo,
+                          tkDetIdList,
+                          {},
+                          {},
+                          {},
+                          {},
+                          0,
+                          nRod);
         break;
       case TkLayerMap::TOB_L2:
         nRod = 48;
-        return TkLayerMap(layer, 12, -6., 6., 2*(nRod+1), -1.*(nRod+1.), (nRod+1.), tTopo, tkDetIdList,
-            {}, {}, {}, {}, 0, nRod);
+        return TkLayerMap(layer,
+                          12,
+                          -6.,
+                          6.,
+                          2 * (nRod + 1),
+                          -1. * (nRod + 1.),
+                          (nRod + 1.),
+                          tTopo,
+                          tkDetIdList,
+                          {},
+                          {},
+                          {},
+                          {},
+                          0,
+                          nRod);
         break;
-      case TkLayerMap::TOB_L3: //TOBL3
+      case TkLayerMap::TOB_L3:  //TOBL3
         nRod = 54;
-        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
-            {}, {}, {}, {}, 0, nRod);
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1. * nRod, tTopo, tkDetIdList, {}, {}, {}, {}, 0, nRod);
         break;
       case TkLayerMap::TOB_L4:
         nRod = 60;
-        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
-            {}, {}, {}, {}, 0, nRod);
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1. * nRod, tTopo, tkDetIdList, {}, {}, {}, {}, 0, nRod);
         break;
       case TkLayerMap::TOB_L5:
         nRod = 66;
-        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
-            {}, {}, {}, {}, 0, nRod);
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1. * nRod, tTopo, tkDetIdList, {}, {}, {}, {}, 0, nRod);
         break;
       case TkLayerMap::TOB_L6:
         nRod = 74;
-        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
-            {}, {}, {}, {}, 0, nRod);
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1. * nRod, tTopo, tkDetIdList, {}, {}, {}, {}, 0, nRod);
         break;
-      default: //TEC
-        std::vector<uint32_t> modulesInRingFront = { 0, 2, 2, 3, 4, 2, 4, 5 };
-        std::vector<uint32_t> modulesInRingBack  = { 0, 1, 1, 2, 3, 3, 3, 5 };
+      default:  //TEC
+        std::vector<uint32_t> modulesInRingFront = {0, 2, 2, 3, 4, 2, 4, 5};
+        std::vector<uint32_t> modulesInRingBack = {0, 1, 1, 2, 3, 3, 3, 5};
         switch (layer) {
           case TkLayerMap::TECM_W1:
           case TkLayerMap::TECM_W2:
           case TkLayerMap::TECM_W3:
-            return TkLayerMap(layer, 16, -16., 0., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 1, 4, 7, 9, 11, 14, 16 });
+            return TkLayerMap(layer,
+                              16,
+                              -16.,
+                              0.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 1, 4, 7, 9, 11, 14, 16});
             break;
           case TkLayerMap::TECM_W4:
           case TkLayerMap::TECM_W5:
           case TkLayerMap::TECM_W6:
-            return TkLayerMap(layer, 13, -16., -3., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 1, 4, 6, 8, 11, 13 });
+            return TkLayerMap(layer,
+                              13,
+                              -16.,
+                              -3.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 0, 1, 4, 6, 8, 11, 13});
             break;
           case TkLayerMap::TECM_W7:
           case TkLayerMap::TECM_W8:
-            return TkLayerMap(layer, 10, -16., -6., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 1, 3, 5, 8, 10 });
+            return TkLayerMap(layer,
+                              10,
+                              -16.,
+                              -6.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 0, 0, 1, 3, 5, 8, 10});
             break;
           case TkLayerMap::TECM_W9:
-            return TkLayerMap(layer, 8, -16., -8., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 0, 1, 3, 6, 8 });
+            return TkLayerMap(layer,
+                              8,
+                              -16.,
+                              -8.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 0, 0, 0, 1, 3, 6, 8});
             break;
           case TkLayerMap::TECP_W1:
           case TkLayerMap::TECP_W2:
           case TkLayerMap::TECP_W3:
-            return TkLayerMap(layer, 16, 0., 16., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 1, 4, 7, 9, 11, 14, 16 });
+            return TkLayerMap(layer,
+                              16,
+                              0.,
+                              16.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 1, 4, 7, 9, 11, 14, 16});
             break;
           case TkLayerMap::TECP_W4:
           case TkLayerMap::TECP_W5:
           case TkLayerMap::TECP_W6:
-            return TkLayerMap(layer, 13, 3., 16., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 1, 4, 6, 8, 11, 13 });
+            return TkLayerMap(layer,
+                              13,
+                              3.,
+                              16.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 0, 1, 4, 6, 8, 11, 13});
             break;
           case TkLayerMap::TECP_W7:
           case TkLayerMap::TECP_W8:
-            return TkLayerMap(layer, 10, 6., 16., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 1, 3, 5, 8, 10 });
+            return TkLayerMap(layer,
+                              10,
+                              6.,
+                              16.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 0, 0, 1, 3, 5, 8, 10});
             break;
           case TkLayerMap::TECP_W9:
-            return TkLayerMap(layer, 8, 8., 16., 80, 0., 80., tTopo, tkDetIdList,
-                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 0, 1, 3, 6, 8 });
+            return TkLayerMap(layer,
+                              8,
+                              8.,
+                              16.,
+                              80,
+                              0.,
+                              80.,
+                              tTopo,
+                              tkDetIdList,
+                              {},
+                              modulesInRingFront,
+                              modulesInRingBack,
+                              {0, 0, 0, 0, 1, 3, 6, 8});
         }
     }
     return TkLayerMap{};
   }
-}
+}  // namespace
 
-std::unique_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd& tTopoRcd)
-{
-  if ( ! edm::Service<SiStripDetInfoFileReader>().isAvailable() ) {
-    edm::LogError("TkLayerMap") <<
-      "\n------------------------------------------"
-      "\nUnAvailable Service SiStripDetInfoFileReader: please insert in the configuration file an instance like"
-      "\n\tprocess.SiStripDetInfoFileReader = cms.Service(\"SiStripDetInfoFileReader\")"
-      "\n------------------------------------------";
+std::unique_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd& tTopoRcd) {
+  if (!edm::Service<SiStripDetInfoFileReader>().isAvailable()) {
+    edm::LogError("TkLayerMap")
+        << "\n------------------------------------------"
+           "\nUnAvailable Service SiStripDetInfoFileReader: please insert in the configuration file an instance like"
+           "\n\tprocess.SiStripDetInfoFileReader = cms.Service(\"SiStripDetInfoFileReader\")"
+           "\n------------------------------------------";
   }
   SiStripDetInfoFileReader* fr = edm::Service<SiStripDetInfoFileReader>().operator->();
   const std::vector<uint32_t>& TkDetIdList = fr->getAllDetIds();
@@ -175,9 +303,9 @@ std::unique_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd& 
   const auto& tTopo = tTopoRcd.get(tTopoToken_);
   auto tkDetMap = std::make_unique<TkDetMap>(&tTopo);
 
-  LogTrace("TkDetMap") <<"TkDetMap::constructor ";
+  LogTrace("TkDetMap") << "TkDetMap::constructor ";
   //Create TkLayerMap for each layer declared in the TkLayerEnum
-  for ( int layer=1 ; layer < TkLayerMap::NUMLAYERS; ++layer ) {
+  for (int layer = 1; layer < TkLayerMap::NUMLAYERS; ++layer) {
     tkDetMap->setLayerMap(layer, makeTkLayerMap(layer, &tTopo, TkDetIdList));
   }
 

--- a/CalibTracker/SiStripCommon/src/ShallowTools.cc
+++ b/CalibTracker/SiStripCommon/src/ShallowTools.cc
@@ -6,41 +6,42 @@
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 
-
 namespace shallow {
 
-CLUSTERMAP 
-make_cluster_map( const edm::Event& iEvent, const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > & cluster_token) {
-  CLUSTERMAP clustermap;
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusters;
-  iEvent.getByToken(cluster_token, clusters);
-  
-  unsigned int clusterindex = 0;  
-  for(auto const& ds : *clusters)
-    for(auto const& cluster : ds)
-    clustermap.insert( std::make_pair( std::make_pair(ds.detId(),cluster.firstStrip()),
-				       clusterindex++));
-  return clustermap;
-}
+  CLUSTERMAP
+  make_cluster_map(const edm::Event& iEvent,
+                   const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> >& cluster_token) {
+    CLUSTERMAP clustermap;
+    edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusters;
+    iEvent.getByToken(cluster_token, clusters);
 
-int 
-findTrackIndex(const edm::Handle<edm::View<reco::Track> >& tracks, const reco::Track* track) {
-  edm::View<reco::Track>::const_iterator
-    it = tracks->begin(),
-    end = tracks->end();
-  //Compare addresses
-  for(; it!=end; it++) {    if (&(*it)==track) { return it - tracks->begin(); }  }
-  return -2;
-}
+    unsigned int clusterindex = 0;
+    for (auto const& ds : *clusters)
+      for (auto const& cluster : ds)
+        clustermap.insert(std::make_pair(std::make_pair(ds.detId(), cluster.firstStrip()), clusterindex++));
+    return clustermap;
+  }
 
-LocalVector 
-drift( const StripGeomDetUnit* stripDet, const MagneticField& magfield, const SiStripLorentzAngle& lorentzAngle ) {
-  LocalVector lbfield=( stripDet->surface()).toLocal( magfield.inTesla(stripDet->surface().position()));
-  float tanLorentzAnglePerTesla = lorentzAngle.getLorentzAngle(stripDet->geographicalId());  
-  float driftz = stripDet->specificSurface().bounds().thickness();
-  float driftx =-tanLorentzAnglePerTesla * lbfield.y() * driftz;
-  float drifty = tanLorentzAnglePerTesla * lbfield.x() * driftz;
-  return LocalVector(driftx,drifty,driftz);
-}
+  int findTrackIndex(const edm::Handle<edm::View<reco::Track> >& tracks, const reco::Track* track) {
+    edm::View<reco::Track>::const_iterator it = tracks->begin(), end = tracks->end();
+    //Compare addresses
+    for (; it != end; it++) {
+      if (&(*it) == track) {
+        return it - tracks->begin();
+      }
+    }
+    return -2;
+  }
 
-}
+  LocalVector drift(const StripGeomDetUnit* stripDet,
+                    const MagneticField& magfield,
+                    const SiStripLorentzAngle& lorentzAngle) {
+    LocalVector lbfield = (stripDet->surface()).toLocal(magfield.inTesla(stripDet->surface().position()));
+    float tanLorentzAnglePerTesla = lorentzAngle.getLorentzAngle(stripDet->geographicalId());
+    float driftz = stripDet->specificSurface().bounds().thickness();
+    float driftx = -tanLorentzAnglePerTesla * lbfield.y() * driftz;
+    float drifty = tanLorentzAnglePerTesla * lbfield.x() * driftz;
+    return LocalVector(driftx, drifty, driftz);
+  }
+
+}  // namespace shallow

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -1,4 +1,4 @@
-#include "CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h" 
+#include "CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -8,7 +8,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-// FED cabling and numbering                                                                                                                  
+// FED cabling and numbering
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 
@@ -18,81 +18,78 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
- 
+
 //
 // -- Constructor
 //
-SiStripDCSStatus::SiStripDCSStatus(edm::ConsumesCollector & iC) :
-  TIBTIDinDAQ(false),
-  TOBinDAQ(false),
-  TECFinDAQ(false),
-  TECBinDAQ(false),
-  trackerAbsent(false),
-  rawdataAbsent(true),
-  initialised(false) {
-
+SiStripDCSStatus::SiStripDCSStatus(edm::ConsumesCollector& iC)
+    : TIBTIDinDAQ(false),
+      TOBinDAQ(false),
+      TECFinDAQ(false),
+      TECBinDAQ(false),
+      trackerAbsent(false),
+      rawdataAbsent(true),
+      initialised(false) {
   dcsStatusToken_ = iC.consumes<DcsStatusCollection>(edm::InputTag("scalersRawToDigi"));
-  rawDataToken_   = iC.consumes<FEDRawDataCollection>(edm::InputTag("rawDataCollector"));
+  rawDataToken_ = iC.consumes<FEDRawDataCollection>(edm::InputTag("rawDataCollector"));
 }
 //
 // -- Destructor
 //
-SiStripDCSStatus::~SiStripDCSStatus() {
-}
+SiStripDCSStatus::~SiStripDCSStatus() {}
 //
 // -- Get State
 //
-bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSetup){
-
+bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSetup) {
   bool retVal = true;
-  if (!initialised) initialise(e, eSetup);
+  if (!initialised)
+    initialise(e, eSetup);
 
   edm::Handle<DcsStatusCollection> dcsStatus;
   //  e.getByLabel("scalersRawToDigi", dcsStatus);
   e.getByToken(dcsStatusToken_, dcsStatus);
-  if ( trackerAbsent || !dcsStatus.isValid())  return retVal;
-  if ((*dcsStatus).empty()) return retVal;
+  if (trackerAbsent || !dcsStatus.isValid())
+    return retVal;
+  if ((*dcsStatus).empty())
+    return retVal;
 
   statusTIBTID = true;
-  statusTOB    = true;
-  statusTECF   = true;
-  statusTECB   = true;
+  statusTOB = true;
+  statusTECF = true;
+  statusTECB = true;
 
   bool dcsTIBTID = ((*dcsStatus)[0].ready(DcsStatus::TIBTID));
-  bool dcsTOB    = ((*dcsStatus)[0].ready(DcsStatus::TOB));
-  bool dcsTECF   = ((*dcsStatus)[0].ready(DcsStatus::TECp));
-  bool dcsTECB   = ((*dcsStatus)[0].ready(DcsStatus::TECm));
+  bool dcsTOB = ((*dcsStatus)[0].ready(DcsStatus::TOB));
+  bool dcsTECF = ((*dcsStatus)[0].ready(DcsStatus::TECp));
+  bool dcsTECB = ((*dcsStatus)[0].ready(DcsStatus::TECm));
   if (rawdataAbsent) {
     statusTIBTID = dcsTIBTID;
-    statusTOB    = dcsTOB;
-    statusTECF   = dcsTECF;
-    statusTECB   = dcsTECB;
+    statusTOB = dcsTOB;
+    statusTECF = dcsTECF;
+    statusTECB = dcsTECB;
   } else {
-    if ( TIBTIDinDAQ && !dcsTIBTID ) statusTIBTID = false;
-    if ( TOBinDAQ    && !dcsTOB )    statusTOB    = false;
-    if ( TECFinDAQ   && !dcsTECF )   statusTECF   = false;
-    if ( TECBinDAQ   && !dcsTECB )   statusTECB   = false;
+    if (TIBTIDinDAQ && !dcsTIBTID)
+      statusTIBTID = false;
+    if (TOBinDAQ && !dcsTOB)
+      statusTOB = false;
+    if (TECFinDAQ && !dcsTECF)
+      statusTECF = false;
+    if (TECBinDAQ && !dcsTECB)
+      statusTECB = false;
   }
-  
-  LogDebug("SiStripDCSStatus") << " SiStripDCSStatus :: Detectors in DAQ (TIBTID, TOB, TEC+ TEC-)" 
-	    << TIBTIDinDAQ << " " 
-	    << TOBinDAQ << " " 
-	    << TECFinDAQ << " " 
-	    << TECBinDAQ << std::endl;
-  LogDebug("SiStripDCSStatus") << " SiStripDCSStatus :: Detectors in ON (TIBTID, TOB, TEC+ TEC-)"
-	    << dcsTIBTID << " "
-	    << dcsTOB << " "
-	    << dcsTECF << " "
-	    << dcsTECB << std::endl;
-  
-  LogDebug("SiStripDCSStatus") << " SiStripDCSStatus :: Final Flags     (TIBTID, TOB, TEC+ TEC-)"
-	    << statusTIBTID << " " 
-	    << statusTOB  << " " 
-	    << statusTECF << " " 
-	    << statusTECB << std::endl;
-  if (statusTIBTID && statusTOB && statusTECF && statusTECB) retVal = true;
-  else retVal = false;
-  LogDebug("SiStripDCSStatus") << " Return Value " << retVal ;
+
+  LogDebug("SiStripDCSStatus") << " SiStripDCSStatus :: Detectors in DAQ (TIBTID, TOB, TEC+ TEC-)" << TIBTIDinDAQ << " "
+                               << TOBinDAQ << " " << TECFinDAQ << " " << TECBinDAQ << std::endl;
+  LogDebug("SiStripDCSStatus") << " SiStripDCSStatus :: Detectors in ON (TIBTID, TOB, TEC+ TEC-)" << dcsTIBTID << " "
+                               << dcsTOB << " " << dcsTECF << " " << dcsTECB << std::endl;
+
+  LogDebug("SiStripDCSStatus") << " SiStripDCSStatus :: Final Flags     (TIBTID, TOB, TEC+ TEC-)" << statusTIBTID << " "
+                               << statusTOB << " " << statusTECF << " " << statusTECB << std::endl;
+  if (statusTIBTID && statusTOB && statusTECF && statusTECB)
+    retVal = true;
+  else
+    retVal = false;
+  LogDebug("SiStripDCSStatus") << " Return Value " << retVal;
   return retVal;
 }
 //
@@ -104,7 +101,7 @@ void SiStripDCSStatus::initialise(edm::Event const& e, edm::EventSetup const& eS
   eSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
-  edm::ESHandle< SiStripFedCabling > fedCabling_;
+  edm::ESHandle<SiStripFedCabling> fedCabling_;
   eSetup.get<SiStripFedCablingRcd>().get(fedCabling_);
   auto connectedFEDs = fedCabling_->fedIds();
 
@@ -112,36 +109,42 @@ void SiStripDCSStatus::initialise(edm::Event const& e, edm::EventSetup const& eS
   //  e.getByLabel("source", rawDataHandle);
   e.getByToken(rawDataToken_, rawDataHandle);
 
-  if ( !rawDataHandle.isValid() ) {
+  if (!rawDataHandle.isValid()) {
     rawdataAbsent = true;
     return;
   }
 
   rawdataAbsent = false;
   const FEDRawDataCollection& rawDataCollection = *rawDataHandle;
-  for(std::vector<unsigned short>::const_iterator ifed = connectedFEDs.begin(); ifed != connectedFEDs.end(); ifed++){
-    auto fedChannels = fedCabling_->fedConnections( *ifed );
-    if (!(rawDataCollection.FEDData(*ifed).size()) || !(rawDataCollection.FEDData(*ifed).data()) ) continue;
+  for (std::vector<unsigned short>::const_iterator ifed = connectedFEDs.begin(); ifed != connectedFEDs.end(); ifed++) {
+    auto fedChannels = fedCabling_->fedConnections(*ifed);
+    if (!(rawDataCollection.FEDData(*ifed).size()) || !(rawDataCollection.FEDData(*ifed).data()))
+      continue;
     // Check Modules Connected
-    for (std::vector<FedChannelConnection>::const_iterator iconn = fedChannels.begin();
-	 iconn < fedChannels.end(); iconn++){
-      if (!iconn->isConnected()) continue;
+    for (std::vector<FedChannelConnection>::const_iterator iconn = fedChannels.begin(); iconn < fedChannels.end();
+         iconn++) {
+      if (!iconn->isConnected())
+        continue;
       uint32_t detId = iconn->detId();
       StripSubdetector subdet(detId);
-      if ( (subdet.subdetId() == StripSubdetector::TIB) || (subdet.subdetId() == StripSubdetector::TID)) {
-	TIBTIDinDAQ = true;
-	break;
+      if ((subdet.subdetId() == StripSubdetector::TIB) || (subdet.subdetId() == StripSubdetector::TID)) {
+        TIBTIDinDAQ = true;
+        break;
       } else if (subdet.subdetId() == StripSubdetector::TOB) {
-	TOBinDAQ = true;
-	break;
+        TOBinDAQ = true;
+        break;
       } else if (subdet.subdetId() == StripSubdetector::TEC) {
-	if (tTopo->tecSide(detId) == 2) TECFinDAQ = true;
-	else if (tTopo->tecSide(detId) == 1) TECBinDAQ = true;
-	break;
+        if (tTopo->tecSide(detId) == 2)
+          TECFinDAQ = true;
+        else if (tTopo->tecSide(detId) == 1)
+          TECBinDAQ = true;
+        break;
       }
     }
-    if (TIBTIDinDAQ && TOBinDAQ && TECFinDAQ && TECBinDAQ) break;
-  } 
+    if (TIBTIDinDAQ && TOBinDAQ && TECFinDAQ && TECBinDAQ)
+      break;
+  }
   initialised = true;
-  if (!TIBTIDinDAQ && !TOBinDAQ && !TECFinDAQ && !TECBinDAQ) trackerAbsent = true;
+  if (!TIBTIDinDAQ && !TOBinDAQ && !TECFinDAQ && !TECBinDAQ)
+    trackerAbsent = true;
 }

--- a/CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDetInfoFileReader.cc
@@ -12,146 +12,118 @@
 using namespace cms;
 using namespace std;
 
-SiStripDetInfoFileReader& SiStripDetInfoFileReader::operator=(const SiStripDetInfoFileReader &copy) {
-  detData_=copy.detData_;
-  detIds_=copy.detIds_;
-  return *this;  
+SiStripDetInfoFileReader& SiStripDetInfoFileReader::operator=(const SiStripDetInfoFileReader& copy) {
+  detData_ = copy.detData_;
+  detIds_ = copy.detIds_;
+  return *this;
 }
 
-SiStripDetInfoFileReader::SiStripDetInfoFileReader(const edm::ParameterSet& pset, const edm::ActivityRegistry& ar){
-  edm::FileInPath fp(pset.getUntrackedParameter<std::string>("filePath","CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"));
+SiStripDetInfoFileReader::SiStripDetInfoFileReader(const edm::ParameterSet& pset, const edm::ActivityRegistry& ar) {
+  edm::FileInPath fp(
+      pset.getUntrackedParameter<std::string>("filePath", "CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"));
   reader(fp.fullPath());
 }
 
 SiStripDetInfoFileReader::SiStripDetInfoFileReader(const SiStripDetInfoFileReader& copy) {
-  detData_=copy.detData_;
-  detIds_=copy.detIds_;
+  detData_ = copy.detData_;
+  detIds_ = copy.detIds_;
 }
 
-SiStripDetInfoFileReader::SiStripDetInfoFileReader(std::string filePath) {
-  reader(filePath);
-}
+SiStripDetInfoFileReader::SiStripDetInfoFileReader(std::string filePath) { reader(filePath); }
 
 void SiStripDetInfoFileReader::reader(std::string filePath) {
-
-//   if(filePath==std::string("")){
-//     filePath = edm::FileInPath(std::string("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat") ).fullPath();
-//   }
+  //   if(filePath==std::string("")){
+  //     filePath = edm::FileInPath(std::string("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat") ).fullPath();
+  //   }
 
   edm::LogInfo("SiStripDetInfoFileReader") << "filePath " << filePath << std::endl;
-
 
   detData_.clear();
   detIds_.clear();
 
   inputFile_.open(filePath.c_str());
 
-  if (inputFile_.is_open()){
-
-    for(;;) {
-
-      uint32_t detid; 
+  if (inputFile_.is_open()) {
+    for (;;) {
+      uint32_t detid;
       double stripLength;
       unsigned short numberOfAPVs;
       float thickness;
 
-      inputFile_ >> detid >> numberOfAPVs  >> stripLength >> thickness;
+      inputFile_ >> detid >> numberOfAPVs >> stripLength >> thickness;
 
-      if (!(inputFile_.eof() || inputFile_.fail())){
+      if (!(inputFile_.eof() || inputFile_.fail())) {
+        detIds_.push_back(detid);
 
-	detIds_.push_back(detid);
+        //	inputFile_ >> numberOfAPVs;
+        //	inputFile_ >> stripLength;
 
-	//	inputFile_ >> numberOfAPVs;
-	//	inputFile_ >> stripLength;
+        //     	edm::LogInfo("SiStripDetInfoFileReader::SiStripDetInfoFileReader") << detid <<" " <<numberOfAPVs <<" " <<stripLength << " "<< thickness<< endl;
 
-	//     	edm::LogInfo("SiStripDetInfoFileReader::SiStripDetInfoFileReader") << detid <<" " <<numberOfAPVs <<" " <<stripLength << " "<< thickness<< endl;
+        std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detid);
 
-	std::map<uint32_t, DetInfo >::const_iterator it = detData_.find(detid);
+        if (it == detData_.end()) {
+          detData_[detid] = DetInfo(numberOfAPVs, stripLength, thickness);
+        } else {
+          edm::LogError("SiStripDetInfoFileReader::SiStripDetInfoFileReader")
+              << "DetId " << detid << " already found on file. Ignoring new data" << endl;
 
-	if(it==detData_.end()){
-	  detData_[detid]=DetInfo(numberOfAPVs, stripLength,thickness);
-	}
-	else{
+          detIds_.pop_back();
+          continue;
+        }
+      } else if (inputFile_.eof()) {
+        edm::LogInfo("SiStripDetInfoFileReader::SiStripDetInfoFileReader - END of file reached") << endl;
+        break;
 
-	  edm::LogError("SiStripDetInfoFileReader::SiStripDetInfoFileReader") <<"DetId " << detid << " already found on file. Ignoring new data"<<endl;
-	
-	  detIds_.pop_back();
-	  continue;
-	}
-      }
-      else if (inputFile_.eof()){
-
-	edm::LogInfo("SiStripDetInfoFileReader::SiStripDetInfoFileReader - END of file reached")<<endl;
-	break;
-
-      }
-      else if (inputFile_.fail()) {
-      
-	edm::LogError("SiStripDetInfoFileReader::SiStripDetInfoFileReader - ERROR while reading file")<<endl;     
-	break;
+      } else if (inputFile_.fail()) {
+        edm::LogError("SiStripDetInfoFileReader::SiStripDetInfoFileReader - ERROR while reading file") << endl;
+        break;
       }
     }
 
     inputFile_.close();
 
-  }  
-  else {
-
-    edm::LogError("SiStripDetInfoFileReader::SiStripDetInfoFileReader - Unable to open file")<<endl;
+  } else {
+    edm::LogError("SiStripDetInfoFileReader::SiStripDetInfoFileReader - Unable to open file") << endl;
     return;
-  
   }
 
-//   int i=0;
-//   for(std::map<uint32_t, std::pair<unsigned short, double> >::iterator it =detData_.begin(); it!=detData_.end(); it++ ) {
-//     std::cout<< it->first << " " << (it->second).first << " " << (it->second).second<<endl;
-//     i++;
-//   }
-//   std::cout<<i;
-
-
+  //   int i=0;
+  //   for(std::map<uint32_t, std::pair<unsigned short, double> >::iterator it =detData_.begin(); it!=detData_.end(); it++ ) {
+  //     std::cout<< it->first << " " << (it->second).first << " " << (it->second).second<<endl;
+  //     i++;
+  //   }
+  //   std::cout<<i;
 }
 
+SiStripDetInfoFileReader::~SiStripDetInfoFileReader() {}
 
-SiStripDetInfoFileReader::~SiStripDetInfoFileReader(){
-}
+const std::pair<unsigned short, double> SiStripDetInfoFileReader::getNumberOfApvsAndStripLength(uint32_t detId) const {
+  std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detId);
 
+  if (it != detData_.end()) {
+    return std::pair<unsigned short, double>(it->second.nApvs, it->second.stripLength);
 
-const std::pair<unsigned short, double>  SiStripDetInfoFileReader::getNumberOfApvsAndStripLength(uint32_t detId) const{
-
-  std::map<uint32_t, DetInfo >::const_iterator it = detData_.find(detId);
-
-  if(it!=detData_.end()){
-
-    return std::pair<unsigned short, double>(it->second.nApvs,it->second.stripLength); 
-
-  }
-  else{
-
-    std::pair<unsigned short, double> defaultValue(0,0.);
-    edm::LogWarning("SiStripDetInfoFileReader::getNumberOfApvsAndStripLength - Unable to find requested detid. Returning invalid data ")<<endl; 
+  } else {
+    std::pair<unsigned short, double> defaultValue(0, 0.);
+    edm::LogWarning(
+        "SiStripDetInfoFileReader::getNumberOfApvsAndStripLength - Unable to find requested detid. Returning invalid "
+        "data ")
+        << endl;
     return defaultValue;
-
   }
-
 }
 
-const float & SiStripDetInfoFileReader::getThickness(uint32_t detId) const{
+const float& SiStripDetInfoFileReader::getThickness(uint32_t detId) const {
+  std::map<uint32_t, DetInfo>::const_iterator it = detData_.find(detId);
 
-  std::map<uint32_t, DetInfo >::const_iterator it = detData_.find(detId);
+  if (it != detData_.end()) {
+    return it->second.thickness;
 
-  if(it!=detData_.end()){
-
-    return it->second.thickness; 
-
-  }
-  else{
-
-    static const float defaultValue=0;
-    edm::LogWarning("SiStripDetInfoFileReader::getThickness - Unable to find requested detid. Returning invalid data ")<<endl; 
+  } else {
+    static const float defaultValue = 0;
+    edm::LogWarning("SiStripDetInfoFileReader::getThickness - Unable to find requested detid. Returning invalid data ")
+        << endl;
     return defaultValue;
-
   }
-
 }
-

--- a/CalibTracker/SiStripCommon/src/SiStripFedIdListReader.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripFedIdListReader.cc
@@ -5,88 +5,77 @@
 
 // -----------------------------------------------------------------------------
 //
-SiStripFedIdListReader::SiStripFedIdListReader( std::string filePath ) {
+SiStripFedIdListReader::SiStripFedIdListReader(std::string filePath) {
   fedIds_.clear();
-  inputFile_.open( filePath.c_str() );
+  inputFile_.open(filePath.c_str());
 
-  if ( inputFile_.is_open() ) {
-    
-    for(;;) {
-      
-      uint32_t fed_id; 
+  if (inputFile_.is_open()) {
+    for (;;) {
+      uint32_t fed_id;
       inputFile_ >> fed_id;
 
-      if ( !( inputFile_.eof() || inputFile_.fail() ) ) {
-	
-	std::vector<uint16_t>::const_iterator it = find( fedIds_.begin(), fedIds_.end(), fed_id );
-	if( it == fedIds_.end() ) { fedIds_.push_back(fed_id); }
-	else {
-	  edm::LogWarning("Unknown") 
-	    << "[SiStripFedIdListReader::" << __func__ << "]"
-	    << " FedId " << fed_id << " has already been found in file!" << std::endl;
-	  continue;
-	}
+      if (!(inputFile_.eof() || inputFile_.fail())) {
+        std::vector<uint16_t>::const_iterator it = find(fedIds_.begin(), fedIds_.end(), fed_id);
+        if (it == fedIds_.end()) {
+          fedIds_.push_back(fed_id);
+        } else {
+          edm::LogWarning("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]"
+                                     << " FedId " << fed_id << " has already been found in file!" << std::endl;
+          continue;
+        }
 
-      } else if ( inputFile_.eof() ) {
-	edm::LogVerbatim("Unknown") 
-	  << "[SiStripFedIdListReader::" << __func__ << "]"
-	  << " End of file reached! Found " << fedIds_.size() 
-	  << " valid FedIds!" << std::endl;
-	break;
-      } else if ( inputFile_.fail() ) {
-	edm::LogVerbatim("Unknown") 
-	  << "[SiStripFedIdListReader::" << __func__ << "]"
-	  << " Error while reading file \"" << filePath << "\"!" << std::endl;
-	break;
+      } else if (inputFile_.eof()) {
+        edm::LogVerbatim("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]"
+                                    << " End of file reached! Found " << fedIds_.size() << " valid FedIds!"
+                                    << std::endl;
+        break;
+      } else if (inputFile_.fail()) {
+        edm::LogVerbatim("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]"
+                                    << " Error while reading file \"" << filePath << "\"!" << std::endl;
+        break;
       }
     }
 
     inputFile_.close();
   } else {
-    edm::LogVerbatim("Unknown") 
-      << "[SiStripFedIdListReader::" << __func__ << "]"
-      << " Unable to open file \"" << filePath << "\"!" << std::endl;
+    edm::LogVerbatim("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]"
+                                << " Unable to open file \"" << filePath << "\"!" << std::endl;
     return;
-    
   }
-
 }
 
 // -----------------------------------------------------------------------------
 //
-SiStripFedIdListReader::SiStripFedIdListReader( const SiStripFedIdListReader& copy ) {
-  edm::LogVerbatim("Unknown") 
-    << "[SiStripFedIdListReader::" << __func__ << "]";
+SiStripFedIdListReader::SiStripFedIdListReader(const SiStripFedIdListReader& copy) {
+  edm::LogVerbatim("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]";
   fedIds_ = copy.fedIds_;
 }
 
 // -----------------------------------------------------------------------------
 //
-SiStripFedIdListReader& SiStripFedIdListReader::operator=( const SiStripFedIdListReader& copy ) {
-  edm::LogVerbatim("Unknown") 
-    << "[SiStripFedIdListReader::" << __func__ << "]";
+SiStripFedIdListReader& SiStripFedIdListReader::operator=(const SiStripFedIdListReader& copy) {
+  edm::LogVerbatim("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]";
   fedIds_ = copy.fedIds_;
-  return *this;  
+  return *this;
 }
 
 // -----------------------------------------------------------------------------
 //
-SiStripFedIdListReader::~SiStripFedIdListReader(){
-  edm::LogVerbatim("Unknown") 
-    << "[SiStripFedIdListReader::" << __func__ << "]";
+SiStripFedIdListReader::~SiStripFedIdListReader() {
+  edm::LogVerbatim("Unknown") << "[SiStripFedIdListReader::" << __func__ << "]";
 }
-
 
 // -----------------------------------------------------------------------------
 //
-std::ostream& operator<< ( std::ostream& os, const SiStripFedIdListReader& in ) {
+std::ostream& operator<<(std::ostream& os, const SiStripFedIdListReader& in) {
   std::vector<uint16_t> fed_ids = in.fedIds();
   std::stringstream ss;
   ss << "[SiStripFedIdListReader::" << __func__ << "]"
      << " Found " << fed_ids.size() << " valid FED ids with values: ";
   std::vector<uint16_t>::const_iterator iter = fed_ids.begin();
-  for ( ; iter != fed_ids.end(); ++iter ) { ss << *iter << " "; }
+  for (; iter != fed_ids.end(); ++iter) {
+    ss << *iter << " ";
+  }
   os << ss.str();
   return os;
 }
-

--- a/CalibTracker/SiStripCommon/src/TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/TkDetMap.cc
@@ -6,9 +6,8 @@
 
 // TkLayerMap
 
-void TkLayerMap::initMap(const std::vector<uint32_t>& TkDetIdList)
-{
-  switch(layer_) {
+void TkLayerMap::initMap(const std::vector<uint32_t>& TkDetIdList) {
+  switch (layer_) {
     case TkLayerMap::TIB_L1:
     case TkLayerMap::TIB_L2:
     case TkLayerMap::TIB_L3:
@@ -30,7 +29,7 @@ void TkLayerMap::initMap(const std::vector<uint32_t>& TkDetIdList)
     case TkLayerMap::TOB_L5:
     case TkLayerMap::TOB_L6:
       initMap_TOB(TkDetIdList);
-    break;
+      break;
     case TkLayerMap::TECP_W1:
     case TkLayerMap::TECP_W2:
     case TkLayerMap::TECP_W3:
@@ -56,184 +55,186 @@ void TkLayerMap::initMap(const std::vector<uint32_t>& TkDetIdList)
   }
 }
 
-void TkLayerMap::initMap_TIB(const std::vector<uint32_t>& TkDetIdList)
-{
+void TkLayerMap::initMap_TIB(const std::vector<uint32_t>& TkDetIdList) {
   //extract  vector of module in the layer
   std::vector<uint32_t> LayerDetIdList;
   SiStripSubStructure::getTIBDetectors(TkDetIdList, LayerDetIdList, tTopo_, layer_, 0, 0, 0);
 
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTIB12] layer " << layer_ << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTIB12] layer " << layer_ << " number of dets " << LayerDetIdList.size()
+                         << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  for ( uint32_t det : LayerDetIdList ) {
+  for (uint32_t det : LayerDetIdList) {
     const auto xyb = getXY_TIB(det);
     binToDet_[bin(xyb.ix, xyb.iy)] = det;
 
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTIB] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " " << xyb.y;
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTIB] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " "
+                           << xyb.y;
   }
 }
 
-void TkLayerMap::initMap_TOB(const std::vector<uint32_t>& TkDetIdList)
-{
+void TkLayerMap::initMap_TOB(const std::vector<uint32_t>& TkDetIdList) {
   //extract  vector of module in the layer
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure::getTOBDetectors(TkDetIdList, LayerDetIdList, tTopo_, layer_-10, 0, 0);
+  SiStripSubStructure::getTOBDetectors(TkDetIdList, LayerDetIdList, tTopo_, layer_ - 10, 0, 0);
 
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] layer " << layer_-10  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] layer " << layer_ - 10 << " number of dets "
+                         << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring "
+                         << nStringExt_;
 
-  for ( uint32_t det : LayerDetIdList ) {
+  for (uint32_t det : LayerDetIdList) {
     const auto xyb = getXY_TOB(det);
     binToDet_[bin(xyb.ix, xyb.iy)] = det;
 
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " " << xyb.y;
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " "
+                           << xyb.y;
   }
 }
 
-void TkLayerMap::initMap_TID(const std::vector<uint32_t>& TkDetIdList)
-{
+void TkLayerMap::initMap_TID(const std::vector<uint32_t>& TkDetIdList) {
   //extract  vector of module in the layer
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure::getTIDDetectors(TkDetIdList, LayerDetIdList, tTopo_, (layer_-TkLayerMap::TIDM_D1)/3+1, (layer_-TkLayerMap::TIDM_D1)%3+1, 0, 0);
+  SiStripSubStructure::getTIDDetectors(TkDetIdList,
+                                       LayerDetIdList,
+                                       tTopo_,
+                                       (layer_ - TkLayerMap::TIDM_D1) / 3 + 1,
+                                       (layer_ - TkLayerMap::TIDM_D1) % 3 + 1,
+                                       0,
+                                       0);
 
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTID] layer side " << (layer_-TkLayerMap::TIDM_D1)/3+1 << " nb " << (layer_-TkLayerMap::TIDM_D1)%3+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTID] layer side " << (layer_ - TkLayerMap::TIDM_D1) / 3 + 1 << " nb "
+                         << (layer_ - TkLayerMap::TIDM_D1) % 3 + 1 << " number of dets " << LayerDetIdList.size()
+                         << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  for ( uint32_t det : LayerDetIdList ) {
+  for (uint32_t det : LayerDetIdList) {
     const auto xyb = getXY_TID(det);
     binToDet_[bin(xyb.ix, xyb.iy)] = det;
 
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTID] " << det << " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTID] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " "
+                           << xyb.y;
   }
 }
 
-void TkLayerMap::initMap_TEC(const std::vector<uint32_t>& TkDetIdList)
-{
+void TkLayerMap::initMap_TEC(const std::vector<uint32_t>& TkDetIdList) {
   //extract  vector of module in the layer
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure::getTECDetectors(TkDetIdList, LayerDetIdList, tTopo_, (layer_-TkLayerMap::TECM_W1)/9+1, (layer_-TkLayerMap::TECM_W1)%9+1, 0, 0);
+  SiStripSubStructure::getTECDetectors(TkDetIdList,
+                                       LayerDetIdList,
+                                       tTopo_,
+                                       (layer_ - TkLayerMap::TECM_W1) / 9 + 1,
+                                       (layer_ - TkLayerMap::TECM_W1) % 9 + 1,
+                                       0,
+                                       0);
 
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] layer side " << (layer_-TkLayerMap::TECM_W1)/9+1 << " " << (layer_-TkLayerMap::TECM_W1)%9+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] layer side " << (layer_ - TkLayerMap::TECM_W1) / 9 + 1 << " "
+                         << (layer_ - TkLayerMap::TECM_W1) % 9 + 1 << " number of dets " << LayerDetIdList.size()
+                         << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  for ( uint32_t det : LayerDetIdList ) {
+  for (uint32_t det : LayerDetIdList) {
     const auto xyb = getXY_TEC(det);
     binToDet_[bin(xyb.ix, xyb.iy)] = det;
 
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] " << det << " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y;
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " "
+                           << xyb.y;
   }
 }
 
-const int16_t TkLayerMap::layerSearch(DetId detid, const TrackerTopology* tTopo)
-{
+const int16_t TkLayerMap::layerSearch(DetId detid, const TrackerTopology* tTopo) {
   switch (detid.subdetId()) {
     case SiStripDetId::TIB:
-      return TkLayerMap::TIB_L1  -1 + tTopo->tibLayer(detid);
+      return TkLayerMap::TIB_L1 - 1 + tTopo->tibLayer(detid);
     case SiStripDetId::TID:
-      return TkLayerMap::TIDM_D1 -1 + (tTopo->tidSide(detid)-1)*3 + tTopo->tidWheel(detid);
+      return TkLayerMap::TIDM_D1 - 1 + (tTopo->tidSide(detid) - 1) * 3 + tTopo->tidWheel(detid);
     case SiStripDetId::TOB:
-      return TkLayerMap::TOB_L1  -1 + tTopo->tobLayer(detid);
+      return TkLayerMap::TOB_L1 - 1 + tTopo->tobLayer(detid);
     case SiStripDetId::TEC:
-      return TkLayerMap::TECM_W1 -1 + (tTopo->tecSide(detid)-1)*9 + tTopo->tecWheel(detid);
+      return TkLayerMap::TECM_W1 - 1 + (tTopo->tecSide(detid) - 1) * 9 + tTopo->tecWheel(detid);
     default:
       return 0;
   }
 }
 
-const TkLayerMap::XYbin TkLayerMap::getXY(DetId detid, int layerEnumNb) const
-{
+const TkLayerMap::XYbin TkLayerMap::getXY(DetId detid, int layerEnumNb) const {
   LogTrace("TkLayerMap") << "[TkLayerMap::getXY] " << detid.rawId() << " layer " << layerEnumNb;
 
-  if ( ! layerEnumNb ) layerEnumNb = layerSearch(detid, tTopo_);
+  if (!layerEnumNb)
+    layerEnumNb = layerSearch(detid, tTopo_);
 
-  if ( layerEnumNb != layer_ )
+  if (layerEnumNb != layer_)
     throw cms::Exception("CorruptedData")
-      << "[TkLayerMap::getXY] Fill of DetId " << detid.rawId() << " layerEnumNb " << layerEnumNb << " are requested to wrong TkLayerMap " << layer_ << " \nPlease check the TkDetMap code";
+        << "[TkLayerMap::getXY] Fill of DetId " << detid.rawId() << " layerEnumNb " << layerEnumNb
+        << " are requested to wrong TkLayerMap " << layer_ << " \nPlease check the TkDetMap code";
 
-  if ( layerEnumNb >= TkLayerMap::TIB_L1 && layerEnumNb <= TkLayerMap::TIB_L4 )
+  if (layerEnumNb >= TkLayerMap::TIB_L1 && layerEnumNb <= TkLayerMap::TIB_L4)
     return getXY_TIB(detid);
-  else if ( layerEnumNb >= TkLayerMap::TIDM_D1 && layerEnumNb <= TkLayerMap::TIDP_D3 )
+  else if (layerEnumNb >= TkLayerMap::TIDM_D1 && layerEnumNb <= TkLayerMap::TIDP_D3)
     return getXY_TID(detid);
-  else if ( layerEnumNb >= TkLayerMap::TOB_L1 && layerEnumNb <= TkLayerMap::TOB_L6 )
+  else if (layerEnumNb >= TkLayerMap::TOB_L1 && layerEnumNb <= TkLayerMap::TOB_L6)
     return getXY_TOB(detid);
   else
     return getXY_TEC(detid);
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TIB(DetId detid) const
-{
+TkLayerMap::XYbin TkLayerMap::getXY_TIB(DetId detid) const {
   XYbin xyb;
-  xyb.ix = ( 2*( tTopo_->tibIsZMinusSide(detid) ?
-                  -1*tTopo_->tibModule(detid)+3 :
-                  tTopo_->tibModule(detid)+2 )
-           + ( tTopo_->tibLayer(detid) % 2 ?
-               ( tTopo_->tibIsInternalString(detid) ? 2 : 1 ) :
-               ( tTopo_->tibIsInternalString(detid) ? 1 : 2 ) ) );
-  xyb.iy = ( ( tTopo_->tibIsInternalString(detid) ?
-              tTopo_->tibString(detid)+singleExtStr_[tTopo_->tibString(detid)] :
-              tTopo_->tibString(detid) )
-           + ( ( tTopo_->tibLayer(detid) < 3 ) && ( ! tTopo_->tibIsStereo(detid) ) ?
-                nStringExt_+2 : 0 ) );
+  xyb.ix = (2 * (tTopo_->tibIsZMinusSide(detid) ? -1 * tTopo_->tibModule(detid) + 3 : tTopo_->tibModule(detid) + 2) +
+            (tTopo_->tibLayer(detid) % 2 ? (tTopo_->tibIsInternalString(detid) ? 2 : 1)
+                                         : (tTopo_->tibIsInternalString(detid) ? 1 : 2)));
+  xyb.iy = ((tTopo_->tibIsInternalString(detid) ? tTopo_->tibString(detid) + singleExtStr_[tTopo_->tibString(detid)]
+                                                : tTopo_->tibString(detid)) +
+            ((tTopo_->tibLayer(detid) < 3) && (!tTopo_->tibIsStereo(detid)) ? nStringExt_ + 2 : 0));
 
-  xyb.x = lowX_+xyb.ix-0.5;
-  xyb.y = lowY_+xyb.iy-0.5;
+  xyb.x = lowX_ + xyb.ix - 0.5;
+  xyb.y = lowY_ + xyb.iy - 0.5;
 
   return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TOB(DetId detid) const
-{
+TkLayerMap::XYbin TkLayerMap::getXY_TOB(DetId detid) const {
   XYbin xyb;
-  xyb.ix = ( tTopo_->tobIsZMinusSide(detid) ?
-              -1*tTopo_->tobModule(detid)+7 :
-              tTopo_->tobModule(detid)+6 );
-  xyb.iy = ( tTopo_->tobRod(detid)
-           + ( tTopo_->tobLayer(detid) < 3 && ! tTopo_->tobIsStereo(detid) ?
-                nRod_+2 : 0 ) );
+  xyb.ix = (tTopo_->tobIsZMinusSide(detid) ? -1 * tTopo_->tobModule(detid) + 7 : tTopo_->tobModule(detid) + 6);
+  xyb.iy = (tTopo_->tobRod(detid) + (tTopo_->tobLayer(detid) < 3 && !tTopo_->tobIsStereo(detid) ? nRod_ + 2 : 0));
 
-  xyb.x = lowX_+xyb.ix-0.5;
-  xyb.y = lowY_+xyb.iy-0.5;
+  xyb.x = lowX_ + xyb.ix - 0.5;
+  xyb.y = lowY_ + xyb.iy - 0.5;
 
   return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TID(DetId detid) const
-{
+TkLayerMap::XYbin TkLayerMap::getXY_TID(DetId detid) const {
   XYbin xyb;
-  xyb.ix = ( ( tTopo_->tidIsZMinusSide(detid) ?
-                -3*tTopo_->tidRing(detid)+10 :
-                3*tTopo_->tidRing(detid)-2 )
-           + ( tTopo_->tidIsStereo(detid) ?
-               ( tTopo_->tidIsZMinusSide(detid) ? -1 : 1 ) : 0 ) );
-  xyb.iy = 2*tTopo_->tidModule(detid) - ( tTopo_->tidIsBackRing(detid) ? 0 : 1 );
+  xyb.ix = ((tTopo_->tidIsZMinusSide(detid) ? -3 * tTopo_->tidRing(detid) + 10 : 3 * tTopo_->tidRing(detid) - 2) +
+            (tTopo_->tidIsStereo(detid) ? (tTopo_->tidIsZMinusSide(detid) ? -1 : 1) : 0));
+  xyb.iy = 2 * tTopo_->tidModule(detid) - (tTopo_->tidIsBackRing(detid) ? 0 : 1);
 
-  xyb.x = lowX_+xyb.ix-0.5;
-  xyb.y = lowY_+xyb.iy-0.5;
+  xyb.x = lowX_ + xyb.ix - 0.5;
+  xyb.y = lowY_ + xyb.iy - 0.5;
 
   return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TEC(DetId detid) const
-{
+TkLayerMap::XYbin TkLayerMap::getXY_TEC(DetId detid) const {
   XYbin xyb;
-  xyb.ix = ( ( tTopo_->tecIsZMinusSide(detid) ?
-                binForRing_[7]-binForRing_[tTopo_->tecRing(detid)]+1 :
-                binForRing_[tTopo_->tecRing(detid)] )
-           + ( tTopo_->tecIsStereo(detid) ?
-               ( tTopo_->tecIsZMinusSide(detid) ? -1 : 1 ) : 0 ) );
+  xyb.ix = ((tTopo_->tecIsZMinusSide(detid) ? binForRing_[7] - binForRing_[tTopo_->tecRing(detid)] + 1
+                                            : binForRing_[tTopo_->tecRing(detid)]) +
+            (tTopo_->tecIsStereo(detid) ? (tTopo_->tecIsZMinusSide(detid) ? -1 : 1) : 0));
 
-  xyb.iy = ( (tTopo_->tecPetalNumber(detid)-1)*(modulesInRingFront_[tTopo_->tecRing(detid)] + modulesInRingBack_[tTopo_->tecRing(detid)])
-           + ( tTopo_->tecIsZMinusSide(detid) ?
-                  modulesInRingFront_[tTopo_->tecRing(detid)]-tTopo_->tecModule(detid)+1
-                + ( tTopo_->tecIsBackPetal(detid) ? modulesInRingBack_[tTopo_->tecRing(detid)] : 0 )
-              : tTopo_->tecModule(detid) + ( tTopo_->tecIsBackPetal(detid) ? modulesInRingFront_[tTopo_->tecRing(detid)] : 0 ) ) );
+  xyb.iy = ((tTopo_->tecPetalNumber(detid) - 1) *
+                (modulesInRingFront_[tTopo_->tecRing(detid)] + modulesInRingBack_[tTopo_->tecRing(detid)]) +
+            (tTopo_->tecIsZMinusSide(detid)
+                 ? modulesInRingFront_[tTopo_->tecRing(detid)] - tTopo_->tecModule(detid) + 1 +
+                       (tTopo_->tecIsBackPetal(detid) ? modulesInRingBack_[tTopo_->tecRing(detid)] : 0)
+                 : tTopo_->tecModule(detid) +
+                       (tTopo_->tecIsBackPetal(detid) ? modulesInRingFront_[tTopo_->tecRing(detid)] : 0)));
 
-  xyb.x = lowX_+xyb.ix-0.5;
-  xyb.y = lowY_+xyb.iy-0.5;
+  xyb.x = lowX_ + xyb.ix - 0.5;
+  xyb.y = lowY_ + xyb.iy - 0.5;
 
   return xyb;
 }
 
 // TkDetMap
 
-std::string TkDetMap::getLayerName(int in)
-{
+std::string TkDetMap::getLayerName(int in) {
   switch (in) {
     case TkLayerMap::TIB_L1:
       return "TIB_L1";
@@ -307,81 +308,79 @@ std::string TkDetMap::getLayerName(int in)
   return "Invalid";
 }
 
-int TkDetMap::getLayerNum(const std::string& in)
-{
-  if ( in == "TIB_L1" )
+int TkDetMap::getLayerNum(const std::string& in) {
+  if (in == "TIB_L1")
     return TkLayerMap::TIB_L1;
-  if ( in == "TIB_L2" )
+  if (in == "TIB_L2")
     return TkLayerMap::TIB_L2;
-  if ( in == "TIB_L3" )
+  if (in == "TIB_L3")
     return TkLayerMap::TIB_L3;
-  if ( in == "TIB_L4" )
+  if (in == "TIB_L4")
     return TkLayerMap::TIB_L4;
-  if ( in == "TIDP_D1" )
+  if (in == "TIDP_D1")
     return TkLayerMap::TIDP_D1;
-  if ( in == "TIDP_D2" )
+  if (in == "TIDP_D2")
     return TkLayerMap::TIDP_D2;
-  if ( in == "TIDP_D3" )
+  if (in == "TIDP_D3")
     return TkLayerMap::TIDP_D3;
-  if ( in == "TIDM_D1" )
+  if (in == "TIDM_D1")
     return TkLayerMap::TIDM_D1;
-  if ( in == "TIDM_D2" )
+  if (in == "TIDM_D2")
     return TkLayerMap::TIDM_D2;
-  if ( in == "TIDM_D3" )
+  if (in == "TIDM_D3")
     return TkLayerMap::TIDM_D3;
-  if ( in == "TOB_L1" )
+  if (in == "TOB_L1")
     return TkLayerMap::TOB_L1;
-  if ( in == "TOB_L2" )
+  if (in == "TOB_L2")
     return TkLayerMap::TOB_L2;
-  if ( in == "TOB_L3" )
+  if (in == "TOB_L3")
     return TkLayerMap::TOB_L3;
-  if ( in == "TOB_L4" )
+  if (in == "TOB_L4")
     return TkLayerMap::TOB_L4;
-  if ( in == "TOB_L5" )
+  if (in == "TOB_L5")
     return TkLayerMap::TOB_L5;
-  if ( in == "TOB_L6" )
+  if (in == "TOB_L6")
     return TkLayerMap::TOB_L6;
-  if ( in == "TECP_W1" )
+  if (in == "TECP_W1")
     return TkLayerMap::TECP_W1;
-  if ( in == "TECP_W2" )
+  if (in == "TECP_W2")
     return TkLayerMap::TECP_W2;
-  if ( in == "TECP_W3" )
+  if (in == "TECP_W3")
     return TkLayerMap::TECP_W3;
-  if ( in == "TECP_W4" )
+  if (in == "TECP_W4")
     return TkLayerMap::TECP_W4;
-  if ( in == "TECP_W5" )
+  if (in == "TECP_W5")
     return TkLayerMap::TECP_W5;
-  if ( in == "TECP_W6" )
+  if (in == "TECP_W6")
     return TkLayerMap::TECP_W6;
-  if ( in == "TECP_W7" )
+  if (in == "TECP_W7")
     return TkLayerMap::TECP_W7;
-  if ( in == "TECP_W8" )
+  if (in == "TECP_W8")
     return TkLayerMap::TECP_W8;
-  if ( in == "TECP_W9" )
+  if (in == "TECP_W9")
     return TkLayerMap::TECP_W9;
-  if ( in == "TECM_W1" )
+  if (in == "TECM_W1")
     return TkLayerMap::TECM_W1;
-  if ( in == "TECM_W2" )
+  if (in == "TECM_W2")
     return TkLayerMap::TECM_W2;
-  if ( in == "TECM_W3" )
+  if (in == "TECM_W3")
     return TkLayerMap::TECM_W3;
-  if ( in == "TECM_W4" )
+  if (in == "TECM_W4")
     return TkLayerMap::TECM_W4;
-  if ( in == "TECM_W5" )
+  if (in == "TECM_W5")
     return TkLayerMap::TECM_W5;
-  if ( in == "TECM_W6" )
+  if (in == "TECM_W6")
     return TkLayerMap::TECM_W6;
-  if ( in == "TECM_W7" )
+  if (in == "TECM_W7")
     return TkLayerMap::TECM_W7;
-  if ( in == "TECM_W8" )
+  if (in == "TECM_W8")
     return TkLayerMap::TECM_W8;
-  if ( in == "TECM_W9" )
+  if (in == "TECM_W9")
     return TkLayerMap::TECM_W9;
   return 0;
 }
 
-void TkDetMap::getSubDetLayerSide(int in, SiStripDetId::SubDetector& subDet, uint32_t& layer, uint32_t& side)
-{
+void TkDetMap::getSubDetLayerSide(int in, SiStripDetId::SubDetector& subDet, uint32_t& layer, uint32_t& side) {
   switch (in) {
     case TkLayerMap::TIB_L1:
       subDet = SiStripDetId::TIB;
@@ -546,42 +545,49 @@ void TkDetMap::getSubDetLayerSide(int in, SiStripDetId::SubDetector& subDet, uin
   }
 }
 
-const TkLayerMap::XYbin& TkDetMap::getXY(DetId detid, DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const
-{
-  LogTrace("TkDetMap") << "[getXY] detid " << detid.rawId() << " cache " << cached_detid.rawId() << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy << " " << cached_XYbin.x << " " << cached_XYbin.y;
-  if ( detid == cached_detid )
+const TkLayerMap::XYbin& TkDetMap::getXY(DetId detid,
+                                         DetId& cached_detid,
+                                         int16_t& cached_layer,
+                                         TkLayerMap::XYbin& cached_XYbin) const {
+  LogTrace("TkDetMap") << "[getXY] detid " << detid.rawId() << " cache " << cached_detid.rawId() << " layer "
+                       << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy << " " << cached_XYbin.x
+                       << " " << cached_XYbin.y;
+  if (detid == cached_detid)
     return cached_XYbin;
 
   /*FIXME*/
   //if (layer!=INVALID)
-  findLayer(detid, cached_detid , cached_layer, cached_XYbin);
-  LogTrace("TkDetMap") << "[getXY] detid " << detid.rawId() << " cache " << cached_detid.rawId() << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y;
+  findLayer(detid, cached_detid, cached_layer, cached_XYbin);
+  LogTrace("TkDetMap") << "[getXY] detid " << detid.rawId() << " cache " << cached_detid.rawId() << " layer "
+                       << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy << " " << cached_XYbin.x
+                       << " " << cached_XYbin.y;
 
   return cached_XYbin;
 }
 
-int16_t TkDetMap::findLayer( DetId detid, DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin ) const
-{
-  if ( detid == cached_detid )
+int16_t TkDetMap::findLayer(DetId detid,
+                            DetId& cached_detid,
+                            int16_t& cached_layer,
+                            TkLayerMap::XYbin& cached_XYbin) const {
+  if (detid == cached_detid)
     return cached_layer;
 
   cached_detid = detid;
 
   int16_t layer = TkLayerMap::layerSearch(detid, tTopo_);
   LogTrace("TkDetMap") << "[findLayer] detid " << detid.rawId() << " layer " << layer;
-  if ( layer != cached_layer ) {
-    cached_layer=layer;
+  if (layer != cached_layer) {
+    cached_layer = layer;
   }
   cached_XYbin = TkMap[cached_layer].getXY(detid, layer);
-  LogTrace("TkDetMap") << "[findLayer] detid " << detid.rawId() << " cached_XYbin " << cached_XYbin.ix << " " << cached_XYbin.iy;
+  LogTrace("TkDetMap") << "[findLayer] detid " << detid.rawId() << " cached_XYbin " << cached_XYbin.ix << " "
+                       << cached_XYbin.iy;
 
   return cached_layer;
 }
 
-void TkDetMap::getComponents(int layer,
-			     int& nchX,double& lowX,double& highX,
-			     int& nchY,double& lowY,double& highY) const
-{
+void TkDetMap::getComponents(
+    int layer, int& nchX, double& lowX, double& highX, int& nchY, double& lowY, double& highY) const {
   nchX = TkMap[layer].get_nchX();
   lowX = TkMap[layer].get_lowX();
   highX = TkMap[layer].get_highX();

--- a/CalibTracker/SiStripCommon/test/testCalibTrackerSiStripCommon.cpp
+++ b/CalibTracker/SiStripCommon/test/testCalibTrackerSiStripCommon.cpp
@@ -1,4 +1,3 @@
 #include "FWCore/Utilities/interface/TestHelper.h"
 
 RUNTEST()
-

--- a/CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h
@@ -12,99 +12,122 @@
 class TProfile;
 
 class LA_Filler_Fitter {
-
- public:
-
+public:
   //ensemble constructor
-  LA_Filler_Fitter(int methods, int M, int N, double low, double up, unsigned max, const TrackerTopology *tTopo) :
-    ensembleSize_(M),
-    ensembleBins_(N),ensembleLow_(low),ensembleUp_(up),
-    byLayer_(true),byModule_(false),
-    localYbin_(0),
-    stripsPerBin_(0),
-    maxEvents_(max),
-    methods_(methods),
-    tTopo_(tTopo) {}
+  LA_Filler_Fitter(int methods, int M, int N, double low, double up, unsigned max, const TrackerTopology* tTopo)
+      : ensembleSize_(M),
+        ensembleBins_(N),
+        ensembleLow_(low),
+        ensembleUp_(up),
+        byLayer_(true),
+        byModule_(false),
+        localYbin_(0),
+        stripsPerBin_(0),
+        maxEvents_(max),
+        methods_(methods),
+        tTopo_(tTopo) {}
 
   //measurement constructor
-  LA_Filler_Fitter(int methods, bool layer, bool module, float localybin, unsigned stripbin, unsigned max, const TrackerTopology *tTopo) :
-    ensembleSize_(0),
-    ensembleBins_(0),ensembleLow_(0),ensembleUp_(0),
-    byLayer_(layer),byModule_(module),
-    localYbin_(localybin),
-    stripsPerBin_(stripbin),
-    maxEvents_(max),
-    methods_(methods),
-    tTopo_(tTopo) {}
+  LA_Filler_Fitter(int methods,
+                   bool layer,
+                   bool module,
+                   float localybin,
+                   unsigned stripbin,
+                   unsigned max,
+                   const TrackerTopology* tTopo)
+      : ensembleSize_(0),
+        ensembleBins_(0),
+        ensembleLow_(0),
+        ensembleUp_(0),
+        byLayer_(layer),
+        byModule_(module),
+        localYbin_(localybin),
+        stripsPerBin_(stripbin),
+        maxEvents_(max),
+        methods_(methods),
+        tTopo_(tTopo) {}
 
-  enum Method { WIDTH =1<<0, FIRST_METHOD=1<<0, 
-		PROB1 =1<<1,
-		AVGV2 =1<<2,  
-		AVGV3 =1<<3, 
-		RMSV2 =1<<4,
-		RMSV3 =1<<5, LAST_METHOD=1<<5};
+  enum Method {
+    WIDTH = 1 << 0,
+    FIRST_METHOD = 1 << 0,
+    PROB1 = 1 << 1,
+    AVGV2 = 1 << 2,
+    AVGV3 = 1 << 3,
+    RMSV2 = 1 << 4,
+    RMSV3 = 1 << 5,
+    LAST_METHOD = 1 << 5
+  };
 
-  static std::string method(Method m,bool fit=true) { 
-    switch(m) {
-    case WIDTH: return      "_width_prof";
-    case PROB1: return fit? SymmetryFit::name(method(m,false)): "_prob_w1"   ;  
-    case AVGV2: return fit? SymmetryFit::name(method(m,false)): "_avg_var_w2";  
-    case AVGV3: return fit? SymmetryFit::name(method(m,false)): "_avg_var_w3";  
-    case RMSV2: return fit? SymmetryFit::name(method(m,false)): "_rms_var_w2";  
-    case RMSV3: return fit? SymmetryFit::name(method(m,false)): "_rms_var_w3";  
-    default: return "_UNKNOWN";
+  static std::string method(Method m, bool fit = true) {
+    switch (m) {
+      case WIDTH:
+        return "_width_prof";
+      case PROB1:
+        return fit ? SymmetryFit::name(method(m, false)) : "_prob_w1";
+      case AVGV2:
+        return fit ? SymmetryFit::name(method(m, false)) : "_avg_var_w2";
+      case AVGV3:
+        return fit ? SymmetryFit::name(method(m, false)) : "_avg_var_w3";
+      case RMSV2:
+        return fit ? SymmetryFit::name(method(m, false)) : "_rms_var_w2";
+      case RMSV3:
+        return fit ? SymmetryFit::name(method(m, false)) : "_rms_var_w3";
+      default:
+        return "_UNKNOWN";
     }
   }
 
-  struct Result { 
-    std::pair<float,float> reco,measured,calMeasured;
-    float field,chi2;
-    unsigned ndof,entries; 
-    Result() : reco(1000,0), measured(1000,0), calMeasured(1000,0),
-	       field(0), chi2(0), ndof(0), entries(0) {}
+  struct Result {
+    std::pair<float, float> reco, measured, calMeasured;
+    float field, chi2;
+    unsigned ndof, entries;
+    Result() : reco(1000, 0), measured(1000, 0), calMeasured(1000, 0), field(0), chi2(0), ndof(0), entries(0) {}
   };
-  
+
   struct EnsembleSummary {
-    std::pair<float,float> meanMeasured, sigmaMeasured, meanUncertainty, pull;
+    std::pair<float, float> meanMeasured, sigmaMeasured, meanUncertainty, pull;
     float truth;
     unsigned samples;
-    EnsembleSummary() : meanMeasured(0,0), sigmaMeasured(0,0), meanUncertainty(0,0), pull(0,0),
-			truth(0), samples(0) {}
+    EnsembleSummary()
+        : meanMeasured(0, 0), sigmaMeasured(0, 0), meanUncertainty(0, 0), pull(0, 0), truth(0), samples(0) {}
   };
-  
+
   //Located in src/LA_Filler.cc
   void fill(TTree*, Book&) const;
-  void fill_one_cluster(Book&,
-			const poly<std::string>&,
-			const unsigned,	const float, const float, const float, const float) const;
+  void fill_one_cluster(
+      Book&, const poly<std::string>&, const unsigned, const float, const float, const float, const float) const;
   poly<std::string> allAndOne(const unsigned width) const;
   poly<std::string> varWidth(const unsigned width) const;
   poly<std::string> granularity(const SiStripDetId, const float, const Long64_t, const float, const unsigned) const;
   static std::string subdetLabel(const SiStripDetId);
   static std::string moduleLabel(const SiStripDetId);
   std::string layerLabel(const SiStripDetId) const;
-  static unsigned layer_index(bool TIB, bool stereo, unsigned layer) { return  layer + (TIB?0:6) +(stereo?1:0) + ( (layer>2)?1:(layer==1)?-1:0 );}
+  static unsigned layer_index(bool TIB, bool stereo, unsigned layer) {
+    return layer + (TIB ? 0 : 6) + (stereo ? 1 : 0) + ((layer > 2) ? 1 : (layer == 1) ? -1 : 0);
+  }
 
   //Located in src/LA_Fitter.cc
-  static void fit(Book& book) { make_and_fit_symmchi2(book); fit_width_profile(book); }
+  static void fit(Book& book) {
+    make_and_fit_symmchi2(book);
+    fit_width_profile(book);
+  }
   static void make_and_fit_symmchi2(Book&);
   static void fit_width_profile(Book&);
   static TH1* rms_profile(const std::string, const TProfile* const);
-  static TH1* subset_probability(const std::string name, const TH1* const , const TH1* const );
+  static TH1* subset_probability(const std::string name, const TH1* const, const TH1* const);
   static unsigned find_rebin(const TH1* const);
 
   //Located in src/LA_Results.cc
   void summarize_ensembles(Book&) const;
   static Result result(Method, const std::string name, const Book&);
-  static std::map< std::string,                      Result  >    layer_results(const Book&, const Method);
-  static std::map<    uint32_t,                      Result  >   module_results(const Book&, const Method);
-  static std::map< std::string,          std::vector<Result> > ensemble_results(const Book&, const Method );
-  static std::map< std::string, std::vector<EnsembleSummary> > ensemble_summary(const Book& );
-  static std::pair<std::pair<float,float>, std::pair<float,float> > offset_slope(const std::vector<EnsembleSummary>&);
+  static std::map<std::string, Result> layer_results(const Book&, const Method);
+  static std::map<uint32_t, Result> module_results(const Book&, const Method);
+  static std::map<std::string, std::vector<Result> > ensemble_results(const Book&, const Method);
+  static std::map<std::string, std::vector<EnsembleSummary> > ensemble_summary(const Book&);
+  static std::pair<std::pair<float, float>, std::pair<float, float> > offset_slope(const std::vector<EnsembleSummary>&);
   static float pull(const std::vector<EnsembleSummary>&);
- 
- private:
-  
+
+private:
   const int ensembleSize_, ensembleBins_;
   const double ensembleLow_, ensembleUp_;
   const bool byLayer_, byModule_;

--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripCalibLorentzAngle.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripCalibLorentzAngle.h
@@ -35,58 +35,55 @@
 class TrackerTopology;
 class MonitorElement;
 
-class SiStripCalibLorentzAngle : public ConditionDBWriter<SiStripLorentzAngle>
-{
- public:
-  
-  explicit SiStripCalibLorentzAngle(const edm::ParameterSet& conf);
-  
+class SiStripCalibLorentzAngle : public ConditionDBWriter<SiStripLorentzAngle> {
+public:
+  explicit SiStripCalibLorentzAngle(const edm::ParameterSet &conf);
+
   ~SiStripCalibLorentzAngle() override;
-  
+
   std::unique_ptr<SiStripLorentzAngle> getNewObject() override;
-  
-  void algoBeginJob(const edm::EventSetup&) override;
-  
- private:
- 
-   edm::ESHandle<TrackerGeometry> estracker;
-   edm::ESHandle<MagneticField> magfield_;
-   
-   const TrackerGeometry *tracker;
-   const TrackerTopology *tTopo;
-  
-  typedef std::map <std::string , TProfile*> ProfileMap;
+
+  void algoBeginJob(const edm::EventSetup &) override;
+
+private:
+  edm::ESHandle<TrackerGeometry> estracker;
+  edm::ESHandle<MagneticField> magfield_;
+
+  const TrackerGeometry *tracker;
+  const TrackerTopology *tTopo;
+
+  typedef std::map<std::string, TProfile *> ProfileMap;
   ProfileMap Profiles;
-  typedef std::map <std::string , TH1D*> TH1Dmap;
+  typedef std::map<std::string, TH1D *> TH1Dmap;
   TH1Dmap TH1Ds;
-  typedef std::map <std::string , TH2D*> TH2Dmap;
+  typedef std::map<std::string, TH2D *> TH2Dmap;
   TH2Dmap TH2Ds;
-  std::vector<MonitorElement*> histolist;
-  
+  std::vector<MonitorElement *> histolist;
+
   TF1 *fitfunc, *fitfunc2IT, *FitFunction2IT, *FitFunction;
-  
+
   float histoEntries, gR, gphi, geta, gz, globalX, globalY, globalZ, muH, theBfield, AsymmParam;
   int goodFit, goodFit1IT, badFit, TIB, TOB, Layer, MonoStereo;
   const GlobalPoint gposition;
-  
-  float mean_TIB1, mean_TIB2, mean_TIB3, mean_TIB4, mean_TOB1, mean_TOB2, mean_TOB3, mean_TOB4, mean_TOB5, mean_TOB6;
-  
-  float hallMobility, meanMobility_TIB, meanMobility_TOB;
-  
-  bool LayerDB, CalibByMC;
-  
-  TGraphErrors *TIB_graph, *TOB_graph;
-  
-  TTree* ModuleTree;
-  TFile *hFile;
-  
-  TDirectory *LorentzAngle_Plots, *Rootple, *MuH, *TIB_MuH, *TOB_MuH, *MuH_vs_Phi, *TIB_Phi, *TOB_Phi, *MuH_vs_Eta, *TIB_Eta, *TOB_Eta;
-  TDirectory *FirstIT_GoodFit_Histos, *TIB_1IT_GoodFit, *TOB_1IT_GoodFit, *SecondIT_GoodFit_Histos, *TIB_2IT_GoodFit, *TOB_2IT_GoodFit, *SecondIT_BadFit_Histos, *TIB_2IT_BadFit, *TOB_2IT_BadFit;
-  
-  std::map< uint32_t, float> detid_la;
-  edm::ParameterSet conf_;
-  
-};
 
+  float mean_TIB1, mean_TIB2, mean_TIB3, mean_TIB4, mean_TOB1, mean_TOB2, mean_TOB3, mean_TOB4, mean_TOB5, mean_TOB6;
+
+  float hallMobility, meanMobility_TIB, meanMobility_TOB;
+
+  bool LayerDB, CalibByMC;
+
+  TGraphErrors *TIB_graph, *TOB_graph;
+
+  TTree *ModuleTree;
+  TFile *hFile;
+
+  TDirectory *LorentzAngle_Plots, *Rootple, *MuH, *TIB_MuH, *TOB_MuH, *MuH_vs_Phi, *TIB_Phi, *TOB_Phi, *MuH_vs_Eta,
+      *TIB_Eta, *TOB_Eta;
+  TDirectory *FirstIT_GoodFit_Histos, *TIB_1IT_GoodFit, *TOB_1IT_GoodFit, *SecondIT_GoodFit_Histos, *TIB_2IT_GoodFit,
+      *TOB_2IT_GoodFit, *SecondIT_BadFit_Histos, *TIB_2IT_BadFit, *TOB_2IT_BadFit;
+
+  std::map<uint32_t, float> detid_la;
+  edm::ParameterSet conf_;
+};
 
 #endif

--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
@@ -26,53 +26,55 @@ class TrackerTopology;
 class MonitorElement;
 class DQMStore;
 
-class SiStripLAProfileBooker : public edm::EDAnalyzer
-{
- public:
-  
+class SiStripLAProfileBooker : public edm::EDAnalyzer {
+public:
   explicit SiStripLAProfileBooker(const edm::ParameterSet& conf);
-  
+
   ~SiStripLAProfileBooker() override;
-  
-  void beginRun(edm::Run const&,const edm::EventSetup& c) override;
-  
-  void endJob() override; 
-  
+
+  void beginRun(edm::Run const&, const edm::EventSetup& c) override;
+
+  void endJob() override;
+
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  
-  void getlayer(const DetId & detid, const TrackerTopology* tTopo, std::string &name,unsigned int &layerid);
-  
- private:
- 
-  typedef struct {float thickness; float pitch; LocalVector magfield;} detparameters;
-  typedef std::map <unsigned int, detparameters*> detparmap;
-  typedef std::map <unsigned int, MonitorElement*> histomap;
-  
-  int trackcollsize, trajsize,RunNumber, EventNumber, ClSize, HitCharge, Type, Layer, Wheel, bw_fw, Ext_Int, MonoStereo, ParticleCharge;
-  float sumx, hit_std_dev, barycenter, TanTrackAngle, TanTrackAngleParallel, SignCorrection, MagField, XGlobal, YGlobal, ZGlobal, Momentum, pt, chi2norm, EtaTrack, PhiTrack;
-  int nstrip, eventcounter,size, HitNr, hitcounter, hitcounter_2ndloop, worse_double_hit, better_double_hit, HitPerTrack;
+
+  void getlayer(const DetId& detid, const TrackerTopology* tTopo, std::string& name, unsigned int& layerid);
+
+private:
+  typedef struct {
+    float thickness;
+    float pitch;
+    LocalVector magfield;
+  } detparameters;
+  typedef std::map<unsigned int, detparameters*> detparmap;
+  typedef std::map<unsigned int, MonitorElement*> histomap;
+
+  int trackcollsize, trajsize, RunNumber, EventNumber, ClSize, HitCharge, Type, Layer, Wheel, bw_fw, Ext_Int,
+      MonoStereo, ParticleCharge;
+  float sumx, hit_std_dev, barycenter, TanTrackAngle, TanTrackAngleParallel, SignCorrection, MagField, XGlobal, YGlobal,
+      ZGlobal, Momentum, pt, chi2norm, EtaTrack, PhiTrack;
+  int nstrip, eventcounter, size, HitNr, hitcounter, hitcounter_2ndloop, worse_double_hit, better_double_hit,
+      HitPerTrack;
   int id_detector, TrackCounter, EventCounter;
   float thick_detector, pitch_detector;
   uint8_t Amplitudes[100];
-  
-  TTree  *HitsTree, *TrackTree, *EventTree;
+
+  TTree *HitsTree, *TrackTree, *EventTree;
   TFile* hFile;
-  
+
   TDirectory *Hit_Tree, *Track_Tree, *Event_Tree;
-  
+
   histomap histos;
   histomap summaryhisto;
 
   DQMStore* dbe_;
-  
+
   detparmap detmap;
   detparmap summarydetmap;
   edm::ParameterSet conf_;
   std::string treename_;
-  
-  const TrackerGeometry * tracker;
 
+  const TrackerGeometry* tracker;
 };
-
 
 #endif

--- a/CalibTracker/SiStripLorentzAngle/interface/SymmetryFit.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SymmetryFit.h
@@ -1,39 +1,39 @@
-#ifndef CalibTracker_SiStripLorentzAngle_SymmetryFit                                                        
-#define CalibTracker_SiStripLorentzAngle_SymmetryFit           
+#ifndef CalibTracker_SiStripLorentzAngle_SymmetryFit
+#define CalibTracker_SiStripLorentzAngle_SymmetryFit
 
 #include "TH1.h"
 #include "TF1.h"
 #include <string>
 
 class SymmetryFit {
-
- public:
-  
-  static TH1* symmetryChi2(std::string, const std::vector<TH1*>&, const std::pair<unsigned,unsigned>);
-  static TH1* symmetryChi2(const TH1*, const std::pair<unsigned,unsigned>);
-  static std::string name(std::string base) {return base+"_symmchi2";}
+public:
+  static TH1* symmetryChi2(std::string, const std::vector<TH1*>&, const std::pair<unsigned, unsigned>);
+  static TH1* symmetryChi2(const TH1*, const std::pair<unsigned, unsigned>);
+  static std::string name(std::string base) { return base + "_symmchi2"; }
   static TF1* fitfunction();
   static std::vector<double> pol2_from_pol2(TH1* hist);
   static std::vector<double> pol2_from_pol3(TH1* hist);
-  
- private:
 
-  SymmetryFit(const TH1*, const std::pair<unsigned,unsigned>);
-  std::pair<unsigned,unsigned> findUsableMinMax() const;
-  std::vector<std::pair<unsigned,unsigned> > continuousRanges() const;
-  float chi2_element(std::pair<unsigned,unsigned>);
-  float chi2(std::pair<unsigned,unsigned>);
+private:
+  SymmetryFit(const TH1*, const std::pair<unsigned, unsigned>);
+  std::pair<unsigned, unsigned> findUsableMinMax() const;
+  std::vector<std::pair<unsigned, unsigned> > continuousRanges() const;
+  float chi2_element(std::pair<unsigned, unsigned>);
+  float chi2(std::pair<unsigned, unsigned>);
   void makeChi2Histogram();
   void fillchi2();
   int fit();
-  SymmetryFit operator+=(const SymmetryFit& R) { ndf_+=R.ndf_; chi2_->Add(R.chi2_); return *this;}
+  SymmetryFit operator+=(const SymmetryFit& R) {
+    ndf_ += R.ndf_;
+    chi2_->Add(R.chi2_);
+    return *this;
+  }
 
   const TH1* symm_candidate_;
   const unsigned minDF_;
-  const std::pair<unsigned,unsigned> range_,minmaxUsable_;
+  const std::pair<unsigned, unsigned> range_, minmaxUsable_;
   unsigned ndf_;
   TH1* chi2_;
-
 };
 
 #endif

--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
@@ -10,112 +10,114 @@
 
 namespace sistrip {
 
-EnsembleCalibrationLA::EnsembleCalibrationLA(const edm::ParameterSet& conf) :
-  inputFiles( conf.getParameter<std::vector<std::string> >("InputFiles") ),
-  inFileLocation( conf.getParameter<std::string>("InFileLocation")),
-  Prefix( conf.getUntrackedParameter<std::string>("Prefix","")),
-  maxEvents( conf.getUntrackedParameter<unsigned>("MaxEvents",0)),
-  samples( conf.getParameter<unsigned>("Samples")),
-  nbins( conf.getParameter<unsigned>("NBins")),
-  lowBin( conf.getParameter<double>("LowBin")),
-  highBin( conf.getParameter<double>("HighBin")),
-  vMethods( conf.getParameter<std::vector<int> >("Methods"))
-{}
+  EnsembleCalibrationLA::EnsembleCalibrationLA(const edm::ParameterSet& conf)
+      : inputFiles(conf.getParameter<std::vector<std::string> >("InputFiles")),
+        inFileLocation(conf.getParameter<std::string>("InFileLocation")),
+        Prefix(conf.getUntrackedParameter<std::string>("Prefix", "")),
+        maxEvents(conf.getUntrackedParameter<unsigned>("MaxEvents", 0)),
+        samples(conf.getParameter<unsigned>("Samples")),
+        nbins(conf.getParameter<unsigned>("NBins")),
+        lowBin(conf.getParameter<double>("LowBin")),
+        highBin(conf.getParameter<double>("HighBin")),
+        vMethods(conf.getParameter<std::vector<int> >("Methods")) {}
 
-void EnsembleCalibrationLA::endJob() 
-{
-  Book book("la_ensemble");
-  TChain*const chain = new TChain("la_ensemble"); 
-  for(auto const& file : inputFiles) chain->Add((file+inFileLocation).c_str());
+  void EnsembleCalibrationLA::endJob() {
+    Book book("la_ensemble");
+    TChain* const chain = new TChain("la_ensemble");
+    for (auto const& file : inputFiles)
+      chain->Add((file + inFileLocation).c_str());
 
-  int methods = 0;
-  for(unsigned int method : vMethods) methods|=method;
+    int methods = 0;
+    for (unsigned int method : vMethods)
+      methods |= method;
 
-  LA_Filler_Fitter laff(methods,samples,nbins,lowBin,highBin,maxEvents,tTopo_);
-  laff.fill(chain,book);           
-  laff.fit(book);                  
-  laff.summarize_ensembles(book);  
+    LA_Filler_Fitter laff(methods, samples, nbins, lowBin, highBin, maxEvents, tTopo_);
+    laff.fill(chain, book);
+    laff.fit(book);
+    laff.summarize_ensembles(book);
 
-  write_ensembles_text(book);
-  write_ensembles_plots(book);
-  write_samples_plots(book);
-  write_calibrations();
-}
-
-void EnsembleCalibrationLA::endRun(const edm::Run&, const edm::EventSetup& eSetup)
-{
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  eSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  tTopo_ = tTopoHandle.product();
-}
-
-void EnsembleCalibrationLA::write_ensembles_text(const Book& book)
-{
-  for(auto const& ensemble : LA_Filler_Fitter::ensemble_summary(book)) {
-    std::fstream file((Prefix+ensemble.first+".dat").c_str(),std::ios::out);
-    for(auto const& summary : ensemble.second)
-      file << summary << std::endl;
-
-    const std::pair<std::pair<float,float>,std::pair<float,float> > line = LA_Filler_Fitter::offset_slope(ensemble.second);
-    const float pull =  LA_Filler_Fitter::pull(ensemble.second);
-
-    unsigned index = 15;
-    std::string label;
-    {
-      std::cout << ensemble.first << std::endl;
-      boost::regex format(".*(T[IO]B)_layer(\\d)([as])_(.*)");
-      if(boost::regex_match(ensemble.first,format)) {
-	const bool TIB = "TIB" == boost::regex_replace(ensemble.first, format, "\\1");
-	const bool stereo = "s" == boost::regex_replace(ensemble.first, format, "\\3");
-	const unsigned layer = boost::lexical_cast<unsigned>(boost::regex_replace(ensemble.first, format, "\\2"));
-	label = boost::regex_replace(ensemble.first, format, "\\4");
-	index = LA_Filler_Fitter::layer_index(TIB,stereo,layer);
-
-	calibrations[label].slopes[index]=line.second.first;
-	calibrations[label].offsets[index]=line.first.first;
-	calibrations[label].pulls[index]=pull;
-      }
-    }
-
-    file << std::endl << std::endl
-	 << "# Best Fit Line: "	 
-	 << line.first.first <<"("<< line.first.second<<")   +   x* "
-	 << line.second.first<<"("<< line.second.second<<")"           
-	 << std::endl
-	 << "# Pull (average sigma of (x_measure-x_truth)/e_measure): " << pull 
-	 << std::endl
-	 << "LA_Calibration( METHOD_XXXXX , xxx, " << line.second.first << ", " << line.first.first << ", " << pull << ")," << std::endl;
-    file.close();
-  } 
-}
-
-void EnsembleCalibrationLA::
-write_ensembles_plots(const Book& book) const {
-  TFile file((Prefix+"sampleFits.root").c_str(),"RECREATE");
-  for(Book::const_iterator hist = book.begin(".*(profile|ratio|reconstruction|symm|symmchi2|_w\\d)"); hist!=book.end(); ++hist)
-    hist->second->Write();
-  file.Close();
-}
- 
-void EnsembleCalibrationLA::
-write_samples_plots(const Book& book) const {
-  TFile file((Prefix+"ensembleFits.root").c_str(),"RECREATE");
-  for(Book::const_iterator hist = book.begin(".*(measure|merr|ensembleReco|pull)"); hist!=book.end(); ++hist)
-    hist->second->Write();
-  file.Close();
-}
-
-void EnsembleCalibrationLA::
-write_calibrations() const {
-  std::fstream file((Prefix+"calibrations.dat").c_str(),std::ios::out);
-  for(auto const& cal : calibrations) {
-    file << cal.first << std::endl
-	 << "\t slopes(";    for(float i : cal.second.slopes) file << i<< ","; file << ")" << std::endl
-	 << "\t offsets(";   for(float i : cal.second.offsets) file << i<< ","; file << ")" << std::endl
-	 << "\t pulls(";     for(float i : cal.second.pulls) file << i<< ","; file << ")" << std::endl;
+    write_ensembles_text(book);
+    write_ensembles_plots(book);
+    write_samples_plots(book);
+    write_calibrations();
   }
-  file.close();
-}
-  
-}
 
+  void EnsembleCalibrationLA::endRun(const edm::Run&, const edm::EventSetup& eSetup) {
+    edm::ESHandle<TrackerTopology> tTopoHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+    tTopo_ = tTopoHandle.product();
+  }
+
+  void EnsembleCalibrationLA::write_ensembles_text(const Book& book) {
+    for (auto const& ensemble : LA_Filler_Fitter::ensemble_summary(book)) {
+      std::fstream file((Prefix + ensemble.first + ".dat").c_str(), std::ios::out);
+      for (auto const& summary : ensemble.second)
+        file << summary << std::endl;
+
+      const std::pair<std::pair<float, float>, std::pair<float, float> > line =
+          LA_Filler_Fitter::offset_slope(ensemble.second);
+      const float pull = LA_Filler_Fitter::pull(ensemble.second);
+
+      unsigned index = 15;
+      std::string label;
+      {
+        std::cout << ensemble.first << std::endl;
+        boost::regex format(".*(T[IO]B)_layer(\\d)([as])_(.*)");
+        if (boost::regex_match(ensemble.first, format)) {
+          const bool TIB = "TIB" == boost::regex_replace(ensemble.first, format, "\\1");
+          const bool stereo = "s" == boost::regex_replace(ensemble.first, format, "\\3");
+          const unsigned layer = boost::lexical_cast<unsigned>(boost::regex_replace(ensemble.first, format, "\\2"));
+          label = boost::regex_replace(ensemble.first, format, "\\4");
+          index = LA_Filler_Fitter::layer_index(TIB, stereo, layer);
+
+          calibrations[label].slopes[index] = line.second.first;
+          calibrations[label].offsets[index] = line.first.first;
+          calibrations[label].pulls[index] = pull;
+        }
+      }
+
+      file << std::endl
+           << std::endl
+           << "# Best Fit Line: " << line.first.first << "(" << line.first.second << ")   +   x* " << line.second.first
+           << "(" << line.second.second << ")" << std::endl
+           << "# Pull (average sigma of (x_measure-x_truth)/e_measure): " << pull << std::endl
+           << "LA_Calibration( METHOD_XXXXX , xxx, " << line.second.first << ", " << line.first.first << ", " << pull
+           << ")," << std::endl;
+      file.close();
+    }
+  }
+
+  void EnsembleCalibrationLA::write_ensembles_plots(const Book& book) const {
+    TFile file((Prefix + "sampleFits.root").c_str(), "RECREATE");
+    for (Book::const_iterator hist = book.begin(".*(profile|ratio|reconstruction|symm|symmchi2|_w\\d)");
+         hist != book.end();
+         ++hist)
+      hist->second->Write();
+    file.Close();
+  }
+
+  void EnsembleCalibrationLA::write_samples_plots(const Book& book) const {
+    TFile file((Prefix + "ensembleFits.root").c_str(), "RECREATE");
+    for (Book::const_iterator hist = book.begin(".*(measure|merr|ensembleReco|pull)"); hist != book.end(); ++hist)
+      hist->second->Write();
+    file.Close();
+  }
+
+  void EnsembleCalibrationLA::write_calibrations() const {
+    std::fstream file((Prefix + "calibrations.dat").c_str(), std::ios::out);
+    for (auto const& cal : calibrations) {
+      file << cal.first << std::endl << "\t slopes(";
+      for (float i : cal.second.slopes)
+        file << i << ",";
+      file << ")" << std::endl << "\t offsets(";
+      for (float i : cal.second.offsets)
+        file << i << ",";
+      file << ")" << std::endl << "\t pulls(";
+      for (float i : cal.second.pulls)
+        file << i << ",";
+      file << ")" << std::endl;
+    }
+    file.close();
+  }
+
+}  // namespace sistrip

--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h
@@ -6,40 +6,35 @@
 #include "CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h"
 
 namespace sistrip {
-class EnsembleCalibrationLA : public edm::EDAnalyzer {
+  class EnsembleCalibrationLA : public edm::EDAnalyzer {
+  public:
+    explicit EnsembleCalibrationLA(const edm::ParameterSet&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override {}
+    void endRun(const edm::Run&, const edm::EventSetup&) override;
+    void endJob() override;
 
- public:
+  private:
+    void write_ensembles_text(const Book&);
+    void write_ensembles_plots(const Book&) const;
+    void write_samples_plots(const Book&) const;
+    void write_calibrations() const;
 
-  explicit EnsembleCalibrationLA(const edm::ParameterSet&);
-  void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  void endRun(const edm::Run&, const edm::EventSetup&) override;
-  void endJob() override;
+    const std::vector<std::string> inputFiles;
+    const std::string inFileLocation, Prefix;
+    const unsigned maxEvents, samples, nbins;
+    const double lowBin, highBin;
+    std::vector<int> vMethods;
 
- private:
-  
-  void write_ensembles_text(const Book&);
-  void write_ensembles_plots(const Book&) const;
-  void write_samples_plots(const Book&) const;
-  void write_calibrations() const;
+    struct MethodCalibrations {
+      MethodCalibrations()
+          : slopes(std::vector<float>(14, 0)), offsets(std::vector<float>(14, 10)), pulls(std::vector<float>(14, 0)) {}
+      std::vector<float> slopes;
+      std::vector<float> offsets;
+      std::vector<float> pulls;
+    };
+    std::map<std::string, MethodCalibrations> calibrations;
 
-  const std::vector<std::string> inputFiles;
-  const std::string inFileLocation, Prefix;
-  const unsigned maxEvents,samples, nbins;
-  const double lowBin,highBin;
-  std::vector<int> vMethods;
-
-  struct MethodCalibrations {
-    MethodCalibrations() : 
-      slopes(std::vector<float>(14,0)),
-      offsets(std::vector<float>(14,10)),
-      pulls(std::vector<float>(14,0)) {}
-    std::vector<float> slopes;
-    std::vector<float> offsets;
-    std::vector<float> pulls;
+    const TrackerTopology* tTopo_;
   };
-  std::map<std::string,MethodCalibrations> calibrations;
-  
-  const TrackerTopology* tTopo_;
-};
-}
+}  // namespace sistrip
 #endif

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
@@ -7,52 +7,51 @@
 #include <TChain.h>
 #include <TFile.h>
 
-
 namespace sistrip {
 
-void MeasureLA::
-store_methods_and_granularity( const edm::VParameterSet& vpset) {
-  for(auto const& p : vpset) {
-    methods |= p.getParameter<int32_t>("Method"); 
-    byModule = byModule || p.getParameter<int32_t>("Granularity");
-    byLayer  = byLayer  || !p.getParameter<int32_t>("Granularity");
+  void MeasureLA::store_methods_and_granularity(const edm::VParameterSet& vpset) {
+    for (auto const& p : vpset) {
+      methods |= p.getParameter<int32_t>("Method");
+      byModule = byModule || p.getParameter<int32_t>("Granularity");
+      byLayer = byLayer || !p.getParameter<int32_t>("Granularity");
+    }
   }
-}
 
-MeasureLA::MeasureLA(const edm::ParameterSet& conf) :
-  inputFiles( conf.getParameter<std::vector<std::string> >("InputFiles") ),
-  inFileLocation( conf.getParameter<std::string>("InFileLocation")),
-  fp_(conf.getParameter<edm::FileInPath>("SiStripDetInfo") ),
-  reports( conf.getParameter<edm::VParameterSet>("Reports")),
-  measurementPreferences( conf.getParameter<edm::VParameterSet>("MeasurementPreferences")),
-  calibrations(conf.getParameter<edm::VParameterSet>("Calibrations")),
-  methods(0), byModule(false), byLayer(false), 
-  localybin(conf.getUntrackedParameter<double>("LocalYBin",0.0)),
-  stripsperbin(conf.getUntrackedParameter<unsigned>("StripsPerBin",0)),
-  maxEvents( conf.getUntrackedParameter<unsigned>("MaxEvents",0)),
-  tTopo_(StandaloneTrackerTopology::fromTrackerParametersXMLFile(conf.getParameter<edm::FileInPath>("TrackerParameters").fullPath()))
-{
-  store_methods_and_granularity( reports );
-  store_methods_and_granularity( measurementPreferences );
-  store_calibrations();
+  MeasureLA::MeasureLA(const edm::ParameterSet& conf)
+      : inputFiles(conf.getParameter<std::vector<std::string> >("InputFiles")),
+        inFileLocation(conf.getParameter<std::string>("InFileLocation")),
+        fp_(conf.getParameter<edm::FileInPath>("SiStripDetInfo")),
+        reports(conf.getParameter<edm::VParameterSet>("Reports")),
+        measurementPreferences(conf.getParameter<edm::VParameterSet>("MeasurementPreferences")),
+        calibrations(conf.getParameter<edm::VParameterSet>("Calibrations")),
+        methods(0),
+        byModule(false),
+        byLayer(false),
+        localybin(conf.getUntrackedParameter<double>("LocalYBin", 0.0)),
+        stripsperbin(conf.getUntrackedParameter<unsigned>("StripsPerBin", 0)),
+        maxEvents(conf.getUntrackedParameter<unsigned>("MaxEvents", 0)),
+        tTopo_(StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+            conf.getParameter<edm::FileInPath>("TrackerParameters").fullPath())) {
+    store_methods_and_granularity(reports);
+    store_methods_and_granularity(measurementPreferences);
+    store_calibrations();
 
-  TChain*const chain = new TChain("la_data"); 
-  for(auto const& file : inputFiles) chain->Add((file+inFileLocation).c_str());
-  
-  LA_Filler_Fitter laff(methods, byLayer, byModule, localybin, stripsperbin, maxEvents, &tTopo_);
-  laff.fill(chain, book);
-  laff.fit(book);
-  summarize_module_muH_byLayer(laff);
-  process_reports();
+    TChain* const chain = new TChain("la_data");
+    for (auto const& file : inputFiles)
+      chain->Add((file + inFileLocation).c_str());
 
-  setWhatProduced(this,&MeasureLA::produce);
-}
+    LA_Filler_Fitter laff(methods, byLayer, byModule, localybin, stripsperbin, maxEvents, &tTopo_);
+    laff.fill(chain, book);
+    laff.fit(book);
+    summarize_module_muH_byLayer(laff);
+    process_reports();
 
+    setWhatProduced(this, &MeasureLA::produce);
+  }
 
-std::unique_ptr<SiStripLorentzAngle> MeasureLA::
-produce(const SiStripLorentzAngleRcd& ) {
-  auto lorentzAngle = std::make_unique<SiStripLorentzAngle>();
-  /*
+  std::unique_ptr<SiStripLorentzAngle> MeasureLA::produce(const SiStripLorentzAngleRcd&) {
+    auto lorentzAngle = std::make_unique<SiStripLorentzAngle>();
+    /*
   std::map<uint32_t,LA_Filler_Fitter::Result> 
     module_results = LA_Filler_Fitter::module_results(book, LA_Filler_Fitter::SQRTVAR);
   
@@ -61,133 +60,139 @@ produce(const SiStripLorentzAngleRcd& ) {
     lorentzAngle->putLorentzAngle( detid, la );
   }
   */
-  return lorentzAngle;
-}
+    return lorentzAngle;
+  }
 
+  void MeasureLA::summarize_module_muH_byLayer(const LA_Filler_Fitter& laff) {
+    for (int m = LA_Filler_Fitter::FIRST_METHOD; m <= LA_Filler_Fitter::LAST_METHOD; m <<= 1) {
+      const LA_Filler_Fitter::Method method = (LA_Filler_Fitter::Method)m;
+      for (auto& result : LA_Filler_Fitter::module_results(book, method)) {
+        calibrate(calibration_key(result.first, method), result.second);
+        std::string label =
+            laff.layerLabel(result.first) + granularity(MODULESUMMARY) + LA_Filler_Fitter::method(method);
+        label = boost::regex_replace(label, boost::regex("layer"), "");
 
+        const double mu_H = -result.second.calMeasured.first / result.second.field;
+        const double sigma_mu_H = result.second.calMeasured.second / result.second.field;
+        const double weight = pow(1. / sigma_mu_H, 2);
 
-
-void MeasureLA::
-summarize_module_muH_byLayer(const LA_Filler_Fitter& laff) {
-  for(int m = LA_Filler_Fitter::FIRST_METHOD; m <= LA_Filler_Fitter::LAST_METHOD; m<<=1) {
-    const LA_Filler_Fitter::Method method = (LA_Filler_Fitter::Method)m;
-    for(auto& result : LA_Filler_Fitter::module_results(book, method)) {
-      
-      calibrate( calibration_key(result.first,method), result.second); 
-      std::string label = laff.layerLabel(result.first) + granularity(MODULESUMMARY) + LA_Filler_Fitter::method(method);
-      label = boost::regex_replace(label,boost::regex("layer"),"");
-      
-      const double mu_H = -result.second.calMeasured.first / result.second.field;
-      const double sigma_mu_H = result.second.calMeasured.second / result.second.field;
-      const double weight = pow(1./sigma_mu_H, 2);
-      
-      book.fill(mu_H, label, 150,-0.05,0.1, weight);
-    }
-    for(Book::iterator it = book.begin(".*"+granularity(MODULESUMMARY)+".*"); it!=book.end(); ++it) {
-      if(it->second->GetEntries()) it->second->Fit("gaus","LLQ");
+        book.fill(mu_H, label, 150, -0.05, 0.1, weight);
+      }
+      for (Book::iterator it = book.begin(".*" + granularity(MODULESUMMARY) + ".*"); it != book.end(); ++it) {
+        if (it->second->GetEntries())
+          it->second->Fit("gaus", "LLQ");
+      }
     }
   }
-}
 
-void MeasureLA::
-process_reports() const {
-  for(auto const& p : reports) {
-    const GRANULARITY gran = (GRANULARITY) p.getParameter<int32_t>("Granularity");
-    const std::string name = p.getParameter<std::string>("ReportName");
-    const LA_Filler_Fitter::Method method = (LA_Filler_Fitter::Method) p.getParameter<int32_t>("Method");
+  void MeasureLA::process_reports() const {
+    for (auto const& p : reports) {
+      const GRANULARITY gran = (GRANULARITY)p.getParameter<int32_t>("Granularity");
+      const std::string name = p.getParameter<std::string>("ReportName");
+      const LA_Filler_Fitter::Method method = (LA_Filler_Fitter::Method)p.getParameter<int32_t>("Method");
 
-    write_report_plots( name, method, gran);
-    switch(gran) {
-    case LAYER: write_report_text( name, method, LA_Filler_Fitter::layer_results(book, method) ); break;
-    case MODULE: write_report_text( name, method, LA_Filler_Fitter::module_results(book, method) ); break;
-    case MODULESUMMARY: write_report_text_ms( name, method); break;
+      write_report_plots(name, method, gran);
+      switch (gran) {
+        case LAYER:
+          write_report_text(name, method, LA_Filler_Fitter::layer_results(book, method));
+          break;
+        case MODULE:
+          write_report_text(name, method, LA_Filler_Fitter::module_results(book, method));
+          break;
+        case MODULESUMMARY:
+          write_report_text_ms(name, method);
+          break;
+      }
+    }
+
+    {
+      TFile widthsFile("widths.root", "RECREATE");
+      for (Book::const_iterator it = book.begin(".*_width"); it != book.end(); it++)
+        if (it->second)
+          it->second->Write();
+      widthsFile.Close();
     }
   }
-  
-  { TFile widthsFile("widths.root","RECREATE"); 
-    for(Book::const_iterator it = book.begin(".*_width"); it!=book.end(); it++) if(it->second) it->second->Write();
-    widthsFile.Close();}
-}
 
-void MeasureLA::
-write_report_plots(std::string name, LA_Filler_Fitter::Method method, GRANULARITY gran) const {
-  TFile file((name+".root").c_str(),"RECREATE");
-  const std::string key = ".*" + granularity(gran) + ".*("+LA_Filler_Fitter::method(method)+"|"+LA_Filler_Fitter::method(method,false)+".*)";
-  for(Book::const_iterator hist = book.begin(key); hist!=book.end(); ++hist) 
-    if(hist->second) hist->second->Write();
-  file.Close();
-}
-
-template <class T>
-void MeasureLA::
-write_report_text(std::string name, const LA_Filler_Fitter::Method& _method, const std::map<T,LA_Filler_Fitter::Result>& _results) const {
-  LA_Filler_Fitter::Method method = _method;
-  std::map<T,LA_Filler_Fitter::Result>results = _results;
-  std::fstream file((name+".dat").c_str(),std::ios::out);
-  for(auto& result : results) {
-    calibrate( calibration_key(result.first,method), result.second); 
-    file << result.first << "\t" << result.second << std::endl;
+  void MeasureLA::write_report_plots(std::string name, LA_Filler_Fitter::Method method, GRANULARITY gran) const {
+    TFile file((name + ".root").c_str(), "RECREATE");
+    const std::string key = ".*" + granularity(gran) + ".*(" + LA_Filler_Fitter::method(method) + "|" +
+                            LA_Filler_Fitter::method(method, false) + ".*)";
+    for (Book::const_iterator hist = book.begin(key); hist != book.end(); ++hist)
+      if (hist->second)
+        hist->second->Write();
+    file.Close();
   }
-  file.close();
-}
 
-void MeasureLA::
-write_report_text_ms(std::string name, LA_Filler_Fitter::Method method) const {
-  std::fstream file((name+".dat").c_str(),std::ios::out);
-  const std::string key = ".*"+granularity(MODULESUMMARY)+LA_Filler_Fitter::method(method);
-  for(Book::const_iterator it = book.begin(key); it!=book.end(); ++it) {
-    const TF1*const f = it->second->GetFunction("gaus");
-    if(f) {
-      file << it->first << "\t"
-	   << f->GetParameter(1) << "\t"
-	   << f->GetParError(1) << "\t"
-	   << f->GetParameter(2) << "\t"
-	   << f->GetParError(2) << std::endl;
+  template <class T>
+  void MeasureLA::write_report_text(std::string name,
+                                    const LA_Filler_Fitter::Method& _method,
+                                    const std::map<T, LA_Filler_Fitter::Result>& _results) const {
+    LA_Filler_Fitter::Method method = _method;
+    std::map<T, LA_Filler_Fitter::Result> results = _results;
+    std::fstream file((name + ".dat").c_str(), std::ios::out);
+    for (auto& result : results) {
+      calibrate(calibration_key(result.first, method), result.second);
+      file << result.first << "\t" << result.second << std::endl;
+    }
+    file.close();
+  }
+
+  void MeasureLA::write_report_text_ms(std::string name, LA_Filler_Fitter::Method method) const {
+    std::fstream file((name + ".dat").c_str(), std::ios::out);
+    const std::string key = ".*" + granularity(MODULESUMMARY) + LA_Filler_Fitter::method(method);
+    for (Book::const_iterator it = book.begin(key); it != book.end(); ++it) {
+      const TF1* const f = it->second->GetFunction("gaus");
+      if (f) {
+        file << it->first << "\t" << f->GetParameter(1) << "\t" << f->GetParError(1) << "\t" << f->GetParameter(2)
+             << "\t" << f->GetParError(2) << std::endl;
+      }
+    }
+    file.close();
+  }
+
+  void MeasureLA::store_calibrations() {
+    for (auto const& p : calibrations) {
+      LA_Filler_Fitter::Method method = (LA_Filler_Fitter::Method)p.getParameter<int32_t>("Method");
+      std::vector<double> slopes(p.getParameter<std::vector<double> >("Slopes"));
+      assert(slopes.size() == 14);
+      std::vector<double> offsets(p.getParameter<std::vector<double> >("Offsets"));
+      assert(offsets.size() == 14);
+      std::vector<double> pulls(p.getParameter<std::vector<double> >("Pulls"));
+      assert(pulls.size() == 14);
+
+      for (unsigned i = 0; i < 14; i++) {
+        const std::pair<unsigned, LA_Filler_Fitter::Method> key(i, method);
+        offset[key] = offsets[i];
+        slope[key] = slopes[i];
+        error_scaling[key] = pulls[i];
+      }
     }
   }
-  file.close();
-}
-  
-void MeasureLA::
-store_calibrations() {
-  for(auto const& p : calibrations) {
-    LA_Filler_Fitter::Method method = (LA_Filler_Fitter::Method) p.getParameter<int32_t>("Method");
-    std::vector<double> slopes(p.getParameter<std::vector<double> >("Slopes"));    assert(slopes.size()==14);
-    std::vector<double> offsets(p.getParameter<std::vector<double> >("Offsets"));  assert(offsets.size()==14);
-    std::vector<double> pulls(p.getParameter<std::vector<double> >("Pulls"));      assert(pulls.size()==14);
-    
-    for(unsigned i=0; i<14; i++) {
-      const std::pair<unsigned,LA_Filler_Fitter::Method> key( i, method);
-      offset[key] = offsets[i];
-      slope[key] = slopes[i];
-      error_scaling[key] = pulls[i];
-    }
+
+  inline void MeasureLA::calibrate(const std::pair<unsigned, LA_Filler_Fitter::Method> key,
+                                   LA_Filler_Fitter::Result& result) const {
+    result.calMeasured = std::make_pair<float, float>(
+        (result.measured.first - offset.find(key)->second) / slope.find(key)->second,
+        result.measured.second * error_scaling.find(key)->second / slope.find(key)->second);
   }
-}
 
-inline
-void MeasureLA::
-calibrate(const std::pair<unsigned,LA_Filler_Fitter::Method> key, LA_Filler_Fitter::Result& result) const {
-  result.calMeasured = std::make_pair<float,float>( ( result.measured.first - offset.find(key)->second ) / slope.find(key)->second ,
-						    result.measured.second * error_scaling.find(key)->second / slope.find(key)->second );
-}
-  
-std::pair<uint32_t,LA_Filler_Fitter::Method> MeasureLA::
-calibration_key(const std::string layer, const LA_Filler_Fitter::Method method) const {
-  boost::regex format(".*(T[IO]B)_layer(\\d)([as]).*");
-  const bool isTIB = "TIB" == boost::regex_replace(layer, format, "\\1");
-  const bool stereo = "s" == boost::regex_replace(layer, format, "\\3");
-  const unsigned layerNum = boost::lexical_cast<unsigned>(boost::regex_replace(layer, format, "\\2"));
-  return std::make_pair(LA_Filler_Fitter::layer_index(isTIB,stereo,layerNum),method);
-}
+  std::pair<uint32_t, LA_Filler_Fitter::Method> MeasureLA::calibration_key(
+      const std::string layer, const LA_Filler_Fitter::Method method) const {
+    boost::regex format(".*(T[IO]B)_layer(\\d)([as]).*");
+    const bool isTIB = "TIB" == boost::regex_replace(layer, format, "\\1");
+    const bool stereo = "s" == boost::regex_replace(layer, format, "\\3");
+    const unsigned layerNum = boost::lexical_cast<unsigned>(boost::regex_replace(layer, format, "\\2"));
+    return std::make_pair(LA_Filler_Fitter::layer_index(isTIB, stereo, layerNum), method);
+  }
 
-std::pair<uint32_t,LA_Filler_Fitter::Method> MeasureLA::
-calibration_key(const uint32_t detid, const LA_Filler_Fitter::Method method) const {
-  const bool isTIB = SiStripDetId(detid).subDetector() == SiStripDetId::TIB;
-  const bool stereo = isTIB ? tTopo_.tibStereo(detid) : tTopo_.tobStereo(detid);
-  const unsigned layer = isTIB ? tTopo_.tibLayer(detid) : tTopo_.tobStereo(detid);
+  std::pair<uint32_t, LA_Filler_Fitter::Method> MeasureLA::calibration_key(
+      const uint32_t detid, const LA_Filler_Fitter::Method method) const {
+    const bool isTIB = SiStripDetId(detid).subDetector() == SiStripDetId::TIB;
+    const bool stereo = isTIB ? tTopo_.tibStereo(detid) : tTopo_.tobStereo(detid);
+    const unsigned layer = isTIB ? tTopo_.tibLayer(detid) : tTopo_.tobStereo(detid);
 
-  return std::make_pair(LA_Filler_Fitter::layer_index(isTIB,stereo,layer),method);
-}
+    return std::make_pair(LA_Filler_Fitter::layer_index(isTIB, stereo, layer), method);
+  }
 
-}
+}  // namespace sistrip

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.h
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.h
@@ -14,49 +14,56 @@
 
 namespace sistrip {
 
-class MeasureLA : public edm::ESProducer {
+  class MeasureLA : public edm::ESProducer {
+  public:
+    explicit MeasureLA(const edm::ParameterSet&);
+    std::unique_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleRcd&);
 
- public:
+  private:
+    enum GRANULARITY { LAYER = 0, MODULE = 1, MODULESUMMARY = 2 };
+    static std::string granularity(int32_t g) {
+      switch (g) {
+        case LAYER:
+          return "_layer";
+        case MODULE:
+          return "_module";
+        case MODULESUMMARY:
+          return "_moduleSummary";
+      }
+      return "";
+    };
 
-  explicit MeasureLA(const edm::ParameterSet&);
-  std::unique_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleRcd&);
-  
- private:
+    void store_calibrations();
+    void store_methods_and_granularity(const edm::VParameterSet&);
 
-  enum GRANULARITY {LAYER=0, MODULE=1, MODULESUMMARY=2};
-  static std::string granularity(int32_t g) { switch(g) {
-    case LAYER: return "_layer"; 
-    case MODULE: return "_module"; 
-    case MODULESUMMARY: return "_moduleSummary";
-  } return "";};
+    void summarize_module_muH_byLayer(const LA_Filler_Fitter&);
+    void process_reports() const;
+    template <class T>
+    void write_report_text(const std::string,
+                           const LA_Filler_Fitter::Method&,
+                           const std::map<T, LA_Filler_Fitter::Result>&) const;
+    void write_report_text_ms(const std::string, const LA_Filler_Fitter::Method) const;
+    void write_report_plots(const std::string, const LA_Filler_Fitter::Method, const GRANULARITY) const;
 
-  void store_calibrations();
-  void store_methods_and_granularity(const edm::VParameterSet&);
+    void calibrate(const std::pair<unsigned, LA_Filler_Fitter::Method>, LA_Filler_Fitter::Result&) const;
+    std::pair<unsigned, LA_Filler_Fitter::Method> calibration_key(const std::string layer,
+                                                                  const LA_Filler_Fitter::Method) const;
+    std::pair<unsigned, LA_Filler_Fitter::Method> calibration_key(const uint32_t detid,
+                                                                  const LA_Filler_Fitter::Method) const;
 
-  void summarize_module_muH_byLayer(const LA_Filler_Fitter&);
-  void process_reports() const;
-  template<class T>
-  void write_report_text(const std::string, const LA_Filler_Fitter::Method&, const std::map<T,LA_Filler_Fitter::Result>&) const;
-  void write_report_text_ms(const std::string, const LA_Filler_Fitter::Method ) const;
-  void write_report_plots(const std::string, const LA_Filler_Fitter::Method, const GRANULARITY) const;
+    const std::vector<std::string> inputFiles;
+    const std::string inFileLocation;
+    const edm::FileInPath fp_;
+    const edm::VParameterSet reports, measurementPreferences, calibrations;
+    std::map<std::pair<uint32_t, LA_Filler_Fitter::Method>, float> slope, offset, error_scaling;
+    int32_t methods;
+    bool byModule, byLayer;
+    const float localybin;
+    const unsigned stripsperbin, maxEvents;
+    Book book;
 
-  void calibrate(const std::pair<unsigned,LA_Filler_Fitter::Method>, LA_Filler_Fitter::Result&) const;
-  std::pair<unsigned,LA_Filler_Fitter::Method> calibration_key(const std::string layer, const LA_Filler_Fitter::Method) const;
-  std::pair<unsigned,LA_Filler_Fitter::Method> calibration_key(const uint32_t detid, const LA_Filler_Fitter::Method) const ;
+    TrackerTopology tTopo_;
+  };
 
-  const std::vector<std::string> inputFiles;
-  const std::string inFileLocation;
-  const edm::FileInPath fp_;
-  const edm::VParameterSet reports, measurementPreferences, calibrations;
-  std::map<std::pair<uint32_t,LA_Filler_Fitter::Method>,float> slope, offset, error_scaling;
-  int32_t methods;
-  bool byModule, byLayer;
-  const float localybin;
-  const unsigned stripsperbin,maxEvents;
-  Book book;
-
-  TrackerTopology tTopo_;
-};
-
-}
+}  // namespace sistrip
 #endif

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
@@ -19,47 +19,48 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-SiStripCalibLorentzAngle::SiStripCalibLorentzAngle(edm::ParameterSet const& conf) : ConditionDBWriter<SiStripLorentzAngle>(conf) , tTopo(nullptr), conf_(conf) {}
+SiStripCalibLorentzAngle::SiStripCalibLorentzAngle(edm::ParameterSet const& conf)
+    : ConditionDBWriter<SiStripLorentzAngle>(conf), tTopo(nullptr), conf_(conf) {}
 
-void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
+void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   c.get<TrackerTopologyRcd>().get(tTopoHandle);
   tTopo = tTopoHandle.product();
 
   c.get<TrackerDigiGeometryRecord>().get(estracker);
-  tracker=&(*estracker); 
-  
+  tracker = &(*estracker);
+
   //get magnetic field and geometry from ES
   edm::ESHandle<MagneticField> magfield_;
   c.get<IdealMagneticFieldRecord>().get(magfield_);
 
   edm::ESHandle<SiStripLorentzAngle> SiStripLorentzAngle_;
   c.get<SiStripLorentzAngleRcd>().get(SiStripLorentzAngle_);
-  detid_la= SiStripLorentzAngle_->getLorentzAngles();
-  
+  detid_la = SiStripLorentzAngle_->getLorentzAngles();
+
   DQMStore* dbe_ = edm::Service<DQMStore>().operator->();
-  
-  std::string inputFile_ =conf_.getUntrackedParameter<std::string>("fileName", "LAProfiles.root");
-  std::string LAreport_ =conf_.getUntrackedParameter<std::string>("LA_Report", "LA_Report.txt");
-  std::string NoEntriesHisto_ =conf_.getUntrackedParameter<std::string>("NoEntriesHisto", "NoEntriesHisto.txt");
-  std::string Dir_Name_ =conf_.getUntrackedParameter<std::string>("Dir_Name", "SiStrip");
-  
+
+  std::string inputFile_ = conf_.getUntrackedParameter<std::string>("fileName", "LAProfiles.root");
+  std::string LAreport_ = conf_.getUntrackedParameter<std::string>("LA_Report", "LA_Report.txt");
+  std::string NoEntriesHisto_ = conf_.getUntrackedParameter<std::string>("NoEntriesHisto", "NoEntriesHisto.txt");
+  std::string Dir_Name_ = conf_.getUntrackedParameter<std::string>("Dir_Name", "SiStrip");
+
   LayerDB = conf_.getUntrackedParameter<bool>("LayerDB", false);
-  
+
   CalibByMC = conf_.getUntrackedParameter<bool>("CalibByMC", false);
-  
+
   dbe_->open(inputFile_);
-  
+
   // use SistripHistoId for producing histogram id (and title)
   SiStripHistoId hidmanager;
-  
-  edm::LogInfo("SiStripCalibLorentzAngle")<<"### DIR-NAME = "<<Dir_Name_;
-  histolist= dbe_->getAllContents(Dir_Name_);
+
+  edm::LogInfo("SiStripCalibLorentzAngle") << "### DIR-NAME = " << Dir_Name_;
+  histolist = dbe_->getAllContents(Dir_Name_);
   std::vector<MonitorElement*>::iterator histo;
-  
-  hFile = new TFile (conf_.getUntrackedParameter<std::string>("out_fileName").c_str(), "RECREATE" );
-    
+
+  hFile = new TFile(conf_.getUntrackedParameter<std::string>("out_fileName").c_str(), "RECREATE");
+
   LorentzAngle_Plots = hFile->mkdir("LorentzAngle_Plots");
   Rootple = LorentzAngle_Plots->mkdir("Rootple");
   MuH = LorentzAngle_Plots->mkdir("MuH");
@@ -80,153 +81,181 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
   SecondIT_BadFit_Histos = LorentzAngle_Plots->mkdir("2IT_BadFit_Histos");
   TIB_2IT_BadFit = SecondIT_BadFit_Histos->mkdir("TIB_2IT_BadFit");
   TOB_2IT_BadFit = SecondIT_BadFit_Histos->mkdir("TOB_2IT_BadFit");
-    
-  TH1Ds["LA_TIB"] = new TH1D("TanLAPerTesla TIB","TanLAPerTesla TIB",1000,-0.5,0.5);
+
+  TH1Ds["LA_TIB"] = new TH1D("TanLAPerTesla TIB", "TanLAPerTesla TIB", 1000, -0.5, 0.5);
   TH1Ds["LA_TIB"]->SetDirectory(MuH);
-  TH1Ds["LA_TOB"] = new TH1D("TanLAPerTesla TOB","TanLAPerTesla TOB",1000,-0.5,0.5);
+  TH1Ds["LA_TOB"] = new TH1D("TanLAPerTesla TOB", "TanLAPerTesla TOB", 1000, -0.5, 0.5);
   TH1Ds["LA_TOB"]->SetDirectory(MuH);
-  TH1Ds["LA_err_TIB"] = new TH1D("TanLAPerTesla Error TIB","TanLAPerTesla Error TIB",1000,0,1);
+  TH1Ds["LA_err_TIB"] = new TH1D("TanLAPerTesla Error TIB", "TanLAPerTesla Error TIB", 1000, 0, 1);
   TH1Ds["LA_err_TIB"]->SetDirectory(MuH);
-  TH1Ds["LA_err_TOB"] = new TH1D("TanLAPerTesla Error TOB","TanLAPerTesla Error TOB",1000,0,1);
+  TH1Ds["LA_err_TOB"] = new TH1D("TanLAPerTesla Error TOB", "TanLAPerTesla Error TOB", 1000, 0, 1);
   TH1Ds["LA_err_TOB"]->SetDirectory(MuH);
-  TH1Ds["LA_chi2norm_TIB"] = new TH1D("TanLAPerTesla Chi2norm TIB","TanLAPerTesla Chi2norm TIB",2000,0,10);
+  TH1Ds["LA_chi2norm_TIB"] = new TH1D("TanLAPerTesla Chi2norm TIB", "TanLAPerTesla Chi2norm TIB", 2000, 0, 10);
   TH1Ds["LA_chi2norm_TIB"]->SetDirectory(MuH);
-  TH1Ds["LA_chi2norm_TOB"] = new TH1D("TanLAPerTesla Chi2norm TOB","TanLAPerTesla Chi2norm TOB",2000,0,10);
+  TH1Ds["LA_chi2norm_TOB"] = new TH1D("TanLAPerTesla Chi2norm TOB", "TanLAPerTesla Chi2norm TOB", 2000, 0, 10);
   TH1Ds["LA_chi2norm_TOB"]->SetDirectory(MuH);
-  TH1Ds["MagneticField"] = new TH1D("MagneticField","MagneticField",500,0,5);
+  TH1Ds["MagneticField"] = new TH1D("MagneticField", "MagneticField", 500, 0, 5);
   TH1Ds["MagneticField"]->SetDirectory(MuH);
-  
-  TH2Ds["LA_TIB_graph"] = new TH2D("TanLAPerTesla TIB Layers","TanLAPerTesla TIB Layers",60,0,5,1000,-0.3,0.3);
+
+  TH2Ds["LA_TIB_graph"] = new TH2D("TanLAPerTesla TIB Layers", "TanLAPerTesla TIB Layers", 60, 0, 5, 1000, -0.3, 0.3);
   TH2Ds["LA_TIB_graph"]->SetDirectory(MuH);
   TH2Ds["LA_TIB_graph"]->SetNdivisions(6);
-  TH2Ds["LA_TOB_graph"] = new TH2D("TanLAPerTesla TOB Layers","TanLAPerTesla TOB Layers",80,0,7,1000,-0.3,0.3);
+  TH2Ds["LA_TOB_graph"] = new TH2D("TanLAPerTesla TOB Layers", "TanLAPerTesla TOB Layers", 80, 0, 7, 1000, -0.3, 0.3);
   TH2Ds["LA_TOB_graph"]->SetDirectory(MuH);
   TH2Ds["LA_TOB_graph"]->SetNdivisions(8);
 
-  TH1Ds["LA_TIB_1"] = new TH1D("TanLAPerTesla TIB1","TanLAPerTesla TIB1",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_1"] = new TH1D("TanLAPerTesla TIB1", "TanLAPerTesla TIB1", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_1"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_1_mono"] = new TH1D("TanLAPerTesla TIB1 MONO","TanLAPerTesla TIB1 MONO",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_1_mono"] = new TH1D("TanLAPerTesla TIB1 MONO", "TanLAPerTesla TIB1 MONO", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_1_mono"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_1_stereo"] = new TH1D("TanLAPerTesla TIB1 STEREO","TanLAPerTesla TIB1 STEREO",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_1_stereo"] = new TH1D("TanLAPerTesla TIB1 STEREO", "TanLAPerTesla TIB1 STEREO", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_1_stereo"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_2"] = new TH1D("TanLAPerTesla TIB2","TanLAPerTesla TIB2",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_2"] = new TH1D("TanLAPerTesla TIB2", "TanLAPerTesla TIB2", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_2"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_2_mono"] = new TH1D("TanLAPerTesla TIB2 MONO","TanLAPerTesla TIB2 MONO",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_2_mono"] = new TH1D("TanLAPerTesla TIB2 MONO", "TanLAPerTesla TIB2 MONO", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_2_mono"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_2_stereo"] = new TH1D("TanLAPerTesla TIB2 STEREO","TanLAPerTesla TIB2 STEREO",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_2_stereo"] = new TH1D("TanLAPerTesla TIB2 STEREO", "TanLAPerTesla TIB2 STEREO", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_2_stereo"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_3"] = new TH1D("TanLAPerTesla_TIB 3","TanLAPerTesla TIB3",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_3"] = new TH1D("TanLAPerTesla_TIB 3", "TanLAPerTesla TIB3", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_3"]->SetDirectory(TIB_MuH);
-  TH1Ds["LA_TIB_4"] = new TH1D("TanLAPerTesla_TIB 4","TanLAPerTesla TIB4",2000,-0.5,0.5);
+  TH1Ds["LA_TIB_4"] = new TH1D("TanLAPerTesla_TIB 4", "TanLAPerTesla TIB4", 2000, -0.5, 0.5);
   TH1Ds["LA_TIB_4"]->SetDirectory(TIB_MuH);
-  
-  TH1Ds["LA_TOB_1"] = new TH1D("TanLAPerTesla TOB1","TanLAPerTesla TOB1",2000,-0.5,0.5);
+
+  TH1Ds["LA_TOB_1"] = new TH1D("TanLAPerTesla TOB1", "TanLAPerTesla TOB1", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_1"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_1_mono"] = new TH1D("TanLAPerTesla TOB1 MONO","TanLAPerTesla TOB1 MONO",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_1_mono"] = new TH1D("TanLAPerTesla TOB1 MONO", "TanLAPerTesla TOB1 MONO", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_1_mono"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_1_stereo"] = new TH1D("TanLAPerTesla TOB1 STEREO","TanLAPerTesla TOB1 STEREO",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_1_stereo"] = new TH1D("TanLAPerTesla TOB1 STEREO", "TanLAPerTesla TOB1 STEREO", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_1_stereo"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_2"] = new TH1D("TanLAPerTesla TOB2","TanLAPerTesla TOB2",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_2"] = new TH1D("TanLAPerTesla TOB2", "TanLAPerTesla TOB2", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_2"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_2_mono"] = new TH1D("TanLAPerTesla TOB2 MONO","TanLAPerTesla TOB2 MONO",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_2_mono"] = new TH1D("TanLAPerTesla TOB2 MONO", "TanLAPerTesla TOB2 MONO", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_2_mono"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_2_stereo"] = new TH1D("TanLAPerTesla TOB2 STEREO","TanLAPerTesla TOB2 STEREO",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_2_stereo"] = new TH1D("TanLAPerTesla TOB2 STEREO", "TanLAPerTesla TOB2 STEREO", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_2_stereo"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_3"] = new TH1D("TanLAPerTesla TOB3","TanLAPerTesla TOB3",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_3"] = new TH1D("TanLAPerTesla TOB3", "TanLAPerTesla TOB3", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_3"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_4"] = new TH1D("TanLAPerTesla TOB4","TanLAPerTesla TOB4",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_4"] = new TH1D("TanLAPerTesla TOB4", "TanLAPerTesla TOB4", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_4"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_5"] = new TH1D("TanLAPerTesla TOB5","TanLAPerTesla TOB5",2000,-0.5,0.5);
+  TH1Ds["LA_TOB_5"] = new TH1D("TanLAPerTesla TOB5", "TanLAPerTesla TOB5", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_5"]->SetDirectory(TOB_MuH);
-  TH1Ds["LA_TOB_6"] = new TH1D("TanLAPerTesla TOB6","TanLAPerTesla TOB6",2000,-0.5,0.5); 
+  TH1Ds["LA_TOB_6"] = new TH1D("TanLAPerTesla TOB6", "TanLAPerTesla TOB6", 2000, -0.5, 0.5);
   TH1Ds["LA_TOB_6"]->SetDirectory(TOB_MuH);
-    
-  TH2Ds["LA_phi_TIB"] = new TH2D("TanLAPerTesla vs Phi TIB","TanLAPerTesla vs Phi TIB",800,-4,4,600,-0.3,0.3);
+
+  TH2Ds["LA_phi_TIB"] = new TH2D("TanLAPerTesla vs Phi TIB", "TanLAPerTesla vs Phi TIB", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB"]->SetDirectory(MuH_vs_Phi);
-  TH2Ds["LA_phi_TOB"] = new TH2D("TanLAPerTesla vs Phi TOB","TanLAPerTesla vs Phi TOB",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB"] = new TH2D("TanLAPerTesla vs Phi TOB", "TanLAPerTesla vs Phi TOB", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB"]->SetDirectory(MuH_vs_Phi);
-  
-  TH2Ds["LA_phi_TIB1"] = new TH2D("TanLAPerTesla vs Phi TIB1","TanLAPerTesla vs Phi TIB1",800,-4,4,600,-0.3,0.3);
+
+  TH2Ds["LA_phi_TIB1"] = new TH2D("TanLAPerTesla vs Phi TIB1", "TanLAPerTesla vs Phi TIB1", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB1"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB1_mono"] = new TH2D("TanLAPerTesla vs Phi TIB1 MONO","TanLAPerTesla vs Phi TIB1 MONO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB1_mono"] =
+      new TH2D("TanLAPerTesla vs Phi TIB1 MONO", "TanLAPerTesla vs Phi TIB1 MONO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB1_mono"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB1_stereo"] = new TH2D("TanLAPerTesla vs Phi TIB1 STEREO","TanLAPerTesla vs Phi TIB1 STEREO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB1_stereo"] =
+      new TH2D("TanLAPerTesla vs Phi TIB1 STEREO", "TanLAPerTesla vs Phi TIB1 STEREO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB1_stereo"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB2"] = new TH2D("TanLAPerTesla vs Phi TIB2","TanLAPerTesla vs Phi TIB2",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB2"] = new TH2D("TanLAPerTesla vs Phi TIB2", "TanLAPerTesla vs Phi TIB2", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB2"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB2_mono"] = new TH2D("TanLAPerTesla vs Phi TIB2 MONO","TanLAPerTesla vs Phi TIB2 MONO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB2_mono"] =
+      new TH2D("TanLAPerTesla vs Phi TIB2 MONO", "TanLAPerTesla vs Phi TIB2 MONO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB2_mono"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB2_stereo"] = new TH2D("TanLAPerTesla vs Phi TIB2 STEREO","TanLAPerTesla vs Phi TIB2 STEREO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB2_stereo"] =
+      new TH2D("TanLAPerTesla vs Phi TIB2 STEREO", "TanLAPerTesla vs Phi TIB2 STEREO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB2_stereo"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB3"] = new TH2D("TanLAPerTesla vs Phi TIB3","TanLAPerTesla vs Phi TIB3",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB3"] = new TH2D("TanLAPerTesla vs Phi TIB3", "TanLAPerTesla vs Phi TIB3", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB3"]->SetDirectory(TIB_Phi);
-  TH2Ds["LA_phi_TIB4"] = new TH2D("TanLAPerTesla vs Phi TIB4","TanLAPerTesla vs Phi TIB4",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TIB4"] = new TH2D("TanLAPerTesla vs Phi TIB4", "TanLAPerTesla vs Phi TIB4", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TIB4"]->SetDirectory(TIB_Phi);
-  
-  TH2Ds["LA_phi_TOB1"] = new TH2D("TanLAPerTesla vs Phi TOB1","TanLAPerTesla vs Phi TOB1",800,-4,4,600,-0.3,0.3);
+
+  TH2Ds["LA_phi_TOB1"] = new TH2D("TanLAPerTesla vs Phi TOB1", "TanLAPerTesla vs Phi TOB1", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB1"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB1_mono"] = new TH2D("TanLAPerTesla vs Phi TOB1 MONO","TanLAPerTesla vs Phi TOB1 MONO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB1_mono"] =
+      new TH2D("TanLAPerTesla vs Phi TOB1 MONO", "TanLAPerTesla vs Phi TOB1 MONO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB1_mono"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB1_stereo"] = new TH2D("TanLAPerTesla vs Phi TOB1 STEREO","TanLAPerTesla vs Phi TOB1 STEREO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB1_stereo"] =
+      new TH2D("TanLAPerTesla vs Phi TOB1 STEREO", "TanLAPerTesla vs Phi TOB1 STEREO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB1_stereo"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB2"] = new TH2D("TanLAPerTesla vs Phi TOB2","TanLAPerTesla vs Phi TOB2",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB2"] = new TH2D("TanLAPerTesla vs Phi TOB2", "TanLAPerTesla vs Phi TOB2", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB2"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB2_mono"] = new TH2D("TanLAPerTesla vs Phi TOB2 MONO","TanLAPerTesla vs Phi TOB2 MONO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB2_mono"] =
+      new TH2D("TanLAPerTesla vs Phi TOB2 MONO", "TanLAPerTesla vs Phi TOB2 MONO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB2_mono"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB2_stereo"] = new TH2D("TanLAPerTesla vs Phi TOB2 STEREO","TanLAPerTesla vs Phi TOB2 STEREO",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB2_stereo"] =
+      new TH2D("TanLAPerTesla vs Phi TOB2 STEREO", "TanLAPerTesla vs Phi TOB2 STEREO", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB2_stereo"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB3"] = new TH2D("TanLAPerTesla vs Phi TOB3","TanLAPerTesla vs Phi TOB3",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB3"] = new TH2D("TanLAPerTesla vs Phi TOB3", "TanLAPerTesla vs Phi TOB3", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB3"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB4"] = new TH2D("TanLAPerTesla vs Phi TOB4","TanLAPerTesla vs Phi TOB4",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB4"] = new TH2D("TanLAPerTesla vs Phi TOB4", "TanLAPerTesla vs Phi TOB4", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB4"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB5"] = new TH2D("TanLAPerTesla vs Phi TOB5","TanLAPerTesla vs Phi TOB5",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB5"] = new TH2D("TanLAPerTesla vs Phi TOB5", "TanLAPerTesla vs Phi TOB5", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB5"]->SetDirectory(TOB_Phi);
-  TH2Ds["LA_phi_TOB6"] = new TH2D("TanLAPerTesla vs Phi TOB6","TanLAPerTesla vs Phi TOB6",800,-4,4,600,-0.3,0.3);
+  TH2Ds["LA_phi_TOB6"] = new TH2D("TanLAPerTesla vs Phi TOB6", "TanLAPerTesla vs Phi TOB6", 800, -4, 4, 600, -0.3, 0.3);
   TH2Ds["LA_phi_TOB6"]->SetDirectory(TOB_Phi);
-  
-  TH2Ds["LA_eta_TIB"] = new TH2D("TanLAPerTesla vs Eta TIB","TanLAPerTesla vs Eta TIB",800,-2.6,2.6,600,-0.3,0.3);
+
+  TH2Ds["LA_eta_TIB"] =
+      new TH2D("TanLAPerTesla vs Eta TIB", "TanLAPerTesla vs Eta TIB", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB"]->SetDirectory(MuH_vs_Eta);
-  TH2Ds["LA_eta_TOB"] = new TH2D("TanLAPerTesla vs Eta TOB","TanLAPerTesla vs Eta TOB",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB"] =
+      new TH2D("TanLAPerTesla vs Eta TOB", "TanLAPerTesla vs Eta TOB", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB"]->SetDirectory(MuH_vs_Eta);
-  
-  TH2Ds["LA_eta_TIB1"] = new TH2D("TanLAPerTesla vs Eta TIB1","TanLAPerTesla vs Eta TIB1",800,-2.6,2.6,600,-0.3,0.3);
+
+  TH2Ds["LA_eta_TIB1"] =
+      new TH2D("TanLAPerTesla vs Eta TIB1", "TanLAPerTesla vs Eta TIB1", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB1"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB1_mono"] = new TH2D("TanLAPerTesla vs Eta TIB1 MONO","TanLAPerTesla vs Eta TIB1 MONO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB1_mono"] =
+      new TH2D("TanLAPerTesla vs Eta TIB1 MONO", "TanLAPerTesla vs Eta TIB1 MONO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB1_mono"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB1_stereo"] = new TH2D("TanLAPerTesla vs Eta TIB1 STEREO","TanLAPerTesla vs Eta TIB1 STEREO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB1_stereo"] =
+      new TH2D("TanLAPerTesla vs Eta TIB1 STEREO", "TanLAPerTesla vs Eta TIB1 STEREO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB1_stereo"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB2"] = new TH2D("TanLAPerTesla vs Eta TIB2","TanLAPerTesla vs Eta TIB2",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB2"] =
+      new TH2D("TanLAPerTesla vs Eta TIB2", "TanLAPerTesla vs Eta TIB2", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB2"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB2_mono"] = new TH2D("TanLAPerTesla vs Eta TIB2 MONO","TanLAPerTesla vs Eta TIB2 MONO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB2_mono"] =
+      new TH2D("TanLAPerTesla vs Eta TIB2 MONO", "TanLAPerTesla vs Eta TIB2 MONO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB2_mono"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB2_stereo"] = new TH2D("TanLAPerTesla vs Eta TIB2 STEREO","TanLAPerTesla vs Eta TIB2 STEREO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB2_stereo"] =
+      new TH2D("TanLAPerTesla vs Eta TIB2 STEREO", "TanLAPerTesla vs Eta TIB2 STEREO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB2_stereo"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB3"] = new TH2D("TanLAPerTesla vs Eta TIB3","TanLAPerTesla vs Eta TIB3",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB3"] =
+      new TH2D("TanLAPerTesla vs Eta TIB3", "TanLAPerTesla vs Eta TIB3", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB3"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TIB4"] = new TH2D("TanLAPerTesla vs Eta TIB4","TanLAPerTesla vs Eta TIB4",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TIB4"] =
+      new TH2D("TanLAPerTesla vs Eta TIB4", "TanLAPerTesla vs Eta TIB4", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TIB4"]->SetDirectory(TIB_Eta);
-  
-  TH2Ds["LA_eta_TOB1"] = new TH2D("TanLAPerTesla vs Eta TOB1","TanLAPerTesla vs Eta TOB1",800,-2.6,2.6,600,-0.3,0.3);
+
+  TH2Ds["LA_eta_TOB1"] =
+      new TH2D("TanLAPerTesla vs Eta TOB1", "TanLAPerTesla vs Eta TOB1", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB1"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB1_mono"] = new TH2D("TanLAPerTesla vs Eta TOB1 MONO","TanLAPerTesla vs Eta TOB1 MONO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB1_mono"] =
+      new TH2D("TanLAPerTesla vs Eta TOB1 MONO", "TanLAPerTesla vs Eta TOB1 MONO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB1_mono"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB1_stereo"] = new TH2D("TanLAPerTesla vs Eta TOB1 STEREO","TanLAPerTesla vs Eta TOB1 STEREO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB1_stereo"] =
+      new TH2D("TanLAPerTesla vs Eta TOB1 STEREO", "TanLAPerTesla vs Eta TOB1 STEREO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB1_stereo"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB2"] = new TH2D("TanLAPerTesla vs Eta TOB2","TanLAPerTesla vs Eta TOB2",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB2"] =
+      new TH2D("TanLAPerTesla vs Eta TOB2", "TanLAPerTesla vs Eta TOB2", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB2"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB2_mono"] = new TH2D("TanLAPerTesla vs Eta TOB2 MONO","TanLAPerTesla vs Eta TOB2 MONO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB2_mono"] =
+      new TH2D("TanLAPerTesla vs Eta TOB2 MONO", "TanLAPerTesla vs Eta TOB2 MONO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB2_mono"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB2_stereo"] = new TH2D("TanLAPerTesla vs Eta TOB2 STEREO","TanLAPerTesla vs Eta TOB2 STEREO",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB2_stereo"] =
+      new TH2D("TanLAPerTesla vs Eta TOB2 STEREO", "TanLAPerTesla vs Eta TOB2 STEREO", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB2_stereo"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB3"] = new TH2D("TanLAPerTesla vs Eta TOB3","TanLAPerTesla vs Eta TOB3",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB3"] =
+      new TH2D("TanLAPerTesla vs Eta TOB3", "TanLAPerTesla vs Eta TOB3", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB3"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB4"] = new TH2D("TanLAPerTesla vs Eta TOB4","TanLAPerTesla vs Eta TOB4",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB4"] =
+      new TH2D("TanLAPerTesla vs Eta TOB4", "TanLAPerTesla vs Eta TOB4", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB4"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB5"] = new TH2D("TanLAPerTesla vs Eta TOB5","TanLAPerTesla vs Eta TOB5",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB5"] =
+      new TH2D("TanLAPerTesla vs Eta TOB5", "TanLAPerTesla vs Eta TOB5", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB5"]->SetDirectory(TIB_Eta);
-  TH2Ds["LA_eta_TOB6"] = new TH2D("TanLAPerTesla vs Eta TOB6","TanLAPerTesla vs Eta TOB6",800,-2.6,2.6,600,-0.3,0.3);
+  TH2Ds["LA_eta_TOB6"] =
+      new TH2D("TanLAPerTesla vs Eta TOB6", "TanLAPerTesla vs Eta TOB6", 800, -2.6, 2.6, 600, -0.3, 0.3);
   TH2Ds["LA_eta_TOB6"]->SetDirectory(TIB_Eta);
-  
+
   ModuleTree = new TTree("ModuleTree", "ModuleTree");
   ModuleTree->Branch("histoEntries", &histoEntries, "histoEntries/F");
   ModuleTree->Branch("globalX", &globalX, "globalX/F");
@@ -244,9 +273,9 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
   ModuleTree->Branch("MonoStereo", &MonoStereo, "MonoStereo/I");
   ModuleTree->Branch("theBfield", &theBfield, "theBfield/F");
   ModuleTree->Branch("muH", &muH, "muH/F");
-  
+
   ModuleTree->SetDirectory(Rootple);
-     
+
   int histocounter = 0;
   int NotEnoughEntries = 0;
   int ZeroEntries = 0;
@@ -257,22 +286,22 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
   int SecondIT_goodfit = 0;
   int no_mod_histo = 0;
   float chi2norm = 0;
-  LocalPoint p =LocalPoint(0,0,0);
-  
-  double ModuleRangeMin=conf_.getParameter<double>("ModuleFitXMin");
-  double ModuleRangeMax=conf_.getParameter<double>("ModuleFitXMax");
-  double ModuleRangeMin2IT=conf_.getParameter<double>("ModuleFit2ITXMin");
-  double ModuleRangeMax2IT=conf_.getParameter<double>("ModuleFit2ITXMax");
-  double FitCuts_Entries=conf_.getParameter<double>("FitCuts_Entries");
-  double FitCuts_p0=conf_.getParameter<double>("FitCuts_p0");
-  double FitCuts_p1=conf_.getParameter<double>("FitCuts_p1");
-  double FitCuts_p2=conf_.getParameter<double>("FitCuts_p2");
-  double FitCuts_chi2=conf_.getParameter<double>("FitCuts_chi2");
-  double FitCuts_ParErr_p0=conf_.getParameter<double>("FitCuts_ParErr_p0");
-  double p0_guess=conf_.getParameter<double>("p0_guess");
-  double p1_guess=conf_.getParameter<double>("p1_guess");
-  double p2_guess=conf_.getParameter<double>("p2_guess");
-  
+  LocalPoint p = LocalPoint(0, 0, 0);
+
+  double ModuleRangeMin = conf_.getParameter<double>("ModuleFitXMin");
+  double ModuleRangeMax = conf_.getParameter<double>("ModuleFitXMax");
+  double ModuleRangeMin2IT = conf_.getParameter<double>("ModuleFit2ITXMin");
+  double ModuleRangeMax2IT = conf_.getParameter<double>("ModuleFit2ITXMax");
+  double FitCuts_Entries = conf_.getParameter<double>("FitCuts_Entries");
+  double FitCuts_p0 = conf_.getParameter<double>("FitCuts_p0");
+  double FitCuts_p1 = conf_.getParameter<double>("FitCuts_p1");
+  double FitCuts_p2 = conf_.getParameter<double>("FitCuts_p2");
+  double FitCuts_chi2 = conf_.getParameter<double>("FitCuts_chi2");
+  double FitCuts_ParErr_p0 = conf_.getParameter<double>("FitCuts_ParErr_p0");
+  double p0_guess = conf_.getParameter<double>("p0_guess");
+  double p1_guess = conf_.getParameter<double>("p1_guess");
+  double p2_guess = conf_.getParameter<double>("p2_guess");
+
   double TIB1calib = 1.;
   double TIB2calib = 1.;
   double TIB3calib = 1.;
@@ -283,573 +312,591 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
   double TOB4calib = 1.;
   double TOB5calib = 1.;
   double TOB6calib = 1.;
-  
-  if(CalibByMC==true){
-  //Calibration factors evaluated by using MC analysis
-  TIB1calib=conf_.getParameter<double>("TIB1calib");
-  TIB2calib=conf_.getParameter<double>("TIB2calib");
-  TIB3calib=conf_.getParameter<double>("TIB3calib");
-  TIB4calib=conf_.getParameter<double>("TIB4calib");
-  TOB1calib=conf_.getParameter<double>("TOB1calib");
-  TOB2calib=conf_.getParameter<double>("TOB2calib");
-  TOB3calib=conf_.getParameter<double>("TOB3calib");
-  TOB4calib=conf_.getParameter<double>("TOB4calib");
-  TOB5calib=conf_.getParameter<double>("TOB5calib");
-  TOB6calib=conf_.getParameter<double>("TOB6calib");
+
+  if (CalibByMC == true) {
+    //Calibration factors evaluated by using MC analysis
+    TIB1calib = conf_.getParameter<double>("TIB1calib");
+    TIB2calib = conf_.getParameter<double>("TIB2calib");
+    TIB3calib = conf_.getParameter<double>("TIB3calib");
+    TIB4calib = conf_.getParameter<double>("TIB4calib");
+    TOB1calib = conf_.getParameter<double>("TOB1calib");
+    TOB2calib = conf_.getParameter<double>("TOB2calib");
+    TOB3calib = conf_.getParameter<double>("TOB3calib");
+    TOB4calib = conf_.getParameter<double>("TOB4calib");
+    TOB5calib = conf_.getParameter<double>("TOB5calib");
+    TOB6calib = conf_.getParameter<double>("TOB6calib");
   }
-  
-  
-  auto fitfunc= std::make_unique<TF1>("fitfunc","([4]/[3])*[1]*(TMath::Abs(x-[0]))+[2]",-1,1);
-  auto fitfunc2IT= std::make_unique<TF1>("fitfunc2IT","([4]/[3])*[1]*(TMath::Abs(x-[0]))+[2]",-1,1);
- 
+
+  auto fitfunc = std::make_unique<TF1>("fitfunc", "([4]/[3])*[1]*(TMath::Abs(x-[0]))+[2]", -1, 1);
+  auto fitfunc2IT = std::make_unique<TF1>("fitfunc2IT", "([4]/[3])*[1]*(TMath::Abs(x-[0]))+[2]", -1, 1);
+
   std::ofstream NoEntries;
   NoEntries.open(NoEntriesHisto_.c_str());
   std::ofstream Rep;
   Rep.open(LAreport_.c_str());
-  
+
   gStyle->SetOptStat(1110);
-  
-  for(histo=histolist.begin();histo!=histolist.end();++histo){
-  
-  FitFunction = nullptr;
-  FitFunction2IT = nullptr;
-  bool Good2ITFit = false;
-  bool ModuleHisto = true;
-  
-  histoEntries = -99;
-  gphi=-99;
-  geta=-99;
-  gz = -99;
-  gR=-1;
-  globalX = -99;
-  globalY = -99;
-  globalZ = -99;
-  goodFit = 0;
-  goodFit1IT = 0;
-  badFit = 0;
-  muH = -1;
-  TIB = 0;
-  TOB = 0;
-  MonoStereo = -1;
-  
-    uint32_t id=hidmanager.getComponentId((*histo)->getName());
+
+  for (histo = histolist.begin(); histo != histolist.end(); ++histo) {
+    FitFunction = nullptr;
+    FitFunction2IT = nullptr;
+    bool Good2ITFit = false;
+    bool ModuleHisto = true;
+
+    histoEntries = -99;
+    gphi = -99;
+    geta = -99;
+    gz = -99;
+    gR = -1;
+    globalX = -99;
+    globalY = -99;
+    globalZ = -99;
+    goodFit = 0;
+    goodFit1IT = 0;
+    badFit = 0;
+    muH = -1;
+    TIB = 0;
+    TOB = 0;
+    MonoStereo = -1;
+
+    uint32_t id = hidmanager.getComponentId((*histo)->getName());
     DetId detid(id);
     StripSubdetector subid(id);
-    const GeomDetUnit * stripdet;
+    const GeomDetUnit* stripdet;
     MonoStereo = subid.stereo();
-    
-    if(!(stripdet=tracker->idToDetUnit(subid))){
-    no_mod_histo++;
-    ModuleHisto=false;
-    edm::LogInfo("SiStripCalibLorentzAngle")<<"### NO MODULE HISTOGRAM";}
-    
-    if(stripdet!=nullptr && ModuleHisto==true){
-    
-      if(subid.subdetId() == int (StripSubdetector::TIB)){
-      
-      Layer = tTopo->tibLayer(detid);
-      TIB = 1;}     
-      if(subid.subdetId() == int (StripSubdetector::TOB)){
-      
-      Layer = tTopo->tobLayer(detid);
-      TOB = 1;}
-      
-    //get module coordinates
-    const GlobalPoint gposition = (stripdet->surface()).toGlobal(p);
-    histoEntries = (*histo)->getEntries();
-    globalX = gposition.x();
-    globalY = gposition.y();
-    globalZ = gposition.z();
-    gphi = gposition.phi();
-    geta = gposition.eta();
-    gR = sqrt(pow(gposition.x(),2)+pow(gposition.y(),2));
-    gz = gposition.z();
-    
-    //get magnetic field
-    const StripGeomDetUnit* det = dynamic_cast<const StripGeomDetUnit*>(estracker->idToDetUnit(detid));
-    if (det==nullptr){
-    edm::LogError("SiStripCalibLorentzAngle") << "[SiStripCalibLorentzAngle::getNewObject] the detID " << id << " doesn't seem to belong to Tracker" <<std::endl; 	
-    continue;
+
+    if (!(stripdet = tracker->idToDetUnit(subid))) {
+      no_mod_histo++;
+      ModuleHisto = false;
+      edm::LogInfo("SiStripCalibLorentzAngle") << "### NO MODULE HISTOGRAM";
     }
-    LocalVector lbfield=(det->surface()).toLocal(magfield_->inTesla(det->surface().position()));
-    theBfield = lbfield.mag();
-    theBfield = (theBfield > 0) ? theBfield : 0.00001; 
-    TH1Ds["MagneticField"]->Fill(theBfield);    
+
+    if (stripdet != nullptr && ModuleHisto == true) {
+      if (subid.subdetId() == int(StripSubdetector::TIB)) {
+        Layer = tTopo->tibLayer(detid);
+        TIB = 1;
+      }
+      if (subid.subdetId() == int(StripSubdetector::TOB)) {
+        Layer = tTopo->tobLayer(detid);
+        TOB = 1;
+      }
+
+      //get module coordinates
+      const GlobalPoint gposition = (stripdet->surface()).toGlobal(p);
+      histoEntries = (*histo)->getEntries();
+      globalX = gposition.x();
+      globalY = gposition.y();
+      globalZ = gposition.z();
+      gphi = gposition.phi();
+      geta = gposition.eta();
+      gR = sqrt(pow(gposition.x(), 2) + pow(gposition.y(), 2));
+      gz = gposition.z();
+
+      //get magnetic field
+      const StripGeomDetUnit* det = dynamic_cast<const StripGeomDetUnit*>(estracker->idToDetUnit(detid));
+      if (det == nullptr) {
+        edm::LogError("SiStripCalibLorentzAngle") << "[SiStripCalibLorentzAngle::getNewObject] the detID " << id
+                                                  << " doesn't seem to belong to Tracker" << std::endl;
+        continue;
+      }
+      LocalVector lbfield = (det->surface()).toLocal(magfield_->inTesla(det->surface().position()));
+      theBfield = lbfield.mag();
+      theBfield = (theBfield > 0) ? theBfield : 0.00001;
+      TH1Ds["MagneticField"]->Fill(theBfield);
     }
-    if(stripdet==nullptr)continue;
-      
-    if(((*histo)->getEntries()<=FitCuts_Entries)&&ModuleHisto==true){
-    if(((*histo)->getEntries()==0)&&ModuleHisto==true){    
-    NoEntries<<"NO ENTRIES MODULE, ID = "<<id<<std::endl;    
-    edm::LogInfo("SiStripCalibLorentzAngle")<<"### HISTOGRAM WITH 0 ENTRIES => TYPE:"<<subid.subdetId();
-    ZeroEntries++;
-    }else{    
-    edm::LogInfo("SiStripCalibLorentzAngle")<<"### HISTOGRAM WITH NR. ENTRIES <= ENTRIES_CUT => TYPE:"<<subid.subdetId();
-    NotEnoughEntries++;}    
+    if (stripdet == nullptr)
+      continue;
+
+    if (((*histo)->getEntries() <= FitCuts_Entries) && ModuleHisto == true) {
+      if (((*histo)->getEntries() == 0) && ModuleHisto == true) {
+        NoEntries << "NO ENTRIES MODULE, ID = " << id << std::endl;
+        edm::LogInfo("SiStripCalibLorentzAngle") << "### HISTOGRAM WITH 0 ENTRIES => TYPE:" << subid.subdetId();
+        ZeroEntries++;
+      } else {
+        edm::LogInfo("SiStripCalibLorentzAngle")
+            << "### HISTOGRAM WITH NR. ENTRIES <= ENTRIES_CUT => TYPE:" << subid.subdetId();
+        NotEnoughEntries++;
+      }
     }
-    
-      std::string name;
-      if(TIB==1){
-      name+="TIB";
-      }else{
-      name+="TOB";}
-      std::stringstream LayerStream;
-      LayerStream<<Layer;
-      name+=LayerStream.str();    
-      std::stringstream idnum;
-      idnum<<id;
-      name+="_Id_";
-      name+=idnum.str();
-      
-    gStyle->SetOptFit(111);  
-    
+
+    std::string name;
+    if (TIB == 1) {
+      name += "TIB";
+    } else {
+      name += "TOB";
+    }
+    std::stringstream LayerStream;
+    LayerStream << Layer;
+    name += LayerStream.str();
+    std::stringstream idnum;
+    idnum << id;
+    name += "_Id_";
+    name += idnum.str();
+
+    gStyle->SetOptFit(111);
+
     //Extract TProfile from Monitor Element to ProfileMap
-    Profiles[name] = new TProfile;   
-    TProfile* theProfile=ExtractTObject<TProfile>().extract(*histo);   
-    theProfile->Copy(*Profiles[name]);    
+    Profiles[name] = new TProfile;
+    TProfile* theProfile = ExtractTObject<TProfile>().extract(*histo);
+    theProfile->Copy(*Profiles[name]);
     Profiles[name]->SetName(name.c_str());
-  
-    if(((*histo)->getEntries()>FitCuts_Entries) && ModuleHisto==true){   
-      histocounter++;            
-      if(TIB==1){
-      edm::LogInfo("SiStripCalibLorentzAngle")<<"TIB layer = "<<Layer;}    
-      if(TOB==1){
-      edm::LogInfo("SiStripCalibLorentzAngle")<<"TOB layer = "<<Layer;}     
-      edm::LogInfo("SiStripCalibLorentzAngle")<<"id: "<<id;    
-            
-      float thickness=stripdet->specificSurface().bounds().thickness();
-      const StripTopology& topol=(const StripTopology&)stripdet->topology();
+
+    if (((*histo)->getEntries() > FitCuts_Entries) && ModuleHisto == true) {
+      histocounter++;
+      if (TIB == 1) {
+        edm::LogInfo("SiStripCalibLorentzAngle") << "TIB layer = " << Layer;
+      }
+      if (TOB == 1) {
+        edm::LogInfo("SiStripCalibLorentzAngle") << "TOB layer = " << Layer;
+      }
+      edm::LogInfo("SiStripCalibLorentzAngle") << "id: " << id;
+
+      float thickness = stripdet->specificSurface().bounds().thickness();
+      const StripTopology& topol = (const StripTopology&)stripdet->topology();
       float pitch = topol.localPitch(p);
-           	  
+
       fitfunc->SetParameter(0, p0_guess);
       fitfunc->SetParameter(1, p1_guess);
       fitfunc->SetParameter(2, p2_guess);
       fitfunc->FixParameter(3, pitch);
       fitfunc->FixParameter(4, thickness);
-      
-      Profiles[name]->Fit(fitfunc.get(),"E","",ModuleRangeMin, ModuleRangeMax);
-            
+
+      Profiles[name]->Fit(fitfunc.get(), "E", "", ModuleRangeMin, ModuleRangeMax);
+
       FitFunction = fitfunc.get();
-      chi2norm = FitFunction->GetChisquare()/FitFunction->GetNDF();
-      
-      if(FitFunction->GetParameter(0)>FitCuts_p0 || FitFunction->GetParameter(1)<FitCuts_p1 || FitFunction->GetParameter(2)<FitCuts_p2 || chi2norm>FitCuts_chi2 || FitFunction->GetParError(0)<FitCuts_ParErr_p0){
-      
-      FirstIT_badfit++;   
-            
-      fitfunc2IT->SetParameter(0, p0_guess);
-      fitfunc2IT->SetParameter(1, p1_guess);
-      fitfunc2IT->SetParameter(2, p2_guess);
-      fitfunc2IT->FixParameter(3, pitch);
-      fitfunc2IT->FixParameter(4, thickness);
-      
-      //2nd Iteration
-      Profiles[name]->Fit(fitfunc2IT.get(),"E","",ModuleRangeMin2IT, ModuleRangeMax2IT);
-      
-      FitFunction = fitfunc2IT.get();
-      chi2norm = FitFunction->GetChisquare()/FitFunction->GetNDF();
-                
-      //2nd Iteration failed
-      
-      if(FitFunction->GetParameter(0)>FitCuts_p0 || FitFunction->GetParameter(1)<FitCuts_p1 || FitFunction->GetParameter(2)<FitCuts_p2 || chi2norm>FitCuts_chi2 || FitFunction->GetParError(0)<FitCuts_ParErr_p0){
-      
-      if(subid.subdetId() == int (StripSubdetector::TIB)){
-      Profiles[name]->SetDirectory(TIB_2IT_BadFit);
-      }else{
-      Profiles[name]->SetDirectory(TOB_2IT_BadFit);} 
-            
-      SecondIT_badfit++;
-      badFit=1;     
-          
+      chi2norm = FitFunction->GetChisquare() / FitFunction->GetNDF();
+
+      if (FitFunction->GetParameter(0) > FitCuts_p0 || FitFunction->GetParameter(1) < FitCuts_p1 ||
+          FitFunction->GetParameter(2) < FitCuts_p2 || chi2norm > FitCuts_chi2 ||
+          FitFunction->GetParError(0) < FitCuts_ParErr_p0) {
+        FirstIT_badfit++;
+
+        fitfunc2IT->SetParameter(0, p0_guess);
+        fitfunc2IT->SetParameter(1, p1_guess);
+        fitfunc2IT->SetParameter(2, p2_guess);
+        fitfunc2IT->FixParameter(3, pitch);
+        fitfunc2IT->FixParameter(4, thickness);
+
+        //2nd Iteration
+        Profiles[name]->Fit(fitfunc2IT.get(), "E", "", ModuleRangeMin2IT, ModuleRangeMax2IT);
+
+        FitFunction = fitfunc2IT.get();
+        chi2norm = FitFunction->GetChisquare() / FitFunction->GetNDF();
+
+        //2nd Iteration failed
+
+        if (FitFunction->GetParameter(0) > FitCuts_p0 || FitFunction->GetParameter(1) < FitCuts_p1 ||
+            FitFunction->GetParameter(2) < FitCuts_p2 || chi2norm > FitCuts_chi2 ||
+            FitFunction->GetParError(0) < FitCuts_ParErr_p0) {
+          if (subid.subdetId() == int(StripSubdetector::TIB)) {
+            Profiles[name]->SetDirectory(TIB_2IT_BadFit);
+          } else {
+            Profiles[name]->SetDirectory(TOB_2IT_BadFit);
+          }
+
+          SecondIT_badfit++;
+          badFit = 1;
+        }
+
+        //2nd Iteration ok
+
+        if (FitFunction->GetParameter(0) < FitCuts_p0 && FitFunction->GetParameter(1) > FitCuts_p1 &&
+            FitFunction->GetParameter(2) > FitCuts_p2 && chi2norm < FitCuts_chi2 &&
+            FitFunction->GetParError(0) > FitCuts_ParErr_p0) {
+          if (subid.subdetId() == int(StripSubdetector::TIB)) {
+            Profiles[name]->SetDirectory(TIB_2IT_GoodFit);
+          } else {
+            Profiles[name]->SetDirectory(TOB_2IT_GoodFit);
+          }
+
+          SecondIT_goodfit++;
+          Good2ITFit = true;
+        }
       }
-      
-      //2nd Iteration ok
-     
-      if(FitFunction->GetParameter(0)<FitCuts_p0 && FitFunction->GetParameter(1)>FitCuts_p1 && FitFunction->GetParameter(2)>FitCuts_p2 && chi2norm<FitCuts_chi2 && FitFunction->GetParError(0)>FitCuts_ParErr_p0){
-      
-      if(subid.subdetId() == int (StripSubdetector::TIB)){
-      Profiles[name]->SetDirectory(TIB_2IT_GoodFit);
-      }else{
-      Profiles[name]->SetDirectory(TOB_2IT_GoodFit);} 
-      
-      SecondIT_goodfit++;      
-      Good2ITFit = true;
-      
+
+      if (FitFunction->GetParameter(0) < FitCuts_p0 && FitFunction->GetParameter(1) > FitCuts_p1 &&
+          FitFunction->GetParameter(2) > FitCuts_p2 && chi2norm < FitCuts_chi2 &&
+          FitFunction->GetParError(0) > FitCuts_ParErr_p0) {
+        if (Good2ITFit == false) {
+          FirstIT_goodfit++;
+          goodFit1IT = 1;
+
+          if (subid.subdetId() == int(StripSubdetector::TIB)) {
+            Profiles[name]->SetDirectory(TIB_1IT_GoodFit);
+          } else {
+            Profiles[name]->SetDirectory(TOB_1IT_GoodFit);
+          }
+        }
+
+        GoodFit++;
+        goodFit = 1;
+
+        LorentzAngle_Plots->cd();
+
+        edm::LogInfo("SiStripCalibLorentzAngle") << FitFunction->GetParameter(0);
+
+        muH = -(FitFunction->GetParameter(0)) / theBfield;
+
+        if (TIB == 1) {
+          if (Layer == 1)
+            muH = muH / TIB1calib;
+          if (Layer == 2)
+            muH = muH / TIB2calib;
+          if (Layer == 3)
+            muH = muH / TIB3calib;
+          if (Layer == 4)
+            muH = muH / TIB4calib;
+        }
+        if (TOB == 1) {
+          if (Layer == 1)
+            muH = muH / TOB1calib;
+          if (Layer == 2)
+            muH = muH / TOB2calib;
+          if (Layer == 3)
+            muH = muH / TOB3calib;
+          if (Layer == 4)
+            muH = muH / TOB4calib;
+          if (Layer == 5)
+            muH = muH / TOB5calib;
+          if (Layer == 6)
+            muH = muH / TOB6calib;
+        }
+
+        detid_la[id] = muH;
+
+        if (TIB == 1) {
+          TH1Ds["LA_TIB"]->Fill(muH);
+          TH1Ds["LA_err_TIB"]->Fill(FitFunction->GetParError(0) / theBfield);
+          TH1Ds["LA_chi2norm_TIB"]->Fill(chi2norm);
+          TH2Ds["LA_phi_TIB"]->Fill(gphi, muH);
+          TH2Ds["LA_eta_TIB"]->Fill(geta, muH);
+          TH2Ds["LA_TIB_graph"]->Fill(Layer, muH);
+
+          if (Layer == 1) {
+            TH1Ds["LA_TIB_1"]->Fill(muH);
+            TH2Ds["LA_phi_TIB1"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TIB1"]->Fill(geta, muH);
+            if (MonoStereo == 0) {
+              TH1Ds["LA_TIB_1_mono"]->Fill(muH);
+              TH2Ds["LA_phi_TIB1_mono"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TIB1_mono"]->Fill(geta, muH);
+            }
+            if (MonoStereo == 1) {
+              TH1Ds["LA_TIB_1_stereo"]->Fill(muH);
+              TH2Ds["LA_phi_TIB1_stereo"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TIB1_stereo"]->Fill(geta, muH);
+            }
+          }
+
+          if (Layer == 2) {
+            TH1Ds["LA_TIB_2"]->Fill(muH);
+            TH2Ds["LA_phi_TIB2"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TIB2"]->Fill(geta, muH);
+            if (MonoStereo == 0) {
+              TH1Ds["LA_TIB_2_mono"]->Fill(muH);
+              TH2Ds["LA_phi_TIB2_mono"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TIB2_mono"]->Fill(geta, muH);
+            }
+            if (MonoStereo == 1) {
+              TH1Ds["LA_TIB_2_stereo"]->Fill(muH);
+              TH2Ds["LA_phi_TIB2_stereo"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TIB2_stereo"]->Fill(geta, muH);
+            }
+          }
+
+          if (Layer == 3) {
+            TH1Ds["LA_TIB_3"]->Fill(muH);
+            TH2Ds["LA_phi_TIB3"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TIB3"]->Fill(geta, muH);
+          }
+
+          if (Layer == 4) {
+            TH1Ds["LA_TIB_4"]->Fill(muH);
+            TH2Ds["LA_phi_TIB4"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TIB4"]->Fill(geta, muH);
+          }
+        }
+
+        if (TOB == 1) {
+          TH1Ds["LA_TOB"]->Fill(muH);
+          TH1Ds["LA_err_TOB"]->Fill(FitFunction->GetParError(0) / theBfield);
+          TH1Ds["LA_chi2norm_TOB"]->Fill(chi2norm);
+          TH2Ds["LA_phi_TOB"]->Fill(gphi, muH);
+          TH2Ds["LA_eta_TOB"]->Fill(geta, muH);
+          TH2Ds["LA_TOB_graph"]->Fill(Layer, muH);
+
+          if (Layer == 1) {
+            TH1Ds["LA_TOB_1"]->Fill(muH);
+            TH2Ds["LA_phi_TOB1"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TOB1"]->Fill(geta, muH);
+            if (MonoStereo == 0) {
+              TH1Ds["LA_TOB_1_mono"]->Fill(muH);
+              TH2Ds["LA_phi_TOB1_mono"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TOB1_mono"]->Fill(geta, muH);
+            }
+            if (MonoStereo == 1) {
+              TH1Ds["LA_TOB_1_stereo"]->Fill(muH);
+              TH2Ds["LA_phi_TOB1_stereo"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TOB1_stereo"]->Fill(geta, muH);
+            }
+          }
+
+          if (Layer == 2) {
+            TH1Ds["LA_TOB_2"]->Fill(muH);
+            TH2Ds["LA_phi_TOB2"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TOB2"]->Fill(geta, muH);
+            if (MonoStereo == 0) {
+              TH1Ds["LA_TOB_2_mono"]->Fill(muH);
+              TH2Ds["LA_phi_TOB2_mono"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TOB2_mono"]->Fill(geta, muH);
+            }
+            if (MonoStereo == 1) {
+              TH1Ds["LA_TOB_2_stereo"]->Fill(muH);
+              TH2Ds["LA_phi_TOB2_stereo"]->Fill(gphi, muH);
+              TH2Ds["LA_eta_TOB2_stereo"]->Fill(geta, muH);
+            }
+          }
+
+          if (Layer == 3) {
+            TH1Ds["LA_TOB_3"]->Fill(muH);
+            TH2Ds["LA_phi_TOB3"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TOB3"]->Fill(geta, muH);
+          }
+
+          if (Layer == 4) {
+            TH1Ds["LA_TOB_4"]->Fill(muH);
+            TH2Ds["LA_phi_TOB4"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TOB4"]->Fill(geta, muH);
+          }
+
+          if (Layer == 5) {
+            TH1Ds["LA_TOB_5"]->Fill(muH);
+            TH2Ds["LA_phi_TOB5"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TOB5"]->Fill(geta, muH);
+          }
+
+          if (Layer == 6) {
+            TH1Ds["LA_TOB_6"]->Fill(muH);
+            TH2Ds["LA_phi_TOB6"]->Fill(gphi, muH);
+            TH2Ds["LA_eta_TOB6"]->Fill(geta, muH);
+          }
+        }
       }
-            
-      }  
-                       
-      if(FitFunction->GetParameter(0)<FitCuts_p0 && FitFunction->GetParameter(1)>FitCuts_p1 && FitFunction->GetParameter(2)>FitCuts_p2 && chi2norm<FitCuts_chi2 && FitFunction->GetParError(0)>FitCuts_ParErr_p0){
-      
-	if(Good2ITFit==false){
-	
-	FirstIT_goodfit++;
-	goodFit1IT = 1;
-	
-	if(subid.subdetId() == int (StripSubdetector::TIB)){
-        Profiles[name]->SetDirectory(TIB_1IT_GoodFit);
-        }else{
-        Profiles[name]->SetDirectory(TOB_1IT_GoodFit);} 
-	
-	}
-	
-	GoodFit++;
-	goodFit=1;
-	
-	LorentzAngle_Plots->cd();
-            
-	edm::LogInfo("SiStripCalibLorentzAngle")<<FitFunction->GetParameter(0);
-	
-	muH = -(FitFunction->GetParameter(0))/theBfield;
-	
-	if(TIB==1){
-	if(Layer==1) muH = muH/TIB1calib;
-	if(Layer==2) muH = muH/TIB2calib;
-	if(Layer==3) muH = muH/TIB3calib;
-	if(Layer==4) muH = muH/TIB4calib;
-	}
-	if(TOB==1){
-	if(Layer==1) muH = muH/TOB1calib;
-	if(Layer==2) muH = muH/TOB2calib;
-	if(Layer==3) muH = muH/TOB3calib;
-	if(Layer==4) muH = muH/TOB4calib;
-	if(Layer==5) muH = muH/TOB5calib;
-	if(Layer==6) muH = muH/TOB6calib;
-	}
-	
-	detid_la[id]= muH;
-	
-	if(TIB==1){
-	
-	TH1Ds["LA_TIB"]->Fill(muH);
-	TH1Ds["LA_err_TIB"]->Fill(FitFunction->GetParError(0)/theBfield);
-	TH1Ds["LA_chi2norm_TIB"]->Fill(chi2norm);
-	TH2Ds["LA_phi_TIB"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB"]->Fill(geta,muH);
-	TH2Ds["LA_TIB_graph"]->Fill(Layer,muH);
-	
-	if(Layer==1){
-	TH1Ds["LA_TIB_1"]->Fill(muH);
-	TH2Ds["LA_phi_TIB1"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB1"]->Fill(geta,muH);
-	if(MonoStereo==0){
-	TH1Ds["LA_TIB_1_mono"]->Fill(muH);
-	TH2Ds["LA_phi_TIB1_mono"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB1_mono"]->Fill(geta,muH);}
-	if(MonoStereo==1){
-	TH1Ds["LA_TIB_1_stereo"]->Fill(muH);
-	TH2Ds["LA_phi_TIB1_stereo"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB1_stereo"]->Fill(geta,muH);}
-	}
-	
-	if(Layer==2){
-	TH1Ds["LA_TIB_2"]->Fill(muH);
-	TH2Ds["LA_phi_TIB2"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB2"]->Fill(geta,muH);
-	if(MonoStereo==0){
-	TH1Ds["LA_TIB_2_mono"]->Fill(muH);
-	TH2Ds["LA_phi_TIB2_mono"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB2_mono"]->Fill(geta,muH);}
-	if(MonoStereo==1){
-	TH1Ds["LA_TIB_2_stereo"]->Fill(muH);
-	TH2Ds["LA_phi_TIB2_stereo"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB2_stereo"]->Fill(geta,muH);}
-	}
-	
-	if(Layer==3){
-	TH1Ds["LA_TIB_3"]->Fill(muH);
-	TH2Ds["LA_phi_TIB3"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB3"]->Fill(geta,muH);
-	}
-	
-	if(Layer==4){
-	TH1Ds["LA_TIB_4"]->Fill(muH);
-	TH2Ds["LA_phi_TIB4"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TIB4"]->Fill(geta,muH);
-	}
-	}	
-	
-	if(TOB==1){
-	
-        TH1Ds["LA_TOB"]->Fill(muH);
-	TH1Ds["LA_err_TOB"]->Fill(FitFunction->GetParError(0)/theBfield);
-	TH1Ds["LA_chi2norm_TOB"]->Fill(chi2norm);
-	TH2Ds["LA_phi_TOB"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB"]->Fill(geta,muH);
-	TH2Ds["LA_TOB_graph"]->Fill(Layer,muH);
-	
-	if(Layer==1){
-	TH1Ds["LA_TOB_1"]->Fill(muH);
-	TH2Ds["LA_phi_TOB1"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB1"]->Fill(geta,muH);
-	if(MonoStereo==0){
-	TH1Ds["LA_TOB_1_mono"]->Fill(muH);
-	TH2Ds["LA_phi_TOB1_mono"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB1_mono"]->Fill(geta,muH);}
-	if(MonoStereo==1){
-	TH1Ds["LA_TOB_1_stereo"]->Fill(muH);
-	TH2Ds["LA_phi_TOB1_stereo"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB1_stereo"]->Fill(geta,muH);}
-	}
-	
-	if(Layer==2){
-	TH1Ds["LA_TOB_2"]->Fill(muH);
-	TH2Ds["LA_phi_TOB2"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB2"]->Fill(geta,muH);
-	if(MonoStereo==0){
-	TH1Ds["LA_TOB_2_mono"]->Fill(muH);
-	TH2Ds["LA_phi_TOB2_mono"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB2_mono"]->Fill(geta,muH);}
-	if(MonoStereo==1){
-	TH1Ds["LA_TOB_2_stereo"]->Fill(muH);
-	TH2Ds["LA_phi_TOB2_stereo"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB2_stereo"]->Fill(geta,muH);}
-	}
-	
-	if(Layer==3){
-	TH1Ds["LA_TOB_3"]->Fill(muH);
-	TH2Ds["LA_phi_TOB3"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB3"]->Fill(geta,muH);
-	}
-	
-	if(Layer==4){
-	TH1Ds["LA_TOB_4"]->Fill(muH);
-	TH2Ds["LA_phi_TOB4"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB4"]->Fill(geta,muH);
-	}
-	
-	if(Layer==5){
-	TH1Ds["LA_TOB_5"]->Fill(muH);
-	TH2Ds["LA_phi_TOB5"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB5"]->Fill(geta,muH);
-	}
-	
-	if(Layer==6){
-	TH1Ds["LA_TOB_6"]->Fill(muH);
-	TH2Ds["LA_phi_TOB6"]->Fill(gphi,muH);
-	TH2Ds["LA_eta_TOB6"]->Fill(geta,muH);
-	}
-	}
-	
-       }
     }
-    
+
     ModuleTree->Fill();
-     
   }
-  
-  double GaussFitRange=conf_.getParameter<double>("GaussFitRange");
-  auto gaus = std::make_unique<TF1>("gaus","gaus");
-  
-  TH1Ds["LA_TIB_1"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+
+  double GaussFitRange = conf_.getParameter<double>("GaussFitRange");
+  auto gaus = std::make_unique<TF1>("gaus", "gaus");
+
+  TH1Ds["LA_TIB_1"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TIB1 = gaus->GetParameter(1);
   float err_mean_TIB1 = gaus->GetParError(1);
   float rms_TIB1 = gaus->GetParameter(2);
-  TH1Ds["LA_TIB_2"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TIB_2"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TIB2 = gaus->GetParameter(1);
   float err_mean_TIB2 = gaus->GetParError(1);
   float rms_TIB2 = gaus->GetParameter(2);
-  TH1Ds["LA_TIB_3"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TIB_3"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TIB3 = gaus->GetParameter(1);
   float err_mean_TIB3 = gaus->GetParError(1);
   float rms_TIB3 = gaus->GetParameter(2);
-  TH1Ds["LA_TIB_4"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TIB_4"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TIB4 = gaus->GetParameter(1);
   float err_mean_TIB4 = gaus->GetParError(1);
   float rms_TIB4 = gaus->GetParameter(2);
 
-  TH1Ds["LA_TOB_1"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TOB_1"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TOB1 = gaus->GetParameter(1);
   float err_mean_TOB1 = gaus->GetParError(1);
   float rms_TOB1 = gaus->GetParameter(2);
-  TH1Ds["LA_TOB_2"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TOB_2"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TOB2 = gaus->GetParameter(1);
   float err_mean_TOB2 = gaus->GetParError(1);
   float rms_TOB2 = gaus->GetParameter(2);
-  TH1Ds["LA_TOB_3"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TOB_3"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TOB3 = gaus->GetParameter(1);
   float err_mean_TOB3 = gaus->GetParError(1);
   float rms_TOB3 = gaus->GetParameter(2);
-  TH1Ds["LA_TOB_4"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TOB_4"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TOB4 = gaus->GetParameter(1);
   float err_mean_TOB4 = gaus->GetParError(1);
   float rms_TOB4 = gaus->GetParameter(2);
-  TH1Ds["LA_TOB_5"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TOB_5"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TOB5 = gaus->GetParameter(1);
   float err_mean_TOB5 = gaus->GetParError(1);
   float rms_TOB5 = gaus->GetParameter(2);
-  TH1Ds["LA_TOB_6"]->Fit(gaus.get(),"","",-GaussFitRange,GaussFitRange);  
+  TH1Ds["LA_TOB_6"]->Fit(gaus.get(), "", "", -GaussFitRange, GaussFitRange);
   mean_TOB6 = gaus->GetParameter(1);
   float err_mean_TOB6 = gaus->GetParError(1);
   float rms_TOB6 = gaus->GetParameter(2);
 
-int nlayersTIB = 4;
-float TIBx[4]={1,2,3,4};
-float TIBex[4]={0,0,0,0};
-float TIBy[4]={mean_TIB1, mean_TIB2, mean_TIB3, mean_TIB4};
-float TIBey[4]={err_mean_TIB1, err_mean_TIB2, err_mean_TIB3, err_mean_TIB4};
+  int nlayersTIB = 4;
+  float TIBx[4] = {1, 2, 3, 4};
+  float TIBex[4] = {0, 0, 0, 0};
+  float TIBy[4] = {mean_TIB1, mean_TIB2, mean_TIB3, mean_TIB4};
+  float TIBey[4] = {err_mean_TIB1, err_mean_TIB2, err_mean_TIB3, err_mean_TIB4};
 
-int nlayersTOB = 6;
-float TOBx[6]={1,2,3,4,5,6};
-float TOBex[6]={0,0,0,0,0,0};
-float TOBy[6]={mean_TOB1, mean_TOB2, mean_TOB3, mean_TOB4, mean_TOB5, mean_TOB6};
-float TOBey[6]={err_mean_TOB1, err_mean_TOB2, err_mean_TOB3, err_mean_TOB4, err_mean_TOB5, err_mean_TOB6};
+  int nlayersTOB = 6;
+  float TOBx[6] = {1, 2, 3, 4, 5, 6};
+  float TOBex[6] = {0, 0, 0, 0, 0, 0};
+  float TOBy[6] = {mean_TOB1, mean_TOB2, mean_TOB3, mean_TOB4, mean_TOB5, mean_TOB6};
+  float TOBey[6] = {err_mean_TOB1, err_mean_TOB2, err_mean_TOB3, err_mean_TOB4, err_mean_TOB5, err_mean_TOB6};
 
-TIB_graph = new TGraphErrors(nlayersTIB,TIBx,TIBy,TIBex,TIBey);
-TOB_graph = new TGraphErrors(nlayersTOB,TOBx,TOBy,TOBex,TOBey);
+  TIB_graph = new TGraphErrors(nlayersTIB, TIBx, TIBy, TIBex, TIBey);
+  TOB_graph = new TGraphErrors(nlayersTOB, TOBx, TOBy, TOBex, TOBey);
 
-//TF1 *fit_TIB= new TF1("fit_TIB","[0]",0,4);
-//TF1 *fit_TOB= new TF1("fit_TOB","[0]",0,6);
+  //TF1 *fit_TIB= new TF1("fit_TIB","[0]",0,4);
+  //TF1 *fit_TOB= new TF1("fit_TOB","[0]",0,6);
 
-gStyle->SetOptFit(111);
-gStyle->SetOptStat(111);
+  gStyle->SetOptFit(111);
+  gStyle->SetOptStat(111);
 
-TIB_graph->SetTitle("TIB Layers #mu_{H}");
-TIB_graph->GetXaxis()->SetTitle("Layers");
-TIB_graph->GetXaxis()->SetNdivisions(4);
-TIB_graph->GetYaxis()->SetTitle("#mu_{H}");
-TIB_graph->SetMarkerStyle(20);
-TIB_graph->GetYaxis()->SetTitleOffset(1.3);
-TIB_graph->Fit("fit_TIB","E","",1,4);
-meanMobility_TIB = TIB_graph->GetFunction("fit_TIB")->GetParameter(0);
+  TIB_graph->SetTitle("TIB Layers #mu_{H}");
+  TIB_graph->GetXaxis()->SetTitle("Layers");
+  TIB_graph->GetXaxis()->SetNdivisions(4);
+  TIB_graph->GetYaxis()->SetTitle("#mu_{H}");
+  TIB_graph->SetMarkerStyle(20);
+  TIB_graph->GetYaxis()->SetTitleOffset(1.3);
+  TIB_graph->Fit("fit_TIB", "E", "", 1, 4);
+  meanMobility_TIB = TIB_graph->GetFunction("fit_TIB")->GetParameter(0);
 
-TOB_graph->SetTitle("TOB Layers #mu_{H}");
-TOB_graph->GetXaxis()->SetTitle("Layers");
-TOB_graph->GetXaxis()->SetNdivisions(6);
-TOB_graph->GetYaxis()->SetTitle("#mu_{H}");
-TOB_graph->SetMarkerStyle(20);
-TOB_graph->GetYaxis()->SetTitleOffset(1.3);
-TOB_graph->Fit("fit_TOB","E","",1,6);
-meanMobility_TOB = TOB_graph->GetFunction("fit_TOB")->GetParameter(0);
+  TOB_graph->SetTitle("TOB Layers #mu_{H}");
+  TOB_graph->GetXaxis()->SetTitle("Layers");
+  TOB_graph->GetXaxis()->SetNdivisions(6);
+  TOB_graph->GetYaxis()->SetTitle("#mu_{H}");
+  TOB_graph->SetMarkerStyle(20);
+  TOB_graph->GetYaxis()->SetTitleOffset(1.3);
+  TOB_graph->Fit("fit_TOB", "E", "", 1, 6);
+  meanMobility_TOB = TOB_graph->GetFunction("fit_TOB")->GetParameter(0);
 
   TIB_graph->Write("TIB_graph");
   TOB_graph->Write("TOB_graph");
 
-  Rep<<"- NR.OF TIB AND TOB MODULES = 7932"<<std::endl<<std::endl<<std::endl;
-  Rep<<"- NO MODULE HISTOS FOUND = "<<no_mod_histo<<std::endl<<std::endl;
-  Rep<<"- NR.OF HISTOS WITH ENTRIES > "<<FitCuts_Entries<<" = "<<histocounter<<std::endl<<std::endl;
-  Rep<<"- NR.OF HISTOS WITH ENTRIES <= "<<FitCuts_Entries<<" (!=0) = "<<NotEnoughEntries<<std::endl<<std::endl;
-  Rep<<"- NR.OF HISTOS WITH 0 ENTRIES = "<<ZeroEntries<<std::endl<<std::endl<<std::endl;
-  Rep<<"- NR.OF GOOD FIT (FIRST IT + SECOND IT GOOD FIT)= "<<GoodFit<<std::endl<<std::endl;
-  Rep<<"- NR.OF FIRST IT GOOD FIT = "<<FirstIT_goodfit<<std::endl<<std::endl;
-  Rep<<"- NR.OF SECOND IT GOOD FIT = "<<SecondIT_goodfit<<std::endl<<std::endl;
-  Rep<<"- NR.OF FIRST IT BAD FIT = "<<FirstIT_badfit<<std::endl<<std::endl;
-  Rep<<"- NR.OF SECOND IT BAD FIT = "<<SecondIT_badfit<<std::endl<<std::endl<<std::endl;
-  
-  Rep<<"--------------- Mean MuH values per Layer -------------------"<<std::endl<<std::endl<<std::endl;
-  Rep<<"TIB1 = "<<mean_TIB1<<" +- "<<err_mean_TIB1<<" RMS = "<<rms_TIB1<<std::endl;
-  Rep<<"TIB2 = "<<mean_TIB2<<" +- "<<err_mean_TIB2<<" RMS = "<<rms_TIB2<<std::endl;
-  Rep<<"TIB3 = "<<mean_TIB3<<" +- "<<err_mean_TIB3<<" RMS = "<<rms_TIB3<<std::endl;
-  Rep<<"TIB4 = "<<mean_TIB4<<" +- "<<err_mean_TIB4<<" RMS = "<<rms_TIB4<<std::endl;
-  Rep<<"TOB1 = "<<mean_TOB1<<" +- "<<err_mean_TOB1<<" RMS = "<<rms_TOB1<<std::endl;
-  Rep<<"TOB2 = "<<mean_TOB2<<" +- "<<err_mean_TOB2<<" RMS = "<<rms_TOB2<<std::endl;
-  Rep<<"TOB3 = "<<mean_TOB3<<" +- "<<err_mean_TOB3<<" RMS = "<<rms_TOB3<<std::endl;
-  Rep<<"TOB4 = "<<mean_TOB4<<" +- "<<err_mean_TOB4<<" RMS = "<<rms_TOB4<<std::endl;
-  Rep<<"TOB5 = "<<mean_TOB5<<" +- "<<err_mean_TOB5<<" RMS = "<<rms_TOB5<<std::endl;
-  Rep<<"TOB6 = "<<mean_TOB6<<" +- "<<err_mean_TOB6<<" RMS = "<<rms_TOB6<<std::endl<<std::endl;
-  Rep<<"Mean Hall Mobility TIB = "<<meanMobility_TIB<<" +- "<<TIB_graph->GetFunction("fit_TIB")->GetParError(0)<<std::endl;
-  Rep<<"Mean Hall Mobility TOB = "<<meanMobility_TOB<<" +- "<<TOB_graph->GetFunction("fit_TOB")->GetParError(0)<<std::endl<<std::endl<<std::endl;
-        
+  Rep << "- NR.OF TIB AND TOB MODULES = 7932" << std::endl << std::endl << std::endl;
+  Rep << "- NO MODULE HISTOS FOUND = " << no_mod_histo << std::endl << std::endl;
+  Rep << "- NR.OF HISTOS WITH ENTRIES > " << FitCuts_Entries << " = " << histocounter << std::endl << std::endl;
+  Rep << "- NR.OF HISTOS WITH ENTRIES <= " << FitCuts_Entries << " (!=0) = " << NotEnoughEntries << std::endl
+      << std::endl;
+  Rep << "- NR.OF HISTOS WITH 0 ENTRIES = " << ZeroEntries << std::endl << std::endl << std::endl;
+  Rep << "- NR.OF GOOD FIT (FIRST IT + SECOND IT GOOD FIT)= " << GoodFit << std::endl << std::endl;
+  Rep << "- NR.OF FIRST IT GOOD FIT = " << FirstIT_goodfit << std::endl << std::endl;
+  Rep << "- NR.OF SECOND IT GOOD FIT = " << SecondIT_goodfit << std::endl << std::endl;
+  Rep << "- NR.OF FIRST IT BAD FIT = " << FirstIT_badfit << std::endl << std::endl;
+  Rep << "- NR.OF SECOND IT BAD FIT = " << SecondIT_badfit << std::endl << std::endl << std::endl;
+
+  Rep << "--------------- Mean MuH values per Layer -------------------" << std::endl << std::endl << std::endl;
+  Rep << "TIB1 = " << mean_TIB1 << " +- " << err_mean_TIB1 << " RMS = " << rms_TIB1 << std::endl;
+  Rep << "TIB2 = " << mean_TIB2 << " +- " << err_mean_TIB2 << " RMS = " << rms_TIB2 << std::endl;
+  Rep << "TIB3 = " << mean_TIB3 << " +- " << err_mean_TIB3 << " RMS = " << rms_TIB3 << std::endl;
+  Rep << "TIB4 = " << mean_TIB4 << " +- " << err_mean_TIB4 << " RMS = " << rms_TIB4 << std::endl;
+  Rep << "TOB1 = " << mean_TOB1 << " +- " << err_mean_TOB1 << " RMS = " << rms_TOB1 << std::endl;
+  Rep << "TOB2 = " << mean_TOB2 << " +- " << err_mean_TOB2 << " RMS = " << rms_TOB2 << std::endl;
+  Rep << "TOB3 = " << mean_TOB3 << " +- " << err_mean_TOB3 << " RMS = " << rms_TOB3 << std::endl;
+  Rep << "TOB4 = " << mean_TOB4 << " +- " << err_mean_TOB4 << " RMS = " << rms_TOB4 << std::endl;
+  Rep << "TOB5 = " << mean_TOB5 << " +- " << err_mean_TOB5 << " RMS = " << rms_TOB5 << std::endl;
+  Rep << "TOB6 = " << mean_TOB6 << " +- " << err_mean_TOB6 << " RMS = " << rms_TOB6 << std::endl << std::endl;
+  Rep << "Mean Hall Mobility TIB = " << meanMobility_TIB << " +- " << TIB_graph->GetFunction("fit_TIB")->GetParError(0)
+      << std::endl;
+  Rep << "Mean Hall Mobility TOB = " << meanMobility_TOB << " +- " << TOB_graph->GetFunction("fit_TOB")->GetParError(0)
+      << std::endl
+      << std::endl
+      << std::endl;
+
   Rep.close();
-  NoEntries.close(); 
-  
-hFile->Write();
-hFile->Close();
-    
+  NoEntries.close();
+
+  hFile->Write();
+  hFile->Close();
 }
 
 // Virtual destructor needed.
 
-SiStripCalibLorentzAngle::~SiStripCalibLorentzAngle(){
- delete hFile;
-}
-  
+SiStripCalibLorentzAngle::~SiStripCalibLorentzAngle() { delete hFile; }
 
 // Analyzer: Functions that gets called by framework every event
-   
-std::unique_ptr<SiStripLorentzAngle> SiStripCalibLorentzAngle::getNewObject(){
 
+std::unique_ptr<SiStripLorentzAngle> SiStripCalibLorentzAngle::getNewObject() {
   auto LorentzAngle = std::make_unique<SiStripLorentzAngle>();
-  
-  if(!LayerDB){
-  for(std::map<uint32_t, float>::iterator it = detid_la.begin(); it != detid_la.end(); it++){
-    
-    float langle=it->second;
-    if ( ! LorentzAngle->putLorentzAngle(it->first,langle) )
-      edm::LogError("SiStripCalibLorentzAngle")<<"[SiStripCalibLorentzAngle::analyze] detid already exists"<<std::endl;
+
+  if (!LayerDB) {
+    for (std::map<uint32_t, float>::iterator it = detid_la.begin(); it != detid_la.end(); it++) {
+      float langle = it->second;
+      if (!LorentzAngle->putLorentzAngle(it->first, langle))
+        edm::LogError("SiStripCalibLorentzAngle")
+            << "[SiStripCalibLorentzAngle::analyze] detid already exists" << std::endl;
+    }
   }
-  }
-  
-  else{
-  
+
+  else {
     const TrackerGeometry::DetIdContainer& Id = estracker->detIds();
-    TrackerGeometry::DetIdContainer::const_iterator Iditer; 
-       
-    for(Iditer=Id.begin();Iditer!=Id.end();Iditer++){
-  
-    StripSubdetector subid(Iditer->rawId());
-    
-    hallMobility = 0.;
-    
-    if(subid.subdetId() == int (StripSubdetector::TIB)){
-    
-    uint32_t tibLayer = tTopo->tibLayer(*Iditer);
-    if(tibLayer==1){
-    hallMobility=mean_TIB1;}
-    if(tibLayer==2){
-    hallMobility=mean_TIB2;}
-    if(tibLayer==3){
-    hallMobility=mean_TIB3;}
-    if(tibLayer==4){
-    hallMobility=mean_TIB4;}
-    if (!LorentzAngle->putLorentzAngle(Iditer->rawId(),hallMobility)) edm::LogError("SiStripLorentzAngleGenerator")<<" detid already exists"<<std::endl;
+    TrackerGeometry::DetIdContainer::const_iterator Iditer;
+
+    for (Iditer = Id.begin(); Iditer != Id.end(); Iditer++) {
+      StripSubdetector subid(Iditer->rawId());
+
+      hallMobility = 0.;
+
+      if (subid.subdetId() == int(StripSubdetector::TIB)) {
+        uint32_t tibLayer = tTopo->tibLayer(*Iditer);
+        if (tibLayer == 1) {
+          hallMobility = mean_TIB1;
+        }
+        if (tibLayer == 2) {
+          hallMobility = mean_TIB2;
+        }
+        if (tibLayer == 3) {
+          hallMobility = mean_TIB3;
+        }
+        if (tibLayer == 4) {
+          hallMobility = mean_TIB4;
+        }
+        if (!LorentzAngle->putLorentzAngle(Iditer->rawId(), hallMobility))
+          edm::LogError("SiStripLorentzAngleGenerator") << " detid already exists" << std::endl;
+      }
+
+      if (subid.subdetId() == int(StripSubdetector::TOB)) {
+        uint32_t tobLayer = tTopo->tobLayer(*Iditer);
+        if (tobLayer == 1) {
+          hallMobility = mean_TOB1;
+        }
+        if (tobLayer == 2) {
+          hallMobility = mean_TOB2;
+        }
+        if (tobLayer == 3) {
+          hallMobility = mean_TOB3;
+        }
+        if (tobLayer == 4) {
+          hallMobility = mean_TOB4;
+        }
+        if (tobLayer == 5) {
+          hallMobility = mean_TOB5;
+        }
+        if (tobLayer == 6) {
+          hallMobility = mean_TOB6;
+        }
+        if (!LorentzAngle->putLorentzAngle(Iditer->rawId(), hallMobility))
+          edm::LogError("SiStripLorentzAngleGenerator") << " detid already exists" << std::endl;
+      }
+
+      if (subid.subdetId() == int(StripSubdetector::TID)) {
+        hallMobility = meanMobility_TIB;
+        if (!LorentzAngle->putLorentzAngle(Iditer->rawId(), hallMobility))
+          edm::LogError("SiStripLorentzAngleGenerator") << " detid already exists" << std::endl;
+      }
+
+      if (subid.subdetId() == int(StripSubdetector::TEC)) {
+        if (tTopo->tecRing(subid) < 5) {
+          hallMobility = meanMobility_TIB;
+        } else {
+          hallMobility = meanMobility_TOB;
+        }
+        if (!LorentzAngle->putLorentzAngle(Iditer->rawId(), hallMobility))
+          edm::LogError("SiStripLorentzAngleGenerator") << " detid already exists" << std::endl;
+      }
     }
-    
-    if(subid.subdetId() == int (StripSubdetector::TOB)){
-    
-    uint32_t tobLayer = tTopo->tobLayer(*Iditer);
-    if(tobLayer==1){
-    hallMobility=mean_TOB1;}
-    if(tobLayer==2){
-    hallMobility=mean_TOB2;}
-    if(tobLayer==3){
-    hallMobility=mean_TOB3;}
-    if(tobLayer==4){
-    hallMobility=mean_TOB4;}
-    if(tobLayer==5){
-    hallMobility=mean_TOB5;}
-    if(tobLayer==6){
-    hallMobility=mean_TOB6;}
-    if (!LorentzAngle->putLorentzAngle(Iditer->rawId(),hallMobility)) edm::LogError("SiStripLorentzAngleGenerator")<<" detid already exists"<<std::endl;
-    } 
-     
-    if( subid.subdetId() == int(StripSubdetector::TID) ) {
-    hallMobility=meanMobility_TIB;
-    if (!LorentzAngle->putLorentzAngle(Iditer->rawId(),hallMobility)) edm::LogError("SiStripLorentzAngleGenerator")<<" detid already exists"<<std::endl;
-    } 
-    
-    if( subid.subdetId() == int(StripSubdetector::TEC) ) {
-    
-    if(tTopo->tecRing(subid)<5 ) {
-    hallMobility=meanMobility_TIB;
-    }else{
-    hallMobility=meanMobility_TOB;
-    }
-    if (!LorentzAngle->putLorentzAngle(Iditer->rawId(),hallMobility)) edm::LogError("SiStripLorentzAngleGenerator")<<" detid already exists"<<std::endl;
-    }
-                 
   }
-  }
-  
+
   return LorentzAngle;
-  
 }
-
-
-
-
-
-  
-  
-  
-
-

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <fstream>
 
-
 #include "CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
@@ -45,80 +44,73 @@
 #include <TStyle.h>
 #include <TF1.h>
 
-#include<list>
+#include <list>
 
 class DetIdLess {
 public:
-  
   DetIdLess() {}
-  
-  bool operator()( const SiStripRecHit2D* a, const SiStripRecHit2D* b) const {
-    return *(a->cluster())<*(b->cluster());
+
+  bool operator()(const SiStripRecHit2D* a, const SiStripRecHit2D* b) const {
+    return *(a->cluster()) < *(b->cluster());
   }
 };
-  
 
-  //Constructor
+//Constructor
 
-SiStripLAProfileBooker::SiStripLAProfileBooker(edm::ParameterSet const& conf) : 
-  conf_(conf)
-{
-}
+SiStripLAProfileBooker::SiStripLAProfileBooker(edm::ParameterSet const& conf) : conf_(conf) {}
 
-  //BeginRun
+//BeginRun
 
-void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c){
-
+void SiStripLAProfileBooker::beginRun(const edm::Run&, const edm::EventSetup& c) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   c.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
- 
+
   //get magnetic field and geometry from ES
   edm::ESHandle<MagneticField> esmagfield;
   c.get<IdealMagneticFieldRecord>().get(esmagfield);
-  const MagneticField *  magfield=&(*esmagfield);
-  
+  const MagneticField* magfield = &(*esmagfield);
+
   edm::ESHandle<TrackerGeometry> estracker;
   c.get<TrackerDigiGeometryRecord>().get(estracker);
-  tracker=&(*estracker); 
+  tracker = &(*estracker);
 
   std::vector<uint32_t> activeDets;
-  edm::ESHandle<SiStripDetCabling> tkmechstruct=nullptr;
-  if (conf_.getParameter<bool>("UseStripCablingDB")){ 
+  edm::ESHandle<SiStripDetCabling> tkmechstruct = nullptr;
+  if (conf_.getParameter<bool>("UseStripCablingDB")) {
     c.get<SiStripDetCablingRcd>().get(tkmechstruct);
     activeDets.clear();
     tkmechstruct->addActiveDetectorsRawIds(activeDets);
-  }
-  else {
+  } else {
     const TrackerGeometry::DetIdContainer& Id = estracker->detIds();
-    TrackerGeometry::DetIdContainer::const_iterator Iditer;    
+    TrackerGeometry::DetIdContainer::const_iterator Iditer;
     activeDets.clear();
-    for(Iditer=Id.begin();Iditer!=Id.end();Iditer++){
+    for (Iditer = Id.begin(); Iditer != Id.end(); Iditer++) {
       activeDets.push_back(Iditer->rawId());
     }
   }
-   
+
   edm::InputTag TkTag = conf_.getParameter<edm::InputTag>("Tracks");
   //Get Ids;
-  double ModuleRangeMin=conf_.getParameter<double>("ModuleXMin");
-  double ModuleRangeMax=conf_.getParameter<double>("ModuleXMax");
-  double TIBRangeMin=conf_.getParameter<double>("TIBXMin");
-  double TIBRangeMax=conf_.getParameter<double>("TIBXMax");
-  double TOBRangeMin=conf_.getParameter<double>("TOBXMin");
-  double TOBRangeMax=conf_.getParameter<double>("TOBXMax");
-  int TIB_bin=conf_.getParameter<int>("TIB_bin");
-  int TOB_bin=conf_.getParameter<int>("TOB_bin");
-  int SUM_bin=conf_.getParameter<int>("SUM_bin");
-    
-  hFile = new TFile (conf_.getUntrackedParameter<std::string>("treeName").c_str(), "RECREATE" );
-  
+  double ModuleRangeMin = conf_.getParameter<double>("ModuleXMin");
+  double ModuleRangeMax = conf_.getParameter<double>("ModuleXMax");
+  double TIBRangeMin = conf_.getParameter<double>("TIBXMin");
+  double TIBRangeMax = conf_.getParameter<double>("TIBXMax");
+  double TOBRangeMin = conf_.getParameter<double>("TOBXMin");
+  double TOBRangeMax = conf_.getParameter<double>("TOBXMax");
+  int TIB_bin = conf_.getParameter<int>("TIB_bin");
+  int TOB_bin = conf_.getParameter<int>("TOB_bin");
+  int SUM_bin = conf_.getParameter<int>("SUM_bin");
+
+  hFile = new TFile(conf_.getUntrackedParameter<std::string>("treeName").c_str(), "RECREATE");
+
   Hit_Tree = hFile->mkdir("Hit_Tree");
   Track_Tree = hFile->mkdir("Track_Tree");
   Event_Tree = hFile->mkdir("Event_Tree");
-  
+
   HitsTree = new TTree("HitsTree", "HitsTree");
-  
+
   HitsTree->Branch("RunNumber", &RunNumber, "RunNumber/I");
   HitsTree->Branch("EventNumber", &EventNumber, "EventNumber/I");
   HitsTree->Branch("TanTrackAngle", &TanTrackAngle, "TanTrackAngle/F");
@@ -148,24 +140,23 @@ void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c)
   HitsTree->Branch("HitPerTrack", &HitPerTrack, "HitPerTrack/I");
   HitsTree->Branch("id_detector", &id_detector, "id_detector/I");
   HitsTree->Branch("thick_detector", &thick_detector, "thick_detector/F");
-  HitsTree->Branch("pitch_detector", &pitch_detector, "pitch_detector/F");  
+  HitsTree->Branch("pitch_detector", &pitch_detector, "pitch_detector/F");
   HitsTree->Branch("Amplitudes", Amplitudes, "Amplitudes[ClSize]/I");
-  
+
   HitsTree->SetDirectory(Hit_Tree);
-  
+
   TrackTree = new TTree("TrackTree", "TrackTree");
-  
+
   TrackTree->Branch("TrackCounter", &TrackCounter, "TrackCounter/I");
-  
+
   TrackTree->SetDirectory(Track_Tree);
-  
+
   EventTree = new TTree("EventTree", "EventTree");
-  
+
   EventTree->Branch("EventCounter", &EventCounter, "EventCounter/I");
-  
+
   EventTree->SetDirectory(Event_Tree);
-  
-      
+
   // use SistripHistoId for producing histogram id (and title)
   SiStripHistoId hidmanager;
 
@@ -173,75 +164,75 @@ void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c)
   SiStripFolderOrganizer folder_organizer;
 
   dbe_ = edm::Service<DQMStore>().operator->();
-  
+
   //get all detids
-  
-  for(std::vector<uint32_t>::const_iterator Id = activeDets.begin(); Id!=activeDets.end(); Id++){
-    
+
+  for (std::vector<uint32_t>::const_iterator Id = activeDets.begin(); Id != activeDets.end(); Id++) {
     //  for(Iditer=Id.begin();Iditer!=Id.end();Iditer++){ //loop on detids
-    DetId Iditero=DetId(*Id);
-    DetId *Iditer=&Iditero;
-    if((Iditer->subdetId() == int(StripSubdetector::TIB)) || (Iditer->subdetId() == int(StripSubdetector::TOB))){ //include only barrel
-      
+    DetId Iditero = DetId(*Id);
+    DetId* Iditer = &Iditero;
+    if ((Iditer->subdetId() == int(StripSubdetector::TIB)) ||
+        (Iditer->subdetId() == int(StripSubdetector::TOB))) {  //include only barrel
+
       int module_bin = 0;
-      if(Iditer->subdetId() == int(StripSubdetector::TIB)){
-	module_bin = TIB_bin;
-      }else{
-	module_bin = TOB_bin;
+      if (Iditer->subdetId() == int(StripSubdetector::TIB)) {
+        module_bin = TIB_bin;
+      } else {
+        module_bin = TOB_bin;
       }
-      
+
       // create a TProfile for each module
       StripSubdetector subid(*Iditer);
       std::string hid;
       //Mono single sided detectors
       LocalPoint p;
       auto stripdet = tracker->idToDet(subid);
-      if(!stripdet->isLeaf())continue;
-      const StripTopology& topol=(const StripTopology&)stripdet->topology();
-      float thickness=stripdet->specificSurface().bounds().thickness();
-      
+      if (!stripdet->isLeaf())
+        continue;
+      const StripTopology& topol = (const StripTopology&)stripdet->topology();
+      float thickness = stripdet->specificSurface().bounds().thickness();
+
       folder_organizer.setDetectorFolder(Iditer->rawId(), tTopo);
-      hid = hidmanager.createHistoId(TkTag.label(),"det",Iditer->rawId());
-      MonitorElement * profile=dbe_->bookProfile(hid,hid,module_bin,ModuleRangeMin,ModuleRangeMax,20,0,5,"");
-      detparameters *param=new detparameters;
+      hid = hidmanager.createHistoId(TkTag.label(), "det", Iditer->rawId());
+      MonitorElement* profile = dbe_->bookProfile(hid, hid, module_bin, ModuleRangeMin, ModuleRangeMax, 20, 0, 5, "");
+      detparameters* param = new detparameters;
       histos[Iditer->rawId()] = profile;
       detmap[Iditer->rawId()] = param;
-      param->thickness = thickness*10000;
-      param->pitch = topol.localPitch(p)*10000;
-      
+      param->thickness = thickness * 10000;
+      param->pitch = topol.localPitch(p) * 10000;
+
       const GlobalPoint globalp = (stripdet->surface()).toGlobal(p);
       GlobalVector globalmagdir = magfield->inTesla(globalp);
-      param->magfield=(stripdet->surface()).toLocal(globalmagdir);
-      
-      profile->setAxisTitle("tan(#theta_{t})",1);
-      profile->setAxisTitle("Cluster size",2);
-      
+      param->magfield = (stripdet->surface()).toLocal(globalmagdir);
+
+      profile->setAxisTitle("tan(#theta_{t})", 1);
+      profile->setAxisTitle("Cluster size", 2);
+
       // create a summary histo if it does not exist already
       std::string name;
       unsigned int layerid;
-      getlayer(subid,tTopo,name,layerid);
-      name+=TkTag.label();
-      if(summaryhisto.find(layerid)==(summaryhisto.end())){
-	folder_organizer.setSiStripFolder();
-	MonitorElement * summaryprofile=nullptr;
-	if (subid.subdetId()==int (StripSubdetector::TIB)||subid.subdetId()==int (StripSubdetector::TID))
-	  summaryprofile=dbe_->bookProfile(name,name,SUM_bin,TIBRangeMin,TIBRangeMax,20,0,5,"");
-	else if (subid.subdetId()==int (StripSubdetector::TOB)||subid.subdetId()==int (StripSubdetector::TEC))
-	  summaryprofile=dbe_->bookProfile(name,name,SUM_bin,TOBRangeMin,TOBRangeMax,20,0,5,"");
-	if(summaryprofile){
-	  detparameters *summaryparam=new detparameters;
-	  summaryhisto[layerid] = summaryprofile;
-	  summarydetmap[layerid] = summaryparam;
-	  summaryparam->thickness = thickness*10000;
-	  summaryparam->pitch = topol.localPitch(p)*10000;
-	  summaryprofile->setAxisTitle("tan(#theta_{t})",1);
-	  summaryprofile->setAxisTitle("Cluster size",2);
-	}
+      getlayer(subid, tTopo, name, layerid);
+      name += TkTag.label();
+      if (summaryhisto.find(layerid) == (summaryhisto.end())) {
+        folder_organizer.setSiStripFolder();
+        MonitorElement* summaryprofile = nullptr;
+        if (subid.subdetId() == int(StripSubdetector::TIB) || subid.subdetId() == int(StripSubdetector::TID))
+          summaryprofile = dbe_->bookProfile(name, name, SUM_bin, TIBRangeMin, TIBRangeMax, 20, 0, 5, "");
+        else if (subid.subdetId() == int(StripSubdetector::TOB) || subid.subdetId() == int(StripSubdetector::TEC))
+          summaryprofile = dbe_->bookProfile(name, name, SUM_bin, TOBRangeMin, TOBRangeMax, 20, 0, 5, "");
+        if (summaryprofile) {
+          detparameters* summaryparam = new detparameters;
+          summaryhisto[layerid] = summaryprofile;
+          summarydetmap[layerid] = summaryparam;
+          summaryparam->thickness = thickness * 10000;
+          summaryparam->pitch = topol.localPitch(p) * 10000;
+          summaryprofile->setAxisTitle("tan(#theta_{t})", 1);
+          summaryprofile->setAxisTitle("Cluster size", 2);
+        }
       }
-      
-    } 
-  } 
-  
+    }
+  }
+
   trackcollsize = 0;
   trajsize = 0;
   RunNumber = 0;
@@ -251,68 +242,68 @@ void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c)
   worse_double_hit = 0;
   better_double_hit = 0;
   eventcounter = 0;
-  
+
   EventCounter = 1;
   TrackCounter = 1;
-  
 }
 
-SiStripLAProfileBooker::~SiStripLAProfileBooker() {  
+SiStripLAProfileBooker::~SiStripLAProfileBooker() {
   detparmap::iterator detpariter;
-  for( detpariter=detmap.begin(); detpariter!=detmap.end();++detpariter)delete detpariter->second;
-  for( detpariter=summarydetmap.begin(); detpariter!=summarydetmap.end();++detpariter)delete detpariter->second;
+  for (detpariter = detmap.begin(); detpariter != detmap.end(); ++detpariter)
+    delete detpariter->second;
+  for (detpariter = summarydetmap.begin(); detpariter != summarydetmap.end(); ++detpariter)
+    delete detpariter->second;
   delete hFile;
-}  
+}
 
 // Analyzer: Functions that gets called by framework every event
 
-void SiStripLAProfileBooker::analyze(const edm::Event& e, const edm::EventSetup& es)
-{
+void SiStripLAProfileBooker::analyze(const edm::Event& e, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
-  
+
   RunNumber = e.id().run();
   EventNumber = e.id().event();
-  
+
   eventcounter++;
-  
+
   EventTree->Fill();
-  
+
   //Analysis of Trajectory-RecHits
-  
+
   edm::InputTag TkTag = conf_.getParameter<edm::InputTag>("Tracks");
-  
+
   edm::Handle<reco::TrackCollection> trackCollection;
-  e.getByLabel(TkTag,trackCollection);
-  
+  e.getByLabel(TkTag, trackCollection);
+
   edm::Handle<std::vector<Trajectory> > TrajectoryCollection;
-  e.getByLabel(TkTag,TrajectoryCollection);
-  
+  e.getByLabel(TkTag, TrajectoryCollection);
+
   edm::Handle<TrajTrackAssociationCollection> TrajTrackMap;
   e.getByLabel(TkTag, TrajTrackMap);
-  
-  const reco::TrackCollection *tracks=trackCollection.product();
-  
+
+  const reco::TrackCollection* tracks = trackCollection.product();
+
   // FIXME this has to be changed to use pointers to clusters...
-  std::map<const SiStripRecHit2D*,std::pair<float,float>,DetIdLess> hitangleassociation;
+  std::map<const SiStripRecHit2D*, std::pair<float, float>, DetIdLess> hitangleassociation;
   std::list<SiStripRecHit2D> cache;  // ugly, inefficient, effective in making the above working
-  
-  trackcollsize=tracks->size();
-  trajsize=TrajectoryCollection->size();
-  
-  edm::LogInfo("SiStripLAProfileBooker::analyze") <<" Number of tracks in event = "<<trackcollsize<<"\n";
-  edm::LogInfo("SiStripLAProfileBooker::analyze") <<" Number of trajectories in event = "<<trajsize<<"\n";
-  
+
+  trackcollsize = tracks->size();
+  trajsize = TrajectoryCollection->size();
+
+  edm::LogInfo("SiStripLAProfileBooker::analyze") << " Number of tracks in event = " << trackcollsize << "\n";
+  edm::LogInfo("SiStripLAProfileBooker::analyze") << " Number of trajectories in event = " << trajsize << "\n";
+
   TrajTrackAssociationCollection::const_iterator TrajTrackIter;
-  
-  for(TrajTrackIter = TrajTrackMap->begin(); TrajTrackIter!= TrajTrackMap->end(); TrajTrackIter++){ //loop on trajectories
-    
-    if(TrajTrackIter->key->foundHits()>=5){
-      
+
+  for (TrajTrackIter = TrajTrackMap->begin(); TrajTrackIter != TrajTrackMap->end();
+       TrajTrackIter++) {  //loop on trajectories
+
+    if (TrajTrackIter->key->foundHits() >= 5) {
       TrackTree->Fill();
-      
+
       ParticleCharge = -99;
       Momentum = -99;
       pt = -99;
@@ -320,7 +311,7 @@ void SiStripLAProfileBooker::analyze(const edm::Event& e, const edm::EventSetup&
       HitPerTrack = -99;
       EtaTrack = -99;
       PhiTrack = -99;
-      
+
       ParticleCharge = TrajTrackIter->val->charge();
       pt = TrajTrackIter->val->pt();
       Momentum = TrajTrackIter->val->p();
@@ -328,443 +319,436 @@ void SiStripLAProfileBooker::analyze(const edm::Event& e, const edm::EventSetup&
       EtaTrack = TrajTrackIter->val->eta();
       PhiTrack = TrajTrackIter->val->phi();
       HitPerTrack = TrajTrackIter->key->foundHits();
-      
-      std::vector<TrajectoryMeasurement> TMeas=TrajTrackIter->key->measurements();
+
+      std::vector<TrajectoryMeasurement> TMeas = TrajTrackIter->key->measurements();
       std::vector<TrajectoryMeasurement>::iterator itm;
-      
-      for (itm=TMeas.begin();itm!=TMeas.end();itm++){ //loop on hits
-	
-	int i;
-	for(i=0;i<100;i++){Amplitudes[i]=0;}
-	
-	TanTrackAngle = -99;
-	TanTrackAngleParallel=-99;
-	ClSize = -99;
-	HitCharge = 0;
-	Type = -99;
-	Layer = -99;
-	Wheel = -99;
-	bw_fw = -99;
-	Ext_Int = -99;
-	MonoStereo = -99;
-	MagField = -99;
-	SignCorrection = -99;
-	XGlobal = -99;
-	YGlobal = -99;
-	ZGlobal = -99;
-	barycenter = -99;
-	hit_std_dev = -99;
-	sumx = 0;
-	id_detector=-1;
-	thick_detector=-1;
-	pitch_detector=-1;       
-	HitNr = 1;    
-	
+
+      for (itm = TMeas.begin(); itm != TMeas.end(); itm++) {  //loop on hits
+
+        int i;
+        for (i = 0; i < 100; i++) {
+          Amplitudes[i] = 0;
+        }
+
+        TanTrackAngle = -99;
+        TanTrackAngleParallel = -99;
+        ClSize = -99;
+        HitCharge = 0;
+        Type = -99;
+        Layer = -99;
+        Wheel = -99;
+        bw_fw = -99;
+        Ext_Int = -99;
+        MonoStereo = -99;
+        MagField = -99;
+        SignCorrection = -99;
+        XGlobal = -99;
+        YGlobal = -99;
+        ZGlobal = -99;
+        barycenter = -99;
+        hit_std_dev = -99;
+        sumx = 0;
+        id_detector = -1;
+        thick_detector = -1;
+        pitch_detector = -1;
+        HitNr = 1;
+
         SiStripRecHit2D lhit;
-	TrajectoryStateOnSurface tsos=itm->updatedState();
-	const TransientTrackingRecHit::ConstRecHitPointer thit=itm->recHit();
-	if((thit->geographicalId().subdetId() == int(StripSubdetector::TIB)) ||  thit->geographicalId().subdetId()== int(StripSubdetector::TOB)){ //include only barrel
-	  const SiStripMatchedRecHit2D* matchedhit=dynamic_cast<const SiStripMatchedRecHit2D*>((*thit).hit());
-	  const ProjectedSiStripRecHit2D* phit=dynamic_cast<const ProjectedSiStripRecHit2D*>((*thit).hit());
-	  const SiStripRecHit2D* hit=dynamic_cast<const SiStripRecHit2D*>((*thit).hit());
-	  if(phit) {lhit = phit->originalHit(); hit = &lhit;}
-	  
-	  LocalVector trackdirection=tsos.localDirection();
-	  
-	  if(matchedhit){//if matched hit...
-	    
-	    GluedGeomDet * gdet=(GluedGeomDet *)tracker->idToDet(matchedhit->geographicalId());
-	    
-	    GlobalVector gtrkdir=gdet->toGlobal(trackdirection);	
-	    
-	    // THIS THE POINTER TO THE MONO HIT OF A MATCHED HIT 
-	    
-	    // top be migrated to the more direct interface of matchedhit
-	    cache.push_back(matchedhit->monoHit()); 
-	    const SiStripRecHit2D * monohit = &cache.back();   
-	    const SiStripRecHit2D::ClusterRef & monocluster=monohit->cluster();
-	    const GeomDetUnit * monodet=gdet->monoDet();
-	    // this does not exists anymore! either project the matched or use CPE
-	    const LocalPoint monoposition = monohit->localPosition();   
-	    
-            StripSubdetector detid=(StripSubdetector)monohit->geographicalId();
-	    id_detector = detid.rawId();
-	    thick_detector=monodet->specificSurface().bounds().thickness();
-            const StripTopology& mtopol=(StripTopology&)monodet->topology();
+        TrajectoryStateOnSurface tsos = itm->updatedState();
+        const TransientTrackingRecHit::ConstRecHitPointer thit = itm->recHit();
+        if ((thit->geographicalId().subdetId() == int(StripSubdetector::TIB)) ||
+            thit->geographicalId().subdetId() == int(StripSubdetector::TOB)) {  //include only barrel
+          const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>((*thit).hit());
+          const ProjectedSiStripRecHit2D* phit = dynamic_cast<const ProjectedSiStripRecHit2D*>((*thit).hit());
+          const SiStripRecHit2D* hit = dynamic_cast<const SiStripRecHit2D*>((*thit).hit());
+          if (phit) {
+            lhit = phit->originalHit();
+            hit = &lhit;
+          }
+
+          LocalVector trackdirection = tsos.localDirection();
+
+          if (matchedhit) {  //if matched hit...
+
+            GluedGeomDet* gdet = (GluedGeomDet*)tracker->idToDet(matchedhit->geographicalId());
+
+            GlobalVector gtrkdir = gdet->toGlobal(trackdirection);
+
+            // THIS THE POINTER TO THE MONO HIT OF A MATCHED HIT
+
+            // top be migrated to the more direct interface of matchedhit
+            cache.push_back(matchedhit->monoHit());
+            const SiStripRecHit2D* monohit = &cache.back();
+            const SiStripRecHit2D::ClusterRef& monocluster = monohit->cluster();
+            const GeomDetUnit* monodet = gdet->monoDet();
+            // this does not exists anymore! either project the matched or use CPE
+            const LocalPoint monoposition = monohit->localPosition();
+
+            StripSubdetector detid = (StripSubdetector)monohit->geographicalId();
+            id_detector = detid.rawId();
+            thick_detector = monodet->specificSurface().bounds().thickness();
+            const StripTopology& mtopol = (StripTopology&)monodet->topology();
             pitch_detector = mtopol.localPitch(monoposition);
             const GlobalPoint monogposition = (monodet->surface()).toGlobal(monoposition);
-	    ClSize = (monocluster->amplitudes()).size();
-	    
-	    const auto & amplitudes = monocluster->amplitudes();
-	    
-	    barycenter = monocluster->barycenter()- 0.5; 
-	    uint16_t FirstStrip = monocluster->firstStrip();
-	    auto begin=amplitudes.begin();
-	    nstrip=0;
-	    for(auto idigi=begin; idigi!=amplitudes.end(); idigi++){
-	      Amplitudes[nstrip]=*idigi;
-	      sumx+=pow(((FirstStrip+idigi-begin)-barycenter),2)*(*idigi);
-	      HitCharge+=*idigi;
-	    }
-	    hit_std_dev = sqrt(sumx/HitCharge);
-	    
-	    
+            ClSize = (monocluster->amplitudes()).size();
+
+            const auto& amplitudes = monocluster->amplitudes();
+
+            barycenter = monocluster->barycenter() - 0.5;
+            uint16_t FirstStrip = monocluster->firstStrip();
+            auto begin = amplitudes.begin();
+            nstrip = 0;
+            for (auto idigi = begin; idigi != amplitudes.end(); idigi++) {
+              Amplitudes[nstrip] = *idigi;
+              sumx += pow(((FirstStrip + idigi - begin) - barycenter), 2) * (*idigi);
+              HitCharge += *idigi;
+            }
+            hit_std_dev = sqrt(sumx / HitCharge);
+
             XGlobal = monogposition.x();
-	    YGlobal = monogposition.y();
-	    ZGlobal = monogposition.z();
-	    
-	    Type = detid.subdetId();
-	    MonoStereo=detid.stereo();
-	    
-	    if(detid.subdetId() == int (StripSubdetector::TIB)){
-	      
-	      Layer = tTopo->tibLayer(detid);
-	      bw_fw = tTopo->tibStringInfo(detid)[0];
-	      Ext_Int = tTopo->tibStringInfo(detid)[1];
+            YGlobal = monogposition.y();
+            ZGlobal = monogposition.z();
+
+            Type = detid.subdetId();
+            MonoStereo = detid.stereo();
+
+            if (detid.subdetId() == int(StripSubdetector::TIB)) {
+              Layer = tTopo->tibLayer(detid);
+              bw_fw = tTopo->tibStringInfo(detid)[0];
+              Ext_Int = tTopo->tibStringInfo(detid)[1];
             }
-	    if(detid.subdetId() == int (StripSubdetector::TOB)){
-	      
-	      Layer = tTopo->tobLayer(detid);
-	      bw_fw = tTopo->tobRodInfo(detid)[0];
+            if (detid.subdetId() == int(StripSubdetector::TOB)) {
+              Layer = tTopo->tobLayer(detid);
+              bw_fw = tTopo->tobRodInfo(detid)[0];
             }
-	    if(detid.subdetId() == int (StripSubdetector::TID)){
-	      
-	      Wheel = tTopo->tidWheel(detid);
-	      bw_fw = tTopo->tidModuleInfo(detid)[0];
+            if (detid.subdetId() == int(StripSubdetector::TID)) {
+              Wheel = tTopo->tidWheel(detid);
+              bw_fw = tTopo->tidModuleInfo(detid)[0];
             }
-	    if(detid.subdetId() == int (StripSubdetector::TEC)){
-	      
-	      Wheel = tTopo->tecWheel(detid);
-	      bw_fw = tTopo->tecPetalInfo(detid)[0];
+            if (detid.subdetId() == int(StripSubdetector::TEC)) {
+              Wheel = tTopo->tecWheel(detid);
+              bw_fw = tTopo->tecPetalInfo(detid)[0];
             }
-	    
-	    
-	    LocalVector monotkdir=monodet->toLocal(gtrkdir);
-	    
-	    if(monotkdir.z()!=0){
-	      
-	      // THE LOCAL ANGLE (MONO)
-	      float tanangle = monotkdir.x()/monotkdir.z();
-	      TanTrackAngleParallel = monotkdir.y()/monotkdir.z();	      
-	      TanTrackAngle = tanangle;
-	      detparmap::iterator TheDet=detmap.find(detid.rawId());
+
+            LocalVector monotkdir = monodet->toLocal(gtrkdir);
+
+            if (monotkdir.z() != 0) {
+              // THE LOCAL ANGLE (MONO)
+              float tanangle = monotkdir.x() / monotkdir.z();
+              TanTrackAngleParallel = monotkdir.y() / monotkdir.z();
+              TanTrackAngle = tanangle;
+              detparmap::iterator TheDet = detmap.find(detid.rawId());
               LocalVector localmagdir;
-              if(TheDet!=detmap.end())localmagdir=TheDet->second->magfield;
+              if (TheDet != detmap.end())
+                localmagdir = TheDet->second->magfield;
               MagField = localmagdir.mag();
-	      if(MagField != 0.){
-		LocalVector monoylocal(0,1,0);
-		float signcorrection = (localmagdir * monoylocal)/(MagField);
-		if(signcorrection!=0)SignCorrection=1/signcorrection;
-	      }
-	      
-	      std::map<const SiStripRecHit2D *,std::pair<float,float>,DetIdLess>::iterator alreadystored=hitangleassociation.find(monohit);
-	      
-	      
-	      if(alreadystored != hitangleassociation.end()){//decide which hit take
-		if(itm->estimate() >  alreadystored->second.first){
-		  worse_double_hit++;}
-		if(itm->estimate() <  alreadystored->second.first){
-		  better_double_hit++;
-		  hitangleassociation.insert(std::make_pair(monohit, std::make_pair(itm->estimate(),tanangle)));
-		  
-		}}
-	      else{
-		hitangleassociation.insert(make_pair(monohit, std::make_pair(itm->estimate(),tanangle)));
-		HitsTree->Fill();
-		hitcounter++;}
-	      
-	      // THIS THE POINTER TO THE STEREO HIT OF A MATCHED HIT 
-	      
-	      // top be migrated to the more direct interface of matchedhit
-	      cache.push_back(matchedhit->stereoHit());
-	      const SiStripRecHit2D * stereohit = &cache.back();
-	      const SiStripRecHit2D::ClusterRef & stereocluster=stereohit->cluster();
-	      const GeomDetUnit * stereodet=gdet->stereoDet();
-	      // this does not exists anymore! either project the matched or use CPE
-	      const LocalPoint stereoposition = stereohit->localPosition();    
-	      StripSubdetector detid=(StripSubdetector)stereohit->geographicalId();
-	      id_detector = detid.rawId();
-	      thick_detector=stereodet->specificSurface().bounds().thickness();
-	      const StripTopology& stopol=(StripTopology&)stereodet->topology();
-	      pitch_detector = stopol.localPitch(stereoposition);
-	      const GlobalPoint stereogposition = (stereodet->surface()).toGlobal(stereoposition);
-	      
-	      ClSize = (stereocluster->amplitudes()).size();
-	      
-	      const auto &  amplitudes = stereocluster->amplitudes();
-	      
-	      barycenter = stereocluster->barycenter()- 0.5; 
-	      uint16_t FirstStrip = stereocluster->firstStrip();
-	      auto begin=amplitudes.begin();
-	      nstrip=0;
-	      for(auto idigi=begin; idigi!=amplitudes.end(); idigi++){
-		Amplitudes[nstrip]=*idigi;
-		sumx+=pow(((FirstStrip+idigi-begin)-barycenter),2)*(*idigi);
-		HitCharge+=*idigi;
-	      }
-	      hit_std_dev = sqrt(sumx/HitCharge);
-	      
-	      XGlobal = stereogposition.x();
-	      YGlobal = stereogposition.y();
-	      ZGlobal = stereogposition.z();
-	      
-	      Type = detid.subdetId();
-	      MonoStereo=detid.stereo();
-	      
-	      if(detid.subdetId() == int (StripSubdetector::TIB)){
-		
-		Layer = tTopo->tibLayer(detid);
-		bw_fw = tTopo->tibStringInfo(detid)[0];
-		Ext_Int = tTopo->tibStringInfo(detid)[1];
-	      }
-	      if(detid.subdetId() == int (StripSubdetector::TOB)){
-		
-		Layer = tTopo->tobLayer(detid);
-		bw_fw = tTopo->tobRodInfo(detid)[0];
-	      }
-	      if(detid.subdetId() == int (StripSubdetector::TID)){
-		
-		Wheel = tTopo->tidWheel(detid);
-		bw_fw = tTopo->tidModuleInfo(detid)[0];
-	      }
-	      if(detid.subdetId() == int (StripSubdetector::TEC)){
-		
-		Wheel = tTopo->tecWheel(detid);
-		bw_fw = tTopo->tecPetalInfo(detid)[0];
-	      }
-	      
-	      
-	      LocalVector stereotkdir=stereodet->toLocal(gtrkdir);
-	      
-	      if(stereotkdir.z()!=0){
-		
-		// THE LOCAL ANGLE (STEREO)
-		float tanangle = stereotkdir.x()/stereotkdir.z();
-		TanTrackAngleParallel = stereotkdir.y()/stereotkdir.z();
-		TanTrackAngle = tanangle;
-		detparmap::iterator TheDet=detmap.find(detid.rawId());
+              if (MagField != 0.) {
+                LocalVector monoylocal(0, 1, 0);
+                float signcorrection = (localmagdir * monoylocal) / (MagField);
+                if (signcorrection != 0)
+                  SignCorrection = 1 / signcorrection;
+              }
+
+              std::map<const SiStripRecHit2D*, std::pair<float, float>, DetIdLess>::iterator alreadystored =
+                  hitangleassociation.find(monohit);
+
+              if (alreadystored != hitangleassociation.end()) {  //decide which hit take
+                if (itm->estimate() > alreadystored->second.first) {
+                  worse_double_hit++;
+                }
+                if (itm->estimate() < alreadystored->second.first) {
+                  better_double_hit++;
+                  hitangleassociation.insert(std::make_pair(monohit, std::make_pair(itm->estimate(), tanangle)));
+                }
+              } else {
+                hitangleassociation.insert(make_pair(monohit, std::make_pair(itm->estimate(), tanangle)));
+                HitsTree->Fill();
+                hitcounter++;
+              }
+
+              // THIS THE POINTER TO THE STEREO HIT OF A MATCHED HIT
+
+              // top be migrated to the more direct interface of matchedhit
+              cache.push_back(matchedhit->stereoHit());
+              const SiStripRecHit2D* stereohit = &cache.back();
+              const SiStripRecHit2D::ClusterRef& stereocluster = stereohit->cluster();
+              const GeomDetUnit* stereodet = gdet->stereoDet();
+              // this does not exists anymore! either project the matched or use CPE
+              const LocalPoint stereoposition = stereohit->localPosition();
+              StripSubdetector detid = (StripSubdetector)stereohit->geographicalId();
+              id_detector = detid.rawId();
+              thick_detector = stereodet->specificSurface().bounds().thickness();
+              const StripTopology& stopol = (StripTopology&)stereodet->topology();
+              pitch_detector = stopol.localPitch(stereoposition);
+              const GlobalPoint stereogposition = (stereodet->surface()).toGlobal(stereoposition);
+
+              ClSize = (stereocluster->amplitudes()).size();
+
+              const auto& amplitudes = stereocluster->amplitudes();
+
+              barycenter = stereocluster->barycenter() - 0.5;
+              uint16_t FirstStrip = stereocluster->firstStrip();
+              auto begin = amplitudes.begin();
+              nstrip = 0;
+              for (auto idigi = begin; idigi != amplitudes.end(); idigi++) {
+                Amplitudes[nstrip] = *idigi;
+                sumx += pow(((FirstStrip + idigi - begin) - barycenter), 2) * (*idigi);
+                HitCharge += *idigi;
+              }
+              hit_std_dev = sqrt(sumx / HitCharge);
+
+              XGlobal = stereogposition.x();
+              YGlobal = stereogposition.y();
+              ZGlobal = stereogposition.z();
+
+              Type = detid.subdetId();
+              MonoStereo = detid.stereo();
+
+              if (detid.subdetId() == int(StripSubdetector::TIB)) {
+                Layer = tTopo->tibLayer(detid);
+                bw_fw = tTopo->tibStringInfo(detid)[0];
+                Ext_Int = tTopo->tibStringInfo(detid)[1];
+              }
+              if (detid.subdetId() == int(StripSubdetector::TOB)) {
+                Layer = tTopo->tobLayer(detid);
+                bw_fw = tTopo->tobRodInfo(detid)[0];
+              }
+              if (detid.subdetId() == int(StripSubdetector::TID)) {
+                Wheel = tTopo->tidWheel(detid);
+                bw_fw = tTopo->tidModuleInfo(detid)[0];
+              }
+              if (detid.subdetId() == int(StripSubdetector::TEC)) {
+                Wheel = tTopo->tecWheel(detid);
+                bw_fw = tTopo->tecPetalInfo(detid)[0];
+              }
+
+              LocalVector stereotkdir = stereodet->toLocal(gtrkdir);
+
+              if (stereotkdir.z() != 0) {
+                // THE LOCAL ANGLE (STEREO)
+                float tanangle = stereotkdir.x() / stereotkdir.z();
+                TanTrackAngleParallel = stereotkdir.y() / stereotkdir.z();
+                TanTrackAngle = tanangle;
+                detparmap::iterator TheDet = detmap.find(detid.rawId());
                 LocalVector localmagdir;
-                if(TheDet!=detmap.end())localmagdir=TheDet->second->magfield;
+                if (TheDet != detmap.end())
+                  localmagdir = TheDet->second->magfield;
                 MagField = localmagdir.mag();
-		LocalVector stereoylocal(0,1,0);
-	        if(MagField != 0.){
-		  float signcorrection = (localmagdir * stereoylocal)/(MagField);
-		  if(signcorrection!=0)SignCorrection=1/signcorrection;}
-		
-		std::map<const SiStripRecHit2D *,std::pair<float,float>,DetIdLess>::iterator alreadystored=hitangleassociation.find(stereohit);
-		
-		if(alreadystored != hitangleassociation.end()){//decide which hit take
-		  if(itm->estimate() >  alreadystored->second.first){
-		    worse_double_hit++;}
-		  if(itm->estimate() <  alreadystored->second.first){
-		    better_double_hit++;
-		    hitangleassociation.insert(std::make_pair(stereohit, std::make_pair(itm->estimate(),tanangle)));
-		    
-		  }}
-		else{
-		  hitangleassociation.insert(std::make_pair(stereohit, std::make_pair(itm->estimate(),tanangle)));
-		  HitsTree->Fill();
-		  hitcounter++;}
-		
-	      }
-	    }
-	  }
-	  else if(hit){
-	    
-	    
-	    //  hit= POINTER TO THE RECHIT
-	    
-	    const SiStripRecHit2D::ClusterRef & cluster=hit->cluster();
-	    
-	    GeomDetUnit * gdet=(GeomDetUnit *)tracker->idToDet(hit->geographicalId());
-	    const LocalPoint position = hit->localPosition();    
-            StripSubdetector detid=(StripSubdetector)hit->geographicalId();
-	    id_detector = detid.rawId();
-	    thick_detector=gdet->specificSurface().bounds().thickness();
-            const StripTopology& topol=(StripTopology&)gdet->topology();
+                LocalVector stereoylocal(0, 1, 0);
+                if (MagField != 0.) {
+                  float signcorrection = (localmagdir * stereoylocal) / (MagField);
+                  if (signcorrection != 0)
+                    SignCorrection = 1 / signcorrection;
+                }
+
+                std::map<const SiStripRecHit2D*, std::pair<float, float>, DetIdLess>::iterator alreadystored =
+                    hitangleassociation.find(stereohit);
+
+                if (alreadystored != hitangleassociation.end()) {  //decide which hit take
+                  if (itm->estimate() > alreadystored->second.first) {
+                    worse_double_hit++;
+                  }
+                  if (itm->estimate() < alreadystored->second.first) {
+                    better_double_hit++;
+                    hitangleassociation.insert(std::make_pair(stereohit, std::make_pair(itm->estimate(), tanangle)));
+                  }
+                } else {
+                  hitangleassociation.insert(std::make_pair(stereohit, std::make_pair(itm->estimate(), tanangle)));
+                  HitsTree->Fill();
+                  hitcounter++;
+                }
+              }
+            }
+          } else if (hit) {
+            //  hit= POINTER TO THE RECHIT
+
+            const SiStripRecHit2D::ClusterRef& cluster = hit->cluster();
+
+            GeomDetUnit* gdet = (GeomDetUnit*)tracker->idToDet(hit->geographicalId());
+            const LocalPoint position = hit->localPosition();
+            StripSubdetector detid = (StripSubdetector)hit->geographicalId();
+            id_detector = detid.rawId();
+            thick_detector = gdet->specificSurface().bounds().thickness();
+            const StripTopology& topol = (StripTopology&)gdet->topology();
             pitch_detector = topol.localPitch(position);
             const GlobalPoint gposition = (gdet->surface()).toGlobal(position);
-	    
-	    ClSize = (cluster->amplitudes()).size();
-	    
-	    const auto &  amplitudes = cluster->amplitudes();
-	    
-	    barycenter = cluster->barycenter()- 0.5; 
-	    uint16_t FirstStrip = cluster->firstStrip();
-	    nstrip=0;
-            auto begin =amplitudes.begin();
-	    for(auto idigi=amplitudes.begin(); idigi!=amplitudes.end(); idigi++){
-	      Amplitudes[nstrip]=*idigi;
-	      sumx+=pow(((FirstStrip+idigi-begin)-barycenter),2)*(*idigi);
-	      HitCharge+=*idigi;
-	    }
-	    hit_std_dev = sqrt(sumx/HitCharge);
-	    
+
+            ClSize = (cluster->amplitudes()).size();
+
+            const auto& amplitudes = cluster->amplitudes();
+
+            barycenter = cluster->barycenter() - 0.5;
+            uint16_t FirstStrip = cluster->firstStrip();
+            nstrip = 0;
+            auto begin = amplitudes.begin();
+            for (auto idigi = amplitudes.begin(); idigi != amplitudes.end(); idigi++) {
+              Amplitudes[nstrip] = *idigi;
+              sumx += pow(((FirstStrip + idigi - begin) - barycenter), 2) * (*idigi);
+              HitCharge += *idigi;
+            }
+            hit_std_dev = sqrt(sumx / HitCharge);
+
             XGlobal = gposition.x();
-	    YGlobal = gposition.y();
-	    ZGlobal = gposition.z();
-	    
-	    Type = detid.subdetId();
-	    MonoStereo=detid.stereo();
-	    
-	    if(detid.subdetId() == int (StripSubdetector::TIB)){
-	      
-	      Layer = tTopo->tibLayer(detid);
-	      bw_fw = tTopo->tibStringInfo(detid)[0];
-	      Ext_Int = tTopo->tibStringInfo(detid)[1];
+            YGlobal = gposition.y();
+            ZGlobal = gposition.z();
+
+            Type = detid.subdetId();
+            MonoStereo = detid.stereo();
+
+            if (detid.subdetId() == int(StripSubdetector::TIB)) {
+              Layer = tTopo->tibLayer(detid);
+              bw_fw = tTopo->tibStringInfo(detid)[0];
+              Ext_Int = tTopo->tibStringInfo(detid)[1];
             }
-	    if(detid.subdetId() == int (StripSubdetector::TOB)){
-	      
-	      Layer = tTopo->tobLayer(detid);
-	      bw_fw = tTopo->tobRodInfo(detid)[0];
+            if (detid.subdetId() == int(StripSubdetector::TOB)) {
+              Layer = tTopo->tobLayer(detid);
+              bw_fw = tTopo->tobRodInfo(detid)[0];
             }
-	    if(detid.subdetId() == int (StripSubdetector::TID)){
-	      
-	      Wheel = tTopo->tidWheel(detid);
-	      bw_fw = tTopo->tidModuleInfo(detid)[0];
+            if (detid.subdetId() == int(StripSubdetector::TID)) {
+              Wheel = tTopo->tidWheel(detid);
+              bw_fw = tTopo->tidModuleInfo(detid)[0];
             }
-	    if(detid.subdetId() == int (StripSubdetector::TEC)){
-	      
-	      Wheel = tTopo->tecWheel(detid);
-	      bw_fw = tTopo->tecPetalInfo(detid)[0];
+            if (detid.subdetId() == int(StripSubdetector::TEC)) {
+              Wheel = tTopo->tecWheel(detid);
+              bw_fw = tTopo->tecPetalInfo(detid)[0];
             }
-	    
-	    if(trackdirection.z()!=0){
-	      
-	      // THE LOCAL ANGLE 
-	      float tanangle = trackdirection.x()/trackdirection.z();
-	      TanTrackAngleParallel = trackdirection.y()/trackdirection.z();
-	      TanTrackAngle = tanangle;
-              detparmap::iterator TheDet=detmap.find(detid.rawId());
+
+            if (trackdirection.z() != 0) {
+              // THE LOCAL ANGLE
+              float tanangle = trackdirection.x() / trackdirection.z();
+              TanTrackAngleParallel = trackdirection.y() / trackdirection.z();
+              TanTrackAngle = tanangle;
+              detparmap::iterator TheDet = detmap.find(detid.rawId());
               LocalVector localmagdir;
-              if(TheDet!=detmap.end())localmagdir=TheDet->second->magfield;
+              if (TheDet != detmap.end())
+                localmagdir = TheDet->second->magfield;
               MagField = localmagdir.mag();
-	      if(MagField != 0.){
-		LocalVector ylocal(0,1,0);
-		float signcorrection = (localmagdir * ylocal)/(MagField);
-		if(signcorrection!=0)SignCorrection=1/signcorrection;}
-	      
-	      std::map<const SiStripRecHit2D *,std::pair<float,float>, DetIdLess>::iterator alreadystored=hitangleassociation.find(hit);
-	      
-	      if(alreadystored != hitangleassociation.end()){//decide which hit take
-		if(itm->estimate() >  alreadystored->second.first){
-		  worse_double_hit++;}
-		if(itm->estimate() <  alreadystored->second.first){
-		  better_double_hit++;
-		  hitangleassociation.insert(std::make_pair(hit, std::make_pair(itm->estimate(),tanangle)));
-		  
-		}}
-	      else{
-		hitangleassociation.insert(std::make_pair(hit,std::make_pair(itm->estimate(), tanangle) ) );
-		HitsTree->Fill();
-		hitcounter++;}
-	      
-	      
-	    }
-	  }
-	}
+              if (MagField != 0.) {
+                LocalVector ylocal(0, 1, 0);
+                float signcorrection = (localmagdir * ylocal) / (MagField);
+                if (signcorrection != 0)
+                  SignCorrection = 1 / signcorrection;
+              }
+
+              std::map<const SiStripRecHit2D*, std::pair<float, float>, DetIdLess>::iterator alreadystored =
+                  hitangleassociation.find(hit);
+
+              if (alreadystored != hitangleassociation.end()) {  //decide which hit take
+                if (itm->estimate() > alreadystored->second.first) {
+                  worse_double_hit++;
+                }
+                if (itm->estimate() < alreadystored->second.first) {
+                  better_double_hit++;
+                  hitangleassociation.insert(std::make_pair(hit, std::make_pair(itm->estimate(), tanangle)));
+                }
+              } else {
+                hitangleassociation.insert(std::make_pair(hit, std::make_pair(itm->estimate(), tanangle)));
+                HitsTree->Fill();
+                hitcounter++;
+              }
+            }
+          }
+        }
       }
     }
   }
-  std::map<const SiStripRecHit2D *,std::pair<float,float>,DetIdLess>::iterator hitsiter;
-  
-  
-  for(hitsiter=hitangleassociation.begin();hitsiter!=hitangleassociation.end();hitsiter++){
-    
+  std::map<const SiStripRecHit2D*, std::pair<float, float>, DetIdLess>::iterator hitsiter;
+
+  for (hitsiter = hitangleassociation.begin(); hitsiter != hitangleassociation.end(); hitsiter++) {
     hitcounter_2ndloop++;
-    
-    const SiStripRecHit2D* hit=hitsiter->first;
-    const SiStripRecHit2D::ClusterRef & cluster=hit->cluster();
-    
-    size=(cluster->amplitudes()).size();
-    
-    StripSubdetector detid=(StripSubdetector)hit->geographicalId();  
-    
+
+    const SiStripRecHit2D* hit = hitsiter->first;
+    const SiStripRecHit2D::ClusterRef& cluster = hit->cluster();
+
+    size = (cluster->amplitudes()).size();
+
+    StripSubdetector detid = (StripSubdetector)hit->geographicalId();
+
     float tangent = hitsiter->second.second;
-    
+
     //Sign and XZ plane projection correction applied in TrackLocalAngle (TIB|TOB layers)
-    
-    detparmap::iterator thedet=detmap.find(detid.rawId());
+
+    detparmap::iterator thedet = detmap.find(detid.rawId());
     LocalVector localmagdir;
-    if(thedet!=detmap.end())localmagdir=thedet->second->magfield;
+    if (thedet != detmap.end())
+      localmagdir = thedet->second->magfield;
     float localmagfield = localmagdir.mag();
-    
-    if(localmagfield != 0.){
-      
-      LocalVector ylocal(0,1,0);
-      
-      float normprojection = (localmagdir * ylocal)/(localmagfield);
-      
-      if(normprojection == 0.)LogDebug("SiStripLAProfileBooker::analyze")<<"Error: YBprojection = 0";
-      
-      else{
-	float signprojcorrection = 1/normprojection;
-	tangent*=signprojcorrection;
+
+    if (localmagfield != 0.) {
+      LocalVector ylocal(0, 1, 0);
+
+      float normprojection = (localmagdir * ylocal) / (localmagfield);
+
+      if (normprojection == 0.)
+        LogDebug("SiStripLAProfileBooker::analyze") << "Error: YBprojection = 0";
+
+      else {
+        float signprojcorrection = 1 / normprojection;
+        tangent *= signprojcorrection;
       }
     }
-    
+
     //Filling histograms
-    
-    histomap::iterator thehisto=histos.find(detid.rawId());
-    
-    if(thehisto==histos.end())edm::LogError("SiStripLAProfileBooker::analyze")<<"Error: the profile associated to"<<detid.rawId()<<"does not exist! ";    
-    else thehisto->second->Fill(tangent,size);
-    
+
+    histomap::iterator thehisto = histos.find(detid.rawId());
+
+    if (thehisto == histos.end())
+      edm::LogError("SiStripLAProfileBooker::analyze")
+          << "Error: the profile associated to" << detid.rawId() << "does not exist! ";
+    else
+      thehisto->second->Fill(tangent, size);
+
     //Summary histograms
     std::string name;
     unsigned int layerid;
-    getlayer(detid,tTopo,name,layerid);
-    histomap::iterator thesummaryhisto=summaryhisto.find(layerid);
-    if(thesummaryhisto==summaryhisto.end())edm::LogError("SiStripLAProfileBooker::analyze")<<"Error: the profile associated to subdet "<<name<<"does not exist! ";   
-    else thesummaryhisto->second->Fill(tangent,size);
-    
+    getlayer(detid, tTopo, name, layerid);
+    histomap::iterator thesummaryhisto = summaryhisto.find(layerid);
+    if (thesummaryhisto == summaryhisto.end())
+      edm::LogError("SiStripLAProfileBooker::analyze")
+          << "Error: the profile associated to subdet " << name << "does not exist! ";
+    else
+      thesummaryhisto->second->Fill(tangent, size);
   }
-  
-  
 }
-
 
 //Makename function
- 
-void SiStripLAProfileBooker::getlayer(const DetId & detid, const TrackerTopology* tTopo, std::string &name,unsigned int &layerid){
-    int layer=0;
-    std::stringstream layernum;
 
-    if(detid.subdetId() == int (StripSubdetector::TIB)){
-      
-      name+="TIB_Layer_";
-      layer = tTopo->tibLayer(detid);
-    }
+void SiStripLAProfileBooker::getlayer(const DetId& detid,
+                                      const TrackerTopology* tTopo,
+                                      std::string& name,
+                                      unsigned int& layerid) {
+  int layer = 0;
+  std::stringstream layernum;
 
-    else if(detid.subdetId() == int (StripSubdetector::TID)){
-      
-      name+="TID_Ring_";
-      layer = tTopo->tidRing(detid);
-    }
+  if (detid.subdetId() == int(StripSubdetector::TIB)) {
+    name += "TIB_Layer_";
+    layer = tTopo->tibLayer(detid);
+  }
 
-    else if(detid.subdetId() == int (StripSubdetector::TOB)){
-      
-      name+="TOB_Layer_";
-      layer = tTopo->tobLayer(detid);
+  else if (detid.subdetId() == int(StripSubdetector::TID)) {
+    name += "TID_Ring_";
+    layer = tTopo->tidRing(detid);
+  }
 
-    }
+  else if (detid.subdetId() == int(StripSubdetector::TOB)) {
+    name += "TOB_Layer_";
+    layer = tTopo->tobLayer(detid);
 
-    else if(detid.subdetId() == int (StripSubdetector::TEC)){
-      
-      name+="TEC_Ring_";
-      layer = tTopo->tecRing(detid);
-    }
-    layernum<<layer;
-    name+=layernum.str();
-    layerid=detid.subdetId()*10+layer;
-  
+  }
+
+  else if (detid.subdetId() == int(StripSubdetector::TEC)) {
+    name += "TEC_Ring_";
+    layer = tTopo->tecRing(detid);
+  }
+  layernum << layer;
+  name += layernum.str();
+  layerid = detid.subdetId() * 10 + layer;
 }
- 
-void SiStripLAProfileBooker::endJob(){
 
-  std::string outputFile_ =conf_.getUntrackedParameter<std::string>("fileName", "LorentzAngle.root");
+void SiStripLAProfileBooker::endJob() {
+  std::string outputFile_ = conf_.getUntrackedParameter<std::string>("fileName", "LorentzAngle.root");
   dbe_->save(outputFile_);
-  
+
   hFile->Write();
   hFile->Close();
 }

--- a/CalibTracker/SiStripLorentzAngle/plugins/modules.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/modules.cc
@@ -3,8 +3,6 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
-
-
 #include "CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h"
 DEFINE_FWK_MODULE(sistrip::EnsembleCalibrationLA);
 

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
@@ -5,96 +5,130 @@
 #include <cmath>
 #include <boost/lexical_cast.hpp>
 
-
-void LA_Filler_Fitter::
-fill(TTree* tree, Book& book) const {
+void LA_Filler_Fitter::fill(TTree* tree, Book& book) const {
   TTREE_FOREACH_ENTRY(tree) {
     TFE_MAX(maxEvents_);
     TFE_PRINTSTATUS;
-    std::vector<unsigned> PLEAF( tsostrackmulti , tree );
-    std::vector<unsigned> PLEAF( clusterdetid , tree );
-    std::vector<unsigned> PLEAF( clusterwidth , tree );
-    std::vector<float>    PLEAF( clustervariance , tree );
-    std::vector<float>    PLEAF( tsosdriftx , tree );
-    std::vector<float>    PLEAF( tsosdriftz , tree );
-    std::vector<float>    PLEAF( tsoslocaltheta , tree );
-    std::vector<float>    PLEAF( tsoslocalphi , tree );
-    std::vector<float>    PLEAF( tsosglobalZofunitlocalY , tree );
+    std::vector<unsigned> PLEAF(tsostrackmulti, tree);
+    std::vector<unsigned> PLEAF(clusterdetid, tree);
+    std::vector<unsigned> PLEAF(clusterwidth, tree);
+    std::vector<float> PLEAF(clustervariance, tree);
+    std::vector<float> PLEAF(tsosdriftx, tree);
+    std::vector<float> PLEAF(tsosdriftz, tree);
+    std::vector<float> PLEAF(tsoslocaltheta, tree);
+    std::vector<float> PLEAF(tsoslocalphi, tree);
+    std::vector<float> PLEAF(tsosglobalZofunitlocalY, tree);
 
     const unsigned N(clusterdetid.size());
-    std::vector<float> BdotY(N,0); if(!ensembleBins_) { std::vector<float> PLEAF( tsosBdotY , tree ); swap(BdotY, tsosBdotY); }
-    std::vector<float> localy(N,0); if(localYbin_) { std::vector<float> PLEAF( tsoslocaly , tree ); swap(localy, tsoslocaly);}
-    std::vector<unsigned> seedstrip(N,0); if(stripsPerBin_) { std::vector<unsigned> PLEAF( clusterseedstrip , tree ); swap(seedstrip, clusterseedstrip);}
+    std::vector<float> BdotY(N, 0);
+    if (!ensembleBins_) {
+      std::vector<float> PLEAF(tsosBdotY, tree);
+      swap(BdotY, tsosBdotY);
+    }
+    std::vector<float> localy(N, 0);
+    if (localYbin_) {
+      std::vector<float> PLEAF(tsoslocaly, tree);
+      swap(localy, tsoslocaly);
+    }
+    std::vector<unsigned> seedstrip(N, 0);
+    if (stripsPerBin_) {
+      std::vector<unsigned> PLEAF(clusterseedstrip, tree);
+      swap(seedstrip, clusterseedstrip);
+    }
 
-    for(unsigned i=0; i<N ; i++) {
-
+    for (unsigned i = 0; i < N; i++) {
       const SiStripDetId detid(clusterdetid[i]);
-      if( tsostrackmulti[i] != 1 || ( detid.subDetector()!=SiStripDetId::TIB && 
-				      detid.subDetector()!=SiStripDetId::TOB)    )  continue;
+      if (tsostrackmulti[i] != 1 ||
+          (detid.subDetector() != SiStripDetId::TIB && detid.subDetector() != SiStripDetId::TOB))
+        continue;
 
       const int sign = tsosglobalZofunitlocalY[i] < 0 ? -1 : 1;
       const float tthetaL = sign * tsosdriftx[i] / tsosdriftz[i];
       const float tthetaT = sign * tan(tsoslocaltheta[i]) * cos(tsoslocalphi[i]);
-  
-      fill_one_cluster( book, 
-			granularity(detid, tthetaL, TFE_index, localy[i], seedstrip[i]%128),
-			clusterwidth[i], clustervariance[i], tthetaL, tthetaT, fabs(BdotY[i]) );
+
+      fill_one_cluster(book,
+                       granularity(detid, tthetaL, TFE_index, localy[i], seedstrip[i] % 128),
+                       clusterwidth[i],
+                       clustervariance[i],
+                       tthetaL,
+                       tthetaT,
+                       fabs(BdotY[i]));
     }
   }
 }
 
-void LA_Filler_Fitter::
-fill_one_cluster( Book& book, 
-		  const poly<std::string>& gran,
-		  const unsigned width, const float variance, const float tthetaL, const float tthetaT,  const float BdotY ) const 
-{
-  book.fill( tthetaL,                   gran+"_reconstruction", 360,-1.0,1.0 );
-  book.fill( tthetaT-tthetaL,           gran+ allAndOne(width), 360,-1.0,1.0 );
-  book.fill( tthetaT-tthetaL, variance, gran+  varWidth(width), 360,-1.0,1.0 );
-  if(methods_ & WIDTH) book.fill( tthetaT, width, gran+method(WIDTH), 81,-0.6,0.6 );
-  if(!ensembleBins_) {
-    book.fill( BdotY, gran+"_field", 101,1,5);
-    book.fill( width, gran+"_width", 10,0,10);
+void LA_Filler_Fitter::fill_one_cluster(Book& book,
+                                        const poly<std::string>& gran,
+                                        const unsigned width,
+                                        const float variance,
+                                        const float tthetaL,
+                                        const float tthetaT,
+                                        const float BdotY) const {
+  book.fill(tthetaL, gran + "_reconstruction", 360, -1.0, 1.0);
+  book.fill(tthetaT - tthetaL, gran + allAndOne(width), 360, -1.0, 1.0);
+  book.fill(tthetaT - tthetaL, variance, gran + varWidth(width), 360, -1.0, 1.0);
+  if (methods_ & WIDTH)
+    book.fill(tthetaT, width, gran + method(WIDTH), 81, -0.6, 0.6);
+  if (!ensembleBins_) {
+    book.fill(BdotY, gran + "_field", 101, 1, 5);
+    book.fill(width, gran + "_width", 10, 0, 10);
   }
 }
 
-poly<std::string> LA_Filler_Fitter::
-allAndOne(const unsigned width) const 
-{ poly<std::string> a1("_all"); if(width==1) a1*="_w1"; return a1;}
+poly<std::string> LA_Filler_Fitter::allAndOne(const unsigned width) const {
+  poly<std::string> a1("_all");
+  if (width == 1)
+    a1 *= "_w1";
+  return a1;
+}
 
-poly<std::string> LA_Filler_Fitter::
-varWidth(const unsigned width) const { 
-  poly<std::string> vw; vw++; 
-  if(width==2 && methods_ & (AVGV2|RMSV2) ) vw*=method(AVGV2,false);
-  if(width==3 && methods_ & (AVGV3|RMSV3) ) vw*=method(AVGV3,false);
+poly<std::string> LA_Filler_Fitter::varWidth(const unsigned width) const {
+  poly<std::string> vw;
+  vw++;
+  if (width == 2 && methods_ & (AVGV2 | RMSV2))
+    vw *= method(AVGV2, false);
+  if (width == 3 && methods_ & (AVGV3 | RMSV3))
+    vw *= method(AVGV3, false);
   return vw;
 }
 
-poly<std::string> LA_Filler_Fitter::
-granularity(const SiStripDetId detid, const float tthetaL, const Long64_t TFE_index, const float localy, const unsigned apvstrip) const {
+poly<std::string> LA_Filler_Fitter::granularity(const SiStripDetId detid,
+                                                const float tthetaL,
+                                                const Long64_t TFE_index,
+                                                const float localy,
+                                                const unsigned apvstrip) const {
   poly<std::string> gran;
   gran += subdetLabel(detid);
-  if(byLayer_)  gran *= layerLabel(detid);
-  if(byModule_) gran *= moduleLabel(detid);
-  if(localYbin_) gran += (localy < 0 ? "_yM":"_yP") + std::to_string(abs((int)(localy/localYbin_+(localy<0?-1:0))));
-  if(stripsPerBin_) gran += "_strip"+std::to_string((unsigned)((0.5+((apvstrip/64)?(127-apvstrip):apvstrip)/stripsPerBin_)*stripsPerBin_) );
-  if(ensembleBins_) {
-    gran+= "_ensembleBin"+std::to_string((int)(ensembleBins_*(tthetaL-ensembleLow_)/(ensembleUp_-ensembleLow_)));
-    gran+= "";
-    if(ensembleSize_) gran*= "_sample"+std::to_string(TFE_index % ensembleSize_);
+  if (byLayer_)
+    gran *= layerLabel(detid);
+  if (byModule_)
+    gran *= moduleLabel(detid);
+  if (localYbin_)
+    gran += (localy < 0 ? "_yM" : "_yP") + std::to_string(abs((int)(localy / localYbin_ + (localy < 0 ? -1 : 0))));
+  if (stripsPerBin_)
+    gran += "_strip" +
+            std::to_string(
+                (unsigned)((0.5 + ((apvstrip / 64) ? (127 - apvstrip) : apvstrip) / stripsPerBin_) * stripsPerBin_));
+  if (ensembleBins_) {
+    gran +=
+        "_ensembleBin" + std::to_string((int)(ensembleBins_ * (tthetaL - ensembleLow_) / (ensembleUp_ - ensembleLow_)));
+    gran += "";
+    if (ensembleSize_)
+      gran *= "_sample" + std::to_string(TFE_index % ensembleSize_);
   }
   return gran;
 }
 
-std::string LA_Filler_Fitter::
-subdetLabel(const SiStripDetId detid) { return detid.subDetector()==SiStripDetId::TOB ? "TOB" : "TIB";}
-std::string LA_Filler_Fitter::
-moduleLabel(const SiStripDetId detid) { return subdetLabel(detid) + "_module"+std::to_string(detid());}
-std::string LA_Filler_Fitter::
-layerLabel(const SiStripDetId detid) const {
+std::string LA_Filler_Fitter::subdetLabel(const SiStripDetId detid) {
+  return detid.subDetector() == SiStripDetId::TOB ? "TOB" : "TIB";
+}
+std::string LA_Filler_Fitter::moduleLabel(const SiStripDetId detid) {
+  return subdetLabel(detid) + "_module" + std::to_string(detid());
+}
+std::string LA_Filler_Fitter::layerLabel(const SiStripDetId detid) const {
   const bool isTIB = detid.subdetId() == StripSubdetector::TIB;
   unsigned layer = isTIB ? tTopo_->tibLayer(detid) : tTopo_->tobLayer(detid);
   bool stereo = isTIB ? tTopo_->tibStereo(detid) : tTopo_->tobStereo(detid);
-  
-  return subdetLabel(detid)+"_layer"+std::to_string(layer)+(stereo?"s":"a");
+
+  return subdetLabel(detid) + "_layer" + std::to_string(layer) + (stereo ? "s" : "a");
 }

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Fitter.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Fitter.cc
@@ -5,118 +5,147 @@
 #include <boost/algorithm/string/erase.hpp>
 #include <TF1.h>
 
-void LA_Filler_Fitter::
-fit_width_profile(Book& book) {
-  for(Book::iterator it = book.begin(".*"+method(WIDTH)); it!=book.end(); ++it) {
+void LA_Filler_Fitter::fit_width_profile(Book& book) {
+  for (Book::iterator it = book.begin(".*" + method(WIDTH)); it != book.end(); ++it) {
     it->second->SetTitle("Mean Cluster Width;tan#theta_{t}");
     TH1* const p = it->second;
-    if(p->GetEntries() < 400) { delete p; book[it->first]=nullptr; continue;}
+    if (p->GetEntries() < 400) {
+      delete p;
+      book[it->first] = nullptr;
+      continue;
+    }
     p->SetTitle(";tan#theta_{t};");
     const float min = p->GetMinimum();
     const float max = p->GetMaximum();
-    float xofmin = p->GetBinCenter(p->GetMinimumBin()); if( xofmin>0.0 || xofmin<-0.15) xofmin = -0.05;
+    float xofmin = p->GetBinCenter(p->GetMinimumBin());
+    if (xofmin > 0.0 || xofmin < -0.15)
+      xofmin = -0.05;
     const float xofmax = p->GetBinCenter(p->GetMaximumBin());
 
-    TF1* const fit = new TF1("LA_profile_fit","[2]*(TMath::Abs(x-[0]))+[1]",-1,1);
-    fit->SetParLimits(0,-0.15,0.01);
-    fit->SetParLimits(1, 0.6*min, 1.25*min );
-    fit->SetParLimits(2,0.1,10);
-    fit->SetParameters( xofmin, min, (max-min) / fabs( xofmax - xofmin ) );
+    TF1* const fit = new TF1("LA_profile_fit", "[2]*(TMath::Abs(x-[0]))+[1]", -1, 1);
+    fit->SetParLimits(0, -0.15, 0.01);
+    fit->SetParLimits(1, 0.6 * min, 1.25 * min);
+    fit->SetParLimits(2, 0.1, 10);
+    fit->SetParameters(xofmin, min, (max - min) / fabs(xofmax - xofmin));
 
-    int badfit = p->Fit(fit,"IEQ","",-.5,.3);
-    if( badfit ) badfit = p->Fit(fit,"IEQ","", -.46,.26);
-    if( badfit ) { book.erase(it); }
+    int badfit = p->Fit(fit, "IEQ", "", -.5, .3);
+    if (badfit)
+      badfit = p->Fit(fit, "IEQ", "", -.46, .26);
+    if (badfit) {
+      book.erase(it);
+    }
   }
 }
 
-void LA_Filler_Fitter::
-make_and_fit_symmchi2(Book& book) {
-  for(Book::iterator it = book.begin(".*_all"); it!=book.end(); ++it) {
-    const std::string base = boost::erase_all_copy(it->first,"_all");
+void LA_Filler_Fitter::make_and_fit_symmchi2(Book& book) {
+  for (Book::iterator it = book.begin(".*_all"); it != book.end(); ++it) {
+    const std::string base = boost::erase_all_copy(it->first, "_all");
 
-    std::vector<Book::iterator> rebin_hists;              
-    const Book::iterator&    all = it;	                             rebin_hists.push_back(all);   
-    Book::iterator     w1 = book.find(base+"_w1");           rebin_hists.push_back(w1);    
-    Book::iterator var_w2 = book.find(base+method(AVGV2,false)); rebin_hists.push_back(var_w2);
-    Book::iterator var_w3 = book.find(base+method(AVGV3,false)); rebin_hists.push_back(var_w3);
+    std::vector<Book::iterator> rebin_hists;
+    const Book::iterator& all = it;
+    rebin_hists.push_back(all);
+    Book::iterator w1 = book.find(base + "_w1");
+    rebin_hists.push_back(w1);
+    Book::iterator var_w2 = book.find(base + method(AVGV2, false));
+    rebin_hists.push_back(var_w2);
+    Book::iterator var_w3 = book.find(base + method(AVGV3, false));
+    rebin_hists.push_back(var_w3);
 
-    const unsigned rebin = std::max( var_w2==book.end() ? 0 : find_rebin(var_w2->second), 
-				     var_w3==book.end() ? 0 : find_rebin(var_w3->second) );
-    for(const auto& it : rebin_hists) if(it!=book.end()) it->second->Rebin( rebin>1 ? rebin<7 ? rebin : 6 : 1);
+    const unsigned rebin = std::max(var_w2 == book.end() ? 0 : find_rebin(var_w2->second),
+                                    var_w3 == book.end() ? 0 : find_rebin(var_w3->second));
+    for (const auto& it : rebin_hists)
+      if (it != book.end())
+        it->second->Rebin(rebin > 1 ? rebin < 7 ? rebin : 6 : 1);
 
-    TH1* const prob_w1 = w1==book.end()     ? nullptr : subset_probability( base+method(PROB1,false) ,w1->second,all->second);
-    TH1* const rmsv_w2 = var_w2==book.end() ? nullptr :        rms_profile( base+method(RMSV2,false), (TProfile*const)var_w2->second);
-    TH1* const rmsv_w3 = var_w3==book.end() ? nullptr :        rms_profile( base+method(RMSV3,false), (TProfile*const)var_w3->second);
-    
+    TH1* const prob_w1 =
+        w1 == book.end() ? nullptr : subset_probability(base + method(PROB1, false), w1->second, all->second);
+    TH1* const rmsv_w2 =
+        var_w2 == book.end() ? nullptr : rms_profile(base + method(RMSV2, false), (TProfile* const)var_w2->second);
+    TH1* const rmsv_w3 =
+        var_w3 == book.end() ? nullptr : rms_profile(base + method(RMSV3, false), (TProfile* const)var_w3->second);
+
     std::vector<TH1*> fit_hists;
-    if(prob_w1) {
-      book.book(base+method(PROB1,false),prob_w1);
-      fit_hists.push_back(prob_w1);  prob_w1->SetTitle("Width==1 Probability;tan#theta_{t}-(dx/dz)_{reco}");
+    if (prob_w1) {
+      book.book(base + method(PROB1, false), prob_w1);
+      fit_hists.push_back(prob_w1);
+      prob_w1->SetTitle("Width==1 Probability;tan#theta_{t}-(dx/dz)_{reco}");
     }
-    if(var_w2!=book.end())  {
-      book.book(base+method(RMSV2,false),rmsv_w2);
-      fit_hists.push_back(var_w2->second);   var_w2->second->SetTitle("Width==2 Mean Variance;tan#theta_{t}-(dx/dz)_{reco}");
-      fit_hists.push_back(rmsv_w2);                 rmsv_w2->SetTitle("Width==2 RMS Variance;tan#theta_{t}-(dx/dz)_{reco}");
+    if (var_w2 != book.end()) {
+      book.book(base + method(RMSV2, false), rmsv_w2);
+      fit_hists.push_back(var_w2->second);
+      var_w2->second->SetTitle("Width==2 Mean Variance;tan#theta_{t}-(dx/dz)_{reco}");
+      fit_hists.push_back(rmsv_w2);
+      rmsv_w2->SetTitle("Width==2 RMS Variance;tan#theta_{t}-(dx/dz)_{reco}");
     }
-    if(var_w3!=book.end())  {
-      book.book(base+method(RMSV3,false),rmsv_w3);
-      fit_hists.push_back(var_w3->second);   var_w3->second->SetTitle("Width==3 Mean Variance;tan#theta_{t}-(dx/dz)_{reco}");
-      fit_hists.push_back(rmsv_w3);                 rmsv_w3->SetTitle("Width==3 RMS Variance;tan#theta_{t}-(dx/dz)_{reco}");
+    if (var_w3 != book.end()) {
+      book.book(base + method(RMSV3, false), rmsv_w3);
+      fit_hists.push_back(var_w3->second);
+      var_w3->second->SetTitle("Width==3 Mean Variance;tan#theta_{t}-(dx/dz)_{reco}");
+      fit_hists.push_back(rmsv_w3);
+      rmsv_w3->SetTitle("Width==3 RMS Variance;tan#theta_{t}-(dx/dz)_{reco}");
     }
 
-    if(fit_hists.empty()) continue;
+    if (fit_hists.empty())
+      continue;
     const unsigned bins = fit_hists[0]->GetNbinsX();
     const unsigned guess = fit_hists[0]->FindBin(0);
-    const std::pair<unsigned,unsigned> range(guess-bins/30,guess+bins/30);
+    const std::pair<unsigned, unsigned> range(guess - bins / 30, guess + bins / 30);
 
-    for(auto const& hist : fit_hists) {
-      TH1*const chi2 = SymmetryFit::symmetryChi2(hist,range);
-      if(chi2) {book.book(chi2->GetName(),chi2); chi2->SetTitle("Symmetry #chi^{2};tan#theta_{t}-(dx/dz)_{reco}");}
+    for (auto const& hist : fit_hists) {
+      TH1* const chi2 = SymmetryFit::symmetryChi2(hist, range);
+      if (chi2) {
+        book.book(chi2->GetName(), chi2);
+        chi2->SetTitle("Symmetry #chi^{2};tan#theta_{t}-(dx/dz)_{reco}");
+      }
     }
   }
 }
 
-unsigned LA_Filler_Fitter::
-find_rebin(const TH1* const hist) {
+unsigned LA_Filler_Fitter::find_rebin(const TH1* const hist) {
   const double mean = hist->GetMean();
   const double rms = hist->GetRMS();
-  const int begin = std::min(                1, hist->GetXaxis()->FindFixBin(mean-rms));
-  const int end   = std::max(hist->GetNbinsX(), hist->GetXaxis()->FindFixBin(mean+rms)) + 1;
+  const int begin = std::min(1, hist->GetXaxis()->FindFixBin(mean - rms));
+  const int end = std::max(hist->GetNbinsX(), hist->GetXaxis()->FindFixBin(mean + rms)) + 1;
   unsigned current_hole(0), max_hole(0);
-  for(int i=begin; i<end; i++) {
-    if(!hist->GetBinError(i)) current_hole++;
-    else if(current_hole) {max_hole = std::max(current_hole,max_hole); current_hole=0;}
+  for (int i = begin; i < end; i++) {
+    if (!hist->GetBinError(i))
+      current_hole++;
+    else if (current_hole) {
+      max_hole = std::max(current_hole, max_hole);
+      current_hole = 0;
+    }
   }
-  return max_hole+1;
+  return max_hole + 1;
 }
 
-TH1* LA_Filler_Fitter::
-rms_profile(const std::string name, const TProfile* const prof) {
+TH1* LA_Filler_Fitter::rms_profile(const std::string name, const TProfile* const prof) {
   const int bins = prof->GetNbinsX();
-  TH1* const rms = new TH1F(name.c_str(),"",bins, prof->GetBinLowEdge(1),  prof->GetBinLowEdge(bins) + prof->GetBinWidth(bins) );
-  for(int i = 1; i<=bins; i++) {
+  TH1* const rms =
+      new TH1F(name.c_str(), "", bins, prof->GetBinLowEdge(1), prof->GetBinLowEdge(bins) + prof->GetBinWidth(bins));
+  for (int i = 1; i <= bins; i++) {
     const double Me = prof->GetBinError(i);
-    const double neff = prof->GetBinEntries(i); //Should be prof->GetBinEffectiveEntries(i);, not availible this version ROOT.  This is only ok for unweighted fills
-    rms->SetBinContent(i, Me*sqrt(neff) );
-    rms->SetBinError(i, Me/sqrt(2) );
+    const double neff = prof->GetBinEntries(
+        i);  //Should be prof->GetBinEffectiveEntries(i);, not availible this version ROOT.  This is only ok for unweighted fills
+    rms->SetBinContent(i, Me * sqrt(neff));
+    rms->SetBinError(i, Me / sqrt(2));
   }
   return rms;
 }
 
-TH1* LA_Filler_Fitter::
-subset_probability(const std::string name, const TH1* const subset, const TH1* const total) {
+TH1* LA_Filler_Fitter::subset_probability(const std::string name, const TH1* const subset, const TH1* const total) {
   const int bins = subset->GetNbinsX();
-  TH1* const prob = new TH1F(name.c_str(),"",bins, subset->GetBinLowEdge(1),  subset->GetBinLowEdge(bins) + subset->GetBinWidth(bins) );
-  for(int i = 1; i<=bins; i++) {
+  TH1* const prob = new TH1F(
+      name.c_str(), "", bins, subset->GetBinLowEdge(1), subset->GetBinLowEdge(bins) + subset->GetBinWidth(bins));
+  for (int i = 1; i <= bins; i++) {
     const double s = subset->GetBinContent(i);
     const double T = total->GetBinContent(i);
-    const double B = T-s;
+    const double B = T - s;
 
-    const double p = T? s/T : 0;
-    const double perr = T? ( (s&&B)? sqrt(s*s*B+B*B*s)/(T*T) : 1/T ) : 0;
+    const double p = T ? s / T : 0;
+    const double perr = T ? ((s && B) ? sqrt(s * s * B + B * B * s) / (T * T) : 1 / T) : 0;
 
-    prob->SetBinContent(i,p);
-    prob->SetBinError(i,perr);
-  }  
+    prob->SetBinContent(i, p);
+    prob->SetBinError(i, perr);
+  }
   return prob;
 }

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
@@ -2,185 +2,188 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <cmath>
-#include <boost/regex.hpp> 
+#include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <TF1.h>
 #include <TGraphErrors.h>
 #include <TProfile.h>
 
-LA_Filler_Fitter::Result LA_Filler_Fitter::
-result(Method m, const std::string name, const Book& book) {
+LA_Filler_Fitter::Result LA_Filler_Fitter::result(Method m, const std::string name, const Book& book) {
   Result p;
-  const std::string base = boost::erase_all_copy(name,method(m));
-  
-  const TH1* const h = book[name];
-  const TH1* const reco = book[base+"_reconstruction"];
-  const TH1* const field = book[base+"_field"];
+  const std::string base = boost::erase_all_copy(name, method(m));
 
-  if(reco) p.reco = std::make_pair<float,float>( reco->GetMean(), reco->GetMeanError());
-  if(field) p.field = field->GetMean();
-  if(h) { switch(m) {
-    case WIDTH: {
-      const TF1*const f = h->GetFunction("LA_profile_fit"); if(!f) break;
-      p.measured = std::make_pair<float,float>(f->GetParameter(0),f->GetParError(0));
-      p.chi2 = f->GetChisquare();
-      p.ndof = f->GetNDF();
-      p.entries = (unsigned)(h->GetEntries());
-      break;
-    }
-    case PROB1: case AVGV2: case AVGV3: case RMSV2: case RMSV3: /*case MULTI:*/ {
-      const TF1*const f = h->GetFunction("SymmetryFit"); if(!f) break;
-      p.measured = std::make_pair<float,float>( p.reco.first + f->GetParameter(0), f->GetParameter(1) );
-      p.chi2 = f->GetParameter(2);
-      p.ndof = (unsigned) (f->GetParameter(3));
-      p.entries = 
-	(m&PROB1)         ? (unsigned) book[base+"_w1"]->GetEntries() : 
-	(m&(AVGV2|RMSV2)) ? (unsigned) book[base+method(AVGV2,false)]->GetEntries() : 
-	(m&(AVGV3|RMSV3)) ? (unsigned) book[base+method(AVGV3,false)]->GetEntries() : 0 ;
-      break;
-    }
-    default: break;
+  const TH1* const h = book[name];
+  const TH1* const reco = book[base + "_reconstruction"];
+  const TH1* const field = book[base + "_field"];
+
+  if (reco)
+    p.reco = std::make_pair<float, float>(reco->GetMean(), reco->GetMeanError());
+  if (field)
+    p.field = field->GetMean();
+  if (h) {
+    switch (m) {
+      case WIDTH: {
+        const TF1* const f = h->GetFunction("LA_profile_fit");
+        if (!f)
+          break;
+        p.measured = std::make_pair<float, float>(f->GetParameter(0), f->GetParError(0));
+        p.chi2 = f->GetChisquare();
+        p.ndof = f->GetNDF();
+        p.entries = (unsigned)(h->GetEntries());
+        break;
+      }
+      case PROB1:
+      case AVGV2:
+      case AVGV3:
+      case RMSV2:
+      case RMSV3: /*case MULTI:*/ {
+        const TF1* const f = h->GetFunction("SymmetryFit");
+        if (!f)
+          break;
+        p.measured = std::make_pair<float, float>(p.reco.first + f->GetParameter(0), f->GetParameter(1));
+        p.chi2 = f->GetParameter(2);
+        p.ndof = (unsigned)(f->GetParameter(3));
+        p.entries = (m & PROB1)
+                        ? (unsigned)book[base + "_w1"]->GetEntries()
+                        : (m & (AVGV2 | RMSV2))
+                              ? (unsigned)book[base + method(AVGV2, false)]->GetEntries()
+                              : (m & (AVGV3 | RMSV3)) ? (unsigned)book[base + method(AVGV3, false)]->GetEntries() : 0;
+        break;
+      }
+      default:
+        break;
     }
   }
   return p;
 }
 
-std::map<uint32_t,LA_Filler_Fitter::Result> LA_Filler_Fitter::
-module_results( const Book& book, const Method m) {
-  std::map<uint32_t,Result> results;
-  for(Book::const_iterator it = book.begin(".*_module\\d*"+method(m)); it!=book.end(); ++it ) {
-    const uint32_t detid = boost::lexical_cast<uint32_t>( boost::regex_replace( it->first,
-										boost::regex(".*_module(\\d*)_.*"),
-										std::string("\\1")));
-    results[detid] = result(m,it->first,book);
+std::map<uint32_t, LA_Filler_Fitter::Result> LA_Filler_Fitter::module_results(const Book& book, const Method m) {
+  std::map<uint32_t, Result> results;
+  for (Book::const_iterator it = book.begin(".*_module\\d*" + method(m)); it != book.end(); ++it) {
+    const uint32_t detid = boost::lexical_cast<uint32_t>(
+        boost::regex_replace(it->first, boost::regex(".*_module(\\d*)_.*"), std::string("\\1")));
+    results[detid] = result(m, it->first, book);
   }
   return results;
 }
 
-std::map<std::string,LA_Filler_Fitter::Result> LA_Filler_Fitter::
-layer_results( const Book& book, const Method m) {
-  std::map<std::string,Result> results;
-  for(Book::const_iterator it = book.begin(".*layer\\d.*"+method(m)); it!=book.end(); ++it ) {
-    const std::string name = boost::erase_all_copy(it->first,method(m));
-    results[name] = result(m,it->first,book);
+std::map<std::string, LA_Filler_Fitter::Result> LA_Filler_Fitter::layer_results(const Book& book, const Method m) {
+  std::map<std::string, Result> results;
+  for (Book::const_iterator it = book.begin(".*layer\\d.*" + method(m)); it != book.end(); ++it) {
+    const std::string name = boost::erase_all_copy(it->first, method(m));
+    results[name] = result(m, it->first, book);
   }
   return results;
 }
 
-std::map<std::string, std::vector<LA_Filler_Fitter::Result> > LA_Filler_Fitter::
-ensemble_results( const Book& book, const Method m) {
+std::map<std::string, std::vector<LA_Filler_Fitter::Result> > LA_Filler_Fitter::ensemble_results(const Book& book,
+                                                                                                 const Method m) {
   std::map<std::string, std::vector<Result> > results;
-  for(Book::const_iterator it = book.begin(".*_sample.*"+method(m)); it!=book.end(); ++it ) {
-    const std::string name = boost::regex_replace(it->first,boost::regex("sample\\d*_"),"");
-    results[name].push_back(result(m,it->first,book));
+  for (Book::const_iterator it = book.begin(".*_sample.*" + method(m)); it != book.end(); ++it) {
+    const std::string name = boost::regex_replace(it->first, boost::regex("sample\\d*_"), "");
+    results[name].push_back(result(m, it->first, book));
   }
   return results;
 }
 
-void LA_Filler_Fitter::
-summarize_ensembles(Book& book) const {
+void LA_Filler_Fitter::summarize_ensembles(Book& book) const {
   typedef std::map<std::string, std::vector<Result> > results_t;
   results_t results;
-  for(int m = FIRST_METHOD; m <= LAST_METHOD; m<<=1)
-    if(methods_ & m) { results_t g = ensemble_results(book,(Method)(m)); results.insert(g.begin(),g.end());}
-  
-  for(auto const& group : results) {
+  for (int m = FIRST_METHOD; m <= LAST_METHOD; m <<= 1)
+    if (methods_ & m) {
+      results_t g = ensemble_results(book, (Method)(m));
+      results.insert(g.begin(), g.end());
+    }
+
+  for (auto const& group : results) {
     const std::string name = group.first;
-    for(auto const& p : group.second) {
-      const float pad = (ensembleUp_-ensembleLow_)/10;
-      book.fill( p.reco.first,      name+"_ensembleReco", 12*ensembleBins_, ensembleLow_-pad, ensembleUp_+pad );
-      book.fill( p.measured.first,  name+"_measure",      12*ensembleBins_, ensembleLow_-pad, ensembleUp_+pad );
-      book.fill( p.measured.second, name+"_merr",         500, 0, 0.01);
-      book.fill( (p.measured.first-p.reco.first)/p.measured.second, name+"_pull", 500, -10,10);
+    for (auto const& p : group.second) {
+      const float pad = (ensembleUp_ - ensembleLow_) / 10;
+      book.fill(p.reco.first, name + "_ensembleReco", 12 * ensembleBins_, ensembleLow_ - pad, ensembleUp_ + pad);
+      book.fill(p.measured.first, name + "_measure", 12 * ensembleBins_, ensembleLow_ - pad, ensembleUp_ + pad);
+      book.fill(p.measured.second, name + "_merr", 500, 0, 0.01);
+      book.fill((p.measured.first - p.reco.first) / p.measured.second, name + "_pull", 500, -10, 10);
     }
     //Need our own copy for thread safety
-    TF1 gaus("mygaus","gaus");
-    book[name+"_measure"]->Fit(&gaus,"LLQ");
-    book[name+"_merr"]->Fit(&gaus,"LLQ");
-    book[name+"_pull"]->Fit(&gaus,"LLQ");
+    TF1 gaus("mygaus", "gaus");
+    book[name + "_measure"]->Fit(&gaus, "LLQ");
+    book[name + "_merr"]->Fit(&gaus, "LLQ");
+    book[name + "_pull"]->Fit(&gaus, "LLQ");
   }
 }
 
-std::map<std::string, std::vector<LA_Filler_Fitter::EnsembleSummary> > LA_Filler_Fitter::
-ensemble_summary(const Book& book) {
+std::map<std::string, std::vector<LA_Filler_Fitter::EnsembleSummary> > LA_Filler_Fitter::ensemble_summary(
+    const Book& book) {
   std::map<std::string, std::vector<EnsembleSummary> > summary;
-  for(Book::const_iterator it = book.begin(".*_ensembleReco"); it!=book.end(); ++it) {
-    const std::string base = boost::erase_all_copy(it->first,"_ensembleReco");
+  for (Book::const_iterator it = book.begin(".*_ensembleReco"); it != book.end(); ++it) {
+    const std::string base = boost::erase_all_copy(it->first, "_ensembleReco");
 
-    const TH1*const reco = it->second;
-    const TH1*const measure = book[base+"_measure"];
-    const TH1*const merr = book[base+"_merr"];
-    const TH1*const pull = book[base+"_pull"];
+    const TH1* const reco = it->second;
+    const TH1* const measure = book[base + "_measure"];
+    const TH1* const merr = book[base + "_merr"];
+    const TH1* const pull = book[base + "_pull"];
 
     EnsembleSummary s;
     s.samples = reco->GetEntries();
     s.truth = reco->GetMean();
-    s.meanMeasured = std::make_pair<float,float>( measure->GetFunction("gaus")->GetParameter(1), measure->GetFunction("gaus")->GetParError(1) );
-    s.sigmaMeasured = std::make_pair<float,float>( measure->GetFunction("gaus")->GetParameter(2), measure->GetFunction("gaus")->GetParError(2) );
-    s.meanUncertainty = std::make_pair<float,float>( merr->GetFunction("gaus")->GetParameter(1), merr->GetFunction("gaus")->GetParError(1) );
-    s.pull = std::make_pair<float,float>( pull->GetFunction("gaus")->GetParameter(2), pull->GetFunction("gaus")->GetParError(2) );
+    s.meanMeasured = std::make_pair<float, float>(measure->GetFunction("gaus")->GetParameter(1),
+                                                  measure->GetFunction("gaus")->GetParError(1));
+    s.sigmaMeasured = std::make_pair<float, float>(measure->GetFunction("gaus")->GetParameter(2),
+                                                   measure->GetFunction("gaus")->GetParError(2));
+    s.meanUncertainty = std::make_pair<float, float>(merr->GetFunction("gaus")->GetParameter(1),
+                                                     merr->GetFunction("gaus")->GetParError(1));
+    s.pull = std::make_pair<float, float>(pull->GetFunction("gaus")->GetParameter(2),
+                                          pull->GetFunction("gaus")->GetParError(2));
 
-    const std::string name = boost::regex_replace(base,boost::regex("ensembleBin\\d*_"),"");
+    const std::string name = boost::regex_replace(base, boost::regex("ensembleBin\\d*_"), "");
     summary[name].push_back(s);
   }
   return summary;
 }
 
-std::pair<std::pair<float,float>, std::pair<float,float> > LA_Filler_Fitter::
-offset_slope(const std::vector<LA_Filler_Fitter::EnsembleSummary>& ensembles) { 
+std::pair<std::pair<float, float>, std::pair<float, float> > LA_Filler_Fitter::offset_slope(
+    const std::vector<LA_Filler_Fitter::EnsembleSummary>& ensembles) {
   try {
-    std::vector<float> x,y,xerr,yerr;
-    for(auto const& ensemble : ensembles) {
+    std::vector<float> x, y, xerr, yerr;
+    for (auto const& ensemble : ensembles) {
       x.push_back(ensemble.truth);
       xerr.push_back(0);
       y.push_back(ensemble.meanMeasured.first);
       yerr.push_back(ensemble.meanMeasured.second);
     }
-    TGraphErrors graph(x.size(),&(x[0]),&(y[0]),&(xerr[0]),&(yerr[0]));
+    TGraphErrors graph(x.size(), &(x[0]), &(y[0]), &(xerr[0]), &(yerr[0]));
     //Need our own copy for thread safety
-    TF1 pol1("mypol1","pol1");
+    TF1 pol1("mypol1", "pol1");
     graph.Fit(&pol1);
-    const TF1*const fit = graph.GetFunction("pol1");
-    
-    return std::make_pair( std::make_pair(fit->GetParameter(0), fit->GetParError(0)),
-			   std::make_pair(fit->GetParameter(1), fit->GetParError(1)) );
-  } catch(edm::Exception const& e) {
+    const TF1* const fit = graph.GetFunction("pol1");
+
+    return std::make_pair(std::make_pair(fit->GetParameter(0), fit->GetParError(0)),
+                          std::make_pair(fit->GetParameter(1), fit->GetParError(1)));
+  } catch (edm::Exception const& e) {
     std::cerr << "Fitting Line Failed " << std::endl << e << std::endl;
-    return std::make_pair( std::make_pair(0,0), std::make_pair(0,0));
+    return std::make_pair(std::make_pair(0, 0), std::make_pair(0, 0));
   }
 }
 
-float LA_Filler_Fitter::
-pull(const std::vector<LA_Filler_Fitter::EnsembleSummary>& ensembles) {
-  float p(0),w(0);
-  for(auto const& ensemble : ensembles) {
-    const float unc2 = pow(ensemble.pull.second,2);
-    p+=  ensemble.pull.first / unc2;
-    w+= 1/unc2;
+float LA_Filler_Fitter::pull(const std::vector<LA_Filler_Fitter::EnsembleSummary>& ensembles) {
+  float p(0), w(0);
+  for (auto const& ensemble : ensembles) {
+    const float unc2 = pow(ensemble.pull.second, 2);
+    p += ensemble.pull.first / unc2;
+    w += 1 / unc2;
   }
-  return p/w;
+  return p / w;
 }
 
-
-std::ostream& operator<<(std::ostream& strm, const LA_Filler_Fitter::Result& r) { 
-  return strm << r.reco.first <<"\t"<< r.reco.second <<"\t"
-	      << r.measured.first <<"\t"<< r.measured.second <<"\t"
-	      << r.calMeasured.first <<"\t"<< r.calMeasured.second <<"\t"
-	      << r.field <<"\t"
-	      << r.chi2 <<"\t"
-	      << r.ndof <<"\t"
-	      << r.entries;
+std::ostream& operator<<(std::ostream& strm, const LA_Filler_Fitter::Result& r) {
+  return strm << r.reco.first << "\t" << r.reco.second << "\t" << r.measured.first << "\t" << r.measured.second << "\t"
+              << r.calMeasured.first << "\t" << r.calMeasured.second << "\t" << r.field << "\t" << r.chi2 << "\t"
+              << r.ndof << "\t" << r.entries;
 }
 
-std::ostream& operator<<(std::ostream& strm, const LA_Filler_Fitter::EnsembleSummary& e) { 
-  return strm << e.truth <<"\t"
-	      << e.meanMeasured.first    <<"\t"<< e.meanMeasured.second <<"\t"
-	      << e.sigmaMeasured.first   <<"\t"<< e.sigmaMeasured.second <<"\t"
-	      << e.meanUncertainty.first <<"\t"<< e.meanUncertainty.second << "\t"
-	      << e.pull.first            <<"\t"<< e.pull.second << "\t"
-	      << e.samples;
+std::ostream& operator<<(std::ostream& strm, const LA_Filler_Fitter::EnsembleSummary& e) {
+  return strm << e.truth << "\t" << e.meanMeasured.first << "\t" << e.meanMeasured.second << "\t"
+              << e.sigmaMeasured.first << "\t" << e.sigmaMeasured.second << "\t" << e.meanUncertainty.first << "\t"
+              << e.meanUncertainty.second << "\t" << e.pull.first << "\t" << e.pull.second << "\t" << e.samples;
 }
-
-
-

--- a/CalibTracker/SiStripLorentzAngle/src/SymmetryFit.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/SymmetryFit.cc
@@ -3,166 +3,169 @@
 #include <cassert>
 #include <memory>
 
-TH1* SymmetryFit::symmetryChi2(std::string basename, const std::vector<TH1*>& candidates, const std::pair<unsigned,unsigned> range)
-{
-  TH1* fake = (TH1*)(candidates[0]->Clone(basename.c_str())); 
+TH1* SymmetryFit::symmetryChi2(std::string basename,
+                               const std::vector<TH1*>& candidates,
+                               const std::pair<unsigned, unsigned> range) {
+  TH1* fake = (TH1*)(candidates[0]->Clone(basename.c_str()));
   fake->Reset();
-  SymmetryFit combined(fake,range);
+  SymmetryFit combined(fake, range);
   delete fake;
 
-  for(auto const* candidate : candidates) {
-    SymmetryFit sf(candidate,range); 
-    combined+=sf; 
-    delete sf.chi2_; 
+  for (auto const* candidate : candidates) {
+    SymmetryFit sf(candidate, range);
+    combined += sf;
+    delete sf.chi2_;
   }
 
   int status = combined.fit();
-  if(status) { delete combined.chi2_; combined.chi2_=nullptr;}
+  if (status) {
+    delete combined.chi2_;
+    combined.chi2_ = nullptr;
+  }
   return combined.chi2_;
 }
 
-TH1* SymmetryFit::symmetryChi2(const TH1* candidate, const std::pair<unsigned,unsigned> range) 
-{
+TH1* SymmetryFit::symmetryChi2(const TH1* candidate, const std::pair<unsigned, unsigned> range) {
   SymmetryFit sf(candidate, range);
   int status = sf.fit();
-  if(status) { delete sf.chi2_; sf.chi2_=nullptr; }
+  if (status) {
+    delete sf.chi2_;
+    sf.chi2_ = nullptr;
+  }
   return sf.chi2_;
 }
 
-SymmetryFit::SymmetryFit(const TH1* h, const std::pair<unsigned,unsigned> r)
-  : symm_candidate_(h), 
-    minDF_(r.second-r.first),
-    range_(r),
-    minmaxUsable_(findUsableMinMax()),
-    ndf_( minmaxUsable_.first<minmaxUsable_.second ? minmaxUsable_.second-minmaxUsable_.first : 0),
-    chi2_(nullptr)
-{
+SymmetryFit::SymmetryFit(const TH1* h, const std::pair<unsigned, unsigned> r)
+    : symm_candidate_(h),
+      minDF_(r.second - r.first),
+      range_(r),
+      minmaxUsable_(findUsableMinMax()),
+      ndf_(minmaxUsable_.first < minmaxUsable_.second ? minmaxUsable_.second - minmaxUsable_.first : 0),
+      chi2_(nullptr) {
   makeChi2Histogram();
   fillchi2();
 }
 
-void SymmetryFit::makeChi2Histogram() 
-{
+void SymmetryFit::makeChi2Histogram() {
   std::string XXname = name(symm_candidate_->GetName());
-  unsigned Nbins = 2*( range_.second - range_.first ) + 1;
+  unsigned Nbins = 2 * (range_.second - range_.first) + 1;
   double binwidth = symm_candidate_->GetBinWidth(1);
-  double low = symm_candidate_->GetBinCenter(range_.first) - 3*binwidth/4;
-  double up = symm_candidate_->GetBinCenter(range_.second-1) + 3*binwidth/4;
-  chi2_ = new TH1F(XXname.c_str(),"", Nbins, low, up);
+  double low = symm_candidate_->GetBinCenter(range_.first) - 3 * binwidth / 4;
+  double up = symm_candidate_->GetBinCenter(range_.second - 1) + 3 * binwidth / 4;
+  chi2_ = new TH1F(XXname.c_str(), "", Nbins, low, up);
 }
-  
-std::pair<unsigned,unsigned> SymmetryFit::findUsableMinMax() const
-{
+
+std::pair<unsigned, unsigned> SymmetryFit::findUsableMinMax() const {
   unsigned NEAR(0), FAR(0);
-  const std::vector<std::pair<unsigned,unsigned> > cont = continuousRanges();
-  for(unsigned L=0; L<cont.size(); L++) { if( cont[L].first > range_.first) continue;
-    for(unsigned R=L; R<cont.size(); R++) { if( cont[R].second < range_.second) continue;
+  const std::vector<std::pair<unsigned, unsigned> > cont = continuousRanges();
+  for (unsigned L = 0; L < cont.size(); L++) {
+    if (cont[L].first > range_.first)
+      continue;
+    for (unsigned R = L; R < cont.size(); R++) {
+      if (cont[R].second < range_.second)
+        continue;
 
-      const unsigned far = std::min( range_.first - cont[L].first,    
-				      cont[R].second - range_.second );
-      const unsigned near = std::max( range_.second<cont[L].second ? 0 : range_.second - cont[L].second,  
-				     cont[R].first<range_.first ? 0 : cont[R].first - range_.first );
+      const unsigned far = std::min(range_.first - cont[L].first, cont[R].second - range_.second);
+      const unsigned near = std::max(range_.second < cont[L].second ? 0 : range_.second - cont[L].second,
+                                     cont[R].first < range_.first ? 0 : cont[R].first - range_.first);
 
-      if ( (far>near) && (far-near)>(FAR-NEAR) ) { FAR = far; NEAR = near;}
+      if ((far > near) && (far - near) > (FAR - NEAR)) {
+        FAR = far;
+        NEAR = near;
+      }
     }
   }
-  return std::make_pair(NEAR,FAR);
+  return std::make_pair(NEAR, FAR);
 }
 
-std::vector<std::pair<unsigned,unsigned> > SymmetryFit::continuousRanges() const
-{
-  std::vector<std::pair<unsigned,unsigned> > ranges;
+std::vector<std::pair<unsigned, unsigned> > SymmetryFit::continuousRanges() const {
+  std::vector<std::pair<unsigned, unsigned> > ranges;
   const unsigned Nbins = symm_candidate_->GetNbinsX();
-  unsigned i=0;
-  while(++i<=Nbins) {
-    if(symm_candidate_->GetBinError(i)) {
-      std::pair<unsigned,unsigned> range(i,i+1);
-      while(++i<=Nbins && symm_candidate_->GetBinError(i)) range.second++;
+  unsigned i = 0;
+  while (++i <= Nbins) {
+    if (symm_candidate_->GetBinError(i)) {
+      std::pair<unsigned, unsigned> range(i, i + 1);
+      while (++i <= Nbins && symm_candidate_->GetBinError(i))
+        range.second++;
       ranges.push_back(range);
     }
   }
   return ranges;
 }
 
+void SymmetryFit::fillchi2() {
+  if (ndf_ < minDF_)
+    return;
 
-void SymmetryFit::fillchi2()
-{
-  if(ndf_<minDF_) return;
-
-  for(int i=1;  i<=chi2_->GetNbinsX() ; ++i) {
-    const unsigned L( range_.first-1+(i-1)/2 ), R( range_.first+i/2 );
-    chi2_->SetBinContent( i, chi2( std::make_pair(L,R)) );
+  for (int i = 1; i <= chi2_->GetNbinsX(); ++i) {
+    const unsigned L(range_.first - 1 + (i - 1) / 2), R(range_.first + i / 2);
+    chi2_->SetBinContent(i, chi2(std::make_pair(L, R)));
   }
 }
 
-float SymmetryFit::chi2(std::pair<unsigned,unsigned> point)
-{
+float SymmetryFit::chi2(std::pair<unsigned, unsigned> point) {
   point.first -= minmaxUsable_.first;
   point.second += minmaxUsable_.first;
-  float XX=0;
-  unsigned i=ndf_;
-  while(i-->0) {
-    XX += chi2_element(point); 
-    point.first--; 
+  float XX = 0;
+  unsigned i = ndf_;
+  while (i-- > 0) {
+    XX += chi2_element(point);
+    point.first--;
     point.second++;
   }
   return XX;
 }
 
-float SymmetryFit::chi2_element(std::pair<unsigned,unsigned> range)
-{
-  float
-    y0(symm_candidate_->GetBinContent(range.first)),
-    y1(symm_candidate_->GetBinContent(range.second)),
-    e0(symm_candidate_->GetBinError(range.first)),
-    e1(symm_candidate_->GetBinError(range.second));           assert(e0&&e1);
+float SymmetryFit::chi2_element(std::pair<unsigned, unsigned> range) {
+  float y0(symm_candidate_->GetBinContent(range.first)), y1(symm_candidate_->GetBinContent(range.second)),
+      e0(symm_candidate_->GetBinError(range.first)), e1(symm_candidate_->GetBinError(range.second));
+  assert(e0 && e1);
 
-  return pow(y0-y1, 2)/(e0*e0+e1*e1);
+  return pow(y0 - y1, 2) / (e0 * e0 + e1 * e1);
 }
 
 int SymmetryFit::fit() {
-
   std::vector<double> p = pol2_from_pol3(chi2_);
-  if( p.empty() || 
-      p[0] < chi2_->GetBinCenter(1) || 
-      p[0] > chi2_->GetBinCenter(chi2_->GetNbinsX()))
+  if (p.empty() || p[0] < chi2_->GetBinCenter(1) || p[0] > chi2_->GetBinCenter(chi2_->GetNbinsX()))
     return 7;
 
-  std::unique_ptr<TF1> f( fitfunction() );
-  f->SetParameter(0, p[0]);  f->SetParLimits(0, p[0], p[0]);
-  f->SetParameter(1, p[1]);  f->SetParLimits(1, p[1], p[1]);
-  f->SetParameter(2, p[2]);  f->SetParLimits(2, p[2], p[2]);
-  f->SetParameter(3, ndf_);  f->SetParLimits(3, ndf_,ndf_); //Fixed
-  chi2_->Fit(f.get(),"WQ");
+  std::unique_ptr<TF1> f(fitfunction());
+  f->SetParameter(0, p[0]);
+  f->SetParLimits(0, p[0], p[0]);
+  f->SetParameter(1, p[1]);
+  f->SetParLimits(1, p[1], p[1]);
+  f->SetParameter(2, p[2]);
+  f->SetParLimits(2, p[2], p[2]);
+  f->SetParameter(3, ndf_);
+  f->SetParLimits(3, ndf_, ndf_);  //Fixed
+  chi2_->Fit(f.get(), "WQ");
   return 0;
 }
 
-TF1* SymmetryFit::fitfunction() 
-{
-  TF1* f = new TF1("SymmetryFit","((x-[0])/[1])**2+[2]+0*[3]");
-  f->SetParName(0,"middle");
-  f->SetParName(1,"uncertainty");
-  f->SetParName(2,"chi2");
-  f->SetParName(3,"NDF");
+TF1* SymmetryFit::fitfunction() {
+  TF1* f = new TF1("SymmetryFit", "((x-[0])/[1])**2+[2]+0*[3]");
+  f->SetParName(0, "middle");
+  f->SetParName(1, "uncertainty");
+  f->SetParName(2, "chi2");
+  f->SetParName(3, "NDF");
   return f;
 }
-
 
 std::vector<double> SymmetryFit::pol2_from_pol2(TH1* hist) {
   std::vector<double> v;
 
   //Need our own copy for thread safety
-  TF1 func("mypol2","pol2"); 
-  int status = hist->Fit(&func,"WQ");
-  if(!status) {
+  TF1 func("mypol2", "pol2");
+  int status = hist->Fit(&func, "WQ");
+  if (!status) {
     std::vector<double> p;
     p.push_back(func.GetParameter(0));
     p.push_back(func.GetParameter(1));
     p.push_back(func.GetParameter(2));
-    if(p[2]>0) {
-      v.push_back( -0.5*p[1]/p[2] );
-      v.push_back( 1./sqrt(p[2]) );
-      v.push_back( p[0]-0.25*p[1]*p[1]/p[2] );
+    if (p[2] > 0) {
+      v.push_back(-0.5 * p[1] / p[2]);
+      v.push_back(1. / sqrt(p[2]));
+      v.push_back(p[0] - 0.25 * p[1] * p[1] / p[2]);
     }
   }
   return v;
@@ -171,20 +174,20 @@ std::vector<double> SymmetryFit::pol2_from_pol2(TH1* hist) {
 std::vector<double> SymmetryFit::pol2_from_pol3(TH1* hist) {
   std::vector<double> v;
 
-  auto func = std::make_unique<TF1>("mypol3","pol3"); 
-  int status = hist->Fit(func.get(),"WQ");
-  if(!status) {
+  auto func = std::make_unique<TF1>("mypol3", "pol3");
+  int status = hist->Fit(func.get(), "WQ");
+  if (!status) {
     std::vector<double> p;
     p.push_back(func->GetParameter(0));
     p.push_back(func->GetParameter(1));
     p.push_back(func->GetParameter(2));
     p.push_back(func->GetParameter(3));
-    double radical = p[2]*p[2] - 3*p[1]*p[3] ;
-    if(radical>0) {
-      double x0 = ( -p[2] + sqrt(radical) ) / ( 3*p[3] ) ;
-      v.push_back( x0 );
-      v.push_back( pow( radical, -0.25) );
-      v.push_back( p[0] + p[1]*x0 + p[2]*x0*x0 + p[3]*x0*x0*x0 );
+    double radical = p[2] * p[2] - 3 * p[1] * p[3];
+    if (radical > 0) {
+      double x0 = (-p[2] + sqrt(radical)) / (3 * p[3]);
+      v.push_back(x0);
+      v.push_back(pow(radical, -0.25));
+      v.push_back(p[0] + p[1] * x0 + p[2] * x0 * x0 + p[3] * x0 * x0 * x0);
     }
   }
   return v;


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/372//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


