### PR TITLE
Running code-format for alca

### DIFF
--- a/CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h
@@ -9,6 +9,9 @@
 
 #include "boost/mpl/vector.hpp"
 
-class SiPixel2DTemplateDBObjectESProducerRcd : public edm::eventsetup::DependentRecordImplementation<SiPixel2DTemplateDBObjectESProducerRcd, boost::mpl::vector<IdealMagneticFieldRecord, SiPixel2DTemplateDBObjectRcd> > {};
+class SiPixel2DTemplateDBObjectESProducerRcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          SiPixel2DTemplateDBObjectESProducerRcd,
+          boost::mpl::vector<IdealMagneticFieldRecord, SiPixel2DTemplateDBObjectRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h
@@ -4,8 +4,10 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "boost/mpl/vector.hpp"
-#include "CondFormats/DataRecord/interface/SiPixelStatusScenariosRcd.h" 
+#include "CondFormats/DataRecord/interface/SiPixelStatusScenariosRcd.h"
 
-class SiPixelFEDChannelContainerESProducerRcd : public edm::eventsetup::DependentRecordImplementation<SiPixelFEDChannelContainerESProducerRcd,boost::mpl::vector<SiPixelStatusScenariosRcd> > {};
+class SiPixelFEDChannelContainerESProducerRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiPixelFEDChannelContainerESProducerRcd,
+                                                            boost::mpl::vector<SiPixelStatusScenariosRcd> > {};
 
-#endif 
+#endif

--- a/CalibTracker/Records/interface/SiPixelGenErrorDBObjectESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixelGenErrorDBObjectESProducerRcd.h
@@ -8,6 +8,9 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
 
-class SiPixelGenErrorDBObjectESProducerRcd : public edm::eventsetup::DependentRecordImplementation<SiPixelGenErrorDBObjectESProducerRcd, boost::mpl::vector<IdealMagneticFieldRecord, SiPixelGenErrorDBObjectRcd> > {};
+class SiPixelGenErrorDBObjectESProducerRcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          SiPixelGenErrorDBObjectESProducerRcd,
+          boost::mpl::vector<IdealMagneticFieldRecord, SiPixelGenErrorDBObjectRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h
+++ b/CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h
@@ -8,6 +8,9 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObjectRcd.h"
 
-class SiPixelTemplateDBObjectESProducerRcd : public edm::eventsetup::DependentRecordImplementation<SiPixelTemplateDBObjectESProducerRcd, boost::mpl::vector<IdealMagneticFieldRecord, SiPixelTemplateDBObjectRcd> > {};
+class SiPixelTemplateDBObjectESProducerRcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          SiPixelTemplateDBObjectESProducerRcd,
+          boost::mpl::vector<IdealMagneticFieldRecord, SiPixelTemplateDBObjectRcd> > {};
 
 #endif

--- a/CalibTracker/Records/interface/SiStripDependentRecords.h
+++ b/CalibTracker/Records/interface/SiStripDependentRecords.h
@@ -12,32 +12,57 @@
 #include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
+class SiStripFecCablingRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiStripFecCablingRcd,
+                                                            boost::mpl::vector<SiStripFedCablingRcd> > {};
 
-class SiStripFecCablingRcd : public edm::eventsetup::DependentRecordImplementation<SiStripFecCablingRcd,
-  boost::mpl::vector<SiStripFedCablingRcd> > {};
+class SiStripDetCablingRcd : public edm::eventsetup::DependentRecordImplementation<
+                                 SiStripDetCablingRcd,
+                                 boost::mpl::vector<SiStripFedCablingRcd, TrackerTopologyRcd, IdealGeometryRecord> > {};
 
-class SiStripDetCablingRcd : public edm::eventsetup::DependentRecordImplementation<SiStripDetCablingRcd,
-  boost::mpl::vector<SiStripFedCablingRcd,TrackerTopologyRcd,IdealGeometryRecord> > {};
-
-class SiStripRegionCablingRcd : public edm::eventsetup::DependentRecordImplementation<SiStripRegionCablingRcd,
-  boost::mpl::vector<SiStripDetCablingRcd,TrackerDigiGeometryRecord,TrackerTopologyRcd> > {};
+class SiStripRegionCablingRcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          SiStripRegionCablingRcd,
+          boost::mpl::vector<SiStripDetCablingRcd, TrackerDigiGeometryRecord, TrackerTopologyRcd> > {};
 
 // class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, boost::mpl::vector<SiStripApvGainRcd> > {};
-class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, boost::mpl::vector<SiStripApvGainRcd, SiStripApvGain2Rcd, SiStripApvGain3Rcd> > {};
-class SiStripGainSimRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainSimRcd, boost::mpl::vector<SiStripApvGainSimRcd> > {};
+class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<
+                           SiStripGainRcd,
+                           boost::mpl::vector<SiStripApvGainRcd, SiStripApvGain2Rcd, SiStripApvGain3Rcd> > {};
+class SiStripGainSimRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiStripGainSimRcd,
+                                                            boost::mpl::vector<SiStripApvGainSimRcd> > {};
 
+class SiStripDelayRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiStripDelayRcd, boost::mpl::vector<SiStripBaseDelayRcd> > {
+};
 
-class SiStripDelayRcd : public edm::eventsetup::DependentRecordImplementation<SiStripDelayRcd, boost::mpl::vector<SiStripBaseDelayRcd> > {};
+class SiStripLorentzAngleDepRcd : public edm::eventsetup::DependentRecordImplementation<
+                                      SiStripLorentzAngleDepRcd,
+                                      boost::mpl::vector<SiStripLatencyRcd, SiStripLorentzAngleRcd> > {};
 
-class SiStripLorentzAngleDepRcd : public edm::eventsetup::DependentRecordImplementation<SiStripLorentzAngleDepRcd, boost::mpl::vector<SiStripLatencyRcd, SiStripLorentzAngleRcd> > {};
+class SiStripBackPlaneCorrectionDepRcd : public edm::eventsetup::DependentRecordImplementation<
+                                             SiStripBackPlaneCorrectionDepRcd,
+                                             boost::mpl::vector<SiStripLatencyRcd, SiStripBackPlaneCorrectionRcd> > {};
 
-class SiStripBackPlaneCorrectionDepRcd : public edm::eventsetup::DependentRecordImplementation<SiStripBackPlaneCorrectionDepRcd, boost::mpl::vector<SiStripLatencyRcd, SiStripBackPlaneCorrectionRcd> > {};
+class SiStripHashedDetIdRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiStripHashedDetIdRcd,
+                                                            boost::mpl::vector<TrackerDigiGeometryRecord> > {};
 
-class SiStripHashedDetIdRcd : public edm::eventsetup::DependentRecordImplementation<SiStripHashedDetIdRcd, boost::mpl::vector<TrackerDigiGeometryRecord> > {};
+class SiStripBadModuleFedErrRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleFedErrRcd,
+                                                            boost::mpl::vector<SiStripFedCablingRcd> > {};
 
-class SiStripBadModuleFedErrRcd : public edm::eventsetup::DependentRecordImplementation<SiStripBadModuleFedErrRcd, boost::mpl::vector<SiStripFedCablingRcd> > {};
+class SiStripQualityRcd
+    : public edm::eventsetup::DependentRecordImplementation<SiStripQualityRcd,
+                                                            boost::mpl::vector<SiStripBadModuleRcd,
+                                                                               SiStripBadFiberRcd,
+                                                                               SiStripBadChannelRcd,
+                                                                               SiStripBadStripRcd,
+                                                                               SiStripDetCablingRcd,
+                                                                               SiStripDCSStatusRcd,
+                                                                               SiStripDetVOffRcd,
+                                                                               RunInfoRcd,
+                                                                               SiStripBadModuleFedErrRcd> > {};
 
-class SiStripQualityRcd : public edm::eventsetup::DependentRecordImplementation<SiStripQualityRcd, boost::mpl::vector<SiStripBadModuleRcd, SiStripBadFiberRcd, SiStripBadChannelRcd, SiStripBadStripRcd, SiStripDetCablingRcd, SiStripDCSStatusRcd, SiStripDetVOffRcd, RunInfoRcd,  SiStripBadModuleFedErrRcd > > {};
-
-#endif 
-
+#endif

--- a/CalibTracker/Records/src/SiStripDependentRecords.cc
+++ b/CalibTracker/Records/src/SiStripDependentRecords.cc
@@ -8,7 +8,6 @@ EVENTSETUP_RECORD_REG(SiStripRegionCablingRcd);
 EVENTSETUP_RECORD_REG(SiStripGainRcd);
 EVENTSETUP_RECORD_REG(SiStripGainSimRcd);
 
-
 EVENTSETUP_RECORD_REG(SiStripDelayRcd);
 EVENTSETUP_RECORD_REG(SiStripLorentzAngleDepRcd);
 EVENTSETUP_RECORD_REG(SiStripBackPlaneCorrectionDepRcd);


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/381//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


