### PR TITLE
Added dependency on py2-sqlalchemy

### DIFF
--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CondTools/RunInfo"/>
 
 <architecture name="slc.*_amd64_.*">
+  <use name="py2-sqlalchemy"/>
   <test name="RunInfoStart_O2O_test" command="RunInfoStart_O2O_test.sh"/>
 </architecture>


### PR DESCRIPTION
This PR adds py2-sqlalchemy dependency for unit tests to make sure it is run when py2-sqlalchemy is updated.