### PR TITLE
Running code-format for simulation

### DIFF
--- a/DataFormats/MuonDetId/interface/CSCDetId.h
+++ b/DataFormats/MuonDetId/interface/CSCDetId.h
@@ -21,108 +21,95 @@
 
 class CSCDetId;
 
-std::ostream& operator<<( std::ostream& os, const CSCDetId& id );
+std::ostream& operator<<(std::ostream& os, const CSCDetId& id);
 
 class CSCDetId : public DetId {
-
 public:
-
-
   /// Default constructor; fills the common part in the base
   /// and leaves 0 in all other fields
-  CSCDetId() : DetId(DetId::Muon, MuonSubdetId::CSC){}
+  CSCDetId() : DetId(DetId::Muon, MuonSubdetId::CSC) {}
 
   /// Construct from a packed id. It is required that the Detector part of
   /// id is Muon and the SubDet part is CSC, otherwise an exception is thrown.
   CSCDetId(uint32_t id) : DetId(id) {}
   CSCDetId(DetId id) : DetId(id) {}
 
-
   /// Construct from fully qualified identifier.
   /// Input values are required to be within legal ranges, otherwise an
   /// exception is thrown.<br>
   /// iendcap: 1=forward (+Z), 2=backward(-Z)
-  CSCDetId( int iendcap, int istation, 
-	    int iring, int ichamber, 
-	    int ilayer = 0 ) : DetId(DetId::Muon, MuonSubdetId::CSC) {
-     id_ |= init(iendcap, istation, iring, ichamber, ilayer);
+  CSCDetId(int iendcap, int istation, int iring, int ichamber, int ilayer = 0) : DetId(DetId::Muon, MuonSubdetId::CSC) {
+    id_ |= init(iendcap, istation, iring, ichamber, ilayer);
   }
 
   /** Chamber CSCDetId from a Layer CSCDetId
    */
   CSCDetId chamberId() const {
     // build chamber id by removing layer bits
-    return CSCDetId( id_ - layer() ) ; }
+    return CSCDetId(id_ - layer());
+  }
 
   /**
    * Return Layer label.
    *
    */
-  int layer() const {
-    return (id_ & MASK_LAYER); } 
+  int layer() const { return (id_ & MASK_LAYER); }
 
   /**
    * Return Chamber label.
    *
    */
-   int chamber() const {
-     return (  (id_>>START_CHAMBER) & MASK_CHAMBER ); }
+  int chamber() const { return ((id_ >> START_CHAMBER) & MASK_CHAMBER); }
 
   /**
    * Return Ring label.
    *
    */
-   int ring() const {
-     if (((id_>>START_STATION) & MASK_STATION) == 1)
-       return (  detIdToInt((id_>>START_RING) & MASK_RING )); 
-     else
-       return (((id_>>START_RING) & MASK_RING )); 
-   }
+  int ring() const {
+    if (((id_ >> START_STATION) & MASK_STATION) == 1)
+      return (detIdToInt((id_ >> START_RING) & MASK_RING));
+    else
+      return (((id_ >> START_RING) & MASK_RING));
+  }
 
   /**
    * Return Station label.
    *
    */
-   int station() const {
-     return (  (id_>>START_STATION) & MASK_STATION ); }
+  int station() const { return ((id_ >> START_STATION) & MASK_STATION); }
 
   /**
    * Return Endcap label. 1=forward (+Z); 2=backward (-Z)
    *
    */
-   int endcap() const {
-     return (  (id_>>START_ENDCAP) & MASK_ENDCAP ); }
+  int endcap() const { return ((id_ >> START_ENDCAP) & MASK_ENDCAP); }
 
-   /**
+  /**
     * What is the sign of global z?
     *
     */
-   short int zendcap() const {
-     return ( endcap()!=1 ? -1 : +1 );
-   }
+  short int zendcap() const { return (endcap() != 1 ? -1 : +1); }
 
-   /**
+  /**
     * Chamber type (integer 1-10)
     */
-   unsigned short iChamberType() const {
-     return iChamberType( station(), ring() );
-   }
+  unsigned short iChamberType() const { return iChamberType(station(), ring()); }
 
-   /**
+  /**
     * Geometric channel no. from geometric strip no. - identical except for ME1a ganged strips
     *
     * Note that 'Geometric' means increasing number corresponds to increasing local x coordinate. 
     * \warning There is no attempt here to handle cabling or readout questions. 
     * If you need that look at CondFormats/CSCObjects/CSCChannelTranslator.
     */
-   int channel( int istrip ) { 
-     if ( ring()== 4 ) 
-       // strips 1-48 mapped to channels 1-16:
-       // 1+17+33->1, 2+18+34->2, .... 16+32+48->16
-       return 1 + (istrip-1)%16; 
-     else 
-       return istrip; 
-   }
+  int channel(int istrip) {
+    if (ring() == 4)
+      // strips 1-48 mapped to channels 1-16:
+      // 1+17+33->1, 2+18+34->2, .... 16+32+48->16
+      return 1 + (istrip - 1) % 16;
+    else
+      return istrip;
+  }
 
   // static methods
   // Used when we need information about subdetector labels.
@@ -141,60 +128,56 @@ public:
    * starting from the component ids.
    *
    */
-   static int rawIdMaker( int iendcap, int istation, int iring, 
-               int ichamber, int ilayer ) {
-     return ( (DetId::Muon&0xF)<<(DetId::kDetOffset) ) |            // set Muon flag
-            ( (MuonSubdetId::CSC&0x7)<<(DetId::kSubdetOffset) ) |   // set CSC flag
-               init(iendcap, istation, iring, ichamber, ilayer) ; } // set CSC id
+  static int rawIdMaker(int iendcap, int istation, int iring, int ichamber, int ilayer) {
+    return ((DetId::Muon & 0xF) << (DetId::kDetOffset)) |           // set Muon flag
+           ((MuonSubdetId::CSC & 0x7) << (DetId::kSubdetOffset)) |  // set CSC flag
+           init(iendcap, istation, iring, ichamber, ilayer);
+  }  // set CSC id
 
-   /**
+  /**
     * Return Layer label for supplied CSCDetId index.
     *
     */
-   static int layer( int index ) {
-     return (index & MASK_LAYER); }
+  static int layer(int index) { return (index & MASK_LAYER); }
 
-   /**
+  /**
     * Return Chamber label for supplied CSCDetId index.
     *
     */
-   static int chamber( int index ) {
-     return (  (index>>START_CHAMBER) & MASK_CHAMBER ); }
+  static int chamber(int index) { return ((index >> START_CHAMBER) & MASK_CHAMBER); }
 
-   /**
+  /**
     * Return Ring label for supplied CSCDetId index.
     *
     */
-   static int ring( int index ) {
-     if (((index>>START_STATION) & MASK_STATION) == 1)
-       return (  detIdToInt((index>>START_RING) & MASK_RING )); 
-     else
-       return (( index>>START_RING) & MASK_RING ); 
-   }
+  static int ring(int index) {
+    if (((index >> START_STATION) & MASK_STATION) == 1)
+      return (detIdToInt((index >> START_RING) & MASK_RING));
+    else
+      return ((index >> START_RING) & MASK_RING);
+  }
 
-   /**
+  /**
     * Return Station label for supplied CSCDetId index.
     *
     */
-   static int station( int index ) {
-     return (  (index>>START_STATION) & MASK_STATION ); }
+  static int station(int index) { return ((index >> START_STATION) & MASK_STATION); }
 
-   /**
+  /**
     * Return Endcap label for supplied CSCDetId index.
     *
     */
-   static int endcap( int index ) {
-     return (  (index>>START_ENDCAP) & MASK_ENDCAP ); }
+  static int endcap(int index) { return ((index >> START_ENDCAP) & MASK_ENDCAP); }
 
-   /**
+  /**
     * Return a unique integer 1-10 for a station, ring pair:
     *        1           for S = 1  and R=4 inner strip part of ME11 (ME1a)
     *      2,3,4 =  R+1  for S = 1  and R = 1,2,3 (ME11 means ME1b)
     *      5-10  = 2*S+R for S = 2,3,4 and R = 1,2
     */
-   static unsigned short iChamberType( unsigned short istation, unsigned short iring );
+  static unsigned short iChamberType(unsigned short istation, unsigned short iring);
 
-   /**
+  /**
     * Return trigger-level sector id for an Endcap Muon chamber.
     *
     * This method encapsulates the information about which chambers
@@ -213,9 +196,9 @@ public:
     * We count from one not zero.
     *
     */
-   int triggerSector() const;
+  int triggerSector() const;
 
-   /**
+  /**
     * Return trigger-level CSC id  within a sector for an Endcap Muon chamber.
     *
     * This id is an index within a sector such that the 3 inner ring chambers 
@@ -228,47 +211,41 @@ public:
     * and software changes.
     *
     */
-   int triggerCscId() const;
+  int triggerCscId() const;
 
-   /**
+  /**
     * Lower and upper counts for the subdetector hierarchy
     */
-   static int minEndcapId()  { return MIN_ENDCAP; }
-   static int maxEndcapId()  { return MAX_ENDCAP; }
-   static int minStationId() { return MIN_STATION; }
-   static int maxStationId() { return MAX_STATION; }
-   static int minRingId()    { return MIN_RING; }
-   static int maxRingId()    { return MAX_RING; }
-   static int minChamberId() { return MIN_CHAMBER; }
-   static int maxChamberId() { return MAX_CHAMBER; }
-   static int minLayerId()   { return MIN_LAYER; }
-   static int maxLayerId()   { return MAX_LAYER; }
+  static int minEndcapId() { return MIN_ENDCAP; }
+  static int maxEndcapId() { return MAX_ENDCAP; }
+  static int minStationId() { return MIN_STATION; }
+  static int maxStationId() { return MAX_STATION; }
+  static int minRingId() { return MIN_RING; }
+  static int maxRingId() { return MAX_RING; }
+  static int minChamberId() { return MIN_CHAMBER; }
+  static int maxChamberId() { return MAX_CHAMBER; }
+  static int minLayerId() { return MIN_LAYER; }
+  static int maxLayerId() { return MAX_LAYER; }
 
-   /**
+  /**
     * Returns the chamber name in the format
     * ME$sign$station/$ring/$chamber. Example: ME+1/1/9
     */
-   static std::string chamberName(int endcap, int station, int ring, int chamber);
-   std::string chamberName() const;
+  static std::string chamberName(int endcap, int station, int ring, int chamber);
+  std::string chamberName() const;
 
 private:
- 
   /**
    * Method for initialization within ctors.
    *
    */
-  static uint32_t init( int iendcap, int istation, 
-			int iring, int ichamber, int ilayer ) {
-    
+  static uint32_t init(int iendcap, int istation, int iring, int ichamber, int ilayer) {
     if (istation == 1)
       iring = intToDetId(iring);
 
-     return
-         (ilayer   & MASK_LAYER)                      |
-       ( (ichamber & MASK_CHAMBER) << START_CHAMBER ) |
-       ( (iring    & MASK_RING)    << START_RING )    |
-       ( (istation & MASK_STATION) << START_STATION ) | 
-       ( (iendcap  & MASK_ENDCAP)  << START_ENDCAP ) ; }
+    return (ilayer & MASK_LAYER) | ((ichamber & MASK_CHAMBER) << START_CHAMBER) | ((iring & MASK_RING) << START_RING) |
+           ((istation & MASK_STATION) << START_STATION) | ((iendcap & MASK_ENDCAP) << START_ENDCAP);
+  }
 
   /**
    *
@@ -283,38 +260,42 @@ private:
   static int intToDetId(int iring) {
     // change iring = 1, 2, 3, 4 input to 2, 3, 4, 1 for use inside the DetId
     // i.e. ME1b, ME12, ME13, ME1a externally become stored internally in order ME1a, ME1b, ME12, ME13
-    int i = (iring+1)%4;
-    if (i == 0) i = 4;
+    int i = (iring + 1) % 4;
+    if (i == 0)
+      i = 4;
     return i;
   }
 
   static int detIdToInt(int iring) {
     // reverse intToDetId: change 1, 2, 3, 4 inside the DetId to 4, 1, 2, 3 for external use
     // i.e. output ring # 1, 2, 3, 4 in ME1 means ME1b, ME12, ME13, ME1a as usual in the offline software.
-    int i = (iring-1);
-    if (i == 0) i = 4;
+    int i = (iring - 1);
+    if (i == 0)
+      i = 4;
     return i;
   }
- 
+
   // The following define the bit-packing implementation...
 
   // The maximum numbers of various parts
-  enum eMaxNum{ MAX_ENDCAP=2, MAX_STATION=4, MAX_RING=4, MAX_CHAMBER=36, MAX_LAYER=6 };
-  // We count from 1 
-  enum eMinNum{ MIN_ENDCAP=1, MIN_STATION=1, MIN_RING=1, MIN_CHAMBER=1, MIN_LAYER=1 };
+  enum eMaxNum { MAX_ENDCAP = 2, MAX_STATION = 4, MAX_RING = 4, MAX_CHAMBER = 36, MAX_LAYER = 6 };
+  // We count from 1
+  enum eMinNum { MIN_ENDCAP = 1, MIN_STATION = 1, MIN_RING = 1, MIN_CHAMBER = 1, MIN_LAYER = 1 };
 
   // BITS_det is no. of binary bits required to label 'det' but allow 0 as a wild-card character
   // Keep as multiples of 3 so that number can be easily decodable from octal
-  enum eNumBitDet{ BITS_ENDCAP=3, BITS_STATION=3,  BITS_RING=3, BITS_CHAMBER=6, BITS_LAYER=3 };
+  enum eNumBitDet { BITS_ENDCAP = 3, BITS_STATION = 3, BITS_RING = 3, BITS_CHAMBER = 6, BITS_LAYER = 3 };
 
   // MASK_det is binary bits set to pick off the bits for 'det' (defined as octal)
-  enum eMaskBitDet{ MASK_ENDCAP=07, MASK_STATION=07, MASK_RING=07, MASK_CHAMBER=077, MASK_LAYER=07 };
+  enum eMaskBitDet { MASK_ENDCAP = 07, MASK_STATION = 07, MASK_RING = 07, MASK_CHAMBER = 077, MASK_LAYER = 07 };
 
   // START_det is bit position (counting from zero) at which bits for 'det' start in 'rawId' word
-  enum eStartBitDet{ START_CHAMBER=BITS_LAYER, START_RING=START_CHAMBER+BITS_CHAMBER,
-          START_STATION=START_RING+BITS_RING, START_ENDCAP=START_STATION+BITS_STATION };
+  enum eStartBitDet {
+    START_CHAMBER = BITS_LAYER,
+    START_RING = START_CHAMBER + BITS_CHAMBER,
+    START_STATION = START_RING + BITS_RING,
+    START_ENDCAP = START_STATION + BITS_STATION
+  };
 };
 
 #endif
-
-

--- a/DataFormats/MuonDetId/interface/CSCIndexer.h
+++ b/DataFormats/MuonDetId/interface/CSCIndexer.h
@@ -42,9 +42,7 @@
 #include <utility>  // for pair
 
 class CSCIndexer {
-
 public:
-
   //  typedef unsigned short int IndexType;
   //  typedef unsigned       int LongIndexType;
   typedef uint16_t IndexType;
@@ -63,9 +61,9 @@ public:
    * No sanity checking on input value: if you supply an ME1a CSCDetId then you'll get nonsense.
    */
 
-   IndexType chamberIndex( const CSCDetId& id ) const {
-     return chamberIndex( id.endcap(), id.station(), id.ring(), id.chamber() );
-   }
+  IndexType chamberIndex(const CSCDetId& id) const {
+    return chamberIndex(id.endcap(), id.station(), id.ring(), id.chamber());
+  }
 
   /**
    * Linear index to label each hardware layer in CSC system.
@@ -77,58 +75,58 @@ public:
    * No sanity checking on input value: if you supply an ME1a CSCDetId then you'll get nonsense.
    */
 
-   IndexType layerIndex( const CSCDetId& id ) const {
-     return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer());
-   }
+  IndexType layerIndex(const CSCDetId& id) const {
+    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer());
+  }
 
-   /** 
+  /** 
     * Starting index for first chamber in ring 'ir' of station 'is' in endcap 'ie',
     * in range 1-468 (CSCs 2008) or 469-540 (ME42).
     */
-   IndexType startChamberIndexInEndcap(IndexType ie, IndexType is, IndexType ir) const {
-     const IndexType nschin[24] = {1,37,73,    109,127,0, 163,181,0, 217,469,0,
-                                  235,271,307, 343,361,0, 397,415,0, 451,505,0 };
-     return nschin[(ie-1)*12 + (is-1)*3 + ir-1];
+  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is, IndexType ir) const {
+    const IndexType nschin[24] = {1,   37,  73,  109, 127, 0, 163, 181, 0, 217, 469, 0,
+                                  235, 271, 307, 343, 361, 0, 397, 415, 0, 451, 505, 0};
+    return nschin[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
+  }
 
-   }
-
-   /**
+  /**
     * Linear index for chamber 'ic' in ring 'ir' of station 'is' in endcap 'ie',
     * in range 1-468 (CSCs 2008) or 469-540 (ME42)
     */
-   IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic) const {
-     return startChamberIndexInEndcap(ie,is,ir) + ic - 1; // -1 so start index _is_ ic=1
-   }
+  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic) const {
+    return startChamberIndexInEndcap(ie, is, ir) + ic - 1;  // -1 so start index _is_ ic=1
+  }
 
-   /**
+  /**
     * Linear index for layer 'il' of chamber 'ic' in ring 'ir' of station 'is' in endcap 'ie',
     * in range 1-2808 (CSCs 2008) or 2809-3240 (ME42).
     */
-   IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il) const {
+  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il) const {
     const IndexType layersInChamber = 6;
-     return (chamberIndex(ie,is,ir,ic) - 1 ) * layersInChamber + il;
-   }
+    return (chamberIndex(ie, is, ir, ic) - 1) * layersInChamber + il;
+  }
 
   /**
    * How many rings are there in station is=1, 2, 3, 4 ?
    *
    * BEWARE! Includes ME42 so claims 2 rings in station 4. There is only 1 at CSC installation 2008.
    */
-   IndexType ringsInStation( IndexType is ) const {
-      const IndexType nrins[5] = {0,3,2,2,2}; // rings per station
-      return nrins[is];
-   }
+  IndexType ringsInStation(IndexType is) const {
+    const IndexType nrins[5] = {0, 3, 2, 2, 2};  // rings per station
+    return nrins[is];
+  }
 
   /**
    * How many chambers are there in ring ir of station is?
    *
    * Works for ME1a (ring 4 of ME1) too.
    */
-   IndexType chambersInRingOfStation(IndexType is, IndexType ir) const {
-      IndexType nc = 36; // most rings have 36 chambers
-      if (is >1 && ir<2 ) nc = 18; // but 21, 31, 41 have 18
-      return nc;
-   }
+  IndexType chambersInRingOfStation(IndexType is, IndexType ir) const {
+    IndexType nc = 36;  // most rings have 36 chambers
+    if (is > 1 && ir < 2)
+      nc = 18;  // but 21, 31, 41 have 18
+    return nc;
+  }
 
   /** 
    * Number of strip channels per layer in a chamber in ring ir of station is.
@@ -139,10 +137,10 @@ public:
    * and an input ir=4 is invalid and will give nonsense. <br>
    * Considers ME42 as standard 80-strip per layer chambers.
    */
-   IndexType stripChannelsPerLayer( IndexType is, IndexType ir ) const {
-     const IndexType nSCinC[12] = { 80,80,64, 80,80,0, 80,80,0, 80,80,0 };
-     return nSCinC[(is-1)*3 + ir - 1];
-   }
+  IndexType stripChannelsPerLayer(IndexType is, IndexType ir) const {
+    const IndexType nSCinC[12] = {80, 80, 64, 80, 80, 0, 80, 80, 0, 80, 80, 0};
+    return nSCinC[(is - 1) * 3 + ir - 1];
+  }
 
   /**
    * Linear index for 1st strip channel in ring 'ir' of station 'is' in endcap 'ie'.
@@ -152,17 +150,16 @@ public:
    * WARNING: ME1a channels are the last 16 of the 80 total in each layer of an ME11 chamber, 
    * and an input ir=4 is invalid and will give nonsense.
    */
-   LongIndexType stripChannelStart( IndexType ie, IndexType is, IndexType ir ) const {
-
-     // These are in the ranges 1-217728 (CSCs 2008) and 217729-252288 (ME42).
-     // There are 1-108884 channels per endcap (CSCs 2008) and 17280 channels per endcap (ME42).
-     // Start of -z channels (CSCs 2008) is 108864 + 1 = 108865
-     // Start of +z (ME42) is 217728 + 1 = 217729
-     // Start of -z (ME42) is 217728 + 1 + 17280 = 235009
-      const LongIndexType nStart[24] = { 1,17281,34561, 48385,57025,0, 74305,82945,0, 100225,217729,0,
-                                   108865,126145,143425, 157249,165889,0, 183169,191809,0, 209089,235009,0 };
-      return  nStart[(ie-1)*12 + (is-1)*3 + ir - 1];
-   }
+  LongIndexType stripChannelStart(IndexType ie, IndexType is, IndexType ir) const {
+    // These are in the ranges 1-217728 (CSCs 2008) and 217729-252288 (ME42).
+    // There are 1-108884 channels per endcap (CSCs 2008) and 17280 channels per endcap (ME42).
+    // Start of -z channels (CSCs 2008) is 108864 + 1 = 108865
+    // Start of +z (ME42) is 217728 + 1 = 217729
+    // Start of -z (ME42) is 217728 + 1 + 17280 = 235009
+    const LongIndexType nStart[24] = {1,      17281,  34561,  48385,  57025,  0, 74305,  82945,  0, 100225, 217729, 0,
+                                      108865, 126145, 143425, 157249, 165889, 0, 183169, 191809, 0, 209089, 235009, 0};
+    return nStart[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
+  }
 
   /**
    * Linear index for strip channel istrip in layer 'il' of chamber 'ic' of ring 'ir'
@@ -173,9 +170,10 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware ranges.
    * No trapping on out-of-range values!
    */
-   LongIndexType stripChannelIndex( IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip ) const {
-      return stripChannelStart(ie,is,ir)+( (ic-1)*6 + il - 1 )*stripChannelsPerLayer(is,ir) + (istrip-1);
-   }
+  LongIndexType stripChannelIndex(
+      IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip) const {
+    return stripChannelStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) + (istrip - 1);
+  }
 
   /**
    * Linear index for strip channel 'istrip' in layer labelled by CSCDetId 'id'.
@@ -186,9 +184,9 @@ public:
    * No trapping on out-of-range values!
    */
 
-   LongIndexType stripChannelIndex( const CSCDetId& id, IndexType istrip ) const {
-      return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), istrip );
-   }
+  LongIndexType stripChannelIndex(const CSCDetId& id, IndexType istrip) const {
+    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), istrip);
+  }
 
   /** 
    * Number of Buckeye chips per layer in a chamber in ring ir of station is.
@@ -199,10 +197,10 @@ public:
    * and an input ir=4 is invalid and will give nonsense. <br>
    * Considers ME42 as standard 5 chip per layer chambers.
    */
-   IndexType chipsPerLayer( IndexType is, IndexType ir ) const {
-     const IndexType nCinL[12] = { 5,5,4, 5,5,0, 5,5,0, 5,5,0 };
-     return nCinL[(is-1)*3 + ir - 1];
-   }
+  IndexType chipsPerLayer(IndexType is, IndexType ir) const {
+    const IndexType nCinL[12] = {5, 5, 4, 5, 5, 0, 5, 5, 0, 5, 5, 0};
+    return nCinL[(is - 1) * 3 + ir - 1];
+  }
 
   /**
    * Linear index for 1st Buckey chip in ring 'ir' of station 'is' in endcap 'ie'.
@@ -212,18 +210,17 @@ public:
    * WARNING: ME1a channels are the last 1 of the 5 chips total in each layer of an ME11 chamber, 
    * and an input ir=4 is invalid and will give nonsense.
    */
-   IndexType chipStart( IndexType ie, IndexType is, IndexType ir ) const {
+  IndexType chipStart(IndexType ie, IndexType is, IndexType ir) const {
+    // These are in the ranges 1-13608 (CSCs 2008) and 13609-15768 (ME42).
+    // There are 1-6804 chips per endcap (CSCs 2008) and 1080 channels per endcap (ME42).
+    // Start of -z channels (CSCs 2008) is 6804 + 1 = 6805
+    // Start of +z (ME42) is 13608 + 1 = 13609
+    // Start of -z (ME42) is 13608 + 1 + 1080 = 14689
+    const IndexType nStart[24] = {1,    1081, 2161, 3025, 3565,  0, 4645,  5185,  0, 6265,  13609, 0,
+                                  6805, 7885, 8965, 9829, 10369, 0, 11449, 11989, 0, 13069, 14689, 0};
 
-     // These are in the ranges 1-13608 (CSCs 2008) and 13609-15768 (ME42).
-     // There are 1-6804 chips per endcap (CSCs 2008) and 1080 channels per endcap (ME42).
-     // Start of -z channels (CSCs 2008) is 6804 + 1 = 6805
-     // Start of +z (ME42) is 13608 + 1 = 13609
-     // Start of -z (ME42) is 13608 + 1 + 1080 = 14689
-     const IndexType nStart[24] = {1, 1081, 2161, 3025, 3565, 0, 4645, 5185, 0, 6265, 13609,0,
-				    6805, 7885, 8965, 9829, 10369,0, 11449, 11989, 0, 13069, 14689 ,0 };
-                                   
-     return  nStart[(ie-1)*12 + (is-1)*3 + ir - 1];
-   }
+    return nStart[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
+  }
 
   /**
    * Linear index for Buckeye chip 'ichip' in layer 'il' of chamber 'ic' of ring 'ir'
@@ -234,10 +231,9 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware ranges.
    * No trapping on out-of-range values!
    */
-   IndexType chipIndex( IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType ichip ) const {
-     //printf("ME%d/%d/%d/%d layer %d  chip %d chipindex %d\n",ie,is,ir,ic,il,ichip,chipStart(ie,is,ir)+( (ic-1)*6 + il - 1 )*chipsPerLayer(is,ir) + (ichip-1));
-     return chipStart(ie,is,ir)+( (ic-1)*6 + il - 1 )*chipsPerLayer(is,ir) + (ichip-1);
-
+  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType ichip) const {
+    //printf("ME%d/%d/%d/%d layer %d  chip %d chipindex %d\n",ie,is,ir,ic,il,ichip,chipStart(ie,is,ir)+( (ic-1)*6 + il - 1 )*chipsPerLayer(is,ir) + (ichip-1));
+    return chipStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
   /**
@@ -249,9 +245,9 @@ public:
    * No trapping on out-of-range values!
    */
 
-   IndexType chipIndex( const CSCDetId& id, IndexType ichip ) const {
-      return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ichip );
-   }
+  IndexType chipIndex(const CSCDetId& id, IndexType ichip) const {
+    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ichip);
+  }
 
   /**
    * Linear index for Buckeye chip processing strip 'istrip'.
@@ -263,9 +259,7 @@ public:
    * No trapping on out-of-range values!
    */
 
-   IndexType chipIndex( IndexType istrip ) const {
-     return (istrip-1)/16+1;
-   }
+  IndexType chipIndex(IndexType istrip) const { return (istrip - 1) / 16 + 1; }
 
   /** 
    * Number of HV segments per layer in a chamber in ring ir of station is.
@@ -275,9 +269,9 @@ public:
    * WARNING: ME1a channels are the last 1 of the 5 total in each layer of an ME11 chamber, 
    * and an input ir=4 is invalid and will give nonsense. <br>
    */
-  IndexType hvSegmentsPerLayer( IndexType is, IndexType ir ) const {
-    const IndexType nSinL[12] = { 1,3,3, 3,5,0, 3,5,0, 3,5,0 };
-    return nSinL[(is-1)*3 + ir - 1];
+  IndexType hvSegmentsPerLayer(IndexType is, IndexType ir) const {
+    const IndexType nSinL[12] = {1, 3, 3, 3, 5, 0, 3, 5, 0, 3, 5, 0};
+    return nSinL[(is - 1) * 3 + ir - 1];
   }
 
   /** 
@@ -288,8 +282,8 @@ public:
    * WARNING: ME1a channels are the last 1 of the 5 total in each layer of an ME11 chamber, 
    * and an input ir=4 is invalid and will give nonsense. <br>
    */
-  IndexType sectorsPerLayer( IndexType is, IndexType ir ) const {
-    return chipsPerLayer(is,ir)*hvSegmentsPerLayer(is,ir);
+  IndexType sectorsPerLayer(IndexType is, IndexType ir) const {
+    return chipsPerLayer(is, ir) * hvSegmentsPerLayer(is, ir);
   }
 
   /**
@@ -300,32 +294,47 @@ public:
    * WARNING: Use at your own risk! The supplied CSCDetId must be chamber station, ring, and wire.
    * No trapping on out-of-range values!
    */
-  IndexType hvSegmentIndex(IndexType is, IndexType ir, IndexType iwire ) const {
+  IndexType hvSegmentIndex(IndexType is, IndexType ir, IndexType iwire) const {
+    IndexType hvSegment = 1;  // There is only one HV segment in ME1/1
 
-    IndexType hvSegment = 1;   // There is only one HV segment in ME1/1
-     
-    if (is > 2 && ir == 1) {        // HV segments are the same in ME3/1 and ME4/1
-      if      ( iwire >= 33 && iwire <= 64 ) { hvSegment = 2; }
-      else if ( iwire >= 65 && iwire <= 96 ) { hvSegment = 3; }
-      
-    } else if (is > 1 && ir == 2) { // HV segments are the same in ME2/2, ME3/2, and ME4/2
-      if      ( iwire >= 17 && iwire <= 28 ) { hvSegment = 2; }
-      else if ( iwire >= 29 && iwire <= 40 ) { hvSegment = 3; }
-      else if ( iwire >= 41 && iwire <= 52 ) { hvSegment = 4; }
-      else if ( iwire >= 53 && iwire <= 64 ) { hvSegment = 5; } 
-      
+    if (is > 2 && ir == 1) {  // HV segments are the same in ME3/1 and ME4/1
+      if (iwire >= 33 && iwire <= 64) {
+        hvSegment = 2;
+      } else if (iwire >= 65 && iwire <= 96) {
+        hvSegment = 3;
+      }
+
+    } else if (is > 1 && ir == 2) {  // HV segments are the same in ME2/2, ME3/2, and ME4/2
+      if (iwire >= 17 && iwire <= 28) {
+        hvSegment = 2;
+      } else if (iwire >= 29 && iwire <= 40) {
+        hvSegment = 3;
+      } else if (iwire >= 41 && iwire <= 52) {
+        hvSegment = 4;
+      } else if (iwire >= 53 && iwire <= 64) {
+        hvSegment = 5;
+      }
+
     } else if (is == 1 && ir == 2) {
-      if      ( iwire >= 25 && iwire <= 48 ) { hvSegment = 2; }
-      else if ( iwire >= 49 && iwire <= 64 ) { hvSegment = 3; }
-      
+      if (iwire >= 25 && iwire <= 48) {
+        hvSegment = 2;
+      } else if (iwire >= 49 && iwire <= 64) {
+        hvSegment = 3;
+      }
+
     } else if (is == 1 && ir == 3) {
-      if      ( iwire >= 13 && iwire <= 22 ) { hvSegment = 2; }
-      else if ( iwire >= 23 && iwire <= 32 ) { hvSegment = 3; }
-      
+      if (iwire >= 13 && iwire <= 22) {
+        hvSegment = 2;
+      } else if (iwire >= 23 && iwire <= 32) {
+        hvSegment = 3;
+      }
+
     } else if (is == 2 && ir == 1) {
-      if      ( iwire >= 45 && iwire <= 80 ) { hvSegment = 2; }
-      else if ( iwire >= 81 && iwire <= 112) { hvSegment = 3; }
-      
+      if (iwire >= 45 && iwire <= 80) {
+        hvSegment = 2;
+      } else if (iwire >= 81 && iwire <= 112) {
+        hvSegment = 3;
+      }
     }
 
     return hvSegment;
@@ -339,7 +348,7 @@ public:
    * WARNING: ME1a channels are the last 1 of the 5 chips total in each layer of an ME11 chamber, 
    * and an input ir=4 is invalid and will give nonsense.
    */
-  IndexType sectorStart( IndexType ie, IndexType is, IndexType ir ) const {
+  IndexType sectorStart(IndexType ie, IndexType is, IndexType ir) const {
     // There are 36 chambers * 6 layers * 5 CFEB's * 1 HV segment = 1080 gas-gain sectors in ME1/1
     // There are 36*6*5*3 = 3240 gas-gain sectors in ME1/2
     // There are 36*6*4*3 = 2592 gas-gain sectors in ME1/3
@@ -348,15 +357,15 @@ public:
     // Start of -z channels (CSCs 2008) is 22572 + 1 = 22573
     // Start of +z (ME42) is 45144 + 1 = 45145
     // Start of -z (ME42) is 45144 + 1 + 5400 = 50545
-    const IndexType nStart[24] = {1    ,1081 , 4321,   //ME+1/1,ME+1/2,ME+1/3
-				  6913 ,8533 ,    0,   //ME+2/1,ME+2/2,ME+2/3
-				  13933,15553,    0,   //ME+3/1,ME+3/2,ME+3/3
-				  20953,45145,    0,   //ME+4/1,ME+4/2,ME+4/3 (note, ME+4/2 index follows ME-4/1...)
-				  22573,23653,26893,   //ME-1/1,ME-1/2,ME-1/3
-				  29485,31105    ,0,   //ME-2/1,ME-2/2,ME-2/3
-				  36505,38125,    0,   //ME-3/1,ME-3/2,ME-3/3
-				  43525,50545,    0};  //ME-4/1,ME-4/2,ME-4/3 (note, ME-4/2 index follows ME+4/2...)                                   
-    return  nStart[(ie-1)*12 + (is-1)*3 + ir - 1];
+    const IndexType nStart[24] = {1,     1081,  4321,   //ME+1/1,ME+1/2,ME+1/3
+                                  6913,  8533,  0,      //ME+2/1,ME+2/2,ME+2/3
+                                  13933, 15553, 0,      //ME+3/1,ME+3/2,ME+3/3
+                                  20953, 45145, 0,      //ME+4/1,ME+4/2,ME+4/3 (note, ME+4/2 index follows ME-4/1...)
+                                  22573, 23653, 26893,  //ME-1/1,ME-1/2,ME-1/3
+                                  29485, 31105, 0,      //ME-2/1,ME-2/2,ME-2/3
+                                  36505, 38125, 0,      //ME-3/1,ME-3/2,ME-3/3
+                                  43525, 50545, 0};     //ME-4/1,ME-4/2,ME-4/3 (note, ME-4/2 index follows ME+4/2...)
+    return nStart[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
   }
 
   /**
@@ -367,7 +376,7 @@ public:
    * WARNING: Use at your own risk!  You must input labels within hardware ranges (e.g., 'id' must correspond 
    * to a specific layer 1-6). No trapping on out-of-range values!
    */
-  IndexType gasGainIndex( const CSCDetId& id, IndexType istrip, IndexType iwire ) const {
+  IndexType gasGainIndex(const CSCDetId& id, IndexType istrip, IndexType iwire) const {
     return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), istrip, iwire);
   }
 
@@ -380,23 +389,25 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware ranges.
    * No trapping on out-of-range values!
    */
-  IndexType gasGainIndex( IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip, IndexType iwire ) const {
-    IndexType ichip      = this->chipIndex(istrip);
-    IndexType ihvsegment = this->hvSegmentIndex(is,ir,iwire);
-    return sectorStart(ie,is,ir)+( (ic-1)*6 + il - 1 )*sectorsPerLayer(is,ir) + (ihvsegment-1)*chipsPerLayer(is,ir) + (ichip-1);
+  IndexType gasGainIndex(
+      IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip, IndexType iwire) const {
+    IndexType ichip = this->chipIndex(istrip);
+    IndexType ihvsegment = this->hvSegmentIndex(is, ir, iwire);
+    return sectorStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
+           (ihvsegment - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
   /**
    *  Decode CSCDetId from various indexes and labels
    */
-  CSCDetId detIdFromLayerIndex( IndexType ili ) const;
-  CSCDetId detIdFromChamberIndex( IndexType ici ) const;
-  CSCDetId detIdFromChamberIndex_OLD( IndexType ici ) const;
-  CSCDetId detIdFromChamberLabel( IndexType ie, IndexType icl ) const;
-  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex( LongIndexType ichi ) const;
-  std::pair<CSCDetId, IndexType> detIdFromChipIndex( IndexType ichi ) const;
+  CSCDetId detIdFromLayerIndex(IndexType ili) const;
+  CSCDetId detIdFromChamberIndex(IndexType ici) const;
+  CSCDetId detIdFromChamberIndex_OLD(IndexType ici) const;
+  CSCDetId detIdFromChamberLabel(IndexType ie, IndexType icl) const;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex(LongIndexType ichi) const;
+  std::pair<CSCDetId, IndexType> detIdFromChipIndex(IndexType ichi) const;
 
-  IndexType chamberLabelFromChamberIndex( IndexType ) const; // just for cross-checks
+  IndexType chamberLabelFromChamberIndex(IndexType) const;  // just for cross-checks
 
   /**
    * Build index used internally in online CSC conditions databases (the 'Igor Index')
@@ -405,20 +416,12 @@ public:
    * (ie=1-2, is=1-4, ir=1-4, ic=1-36, il=1-6) <br>
    * Channels 1-16 in ME1A (is=1, ir=4) are reset to channels 65-80 of ME11.
    */
-  int dbIndex(const CSCDetId & id, int & channel);
+  int dbIndex(const CSCDetId& id, int& channel);
 
 private:
-  void fillChamberLabel() const; // const so it can be called in const function detIdFromChamberIndex
+  void fillChamberLabel() const;  // const so it can be called in const function detIdFromChamberIndex
 
-  mutable std::vector<IndexType> chamberLabel; // mutable so can be filled by fillChamberLabel
-
-
+  mutable std::vector<IndexType> chamberLabel;  // mutable so can be filled by fillChamberLabel
 };
 
 #endif
-
-
-
-
-
-

--- a/DataFormats/MuonDetId/interface/CSCTriggerNumbering.h
+++ b/DataFormats/MuonDetId/interface/CSCTriggerNumbering.h
@@ -13,17 +13,15 @@
 class CSCDetId;
 
 class CSCTriggerNumbering {
-  
- public:
-
+public:
   CSCTriggerNumbering();
   ~CSCTriggerNumbering();
-  
+
   /**
    * The following functions transform standard chamber labels into
    * their corresponding trigger labels.
    */
-  
+
   /**
     * Return trigger-level sector id for an Endcap Muon chamber.
     *
@@ -45,7 +43,7 @@ class CSCTriggerNumbering {
     */
   static int triggerSectorFromLabels(int station, int ring, int chamber);
   static int triggerSectorFromLabels(CSCDetId id);
-  
+
   /**
    * Return trigger-level sub sector id within a sector in station one.
    * 
@@ -109,22 +107,21 @@ class CSCTriggerNumbering {
    * Minimum and Maximum values for trigger specific labels.
    */
 
-  static int maxTriggerCscId()        { return MAX_CSCID; }
-  static int minTriggerCscId()        { return MIN_CSCID; }
-  static int maxTriggerSectorId()     { return MAX_TRIGSECTOR; }
-  static int minTriggerSectorId()     { return MIN_TRIGSECTOR; }
-  static int maxTriggerSubSectorId()  { return MAX_TRIGSUBSECTOR; }
-  static int minTriggerSubSectorId()  { return MIN_TRIGSUBSECTOR+1; }
+  static int maxTriggerCscId() { return MAX_CSCID; }
+  static int minTriggerCscId() { return MIN_CSCID; }
+  static int maxTriggerSectorId() { return MAX_TRIGSECTOR; }
+  static int minTriggerSectorId() { return MIN_TRIGSECTOR; }
+  static int maxTriggerSubSectorId() { return MAX_TRIGSUBSECTOR; }
+  static int minTriggerSubSectorId() { return MIN_TRIGSUBSECTOR + 1; }
 
- private:
-
+private:
   // Below are counts for trigger based labels.
-  
+
   // Max counts for trigger labels.
-  enum eTrigMaxNum{ MAX_TRIGSECTOR=6, MAX_CSCID=9, MAX_TRIGSUBSECTOR = 2 };
+  enum eTrigMaxNum { MAX_TRIGSECTOR = 6, MAX_CSCID = 9, MAX_TRIGSUBSECTOR = 2 };
 
   // Min counts for trigger labels. Again, we count from one.
-  enum eTrigMinNum{ MIN_TRIGSECTOR=1, MIN_CSCID=1, MIN_TRIGSUBSECTOR = 0 };
+  enum eTrigMinNum { MIN_TRIGSECTOR = 1, MIN_CSCID = 1, MIN_TRIGSUBSECTOR = 0 };
 };
 
 #endif

--- a/DataFormats/MuonDetId/interface/DTBtiId.h
+++ b/DataFormats/MuonDetId/interface/DTBtiId.h
@@ -30,85 +30,86 @@
 
 //typedef unsigned char myint8;
 class DTBtiId {
-
- public:
-
+public:
   ///  Constructor
   DTBtiId() : _bti(0) {}
 
   ///  Constructor
-  DTBtiId(const DTSuperLayerId& mu_superlayer_id, 
-	          const int bti_id) : _suplId(mu_superlayer_id),
-                                         _bti(bti_id) {}
+  DTBtiId(const DTSuperLayerId& mu_superlayer_id, const int bti_id) : _suplId(mu_superlayer_id), _bti(bti_id) {}
 
   ///  Constructor
-  DTBtiId(const DTChamberId& mu_stat_id, 
-	          const int superlayer_id, 
-	          const int bti_id) : _suplId(mu_stat_id,superlayer_id),
-                                         _bti(bti_id) {}
+  DTBtiId(const DTChamberId& mu_stat_id, const int superlayer_id, const int bti_id)
+      : _suplId(mu_stat_id, superlayer_id), _bti(bti_id) {}
 
   ///  Constructor
-  DTBtiId(const int wheel_id, 
-	          const int station_id, 
-	          const int sector_id, 
-	          const int superlayer_id, 
-	          const int bti_id) : 
-                          _suplId(wheel_id,station_id,sector_id,superlayer_id),
-                          _bti(bti_id) {}
-  
+  DTBtiId(const int wheel_id, const int station_id, const int sector_id, const int superlayer_id, const int bti_id)
+      : _suplId(wheel_id, station_id, sector_id, superlayer_id), _bti(bti_id) {}
+
   ///  Constructor
-  DTBtiId(const DTBtiId& btiId) :
-                                   _suplId(btiId._suplId), _bti(btiId._bti) {}
- 
+  DTBtiId(const DTBtiId& btiId) : _suplId(btiId._suplId), _bti(btiId._bti) {}
+
   /// Destructor
   virtual ~DTBtiId() {}
 
   /// Returns wheel number
-  inline int wheel()      const { return _suplId.wheel(); }
+  inline int wheel() const { return _suplId.wheel(); }
   /// Returns station number
-  inline int station()    const { return _suplId.station(); }
+  inline int station() const { return _suplId.station(); }
   /// Returns sector number
-  inline int sector()     const { return _suplId.sector(); }
+  inline int sector() const { return _suplId.sector(); }
   /// Returns the superlayer
   inline int superlayer() const { return _suplId.superlayer(); }
   /// Returns the bti
-  inline int bti()        const { return _bti; }
+  inline int bti() const { return _bti; }
   /// Returns the superlayer id
   inline DTSuperLayerId SLId() const { return _suplId; }
 
-  bool operator == ( const DTBtiId& id) const { 
-    if ( wheel()!=id.wheel()) return false;
-    if ( sector()!=id.sector())return false;
-    if ( station()!=id.station())return false;
-    if ( superlayer()!=id.superlayer())return false;
-    if ( _bti!=id.bti())return false;
+  bool operator==(const DTBtiId& id) const {
+    if (wheel() != id.wheel())
+      return false;
+    if (sector() != id.sector())
+      return false;
+    if (station() != id.station())
+      return false;
+    if (superlayer() != id.superlayer())
+      return false;
+    if (_bti != id.bti())
+      return false;
     return true;
   }
 
-  bool operator <  ( const DTBtiId& id) const { 
-    if ( wheel()       < id.wheel()      ) return true;
-    if ( wheel()       > id.wheel()      ) return false;
-  
-    if ( station()     < id.station()    ) return true;
-    if ( station()     > id.station()    ) return false;
-  
-    if ( sector()      < id.sector()     ) return true;
-    if ( sector()      > id.sector()     ) return false;
+  bool operator<(const DTBtiId& id) const {
+    if (wheel() < id.wheel())
+      return true;
+    if (wheel() > id.wheel())
+      return false;
 
-    if ( superlayer()  < id.superlayer() ) return true;
-    if ( superlayer()  > id.superlayer() ) return false;
+    if (station() < id.station())
+      return true;
+    if (station() > id.station())
+      return false;
 
-    if ( bti()         < id.bti()        ) return true;
-    if ( bti()         > id.bti()        ) return false;
+    if (sector() < id.sector())
+      return true;
+    if (sector() > id.sector())
+      return false;
+
+    if (superlayer() < id.superlayer())
+      return true;
+    if (superlayer() > id.superlayer())
+      return false;
+
+    if (bti() < id.bti())
+      return true;
+    if (bti() > id.bti())
+      return false;
 
     return false;
   }
 
-
- private:
-  DTSuperLayerId _suplId; // this is 4 bytes
+private:
+  DTSuperLayerId _suplId;  // this is 4 bytes
   int _bti;
-
 };
 
 #endif

--- a/DataFormats/MuonDetId/interface/DTChamberId.h
+++ b/DataFormats/MuonDetId/interface/DTChamberId.h
@@ -13,10 +13,9 @@
 
 class DTChamberId : public DetId {
 public:
-  /// Default constructor. 
+  /// Default constructor.
   /// Fills the common part in the base and leaves 0 in all other fields
   DTChamberId();
-  
 
   /// Construct from a packed id.
   /// It is required that the packed id represents a valid DT DetId
@@ -26,108 +25,87 @@ public:
   DTChamberId(uint32_t id);
   DTChamberId(DetId id);
 
-
   /// Construct from indexes.
   /// Input values are required to be within legal ranges, otherwise an
   /// exception is thrown.
-  DTChamberId(int wheel, 
-	      int station, 
-	      int sector);
-
+  DTChamberId(int wheel, int station, int sector);
 
   /// Copy Constructor.
   /// Any bits outside the DTChamberId fields are zeroed; apart for
   /// this, no check is done on the vaildity of the values.
   DTChamberId(const DTChamberId& chId);
 
-
   /// Return the wheel number
-  int wheel() const {
-    return int((id_>>wheelStartBit_) & wheelMask_)+ minWheelId -1;
-  }
-
+  int wheel() const { return int((id_ >> wheelStartBit_) & wheelMask_) + minWheelId - 1; }
 
   /// Return the station number
-  int station() const {
-    return ((id_>>stationStartBit_) & stationMask_);
-  }
-
+  int station() const { return ((id_ >> stationStartBit_) & stationMask_); }
 
   /// Return the sector number. Sectors are numbered from 1 to 12,
   /// starting at phi=0 and increasing with phi.
   /// In station 4, where the top and bottom setcors are made of two chambers,
   /// two additional sector numbers are used, 13 (after sector 4, top)
   /// and 14 (after sector 10, bottom).
-  int sector() const {
-    return ((id_>>sectorStartBit_)& sectorMask_);
-  }
-
+  int sector() const { return ((id_ >> sectorStartBit_) & sectorMask_); }
 
   /// lowest station id
-  static const int minStationId=    1;
+  static const int minStationId = 1;
   /// highest station id
-  static const int maxStationId=    4;
-  /// lowest sector id. 0 indicates all sectors (a station) 
-  static const int minSectorId=     0;
+  static const int maxStationId = 4;
+  /// lowest sector id. 0 indicates all sectors (a station)
+  static const int minSectorId = 0;
   /// highest sector id.
-  static const int maxSectorId=    14;
+  static const int maxSectorId = 14;
   /// lowest wheel number
-  static const int minWheelId=     -2;
+  static const int minWheelId = -2;
   /// highest wheel number
-  static const int maxWheelId=      2;
+  static const int maxWheelId = 2;
   /// loweset super layer id. 0 indicates a full chamber
-  static const int minSuperLayerId= 0;
+  static const int minSuperLayerId = 0;
   /// highest superlayer id
-  static const int maxSuperLayerId= 3;
+  static const int maxSuperLayerId = 3;
   /// lowest layer id. 0 indicates a full SL
-  static const int minLayerId=      0;
+  static const int minLayerId = 0;
   /// highest layer id
-  static const int maxLayerId=      4;
+  static const int maxLayerId = 4;
   /// lowest wire id (numbering starts from 1 or 2). 0 indicates a full layer
-  static const int minWireId=       0;
+  static const int minWireId = 0;
   /// highest wire id (chambers have 48 to 96 wires)
-  static const int maxWireId=      97;
- 
+  static const int maxWireId = 97;
 
- protected:
+protected:
   /// two bits would be enough, but  we could use the number "0" as a wildcard
-  static const int wireNumBits_=   7;  
-  static const int wireStartBit_=  3;
-  static const int layerNumBits_=   3;
-  static const int layerStartBit_=  wireStartBit_ + wireNumBits_;
-  static const int slayerNumBits_=  2;
-  static const int slayerStartBit_= layerStartBit_+ layerNumBits_;
-  static const int wheelNumBits_  = 3;
-  static const int wheelStartBit_=  slayerStartBit_ + slayerNumBits_;
-  static const int sectorNumBits_=  4;
-  static const int sectorStartBit_= wheelStartBit_ + wheelNumBits_;
+  static const int wireNumBits_ = 7;
+  static const int wireStartBit_ = 3;
+  static const int layerNumBits_ = 3;
+  static const int layerStartBit_ = wireStartBit_ + wireNumBits_;
+  static const int slayerNumBits_ = 2;
+  static const int slayerStartBit_ = layerStartBit_ + layerNumBits_;
+  static const int wheelNumBits_ = 3;
+  static const int wheelStartBit_ = slayerStartBit_ + slayerNumBits_;
+  static const int sectorNumBits_ = 4;
+  static const int sectorStartBit_ = wheelStartBit_ + wheelNumBits_;
   /// two bits would be enough, but  we could use the number "0" as a wildcard
-  static const int stationNumBits_= 3;
+  static const int stationNumBits_ = 3;
   static const int stationStartBit_ = sectorStartBit_ + sectorNumBits_;
 
+  static const uint32_t wheelMask_ = 0x7;
+  static const uint32_t stationMask_ = 0x7;
+  static const uint32_t sectorMask_ = 0xf;
+  static const uint32_t slMask_ = 0x3;
+  static const uint32_t lMask_ = 0x7;
+  static const uint32_t wireMask_ = 0x7f;
 
-  static const uint32_t wheelMask_=    0x7;
-  static const uint32_t stationMask_=  0x7;
-  static const uint32_t sectorMask_=   0xf;
-  static const uint32_t slMask_=       0x3;
-  static const uint32_t lMask_=        0x7;
-  static const uint32_t wireMask_=    0x7f;
-
-  static const uint32_t layerIdMask_= ~(wireMask_<<wireStartBit_);
-  static const uint32_t slIdMask_ = ~((wireMask_<<wireStartBit_) |
-				      (lMask_<<layerStartBit_));
-  static const uint32_t chamberIdMask_ = ~((wireMask_<<wireStartBit_) |
-					   (lMask_<<layerStartBit_) |
-					   (slMask_<<slayerStartBit_));
+  static const uint32_t layerIdMask_ = ~(wireMask_ << wireStartBit_);
+  static const uint32_t slIdMask_ = ~((wireMask_ << wireStartBit_) | (lMask_ << layerStartBit_));
+  static const uint32_t chamberIdMask_ =
+      ~((wireMask_ << wireStartBit_) | (lMask_ << layerStartBit_) | (slMask_ << slayerStartBit_));
 
   // Perform a consistency check of the id with a DT Id
   // It thorows an exception if this is not the case
   void checkMuonId();
-  
 };
 
-
-std::ostream& operator<<( std::ostream& os, const DTChamberId& id );
+std::ostream& operator<<(std::ostream& os, const DTChamberId& id);
 
 #endif
-

--- a/DataFormats/MuonDetId/interface/DTLayerId.h
+++ b/DataFormats/MuonDetId/interface/DTLayerId.h
@@ -10,61 +10,41 @@
 #include <DataFormats/MuonDetId/interface/DTSuperLayerId.h>
 
 class DTLayerId : public DTSuperLayerId {
- public:
-      
-  /// Default constructor. 
+public:
+  /// Default constructor.
   /// Fills the common part in the base and leaves 0 in all other fields
   DTLayerId();
 
-
-  /// Construct from a packed id.   
+  /// Construct from a packed id.
   /// It is required that the packed id represents a valid DT DetId
   /// (proper Detector and  SubDet fields), otherwise an exception is thrown.
   /// Any bits outside the DTLayerId fields are zeroed; apart for
   /// this, no check is done on the vaildity of the values.
   explicit DTLayerId(uint32_t id);
 
-
   /// Construct from indexes.
   /// Input values are required to be within legal ranges, otherwise an
   /// exception is thrown.
-  DTLayerId(int wheel, 
-	    int station, 
-	    int sector,
-	    int superlayer,
-	    int layer);
-
+  DTLayerId(int wheel, int station, int sector, int superlayer, int layer);
 
   /// Copy Constructor.
   /// Any bits outside the DTLayerId fields are zeroed; apart for
   /// this, no check is done on the vaildity of the values.
   DTLayerId(const DTLayerId& layerId);
 
-
   /// Constructor from a camberId and SL and layer numbers
   DTLayerId(const DTChamberId& chId, int superlayer, int layer);
-
 
   /// Constructor from a SuperLayerId and layer number
   DTLayerId(const DTSuperLayerId& slId, int layer);
 
-
   /// Return the layer number
-  int layer() const {
-    return ((id_>>layerStartBit_)&lMask_);
-  }
-
+  int layer() const { return ((id_ >> layerStartBit_) & lMask_); }
 
   /// Return the corresponding SuperLayerId
-  DTSuperLayerId superlayerId() const {
-    return DTSuperLayerId(id_ & slIdMask_);
-  }
-  
-
-
+  DTSuperLayerId superlayerId() const { return DTSuperLayerId(id_ & slIdMask_); }
 };
 
-
-std::ostream& operator<<( std::ostream& os, const DTLayerId& id );
+std::ostream& operator<<(std::ostream& os, const DTLayerId& id);
 
 #endif

--- a/DataFormats/MuonDetId/interface/DTSectCollId.h
+++ b/DataFormats/MuonDetId/interface/DTSectCollId.h
@@ -16,53 +16,33 @@
 #define DT_SECT_COLL_ID_H
 
 class DTSectCollId {
-
- public:
+public:
   //  Constructor
-  DTSectCollId():
-    _wheel(  0),
-    _sector( 0) {}
+  DTSectCollId() : _wheel(0), _sector(0) {}
 
-  DTSectCollId(int wheel_id,  
-	      int sector_id): 
-    _wheel(wheel_id),
-    _sector(sector_id) {}
-  
+  DTSectCollId(int wheel_id, int sector_id) : _wheel(wheel_id), _sector(sector_id) {}
 
-   DTSectCollId(const  DTSectCollId& statId) :
-    _wheel(statId._wheel),
-    _sector(statId._sector) {}
-
+  DTSectCollId(const DTSectCollId& statId) : _wheel(statId._wheel), _sector(statId._sector) {}
 
   // Destructor
 
-  // Operations 
-  inline int wheel()   const { return _wheel; }
-  inline int sector()  const { return _sector; }
+  // Operations
+  inline int wheel() const { return _wheel; }
+  inline int sector() const { return _sector; }
 
-  inline bool operator == ( const DTSectCollId & ) const;
-  inline bool operator != ( const DTSectCollId & ) const;
-  inline bool operator < ( const  DTSectCollId& ) const;
-  
-  inline  DTSectCollId & operator = ( const  DTSectCollId& );
+  inline bool operator==(const DTSectCollId&) const;
+  inline bool operator!=(const DTSectCollId&) const;
+  inline bool operator<(const DTSectCollId&) const;
 
- private:
+  inline DTSectCollId& operator=(const DTSectCollId&);
+
+private:
   int _wheel;
   int _sector;
-
 };
 
 #include <iosfwd>
-std::ostream& operator<<(std::ostream &os, const  DTSectCollId& id)  ;
+std::ostream& operator<<(std::ostream& os, const DTSectCollId& id);
 #include "DataFormats/MuonDetId/interface/DTSectCollId.icc"
 
 #endif
-
-
-
-
-
-
-
-
-

--- a/DataFormats/MuonDetId/interface/DTSectCollId.icc
+++ b/DataFormats/MuonDetId/interface/DTSectCollId.icc
@@ -2,35 +2,33 @@
 //--------------
 // Operations --
 //--------------
-bool DTSectCollId::operator== (const DTSectCollId& id) const
-{ 
-  if ( _wheel!=id.wheel()) return false;
-  if ( _sector!=id.sector())return false;
+bool DTSectCollId::operator==(const DTSectCollId& id) const {
+  if (_wheel != id.wheel())
+    return false;
+  if (_sector != id.sector())
+    return false;
   return true;
 }
 
-bool DTSectCollId::operator!= (const DTSectCollId& id) const
-{
-  return !(*this==id);
-}
+bool DTSectCollId::operator!=(const DTSectCollId& id) const { return !(*this == id); }
 
-bool DTSectCollId::operator < (const DTSectCollId& id) const
-{ 
-  if ( wheel()       < id.wheel()      ) return true;
-  if ( wheel()       > id.wheel()      ) return false;
-    
-  if ( sector()      < id.sector()     ) return true;
-  if ( sector()      > id.sector()     ) return false;
+bool DTSectCollId::operator<(const DTSectCollId& id) const {
+  if (wheel() < id.wheel())
+    return true;
+  if (wheel() > id.wheel())
+    return false;
+
+  if (sector() < id.sector())
+    return true;
+  if (sector() > id.sector())
+    return false;
 
   return false;
 }
-DTSectCollId & 
-DTSectCollId::operator = ( const DTSectCollId& statId){
+DTSectCollId& DTSectCollId::operator=(const DTSectCollId& statId) {
   _wheel = statId._wheel;
   _sector = statId._sector;
-  return *this; 
+  return *this;
 }
-
-
 
 //------------

--- a/DataFormats/MuonDetId/interface/DTSuperLayerId.h
+++ b/DataFormats/MuonDetId/interface/DTSuperLayerId.h
@@ -9,14 +9,11 @@
 
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
 
-
 class DTSuperLayerId : public DTChamberId {
 public:
-
   /// Default constructor. It fills the common part in the base
   /// and leaves 0 in all other fields
   DTSuperLayerId();
-
 
   /// Construct from a packed id.
   /// It is required that the packed id represents a valid DT DetId
@@ -25,48 +22,31 @@ public:
   /// this, no check is done on the vaildity of the values.
   explicit DTSuperLayerId(uint32_t id);
 
-
   /// Construct from indexes.
   /// Input values are required to be within legal ranges, otherwise an
   /// exception is thrown.
-  DTSuperLayerId(int wheel, 
-		 int station, 
-		 int sector,
-		 int superlayer);
-
+  DTSuperLayerId(int wheel, int station, int sector, int superlayer);
 
   /// Copy Constructor.
   /// Any bits outside the DTChamberId fields are zeroed; apart for
   /// this, no check is done on the vaildity of the values.
   DTSuperLayerId(const DTSuperLayerId& slId);
 
-
   /// Constructor from a DTChamberId and SL number.
   DTSuperLayerId(const DTChamberId& chId, int superlayer);
 
-
   /// Return the superlayer number
-  int superLayer() const {
-    return ((id_>>slayerStartBit_)&slMask_);
-  }
-
+  int superLayer() const { return ((id_ >> slayerStartBit_) & slMask_); }
 
   /// Return the superlayer number (deprecated method name)
-  int superlayer() const {
-    return superLayer();
-  }
-
+  int superlayer() const { return superLayer(); }
 
   /// Return the corresponding ChamberId
-  DTChamberId chamberId() const {
-    return DTChamberId(id_ & chamberIdMask_);
-  }
+  DTChamberId chamberId() const { return DTChamberId(id_ & chamberIdMask_); }
 
- private:
-
+private:
 };
 
-std::ostream& operator<<( std::ostream& os, const DTSuperLayerId& id );
+std::ostream& operator<<(std::ostream& os, const DTSuperLayerId& id);
 
 #endif
-

--- a/DataFormats/MuonDetId/interface/DTTracoId.h
+++ b/DataFormats/MuonDetId/interface/DTTracoId.h
@@ -27,80 +27,78 @@
 //                      DTTracoChip
 //---------------------------------------------------
 
-
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------
 
 class DTTracoId {
-
- public:
-
+public:
   ///  Constructor
   DTTracoId() : _traco(0) {}
 
   ///  Constructor
-  DTTracoId(const DTChamberId& mu_stat_id, 
-                    const int traco_id) : _statId(mu_stat_id),
-                                             _traco(traco_id) {}
+  DTTracoId(const DTChamberId& mu_stat_id, const int traco_id) : _statId(mu_stat_id), _traco(traco_id) {}
 
   ///  Constructor
-  DTTracoId(const int wheel_id, 
-	        const int station_id, 
-                const int sector_id, 
-                const int traco_id) :
-                  _statId(wheel_id,station_id,sector_id),
-                  _traco(traco_id) {}
- 
+  DTTracoId(const int wheel_id, const int station_id, const int sector_id, const int traco_id)
+      : _statId(wheel_id, station_id, sector_id), _traco(traco_id) {}
+
   ///  Constructor
-  DTTracoId(const DTTracoId& tracoId) :
-                  _statId(tracoId._statId), 
-                  _traco(tracoId._traco) {}
- 
+  DTTracoId(const DTTracoId& tracoId) : _statId(tracoId._statId), _traco(tracoId._traco) {}
+
   /// Destructor
   virtual ~DTTracoId() {}
 
   /// Returns wheel number
-  inline int wheel()   const { return _statId.wheel(); }
+  inline int wheel() const { return _statId.wheel(); }
   /// Returns station number
   inline int station() const { return _statId.station(); }
   /// Returns sector number
-  inline int sector()  const { return _statId.sector(); }
+  inline int sector() const { return _statId.sector(); }
   /// Returns the traco
-  inline int traco()   const { return _traco; }
+  inline int traco() const { return _traco; }
   /// Returns the chamber id
   inline DTChamberId ChamberId() const { return _statId; }
 
-  bool operator == ( const DTTracoId& id) const { 
-    if ( wheel()!=id.wheel()) return false;
-    if ( sector()!=id.sector())return false;
-    if ( station()!=id.station())return false;
-    if ( _traco!=id.traco())return false;
+  bool operator==(const DTTracoId& id) const {
+    if (wheel() != id.wheel())
+      return false;
+    if (sector() != id.sector())
+      return false;
+    if (station() != id.station())
+      return false;
+    if (_traco != id.traco())
+      return false;
     return true;
   }
 
-  bool operator <  ( const DTTracoId& id) const { 
-    if ( wheel()       < id.wheel()      ) return true;
-    if ( wheel()       > id.wheel()      ) return false;
-  
-    if ( station()     < id.station()    ) return true;
-    if ( station()     > id.station()    ) return false;
-    
-    if ( sector()      < id.sector()     ) return true;
-    if ( sector()      > id.sector()     ) return false;
+  bool operator<(const DTTracoId& id) const {
+    if (wheel() < id.wheel())
+      return true;
+    if (wheel() > id.wheel())
+      return false;
 
-    if ( traco()         < id.traco()    ) return true;
-    if ( traco()         > id.traco()    ) return false;
+    if (station() < id.station())
+      return true;
+    if (station() > id.station())
+      return false;
+
+    if (sector() < id.sector())
+      return true;
+    if (sector() > id.sector())
+      return false;
+
+    if (traco() < id.traco())
+      return true;
+    if (traco() > id.traco())
+      return false;
 
     return false;
-  
   }
 
-
- private:
-  DTChamberId _statId; // this is 3 bytes
+private:
+  DTChamberId _statId;  // this is 3 bytes
   int _traco;
-
 };
 
 #endif

--- a/DataFormats/MuonDetId/interface/DTWireId.h
+++ b/DataFormats/MuonDetId/interface/DTWireId.h
@@ -9,66 +9,44 @@
 
 #include <DataFormats/MuonDetId/interface/DTLayerId.h>
 
-
-class DTWireId :public DTLayerId {
- public:
-      
+class DTWireId : public DTLayerId {
+public:
   /// Default constructor.
   /// Fills the common part in the base and leaves 0 in all other fields
   DTWireId();
 
-
-  /// Construct from a packed id. 
+  /// Construct from a packed id.
   /// It is required that the packed id represents a valid DT DetId
   /// (proper Detector and  SubDet fields), otherwise an exception is thrown.
   /// No check is done on the vaildity of the values.
   explicit DTWireId(uint32_t id);
 
-
-  /// Construct from fully qualified identifier. 
+  /// Construct from fully qualified identifier.
   /// Input values are required to be within legal ranges, otherwise an
   /// exception is thrown.
-  DTWireId(int wheel, 
-	   int station, 
-	   int sector,
-	   int superlayer,
-	   int layer,
-	   int wire);
-  
+  DTWireId(int wheel, int station, int sector, int superlayer, int layer, int wire);
 
   /// Copy Constructor.
   DTWireId(const DTWireId& wireId);
 
-
   /// Constructor from a CamberId and SL, layer and wire numbers
   DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire);
-
 
   /// Constructor from a SuperLayerId and layer and wire numbers
   DTWireId(const DTSuperLayerId& slId, int layer, int wire);
 
-
   /// Constructor from a layerId and a wire number
   DTWireId(const DTLayerId& layerId, int wire);
 
-
   /// Return the wire number
-  int wire() const {
-    return ((id_>>wireStartBit_)&wireMask_);
-  }
-
+  int wire() const { return ((id_ >> wireStartBit_) & wireMask_); }
 
   /// Return the corresponding LayerId
-  DTLayerId layerId() const {
-    return DTLayerId(id_ & layerIdMask_);
-  }
-  
+  DTLayerId layerId() const { return DTLayerId(id_ & layerIdMask_); }
 
- private:
- 
-
+private:
 };
 
-std::ostream& operator<<( std::ostream& os, const DTWireId& id );
+std::ostream& operator<<(std::ostream& os, const DTWireId& id);
 
 #endif

--- a/DataFormats/MuonDetId/interface/ME0DetId.h
+++ b/DataFormats/MuonDetId/interface/ME0DetId.h
@@ -13,10 +13,8 @@
 #include <iosfwd>
 #include <iostream>
 
-class ME0DetId :public DetId {
-  
- public:
-      
+class ME0DetId : public DetId {
+public:
   ME0DetId();
 
   /// Construct from a packed id. It is required that the Detector part of
@@ -24,106 +22,82 @@ class ME0DetId :public DetId {
   ME0DetId(uint32_t id);
   ME0DetId(DetId id);
 
-
   /// Construct from fully qualified identifier.
-  ME0DetId(int region, 
-	   int layer,
-	   int chamber,
-	   int roll);
-	   
+  ME0DetId(int region, int layer, int chamber, int roll);
 
   /// Sort Operator based on the raw detector id
-  bool operator < (const ME0DetId& r) const{
-    if (this->layer() ==  r.layer()  ){
-      return this->rawId()<r.rawId();
-    }
-    else{
-      return (this->layer() >  r.layer());
+  bool operator<(const ME0DetId& r) const {
+    if (this->layer() == r.layer()) {
+      return this->rawId() < r.rawId();
+    } else {
+      return (this->layer() > r.layer());
     }
   }
 
   /// Region id: 0 for Barrel Not in use, +/-1 For +/- Endcap
-  int region() const{
-    return int((id_>>RegionStartBit_) & RegionMask_) + minRegionId;
-  }
+  int region() const { return int((id_ >> RegionStartBit_) & RegionMask_) + minRegionId; }
 
-  /// Chamber id: it identifies a chamber in a ring it goes from 1 to 36 
-  int chamber() const{
-    return int((id_>>ChamberStartBit_) & ChamberMask_) + minChamberId;
-  }
+  /// Chamber id: it identifies a chamber in a ring it goes from 1 to 36
+  int chamber() const { return int((id_ >> ChamberStartBit_) & ChamberMask_) + minChamberId; }
 
-  /// Layer id: each chamber has six layers of chambers: layer 1 is the inner layer and layer 6 is the outer layer 
-  int layer() const{
-    return int((id_>>LayerStartBit_) & LayerMask_) + minLayerId;
-  }
+  /// Layer id: each chamber has six layers of chambers: layer 1 is the inner layer and layer 6 is the outer layer
+  int layer() const { return int((id_ >> LayerStartBit_) & LayerMask_) + minLayerId; }
 
-  /// Roll id  (also known as eta partition): each chamber is divided along the strip direction in  
+  /// Roll id  (also known as eta partition): each chamber is divided along the strip direction in
   /// several parts  (rolls) ME0 up to 10
-  int roll() const{
-    return int((id_>>RollStartBit_) & RollMask_) + minRollId; // value 0 is used as wild card
+  int roll() const {
+    return int((id_ >> RollStartBit_) & RollMask_) + minRollId;  // value 0 is used as wild card
   }
 
   /// Return the corresponding ChamberId (mask layers)
-  ME0DetId chamberId() const {
-    return ME0DetId(id_ & chamberIdMask_);
-  }
+  ME0DetId chamberId() const { return ME0DetId(id_ & chamberIdMask_); }
   /// Return the corresponding LayerId (mask eta partition)
-  ME0DetId layerId() const {
-    return ME0DetId(id_ & layerIdMask_);
-  }
+  ME0DetId layerId() const { return ME0DetId(id_ & layerIdMask_); }
 
-  //Return the stationId, always 1 for now 
-  int station() const{
-    return 1;
-  }
-
+  //Return the stationId, always 1 for now
+  int station() const { return 1; }
 
   /// For future modifications (implement more layers)
-  int nlayers() const{
-    return int(maxLayerId);
-  }
+  int nlayers() const { return int(maxLayerId); }
 
-  static const int minRegionId=     -1;
-  static const int maxRegionId=      1;
- 
-  static const int minChamberId=     0;
-  static const int maxChamberId=     18; // ME0 ring consists of 18 chambers spanning 20 degrees
+  static const int minRegionId = -1;
+  static const int maxRegionId = 1;
 
-  static const int minLayerId=     0;
-  static const int maxLayerId=    6;
+  static const int minChamberId = 0;
+  static const int maxChamberId = 18;  // ME0 ring consists of 18 chambers spanning 20 degrees
 
-  static const int minRollId=	  0;  
-  static const int maxRollId=	  10; // ME0 layer consists of 10 etapartitions
+  static const int minLayerId = 0;
+  static const int maxLayerId = 6;
 
- private:
-  static const int RegionNumBits_  =  2;
-  static const int RegionStartBit_ =  0;  
-  static const int RegionMask_     =  0X3;
+  static const int minRollId = 0;
+  static const int maxRollId = 10;  // ME0 layer consists of 10 etapartitions
 
-  static const int ChamberNumBits_  =  6;
-  static const int ChamberStartBit_ =  RegionStartBit_+RegionNumBits_;  
-  static const unsigned int ChamberMask_     =  0X3F;
+private:
+  static const int RegionNumBits_ = 2;
+  static const int RegionStartBit_ = 0;
+  static const int RegionMask_ = 0X3;
 
-  static const int LayerNumBits_  =  5;
-  static const int LayerStartBit_ =  ChamberStartBit_+ChamberNumBits_;  
-  static const unsigned int LayerMask_     =  0X1F;
+  static const int ChamberNumBits_ = 6;
+  static const int ChamberStartBit_ = RegionStartBit_ + RegionNumBits_;
+  static const unsigned int ChamberMask_ = 0X3F;
 
-  static const int RollNumBits_  =  5;
-  static const int RollStartBit_ =  LayerStartBit_+LayerNumBits_;  
-  static const unsigned int RollMask_     =  0X1F;
- 
-  static const uint32_t chamberIdMask_ = ~( (LayerMask_<<LayerStartBit_) | (RollMask_<<RollStartBit_));
-  static const uint32_t layerIdMask_ = ~(RollMask_<<RollStartBit_);
+  static const int LayerNumBits_ = 5;
+  static const int LayerStartBit_ = ChamberStartBit_ + ChamberNumBits_;
+  static const unsigned int LayerMask_ = 0X1F;
 
- private:
-  void init(int region, 
-	    int layer,
-	    int chamber,
-	    int roll);
-  
+  static const int RollNumBits_ = 5;
+  static const int RollStartBit_ = LayerStartBit_ + LayerNumBits_;
+  static const unsigned int RollMask_ = 0X1F;
+
+  static const uint32_t chamberIdMask_ = ~((LayerMask_ << LayerStartBit_) | (RollMask_ << RollStartBit_));
+  static const uint32_t layerIdMask_ = ~(RollMask_ << RollStartBit_);
+
+private:
+  void init(int region, int layer, int chamber, int roll);
+
   int trind;
-}; // ME0DetId
+};  // ME0DetId
 
-std::ostream& operator<<( std::ostream& os, const ME0DetId& id );
+std::ostream& operator<<(std::ostream& os, const ME0DetId& id);
 
 #endif

--- a/DataFormats/MuonDetId/interface/MuonSubdetId.h
+++ b/DataFormats/MuonDetId/interface/MuonSubdetId.h
@@ -8,13 +8,11 @@
 
 class MuonSubdetId {
 public:
-
-  static constexpr int DT= 1;
-  static constexpr int CSC=2;
-  static constexpr int RPC=3;
-  static constexpr int GEM=4;
-  static constexpr int ME0=5;
+  static constexpr int DT = 1;
+  static constexpr int CSC = 2;
+  static constexpr int RPC = 3;
+  static constexpr int GEM = 4;
+  static constexpr int ME0 = 5;
 };
 
 #endif
-

--- a/DataFormats/MuonDetId/interface/RPCCompDetId.h
+++ b/DataFormats/MuonDetId/interface/RPCCompDetId.h
@@ -4,7 +4,7 @@
 //
 // Package:     MuonDetId
 // Class  :     RPCCompDetId
-// 
+//
 /**\class RPCCompDetId RPCCompDetId.h DataFormats/MuonDetId/interface/RPCCompDetId.h
 
  Description: DetId for composite RPC objects
@@ -18,10 +18,8 @@
 #include <FWCore/Utilities/interface/Exception.h>
 #include <string>
 
-class RPCCompDetId :public DetId {
-  
- public:
-      
+class RPCCompDetId : public DetId {
+public:
   RPCCompDetId();
 
   /// Construct from a packed id. It is required that the Detector part of
@@ -29,21 +27,14 @@ class RPCCompDetId :public DetId {
   RPCCompDetId(uint32_t id);
   RPCCompDetId(DetId id);
 
-
   /// Construct from fully qualified identifier.
-  RPCCompDetId(int region, 
-	       int ring,
-	       int station, 
-	       int sector,
-	       int layer,
-	       int subsector,
-	       int type);
+  RPCCompDetId(int region, int ring, int station, int sector, int layer, int subsector, int type);
 
   /// Construct from name stored in DB
   RPCCompDetId(const std::string& dbname, int type);
 
   /// Sort Operator based on the name
-  bool operator < (const RPCCompDetId& r) const;
+  bool operator<(const RPCCompDetId& r) const;
 
   int region() const;
   int ring() const;
@@ -54,83 +45,77 @@ class RPCCompDetId :public DetId {
   int layer() const;
   int subsector() const;
   int type() const;
-  std::string dbname() const; 
+  std::string dbname() const;
 
-  static const int minRegionId=     -1;
-  static const int maxRegionId=      1;
-  static const int allRegionId=minRegionId-1;
- 
-  static const int minRingForwardId=   1;
-  static const int maxRingForwardId=   3;
-  static const int minRingBarrelId=   -2;
-  static const int maxRingBarrelId=    2;
-  static const int RingBarrelOffSet=   3;
-  static const int allRingId=minRingBarrelId-1; 
- 
-  static const int minStationId=     1;
-  static const int maxStationId=     4;
-  static const int allStationId=minStationId-1; 
+  static const int minRegionId = -1;
+  static const int maxRegionId = 1;
+  static const int allRegionId = minRegionId - 1;
 
-  static const int minSectorId=     1;
-  static const int maxSectorId=     36;
-  static const int minSectorBarrelId=     1;
-  static const int maxSectorBarrelId=     12;
-  static const int minSectorForwardId=     1;
-  static const int maxSectorForwardId=    36;
-  static const int allSectorId=minSectorId-1; 
+  static const int minRingForwardId = 1;
+  static const int maxRingForwardId = 3;
+  static const int minRingBarrelId = -2;
+  static const int maxRingBarrelId = 2;
+  static const int RingBarrelOffSet = 3;
+  static const int allRingId = minRingBarrelId - 1;
 
-  static const int minLayerId=     1;
-  static const int maxLayerId=     2;
-  static const int allLayerId=minLayerId-1; 
-  
+  static const int minStationId = 1;
+  static const int maxStationId = 4;
+  static const int allStationId = minStationId - 1;
 
-  static const int minSubSectorId= 1;
-  static const int maxSubSectorId= 2;
-  static const int allSubSectorId=minSubSectorId-1; 
+  static const int minSectorId = 1;
+  static const int maxSectorId = 36;
+  static const int minSectorBarrelId = 1;
+  static const int maxSectorBarrelId = 12;
+  static const int minSectorForwardId = 1;
+  static const int maxSectorForwardId = 36;
+  static const int allSectorId = minSectorId - 1;
 
- private:
-  static const int RegionNumBits_  =  2;
-  static const int RegionStartBit_ =  0;  
-  static const int RegionMask_     =  0X3;
+  static const int minLayerId = 1;
+  static const int maxLayerId = 2;
+  static const int allLayerId = minLayerId - 1;
 
-  static const int RingNumBits_  =  3;
-  static const int RingStartBit_ =  RegionStartBit_+RegionNumBits_;  
-  static const unsigned int RingMask_     =  0X7;
+  static const int minSubSectorId = 1;
+  static const int maxSubSectorId = 2;
+  static const int allSubSectorId = minSubSectorId - 1;
 
-  static const int StationNumBits_  =  3;
-  static const int StationStartBit_ =  RingStartBit_+RingNumBits_;  
-  static const unsigned int StationMask_     =  0X7;
+private:
+  static const int RegionNumBits_ = 2;
+  static const int RegionStartBit_ = 0;
+  static const int RegionMask_ = 0X3;
 
-  static const int SectorNumBits_  =  6;
-  static const int SectorStartBit_ =  StationStartBit_+StationNumBits_;  
-  static const unsigned int SectorMask_     =  0X3F;
+  static const int RingNumBits_ = 3;
+  static const int RingStartBit_ = RegionStartBit_ + RegionNumBits_;
+  static const unsigned int RingMask_ = 0X7;
 
-  static const int LayerNumBits_  =  2;
-  static const int LayerStartBit_ =  SectorStartBit_+SectorNumBits_;  
-  static const unsigned int LayerMask_     =  0X3;
+  static const int StationNumBits_ = 3;
+  static const int StationStartBit_ = RingStartBit_ + RingNumBits_;
+  static const unsigned int StationMask_ = 0X7;
 
-  static const int SubSectorNumBits_  =  2;
-  static const int SubSectorStartBit_ =  LayerStartBit_+LayerNumBits_;  
-  static const unsigned int SubSectorMask_     =  0X3;
+  static const int SectorNumBits_ = 6;
+  static const int SectorStartBit_ = StationStartBit_ + StationNumBits_;
+  static const unsigned int SectorMask_ = 0X3F;
 
+  static const int LayerNumBits_ = 2;
+  static const int LayerStartBit_ = SectorStartBit_ + SectorNumBits_;
+  static const unsigned int LayerMask_ = 0X3;
 
- private:
-  void init(int region, 
-	    int ring,
-	    int station, 
-	    int sector,
-	    int layer,
-	    int subsector);
+  static const int SubSectorNumBits_ = 2;
+  static const int SubSectorStartBit_ = LayerStartBit_ + LayerNumBits_;
+  static const unsigned int SubSectorMask_ = 0X3;
+
+private:
+  void init(int region, int ring, int station, int sector, int layer, int subsector);
 
   void init();
   void initGas();
   std::string gasDBname() const;
- private:
+
+private:
   std::string _dbname;
   int _type;
 
-}; // RPCCompDetId
+};  // RPCCompDetId
 
-std::ostream& operator<<( std::ostream& os, const RPCCompDetId& id );
+std::ostream& operator<<(std::ostream& os, const RPCCompDetId& id);
 
 #endif

--- a/DataFormats/MuonDetId/interface/RPCDetId.h
+++ b/DataFormats/MuonDetId/interface/RPCDetId.h
@@ -13,10 +13,8 @@
 
 #include <iosfwd>
 
-class RPCDetId :public DetId {
-  
- public:
-      
+class RPCDetId : public DetId {
+public:
   RPCDetId();
 
   /// Construct from a packed id. It is required that the Detector part of
@@ -24,193 +22,153 @@ class RPCDetId :public DetId {
   RPCDetId(uint32_t id);
   RPCDetId(DetId id);
 
-
   /// Construct from fully qualified identifier.
-  RPCDetId(int region, 
-	   int ring,
-	   int station, 
-	   int sector,
-	   int layer,
-	   int subsector,
-	   int roll);
-	   
+  RPCDetId(int region, int ring, int station, int sector, int layer, int subsector, int roll);
 
   /// Sort Operator based on the raw detector id
-  bool operator < (const RPCDetId& r) const{
-    if (r.station() == this->station()  ){
-      if (this->layer() ==  r.layer()  ){
-
-	return this->rawId()<r.rawId();
+  bool operator<(const RPCDetId& r) const {
+    if (r.station() == this->station()) {
+      if (this->layer() == r.layer()) {
+        return this->rawId() < r.rawId();
+      } else {
+        return (this->layer() < r.layer());
       }
-      else{
-	return (this->layer() < r.layer());
-      }
-    }
-    else {
+    } else {
       return this->station() < r.station();
     }
   }
 
-  void buildfromDB(int region, int ring, int layer, int sector, 
-		   const std::string& subsector,
-		   const std::string& roll,
-		   const std::string& dbname);
+  void buildfromDB(int region,
+                   int ring,
+                   int layer,
+                   int sector,
+                   const std::string& subsector,
+                   const std::string& roll,
+                   const std::string& dbname);
 
   /// Built from the trigger det Index
   void buildfromTrIndex(int trIndex);
 
   /// Region id: 0 for Barrel, +/-1 For +/- Endcap
-  int region() const{
-    return int((id_>>RegionStartBit_) & RegionMask_) + minRegionId;
-  }
-
+  int region() const { return int((id_ >> RegionStartBit_) & RegionMask_) + minRegionId; }
 
   /// Ring id: Wheel number in Barrel (from -2 to +2) Ring Number in Endcap (from 1 to 3)
-  /// Ring has a different meaning in Barrel and Endcap! In Barrel it is wheel, in Endcap 
-  /// it is the physical ring located on a disk (a disk contains three rings). In Endcap 
+  /// Ring has a different meaning in Barrel and Endcap! In Barrel it is wheel, in Endcap
+  /// it is the physical ring located on a disk (a disk contains three rings). In Endcap
   /// the ring is the group of chambers with same r (distance of beam axis) and increasing phi
-  int ring() const{
-  
-    int ring_= (id_>>RingStartBit_) & RingMask_;
-    
-    if(ring_ <RingBarrelOffSet){
-    
-    	if(this->region() == 0)
-	{
-    	 throw cms::Exception("InvalidDetId") << "RPCDetId ctor:" 
-					 << " Ring - Region Inconsistency, " 
-					 << " region "<< this->region()
-					 << " ring "<<ring_
-					 << std::endl;
-	}
-	 
-    	return int(ring_ + minRingForwardId);
+  int ring() const {
+    int ring_ = (id_ >> RingStartBit_) & RingMask_;
 
-    } else { // if(ring_ >= RingBarrelOffSet) 
+    if (ring_ < RingBarrelOffSet) {
+      if (this->region() == 0) {
+        throw cms::Exception("InvalidDetId") << "RPCDetId ctor:"
+                                             << " Ring - Region Inconsistency, "
+                                             << " region " << this->region() << " ring " << ring_ << std::endl;
+      }
+
+      return int(ring_ + minRingForwardId);
+
+    } else {  // if(ring_ >= RingBarrelOffSet)
       return int(ring_ - RingBarrelOffSet + minRingBarrelId);
     }
   }
 
   /// Station id : For Barrel: the four groups of chambers at same r (distance from beam axis) and increasing phi
   ///              For Endcap: the three groups of chambers at same z (distance from interaction point), i.e. the disk
-  int station() const{
-    return int((id_>>StationStartBit_) & StationMask_) + minStationId;
-  }
+  int station() const { return int((id_ >> StationStartBit_) & StationMask_) + minStationId; }
 
+  /// Sector id: the group of chambers at same phi (and increasing r)
+  int sector() const { return int((id_ >> SectorStartBit_) & SectorMask_) + (minSectorId + 1); }
 
-  /// Sector id: the group of chambers at same phi (and increasing r) 
-  int sector() const{
-    return int((id_>>SectorStartBit_) & SectorMask_) + (minSectorId+1);
-  }
-
-  /// Layer id: each station can have two layers of chambers: layer 1 is the inner chamber and layer 2 is the outer chamber (when present)  
+  /// Layer id: each station can have two layers of chambers: layer 1 is the inner chamber and layer 2 is the outer chamber (when present)
   /// Only in Barrel: RB1 and RB2.
-  int layer() const{
-    return int((id_>>LayerStartBit_) & LayerMask_) + minLayerId;
+  int layer() const { return int((id_ >> LayerStartBit_) & LayerMask_) + minLayerId; }
+
+  /// SubSector id : some sectors are divided along the phi direction in subsectors (from 1 to 4 in Barrel, from 1 to 6 in Endcap)
+  int subsector() const { return int((id_ >> SubSectorStartBit_) & SubSectorMask_) + (minSubSectorId + 1); }
+
+  /// Roll id  (also known as eta partition): each chamber is divided along the strip direction in
+  /// two or three parts (rolls) for Barrel and two, three or four parts for endcap
+  int roll() const {
+    return int((id_ >> RollStartBit_) & RollMask_);  // value 0 is used as wild card
   }
 
-
-  /// SubSector id : some sectors are divided along the phi direction in subsectors (from 1 to 4 in Barrel, from 1 to 6 in Endcap) 
-  int subsector() const{
-    return int((id_>>SubSectorStartBit_) & SubSectorMask_) + (minSubSectorId+1);
-  }
-
- /// Roll id  (also known as eta partition): each chamber is divided along the strip direction in  
- /// two or three parts (rolls) for Barrel and two, three or four parts for endcap
-  int roll() const{
-    return int((id_>>RollStartBit_) & RollMask_); // value 0 is used as wild card
-  }
-
-
-  int trIndex() const{
-    return trind;
-  }
+  int trIndex() const { return trind; }
 
   /// Return the corresponding ChamberId
-  RPCDetId chamberId() const {
-    return RPCDetId(id_ & chamberIdMask_);
-  }
+  RPCDetId chamberId() const { return RPCDetId(id_ & chamberIdMask_); }
 
+  static const int minRegionId = -1;
+  static const int maxRegionId = 1;
 
-  static const int minRegionId=     -1;
-  static const int maxRegionId=      1;
- 
-  static const int minRingForwardId=   1;
-  static const int maxRingForwardId=   3;
-  static const int minRingBarrelId=   -2;
-  static const int maxRingBarrelId=    2;
-  static const int RingBarrelOffSet=   3;
- 
-  static const int minStationId=     1;
-  static const int maxStationId=     4;
+  static const int minRingForwardId = 1;
+  static const int maxRingForwardId = 3;
+  static const int minRingBarrelId = -2;
+  static const int maxRingBarrelId = 2;
+  static const int RingBarrelOffSet = 3;
 
-  static const int minSectorId=     0;
-  static const int maxSectorId=     12;
-  static const int minSectorBarrelId=     1;
-  static const int maxSectorBarrelId=     12;
-  static const int minSectorForwardId=     1;
-  static const int maxSectorForwardId=     6;
+  static const int minStationId = 1;
+  static const int maxStationId = 4;
 
-  static const int minLayerId=     1;
-  static const int maxLayerId=     2;
+  static const int minSectorId = 0;
+  static const int maxSectorId = 12;
+  static const int minSectorBarrelId = 1;
+  static const int maxSectorBarrelId = 12;
+  static const int minSectorForwardId = 1;
+  static const int maxSectorForwardId = 6;
 
-  static const int minSubSectorId=	 0;
-  static const int maxSubSectorId=	 6;
-  static const int minSubSectorBarrelId=	 1;
-  static const int maxSubSectorBarrelId=	 4;
-  static const int minSubSectorForwardId=	 1;
-  static const int maxSubSectorForwardId=	 6;
+  static const int minLayerId = 1;
+  static const int maxLayerId = 2;
 
-  static const int minRollId=	  0;
-  static const int maxRollId=	  5; // used to be 4 ... need 5 for upgrade 
-  // if we decide to divide the upgrade RE3/1 and RE4/1 up to eta=2.4 
-  // and we want basically to have 0.10 eta / roll ...
+  static const int minSubSectorId = 0;
+  static const int maxSubSectorId = 6;
+  static const int minSubSectorBarrelId = 1;
+  static const int maxSubSectorBarrelId = 4;
+  static const int minSubSectorForwardId = 1;
+  static const int maxSubSectorForwardId = 6;
 
+  static const int minRollId = 0;
+  static const int maxRollId = 5;  // used to be 4 ... need 5 for upgrade
+                                   // if we decide to divide the upgrade RE3/1 and RE4/1 up to eta=2.4
+                                   // and we want basically to have 0.10 eta / roll ...
 
- private:
-  static const int RegionNumBits_  =  2;
-  static const int RegionStartBit_ =  0;  
-  static const int RegionMask_     =  0X3;
+private:
+  static const int RegionNumBits_ = 2;
+  static const int RegionStartBit_ = 0;
+  static const int RegionMask_ = 0X3;
 
-  static const int RingNumBits_  =  3;
-  static const int RingStartBit_ =  RegionStartBit_+RegionNumBits_;  
-  static const unsigned int RingMask_     =  0X7;
+  static const int RingNumBits_ = 3;
+  static const int RingStartBit_ = RegionStartBit_ + RegionNumBits_;
+  static const unsigned int RingMask_ = 0X7;
 
-  static const int StationNumBits_  =  2;
-  static const int StationStartBit_ =  RingStartBit_+RingNumBits_;  
-  static const unsigned int StationMask_     =  0X3;
+  static const int StationNumBits_ = 2;
+  static const int StationStartBit_ = RingStartBit_ + RingNumBits_;
+  static const unsigned int StationMask_ = 0X3;
 
+  static const int SectorNumBits_ = 4;
+  static const int SectorStartBit_ = StationStartBit_ + StationNumBits_;
+  static const unsigned int SectorMask_ = 0XF;
 
-  static const int SectorNumBits_  =  4;
-  static const int SectorStartBit_ =  StationStartBit_+StationNumBits_;  
-  static const unsigned int SectorMask_     =  0XF;
+  static const int LayerNumBits_ = 1;
+  static const int LayerStartBit_ = SectorStartBit_ + SectorNumBits_;
+  static const unsigned int LayerMask_ = 0X1;
 
-  static const int LayerNumBits_  =  1;
-  static const int LayerStartBit_ =  SectorStartBit_+SectorNumBits_;  
-  static const unsigned int LayerMask_     =  0X1;
+  static const int SubSectorNumBits_ = 3;
+  static const int SubSectorStartBit_ = LayerStartBit_ + LayerNumBits_;
+  static const unsigned int SubSectorMask_ = 0X7;
 
-  static const int SubSectorNumBits_  =  3;
-  static const int SubSectorStartBit_ =  LayerStartBit_+LayerNumBits_;  
-  static const unsigned int SubSectorMask_     =  0X7;
-  
-  static const int RollNumBits_  =  3;
-  static const int RollStartBit_ =  SubSectorStartBit_+SubSectorNumBits_;  
-  static const unsigned int RollMask_     =  0X7;
- 
-  static const uint32_t chamberIdMask_ = ~(RollMask_<<RollStartBit_);
+  static const int RollNumBits_ = 3;
+  static const int RollStartBit_ = SubSectorStartBit_ + SubSectorNumBits_;
+  static const unsigned int RollMask_ = 0X7;
 
- private:
-  void init(int region, 
-	    int ring,
-	    int station, 
-	    int sector,
-	    int layer,
-	    int subsector,
-	    int roll);
-  
+  static const uint32_t chamberIdMask_ = ~(RollMask_ << RollStartBit_);
+
+private:
+  void init(int region, int ring, int station, int sector, int layer, int subsector, int roll);
+
   int trind;
-}; // RPCDetId
+};  // RPCDetId
 
-std::ostream& operator<<( std::ostream& os, const RPCDetId& id );
+std::ostream& operator<<(std::ostream& os, const RPCDetId& id);
 
 #endif

--- a/DataFormats/MuonDetId/src/CSCDetId.cc
+++ b/DataFormats/MuonDetId/src/CSCDetId.cc
@@ -1,87 +1,75 @@
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-int CSCDetId::triggerSector() const
-{
+int CSCDetId::triggerSector() const {
   // UPDATED TO OCT 2005 - LGRAY Feb 2006
 
   int result;
-  int ring    = this->ring();
+  int ring = this->ring();
   int station = this->station();
   int chamber = this->chamber();
 
-    if(station > 1 && ring > 1 ) {
-      result = ((static_cast<unsigned>(chamber-3) & 0x7f) / 6) + 1; // ch 3-8->1, 9-14->2, ... 1,2 -> 6
-    }
-    else {
-      result =  (station != 1) ? ((static_cast<unsigned>(chamber-2) & 0x1f) / 3) + 1 : // ch 2-4-> 1, 5-7->2, ...
-	                         ((static_cast<unsigned>(chamber-3) & 0x7f) / 6) + 1;
-    }
+  if (station > 1 && ring > 1) {
+    result = ((static_cast<unsigned>(chamber - 3) & 0x7f) / 6) + 1;  // ch 3-8->1, 9-14->2, ... 1,2 -> 6
+  } else {
+    result = (station != 1) ? ((static_cast<unsigned>(chamber - 2) & 0x1f) / 3) + 1 :  // ch 2-4-> 1, 5-7->2, ...
+                 ((static_cast<unsigned>(chamber - 3) & 0x7f) / 6) + 1;
+  }
 
-  return (result <= 6) ? result : 6; // max sector is 6, some calculations give a value greater than six but this is expected.
+  return (result <= 6) ? result
+                       : 6;  // max sector is 6, some calculations give a value greater than six but this is expected.
 }
 
-int CSCDetId::triggerCscId() const
-{
+int CSCDetId::triggerCscId() const {
   // UPDATED TO OCT 2005 - LGRAY Feb 2006
 
   int result;
-  int ring    = this->ring();
+  int ring = this->ring();
   int station = this->station();
   int chamber = this->chamber();
 
-  if( station == 1 ) {
-    result = (chamber) % 3 + 1; // 1,2,3
+  if (station == 1) {
+    result = (chamber) % 3 + 1;  // 1,2,3
     switch (ring) {
-    case 1:
-      break;
-    case 2:
-      result += 3; // 4,5,6
-      break;
-    case 3:
-      result += 6; // 7,8,9
-      break;
+      case 1:
+        break;
+      case 2:
+        result += 3;  // 4,5,6
+        break;
+      case 3:
+        result += 6;  // 7,8,9
+        break;
     }
-  }
-  else {
-    if( ring == 1 ) {
-      result = (chamber+1) % 3 + 1; // 1,2,3
-    }
-    else {
-      result = (chamber+3) % 6 + 4; // 4,5,6,7,8,9
+  } else {
+    if (ring == 1) {
+      result = (chamber + 1) % 3 + 1;  // 1,2,3
+    } else {
+      result = (chamber + 3) % 6 + 4;  // 4,5,6,7,8,9
     }
   }
   return result;
 }
 
-unsigned short CSCDetId::iChamberType( unsigned short istation, unsigned short iring ) {
-  int i = 2 * istation + iring; // i=2S+R ok for S=2, 3, 4
-  if ( istation == 1 ) {
-    --i;                       // ring 1R -> i=1+R (2S+R-1=1+R for S=1)
-    if ( i > 4 ) i = 1;        // But ring 1A (R=4) -> i=1
-  }   
+unsigned short CSCDetId::iChamberType(unsigned short istation, unsigned short iring) {
+  int i = 2 * istation + iring;  // i=2S+R ok for S=2, 3, 4
+  if (istation == 1) {
+    --i;  // ring 1R -> i=1+R (2S+R-1=1+R for S=1)
+    if (i > 4)
+      i = 1;  // But ring 1A (R=4) -> i=1
+  }
   return i;
 }
 
-std::string CSCDetId::chamberName(int endcap, int station, int ring, int chamber)
-{
-  const std::string eSign = endcap==1 ? "+" : "-";
+std::string CSCDetId::chamberName(int endcap, int station, int ring, int chamber) {
+  const std::string eSign = endcap == 1 ? "+" : "-";
   return "ME" + eSign + std::to_string(station) + "/" + std::to_string(ring) + "/" + std::to_string(chamber);
 }
 
-std::string CSCDetId::chamberName() const
-{
-  return chamberName(endcap(), station(), ring(), chamber());
-}
+std::string CSCDetId::chamberName() const { return chamberName(endcap(), station(), ring(), chamber()); }
 
-std::ostream& operator<<( std::ostream& os, const CSCDetId& id )
-{
+std::ostream& operator<<(std::ostream& os, const CSCDetId& id) {
   // Note that there is no endl to end the output
 
-   os << " E:" << id.endcap()
-      << " S:" << id.station()
-      << " R:" << id.ring()
-      << " C:" << id.chamber()
-      << " L:" << id.layer();
-   return os;
-}  
-
+  os << " E:" << id.endcap() << " S:" << id.station() << " R:" << id.ring() << " C:" << id.chamber()
+     << " L:" << id.layer();
+  return os;
+}

--- a/DataFormats/MuonDetId/src/CSCIndexer.cc
+++ b/DataFormats/MuonDetId/src/CSCIndexer.cc
@@ -6,137 +6,132 @@ void CSCIndexer::fillChamberLabel() const {
   // Logically const since initializes cache only,
   // Beware that the ME42 indices 235-270 within this vector do NOT correspond to
   // their 'real' linear indices (which are 469-504 for +z)
-   chamberLabel.resize( 271 ); // one more than #chambers per endcap. Includes ME42.
-   IndexType count = 0;
-   chamberLabel[count] = 0;
+  chamberLabel.resize(271);  // one more than #chambers per endcap. Includes ME42.
+  IndexType count = 0;
+  chamberLabel[count] = 0;
 
-   for ( IndexType is = 1 ; is != 5; ++is ) {
-      IndexType irmax = ringsInStation(is);
-      for ( IndexType ir = 1; ir != irmax+1; ++ir ) {
-         IndexType icmax = chambersInRingOfStation(is, ir);
-         for ( IndexType ic = 1; ic != icmax+1; ++ic ) {
-	   chamberLabel[ ++count ] = is*1000 + ir*100 + ic ;
-         }
-      } 
-   }
+  for (IndexType is = 1; is != 5; ++is) {
+    IndexType irmax = ringsInStation(is);
+    for (IndexType ir = 1; ir != irmax + 1; ++ir) {
+      IndexType icmax = chambersInRingOfStation(is, ir);
+      for (IndexType ic = 1; ic != icmax + 1; ++ic) {
+        chamberLabel[++count] = is * 1000 + ir * 100 + ic;
+      }
+    }
+  }
 }
 
-CSCDetId CSCIndexer::detIdFromChamberIndex_OLD( IndexType ici ) const {
-
+CSCDetId CSCIndexer::detIdFromChamberIndex_OLD(IndexType ici) const {
   // Will not work as is for ME42
   // ============================
 
   IndexType ie = 1;
-  if (ici > 234 ) {
-     ie = 2;
-     ici -= 234; 
+  if (ici > 234) {
+    ie = 2;
+    ici -= 234;
   }
   // Now ici is in range 1-234 (assuming valid input in range 1-468)
 
   // MEij pairs...
-  const IndexType station[] = {0,1,1,1,2,2,3,3,4};
-  const IndexType ring[]    = {0,1,2,3,1,2,1,2,1};
+  const IndexType station[] = {0, 1, 1, 1, 2, 2, 3, 3, 4};
+  const IndexType ring[] = {0, 1, 2, 3, 1, 2, 1, 2, 1};
 
   // MEij preceding a given MEij matching linear index above
-  const IndexType prevs[] =  {0,0,1,1,1,2,2,3,3}; 
-  const IndexType prevr[] =  {0,0,1,2,3,1,2,1,2};
+  const IndexType prevs[] = {0, 0, 1, 1, 1, 2, 2, 3, 3};
+  const IndexType prevr[] = {0, 0, 1, 2, 3, 1, 2, 1, 2};
 
   IndexType is = 4;
   IndexType ir = 1;
-  for ( IndexType i = 2; i<=8; ++i) {
+  for (IndexType i = 2; i <= 8; ++i) {
     IndexType js = station[i];
     IndexType jr = ring[i];
     // if it's before start of MEjs/jr then it's in the previous MEis/ir
-      if ( ici < startChamberIndexInEndcap(ie,js,jr) ) {
-	is = prevs[i];
-	ir = prevr[i];
-	break;
-      }
-      // otherwise it's in ME41
+    if (ici < startChamberIndexInEndcap(ie, js, jr)) {
+      is = prevs[i];
+      ir = prevr[i];
+      break;
+    }
+    // otherwise it's in ME41
   }
-  IndexType ic = ici - startChamberIndexInEndcap(ie,is,ir) + 1;
+  IndexType ic = ici - startChamberIndexInEndcap(ie, is, ir) + 1;
 
-  return CSCDetId( ie, is, ir, ic );
+  return CSCDetId(ie, is, ir, ic);
 }
- 
-CSCDetId CSCIndexer::detIdFromChamberIndex( IndexType ici ) const {
+
+CSCDetId CSCIndexer::detIdFromChamberIndex(IndexType ici) const {
   // Expected range of input range argument is 1-540.
   // 1-468 for CSCs installed at 2008 start-up. 469-540 for ME42.
 
   IndexType ie = 1;
-  if ( ici > 468 ) {
+  if (ici > 468) {
     // ME42
-    ici -= 234; // now in range 235-306
-    if ( ici > 270 ) { // -z
+    ici -= 234;       // now in range 235-306
+    if (ici > 270) {  // -z
       ie = 2;
-      ici -= 36; // now in range 235-270
+      ici -= 36;  // now in range 235-270
+    }
+  } else {            // in range 1-468
+    if (ici > 234) {  // -z
+      ie = 2;
+      ici -= 234;  // now in range 1-234
     }
   }
-  else { // in range 1-468
-    if ( ici > 234 ) { // -z
-      ie = 2;
-      ici -= 234; // now in range 1-234
-    }
-  }
-  if (chamberLabel.empty()) fillChamberLabel();
-  IndexType label = chamberLabel[ici];    
-  return detIdFromChamberLabel( ie, label );
+  if (chamberLabel.empty())
+    fillChamberLabel();
+  IndexType label = chamberLabel[ici];
+  return detIdFromChamberLabel(ie, label);
 }
 
-CSCIndexer::IndexType CSCIndexer::chamberLabelFromChamberIndex( IndexType ici ) const {
+CSCIndexer::IndexType CSCIndexer::chamberLabelFromChamberIndex(IndexType ici) const {
   // This is just for cross-checking
 
   // Expected range of input range argument is 1-540.
   // 1-468 for CSCs installed at 2008 start-up. 469-540 for ME42.
 
-  if ( ici > 468 ) {
+  if (ici > 468) {
     // ME42
-    ici -= 234; // now in range 235-306
-    if ( ici > 270 ) { // -z
-      ici -= 36; // now in range 235-270
+    ici -= 234;       // now in range 235-306
+    if (ici > 270) {  // -z
+      ici -= 36;      // now in range 235-270
+    }
+  } else {            // in range 1-468
+    if (ici > 234) {  // -z
+      ici -= 234;     // now in range 1-234
     }
   }
-  else { // in range 1-468
-    if ( ici > 234 ) { // -z
-      ici -= 234; // now in range 1-234
-    }
-  }
-  if (chamberLabel.empty()) fillChamberLabel();
-  return chamberLabel[ici];  
-
+  if (chamberLabel.empty())
+    fillChamberLabel();
+  return chamberLabel[ici];
 }
 
-CSCDetId CSCIndexer::detIdFromChamberLabel( IndexType ie, IndexType label ) const {
-
-  IndexType is = label/1000;
-  label -= is*1000;
-  IndexType ir = label/100;
-  label -= ir*100;
+CSCDetId CSCIndexer::detIdFromChamberLabel(IndexType ie, IndexType label) const {
+  IndexType is = label / 1000;
+  label -= is * 1000;
+  IndexType ir = label / 100;
+  label -= ir * 100;
   IndexType ic = label;
 
-  return CSCDetId( ie, is, ir, ic );
+  return CSCDetId(ie, is, ir, ic);
 }
 
-CSCDetId CSCIndexer::detIdFromLayerIndex( IndexType ili ) const {
-
-  IndexType il = (ili-1)%6 + 1;
-  IndexType ici = (ili-1)/6 + 1;
-  CSCDetId id = detIdFromChamberIndex( ici ); 
+CSCDetId CSCIndexer::detIdFromLayerIndex(IndexType ili) const {
+  IndexType il = (ili - 1) % 6 + 1;
+  IndexType ici = (ili - 1) / 6 + 1;
+  CSCDetId id = detIdFromChamberIndex(ici);
 
   return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), il);
 }
 
-std::pair<CSCDetId, CSCIndexer::IndexType>  CSCIndexer::detIdFromStripChannelIndex( LongIndexType isi ) const {
-
-  const LongIndexType lastnonme42 = 217728; // channels in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 108864; // = 217728/2
-  const LongIndexType firstme13  = 34561; // First channel of ME13
-  const LongIndexType lastme13   = 48384; // Last channel of ME13
+std::pair<CSCDetId, CSCIndexer::IndexType> CSCIndexer::detIdFromStripChannelIndex(LongIndexType isi) const {
+  const LongIndexType lastnonme42 = 217728;       // channels in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 108864;  // = 217728/2
+  const LongIndexType firstme13 = 34561;          // First channel of ME13
+  const LongIndexType lastme13 = 48384;           // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer  = 433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer   = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   // All chambers but ME13 have 80 channels
   IndexType nchan = 80;
@@ -147,52 +142,49 @@ std::pair<CSCDetId, CSCIndexer::IndexType>  CSCIndexer::detIdFromStripChannelInd
   LongIndexType istart = 0;
   IndexType layerOffset = 0;
 
-  if ( isi <= lastnonme42 ) {	
+  if (isi <= lastnonme42) {
     // Chambers as of 2008 Installation
 
-    if ( isi > lastplusznonme42 ) {
+    if (isi > lastplusznonme42) {
       ie = 2;
       isi -= lastplusznonme42;
     }
-	
-    if ( isi > lastme13 ) { // after ME13
+
+    if (isi > lastme13) {  // after ME13
       istart = lastme13;
       layerOffset = lastme13layer;
-    }
-    else if ( isi >= firstme13 ) { // ME13
+    } else if (isi >= firstme13) {  // ME13
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchan = 64;
     }
-  }
-  else {
-     // ME42 chambers
+  } else {
+    // ME42 chambers
 
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
   }
 
-   isi -= istart; // remove earlier group(s)
-   IndexType ichan = (isi-1)%nchan + 1;
-   IndexType ili = (isi-1)/nchan + 1;
-   ili += layerOffset; // add appropriate offset for earlier group(s)
-   if ( ie != 1 ) ili+= lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need this.
-	
-   return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichan);
+  isi -= istart;  // remove earlier group(s)
+  IndexType ichan = (isi - 1) % nchan + 1;
+  IndexType ili = (isi - 1) / nchan + 1;
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
+  if (ie != 1)
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need this.
+
+  return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichan);
 }
 
-
-std::pair<CSCDetId, CSCIndexer::IndexType>  CSCIndexer::detIdFromChipIndex( IndexType ici ) const {
-
-  const LongIndexType lastnonme42 = 13608; // chips in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 6804; // = 13608/2
-  const LongIndexType firstme13  = 2161; // First channel of ME13
-  const LongIndexType lastme13   = 3024; // Last channel of ME13
+std::pair<CSCDetId, CSCIndexer::IndexType> CSCIndexer::detIdFromChipIndex(IndexType ici) const {
+  const LongIndexType lastnonme42 = 13608;      // chips in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 6804;  // = 13608/2
+  const LongIndexType firstme13 = 2161;         // First channel of ME13
+  const LongIndexType lastme13 = 3024;          // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer  = 433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer   = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   // All chambers but ME13 have 5 chips/layer
   IndexType nchipPerLayer = 5;
@@ -203,42 +195,40 @@ std::pair<CSCDetId, CSCIndexer::IndexType>  CSCIndexer::detIdFromChipIndex( Inde
   LongIndexType istart = 0;
   IndexType layerOffset = 0;
 
-  if ( ici <= lastnonme42 ) {	
+  if (ici <= lastnonme42) {
     // Chambers as of 2008 Installation
 
-    if ( ici > lastplusznonme42 ) {
+    if (ici > lastplusznonme42) {
       ie = 2;
       ici -= lastplusznonme42;
     }
-	
-    if ( ici > lastme13 ) { // after ME13
+
+    if (ici > lastme13) {  // after ME13
       istart = lastme13;
       layerOffset = lastme13layer;
-    }
-    else if ( ici >= firstme13 ) { // ME13
+    } else if (ici >= firstme13) {  // ME13
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchipPerLayer = 4;
     }
-  }
-  else {
-     // ME42 chambers
+  } else {
+    // ME42 chambers
 
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
   }
 
-   ici -= istart; // remove earlier group(s)
-   IndexType ichip = (ici-1)%nchipPerLayer + 1;
-   IndexType ili = (ici-1)/nchipPerLayer + 1;
-   ili += layerOffset; // add appropriate offset for earlier group(s)
-   if ( ie != 1 ) ili+= lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need this.
-	
-   return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichip);
+  ici -= istart;  // remove earlier group(s)
+  IndexType ichip = (ici - 1) % nchipPerLayer + 1;
+  IndexType ili = (ici - 1) / nchipPerLayer + 1;
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
+  if (ie != 1)
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need this.
+
+  return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichip);
 }
 
-int CSCIndexer::dbIndex(const CSCDetId & id, int & channel)
-{
+int CSCIndexer::dbIndex(const CSCDetId& id, int& channel) {
   int ec = id.endcap();
   int st = id.station();
   int rg = id.ring();
@@ -246,10 +236,10 @@ int CSCIndexer::dbIndex(const CSCDetId & id, int & channel)
   int la = id.layer();
 
   // The channels of ME1A are channels 65-80 of ME11
-  if(st == 1 && rg == 4)
-    {
-      rg = 1;
-      if(channel <= 16) channel += 64; // no trapping for any bizarreness
-    }
-  return ec*100000 + st*10000 + rg*1000 + ch*10 + la;
+  if (st == 1 && rg == 4) {
+    rg = 1;
+    if (channel <= 16)
+      channel += 64;  // no trapping for any bizarreness
+  }
+  return ec * 100000 + st * 10000 + rg * 1000 + ch * 10 + la;
 }

--- a/DataFormats/MuonDetId/src/CSCTriggerNumbering.cc
+++ b/DataFormats/MuonDetId/src/CSCTriggerNumbering.cc
@@ -2,133 +2,118 @@
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
-int CSCTriggerNumbering::ringFromTriggerLabels(int station, int triggerCSCID)
-{
-  if(station      < CSCDetId::minStationId() || station      > CSCDetId::maxStationId() ||
-     triggerCSCID < MIN_CSCID                || triggerCSCID > MAX_CSCID)
-    throw cms::Exception("CSCTriggerNumbering::InvalidInput") << "CSCTriggerNumbering::ringFromTriggerLabels():"
-							      << " Station: " << station
-							      << " TriggerCSCID: " << triggerCSCID
-							      << " is not a valid set of labels."
-							      << " Cannot Convert!!";
+int CSCTriggerNumbering::ringFromTriggerLabels(int station, int triggerCSCID) {
+  if (station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() || triggerCSCID < MIN_CSCID ||
+      triggerCSCID > MAX_CSCID)
+    throw cms::Exception("CSCTriggerNumbering::InvalidInput")
+        << "CSCTriggerNumbering::ringFromTriggerLabels():"
+        << " Station: " << station << " TriggerCSCID: " << triggerCSCID << " is not a valid set of labels."
+        << " Cannot Convert!!";
 
   int ring = 0;
 
-  if(station == 1)
-    if(triggerCSCID <= 3)
-      ring = 1;	
-    else if(triggerCSCID <= 6)
+  if (station == 1)
+    if (triggerCSCID <= 3)
+      ring = 1;
+    else if (triggerCSCID <= 6)
       ring = 2;
     else
       ring = 3;
+  else if (triggerCSCID <= 3)
+    ring = 1;
   else
-    if(triggerCSCID <= 3)
-      ring = 1;
-    else 
-      ring = 2;
-  
-  return ring;  
+    ring = 2;
+
+  return ring;
 }
 
-int CSCTriggerNumbering::chamberFromTriggerLabels(int TriggerSector, int TriggerSubSector, int station, int TriggerCSCID)
-{
-  if(TriggerSector    < MIN_TRIGSECTOR           || TriggerSector    > MAX_TRIGSECTOR           ||
-     TriggerSubSector < MIN_TRIGSUBSECTOR        || TriggerSubSector > MAX_TRIGSUBSECTOR        ||
-     station          < CSCDetId::minStationId() || station          > CSCDetId::maxStationId() ||
-     TriggerCSCID     < MIN_CSCID                || TriggerCSCID     > MAX_CSCID)
-    throw cms::Exception("CSCTriggerNumbering::InvalidInput") << "CSCTriggerNumbering::chamberFromTriggerLabels():"
-							      << " Trigger Sector: " << TriggerSector 
-							      << " Trigger SubSector: " << TriggerSubSector
-							      << " Station: " << station
-							      << " TriggerCSCID: " << TriggerCSCID
-							      << " is not a valid set of labels."
-							      << " Cannot Convert!!";
-    
+int CSCTriggerNumbering::chamberFromTriggerLabels(int TriggerSector,
+                                                  int TriggerSubSector,
+                                                  int station,
+                                                  int TriggerCSCID) {
+  if (TriggerSector < MIN_TRIGSECTOR || TriggerSector > MAX_TRIGSECTOR || TriggerSubSector < MIN_TRIGSUBSECTOR ||
+      TriggerSubSector > MAX_TRIGSUBSECTOR || station < CSCDetId::minStationId() ||
+      station > CSCDetId::maxStationId() || TriggerCSCID < MIN_CSCID || TriggerCSCID > MAX_CSCID)
+    throw cms::Exception("CSCTriggerNumbering::InvalidInput")
+        << "CSCTriggerNumbering::chamberFromTriggerLabels():"
+        << " Trigger Sector: " << TriggerSector << " Trigger SubSector: " << TriggerSubSector << " Station: " << station
+        << " TriggerCSCID: " << TriggerCSCID << " is not a valid set of labels."
+        << " Cannot Convert!!";
 
   int chamber = 0;
-  int realsubsector = (TriggerSubSector + 2*(TriggerSector - 1))%12 + 1; // station 1 only
+  int realsubsector = (TriggerSubSector + 2 * (TriggerSector - 1)) % 12 + 1;  // station 1 only
 
-  if(station != 1)
-    if(TriggerCSCID <= 3)
-      chamber = (TriggerCSCID + 3*(TriggerSector - 1))%18 + 1; // Derived from CMS Note: CMS IN 2000/04 ver 2.1 Oct/2005
-                                                               // As far as I know this is reality.
+  if (station != 1)
+    if (TriggerCSCID <= 3)
+      chamber =
+          (TriggerCSCID + 3 * (TriggerSector - 1)) % 18 + 1;  // Derived from CMS Note: CMS IN 2000/04 ver 2.1 Oct/2005
+                                                              // As far as I know this is reality.
     else
-      chamber = (TriggerCSCID + 6*(TriggerSector - 1) - 2)%36 + 1;
+      chamber = (TriggerCSCID + 6 * (TriggerSector - 1) - 2) % 36 + 1;
+  else if (TriggerCSCID <= 3)
+    chamber = (TriggerCSCID + 3 * (realsubsector - 1) + 34) % 36 + 1;
+  else if (TriggerCSCID <= 6)
+    chamber = (TriggerCSCID + 3 * (realsubsector - 1) + 31) % 36 + 1;
   else
-    if(TriggerCSCID <= 3)
-      chamber = (TriggerCSCID + 3*(realsubsector - 1)+34)%36 + 1;
-    else if(TriggerCSCID <= 6)
-      chamber = (TriggerCSCID + 3*(realsubsector - 1)+31)%36 + 1;
-    else
-      chamber = (TriggerCSCID + 3*(realsubsector - 1)+28)%36 + 1;
+    chamber = (TriggerCSCID + 3 * (realsubsector - 1) + 28) % 36 + 1;
 
   return chamber;
 }
 
-int CSCTriggerNumbering::sectorFromTriggerLabels(int TriggerSector, int TriggerSubSector, int station)
-{
-  if(TriggerSector    < MIN_TRIGSECTOR           || TriggerSector    > MAX_TRIGSECTOR           ||
-     TriggerSubSector < MIN_TRIGSUBSECTOR        || TriggerSubSector > MAX_TRIGSUBSECTOR        ||
-     station          < CSCDetId::minStationId() || station          > CSCDetId::maxStationId())
-    throw cms::Exception("CSCTriggerNumbering::InvalidInput") << "CSCTriggerNumbering::sectorFromTriggerLabels():"
-							      << " Trigger Sector: " << TriggerSector 
-							      << " Trigger SubSector: " << TriggerSubSector
-							      << " Station: " << station
-							      << " is not a valid set of labels."
-							      << " Cannot Convert!!";
+int CSCTriggerNumbering::sectorFromTriggerLabels(int TriggerSector, int TriggerSubSector, int station) {
+  if (TriggerSector < MIN_TRIGSECTOR || TriggerSector > MAX_TRIGSECTOR || TriggerSubSector < MIN_TRIGSUBSECTOR ||
+      TriggerSubSector > MAX_TRIGSUBSECTOR || station < CSCDetId::minStationId() || station > CSCDetId::maxStationId())
+    throw cms::Exception("CSCTriggerNumbering::InvalidInput")
+        << "CSCTriggerNumbering::sectorFromTriggerLabels():"
+        << " Trigger Sector: " << TriggerSector << " Trigger SubSector: " << TriggerSubSector << " Station: " << station
+        << " is not a valid set of labels."
+        << " Cannot Convert!!";
 
-  return ((station == 1) ? ((TriggerSubSector + 2*(TriggerSector - 1))%12 + 1) : TriggerSector);
+  return ((station == 1) ? ((TriggerSubSector + 2 * (TriggerSector - 1)) % 12 + 1) : TriggerSector);
 }
 
-int CSCTriggerNumbering::triggerSectorFromLabels(int station, int ring, int chamber)
-{
-  if(station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() ||
-     ring    < CSCDetId::minRingId()    || ring    > CSCDetId::maxRingId()    ||
-     chamber < CSCDetId::minChamberId() || chamber > CSCDetId::maxChamberId())
-    throw cms::Exception("CSCTriggerNumbering::InvalidInput") << "CSCTriggerNumbering::triggerSectorFromLabels():"
-							      << " Station: " << station
-							      << " Ring: " << ring
-							      << " Chamber: " << chamber
-							      << " is not a valid set of labels."
-							      << " Cannot Convert!!";
-
+int CSCTriggerNumbering::triggerSectorFromLabels(int station, int ring, int chamber) {
+  if (station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() || ring < CSCDetId::minRingId() ||
+      ring > CSCDetId::maxRingId() || chamber < CSCDetId::minChamberId() || chamber > CSCDetId::maxChamberId())
+    throw cms::Exception("CSCTriggerNumbering::InvalidInput")
+        << "CSCTriggerNumbering::triggerSectorFromLabels():"
+        << " Station: " << station << " Ring: " << ring << " Chamber: " << chamber << " is not a valid set of labels."
+        << " Cannot Convert!!";
 
   int result;
   // This version 16-Nov-99 ptc to match simplified chamber labelling for cms116
   //@@ REQUIRES UPDATE TO 2005 REALITY, ONCE I UNDERSTAND WHAT THAT IS
   // UPDATED - LGRAY Feb 2006
-  
-  if(station > 1 && ring > 1 ) {
-    result = ((static_cast<unsigned>(chamber-3) & 0x7f) / 6) + 1; // ch 3-8->1, 9-14->2, ... 1,2 -> 6
-  }
-  else {
-    result =  (station != 1) ? ((static_cast<unsigned>(chamber-2) & 0x1f) / 3) + 1 : // ch 2-4-> 1, 5-7->2, ...
-              ((static_cast<unsigned>(chamber-3) & 0x7f) / 6) + 1;
+
+  if (station > 1 && ring > 1) {
+    result = ((static_cast<unsigned>(chamber - 3) & 0x7f) / 6) + 1;  // ch 3-8->1, 9-14->2, ... 1,2 -> 6
+  } else {
+    result = (station != 1) ? ((static_cast<unsigned>(chamber - 2) & 0x1f) / 3) + 1 :  // ch 2-4-> 1, 5-7->2, ...
+                 ((static_cast<unsigned>(chamber - 3) & 0x7f) / 6) + 1;
   }
 
-  return (result <= 6) ? result : 6; // Max sector is 6, some calculations give a value greater than six but this is expected
-                                     // and delt with.
+  return (result <= 6) ? result
+                       : 6;  // Max sector is 6, some calculations give a value greater than six but this is expected
+                             // and delt with.
 }
 
-int CSCTriggerNumbering::triggerSectorFromLabels(CSCDetId id)
-{
-  return triggerSectorFromLabels(id.station(),id.ring(),id.chamber());
+int CSCTriggerNumbering::triggerSectorFromLabels(CSCDetId id) {
+  return triggerSectorFromLabels(id.station(), id.ring(), id.chamber());
 }
 
-int CSCTriggerNumbering::triggerSubSectorFromLabels(int station, int chamber)
-{
-  if(station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() ||
-     chamber < CSCDetId::minChamberId() || chamber > CSCDetId::maxChamberId())
-    throw cms::Exception("CSCTriggerNumbering::InvalidInput") << "CSCTriggerNumbering::triggerSectorFromLabels():"
-							      << " Station: " << station
-							      << " Chamber: " << chamber
-							      << " is not a valid set of labels."
-							      << " Cannot Convert!!";
+int CSCTriggerNumbering::triggerSubSectorFromLabels(int station, int chamber) {
+  if (station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() || chamber < CSCDetId::minChamberId() ||
+      chamber > CSCDetId::maxChamberId())
+    throw cms::Exception("CSCTriggerNumbering::InvalidInput")
+        << "CSCTriggerNumbering::triggerSectorFromLabels():"
+        << " Station: " << station << " Chamber: " << chamber << " is not a valid set of labels."
+        << " Cannot Convert!!";
 
-  if(station != 1) return 0; // only station one has subsectors
+  if (station != 1)
+    return 0;  // only station one has subsectors
 
-  switch(chamber) // first make things easier to deal with
-    {
+  switch (chamber)  // first make things easier to deal with
+  {
     case 1:
       chamber = 36;
       break;
@@ -137,57 +122,50 @@ int CSCTriggerNumbering::triggerSubSectorFromLabels(int station, int chamber)
       break;
     default:
       chamber -= 2;
-    }
+  }
 
-  chamber = ((chamber-1)%6) + 1; // renumber all chambers to 1-6
+  chamber = ((chamber - 1) % 6) + 1;  // renumber all chambers to 1-6
 
-  return ((chamber-1) / 3) + 1; // [1,3] -> 1 , [4,6]->2
+  return ((chamber - 1) / 3) + 1;  // [1,3] -> 1 , [4,6]->2
 }
 
-int CSCTriggerNumbering::triggerSubSectorFromLabels(CSCDetId id)
-{
-  return triggerSubSectorFromLabels(id.station(),id.chamber());
+int CSCTriggerNumbering::triggerSubSectorFromLabels(CSCDetId id) {
+  return triggerSubSectorFromLabels(id.station(), id.chamber());
 }
 
-int CSCTriggerNumbering::triggerCscIdFromLabels(int station, int ring, int chamber) // updated to 2005
+int CSCTriggerNumbering::triggerCscIdFromLabels(int station, int ring, int chamber)  // updated to 2005
 {
-  if(station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() ||
-     ring    < CSCDetId::minRingId()    || ring    > CSCDetId::maxRingId()    ||
-     chamber < CSCDetId::minChamberId() || chamber > CSCDetId::maxChamberId())
-    throw cms::Exception("CSCTriggerNumbering::InvalidInput") << "CSCTriggerNumbering::triggerSectorFromLabels():"
-							      << " Station: " << station
-							      << " Ring: " << ring
-							      << " Chamber: " << chamber
-							      << " is not a valid set of labels."
-							      << " Cannot Convert!!";
+  if (station < CSCDetId::minStationId() || station > CSCDetId::maxStationId() || ring < CSCDetId::minRingId() ||
+      ring > CSCDetId::maxRingId() || chamber < CSCDetId::minChamberId() || chamber > CSCDetId::maxChamberId())
+    throw cms::Exception("CSCTriggerNumbering::InvalidInput")
+        << "CSCTriggerNumbering::triggerSectorFromLabels():"
+        << " Station: " << station << " Ring: " << ring << " Chamber: " << chamber << " is not a valid set of labels."
+        << " Cannot Convert!!";
 
   int result;
 
-  if( station == 1 ) {
-    result = (chamber) % 3 + 1; // 1,2,3
+  if (station == 1) {
+    result = (chamber) % 3 + 1;  // 1,2,3
     switch (ring) {
-    case 1:
-      break;
-    case 2:
-      result += 3; // 4,5,6
-      break;
-    case 3:
-      result += 6; // 7,8,9
-      break;
+      case 1:
+        break;
+      case 2:
+        result += 3;  // 4,5,6
+        break;
+      case 3:
+        result += 6;  // 7,8,9
+        break;
     }
-  }
-  else {
-    if( ring == 1 ) {
-      result = (chamber+1) % 3 + 1; // 1,2,3
-    }
-    else {
-      result = (chamber+3) % 6 + 4; // 4,5,6,7,8,9
+  } else {
+    if (ring == 1) {
+      result = (chamber + 1) % 3 + 1;  // 1,2,3
+    } else {
+      result = (chamber + 3) % 6 + 4;  // 4,5,6,7,8,9
     }
   }
   return result;
 }
 
-int CSCTriggerNumbering::triggerCscIdFromLabels(CSCDetId id)
-{
-  return triggerCscIdFromLabels(id.station(),id.ring(),id.chamber());
+int CSCTriggerNumbering::triggerCscIdFromLabels(CSCDetId id) {
+  return triggerCscIdFromLabels(id.station(), id.ring(), id.chamber());
 }

--- a/DataFormats/MuonDetId/src/DTChamberId.cc
+++ b/DataFormats/MuonDetId/src/DTChamberId.cc
@@ -5,74 +5,49 @@
  */
 
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include "DataFormats/MuonDetId/interface/MuonSubdetId.h" 
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <ostream>
 
 using namespace std;
 
-DTChamberId::DTChamberId() : DetId(DetId::Muon, MuonSubdetId::DT){}
+DTChamberId::DTChamberId() : DetId(DetId::Muon, MuonSubdetId::DT) {}
 
-
-DTChamberId::DTChamberId(uint32_t id) :
-  DetId(id & chamberIdMask_) { // Mask the bits outside DTChamberId fields
-  checkMuonId();               // Check this is a valid id for muon DTs.
+DTChamberId::DTChamberId(uint32_t id) : DetId(id & chamberIdMask_) {  // Mask the bits outside DTChamberId fields
+  checkMuonId();                                                      // Check this is a valid id for muon DTs.
 }
-DTChamberId::DTChamberId(DetId id) :
-  DetId(id.rawId() & chamberIdMask_) { // Mask the bits outside DTChamberId fields
-  checkMuonId();               // Check this is a valid id for muon DTs.
+DTChamberId::DTChamberId(DetId id) : DetId(id.rawId() & chamberIdMask_) {  // Mask the bits outside DTChamberId fields
+  checkMuonId();                                                           // Check this is a valid id for muon DTs.
 }
 
+DTChamberId::DTChamberId(int wheel, int station, int sector) : DetId(DetId::Muon, MuonSubdetId::DT) {
+  // Check that arguments are within the range
+  if (wheel < minWheelId || wheel > maxWheelId || station < minStationId || station > maxStationId ||
+      sector < minSectorId || sector > maxSectorId) {
+    throw cms::Exception("InvalidDetId") << "DTChamberId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wh:" << wheel << " St:" << station << " Se:" << sector << std::endl;
+  }
 
-
-DTChamberId::DTChamberId(int wheel, int station, int sector):
-  DetId(DetId::Muon, MuonSubdetId::DT) {
-    // Check that arguments are within the range
-    if (wheel      < minWheelId      || wheel      > maxWheelId ||
-	station    < minStationId    || station    > maxStationId ||
-	sector     < minSectorId     || sector     > maxSectorId) {
-      throw cms::Exception("InvalidDetId") << "DTChamberId ctor:" 
-					   << " Invalid parameters: " 
-					   << " Wh:"<< wheel
-					   << " St:"<< station
-					   << " Se:"<< sector
-					   << std::endl;
-    }
-
-    int tmpwheelid = wheel- minWheelId +1;
-    id_ |= (tmpwheelid& wheelMask_) << wheelStartBit_   |
-      (station & stationMask_)      << stationStartBit_ |
-      (sector  &sectorMask_ )       << sectorStartBit_;
-
+  int tmpwheelid = wheel - minWheelId + 1;
+  id_ |= (tmpwheelid & wheelMask_) << wheelStartBit_ | (station & stationMask_) << stationStartBit_ |
+         (sector & sectorMask_) << sectorStartBit_;
 }
 
-
-
-DTChamberId::DTChamberId(const DTChamberId& chId) :
-  DetId(chId.rawId() & chamberIdMask_) {   // The mask is required for proper slicing, i.e. if chId is actually a derived class.
+DTChamberId::DTChamberId(const DTChamberId& chId)
+    : DetId(chId.rawId() &
+            chamberIdMask_) {  // The mask is required for proper slicing, i.e. if chId is actually a derived class.
 }
-
-
 
 void DTChamberId::checkMuonId() {
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::DT) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::DT) {
     throw cms::Exception("InvalidDetId") << "DTChamberId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid DT id";  
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid DT id";
   }
 }
 
-
-
-std::ostream& operator<<( std::ostream& os, const DTChamberId& id ){
-  os << " Wh:"<< id.wheel()
-     << " St:"<< id.station() 
-     << " Se:"<< id.sector()
-     <<" ";
+std::ostream& operator<<(std::ostream& os, const DTChamberId& id) {
+  os << " Wh:" << id.wheel() << " St:" << id.station() << " Se:" << id.sector() << " ";
 
   return os;
 }
-
-
-

--- a/DataFormats/MuonDetId/src/DTLayerId.cc
+++ b/DataFormats/MuonDetId/src/DTLayerId.cc
@@ -9,10 +9,7 @@
 #include <DataFormats/MuonDetId/interface/DTLayerId.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
-
-
 DTLayerId::DTLayerId() : DTSuperLayerId() {}
-
 
 DTLayerId::DTLayerId(uint32_t id) {
   // Mask the bits outside DTLayerId fields (notably, the wire number)
@@ -21,8 +18,6 @@ DTLayerId::DTLayerId(uint32_t id) {
   checkMuonId();
 }
 
-
-
 // Copy Constructor.
 DTLayerId::DTLayerId(const DTLayerId& layerId) {
   // The mask is required for proper slicing, i.e. if layerId is
@@ -30,65 +25,41 @@ DTLayerId::DTLayerId(const DTLayerId& layerId) {
   id_ = (layerId.rawId() & layerIdMask_);
 }
 
-
-
 // Constructor from a camberId and SL and layer numbers
 DTLayerId::DTLayerId(const DTChamberId& chId, int superlayer, int layer) : DTSuperLayerId(chId, superlayer) {
   if (layer < minLayerId || layer > maxLayerId) {
-    throw cms::Exception("InvalidDetId") << "DTLayerId ctor:" 
-					 << " Invalid parameters: " 
-					 << " La:"<< layer
-					 << std::endl;
+    throw cms::Exception("InvalidDetId") << "DTLayerId ctor:"
+                                         << " Invalid parameters: "
+                                         << " La:" << layer << std::endl;
   }
   id_ |= (layer & lMask_) << layerStartBit_;
 }
-
-
 
 // Constructor from a SuperLayerId and layer number
 DTLayerId::DTLayerId(const DTSuperLayerId& slId, int layer) : DTSuperLayerId(slId) {
   if (layer < minLayerId || layer > maxLayerId) {
-    throw cms::Exception("InvalidDetId") << "DTLayerId ctor:" 
-					 << " Invalid parameters: " 
-					 << " La:"<< layer
-					 << std::endl;
+    throw cms::Exception("InvalidDetId") << "DTLayerId ctor:"
+                                         << " Invalid parameters: "
+                                         << " La:" << layer << std::endl;
   }
   id_ |= (layer & lMask_) << layerStartBit_;
 }
 
+DTLayerId::DTLayerId(int wheel, int station, int sector, int superlayer, int layer)
+    : DTSuperLayerId(wheel, station, sector, superlayer) {
+  if (layer < minLayerId || layer > maxLayerId) {
+    throw cms::Exception("InvalidDetId") << "DTLayerId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wh:" << wheel << " St:" << station << " Se:" << sector
+                                         << " Sl:" << superlayer << " La:" << layer << std::endl;
+  }
 
+  id_ |= (layer & lMask_) << layerStartBit_;
+}
 
-
-DTLayerId::DTLayerId(int wheel,
-		     int station,
-		     int sector,
-		     int superlayer,
-		     int layer) : DTSuperLayerId(wheel, station, sector, superlayer) {
-		       if (layer < minLayerId || layer > maxLayerId) {
-			 throw cms::Exception("InvalidDetId") << "DTLayerId ctor:" 
-							      << " Invalid parameters: " 
-							      << " Wh:"<< wheel
-							      << " St:"<< station
-							      << " Se:"<< sector
-							      << " Sl:"<< superlayer
-							      << " La:"<< layer
-							      << std::endl;
-		       }
-		       
-		       id_ |= (layer & lMask_) << layerStartBit_;
-		     }
-
-
-
-std::ostream& operator<<( std::ostream& os, const DTLayerId& id ){
-  os << " Wh:"<< id.wheel()
-     << " St:"<< id.station() 
-     << " Se:"<< id.sector()
-     << " Sl:"<< id.superlayer()
-     << " La:"<< id.layer()
-     <<" ";
+std::ostream& operator<<(std::ostream& os, const DTLayerId& id) {
+  os << " Wh:" << id.wheel() << " St:" << id.station() << " Se:" << id.sector() << " Sl:" << id.superlayer()
+     << " La:" << id.layer() << " ";
 
   return os;
 }
-
-

--- a/DataFormats/MuonDetId/src/DTSectCollId.cc
+++ b/DataFormats/MuonDetId/src/DTSectCollId.cc
@@ -8,11 +8,10 @@
 //   Author List:
 //   S. Marcellini
 //   Modifications:
-//   11/12/06 C.Battilana : new SectCollId definitions 
+//   11/12/06 C.Battilana : new SectCollId definitions
 //
 //
 //--------------------------------------------------
-
 
 //-----------------------
 // This Class's Header --
@@ -23,18 +22,12 @@
 // Collaborating Class Headers --
 //-------------------------------
 
-
 //---------------
 // C++ Headers --
 //---------------
 
-
-
 #include <iostream>
-std::ostream& operator<<(std::ostream &os, const DTSectCollId& id){
-  os << "Wheel: "   << id.wheel() 
-     << " Sector: " << id.sector();
+std::ostream& operator<<(std::ostream& os, const DTSectCollId& id) {
+  os << "Wheel: " << id.wheel() << " Sector: " << id.sector();
   return os;
 }
-
-

--- a/DataFormats/MuonDetId/src/DTSuperLayerId.cc
+++ b/DataFormats/MuonDetId/src/DTSuperLayerId.cc
@@ -8,68 +8,43 @@
 #include <DataFormats/MuonDetId/interface/DTSuperLayerId.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
-
-
 DTSuperLayerId::DTSuperLayerId() : DTChamberId() {}
 
-
-
 DTSuperLayerId::DTSuperLayerId(uint32_t id) {
-  id_ = id & slIdMask_; // Mask the bits outside DTSuperLayerId fields
-  checkMuonId();        // Check this is a valid id for muon DTs.
+  id_ = id & slIdMask_;  // Mask the bits outside DTSuperLayerId fields
+  checkMuonId();         // Check this is a valid id for muon DTs.
 }
 
-
-DTSuperLayerId::DTSuperLayerId(int wheel,
-	       int station,
-	       int sector,
-	       int superlayer) : DTChamberId(wheel, station, sector) {
-		 if(superlayer < minSuperLayerId || superlayer > maxSuperLayerId) {
-		   throw cms::Exception("InvalidDetId") << "DTSuperLayerId ctor:" 
-							<< " Invalid parameters: " 
-							<< " Wh:"<< wheel
-							<< " St:"<< station
-							<< " Se:"<< sector
-							<< " Sl:"<< superlayer
-							<< std::endl;
-		 }
-		 id_ |= (superlayer & slMask_) << slayerStartBit_;
-	       }
-
-
+DTSuperLayerId::DTSuperLayerId(int wheel, int station, int sector, int superlayer)
+    : DTChamberId(wheel, station, sector) {
+  if (superlayer < minSuperLayerId || superlayer > maxSuperLayerId) {
+    throw cms::Exception("InvalidDetId") << "DTSuperLayerId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wh:" << wheel << " St:" << station << " Se:" << sector
+                                         << " Sl:" << superlayer << std::endl;
+  }
+  id_ |= (superlayer & slMask_) << slayerStartBit_;
+}
 
 // Copy Constructor.
 DTSuperLayerId::DTSuperLayerId(const DTSuperLayerId& slId) {
   // The mask is required for proper slicing, i.e. if slId is
   // actually a derived class.
-  id_ = (slId.rawId() &  slIdMask_);						 
+  id_ = (slId.rawId() & slIdMask_);
 }
-
-
 
 // Constructor from a camberId and SL number
 DTSuperLayerId::DTSuperLayerId(const DTChamberId& chId, int superlayer) : DTChamberId(chId) {
-  if(superlayer < minSuperLayerId || superlayer > maxSuperLayerId) {
-    throw cms::Exception("InvalidDetId") << "DTSuperLayerId ctor:" 
-					 << " Invalid parameter: " 
-					 << " Sl:"<< superlayer
-					 << std::endl;
+  if (superlayer < minSuperLayerId || superlayer > maxSuperLayerId) {
+    throw cms::Exception("InvalidDetId") << "DTSuperLayerId ctor:"
+                                         << " Invalid parameter: "
+                                         << " Sl:" << superlayer << std::endl;
   }
   id_ |= (superlayer & slMask_) << slayerStartBit_;
 }
 
-
-
-
-
-
-std::ostream& operator<<( std::ostream& os, const DTSuperLayerId& id ){
-  os << " Wh:"<< id.wheel()
-     << " St:"<< id.station() 
-     << " Se:"<< id.sector()
-     << " Sl:"<< id.superlayer()
-     <<" ";
+std::ostream& operator<<(std::ostream& os, const DTSuperLayerId& id) {
+  os << " Wh:" << id.wheel() << " St:" << id.station() << " Se:" << id.sector() << " Sl:" << id.superlayer() << " ";
 
   return os;
 }
-

--- a/DataFormats/MuonDetId/src/DTWireId.cc
+++ b/DataFormats/MuonDetId/src/DTWireId.cc
@@ -5,110 +5,69 @@
  * \date 02 Aug 2005
 */
 
-
 #include <iostream>
 #include <DataFormats/MuonDetId/interface/DTWireId.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
-
-
 DTWireId::DTWireId() : DTLayerId() {}
 
-
-
 DTWireId::DTWireId(uint32_t id) {
-  id_= id;
-  checkMuonId(); // Check this is a valid id for muon DTs.
+  id_ = id;
+  checkMuonId();  // Check this is a valid id for muon DTs.
 }
 
+DTWireId::DTWireId(int wheel, int station, int sector, int superlayer, int layer, int wire)
+    : DTLayerId(wheel, station, sector, superlayer, layer) {
+  if (wire < minWireId || wire > maxWireId) {
+    throw cms::Exception("InvalidDetId") << "DTWireId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wh:" << wheel << " St:" << station << " Se:" << sector
+                                         << " Sl:" << superlayer << " La:" << layer << " Wi:" << wire << std::endl;
+  }
 
-
-DTWireId::DTWireId(int wheel,
-		   int station,
-		   int sector,
-		   int superlayer,
-		   int layer,
-		   int wire) : DTLayerId(wheel, station, sector, superlayer, layer) {
-		     if (wire < minWireId || wire > maxWireId) {
-		       throw cms::Exception("InvalidDetId") << "DTWireId ctor:" 
-							    << " Invalid parameters: " 
-							    << " Wh:"<< wheel
-							    << " St:"<< station
-							    << " Se:"<< sector
-							    << " Sl:"<< superlayer
-							    << " La:"<< layer
-							    << " Wi:"<< wire
-							    << std::endl;
-		     }
-      
-		     id_ |= (wire & wireMask_) << wireStartBit_;
-		   }
-
-
+  id_ |= (wire & wireMask_) << wireStartBit_;
+}
 
 // Copy Constructor.
-DTWireId::DTWireId(const DTWireId& wireId) {
-  id_ = wireId.rawId();
-}
-
-
+DTWireId::DTWireId(const DTWireId& wireId) { id_ = wireId.rawId(); }
 
 // Constructor from a CamberId and SL, layer and wire numbers
-DTWireId::DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire) :
-  DTLayerId(chId, superlayer, layer) {
-    if (wire < minWireId || wire > maxWireId) {
-      throw cms::Exception("InvalidDetId") << "DTWireId ctor:" 
-					   << " Invalid parameters: " 
-					   << " Wi:"<< wire
-					   << std::endl;
-    }
-      
-    id_ |= (wire & wireMask_) << wireStartBit_;
+DTWireId::DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire) : DTLayerId(chId, superlayer, layer) {
+  if (wire < minWireId || wire > maxWireId) {
+    throw cms::Exception("InvalidDetId") << "DTWireId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wi:" << wire << std::endl;
   }
 
-
+  id_ |= (wire & wireMask_) << wireStartBit_;
+}
 
 // Constructor from a SuperLayerId and layer and wire numbers
-DTWireId::DTWireId(const DTSuperLayerId& slId, int layer, int wire) :
-  DTLayerId(slId, layer) {
-    if (wire < minWireId || wire > maxWireId) {
-      throw cms::Exception("InvalidDetId") << "DTWireId ctor:" 
-					   << " Invalid parameters: " 
-					   << " Wi:"<< wire
-					   << std::endl;
-    }
-    
-    id_ |= (wire & wireMask_) << wireStartBit_;
+DTWireId::DTWireId(const DTSuperLayerId& slId, int layer, int wire) : DTLayerId(slId, layer) {
+  if (wire < minWireId || wire > maxWireId) {
+    throw cms::Exception("InvalidDetId") << "DTWireId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wi:" << wire << std::endl;
   }
 
-
+  id_ |= (wire & wireMask_) << wireStartBit_;
+}
 
 // Constructor from a layerId and a wire number
 DTWireId::DTWireId(const DTLayerId& layerId, int wire) : DTLayerId(layerId) {
   if (wire < minWireId || wire > maxWireId) {
-    throw cms::Exception("InvalidDetId") << "DTWireId ctor:" 
-					 << " Invalid parameters: " 
-					 << " Wi:"<< wire
-					 << std::endl;
+    throw cms::Exception("InvalidDetId") << "DTWireId ctor:"
+                                         << " Invalid parameters: "
+                                         << " Wi:" << wire << std::endl;
   }
-    
+
   id_ |= (wire & wireMask_) << wireStartBit_;
 }
-  
-
 
 // Ostream operator
-std::ostream& operator<<( std::ostream& os, const DTWireId& id ){
-
-  os << " Wh:"<< id.wheel()
-     << " St:"<< id.station() 
-     << " Se:"<< id.sector()
-     << " Sl:"<< id.superlayer()
-     << " La:"<< id.layer()
-     << " Wi:"<< id.wire()
-     <<" ";
+std::ostream& operator<<(std::ostream& os, const DTWireId& id) {
+  os << " Wh:" << id.wheel() << " St:" << id.station() << " Se:" << id.sector() << " Sl:" << id.superlayer()
+     << " La:" << id.layer() << " Wi:" << id.wire() << " ";
 
   return os;
 }
-
-

--- a/DataFormats/MuonDetId/src/ME0DetId.cc
+++ b/DataFormats/MuonDetId/src/ME0DetId.cc
@@ -3,74 +3,48 @@
  */
 
 #include <DataFormats/MuonDetId/interface/ME0DetId.h>
-#include <DataFormats/MuonDetId/interface/MuonSubdetId.h> 
+#include <DataFormats/MuonDetId/interface/MuonSubdetId.h>
 
-ME0DetId::ME0DetId():DetId(DetId::Muon, MuonSubdetId::ME0){}
+ME0DetId::ME0DetId() : DetId(DetId::Muon, MuonSubdetId::ME0) {}
 
-
-ME0DetId::ME0DetId(uint32_t id):DetId(id){
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::ME0) {
+ME0DetId::ME0DetId(uint32_t id) : DetId(id) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::ME0) {
     throw cms::Exception("InvalidDetId") << "ME0DetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid ME0 id";  
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid ME0 id";
   }
 }
 
-ME0DetId::ME0DetId(DetId id):DetId(id) {
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::ME0) {
+ME0DetId::ME0DetId(DetId id) : DetId(id) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::ME0) {
     throw cms::Exception("InvalidDetId") << "ME0DetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid ME0 id";  
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid ME0 id";
   }
 }
 
-ME0DetId::ME0DetId(int region, int layer,int chamber, int roll):	      
-  DetId(DetId::Muon, MuonSubdetId::ME0)
-{
-  this->init(region,layer,chamber,roll);
+ME0DetId::ME0DetId(int region, int layer, int chamber, int roll) : DetId(DetId::Muon, MuonSubdetId::ME0) {
+  this->init(region, layer, chamber, roll);
 }
 
-void
-ME0DetId::init(int region,int layer,int chamber,int roll)
-{
-  if ( region     < minRegionId    || region    > maxRegionId ||
-       layer      < minLayerId     || layer     > maxLayerId ||
-       chamber    < minChamberId   || chamber   > maxChamberId ||
-       roll       < minRollId      || roll      > maxRollId) {
-    throw cms::Exception("InvalidDetId") << "ME0DetId ctor:" 
-					 << " Invalid parameters: " 
-					 << " region "<<region
-					 << " layer "<<layer
-					 << " chamber "<<chamber
-					 << " etaPartition "<<roll
-					 << std::endl;
+void ME0DetId::init(int region, int layer, int chamber, int roll) {
+  if (region < minRegionId || region > maxRegionId || layer < minLayerId || layer > maxLayerId ||
+      chamber < minChamberId || chamber > maxChamberId || roll < minRollId || roll > maxRollId) {
+    throw cms::Exception("InvalidDetId") << "ME0DetId ctor:"
+                                         << " Invalid parameters: "
+                                         << " region " << region << " layer " << layer << " chamber " << chamber
+                                         << " etaPartition " << roll << std::endl;
   }
-  int regionInBits=region-minRegionId;
-  int layerInBits=layer-minLayerId;
-  int chamberInBits=chamber-minChamberId;
-  int rollInBits=roll-minRollId;
-  
-  id_ |= ( regionInBits    & RegionMask_)    << RegionStartBit_    | 
-         ( layerInBits     & LayerMask_)     << LayerStartBit_     |
-         ( chamberInBits   & ChamberMask_)    << ChamberStartBit_  |
-         ( rollInBits      & RollMask_)      << RollStartBit_        ;
-   
+  int regionInBits = region - minRegionId;
+  int layerInBits = layer - minLayerId;
+  int chamberInBits = chamber - minChamberId;
+  int rollInBits = roll - minRollId;
+
+  id_ |= (regionInBits & RegionMask_) << RegionStartBit_ | (layerInBits & LayerMask_) << LayerStartBit_ |
+         (chamberInBits & ChamberMask_) << ChamberStartBit_ | (rollInBits & RollMask_) << RollStartBit_;
 }
 
-
-
-std::ostream& operator<<( std::ostream& os, const ME0DetId& id ){
-
-
-  os <<  " Region "<<id.region()
-     << " Layer "<<id.layer()
-     << " Chamber "<<id.chamber()
-     << " EtaPartition "<<id.roll()
-     <<" ";
+std::ostream& operator<<(std::ostream& os, const ME0DetId& id) {
+  os << " Region " << id.region() << " Layer " << id.layer() << " Chamber " << id.chamber() << " EtaPartition "
+     << id.roll() << " ";
 
   return os;
 }
-
-

--- a/DataFormats/MuonDetId/src/RPCCompDetId.cc
+++ b/DataFormats/MuonDetId/src/RPCCompDetId.cc
@@ -2,7 +2,7 @@
 //
 // Package:     src
 // Class  :     RPCCompDetId
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -12,316 +12,235 @@
 #include <sstream>
 #include <iomanip>
 #include "DataFormats/MuonDetId/interface/RPCCompDetId.h"
-#include "DataFormats/MuonDetId/interface/MuonSubdetId.h" 
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 
-RPCCompDetId::RPCCompDetId():DetId(DetId::Muon, MuonSubdetId::RPC),_dbname(""),_type(0){}
+RPCCompDetId::RPCCompDetId() : DetId(DetId::Muon, MuonSubdetId::RPC), _dbname(""), _type(0) {}
 
-RPCCompDetId::RPCCompDetId(uint32_t id):DetId(id),_dbname(""),_type(0) {
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::RPC) {
+RPCCompDetId::RPCCompDetId(uint32_t id) : DetId(id), _dbname(""), _type(0) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::RPC) {
     throw cms::Exception("InvalidDetId") << "RPCCompDetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-      					 << " is not a valid RPC id";  
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid RPC id";
   }
 }
 
-
-
-RPCCompDetId::RPCCompDetId(DetId id):DetId(id),_dbname(""),_type(0) {
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::RPC) {
+RPCCompDetId::RPCCompDetId(DetId id) : DetId(id), _dbname(""), _type(0) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::RPC) {
     throw cms::Exception("InvalidDetId") << "RPCCompDetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid RPC id";
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid RPC id";
   }
 }
 
-
-
-RPCCompDetId::RPCCompDetId(int region,
-			   int ring,
-			   int station,
-			   int sector,
-			   int layer,
-			   int subsector,
-			   int type):
-  DetId(DetId::Muon, MuonSubdetId::RPC),_dbname(""),_type(type)
-{
-  this->init(region,ring,station,sector,layer,subsector); 
+RPCCompDetId::RPCCompDetId(int region, int ring, int station, int sector, int layer, int subsector, int type)
+    : DetId(DetId::Muon, MuonSubdetId::RPC), _dbname(""), _type(type) {
+  this->init(region, ring, station, sector, layer, subsector);
 }
 
-RPCCompDetId::RPCCompDetId(const std::string& name, int type):
-  DetId(DetId::Muon, MuonSubdetId::RPC),_dbname(name),_type(type)
-{
+RPCCompDetId::RPCCompDetId(const std::string& name, int type)
+    : DetId(DetId::Muon, MuonSubdetId::RPC), _dbname(name), _type(type) {
   this->init();
 }
 
-bool 
-RPCCompDetId::operator < (const RPCCompDetId& r) const{
-  return this->dbname()<r.dbname();
-}
+bool RPCCompDetId::operator<(const RPCCompDetId& r) const { return this->dbname() < r.dbname(); }
 
-int 
-RPCCompDetId::region() const{
-  return int((id_>>RegionStartBit_) & RegionMask_) + allRegionId;
-}
+int RPCCompDetId::region() const { return int((id_ >> RegionStartBit_) & RegionMask_) + allRegionId; }
 
-int
-RPCCompDetId::ring() const{
-  return int((id_>>RingStartBit_) & RingMask_) + allRingId;
-}
+int RPCCompDetId::ring() const { return int((id_ >> RingStartBit_) & RingMask_) + allRingId; }
 
-
-int
-RPCCompDetId::wheel() const{
-  int w=allRingId;
-  if (this->region()==0)
-    w=this->ring();
+int RPCCompDetId::wheel() const {
+  int w = allRingId;
+  if (this->region() == 0)
+    w = this->ring();
   return w;
 }
 
-int
-RPCCompDetId::station() const{
-  return int((id_>>StationStartBit_) & StationMask_) + allStationId;
-}
+int RPCCompDetId::station() const { return int((id_ >> StationStartBit_) & StationMask_) + allStationId; }
 
-int
-RPCCompDetId::disk() const{
-  int d=allStationId;
-  if (this->region()!=0)
-    d=this->station();
+int RPCCompDetId::disk() const {
+  int d = allStationId;
+  if (this->region() != 0)
+    d = this->station();
   return d;
 }
 
+int RPCCompDetId::sector() const { return int((id_ >> SectorStartBit_) & SectorMask_) + allSectorId; }
 
-int
-RPCCompDetId::sector() const{
-  return int((id_>>SectorStartBit_) & SectorMask_) + allSectorId;
-}
+int RPCCompDetId::layer() const { return int((id_ >> LayerStartBit_) & LayerMask_) + allLayerId; }
 
+int RPCCompDetId::subsector() const { return int((id_ >> SubSectorStartBit_) & SubSectorMask_) + allSubSectorId; }
 
-int
-RPCCompDetId::layer() const{
-  return int((id_>>LayerStartBit_) & LayerMask_) + allLayerId;
-}
+int RPCCompDetId::type() const { return _type; }
 
-
-int
-RPCCompDetId::subsector() const{
-  return int((id_>>SubSectorStartBit_) & SubSectorMask_) + allSubSectorId;
-}
-
-
-int
-RPCCompDetId::type() const{
-  return _type;
-}
-
-std::string
-RPCCompDetId::dbname() const{
-  std::string a=_dbname;
-  if (a.empty()){
-    if(this->type() == 0){
-      a=this->gasDBname();
+std::string RPCCompDetId::dbname() const {
+  std::string a = _dbname;
+  if (a.empty()) {
+    if (this->type() == 0) {
+      a = this->gasDBname();
     }
   }
   return a;
 }
 
-void
-RPCCompDetId::init(int region,
-		   int ring,
-		   int station,
-		   int sector,
-		   int layer,
-		   int subsector)
-{
-  int maxRing=maxRingForwardId;
-  if (!region)
-    {
-      maxRing=maxRingBarrelId;
-    }
-  
-  if ( region     < allRegionId    || region    > maxRegionId ||
-       ring       < allRingId      || ring      > maxRing ||
-       station    < allStationId   || station   > maxStationId ||
-       sector     < allSectorId    || sector    > maxSectorId ||
-       layer      < allLayerId     || layer     > maxLayerId ||
-       subsector  < allSubSectorId || subsector > maxSubSectorId ){
-    
+void RPCCompDetId::init(int region, int ring, int station, int sector, int layer, int subsector) {
+  int maxRing = maxRingForwardId;
+  if (!region) {
+    maxRing = maxRingBarrelId;
+  }
+
+  if (region < allRegionId || region > maxRegionId || ring < allRingId || ring > maxRing || station < allStationId ||
+      station > maxStationId || sector < allSectorId || sector > maxSectorId || layer < allLayerId ||
+      layer > maxLayerId || subsector < allSubSectorId || subsector > maxSubSectorId) {
     throw cms::Exception("InvalidDetId") << "RPCDetId ctor:"
                                          << " Invalid parameters: "
-                                         << " region "<<region
-                                         << " ring "<<ring
-                                         << " station "<<station
-                                         << " sector "<<sector
-                                         << " layer "<<layer
-                                         << " subsector "<<subsector
+                                         << " region " << region << " ring " << ring << " station " << station
+                                         << " sector " << sector << " layer " << layer << " subsector " << subsector
                                          << std::endl;
   }
-  int regionInBits    = region  -  allRegionId;
-  int ringInBits      = ring     - allRingId;
-  int stationInBits   = station  - allStationId;
-  int sectorInBits    = sector   - allSectorId;
-  int layerInBits     = layer    - allLayerId;
-  int subSectorInBits = subsector- allSubSectorId;
+  int regionInBits = region - allRegionId;
+  int ringInBits = ring - allRingId;
+  int stationInBits = station - allStationId;
+  int sectorInBits = sector - allSectorId;
+  int layerInBits = layer - allLayerId;
+  int subSectorInBits = subsector - allSubSectorId;
 
-  id_ |= ( regionInBits    & RegionMask_)    << RegionStartBit_    |
-         ( ringInBits      & RingMask_)      << RingStartBit_      |
-         ( stationInBits   & StationMask_)   << StationStartBit_   |
-         ( sectorInBits    & SectorMask_)    << SectorStartBit_    |
-         ( layerInBits     & LayerMask_)     << LayerStartBit_     |
-         ( subSectorInBits & SubSectorMask_) << SubSectorStartBit_ ;
+  id_ |= (regionInBits & RegionMask_) << RegionStartBit_ | (ringInBits & RingMask_) << RingStartBit_ |
+         (stationInBits & StationMask_) << StationStartBit_ | (sectorInBits & SectorMask_) << SectorStartBit_ |
+         (layerInBits & LayerMask_) << LayerStartBit_ | (subSectorInBits & SubSectorMask_) << SubSectorStartBit_;
 }
 
-void 
-RPCCompDetId::init()
-{
-  if (this->type()==0){
+void RPCCompDetId::init() {
+  if (this->type() == 0) {
     this->initGas();
   }
 }
 
-void
-RPCCompDetId::initGas()
-{
-  std::string buf(this->dbname()); 
+void RPCCompDetId::initGas() {
+  std::string buf(this->dbname());
   // check if the name contains the dcs namespace
-  if (buf.find(':')!=buf.npos){
-    buf = buf.substr(buf.find(':')+1,buf.npos);
+  if (buf.find(':') != buf.npos) {
+    buf = buf.substr(buf.find(':') + 1, buf.npos);
   }
-  _dbname=buf;
+  _dbname = buf;
   // Check if endcap o barrel
-  int region=0;
-  if(buf.substr(0,1)=="W"){
-    region=0;
-  }else if(buf.substr(0,2)=="EP"){
-    region=1;
-  }else if(buf.substr(0,2)=="EM"){
-    region=-1;
-  }else{
-    throw cms::Exception("InvalidDBName")<<" RPCCompDetId: "<<this->dbname()
-					 <<" is not a valid DB Name for RPCCompDetId"
-                                         << " det: " << det()
-					 << " subdet: " << subdetId();
+  int region = 0;
+  if (buf.substr(0, 1) == "W") {
+    region = 0;
+  } else if (buf.substr(0, 2) == "EP") {
+    region = 1;
+  } else if (buf.substr(0, 2) == "EM") {
+    region = -1;
+  } else {
+    throw cms::Exception("InvalidDBName")
+        << " RPCCompDetId: " << this->dbname() << " is not a valid DB Name for RPCCompDetId"
+        << " det: " << det() << " subdet: " << subdetId();
   }
-  int ring=allRingId;
+  int ring = allRingId;
   int station = allStationId;
-  int sector=allSectorId;
-  int layer=allLayerId;
-  int subsector=allSubSectorId;
-    //Barrel
-  if (region==0) {
+  int sector = allSectorId;
+  int layer = allLayerId;
+  int subsector = allSubSectorId;
+  //Barrel
+  if (region == 0) {
     // Extract the Wheel (named ring)
     {
       std::stringstream os;
-      os<<buf.substr(2,1);
-      os>>ring;
-      if (buf.substr(1,1)=="M"){
-	ring *= -1;
+      os << buf.substr(2, 1);
+      os >> ring;
+      if (buf.substr(1, 1) == "M") {
+        ring *= -1;
       }
     }
     //Extract the station
     {
       std::stringstream os;
-      os<<buf.substr(buf.find("RB")+2,1);
-      os>>station;
+      os << buf.substr(buf.find("RB") + 2, 1);
+      os >> station;
     }
     //Extract the sector
     {
       std::stringstream os;
-      os<<buf.substr(buf.find("S")+1,2);
-      os>>sector;
+      os << buf.substr(buf.find("S") + 1, 2);
+      os >> sector;
     }
     //Extract subsector of sectors 4 and 10
     {
-      if (buf.find("4L")!=buf.npos)
-	subsector=1;
-      if (buf.find("4R")!=buf.npos)
-	subsector=2;
+      if (buf.find("4L") != buf.npos)
+        subsector = 1;
+      if (buf.find("4R") != buf.npos)
+        subsector = 2;
     }
-  }else{
-  // Extract the Ring 
+  } else {
+    // Extract the Ring
     {
       std::stringstream os;
-      os<<buf.substr(buf.find("_R0")+3,1);
-      os>>ring;
+      os << buf.substr(buf.find("_R0") + 3, 1);
+      os >> ring;
     }
-  //Extract the disk (named station)
+    //Extract the disk (named station)
     {
       std::stringstream os;
-      os<<buf.substr(2,1);
-      os>>station;
+      os << buf.substr(2, 1);
+      os >> station;
     }
     //Extract the sector or chamber
     {
       std::stringstream os;
-      os<<buf.substr(buf.find("_C")+2,2);
-      os>>sector;
+      os << buf.substr(buf.find("_C") + 2, 2);
+      os >> sector;
     }
     //Extract layer
     {
-      if (buf.find("UP")!=buf.npos)
-	layer=1;
-      if (buf.find("DW")!=buf.npos)
-	layer=2;
+      if (buf.find("UP") != buf.npos)
+        layer = 1;
+      if (buf.find("DW") != buf.npos)
+        layer = 2;
     }
   }
-  this->init(region,ring,station,sector,layer,subsector); 
+  this->init(region, ring, station, sector, layer, subsector);
 }
 
-std::string
-RPCCompDetId::gasDBname() const{
+std::string RPCCompDetId::gasDBname() const {
   std::stringstream os;
-  if(this->region()==0){
+  if (this->region() == 0) {
     // Barrel
-    std::string wsign="P";
-    if (this->wheel()<0)wsign= "M";
-    std::string lr="";
-    if (this->subsector()==1) lr="L";
-    if (this->subsector()==2) lr="R";
-    os<<"W"<<wsign<<abs(this->wheel())<<"_S"<<std::setw(2)<<std::setfill('0')<<this->sector()<<"_RB"<<this->station()<<lr;
+    std::string wsign = "P";
+    if (this->wheel() < 0)
+      wsign = "M";
+    std::string lr = "";
+    if (this->subsector() == 1)
+      lr = "L";
+    if (this->subsector() == 2)
+      lr = "R";
+    os << "W" << wsign << abs(this->wheel()) << "_S" << std::setw(2) << std::setfill('0') << this->sector() << "_RB"
+       << this->station() << lr;
   } else {
     // Endcap
-    std::string esign="P";
-    if (this->region()<0)
-      esign="M";
+    std::string esign = "P";
+    if (this->region() < 0)
+      esign = "M";
 
-    os<<"E"<<esign<<this->disk();
+    os << "E" << esign << this->disk();
 
-
-    if (this->disk()==1){
-      os<<"_R"<<std::setw(2)<<std::setfill('0')<<this->ring()
-	<<"_C"<<std::setw(2)<<std::setfill('0')<<this->sector()
-	<<"_C"<<std::setw(2)<<std::setfill('0')<<this->sector()+5;
-    }else{
-      os<<"_R"<<std::setw(2)<<std::setfill('0')<<this->ring()
-	<<"_R"<<std::setw(2)<<std::setfill('0')<<this->ring()+1
-	<<"_C"<<std::setw(2)<<std::setfill('0')<<this->sector()
-	<<"_C"<<std::setw(2)<<std::setfill('0')<<this->sector()+2;
-     
+    if (this->disk() == 1) {
+      os << "_R" << std::setw(2) << std::setfill('0') << this->ring() << "_C" << std::setw(2) << std::setfill('0')
+         << this->sector() << "_C" << std::setw(2) << std::setfill('0') << this->sector() + 5;
+    } else {
+      os << "_R" << std::setw(2) << std::setfill('0') << this->ring() << "_R" << std::setw(2) << std::setfill('0')
+         << this->ring() + 1 << "_C" << std::setw(2) << std::setfill('0') << this->sector() << "_C" << std::setw(2)
+         << std::setfill('0') << this->sector() + 2;
     }
-    std::string lay="";
-    if(this->layer()==1)
-      lay="UP";
-    else if (this->layer()==2)
-      lay="DW";
+    std::string lay = "";
+    if (this->layer() == 1)
+      lay = "UP";
+    else if (this->layer() == 2)
+      lay = "DW";
 
-    os<<"_"<<lay;
-      
- }
+    os << "_" << lay;
+  }
   return os.str();
 }
 
-std::ostream& operator<<( std::ostream& os, const RPCCompDetId& id ){
-
-  os <<id.dbname();
+std::ostream& operator<<(std::ostream& os, const RPCCompDetId& id) {
+  os << id.dbname();
 
   return os;
 }
-
-
-
-
-
-

--- a/DataFormats/MuonDetId/src/RPCDetId.cc
+++ b/DataFormats/MuonDetId/src/RPCDetId.cc
@@ -6,167 +6,164 @@
  */
 
 #include <DataFormats/MuonDetId/interface/RPCDetId.h>
-#include <DataFormats/MuonDetId/interface/MuonSubdetId.h> 
+#include <DataFormats/MuonDetId/interface/MuonSubdetId.h>
 
-#include<iostream>
+#include <iostream>
 
-RPCDetId::RPCDetId():DetId(DetId::Muon, MuonSubdetId::RPC),trind(0){}
+RPCDetId::RPCDetId() : DetId(DetId::Muon, MuonSubdetId::RPC), trind(0) {}
 
-
-RPCDetId::RPCDetId(uint32_t id):DetId(id),trind(0) {
+RPCDetId::RPCDetId(uint32_t id) : DetId(id), trind(0) {
   //  std::cout<<" constructor of the RPCDetId" <<std::endl;
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::RPC) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::RPC) {
     throw cms::Exception("InvalidDetId") << "RPCDetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid RPC id";  
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid RPC id";
   }
 }
-RPCDetId::RPCDetId(DetId id):DetId(id),trind(0) {
+RPCDetId::RPCDetId(DetId id) : DetId(id), trind(0) {
   //  std::cout<<" constructor of the RPCDetId" <<std::endl;
-  if (det()!=DetId::Muon || subdetId()!=MuonSubdetId::RPC) {
+  if (det() != DetId::Muon || subdetId() != MuonSubdetId::RPC) {
     throw cms::Exception("InvalidDetId") << "RPCDetId ctor:"
-					 << " det: " << det()
-					 << " subdet: " << subdetId()
-					 << " is not a valid RPC id";  
+                                         << " det: " << det() << " subdet: " << subdetId() << " is not a valid RPC id";
   }
 }
 
-
-
-RPCDetId::RPCDetId(int region, int ring, int station, int sector, int layer,int subsector, int roll):	      
-  DetId(DetId::Muon, MuonSubdetId::RPC),trind(0)
-{
-  this->init(region,ring,station,sector,layer,subsector,roll);
+RPCDetId::RPCDetId(int region, int ring, int station, int sector, int layer, int subsector, int roll)
+    : DetId(DetId::Muon, MuonSubdetId::RPC), trind(0) {
+  this->init(region, ring, station, sector, layer, subsector, roll);
 }
 
-
-void 
-RPCDetId::buildfromDB(int region, int ring, int trlayer, int sector, 
-		      const std::string& subs,
-		      const std::string& roll,
-		      const std::string& dbname){
-
-  bool barrel = (region==0);
+void RPCDetId::buildfromDB(int region,
+                           int ring,
+                           int trlayer,
+                           int sector,
+                           const std::string& subs,
+                           const std::string& roll,
+                           const std::string& dbname) {
+  bool barrel = (region == 0);
   //STATION
   int station = -1;
   if (barrel) {
-    if (trlayer==1 || trlayer==2) station = 1;
-    else if (trlayer==3 || trlayer==4) station = 2;
-    else station = trlayer-2;
-  } else {   
-   station = abs(ring); 
+    if (trlayer == 1 || trlayer == 2)
+      station = 1;
+    else if (trlayer == 3 || trlayer == 4)
+      station = 2;
+    else
+      station = trlayer - 2;
+  } else {
+    station = abs(ring);
   }
-
 
   //LAYER
   //int layer = 1;
   //if (barrel && station==1) layer = trlayer;
-  //if (barrel && station==2) layer = trlayer-2; 
+  //if (barrel && station==2) layer = trlayer-2;
 
   //SUBSECTOR
   int subsector = 1;
 
   if (barrel) {
-    if (station==3 && subs=="+") subsector = 2;
-    if (station==4 && 
-         (   sector==1 || sector==2 || sector==3 
-                       || sector==5 || sector==6   
-          || sector==7 || sector==8 
-          || sector==10             || sector==12)
-          && (subs=="+")) {
-         subsector = 2;
+    if (station == 3 && subs == "+")
+      subsector = 2;
+    if (station == 4 &&
+        (sector == 1 || sector == 2 || sector == 3 || sector == 5 || sector == 6 || sector == 7 || sector == 8 ||
+         sector == 10 || sector == 12) &&
+        (subs == "+")) {
+      subsector = 2;
     }
 
-    if (station==4 && sector==4) {
-      if (subs=="--") subsector=1;
-      if (subs=="-")  subsector=2;
-      if (subs=="+")  subsector=3;
-      if (subs=="++") subsector=4;
-    } 
+    if (station == 4 && sector == 4) {
+      if (subs == "--")
+        subsector = 1;
+      if (subs == "-")
+        subsector = 2;
+      if (subs == "+")
+        subsector = 3;
+      if (subs == "++")
+        subsector = 4;
+    }
   }
 
-   // ROLL
-  int iroll=0;
+  // ROLL
+  int iroll = 0;
 
-  if      (roll=="Backward" || roll=="A") iroll = 1;
-  else if (roll=="Central" || roll=="B") iroll = 2;
-  else if (roll=="Forward" || roll=="C") iroll = 3;
-  else if (roll=="D") iroll = 4;
+  if (roll == "Backward" || roll == "A")
+    iroll = 1;
+  else if (roll == "Central" || roll == "B")
+    iroll = 2;
+  else if (roll == "Forward" || roll == "C")
+    iroll = 3;
+  else if (roll == "D")
+    iroll = 4;
   else {
-    std::cout << "** RPC: DBSpecToDetUnit, how to assigne roll to: "
-         <<roll<<" ???" << std::endl;
+    std::cout << "** RPC: DBSpecToDetUnit, how to assigne roll to: " << roll << " ???" << std::endl;
   }
 
   int trIndex = 0;
-  if(barrel){   
-    //cout <<" BARREL: " << endl; 
-    int eta_id = 6+ring;
+  if (barrel) {
+    //cout <<" BARREL: " << endl;
+    int eta_id = 6 + ring;
     int plane_id = station;
-    if(trlayer==2) plane_id=5;
-    if(trlayer==4) plane_id=6;
-    int sector_id = sector*3;
+    if (trlayer == 2)
+      plane_id = 5;
+    if (trlayer == 4)
+      plane_id = 6;
+    int sector_id = sector * 3;
     int copy_id = subsector;
     int roll_id = iroll;
-    trIndex=(eta_id*10000+plane_id*1000+sector_id*10+copy_id)*10+roll_id;
-  } 
-  else { 
+    trIndex = (eta_id * 10000 + plane_id * 1000 + sector_id * 10 + copy_id) * 10 + roll_id;
+  } else {
     //    cout << "ENDCAP : " << endl;
     int eta_id = trlayer;
-    if(ring>0) eta_id = 12-trlayer;
+    if (ring > 0)
+      eta_id = 12 - trlayer;
     int plane_id = abs(ring);
     int sector_id = sector;
 
-    if (region <0){
-      if (sector_id < 20 ){
-	sector_id = 19+ 1-sector_id;
-      }else{
-	sector_id = 36+20-sector_id;
+    if (region < 0) {
+      if (sector_id < 20) {
+        sector_id = 19 + 1 - sector_id;
+      } else {
+        sector_id = 36 + 20 - sector_id;
       }
     }
-    sector_id-=1;
+    sector_id -= 1;
 
     //
     int copy_id = 1;
     int roll_id = iroll;
-    trIndex=(eta_id*10000+plane_id*1000+sector_id*10+copy_id)*10+ roll_id;
+    trIndex = (eta_id * 10000 + plane_id * 1000 + sector_id * 10 + copy_id) * 10 + roll_id;
   }
   this->buildfromTrIndex(trIndex);
 }
 
-void
-RPCDetId::buildfromTrIndex(int trIndex)
-{
+void RPCDetId::buildfromTrIndex(int trIndex) {
   trind = trIndex;
-  int eta_id = trIndex/100000;
-  int region=0;
-  int ring =0; 
-  if (eta_id <=3 ){
+  int eta_id = trIndex / 100000;
+  int region = 0;
+  int ring = 0;
+  if (eta_id <= 3) {
     region = -1;
     ring = eta_id;
-  }
-  else if (eta_id >=9 ) {
+  } else if (eta_id >= 9) {
     region = 1;
-    ring = 12-eta_id;
-  }
-  else{
+    ring = 12 - eta_id;
+  } else {
     region = 0;
     ring = eta_id - 6;
   }
-  trIndex = trIndex%100000;
-  int plane_id = trIndex/10000;
-  int station=0;
-  int layer=0;
-  if (plane_id <=4){
+  trIndex = trIndex % 100000;
+  int plane_id = trIndex / 10000;
+  int station = 0;
+  int layer = 0;
+  if (plane_id <= 4) {
     station = plane_id;
     layer = 1;
-  }
-  else{
-    station = plane_id -4;
+  } else {
+    station = plane_id - 4;
     layer = 2;
   }
-  trIndex = trIndex%10000;
-  int sector_id = trIndex/100;
+  trIndex = trIndex % 10000;
+  int sector_id = trIndex / 100;
 
   // RE+1/1 :: the chamber at x=0 (phi=0) start as CH02 instead of CH01, which is not desired
   // while for other chambers: RE+1/(2,3) and RE+2,3,4/(2,3) the rotation seems to be arbitrary
@@ -176,121 +173,90 @@ RPCDetId::buildfromTrIndex(int trIndex)
   // - it affects the whole RE+/-1 Station
   // - it affects all RE+(1,2,3,4)/(2,3)
   // ==> why does it act differently on RE-(2,3,4)/1 and RE+(2,3,4)/1 ???
-  if (region!=0) {
-    if ( !(ring == 1 && station > 1 && region==1)) {
+  if (region != 0) {
+    if (!(ring == 1 && station > 1 && region == 1)) {
       // skip RE+1/1 (ri=1, st=1, re=-1,+1)
-      if(!(ring == 1 && station == 1 && region!=0)) {
-	sector_id+=1;
-	if (sector_id==37) sector_id=1;
+      if (!(ring == 1 && station == 1 && region != 0)) {
+        sector_id += 1;
+        if (sector_id == 37)
+          sector_id = 1;
       }
     }
   }
-    
-  if (region==-1){
-    if (sector_id < 20 ){
-      sector_id = 19+ 1-sector_id;
-    }else{
-      sector_id = 36+20-sector_id;
+
+  if (region == -1) {
+    if (sector_id < 20) {
+      sector_id = 19 + 1 - sector_id;
+    } else {
+      sector_id = 36 + 20 - sector_id;
     }
   }
-  trIndex = trIndex%100;
-  int copy_id = trIndex/10;
-  int sector=(sector_id-1)/3+1;
-  if (region!=0) {
-    sector=(sector+1)/2;
+  trIndex = trIndex % 100;
+  int copy_id = trIndex / 10;
+  int sector = (sector_id - 1) / 3 + 1;
+  if (region != 0) {
+    sector = (sector + 1) / 2;
   }
-  int subsector=0;
-  if ( region == 0 ) {
+  int subsector = 0;
+  if (region == 0) {
     subsector = copy_id;
-  }
-  else {
-    if ( ring == 1 && station > 1) {
+  } else {
+    if (ring == 1 && station > 1) {
       // 20 degree chambers
-       subsector = ((sector_id+1)/2-1)%3+1;
-    }else {
+      subsector = ((sector_id + 1) / 2 - 1) % 3 + 1;
+    } else {
       // 10 degree chambers
-      subsector = (sector_id-1)%6+1;
+      subsector = (sector_id - 1) % 6 + 1;
     }
-//     std::cout <<" RE"<<station*region<<"/"<<ring<<" sector_id "<<sector_id
-//    	      << " sector "<<sector <<" sub "<<subsector<<std::endl;
+    //     std::cout <<" RE"<<station*region<<"/"<<ring<<" sector_id "<<sector_id
+    //    	      << " sector "<<sector <<" sub "<<subsector<<std::endl;
   }
 
-
-  int roll=trIndex%10;
-  this->init(region,ring,station,sector,layer,subsector,roll);
+  int roll = trIndex % 10;
+  this->init(region, ring, station, sector, layer, subsector, roll);
 }
 
-
-
-void
-RPCDetId::init(int region,int ring,int station,int sector,
-	       int layer,int subsector,int roll)
-{
-  int minRing=0;
-  int maxRing=RPCDetId::maxRingForwardId;
-  if (!region) 
-    {
-      minRing=RPCDetId::minRingBarrelId;
-      maxRing=RPCDetId::maxRingBarrelId;
-    } 
-  
-  if ( region     < minRegionId    || region    > maxRegionId ||
-       ring       < minRing        || ring      > maxRing ||
-       station    < minStationId   || station   > maxStationId ||
-       sector     < minSectorId    || sector    > maxSectorId ||
-       layer      < minLayerId     || layer     > maxLayerId ||
-       subsector  < minSubSectorId || subsector > maxSubSectorId ||
-       roll       < minRollId      || roll      > maxRollId) {
-    throw cms::Exception("InvalidDetId") << "RPCDetId ctor:" 
-					 << " Invalid parameters: " 
-					 << " region "<<region
-					 << " ring "<<ring
-					 << " station "<<station
-					 << " sector "<<sector
-					 << " layer "<<layer
-					 << " subsector "<<subsector
-					 << " roll "<<roll
-					 << std::endl;
+void RPCDetId::init(int region, int ring, int station, int sector, int layer, int subsector, int roll) {
+  int minRing = 0;
+  int maxRing = RPCDetId::maxRingForwardId;
+  if (!region) {
+    minRing = RPCDetId::minRingBarrelId;
+    maxRing = RPCDetId::maxRingBarrelId;
   }
-	      
-  
-  int regionInBits=region-minRegionId;
-  int ringInBits =0;
-  if(region != 0) ringInBits = ring - minRingForwardId;
-  if(!region) ringInBits = ring + RingBarrelOffSet - minRingBarrelId;
-  
-  int stationInBits=station-minStationId;
-  int sectorInBits=sector-(minSectorId+1);
-  int layerInBits=layer-minLayerId;
-  int subSectorInBits=subsector-(minSubSectorId+1);
-  int rollInBits=roll;
-  
-  id_ |= ( regionInBits    & RegionMask_)    << RegionStartBit_    | 
-         ( ringInBits      & RingMask_)      << RingStartBit_      |
-         ( stationInBits   & StationMask_)   << StationStartBit_   |
-         ( sectorInBits    & SectorMask_)    << SectorStartBit_    |
-         ( layerInBits     & LayerMask_)     << LayerStartBit_     |
-         ( subSectorInBits & SubSectorMask_) << SubSectorStartBit_ |
-         ( rollInBits      & RollMask_)      << RollStartBit_        ;
-   
+
+  if (region < minRegionId || region > maxRegionId || ring < minRing || ring > maxRing || station < minStationId ||
+      station > maxStationId || sector < minSectorId || sector > maxSectorId || layer < minLayerId ||
+      layer > maxLayerId || subsector < minSubSectorId || subsector > maxSubSectorId || roll < minRollId ||
+      roll > maxRollId) {
+    throw cms::Exception("InvalidDetId") << "RPCDetId ctor:"
+                                         << " Invalid parameters: "
+                                         << " region " << region << " ring " << ring << " station " << station
+                                         << " sector " << sector << " layer " << layer << " subsector " << subsector
+                                         << " roll " << roll << std::endl;
+  }
+
+  int regionInBits = region - minRegionId;
+  int ringInBits = 0;
+  if (region != 0)
+    ringInBits = ring - minRingForwardId;
+  if (!region)
+    ringInBits = ring + RingBarrelOffSet - minRingBarrelId;
+
+  int stationInBits = station - minStationId;
+  int sectorInBits = sector - (minSectorId + 1);
+  int layerInBits = layer - minLayerId;
+  int subSectorInBits = subsector - (minSubSectorId + 1);
+  int rollInBits = roll;
+
+  id_ |= (regionInBits & RegionMask_) << RegionStartBit_ | (ringInBits & RingMask_) << RingStartBit_ |
+         (stationInBits & StationMask_) << StationStartBit_ | (sectorInBits & SectorMask_) << SectorStartBit_ |
+         (layerInBits & LayerMask_) << LayerStartBit_ | (subSectorInBits & SubSectorMask_) << SubSectorStartBit_ |
+         (rollInBits & RollMask_) << RollStartBit_;
 }
 
-
-
-std::ostream& operator<<( std::ostream& os, const RPCDetId& id ){
-
-
-  os <<  " Re "<<id.region()
-     << " Ri "<<id.ring()
-     << " St "<<id.station()
-     << " Se "<<id.sector()
-     << " La "<<id.layer()
-     << " Su "<<id.subsector()
-     << " Ro "<<id.roll()
-     << " Tr "<<id.trIndex()
-     <<" ";
+std::ostream& operator<<(std::ostream& os, const RPCDetId& id) {
+  os << " Re " << id.region() << " Ri " << id.ring() << " St " << id.station() << " Se " << id.sector() << " La "
+     << id.layer() << " Su " << id.subsector() << " Ro " << id.roll() << " Tr " << id.trIndex() << " ";
 
   return os;
 }
-
-

--- a/DataFormats/MuonDetId/src/classes.h
+++ b/DataFormats/MuonDetId/src/classes.h
@@ -1,6 +1,6 @@
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include <DataFormats/MuonDetId/interface/MuonSubdetId.h> 
-#include <boost/cstdint.hpp> 
+#include <DataFormats/MuonDetId/interface/MuonSubdetId.h>
+#include <boost/cstdint.hpp>
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"

--- a/DataFormats/MuonDetId/test/CSCDetIdAnalyzer.cc
+++ b/DataFormats/MuonDetId/test/CSCDetIdAnalyzer.cc
@@ -12,175 +12,166 @@
 #include <DataFormats/GeometryVector/interface/Pi.h>
 
 #include <cmath>
-#include <iomanip> // for setw() etc.
+#include <iomanip>  // for setw() etc.
 #include <string>
 #include <vector>
 
 class CSCDetIdAnalyzer : public edm::EDAnalyzer {
+public:
+  explicit CSCDetIdAnalyzer(const edm::ParameterSet&);
+  ~CSCDetIdAnalyzer();
 
-   public:
- 
-     explicit CSCDetIdAnalyzer( const edm::ParameterSet& );
-      ~CSCDetIdAnalyzer();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-      virtual void analyze( const edm::Event&, const edm::EventSetup& );
- 
-      const std::string& myName() { return myName_;}
+  const std::string& myName() { return myName_; }
 
-   private: 
-
-      const int dashedLineWidth_;
-      const std::string dashedLine_;
-      const std::string myName_;
+private:
+  const int dashedLineWidth_;
+  const std::string dashedLine_;
+  const std::string myName_;
 };
 
-CSCDetIdAnalyzer::CSCDetIdAnalyzer( const edm::ParameterSet& iConfig )
- : dashedLineWidth_(140), dashedLine_( std::string(dashedLineWidth_, '-') ), 
-  myName_( "CSCDetIdAnalyzer" )
-{
+CSCDetIdAnalyzer::CSCDetIdAnalyzer(const edm::ParameterSet& iConfig)
+    : dashedLineWidth_(140), dashedLine_(std::string(dashedLineWidth_, '-')), myName_("CSCDetIdAnalyzer") {
   std::cout << dashedLine_ << std::endl;
   std::cout << "Welcome to " << myName_ << std::endl;
   std::cout << dashedLine_ << std::endl;
   std::cout << "I will build the CSC geometry, then iterate over all layers." << std::endl;
   std::cout << "From each CSCDetId I will build the associated linear index, skipping ME1a layers." << std::endl;
-  std::cout << "I will build this index once from the layer labels and once from the CSCDetId, and check they agree." << std::endl;
-  std::cout << "I will output one line per layer, listing the CSCDetId, the labels, and these two indexes." << std::endl;
+  std::cout << "I will build this index once from the layer labels and once from the CSCDetId, and check they agree."
+            << std::endl;
+  std::cout << "I will output one line per layer, listing the CSCDetId, the labels, and these two indexes."
+            << std::endl;
   std::cout << "I will append the strip-channel indexes for the two edge strips and the central strip." << std::endl;
-  std::cout << "Finally, I will rebuild a CSCDetId from the layer index, and check it is the same as the original," << std::endl;
-  std::cout << "and rebuild a CSCDetId from the final strip-channel index, and check it is the same as the original." << std::endl;
+  std::cout << "Finally, I will rebuild a CSCDetId from the layer index, and check it is the same as the original,"
+            << std::endl;
+  std::cout << "and rebuild a CSCDetId from the final strip-channel index, and check it is the same as the original."
+            << std::endl;
   std::cout << "If any of these tests fail, you will see assert failure messages in the output." << std::endl;
   std::cout << "If there are no such failures then the tests passed." << std::endl;
   std::cout << dashedLine_ << std::endl;
 }
 
+CSCDetIdAnalyzer::~CSCDetIdAnalyzer() {}
 
-CSCDetIdAnalyzer::~CSCDetIdAnalyzer(){}
+void CSCDetIdAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const double dPi = Geom::pi();
+  const double radToDeg = 180. / dPi;
 
-void CSCDetIdAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-   const double dPi = Geom::pi();
-   const double radToDeg = 180. / dPi;
+  std::cout << myName() << ": Analyzer..." << std::endl;
+  std::cout << "start " << dashedLine_ << std::endl;
+  std::cout << "pi = " << dPi << ", radToDeg = " << radToDeg << std::endl;
 
-   std::cout << myName() << ": Analyzer..." << std::endl;
-   std::cout << "start " << dashedLine_ << std::endl;
-   std::cout << "pi = " << dPi << ", radToDeg = " << radToDeg << std::endl;
+  edm::ESHandle<CSCGeometry> pDD;
+  iSetup.get<MuonGeometryRecord>().get(pDD);
+  std::cout << " Geometry node for CSCGeom is  " << &(*pDD) << std::endl;
+  std::cout << " I have " << pDD->detTypes().size() << " detTypes" << std::endl;
+  std::cout << " I have " << pDD->detUnits().size() << " detUnits" << std::endl;
+  std::cout << " I have " << pDD->dets().size() << " dets" << std::endl;
+  std::cout << " I have " << pDD->layers().size() << " layers" << std::endl;
+  std::cout << " I have " << pDD->chambers().size() << " chambers" << std::endl;
 
-   edm::ESHandle<CSCGeometry> pDD;
-   iSetup.get<MuonGeometryRecord>().get( pDD );     
-   std::cout << " Geometry node for CSCGeom is  " << &(*pDD) << std::endl;   
-   std::cout << " I have "<<pDD->detTypes().size()    << " detTypes" << std::endl;
-   std::cout << " I have "<<pDD->detUnits().size()    << " detUnits" << std::endl;
-   std::cout << " I have "<<pDD->dets().size()        << " dets" << std::endl;
-   std::cout << " I have "<<pDD->layers().size()      << " layers" << std::endl;
-   std::cout << " I have "<<pDD->chambers().size()    << " chambers" << std::endl;
+  std::cout << myName() << ": Begin iteration over geometry..." << std::endl;
+  std::cout << "iter " << dashedLine_ << std::endl;
 
+  std::cout << "\n  #     id(dec)      id(oct)                        "
+               "lindex     lindex2      cindex       label       strip  sindex   strip  sindex   strip  sindex"
+            << std::endl;
 
-   std::cout << myName() << ": Begin iteration over geometry..." << std::endl;
-   std::cout << "iter " << dashedLine_ << std::endl;
+  // Construct an indexer object
+  CSCIndexer* theIndexer = new CSCIndexer;
 
-   std::cout << "\n  #     id(dec)      id(oct)                        "
-     "lindex     lindex2      cindex       label       strip  sindex   strip  sindex   strip  sindex" << std::endl;
+  int icount = 0;
+  int icountAll = 0;
 
- // Construct an indexer object
-   CSCIndexer* theIndexer = new CSCIndexer;
+  // Iterate over the DetUnits in the CSCGeometry
+  for (const auto& it : pDD->detUnits()) {
+    // Check each DetUnit really is a CSC layer
+    auto layer = dynamic_cast<CSCLayer const*>(it);
 
-   int icount = 0;
-   int icountAll = 0;
+    if (layer) {
+      ++icountAll;  // how many layers we see
 
-   // Iterate over the DetUnits in the CSCGeometry
-   for( const auto& it : pDD->detUnits()) {
+      // What's its DetId?
 
-     // Check each DetUnit really is a CSC layer
-     auto layer = dynamic_cast<CSCLayer const*>( it );
-     
-      if( layer ) {
-        ++icountAll; // how many layers we see
+      DetId detId = layer->geographicalId();
+      int id = detId();  // or detId.rawId()
+      CSCDetId cscDetId = layer->id();
 
-	// What's its DetId?
+      // There's going to be a lot of messing with field width (and precision) so
+      // save input values...
+      int iw = std::cout.width();      // save current width
+      int ip = std::cout.precision();  // save current precision
 
-        DetId detId = layer->geographicalId();
-        int id = detId(); // or detId.rawId()
-        CSCDetId cscDetId = layer->id();
+      short ie = CSCDetId::endcap(id);
+      short is = CSCDetId::station(id);
+      short ir = CSCDetId::ring(id);
+      short ic = CSCDetId::chamber(id);
+      short il = CSCDetId::layer(id);
 
-	// There's going to be a lot of messing with field width (and precision) so
-	// save input values...
-        int iw = std::cout.width(); // save current width
-        int ip = std::cout.precision(); // save current precision
+      if (ir == 4)
+        continue;  // DOES NOT HANDLE ME1a SEPARATELY FROM ME11
+      ++icount;    // count ONLY non-ME1a layers!
 
-	short ie = CSCDetId::endcap(id);
-	short is = CSCDetId::station(id);
-	short ir = CSCDetId::ring(id);
-	short ic = CSCDetId::chamber(id);
-        short il = CSCDetId::layer(id);
+      std::cout << std::setw(4) << icount << std::setw(12) << id << std::oct << std::setw(12) << id << std::dec
+                << std::setw(iw) << "   E" << ie << " S" << is << " R" << ir << " C" << std::setw(2) << ic
+                << std::setw(iw) << " L" << il;
 
-        if ( ir == 4 ) continue; // DOES NOT HANDLE ME1a SEPARATELY FROM ME11
-	   ++icount; // count ONLY non-ME1a layers!
+      unsigned lind = theIndexer->layerIndex(ie, is, ir, ic, il);
+      unsigned cind = theIndexer->startChamberIndexInEndcap(ie, is, ir) + ic - 1;
+      unsigned lind2 = theIndexer->layerIndex(cscDetId);
 
-	   std::cout <<
-	   std::setw( 4 ) << icount << 
-  	   std::setw(12) << id << std::oct << std::setw(12) << id << std::dec << std::setw( iw ) <<
-           "   E" << ie << " S" << is << " R" << ir << " C" << std::setw( 2 ) << ic << std::setw( iw ) << " L" << il;
+      //	   std::cout << std::setw(12) << std::setw(12) << lind << std::setw(12) << lind2 << "     " << std::endl;
+      std::cout << std::setw(12) << lind << std::setw(12) << lind2 << std::setw(12) << cind << std::setw(12)
+                << theIndexer->chamberLabelFromChamberIndex(cind) << "     ";
 
-	   unsigned lind = theIndexer->layerIndex( ie, is, ir, ic, il );
-	   unsigned cind = theIndexer->startChamberIndexInEndcap( ie, is, ir ) + ic - 1; 
-	   unsigned lind2 = theIndexer->layerIndex( cscDetId );
+      // Index a few strips
+      unsigned short nstrips = theIndexer->stripChannelsPerLayer(is, ir);
+      unsigned int sc1 = theIndexer->stripChannelIndex(ie, is, ir, ic, il, 1);
+      unsigned int scm = theIndexer->stripChannelIndex(ie, is, ir, ic, il, nstrips / 2);
+      unsigned int scn = theIndexer->stripChannelIndex(ie, is, ir, ic, il, nstrips);
 
-	   //	   std::cout << std::setw(12) << std::setw(12) << lind << std::setw(12) << lind2 << "     " << std::endl;
-	   std::cout << std::setw(12) << lind << std::setw(12) << lind2 << std::setw(12)<< cind << std::setw(12) <<  theIndexer->chamberLabelFromChamberIndex(cind) << "     " ;
+      std::cout << "      1  " << std::setw(6) << sc1 << "      " << nstrips / 2 << "  " << std::setw(6) << scm
+                << "      " << nstrips << "  " << std::setw(6) << scn << std::endl;
 
-           // Index a few strips
-           unsigned short nstrips = theIndexer->stripChannelsPerLayer(is,ir);
-	   unsigned int sc1 = theIndexer->stripChannelIndex(ie, is, ir, ic, il, 1);
-	   unsigned int scm = theIndexer->stripChannelIndex(ie, is, ir, ic, il, nstrips/2);
-	   unsigned int scn = theIndexer->stripChannelIndex(ie, is, ir, ic, il, nstrips);
+      // Reset the values we changed
+      std::cout << std::setprecision(ip) << std::setw(iw);
 
-	   std::cout << "      1  " << std::setw(6) << sc1 << "      " << nstrips/2 << "  " <<
-                   	               std::setw(6) << scm << "      " << nstrips << "  " <<
-                                       std::setw(6) << scn << std::endl;
+      // ASSERTS
+      // =======
 
-	   // Reset the values we changed
-	   std::cout << std::setprecision( ip ) << std::setw( iw );
+      // Check layer indices are consistent
+      //	   std::cout << "lind2 = " << lind2 << ", lind=" << lind << std::endl;
+      assert(lind2 == lind);
 
+      // Build CSCDetId from this index and check it's same as original
+      CSCDetId cscDetId2 = theIndexer->detIdFromLayerIndex(lind);
+      // std::cout << "cscDetId2 = E" << cscDetId2.endcap() << " S" << cscDetId2.station() << " R" << cscDetId2.ring() << " C" << cscDetId2.chamber() << " L" << cscDetId2.layer() << std::endl;
+      assert(cscDetId2 == cscDetId);
 
+      // Build CSCDetId from the strip-channel index for strip 'nstrips' and check it matches
+      std::pair<CSCDetId, unsigned short int> p = theIndexer->detIdFromStripChannelIndex(scn);
+      CSCDetId cscDetId3 = p.first;
+      unsigned short iscn = p.second;
+      // std::cout << "scn=" << scn << "  iscn=" << iscn << std::endl;
+      // std::cout << "cscDetId3 = E" << cscDetId3.endcap() << " S" << cscDetId3.station() << " R" << cscDetId3.ring() << " C" << cscDetId3.chamber() << " L" << cscDetId3.layer() << std::endl;
+      assert(iscn == nstrips);
+      assert(cscDetId3 == cscDetId);
 
-
-	
-	   // ASSERTS
-	   // =======
-
-	// Check layer indices are consistent  
-	   //	   std::cout << "lind2 = " << lind2 << ", lind=" << lind << std::endl;
-        assert ( lind2 == lind );
-
-	// Build CSCDetId from this index and check it's same as original
-	   CSCDetId cscDetId2 = theIndexer->detIdFromLayerIndex( lind );
-	   // std::cout << "cscDetId2 = E" << cscDetId2.endcap() << " S" << cscDetId2.station() << " R" << cscDetId2.ring() << " C" << cscDetId2.chamber() << " L" << cscDetId2.layer() << std::endl;
-	assert( cscDetId2 == cscDetId );
-
-	// Build CSCDetId from the strip-channel index for strip 'nstrips' and check it matches
-           std::pair<CSCDetId, unsigned short int> p = theIndexer->detIdFromStripChannelIndex( scn );
-           CSCDetId cscDetId3 = p.first;
-           unsigned short iscn = p.second;
-	   // std::cout << "scn=" << scn << "  iscn=" << iscn << std::endl;
-	   // std::cout << "cscDetId3 = E" << cscDetId3.endcap() << " S" << cscDetId3.station() << " R" << cscDetId3.ring() << " C" << cscDetId3.chamber() << " L" << cscDetId3.layer() << std::endl;
-        assert( iscn == nstrips );
-	assert( cscDetId3 == cscDetId );
-          
-	// Check idToDetUnit
-	   const GeomDetUnit * gdu = pDD->idToDetUnit(detId);
-	   assert(gdu==layer);
-	// Check idToDet
-	   const GeomDet * gd = pDD->idToDet(detId);
-	   assert(gd==layer);
+      // Check idToDetUnit
+      const GeomDetUnit* gdu = pDD->idToDetUnit(detId);
+      assert(gdu == layer);
+      // Check idToDet
+      const GeomDet* gd = pDD->idToDet(detId);
+      assert(gd == layer);
+    } else {
+      std::cout << "Something wrong ... could not dynamic_cast Det* to CSCLayer* " << std::endl;
     }
-    else {
-       std::cout << "Something wrong ... could not dynamic_cast Det* to CSCLayer* " << std::endl;
-    }
-   }
+  }
 
-   delete theIndexer;
+  delete theIndexer;
 
-   std::cout << dashedLine_ << " end" << std::endl;
+  std::cout << dashedLine_ << " end" << std::endl;
 }
 
 //define this as a plug-in

--- a/DataFormats/MuonDetId/test/RPCDetIdAnalyzer.cc
+++ b/DataFormats/MuonDetId/test/RPCDetIdAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    RPCDetIdAnalyzer
 // Class:      RPCDetIdAnalyzer
-// 
+//
 /**\class RPCDetIdAnalyzer RPCDetIdAnalyzer.cc DataFormats/RPCDetIdAnalyzer/src/RPCDetIdAnalyzer.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Fri Nov  4 12:32:59 CET 2011
 //
 //
-
 
 // system include files
 #include <iostream>
@@ -35,24 +34,23 @@
 //
 
 class RPCDetIdAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit RPCDetIdAnalyzer(const edm::ParameterSet&);
-      ~RPCDetIdAnalyzer();
+public:
+  explicit RPCDetIdAnalyzer(const edm::ParameterSet&);
+  ~RPCDetIdAnalyzer();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  virtual void beginJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob();
 
-   private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
-      virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-      virtual void endRun(edm::Run const&, edm::EventSetup const&);
-      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 //
@@ -69,92 +67,64 @@ class RPCDetIdAnalyzer : public edm::EDAnalyzer {
 RPCDetIdAnalyzer::RPCDetIdAnalyzer(const edm::ParameterSet& iConfig)
 
 {
-   //now do what ever initialization is needed
-
+  //now do what ever initialization is needed
 }
 
-
-RPCDetIdAnalyzer::~RPCDetIdAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+RPCDetIdAnalyzer::~RPCDetIdAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-RPCDetIdAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+void RPCDetIdAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 {
-  RPCCompDetId rpcgasid("WM2_S04_RB4R",0);
-  
-  //RPCCompDetId rpcgasid("cms_rpc_dcs_03:EM1_R03_C12_C17_UP",0);
-  std::cout <<rpcgasid<<" rawid = "<< rpcgasid.rawId()<<std::endl;
-  std::cout <<"Region = "<<rpcgasid.region()<<std::endl;
-  std::cout <<"Ring or Wheel = "<<rpcgasid.ring()<<" - Wheel = "<<rpcgasid.wheel()<<std::endl;
-  std::cout <<"Station or Disk = "<<rpcgasid.station()<<" - Disk = "<<rpcgasid.disk()<<std::endl;
-  std::cout <<"Sector = "<<rpcgasid.sector()<<std::endl;
-  std::cout <<"Layer = "<<rpcgasid.layer()<<std::endl;
-  std::cout <<"SubSector = "<<rpcgasid.subsector()<<std::endl;
-  std::cout <<std::setw(100)<<std::setfill('-')<<std::endl;
-  std::cout <<"ok"<<std::endl;
-  RPCCompDetId check(rpcgasid.rawId());
-  std::cout <<check<<" rawid = "<< check.rawId()<<std::endl;
-  std::cout <<"Region = "<<check.region()<<std::endl;
-  std::cout <<"Ring or Wheel = "<<check.ring()<<" - Wheel = "<<check.wheel()<<std::endl;
-  std::cout <<"Station or Disk = "<<check.station()<<" - Disk = "<<check.disk()<<std::endl;
-  std::cout <<"Sector = "<<check.sector()<<std::endl;
-  std::cout <<"Layer = "<<check.layer()<<std::endl;
-  std::cout <<"SubSector = "<<check.subsector()<<std::endl;
-  
-}
+  RPCCompDetId rpcgasid("WM2_S04_RB4R", 0);
 
+  //RPCCompDetId rpcgasid("cms_rpc_dcs_03:EM1_R03_C12_C17_UP",0);
+  std::cout << rpcgasid << " rawid = " << rpcgasid.rawId() << std::endl;
+  std::cout << "Region = " << rpcgasid.region() << std::endl;
+  std::cout << "Ring or Wheel = " << rpcgasid.ring() << " - Wheel = " << rpcgasid.wheel() << std::endl;
+  std::cout << "Station or Disk = " << rpcgasid.station() << " - Disk = " << rpcgasid.disk() << std::endl;
+  std::cout << "Sector = " << rpcgasid.sector() << std::endl;
+  std::cout << "Layer = " << rpcgasid.layer() << std::endl;
+  std::cout << "SubSector = " << rpcgasid.subsector() << std::endl;
+  std::cout << std::setw(100) << std::setfill('-') << std::endl;
+  std::cout << "ok" << std::endl;
+  RPCCompDetId check(rpcgasid.rawId());
+  std::cout << check << " rawid = " << check.rawId() << std::endl;
+  std::cout << "Region = " << check.region() << std::endl;
+  std::cout << "Ring or Wheel = " << check.ring() << " - Wheel = " << check.wheel() << std::endl;
+  std::cout << "Station or Disk = " << check.station() << " - Disk = " << check.disk() << std::endl;
+  std::cout << "Sector = " << check.sector() << std::endl;
+  std::cout << "Layer = " << check.layer() << std::endl;
+  std::cout << "SubSector = " << check.subsector() << std::endl;
+}
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-RPCDetIdAnalyzer::beginJob()
-{
-}
+void RPCDetIdAnalyzer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-RPCDetIdAnalyzer::endJob() 
-{
-}
+void RPCDetIdAnalyzer::endJob() {}
 
 // ------------ method called when starting to processes a run  ------------
-void 
-RPCDetIdAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
+void RPCDetIdAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&) {}
 
 // ------------ method called when ending the processing of a run  ------------
-void 
-RPCDetIdAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
+void RPCDetIdAnalyzer::endRun(edm::Run const&, edm::EventSetup const&) {}
 
 // ------------ method called when starting to processes a luminosity block  ------------
-void 
-RPCDetIdAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
+void RPCDetIdAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 // ------------ method called when ending the processing of a luminosity block  ------------
-void 
-RPCDetIdAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
+void RPCDetIdAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-RPCDetIdAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void RPCDetIdAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/DataFormats/MuonDetId/test/testCSCDetId.cc
+++ b/DataFormats/MuonDetId/test/testCSCDetId.cc
@@ -13,10 +13,9 @@
 #include <iostream>
 using namespace std;
 
-class testCSCDetId: public CppUnit::TestFixture
-{
+class testCSCDetId : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testCSCDetId);
-  
+
   CPPUNIT_TEST(testOne);
   CPPUNIT_TEST(testFail);
   CPPUNIT_TEST(testStatic);
@@ -24,12 +23,12 @@ class testCSCDetId: public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void testOne();
   void testFail();
   void testStatic();
-  
+
 private:
   void testValid(CSCDetId&);
 };
@@ -37,8 +36,7 @@ private:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testCSCDetId);
 
-void testCSCDetId::testOne(){
-
+void testCSCDetId::testOne() {
   /*
     std::cout << "\ntestCSCDetId: testOne starting... " << std::endl;
   
@@ -49,57 +47,54 @@ void testCSCDetId::testOne(){
     std::cout << "max station = " << CSCDetId::maxStationId() << std::endl;
   */
 
-  unsigned short rings[]={4,2,2,2};
-  unsigned short chambers[]={36,36,36,36, 18,36, 18,36, 18, 36};
+  unsigned short rings[] = {4, 2, 2, 2};
+  unsigned short chambers[] = {36, 36, 36, 36, 18, 36, 18, 36, 18, 36};
 
-  for (int endcap=CSCDetId::minEndcapId(); endcap<=CSCDetId::maxEndcapId(); ++endcap)
-    for (int station=CSCDetId::minStationId(); station <= CSCDetId::maxStationId() ; ++station)
-      for (int ring=CSCDetId::minRingId(); ring<=rings[station-1]; ++ring) {
-        unsigned short itype = CSCDetId::iChamberType( station, ring );
-        unsigned short nchambers = chambers[itype-1];
-	for (int chamber=CSCDetId::minChamberId(); chamber<=nchambers; ++chamber)
-	  for (int layer=CSCDetId::minLayerId(); layer<=CSCDetId::maxLayerId(); ++layer){
-
-	    CSCDetId detid(endcap, station, ring, chamber, layer);
-	    //                std::cout << "detid = " << detid.rawId() << "  " << hex << detid.rawId() << 
-	    //	    	      "  " << oct << detid.rawId() << dec << std::endl;
-	    //	    	    std::cout << "\ndetid.endcap()= " << detid.endcap() << " endcap = " << endcap << std::endl;
-	    CPPUNIT_ASSERT(detid.endcap() == endcap);
-	    //	    	    std::cout << "\ndetid.station()= " << detid.station() << " station = " << station << std::endl;
+  for (int endcap = CSCDetId::minEndcapId(); endcap <= CSCDetId::maxEndcapId(); ++endcap)
+    for (int station = CSCDetId::minStationId(); station <= CSCDetId::maxStationId(); ++station)
+      for (int ring = CSCDetId::minRingId(); ring <= rings[station - 1]; ++ring) {
+        unsigned short itype = CSCDetId::iChamberType(station, ring);
+        unsigned short nchambers = chambers[itype - 1];
+        for (int chamber = CSCDetId::minChamberId(); chamber <= nchambers; ++chamber)
+          for (int layer = CSCDetId::minLayerId(); layer <= CSCDetId::maxLayerId(); ++layer) {
+            CSCDetId detid(endcap, station, ring, chamber, layer);
+            //                std::cout << "detid = " << detid.rawId() << "  " << hex << detid.rawId() <<
+            //	    	      "  " << oct << detid.rawId() << dec << std::endl;
+            //	    	    std::cout << "\ndetid.endcap()= " << detid.endcap() << " endcap = " << endcap << std::endl;
+            CPPUNIT_ASSERT(detid.endcap() == endcap);
+            //	    	    std::cout << "\ndetid.station()= " << detid.station() << " station = " << station << std::endl;
             CPPUNIT_ASSERT(detid.station() == station);
             CPPUNIT_ASSERT(detid.ring() == ring);
-	    CPPUNIT_ASSERT(detid.chamber() == chamber);
+            CPPUNIT_ASSERT(detid.chamber() == chamber);
             CPPUNIT_ASSERT(detid.layer() == layer);
 
-	    // check chamber type number	    
-	    //            std::cout << "E" << endcap << " S" << station << " R" << ring << " C" << chamber <<
-	    //	      " L" << layer << "   chamber type=" << detid.iChamberType() << std::endl;
-            CPPUNIT_ASSERT(detid.iChamberType() == CSCDetId::iChamberType( station, ring ) );
+            // check chamber type number
+            //            std::cout << "E" << endcap << " S" << station << " R" << ring << " C" << chamber <<
+            //	      " L" << layer << "   chamber type=" << detid.iChamberType() << std::endl;
+            CPPUNIT_ASSERT(detid.iChamberType() == CSCDetId::iChamberType(station, ring));
 
-	    // test constructor from id
-	    int myId = detid.rawId();
-	    CSCDetId anotherId(myId);
-	    CPPUNIT_ASSERT(detid==anotherId);
-	  }
+            // test constructor from id
+            int myId = detid.rawId();
+            CSCDetId anotherId(myId);
+            CPPUNIT_ASSERT(detid == anotherId);
+          }
       }
 }
 
-
-void testCSCDetId::testFail()
-{  
+void testCSCDetId::testFail() {
   // construct using an invalid input index
   // Invalid layer
   std::cout << "\nConstruct CSCDetId using an invalid input index\n";
-  CSCDetId detid1(3,1,1,1,7);
+  CSCDetId detid1(3, 1, 1, 1, 7);
   testValid(detid1);
-  
+
   // contruct using an invalid input id
   std::cout << "\nConstruct CSCDetId using an invalid input id\n";
   CSCDetId detid2(3211);
   testValid(detid2);
 }
 
-void testCSCDetId::testStatic(){
+void testCSCDetId::testStatic() {
   int ie = 2;
   int is = 3;
   int ir = 2;
@@ -108,7 +103,7 @@ void testCSCDetId::testStatic(){
 
   int id1 = CSCDetId::rawIdMaker(2, 3, 2, 10, 3);
   int id2 = CSCDetId::rawIdMaker(ie, is, ir, ic, il);
-  int id3 = CSCDetId::rawIdMaker(ie, is, ir, ic, 0 ); // all layers i.e. chamber id
+  int id3 = CSCDetId::rawIdMaker(ie, is, ir, ic, 0);  // all layers i.e. chamber id
 
   //  std::cout << "\nE" << ie << " S" << is << " R" << ir << " C" << ic
   //       << " L" << il << " has rawId = " << id2 << " (dec) = "
@@ -118,42 +113,36 @@ void testCSCDetId::testStatic(){
   //       << " L0" << " has rawId = " << id3 << " = "
   //       << hex << id3 << " (hex) " << oct << id3 << " (oct)" << dec << std::endl;
 
-  CPPUNIT_ASSERT(id1 == id2 );
-  CPPUNIT_ASSERT(CSCDetId::endcap(id2)  == ie );
-  CPPUNIT_ASSERT(CSCDetId::station(id2) == is );
-  CPPUNIT_ASSERT(CSCDetId::ring(id2)    == ir );
-  CPPUNIT_ASSERT(CSCDetId::chamber(id2) == ic );
-  CPPUNIT_ASSERT(CSCDetId::layer(id2)   == il );
-  CPPUNIT_ASSERT(CSCDetId::chamber(id3) == ic );
+  CPPUNIT_ASSERT(id1 == id2);
+  CPPUNIT_ASSERT(CSCDetId::endcap(id2) == ie);
+  CPPUNIT_ASSERT(CSCDetId::station(id2) == is);
+  CPPUNIT_ASSERT(CSCDetId::ring(id2) == ir);
+  CPPUNIT_ASSERT(CSCDetId::chamber(id2) == ic);
+  CPPUNIT_ASSERT(CSCDetId::layer(id2) == il);
+  CPPUNIT_ASSERT(CSCDetId::chamber(id3) == ic);
 }
 
-void testCSCDetId::testValid(CSCDetId& detId)
-{
-  if( detId.det() != DetId::Muon || detId.subdetId() != MuonSubdetId::CSC )
-  {
+void testCSCDetId::testValid(CSCDetId& detId) {
+  if (detId.det() != DetId::Muon || detId.subdetId() != MuonSubdetId::CSC) {
     std::cout << "Invalid CSCDetId:"
-	      << " det: " << detId.det()
-	      << " subdet: " << detId.subdetId()
-	      << " is not a valid CSC id\n";  
+              << " det: " << detId.det() << " subdet: " << detId.subdetId() << " is not a valid CSC id\n";
   }
   int iendcap = detId.endcap();
   int istation = detId.station();
   int iring = detId.ring();
   int ichamber = detId.chamber();
   int ilayer = detId.layer();
-  if( iendcap  < detId.minEndcapId() || iendcap  > detId.maxEndcapId() ||
-      istation < detId.minStationId() || istation > detId.maxStationId() ||
-      iring    < detId.minRingId() || iring    > detId.maxRingId() ||
-      ichamber < detId.minChamberId() || ichamber > detId.maxChamberId() ||
-      ilayer   < detId.minLayerId() || ilayer   > detId.maxLayerId())
-  {
-    std::cout << "Invalid CSCDetId:" 
-	      << " Invalid parameters: " 
-	      << " E:"<< iendcap << "(" << detId.minEndcapId() << ":" <<  detId.maxEndcapId() << ")" 
-	      << " S:"<< istation << "(" << detId.minStationId() << ":" <<  detId.maxStationId() << ")" 
-	      << " R:"<< iring << "(" << detId.minRingId() << ":" <<  detId.maxRingId() << ")" 
-	      << " C:"<< ichamber << "(" << detId.minChamberId() << ":" <<  detId.maxChamberId() << ")" 
-	      << " L:"<< ilayer << "(" << detId.minLayerId() << ":" <<  detId.maxLayerId() << ")" 
-	      << "\n";
+  if (iendcap < detId.minEndcapId() || iendcap > detId.maxEndcapId() || istation < detId.minStationId() ||
+      istation > detId.maxStationId() || iring < detId.minRingId() || iring > detId.maxRingId() ||
+      ichamber < detId.minChamberId() || ichamber > detId.maxChamberId() || ilayer < detId.minLayerId() ||
+      ilayer > detId.maxLayerId()) {
+    std::cout << "Invalid CSCDetId:"
+              << " Invalid parameters: "
+              << " E:" << iendcap << "(" << detId.minEndcapId() << ":" << detId.maxEndcapId() << ")"
+              << " S:" << istation << "(" << detId.minStationId() << ":" << detId.maxStationId() << ")"
+              << " R:" << iring << "(" << detId.minRingId() << ":" << detId.maxRingId() << ")"
+              << " C:" << ichamber << "(" << detId.minChamberId() << ":" << detId.maxChamberId() << ")"
+              << " L:" << ilayer << "(" << detId.minLayerId() << ":" << detId.maxLayerId() << ")"
+              << "\n";
   }
 }

--- a/DataFormats/MuonDetId/test/testCSCTriggerNumbering.cc
+++ b/DataFormats/MuonDetId/test/testCSCTriggerNumbering.cc
@@ -14,8 +14,7 @@
 #include <iostream>
 using namespace std;
 
-class testCSCTriggerNumbering: public CppUnit::TestFixture
-{
+class testCSCTriggerNumbering : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testCSCTriggerNumbering);
 
   CPPUNIT_TEST(testNumbering);
@@ -24,8 +23,8 @@ class testCSCTriggerNumbering: public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
   void testNumbering();
   void testFail();
 };
@@ -34,117 +33,95 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(testCSCTriggerNumbering);
 
 // run a self consistency check
-void testCSCTriggerNumbering::testNumbering()
-{
-  for (int endcap = CSCDetId::minEndcapId();
-       endcap <= CSCDetId::maxEndcapId(); ++endcap)
-    for(int station = CSCDetId::minStationId();
-	station <= CSCDetId::maxStationId(); ++station)
-      for(int sector = CSCTriggerNumbering::minTriggerSectorId();
-	  sector <= CSCTriggerNumbering::maxTriggerSectorId(); ++sector)
-	for(int cscid = CSCTriggerNumbering::minTriggerCscId();
-	    cscid <= CSCTriggerNumbering::maxTriggerCscId(); ++cscid)
-	  {
-	    if(station == 1)
-	      for(int subs = CSCTriggerNumbering::minTriggerSubSectorId();
-		  subs <= CSCTriggerNumbering::maxTriggerSubSectorId(); subs++)
-		{
-		  int tcscid = CSCTriggerNumbering::triggerCscIdFromLabels(station, 
-									   CSCTriggerNumbering::ringFromTriggerLabels(station,cscid),
-									   CSCTriggerNumbering::chamberFromTriggerLabels(sector,subs,station,cscid));
-		  CPPUNIT_ASSERT(tcscid == cscid);
+void testCSCTriggerNumbering::testNumbering() {
+  for (int endcap = CSCDetId::minEndcapId(); endcap <= CSCDetId::maxEndcapId(); ++endcap)
+    for (int station = CSCDetId::minStationId(); station <= CSCDetId::maxStationId(); ++station)
+      for (int sector = CSCTriggerNumbering::minTriggerSectorId(); sector <= CSCTriggerNumbering::maxTriggerSectorId();
+           ++sector)
+        for (int cscid = CSCTriggerNumbering::minTriggerCscId(); cscid <= CSCTriggerNumbering::maxTriggerCscId();
+             ++cscid) {
+          if (station == 1)
+            for (int subs = CSCTriggerNumbering::minTriggerSubSectorId();
+                 subs <= CSCTriggerNumbering::maxTriggerSubSectorId();
+                 subs++) {
+              int tcscid = CSCTriggerNumbering::triggerCscIdFromLabels(
+                  station,
+                  CSCTriggerNumbering::ringFromTriggerLabels(station, cscid),
+                  CSCTriggerNumbering::chamberFromTriggerLabels(sector, subs, station, cscid));
+              CPPUNIT_ASSERT(tcscid == cscid);
 
-		  int tsubs = CSCTriggerNumbering::triggerSubSectorFromLabels(station,
-									      CSCTriggerNumbering::chamberFromTriggerLabels(sector,subs,station,cscid));
+              int tsubs = CSCTriggerNumbering::triggerSubSectorFromLabels(
+                  station, CSCTriggerNumbering::chamberFromTriggerLabels(sector, subs, station, cscid));
 
-		  CPPUNIT_ASSERT(tsubs == subs);	  
+              CPPUNIT_ASSERT(tsubs == subs);
 
-		  int tsector = CSCTriggerNumbering::triggerSectorFromLabels(station, 
-									     CSCTriggerNumbering::ringFromTriggerLabels(station,cscid),
-									     CSCTriggerNumbering::chamberFromTriggerLabels(sector,subs,station,cscid));
-		  CPPUNIT_ASSERT(tsector == sector);		  	  
-		}
-	    else
-	      {
-		int tcscid = CSCTriggerNumbering::triggerCscIdFromLabels(station, 
-									 CSCTriggerNumbering::ringFromTriggerLabels(station,cscid),
-									 CSCTriggerNumbering::chamberFromTriggerLabels(sector,0,station,cscid));
-		CPPUNIT_ASSERT(tcscid == cscid);
+              int tsector = CSCTriggerNumbering::triggerSectorFromLabels(
+                  station,
+                  CSCTriggerNumbering::ringFromTriggerLabels(station, cscid),
+                  CSCTriggerNumbering::chamberFromTriggerLabels(sector, subs, station, cscid));
+              CPPUNIT_ASSERT(tsector == sector);
+            }
+          else {
+            int tcscid = CSCTriggerNumbering::triggerCscIdFromLabels(
+                station,
+                CSCTriggerNumbering::ringFromTriggerLabels(station, cscid),
+                CSCTriggerNumbering::chamberFromTriggerLabels(sector, 0, station, cscid));
+            CPPUNIT_ASSERT(tcscid == cscid);
 
-		int tsector = CSCTriggerNumbering::triggerSectorFromLabels(station, 
-									   CSCTriggerNumbering::ringFromTriggerLabels(station,cscid),
-									   CSCTriggerNumbering::chamberFromTriggerLabels(sector,0,station,cscid));
-		CPPUNIT_ASSERT(tsector == sector);		
-	      }	    
-	  }
+            int tsector = CSCTriggerNumbering::triggerSectorFromLabels(
+                station,
+                CSCTriggerNumbering::ringFromTriggerLabels(station, cscid),
+                CSCTriggerNumbering::chamberFromTriggerLabels(sector, 0, station, cscid));
+            CPPUNIT_ASSERT(tsector == sector);
+          }
+        }
 }
 
-void testCSCTriggerNumbering::testFail()
-{
+void testCSCTriggerNumbering::testFail() {
   // Give triggerSectorFromLabels a bad input
-  try 
-    {
-      CSCTriggerNumbering::triggerSectorFromLabels(0,1,2);
-      CPPUNIT_ASSERT("Failed to throw required exception" == 0); 
-    } 
-  catch (cms::Exception& e) 
-    { } 
-  catch (...) 
-    {
-      CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
-    }
+  try {
+    CSCTriggerNumbering::triggerSectorFromLabels(0, 1, 2);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  } catch (cms::Exception& e) {
+  } catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
+  }
 
   // Give triggerSubSectorFromLabels a bad input
 
-  try
-    {
-      CSCTriggerNumbering::triggerSubSectorFromLabels(0, 34);
-      CPPUNIT_ASSERT("Failed to throw required exception" == 0); 
-    }
-  catch(cms::Exception& e)
-    { }
-  catch(...)
-    {
-      CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
-    }
+  try {
+    CSCTriggerNumbering::triggerSubSectorFromLabels(0, 34);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  } catch (cms::Exception& e) {
+  } catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
+  }
 
   // Give triggerCscIdFromLabels a bad input
 
-  try 
-    {
-      CSCTriggerNumbering::triggerCscIdFromLabels(0,1,2);
-      CPPUNIT_ASSERT("Failed to throw required exception" == 0); 
-    } 
-  catch (cms::Exception& e) 
-    { } 
-  catch (...) 
-    {
-      CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
-    }
+  try {
+    CSCTriggerNumbering::triggerCscIdFromLabels(0, 1, 2);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  } catch (cms::Exception& e) {
+  } catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
+  }
 
   // Give ringFromTriggerLabels a bad input
-  try
-    {
-      CSCTriggerNumbering::ringFromTriggerLabels(0,2);
-      CPPUNIT_ASSERT("Failed to throw required exception" == 0); 
-    }
-  catch (cms::Exception& e)
-    { }
-  catch(...)
-    {
-      CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
-    }
+  try {
+    CSCTriggerNumbering::ringFromTriggerLabels(0, 2);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  } catch (cms::Exception& e) {
+  } catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
+  }
 
   // Give ringFromTriggerLabels a bad input
-  try
-    {
-      CSCTriggerNumbering::chamberFromTriggerLabels(0,1,2,9);
-      CPPUNIT_ASSERT("Failed to throw required exception" == 0); 
-    }
-  catch (cms::Exception& e)
-    { }
-  catch(...)
-    {
-      CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
-    } 
+  try {
+    CSCTriggerNumbering::chamberFromTriggerLabels(0, 1, 2, 9);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  } catch (cms::Exception& e) {
+  } catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
+  }
 }

--- a/DataFormats/MuonDetId/test/testDTDetIds.cc
+++ b/DataFormats/MuonDetId/test/testDTDetIds.cc
@@ -6,7 +6,7 @@
    \date 27 Jul 2005
 */
 
-//#define TEST_FORBIDDEN_CTORS 
+//#define TEST_FORBIDDEN_CTORS
 
 #include <cppunit/extensions/HelperMacros.h>
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
@@ -18,17 +18,16 @@
 #include <iostream>
 using namespace std;
 
-class testDTDetIds: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testDTDetIds);
-CPPUNIT_TEST(testConstructors);
-CPPUNIT_TEST(testFail);
-CPPUNIT_TEST(testMemberOperators);
-CPPUNIT_TEST_SUITE_END();
+class testDTDetIds : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testDTDetIds);
+  CPPUNIT_TEST(testConstructors);
+  CPPUNIT_TEST(testFail);
+  CPPUNIT_TEST(testMemberOperators);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void testConstructors();
   void testFail();
@@ -39,308 +38,294 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(testDTDetIds);
 
 // Try every possible constructor
-void testDTDetIds::testConstructors(){
-  for (int wheel=DTWireId::minWheelId; wheel<=DTWireId::maxWheelId; ++wheel) {
-    for (int station=DTWireId::minStationId; 
-	 station <= DTWireId::maxStationId ; ++station) {
-      for (int sector=DTWireId::minSectorId; 
-	   sector<=DTWireId::maxSectorId; ++sector) {
-	// Build a DTChamberId
-	DTChamberId chamberId(wheel, station, sector);
-	CPPUNIT_ASSERT(chamberId.wheel() == wheel);
-	CPPUNIT_ASSERT(chamberId.station() == station);
-	CPPUNIT_ASSERT(chamberId.sector() == sector);
-	
-	// Test constructor from id
-	int chId = chamberId.rawId();
-	DTChamberId newChamberId(chId);
-	CPPUNIT_ASSERT(newChamberId == chamberId);
+void testDTDetIds::testConstructors() {
+  for (int wheel = DTWireId::minWheelId; wheel <= DTWireId::maxWheelId; ++wheel) {
+    for (int station = DTWireId::minStationId; station <= DTWireId::maxStationId; ++station) {
+      for (int sector = DTWireId::minSectorId; sector <= DTWireId::maxSectorId; ++sector) {
+        // Build a DTChamberId
+        DTChamberId chamberId(wheel, station, sector);
+        CPPUNIT_ASSERT(chamberId.wheel() == wheel);
+        CPPUNIT_ASSERT(chamberId.station() == station);
+        CPPUNIT_ASSERT(chamberId.sector() == sector);
 
-	// Test DTChamberId copy constructor
-	DTChamberId copyChamberId(newChamberId);
-	CPPUNIT_ASSERT(copyChamberId == newChamberId);
+        // Test constructor from id
+        int chId = chamberId.rawId();
+        DTChamberId newChamberId(chId);
+        CPPUNIT_ASSERT(newChamberId == chamberId);
 
-	for (int slayer=DTWireId::minSuperLayerId; 
-	     slayer<=DTWireId::maxSuperLayerId; ++slayer) {
-	  // Build a DTSuperLayerId
-	  DTSuperLayerId slId(wheel, station, sector, slayer);
-	  CPPUNIT_ASSERT(slId.wheel() == wheel);
-	  CPPUNIT_ASSERT(slId.station() == station);
-	  CPPUNIT_ASSERT(slId.sector() == sector);
-	  CPPUNIT_ASSERT(slId.superlayer() == slayer);
+        // Test DTChamberId copy constructor
+        DTChamberId copyChamberId(newChamberId);
+        CPPUNIT_ASSERT(copyChamberId == newChamberId);
 
-	  // Test constructor from id
-	  int sId = slId.rawId();
-	  DTSuperLayerId newSlId(sId);
-	  CPPUNIT_ASSERT(newSlId == slId);
+        for (int slayer = DTWireId::minSuperLayerId; slayer <= DTWireId::maxSuperLayerId; ++slayer) {
+          // Build a DTSuperLayerId
+          DTSuperLayerId slId(wheel, station, sector, slayer);
+          CPPUNIT_ASSERT(slId.wheel() == wheel);
+          CPPUNIT_ASSERT(slId.station() == station);
+          CPPUNIT_ASSERT(slId.sector() == sector);
+          CPPUNIT_ASSERT(slId.superlayer() == slayer);
 
-	  // Test constructor from chamberId and sl number
-	  DTSuperLayerId anotherSLId(chamberId, slayer);
-	  CPPUNIT_ASSERT(anotherSLId == slId);
+          // Test constructor from id
+          int sId = slId.rawId();
+          DTSuperLayerId newSlId(sId);
+          CPPUNIT_ASSERT(newSlId == slId);
 
-	  // Test DTChamberId copy constructor
-	  DTChamberId copyChamberIdFromSl(slId);
-	  CPPUNIT_ASSERT(copyChamberIdFromSl == chamberId);
+          // Test constructor from chamberId and sl number
+          DTSuperLayerId anotherSLId(chamberId, slayer);
+          CPPUNIT_ASSERT(anotherSLId == slId);
 
-	  // Test DTSuperLayerId constructor from raw SL Id
-	  DTChamberId copyChamberIdFromRawSl(sId);
-	  CPPUNIT_ASSERT(copyChamberIdFromRawSl == chamberId);
+          // Test DTChamberId copy constructor
+          DTChamberId copyChamberIdFromSl(slId);
+          CPPUNIT_ASSERT(copyChamberIdFromSl == chamberId);
 
-	  // Test DTSuperLayerId copy constructor
-	  DTSuperLayerId copySlId(slId);
-	  CPPUNIT_ASSERT(slId == copySlId);
+          // Test DTSuperLayerId constructor from raw SL Id
+          DTChamberId copyChamberIdFromRawSl(sId);
+          CPPUNIT_ASSERT(copyChamberIdFromRawSl == chamberId);
 
-	  for (int layer=DTWireId::minLayerId; 
-	       layer<=DTWireId::maxLayerId; ++layer) {
-	    // Build a DTLayerId
-	    DTLayerId layerId(wheel, station, sector, slayer, layer);
-	    CPPUNIT_ASSERT(layerId.wheel() == wheel);
-	    CPPUNIT_ASSERT(layerId.station() == station);
-	    CPPUNIT_ASSERT(layerId.sector() == sector);
-	    CPPUNIT_ASSERT(layerId.superlayer() == slayer);
-	    CPPUNIT_ASSERT(layerId.layer() == layer);
+          // Test DTSuperLayerId copy constructor
+          DTSuperLayerId copySlId(slId);
+          CPPUNIT_ASSERT(slId == copySlId);
 
-	    // Test constructor from id
-	    int lId = layerId.rawId();
-	    DTLayerId newLayerId(lId);
-	    CPPUNIT_ASSERT(newLayerId == layerId);
-	    
-	    // Test constructor from chamberId, sl and layer numbers
-	    DTLayerId anotherLayerId(chamberId, slayer, layer);
-	    CPPUNIT_ASSERT(anotherLayerId == layerId);
+          for (int layer = DTWireId::minLayerId; layer <= DTWireId::maxLayerId; ++layer) {
+            // Build a DTLayerId
+            DTLayerId layerId(wheel, station, sector, slayer, layer);
+            CPPUNIT_ASSERT(layerId.wheel() == wheel);
+            CPPUNIT_ASSERT(layerId.station() == station);
+            CPPUNIT_ASSERT(layerId.sector() == sector);
+            CPPUNIT_ASSERT(layerId.superlayer() == slayer);
+            CPPUNIT_ASSERT(layerId.layer() == layer);
 
-	    // Test constructor from slId and layer number
-	    DTLayerId anotherLayerId1(slId, layer);
-	    CPPUNIT_ASSERT(anotherLayerId1 == layerId);
+            // Test constructor from id
+            int lId = layerId.rawId();
+            DTLayerId newLayerId(lId);
+            CPPUNIT_ASSERT(newLayerId == layerId);
 
-	    // Test DTChamberId copy constructor
-	    DTChamberId copyChamberIdFromLayer(layerId);
-	    CPPUNIT_ASSERT(copyChamberIdFromLayer == chamberId);
+            // Test constructor from chamberId, sl and layer numbers
+            DTLayerId anotherLayerId(chamberId, slayer, layer);
+            CPPUNIT_ASSERT(anotherLayerId == layerId);
 
-	    // Test DTSuperLayerId constructor from raw layer Id
-	    DTChamberId copyChamberIdFromRawLayer(lId);
-	    CPPUNIT_ASSERT(copyChamberIdFromRawLayer == chamberId);
-	    
-	    // Test DTSuperLayerId copy constructor
-	    DTSuperLayerId copySlIdFromLayer(layerId);
-	    CPPUNIT_ASSERT(copySlIdFromLayer == slId);
+            // Test constructor from slId and layer number
+            DTLayerId anotherLayerId1(slId, layer);
+            CPPUNIT_ASSERT(anotherLayerId1 == layerId);
 
-	    // Test DTSuperLayerId constructor from raw layer Id
-	    DTSuperLayerId copySlIdFromRawLayer(lId);
-	    CPPUNIT_ASSERT(copySlIdFromRawLayer == slId);
+            // Test DTChamberId copy constructor
+            DTChamberId copyChamberIdFromLayer(layerId);
+            CPPUNIT_ASSERT(copyChamberIdFromLayer == chamberId);
 
-	    // Test DTLayerId copy constructor
-	    DTLayerId copyLayerId(layerId);
-	    CPPUNIT_ASSERT(copyLayerId == layerId);
-	    
-	    for (int wire=DTWireId::minWireId; 
-		 wire<=DTWireId::maxWireId; ++wire) {
-	      
-	      // Build a wireId
-	      DTWireId wireId(wheel, station, sector, slayer, layer, wire);
-	      CPPUNIT_ASSERT(wireId.wheel() == wheel);
-	      CPPUNIT_ASSERT(wireId.station() == station);
-	      CPPUNIT_ASSERT(wireId.sector() == sector);
-	      CPPUNIT_ASSERT(wireId.superlayer() == slayer);
-	      CPPUNIT_ASSERT(wireId.layer() == layer);
-	      CPPUNIT_ASSERT(wireId.wire() == wire);
+            // Test DTSuperLayerId constructor from raw layer Id
+            DTChamberId copyChamberIdFromRawLayer(lId);
+            CPPUNIT_ASSERT(copyChamberIdFromRawLayer == chamberId);
 
-	      // Test constructor from id
-	      int myId = wireId.rawId();
-	      DTWireId newWireId(myId);
-	      CPPUNIT_ASSERT(wireId == newWireId);
-	      
-	      // Test constructor from chamberId, sl, layer and wire numbers
-	      DTWireId anotherWireId(chamberId, slayer, layer, wire);
-	      CPPUNIT_ASSERT(anotherWireId == wireId);
+            // Test DTSuperLayerId copy constructor
+            DTSuperLayerId copySlIdFromLayer(layerId);
+            CPPUNIT_ASSERT(copySlIdFromLayer == slId);
 
-	      // Test constructor from slId and layer and wire numbers
-	      DTWireId anotherWireId1(slId, layer, wire);
-	      CPPUNIT_ASSERT(anotherWireId1 == wireId);
+            // Test DTSuperLayerId constructor from raw layer Id
+            DTSuperLayerId copySlIdFromRawLayer(lId);
+            CPPUNIT_ASSERT(copySlIdFromRawLayer == slId);
 
-	      // Test constructor from layerId and wire number
-	      DTWireId anotherWireId2(layerId, wire);
-	      CPPUNIT_ASSERT(anotherWireId2 == wireId);
+            // Test DTLayerId copy constructor
+            DTLayerId copyLayerId(layerId);
+            CPPUNIT_ASSERT(copyLayerId == layerId);
 
-	      // Test DTChamberId copy constructor
-	      DTChamberId copyChamberIdFromWire(wireId);
-	      CPPUNIT_ASSERT(copyChamberIdFromWire == chamberId);
+            for (int wire = DTWireId::minWireId; wire <= DTWireId::maxWireId; ++wire) {
+              // Build a wireId
+              DTWireId wireId(wheel, station, sector, slayer, layer, wire);
+              CPPUNIT_ASSERT(wireId.wheel() == wheel);
+              CPPUNIT_ASSERT(wireId.station() == station);
+              CPPUNIT_ASSERT(wireId.sector() == sector);
+              CPPUNIT_ASSERT(wireId.superlayer() == slayer);
+              CPPUNIT_ASSERT(wireId.layer() == layer);
+              CPPUNIT_ASSERT(wireId.wire() == wire);
 
-	      // Test DTChamberId constructor from raw wireId
-	      DTChamberId copyChamberIdFromRawWire(myId);
-	      CPPUNIT_ASSERT(copyChamberIdFromRawWire == chamberId);
+              // Test constructor from id
+              int myId = wireId.rawId();
+              DTWireId newWireId(myId);
+              CPPUNIT_ASSERT(wireId == newWireId);
 
-	      // Test DTSuperLayerId copy constructor
-	      DTSuperLayerId copySlIdFromWire(wireId);
-	      CPPUNIT_ASSERT(copySlIdFromWire == slId);
+              // Test constructor from chamberId, sl, layer and wire numbers
+              DTWireId anotherWireId(chamberId, slayer, layer, wire);
+              CPPUNIT_ASSERT(anotherWireId == wireId);
 
-	      // Test DTSuperLayerId constructor from raw wireId
-	      DTSuperLayerId copySlIdFromRawWire(myId);
-	      CPPUNIT_ASSERT(copySlIdFromRawWire == slId);
-	      
-	      // Test DTLayerId copy constructor
-	      DTLayerId copyLayerIdFromWire(wireId);
-	      CPPUNIT_ASSERT(copyLayerIdFromWire == layerId);
+              // Test constructor from slId and layer and wire numbers
+              DTWireId anotherWireId1(slId, layer, wire);
+              CPPUNIT_ASSERT(anotherWireId1 == wireId);
 
-	      // Test DTLayerId constructor from raw wireId
-	      DTLayerId copyLayerIdFromRawWire(myId);
-	      CPPUNIT_ASSERT(copyLayerIdFromRawWire == layerId);
+              // Test constructor from layerId and wire number
+              DTWireId anotherWireId2(layerId, wire);
+              CPPUNIT_ASSERT(anotherWireId2 == wireId);
 
-	      // Test DTWireId copy constructor
-	      DTWireId copyWireId(wireId);
-	      CPPUNIT_ASSERT(copyWireId == wireId);
-	    }
-	  }
-	}
+              // Test DTChamberId copy constructor
+              DTChamberId copyChamberIdFromWire(wireId);
+              CPPUNIT_ASSERT(copyChamberIdFromWire == chamberId);
+
+              // Test DTChamberId constructor from raw wireId
+              DTChamberId copyChamberIdFromRawWire(myId);
+              CPPUNIT_ASSERT(copyChamberIdFromRawWire == chamberId);
+
+              // Test DTSuperLayerId copy constructor
+              DTSuperLayerId copySlIdFromWire(wireId);
+              CPPUNIT_ASSERT(copySlIdFromWire == slId);
+
+              // Test DTSuperLayerId constructor from raw wireId
+              DTSuperLayerId copySlIdFromRawWire(myId);
+              CPPUNIT_ASSERT(copySlIdFromRawWire == slId);
+
+              // Test DTLayerId copy constructor
+              DTLayerId copyLayerIdFromWire(wireId);
+              CPPUNIT_ASSERT(copyLayerIdFromWire == layerId);
+
+              // Test DTLayerId constructor from raw wireId
+              DTLayerId copyLayerIdFromRawWire(myId);
+              CPPUNIT_ASSERT(copyLayerIdFromRawWire == layerId);
+
+              // Test DTWireId copy constructor
+              DTWireId copyWireId(wireId);
+              CPPUNIT_ASSERT(copyWireId == wireId);
+            }
+          }
+        }
       }
     }
   }
 }
 
-void testDTDetIds::testFail(){
+void testDTDetIds::testFail() {
   // Contruct a DTChamberId using an invalid input index
   try {
     // Invalid sector
-    DTChamberId detid(0,1,15);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    DTChamberId detid(0, 1, 15);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-  
+
   // Contruct a DTChamberId using an invalid input id
   try {
     DTChamberId detid(3211);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-
-
 
   // Contruct a DTSuperLayerId using an invalid input index
   try {
     // Invalid superlayer
-    DTSuperLayerId detid(0,1,1,5);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    DTSuperLayerId detid(0, 1, 1, 5);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-  
+
   // Contruct a DTSuperLayerId using an invalid input id
   try {
     DTSuperLayerId detid(3211);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
 
-
-   // Contruct a DTLayerId using an invalid input index
+  // Contruct a DTLayerId using an invalid input index
   try {
     // Invalid layer
-    DTLayerId detid(0,1,1,1,7);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    DTLayerId detid(0, 1, 1, 1, 7);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-  
+
   // Contruct a DTLayerId using an invalid input id
   try {
     DTLayerId detid(3211);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-
 
   // Contruct a DTWireId using an invalid input index
   try {
     // Invalid wire
-    DTWireId wireId(0,1,1,1,1,1000);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    wireId.rawId(); // avoid compiler warning
+    DTWireId wireId(0, 1, 1, 1, 1, 1000);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    wireId.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-
 
   // Contruct a DTWireId using an invalid input id
   try {
     DTWireId wireId(3211);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    wireId.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    wireId.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-
 }
 
-
-void testDTDetIds::testMemberOperators(){
+void testDTDetIds::testMemberOperators() {
   int wheel = 2;
   int station = 3;
   int sector = 8;
   int sl = 1;
   int layer = 4;
-  int wire = 15;  
+  int wire = 15;
 
   // Test assignement operators from same type
   DTChamberId chamber1(wheel, station, sector);
   DTChamberId chamber2;
   chamber2 = chamber1;
-  CPPUNIT_ASSERT(chamber2==chamber1);
+  CPPUNIT_ASSERT(chamber2 == chamber1);
 
   DTSuperLayerId superlayer1(wheel, station, sector, sl);
   DTSuperLayerId superlayer2;
-  superlayer2 = superlayer1;  
-  CPPUNIT_ASSERT(superlayer2==superlayer1);
+  superlayer2 = superlayer1;
+  CPPUNIT_ASSERT(superlayer2 == superlayer1);
 
   DTLayerId layer1(wheel, station, sector, sl, layer);
   DTLayerId layer2;
-  layer2=layer1;
-  CPPUNIT_ASSERT(layer2==layer1);
+  layer2 = layer1;
+  CPPUNIT_ASSERT(layer2 == layer1);
 
   DTWireId wire1(wheel, station, sector, sl, layer, wire);
   DTWireId wire2;
-  wire2=wire1;
-  CPPUNIT_ASSERT(wire2==wire1);  
-
+  wire2 = wire1;
+  CPPUNIT_ASSERT(wire2 == wire1);
 
   // Test getter of base id
   DTChamberId chamber3 = superlayer1.chamberId();
   CPPUNIT_ASSERT(chamber3 == chamber1);
-  
+
   DTChamberId chamber4 = layer1.chamberId();
   CPPUNIT_ASSERT(chamber4 == chamber1);
-  
+
   DTChamberId chamber5 = wire1.chamberId();
   CPPUNIT_ASSERT(chamber5 == chamber1);
 
   DTSuperLayerId superlayer3 = layer1.superlayerId();
   CPPUNIT_ASSERT(superlayer3 == superlayer1);
-  
+
   DTSuperLayerId superlayer4 = wire1.superlayerId();
   CPPUNIT_ASSERT(superlayer4 == superlayer1);
 
@@ -357,23 +342,22 @@ void testDTDetIds::testMemberOperators(){
   DTLayerId layer6 = wire1;
   CPPUNIT_ASSERT(layer6 == layer3);
 
-
 #ifdef TEST_FORBIDDEN_CTORS
   // Forbidden constructors. None of these should be accepted by the compiler!!!
 
-  // It should not be allowed to create a derived from a base 
+  // It should not be allowed to create a derived from a base
   // (it would result in invalid IDs)
   DTSuperLayerId s(chamber1);
-  DTLayerId      l(superlayer1);
-  DTWireId       w(layer1);  
-  
+  DTLayerId l(superlayer1);
+  DTWireId w(layer1);
+
   // It is not currently allowed to build any DT id directly from a Detid
   // (would allow the above ones and may prevent proper slicing)
   DetId d;
-  DTChamberId    c(d);
+  DTChamberId c(d);
   DTSuperLayerId s1(d);
-  DTLayerId      l1(d);
-  DTWireId       w1(d);  
+  DTLayerId l1(d);
+  DTWireId w1(d);
 
   // It is not allowed to copy a derived to a base.
   DTChamberId chamber7 = d;
@@ -381,6 +365,4 @@ void testDTDetIds::testMemberOperators(){
   DTLayerId layer7 = superlayer1;
   DTWireId wire7 = layer1;
 #endif
-
-
 }

--- a/DataFormats/MuonDetId/test/testME0DetId.cc
+++ b/DataFormats/MuonDetId/test/testME0DetId.cc
@@ -13,17 +13,16 @@
 #include <iostream>
 using namespace std;
 
-class testME0DetId: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testME0DetId);
-CPPUNIT_TEST(testOne);
-CPPUNIT_TEST(testFail);
-CPPUNIT_TEST(testMemberOperators);
-CPPUNIT_TEST_SUITE_END();
+class testME0DetId : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testME0DetId);
+  CPPUNIT_TEST(testOne);
+  CPPUNIT_TEST(testFail);
+  CPPUNIT_TEST(testMemberOperators);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void testOne();
   void testFail();
@@ -33,42 +32,33 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testME0DetId);
 
-void testME0DetId::testOne(){
+void testME0DetId::testOne() {
+  for (int region = ME0DetId::minRegionId; region <= ME0DetId::maxRegionId; ++region) {
+    for (int layer = ME0DetId::minLayerId; layer <= ME0DetId::maxLayerId; ++layer)
+      for (int chamber = ME0DetId::minChamberId; chamber <= ME0DetId::maxChamberId; ++chamber) {
+        for (int roll = ME0DetId::minRollId; roll <= ME0DetId::maxRollId; ++roll) {
+          ME0DetId detid(region, layer, chamber, roll);
+          CPPUNIT_ASSERT(detid.region() == region);
+          CPPUNIT_ASSERT(detid.layer() == layer);
+          CPPUNIT_ASSERT(detid.chamber() == chamber);
+          CPPUNIT_ASSERT(detid.roll() == roll);
 
-
-  for (int region=ME0DetId::minRegionId; region<=ME0DetId::maxRegionId; ++region)
-  {
-    for (int layer=ME0DetId::minLayerId; layer<=ME0DetId::maxLayerId; ++layer)
-      for (int chamber=ME0DetId::minChamberId; chamber<=ME0DetId::maxChamberId; ++chamber){
-	for (int roll=ME0DetId::minRollId; roll<=ME0DetId::maxRollId; ++roll){
-
-
-	  ME0DetId detid(region, layer, chamber, roll);
-	  CPPUNIT_ASSERT(detid.region() == region);
-	  CPPUNIT_ASSERT(detid.layer() == layer);
-	  CPPUNIT_ASSERT(detid.chamber() == chamber);
-	  CPPUNIT_ASSERT(detid.roll() == roll);
-
-	         //  test constructor from id
-	  int myId = detid.rawId();
-	  ME0DetId anotherId(myId);
-	  CPPUNIT_ASSERT(detid==anotherId);
-	  
-	}
+          //  test constructor from id
+          int myId = detid.rawId();
+          ME0DetId anotherId(myId);
+          CPPUNIT_ASSERT(detid == anotherId);
+        }
       }
   }
 }
 
-
-void testME0DetId::testFail(){
-
-
+void testME0DetId::testFail() {
   // contruct using an invalid input index
   try {
     // Wrong Layer
-    ME0DetId detid(0,57,0,0);
-    CPPUNIT_ASSERT("Failed to throw required exception 0" == 0);      
-    detid.rawId(); // avoid compiler warning
+    ME0DetId detid(0, 57, 0, 0);
+    CPPUNIT_ASSERT("Failed to throw required exception 0" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
@@ -77,9 +67,9 @@ void testME0DetId::testFail(){
 
   try {
     // Wrong Region
-    ME0DetId detid(2,0,0,0);
-    CPPUNIT_ASSERT("Failed to throw required exception 1" == 0);      
-    detid.rawId(); // avoid compiler warning
+    ME0DetId detid(2, 0, 0, 0);
+    CPPUNIT_ASSERT("Failed to throw required exception 1" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
@@ -88,44 +78,40 @@ void testME0DetId::testFail(){
 
   try {
     // Not existant chamber number
-    ME0DetId detid(-1,1,37,1);
-    CPPUNIT_ASSERT("Failed to throw required exception 2" == 0);      
-    detid.rawId(); // avoid compiler warning
+    ME0DetId detid(-1, 1, 37, 1);
+    CPPUNIT_ASSERT("Failed to throw required exception 2" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception 2" == 0);
   }
-  
+
   // contruct using an invalid input id
   try {
     ME0DetId detid(100);
-    CPPUNIT_ASSERT("Failed to throw required exception 3" == 0);      
-    detid.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception 3" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception 3" == 0);
   }
-
 }
 
+void testME0DetId::testMemberOperators() {
+  ME0DetId unit1(1, 5, 3, 1);
+  ME0DetId unit2 = unit1;
 
-void testME0DetId::testMemberOperators(){
-  ME0DetId unit1(1,5,3,1);
-  ME0DetId unit2=unit1;
-  
-  CPPUNIT_ASSERT(unit2==unit1);
+  CPPUNIT_ASSERT(unit2 == unit1);
 
   ME0DetId layer = unit1.layerId();
-  ME0DetId unit3(1,5,3,0);
+  ME0DetId unit3(1, 5, 3, 0);
 
-  CPPUNIT_ASSERT(layer==unit3);
+  CPPUNIT_ASSERT(layer == unit3);
 
   ME0DetId chamber = unit1.chamberId();
-  ME0DetId unit4(1,0,3,0);
+  ME0DetId unit4(1, 0, 3, 0);
 
-  CPPUNIT_ASSERT(chamber==unit4);
-  
-
+  CPPUNIT_ASSERT(chamber == unit4);
 }

--- a/DataFormats/MuonDetId/test/testRPCCompDetId.cc
+++ b/DataFormats/MuonDetId/test/testRPCCompDetId.cc
@@ -13,17 +13,16 @@
 #include <iostream>
 using namespace std;
 
-class testRPCCompDetId: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testRPCCompDetId);
-CPPUNIT_TEST(testOne);
-CPPUNIT_TEST(testFail);
-CPPUNIT_TEST(testMemberOperators);
-CPPUNIT_TEST_SUITE_END();
+class testRPCCompDetId : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testRPCCompDetId);
+  CPPUNIT_TEST(testOne);
+  CPPUNIT_TEST(testFail);
+  CPPUNIT_TEST(testMemberOperators);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void testOne();
   void testFail();
@@ -33,58 +32,53 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testRPCCompDetId);
 
-void testRPCCompDetId::testOne(){
-  for (int region=RPCCompDetId::minRegionId; region<=RPCCompDetId::maxRegionId; ++region)
-  {
-     const int minRing ( 0 != region ? RPCCompDetId::minRingForwardId : RPCCompDetId::minRingBarrelId ) ;
-     const int maxRing ( 0 != region ? RPCCompDetId::maxRingForwardId : RPCCompDetId::maxRingBarrelId ) ;
-     const int minSector ( 0 != region ? RPCCompDetId::minSectorForwardId : RPCCompDetId::minSectorBarrelId ) ;
-     const int maxSector ( 0 != region ? RPCCompDetId::maxSectorForwardId : RPCCompDetId::maxSectorBarrelId ) ;
-    
-      for (int ring=minRing; ring<=maxRing; ++ring) 	    
-        for (int station=RPCCompDetId::minStationId; station<=RPCCompDetId::maxStationId; ++station)
-          for (int sector=minSector; sector<=maxSector; ++sector)
-            for (int layer=RPCCompDetId::minLayerId; layer<=RPCCompDetId::maxLayerId; ++layer)
-              for (int subSector=RPCCompDetId::minSubSectorId; subSector<=RPCCompDetId::maxSubSectorId; ++subSector){
+void testRPCCompDetId::testOne() {
+  for (int region = RPCCompDetId::minRegionId; region <= RPCCompDetId::maxRegionId; ++region) {
+    const int minRing(0 != region ? RPCCompDetId::minRingForwardId : RPCCompDetId::minRingBarrelId);
+    const int maxRing(0 != region ? RPCCompDetId::maxRingForwardId : RPCCompDetId::maxRingBarrelId);
+    const int minSector(0 != region ? RPCCompDetId::minSectorForwardId : RPCCompDetId::minSectorBarrelId);
+    const int maxSector(0 != region ? RPCCompDetId::maxSectorForwardId : RPCCompDetId::maxSectorBarrelId);
 
-		RPCCompDetId detid(region, ring, station, sector, layer, subSector,0);
-		
-		CPPUNIT_ASSERT(detid.region() == region);
-		CPPUNIT_ASSERT(detid.ring() == ring);
-		CPPUNIT_ASSERT(detid.station() == station);
-		CPPUNIT_ASSERT(detid.sector() == sector);
-		CPPUNIT_ASSERT(detid.layer() == layer);
-		CPPUNIT_ASSERT(detid.subsector() == subSector);
-		
-	         //  test constructor from id
-		int myId = detid.rawId();
-		RPCCompDetId anotherId(myId);
-		CPPUNIT_ASSERT(detid==anotherId);
-		
-	      }
+    for (int ring = minRing; ring <= maxRing; ++ring)
+      for (int station = RPCCompDetId::minStationId; station <= RPCCompDetId::maxStationId; ++station)
+        for (int sector = minSector; sector <= maxSector; ++sector)
+          for (int layer = RPCCompDetId::minLayerId; layer <= RPCCompDetId::maxLayerId; ++layer)
+            for (int subSector = RPCCompDetId::minSubSectorId; subSector <= RPCCompDetId::maxSubSectorId; ++subSector) {
+              RPCCompDetId detid(region, ring, station, sector, layer, subSector, 0);
+
+              CPPUNIT_ASSERT(detid.region() == region);
+              CPPUNIT_ASSERT(detid.ring() == ring);
+              CPPUNIT_ASSERT(detid.station() == station);
+              CPPUNIT_ASSERT(detid.sector() == sector);
+              CPPUNIT_ASSERT(detid.layer() == layer);
+              CPPUNIT_ASSERT(detid.subsector() == subSector);
+
+              //  test constructor from id
+              int myId = detid.rawId();
+              RPCCompDetId anotherId(myId);
+              CPPUNIT_ASSERT(detid == anotherId);
+            }
   }
 }
 
-
-void testRPCCompDetId::testFail(){
-
+void testRPCCompDetId::testFail() {
   // contruct using an invalid input index
   try {
     // Station number too high
-    RPCCompDetId detid(0,1,7,2,2,1,1);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    RPCCompDetId detid(0, 1, 7, 2, 2, 1, 1);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-  
+
   // contruct using an invalid input id
   try {
     RPCCompDetId detid(100);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
@@ -92,9 +86,8 @@ void testRPCCompDetId::testFail(){
   }
 }
 
-
-void testRPCCompDetId::testMemberOperators(){
-  RPCCompDetId unit1(0,-2,1,2,2,1,1);
-  RPCCompDetId unit2=unit1;
-  CPPUNIT_ASSERT(unit2==unit1);
+void testRPCCompDetId::testMemberOperators() {
+  RPCCompDetId unit1(0, -2, 1, 2, 2, 1, 1);
+  RPCCompDetId unit2 = unit1;
+  CPPUNIT_ASSERT(unit2 == unit1);
 }

--- a/DataFormats/MuonDetId/test/testRPCDetId.cc
+++ b/DataFormats/MuonDetId/test/testRPCDetId.cc
@@ -13,17 +13,16 @@
 #include <iostream>
 using namespace std;
 
-class testRPCDetId: public CppUnit::TestFixture
-{
-CPPUNIT_TEST_SUITE(testRPCDetId);
-CPPUNIT_TEST(testOne);
-CPPUNIT_TEST(testFail);
-CPPUNIT_TEST(testMemberOperators);
-CPPUNIT_TEST_SUITE_END();
+class testRPCDetId : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testRPCDetId);
+  CPPUNIT_TEST(testOne);
+  CPPUNIT_TEST(testFail);
+  CPPUNIT_TEST(testMemberOperators);
+  CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp(){}
-  void tearDown(){}
+  void setUp() {}
+  void tearDown() {}
 
   void testOne();
   void testFail();
@@ -33,86 +32,72 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testRPCDetId);
 
-void testRPCDetId::testOne(){
+void testRPCDetId::testOne() {
+  for (int region = RPCDetId::minRegionId; region <= RPCDetId::maxRegionId; ++region) {
+    const int minRing(0 != region ? RPCDetId::minRingForwardId : RPCDetId::minRingBarrelId);
+    const int maxRing(0 != region ? RPCDetId::maxRingForwardId : RPCDetId::maxRingBarrelId);
+    const int minSector(0 != region ? RPCDetId::minSectorForwardId : RPCDetId::minSectorBarrelId);
+    const int maxSector(0 != region ? RPCDetId::maxSectorForwardId : RPCDetId::maxSectorBarrelId);
+    const int minSubSector(0 != region ? RPCDetId::minSubSectorForwardId : RPCDetId::minSubSectorBarrelId);
+    const int maxSubSector(0 != region ? RPCDetId::maxSubSectorForwardId : RPCDetId::maxSubSectorBarrelId);
 
+    for (int ring = minRing; ring <= maxRing; ++ring)
+      for (int station = RPCDetId::minStationId; station <= RPCDetId::maxStationId; ++station)
+        for (int sector = minSector; sector <= maxSector; ++sector)
+          for (int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer)
+            for (int subSector = minSubSector; subSector <= maxSubSector; ++subSector)
+              for (int roll = RPCDetId::minRollId; roll <= RPCDetId::maxRollId; ++roll) {
+                RPCDetId detid(region, ring, station, sector, layer, subSector, roll);
 
-  for (int region=RPCDetId::minRegionId; region<=RPCDetId::maxRegionId; ++region)
-  {
-     const int minRing ( 0 != region ? RPCDetId::minRingForwardId : RPCDetId::minRingBarrelId ) ;
-     const int maxRing ( 0 != region ? RPCDetId::maxRingForwardId : RPCDetId::maxRingBarrelId ) ;
-     const int minSector ( 0 != region ? RPCDetId::minSectorForwardId : RPCDetId::minSectorBarrelId ) ;
-     const int maxSector ( 0 != region ? RPCDetId::maxSectorForwardId : RPCDetId::maxSectorBarrelId ) ;
-     const int minSubSector ( 0 != region ? RPCDetId::minSubSectorForwardId : RPCDetId::minSubSectorBarrelId ) ;
-     const int maxSubSector ( 0 != region ? RPCDetId::maxSubSectorForwardId : RPCDetId::maxSubSectorBarrelId ) ;
-    
-      for (int ring=minRing; ring<=maxRing; ++ring) 	    
-        for (int station=RPCDetId::minStationId; station<=RPCDetId::maxStationId; ++station)
-          for (int sector=minSector; sector<=maxSector; ++sector)
-            for (int layer=RPCDetId::minLayerId; layer<=RPCDetId::maxLayerId; ++layer)
-              for (int subSector=minSubSector; subSector<=maxSubSector; ++subSector)
-                for (int roll=RPCDetId::minRollId; roll<=RPCDetId::maxRollId; ++roll){
+                CPPUNIT_ASSERT(detid.region() == region);
+                CPPUNIT_ASSERT(detid.ring() == ring);
+                CPPUNIT_ASSERT(detid.station() == station);
+                CPPUNIT_ASSERT(detid.sector() == sector);
+                CPPUNIT_ASSERT(detid.layer() == layer);
+                CPPUNIT_ASSERT(detid.subsector() == subSector);
+                CPPUNIT_ASSERT(detid.roll() == roll);
 
-	          RPCDetId detid(region, ring, station, sector, layer, subSector, roll);
-
-	          CPPUNIT_ASSERT(detid.region() == region);
-                  CPPUNIT_ASSERT(detid.ring() == ring);
-                  CPPUNIT_ASSERT(detid.station() == station);
-	          CPPUNIT_ASSERT(detid.sector() == sector);
-                  CPPUNIT_ASSERT(detid.layer() == layer);
-	          CPPUNIT_ASSERT(detid.subsector() == subSector);
-                  CPPUNIT_ASSERT(detid.roll() == roll);
-
-	         //  test constructor from id
-	          int myId = detid.rawId();
-	          RPCDetId anotherId(myId);
-	          CPPUNIT_ASSERT(detid==anotherId);
-  
-               }
+                //  test constructor from id
+                int myId = detid.rawId();
+                RPCDetId anotherId(myId);
+                CPPUNIT_ASSERT(detid == anotherId);
+              }
   }
-
-
 }
 
-
-void testRPCDetId::testFail(){
-
-
+void testRPCDetId::testFail() {
   // contruct using an invalid input index
   try {
     // Station number too high
-    RPCDetId detid(0,1,7,2,2,1,1);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    RPCDetId detid(0, 1, 7, 2, 2, 1, 1);
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-  
+
   // contruct using an invalid input id
   try {
     RPCDetId detid(100);
-    CPPUNIT_ASSERT("Failed to throw required exception" == 0);      
-    detid.rawId(); // avoid compiler warning
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+    detid.rawId();  // avoid compiler warning
   } catch (cms::Exception& e) {
     // OK
   } catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
-
 }
 
+void testRPCDetId::testMemberOperators() {
+  RPCDetId unit1(0, -2, 1, 2, 2, 1, 1);
+  RPCDetId unit2 = unit1;
 
-void testRPCDetId::testMemberOperators(){
-  RPCDetId unit1(0,-2,1,2,2,1,1);
-  RPCDetId unit2=unit1;
-  
-  CPPUNIT_ASSERT(unit2==unit1);
+  CPPUNIT_ASSERT(unit2 == unit1);
 
   RPCDetId chamber = unit1.chamberId();
-  RPCDetId unit3(0,-2,1,2,2,1,0);
+  RPCDetId unit3(0, -2, 1, 2, 2, 1, 0);
 
-  CPPUNIT_ASSERT(chamber==unit3);
-  
-
+  CPPUNIT_ASSERT(chamber == unit3);
 }


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/394//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


