### PR TITLE
Further non-physics refactoring of PFAlgo::processBlock

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -144,6 +144,8 @@ class PFAlgo {
   void conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active);
   void elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
   int decideType(const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockElement::Type type, std::vector<bool>& active, ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle);
+  bool recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockRef &blockref, std::vector<bool>& active, bool goodTrackDeadHcal, bool hasDeadHcal, unsigned int iTrack, std::multimap<double, unsigned>& ecalElems, reco::TrackRef& trackRef);
+
 
   //Looks for a HF-associated element in the block and produces a PFCandidate from it with HF_EM and/or HF_HAD calibrations
   void createCandidateHF(const reco::PFBlock &block, const reco::PFBlockRef &blockref, const edm::OwnVector<reco::PFBlockElement> &elements, ElementIndices& inds);

--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -140,14 +140,21 @@ class PFAlgo {
   
  private:
 
-  /// process one block. can be reimplemented in more sophisticated 
-  /// algorithms
-  
   void egammaFilters(const reco::PFBlockRef &blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma);
   void conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active);
   void elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
   int decideType(const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockElement::Type type, std::vector<bool>& active, ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle);
 
+  //Looks for a HF-associated element in the block and produces a PFCandidate from it with HF_EM and/or HF_HAD calibrations
+  void createCandidateHF(const reco::PFBlock &block, const reco::PFBlockRef &blockref, const edm::OwnVector<reco::PFBlockElement> &elements, ElementIndices& inds);
+
+  void createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
+  void createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
+
+void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
+
+  /// process one block. can be reimplemented in more sophisticated 
+  /// algorithms
   void processBlock( const reco::PFBlockRef& blockref,
                              std::list<reco::PFBlockRef>& hcalBlockRefs, 
                              std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma );

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -470,7 +470,6 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
 
   // If it is not a muon check if Is it a fake track ?
   //Michalis: I wonder if we should convert this to dpt/pt?
-  bool rejectFake = false;
   if ( !thisIsAMuon  && elements[iTrack].trackRef()->ptError() > ptError_ ) {
 
     double deficit = trackMomentum;
@@ -501,7 +500,6 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
     bool isPrimary = isFromSecInt(elements[iTrack], "primary");
 
     if ( deficit > nSigmaTRACK_*resol && !isPrimary && !goodTrackDeadHcal) {
-      rejectFake = true;
       active[iTrack] = false;
       if ( debug_ )
         std::cout << elements[iTrack] << std::endl
@@ -517,10 +515,9 @@ bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkDa
                    << " |dz| " << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
     	      << "is probably a fake (1) --> lock the track"
     	      << std::endl;
+    return true;
     }
   } // !thisIsaMuon
-
-  if ( rejectFake ) { return true; };
 
   // Create a track candidate
   // unsigned tmpi = reconstructTrack( elements[iTrack] );

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -447,471 +447,475 @@ void PFAlgo::conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements
 }
 
 
-  bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockRef &blockref, std::vector<bool>& active, bool goodTrackDeadHcal, bool hasDeadHcal, unsigned int iTrack, std::multimap<double, unsigned>& ecalElems, reco::TrackRef& trackRef) {
-      if ( debug_ )
-	std::cout << "Now deals with tracks linked to no HCAL clusters. Was HCal active? " << (!hasDeadHcal) << std::endl;
-      // vector<unsigned> elementIndices;
-      // elementIndices.push_back(iTrack);
+bool PFAlgo::recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData,
+  const edm::OwnVector<reco::PFBlockElement> &elements,
+  const reco::PFBlockRef &blockref, std::vector<bool>& active,
+  bool goodTrackDeadHcal, bool hasDeadHcal, unsigned int iTrack,
+  std::multimap<double, unsigned>& ecalElems, reco::TrackRef& trackRef) {
+  if ( debug_ )
+    std::cout << "Now deals with tracks linked to no HCAL clusters. Was HCal active? " << (!hasDeadHcal) << std::endl;
+  // vector<unsigned> elementIndices;
+  // elementIndices.push_back(iTrack);
 
-      // The track momentum
-      double trackMomentum = elements[iTrack].trackRef()->p();
-      if ( debug_ )
-	std::cout << elements[iTrack] << std::endl;
+  // The track momentum
+  double trackMomentum = elements[iTrack].trackRef()->p();
+  if ( debug_ )
+    std::cout << elements[iTrack] << std::endl;
 
-      // Is it a "tight" muon ? In that case assume no
-      //Track momentum corresponds to the calorimeter
-      //energy for now
-      bool thisIsAMuon = PFMuonAlgo::isMuon(elements[iTrack]);
-      if ( thisIsAMuon ) trackMomentum = 0.;
+  // Is it a "tight" muon ? In that case assume no
+  //Track momentum corresponds to the calorimeter
+  //energy for now
+  bool thisIsAMuon = PFMuonAlgo::isMuon(elements[iTrack]);
+  if ( thisIsAMuon ) trackMomentum = 0.;
 
-      // If it is not a muon check if Is it a fake track ?
-      //Michalis: I wonder if we should convert this to dpt/pt?
-      bool rejectFake = false;
-      if ( !thisIsAMuon  && elements[iTrack].trackRef()->ptError() > ptError_ ) {
+  // If it is not a muon check if Is it a fake track ?
+  //Michalis: I wonder if we should convert this to dpt/pt?
+  bool rejectFake = false;
+  if ( !thisIsAMuon  && elements[iTrack].trackRef()->ptError() > ptError_ ) {
 
-	double deficit = trackMomentum;
-	double resol = neutralHadronEnergyResolution(trackMomentum,
-						     elements[iTrack].trackRef()->eta());
-	resol *= trackMomentum;
+    double deficit = trackMomentum;
+    double resol = neutralHadronEnergyResolution(trackMomentum,
+    					     elements[iTrack].trackRef()->eta());
+    resol *= trackMomentum;
 
-	if ( !ecalElems.empty() ) {
-	  unsigned thisEcal = ecalElems.begin()->second;
-	  reco::PFClusterRef clusterRef = elements[thisEcal].clusterRef();
-	  bool useCluster = true;
-	  if (hasDeadHcal) {
-	    std::multimap<double, unsigned> sortedTracks;
-	    block.associatedElements( thisEcal,  linkData,
-				sortedTracks,
-				reco::PFBlockElement::TRACK,
-				reco::PFBlock::LINKTEST_ALL );
-	    useCluster = (sortedTracks.begin()->second == iTrack);
-	  }
-	  if (useCluster) {
-	    deficit -= clusterRef->energy();
-	    resol = neutralHadronEnergyResolution(trackMomentum,
-	                                          clusterRef->positionREP().Eta());
-	    resol *= trackMomentum;
-	  }
-	}
-
-	bool isPrimary = isFromSecInt(elements[iTrack], "primary");
-
-	if ( deficit > nSigmaTRACK_*resol && !isPrimary && !goodTrackDeadHcal) {
-	  rejectFake = true;
-	  active[iTrack] = false;
-	  if ( debug_ )
-	    std::cout << elements[iTrack] << std::endl
-		       << " deficit " << deficit << " > " << nSigmaTRACK_ << " x " << resol
-		       << " track pt " << trackRef->pt() << " +- " << trackRef->ptError()
-		       << " layers valid " << trackRef->hitPattern().trackerLayersWithMeasurement()
-		             << ", lost " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS)
-		             << ", lost outer " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS)
-		             << ", lost inner " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS)
-		             << "(valid fraction " << trackRef->validFraction() <<")"
-		       << " chi2/ndf " << trackRef->normalizedChi2()
-		       << " |dxy| " << std::abs(trackRef->dxy(primaryVertex_.position())) << " +- " << trackRef->dxyError()
-                       << " |dz| " << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
-		      << "is probably a fake (1) --> lock the track"
-		      << std::endl;
-	}
-      }
-
-      if ( rejectFake ) { return true; };
-
-      // Create a track candidate
-      // unsigned tmpi = reconstructTrack( elements[iTrack] );
-      //active[iTrack] = false;
-      std::vector<unsigned> tmpi;
-      std::vector<unsigned> kTrack;
-
-      // Some cleaning : secondary tracks without calo's and large momentum must be fake
-      double Dpt = trackRef->ptError();
-
-      if ( rejectTracks_Step45_ && ecalElems.empty() &&
-	   trackMomentum > 30. && Dpt > 0.5 &&
-	   ( PFTrackAlgoTools::step45(trackRef->algo())
-	    && !goodTrackDeadHcal) ) {
-
-	double dptRel = Dpt/trackRef->pt()*100;
-	bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
-
-	if ( isPrimaryOrSecondary && dptRel < dptRel_DispVtx_) { return true; };
-	unsigned nHits =  elements[iTrack].trackRef()->hitPattern().trackerLayersWithMeasurement();
-	unsigned int NLostHit = trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS);
-
-	if ( debug_ )
-	  std::cout << "A track (algo = " << trackRef->algo() << ") with momentum " << trackMomentum
-		    << " / " << elements[iTrack].trackRef()->pt() << " +/- " << Dpt
-		    << " / " << elements[iTrack].trackRef()->eta()
-		    << " without any link to ECAL/HCAL and with " << nHits << " (" << NLostHit
-		    << ") hits (lost hits) has been cleaned" << std::endl;
-	active[iTrack] = false;
-	return true;
-      }
-
-
-      tmpi.push_back(reconstructTrack( elements[iTrack]));
-
-      kTrack.push_back(iTrack);
-      active[iTrack] = false;
-
-      // No ECAL cluster either ... continue...
-      if ( ecalElems.empty() ) {
-	(*pfCandidates_)[tmpi[0]].setEcalEnergy( 0., 0. );
-	(*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
-	(*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
-	(*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
-	(*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
-	(*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
-	return true;
-      }
-
-      // Look for closest ECAL cluster
-      const unsigned int thisEcal = ecalElems.begin()->second;
+    if ( !ecalElems.empty() ) {
+      unsigned thisEcal = ecalElems.begin()->second;
       reco::PFClusterRef clusterRef = elements[thisEcal].clusterRef();
-      if ( debug_ ) std::cout << " is associated to " << elements[thisEcal] << std::endl;
-
-
-      // Set ECAL energy for muons
-      if ( thisIsAMuon ) {
-	(*pfCandidates_)[tmpi[0]].setEcalEnergy( clusterRef->energy(),
-						 std::min(clusterRef->energy(), muonECAL_[0]) );
-	(*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
-	(*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
-	(*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
-	(*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
-	(*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
+      bool useCluster = true;
+      if (hasDeadHcal) {
+        std::multimap<double, unsigned> sortedTracks;
+        block.associatedElements( thisEcal,  linkData,
+    			sortedTracks,
+    			reco::PFBlockElement::TRACK,
+    			reco::PFBlock::LINKTEST_ALL );
+        useCluster = (sortedTracks.begin()->second == iTrack);
       }
-
-      double slopeEcal = 1.;
-      bool connectedToEcal = false;
-      unsigned iEcal = 99999;
-      double calibEcal = 0.;
-      double calibHcal = 0.;
-      double totalEcal = thisIsAMuon ? -muonECAL_[0] : 0.;
-
-      // Consider charged particles closest to the same ECAL cluster
-      std::multimap<double, unsigned> sortedTracks;
-      block.associatedElements( thisEcal,  linkData,
-				sortedTracks,
-				reco::PFBlockElement::TRACK,
-				reco::PFBlock::LINKTEST_ALL );
-      if (debug_) cout << "the closest ECAL cluster, id " << thisEcal << ", has " << sortedTracks.size() << " associated tracks, now processing them. " << endl;
-
-      if (hasDeadHcal && !sortedTracks.empty()) {
-          // GP: only allow the ecal cluster closest to this track to be considered
-          if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " (distance " << sortedTracks.begin()->first << ")" << endl;
-          if (sortedTracks.begin()->second != iTrack) {
-            if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " which is not the one being processed. Will skip ECAL linking for this track" << endl;
-            (*pfCandidates_)[tmpi[0]].setEcalEnergy( 0., 0. );
-            (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
-            (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
-            (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
-            (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
-            (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
-            return true;
-          } else {
-            if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " which is the one being processed. Will skip ECAL linking for all other track" << endl;
-            sortedTracks.clear();
-          }
+      if (useCluster) {
+        deficit -= clusterRef->energy();
+        resol = neutralHadronEnergyResolution(trackMomentum,
+                                              clusterRef->positionREP().Eta());
+        resol *= trackMomentum;
       }
+    }
 
-      for(auto const& trk : sortedTracks) {
-	unsigned jTrack = trk.second;
+    bool isPrimary = isFromSecInt(elements[iTrack], "primary");
 
-	// Don't consider already used tracks
-	if ( !active[jTrack] ) continue;
+    if ( deficit > nSigmaTRACK_*resol && !isPrimary && !goodTrackDeadHcal) {
+      rejectFake = true;
+      active[iTrack] = false;
+      if ( debug_ )
+        std::cout << elements[iTrack] << std::endl
+    	       << " deficit " << deficit << " > " << nSigmaTRACK_ << " x " << resol
+    	       << " track pt " << trackRef->pt() << " +- " << trackRef->ptError()
+    	       << " layers valid " << trackRef->hitPattern().trackerLayersWithMeasurement()
+    	             << ", lost " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS)
+    	             << ", lost outer " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_OUTER_HITS)
+    	             << ", lost inner " << trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::MISSING_INNER_HITS)
+    	             << "(valid fraction " << trackRef->validFraction() <<")"
+    	       << " chi2/ndf " << trackRef->normalizedChi2()
+    	       << " |dxy| " << std::abs(trackRef->dxy(primaryVertex_.position())) << " +- " << trackRef->dxyError()
+                   << " |dz| " << std::abs(trackRef->dz(primaryVertex_.position())) << " +- " << trackRef->dzError()
+    	      << "is probably a fake (1) --> lock the track"
+    	      << std::endl;
+    }
+  } // !thisIsaMuon
 
-	// The loop is on the other tracks !
-	if ( jTrack == iTrack ) continue;
+  if ( rejectFake ) { return true; };
 
-	// Check if the ECAL cluster closest to this track is
-	// indeed the current ECAL cluster. Only tracks not
-	// linked to an HCAL cluster are considered here
-	// (GP: this is because if there's a jTrack linked
-	// to the same Ecal cluster and that also has an Hcal link
-	// we would have also linked iTrack to that Hcal above)
-	std::multimap<double, unsigned> sortedECAL;
-	block.associatedElements( jTrack,  linkData,
-				  sortedECAL,
-				  reco::PFBlockElement::ECAL,
-				  reco::PFBlock::LINKTEST_ALL );
-	if ( sortedECAL.begin()->second != thisEcal ) continue;
+  // Create a track candidate
+  // unsigned tmpi = reconstructTrack( elements[iTrack] );
+  //active[iTrack] = false;
+  std::vector<unsigned> tmpi;
+  std::vector<unsigned> kTrack;
 
-	// Check if this track is a muon
-	bool thatIsAMuon = PFMuonAlgo::isMuon(elements[jTrack]);
-        if (debug_) {
-            cout << " found track " << jTrack << (thatIsAMuon ? " (muon) " : " (non-muon)") << ", with distance = " << sortedECAL.begin()->first << std::endl;
-        }
+  // Some cleaning : secondary tracks without calo's and large momentum must be fake
+  double Dpt = trackRef->ptError();
 
+  if ( rejectTracks_Step45_ && ecalElems.empty() &&
+       trackMomentum > 30. && Dpt > 0.5 &&
+       ( PFTrackAlgoTools::step45(trackRef->algo())
+        && !goodTrackDeadHcal) ) {
 
-	// Check if this track is not a fake
-	bool rejectFake = false;
-	reco::TrackRef trackRef = elements[jTrack].trackRef();
-	if ( !thatIsAMuon && trackRef->ptError() > ptError_) {
-	  // GP: FIXME this selection should be adapted depending on hasDeadHcal
-	  //     but we don't know if jTrack is linked to a dead Hcal or not
-	  double deficit = trackMomentum + trackRef->p() - clusterRef->energy();
-	  double resol = nSigmaTRACK_*neutralHadronEnergyResolution(trackMomentum+trackRef->p(),
-								    clusterRef->positionREP().Eta());
-	  resol *= (trackMomentum+trackRef->p());
-	  if ( deficit > nSigmaTRACK_*resol  && !goodTrackDeadHcal) {
- 	    rejectFake = true;
-	    kTrack.push_back(jTrack);
-	    active[jTrack] = false;
-	    if ( debug_ )
-	      std::cout << elements[jTrack] << std::endl
-			<< "is probably a fake (2) --> lock the track"
-			<< "(trackMomentum = " << trackMomentum << ", clusterEnergy = " << clusterRef->energy() <<
-			        ", deficit = " << deficit << " > " << nSigmaTRACK_ << " x " << resol <<
-			        " assuming neutralHadronEnergyResolution " << neutralHadronEnergyResolution(trackMomentum+trackRef->p(), clusterRef->positionREP().Eta()) << ") "
-			<< std::endl;
-	  }
-	}
-	if ( rejectFake ) continue;
+    double dptRel = Dpt/trackRef->pt()*100;
+    bool isPrimaryOrSecondary = isFromSecInt(elements[iTrack], "all");
 
+    if ( isPrimaryOrSecondary && dptRel < dptRel_DispVtx_) { return true; };
+    unsigned nHits =  elements[iTrack].trackRef()->hitPattern().trackerLayersWithMeasurement();
+    unsigned int NLostHit = trackRef->hitPattern().trackerLayersWithoutMeasurement(HitPattern::TRACK_HITS);
 
-	// Otherwise, add this track momentum to the total track momentum
-	/* */
-	// reco::TrackRef trackRef = elements[jTrack].trackRef();
-	if ( !thatIsAMuon ) {
-	  if ( debug_ )
-	    std::cout << "Track momentum increased from " << trackMomentum << " GeV ";
-	  trackMomentum += trackRef->p();
-	  if ( debug_ ) {
-	    std::cout << "to " << trackMomentum << " GeV." << std::endl;
-	    std::cout << "with " << elements[jTrack] << std::endl;
-	  }
-	} else {
-	  totalEcal -= muonECAL_[0];
-	  totalEcal = std::max(totalEcal, 0.);
-	}
-
-	// And create a charged particle candidate !
-
-	tmpi.push_back(reconstructTrack( elements[jTrack] ));
+    if ( debug_ )
+      std::cout << "A track (algo = " << trackRef->algo() << ") with momentum " << trackMomentum
+    	    << " / " << elements[iTrack].trackRef()->pt() << " +/- " << Dpt
+    	    << " / " << elements[iTrack].trackRef()->eta()
+    	    << " without any link to ECAL/HCAL and with " << nHits << " (" << NLostHit
+    	    << ") hits (lost hits) has been cleaned" << std::endl;
+    active[iTrack] = false;
+    return true;
+  }
 
 
-	kTrack.push_back(jTrack);
-	active[jTrack] = false;
+  tmpi.push_back(reconstructTrack( elements[iTrack]));
 
-	if ( thatIsAMuon ) {
-	  (*pfCandidates_)[tmpi.back()].setEcalEnergy(clusterRef->energy(),
-						      std::min(clusterRef->energy(),muonECAL_[0]));
-	  (*pfCandidates_)[tmpi.back()].setHcalEnergy( 0., 0. );
-	  (*pfCandidates_)[tmpi.back()].setHoEnergy( 0., 0. );
-	  (*pfCandidates_)[tmpi.back()].setPs1Energy( 0 );
-	  (*pfCandidates_)[tmpi.back()].setPs2Energy( 0 );
-	  (*pfCandidates_)[tmpi.back()].addElementInBlock( blockref, kTrack.back() );
-	}
+  kTrack.push_back(iTrack);
+  active[iTrack] = false;
+
+  // No ECAL cluster either ... continue...
+  if ( ecalElems.empty() ) {
+    (*pfCandidates_)[tmpi[0]].setEcalEnergy( 0., 0. );
+    (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
+    (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
+    (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
+    (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
+    (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
+    return true;
+  }
+
+  // Look for closest ECAL cluster
+  const unsigned int thisEcal = ecalElems.begin()->second;
+  reco::PFClusterRef clusterRef = elements[thisEcal].clusterRef();
+  if ( debug_ ) std::cout << " is associated to " << elements[thisEcal] << std::endl;
+
+
+  // Set ECAL energy for muons
+  if ( thisIsAMuon ) {
+    (*pfCandidates_)[tmpi[0]].setEcalEnergy( clusterRef->energy(),
+    					 std::min(clusterRef->energy(), muonECAL_[0]) );
+    (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
+    (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
+    (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
+    (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
+    (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
+  }
+
+  double slopeEcal = 1.;
+  bool connectedToEcal = false;
+  unsigned iEcal = 99999;
+  double calibEcal = 0.;
+  double calibHcal = 0.;
+  double totalEcal = thisIsAMuon ? -muonECAL_[0] : 0.;
+
+  // Consider charged particles closest to the same ECAL cluster
+  std::multimap<double, unsigned> sortedTracks;
+  block.associatedElements( thisEcal,  linkData,
+    			sortedTracks,
+    			reco::PFBlockElement::TRACK,
+    			reco::PFBlock::LINKTEST_ALL );
+  if (debug_) cout << "the closest ECAL cluster, id " << thisEcal << ", has " << sortedTracks.size() << " associated tracks, now processing them. " << endl;
+
+  if (hasDeadHcal && !sortedTracks.empty()) {
+      // GP: only allow the ecal cluster closest to this track to be considered
+      if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " (distance " << sortedTracks.begin()->first << ")" << endl;
+      if (sortedTracks.begin()->second != iTrack) {
+        if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " which is not the one being processed. Will skip ECAL linking for this track" << endl;
+        (*pfCandidates_)[tmpi[0]].setEcalEnergy( 0., 0. );
+        (*pfCandidates_)[tmpi[0]].setHcalEnergy( 0., 0. );
+        (*pfCandidates_)[tmpi[0]].setHoEnergy( 0., 0. );
+        (*pfCandidates_)[tmpi[0]].setPs1Energy( 0 );
+        (*pfCandidates_)[tmpi[0]].setPs2Energy( 0 );
+        (*pfCandidates_)[tmpi[0]].addElementInBlock( blockref, kTrack[0] );
+        return true;
+      } else {
+        if (debug_) cout << " the closest track to ECAL " << thisEcal << " is " << sortedTracks.begin()->second << " which is the one being processed. Will skip ECAL linking for all other track" << endl;
+        sortedTracks.clear();
       }
+  }
+
+  for(auto const& trk : sortedTracks) {
+    unsigned jTrack = trk.second;
+
+    // Don't consider already used tracks
+    if ( !active[jTrack] ) continue;
+
+    // The loop is on the other tracks !
+    if ( jTrack == iTrack ) continue;
+
+    // Check if the ECAL cluster closest to this track is
+    // indeed the current ECAL cluster. Only tracks not
+    // linked to an HCAL cluster are considered here
+    // (GP: this is because if there's a jTrack linked
+    // to the same Ecal cluster and that also has an Hcal link
+    // we would have also linked iTrack to that Hcal above)
+    std::multimap<double, unsigned> sortedECAL;
+    block.associatedElements( jTrack,  linkData,
+    			  sortedECAL,
+    			  reco::PFBlockElement::ECAL,
+    			  reco::PFBlock::LINKTEST_ALL );
+    if ( sortedECAL.begin()->second != thisEcal ) continue;
+
+    // Check if this track is a muon
+    bool thatIsAMuon = PFMuonAlgo::isMuon(elements[jTrack]);
+    if (debug_) {
+        cout << " found track " << jTrack << (thatIsAMuon ? " (muon) " : " (non-muon)") << ", with distance = " << sortedECAL.begin()->first << std::endl;
+    }
 
 
-      if ( debug_ ) std::cout << "Loop over all associated ECAL clusters" << std::endl;
-      // Loop over all ECAL linked clusters ordered by increasing distance.
-      for(auto const& ecal : ecalElems)
-      {
-        const unsigned index = ecal.second;
-        const PFBlockElement::Type type = elements[index].type();
-        assert( type == PFBlockElement::ECAL );
-        if ( debug_ ) std::cout << elements[index] << std::endl;
-
-        // Just skip clusters already taken
-        if ( debug_ && ! active[index] ) std::cout << "is not active  - ignore " << std::endl;
-        if ( ! active[index] ) continue;
-
-        // Just skip this cluster if it's closer to another track
-        block.associatedElements( index,  linkData, sortedTracks,
-                                  reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL );
-
-        const bool skip = std::none_of(kTrack.begin(), kTrack.end(), [&](unsigned iTrack){
-                    return sortedTracks.begin()->second == iTrack;
-                });
-
-        if ( debug_ && skip ) std::cout << "is closer to another track - ignore " << std::endl;
-        if ( skip ) continue;
-
-        // The corresponding PFCluster and energy
-        const reco::PFClusterRef clusterRef = elements[index].clusterRef();
-        assert( !clusterRef.isNull() );
-
-        if ( debug_ ) {
-          std::cout <<"Ecal cluster with raw energy = " << clusterRef->energy()
-                <<" linked with distance = " << ecal.first << std::endl;
-        }
-        //double dist = ie->first;
-        //if ( !connectedToEcal && dist > 0.1 ) {
-          //std::cout << "Warning - first ECAL cluster at a distance of " << dist << "from the closest track!" << std::endl;
-          //cout<<"\telement "<<elements[index]<<" linked with distance = "<< dist <<endl;
-          //cout<<"\telement "<<elements[iTrack]<<" linked with distance = "<< dist <<endl;
-        //}
-
-        // Check the presence of preshower clusters in the vicinity
-        // Preshower cluster closer to another ECAL cluster are ignored.
-        //JOSH: This should use the association map already produced by the cluster corrector for consistency,
-        //but should be ok for now
-        vector<double> ps1Ene{0.};
-        associatePSClusters(index, reco::PFBlockElement::PS1, block, elements, linkData, active, ps1Ene);
-        vector<double> ps2Ene{0.};
-        associatePSClusters(index, reco::PFBlockElement::PS2, block, elements, linkData, active, ps2Ene);
-
-	// KH: use raw ECAL energy for PF hadron calibration. use calibrated ECAL energy when adding PF photons
-	const double ecalEnergy = clusterRef->energy();
-	const double ecalEnergyCalibrated = clusterRef->correctedEnergy(); // calibrated based on the egamma hypothesis
-        if ( debug_ ) std::cout << "Corrected ECAL(+PS) energy = " << ecalEnergy << std::endl;
-
-        // Since the electrons were found beforehand, this track must be a hadron. Calibrate
-        // the energy under the hadron hypothesis.
-        totalEcal += ecalEnergy;
-        const double previousCalibEcal = calibEcal;
-        const double previousSlopeEcal = slopeEcal;
-        calibEcal = std::max(totalEcal,0.);
-        calibHcal = 0.;
-        calibration_->energyEmHad( trackMomentum,calibEcal,calibHcal,
-                                   clusterRef->positionREP().Eta(),
-                                   clusterRef->positionREP().Phi() );
-        if ( totalEcal > 0.) slopeEcal = calibEcal/totalEcal;
-
+    // Check if this track is not a fake
+    bool rejectFake = false;
+    reco::TrackRef trackRef = elements[jTrack].trackRef();
+    if ( !thatIsAMuon && trackRef->ptError() > ptError_) {
+      // GP: FIXME this selection should be adapted depending on hasDeadHcal
+      //     but we don't know if jTrack is linked to a dead Hcal or not
+      double deficit = trackMomentum + trackRef->p() - clusterRef->energy();
+      double resol = nSigmaTRACK_*neutralHadronEnergyResolution(trackMomentum+trackRef->p(),
+    							    clusterRef->positionREP().Eta());
+      resol *= (trackMomentum+trackRef->p());
+      if ( deficit > nSigmaTRACK_*resol  && !goodTrackDeadHcal) {
+        rejectFake = true;
+        kTrack.push_back(jTrack);
+        active[jTrack] = false;
         if ( debug_ )
-          std::cout << "The total calibrated energy so far amounts to = " << calibEcal << " (slope = " << slopeEcal << ")" << std::endl;
-
-
-        // Stop the loop when adding more ECAL clusters ruins the compatibility
-        if ( connectedToEcal && calibEcal - trackMomentum >= 0. ) {
-        // if ( connectedToEcal && calibEcal - trackMomentum >=
-        //     nSigmaECAL_*neutralHadronEnergyResolution(trackMomentum,clusterRef->positionREP().Eta())  ) {
-          calibEcal = previousCalibEcal;
-          slopeEcal = previousSlopeEcal;
-          totalEcal = calibEcal/slopeEcal;
-
-          // Turn this last cluster in a photon
-          // (The PS clusters are already locked in "associatePSClusters")
-          active[index] = false;
-
-          // Find the associated tracks
-          std::multimap<double, unsigned> assTracks;
-          block.associatedElements( index,  linkData,
-                                    assTracks,
-                                    reco::PFBlockElement::TRACK,
-                                    reco::PFBlock::LINKTEST_ALL );
-
-          auto& ecalCand = (*pfCandidates_)[reconstructCluster( *clusterRef, ecalEnergyCalibrated )]; // KH: use the PF ECAL cluster calibrated energy
-          ecalCand.setEcalEnergy( clusterRef->energy(), ecalEnergyCalibrated );
-          ecalCand.setHcalEnergy( 0., 0. );
-          ecalCand.setHoEnergy( 0., 0. );
-          ecalCand.setPs1Energy( ps1Ene[0] );
-          ecalCand.setPs2Energy( ps2Ene[0] );
-          ecalCand.addElementInBlock( blockref, index );
-          // Check that there is at least one track
-          if(!assTracks.empty()) {
-            ecalCand.addElementInBlock( blockref, assTracks.begin()->second );
-
-            // Assign the position of the track at the ECAL entrance
-            const ::math::XYZPointF& chargedPosition =
-              dynamic_cast<const reco::PFBlockElementTrack*>(&elements[assTracks.begin()->second])->positionAtECALEntrance();
-            ecalCand.setPositionAtECALEntrance(chargedPosition);
-          }
-          break;
-        }
-
-        // Lock used clusters.
-        connectedToEcal = true;
-        iEcal = index;
-        active[index] = false;
-        for (unsigned ic : tmpi) (*pfCandidates_)[ic].addElementInBlock( blockref, iEcal );
-
-      } // Loop ecal elements
-
-      bool bNeutralProduced = false;
-
-      // Create a photon if the ecal energy is too large
-      if( connectedToEcal ) {
-	reco::PFClusterRef pivotalRef = elements[iEcal].clusterRef();
-
-	double neutralEnergy = calibEcal - trackMomentum;
-
-	/*
-	// Check if there are other tracks linked to that ECAL
-	for(IE ie = sortedTracks.begin(); ie != sortedTracks.end() && neutralEnergy > 0; ++ie ) {
-	  unsigned jTrack = ie->second;
-
-	  // The loop is on the other tracks !
-	  if ( jTrack == iTrack ) continue;
-
-	  // Check if the ECAL closest to this track is the current ECAL
-	  // Otherwise ignore this track in the neutral energy determination
-	  std::multimap<double, unsigned> sortedECAL;
-	  block.associatedElements( jTrack,  linkData,
-				    sortedECAL,
-				    reco::PFBlockElement::ECAL,
-				    reco::PFBlock::LINKTEST_ALL );
-	  if ( sortedECAL.begin()->second != iEcal ) continue;
-
-	  // Check if this track is also linked to an HCAL
-	  // (in which case it goes to the next loop and is ignored here)
-	  std::multimap<double, unsigned> sortedHCAL;
-	  block.associatedElements( jTrack,  linkData,
-				    sortedHCAL,
-				    reco::PFBlockElement::HCAL,
-				    reco::PFBlock::LINKTEST_ALL );
-	  if ( sortedHCAL.size() ) continue;
-
-	  // Otherwise, subtract this track momentum from the ECAL energy
-	  reco::TrackRef trackRef = elements[jTrack].trackRef();
-	  neutralEnergy -= trackRef->p();
-
-	} // End other tracks
-	*/
-
-	// Add a photon is the energy excess is large enough
-	double resol = neutralHadronEnergyResolution(trackMomentum,pivotalRef->positionREP().Eta());
-	resol *= trackMomentum;
-	if ( neutralEnergy > std::max(0.5,nSigmaECAL_*resol) ) {
-	  neutralEnergy /= slopeEcal;
-	  unsigned tmpj = reconstructCluster( *pivotalRef, neutralEnergy );
-	  (*pfCandidates_)[tmpj].setEcalEnergy( pivotalRef->energy(), neutralEnergy );
-	  (*pfCandidates_)[tmpj].setHcalEnergy( 0., 0. );
-	  (*pfCandidates_)[tmpj].setHoEnergy( 0., 0. );
-	  (*pfCandidates_)[tmpj].setPs1Energy( 0. );
-	  (*pfCandidates_)[tmpj].setPs2Energy( 0. );
-	  (*pfCandidates_)[tmpj].addElementInBlock(blockref, iEcal);
-	  bNeutralProduced = true;
-	  for (unsigned ic=0; ic<kTrack.size();++ic)
-	    (*pfCandidates_)[tmpj].addElementInBlock( blockref, kTrack[ic] );
-	} // End neutral energy
-
-	// Set elements in blocks and ECAL energies to all tracks
-      	for (unsigned ic=0; ic<tmpi.size();++ic) {
-
-	  // Skip muons
-	  if ( (*pfCandidates_)[tmpi[ic]].particleId() == reco::PFCandidate::mu ) continue;
-
-	  double fraction = trackMomentum > 0 ? (*pfCandidates_)[tmpi[ic]].trackRef()->p()/trackMomentum : 0;
-	  double ecalCal = bNeutralProduced ?
-	    (calibEcal-neutralEnergy*slopeEcal)*fraction : calibEcal*fraction;
-	  double ecalRaw = totalEcal*fraction;
-
-	  if (debug_) cout << "The fraction after photon supression is " << fraction << " calibrated ecal = " << ecalCal << endl;
-
-	  (*pfCandidates_)[tmpi[ic]].setEcalEnergy( ecalRaw, ecalCal );
-	  (*pfCandidates_)[tmpi[ic]].setHcalEnergy( 0., 0. );
-	  (*pfCandidates_)[tmpi[ic]].setHoEnergy( 0., 0. );
-	  (*pfCandidates_)[tmpi[ic]].setPs1Energy( 0 );
-	  (*pfCandidates_)[tmpi[ic]].setPs2Energy( 0 );
-	  (*pfCandidates_)[tmpi[ic]].addElementInBlock( blockref, kTrack[ic] );
-	}
-
-      } // End connected ECAL
-
-      // Fill the element_in_block for tracks that are eventually linked to no ECAL clusters at all.
-      for (unsigned ic=0; ic<tmpi.size();++ic) {
-	const PFCandidate& pfc = (*pfCandidates_)[tmpi[ic]];
-	const PFCandidate::ElementsInBlocks& eleInBlocks = pfc.elementsInBlocks();
-	if ( eleInBlocks.empty() ) {
-	  if ( debug_ )std::cout << "Single track / Fill element in block! " << std::endl;
-	  (*pfCandidates_)[tmpi[ic]].addElementInBlock( blockref, kTrack[ic] );
-	}
+          std::cout << elements[jTrack] << std::endl
+    		<< "is probably a fake (2) --> lock the track"
+    		<< "(trackMomentum = " << trackMomentum << ", clusterEnergy = " << clusterRef->energy() <<
+    		        ", deficit = " << deficit << " > " << nSigmaTRACK_ << " x " << resol <<
+    		        " assuming neutralHadronEnergyResolution " << neutralHadronEnergyResolution(trackMomentum+trackRef->p(), clusterRef->positionREP().Eta()) << ") "
+    		<< std::endl;
       }
+    }
+    if ( rejectFake ) continue;
+
+
+    // Otherwise, add this track momentum to the total track momentum
+    /* */
+    // reco::TrackRef trackRef = elements[jTrack].trackRef();
+    if ( !thatIsAMuon ) {
+      if ( debug_ )
+        std::cout << "Track momentum increased from " << trackMomentum << " GeV ";
+      trackMomentum += trackRef->p();
+      if ( debug_ ) {
+        std::cout << "to " << trackMomentum << " GeV." << std::endl;
+        std::cout << "with " << elements[jTrack] << std::endl;
+      }
+    } else {
+      totalEcal -= muonECAL_[0];
+      totalEcal = std::max(totalEcal, 0.);
+    }
+
+    // And create a charged particle candidate !
+
+    tmpi.push_back(reconstructTrack( elements[jTrack] ));
+
+
+    kTrack.push_back(jTrack);
+    active[jTrack] = false;
+
+    if ( thatIsAMuon ) {
+      (*pfCandidates_)[tmpi.back()].setEcalEnergy(clusterRef->energy(),
+    					      std::min(clusterRef->energy(),muonECAL_[0]));
+      (*pfCandidates_)[tmpi.back()].setHcalEnergy( 0., 0. );
+      (*pfCandidates_)[tmpi.back()].setHoEnergy( 0., 0. );
+      (*pfCandidates_)[tmpi.back()].setPs1Energy( 0 );
+      (*pfCandidates_)[tmpi.back()].setPs2Energy( 0 );
+      (*pfCandidates_)[tmpi.back()].addElementInBlock( blockref, kTrack.back() );
+    }
+  }
+
+
+  if ( debug_ ) std::cout << "Loop over all associated ECAL clusters" << std::endl;
+  // Loop over all ECAL linked clusters ordered by increasing distance.
+  for(auto const& ecal : ecalElems)
+  {
+    const unsigned index = ecal.second;
+    const PFBlockElement::Type type = elements[index].type();
+    assert( type == PFBlockElement::ECAL );
+    if ( debug_ ) std::cout << elements[index] << std::endl;
+
+    // Just skip clusters already taken
+    if ( debug_ && ! active[index] ) std::cout << "is not active  - ignore " << std::endl;
+    if ( ! active[index] ) continue;
+
+    // Just skip this cluster if it's closer to another track
+    block.associatedElements( index,  linkData, sortedTracks,
+                              reco::PFBlockElement::TRACK, reco::PFBlock::LINKTEST_ALL );
+
+    const bool skip = std::none_of(kTrack.begin(), kTrack.end(), [&](unsigned iTrack){
+                return sortedTracks.begin()->second == iTrack;
+            });
+
+    if ( debug_ && skip ) std::cout << "is closer to another track - ignore " << std::endl;
+    if ( skip ) continue;
+
+    // The corresponding PFCluster and energy
+    const reco::PFClusterRef clusterRef = elements[index].clusterRef();
+    assert( !clusterRef.isNull() );
+
+    if ( debug_ ) {
+      std::cout <<"Ecal cluster with raw energy = " << clusterRef->energy()
+            <<" linked with distance = " << ecal.first << std::endl;
+    }
+    //double dist = ie->first;
+    //if ( !connectedToEcal && dist > 0.1 ) {
+      //std::cout << "Warning - first ECAL cluster at a distance of " << dist << "from the closest track!" << std::endl;
+      //cout<<"\telement "<<elements[index]<<" linked with distance = "<< dist <<endl;
+      //cout<<"\telement "<<elements[iTrack]<<" linked with distance = "<< dist <<endl;
+    //}
+
+    // Check the presence of preshower clusters in the vicinity
+    // Preshower cluster closer to another ECAL cluster are ignored.
+    //JOSH: This should use the association map already produced by the cluster corrector for consistency,
+    //but should be ok for now
+    vector<double> ps1Ene{0.};
+    associatePSClusters(index, reco::PFBlockElement::PS1, block, elements, linkData, active, ps1Ene);
+    vector<double> ps2Ene{0.};
+    associatePSClusters(index, reco::PFBlockElement::PS2, block, elements, linkData, active, ps2Ene);
+
+    // KH: use raw ECAL energy for PF hadron calibration. use calibrated ECAL energy when adding PF photons
+    const double ecalEnergy = clusterRef->energy();
+    const double ecalEnergyCalibrated = clusterRef->correctedEnergy(); // calibrated based on the egamma hypothesis
+    if ( debug_ ) std::cout << "Corrected ECAL(+PS) energy = " << ecalEnergy << std::endl;
+
+    // Since the electrons were found beforehand, this track must be a hadron. Calibrate
+    // the energy under the hadron hypothesis.
+    totalEcal += ecalEnergy;
+    const double previousCalibEcal = calibEcal;
+    const double previousSlopeEcal = slopeEcal;
+    calibEcal = std::max(totalEcal,0.);
+    calibHcal = 0.;
+    calibration_->energyEmHad( trackMomentum,calibEcal,calibHcal,
+                               clusterRef->positionREP().Eta(),
+                               clusterRef->positionREP().Phi() );
+    if ( totalEcal > 0.) slopeEcal = calibEcal/totalEcal;
+
+    if ( debug_ )
+      std::cout << "The total calibrated energy so far amounts to = " << calibEcal << " (slope = " << slopeEcal << ")" << std::endl;
+
+
+    // Stop the loop when adding more ECAL clusters ruins the compatibility
+    if ( connectedToEcal && calibEcal - trackMomentum >= 0. ) {
+    // if ( connectedToEcal && calibEcal - trackMomentum >=
+    //     nSigmaECAL_*neutralHadronEnergyResolution(trackMomentum,clusterRef->positionREP().Eta())  ) {
+      calibEcal = previousCalibEcal;
+      slopeEcal = previousSlopeEcal;
+      totalEcal = calibEcal/slopeEcal;
+
+      // Turn this last cluster in a photon
+      // (The PS clusters are already locked in "associatePSClusters")
+      active[index] = false;
+
+      // Find the associated tracks
+      std::multimap<double, unsigned> assTracks;
+      block.associatedElements( index,  linkData,
+                                assTracks,
+                                reco::PFBlockElement::TRACK,
+                                reco::PFBlock::LINKTEST_ALL );
+
+      auto& ecalCand = (*pfCandidates_)[reconstructCluster( *clusterRef, ecalEnergyCalibrated )]; // KH: use the PF ECAL cluster calibrated energy
+      ecalCand.setEcalEnergy( clusterRef->energy(), ecalEnergyCalibrated );
+      ecalCand.setHcalEnergy( 0., 0. );
+      ecalCand.setHoEnergy( 0., 0. );
+      ecalCand.setPs1Energy( ps1Ene[0] );
+      ecalCand.setPs2Energy( ps2Ene[0] );
+      ecalCand.addElementInBlock( blockref, index );
+      // Check that there is at least one track
+      if(!assTracks.empty()) {
+        ecalCand.addElementInBlock( blockref, assTracks.begin()->second );
+
+        // Assign the position of the track at the ECAL entrance
+        const ::math::XYZPointF& chargedPosition =
+          dynamic_cast<const reco::PFBlockElementTrack*>(&elements[assTracks.begin()->second])->positionAtECALEntrance();
+        ecalCand.setPositionAtECALEntrance(chargedPosition);
+      }
+      break;
+    }
+
+    // Lock used clusters.
+    connectedToEcal = true;
+    iEcal = index;
+    active[index] = false;
+    for (unsigned ic : tmpi) (*pfCandidates_)[ic].addElementInBlock( blockref, iEcal );
+
+  } // Loop ecal elements
+
+  bool bNeutralProduced = false;
+
+  // Create a photon if the ecal energy is too large
+  if( connectedToEcal ) {
+    reco::PFClusterRef pivotalRef = elements[iEcal].clusterRef();
+
+    double neutralEnergy = calibEcal - trackMomentum;
+
+    /*
+    // Check if there are other tracks linked to that ECAL
+    for(IE ie = sortedTracks.begin(); ie != sortedTracks.end() && neutralEnergy > 0; ++ie ) {
+      unsigned jTrack = ie->second;
+
+      // The loop is on the other tracks !
+      if ( jTrack == iTrack ) continue;
+
+      // Check if the ECAL closest to this track is the current ECAL
+      // Otherwise ignore this track in the neutral energy determination
+      std::multimap<double, unsigned> sortedECAL;
+      block.associatedElements( jTrack,  linkData,
+    			    sortedECAL,
+    			    reco::PFBlockElement::ECAL,
+    			    reco::PFBlock::LINKTEST_ALL );
+      if ( sortedECAL.begin()->second != iEcal ) continue;
+
+      // Check if this track is also linked to an HCAL
+      // (in which case it goes to the next loop and is ignored here)
+      std::multimap<double, unsigned> sortedHCAL;
+      block.associatedElements( jTrack,  linkData,
+    			    sortedHCAL,
+    			    reco::PFBlockElement::HCAL,
+    			    reco::PFBlock::LINKTEST_ALL );
+      if ( sortedHCAL.size() ) continue;
+
+      // Otherwise, subtract this track momentum from the ECAL energy
+      reco::TrackRef trackRef = elements[jTrack].trackRef();
+      neutralEnergy -= trackRef->p();
+
+    } // End other tracks
+    */
+
+    // Add a photon if the energy excess is large enough
+    double resol = neutralHadronEnergyResolution(trackMomentum,pivotalRef->positionREP().Eta());
+    resol *= trackMomentum;
+    if ( neutralEnergy > std::max(0.5,nSigmaECAL_*resol) ) {
+      neutralEnergy /= slopeEcal;
+      unsigned tmpj = reconstructCluster( *pivotalRef, neutralEnergy );
+      (*pfCandidates_)[tmpj].setEcalEnergy( pivotalRef->energy(), neutralEnergy );
+      (*pfCandidates_)[tmpj].setHcalEnergy( 0., 0. );
+      (*pfCandidates_)[tmpj].setHoEnergy( 0., 0. );
+      (*pfCandidates_)[tmpj].setPs1Energy( 0. );
+      (*pfCandidates_)[tmpj].setPs2Energy( 0. );
+      (*pfCandidates_)[tmpj].addElementInBlock(blockref, iEcal);
+      bNeutralProduced = true;
+      for (unsigned ic=0; ic<kTrack.size();++ic)
+        (*pfCandidates_)[tmpj].addElementInBlock( blockref, kTrack[ic] );
+    } // End neutral energy
+
+    // Set elements in blocks and ECAL energies to all tracks
+  	for (unsigned ic=0; ic<tmpi.size();++ic) {
+
+      // Skip muons
+      if ( (*pfCandidates_)[tmpi[ic]].particleId() == reco::PFCandidate::mu ) continue;
+
+      double fraction = trackMomentum > 0 ? (*pfCandidates_)[tmpi[ic]].trackRef()->p()/trackMomentum : 0;
+      double ecalCal = bNeutralProduced ?
+        (calibEcal-neutralEnergy*slopeEcal)*fraction : calibEcal*fraction;
+      double ecalRaw = totalEcal*fraction;
+
+      if (debug_) cout << "The fraction after photon supression is " << fraction << " calibrated ecal = " << ecalCal << endl;
+
+      (*pfCandidates_)[tmpi[ic]].setEcalEnergy( ecalRaw, ecalCal );
+      (*pfCandidates_)[tmpi[ic]].setHcalEnergy( 0., 0. );
+      (*pfCandidates_)[tmpi[ic]].setHoEnergy( 0., 0. );
+      (*pfCandidates_)[tmpi[ic]].setPs1Energy( 0 );
+      (*pfCandidates_)[tmpi[ic]].setPs2Energy( 0 );
+      (*pfCandidates_)[tmpi[ic]].addElementInBlock( blockref, kTrack[ic] );
+    }
+
+  } // End connected ECAL
+
+  // Fill the element_in_block for tracks that are eventually linked to no ECAL clusters at all.
+  for (unsigned ic=0; ic<tmpi.size();++ic) {
+    const PFCandidate& pfc = (*pfCandidates_)[tmpi[ic]];
+    const PFCandidate::ElementsInBlocks& eleInBlocks = pfc.elementsInBlocks();
+    if ( eleInBlocks.empty() ) {
+      if ( debug_ )std::cout << "Single track / Fill element in block! " << std::endl;
+      (*pfCandidates_)[tmpi[ic]].addElementInBlock( blockref, kTrack[ic] );
+    }
+  }
   return false;
 }
 
@@ -951,7 +955,6 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
 	active[iTrack] = false;
       }
     }
-
 
     if(debug_) {
       if ( !active[iTrack] )
@@ -2550,10 +2553,7 @@ void PFAlgo::createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBl
   
   // Processing the remaining HCAL clusters
   if(debug_) {
-    cout<<endl;
-    if(debug_)
-      cout<<endl
-          <<"---- loop remaining hcal ------- "<<endl;
+    cout << endl << endl <<"---- loop remaining hcal ------- " << endl;
   }
 
 
@@ -2897,16 +2897,13 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
     createCandidateHF(block, blockref, elements, inds);
   }
 
-
-
-
   createCandidatesHCAL(block, linkData, elements, active, blockref, inds, deadArea);
   // COLINFEB16: now dealing with the HCAL elements that are not linked to any track
   createCandidatesHCALUnlinked(block, linkData, elements, active, blockref, inds, deadArea); 
   createCandidatesECAL(block, linkData, elements, active, blockref, inds, deadArea);
 
 
-}  // end processBlock HCALLoop
+}  // end processBlock
 
 /////////////////////////////////////////////////////////////////////
 unsigned PFAlgo::reconstructTrack( const reco::PFBlockElement& elt, bool allowLoose) {


### PR DESCRIPTION
#### PR description:

This is a continuation of the PR https://github.com/cms-sw/cmssw/pull/26894.

I further factorize `PFAlgo::processBlock`, creating the following functions from the loop body:

```C++
  bool recoTracksNotHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockRef &blockref, std::vector<bool>& active, bool goodTrackDeadHcal, bool hasDeadHcal, unsigned int iTrack, std::multimap<double, unsigned>& ecalElems, reco::TrackRef& trackRef);
  //Looks for a HF-associated element in the block and produces a PFCandidate from it with HF_EM and/or HF_HAD calibrations
  void createCandidateHF(const reco::PFBlock &block, const reco::PFBlockRef &blockref, const edm::OwnVector<reco::PFBlockElement> &elements, ElementIndices& inds);
  void createCandidatesHCAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
  void createCandidatesHCALUnlinked(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
  void createCandidatesECAL(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
```

The functionality and physics logic of PFAlgo have not been changed, therefore timing, memory usage and physics output should be the same.

This is meant to further clear up PFAlgo code, for which I imagine the path could be something like the following:

- [x] Factorize `PFAlgo::processBlock` to smaller subfunctions (this PR and https://github.com/cms-sw/cmssw/pull/26894)
- [x] Follow up with a clang-format pass.
- [x] Sanitize the inputs and outputs of the functions and making sure they rely less on the PFAlgo state, each function ideally having a single purpose and clear inputs and outputs.
- [ ] Given the cleaned-up implementation from above, revisit the logic/physics of the algo to rewrite it from with Run3/HL-LHC in mind
- [ ] Compare to an eventual ML PF algo that arrives in CMS

Therefore, please do not consider the function names, arguments etc as final at this stage.

#### PR validation:

We do not change the functionality of the PFAlgo, hence the output should not change at all and timing performance should change only in as much as the C++ compiler is able to optimize the code better. We have checked this in a previous version of this PR, see [here](https://github.com/jpata/cmssw/pull/44). I'm running the following comparisons:
- `runTheMatrix -l 38.0` between 45a962ed4ce87e899871bb214718f03464bef678 and 17507fb9bbd5f1db06dda9c95d52758ef2356994: output files have the same number of bytes

cc PF group: @hatakeyamak @bendavid
