### PR TITLE
Fix assert failure in readLuminosityBlock

### DIFF
--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -91,9 +91,9 @@ namespace edm {
 
   private:
     // ---------- member data --------------------------------
-    std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
     std::shared_ptr<void> run_;
     LimitedTaskQueue::Resumer globalLumiQueueResumer_;
+    std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
     EventProcessor* eventProcessor_ = nullptr;
     IOVSyncValue nextSyncValue_;
     std::atomic<unsigned int> nStreamsStillProcessingLumi_{0};  //read/write as streams finish lumi so must be atomic


### PR DESCRIPTION
#### PR description:

We are having a rare, nonreproducible failure in
EventProcessor::readLuminosityBlock in the IBs.
The symptom is an assert because the pointer to
the LuminosityBlockPrincipal is null. If the
LuminosityBlockProcessingStatus object was being
destroyed before calling resumeGlobalLumiQueue
then such a failure could occur because the order the
of the member variables in LuminosityBlockProcessingStatus
is wrong. We should free the LuminosityBlockPrincipal
before resuming the lumi queue. I am not sure this will
actually help though, because I can see no way to get
into this state. The existing code tries to always call
resumeGlobalLumiQueue, but this should eliminate at least
one possible source for the assert we have seen.

This should not change any behavior except maybe in some
complex case where we are already dealing with an unrelated
exception.

#### PR validation:

Run existing unit tests.