### PR TITLE
HCALDQM: Updates for Run 3 HB (10_6_X backport)

### DIFF
--- a/DQM/HcalCommon/src/DetectorQuantity.cc
+++ b/DQM/HcalCommon/src/DetectorQuantity.cc
@@ -26,7 +26,8 @@ namespace hcaldqm {
 
     uint32_t getBin_ieta(HcalDetId const &did) { return (uint32_t)(getValue_ieta(did) + 1); }
 
-    uint32_t getBin_depth(HcalDetId const &did) { return (uint32_t)(did.depth()); }
+    uint32_t getBin_depth(HcalDetId const &did) { return (uint32_t)(
+      did.subdet() == HcalOuter ? 7 : did.depth()); }
 
     uint32_t getBin_Subdet(HcalDetId const &did) { return (uint32_t)(did.subdet()); }
 

--- a/DQM/HcalCommon/src/DetectorQuantity.cc
+++ b/DQM/HcalCommon/src/DetectorQuantity.cc
@@ -26,8 +26,9 @@ namespace hcaldqm {
 
     uint32_t getBin_ieta(HcalDetId const &did) { return (uint32_t)(getValue_ieta(did) + 1); }
 
-    uint32_t getBin_depth(HcalDetId const &did) { return (uint32_t)(
-      did.subdet() == HcalOuter ? 7 : did.depth()); }
+    uint32_t getBin_depth(HcalDetId const &did) { //return (uint32_t)(did.depth());}
+      return (uint32_t)(did.subdet() == HcalOuter ? 7 : did.depth());
+    }
 
     uint32_t getBin_Subdet(HcalDetId const &did) { return (uint32_t)(did.subdet()); }
 

--- a/DQM/HcalTasks/interface/DigiComparisonTask.h
+++ b/DQM/HcalTasks/interface/DigiComparisonTask.h
@@ -16,60 +16,56 @@
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 #include "DQM/HcalCommon/interface/HashFilter.h"
 
-class DigiComparisonTask : public hcaldqm::DQTask
-{
-	public: 
-		DigiComparisonTask(edm::ParameterSet const&);
-		~DigiComparisonTask() override
-		{}
+class DigiComparisonTask : public hcaldqm::DQTask {
+public:
+  DigiComparisonTask(edm::ParameterSet const&);
+  ~DigiComparisonTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  //	funcs
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		//	Tags and corresponding Tokens
-		edm::InputTag	_tagHBHE1;
-		edm::InputTag	_tagHBHE2;
-		edm::EDGetTokenT<HBHEDigiCollection>	_tokHBHE1;
-		edm::EDGetTokenT<HBHEDigiCollection>	_tokHBHE2;
+  //	Tags and corresponding Tokens
+  edm::InputTag _tagHBHE1;
+  edm::InputTag _tagHBHE2;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE1;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE2;
 
-		//	emap+hashmap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmapuTCA;
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmapVME;
+  //	emap+hashmap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmapuTCA;
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmapVME;
 
-		//	hashes/FED vectors
-		std::vector<uint32_t> _vhashFEDs;
+  //	hashes/FED vectors
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
 
-		/**
+  /**
 		 *	Containers
 		 */
 
-		//	ADC
-		hcaldqm::Container2D			_cADC_Subdet[10];
-		hcaldqm::Container2D			_cADCall_Subdet;
+  //	ADC
+  hcaldqm::Container2D _cADC_Subdet[10];
+  hcaldqm::Container2D _cADCall_Subdet;
 
-		//	Mismatched
-		hcaldqm::Container2D			_cMsm_FEDVME;
-		hcaldqm::Container2D			_cMsm_FEDuTCA;
-		hcaldqm::Container2D			_cMsm_depth;
+  //	Mismatched
+  hcaldqm::Container2D _cMsm_FEDVME;
+  hcaldqm::Container2D _cMsm_FEDuTCA;
+  hcaldqm::Container2D _cMsm_depth;
 
-		//	Missing Completely
-		hcaldqm::Container1D			_cADCMsnuTCA_Subdet;
-		hcaldqm::Container1D			_cADCMsnVME_Subdet;
-		hcaldqm::Container2D			_cMsnVME_depth;
-		hcaldqm::Container2D			_cMsnuTCA_depth;
-		hcaldqm::Container2D			_cMsn_FEDVME;
-		hcaldqm::Container2D			_cMsn_FEDuTCA;
+  //	Missing Completely
+  hcaldqm::Container1D _cADCMsnuTCA_Subdet;
+  hcaldqm::Container1D _cADCMsnVME_Subdet;
+  hcaldqm::Container2D _cMsnVME_depth;
+  hcaldqm::Container2D _cMsnuTCA_depth;
+  hcaldqm::Container2D _cMsn_FEDVME;
+  hcaldqm::Container2D _cMsn_FEDuTCA;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/DigiPhase1Task.h
+++ b/DQM/HcalTasks/interface/DigiPhase1Task.h
@@ -26,127 +26,116 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerXXX.h"
 
-class DigiPhase1Task : public hcaldqm::DQTask
-{
-	public:
-		DigiPhase1Task(edm::ParameterSet const&);
-		~DigiPhase1Task() override {}
+class DigiPhase1Task : public hcaldqm::DQTask {
+public:
+  DigiPhase1Task(edm::ParameterSet const &);
+  ~DigiPhase1Task() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const &, edm::EventSetup const &) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		edm::InputTag		_tagHBHE;
-		edm::InputTag		_tagHO;
-		edm::InputTag		_tagHF;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHBHE;
-		edm::EDGetTokenT<HODigiCollection>	 _tokHO;
-		edm::EDGetTokenT<QIE10DigiCollection>	_tokHF;
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokHBHE;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
 
-		double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
-		double _thresh_unihf;
+  double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
+  double _thresh_unihf;
 
-		//	flag vector
-		std::vector<hcaldqm::flag::Flag> _vflags;
-		enum DigiFlag
-		{
-			fDigiSize=0,
-			fUni = 1,
-			fNChsHF = 2,
-			fUnknownIds = 3,
-			nDigiFlag = 4
-		};
+  //	flag vector
+  std::vector<hcaldqm::flag::Flag> _vflags;
+  enum DigiFlag { fDigiSize = 0, fUni = 1, fNChsHF = 2, fUnknownIds = 3, nDigiFlag = 4 };
 
-		//	hashes/FED vectors
-		std::vector<uint32_t> _vhashFEDs;
+  //	hashes/FED vectors
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap; // online only
-		hcaldqm::electronicsmap::ElectronicsMap _dhashmap;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;  // online only
+  hcaldqm::electronicsmap::ElectronicsMap _dhashmap;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_FEDHF;
-		hcaldqm::filter::HashFilter _filter_HF;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_FEDHF;
+  hcaldqm::filter::HashFilter _filter_HF;
 
-		/* hcaldqm::Containers */
-		//	ADC, fC - Charge - just filling - no summary!
-		hcaldqm::Container1D _cADC_SubdetPM;
-		hcaldqm::Container1D _cfC_SubdetPM;
-		hcaldqm::Container1D _cSumQ_SubdetPM;
-		hcaldqm::ContainerProf2D	_cSumQ_depth;
-		hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM;
-		hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM;	// online only!
+  /* hcaldqm::Containers */
+  //	ADC, fC - Charge - just filling - no summary!
+  hcaldqm::Container1D _cADC_SubdetPM;
+  hcaldqm::Container1D _cfC_SubdetPM;
+  hcaldqm::Container1D _cSumQ_SubdetPM;
+  hcaldqm::ContainerProf2D _cSumQ_depth;
+  hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM;  // online only!
 
-		//	Shape - just filling - not summary!
-		hcaldqm::Container1D _cShapeCut_FED;
+  //	Shape - just filling - not summary!
+  hcaldqm::Container1D _cShapeCut_FED;
 
-		//	Timing
-		//	just filling - no summary!
-		hcaldqm::Container1D		_cTimingCut_SubdetPM;
-		hcaldqm::ContainerProf2D _cTimingCut_FEDVME;
-		hcaldqm::ContainerProf2D	_cTimingCut_FEDuTCA;
-		hcaldqm::ContainerProf2D _cTimingCut_ElectronicsVME;
-		hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
-		hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
-		hcaldqm::ContainerProf2D _cTimingCut_depth;
-		hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM;	// online only!
-		hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;	// online only!
+  //	Timing
+  //	just filling - no summary!
+  hcaldqm::Container1D _cTimingCut_SubdetPM;
+  hcaldqm::ContainerProf2D _cTimingCut_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingCut_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingCut_ElectronicsVME;
+  hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
+  hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
+  hcaldqm::ContainerProf2D _cTimingCut_depth;
+  hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM;  // online only!
+  hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;    // online only!
 
-		//	Only for Online mode! just filling - no summary!
-		hcaldqm::ContainerProf1D _cQ2Q12CutvsLS_FEDHF;	//	online only!
+  //	Only for Online mode! just filling - no summary!
+  hcaldqm::ContainerProf1D _cQ2Q12CutvsLS_FEDHF;  //	online only!
 
-		//	Occupancy w/o a Cut - whatever is sitting in the Digi Collection
-		//	used to determine Missing Digis => used for Summary!
-		hcaldqm::Container2D _cOccupancy_FEDVME;
-		hcaldqm::Container2D _cOccupancy_FEDuTCA;
-		hcaldqm::Container2D _cOccupancy_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancy_ElectronicsuTCA;
-		hcaldqm::Container2D _cOccupancy_depth;
-		hcaldqm::Container1D _cOccupancyvsiphi_SubdetPM; // online only
-		hcaldqm::Container1D _cOccupancyvsieta_Subdet;	// online only
+  //	Occupancy w/o a Cut - whatever is sitting in the Digi Collection
+  //	used to determine Missing Digis => used for Summary!
+  hcaldqm::Container2D _cOccupancy_FEDVME;
+  hcaldqm::Container2D _cOccupancy_FEDuTCA;
+  hcaldqm::Container2D _cOccupancy_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancy_ElectronicsuTCA;
+  hcaldqm::Container2D _cOccupancy_depth;
+  hcaldqm::Container1D _cOccupancyvsiphi_SubdetPM;  // online only
+  hcaldqm::Container1D _cOccupancyvsieta_Subdet;    // online only
 
-		//	Occupancy w/ a Cut
-		//	used to determine if occupancy is symmetric or not. =>
-		//	used for Summary
-		hcaldqm::Container2D _cOccupancyCut_FEDVME;
-		hcaldqm::Container2D _cOccupancyCut_FEDuTCA;
-		hcaldqm::Container2D _cOccupancyCut_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyCut_ElectronicsuTCA;
-		hcaldqm::Container2D _cOccupancyCut_depth;
-		hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM; // online only
-		hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;	// online only
-		hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM; // online only
-		hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM; // online only
+  //	Occupancy w/ a Cut
+  //	used to determine if occupancy is symmetric or not. =>
+  //	used for Summary
+  hcaldqm::Container2D _cOccupancyCut_FEDVME;
+  hcaldqm::Container2D _cOccupancyCut_FEDuTCA;
+  hcaldqm::Container2D _cOccupancyCut_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyCut_ElectronicsuTCA;
+  hcaldqm::Container2D _cOccupancyCut_depth;
+  hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM;      // online only
+  hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;        // online only
+  hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM;      // online only
+  hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM;  // online only
 
-		//	Occupancy w/o and w/ a Cut vs BX and vs LS
-		hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
-		hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;	// online only
+  //	Occupancy w/o and w/ a Cut vs BX and vs LS
+  hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
+  hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet;  // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;  // online only
 
-		//	#Time Samples for a digi. Used for Summary generation
-		hcaldqm::Container1D _cDigiSize_FED;
-		hcaldqm::ContainerProf1D _cDigiSizevsLS_FED;	// online only
-		hcaldqm::ContainerXXX<uint32_t> _xDigiSize; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xUniHF,_xUni; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xNChs; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xNChsNominal; // online only
+  //	#Time Samples for a digi. Used for Summary generation
+  hcaldqm::Container1D _cDigiSize_FED;
+  hcaldqm::ContainerProf1D _cDigiSizevsLS_FED;     // online only
+  hcaldqm::ContainerXXX<uint32_t> _xDigiSize;      // online only
+  hcaldqm::ContainerXXX<uint32_t> _xUniHF, _xUni;  // online only
+  hcaldqm::ContainerXXX<uint32_t> _xNChs;          // online only
+  hcaldqm::ContainerXXX<uint32_t> _xNChsNominal;   // online only
 
-		//	#events counters
-		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
-		MonitorElement *meUnknownIds1LS;
-		bool _unknownIdsPresent;
+  //	#events counters
+  MonitorElement *meNumEvents1LS;  // to transfer the #events to harvesting
+  MonitorElement *meUnknownIds1LS;
+  bool _unknownIdsPresent;
 
-		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
-		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only
+  hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
 };
 
 #endif

--- a/DQM/HcalTasks/interface/DigiRunSummary.h
+++ b/DQM/HcalTasks/interface/DigiRunSummary.h
@@ -5,55 +5,50 @@
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-namespace hcaldqm
-{
-	class DigiRunSummary : public DQClient
-	{
-		public:
-			DigiRunSummary(std::string const&, std::string const&,
-				edm::ParameterSet const&);
-			~DigiRunSummary() override {}
+namespace hcaldqm {
+  class DigiRunSummary : public DQClient {
+  public:
+    DigiRunSummary(std::string const &, std::string const &, edm::ParameterSet const &);
+    ~DigiRunSummary() override {}
 
-			void beginRun(edm::Run const&, edm::EventSetup const&) override;
-			void endLuminosityBlock(DQMStore::IBooker&,
-				DQMStore::IGetter&, edm::LuminosityBlock const&,
-				edm::EventSetup const&) override;
-			std::vector<flag::Flag> endJob(
-				DQMStore::IBooker&, DQMStore::IGetter&) override;
+    void beginRun(edm::Run const &, edm::EventSetup const &) override;
+    void endLuminosityBlock(DQMStore::IBooker &,
+                            DQMStore::IGetter &,
+                            edm::LuminosityBlock const &,
+                            edm::EventSetup const &) override;
+    std::vector<flag::Flag> endJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
-		protected:
-			std::vector<LSSummary> _vflagsLS;
+  protected:
+    std::vector<LSSummary> _vflagsLS;
 
-			double _thresh_unihf;
+    double _thresh_unihf;
 
-			electronicsmap::ElectronicsMap _ehashmap;
+    electronicsmap::ElectronicsMap _ehashmap;
 
-			std::vector<uint32_t> _vhashVME, _vhashuTCA, _vhashFEDHF;
-			std::vector<int> _vFEDsVME, _vFEDsuTCA;
-			filter::HashFilter _filter_VME, _filter_uTCA, _filter_FEDHF;
+    std::vector<uint32_t> _vhashVME, _vhashuTCA, _vhashFEDHF;
+    std::vector<int> _vFEDsVME, _vFEDsuTCA;
+    filter::HashFilter _filter_VME, _filter_uTCA, _filter_FEDHF;
 
-			Container2D _cOccupancy_depth;
-			bool _booked;
-			MonitorElement *_meNumEvents; // number of events vs LS
+    Container2D _cOccupancy_depth;
+    bool _booked;
+    MonitorElement *_meNumEvents;  // number of events vs LS
 
-			ContainerXXX<uint32_t> _xDead, _xDigiSize, _xUniHF,
-				_xUni, _xNChs, _xNChsNominal;
+    ContainerXXX<uint32_t> _xDead, _xDigiSize, _xUniHF, _xUni, _xNChs, _xNChsNominal;
 
-			std::map<HcalSubdetector, uint32_t> _refDigiSize;
+    std::map<HcalSubdetector, uint32_t> _refDigiSize;
 
-			//	flag enum
-			enum DigiLSFlag
-			{
-				fDigiSize = 0,
-				fNChsHF=1,
-				fUnknownIds=2,
-				fLED=3,
-				nLSFlags=4, // defines the boundary between lumi-based and run-based flags
-				fUniHF=5,
-				fDead=6,
-				nDigiFlag = 7
-			};
-	};
-}
+    //	flag enum
+    enum DigiLSFlag {
+      fDigiSize = 0,
+      fNChsHF = 1,
+      fUnknownIds = 2,
+      fLED = 3,
+      nLSFlags = 4,  // defines the boundary between lumi-based and run-based flags
+      fUniHF = 5,
+      fDead = 6,
+      nDigiFlag = 7
+    };
+  };
+}  // namespace hcaldqm
 
 #endif

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -26,186 +26,173 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerXXX.h"
 
-class DigiTask : public hcaldqm::DQTask
-{
-	public:
-		DigiTask(edm::ParameterSet const&);
-		~DigiTask() override {}
+class DigiTask : public hcaldqm::DQTask {
+public:
+  DigiTask(edm::ParameterSet const &);
+  ~DigiTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const &, edm::EventSetup const &) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		edm::InputTag		_tagHBHE;
-		edm::InputTag		_tagHE;
-		edm::InputTag		_tagHO;
-		edm::InputTag		_tagHF;
-		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
-		edm::EDGetTokenT<HODigiCollection>	 _tokHO;
-		edm::EDGetTokenT<QIE10DigiCollection>	_tokHF;
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
 
-		double _cutSumQ_HBHE, _cutSumQ_HE, _cutSumQ_HO, _cutSumQ_HF;
-		double _thresh_unihf;
+  double _cutSumQ_HBHE, _cutSumQ_HE, _cutSumQ_HO, _cutSumQ_HF;
+  double _thresh_unihf;
 
-		//	flag vector
-		std::vector<hcaldqm::flag::Flag> _vflags;
-		enum DigiFlag
-		{
-			fDigiSize=0,
-			fUni = 1,
-			fNChsHF = 2,
-			fUnknownIds = 3,
-			fLED=4,
-			fCapId=5,
-			nDigiFlag=6
-		};
+  //	flag vector
+  std::vector<hcaldqm::flag::Flag> _vflags;
+  enum DigiFlag { fDigiSize = 0, fUni = 1, fNChsHF = 2, fUnknownIds = 3, fLED = 4, fCapId = 5, nDigiFlag = 6 };
 
-		//	hashes/FED vectors
-		std::vector<uint32_t> _vhashFEDs;
+  //	hashes/FED vectors
+  std::vector<uint32_t> _vhashFEDs;
 
-		std::map<HcalSubdetector, int> _refDigiSize;
+  std::map<HcalSubdetector, int> _refDigiSize;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap; // online only
-		hcaldqm::electronicsmap::ElectronicsMap _dhashmap;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;  // online only
+  hcaldqm::electronicsmap::ElectronicsMap _dhashmap;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_FEDHF;
-		hcaldqm::filter::HashFilter _filter_QIE1011;
-		hcaldqm::filter::HashFilter _filter_QIE8;
-		hcaldqm::filter::HashFilter _filter_HEP17;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_FEDHF;
+  hcaldqm::filter::HashFilter _filter_QIE1011;
+  hcaldqm::filter::HashFilter _filter_QIE8;
+  hcaldqm::filter::HashFilter _filter_HEP17;
 
-		/* hcaldqm::Containers */
-		//	ADC, fC - Charge - just filling - no summary!
-		hcaldqm::Container1D _cADC_SubdetPM;
-		hcaldqm::Container1D _cfC_SubdetPM;
-		hcaldqm::Container1D _cSumQ_SubdetPM;
-		hcaldqm::ContainerProf2D	_cSumQ_depth;
-		hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM;
-		hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM;	// online only!
+  /* hcaldqm::Containers */
+  //	ADC, fC - Charge - just filling - no summary!
+  hcaldqm::Container1D _cADC_SubdetPM;
+  hcaldqm::Container1D _cfC_SubdetPM;
+  hcaldqm::Container1D _cSumQ_SubdetPM;
+  hcaldqm::ContainerProf2D _cSumQ_depth;
+  hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM;  // online only!
 
-		// ADC, fC for HF (QIE10 has different ADC/fC)
-		hcaldqm::Container1D _cADC_SubdetPM_QIE1011;
-		hcaldqm::Container1D _cfC_SubdetPM_QIE1011;
-		hcaldqm::Container1D _cSumQ_SubdetPM_QIE1011;
-		hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM_QIE1011;
-		hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM_QIE1011;	// online only!
+  // ADC, fC for HF (QIE10 has different ADC/fC)
+  hcaldqm::Container1D _cADC_SubdetPM_QIE1011;
+  hcaldqm::Container1D _cfC_SubdetPM_QIE1011;
+  hcaldqm::Container1D _cSumQ_SubdetPM_QIE1011;
+  hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM_QIE1011;
+  hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM_QIE1011;  // online only!
 
-		
-		//	Shape - just filling - not summary!
-		hcaldqm::Container1D _cShapeCut_FED;
-		hcaldqm::Container2D _cADCvsTS_SubdetPM;
-		hcaldqm::Container2D _cADCvsTS_SubdetPM_QIE1011;
+  //	Shape - just filling - not summary!
+  hcaldqm::Container1D _cShapeCut_FED;
+  hcaldqm::Container2D _cADCvsTS_SubdetPM;
+  hcaldqm::Container2D _cADCvsTS_SubdetPM_QIE1011;
 
-		//	Timing
-		//	just filling - no summary!
-		hcaldqm::Container1D		_cTimingCut_SubdetPM;
-		hcaldqm::ContainerProf2D _cTimingCut_FEDVME;
-		hcaldqm::ContainerProf2D	_cTimingCut_FEDuTCA;
-		hcaldqm::ContainerProf2D _cTimingCut_ElectronicsVME;
-		hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
-		hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
-		hcaldqm::ContainerProf1D _cTimingCutvsLS_SubdetPM;
-		hcaldqm::ContainerProf2D _cTimingCut_depth;
-		hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM;	// online only!
-		hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;	// online only!
+  //	Timing
+  //	just filling - no summary!
+  hcaldqm::Container1D _cTimingCut_SubdetPM;
+  hcaldqm::ContainerProf2D _cTimingCut_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingCut_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingCut_ElectronicsVME;
+  hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
+  hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
+  hcaldqm::ContainerProf1D _cTimingCutvsLS_SubdetPM;
+  hcaldqm::ContainerProf2D _cTimingCut_depth;
+  hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM;  // online only!
+  hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;    // online only!
 
-		//	Only for Online mode! just filling - no summary!
-		hcaldqm::ContainerProf1D _cQ2Q12CutvsLS_FEDHF;	//	online only!
+  //	Only for Online mode! just filling - no summary!
+  hcaldqm::ContainerProf1D _cQ2Q12CutvsLS_FEDHF;  //	online only!
 
-		//	Occupancy w/o a Cut - whatever is sitting in the Digi Collection
-		//	used to determine Missing Digis => used for Summary!
-		hcaldqm::Container2D _cOccupancy_FEDVME;
-		hcaldqm::Container2D _cOccupancy_FEDuTCA;
-		hcaldqm::Container2D _cOccupancy_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancy_ElectronicsuTCA;
-		hcaldqm::Container2D _cOccupancy_Crate;
-		hcaldqm::Container2D _cOccupancy_CrateSlot;
-		hcaldqm::Container2D _cOccupancy_depth;
-		hcaldqm::Container1D _cOccupancyvsiphi_SubdetPM; // online only
-		hcaldqm::Container1D _cOccupancyvsieta_Subdet;	// online only
+  //	Occupancy w/o a Cut - whatever is sitting in the Digi Collection
+  //	used to determine Missing Digis => used for Summary!
+  hcaldqm::Container2D _cOccupancy_FEDVME;
+  hcaldqm::Container2D _cOccupancy_FEDuTCA;
+  hcaldqm::Container2D _cOccupancy_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancy_ElectronicsuTCA;
+  hcaldqm::Container2D _cOccupancy_Crate;
+  hcaldqm::Container2D _cOccupancy_CrateSlot;
+  hcaldqm::Container2D _cOccupancy_depth;
+  hcaldqm::Container1D _cOccupancyvsiphi_SubdetPM;  // online only
+  hcaldqm::Container1D _cOccupancyvsieta_Subdet;    // online only
 
-		//	Occupancy w/ a Cut
-		//	used to determine if occupancy is symmetric or not. =>
-		//	used for Summary
-		hcaldqm::Container2D _cOccupancyCut_FEDVME;
-		hcaldqm::Container2D _cOccupancyCut_FEDuTCA;
-		hcaldqm::Container2D _cOccupancyCut_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyCut_ElectronicsuTCA;
-		hcaldqm::Container2D _cOccupancyCut_depth;
-		hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM; // online only
-		hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;	// online only
-		//hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM; // online only
-		hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM; // online only
+  //	Occupancy w/ a Cut
+  //	used to determine if occupancy is symmetric or not. =>
+  //	used for Summary
+  hcaldqm::Container2D _cOccupancyCut_FEDVME;
+  hcaldqm::Container2D _cOccupancyCut_FEDuTCA;
+  hcaldqm::Container2D _cOccupancyCut_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyCut_ElectronicsuTCA;
+  hcaldqm::Container2D _cOccupancyCut_depth;
+  hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM;  // online only
+  hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;    // online only
+  //hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM; // online only
+  hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM;  // online only
 
-		//	Occupancy w/o and w/ a Cut vs BX and vs LS
-		hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
-		hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;	// online only
+  //	Occupancy w/o and w/ a Cut vs BX and vs LS
+  hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
+  hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet;  // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;  // online only
 
-		//	#Time Samples for a digi. Used for Summary generation
-		hcaldqm::Container1D _cDigiSize_Crate;
-		hcaldqm::Container1D _cDigiSize_FED;
-		hcaldqm::ContainerProf1D _cDigiSizevsLS_FED;	// online only
-		hcaldqm::ContainerXXX<uint32_t> _xDigiSize; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xUniHF,_xUni; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xNChs; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xNChsNominal; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xBadCapid; // online only
+  //	#Time Samples for a digi. Used for Summary generation
+  hcaldqm::Container1D _cDigiSize_Crate;
+  hcaldqm::Container1D _cDigiSize_FED;
+  hcaldqm::ContainerProf1D _cDigiSizevsLS_FED;     // online only
+  hcaldqm::ContainerXXX<uint32_t> _xDigiSize;      // online only
+  hcaldqm::ContainerXXX<uint32_t> _xUniHF, _xUni;  // online only
+  hcaldqm::ContainerXXX<uint32_t> _xNChs;          // online only
+  hcaldqm::ContainerXXX<uint32_t> _xNChsNominal;   // online only
+  hcaldqm::ContainerXXX<uint32_t> _xBadCapid;      // online only
 
-		// QIE10 TDC histograms
-		hcaldqm::Container2D _cLETDCTimevsADC_SubdetPM;
-		hcaldqm::Container2D _cLETDCvsADC_SubdetPM;
-		hcaldqm::Container2D _cLETDCvsTS_SubdetPM;
-		hcaldqm::Container1D _cLETDCTime_SubdetPM;
-		hcaldqm::ContainerProf2D _cLETDCTime_depth;
+  // QIE10 TDC histograms
+  hcaldqm::Container2D _cLETDCTimevsADC_SubdetPM;
+  hcaldqm::Container2D _cLETDCvsADC_SubdetPM;
+  hcaldqm::Container2D _cLETDCvsTS_SubdetPM;
+  hcaldqm::Container1D _cLETDCTime_SubdetPM;
+  hcaldqm::ContainerProf2D _cLETDCTime_depth;
 
-		// Bad TDC histograms
-		hcaldqm::Container1D _cBadTDCValues_SubdetPM;
-		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM;
-		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM;
-		hcaldqm::Container2D _cBadTDCCount_depth;
+  // Bad TDC histograms
+  hcaldqm::Container1D _cBadTDCValues_SubdetPM;
+  hcaldqm::Container1D _cBadTDCvsBX_SubdetPM;
+  hcaldqm::Container1D _cBadTDCvsLS_SubdetPM;
+  hcaldqm::Container2D _cBadTDCCount_depth;
 
-		hcaldqm::Container1D _cBadTDCValues;
-		hcaldqm::Container1D _cBadTDCvsBX;
-		hcaldqm::Container1D _cBadTDCvsLS;
+  hcaldqm::Container1D _cBadTDCValues;
+  hcaldqm::Container1D _cBadTDCvsBX;
+  hcaldqm::Container1D _cBadTDCvsLS;
 
-		// (Capid - BX) % 4		
-		hcaldqm::Container1D _cCapidMinusBXmod4_SubdetPM;
-		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4]; // CrateSlot 2D histograms for each (capid-BX)%4
-		hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotVME[4]; // CrateSlot 2D histograms for each (capid-BX)%4
-		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
-		hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLSmod60; // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
+  // (Capid - BX) % 4
+  hcaldqm::Container1D _cCapidMinusBXmod4_SubdetPM;
+  hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4];  // CrateSlot 2D histograms for each (capid-BX)%4
+  hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotVME[4];   // CrateSlot 2D histograms for each (capid-BX)%4
+  hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
+  hcaldqm::ContainerSingle2D
+      _cCapid_BadvsFEDvsLSmod60;  // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
 
-		//	#events counters
-		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
-		MonitorElement *meUnknownIds1LS;
-		bool _unknownIdsPresent;
+  //	#events counters
+  MonitorElement *meNumEvents1LS;  // to transfer the #events to harvesting
+  MonitorElement *meUnknownIds1LS;
+  bool _unknownIdsPresent;
 
-		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
-		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only
+  hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
 
-		bool _qie10InConditions; // Flag to protect against QIE10 digis not in conditions in 2016.
+  bool _qie10InConditions;  // Flag to protect against QIE10 digis not in conditions in 2016.
 
-		std::map<HcalSubdetector, short> _capidmbx; // Expected (capid - BX) % 4 for each subdet
+  std::map<HcalSubdetector, short> _capidmbx;  // Expected (capid - BX) % 4 for each subdet
 
-		// LED monitoring stuff
-		double _thresh_led;
-		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
+  // LED monitoring stuff
+  double _thresh_led;
+  std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
 
-		hcaldqm::Container1D _LED_CUCountvsLS_Subdet; // Misfire count vs LS
-		hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet; // Misfire count vs LS
-		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX	
+  hcaldqm::Container1D _LED_CUCountvsLS_Subdet;       // Misfire count vs LS
+  hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet;  // Misfire count vs LS
+  hcaldqm::Container2D _LED_ADCvsBX_Subdet;           // Pin diode amplitude vs BX
 };
 
 #endif

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -39,16 +39,14 @@ protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;
   void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
+  edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::InputTag _tagQIE10;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
 
-  double _cutSumQ_HBHE, _cutSumQ_HE, _cutSumQ_HO, _cutSumQ_HF;
+  double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
   double _thresh_unihf;
 
   //	flag vector
@@ -70,7 +68,6 @@ protected:
   hcaldqm::filter::HashFilter _filter_FEDHF;
   hcaldqm::filter::HashFilter _filter_QIE1011;
   hcaldqm::filter::HashFilter _filter_QIE8;
-  hcaldqm::filter::HashFilter _filter_HEP17;
 
   /* hcaldqm::Containers */
   //	ADC, fC - Charge - just filling - no summary!

--- a/DQM/HcalTasks/interface/FCDTask.h
+++ b/DQM/HcalTasks/interface/FCDTask.h
@@ -10,45 +10,38 @@
 
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class FCDTask : public DQMEDAnalyzer
-{
-	public:
-	struct FCDChannel {
-		int crate;
-		int slot;
-		int fiber;
-		int fiberChannel;
-	};
+class FCDTask : public DQMEDAnalyzer {
+public:
+  struct FCDChannel {
+    int crate;
+    int slot;
+    int fiber;
+    int fiberChannel;
+  };
 
-	public:
-		FCDTask(edm::ParameterSet const&);
-		~FCDTask() override{}
+public:
+  FCDTask(edm::ParameterSet const&);
+  ~FCDTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-		edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
-	protected:
-		void analyze(edm::Event const&, edm::EventSetup const&) override;
+protected:
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
-		//	tags
-		edm::InputTag	_tagQIE10;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
+  //	tags
+  edm::InputTag _tagQIE10;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
 
-		//	hcaldqm::Containers
-		std::map<HcalElectronicsId, MonitorElement*>   _cADC;
-		std::map<HcalElectronicsId, MonitorElement*>   _cADC_vs_TS;
-		std::map<HcalElectronicsId, MonitorElement*>   _cTDC;
-		std::map<HcalElectronicsId, MonitorElement*>   _cTDCTime;
+  //	hcaldqm::Containers
+  std::map<HcalElectronicsId, MonitorElement*> _cADC;
+  std::map<HcalElectronicsId, MonitorElement*> _cADC_vs_TS;
+  std::map<HcalElectronicsId, MonitorElement*> _cTDC;
+  std::map<HcalElectronicsId, MonitorElement*> _cTDCTime;
 
-		std::vector<HcalElectronicsId> _fcd_eids;
-		std::vector<FCDChannel> _channels;
-		HcalElectronicsMap const* _emap;
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-
-
+  std::vector<HcalElectronicsId> _fcd_eids;
+  std::vector<FCDChannel> _channels;
+  HcalElectronicsMap const* _emap;
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 };
 
 #endif
-
-
-

--- a/DQM/HcalTasks/interface/HFRaddamTask.h
+++ b/DQM/HcalTasks/interface/HFRaddamTask.h
@@ -15,43 +15,33 @@
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerSingle1D.h"
 
-class HFRaddamTask : public hcaldqm::DQTask
-{
-	public:
-		HFRaddamTask(edm::ParameterSet const&);
-		~HFRaddamTask() override
-		{}
+class HFRaddamTask : public hcaldqm::DQTask {
+public:
+  HFRaddamTask(edm::ParameterSet const&);
+  ~HFRaddamTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		bool _isApplicable(edm::Event const&) override;
+protected:
+  //	funcs
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  bool _isApplicable(edm::Event const&) override;
 
-		//	Tags and Tokens
-		edm::InputTag	_tagHF;
-		edm::InputTag   _taguMN;
-		edm::EDGetTokenT<HFDigiCollection>	_tokHF;
-		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
+  //	Tags and Tokens
+  edm::InputTag _tagHF;
+  edm::InputTag _taguMN;
+  edm::EDGetTokenT<HFDigiCollection> _tokHF;
+  edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
-		//	vector of Detector Ids for RadDam
-		std::vector<HcalDetId>	_vDetIds;
+  //	vector of Detector Ids for RadDam
+  std::vector<HcalDetId> _vDetIds;
 
-		//	Cuts
+  //	Cuts
 
-		//	Compact
+  //	Compact
 
-		//	1D
-		std::vector<hcaldqm::ContainerSingle1D> _vcShape;
+  //	1D
+  std::vector<hcaldqm::ContainerSingle1D> _vcShape;
 };
 
 #endif
-
-
-
-
-
-
-

--- a/DQM/HcalTasks/interface/HcalOfflineHarvesting.h
+++ b/DQM/HcalTasks/interface/HcalOfflineHarvesting.h
@@ -36,42 +36,33 @@
 #include "DQM/HcalTasks/interface/RecoRunSummary.h"
 #include "DQM/HcalTasks/interface/TPRunSummary.h"
 
-class HcalOfflineHarvesting : public hcaldqm::DQHarvester
-{
-	public:
-		HcalOfflineHarvesting(edm::ParameterSet const&);
-		~HcalOfflineHarvesting() override{}
+class HcalOfflineHarvesting : public hcaldqm::DQHarvester {
+public:
+  HcalOfflineHarvesting(edm::ParameterSet const &);
+  ~HcalOfflineHarvesting() override {}
 
-		void beginRun(edm::Run const&,
-			edm::EventSetup const&) override;
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
 
-	protected:
-		void _dqmEndLuminosityBlock(DQMStore::IBooker&,
-			DQMStore::IGetter&, edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void _dqmEndJob(DQMStore::IBooker&,
-			DQMStore::IGetter&) override;
+protected:
+  void _dqmEndLuminosityBlock(DQMStore::IBooker &,
+                              DQMStore::IGetter &,
+                              edm::LuminosityBlock const &,
+                              edm::EventSetup const &) override;
+  void _dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
-		enum Summary
-		{
-			fRaw=0,
-			fDigi=1,
-			fReco=2,
-			fTP=3,
-			nSummary=4
-		};
+  enum Summary { fRaw = 0, fDigi = 1, fReco = 2, fTP = 3, nSummary = 4 };
 
-		std::vector<Summary> _summaryList;
+  std::vector<Summary> _summaryList;
 
-		//	vector of Summary Generators and marks of being present
-		//	by default all false
-		std::map<Summary, hcaldqm::DQClient*> _sumgen;
-		std::map<Summary, bool> _summarks;
-		std::map<Summary, std::string> _sumnames;
-		
-		//	reportSummaryMap
-		MonitorElement *_reportSummaryMap;
-		MonitorElement *me;
+  //	vector of Summary Generators and marks of being present
+  //	by default all false
+  std::map<Summary, hcaldqm::DQClient *> _sumgen;
+  std::map<Summary, bool> _summarks;
+  std::map<Summary, std::string> _sumnames;
+
+  //	reportSummaryMap
+  MonitorElement *_reportSummaryMap;
+  MonitorElement *me;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/HcalOnlineHarvesting.h
+++ b/DQM/HcalTasks/interface/HcalOnlineHarvesting.h
@@ -44,55 +44,45 @@
 #include "DQM/HcalTasks/interface/TPRunSummary.h"
 #include "DQM/HcalTasks/interface/PedestalRunSummary.h"
 
-class HcalOnlineHarvesting : public hcaldqm::DQHarvester
-{
-	public:
-		HcalOnlineHarvesting(edm::ParameterSet const&);
-		~HcalOnlineHarvesting() override{}
-		void beginRun(edm::Run const&, edm::EventSetup const&) override;
+class HcalOnlineHarvesting : public hcaldqm::DQHarvester {
+public:
+  HcalOnlineHarvesting(edm::ParameterSet const &);
+  ~HcalOnlineHarvesting() override {}
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
 
-	protected:
-		void _dqmEndLuminosityBlock(DQMStore::IBooker&,
-			DQMStore::IGetter&, edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void _dqmEndJob(DQMStore::IBooker&,
-			DQMStore::IGetter&) override;
+protected:
+  void _dqmEndLuminosityBlock(DQMStore::IBooker &,
+                              DQMStore::IGetter &,
+                              edm::LuminosityBlock const &,
+                              edm::EventSetup const &) override;
+  void _dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
-		enum Summary
-		{
-			fRaw=0,
-			fDigi=1,
-			fReco=2,
-			fTP=3,
-			fPedestal=4,
-			nSummary=5
-		};
+  enum Summary { fRaw = 0, fDigi = 1, fReco = 2, fTP = 3, fPedestal = 4, nSummary = 5 };
 
-		//	flags to harvest...
-		std::vector<bool> _vmarks;
-		std::vector<hcaldqm::DQClient*> _vsumgen;
-		std::vector<std::string> _vnames;
+  //	flags to harvest...
+  std::vector<bool> _vmarks;
+  std::vector<hcaldqm::DQClient *> _vsumgen;
+  std::vector<std::string> _vnames;
 
-		//	thresholds
-		double _thresh_bad_bad;
+  //	thresholds
+  double _thresh_bad_bad;
 
-		//	counters
-		int _nBad;
-		int _nTotal;
+  //	counters
+  int _nBad;
+  int _nTotal;
 
-		//	summaries
-		std::vector<hcaldqm::ContainerSingle2D> _vcSummaryvsLS;
+  //	summaries
+  std::vector<hcaldqm::ContainerSingle2D> _vcSummaryvsLS;
 
-		hcaldqm::Container2D _cKnownBadChannels_depth;
+  hcaldqm::Container2D _cKnownBadChannels_depth;
 
-		//	reportSummaryMap
-		MonitorElement *_reportSummaryMap;
-		MonitorElement *_runSummary;
+  //	reportSummaryMap
+  MonitorElement *_reportSummaryMap;
+  MonitorElement *_runSummary;
 
-		// Efficiencies
-		hcaldqm::ContainerSingle2D _cTDCCutEfficiency_depth;
-		hcaldqm::ContainerSingle1D _cTDCCutEfficiency_ieta;
-
+  // Efficiencies
+  hcaldqm::ContainerSingle2D _cTDCCutEfficiency_depth;
+  hcaldqm::ContainerSingle1D _cTDCCutEfficiency_ieta;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -19,111 +19,99 @@
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "FWCore/Framework/interface/Run.h"
 
-class LEDTask : public hcaldqm::DQTask
-{
-	public:
-		LEDTask(edm::ParameterSet const&);
-		~LEDTask() override
-		{}
+class LEDTask : public hcaldqm::DQTask {
+public:
+  LEDTask(edm::ParameterSet const&);
+  ~LEDTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endRun(edm::Run const& r, edm::EventSetup const&) override
-		{
-			if (_ptype==hcaldqm::fLocal)
-				if (r.runAuxiliary().run()==1)
-					return;
-			this->_dump();
-		}
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const& r, edm::EventSetup const&) override {
+    if (_ptype == hcaldqm::fLocal)
+      if (r.runAuxiliary().run() == 1)
+        return;
+    this->_dump();
+  }
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
-		bool _isApplicable(edm::Event const&) override;
-		virtual void _dump();
+protected:
+  //	funcs
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
+  bool _isApplicable(edm::Event const&) override;
+  virtual void _dump();
 
-		//	tags and tokens
-		edm::InputTag	_tagHBHE;
-		edm::InputTag	_tagHE;
-		edm::InputTag	_tagHO;
-		edm::InputTag	_tagHF;
-		edm::InputTag	_tagTrigger;
-		edm::InputTag	_taguMN;
-		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
-		edm::EDGetTokenT<HODigiCollection> _tokHO;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
-		edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
-		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
+  //	tags and tokens
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::InputTag _tagTrigger;
+  edm::InputTag _taguMN;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
+  edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_VME;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_VME;
 
-		//	Cuts
-		int _nevents;
-		double _lowHBHE;
-		double _lowHE;
-		double _lowHO;
-		double _lowHF;
+  //	Cuts
+  int _nevents;
+  double _lowHBHE;
+  double _lowHE;
+  double _lowHO;
+  double _lowHF;
 
-		//	Compact
-		hcaldqm::ContainerXXX<double> _xSignalSum;
-		hcaldqm::ContainerXXX<double> _xSignalSum2;
-		hcaldqm::ContainerXXX<int> _xEntries;
-		hcaldqm::ContainerXXX<double> _xTimingSum;
-		hcaldqm::ContainerXXX<double> _xTimingSum2;
+  //	Compact
+  hcaldqm::ContainerXXX<double> _xSignalSum;
+  hcaldqm::ContainerXXX<double> _xSignalSum2;
+  hcaldqm::ContainerXXX<int> _xEntries;
+  hcaldqm::ContainerXXX<double> _xTimingSum;
+  hcaldqm::ContainerXXX<double> _xTimingSum2;
 
-		//	1D
-		hcaldqm::Container1D		_cSignalMean_Subdet;
-		hcaldqm::Container1D		_cSignalRMS_Subdet;
-		hcaldqm::Container1D		_cTimingMean_Subdet;
-		hcaldqm::Container1D		_cTimingRMS_Subdet;
+  //	1D
+  hcaldqm::Container1D _cSignalMean_Subdet;
+  hcaldqm::Container1D _cSignalRMS_Subdet;
+  hcaldqm::Container1D _cTimingMean_Subdet;
+  hcaldqm::Container1D _cTimingRMS_Subdet;
 
-		//	Prof1D
-		hcaldqm::ContainerProf1D	_cShapeCut_FEDSlot;
+  //	Prof1D
+  hcaldqm::ContainerProf1D _cShapeCut_FEDSlot;
 
-		//	2D timing/signals
-		hcaldqm::ContainerProf2D		_cSignalMean_depth;
-		hcaldqm::ContainerProf2D		_cSignalRMS_depth;
-		hcaldqm::ContainerProf2D		_cTimingMean_depth;
-		hcaldqm::ContainerProf2D		_cTimingRMS_depth;
+  //	2D timing/signals
+  hcaldqm::ContainerProf2D _cSignalMean_depth;
+  hcaldqm::ContainerProf2D _cSignalRMS_depth;
+  hcaldqm::ContainerProf2D _cTimingMean_depth;
+  hcaldqm::ContainerProf2D _cTimingRMS_depth;
 
-		hcaldqm::ContainerProf2D		_cSignalMean_FEDVME;
-		hcaldqm::ContainerProf2D		_cSignalMean_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cTimingMean_FEDVME;
-		hcaldqm::ContainerProf2D		_cTimingMean_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cSignalRMS_FEDVME;
-		hcaldqm::ContainerProf2D		_cSignalRMS_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cTimingRMS_FEDVME;
-		hcaldqm::ContainerProf2D		_cTimingRMS_FEDuTCA;
+  hcaldqm::ContainerProf2D _cSignalMean_FEDVME;
+  hcaldqm::ContainerProf2D _cSignalMean_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingMean_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingMean_FEDuTCA;
+  hcaldqm::ContainerProf2D _cSignalRMS_FEDVME;
+  hcaldqm::ContainerProf2D _cSignalRMS_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingRMS_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingRMS_FEDuTCA;
 
-		//	Bad Quality and Missing Channels
-		hcaldqm::Container2D		_cMissing_depth;
-		hcaldqm::Container2D		_cMissing_FEDVME;
-		hcaldqm::Container2D		_cMissing_FEDuTCA;
+  //	Bad Quality and Missing Channels
+  hcaldqm::Container2D _cMissing_depth;
+  hcaldqm::Container2D _cMissing_FEDVME;
+  hcaldqm::Container2D _cMissing_FEDuTCA;
 
-		// For hcalcalib online LED
-		hcaldqm::Container2D _cADCvsTS_SubdetPM;
-		hcaldqm::Container1D _cSumQ_SubdetPM;
-		hcaldqm::Container1D _cTDCTime_SubdetPM;
-		hcaldqm::ContainerProf2D _cTDCTime_depth;
-		hcaldqm::ContainerSingle2D _cLowSignal_CrateSlot;
+  // For hcalcalib online LED
+  hcaldqm::Container2D _cADCvsTS_SubdetPM;
+  hcaldqm::Container1D _cSumQ_SubdetPM;
+  hcaldqm::Container1D _cTDCTime_SubdetPM;
+  hcaldqm::ContainerProf2D _cTDCTime_depth;
+  hcaldqm::ContainerSingle2D _cLowSignal_CrateSlot;
 
-		// For monitoring LED firing: ADC vs BX
-		std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
-		hcaldqm::Container2D _LED_ADCvsBX_Subdet; // Pin diode amplitude vs BX for online DQM
-		hcaldqm::Container2D _LED_ADCvsEvn_Subdet; // Pin diode amplitude vs Evn for local DQM
-		
+  // For monitoring LED firing: ADC vs BX
+  std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
+  hcaldqm::Container2D _LED_ADCvsBX_Subdet;   // Pin diode amplitude vs BX for online DQM
+  hcaldqm::Container2D _LED_ADCvsEvn_Subdet;  // Pin diode amplitude vs Evn for local DQM
 };
 
 #endif
-
-
-
-
-
-
-

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -40,16 +40,14 @@ protected:
   virtual void _dump();
 
   //	tags and tokens
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
-  edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
-  edm::InputTag _tagTrigger;
-  edm::InputTag _taguMN;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::InputTag	_tagQIE11;
+  edm::InputTag	_tagHO;
+  edm::InputTag	_tagQIE10;
+  edm::InputTag	_tagTrigger;
+  edm::InputTag	_taguMN;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
@@ -61,7 +59,6 @@ protected:
   //	Cuts
   int _nevents;
   double _lowHBHE;
-  double _lowHE;
   double _lowHO;
   double _lowHF;
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -21,154 +21,141 @@
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "FWCore/Framework/interface/Run.h"
 
-class LaserTask : public hcaldqm::DQTask
-{
-	public:
-		LaserTask(edm::ParameterSet const&);
-		~LaserTask() override
-		{}
+class LaserTask : public hcaldqm::DQTask {
+public:
+  LaserTask(edm::ParameterSet const &);
+  ~LaserTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endRun(edm::Run const& r, edm::EventSetup const&) override
-		{
-			if (_ptype==hcaldqm::fLocal)
-			{
-				if (r.runAuxiliary().run()==1)
-					return;
-				else 
-					this->_dump();
-			}
-		}
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void endRun(edm::Run const &r, edm::EventSetup const &) override {
+    if (_ptype == hcaldqm::fLocal) {
+      if (r.runAuxiliary().run() == 1)
+        return;
+      else
+        this->_dump();
+    }
+  }
+  void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
-		bool _isApplicable(edm::Event const&) override;
-		virtual void _dump();
-		void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
+protected:
+  //	funcs
+  void _process(edm::Event const &, edm::EventSetup const &) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
+  bool _isApplicable(edm::Event const &) override;
+  virtual void _dump();
+  void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
 
+  //	tags and tokens
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::InputTag _taguMN;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
-		//	tags and tokens
-		edm::InputTag	_tagHBHE;
-		edm::InputTag	_tagHE;
-		edm::InputTag	_tagHO;
-		edm::InputTag	_tagHF;
-		edm::InputTag	_taguMN;
-		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
-		edm::EDGetTokenT<HODigiCollection> _tokHO;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
-		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
+  enum LaserFlag { fBadTiming = 0, fMissingLaserMon = 1, nLaserFlag = 2 };
+  std::vector<hcaldqm::flag::Flag> _vflags;
 
-		enum LaserFlag
-		{
-			fBadTiming = 0,
-			fMissingLaserMon = 1,
-			nLaserFlag = 2
-		};
-		std::vector<hcaldqm::flag::Flag> _vflags;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_VME;
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_VME;
-		std::vector<uint32_t> _vhashFEDs;
+  //	Cuts and variables
+  int _nevents;
+  double _lowHBHE;
+  double _lowHE;
+  double _lowHO;
+  double _lowHF;
+  uint32_t _laserType;
 
-		//	Cuts and variables
-		int _nevents;
-		double _lowHBHE;
-		double _lowHE;
-		double _lowHO;
-		double _lowHF;
-		uint32_t _laserType;
+  //	Compact
+  hcaldqm::ContainerXXX<double> _xSignalSum;
+  hcaldqm::ContainerXXX<double> _xSignalSum2;
+  hcaldqm::ContainerXXX<int> _xEntries;
+  hcaldqm::ContainerXXX<double> _xTimingSum;
+  hcaldqm::ContainerXXX<double> _xTimingSum2;
+  hcaldqm::ContainerXXX<double> _xTimingRefLMSum;  // For computation of channel-by-channel mean timing w.r.t. lasermon
+  hcaldqm::ContainerXXX<double> _xTimingRefLMSum2;
+  hcaldqm::ContainerXXX<int> _xNBadTimingRefLM;  // Count channels with bad timing
+  hcaldqm::ContainerXXX<int> _xNChs;             // number of channels per FED as in emap
 
-		//	Compact
-		hcaldqm::ContainerXXX<double> _xSignalSum;
-		hcaldqm::ContainerXXX<double> _xSignalSum2;
-		hcaldqm::ContainerXXX<int> _xEntries;
-		hcaldqm::ContainerXXX<double> _xTimingSum;
-		hcaldqm::ContainerXXX<double> _xTimingSum2;
-		hcaldqm::ContainerXXX<double> _xTimingRefLMSum; // For computation of channel-by-channel mean timing w.r.t. lasermon
-		hcaldqm::ContainerXXX<double> _xTimingRefLMSum2;
-		hcaldqm::ContainerXXX<int> _xNBadTimingRefLM; // Count channels with bad timing
-		hcaldqm::ContainerXXX<int> _xNChs; // number of channels per FED as in emap
+  //	1D
+  hcaldqm::Container1D _cSignalMean_Subdet;
+  hcaldqm::Container1D _cSignalRMS_Subdet;
+  hcaldqm::Container1D _cSignalMeanQIE1011_Subdet;
+  hcaldqm::Container1D _cSignalRMSQIE1011_Subdet;
+  hcaldqm::Container1D _cTimingMean_Subdet;
+  hcaldqm::Container1D _cTimingRMS_Subdet;
 
+  hcaldqm::Container1D _cADC_SubdetPM;
 
-		//	1D
-		hcaldqm::Container1D		_cSignalMean_Subdet;
-		hcaldqm::Container1D		_cSignalRMS_Subdet;
-		hcaldqm::Container1D		_cSignalMeanQIE1011_Subdet;
-		hcaldqm::Container1D		_cSignalRMSQIE1011_Subdet;
-		hcaldqm::Container1D		_cTimingMean_Subdet;
-		hcaldqm::Container1D		_cTimingRMS_Subdet;
+  //	Prof1D
+  hcaldqm::ContainerProf1D _cShapeCut_FEDSlot;
+  hcaldqm::ContainerProf1D _cTimingvsEvent_SubdetPM;
+  hcaldqm::ContainerProf1D _cSignalvsEvent_SubdetPM;
+  hcaldqm::ContainerProf1D _cTimingvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cSignalvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cSignalvsLSQIE1011_SubdetPM;
+  hcaldqm::ContainerProf1D _cTimingvsBX_SubdetPM;
+  hcaldqm::ContainerProf1D _cSignalvsBX_SubdetPM;
+  hcaldqm::ContainerProf1D _cSignalvsBXQIE1011_SubdetPM;
 
-		hcaldqm::Container1D _cADC_SubdetPM;
+  //	2D timing/signals
+  hcaldqm::ContainerProf2D _cSignalMean_depth;
+  hcaldqm::ContainerProf2D _cSignalRMS_depth;
+  hcaldqm::ContainerProf2D _cSignalMeanQIE1011_depth;
+  hcaldqm::ContainerProf2D _cSignalRMSQIE1011_depth;
+  hcaldqm::ContainerProf2D _cTimingMean_depth;
+  hcaldqm::ContainerProf2D _cTimingRMS_depth;
 
-		//	Prof1D
-		hcaldqm::ContainerProf1D	_cShapeCut_FEDSlot;
-		hcaldqm::ContainerProf1D _cTimingvsEvent_SubdetPM;
-		hcaldqm::ContainerProf1D _cSignalvsEvent_SubdetPM;
-		hcaldqm::ContainerProf1D _cTimingvsLS_SubdetPM;
-		hcaldqm::ContainerProf1D _cSignalvsLS_SubdetPM;
-		hcaldqm::ContainerProf1D _cSignalvsLSQIE1011_SubdetPM;
-		hcaldqm::ContainerProf1D _cTimingvsBX_SubdetPM;
-		hcaldqm::ContainerProf1D _cSignalvsBX_SubdetPM;
-		hcaldqm::ContainerProf1D _cSignalvsBXQIE1011_SubdetPM;
+  hcaldqm::ContainerProf2D _cSignalMean_FEDVME;
+  hcaldqm::ContainerProf2D _cSignalMean_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingMean_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingMean_FEDuTCA;
+  hcaldqm::ContainerProf2D _cSignalRMS_FEDVME;
+  hcaldqm::ContainerProf2D _cSignalRMS_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingRMS_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingRMS_FEDuTCA;
 
-		//	2D timing/signals
-		hcaldqm::ContainerProf2D		_cSignalMean_depth;
-		hcaldqm::ContainerProf2D		_cSignalRMS_depth;
-		hcaldqm::ContainerProf2D		_cSignalMeanQIE1011_depth;
-		hcaldqm::ContainerProf2D		_cSignalRMSQIE1011_depth;
-		hcaldqm::ContainerProf2D		_cTimingMean_depth;
-		hcaldqm::ContainerProf2D		_cTimingRMS_depth;
+  //	Bad Quality and Missing Channels
+  hcaldqm::Container2D _cMissing_depth;
+  hcaldqm::Container2D _cMissing_FEDVME;
+  hcaldqm::Container2D _cMissing_FEDuTCA;
 
-		hcaldqm::ContainerProf2D		_cSignalMean_FEDVME;
-		hcaldqm::ContainerProf2D		_cSignalMean_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cTimingMean_FEDVME;
-		hcaldqm::ContainerProf2D		_cTimingMean_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cSignalRMS_FEDVME;
-		hcaldqm::ContainerProf2D		_cSignalRMS_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cTimingRMS_FEDVME;
-		hcaldqm::ContainerProf2D		_cTimingRMS_FEDuTCA;
+  // Things for LASERMON
+  edm::InputTag _tagLaserMon;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokLaserMon;
 
-		//	Bad Quality and Missing Channels
-		hcaldqm::Container2D		_cMissing_depth;
-		hcaldqm::Container2D		_cMissing_FEDVME;
-		hcaldqm::Container2D		_cMissing_FEDuTCA;
+  std::vector<int> _vLaserMonIPhi;  // Laser mon digis are assigned to CBox=5, IEta=0, IPhi=[23-index] by the emap
+  int _laserMonIEta;
+  int _laserMonCBox;
+  int _laserMonDigiOverlap;
+  int _laserMonTS0;
+  double _laserMonThreshold;
+  std::map<HcalSubdetector, std::pair<double, double>> _thresh_timingreflm;  // Min and max timing (ref. lasermon)
+  double _thresh_frac_timingreflm;  // Flag threshold (BAD) on fraction of channels with bad timing
+  double _thresh_min_lmsumq;        // Threshold on minimum SumQ from lasermon, if laser is expected
+  int _xMissingLaserMon;            // Counter for missing lasermon events
 
-		// Things for LASERMON
-		edm::InputTag _tagLaserMon;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokLaserMon;
+  hcaldqm::ContainerSingle1D _cLaserMonSumQ;
+  hcaldqm::ContainerSingle1D _cLaserMonTiming;
+  hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_LS;       // Online
+  hcaldqm::ContainerSingleProf1D _cLaserMonTiming_LS;     // Online
+  hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_Event;    // Local
+  hcaldqm::ContainerSingleProf1D _cLaserMonTiming_Event;  // Local
+  hcaldqm::Container2D _cTiming_DigivsLaserMon_SubdetPM;
+  hcaldqm::ContainerProf2D _cTimingDiffLS_SubdetPM;
+  hcaldqm::ContainerProf2D _cTimingDiffEvent_SubdetPM;
 
-		std::vector<int> _vLaserMonIPhi; // Laser mon digis are assigned to CBox=5, IEta=0, IPhi=[23-index] by the emap
-		int _laserMonIEta;
-		int _laserMonCBox;
-		int _laserMonDigiOverlap;
-		int _laserMonTS0;
-		double _laserMonThreshold;
-		std::map<HcalSubdetector, std::pair<double, double>> _thresh_timingreflm; // Min and max timing (ref. lasermon)
-		double _thresh_frac_timingreflm; // Flag threshold (BAD) on fraction of channels with bad timing
-		double _thresh_min_lmsumq; // Threshold on minimum SumQ from lasermon, if laser is expected
-		int _xMissingLaserMon; // Counter for missing lasermon events
-
-		hcaldqm::ContainerSingle1D _cLaserMonSumQ;
-		hcaldqm::ContainerSingle1D _cLaserMonTiming;
-		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_LS; // Online
-		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_LS; // Online
-		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_Event; // Local
-		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_Event; // Local
-		hcaldqm::Container2D _cTiming_DigivsLaserMon_SubdetPM;
-		hcaldqm::ContainerProf2D _cTimingDiffLS_SubdetPM;
-		hcaldqm::ContainerProf2D _cTimingDiffEvent_SubdetPM;
-
-		//	Summaries
-		hcaldqm::Container2D _cSummaryvsLS_FED;
-		hcaldqm::ContainerSingle2D _cSummaryvsLS;
+  //	Summaries
+  hcaldqm::Container2D _cSummaryvsLS_FED;
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -46,15 +46,13 @@ protected:
   void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
 
   //	tags and tokens
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
+  edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
+  edm::InputTag _tagQIE10;
   edm::InputTag _taguMN;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
   enum LaserFlag { fBadTiming = 0, fMissingLaserMon = 1, nLaserFlag = 2 };

--- a/DQM/HcalTasks/interface/NoCQTask.h
+++ b/DQM/HcalTasks/interface/NoCQTask.h
@@ -6,7 +6,7 @@
 #include "DQM/HcalCommon/interface/HashFilter.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 #include "DQM/HcalCommon/interface/Container1D.h"
- #include "DQM/HcalCommon/interface/Container2D.h"
+#include "DQM/HcalCommon/interface/Container2D.h"
 #include "DQM/HcalCommon/interface/ContainerProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerSingle1D.h"
@@ -14,40 +14,36 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerXXX.h"
 
-class NoCQTask : public hcaldqm::DQTask
-{
-	public:
-		NoCQTask(edm::ParameterSet const&);
-		~NoCQTask() override {}
+class NoCQTask : public hcaldqm::DQTask {
+public:
+  NoCQTask(edm::ParameterSet const&);
+  ~NoCQTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		edm::InputTag _tagHBHE;
-		edm::InputTag _tagHO;
-		edm::InputTag _tagHF;
-		edm::InputTag _tagReport;
-		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<HODigiCollection> _tokHO;
-		edm::EDGetTokenT<HFDigiCollection> _tokHF;
-		edm::EDGetTokenT<HcalUnpackerReport> _tokReport;
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::InputTag _tagReport;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<HFDigiCollection> _tokHF;
+  edm::EDGetTokenT<HcalUnpackerReport> _tokReport;
 
-		double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
+  double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
 
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 
-		hcaldqm::ContainerProf2D _cTimingCut_depth;
-		hcaldqm::Container2D _cOccupancy_depth;
-		hcaldqm::Container2D _cOccupancyCut_depth;
-		hcaldqm::Container2D _cBadQuality_depth;
+  hcaldqm::ContainerProf2D _cTimingCut_depth;
+  hcaldqm::Container2D _cOccupancy_depth;
+  hcaldqm::Container2D _cOccupancyCut_depth;
+  hcaldqm::Container2D _cBadQuality_depth;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/PedestalRunSummary.h
+++ b/DQM/HcalTasks/interface/PedestalRunSummary.h
@@ -4,24 +4,21 @@
 #include "DQM/HcalCommon/interface/DQClient.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-namespace hcaldqm
-{
-	class PedestalRunSummary : public DQClient
-	{
-		public:
-			PedestalRunSummary(std::string const&, std::string const&,
-				edm::ParameterSet const&);
-			~PedestalRunSummary() override {}
+namespace hcaldqm {
+  class PedestalRunSummary : public DQClient {
+  public:
+    PedestalRunSummary(std::string const&, std::string const&, edm::ParameterSet const&);
+    ~PedestalRunSummary() override {}
 
-			void beginRun(edm::Run const&, edm::EventSetup const&) override;
-			void endLuminosityBlock(DQMStore::IBooker&,
-				DQMStore::IGetter&, edm::LuminosityBlock const&,
-				edm::EventSetup const&) override;
-			std::vector<flag::Flag> endJob(
-				DQMStore::IBooker&, DQMStore::IGetter&) override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(DQMStore::IBooker&,
+                            DQMStore::IGetter&,
+                            edm::LuminosityBlock const&,
+                            edm::EventSetup const&) override;
+    std::vector<flag::Flag> endJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
-		protected:
-	};
-}
+  protected:
+  };
+}  // namespace hcaldqm
 
 #endif

--- a/DQM/HcalTasks/interface/PedestalTask.h
+++ b/DQM/HcalTasks/interface/PedestalTask.h
@@ -18,163 +18,145 @@
 #include "DQM/HcalCommon/interface/HashFilter.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class PedestalTask : public hcaldqm::DQTask
-{
-	public:
-		PedestalTask(edm::ParameterSet const&);
-		~PedestalTask() override
-		{}
+class PedestalTask : public hcaldqm::DQTask {
+public:
+  PedestalTask(edm::ParameterSet const&);
+  ~PedestalTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
-		bool _isApplicable(edm::Event const&) override;
-		virtual void _dump();
+protected:
+  //	funcs
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
+  bool _isApplicable(edm::Event const&) override;
+  virtual void _dump();
 
-		//	tags and tokens
-		edm::InputTag	_tagHBHE;
-		edm::InputTag	_tagHE;
-		edm::InputTag	_tagHO;
-		edm::InputTag	_tagHF;
-		edm::InputTag	_tagTrigger;
-		edm::InputTag   _taguMN;
-		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
-		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
-		edm::EDGetTokenT<HODigiCollection> _tokHO;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
-		edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
+  //	tags and tokens
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::InputTag _tagTrigger;
+  edm::InputTag _taguMN;
+  edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
 
-		std::vector<hcaldqm::flag::Flag> _vflags;
-		enum PedestalFlag
-		{
-			fMsn = 0,
-			fBadM = 1,
-			fBadR = 2,
-			nPedestalFlag=3
-		};
+  std::vector<hcaldqm::flag::Flag> _vflags;
+  enum PedestalFlag { fMsn = 0, fBadM = 1, fBadR = 2, nPedestalFlag = 3 };
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_C38;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_C38;
 
-		//	thresholds
-		double _thresh_mean, _thresh_rms, _thresh_badm, _thresh_badr;
-		double _thresh_missing_high, _thresh_missing_low;
+  //	thresholds
+  double _thresh_mean, _thresh_rms, _thresh_badm, _thresh_badr;
+  double _thresh_missing_high, _thresh_missing_low;
 
-		//	hashed ids of FEDs
-		std::vector<uint32_t> _vhashFEDs;
+  //	hashed ids of FEDs
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	need containers total over the run and per 1LS
-		hcaldqm::ContainerXXX<double> _xPedSum1LS;
-		hcaldqm::ContainerXXX<double> _xPedSum21LS;
-		hcaldqm::ContainerXXX<int>	_xPedEntries1LS;
-		hcaldqm::ContainerXXX<double> _xPedSumTotal;
-		hcaldqm::ContainerXXX<double> _xPedSum2Total;
-		hcaldqm::ContainerXXX<int>	_xPedEntriesTotal;
-		hcaldqm::ContainerXXX<int> _xNChs; // number of channels per FED as in emap
-		hcaldqm::ContainerXXX<int> _xNMsn1LS; // #missing for 1LS per FED
-		hcaldqm::ContainerXXX<int> _xNBadMean1LS,_xNBadRMS1LS;
+  //	need containers total over the run and per 1LS
+  hcaldqm::ContainerXXX<double> _xPedSum1LS;
+  hcaldqm::ContainerXXX<double> _xPedSum21LS;
+  hcaldqm::ContainerXXX<int> _xPedEntries1LS;
+  hcaldqm::ContainerXXX<double> _xPedSumTotal;
+  hcaldqm::ContainerXXX<double> _xPedSum2Total;
+  hcaldqm::ContainerXXX<int> _xPedEntriesTotal;
+  hcaldqm::ContainerXXX<int> _xNChs;     // number of channels per FED as in emap
+  hcaldqm::ContainerXXX<int> _xNMsn1LS;  // #missing for 1LS per FED
+  hcaldqm::ContainerXXX<int> _xNBadMean1LS, _xNBadRMS1LS;
 
-		//	CondBD Reference
-		hcaldqm::ContainerXXX<double> _xPedRefMean;
-		hcaldqm::ContainerXXX<double> _xPedRefRMS;
+  //	CondBD Reference
+  hcaldqm::ContainerXXX<double> _xPedRefMean;
+  hcaldqm::ContainerXXX<double> _xPedRefRMS;
 
-		//	1D actual Means/RMSs
-		hcaldqm::Container1D		_cMeanTotal_Subdet;
-		hcaldqm::Container1D		_cRMSTotal_Subdet;
-		hcaldqm::Container1D		_cMean1LS_Subdet; // 1LS
-		hcaldqm::Container1D		_cRMS1LS_Subdet; // 1LS 
+  //	1D actual Means/RMSs
+  hcaldqm::Container1D _cMeanTotal_Subdet;
+  hcaldqm::Container1D _cRMSTotal_Subdet;
+  hcaldqm::Container1D _cMean1LS_Subdet;  // 1LS
+  hcaldqm::Container1D _cRMS1LS_Subdet;   // 1LS
 
-		//	2D actual values
-		hcaldqm::ContainerProf2D		_cMean1LS_depth; // 1LS
-		hcaldqm::ContainerProf2D		_cRMS1LS_depth; //  1lS
-		hcaldqm::ContainerProf2D		_cMean1LS_FEDVME; // 1ls
-		hcaldqm::ContainerProf2D		_cMean1LS_FEDuTCA; // 1ls
-		hcaldqm::ContainerProf2D		_cRMS1LS_FEDVME; // 1ls
-		hcaldqm::ContainerProf2D		_cRMS1LS_FEDuTCA; // 1ls
-		
-		hcaldqm::ContainerProf2D		_cMeanTotal_depth;
-		hcaldqm::ContainerProf2D		_cRMSTotal_depth;
-		hcaldqm::ContainerProf2D		_cMeanTotal_FEDVME;
-		hcaldqm::ContainerProf2D		_cMeanTotal_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cRMSTotal_FEDVME;
-		hcaldqm::ContainerProf2D		_cRMSTotal_FEDuTCA;
-		
-		//	Comparison with DB Conditions
-		hcaldqm::Container1D		_cMeanDBRef1LS_Subdet; // 1LS 
-		hcaldqm::Container1D		_cRMSDBRef1LS_Subdet; // 1LS
-		hcaldqm::Container1D		_cMeanDBRefTotal_Subdet;
-		hcaldqm::Container1D		_cRMSDBRefTotal_Subdet;
-		hcaldqm::ContainerProf2D		_cMeanDBRef1LS_depth;
-		hcaldqm::ContainerProf2D		_cRMSDBRef1LS_depth;
-		hcaldqm::ContainerProf2D		_cMeanDBRef1LS_FEDVME;
-		hcaldqm::ContainerProf2D		_cMeanDBRef1LS_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cRMSDBRef1LS_FEDVME;
-		hcaldqm::ContainerProf2D		_cRMSDBRef1LS_FEDuTCA;
-		
-		hcaldqm::ContainerProf2D		_cMeanDBRefTotal_depth;
-		hcaldqm::ContainerProf2D		_cRMSDBRefTotal_depth;
-		hcaldqm::ContainerProf2D		_cMeanDBRefTotal_FEDVME;
-		hcaldqm::ContainerProf2D		_cMeanDBRefTotal_FEDuTCA;
-		hcaldqm::ContainerProf2D		_cRMSDBRefTotal_FEDVME;
-		hcaldqm::ContainerProf2D		_cRMSDBRefTotal_FEDuTCA;
+  //	2D actual values
+  hcaldqm::ContainerProf2D _cMean1LS_depth;    // 1LS
+  hcaldqm::ContainerProf2D _cRMS1LS_depth;     //  1lS
+  hcaldqm::ContainerProf2D _cMean1LS_FEDVME;   // 1ls
+  hcaldqm::ContainerProf2D _cMean1LS_FEDuTCA;  // 1ls
+  hcaldqm::ContainerProf2D _cRMS1LS_FEDVME;    // 1ls
+  hcaldqm::ContainerProf2D _cRMS1LS_FEDuTCA;   // 1ls
 
-		//	vs LS
-		hcaldqm::Container1D _cMissingvsLS_Subdet;
-		hcaldqm::Container1D _cOccupancyvsLS_Subdet;
-		hcaldqm::Container1D _cNBadMeanvsLS_Subdet;
-		hcaldqm::Container1D _cNBadRMSvsLS_Subdet;
+  hcaldqm::ContainerProf2D _cMeanTotal_depth;
+  hcaldqm::ContainerProf2D _cRMSTotal_depth;
+  hcaldqm::ContainerProf2D _cMeanTotal_FEDVME;
+  hcaldqm::ContainerProf2D _cMeanTotal_FEDuTCA;
+  hcaldqm::ContainerProf2D _cRMSTotal_FEDVME;
+  hcaldqm::ContainerProf2D _cRMSTotal_FEDuTCA;
 
-		//	averaging per event
-		hcaldqm::ContainerProf1D _cOccupancyEAvsLS_Subdet;
+  //	Comparison with DB Conditions
+  hcaldqm::Container1D _cMeanDBRef1LS_Subdet;  // 1LS
+  hcaldqm::Container1D _cRMSDBRef1LS_Subdet;   // 1LS
+  hcaldqm::Container1D _cMeanDBRefTotal_Subdet;
+  hcaldqm::Container1D _cRMSDBRefTotal_Subdet;
+  hcaldqm::ContainerProf2D _cMeanDBRef1LS_depth;
+  hcaldqm::ContainerProf2D _cRMSDBRef1LS_depth;
+  hcaldqm::ContainerProf2D _cMeanDBRef1LS_FEDVME;
+  hcaldqm::ContainerProf2D _cMeanDBRef1LS_FEDuTCA;
+  hcaldqm::ContainerProf2D _cRMSDBRef1LS_FEDVME;
+  hcaldqm::ContainerProf2D _cRMSDBRef1LS_FEDuTCA;
 
-		//	map of missing channels
-		hcaldqm::Container2D	_cMissing1LS_depth;
-		hcaldqm::Container2D	_cMissing1LS_FEDVME;
-		hcaldqm::Container2D	_cMissing1LS_FEDuTCA;
-		hcaldqm::Container2D _cMissingTotal_depth;
-		hcaldqm::Container2D _cMissingTotal_FEDVME;
-		hcaldqm::Container2D _cMissingTotal_FEDuTCA;
+  hcaldqm::ContainerProf2D _cMeanDBRefTotal_depth;
+  hcaldqm::ContainerProf2D _cRMSDBRefTotal_depth;
+  hcaldqm::ContainerProf2D _cMeanDBRefTotal_FEDVME;
+  hcaldqm::ContainerProf2D _cMeanDBRefTotal_FEDuTCA;
+  hcaldqm::ContainerProf2D _cRMSDBRefTotal_FEDVME;
+  hcaldqm::ContainerProf2D _cRMSDBRefTotal_FEDuTCA;
 
-		//	Mean/RMS Bad Maps
-		hcaldqm::Container2D	_cMeanBad1LS_depth;
-		hcaldqm::Container2D _cRMSBad1LS_depth;
-		hcaldqm::Container2D	_cMeanBad1LS_FEDVME;
-		hcaldqm::Container2D	_cRMSBad1LS_FEDuTCA;
-		hcaldqm::Container2D	_cRMSBad1LS_FEDVME;
-		hcaldqm::Container2D	_cMeanBad1LS_FEDuTCA;
+  //	vs LS
+  hcaldqm::Container1D _cMissingvsLS_Subdet;
+  hcaldqm::Container1D _cOccupancyvsLS_Subdet;
+  hcaldqm::Container1D _cNBadMeanvsLS_Subdet;
+  hcaldqm::Container1D _cNBadRMSvsLS_Subdet;
 
-		hcaldqm::Container2D	_cMeanBadTotal_depth;
-		hcaldqm::Container2D _cRMSBadTotal_depth;
-		hcaldqm::Container2D	_cMeanBadTotal_FEDVME;
-		hcaldqm::Container2D	_cRMSBadTotal_FEDuTCA;
-		hcaldqm::Container2D	_cRMSBadTotal_FEDVME;
-		hcaldqm::Container2D	_cMeanBadTotal_FEDuTCA;
+  //	averaging per event
+  hcaldqm::ContainerProf1D _cOccupancyEAvsLS_Subdet;
 
-		hcaldqm::Container1D _cADC_SubdetPM;
-		
-		//	Summaries
-		hcaldqm::Container2D _cSummaryvsLS_FED;
-		hcaldqm::ContainerSingle2D _cSummaryvsLS;
+  //	map of missing channels
+  hcaldqm::Container2D _cMissing1LS_depth;
+  hcaldqm::Container2D _cMissing1LS_FEDVME;
+  hcaldqm::Container2D _cMissing1LS_FEDuTCA;
+  hcaldqm::Container2D _cMissingTotal_depth;
+  hcaldqm::Container2D _cMissingTotal_FEDVME;
+  hcaldqm::Container2D _cMissingTotal_FEDuTCA;
+
+  //	Mean/RMS Bad Maps
+  hcaldqm::Container2D _cMeanBad1LS_depth;
+  hcaldqm::Container2D _cRMSBad1LS_depth;
+  hcaldqm::Container2D _cMeanBad1LS_FEDVME;
+  hcaldqm::Container2D _cRMSBad1LS_FEDuTCA;
+  hcaldqm::Container2D _cRMSBad1LS_FEDVME;
+  hcaldqm::Container2D _cMeanBad1LS_FEDuTCA;
+
+  hcaldqm::Container2D _cMeanBadTotal_depth;
+  hcaldqm::Container2D _cRMSBadTotal_depth;
+  hcaldqm::Container2D _cMeanBadTotal_FEDVME;
+  hcaldqm::Container2D _cRMSBadTotal_FEDuTCA;
+  hcaldqm::Container2D _cRMSBadTotal_FEDVME;
+  hcaldqm::Container2D _cMeanBadTotal_FEDuTCA;
+
+  hcaldqm::Container1D _cADC_SubdetPM;
+
+  //	Summaries
+  hcaldqm::Container2D _cSummaryvsLS_FED;
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;
 };
 
 #endif
-
-
-
-
-
-
-

--- a/DQM/HcalTasks/interface/PedestalTask.h
+++ b/DQM/HcalTasks/interface/PedestalTask.h
@@ -36,17 +36,15 @@ protected:
   virtual void _dump();
 
   //	tags and tokens
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
+  edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
+  edm::InputTag _tagQIE10;
   edm::InputTag _tagTrigger;
   edm::InputTag _taguMN;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
 
   std::vector<hcaldqm::flag::Flag> _vflags;

--- a/DQM/HcalTasks/interface/QIE10Task.h
+++ b/DQM/HcalTasks/interface/QIE10Task.h
@@ -19,62 +19,55 @@
 #include "DQM/HcalCommon/interface/HashFilter.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class QIE10Task : public hcaldqm::DQTask
-{
-	public:
-		QIE10Task(edm::ParameterSet const&);
-		~QIE10Task() override{}
+class QIE10Task : public hcaldqm::DQTask {
+public:
+  QIE10Task(edm::ParameterSet const&);
+  ~QIE10Task() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		//	tags
-		edm::InputTag	_tagQIE10;
-		edm::InputTag       _tagHF;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
-		edm::EDGetTokenT<HFDigiCollection>  _tokHF;
+  //	tags
+  edm::InputTag _tagQIE10;
+  edm::InputTag _tagHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
+  edm::EDGetTokenT<HFDigiCollection> _tokHF;
 
-		//	cuts/constants from input
-		double _cut;
-		int _ped;
+  //	cuts/constants from input
+  double _cut;
+  int _ped;
 
-		//	filters
-		hcaldqm::filter::HashFilter _filter_slot[36];
+  //	filters
+  hcaldqm::filter::HashFilter _filter_slot[36];
 
+  //	Electronics Maps/Hashes
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 
-		//	Electronics Maps/Hashes
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-		
-		//	hcaldqm::Containers
-		hcaldqm::ContainerProf1D	_cShapeCut_EChannel[36];
-		hcaldqm::Container2D	_cLETDCvsADC_EChannel[10][36];
-		hcaldqm::Container2D    _cLETDCvsTS_EChannel[36];
-		hcaldqm::Container1D _cLETDC_EChannel[10][36];
-		hcaldqm::Container1D _cADC_EChannel[10][36];
-		hcaldqm::Container1D _cLETDCTime_EChannel[36];
+  //	hcaldqm::Containers
+  hcaldqm::ContainerProf1D _cShapeCut_EChannel[36];
+  hcaldqm::Container2D _cLETDCvsADC_EChannel[10][36];
+  hcaldqm::Container2D _cLETDCvsTS_EChannel[36];
+  hcaldqm::Container1D _cLETDC_EChannel[10][36];
+  hcaldqm::Container1D _cADC_EChannel[10][36];
+  hcaldqm::Container1D _cLETDCTime_EChannel[36];
 
-		//	hcaldqm::Containers overall
-		hcaldqm::ContainerSingleProf1D	_cShapeCut;
-		hcaldqm::ContainerSingle2D		_cLETDCTimevsADC;
-		hcaldqm::ContainerSingle2D		_cLETDCvsADC;
-		hcaldqm::ContainerSingle1D		_cLETDC;
-		hcaldqm::ContainerSingle1D		_cADC;
+  //	hcaldqm::Containers overall
+  hcaldqm::ContainerSingleProf1D _cShapeCut;
+  hcaldqm::ContainerSingle2D _cLETDCTimevsADC;
+  hcaldqm::ContainerSingle2D _cLETDCvsADC;
+  hcaldqm::ContainerSingle1D _cLETDC;
+  hcaldqm::ContainerSingle1D _cADC;
 
-		//occupancy per crate/slot
-		hcaldqm::Container2D _cOccupancy_Crate;
-		hcaldqm::Container2D _cOccupancy_CrateSlot;
+  //occupancy per crate/slot
+  hcaldqm::Container2D _cOccupancy_Crate;
+  hcaldqm::Container2D _cOccupancy_CrateSlot;
 
-		// Detector coordinates
-		hcaldqm::Container2D _cOccupancy_depth;
+  // Detector coordinates
+  hcaldqm::Container2D _cOccupancy_depth;
 };
 
 #endif
-
-
-

--- a/DQM/HcalTasks/interface/QIE11Task.h
+++ b/DQM/HcalTasks/interface/QIE11Task.h
@@ -19,66 +19,55 @@
 #include "DQM/HcalCommon/interface/HashFilter.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class QIE11Task : public hcaldqm::DQTask
-{
-	public:
-		QIE11Task(edm::ParameterSet const&);
-		~QIE11Task() override{}
+class QIE11Task : public hcaldqm::DQTask {
+public:
+  QIE11Task(edm::ParameterSet const&);
+  ~QIE11Task() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
-		bool _isApplicable(edm::Event const&) override;
+protected:
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
+  bool _isApplicable(edm::Event const&) override;
 
+  //	tags
+  edm::InputTag _tagQIE11;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
 
-		//	tags
-		edm::InputTag	_tagQIE11;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
+  edm::InputTag _taguMN;
+  edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
-		edm::InputTag _taguMN;
-		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
+  //	cuts/constants from input
+  double _cut;
+  int _ped;
+  int _laserType;
+  int _eventType;
 
+  //	filters
+  hcaldqm::filter::HashFilter _filter_C34;
+  hcaldqm::filter::HashFilter _filter_slot[2];
+  hcaldqm::filter::HashFilter _filter_timingChannels[4];
 
+  //	Electronics Maps/Hashes
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 
-		//	cuts/constants from input
-		double _cut;
-		int _ped;
-		int _laserType;
-		int _eventType;
+  //	hcaldqm::Containers
+  hcaldqm::ContainerProf1D _cShapeCut_EChannel[2];
+  hcaldqm::Container2D _cLETDCvsADC_EChannel[10][2];
+  hcaldqm::Container2D _cLETDCvsTS_EChannel[2];
+  hcaldqm::Container1D _cLETDC_EChannel[10][2];
+  hcaldqm::Container1D _cLETDCTime_EChannel[2];
+  hcaldqm::Container1D _cADC_EChannel[10][2];
+  hcaldqm::Container2D _cOccupancy_depth;
 
-
-		//	filters
-		hcaldqm::filter::HashFilter _filter_C34;
-		hcaldqm::filter::HashFilter _filter_slot[2];
-		hcaldqm::filter::HashFilter _filter_timingChannels[4];
-
-		//	Electronics Maps/Hashes
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-		
-		//	hcaldqm::Containers
-		hcaldqm::ContainerProf1D	_cShapeCut_EChannel[2];
-		hcaldqm::Container2D	_cLETDCvsADC_EChannel[10][2];
-		hcaldqm::Container2D    _cLETDCvsTS_EChannel[2];
-		hcaldqm::Container1D _cLETDC_EChannel[10][2];
-		hcaldqm::Container1D _cLETDCTime_EChannel[2];
-		hcaldqm::Container1D _cADC_EChannel[10][2];
-		hcaldqm::Container2D _cOccupancy_depth;
-
-		//	hcaldqm::Containers overall
-		hcaldqm::ContainerSingleProf1D	_cShapeCut;
-		hcaldqm::ContainerSingle2D		_cLETDCvsADC;
-		hcaldqm::ContainerSingle2D		_cLETDCTimevsADC;
-		hcaldqm::ContainerSingle1D		_cLETDC;
-		hcaldqm::ContainerSingle1D		_cADC;
-
+  //	hcaldqm::Containers overall
+  hcaldqm::ContainerSingleProf1D _cShapeCut;
+  hcaldqm::ContainerSingle2D _cLETDCvsADC;
+  hcaldqm::ContainerSingle2D _cLETDCTimevsADC;
+  hcaldqm::ContainerSingle1D _cLETDC;
+  hcaldqm::ContainerSingle1D _cADC;
 };
 
 #endif
-
-
-

--- a/DQM/HcalTasks/interface/RawRunSummary.h
+++ b/DQM/HcalTasks/interface/RawRunSummary.h
@@ -4,51 +4,42 @@
 #include "DQM/HcalCommon/interface/DQClient.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-namespace hcaldqm
-{
-	class RawRunSummary : public DQClient
-	{
-		public:
-			RawRunSummary(std::string const&, std::string const&,
-				edm::ParameterSet const&);
-			~RawRunSummary() override {}
+namespace hcaldqm {
+  class RawRunSummary : public DQClient {
+  public:
+    RawRunSummary(std::string const&, std::string const&, edm::ParameterSet const&);
+    ~RawRunSummary() override {}
 
-			void beginRun(edm::Run const&, edm::EventSetup const&) override;
-			void endLuminosityBlock(DQMStore::IBooker&,
-				DQMStore::IGetter&, edm::LuminosityBlock const&,
-				edm::EventSetup const&) override;
-			std::vector<flag::Flag> endJob(
-				DQMStore::IBooker&, DQMStore::IGetter&) override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(DQMStore::IBooker&,
+                            DQMStore::IGetter&,
+                            edm::LuminosityBlock const&,
+                            edm::EventSetup const&) override;
+    std::vector<flag::Flag> endJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
-		protected:
-			//	Flag Summary for each LS and Run as a whole
-			std::vector<LSSummary> _vflagsLS; 
+  protected:
+    //	Flag Summary for each LS and Run as a whole
+    std::vector<LSSummary> _vflagsLS;
 
-			electronicsmap::ElectronicsMap _ehashmap;
+    electronicsmap::ElectronicsMap _ehashmap;
 
-			//	some useful vectors - not to reintialize all the time
-			std::vector<uint32_t> _vhashVME, _vhashuTCA;
-			std::vector<int> _vFEDsVME, _vFEDsuTCA;
-			filter::HashFilter _filter_VME, _filter_uTCA;
+    //	some useful vectors - not to reintialize all the time
+    std::vector<uint32_t> _vhashVME, _vhashuTCA;
+    std::vector<int> _vFEDsVME, _vFEDsuTCA;
+    filter::HashFilter _filter_VME, _filter_uTCA;
 
-			//	Containers to store info for the whole run
-			Container2D _cEvnMsm_ElectronicsVME, _cEvnMsm_ElectronicsuTCA;
-			Container2D _cBcnMsm_ElectronicsVME, _cBcnMsm_ElectronicsuTCA;
-			Container2D _cBadQuality_depth;
+    //	Containers to store info for the whole run
+    Container2D _cEvnMsm_ElectronicsVME, _cEvnMsm_ElectronicsuTCA;
+    Container2D _cBcnMsm_ElectronicsVME, _cBcnMsm_ElectronicsuTCA;
+    Container2D _cBadQuality_depth;
 
-			bool _booked;
+    bool _booked;
 
-			//	
-			ContainerXXX<uint32_t> _xEvn, _xBcn, _xBadQ;
+    //
+    ContainerXXX<uint32_t> _xEvn, _xBcn, _xBadQ;
 
-			enum RawLSFlag
-			{
-				fEvnMsm=0,
-				fBcnMsm=1,
-				fBadQ=2,
-				nRawFlag=3
-			};
-	};
-}
+    enum RawLSFlag { fEvnMsm = 0, fBcnMsm = 1, fBadQ = 2, nRawFlag = 3 };
+  };
+}  // namespace hcaldqm
 
 #endif

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -21,75 +21,64 @@
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 #include "DQM/HcalCommon/interface/Flag.h"
 
-class RawTask : public hcaldqm::DQTask
-{
-	public:
-		RawTask(edm::ParameterSet const&);
-		~RawTask() override {}
+class RawTask : public hcaldqm::DQTask {
+public:
+  RawTask(edm::ParameterSet const&);
+  ~RawTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		edm::InputTag		_tagFEDs;
-		edm::InputTag		_tagReport;
-		edm::EDGetTokenT<FEDRawDataCollection>	_tokFEDs;
-		edm::EDGetTokenT<HcalUnpackerReport> _tokReport;
+  edm::InputTag _tagFEDs;
+  edm::InputTag _tagReport;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
+  edm::EDGetTokenT<HcalUnpackerReport> _tokReport;
 
-		//	flag vector
-		std::vector<hcaldqm::flag::Flag> _vflags;
-		enum RawFlag
-		{
-			fEvnMsm = 0,
-			fBcnMsm = 1,
-			fOrnMsm = 2,
-			fBadQ = 3,
-			nRawFlag = 4
-		};
+  //	flag vector
+  std::vector<hcaldqm::flag::Flag> _vflags;
+  enum RawFlag { fEvnMsm = 0, fBcnMsm = 1, fOrnMsm = 2, fBadQ = 3, nRawFlag = 4 };
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 
-		//	physics vs calib processing switch
-		bool _calibProcessing;
-		int _thresh_calib_nbadq;
+  //	physics vs calib processing switch
+  bool _calibProcessing;
+  int _thresh_calib_nbadq;
 
-		//	vector of HcalElectronicsId for FEDs
-		std::vector<uint32_t> _vhashFEDs;
+  //	vector of HcalElectronicsId for FEDs
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_FEDsVME;
-		hcaldqm::filter::HashFilter _filter_FEDsuTCA;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_FEDsVME;
+  hcaldqm::filter::HashFilter _filter_FEDsuTCA;
 
-		//	Bad Quality
-		hcaldqm::Container2D _cBadQuality_FEDVME;
-		hcaldqm::Container2D _cBadQuality_FEDuTCA;
-		hcaldqm::Container2D _cBadQuality_depth;
-		hcaldqm::Container2D _cBadQualityLS_depth; // online only
-		hcaldqm::ContainerSingleProf1D _cBadQualityvsLS;
-		hcaldqm::ContainerSingleProf1D _cBadQualityvsBX;
-		hcaldqm::ContainerProf1D _cDataSizevsLS_FED; // online only
+  //	Bad Quality
+  hcaldqm::Container2D _cBadQuality_FEDVME;
+  hcaldqm::Container2D _cBadQuality_FEDuTCA;
+  hcaldqm::Container2D _cBadQuality_depth;
+  hcaldqm::Container2D _cBadQualityLS_depth;  // online only
+  hcaldqm::ContainerSingleProf1D _cBadQualityvsLS;
+  hcaldqm::ContainerSingleProf1D _cBadQualityvsBX;
+  hcaldqm::ContainerProf1D _cDataSizevsLS_FED;  // online only
 
-		//	Mismatches
-		hcaldqm::Container2D _cEvnMsm_ElectronicsVME;
-		hcaldqm::Container2D _cBcnMsm_ElectronicsVME;
-		hcaldqm::Container2D _cOrnMsm_ElectronicsVME;
-		hcaldqm::Container2D _cEvnMsm_ElectronicsuTCA;
-		hcaldqm::Container2D _cBcnMsm_ElectronicsuTCA;
-		hcaldqm::Container2D _cOrnMsm_ElectronicsuTCA;
-		hcaldqm::ContainerXXX<uint32_t> _xEvnMsmLS, _xBcnMsmLS, _xOrnMsmLS, _xBadQLS;
-	
-		hcaldqm::Container2D	_cSummaryvsLS_FED; // online only
-		hcaldqm::ContainerSingle2D	_cSummaryvsLS; // online only
+  //	Mismatches
+  hcaldqm::Container2D _cEvnMsm_ElectronicsVME;
+  hcaldqm::Container2D _cBcnMsm_ElectronicsVME;
+  hcaldqm::Container2D _cOrnMsm_ElectronicsVME;
+  hcaldqm::Container2D _cEvnMsm_ElectronicsuTCA;
+  hcaldqm::Container2D _cBcnMsm_ElectronicsuTCA;
+  hcaldqm::Container2D _cOrnMsm_ElectronicsuTCA;
+  hcaldqm::ContainerXXX<uint32_t> _xEvnMsmLS, _xBcnMsmLS, _xOrnMsmLS, _xBadQLS;
+
+  hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
 };
 
 #endif

--- a/DQM/HcalTasks/interface/RecHitTask.h
+++ b/DQM/HcalTasks/interface/RecHitTask.h
@@ -23,119 +23,109 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class RecHitTask : public hcaldqm::DQTask
-{
-	public:
-		RecHitTask(edm::ParameterSet const&);
-		~RecHitTask() override {}
+class RecHitTask : public hcaldqm::DQTask {
+public:
+  RecHitTask(edm::ParameterSet const &);
+  ~RecHitTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const &, edm::EventSetup const &) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		edm::InputTag		_tagHBHE;
-		edm::InputTag		_tagHO;
-		edm::InputTag		_tagHF;
-		edm::InputTag		_tagPreHF;
-		bool _hfPreRecHitsAvailable;
-		edm::EDGetTokenT<HBHERecHitCollection>	_tokHBHE;
-		edm::EDGetTokenT<HORecHitCollection>	_tokHO;
-		edm::EDGetTokenT<HFRecHitCollection>	_tokHF;
-		edm::EDGetTokenT<HFPreRecHitCollection>	_tokPreHF;
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::InputTag _tagPreHF;
+  bool _hfPreRecHitsAvailable;
+  edm::EDGetTokenT<HBHERecHitCollection> _tokHBHE;
+  edm::EDGetTokenT<HORecHitCollection> _tokHO;
+  edm::EDGetTokenT<HFRecHitCollection> _tokHF;
+  edm::EDGetTokenT<HFPreRecHitCollection> _tokPreHF;
 
-		double _cutE_HBHE, _cutE_HO, _cutE_HF;
-		double _thresh_unihf;
+  double _cutE_HBHE, _cutE_HO, _cutE_HF;
+  double _thresh_unihf;
 
-		//	hashes/FED vectors
-		std::vector<uint32_t> _vhashFEDs;
+  //	hashes/FED vectors
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	flag vectors
-		std::vector<hcaldqm::flag::Flag> _vflags;
-		enum RecoFlag
-		{
-			fUni=0,
-			fTCDS=1,
-			fUnknownIds = 2,
-			nRecoFlag=3
-		};
+  //	flag vectors
+  std::vector<hcaldqm::flag::Flag> _vflags;
+  enum RecoFlag { fUni = 0, fTCDS = 1, fUnknownIds = 2, nRecoFlag = 3 };
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_FEDsVME;
-		hcaldqm::filter::HashFilter _filter_FEDsuTCA;
-		hcaldqm::filter::HashFilter _filter_HF;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_FEDsVME;
+  hcaldqm::filter::HashFilter _filter_FEDsuTCA;
+  hcaldqm::filter::HashFilter _filter_HF;
 
-		//	Energy. Just filling. No Summary Generation
-		hcaldqm::Container1D _cEnergy_Subdet;
-		hcaldqm::ContainerProf1D _cEnergyvsieta_Subdet;	//	online only!
-		hcaldqm::ContainerProf1D _cEnergyvsiphi_SubdetPM;	// online only!
-		hcaldqm::ContainerProf2D _cEnergy_depth;
-		hcaldqm::ContainerProf1D _cEnergyvsLS_SubdetPM;	// online only!
-		hcaldqm::ContainerProf1D _cEnergyvsBX_SubdetPM;	// online only
+  //	Energy. Just filling. No Summary Generation
+  hcaldqm::Container1D _cEnergy_Subdet;
+  hcaldqm::ContainerProf1D _cEnergyvsieta_Subdet;    //	online only!
+  hcaldqm::ContainerProf1D _cEnergyvsiphi_SubdetPM;  // online only!
+  hcaldqm::ContainerProf2D _cEnergy_depth;
+  hcaldqm::ContainerProf1D _cEnergyvsLS_SubdetPM;  // online only!
+  hcaldqm::ContainerProf1D _cEnergyvsBX_SubdetPM;  // online only
 
-		//	Timing vs Energy. No Summary Generation
-		hcaldqm::Container2D _cTimingvsEnergy_SubdetPM;
+  //	Timing vs Energy. No Summary Generation
+  hcaldqm::Container2D _cTimingvsEnergy_SubdetPM;
 
-		//	Timing. HBHE Partition is used for TCDS shift monitoring
-		hcaldqm::Container1D		_cTimingCut_SubdetPM;
-		hcaldqm::Container1D		_cTimingCut_HBHEPartition;
-		hcaldqm::ContainerProf2D _cTimingCut_FEDVME;
-		hcaldqm::ContainerProf2D	_cTimingCut_FEDuTCA;
-		hcaldqm::ContainerProf2D _cTimingCut_ElectronicsVME;
-		hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
-		hcaldqm::ContainerProf2D _cTimingCut_depth;
-		hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
-		hcaldqm::ContainerProf1D _cTimingCutvsLS_SubdetPM;
-		hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;	//	online only
-		hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM; //	online only
-		hcaldqm::ContainerProf1D _cTimingCutvsBX_SubdetPM;	// online only
+  //	Timing. HBHE Partition is used for TCDS shift monitoring
+  hcaldqm::Container1D _cTimingCut_SubdetPM;
+  hcaldqm::Container1D _cTimingCut_HBHEPartition;
+  hcaldqm::ContainerProf2D _cTimingCut_FEDVME;
+  hcaldqm::ContainerProf2D _cTimingCut_FEDuTCA;
+  hcaldqm::ContainerProf2D _cTimingCut_ElectronicsVME;
+  hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
+  hcaldqm::ContainerProf2D _cTimingCut_depth;
+  hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
+  hcaldqm::ContainerProf1D _cTimingCutvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;    //	online only
+  hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM;  //	online only
+  hcaldqm::ContainerProf1D _cTimingCutvsBX_SubdetPM;    // online only
 
-		//	Occupancy w/o a cut. Used for checking missing channels
-		hcaldqm::Container2D _cOccupancy_depth;
-		hcaldqm::Container2D _cOccupancy_FEDVME;
-		hcaldqm::Container2D _cOccupancy_FEDuTCA;
-		hcaldqm::Container2D _cOccupancy_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancy_ElectronicsuTCA;
-		hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
-		hcaldqm::Container1D _cOccupancyvsiphi_SubdetPM;	// online only
-		hcaldqm::Container1D _cOccupancyvsieta_Subdet;	//	online only
+  //	Occupancy w/o a cut. Used for checking missing channels
+  hcaldqm::Container2D _cOccupancy_depth;
+  hcaldqm::Container2D _cOccupancy_FEDVME;
+  hcaldqm::Container2D _cOccupancy_FEDuTCA;
+  hcaldqm::Container2D _cOccupancy_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancy_ElectronicsuTCA;
+  hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
+  hcaldqm::Container1D _cOccupancyvsiphi_SubdetPM;  // online only
+  hcaldqm::Container1D _cOccupancyvsieta_Subdet;    //	online only
 
-		//	Occupancy w/ a Cut.
-		hcaldqm::Container2D _cOccupancyCut_FEDVME;
-		hcaldqm::Container2D _cOccupancyCut_FEDuTCA;
-		hcaldqm::Container2D _cOccupancyCut_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyCut_ElectronicsuTCA;
-		hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet; // online only
-		hcaldqm::Container2D _cOccupancyCut_depth;
-		hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM;	// online only
-		hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;	// online only!
-		hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xUniHF, _xUni;
+  //	Occupancy w/ a Cut.
+  hcaldqm::Container2D _cOccupancyCut_FEDVME;
+  hcaldqm::Container2D _cOccupancyCut_FEDuTCA;
+  hcaldqm::Container2D _cOccupancyCut_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyCut_ElectronicsuTCA;
+  hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet;  // online only
+  hcaldqm::Container2D _cOccupancyCut_depth;
+  hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM;      // online only
+  hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;        // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;      // online only!
+  hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM;  // online only
+  hcaldqm::ContainerXXX<uint32_t> _xUniHF, _xUni;
 
-		// QIE10 dual anode histograms
-		hcaldqm::Container2D _cDAAsymmetryVsCharge_SubdetPM;
-		hcaldqm::ContainerProf2D _cDAAsymmetryMean_cut_depth;
-		hcaldqm::Container1D _cDAAsymmetry_cut_SubdetPM;
+  // QIE10 dual anode histograms
+  hcaldqm::Container2D _cDAAsymmetryVsCharge_SubdetPM;
+  hcaldqm::ContainerProf2D _cDAAsymmetryMean_cut_depth;
+  hcaldqm::Container1D _cDAAsymmetry_cut_SubdetPM;
 
-		//	tracks the unknown ids
-		MonitorElement *meUnknownIds1LS;
-		bool _unknownIdsPresent;
+  //	tracks the unknown ids
+  MonitorElement *meUnknownIds1LS;
+  bool _unknownIdsPresent;
 
-		std::vector<HcalGenericDetId> _gids; // online only
-		hcaldqm::Container2D _cSummaryvsLS_FED; // online only!
-		hcaldqm::ContainerSingle2D _cSummaryvsLS;
+  std::vector<HcalGenericDetId> _gids;     // online only
+  hcaldqm::Container2D _cSummaryvsLS_FED;  // online only!
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/RecoRunSummary.h
+++ b/DQM/HcalTasks/interface/RecoRunSummary.h
@@ -4,32 +4,24 @@
 #include "DQM/HcalCommon/interface/DQClient.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-namespace hcaldqm
-{
-	class RecoRunSummary : public DQClient
-	{
-		public:
-			RecoRunSummary(std::string const&, std::string const&,
-				edm::ParameterSet const&);
-			~RecoRunSummary() override {}
+namespace hcaldqm {
+  class RecoRunSummary : public DQClient {
+  public:
+    RecoRunSummary(std::string const&, std::string const&, edm::ParameterSet const&);
+    ~RecoRunSummary() override {}
 
-			void beginRun(edm::Run const&, edm::EventSetup const&) override;
-			void endLuminosityBlock(DQMStore::IBooker&,
-				DQMStore::IGetter&, edm::LuminosityBlock const&,
-				edm::EventSetup const&) override;
-			std::vector<flag::Flag> endJob(
-				DQMStore::IBooker&, DQMStore::IGetter&) override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(DQMStore::IBooker&,
+                            DQMStore::IGetter&,
+                            edm::LuminosityBlock const&,
+                            edm::EventSetup const&) override;
+    std::vector<flag::Flag> endJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
-		protected:
-			double _thresh_unihf, _thresh_tcds;
+  protected:
+    double _thresh_unihf, _thresh_tcds;
 
-			enum RecoFlag
-			{
-				fTCDS = 0,
-				fUniSlotHF=1,
-				nRecoFlag=2
-			};
-	};
-}
+    enum RecoFlag { fTCDS = 0, fUniSlotHF = 1, nRecoFlag = 2 };
+  };
+}  // namespace hcaldqm
 
 #endif

--- a/DQM/HcalTasks/interface/TPComparisonTask.h
+++ b/DQM/HcalTasks/interface/TPComparisonTask.h
@@ -17,69 +17,65 @@
 #include "DQM/HcalCommon/interface/HashFilter.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class TPComparisonTask : public hcaldqm::DQTask
-{
-	public: 
-		TPComparisonTask(edm::ParameterSet const&);
-		~TPComparisonTask() override
-		{}
+class TPComparisonTask : public hcaldqm::DQTask {
+public:
+  TPComparisonTask(edm::ParameterSet const&);
+  ~TPComparisonTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  //	funcs
+  void _process(edm::Event const&, edm::EventSetup const&) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		//	Tags and corresponding Tokens
-		edm::InputTag	_tag1;
-		edm::InputTag	_tag2;
-		edm::EDGetTokenT<HcalTrigPrimDigiCollection>	_tok1;
-		edm::EDGetTokenT<HcalTrigPrimDigiCollection>	_tok2;
+  //	Tags and corresponding Tokens
+  edm::InputTag _tag1;
+  edm::InputTag _tag2;
+  edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tok1;
+  edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tok2;
 
-		//	tmp flags
-		bool _skip1x1;
+  //	tmp flags
+  bool _skip1x1;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmapuTCA;
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmapVME;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmapuTCA;
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmapVME;
 
-		//	hahses/FED vectors
-		std::vector<uint32_t> _vhashFEDs;
+  //	hahses/FED vectors
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
 
-		/**
+  /**
 		 *	hcaldqm::Containers
 		 */
 
-		//	Et
-		hcaldqm::Container2D			_cEt_TTSubdet[4];
-		hcaldqm::Container2D			_cEtall_TTSubdet;
+  //	Et
+  hcaldqm::Container2D _cEt_TTSubdet[4];
+  hcaldqm::Container2D _cEtall_TTSubdet;
 
-		//	FG
-		hcaldqm::Container2D			_cFG_TTSubdet[4];
+  //	FG
+  hcaldqm::Container2D _cFG_TTSubdet[4];
 
-		//	Missing
-		hcaldqm::Container2D			_cMsn_FEDVME;
-		hcaldqm::Container2D			_cMsn_FEDuTCA;
-		hcaldqm::ContainerSingle2D	_cMsnVME;
-		hcaldqm::ContainerSingle2D	_cMsnuTCA;
+  //	Missing
+  hcaldqm::Container2D _cMsn_FEDVME;
+  hcaldqm::Container2D _cMsn_FEDuTCA;
+  hcaldqm::ContainerSingle2D _cMsnVME;
+  hcaldqm::ContainerSingle2D _cMsnuTCA;
 
-		//	mismatches
-		hcaldqm::Container2D			_cEtMsm_FEDVME;
-		hcaldqm::Container2D			_cEtMsm_FEDuTCA;
-		hcaldqm::Container2D			_cFGMsm_FEDVME;
-		hcaldqm::Container2D			_cFGMsm_FEDuTCA;
+  //	mismatches
+  hcaldqm::Container2D _cEtMsm_FEDVME;
+  hcaldqm::Container2D _cEtMsm_FEDuTCA;
+  hcaldqm::Container2D _cFGMsm_FEDVME;
+  hcaldqm::Container2D _cFGMsm_FEDuTCA;
 
-		//	depth like
-		hcaldqm::ContainerSingle2D	_cEtMsm;
-		hcaldqm::ContainerSingle2D	_cFGMsm;
+  //	depth like
+  hcaldqm::ContainerSingle2D _cEtMsm;
+  hcaldqm::ContainerSingle2D _cFGMsm;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/TPRunSummary.h
+++ b/DQM/HcalTasks/interface/TPRunSummary.h
@@ -4,36 +4,28 @@
 #include "DQM/HcalCommon/interface/DQClient.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-namespace hcaldqm
-{
-	class TPRunSummary : public DQClient
-	{
-		public:
-			TPRunSummary(std::string const&, std::string const&,
-				edm::ParameterSet const&);
-			~TPRunSummary() override {}
+namespace hcaldqm {
+  class TPRunSummary : public DQClient {
+  public:
+    TPRunSummary(std::string const&, std::string const&, edm::ParameterSet const&);
+    ~TPRunSummary() override {}
 
-			void beginRun(edm::Run const&, edm::EventSetup const&) override;
-			void endLuminosityBlock(DQMStore::IBooker&,
-				DQMStore::IGetter&, edm::LuminosityBlock const&,
-				edm::EventSetup const&) override;
-			std::vector<flag::Flag> endJob(
-				DQMStore::IBooker&, DQMStore::IGetter&) override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(DQMStore::IBooker&,
+                            DQMStore::IGetter&,
+                            edm::LuminosityBlock const&,
+                            edm::EventSetup const&) override;
+    std::vector<flag::Flag> endJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
-		protected:
-			ContainerSingle2D _cEtMsmFraction_depthlike;
-			ContainerSingle2D _cFGMsmFraction_depthlike;
+  protected:
+    ContainerSingle2D _cEtMsmFraction_depthlike;
+    ContainerSingle2D _cFGMsmFraction_depthlike;
 
-			double _thresh_FGMsmRate_high, _thresh_FGMsmRate_low;
-			double _thresh_EtMsmRate_high, _thresh_EtMsmRate_low;
+    double _thresh_FGMsmRate_high, _thresh_FGMsmRate_low;
+    double _thresh_EtMsmRate_high, _thresh_EtMsmRate_low;
 
-			enum TPFlag
-			{
-				fEtMsm=0,
-				fFGMsm=1,
-				nTPFlag=3
-			};
-	};
-}
+    enum TPFlag { fEtMsm = 0, fFGMsm = 1, nTPFlag = 3 };
+  };
+}  // namespace hcaldqm
 
 #endif

--- a/DQM/HcalTasks/interface/TPTask.h
+++ b/DQM/HcalTasks/interface/TPTask.h
@@ -19,173 +19,159 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class TPTask : public hcaldqm::DQTask
-{
-	public:
-		TPTask(edm::ParameterSet const&);
-		~TPTask() override {}
+class TPTask : public hcaldqm::DQTask {
+public:
+  TPTask(edm::ParameterSet const &);
+  ~TPTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
-		void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
-	protected:
-		void _process(edm::Event const&, edm::EventSetup const&) override;
-		void _resetMonitors(hcaldqm::UpdateFreq) override;
+protected:
+  void _process(edm::Event const &, edm::EventSetup const &) override;
+  void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-		edm::InputTag		_tagData;
-		edm::InputTag		_tagDataL1Rec;
-		edm::InputTag		_tagEmul;
-		edm::InputTag		_tagEmulNoTDCCut;
-		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokData;
-		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokDataL1Rec;
-		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmul;
-		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmulNoTDCCut;
+  edm::InputTag _tagData;
+  edm::InputTag _tagDataL1Rec;
+  edm::InputTag _tagEmul;
+  edm::InputTag _tagEmulNoTDCCut;
+  edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokData;
+  edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokDataL1Rec;
+  edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmul;
+  edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmulNoTDCCut;
 
-		//	flag vector
-		std::vector<hcaldqm::flag::Flag> _vflags;
-		enum TPFlag
-		{
-			fEtMsm=0,
-			fDataMsn=1,
-			fEmulMsn=2,
-			fUnknownIds=3,
-			fSentRecL1Msm=4,
-			nTPFlag=5
-		};
+  //	flag vector
+  std::vector<hcaldqm::flag::Flag> _vflags;
+  enum TPFlag { fEtMsm = 0, fDataMsn = 1, fEmulMsn = 2, fUnknownIds = 3, fSentRecL1Msm = 4, nTPFlag = 5 };
 
-		//	switches/cuts/etc...
-		bool _skip1x1;
-		int _cutEt;
-		double _thresh_EtMsmRate_high, _thresh_EtMsmRate_low,
-			_thresh_FGMsmRate_high, _thresh_FGMsmRate_low,
-			_thresh_DataMsn, _thresh_EmulMsn;
-		std::vector<bool> _vFGBitsReady;
+  //	switches/cuts/etc...
+  bool _skip1x1;
+  int _cutEt;
+  double _thresh_EtMsmRate_high, _thresh_EtMsmRate_low, _thresh_FGMsmRate_high, _thresh_FGMsmRate_low, _thresh_DataMsn,
+      _thresh_EmulMsn;
+  std::vector<bool> _vFGBitsReady;
 
-		//	hashes/FEDs vectors
-		std::vector<uint32_t> _vhashFEDs;
+  //	hashes/FEDs vectors
+  std::vector<uint32_t> _vhashFEDs;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 
-		//	Filters
-		hcaldqm::filter::HashFilter _filter_VME;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_depth0;
+  //	Filters
+  hcaldqm::filter::HashFilter _filter_VME;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_depth0;
 
-		//	Et/FG
-		hcaldqm::Container1D _cEtData_TTSubdet;
-		hcaldqm::Container1D _cEtEmul_TTSubdet;
-		hcaldqm::Container2D	_cEtCorr_TTSubdet;
-		hcaldqm::Container2D _cEtCorr2x3_TTSubdet;	//	online only
-		hcaldqm::Container2D _cFGCorr_TTSubdet[hcaldqm::constants::NUM_FGBITS];
-		hcaldqm::ContainerProf1D _cEtCutDatavsLS_TTSubdet;	// online only!
-		hcaldqm::ContainerProf1D _cEtCutEmulvsLS_TTSubdet;	// online only!
-		hcaldqm::ContainerProf1D _cEtCutDatavsBX_TTSubdet;	// online only!
-		hcaldqm::ContainerProf1D _cEtCutEmulvsBX_TTSubdet;	// online only!
+  //	Et/FG
+  hcaldqm::Container1D _cEtData_TTSubdet;
+  hcaldqm::Container1D _cEtEmul_TTSubdet;
+  hcaldqm::Container2D _cEtCorr_TTSubdet;
+  hcaldqm::Container2D _cEtCorr2x3_TTSubdet;  //	online only
+  hcaldqm::Container2D _cFGCorr_TTSubdet[hcaldqm::constants::NUM_FGBITS];
+  hcaldqm::ContainerProf1D _cEtCutDatavsLS_TTSubdet;  // online only!
+  hcaldqm::ContainerProf1D _cEtCutEmulvsLS_TTSubdet;  // online only!
+  hcaldqm::ContainerProf1D _cEtCutDatavsBX_TTSubdet;  // online only!
+  hcaldqm::ContainerProf1D _cEtCutEmulvsBX_TTSubdet;  // online only!
 
-		hcaldqm::ContainerProf2D _cEtData_ElectronicsVME;
-		hcaldqm::ContainerProf2D _cEtData_ElectronicsuTCA;
-		hcaldqm::ContainerProf2D _cEtEmul_ElectronicsVME;
-		hcaldqm::ContainerProf2D _cEtEmul_ElectronicsuTCA;
+  hcaldqm::ContainerProf2D _cEtData_ElectronicsVME;
+  hcaldqm::ContainerProf2D _cEtData_ElectronicsuTCA;
+  hcaldqm::ContainerProf2D _cEtEmul_ElectronicsVME;
+  hcaldqm::ContainerProf2D _cEtEmul_ElectronicsuTCA;
 
-		//	depth like
-		hcaldqm::ContainerSingleProf2D _cEtData_depthlike;
-		hcaldqm::ContainerSingleProf2D _cEtEmul_depthlike;
-		hcaldqm::ContainerSingleProf2D _cEtCutData_depthlike;
-		hcaldqm::ContainerSingleProf2D _cEtCutEmul_depthlike;
+  //	depth like
+  hcaldqm::ContainerSingleProf2D _cEtData_depthlike;
+  hcaldqm::ContainerSingleProf2D _cEtEmul_depthlike;
+  hcaldqm::ContainerSingleProf2D _cEtCutData_depthlike;
+  hcaldqm::ContainerSingleProf2D _cEtCutEmul_depthlike;
 
-		//	Et Correlation Ratio
-		hcaldqm::ContainerProf2D _cEtCorrRatio_ElectronicsVME;
-		hcaldqm::ContainerProf2D _cEtCorrRatio_ElectronicsuTCA;
-		hcaldqm::ContainerSingleProf2D _cEtCorrRatio_depthlike;
-		hcaldqm::ContainerProf1D _cEtCorrRatiovsLS_TTSubdet;	// online only!
-		hcaldqm::ContainerProf1D _cEtCorrRatiovsBX_TTSubdet; // online only!
+  //	Et Correlation Ratio
+  hcaldqm::ContainerProf2D _cEtCorrRatio_ElectronicsVME;
+  hcaldqm::ContainerProf2D _cEtCorrRatio_ElectronicsuTCA;
+  hcaldqm::ContainerSingleProf2D _cEtCorrRatio_depthlike;
+  hcaldqm::ContainerProf1D _cEtCorrRatiovsLS_TTSubdet;  // online only!
+  hcaldqm::ContainerProf1D _cEtCorrRatiovsBX_TTSubdet;  // online only!
 
-		//	Occupancies
-		hcaldqm::Container2D _cOccupancyData_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyData_ElectronicsuTCA;
-		hcaldqm::Container2D _cOccupancyEmul_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyEmul_ElectronicsuTCA;
-		
-		hcaldqm::Container2D _cOccupancyCutData_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyCutData_ElectronicsuTCA;
-		hcaldqm::Container2D _cOccupancyCutEmul_ElectronicsVME;
-		hcaldqm::Container2D _cOccupancyCutEmul_ElectronicsuTCA;
+  //	Occupancies
+  hcaldqm::Container2D _cOccupancyData_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyData_ElectronicsuTCA;
+  hcaldqm::Container2D _cOccupancyEmul_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyEmul_ElectronicsuTCA;
 
-		//	depth like
-		hcaldqm::ContainerSingle2D _cOccupancyData_depthlike;
-		hcaldqm::ContainerSingle2D _cOccupancyEmul_depthlike;
-		hcaldqm::ContainerSingle2D _cOccupancyCutData_depthlike;
-		hcaldqm::ContainerSingle2D _cOccupancyCutEmul_depthlike;
+  hcaldqm::Container2D _cOccupancyCutData_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyCutData_ElectronicsuTCA;
+  hcaldqm::Container2D _cOccupancyCutEmul_ElectronicsVME;
+  hcaldqm::Container2D _cOccupancyCutEmul_ElectronicsuTCA;
 
-		//	2x3 occupancies just in case
-		hcaldqm::ContainerSingle2D _cOccupancyData2x3_depthlike;	// online only!
-		hcaldqm::ContainerSingle2D _cOccupancyEmul2x3_depthlike; // online only!
+  //	depth like
+  hcaldqm::ContainerSingle2D _cOccupancyData_depthlike;
+  hcaldqm::ContainerSingle2D _cOccupancyEmul_depthlike;
+  hcaldqm::ContainerSingle2D _cOccupancyCutData_depthlike;
+  hcaldqm::ContainerSingle2D _cOccupancyCutEmul_depthlike;
 
-		//	Mismatches: Et and FG
-		hcaldqm::Container2D _cEtMsm_ElectronicsVME;
-		hcaldqm::Container2D _cEtMsm_ElectronicsuTCA;
-		hcaldqm::Container2D _cFGMsm_ElectronicsVME;
-		hcaldqm::Container2D _cFGMsm_ElectronicsuTCA;
-		hcaldqm::ContainerSingle2D _cEtMsm_depthlike;
-		hcaldqm::ContainerSingle2D _cFGMsm_depthlike;
-		hcaldqm::ContainerProf1D _cEtMsmvsLS_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cEtMsmRatiovsLS_TTSubdet; // online only
-		hcaldqm::ContainerProf1D _cEtMsmvsBX_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cEtMsmRatiovsBX_TTSubdet; // online only
+  //	2x3 occupancies just in case
+  hcaldqm::ContainerSingle2D _cOccupancyData2x3_depthlike;  // online only!
+  hcaldqm::ContainerSingle2D _cOccupancyEmul2x3_depthlike;  // online only!
 
-		// Mismatches: data sent vs received
-		hcaldqm::ContainerSingle2D _cEtMsm_uHTR_L1T_depthlike;
-		hcaldqm::ContainerSingle1D _cEtMsm_uHTR_L1T_LS;
+  //	Mismatches: Et and FG
+  hcaldqm::Container2D _cEtMsm_ElectronicsVME;
+  hcaldqm::Container2D _cEtMsm_ElectronicsuTCA;
+  hcaldqm::Container2D _cFGMsm_ElectronicsVME;
+  hcaldqm::Container2D _cFGMsm_ElectronicsuTCA;
+  hcaldqm::ContainerSingle2D _cEtMsm_depthlike;
+  hcaldqm::ContainerSingle2D _cFGMsm_depthlike;
+  hcaldqm::ContainerProf1D _cEtMsmvsLS_TTSubdet;       // online only
+  hcaldqm::ContainerProf1D _cEtMsmRatiovsLS_TTSubdet;  // online only
+  hcaldqm::ContainerProf1D _cEtMsmvsBX_TTSubdet;       // online only
+  hcaldqm::ContainerProf1D _cEtMsmRatiovsBX_TTSubdet;  // online only
 
-		//	Missing Data w.r.t. Emulator
-		hcaldqm::Container2D _cMsnData_ElectronicsVME;
-		hcaldqm::Container2D _cMsnData_ElectronicsuTCA;
-		hcaldqm::ContainerSingle2D _cMsnData_depthlike;
-		hcaldqm::ContainerProf1D _cMsnDatavsLS_TTSubdet;	//	online only
-		hcaldqm::ContainerProf1D _cMsnCutDatavsLS_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cMsnDatavsBX_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cMsnCutDatavsBX_TTSubdet; // online only
+  // Mismatches: data sent vs received
+  hcaldqm::ContainerSingle2D _cEtMsm_uHTR_L1T_depthlike;
+  hcaldqm::ContainerSingle1D _cEtMsm_uHTR_L1T_LS;
 
-		//	Missing Emulator w.r.t. Data
-		hcaldqm::Container2D _cMsnEmul_ElectronicsVME;
-		hcaldqm::Container2D _cMsnEmul_ElectronicsuTCA;
-		hcaldqm::ContainerSingle2D _cMsnEmul_depthlike;
-		hcaldqm::ContainerProf1D _cMsnEmulvsLS_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cMsnCutEmulvsLS_TTSubdet; //	online only
-		hcaldqm::ContainerProf1D _cMsnEmulvsBX_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cMsnCutEmulvsBX_TTSubdet; // online only
+  //	Missing Data w.r.t. Emulator
+  hcaldqm::Container2D _cMsnData_ElectronicsVME;
+  hcaldqm::Container2D _cMsnData_ElectronicsuTCA;
+  hcaldqm::ContainerSingle2D _cMsnData_depthlike;
+  hcaldqm::ContainerProf1D _cMsnDatavsLS_TTSubdet;     //	online only
+  hcaldqm::ContainerProf1D _cMsnCutDatavsLS_TTSubdet;  // online only
+  hcaldqm::ContainerProf1D _cMsnDatavsBX_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cMsnCutDatavsBX_TTSubdet;  // online only
 
-		//	Occupancy vs BX and LS
-		hcaldqm::ContainerProf1D _cOccupancyDatavsBX_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyEmulvsBX_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyCutDatavsBX_TTSubdet; // online only
-		hcaldqm::ContainerProf1D _cOccupancyCutEmulvsBX_TTSubdet; // online only
-		hcaldqm::ContainerProf1D _cOccupancyDatavsLS_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyEmulvsLS_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyCutDatavsLS_TTSubdet;	// online only
-		hcaldqm::ContainerProf1D _cOccupancyCutEmulvsLS_TTSubdet; // online only
+  //	Missing Emulator w.r.t. Data
+  hcaldqm::Container2D _cMsnEmul_ElectronicsVME;
+  hcaldqm::Container2D _cMsnEmul_ElectronicsuTCA;
+  hcaldqm::ContainerSingle2D _cMsnEmul_depthlike;
+  hcaldqm::ContainerProf1D _cMsnEmulvsLS_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cMsnCutEmulvsLS_TTSubdet;  //	online only
+  hcaldqm::ContainerProf1D _cMsnEmulvsBX_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cMsnCutEmulvsBX_TTSubdet;  // online only
 
-		//	track unknown ids
-		MonitorElement *meUnknownIds1LS;
-		bool _unknownIdsPresent;
+  //	Occupancy vs BX and LS
+  hcaldqm::ContainerProf1D _cOccupancyDatavsBX_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cOccupancyEmulvsBX_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutDatavsBX_TTSubdet;  // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutEmulvsBX_TTSubdet;  // online only
+  hcaldqm::ContainerProf1D _cOccupancyDatavsLS_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cOccupancyEmulvsLS_TTSubdet;     // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutDatavsLS_TTSubdet;  // online only
+  hcaldqm::ContainerProf1D _cOccupancyCutEmulvsLS_TTSubdet;  // online only
 
-		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
-		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only
-		hcaldqm::ContainerXXX<uint32_t> _xEtMsm, _xFGMsm, _xNumCorr,
-			_xDataMsn, _xDataTotal, _xEmulMsn, _xEmulTotal, _xSentRecL1Msm;
+  //	track unknown ids
+  MonitorElement *meUnknownIds1LS;
+  bool _unknownIdsPresent;
 
-		// Temporary storage for occupancy with and without HF TDC cut
-		hcaldqm::ContainerSingle2D _cOccupancy_HF_depth, _cOccupancyNoTDC_HF_depth;
-		hcaldqm::ContainerSingle1D _cOccupancy_HF_ieta, _cOccupancyNoTDC_HF_ieta;
+  hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
+  hcaldqm::ContainerXXX<uint32_t> _xEtMsm, _xFGMsm, _xNumCorr, _xDataMsn, _xDataTotal, _xEmulMsn, _xEmulTotal,
+      _xSentRecL1Msm;
 
-		// Container storing matched sent-received TPs
-		std::vector<std::pair<HcalTriggerPrimitiveDigi, HcalTriggerPrimitiveDigi> > _vTPDigis_SentRec;
+  // Temporary storage for occupancy with and without HF TDC cut
+  hcaldqm::ContainerSingle2D _cOccupancy_HF_depth, _cOccupancyNoTDC_HF_depth;
+  hcaldqm::ContainerSingle1D _cOccupancy_HF_ieta, _cOccupancyNoTDC_HF_ieta;
 
+  // Container storing matched sent-received TPs
+  std::vector<std::pair<HcalTriggerPrimitiveDigi, HcalTriggerPrimitiveDigi> > _vTPDigis_SentRec;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/UMNioTask.h
+++ b/DQM/HcalTasks/interface/UMNioTask.h
@@ -20,56 +20,50 @@
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
 #include "FWCore/Framework/interface/Run.h"
 
-class UMNioTask : public hcaldqm::DQTask
-{
-	public:
-		UMNioTask(edm::ParameterSet const&);
-		~UMNioTask() override
-		{}
+class UMNioTask : public hcaldqm::DQTask {
+public:
+  UMNioTask(edm::ParameterSet const&);
+  ~UMNioTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
-		void endRun(edm::Run const& r, edm::EventSetup const&) override
-		{
-			if (_ptype==hcaldqm::fLocal)
-			{
-				if (r.runAuxiliary().run()==1)
-					return;
-			}
-		}
-		void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const& r, edm::EventSetup const&) override {
+    if (_ptype == hcaldqm::fLocal) {
+      if (r.runAuxiliary().run() == 1)
+        return;
+    }
+  }
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-	protected:
-		//	funcs
-		void _process(edm::Event const&, edm::EventSetup const&) override;
+protected:
+  //	funcs
+  void _process(edm::Event const&, edm::EventSetup const&) override;
 
-		// Get index of a particular OrbitGapType in the vector, which is used as the value for filling the histogram
-		int getOrbitGapIndex(uint8_t eventType, uint32_t laserType);
+  // Get index of a particular OrbitGapType in the vector, which is used as the value for filling the histogram
+  int getOrbitGapIndex(uint8_t eventType, uint32_t laserType);
 
-		std::vector<uint32_t> _eventtypes;
+  std::vector<uint32_t> _eventtypes;
 
-		//	tags and tokens
-		edm::InputTag	_taguMN;
-		edm::InputTag   _tagHBHE;
-		edm::InputTag   _tagHO;
-		edm::InputTag   _tagHF;
-		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<HODigiCollection> _tokHO;
-		edm::EDGetTokenT<HFDigiCollection> _tokHF;
-		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
+  //	tags and tokens
+  edm::InputTag _taguMN;
+  edm::InputTag _tagHBHE;
+  edm::InputTag _tagHO;
+  edm::InputTag _tagHF;
+  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+  edm::EDGetTokenT<HODigiCollection> _tokHO;
+  edm::EDGetTokenT<HFDigiCollection> _tokHF;
+  edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
-		//	cuts
-		double _lowHBHE, _lowHO, _lowHF;
+  //	cuts
+  double _lowHBHE, _lowHO, _lowHF;
 
-		//	emap
-		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
-		hcaldqm::filter::HashFilter _filter_uTCA;
-		hcaldqm::filter::HashFilter _filter_VME;
+  //	emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
+  hcaldqm::filter::HashFilter _filter_uTCA;
+  hcaldqm::filter::HashFilter _filter_VME;
 
-		//	1D
-		hcaldqm::ContainerSingle2D		_cEventType;
-		hcaldqm::ContainerSingle2D		_cTotalCharge;
-		hcaldqm::ContainerSingleProf2D		_cTotalChargeProfile;
+  //	1D
+  hcaldqm::ContainerSingle2D _cEventType;
+  hcaldqm::ContainerSingle2D _cTotalCharge;
+  hcaldqm::ContainerSingleProf2D _cTotalChargeProfile;
 };
 #endif

--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -10,29 +10,23 @@
 
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class ZDCQIE10Task : public DQMEDAnalyzer
-{
-	public:
-		ZDCQIE10Task(edm::ParameterSet const&);
-		~ZDCQIE10Task() override{}
+class ZDCQIE10Task : public DQMEDAnalyzer {
+public:
+  ZDCQIE10Task(edm::ParameterSet const&);
+  ~ZDCQIE10Task() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-		edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
-	protected:
-		void analyze(edm::Event const&, edm::EventSetup const&) override;
+protected:
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
-		//	tags
-		edm::InputTag	_tagQIE10;
-		edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
+  //	tags
+  edm::InputTag _tagQIE10;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
 
-		//	hcaldqm::Containers
-		std::map<uint32_t,MonitorElement*>   _cADC_EChannel;
-		std::map<uint32_t,MonitorElement*>   _cADC_vs_TS_EChannel;
-
+  //	hcaldqm::Containers
+  std::map<uint32_t, MonitorElement*> _cADC_EChannel;
+  std::map<uint32_t, MonitorElement*> _cADC_vs_TS_EChannel;
 };
 
 #endif
-
-
-

--- a/DQM/HcalTasks/interface/ZDCTask.h
+++ b/DQM/HcalTasks/interface/ZDCTask.h
@@ -19,40 +19,33 @@
 #include "DQM/HcalCommon/interface/HashFilter.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
 
-class ZDCTask : public DQMEDAnalyzer
-{
-	public:
-		ZDCTask(edm::ParameterSet const&);
-		~ZDCTask() override{}
+class ZDCTask : public DQMEDAnalyzer {
+public:
+  ZDCTask(edm::ParameterSet const&);
+  ~ZDCTask() override {}
 
-		void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
-	protected:
-		void analyze(edm::Event const&, edm::EventSetup const&) override;
+protected:
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
-		//	tags
-		edm::InputTag	_tagQIE10;
-		edm::EDGetTokenT<ZDCDigiCollection> _tokQIE10;
+  //	tags
+  edm::InputTag _tagQIE10;
+  edm::EDGetTokenT<ZDCDigiCollection> _tokQIE10;
 
-		//	cuts/constants from input
-		double _cut;
-		int _ped;
+  //	cuts/constants from input
+  double _cut;
+  int _ped;
 
-		
-		//	hcaldqm::Containers
-		std::map<std::string,MonitorElement*>   _cShape_EChannel;
-		std::map<std::string,MonitorElement*>   _cADC_EChannel;
-		std::map<std::string,MonitorElement*>   _cADC_vs_TS_EChannel;
+  //	hcaldqm::Containers
+  std::map<std::string, MonitorElement*> _cShape_EChannel;
+  std::map<std::string, MonitorElement*> _cADC_EChannel;
+  std::map<std::string, MonitorElement*> _cADC_vs_TS_EChannel;
 
-
-		//	hcaldqm::Containers overall
-		MonitorElement*   _cShape;
-		MonitorElement*   _cADC;
-		MonitorElement*   _cADC_vs_TS;
+  //	hcaldqm::Containers overall
+  MonitorElement* _cShape;
+  MonitorElement* _cADC;
+  MonitorElement* _cADC_vs_TS;
 };
 
 #endif
-
-
-

--- a/DQM/HcalTasks/plugins/DigiComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/DigiComparisonTask.cc
@@ -4,228 +4,216 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 
-DigiComparisonTask::DigiComparisonTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	//	tags and tokens
-	_tagHBHE1 = ps.getUntrackedParameter<edm::InputTag>("tagHBHE1",
-		edm::InputTag("hcalDigis"));
-	_tagHBHE2 = ps.getUntrackedParameter<edm::InputTag>("tagHBHE2",
-		edm::InputTag("vmeDigis"));
-	_tokHBHE1 = consumes<HBHEDigiCollection>(_tagHBHE1);
-	_tokHBHE2 = consumes<HBHEDigiCollection>(_tagHBHE2);
+DigiComparisonTask::DigiComparisonTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  //	tags and tokens
+  _tagHBHE1 = ps.getUntrackedParameter<edm::InputTag>("tagHBHE1", edm::InputTag("hcalDigis"));
+  _tagHBHE2 = ps.getUntrackedParameter<edm::InputTag>("tagHBHE2", edm::InputTag("vmeDigis"));
+  _tokHBHE1 = consumes<HBHEDigiCollection>(_tagHBHE1);
+  _tokHBHE2 = consumes<HBHEDigiCollection>(_tagHBHE2);
 }
-/* virtual */ void DigiComparisonTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib, r, es);
+/* virtual */ void DigiComparisonTask::bookHistograms(DQMStore::IBooker& ib,
+                                                      edm::Run const& r,
+                                                      edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	edm::ESHandle<HcalElectronicsMap> item;
-	es.get<HcalElectronicsMapRcd>().get("full", item);
-	_emap = item.product();
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = utilities::getFEDuTCAList(_emap);
-	}
-	std::vector<uint32_t> vhashVME;
-	std::vector<uint32_t> vhashuTCA;
-	vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hashfunctions::fElectronics,
-		vhashVME);
-	_filter_uTCA.initialize(filter::fFilter, hashfunctions::fElectronics,
-		vhashuTCA);
-	
-	//	INITIALIZE
-	for  (unsigned int i=0; i<10; i++)
-	{
-		_cADC_Subdet[i].initialize(_name, "ADC",
-			hashfunctions::fSubdet,
-			new quantity::ValueQuantity(quantity::fADCCorr_128),
-			new quantity::ValueQuantity(quantity::fADCCorr_128),
-			new quantity::ValueQuantity(quantity::fN, true),0);
-	}
-	_cADCall_Subdet.initialize(_name, "ADC",
-		hashfunctions::fSubdet,
-		new quantity::ValueQuantity(quantity::fADCCorr_128),
-		new quantity::ValueQuantity(quantity::fADCCorr_128),
-		new quantity::ValueQuantity(quantity::fN, true),0);
-	_cADCMsnuTCA_Subdet.initialize(_name, "ADCMsnuTCA",
-		hashfunctions::fSubdet,
-		new quantity::ValueQuantity(quantity::fADC_128),
-		new quantity::ValueQuantity(quantity::fN, true),0);
-	_cADCMsnVME_Subdet.initialize(_name, "ADCMsnVME",
-		hashfunctions::fSubdet,
-		new quantity::ValueQuantity(quantity::fADC_128),
-		new quantity::ValueQuantity(quantity::fN, true),0);
-	_cMsm_depth.initialize(_name, "Mismatched",
-		hashfunctions::fdepth,
-		new quantity::DetectorQuantity(quantity::fieta),
-		new quantity::DetectorQuantity(quantity::fiphi),
-		new quantity::ValueQuantity(quantity::fN),0);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMsm_FEDVME.initialize(_name, "Mismatched",
-			hashfunctions::fFED,
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ElectronicsQuantity(quantity::fFiberVMEFiberCh),
-			new quantity::ValueQuantity(quantity::fN),0);
-		_cMsm_FEDuTCA.initialize(_name, "Mismatched",
-			hashfunctions::fFED,
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
-			new quantity::ValueQuantity(quantity::fN),0);
-	}
-	_cMsnVME_depth.initialize(_name, "Missing",
-		hashfunctions::fdepth,
-		new quantity::DetectorQuantity(quantity::fieta),
-		new quantity::DetectorQuantity(quantity::fiphi),
-		new quantity::ValueQuantity(quantity::fN),0);
-	_cMsnuTCA_depth.initialize(_name, "Missing",
-		hashfunctions::fdepth,
-		new quantity::DetectorQuantity(quantity::fieta),
-		new quantity::DetectorQuantity(quantity::fiphi),
-		new quantity::ValueQuantity(quantity::fN),0);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMsn_FEDVME.initialize(_name, "Missing",
-			hashfunctions::fFED,
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ElectronicsQuantity(quantity::fFiberVMEFiberCh),
-			new quantity::ValueQuantity(quantity::fN),0);
-		_cMsn_FEDuTCA.initialize(_name, "Missing",
-			hashfunctions::fFED,
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
-			new quantity::ValueQuantity(quantity::fN),0);
-	}
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  edm::ESHandle<HcalElectronicsMap> item;
+  es.get<HcalElectronicsMapRcd>().get("full", item);
+  _emap = item.product();
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = utilities::getFEDuTCAList(_emap);
+  }
+  std::vector<uint32_t> vhashVME;
+  std::vector<uint32_t> vhashuTCA;
+  vhashVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hashfunctions::fElectronics, vhashVME);
+  _filter_uTCA.initialize(filter::fFilter, hashfunctions::fElectronics, vhashuTCA);
 
-	//	BOOK
-	char aux[20];
-	for (unsigned int i=0; i<10; i++)
-	{
-		sprintf(aux, "TS%d", i);
-		_cADC_Subdet[i].book(ib, _emap, _subsystem, aux);
-	}
-	_cADCall_Subdet.book(ib, _emap, _subsystem);
-	_cADCMsnVME_Subdet.book(ib, _emap, _subsystem);
-	_cADCMsnuTCA_Subdet.book(ib, _emap, _subsystem);
-	_cMsm_depth.book(ib, _emap, _subsystem);
-	_cMsnVME_depth.book(ib, _emap, _subsystem, std::string("VME"));
-	_cMsnuTCA_depth.book(ib, _emap, _subsystem, std::string("uTCA"));
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMsm_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMsn_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMsm_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMsn_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
+  //	INITIALIZE
+  for (unsigned int i = 0; i < 10; i++) {
+    _cADC_Subdet[i].initialize(_name,
+                               "ADC",
+                               hashfunctions::fSubdet,
+                               new quantity::ValueQuantity(quantity::fADCCorr_128),
+                               new quantity::ValueQuantity(quantity::fADCCorr_128),
+                               new quantity::ValueQuantity(quantity::fN, true),
+                               0);
+  }
+  _cADCall_Subdet.initialize(_name,
+                             "ADC",
+                             hashfunctions::fSubdet,
+                             new quantity::ValueQuantity(quantity::fADCCorr_128),
+                             new quantity::ValueQuantity(quantity::fADCCorr_128),
+                             new quantity::ValueQuantity(quantity::fN, true),
+                             0);
+  _cADCMsnuTCA_Subdet.initialize(_name,
+                                 "ADCMsnuTCA",
+                                 hashfunctions::fSubdet,
+                                 new quantity::ValueQuantity(quantity::fADC_128),
+                                 new quantity::ValueQuantity(quantity::fN, true),
+                                 0);
+  _cADCMsnVME_Subdet.initialize(_name,
+                                "ADCMsnVME",
+                                hashfunctions::fSubdet,
+                                new quantity::ValueQuantity(quantity::fADC_128),
+                                new quantity::ValueQuantity(quantity::fN, true),
+                                0);
+  _cMsm_depth.initialize(_name,
+                         "Mismatched",
+                         hashfunctions::fdepth,
+                         new quantity::DetectorQuantity(quantity::fieta),
+                         new quantity::DetectorQuantity(quantity::fiphi),
+                         new quantity::ValueQuantity(quantity::fN),
+                         0);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMsm_FEDVME.initialize(_name,
+                            "Mismatched",
+                            hashfunctions::fFED,
+                            new quantity::ElectronicsQuantity(quantity::fSpigot),
+                            new quantity::ElectronicsQuantity(quantity::fFiberVMEFiberCh),
+                            new quantity::ValueQuantity(quantity::fN),
+                            0);
+    _cMsm_FEDuTCA.initialize(_name,
+                             "Mismatched",
+                             hashfunctions::fFED,
+                             new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                             new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
+                             new quantity::ValueQuantity(quantity::fN),
+                             0);
+  }
+  _cMsnVME_depth.initialize(_name,
+                            "Missing",
+                            hashfunctions::fdepth,
+                            new quantity::DetectorQuantity(quantity::fieta),
+                            new quantity::DetectorQuantity(quantity::fiphi),
+                            new quantity::ValueQuantity(quantity::fN),
+                            0);
+  _cMsnuTCA_depth.initialize(_name,
+                             "Missing",
+                             hashfunctions::fdepth,
+                             new quantity::DetectorQuantity(quantity::fieta),
+                             new quantity::DetectorQuantity(quantity::fiphi),
+                             new quantity::ValueQuantity(quantity::fN),
+                             0);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMsn_FEDVME.initialize(_name,
+                            "Missing",
+                            hashfunctions::fFED,
+                            new quantity::ElectronicsQuantity(quantity::fSpigot),
+                            new quantity::ElectronicsQuantity(quantity::fFiberVMEFiberCh),
+                            new quantity::ValueQuantity(quantity::fN),
+                            0);
+    _cMsn_FEDuTCA.initialize(_name,
+                             "Missing",
+                             hashfunctions::fFED,
+                             new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                             new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
+                             new quantity::ValueQuantity(quantity::fN),
+                             0);
+  }
 
-	_ehashmapuTCA.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap,
-		_filter_VME);
-	_ehashmapVME.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap,
-		_filter_uTCA);
-}
+  //	BOOK
+  char aux[20];
+  for (unsigned int i = 0; i < 10; i++) {
+    sprintf(aux, "TS%d", i);
+    _cADC_Subdet[i].book(ib, _emap, _subsystem, aux);
+  }
+  _cADCall_Subdet.book(ib, _emap, _subsystem);
+  _cADCMsnVME_Subdet.book(ib, _emap, _subsystem);
+  _cADCMsnuTCA_Subdet.book(ib, _emap, _subsystem);
+  _cMsm_depth.book(ib, _emap, _subsystem);
+  _cMsnVME_depth.book(ib, _emap, _subsystem, std::string("VME"));
+  _cMsnuTCA_depth.book(ib, _emap, _subsystem, std::string("uTCA"));
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMsm_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMsn_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMsm_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMsn_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
 
-/* virtual */ void DigiComparisonTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
-}
-
-/* virtual */ void DigiComparisonTask::_process(edm::Event const& e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HBHEDigiCollection>	chbhe1;
-	edm::Handle<HBHEDigiCollection>	chbhe2;
-	
-	if (!e.getByToken(_tokHBHE1, chbhe1))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
-			+ _tagHBHE1.label() + " " + _tagHBHE1.instance());
-	if (!e.getByToken(_tokHBHE2, chbhe2))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
-			+ _tagHBHE2.label() + " " + _tagHBHE2.instance());
-
-	//	assume that coll1 is primary(uTCA) and coll2 is secondary(VME)
-	//	uTCA is X and VME is Y axis
-	for (HBHEDigiCollection::const_iterator it1=chbhe1->begin();
-		it1!=chbhe1->end(); ++it1)
-	{
-		//	iterate thru the utca collection
-		//	get the same detid digi from vme collection
-		//	if missing - fill vme missing
-		//	else correlate
-		HcalDetId did = it1->id();
-		HcalElectronicsId eid1 = it1->elecId();
-		HBHEDigiCollection::const_iterator it2 = chbhe2->find(did);
-
-		//	get the eid for vme by did
-		HcalElectronicsId eid2 = HcalElectronicsId(_ehashmapVME.lookup(did));
-		if (it2==chbhe2->end())
-		{
-			//	fill the depth plot
-			_cMsnVME_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cMsn_FEDVME.fill(eid2);
-			}
-			for (int i=0; i<it1->size(); i++)
-			{
-				_cADCMsnVME_Subdet.fill(did, it1->sample(i).adc());
-				_cADCall_Subdet.fill(did, it1->sample(i).adc(), -2);
-				_cADC_Subdet[i].fill(did, it1->sample(i).adc(), -2);
-			}
-		}
-		else
-			for (int i=0; i<it1->size(); i++)
-			{
-				_cADCall_Subdet.fill(did, double(it1->sample(i).adc()),
-					double(it2->sample(i).adc()));
-				_cADC_Subdet[i].fill(did, double(it1->sample(i).adc()),
-					double(it2->sample(i).adc()));
-				if (it1->sample(i).adc()!=it2->sample(i).adc())
-				{
-					//	fill depth, uTCA and VME as well for which guys
-					//	mismatches happen
-					_cMsm_depth.fill(did);
-					if (_ptype != fOffline) { // hidefed2crate
-						_cMsm_FEDVME.fill(eid2);
-						_cMsm_FEDuTCA.fill(eid1);
-					}
-				}
-			}
-	}
-	for (HBHEDigiCollection::const_iterator it2=chbhe2->begin();
-		it2!=chbhe2->end(); ++it2)
-	{
-		//	itearte thru VME 
-		//	find utca digi by detid
-		//	check if present or missing
-		HcalDetId did = it2->id();
-		HBHEDigiCollection::const_iterator it1 = chbhe1->find(did);
-		if (it1==chbhe1->end())
-		{
-			HcalElectronicsId eid1 = HcalElectronicsId(_ehashmapuTCA.lookup(did));
-			if (_ptype != fOffline) { // hidefed2crate
-				_cMsn_FEDuTCA.fill(eid1);
-			}
-			for (int i=0; i<it2->size(); i++)
-			{
-				_cADCMsnuTCA_Subdet.fill(did, it2->sample(i).adc());
-				_cADCall_Subdet.fill(did, -2, it2->sample(i).adc());
-				_cADC_Subdet[i].fill(did, -2, it2->sample(i).adc());
-			}
-		}
-	}
+  _ehashmapuTCA.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap, _filter_VME);
+  _ehashmapVME.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap, _filter_uTCA);
 }
 
-/* virtual */ void DigiComparisonTask::endLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	//	in the end always
-	DQTask::endLuminosityBlock(lb, es);
+/* virtual */ void DigiComparisonTask::_resetMonitors(hcaldqm::UpdateFreq uf) { DQTask::_resetMonitors(uf); }
+
+/* virtual */ void DigiComparisonTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HBHEDigiCollection> chbhe1;
+  edm::Handle<HBHEDigiCollection> chbhe2;
+
+  if (!e.getByToken(_tokHBHE1, chbhe1))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE1.label() + " " + _tagHBHE1.instance());
+  if (!e.getByToken(_tokHBHE2, chbhe2))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE2.label() + " " + _tagHBHE2.instance());
+
+  //	assume that coll1 is primary(uTCA) and coll2 is secondary(VME)
+  //	uTCA is X and VME is Y axis
+  for (HBHEDigiCollection::const_iterator it1 = chbhe1->begin(); it1 != chbhe1->end(); ++it1) {
+    //	iterate thru the utca collection
+    //	get the same detid digi from vme collection
+    //	if missing - fill vme missing
+    //	else correlate
+    HcalDetId did = it1->id();
+    HcalElectronicsId eid1 = it1->elecId();
+    HBHEDigiCollection::const_iterator it2 = chbhe2->find(did);
+
+    //	get the eid for vme by did
+    HcalElectronicsId eid2 = HcalElectronicsId(_ehashmapVME.lookup(did));
+    if (it2 == chbhe2->end()) {
+      //	fill the depth plot
+      _cMsnVME_depth.fill(did);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cMsn_FEDVME.fill(eid2);
+      }
+      for (int i = 0; i < it1->size(); i++) {
+        _cADCMsnVME_Subdet.fill(did, it1->sample(i).adc());
+        _cADCall_Subdet.fill(did, it1->sample(i).adc(), -2);
+        _cADC_Subdet[i].fill(did, it1->sample(i).adc(), -2);
+      }
+    } else
+      for (int i = 0; i < it1->size(); i++) {
+        _cADCall_Subdet.fill(did, double(it1->sample(i).adc()), double(it2->sample(i).adc()));
+        _cADC_Subdet[i].fill(did, double(it1->sample(i).adc()), double(it2->sample(i).adc()));
+        if (it1->sample(i).adc() != it2->sample(i).adc()) {
+          //	fill depth, uTCA and VME as well for which guys
+          //	mismatches happen
+          _cMsm_depth.fill(did);
+          if (_ptype != fOffline) {  // hidefed2crate
+            _cMsm_FEDVME.fill(eid2);
+            _cMsm_FEDuTCA.fill(eid1);
+          }
+        }
+      }
+  }
+  for (HBHEDigiCollection::const_iterator it2 = chbhe2->begin(); it2 != chbhe2->end(); ++it2) {
+    //	itearte thru VME
+    //	find utca digi by detid
+    //	check if present or missing
+    HcalDetId did = it2->id();
+    HBHEDigiCollection::const_iterator it1 = chbhe1->find(did);
+    if (it1 == chbhe1->end()) {
+      HcalElectronicsId eid1 = HcalElectronicsId(_ehashmapuTCA.lookup(did));
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cMsn_FEDuTCA.fill(eid1);
+      }
+      for (int i = 0; i < it2->size(); i++) {
+        _cADCMsnuTCA_Subdet.fill(did, it2->sample(i).adc());
+        _cADCall_Subdet.fill(did, -2, it2->sample(i).adc());
+        _cADC_Subdet[i].fill(did, -2, it2->sample(i).adc());
+      }
+    }
+  }
+}
+
+/* virtual */ void DigiComparisonTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  //	in the end always
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(DigiComparisonTask);
-

--- a/DQM/HcalTasks/plugins/DigiPhase1Task.cc
+++ b/DQM/HcalTasks/plugins/DigiPhase1Task.cc
@@ -4,671 +4,650 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
-DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
+DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
 
-	_tokHBHE = consumes<QIE11DigiCollection>(_tagHBHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokHBHE = consumes<QIE11DigiCollection>(_tagHBHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
 
-	_cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
-	_cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
-	_cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
-	_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
+  _cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
+  _cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
+  _cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
+  _thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
 
-	_vflags.resize(nDigiFlag);
-	_vflags[fUni]=hcaldqm::flag::Flag("UniSlotHF");
-	_vflags[fDigiSize]=hcaldqm::flag::Flag("DigiSize");
-	_vflags[fNChsHF]=hcaldqm::flag::Flag("NChsHF");
-	_vflags[fUnknownIds]=hcaldqm::flag::Flag("UnknownIds");
+  _vflags.resize(nDigiFlag);
+  _vflags[fUni] = hcaldqm::flag::Flag("UniSlotHF");
+  _vflags[fDigiSize] = hcaldqm::flag::Flag("DigiSize");
+  _vflags[fNChsHF] = hcaldqm::flag::Flag("NChsHF");
+  _vflags[fUnknownIds] = hcaldqm::flag::Flag("UnknownIds");
 }
 
-/* virtual */ void DigiPhase1Task::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib,r,es);
+/* virtual */ void DigiPhase1Task::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//  GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
-	std::vector<uint32_t> vVME;
-	std::vector<uint32_t> vuTCA;
-	vVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN, 
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vuTCA);
+  //  GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
+  std::vector<uint32_t> vVME;
+  std::vector<uint32_t> vuTCA;
+  vVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vuTCA);
 
-	//  INITIALIZE FIRST
-	_cADC_SubdetPM.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cfC_SubdetPM.initialize(_name, "fC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQ_SubdetPM.initialize(_name, "SumQ", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQ_depth.initialize(_name, "SumQ", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
-	_cSumQvsLS_SubdetPM.initialize(_name, "SumQvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
-	_cTimingCut_SubdetPM.initialize(_name, "TimingCut",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cTimingCut_depth.initialize(_name, "TimingCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
+  //  INITIALIZE FIRST
+  _cADC_SubdetPM.initialize(_name,
+                            "ADC",
+                            hcaldqm::hashfunctions::fSubdetPM,
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                            0);
+  _cfC_SubdetPM.initialize(_name,
+                           "fC",
+                           hcaldqm::hashfunctions::fSubdetPM,
+                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                           0);
+  _cSumQ_SubdetPM.initialize(_name,
+                             "SumQ",
+                             hcaldqm::hashfunctions::fSubdetPM,
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                             0);
+  _cSumQ_depth.initialize(_name,
+                          "SumQ",
+                          hcaldqm::hashfunctions::fdepth,
+                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                          0);
+  _cSumQvsLS_SubdetPM.initialize(_name,
+                                 "SumQvsLS",
+                                 hcaldqm::hashfunctions::fSubdetPM,
+                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                                 0);
+  _cTimingCut_SubdetPM.initialize(_name,
+                                  "TimingCut",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+  _cTimingCut_depth.initialize(_name,
+                               "TimingCut",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                               0);
 
-	//  Occupancy w/o a cut
-	_cOccupancyvsLS_Subdet.initialize(_name, "OccupancyvsLS",
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-	_cOccupancy_depth.initialize(_name, "Occupancy",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //  Occupancy w/o a cut
+  _cOccupancyvsLS_Subdet.initialize(_name,
+                                    "OccupancyvsLS",
+                                    hcaldqm::hashfunctions::fSubdet,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                    0);
+  _cOccupancy_depth.initialize(_name,
+                               "Occupancy",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
 
-	//  Occupancy w/ a cut
-	_cOccupancyCutvsLS_Subdet.initialize(_name, "OccupancyCutvsLS",
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-	_cOccupancyCut_depth.initialize(_name, "OccupancyCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //  Occupancy w/ a cut
+  _cOccupancyCutvsLS_Subdet.initialize(_name,
+                                       "OccupancyCutvsLS",
+                                       hcaldqm::hashfunctions::fSubdet,
+                                       new hcaldqm::quantity::LumiSection(_maxLS),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                       0);
+  _cOccupancyCut_depth.initialize(_name,
+                                  "OccupancyCut",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
 
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-	
-		std::vector<uint32_t> vFEDHF;
-		vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		//  initialize filters
-		_filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED,
-			vFEDHF);
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
 
-		//  push the rawIds of each fed into the vector...
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin(); it!=vFEDsVME.end(); ++it) {
-			_vhashFEDs.push_back(HcalElectronicsId(
-				constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN,
-				(*it)-FED_VME_MIN).rawId());
-		}
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin();
-			it!=vFEDsuTCA.end(); ++it)
-		{
-			std::pair<uint16_t, uint16_t> cspair = hcaldqm::utilities::fed2crate(*it);
-			_vhashFEDs.push_back(HcalElectronicsId(
-				cspair.first, cspair.second, FIBER_uTCA_MIN1,
-				FIBERCH_MIN, false).rawId());
-		}
-	
-		_cShapeCut_FED.initialize(_name, "Shape",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
-	
-		_cTimingCut_FEDVME.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCut_FEDuTCA.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCut_ElectronicsVME.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCut_ElectronicsuTCA.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCutvsLS_FED.initialize(_name, "TimingvsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	
-		_cOccupancy_FEDVME.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_FEDuTCA.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_ElectronicsVME.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_ElectronicsuTCA.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    std::vector<uint32_t> vFEDHF;
+    vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    //  initialize filters
+    _filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vFEDHF);
 
-		_cOccupancyCut_FEDVME.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_FEDuTCA.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_ElectronicsVME.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_ElectronicsuTCA.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    //  push the rawIds of each fed into the vector...
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it) {
+      _vhashFEDs.push_back(
+          HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+    }
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = hcaldqm::utilities::fed2crate(*it);
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
 
-		_cDigiSize_FED.initialize(_name, "DigiSize",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	
-	}
+    _cShapeCut_FED.initialize(_name,
+                              "Shape",
+                              hcaldqm::hashfunctions::fFED,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                              0);
 
+    _cTimingCut_FEDVME.initialize(_name,
+                                  "TimingCut",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                  0);
+    _cTimingCut_FEDuTCA.initialize(_name,
+                                   "TimingCut",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+    _cTimingCut_ElectronicsVME.initialize(_name,
+                                          "TimingCut",
+                                          hcaldqm::hashfunctions::fElectronics,
+                                          new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                          new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                          0);
+    _cTimingCut_ElectronicsuTCA.initialize(_name,
+                                           "TimingCut",
+                                           hcaldqm::hashfunctions::fElectronics,
+                                           new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                           new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                           0);
+    _cTimingCutvsLS_FED.initialize(_name,
+                                   "TimingvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
 
-	//  BOOK HISTOGRAMS
-	char cutstr[200];
-	sprintf(cutstr, "_SumQHBHE%dHO%dHF%d", int(_cutSumQ_HBHE),
-		int(_cutSumQ_HO), int(_cutSumQ_HF));
-	char cutstr2[200];
-	sprintf(cutstr2, "_SumQHF%d", int(_cutSumQ_HF));
+    _cOccupancy_FEDVME.initialize(_name,
+                                  "Occupancy",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+    _cOccupancy_FEDuTCA.initialize(_name,
+                                   "Occupancy",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cOccupancy_ElectronicsVME.initialize(_name,
+                                          "Occupancy",
+                                          hcaldqm::hashfunctions::fElectronics,
+                                          new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                          new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+    _cOccupancy_ElectronicsuTCA.initialize(_name,
+                                           "Occupancy",
+                                           hcaldqm::hashfunctions::fElectronics,
+                                           new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                           new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                           0);
 
-	_cADC_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyCut_FEDVME.initialize(_name,
+                                     "OccupancyCut",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+    _cOccupancyCut_FEDuTCA.initialize(_name,
+                                      "OccupancyCut",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cOccupancyCut_ElectronicsVME.initialize(_name,
+                                             "OccupancyCut",
+                                             hcaldqm::hashfunctions::fElectronics,
+                                             new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                             new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cOccupancyCut_ElectronicsuTCA.initialize(_name,
+                                              "OccupancyCut",
+                                              hcaldqm::hashfunctions::fElectronics,
+                                              new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                              0);
 
-	_cfC_SubdetPM.book(ib, _emap, _subsystem);
-	_cSumQ_SubdetPM.book(ib, _emap, _subsystem);
-	_cSumQ_depth.book(ib, _emap, _subsystem);
-	_cSumQvsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cDigiSize_FED.initialize(_name,
+                              "DigiSize",
+                              hcaldqm::hashfunctions::fFED,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                              0);
+  }
 
+  //  BOOK HISTOGRAMS
+  char cutstr[200];
+  sprintf(cutstr, "_SumQHBHE%dHO%dHF%d", int(_cutSumQ_HBHE), int(_cutSumQ_HO), int(_cutSumQ_HF));
+  char cutstr2[200];
+  sprintf(cutstr2, "_SumQHF%d", int(_cutSumQ_HF));
 
-	_cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
-	_cTimingCut_depth.book(ib, _emap, _subsystem);
+  _cADC_SubdetPM.book(ib, _emap, _subsystem);
 
-	_cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cOccupancy_depth.book(ib, _emap, _subsystem);
-	_cOccupancyCut_depth.book(ib, _emap, _subsystem);
+  _cfC_SubdetPM.book(ib, _emap, _subsystem);
+  _cSumQ_SubdetPM.book(ib, _emap, _subsystem);
+  _cSumQ_depth.book(ib, _emap, _subsystem);
+  _cSumQvsLS_SubdetPM.book(ib, _emap, _subsystem);
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_cShapeCut_FED.book(ib, _emap, _subsystem);
-		_cTimingCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingCutvsLS_FED.book(ib, _emap, _subsystem);
-		_cTimingCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancy_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancy_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancy_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancy_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cDigiSize_FED.book(ib, _emap, _subsystem);
-	}
+  _cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
+  _cTimingCut_depth.book(ib, _emap, _subsystem);
 
-	//  BOOK HISTOGRAMS that are only for Online
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
-	_dhashmap.initialize(_emap, electronicsmap::fE2DHashMap);
+  _cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cOccupancy_depth.book(ib, _emap, _subsystem);
+  _cOccupancyCut_depth.book(ib, _emap, _subsystem);
 
-		//      MARK THESE HISTOGRAMS AS LUMI BASED FOR OFFLINE PROCESSING
-		if (_ptype==fOffline)
-	  {
-		//_cDigiSize_FED.setLumiFlag(); // hidefed2crate : FED stuff not available offline anymore, so this histogram doesn't make sense?
-		_cOccupancy_depth.setLumiFlag();
-	  }
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cShapeCut_FED.book(ib, _emap, _subsystem);
+    _cTimingCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingCutvsLS_FED.book(ib, _emap, _subsystem);
+    _cTimingCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancy_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancy_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancy_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancy_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cDigiSize_FED.book(ib, _emap, _subsystem);
+  }
 
-		//      book Number of Events vs LS histogram                                                                                                                                     
-		ib.setCurrentFolder(_subsystem+"/RunInfo");
-		meNumEvents1LS = ib.book1D("NumberOfEvents", "NumberOfEvents",
-				   1, 0, 1);
-	meNumEvents1LS->setLumiFlag();
+  //  BOOK HISTOGRAMS that are only for Online
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+  _dhashmap.initialize(_emap, electronicsmap::fE2DHashMap);
 
-		//      book the flag for unknown ids and the online guy as well                                                                                                                  
-		ib.setCurrentFolder(_subsystem+"/"+_name);
-		meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds",
-					1, 0, 1);
-		_unknownIdsPresent = false;
-		meUnknownIds1LS->setLumiFlag();
+  //      MARK THESE HISTOGRAMS AS LUMI BASED FOR OFFLINE PROCESSING
+  if (_ptype == fOffline) {
+    //_cDigiSize_FED.setLumiFlag(); // hidefed2crate : FED stuff not available offline anymore, so this histogram doesn't make sense?
+    _cOccupancy_depth.setLumiFlag();
+  }
+
+  //      book Number of Events vs LS histogram
+  ib.setCurrentFolder(_subsystem + "/RunInfo");
+  meNumEvents1LS = ib.book1D("NumberOfEvents", "NumberOfEvents", 1, 0, 1);
+  meNumEvents1LS->setLumiFlag();
+
+  //      book the flag for unknown ids and the online guy as well
+  ib.setCurrentFolder(_subsystem + "/" + _name);
+  meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds", 1, 0, 1);
+  _unknownIdsPresent = false;
+  meUnknownIds1LS->setLumiFlag();
 }
 
-/* virtual */ void DigiPhase1Task::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void DigiPhase1Task::_resetMonitors(hcaldqm::UpdateFreq uf) {
+  DQTask::_resetMonitors(uf);
 
-	switch(uf)
-	{
-		case hcaldqm::f1LS:
-			_unknownIdsPresent = false;
-			break;
-		case hcaldqm::f50LS:
-			break;
-		default:
-			break;
-	}
+  switch (uf) {
+    case hcaldqm::f1LS:
+      _unknownIdsPresent = false;
+      break;
+    case hcaldqm::f50LS:
+      break;
+    default:
+      break;
+  }
 }
 
-/* virtual */ void DigiPhase1Task::_process(edm::Event const& e,
-	edm::EventSetup const&)
-{
-	edm::Handle<QIE11DigiCollection>     chbhe;
-	edm::Handle<HODigiCollection>        cho;
-	edm::Handle<QIE10DigiCollection>     chf;
+/* virtual */ void DigiPhase1Task::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<QIE11DigiCollection> chbhe;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<QIE10DigiCollection> chf;
 
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available"
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection HF QIE10Collection isn't available"
-			+ _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection HF QIE10Collection isn't available" + _tagHF.label() + " " + _tagHF.instance());
 
-	//  extract some info per event
-	meNumEvents1LS->Fill(0.5); // just increment
+  //  extract some info per event
+  meNumEvents1LS->Fill(0.5);  // just increment
 
-	//  To fill histograms outside of the loop, you need to determine if there were
-	//  any valid det ids first
-	uint32_t rawidValid = 0;
-	uint32_t rawidHBValid = 0;
-	uint32_t rawidHEValid = 0;
+  //  To fill histograms outside of the loop, you need to determine if there were
+  //  any valid det ids first
+  uint32_t rawidValid = 0;
+  uint32_t rawidHBValid = 0;
+  uint32_t rawidHEValid = 0;
 
-	//  HB collection
-	int numChs = 0;
-	int numChsCut = 0;
-	int numChsHE = 0;
-	int numChsCutHE = 0;
-	for (QIE11DigiCollection::const_iterator it=chbhe->begin(); it!=chbhe->end(); ++it) {
-		QIE11DataFrame const& frame = *it;
-		double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(frame, 2.5, 0, frame.samples()-1);
+  //  HB collection
+  int numChs = 0;
+  int numChsCut = 0;
+  int numChsHE = 0;
+  int numChsCutHE = 0;
+  for (QIE11DigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    QIE11DataFrame const& frame = *it;
+    double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(frame, 2.5, 0, frame.samples() - 1);
 
-		//  Explicit check on the DetIds present in the Collection
-		HcalDetId const& did = frame.detid();
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid==0) 
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalBarrel) {
-			rawidHBValid = did.rawId();
-		} else if (did.subdet()==HcalEndcap) {
-			rawidHEValid = did.rawId();
-		} else {
-			// Skip non-HB or HE detids
-			continue;
-		}
+    //  Explicit check on the DetIds present in the Collection
+    HcalDetId const& did = frame.detid();
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (did.subdet() == HcalBarrel) {
+      rawidHBValid = did.rawId();
+    } else if (did.subdet() == HcalEndcap) {
+      rawidHEValid = did.rawId();
+    } else {
+      // Skip non-HB or HE detids
+      continue;
+    }
 
-		//  filter out channels that are masked out
-		if (_xQuality.exists(did)) 
-		{
-			HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
+    //  filter out channels that are masked out
+    if (_xQuality.exists(did)) {
+      HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-		_cSumQ_SubdetPM.fill(did, sumQ);
-		_cOccupancy_depth.fill(did);
+    _cSumQ_SubdetPM.fill(did, sumQ);
+    _cOccupancy_depth.fill(did);
 
-		if (_ptype != fOffline) { // hidefed2crate
-			_cDigiSize_FED.fill(eid, frame.samples());
-		}
-		if (eid.isVMEid())
-		{
-			if (_ptype != fOffline) { // hidefed2crate
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-		}
-		else
-		{
-			if (_ptype != fOffline) { // hidefed2crate
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-			}
-			/*
+    if (_ptype != fOffline) {  // hidefed2crate
+      _cDigiSize_FED.fill(eid, frame.samples());
+    }
+    if (eid.isVMEid()) {
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      }
+    } else {
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+      }
+      /*
 			if (!it->validate(0, it->size()))
 			{
 				_cCapIdRots_depth.fill(did);
 				_cCapIdRots_FEDuTCA.fill(eid, 1);
 			}*/
-		}
+    }
 
-		for (int i=0; i<frame.samples(); i++)
-		{
-			_cADC_SubdetPM.fill(did, frame[i].adc());
-			_cfC_SubdetPM.fill(did,constants::adc2fC[frame[i].adc()]);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (sumQ>_cutSumQ_HBHE)
-					_cShapeCut_FED.fill(eid, i, constants::adc2fC[frame[i].adc()]);
-			}
-		}
+    for (int i = 0; i < frame.samples(); i++) {
+      _cADC_SubdetPM.fill(did, frame[i].adc());
+      _cfC_SubdetPM.fill(did, constants::adc2fC[frame[i].adc()]);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (sumQ > _cutSumQ_HBHE)
+          _cShapeCut_FED.fill(eid, i, constants::adc2fC[frame[i].adc()]);
+      }
+    }
 
-		if (sumQ>_cutSumQ_HBHE)
-		{
-			double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(frame, 2.5, 0, frame.samples()-1);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_depth.fill(did, timing);
-			_cOccupancyCut_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			_cSumQ_depth.fill(did, sumQ);
-			_cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+    if (sumQ > _cutSumQ_HBHE) {
+      double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(frame, 2.5, 0, frame.samples() - 1);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_depth.fill(did, timing);
+      _cOccupancyCut_depth.fill(did);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      _cSumQ_depth.fill(did, sumQ);
+      _cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
 
-			if (eid.isVMEid())
-			{
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-			}
-			else 
-			{
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			did.subdet()==HcalBarrel?numChsCut++:numChsCutHE++;
-		}
-		did.subdet()==HcalBarrel?numChs++:numChsHE++;
-	}
+      if (eid.isVMEid()) {
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        }
+      } else {
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      did.subdet() == HcalBarrel ? numChsCut++ : numChsCutHE++;
+    }
+    did.subdet() == HcalBarrel ? numChs++ : numChsHE++;
+  }
 
-	if (rawidHBValid!=0 && rawidHEValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, 
-			numChs);
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS,
-			numChsHE);
+  if (rawidHBValid != 0 && rawidHEValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChs);
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsHE);
+  }
+  numChs = 0;
+  numChsCut = 0;
 
-	}
-	numChs=0;
-	numChsCut = 0;
+  //  reset
+  rawidValid = 0;
 
-	//  reset
-	rawidValid = 0;
+  //  HO collection
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size() - 1);
 
-	//  HO collection
-	for (HODigiCollection::const_iterator it=cho->begin(); it!=cho->end();
-		++it)
-	{
-		double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size()-1);
+    //  Explicit check on the DetIds present in the Collection
+    HcalDetId const& did = it->id();
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (did.subdet() == HcalOuter)
+      rawidValid = did.rawId();
 
-		//  Explicit check on the DetIds present in the Collection
-		HcalDetId const& did = it->id();
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid==0) 
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalOuter)
-			rawidValid = did.rawId();
+    //  filter out channels that are masked out
+    if (_xQuality.exists(did)) {
+      HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-		//  filter out channels that are masked out
-		if (_xQuality.exists(did)) 
-		{
-			HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
-
-		_cSumQ_SubdetPM.fill(did, sumQ);
-		_cOccupancy_depth.fill(did);
-		if (_ptype != fOffline) { // hidefed2crate
-			_cDigiSize_FED.fill(eid, it->size());
-		}
-		if (eid.isVMEid())
-		{
-			if (_ptype != fOffline) { // hidefed2crate
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-			/*
+    _cSumQ_SubdetPM.fill(did, sumQ);
+    _cOccupancy_depth.fill(did);
+    if (_ptype != fOffline) {  // hidefed2crate
+      _cDigiSize_FED.fill(eid, it->size());
+    }
+    if (eid.isVMEid()) {
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      }
+      /*
 			if (!it->validate(0, it->size()))
 				_cCapIdRots_FEDVME.fill(eid, 1);
 				*/
-		}
-		else
-		{
-			if (_ptype != fOffline) { // hidefed2crate
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-			}
-			/*
+    } else {
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+      }
+      /*
 			if (!it->validate(0, it->size()))
 				_cCapIdRots_FEDuTCA.fill(eid, 1);*/
-		}
+    }
 
-		for (int i=0; i<it->size(); i++)
-		{
-			_cADC_SubdetPM.fill(did, it->sample(i).adc());
-			_cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
-			if (_ptype != fOffline) { // hidefed2crate
-				if (sumQ>_cutSumQ_HO)
-					_cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
-			}
-		}
+    for (int i = 0; i < it->size(); i++) {
+      _cADC_SubdetPM.fill(did, it->sample(i).adc());
+      _cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (sumQ > _cutSumQ_HO)
+          _cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
+      }
+    }
 
-		if (sumQ>_cutSumQ_HO)
-		{
-			double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0,
-				it->size()-1);
-			_cSumQ_depth.fill(did, sumQ);
-			_cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_depth.fill(did, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
+    if (sumQ > _cutSumQ_HO) {
+      double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0, it->size() - 1);
+      _cSumQ_depth.fill(did, sumQ);
+      _cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_depth.fill(did, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
 
-			if (eid.isVMEid())
-			{
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-			}
-			else 
-			{
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			numChsCut++;
-		}
-		numChs++;
-	}
+      if (eid.isVMEid()) {
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        }
+      } else {
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      numChsCut++;
+    }
+    numChs++;
+  }
 
-	if (rawidValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS,
-			numChs);
-	}
-	numChs=0; numChsCut=0;
+  if (rawidValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
+  }
+  numChs = 0;
+  numChsCut = 0;
 
-	//  reset
-	rawidValid = 0;
+  //  reset
+  rawidValid = 0;
 
-	//  HF collection
-	for (QIE10DigiCollection::const_iterator it=chf->begin(); it!=chf->end();
-		++it)
-	{
-			QIE10DataFrame frame = *it;
-			double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(frame, 
-									   2.5, 0, frame.samples()-1);
+  //  HF collection
+  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    QIE10DataFrame frame = *it;
+    double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(frame, 2.5, 0, frame.samples() - 1);
 
-		//  Explicit check on the DetIds present in the Collection
-		HcalDetId const& did = it->id();
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid==0) 
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalForward) {
-			rawidValid = did.rawId();
-		} else {
-			// Skip non-HF detids
-			continue;
-		}
+    //  Explicit check on the DetIds present in the Collection
+    HcalDetId const& did = it->id();
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (did.subdet() == HcalForward) {
+      rawidValid = did.rawId();
+    } else {
+      // Skip non-HF detids
+      continue;
+    }
 
-		//  filter out channels that are masked out
-		if (_xQuality.exists(did)) 
-		{
-			HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
+    //  filter out channels that are masked out
+    if (_xQuality.exists(did)) {
+      HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-		_cSumQ_SubdetPM.fill(did, sumQ);
-		_cOccupancy_depth.fill(did);
-		if (_ptype != fOffline) { // hidefed2crate
-			_cDigiSize_FED.fill(eid, frame.samples());
-		}
-		if (eid.isVMEid())
-		{
-			if (_ptype != fOffline) { // hidefed2crate
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-			/*
+    _cSumQ_SubdetPM.fill(did, sumQ);
+    _cOccupancy_depth.fill(did);
+    if (_ptype != fOffline) {  // hidefed2crate
+      _cDigiSize_FED.fill(eid, frame.samples());
+    }
+    if (eid.isVMEid()) {
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      }
+      /*
 			if (!it->validate(0, it->size()))
 				_cCapIdRots_FEDVME.fill(eid, 1);*/
-		}
-		else
-		{
-			if (_ptype != fOffline) { // hidefed2crate
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-			}
-			/*
+    } else {
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+      }
+      /*
 			if (!it->validate(0, it->size()))
 				_cCapIdRots_FEDuTCA.fill(eid, 1);*/
-		}
+    }
 
-		for (int i=0; i<frame.samples(); i++)
-		{
-			_cADC_SubdetPM.fill(did, frame[i].adc());
-			_cfC_SubdetPM.fill(did, constants::adc2fC[frame[i].adc()]);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (sumQ>_cutSumQ_HF)
-						_cShapeCut_FED.fill(eid, i, constants::adc2fC[frame[i].adc()]);
-			}
-		}
+    for (int i = 0; i < frame.samples(); i++) {
+      _cADC_SubdetPM.fill(did, frame[i].adc());
+      _cfC_SubdetPM.fill(did, constants::adc2fC[frame[i].adc()]);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (sumQ > _cutSumQ_HF)
+          _cShapeCut_FED.fill(eid, i, constants::adc2fC[frame[i].adc()]);
+      }
+    }
 
-		if (sumQ>_cutSumQ_HF)
-		{
-				double timing = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(frame, 2.5, 0,
-											  frame.samples()-1);
+    if (sumQ > _cutSumQ_HF) {
+      double timing = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(frame, 2.5, 0, frame.samples() - 1);
 
-			_cSumQ_depth.fill(did, sumQ);
-			_cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cSumQ_depth.fill(did, sumQ);
+      _cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
 
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_depth.fill(did, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			_cOccupancyCut_depth.fill(did);
-			if (eid.isVMEid())
-			{
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-			}
-			else 
-			{
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			numChsCut++;
-		}
-		numChs++;
-	}
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_depth.fill(did, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      _cOccupancyCut_depth.fill(did);
+      if (eid.isVMEid()) {
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        }
+      } else {
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      numChsCut++;
+    }
+    numChs++;
+  }
 
-	if (rawidValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, 
-			numChs);
-	
-	}
+  if (rawidValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
+  }
 }
 
-/* virtual */ void DigiPhase1Task::beginLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
+/* virtual */ void DigiPhase1Task::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void DigiPhase1Task::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	DQTask::endLuminosityBlock(lb, es);
+/* virtual */ void DigiPhase1Task::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(DigiPhase1Task);
-

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -4,1614 +4,1613 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
-DigiTask::DigiTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
+DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
 
-	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
+  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
 
-	_cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
-	_cutSumQ_HE = ps.getUntrackedParameter<double>("cutSumQ_HE", 20);
-	_cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
-	_cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
-	_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
-	_thresh_led = ps.getUntrackedParameter<double>("thresh_led", 20);
+  _cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
+  _cutSumQ_HE = ps.getUntrackedParameter<double>("cutSumQ_HE", 20);
+  _cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
+  _cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
+  _thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
+  _thresh_led = ps.getUntrackedParameter<double>("thresh_led", 20);
 
-	_vflags.resize(nDigiFlag);
-	_vflags[fUni]=hcaldqm::flag::Flag("UniSlotHF");
-	_vflags[fDigiSize]=hcaldqm::flag::Flag("DigiSize");
-	_vflags[fNChsHF]=hcaldqm::flag::Flag("NChsHF");
-	_vflags[fUnknownIds]=hcaldqm::flag::Flag("UnknownIds");
-	_vflags[fLED]=hcaldqm::flag::Flag("LEDMisfire");
-	_vflags[fCapId]=hcaldqm::flag::Flag("BadCapId");
+  _vflags.resize(nDigiFlag);
+  _vflags[fUni] = hcaldqm::flag::Flag("UniSlotHF");
+  _vflags[fDigiSize] = hcaldqm::flag::Flag("DigiSize");
+  _vflags[fNChsHF] = hcaldqm::flag::Flag("NChsHF");
+  _vflags[fUnknownIds] = hcaldqm::flag::Flag("UnknownIds");
+  _vflags[fLED] = hcaldqm::flag::Flag("LEDMisfire");
+  _vflags[fCapId] = hcaldqm::flag::Flag("BadCapId");
 
-	_qie10InConditions = ps.getUntrackedParameter<bool>("qie10InConditions", true);
+  _qie10InConditions = ps.getUntrackedParameter<bool>("qie10InConditions", true);
 
-	// Get reference digi sizes. Convert from unsigned to signed int, because <digi>::size()/samples() return ints for some reason.
-	std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
-	_refDigiSize[HcalBarrel]  = (int)vrefDigiSize[0];
-	_refDigiSize[HcalEndcap]  = (int)vrefDigiSize[1];
-	_refDigiSize[HcalOuter]   = (int)vrefDigiSize[2];
-	_refDigiSize[HcalForward] = (int)vrefDigiSize[3];
+  // Get reference digi sizes. Convert from unsigned to signed int, because <digi>::size()/samples() return ints for some reason.
+  std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
+  _refDigiSize[HcalBarrel] = (int)vrefDigiSize[0];
+  _refDigiSize[HcalEndcap] = (int)vrefDigiSize[1];
+  _refDigiSize[HcalOuter] = (int)vrefDigiSize[2];
+  _refDigiSize[HcalForward] = (int)vrefDigiSize[3];
 
-	// (capid - BX) % 4 to 1
-	_capidmbx[HcalBarrel] = 1;
-	_capidmbx[HcalEndcap] = 1;
-	_capidmbx[HcalOuter] = 1;
-	_capidmbx[HcalForward] = 1;
+  // (capid - BX) % 4 to 1
+  _capidmbx[HcalBarrel] = 1;
+  _capidmbx[HcalEndcap] = 1;
+  _capidmbx[HcalOuter] = 1;
+  _capidmbx[HcalForward] = 1;
 
-	// LED calibration channels
-	std::vector<edm::ParameterSet> vLedCalibChannels = ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
-	for (int i = 0; i <= 3; ++i) {
-		HcalSubdetector this_subdet = HcalEmpty;
-		switch (i) {
-			case 0:
-				this_subdet = HcalBarrel;
-				break;
-			case 1:
-				this_subdet = HcalEndcap;
-				break;
-			case 2:
-				this_subdet = HcalOuter;
-				break;
-			case 3:
-				this_subdet = HcalForward;
-				break;
-			default:
-				this_subdet = HcalEmpty;
-				break;
-		}
-		std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
-		std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
-		std::vector<int32_t> subdet_calib_depths = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
-		for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
-			_ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
-		}
-	}
+  // LED calibration channels
+  std::vector<edm::ParameterSet> vLedCalibChannels =
+      ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
+  for (int i = 0; i <= 3; ++i) {
+    HcalSubdetector this_subdet = HcalEmpty;
+    switch (i) {
+      case 0:
+        this_subdet = HcalBarrel;
+        break;
+      case 1:
+        this_subdet = HcalEndcap;
+        break;
+      case 2:
+        this_subdet = HcalOuter;
+        break;
+      case 3:
+        this_subdet = HcalForward;
+        break;
+      default:
+        this_subdet = HcalEmpty;
+        break;
+    }
+    std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
+    std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
+    std::vector<int32_t> subdet_calib_depths =
+        vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
+    for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
+      _ledCalibrationChannels[this_subdet].push_back(HcalDetId(
+          HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
+    }
+  }
 }
 
-/* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib,r,es);
+/* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
-	std::vector<uint32_t> vVME;
-	std::vector<uint32_t> vuTCA;
-	vVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN, 
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vuTCA);
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
+  std::vector<uint32_t> vVME;
+  std::vector<uint32_t> vuTCA;
+  vVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vuTCA);
 
-	// Filters for QIE8 vs QIE10/11
-	std::vector<uint32_t> vhashQIE1011; 
-	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalEndcap, 20,1,1)));
-	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
-	_filter_QIE1011.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet,
-		vhashQIE1011);
-	_filter_QIE8.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet,
-		vhashQIE1011);
+  // Filters for QIE8 vs QIE10/11
+  std::vector<uint32_t> vhashQIE1011;
+  vhashQIE1011.push_back(
+      hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalEndcap, 20, 1, 1)));
+  vhashQIE1011.push_back(
+      hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29, 1, 1)));
+  _filter_QIE1011.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet, vhashQIE1011);
+  _filter_QIE8.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet, vhashQIE1011);
 
-	//	INITIALIZE FIRST
-	_cADC_SubdetPM.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cfC_SubdetPM.initialize(_name, "fC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQ_SubdetPM.initialize(_name, "SumQ", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQ_depth.initialize(_name, "SumQ", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),0);
-	_cSumQvsLS_SubdetPM.initialize(_name, "SumQvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
+  //	INITIALIZE FIRST
+  _cADC_SubdetPM.initialize(_name,
+                            "ADC",
+                            hcaldqm::hashfunctions::fSubdetPM,
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                            0);
+  _cfC_SubdetPM.initialize(_name,
+                           "fC",
+                           hcaldqm::hashfunctions::fSubdetPM,
+                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                           0);
+  _cSumQ_SubdetPM.initialize(_name,
+                             "SumQ",
+                             hcaldqm::hashfunctions::fSubdetPM,
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                             0);
+  _cSumQ_depth.initialize(_name,
+                          "SumQ",
+                          hcaldqm::hashfunctions::fdepth,
+                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),
+                          0);
+  _cSumQvsLS_SubdetPM.initialize(_name,
+                                 "SumQvsLS",
+                                 hcaldqm::hashfunctions::fSubdetPM,
+                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                                 0);
 
-	_cADC_SubdetPM_QIE1011.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cfC_SubdetPM_QIE1011.initialize(_name, "fC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQ_SubdetPM_QIE1011.initialize(_name, "SumQ", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQvsLS_SubdetPM_QIE1011.initialize(_name, "SumQvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),0);
+  _cADC_SubdetPM_QIE1011.initialize(_name,
+                                    "ADC",
+                                    hcaldqm::hashfunctions::fSubdetPM,
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                    0);
+  _cfC_SubdetPM_QIE1011.initialize(_name,
+                                   "fC",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                   0);
+  _cSumQ_SubdetPM_QIE1011.initialize(_name,
+                                     "SumQ",
+                                     hcaldqm::hashfunctions::fSubdetPM,
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                     0);
+  _cSumQvsLS_SubdetPM_QIE1011.initialize(_name,
+                                         "SumQvsLS",
+                                         hcaldqm::hashfunctions::fSubdetPM,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+                                         0);
 
-	_cTimingCut_SubdetPM.initialize(_name, "TimingCut",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cTimingCut_depth.initialize(_name, "TimingCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cTimingCutvsLS_SubdetPM.initialize(_name, "TimingvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
+  _cTimingCut_SubdetPM.initialize(_name,
+                                  "TimingCut",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+  _cTimingCut_depth.initialize(_name,
+                               "TimingCut",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                               0);
+  _cTimingCutvsLS_SubdetPM.initialize(_name,
+                                      "TimingvsLS",
+                                      hcaldqm::hashfunctions::fSubdetPM,
+                                      new hcaldqm::quantity::LumiSection(_maxLS),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                      0);
 
-	//	Occupancy w/o a cut
-	_cOccupancyvsLS_Subdet.initialize(_name, "OccupancyvsLS",
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-	_cOccupancy_depth.initialize(_name, "Occupancy",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //	Occupancy w/o a cut
+  _cOccupancyvsLS_Subdet.initialize(_name,
+                                    "OccupancyvsLS",
+                                    hcaldqm::hashfunctions::fSubdet,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                    0);
+  _cOccupancy_depth.initialize(_name,
+                               "Occupancy",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
 
-	//	Occupancy w/ a cut
-	_cOccupancyCutvsLS_Subdet.initialize(_name, "OccupancyCutvsLS",
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-	_cOccupancyCut_depth.initialize(_name, "OccupancyCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //	Occupancy w/ a cut
+  _cOccupancyCutvsLS_Subdet.initialize(_name,
+                                       "OccupancyCutvsLS",
+                                       hcaldqm::hashfunctions::fSubdet,
+                                       new hcaldqm::quantity::LumiSection(_maxLS),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                       0);
+  _cOccupancyCut_depth.initialize(_name,
+                                  "OccupancyCut",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
 
-	// Digi size
-	_cDigiSize_Crate.initialize(_name, "DigiSize",
-		hcaldqm::hashfunctions::fCrate,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cADCvsTS_SubdetPM.initialize(_name, "ADCvsTS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cADCvsTS_SubdetPM_QIE1011.initialize(_name, "ADCvsTS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  // Digi size
+  _cDigiSize_Crate.initialize(_name,
+                              "DigiSize",
+                              hcaldqm::hashfunctions::fCrate,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                              0);
+  _cADCvsTS_SubdetPM.initialize(_name,
+                                "ADCvsTS",
+                                hcaldqm::hashfunctions::fSubdetPM,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+  _cADCvsTS_SubdetPM_QIE1011.initialize(_name,
+                                        "ADCvsTS",
+                                        hcaldqm::hashfunctions::fSubdetPM,
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
 
-	_cLETDCTimevsADC_SubdetPM.initialize(_name, "LETDCTimevsADC",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cLETDCvsADC_SubdetPM.initialize(_name, "LETDCvsADC",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cLETDCvsTS_SubdetPM.initialize(_name, "LETDCvsTS", 
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64), 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));		
-	_cLETDCTime_SubdetPM.initialize(_name, "LETDCTime",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cLETDCTime_depth.initialize(_name, "LETDCTime",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cLETDCTimevsADC_SubdetPM.initialize(_name,
+                                       "LETDCTimevsADC",
+                                       hcaldqm::hashfunctions::fSubdetPM,
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cLETDCvsADC_SubdetPM.initialize(_name,
+                                   "LETDCvsADC",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cLETDCvsTS_SubdetPM.initialize(_name,
+                                  "LETDCvsTS",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cLETDCTime_SubdetPM.initialize(_name,
+                                  "LETDCTime",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cLETDCTime_depth.initialize(_name,
+                               "LETDCTime",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
 
-	_cBadTDCValues_SubdetPM.initialize(_name, "BadTDCValues", 
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBadTDC),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCvsBX_SubdetPM.initialize(_name, "BadTDCvsBX", 
-		hcaldqm::hashfunctions::fSubdetPM, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCvsLS_SubdetPM.initialize(_name, "BadTDCvsLS", 
-		hcaldqm::hashfunctions::fSubdetPM, 
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCCount_depth.initialize(_name, "BadTDCCount", 
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cBadTDCValues_SubdetPM.initialize(_name,
+                                     "BadTDCValues",
+                                     hcaldqm::hashfunctions::fSubdetPM,
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBadTDC),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cBadTDCvsBX_SubdetPM.initialize(_name,
+                                   "BadTDCvsBX",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cBadTDCvsLS_SubdetPM.initialize(_name,
+                                   "BadTDCvsLS",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cBadTDCCount_depth.initialize(_name,
+                                 "BadTDCCount",
+                                 hcaldqm::hashfunctions::fdepth,
+                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                 0);
 
-	if (_ptype == fOnline || _ptype == fLocal) {
-		_cOccupancy_Crate.initialize(_name,
-			 "Occupancy", hashfunctions::fCrate,
-			 new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			 new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
-			 new quantity::ValueQuantity(quantity::fN),0);
-		_cOccupancy_CrateSlot.initialize(_name,
-			 "Occupancy", hashfunctions::fCrateSlot,
-			 new quantity::ElectronicsQuantity(quantity::fFiberuTCA),
-			 new quantity::ElectronicsQuantity(quantity::fFiberCh),
-			 new quantity::ValueQuantity(quantity::fN),0);		
-	}
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cOccupancy_Crate.initialize(_name,
+                                 "Occupancy",
+                                 hashfunctions::fCrate,
+                                 new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                                 new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
+                                 new quantity::ValueQuantity(quantity::fN),
+                                 0);
+    _cOccupancy_CrateSlot.initialize(_name,
+                                     "Occupancy",
+                                     hashfunctions::fCrateSlot,
+                                     new quantity::ElectronicsQuantity(quantity::fFiberuTCA),
+                                     new quantity::ElectronicsQuantity(quantity::fFiberCh),
+                                     new quantity::ValueQuantity(quantity::fN),
+                                     0);
+  }
 
-	//	INITIALIZE HISTOGRAMS that are only for Online
-	if (_ptype==fOnline)
-	{
-		//	Charge sharing
-		_cQ2Q12CutvsLS_FEDHF.initialize(_name, "Q2Q12vsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),0);
-		_cSumQvsBX_SubdetPM.initialize(_name, "SumQvsBX",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
-		_cSumQvsBX_SubdetPM_QIE1011.initialize(_name, "SumQvsBX",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),0);
-		_cDigiSizevsLS_FED.initialize(_name, "DigiSizevsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),0);
-		_cTimingCutvsiphi_SubdetPM.initialize(_name, "TimingCutvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCutvsieta_Subdet.initialize(_name, "TimingCutvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cOccupancyvsiphi_SubdetPM.initialize(_name, "Occupancyvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyvsieta_Subdet.initialize(_name, "Occupancyvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsiphi_SubdetPM.initialize(_name, "OccupancyCutvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsieta_Subdet.initialize(_name, "OccupancyCutvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsLS_Subdet.initialize(_name, "OccupancyCutvsLS",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-		_cOccupancyCutvsBX_Subdet.initialize(_name, "OccupancyCutvsBX",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-//		_cOccupancyCutvsSlotvsLS_HFPM.initialize(_name, 
-//			"OccupancyCutvsSlotvsLS", hcaldqm::hashfunctions::fSubdetPM,
-//			new hcaldqm::quantity::LumiSection(_maxLS),
-//			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-//			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsiphivsLS_SubdetPM.initialize(_name, 
-			"OccupancyCutvsiphivsLS", hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	}
-	_cCapidMinusBXmod4_SubdetPM.initialize(_name, 
-		"CapID", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fCapidMinusBXmod4),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  //	INITIALIZE HISTOGRAMS that are only for Online
+  if (_ptype == fOnline) {
+    //	Charge sharing
+    _cQ2Q12CutvsLS_FEDHF.initialize(_name,
+                                    "Q2Q12vsLS",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                    0);
+    _cSumQvsBX_SubdetPM.initialize(_name,
+                                   "SumQvsBX",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                                   0);
+    _cSumQvsBX_SubdetPM_QIE1011.initialize(_name,
+                                           "SumQvsBX",
+                                           hcaldqm::hashfunctions::fSubdetPM,
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),
+                                           0);
+    _cDigiSizevsLS_FED.initialize(_name,
+                                  "DigiSizevsLS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::LumiSection(_maxLS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
+                                  0);
+    _cTimingCutvsiphi_SubdetPM.initialize(_name,
+                                          "TimingCutvsiphi",
+                                          hcaldqm::hashfunctions::fSubdetPM,
+                                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                          0);
+    _cTimingCutvsieta_Subdet.initialize(_name,
+                                        "TimingCutvsieta",
+                                        hcaldqm::hashfunctions::fSubdet,
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                        0);
+    _cOccupancyvsiphi_SubdetPM.initialize(_name,
+                                          "Occupancyvsiphi",
+                                          hcaldqm::hashfunctions::fSubdetPM,
+                                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+    _cOccupancyvsieta_Subdet.initialize(_name,
+                                        "Occupancyvsieta",
+                                        hcaldqm::hashfunctions::fSubdet,
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cOccupancyCutvsiphi_SubdetPM.initialize(_name,
+                                             "OccupancyCutvsiphi",
+                                             hcaldqm::hashfunctions::fSubdetPM,
+                                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cOccupancyCutvsieta_Subdet.initialize(_name,
+                                           "OccupancyCutvsieta",
+                                           hcaldqm::hashfunctions::fSubdet,
+                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                           0);
+    _cOccupancyCutvsLS_Subdet.initialize(_name,
+                                         "OccupancyCutvsLS",
+                                         hcaldqm::hashfunctions::fSubdet,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                         0);
+    _cOccupancyCutvsBX_Subdet.initialize(_name,
+                                         "OccupancyCutvsBX",
+                                         hcaldqm::hashfunctions::fSubdet,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                         0);
+    //		_cOccupancyCutvsSlotvsLS_HFPM.initialize(_name,
+    //			"OccupancyCutvsSlotvsLS", hcaldqm::hashfunctions::fSubdetPM,
+    //			new hcaldqm::quantity::LumiSection(_maxLS),
+    //			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+    //			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    _cOccupancyCutvsiphivsLS_SubdetPM.initialize(_name,
+                                                 "OccupancyCutvsiphivsLS",
+                                                 hcaldqm::hashfunctions::fSubdetPM,
+                                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                                 0);
+  }
+  _cCapidMinusBXmod4_SubdetPM.initialize(_name,
+                                         "CapID",
+                                         hcaldqm::hashfunctions::fSubdetPM,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fCapidMinusBXmod4),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
 
-	for (int i = 0; i < 4; ++i) {
-		_cCapidMinusBXmod4_CrateSlotuTCA[i].initialize(_name, "CapID", 
-			new quantity::ElectronicsQuantity(quantity::fCrateuTCA),
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cCapidMinusBXmod4_CrateSlotVME[i].initialize(_name, "CapID", 
-			new quantity::ElectronicsQuantity(quantity::fCrateVME),
-			new quantity::ElectronicsQuantity(quantity::fSlotVME),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	}
+  for (int i = 0; i < 4; ++i) {
+    _cCapidMinusBXmod4_CrateSlotuTCA[i].initialize(_name,
+                                                   "CapID",
+                                                   new quantity::ElectronicsQuantity(quantity::fCrateuTCA),
+                                                   new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                                   0);
+    _cCapidMinusBXmod4_CrateSlotVME[i].initialize(_name,
+                                                  "CapID",
+                                                  new quantity::ElectronicsQuantity(quantity::fCrateVME),
+                                                  new quantity::ElectronicsQuantity(quantity::fSlotVME),
+                                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                                  0);
+  }
 
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
 
-		if (_ptype == fOnline) {
-			_cCapid_BadvsFEDvsLS.initialize(_name, "CapID", 
-				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-				new hcaldqm::quantity::FEDQuantity(vFEDs),		
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+    if (_ptype == fOnline) {
+      _cCapid_BadvsFEDvsLS.initialize(_name,
+                                      "CapID",
+                                      new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+                                      new hcaldqm::quantity::FEDQuantity(vFEDs),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                      0);
 
-			_cCapid_BadvsFEDvsLSmod60.initialize(_name, "CapID", 
-				new hcaldqm::quantity::LumiSection(60),
-				new hcaldqm::quantity::FEDQuantity(vFEDs),		
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		}
-	
-		std::vector<uint32_t> vFEDHF;
-		vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+      _cCapid_BadvsFEDvsLSmod60.initialize(_name,
+                                           "CapID",
+                                           new hcaldqm::quantity::LumiSection(60),
+                                           new hcaldqm::quantity::FEDQuantity(vFEDs),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                           0);
+    }
 
-		//	initialize filters
-		_filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED,
-		vFEDHF);
-	
-		//	push the rawIds of each fed into the vector...
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin();
-			it!=vFEDsVME.end(); ++it)
-			_vhashFEDs.push_back(HcalElectronicsId(
-				constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN,
-				(*it)-FED_VME_MIN).rawId());
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin();
-			it!=vFEDsuTCA.end(); ++it)
-		{
-			std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
-			_vhashFEDs.push_back(HcalElectronicsId(
-				cspair.first, cspair.second, FIBER_uTCA_MIN1,
-				FIBERCH_MIN, false).rawId());
-		}
-	
-		_cShapeCut_FED.initialize(_name, "ShapeCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
-	
-		_cTimingCut_FEDVME.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCut_FEDuTCA.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCut_ElectronicsVME.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCut_ElectronicsuTCA.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingCutvsLS_FED.initialize(_name, "TimingvsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	
-		_cOccupancy_FEDVME.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_FEDuTCA.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_ElectronicsVME.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_ElectronicsuTCA.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	
-		_cOccupancyCut_FEDVME.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_FEDuTCA.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_ElectronicsVME.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_ElectronicsuTCA.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    std::vector<uint32_t> vFEDHF;
+    vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
 
-		_cDigiSize_FED.initialize(_name, "DigiSize",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    //	initialize filters
+    _filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vFEDHF);
 
-		if (_ptype == fOnline) {
-			_cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-				hcaldqm::hashfunctions::fFED,
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FlagQuantity(_vflags),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-			_cSummaryvsLS.initialize(_name, "SummaryvsLS",
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FEDQuantity(vFEDs),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
+    //	push the rawIds of each fed into the vector...
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
+      _vhashFEDs.push_back(
+          HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
 
-			_xUniHF.initialize(hcaldqm::hashfunctions::fFEDSlot);
-			_xUni.initialize(hcaldqm::hashfunctions::fFED);
-			_xDigiSize.initialize(hcaldqm::hashfunctions::fFED);
-			_xNChs.initialize(hcaldqm::hashfunctions::fFED);
-			_xNChsNominal.initialize(hcaldqm::hashfunctions::fFED);
-			_xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
-		}
-	}
-	if (_ptype != fLocal) {
-		_LED_ADCvsBX_Subdet.initialize(_name, "LED_ADCvsBX", 
-			hcaldqm::hashfunctions::fSubdet, 
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX_36),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    _cShapeCut_FED.initialize(_name,
+                              "ShapeCut",
+                              hcaldqm::hashfunctions::fFED,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                              0);
 
-		_LED_CUCountvsLS_Subdet.initialize(_name, "LED_CUCountvsLS",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		if (_ptype == fOnline) {
-			_LED_CUCountvsLSmod60_Subdet.initialize(_name, "LED_CUCountvsLSmod60",
-				hcaldqm::hashfunctions::fSubdet,
-				new hcaldqm::quantity::LumiSection(60),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		}
-	}
+    _cTimingCut_FEDVME.initialize(_name,
+                                  "TimingCut",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                  0);
+    _cTimingCut_FEDuTCA.initialize(_name,
+                                   "TimingCut",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+    _cTimingCut_ElectronicsVME.initialize(_name,
+                                          "TimingCut",
+                                          hcaldqm::hashfunctions::fElectronics,
+                                          new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                          new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                          0);
+    _cTimingCut_ElectronicsuTCA.initialize(_name,
+                                           "TimingCut",
+                                           hcaldqm::hashfunctions::fElectronics,
+                                           new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                           new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                           0);
+    _cTimingCutvsLS_FED.initialize(_name,
+                                   "TimingvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
 
-	//	BOOK HISTOGRAMS
-	char cutstr[200];
-	sprintf(cutstr, "_SumQHBHE%dHO%dHF%d", int(_cutSumQ_HBHE),
-		int(_cutSumQ_HO), int(_cutSumQ_HF));
-	char cutstr2[200];
-	sprintf(cutstr2, "_SumQHF%d", int(_cutSumQ_HF));
+    _cOccupancy_FEDVME.initialize(_name,
+                                  "Occupancy",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+    _cOccupancy_FEDuTCA.initialize(_name,
+                                   "Occupancy",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cOccupancy_ElectronicsVME.initialize(_name,
+                                          "Occupancy",
+                                          hcaldqm::hashfunctions::fElectronics,
+                                          new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                          new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+    _cOccupancy_ElectronicsuTCA.initialize(_name,
+                                           "Occupancy",
+                                           hcaldqm::hashfunctions::fElectronics,
+                                           new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                           new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                           0);
 
-	_cADC_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
-	_cADC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
-	_cfC_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
-	_cfC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
-	_cSumQ_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
-	_cSumQ_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
-	_cSumQ_depth.book(ib, _emap, _subsystem);
-	_cSumQvsLS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
-	_cSumQvsLS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
-	_cDigiSize_Crate.book(ib, _emap, _subsystem);
-	_cADCvsTS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
-	_cADCvsTS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+    _cOccupancyCut_FEDVME.initialize(_name,
+                                     "OccupancyCut",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+    _cOccupancyCut_FEDuTCA.initialize(_name,
+                                      "OccupancyCut",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cOccupancyCut_ElectronicsVME.initialize(_name,
+                                             "OccupancyCut",
+                                             hcaldqm::hashfunctions::fElectronics,
+                                             new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                             new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cOccupancyCut_ElectronicsuTCA.initialize(_name,
+                                              "OccupancyCut",
+                                              hcaldqm::hashfunctions::fElectronics,
+                                              new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                              0);
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_cShapeCut_FED.book(ib, _emap, _subsystem);
-		_cTimingCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingCutvsLS_FED.book(ib, _emap, _subsystem);
-		_cOccupancy_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancy_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancy_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancy_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cDigiSize_FED.book(ib, _emap, _subsystem);
-	}
+    _cDigiSize_FED.initialize(_name,
+                              "DigiSize",
+                              hcaldqm::hashfunctions::fFED,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                              0);
 
-	_cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
-	_cTimingCut_depth.book(ib, _emap, _subsystem);
-	_cTimingCutvsLS_SubdetPM.book(ib, _emap, _subsystem);
+    if (_ptype == fOnline) {
+      _cSummaryvsLS_FED.initialize(_name,
+                                   "SummaryvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::FlagQuantity(_vflags),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                                   0);
+      _cSummaryvsLS.initialize(_name,
+                               "SummaryvsLS",
+                               new hcaldqm::quantity::LumiSection(_maxLS),
+                               new hcaldqm::quantity::FEDQuantity(vFEDs),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                               0);
 
-	_cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cOccupancy_depth.book(ib, _emap, _subsystem);
-	_cOccupancyCut_depth.book(ib, _emap, _subsystem);
+      _xUniHF.initialize(hcaldqm::hashfunctions::fFEDSlot);
+      _xUni.initialize(hcaldqm::hashfunctions::fFED);
+      _xDigiSize.initialize(hcaldqm::hashfunctions::fFED);
+      _xNChs.initialize(hcaldqm::hashfunctions::fFED);
+      _xNChsNominal.initialize(hcaldqm::hashfunctions::fFED);
+      _xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
+    }
+  }
+  if (_ptype != fLocal) {
+    _LED_ADCvsBX_Subdet.initialize(_name,
+                                   "LED_ADCvsBX",
+                                   hcaldqm::hashfunctions::fSubdet,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX_36),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
 
-	_cLETDCTimevsADC_SubdetPM.book(ib, _emap, _subsystem);
-	_cLETDCvsADC_SubdetPM.book(ib, _emap, _subsystem);
-	_cLETDCvsTS_SubdetPM.book(ib, _emap, _subsystem);
-	_cLETDCTime_SubdetPM.book(ib, _emap, _subsystem);
-	_cLETDCTime_depth.book(ib, _emap, _subsystem);
+    _LED_CUCountvsLS_Subdet.initialize(_name,
+                                       "LED_CUCountvsLS",
+                                       hcaldqm::hashfunctions::fSubdet,
+                                       new hcaldqm::quantity::LumiSection(_maxLS),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+    if (_ptype == fOnline) {
+      _LED_CUCountvsLSmod60_Subdet.initialize(_name,
+                                              "LED_CUCountvsLSmod60",
+                                              hcaldqm::hashfunctions::fSubdet,
+                                              new hcaldqm::quantity::LumiSection(60),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                              0);
+    }
+  }
 
-	_cBadTDCValues_SubdetPM.book(ib, _emap, _subsystem);
-	_cBadTDCvsBX_SubdetPM.book(ib, _emap, _subsystem);
-	_cBadTDCvsLS_SubdetPM.book(ib, _emap, _subsystem);
-	_cBadTDCCount_depth.book(ib, _emap, _subsystem);
+  //	BOOK HISTOGRAMS
+  char cutstr[200];
+  sprintf(cutstr, "_SumQHBHE%dHO%dHF%d", int(_cutSumQ_HBHE), int(_cutSumQ_HO), int(_cutSumQ_HF));
+  char cutstr2[200];
+  sprintf(cutstr2, "_SumQHF%d", int(_cutSumQ_HF));
 
-	_cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
-	if (_ptype == fOnline) {
-		_cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-		_cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod60");
-	}
-	for (int i = 0; i < 4; ++i) {
-		constexpr unsigned int kSize=16;
-		char aux[kSize];
-		snprintf(aux, kSize, "%d_uTCA", i);
-		_cCapidMinusBXmod4_CrateSlotuTCA[i].book(ib, _subsystem, aux);
+  _cADC_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+  _cADC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+  _cfC_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+  _cfC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+  _cSumQ_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+  _cSumQ_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+  _cSumQ_depth.book(ib, _emap, _subsystem);
+  _cSumQvsLS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+  _cSumQvsLS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+  _cDigiSize_Crate.book(ib, _emap, _subsystem);
+  _cADCvsTS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+  _cADCvsTS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
 
-		snprintf(aux, kSize, "%d_VME", i);
-		_cCapidMinusBXmod4_CrateSlotVME[i].book(ib, _subsystem, aux);
-	}
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cShapeCut_FED.book(ib, _emap, _subsystem);
+    _cTimingCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingCutvsLS_FED.book(ib, _emap, _subsystem);
+    _cOccupancy_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancy_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancy_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancy_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cDigiSize_FED.book(ib, _emap, _subsystem);
+  }
 
-	if (_ptype != fLocal) {
-		_LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
-		_LED_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
-		if (_ptype == fOnline) {
-			_LED_CUCountvsLSmod60_Subdet.book(ib, _emap, _subsystem);
-		}
-	}
+  _cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
+  _cTimingCut_depth.book(ib, _emap, _subsystem);
+  _cTimingCutvsLS_SubdetPM.book(ib, _emap, _subsystem);
 
-	//	BOOK HISTOGRAMS that are only for Online
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
-	_dhashmap.initialize(_emap, electronicsmap::fE2DHashMap);
+  _cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cOccupancy_depth.book(ib, _emap, _subsystem);
+  _cOccupancyCut_depth.book(ib, _emap, _subsystem);
 
-	if (_ptype == fOnline || _ptype == fLocal) {
-		_cOccupancy_Crate.book(ib, _emap, _subsystem);
-		_cOccupancy_CrateSlot.book(ib, _emap, _subsystem);
-	}
+  _cLETDCTimevsADC_SubdetPM.book(ib, _emap, _subsystem);
+  _cLETDCvsADC_SubdetPM.book(ib, _emap, _subsystem);
+  _cLETDCvsTS_SubdetPM.book(ib, _emap, _subsystem);
+  _cLETDCTime_SubdetPM.book(ib, _emap, _subsystem);
+  _cLETDCTime_depth.book(ib, _emap, _subsystem);
 
-	if (_ptype==fOnline)
-	{
-		_cQ2Q12CutvsLS_FEDHF.book(ib, _emap, _filter_FEDHF, _subsystem);
-		_cSumQvsBX_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
-		_cSumQvsBX_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
-		_cDigiSizevsLS_FED.book(ib, _emap, _subsystem);
-		_cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsBX_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cOccupancyvsieta_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
-//		_cOccupancyCutvsSlotvsLS_HFPM.book(ib, _emap, _filter_QIE1011, _subsystem);
-		_cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
-		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		_cSummaryvsLS.book(ib, _subsystem);
+  _cBadTDCValues_SubdetPM.book(ib, _emap, _subsystem);
+  _cBadTDCvsBX_SubdetPM.book(ib, _emap, _subsystem);
+  _cBadTDCvsLS_SubdetPM.book(ib, _emap, _subsystem);
+  _cBadTDCCount_depth.book(ib, _emap, _subsystem);
 
-		_xUniHF.book(_emap, _filter_FEDHF);
-		_xNChs.book(_emap);
-		_xNChsNominal.book(_emap);
-		_xUni.book(_emap);
-		_xDigiSize.book(_emap);
-		_xBadCapid.book(_emap);
+  _cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
+  if (_ptype == fOnline) {
+    _cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
+    _cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod60");
+  }
+  for (int i = 0; i < 4; ++i) {
+    constexpr unsigned int kSize = 16;
+    char aux[kSize];
+    snprintf(aux, kSize, "%d_uTCA", i);
+    _cCapidMinusBXmod4_CrateSlotuTCA[i].book(ib, _subsystem, aux);
 
-		// just PER HF FED RECORD THE #CHANNELS
-		// ONLY WAY TO DO THAT AUTOMATICALLY AND W/O HARDCODING 1728
-		// or ANY OTHER VALUES LIKE 2592, 2192
-		std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-		for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-			it!=gids.end(); ++it)
-		{
-			if (!it->isHcalDetId())
-				continue;
-			HcalDetId did(it->rawId());
-			if (_xQuality.exists(did)) 
-			{
-				HcalChannelStatus cs(it->rawId(), _xQuality.get(
-					HcalDetId(*it)));
-				if (
-					cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-					cs.isBitSet(HcalChannelStatus::HcalCellDead))
-					continue;
-			}
-			HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
-			_xNChsNominal.get(eid)++;	// he will know the nominal #channels per FED
-		}
-	}
+    snprintf(aux, kSize, "%d_VME", i);
+    _cCapidMinusBXmod4_CrateSlotVME[i].book(ib, _subsystem, aux);
+  }
 
-	//	MARK THESE HISTOGRAMS AS LUMI BASED FOR OFFLINE PROCESSING
-	if (_ptype==fOffline)
-	{
-		_cDigiSize_Crate.setLumiFlag();
-		//_cDigiSize_FED.setLumiFlag();
-		_cOccupancy_depth.setLumiFlag();
-	}
+  if (_ptype != fLocal) {
+    _LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
+    _LED_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
+    if (_ptype == fOnline) {
+      _LED_CUCountvsLSmod60_Subdet.book(ib, _emap, _subsystem);
+    }
+  }
 
-	//	book Number of Events vs LS histogram
-	ib.setCurrentFolder(_subsystem+"/RunInfo");
-	meNumEvents1LS = ib.book1D("NumberOfEvents", "NumberOfEvents",
-		1, 0, 1);
-	meNumEvents1LS->setLumiFlag();
+  //	BOOK HISTOGRAMS that are only for Online
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+  _dhashmap.initialize(_emap, electronicsmap::fE2DHashMap);
 
-	//	book the flag for unknown ids and the online guy as well
-	ib.setCurrentFolder(_subsystem+"/"+_name);
-	meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds",
-		1, 0, 1);
-	_unknownIdsPresent = false;
-	meUnknownIds1LS->setLumiFlag();
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cOccupancy_Crate.book(ib, _emap, _subsystem);
+    _cOccupancy_CrateSlot.book(ib, _emap, _subsystem);
+  }
 
+  if (_ptype == fOnline) {
+    _cQ2Q12CutvsLS_FEDHF.book(ib, _emap, _filter_FEDHF, _subsystem);
+    _cSumQvsBX_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+    _cSumQvsBX_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+    _cDigiSizevsLS_FED.book(ib, _emap, _subsystem);
+    _cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsBX_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
+    //		_cOccupancyCutvsSlotvsLS_HFPM.book(ib, _emap, _filter_QIE1011, _subsystem);
+    _cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    _cSummaryvsLS.book(ib, _subsystem);
+
+    _xUniHF.book(_emap, _filter_FEDHF);
+    _xNChs.book(_emap);
+    _xNChsNominal.book(_emap);
+    _xUni.book(_emap);
+    _xDigiSize.book(_emap);
+    _xBadCapid.book(_emap);
+
+    // just PER HF FED RECORD THE #CHANNELS
+    // ONLY WAY TO DO THAT AUTOMATICALLY AND W/O HARDCODING 1728
+    // or ANY OTHER VALUES LIKE 2592, 2192
+    std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = gids.begin(); it != gids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
+      HcalDetId did(it->rawId());
+      if (_xQuality.exists(did)) {
+        HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
+        if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+          continue;
+      }
+      HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+      _xNChsNominal.get(eid)++;  // he will know the nominal #channels per FED
+    }
+  }
+
+  //	MARK THESE HISTOGRAMS AS LUMI BASED FOR OFFLINE PROCESSING
+  if (_ptype == fOffline) {
+    _cDigiSize_Crate.setLumiFlag();
+    //_cDigiSize_FED.setLumiFlag();
+    _cOccupancy_depth.setLumiFlag();
+  }
+
+  //	book Number of Events vs LS histogram
+  ib.setCurrentFolder(_subsystem + "/RunInfo");
+  meNumEvents1LS = ib.book1D("NumberOfEvents", "NumberOfEvents", 1, 0, 1);
+  meNumEvents1LS->setLumiFlag();
+
+  //	book the flag for unknown ids and the online guy as well
+  ib.setCurrentFolder(_subsystem + "/" + _name);
+  meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds", 1, 0, 1);
+  _unknownIdsPresent = false;
+  meUnknownIds1LS->setLumiFlag();
 }
 
-/* virtual */ void DigiTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void DigiTask::_resetMonitors(hcaldqm::UpdateFreq uf) {
+  DQTask::_resetMonitors(uf);
 
-	switch(uf)
-	{
-		case hcaldqm::f1LS:
-			_unknownIdsPresent = false;
-			break;
-		case hcaldqm::f50LS:
-			//	^^^ONLINE ONLY!
-			if (_ptype==fOnline)
-				_cOccupancyvsiphi_SubdetPM.reset();
-			//	^^^
-			break;
-		default:
-			break;
-	}
+  switch (uf) {
+    case hcaldqm::f1LS:
+      _unknownIdsPresent = false;
+      break;
+    case hcaldqm::f50LS:
+      //	^^^ONLINE ONLY!
+      if (_ptype == fOnline)
+        _cOccupancyvsiphi_SubdetPM.reset();
+      //	^^^
+      break;
+    default:
+      break;
+  }
 }
 
-/* virtual */ void DigiTask::_process(edm::Event const& e,
-	edm::EventSetup const&)
-{
-	edm::Handle<HBHEDigiCollection>     chbhe;
-	edm::Handle<QIE11DigiCollection>     che_qie11;
-	edm::Handle<HODigiCollection>       cho;
-	edm::Handle<QIE10DigiCollection>       chf;
+/* virtual */ void DigiTask::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<HBHEDigiCollection> chbhe;
+  edm::Handle<QIE11DigiCollection> che_qie11;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<QIE10DigiCollection> chf;
 
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHE, che_qie11))
-		_logger.dqmthrow("Collection QIE11DigiCollection isn't available"
-			+ _tagHE.label() + " " + _tagHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available"
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection QIE10DigiCollection isn't available"
-			+ _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHE, che_qie11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagHF.label() + " " + _tagHF.instance());
 
-	//	extract some info per event
-	int bx = e.bunchCrossing();
-	meNumEvents1LS->Fill(0.5); // just increment
+  //	extract some info per event
+  int bx = e.bunchCrossing();
+  meNumEvents1LS->Fill(0.5);  // just increment
 
-	//	To fill histograms outside of the loop, you need to determine if there were
-	//	any valid det ids first
-	uint32_t rawidValid = 0;
-	uint32_t rawidHBValid = 0;
-	uint32_t rawidHEValid = 0;
+  //	To fill histograms outside of the loop, you need to determine if there were
+  //	any valid det ids first
+  uint32_t rawidValid = 0;
+  uint32_t rawidHBValid = 0;
+  uint32_t rawidHEValid = 0;
 
-	//	HB collection
-	int numChs = 0;
-	int numChsCut = 0;
-	int numChsHE = 0;
-	int numChsCutHE = 0;
-	for (HBHEDigiCollection::const_iterator it=chbhe->begin(); it!=chbhe->end();
-		++it)
-	{
-		//	Explicit check on the DetIds present in the Collection
-		HcalDetId const& did = it->id();
-		if (did.subdet() != HcalBarrel) {
-			continue;
-		}
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid == 0) {
-			meUnknownIds1LS->Fill(1); 
-			_unknownIdsPresent=true;
-			continue;
-		} else {
-			if (did.subdet()==HcalBarrel) {
-				rawidHBValid = did.rawId();
-			} else if (did.subdet()==HcalEndcap) {
-				rawidHEValid = did.rawId();
-			}
-		}
-		HcalElectronicsId const& eid(rawid);
+  //	HB collection
+  int numChs = 0;
+  int numChsCut = 0;
+  int numChsHE = 0;
+  int numChsCutHE = 0;
+  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    //	Explicit check on the DetIds present in the Collection
+    HcalDetId const& did = it->id();
+    if (did.subdet() != HcalBarrel) {
+      continue;
+    }
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    } else {
+      if (did.subdet() == HcalBarrel) {
+        rawidHBValid = did.rawId();
+      } else if (did.subdet() == HcalEndcap) {
+        rawidHEValid = did.rawId();
+      }
+    }
+    HcalElectronicsId const& eid(rawid);
 
-		//	filter out channels that are masked out
-		if (_xQuality.exists(did)) 
-		{
-			HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
+    //	filter out channels that are masked out
+    if (_xQuality.exists(did)) {
+      HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-		if (_ptype == fOnline) {
-			short this_capidmbx = (it->sample(it->presamples()).capid() - bx) % 4;
-			if (this_capidmbx < 0) {
-				this_capidmbx += 4;
-			}
-			_cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
-			bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
-			if (!good_capidmbx) {
-				_xBadCapid.get(eid)++;
-				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
-			}
-			if (eid.isVMEid()) {
-				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
+    if (_ptype == fOnline) {
+      short this_capidmbx = (it->sample(it->presamples()).capid() - bx) % 4;
+      if (this_capidmbx < 0) {
+        this_capidmbx += 4;
+      }
+      _cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
+      bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
+      if (!good_capidmbx) {
+        _xBadCapid.get(eid)++;
+        _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+        _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+      }
+      if (eid.isVMEid()) {
+        _cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
 
-			} else {
-				_cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
-			}
-		}
+      } else {
+        _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
+      }
+    }
 
-		//double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, *it);
-		double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
+    //double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, *it);
+    double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size() - 1);
 
-		_cSumQ_SubdetPM.fill(did, sumQ);
-		_cOccupancy_depth.fill(did);
-		if (_ptype == fOnline || _ptype == fLocal) {
-			_cOccupancy_Crate.fill(eid);
-			_cOccupancy_CrateSlot.fill(eid);
-		}
-		if (_ptype==fOnline)
-		{
-			_cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
-			it->size()!=_refDigiSize[did.subdet()]?
-				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
-			_cOccupancyvsiphi_SubdetPM.fill(did);
-			_cOccupancyvsieta_Subdet.fill(did);
-		}
-		_cDigiSize_Crate.fill(eid, it->size());
-		if (_ptype != fOffline) { // hidefed2crate
-			_cDigiSize_FED.fill(eid, it->size());
-			if (eid.isVMEid())
-			{
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-			else
-			{
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-				/*
+    _cSumQ_SubdetPM.fill(did, sumQ);
+    _cOccupancy_depth.fill(did);
+    if (_ptype == fOnline || _ptype == fLocal) {
+      _cOccupancy_Crate.fill(eid);
+      _cOccupancy_CrateSlot.fill(eid);
+    }
+    if (_ptype == fOnline) {
+      _cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
+      it->size() != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+      _cOccupancyvsiphi_SubdetPM.fill(did);
+      _cOccupancyvsieta_Subdet.fill(did);
+    }
+    _cDigiSize_Crate.fill(eid, it->size());
+    if (_ptype != fOffline) {  // hidefed2crate
+      _cDigiSize_FED.fill(eid, it->size());
+      if (eid.isVMEid()) {
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      } else {
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+        /*
 				if (!it->validate(0, it->size()))
 				{
 					_cCapIdRots_depth.fill(did);
 					_cCapIdRots_FEDuTCA.fill(eid, 1);
 				}*/
-			}
-		}
+      }
+    }
 
-		for (int i=0; i<it->size(); i++)
-		{
-			_cADC_SubdetPM.fill(did, it->sample(i).adc());
-			_cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
-			if (_ptype != fOffline) { // hidefed2crate
-				_cADCvsTS_SubdetPM.fill(did, i, it->sample(i).adc());
-				if (sumQ>_cutSumQ_HBHE) {
-					_cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
-				}
-			}
-		}
+    for (int i = 0; i < it->size(); i++) {
+      _cADC_SubdetPM.fill(did, it->sample(i).adc());
+      _cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cADCvsTS_SubdetPM.fill(did, i, it->sample(i).adc());
+        if (sumQ > _cutSumQ_HBHE) {
+          _cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
+        }
+      }
+    }
 
-		if (sumQ>_cutSumQ_HBHE)
-		{
-			//double timing = hcaldqm::utilities::aveTS<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
-			double timing = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_depth.fill(did, timing);
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			_cSumQ_depth.fill(did, sumQ);
-			_cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			if (_ptype==fOnline)
-			{
-				_cSumQvsBX_SubdetPM.fill(did, bx, sumQ);
-				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-				_cTimingCutvsieta_Subdet.fill(did, timing);
-				_cOccupancyCutvsiphi_SubdetPM.fill(did);
-				_cOccupancyCutvsieta_Subdet.fill(did);
-				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-			}
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-				else 
-				{
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			did.subdet()==HcalBarrel?numChsCut++:numChsCutHE++;
-		}
-		did.subdet()==HcalBarrel?numChs++:numChsHE++;
-	}
+    if (sumQ > _cutSumQ_HBHE) {
+      //double timing = hcaldqm::utilities::aveTS<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
+      double timing = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size() - 1);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_depth.fill(did, timing);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      _cSumQ_depth.fill(did, sumQ);
+      _cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      if (_ptype == fOnline) {
+        _cSumQvsBX_SubdetPM.fill(did, bx, sumQ);
+        _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+        _cTimingCutvsieta_Subdet.fill(did, timing);
+        _cOccupancyCutvsiphi_SubdetPM.fill(did);
+        _cOccupancyCutvsieta_Subdet.fill(did);
+        _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+      }
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid()) {
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        } else {
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      did.subdet() == HcalBarrel ? numChsCut++ : numChsCutHE++;
+    }
+    did.subdet() == HcalBarrel ? numChs++ : numChsHE++;
+  }
 
-	// HE QIE11 collection
-	for (QIE11DigiCollection::const_iterator it=che_qie11->begin(); it!=che_qie11->end();
-		++it)
-	{
-		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
+  // HE QIE11 collection
+  for (QIE11DigiCollection::const_iterator it = che_qie11->begin(); it != che_qie11->end(); ++it) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
 
-		//	Explicit check on the DetIds present in the Collection
-		HcalDetId const& did = digi.detid();
-		if (did.subdet() != HcalEndcap) {
-			// LED monitoring from calibration channels
-			if (_ptype != fLocal) {
-				if (did.subdet() == HcalOther) {
-					HcalOtherDetId hodid(digi.detid());
-					if (hodid.subdet() == HcalCalibration) {
-						// New method: use configurable list of channels
-						if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) != _ledCalibrationChannels[HcalEndcap].end()) {
-							bool channelLEDSignalPresent = false;
-							for (int i=0; i<digi.samples(); i++) {
-								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), bx, digi[i].adc());
+    //	Explicit check on the DetIds present in the Collection
+    HcalDetId const& did = digi.detid();
+    if (did.subdet() != HcalEndcap) {
+      // LED monitoring from calibration channels
+      if (_ptype != fLocal) {
+        if (did.subdet() == HcalOther) {
+          HcalOtherDetId hodid(digi.detid());
+          if (hodid.subdet() == HcalCalibration) {
+            // New method: use configurable list of channels
+            if (std::find(_ledCalibrationChannels[HcalEndcap].begin(),
+                          _ledCalibrationChannels[HcalEndcap].end(),
+                          did) != _ledCalibrationChannels[HcalEndcap].end()) {
+              bool channelLEDSignalPresent = false;
+              for (int i = 0; i < digi.samples(); i++) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), bx, digi[i].adc());
 
-								if (digi[i].adc() > _thresh_led) {
-									channelLEDSignalPresent = true;
-								}
-							}
-							if (channelLEDSignalPresent) {
-								_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
-								if (_ptype == fOnline) {
-									_LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
-								}
-							}
-						}
-					}
-				}
-			}
-			continue;
-		}
+                if (digi[i].adc() > _thresh_led) {
+                  channelLEDSignalPresent = true;
+                }
+              }
+              if (channelLEDSignalPresent) {
+                _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
+                if (_ptype == fOnline) {
+                  _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
+                }
+              }
+            }
+          }
+        }
+      }
+      continue;
+    }
 
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid == 0) {
-			meUnknownIds1LS->Fill(1);
-			_unknownIdsPresent=true;
-			continue;
-		} else {
-			if (did.subdet()==HcalBarrel) { // Note: since this is HE, we obviously expect did.subdet() always to be HcalEndcap, but QIE11DigiCollection will have HB for Run 3.
-				rawidHBValid = did.rawId();
-			} else if (did.subdet()==HcalEndcap) {
-				rawidHEValid = did.rawId();
-			}
-		}
-		HcalElectronicsId const& eid(rawid);
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    } else {
+      if (did.subdet() ==
+          HcalBarrel) {  // Note: since this is HE, we obviously expect did.subdet() always to be HcalEndcap, but QIE11DigiCollection will have HB for Run 3.
+        rawidHBValid = did.rawId();
+      } else if (did.subdet() == HcalEndcap) {
+        rawidHEValid = did.rawId();
+      }
+    }
+    HcalElectronicsId const& eid(rawid);
 
-		//	filter out channels that are masked out
-		if (_xQuality.exists(did)) 
-		{
-			HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
+    //	filter out channels that are masked out
+    if (_xQuality.exists(did)) {
+      HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-		// (capid - BX) % 4
-		if (_ptype == fOnline) {
-			short soi = -1;
-			for (int i=0; i<digi.samples(); i++) {
-				if (digi[i].soi()) {
-					soi = i;
-					break;
-				}
-			}
-			short this_capidmbx = (digi[soi].capid() - bx) % 4;
-			if (this_capidmbx < 0) {
-				this_capidmbx += 4;
-			}
-			_cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
-			bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
-			if (!good_capidmbx) {
-				_xBadCapid.get(eid)++;
-				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
-			}
-			if (eid.isVMEid()) {
-				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
+    // (capid - BX) % 4
+    if (_ptype == fOnline) {
+      short soi = -1;
+      for (int i = 0; i < digi.samples(); i++) {
+        if (digi[i].soi()) {
+          soi = i;
+          break;
+        }
+      }
+      short this_capidmbx = (digi[soi].capid() - bx) % 4;
+      if (this_capidmbx < 0) {
+        this_capidmbx += 4;
+      }
+      _cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
+      bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
+      if (!good_capidmbx) {
+        _xBadCapid.get(eid)++;
+        _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+        _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+      }
+      if (eid.isVMEid()) {
+        _cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
 
-			} else {
-				_cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
-			}
-		}
+      } else {
+        _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
+      }
+    }
 
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
+    double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
 
-		_cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
-		_cOccupancy_depth.fill(did);
-		if (_ptype == fOnline || _ptype == fLocal) {
-			_cOccupancy_Crate.fill(eid);
-			_cOccupancy_CrateSlot.fill(eid);
-		}
-		if (_ptype==fOnline)
-		{
-			_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
-			digi.samples()!=_refDigiSize[did.subdet()]?
-				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
-			_cOccupancyvsiphi_SubdetPM.fill(did);
-			_cOccupancyvsieta_Subdet.fill(did);
-		}
-		_cDigiSize_Crate.fill(eid, digi.samples());
-		if (_ptype != fOffline) { // hidefed2crate
-			_cDigiSize_FED.fill(eid, digi.samples());
-			if (eid.isVMEid())
-			{
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-			else
-			{
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-				/*
+    _cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
+    _cOccupancy_depth.fill(did);
+    if (_ptype == fOnline || _ptype == fLocal) {
+      _cOccupancy_Crate.fill(eid);
+      _cOccupancy_CrateSlot.fill(eid);
+    }
+    if (_ptype == fOnline) {
+      _cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
+      digi.samples() != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+      _cOccupancyvsiphi_SubdetPM.fill(did);
+      _cOccupancyvsieta_Subdet.fill(did);
+    }
+    _cDigiSize_Crate.fill(eid, digi.samples());
+    if (_ptype != fOffline) {  // hidefed2crate
+      _cDigiSize_FED.fill(eid, digi.samples());
+      if (eid.isVMEid()) {
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      } else {
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+        /*
 				if (!digi.validate(0, digi.size()))
 				{
 					_cCapIdRots_depth.fill(did);
 					_cCapIdRots_FEDuTCA.fill(eid, 1);
 				}*/
-			}
-		}
-		for (int i=0; i<digi.samples(); i++) {
-			double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i);
-			_cADC_SubdetPM_QIE1011.fill(did, digi[i].adc());
-			_cfC_SubdetPM_QIE1011.fill(did, q);
-			_cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].tdc());
-			_cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].tdc());
-			if (digi[i].tdc() <50) {
-				double time = i*25. + (digi[i].tdc() / 2.);
-				_cLETDCTime_SubdetPM.fill(did, time);
-				_cLETDCTime_depth.fill(did, time);
-				_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
-			}
-			// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we saw some in 2017 data.
-			if ((50 <= digi[i].tdc()) && (digi[i].tdc() <= 61)) {
-				_cBadTDCValues_SubdetPM.fill(did, digi[i].tdc());
-				_cBadTDCvsBX_SubdetPM.fill(did, bx);
-				_cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
-				_cBadTDCCount_depth.fill(did);
-			}
-			if (_ptype != fOffline) { // hidefed2crate
-				_cADCvsTS_SubdetPM_QIE1011.fill(did, i, digi[i].adc());
-				if (sumQ>_cutSumQ_HE) {
-					_cShapeCut_FED.fill(eid, i, q);
-				}
-			}			
-		}
+      }
+    }
+    for (int i = 0; i < digi.samples(); i++) {
+      double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i);
+      _cADC_SubdetPM_QIE1011.fill(did, digi[i].adc());
+      _cfC_SubdetPM_QIE1011.fill(did, q);
+      _cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].tdc());
+      _cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].tdc());
+      if (digi[i].tdc() < 50) {
+        double time = i * 25. + (digi[i].tdc() / 2.);
+        _cLETDCTime_SubdetPM.fill(did, time);
+        _cLETDCTime_depth.fill(did, time);
+        _cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
+      }
+      // Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we saw some in 2017 data.
+      if ((50 <= digi[i].tdc()) && (digi[i].tdc() <= 61)) {
+        _cBadTDCValues_SubdetPM.fill(did, digi[i].tdc());
+        _cBadTDCvsBX_SubdetPM.fill(did, bx);
+        _cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
+        _cBadTDCCount_depth.fill(did);
+      }
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cADCvsTS_SubdetPM_QIE1011.fill(did, i, digi[i].adc());
+        if (sumQ > _cutSumQ_HE) {
+          _cShapeCut_FED.fill(eid, i, q);
+        }
+      }
+    }
 
-		if (sumQ>_cutSumQ_HE)
-		{
-			//double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
-			double timing = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_depth.fill(did, timing);
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			_cSumQ_depth.fill(did, sumQ);
-			_cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
-			if (_ptype==fOnline)
-			{
-				_cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
-				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-				_cTimingCutvsieta_Subdet.fill(did, timing);
-				_cOccupancyCutvsiphi_SubdetPM.fill(did);
-				_cOccupancyCutvsieta_Subdet.fill(did);
-				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-			}
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-				else 
-				{
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			did.subdet()==HcalBarrel?numChsCut++:numChsCutHE++;
-		}
-		did.subdet()==HcalBarrel?numChs++:numChsHE++;
-	}
+    if (sumQ > _cutSumQ_HE) {
+      //double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
+      double timing =
+          hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_depth.fill(did, timing);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      _cSumQ_depth.fill(did, sumQ);
+      _cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
+      if (_ptype == fOnline) {
+        _cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
+        _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+        _cTimingCutvsieta_Subdet.fill(did, timing);
+        _cOccupancyCutvsiphi_SubdetPM.fill(did);
+        _cOccupancyCutvsieta_Subdet.fill(did);
+        _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+      }
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid()) {
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        } else {
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      did.subdet() == HcalBarrel ? numChsCut++ : numChsCutHE++;
+    }
+    did.subdet() == HcalBarrel ? numChs++ : numChsHE++;
+  }
 
-	if (rawidHBValid!=0 && rawidHEValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, 
-			numChs);
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS,
-			numChsHE);
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHBValid), 
-				_currentLS, numChsCut);
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHBValid), bx,
-				numChsCut);
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHEValid), 
-				_currentLS, numChsCutHE);
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHEValid), bx,
-				numChsCutHE);
-		}
-		//	^^^ONLINE ONLY!
-	}
-	numChs=0;
-	numChsCut = 0;
+  if (rawidHBValid != 0 && rawidHEValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChs);
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsHE);
+    //	ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChsCut);
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHBValid), bx, numChsCut);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsCutHE);
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHEValid), bx, numChsCutHE);
+    }
+    //	^^^ONLINE ONLY!
+  }
+  numChs = 0;
+  numChsCut = 0;
 
-	//	reset
-	rawidValid = 0;
+  //	reset
+  rawidValid = 0;
 
+  //	HO collection
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    //	Explicit check on the DetIds present in the Collection
+    HcalDetId const& did = it->id();
+    if (did.subdet() != HcalOuter) {
+      continue;
+    }
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    } else {
+      rawidValid = did.rawId();
+    }
+    HcalElectronicsId const& eid(rawid);
 
-	//	HO collection
-	for (HODigiCollection::const_iterator it=cho->begin(); it!=cho->end();
-		++it)
-	{		
-		//	Explicit check on the DetIds present in the Collection
-		HcalDetId const& did = it->id();
-		if (did.subdet() != HcalOuter) {
-			continue;
-		}
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid == 0) {
-			meUnknownIds1LS->Fill(1);
-			_unknownIdsPresent = true;
-			continue;
-		} else {
-			rawidValid = did.rawId();
-		}
-		HcalElectronicsId const& eid(rawid);
+    //	filter out channels that are masked out
+    if (_xQuality.exists(did)) {
+      HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-		//	filter out channels that are masked out
-		if (_xQuality.exists(did)) 
-		{
-			HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
+    if (_ptype == fOnline) {
+      short this_capidmbx = (it->sample(it->presamples()).capid() - bx) % 4;
+      if (this_capidmbx < 0) {
+        this_capidmbx += 4;
+      }
+      _cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
+      bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
+      if (!good_capidmbx) {
+        _xBadCapid.get(eid)++;
+        _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+        _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+      }
+      if (eid.isVMEid()) {
+        _cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
 
-		if (_ptype == fOnline) {
-			short this_capidmbx = (it->sample(it->presamples()).capid() - bx) % 4;
-			if (this_capidmbx < 0) {
-				this_capidmbx += 4;
-			}
-			_cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
-			bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
-			if (!good_capidmbx) {
-				_xBadCapid.get(eid)++;
-				_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-				_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
-			}
-			if (eid.isVMEid()) {
-				_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
+      } else {
+        _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
+      }
+    }
 
-			} else {
-				_cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
-			}
-		}
+    //double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size()-1);
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, *it);
+    double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size() - 1);
 
-		//double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, *it);
-		double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
-
-		_cSumQ_SubdetPM.fill(did, sumQ);
-		_cOccupancy_depth.fill(did);
-		if (_ptype==fOnline)
-		{
-			_cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
-			it->size()!=_refDigiSize[did.subdet()]?
-				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
-			_cOccupancyvsiphi_SubdetPM.fill(did);
-			_cOccupancyvsieta_Subdet.fill(did);
-		}
-		_cDigiSize_Crate.fill(eid, it->size());
-		if (_ptype != fOffline) { // hidefed2crate
-			_cDigiSize_FED.fill(eid, it->size());
-			if (eid.isVMEid())
-			{
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-				/*
+    _cSumQ_SubdetPM.fill(did, sumQ);
+    _cOccupancy_depth.fill(did);
+    if (_ptype == fOnline) {
+      _cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
+      it->size() != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+      _cOccupancyvsiphi_SubdetPM.fill(did);
+      _cOccupancyvsieta_Subdet.fill(did);
+    }
+    _cDigiSize_Crate.fill(eid, it->size());
+    if (_ptype != fOffline) {  // hidefed2crate
+      _cDigiSize_FED.fill(eid, it->size());
+      if (eid.isVMEid()) {
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+        /*
 				if (!it->validate(0, it->size()))
 					_cCapIdRots_FEDVME.fill(eid, 1);
 					*/
-			}
-			else
-			{
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-				/*
+      } else {
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+        /*
 				if (!it->validate(0, it->size()))
 					_cCapIdRots_FEDuTCA.fill(eid, 1);*/
-			}
-		}
+      }
+    }
 
-		for (int i=0; i<it->size(); i++)
-		{
-			_cADC_SubdetPM.fill(did, it->sample(i).adc());
-			_cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
-			if (_ptype != fOffline) { // hidefed2crate
-				_cADCvsTS_SubdetPM.fill(did, i, it->sample(i).adc());
-				if (sumQ>_cutSumQ_HO)
-					_cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
-			}
-		}
+    for (int i = 0; i < it->size(); i++) {
+      _cADC_SubdetPM.fill(did, it->sample(i).adc());
+      _cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cADCvsTS_SubdetPM.fill(did, i, it->sample(i).adc());
+        if (sumQ > _cutSumQ_HO)
+          _cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
+      }
+    }
 
-		if (sumQ>_cutSumQ_HO)
-		{
-			//double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0,it->size()-1);
-			double timing = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
-			_cSumQ_depth.fill(did, sumQ);
-			_cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_depth.fill(did, timing);
-			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			if (_ptype==fOnline)
-			{
-				_cSumQvsBX_SubdetPM.fill(did, bx, sumQ);
-				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-				_cTimingCutvsieta_Subdet.fill(did, timing);
-				_cOccupancyCutvsiphi_SubdetPM.fill(did);
-				_cOccupancyCutvsieta_Subdet.fill(did);
-				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-			}
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-				else 
-				{
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			numChsCut++;
-		}
-		numChs++;
-	}
+    if (sumQ > _cutSumQ_HO) {
+      //double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0,it->size()-1);
+      double timing = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size() - 1);
+      _cSumQ_depth.fill(did, sumQ);
+      _cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_depth.fill(did, timing);
+      _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      if (_ptype == fOnline) {
+        _cSumQvsBX_SubdetPM.fill(did, bx, sumQ);
+        _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+        _cTimingCutvsieta_Subdet.fill(did, timing);
+        _cOccupancyCutvsiphi_SubdetPM.fill(did);
+        _cOccupancyCutvsieta_Subdet.fill(did);
+        _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+      }
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid()) {
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        } else {
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      numChsCut++;
+    }
+    numChs++;
+  }
 
-	if (rawidValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS,
-			numChs);
-	
-		if (_ptype==fOnline)
-		{
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), 
-				_currentLS, numChsCut);
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx,
-				numChsCut);
-		}
-	}
-	numChs=0; numChsCut=0;
+  if (rawidValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
 
-	//	reset
-	rawidValid = 0;
+    if (_ptype == fOnline) {
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChsCut);
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx, numChsCut);
+    }
+  }
+  numChs = 0;
+  numChsCut = 0;
 
-	//	HF collection
-	if (_qie10InConditions) {
-		for (QIE10DigiCollection::const_iterator it=chf->begin(); it!=chf->end(); ++it) {
-			const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+  //	reset
+  rawidValid = 0;
 
-			//	Explicit check on the DetIds present in the Collection
-			HcalDetId const& did = digi.detid();
-			if (did.subdet() != HcalForward) {
-				// LED monitoring from calibration channels
-				if (_ptype != fLocal) {
-					if (did.subdet() == HcalOther) {
-						HcalOtherDetId hodid(digi.detid());
-						if (hodid.subdet() == HcalCalibration) {
-							// New method: use configurable list of channels
-							if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
-								bool channelLEDSignalPresent = false;
-								for (int i=0; i<digi.samples(); i++) {
-									_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), bx, digi[i].adc());
+  //	HF collection
+  if (_qie10InConditions) {
+    for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+      const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
 
-									if (digi[i].adc() > _thresh_led) {
-										channelLEDSignalPresent = true;
-									}
-								}
-								if (channelLEDSignalPresent) {
-									_LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS);
-									if (_ptype == fOnline) { 
-										_LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS % 60);
-									}
-								}
-							}
-						}
-					}
-				}
-				continue;
-			}
+      //	Explicit check on the DetIds present in the Collection
+      HcalDetId const& did = digi.detid();
+      if (did.subdet() != HcalForward) {
+        // LED monitoring from calibration channels
+        if (_ptype != fLocal) {
+          if (did.subdet() == HcalOther) {
+            HcalOtherDetId hodid(digi.detid());
+            if (hodid.subdet() == HcalCalibration) {
+              // New method: use configurable list of channels
+              if (std::find(_ledCalibrationChannels[HcalForward].begin(),
+                            _ledCalibrationChannels[HcalForward].end(),
+                            did) != _ledCalibrationChannels[HcalForward].end()) {
+                bool channelLEDSignalPresent = false;
+                for (int i = 0; i < digi.samples(); i++) {
+                  _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), bx, digi[i].adc());
 
-			uint32_t rawid = _ehashmap.lookup(did);
-			if (rawid == 0) {
-				meUnknownIds1LS->Fill(1); 
-				_unknownIdsPresent=true;
-				continue;
-			} else {
-				rawidValid = did.rawId();
-			}
-			HcalElectronicsId const& eid(rawid);
+                  if (digi[i].adc() > _thresh_led) {
+                    channelLEDSignalPresent = true;
+                  }
+                }
+                if (channelLEDSignalPresent) {
+                  _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS);
+                  if (_ptype == fOnline) {
+                    _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 16, 1, 1), _currentLS % 60);
+                  }
+                }
+              }
+            }
+          }
+        }
+        continue;
+      }
 
-			//	filter out channels that are masked out
-			if (_xQuality.exists(did)) 
-			{
-				HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
-				if (
-					cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-					cs.isBitSet(HcalChannelStatus::HcalCellDead))
-					continue;
-			}
+      uint32_t rawid = _ehashmap.lookup(did);
+      if (rawid == 0) {
+        meUnknownIds1LS->Fill(1);
+        _unknownIdsPresent = true;
+        continue;
+      } else {
+        rawidValid = did.rawId();
+      }
+      HcalElectronicsId const& eid(rawid);
 
-			// (capid - BX) % 4
-			if (_ptype == fOnline) {
-				short soi = -1;
-				for (int i=0; i<digi.samples(); i++) {
-					if (digi[i].soi()) {
-						soi = i;
-						break;
-					}
-				}
-				short this_capidmbx = (digi[soi].capid() - bx) % 4;
-				if (this_capidmbx < 0) {
-					this_capidmbx += 4;
-				}
-				_cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
-				bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
-				if (!good_capidmbx) {
-					_xBadCapid.get(eid)++;
-					_cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-					_cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
-				}
-				if (eid.isVMEid()) {
-					_cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
+      //	filter out channels that are masked out
+      if (_xQuality.exists(did)) {
+        HcalChannelStatus cs(did.rawId(), _xQuality.get(did));
+        if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+          continue;
+      }
 
-				} else {
-					_cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
-				}
-			}
+      // (capid - BX) % 4
+      if (_ptype == fOnline) {
+        short soi = -1;
+        for (int i = 0; i < digi.samples(); i++) {
+          if (digi[i].soi()) {
+            soi = i;
+            break;
+          }
+        }
+        short this_capidmbx = (digi[soi].capid() - bx) % 4;
+        if (this_capidmbx < 0) {
+          this_capidmbx += 4;
+        }
+        _cCapidMinusBXmod4_SubdetPM.fill(did, this_capidmbx);
+        bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
+        if (!good_capidmbx) {
+          _xBadCapid.get(eid)++;
+          _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
+          _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+        }
+        if (eid.isVMEid()) {
+          _cCapidMinusBXmod4_CrateSlotVME[this_capidmbx].fill(eid);
 
-			CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
-			double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-			//double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+        } else {
+          _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
+        }
+      }
 
-			//if (!_filter_QIE1011.filter(did)) {
-			_cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
-			//}
-			_cOccupancy_depth.fill(did);
-			if (_ptype==fOnline)
-			{
-				_xNChs.get(eid)++;
-				_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
-				digi.samples()!=_refDigiSize[did.subdet()]?
-					_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
-				_cOccupancyvsiphi_SubdetPM.fill(did);
-				_cOccupancyvsieta_Subdet.fill(did);
-			}
-			_cDigiSize_Crate.fill(eid, digi.samples());
-			if (_ptype != fOffline) { // hidefed2crate
-				_cDigiSize_FED.fill(eid, digi.samples());
-				if (eid.isVMEid())
-				{
-					_cOccupancy_FEDVME.fill(eid);
-					_cOccupancy_ElectronicsVME.fill(eid);
-					/*
+      CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
+      double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+      //double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+
+      //if (!_filter_QIE1011.filter(did)) {
+      _cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
+      //}
+      _cOccupancy_depth.fill(did);
+      if (_ptype == fOnline) {
+        _xNChs.get(eid)++;
+        _cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
+        digi.samples() != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+        _cOccupancyvsiphi_SubdetPM.fill(did);
+        _cOccupancyvsieta_Subdet.fill(did);
+      }
+      _cDigiSize_Crate.fill(eid, digi.samples());
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cDigiSize_FED.fill(eid, digi.samples());
+        if (eid.isVMEid()) {
+          _cOccupancy_FEDVME.fill(eid);
+          _cOccupancy_ElectronicsVME.fill(eid);
+          /*
 					if (!it->validate(0, it->size()))
 						_cCapIdRots_FEDVME.fill(eid, 1);*/
-				}
-				else
-				{
-					_cOccupancy_FEDuTCA.fill(eid);
-					_cOccupancy_ElectronicsuTCA.fill(eid);
-					/*
+        } else {
+          _cOccupancy_FEDuTCA.fill(eid);
+          _cOccupancy_ElectronicsuTCA.fill(eid);
+          /*
 					if (!it->validate(0, it->size()))
 						_cCapIdRots_FEDuTCA.fill(eid, 1);*/
-				}
-			}
+        }
+      }
 
-			for (int i=0; i<digi.samples(); i++)
-			{
-				double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i);
-				//if (!_filter_QIE1011.filter(did)) {
-				_cADC_SubdetPM_QIE1011.fill(did, digi[i].adc());
-				_cfC_SubdetPM_QIE1011.fill(did, q);
-				_cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].le_tdc());
-				_cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].le_tdc());
-				if (digi[i].le_tdc() <50) {
-					double time = i*25. + (digi[i].le_tdc() / 2.);
-					_cLETDCTime_SubdetPM.fill(did, time);
-					_cLETDCTime_depth.fill(did, time);
-					_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
-				}
+      for (int i = 0; i < digi.samples(); i++) {
+        double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i);
+        //if (!_filter_QIE1011.filter(did)) {
+        _cADC_SubdetPM_QIE1011.fill(did, digi[i].adc());
+        _cfC_SubdetPM_QIE1011.fill(did, q);
+        _cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].le_tdc());
+        _cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].le_tdc());
+        if (digi[i].le_tdc() < 50) {
+          double time = i * 25. + (digi[i].le_tdc() / 2.);
+          _cLETDCTime_SubdetPM.fill(did, time);
+          _cLETDCTime_depth.fill(did, time);
+          _cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
+        }
 
-				// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we are seeing some in 2017 data.
-				if ((50 <= digi[i].le_tdc()) && (digi[i].le_tdc() <= 61)) {
-					_cBadTDCValues_SubdetPM.fill(did, digi[i].le_tdc());
-					_cBadTDCvsBX_SubdetPM.fill(did, bx);
-					_cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
-					_cBadTDCCount_depth.fill(did);
-				}
-				if (_ptype != fOffline) { // hidefed2crate
-					_cADCvsTS_SubdetPM_QIE1011.fill(did, (int)i, digi[i].adc());
-					if (sumQ>_cutSumQ_HF)
-						_cShapeCut_FED.fill(eid, (int)i, q);
-				}
-				//}
-			}
+        // Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we are seeing some in 2017 data.
+        if ((50 <= digi[i].le_tdc()) && (digi[i].le_tdc() <= 61)) {
+          _cBadTDCValues_SubdetPM.fill(did, digi[i].le_tdc());
+          _cBadTDCvsBX_SubdetPM.fill(did, bx);
+          _cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
+          _cBadTDCCount_depth.fill(did);
+        }
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cADCvsTS_SubdetPM_QIE1011.fill(did, (int)i, digi[i].adc());
+          if (sumQ > _cutSumQ_HF)
+            _cShapeCut_FED.fill(eid, (int)i, q);
+        }
+        //}
+      }
 
-			if (sumQ>_cutSumQ_HF)
-			{
-				double timing = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0,
-					digi.samples()-1);
-				double q1 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 1);
-				double q2 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 2);
-				double q2q12 = q2/(q1+q2);
-				_cSumQ_depth.fill(did, sumQ);
-				//if (!_filter_QIE1011.filter(did)) {
-				_cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
-				//}
-				_cTimingCut_SubdetPM.fill(did, timing);
-				_cTimingCut_depth.fill(did, timing);
-				_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
-				if (_ptype==fOnline)
-				{
-					//if (!_filter_QIE1011.filter(did)) {
-					_cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
-					//}
-					_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-					_cTimingCutvsieta_Subdet.fill(did, timing);
-					_cOccupancyCutvsiphi_SubdetPM.fill(did);
-					_cOccupancyCutvsieta_Subdet.fill(did);
-					_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-	//				_cOccupancyCutvsSlotvsLS_HFPM.fill(did, _currentLS);
-					_xUniHF.get(eid)++;
-				}
-				if (_ptype != fOffline) { // hidefed2crate
-					_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-				}
-				_cOccupancyCut_depth.fill(did);
-				if (!eid.isVMEid())
-					if (_ptype==fOnline)
-						_cQ2Q12CutvsLS_FEDHF.fill(eid, _currentLS, q2q12);
-				if (_ptype != fOffline) { // hidefed2crate
-					if (eid.isVMEid())
-					{
-						_cTimingCut_FEDVME.fill(eid, timing);
-						_cTimingCut_ElectronicsVME.fill(eid, timing);
-						_cOccupancyCut_FEDVME.fill(eid);
-						_cOccupancyCut_ElectronicsVME.fill(eid);
-					}
-					else 
-					{
-						_cTimingCut_FEDuTCA.fill(eid, timing);
-						_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-						_cOccupancyCut_FEDuTCA.fill(eid);
-						_cOccupancyCut_ElectronicsuTCA.fill(eid);
-					}
-				}
-				numChsCut++;
-			}
-			numChs++;
-		}
-	}
+      if (sumQ > _cutSumQ_HF) {
+        double timing = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples() - 1);
+        double q1 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 1);
+        double q2 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 2);
+        double q2q12 = q2 / (q1 + q2);
+        _cSumQ_depth.fill(did, sumQ);
+        //if (!_filter_QIE1011.filter(did)) {
+        _cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
+        //}
+        _cTimingCut_SubdetPM.fill(did, timing);
+        _cTimingCut_depth.fill(did, timing);
+        _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+        if (_ptype == fOnline) {
+          //if (!_filter_QIE1011.filter(did)) {
+          _cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
+          //}
+          _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+          _cTimingCutvsieta_Subdet.fill(did, timing);
+          _cOccupancyCutvsiphi_SubdetPM.fill(did);
+          _cOccupancyCutvsieta_Subdet.fill(did);
+          _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+          //				_cOccupancyCutvsSlotvsLS_HFPM.fill(did, _currentLS);
+          _xUniHF.get(eid)++;
+        }
+        if (_ptype != fOffline) {  // hidefed2crate
+          _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+        }
+        _cOccupancyCut_depth.fill(did);
+        if (!eid.isVMEid())
+          if (_ptype == fOnline)
+            _cQ2Q12CutvsLS_FEDHF.fill(eid, _currentLS, q2q12);
+        if (_ptype != fOffline) {  // hidefed2crate
+          if (eid.isVMEid()) {
+            _cTimingCut_FEDVME.fill(eid, timing);
+            _cTimingCut_ElectronicsVME.fill(eid, timing);
+            _cOccupancyCut_FEDVME.fill(eid);
+            _cOccupancyCut_ElectronicsVME.fill(eid);
+          } else {
+            _cTimingCut_FEDuTCA.fill(eid, timing);
+            _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+            _cOccupancyCut_FEDuTCA.fill(eid);
+            _cOccupancyCut_ElectronicsuTCA.fill(eid);
+          }
+        }
+        numChsCut++;
+      }
+      numChs++;
+    }
+  }
 
-	if (rawidValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, 
-			numChs);
-	
-		if (_ptype==fOnline)
-		{
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), 
-				_currentLS, numChsCut);
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx,
-				numChsCut);
-		}
-	}
+  if (rawidValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
+
+    if (_ptype == fOnline) {
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChsCut);
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx, numChsCut);
+    }
+  }
 }
 
-/* virtual */ void DigiTask::beginLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
-	if (_ptype == fOnline) {
-		// Reset the bin for _cCapid_BadvsFEDvsLSmod60
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-				it!=_vhashFEDs.end(); ++it) {
-			HcalElectronicsId eid = HcalElectronicsId(*it);
-			_cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 50, 0);
-		}	
-	}
+/* virtual */ void DigiTask::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
+  if (_ptype == fOnline) {
+    // Reset the bin for _cCapid_BadvsFEDvsLSmod60
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      HcalElectronicsId eid = HcalElectronicsId(*it);
+      _cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 50, 0);
+    }
+  }
 }
 
-/* virtual */ void DigiTask::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	if (_ptype!=fOnline)
-		return;
+/* virtual */ void DigiTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  if (_ptype != fOnline)
+    return;
 
-	for (uintCompactMap::const_iterator it=_xUniHF.begin();
-		it!=_xUniHF.end(); ++it)
-	{
-		uint32_t hash1 = it->first;
-		HcalElectronicsId eid1(hash1);
-		double x1 = it->second;
+  for (uintCompactMap::const_iterator it = _xUniHF.begin(); it != _xUniHF.end(); ++it) {
+    uint32_t hash1 = it->first;
+    HcalElectronicsId eid1(hash1);
+    double x1 = it->second;
 
-		for (uintCompactMap::const_iterator jt=_xUniHF.begin();
-			jt!=_xUniHF.end(); ++jt)
-		{
-			if (jt==it)
-				continue;
-			double x2 = jt->second;
-			if (x2==0)
-				continue;
-			if (x1/x2<_thresh_unihf)
-				_xUni.get(eid1)++;
-		}
-	}
+    for (uintCompactMap::const_iterator jt = _xUniHF.begin(); jt != _xUniHF.end(); ++jt) {
+      if (jt == it)
+        continue;
+      double x2 = jt->second;
+      if (x2 == 0)
+        continue;
+      if (x1 / x2 < _thresh_unihf)
+        _xUni.get(eid1)++;
+    }
+  }
 
-	if (_ptype != fOffline) { // hidefed2crate
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-			it!=_vhashFEDs.end(); ++it)
-		{
-			hcaldqm::flag::Flag fSum("DIGI");
-			HcalElectronicsId eid = HcalElectronicsId(*it);
+  if (_ptype != fOffline) {  // hidefed2crate
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      hcaldqm::flag::Flag fSum("DIGI");
+      HcalElectronicsId eid = HcalElectronicsId(*it);
 
-			std::vector<uint32_t>::const_iterator cit=std::find(
-				_vcdaqEids.begin(), _vcdaqEids.end(), *it);
-			if (cit==_vcdaqEids.end())
-			{
-				//	not @cDAQ
-				for (uint32_t iflag=0; iflag<_vflags.size(); iflag++)
-					_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-						int(hcaldqm::flag::fNCDAQ));
-				_cSummaryvsLS.setBinContent(eid, _currentLS, int(hcaldqm::flag::fNCDAQ));
-				continue;
-			}
+      std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
+      if (cit == _vcdaqEids.end()) {
+        //	not @cDAQ
+        for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
+          _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(hcaldqm::flag::fNCDAQ));
+        _cSummaryvsLS.setBinContent(eid, _currentLS, int(hcaldqm::flag::fNCDAQ));
+        continue;
+      }
 
-			//	FED is @cDAQ		
-			if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) ||
-				hcaldqm::utilities::isFEDHO(eid))
-			{
-				if (_xDigiSize.get(eid)>0)
-					_vflags[fDigiSize]._state = hcaldqm::flag::fBAD;
-				else
-					_vflags[fDigiSize]._state = hcaldqm::flag::fGOOD;
+      //	FED is @cDAQ
+      if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) || hcaldqm::utilities::isFEDHO(eid)) {
+        if (_xDigiSize.get(eid) > 0)
+          _vflags[fDigiSize]._state = hcaldqm::flag::fBAD;
+        else
+          _vflags[fDigiSize]._state = hcaldqm::flag::fGOOD;
 
-				if (_xBadCapid.get(eid) > 0) {
-					_vflags[fCapId]._state = hcaldqm::flag::fBAD;
-				} else {
-					_vflags[fCapId]._state = hcaldqm::flag::fGOOD;
-				}
+        if (_xBadCapid.get(eid) > 0) {
+          _vflags[fCapId]._state = hcaldqm::flag::fBAD;
+        } else {
+          _vflags[fCapId]._state = hcaldqm::flag::fGOOD;
+        }
 
-				if (hcaldqm::utilities::isFEDHF(eid))
-				{
-					double fr = double(_xNChs.get(eid))/double(
-						_xNChsNominal.get(eid)*_evsPerLS);
-					if (_runkeyVal==0 || _runkeyVal==4)
-					{
-						//	only for pp or hi
-						if (_xUni.get(eid)>0)
-							_vflags[fUni]._state = hcaldqm::flag::fPROBLEMATIC;
-						else
-							_vflags[fUni]._state = hcaldqm::flag::fGOOD;
-					}
-					if (fr<0.95)
-						_vflags[fNChsHF]._state = hcaldqm::flag::fBAD;
-					else if (fr<1.0)
-						_vflags[fNChsHF]._state = hcaldqm::flag::fPROBLEMATIC;
-					else
-						_vflags[fNChsHF]._state = hcaldqm::flag::fGOOD;
-				}
-			}
-			if (_unknownIdsPresent) 
-				_vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
-			else
-				_vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
+        if (hcaldqm::utilities::isFEDHF(eid)) {
+          double fr = double(_xNChs.get(eid)) / double(_xNChsNominal.get(eid) * _evsPerLS);
+          if (_runkeyVal == 0 || _runkeyVal == 4) {
+            //	only for pp or hi
+            if (_xUni.get(eid) > 0)
+              _vflags[fUni]._state = hcaldqm::flag::fPROBLEMATIC;
+            else
+              _vflags[fUni]._state = hcaldqm::flag::fGOOD;
+          }
+          if (fr < 0.95)
+            _vflags[fNChsHF]._state = hcaldqm::flag::fBAD;
+          else if (fr < 1.0)
+            _vflags[fNChsHF]._state = hcaldqm::flag::fPROBLEMATIC;
+          else
+            _vflags[fNChsHF]._state = hcaldqm::flag::fGOOD;
+        }
+      }
+      if (_unknownIdsPresent)
+        _vflags[fUnknownIds]._state = hcaldqm::flag::fBAD;
+      else
+        _vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
 
-			// LED misfires
-			if (_ptype != fLocal) {
-				if (hcaldqm::utilities::isFEDHBHE(eid)) {
-					HcalDetId did_hb(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalBarrel, 1, 1, 1)));
-					HcalDetId did_he(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalEndcap, 16, 1, 1)));
+      // LED misfires
+      if (_ptype != fLocal) {
+        if (hcaldqm::utilities::isFEDHBHE(eid)) {
+          HcalDetId did_hb(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalBarrel, 1, 1, 1)));
+          HcalDetId did_he(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalEndcap, 16, 1, 1)));
 
-					if (_LED_CUCountvsLS_Subdet.getBinContent(did_hb, _currentLS) > 0 || _LED_CUCountvsLS_Subdet.getBinContent(did_he, _currentLS) > 0) {
-						_vflags[fLED]._state = hcaldqm::flag::fBAD;
-					} else {
-						_vflags[fLED]._state = hcaldqm::flag::fGOOD;
-					}
-				} else if (hcaldqm::utilities::isFEDHF(eid)) {
-					HcalDetId did_hf(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalForward, 29, 1, 1)));
-					if (_LED_CUCountvsLS_Subdet.getBinContent(did_hf, _currentLS) > 0) {
-						_vflags[fLED]._state = hcaldqm::flag::fBAD;
-					} else {
-						_vflags[fLED]._state = hcaldqm::flag::fGOOD;
-					}
-				} else if (hcaldqm::utilities::isFEDHO(eid)) {
-					HcalDetId did_ho(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalOuter, 1, 1, 1)));
-					if (_LED_CUCountvsLS_Subdet.getBinContent(did_ho, _currentLS) > 0) {
-						_vflags[fLED]._state = hcaldqm::flag::fBAD;
-					} else {
-						_vflags[fLED]._state = hcaldqm::flag::fGOOD;
-					}
-				}
-			}
+          if (_LED_CUCountvsLS_Subdet.getBinContent(did_hb, _currentLS) > 0 ||
+              _LED_CUCountvsLS_Subdet.getBinContent(did_he, _currentLS) > 0) {
+            _vflags[fLED]._state = hcaldqm::flag::fBAD;
+          } else {
+            _vflags[fLED]._state = hcaldqm::flag::fGOOD;
+          }
+        } else if (hcaldqm::utilities::isFEDHF(eid)) {
+          HcalDetId did_hf(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalForward, 29, 1, 1)));
+          if (_LED_CUCountvsLS_Subdet.getBinContent(did_hf, _currentLS) > 0) {
+            _vflags[fLED]._state = hcaldqm::flag::fBAD;
+          } else {
+            _vflags[fLED]._state = hcaldqm::flag::fGOOD;
+          }
+        } else if (hcaldqm::utilities::isFEDHO(eid)) {
+          HcalDetId did_ho(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalOuter, 1, 1, 1)));
+          if (_LED_CUCountvsLS_Subdet.getBinContent(did_ho, _currentLS) > 0) {
+            _vflags[fLED]._state = hcaldqm::flag::fBAD;
+          } else {
+            _vflags[fLED]._state = hcaldqm::flag::fGOOD;
+          }
+        }
+      }
 
-			int iflag=0;
-			for (std::vector<hcaldqm::flag::Flag>::iterator ft=_vflags.begin();
-				ft!=_vflags.end(); ++ft)
-			{
-				_cSummaryvsLS_FED.setBinContent(eid, _currentLS, iflag,
-					int(ft->_state));
-				fSum+=(*ft);
-				iflag++;
+      int iflag = 0;
+      for (std::vector<hcaldqm::flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
+        _cSummaryvsLS_FED.setBinContent(eid, _currentLS, iflag, int(ft->_state));
+        fSum += (*ft);
+        iflag++;
 
-				//	reset!
-				ft->reset();
-			}
-			_cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
-		}
-	}
+        //	reset!
+        ft->reset();
+      }
+      _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
+    }
+  }
 
-	_xDigiSize.reset(); _xUniHF.reset(); _xUni.reset(); 
-	_xNChs.reset();
-	_xBadCapid.reset();
+  _xDigiSize.reset();
+  _xUniHF.reset();
+  _xUni.reset();
+  _xNChs.reset();
+  _xBadCapid.reset();
 
-	//	in the end always do the DQTask::endLumi
-	DQTask::endLuminosityBlock(lb, es);
+  //	in the end always do the DQTask::endLumi
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(DigiTask);
-

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -779,15 +779,15 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void DigiTask::_process(edm::Event const& e, edm::EventSetup const&) {
-  edm::Handle<QIE11DigiCollection>     c_qie11;
+  edm::Handle<QIE11DigiCollection>     c_QIE11;
   edm::Handle<HODigiCollection>       c_ho;
-  edm::Handle<QIE10DigiCollection>       c_qie10;
+  edm::Handle<QIE10DigiCollection>       c_QIE10;
 
-  if (!e.getByToken(_tokQIE11, c_qie11))
+  if (!e.getByToken(_tokQIE11, c_QIE11))
     _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagQIE11.label() + " " + _tagQIE11.instance());
   if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokQIE10, c_qie10))
+  if (!e.getByToken(_tokQIE10, c_QIE10))
     _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagQIE10.label() + " " + _tagQIE10.instance());
 
   //	extract some info per event
@@ -807,7 +807,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   int numChsCutHE = 0;
 
   // HB+HE QIE11 collection
-  for (QIE11DigiCollection::const_iterator it=c_qie11->begin(); it!=c_qie11->end();
+  for (QIE11DigiCollection::const_iterator it=c_QIE11->begin(); it!=c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
 
     //	Explicit check on the DetIds present in the Collection
@@ -1146,7 +1146,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   rawidValid = 0;
 
   //	HF collection
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
 
     //	Explicit check on the DetIds present in the Collection

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -94,7 +94,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   // Filters for QIE8 vs QIE10/11
   std::vector<uint32_t> vhashQIE8;
   vhashQIE8.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalOuter, 1,1,4)));  
-  _filter_QIE8.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet,
+  _filter_QIE8.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet,
     vhashQIE8);
 
   std::vector<uint32_t> vhashQIE1011; 
@@ -1234,6 +1234,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
     //if (!_filter_QIE1011.filter(did)) {
     _cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
     //}
+    
     _cOccupancy_depth.fill(did);
     if (_ptype == fOnline) {
       _xNChs.get(eid)++;

--- a/DQM/HcalTasks/plugins/FCDTask.cc
+++ b/DQM/HcalTasks/plugins/FCDTask.cc
@@ -2,105 +2,98 @@
 #include "DQM/HcalTasks/interface/FCDTask.h"
 
 bool operator==(const FCDTask::FCDChannel& lhs, const FCDTask::FCDChannel& rhs) {
-    return ((lhs.crate == rhs.crate) && (lhs.slot == rhs.slot) && (lhs.fiber == rhs.fiber) && (lhs.fiberChannel == rhs.fiberChannel));
+  return ((lhs.crate == rhs.crate) && (lhs.slot == rhs.slot) && (lhs.fiber == rhs.fiber) &&
+          (lhs.fiberChannel == rhs.fiberChannel));
 }
 
+FCDTask::FCDTask(edm::ParameterSet const& ps) {
+  //	tags
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis", "ZDC"));
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
 
-FCDTask::FCDTask(edm::ParameterSet const& ps)
-{
-	//	tags
-	_tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10",
-		edm::InputTag("hcalDigis", "ZDC"));
-	_tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
-
-	// channels
-	edm::ParameterSet channelPSet = ps.getParameter<edm::ParameterSet>("fcdChannels");
-	std::vector<int32_t> crates = channelPSet.getUntrackedParameter<std::vector<int32_t> >("crate");
-	std::vector<int32_t> slots = channelPSet.getUntrackedParameter<std::vector<int32_t> >("slot");
-	std::vector<int32_t> fibers = channelPSet.getUntrackedParameter<std::vector<int32_t> >("fiber");
-	std::vector<int32_t> fiberChannels = channelPSet.getUntrackedParameter<std::vector<int32_t> >("fiber_channel");
-	for (unsigned int i = 0; i < crates.size(); ++i) {
-		_channels.push_back({crates[i], slots[i], fibers[i], fiberChannels[i]});
-	}
+  // channels
+  edm::ParameterSet channelPSet = ps.getParameter<edm::ParameterSet>("fcdChannels");
+  std::vector<int32_t> crates = channelPSet.getUntrackedParameter<std::vector<int32_t> >("crate");
+  std::vector<int32_t> slots = channelPSet.getUntrackedParameter<std::vector<int32_t> >("slot");
+  std::vector<int32_t> fibers = channelPSet.getUntrackedParameter<std::vector<int32_t> >("fiber");
+  std::vector<int32_t> fiberChannels = channelPSet.getUntrackedParameter<std::vector<int32_t> >("fiber_channel");
+  for (unsigned int i = 0; i < crates.size(); ++i) {
+    _channels.push_back({crates[i], slots[i], fibers[i], fiberChannels[i]});
+  }
 }
 
-/* virtual */ void FCDTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	edm::ESHandle<HcalDbService> dbService;
-	es.get<HcalDbRecord>().get(dbService);
-	_emap = dbService->getHcalMapping();
-	_ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
+/* virtual */ void FCDTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  edm::ESHandle<HcalDbService> dbService;
+  es.get<HcalDbRecord>().get(dbService);
+  _emap = dbService->getHcalMapping();
+  _ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
 
-	ib.cd();
+  ib.cd();
 
-	//book histos per channel
-	std::string histoname;
-	std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-	for (auto& it_gid : gids) {
-		if (it_gid.genericSubdet() != HcalGenericDetId::HcalGenZDC) {
-			continue;
-		}
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(it_gid));
-		for (auto& it_channel : _channels) {
-			if ((eid.crateId() == it_channel.crate) && (eid.slot() == it_channel.slot) && (eid.fiberIndex() == it_channel.fiber) && (eid.fiberChanId() == it_channel.fiberChannel)) {
-				_fcd_eids.push_back(eid);
-			}
-		}
-	}
-	for (auto& it_eid : _fcd_eids) {
-		// EM Pos
-		histoname = std::to_string(it_eid.crateId()) + "-" + std::to_string(it_eid.slot()) + "-" + std::to_string(it_eid.fiberIndex()) + "-" + std::to_string(it_eid.fiberChanId());
-		ib.setCurrentFolder("Hcal/FCDTask/ADC");
-		_cADC[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC[it_eid]->setAxisTitle("ADC", 1);
-		_cADC[it_eid]->setAxisTitle("N", 2);
+  //book histos per channel
+  std::string histoname;
+  std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+  for (auto& it_gid : gids) {
+    if (it_gid.genericSubdet() != HcalGenericDetId::HcalGenZDC) {
+      continue;
+    }
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(it_gid));
+    for (auto& it_channel : _channels) {
+      if ((eid.crateId() == it_channel.crate) && (eid.slot() == it_channel.slot) &&
+          (eid.fiberIndex() == it_channel.fiber) && (eid.fiberChanId() == it_channel.fiberChannel)) {
+        _fcd_eids.push_back(eid);
+      }
+    }
+  }
+  for (auto& it_eid : _fcd_eids) {
+    // EM Pos
+    histoname = std::to_string(it_eid.crateId()) + "-" + std::to_string(it_eid.slot()) + "-" +
+                std::to_string(it_eid.fiberIndex()) + "-" + std::to_string(it_eid.fiberChanId());
+    ib.setCurrentFolder("Hcal/FCDTask/ADC");
+    _cADC[it_eid] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC[it_eid]->setAxisTitle("ADC", 1);
+    _cADC[it_eid]->setAxisTitle("N", 2);
 
-		ib.setCurrentFolder("Hcal/FCDTask/ADC_vs_TS"),
-		_cADC_vs_TS[it_eid] = ib.book2D( histoname.c_str(), histoname.c_str(), 10, 0, 10, 64, 0, 256);
-		_cADC_vs_TS[it_eid]->setAxisTitle("TS", 1);
-		_cADC_vs_TS[it_eid]->setAxisTitle("ADC", 2);
+    ib.setCurrentFolder("Hcal/FCDTask/ADC_vs_TS"),
+        _cADC_vs_TS[it_eid] = ib.book2D(histoname.c_str(), histoname.c_str(), 10, 0, 10, 64, 0, 256);
+    _cADC_vs_TS[it_eid]->setAxisTitle("TS", 1);
+    _cADC_vs_TS[it_eid]->setAxisTitle("ADC", 2);
 
-		ib.setCurrentFolder("Hcal/FCDTask/TDCTime");
-		_cTDCTime[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 500, 0., 250.);
-		_cTDCTime[it_eid]->setAxisTitle("TDC time [ns]", 1);
+    ib.setCurrentFolder("Hcal/FCDTask/TDCTime");
+    _cTDCTime[it_eid] = ib.book1D(histoname.c_str(), histoname.c_str(), 500, 0., 250.);
+    _cTDCTime[it_eid]->setAxisTitle("TDC time [ns]", 1);
 
-
-		ib.setCurrentFolder("Hcal/FCDTask/TDC");
-		_cTDC[it_eid] = ib.book1D( histoname.c_str(), histoname.c_str(), 64, -0.5, 63.5);
-		_cTDC[it_eid]->setAxisTitle("TDC", 1);
-
-	}
+    ib.setCurrentFolder("Hcal/FCDTask/TDC");
+    _cTDC[it_eid] = ib.book1D(histoname.c_str(), histoname.c_str(), 64, -0.5, 63.5);
+    _cTDC[it_eid]->setAxisTitle("TDC", 1);
+  }
 }
 
+/* virtual */ void FCDTask::analyze(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<QIE10DigiCollection> digis;
+  if (!e.getByToken(_tokQIE10, digis))
+    edm::LogError("Collection QIE10DigiCollection for ZDC isn't available" + _tagQIE10.label() + " " +
+                  _tagQIE10.instance());
 
-/* virtual */ void FCDTask::analyze(edm::Event const& e, edm::EventSetup const&)
-{
-	edm::Handle<QIE10DigiCollection> digis;
-	if (!e.getByToken(_tokQIE10, digis))
-		edm::LogError("Collection QIE10DigiCollection for ZDC isn't available"
-				+ _tagQIE10.label() + " " + _tagQIE10.instance());
+  for (auto it = digis->begin(); it != digis->end(); it++) {
+    const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+    HcalGenericDetId const& gdid = digi.detid();
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(gdid));
+    if (std::find(_fcd_eids.begin(), _fcd_eids.end(), eid) == _fcd_eids.end()) {
+      continue;
+    }
 
-	for ( auto it = digis->begin(); it != digis->end(); it++ ) {
-		const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
-		HcalGenericDetId const& gdid = digi.detid();
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(gdid));
-		if (std::find(_fcd_eids.begin(), _fcd_eids.end(), eid) == _fcd_eids.end()) {
-			continue;
-		}
-
-		for ( int i = 0; i < digi.samples(); i++ ) {
-			// iter over all samples
-			_cADC[eid]->Fill(digi[i].adc());
-			_cADC_vs_TS[eid]->Fill(i, digi[i].adc());
-			_cTDC[eid]->Fill(digi[i].le_tdc());
-			if (digi[i].le_tdc() <= 50.) {
-				double tdctime = 25. * i + 0.5 * digi[i].le_tdc();
-				_cTDCTime[eid]->Fill(tdctime);
-			}
-		}
-	}
+    for (int i = 0; i < digi.samples(); i++) {
+      // iter over all samples
+      _cADC[eid]->Fill(digi[i].adc());
+      _cADC_vs_TS[eid]->Fill(i, digi[i].adc());
+      _cTDC[eid]->Fill(digi[i].le_tdc());
+      if (digi[i].le_tdc() <= 50.) {
+        double tdctime = 25. * i + 0.5 * digi[i].le_tdc();
+        _cTDCTime[eid]->Fill(tdctime);
+      }
+    }
+  }
 }
-
 
 DEFINE_FWK_MODULE(FCDTask);

--- a/DQM/HcalTasks/plugins/HFRaddamTask.cc
+++ b/DQM/HcalTasks/plugins/HFRaddamTask.cc
@@ -1,150 +1,130 @@
-	
+
 #include "DQM/HcalTasks/interface/HFRaddamTask.h"
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
-HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	//	List all the DetIds
-	_vDetIds.push_back(HcalDetId(HcalForward, -30, 35, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -30, 71, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -32, 15, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -32, 51, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -34, 35, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -34, 71, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -36, 15, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -36, 51, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -38, 35, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -38, 71, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -40, 15, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -40, 51, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -41, 35, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -41, 71, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, -30, 15, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -30, 51, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -32, 35, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -32, 71, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -34, 15, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -34, 51, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -36, 35, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -36, 71, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -38, 15, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -38, 51, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -40, 35, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -40, 71, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -41, 15, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, -41, 51, 2));
+HFRaddamTask::HFRaddamTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  //	List all the DetIds
+  _vDetIds.push_back(HcalDetId(HcalForward, -30, 35, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -30, 71, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -32, 15, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -32, 51, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -34, 35, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -34, 71, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -36, 15, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -36, 51, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -38, 35, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -38, 71, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -40, 15, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -40, 51, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -41, 35, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -41, 71, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, -30, 15, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -30, 51, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -32, 35, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -32, 71, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -34, 15, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -34, 51, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -36, 35, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -36, 71, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -38, 15, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -38, 51, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -40, 35, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -40, 71, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -41, 15, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, -41, 51, 2));
 
-	_vDetIds.push_back(HcalDetId(HcalForward, 30, 21, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 30, 57, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 32, 1, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 32, 37, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 34, 21, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 34, 57, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 36, 1, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 36, 37, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 38, 21, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 38, 57, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 40, 35, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 40, 71, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 41, 19, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 41, 55, 1));
-	_vDetIds.push_back(HcalDetId(HcalForward, 30, 1, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 30, 37, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 32, 21, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 32, 57, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 34, 1, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 34, 37, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 36, 21, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 36, 57, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 38, 1, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 38, 37, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 40, 19, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 40, 55, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 41, 35, 2));
-	_vDetIds.push_back(HcalDetId(HcalForward, 41, 71, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 30, 21, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 30, 57, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 32, 1, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 32, 37, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 34, 21, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 34, 57, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 36, 1, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 36, 37, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 38, 21, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 38, 57, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 40, 35, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 40, 71, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 41, 19, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 41, 55, 1));
+  _vDetIds.push_back(HcalDetId(HcalForward, 30, 1, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 30, 37, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 32, 21, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 32, 57, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 34, 1, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 34, 37, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 36, 21, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 36, 57, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 38, 1, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 38, 37, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 40, 19, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 40, 55, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 41, 35, 2));
+  _vDetIds.push_back(HcalDetId(HcalForward, 41, 71, 2));
 
-	//	tags
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", 
-		edm::InputTag("hcalDigis"));
-	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
-		edm::InputTag("hcalDigis"));
-	_tokHF = consumes<HFDigiCollection>(_tagHF);
-	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
+  //	tags
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
+  _tokHF = consumes<HFDigiCollection>(_tagHF);
+  _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 }
 
-/* virtual */ void HFRaddamTask::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	//	Initialize all the Single Containers
-	for (std::vector<HcalDetId>::const_iterator it=_vDetIds.begin();
-		it!=_vDetIds.end(); ++it)
-	{
-		_vcShape.push_back(ContainerSingle1D(_name, 
-			"Shape",
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000)));
-	}
+/* virtual */ void HFRaddamTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  //	Initialize all the Single Containers
+  for (std::vector<HcalDetId>::const_iterator it = _vDetIds.begin(); it != _vDetIds.end(); ++it) {
+    _vcShape.push_back(ContainerSingle1D(_name,
+                                         "Shape",
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000)));
+  }
 
-	DQTask::bookHistograms(ib, r, es);	
-	char aux[200];
-	for (unsigned int i=0; i<_vDetIds.size(); i++)
-	{
-		sprintf(aux, "ieta%diphi%dd%d", _vDetIds[i].ieta(), 
-			_vDetIds[i].iphi(), _vDetIds[i].depth());
-		_vcShape[i].book(ib, _subsystem, aux);
-	}
+  DQTask::bookHistograms(ib, r, es);
+  char aux[200];
+  for (unsigned int i = 0; i < _vDetIds.size(); i++) {
+    sprintf(aux, "ieta%diphi%dd%d", _vDetIds[i].ieta(), _vDetIds[i].iphi(), _vDetIds[i].depth());
+    _vcShape[i].book(ib, _subsystem, aux);
+  }
 }
 
-/* virtual */ void HFRaddamTask::_process(edm::Event const &e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HFDigiCollection> chf;
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection HFDigiCollection isn't avalaible"
-			+ _tagHF.label() + " " + _tagHF.instance());
+/* virtual */ void HFRaddamTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HFDigiCollection> chf;
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection HFDigiCollection isn't avalaible" + _tagHF.label() + " " + _tagHF.instance());
 
-	for (HFDigiCollection::const_iterator it=chf->begin(); 
-		it!=chf->end(); ++it)
-	{
-		const HFDataFrame digi = (const HFDataFrame)(*it);
-		for (unsigned int i=0; i<_vDetIds.size(); i++)
-			if (digi.id()==_vDetIds[i])
-			{
-				for (int j=0; j<digi.size(); j++)
-					_vcShape[i].fill(j, 
-						digi.sample(j).nominal_fC()-2.5);
-			}
-	}
+  for (HFDigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    const HFDataFrame digi = (const HFDataFrame)(*it);
+    for (unsigned int i = 0; i < _vDetIds.size(); i++)
+      if (digi.id() == _vDetIds[i]) {
+        for (int j = 0; j < digi.size(); j++)
+          _vcShape[i].fill(j, digi.sample(j).nominal_fC() - 2.5);
+      }
+  }
 }
 
-/* virtual */ bool HFRaddamTask::_isApplicable(edm::Event const &e)
-{
-	if (_ptype==fOnline)
-	{
-		edm::Handle<HcalUMNioDigi> cumn;
-		if (!e.getByToken(_tokuMN, cumn))
-			return false;
+/* virtual */ bool HFRaddamTask::_isApplicable(edm::Event const& e) {
+  if (_ptype == fOnline) {
+    edm::Handle<HcalUMNioDigi> cumn;
+    if (!e.getByToken(_tokuMN, cumn))
+      return false;
 
-		//  event type check first
-		uint8_t eventType = cumn->eventType();
-		if (eventType!=constants::EVENTTYPE_LASER)
-			return false;
+    //  event type check first
+    uint8_t eventType = cumn->eventType();
+    if (eventType != constants::EVENTTYPE_LASER)
+      return false;
 
-		//  check if this analysis task is of the right laser type
-		uint32_t laserType = cumn->valueUserWord(0);
-		if (laserType==constants::tHFRaddam) return true;
-	}
-	else
-	{
-		//	local, just return true as all the settings will be done in cfg
-		return true;
-	}
+    //  check if this analysis task is of the right laser type
+    uint32_t laserType = cumn->valueUserWord(0);
+    if (laserType == constants::tHFRaddam)
+      return true;
+  } else {
+    //	local, just return true as all the settings will be done in cfg
+    return true;
+  }
 
-	return false;
+  return false;
 }
 
 DEFINE_FWK_MODULE(HFRaddamTask);

--- a/DQM/HcalTasks/plugins/HcalOfflineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOfflineHarvesting.cc
@@ -4,145 +4,132 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
-HcalOfflineHarvesting::HcalOfflineHarvesting(edm::ParameterSet const& ps) :
-	DQHarvester(ps), _reportSummaryMap(nullptr)
-{
-	_summaryList.push_back(fTP);
-	_summaryList.push_back(fDigi);
-	_summaryList.push_back(fReco);
-	_sumnames[fRaw]="RawTask";
-	_sumnames[fDigi]="DigiTask";
-	_sumnames[fReco]="RecHitTask";
-	_sumnames[fTP]="TPTask";
-	for (auto& it_sum : _summaryList) {
-		_summarks[it_sum]=false;
-	}
+HcalOfflineHarvesting::HcalOfflineHarvesting(edm::ParameterSet const& ps)
+    : DQHarvester(ps), _reportSummaryMap(nullptr) {
+  _summaryList.push_back(fTP);
+  _summaryList.push_back(fDigi);
+  _summaryList.push_back(fReco);
+  _sumnames[fRaw] = "RawTask";
+  _sumnames[fDigi] = "DigiTask";
+  _sumnames[fReco] = "RecHitTask";
+  _sumnames[fTP] = "TPTask";
+  for (auto& it_sum : _summaryList) {
+    _summarks[it_sum] = false;
+  }
 
-	if (std::find(_summaryList.begin(), _summaryList.end(), fRaw) != _summaryList.end()) {
-		_sumgen[fRaw]=new hcaldqm::RawRunSummary("RawRunHarvesting", _sumnames[fRaw],ps);
-	}
-	if (std::find(_summaryList.begin(), _summaryList.end(), fDigi) != _summaryList.end()) {
-		_sumgen[fDigi]=new hcaldqm::DigiRunSummary("DigiRunHarvesting", _sumnames[fDigi],ps);
-	}
-	if (std::find(_summaryList.begin(), _summaryList.end(), fReco) != _summaryList.end()) {
-		_sumgen[fReco]=new hcaldqm::RecoRunSummary("RecoRunHarvesting", _sumnames[fReco],ps);
-	}
-	if (std::find(_summaryList.begin(), _summaryList.end(), fTP) != _summaryList.end()) {
-		_sumgen[fTP]=new hcaldqm::TPRunSummary("TPRunHarvesting", _sumnames[fTP],ps);
-	}
+  if (std::find(_summaryList.begin(), _summaryList.end(), fRaw) != _summaryList.end()) {
+    _sumgen[fRaw] = new hcaldqm::RawRunSummary("RawRunHarvesting", _sumnames[fRaw], ps);
+  }
+  if (std::find(_summaryList.begin(), _summaryList.end(), fDigi) != _summaryList.end()) {
+    _sumgen[fDigi] = new hcaldqm::DigiRunSummary("DigiRunHarvesting", _sumnames[fDigi], ps);
+  }
+  if (std::find(_summaryList.begin(), _summaryList.end(), fReco) != _summaryList.end()) {
+    _sumgen[fReco] = new hcaldqm::RecoRunSummary("RecoRunHarvesting", _sumnames[fReco], ps);
+  }
+  if (std::find(_summaryList.begin(), _summaryList.end(), fTP) != _summaryList.end()) {
+    _sumgen[fTP] = new hcaldqm::TPRunSummary("TPRunHarvesting", _sumnames[fTP], ps);
+  }
 }
 
-/* virtual */ void HcalOfflineHarvesting::beginRun(
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQHarvester::beginRun(r,es);
+/* virtual */ void HcalOfflineHarvesting::beginRun(edm::Run const& r, edm::EventSetup const& es) {
+  DQHarvester::beginRun(r, es);
 
-	for (auto& it_sum : _summaryList) {
-		_sumgen[it_sum]->beginRun(r,es);
-	}
+  for (auto& it_sum : _summaryList) {
+    _sumgen[it_sum]->beginRun(r, es);
+  }
 }
 
 //
 //	For OFFLINE there is no per LS evaluation
 //
-/* virtual */ void HcalOfflineHarvesting::_dqmEndLuminosityBlock(
-	DQMStore::IBooker& ib,
-	DQMStore::IGetter& ig, edm::LuminosityBlock const& lb, 
-	edm::EventSetup const& es)
-{	
-	for (auto& it_sum : _summaryList) {
-		if (ig.get(_subsystem + "/" + _sumnames[it_sum] + "/EventsTotal") != nullptr) {
-			_summarks[it_sum] = true;
-		}
-	}
+/* virtual */ void HcalOfflineHarvesting::_dqmEndLuminosityBlock(DQMStore::IBooker& ib,
+                                                                 DQMStore::IGetter& ig,
+                                                                 edm::LuminosityBlock const& lb,
+                                                                 edm::EventSetup const& es) {
+  for (auto& it_sum : _summaryList) {
+    if (ig.get(_subsystem + "/" + _sumnames[it_sum] + "/EventsTotal") != nullptr) {
+      _summarks[it_sum] = true;
+    }
+  }
 
-	//	CALL ALL THE HARVESTERS
-	for (auto& it_sum : _summaryList) {
-		//	run only if have to
-		if (_summarks[it_sum]) {
-			(_sumgen[it_sum])->endLuminosityBlock(ib,ig,lb,es);
-		}
-	}
+  //	CALL ALL THE HARVESTERS
+  for (auto& it_sum : _summaryList) {
+    //	run only if have to
+    if (_summarks[it_sum]) {
+      (_sumgen[it_sum])->endLuminosityBlock(ib, ig, lb, es);
+    }
+  }
 }
 
 //
 //	Evaluate and Generate Run Summary
 //
-/* virtual */ void HcalOfflineHarvesting::_dqmEndJob(DQMStore::IBooker& ib,
-	DQMStore::IGetter& ig)
-{
-	//	OBTAIN/SET WHICH MODULES ARE PRESENT
-	std::map<Summary, std::string> datatier_names;
-	datatier_names[fRaw] = "RAW";
-	datatier_names[fDigi] = "DIGI";
-	datatier_names[fReco] = "RECO";
-	datatier_names[fTP] = "TP";
+/* virtual */ void HcalOfflineHarvesting::_dqmEndJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {
+  //	OBTAIN/SET WHICH MODULES ARE PRESENT
+  std::map<Summary, std::string> datatier_names;
+  datatier_names[fRaw] = "RAW";
+  datatier_names[fDigi] = "DIGI";
+  datatier_names[fReco] = "RECO";
+  datatier_names[fTP] = "TP";
 
-	int num=0; std::map<std::string, int> datatiers;
-	for (auto& it_sum : _summaryList) {
-		if (_summarks[it_sum]) {
-			datatiers.insert(std::pair<std::string, int>(datatier_names[it_sum], num));
-			++num;
-		}
-	}
-	
-	//	CREATE THE REPORT SUMMARY MAP
-	//	num is #modules
-	//	datatiers - std map [DATATIER_NAME] -> [positional value [0,num-1]]
-	//	-> bin wise +1 should be
-	if (!_reportSummaryMap)
-	{
-		ib.setCurrentFolder(_subsystem+"/EventInfo");
-		_reportSummaryMap = ib.book2D("reportSummaryMap", "reportSummaryMap",
-			_vCrates.size(), 0, _vCrates.size(), num,0,num);
-		//	x axis labels
-		
-		for (uint32_t i=0; i<_vCrates.size(); i++)
-		{
-			char name[5];
-			sprintf(name, "%d", _vCrates[i]);
-			_reportSummaryMap->setBinLabel(i+1, name, 1);
-		}
-		//	y axis lables
-		for (std::map<std::string, int>::const_iterator
-			it=datatiers.begin(); it!=datatiers.end(); ++it)
-		{
-			std::string name = it->first;
-			int value = it->second;
-			_reportSummaryMap->setBinLabel(value+1, name, 2);
-		}
-	}
+  int num = 0;
+  std::map<std::string, int> datatiers;
+  for (auto& it_sum : _summaryList) {
+    if (_summarks[it_sum]) {
+      datatiers.insert(std::pair<std::string, int>(datatier_names[it_sum], num));
+      ++num;
+    }
+  }
 
-	//	iterate over all summary generators and get the flags
-	for (auto& it_sum : _summaryList) {
-		//	IF MODULE IS NOT PRESENT IN DATA SKIP
-		if (!_summarks[it_sum]) {
-			continue;
-		}
+  //	CREATE THE REPORT SUMMARY MAP
+  //	num is #modules
+  //	datatiers - std map [DATATIER_NAME] -> [positional value [0,num-1]]
+  //	-> bin wise +1 should be
+  if (!_reportSummaryMap) {
+    ib.setCurrentFolder(_subsystem + "/EventInfo");
+    _reportSummaryMap =
+        ib.book2D("reportSummaryMap", "reportSummaryMap", _vCrates.size(), 0, _vCrates.size(), num, 0, num);
+    //	x axis labels
 
-		//	OBTAIN ALL THE FLAGS FOR THIS MODULE
-		//	AND SET THE REPORT STATUS MAP
-		//	NOTE AGAIN: datatiers map [DATATIER]->[value not bin!]+1 therefore
-		if (_debug>0) {
-			std::cout << _sumnames[it_sum] << std::endl;
-		}
-		std::vector<hcaldqm::flag::Flag> flags = (_sumgen[it_sum])->endJob(ib,ig);
-		if (_debug>0)
-		{
-			std::cout << "********************" << std::endl;
-			std::cout << "SUMMARY" << std::endl;
-		}
-		for (uint32_t icrate=0; icrate<_vCrates.size(); icrate++)
-		{
-			_reportSummaryMap->setBinContent(icrate+1, datatiers[flags[icrate]._name]+1, (int)flags[icrate]._state);
-			if (_debug>0)
-			{
-				std::cout << "Crate=" << _vCrates[icrate] << std::endl;
-				std::cout << flags[icrate]._name << "  " << flags[icrate]._state
-				<<std::endl;
-			}
-		}
-	}
+    for (uint32_t i = 0; i < _vCrates.size(); i++) {
+      char name[5];
+      sprintf(name, "%d", _vCrates[i]);
+      _reportSummaryMap->setBinLabel(i + 1, name, 1);
+    }
+    //	y axis lables
+    for (std::map<std::string, int>::const_iterator it = datatiers.begin(); it != datatiers.end(); ++it) {
+      std::string name = it->first;
+      int value = it->second;
+      _reportSummaryMap->setBinLabel(value + 1, name, 2);
+    }
+  }
+
+  //	iterate over all summary generators and get the flags
+  for (auto& it_sum : _summaryList) {
+    //	IF MODULE IS NOT PRESENT IN DATA SKIP
+    if (!_summarks[it_sum]) {
+      continue;
+    }
+
+    //	OBTAIN ALL THE FLAGS FOR THIS MODULE
+    //	AND SET THE REPORT STATUS MAP
+    //	NOTE AGAIN: datatiers map [DATATIER]->[value not bin!]+1 therefore
+    if (_debug > 0) {
+      std::cout << _sumnames[it_sum] << std::endl;
+    }
+    std::vector<hcaldqm::flag::Flag> flags = (_sumgen[it_sum])->endJob(ib, ig);
+    if (_debug > 0) {
+      std::cout << "********************" << std::endl;
+      std::cout << "SUMMARY" << std::endl;
+    }
+    for (uint32_t icrate = 0; icrate < _vCrates.size(); icrate++) {
+      _reportSummaryMap->setBinContent(icrate + 1, datatiers[flags[icrate]._name] + 1, (int)flags[icrate]._state);
+      if (_debug > 0) {
+        std::cout << "Crate=" << _vCrates[icrate] << std::endl;
+        std::cout << flags[icrate]._name << "  " << flags[icrate]._state << std::endl;
+      }
+    }
+  }
 }
 
 DEFINE_FWK_MODULE(HcalOfflineHarvesting);

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -3,178 +3,162 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 
-HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
-	DQHarvester(ps), _nBad(0), _nTotal(0), _reportSummaryMap(nullptr)
-{
+HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps)
+    : DQHarvester(ps), _nBad(0), _nTotal(0), _reportSummaryMap(nullptr) {
+  //	NOTE: I will leave Run Summary Generators in place
+  //	just not triggering on endJob!
+  _vsumgen.resize(nSummary);
+  _vnames.resize(nSummary);
+  _vmarks.resize(nSummary);
+  for (uint32_t i = 0; i < _vmarks.size(); i++)
+    _vmarks[i] = false;
+  _vnames[fRaw] = "RawTask";
+  _vnames[fDigi] = "DigiTask";
+  _vnames[fReco] = "RecHitTask";
+  _vnames[fTP] = "TPTask";
+  _vnames[fPedestal] = "PedestalTask";
 
-	//	NOTE: I will leave Run Summary Generators in place 
-	//	just not triggering on endJob!
-	_vsumgen.resize(nSummary);
-	_vnames.resize(nSummary);
-	_vmarks.resize(nSummary);
-	for (uint32_t i=0; i<_vmarks.size(); i++)
-		_vmarks[i]=false;
-	_vnames[fRaw]="RawTask";
-	_vnames[fDigi]="DigiTask";
-	_vnames[fReco]="RecHitTask";
-	_vnames[fTP]="TPTask";
-	_vnames[fPedestal]="PedestalTask";
+  _vsumgen[fRaw] = new hcaldqm::RawRunSummary("RawRunHarvesting", _vnames[fRaw], ps);
+  _vsumgen[fDigi] = new hcaldqm::DigiRunSummary("DigiRunHarvesting", _vnames[fDigi], ps);
+  _vsumgen[fReco] = new hcaldqm::RecoRunSummary("RecoRunHarvesting", _vnames[fReco], ps);
+  _vsumgen[fTP] = new hcaldqm::TPRunSummary("TPRunHarvesting", _vnames[fTP], ps);
+  _vsumgen[fPedestal] = new hcaldqm::PedestalRunSummary("PedestalRunHarvesting", _vnames[fPedestal], ps);
 
-	_vsumgen[fRaw] = new hcaldqm::RawRunSummary("RawRunHarvesting",
-		_vnames[fRaw], ps);
-	_vsumgen[fDigi] = new hcaldqm::DigiRunSummary("DigiRunHarvesting", 
-		_vnames[fDigi],ps);
-	_vsumgen[fReco] = new hcaldqm::RecoRunSummary("RecoRunHarvesting",
-		_vnames[fReco], ps);
-	_vsumgen[fTP] = new hcaldqm::TPRunSummary("TPRunHarvesting",
-		_vnames[fTP], ps);
-	_vsumgen[fPedestal] = new hcaldqm::PedestalRunSummary("PedestalRunHarvesting",
-		_vnames[fPedestal], ps);
-
-	_thresh_bad_bad = ps.getUntrackedParameter("thresh_bad_bad", 0.05);
+  _thresh_bad_bad = ps.getUntrackedParameter("thresh_bad_bad", 0.05);
 }
 
-/* virtual */ void HcalOnlineHarvesting::beginRun(
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQHarvester::beginRun(r,es);
-	for (std::vector<DQClient*>::const_iterator it=_vsumgen.begin();
-		it!=_vsumgen.end(); ++it)
-		(*it)->beginRun(r,es);
+/* virtual */ void HcalOnlineHarvesting::beginRun(edm::Run const& r, edm::EventSetup const& es) {
+  DQHarvester::beginRun(r, es);
+  for (std::vector<DQClient*>::const_iterator it = _vsumgen.begin(); it != _vsumgen.end(); ++it)
+    (*it)->beginRun(r, es);
 }
 
-/* virtual */ void HcalOnlineHarvesting::_dqmEndLuminosityBlock(
-	DQMStore::IBooker& ib,
-	DQMStore::IGetter& ig, edm::LuminosityBlock const&, 
-	edm::EventSetup const&)
-{
-	//	DETERMINE WHICH MODULES ARE PRESENT IN DATA
-	if (ig.get(_subsystem+"/"+_vnames[fRaw]+"/EventsTotal")!=nullptr)
-		_vmarks[fRaw]=true;
-	if (ig.get(_subsystem+"/"+_vnames[fDigi]+"/EventsTotal")!=nullptr)
-		_vmarks[fDigi]=true;
-	if (ig.get(_subsystem+"/"+_vnames[fTP]+"/EventsTotal")!=nullptr)
-		_vmarks[fTP]=true;
-	if (ig.get(_subsystem+"/"+_vnames[fReco]+"/EventsTotal")!=nullptr)
-		_vmarks[fReco]=true;
-	if (ig.get(_subsystem+"/"+_vnames[fPedestal]+"/EventsTotal")!=nullptr)
-		_vmarks[fPedestal]=true;
+/* virtual */ void HcalOnlineHarvesting::_dqmEndLuminosityBlock(DQMStore::IBooker& ib,
+                                                                DQMStore::IGetter& ig,
+                                                                edm::LuminosityBlock const&,
+                                                                edm::EventSetup const&) {
+  //	DETERMINE WHICH MODULES ARE PRESENT IN DATA
+  if (ig.get(_subsystem + "/" + _vnames[fRaw] + "/EventsTotal") != nullptr)
+    _vmarks[fRaw] = true;
+  if (ig.get(_subsystem + "/" + _vnames[fDigi] + "/EventsTotal") != nullptr)
+    _vmarks[fDigi] = true;
+  if (ig.get(_subsystem + "/" + _vnames[fTP] + "/EventsTotal") != nullptr)
+    _vmarks[fTP] = true;
+  if (ig.get(_subsystem + "/" + _vnames[fReco] + "/EventsTotal") != nullptr)
+    _vmarks[fReco] = true;
+  if (ig.get(_subsystem + "/" + _vnames[fPedestal] + "/EventsTotal") != nullptr)
+    _vmarks[fPedestal] = true;
 
-	//	CREATE SUMMARY REPORT MAP FED vs LS and LOAD MODULE'S SUMMARIES
-	//	NOTE: THIS STATEMENTS WILL BE EXECUTED ONLY ONCE!
-	if (!_reportSummaryMap)
-	{
-		ig.setCurrentFolder(_subsystem+"/EventInfo");
-		_reportSummaryMap = ib.book2D("reportSummaryMap", "reportSummaryMap",
-			_maxLS, 1, _maxLS+1, _vFEDs.size(), 0, _vFEDs.size());
-		for (uint32_t i=0; i<_vFEDs.size(); i++)
-		{
-			char name[5];
-			sprintf(name, "%d", _vFEDs[i]);
-			_reportSummaryMap->setBinLabel(i+1, name, 2);
-		}
-		//	set LS bit to mark Xaxis as LS axis
-		_reportSummaryMap->getTH1()->SetBit(BIT(BIT_OFFSET+BIT_AXIS_LS));
+  //	CREATE SUMMARY REPORT MAP FED vs LS and LOAD MODULE'S SUMMARIES
+  //	NOTE: THIS STATEMENTS WILL BE EXECUTED ONLY ONCE!
+  if (!_reportSummaryMap) {
+    ig.setCurrentFolder(_subsystem + "/EventInfo");
+    _reportSummaryMap =
+        ib.book2D("reportSummaryMap", "reportSummaryMap", _maxLS, 1, _maxLS + 1, _vFEDs.size(), 0, _vFEDs.size());
+    for (uint32_t i = 0; i < _vFEDs.size(); i++) {
+      char name[5];
+      sprintf(name, "%d", _vFEDs[i]);
+      _reportSummaryMap->setBinLabel(i + 1, name, 2);
+    }
+    //	set LS bit to mark Xaxis as LS axis
+    _reportSummaryMap->getTH1()->SetBit(BIT(BIT_OFFSET + BIT_AXIS_LS));
 
-		// INITIALIZE ALL THE MODULES
-		for (uint32_t i=0; i<_vnames.size(); i++)
-			_vcSummaryvsLS.push_back(ContainerSingle2D(_vnames[i],
-				"SummaryvsLS",
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FEDQuantity(_vFEDs),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState)));
+    // INITIALIZE ALL THE MODULES
+    for (uint32_t i = 0; i < _vnames.size(); i++)
+      _vcSummaryvsLS.push_back(ContainerSingle2D(_vnames[i],
+                                                 "SummaryvsLS",
+                                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                                 new hcaldqm::quantity::FEDQuantity(_vFEDs),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState)));
 
-		//	LOAD ONLY THOSE MODULES THAT ARE PRESENT IN DATA
-		for (uint32_t i=0; i<_vmarks.size(); i++)
-		{
-			if (_vmarks[i])
-				_vcSummaryvsLS[i].load(ig, _subsystem);
-		}
+    //	LOAD ONLY THOSE MODULES THAT ARE PRESENT IN DATA
+    for (uint32_t i = 0; i < _vmarks.size(); i++) {
+      if (_vmarks[i])
+        _vcSummaryvsLS[i].load(ig, _subsystem);
+    }
 
-		//	Create a map of bad channels and fill
-		_cKnownBadChannels_depth.initialize("RunInfo", "KnownBadChannels",
-			hcaldqm::hashfunctions::fdepth,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cKnownBadChannels_depth.book(ib, _emap, _subsystem);
-		for (uintCompactMap::const_iterator it=_xQuality.begin();
-			it!=_xQuality.end(); ++it)
-			_cKnownBadChannels_depth.fill(HcalDetId(it->first));
+    //	Create a map of bad channels and fill
+    _cKnownBadChannels_depth.initialize("RunInfo",
+                                        "KnownBadChannels",
+                                        hcaldqm::hashfunctions::fdepth,
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cKnownBadChannels_depth.book(ib, _emap, _subsystem);
+    for (uintCompactMap::const_iterator it = _xQuality.begin(); it != _xQuality.end(); ++it)
+      _cKnownBadChannels_depth.fill(HcalDetId(it->first));
 
-		ig.setCurrentFolder(_subsystem+"/EventInfo");
-		_runSummary = ib.book2D("runSummary", "runSummary",
-			1, 0, 1, 1, 0, 1);
-	}
+    ig.setCurrentFolder(_subsystem + "/EventInfo");
+    _runSummary = ib.book2D("runSummary", "runSummary", 1, 0, 1, 1, 0, 1);
+  }
 
-	int ifed=0;
-	hcaldqm::flag::Flag fTotal("Status", hcaldqm::flag::fNCDAQ);
-	if (_ptype != fOffline) { // hidefed2crate
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-			it!=_vhashFEDs.end(); ++it)
-		{
-			HcalElectronicsId eid(*it);
-			hcaldqm::flag::Flag fSum("Status", hcaldqm::flag::fNCDAQ);
-			for (uint32_t im=0; im<_vmarks.size(); im++)
-				if (_vmarks[im])
-				{
-					int x = _vcSummaryvsLS[im].getBinContent(eid, _currentLS);
-					hcaldqm::flag::Flag flag("Status", (hcaldqm::flag::State)x);
-					fSum+=flag;
-				}
-			_reportSummaryMap->setBinContent(_currentLS, ifed+1, int(fSum._state));
-			ifed++;
-			fTotal+=fSum;
-		}
-	}
+  int ifed = 0;
+  hcaldqm::flag::Flag fTotal("Status", hcaldqm::flag::fNCDAQ);
+  if (_ptype != fOffline) {  // hidefed2crate
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      HcalElectronicsId eid(*it);
+      hcaldqm::flag::Flag fSum("Status", hcaldqm::flag::fNCDAQ);
+      for (uint32_t im = 0; im < _vmarks.size(); im++)
+        if (_vmarks[im]) {
+          int x = _vcSummaryvsLS[im].getBinContent(eid, _currentLS);
+          hcaldqm::flag::Flag flag("Status", (hcaldqm::flag::State)x);
+          fSum += flag;
+        }
+      _reportSummaryMap->setBinContent(_currentLS, ifed + 1, int(fSum._state));
+      ifed++;
+      fTotal += fSum;
+    }
+  }
 
-	// update the Run Summary
-	// ^^^TEMPORARY AT THIS POINT!
-	if (fTotal._state==hcaldqm::flag::fBAD) _nBad++;
-	_nTotal++;
-	if (double(_nBad)/double(_nTotal)>=_thresh_bad_bad)
-		_runSummary->setBinContent(1, 1, int(hcaldqm::flag::fBAD));
-	else if (fTotal._state==hcaldqm::flag::fNCDAQ)
-		_runSummary->setBinContent(1,1, int(hcaldqm::flag::fNCDAQ));
-	else
-		_runSummary->setBinContent(1,1, int(hcaldqm::flag::fGOOD));
+  // update the Run Summary
+  // ^^^TEMPORARY AT THIS POINT!
+  if (fTotal._state == hcaldqm::flag::fBAD)
+    _nBad++;
+  _nTotal++;
+  if (double(_nBad) / double(_nTotal) >= _thresh_bad_bad)
+    _runSummary->setBinContent(1, 1, int(hcaldqm::flag::fBAD));
+  else if (fTotal._state == hcaldqm::flag::fNCDAQ)
+    _runSummary->setBinContent(1, 1, int(hcaldqm::flag::fNCDAQ));
+  else
+    _runSummary->setBinContent(1, 1, int(hcaldqm::flag::fGOOD));
 
-	// HF TDC TP efficiency
-	if (_vmarks[fTP]) {
-		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyDataHF_depth/OccupancyDataHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyEmulHFNoTDC_depth/OccupancyEmulHFNoTDC_depth");
-		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyDataHF_ieta/OccupancyDataHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyEmulHFNoTDC_ieta/OccupancyEmulHFNoTDC_ieta");
+  // HF TDC TP efficiency
+  if (_vmarks[fTP]) {
+    MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyDataHF_depth/OccupancyDataHF_depth");
+    MonitorElement* meOccupancyNoTDC_HF_depth =
+        ig.get("Hcal/TPTask/OccupancyEmulHFNoTDC_depth/OccupancyEmulHFNoTDC_depth");
+    MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyDataHF_ieta/OccupancyDataHF_ieta");
+    MonitorElement* meOccupancyNoTDC_HF_ieta =
+        ig.get("Hcal/TPTask/OccupancyEmulHFNoTDC_ieta/OccupancyEmulHFNoTDC_ieta");
 
-		if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
-			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
-			TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
-			TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
-			TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
+    if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
+      TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
+      TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
+      TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
+      TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
 
-			TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
-			hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
-			TH1F *hEfficiency_HF_ieta = (TH1F*)hOccupancy_HF_ieta->Clone();
-			hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
+      TH2F* hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
+      hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
+      TH1F* hEfficiency_HF_ieta = (TH1F*)hOccupancy_HF_ieta->Clone();
+      hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
 
-			ib.setCurrentFolder("Hcal/TPTask");
+      ib.setCurrentFolder("Hcal/TPTask");
 
-			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", hEfficiency_HF_depth);
-			meEfficiency_HF_depth->setEfficiencyFlag();
-			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
-			meEfficiency_HF_ieta->setEfficiencyFlag();	
+      MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", hEfficiency_HF_depth);
+      meEfficiency_HF_depth->setEfficiencyFlag();
+      MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+      meEfficiency_HF_ieta->setEfficiencyFlag();
 
-			delete hEfficiency_HF_depth;
-			delete hEfficiency_HF_ieta;
-		}	
-	}
+      delete hEfficiency_HF_depth;
+      delete hEfficiency_HF_ieta;
+    }
+  }
 }
 
 /*
  *	NO END JOB PROCESSING FOR ONLINE!
  */
-/* virtual */ void HcalOnlineHarvesting::_dqmEndJob(DQMStore::IBooker& ib,
-	DQMStore::IGetter& ig)
-{}
+/* virtual */ void HcalOnlineHarvesting::_dqmEndJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {}
 
 DEFINE_FWK_MODULE(HcalOnlineHarvesting);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -4,632 +4,651 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
-LEDTask::LEDTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_nevents = ps.getUntrackedParameter<int>("nevents", 2000);
-	//	tags
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
-	_tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
-		edm::InputTag("tbunpacker"));
-	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
-		edm::InputTag("hcalDigis"));
-	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
-	_tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
-	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
+LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
+  //	tags
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
+  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
+  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
+  _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
-	//	constants
-	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
-		20);
-	_lowHE = ps.getUntrackedParameter<double>("lowHE",
-		20);
-	_lowHO = ps.getUntrackedParameter<double>("lowHO",
-		20);
-	_lowHF = ps.getUntrackedParameter<double>("lowHF",
-		20);
+  //	constants
+  _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 20);
+  _lowHE = ps.getUntrackedParameter<double>("lowHE", 20);
+  _lowHO = ps.getUntrackedParameter<double>("lowHO", 20);
+  _lowHF = ps.getUntrackedParameter<double>("lowHF", 20);
 
-	// LED calibration channels
-	std::vector<edm::ParameterSet> vLedCalibChannels = ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
-	for (int i = 0; i <= 3; ++i) {
-		HcalSubdetector this_subdet = HcalEmpty;
-		switch (i) {
-			case 0:
-				this_subdet = HcalBarrel;
-				break;
-			case 1:
-				this_subdet = HcalEndcap;
-				break;
-			case 2:
-				this_subdet = HcalOuter;
-				break;
-			case 3:
-				this_subdet = HcalForward;
-				break;
-			default:
-				this_subdet = HcalEmpty;
-				break;
-		}
-		std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
-		std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
-		std::vector<int32_t> subdet_calib_depths = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
-		for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
-			_ledCalibrationChannels[this_subdet].push_back(HcalDetId(HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
-		}
-	}
-
-}
-	
-/* virtual */ void LEDTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		if (r.runAuxiliary().run()==1)
-			return;
-
-	DQTask::bookHistograms(ib, r, es);
-	
-	edm::ESHandle<HcalDbService> dbService;
-	es.get<HcalDbRecord>().get(dbService);
-	_emap = dbService->getHcalMapping();
-
-	std::vector<uint32_t> vhashVME;
-	std::vector<uint32_t> vhashuTCA;
-	std::vector<uint32_t> vhashC36;
-	vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashuTCA);
-
-	//	INITIALIZE
-	_cSignalMean_Subdet.initialize(_name, "SignalMean",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSignalRMS_Subdet.initialize(_name, "SignalRMS",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cTimingMean_Subdet.initialize(_name, "TimingMean",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cTimingRMS_Subdet.initialize(_name, "TimingRMS",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200), 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-
-	if (_ptype == fLocal) { // hidefed2crate
-		_cSignalMean_FEDVME.initialize(_name, "SignalMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),0);
-		_cSignalMean_FEDuTCA.initialize(_name, "SignalMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),0);
-		_cSignalRMS_FEDVME.initialize(_name, "SignalRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_10000, true),0);
-		_cSignalRMS_FEDuTCA.initialize(_name, "SignalRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_10000, true),0);
-		_cTimingMean_FEDVME.initialize(_name, "TimingMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingMean_FEDuTCA.initialize(_name, "TimingMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingRMS_FEDVME.initialize(_name, "TimingRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingRMS_FEDuTCA.initialize(_name, "TimingRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-
-		_cShapeCut_FEDSlot.initialize(_name, "Shape", 
-			hcaldqm::hashfunctions::fFEDSlot,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000),0);
-	}
-
-	_cSignalMean_depth.initialize(_name, "SignalMean",
-		hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),0);
-	_cSignalRMS_depth.initialize(_name, "SignalRMS",
-		hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_10000, true),0);
-	_cTimingMean_depth.initialize(_name, "TimingMean",
-		hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cTimingRMS_depth.initialize(_name, "TimingRMS",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-
-	_cMissing_depth.initialize(_name, "Missing",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMissing_FEDVME.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMissing_FEDuTCA.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	}
-
-	// Plots for LED in global
-	if (_ptype == fOnline) {
-		_cADCvsTS_SubdetPM.initialize(_name, "ADCvsTS",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cLowSignal_CrateSlot.initialize(_name, "LowSignal", 
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fCrateuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cSumQ_SubdetPM.initialize(_name, "SumQ", 
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cTDCTime_SubdetPM.initialize(_name, "TDCTime", 
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cTDCTime_depth.initialize(_name, "TDCTime", 
-			hcaldqm::hashfunctions::fdepth,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),			
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),0);
-		_LED_ADCvsBX_Subdet.initialize(_name, "LED_ADCvsBX", 
-			hcaldqm::hashfunctions::fSubdet, 
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX_36),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);		
-	} else if (_ptype == fLocal) {
-		_LED_ADCvsEvn_Subdet.initialize(_name, "LED_ADCvsEvn", 
-			hcaldqm::hashfunctions::fSubdet, 
-			new hcaldqm::quantity::EventNumber(_nevents),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	}
-	
-	//	initialize compact containers
-	_xSignalSum.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xSignalSum2.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xTimingSum.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xTimingSum2.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xEntries.initialize(hcaldqm::hashfunctions::fDChannel);
-
-	//	BOOK
-	_cSignalMean_Subdet.book(ib, _emap, _subsystem);
-	_cSignalRMS_Subdet.book(ib, _emap, _subsystem);
-	_cTimingMean_Subdet.book(ib, _emap, _subsystem);
-	_cTimingRMS_Subdet.book(ib, _emap, _subsystem);
-
-	_cSignalMean_depth.book(ib, _emap, _subsystem);
-	_cSignalRMS_depth.book(ib, _emap, _subsystem);
-	_cTimingMean_depth.book(ib, _emap, _subsystem);
-	_cTimingRMS_depth.book(ib, _emap, _subsystem);
-
-	_cMissing_depth.book(ib, _emap, _subsystem);
-	if (_ptype == fLocal) { // hidefed2crate
-		_cSignalMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cSignalMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cSignalRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cSignalRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
-		_cMissing_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMissing_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
-	if (_ptype == fOnline) {
-		_cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
-		_cLowSignal_CrateSlot.book(ib, _subsystem);
-		_cSumQ_SubdetPM.book(ib, _emap, _subsystem);
-		_cTDCTime_SubdetPM.book(ib, _emap, _subsystem);
-		_cTDCTime_depth.book(ib, _emap, _subsystem);
-	}
-
-	if (_ptype == fOnline) {
-		_LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
-	} else if (_ptype == fLocal) {
-		_LED_ADCvsEvn_Subdet.book(ib, _emap, _subsystem);
-	}
-
-	_xSignalSum.book(_emap);
-	_xSignalSum2.book(_emap);
-	_xEntries.book(_emap);
-	_xTimingSum.book(_emap);
-	_xTimingSum2.book(_emap);
-
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+  // LED calibration channels
+  std::vector<edm::ParameterSet> vLedCalibChannels =
+      ps.getParameter<std::vector<edm::ParameterSet>>("ledCalibrationChannels");
+  for (int i = 0; i <= 3; ++i) {
+    HcalSubdetector this_subdet = HcalEmpty;
+    switch (i) {
+      case 0:
+        this_subdet = HcalBarrel;
+        break;
+      case 1:
+        this_subdet = HcalEndcap;
+        break;
+      case 2:
+        this_subdet = HcalOuter;
+        break;
+      case 3:
+        this_subdet = HcalForward;
+        break;
+      default:
+        this_subdet = HcalEmpty;
+        break;
+    }
+    std::vector<int32_t> subdet_calib_ietas = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("ieta");
+    std::vector<int32_t> subdet_calib_iphis = vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("iphi");
+    std::vector<int32_t> subdet_calib_depths =
+        vLedCalibChannels[i].getUntrackedParameter<std::vector<int32_t>>("depth");
+    for (unsigned int ichannel = 0; ichannel < subdet_calib_ietas.size(); ++ichannel) {
+      _ledCalibrationChannels[this_subdet].push_back(HcalDetId(
+          HcalOther, subdet_calib_ietas[ichannel], subdet_calib_iphis[ichannel], subdet_calib_depths[ichannel]));
+    }
+  }
 }
 
-/* virtual */ void LEDTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void LEDTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    if (r.runAuxiliary().run() == 1)
+      return;
+
+  DQTask::bookHistograms(ib, r, es);
+
+  edm::ESHandle<HcalDbService> dbService;
+  es.get<HcalDbRecord>().get(dbService);
+  _emap = dbService->getHcalMapping();
+
+  std::vector<uint32_t> vhashVME;
+  std::vector<uint32_t> vhashuTCA;
+  std::vector<uint32_t> vhashC36;
+  vhashVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashuTCA);
+
+  //	INITIALIZE
+  _cSignalMean_Subdet.initialize(_name,
+                                 "SignalMean",
+                                 hcaldqm::hashfunctions::fSubdet,
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                 0);
+  _cSignalRMS_Subdet.initialize(_name,
+                                "SignalRMS",
+                                hcaldqm::hashfunctions::fSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+  _cTimingMean_Subdet.initialize(_name,
+                                 "TimingMean",
+                                 hcaldqm::hashfunctions::fSubdet,
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                 0);
+  _cTimingRMS_Subdet.initialize(_name,
+                                "TimingRMS",
+                                hcaldqm::hashfunctions::fSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+
+  if (_ptype == fLocal) {  // hidefed2crate
+    _cSignalMean_FEDVME.initialize(_name,
+                                   "SignalMean",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),
+                                   0);
+    _cSignalMean_FEDuTCA.initialize(_name,
+                                    "SignalMean",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),
+                                    0);
+    _cSignalRMS_FEDVME.initialize(_name,
+                                  "SignalRMS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_10000, true),
+                                  0);
+    _cSignalRMS_FEDuTCA.initialize(_name,
+                                   "SignalRMS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_10000, true),
+                                   0);
+    _cTimingMean_FEDVME.initialize(_name,
+                                   "TimingMean",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+    _cTimingMean_FEDuTCA.initialize(_name,
+                                    "TimingMean",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                    0);
+    _cTimingRMS_FEDVME.initialize(_name,
+                                  "TimingRMS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                  0);
+    _cTimingRMS_FEDuTCA.initialize(_name,
+                                   "TimingRMS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+
+    _cShapeCut_FEDSlot.initialize(_name,
+                                  "Shape",
+                                  hcaldqm::hashfunctions::fFEDSlot,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000),
+                                  0);
+  }
+
+  _cSignalMean_depth.initialize(_name,
+                                "SignalMean",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000, true),
+                                0);
+  _cSignalRMS_depth.initialize(_name,
+                               "SignalRMS",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_10000, true),
+                               0);
+  _cTimingMean_depth.initialize(_name,
+                                "TimingMean",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                0);
+  _cTimingRMS_depth.initialize(_name,
+                               "TimingRMS",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                               0);
+
+  _cMissing_depth.initialize(_name,
+                             "Missing",
+                             hcaldqm::hashfunctions::fdepth,
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                             0);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMissing_FEDVME.initialize(_name,
+                                "Missing",
+                                hcaldqm::hashfunctions::fFED,
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+    _cMissing_FEDuTCA.initialize(_name,
+                                 "Missing",
+                                 hcaldqm::hashfunctions::fFED,
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                 0);
+  }
+
+  // Plots for LED in global
+  if (_ptype == fOnline) {
+    _cADCvsTS_SubdetPM.initialize(_name,
+                                  "ADCvsTS",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                  0);
+    _cLowSignal_CrateSlot.initialize(_name,
+                                     "LowSignal",
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fCrateuTCA),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                     0);
+    _cSumQ_SubdetPM.initialize(_name,
+                               "SumQ",
+                               hcaldqm::hashfunctions::fSubdetPM,
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                               0);
+    _cTDCTime_SubdetPM.initialize(_name,
+                                  "TDCTime",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                  0);
+    _cTDCTime_depth.initialize(_name,
+                               "TDCTime",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                               0);
+    _LED_ADCvsBX_Subdet.initialize(_name,
+                                   "LED_ADCvsBX",
+                                   hcaldqm::hashfunctions::fSubdet,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX_36),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+  } else if (_ptype == fLocal) {
+    _LED_ADCvsEvn_Subdet.initialize(_name,
+                                    "LED_ADCvsEvn",
+                                    hcaldqm::hashfunctions::fSubdet,
+                                    new hcaldqm::quantity::EventNumber(_nevents),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256_4),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+  }
+
+  //	initialize compact containers
+  _xSignalSum.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xSignalSum2.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xTimingSum.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xTimingSum2.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xEntries.initialize(hcaldqm::hashfunctions::fDChannel);
+
+  //	BOOK
+  _cSignalMean_Subdet.book(ib, _emap, _subsystem);
+  _cSignalRMS_Subdet.book(ib, _emap, _subsystem);
+  _cTimingMean_Subdet.book(ib, _emap, _subsystem);
+  _cTimingRMS_Subdet.book(ib, _emap, _subsystem);
+
+  _cSignalMean_depth.book(ib, _emap, _subsystem);
+  _cSignalRMS_depth.book(ib, _emap, _subsystem);
+  _cTimingMean_depth.book(ib, _emap, _subsystem);
+  _cTimingRMS_depth.book(ib, _emap, _subsystem);
+
+  _cMissing_depth.book(ib, _emap, _subsystem);
+  if (_ptype == fLocal) {  // hidefed2crate
+    _cSignalMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cSignalMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cSignalRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cSignalRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
+    _cMissing_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMissing_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+  if (_ptype == fOnline) {
+    _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
+    _cLowSignal_CrateSlot.book(ib, _subsystem);
+    _cSumQ_SubdetPM.book(ib, _emap, _subsystem);
+    _cTDCTime_SubdetPM.book(ib, _emap, _subsystem);
+    _cTDCTime_depth.book(ib, _emap, _subsystem);
+  }
+
+  if (_ptype == fOnline) {
+    _LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
+  } else if (_ptype == fLocal) {
+    _LED_ADCvsEvn_Subdet.book(ib, _emap, _subsystem);
+  }
+
+  _xSignalSum.book(_emap);
+  _xSignalSum2.book(_emap);
+  _xEntries.book(_emap);
+  _xTimingSum.book(_emap);
+  _xTimingSum2.book(_emap);
+
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 }
 
-/* virtual */ void LEDTask::_dump()
-{
-	_cSignalMean_Subdet.reset();
-	_cSignalRMS_Subdet.reset();
-	_cTimingMean_Subdet.reset();
-	_cTimingRMS_Subdet.reset();
-	_cSignalMean_depth.reset();
-	_cSignalRMS_depth.reset();
-	_cTimingMean_depth.reset();
-	_cTimingRMS_depth.reset();
+/* virtual */ void LEDTask::_resetMonitors(hcaldqm::UpdateFreq uf) { DQTask::_resetMonitors(uf); }
 
-	if (_ptype == fLocal) { // hidefed2crate
-		_cSignalMean_FEDVME.reset();
-		_cSignalMean_FEDuTCA.reset();
-		_cSignalRMS_FEDVME.reset();
-		_cSignalRMS_FEDuTCA.reset();
-		_cTimingMean_FEDVME.reset();
-		_cTimingMean_FEDuTCA.reset();
-		_cTimingRMS_FEDVME.reset();
-		_cTimingRMS_FEDuTCA.reset();
-	}
+/* virtual */ void LEDTask::_dump() {
+  _cSignalMean_Subdet.reset();
+  _cSignalRMS_Subdet.reset();
+  _cTimingMean_Subdet.reset();
+  _cTimingRMS_Subdet.reset();
+  _cSignalMean_depth.reset();
+  _cSignalRMS_depth.reset();
+  _cTimingMean_depth.reset();
+  _cTimingRMS_depth.reset();
 
-	std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
-	for (std::vector<HcalGenericDetId>::const_iterator it=dids.begin();
-		it!=dids.end(); ++it)
-	{
-		if (!it->isHcalDetId())
-			continue;
-		HcalDetId did = HcalDetId(it->rawId());
-		HcalElectronicsId eid(_ehashmap.lookup(did));
-		int n = _xEntries.get(did);
-		double msig = _xSignalSum.get(did)/n; 
-		double mtim = _xTimingSum.get(did)/n;
-		double rsig = sqrt(_xSignalSum2.get(did)/n-msig*msig);
-		double rtim = sqrt(_xTimingSum2.get(did)/n-mtim*mtim);
+  if (_ptype == fLocal) {  // hidefed2crate
+    _cSignalMean_FEDVME.reset();
+    _cSignalMean_FEDuTCA.reset();
+    _cSignalRMS_FEDVME.reset();
+    _cSignalRMS_FEDuTCA.reset();
+    _cTimingMean_FEDVME.reset();
+    _cTimingMean_FEDuTCA.reset();
+    _cTimingRMS_FEDVME.reset();
+    _cTimingRMS_FEDuTCA.reset();
+  }
 
-		//	channels missing or low signal
-		if (n==0)
-		{
-			_cMissing_depth.fill(did);
-			if (_ptype == fLocal) { // hidefed2crate
-				if (eid.isVMEid())
-					_cMissing_FEDVME.fill(eid);
-				else
-					_cMissing_FEDuTCA.fill(eid);
-			}
-			continue;
-		}
-		_cSignalMean_Subdet.fill(did, msig);
-		_cSignalMean_depth.fill(did, msig);
-		_cSignalRMS_Subdet.fill(did, rsig);
-		_cSignalRMS_depth.fill(did, rsig);
-		_cTimingMean_Subdet.fill(did, mtim);
-		_cTimingMean_depth.fill(did, mtim);
-		_cTimingRMS_Subdet.fill(did, rtim);
-		_cTimingRMS_depth.fill(did, rtim);
-		if (_ptype == fLocal) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cSignalMean_FEDVME.fill(eid, msig);
-				_cSignalRMS_FEDVME.fill(eid, rsig);
-				_cTimingMean_FEDVME.fill(eid, mtim);
-				_cTimingRMS_FEDVME.fill(eid, rtim);
-			}
-			else
-			{
-				_cSignalMean_FEDuTCA.fill(eid, msig);
-				_cSignalRMS_FEDuTCA.fill(eid, rsig);
-				_cTimingMean_FEDuTCA.fill(eid, mtim);
-				_cTimingRMS_FEDuTCA.fill(eid, rtim);
-			}
-		}
-	}
+  std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
+  for (std::vector<HcalGenericDetId>::const_iterator it = dids.begin(); it != dids.end(); ++it) {
+    if (!it->isHcalDetId())
+      continue;
+    HcalDetId did = HcalDetId(it->rawId());
+    HcalElectronicsId eid(_ehashmap.lookup(did));
+    int n = _xEntries.get(did);
+    double msig = _xSignalSum.get(did) / n;
+    double mtim = _xTimingSum.get(did) / n;
+    double rsig = sqrt(_xSignalSum2.get(did) / n - msig * msig);
+    double rtim = sqrt(_xTimingSum2.get(did) / n - mtim * mtim);
+
+    //	channels missing or low signal
+    if (n == 0) {
+      _cMissing_depth.fill(did);
+      if (_ptype == fLocal) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cMissing_FEDVME.fill(eid);
+        else
+          _cMissing_FEDuTCA.fill(eid);
+      }
+      continue;
+    }
+    _cSignalMean_Subdet.fill(did, msig);
+    _cSignalMean_depth.fill(did, msig);
+    _cSignalRMS_Subdet.fill(did, rsig);
+    _cSignalRMS_depth.fill(did, rsig);
+    _cTimingMean_Subdet.fill(did, mtim);
+    _cTimingMean_depth.fill(did, mtim);
+    _cTimingRMS_Subdet.fill(did, rtim);
+    _cTimingRMS_depth.fill(did, rtim);
+    if (_ptype == fLocal) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cSignalMean_FEDVME.fill(eid, msig);
+        _cSignalRMS_FEDVME.fill(eid, rsig);
+        _cTimingMean_FEDVME.fill(eid, mtim);
+        _cTimingRMS_FEDVME.fill(eid, rtim);
+      } else {
+        _cSignalMean_FEDuTCA.fill(eid, msig);
+        _cSignalRMS_FEDuTCA.fill(eid, rsig);
+        _cTimingMean_FEDuTCA.fill(eid, mtim);
+        _cTimingRMS_FEDuTCA.fill(eid, rtim);
+      }
+    }
+  }
 }
 
-/* virtual */ void LEDTask::_process(edm::Event const& e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HBHEDigiCollection>		chbhe;
-	edm::Handle<HODigiCollection>		cho;
-	edm::Handle<QIE10DigiCollection>		chf;
-	edm::Handle<QIE11DigiCollection>		che;
+/* virtual */ void LEDTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HBHEDigiCollection> chbhe;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<QIE10DigiCollection> chf;
+  edm::Handle<QIE11DigiCollection> che;
 
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available "
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available "
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection QIE10DigiCollection isn't available "
-			+ _tagHF.label() + " " + _tagHF.instance());
-	if (!e.getByToken(_tokHE, che))
-		_logger.dqmthrow("Collection QIE11DigiCollection isn't available "
-			+ _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokHE, che))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagHE.label() + " " + _tagHE.instance());
 
-//	int currentEvent = e.eventAuxiliary().id().event();
+  //	int currentEvent = e.eventAuxiliary().id().event();
 
-	for (HBHEDigiCollection::const_iterator it=chbhe->begin();
-		it!=chbhe->end(); ++it)
-	{
-		const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-		HcalDetId did = digi.id();
-		HcalElectronicsId eid = digi.elecId();
+  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
+    HcalDetId did = digi.id();
+    HcalElectronicsId eid = digi.elecId();
 
-		// Get total charge and apply charge cut
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, digi);
-		//double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size()-1);
-		double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
-		if (sumQ >= _lowHBHE) {
-			//double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,digi.size()-1);
-			double aveTS = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+    // Get total charge and apply charge cut
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, digi);
+    //double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size()-1);
+    double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
+    if (sumQ >= _lowHBHE) {
+      //double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,digi.size()-1);
+      double aveTS = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
 
-			_xSignalSum.get(did)+=sumQ;
-			_xSignalSum2.get(did)+=sumQ*sumQ;
-			_xTimingSum.get(did)+=aveTS;
-			_xTimingSum2.get(did)+=aveTS*aveTS;
-			_xEntries.get(did)++;
+      _xSignalSum.get(did) += sumQ;
+      _xSignalSum2.get(did) += sumQ * sumQ;
+      _xTimingSum.get(did) += aveTS;
+      _xTimingSum2.get(did) += aveTS * aveTS;
+      _xEntries.get(did)++;
 
-			if (_ptype == fLocal) { // hidefed2crate
-				for (int i=0; i<digi.size(); i++) {
-					//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
-					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HBHEDataFrame>(_dbService, digi_fC, did, digi, i));
-				}
-			}
+      if (_ptype == fLocal) {  // hidefed2crate
+        for (int i = 0; i < digi.size(); i++) {
+          //_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
+          _cShapeCut_FEDSlot.fill(
+              eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HBHEDataFrame>(_dbService, digi_fC, did, digi, i));
+        }
+      }
 
-			if (_ptype == fOnline) {
-				for (int iTS = 0; iTS < digi.size(); ++iTS) {
-					_cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());					
-				}
-				_cSumQ_SubdetPM.fill(did, sumQ);
-			}
-		}
-	}
+      if (_ptype == fOnline) {
+        for (int iTS = 0; iTS < digi.size(); ++iTS) {
+          _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
+        }
+        _cSumQ_SubdetPM.fill(did, sumQ);
+      }
+    }
+  }
 
-	for (QIE11DigiCollection::const_iterator it=che->begin(); it!=che->end();
-		++it)
-	{
-		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
-		HcalDetId const& did = digi.detid();
-		if (did.subdet() != HcalEndcap) {
-			// LED monitoring from calibration channels
-			if (did.subdet() == HcalOther) {
-				HcalOtherDetId hodid(digi.detid());
-				if (hodid.subdet() == HcalCalibration) {
-					if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) != _ledCalibrationChannels[HcalEndcap].end()) {
-						for (int i=0; i<digi.samples(); i++) {
-							if (_ptype == fOnline) {
-								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), e.bunchCrossing(), digi[i].adc());
-							} else if (_ptype == fLocal) {
-								_LED_ADCvsEvn_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
-							}
-						}
-					}
-				}
-			}
+  for (QIE11DigiCollection::const_iterator it = che->begin(); it != che->end(); ++it) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
+    HcalDetId const& did = digi.detid();
+    if (did.subdet() != HcalEndcap) {
+      // LED monitoring from calibration channels
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(digi.detid());
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_ledCalibrationChannels[HcalEndcap].begin(), _ledCalibrationChannels[HcalEndcap].end(), did) !=
+              _ledCalibrationChannels[HcalEndcap].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), e.bunchCrossing(), digi[i].adc());
+              } else if (_ptype == fLocal) {
+                _LED_ADCvsEvn_Subdet.fill(
+                    HcalDetId(HcalEndcap, 16, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
+              }
+            }
+          }
+        }
+      }
 
-			continue;
-		}
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (!rawid) {
-		  std::string unknown_id_string="Detid "+std::to_string(int(did))+", ieta "+std::to_string(did.ieta());
-		  unknown_id_string+=", iphi "+std::to_string(did.iphi())+", depth "+std::to_string(did.depth());
-		  unknown_id_string+=", is not in emap. Skipping.";
-		  _logger.warn(unknown_id_string);
-		  continue;
-		}
-		HcalElectronicsId const& eid(rawid);
+      continue;
+    }
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (!rawid) {
+      std::string unknown_id_string = "Detid " + std::to_string(int(did)) + ", ieta " + std::to_string(did.ieta());
+      unknown_id_string += ", iphi " + std::to_string(did.iphi()) + ", depth " + std::to_string(did.depth());
+      unknown_id_string += ", is not in emap. Skipping.";
+      _logger.warn(unknown_id_string);
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
 
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
-		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		if (sumQ >= _lowHE) {
-			//double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
-			double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
+    //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
+    double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    if (sumQ >= _lowHE) {
+      //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
+      double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
 
-			_xSignalSum.get(did)+=sumQ;
-			_xSignalSum2.get(did)+=sumQ*sumQ;
-			_xTimingSum.get(did)+=aveTS;
-			_xTimingSum2.get(did)+=aveTS*aveTS;
-			_xEntries.get(did)++;
+      _xSignalSum.get(did) += sumQ;
+      _xSignalSum2.get(did) += sumQ * sumQ;
+      _xTimingSum.get(did) += aveTS;
+      _xTimingSum2.get(did) += aveTS * aveTS;
+      _xEntries.get(did)++;
 
-			if (_ptype == fLocal) { // hidefed2crate
-				for (int i=0; i<digi.samples(); i++) {
-					//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
-					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
-				}
-			}
-			if (_ptype == fOnline) {
-				for (int iTS = 0; iTS < digi.samples(); ++iTS) {
-					_cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());					
-					if (digi[iTS].tdc() <50) {
-						double time = iTS*25. + (digi[iTS].tdc() / 2.);
-						_cTDCTime_SubdetPM.fill(did, time);
-						_cTDCTime_depth.fill(did, time);
-					}
-				}
-				_cSumQ_SubdetPM.fill(did, sumQ);
+      if (_ptype == fLocal) {  // hidefed2crate
+        for (int i = 0; i < digi.samples(); i++) {
+          //_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
+          _cShapeCut_FEDSlot.fill(
+              eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
+        }
+      }
+      if (_ptype == fOnline) {
+        for (int iTS = 0; iTS < digi.samples(); ++iTS) {
+          _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
+          if (digi[iTS].tdc() < 50) {
+            double time = iTS * 25. + (digi[iTS].tdc() / 2.);
+            _cTDCTime_SubdetPM.fill(did, time);
+            _cTDCTime_depth.fill(did, time);
+          }
+        }
+        _cSumQ_SubdetPM.fill(did, sumQ);
 
-				// Low signal in SOI
-				short soi = -1;
-				for (int i=0; i<digi.samples(); i++) {
-					if (digi[i].soi()) {
-						soi = i;
-						break;
-					}
-				}
-				if (digi[soi].adc() < 30) {
-					_cLowSignal_CrateSlot.fill(eid);
-				}	
-			}
-		}			
-	}
-	for (HODigiCollection::const_iterator it=cho->begin();
-		it!=cho->end(); ++it)
-	{
-		const HODataFrame digi = (const HODataFrame)(*it);
-		HcalDetId did = digi.id();
-		HcalElectronicsId eid = digi.elecId();
-		//double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, digi);
-		double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
-		if (sumQ >= _lowHO) {
-			//double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size()-1);
-			double aveTS = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+        // Low signal in SOI
+        short soi = -1;
+        for (int i = 0; i < digi.samples(); i++) {
+          if (digi[i].soi()) {
+            soi = i;
+            break;
+          }
+        }
+        if (digi[soi].adc() < 30) {
+          _cLowSignal_CrateSlot.fill(eid);
+        }
+      }
+    }
+  }
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    const HODataFrame digi = (const HODataFrame)(*it);
+    HcalDetId did = digi.id();
+    HcalElectronicsId eid = digi.elecId();
+    //double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size()-1);
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, digi);
+    double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
+    if (sumQ >= _lowHO) {
+      //double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size()-1);
+      double aveTS = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
 
-			_xSignalSum.get(did)+=sumQ;
-			_xSignalSum2.get(did)+=sumQ*sumQ;
-			_xTimingSum.get(did)+=aveTS;
-			_xTimingSum2.get(did)+=aveTS*aveTS;
-			_xEntries.get(did)++;
+      _xSignalSum.get(did) += sumQ;
+      _xSignalSum2.get(did) += sumQ * sumQ;
+      _xTimingSum.get(did) += aveTS;
+      _xTimingSum2.get(did) += aveTS * aveTS;
+      _xEntries.get(did)++;
 
-			if (_ptype == fLocal) { // hidefed2crate
-				for (int i=0; i<digi.size(); i++) {
-					//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-8.5);
-					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HODataFrame>(_dbService, digi_fC, did, digi, i));
-				}
-			}
-			if (_ptype == fOnline) {
-				for (int iTS = 0; iTS < digi.size(); ++iTS) {
-					_cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());					
-				}
-				_cSumQ_SubdetPM.fill(did, sumQ);
-			}
-		}
-	}
+      if (_ptype == fLocal) {  // hidefed2crate
+        for (int i = 0; i < digi.size(); i++) {
+          //_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-8.5);
+          _cShapeCut_FEDSlot.fill(
+              eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HODataFrame>(_dbService, digi_fC, did, digi, i));
+        }
+      }
+      if (_ptype == fOnline) {
+        for (int iTS = 0; iTS < digi.size(); ++iTS) {
+          _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
+        }
+        _cSumQ_SubdetPM.fill(did, sumQ);
+      }
+    }
+  }
 
-	for (QIE10DigiCollection::const_iterator it=chf->begin();
-		it!=chf->end(); ++it)
-	{
-		const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
-		HcalDetId did = digi.detid();
-		if (did.subdet() != HcalForward) {
-			// LED monitoring from calibration channels
-			if (did.subdet() == HcalOther) {
-				HcalOtherDetId hodid(digi.detid());
-				if (hodid.subdet() == HcalCalibration) {
-					if (std::find(_ledCalibrationChannels[HcalForward].begin(), _ledCalibrationChannels[HcalForward].end(), did) != _ledCalibrationChannels[HcalForward].end()) {
-						for (int i=0; i<digi.samples(); i++) {
-							if (_ptype == fOnline) {
-								_LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), e.bunchCrossing(), digi[i].adc());
-							} else if (_ptype == fLocal) {
-								_LED_ADCvsEvn_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
-							}
-						}
-					}
-				}
-			}
-			continue;
-		}
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
-		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		if (sumQ >= _lowHF) {
-			//double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
-			double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+    HcalDetId did = digi.detid();
+    if (did.subdet() != HcalForward) {
+      // LED monitoring from calibration channels
+      if (did.subdet() == HcalOther) {
+        HcalOtherDetId hodid(digi.detid());
+        if (hodid.subdet() == HcalCalibration) {
+          if (std::find(_ledCalibrationChannels[HcalForward].begin(),
+                        _ledCalibrationChannels[HcalForward].end(),
+                        did) != _ledCalibrationChannels[HcalForward].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), e.bunchCrossing(), digi[i].adc());
+              } else if (_ptype == fLocal) {
+                _LED_ADCvsEvn_Subdet.fill(
+                    HcalDetId(HcalForward, 29, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
+              }
+            }
+          }
+        }
+      }
+      continue;
+    }
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+    //double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
+    double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    if (sumQ >= _lowHF) {
+      //double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+      double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
 
-			_xSignalSum.get(did)+=sumQ;
-			_xSignalSum2.get(did)+=sumQ*sumQ;
-			_xTimingSum.get(did)+=aveTS;
-			_xTimingSum2.get(did)+=aveTS*aveTS;
-			_xEntries.get(did)++;
+      _xSignalSum.get(did) += sumQ;
+      _xSignalSum2.get(did) += sumQ * sumQ;
+      _xTimingSum.get(did) += aveTS;
+      _xTimingSum2.get(did) += aveTS * aveTS;
+      _xEntries.get(did)++;
 
-			if (_ptype == fLocal) { // hidefed2crate
-				for (int i = 0; i < digi.samples(); ++i) {
-					// Note: this used to be digi.sample(i).nominal_fC() - 2.5, but this branch doesn't exist in QIE10DataFrame.
-					// Instead, use lookup table.
-					//_cShapeCut_FEDSlot.fill(eid, i, constants::adc2fC[digi[i].adc()]);
-					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
-				}
-			}
-			if (_ptype == fOnline) {
-				for (int iTS = 0; iTS < digi.samples(); ++iTS) {
-					_cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());					
-					if (digi[iTS].le_tdc() <50) {
-						double time = iTS*25. + (digi[iTS].le_tdc() / 2.);
-						_cTDCTime_SubdetPM.fill(did, time);
-						_cTDCTime_depth.fill(did, time);
-					}
-				}
-				_cSumQ_SubdetPM.fill(did, sumQ);
-			}
-		}			
-	}
+      if (_ptype == fLocal) {  // hidefed2crate
+        for (int i = 0; i < digi.samples(); ++i) {
+          // Note: this used to be digi.sample(i).nominal_fC() - 2.5, but this branch doesn't exist in QIE10DataFrame.
+          // Instead, use lookup table.
+          //_cShapeCut_FEDSlot.fill(eid, i, constants::adc2fC[digi[i].adc()]);
+          _cShapeCut_FEDSlot.fill(
+              eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
+        }
+      }
+      if (_ptype == fOnline) {
+        for (int iTS = 0; iTS < digi.samples(); ++iTS) {
+          _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
+          if (digi[iTS].le_tdc() < 50) {
+            double time = iTS * 25. + (digi[iTS].le_tdc() / 2.);
+            _cTDCTime_SubdetPM.fill(did, time);
+            _cTDCTime_depth.fill(did, time);
+          }
+        }
+        _cSumQ_SubdetPM.fill(did, sumQ);
+      }
+    }
+  }
 
-	if (_ptype==fOnline && _evsTotal>0 &&
-		_evsTotal%constants::CALIBEVENTS_MIN==0)
-		this->_dump();
+  if (_ptype == fOnline && _evsTotal > 0 && _evsTotal % constants::CALIBEVENTS_MIN == 0)
+    this->_dump();
 }
 
-/* virtual */ bool LEDTask::_isApplicable(edm::Event const& e)
-{
-	if (_ptype!=fOnline)
-	{
-		//	local
-		edm::Handle<HcalTBTriggerData> ctrigger;
-		if (!e.getByToken(_tokTrigger, ctrigger))
-			_logger.dqmthrow("Collection HcalTBTriggerData isn't available "
-				+ _tagTrigger.label() + " " + _tagTrigger.instance());
-		return ctrigger->wasLEDTrigger();
-	} else {
-		//	fOnline mode
-		edm::Handle<HcalUMNioDigi> cumn;
-		if (!e.getByToken(_tokuMN, cumn)) {
-			return false;
-		}
-		
-		return (cumn->eventType() == constants::EVENTTYPE_LED);
-	}
+/* virtual */ bool LEDTask::_isApplicable(edm::Event const& e) {
+  if (_ptype != fOnline) {
+    //	local
+    edm::Handle<HcalTBTriggerData> ctrigger;
+    if (!e.getByToken(_tokTrigger, ctrigger))
+      _logger.dqmthrow("Collection HcalTBTriggerData isn't available " + _tagTrigger.label() + " " +
+                       _tagTrigger.instance());
+    return ctrigger->wasLEDTrigger();
+  } else {
+    //	fOnline mode
+    edm::Handle<HcalUMNioDigi> cumn;
+    if (!e.getByToken(_tokuMN, cumn)) {
+      return false;
+    }
 
-	return false;
+    return (cumn->eventType() == constants::EVENTTYPE_LED);
+  }
+
+  return false;
 }
 
 DEFINE_FWK_MODULE(LEDTask);
-
-

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -407,22 +407,22 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
 /* virtual */ void LEDTask::_process(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<HODigiCollection>   c_ho;
-  edm::Handle<QIE10DigiCollection>    c_qie10;
-  edm::Handle<QIE11DigiCollection>    c_qie11;
+  edm::Handle<QIE10DigiCollection>    c_QIE10;
+  edm::Handle<QIE11DigiCollection>    c_QIE11;
 
   if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available "
       + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokQIE10, c_qie10))
+  if (!e.getByToken(_tokQIE10, c_QIE10))
     _logger.dqmthrow("Collection QIE10DigiCollection isn't available "
       + _tagQIE10.label() + " " + _tagQIE10.instance());
-  if (!e.getByToken(_tokQIE11, c_qie11))
+  if (!e.getByToken(_tokQIE11, c_QIE11))
     _logger.dqmthrow("Collection QIE11DigiCollection isn't available "
       + _tagQIE11.label() + " " + _tagQIE11.instance());
 
   //	int currentEvent = e.eventAuxiliary().id().event();
 
-  for (QIE11DigiCollection::const_iterator it = c_qie11->begin(); it != c_qie11->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
@@ -438,6 +438,16 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               } else if (_ptype == fLocal) {
                 _LED_ADCvsEvn_Subdet.fill(
                     HcalDetId(HcalEndcap, 16, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
+              }
+            }
+          } else if (std::find(_ledCalibrationChannels[HcalBarrel].begin(), _ledCalibrationChannels[HcalBarrel].end(), did) !=
+              _ledCalibrationChannels[HcalBarrel].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), e.bunchCrossing(), digi[i].adc());
+              } else if (_ptype == fLocal) {
+                _LED_ADCvsEvn_Subdet.fill(
+                    HcalDetId(HcalBarrel, 1, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
               }
             }
           }
@@ -504,7 +514,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
       }
     }
   }
-  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+  for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     HcalDetId did = digi.id();
     HcalElectronicsId eid = digi.elecId();
@@ -539,7 +549,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
     }
   }
 
-  for (QIE10DigiCollection::const_iterator it = c_qie10->begin(); it != c_qie10->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -4,25 +4,28 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
+
 LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
   //	tags
-  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
-  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
-  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
-  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
-  _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
-  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
-  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE",
+    edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
+    edm::InputTag("hcalDigis"));
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF",
+    edm::InputTag("hcalDigis"));
+  _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
+    edm::InputTag("tbunpacker"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
+    edm::InputTag("hcalDigis"));
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
-  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
   //	constants
   _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 20);
-  _lowHE = ps.getUntrackedParameter<double>("lowHE", 20);
   _lowHO = ps.getUntrackedParameter<double>("lowHO", 20);
   _lowHF = ps.getUntrackedParameter<double>("lowHF", 20);
 
@@ -225,14 +228,14 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   }
 
   // Plots for LED in global
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cADCvsTS_SubdetPM.initialize(_name, "ADCvsTS",
+      hcaldqm::hashfunctions::fSubdetPM,
+      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);   
+  }
   if (_ptype == fOnline) {
-    _cADCvsTS_SubdetPM.initialize(_name,
-                                  "ADCvsTS",
-                                  hcaldqm::hashfunctions::fSubdetPM,
-                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
-                                  0);
     _cLowSignal_CrateSlot.initialize(_name,
                                      "LowSignal",
                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fCrateuTCA),
@@ -307,8 +310,10 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
     _cMissing_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
     _cMissing_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
   }
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);   
+  }
   if (_ptype == fOnline) {
-    _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
     _cLowSignal_CrateSlot.book(ib, _subsystem);
     _cSumQ_SubdetPM.book(ib, _emap, _subsystem);
     _cTDCTime_SubdetPM.book(ib, _emap, _subsystem);
@@ -401,62 +406,26 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void LEDTask::_process(edm::Event const& e, edm::EventSetup const& es) {
-  edm::Handle<HBHEDigiCollection> chbhe;
-  edm::Handle<HODigiCollection> cho;
-  edm::Handle<QIE10DigiCollection> chf;
-  edm::Handle<QIE11DigiCollection> che;
+  edm::Handle<HODigiCollection>   c_ho;
+  edm::Handle<QIE10DigiCollection>    c_qie10;
+  edm::Handle<QIE11DigiCollection>    c_qie11;
 
-  if (!e.getByToken(_tokHBHE, chbhe))
-    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
-  if (!e.getByToken(_tokHO, cho))
-    _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokHF, chf))
-    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
-  if (!e.getByToken(_tokHE, che))
-    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokHO, c_ho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available "
+      + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokQIE10, c_qie10))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available "
+      + _tagQIE10.label() + " " + _tagQIE10.instance());
+  if (!e.getByToken(_tokQIE11, c_qie11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available "
+      + _tagQIE11.label() + " " + _tagQIE11.instance());
 
   //	int currentEvent = e.eventAuxiliary().id().event();
 
-  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
-    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-    HcalDetId did = digi.id();
-    HcalElectronicsId eid = digi.elecId();
-
-    // Get total charge and apply charge cut
-    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, digi);
-    //double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size()-1);
-    double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
-    if (sumQ >= _lowHBHE) {
-      //double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,digi.size()-1);
-      double aveTS = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
-
-      _xSignalSum.get(did) += sumQ;
-      _xSignalSum2.get(did) += sumQ * sumQ;
-      _xTimingSum.get(did) += aveTS;
-      _xTimingSum2.get(did) += aveTS * aveTS;
-      _xEntries.get(did)++;
-
-      if (_ptype == fLocal) {  // hidefed2crate
-        for (int i = 0; i < digi.size(); i++) {
-          //_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
-          _cShapeCut_FEDSlot.fill(
-              eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HBHEDataFrame>(_dbService, digi_fC, did, digi, i));
-        }
-      }
-
-      if (_ptype == fOnline) {
-        for (int iTS = 0; iTS < digi.size(); ++iTS) {
-          _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
-        }
-        _cSumQ_SubdetPM.fill(did, sumQ);
-      }
-    }
-  }
-
-  for (QIE11DigiCollection::const_iterator it = che->begin(); it != che->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_qie11->begin(); it != c_qie11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
-    if (did.subdet() != HcalEndcap) {
+    if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
       // LED monitoring from calibration channels
       if (did.subdet() == HcalOther) {
         HcalOtherDetId hodid(digi.detid());
@@ -474,7 +443,6 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
           }
         }
       }
-
       continue;
     }
     uint32_t rawid = _ehashmap.lookup(did);
@@ -490,7 +458,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
     //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
     double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
-    if (sumQ >= _lowHE) {
+    if (sumQ >= _lowHBHE) {
       //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
       double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
 
@@ -507,9 +475,13 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
         }
       }
+      if (_ptype == fOnline || _ptype == fLocal) {
+        for (int iTS = 0; iTS < digi.samples(); ++iTS) {
+          _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc()); 
+        }       
+      }
       if (_ptype == fOnline) {
         for (int iTS = 0; iTS < digi.samples(); ++iTS) {
-          _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
           if (digi[iTS].tdc() < 50) {
             double time = iTS * 25. + (digi[iTS].tdc() / 2.);
             _cTDCTime_SubdetPM.fill(did, time);
@@ -556,16 +528,18 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HODataFrame>(_dbService, digi_fC, did, digi, i));
         }
       }
-      if (_ptype == fOnline) {
+      if (_ptype == fOnline || _ptype == fLocal) {
         for (int iTS = 0; iTS < digi.size(); ++iTS) {
           _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
         }
+      }
+      if (_ptype == fOnline) {
         _cSumQ_SubdetPM.fill(did, sumQ);
       }
     }
   }
 
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_qie10->begin(); it != c_qie10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {
@@ -612,9 +586,13 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
         }
       }
-      if (_ptype == fOnline) {
+      if (_ptype == fOnline || _ptype == fLocal) {
         for (int iTS = 0; iTS < digi.samples(); ++iTS) {
           _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
+       	}
+      }
+      if (_ptype == fOnline) {
+        for (int iTS = 0; iTS < digi.samples(); ++iTS) {
           if (digi[iTS].le_tdc() < 50) {
             double time = iTS * 25. + (digi[iTS].le_tdc() / 2.);
             _cTDCTime_SubdetPM.fill(did, time);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -3,888 +3,877 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
-LaserTask::LaserTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_nevents = ps.getUntrackedParameter<int>("nevents", 2000);
+LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
 
-	//	tags
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
-	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
-		edm::InputTag("hcalDigis"));
-	_tagLaserMon = ps.getUntrackedParameter<edm::InputTag>("tagLaserMon", 
-		edm::InputTag("LASERMON"));
-	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
-	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
-	_tokLaserMon = consumes<QIE10DigiCollection>(_tagLaserMon);
+  //	tags
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
+  _tagLaserMon = ps.getUntrackedParameter<edm::InputTag>("tagLaserMon", edm::InputTag("LASERMON"));
+  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
+  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
+  _tokLaserMon = consumes<QIE10DigiCollection>(_tagLaserMon);
 
-	_vflags.resize(nLaserFlag);
-	_vflags[fBadTiming]=hcaldqm::flag::Flag("BadTiming");
-	_vflags[fMissingLaserMon]=hcaldqm::flag::Flag("MissingLaserMon");
+  _vflags.resize(nLaserFlag);
+  _vflags[fBadTiming] = hcaldqm::flag::Flag("BadTiming");
+  _vflags[fMissingLaserMon] = hcaldqm::flag::Flag("MissingLaserMon");
 
-	//	constants
-	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
-		50);
-	_lowHE = ps.getUntrackedParameter<double>("lowHE",
-		150);
-	_lowHO = ps.getUntrackedParameter<double>("lowHO",
-		100);
-	_lowHF = ps.getUntrackedParameter<double>("lowHF",
-		50);
-	_laserType = (uint32_t)ps.getUntrackedParameter<uint32_t>("laserType");
+  //	constants
+  _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 50);
+  _lowHE = ps.getUntrackedParameter<double>("lowHE", 150);
+  _lowHO = ps.getUntrackedParameter<double>("lowHO", 100);
+  _lowHF = ps.getUntrackedParameter<double>("lowHF", 50);
+  _laserType = (uint32_t)ps.getUntrackedParameter<uint32_t>("laserType");
 
-	// Laser mon digi ordering list
-	_vLaserMonIPhi = ps.getUntrackedParameter<std::vector<int> >("vLaserMonIPhi");
-	_laserMonIEta = ps.getUntrackedParameter<int>("laserMonIEta");
-	_laserMonCBox = ps.getUntrackedParameter<int>("laserMonCBox");
-	_laserMonDigiOverlap = ps.getUntrackedParameter<int>("laserMonDigiOverlap");
-	_laserMonTS0 = ps.getUntrackedParameter<int>("laserMonTS0");
-	_laserMonThreshold = ps.getUntrackedParameter<double>("laserMonThreshold", 1.e5);
-	_thresh_frac_timingreflm = ps.getUntrackedParameter<double>("_thresh_frac_timingreflm", 0.01);
-	_thresh_min_lmsumq = ps.getUntrackedParameter<double>("thresh_min_lmsumq", 50000.);
+  // Laser mon digi ordering list
+  _vLaserMonIPhi = ps.getUntrackedParameter<std::vector<int>>("vLaserMonIPhi");
+  _laserMonIEta = ps.getUntrackedParameter<int>("laserMonIEta");
+  _laserMonCBox = ps.getUntrackedParameter<int>("laserMonCBox");
+  _laserMonDigiOverlap = ps.getUntrackedParameter<int>("laserMonDigiOverlap");
+  _laserMonTS0 = ps.getUntrackedParameter<int>("laserMonTS0");
+  _laserMonThreshold = ps.getUntrackedParameter<double>("laserMonThreshold", 1.e5);
+  _thresh_frac_timingreflm = ps.getUntrackedParameter<double>("_thresh_frac_timingreflm", 0.01);
+  _thresh_min_lmsumq = ps.getUntrackedParameter<double>("thresh_min_lmsumq", 50000.);
 
-	std::vector<double> vTimingRangeHB = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HB", std::vector<double>({-70, -10.}));
-	std::vector<double> vTimingRangeHE = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HE", std::vector<double>({-60., 0.}));
-	std::vector<double> vTimingRangeHO = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HO", std::vector<double>({-50., 20.}));
-	std::vector<double> vTimingRangeHF = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HF", std::vector<double>({-50., 20.}));
-	_thresh_timingreflm[HcalBarrel] = std::make_pair(vTimingRangeHB[0], vTimingRangeHB[1]);
-	_thresh_timingreflm[HcalEndcap] = std::make_pair(vTimingRangeHE[0], vTimingRangeHE[1]);
-	_thresh_timingreflm[HcalOuter] = std::make_pair(vTimingRangeHO[0], vTimingRangeHO[1]);
-	_thresh_timingreflm[HcalForward] = std::make_pair(vTimingRangeHF[0], vTimingRangeHF[1]);
-}
-	
-/* virtual */ void LaserTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		if (r.runAuxiliary().run()==1)
-			return;
-
-	DQTask::bookHistograms(ib, r, es);
-	
-	edm::ESHandle<HcalDbService> dbService;
-	es.get<HcalDbRecord>().get(dbService);
-	_emap = dbService->getHcalMapping();
-
-	std::vector<uint32_t> vhashVME;
-	std::vector<uint32_t> vhashuTCA;
-	std::vector<uint32_t> vhashC36;
-	vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashuTCA);
-
-	//	INITIALIZE
-	_cSignalMean_Subdet.initialize(_name, "SignalMean",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSignalRMS_Subdet.initialize(_name, "SignalRMS",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cTimingMean_Subdet.initialize(_name, "TimingMean",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cTimingRMS_Subdet.initialize(_name, "TimingRMS",
-		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200), 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-
-	_cADC_SubdetPM.initialize(_name, "ADC",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-
-	if (_ptype == fLocal) { // hidefed2crate
-		_cSignalMean_FEDVME.initialize(_name, "SignalMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),0);
-		_cSignalMean_FEDuTCA.initialize(_name, "SignalMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),0);
-		_cSignalRMS_FEDVME.initialize(_name, "SignalRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
-		_cSignalRMS_FEDuTCA.initialize(_name, "SignalRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
-		_cTimingMean_FEDVME.initialize(_name, "TimingMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingMean_FEDuTCA.initialize(_name, "TimingMean",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingRMS_FEDVME.initialize(_name, "TimingRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cTimingRMS_FEDuTCA.initialize(_name, "TimingRMS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-		_cMissing_FEDVME.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMissing_FEDuTCA.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-
-		_cShapeCut_FEDSlot.initialize(_name, "Shape", 
-			hcaldqm::hashfunctions::fFEDSlot,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
-	}
-	_cTimingvsEvent_SubdetPM.initialize(_name, "TimingvsEvent",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::EventNumber(_nevents),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cSignalvsEvent_SubdetPM.initialize(_name, "SignalvsEvent",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::EventNumber(_nevents),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
-	_cTimingvsLS_SubdetPM.initialize(_name, "TimingvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cSignalvsLS_SubdetPM.initialize(_name, "SignalvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
-	_cTimingvsBX_SubdetPM.initialize(_name, "TimingvsBX",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cSignalvsBX_SubdetPM.initialize(_name, "SignalvsBX",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
-
-	_cSignalMean_depth.initialize(_name, "SignalMean",
-		hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),0);
-	_cSignalRMS_depth.initialize(_name, "SignalRMS",
-		hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000),0);
-	_cTimingMean_depth.initialize(_name, "TimingMean",
-		hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cTimingRMS_depth.initialize(_name, "TimingRMS",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-
-	_cMissing_depth.initialize(_name, "Missing",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-
-	
-	//	initialize compact containers
-	_xSignalSum.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xSignalSum2.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xTimingSum.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xTimingSum2.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xEntries.initialize(hcaldqm::hashfunctions::fDChannel);
-
-	// LaserMon containers
-	if (_ptype == fOnline || _ptype == fLocal) {
-		_cLaserMonSumQ.initialize(_name, 
-			"LaserMonSumQ",
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cLaserMonSumQ.showOverflowX(true);
-
-		_cLaserMonTiming.initialize(_name, 
-			"LaserMonTiming",
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cLaserMonTiming.showOverflowX(true);
-
-		if (_ptype == fOnline) {
-			_cLaserMonSumQ_LS.initialize(_name, 
-				"LaserMonSumQ_LS",
-				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000)
-			);
-			_cLaserMonTiming_LS.initialize(_name, 
-				"LaserMonTiming_LS",
-				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS)
-			);
-			_cTimingDiffLS_SubdetPM.initialize(_name, "TimingDiff_DigiMinusLaserMon",
-				hcaldqm::hashfunctions::fSubdetPM,
-				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns), 0);
-			_cTimingDiffLS_SubdetPM.showOverflowY(true);
-		} else if (_ptype == fLocal) {
-			_cLaserMonSumQ_Event.initialize(_name, 
-				"LaserMonSumQ_Event",
-				new hcaldqm::quantity::EventNumber(_nevents),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000)
-			);
-			_cLaserMonTiming_Event.initialize(_name, 
-				"LaserMonTiming_Event",
-				new hcaldqm::quantity::EventNumber(_nevents),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS)
-			);
-			_cTimingDiffEvent_SubdetPM.initialize(_name, "TimingDiff_DigiMinusLaserMon",
-				hcaldqm::hashfunctions::fSubdetPM,
-				new hcaldqm::quantity::EventNumber(_nevents),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns), 0);
-			_cTimingDiffEvent_SubdetPM.showOverflowY(true);
-		}
-		_cTiming_DigivsLaserMon_SubdetPM.initialize(_name, "Timing_DigivsLaserMon", 
-			hcaldqm::hashfunctions::fSubdetPM, 
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cTiming_DigivsLaserMon_SubdetPM.showOverflowX(true);
-		_cTiming_DigivsLaserMon_SubdetPM.showOverflowY(true);
-
-		_xTimingRefLMSum.initialize(hcaldqm::hashfunctions::fDChannel);
-		_xTimingRefLMSum2.initialize(hcaldqm::hashfunctions::fDChannel);
-		_xNBadTimingRefLM.initialize(hcaldqm::hashfunctions::fFED);
-		_xNChs.initialize(hcaldqm::hashfunctions::fFED);
-		_xMissingLaserMon = 0;
-
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin();
-			it!=vFEDsVME.end(); ++it)
-			_vhashFEDs.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-				FIBER_VME_MIN, SPIGOT_MIN, (*it)-FED_VME_MIN).rawId());
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin();
-			it!=vFEDsuTCA.end(); ++it)
-	    {
-	        std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
-			_vhashFEDs.push_back(HcalElectronicsId(
-				cspair.first, cspair.second, FIBER_uTCA_MIN1,
-				FIBERCH_MIN, false).rawId());
-	    }
-
-		_cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::FlagQuantity(_vflags),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-		_cSummaryvsLS.initialize(_name, "SummaryvsLS",
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::FEDQuantity(vFEDs),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-	} // End if (_ptype == fOnline || _ptype == fLocal) {
-
-
-	//	BOOK
-	_cSignalMean_Subdet.book(ib, _emap, _subsystem);
-	_cSignalRMS_Subdet.book(ib, _emap, _subsystem);
-	_cTimingMean_Subdet.book(ib, _emap, _subsystem);
-	_cTimingRMS_Subdet.book(ib, _emap, _subsystem);
-
-	_cSignalMean_depth.book(ib, _emap, _subsystem);
-	_cSignalRMS_depth.book(ib, _emap, _subsystem);
-	_cTimingMean_depth.book(ib, _emap, _subsystem);
-	_cTimingRMS_depth.book(ib, _emap, _subsystem);
-
-	if (_ptype==fLocal)
-	{
-		_cTimingvsEvent_SubdetPM.book(ib, _emap, _subsystem);
-		_cSignalvsEvent_SubdetPM.book(ib, _emap, _subsystem);
-	}
-	else
-	{	
-		_cTimingvsLS_SubdetPM.book(ib, _emap, _subsystem);
-		_cSignalvsLS_SubdetPM.book(ib, _emap, _subsystem);
-		_cTimingvsBX_SubdetPM.book(ib, _emap, _subsystem);
-		_cSignalvsBX_SubdetPM.book(ib, _emap, _subsystem);
-	}
-
-	if (_ptype == fLocal) { // hidefed2crate
-		_cSignalMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cSignalMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cSignalRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cSignalRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMissing_FEDVME.book(ib, _emap, _filter_uTCA,_subsystem);
-		_cMissing_FEDuTCA.book(ib, _emap, _filter_VME,_subsystem);
-		_cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
-	}
-	_cADC_SubdetPM.book(ib, _emap, _subsystem);
-
-	_cMissing_depth.book(ib, _emap,_subsystem);
-
-	_xSignalSum.book(_emap);
-	_xSignalSum2.book(_emap);
-	_xEntries.book(_emap);
-	_xTimingSum.book(_emap);
-	_xTimingSum2.book(_emap);
-
-	if (_ptype == fOnline || _ptype == fLocal) {
-		_cLaserMonSumQ.book(ib, _subsystem);
-		_cLaserMonTiming.book(ib, _subsystem);
-		if (_ptype == fOnline) {
-			_cLaserMonSumQ_LS.book(ib, _subsystem);
-			_cLaserMonTiming_LS.book(ib, _subsystem);
-			_cTimingDiffLS_SubdetPM.book(ib, _emap, _subsystem);
-		} else if (_ptype == fLocal) {
-			_cLaserMonSumQ_Event.book(ib, _subsystem);
-			_cLaserMonTiming_Event.book(ib, _subsystem);
-			_cTimingDiffEvent_SubdetPM.book(ib, _emap, _subsystem);
-		}
-		_cTiming_DigivsLaserMon_SubdetPM.book(ib, _emap, _subsystem);
-		_xTimingRefLMSum.book(_emap);
-		_xTimingRefLMSum2.book(_emap);
-		_xNBadTimingRefLM.book(_emap);
-		_xNChs.book(_emap);
-		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		_cSummaryvsLS.book(ib, _subsystem);
-	}
-
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+  std::vector<double> vTimingRangeHB =
+      ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HB", std::vector<double>({-70, -10.}));
+  std::vector<double> vTimingRangeHE =
+      ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HE", std::vector<double>({-60., 0.}));
+  std::vector<double> vTimingRangeHO =
+      ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HO", std::vector<double>({-50., 20.}));
+  std::vector<double> vTimingRangeHF =
+      ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HF", std::vector<double>({-50., 20.}));
+  _thresh_timingreflm[HcalBarrel] = std::make_pair(vTimingRangeHB[0], vTimingRangeHB[1]);
+  _thresh_timingreflm[HcalEndcap] = std::make_pair(vTimingRangeHE[0], vTimingRangeHE[1]);
+  _thresh_timingreflm[HcalOuter] = std::make_pair(vTimingRangeHO[0], vTimingRangeHO[1]);
+  _thresh_timingreflm[HcalForward] = std::make_pair(vTimingRangeHF[0], vTimingRangeHF[1]);
 }
 
-/* virtual */ void LaserTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void LaserTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    if (r.runAuxiliary().run() == 1)
+      return;
+
+  DQTask::bookHistograms(ib, r, es);
+
+  edm::ESHandle<HcalDbService> dbService;
+  es.get<HcalDbRecord>().get(dbService);
+  _emap = dbService->getHcalMapping();
+
+  std::vector<uint32_t> vhashVME;
+  std::vector<uint32_t> vhashuTCA;
+  std::vector<uint32_t> vhashC36;
+  vhashVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashuTCA);
+
+  //	INITIALIZE
+  _cSignalMean_Subdet.initialize(_name,
+                                 "SignalMean",
+                                 hcaldqm::hashfunctions::fSubdet,
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                 0);
+  _cSignalRMS_Subdet.initialize(_name,
+                                "SignalRMS",
+                                hcaldqm::hashfunctions::fSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+  _cTimingMean_Subdet.initialize(_name,
+                                 "TimingMean",
+                                 hcaldqm::hashfunctions::fSubdet,
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                 0);
+  _cTimingRMS_Subdet.initialize(_name,
+                                "TimingRMS",
+                                hcaldqm::hashfunctions::fSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+
+  _cADC_SubdetPM.initialize(_name,
+                            "ADC",
+                            hcaldqm::hashfunctions::fSubdetPM,
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                            0);
+
+  if (_ptype == fLocal) {  // hidefed2crate
+    _cSignalMean_FEDVME.initialize(_name,
+                                   "SignalMean",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),
+                                   0);
+    _cSignalMean_FEDuTCA.initialize(_name,
+                                    "SignalMean",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),
+                                    0);
+    _cSignalRMS_FEDVME.initialize(_name,
+                                  "SignalRMS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                  0);
+    _cSignalRMS_FEDuTCA.initialize(_name,
+                                   "SignalRMS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                   0);
+    _cTimingMean_FEDVME.initialize(_name,
+                                   "TimingMean",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+    _cTimingMean_FEDuTCA.initialize(_name,
+                                    "TimingMean",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                    0);
+    _cTimingRMS_FEDVME.initialize(_name,
+                                  "TimingRMS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                  0);
+    _cTimingRMS_FEDuTCA.initialize(_name,
+                                   "TimingRMS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+    _cMissing_FEDVME.initialize(_name,
+                                "Missing",
+                                hcaldqm::hashfunctions::fFED,
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+    _cMissing_FEDuTCA.initialize(_name,
+                                 "Missing",
+                                 hcaldqm::hashfunctions::fFED,
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                 0);
+
+    _cShapeCut_FEDSlot.initialize(_name,
+                                  "Shape",
+                                  hcaldqm::hashfunctions::fFEDSlot,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                  0);
+  }
+  _cTimingvsEvent_SubdetPM.initialize(_name,
+                                      "TimingvsEvent",
+                                      hcaldqm::hashfunctions::fSubdetPM,
+                                      new hcaldqm::quantity::EventNumber(_nevents),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                      0);
+  _cSignalvsEvent_SubdetPM.initialize(_name,
+                                      "SignalvsEvent",
+                                      hcaldqm::hashfunctions::fSubdetPM,
+                                      new hcaldqm::quantity::EventNumber(_nevents),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                      0);
+  _cTimingvsLS_SubdetPM.initialize(_name,
+                                   "TimingvsLS",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+  _cSignalvsLS_SubdetPM.initialize(_name,
+                                   "SignalvsLS",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                   0);
+  _cTimingvsBX_SubdetPM.initialize(_name,
+                                   "TimingvsBX",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
+  _cSignalvsBX_SubdetPM.initialize(_name,
+                                   "SignalvsBX",
+                                   hcaldqm::hashfunctions::fSubdetPM,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+                                   0);
+
+  _cSignalMean_depth.initialize(_name,
+                                "SignalMean",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),
+                                0);
+  _cSignalRMS_depth.initialize(_name,
+                               "SignalRMS",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000),
+                               0);
+  _cTimingMean_depth.initialize(_name,
+                                "TimingMean",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                0);
+  _cTimingRMS_depth.initialize(_name,
+                               "TimingRMS",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                               0);
+
+  _cMissing_depth.initialize(_name,
+                             "Missing",
+                             hcaldqm::hashfunctions::fdepth,
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                             0);
+
+  //	initialize compact containers
+  _xSignalSum.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xSignalSum2.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xTimingSum.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xTimingSum2.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xEntries.initialize(hcaldqm::hashfunctions::fDChannel);
+
+  // LaserMon containers
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cLaserMonSumQ.initialize(_name,
+                              "LaserMonSumQ",
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                              0);
+    _cLaserMonSumQ.showOverflowX(true);
+
+    _cLaserMonTiming.initialize(_name,
+                                "LaserMonTiming",
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+    _cLaserMonTiming.showOverflowX(true);
+
+    if (_ptype == fOnline) {
+      _cLaserMonSumQ_LS.initialize(_name,
+                                   "LaserMonSumQ_LS",
+                                   new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000));
+      _cLaserMonTiming_LS.initialize(_name,
+                                     "LaserMonTiming_LS",
+                                     new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS));
+      _cTimingDiffLS_SubdetPM.initialize(_name,
+                                         "TimingDiff_DigiMinusLaserMon",
+                                         hcaldqm::hashfunctions::fSubdetPM,
+                                         new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns),
+                                         0);
+      _cTimingDiffLS_SubdetPM.showOverflowY(true);
+    } else if (_ptype == fLocal) {
+      _cLaserMonSumQ_Event.initialize(_name,
+                                      "LaserMonSumQ_Event",
+                                      new hcaldqm::quantity::EventNumber(_nevents),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000));
+      _cLaserMonTiming_Event.initialize(_name,
+                                        "LaserMonTiming_Event",
+                                        new hcaldqm::quantity::EventNumber(_nevents),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS));
+      _cTimingDiffEvent_SubdetPM.initialize(_name,
+                                            "TimingDiff_DigiMinusLaserMon",
+                                            hcaldqm::hashfunctions::fSubdetPM,
+                                            new hcaldqm::quantity::EventNumber(_nevents),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns),
+                                            0);
+      _cTimingDiffEvent_SubdetPM.showOverflowY(true);
+    }
+    _cTiming_DigivsLaserMon_SubdetPM.initialize(
+        _name,
+        "Timing_DigivsLaserMon",
+        hcaldqm::hashfunctions::fSubdetPM,
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+        0);
+    _cTiming_DigivsLaserMon_SubdetPM.showOverflowX(true);
+    _cTiming_DigivsLaserMon_SubdetPM.showOverflowY(true);
+
+    _xTimingRefLMSum.initialize(hcaldqm::hashfunctions::fDChannel);
+    _xTimingRefLMSum2.initialize(hcaldqm::hashfunctions::fDChannel);
+    _xNBadTimingRefLM.initialize(hcaldqm::hashfunctions::fFED);
+    _xNChs.initialize(hcaldqm::hashfunctions::fFED);
+    _xMissingLaserMon = 0;
+
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
+      _vhashFEDs.push_back(
+          HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
+
+    _cSummaryvsLS_FED.initialize(_name,
+                                 "SummaryvsLS",
+                                 hcaldqm::hashfunctions::fFED,
+                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                 new hcaldqm::quantity::FlagQuantity(_vflags),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                                 0);
+    _cSummaryvsLS.initialize(_name,
+                             "SummaryvsLS",
+                             new hcaldqm::quantity::LumiSection(_maxLS),
+                             new hcaldqm::quantity::FEDQuantity(vFEDs),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                             0);
+  }  // End if (_ptype == fOnline || _ptype == fLocal) {
+
+  //	BOOK
+  _cSignalMean_Subdet.book(ib, _emap, _subsystem);
+  _cSignalRMS_Subdet.book(ib, _emap, _subsystem);
+  _cTimingMean_Subdet.book(ib, _emap, _subsystem);
+  _cTimingRMS_Subdet.book(ib, _emap, _subsystem);
+
+  _cSignalMean_depth.book(ib, _emap, _subsystem);
+  _cSignalRMS_depth.book(ib, _emap, _subsystem);
+  _cTimingMean_depth.book(ib, _emap, _subsystem);
+  _cTimingRMS_depth.book(ib, _emap, _subsystem);
+
+  if (_ptype == fLocal) {
+    _cTimingvsEvent_SubdetPM.book(ib, _emap, _subsystem);
+    _cSignalvsEvent_SubdetPM.book(ib, _emap, _subsystem);
+  } else {
+    _cTimingvsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cSignalvsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cTimingvsBX_SubdetPM.book(ib, _emap, _subsystem);
+    _cSignalvsBX_SubdetPM.book(ib, _emap, _subsystem);
+  }
+
+  if (_ptype == fLocal) {  // hidefed2crate
+    _cSignalMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cSignalMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cSignalRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cSignalRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMissing_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMissing_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
+  }
+  _cADC_SubdetPM.book(ib, _emap, _subsystem);
+
+  _cMissing_depth.book(ib, _emap, _subsystem);
+
+  _xSignalSum.book(_emap);
+  _xSignalSum2.book(_emap);
+  _xEntries.book(_emap);
+  _xTimingSum.book(_emap);
+  _xTimingSum2.book(_emap);
+
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cLaserMonSumQ.book(ib, _subsystem);
+    _cLaserMonTiming.book(ib, _subsystem);
+    if (_ptype == fOnline) {
+      _cLaserMonSumQ_LS.book(ib, _subsystem);
+      _cLaserMonTiming_LS.book(ib, _subsystem);
+      _cTimingDiffLS_SubdetPM.book(ib, _emap, _subsystem);
+    } else if (_ptype == fLocal) {
+      _cLaserMonSumQ_Event.book(ib, _subsystem);
+      _cLaserMonTiming_Event.book(ib, _subsystem);
+      _cTimingDiffEvent_SubdetPM.book(ib, _emap, _subsystem);
+    }
+    _cTiming_DigivsLaserMon_SubdetPM.book(ib, _emap, _subsystem);
+    _xTimingRefLMSum.book(_emap);
+    _xTimingRefLMSum2.book(_emap);
+    _xNBadTimingRefLM.book(_emap);
+    _xNChs.book(_emap);
+    _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    _cSummaryvsLS.book(ib, _subsystem);
+  }
+
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 }
 
-/* virtual */ void LaserTask::_dump()
-{
-	_cSignalMean_Subdet.reset();
-	_cSignalRMS_Subdet.reset();
-	_cTimingMean_Subdet.reset();
-	_cTimingRMS_Subdet.reset();
-	_cSignalMean_depth.reset();
-	_cSignalRMS_depth.reset();
-	_cTimingMean_depth.reset();
-	_cTimingRMS_depth.reset();
+/* virtual */ void LaserTask::_resetMonitors(hcaldqm::UpdateFreq uf) { DQTask::_resetMonitors(uf); }
 
-	if (_ptype == fLocal) { // hidefed2crate
-		_cSignalMean_FEDVME.reset();
-		_cSignalMean_FEDuTCA.reset();
-		_cSignalRMS_FEDVME.reset();
-		_cSignalRMS_FEDuTCA.reset();
-		_cTimingMean_FEDVME.reset();
-		_cTimingMean_FEDuTCA.reset();
-		_cTimingRMS_FEDVME.reset();
-		_cTimingRMS_FEDuTCA.reset();
-	}
-	if (_ptype != fOffline) {
-		_xNChs.reset();		
-	}
+/* virtual */ void LaserTask::_dump() {
+  _cSignalMean_Subdet.reset();
+  _cSignalRMS_Subdet.reset();
+  _cTimingMean_Subdet.reset();
+  _cTimingRMS_Subdet.reset();
+  _cSignalMean_depth.reset();
+  _cSignalRMS_depth.reset();
+  _cTimingMean_depth.reset();
+  _cTimingRMS_depth.reset();
 
-	std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
-	for (std::vector<HcalGenericDetId>::const_iterator it=dids.begin();
-		it!=dids.end(); ++it)
-	{
-		if (!it->isHcalDetId())
-			continue;
-		HcalDetId did = HcalDetId(it->rawId());
-		HcalElectronicsId eid(_ehashmap.lookup(*it));
-		int n = _xEntries.get(did);
-		//	channels missing or low signal
-		if (n == 0) {
-			_cMissing_depth.fill(did);
-			if (_ptype == fLocal) { // hidefed2crate
-				if (eid.isVMEid())
-					_cMissing_FEDVME.fill(eid);
-				else
-					_cMissing_FEDuTCA.fill(eid);
-			}
-			continue;
-		}
+  if (_ptype == fLocal) {  // hidefed2crate
+    _cSignalMean_FEDVME.reset();
+    _cSignalMean_FEDuTCA.reset();
+    _cSignalRMS_FEDVME.reset();
+    _cSignalRMS_FEDuTCA.reset();
+    _cTimingMean_FEDVME.reset();
+    _cTimingMean_FEDuTCA.reset();
+    _cTimingRMS_FEDVME.reset();
+    _cTimingRMS_FEDuTCA.reset();
+  }
+  if (_ptype != fOffline) {
+    _xNChs.reset();
+  }
 
-		_xNChs.get(eid)++;
+  std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
+  for (std::vector<HcalGenericDetId>::const_iterator it = dids.begin(); it != dids.end(); ++it) {
+    if (!it->isHcalDetId())
+      continue;
+    HcalDetId did = HcalDetId(it->rawId());
+    HcalElectronicsId eid(_ehashmap.lookup(*it));
+    int n = _xEntries.get(did);
+    //	channels missing or low signal
+    if (n == 0) {
+      _cMissing_depth.fill(did);
+      if (_ptype == fLocal) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cMissing_FEDVME.fill(eid);
+        else
+          _cMissing_FEDuTCA.fill(eid);
+      }
+      continue;
+    }
 
-		double msig = _xSignalSum.get(did)/n; 
-		double mtim = _xTimingSum.get(did)/n;
-		double rsig = sqrt(_xSignalSum2.get(did)/n-msig*msig);
-		double rtim = sqrt(_xTimingSum2.get(did)/n-mtim*mtim);
+    _xNChs.get(eid)++;
 
-		_cSignalMean_Subdet.fill(did, msig);
-		_cSignalMean_depth.fill(did, msig);
-		_cSignalRMS_Subdet.fill(did, rsig);
-		_cSignalRMS_depth.fill(did, rsig);
-		_cTimingMean_Subdet.fill(did, mtim);
-		_cTimingMean_depth.fill(did, mtim);
-		_cTimingRMS_Subdet.fill(did, rtim);
-		_cTimingRMS_depth.fill(did, rtim);
-		if (_ptype == fLocal) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cSignalMean_FEDVME.fill(eid, msig);
-				_cSignalRMS_FEDVME.fill(eid, rsig);
-				_cTimingMean_FEDVME.fill(eid, mtim);
-				_cTimingRMS_FEDVME.fill(eid, rtim);
-			}
-			else
-			{
-				_cSignalMean_FEDuTCA.fill(eid, msig);
-				_cSignalRMS_FEDuTCA.fill(eid, rsig);
-				_cTimingMean_FEDuTCA.fill(eid, mtim);
-				_cTimingRMS_FEDuTCA.fill(eid, rtim);
-			}
-		}
+    double msig = _xSignalSum.get(did) / n;
+    double mtim = _xTimingSum.get(did) / n;
+    double rsig = sqrt(_xSignalSum2.get(did) / n - msig * msig);
+    double rtim = sqrt(_xTimingSum2.get(did) / n - mtim * mtim);
 
-		// Bad timing
-		
-		double timingreflm_mean = _xTimingRefLMSum.get(did) / n;
-		//double timingreflm_rms = sqrt(_xTimingRefLMSum2.get(did) / n - timingreflm_mean * timingreflm_mean);
+    _cSignalMean_Subdet.fill(did, msig);
+    _cSignalMean_depth.fill(did, msig);
+    _cSignalRMS_Subdet.fill(did, rsig);
+    _cSignalRMS_depth.fill(did, rsig);
+    _cTimingMean_Subdet.fill(did, mtim);
+    _cTimingMean_depth.fill(did, mtim);
+    _cTimingRMS_Subdet.fill(did, rtim);
+    _cTimingRMS_depth.fill(did, rtim);
+    if (_ptype == fLocal) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cSignalMean_FEDVME.fill(eid, msig);
+        _cSignalRMS_FEDVME.fill(eid, rsig);
+        _cTimingMean_FEDVME.fill(eid, mtim);
+        _cTimingRMS_FEDVME.fill(eid, rtim);
+      } else {
+        _cSignalMean_FEDuTCA.fill(eid, msig);
+        _cSignalRMS_FEDuTCA.fill(eid, rsig);
+        _cTimingMean_FEDuTCA.fill(eid, mtim);
+        _cTimingRMS_FEDuTCA.fill(eid, rtim);
+      }
+    }
 
-		if ((timingreflm_mean < _thresh_timingreflm[did.subdet()].first) || (timingreflm_mean > _thresh_timingreflm[did.subdet()].second)) {
-			_xNBadTimingRefLM.get(eid)++;
-		}		
-	}
-	if (_ptype != fOffline) { // hidefed2crate
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin(); it!=_vhashFEDs.end(); ++it) {
-			hcaldqm::flag::Flag fSum("LASER");
-			HcalElectronicsId eid = HcalElectronicsId(*it);
-			std::vector<uint32_t>::const_iterator jt=
-				std::find(_vcdaqEids.begin(), _vcdaqEids.end(), (*it));
-			if (jt==_vcdaqEids.end())
-			{
-				//	not @cDAQ
-				for (
-					uint32_t iflag=0; iflag<_vflags.size(); iflag++)
-					_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-						int(hcaldqm::flag::fNCDAQ));
-				_cSummaryvsLS.setBinContent(eid, _currentLS, int(hcaldqm::flag::fNCDAQ));
-				continue;
-			}
-			//	@cDAQ
-			if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHO(eid) || hcaldqm::utilities::isFEDHF(eid)) {
-				int min_nchs = 10;
-				if (_xNChs.get(eid) < min_nchs) {
-					_vflags[fBadTiming]._state = hcaldqm::flag::fNA;
-				} else {
-					double frbadtimingreflm = double(_xNBadTimingRefLM.get(eid))/double(_xNChs.get(eid));
-					if (frbadtimingreflm > _thresh_frac_timingreflm) {
-						_vflags[fBadTiming]._state = hcaldqm::flag::fBAD;
-					} else {
-						_vflags[fBadTiming]._state = hcaldqm::flag::fGOOD;
-					}
-				}
-				if (_xMissingLaserMon) {
-					_vflags[fMissingLaserMon]._state = hcaldqm::flag::fBAD;
-				} else {
-					_vflags[fMissingLaserMon]._state = hcaldqm::flag::fGOOD;
-				}
-			}
+    // Bad timing
 
-			// Set SummaryVsLS bins
-			int iflag=0;
-			for (std::vector<hcaldqm::flag::Flag>::iterator ft=_vflags.begin();
-				ft!=_vflags.end(); ++ft)
-			{
-				_cSummaryvsLS_FED.setBinContent(eid, _currentLS, iflag,
-					int(ft->_state));
-				fSum+=(*ft);
-				iflag++;
-				ft->reset();
-			}
-			_cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
-		} // End loop over FEDs
+    double timingreflm_mean = _xTimingRefLMSum.get(did) / n;
+    //double timingreflm_rms = sqrt(_xTimingRefLMSum2.get(did) / n - timingreflm_mean * timingreflm_mean);
 
-		// Reset per-LS containers
-		_xNBadTimingRefLM.reset();
-		_xMissingLaserMon = 0;
-	} // End if _ptype != fOffline
+    if ((timingreflm_mean < _thresh_timingreflm[did.subdet()].first) ||
+        (timingreflm_mean > _thresh_timingreflm[did.subdet()].second)) {
+      _xNBadTimingRefLM.get(eid)++;
+    }
+  }
+  if (_ptype != fOffline) {  // hidefed2crate
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      hcaldqm::flag::Flag fSum("LASER");
+      HcalElectronicsId eid = HcalElectronicsId(*it);
+      std::vector<uint32_t>::const_iterator jt = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), (*it));
+      if (jt == _vcdaqEids.end()) {
+        //	not @cDAQ
+        for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
+          _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(hcaldqm::flag::fNCDAQ));
+        _cSummaryvsLS.setBinContent(eid, _currentLS, int(hcaldqm::flag::fNCDAQ));
+        continue;
+      }
+      //	@cDAQ
+      if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHO(eid) || hcaldqm::utilities::isFEDHF(eid)) {
+        int min_nchs = 10;
+        if (_xNChs.get(eid) < min_nchs) {
+          _vflags[fBadTiming]._state = hcaldqm::flag::fNA;
+        } else {
+          double frbadtimingreflm = double(_xNBadTimingRefLM.get(eid)) / double(_xNChs.get(eid));
+          if (frbadtimingreflm > _thresh_frac_timingreflm) {
+            _vflags[fBadTiming]._state = hcaldqm::flag::fBAD;
+          } else {
+            _vflags[fBadTiming]._state = hcaldqm::flag::fGOOD;
+          }
+        }
+        if (_xMissingLaserMon) {
+          _vflags[fMissingLaserMon]._state = hcaldqm::flag::fBAD;
+        } else {
+          _vflags[fMissingLaserMon]._state = hcaldqm::flag::fGOOD;
+        }
+      }
+
+      // Set SummaryVsLS bins
+      int iflag = 0;
+      for (std::vector<hcaldqm::flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
+        _cSummaryvsLS_FED.setBinContent(eid, _currentLS, iflag, int(ft->_state));
+        fSum += (*ft);
+        iflag++;
+        ft->reset();
+      }
+      _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
+    }  // End loop over FEDs
+
+    // Reset per-LS containers
+    _xNBadTimingRefLM.reset();
+    _xMissingLaserMon = 0;
+  }  // End if _ptype != fOffline
 }
 
-/* virtual */ void LaserTask::_process(edm::Event const& e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HBHEDigiCollection>		chbhe;
-	edm::Handle<QIE11DigiCollection>		cHE;
-	edm::Handle<HODigiCollection>		cho;
-	edm::Handle<QIE10DigiCollection>		chf;
+/* virtual */ void LaserTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HBHEDigiCollection> chbhe;
+  edm::Handle<QIE11DigiCollection> cHE;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<QIE10DigiCollection> chf;
 
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available "
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHE, cHE))
-		_logger.dqmthrow("Collection QIE11DigiCollection isn't available "
-			+ _tagHE.label() + " " + _tagHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available "
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection QIE10DigiCollection isn't available "
-			+ _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHE, cHE))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
 
-//	int currentEvent = e.eventAuxiliary().id().event();
-	int bx = e.bunchCrossing();
-	
+  //	int currentEvent = e.eventAuxiliary().id().event();
+  int bx = e.bunchCrossing();
 
-	// LASERMON
-	edm::Handle<QIE10DigiCollection>  cLaserMon;
-	if (!e.getByToken(_tokLaserMon, cLaserMon)) {
-		_logger.dqmthrow("QIE10DigiCollection for laserMonDigis isn't available.");
-	}
-	std::vector<int> laserMonADC;
-	processLaserMon(cLaserMon, laserMonADC);
+  // LASERMON
+  edm::Handle<QIE10DigiCollection> cLaserMon;
+  if (!e.getByToken(_tokLaserMon, cLaserMon)) {
+    _logger.dqmthrow("QIE10DigiCollection for laserMonDigis isn't available.");
+  }
+  std::vector<int> laserMonADC;
+  processLaserMon(cLaserMon, laserMonADC);
 
-	// SumQ = peak +/- 3 TSes
-	// Timing = fC-weighted average (TS-TS0) * 25 ns, also in peak +/- 3 TSes
-	int peakTS = -1;
-	double peakLaserMonADC = -1;
-	for (unsigned int iTS = 0; iTS < laserMonADC.size(); ++iTS) {
-		if (laserMonADC[iTS] > peakLaserMonADC) {
-			peakLaserMonADC = laserMonADC[iTS];
-			peakTS = iTS;
-		}
-	}
+  // SumQ = peak +/- 3 TSes
+  // Timing = fC-weighted average (TS-TS0) * 25 ns, also in peak +/- 3 TSes
+  int peakTS = -1;
+  double peakLaserMonADC = -1;
+  for (unsigned int iTS = 0; iTS < laserMonADC.size(); ++iTS) {
+    if (laserMonADC[iTS] > peakLaserMonADC) {
+      peakLaserMonADC = laserMonADC[iTS];
+      peakTS = iTS;
+    }
+  }
 
-	double laserMonSumQ = 0;
-	double laserMonTiming = 0.;
+  double laserMonSumQ = 0;
+  double laserMonTiming = 0.;
 
-	if (peakTS >= 0) {
-		int minTS = std::max(0, peakTS - 3);
-		int maxTS = std::min(int(laserMonADC.size()-1), peakTS + 3);
-		for (int iTS = minTS; iTS <= maxTS; ++iTS) {
-			double this_fC = hcaldqm::constants::adc2fC[laserMonADC[iTS]];
-			laserMonSumQ += this_fC;
-			laserMonTiming += 25. * (iTS - _laserMonTS0) * this_fC;
-		}
-	}
-	if (laserMonSumQ > 0.) {
-		laserMonTiming = laserMonTiming / laserMonSumQ;
-	} else {
-		++_xMissingLaserMon;
-	}
+  if (peakTS >= 0) {
+    int minTS = std::max(0, peakTS - 3);
+    int maxTS = std::min(int(laserMonADC.size() - 1), peakTS + 3);
+    for (int iTS = minTS; iTS <= maxTS; ++iTS) {
+      double this_fC = hcaldqm::constants::adc2fC[laserMonADC[iTS]];
+      laserMonSumQ += this_fC;
+      laserMonTiming += 25. * (iTS - _laserMonTS0) * this_fC;
+    }
+  }
+  if (laserMonSumQ > 0.) {
+    laserMonTiming = laserMonTiming / laserMonSumQ;
+  } else {
+    ++_xMissingLaserMon;
+  }
 
-	if (laserMonSumQ > _laserMonThreshold) {
-		_cLaserMonSumQ.fill(laserMonSumQ);
-		_cLaserMonTiming.fill(laserMonTiming);
-		if (_ptype == fOnline) {
-			_cLaserMonSumQ_LS.fill(_currentLS, laserMonSumQ);
-			_cLaserMonTiming_LS.fill(_currentLS, laserMonTiming);
-		} else if (_ptype == fLocal) {
-			int currentEvent = e.eventAuxiliary().id().event();
-			_cLaserMonSumQ_Event.fill(currentEvent, laserMonSumQ);
-			_cLaserMonTiming_Event.fill(currentEvent, laserMonTiming);
-		}
-	}
+  if (laserMonSumQ > _laserMonThreshold) {
+    _cLaserMonSumQ.fill(laserMonSumQ);
+    _cLaserMonTiming.fill(laserMonTiming);
+    if (_ptype == fOnline) {
+      _cLaserMonSumQ_LS.fill(_currentLS, laserMonSumQ);
+      _cLaserMonTiming_LS.fill(_currentLS, laserMonTiming);
+    } else if (_ptype == fLocal) {
+      int currentEvent = e.eventAuxiliary().id().event();
+      _cLaserMonSumQ_Event.fill(currentEvent, laserMonSumQ);
+      _cLaserMonTiming_Event.fill(currentEvent, laserMonTiming);
+    }
+  }
 
-	for (HBHEDigiCollection::const_iterator it=chbhe->begin();
-		it!=chbhe->end(); ++it)
-	{
-		const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-		double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, 
-			digi.size()-1);
-		if (sumQ<_lowHBHE)
-			continue;
-		HcalDetId did = digi.id();
-		HcalElectronicsId eid = digi.elecId();
+  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
+    double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size() - 1);
+    if (sumQ < _lowHBHE)
+      continue;
+    HcalDetId did = digi.id();
+    HcalElectronicsId eid = digi.elecId();
 
-		double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,
-			digi.size()-1);
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
+    double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0, digi.size() - 1);
+    _xSignalSum.get(did) += sumQ;
+    _xSignalSum2.get(did) += sumQ * sumQ;
+    _xTimingSum.get(did) += aveTS;
+    _xTimingSum2.get(did) += aveTS * aveTS;
+    _xEntries.get(did)++;
 
-		for (int i=0; i<digi.size(); i++)
-		{
-			if (_ptype == fLocal) { // hidefed2crate
-				_cShapeCut_FEDSlot.fill(eid, i, 
-					digi.sample(i).nominal_fC()-2.5);
-			}
-			_cADC_SubdetPM.fill(did, digi.sample(i).adc());
-		}
+    for (int i = 0; i < digi.size(); i++) {
+      if (_ptype == fLocal) {  // hidefed2crate
+        _cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC() - 2.5);
+      }
+      _cADC_SubdetPM.fill(did, digi.sample(i).adc());
+    }
 
-		//	select based on local global
-		double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-		double deltaTiming = digiTimingSOI - laserMonTiming;
-		_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
-		_xTimingRefLMSum.get(did) += deltaTiming;
-		_xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
-		if (_ptype==fLocal) {
-			int currentEvent = e.eventAuxiliary().id().event();
-			_cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
-			_cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
-			_cTimingDiffLS_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-		else {
-			_cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
-			_cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			_cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
-			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
-			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-	}
-	for (QIE11DigiCollection::const_iterator it=cHE->begin(); it!=cHE->end();
-		++it)
-	{
-		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
-		HcalDetId const& did = digi.detid();
-		if (did.subdet() != HcalEndcap) {
-			continue;
-		}
-		uint32_t rawid = _ehashmap.lookup(did);
-		HcalElectronicsId const& eid(rawid);
+    //	select based on local global
+    double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
+    double deltaTiming = digiTimingSOI - laserMonTiming;
+    _cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
+    _xTimingRefLMSum.get(did) += deltaTiming;
+    _xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
+    if (_ptype == fLocal) {
+      int currentEvent = e.eventAuxiliary().id().event();
+      _cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
+      _cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
+      _cTimingDiffLS_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    } else {
+      _cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
+      _cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
+      _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
+      _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    }
+  }
+  for (QIE11DigiCollection::const_iterator it = cHE->begin(); it != cHE->end(); ++it) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
+    HcalDetId const& did = digi.detid();
+    if (did.subdet() != HcalEndcap) {
+      continue;
+    }
+    uint32_t rawid = _ehashmap.lookup(did);
+    HcalElectronicsId const& eid(rawid);
 
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
-		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		if (sumQ<_lowHE)
-			continue;
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
+    //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
+    double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    if (sumQ < _lowHE)
+      continue;
 
+    //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
+    double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    _xSignalSum.get(did) += sumQ;
+    _xSignalSum2.get(did) += sumQ * sumQ;
+    _xTimingSum.get(did) += aveTS;
+    _xTimingSum2.get(did) += aveTS * aveTS;
+    _xEntries.get(did)++;
 
-		//double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
-		double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
+    for (int i = 0; i < digi.samples(); i++) {
+      if (_ptype == fLocal) {
+        _cShapeCut_FEDSlot.fill(
+            eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
+      }
+      _cADC_SubdetPM.fill(did, digi[i].adc());
+    }
 
-		for (int i=0; i<digi.samples(); i++)
-		{
-			if (_ptype == fLocal) {
-				_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
-			}
-			_cADC_SubdetPM.fill(did, digi[i].adc());
-		}
+    //	select based on local global
+    double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
+    double deltaTiming = digiTimingSOI - laserMonTiming;
+    _cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
+    _xTimingRefLMSum.get(did) += deltaTiming;
+    _xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
+    if (_ptype == fLocal) {
+      int currentEvent = e.eventAuxiliary().id().event();
+      _cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
+      _cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
+      _cTimingDiffEvent_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    } else {
+      _cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
+      _cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
+      _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
+      _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    }
+  }
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    const HODataFrame digi = (const HODataFrame)(*it);
+    double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size() - 1);
+    if (sumQ < _lowHO)
+      continue;
+    HcalDetId did = digi.id();
+    HcalElectronicsId eid = digi.elecId();
 
-		//	select based on local global
-		double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-		double deltaTiming = digiTimingSOI - laserMonTiming;
-		_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
-		_xTimingRefLMSum.get(did) += deltaTiming;
-		_xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
-		if (_ptype==fLocal)
-		{
-			int currentEvent = e.eventAuxiliary().id().event();
-			_cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
-			_cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
-			_cTimingDiffEvent_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-		else
-		{
-			_cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
-			_cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			_cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
-			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
-			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-	}
-	for (HODigiCollection::const_iterator it=cho->begin();
-		it!=cho->end(); ++it)
-	{
-		const HODataFrame digi = (const HODataFrame)(*it);
-		double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, 
-			digi.size()-1);
-		if (sumQ<_lowHO)
-			continue;
-		HcalDetId did = digi.id();
-		HcalElectronicsId eid = digi.elecId();
+    double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size() - 1);
+    _xSignalSum.get(did) += sumQ;
+    _xSignalSum2.get(did) += sumQ * sumQ;
+    _xTimingSum.get(did) += aveTS;
+    _xTimingSum2.get(did) += aveTS * aveTS;
+    _xEntries.get(did)++;
 
-		double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0,
-			digi.size()-1);
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
+    for (int i = 0; i < digi.size(); i++) {
+      if (_ptype == fLocal) {  // hidefed2crate
+        _cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC() - 8.5);
+      }
+      _cADC_SubdetPM.fill(did, digi.sample(i).adc());
+    }
 
-		for (int i=0; i<digi.size(); i++)
-		{
-			if (_ptype == fLocal) { // hidefed2crate
-				_cShapeCut_FEDSlot.fill(eid, i, 
-					digi.sample(i).nominal_fC()-8.5);
-			}
-			_cADC_SubdetPM.fill(did, digi.sample(i).adc());
-		}
+    //	select based on local global
+    double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
+    double deltaTiming = digiTimingSOI - laserMonTiming;
+    _cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
+    _xTimingRefLMSum.get(did) += deltaTiming;
+    _xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
+    if (_ptype == fLocal) {
+      int currentEvent = e.eventAuxiliary().id().event();
+      _cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
+      _cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
+      _cTimingDiffEvent_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    } else {
+      _cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
+      _cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
+      _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
+      _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    }
+  }
+  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
+    HcalDetId did = digi.detid();
+    if (did.subdet() != HcalForward) {
+      continue;
+    }
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
 
-		//	select based on local global
-		double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-		double deltaTiming = digiTimingSOI - laserMonTiming;
-		_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
-		_xTimingRefLMSum.get(did) += deltaTiming;
-		_xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
-		if (_ptype==fLocal)
-		{
-			int currentEvent = e.eventAuxiliary().id().event();
-			_cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
-			_cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
-			_cTimingDiffEvent_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-		else
-		{
-			_cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
-			_cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			_cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
-			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
-			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-	}
-	for (QIE10DigiCollection::const_iterator it=chf->begin();
-		it!=chf->end(); ++it)
-	{
-		const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
-		HcalDetId did = digi.detid();
-		if (did.subdet() != HcalForward) {
-			continue;
-		}
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
+    double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    //double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+    if (sumQ < _lowHF)
+      continue;
 
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		if (sumQ<_lowHF)
-			continue;
+    //double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+    double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
 
-		//double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
+    _xSignalSum.get(did) += sumQ;
+    _xSignalSum2.get(did) += sumQ * sumQ;
+    _xTimingSum.get(did) += aveTS;
+    _xTimingSum2.get(did) += aveTS * aveTS;
+    _xEntries.get(did)++;
 
-		for (int i=0; i<digi.samples(); i++)
-		{
-			if (_ptype == fLocal) { // hidefed2crate
-				_cShapeCut_FEDSlot.fill(eid, (int)i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
-			}
-			_cADC_SubdetPM.fill(did, digi[i].adc());
-		}
+    for (int i = 0; i < digi.samples(); i++) {
+      if (_ptype == fLocal) {  // hidefed2crate
+        _cShapeCut_FEDSlot.fill(
+            eid, (int)i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
+      }
+      _cADC_SubdetPM.fill(did, digi[i].adc());
+    }
 
-		//	select based on local global
-		double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-		double deltaTiming = digiTimingSOI - laserMonTiming;
-		_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
-		_xTimingRefLMSum.get(did) += deltaTiming;
-		_xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
-		if (_ptype==fLocal)
-		{
-			int currentEvent = e.eventAuxiliary().id().event();
-			_cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
-			_cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
-			_cTimingDiffEvent_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-		else
-		{
-			_cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
-			_cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-			_cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
-			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
-			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-		}
-	}
+    //	select based on local global
+    double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
+    double deltaTiming = digiTimingSOI - laserMonTiming;
+    _cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
+    _xTimingRefLMSum.get(did) += deltaTiming;
+    _xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
+    if (_ptype == fLocal) {
+      int currentEvent = e.eventAuxiliary().id().event();
+      _cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
+      _cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
+      _cTimingDiffEvent_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    } else {
+      _cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
+      _cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
+      _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
+      _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
+      _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    }
+  }
 }
 
-void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC) {
-	for (QIE10DigiCollection::const_iterator it=col->begin(); it!=col->end(); ++it) {
-		const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
-		HcalCalibDetId hcdid(digi.id());
+void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection>& col, std::vector<int>& iLaserMonADC) {
+  for (QIE10DigiCollection::const_iterator it = col->begin(); it != col->end(); ++it) {
+    const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
+    HcalCalibDetId hcdid(digi.id());
 
-		if ((hcdid.ieta() != _laserMonIEta) || (hcdid.cboxChannel() != _laserMonCBox)) {
-			continue;
-		}
+    if ((hcdid.ieta() != _laserMonIEta) || (hcdid.cboxChannel() != _laserMonCBox)) {
+      continue;
+    }
 
-		unsigned int digiIndex = std::find(_vLaserMonIPhi.begin(), _vLaserMonIPhi.end(), hcdid.iphi()) - _vLaserMonIPhi.begin();
-		if (digiIndex == _vLaserMonIPhi.size()) {
-			continue;
-		}		
+    unsigned int digiIndex =
+        std::find(_vLaserMonIPhi.begin(), _vLaserMonIPhi.end(), hcdid.iphi()) - _vLaserMonIPhi.begin();
+    if (digiIndex == _vLaserMonIPhi.size()) {
+      continue;
+    }
 
-		// First digi: initialize the vectors to -1 (need to know the length of the digi)
-		if (iLaserMonADC.empty()) {
-			int totalNSamples = (digi.samples() - _laserMonDigiOverlap) * _vLaserMonIPhi.size();
-			for (int i = 0; i < totalNSamples; ++i) {
-				iLaserMonADC.push_back(-1);
-			}
-		}
+    // First digi: initialize the vectors to -1 (need to know the length of the digi)
+    if (iLaserMonADC.empty()) {
+      int totalNSamples = (digi.samples() - _laserMonDigiOverlap) * _vLaserMonIPhi.size();
+      for (int i = 0; i < totalNSamples; ++i) {
+        iLaserMonADC.push_back(-1);
+      }
+    }
 
-		for (int subindex = 0; subindex < digi.samples() - _laserMonDigiOverlap; ++subindex) {
-			int totalIndex = (digi.samples() - _laserMonDigiOverlap) * digiIndex + subindex;
-			iLaserMonADC[totalIndex] = (digi[subindex].ok() ? digi[subindex].adc() : -1);
-		}
-	}
+    for (int subindex = 0; subindex < digi.samples() - _laserMonDigiOverlap; ++subindex) {
+      int totalIndex = (digi.samples() - _laserMonDigiOverlap) * digiIndex + subindex;
+      iLaserMonADC[totalIndex] = (digi[subindex].ok() ? digi[subindex].adc() : -1);
+    }
+  }
 }
 
-/* virtual */ void LaserTask::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		return;	
-	this->_dump();
+/* virtual */ void LaserTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    return;
+  this->_dump();
 
-	DQTask::endLuminosityBlock(lb, es);
+  DQTask::endLuminosityBlock(lb, es);
 }
 
-/* virtual */ bool LaserTask::_isApplicable(edm::Event const& e)
-{
-	if (_ptype!=fOnline)
-		return true;
-	else 
-	{
-		//	fOnline mode
-		edm::Handle<HcalUMNioDigi> cumn;
-		if (!e.getByToken(_tokuMN, cumn))
-			return false;
-		
-		//	event type check first
-		uint8_t eventType = cumn->eventType();
-		if (eventType!=constants::EVENTTYPE_LASER)
-			return false;
+/* virtual */ bool LaserTask::_isApplicable(edm::Event const& e) {
+  if (_ptype != fOnline)
+    return true;
+  else {
+    //	fOnline mode
+    edm::Handle<HcalUMNioDigi> cumn;
+    if (!e.getByToken(_tokuMN, cumn))
+      return false;
 
-		//	check if this analysis task is of the right laser type
-		uint32_t laserType = cumn->valueUserWord(0);
-		if (laserType==_laserType) return true;
-	}
+    //	event type check first
+    uint8_t eventType = cumn->eventType();
+    if (eventType != constants::EVENTTYPE_LASER)
+      return false;
 
-	return false;
+    //	check if this analysis task is of the right laser type
+    uint32_t laserType = cumn->valueUserWord(0);
+    if (laserType == _laserType)
+      return true;
+  }
+
+  return false;
 }
 
 DEFINE_FWK_MODULE(LaserTask);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -7,16 +7,14 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
 
   //	tags
-  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
-  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
-  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
   _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
   _tagLaserMon = ps.getUntrackedParameter<edm::InputTag>("tagLaserMon", edm::InputTag("LASERMON"));
-  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
-  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
   _tokLaserMon = consumes<QIE10DigiCollection>(_tagLaserMon);
 
@@ -26,7 +24,6 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
   //	constants
   _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 50);
-  _lowHE = ps.getUntrackedParameter<double>("lowHE", 150);
   _lowHO = ps.getUntrackedParameter<double>("lowHO", 100);
   _lowHF = ps.getUntrackedParameter<double>("lowHF", 50);
   _laserType = (uint32_t)ps.getUntrackedParameter<uint32_t>("laserType");
@@ -564,19 +561,16 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void LaserTask::_process(edm::Event const& e, edm::EventSetup const& es) {
-  edm::Handle<HBHEDigiCollection> chbhe;
-  edm::Handle<QIE11DigiCollection> cHE;
-  edm::Handle<HODigiCollection> cho;
-  edm::Handle<QIE10DigiCollection> chf;
+  edm::Handle<QIE11DigiCollection> c_QIE11;
+  edm::Handle<HODigiCollection> c_ho;
+  edm::Handle<QIE10DigiCollection> c_QIE10;
 
-  if (!e.getByToken(_tokHBHE, chbhe))
-    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
-  if (!e.getByToken(_tokHE, cHE))
-    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagHE.label() + " " + _tagHE.instance());
-  if (!e.getByToken(_tokHO, cho))
+  if (!e.getByToken(_tokQIE11, c_QIE11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagQIE11.label() + " " + _tagQIE11.instance());
+  if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokHF, chf))
-    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokQIE10, c_QIE10))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagQIE10.label() + " " + _tagQIE10.instance());
 
   //	int currentEvent = e.eventAuxiliary().id().event();
   int bx = e.bunchCrossing();
@@ -631,51 +625,10 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
     }
   }
 
-  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
-    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-    double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size() - 1);
-    if (sumQ < _lowHBHE)
-      continue;
-    HcalDetId did = digi.id();
-    HcalElectronicsId eid = digi.elecId();
-
-    double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0, digi.size() - 1);
-    _xSignalSum.get(did) += sumQ;
-    _xSignalSum2.get(did) += sumQ * sumQ;
-    _xTimingSum.get(did) += aveTS;
-    _xTimingSum2.get(did) += aveTS * aveTS;
-    _xEntries.get(did)++;
-
-    for (int i = 0; i < digi.size(); i++) {
-      if (_ptype == fLocal) {  // hidefed2crate
-        _cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC() - 2.5);
-      }
-      _cADC_SubdetPM.fill(did, digi.sample(i).adc());
-    }
-
-    //	select based on local global
-    double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-    double deltaTiming = digiTimingSOI - laserMonTiming;
-    _cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
-    _xTimingRefLMSum.get(did) += deltaTiming;
-    _xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
-    if (_ptype == fLocal) {
-      int currentEvent = e.eventAuxiliary().id().event();
-      _cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
-      _cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
-      _cTimingDiffLS_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-    } else {
-      _cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
-      _cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-      _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
-      _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
-      _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-    }
-  }
   for (QIE11DigiCollection::const_iterator it = cHE->begin(); it != cHE->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
-    if (did.subdet() != HcalEndcap) {
+    if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
       continue;
     }
     uint32_t rawid = _ehashmap.lookup(did);
@@ -684,7 +637,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
     //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
     double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
-    if (sumQ < _lowHE)
+    if (sumQ < _lowHBHE)
       continue;
 
     //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
@@ -722,7 +675,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
     }
   }
-  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+  for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size() - 1);
     if (sumQ < _lowHO)
@@ -763,7 +716,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
     }
   }
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -625,7 +625,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
     }
   }
 
-  for (QIE11DigiCollection::const_iterator it = cHE->begin(); it != cHE->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {

--- a/DQM/HcalTasks/plugins/NoCQTask.cc
+++ b/DQM/HcalTasks/plugins/NoCQTask.cc
@@ -3,159 +3,134 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 
-NoCQTask::NoCQTask(edm::ParameterSet const& ps) : 
-	DQTask(ps)
-{
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		 edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
-	_tagReport = ps.getUntrackedParameter<edm::InputTag>("tagReport",
-		edm::InputTag("hcalDigis"));
+NoCQTask::NoCQTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagReport = ps.getUntrackedParameter<edm::InputTag>("tagReport", edm::InputTag("hcalDigis"));
 
-	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<HFDigiCollection>(_tagHF);
-	_tokReport = consumes<HcalUnpackerReport>(_tagReport);
+  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<HFDigiCollection>(_tagHF);
+  _tokReport = consumes<HcalUnpackerReport>(_tagReport);
 
-	_cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
-	_cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
-	_cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
+  _cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
+  _cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
+  _cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
 }
 
-/* virtual */ void NoCQTask::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib, r, es);
+/* virtual */ void NoCQTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
 
-	_cTimingCut_depth.initialize(_name, "TimingCut", 
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
-	_cOccupancy_depth.initialize(_name, "Occupancy",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cOccupancyCut_depth.initialize(_name, "OccupancyCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cBadQuality_depth.initialize(_name, "BadQuality",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cTimingCut_depth.initialize(_name,
+                               "TimingCut",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                               0);
+  _cOccupancy_depth.initialize(_name,
+                               "Occupancy",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
+  _cOccupancyCut_depth.initialize(_name,
+                                  "OccupancyCut",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+  _cBadQuality_depth.initialize(_name,
+                                "BadQuality",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
 
-	_cTimingCut_depth.book(ib, _emap, _subsystem);
-	_cOccupancy_depth.book(ib, _emap, _subsystem);
-	_cOccupancyCut_depth.book(ib, _emap, _subsystem);
-	_cBadQuality_depth.book(ib, _emap, _subsystem);
+  _cTimingCut_depth.book(ib, _emap, _subsystem);
+  _cOccupancy_depth.book(ib, _emap, _subsystem);
+  _cOccupancyCut_depth.book(ib, _emap, _subsystem);
+  _cBadQuality_depth.book(ib, _emap, _subsystem);
 }
 
-/* virtual */ void NoCQTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void NoCQTask::_resetMonitors(hcaldqm::UpdateFreq uf) { DQTask::_resetMonitors(uf); }
+
+/* virtual */ void NoCQTask::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<HBHEDigiCollection> chbhe;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<HFDigiCollection> chf;
+  edm::Handle<HcalUnpackerReport> creport;
+
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection HFDigiCollection isn't available" + _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokReport, creport))
+    _logger.dqmthrow("Collection HcalUnpackerReport isn't available" + _tagReport.label() + " " +
+                     _tagReport.instance());
+
+  //	RAW Bad Quality
+  for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
+    if (!HcalGenericDetId(*it).isHcalDetId())
+      continue;
+
+    _cBadQuality_depth.fill(HcalDetId(*it));
+  }
+
+  //	DIGI HBH, HO, HF
+  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size() - 1);
+    HcalDetId const& did = it->id();
+
+    _cOccupancy_depth.fill(did);
+    if (sumQ > _cutSumQ_HBHE) {
+      double timing = hcaldqm::utilities::aveTS<HBHEDataFrame>(*it, 2.5, 0, it->size() - 1);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_depth.fill(did, timing);
+    }
+  }
+
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size() - 1);
+    HcalDetId const& did = it->id();
+
+    _cOccupancy_depth.fill(did);
+    if (sumQ > _cutSumQ_HO) {
+      double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0, it->size() - 1);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_depth.fill(did, timing);
+    }
+  }
+
+  for (HFDigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HFDataFrame>(*it, 2.5, 0, it->size() - 1);
+    HcalDetId const& did = it->id();
+
+    _cOccupancy_depth.fill(did);
+    if (sumQ > _cutSumQ_HF) {
+      double timing = hcaldqm::utilities::aveTS<HFDataFrame>(*it, 2.5, 0, it->size() - 1);
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_depth.fill(did, timing);
+    }
+  }
 }
 
-/* virtual */ void NoCQTask::_process(edm::Event const& e,
-	edm::EventSetup const&)
-{
-	edm::Handle<HBHEDigiCollection> chbhe;
-	edm::Handle<HODigiCollection> cho;
-	edm::Handle<HFDigiCollection> chf;
-	edm::Handle<HcalUnpackerReport> creport;
-
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available"
-			 + _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection HFDigiCollection isn't available"
-			+ _tagHF.label() + " " + _tagHF.instance());
-	if (!e.getByToken(_tokReport, creport))
-		_logger.dqmthrow("Collection HcalUnpackerReport isn't available"+
-			_tagReport.label()+" " +_tagReport.instance());
-
-	//	RAW Bad Quality
-	for (std::vector<DetId>::const_iterator it=creport->bad_quality_begin();
-		it!=creport->bad_quality_end(); ++it)
-	{
-		if (!HcalGenericDetId(*it).isHcalDetId())
-			continue;
-
-		_cBadQuality_depth.fill(HcalDetId(*it));
-	}
-
-	//	DIGI HBH, HO, HF
-	for (HBHEDigiCollection::const_iterator it=chbhe->begin(); it!=chbhe->end();
-		++it)
-	{
-		double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
-		HcalDetId const& did = it->id();
-
-		_cOccupancy_depth.fill(did);
-		if (sumQ>_cutSumQ_HBHE)
-		{
-			double timing = hcaldqm::utilities::aveTS<HBHEDataFrame>(*it, 2.5, 0,
-				it->size()-1);
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCut_depth.fill(did, timing);
-		}
-	}
-
-	for (HODigiCollection::const_iterator it=cho->begin(); it!=cho->end();
-		++it)
-	{
-		double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size()-1);
-		HcalDetId const& did = it->id();
-
-		_cOccupancy_depth.fill(did);
-		if (sumQ>_cutSumQ_HO)
-		{
-			double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0,
-				it->size()-1);
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCut_depth.fill(did, timing);
-		}
-	}
-
-	for (HFDigiCollection::const_iterator it=chf->begin(); it!=chf->end();
-		++it)
-	{
-		 double sumQ = hcaldqm::utilities::sumQ<HFDataFrame>(*it, 2.5, 0, it->size()-1);
-		 HcalDetId const& did = it->id();
-
-		 _cOccupancy_depth.fill(did);
-		 if (sumQ>_cutSumQ_HF)
-		 {
-			 double timing = hcaldqm::utilities::aveTS<HFDataFrame>(*it, 2.5, 0, it->size()-1);
-			 _cOccupancyCut_depth.fill(did);
-			 _cTimingCut_depth.fill(did, timing);
-		 }
-	}
+/* virtual */ void NoCQTask::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void NoCQTask::beginLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
-}
-
-/* virtual */ void NoCQTask::endLuminosityBlock(edm::LuminosityBlock const& 
-	lb, edm::EventSetup const& es)
-{
-	DQTask::endLuminosityBlock(lb, es);
+/* virtual */ void NoCQTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(NoCQTask);

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -3,996 +3,1073 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-PedestalTask::PedestalTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	//	tags
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
-	_tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
-		edm::InputTag("tbunpacker"));
-	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
-		edm::InputTag("hcalDigis"));
-	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
-	_tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
-	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
+PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  //	tags
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
+  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
+  _tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
+  _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
-	_vflags.resize(2);
-	_vflags[fMsn]=hcaldqm::flag::Flag("Msn");
-	_vflags[fBadM]=hcaldqm::flag::Flag("BadM");
-	//_vflags[fBadR]=hcaldqm::flag::Flag("BadR");
+  _vflags.resize(2);
+  _vflags[fMsn] = hcaldqm::flag::Flag("Msn");
+  _vflags[fBadM] = hcaldqm::flag::Flag("BadM");
+  //_vflags[fBadR]=hcaldqm::flag::Flag("BadR");
 
-	_thresh_mean = ps.getUntrackedParameter<double>("thresh_mean",
-		0.25);
-	_thresh_rms = ps.getUntrackedParameter<double>("thresh_mean",
-		0.25);
-	_thresh_badm = ps.getUntrackedParameter<double>("thresh_badm", 0.1);
-	_thresh_badr = ps.getUntrackedParameter<double>("thresh_badr", 0.1);
-	_thresh_missing_high = ps.getUntrackedParameter<double>(
-		"thresh_missing_high", 0.2);
-	_thresh_missing_low = ps.getUntrackedParameter<double>(
-		"thresh_missing_low", 0.05);
+  _thresh_mean = ps.getUntrackedParameter<double>("thresh_mean", 0.25);
+  _thresh_rms = ps.getUntrackedParameter<double>("thresh_mean", 0.25);
+  _thresh_badm = ps.getUntrackedParameter<double>("thresh_badm", 0.1);
+  _thresh_badr = ps.getUntrackedParameter<double>("thresh_badr", 0.1);
+  _thresh_missing_high = ps.getUntrackedParameter<double>("thresh_missing_high", 0.2);
+  _thresh_missing_low = ps.getUntrackedParameter<double>("thresh_missing_low", 0.05);
 }
 
-/* virtual */ void PedestalTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		if (r.runAuxiliary().run()==1)
-			return;
-	DQTask::bookHistograms(ib, r, es);
-	
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
-	std::vector<uint32_t> vhashVME;
-	std::vector<uint32_t> vhashuTCA;
-	std::vector<uint32_t> vhashC38;
-	vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	vhashC38.push_back(HcalElectronicsId(38, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashuTCA);
-	_filter_C38.initialize(filter::fFilter, hcaldqm::hashfunctions::fCrate,
-		vhashC38);
+/* virtual */ void PedestalTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    if (r.runAuxiliary().run() == 1)
+      return;
+  DQTask::bookHistograms(ib, r, es);
 
-	//	Containers XXX
-	_xPedSum1LS.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xPedSum21LS.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xPedEntries1LS.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xPedSumTotal.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xPedSum2Total.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xPedEntriesTotal.initialize(hcaldqm::hashfunctions::fDChannel);
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
+  std::vector<uint32_t> vhashVME;
+  std::vector<uint32_t> vhashuTCA;
+  std::vector<uint32_t> vhashC38;
+  vhashVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  vhashC38.push_back(HcalElectronicsId(38, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashuTCA);
+  _filter_C38.initialize(filter::fFilter, hcaldqm::hashfunctions::fCrate, vhashC38);
+
+  //	Containers XXX
+  _xPedSum1LS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedSum21LS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedEntries1LS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedSumTotal.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedSum2Total.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedEntriesTotal.initialize(hcaldqm::hashfunctions::fDChannel);
 
 #ifndef HIDE_PEDESTAL_CONDITIONS
-	_xPedRefMean.initialize(hcaldqm::hashfunctions::fDChannel);
-	_xPedRefRMS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedRefMean.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedRefRMS.initialize(hcaldqm::hashfunctions::fDChannel);
 #endif
 
+  //	Containers
+  _cMean1LS_Subdet.initialize(_name,
+                              "Mean1LS",
+                              hcaldqm::hashfunctions::fSubdet,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                              0);
+  _cRMS1LS_Subdet.initialize(_name,
+                             "RMS1LS",
+                             hcaldqm::hashfunctions::fSubdet,
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                             0);
+  _cMean1LS_depth.initialize(_name,
+                             "Mean1LS",
+                             hcaldqm::hashfunctions::fdepth,
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                             0);
+  _cRMS1LS_depth.initialize(_name,
+                            "RMS1LS",
+                            hcaldqm::hashfunctions::fdepth,
+                            new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                            new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                            0);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMean1LS_FEDVME.initialize(_name,
+                                "Mean1LS",
+                                hcaldqm::hashfunctions::fFED,
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                                0);
+    _cMean1LS_FEDuTCA.initialize(_name,
+                                 "Mean1LS",
+                                 hcaldqm::hashfunctions::fFED,
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                                 0);
+    _cRMS1LS_FEDVME.initialize(_name,
+                               "RMS1LS",
+                               hcaldqm::hashfunctions::fFED,
+                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                               0);
+    _cRMS1LS_FEDuTCA.initialize(_name,
+                                "RMS1LS",
+                                hcaldqm::hashfunctions::fFED,
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                0);
+  }
 
-	//	Containers
-	_cMean1LS_Subdet.initialize(_name, "Mean1LS",hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cRMS1LS_Subdet.initialize(_name, "RMS1LS", hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cMean1LS_depth.initialize(_name, "Mean1LS", hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
-	_cRMS1LS_depth.initialize(_name, "RMS1LS", hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMean1LS_FEDVME.initialize(_name, "Mean1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
-		_cMean1LS_FEDuTCA.initialize(_name, "Mean1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
-		_cRMS1LS_FEDVME.initialize(_name, "RMS1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cRMS1LS_FEDuTCA.initialize(_name, "RMS1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-	}
-	
-	_cMeanTotal_Subdet.initialize(_name, "Mean",hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cRMSTotal_Subdet.initialize(_name, "RMS", hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cMeanTotal_depth.initialize(_name, "Mean", hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
-	_cRMSTotal_depth.initialize(_name, "RMS", hcaldqm::hashfunctions::fdepth, 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
+  _cMeanTotal_Subdet.initialize(_name,
+                                "Mean",
+                                hcaldqm::hashfunctions::fSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+  _cRMSTotal_Subdet.initialize(_name,
+                               "RMS",
+                               hcaldqm::hashfunctions::fSubdet,
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                               0);
+  _cMeanTotal_depth.initialize(_name,
+                               "Mean",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                               0);
+  _cRMSTotal_depth.initialize(_name,
+                              "RMS",
+                              hcaldqm::hashfunctions::fdepth,
+                              new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                              new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                              0);
 
-	_cMeanDBRef1LS_Subdet.initialize(_name, "MeanDBRef1LS", hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cRMSDBRef1LS_Subdet.initialize(_name, "RMSDBRef1LS", hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cMeanDBRef1LS_depth.initialize(_name, "MeanDBRef1LS", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),0);
-	_cRMSDBRef1LS_depth.initialize(_name, "RMSDBRef1LS", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),0);
-	
-	_cMeanDBRefTotal_Subdet.initialize(_name, "MeanDBRef", hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cRMSDBRefTotal_Subdet.initialize(_name, "RMSDBRef", hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cMeanDBRefTotal_depth.initialize(_name, "MeanDBRef", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),0);
-	_cRMSDBRefTotal_depth.initialize(_name, "RMSDBRef", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),0);
+  _cMeanDBRef1LS_Subdet.initialize(_name,
+                                   "MeanDBRef1LS",
+                                   hcaldqm::hashfunctions::fSubdet,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                   0);
+  _cRMSDBRef1LS_Subdet.initialize(_name,
+                                  "RMSDBRef1LS",
+                                  hcaldqm::hashfunctions::fSubdet,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                  0);
+  _cMeanDBRef1LS_depth.initialize(_name,
+                                  "MeanDBRef1LS",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                  0);
+  _cRMSDBRef1LS_depth.initialize(_name,
+                                 "RMSDBRef1LS",
+                                 hcaldqm::hashfunctions::fdepth,
+                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                 0);
 
-	_cMissingvsLS_Subdet.initialize(_name, "MissingvsLS", 
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cOccupancyvsLS_Subdet.initialize(_name, "OccupancyvsLS", 
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cOccupancyEAvsLS_Subdet.initialize(_name, "OccupancyEAvsLS", 
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-	_cNBadMeanvsLS_Subdet.initialize(_name, "NBadMeanvsLS", 
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cNBadRMSvsLS_Subdet.initialize(_name, "NBadRMSvsLS", 
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cMeanDBRefTotal_Subdet.initialize(_name,
+                                     "MeanDBRef",
+                                     hcaldqm::hashfunctions::fSubdet,
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                     0);
+  _cRMSDBRefTotal_Subdet.initialize(_name,
+                                    "RMSDBRef",
+                                    hcaldqm::hashfunctions::fSubdet,
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                    0);
+  _cMeanDBRefTotal_depth.initialize(_name,
+                                    "MeanDBRef",
+                                    hcaldqm::hashfunctions::fdepth,
+                                    new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                    new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                    0);
+  _cRMSDBRefTotal_depth.initialize(_name,
+                                   "RMSDBRef",
+                                   hcaldqm::hashfunctions::fdepth,
+                                   new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                   new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fAroundZero),
+                                   0);
 
-	_cMissing1LS_depth.initialize(_name, "Missing1LS", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cMeanBad1LS_depth.initialize(_name, "MeanBad1LS", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cRMSBad1LS_depth.initialize(_name, "RMSBad1LS", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	
-	_cMissingTotal_depth.initialize(_name, "Missing", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cMeanBadTotal_depth.initialize(_name, "MeanBad", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cRMSBadTotal_depth.initialize(_name, "RMSBad", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cMissingvsLS_Subdet.initialize(_name,
+                                  "MissingvsLS",
+                                  hcaldqm::hashfunctions::fSubdet,
+                                  new hcaldqm::quantity::LumiSection(_maxLS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+  _cOccupancyvsLS_Subdet.initialize(_name,
+                                    "OccupancyvsLS",
+                                    hcaldqm::hashfunctions::fSubdet,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+  _cOccupancyEAvsLS_Subdet.initialize(_name,
+                                      "OccupancyEAvsLS",
+                                      hcaldqm::hashfunctions::fSubdet,
+                                      new hcaldqm::quantity::LumiSection(_maxLS),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                      0);
+  _cNBadMeanvsLS_Subdet.initialize(_name,
+                                   "NBadMeanvsLS",
+                                   hcaldqm::hashfunctions::fSubdet,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+  _cNBadRMSvsLS_Subdet.initialize(_name,
+                                  "NBadRMSvsLS",
+                                  hcaldqm::hashfunctions::fSubdet,
+                                  new hcaldqm::quantity::LumiSection(_maxLS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
 
-	_cADC_SubdetPM.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+  _cMissing1LS_depth.initialize(_name,
+                                "Missing1LS",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+  _cMeanBad1LS_depth.initialize(_name,
+                                "MeanBad1LS",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
+  _cRMSBad1LS_depth.initialize(_name,
+                               "RMSBad1LS",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
 
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin();
-			it!=vFEDsVME.end(); ++it)
-			_vhashFEDs.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-				FIBER_VME_MIN, SPIGOT_MIN, (*it)-FED_VME_MIN).rawId());
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin();
-			it!=vFEDsuTCA.end(); ++it)
-	    {
-	        std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
-			_vhashFEDs.push_back(HcalElectronicsId(
-				cspair.first, cspair.second, FIBER_uTCA_MIN1,
-				FIBERCH_MIN, false).rawId());
-	    }
-		_xNChs.initialize(hcaldqm::hashfunctions::fFED);
-		_xNMsn1LS.initialize(hcaldqm::hashfunctions::fFED);
-		_xNBadMean1LS.initialize(hcaldqm::hashfunctions::fFED);
-		_xNBadRMS1LS.initialize(hcaldqm::hashfunctions::fFED);
-		_cMeanTotal_FEDVME.initialize(_name, "Mean", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
-		_cMeanTotal_FEDuTCA.initialize(_name, "Mean", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),0);
-		_cRMSTotal_FEDVME.initialize(_name, "RMS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cRMSTotal_FEDuTCA.initialize(_name, "RMS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cMeanDBRef1LS_FEDVME.initialize(_name, "MeanDBRef1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cMeanDBRef1LS_FEDuTCA.initialize(_name, "MeanDBRef1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cRMSDBRef1LS_FEDVME.initialize(_name, "RMSDBRef1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cRMSDBRef1LS_FEDuTCA.initialize(_name, "RMSDBRef1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cMeanDBRefTotal_FEDVME.initialize(_name, "MeanDBRef", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cMeanDBRefTotal_FEDuTCA.initialize(_name, "MeanDBRef", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cRMSDBRefTotal_FEDVME.initialize(_name, "RMSDBRef", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cRMSDBRefTotal_FEDuTCA.initialize(_name, "RMSDBRef", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),0);
-		_cMissing1LS_FEDVME.initialize(_name, "Missing1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMissing1LS_FEDuTCA.initialize(_name, "Missing1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMeanBad1LS_FEDVME.initialize(_name, "MeanBad1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMeanBad1LS_FEDuTCA.initialize(_name, "MeanBad1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cRMSBad1LS_FEDVME.initialize(_name, "RMSBad1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cRMSBad1LS_FEDuTCA.initialize(_name, "RMSBad1LS", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMissingTotal_FEDVME.initialize(_name, "Missing", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMissingTotal_FEDuTCA.initialize(_name, "Missing", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMeanBadTotal_FEDVME.initialize(_name, "MeanBad", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMeanBadTotal_FEDuTCA.initialize(_name, "MeanBad", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cRMSBadTotal_FEDVME.initialize(_name, "RMSBad", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cRMSBadTotal_FEDuTCA.initialize(_name, "RMSBad", hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::FlagQuantity(_vflags),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-		_cSummaryvsLS.initialize(_name, "SummaryvsLS",
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::FEDQuantity(vFEDs),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-	}
+  _cMissingTotal_depth.initialize(_name,
+                                  "Missing",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+  _cMeanBadTotal_depth.initialize(_name,
+                                  "MeanBad",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+  _cRMSBadTotal_depth.initialize(_name,
+                                 "RMSBad",
+                                 hcaldqm::hashfunctions::fdepth,
+                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                 0);
 
-	//	book plots
-	_cADC_SubdetPM.book(ib, _emap, _subsystem);
-	_cMean1LS_Subdet.book(ib, _emap, _subsystem);
-	_cRMS1LS_Subdet.book(ib, _emap, _subsystem);
-	_cMean1LS_depth.book(ib, _emap, _subsystem);
-	_cRMS1LS_depth.book(ib, _emap, _subsystem);
-	_cMeanDBRef1LS_Subdet.book(ib, _emap, _subsystem);
-	_cRMSDBRef1LS_Subdet.book(ib, _emap, _subsystem);
-	_cMeanDBRef1LS_depth.book(ib, _emap, _subsystem);
-	_cRMSDBRef1LS_depth.book(ib, _emap, _subsystem);
-	_cMissing1LS_depth.book(ib, _emap, _subsystem);
-	_cMeanBad1LS_depth.book(ib, _emap, _subsystem);
-	_cRMSBad1LS_depth.book(ib, _emap, _subsystem);
-	
-	_cMeanTotal_Subdet.book(ib, _emap, _subsystem);
-	_cRMSTotal_Subdet.book(ib, _emap, _subsystem);
-	_cMeanTotal_depth.book(ib, _emap, _subsystem);
-	_cRMSTotal_depth.book(ib, _emap, _subsystem);
-	_cMeanDBRefTotal_Subdet.book(ib, _emap, _subsystem);
-	_cRMSDBRefTotal_Subdet.book(ib, _emap, _subsystem);
-	_cMeanDBRefTotal_depth.book(ib, _emap, _subsystem);
-	_cRMSDBRefTotal_depth.book(ib, _emap, _subsystem);
-	_cMissingTotal_depth.book(ib, _emap, _subsystem);
-	_cMeanBadTotal_depth.book(ib, _emap, _subsystem);
-	_cRMSBadTotal_depth.book(ib, _emap, _subsystem);
+  _cADC_SubdetPM.initialize(_name,
+                            "ADC",
+                            hcaldqm::hashfunctions::fSubdetPM,
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_256),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                            0);
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMean1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMean1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cRMS1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cRMS1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMeanDBRef1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMeanDBRef1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cRMSDBRef1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cRMSDBRef1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMissing1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMissing1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cRMSBad1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cRMSBad1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMeanBad1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMeanBad1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
+      _vhashFEDs.push_back(
+          HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
+    _xNChs.initialize(hcaldqm::hashfunctions::fFED);
+    _xNMsn1LS.initialize(hcaldqm::hashfunctions::fFED);
+    _xNBadMean1LS.initialize(hcaldqm::hashfunctions::fFED);
+    _xNBadRMS1LS.initialize(hcaldqm::hashfunctions::fFED);
+    _cMeanTotal_FEDVME.initialize(_name,
+                                  "Mean",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                                  0);
+    _cMeanTotal_FEDuTCA.initialize(_name,
+                                   "Mean",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_15),
+                                   0);
+    _cRMSTotal_FEDVME.initialize(_name,
+                                 "RMS",
+                                 hcaldqm::hashfunctions::fFED,
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                 0);
+    _cRMSTotal_FEDuTCA.initialize(_name,
+                                  "RMS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                  0);
+    _cMeanDBRef1LS_FEDVME.initialize(_name,
+                                     "MeanDBRef1LS",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                     0);
+    _cMeanDBRef1LS_FEDuTCA.initialize(_name,
+                                      "MeanDBRef1LS",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                      0);
+    _cRMSDBRef1LS_FEDVME.initialize(_name,
+                                    "RMSDBRef1LS",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                    0);
+    _cRMSDBRef1LS_FEDuTCA.initialize(_name,
+                                     "RMSDBRef1LS",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                     0);
+    _cMeanDBRefTotal_FEDVME.initialize(_name,
+                                       "MeanDBRef",
+                                       hcaldqm::hashfunctions::fFED,
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                       0);
+    _cMeanDBRefTotal_FEDuTCA.initialize(
+        _name,
+        "MeanDBRef",
+        hcaldqm::hashfunctions::fFED,
+        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+        0);
+    _cRMSDBRefTotal_FEDVME.initialize(_name,
+                                      "RMSDBRef",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                      0);
+    _cRMSDBRefTotal_FEDuTCA.initialize(_name,
+                                       "RMSDBRef",
+                                       hcaldqm::hashfunctions::fFED,
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_5),
+                                       0);
+    _cMissing1LS_FEDVME.initialize(_name,
+                                   "Missing1LS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cMissing1LS_FEDuTCA.initialize(_name,
+                                    "Missing1LS",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+    _cMeanBad1LS_FEDVME.initialize(_name,
+                                   "MeanBad1LS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cMeanBad1LS_FEDuTCA.initialize(_name,
+                                    "MeanBad1LS",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+    _cRMSBad1LS_FEDVME.initialize(_name,
+                                  "RMSBad1LS",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+    _cRMSBad1LS_FEDuTCA.initialize(_name,
+                                   "RMSBad1LS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cMissingTotal_FEDVME.initialize(_name,
+                                     "Missing",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+    _cMissingTotal_FEDuTCA.initialize(_name,
+                                      "Missing",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cMeanBadTotal_FEDVME.initialize(_name,
+                                     "MeanBad",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+    _cMeanBadTotal_FEDuTCA.initialize(_name,
+                                      "MeanBad",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cRMSBadTotal_FEDVME.initialize(_name,
+                                    "RMSBad",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+    _cRMSBadTotal_FEDuTCA.initialize(_name,
+                                     "RMSBad",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+    _cSummaryvsLS_FED.initialize(_name,
+                                 "SummaryvsLS",
+                                 hcaldqm::hashfunctions::fFED,
+                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                 new hcaldqm::quantity::FlagQuantity(_vflags),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                                 0);
+    _cSummaryvsLS.initialize(_name,
+                             "SummaryvsLS",
+                             new hcaldqm::quantity::LumiSection(_maxLS),
+                             new hcaldqm::quantity::FEDQuantity(vFEDs),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                             0);
+  }
 
-		_cMeanTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMeanTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cRMSTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cRMSTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMeanDBRefTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMeanDBRefTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cRMSDBRefTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cRMSDBRefTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMissingTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMissingTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cRMSBadTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cRMSBadTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMeanBadTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMeanBadTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
+  //	book plots
+  _cADC_SubdetPM.book(ib, _emap, _subsystem);
+  _cMean1LS_Subdet.book(ib, _emap, _subsystem);
+  _cRMS1LS_Subdet.book(ib, _emap, _subsystem);
+  _cMean1LS_depth.book(ib, _emap, _subsystem);
+  _cRMS1LS_depth.book(ib, _emap, _subsystem);
+  _cMeanDBRef1LS_Subdet.book(ib, _emap, _subsystem);
+  _cRMSDBRef1LS_Subdet.book(ib, _emap, _subsystem);
+  _cMeanDBRef1LS_depth.book(ib, _emap, _subsystem);
+  _cRMSDBRef1LS_depth.book(ib, _emap, _subsystem);
+  _cMissing1LS_depth.book(ib, _emap, _subsystem);
+  _cMeanBad1LS_depth.book(ib, _emap, _subsystem);
+  _cRMSBad1LS_depth.book(ib, _emap, _subsystem);
 
-	_cMissingvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cOccupancyEAvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cNBadMeanvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cNBadRMSvsLS_Subdet.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		_cSummaryvsLS.book(ib, _subsystem);
-	}
+  _cMeanTotal_Subdet.book(ib, _emap, _subsystem);
+  _cRMSTotal_Subdet.book(ib, _emap, _subsystem);
+  _cMeanTotal_depth.book(ib, _emap, _subsystem);
+  _cRMSTotal_depth.book(ib, _emap, _subsystem);
+  _cMeanDBRefTotal_Subdet.book(ib, _emap, _subsystem);
+  _cRMSDBRefTotal_Subdet.book(ib, _emap, _subsystem);
+  _cMeanDBRefTotal_depth.book(ib, _emap, _subsystem);
+  _cRMSDBRefTotal_depth.book(ib, _emap, _subsystem);
+  _cMissingTotal_depth.book(ib, _emap, _subsystem);
+  _cMeanBadTotal_depth.book(ib, _emap, _subsystem);
+  _cRMSBadTotal_depth.book(ib, _emap, _subsystem);
 
-	//	book compact containers
-	_xPedSum1LS.book(_emap);
-	_xPedSum21LS.book(_emap);
-	_xPedEntries1LS.book(_emap);
-	_xPedSumTotal.book(_emap);
-	_xPedSum2Total.book(_emap);
-	_xPedEntriesTotal.book(_emap);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMean1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMean1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cRMS1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cRMS1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMeanDBRef1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMeanDBRef1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cRMSDBRef1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cRMSDBRef1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMissing1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMissing1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cRMSBad1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cRMSBad1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMeanBad1LS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMeanBad1LS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+
+    _cMeanTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMeanTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cRMSTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cRMSTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMeanDBRefTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMeanDBRefTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cRMSDBRefTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cRMSDBRefTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMissingTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMissingTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cRMSBadTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cRMSBadTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMeanBadTotal_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMeanBadTotal_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+
+  _cMissingvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cOccupancyEAvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cNBadMeanvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cNBadRMSvsLS_Subdet.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    _cSummaryvsLS.book(ib, _subsystem);
+  }
+
+  //	book compact containers
+  _xPedSum1LS.book(_emap);
+  _xPedSum21LS.book(_emap);
+  _xPedEntries1LS.book(_emap);
+  _xPedSumTotal.book(_emap);
+  _xPedSum2Total.book(_emap);
+  _xPedEntriesTotal.book(_emap);
 
 #ifndef HIDE_PEDESTAL_CONDITIONS
-	_xPedRefMean.book(_emap);
-	_xPedRefRMS.book(_emap);
+  _xPedRefMean.book(_emap);
+  _xPedRefRMS.book(_emap);
 #endif
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_xNChs.book(_emap);
-		_xNMsn1LS.book(_emap);
-		_xNBadMean1LS.book(_emap);
-		_xNBadRMS1LS.book(_emap);
-	}
+  if (_ptype != fOffline) {  // hidefed2crate
+    _xNChs.book(_emap);
+    _xNMsn1LS.book(_emap);
+    _xNBadMean1LS.book(_emap);
+    _xNBadRMS1LS.book(_emap);
+  }
 
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 
-	//	load conditions pedestals
-	std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
-	for (std::vector<HcalGenericDetId>::const_iterator it=dids.begin();
-		it!=dids.end(); ++it)
-	{
-		//	skip if calib or whatever
-		if (!it->isHcalDetId())
-			continue;
-		//	skip Crate 38
-		if (_filter_C38.filter(HcalElectronicsId(_ehashmap.lookup(*it))))
-			continue;
+  //	load conditions pedestals
+  std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
+  for (std::vector<HcalGenericDetId>::const_iterator it = dids.begin(); it != dids.end(); ++it) {
+    //	skip if calib or whatever
+    if (!it->isHcalDetId())
+      continue;
+    //	skip Crate 38
+    if (_filter_C38.filter(HcalElectronicsId(_ehashmap.lookup(*it))))
+      continue;
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		HcalDetId did = HcalDetId(it->rawId());
+    HcalDetId did = HcalDetId(it->rawId());
 
-		HcalPedestal const* peds = dbs->getPedestal(did);
-		float const *means = peds->getValues();
-		float const *rmss = peds->getWidths();
-		double msum=0; double rsum=0;
-		for (uint32_t i=0; i<4; i++)
-		{msum+=means[i]; rsum+=rmss[i];}
-		msum/=4; rsum/=4;
-		_xPedRefMean.set(did, msum);
-		_xPedRefRMS.set(did, rsum);
+    HcalPedestal const* peds = dbs->getPedestal(did);
+    float const* means = peds->getValues();
+    float const* rmss = peds->getWidths();
+    double msum = 0;
+    double rsum = 0;
+    for (uint32_t i = 0; i < 4; i++) {
+      msum += means[i];
+      rsum += rmss[i];
+    }
+    msum /= 4;
+    rsum /= 4;
+    _xPedRefMean.set(did, msum);
+    _xPedRefRMS.set(did, rsum);
 #endif
-	}
+  }
 }
 
-/* virtual */ void PedestalTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void PedestalTask::_resetMonitors(hcaldqm::UpdateFreq uf) {
+  DQTask::_resetMonitors(uf);
 
-	switch(uf)
-	{
-		case hcaldqm::f50LS:
-			_cADC_SubdetPM.reset();
-			break;
-		default:
-			break;
-	}
+  switch (uf) {
+    case hcaldqm::f50LS:
+      _cADC_SubdetPM.reset();
+      break;
+    default:
+      break;
+  }
 }
 
-/* virtual */ void PedestalTask::_dump()
-{
-	//	reset what's needed
-	
-	//	Mean/RMS actual values
-	_cMean1LS_Subdet.reset();
-	_cRMS1LS_Subdet.reset();
-	_cMean1LS_depth.reset();
-	_cRMS1LS_depth.reset();
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMean1LS_FEDVME.reset();
-		_cMean1LS_FEDuTCA.reset();
-		_cRMS1LS_FEDVME.reset();
-		_cRMS1LS_FEDuTCA.reset();
-	}
-	
-	_cMeanTotal_Subdet.reset();
-	_cRMSTotal_Subdet.reset();
-	_cMeanTotal_depth.reset();
-	_cRMSTotal_depth.reset();
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMeanTotal_FEDVME.reset();
-		_cMeanTotal_FEDuTCA.reset();
-		_cRMSTotal_FEDVME.reset();
-		_cRMSTotal_FEDuTCA.reset();
-	}
-	
+/* virtual */ void PedestalTask::_dump() {
+  //	reset what's needed
 
-	//	DB Conditions Comparison
-	_cMeanDBRef1LS_Subdet.reset();
-	_cMeanDBRef1LS_depth.reset();
-	_cRMSDBRef1LS_Subdet.reset();
-	_cRMSDBRef1LS_depth.reset();
-	
-	_cMeanDBRefTotal_Subdet.reset();
-	_cMeanDBRefTotal_depth.reset();
-	_cRMSDBRefTotal_Subdet.reset();
-	_cRMSDBRefTotal_depth.reset();
+  //	Mean/RMS actual values
+  _cMean1LS_Subdet.reset();
+  _cRMS1LS_Subdet.reset();
+  _cMean1LS_depth.reset();
+  _cRMS1LS_depth.reset();
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMean1LS_FEDVME.reset();
+    _cMean1LS_FEDuTCA.reset();
+    _cRMS1LS_FEDVME.reset();
+    _cRMS1LS_FEDuTCA.reset();
+  }
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMeanDBRef1LS_FEDVME.reset();
-		_cMeanDBRef1LS_FEDuTCA.reset();
-		_cRMSDBRef1LS_FEDVME.reset();
-		_cRMSDBRef1LS_FEDuTCA.reset();
-		
-		_cMeanDBRefTotal_FEDVME.reset();
-		_cMeanDBRefTotal_FEDuTCA.reset();
-		_cRMSDBRefTotal_FEDVME.reset();
-		_cRMSDBRefTotal_FEDuTCA.reset();
-	}
+  _cMeanTotal_Subdet.reset();
+  _cRMSTotal_Subdet.reset();
+  _cMeanTotal_depth.reset();
+  _cRMSTotal_depth.reset();
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMeanTotal_FEDVME.reset();
+    _cMeanTotal_FEDuTCA.reset();
+    _cRMSTotal_FEDVME.reset();
+    _cRMSTotal_FEDuTCA.reset();
+  }
 
-	//	missing channels
-	_cMissing1LS_depth.reset();
-	_cMeanBad1LS_depth.reset();
-	_cRMSBad1LS_depth.reset();
-	
-	_cMissingTotal_depth.reset();
-	_cMeanBadTotal_depth.reset();
-	_cRMSBadTotal_depth.reset();
+  //	DB Conditions Comparison
+  _cMeanDBRef1LS_Subdet.reset();
+  _cMeanDBRef1LS_depth.reset();
+  _cRMSDBRef1LS_Subdet.reset();
+  _cRMSDBRef1LS_depth.reset();
 
-	//	Missing or Bad
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMissing1LS_FEDVME.reset();
-		_cMissing1LS_FEDuTCA.reset();
-		_cMeanBad1LS_FEDVME.reset();
-		_cMeanBad1LS_FEDuTCA.reset();
-		_cRMSBad1LS_FEDVME.reset();
-		_cRMSBad1LS_FEDuTCA.reset();
+  _cMeanDBRefTotal_Subdet.reset();
+  _cMeanDBRefTotal_depth.reset();
+  _cRMSDBRefTotal_Subdet.reset();
+  _cRMSDBRefTotal_depth.reset();
 
-		_cMissingTotal_FEDVME.reset();
-		_cMissingTotal_FEDuTCA.reset();
-		_cMeanBadTotal_FEDVME.reset();
-		_cMeanBadTotal_FEDuTCA.reset();
-		_cRMSBadTotal_FEDVME.reset();
-		_cRMSBadTotal_FEDuTCA.reset();
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMeanDBRef1LS_FEDVME.reset();
+    _cMeanDBRef1LS_FEDuTCA.reset();
+    _cRMSDBRef1LS_FEDVME.reset();
+    _cRMSDBRef1LS_FEDuTCA.reset();
 
-		//	reset some XXX containers
-		_xNChs.reset();
-		_xNMsn1LS.reset();
-		_xNBadMean1LS.reset(); _xNBadRMS1LS.reset();
-	}
-	// - ITERATE OVER ALL TEH CHANNELS
-	// - FIND THE ONES THAT ARE MISSING
-	// - FIND THE ONES WITH BAD PEDESTAL MEANs
-	// - FIND THE ONES WITH BAD PEDESTAL RMSs
-	std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
-	for (std::vector<HcalGenericDetId>::const_iterator it=dids.begin();
-		it!=dids.end(); ++it)
-	{
-		if (!it->isHcalDetId())
-			continue;
-		HcalElectronicsId eid(_ehashmap.lookup(*it));
-		if (_filter_C38.filter(eid))
-			continue;
+    _cMeanDBRefTotal_FEDVME.reset();
+    _cMeanDBRefTotal_FEDuTCA.reset();
+    _cRMSDBRefTotal_FEDVME.reset();
+    _cRMSDBRefTotal_FEDuTCA.reset();
+  }
 
-		//	filter out channels with bad quality
-		if (_xQuality.exists(HcalDetId(*it)))
-		{
-			HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
-			if (
-				cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-				continue;
-		}
+  //	missing channels
+  _cMissing1LS_depth.reset();
+  _cMeanBad1LS_depth.reset();
+  _cRMSBad1LS_depth.reset();
 
-		HcalDetId did = HcalDetId(it->rawId());
-		double sum1LS = _xPedSum1LS.get(did); 
+  _cMissingTotal_depth.reset();
+  _cMeanBadTotal_depth.reset();
+  _cRMSBadTotal_depth.reset();
+
+  //	Missing or Bad
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMissing1LS_FEDVME.reset();
+    _cMissing1LS_FEDuTCA.reset();
+    _cMeanBad1LS_FEDVME.reset();
+    _cMeanBad1LS_FEDuTCA.reset();
+    _cRMSBad1LS_FEDVME.reset();
+    _cRMSBad1LS_FEDuTCA.reset();
+
+    _cMissingTotal_FEDVME.reset();
+    _cMissingTotal_FEDuTCA.reset();
+    _cMeanBadTotal_FEDVME.reset();
+    _cMeanBadTotal_FEDuTCA.reset();
+    _cRMSBadTotal_FEDVME.reset();
+    _cRMSBadTotal_FEDuTCA.reset();
+
+    //	reset some XXX containers
+    _xNChs.reset();
+    _xNMsn1LS.reset();
+    _xNBadMean1LS.reset();
+    _xNBadRMS1LS.reset();
+  }
+  // - ITERATE OVER ALL TEH CHANNELS
+  // - FIND THE ONES THAT ARE MISSING
+  // - FIND THE ONES WITH BAD PEDESTAL MEANs
+  // - FIND THE ONES WITH BAD PEDESTAL RMSs
+  std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
+  for (std::vector<HcalGenericDetId>::const_iterator it = dids.begin(); it != dids.end(); ++it) {
+    if (!it->isHcalDetId())
+      continue;
+    HcalElectronicsId eid(_ehashmap.lookup(*it));
+    if (_filter_C38.filter(eid))
+      continue;
+
+    //	filter out channels with bad quality
+    if (_xQuality.exists(HcalDetId(*it))) {
+      HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
+
+    HcalDetId did = HcalDetId(it->rawId());
+    double sum1LS = _xPedSum1LS.get(did);
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		double refm = _xPedRefMean.get(did);
+    double refm = _xPedRefMean.get(did);
 #endif
-		double sum21LS = _xPedSum21LS.get(did); 
+    double sum21LS = _xPedSum21LS.get(did);
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		double refr = _xPedRefRMS.get(did);
+    double refr = _xPedRefRMS.get(did);
 #endif
-		double n1LS = _xPedEntries1LS.get(did);
-		
-		double sumTotal = _xPedSumTotal.get(did);
-		double sum2Total = _xPedSum2Total.get(did);
-		double nTotal = _xPedEntriesTotal.get(did);
+    double n1LS = _xPedEntries1LS.get(did);
 
-		if (_ptype != fOffline) { // hidefed2crate
-			_xNChs.get(eid)++;
-		}
-		// IF A CHANNEL IS MISSING FOR THIS LS
-		if (n1LS==0)
-		{
-			_cMissing1LS_depth.fill(did);
-			_cMissingvsLS_Subdet.fill(did, _currentLS);
-			if (_ptype != fOffline) { // hidefed2crate
-				eid.isVMEid()?_cMissing1LS_FEDVME.fill(eid):
-					_cMissing1LS_FEDuTCA.fill(eid);
-				_xNMsn1LS.get(eid)++;
-			}
-			//	ALSO CHECK
-			//	IF A CHANNEL HAS BEEN MISSING FOR ALL LSs SO FAR
-			if (nTotal==0)
-			{
-				_cMissingTotal_depth.fill(did);
-				if (_ptype != fOffline) { // hidefed2crate
-					eid.isVMEid()?_cMissingTotal_FEDVME.fill(eid):
-					_cMissingTotal_FEDuTCA.fill(eid);
-				}
-			}
-			continue;
-		}
+    double sumTotal = _xPedSumTotal.get(did);
+    double sum2Total = _xPedSum2Total.get(did);
+    double nTotal = _xPedEntriesTotal.get(did);
 
-		//	if not missing, fill the occupancy...
-		_cOccupancyvsLS_Subdet.fill(did, _currentLS);
+    if (_ptype != fOffline) {  // hidefed2crate
+      _xNChs.get(eid)++;
+    }
+    // IF A CHANNEL IS MISSING FOR THIS LS
+    if (n1LS == 0) {
+      _cMissing1LS_depth.fill(did);
+      _cMissingvsLS_Subdet.fill(did, _currentLS);
+      if (_ptype != fOffline) {  // hidefed2crate
+        eid.isVMEid() ? _cMissing1LS_FEDVME.fill(eid) : _cMissing1LS_FEDuTCA.fill(eid);
+        _xNMsn1LS.get(eid)++;
+      }
+      //	ALSO CHECK
+      //	IF A CHANNEL HAS BEEN MISSING FOR ALL LSs SO FAR
+      if (nTotal == 0) {
+        _cMissingTotal_depth.fill(did);
+        if (_ptype != fOffline) {  // hidefed2crate
+          eid.isVMEid() ? _cMissingTotal_FEDVME.fill(eid) : _cMissingTotal_FEDuTCA.fill(eid);
+        }
+      }
+      continue;
+    }
 
-		//	compute the means and diffs for this LS
-		sum1LS/=n1LS; double rms1LS = sqrt(sum21LS/n1LS-sum1LS*sum1LS);
+    //	if not missing, fill the occupancy...
+    _cOccupancyvsLS_Subdet.fill(did, _currentLS);
+
+    //	compute the means and diffs for this LS
+    sum1LS /= n1LS;
+    double rms1LS = sqrt(sum21LS / n1LS - sum1LS * sum1LS);
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		double diffm1LS = sum1LS-refm;
-		double diffr1LS = rms1LS - refr;
+    double diffm1LS = sum1LS - refm;
+    double diffr1LS = rms1LS - refr;
 #endif
-		//	compute the means and diffs for the whole Run
-		sumTotal/=nTotal; 
-		double rmsTotal = sqrt(sum2Total/nTotal-sumTotal*sumTotal);
+    //	compute the means and diffs for the whole Run
+    sumTotal /= nTotal;
+    double rmsTotal = sqrt(sum2Total / nTotal - sumTotal * sumTotal);
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		double diffmTotal = sumTotal-refm;
-		double diffrTotal = rmsTotal - refr;
+    double diffmTotal = sumTotal - refm;
+    double diffrTotal = rmsTotal - refr;
 #endif
-		//	FILL ACTUAL MEANs AND RMSs FOR THIS LS
-		_cMean1LS_Subdet.fill(did, sum1LS);
-		_cMean1LS_depth.fill(did, sum1LS);
-		_cRMS1LS_Subdet.fill(did, rms1LS);
-		_cRMS1LS_depth.fill(did, rms1LS);
+    //	FILL ACTUAL MEANs AND RMSs FOR THIS LS
+    _cMean1LS_Subdet.fill(did, sum1LS);
+    _cMean1LS_depth.fill(did, sum1LS);
+    _cRMS1LS_Subdet.fill(did, rms1LS);
+    _cRMS1LS_depth.fill(did, rms1LS);
 
-		//	FILL THE DIFFERENCES FOR THIS LS
+    //	FILL THE DIFFERENCES FOR THIS LS
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		_cMeanDBRef1LS_Subdet.fill(did, diffm1LS);
-		_cMeanDBRef1LS_depth.fill(did, diffm1LS);
-		_cRMSDBRef1LS_Subdet.fill(did, diffr1LS);
-		_cRMSDBRef1LS_depth.fill(did, diffr1LS);
+    _cMeanDBRef1LS_Subdet.fill(did, diffm1LS);
+    _cMeanDBRef1LS_depth.fill(did, diffm1LS);
+    _cRMSDBRef1LS_Subdet.fill(did, diffr1LS);
+    _cRMSDBRef1LS_depth.fill(did, diffr1LS);
 #endif
-			//	FILL ACTUAL MEANs AND RMSs FOR THE WHOLE RUN
-		_cMeanTotal_Subdet.fill(did, sumTotal);
-		_cMeanTotal_depth.fill(did, sumTotal);
-		_cRMSTotal_Subdet.fill(did, rmsTotal);
-		_cRMSTotal_depth.fill(did, rmsTotal);
+    //	FILL ACTUAL MEANs AND RMSs FOR THE WHOLE RUN
+    _cMeanTotal_Subdet.fill(did, sumTotal);
+    _cMeanTotal_depth.fill(did, sumTotal);
+    _cRMSTotal_Subdet.fill(did, rmsTotal);
+    _cRMSTotal_depth.fill(did, rmsTotal);
 
-		//	FILL THE DIFFERENCES FOR THE WHOLE RUN
+    //	FILL THE DIFFERENCES FOR THE WHOLE RUN
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		_cMeanDBRefTotal_Subdet.fill(did, diffmTotal);
-		_cMeanDBRefTotal_depth.fill(did, diffmTotal);
-		_cRMSDBRefTotal_Subdet.fill(did, diffrTotal);
-		_cRMSDBRefTotal_depth.fill(did, diffrTotal);
+    _cMeanDBRefTotal_Subdet.fill(did, diffmTotal);
+    _cMeanDBRefTotal_depth.fill(did, diffmTotal);
+    _cRMSDBRefTotal_Subdet.fill(did, diffrTotal);
+    _cRMSDBRefTotal_depth.fill(did, diffrTotal);
 #endif
-		//	FOR THIS LS
-		if (_ptype != fOffline) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cMean1LS_FEDVME.fill(eid, sum1LS);
-				_cRMS1LS_FEDVME.fill(eid, rms1LS);
-				_cMeanDBRef1LS_FEDVME.fill(eid, diffm1LS);
-				_cRMSDBRef1LS_FEDVME.fill(eid, diffr1LS);
-			}
-			else
-			{
-				_cMean1LS_FEDuTCA.fill(eid, sum1LS);
-				_cRMS1LS_FEDuTCA.fill(eid, rms1LS);
-				_cMeanDBRef1LS_FEDuTCA.fill(eid, diffm1LS);
-				_cRMSDBRef1LS_FEDuTCA.fill(eid, diffr1LS);
-			}
-			
-			//	FOR THE WHOLE RUN
-			if (eid.isVMEid())
-			{
-				_cMeanTotal_FEDVME.fill(eid, sumTotal);
-				_cRMSTotal_FEDVME.fill(eid, rmsTotal);
-				_cMeanDBRefTotal_FEDVME.fill(eid, diffmTotal);
-				_cRMSDBRefTotal_FEDVME.fill(eid, diffrTotal);
-			}
-			else
-			{
-				_cMeanTotal_FEDuTCA.fill(eid, sumTotal);
-				_cRMSTotal_FEDuTCA.fill(eid, rmsTotal);
-				_cMeanDBRefTotal_FEDuTCA.fill(eid, diffmTotal);
-				_cRMSDBRefTotal_FEDuTCA.fill(eid, diffrTotal);
-			}
-		}
+    //	FOR THIS LS
+    if (_ptype != fOffline) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cMean1LS_FEDVME.fill(eid, sum1LS);
+        _cRMS1LS_FEDVME.fill(eid, rms1LS);
+        _cMeanDBRef1LS_FEDVME.fill(eid, diffm1LS);
+        _cRMSDBRef1LS_FEDVME.fill(eid, diffr1LS);
+      } else {
+        _cMean1LS_FEDuTCA.fill(eid, sum1LS);
+        _cRMS1LS_FEDuTCA.fill(eid, rms1LS);
+        _cMeanDBRef1LS_FEDuTCA.fill(eid, diffm1LS);
+        _cRMSDBRef1LS_FEDuTCA.fill(eid, diffr1LS);
+      }
 
-		//	FOR THE CURRENT LS COMPARE MEANS AND RMSS
+      //	FOR THE WHOLE RUN
+      if (eid.isVMEid()) {
+        _cMeanTotal_FEDVME.fill(eid, sumTotal);
+        _cRMSTotal_FEDVME.fill(eid, rmsTotal);
+        _cMeanDBRefTotal_FEDVME.fill(eid, diffmTotal);
+        _cRMSDBRefTotal_FEDVME.fill(eid, diffrTotal);
+      } else {
+        _cMeanTotal_FEDuTCA.fill(eid, sumTotal);
+        _cRMSTotal_FEDuTCA.fill(eid, rmsTotal);
+        _cMeanDBRefTotal_FEDuTCA.fill(eid, diffmTotal);
+        _cRMSDBRefTotal_FEDuTCA.fill(eid, diffrTotal);
+      }
+    }
+
+    //	FOR THE CURRENT LS COMPARE MEANS AND RMSS
 #ifndef HIDE_PEDESTAL_CONDITIONS
-		if (fabs(diffm1LS)>_thresh_mean)
-		{
-			_cMeanBad1LS_depth.fill(did);
-			_cNBadMeanvsLS_Subdet.fill(did, _currentLS);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cMeanBad1LS_FEDVME.fill(eid);
-				else
-					_cMeanBad1LS_FEDuTCA.fill(eid);
-				_xNBadMean1LS.get(eid)++;
-			}
-		}
-		if (fabs(diffr1LS)>_thresh_rms)
-		{
-			_cRMSBad1LS_depth.fill(did);
-			_cNBadRMSvsLS_Subdet.fill(did, _currentLS);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cRMSBad1LS_FEDVME.fill(eid);
-				else 
-					_cRMSBad1LS_FEDuTCA.fill(eid);
-				_xNBadRMS1LS.get(eid)++;
-			}
-		}
+    if (fabs(diffm1LS) > _thresh_mean) {
+      _cMeanBad1LS_depth.fill(did);
+      _cNBadMeanvsLS_Subdet.fill(did, _currentLS);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cMeanBad1LS_FEDVME.fill(eid);
+        else
+          _cMeanBad1LS_FEDuTCA.fill(eid);
+        _xNBadMean1LS.get(eid)++;
+      }
+    }
+    if (fabs(diffr1LS) > _thresh_rms) {
+      _cRMSBad1LS_depth.fill(did);
+      _cNBadRMSvsLS_Subdet.fill(did, _currentLS);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cRMSBad1LS_FEDVME.fill(eid);
+        else
+          _cRMSBad1LS_FEDuTCA.fill(eid);
+        _xNBadRMS1LS.get(eid)++;
+      }
+    }
 
-		//	FOR THIS RUN 
-		if (fabs(diffmTotal)>_thresh_mean)
-		{
-			_cMeanBadTotal_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cMeanBadTotal_FEDVME.fill(eid);
-				else
-					_cMeanBadTotal_FEDuTCA.fill(eid);
-			}
-		}
-		if (fabs(diffrTotal)>_thresh_rms)
-		{
-			_cRMSBadTotal_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cRMSBadTotal_FEDVME.fill(eid);
-				else 
-					_cRMSBadTotal_FEDuTCA.fill(eid);
-			}
-		}
+    //	FOR THIS RUN
+    if (fabs(diffmTotal) > _thresh_mean) {
+      _cMeanBadTotal_depth.fill(did);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cMeanBadTotal_FEDVME.fill(eid);
+        else
+          _cMeanBadTotal_FEDuTCA.fill(eid);
+      }
+    }
+    if (fabs(diffrTotal) > _thresh_rms) {
+      _cRMSBadTotal_depth.fill(did);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cRMSBadTotal_FEDVME.fill(eid);
+        else
+          _cRMSBadTotal_FEDuTCA.fill(eid);
+      }
+    }
 #endif
+  }
 
-	}
+  //	SET THE FLAGS FOR THIS LS
+  if (_ptype != fOffline) {  // hidefed2crate
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      hcaldqm::flag::Flag fSum("PED");
+      HcalElectronicsId eid = HcalElectronicsId(*it);
 
-	//	SET THE FLAGS FOR THIS LS
-	if (_ptype != fOffline) { // hidefed2crate
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-			it!=_vhashFEDs.end(); ++it)
-		{
-			hcaldqm::flag::Flag fSum("PED");
-			HcalElectronicsId eid = HcalElectronicsId(*it);
+      std::vector<uint32_t>::const_iterator jt = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), (*it));
+      if (jt == _vcdaqEids.end()) {
+        //	not @cDAQ
+        for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
+          _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(hcaldqm::flag::fNCDAQ));
+        _cSummaryvsLS.setBinContent(eid, _currentLS, int(hcaldqm::flag::fNCDAQ));
+        continue;
+      }
 
-			std::vector<uint32_t>::const_iterator jt=
-				std::find(_vcdaqEids.begin(), _vcdaqEids.end(), (*it));
-			if (jt==_vcdaqEids.end())
-			{
-				//	not @cDAQ
-				for (uint32_t iflag=0; iflag<_vflags.size(); iflag++)
-					_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-						int(hcaldqm::flag::fNCDAQ));
-				_cSummaryvsLS.setBinContent(eid, _currentLS, int(hcaldqm::flag::fNCDAQ));
-				continue;
-			}
+      //	@cDAQ
+      if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHO(eid) || hcaldqm::utilities::isFEDHF(eid)) {
+        double frmissing = double(_xNMsn1LS.get(eid)) / double(_xNChs.get(eid));
+        double frbadm = _xNBadMean1LS.get(eid) / _xNChs.get(eid);
+        //double frbadr = _xNBadRMS1LS.get(eid)/_xNChs.get(eid);
 
-			//	@cDAQ
-			if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHO(eid) ||
-				hcaldqm::utilities::isFEDHF(eid))
-			{
-				double frmissing = double(_xNMsn1LS.get(eid))/
-					double(_xNChs.get(eid));
-				double frbadm = _xNBadMean1LS.get(eid)/_xNChs.get(eid);
-				//double frbadr = _xNBadRMS1LS.get(eid)/_xNChs.get(eid);
+        if (frmissing >= _thresh_missing_high)
+          _vflags[fMsn]._state = hcaldqm::flag::fBAD;
+        else if (frmissing >= _thresh_missing_low)
+          _vflags[fMsn]._state = hcaldqm::flag::fPROBLEMATIC;
+        else
+          _vflags[fMsn]._state = hcaldqm::flag::fGOOD;
+        if (frbadm >= _thresh_badm)
+          _vflags[fBadM]._state = hcaldqm::flag::fBAD;
+        else
+          _vflags[fBadM]._state = hcaldqm::flag::fGOOD;
+        // BadR removed May 9, 2018 - the pedestal RMS isn't stable enough to monitor right now.
+        //if (frbadr>=_thresh_badr)
+        //	_vflags[fBadR]._state = hcaldqm::flag::fBAD;
+        //else
+        //	_vflags[fBadR]._state = hcaldqm::flag::fGOOD;
+      }
 
-				if (frmissing>=_thresh_missing_high)
-					_vflags[fMsn]._state = hcaldqm::flag::fBAD;
-				else if (frmissing>=_thresh_missing_low)
-					_vflags[fMsn]._state = hcaldqm::flag::fPROBLEMATIC;
-				else
-					_vflags[fMsn]._state = hcaldqm::flag::fGOOD;
-				if (frbadm>=_thresh_badm)
-					_vflags[fBadM]._state = hcaldqm::flag::fBAD;
-				else
-					_vflags[fBadM]._state = hcaldqm::flag::fGOOD;
-				// BadR removed May 9, 2018 - the pedestal RMS isn't stable enough to monitor right now.
-				//if (frbadr>=_thresh_badr)
-				//	_vflags[fBadR]._state = hcaldqm::flag::fBAD;
-				//else
-				//	_vflags[fBadR]._state = hcaldqm::flag::fGOOD;
-			}
+      int iflag = 0;
+      for (std::vector<hcaldqm::flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
+        _cSummaryvsLS_FED.setBinContent(eid, _currentLS, iflag, int(ft->_state));
+        fSum += (*ft);
+        iflag++;
+        ft->reset();
+      }
+      _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
+    }
+  }
 
-			int iflag=0;
-			for (std::vector<hcaldqm::flag::Flag>::iterator ft=_vflags.begin();
-				ft!=_vflags.end(); ++ft)
-			{
-				_cSummaryvsLS_FED.setBinContent(eid, _currentLS, iflag,
-					int(ft->_state));
-				fSum+=(*ft);
-				iflag++;
-				ft->reset();
-			}
-			_cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
-		}
-	}
-
-	//	reset the pedestal containers instead of writting reset... func
-	_xPedSum1LS.reset(); _xPedSum21LS.reset(); _xPedEntries1LS.reset();
-	
+  //	reset the pedestal containers instead of writting reset... func
+  _xPedSum1LS.reset();
+  _xPedSum21LS.reset();
+  _xPedEntries1LS.reset();
 }
 
-/* virtual */ void PedestalTask::beginLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
+/* virtual */ void PedestalTask::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void PedestalTask::endRun(edm::Run const& r,
-	edm::EventSetup const&)
-{
-	if (_ptype==fLocal)
-	{
-		if (r.runAuxiliary().run()==1)
-			return;
-		else
-			this->_dump();
-	}
-	else if (_ptype==fOnline)
-		return;
+/* virtual */ void PedestalTask::endRun(edm::Run const& r, edm::EventSetup const&) {
+  if (_ptype == fLocal) {
+    if (r.runAuxiliary().run() == 1)
+      return;
+    else
+      this->_dump();
+  } else if (_ptype == fOnline)
+    return;
 }
 
-/* virtual */ void PedestalTask::endLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		return;
-	this->_dump();
+/* virtual */ void PedestalTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    return;
+  this->_dump();
 
-	DQTask::endLuminosityBlock(lb, es);
+  DQTask::endLuminosityBlock(lb, es);
 }
 
-/* virtual */ void PedestalTask::_process(edm::Event const& e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HBHEDigiCollection>		chbhe;
-	edm::Handle<HODigiCollection>		cho;
-	edm::Handle<QIE10DigiCollection>		chf;
-	edm::Handle<QIE11DigiCollection>		chep17;
+/* virtual */ void PedestalTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HBHEDigiCollection> chbhe;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<QIE10DigiCollection> chf;
+  edm::Handle<QIE11DigiCollection> chep17;
 
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available"
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection QIE10DigiCollection isn't available"
-			+ _tagHF.label() + " " + _tagHF.instance());
-	if (!e.getByToken(_tokHEP17, chep17))
-		_logger.dqmthrow("Collection QIE11DigiCollection isn't available"
-			+ _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokHEP17, chep17))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagHE.label() + " " + _tagHE.instance());
 
-	int nHB(0), nHE(0), nHO(0), nHF(0);
-	for (HBHEDigiCollection::const_iterator it=chbhe->begin();
-		it!=chbhe->end(); ++it)
-	{
-		const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-		HcalDetId did = digi.id();
-		int digiSizeToUse = floor(digi.size()/constants::CAPS_NUM)*
-			constants::CAPS_NUM-1;
-		did.subdet()==HcalBarrel ? nHB++ : nHE++;
+  int nHB(0), nHE(0), nHO(0), nHF(0);
+  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
+    HcalDetId did = digi.id();
+    int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
+    did.subdet() == HcalBarrel ? nHB++ : nHE++;
 
-		for (int i=0; i<digiSizeToUse; i++)
-		{
-			_cADC_SubdetPM.fill(did, it->sample(i).adc());
+    for (int i = 0; i < digiSizeToUse; i++) {
+      _cADC_SubdetPM.fill(did, it->sample(i).adc());
 
-			_xPedSum1LS.get(did)+=it->sample(i).adc();
-			_xPedSum21LS.get(did)+=it->sample(i).adc()*it->sample(i).adc();
-			_xPedEntries1LS.get(did)++;
-			
-			_xPedSumTotal.get(did)+=it->sample(i).adc();
-			_xPedSum2Total.get(did)+=it->sample(i).adc()*it->sample(i).adc();
-			_xPedEntriesTotal.get(did)++;
-		}
-	}
-	for (QIE11DigiCollection::const_iterator it=chep17->begin(); it!=chep17->end();
-		++it)
-	{
-		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
-		HcalDetId const& did = digi.detid();
-		// Require barrel or endcap. As of 2017, some calibration channels are ending up in this collection.
-		if ((did.subdet() != HcalEndcap) && (did.subdet() != HcalBarrel)) {
-			continue;
-		}
-		int digiSizeToUse = floor(digi.samples()/constants::CAPS_NUM)*
-			constants::CAPS_NUM-1;
-		did.subdet()==HcalBarrel ? nHB++ : nHE++;
+      _xPedSum1LS.get(did) += it->sample(i).adc();
+      _xPedSum21LS.get(did) += it->sample(i).adc() * it->sample(i).adc();
+      _xPedEntries1LS.get(did)++;
 
-		for (int i=0; i<digiSizeToUse; i++)
-		{
-			_cADC_SubdetPM.fill(did, digi[i].adc());
+      _xPedSumTotal.get(did) += it->sample(i).adc();
+      _xPedSum2Total.get(did) += it->sample(i).adc() * it->sample(i).adc();
+      _xPedEntriesTotal.get(did)++;
+    }
+  }
+  for (QIE11DigiCollection::const_iterator it = chep17->begin(); it != chep17->end(); ++it) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
+    HcalDetId const& did = digi.detid();
+    // Require barrel or endcap. As of 2017, some calibration channels are ending up in this collection.
+    if ((did.subdet() != HcalEndcap) && (did.subdet() != HcalBarrel)) {
+      continue;
+    }
+    int digiSizeToUse = floor(digi.samples() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
+    did.subdet() == HcalBarrel ? nHB++ : nHE++;
 
-			_xPedSum1LS.get(did)+=digi[i].adc();
-			_xPedSum21LS.get(did)+=digi[i].adc()*digi[i].adc();
-			_xPedEntries1LS.get(did)++;
-			
-			_xPedSumTotal.get(did)+=digi[i].adc();
-			_xPedSum2Total.get(did)+=digi[i].adc()*digi[i].adc();
-			_xPedEntriesTotal.get(did)++;
-		}
-	}
+    for (int i = 0; i < digiSizeToUse; i++) {
+      _cADC_SubdetPM.fill(did, digi[i].adc());
 
-	_cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1,1,1), 
-		_currentLS, nHB);
-	_cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalEndcap, 1,1,1), 
-		_currentLS, nHE);
+      _xPedSum1LS.get(did) += digi[i].adc();
+      _xPedSum21LS.get(did) += digi[i].adc() * digi[i].adc();
+      _xPedEntries1LS.get(did)++;
 
-	for (HODigiCollection::const_iterator it=cho->begin();
-		it!=cho->end(); ++it)
-	{
-		const HODataFrame digi = (const HODataFrame)(*it);
-		HcalDetId did = digi.id();
-		int digiSizeToUse = floor(digi.size()/constants::CAPS_NUM)*
-			constants::CAPS_NUM-1;
-		nHO++;
-		for (int i=0; i<digiSizeToUse; i++)
-		{
-			_cADC_SubdetPM.fill(did, it->sample(i).adc());
+      _xPedSumTotal.get(did) += digi[i].adc();
+      _xPedSum2Total.get(did) += digi[i].adc() * digi[i].adc();
+      _xPedEntriesTotal.get(did)++;
+    }
+  }
 
-			_xPedSum1LS.get(did)+=it->sample(i).adc();
-			_xPedSum21LS.get(did)+=it->sample(i).adc()*it->sample(i).adc();
-			_xPedEntries1LS.get(did)++;
-			
-			_xPedSumTotal.get(did)+=it->sample(i).adc();
-			_xPedSum2Total.get(did)+=it->sample(i).adc()*it->sample(i).adc();
-			_xPedEntriesTotal.get(did)++;
-		}
-	}
-	_cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalOuter, 1,1,1), 
-		_currentLS, nHO);
+  _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS, nHB);
+  _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalEndcap, 1, 1, 1), _currentLS, nHE);
 
-	for (QIE10DigiCollection::const_iterator it=chf->begin();
-		it!=chf->end(); ++it)
-	{
-		const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
-		HcalDetId did = digi.detid();
-		if (did.subdet() != HcalForward) {
-			continue;
-		}
-		// HF has 3 samples in global, so impossible to make divisible by 4
-		int digiSizeToUse = (digi.samples() >= 4 ? floor(digi.samples()/constants::CAPS_NUM)*constants::CAPS_NUM-1 : digi.samples());
-		nHF++;
-		for (int i=0; i<digiSizeToUse; i++)
-		{
-			_cADC_SubdetPM.fill(did, digi[i].adc());
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    const HODataFrame digi = (const HODataFrame)(*it);
+    HcalDetId did = digi.id();
+    int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
+    nHO++;
+    for (int i = 0; i < digiSizeToUse; i++) {
+      _cADC_SubdetPM.fill(did, it->sample(i).adc());
 
-			_xPedSum1LS.get(did)+=digi[i].adc();
-			_xPedSum21LS.get(did)+=digi[i].adc()*digi[i].adc();
-			_xPedEntries1LS.get(did)++;
-			
-			_xPedSumTotal.get(did)+=digi[i].adc();
-			_xPedSum2Total.get(did)+=digi[i].adc()*digi[i].adc();
-			_xPedEntriesTotal.get(did)++;
-		}
-	}
-	_cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalForward, 1,1,1), 
-		_currentLS, nHF);
+      _xPedSum1LS.get(did) += it->sample(i).adc();
+      _xPedSum21LS.get(did) += it->sample(i).adc() * it->sample(i).adc();
+      _xPedEntries1LS.get(did)++;
+
+      _xPedSumTotal.get(did) += it->sample(i).adc();
+      _xPedSum2Total.get(did) += it->sample(i).adc() * it->sample(i).adc();
+      _xPedEntriesTotal.get(did)++;
+    }
+  }
+  _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 1), _currentLS, nHO);
+
+  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+    HcalDetId did = digi.detid();
+    if (did.subdet() != HcalForward) {
+      continue;
+    }
+    // HF has 3 samples in global, so impossible to make divisible by 4
+    int digiSizeToUse =
+        (digi.samples() >= 4 ? floor(digi.samples() / constants::CAPS_NUM) * constants::CAPS_NUM - 1 : digi.samples());
+    nHF++;
+    for (int i = 0; i < digiSizeToUse; i++) {
+      _cADC_SubdetPM.fill(did, digi[i].adc());
+
+      _xPedSum1LS.get(did) += digi[i].adc();
+      _xPedSum21LS.get(did) += digi[i].adc() * digi[i].adc();
+      _xPedEntries1LS.get(did)++;
+
+      _xPedSumTotal.get(did) += digi[i].adc();
+      _xPedSum2Total.get(did) += digi[i].adc() * digi[i].adc();
+      _xPedEntriesTotal.get(did)++;
+    }
+  }
+  _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalForward, 1, 1, 1), _currentLS, nHF);
 }
 
-/* virtual */ bool PedestalTask::_isApplicable(edm::Event const& e)
-{
-	if (_ptype==fOnline)
-	{
-		edm::Handle<HcalUMNioDigi> cumn;
-		if (!e.getByToken(_tokuMN, cumn))
-			return false;
+/* virtual */ bool PedestalTask::_isApplicable(edm::Event const& e) {
+  if (_ptype == fOnline) {
+    edm::Handle<HcalUMNioDigi> cumn;
+    if (!e.getByToken(_tokuMN, cumn))
+      return false;
 
-		//	for online just check the event type not the user Word
-		uint8_t eventType = cumn->eventType();
-		if (eventType == constants::EVENTTYPE_PEDESTAL)
-			return true;
-	}
-	else 
-	{
-		//	local
-		edm::Handle<HcalTBTriggerData>	ctrigger;
-		if (!e.getByToken(_tokTrigger, ctrigger))
-			_logger.dqmthrow("Collection HcalTBTriggerData isn't available"
-				+ _tagTrigger.label() + " " + _tagTrigger.instance());
-		return ctrigger->wasSpillIgnorantPedestalTrigger();
-	}
+    //	for online just check the event type not the user Word
+    uint8_t eventType = cumn->eventType();
+    if (eventType == constants::EVENTTYPE_PEDESTAL)
+      return true;
+  } else {
+    //	local
+    edm::Handle<HcalTBTriggerData> ctrigger;
+    if (!e.getByToken(_tokTrigger, ctrigger))
+      _logger.dqmthrow("Collection HcalTBTriggerData isn't available" + _tagTrigger.label() + " " +
+                       _tagTrigger.instance());
+    return ctrigger->wasSpillIgnorantPedestalTrigger();
+  }
 
-	return false;
+  return false;
 }
 
 DEFINE_FWK_MODULE(PedestalTask);

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -6,15 +6,15 @@ using namespace hcaldqm::constants;
 PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   //	tags
   _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
-  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
-  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
   _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
   _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
   _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-  _tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
-  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
@@ -947,40 +947,19 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void PedestalTask::_process(edm::Event const& e, edm::EventSetup const& es) {
-  edm::Handle<HBHEDigiCollection> chbhe;
-  edm::Handle<HODigiCollection> cho;
-  edm::Handle<QIE10DigiCollection> chf;
-  edm::Handle<QIE11DigiCollection> chep17;
+  edm::Handle<HODigiCollection> c_ho;
+  edm::Handle<QIE10DigiCollection> c_qie10;
+  edm::Handle<QIE11DigiCollection> c_qie11;
 
-  if (!e.getByToken(_tokHBHE, chbhe))
-    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE.label() + " " + _tagHBHE.instance());
-  if (!e.getByToken(_tokHO, cho))
+  if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokHF, chf))
-    _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagHF.label() + " " + _tagHF.instance());
-  if (!e.getByToken(_tokHEP17, chep17))
-    _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokQIE10, c_QIE10))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagQIE10.label() + " " + _tagQIE10.instance());
+  if (!e.getByToken(_tokQIE11, c_QIE11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagQIE11.label() + " " + _tagQIE11.instance());
 
   int nHB(0), nHE(0), nHO(0), nHF(0);
-  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
-    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-    HcalDetId did = digi.id();
-    int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
-    did.subdet() == HcalBarrel ? nHB++ : nHE++;
-
-    for (int i = 0; i < digiSizeToUse; i++) {
-      _cADC_SubdetPM.fill(did, it->sample(i).adc());
-
-      _xPedSum1LS.get(did) += it->sample(i).adc();
-      _xPedSum21LS.get(did) += it->sample(i).adc() * it->sample(i).adc();
-      _xPedEntries1LS.get(did)++;
-
-      _xPedSumTotal.get(did) += it->sample(i).adc();
-      _xPedSum2Total.get(did) += it->sample(i).adc() * it->sample(i).adc();
-      _xPedEntriesTotal.get(did)++;
-    }
-  }
-  for (QIE11DigiCollection::const_iterator it = chep17->begin(); it != chep17->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     // Require barrel or endcap. As of 2017, some calibration channels are ending up in this collection.
@@ -1006,7 +985,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS, nHB);
   _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalEndcap, 1, 1, 1), _currentLS, nHE);
 
-  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+  for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     HcalDetId did = digi.id();
     int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
@@ -1025,7 +1004,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   }
   _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 1), _currentLS, nHO);
 
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -5,13 +5,11 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   //	tags
-  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
   _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
   _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
   _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
   _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
-  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
   _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
   _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
@@ -948,8 +946,8 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
 /* virtual */ void PedestalTask::_process(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<HODigiCollection> c_ho;
-  edm::Handle<QIE10DigiCollection> c_qie10;
-  edm::Handle<QIE11DigiCollection> c_qie11;
+  edm::Handle<QIE10DigiCollection> c_QIE10;
+  edm::Handle<QIE11DigiCollection> c_QIE11;
 
   if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());

--- a/DQM/HcalTasks/plugins/QIE10Task.cc
+++ b/DQM/HcalTasks/plugins/QIE10Task.cc
@@ -5,241 +5,231 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-QIE10Task::QIE10Task(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	
-	//	tags
-	_tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
-	_tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
-	_tokHF = consumes<HFDigiCollection>(_tagHF);
+QIE10Task::QIE10Task(edm::ParameterSet const& ps) : DQTask(ps) {
+  //	tags
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
+  _tokHF = consumes<HFDigiCollection>(_tagHF);
 
-	//	cuts
-	_cut = ps.getUntrackedParameter<double>("cut", 50.0);
-	_ped = ps.getUntrackedParameter<int>("ped", 4);
+  //	cuts
+  _cut = ps.getUntrackedParameter<double>("cut", 50.0);
+  _ped = ps.getUntrackedParameter<int>("ped", 4);
 }
-/* virtual */ void QIE10Task::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		if (r.runAuxiliary().run()==1)
-			return;
+/* virtual */ void QIE10Task::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    if (r.runAuxiliary().run() == 1)
+      return;
 
-	DQTask::bookHistograms(ib, r, es);
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
 
-	unsigned int nTS = _ptype==fLocal ? 10 : 6;
+  unsigned int nTS = _ptype == fLocal ? 10 : 6;
 
-	// create a slot filter and initialize what you need
-	unsigned int itr=0;
-	for (auto& crate : constants::crateListHF) {
-		for(unsigned int slot=SLOT_uTCA_MIN; slot<=SLOT_uTCA_MAX; ++slot) {
-			std::vector<uint32_t> vhashSlot;
-			vhashSlot.push_back(HcalElectronicsId(crate, slot, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-			_filter_slot[itr].initialize(filter::fPreserver, hashfunctions::fCrateSlot, vhashSlot);
+  // create a slot filter and initialize what you need
+  unsigned int itr = 0;
+  for (auto& crate : constants::crateListHF) {
+    for (unsigned int slot = SLOT_uTCA_MIN; slot <= SLOT_uTCA_MAX; ++slot) {
+      std::vector<uint32_t> vhashSlot;
+      vhashSlot.push_back(HcalElectronicsId(crate, slot, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+      _filter_slot[itr].initialize(filter::fPreserver, hashfunctions::fCrateSlot, vhashSlot);
 
-		 	_cShapeCut_EChannel[itr].initialize(_name,
-				"ShapeCut", hcaldqm::hashfunctions::fEChannel,
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
-			_cLETDCTime_EChannel[itr].initialize(_name,
-				"LETDCTime", hcaldqm::hashfunctions::fEChannel,
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-			_cLETDCvsTS_EChannel[itr].initialize(_name, 
-				"TDCvsTS", hcaldqm::hashfunctions::fEChannel, 
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64), 
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+      _cShapeCut_EChannel[itr].initialize(_name,
+                                          "ShapeCut",
+                                          hcaldqm::hashfunctions::fEChannel,
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
+      _cLETDCTime_EChannel[itr].initialize(_name,
+                                           "LETDCTime",
+                                           hcaldqm::hashfunctions::fEChannel,
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+      _cLETDCvsTS_EChannel[itr].initialize(_name,
+                                           "TDCvsTS",
+                                           hcaldqm::hashfunctions::fEChannel,
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
 
-			for (unsigned int j=0; j<nTS; j++) {
-				_cLETDCvsADC_EChannel[j][itr].initialize(_name,
-					"LETDCvsADC", hcaldqm::hashfunctions::fEChannel,
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-				_cADC_EChannel[j][itr].initialize(_name,
-					"ADC", hcaldqm::hashfunctions::fEChannel,
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-				_cLETDC_EChannel[j][itr].initialize(_name,
-					"LETDC", hcaldqm::hashfunctions::fEChannel,
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+      for (unsigned int j = 0; j < nTS; j++) {
+        _cLETDCvsADC_EChannel[j][itr].initialize(_name,
+                                                 "LETDCvsADC",
+                                                 hcaldqm::hashfunctions::fEChannel,
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+        _cADC_EChannel[j][itr].initialize(_name,
+                                          "ADC",
+                                          hcaldqm::hashfunctions::fEChannel,
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+        _cLETDC_EChannel[j][itr].initialize(_name,
+                                            "LETDC",
+                                            hcaldqm::hashfunctions::fEChannel,
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+      }
+      ++itr;
+    }
+  }
 
-			}
-			++itr;
-		}
-	  }
+  _cShapeCut.initialize(_name,
+                        "ShapeCut",
+                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
+  _cLETDCvsADC.initialize(_name,
+                          "LETDCvsADC",
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cLETDCTimevsADC.initialize(_name,
+                              "LETDCTimevsADC",
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cLETDC.initialize(_name,
+                     "LETDC",
+                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  _cADC.initialize(_name,
+                   "ADC",
+                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
 
-	_cShapeCut.initialize(_name,
-		"ShapeCut", 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
-	_cLETDCvsADC.initialize(_name, "LETDCvsADC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cLETDCTimevsADC.initialize(_name, "LETDCTimevsADC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cLETDC.initialize(_name, "LETDC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cADC.initialize(_name, "ADC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+  //OCCUPANCY PER CRATE/SLOT
+  _cOccupancy_Crate.initialize(_name,
+                               "Occupancy",
+                               hashfunctions::fCrate,
+                               new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                               new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
+                               new quantity::ValueQuantity(quantity::fN));
+  _cOccupancy_CrateSlot.initialize(_name,
+                                   "Occupancy",
+                                   hashfunctions::fCrateSlot,
+                                   new quantity::ElectronicsQuantity(quantity::fFiberuTCA),
+                                   new quantity::ElectronicsQuantity(quantity::fFiberCh),
+                                   new quantity::ValueQuantity(quantity::fN));
 
+  // OCCUPANCY IN DETECTOR COORDINATES
+  _cOccupancy_depth.initialize(_name,
+                               "Occupancy",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN));
 
+  itr = 0;
+  for (auto& crate : constants::crateListHF) {
+    for (unsigned int slot = SLOT_uTCA_MIN; slot <= SLOT_uTCA_MAX; ++slot) {
+      char aux[100];
+      sprintf(aux, "/Crate%d_Slot%d", crate, slot);
+      _cShapeCut_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+      _cLETDCTime_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+      _cLETDCvsTS_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+      for (unsigned int i = 0; i < nTS; i++) {
+        char aux2[100];
+        sprintf(aux2, "/Crate%d_Slot%d/TS%d", crate, slot, i);
+        _cLETDCvsADC_EChannel[i][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+        _cLETDC_EChannel[i][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+        _cADC_EChannel[i][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+      }
+      ++itr;
+    }
+  }
 
-	//OCCUPANCY PER CRATE/SLOT
-	_cOccupancy_Crate.initialize(_name,
-									 "Occupancy", hashfunctions::fCrate,
-									 new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-									 new quantity::ElectronicsQuantity(quantity::fFiberuTCAFiberCh),
-									 new quantity::ValueQuantity(quantity::fN));
-	_cOccupancy_CrateSlot.initialize(_name,
-										 "Occupancy", hashfunctions::fCrateSlot,
-										 new quantity::ElectronicsQuantity(quantity::fFiberuTCA),
-										 new quantity::ElectronicsQuantity(quantity::fFiberCh),
-										 new quantity::ValueQuantity(quantity::fN));
+  _cShapeCut.book(ib, _subsystem);
+  _cLETDCvsADC.book(ib, _subsystem);
+  _cLETDCTimevsADC.book(ib, _subsystem);
+  _cLETDC.book(ib, _subsystem);
+  _cADC.book(ib, _subsystem);
 
-	// OCCUPANCY IN DETECTOR COORDINATES
-	_cOccupancy_depth.initialize(_name, "Occupancy",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN));
+  _cOccupancy_Crate.book(ib, _emap, _subsystem);
+  _cOccupancy_CrateSlot.book(ib, _emap, _subsystem);
+  _cOccupancy_depth.book(ib, _emap, _subsystem);
 
-
-	itr = 0;
-	for(auto& crate : constants::crateListHF) {
-		for(unsigned int slot=SLOT_uTCA_MIN; slot<=SLOT_uTCA_MAX; ++slot) {
-			char aux[100];
-			sprintf(aux, "/Crate%d_Slot%d", crate, slot);
-			_cShapeCut_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-			_cLETDCTime_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-			_cLETDCvsTS_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-			for (unsigned int i=0; i<nTS; i++) {
-				char aux2[100];
-				sprintf(aux2, "/Crate%d_Slot%d/TS%d", crate, slot, i);
-				_cLETDCvsADC_EChannel[i][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-				_cLETDC_EChannel[i][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-				_cADC_EChannel[i][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-			}
-			++itr;
-		}
-	}
-
-	_cShapeCut.book(ib, _subsystem);
-	_cLETDCvsADC.book(ib, _subsystem);
-	_cLETDCTimevsADC.book(ib, _subsystem);
-	_cLETDC.book(ib, _subsystem);
-	_cADC.book(ib, _subsystem);
-
-	_cOccupancy_Crate.book(ib, _emap, _subsystem);
-	_cOccupancy_CrateSlot.book(ib, _emap, _subsystem);
-	_cOccupancy_depth.book(ib, _emap, _subsystem);
-
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
-}
-
-/* virtual */ void QIE10Task::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	
-	//	finish
-	DQTask::endLuminosityBlock(lb, es);
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 }
 
-/* virtual */ void QIE10Task::_process(edm::Event const& e, 
-	edm::EventSetup const&)
-{
-	edm::Handle<QIE10DigiCollection> cqie10;
-	edm::Handle<HFDigiCollection>       chf;
-	if (!e.getByToken(_tokQIE10, cqie10))
-		return;
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection HFDigiCollection isn't available"
-			+ _tagHF.label() + " " + _tagHF.instance());
-
-	std::map<uint32_t, QIE10DataFrame> mqie10;
-	for (uint32_t i=0; i<cqie10->size(); i++)
-	{
-		QIE10DataFrame frame = static_cast<QIE10DataFrame>((*cqie10)[i]);
-		HcalDetId did = frame.detid();
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
-		if (did.subdet() != HcalForward) {
-			continue;
-		}
-
-		// Compute index for EChannel plots
-		int fakecrate =-1;
-		if (eid.crateId() == 22) {
-			fakecrate = 0;
-		} else if (eid.crateId() == 29) {
-			fakecrate = 1;
-		} else if (eid.crateId() == 32) {
-			fakecrate = 2;
-		} else {
-			// Unknown crate, skip digi
-			continue;
-		}
-		int index = fakecrate*12+eid.slot()-1;
-
-		//	compute the signal, ped subracted
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, frame);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, frame, 0, frame.samples()-1);
-		// double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(frame, constants::adc2fC[_ped], 0, frame.samples()-1);
-
-		_cOccupancy_Crate.fill(eid);
-		_cOccupancy_CrateSlot.fill(eid);
-		_cOccupancy_depth.fill(did);
-
-		//	iterate thru all TS and fill
-		for (int j=0; j<frame.samples(); j++)
-		{
-			//	shapes are after the cut
-			if (sumQ>_cut)
-			{
-				double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, frame, j);
-				_cShapeCut_EChannel[index].fill(eid, j, q);
-				_cShapeCut.fill(j, q);
-			}
-			//	w/o a cut
-			_cLETDCvsADC_EChannel[j][index].fill(eid, frame[j].adc(), 
-							  frame[j].le_tdc());
-			_cLETDCvsADC.fill(frame[j].adc(), frame[j].le_tdc());
-			_cLETDC_EChannel[j][index].fill(eid, frame[j].le_tdc());
-			_cLETDC.fill(frame[j].le_tdc());
-			_cADC_EChannel[j][index].fill(eid, frame[j].adc());
-			_cADC.fill(frame[j].adc());
-			_cLETDCvsTS_EChannel[index].fill(eid, j, frame[j].le_tdc());	
-
-			// TDC conversion to time
-			if (frame[j].le_tdc() < 50) {
-				// Each TDC count is 0.5 ns. 
-				// tdc == 62 or 63 means value was below or above threshold for whole time slice. 
-				double time = j*25. + (frame[j].le_tdc() / 2.);
-				_cLETDCTime_EChannel[index].fill(eid, time);
-				_cLETDCTimevsADC.fill(frame[j].adc(), time);
-			}
-		}
-
-		mqie10[did.rawId()] = frame;
-	}
+/* virtual */ void QIE10Task::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  //	finish
+  DQTask::endLuminosityBlock(lb, es);
 }
 
-/* virtual */ void QIE10Task::_resetMonitors(hcaldqm::UpdateFreq)
-{
+/* virtual */ void QIE10Task::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<QIE10DigiCollection> cqie10;
+  edm::Handle<HFDigiCollection> chf;
+  if (!e.getByToken(_tokQIE10, cqie10))
+    return;
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection HFDigiCollection isn't available" + _tagHF.label() + " " + _tagHF.instance());
+
+  std::map<uint32_t, QIE10DataFrame> mqie10;
+  for (uint32_t i = 0; i < cqie10->size(); i++) {
+    QIE10DataFrame frame = static_cast<QIE10DataFrame>((*cqie10)[i]);
+    HcalDetId did = frame.detid();
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+    if (did.subdet() != HcalForward) {
+      continue;
+    }
+
+    // Compute index for EChannel plots
+    int fakecrate = -1;
+    if (eid.crateId() == 22) {
+      fakecrate = 0;
+    } else if (eid.crateId() == 29) {
+      fakecrate = 1;
+    } else if (eid.crateId() == 32) {
+      fakecrate = 2;
+    } else {
+      // Unknown crate, skip digi
+      continue;
+    }
+    int index = fakecrate * 12 + eid.slot() - 1;
+
+    //	compute the signal, ped subracted
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, frame);
+    double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, frame, 0, frame.samples() - 1);
+    // double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(frame, constants::adc2fC[_ped], 0, frame.samples()-1);
+
+    _cOccupancy_Crate.fill(eid);
+    _cOccupancy_CrateSlot.fill(eid);
+    _cOccupancy_depth.fill(did);
+
+    //	iterate thru all TS and fill
+    for (int j = 0; j < frame.samples(); j++) {
+      //	shapes are after the cut
+      if (sumQ > _cut) {
+        double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, frame, j);
+        _cShapeCut_EChannel[index].fill(eid, j, q);
+        _cShapeCut.fill(j, q);
+      }
+      //	w/o a cut
+      _cLETDCvsADC_EChannel[j][index].fill(eid, frame[j].adc(), frame[j].le_tdc());
+      _cLETDCvsADC.fill(frame[j].adc(), frame[j].le_tdc());
+      _cLETDC_EChannel[j][index].fill(eid, frame[j].le_tdc());
+      _cLETDC.fill(frame[j].le_tdc());
+      _cADC_EChannel[j][index].fill(eid, frame[j].adc());
+      _cADC.fill(frame[j].adc());
+      _cLETDCvsTS_EChannel[index].fill(eid, j, frame[j].le_tdc());
+
+      // TDC conversion to time
+      if (frame[j].le_tdc() < 50) {
+        // Each TDC count is 0.5 ns.
+        // tdc == 62 or 63 means value was below or above threshold for whole time slice.
+        double time = j * 25. + (frame[j].le_tdc() / 2.);
+        _cLETDCTime_EChannel[index].fill(eid, time);
+        _cLETDCTimevsADC.fill(frame[j].adc(), time);
+      }
+    }
+
+    mqie10[did.rawId()] = frame;
+  }
 }
+
+/* virtual */ void QIE10Task::_resetMonitors(hcaldqm::UpdateFreq) {}
 
 DEFINE_FWK_MODULE(QIE10Task);

--- a/DQM/HcalTasks/plugins/QIE11Task.cc
+++ b/DQM/HcalTasks/plugins/QIE11Task.cc
@@ -3,252 +3,249 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-QIE11Task::QIE11Task(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	
-	//	tags
-	_tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagQIE11",
-		edm::InputTag("hcalDigis"));
-	_tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
+QIE11Task::QIE11Task(edm::ParameterSet const& ps) : DQTask(ps) {
+  //	tags
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagQIE11", edm::InputTag("hcalDigis"));
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
 
-	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
-							  edm::InputTag("hcalDigis"));
-	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
+  _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
-	//	cuts
-	_cut = ps.getUntrackedParameter<double>("cut", 50.0);
-	_ped = ps.getUntrackedParameter<int>("ped", 4);
-	_laserType = ps.getUntrackedParameter<int32_t>("laserType", -1);
-	_eventType = ps.getUntrackedParameter<int32_t>("eventType", -1);
+  //	cuts
+  _cut = ps.getUntrackedParameter<double>("cut", 50.0);
+  _ped = ps.getUntrackedParameter<int>("ped", 4);
+  _laserType = ps.getUntrackedParameter<int32_t>("laserType", -1);
+  _eventType = ps.getUntrackedParameter<int32_t>("eventType", -1);
 }
-/* virtual */ void QIE11Task::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		if (r.runAuxiliary().run()==1)
-			return;
+/* virtual */ void QIE11Task::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    if (r.runAuxiliary().run() == 1)
+      return;
 
-	DQTask::bookHistograms(ib, r, es);
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
-	std::vector<uint32_t> vhashC34;
-	vhashC34.push_back(HcalElectronicsId(34, 11,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	vhashC34.push_back(HcalElectronicsId(34, 12,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_C34.initialize(filter::fPreserver, hcaldqm::hashfunctions::fCrateSlot,
-		vhashC34);
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
+  std::vector<uint32_t> vhashC34;
+  vhashC34.push_back(HcalElectronicsId(34, 11, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  vhashC34.push_back(HcalElectronicsId(34, 12, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_C34.initialize(filter::fPreserver, hcaldqm::hashfunctions::fCrateSlot, vhashC34);
 
-	std::vector<std::pair<int, int> > timingChannels;
-	timingChannels.push_back(std::pair<int, int>(28, 63));
-	timingChannels.push_back(std::pair<int, int>(28, 65));
-	timingChannels.push_back(std::pair<int, int>(20, 63));
-	timingChannels.push_back(std::pair<int, int>(20, 65));
-	for (int iChan = 0; iChan < 4; ++iChan) {
-		std::vector<uint32_t> vhashTimingChannel;
-		for (int depth = 1; depth <= 7; ++depth) {
-			vhashTimingChannel.push_back(HcalDetId(HcalEndcap, timingChannels[iChan].first, timingChannels[iChan].second, depth));
-		}
-		_filter_timingChannels[iChan].initialize(filter::fPreserver, hcaldqm::hashfunctions::fDChannel, vhashTimingChannel);
-	}
-
-	//	INITIALIZE what you need
-	
-	// EChannel plots, online+local only
-	if (_ptype != fOffline) {
-		unsigned int itr = 0;
-		for (unsigned int crate = 34; crate <= 34; ++crate) {
-			for (unsigned int slot = 11; slot <= 12; ++slot) {
-				std::vector<uint32_t> vhashSlot;
-				vhashSlot.push_back(HcalElectronicsId(crate, slot, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-				_filter_slot[itr].initialize(filter::fPreserver, hashfunctions::fCrateSlot, vhashSlot);
-				_cShapeCut_EChannel[itr].initialize(_name,
-					"ShapeCut", hcaldqm::hashfunctions::fEChannel,
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
-				_cLETDCvsTS_EChannel[itr].initialize(_name, 
-					"LETDCvsTS", hcaldqm::hashfunctions::fEChannel, 
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-	                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true), 0);
-				_cLETDCTime_EChannel[itr].initialize(_name,
-					"LETDCTime", hcaldqm::hashfunctions::fEChannel,
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-					new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-				for (unsigned int j=0; j<10; j++) {
-					_cLETDCvsADC_EChannel[j][itr].initialize(_name,
-						"LETDCvsADC", hcaldqm::hashfunctions::fEChannel,
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-					_cADC_EChannel[j][itr].initialize(_name,
-						"ADC", hcaldqm::hashfunctions::fEChannel,
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-					_cLETDC_EChannel[j][itr].initialize(_name,
-						"LETDC", hcaldqm::hashfunctions::fEChannel,
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-						new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-				}
-				++itr;
-			}
-		}
-	}
-	_cShapeCut.initialize(_name,
-		"ShapeCut", 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
-	_cLETDCvsADC.initialize(_name, "LETDCvsADC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cLETDCTimevsADC.initialize(_name, "LETDCTimevsADC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cLETDC.initialize(_name, "LETDC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cADC.initialize(_name, "ADC",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-
-	if (_ptype != fOffline) {
-		unsigned int itr = 0;
-		std::map<std::pair<unsigned int, unsigned int>, unsigned int> itr_map;
-		for(unsigned int crate = 34; crate <= 34; ++crate) {
-			for(unsigned int slot=11; slot<=12; ++slot) {
-				char aux[100];
-				sprintf(aux, "/Crate%d_Slot%d", crate, slot);
-				_cShapeCut_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-				_cLETDCvsTS_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-				_cLETDCTime_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
-				for (unsigned int j=0; j<10; j++) {
-					char aux2[100];
-					sprintf(aux2, "/Crate%d_Slot%d/TS%d", crate, slot, j);
-					_cLETDCvsADC_EChannel[j][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux2);
-					_cLETDC_EChannel[j][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux2);
-					_cADC_EChannel[j][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux2);
-				}
-				itr_map[std::make_pair(crate, slot)] = itr;
-				++itr;
-			}
-		}
-	}
-	_cShapeCut.book(ib, _subsystem);
-	_cLETDCvsADC.book(ib, _subsystem);
-	_cLETDCTimevsADC.book(ib, _subsystem);
-	_cLETDC.book(ib, _subsystem);
-	_cADC.book(ib, _subsystem);
-
-	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap, _filter_C34);
-}
-
-/* virtual */ void QIE11Task::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	
-	//	finish
-	DQTask::endLuminosityBlock(lb, es);
-}
-
-/* virtual */ void QIE11Task::_process(edm::Event const& e, 
-	edm::EventSetup const&)
-{
-	edm::Handle<QIE11DigiCollection> cqie11;
-	if (!e.getByToken(_tokQIE11, cqie11))
-		return;
-
-	for (uint32_t i=0; i<cqie11->size(); i++)
-	{
-		QIE11DataFrame frame = static_cast<QIE11DataFrame>((*cqie11)[i]);
-		DetId did = frame.detid();
-		if (HcalDetId(frame.detid()).subdet() != HcalEndcap) {
-			continue;
-		}
-
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
-		if (!eid.rawId()) {
-		  continue;
-		}
-		int fakecrate = -1;
-		if (eid.crateId() == 34) fakecrate = 0;
-		int index = fakecrate * 12 + (eid.slot() - 10) - 1;
-
-		//	compute the signal, ped subracted
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, frame);
-//		double q = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(frame,
-//			constants::adc2fC[_ped], 0, frame.samples()-1);
-
-		//	iterate thru all TS and fill
-		for (int j=0; j<frame.samples(); j++)
-		{
-			double q_pedsub = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, frame, j);
-			if (_ptype != fOffline) {
-				if (index == 0 || index == 1) {
-					//	shapes are after the cut
-					_cShapeCut_EChannel[index].fill(eid, j, q_pedsub);	
-					_cLETDCvsTS_EChannel[index].fill(eid, j, frame[j].tdc());	
-
-					//	w/o a cut
-					_cLETDCvsADC_EChannel[j][index].fill(eid, frame[j].adc(), 
-						frame[j].tdc());
-					_cLETDC_EChannel[j][index].fill(eid, frame[j].tdc());
-					if (frame[j].tdc() < 50) {
-						// Each TDC count is 0.5 ns. 
-						// tdc == 62 or 63 means value was below or above threshold for whole time slice. 
-						_cLETDCTime_EChannel[index].fill(eid, j*25. + (frame[j].tdc() / 2.));
-					}
-					_cADC_EChannel[j][index].fill(eid, frame[j].adc());
-				}
-			}
-			_cShapeCut.fill(eid, j, q_pedsub);
-
-			_cLETDCvsADC.fill(frame[j].adc(), frame[j].tdc());
-			if (frame[j].tdc() < 50) {
-				_cLETDCTimevsADC.fill(frame[j].adc(), j*25. + (frame[j].tdc() / 2.));
-			}
-			_cLETDC.fill(eid, frame[j].tdc());
-
-			_cADC.fill(eid, frame[j].adc());
-
-		}
-	}
-}
-
-
-/* virtual */ bool QIE11Task::_isApplicable(edm::Event const& e)
-{
-  if (_ptype!=fOnline || (_laserType < 0 && _eventType < 0))
-    return true;
-  else
-    {
-      //      fOnline mode
-      edm::Handle<HcalUMNioDigi> cumn;
-      if (!e.getByToken(_tokuMN, cumn))
-	return false;
-
-      //      event type check first
-      int eventType = cumn->eventType();
-      if (eventType==_eventType)
-	return true;
-
-      //      check if this analysis task is of the right laser type
-      int laserType = cumn->valueUserWord(0);
-      if (laserType==_laserType)
-	return true;
+  std::vector<std::pair<int, int> > timingChannels;
+  timingChannels.push_back(std::pair<int, int>(28, 63));
+  timingChannels.push_back(std::pair<int, int>(28, 65));
+  timingChannels.push_back(std::pair<int, int>(20, 63));
+  timingChannels.push_back(std::pair<int, int>(20, 65));
+  for (int iChan = 0; iChan < 4; ++iChan) {
+    std::vector<uint32_t> vhashTimingChannel;
+    for (int depth = 1; depth <= 7; ++depth) {
+      vhashTimingChannel.push_back(
+          HcalDetId(HcalEndcap, timingChannels[iChan].first, timingChannels[iChan].second, depth));
     }
+    _filter_timingChannels[iChan].initialize(filter::fPreserver, hcaldqm::hashfunctions::fDChannel, vhashTimingChannel);
+  }
+
+  //	INITIALIZE what you need
+
+  // EChannel plots, online+local only
+  if (_ptype != fOffline) {
+    unsigned int itr = 0;
+    for (unsigned int crate = 34; crate <= 34; ++crate) {
+      for (unsigned int slot = 11; slot <= 12; ++slot) {
+        std::vector<uint32_t> vhashSlot;
+        vhashSlot.push_back(HcalElectronicsId(crate, slot, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+        _filter_slot[itr].initialize(filter::fPreserver, hashfunctions::fCrateSlot, vhashSlot);
+        _cShapeCut_EChannel[itr].initialize(_name,
+                                            "ShapeCut",
+                                            hcaldqm::hashfunctions::fEChannel,
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
+        _cLETDCvsTS_EChannel[itr].initialize(_name,
+                                             "LETDCvsTS",
+                                             hcaldqm::hashfunctions::fEChannel,
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                             0);
+        _cLETDCTime_EChannel[itr].initialize(_name,
+                                             "LETDCTime",
+                                             hcaldqm::hashfunctions::fEChannel,
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                             0);
+        for (unsigned int j = 0; j < 10; j++) {
+          _cLETDCvsADC_EChannel[j][itr].initialize(
+              _name,
+              "LETDCvsADC",
+              hcaldqm::hashfunctions::fEChannel,
+              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+              0);
+          _cADC_EChannel[j][itr].initialize(_name,
+                                            "ADC",
+                                            hcaldqm::hashfunctions::fEChannel,
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                            0);
+          _cLETDC_EChannel[j][itr].initialize(_name,
+                                              "LETDC",
+                                              hcaldqm::hashfunctions::fEChannel,
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                              0);
+        }
+        ++itr;
+      }
+    }
+  }
+  _cShapeCut.initialize(_name,
+                        "ShapeCut",
+                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000));
+  _cLETDCvsADC.initialize(_name,
+                          "LETDCvsADC",
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                          0);
+  _cLETDCTimevsADC.initialize(_name,
+                              "LETDCTimevsADC",
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                              0);
+  _cLETDC.initialize(_name,
+                     "LETDC",
+                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                     0);
+  _cADC.initialize(_name,
+                   "ADC",
+                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                   0);
+
+  if (_ptype != fOffline) {
+    unsigned int itr = 0;
+    std::map<std::pair<unsigned int, unsigned int>, unsigned int> itr_map;
+    for (unsigned int crate = 34; crate <= 34; ++crate) {
+      for (unsigned int slot = 11; slot <= 12; ++slot) {
+        char aux[100];
+        sprintf(aux, "/Crate%d_Slot%d", crate, slot);
+        _cShapeCut_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+        _cLETDCvsTS_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+        _cLETDCTime_EChannel[itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux);
+        for (unsigned int j = 0; j < 10; j++) {
+          char aux2[100];
+          sprintf(aux2, "/Crate%d_Slot%d/TS%d", crate, slot, j);
+          _cLETDCvsADC_EChannel[j][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux2);
+          _cLETDC_EChannel[j][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux2);
+          _cADC_EChannel[j][itr].book(ib, _emap, _filter_slot[itr], _subsystem, aux2);
+        }
+        itr_map[std::make_pair(crate, slot)] = itr;
+        ++itr;
+      }
+    }
+  }
+  _cShapeCut.book(ib, _subsystem);
+  _cLETDCvsADC.book(ib, _subsystem);
+  _cLETDCTimevsADC.book(ib, _subsystem);
+  _cLETDC.book(ib, _subsystem);
+  _cADC.book(ib, _subsystem);
+
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap, _filter_C34);
+}
+
+/* virtual */ void QIE11Task::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  //	finish
+  DQTask::endLuminosityBlock(lb, es);
+}
+
+/* virtual */ void QIE11Task::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<QIE11DigiCollection> cqie11;
+  if (!e.getByToken(_tokQIE11, cqie11))
+    return;
+
+  for (uint32_t i = 0; i < cqie11->size(); i++) {
+    QIE11DataFrame frame = static_cast<QIE11DataFrame>((*cqie11)[i]);
+    DetId did = frame.detid();
+    if (HcalDetId(frame.detid()).subdet() != HcalEndcap) {
+      continue;
+    }
+
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+    if (!eid.rawId()) {
+      continue;
+    }
+    int fakecrate = -1;
+    if (eid.crateId() == 34)
+      fakecrate = 0;
+    int index = fakecrate * 12 + (eid.slot() - 10) - 1;
+
+    //	compute the signal, ped subracted
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, frame);
+    //		double q = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(frame,
+    //			constants::adc2fC[_ped], 0, frame.samples()-1);
+
+    //	iterate thru all TS and fill
+    for (int j = 0; j < frame.samples(); j++) {
+      double q_pedsub = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, frame, j);
+      if (_ptype != fOffline) {
+        if (index == 0 || index == 1) {
+          //	shapes are after the cut
+          _cShapeCut_EChannel[index].fill(eid, j, q_pedsub);
+          _cLETDCvsTS_EChannel[index].fill(eid, j, frame[j].tdc());
+
+          //	w/o a cut
+          _cLETDCvsADC_EChannel[j][index].fill(eid, frame[j].adc(), frame[j].tdc());
+          _cLETDC_EChannel[j][index].fill(eid, frame[j].tdc());
+          if (frame[j].tdc() < 50) {
+            // Each TDC count is 0.5 ns.
+            // tdc == 62 or 63 means value was below or above threshold for whole time slice.
+            _cLETDCTime_EChannel[index].fill(eid, j * 25. + (frame[j].tdc() / 2.));
+          }
+          _cADC_EChannel[j][index].fill(eid, frame[j].adc());
+        }
+      }
+      _cShapeCut.fill(eid, j, q_pedsub);
+
+      _cLETDCvsADC.fill(frame[j].adc(), frame[j].tdc());
+      if (frame[j].tdc() < 50) {
+        _cLETDCTimevsADC.fill(frame[j].adc(), j * 25. + (frame[j].tdc() / 2.));
+      }
+      _cLETDC.fill(eid, frame[j].tdc());
+
+      _cADC.fill(eid, frame[j].adc());
+    }
+  }
+}
+
+/* virtual */ bool QIE11Task::_isApplicable(edm::Event const& e) {
+  if (_ptype != fOnline || (_laserType < 0 && _eventType < 0))
+    return true;
+  else {
+    //      fOnline mode
+    edm::Handle<HcalUMNioDigi> cumn;
+    if (!e.getByToken(_tokuMN, cumn))
+      return false;
+
+    //      event type check first
+    int eventType = cumn->eventType();
+    if (eventType == _eventType)
+      return true;
+
+    //      check if this analysis task is of the right laser type
+    int laserType = cumn->valueUserWord(0);
+    if (laserType == _laserType)
+      return true;
+  }
 
   return false;
 }
 
-
-/* virtual */ void QIE11Task::_resetMonitors(hcaldqm::UpdateFreq)
-{
-}
+/* virtual */ void QIE11Task::_resetMonitors(hcaldqm::UpdateFreq) {}
 
 DEFINE_FWK_MODULE(QIE11Task);

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -1,525 +1,486 @@
 #include "DQM/HcalTasks/interface/RawTask.h"
 
-
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 
-RawTask::RawTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_tagFEDs = ps.getUntrackedParameter<edm::InputTag>("tagFEDs",
-		edm::InputTag("rawDataCollector"));
-	_tagReport = ps.getUntrackedParameter<edm::InputTag>("tagReport",
-		edm::InputTag("hcalDigis"));
-	_calibProcessing = ps.getUntrackedParameter<bool>("calibProcessing",
-		false);
-	_thresh_calib_nbadq = ps.getUntrackedParameter<int>("thresh_calib_nbadq",
-		5000);
+RawTask::RawTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagFEDs = ps.getUntrackedParameter<edm::InputTag>("tagFEDs", edm::InputTag("rawDataCollector"));
+  _tagReport = ps.getUntrackedParameter<edm::InputTag>("tagReport", edm::InputTag("hcalDigis"));
+  _calibProcessing = ps.getUntrackedParameter<bool>("calibProcessing", false);
+  _thresh_calib_nbadq = ps.getUntrackedParameter<int>("thresh_calib_nbadq", 5000);
 
-	_tokFEDs = consumes<FEDRawDataCollection>(_tagFEDs);
-	_tokReport = consumes<HcalUnpackerReport>(_tagReport);
+  _tokFEDs = consumes<FEDRawDataCollection>(_tagFEDs);
+  _tokReport = consumes<HcalUnpackerReport>(_tagReport);
 
-	_vflags.resize(nRawFlag);
-	_vflags[fEvnMsm]=flag::Flag("EvnMsm");
-	_vflags[fBcnMsm]=flag::Flag("BcnMsm");
-	_vflags[fBadQ]=flag::Flag("BadQ");
-	_vflags[fOrnMsm]=flag::Flag("OrnMsm");
+  _vflags.resize(nRawFlag);
+  _vflags[fEvnMsm] = flag::Flag("EvnMsm");
+  _vflags[fBcnMsm] = flag::Flag("BcnMsm");
+  _vflags[fBadQ] = flag::Flag("BadQ");
+  _vflags[fOrnMsm] = flag::Flag("OrnMsm");
 }
 
-/* virtual */ void RawTask::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib,r,es);
+/* virtual */ void RawTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
-	std::vector<uint32_t> vVME;
-	std::vector<uint32_t> vuTCA;
-	vVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN, 
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vuTCA);
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
+  std::vector<uint32_t> vVME;
+  std::vector<uint32_t> vuTCA;
+  vVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vuTCA);
 
-	_cBadQualityvsLS.initialize(_name, "BadQualityvsLS",
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_m0to10000),0);
-	_cBadQualityvsBX.initialize(_name, "BadQualityvsBX",
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_m0to10000),0);
-	_cBadQuality_depth.initialize(_name, "BadQuality",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cBadQualityvsLS.initialize(_name,
+                              "BadQualityvsLS",
+                              new hcaldqm::quantity::LumiSection(_maxLS),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_m0to10000),
+                              0);
+  _cBadQualityvsBX.initialize(_name,
+                              "BadQualityvsBX",
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_m0to10000),
+                              0);
+  _cBadQuality_depth.initialize(_name,
+                                "BadQuality",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                0);
 
-	// FED-based plots
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-	
-		std::vector<uint32_t> vhashFEDsVME;
-		std::vector<uint32_t> vhashFEDsuTCA;
-	
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin();
-			it!=vFEDsVME.end(); ++it)
-		{
-			vhashFEDsVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-				constants::FIBER_VME_MIN, SPIGOT_MIN,
-				(*it)-constants::FED_VME_MIN).rawId());
-			_vhashFEDs.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-				constants::FIBER_VME_MIN, SPIGOT_MIN,
-				(*it)-constants::FED_VME_MIN).rawId());
-		}
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin();
-			it!=vFEDsuTCA.end(); ++it)
-		{
-	        std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
-			vhashFEDsuTCA.push_back(HcalElectronicsId(
-			    cspair.first, cspair.second, FIBER_uTCA_MIN1,
-			    FIBERCH_MIN, false).rawId());
-			_vhashFEDs.push_back(HcalElectronicsId(
-			    cspair.first, cspair.second, FIBER_uTCA_MIN1,
-			    FIBERCH_MIN, false).rawId());
-		}
-		_filter_FEDsVME.initialize(filter::fPreserver, 
-			hcaldqm::hashfunctions::fFED, vhashFEDsVME);
-		_filter_FEDsuTCA.initialize(filter::fPreserver,
-			hcaldqm::hashfunctions::fFED, vhashFEDsuTCA);
+  // FED-based plots
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
 
-		//	INITIALIZE FIRST
-		_cEvnMsm_ElectronicsVME.initialize(_name, "EvnMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cBcnMsm_ElectronicsVME.initialize(_name, "BcnMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOrnMsm_ElectronicsVME.initialize(_name, "OrnMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEvnMsm_ElectronicsuTCA.initialize(_name, "EvnMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cBcnMsm_ElectronicsuTCA.initialize(_name, "BcnMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOrnMsm_ElectronicsuTCA.initialize(_name, "OrnMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    std::vector<uint32_t> vhashFEDsVME;
+    std::vector<uint32_t> vhashFEDsuTCA;
 
-		//	Bad Quality
-		_cBadQuality_FEDVME.initialize(_name, "BadQuality",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cBadQuality_FEDuTCA.initialize(_name, "BadQuality",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it) {
+      vhashFEDsVME.push_back(
+          HcalElectronicsId(
+              constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, (*it) - constants::FED_VME_MIN)
+              .rawId());
+      _vhashFEDs.push_back(
+          HcalElectronicsId(
+              constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, (*it) - constants::FED_VME_MIN)
+              .rawId());
+    }
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+      vhashFEDsuTCA.push_back(
+          HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
+    _filter_FEDsVME.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vhashFEDsVME);
+    _filter_FEDsuTCA.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vhashFEDsuTCA);
 
-		//	Online only
-		if (_ptype==fOnline)
-		{
-			_xEvnMsmLS.initialize(hcaldqm::hashfunctions::fFED);
-			_xBcnMsmLS.initialize(hcaldqm::hashfunctions::fFED);
-			_xOrnMsmLS.initialize(hcaldqm::hashfunctions::fFED);
-			_xBadQLS.initialize(hcaldqm::hashfunctions::fFED);
-			_cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-				hcaldqm::hashfunctions::fFED,
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FlagQuantity(_vflags),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-			_cSummaryvsLS.initialize(_name, "SummaryvsLS",
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FEDQuantity(vFEDs),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-			//	FED Size vs LS
-			_cDataSizevsLS_FED.initialize(_name, "DataSizevsLS",
-				hcaldqm::hashfunctions::fFED,
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDataSize),0);
-		}
+    //	INITIALIZE FIRST
+    _cEvnMsm_ElectronicsVME.initialize(_name,
+                                       "EvnMsm",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+    _cBcnMsm_ElectronicsVME.initialize(_name,
+                                       "BcnMsm",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+    _cOrnMsm_ElectronicsVME.initialize(_name,
+                                       "OrnMsm",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+    _cEvnMsm_ElectronicsuTCA.initialize(_name,
+                                        "EvnMsm",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cBcnMsm_ElectronicsuTCA.initialize(_name,
+                                        "BcnMsm",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cOrnMsm_ElectronicsuTCA.initialize(_name,
+                                        "OrnMsm",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
 
-	}
+    //	Bad Quality
+    _cBadQuality_FEDVME.initialize(_name,
+                                   "BadQuality",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cBadQuality_FEDuTCA.initialize(_name,
+                                    "BadQuality",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                    new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
 
+    //	Online only
+    if (_ptype == fOnline) {
+      _xEvnMsmLS.initialize(hcaldqm::hashfunctions::fFED);
+      _xBcnMsmLS.initialize(hcaldqm::hashfunctions::fFED);
+      _xOrnMsmLS.initialize(hcaldqm::hashfunctions::fFED);
+      _xBadQLS.initialize(hcaldqm::hashfunctions::fFED);
+      _cSummaryvsLS_FED.initialize(_name,
+                                   "SummaryvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::FlagQuantity(_vflags),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                                   0);
+      _cSummaryvsLS.initialize(_name,
+                               "SummaryvsLS",
+                               new hcaldqm::quantity::LumiSection(_maxLS),
+                               new hcaldqm::quantity::FEDQuantity(vFEDs),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                               0);
+      //	FED Size vs LS
+      _cDataSizevsLS_FED.initialize(_name,
+                                    "DataSizevsLS",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDataSize),
+                                    0);
+    }
+  }
 
-	//	BOOK HISTOGRAMS
-	if (_ptype != fOffline) {
-		_cEvnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cBcnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOrnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cEvnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cBcnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOrnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  //	BOOK HISTOGRAMS
+  if (_ptype != fOffline) {
+    _cEvnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cBcnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOrnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cEvnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cBcnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOrnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
 
-		_cBadQuality_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cBadQuality_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
-	_cBadQuality_depth.book(ib, _emap, _subsystem);
-	_cBadQualityvsLS.book(ib, _subsystem);
-	_cBadQualityvsBX.book(ib, _subsystem);
+    _cBadQuality_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cBadQuality_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+  _cBadQuality_depth.book(ib, _emap, _subsystem);
+  _cBadQualityvsLS.book(ib, _subsystem);
+  _cBadQualityvsBX.book(ib, _subsystem);
 
-	// BOOK HISTOGRAMS to be used in ONLINE ONLY!
-	if (_ptype==fOnline)
-	{
-		_xEvnMsmLS.book(_emap);
-		_xBcnMsmLS.book(_emap);
-		_xOrnMsmLS.book(_emap);
-		_xBadQLS.book(_emap);
-		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		_cSummaryvsLS.book(ib, _subsystem);
-		_cDataSizevsLS_FED.book(ib, _emap, _subsystem);
-	}
+  // BOOK HISTOGRAMS to be used in ONLINE ONLY!
+  if (_ptype == fOnline) {
+    _xEvnMsmLS.book(_emap);
+    _xBcnMsmLS.book(_emap);
+    _xOrnMsmLS.book(_emap);
+    _xBadQLS.book(_emap);
+    _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    _cSummaryvsLS.book(ib, _subsystem);
+    _cDataSizevsLS_FED.book(ib, _emap, _subsystem);
+  }
 
-	//	FOR OFFLINE PROCESSING MARK THESE HISTOGRAMS AS LUMI BASED
-	if (_ptype==fOffline)
-	{
-		if (_ptype != fOffline) { // hidefed2crate
-			// Note that this is deliberately contradictory for the fed2crate fix, so it can be reversed if fed2crate is ever fixed properly,
-			_cEvnMsm_ElectronicsVME.setLumiFlag();
-			_cBcnMsm_ElectronicsVME.setLumiFlag();
-			_cEvnMsm_ElectronicsuTCA.setLumiFlag();
-			_cBcnMsm_ElectronicsuTCA.setLumiFlag();
-		}
-		_cBadQuality_depth.setLumiFlag();
-	}
+  //	FOR OFFLINE PROCESSING MARK THESE HISTOGRAMS AS LUMI BASED
+  if (_ptype == fOffline) {
+    if (_ptype != fOffline) {  // hidefed2crate
+      // Note that this is deliberately contradictory for the fed2crate fix, so it can be reversed if fed2crate is ever fixed properly,
+      _cEvnMsm_ElectronicsVME.setLumiFlag();
+      _cBcnMsm_ElectronicsVME.setLumiFlag();
+      _cEvnMsm_ElectronicsuTCA.setLumiFlag();
+      _cBcnMsm_ElectronicsuTCA.setLumiFlag();
+    }
+    _cBadQuality_depth.setLumiFlag();
+  }
 
-	//	initialize hash map
-	_ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
+  //	initialize hash map
+  _ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
 }
 
-/* virtual */ void RawTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	//	base reset
-	DQTask::_resetMonitors(uf);
+/* virtual */ void RawTask::_resetMonitors(hcaldqm::UpdateFreq uf) {
+  //	base reset
+  DQTask::_resetMonitors(uf);
 }
 
-/* virtual */ void RawTask::_process(edm::Event const& e,
-	edm::EventSetup const&)
-{
-	edm::Handle<FEDRawDataCollection> craw;
-	edm::Handle<HcalUnpackerReport> creport;
-	if (!e.getByToken(_tokFEDs, craw))
-		_logger.dqmthrow("Collection FEDRawDataCollection isn't available"+
-			_tagFEDs.label()+" " +_tagFEDs.instance());
-	if (!e.getByToken(_tokReport, creport))
-		_logger.dqmthrow("Collection HcalUnpackerReport isn't available"+
-			_tagReport.label()+" " +_tagReport.instance());
+/* virtual */ void RawTask::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<FEDRawDataCollection> craw;
+  edm::Handle<HcalUnpackerReport> creport;
+  if (!e.getByToken(_tokFEDs, craw))
+    _logger.dqmthrow("Collection FEDRawDataCollection isn't available" + _tagFEDs.label() + " " + _tagFEDs.instance());
+  if (!e.getByToken(_tokReport, creport))
+    _logger.dqmthrow("Collection HcalUnpackerReport isn't available" + _tagReport.label() + " " +
+                     _tagReport.instance());
 
-	//	extract some info
-	int bx = e.bunchCrossing();
+  //	extract some info
+  int bx = e.bunchCrossing();
 
-	/*
+  /*
 	 *	For Calibration/Abort Gap Processing
 	 *	check if the #channels taht are bad from the unpacker 
 	 *	is > 5000. If it is skip...
 	 */
-	if (_calibProcessing)
-	{
-		int nbadq = creport->badQualityDigis();
-		if (nbadq>=_thresh_calib_nbadq)
-			return;
-	}
-	
-	int nn = 0;
-	//	loop thru and fill the detIds with bad quality
-	//	NOTE: Calibration Channels are skipped!
-	//	TODO: Include for Online Calibration Channels marked as bad
-	//	a comment below is left on purpose!
-	//_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
-	for (std::vector<DetId>::const_iterator it=creport->bad_quality_begin();
-		it!=creport->bad_quality_end(); ++it)
-	{
-		//	skip non HCAL det ids
-		if (!HcalGenericDetId(*it).isHcalDetId())
-			continue;
+  if (_calibProcessing) {
+    int nbadq = creport->badQualityDigis();
+    if (nbadq >= _thresh_calib_nbadq)
+      return;
+  }
 
-		//	skip those that are of bad quality from conditions
-		//	Masked or Dead
-		if (_xQuality.exists(HcalDetId(*it)))
-		{
-			HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
-			if (cs.isBitSet(HcalChannelStatus::HcalCellMask) ||
-				cs.isBitSet(HcalChannelStatus::HcalCellDead))
-			continue;
-		}
+  int nn = 0;
+  //	loop thru and fill the detIds with bad quality
+  //	NOTE: Calibration Channels are skipped!
+  //	TODO: Include for Online Calibration Channels marked as bad
+  //	a comment below is left on purpose!
+  //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
+  for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
+    //	skip non HCAL det ids
+    if (!HcalGenericDetId(*it).isHcalDetId())
+      continue;
 
-		nn++;
-		HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(*it));
-		_cBadQuality_depth.fill(HcalDetId(*it));
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-			_xBadQLS.get(eid)++;
-		if (_ptype != fOffline) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				if (_filter_FEDsVME.filter(eid))
-					continue;
-				_cBadQuality_FEDVME.fill(eid);
-			}
-			else
-			{
-				if (_filter_FEDsuTCA.filter(eid))
-					continue;
-				_cBadQuality_FEDuTCA.fill(eid);
-			}
-		}
-	}
-	_cBadQualityvsLS.fill(_currentLS,nn);
-	_cBadQualityvsBX.fill(bx, nn);
+    //	skip those that are of bad quality from conditions
+    //	Masked or Dead
+    if (_xQuality.exists(HcalDetId(*it))) {
+      HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
+      if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+        continue;
+    }
 
-	if (_ptype != fOffline) { // hidefed2crate
-		for (int fed=FEDNumbering::MINHCALFEDID; fed<=FEDNumbering::MAXHCALuTCAFEDID; fed++) {
-			//	skip nonHCAL FEDs
-			if ((fed>FEDNumbering::MAXHCALFEDID &&
-				fed<FEDNumbering::MINHCALuTCAFEDID) || 
-				fed>FEDNumbering::MAXHCALuTCAFEDID)
-				continue;
-			FEDRawData const& raw = craw->FEDData(fed);
-			if (raw.size()<constants::RAW_EMPTY)
-				continue;
+    nn++;
+    HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(*it));
+    _cBadQuality_depth.fill(HcalDetId(*it));
+    //	ONLINE ONLY!
+    if (_ptype == fOnline)
+      _xBadQLS.get(eid)++;
+    if (_ptype != fOffline) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        if (_filter_FEDsVME.filter(eid))
+          continue;
+        _cBadQuality_FEDVME.fill(eid);
+      } else {
+        if (_filter_FEDsuTCA.filter(eid))
+          continue;
+        _cBadQuality_FEDuTCA.fill(eid);
+      }
+    }
+  }
+  _cBadQualityvsLS.fill(_currentLS, nn);
+  _cBadQualityvsBX.fill(bx, nn);
 
-			if (fed<=FEDNumbering::MAXHCALFEDID)	// VME
-			{
-				HcalDCCHeader const* hdcc = (HcalDCCHeader const*)(raw.data());
-				if (!hdcc)
-					continue;
+  if (_ptype != fOffline) {  // hidefed2crate
+    for (int fed = FEDNumbering::MINHCALFEDID; fed <= FEDNumbering::MAXHCALuTCAFEDID; fed++) {
+      //	skip nonHCAL FEDs
+      if ((fed > FEDNumbering::MAXHCALFEDID && fed < FEDNumbering::MINHCALuTCAFEDID) ||
+          fed > FEDNumbering::MAXHCALuTCAFEDID)
+        continue;
+      FEDRawData const& raw = craw->FEDData(fed);
+      if (raw.size() < constants::RAW_EMPTY)
+        continue;
 
-				uint32_t bcn = hdcc->getBunchId();
-				uint32_t orn = hdcc->getOrbitNumber() & 0x1F; // LS 5 bits only
-				uint32_t evn = hdcc->getDCCEventNumber();
-				int dccId = hdcc->getSourceId()-constants::FED_VME_MIN;
+      if (fed <= FEDNumbering::MAXHCALFEDID)  // VME
+      {
+        HcalDCCHeader const* hdcc = (HcalDCCHeader const*)(raw.data());
+        if (!hdcc)
+          continue;
 
-				/* online only */
-				if (_ptype==fOnline)
-				{
-					HcalElectronicsId eid = HcalElectronicsId(constants::FIBERCH_MIN,
-						constants::FIBER_VME_MIN, constants::SPIGOT_MIN, dccId);
-					if (_filter_FEDsVME.filter(eid))
-						continue;
-					_cDataSizevsLS_FED.fill(eid, _currentLS, double(raw.size())/1024.);
-				}
+        uint32_t bcn = hdcc->getBunchId();
+        uint32_t orn = hdcc->getOrbitNumber() & 0x1F;  // LS 5 bits only
+        uint32_t evn = hdcc->getDCCEventNumber();
+        int dccId = hdcc->getSourceId() - constants::FED_VME_MIN;
 
-				//	iterate over spigots
-				HcalHTRData htr;
-				for (int is=0; is<HcalDCCHeader::SPIGOT_COUNT; is++)
-				{
-					int r = hdcc->getSpigotData(is, htr, raw.size());
-					if (r!=0 || !htr.check())
-						continue;
-					HcalElectronicsId eid = HcalElectronicsId(
-						constants::FIBERCH_MIN, constants::FIBER_VME_MIN,
-						is, dccId);
-					if (_filter_FEDsVME.filter(eid))
-						continue;
+        /* online only */
+        if (_ptype == fOnline) {
+          HcalElectronicsId eid =
+              HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, constants::SPIGOT_MIN, dccId);
+          if (_filter_FEDsVME.filter(eid))
+            continue;
+          _cDataSizevsLS_FED.fill(eid, _currentLS, double(raw.size()) / 1024.);
+        }
 
-					uint32_t htr_evn = htr.getL1ANumber();
-					uint32_t htr_orn = htr.getOrbitNumber();
-					uint32_t htr_bcn = htr.getBunchNumber();
-					bool qevn = (htr_evn!=evn);
-					bool qbcn = (htr_bcn!=bcn);
-					bool qorn = (htr_orn!=orn);
-					if (qevn)
-					{
-						_cEvnMsm_ElectronicsVME.fill(eid);
+        //	iterate over spigots
+        HcalHTRData htr;
+        for (int is = 0; is < HcalDCCHeader::SPIGOT_COUNT; is++) {
+          int r = hdcc->getSpigotData(is, htr, raw.size());
+          if (r != 0 || !htr.check())
+            continue;
+          HcalElectronicsId eid = HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, is, dccId);
+          if (_filter_FEDsVME.filter(eid))
+            continue;
 
-						if (_ptype==fOnline && is<=constants::SPIGOT_MAX)
-							_xEvnMsmLS.get(eid)++;
-					}
-					if (qorn)
-					{
-						_cOrnMsm_ElectronicsVME.fill(eid);
+          uint32_t htr_evn = htr.getL1ANumber();
+          uint32_t htr_orn = htr.getOrbitNumber();
+          uint32_t htr_bcn = htr.getBunchNumber();
+          bool qevn = (htr_evn != evn);
+          bool qbcn = (htr_bcn != bcn);
+          bool qorn = (htr_orn != orn);
+          if (qevn) {
+            _cEvnMsm_ElectronicsVME.fill(eid);
 
-						if (_ptype==fOnline && is<=constants::SPIGOT_MAX)
-							_xOrnMsmLS.get(eid)++;
-					}
-					if (qbcn)
-					{
-						_cBcnMsm_ElectronicsVME.fill(eid);
+            if (_ptype == fOnline && is <= constants::SPIGOT_MAX)
+              _xEvnMsmLS.get(eid)++;
+          }
+          if (qorn) {
+            _cOrnMsm_ElectronicsVME.fill(eid);
 
-						if (_ptype==fOnline && is<=constants::SPIGOT_MAX)
-							_xBcnMsmLS.get(eid)++;
-					}
-				}
-			}
-			else	// uTCA
-			{
-				hcal::AMC13Header const* hamc13 = (hcal::AMC13Header const*)
-					raw.data();
-				if (!hamc13)
-					continue;
+            if (_ptype == fOnline && is <= constants::SPIGOT_MAX)
+              _xOrnMsmLS.get(eid)++;
+          }
+          if (qbcn) {
+            _cBcnMsm_ElectronicsVME.fill(eid);
 
-				/* online only */
-				if (_ptype==fOnline)
-				{
-	                std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(fed);
-					HcalElectronicsId eid = HcalElectronicsId(cspair.first,
-						cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false);
-					if (_filter_FEDsuTCA.filter(eid))
-						continue;
-					_cDataSizevsLS_FED.fill(eid, _currentLS, double(raw.size())/1024.);
-				}
+            if (_ptype == fOnline && is <= constants::SPIGOT_MAX)
+              _xBcnMsmLS.get(eid)++;
+          }
+        }
+      } else  // uTCA
+      {
+        hcal::AMC13Header const* hamc13 = (hcal::AMC13Header const*)raw.data();
+        if (!hamc13)
+          continue;
 
-				uint32_t bcn = hamc13->bunchId();
-				uint32_t orn = hamc13->orbitNumber() & 0xFFFF; // LS 16bits only
-				uint32_t evn = hamc13->l1aNumber();
-				int namc = hamc13->NAMC();
+        /* online only */
+        if (_ptype == fOnline) {
+          std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(fed);
+          HcalElectronicsId eid = HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false);
+          if (_filter_FEDsuTCA.filter(eid))
+            continue;
+          _cDataSizevsLS_FED.fill(eid, _currentLS, double(raw.size()) / 1024.);
+        }
 
-				for (int iamc=0; iamc<namc; iamc++)
-				{
-					int slot = hamc13->AMCSlot(iamc);
-					int crate = hamc13->AMCId(iamc)&0xFF;
-					HcalElectronicsId eid(crate, slot, FIBER_uTCA_MIN1,
-						FIBERCH_MIN, false);
-					if (_filter_FEDsuTCA.filter(eid))
-						continue;
-					HcalUHTRData uhtr(hamc13->AMCPayload(iamc),
-						hamc13->AMCSize(iamc));
+        uint32_t bcn = hamc13->bunchId();
+        uint32_t orn = hamc13->orbitNumber() & 0xFFFF;  // LS 16bits only
+        uint32_t evn = hamc13->l1aNumber();
+        int namc = hamc13->NAMC();
 
-					uint32_t uhtr_evn = uhtr.l1ANumber();
-					uint32_t uhtr_bcn = uhtr.bunchNumber();
-					uint32_t uhtr_orn = uhtr.orbitNumber();
-					bool qevn = (uhtr_evn!=evn);
-					bool qbcn = (uhtr_bcn!=bcn);
-					bool qorn = (uhtr_orn!=orn);
-					if (qevn)
-					{
-						_cEvnMsm_ElectronicsuTCA.fill(eid);
+        for (int iamc = 0; iamc < namc; iamc++) {
+          int slot = hamc13->AMCSlot(iamc);
+          int crate = hamc13->AMCId(iamc) & 0xFF;
+          HcalElectronicsId eid(crate, slot, FIBER_uTCA_MIN1, FIBERCH_MIN, false);
+          if (_filter_FEDsuTCA.filter(eid))
+            continue;
+          HcalUHTRData uhtr(hamc13->AMCPayload(iamc), hamc13->AMCSize(iamc));
 
-						if (_ptype==fOnline)
-							_xEvnMsmLS.get(eid)++;
-					}
-					if (qorn)
-					{
-						_cOrnMsm_ElectronicsuTCA.fill(eid);
+          uint32_t uhtr_evn = uhtr.l1ANumber();
+          uint32_t uhtr_bcn = uhtr.bunchNumber();
+          uint32_t uhtr_orn = uhtr.orbitNumber();
+          bool qevn = (uhtr_evn != evn);
+          bool qbcn = (uhtr_bcn != bcn);
+          bool qorn = (uhtr_orn != orn);
+          if (qevn) {
+            _cEvnMsm_ElectronicsuTCA.fill(eid);
 
-						if (_ptype==fOnline)
-							_xOrnMsmLS.get(eid)++;
-					}
-					if (qbcn)
-					{
-						_cBcnMsm_ElectronicsuTCA.fill(eid);
+            if (_ptype == fOnline)
+              _xEvnMsmLS.get(eid)++;
+          }
+          if (qorn) {
+            _cOrnMsm_ElectronicsuTCA.fill(eid);
 
-						if (_ptype==fOnline)
-							_xBcnMsmLS.get(eid)++;
-					}
-				}
-			}
-		}
-	}
+            if (_ptype == fOnline)
+              _xOrnMsmLS.get(eid)++;
+          }
+          if (qbcn) {
+            _cBcnMsm_ElectronicsuTCA.fill(eid);
+
+            if (_ptype == fOnline)
+              _xBcnMsmLS.get(eid)++;
+          }
+        }
+      }
+    }
+  }
 }
 
-/* virtual */ void RawTask::beginLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
+/* virtual */ void RawTask::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
 
-//	_cBadQualityvsLS.extendAxisRange(_currentLS);
+  //	_cBadQualityvsLS.extendAxisRange(_currentLS);
 
-	//	ONLINE ONLY!
-	if (_ptype!=fOnline)
-		return;
-//	_cSummaryvsLS_FED.extendAxisRange(_currentLS);
-//	_cSummaryvsLS.extendAxisRange(_currentLS);
-	
+  //	ONLINE ONLY!
+  if (_ptype != fOnline)
+    return;
+  //	_cSummaryvsLS_FED.extendAxisRange(_currentLS);
+  //	_cSummaryvsLS.extendAxisRange(_currentLS);
 }
 
-/* virtual */ void RawTask::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	if (_ptype!=fOnline)
-		return;
+/* virtual */ void RawTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  if (_ptype != fOnline)
+    return;
 
-	//	
-	//	GENERATE STATUS ONLY FOR ONLINE!
-	//
-	for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-		it!=_vhashFEDs.end(); ++it)
-	{
-		flag::Flag fSum("RAW");
-		HcalElectronicsId eid = HcalElectronicsId(*it);
+  //
+  //	GENERATE STATUS ONLY FOR ONLINE!
+  //
+  for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+    flag::Flag fSum("RAW");
+    HcalElectronicsId eid = HcalElectronicsId(*it);
 
-		std::vector<uint32_t>::const_iterator cit=std::find(
-			_vcdaqEids.begin(), _vcdaqEids.end(), *it);
-		if (cit==_vcdaqEids.end())
-		{
-			// not @cDAQ
-			for (uint32_t iflag=0; iflag<_vflags.size(); iflag++)
-				_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-					int(flag::fNCDAQ));
-			_cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-			continue;
-		}
+    std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
+    if (cit == _vcdaqEids.end()) {
+      // not @cDAQ
+      for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
+        _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
+      _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+      continue;
+    }
 
-		//	FED is @cDAQ
-		if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) ||
-			hcaldqm::utilities::isFEDHO(eid))
-		{
-			if (_xEvnMsmLS.get(eid)>0)
-				_vflags[fEvnMsm]._state = flag::fBAD;
-			else
-				_vflags[fEvnMsm]._state = flag::fGOOD;
-			if (_xBcnMsmLS.get(eid)>0)
-				_vflags[fBcnMsm]._state = flag::fBAD;
-			else
-				_vflags[fBcnMsm]._state = flag::fGOOD;
-			if (_xOrnMsmLS.get(eid)>0)
-				_vflags[fOrnMsm]._state = flag::fBAD;
-			else
-				_vflags[fOrnMsm]._state = flag::fGOOD;
-			if (double(_xBadQLS.get(eid))>double(12*_evsPerLS))
-				_vflags[fBadQ]._state = flag::fBAD;
-			else if (_xBadQLS.get(eid)>0)
-				_vflags[fBadQ]._state = flag::fPROBLEMATIC;
-			else
-				_vflags[fBadQ]._state = flag::fGOOD;
-		}
+    //	FED is @cDAQ
+    if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) || hcaldqm::utilities::isFEDHO(eid)) {
+      if (_xEvnMsmLS.get(eid) > 0)
+        _vflags[fEvnMsm]._state = flag::fBAD;
+      else
+        _vflags[fEvnMsm]._state = flag::fGOOD;
+      if (_xBcnMsmLS.get(eid) > 0)
+        _vflags[fBcnMsm]._state = flag::fBAD;
+      else
+        _vflags[fBcnMsm]._state = flag::fGOOD;
+      if (_xOrnMsmLS.get(eid) > 0)
+        _vflags[fOrnMsm]._state = flag::fBAD;
+      else
+        _vflags[fOrnMsm]._state = flag::fGOOD;
+      if (double(_xBadQLS.get(eid)) > double(12 * _evsPerLS))
+        _vflags[fBadQ]._state = flag::fBAD;
+      else if (_xBadQLS.get(eid) > 0)
+        _vflags[fBadQ]._state = flag::fPROBLEMATIC;
+      else
+        _vflags[fBadQ]._state = flag::fGOOD;
+    }
 
-		int iflag=0;
-		//	iterate over all flags:
-		//	- sum them all up in summary flag for this FED
-		//	- reset each flag right after using it
-		for (std::vector<flag::Flag>::iterator ft=_vflags.begin();
-			ft!=_vflags.end(); ++ft)
-		{
-			_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-				ft->_state);
-			fSum+=(*ft);
-			iflag++;
+    int iflag = 0;
+    //	iterate over all flags:
+    //	- sum them all up in summary flag for this FED
+    //	- reset each flag right after using it
+    for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
+      _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
+      fSum += (*ft);
+      iflag++;
 
-			//	this is the MUST! We don't keep flags per FED, reset
-			//	each one of them after using
-			ft->reset();
-		}
-		_cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
-	}
+      //	this is the MUST! We don't keep flags per FED, reset
+      //	each one of them after using
+      ft->reset();
+    }
+    _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
+  }
 
-	//	reset...
-	_xOrnMsmLS.reset(); _xEvnMsmLS.reset(); _xBcnMsmLS.reset(); _xBadQLS.reset();
+  //	reset...
+  _xOrnMsmLS.reset();
+  _xEvnMsmLS.reset();
+  _xBcnMsmLS.reset();
+  _xBadQLS.reset();
 
-	//	in the end always do the DQTask::endLumi
-	DQTask::endLuminosityBlock(lb, es);
+  //	in the end always do the DQTask::endLumi
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(RawTask);
-

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -5,939 +5,936 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
-RecHitTask::RecHitTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hbhereco"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("horeco"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hfreco"));
-	_tagPreHF = ps.getUntrackedParameter<edm::InputTag>("tagPreHF",
-		edm::InputTag(""));
-	_hfPreRecHitsAvailable = ps.getUntrackedParameter<bool>("hfPreRecHitsAvailable", false);
+RecHitTask::RecHitTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hbhereco"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("horeco"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hfreco"));
+  _tagPreHF = ps.getUntrackedParameter<edm::InputTag>("tagPreHF", edm::InputTag(""));
+  _hfPreRecHitsAvailable = ps.getUntrackedParameter<bool>("hfPreRecHitsAvailable", false);
 
-	_tokHBHE = consumes<HBHERecHitCollection>(_tagHBHE);
-	_tokHO = consumes<HORecHitCollection>(_tagHO);
-	_tokHF = consumes<HFRecHitCollection>(_tagHF);
-	_tokPreHF = consumes<HFPreRecHitCollection>(_tagPreHF);
+  _tokHBHE = consumes<HBHERecHitCollection>(_tagHBHE);
+  _tokHO = consumes<HORecHitCollection>(_tagHO);
+  _tokHF = consumes<HFRecHitCollection>(_tagHF);
+  _tokPreHF = consumes<HFPreRecHitCollection>(_tagPreHF);
 
-	_cutE_HBHE = ps.getUntrackedParameter<double>("cutE_HBHE", 5);
-	_cutE_HO = ps.getUntrackedParameter<double>("cutE_HO", 5);
-	_cutE_HF = ps.getUntrackedParameter<double>("cutE_HF", 5);
-	_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
+  _cutE_HBHE = ps.getUntrackedParameter<double>("cutE_HBHE", 5);
+  _cutE_HO = ps.getUntrackedParameter<double>("cutE_HO", 5);
+  _cutE_HF = ps.getUntrackedParameter<double>("cutE_HF", 5);
+  _thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
 
-	//	order must be the same as in RecoFlag enum
-	_vflags.resize(nRecoFlag);
-	_vflags[fUni]=flag::Flag("UniSlotHF");
-	_vflags[fTCDS]=flag::Flag("TCDS");
-	_vflags[fUnknownIds] = flag::Flag("UnknownIds");
+  //	order must be the same as in RecoFlag enum
+  _vflags.resize(nRecoFlag);
+  _vflags[fUni] = flag::Flag("UniSlotHF");
+  _vflags[fTCDS] = flag::Flag("TCDS");
+  _vflags[fUnknownIds] = flag::Flag("UnknownIds");
 }
 
-/* virtual */ void RecHitTask::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib,r,es);
+/* virtual */ void RecHitTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
 
-	std::vector<uint32_t> vVME;
-	std::vector<uint32_t> vuTCA;
-	vVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN, 
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vuTCA);
-	std::vector<uint32_t> vhashHF; 
-	vhashHF.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
+  std::vector<uint32_t> vVME;
+  std::vector<uint32_t> vuTCA;
+  vVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vuTCA);
+  std::vector<uint32_t> vhashHF;
+  vhashHF.push_back(
+      hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29, 1, 1)));
 
-	_filter_HF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet, vhashHF);
+  _filter_HF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet, vhashHF);
 
-	//	INITIALIZE FIRST
-	//	Energy
-	_cEnergy_Subdet.initialize(_name, "Energy", hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cEnergy_depth.initialize(_name, "Energy", hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy, true),0);
+  //	INITIALIZE FIRST
+  //	Energy
+  _cEnergy_Subdet.initialize(_name,
+                             "Energy",
+                             hcaldqm::hashfunctions::fSubdet,
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                             0);
+  _cEnergy_depth.initialize(_name,
+                            "Energy",
+                            hcaldqm::hashfunctions::fdepth,
+                            new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                            new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy, true),
+                            0);
 
-	//	Timing
-	_cTimingCut_SubdetPM.initialize(_name, "TimingCut", 
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cTimingvsEnergy_SubdetPM.initialize(_name, "TimingvsEnergy",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy, true),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+  //	Timing
+  _cTimingCut_SubdetPM.initialize(_name,
+                                  "TimingCut",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                  0);
+  _cTimingvsEnergy_SubdetPM.initialize(_name,
+                                       "TimingvsEnergy",
+                                       hcaldqm::hashfunctions::fSubdetPM,
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy, true),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                       0);
 
-	_cTimingCut_HBHEPartition.initialize(_name, "TimingCut",
-		hcaldqm::hashfunctions::fHBHEPartition,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cTimingCut_depth.initialize(_name, "TimingCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-	_cTimingCutvsLS_SubdetPM.initialize(_name, "TimingCutvsLS",
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
+  _cTimingCut_HBHEPartition.initialize(_name,
+                                       "TimingCut",
+                                       hcaldqm::hashfunctions::fHBHEPartition,
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+  _cTimingCut_depth.initialize(_name,
+                               "TimingCut",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                               0);
+  _cTimingCutvsLS_SubdetPM.initialize(_name,
+                                      "TimingCutvsLS",
+                                      hcaldqm::hashfunctions::fSubdetPM,
+                                      new hcaldqm::quantity::LumiSection(_maxLS),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                      0);
 
-	//	Occupancy
-	_cOccupancy_depth.initialize(_name, "Occupancy",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //	Occupancy
+  _cOccupancy_depth.initialize(_name,
+                               "Occupancy",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
 
-	_cOccupancyvsLS_Subdet.initialize(_name, "OccupancyvsLS",
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
+  _cOccupancyvsLS_Subdet.initialize(_name,
+                                    "OccupancyvsLS",
+                                    hcaldqm::hashfunctions::fSubdet,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                    0);
 
-	_cOccupancyCut_depth.initialize(_name, "OccupancyCut",
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cOccupancyCut_depth.initialize(_name,
+                                  "OccupancyCut",
+                                  hcaldqm::hashfunctions::fdepth,
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                  new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
 
-	if (_hfPreRecHitsAvailable) {
-		_cDAAsymmetryVsCharge_SubdetPM.initialize(_name, "ChargeVsAsymmetry", 
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDualAnodeAsymmetry), 
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cDAAsymmetryMean_cut_depth.initialize(_name, "AsymmetryMean",
-			hcaldqm::hashfunctions::fdepth,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDualAnodeAsymmetry),0);
-		_cDAAsymmetry_cut_SubdetPM.initialize(_name, "Asymmetry",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDualAnodeAsymmetry),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN), 0);
-	}
+  if (_hfPreRecHitsAvailable) {
+    _cDAAsymmetryVsCharge_SubdetPM.initialize(
+        _name,
+        "ChargeVsAsymmetry",
+        hcaldqm::hashfunctions::fSubdetPM,
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDualAnodeAsymmetry),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+        0);
+    _cDAAsymmetryMean_cut_depth.initialize(_name,
+                                           "AsymmetryMean",
+                                           hcaldqm::hashfunctions::fdepth,
+                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDualAnodeAsymmetry),
+                                           0);
+    _cDAAsymmetry_cut_SubdetPM.initialize(_name,
+                                          "Asymmetry",
+                                          hcaldqm::hashfunctions::fSubdetPM,
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDualAnodeAsymmetry),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+  }
 
-	//	INITIALIZE HISTOGRAMS to be used only in Online
-	if (_ptype==fOnline)
-	{
-		_cEnergyvsieta_Subdet.initialize(_name, "Energyvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),0);
-		_cEnergyvsiphi_SubdetPM.initialize(_name, "Energyvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),0);
-		_cEnergyvsLS_SubdetPM.initialize(_name, "EnergyvsLS",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),0);
-		_cEnergyvsBX_SubdetPM.initialize(_name, "EnergyvsBX",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),0);
-		_cTimingCutvsieta_Subdet.initialize(_name, "TimingCutvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cTimingCutvsiphi_SubdetPM.initialize(_name, "TimingCutvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cTimingCutvsBX_SubdetPM.initialize(_name, "TimingCutvsBX",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cOccupancyvsiphi_SubdetPM.initialize(_name, "Occupancyvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyvsieta_Subdet.initialize(_name, "Occupancyvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsiphi_SubdetPM.initialize(_name, "OccupancyCutvsiphi",
-			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsieta_Subdet.initialize(_name, "OccupancyCutvsieta",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsBX_Subdet.initialize(_name, "OccupancyCutvsBX",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsiphivsLS_SubdetPM.initialize(_name,
-			"OccupancyCutvsiphivsLS", hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutvsLS_Subdet.initialize(_name, "OccupancyCutvsLS",
-			hcaldqm::hashfunctions::fSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),0);
-	}
+  //	INITIALIZE HISTOGRAMS to be used only in Online
+  if (_ptype == fOnline) {
+    _cEnergyvsieta_Subdet.initialize(_name,
+                                     "Energyvsieta",
+                                     hcaldqm::hashfunctions::fSubdet,
+                                     new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),
+                                     0);
+    _cEnergyvsiphi_SubdetPM.initialize(_name,
+                                       "Energyvsiphi",
+                                       hcaldqm::hashfunctions::fSubdetPM,
+                                       new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),
+                                       0);
+    _cEnergyvsLS_SubdetPM.initialize(_name,
+                                     "EnergyvsLS",
+                                     hcaldqm::hashfunctions::fSubdetPM,
+                                     new hcaldqm::quantity::LumiSection(_maxLS),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),
+                                     0);
+    _cEnergyvsBX_SubdetPM.initialize(_name,
+                                     "EnergyvsBX",
+                                     hcaldqm::hashfunctions::fSubdetPM,
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEnergy_1TeV),
+                                     0);
+    _cTimingCutvsieta_Subdet.initialize(_name,
+                                        "TimingCutvsieta",
+                                        hcaldqm::hashfunctions::fSubdet,
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                        0);
+    _cTimingCutvsiphi_SubdetPM.initialize(_name,
+                                          "TimingCutvsiphi",
+                                          hcaldqm::hashfunctions::fSubdetPM,
+                                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                          0);
+    _cTimingCutvsBX_SubdetPM.initialize(_name,
+                                        "TimingCutvsBX",
+                                        hcaldqm::hashfunctions::fSubdetPM,
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                        0);
+    _cOccupancyvsiphi_SubdetPM.initialize(_name,
+                                          "Occupancyvsiphi",
+                                          hcaldqm::hashfunctions::fSubdetPM,
+                                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+    _cOccupancyvsieta_Subdet.initialize(_name,
+                                        "Occupancyvsieta",
+                                        hcaldqm::hashfunctions::fSubdet,
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cOccupancyCutvsiphi_SubdetPM.initialize(_name,
+                                             "OccupancyCutvsiphi",
+                                             hcaldqm::hashfunctions::fSubdetPM,
+                                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cOccupancyCutvsieta_Subdet.initialize(_name,
+                                           "OccupancyCutvsieta",
+                                           hcaldqm::hashfunctions::fSubdet,
+                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                           0);
+    _cOccupancyCutvsBX_Subdet.initialize(_name,
+                                         "OccupancyCutvsBX",
+                                         hcaldqm::hashfunctions::fSubdet,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cOccupancyCutvsiphivsLS_SubdetPM.initialize(_name,
+                                                 "OccupancyCutvsiphivsLS",
+                                                 hcaldqm::hashfunctions::fSubdetPM,
+                                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                                 0);
+    _cOccupancyCutvsLS_Subdet.initialize(_name,
+                                         "OccupancyCutvsLS",
+                                         hcaldqm::hashfunctions::fSubdet,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                         0);
+  }
 
-	// FED-based plots
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-	
-		//	push the rawIds of each fed into the vector
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin();
-			it!=vFEDsVME.end(); ++it)
-			_vhashFEDs.push_back(HcalElectronicsId(
-				FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it)-FED_VME_MIN).rawId());
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin(); 
-			it!=vFEDsuTCA.end(); ++it)
-		{
-			std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
-			_vhashFEDs.push_back(HcalElectronicsId(
-				cspair.first, cspair.second, FIBER_uTCA_MIN1,
-				FIBERCH_MIN, false).rawId());
-		}
-	
-		_cTimingCut_FEDVME.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cTimingCut_FEDuTCA.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cTimingCutvsLS_FED.initialize(_name, "TimingCutvsLS",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cTimingCut_ElectronicsVME.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-		_cTimingCut_ElectronicsuTCA.initialize(_name, "TimingCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),0);
-	
-		_cOccupancy_FEDVME.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_FEDuTCA.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_ElectronicsVME.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancy_ElectronicsuTCA.initialize(_name, "Occupancy",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	
-		_cOccupancyCut_FEDVME.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_FEDuTCA.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_ElectronicsVME.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCut_ElectronicsuTCA.initialize(_name, "OccupancyCut",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		if (_ptype == fOnline) {
-			_cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-				hcaldqm::hashfunctions::fFED,
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FlagQuantity(_vflags),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-			_cSummaryvsLS.initialize(_name, "SummaryvsLS",
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FEDQuantity(vFEDs),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-			
-			_xUniHF.initialize(hcaldqm::hashfunctions::fFEDSlot);
-			_xUni.initialize(hcaldqm::hashfunctions::fFED);
-		}
-	}
+  // FED-based plots
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
 
-	//	BOOK HISTOGRAMS
-	char cutstr[200];
-	sprintf(cutstr, "_EHBHE%dHO%dHF%d", int(_cutE_HBHE),
-		int(_cutE_HO), int(_cutE_HF));
-	char cutstr2[200];
-	sprintf(cutstr2, "_EHF%d", int(_cutE_HF));
+    //	push the rawIds of each fed into the vector
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
+      _vhashFEDs.push_back(HcalElectronicsId(FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
 
-	//	Energy
-	_cEnergy_Subdet.book(ib, _emap, _subsystem);
-	_cEnergy_depth.book(ib, _emap, _subsystem);
+    _cTimingCut_FEDVME.initialize(_name,
+                                  "TimingCut",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                  0);
+    _cTimingCut_FEDuTCA.initialize(_name,
+                                   "TimingCut",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                   0);
+    _cTimingCutvsLS_FED.initialize(_name,
+                                   "TimingCutvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                   0);
+    _cTimingCut_ElectronicsVME.initialize(_name,
+                                          "TimingCut",
+                                          hcaldqm::hashfunctions::fElectronics,
+                                          new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                          new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                          0);
+    _cTimingCut_ElectronicsuTCA.initialize(_name,
+                                           "TimingCut",
+                                           hcaldqm::hashfunctions::fElectronics,
+                                           new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                           new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_ns),
+                                           0);
 
-	//	Timing
-	_cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
-	_cTimingvsEnergy_SubdetPM.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cTimingCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cTimingCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cTimingCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
-	_cTimingCut_HBHEPartition.book(ib, _emap, _subsystem);
-	_cTimingCut_depth.book(ib, _emap, _subsystem);
-	_cTimingCutvsLS_SubdetPM.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cTimingCutvsLS_FED.book(ib, _emap, _subsystem);
-	}
+    _cOccupancy_FEDVME.initialize(_name,
+                                  "Occupancy",
+                                  hcaldqm::hashfunctions::fFED,
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                  new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                  0);
+    _cOccupancy_FEDuTCA.initialize(_name,
+                                   "Occupancy",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                   new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                   0);
+    _cOccupancy_ElectronicsVME.initialize(_name,
+                                          "Occupancy",
+                                          hcaldqm::hashfunctions::fElectronics,
+                                          new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                          new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+    _cOccupancy_ElectronicsuTCA.initialize(_name,
+                                           "Occupancy",
+                                           hcaldqm::hashfunctions::fElectronics,
+                                           new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                           new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                           0);
 
-	//	Occupancy
-	_cOccupancy_depth.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cOccupancy_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancy_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancy_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancy_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
-	_cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
-	_cOccupancyCut_depth.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cOccupancyCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
+    _cOccupancyCut_FEDVME.initialize(_name,
+                                     "OccupancyCut",
+                                     hcaldqm::hashfunctions::fFED,
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                     new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
+    _cOccupancyCut_FEDuTCA.initialize(_name,
+                                      "OccupancyCut",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cOccupancyCut_ElectronicsVME.initialize(_name,
+                                             "OccupancyCut",
+                                             hcaldqm::hashfunctions::fElectronics,
+                                             new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                             new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cOccupancyCut_ElectronicsuTCA.initialize(_name,
+                                              "OccupancyCut",
+                                              hcaldqm::hashfunctions::fElectronics,
+                                              new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                              0);
+    if (_ptype == fOnline) {
+      _cSummaryvsLS_FED.initialize(_name,
+                                   "SummaryvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::FlagQuantity(_vflags),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                                   0);
+      _cSummaryvsLS.initialize(_name,
+                               "SummaryvsLS",
+                               new hcaldqm::quantity::LumiSection(_maxLS),
+                               new hcaldqm::quantity::FEDQuantity(vFEDs),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                               0);
 
-	if (_hfPreRecHitsAvailable) {
-		_cDAAsymmetryVsCharge_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
-		_cDAAsymmetryMean_cut_depth.book(ib, _emap, _filter_HF, _subsystem);
-		_cDAAsymmetry_cut_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
-	}
+      _xUniHF.initialize(hcaldqm::hashfunctions::fFEDSlot);
+      _xUni.initialize(hcaldqm::hashfunctions::fFED);
+    }
+  }
 
-	//	BOOK HISTOGRAMS to be used only in Online
-	if (_ptype==fOnline)
-	{
-		_cEnergyvsLS_SubdetPM.book(ib, _emap, _subsystem);
-		_cEnergyvsieta_Subdet.book(ib, _emap, _subsystem);
-		_cEnergyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cEnergyvsBX_SubdetPM.book(ib, _emap, _subsystem);
-		_cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
-		_cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cTimingCutvsBX_SubdetPM.book(ib, _emap, _subsystem);
-		_cOccupancyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cOccupancyvsieta_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsBX_Subdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
-		_cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
-		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		_cSummaryvsLS.book(ib, _subsystem);
+  //	BOOK HISTOGRAMS
+  char cutstr[200];
+  sprintf(cutstr, "_EHBHE%dHO%dHF%d", int(_cutE_HBHE), int(_cutE_HO), int(_cutE_HF));
+  char cutstr2[200];
+  sprintf(cutstr2, "_EHF%d", int(_cutE_HF));
 
-		std::vector<uint32_t> vhashFEDHF;
-		vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		HashFilter filter_FEDHF;
-		filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED,
-			vhashFEDHF);
+  //	Energy
+  _cEnergy_Subdet.book(ib, _emap, _subsystem);
+  _cEnergy_depth.book(ib, _emap, _subsystem);
 
-		_gids = _emap->allPrecisionId();
-		if (_ptype != fOffline) { // hidefed2crate
-			_xUniHF.book(_emap, filter_FEDHF);
-			_xUni.book(_emap);
-		}
-	}
+  //	Timing
+  _cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
+  _cTimingvsEnergy_SubdetPM.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cTimingCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cTimingCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cTimingCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+  _cTimingCut_HBHEPartition.book(ib, _emap, _subsystem);
+  _cTimingCut_depth.book(ib, _emap, _subsystem);
+  _cTimingCutvsLS_SubdetPM.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cTimingCutvsLS_FED.book(ib, _emap, _subsystem);
+  }
 
-	//	initialize hash map
-	_ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
+  //	Occupancy
+  _cOccupancy_depth.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cOccupancy_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancy_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancy_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancy_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+  _cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cOccupancyCut_depth.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cOccupancyCut_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCut_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCut_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCut_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
 
-	//	book some mes...
-	ib.setCurrentFolder(_subsystem+"/"+_name);
-	meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds",
-		1, 0, 1);
-	_unknownIdsPresent = false;
-	meUnknownIds1LS->setLumiFlag();
+  if (_hfPreRecHitsAvailable) {
+    _cDAAsymmetryVsCharge_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
+    _cDAAsymmetryMean_cut_depth.book(ib, _emap, _filter_HF, _subsystem);
+    _cDAAsymmetry_cut_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
+  }
+
+  //	BOOK HISTOGRAMS to be used only in Online
+  if (_ptype == fOnline) {
+    _cEnergyvsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cEnergyvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cEnergyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cEnergyvsBX_SubdetPM.book(ib, _emap, _subsystem);
+    _cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cTimingCutvsBX_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsBX_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
+    _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    _cSummaryvsLS.book(ib, _subsystem);
+
+    std::vector<uint32_t> vhashFEDHF;
+    vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    HashFilter filter_FEDHF;
+    filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vhashFEDHF);
+
+    _gids = _emap->allPrecisionId();
+    if (_ptype != fOffline) {  // hidefed2crate
+      _xUniHF.book(_emap, filter_FEDHF);
+      _xUni.book(_emap);
+    }
+  }
+
+  //	initialize hash map
+  _ehashmap.initialize(_emap, hcaldqm::electronicsmap::fD2EHashMap);
+
+  //	book some mes...
+  ib.setCurrentFolder(_subsystem + "/" + _name);
+  meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds", 1, 0, 1);
+  _unknownIdsPresent = false;
+  meUnknownIds1LS->setLumiFlag();
 }
 
-/* virtual */ void RecHitTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	switch(uf)
-	{
-		case hcaldqm::f1LS:
-			_unknownIdsPresent = false;
-			break;
-		default:
-			break;
-	}
+/* virtual */ void RecHitTask::_resetMonitors(hcaldqm::UpdateFreq uf) {
+  switch (uf) {
+    case hcaldqm::f1LS:
+      _unknownIdsPresent = false;
+      break;
+    default:
+      break;
+  }
 
-	DQTask::_resetMonitors(uf);
+  DQTask::_resetMonitors(uf);
 }
 
-/* virtual */ void RecHitTask::_process(edm::Event const& e,
-	edm::EventSetup const&)
-{
-	edm::Handle<HBHERecHitCollection> chbhe;
-	edm::Handle<HORecHitCollection> cho;
-	edm::Handle<HFRecHitCollection> chf;
+/* virtual */ void RecHitTask::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<HBHERecHitCollection> chbhe;
+  edm::Handle<HORecHitCollection> cho;
+  edm::Handle<HFRecHitCollection> chf;
 
-	if (!(e.getByToken(_tokHBHE, chbhe)))
-		_logger.dqmthrow("Collection HBHERecHitCollection not available "
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!(e.getByToken(_tokHO, cho)))
-		_logger.dqmthrow("Collection HORecHitCollection not available "
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!(e.getByToken(_tokHF, chf)))
-		_logger.dqmthrow("Collection HFRecHitCollection not available "
-			+ _tagHF.label() + " " + _tagHF.instance());
+  if (!(e.getByToken(_tokHBHE, chbhe)))
+    _logger.dqmthrow("Collection HBHERecHitCollection not available " + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!(e.getByToken(_tokHO, cho)))
+    _logger.dqmthrow("Collection HORecHitCollection not available " + _tagHO.label() + " " + _tagHO.instance());
+  if (!(e.getByToken(_tokHF, chf)))
+    _logger.dqmthrow("Collection HFRecHitCollection not available " + _tagHF.label() + " " + _tagHF.instance());
 
-	edm::Handle<HFPreRecHitCollection> cprehf;
-	if (_hfPreRecHitsAvailable) {
-		if (!(e.getByToken(_tokPreHF, cprehf)))
-			_logger.dqmthrow("Collection HFPreRecHitCollection not available "
-				+ _tagPreHF.label() + " " + _tagPreHF.instance());
-	}
+  edm::Handle<HFPreRecHitCollection> cprehf;
+  if (_hfPreRecHitsAvailable) {
+    if (!(e.getByToken(_tokPreHF, cprehf)))
+      _logger.dqmthrow("Collection HFPreRecHitCollection not available " + _tagPreHF.label() + " " +
+                       _tagPreHF.instance());
+  }
 
-	//	extract some info per event
-	int bx = e.bunchCrossing();
+  //	extract some info per event
+  int bx = e.bunchCrossing();
 
-	//  To fill histograms outside of the loop, you need to determine if there were
-	//  any valid det ids first
-	uint32_t rawidValid = 0;
-	uint32_t rawidHBValid = 0;
-	uint32_t rawidHEValid = 0;
+  //  To fill histograms outside of the loop, you need to determine if there were
+  //  any valid det ids first
+  uint32_t rawidValid = 0;
+  uint32_t rawidHBValid = 0;
+  uint32_t rawidHEValid = 0;
 
-	double ehbm = 0; double ehbp = 0;
-	double ehem = 0; double ehep = 0;
-	int nChsHB = 0; int nChsHE = 0;
-	int nChsHBCut = 0; int nChsHECut = 0;
-	for (HBHERecHitCollection::const_iterator it=chbhe->begin();
-		it!=chbhe->end(); ++it)
-	{
-		double energy = it->energy();
-		double timing = it->time();
+  double ehbm = 0;
+  double ehbp = 0;
+  double ehem = 0;
+  double ehep = 0;
+  int nChsHB = 0;
+  int nChsHE = 0;
+  int nChsHBCut = 0;
+  int nChsHECut = 0;
+  for (HBHERecHitCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    double energy = it->energy();
+    double timing = it->time();
 
-		//	Explicit check on the DetIds present in the Collection
-		HcalDetId did = it->id();
-		uint32_t rawid = _ehashmap.lookup(did);
-        /*
+    //	Explicit check on the DetIds present in the Collection
+    HcalDetId did = it->id();
+    uint32_t rawid = _ehashmap.lookup(did);
+    /*
          * Needs to be removed as DetIds that belong to the HEP17 after combination
          * are not present in the emap
          * Removed until further notice!
          *
          */
-		//if (rawid==0)
-		//{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-        
-		HcalElectronicsId const& eid(rawid);
-		rawidValid = did.rawId();
-		if (did.subdet()==HcalBarrel)
-			rawidHBValid = did.rawId();
-		else if (did.subdet()==HcalEndcap)
-			rawidHEValid = did.rawId();
+    //if (rawid==0)
+    //{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
 
-		_cEnergy_Subdet.fill(did, energy);
-		_cTimingvsEnergy_SubdetPM.fill(did, energy, timing);
-		_cOccupancy_depth.fill(did);
-		did.subdet()==HcalBarrel?did.ieta()>0?ehbp+=energy:ehbm+=energy:
-			did.ieta()>0?ehep+=energy:ehem+=energy;
+    HcalElectronicsId const& eid(rawid);
+    rawidValid = did.rawId();
+    if (did.subdet() == HcalBarrel)
+      rawidHBValid = did.rawId();
+    else if (did.subdet() == HcalEndcap)
+      rawidHEValid = did.rawId();
 
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyvsiphi_SubdetPM.fill(did);
-			_cOccupancyvsieta_Subdet.fill(did);
-		}
-		//	^^^ONLINE ONLY!
-		//	
-		if (_ptype != fOffline) { // hidefed2crate
-			//	Also, for these electronics plots, require that the channel was found in the emap.
-			if (rawid != 0) {
-				if (eid.isVMEid())
-				{
-					_cOccupancy_FEDVME.fill(eid);
-					_cOccupancy_ElectronicsVME.fill(eid);
-				} else if (eid.isUTCAid()) {
-					_cOccupancy_FEDuTCA.fill(eid);
-					_cOccupancy_ElectronicsuTCA.fill(eid);
-				}
-			}
-		}
+    _cEnergy_Subdet.fill(did, energy);
+    _cTimingvsEnergy_SubdetPM.fill(did, energy, timing);
+    _cOccupancy_depth.fill(did);
+    did.subdet() == HcalBarrel ? did.ieta() > 0 ? ehbp += energy : ehbm += energy
+                               : did.ieta() > 0 ? ehep += energy : ehem += energy;
 
-		if (energy>_cutE_HBHE)
-		{
-			//	ONLINE ONLY!
-			if (_ptype==fOnline)
-			{
-				_cEnergyvsLS_SubdetPM.fill(did, _currentLS, energy);
-				_cEnergyvsBX_SubdetPM.fill(did, bx, energy);
-				_cEnergyvsieta_Subdet.fill(did, energy);
-				_cEnergyvsiphi_SubdetPM.fill(did, energy);
-				_cTimingCutvsieta_Subdet.fill(did, timing);
-				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-				_cTimingCutvsBX_SubdetPM.fill(did, bx, timing);
-				_cOccupancyCutvsiphi_SubdetPM.fill(did);
-				_cOccupancyCutvsieta_Subdet.fill(did);
-				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-			}
-			//	^^^ONLINE ONLY!
-			_cEnergy_depth.fill(did, energy);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCut_HBHEPartition.fill(did, timing);
-			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+    //	ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyvsiphi_SubdetPM.fill(did);
+      _cOccupancyvsieta_Subdet.fill(did);
+    }
+    //	^^^ONLINE ONLY!
+    //
+    if (_ptype != fOffline) {  // hidefed2crate
+      //	Also, for these electronics plots, require that the channel was found in the emap.
+      if (rawid != 0) {
+        if (eid.isVMEid()) {
+          _cOccupancy_FEDVME.fill(eid);
+          _cOccupancy_ElectronicsVME.fill(eid);
+        } else if (eid.isUTCAid()) {
+          _cOccupancy_FEDuTCA.fill(eid);
+          _cOccupancy_ElectronicsuTCA.fill(eid);
+        }
+      }
+    }
 
-			//	ONLINE 
-			if (_ptype==fOnline) {
-				if (rawid != 0) {
-					_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-				}
-				_cTimingCut_depth.fill(did, timing);
-				//	^^^ONLINE
-			} else {
-				if (_ptype != fOffline) { // hidefed2crate
-					if (rawid != 0) {
-						_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-					}
-				}
-				_cTimingCut_depth.fill(did, timing);
-			}
-			_cOccupancyCut_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (rawid != 0) {
-					if (eid.isVMEid()){ 
-						//	ONLINE 
-						if (_ptype==fOnline)
-						{
-							_cTimingCut_FEDVME.fill(eid, timing);
-							_cTimingCut_ElectronicsVME.fill(eid, timing);
-						} // ^^^ ONLINE
-						else
-						{
-							_cTimingCut_FEDVME.fill(eid, timing);
-							_cTimingCut_ElectronicsVME.fill(eid, timing);
-						}
-						//	^^^ONLINE
+    if (energy > _cutE_HBHE) {
+      //	ONLINE ONLY!
+      if (_ptype == fOnline) {
+        _cEnergyvsLS_SubdetPM.fill(did, _currentLS, energy);
+        _cEnergyvsBX_SubdetPM.fill(did, bx, energy);
+        _cEnergyvsieta_Subdet.fill(did, energy);
+        _cEnergyvsiphi_SubdetPM.fill(did, energy);
+        _cTimingCutvsieta_Subdet.fill(did, timing);
+        _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+        _cTimingCutvsBX_SubdetPM.fill(did, bx, timing);
+        _cOccupancyCutvsiphi_SubdetPM.fill(did);
+        _cOccupancyCutvsieta_Subdet.fill(did);
+        _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+      }
+      //	^^^ONLINE ONLY!
+      _cEnergy_depth.fill(did, energy);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCut_HBHEPartition.fill(did, timing);
+      _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
 
-						_cOccupancyCut_FEDVME.fill(eid);
-						_cOccupancyCut_ElectronicsVME.fill(eid);
-					} else if (eid.isUTCAid()) {
-						if (_ptype==fOnline)
-						{
-							//	time constraints are explicit!
-							_cTimingCut_FEDuTCA.fill(eid, timing);
-							_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-						}
-						else
-						{
-							_cTimingCut_FEDuTCA.fill(eid, timing);
-							_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-						}
-						_cOccupancyCut_FEDuTCA.fill(eid);
-						_cOccupancyCut_ElectronicsuTCA.fill(eid);
-					}
-				}
-			}
-			did.subdet()==HcalBarrel?nChsHBCut++:nChsHECut++;
-		}
-		did.subdet()==HcalBarrel?nChsHB++:nChsHE++;
-	}
+      //	ONLINE
+      if (_ptype == fOnline) {
+        if (rawid != 0) {
+          _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+        }
+        _cTimingCut_depth.fill(did, timing);
+        //	^^^ONLINE
+      } else {
+        if (_ptype != fOffline) {  // hidefed2crate
+          if (rawid != 0) {
+            _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+          }
+        }
+        _cTimingCut_depth.fill(did, timing);
+      }
+      _cOccupancyCut_depth.fill(did);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (rawid != 0) {
+          if (eid.isVMEid()) {
+            //	ONLINE
+            if (_ptype == fOnline) {
+              _cTimingCut_FEDVME.fill(eid, timing);
+              _cTimingCut_ElectronicsVME.fill(eid, timing);
+            }  // ^^^ ONLINE
+            else {
+              _cTimingCut_FEDVME.fill(eid, timing);
+              _cTimingCut_ElectronicsVME.fill(eid, timing);
+            }
+            //	^^^ONLINE
 
-	if (rawidHBValid!=0 && rawidHEValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, 
-			nChsHB);
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS,
-			nChsHE);
-	
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHBValid),
-				bx, nChsHBCut);
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHEValid),
-				bx, nChsHECut);
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHBValid), 
-				_currentLS, nChsHBCut);
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHEValid), 
-				_currentLS, nChsHECut);
-		}
-		//	^^^ONLINE ONLY!
-	}
+            _cOccupancyCut_FEDVME.fill(eid);
+            _cOccupancyCut_ElectronicsVME.fill(eid);
+          } else if (eid.isUTCAid()) {
+            if (_ptype == fOnline) {
+              //	time constraints are explicit!
+              _cTimingCut_FEDuTCA.fill(eid, timing);
+              _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+            } else {
+              _cTimingCut_FEDuTCA.fill(eid, timing);
+              _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+            }
+            _cOccupancyCut_FEDuTCA.fill(eid);
+            _cOccupancyCut_ElectronicsuTCA.fill(eid);
+          }
+        }
+      }
+      did.subdet() == HcalBarrel ? nChsHBCut++ : nChsHECut++;
+    }
+    did.subdet() == HcalBarrel ? nChsHB++ : nChsHE++;
+  }
 
-	//	reset
-	rawidValid = 0;
+  if (rawidHBValid != 0 && rawidHEValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, nChsHB);
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, nChsHE);
 
-	int nChsHO = 0; int nChsHOCut = 0;
-	double ehop = 0; double ehom = 0;
-	for (HORecHitCollection::const_iterator it=cho->begin();
-		it!=cho->end(); ++it)
-	{
-		double energy = it->energy();
-		double timing = it->time();
-		
-		//	Explicit check on the DetIds present in the Collection
-		HcalDetId did = it->id();
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid==0)
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalOuter)
-			rawidValid = did.rawId();
+    //	ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHBValid), bx, nChsHBCut);
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHEValid), bx, nChsHECut);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, nChsHBCut);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, nChsHECut);
+    }
+    //	^^^ONLINE ONLY!
+  }
 
-		_cEnergy_Subdet.fill(did, energy);
-		_cTimingvsEnergy_SubdetPM.fill(did, energy, timing);
-		_cOccupancy_depth.fill(did);
-		did.ieta()>0?ehop+=energy:ehom+=energy;
+  //	reset
+  rawidValid = 0;
 
-		//	IMPORTANT: ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyvsiphi_SubdetPM.fill(did);
-			_cOccupancyvsieta_Subdet.fill(did);
-		}
-		//	ONLINE ONLY!
+  int nChsHO = 0;
+  int nChsHOCut = 0;
+  double ehop = 0;
+  double ehom = 0;
+  for (HORecHitCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    double energy = it->energy();
+    double timing = it->time();
 
-		if (_ptype != fOffline) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-			else
-			{
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-			}
-		}
+    //	Explicit check on the DetIds present in the Collection
+    HcalDetId did = it->id();
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (did.subdet() == HcalOuter)
+      rawidValid = did.rawId();
 
-		if (energy>_cutE_HO)
-		{
-			//	ONLINE ONLY!
-			if (_ptype==fOnline)
-			{
-				_cEnergyvsLS_SubdetPM.fill(did, _currentLS, energy);
-				_cEnergyvsBX_SubdetPM.fill(did, bx, energy);
-				_cEnergyvsieta_Subdet.fill(did, energy);
-				_cEnergyvsiphi_SubdetPM.fill(did, energy);
-				_cTimingCutvsieta_Subdet.fill(did, timing);
-				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-				_cTimingCutvsBX_SubdetPM.fill(did, bx, timing);
-				_cOccupancyCutvsiphi_SubdetPM.fill(did);
-				_cOccupancyCutvsieta_Subdet.fill(did);
-				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-			}
-			//	^^^ONLINE ONLY!
-			
-			_cEnergy_depth.fill(did, energy);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCut_depth.fill(did, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-				else
-				{
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			nChsHOCut++;
-		}
-		nChsHO++;
-	}
+    _cEnergy_Subdet.fill(did, energy);
+    _cTimingvsEnergy_SubdetPM.fill(did, energy, timing);
+    _cOccupancy_depth.fill(did);
+    did.ieta() > 0 ? ehop += energy : ehom += energy;
 
-	if (rawidValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS,
-			nChsHO);
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid),
-				bx, nChsHOCut);
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), 
-				_currentLS, nChsHOCut);
-		}
-		//	^^^ONLINE ONLY!
-	}
+    //	IMPORTANT: ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyvsiphi_SubdetPM.fill(did);
+      _cOccupancyvsieta_Subdet.fill(did);
+    }
+    //	ONLINE ONLY!
 
-	//reset 
-	rawidValid = 0;
+    if (_ptype != fOffline) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      } else {
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+      }
+    }
 
-	int nChsHF = 0; int nChsHFCut = 0;
-	double ehfp = 0; double ehfm = 0;
-	for (HFRecHitCollection::const_iterator it=chf->begin();
-		it!=chf->end(); ++it)
-	{
-		double energy = it->energy();
-		double timing = it->time();
+    if (energy > _cutE_HO) {
+      //	ONLINE ONLY!
+      if (_ptype == fOnline) {
+        _cEnergyvsLS_SubdetPM.fill(did, _currentLS, energy);
+        _cEnergyvsBX_SubdetPM.fill(did, bx, energy);
+        _cEnergyvsieta_Subdet.fill(did, energy);
+        _cEnergyvsiphi_SubdetPM.fill(did, energy);
+        _cTimingCutvsieta_Subdet.fill(did, timing);
+        _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+        _cTimingCutvsBX_SubdetPM.fill(did, bx, timing);
+        _cOccupancyCutvsiphi_SubdetPM.fill(did);
+        _cOccupancyCutvsieta_Subdet.fill(did);
+        _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+      }
+      //	^^^ONLINE ONLY!
 
-		//	Explicit check on the DetIds present in the Collection
-		HcalDetId did = it->id();
-		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid==0)
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalForward)
-			rawidValid = did.rawId();
+      _cEnergy_depth.fill(did, energy);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_depth.fill(did, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid()) {
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        } else {
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      nChsHOCut++;
+    }
+    nChsHO++;
+  }
 
-		_cEnergy_Subdet.fill(did, energy);
-		_cTimingvsEnergy_SubdetPM.fill(did, energy, timing);
-		_cOccupancy_depth.fill(did);
-		did.ieta()>0?ehfp+=energy:ehfm+=energy;
-		
-		//	IMPORTANT:
-		//	only for Online Processing
-		//
-		if (_ptype==fOnline)
-		{
-			_cOccupancyvsiphi_SubdetPM.fill(did);
-			_cOccupancyvsieta_Subdet.fill(did);
-		}
-		//	ONLINE ONLY!
+  if (rawidValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, nChsHO);
+    //	ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx, nChsHOCut);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, nChsHOCut);
+    }
+    //	^^^ONLINE ONLY!
+  }
 
-		if (_ptype != fOffline) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cOccupancy_FEDVME.fill(eid);
-				_cOccupancy_ElectronicsVME.fill(eid);
-			}
-			else
-			{
-				_cOccupancy_FEDuTCA.fill(eid);
-				_cOccupancy_ElectronicsuTCA.fill(eid);
-			}
-		}
+  //reset
+  rawidValid = 0;
 
-		if (energy>_cutE_HF)
-		{
-			//	ONLINE ONLY!
-			if (_ptype==fOnline)
-			{
-				_cEnergyvsLS_SubdetPM.fill(did, _currentLS, energy);
-				_cEnergyvsBX_SubdetPM.fill(did, bx, energy);
-				_cEnergyvsieta_Subdet.fill(did, energy);
-				_cEnergyvsiphi_SubdetPM.fill(did, energy);
-				_cTimingCutvsieta_Subdet.fill(did, timing);
-				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
-				_cTimingCutvsBX_SubdetPM.fill(did, bx, timing);
-				_cOccupancyCutvsiphi_SubdetPM.fill(did);
-				_cOccupancyCutvsieta_Subdet.fill(did);
-				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
-				if (_ptype != fOffline) { // hidefed2crate
-					_xUniHF.get(eid)++;
-				}
-			}
-			//	^^^ONLINE ONLY!
-			_cEnergy_depth.fill(did, energy);
-			_cTimingCut_SubdetPM.fill(did, timing);
-			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
-			}
-			_cOccupancyCut_depth.fill(did);
-			_cTimingCut_depth.fill(did, timing);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-					_cOccupancyCut_FEDVME.fill(eid);
-					_cOccupancyCut_ElectronicsVME.fill(eid);
-				}
-				else
-				{
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
-					_cOccupancyCut_FEDuTCA.fill(eid);
-					_cOccupancyCut_ElectronicsuTCA.fill(eid);
-				}
-			}
-			nChsHFCut++;
-		}
-		nChsHF++;
-	}
+  int nChsHF = 0;
+  int nChsHFCut = 0;
+  double ehfp = 0;
+  double ehfm = 0;
+  for (HFRecHitCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    double energy = it->energy();
+    double timing = it->time();
 
-	if (rawidValid!=0)
-	{
-		_cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS,
-			nChsHF);
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid),
-				bx, nChsHFCut);
-			_cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), 
-				_currentLS, nChsHFCut);
-		}
-		//	^^^ONLINE ONLY!
-	}
+    //	Explicit check on the DetIds present in the Collection
+    HcalDetId did = it->id();
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (did.subdet() == HcalForward)
+      rawidValid = did.rawId();
 
-	// Loop over HFPreRecHits to get charge and charge asymmetry
-	if (_hfPreRecHitsAvailable) {
-		for (HFPreRecHitCollection::const_iterator it=cprehf->begin();
-			it!=cprehf->end(); ++it)
-		{
-			HcalDetId did = it->id();
-			if (_filter_HF.filter(did)) {
-				continue;
-			}
-			std::pair<float, bool> chargeAsymmetry = it->chargeAsymmetry(0.);
-			std::pair<float, bool> chargeAsymmetryCut = it->chargeAsymmetry(20.);
+    _cEnergy_Subdet.fill(did, energy);
+    _cTimingvsEnergy_SubdetPM.fill(did, energy, timing);
+    _cOccupancy_depth.fill(did);
+    did.ieta() > 0 ? ehfp += energy : ehfm += energy;
 
-			if (chargeAsymmetry.second) {
-				_cDAAsymmetryVsCharge_SubdetPM.fill(did, chargeAsymmetry.first, it->charge());
-			}
-			if (chargeAsymmetryCut.second) {
-				_cDAAsymmetryMean_cut_depth.fill(did, chargeAsymmetryCut.first);
-				_cDAAsymmetry_cut_SubdetPM.fill(did, chargeAsymmetryCut.first);
-			}
-		}
-	}
+    //	IMPORTANT:
+    //	only for Online Processing
+    //
+    if (_ptype == fOnline) {
+      _cOccupancyvsiphi_SubdetPM.fill(did);
+      _cOccupancyvsieta_Subdet.fill(did);
+    }
+    //	ONLINE ONLY!
+
+    if (_ptype != fOffline) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cOccupancy_FEDVME.fill(eid);
+        _cOccupancy_ElectronicsVME.fill(eid);
+      } else {
+        _cOccupancy_FEDuTCA.fill(eid);
+        _cOccupancy_ElectronicsuTCA.fill(eid);
+      }
+    }
+
+    if (energy > _cutE_HF) {
+      //	ONLINE ONLY!
+      if (_ptype == fOnline) {
+        _cEnergyvsLS_SubdetPM.fill(did, _currentLS, energy);
+        _cEnergyvsBX_SubdetPM.fill(did, bx, energy);
+        _cEnergyvsieta_Subdet.fill(did, energy);
+        _cEnergyvsiphi_SubdetPM.fill(did, energy);
+        _cTimingCutvsieta_Subdet.fill(did, timing);
+        _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+        _cTimingCutvsBX_SubdetPM.fill(did, bx, timing);
+        _cOccupancyCutvsiphi_SubdetPM.fill(did);
+        _cOccupancyCutvsieta_Subdet.fill(did);
+        _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
+        if (_ptype != fOffline) {  // hidefed2crate
+          _xUniHF.get(eid)++;
+        }
+      }
+      //	^^^ONLINE ONLY!
+      _cEnergy_depth.fill(did, energy);
+      _cTimingCut_SubdetPM.fill(did, timing);
+      _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+      }
+      _cOccupancyCut_depth.fill(did);
+      _cTimingCut_depth.fill(did, timing);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid()) {
+          _cTimingCut_FEDVME.fill(eid, timing);
+          _cTimingCut_ElectronicsVME.fill(eid, timing);
+          _cOccupancyCut_FEDVME.fill(eid);
+          _cOccupancyCut_ElectronicsVME.fill(eid);
+        } else {
+          _cTimingCut_FEDuTCA.fill(eid, timing);
+          _cTimingCut_ElectronicsuTCA.fill(eid, timing);
+          _cOccupancyCut_FEDuTCA.fill(eid);
+          _cOccupancyCut_ElectronicsuTCA.fill(eid);
+        }
+      }
+      nChsHFCut++;
+    }
+    nChsHF++;
+  }
+
+  if (rawidValid != 0) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, nChsHF);
+    //	ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx, nChsHFCut);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, nChsHFCut);
+    }
+    //	^^^ONLINE ONLY!
+  }
+
+  // Loop over HFPreRecHits to get charge and charge asymmetry
+  if (_hfPreRecHitsAvailable) {
+    for (HFPreRecHitCollection::const_iterator it = cprehf->begin(); it != cprehf->end(); ++it) {
+      HcalDetId did = it->id();
+      if (_filter_HF.filter(did)) {
+        continue;
+      }
+      std::pair<float, bool> chargeAsymmetry = it->chargeAsymmetry(0.);
+      std::pair<float, bool> chargeAsymmetryCut = it->chargeAsymmetry(20.);
+
+      if (chargeAsymmetry.second) {
+        _cDAAsymmetryVsCharge_SubdetPM.fill(did, chargeAsymmetry.first, it->charge());
+      }
+      if (chargeAsymmetryCut.second) {
+        _cDAAsymmetryMean_cut_depth.fill(did, chargeAsymmetryCut.first);
+        _cDAAsymmetry_cut_SubdetPM.fill(did, chargeAsymmetryCut.first);
+      }
+    }
+  }
 }
 
-/* virtual */ void RecHitTask::beginLuminosityBlock(edm::LuminosityBlock const&
-	lb, edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
+/* virtual */ void RecHitTask::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void RecHitTask::endLuminosityBlock(edm::LuminosityBlock const& 
-	lb, edm::EventSetup const& es)
-{
-	if (_ptype!=fOnline)
-		return;
+/* virtual */ void RecHitTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  if (_ptype != fOnline)
+    return;
 
-	//
-	//	GENERATE STATUS ONLY FOR ONLINE
-	//
-//	for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-//		it!=gids.end(); ++it)
-//	{}
+  //
+  //	GENERATE STATUS ONLY FOR ONLINE
+  //
+  //	for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
+  //		it!=gids.end(); ++it)
+  //	{}
 
-	for (uintCompactMap::const_iterator it=_xUniHF.begin();
-		it!=_xUniHF.end(); ++it)
-	{
-		uint32_t hash1 = it->first;
-		HcalElectronicsId eid1(hash1);
-		double x1 = it->second;
+  for (uintCompactMap::const_iterator it = _xUniHF.begin(); it != _xUniHF.end(); ++it) {
+    uint32_t hash1 = it->first;
+    HcalElectronicsId eid1(hash1);
+    double x1 = it->second;
 
-		for (uintCompactMap::const_iterator jt=_xUniHF.begin();
-			jt!=_xUniHF.end(); ++jt)
-		{
-			if (jt==it)
-				continue;
-			double x2 = jt->second;
-			if (x2==0)
-				continue;
-			if (x1/x2<_thresh_unihf)
-				_xUni.get(eid1)++;
-		}
-	}
+    for (uintCompactMap::const_iterator jt = _xUniHF.begin(); jt != _xUniHF.end(); ++jt) {
+      if (jt == it)
+        continue;
+      double x2 = jt->second;
+      if (x2 == 0)
+        continue;
+      if (x1 / x2 < _thresh_unihf)
+        _xUni.get(eid1)++;
+    }
+  }
 
-	if (_ptype != fOffline) { // hidefed2crate
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-		it!=_vhashFEDs.end(); ++it)
-		{
-			flag::Flag fSum("RECO");
-			HcalElectronicsId eid = HcalElectronicsId(*it);
+  if (_ptype != fOffline) {  // hidefed2crate
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      flag::Flag fSum("RECO");
+      HcalElectronicsId eid = HcalElectronicsId(*it);
 
-			std::vector<uint32_t>::const_iterator cit=std::find(
-				_vcdaqEids.begin(), _vcdaqEids.end(), *it);
-			if (cit==_vcdaqEids.end())
-			{
-				//	not @cDAQ
-				for (uint32_t iflag=0; iflag<_vflags.size(); iflag++)
-					_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-						int(flag::fNCDAQ));
-				_cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-				continue;
-			}
+      std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
+      if (cit == _vcdaqEids.end()) {
+        //	not @cDAQ
+        for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
+          _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
+        _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+        continue;
+      }
 
-			//	FED is @cDAQ
-			if (hcaldqm::utilities::isFEDHF(eid) && (_runkeyVal==0 || _runkeyVal==4))
-			{
-				if (_xUni.get(eid)>0)
-					_vflags[fUni]._state = flag::fPROBLEMATIC;
-				else
-					_vflags[fUni]._state = flag::fGOOD;
-			}
+      //	FED is @cDAQ
+      if (hcaldqm::utilities::isFEDHF(eid) && (_runkeyVal == 0 || _runkeyVal == 4)) {
+        if (_xUni.get(eid) > 0)
+          _vflags[fUni]._state = flag::fPROBLEMATIC;
+        else
+          _vflags[fUni]._state = flag::fGOOD;
+      }
 
-			if (_unknownIdsPresent)
-				_vflags[fUnknownIds]._state = flag::fBAD;
-			else 
-				_vflags[fUnknownIds]._state = flag::fGOOD;
+      if (_unknownIdsPresent)
+        _vflags[fUnknownIds]._state = flag::fBAD;
+      else
+        _vflags[fUnknownIds]._state = flag::fGOOD;
 
-			int iflag=0;
-			for (std::vector<flag::Flag>::iterator ft=_vflags.begin();
-				ft!=_vflags.end(); ++ft)
-			{
-				_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-					int(ft->_state));
-				fSum+=(*ft);
-				iflag++;
+      int iflag = 0;
+      for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
+        _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(ft->_state));
+        fSum += (*ft);
+        iflag++;
 
-				//	reset after using
-				ft->reset();
-			}
-			_cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
-		}
-		_xUniHF.reset(); _xUni.reset();
-	}
+        //	reset after using
+        ft->reset();
+      }
+      _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
+    }
+    _xUniHF.reset();
+    _xUni.reset();
+  }
 
-	//	in the end always do the DQTask::endLumi
-	DQTask::endLuminosityBlock(lb, es);
+  //	in the end always do the DQTask::endLumi
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(RecHitTask);
-

--- a/DQM/HcalTasks/plugins/TPComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/TPComparisonTask.cc
@@ -3,276 +3,251 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-TPComparisonTask::TPComparisonTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	//	tags and tokens
-	_tag1 = ps.getUntrackedParameter<edm::InputTag>("tag1",
-		edm::InputTag("hcalDigis"));
-	_tag2 = ps.getUntrackedParameter<edm::InputTag>("tag2",
-		edm::InputTag("vmeDigis"));
-	_tok1 = consumes<HcalTrigPrimDigiCollection>(_tag1);
-	_tok2 = consumes<HcalTrigPrimDigiCollection>(_tag2);
+TPComparisonTask::TPComparisonTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  //	tags and tokens
+  _tag1 = ps.getUntrackedParameter<edm::InputTag>("tag1", edm::InputTag("hcalDigis"));
+  _tag2 = ps.getUntrackedParameter<edm::InputTag>("tag2", edm::InputTag("vmeDigis"));
+  _tok1 = consumes<HcalTrigPrimDigiCollection>(_tag1);
+  _tok2 = consumes<HcalTrigPrimDigiCollection>(_tag2);
 
-	//	tmp flags
-	_skip1x1 = ps.getUntrackedParameter<bool>("skip1x1", true);
+  //	tmp flags
+  _skip1x1 = ps.getUntrackedParameter<bool>("skip1x1", true);
 }
 
-/* virtual */ void TPComparisonTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib, r, es);
-	
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	edm::ESHandle<HcalElectronicsMap> item;
-	es.get<HcalElectronicsMapRcd>().get("full", item);
-	_emap = item.product();
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-	}
-	std::vector<uint32_t> vhashVME;
-	std::vector<uint32_t> vhashuTCA;
-	vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-		constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vhashuTCA);
+/* virtual */ void TPComparisonTask::bookHistograms(DQMStore::IBooker& ib,
+                                                    edm::Run const& r,
+                                                    edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//	INTIALIZE CONTAINERS
-	for (unsigned int i=0; i<4; i++)
-	{
-		_cEt_TTSubdet[i].initialize(_name, "Et",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cFG_TTSubdet[i].initialize(_name, "FG",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	}
-	_cEtall_TTSubdet.initialize(_name, "Et",
-		hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  edm::ESHandle<HcalElectronicsMap> item;
+  es.get<HcalElectronicsMapRcd>().get("full", item);
+  _emap = item.product();
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
+  }
+  std::vector<uint32_t> vhashVME;
+  std::vector<uint32_t> vhashuTCA;
+  vhashVME.push_back(
+      HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vhashuTCA);
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMsn_FEDVME.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSLBSLBCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsn_FEDuTCA.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCATPFiberChuTCATP),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEtMsm_FEDVME.initialize(_name, "EtMsm",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSLBSLBCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEtMsm_FEDuTCA.initialize(_name, "EtMsm",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCATPFiberChuTCATP),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cFGMsm_FEDVME.initialize(_name, "FGMsm",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSLBSLBCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cFGMsm_FEDuTCA.initialize(_name, "FGMsm",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCATPFiberChuTCATP),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	}
+  //	INTIALIZE CONTAINERS
+  for (unsigned int i = 0; i < 4; i++) {
+    _cEt_TTSubdet[i].initialize(_name,
+                                "Et",
+                                hcaldqm::hashfunctions::fTTSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+    _cFG_TTSubdet[i].initialize(_name,
+                                "FG",
+                                hcaldqm::hashfunctions::fTTSubdet,
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                0);
+  }
+  _cEtall_TTSubdet.initialize(_name,
+                              "Et",
+                              hcaldqm::hashfunctions::fTTSubdet,
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                              0);
 
-	_cMsnuTCA.initialize(_name, "Missing", 
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cMsnVME.initialize(_name, "Missing",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cEtMsm.initialize(_name, "EtMsm",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cFGMsm.initialize(_name, "FGMsm",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMsn_FEDVME.initialize(_name,
+                            "Missing",
+                            hcaldqm::hashfunctions::fFED,
+                            new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                            new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSLBSLBCh),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                            0);
+    _cMsn_FEDuTCA.initialize(_name,
+                             "Missing",
+                             hcaldqm::hashfunctions::fFED,
+                             new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                             new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCATPFiberChuTCATP),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                             0);
+    _cEtMsm_FEDVME.initialize(_name,
+                              "EtMsm",
+                              hcaldqm::hashfunctions::fFED,
+                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSLBSLBCh),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                              0);
+    _cEtMsm_FEDuTCA.initialize(_name,
+                               "EtMsm",
+                               hcaldqm::hashfunctions::fFED,
+                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCATPFiberChuTCATP),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
+    _cFGMsm_FEDVME.initialize(_name,
+                              "FGMsm",
+                              hcaldqm::hashfunctions::fFED,
+                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSLBSLBCh),
+                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                              0);
+    _cFGMsm_FEDuTCA.initialize(_name,
+                               "FGMsm",
+                               hcaldqm::hashfunctions::fFED,
+                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCATPFiberChuTCATP),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
+  }
 
-	char aux[20];
-	for (unsigned int i=0; i<4; i++)
-	{
-		sprintf(aux, "TS%d", i);
-		_cEt_TTSubdet[i].book(ib, _emap, _subsystem, aux);
-		_cFG_TTSubdet[i].book(ib, _emap, _subsystem, aux);
-	}
-	_cEtall_TTSubdet.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMsn_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cEtMsm_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cFGMsm_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMsn_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cEtMsm_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cFGMsm_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
+  _cMsnuTCA.initialize(_name,
+                       "Missing",
+                       new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                       new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                       0);
+  _cMsnVME.initialize(_name,
+                      "Missing",
+                      new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                      new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                      0);
+  _cEtMsm.initialize(_name,
+                     "EtMsm",
+                     new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                     new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                     0);
+  _cFGMsm.initialize(_name,
+                     "FGMsm",
+                     new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                     new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                     0);
 
-	_cMsnuTCA.book(ib, _subsystem, std::string("uTCA"));
-	_cMsnVME.book(ib, _subsystem, std::string("VME"));
-	_cEtMsm.book(ib, _subsystem);
-	_cFGMsm.book(ib, _subsystem);
+  char aux[20];
+  for (unsigned int i = 0; i < 4; i++) {
+    sprintf(aux, "TS%d", i);
+    _cEt_TTSubdet[i].book(ib, _emap, _subsystem, aux);
+    _cFG_TTSubdet[i].book(ib, _emap, _subsystem, aux);
+  }
+  _cEtall_TTSubdet.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cMsn_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cEtMsm_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cFGMsm_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMsn_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cEtMsm_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cFGMsm_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
 
-	_ehashmapuTCA.initialize(_emap, hcaldqm::electronicsmap::fT2EHashMap,
-		_filter_VME);
-	_ehashmapVME.initialize(_emap, hcaldqm::electronicsmap::fT2EHashMap,
-		_filter_uTCA);
-//	_ehashmap.print();
-//	_cMsn_depth.book(ib);
-//	_cEtMsm_depth.book(ib);
-//	_cFGMsm_depth.book(ib);
+  _cMsnuTCA.book(ib, _subsystem, std::string("uTCA"));
+  _cMsnVME.book(ib, _subsystem, std::string("VME"));
+  _cEtMsm.book(ib, _subsystem);
+  _cFGMsm.book(ib, _subsystem);
+
+  _ehashmapuTCA.initialize(_emap, hcaldqm::electronicsmap::fT2EHashMap, _filter_VME);
+  _ehashmapVME.initialize(_emap, hcaldqm::electronicsmap::fT2EHashMap, _filter_uTCA);
+  //	_ehashmap.print();
+  //	_cMsn_depth.book(ib);
+  //	_cEtMsm_depth.book(ib);
+  //	_cFGMsm_depth.book(ib);
 }
 
-/* virtual */ void TPComparisonTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
+/* virtual */ void TPComparisonTask::_resetMonitors(hcaldqm::UpdateFreq uf) { DQTask::_resetMonitors(uf); }
+
+/* virtual */ void TPComparisonTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HcalTrigPrimDigiCollection> coll1;
+  edm::Handle<HcalTrigPrimDigiCollection> coll2;
+
+  if (!e.getByToken(_tok1, coll1))
+    _logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available" + _tag1.label() + " " + _tag1.instance());
+  if (!e.getByToken(_tok2, coll2))
+    _logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available" + _tag2.label() + " " + _tag2.instance());
+
+  //	assume always coll1 is primary (uTCA) and coll2 is secondary(VME)
+  for (HcalTrigPrimDigiCollection::const_iterator it1 = coll1->begin(); it1 != coll1->end(); ++it1) {
+    //	iterate thru utca collection
+    //	get the same detid digi from vme collection
+    //	if missing - fill vme missing
+    //	else correlate
+    //	tmp
+    if (_skip1x1)
+      if (it1->id().version() > 0)
+        continue;
+    //	\tmp
+
+    HcalTrigTowerDetId tid = it1->id();
+    HcalTrigPrimDigiCollection::const_iterator it2 = coll2->find(HcalTrigTowerDetId(tid.ieta(), tid.iphi(), 0));
+    HcalElectronicsId eid1 = HcalElectronicsId(_ehashmapuTCA.lookup(tid));
+    HcalElectronicsId eid2 = HcalElectronicsId(_ehashmapVME.lookup(tid));
+
+    if (it2 == coll2->end()) {
+      //	missing from VME collection
+      _cMsnVME.fill(tid);
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cMsn_FEDVME.fill(eid2);
+      }
+      for (int i = 0; i < it1->size(); i++) {
+        _cEtall_TTSubdet.fill(tid, it1->sample(i).compressedEt(), -2);
+        _cEt_TTSubdet[i].fill(tid, it1->sample(i).compressedEt(), -2);
+      }
+    } else
+      for (int i = 0; i < it1->size(); i++) {
+        _cEtall_TTSubdet.fill(tid, it1->sample(i).compressedEt(), it2->sample(i).compressedEt());
+        _cEt_TTSubdet[i].fill(tid, it1->sample(i).compressedEt(), it2->sample(i).compressedEt());
+        _cFG_TTSubdet[i].fill(tid, it1->sample(i).fineGrain(), it2->sample(i).fineGrain());
+        if (it1->sample(i).compressedEt() != it2->sample(i).compressedEt()) {
+          if (_ptype != fOffline) {  // hidefed2crate
+            _cEtMsm_FEDuTCA.fill(eid1);
+            _cEtMsm_FEDVME.fill(eid2);
+          }
+          _cEtMsm.fill(tid);
+        }
+        if (it1->sample(i).fineGrain() != it2->sample(i).fineGrain()) {
+          if (_ptype != fOffline) {  // hidefed2crate
+            _cFGMsm_FEDuTCA.fill(eid1);
+            _cFGMsm_FEDVME.fill(eid2);
+          }
+          _cFGMsm.fill(tid);
+        }
+      }
+  }
+  for (HcalTrigPrimDigiCollection::const_iterator it2 = coll2->begin(); it2 != coll2->end(); ++it2) {
+    //	itearte thru VME
+    //	find utca tp digi by detid
+    //	check if present of missing
+    HcalTrigTowerDetId tid = it2->id();
+    if (_skip1x1)
+      if (tid.version() > 0)
+        continue;
+
+    HcalTrigPrimDigiCollection::const_iterator it1 = coll1->find(HcalTrigTowerDetId(tid.ieta(), tid.iphi(), 0));
+    if (it1 == coll1->end()) {
+      HcalElectronicsId eid1 = HcalElectronicsId(_ehashmapuTCA.lookup(tid));
+      if (_ptype != fOffline) {  // hidefed2crate
+        _cMsn_FEDuTCA.fill(eid1);
+      }
+      _cMsnuTCA.fill(tid);
+      for (int i = 0; i < it2->size(); i++) {
+        _cEtall_TTSubdet.fill(tid, -2, it2->sample(i).compressedEt());
+        _cEt_TTSubdet[i].fill(tid, -2, it2->sample(i).compressedEt());
+      }
+    }
+  }
 }
 
-/* virtual */ void TPComparisonTask::_process(edm::Event const& e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HcalTrigPrimDigiCollection>	coll1;
-	edm::Handle<HcalTrigPrimDigiCollection>	coll2;
-
-	if (!e.getByToken(_tok1, coll1))
-		_logger.dqmthrow(
-			"Collection HcalTrigPrimDigiCollection isn't available" + 
-			_tag1.label() + " " + _tag1.instance());
-	if (!e.getByToken(_tok2, coll2))
-		_logger.dqmthrow(
-			"Collection HcalTrigPrimDigiCollection isn't available" + 
-			_tag2.label() + " " + _tag2.instance());
-
-	//	assume always coll1 is primary (uTCA) and coll2 is secondary(VME)
-	for (HcalTrigPrimDigiCollection::const_iterator it1=coll1->begin();
-		it1!=coll1->end(); ++it1)
-	{
-		//	iterate thru utca collection
-		//	get the same detid digi from vme collection
-		//	if missing - fill vme missing
-		//	else correlate
-		//	tmp
-		if (_skip1x1)
-			if (it1->id().version()>0)
-				continue;
-		//	\tmp
-
-		HcalTrigTowerDetId tid = it1->id();
-		HcalTrigPrimDigiCollection::const_iterator it2=coll2->find(
-			HcalTrigTowerDetId(tid.ieta(), tid.iphi(), 0));
-		HcalElectronicsId eid1 = HcalElectronicsId(
-			_ehashmapuTCA.lookup(tid));
-		HcalElectronicsId eid2 = HcalElectronicsId(
-			_ehashmapVME.lookup(tid));
-
-		if (it2==coll2->end())
-		{
-			//	missing from VME collection
-			_cMsnVME.fill(tid);
-			if (_ptype != fOffline) { // hidefed2crate
-				_cMsn_FEDVME.fill(eid2);
-			}
-			for (int i=0; i<it1->size(); i++)
-			{
-				_cEtall_TTSubdet.fill(tid, 
-					it1->sample(i).compressedEt(), -2);
-				_cEt_TTSubdet[i].fill(tid, 
-					it1->sample(i).compressedEt(), -2);
-			}
-		}
-		else
-			for (int i=0; i<it1->size(); i++)
-			{
-				_cEtall_TTSubdet.fill(tid, 
-					it1->sample(i).compressedEt(), 
-					it2->sample(i).compressedEt());
-				_cEt_TTSubdet[i].fill(tid, 
-					it1->sample(i).compressedEt(), 
-					it2->sample(i).compressedEt());
-				_cFG_TTSubdet[i].fill(tid,
-					it1->sample(i).fineGrain(),
-					it2->sample(i).fineGrain());
-				if (it1->sample(i).compressedEt()!=
-					it2->sample(i).compressedEt())
-				{
-					if (_ptype != fOffline) { // hidefed2crate
-						_cEtMsm_FEDuTCA.fill(eid1);
-						_cEtMsm_FEDVME.fill(eid2);
-					}
-					_cEtMsm.fill(tid);
-				}
-				if (it1->sample(i).fineGrain()!=
-					it2->sample(i).fineGrain())
-				{
-					if (_ptype != fOffline) { // hidefed2crate
-						_cFGMsm_FEDuTCA.fill(eid1);
-						_cFGMsm_FEDVME.fill(eid2);
-					}
-					_cFGMsm.fill(tid);
-				}
-			}
-	}
-	for (HcalTrigPrimDigiCollection::const_iterator it2=coll2->begin();
-		it2!=coll2->end(); ++it2)
-	{
-		//	itearte thru VME
-		//	find utca tp digi by detid
-		//	check if present of missing
-		HcalTrigTowerDetId tid = it2->id();
-		if (_skip1x1)
-			if (tid.version()>0)
-				continue;
-
-		HcalTrigPrimDigiCollection::const_iterator it1=coll1->find(
-			HcalTrigTowerDetId(tid.ieta(), tid.iphi(), 0));
-		if (it1==coll1->end())
-		{
-			HcalElectronicsId eid1 = HcalElectronicsId(
-				_ehashmapuTCA.lookup(tid));
-			if (_ptype != fOffline) { // hidefed2crate
-				_cMsn_FEDuTCA.fill(eid1);
-			}
-			_cMsnuTCA.fill(tid);
-			for (int i=0; i<it2->size(); i++)
-			{
-				_cEtall_TTSubdet.fill(tid, 
-					-2, it2->sample(i).compressedEt());
-				_cEt_TTSubdet[i].fill(tid, -2, it2->sample(i).compressedEt());
-			}
-		}
-	}
-}
-
-/* virtual */ void TPComparisonTask::endLuminosityBlock(
-	edm::LuminosityBlock const& lb, edm::EventSetup const& es)
-{
-	//	in the end always
-	DQTask::endLuminosityBlock(lb, es);
+/* virtual */ void TPComparisonTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  //	in the end always
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(TPComparisonTask);
-

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -1,656 +1,783 @@
 #include "DQM/HcalTasks/interface/TPTask.h"
-#include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h" // For ComparisonHelper::zip
-
+#include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h"  // For ComparisonHelper::zip
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-TPTask::TPTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_tagData = ps.getUntrackedParameter<edm::InputTag>("tagData",
-		edm::InputTag("hcalDigis"));
-	_tagDataL1Rec = ps.getUntrackedParameter<edm::InputTag>("tagDataL1Rec",
-		edm::InputTag("caloLayer1Digis"));
-	_tagEmul = ps.getUntrackedParameter<edm::InputTag>("tagEmul",
-		edm::InputTag("emulDigis"));
-	_tagEmulNoTDCCut = ps.getUntrackedParameter<edm::InputTag>("tagEmulNoTDCCut",
-		edm::InputTag("emulTPDigisNoTDCCut"));
+TPTask::TPTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagData = ps.getUntrackedParameter<edm::InputTag>("tagData", edm::InputTag("hcalDigis"));
+  _tagDataL1Rec = ps.getUntrackedParameter<edm::InputTag>("tagDataL1Rec", edm::InputTag("caloLayer1Digis"));
+  _tagEmul = ps.getUntrackedParameter<edm::InputTag>("tagEmul", edm::InputTag("emulDigis"));
+  _tagEmulNoTDCCut = ps.getUntrackedParameter<edm::InputTag>("tagEmulNoTDCCut", edm::InputTag("emulTPDigisNoTDCCut"));
 
-	_tokData = consumes<HcalTrigPrimDigiCollection>(_tagData);
-	_tokDataL1Rec = consumes<HcalTrigPrimDigiCollection>(_tagDataL1Rec);
-	_tokEmul = consumes<HcalTrigPrimDigiCollection>(_tagEmul);
-	_tokEmulNoTDCCut = consumes<HcalTrigPrimDigiCollection>(_tagEmulNoTDCCut);
+  _tokData = consumes<HcalTrigPrimDigiCollection>(_tagData);
+  _tokDataL1Rec = consumes<HcalTrigPrimDigiCollection>(_tagDataL1Rec);
+  _tokEmul = consumes<HcalTrigPrimDigiCollection>(_tagEmul);
+  _tokEmulNoTDCCut = consumes<HcalTrigPrimDigiCollection>(_tagEmulNoTDCCut);
 
-	_skip1x1 = ps.getUntrackedParameter<bool>("skip1x1", true);
-	_cutEt = ps.getUntrackedParameter<int>("cutEt", 3);
-	_thresh_EtMsmRate_high = ps.getUntrackedParameter<double>(
-		"thresh_EtMsmRate_high", 0.2);
-	_thresh_EtMsmRate_low = ps.getUntrackedParameter<double>(
-		"thresh_EtMsmRate_low", 0.05);
-	_thresh_FGMsmRate_high = ps.getUntrackedParameter<double>(
-		"thresh_FGMsmRate", 0.2);
-	_thresh_FGMsmRate_low = ps.getUntrackedParameter<double>(
-		"thresh_FGMsmRate_low", 0.05);
-	_thresh_DataMsn = ps.getUntrackedParameter<double>("thresh_DataMsn",
-		0.1);
-	_thresh_EmulMsn = ps.getUntrackedParameter<double>("thresh_EmulMsn");
-	std::vector<int> tmp = ps.getUntrackedParameter<std::vector<int> >("vFGBitsReady");
-	for (uint32_t iii=0; iii<constants::NUM_FGBITS; iii++)
-		_vFGBitsReady.push_back(tmp[iii]);
+  _skip1x1 = ps.getUntrackedParameter<bool>("skip1x1", true);
+  _cutEt = ps.getUntrackedParameter<int>("cutEt", 3);
+  _thresh_EtMsmRate_high = ps.getUntrackedParameter<double>("thresh_EtMsmRate_high", 0.2);
+  _thresh_EtMsmRate_low = ps.getUntrackedParameter<double>("thresh_EtMsmRate_low", 0.05);
+  _thresh_FGMsmRate_high = ps.getUntrackedParameter<double>("thresh_FGMsmRate", 0.2);
+  _thresh_FGMsmRate_low = ps.getUntrackedParameter<double>("thresh_FGMsmRate_low", 0.05);
+  _thresh_DataMsn = ps.getUntrackedParameter<double>("thresh_DataMsn", 0.1);
+  _thresh_EmulMsn = ps.getUntrackedParameter<double>("thresh_EmulMsn");
+  std::vector<int> tmp = ps.getUntrackedParameter<std::vector<int> >("vFGBitsReady");
+  for (uint32_t iii = 0; iii < constants::NUM_FGBITS; iii++)
+    _vFGBitsReady.push_back(tmp[iii]);
 
-	_vflags.resize(nTPFlag);
-	_vflags[fEtMsm]=flag::Flag("EtMsm");
-	_vflags[fDataMsn]=flag::Flag("DataMsn");
-	_vflags[fEmulMsn]=flag::Flag("EmulMsn");
-	_vflags[fUnknownIds]=flag::Flag("UnknownIds");
-	if (_ptype == fOnline) {
-		_vflags[fSentRecL1Msm]=flag::Flag("uHTR-L1TMsm");
-	}
+  _vflags.resize(nTPFlag);
+  _vflags[fEtMsm] = flag::Flag("EtMsm");
+  _vflags[fDataMsn] = flag::Flag("DataMsn");
+  _vflags[fEmulMsn] = flag::Flag("EmulMsn");
+  _vflags[fUnknownIds] = flag::Flag("UnknownIds");
+  if (_ptype == fOnline) {
+    _vflags[fSentRecL1Msm] = flag::Flag("uHTR-L1TMsm");
+  }
 }
 
-/* virtual */ void TPTask::bookHistograms(DQMStore::IBooker& ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	DQTask::bookHistograms(ib,r,es);
+/* virtual */ void TPTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
 
-	//	GET WHAT YOU NEED
-	edm::ESHandle<HcalDbService> dbs;
-	es.get<HcalDbRecord>().get(dbs);
-	_emap = dbs->getHcalMapping();
-	std::vector<uint32_t> vVME;
-	std::vector<uint32_t> vuTCA;
-	std::vector<uint32_t> depth0;
-	vVME.push_back(HcalElectronicsId(FIBERCH_MIN, 
-		FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-	vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-		FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-	_filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vVME);
-	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
-		vuTCA);
-	depth0.push_back(HcalTrigTowerDetId(1, 1, 0).rawId());
-	_filter_depth0.initialize(filter::fPreserver, hcaldqm::hashfunctions::fTTdepth,
-		depth0);
+  //	GET WHAT YOU NEED
+  edm::ESHandle<HcalDbService> dbs;
+  es.get<HcalDbRecord>().get(dbs);
+  _emap = dbs->getHcalMapping();
+  std::vector<uint32_t> vVME;
+  std::vector<uint32_t> vuTCA;
+  std::vector<uint32_t> depth0;
+  vVME.push_back(HcalElectronicsId(FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+  vuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+  _filter_VME.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vVME);
+  _filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics, vuTCA);
+  depth0.push_back(HcalTrigTowerDetId(1, 1, 0).rawId());
+  _filter_depth0.initialize(filter::fPreserver, hcaldqm::hashfunctions::fTTdepth, depth0);
 
-	//	INITIALIZE FIRST
-	//	Et/FG
-	_cEtData_TTSubdet.initialize(_name, "EtData", hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_128),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cEtEmul_TTSubdet.initialize(_name, "EtEmul", hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_128),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cEtCorr_TTSubdet.initialize(_name, "EtCorr", hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	for (uint8_t iii=0; iii<constants::NUM_FGBITS; iii++)
-	{
-		_cFGCorr_TTSubdet[iii].initialize(_name, "FGCorr", hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	}
+  //	INITIALIZE FIRST
+  //	Et/FG
+  _cEtData_TTSubdet.initialize(_name,
+                               "EtData",
+                               hcaldqm::hashfunctions::fTTSubdet,
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_128),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                               0);
+  _cEtEmul_TTSubdet.initialize(_name,
+                               "EtEmul",
+                               hcaldqm::hashfunctions::fTTSubdet,
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_128),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                               0);
+  _cEtCorr_TTSubdet.initialize(_name,
+                               "EtCorr",
+                               hcaldqm::hashfunctions::fTTSubdet,
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                               0);
+  for (uint8_t iii = 0; iii < constants::NUM_FGBITS; iii++) {
+    _cFGCorr_TTSubdet[iii].initialize(_name,
+                                      "FGCorr",
+                                      hcaldqm::hashfunctions::fTTSubdet,
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fFG),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                      0);
+  }
 
-	_cEtData_depthlike.initialize(_name, "EtData",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-	_cEtEmul_depthlike.initialize(_name, "EtEmul",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-	_cEtCutData_depthlike.initialize(_name, "EtCutData",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-	_cEtCutEmul_depthlike.initialize(_name, "EtCutEmul",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
+  _cEtData_depthlike.initialize(_name,
+                                "EtData",
+                                new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                0);
+  _cEtEmul_depthlike.initialize(_name,
+                                "EtEmul",
+                                new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                0);
+  _cEtCutData_depthlike.initialize(_name,
+                                   "EtCutData",
+                                   new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                   new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                   0);
+  _cEtCutEmul_depthlike.initialize(_name,
+                                   "EtCutEmul",
+                                   new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                   new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                   0);
 
-	// Occupancy
-	_cOccupancyData_depthlike.initialize(_name, "OccupancyData",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cOccupancyEmul_depthlike.initialize(_name, "OccupancyEmul",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cOccupancyCutData_depthlike.initialize(_name, "OccupancyCutData",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cOccupancyCutEmul_depthlike.initialize(_name, "OccupancyCutEmul",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+  // Occupancy
+  _cOccupancyData_depthlike.initialize(_name,
+                                       "OccupancyData",
+                                       new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                       new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                       0);
+  _cOccupancyEmul_depthlike.initialize(_name,
+                                       "OccupancyEmul",
+                                       new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                       new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                       0);
+  _cOccupancyCutData_depthlike.initialize(_name,
+                                          "OccupancyCutData",
+                                          new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                          new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                          0);
+  _cOccupancyCutEmul_depthlike.initialize(_name,
+                                          "OccupancyCutEmul",
+                                          new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                          new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                          0);
 
-	//	Mismatches
-	_cEtMsm_depthlike.initialize(_name, "EtMsm",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cFGMsm_depthlike.initialize(_name, "FGMsm",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //	Mismatches
+  _cEtMsm_depthlike.initialize(_name,
+                               "EtMsm",
+                               new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                               new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
+  _cFGMsm_depthlike.initialize(_name,
+                               "FGMsm",
+                               new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                               new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
 
-	if (_ptype == fOnline) {
-		// Mismatches: sent vs received
-		_cEtMsm_uHTR_L1T_depthlike.initialize(_name, "EtMsm_uHTR_L1T", 
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEtMsm_uHTR_L1T_LS.initialize(_name, "EtMsm_uHTR_L1T_LS", 
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	}
+  if (_ptype == fOnline) {
+    // Mismatches: sent vs received
+    _cEtMsm_uHTR_L1T_depthlike.initialize(_name,
+                                          "EtMsm_uHTR_L1T",
+                                          new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                          new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+    _cEtMsm_uHTR_L1T_LS.initialize(_name,
+                                   "EtMsm_uHTR_L1T_LS",
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                   0);
+  }
 
-	//	Missing Data w.r.t. Emulator
-	_cMsnData_depthlike.initialize(_name, "MsnData",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cMsnEmul_depthlike.initialize(_name, "MsnEmul",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //	Missing Data w.r.t. Emulator
+  _cMsnData_depthlike.initialize(_name,
+                                 "MsnData",
+                                 new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                 new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                 0);
+  _cMsnEmul_depthlike.initialize(_name,
+                                 "MsnEmul",
+                                 new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                 new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                 0);
 
-	_cEtCorrRatio_depthlike.initialize(_name, "EtCorrRatio",
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-		new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),0);
+  _cEtCorrRatio_depthlike.initialize(_name,
+                                     "EtCorrRatio",
+                                     new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                     new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                     0);
 
-	_cOccupancyDatavsBX_TTSubdet.initialize(_name, "OccupancyDatavsBX",
-		hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cOccupancyEmulvsBX_TTSubdet.initialize(_name, "OccupancyEmulvsBX",
-		hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cOccupancyCutDatavsBX_TTSubdet.initialize(_name, "OccupancyCutDatavsBX",
-		hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cOccupancyCutEmulvsBX_TTSubdet.initialize(_name, "OccupancyCutEmulvsBX",
-		hcaldqm::hashfunctions::fTTSubdet,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  _cOccupancyDatavsBX_TTSubdet.initialize(_name,
+                                          "OccupancyDatavsBX",
+                                          hcaldqm::hashfunctions::fTTSubdet,
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+  _cOccupancyEmulvsBX_TTSubdet.initialize(_name,
+                                          "OccupancyEmulvsBX",
+                                          hcaldqm::hashfunctions::fTTSubdet,
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                          0);
+  _cOccupancyCutDatavsBX_TTSubdet.initialize(_name,
+                                             "OccupancyCutDatavsBX",
+                                             hcaldqm::hashfunctions::fTTSubdet,
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+  _cOccupancyCutEmulvsBX_TTSubdet.initialize(_name,
+                                             "OccupancyCutEmulvsBX",
+                                             hcaldqm::hashfunctions::fTTSubdet,
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
 
-	//	INITIALIZE HISTOGRAMS to be used in Online only!
-	if (_ptype==fOnline)
-	{
-		_cEtCorr2x3_TTSubdet.initialize(_name, "EtCorr2x3", 
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyData2x3_depthlike.initialize(_name, "OccupancyData2x3",
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta2x3),
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyEmul2x3_depthlike.initialize(_name, "OccupancyEmul2x3",
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta2x3),
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cEtCutDatavsLS_TTSubdet.initialize(_name, "EtCutDatavsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),0);
-		_cEtCutEmulvsLS_TTSubdet.initialize(_name, "EtCutEmulvsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),0);
-		_cEtCutDatavsBX_TTSubdet.initialize(_name, "EtCutDatavsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),0);
-		_cEtCutEmulvsBX_TTSubdet.initialize(_name, "EtCutEmulvsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),0);
-		_cEtCorrRatiovsLS_TTSubdet.initialize(_name, "EtCorrRatiovsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),0);
-		_cEtCorrRatiovsBX_TTSubdet.initialize(_name, "EtCorrRatiovsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),0);
-		_cEtMsmRatiovsLS_TTSubdet.initialize(_name, "EtMsmRatiovsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio),0);
-		_cEtMsmRatiovsBX_TTSubdet.initialize(_name, "EtMsmRatiovsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio),0);
-		_cEtMsmvsLS_TTSubdet.initialize(_name, "EtMsmvsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEtMsmvsBX_TTSubdet.initialize(_name, "EtMsmvsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnDatavsLS_TTSubdet.initialize(_name, "MsnDatavsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnCutDatavsLS_TTSubdet.initialize(_name, "MsnCutDatavsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnDatavsBX_TTSubdet.initialize(_name, "MsnDatavsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnCutDatavsBX_TTSubdet.initialize(_name, "MsnCutDatavsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnEmulvsLS_TTSubdet.initialize(_name, "MsnEmulvsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnCutEmulvsLS_TTSubdet.initialize(_name, "MsnCutEmulvsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnEmulvsBX_TTSubdet.initialize(_name, "MsnEmulvsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnCutEmulvsBX_TTSubdet.initialize(_name, "MsnCutEmulvsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyDatavsLS_TTSubdet.initialize(_name, "OccupancyDatavsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutDatavsLS_TTSubdet.initialize(_name, 
-			"OccupancyCutDatavsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyDatavsBX_TTSubdet.initialize(_name, "OccupancyDatavsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutDatavsBX_TTSubdet.initialize(_name, 
-			"OccupancyCutDatavsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyEmulvsLS_TTSubdet.initialize(_name, "OccupancyEmulvsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutEmulvsLS_TTSubdet.initialize(_name, 
-			"OccupancyCutEmulvsLS",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::LumiSection(_maxLS),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyEmulvsBX_TTSubdet.initialize(_name, "OccupancyEmulvsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cOccupancyCutEmulvsBX_TTSubdet.initialize(_name, 
-			"OccupancyCutEmulvsBX",
-			hcaldqm::hashfunctions::fTTSubdet,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+  //	INITIALIZE HISTOGRAMS to be used in Online only!
+  if (_ptype == fOnline) {
+    _cEtCorr2x3_TTSubdet.initialize(_name,
+                                    "EtCorr2x3",
+                                    hcaldqm::hashfunctions::fTTSubdet,
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                    0);
+    _cOccupancyData2x3_depthlike.initialize(_name,
+                                            "OccupancyData2x3",
+                                            new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta2x3),
+                                            new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                            0);
+    _cOccupancyEmul2x3_depthlike.initialize(_name,
+                                            "OccupancyEmul2x3",
+                                            new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta2x3),
+                                            new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                            0);
+    _cEtCutDatavsLS_TTSubdet.initialize(_name,
+                                        "EtCutDatavsLS",
+                                        hcaldqm::hashfunctions::fTTSubdet,
+                                        new hcaldqm::quantity::LumiSection(_maxLS),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                        0);
+    _cEtCutEmulvsLS_TTSubdet.initialize(_name,
+                                        "EtCutEmulvsLS",
+                                        hcaldqm::hashfunctions::fTTSubdet,
+                                        new hcaldqm::quantity::LumiSection(_maxLS),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                        0);
+    _cEtCutDatavsBX_TTSubdet.initialize(_name,
+                                        "EtCutDatavsBX",
+                                        hcaldqm::hashfunctions::fTTSubdet,
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                        0);
+    _cEtCutEmulvsBX_TTSubdet.initialize(_name,
+                                        "EtCutEmulvsBX",
+                                        hcaldqm::hashfunctions::fTTSubdet,
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEtCorr_256),
+                                        0);
+    _cEtCorrRatiovsLS_TTSubdet.initialize(_name,
+                                          "EtCorrRatiovsLS",
+                                          hcaldqm::hashfunctions::fTTSubdet,
+                                          new hcaldqm::quantity::LumiSection(_maxLS),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                          0);
+    _cEtCorrRatiovsBX_TTSubdet.initialize(_name,
+                                          "EtCorrRatiovsBX",
+                                          hcaldqm::hashfunctions::fTTSubdet,
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                          0);
+    _cEtMsmRatiovsLS_TTSubdet.initialize(_name,
+                                         "EtMsmRatiovsLS",
+                                         hcaldqm::hashfunctions::fTTSubdet,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio),
+                                         0);
+    _cEtMsmRatiovsBX_TTSubdet.initialize(_name,
+                                         "EtMsmRatiovsBX",
+                                         hcaldqm::hashfunctions::fTTSubdet,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio),
+                                         0);
+    _cEtMsmvsLS_TTSubdet.initialize(_name,
+                                    "EtMsmvsLS",
+                                    hcaldqm::hashfunctions::fTTSubdet,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+    _cEtMsmvsBX_TTSubdet.initialize(_name,
+                                    "EtMsmvsBX",
+                                    hcaldqm::hashfunctions::fTTSubdet,
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
+    _cMsnDatavsLS_TTSubdet.initialize(_name,
+                                      "MsnDatavsLS",
+                                      hcaldqm::hashfunctions::fTTSubdet,
+                                      new hcaldqm::quantity::LumiSection(_maxLS),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cMsnCutDatavsLS_TTSubdet.initialize(_name,
+                                         "MsnCutDatavsLS",
+                                         hcaldqm::hashfunctions::fTTSubdet,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cMsnDatavsBX_TTSubdet.initialize(_name,
+                                      "MsnDatavsBX",
+                                      hcaldqm::hashfunctions::fTTSubdet,
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cMsnCutDatavsBX_TTSubdet.initialize(_name,
+                                         "MsnCutDatavsBX",
+                                         hcaldqm::hashfunctions::fTTSubdet,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cMsnEmulvsLS_TTSubdet.initialize(_name,
+                                      "MsnEmulvsLS",
+                                      hcaldqm::hashfunctions::fTTSubdet,
+                                      new hcaldqm::quantity::LumiSection(_maxLS),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cMsnCutEmulvsLS_TTSubdet.initialize(_name,
+                                         "MsnCutEmulvsLS",
+                                         hcaldqm::hashfunctions::fTTSubdet,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cMsnEmulvsBX_TTSubdet.initialize(_name,
+                                      "MsnEmulvsBX",
+                                      hcaldqm::hashfunctions::fTTSubdet,
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cMsnCutEmulvsBX_TTSubdet.initialize(_name,
+                                         "MsnCutEmulvsBX",
+                                         hcaldqm::hashfunctions::fTTSubdet,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cOccupancyDatavsLS_TTSubdet.initialize(_name,
+                                            "OccupancyDatavsLS",
+                                            hcaldqm::hashfunctions::fTTSubdet,
+                                            new hcaldqm::quantity::LumiSection(_maxLS),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                            0);
+    _cOccupancyCutDatavsLS_TTSubdet.initialize(_name,
+                                               "OccupancyCutDatavsLS",
+                                               hcaldqm::hashfunctions::fTTSubdet,
+                                               new hcaldqm::quantity::LumiSection(_maxLS),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                               0);
+    _cOccupancyDatavsBX_TTSubdet.initialize(_name,
+                                            "OccupancyDatavsBX",
+                                            hcaldqm::hashfunctions::fTTSubdet,
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                            0);
+    _cOccupancyCutDatavsBX_TTSubdet.initialize(_name,
+                                               "OccupancyCutDatavsBX",
+                                               hcaldqm::hashfunctions::fTTSubdet,
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                               0);
+    _cOccupancyEmulvsLS_TTSubdet.initialize(_name,
+                                            "OccupancyEmulvsLS",
+                                            hcaldqm::hashfunctions::fTTSubdet,
+                                            new hcaldqm::quantity::LumiSection(_maxLS),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                            0);
+    _cOccupancyCutEmulvsLS_TTSubdet.initialize(_name,
+                                               "OccupancyCutEmulvsLS",
+                                               hcaldqm::hashfunctions::fTTSubdet,
+                                               new hcaldqm::quantity::LumiSection(_maxLS),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                               0);
+    _cOccupancyEmulvsBX_TTSubdet.initialize(_name,
+                                            "OccupancyEmulvsBX",
+                                            hcaldqm::hashfunctions::fTTSubdet,
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                            0);
+    _cOccupancyCutEmulvsBX_TTSubdet.initialize(_name,
+                                               "OccupancyCutEmulvsBX",
+                                               hcaldqm::hashfunctions::fTTSubdet,
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                               0);
 
-		_cOccupancy_HF_depth.initialize(_name, "OccupancyDataHF_depth", 
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyNoTDC_HF_depth.initialize(_name, "OccupancyEmulHFNoTDC_depth", 
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancy_HF_ieta.initialize(_name, "OccupancyDataHF_ieta", 
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0),
-		_cOccupancyNoTDC_HF_ieta.initialize(_name, "OccupancyEmulHFNoTDC_ieta", 
-			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	}
+    _cOccupancy_HF_depth.initialize(_name,
+                                    "OccupancyDataHF_depth",
+                                    new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                    new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                    0);
+    _cOccupancyNoTDC_HF_depth.initialize(_name,
+                                         "OccupancyEmulHFNoTDC_depth",
+                                         new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                         new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                         0);
+    _cOccupancy_HF_ieta.initialize(_name,
+                                   "OccupancyDataHF_ieta",
+                                   new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                   0),
+        _cOccupancyNoTDC_HF_ieta.initialize(_name,
+                                            "OccupancyEmulHFNoTDC_ieta",
+                                            new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                            0);
+  }
 
-	// FED-based containers
-	if (_ptype != fOffline) { // hidefed2crate
-		std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
-		std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
-		std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-		//	push the rawIds of each fed into the vector
-		//	this vector is used at endlumi for online state generation
-		for (std::vector<int>::const_iterator it=vFEDsVME.begin();
-			it!=vFEDsVME.end(); ++it)
-		{
-			_vhashFEDs.push_back(HcalElectronicsId(FIBERCH_MIN, FIBER_VME_MIN,
-				SPIGOT_MIN, (*it)-FED_VME_MIN).rawId());
-		}
-		for (std::vector<int>::const_iterator it=vFEDsuTCA.begin();
-			it!=vFEDsuTCA.end(); ++it)
-		{
-			std::pair<uint16_t, uint16_t> cspair = hcaldqm::utilities::fed2crate(*it);
-			_vhashFEDs.push_back(HcalElectronicsId(cspair.first, 
-				cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		}
-		_cEtData_ElectronicsVME.initialize(_name, "EtData", 
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-		_cEtData_ElectronicsuTCA.initialize(_name, "EtData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-		_cEtEmul_ElectronicsVME.initialize(_name, "EtEmul", 
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-		_cEtEmul_ElectronicsuTCA.initialize(_name, "EtEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),0);
-		//	Occupancies
-		_cOccupancyData_ElectronicsVME.initialize(_name, "OccupancyData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyEmul_ElectronicsVME.initialize(_name, "OccupancyEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyData_ElectronicsuTCA.initialize(_name, "OccupancyData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyEmul_ElectronicsuTCA.initialize(_name, "OccupancyEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+  // FED-based containers
+  if (_ptype != fOffline) {  // hidefed2crate
+    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
+    std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
+    //	push the rawIds of each fed into the vector
+    //	this vector is used at endlumi for online state generation
+    for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it) {
+      _vhashFEDs.push_back(HcalElectronicsId(FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+    }
+    for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+      std::pair<uint16_t, uint16_t> cspair = hcaldqm::utilities::fed2crate(*it);
+      _vhashFEDs.push_back(HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    }
+    _cEtData_ElectronicsVME.initialize(_name,
+                                       "EtData",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                       0);
+    _cEtData_ElectronicsuTCA.initialize(_name,
+                                        "EtData",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                        0);
+    _cEtEmul_ElectronicsVME.initialize(_name,
+                                       "EtEmul",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                       0);
+    _cEtEmul_ElectronicsuTCA.initialize(_name,
+                                        "EtEmul",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fEt_256),
+                                        0);
+    //	Occupancies
+    _cOccupancyData_ElectronicsVME.initialize(_name,
+                                              "OccupancyData",
+                                              hcaldqm::hashfunctions::fElectronics,
+                                              new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                              0);
+    _cOccupancyEmul_ElectronicsVME.initialize(_name,
+                                              "OccupancyEmul",
+                                              hcaldqm::hashfunctions::fElectronics,
+                                              new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                              new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                              0);
+    _cOccupancyData_ElectronicsuTCA.initialize(_name,
+                                               "OccupancyData",
+                                               hcaldqm::hashfunctions::fElectronics,
+                                               new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                               0);
+    _cOccupancyEmul_ElectronicsuTCA.initialize(_name,
+                                               "OccupancyEmul",
+                                               hcaldqm::hashfunctions::fElectronics,
+                                               new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                               new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                               0);
 
-		_cOccupancyCutData_ElectronicsVME.initialize(_name, "OccupancyCutData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyCutEmul_ElectronicsVME.initialize(_name, "OccupancyCutEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyCutData_ElectronicsuTCA.initialize(_name, "OccupancyCutData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyCutEmul_ElectronicsuTCA.initialize(_name, "OccupancyCutEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		//	Mismatches
-		_cEtMsm_ElectronicsVME.initialize(_name, "EtMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cFGMsm_ElectronicsVME.initialize(_name, "FGMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEtMsm_ElectronicsuTCA.initialize(_name, "EtMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cFGMsm_ElectronicsuTCA.initialize(_name, "FGMsm",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+    _cOccupancyCutData_ElectronicsVME.initialize(_name,
+                                                 "OccupancyCutData",
+                                                 hcaldqm::hashfunctions::fElectronics,
+                                                 new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                                 0);
+    _cOccupancyCutEmul_ElectronicsVME.initialize(_name,
+                                                 "OccupancyCutEmul",
+                                                 hcaldqm::hashfunctions::fElectronics,
+                                                 new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                                 new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                                 0);
+    _cOccupancyCutData_ElectronicsuTCA.initialize(
+        _name,
+        "OccupancyCutData",
+        hcaldqm::hashfunctions::fElectronics,
+        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+        0);
+    _cOccupancyCutEmul_ElectronicsuTCA.initialize(
+        _name,
+        "OccupancyCutEmul",
+        hcaldqm::hashfunctions::fElectronics,
+        new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+        0);
+    //	Mismatches
+    _cEtMsm_ElectronicsVME.initialize(_name,
+                                      "EtMsm",
+                                      hcaldqm::hashfunctions::fElectronics,
+                                      new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cFGMsm_ElectronicsVME.initialize(_name,
+                                      "FGMsm",
+                                      hcaldqm::hashfunctions::fElectronics,
+                                      new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
+    _cEtMsm_ElectronicsuTCA.initialize(_name,
+                                       "EtMsm",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+    _cFGMsm_ElectronicsuTCA.initialize(_name,
+                                       "FGMsm",
+                                       hcaldqm::hashfunctions::fElectronics,
+                                       new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                       new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
 
-		//	Missing Data w.r.t. Emulator
-		_cMsnData_ElectronicsVME.initialize(_name, "MsnData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnData_ElectronicsuTCA.initialize(_name, "MsnData",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnEmul_ElectronicsVME.initialize(_name, "MsnEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMsnEmul_ElectronicsuTCA.initialize(_name, "MsnEmul",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cEtCorrRatio_ElectronicsVME.initialize(_name, "EtCorrRatio",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsVME),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),0);
-		_cEtCorrRatio_ElectronicsuTCA.initialize(_name, "EtCorrRatio",
-			hcaldqm::hashfunctions::fElectronics,
-			new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),0);
-		if (_ptype == fOnline) {
-			_cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-				hcaldqm::hashfunctions::fFED,
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FlagQuantity(_vflags),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
-			_cSummaryvsLS.initialize(_name, "SummaryvsLS",
-				new hcaldqm::quantity::LumiSection(_maxLS),
-				new hcaldqm::quantity::FEDQuantity(vFEDs),
-				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),0);
+    //	Missing Data w.r.t. Emulator
+    _cMsnData_ElectronicsVME.initialize(_name,
+                                        "MsnData",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cMsnData_ElectronicsuTCA.initialize(_name,
+                                         "MsnData",
+                                         hcaldqm::hashfunctions::fElectronics,
+                                         new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                         new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cMsnEmul_ElectronicsVME.initialize(_name,
+                                        "MsnEmul",
+                                        hcaldqm::hashfunctions::fElectronics,
+                                        new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                        new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                        0);
+    _cMsnEmul_ElectronicsuTCA.initialize(_name,
+                                         "MsnEmul",
+                                         hcaldqm::hashfunctions::fElectronics,
+                                         new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                         new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                         0);
+    _cEtCorrRatio_ElectronicsVME.initialize(_name,
+                                            "EtCorrRatio",
+                                            hcaldqm::hashfunctions::fElectronics,
+                                            new hcaldqm::quantity::FEDQuantity(vFEDsVME),
+                                            new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                            0);
+    _cEtCorrRatio_ElectronicsuTCA.initialize(_name,
+                                             "EtCorrRatio",
+                                             hcaldqm::hashfunctions::fElectronics,
+                                             new hcaldqm::quantity::FEDQuantity(vFEDsuTCA),
+                                             new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                             0);
+    if (_ptype == fOnline) {
+      _cSummaryvsLS_FED.initialize(_name,
+                                   "SummaryvsLS",
+                                   hcaldqm::hashfunctions::fFED,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::FlagQuantity(_vflags),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                                   0);
+      _cSummaryvsLS.initialize(_name,
+                               "SummaryvsLS",
+                               new hcaldqm::quantity::LumiSection(_maxLS),
+                               new hcaldqm::quantity::FEDQuantity(vFEDs),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
+                               0);
 
-			_xEtMsm.initialize(hcaldqm::hashfunctions::fFED);
-			_xFGMsm.initialize(hcaldqm::hashfunctions::fFED);
-			_xNumCorr.initialize(hcaldqm::hashfunctions::fFED);
-			_xDataMsn.initialize(hcaldqm::hashfunctions::fFED);
-			_xDataTotal.initialize(hcaldqm::hashfunctions::fFED);
-			_xEmulMsn.initialize(hcaldqm::hashfunctions::fFED);
-			_xEmulTotal.initialize(hcaldqm::hashfunctions::fFED);
-			_xSentRecL1Msm.initialize(hcaldqm::hashfunctions::fFED);
-		}
-	}
+      _xEtMsm.initialize(hcaldqm::hashfunctions::fFED);
+      _xFGMsm.initialize(hcaldqm::hashfunctions::fFED);
+      _xNumCorr.initialize(hcaldqm::hashfunctions::fFED);
+      _xDataMsn.initialize(hcaldqm::hashfunctions::fFED);
+      _xDataTotal.initialize(hcaldqm::hashfunctions::fFED);
+      _xEmulMsn.initialize(hcaldqm::hashfunctions::fFED);
+      _xEmulTotal.initialize(hcaldqm::hashfunctions::fFED);
+      _xSentRecL1Msm.initialize(hcaldqm::hashfunctions::fFED);
+    }
+  }
 
-	//	BOOK HISTOGRAMS
-	char aux[20];
-	for (unsigned int iii=0; iii<constants::NUM_FGBITS; iii++)
-	{
-		sprintf(aux, "BIT%d", iii);
-		_cFGCorr_TTSubdet[iii].book(ib, _emap, _subsystem, aux);
-	}
-	_cEtData_TTSubdet.book(ib, _emap, _subsystem);
-	_cEtEmul_TTSubdet.book(ib, _emap, _subsystem);
-	_cEtCorr_TTSubdet.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cEtData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cEtData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cEtEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cEtEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
-	_cEtData_depthlike.book(ib, _subsystem);
-	_cEtEmul_depthlike.book(ib, _subsystem);
-	_cEtCutData_depthlike.book(ib, _subsystem);
-	_cEtCutEmul_depthlike.book(ib, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cOccupancyData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCutData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCutEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cOccupancyCutData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cOccupancyCutEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
-	_cOccupancyData_depthlike.book(ib, _subsystem);
-	_cOccupancyEmul_depthlike.book(ib, _subsystem);
-	_cOccupancyCutData_depthlike.book(ib, _subsystem);
-	_cOccupancyCutEmul_depthlike.book(ib, _subsystem);
+  //	BOOK HISTOGRAMS
+  char aux[20];
+  for (unsigned int iii = 0; iii < constants::NUM_FGBITS; iii++) {
+    sprintf(aux, "BIT%d", iii);
+    _cFGCorr_TTSubdet[iii].book(ib, _emap, _subsystem, aux);
+  }
+  _cEtData_TTSubdet.book(ib, _emap, _subsystem);
+  _cEtEmul_TTSubdet.book(ib, _emap, _subsystem);
+  _cEtCorr_TTSubdet.book(ib, _emap, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cEtData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cEtData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cEtEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cEtEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+  _cEtData_depthlike.book(ib, _subsystem);
+  _cEtEmul_depthlike.book(ib, _subsystem);
+  _cEtCutData_depthlike.book(ib, _subsystem);
+  _cEtCutEmul_depthlike.book(ib, _subsystem);
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cOccupancyData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCutData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCutEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cOccupancyCutData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cOccupancyCutEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
+  _cOccupancyData_depthlike.book(ib, _subsystem);
+  _cOccupancyEmul_depthlike.book(ib, _subsystem);
+  _cOccupancyCutData_depthlike.book(ib, _subsystem);
+  _cOccupancyCutEmul_depthlike.book(ib, _subsystem);
 
-	_cEtCorrRatio_depthlike.book(ib, _subsystem);
-	_cEtMsm_depthlike.book(ib, _subsystem);
-	_cFGMsm_depthlike.book(ib, _subsystem);
-	_cMsnData_depthlike.book(ib, _subsystem);
-	_cMsnEmul_depthlike.book(ib, _subsystem);
+  _cEtCorrRatio_depthlike.book(ib, _subsystem);
+  _cEtMsm_depthlike.book(ib, _subsystem);
+  _cFGMsm_depthlike.book(ib, _subsystem);
+  _cMsnData_depthlike.book(ib, _subsystem);
+  _cMsnEmul_depthlike.book(ib, _subsystem);
 
-	if (_ptype == fOnline) {
-		_cEtMsm_uHTR_L1T_depthlike.book(ib, _subsystem);
-		_cEtMsm_uHTR_L1T_LS.book(ib, _subsystem);
-	}
+  if (_ptype == fOnline) {
+    _cEtMsm_uHTR_L1T_depthlike.book(ib, _subsystem);
+    _cEtMsm_uHTR_L1T_LS.book(ib, _subsystem);
+  }
 
-	if (_ptype != fOffline) { // hidefed2crate
-		_cEtMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cEtMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cFGMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cFGMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMsnData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMsnData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cMsnEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cMsnEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-		_cEtCorrRatio_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-		_cEtCorrRatio_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-	}
+  if (_ptype != fOffline) {  // hidefed2crate
+    _cEtMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cEtMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cFGMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cFGMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMsnData_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMsnData_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cMsnEmul_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cMsnEmul_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+    _cEtCorrRatio_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+    _cEtCorrRatio_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+  }
 
-	//	whatever has to go online only goes here
-	if (_ptype==fOnline)
-	{
-		_cEtCorr2x3_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyData2x3_depthlike.book(ib, _subsystem);
-		_cOccupancyEmul2x3_depthlike.book(ib, _subsystem);
-		_cEtCutDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtCutEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtCutDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtCutEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtCorrRatiovsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtCorrRatiovsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtMsmvsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtMsmvsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtMsmRatiovsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cEtMsmRatiovsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnCutDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnCutDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnCutEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cMsnCutEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cOccupancyCutEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
-		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		_cSummaryvsLS.book(ib, _subsystem);
+  //	whatever has to go online only goes here
+  if (_ptype == fOnline) {
+    _cEtCorr2x3_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyData2x3_depthlike.book(ib, _subsystem);
+    _cOccupancyEmul2x3_depthlike.book(ib, _subsystem);
+    _cEtCutDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtCutEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtCutDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtCutEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtCorrRatiovsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtCorrRatiovsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtMsmvsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtMsmvsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtMsmRatiovsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cEtMsmRatiovsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnCutDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnCutDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnCutEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cMsnCutEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutDatavsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutEmulvsBX_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutDatavsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutEmulvsLS_TTSubdet.book(ib, _emap, _subsystem);
+    _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    _cSummaryvsLS.book(ib, _subsystem);
 
-		_xEtMsm.book(_emap);
-		_xFGMsm.book(_emap);
-		_xNumCorr.book(_emap);
-		_xDataMsn.book(_emap);
-		_xDataTotal.book(_emap);
-		_xEmulMsn.book(_emap);
-		_xEmulTotal.book(_emap);
-		_xSentRecL1Msm.book(_emap);
+    _xEtMsm.book(_emap);
+    _xFGMsm.book(_emap);
+    _xNumCorr.book(_emap);
+    _xDataMsn.book(_emap);
+    _xDataTotal.book(_emap);
+    _xEmulMsn.book(_emap);
+    _xEmulTotal.book(_emap);
+    _xSentRecL1Msm.book(_emap);
 
-		_cOccupancy_HF_depth.book(ib, _subsystem);
-		_cOccupancyNoTDC_HF_depth.book(ib, _subsystem);
-		_cOccupancy_HF_ieta.book(ib, _subsystem);
-		_cOccupancyNoTDC_HF_ieta.book(ib, _subsystem);
+    _cOccupancy_HF_depth.book(ib, _subsystem);
+    _cOccupancyNoTDC_HF_depth.book(ib, _subsystem);
+    _cOccupancy_HF_ieta.book(ib, _subsystem);
+    _cOccupancyNoTDC_HF_ieta.book(ib, _subsystem);
+  }
 
-	}
-	
-	//	initialize the hash map
-	_ehashmap.initialize(_emap, hcaldqm::electronicsmap::fT2EHashMap);
+  //	initialize the hash map
+  _ehashmap.initialize(_emap, hcaldqm::electronicsmap::fT2EHashMap);
 
-	//	book the flag for unknown ids and the online guy as well
-	ib.setCurrentFolder(_subsystem+"/"+_name);
-	meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds",
-		1, 0, 1);
-	_unknownIdsPresent = false;
-	meUnknownIds1LS->setLumiFlag();
+  //	book the flag for unknown ids and the online guy as well
+  ib.setCurrentFolder(_subsystem + "/" + _name);
+  meUnknownIds1LS = ib.book1D("UnknownIds", "UnknownIds", 1, 0, 1);
+  _unknownIdsPresent = false;
+  meUnknownIds1LS->setLumiFlag();
 }
 
-/* virtual */ void TPTask::_resetMonitors(hcaldqm::UpdateFreq uf)
-{
-	DQTask::_resetMonitors(uf);
-	switch (uf)
-	{
-		case hcaldqm::f1LS:
-			_unknownIdsPresent = false;
-			break;
-		default : 
-			break;
-	}
+/* virtual */ void TPTask::_resetMonitors(hcaldqm::UpdateFreq uf) {
+  DQTask::_resetMonitors(uf);
+  switch (uf) {
+    case hcaldqm::f1LS:
+      _unknownIdsPresent = false;
+      break;
+    default:
+      break;
+  }
 }
 
-/* virtual */ void TPTask::_process(edm::Event const& e,
-	edm::EventSetup const&)
-{
-	edm::Handle<HcalTrigPrimDigiCollection> cdata;
-	edm::Handle<HcalTrigPrimDigiCollection> cdataL1Rec;
-	edm::Handle<HcalTrigPrimDigiCollection> cemul;
-	edm::Handle<HcalTrigPrimDigiCollection> cemul_noTDCCut;
-	if (!e.getByToken(_tokData, cdata))
-		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
-			+ _tagData.label() + " " + _tagData.instance());
-	if (_ptype == fOnline) {
-		if (!e.getByToken(_tokDataL1Rec, cdataL1Rec))
-			_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
-				+ _tagDataL1Rec.label() + " " + _tagDataL1Rec.instance());
-	}
-	if (!e.getByToken(_tokEmul, cemul))
-		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
-			+ _tagEmul.label() + " " + _tagEmul.instance());
-	if (_ptype == fOnline) {
-		if (!e.getByToken(_tokEmulNoTDCCut, cemul_noTDCCut)) {
-			_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
-				+ _tagEmulNoTDCCut.label() + " " + _tagEmulNoTDCCut.instance());
-		}
-	}
+/* virtual */ void TPTask::_process(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<HcalTrigPrimDigiCollection> cdata;
+  edm::Handle<HcalTrigPrimDigiCollection> cdataL1Rec;
+  edm::Handle<HcalTrigPrimDigiCollection> cemul;
+  edm::Handle<HcalTrigPrimDigiCollection> cemul_noTDCCut;
+  if (!e.getByToken(_tokData, cdata))
+    _logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: " + _tagData.label() + " " +
+                     _tagData.instance());
+  if (_ptype == fOnline) {
+    if (!e.getByToken(_tokDataL1Rec, cdataL1Rec))
+      _logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: " + _tagDataL1Rec.label() + " " +
+                       _tagDataL1Rec.instance());
+  }
+  if (!e.getByToken(_tokEmul, cemul))
+    _logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: " + _tagEmul.label() + " " +
+                     _tagEmul.instance());
+  if (_ptype == fOnline) {
+    if (!e.getByToken(_tokEmulNoTDCCut, cemul_noTDCCut)) {
+      _logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: " + _tagEmulNoTDCCut.label() + " " +
+                       _tagEmulNoTDCCut.instance());
+    }
+  }
 
-	//	extract some info per event
-	int bx = e.bunchCrossing();
+  //	extract some info per event
+  int bx = e.bunchCrossing();
 
-	//	some summaries... per event
-	int numHBHE(0), numHF(0), numCutHBHE(0), numCutHF(0);
-	int numCorrHBHE(0), numCorrHF(0);
-	int numMsmHBHE(0), numMsmHF(0);
-	int numMsnHBHE(0), numMsnHF(0), numMsnCutHBHE(0), numMsnCutHF(0);
+  //	some summaries... per event
+  int numHBHE(0), numHF(0), numCutHBHE(0), numCutHF(0);
+  int numCorrHBHE(0), numCorrHF(0);
+  int numMsmHBHE(0), numMsmHF(0);
+  int numMsnHBHE(0), numMsnHF(0), numMsnCutHBHE(0), numMsnCutHF(0);
 
-	//	for explanation see RecHit or Digi Tasks
-	uint32_t rawidHBHEValid = 0;
-	uint32_t rawidHFValid = 0;
+  //	for explanation see RecHit or Digi Tasks
+  uint32_t rawidHBHEValid = 0;
+  uint32_t rawidHFValid = 0;
 
-	/*
+  /*
 	 * STEP1: 
 	 * Loop over the data digis and 
 	 * - do ... for all the data digis
@@ -659,284 +786,242 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 	 * --- compare soi FG
 	 * --- Do not fill anything for emulator Et!!!
 	 */
-	for (HcalTrigPrimDigiCollection::const_iterator it=cdata->begin();
-		it!=cdata->end(); ++it)
-	{
-		//	Explicit check on the DetIds present in the Collection
-		HcalTrigTowerDetId tid = it->id();
-		uint32_t rawid = _ehashmap.lookup(tid);
-		if (rawid==0) {
-			meUnknownIds1LS->Fill(1); 
-			_unknownIdsPresent = true; 
-			continue;
-		}
-		HcalElectronicsId const& eid(rawid);
-		if (tid.ietaAbs()>=29)
-			rawidHFValid = tid.rawId();
-		else 
-			rawidHBHEValid = tid.rawId();
+  for (HcalTrigPrimDigiCollection::const_iterator it = cdata->begin(); it != cdata->end(); ++it) {
+    //	Explicit check on the DetIds present in the Collection
+    HcalTrigTowerDetId tid = it->id();
+    uint32_t rawid = _ehashmap.lookup(tid);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (tid.ietaAbs() >= 29)
+      rawidHFValid = tid.rawId();
+    else
+      rawidHBHEValid = tid.rawId();
 
-		//
-		//	HF 2x3 TPs Treat theam separately and only for ONLINE!
-		//
-		if (tid.version()==0 && tid.ietaAbs()>=29)
-		{
-			//	do this only for online processing
-			if (_ptype == fOnline)
-			{
-				_cOccupancyData2x3_depthlike.fill(tid);
-				HcalTrigPrimDigiCollection::const_iterator jt=cemul->find(tid);
-				if (jt!=cemul->end())
-					_cEtCorr2x3_TTSubdet.fill(tid, it->SOI_compressedEt(),
-						jt->SOI_compressedEt());
-			}
+    //
+    //	HF 2x3 TPs Treat theam separately and only for ONLINE!
+    //
+    if (tid.version() == 0 && tid.ietaAbs() >= 29) {
+      //	do this only for online processing
+      if (_ptype == fOnline) {
+        _cOccupancyData2x3_depthlike.fill(tid);
+        HcalTrigPrimDigiCollection::const_iterator jt = cemul->find(tid);
+        if (jt != cemul->end())
+          _cEtCorr2x3_TTSubdet.fill(tid, it->SOI_compressedEt(), jt->SOI_compressedEt());
+      }
 
-			//	skip to the next tp digi
-			continue;
-		}
+      //	skip to the next tp digi
+      continue;
+    }
 
-		//	FROM THIS POINT, HBHE + 1x1 HF TPs
-		int soiEt_d = it->t0().compressedEt();
-		int soiFG_d[constants::NUM_FGBITS];
-		for (uint32_t ibit=0; ibit<constants::NUM_FGBITS; ibit++)
-			soiFG_d[ibit] = it->t0().fineGrain(ibit)?1:0;
-		tid.ietaAbs()>=29?numHF++:numHBHE++;
+    //	FROM THIS POINT, HBHE + 1x1 HF TPs
+    int soiEt_d = it->t0().compressedEt();
+    int soiFG_d[constants::NUM_FGBITS];
+    for (uint32_t ibit = 0; ibit < constants::NUM_FGBITS; ibit++)
+      soiFG_d[ibit] = it->t0().fineGrain(ibit) ? 1 : 0;
+    tid.ietaAbs() >= 29 ? numHF++ : numHBHE++;
 
-		//	 fill w/o a cut
-		_cEtData_TTSubdet.fill(tid, soiEt_d);
-		_cEtData_depthlike.fill(tid, soiEt_d);
-		_cOccupancyData_depthlike.fill(tid);
+    //	 fill w/o a cut
+    _cEtData_TTSubdet.fill(tid, soiEt_d);
+    _cEtData_depthlike.fill(tid, soiEt_d);
+    _cOccupancyData_depthlike.fill(tid);
 
-		if (_ptype == fOnline) {
-			if (tid.ietaAbs()>=29) {
-				if (soiEt_d > 0) {
-					_cOccupancy_HF_depth.fill(tid);
-					_cOccupancy_HF_ieta.fill(tid);
-				}
-			}
-		}
-		if (_ptype != fOffline) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cOccupancyData_ElectronicsVME.fill(eid);
-				_cEtData_ElectronicsVME.fill(eid, soiEt_d);
-			}
-			else
-			{
-				_cOccupancyData_ElectronicsuTCA.fill(eid);
-				_cEtData_ElectronicsuTCA.fill(eid, soiEt_d);
-			}
-		}
+    if (_ptype == fOnline) {
+      if (tid.ietaAbs() >= 29) {
+        if (soiEt_d > 0) {
+          _cOccupancy_HF_depth.fill(tid);
+          _cOccupancy_HF_ieta.fill(tid);
+        }
+      }
+    }
+    if (_ptype != fOffline) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cOccupancyData_ElectronicsVME.fill(eid);
+        _cEtData_ElectronicsVME.fill(eid, soiEt_d);
+      } else {
+        _cOccupancyData_ElectronicsuTCA.fill(eid);
+        _cEtData_ElectronicsuTCA.fill(eid, soiEt_d);
+      }
+    }
 
-		//	FILL w/a CUT
-		if (soiEt_d>_cutEt)
-		{
-			tid.ietaAbs()>=29?numCutHF++:numCutHBHE++;
-			_cOccupancyCutData_depthlike.fill(tid);
-			_cEtCutData_depthlike.fill(tid, soiEt_d);
+    //	FILL w/a CUT
+    if (soiEt_d > _cutEt) {
+      tid.ietaAbs() >= 29 ? numCutHF++ : numCutHBHE++;
+      _cOccupancyCutData_depthlike.fill(tid);
+      _cEtCutData_depthlike.fill(tid, soiEt_d);
 
-			//	ONLINE ONLY!
-			if (_ptype==fOnline)
-			{
-				_cEtCutDatavsLS_TTSubdet.fill(tid, _currentLS, soiEt_d);
-				_cEtCutDatavsBX_TTSubdet.fill(tid, bx, soiEt_d);
-				_xDataTotal.get(eid)++;
-			}
-			//	^^^ONLINE ONLY!
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cOccupancyCutData_ElectronicsVME.fill(eid);
-				else
-					_cOccupancyCutData_ElectronicsuTCA.fill(eid);
-			}
-		}
+      //	ONLINE ONLY!
+      if (_ptype == fOnline) {
+        _cEtCutDatavsLS_TTSubdet.fill(tid, _currentLS, soiEt_d);
+        _cEtCutDatavsBX_TTSubdet.fill(tid, bx, soiEt_d);
+        _xDataTotal.get(eid)++;
+      }
+      //	^^^ONLINE ONLY!
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cOccupancyCutData_ElectronicsVME.fill(eid);
+        else
+          _cOccupancyCutData_ElectronicsuTCA.fill(eid);
+      }
+    }
 
-		//	FIND the EMULATOR DIGI
-		HcalTrigPrimDigiCollection::const_iterator jt=cemul->find(tid);
-		if (jt!=cemul->end())
-		{
-			//	if PRESENT!
-			int soiEt_e = jt->SOI_compressedEt();
-			int soiFG_e[constants::NUM_FGBITS];
-			for (uint32_t ibit=0; ibit<constants::NUM_FGBITS; ibit++)
-				soiFG_e[ibit] = jt->t0().fineGrain(ibit)?1:0;
-			//	if both are zeroes => set 1
-			double rEt = soiEt_d==0 && soiEt_e==0?1:
-				double(std::min(soiEt_d, soiEt_e))/
-				double(std::max(soiEt_e, soiEt_d));
+    //	FIND the EMULATOR DIGI
+    HcalTrigPrimDigiCollection::const_iterator jt = cemul->find(tid);
+    if (jt != cemul->end()) {
+      //	if PRESENT!
+      int soiEt_e = jt->SOI_compressedEt();
+      int soiFG_e[constants::NUM_FGBITS];
+      for (uint32_t ibit = 0; ibit < constants::NUM_FGBITS; ibit++)
+        soiFG_e[ibit] = jt->t0().fineGrain(ibit) ? 1 : 0;
+      //	if both are zeroes => set 1
+      double rEt =
+          soiEt_d == 0 && soiEt_e == 0 ? 1 : double(std::min(soiEt_d, soiEt_e)) / double(std::max(soiEt_e, soiEt_d));
 
-			//	ONLINE ONLY!
-			if (_ptype==fOnline)
-			{		
-				_xNumCorr.get(eid)++;
-				tid.ietaAbs()>=29?numCorrHF++:numCorrHBHE++;
-				_cEtCorrRatiovsLS_TTSubdet.fill(tid, _currentLS, rEt);
-				_cEtCorrRatiovsBX_TTSubdet.fill(tid, bx, rEt);
-			}
-			//	^^^ONLINE ONLY!
+      //	ONLINE ONLY!
+      if (_ptype == fOnline) {
+        _xNumCorr.get(eid)++;
+        tid.ietaAbs() >= 29 ? numCorrHF++ : numCorrHBHE++;
+        _cEtCorrRatiovsLS_TTSubdet.fill(tid, _currentLS, rEt);
+        _cEtCorrRatiovsBX_TTSubdet.fill(tid, bx, rEt);
+      }
+      //	^^^ONLINE ONLY!
 
-			_cEtCorrRatio_depthlike.fill(tid, rEt);
-			_cEtCorr_TTSubdet.fill(tid, soiEt_d, soiEt_e);
-			for (uint32_t ibit=0; ibit<constants::NUM_FGBITS; ibit++)
-				_cFGCorr_TTSubdet[ibit].fill(tid, soiFG_d[ibit], soiFG_e[ibit]);
-			//	FILL w/o a CUT
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-				{
-					_cEtCorrRatio_ElectronicsVME.fill(eid, rEt);
-				}
-				else
-				{
-					_cEtCorrRatio_ElectronicsuTCA.fill(eid, rEt);
-				}
-			}
+      _cEtCorrRatio_depthlike.fill(tid, rEt);
+      _cEtCorr_TTSubdet.fill(tid, soiEt_d, soiEt_e);
+      for (uint32_t ibit = 0; ibit < constants::NUM_FGBITS; ibit++)
+        _cFGCorr_TTSubdet[ibit].fill(tid, soiFG_d[ibit], soiFG_e[ibit]);
+      //	FILL w/o a CUT
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid()) {
+          _cEtCorrRatio_ElectronicsVME.fill(eid, rEt);
+        } else {
+          _cEtCorrRatio_ElectronicsuTCA.fill(eid, rEt);
+        }
+      }
 
-			//	if SOI Et are not equal
-			//	fill mismatched
-			if (soiEt_d!=soiEt_e)
-			{
-				tid.ietaAbs()>=29?numMsmHF++:numMsmHBHE++;
-				_cEtMsm_depthlike.fill(tid);
-				if (_ptype != fOffline) { // hidefed2crate
-					if (eid.isVMEid())
-						_cEtMsm_ElectronicsVME.fill(eid);
-					else
-						_cEtMsm_ElectronicsuTCA.fill(eid);
-				}
-				if (_ptype==fOnline)
-					_xEtMsm.get(eid)++;
-			}
-			//	 if SOI FG are not equal
-			//	 fill mismatched. 
-			//	 Do this comparison only for FG Bits that are commissioned
-			for (uint32_t ibit=0; ibit<constants::NUM_FGBITS; ibit++)
-				if (soiFG_d[ibit]!=soiFG_e[ibit] && _vFGBitsReady[ibit])
-				{
-					_cFGMsm_depthlike.fill(tid);
-					if (_ptype != fOffline) { // hidefed2crate
-						if (eid.isVMEid())
-							_cFGMsm_ElectronicsVME.fill(eid);
-						else
-							_cFGMsm_ElectronicsuTCA.fill(eid);
-					}
-					if (_ptype==fOnline)
-						_xFGMsm.get(eid)++;
-				}
-		}
-		else
-		{
-			//	IF MISSING
-			_cEtCorr_TTSubdet.fill(tid, soiEt_d, -2);
-			_cMsnEmul_depthlike.fill(tid);
-			tid.ietaAbs()>=29?numMsnHF++:numMsnHBHE++;
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cMsnEmul_ElectronicsVME.fill(eid);
-				else
-					_cMsnEmul_ElectronicsuTCA.fill(eid);
-			}
+      //	if SOI Et are not equal
+      //	fill mismatched
+      if (soiEt_d != soiEt_e) {
+        tid.ietaAbs() >= 29 ? numMsmHF++ : numMsmHBHE++;
+        _cEtMsm_depthlike.fill(tid);
+        if (_ptype != fOffline) {  // hidefed2crate
+          if (eid.isVMEid())
+            _cEtMsm_ElectronicsVME.fill(eid);
+          else
+            _cEtMsm_ElectronicsuTCA.fill(eid);
+        }
+        if (_ptype == fOnline)
+          _xEtMsm.get(eid)++;
+      }
+      //	 if SOI FG are not equal
+      //	 fill mismatched.
+      //	 Do this comparison only for FG Bits that are commissioned
+      for (uint32_t ibit = 0; ibit < constants::NUM_FGBITS; ibit++)
+        if (soiFG_d[ibit] != soiFG_e[ibit] && _vFGBitsReady[ibit]) {
+          _cFGMsm_depthlike.fill(tid);
+          if (_ptype != fOffline) {  // hidefed2crate
+            if (eid.isVMEid())
+              _cFGMsm_ElectronicsVME.fill(eid);
+            else
+              _cFGMsm_ElectronicsuTCA.fill(eid);
+          }
+          if (_ptype == fOnline)
+            _xFGMsm.get(eid)++;
+        }
+    } else {
+      //	IF MISSING
+      _cEtCorr_TTSubdet.fill(tid, soiEt_d, -2);
+      _cMsnEmul_depthlike.fill(tid);
+      tid.ietaAbs() >= 29 ? numMsnHF++ : numMsnHBHE++;
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cMsnEmul_ElectronicsVME.fill(eid);
+        else
+          _cMsnEmul_ElectronicsuTCA.fill(eid);
+      }
 
-			if (soiEt_d>_cutEt)
-			{
-				tid.ietaAbs()>=29?numMsnCutHF++:numMsnCutHBHE++;
-				if (_ptype==fOnline)
-					_xEmulMsn.get(eid)++;
-			}
-		}
-	}
-	
-	if (_ptype == fOnline) {
-		for (HcalTrigPrimDigiCollection::const_iterator it=cemul_noTDCCut->begin(); it!=cemul_noTDCCut->end(); ++it)	{
-			//	Explicit check on the DetIds present in the Collection
-			HcalTrigTowerDetId tid = it->id();
-			uint32_t rawid = _ehashmap.lookup(tid);
-			if (rawid==0) {
-				continue;
-			}
-			if (tid.version()==0 && tid.ietaAbs()>=29)
-			{
-				continue;
-			}
-			int soiEt_e = it->SOI_compressedEt();
-			if (tid.ietaAbs() >= 29) {
-				if (soiEt_e > 0) {
-					_cOccupancyNoTDC_HF_depth.fill(tid);
-					_cOccupancyNoTDC_HF_ieta.fill(tid);
-				}
-			}
-		}
-	}
+      if (soiEt_d > _cutEt) {
+        tid.ietaAbs() >= 29 ? numMsnCutHF++ : numMsnCutHBHE++;
+        if (_ptype == fOnline)
+          _xEmulMsn.get(eid)++;
+      }
+    }
+  }
 
-	if (rawidHFValid!=0 && rawidHBHEValid!=0)
-	{
-		//	ONLINE ONLY!
-		if (_ptype==fOnline)
-		{
-			_cOccupancyDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx,
-				numHBHE);
-			_cOccupancyDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx,
-				numHF);
-			_cOccupancyCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), 
-				bx, numCutHBHE);
-			_cOccupancyCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx,
-				numCutHF);
-			_cOccupancyDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), 
-				_currentLS, numHBHE);
-			_cOccupancyDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), 
-				_currentLS,numHF);
-			_cOccupancyCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				_currentLS, numCutHBHE);
-			_cOccupancyCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), 
-				_currentLS, numCutHF);
-	
-			_cEtMsmvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS,
-				numMsmHBHE);
-			_cEtMsmvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, 
-				numMsmHF);
-			_cEtMsmvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx,
-				numMsmHBHE);
-			_cEtMsmvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, 
-				numMsmHF);
-			
-			_cEtMsmRatiovsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), 
-				_currentLS,
-				double(numMsmHBHE)/double(numCorrHBHE));
-			_cEtMsmRatiovsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), 
-				_currentLS, 
-				double(numMsmHF)/double(numCorrHF));
-			_cEtMsmRatiovsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx,
-				double(numMsmHBHE)/double(numCorrHBHE));
-			_cEtMsmRatiovsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, 
-				double(numMsmHF)/double(numCorrHF));
-	
-			_cMsnEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				_currentLS, numMsnHBHE);
-			_cMsnEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				_currentLS, numMsnHF);
-			_cMsnCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				_currentLS, numMsnCutHBHE);
-			_cMsnCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				_currentLS, numMsnCutHF);
-	
-			_cMsnEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				bx, numMsnHBHE);
-			_cMsnEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				bx, numMsnHF);
-			_cMsnCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				bx, numMsnCutHBHE);
-			_cMsnCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				bx, numMsnCutHF);
-		}
-	}
+  if (_ptype == fOnline) {
+    for (HcalTrigPrimDigiCollection::const_iterator it = cemul_noTDCCut->begin(); it != cemul_noTDCCut->end(); ++it) {
+      //	Explicit check on the DetIds present in the Collection
+      HcalTrigTowerDetId tid = it->id();
+      uint32_t rawid = _ehashmap.lookup(tid);
+      if (rawid == 0) {
+        continue;
+      }
+      if (tid.version() == 0 && tid.ietaAbs() >= 29) {
+        continue;
+      }
+      int soiEt_e = it->SOI_compressedEt();
+      if (tid.ietaAbs() >= 29) {
+        if (soiEt_e > 0) {
+          _cOccupancyNoTDC_HF_depth.fill(tid);
+          _cOccupancyNoTDC_HF_ieta.fill(tid);
+        }
+      }
+    }
+  }
 
-	numHBHE=0; numHF=0; numCutHBHE=0; numCutHF=0;
-	numMsnHBHE=0; numMsnHF=0; numCutHBHE=0; numCutHF=0;
+  if (rawidHFValid != 0 && rawidHBHEValid != 0) {
+    //	ONLINE ONLY!
+    if (_ptype == fOnline) {
+      _cOccupancyDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numHBHE);
+      _cOccupancyDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numHF);
+      _cOccupancyCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numCutHBHE);
+      _cOccupancyCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numCutHF);
+      _cOccupancyDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numHBHE);
+      _cOccupancyDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numHF);
+      _cOccupancyCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numCutHBHE);
+      _cOccupancyCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numCutHF);
 
-	//	reset 
-	rawidHBHEValid = 0;
-	rawidHFValid = 0;
+      _cEtMsmvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numMsmHBHE);
+      _cEtMsmvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numMsmHF);
+      _cEtMsmvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numMsmHBHE);
+      _cEtMsmvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numMsmHF);
 
-	/*
+      _cEtMsmRatiovsLS_TTSubdet.fill(
+          HcalTrigTowerDetId(rawidHBHEValid), _currentLS, double(numMsmHBHE) / double(numCorrHBHE));
+      _cEtMsmRatiovsLS_TTSubdet.fill(
+          HcalTrigTowerDetId(rawidHFValid), _currentLS, double(numMsmHF) / double(numCorrHF));
+      _cEtMsmRatiovsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, double(numMsmHBHE) / double(numCorrHBHE));
+      _cEtMsmRatiovsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, double(numMsmHF) / double(numCorrHF));
+
+      _cMsnEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numMsnHBHE);
+      _cMsnEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numMsnHF);
+      _cMsnCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numMsnCutHBHE);
+      _cMsnCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numMsnCutHF);
+
+      _cMsnEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numMsnHBHE);
+      _cMsnEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numMsnHF);
+      _cMsnCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numMsnCutHBHE);
+      _cMsnCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numMsnCutHF);
+    }
+  }
+
+  numHBHE = 0;
+  numHF = 0;
+  numCutHBHE = 0;
+  numCutHF = 0;
+  numMsnHBHE = 0;
+  numMsnHF = 0;
+  numCutHBHE = 0;
+  numCutHF = 0;
+
+  //	reset
+  rawidHBHEValid = 0;
+  rawidHFValid = 0;
+
+  /*
 	 *	STEP2:
 	 *	Loop over the emulator digis and 
 	 *	- do ... for all the emulator digis
@@ -944,222 +1029,192 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 	 *	--- if found skip
 	 *	--- if not found - fill the missing Data plot
 	 */
-	for (HcalTrigPrimDigiCollection::const_iterator it=cemul->begin();
-		it!=cemul->end(); ++it)
-	{
-		//	Explicit check on the DetIds present in the Collection
-		HcalTrigTowerDetId tid = it->id();
-		uint32_t rawid = _ehashmap.lookup(tid);
-		if (rawid==0)
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent = true; continue;}
-		HcalElectronicsId const& eid(rawid);
-		if (tid.ietaAbs()>=29)
-			rawidHFValid = tid.rawId();
-		else 
-			rawidHBHEValid = tid.rawId();
+  for (HcalTrigPrimDigiCollection::const_iterator it = cemul->begin(); it != cemul->end(); ++it) {
+    //	Explicit check on the DetIds present in the Collection
+    HcalTrigTowerDetId tid = it->id();
+    uint32_t rawid = _ehashmap.lookup(tid);
+    if (rawid == 0) {
+      meUnknownIds1LS->Fill(1);
+      _unknownIdsPresent = true;
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+    if (tid.ietaAbs() >= 29)
+      rawidHFValid = tid.rawId();
+    else
+      rawidHBHEValid = tid.rawId();
 
-		//	HF 2x3 TPs. Only do it for Online!!!
-		if (tid.version()==0 && tid.ietaAbs()>=29)
-		{
-			//	only do this for online processing
-			if (_ptype==fOnline)
-				_cOccupancyEmul2x3_depthlike.fill(tid);
-			continue;
-		}
-		int soiEt = it->SOI_compressedEt();
+    //	HF 2x3 TPs. Only do it for Online!!!
+    if (tid.version() == 0 && tid.ietaAbs() >= 29) {
+      //	only do this for online processing
+      if (_ptype == fOnline)
+        _cOccupancyEmul2x3_depthlike.fill(tid);
+      continue;
+    }
+    int soiEt = it->SOI_compressedEt();
 
-		//	FILL/INCREMENT w/o a CUT
-		tid.ietaAbs()>=29?numHF++:numHBHE++;
-		_cEtEmul_TTSubdet.fill(tid, soiEt);
-		_cEtEmul_depthlike.fill(tid, soiEt);
-		_cOccupancyEmul_depthlike.fill(tid);
-		if (_ptype != fOffline) { // hidefed2crate
-			if (eid.isVMEid())
-			{
-				_cOccupancyEmul_ElectronicsVME.fill(eid);
-				_cEtEmul_ElectronicsVME.fill(eid, soiEt);
-			}
-			else
-			{
-				_cOccupancyEmul_ElectronicsuTCA.fill(eid);
-				_cEtEmul_ElectronicsuTCA.fill(eid, soiEt);
-			}
-		}
+    //	FILL/INCREMENT w/o a CUT
+    tid.ietaAbs() >= 29 ? numHF++ : numHBHE++;
+    _cEtEmul_TTSubdet.fill(tid, soiEt);
+    _cEtEmul_depthlike.fill(tid, soiEt);
+    _cOccupancyEmul_depthlike.fill(tid);
+    if (_ptype != fOffline) {  // hidefed2crate
+      if (eid.isVMEid()) {
+        _cOccupancyEmul_ElectronicsVME.fill(eid);
+        _cEtEmul_ElectronicsVME.fill(eid, soiEt);
+      } else {
+        _cOccupancyEmul_ElectronicsuTCA.fill(eid);
+        _cEtEmul_ElectronicsuTCA.fill(eid, soiEt);
+      }
+    }
 
-		//	FILL w/ a CUT
-		if (soiEt>_cutEt)
-		{
-			tid.ietaAbs()>=29?numCutHF++:numCutHBHE++;
-			_cOccupancyCutEmul_depthlike.fill(tid);
-			_cEtCutEmul_depthlike.fill(tid, soiEt);
-			if (_ptype != fOffline) { // hidefed2crate
-				if (eid.isVMEid())
-					_cOccupancyCutEmul_ElectronicsVME.fill(eid);
-				else 
-					_cOccupancyCutEmul_ElectronicsuTCA.fill(eid);
-			}
+    //	FILL w/ a CUT
+    if (soiEt > _cutEt) {
+      tid.ietaAbs() >= 29 ? numCutHF++ : numCutHBHE++;
+      _cOccupancyCutEmul_depthlike.fill(tid);
+      _cEtCutEmul_depthlike.fill(tid, soiEt);
+      if (_ptype != fOffline) {  // hidefed2crate
+        if (eid.isVMEid())
+          _cOccupancyCutEmul_ElectronicsVME.fill(eid);
+        else
+          _cOccupancyCutEmul_ElectronicsuTCA.fill(eid);
+      }
 
-			//	ONLINE ONLY!
-			if (_ptype==fOnline)
-			{
-				_cEtCutEmulvsLS_TTSubdet.fill(tid, _currentLS, soiEt);
-				_cEtCutEmulvsBX_TTSubdet.fill(tid, bx, soiEt);
-				_xEmulTotal.get(eid)++;
-			}
-			//	^^^ONLINE ONLY!
-		}
+      //	ONLINE ONLY!
+      if (_ptype == fOnline) {
+        _cEtCutEmulvsLS_TTSubdet.fill(tid, _currentLS, soiEt);
+        _cEtCutEmulvsBX_TTSubdet.fill(tid, bx, soiEt);
+        _xEmulTotal.get(eid)++;
+      }
+      //	^^^ONLINE ONLY!
+    }
 
-		// Look for a data digi. 
-		// Do not perform if the emulated digi is zero suppressed.
-		if(!(it->zsMarkAndPass())) {
-			HcalTrigPrimDigiCollection::const_iterator jt=cdata->find(tid);
-			if (jt==cdata->end())
-			{
-				tid.ietaAbs()>=29?numMsnHF++:numMsnHBHE++;
-				_cEtCorr_TTSubdet.fill(tid, -2, soiEt);
-				_cMsnData_depthlike.fill(tid);
-				if (_ptype != fOffline) { // hidefed2crate
-					if (eid.isVMEid())
-						_cMsnData_ElectronicsVME.fill(eid);
-					else
-						_cMsnData_ElectronicsuTCA.fill(eid);
-				}
-				if (soiEt>_cutEt)
-				{
-					tid.ietaAbs()>=29?numMsnCutHF++:numMsnCutHBHE++;
-					if (_ptype==fOnline)
-						_xDataMsn.get(eid)++;
-				}
-			}
-		}
-	}
+    // Look for a data digi.
+    // Do not perform if the emulated digi is zero suppressed.
+    if (!(it->zsMarkAndPass())) {
+      HcalTrigPrimDigiCollection::const_iterator jt = cdata->find(tid);
+      if (jt == cdata->end()) {
+        tid.ietaAbs() >= 29 ? numMsnHF++ : numMsnHBHE++;
+        _cEtCorr_TTSubdet.fill(tid, -2, soiEt);
+        _cMsnData_depthlike.fill(tid);
+        if (_ptype != fOffline) {  // hidefed2crate
+          if (eid.isVMEid())
+            _cMsnData_ElectronicsVME.fill(eid);
+          else
+            _cMsnData_ElectronicsuTCA.fill(eid);
+        }
+        if (soiEt > _cutEt) {
+          tid.ietaAbs() >= 29 ? numMsnCutHF++ : numMsnCutHBHE++;
+          if (_ptype == fOnline)
+            _xDataMsn.get(eid)++;
+        }
+      }
+    }
+  }
 
-	//	ONLINE ONLY!
-	if (_ptype==fOnline) {
-		if (rawidHBHEValid != 0) {
-			_cOccupancyEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx,
-				numHBHE);
-			_cOccupancyCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), 
-				bx,
-				numCutHBHE);
-			_cOccupancyEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), 
-				_currentLS, numHBHE);
-			_cOccupancyCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				_currentLS, numCutHBHE);
-			_cMsnDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				_currentLS, numMsnHBHE);
-			_cMsnCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				_currentLS, numMsnCutHBHE);
-			_cMsnDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				bx, numMsnHBHE);
-			_cMsnCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid),
-				bx, numMsnCutHBHE);
-		}
-		if (rawidHFValid!=0) {
-			_cOccupancyEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx,
-				numHF);
-			_cOccupancyCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx,
-				numCutHF);
-			_cOccupancyEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), 
-				_currentLS,numHF);
-			_cOccupancyCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), 
-				_currentLS, numCutHF);
-			_cMsnDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				_currentLS, numMsnHF);
-			_cMsnCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				_currentLS, numMsnCutHF);
-			_cMsnDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				bx, numMsnHF);
-			_cMsnCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid),
-				bx, numMsnCutHF);
-		}
-		//	^^^ONLINE ONLY!
-	}
+  //	ONLINE ONLY!
+  if (_ptype == fOnline) {
+    if (rawidHBHEValid != 0) {
+      _cOccupancyEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numHBHE);
+      _cOccupancyCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numCutHBHE);
+      _cOccupancyEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numHBHE);
+      _cOccupancyCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numCutHBHE);
+      _cMsnDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numMsnHBHE);
+      _cMsnCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), _currentLS, numMsnCutHBHE);
+      _cMsnDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numMsnHBHE);
+      _cMsnCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHBHEValid), bx, numMsnCutHBHE);
+    }
+    if (rawidHFValid != 0) {
+      _cOccupancyEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numHF);
+      _cOccupancyCutEmulvsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numCutHF);
+      _cOccupancyEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numHF);
+      _cOccupancyCutEmulvsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numCutHF);
+      _cMsnDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numMsnHF);
+      _cMsnCutDatavsLS_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), _currentLS, numMsnCutHF);
+      _cMsnDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numMsnHF);
+      _cMsnCutDatavsBX_TTSubdet.fill(HcalTrigTowerDetId(rawidHFValid), bx, numMsnCutHF);
+    }
+    //	^^^ONLINE ONLY!
+  }
 
-	if (_ptype == fOnline) {
-		// Compare the sent ("uHTR") and received (L1T "layer1") TPs
-		// This algorithm is copied from DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc 
-		// ...but it turns out to be extremely useful for detecting uHTR problems
-		_vTPDigis_SentRec.clear();
-		ComparisonHelper::zip(cdata->begin(), cdata->end(), 
-							cdataL1Rec->begin(), cdataL1Rec->end(), 
-							std::inserter(_vTPDigis_SentRec, _vTPDigis_SentRec.begin()), 
-							HcalTrigPrimDigiCollection::key_compare());
+  if (_ptype == fOnline) {
+    // Compare the sent ("uHTR") and received (L1T "layer1") TPs
+    // This algorithm is copied from DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+    // ...but it turns out to be extremely useful for detecting uHTR problems
+    _vTPDigis_SentRec.clear();
+    ComparisonHelper::zip(cdata->begin(),
+                          cdata->end(),
+                          cdataL1Rec->begin(),
+                          cdataL1Rec->end(),
+                          std::inserter(_vTPDigis_SentRec, _vTPDigis_SentRec.begin()),
+                          HcalTrigPrimDigiCollection::key_compare());
 
-		for ( const auto& tpPair : _vTPDigis_SentRec) {
-			// From here, literal copy pasta from L1T
-			const auto& sentTp = tpPair.first;
-			const auto& recdTp = tpPair.second;
-			const int ieta = sentTp.id().ieta();
-			if ( abs(ieta) > 28 && sentTp.id().version() != 1 ) continue;
-			//const int iphi = sentTp.id().iphi();
-			const bool towerMasked = recdTp.sample(0).raw() & (1<<13);
-			//const bool linkMasked  = recdTp.sample(0).raw() & (1<<14);
-			const bool linkError   = recdTp.sample(0).raw() & (1<<15);
+    for (const auto& tpPair : _vTPDigis_SentRec) {
+      // From here, literal copy pasta from L1T
+      const auto& sentTp = tpPair.first;
+      const auto& recdTp = tpPair.second;
+      const int ieta = sentTp.id().ieta();
+      if (abs(ieta) > 28 && sentTp.id().version() != 1)
+        continue;
+      //const int iphi = sentTp.id().iphi();
+      const bool towerMasked = recdTp.sample(0).raw() & (1 << 13);
+      //const bool linkMasked  = recdTp.sample(0).raw() & (1<<14);
+      const bool linkError = recdTp.sample(0).raw() & (1 << 15);
 
-			if ( towerMasked || linkError ) {
-				// Do not compare if known to be bad
-				continue;
-			}
-			const bool HetAgreement = sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt();
-			const bool Hfb1Agreement = sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain();
-			// Ignore minBias (FB2) bit if we receieve 0 ET, which means it is likely zero-suppressed on HCal readout side
-			const bool Hfb2Agreement = ( abs(ieta) < 29 ) ? true : (recdTp.SOI_compressedEt()==0 || (sentTp.SOI_fineGrain(1) == recdTp.SOI_fineGrain(1)));
-			if (!(HetAgreement && Hfb1Agreement && Hfb2Agreement)) {
-				HcalTrigTowerDetId tid = sentTp.id();
-				uint32_t rawid = _ehashmap.lookup(tid);
-				if (rawid==0) {
-					continue;
-				}
-				HcalElectronicsId const& eid(rawid);
+      if (towerMasked || linkError) {
+        // Do not compare if known to be bad
+        continue;
+      }
+      const bool HetAgreement = sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt();
+      const bool Hfb1Agreement = sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain();
+      // Ignore minBias (FB2) bit if we receieve 0 ET, which means it is likely zero-suppressed on HCal readout side
+      const bool Hfb2Agreement =
+          (abs(ieta) < 29) ? true
+                           : (recdTp.SOI_compressedEt() == 0 || (sentTp.SOI_fineGrain(1) == recdTp.SOI_fineGrain(1)));
+      if (!(HetAgreement && Hfb1Agreement && Hfb2Agreement)) {
+        HcalTrigTowerDetId tid = sentTp.id();
+        uint32_t rawid = _ehashmap.lookup(tid);
+        if (rawid == 0) {
+          continue;
+        }
+        HcalElectronicsId const& eid(rawid);
 
-				_cEtMsm_uHTR_L1T_depthlike.fill(tid);
-				_cEtMsm_uHTR_L1T_LS.fill(_currentLS);
-				_xSentRecL1Msm.get(eid)++;
-			}
-		}
-	}
+        _cEtMsm_uHTR_L1T_depthlike.fill(tid);
+        _cEtMsm_uHTR_L1T_LS.fill(_currentLS);
+        _xSentRecL1Msm.get(eid)++;
+      }
+    }
+  }
 }
 
-/* virtual */ void TPTask::beginLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	DQTask::beginLuminosityBlock(lb, es);
+/* virtual */ void TPTask::beginLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::beginLuminosityBlock(lb, es);
 }
 
-/* virtual */ void TPTask::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	if (_ptype!=fOnline)
-		return;
+/* virtual */ void TPTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  if (_ptype != fOnline)
+    return;
 
-	//
-	//	GENERATE STATUS ONLY FOR ONLINE!
-	//
-	for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-		it!=_vhashFEDs.end(); ++it)
-	{
-		flag::Flag fSum("TP");
-		HcalElectronicsId eid = HcalElectronicsId(*it);
+  //
+  //	GENERATE STATUS ONLY FOR ONLINE!
+  //
+  for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+    flag::Flag fSum("TP");
+    HcalElectronicsId eid = HcalElectronicsId(*it);
 
-		std::vector<uint32_t>::const_iterator cit=std::find(
-			_vcdaqEids.begin(), _vcdaqEids.end(), *it);
-		if (cit==_vcdaqEids.end())
-		{
-			//	not @cDAQ
-			for (uint32_t iflag=0; iflag<_vflags.size(); iflag++)
-				_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-					int(flag::fNCDAQ));
-			_cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-			continue;
-		}
+    std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
+    if (cit == _vcdaqEids.end()) {
+      //	not @cDAQ
+      for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
+        _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
+      _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+      continue;
+    }
 
-		if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid))
-		{
-			//	FED is @cDAQ
-			double etmsm = _xNumCorr.get(eid)>0?
-				double(_xEtMsm.get(eid))/double(_xNumCorr.get(eid)):0;
-			/*	
+    if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid)) {
+      //	FED is @cDAQ
+      double etmsm = _xNumCorr.get(eid) > 0 ? double(_xEtMsm.get(eid)) / double(_xNumCorr.get(eid)) : 0;
+      /*	
 			 * UNUSED VARS
 			 * double dmsm = _xDataTotal.get(eid)>0?
 				double(_xDataMsn.get(eid))/double(_xDataTotal.get(eid)):0;
@@ -1168,13 +1223,13 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 			double fgmsm = _xNumCorr.get(eid)>0?
 				double(_xFGMsm.get(eid))/double(_xNumCorr.get(eid)):0;				
 				*/
-			if (etmsm>=_thresh_EtMsmRate_high)
-				_vflags[fEtMsm]._state = flag::fBAD;
-			else if (etmsm>=_thresh_EtMsmRate_low)
-				_vflags[fEtMsm]._state = flag::fPROBLEMATIC;
-			else
-				_vflags[fEtMsm]._state = flag::fGOOD;
-			/*
+      if (etmsm >= _thresh_EtMsmRate_high)
+        _vflags[fEtMsm]._state = flag::fBAD;
+      else if (etmsm >= _thresh_EtMsmRate_low)
+        _vflags[fEtMsm]._state = flag::fPROBLEMATIC;
+      else
+        _vflags[fEtMsm]._state = flag::fGOOD;
+      /*
 			 *	DISABLE THESE FLAGS FOR ONLINE FOR NOW!
 			if (dmsm>=_thresh_DataMsn)
 				_vflags[fDataMsn]._state = flag::fBAD;
@@ -1185,47 +1240,45 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 			else
 				_vflags[fEmulMsn]._state = flag::fGOOD;
 				*/
-			
-			if (_ptype == fOnline) {
-				if (_xSentRecL1Msm.get(eid) >= 1) {
-					_vflags[fSentRecL1Msm]._state = flag::fBAD;
-				} else {
-					_vflags[fSentRecL1Msm]._state = flag::fGOOD;
-				}
-			}
-		}
 
-		if (_unknownIdsPresent)
-			_vflags[fUnknownIds]._state = flag::fBAD;
-		else
-			_vflags[fUnknownIds]._state = flag::fGOOD;
+      if (_ptype == fOnline) {
+        if (_xSentRecL1Msm.get(eid) >= 1) {
+          _vflags[fSentRecL1Msm]._state = flag::fBAD;
+        } else {
+          _vflags[fSentRecL1Msm]._state = flag::fGOOD;
+        }
+      }
+    }
 
+    if (_unknownIdsPresent)
+      _vflags[fUnknownIds]._state = flag::fBAD;
+    else
+      _vflags[fUnknownIds]._state = flag::fGOOD;
 
+    int iflag = 0;
+    for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
+      _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
+      fSum += (*ft);
+      iflag++;
 
-		int iflag=0;
-		for (std::vector<flag::Flag>::iterator ft=_vflags.begin();
-			ft!=_vflags.end(); ++ft)
-		{
-			_cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag),
-				ft->_state);
-			fSum+=(*ft);
-			iflag++;
+      //	this is the MUST!
+      //	reset after using this flag
+      ft->reset();
+    }
+    _cSummaryvsLS.setBinContent(eid, _currentLS, int(fSum._state));
+  }
 
-			//	this is the MUST!
-			//	reset after using this flag
-			ft->reset();
-		}
-		_cSummaryvsLS.setBinContent(eid, _currentLS, int(fSum._state));
-	}
+  //	reset...
+  _xEtMsm.reset();
+  _xFGMsm.reset();
+  _xNumCorr.reset();
+  _xDataMsn.reset();
+  _xDataTotal.reset();
+  _xEmulMsn.reset();
+  _xEmulTotal.reset();
 
-	//	reset...
-	_xEtMsm.reset(); _xFGMsm.reset(); _xNumCorr.reset();
-	_xDataMsn.reset(); _xDataTotal.reset(); _xEmulMsn.reset(); 
-	_xEmulTotal.reset();
-	
-	//	in the end always do the DQTask::endLumi
-	DQTask::endLuminosityBlock(lb, es);
+  //	in the end always do the DQTask::endLumi
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(TPTask);
-

--- a/DQM/HcalTasks/plugins/UMNioTask.cc
+++ b/DQM/HcalTasks/plugins/UMNioTask.cc
@@ -3,148 +3,136 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-UMNioTask::UMNioTask(edm::ParameterSet const& ps):
-	DQTask(ps)
-{
-	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
-		edm::InputTag("hcalDigis"));
-	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
-		edm::InputTag("hcalDigis"));
-	_tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF",
-		edm::InputTag("hcalDigis"));
-	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
-		edm::InputTag("hcalDigis"));
+UMNioTask::UMNioTask(edm::ParameterSet const& ps) : DQTask(ps) {
+  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
+  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
 
-	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHO = consumes<HODigiCollection>(_tagHO);
-	_tokHF = consumes<HFDigiCollection>(_tagHF);
-	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
+  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
+  _tokHO = consumes<HODigiCollection>(_tagHO);
+  _tokHF = consumes<HFDigiCollection>(_tagHF);
+  _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
-	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
-		20);
-	_lowHO = ps.getUntrackedParameter<double>("lowHO",
-		20);
-	_lowHF = ps.getUntrackedParameter<double>("lowHF",
-		20);
+  _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 20);
+  _lowHO = ps.getUntrackedParameter<double>("lowHO", 20);
+  _lowHF = ps.getUntrackedParameter<double>("lowHF", 20);
 
-	//	push all the event types to monitor - whole range basically
-	//	This corresponds to all enum values in hcaldqm::constants::OrbitGapType
-	for (uint32_t type=constants::tNull; type<constants::nOrbitGapType; type++) {
-		_eventtypes.push_back(type);
-	}
+  //	push all the event types to monitor - whole range basically
+  //	This corresponds to all enum values in hcaldqm::constants::OrbitGapType
+  for (uint32_t type = constants::tNull; type < constants::nOrbitGapType; type++) {
+    _eventtypes.push_back(type);
+  }
 }
-	
-/* virtual */ void UMNioTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
-	if (_ptype==fLocal)
-		if (r.runAuxiliary().run()==1)
-			return;
 
-	DQTask::bookHistograms(ib, r, es);
-	
-	edm::ESHandle<HcalDbService> dbService;
-	es.get<HcalDbRecord>().get(dbService);
-	_emap = dbService->getHcalMapping();
+/* virtual */ void UMNioTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  if (_ptype == fLocal)
+    if (r.runAuxiliary().run() == 1)
+      return;
 
-	_cEventType.initialize(_name, "EventType",
-			       new hcaldqm::quantity::LumiSection(_maxLS),
-			       new hcaldqm::quantity::EventType(_eventtypes),
-			       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cTotalCharge.initialize(_name, "TotalCharge",
-				 new hcaldqm::quantity::LumiSection(_maxLS),
-				 new hcaldqm::quantity::DetectorQuantity(quantity::fSubdetPM),
-				 new hcaldqm::quantity::ValueQuantity(quantity::ffC_10000, true),0);
-	_cTotalChargeProfile.initialize(_name, "TotalChargeProfile",
-					new hcaldqm::quantity::LumiSection(_maxLS),
-					new hcaldqm::quantity::DetectorQuantity(quantity::fSubdetPM),
-					new hcaldqm::quantity::ValueQuantity(quantity::ffC_10000, true),0);
-	_cEventType.book(ib, _subsystem);
-	_cTotalCharge.book(ib, _subsystem);
-	_cTotalChargeProfile.book(ib, _subsystem);
+  DQTask::bookHistograms(ib, r, es);
+
+  edm::ESHandle<HcalDbService> dbService;
+  es.get<HcalDbRecord>().get(dbService);
+  _emap = dbService->getHcalMapping();
+
+  _cEventType.initialize(_name,
+                         "EventType",
+                         new hcaldqm::quantity::LumiSection(_maxLS),
+                         new hcaldqm::quantity::EventType(_eventtypes),
+                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                         0);
+  _cTotalCharge.initialize(_name,
+                           "TotalCharge",
+                           new hcaldqm::quantity::LumiSection(_maxLS),
+                           new hcaldqm::quantity::DetectorQuantity(quantity::fSubdetPM),
+                           new hcaldqm::quantity::ValueQuantity(quantity::ffC_10000, true),
+                           0);
+  _cTotalChargeProfile.initialize(_name,
+                                  "TotalChargeProfile",
+                                  new hcaldqm::quantity::LumiSection(_maxLS),
+                                  new hcaldqm::quantity::DetectorQuantity(quantity::fSubdetPM),
+                                  new hcaldqm::quantity::ValueQuantity(quantity::ffC_10000, true),
+                                  0);
+  _cEventType.book(ib, _subsystem);
+  _cTotalCharge.book(ib, _subsystem);
+  _cTotalChargeProfile.book(ib, _subsystem);
 }
 
 int UMNioTask::getOrbitGapIndex(uint8_t eventType, uint32_t laserType) {
-	constants::OrbitGapType orbitGapType;
-	if (eventType == constants::EVENTTYPE_PEDESTAL) {
-		orbitGapType = tPedestal;
-	} else if (eventType == constants::EVENTTYPE_LED) {
-		orbitGapType = tLED;
-	} else if (eventType == constants::EVENTTYPE_LASER) {
-		switch (laserType)
-		{
-			//case tNull : return "Null";
-			//case tHFRaddam : return "HFRaddam";
-			case 3 : return tHBHEHPD;
-			case 4 : return tHO;
-			case 5 : return tHF;
-			//case tZDC : return "ZDC";
-			case 7 : return tHEPMega;
-			case 8 : return tHEMMega;
-			case 9 : return tHBPMega;
-			case 10 : return tHBMMega;
-			//case tCRF : return "CRF";
-			//case tCalib : return "Calib";
-			//case tSafe : return "Safe";
-			default : return tUnknown;
-		}
-	}
-	return (int)(std::find(_eventtypes.begin(), _eventtypes.end(), orbitGapType) - _eventtypes.begin());
+  constants::OrbitGapType orbitGapType;
+  if (eventType == constants::EVENTTYPE_PEDESTAL) {
+    orbitGapType = tPedestal;
+  } else if (eventType == constants::EVENTTYPE_LED) {
+    orbitGapType = tLED;
+  } else if (eventType == constants::EVENTTYPE_LASER) {
+    switch (laserType) {
+      //case tNull : return "Null";
+      //case tHFRaddam : return "HFRaddam";
+      case 3:
+        return tHBHEHPD;
+      case 4:
+        return tHO;
+      case 5:
+        return tHF;
+      //case tZDC : return "ZDC";
+      case 7:
+        return tHEPMega;
+      case 8:
+        return tHEMMega;
+      case 9:
+        return tHBPMega;
+      case 10:
+        return tHBMMega;
+      //case tCRF : return "CRF";
+      //case tCalib : return "Calib";
+      //case tSafe : return "Safe";
+      default:
+        return tUnknown;
+    }
+  }
+  return (int)(std::find(_eventtypes.begin(), _eventtypes.end(), orbitGapType) - _eventtypes.begin());
 }
 
+/* virtual */ void UMNioTask::_process(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<HcalUMNioDigi> cumn;
+  if (!e.getByToken(_tokuMN, cumn))
+    return;
 
-/* virtual */ void UMNioTask::_process(edm::Event const& e,
-	edm::EventSetup const& es)
-{
-	edm::Handle<HcalUMNioDigi> cumn;
-	if (!e.getByToken(_tokuMN, cumn))
-		return;
+  uint8_t eventType = cumn->eventType();
+  uint32_t laserType = cumn->valueUserWord(0);
+  _cEventType.fill(_currentLS, getOrbitGapIndex(eventType, laserType));
 
-	uint8_t eventType = cumn->eventType();
-	uint32_t laserType = cumn->valueUserWord(0);
-	_cEventType.fill(_currentLS, getOrbitGapIndex(eventType, laserType));
+  //	Compute the Total Charge in the Detector...
+  edm::Handle<HBHEDigiCollection> chbhe;
+  edm::Handle<HODigiCollection> cho;
+  edm::Handle<HFDigiCollection> chf;
 
-	//	Compute the Total Charge in the Detector...
-	edm::Handle<HBHEDigiCollection>     chbhe;
-	edm::Handle<HODigiCollection>       cho;
-	edm::Handle<HFDigiCollection>       chf;
+  if (!e.getByToken(_tokHBHE, chbhe))
+    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
+  if (!e.getByToken(_tokHO, cho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokHF, chf))
+    _logger.dqmthrow("Collection HFDigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
 
-	if (!e.getByToken(_tokHBHE, chbhe))
-		_logger.dqmthrow("Collection HBHEDigiCollection isn't available "
-			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHO, cho))
-		_logger.dqmthrow("Collection HODigiCollection isn't available "
-			+ _tagHO.label() + " " + _tagHO.instance());
-	if (!e.getByToken(_tokHF, chf))
-		_logger.dqmthrow("Collection HFDigiCollection isn't available "
-			+ _tagHF.label() + " " + _tagHF.instance());
-
-	for (HBHEDigiCollection::const_iterator it=chbhe->begin();
-		it!=chbhe->end(); ++it)
-	{
-		double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
-		_cTotalCharge.fill(it->id(), _currentLS, sumQ);
-		_cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
-	}
-	for (HODigiCollection::const_iterator it=cho->begin();
-		it!=cho->end(); ++it)
-	{
-		double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size()-1);
-		_cTotalCharge.fill(it->id(), _currentLS, sumQ);
-		_cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
-	}
-	for (HFDigiCollection::const_iterator it=chf->begin();
-		it!=chf->end(); ++it)
-	{
-		double sumQ = hcaldqm::utilities::sumQ<HFDataFrame>(*it, 2.5, 0, it->size()-1);
-		_cTotalCharge.fill(it->id(), _currentLS, sumQ);
-		_cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
-	}
+  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size() - 1);
+    _cTotalCharge.fill(it->id(), _currentLS, sumQ);
+    _cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
+  }
+  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size() - 1);
+    _cTotalCharge.fill(it->id(), _currentLS, sumQ);
+    _cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
+  }
+  for (HFDigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+    double sumQ = hcaldqm::utilities::sumQ<HFDataFrame>(*it, 2.5, 0, it->size() - 1);
+    _cTotalCharge.fill(it->id(), _currentLS, sumQ);
+    _cTotalChargeProfile.fill(it->id(), _currentLS, sumQ);
+  }
 }
-/* virtual */ void UMNioTask::endLuminosityBlock(edm::LuminosityBlock const& lb,
-	edm::EventSetup const& es)
-{
-	DQTask::endLuminosityBlock(lb, es);
+/* virtual */ void UMNioTask::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  DQTask::endLuminosityBlock(lb, es);
 }
 
 DEFINE_FWK_MODULE(UMNioTask);

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -1,126 +1,116 @@
 
 #include "DQM/HcalTasks/interface/ZDCQIE10Task.h"
 
-ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
-{
-	//	tags
-	_tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10",
-		edm::InputTag("hcalDigis", "ZDC"));
-	_tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
+ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
+  //	tags
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis", "ZDC"));
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
 }
 
-/* virtual */ void ZDCQIE10Task::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
+/* virtual */ void ZDCQIE10Task::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  ib.cd();
 
-	ib.cd();
+  //book histos per channel
+  std::string histoname;
+  for (int channel = 1; channel < 6; channel++) {
+    // EM Pos
+    HcalZDCDetId didp(HcalZDCDetId::EM, true, channel);
+    histoname = "EM_P_" + std::to_string(channel) + "_1";
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
-	//book histos per channel
-	std::string histoname;
-	for ( int channel = 1; channel < 6; channel++ ) {
-		// EM Pos
-		HcalZDCDetId didp(HcalZDCDetId::EM, true, channel);
-		histoname = "EM_P_" + std::to_string(channel) + "_1";
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-		_cADC_EChannel[didp()] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
-		_cADC_EChannel[didp()]->setAxisTitle("N", 2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-		_cADC_vs_TS_EChannel[didp()] = ib.book1D( histoname.c_str(), histoname.c_str(), 10, 0, 10);
-		_cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
-		_cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
+    // EM Minus
+    HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
+    histoname = "EM_M_" + std::to_string(channel) + "_1";
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+  }
 
-		// EM Minus
-		HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
-		histoname = "EM_M_" + std::to_string(channel) + "_1";
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-		_cADC_EChannel[didm()] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
-		_cADC_EChannel[didm()]->setAxisTitle("N", 2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-		_cADC_vs_TS_EChannel[didm()] = ib.book1D( histoname.c_str(), histoname.c_str(), 10, 0, 10);
-		_cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
-		_cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
-	}
+  for (int channel = 1; channel < 5; channel++) {
+    // HAD Pos
+    HcalZDCDetId didp(HcalZDCDetId::HAD, true, channel);
+    histoname = "HAD_P_" + std::to_string(channel) + "_" + std::to_string(channel + 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
-	for ( int channel = 1; channel < 5; channel++ ) {
-		// HAD Pos
-		HcalZDCDetId didp(HcalZDCDetId::HAD, true, channel);
-		histoname = "HAD_P_" + std::to_string(channel) + "_" + std::to_string(channel+2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-		_cADC_EChannel[didp()] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
-		_cADC_EChannel[didp()]->setAxisTitle("N", 2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-		_cADC_vs_TS_EChannel[didp()] = ib.book1D( histoname.c_str(), histoname.c_str(), 10, 0, 10);
-		_cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
-		_cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
+    // HAD Minus
+    HcalZDCDetId didm(HcalZDCDetId::HAD, false, channel);
+    histoname = "HAD_M_" + std::to_string(channel) + "_" + std::to_string(channel + 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+  }
 
-		// HAD Minus
-		HcalZDCDetId didm(HcalZDCDetId::HAD, false, channel);
-		histoname = "HAD_M_" + std::to_string(channel) + "_" + std::to_string(channel+2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-		_cADC_EChannel[didm()] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
-		_cADC_EChannel[didm()]->setAxisTitle("N", 2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-		_cADC_vs_TS_EChannel[didm()] = ib.book1D( histoname.c_str(), histoname.c_str(), 10, 0, 10);
-		_cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
-		_cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
-	}
+  for (int channel = 1; channel < 17; channel++) {
+    // RPD Pos
+    HcalZDCDetId didp(HcalZDCDetId::RPD, true, channel);
+    histoname = "RPD_P_" + std::to_string(channel) + "_2";
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didp()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
-	for ( int channel = 1; channel < 17; channel++ ) {
-		// RPD Pos
-		HcalZDCDetId didp(HcalZDCDetId::RPD, true, channel);
-		histoname = "RPD_P_" + std::to_string(channel) + "_2";
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-		_cADC_EChannel[didp()] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
-		_cADC_EChannel[didp()]->setAxisTitle("N", 2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-		_cADC_vs_TS_EChannel[didp()] = ib.book1D( histoname.c_str(), histoname.c_str(), 10, 0, 10);
-		_cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
-		_cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
-
-		// RPD Minus
-		HcalZDCDetId didm(HcalZDCDetId::RPD, false, channel);
-		histoname = "RPD_M_" + std::to_string(channel) + "_2";
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
-		_cADC_EChannel[didm()] = ib.book1D( histoname.c_str(), histoname.c_str(), 256, 0, 256);
-		_cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
-		_cADC_EChannel[didm()]->setAxisTitle("N", 2);
-		ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-		_cADC_vs_TS_EChannel[didm()] = ib.book1D( histoname.c_str(), histoname.c_str(), 10, 0, 10);
-		_cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
-		_cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
-	}
-
+    // RPD Minus
+    HcalZDCDetId didm(HcalZDCDetId::RPD, false, channel);
+    histoname = "RPD_M_" + std::to_string(channel) + "_2";
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didm()] = ib.book1D(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+  }
 }
 
+/* virtual */ void ZDCQIE10Task::analyze(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<QIE10DigiCollection> digis;
+  if (!e.getByToken(_tokQIE10, digis))
+    edm::LogError("Collection QIE10DigiCollection for ZDC isn't available" + _tagQIE10.label() + " " +
+                  _tagQIE10.instance());
 
-/* virtual */ void ZDCQIE10Task::analyze(edm::Event const& e, edm::EventSetup const&)
-{
-	edm::Handle<QIE10DigiCollection> digis;
-	if (!e.getByToken(_tokQIE10, digis))
-		edm::LogError("Collection QIE10DigiCollection for ZDC isn't available"
-				+ _tagQIE10.label() + " " + _tagQIE10.instance());
+  for (auto it = digis->begin(); it != digis->end(); it++) {
+    const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+    HcalZDCDetId const& did = digi.detid();
 
-	for ( auto it = digis->begin(); it != digis->end(); it++ ) {
-		const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
-		HcalZDCDetId const& did = digi.detid();
-
-		for ( int i = 0; i < digi.samples(); i++ ) {
-			// iter over all samples
-			if ( _cADC_EChannel.find( did()) != _cADC_EChannel.end() ) {
-				_cADC_EChannel[did()]->Fill(digi[i].adc());
-			}
-			if ( _cADC_vs_TS_EChannel.find( did() ) != _cADC_vs_TS_EChannel.end() ) {
-				_cADC_vs_TS_EChannel[did()]->Fill(i, digi[i].adc());
-			}
-
-		}
-	}
+    for (int i = 0; i < digi.samples(); i++) {
+      // iter over all samples
+      if (_cADC_EChannel.find(did()) != _cADC_EChannel.end()) {
+        _cADC_EChannel[did()]->Fill(digi[i].adc());
+      }
+      if (_cADC_vs_TS_EChannel.find(did()) != _cADC_vs_TS_EChannel.end()) {
+        _cADC_vs_TS_EChannel[did()]->Fill(i, digi[i].adc());
+      }
+    }
+  }
 }
-
 
 DEFINE_FWK_MODULE(ZDCQIE10Task);

--- a/DQM/HcalTasks/plugins/ZDCTask.cc
+++ b/DQM/HcalTasks/plugins/ZDCTask.cc
@@ -4,191 +4,207 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
-ZDCTask::ZDCTask(edm::ParameterSet const& ps)
-{
-	
-	//	tags
-	_tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10",
-		edm::InputTag("hcalDigis"));
-	_tokQIE10 = consumes<ZDCDigiCollection>(_tagQIE10);
+ZDCTask::ZDCTask(edm::ParameterSet const& ps) {
+  //	tags
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis"));
+  _tokQIE10 = consumes<ZDCDigiCollection>(_tagQIE10);
 
-	//	cuts
-	_cut = ps.getUntrackedParameter<double>("cut", 50.0);
-	_ped = ps.getUntrackedParameter<int>("ped", 4);
+  //	cuts
+  _cut = ps.getUntrackedParameter<double>("cut", 50.0);
+  _ped = ps.getUntrackedParameter<int>("ped", 4);
 }
 
-/* virtual */ void ZDCTask::bookHistograms(DQMStore::IBooker &ib,
-	edm::Run const& r, edm::EventSetup const& es)
-{
+/* virtual */ void ZDCTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  //############################## hardcode manually the zdc mapping #############################
+  //############################# this follows from https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc#L118
+  //##############################################################################################
+  //////ZDC MAP for NEW data (2015 PbPb are newer)
+  //PZDC
+  std::map<HcalElectronicsId, DetId> myEMap;
+  HcalElectronicsId eid = HcalElectronicsId(0, 1, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000051);  //PZDC EM1
 
-	//############################## hardcode manually the zdc mapping #############################
-	//############################# this follows from https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc#L118
-	//##############################################################################################
-	//////ZDC MAP for NEW data (2015 PbPb are newer)
-	//PZDC
-	std::map<HcalElectronicsId,DetId> myEMap;
-	HcalElectronicsId eid = HcalElectronicsId(0, 1, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000051);//PZDC EM1
+  eid = HcalElectronicsId(1, 1, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000052);  //PZDC EM2
 
-	eid = HcalElectronicsId(1, 1, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000052);//PZDC EM2
+  eid = HcalElectronicsId(2, 1, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000053);  //PZDC EM3
 
-	eid = HcalElectronicsId(2, 1, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000053);//PZDC EM3
+  eid = HcalElectronicsId(0, 2, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000061);  //PZDC HAD1
 
-	eid = HcalElectronicsId(0, 2, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000061);//PZDC HAD1
+  eid = HcalElectronicsId(1, 2, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000054);  //PZDC EM4
 
-	eid = HcalElectronicsId(1, 2, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000054);//PZDC EM4
+  eid = HcalElectronicsId(2, 2, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000055);  //PZDC EM5
 
-	eid = HcalElectronicsId(2, 2, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000055);//PZDC EM5
+  eid = HcalElectronicsId(0, 3, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000062);  //PZDC HAD2
 
-	eid = HcalElectronicsId(0, 3, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000062);//PZDC HAD2
+  eid = HcalElectronicsId(1, 3, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000063);  //PZDC HAD3
 
-	eid = HcalElectronicsId(1, 3, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000063);//PZDC HAD3
+  eid = HcalElectronicsId(2, 3, 0, 3);
+  eid.setHTR(18, 8, 1);
+  myEMap[eid] = DetId(0x54000064);  //PZDC HAD4
 
-	eid = HcalElectronicsId(2, 3, 0, 3);
-	eid.setHTR(18, 8, 1);
-	myEMap[eid]=DetId(0x54000064);//PZDC HAD4
+  //NZDC
+  eid = HcalElectronicsId(0, 1, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000011);  //NZDC EM1
 
-	//NZDC
-	eid = HcalElectronicsId(0,1,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000011);//NZDC EM1
+  eid = HcalElectronicsId(1, 1, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000012);  //NZDC EM2
 
-	eid = HcalElectronicsId(1,1,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000012);//NZDC EM2
+  eid = HcalElectronicsId(2, 1, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000013);  //NZDC EM3
 
-	eid = HcalElectronicsId(2,1,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000013);//NZDC EM3
+  eid = HcalElectronicsId(0, 2, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000015);  //NZDC EM5
 
-	eid = HcalElectronicsId(0,2,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000015);//NZDC EM5
+  eid = HcalElectronicsId(1, 2, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000021);  //NZDC HAD1
 
-	eid = HcalElectronicsId(1,2,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000021);//NZDC HAD1
+  eid = HcalElectronicsId(2, 2, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000014);  //NZDC EM4
 
-	eid = HcalElectronicsId(2,2,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000014);//NZDC EM4
+  eid = HcalElectronicsId(0, 3, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000022);  //NZDC HAD2
 
-	eid = HcalElectronicsId(0,3,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000022);//NZDC HAD2
+  eid = HcalElectronicsId(1, 3, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000023);  //NZDC HAD3
 
-	eid = HcalElectronicsId(1,3,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000023);//NZDC HAD3
+  eid = HcalElectronicsId(2, 3, 1, 3);
+  eid.setHTR(18, 8, 0);
+  myEMap[eid] = DetId(0x54000024);  //NZDC HAD4
+  //##################################### end hardcoding ###################################
 
-	eid = HcalElectronicsId(2,3,1,3);
-	eid.setHTR(18, 8, 0);
-	myEMap[eid]=DetId(0x54000024);//NZDC HAD4
-	//##################################### end hardcoding ###################################
+  ib.cd();
 
-	ib.cd();
+  //quantities for axis
+  hcaldqm::quantity::ValueQuantity xAxisShape(hcaldqm::quantity::fTiming_TS);
+  hcaldqm::quantity::ValueQuantity yAxisShape(hcaldqm::quantity::ffC_10000);
 
-	//quantities for axis
-	hcaldqm::quantity::ValueQuantity xAxisShape(hcaldqm::quantity::fTiming_TS);
-	hcaldqm::quantity::ValueQuantity yAxisShape(hcaldqm::quantity::ffC_10000);
+  hcaldqm::quantity::ValueQuantity xAxisADC(hcaldqm::quantity::fADC_128);
 
-	hcaldqm::quantity::ValueQuantity xAxisADC(hcaldqm::quantity::fADC_128);
+  //book histos per channel
+  for (std::map<HcalElectronicsId, DetId>::const_iterator itr = myEMap.begin(); itr != myEMap.end(); ++itr) {
+    char histoname[300];
 
-	//book histos per channel
-	for (std::map<HcalElectronicsId,DetId>::const_iterator itr=myEMap.begin(); itr!=myEMap.end(); ++itr)
-	  {
-	    char histoname[300];
-	    
-	    sprintf(histoname,"%d_%d_%d_%d",itr->first.fiberChanId(),itr->first.fiberIndex(),itr->first.spigot(),itr->first.dccid());
+    sprintf(histoname,
+            "%d_%d_%d_%d",
+            itr->first.fiberChanId(),
+            itr->first.fiberIndex(),
+            itr->first.spigot(),
+            itr->first.dccid());
 
-	    ib.setCurrentFolder("Hcal/ZDCTask/Shape_perChannel");
-	    _cShape_EChannel[histoname] = ib.bookProfile(histoname,histoname,xAxisShape.nbins(),xAxisShape.min(),xAxisShape.max(),yAxisShape.nbins(),yAxisShape.min(),yAxisShape.max());
-	    _cShape_EChannel[histoname]->setAxisTitle("Timing",1);
-	    _cShape_EChannel[histoname]->setAxisTitle("fC QIE8",2);
+    ib.setCurrentFolder("Hcal/ZDCTask/Shape_perChannel");
+    _cShape_EChannel[histoname] = ib.bookProfile(histoname,
+                                                 histoname,
+                                                 xAxisShape.nbins(),
+                                                 xAxisShape.min(),
+                                                 xAxisShape.max(),
+                                                 yAxisShape.nbins(),
+                                                 yAxisShape.min(),
+                                                 yAxisShape.max());
+    _cShape_EChannel[histoname]->setAxisTitle("Timing", 1);
+    _cShape_EChannel[histoname]->setAxisTitle("fC QIE8", 2);
 
-	    ib.setCurrentFolder("Hcal/ZDCTask/ADC_perChannel");
-	    _cADC_EChannel[histoname] = ib.book1D(histoname,histoname,xAxisADC.nbins(),xAxisADC.min(),xAxisADC.max());
-	    _cADC_EChannel[histoname]->getRootObject()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET+hcaldqm::quantity::AxisType::fYAxis));
-	    _cADC_EChannel[histoname]->setAxisTitle("ADC QIE8",1);
+    ib.setCurrentFolder("Hcal/ZDCTask/ADC_perChannel");
+    _cADC_EChannel[histoname] = ib.book1D(histoname, histoname, xAxisADC.nbins(), xAxisADC.min(), xAxisADC.max());
+    _cADC_EChannel[histoname]->getRootObject()->SetBit(
+        BIT(hcaldqm::constants::BIT_OFFSET + hcaldqm::quantity::AxisType::fYAxis));
+    _cADC_EChannel[histoname]->setAxisTitle("ADC QIE8", 1);
 
-	    ib.setCurrentFolder("Hcal/ZDCTask/ADC_vs_TS_perChannel");
-	    _cADC_vs_TS_EChannel[histoname] = ib.book2D(histoname,histoname,xAxisShape.nbins(),xAxisShape.min(),xAxisShape.max(),xAxisADC.nbins(),xAxisADC.min(),xAxisADC.max());
-	    _cADC_vs_TS_EChannel[histoname]->getRootObject()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET+hcaldqm::quantity::AxisType::fYAxis));
-	    _cADC_vs_TS_EChannel[histoname]->setAxisTitle("Timing",1);
-	    _cADC_vs_TS_EChannel[histoname]->setAxisTitle("ADC QIE8",2);
-	    
+    ib.setCurrentFolder("Hcal/ZDCTask/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[histoname] = ib.book2D(histoname,
+                                                histoname,
+                                                xAxisShape.nbins(),
+                                                xAxisShape.min(),
+                                                xAxisShape.max(),
+                                                xAxisADC.nbins(),
+                                                xAxisADC.min(),
+                                                xAxisADC.max());
+    _cADC_vs_TS_EChannel[histoname]->getRootObject()->SetBit(
+        BIT(hcaldqm::constants::BIT_OFFSET + hcaldqm::quantity::AxisType::fYAxis));
+    _cADC_vs_TS_EChannel[histoname]->setAxisTitle("Timing", 1);
+    _cADC_vs_TS_EChannel[histoname]->setAxisTitle("ADC QIE8", 2);
+  }
 
-	  }
+  //book global histos
+  ib.setCurrentFolder("Hcal/ZDCTask");
 
-	//book global histos
-	ib.setCurrentFolder("Hcal/ZDCTask");
+  _cShape = ib.bookProfile("Shape",
+                           "Shape",
+                           xAxisShape.nbins(),
+                           xAxisShape.min(),
+                           xAxisShape.max(),
+                           yAxisShape.nbins(),
+                           yAxisShape.min(),
+                           yAxisShape.max());
+  _cShape->setAxisTitle("Timing", 1);
+  _cShape->setAxisTitle("fC QIE8", 2);
 
-	_cShape = ib.bookProfile("Shape","Shape",xAxisShape.nbins(),xAxisShape.min(),xAxisShape.max(),yAxisShape.nbins(),yAxisShape.min(),yAxisShape.max());
-	_cShape->setAxisTitle("Timing",1);
-	_cShape->setAxisTitle("fC QIE8",2);
+  _cADC = ib.book1D("ADC", "ADC", xAxisADC.nbins(), xAxisADC.min(), xAxisADC.max());
+  _cADC->getRootObject()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET + hcaldqm::quantity::AxisType::fYAxis));
+  _cADC->setAxisTitle("ADC QIE8", 1);
 
-	_cADC = ib.book1D("ADC","ADC",xAxisADC.nbins(),xAxisADC.min(),xAxisADC.max());
-	_cADC->getRootObject()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET+hcaldqm::quantity::AxisType::fYAxis));
-	_cADC->setAxisTitle("ADC QIE8",1);
-
-	_cADC_vs_TS = ib.book2D("ADC_vs_TS","ADC_vs_TS",xAxisShape.nbins(),xAxisShape.min(),xAxisShape.max(),xAxisADC.nbins(),xAxisADC.min(),xAxisADC.max());
-	_cADC_vs_TS->getRootObject()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET+hcaldqm::quantity::AxisType::fYAxis));
-	_cADC_vs_TS->setAxisTitle("Timing",1);
-	_cADC_vs_TS->setAxisTitle("ADC QIE8",2);
-	    
+  _cADC_vs_TS = ib.book2D("ADC_vs_TS",
+                          "ADC_vs_TS",
+                          xAxisShape.nbins(),
+                          xAxisShape.min(),
+                          xAxisShape.max(),
+                          xAxisADC.nbins(),
+                          xAxisADC.min(),
+                          xAxisADC.max());
+  _cADC_vs_TS->getRootObject()->SetBit(BIT(hcaldqm::constants::BIT_OFFSET + hcaldqm::quantity::AxisType::fYAxis));
+  _cADC_vs_TS->setAxisTitle("Timing", 1);
+  _cADC_vs_TS->setAxisTitle("ADC QIE8", 2);
 }
 
+/* virtual */ void ZDCTask::analyze(edm::Event const& e, edm::EventSetup const&) {
+  edm::Handle<ZDCDigiCollection> cqie10;
+  if (!e.getByToken(_tokQIE10, cqie10))
+    edm::LogError("Collection ZDCDigiCollection isn't available" + _tagQIE10.label() + " " + _tagQIE10.instance());
 
-/* virtual */ void ZDCTask::analyze(edm::Event const& e, edm::EventSetup const&)
-{
-	edm::Handle<ZDCDigiCollection> cqie10;
-	if (!e.getByToken(_tokQIE10, cqie10))
-	  edm::LogError("Collection ZDCDigiCollection isn't available"
-			+ _tagQIE10.label() + " " + _tagQIE10.instance());
+  for (uint32_t i = 0; i < cqie10->size(); i++) {
+    ZDCDataFrame frame = static_cast<ZDCDataFrame>((*cqie10)[i]);
+    HcalElectronicsId eid = frame.elecId();
 
+    char histoname[300];
+    sprintf(histoname, "%d_%d_%d_%d", eid.fiberChanId(), eid.fiberIndex(), eid.spigot(), eid.dccid());
 
-	for (uint32_t i=0; i<cqie10->size(); i++)
-	  {
-	    ZDCDataFrame frame = static_cast<ZDCDataFrame>((*cqie10)[i]);
-	    HcalElectronicsId eid = frame.elecId();
+    //	compute the signal, ped subracted
+    //double q = hcaldqm::utilities::sumQ_v10<ZDCDataFrame>(frame, constants::adc2fC[_ped], 0, frame.size()-1);
 
-	    char histoname[300];
-            sprintf(histoname,"%d_%d_%d_%d",eid.fiberChanId(),eid.fiberIndex(),eid.spigot(),eid.dccid());
-	    
-	    //	compute the signal, ped subracted
-	    //double q = hcaldqm::utilities::sumQ_v10<ZDCDataFrame>(frame, constants::adc2fC[_ped], 0, frame.size()-1);
+    //	iterate thru all TS and fill
+    for (int j = 0; j < frame.size(); j++) {
+      _cShape_EChannel[histoname]->Fill(j, frame[j].nominal_fC());
+      _cShape->Fill(j, frame[j].nominal_fC());
 
-	    //	iterate thru all TS and fill
-	    for (int j=0; j<frame.size(); j++)
-	      {
-		_cShape_EChannel[histoname]->Fill(j, frame[j].nominal_fC());
-		_cShape->Fill(j, frame[j].nominal_fC());
+      _cADC_EChannel[histoname]->Fill(frame[j].adc());
+      _cADC->Fill(frame[j].adc());
 
-		_cADC_EChannel[histoname]->Fill(frame[j].adc());
-		_cADC->Fill(frame[j].adc());
-
-		_cADC_vs_TS_EChannel[histoname]->Fill(j,frame[j].adc());
-		_cADC_vs_TS->Fill(j,frame[j].adc());
-
-		
-	      }
-	  }
+      _cADC_vs_TS_EChannel[histoname]->Fill(j, frame[j].adc());
+      _cADC_vs_TS->Fill(j, frame[j].adc());
+    }
+  }
 }
-
 
 DEFINE_FWK_MODULE(ZDCTask);

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -1,394 +1,374 @@
 #include "DQM/HcalTasks/interface/DigiRunSummary.h"
 
-namespace hcaldqm
-{
-	using namespace constants;
-	
-	DigiRunSummary::DigiRunSummary(std::string const& name, 
-		std::string const& taskname, edm::ParameterSet const& ps) :
-		DQClient(name, taskname, ps), _booked(false)
-	{
-		_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf",
-			0.2);
+namespace hcaldqm {
+  using namespace constants;
 
-		std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
-		_refDigiSize[HcalBarrel]  = vrefDigiSize[0];
-		_refDigiSize[HcalEndcap]  = vrefDigiSize[1];
-		_refDigiSize[HcalOuter]   = vrefDigiSize[2];
-		_refDigiSize[HcalForward] = vrefDigiSize[3];
-	}
+  DigiRunSummary::DigiRunSummary(std::string const& name, std::string const& taskname, edm::ParameterSet const& ps)
+      : DQClient(name, taskname, ps), _booked(false) {
+    _thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
 
-	/* virtual */ void DigiRunSummary::beginRun(edm::Run const& r,
-		edm::EventSetup const& es)
-	{
-		DQClient::beginRun(r,es);
+    std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
+    _refDigiSize[HcalBarrel] = vrefDigiSize[0];
+    _refDigiSize[HcalEndcap] = vrefDigiSize[1];
+    _refDigiSize[HcalOuter] = vrefDigiSize[2];
+    _refDigiSize[HcalForward] = vrefDigiSize[3];
+  }
 
-		if (_ptype!=fOffline)
-			return;
+  /* virtual */ void DigiRunSummary::beginRun(edm::Run const& r, edm::EventSetup const& es) {
+    DQClient::beginRun(r, es);
 
-		//  INITIALIZE WHAT NEEDS TO BE INITIALIZE ONLY ONCE!
-		_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
-		_vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-			 constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-		_vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_filter_VME.initialize(filter::fFilter, hashfunctions::fElectronics,
-			_vhashVME);  // filter out VME 
-		_filter_uTCA.initialize(filter::fFilter, hashfunctions::fElectronics,
-			 _vhashuTCA); // filter out uTCA
-		_vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN+6,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_filter_FEDHF.initialize(filter::fPreserver, hashfunctions::fFED,
-			_vhashFEDHF);    // preserve only HF FEDs
-		
-		_xDead.initialize(hashfunctions::fFED);
-		_xDigiSize.initialize(hashfunctions::fFED);
-		_xUni.initialize(hashfunctions::fFED);
-		_xUniHF.initialize(hashfunctions::fFEDSlot);
+    if (_ptype != fOffline)
+      return;
 
-		_xDead.book(_emap); _xDigiSize.book(_emap); _xUniHF.book(_emap);
-		_xUni.book(_emap, _filter_FEDHF);
-		_xNChs.initialize(hashfunctions::fFED);
-		_xNChsNominal.initialize(hashfunctions::fFED);
-		_xNChs.book(_emap); _xNChsNominal.book(_emap);
-		
-		_cOccupancy_depth.initialize(_name, "Occupancy",
-			hashfunctions::fdepth,
-			new quantity::DetectorQuantity(quantity::fieta),
-			new quantity::DetectorQuantity(quantity::fiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
+    //  INITIALIZE WHAT NEEDS TO BE INITIALIZE ONLY ONCE!
+    _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+    _vhashVME.push_back(
+        HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+    _vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _filter_VME.initialize(filter::fFilter, hashfunctions::fElectronics,
+                           _vhashVME);  // filter out VME
+    _filter_uTCA.initialize(filter::fFilter, hashfunctions::fElectronics,
+                            _vhashuTCA);  // filter out uTCA
+    _vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _vhashFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _vhashFEDHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _vhashFEDHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _filter_FEDHF.initialize(filter::fPreserver, hashfunctions::fFED,
+                             _vhashFEDHF);  // preserve only HF FEDs
 
-		//	GET THE NOMINAL NUMBER OF CHANNELS PER FED
-		std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-		for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-			it!=gids.end(); ++it)
-		{
-			if (!it->isHcalDetId())
-				continue;
-			HcalDetId did(it->rawId());
-			HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
-			_xNChsNominal.get(eid)++;
-		}
-	}
+    _xDead.initialize(hashfunctions::fFED);
+    _xDigiSize.initialize(hashfunctions::fFED);
+    _xUni.initialize(hashfunctions::fFED);
+    _xUniHF.initialize(hashfunctions::fFEDSlot);
 
-	/*
+    _xDead.book(_emap);
+    _xDigiSize.book(_emap);
+    _xUniHF.book(_emap);
+    _xUni.book(_emap, _filter_FEDHF);
+    _xNChs.initialize(hashfunctions::fFED);
+    _xNChsNominal.initialize(hashfunctions::fFED);
+    _xNChs.book(_emap);
+    _xNChsNominal.book(_emap);
+
+    _cOccupancy_depth.initialize(_name,
+                                 "Occupancy",
+                                 hashfunctions::fdepth,
+                                 new quantity::DetectorQuantity(quantity::fieta),
+                                 new quantity::DetectorQuantity(quantity::fiphi),
+                                 new quantity::ValueQuantity(quantity::fN),
+                                 0);
+
+    //	GET THE NOMINAL NUMBER OF CHANNELS PER FED
+    std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = gids.begin(); it != gids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
+      HcalDetId did(it->rawId());
+      HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+      _xNChsNominal.get(eid)++;
+    }
+  }
+
+  /*
 	 *	END LUMI. EVALUATE LUMI BASED FLAGS
 	 */
-	/* virtual */ void DigiRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
-		DQMStore::IGetter& ig, edm::LuminosityBlock const& lb,
-		edm::EventSetup const& es)
-	{
-		DQClient::endLuminosityBlock(ib, ig, lb, es);
+  /* virtual */ void DigiRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
+                                                        DQMStore::IGetter& ig,
+                                                        edm::LuminosityBlock const& lb,
+                                                        edm::EventSetup const& es) {
+    DQClient::endLuminosityBlock(ib, ig, lb, es);
 
-		if (_ptype!=fOffline)
-			return;
+    if (_ptype != fOffline)
+      return;
 
-		LSSummary lssum;
-		lssum._LS=_currentLS;
+    LSSummary lssum;
+    lssum._LS = _currentLS;
 
-		_xDigiSize.reset(); _xNChs.reset();
-		
-		//	INITIALIZE LUMI BASED HISTOGRAMS
-		Container2D cDigiSize_Crate, cOccupancy_depth;
-		cDigiSize_Crate.initialize(_taskname, "DigiSize",
-			hashfunctions::fCrate,
-			new quantity::ValueQuantity(quantity::fDigiSize),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cOccupancy_depth.initialize(_taskname, "Occupancy",
-			hashfunctions::fdepth,
-			new quantity::DetectorQuantity(quantity::fieta),
-			new quantity::DetectorQuantity(quantity::fiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
+    _xDigiSize.reset();
+    _xNChs.reset();
 
-		//	LOAD LUMI BASED HISTOGRAMS
-		cOccupancy_depth.load(ig, _emap, _subsystem);
-		cDigiSize_Crate.load(ig, _emap, _subsystem);
-		MonitorElement *meNumEvents = ig.get(_subsystem+
-			"/RunInfo/NumberOfEvents");
-		int numEvents = meNumEvents->getBinContent(1);
-		bool unknownIdsPresent = ig.get(_subsystem+"/"
-			+_taskname+"/UnknownIds")->getBinContent(1)>0;
+    //	INITIALIZE LUMI BASED HISTOGRAMS
+    Container2D cDigiSize_Crate, cOccupancy_depth;
+    cDigiSize_Crate.initialize(_taskname,
+                               "DigiSize",
+                               hashfunctions::fCrate,
+                               new quantity::ValueQuantity(quantity::fDigiSize),
+                               new quantity::ValueQuantity(quantity::fN),
+                               0);
+    cOccupancy_depth.initialize(_taskname,
+                                "Occupancy",
+                                hashfunctions::fdepth,
+                                new quantity::DetectorQuantity(quantity::fieta),
+                                new quantity::DetectorQuantity(quantity::fiphi),
+                                new quantity::ValueQuantity(quantity::fN),
+                                0);
 
-		//	book the Numer of Events - set axis extendable
-		if (!_booked)
-		{
-			ib.setCurrentFolder(_subsystem+"/"+_taskname);
-			_meNumEvents = ib.book1D("NumberOfEvents", "NumberOfEvents",
-				1000, 1, 1001); // 1000 to start with
-			_meNumEvents->getTH1()->SetCanExtend(TH1::kXaxis);
+    //	LOAD LUMI BASED HISTOGRAMS
+    cOccupancy_depth.load(ig, _emap, _subsystem);
+    cDigiSize_Crate.load(ig, _emap, _subsystem);
+    MonitorElement* meNumEvents = ig.get(_subsystem + "/RunInfo/NumberOfEvents");
+    int numEvents = meNumEvents->getBinContent(1);
+    bool unknownIdsPresent = ig.get(_subsystem + "/" + _taskname + "/UnknownIds")->getBinContent(1) > 0;
 
-			_cOccupancy_depth.book(ib, _emap, _subsystem);
-			_booked=true;
-		}
-		_meNumEvents->setBinContent(_currentLS, numEvents);
+    //	book the Numer of Events - set axis extendable
+    if (!_booked) {
+      ib.setCurrentFolder(_subsystem + "/" + _taskname);
+      _meNumEvents = ib.book1D("NumberOfEvents", "NumberOfEvents", 1000, 1, 1001);  // 1000 to start with
+      _meNumEvents->getTH1()->SetCanExtend(TH1::kXaxis);
 
-		//	ANALYZE THIS LS for LS BASED FLAGS
-		std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-		for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-			it!=gids.end(); ++it)
-		{
-			if (!it->isHcalDetId())
-				continue;
+      _cOccupancy_depth.book(ib, _emap, _subsystem);
+      _booked = true;
+    }
+    _meNumEvents->setBinContent(_currentLS, numEvents);
 
-			HcalDetId did = HcalDetId(it->rawId());
-			HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+    //	ANALYZE THIS LS for LS BASED FLAGS
+    std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = gids.begin(); it != gids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
 
-			cOccupancy_depth.getBinContent(did)>0?_xNChs.get(eid)++:
-				_xNChs.get(eid)+=0;
-			_cOccupancy_depth.fill(did, cOccupancy_depth.getBinContent(did));
-			//	digi size
-			cDigiSize_Crate.getMean(eid)!=
-				_refDigiSize[did.subdet()]?
-				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
-			cDigiSize_Crate.getRMS(eid)!=0?
-				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
-		}
+      HcalDetId did = HcalDetId(it->rawId());
+      HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
 
-		//	GENERATE SUMMARY AND STORE IT
-		std::vector<flag::Flag> vtmpflags; 
-		vtmpflags.resize(nLSFlags);
-		vtmpflags[fDigiSize]=flag::Flag("DigiSize");
-		vtmpflags[fNChsHF]=flag::Flag("NChsHF");
-		vtmpflags[fUnknownIds]=flag::Flag("UnknownIds");
-		vtmpflags[fLED]=flag::Flag("LEDMisfire");
-		for (std::vector<uint32_t>::const_iterator it=_vhashCrates.begin();
-			it!=_vhashCrates.end(); ++it)
-		{
-			HcalElectronicsId eid(*it);
-			HcalDetId did = HcalDetId(_emap->lookup(eid));
+      cOccupancy_depth.getBinContent(did) > 0 ? _xNChs.get(eid)++ : _xNChs.get(eid) += 0;
+      _cOccupancy_depth.fill(did, cOccupancy_depth.getBinContent(did));
+      //	digi size
+      cDigiSize_Crate.getMean(eid) != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+      cDigiSize_Crate.getRMS(eid) != 0 ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+    }
 
-			//	reset all the tmp flags to fNA
-			//	MUST DO IT NOW! AS NCDAQ MIGHT OVERWRITE IT!
-			for (std::vector<flag::Flag>::iterator ft=vtmpflags.begin();
-				ft!=vtmpflags.end(); ++ft)
-				ft->reset();
+    //	GENERATE SUMMARY AND STORE IT
+    std::vector<flag::Flag> vtmpflags;
+    vtmpflags.resize(nLSFlags);
+    vtmpflags[fDigiSize] = flag::Flag("DigiSize");
+    vtmpflags[fNChsHF] = flag::Flag("NChsHF");
+    vtmpflags[fUnknownIds] = flag::Flag("UnknownIds");
+    vtmpflags[fLED] = flag::Flag("LEDMisfire");
+    for (std::vector<uint32_t>::const_iterator it = _vhashCrates.begin(); it != _vhashCrates.end(); ++it) {
+      HcalElectronicsId eid(*it);
+      HcalDetId did = HcalDetId(_emap->lookup(eid));
 
-			if (_xDigiSize.get(eid)>0)
-				vtmpflags[fDigiSize]._state = flag::fBAD;
-			else
-				vtmpflags[fDigiSize]._state = flag::fGOOD;
+      //	reset all the tmp flags to fNA
+      //	MUST DO IT NOW! AS NCDAQ MIGHT OVERWRITE IT!
+      for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
+        ft->reset();
 
-			if (did.subdet() == HcalForward)
-			{
-				if (_xNChs.get(eid)!=_xNChsNominal.get(eid))
-					vtmpflags[fNChsHF]._state = flag::fBAD;
-				else
-					vtmpflags[fNChsHF]._state = flag::fGOOD;
-			} else {
-				vtmpflags[fNChsHF]._state = flag::fNA;
-			}
-			if (unknownIdsPresent)
-				vtmpflags[fUnknownIds]._state = flag::fBAD;
-			else
-				vtmpflags[fUnknownIds]._state = flag::fGOOD;
+      if (_xDigiSize.get(eid) > 0)
+        vtmpflags[fDigiSize]._state = flag::fBAD;
+      else
+        vtmpflags[fDigiSize]._state = flag::fGOOD;
 
-			if ((did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel)) {
-				std::string ledHistName = _subsystem + "/" + _taskname + "/LED_CUCountvsLS/Subdet/";
-				if (did.subdet() == HcalBarrel) {
-					ledHistName += "HB";
-				} else if (did.subdet() == HcalEndcap) {
-					ledHistName += "HE";
-				} else if (did.subdet() == HcalOuter) {
-					ledHistName += "HO";
-				} else if (did.subdet() == HcalForward) {
-					ledHistName += "HF";
-				}
-				MonitorElement* ledHist = ig.get(ledHistName);
-				if (ledHist) {
-					bool ledSignalPresent = (ledHist->getEntries() > 0);
-					if (ledSignalPresent)
-						vtmpflags[fLED]._state = flag::fBAD;
-					else
-						vtmpflags[fLED]._state = flag::fGOOD;
-				} else {
-					vtmpflags[fLED]._state = flag::fNA;
-				}
-			} else {
-				vtmpflags[fLED]._state = flag::fNA;
-			}
+      if (did.subdet() == HcalForward) {
+        if (_xNChs.get(eid) != _xNChsNominal.get(eid))
+          vtmpflags[fNChsHF]._state = flag::fBAD;
+        else
+          vtmpflags[fNChsHF]._state = flag::fGOOD;
+      } else {
+        vtmpflags[fNChsHF]._state = flag::fNA;
+      }
+      if (unknownIdsPresent)
+        vtmpflags[fUnknownIds]._state = flag::fBAD;
+      else
+        vtmpflags[fUnknownIds]._state = flag::fGOOD;
 
+      if ((did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) || (did.subdet() == HcalBarrel) ||
+          (did.subdet() == HcalBarrel)) {
+        std::string ledHistName = _subsystem + "/" + _taskname + "/LED_CUCountvsLS/Subdet/";
+        if (did.subdet() == HcalBarrel) {
+          ledHistName += "HB";
+        } else if (did.subdet() == HcalEndcap) {
+          ledHistName += "HE";
+        } else if (did.subdet() == HcalOuter) {
+          ledHistName += "HO";
+        } else if (did.subdet() == HcalForward) {
+          ledHistName += "HF";
+        }
+        MonitorElement* ledHist = ig.get(ledHistName);
+        if (ledHist) {
+          bool ledSignalPresent = (ledHist->getEntries() > 0);
+          if (ledSignalPresent)
+            vtmpflags[fLED]._state = flag::fBAD;
+          else
+            vtmpflags[fLED]._state = flag::fGOOD;
+        } else {
+          vtmpflags[fLED]._state = flag::fNA;
+        }
+      } else {
+        vtmpflags[fLED]._state = flag::fNA;
+      }
 
-			// push all the flags for this crate
-			lssum._vflags.push_back(vtmpflags);
-		}
+      // push all the flags for this crate
+      lssum._vflags.push_back(vtmpflags);
+    }
 
-		//	push all the flags for all FEDs for this LS
-		_vflagsLS.push_back(lssum);
-		cDigiSize_Crate.reset();
-		cOccupancy_depth.reset();
-	}
+    //	push all the flags for all FEDs for this LS
+    _vflagsLS.push_back(lssum);
+    cDigiSize_Crate.reset();
+    cOccupancy_depth.reset();
+  }
 
-	/*
+  /*
 	 *	End Job
 	 */
-	/* virtual */ std::vector<flag::Flag> DigiRunSummary::endJob(
-		DQMStore::IBooker& ib, DQMStore::IGetter& ig)
-	{
-		if (_ptype!=fOffline)
-			return std::vector<flag::Flag>();
+  /* virtual */ std::vector<flag::Flag> DigiRunSummary::endJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {
+    if (_ptype != fOffline)
+      return std::vector<flag::Flag>();
 
-		_xDead.reset(); _xUniHF.reset(); _xUni.reset();
+    _xDead.reset();
+    _xUniHF.reset();
+    _xUni.reset();
 
-		//	PREPARE LS AND RUN BASED FLAGS TO USE IT FOR BOOKING
-		std::vector<flag::Flag> vflagsPerLS;
-		std::vector<flag::Flag> vflagsPerRun;
-		vflagsPerLS.resize(nLSFlags);
-		vflagsPerRun.resize(nDigiFlag-nLSFlags+1);
-		vflagsPerLS[fDigiSize]=flag::Flag("DigiSize");
-		vflagsPerLS[fNChsHF]=flag::Flag("NChsHF");
-		vflagsPerLS[fUnknownIds]=flag::Flag("UnknownIds");
-		vflagsPerLS[fLED]=flag::Flag("LEDMisfire");
-		vflagsPerRun[fDigiSize]=flag::Flag("DigiSize");
-		vflagsPerRun[fNChsHF]=flag::Flag("NChsHF");
-		vflagsPerRun[fUniHF-nLSFlags+1]=flag::Flag("UniSlotHF");
-		vflagsPerRun[fDead-nLSFlags+1]=flag::Flag("Dead");
+    //	PREPARE LS AND RUN BASED FLAGS TO USE IT FOR BOOKING
+    std::vector<flag::Flag> vflagsPerLS;
+    std::vector<flag::Flag> vflagsPerRun;
+    vflagsPerLS.resize(nLSFlags);
+    vflagsPerRun.resize(nDigiFlag - nLSFlags + 1);
+    vflagsPerLS[fDigiSize] = flag::Flag("DigiSize");
+    vflagsPerLS[fNChsHF] = flag::Flag("NChsHF");
+    vflagsPerLS[fUnknownIds] = flag::Flag("UnknownIds");
+    vflagsPerLS[fLED] = flag::Flag("LEDMisfire");
+    vflagsPerRun[fDigiSize] = flag::Flag("DigiSize");
+    vflagsPerRun[fNChsHF] = flag::Flag("NChsHF");
+    vflagsPerRun[fUniHF - nLSFlags + 1] = flag::Flag("UniSlotHF");
+    vflagsPerRun[fDead - nLSFlags + 1] = flag::Flag("Dead");
 
-		//	INITIALIZE SUMMARY CONTAINERS
-		ContainerSingle2D cSummaryvsLS;
-		Container2D cSummaryvsLS_Crate;
-		cSummaryvsLS.initialize(_name, "SummaryvsLS",
-			new quantity::LumiSection(_maxProcessedLS),
-			new quantity::CrateQuantity(_emap),
-			new quantity::ValueQuantity(quantity::fState),0);
-		cSummaryvsLS.book(ib, _subsystem);
-		cSummaryvsLS_Crate.initialize(_name, "SummaryvsLS",
-			hashfunctions::fCrate,
-			new quantity::LumiSection(_maxProcessedLS),
-			new quantity::FlagQuantity(vflagsPerLS),
-			new quantity::ValueQuantity(quantity::fState),0);
-		cSummaryvsLS_Crate.book(ib, _emap, _subsystem);
+    //	INITIALIZE SUMMARY CONTAINERS
+    ContainerSingle2D cSummaryvsLS;
+    Container2D cSummaryvsLS_Crate;
+    cSummaryvsLS.initialize(_name,
+                            "SummaryvsLS",
+                            new quantity::LumiSection(_maxProcessedLS),
+                            new quantity::CrateQuantity(_emap),
+                            new quantity::ValueQuantity(quantity::fState),
+                            0);
+    cSummaryvsLS.book(ib, _subsystem);
+    cSummaryvsLS_Crate.initialize(_name,
+                                  "SummaryvsLS",
+                                  hashfunctions::fCrate,
+                                  new quantity::LumiSection(_maxProcessedLS),
+                                  new quantity::FlagQuantity(vflagsPerLS),
+                                  new quantity::ValueQuantity(quantity::fState),
+                                  0);
+    cSummaryvsLS_Crate.book(ib, _emap, _subsystem);
 
-		// INITIALIZE CONTAINERS WE NEED TO LOAD or BOOK
-		Container2D cOccupancyCut_depth;
-		Container2D cDead_depth, cDead_Crate;
-		cOccupancyCut_depth.initialize(_taskname, "OccupancyCut",
-			hashfunctions::fdepth,
-			new quantity::DetectorQuantity(quantity::fieta),
-			new quantity::DetectorQuantity(quantity::fiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cDead_depth.initialize(_name, "Dead",
-			hashfunctions::fdepth,
-			new quantity::DetectorQuantity(quantity::fieta),
-			new quantity::DetectorQuantity(quantity::fiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cDead_Crate.initialize(_name, "Dead",
-			hashfunctions::fCrate,
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ElectronicsQuantity(quantity::fFiberVMEFiberCh),
-			new quantity::ValueQuantity(quantity::fN),0);
+    // INITIALIZE CONTAINERS WE NEED TO LOAD or BOOK
+    Container2D cOccupancyCut_depth;
+    Container2D cDead_depth, cDead_Crate;
+    cOccupancyCut_depth.initialize(_taskname,
+                                   "OccupancyCut",
+                                   hashfunctions::fdepth,
+                                   new quantity::DetectorQuantity(quantity::fieta),
+                                   new quantity::DetectorQuantity(quantity::fiphi),
+                                   new quantity::ValueQuantity(quantity::fN),
+                                   0);
+    cDead_depth.initialize(_name,
+                           "Dead",
+                           hashfunctions::fdepth,
+                           new quantity::DetectorQuantity(quantity::fieta),
+                           new quantity::DetectorQuantity(quantity::fiphi),
+                           new quantity::ValueQuantity(quantity::fN),
+                           0);
+    cDead_Crate.initialize(_name,
+                           "Dead",
+                           hashfunctions::fCrate,
+                           new quantity::ElectronicsQuantity(quantity::fSpigot),
+                           new quantity::ElectronicsQuantity(quantity::fFiberVMEFiberCh),
+                           new quantity::ValueQuantity(quantity::fN),
+                           0);
 
-		//	LOAD
-		cOccupancyCut_depth.load(ig, _emap, _subsystem);
-		cDead_depth.book(ib, _emap, _subsystem);
-		cDead_Crate.book(ib, _emap, _subsystem);
+    //	LOAD
+    cOccupancyCut_depth.load(ig, _emap, _subsystem);
+    cDead_depth.book(ib, _emap, _subsystem);
+    cDead_Crate.book(ib, _emap, _subsystem);
 
-		//	ANALYZE RUN BASED QUANTITIES
-		std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-		for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-			it!=gids.end(); ++it)
-		{
-			if (!it->isHcalDetId())
-				continue;
+    //	ANALYZE RUN BASED QUANTITIES
+    std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = gids.begin(); it != gids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
 
-			HcalDetId did = HcalDetId(it->rawId());
-			HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+      HcalDetId did = HcalDetId(it->rawId());
+      HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
 
-			if (_cOccupancy_depth.getBinContent(did)<1)
-			{
-				_xDead.get(eid)++;
-				cDead_depth.fill(did);
-				cDead_Crate.fill(eid);
-			}
-			if (did.subdet()==HcalForward)
-				_xUniHF.get(eid)+=cOccupancyCut_depth.getBinContent(did);
-		}
-		//	ANALYZE FOR HF SLOT UNIFORMITY
-		for (uintCompactMap::const_iterator it=_xUniHF.begin();
-			it!=_xUniHF.end(); ++it)
-		{
-			uint32_t hash1 = it->first;
-			HcalElectronicsId eid1(hash1);
-			double x1 = it->second;
+      if (_cOccupancy_depth.getBinContent(did) < 1) {
+        _xDead.get(eid)++;
+        cDead_depth.fill(did);
+        cDead_Crate.fill(eid);
+      }
+      if (did.subdet() == HcalForward)
+        _xUniHF.get(eid) += cOccupancyCut_depth.getBinContent(did);
+    }
+    //	ANALYZE FOR HF SLOT UNIFORMITY
+    for (uintCompactMap::const_iterator it = _xUniHF.begin(); it != _xUniHF.end(); ++it) {
+      uint32_t hash1 = it->first;
+      HcalElectronicsId eid1(hash1);
+      double x1 = it->second;
 
-			for (uintCompactMap::const_iterator jt=_xUniHF.begin();
-				jt!=_xUniHF.end(); ++jt)
-			{
-				if (jt==it)
-					continue;
+      for (uintCompactMap::const_iterator jt = _xUniHF.begin(); jt != _xUniHF.end(); ++jt) {
+        if (jt == it)
+          continue;
 
-				double x2 = jt->second;
-				if (x2==0)
-					continue;
-				if (x1/x2<_thresh_unihf)
-					_xUni.get(eid1)++;
-			}
-		}
+        double x2 = jt->second;
+        if (x2 == 0)
+          continue;
+        if (x1 / x2 < _thresh_unihf)
+          _xUni.get(eid1)++;
+      }
+    }
 
-		/*
+    /*
 		 *	Iterate over each crate
 		 *		Iterate over each LS Summary
 		 *			Iterate over all flags
 		 *				set...
 		 */
-		//	iterate over all crates
-		std::vector<flag::Flag> sumflags;
-		int icrate=0;
-		for (auto& it_crate : _vhashCrates) {
-			flag::Flag fSumRun("DIGI"); // summary flag for this FED
-			flag::Flag ffDead("Dead");
-			flag::Flag ffUniSlotHF("UniSlotHF");
-			HcalElectronicsId eid(it_crate);
-			HcalDetId did = HcalDetId(_emap->lookup(eid));
+    //	iterate over all crates
+    std::vector<flag::Flag> sumflags;
+    int icrate = 0;
+    for (auto& it_crate : _vhashCrates) {
+      flag::Flag fSumRun("DIGI");  // summary flag for this FED
+      flag::Flag ffDead("Dead");
+      flag::Flag ffUniSlotHF("UniSlotHF");
+      HcalElectronicsId eid(it_crate);
+      HcalDetId did = HcalDetId(_emap->lookup(eid));
 
-			//	ITERATE OVER EACH LS
-			for (std::vector<LSSummary>::const_iterator itls=_vflagsLS.begin();
-				itls!=_vflagsLS.end(); ++itls)
-			{
-				int iflag=0;
-				flag::Flag fSumLS("DIGI");
-				for (std::vector<flag::Flag>::const_iterator ft=
-					itls->_vflags[icrate].begin(); ft!=itls->_vflags[icrate].end();
-					++ft)
-				{
-					cSummaryvsLS_Crate.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
-					fSumLS+=(*ft);
-					iflag++;
-				}
-				cSummaryvsLS.setBinContent(eid, itls->_LS, fSumLS._state);
-				fSumRun+=fSumLS;
-			}
+      //	ITERATE OVER EACH LS
+      for (std::vector<LSSummary>::const_iterator itls = _vflagsLS.begin(); itls != _vflagsLS.end(); ++itls) {
+        int iflag = 0;
+        flag::Flag fSumLS("DIGI");
+        for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[icrate].begin();
+             ft != itls->_vflags[icrate].end();
+             ++ft) {
+          cSummaryvsLS_Crate.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
+          fSumLS += (*ft);
+          iflag++;
+        }
+        cSummaryvsLS.setBinContent(eid, itls->_LS, fSumLS._state);
+        fSumRun += fSumLS;
+      }
 
-			//	EVALUATE RUN BASED FLAGS
-			if (_xDead.get(eid)>0)
-				ffDead._state = flag::fBAD;
-			else
-				ffDead._state = flag::fGOOD;
-			if (did.subdet() == HcalForward)
-			{
-				if (_xUni.get(eid)>0)
-					ffUniSlotHF._state = flag::fBAD;
-				else
-					ffUniSlotHF._state = flag::fGOOD;
-			}
-			fSumRun+=ffDead+ffUniSlotHF;
+      //	EVALUATE RUN BASED FLAGS
+      if (_xDead.get(eid) > 0)
+        ffDead._state = flag::fBAD;
+      else
+        ffDead._state = flag::fGOOD;
+      if (did.subdet() == HcalForward) {
+        if (_xUni.get(eid) > 0)
+          ffUniSlotHF._state = flag::fBAD;
+        else
+          ffUniSlotHF._state = flag::fGOOD;
+      }
+      fSumRun += ffDead + ffUniSlotHF;
 
-			// push the summary flag for this FED for the Whole Run
-			sumflags.push_back(fSumRun);
+      // push the summary flag for this FED for the Whole Run
+      sumflags.push_back(fSumRun);
 
-			//	 increment fed
-			icrate++;
-		}
+      //	 increment fed
+      icrate++;
+    }
 
-		return sumflags;
-	}
-}
+    return sumflags;
+  }
+}  // namespace hcaldqm

--- a/DQM/HcalTasks/src/PedestalRunSummary.cc
+++ b/DQM/HcalTasks/src/PedestalRunSummary.cc
@@ -1,29 +1,24 @@
 #include "DQM/HcalTasks/interface/PedestalRunSummary.h"
 
-namespace hcaldqm
-{
-	PedestalRunSummary::PedestalRunSummary(std::string const& name, 
-		std::string const& taskname, edm::ParameterSet const& ps) :
-		DQClient(name, taskname, ps)
-	{}
+namespace hcaldqm {
+  PedestalRunSummary::PedestalRunSummary(std::string const& name,
+                                         std::string const& taskname,
+                                         edm::ParameterSet const& ps)
+      : DQClient(name, taskname, ps) {}
 
-	/* virtual */ void PedestalRunSummary::beginRun(edm::Run const& r,
-		edm::EventSetup const& es)
-	{
-		DQClient::beginRun(r,es);
-	}
+  /* virtual */ void PedestalRunSummary::beginRun(edm::Run const& r, edm::EventSetup const& es) {
+    DQClient::beginRun(r, es);
+  }
 
-	/* virtual */ void PedestalRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
-		DQMStore::IGetter& ig, edm::LuminosityBlock const& lb,
-		edm::EventSetup const& es)
-	{
-		DQClient::endLuminosityBlock(ib, ig, lb, es);
-	}
+  /* virtual */ void PedestalRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
+                                                            DQMStore::IGetter& ig,
+                                                            edm::LuminosityBlock const& lb,
+                                                            edm::EventSetup const& es) {
+    DQClient::endLuminosityBlock(ib, ig, lb, es);
+  }
 
-	/* virtual */ std::vector<flag::Flag> PedestalRunSummary::endJob(
-		DQMStore::IBooker& ib, DQMStore::IGetter& ig)
-	{
-		std::vector<flag::Flag> sumflags;
-		return sumflags;
-	}
-}
+  /* virtual */ std::vector<flag::Flag> PedestalRunSummary::endJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {
+    std::vector<flag::Flag> sumflags;
+    return sumflags;
+  }
+}  // namespace hcaldqm

--- a/DQM/HcalTasks/src/RawRunSummary.cc
+++ b/DQM/HcalTasks/src/RawRunSummary.cc
@@ -1,67 +1,73 @@
 #include "DQM/HcalTasks/interface/RawRunSummary.h"
 
-namespace hcaldqm
-{
-	using namespace constants;
-	RawRunSummary::RawRunSummary(std::string const& name, 
-		std::string const& taskname, edm::ParameterSet const& ps) :
-		DQClient(name, taskname, ps), _booked(false)
-	{}
+namespace hcaldqm {
+  using namespace constants;
+  RawRunSummary::RawRunSummary(std::string const& name, std::string const& taskname, edm::ParameterSet const& ps)
+      : DQClient(name, taskname, ps), _booked(false) {}
 
-	/* virtual */ void RawRunSummary::beginRun(edm::Run const& r,
-		edm::EventSetup const& es)
-	{
-		DQClient::beginRun(r,es);
-		
-		if (_ptype!=fOffline)
-			return;
+  /* virtual */ void RawRunSummary::beginRun(edm::Run const& r, edm::EventSetup const& es) {
+    DQClient::beginRun(r, es);
 
-		//	INITIALIZE WHAT NEEDS TO BE INITIALIZE ONLY ONCE!
-		_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
-		_vhashVME.push_back(HcalElectronicsId(constants::FIBERCH_MIN,
-			constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
-		_vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		_filter_VME.initialize(filter::fFilter, hashfunctions::fElectronics,
-			_vhashVME);	// filter out VME 
-		_filter_uTCA.initialize(filter::fFilter, hashfunctions::fElectronics,
-			_vhashuTCA); // filter out uTCA
+    if (_ptype != fOffline)
+      return;
 
-		//	INTIALIZE CONTAINERS ACTING AS HOLDERS OF RUN INFORAMTION
-		_cEvnMsm_ElectronicsVME.initialize(_name, "EvnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsVME),
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ValueQuantity(quantity::fN),0);
-		_cBcnMsm_ElectronicsVME.initialize(_name, "BcnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsVME),
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ValueQuantity(quantity::fN),0);
-		_cEvnMsm_ElectronicsuTCA.initialize(_name, "EvnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsuTCA),
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new quantity::ValueQuantity(quantity::fN),0);
-		_cBcnMsm_ElectronicsuTCA.initialize(_name, "BcnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsuTCA),
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new quantity::ValueQuantity(quantity::fN),0);
-		_cBadQuality_depth.initialize(_name, "BadQuality",
-			 hashfunctions::fdepth,
-			 new quantity::DetectorQuantity(quantity::fieta),
-			 new quantity::DetectorQuantity(quantity::fiphi),
-			 new quantity::ValueQuantity(quantity::fN),0);
+    //	INITIALIZE WHAT NEEDS TO BE INITIALIZE ONLY ONCE!
+    _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+    _vhashVME.push_back(
+        HcalElectronicsId(constants::FIBERCH_MIN, constants::FIBER_VME_MIN, SPIGOT_MIN, CRATE_VME_MIN).rawId());
+    _vhashuTCA.push_back(HcalElectronicsId(CRATE_uTCA_MIN, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    _filter_VME.initialize(filter::fFilter, hashfunctions::fElectronics,
+                           _vhashVME);  // filter out VME
+    _filter_uTCA.initialize(filter::fFilter, hashfunctions::fElectronics,
+                            _vhashuTCA);  // filter out uTCA
 
-		_xEvn.initialize(hashfunctions::fFED);
-		_xBcn.initialize(hashfunctions::fFED);
-		_xBadQ.initialize(hashfunctions::fFED);
-		//	BOOK CONTAINERSXXX
-		_xEvn.book(_emap); _xBcn.book(_emap); _xBadQ.book(_emap);
-	}
+    //	INTIALIZE CONTAINERS ACTING AS HOLDERS OF RUN INFORAMTION
+    _cEvnMsm_ElectronicsVME.initialize(_name,
+                                       "EvnMsm",
+                                       hashfunctions::fElectronics,
+                                       new quantity::FEDQuantity(_vFEDsVME),
+                                       new quantity::ElectronicsQuantity(quantity::fSpigot),
+                                       new quantity::ValueQuantity(quantity::fN),
+                                       0);
+    _cBcnMsm_ElectronicsVME.initialize(_name,
+                                       "BcnMsm",
+                                       hashfunctions::fElectronics,
+                                       new quantity::FEDQuantity(_vFEDsVME),
+                                       new quantity::ElectronicsQuantity(quantity::fSpigot),
+                                       new quantity::ValueQuantity(quantity::fN),
+                                       0);
+    _cEvnMsm_ElectronicsuTCA.initialize(_name,
+                                        "EvnMsm",
+                                        hashfunctions::fElectronics,
+                                        new quantity::FEDQuantity(_vFEDsuTCA),
+                                        new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                                        new quantity::ValueQuantity(quantity::fN),
+                                        0);
+    _cBcnMsm_ElectronicsuTCA.initialize(_name,
+                                        "BcnMsm",
+                                        hashfunctions::fElectronics,
+                                        new quantity::FEDQuantity(_vFEDsuTCA),
+                                        new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                                        new quantity::ValueQuantity(quantity::fN),
+                                        0);
+    _cBadQuality_depth.initialize(_name,
+                                  "BadQuality",
+                                  hashfunctions::fdepth,
+                                  new quantity::DetectorQuantity(quantity::fieta),
+                                  new quantity::DetectorQuantity(quantity::fiphi),
+                                  new quantity::ValueQuantity(quantity::fN),
+                                  0);
 
-	/*
+    _xEvn.initialize(hashfunctions::fFED);
+    _xBcn.initialize(hashfunctions::fFED);
+    _xBadQ.initialize(hashfunctions::fFED);
+    //	BOOK CONTAINERSXXX
+    _xEvn.book(_emap);
+    _xBcn.book(_emap);
+    _xBadQ.book(_emap);
+  }
+
+  /*
 	 *	END OF LUMINOSITY HARVESTING 
 	 *	RAW FORMAT HAS ONLY LUMI BASED FLAGS!
 	 *	THEREFORE STEPS ARE:
@@ -69,250 +75,234 @@ namespace hcaldqm
 	 *	2) ANALYZE 
 	 *	3) GENERATE SUMMARY FLAGS AND PUSH THEM
 	 */
-	/* virtual */ void RawRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
-		DQMStore::IGetter& ig, edm::LuminosityBlock const& lb,
-		edm::EventSetup const& es)
-	{
-		DQClient::endLuminosityBlock(ib, ig, lb, es);
-		
-		if (_ptype!=fOffline)
-			return;
+  /* virtual */ void RawRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
+                                                       DQMStore::IGetter& ig,
+                                                       edm::LuminosityBlock const& lb,
+                                                       edm::EventSetup const& es) {
+    DQClient::endLuminosityBlock(ib, ig, lb, es);
 
-		//	INITIALIZE WHAT YOU NEED
-		LSSummary lssum; // summary for this LS
-		lssum._LS = _currentLS; // set the LS
+    if (_ptype != fOffline)
+      return;
 
-		//	RESET CONTAINERS USED FOR ANALYSIS OF THIS LS
-		_xEvn.reset(); _xBcn.reset(); _xBadQ.reset();
-		
-		//	INITIALIZE LUMI BASED HISTOGRAMS
-		Container2D cEvnMsm_ElectronicsVME,cEvnMsm_ElectronicsuTCA;
-		Container2D cBcnMsm_ElectronicsVME,cBcnMsm_ElectronicsuTCA;
-		Container2D cBadQuality_depth;
-		cEvnMsm_ElectronicsVME.initialize(_taskname, "EvnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsVME),
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cBcnMsm_ElectronicsVME.initialize(_taskname, "BcnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsVME),
-			new quantity::ElectronicsQuantity(quantity::fSpigot),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cEvnMsm_ElectronicsuTCA.initialize(_taskname, "EvnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsuTCA),
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cBcnMsm_ElectronicsuTCA.initialize(_taskname, "BcnMsm",
-			hashfunctions::fElectronics,
-			new quantity::FEDQuantity(_vFEDsuTCA),
-			new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cBadQuality_depth.initialize(_taskname, "BadQuality",
-			 hashfunctions::fdepth,
-			 new quantity::DetectorQuantity(quantity::fieta),
-			 new quantity::DetectorQuantity(quantity::fiphi),
-			 new quantity::ValueQuantity(quantity::fN),0);
+    //	INITIALIZE WHAT YOU NEED
+    LSSummary lssum;         // summary for this LS
+    lssum._LS = _currentLS;  // set the LS
 
-		//	LOAD LUMI BASED HISTOGRAMS
-		cEvnMsm_ElectronicsVME.load(ig, _emap, _filter_uTCA, _subsystem);
-		cBcnMsm_ElectronicsVME.load(ig, _emap, _filter_uTCA, _subsystem);
-		cEvnMsm_ElectronicsuTCA.load(ig, _emap, _filter_VME, _subsystem);
-		cBcnMsm_ElectronicsuTCA.load(ig, _emap, _filter_VME, _subsystem);
-		cBadQuality_depth.load(ig, _emap, _subsystem);
-		MonitorElement *meNumEvents = ig.get(_subsystem+
-			"/RunInfo/NumberOfEvents");
-		int numEvents = meNumEvents->getBinContent(1);
+    //	RESET CONTAINERS USED FOR ANALYSIS OF THIS LS
+    _xEvn.reset();
+    _xBcn.reset();
+    _xBadQ.reset();
 
-		//	BOOK for the very first time
-		if (!_booked)
-		{
-			_cEvnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-			_cBcnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
-			_cEvnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-			_cBcnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
-			_cBadQuality_depth.book(ib, _emap, _subsystem);
-			_booked=true;
-		}
+    //	INITIALIZE LUMI BASED HISTOGRAMS
+    Container2D cEvnMsm_ElectronicsVME, cEvnMsm_ElectronicsuTCA;
+    Container2D cBcnMsm_ElectronicsVME, cBcnMsm_ElectronicsuTCA;
+    Container2D cBadQuality_depth;
+    cEvnMsm_ElectronicsVME.initialize(_taskname,
+                                      "EvnMsm",
+                                      hashfunctions::fElectronics,
+                                      new quantity::FEDQuantity(_vFEDsVME),
+                                      new quantity::ElectronicsQuantity(quantity::fSpigot),
+                                      new quantity::ValueQuantity(quantity::fN),
+                                      0);
+    cBcnMsm_ElectronicsVME.initialize(_taskname,
+                                      "BcnMsm",
+                                      hashfunctions::fElectronics,
+                                      new quantity::FEDQuantity(_vFEDsVME),
+                                      new quantity::ElectronicsQuantity(quantity::fSpigot),
+                                      new quantity::ValueQuantity(quantity::fN),
+                                      0);
+    cEvnMsm_ElectronicsuTCA.initialize(_taskname,
+                                       "EvnMsm",
+                                       hashfunctions::fElectronics,
+                                       new quantity::FEDQuantity(_vFEDsuTCA),
+                                       new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                                       new quantity::ValueQuantity(quantity::fN),
+                                       0);
+    cBcnMsm_ElectronicsuTCA.initialize(_taskname,
+                                       "BcnMsm",
+                                       hashfunctions::fElectronics,
+                                       new quantity::FEDQuantity(_vFEDsuTCA),
+                                       new quantity::ElectronicsQuantity(quantity::fSlotuTCA),
+                                       new quantity::ValueQuantity(quantity::fN),
+                                       0);
+    cBadQuality_depth.initialize(_taskname,
+                                 "BadQuality",
+                                 hashfunctions::fdepth,
+                                 new quantity::DetectorQuantity(quantity::fieta),
+                                 new quantity::DetectorQuantity(quantity::fiphi),
+                                 new quantity::ValueQuantity(quantity::fN),
+                                 0);
 
-		// ANALYZE THIS LS
-		// iterate over all channels	
-		std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-		for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-			it!=gids.end(); ++it)
-		{
-			if (!it->isHcalDetId())
-				continue;
-			HcalDetId did = HcalDetId(it->rawId());
-			HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
+    //	LOAD LUMI BASED HISTOGRAMS
+    cEvnMsm_ElectronicsVME.load(ig, _emap, _filter_uTCA, _subsystem);
+    cBcnMsm_ElectronicsVME.load(ig, _emap, _filter_uTCA, _subsystem);
+    cEvnMsm_ElectronicsuTCA.load(ig, _emap, _filter_VME, _subsystem);
+    cBcnMsm_ElectronicsuTCA.load(ig, _emap, _filter_VME, _subsystem);
+    cBadQuality_depth.load(ig, _emap, _subsystem);
+    MonitorElement* meNumEvents = ig.get(_subsystem + "/RunInfo/NumberOfEvents");
+    int numEvents = meNumEvents->getBinContent(1);
 
-			_xBadQ.get(eid)+=cBadQuality_depth.getBinContent(did);
-			_cBadQuality_depth.fill(did, cBadQuality_depth.getBinContent(did));
-			if (eid.isVMEid())
-			{
-				_xEvn.get(eid)+=cEvnMsm_ElectronicsVME.getBinContent(eid);
-				_xBcn.get(eid)+=cBcnMsm_ElectronicsVME.getBinContent(eid);
+    //	BOOK for the very first time
+    if (!_booked) {
+      _cEvnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+      _cBcnMsm_ElectronicsVME.book(ib, _emap, _filter_uTCA, _subsystem);
+      _cEvnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+      _cBcnMsm_ElectronicsuTCA.book(ib, _emap, _filter_VME, _subsystem);
+      _cBadQuality_depth.book(ib, _emap, _subsystem);
+      _booked = true;
+    }
 
-				_cEvnMsm_ElectronicsVME.fill(eid, 
-					cEvnMsm_ElectronicsVME.getBinContent(eid));
-				_cBcnMsm_ElectronicsVME.fill(eid, 
-					cBcnMsm_ElectronicsVME.getBinContent(eid));
-			}
-			else
-			{
-				_xEvn.get(eid)+=cEvnMsm_ElectronicsuTCA.getBinContent(eid);
-				_xBcn.get(eid)+=cBcnMsm_ElectronicsuTCA.getBinContent(eid);
+    // ANALYZE THIS LS
+    // iterate over all channels
+    std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = gids.begin(); it != gids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
+      HcalDetId did = HcalDetId(it->rawId());
+      HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
 
-				_cEvnMsm_ElectronicsuTCA.fill(eid, 
-					cEvnMsm_ElectronicsuTCA.getBinContent(eid));
-				_cBcnMsm_ElectronicsuTCA.fill(eid, 
-					cBcnMsm_ElectronicsuTCA.getBinContent(eid));
-			}
-		}
-		
+      _xBadQ.get(eid) += cBadQuality_depth.getBinContent(did);
+      _cBadQuality_depth.fill(did, cBadQuality_depth.getBinContent(did));
+      if (eid.isVMEid()) {
+        _xEvn.get(eid) += cEvnMsm_ElectronicsVME.getBinContent(eid);
+        _xBcn.get(eid) += cBcnMsm_ElectronicsVME.getBinContent(eid);
 
-		//	GENERATE THE SUMMARY FOR THIS LS AND STORE IT
-		std::vector<flag::Flag> vtmpflags; // tmp summary flags vector
-		vtmpflags.resize(nRawFlag);
-		vtmpflags[fEvnMsm]=flag::Flag("EvnMsm");
-		vtmpflags[fBcnMsm]=flag::Flag("BcnMsm");
-		vtmpflags[fBadQ]=flag::Flag("BadQ");
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-			it!=_vhashFEDs.end(); ++it)
-		{
-			HcalElectronicsId eid(*it);
-			
-			//	reset all the tmp flags to fNA
-			//	MUST DO IT NOW! AS NCDAQ MIGHT OVERWRITE IT!
-			for (std::vector<flag::Flag>::iterator ft=vtmpflags.begin();
-				ft!=vtmpflags.end(); ++ft)
-				ft->reset();
-			
-			//	check if this FED was @cDAQ
-			std::vector<uint32_t>::const_iterator cit=std::find(
-				_vcdaqEids.begin(), _vcdaqEids.end(), *it);
-			if (cit==_vcdaqEids.end())
-			{
-				//	was not @cDAQ, set all the flags for this FED as fNCDAQ
-				for (std::vector<flag::Flag>::iterator ft=vtmpflags.begin();
-					ft!=vtmpflags.end(); ++ft)
-					ft->_state = flag::fNCDAQ;
+        _cEvnMsm_ElectronicsVME.fill(eid, cEvnMsm_ElectronicsVME.getBinContent(eid));
+        _cBcnMsm_ElectronicsVME.fill(eid, cBcnMsm_ElectronicsVME.getBinContent(eid));
+      } else {
+        _xEvn.get(eid) += cEvnMsm_ElectronicsuTCA.getBinContent(eid);
+        _xBcn.get(eid) += cBcnMsm_ElectronicsuTCA.getBinContent(eid);
 
-				// push all the flags for this FED
-				// IMPORTANT!!!
-				lssum._vflags.push_back(vtmpflags);
-				continue;
-			}
+        _cEvnMsm_ElectronicsuTCA.fill(eid, cEvnMsm_ElectronicsuTCA.getBinContent(eid));
+        _cBcnMsm_ElectronicsuTCA.fill(eid, cBcnMsm_ElectronicsuTCA.getBinContent(eid));
+      }
+    }
 
-			//	here only if was registered at cDAQ
-			if (utilities::isFEDHBHE(eid) || utilities::isFEDHF(eid) ||
-				utilities::isFEDHO(eid))
-			{
-				if (_xEvn.get(eid)>0)
-					vtmpflags[fEvnMsm]._state = flag::fBAD;
-				else
-					vtmpflags[fEvnMsm]._state = flag::fGOOD;
-				if (_xBcn.get(eid)>0)
-					vtmpflags[fBcnMsm]._state = flag::fBAD;
-				else
-					vtmpflags[fBcnMsm]._state = flag::fGOOD;
-				if (double(_xBadQ.get(eid))>double(12*numEvents))
-					vtmpflags[fBadQ]._state = flag::fBAD;
-				else if (_xBadQ.get(eid)>0)
-					vtmpflags[fBadQ]._state = flag::fPROBLEMATIC;
-				else
-					vtmpflags[fBadQ]._state = flag::fGOOD;
-			}
+    //	GENERATE THE SUMMARY FOR THIS LS AND STORE IT
+    std::vector<flag::Flag> vtmpflags;  // tmp summary flags vector
+    vtmpflags.resize(nRawFlag);
+    vtmpflags[fEvnMsm] = flag::Flag("EvnMsm");
+    vtmpflags[fBcnMsm] = flag::Flag("BcnMsm");
+    vtmpflags[fBadQ] = flag::Flag("BadQ");
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      HcalElectronicsId eid(*it);
 
-			// push all the flags for this FED
-			lssum._vflags.push_back(vtmpflags);
-		}
+      //	reset all the tmp flags to fNA
+      //	MUST DO IT NOW! AS NCDAQ MIGHT OVERWRITE IT!
+      for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
+        ft->reset();
 
-		//	push all flags for all FEDs for this LS
-		_vflagsLS.push_back(lssum);
-	}
+      //	check if this FED was @cDAQ
+      std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
+      if (cit == _vcdaqEids.end()) {
+        //	was not @cDAQ, set all the flags for this FED as fNCDAQ
+        for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
+          ft->_state = flag::fNCDAQ;
 
-	/*
+        // push all the flags for this FED
+        // IMPORTANT!!!
+        lssum._vflags.push_back(vtmpflags);
+        continue;
+      }
+
+      //	here only if was registered at cDAQ
+      if (utilities::isFEDHBHE(eid) || utilities::isFEDHF(eid) || utilities::isFEDHO(eid)) {
+        if (_xEvn.get(eid) > 0)
+          vtmpflags[fEvnMsm]._state = flag::fBAD;
+        else
+          vtmpflags[fEvnMsm]._state = flag::fGOOD;
+        if (_xBcn.get(eid) > 0)
+          vtmpflags[fBcnMsm]._state = flag::fBAD;
+        else
+          vtmpflags[fBcnMsm]._state = flag::fGOOD;
+        if (double(_xBadQ.get(eid)) > double(12 * numEvents))
+          vtmpflags[fBadQ]._state = flag::fBAD;
+        else if (_xBadQ.get(eid) > 0)
+          vtmpflags[fBadQ]._state = flag::fPROBLEMATIC;
+        else
+          vtmpflags[fBadQ]._state = flag::fGOOD;
+      }
+
+      // push all the flags for this FED
+      lssum._vflags.push_back(vtmpflags);
+    }
+
+    //	push all flags for all FEDs for this LS
+    _vflagsLS.push_back(lssum);
+  }
+
+  /*
 	 * END JOB
 	 * BOOK THE SUMMARY CONTAINERS, SET THE FLAGS
 	 * RETURN THE LIST OF FLAGS FOR THIS DATATIER
 	 */
-	/* virtual */ std::vector<flag::Flag> RawRunSummary::endJob(
-		DQMStore::IBooker& ib, DQMStore::IGetter& ig)
-	{
+  /* virtual */ std::vector<flag::Flag> RawRunSummary::endJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {
+    if (_ptype != fOffline)
+      return std::vector<flag::Flag>();
 
-		if (_ptype!=fOffline)
-			return std::vector<flag::Flag>();
+    //	PREPARE LS BASED FLAGS to use it for booking
+    std::vector<flag::Flag> vflagsLS;
+    vflagsLS.resize(nRawFlag);
+    vflagsLS[fEvnMsm] = flag::Flag("EvnMsm");
+    vflagsLS[fBcnMsm] = flag::Flag("BcnMsm");
+    vflagsLS[fBadQ] = flag::Flag("BadQ");
 
+    //	INITIALIZE AND BOOK SUMMARY CONTAINERS
+    ContainerSingle2D cSummaryvsLS;  // summary per FED: flag vs LS
+    Container2D cSummaryvsLS_FED;    // LS based flags vs LS for each FED
+    cSummaryvsLS.initialize(_name,
+                            "SummaryvsLS",
+                            new quantity::LumiSection(_maxProcessedLS),
+                            new quantity::FEDQuantity(_vFEDs),
+                            new quantity::ValueQuantity(quantity::fState),
+                            0);
+    cSummaryvsLS_FED.initialize(_name,
+                                "SummaryvsLS",
+                                hashfunctions::fFED,
+                                new quantity::LumiSection(_maxProcessedLS),
+                                new quantity::FlagQuantity(vflagsLS),
+                                new quantity::ValueQuantity(quantity::fState),
+                                0);
+    cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    cSummaryvsLS.book(ib, _subsystem);
 
-		//	PREPARE LS BASED FLAGS to use it for booking
-		std::vector<flag::Flag> vflagsLS;
-		vflagsLS.resize(nRawFlag);
-		vflagsLS[fEvnMsm]=flag::Flag("EvnMsm");
-		vflagsLS[fBcnMsm]=flag::Flag("BcnMsm");
-		vflagsLS[fBadQ]=flag::Flag("BadQ");
-
-
-		//	INITIALIZE AND BOOK SUMMARY CONTAINERS
-		ContainerSingle2D cSummaryvsLS; // summary per FED: flag vs LS
-		Container2D cSummaryvsLS_FED; // LS based flags vs LS for each FED
-		cSummaryvsLS.initialize(_name, "SummaryvsLS",
-			new quantity::LumiSection(_maxProcessedLS),
-			new quantity::FEDQuantity(_vFEDs),
-			new quantity::ValueQuantity(quantity::fState),0);
-		cSummaryvsLS_FED.initialize(_name, "SummaryvsLS",
-			hashfunctions::fFED,
-			new quantity::LumiSection(_maxProcessedLS),
-			new quantity::FlagQuantity(vflagsLS),
-			new quantity::ValueQuantity(quantity::fState),0);
-		cSummaryvsLS_FED.book(ib, _emap, _subsystem);
-		cSummaryvsLS.book(ib, _subsystem);
-
-		/*
+    /*
 		 *	Iterate over each FED
 		 *		Iterate over each LS SUmmary
 		 *			Iterate over all flags
 		 *				set...
 		 */
 
-		std::vector<flag::Flag> sumflags; // flag per FED
-		int ifed=0;
-		for (std::vector<uint32_t>::const_iterator it=_vhashFEDs.begin();
-			it!=_vhashFEDs.end(); ++it)
-		{
-			flag::Flag fSumRun("RAW"); // summary flag for this FED
-			HcalElectronicsId eid(*it);
+    std::vector<flag::Flag> sumflags;  // flag per FED
+    int ifed = 0;
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      flag::Flag fSumRun("RAW");  // summary flag for this FED
+      HcalElectronicsId eid(*it);
 
-			//	ITERATE OVER EACH LS
-			for (std::vector<LSSummary>::const_iterator itls=_vflagsLS.begin();
-				itls!=_vflagsLS.end(); ++itls)
-			{
-				//	fill histograms per LS
-				int iflag=0;
-				flag::Flag fSumLS("RAW");
-				for (std::vector<flag::Flag>::const_iterator ft=
-					itls->_vflags[ifed].begin(); ft!=itls->_vflags[ifed].end();
-					++ft)
-				{
-					//	Flag vs LS per FEd
-					cSummaryvsLS_FED.setBinContent(eid, itls->_LS, int(iflag),
-						ft->_state);
-					fSumLS+=(*ft);
-					iflag++;
-				}
-				//	FED vs LS
-				cSummaryvsLS.setBinContent(eid, itls->_LS, fSumLS._state);
-				fSumRun+=fSumLS;
-			}
-			
-			//	push the summary flag for this FED for the whole RUN
-			sumflags.push_back(fSumRun);
-			
-			//	increment the fed counter
-			ifed++;
-		}
-	
-		return sumflags;
-	}
-}
+      //	ITERATE OVER EACH LS
+      for (std::vector<LSSummary>::const_iterator itls = _vflagsLS.begin(); itls != _vflagsLS.end(); ++itls) {
+        //	fill histograms per LS
+        int iflag = 0;
+        flag::Flag fSumLS("RAW");
+        for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[ifed].begin(); ft != itls->_vflags[ifed].end();
+             ++ft) {
+          //	Flag vs LS per FEd
+          cSummaryvsLS_FED.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
+          fSumLS += (*ft);
+          iflag++;
+        }
+        //	FED vs LS
+        cSummaryvsLS.setBinContent(eid, itls->_LS, fSumLS._state);
+        fSumRun += fSumLS;
+      }
+
+      //	push the summary flag for this FED for the whole RUN
+      sumflags.push_back(fSumRun);
+
+      //	increment the fed counter
+      ifed++;
+    }
+
+    return sumflags;
+  }
+}  // namespace hcaldqm

--- a/DQM/HcalTasks/src/RecoRunSummary.cc
+++ b/DQM/HcalTasks/src/RecoRunSummary.cc
@@ -1,192 +1,169 @@
 #include "DQM/HcalTasks/interface/RecoRunSummary.h"
 
-namespace hcaldqm
-{
-	using namespace constants;
-	
-	RecoRunSummary::RecoRunSummary(std::string const& name, 
-		std::string const& taskname, edm::ParameterSet const& ps) :
-		DQClient(name, taskname, ps)
-	{
-		_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf",
-			0.2);
-		_thresh_tcds = ps.getUntrackedParameter<double>("thresh_tcds",
-			1.5);
-	}
+namespace hcaldqm {
+  using namespace constants;
 
-	/* virtual */ void RecoRunSummary::beginRun(edm::Run const& r,
-		edm::EventSetup const& es)
-	{
-		DQClient::beginRun(r,es);
-	}
+  RecoRunSummary::RecoRunSummary(std::string const& name, std::string const& taskname, edm::ParameterSet const& ps)
+      : DQClient(name, taskname, ps) {
+    _thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
+    _thresh_tcds = ps.getUntrackedParameter<double>("thresh_tcds", 1.5);
+  }
 
-	/*
+  /* virtual */ void RecoRunSummary::beginRun(edm::Run const& r, edm::EventSetup const& es) {
+    DQClient::beginRun(r, es);
+  }
+
+  /*
 	 *
 	 */
-	/* virtual */ void RecoRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
-		DQMStore::IGetter& ig, edm::LuminosityBlock const& lb,
-		edm::EventSetup const& es)
-	{
-		DQClient::endLuminosityBlock(ib, ig, lb, es);
-	}
+  /* virtual */ void RecoRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
+                                                        DQMStore::IGetter& ig,
+                                                        edm::LuminosityBlock const& lb,
+                                                        edm::EventSetup const& es) {
+    DQClient::endLuminosityBlock(ib, ig, lb, es);
+  }
 
-	/*
+  /*
 	 *
 	 */
-	/* virtual */ std::vector<flag::Flag> RecoRunSummary::endJob(
-		DQMStore::IBooker& ib, DQMStore::IGetter& ig)
-	{
+  /* virtual */ std::vector<flag::Flag> RecoRunSummary::endJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {
+    if (_ptype != fOffline)
+      return std::vector<flag::Flag>();
 
-		if (_ptype!=fOffline)
-			return std::vector<flag::Flag>();
+    // FILTERS, some useful vectors, hash maps
+    std::vector<uint32_t> vhashCrateHF;
+    vhashCrateHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashCrateHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    vhashCrateHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
+    filter::HashFilter filter_CrateHF;
+    filter_CrateHF.initialize(filter::fPreserver, hashfunctions::fCrate,
+                              vhashCrateHF);  // preserve only HF crates
+    electronicsmap::ElectronicsMap ehashmap;
+    ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+    bool tcdsshift = false;
+    std::vector<flag::Flag> vflags;
+    vflags.resize(nRecoFlag);
+    vflags[fUniSlotHF] = flag::Flag("UniSlotHF");
+    vflags[fTCDS] = flag::Flag("TCDS");
 
-		// FILTERS, some useful vectors, hash maps
-		std::vector<uint32_t> vhashCrateHF;
-		vhashCrateHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashCrateHF.push_back(HcalElectronicsId(29, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		vhashCrateHF.push_back(HcalElectronicsId(32, SLOT_uTCA_MIN,
-			FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
-		filter::HashFilter filter_CrateHF;
-		filter_CrateHF.initialize(filter::fPreserver, hashfunctions::fCrate,
-			vhashCrateHF);    // preserve only HF crates
-		electronicsmap::ElectronicsMap ehashmap;
-		ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
-		bool tcdsshift = false;
-		std::vector<flag::Flag> vflags; vflags.resize(nRecoFlag);
-		vflags[fUniSlotHF]=flag::Flag("UniSlotHF");
-		vflags[fTCDS]=flag::Flag("TCDS");
+    //	INITIALIZE
+    Container2D cOccupancy_depth, cOccupancyCut_depth;
+    ContainerSingle2D cSummary;
+    Container1D cTimingCut_HBHEPartition;
+    ContainerXXX<double> xUniHF, xUni;
+    xUni.initialize(hashfunctions::fCrate);
+    xUniHF.initialize(hashfunctions::fCrateSlot);
+    cOccupancy_depth.initialize(_taskname,
+                                "Occupancy",
+                                hashfunctions::fdepth,
+                                new quantity::DetectorQuantity(quantity::fieta),
+                                new quantity::DetectorQuantity(quantity::fiphi),
+                                new quantity::ValueQuantity(quantity::fN),
+                                0);
+    cOccupancyCut_depth.initialize(_taskname,
+                                   "OccupancyCut",
+                                   hashfunctions::fdepth,
+                                   new quantity::DetectorQuantity(quantity::fieta),
+                                   new quantity::DetectorQuantity(quantity::fiphi),
+                                   new quantity::ValueQuantity(quantity::fN),
+                                   0);
+    cTimingCut_HBHEPartition.initialize(_taskname,
+                                        "TimingCut",
+                                        hashfunctions::fHBHEPartition,
+                                        new quantity::ValueQuantity(quantity::fTiming_ns),
+                                        new quantity::ValueQuantity(quantity::fN),
+                                        0);
 
+    cSummary.initialize(_name,
+                        "Summary",
+                        new quantity::CrateQuantity(_emap),
+                        new quantity::FlagQuantity(vflags),
+                        new quantity::ValueQuantity(quantity::fState),
+                        0);
 
-		//	INITIALIZE
-		Container2D cOccupancy_depth, cOccupancyCut_depth;
-		ContainerSingle2D cSummary;
-		Container1D cTimingCut_HBHEPartition;
-		ContainerXXX<double> xUniHF, xUni;
-		xUni.initialize(hashfunctions::fCrate);
-		xUniHF.initialize(hashfunctions::fCrateSlot);
-		cOccupancy_depth.initialize(_taskname, "Occupancy",
-			hashfunctions::fdepth,
-			new quantity::DetectorQuantity(quantity::fieta),
-			new quantity::DetectorQuantity(quantity::fiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cOccupancyCut_depth.initialize(_taskname, "OccupancyCut",
-			hashfunctions::fdepth,
-			new quantity::DetectorQuantity(quantity::fieta),
-			new quantity::DetectorQuantity(quantity::fiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cTimingCut_HBHEPartition.initialize(_taskname, "TimingCut",
-			hashfunctions::fHBHEPartition,
-			new quantity::ValueQuantity(quantity::fTiming_ns),
-			new quantity::ValueQuantity(quantity::fN),0);
+    //	BOOK
+    xUniHF.book(_emap, filter_CrateHF);
 
-		cSummary.initialize(_name, "Summary",
-			new quantity::CrateQuantity(_emap),
-			new quantity::FlagQuantity(vflags),
-			new quantity::ValueQuantity(quantity::fState),0);
+    //	LOAD
+    cOccupancy_depth.load(ig, _emap, _subsystem);
+    cOccupancyCut_depth.load(ig, _emap, _subsystem);
+    cTimingCut_HBHEPartition.book(ib, _emap, _subsystem);
+    cSummary.book(ib, _subsystem);
 
-		//	BOOK
-		xUniHF.book(_emap, filter_CrateHF);
+    //	iterate over all channels
+    std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = gids.begin(); it != gids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
 
+      HcalDetId did(it->rawId());
+      HcalElectronicsId eid = HcalElectronicsId(ehashmap.lookup(did));
 
-		//	LOAD
-		cOccupancy_depth.load(ig, _emap, _subsystem);
-		cOccupancyCut_depth.load(ig, _emap, _subsystem);
-		cTimingCut_HBHEPartition.book(ib, _emap, _subsystem);
-		cSummary.book(ib, _subsystem);
+      if (did.subdet() == HcalForward)
+        xUniHF.get(eid) += cOccupancyCut_depth.getBinContent(did);
+    }
 
-		//	iterate over all channels
-		std::vector<HcalGenericDetId> gids = _emap->allPrecisionId();
-		for (std::vector<HcalGenericDetId>::const_iterator it=gids.begin();
-			it!=gids.end(); ++it)
-		{
-			if (!it->isHcalDetId())			
-				continue;
+    //	iphi/slot HF non uniformity
+    for (doubleCompactMap::const_iterator it = xUniHF.begin(); it != xUniHF.end(); ++it) {
+      uint32_t hash1 = it->first;
+      HcalElectronicsId eid1(hash1);
+      double x1 = it->second;
+      for (doubleCompactMap::const_iterator jt = xUniHF.begin(); jt != xUniHF.end(); ++jt) {
+        if (jt == it)
+          continue;
 
-			HcalDetId did(it->rawId());
-			HcalElectronicsId eid = HcalElectronicsId(ehashmap.lookup(did));
+        double x2 = jt->second;
+        if (x2 == 0)
+          continue;
+        if (x1 / x2 < _thresh_unihf)
+          xUni.get(eid1)++;
+      }
+    }
 
-			if (did.subdet()==HcalForward)
-				xUniHF.get(eid)+=cOccupancyCut_depth.getBinContent(did);
-		}
+    //	TCDS shift
+    double a = cTimingCut_HBHEPartition.getMean(HcalDetId(HcalBarrel, 1, 5, 1));
+    double b = cTimingCut_HBHEPartition.getMean(HcalDetId(HcalBarrel, 1, 30, 1));
+    double c = cTimingCut_HBHEPartition.getMean(HcalDetId(HcalBarrel, 1, 55, 1));
+    double dab = fabs(a - b);
+    double dac = fabs(a - c);
+    double dbc = fabs(b - c);
+    if (dab >= _thresh_tcds || dac >= _thresh_tcds || dbc >= _thresh_tcds)
+      tcdsshift = true;
 
+    //	summary flags
+    std::vector<flag::Flag> sumflags;
+    int icrate = 0;
+    for (std::vector<uint32_t>::const_iterator it = _vhashCrates.begin(); it != _vhashCrates.end(); ++it) {
+      flag::Flag fSum("RECO");
+      HcalElectronicsId eid(*it);
+      HcalDetId did = HcalDetId(_emap->lookup(eid));
 
-		//	iphi/slot HF non uniformity
-		for (doubleCompactMap::const_iterator it=xUniHF.begin();
-			it!=xUniHF.end(); ++it)
-		{
-			uint32_t hash1 = it->first;
-			HcalElectronicsId eid1(hash1);
-			double x1 = it->second;
-			for (doubleCompactMap::const_iterator jt=xUniHF.begin();
-				jt!=xUniHF.end(); ++jt)
-			{
-				if (jt==it)
-					continue;
+      //	registered @cDAQ
+      if (did.subdet() == HcalBarrel || did.subdet() == HcalEndcap) {
+        if (tcdsshift)
+          vflags[fTCDS]._state = flag::fBAD;
+        else
+          vflags[fTCDS]._state = flag::fGOOD;
+      }
+      if (did.subdet() == HcalForward) {
+        if (xUni.get(eid) > 0)
+          vflags[fUniSlotHF]._state = flag::fBAD;
+        else
+          vflags[fUniSlotHF]._state = flag::fGOOD;
+      }
 
-				double x2 = jt->second;
-				if (x2==0)
-					continue;
-				if (x1/x2<_thresh_unihf)
-					xUni.get(eid1)++;
-			}
-		}
+      //	combine
+      int iflag = 0;
+      for (std::vector<flag::Flag>::iterator ft = vflags.begin(); ft != vflags.end(); ++ft) {
+        cSummary.setBinContent(eid, iflag, ft->_state);
+        fSum += (*ft);
+        iflag++;
+        ft->reset();
+      }
+      sumflags.push_back(fSum);
+      icrate++;
+    }
 
-
-		//	TCDS shift
-		double a = cTimingCut_HBHEPartition.getMean(
-			HcalDetId(HcalBarrel,1,5,1));
-		double b = cTimingCut_HBHEPartition.getMean(
-			HcalDetId(HcalBarrel,1,30,1));
-		double c = cTimingCut_HBHEPartition.getMean(
-			HcalDetId(HcalBarrel,1,55,1));
-		double dab = fabs(a-b);
-		double dac = fabs(a-c);
-		double dbc = fabs(b-c);
-		if (dab>=_thresh_tcds || dac>=_thresh_tcds || dbc>=_thresh_tcds)
-			tcdsshift = true;
-
-		//	summary flags
-		std::vector<flag::Flag> sumflags;
-		int icrate=0;
-		for (std::vector<uint32_t>::const_iterator it=_vhashCrates.begin();
-			it!=_vhashCrates.end(); ++it)
-		{
-			flag::Flag fSum("RECO");
-			HcalElectronicsId eid(*it);
-			HcalDetId did = HcalDetId(_emap->lookup(eid));
-
-			//	registered @cDAQ
-			if (did.subdet() == HcalBarrel || did.subdet() == HcalEndcap)
-			{
-				if (tcdsshift)
-					vflags[fTCDS]._state = flag::fBAD;
-				else
-					vflags[fTCDS]._state = flag::fGOOD;
-			}
-			if (did.subdet() == HcalForward)
-			{
-				if (xUni.get(eid)>0)
-					vflags[fUniSlotHF]._state = flag::fBAD;
-				else
-					vflags[fUniSlotHF]._state = flag::fGOOD;
-			}
-			
-			//	combine
-			int iflag=0;
-			for (std::vector<flag::Flag>::iterator ft=vflags.begin();
-				ft!=vflags.end(); ++ft)
-			{
-				cSummary.setBinContent(eid, iflag, ft->_state);
-				fSum+=(*ft);
-				iflag++;
-				ft->reset();
-			}
-			sumflags.push_back(fSum);
-			icrate++;
-		}
-
-		return sumflags;
-	}
-}
+    return sumflags;
+  }
+}  // namespace hcaldqm

--- a/DQM/HcalTasks/src/TPRunSummary.cc
+++ b/DQM/HcalTasks/src/TPRunSummary.cc
@@ -1,174 +1,171 @@
 #include "DQM/HcalTasks/interface/TPRunSummary.h"
 
-namespace hcaldqm
-{
-	using namespace constants;
-	TPRunSummary::TPRunSummary(std::string const& name, 
-		std::string const& taskname, edm::ParameterSet const& ps) :
-		DQClient(name, taskname, ps)
-	{
-		_thresh_EtMsmRate_high = ps.getUntrackedParameter<double>(
-			"thresh_EtMsmRate_high", 0.2);
-		_thresh_EtMsmRate_low = ps.getUntrackedParameter<double>(
-			"thresh_EtMsmRate_low", 0.05);
-		_thresh_FGMsmRate_high = ps.getUntrackedParameter<double>(
-			"thresh_FGMsmRate_high", 0.2);
-		_thresh_FGMsmRate_low = ps.getUntrackedParameter<double>(
-			"thresh_FGMsmRate_low", 0.05);
-	}
+namespace hcaldqm {
+  using namespace constants;
+  TPRunSummary::TPRunSummary(std::string const& name, std::string const& taskname, edm::ParameterSet const& ps)
+      : DQClient(name, taskname, ps) {
+    _thresh_EtMsmRate_high = ps.getUntrackedParameter<double>("thresh_EtMsmRate_high", 0.2);
+    _thresh_EtMsmRate_low = ps.getUntrackedParameter<double>("thresh_EtMsmRate_low", 0.05);
+    _thresh_FGMsmRate_high = ps.getUntrackedParameter<double>("thresh_FGMsmRate_high", 0.2);
+    _thresh_FGMsmRate_low = ps.getUntrackedParameter<double>("thresh_FGMsmRate_low", 0.05);
+  }
 
-	/* virtual */ void TPRunSummary::beginRun(edm::Run const& r,
-		edm::EventSetup const& es)
-	{
-		DQClient::beginRun(r,es);
-	}
+  /* virtual */ void TPRunSummary::beginRun(edm::Run const& r, edm::EventSetup const& es) { DQClient::beginRun(r, es); }
 
-	/* virtual */ void TPRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
-		DQMStore::IGetter& ig, edm::LuminosityBlock const& lb,
-		edm::EventSetup const& es)
-	{
-		DQClient::endLuminosityBlock(ib, ig, lb, es);
-	}
+  /* virtual */ void TPRunSummary::endLuminosityBlock(DQMStore::IBooker& ib,
+                                                      DQMStore::IGetter& ig,
+                                                      edm::LuminosityBlock const& lb,
+                                                      edm::EventSetup const& es) {
+    DQClient::endLuminosityBlock(ib, ig, lb, es);
+  }
 
-	/* virtual */ std::vector<flag::Flag> TPRunSummary::endJob(
-		DQMStore::IBooker& ib, DQMStore::IGetter& ig)
-	{
-		//	hahs maps
-		electronicsmap::ElectronicsMap ehashmap;
-		ehashmap.initialize(_emap, electronicsmap::fT2EHashMap);
-		std::vector<flag::Flag> vflags; vflags.resize(nTPFlag);
-		vflags[fEtMsm]=flag::Flag("EtMsm");
-		vflags[fFGMsm]=flag::Flag("FGMsm");
+  /* virtual */ std::vector<flag::Flag> TPRunSummary::endJob(DQMStore::IBooker& ib, DQMStore::IGetter& ig) {
+    //	hahs maps
+    electronicsmap::ElectronicsMap ehashmap;
+    ehashmap.initialize(_emap, electronicsmap::fT2EHashMap);
+    std::vector<flag::Flag> vflags;
+    vflags.resize(nTPFlag);
+    vflags[fEtMsm] = flag::Flag("EtMsm");
+    vflags[fFGMsm] = flag::Flag("FGMsm");
 
-		//	INITIALIZE
-		ContainerSingle2D cOccupancyData_depthlike, cOccupancyEmul_depthlike;
-		ContainerSingle2D cEtMsm_depthlike, cFGMsm_depthlike,
-			cEtCorrRatio_depthlike;
-		ContainerSingle2D cSummary;
-		ContainerXXX<double> xDeadD, xDeadE, xEtMsm, xFGMsm;
-		ContainerXXX<double> xNumCorr;
-		xDeadD.initialize(hashfunctions::fCrate);
-		xDeadE.initialize(hashfunctions::fCrate);
-		xEtMsm.initialize(hashfunctions::fCrate);
-		xFGMsm.initialize(hashfunctions::fCrate);
-		xNumCorr.initialize(hashfunctions::fCrate);
-		cOccupancyData_depthlike.initialize(_taskname, "OccupancyData",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fN, true),0);
-		cOccupancyEmul_depthlike.initialize(_taskname, "OccupancyEmul",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fN, true),0);
-		cEtMsm_depthlike.initialize(_taskname, "EtMsm",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cFGMsm_depthlike.initialize(_taskname, "FGMsm",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fN),0);
-		cEtCorrRatio_depthlike.initialize(_taskname, "EtCorrRatio",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fRatio_0to2),0);
-		_cEtMsmFraction_depthlike.initialize(_taskname, "EtMsmFraction",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fRatio_0to2),0);
-		_cFGMsmFraction_depthlike.initialize(_taskname, "FGMsmFraction",
-			new quantity::TrigTowerQuantity(quantity::fTTieta),
-			new quantity::TrigTowerQuantity(quantity::fTTiphi),
-			new quantity::ValueQuantity(quantity::fRatio_0to2),0);
-		cSummary.initialize(_name, "Summary",
-			new quantity::CrateQuantity(_emap),
-			new quantity::FlagQuantity(vflags),
-			new quantity::ValueQuantity(quantity::fState),0);
+    //	INITIALIZE
+    ContainerSingle2D cOccupancyData_depthlike, cOccupancyEmul_depthlike;
+    ContainerSingle2D cEtMsm_depthlike, cFGMsm_depthlike, cEtCorrRatio_depthlike;
+    ContainerSingle2D cSummary;
+    ContainerXXX<double> xDeadD, xDeadE, xEtMsm, xFGMsm;
+    ContainerXXX<double> xNumCorr;
+    xDeadD.initialize(hashfunctions::fCrate);
+    xDeadE.initialize(hashfunctions::fCrate);
+    xEtMsm.initialize(hashfunctions::fCrate);
+    xFGMsm.initialize(hashfunctions::fCrate);
+    xNumCorr.initialize(hashfunctions::fCrate);
+    cOccupancyData_depthlike.initialize(_taskname,
+                                        "OccupancyData",
+                                        new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                        new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                        new quantity::ValueQuantity(quantity::fN, true),
+                                        0);
+    cOccupancyEmul_depthlike.initialize(_taskname,
+                                        "OccupancyEmul",
+                                        new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                        new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                        new quantity::ValueQuantity(quantity::fN, true),
+                                        0);
+    cEtMsm_depthlike.initialize(_taskname,
+                                "EtMsm",
+                                new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                new quantity::ValueQuantity(quantity::fN),
+                                0);
+    cFGMsm_depthlike.initialize(_taskname,
+                                "FGMsm",
+                                new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                new quantity::ValueQuantity(quantity::fN),
+                                0);
+    cEtCorrRatio_depthlike.initialize(_taskname,
+                                      "EtCorrRatio",
+                                      new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                      new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                      new quantity::ValueQuantity(quantity::fRatio_0to2),
+                                      0);
+    _cEtMsmFraction_depthlike.initialize(_taskname,
+                                         "EtMsmFraction",
+                                         new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                         new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                         new quantity::ValueQuantity(quantity::fRatio_0to2),
+                                         0);
+    _cFGMsmFraction_depthlike.initialize(_taskname,
+                                         "FGMsmFraction",
+                                         new quantity::TrigTowerQuantity(quantity::fTTieta),
+                                         new quantity::TrigTowerQuantity(quantity::fTTiphi),
+                                         new quantity::ValueQuantity(quantity::fRatio_0to2),
+                                         0);
+    cSummary.initialize(_name,
+                        "Summary",
+                        new quantity::CrateQuantity(_emap),
+                        new quantity::FlagQuantity(vflags),
+                        new quantity::ValueQuantity(quantity::fState),
+                        0);
 
-		//	BOOK
-		xDeadD.book(_emap); xDeadE.book(_emap); xEtMsm.book(_emap); 
-		xFGMsm.book(_emap); xNumCorr.book(_emap);
+    //	BOOK
+    xDeadD.book(_emap);
+    xDeadE.book(_emap);
+    xEtMsm.book(_emap);
+    xFGMsm.book(_emap);
+    xNumCorr.book(_emap);
 
-		//	LOAD
-		cOccupancyData_depthlike.load(ig, _subsystem);
-		cOccupancyEmul_depthlike.load(ig, _subsystem);
-		cEtMsm_depthlike.load(ig, _subsystem);
-		cFGMsm_depthlike.load(ig, _subsystem);
-		cEtCorrRatio_depthlike.load(ig, _subsystem);
-		_cEtMsmFraction_depthlike.book(ib, _subsystem);
-		_cFGMsmFraction_depthlike.book(ib, _subsystem);
-		cSummary.book(ib, _subsystem);
+    //	LOAD
+    cOccupancyData_depthlike.load(ig, _subsystem);
+    cOccupancyEmul_depthlike.load(ig, _subsystem);
+    cEtMsm_depthlike.load(ig, _subsystem);
+    cFGMsm_depthlike.load(ig, _subsystem);
+    cEtCorrRatio_depthlike.load(ig, _subsystem);
+    _cEtMsmFraction_depthlike.book(ib, _subsystem);
+    _cFGMsmFraction_depthlike.book(ib, _subsystem);
+    cSummary.book(ib, _subsystem);
 
-		//	iterate
-		std::vector<HcalTrigTowerDetId> tids = _emap->allTriggerId();
-		for (std::vector<HcalTrigTowerDetId>::const_iterator it=tids.begin();
-			it!=tids.end(); ++it)
-		{
-			//	skip 2x3
-			HcalTrigTowerDetId tid = HcalTrigTowerDetId(*it);
-			if (tid.version()==0 && tid.ietaAbs()>=29)
-				continue;
+    //	iterate
+    std::vector<HcalTrigTowerDetId> tids = _emap->allTriggerId();
+    for (std::vector<HcalTrigTowerDetId>::const_iterator it = tids.begin(); it != tids.end(); ++it) {
+      //	skip 2x3
+      HcalTrigTowerDetId tid = HcalTrigTowerDetId(*it);
+      if (tid.version() == 0 && tid.ietaAbs() >= 29)
+        continue;
 
-			//	do the comparison if there are channels that were correlated
-			//	both had emul and data tps
-			if (cEtCorrRatio_depthlike.getBinEntries(tid)>0)
-			{
-				HcalElectronicsId eid=HcalElectronicsId(ehashmap.lookup(*it));
+      //	do the comparison if there are channels that were correlated
+      //	both had emul and data tps
+      if (cEtCorrRatio_depthlike.getBinEntries(tid) > 0) {
+        HcalElectronicsId eid = HcalElectronicsId(ehashmap.lookup(*it));
 
-				double numetmsm = cEtMsm_depthlike.getBinContent(tid);
-				double numfgmsm = cFGMsm_depthlike.getBinContent(tid);
-				double numcorr = cEtCorrRatio_depthlike.getBinEntries(tid);
+        double numetmsm = cEtMsm_depthlike.getBinContent(tid);
+        double numfgmsm = cFGMsm_depthlike.getBinContent(tid);
+        double numcorr = cEtCorrRatio_depthlike.getBinEntries(tid);
 
-				xEtMsm.get(eid) += numetmsm;
-				xFGMsm.get(eid) += numfgmsm;
-				xNumCorr.get(eid) += numcorr;
+        xEtMsm.get(eid) += numetmsm;
+        xFGMsm.get(eid) += numfgmsm;
+        xNumCorr.get(eid) += numcorr;
 
-				_cEtMsmFraction_depthlike.setBinContent(tid, 
-					numetmsm/numcorr);
-				_cFGMsmFraction_depthlike.setBinContent(tid, 
-					numfgmsm/numcorr);
-			}
-		}
+        _cEtMsmFraction_depthlike.setBinContent(tid, numetmsm / numcorr);
+        _cFGMsmFraction_depthlike.setBinContent(tid, numfgmsm / numcorr);
+      }
+    }
 
-		std::vector<flag::Flag> sumflags;
-		for (auto& it_hashcrate : _vhashCrates) {
-			flag::Flag fSum("TP");
-			HcalElectronicsId eid(it_hashcrate);
-			HcalDetId did = HcalDetId(_emap->lookup(eid));
+    std::vector<flag::Flag> sumflags;
+    for (auto& it_hashcrate : _vhashCrates) {
+      flag::Flag fSum("TP");
+      HcalElectronicsId eid(it_hashcrate);
+      HcalDetId did = HcalDetId(_emap->lookup(eid));
 
-			if (did.subdet() == HcalBarrel || did.subdet() == HcalEndcap || did.subdet() == HcalForward) {
-				double etmsmfr = xNumCorr.get(eid)>0?
-					double(xEtMsm.get(eid))/double(xNumCorr.get(eid)):0;
-				double fgmsmfr = xNumCorr.get(eid)>0?
-					double(xFGMsm.get(eid))/double(xNumCorr.get(eid)):0;
+      if (did.subdet() == HcalBarrel || did.subdet() == HcalEndcap || did.subdet() == HcalForward) {
+        double etmsmfr = xNumCorr.get(eid) > 0 ? double(xEtMsm.get(eid)) / double(xNumCorr.get(eid)) : 0;
+        double fgmsmfr = xNumCorr.get(eid) > 0 ? double(xFGMsm.get(eid)) / double(xNumCorr.get(eid)) : 0;
 
-				if (etmsmfr>=_thresh_EtMsmRate_high)
-					vflags[fEtMsm]._state = flag::fBAD;
-				else if (etmsmfr>=_thresh_EtMsmRate_low)
-					vflags[fEtMsm]._state = flag::fPROBLEMATIC;
-				else
-					vflags[fEtMsm]._state = flag::fGOOD;
-				if (fgmsmfr>=_thresh_FGMsmRate_high)
-					vflags[fFGMsm]._state = flag::fBAD;
-				else if (fgmsmfr>=_thresh_FGMsmRate_low)
-					vflags[fFGMsm]._state = flag::fPROBLEMATIC;
-				else
-					vflags[fFGMsm]._state = flag::fGOOD;
-			}
+        if (etmsmfr >= _thresh_EtMsmRate_high)
+          vflags[fEtMsm]._state = flag::fBAD;
+        else if (etmsmfr >= _thresh_EtMsmRate_low)
+          vflags[fEtMsm]._state = flag::fPROBLEMATIC;
+        else
+          vflags[fEtMsm]._state = flag::fGOOD;
+        if (fgmsmfr >= _thresh_FGMsmRate_high)
+          vflags[fFGMsm]._state = flag::fBAD;
+        else if (fgmsmfr >= _thresh_FGMsmRate_low)
+          vflags[fFGMsm]._state = flag::fPROBLEMATIC;
+        else
+          vflags[fFGMsm]._state = flag::fGOOD;
+      }
 
-			//	combine
-			int iflag=0;
-			for (std::vector<flag::Flag>::iterator ft=vflags.begin();
-				ft!=vflags.end(); ++ft)
-			{
-				cSummary.setBinContent(eid, iflag, ft->_state);
-				fSum+=(*ft);
-				iflag++;
-				ft->reset();
-			}
-			sumflags.push_back(fSum);
-		}
+      //	combine
+      int iflag = 0;
+      for (std::vector<flag::Flag>::iterator ft = vflags.begin(); ft != vflags.end(); ++ft) {
+        cSummary.setBinContent(eid, iflag, ft->_state);
+        fSum += (*ft);
+        iflag++;
+        ft->reset();
+      }
+      sumflags.push_back(fSum);
+    }
 
-		return sumflags;
-	}
-}
+    return sumflags;
+  }
+}  // namespace hcaldqm

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -28,7 +28,7 @@ useMap       = False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1'
+	process.GlobalTag.globaltag = '106X_dataRun2_PromptLike_Candidate_2019_05_04_08_47_47'
 	#process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')


### PR DESCRIPTION
Backport of #27149 

PR description:
This PR implements Run 3 HB in HCAL DQM. The old HBHEDigiCollection is removed, and the new HB digis are taken from QIE11DigiCollection. Since HB now overlaps with HO in (ieta, iphi, depth) space, HO digis are plotted in depth 7 for now. A future PR will improve on that hack, moving HO (and perhaps all subsystems) to their own ieta-iphi plots, rather than attempting to plot all subsystems together.

PR validation:
Successfully ran over recent local and global runs with partial HB installation. Note that running in online DQM will require appropriate conditions, which are being developed in parallel.
runTheMatrix was successful, particularly the one that failed in the last PR (136.731).

