### PR TITLE
Running code-format for alca-db

### DIFF
--- a/CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h
+++ b/CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h
@@ -1,8 +1,10 @@
-#ifndef  CondFormats_SiPixelObjects_CablingPathToDetUnit_H
-#define  CondFormats_SiPixelObjects_CablingPathToDetUnit_H
+#ifndef CondFormats_SiPixelObjects_CablingPathToDetUnit_H
+#define CondFormats_SiPixelObjects_CablingPathToDetUnit_H
 
 namespace sipixelobjects {
-  struct CablingPathToDetUnit { unsigned int fed, link, roc; };
-}
+  struct CablingPathToDetUnit {
+    unsigned int fed, link, roc;
+  };
+}  // namespace sipixelobjects
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/DetectorIndex.h
+++ b/CondFormats/SiPixelObjects/interface/DetectorIndex.h
@@ -4,6 +4,10 @@
 #include <boost/cstdint.hpp>
 
 namespace sipixelobjects {
-  struct DetectorIndex { uint32_t rawId; int row; int col; };
-}
+  struct DetectorIndex {
+    uint32_t rawId;
+    int row;
+    int col;
+  };
+}  // namespace sipixelobjects
 #endif

--- a/CondFormats/SiPixelObjects/interface/ElectronicIndex.h
+++ b/CondFormats/SiPixelObjects/interface/ElectronicIndex.h
@@ -2,6 +2,11 @@
 #define CondFormats_SiPixelObjects_ElectronicIndex_H
 
 namespace sipixelobjects {
-  struct ElectronicIndex { int link; int roc; int dcol; int pxid; };
-}
+  struct ElectronicIndex {
+    int link;
+    int roc;
+    int dcol;
+    int pxid;
+  };
+}  // namespace sipixelobjects
 #endif

--- a/CondFormats/SiPixelObjects/interface/FrameConversion.h
+++ b/CondFormats/SiPixelObjects/interface/FrameConversion.h
@@ -10,26 +10,26 @@ class TrackerTopology;
 
 namespace sipixelobjects {
 
-class FrameConversion {
-public:
-  FrameConversion(){}
-  FrameConversion( const PixelEndcapName & name, int rocIdInDetUnit);
-  FrameConversion( const PixelBarrelName & name, int rocIdInDetUnit);
-  FrameConversion( int rowOffset, int rowSlopeSign, int colOffset, int colSlopeSign)
-    : theRowConversion( LinearConversion(rowOffset,rowSlopeSign) ),
-    theCollumnConversion( LinearConversion(colOffset, colSlopeSign) ) {}
-  // for phase1
-  FrameConversion(bool bpix, int side, int layer, int rocIdInDetUnit);
-  // Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
-  FrameConversion(bool bpix, int side, int rocIdInDetUnit);
+  class FrameConversion {
+  public:
+    FrameConversion() {}
+    FrameConversion(const PixelEndcapName& name, int rocIdInDetUnit);
+    FrameConversion(const PixelBarrelName& name, int rocIdInDetUnit);
+    FrameConversion(int rowOffset, int rowSlopeSign, int colOffset, int colSlopeSign)
+        : theRowConversion(LinearConversion(rowOffset, rowSlopeSign)),
+          theCollumnConversion(LinearConversion(colOffset, colSlopeSign)) {}
+    // for phase1
+    FrameConversion(bool bpix, int side, int layer, int rocIdInDetUnit);
+    // Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
+    FrameConversion(bool bpix, int side, int rocIdInDetUnit);
 
-  const sipixelobjects::LinearConversion & row() const { return theRowConversion; }
-  const sipixelobjects::LinearConversion & collumn() const { return theCollumnConversion;}
+    const sipixelobjects::LinearConversion& row() const { return theRowConversion; }
+    const sipixelobjects::LinearConversion& collumn() const { return theCollumnConversion; }
 
-private:
-  sipixelobjects::LinearConversion theRowConversion;
-  sipixelobjects::LinearConversion theCollumnConversion;
-};
+  private:
+    sipixelobjects::LinearConversion theRowConversion;
+    sipixelobjects::LinearConversion theCollumnConversion;
+  };
 
-}
+}  // namespace sipixelobjects
 #endif

--- a/CondFormats/SiPixelObjects/interface/GlobalPixel.h
+++ b/CondFormats/SiPixelObjects/interface/GlobalPixel.h
@@ -2,7 +2,10 @@
 #define CondFormats_SiPixelObjects_GlobalPixel_H
 
 namespace sipixelobjects {
-   /// global coordinates (row and column in DetUnit, as in PixelDigi)
-   struct GlobalPixel { int row; int col; };
-}
+  /// global coordinates (row and column in DetUnit, as in PixelDigi)
+  struct GlobalPixel {
+    int row;
+    int col;
+  };
+}  // namespace sipixelobjects
 #endif

--- a/CondFormats/SiPixelObjects/interface/LinearConversion.h
+++ b/CondFormats/SiPixelObjects/interface/LinearConversion.h
@@ -3,18 +3,17 @@
 
 namespace sipixelobjects {
 
-class LinearConversion {
+  class LinearConversion {
+  public:
+    LinearConversion(int offset = 0, int slope = 1) : theOffset(offset), theSlope(slope) {}
+    int convert(int item) const { return theOffset + theSlope * item; }
+    int inverse(int item) const { return (item - theOffset) / theSlope; }
+    int offset() const { return theOffset; }
+    int slope() const { return theSlope; }
 
-public:
-  LinearConversion(int offset =0, int slope =1) : theOffset(offset), theSlope(slope) { }
-  int convert( int item) const { return theOffset+theSlope*item; }
-  int inverse( int item) const { return (item - theOffset)/theSlope; } 
-  int offset() const { return theOffset; }
-  int slope() const { return theSlope; }
+  private:
+    int theOffset, theSlope;
+  };
 
-private:
-  int theOffset, theSlope;
-};
-
-}
+}  // namespace sipixelobjects
 #endif

--- a/CondFormats/SiPixelObjects/interface/LocalPixel.h
+++ b/CondFormats/SiPixelObjects/interface/LocalPixel.h
@@ -4,43 +4,41 @@
 namespace sipixelobjects {
 
   /// identify pixel inside single ROC
-  class LocalPixel { 
+  class LocalPixel {
+  public:
+    static const int numRowsInRoc = 80;
+    static const int numColsInRoc = 52;
 
-    public:
+    /// row and collumn in ROC representation
+    struct RocRowCol {
+      int rocRow, rocCol;
+      bool valid() const { return (0 <= rocRow) & (rocRow < numRowsInRoc) & (0 <= rocCol) & (rocCol < numColsInRoc); }
+    };
 
-      static const int numRowsInRoc = 80;
-      static const int numColsInRoc = 52;
+    /// double collumn and pixel ID in double collumn representation
+    struct DcolPxid {
+      int dcol, pxid;
+      bool valid() const { return ((0 <= dcol) & (dcol < 26) & (2 <= pxid) & (pxid < 162)); }
+    };
 
-      /// row and collumn in ROC representation 
-      struct RocRowCol { 
-        int rocRow, rocCol; 
-        bool valid() const { return    (0 <= rocRow) & (rocRow < numRowsInRoc)  
-	    & (0 <= rocCol) & (rocCol < numColsInRoc); }
-      };
+    LocalPixel(const DcolPxid& pixel) {
+      thePixel.rocRow = numRowsInRoc - pixel.pxid / 2;
+      thePixel.rocCol = pixel.dcol * 2 + pixel.pxid % 2;
+    }
 
-      /// double collumn and pixel ID in double collumn representation
-      struct DcolPxid { 
-        int dcol, pxid; 
-        bool valid() const { return ( (0 <= dcol) & (dcol < 26) &  (2 <= pxid) & (pxid < 162) ); }
-      }; 
+    LocalPixel(const RocRowCol& pixel) : thePixel(pixel) {}
 
-      LocalPixel( const DcolPxid & pixel) {
-        thePixel.rocRow = numRowsInRoc - pixel.pxid/2;
-	thePixel.rocCol = pixel.dcol*2 + pixel.pxid%2;
-      }
+    int dcol() const { return thePixel.rocCol / 2; }
+    int pxid() const { return 2 * (numRowsInRoc - thePixel.rocRow) + (thePixel.rocCol % 2); }
 
-      LocalPixel( const RocRowCol & pixel) : thePixel(pixel) {} 
+    int rocRow() const { return thePixel.rocRow; }
+    int rocCol() const { return thePixel.rocCol; }
 
-      int  dcol() const { return thePixel.rocCol/2; }
-      int  pxid() const { return 2*(numRowsInRoc-thePixel.rocRow)+ (thePixel.rocCol%2); }
+    bool valid() const { return thePixel.valid(); }
 
-      int  rocRow() const { return thePixel.rocRow; }
-      int  rocCol() const { return thePixel.rocCol; }
-
-      bool valid() const { return thePixel.valid(); }
-    private:
-      RocRowCol thePixel;
+  private:
+    RocRowCol thePixel;
   };
-}
+}  // namespace sipixelobjects
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/PixelDCSObject.h
+++ b/CondFormats/SiPixelObjects/interface/PixelDCSObject.h
@@ -19,13 +19,11 @@
 #include <vector>
 
 template <class T>
-struct PixelDCSObject
-{
+struct PixelDCSObject {
   typedef T Type;
 
-  struct Item
-  {
-    std::string name; // name of detector element
+  struct Item {
+    std::string name;  // name of detector element
 
     Type value;
 
@@ -37,11 +35,10 @@ struct PixelDCSObject
   COND_SERIALIZABLE;
 };
 
-struct CaenChannel
-{
-  bool isOn;  // true if channel is on
-  float iMon; // current value
-  float vMon; // voltage value
+struct CaenChannel {
+  bool isOn;   // true if channel is on
+  float iMon;  // current value
+  float vMon;  // voltage value
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiPixelObjects/interface/PixelFEDCabling.h
+++ b/CondFormats/SiPixelObjects/interface/PixelFEDCabling.h
@@ -13,42 +13,40 @@ class PixelModuleName;
 
 namespace sipixelobjects {
 
-class PixelFEDCabling {
-public:
+  class PixelFEDCabling {
+  public:
+    typedef std::vector<PixelFEDLink> Links;
 
-  typedef std::vector<PixelFEDLink> Links;
-  
-  PixelFEDCabling(unsigned int id = 0) : theFedId(id) { }
+    PixelFEDCabling(unsigned int id = 0) : theFedId(id) {}
 
-  void setLinks(Links & links);
+    void setLinks(Links& links);
 
-  void addLink(const PixelFEDLink & link);
+    void addLink(const PixelFEDLink& link);
 
-  /// return link identified by id. Link id's are ranged [1, numberOfLinks]
-  const PixelFEDLink * link(unsigned int id) const 
-    { return (id > 0 && id <= theLinks.size()) ? &theLinks[id-1] : nullptr; }
+    /// return link identified by id. Link id's are ranged [1, numberOfLinks]
+    const PixelFEDLink* link(unsigned int id) const {
+      return (id > 0 && id <= theLinks.size()) ? &theLinks[id - 1] : nullptr;
+    }
 
-  /// number of links in FED
-  unsigned int numberOfLinks() const { return theLinks.size(); }
+    /// number of links in FED
+    unsigned int numberOfLinks() const { return theLinks.size(); }
 
-  unsigned int id() const { return theFedId; } 
+    unsigned int id() const { return theFedId; }
 
-  std::string print(int depth = 0) const;
+    std::string print(int depth = 0) const;
 
-  void  addItem(unsigned int linkId, const PixelROC & roc);
+    void addItem(unsigned int linkId, const PixelROC& roc);
 
-  /// check link numbering consistency, ie. that link position in vector
-  /// is the same as its id. Futhermore it checks numbering consistency for
-  /// ROCs belonging to Link. 
-  bool checkLinkNumbering() const;
-private:
-  
-private:
+    /// check link numbering consistency, ie. that link position in vector
+    /// is the same as its id. Futhermore it checks numbering consistency for
+    /// ROCs belonging to Link.
+    bool checkLinkNumbering() const;
 
-  unsigned int   theFedId;
-  Links theLinks;
-
-}; 
-}
+  private:
+  private:
+    unsigned int theFedId;
+    Links theLinks;
+  };
+}  // namespace sipixelobjects
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/PixelFEDLink.h
+++ b/CondFormats/SiPixelObjects/interface/PixelFEDLink.h
@@ -15,43 +15,41 @@ class PixelModuleName;
 
 namespace sipixelobjects {
 
-class PixelFEDLink {
-public:
+  class PixelFEDLink {
+  public:
+    /// ROCs served be this link
+    typedef std::vector<PixelROC> ROCs;
 
-  /// ROCs served be this link
-  typedef std::vector<PixelROC> ROCs;
+    /// ctor with id of link and parent FED
+    PixelFEDLink(unsigned int id = 0) : theId(id) {}
 
-  /// ctor with id of link and parent FED
-  PixelFEDLink(unsigned int id = 0) : theId(id) { } 
+    ///  add connection (defined by connection spec and ROCs)
+    void add(const ROCs& rocs);
 
-  ///  add connection (defined by connection spec and ROCs)
-  void add(const ROCs & rocs);
+    /// link id
+    unsigned int id() const { return theId; }
 
-  /// link id
-  unsigned int id() const { return theId; }
+    /// number of ROCs in fed
+    unsigned int numberOfROCs() const { return theROCs.size(); }
 
-  /// number of ROCs in fed
-  unsigned int numberOfROCs() const { return theROCs.size(); }
+    /// return ROC identified by id. ROC ids are ranged [1,numberOfROCs]
+    const PixelROC* roc(unsigned int id) const { return (id > 0 && id <= theROCs.size()) ? &theROCs[id - 1] : nullptr; }
 
-  /// return ROC identified by id. ROC ids are ranged [1,numberOfROCs]
-  const PixelROC * roc(unsigned int id) const
-    { return (id > 0 && id <= theROCs.size() ) ?  &theROCs[id-1] : nullptr; }
+    /// check ROC in link numbering consistency, ie. that ROC position in
+    /// vector is the same as its id. To be called by owner
+    bool checkRocNumbering() const;
 
-  /// check ROC in link numbering consistency, ie. that ROC position in
-  /// vector is the same as its id. To be called by owner
-  bool checkRocNumbering() const;
+    std::string print(int depth = 0) const;
 
-  std::string print(int depth = 0) const;
+    void addItem(const PixelROC& roc);
 
-  void addItem(const PixelROC & roc);
+  private:
+    unsigned int theId;
+    ROCs theROCs;
+    std::string printForMap() const;
+  };
 
-private:
-  unsigned int theId;
-  ROCs theROCs;
-  std::string printForMap() const;
-};
-
-}
+}  // namespace sipixelobjects
 
 //std::ostream & operator<<( std::ostream& out, const PixelFEDLink & l);
 

--- a/CondFormats/SiPixelObjects/interface/PixelIndices.h
+++ b/CondFormats/SiPixelObjects/interface/PixelIndices.h
@@ -21,60 +21,52 @@
 namespace {
   // A few constants just for error checking
   // The maximum number of ROCs in the X (row) direction per sensor.
-  const int maxROCsInX = 2;  //  
+  const int maxROCsInX = 2;  //
   // The maximum number of ROCs in the Y (column) direction per sensor.
   const int maxROCsInY = 8;  //
-  // The nominal number of double columns per ROC is 26. 
-  const int DColsPerROC = 26; 
-  // Default ROC size 
-  const int ROCSizeInX = 80;  // ROC row size in pixels 
-  const int ROCSizeInY = 52;  // ROC col size in pixels 
-  // Default DET barrel size 
-  const int defaultDetSizeInX = 160;  // Det barrel row size in pixels 
-  const int defaultDetSizeInY = 416;  // Det barrel col size in pixels 
-  
+  // The nominal number of double columns per ROC is 26.
+  const int DColsPerROC = 26;
+  // Default ROC size
+  const int ROCSizeInX = 80;  // ROC row size in pixels
+  const int ROCSizeInY = 52;  // ROC col size in pixels
+  // Default DET barrel size
+  const int defaultDetSizeInX = 160;  // Det barrel row size in pixels
+  const int defaultDetSizeInY = 416;  // Det barrel col size in pixels
+
   // Check the limits
   const bool TP_CHECK_LIMITS = true;
-}
+}  // namespace
 
 class PixelIndices {
-
- public:
-  
+public:
   //*********************************************************************
   // Constructor with the ROC size fixed to the default.
-   PixelIndices(const int colsInDet,  const int rowsInDet ) : 
-                theColsInDet(colsInDet), theRowsInDet (rowsInDet) {
- 
-    theChipsInX = theRowsInDet / ROCSizeInX; // number of ROCs in X
-    theChipsInY = theColsInDet / ROCSizeInY;    // number of ROCs in Y
+  PixelIndices(const int colsInDet, const int rowsInDet) : theColsInDet(colsInDet), theRowsInDet(rowsInDet) {
+    theChipsInX = theRowsInDet / ROCSizeInX;  // number of ROCs in X
+    theChipsInY = theColsInDet / ROCSizeInY;  // number of ROCs in Y
 
-    if(TP_CHECK_LIMITS) {
-      if(theChipsInX<1 || theChipsInX>maxROCsInX) 
-	std::cout << " PixelIndices: Error in ROCsInX " 
-	     << theChipsInX <<" "<<theRowsInDet<<" "<<ROCSizeInX<<std::endl;
-      if(theChipsInY<1 || theChipsInY>maxROCsInY) 
-	std::cout << " PixelIndices: Error in ROCsInY " 
-	     << theChipsInY <<" "<<theColsInDet<<" "<<ROCSizeInY<<std::endl;
+    if (TP_CHECK_LIMITS) {
+      if (theChipsInX < 1 || theChipsInX > maxROCsInX)
+        std::cout << " PixelIndices: Error in ROCsInX " << theChipsInX << " " << theRowsInDet << " " << ROCSizeInX
+                  << std::endl;
+      if (theChipsInY < 1 || theChipsInY > maxROCsInY)
+        std::cout << " PixelIndices: Error in ROCsInY " << theChipsInY << " " << theColsInDet << " " << ROCSizeInY
+                  << std::endl;
     }
-  } 
+  }
   //************************************************************************
   ~PixelIndices() {}
   //***********************************************************************
- 
-  inline int numberOfROCsInX(void) {return theChipsInX;}
-  inline int numberOfROCsInY(void) {return theChipsInY;}
+
+  inline int numberOfROCsInX(void) { return theChipsInX; }
+  inline int numberOfROCsInY(void) { return theChipsInY; }
 
   //***********************************************************************
 
- void print(void) const {
-
-    std::cout << " Pixel det with " << theChipsInX << " chips in x and "
-	 << theChipsInY << " in y " << std::endl; 
-    std::cout << " Pixel rows " << theRowsInDet << " and columns " 
-	 << theColsInDet << std::endl;  
-    std::cout << " Rows in one chip " << ROCSizeInX << " and columns " 
-	 << ROCSizeInY << std::endl;  
+  void print(void) const {
+    std::cout << " Pixel det with " << theChipsInX << " chips in x and " << theChipsInY << " in y " << std::endl;
+    std::cout << " Pixel rows " << theRowsInDet << " and columns " << theColsInDet << std::endl;
+    std::cout << " Rows in one chip " << ROCSizeInX << " and columns " << ROCSizeInY << std::endl;
     std::cout << " Double columns per ROC " << DColsPerROC << std::endl;
   }
 
@@ -85,140 +77,132 @@ class PixelIndices {
   // pix = 2 - 161, zigzag pattern.
   // colAdd = 0-51   ! col&row start from 0
   // rowAdd = 0-79
-  inline static int convertDcolToCol(const int dcol, const int pix, 
-				     int & colROC, int & rowROC) {
-
-      if(TP_CHECK_LIMITS) { 
-	if(dcol<0||dcol>=DColsPerROC||pix<2||pix>161) {
-	  std::cout<<"PixelIndices: wrong dcol or pix "<<dcol<<" "<<pix<<std::endl;
-	  rowROC = -1;     // dummy row Address
-	  colROC = -1;     // dummy col Address
-	  return -1; // Signal error
-	}
+  inline static int convertDcolToCol(const int dcol, const int pix, int& colROC, int& rowROC) {
+    if (TP_CHECK_LIMITS) {
+      if (dcol < 0 || dcol >= DColsPerROC || pix < 2 || pix > 161) {
+        std::cout << "PixelIndices: wrong dcol or pix " << dcol << " " << pix << std::endl;
+        rowROC = -1;  // dummy row Address
+        colROC = -1;  // dummy col Address
+        return -1;    // Signal error
       }
-
-      // First find if we are in the first or 2nd col of a dcol.
-      int colEvenOdd = pix%2;  // module(2), 0-1st sol, 1-2nd col.
-      // Transform
-      colROC = dcol * 2 + colEvenOdd; // col address, starts from 0
-      rowROC = abs( int(pix/2) - 80); // row addres, starts from 0
-
-      if(TP_CHECK_LIMITS) {
-	if(colROC<0||colROC>=ROCSizeInY||rowROC<0||rowROC>=ROCSizeInX ) {
-	  std::cout<<"PixelIndices: wrong col or row "<<colROC<<" "<<rowROC<<" "
-	      <<dcol<<" "<<pix<<std::endl;
-	  rowROC = -1;    // dummy row Address
-	  colROC = -1;    // dummy col Address
-	  return -1;
-	}
-      }
-      return 0;
     }
 
- //********************************************************************
- // colROC, rowROC are coordinates in the ROC frame, for ROC=rocId
- // (Start from 0).
- // cols, row are coordinates in the module frame, start from 0.
- // row is X, col is Y.
- // At the moment this works only for modules read with a single TBM.
-  int transformToModule(const int colROC,const int rowROC,
-			const int rocId,
-			int & col,int & row ) const {
+    // First find if we are in the first or 2nd col of a dcol.
+    int colEvenOdd = pix % 2;  // module(2), 0-1st sol, 1-2nd col.
+    // Transform
+    colROC = dcol * 2 + colEvenOdd;   // col address, starts from 0
+    rowROC = abs(int(pix / 2) - 80);  // row addres, starts from 0
 
-       if(TP_CHECK_LIMITS) {
-	if(colROC<0 || colROC>=ROCSizeInY || rowROC<0 ||rowROC>=ROCSizeInX) {
-	  std::cout<<"PixelIndices: wrong index "<<colROC<<" "<<rowROC<<std::endl;
-	  return -1;
-	}
+    if (TP_CHECK_LIMITS) {
+      if (colROC < 0 || colROC >= ROCSizeInY || rowROC < 0 || rowROC >= ROCSizeInX) {
+        std::cout << "PixelIndices: wrong col or row " << colROC << " " << rowROC << " " << dcol << " " << pix
+                  << std::endl;
+        rowROC = -1;  // dummy row Address
+        colROC = -1;  // dummy col Address
+        return -1;
       }
+    }
+    return 0;
+  }
 
-      // The transformation depends on the ROC-ID
-      if(rocId>=0 && rocId<8) {
-	row = 159-rowROC;
-	//col = rocId*52 + colROC;
-	col = (8-rocId)*ROCSizeInY - colROC - 1;
-      } else if(rocId>=8 && rocId<16) {
-	row = rowROC;
-	//col = (16-rocId)*52 - colROC - 1;
-	col = (rocId-8)*ROCSizeInY + colROC;
-      } else {
-	std::cout<<"PixelIndices: wrong ROC ID "<<rocId<<std::endl;
-	return -1;
+  //********************************************************************
+  // colROC, rowROC are coordinates in the ROC frame, for ROC=rocId
+  // (Start from 0).
+  // cols, row are coordinates in the module frame, start from 0.
+  // row is X, col is Y.
+  // At the moment this works only for modules read with a single TBM.
+  int transformToModule(const int colROC, const int rowROC, const int rocId, int& col, int& row) const {
+    if (TP_CHECK_LIMITS) {
+      if (colROC < 0 || colROC >= ROCSizeInY || rowROC < 0 || rowROC >= ROCSizeInX) {
+        std::cout << "PixelIndices: wrong index " << colROC << " " << rowROC << std::endl;
+        return -1;
       }
-      if(TP_CHECK_LIMITS) {
-	if(col<0 || col>=(ROCSizeInY*theChipsInY) || row<0 || 
-			     row>=(ROCSizeInX*theChipsInX)) {
-	std::cout<<"PixelIndices: wrong index "<<col<<" "<<row<<std::endl;
-	return -1;
-	}
-      }
+    }
 
-      return 0;
+    // The transformation depends on the ROC-ID
+    if (rocId >= 0 && rocId < 8) {
+      row = 159 - rowROC;
+      //col = rocId*52 + colROC;
+      col = (8 - rocId) * ROCSizeInY - colROC - 1;
+    } else if (rocId >= 8 && rocId < 16) {
+      row = rowROC;
+      //col = (16-rocId)*52 - colROC - 1;
+      col = (rocId - 8) * ROCSizeInY + colROC;
+    } else {
+      std::cout << "PixelIndices: wrong ROC ID " << rocId << std::endl;
+      return -1;
+    }
+    if (TP_CHECK_LIMITS) {
+      if (col < 0 || col >= (ROCSizeInY * theChipsInY) || row < 0 || row >= (ROCSizeInX * theChipsInX)) {
+        std::cout << "PixelIndices: wrong index " << col << " " << row << std::endl;
+        return -1;
+      }
+    }
+
+    return 0;
   }
   //**************************************************************************
   // Transform from the module indixes to the ROC indices.
   // col, row - indices in the Module
   // rocId - roc index
   // colROC, rowROC - indices in the ROC frame.
-  int transformToROC(const int col,const int row,
-		     int & rocId, int & colROC, int & rowROC ) const {
-
-      if(TP_CHECK_LIMITS) {
-	if(col<0 || col>=(ROCSizeInY*theChipsInY) || row<0 || 
-			     row>=(ROCSizeInX*theChipsInX)) {
-	  std::cout<<"PixelIndices: wrong index 3 "<<std::endl;
-	  return -1;
-	}
+  int transformToROC(const int col, const int row, int& rocId, int& colROC, int& rowROC) const {
+    if (TP_CHECK_LIMITS) {
+      if (col < 0 || col >= (ROCSizeInY * theChipsInY) || row < 0 || row >= (ROCSizeInX * theChipsInX)) {
+        std::cout << "PixelIndices: wrong index 3 " << std::endl;
+        return -1;
       }
+    }
 
-      // Get the 2d ROC coordinate
-      int chipX = row / ROCSizeInX; // row index of the chip 0-1
-      int chipY = col / ROCSizeInY; // col index of the chip 0-7
+    // Get the 2d ROC coordinate
+    int chipX = row / ROCSizeInX;  // row index of the chip 0-1
+    int chipY = col / ROCSizeInY;  // col index of the chip 0-7
 
-      // Get the ROC id from the 2D index
-      rocId = rocIndex(chipX,chipY); 
-      if(TP_CHECK_LIMITS && (rocId<0 || rocId>=16) ) {
-	std::cout<<"PixelIndices: wrong roc index "<<rocId<<std::endl;
-	return -1;
+    // Get the ROC id from the 2D index
+    rocId = rocIndex(chipX, chipY);
+    if (TP_CHECK_LIMITS && (rocId < 0 || rocId >= 16)) {
+      std::cout << "PixelIndices: wrong roc index " << rocId << std::endl;
+      return -1;
+    }
+    // get the local ROC coordinates
+    rowROC = (row % ROCSizeInX);  // row in chip
+    colROC = (col % ROCSizeInY);  // col in chip
+
+    if (rocId < 8) {  // For lower 8 ROCs the coordinates are reversed
+      colROC = 51 - colROC;
+      rowROC = 79 - rowROC;
+    }
+
+    if (TP_CHECK_LIMITS) {
+      if (colROC < 0 || colROC >= ROCSizeInY || rowROC < 0 || rowROC >= ROCSizeInX) {
+        std::cout << "PixelIndices: wrong index " << colROC << " " << rowROC << std::endl;
+        return -1;
       }
-      // get the local ROC coordinates
-      rowROC = (row%ROCSizeInX); // row in chip
-      colROC = (col%ROCSizeInY); // col in chip
+    }
 
-      if(rocId<8) { // For lower 8 ROCs the coordinates are reversed
-	colROC = 51 - colROC;
-	rowROC = 79 - rowROC;
-      }
-
-      if(TP_CHECK_LIMITS) {
-	if(colROC<0||colROC>=ROCSizeInY||rowROC<0||rowROC>=ROCSizeInX) {
-	  std::cout<<"PixelIndices: wrong index "<<colROC<<" "<<rowROC<<std::endl;
-	  return -1;
-	}
-      }
-
-      return 0;
+    return 0;
   }
   //***********************************************************************
   // Calculate a single number ROC index from the 2 ROC indices (coordinates)
   // chipX and chipY.
   // Goes from 0 to 15.
   inline static int rocIndex(const int chipX, const int chipY) {
-
     int rocId = -1;
-    if(TP_CHECK_LIMITS) {
-      if(chipX<0 || chipX>=2 ||chipY<0 || chipY>=8) {
-	std::cout<<"PixelChipIndices: wrong index "<<chipX<<" "<<chipY<<std::endl;
-	return -1;
+    if (TP_CHECK_LIMITS) {
+      if (chipX < 0 || chipX >= 2 || chipY < 0 || chipY >= 8) {
+        std::cout << "PixelChipIndices: wrong index " << chipX << " " << chipY << std::endl;
+        return -1;
       }
     }
-    if(chipX==0) rocId = chipY + 8;  // should be 8-15
-    else if(chipX==1) rocId = 7 - chipY; // should be 0-7
+    if (chipX == 0)
+      rocId = chipY + 8;  // should be 8-15
+    else if (chipX == 1)
+      rocId = 7 - chipY;  // should be 0-7
 
-    if(TP_CHECK_LIMITS) {
-      if(rocId < 0 || rocId >= (maxROCsInX*maxROCsInY) ) {
-	std::cout << "PixelIndices: Error in ROC index " << rocId << std::endl;
-	return -1;
+    if (TP_CHECK_LIMITS) {
+      if (rocId < 0 || rocId >= (maxROCsInX * maxROCsInY)) {
+        std::cout << "PixelIndices: Error in ROC index " << rocId << std::endl;
+        return -1;
       }
     }
     return rocId;
@@ -227,47 +211,40 @@ class PixelIndices {
   // Calculate the dcol in ROC from the col in ROC frame.
   // dcols go from 0 to 25.
   inline static int DColumn(const int colROC) {
-
-    int dColumnId = (colROC)/2; // double column 0-25
-    if(TP_CHECK_LIMITS) {
-      if(dColumnId<0 || dColumnId>=26) {
-	std::cout<<"PixelIndices: wrong dcol index  "<<dColumnId<<" "<<colROC<<std::endl;
-	return -1;
+    int dColumnId = (colROC) / 2;  // double column 0-25
+    if (TP_CHECK_LIMITS) {
+      if (dColumnId < 0 || dColumnId >= 26) {
+        std::cout << "PixelIndices: wrong dcol index  " << dColumnId << " " << colROC << std::endl;
+        return -1;
       }
     }
     return dColumnId;
   }
   //*************************************************************************
   // Calcuulate the global dcol index within a module
-  // Usefull only forin efficiency calculations.  
+  // Usefull only forin efficiency calculations.
   inline static int DColumnInModule(const int dcol, const int chipIndex) {
     int dcolInMod = dcol + chipIndex * 26;
     return dcolInMod;
   }
 
   // This is routines to generate ROC channel number
-  // Only limited use to store ROC pixel indices for calibration  
+  // Only limited use to store ROC pixel indices for calibration
   inline static int pixelToChannelROC(const int rowROC, const int colROC) {
-    return (rowROC<<6) | colROC;  // reserve 6 bit for col ROC index 0-52
+    return (rowROC << 6) | colROC;  // reserve 6 bit for col ROC index 0-52
   }
-  inline static std::pair<int,int> channelToPixelROC(const int chan) {
-    int rowROC = (chan >> 6) & 0x7F; // reserve 7 bits for row ROC index 0-79 
+  inline static std::pair<int, int> channelToPixelROC(const int chan) {
+    int rowROC = (chan >> 6) & 0x7F;  // reserve 7 bits for row ROC index 0-79
     int colROC = chan & 0x3F;
-    return std::pair<int,int>(rowROC,colROC);
+    return std::pair<int, int>(rowROC, colROC);
   }
-  
 
   //***********************************************************************
- private:
-
-    int theColsInDet;      // Columns per Det
-    int theRowsInDet;      // Rows per Det
-    int theChipsInX;       // Chips in det in X (column direction)
-    int theChipsInY;       // Chips in det in Y (row direction)
+private:
+  int theColsInDet;  // Columns per Det
+  int theRowsInDet;  // Rows per Det
+  int theChipsInX;   // Chips in det in X (column direction)
+  int theChipsInY;   // Chips in det in Y (row direction)
 };
 
 #endif
-
-
-
-

--- a/CondFormats/SiPixelObjects/interface/PixelROC.h
+++ b/CondFormats/SiPixelObjects/interface/PixelROC.h
@@ -1,7 +1,6 @@
 #ifndef SiPixelObjects_PixelROC_H
 #define SiPixelObjects_PixelROC_H
 
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "CondFormats/SiPixelObjects/interface/FrameConversion.h"
@@ -21,75 +20,71 @@
 
 namespace sipixelobjects {
 
-class PixelROC {
-public:
+  class PixelROC {
+  public:
+    /// dummy
+    PixelROC() : theDetUnit(0), theIdDU(0), theIdLk(0) {}
 
-  /// dummy
-  PixelROC() : theDetUnit(0), theIdDU(0), theIdLk(0) {} 
+    /// ctor with DetUnit id,
+    /// ROC number in DU (given by token passage),
+    /// ROC number in Link (given by token passage),
+    PixelROC(uint32_t du, int idInDU, int idLk);
 
+    /// return the DetUnit to which this ROC belongs to.
+    uint32_t rawId() const { return theDetUnit; }
 
-  /// ctor with DetUnit id, 
-  /// ROC number in DU (given by token passage), 
-  /// ROC number in Link (given by token passage),
-  PixelROC( uint32_t du, int idInDU, int idLk);
+    /// id of this ROC in DetUnit etermined by token path
+    unsigned int idInDetUnit() const { return theIdDU; }
 
-  /// return the DetUnit to which this ROC belongs to.
-  uint32_t rawId() const { return theDetUnit; }
+    /// id of this ROC in parent Link.
+    unsigned int idInLink() const { return theIdLk; }
 
-  /// id of this ROC in DetUnit etermined by token path 
-  unsigned int idInDetUnit() const { return theIdDU; }
+    /// converts DU position to local.
+    /// If GlobalPixel is outside ROC the resulting LocalPixel is not inside ROC.
+    /// (call to inside(..) recommended)
+    LocalPixel toLocal(const GlobalPixel& glo) const {
+      int rocRow = theFrameConverter.row().inverse(glo.row);
+      int rocCol = theFrameConverter.collumn().inverse(glo.col);
 
-  /// id of this ROC in parent Link.
-  unsigned int idInLink() const { return theIdLk; }
+      LocalPixel::RocRowCol rocRowCol = {rocRow, rocCol};
+      return LocalPixel(rocRowCol);
+    }
 
-  /// converts DU position to local. 
-  /// If GlobalPixel is outside ROC the resulting LocalPixel is not inside ROC.
-  /// (call to inside(..) recommended)
-  LocalPixel  toLocal(const GlobalPixel & glo) const {
-    int rocRow = theFrameConverter.row().inverse(glo.row);
-    int rocCol = theFrameConverter.collumn().inverse(glo.col);
-    
-    LocalPixel::RocRowCol rocRowCol = {rocRow, rocCol};
-    return LocalPixel(rocRowCol);
+    /// converts LocalPixel in ROC to DU coordinates.
+    /// LocalPixel must be inside ROC. Otherwise result is meaningless
+    GlobalPixel toGlobal(const LocalPixel& loc) const {
+      GlobalPixel result;
+      result.col = theFrameConverter.collumn().convert(loc.rocCol());
+      result.row = theFrameConverter.row().convert(loc.rocRow());
+      return result;
+    }
 
-  }
+    // recognise the detector side and layer number
+    // this methods use hardwired constants
+    // if the numberg changes the methods have to be modified
+    int bpixSidePhase0(uint32_t rawId) const;
+    int fpixSidePhase0(uint32_t rawId) const;
+    int bpixSidePhase1(uint32_t rawId) const;
+    int fpixSidePhase1(uint32_t rawId) const;
+    static int bpixLayerPhase1(uint32_t rawId);
 
-  /// converts LocalPixel in ROC to DU coordinates. 
-  /// LocalPixel must be inside ROC. Otherwise result is meaningless
-  GlobalPixel toGlobal(const LocalPixel & loc) const {
-    GlobalPixel result;
-    result.col    = theFrameConverter.collumn().convert(loc.rocCol());
-    result.row    = theFrameConverter.row().convert(loc.rocRow());
-    return result;
-  }
+    /// printout for debug
+    std::string print(int depth = 0) const;
 
-  // recognise the detector side and layer number
-  // this methods use hardwired constants
-  // if the numberg changes the methods have to be modified
-  int bpixSidePhase0(uint32_t rawId) const;
-  int fpixSidePhase0(uint32_t rawId) const;
-  int bpixSidePhase1(uint32_t rawId) const;
-  int fpixSidePhase1(uint32_t rawId) const;
-  static int bpixLayerPhase1(uint32_t rawId);
+    void initFrameConversion();
+    void initFrameConversionPhase1();
+    //void initFrameConversion(const TrackerTopology *tt, bool phase1=false);
+    // Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
+    void initFrameConversionPhase1_CMSSW_9_0_X();
 
-  /// printout for debug
-  std::string print(int depth = 0) const;
+  private:
+    uint32_t theDetUnit;
+    unsigned int theIdDU, theIdLk;
+    FrameConversion theFrameConverter COND_TRANSIENT;
 
-  void initFrameConversion();
-  void initFrameConversionPhase1();
-  //void initFrameConversion(const TrackerTopology *tt, bool phase1=false);
-  // Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
-  void initFrameConversionPhase1_CMSSW_9_0_X();
+    COND_SERIALIZABLE;
+  };
 
-private:
-  uint32_t theDetUnit;
-  unsigned int theIdDU, theIdLk;
-  FrameConversion theFrameConverter COND_TRANSIENT;
-
-
-  COND_SERIALIZABLE;
-};
-
-}
+}  // namespace sipixelobjects
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h
@@ -15,101 +15,97 @@
 
 class SiPixel2DTemplateDBObject {
 public:
-	SiPixel2DTemplateDBObject():index_(0),maxIndex_(0),numOfTempl_(1),version_(-99.9),isInvalid_(false),sVector_(0) {
-		sVector_.reserve(1000000);
-	}
-	virtual ~SiPixel2DTemplateDBObject(){}
-	
-	//- Allows the dbobject to be read out like cout
-	friend std::ostream& operator<<(std::ostream& s, const SiPixel2DTemplateDBObject& dbobject);
+  SiPixel2DTemplateDBObject()
+      : index_(0), maxIndex_(0), numOfTempl_(1), version_(-99.9), isInvalid_(false), sVector_(0) {
+    sVector_.reserve(1000000);
+  }
+  virtual ~SiPixel2DTemplateDBObject() {}
 
-	//- Fills integer from dbobject
-	SiPixel2DTemplateDBObject& operator>>( int& i)
-		{
-			isInvalid_ = false;
-			if(index_<=maxIndex_) {
-				i = (int) (*this).sVector_[index_];
-				index_++;
-			}
-			else
-				(*this).setInvalid();
-			return *this;
-		}
-	//- Fills float from dbobject
-	SiPixel2DTemplateDBObject& operator>>( float& f)
-		{
-			isInvalid_ = false;
-			if(index_<=maxIndex_) {
-				f = (*this).sVector_[index_];
-				index_++;
-			}
-			else
-				(*this).setInvalid();
-			return *this;
-		}
+  //- Allows the dbobject to be read out like cout
+  friend std::ostream& operator<<(std::ostream& s, const SiPixel2DTemplateDBObject& dbobject);
 
-	//- Functions to monitor integrity of dbobject
-	void setVersion(float version) {version_ = version;}
-	void setInvalid() {isInvalid_ = true;}
-	bool fail() {return isInvalid_;}
+  //- Fills integer from dbobject
+  SiPixel2DTemplateDBObject& operator>>(int& i) {
+    isInvalid_ = false;
+    if (index_ <= maxIndex_) {
+      i = (int)(*this).sVector_[index_];
+      index_++;
+    } else
+      (*this).setInvalid();
+    return *this;
+  }
+  //- Fills float from dbobject
+  SiPixel2DTemplateDBObject& operator>>(float& f) {
+    isInvalid_ = false;
+    if (index_ <= maxIndex_) {
+      f = (*this).sVector_[index_];
+      index_++;
+    } else
+      (*this).setInvalid();
+    return *this;
+  }
 
-	//- Setter functions
-	void push_back(float entry) {sVector_.push_back(entry);}
-	void setIndex(int index) {index_ = index;}
-	void setMaxIndex(int maxIndex) {maxIndex_ = maxIndex;}
-	void setNumOfTempl(int numOfTempl) {numOfTempl_ = numOfTempl;}
-	
-	//- Accessor functions
-	int index() const {return index_;}
-	int maxIndex() const {return maxIndex_;}
-	int numOfTempl() const {return numOfTempl_;}
-	float version() const {return version_;}
-	std::vector<float> sVector() const {return sVector_;}
+  //- Functions to monitor integrity of dbobject
+  void setVersion(float version) { version_ = version; }
+  void setInvalid() { isInvalid_ = true; }
+  bool fail() { return isInvalid_; }
 
-	//- Able to set the index for template header 
-	void incrementIndex(int i) {index_+=i;}
+  //- Setter functions
+  void push_back(float entry) { sVector_.push_back(entry); }
+  void setIndex(int index) { index_ = index; }
+  void setMaxIndex(int maxIndex) { maxIndex_ = maxIndex; }
+  void setNumOfTempl(int numOfTempl) { numOfTempl_ = numOfTempl; }
 
-	//- Allows storage of header (type = char[80]) in dbobject
-	union char2float
-	{
-		char  c[4];
-		float f;
-	};
+  //- Accessor functions
+  int index() const { return index_; }
+  int maxIndex() const { return maxIndex_; }
+  int numOfTempl() const { return numOfTempl_; }
+  float version() const { return version_; }
+  std::vector<float> sVector() const { return sVector_; }
 
-	//- To be used to select template calibration based on detid
-	void putTemplateIDs(std::map<unsigned int,short>& t_ID) {templ_ID = t_ID;}
-	const std::map<unsigned int,short>& getTemplateIDs () const {return templ_ID;}
+  //- Able to set the index for template header
+  void incrementIndex(int i) { index_ += i; }
 
-	bool putTemplateID(const uint32_t& detid, short& value)
-		{
-			std::map<unsigned int,short>::const_iterator id=templ_ID.find(detid);
-			if(id!=templ_ID.end()){
-				edm::LogError("SiPixel2DTemplateDBObject") << "2Dtemplate ID for DetID " << detid
-																								 << " is already stored. Skipping this put" << std::endl;
-				return false;
-			}
-			else templ_ID[detid] = value;
-			return true;
-		}
+  //- Allows storage of header (type = char[80]) in dbobject
+  union char2float {
+    char c[4];
+    float f;
+  };
 
-	short getTemplateID(const uint32_t& detid) const
-		{
-			std::map<unsigned int,short>::const_iterator id=templ_ID.find(detid);
-			if(id!=templ_ID.end()) return id->second;
-			else edm::LogError("SiPixel2DTemplateDBObject") << "2Dtemplate ID for DetID " << detid
-																										<< " is not stored" << std::endl;
-			return 0;
-		}
-	
+  //- To be used to select template calibration based on detid
+  void putTemplateIDs(std::map<unsigned int, short>& t_ID) { templ_ID = t_ID; }
+  const std::map<unsigned int, short>& getTemplateIDs() const { return templ_ID; }
+
+  bool putTemplateID(const uint32_t& detid, short& value) {
+    std::map<unsigned int, short>::const_iterator id = templ_ID.find(detid);
+    if (id != templ_ID.end()) {
+      edm::LogError("SiPixel2DTemplateDBObject")
+          << "2Dtemplate ID for DetID " << detid << " is already stored. Skipping this put" << std::endl;
+      return false;
+    } else
+      templ_ID[detid] = value;
+    return true;
+  }
+
+  short getTemplateID(const uint32_t& detid) const {
+    std::map<unsigned int, short>::const_iterator id = templ_ID.find(detid);
+    if (id != templ_ID.end())
+      return id->second;
+    else
+      edm::LogError("SiPixel2DTemplateDBObject")
+          << "2Dtemplate ID for DetID " << detid << " is not stored" << std::endl;
+    return 0;
+  }
+
 private:
-	int index_;
-	int maxIndex_;
-	int numOfTempl_;
-	float version_;
-	bool isInvalid_;
-	std::vector<float> sVector_;
-	std::map<unsigned int,short> templ_ID;
+  int index_;
+  int maxIndex_;
+  int numOfTempl_;
+  float version_;
+  bool isInvalid_;
+  std::vector<float> sVector_;
+  std::map<unsigned int, short> templ_ID;
 
   COND_SERIALIZABLE;
-};//end SiPixel2DTemplateDBObject
+};  //end SiPixel2DTemplateDBObject
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h
@@ -13,77 +13,75 @@
 #define NONSENSE_I -99999
 
 class SiPixelCPEGenericErrorParm {
- public:
-	//! A struct to hold information for a given (alpha,beta,size)
-	struct DbEntry {
-		float sigma;
-		float rms;
-		float bias;       // For irradiated pixels
-		float pix_height; // For decapitation
-		float ave_Qclus;  // Average cluster charge, For 
-	  DbEntry() : sigma(NONSENSE), rms(NONSENSE), 
-				 bias(NONSENSE), pix_height(NONSENSE), 
-				 ave_Qclus(NONSENSE) {}
-	  ~DbEntry() {}
-	
+public:
+  //! A struct to hold information for a given (alpha,beta,size)
+  struct DbEntry {
+    float sigma;
+    float rms;
+    float bias;        // For irradiated pixels
+    float pix_height;  // For decapitation
+    float ave_Qclus;   // Average cluster charge, For
+    DbEntry() : sigma(NONSENSE), rms(NONSENSE), bias(NONSENSE), pix_height(NONSENSE), ave_Qclus(NONSENSE) {}
+    ~DbEntry() {}
+
+    COND_SERIALIZABLE;
+  };
+  typedef std::vector<DbEntry> DbVector;
+
+  //! A struct to hold the binning information for (part, size, alpha, beta)
+  struct DbEntryBinSize {
+    int partBin_size;
+    int sizeBin_size;
+    int alphaBin_size;
+    int betaBin_size;
+    DbEntryBinSize()
+        : partBin_size(NONSENSE_I), sizeBin_size(NONSENSE_I), alphaBin_size(NONSENSE_I), betaBin_size(NONSENSE_I) {}
+    ~DbEntryBinSize() {}
+
+    COND_SERIALIZABLE;
+  };
+  typedef std::vector<DbEntryBinSize> DbBinSizeVector;
+
+  SiPixelCPEGenericErrorParm() : errors_(), errorsBinSize_() {}
+  virtual ~SiPixelCPEGenericErrorParm() {}
+
+  //!  Function to output the contents of the db object
+  friend std::ostream& operator<<(std::ostream& s, const SiPixelCPEGenericErrorParm& genericErrors);
+
+  //!  Function to fill the db object given a filename
+  void fillCPEGenericErrorParm(double version, std::string file);
+
+  //!  Accessors for the vectors -- non-const version
+  inline DbVector& errors() { return errors_; }
+  inline DbBinSizeVector& errorsBin() { return errorsBinSize_; }
+  inline double& version() { return version_; }
+
+  //!  Accessors for the vectors -- const version
+  inline const DbVector& errors() const { return errors_; }
+  inline const DbBinSizeVector& errorsBinSize() const { return errorsBinSize_; }
+  inline const double& version() const { return version_; }
+
+  //!  Reserve some reasonable sizes for the vectors.
+  inline void reserve() {
+    errors_.reserve(1000);
+    errorsBinSize_.reserve(4);
+  }
+  //  &&& Should these sizes be computed on the fly from other
+  //  &&& variables (which are currently not stored in this object,
+  //  &&& but maybe should be?)
+
+  //inline void push_back( DbEntry e) {errors_.push_back(e);}
+  //	inline void push_back_bin( DbEntryBinSize e) {errorsBinSize_.push_back(e);}
+  inline void set_version(double v) { version_ = v; }
+
+  // &&& Should we be able to read this from an iostream?  See PxCPEdbUploader...
+
+private:
+  DbVector errors_;
+  DbBinSizeVector errorsBinSize_;
+  double version_;
+
   COND_SERIALIZABLE;
-};
-	typedef std::vector<DbEntry> DbVector;
-
-	//! A struct to hold the binning information for (part, size, alpha, beta)
-	struct DbEntryBinSize {
-		int partBin_size;
-		int sizeBin_size;
-		int alphaBin_size;
-		int betaBin_size;
-		DbEntryBinSize() : partBin_size(NONSENSE_I), sizeBin_size(NONSENSE_I),
-				           alphaBin_size(NONSENSE_I), betaBin_size(NONSENSE_I) {}
-		~DbEntryBinSize() {}
-	
-  COND_SERIALIZABLE;
-};
-	typedef std::vector<DbEntryBinSize> DbBinSizeVector;
-
-	SiPixelCPEGenericErrorParm() : errors_(), errorsBinSize_() {}
-	virtual ~SiPixelCPEGenericErrorParm(){}
-
-	//!  Function to output the contents of the db object
-	friend std::ostream& operator<<(std::ostream& s, const SiPixelCPEGenericErrorParm& genericErrors);
-	
-	//!  Function to fill the db object given a filename
-	void fillCPEGenericErrorParm(double version, std::string file);
-
-	//!  Accessors for the vectors -- non-const version
-	inline DbVector & errors() { return errors_ ; }
-	inline DbBinSizeVector & errorsBin() { return errorsBinSize_ ; }
-	inline double & version() { return version_;}
-
-	//!  Accessors for the vectors -- const version
-	inline const DbVector & errors() const { return errors_ ; }
-	inline const DbBinSizeVector & errorsBinSize() const { return errorsBinSize_ ; }
-	inline const double & version() const { return version_;}
-
-	//!  Reserve some reasonable sizes for the vectors. 
-	inline void reserve() {
-	  errors_.reserve(1000);
-		errorsBinSize_.reserve(4);
-	}
-	//  &&& Should these sizes be computed on the fly from other 
-	//  &&& variables (which are currently not stored in this object,
-	//  &&& but maybe should be?)
-
-	//inline void push_back( DbEntry e) {errors_.push_back(e);}
-	//	inline void push_back_bin( DbEntryBinSize e) {errorsBinSize_.push_back(e);}
-	inline void set_version (double v) {version_ = v;}
-
-	// &&& Should we be able to read this from an iostream?  See PxCPEdbUploader...
-
- private:
-	DbVector errors_ ;
-	DbBinSizeVector errorsBinSize_;
-	double version_;
-
- COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelCalibConfiguration.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelCalibConfiguration.h
@@ -16,56 +16,51 @@
 #include <cstdint>
 #include "CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h"
 
-class SiPixelCalibConfiguration
-{
-  
- public :
-
-  SiPixelCalibConfiguration() {;}
+class SiPixelCalibConfiguration {
+public:
+  SiPixelCalibConfiguration() { ; }
   SiPixelCalibConfiguration(const pos::PixelCalibConfiguration &fancyConfig);
 
-  virtual ~SiPixelCalibConfiguration(){;}
+  virtual ~SiPixelCalibConfiguration() { ; }
 
- //-- Setter/Getter
-  
-  short  getNTriggers() const { return fNTriggers;}
-  void  setNTriggers(const  short & in) { fNTriggers = in; }
+  //-- Setter/Getter
 
-  std::vector<short> getRowPattern() const { return fRowPattern;}
-  void  setRowPattern(const std::vector<short> & in) { fRowPattern = in; }
+  short getNTriggers() const { return fNTriggers; }
+  void setNTriggers(const short &in) { fNTriggers = in; }
 
-  std::vector<short> getColumnPattern() const { return fColumnPattern;}
-  void  setColumnPattern(const std::vector<short> & in) { fColumnPattern = in; }
+  std::vector<short> getRowPattern() const { return fRowPattern; }
+  void setRowPattern(const std::vector<short> &in) { fRowPattern = in; }
 
-  void setCalibrationMode(const std::string & in) { fMode = in; }
-  std::string getCalibrationMode() const {return fMode;}
+  std::vector<short> getColumnPattern() const { return fColumnPattern; }
+  void setColumnPattern(const std::vector<short> &in) { fColumnPattern = in; }
 
-  const std::vector<short> getVCalValues() const { return fVCalValues;}
-  void  setVCalValues(const std::vector< short> & in) { fVCalValues = in; }
-  
+  void setCalibrationMode(const std::string &in) { fMode = in; }
+  std::string getCalibrationMode() const { return fMode; }
+
+  const std::vector<short> getVCalValues() const { return fVCalValues; }
+  void setVCalValues(const std::vector<short> &in) { fVCalValues = in; }
+
   // interface with calibration analyzers:
-  short vcalForEvent(const uint32_t & eventnumber) const;
-  short vcalIndexForEvent(const uint32_t & eventnumber) const;
-  std::vector<short> columnPatternForEvent(const uint32_t & eventnumber) const;
-  std::vector<short> rowPatternForEvent(const uint32_t & eventnumber) const;
-  uint32_t nextPatternChangeForEvent(const uint32_t & eventnumber) const;
-  uint32_t expectedTotalEvents () const;
-  uint32_t  patternSize() const {return fNTriggers*fVCalValues.size();}
-  uint32_t nPatterns() const {return nRowPatterns()*nColumnPatterns();}
-  uint32_t nColumnPatterns() const ;
-  uint32_t nRowPatterns() const ;
-  uint32_t nVCal() const { return fVCalValues.size();}
-    
- private :
+  short vcalForEvent(const uint32_t &eventnumber) const;
+  short vcalIndexForEvent(const uint32_t &eventnumber) const;
+  std::vector<short> columnPatternForEvent(const uint32_t &eventnumber) const;
+  std::vector<short> rowPatternForEvent(const uint32_t &eventnumber) const;
+  uint32_t nextPatternChangeForEvent(const uint32_t &eventnumber) const;
+  uint32_t expectedTotalEvents() const;
+  uint32_t patternSize() const { return fNTriggers * fVCalValues.size(); }
+  uint32_t nPatterns() const { return nRowPatterns() * nColumnPatterns(); }
+  uint32_t nColumnPatterns() const;
+  uint32_t nRowPatterns() const;
+  uint32_t nVCal() const { return fVCalValues.size(); }
 
-  short                     fNTriggers;//
-  std::vector<short>        fRowPattern;//
-  std::vector<short>        fColumnPattern;//
-  std::vector<short>        fVCalValues;//
-  std::string               fMode;
+private:
+  short fNTriggers;                   //
+  std::vector<short> fRowPattern;     //
+  std::vector<short> fColumnPattern;  //
+  std::vector<short> fVCalValues;     //
+  std::string fMode;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/SiPixelObjects/interface/SiPixelDbItem.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDbItem.h
@@ -5,8 +5,8 @@
 //! \class SiPixelPedestals
 //! \brief Event Setup object which holds DB information for all pixels.
 //!
-//! \description Event Setup object which holds DB information for all pixels. 
-//! DB info for a single pixel is held in SiPixelDbItem, which contains 
+//! \description Event Setup object which holds DB information for all pixels.
+//! DB info for a single pixel is held in SiPixelDbItem, which contains
 //! pedestal, noise, gain and status bits packed into an 32-bit wide unsigned
 //! int.  The bit allocation is the following:
 //! bits [31:24] - status   (0 if good, bits TBD set if not good)
@@ -19,30 +19,28 @@
 
 #include <boost/cstdint.hpp>
 
-class SiPixelDbItem 
-{
+class SiPixelDbItem {
   typedef uint32_t PackedPixDbType;
 
- public:
+public:
   SiPixelDbItem() : packedVal_(0) { set(2, 0, 1.0, 0); }  // TO DO: is noise==2 in shifted rep or not???
   ~SiPixelDbItem() {}
-  inline short  noise()     { return (packedVal_ >> packing_.noise_shift    ) & packing_.noise_mask   ; }
-  inline short  pedestal()  { return (packedVal_ >> packing_.pedestal_shift ) & packing_.pedestal_mask; }
-  inline float  gain()      { return (packedVal_ >> packing_.gain_shift     ) & packing_.gain_mask    ; }
-  inline char   status()    { return (packedVal_ >> packing_.status_shift   ) & packing_.status_mask  ; }
+  inline short noise() { return (packedVal_ >> packing_.noise_shift) & packing_.noise_mask; }
+  inline short pedestal() { return (packedVal_ >> packing_.pedestal_shift) & packing_.pedestal_mask; }
+  inline float gain() { return (packedVal_ >> packing_.gain_shift) & packing_.gain_mask; }
+  inline char status() { return (packedVal_ >> packing_.status_shift) & packing_.status_mask; }
   inline PackedPixDbType packedValue() { return packedVal_; }
 
-  inline void   setPackedVal( PackedPixDbType p ) { packedVal_ = p; }
+  inline void setPackedVal(PackedPixDbType p) { packedVal_ = p; }
 
   // The following setters are not inline since they are more complicated:
-  void   setNoise   (short n);
-  void   setPedestal(short p);
-  void   setGain    (float g);
-  void   setStatus  (char  s);
-  void   set( short noise, short pedestal, float gain, char status);
+  void setNoise(short n);
+  void setPedestal(short p);
+  void setGain(float g);
+  void setStatus(char s);
+  void set(short noise, short pedestal, float gain, char status);
 
-
- private:
+private:
   PackedPixDbType packedVal_;
 
   //! Pack the pixel information to use less memory
@@ -67,8 +65,7 @@ class SiPixelDbItem
   };
   static Packing packing_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelDetSummary.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDetSummary.h
@@ -25,20 +25,20 @@
 class SiPixelDetSummary {
 public:
   SiPixelDetSummary(int verbose = 0);
-  
+
   void add(const DetId &detid, const float &value);
   void add(const DetId &detid);
-  
+
   void print(std::stringstream &ss, const bool mean = true) const;
-  
-  std::map<int, int> getCounts() { return fCountMap;  }
-  
+
+  std::map<int, int> getCounts() { return fCountMap; }
+
 protected:
   std::map<int, double> fMeanMap;
   std::map<int, double> fRmsMap;
   std::map<int, int> fCountMap;
   bool fComputeMean;
-  int  fVerbose;
+  int fVerbose;
 };
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelDisabledModules.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDisabledModules.h
@@ -16,29 +16,25 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 class SiPixelDisabledModules {
-
- public:
+public:
   typedef DetId disabledModuleType;
   typedef std::vector<disabledModuleType> disabledModuleListType;
 
-  SiPixelDisabledModules() {;}
+  SiPixelDisabledModules() { ; }
 
   // constructor from a list of disabled modules
-  SiPixelDisabledModules(const disabledModuleListType& disabledModules) : theDisabledModules(disabledModules) {;}
+  SiPixelDisabledModules(const disabledModuleListType& disabledModules) : theDisabledModules(disabledModules) { ; }
 
-  virtual ~SiPixelDisabledModules() {;}
+  virtual ~SiPixelDisabledModules() { ; }
 
   // return the list of disabled modules/ROCs
-  disabledModuleListType getDisabledModuleList()
-    { return theDisabledModules; }
+  disabledModuleListType getDisabledModuleList() { return theDisabledModules; }
 
   // set the list of disabled modules (current list is lost)
-  void setDisabledModuleList(const disabledModuleListType& disabledModules)
-    { theDisabledModules = disabledModules; }
+  void setDisabledModuleList(const disabledModuleListType& disabledModules) { theDisabledModules = disabledModules; }
 
   // add a single module to the vector of disabled modules
-  void addDisabledModule(disabledModuleType module)
-  { theDisabledModules.push_back(module); }
+  void addDisabledModule(disabledModuleType module) { theDisabledModules.push_back(module); }
 
   // add a vector of modules to the vector of disabled modules
   void addDisabledModule(const disabledModuleListType& idVector);
@@ -51,13 +47,10 @@ class SiPixelDisabledModules {
   // return true if it is
   bool isModuleDisabled(disabledModuleType module);
 
- private:
+private:
   disabledModuleListType theDisabledModules;
 
-
- COND_SERIALIZABLE;
-}; // class SiPixelDisabledModules
-
-
+  COND_SERIALIZABLE;
+};  // class SiPixelDisabledModules
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h
@@ -3,48 +3,49 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include<vector>
-#include<map>
-#include<iostream>
-#include<boost/cstdint.hpp>
-
+#include <vector>
+#include <map>
+#include <iostream>
+#include <boost/cstdint.hpp>
 
 class SiPixelDynamicInefficiency {
-
- public:
- 
+public:
   SiPixelDynamicInefficiency();
   ~SiPixelDynamicInefficiency(){};
 
-  inline void putPixelGeomFactors (std::map<unsigned int,double>& PixelGeomFactors){m_PixelGeomFactors=PixelGeomFactors;} 
-  inline const std::map<unsigned int,double>&  getPixelGeomFactors () const {return m_PixelGeomFactors;}
+  inline void putPixelGeomFactors(std::map<unsigned int, double>& PixelGeomFactors) {
+    m_PixelGeomFactors = PixelGeomFactors;
+  }
+  inline const std::map<unsigned int, double>& getPixelGeomFactors() const { return m_PixelGeomFactors; }
 
-  inline void putColGeomFactors (std::map<unsigned int,double>& ColGeomFactors){m_ColGeomFactors=ColGeomFactors;} 
-  inline const std::map<unsigned int,double>&  getColGeomFactors () const {return m_ColGeomFactors;}
+  inline void putColGeomFactors(std::map<unsigned int, double>& ColGeomFactors) { m_ColGeomFactors = ColGeomFactors; }
+  inline const std::map<unsigned int, double>& getColGeomFactors() const { return m_ColGeomFactors; }
 
-  inline void putChipGeomFactors (std::map<unsigned int,double>& ChipGeomFactors){m_ChipGeomFactors=ChipGeomFactors;} 
-  inline const std::map<unsigned int,double>&  getChipGeomFactors () const {return m_ChipGeomFactors;}
+  inline void putChipGeomFactors(std::map<unsigned int, double>& ChipGeomFactors) {
+    m_ChipGeomFactors = ChipGeomFactors;
+  }
+  inline const std::map<unsigned int, double>& getChipGeomFactors() const { return m_ChipGeomFactors; }
 
-  inline void putPUFactors (std::map<unsigned int,std::vector<double> >& PUFactors){m_PUFactors=PUFactors;} 
-  inline const std::map<unsigned int,std::vector<double> >&  getPUFactors () const {return m_PUFactors;}
+  inline void putPUFactors(std::map<unsigned int, std::vector<double> >& PUFactors) { m_PUFactors = PUFactors; }
+  inline const std::map<unsigned int, std::vector<double> >& getPUFactors() const { return m_PUFactors; }
 
-  inline void puttheInstLumiScaleFactor_(double& InstLumiScaleFactor){theInstLumiScaleFactor_=InstLumiScaleFactor;}
-  inline const double gettheInstLumiScaleFactor_() const {return theInstLumiScaleFactor_;}
+  inline void puttheInstLumiScaleFactor_(double& InstLumiScaleFactor) { theInstLumiScaleFactor_ = InstLumiScaleFactor; }
+  inline const double gettheInstLumiScaleFactor_() const { return theInstLumiScaleFactor_; }
 
-  inline void putDetIdmasks(std::vector<uint32_t>& masks){v_DetIdmasks=masks;}
-  inline const std::vector<uint32_t> getDetIdmasks() const {return v_DetIdmasks;}
+  inline void putDetIdmasks(std::vector<uint32_t>& masks) { v_DetIdmasks = masks; }
+  inline const std::vector<uint32_t> getDetIdmasks() const { return v_DetIdmasks; }
 
-  bool   putPixelGeomFactor (const uint32_t&, double&);
-  double  getPixelGeomFactor (const uint32_t&) const;
+  bool putPixelGeomFactor(const uint32_t&, double&);
+  double getPixelGeomFactor(const uint32_t&) const;
 
-  bool   putColGeomFactor (const uint32_t&, double&);
-  double  getColGeomFactor (const uint32_t&) const;
+  bool putColGeomFactor(const uint32_t&, double&);
+  double getColGeomFactor(const uint32_t&) const;
 
-  bool   putChipGeomFactor (const uint32_t&, double&);
-  double  getChipGeomFactor (const uint32_t&) const;
+  bool putChipGeomFactor(const uint32_t&, double&);
+  double getChipGeomFactor(const uint32_t&) const;
 
-  bool putPUFactor (const uint32_t&, std::vector<double>&);
-  std::vector<double> getPUFactor (const uint32_t&) const;
+  bool putPUFactor(const uint32_t&, std::vector<double>&);
+  std::vector<double> getPUFactor(const uint32_t&) const;
 
   bool putDetIdmask(uint32_t&);
   uint32_t getDetIdmask(unsigned int&) const;
@@ -52,15 +53,15 @@ class SiPixelDynamicInefficiency {
   bool puttheInstLumiScaleFactor(double&);
   double gettheInstLumiScaleFactor() const;
 
- private:
-  std::map<unsigned int,double> m_PixelGeomFactors;
-  std::map<unsigned int,double> m_ColGeomFactors;
-  std::map<unsigned int,double> m_ChipGeomFactors;
-  std::map<unsigned int,std::vector<double> > m_PUFactors;
+private:
+  std::map<unsigned int, double> m_PixelGeomFactors;
+  std::map<unsigned int, double> m_ColGeomFactors;
+  std::map<unsigned int, double> m_ChipGeomFactors;
+  std::map<unsigned int, std::vector<double> > m_PUFactors;
   std::vector<uint32_t> v_DetIdmasks;
   double theInstLumiScaleFactor_;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h
@@ -1,50 +1,48 @@
-#ifndef CondFormats_SiPixelObjects_SiPixelFEDChannelContainer_h 
+#ifndef CondFormats_SiPixelObjects_SiPixelFEDChannelContainer_h
 #define CondFormats_SiPixelObjects_SiPixelFEDChannelContainer_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"   // N.B. a DataFormat is serialized here (need for dedicated serialization rules, see CondFormats/External/interface/PixelFEDChannel.h)
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"  // N.B. a DataFormat is serialized here (need for dedicated serialization rules, see CondFormats/External/interface/PixelFEDChannel.h)
 
 #include <map>
 #include <string>
 #include <vector>
 
-class SiPixelFEDChannelContainer{
+class SiPixelFEDChannelContainer {
 public:
-  typedef std::map<DetId,std::vector<PixelFEDChannel> > SiPixelFEDChannelCollection;
+  typedef std::map<DetId, std::vector<PixelFEDChannel> > SiPixelFEDChannelCollection;
   typedef std::unordered_map<std::string, SiPixelFEDChannelCollection> SiPixelBadFEDChannelsScenarioMap;
-  
-  SiPixelFEDChannelContainer(){}
-  SiPixelFEDChannelContainer( const SiPixelFEDChannelContainer& rhs ){ m_scenarioMap = rhs.getScenarioMap(); };
-  virtual ~SiPixelFEDChannelContainer(){}
+
+  SiPixelFEDChannelContainer() {}
+  SiPixelFEDChannelContainer(const SiPixelFEDChannelContainer &rhs) { m_scenarioMap = rhs.getScenarioMap(); };
+  virtual ~SiPixelFEDChannelContainer() {}
 
   void setScenario(const std::string &theScenarioId, const SiPixelFEDChannelCollection &theBadFEDChannels);
 
-  const SiPixelBadFEDChannelsScenarioMap& getScenarioMap () const  {return m_scenarioMap;}
+  const SiPixelBadFEDChannelsScenarioMap &getScenarioMap() const { return m_scenarioMap; }
 
   SiPixelFEDChannelCollection getSiPixelBadFedChannels(const std::string &ScenarioId) const;
-  const SiPixelFEDChannelCollection & getSiPixelBadFedChannels(const std::string &ScenarioId);
+  const SiPixelFEDChannelCollection &getSiPixelBadFedChannels(const std::string &ScenarioId);
 
-  const std::vector<PixelFEDChannel>& getSiPixelBadFedChannelsInDetId(const std::string &theScenarioId,DetId theDetId);
+  const std::vector<PixelFEDChannel> &getSiPixelBadFedChannelsInDetId(const std::string &theScenarioId, DetId theDetId);
 
   std::unique_ptr<PixelFEDChannelCollection> getDetSetBadPixelFedChannels(const std::string &ScenarioId) const;
-  
-  double size()const {return m_scenarioMap.size();}
+
+  double size() const { return m_scenarioMap.size(); }
   std::vector<std::string> getScenarioList() const;
 
   void printAll() const;
 
   //dumping values on output stream
-  void print(std::ostream & os) const;
+  void print(std::ostream &os) const;
 
 private:
-
   SiPixelBadFEDChannelsScenarioMap m_scenarioMap;
 
   COND_SERIALIZABLE;
-
 };
 
-std::ostream & operator<<( std::ostream &, SiPixelFEDChannelContainer FEDChannels);
+std::ostream &operator<<(std::ostream &, SiPixelFEDChannelContainer FEDChannels);
 
-#endif //CondFormats_SiPixelObjects_SiPixelFEDChannelContainer_h
+#endif  //CondFormats_SiPixelObjects_SiPixelFEDChannelContainer_h

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h
@@ -8,28 +8,22 @@
 #include <vector>
 
 class SiPixelFedCabling {
-
 public:
-
   virtual ~SiPixelFedCabling() {}
 
   virtual std::string version() const = 0;
 
-  virtual const sipixelobjects::PixelROC* findItem(
-      const sipixelobjects::CablingPathToDetUnit&) const = 0;
+  virtual const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit&) const = 0;
 
-  virtual std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(
-      uint32_t rawDetId) const = 0;
+  virtual std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const = 0;
 
-  virtual bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const =0;
+  virtual bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const = 0;
 
-  virtual std::unordered_map<uint32_t, unsigned int> det2fedMap() const =0; 
+  virtual std::unordered_map<uint32_t, unsigned int> det2fedMap() const = 0;
 
-  virtual std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const=0;
-
+  virtual std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const = 0;
 
   COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
@@ -8,56 +8,52 @@
 
 #include <string>
 #include <map>
-#include<memory>
+#include <memory>
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #define NO_DICT
 #endif
 
-
 class SiPixelFedCablingTree;
 
-
 class SiPixelFedCablingMap : public SiPixelFedCabling {
+public:
+  SiPixelFedCablingMap(const SiPixelFedCablingTree* cab);
 
-public: 
-
-  SiPixelFedCablingMap(const SiPixelFedCablingTree *cab);
-
-  SiPixelFedCablingMap(const std::string & version="") : theVersion(version) {}
+  SiPixelFedCablingMap(const std::string& version = "") : theVersion(version) {}
 
   void initializeRocs();
 
   ~SiPixelFedCablingMap() override {}
 
 #ifdef NO_DICT
-  std::unique_ptr<SiPixelFedCablingTree> cablingTree() const; 
+  std::unique_ptr<SiPixelFedCablingTree> cablingTree() const;
 #endif
 
   std::string version() const override { return theVersion; }
 
-  const sipixelobjects::PixelROC* findItem(
-      const sipixelobjects::CablingPathToDetUnit & path) const final;
+  const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit& path) const final;
 
   std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const final;
 
   bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const final;
 
   std::unordered_map<uint32_t, unsigned int> det2fedMap() const final;
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const final;
-
+  std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const final;
 
   std::vector<unsigned int> fedIds() const;
 
-  struct Key { unsigned int fed, link, roc; bool operator < (const Key & other) const; 
-  COND_SERIALIZABLE;
-};
+  struct Key {
+    unsigned int fed, link, roc;
+    bool operator<(const Key& other) const;
+    COND_SERIALIZABLE;
+  };
 
 private:
   std::string theVersion;
   typedef std::map<Key, sipixelobjects::PixelROC> Map;
-  Map theMap; 
+  Map theMap;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
@@ -8,12 +8,11 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 
-class SiPixelFedCablingTree final : public  SiPixelFedCabling {
-
+class SiPixelFedCablingTree final : public SiPixelFedCabling {
 public:
   typedef sipixelobjects::PixelFEDCabling PixelFEDCabling;
 
-  SiPixelFedCablingTree(const std::string & version="") : theVersion(version) {}
+  SiPixelFedCablingTree(const std::string& version = "") : theVersion(version) {}
 
   ~SiPixelFedCablingTree() override {}
 
@@ -21,9 +20,9 @@ public:
   void addFed(const PixelFEDCabling& f);
 
   /// get fed identified by its id
-  const PixelFEDCabling * fed(unsigned int idFed) const;
+  const PixelFEDCabling* fed(unsigned int idFed) const;
 
-  std::vector<const PixelFEDCabling *> fedList() const;
+  std::vector<const PixelFEDCabling*> fedList() const;
 
   ///map version
   std::string version() const override { return theVersion; }
@@ -35,20 +34,18 @@ public:
   std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const final;
   bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const final;
 
-  const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit & path) const final;  
+  const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit& path) const final;
 
-  const sipixelobjects::PixelROC* findItemInFed(const sipixelobjects::CablingPathToDetUnit & path, 
-						const PixelFEDCabling * aFed) const;  
-
+  const sipixelobjects::PixelROC* findItemInFed(const sipixelobjects::CablingPathToDetUnit& path,
+                                                const PixelFEDCabling* aFed) const;
 
   std::unordered_map<uint32_t, unsigned int> det2fedMap() const final;
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const final;
-
+  std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const final;
 
   int checkNumbering() const;
 
 private:
-  std::string theVersion; 
+  std::string theVersion;
   std::unordered_map<int, PixelFEDCabling> theFedCablings;
 };
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
@@ -1,8 +1,6 @@
 #ifndef SiPixelObjects_SiPixelFrameConverter_H
 #define SiPixelObjects_SiPixelFrameConverter_H
 
-
-
 #include "CondFormats/SiPixelObjects/interface/ElectronicIndex.h"
 #include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
@@ -16,44 +14,39 @@
 
 class SiPixelFrameConverter {
 public:
-
   typedef sipixelobjects::PixelFEDCabling PixelFEDCabling;
 
   //  using PixelFEDCabling = sipixelobjects::PixelFEDCabling;
 
-  SiPixelFrameConverter(const SiPixelFedCabling* map, int fedId); 
+  SiPixelFrameConverter(const SiPixelFedCabling* map, int fedId);
 
   bool hasDetUnit(uint32_t radId) const;
 
-  sipixelobjects::PixelROC const * toRoc(int link, int roc) const;
-  
-  
-  int toDetector(const sipixelobjects::ElectronicIndex & cabling, 
-		 sipixelobjects::DetectorIndex & detector) const {
+  sipixelobjects::PixelROC const* toRoc(int link, int roc) const;
+
+  int toDetector(const sipixelobjects::ElectronicIndex& cabling, sipixelobjects::DetectorIndex& detector) const {
     using namespace sipixelobjects;
     auto roc = toRoc(cabling.link, cabling.roc);
-    if (!roc) return 2;
-    LocalPixel::DcolPxid local = { cabling.dcol, cabling.pxid };
-    if (!local.valid()) return 3;
-    
-    GlobalPixel global = roc->toGlobal( LocalPixel(local) );
+    if (!roc)
+      return 2;
+    LocalPixel::DcolPxid local = {cabling.dcol, cabling.pxid};
+    if (!local.valid())
+      return 3;
+
+    GlobalPixel global = roc->toGlobal(LocalPixel(local));
     detector.rawId = roc->rawId();
-    detector.row   = global.row;
-    detector.col   = global.col;
+    detector.row = global.row;
+    detector.col = global.col;
 
     return 0;
-
   }
 
-
-  int toCabling(       sipixelobjects::ElectronicIndex & cabling, 
-                 const sipixelobjects::DetectorIndex & detector) const;
+  int toCabling(sipixelobjects::ElectronicIndex& cabling, const sipixelobjects::DetectorIndex& detector) const;
 
 private:
   int theFedId;
   const SiPixelFedCabling* theMap;
-  SiPixelFedCablingTree const * theTree;
-  const PixelFEDCabling * theFed;
-  
+  SiPixelFedCablingTree const* theTree;
+  const PixelFEDCabling* theFed;
 };
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
@@ -17,17 +17,15 @@ class SiPixelFedCablingMap;
 
 class SiPixelFrameReverter {
 public:
-
   SiPixelFrameReverter(const edm::EventSetup&, const SiPixelFedCabling* map);
 
   void buildStructure(edm::EventSetup const&);
 
   // Function to test if detId exists
-  bool hasDetUnit(uint32_t detId) const { return (DetToFedMap.find(detId)!=DetToFedMap.end()); }
+  bool hasDetUnit(uint32_t detId) const { return (DetToFedMap.find(detId) != DetToFedMap.end()); }
 
   // Function to convert offline addressing to online
-  int toCabling( sipixelobjects::ElectronicIndex & cabling, 
-                 const sipixelobjects::DetectorIndex & detector) const;
+  int toCabling(sipixelobjects::ElectronicIndex& cabling, const sipixelobjects::DetectorIndex& detector) const;
 
   // Function to find FedId given detId
   int findFedId(uint32_t detId);
@@ -48,12 +46,8 @@ public:
   sipixelobjects::LocalPixel findPixelInRoc(uint32_t detId, sipixelobjects::GlobalPixel global);
 
 private:
+  const SiPixelFedCabling* map_;
 
-  const SiPixelFedCabling * map_;
-
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > DetToFedMap;
-
+  std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > DetToFedMap;
 };
 #endif
-
-

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelObjects
 // Class:      SiPixelGainCalibration
-// 
+//
 /**\class SiPixelGainCalibration SiPixelGainCalibration.h CondFormats/SiPixelObjects/src/SiPixelGainCalibration.cc
 
  Description: Gain calibration object for the Silicon Pixel detector.  Store gain/pedestal information at pixel granularity
@@ -21,50 +21,48 @@
 //
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include<vector>
-#include<map>
-#include<iostream>
-#include<boost/cstdint.hpp>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <boost/cstdint.hpp>
 
 class SiPixelGainCalibration {
-
- public:
-
-  struct DecodingStructure{  
-    unsigned int gain :8;
-    unsigned int ped  :8;
+public:
+  struct DecodingStructure {
+    unsigned int gain : 8;
+    unsigned int ped : 8;
     //    unsigned int ped :10;
   };
-  
-  struct DetRegistry{
+
+  struct DetRegistry {
     uint32_t detid;
     uint32_t ibegin;
     uint32_t iend;
     int ncols;
-  
-  COND_SERIALIZABLE;
-};
-  
-  class StrictWeakOrdering{
-  public:
-    bool operator() (const DetRegistry& p,const uint32_t& i) const {return p.detid < i;}
+
+    COND_SERIALIZABLE;
   };
-  
-  typedef std::vector<char>::const_iterator                ContainerIterator;  
-  typedef std::pair<ContainerIterator, ContainerIterator>  Range;      
-  typedef std::vector<DetRegistry>                         Registry;
-  typedef Registry::const_iterator                         RegistryIterator;
-  
+
+  class StrictWeakOrdering {
+  public:
+    bool operator()(const DetRegistry& p, const uint32_t& i) const { return p.detid < i; }
+  };
+
+  typedef std::vector<char>::const_iterator ContainerIterator;
+  typedef std::pair<ContainerIterator, ContainerIterator> Range;
+  typedef std::vector<DetRegistry> Registry;
+  typedef Registry::const_iterator RegistryIterator;
+
   // Constructors
   SiPixelGainCalibration();
   SiPixelGainCalibration(float minPed, float maxPed, float minGain, float maxGain);
-  ~SiPixelGainCalibration(){}
+  ~SiPixelGainCalibration() {}
 
-  void initialize(){}
+  void initialize() {}
 
-  bool  put(const uint32_t& detID,Range input, const int& nCols);
+  bool put(const uint32_t& detID, Range input, const int& nCols);
   const Range getRange(const uint32_t& detID) const;
-  void  getDetIds(std::vector<uint32_t>& DetIds_) const;
+  void getDetIds(std::vector<uint32_t>& DetIds_) const;
   const int getNCols(const uint32_t& detID) const;
   const std::pair<const Range, const int> getRangeAndNCols(const uint32_t& detID) const;
 
@@ -75,32 +73,32 @@ class SiPixelGainCalibration {
   double getPedHigh() const { return maxPed_; }
 
   // Set and get public methods
-  void  setData(float ped, float gain, std::vector<char>& vped, bool thisPixelIsDead = false, bool thisPixelIsNoisy = false);
+  void setData(
+      float ped, float gain, std::vector<char>& vped, bool thisPixelIsDead = false, bool thisPixelIsNoisy = false);
 
-  void  setDeadPixel(std::vector<char>& vped)  { setData(0, 0, /*dummy values, not used*/ vped,  true , false ); }
-  void  setNoisyPixel(std::vector<char>& vped) { setData(0, 0, /*dummy values, not used*/ vped,  false , true ); }
+  void setDeadPixel(std::vector<char>& vped) { setData(0, 0, /*dummy values, not used*/ vped, true, false); }
+  void setNoisyPixel(std::vector<char>& vped) { setData(0, 0, /*dummy values, not used*/ vped, false, true); }
 
-  float getPed   (const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const;
-  float getGain  (const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const;
+  float getPed(const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const;
+  float getGain(const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const;
 
-  private:
+private:
+  float encodeGain(const float& gain);
+  float encodePed(const float& ped);
+  float decodeGain(unsigned int gain) const;
+  float decodePed(unsigned int ped) const;
 
-  float   encodeGain(const float& gain);
-  float   encodePed (const float& ped);
-  float   decodeGain(unsigned int gain) const;
-  float   decodePed (unsigned int ped) const;
-
-  std::vector<char> v_pedestals; //@@@ blob streaming doesn't work with uint16_t and with classes
+  std::vector<char> v_pedestals;  //@@@ blob streaming doesn't work with uint16_t and with classes
   std::vector<DetRegistry> indexes;
-  float  minPed_, maxPed_, minGain_, maxGain_;
+  float minPed_, maxPed_, minGain_, maxGain_;
 
-  unsigned int numberOfRowsToAverageOver_;   //THIS WILL BE HARDCODED TO 1 (no averaging) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING! 
+  unsigned int
+      numberOfRowsToAverageOver_;  //THIS WILL BE HARDCODED TO 1 (no averaging) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
   unsigned int nBinsToUseForEncoding_;
   unsigned int deadFlag_;
   unsigned int noisyFlag_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
-    
+
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelObjects
 // Class:      SiPixelGainCalibrationOffline
-// 
+//
 /**\class SiPixelGainCalibrationOffline SiPixelGainCalibrationOffline.h CondFormats/SiPixelObjects/src/SiPixelGainCalibrationOffline.cc
 
  Description: Gain calibration object for the Silicon Pixel detector.  Stores pedestal at pixel granularity, gain at column granularity.
@@ -21,55 +21,59 @@
 //
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include<vector>
-#include<map>
-#include<iostream>
-#include<boost/cstdint.hpp>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <boost/cstdint.hpp>
 
 class SiPixelGainCalibrationOffline {
-
- public:
-
-  struct DecodingStructure{  
-    unsigned int datum :8;
+public:
+  struct DecodingStructure {
+    unsigned int datum : 8;
   };
-  
-  struct DetRegistry{
+
+  struct DetRegistry {
     uint32_t detid;
     uint32_t ibegin;
     uint32_t iend;
     int ncols;
-  
-  COND_SERIALIZABLE;
-};
-  
-  class StrictWeakOrdering{
-  public:
-    bool operator() (const DetRegistry& p,const uint32_t& i) const {return p.detid < i;}
+
+    COND_SERIALIZABLE;
   };
-  
-  typedef std::vector<char>::const_iterator                ContainerIterator;  
-  typedef std::pair<ContainerIterator, ContainerIterator>  Range;      
-  typedef std::vector<DetRegistry>                         Registry;
-  typedef Registry::const_iterator                         RegistryIterator;
-  
+
+  class StrictWeakOrdering {
+  public:
+    bool operator()(const DetRegistry& p, const uint32_t& i) const { return p.detid < i; }
+  };
+
+  typedef std::vector<char>::const_iterator ContainerIterator;
+  typedef std::pair<ContainerIterator, ContainerIterator> Range;
+  typedef std::vector<DetRegistry> Registry;
+  typedef Registry::const_iterator RegistryIterator;
+
   // Constructors
   SiPixelGainCalibrationOffline();
   SiPixelGainCalibrationOffline(float minPed, float maxPed, float minGain, float maxGain);
-  ~SiPixelGainCalibrationOffline(){}
+  ~SiPixelGainCalibrationOffline() {}
 
-  void initialize(){}
+  void initialize() {}
 
-
-  bool  put(const uint32_t& detID,Range input, const int& nCols);
+  bool put(const uint32_t& detID, Range input, const int& nCols);
   const Range getRange(const uint32_t& detID) const;
-  void  getDetIds(std::vector<uint32_t>& DetIds_) const;
+  void getDetIds(std::vector<uint32_t>& DetIds_) const;
   const int getNCols(const uint32_t& detID) const;
   const std::pair<const Range, const int> getRangeAndNCols(const uint32_t& detID) const;
 
   // Set and get public methods
-  void  setDataGain     ( float gain, const int& nRows, std::vector<char>& vped , bool thisColumnIsDead = false , bool thisColumnIsNoisy = false);
-  void  setDataPedestal ( float pedestal,               std::vector<char>& vped , bool thisPixelIsDead  = false , bool thisPixelIsNoisy  = false);
+  void setDataGain(float gain,
+                   const int& nRows,
+                   std::vector<char>& vped,
+                   bool thisColumnIsDead = false,
+                   bool thisColumnIsNoisy = false);
+  void setDataPedestal(float pedestal,
+                       std::vector<char>& vped,
+                       bool thisPixelIsDead = false,
+                       bool thisPixelIsNoisy = false);
 
   unsigned int getNumberOfRowsToAverageOver() const { return numberOfRowsToAverageOver_; }
   double getGainLow() const { return minGain_; }
@@ -78,36 +82,43 @@ class SiPixelGainCalibrationOffline {
   double getPedHigh() const { return maxPed_; }
 
   // Set dead pixels
-  void  setDeadPixel(std::vector<char>& vped)                    { setDataPedestal(0 /*dummy value, not used*/,    vped,  true ); }
-  void  setDeadColumn(const int& nRows, std::vector<char>& vped) { setDataGain(0 /*dummy value, not used*/, nRows, vped,  true ); }
+  void setDeadPixel(std::vector<char>& vped) { setDataPedestal(0 /*dummy value, not used*/, vped, true); }
+  void setDeadColumn(const int& nRows, std::vector<char>& vped) {
+    setDataGain(0 /*dummy value, not used*/, nRows, vped, true);
+  }
 
   // Set noisy pixels
-  void  setNoisyPixel(std::vector<char>& vped)                    { setDataPedestal(0 /*dummy value, not used*/,    vped,  false, true ); }
-  void  setNoisyColumn(const int& nRows, std::vector<char>& vped) { setDataGain(0 /*dummy value, not used*/, nRows, vped,  false, true ); }
+  void setNoisyPixel(std::vector<char>& vped) { setDataPedestal(0 /*dummy value, not used*/, vped, false, true); }
+  void setNoisyColumn(const int& nRows, std::vector<char>& vped) {
+    setDataGain(0 /*dummy value, not used*/, nRows, vped, false, true);
+  }
 
   // these methods SHOULD NEVER BE ACESSED BY THE USER - use the services in CondTools/SiPixel!!!!
-  float getPed   (const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const;
-  float getGain  (const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn) const;
+  float getPed(const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const;
+  float getGain(const int& col,
+                const int& row,
+                const Range& range,
+                const int& nCols,
+                bool& isDeadColumn,
+                bool& isNoisyColumn) const;
 
+private:
+  float encodeGain(const float& gain);
+  float encodePed(const float& ped);
+  float decodeGain(unsigned int gain) const;
+  float decodePed(unsigned int ped) const;
 
-  private:
-
-  float   encodeGain(const float& gain);
-  float   encodePed (const float& ped);
-  float   decodeGain(unsigned int gain) const;
-  float   decodePed (unsigned int ped) const;
-
-  std::vector<char> v_pedestals; //@@@ blob streaming doesn't work with uint16_t and with classes
+  std::vector<char> v_pedestals;  //@@@ blob streaming doesn't work with uint16_t and with classes
   std::vector<DetRegistry> indexes;
-  float  minPed_, maxPed_, minGain_, maxGain_;
+  float minPed_, maxPed_, minGain_, maxGain_;
 
-  unsigned int numberOfRowsToAverageOver_;   //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING! 
+  unsigned int
+      numberOfRowsToAverageOver_;  //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING!
   unsigned int nBinsToUseForEncoding_;
   unsigned int deadFlag_;
   unsigned int noisyFlag_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
-    
+
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h
@@ -15,102 +15,96 @@
 
 class SiPixelGenErrorDBObject {
 public:
-	SiPixelGenErrorDBObject():index_(0),maxIndex_(0),numOfTempl_(1),version_(-99.9),isInvalid_(false),sVector_(0) {
-		sVector_.reserve(1000000);
-	}
-	virtual ~SiPixelGenErrorDBObject(){}
-	
-	//- Allows the dbobject to be read out like cout
-	friend std::ostream& operator<<(std::ostream& s, const SiPixelGenErrorDBObject& dbobject);
+  SiPixelGenErrorDBObject() : index_(0), maxIndex_(0), numOfTempl_(1), version_(-99.9), isInvalid_(false), sVector_(0) {
+    sVector_.reserve(1000000);
+  }
+  virtual ~SiPixelGenErrorDBObject() {}
 
-	//- Fills integer from dbobject
-	SiPixelGenErrorDBObject& operator>>( int& i)
-		{
-			isInvalid_ = false;
-			if(index_<=maxIndex_) {
-				i = (int) (*this).sVector_[index_];
-				index_++;
-			}
-			else
-				(*this).setInvalid();
-			return *this;
-		}
-	//- Fills float from dbobject
-	SiPixelGenErrorDBObject& operator>>( float& f)
-		{
-			isInvalid_ = false;
-			if(index_<=maxIndex_) {
-				f = (*this).sVector_[index_];
-				index_++;
-			}
-			else
-				(*this).setInvalid();
-			return *this;
-		}
+  //- Allows the dbobject to be read out like cout
+  friend std::ostream& operator<<(std::ostream& s, const SiPixelGenErrorDBObject& dbobject);
 
-	//- Functions to monitor integrity of dbobject
-	void setVersion(float version) {version_ = version;}
-	void setInvalid() {isInvalid_ = true;}
-	bool fail() {return isInvalid_;}
+  //- Fills integer from dbobject
+  SiPixelGenErrorDBObject& operator>>(int& i) {
+    isInvalid_ = false;
+    if (index_ <= maxIndex_) {
+      i = (int)(*this).sVector_[index_];
+      index_++;
+    } else
+      (*this).setInvalid();
+    return *this;
+  }
+  //- Fills float from dbobject
+  SiPixelGenErrorDBObject& operator>>(float& f) {
+    isInvalid_ = false;
+    if (index_ <= maxIndex_) {
+      f = (*this).sVector_[index_];
+      index_++;
+    } else
+      (*this).setInvalid();
+    return *this;
+  }
 
-	//- Setter functions
-	void push_back(float entry) {sVector_.push_back(entry);}
-	void setIndex(int index) {index_ = index;}
-	void setMaxIndex(int maxIndex) {maxIndex_ = maxIndex;}
-	void setNumOfTempl(int numOfTempl) {numOfTempl_ = numOfTempl;}
-	
-	//- Accessor functions
-	int index() const {return index_;}
-	int maxIndex() const {return maxIndex_;}
-	int numOfTempl() const {return numOfTempl_;}
-	float version() const {return version_;}
-	std::vector<float> sVector() const {return sVector_;}
+  //- Functions to monitor integrity of dbobject
+  void setVersion(float version) { version_ = version; }
+  void setInvalid() { isInvalid_ = true; }
+  bool fail() { return isInvalid_; }
 
-	//- Able to set the index for GenError header 
-	void incrementIndex(int i) {index_+=i;}
+  //- Setter functions
+  void push_back(float entry) { sVector_.push_back(entry); }
+  void setIndex(int index) { index_ = index; }
+  void setMaxIndex(int maxIndex) { maxIndex_ = maxIndex; }
+  void setNumOfTempl(int numOfTempl) { numOfTempl_ = numOfTempl; }
 
-	//- Allows storage of header (type = char[80]) in dbobject
-	union char2float
-	{
-		char  c[4];
-		float f;
-	};
+  //- Accessor functions
+  int index() const { return index_; }
+  int maxIndex() const { return maxIndex_; }
+  int numOfTempl() const { return numOfTempl_; }
+  float version() const { return version_; }
+  std::vector<float> sVector() const { return sVector_; }
 
-	//- To be used to select GenError calibration based on detid
-	void putGenErrorIDs(std::map<unsigned int,short>& t_ID) {templ_ID = t_ID;}
-	const std::map<unsigned int,short>& getGenErrorIDs () const {return templ_ID;}
+  //- Able to set the index for GenError header
+  void incrementIndex(int i) { index_ += i; }
 
-	bool putGenErrorID(const uint32_t& detid, short& value)
-		{
-			std::map<unsigned int,short>::const_iterator id=templ_ID.find(detid);
-			if(id!=templ_ID.end()){
-				edm::LogError("SiPixelGenErrorDBObject") << "GenError ID for DetID " << detid
-																								 << " is already stored. Skipping this put" << std::endl;
-				return false;
-			}
-			else templ_ID[detid] = value;
-			return true;
-		}
+  //- Allows storage of header (type = char[80]) in dbobject
+  union char2float {
+    char c[4];
+    float f;
+  };
 
-	short getGenErrorID(const uint32_t& detid) const
-		{
-			std::map<unsigned int,short>::const_iterator id=templ_ID.find(detid);
-			if(id!=templ_ID.end()) return id->second;
-			else edm::LogError("SiPixelGenErrorDBObject") << "GenError ID for DetID " << detid
-																										<< " is not stored" << std::endl;
-			return 0;
-		}
-	
+  //- To be used to select GenError calibration based on detid
+  void putGenErrorIDs(std::map<unsigned int, short>& t_ID) { templ_ID = t_ID; }
+  const std::map<unsigned int, short>& getGenErrorIDs() const { return templ_ID; }
+
+  bool putGenErrorID(const uint32_t& detid, short& value) {
+    std::map<unsigned int, short>::const_iterator id = templ_ID.find(detid);
+    if (id != templ_ID.end()) {
+      edm::LogError("SiPixelGenErrorDBObject")
+          << "GenError ID for DetID " << detid << " is already stored. Skipping this put" << std::endl;
+      return false;
+    } else
+      templ_ID[detid] = value;
+    return true;
+  }
+
+  short getGenErrorID(const uint32_t& detid) const {
+    std::map<unsigned int, short>::const_iterator id = templ_ID.find(detid);
+    if (id != templ_ID.end())
+      return id->second;
+    else
+      edm::LogError("SiPixelGenErrorDBObject") << "GenError ID for DetID " << detid << " is not stored" << std::endl;
+    return 0;
+  }
+
 private:
-	int index_;
-	int maxIndex_;
-	int numOfTempl_;
-	float version_;
-	bool isInvalid_;
-	std::vector<float> sVector_;
-	std::map<unsigned int,short> templ_ID;
+  int index_;
+  int maxIndex_;
+  int numOfTempl_;
+  float version_;
+  bool isInvalid_;
+  std::vector<float> sVector_;
+  std::map<unsigned int, short> templ_ID;
 
   COND_SERIALIZABLE;
 
-};//end SiPixelGenErrorDBObject
+};  //end SiPixelGenErrorDBObject
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h
@@ -3,30 +3,26 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include<vector>
-#include<map>
-#include<iostream>
-#include<boost/cstdint.hpp>
-
+#include <vector>
+#include <map>
+#include <iostream>
+#include <boost/cstdint.hpp>
 
 class SiPixelLorentzAngle {
-
- public:
- 
+public:
   SiPixelLorentzAngle(){};
   ~SiPixelLorentzAngle(){};
 
-  inline void putLorentsAngles(std::map<unsigned int,float>& LA){m_LA=LA;}   
-  inline const std::map<unsigned int,float>&  getLorentzAngles () const {return m_LA;}
+  inline void putLorentsAngles(std::map<unsigned int, float>& LA) { m_LA = LA; }
+  inline const std::map<unsigned int, float>& getLorentzAngles() const { return m_LA; }
 
-  bool   putLorentzAngle(const uint32_t&, float&);
-  float  getLorentzAngle (const uint32_t&) const;
+  bool putLorentzAngle(const uint32_t&, float&);
+  float getLorentzAngle(const uint32_t&) const;
 
+private:
+  std::map<unsigned int, float> m_LA;
 
- private:
-  std::map<unsigned int,float> m_LA; 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelPedestals.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelPedestals.h
@@ -5,7 +5,7 @@
 //! \class SiPixelPedestals
 //! \brief Event Setup object which holds DB information for all pixels.
 //!
-//! \description Event Setup object which holds DB information for all pixels. 
+//! \description Event Setup object which holds DB information for all pixels.
 //! DB info for a single pixel is held in SiPixelDbItem, which is a bit-packed
 //! 32-bit word.
 //-----------------------------------------------------------------------------
@@ -18,8 +18,7 @@
 #include <map>
 
 class SiPixelPedestals {
- public:
-
+public:
   //! Constructor, destructor
   SiPixelPedestals();
   ~SiPixelPedestals();
@@ -28,13 +27,13 @@ class SiPixelPedestals {
   typedef std::vector<SiPixelDbItem>::const_iterator SiPixelPedestalsVectorIterator;
   //  SiPixelPedestalsVector  v_pedestals;
 
-  typedef std::map<unsigned int, SiPixelPedestalsVector>                 SiPixelPedestalsMap;
+  typedef std::map<unsigned int, SiPixelPedestalsVector> SiPixelPedestalsMap;
   typedef std::map<unsigned int, SiPixelPedestalsVector>::const_iterator SiPixelPedestalsMapIterator;
 
   // TO DO: shouldn't the map be private???
 
   std::map<int, SiPixelPedestalsVector> m_pedestals;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelPerformanceSummary.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelPerformanceSummary.h
@@ -1,72 +1,69 @@
 #ifndef SiPixelPerformanceSummary_h
 #define SiPixelPerformanceSummary_h
 
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include<vector>
-#include<map>
-#include<iostream>
-#include<boost/cstdint.hpp>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <boost/cstdint.hpp>
 
-
-#define kDetSummarySize 60 // float numbers kept in DetSummary.performanceValues
-#define kDefaultValue -99.9 
-
+#define kDetSummarySize 60  // float numbers kept in DetSummary.performanceValues
+#define kDefaultValue -99.9
 
 class SiPixelPerformanceSummary {
 public:
-  struct DetSummary { 
+  struct DetSummary {
     uint32_t detId_;
     std::vector<float> performanceValues_;
-  
-  COND_SERIALIZABLE;
-}; 
-  
-  class StrictWeakOrdering { // sort detSummaries by detId
+
+    COND_SERIALIZABLE;
+  };
+
+  class StrictWeakOrdering {  // sort detSummaries by detId
   public:
-    bool operator() (const DetSummary& detSumm, const uint32_t& otherDetId) const { 
-      return (detSumm.detId_ < otherDetId); 
+    bool operator()(const DetSummary& detSumm, const uint32_t& otherDetId) const {
+      return (detSumm.detId_ < otherDetId);
     };
   };
-  
+
 public:
   SiPixelPerformanceSummary(const SiPixelPerformanceSummary&);
   SiPixelPerformanceSummary();
- ~SiPixelPerformanceSummary();
-  
+  ~SiPixelPerformanceSummary();
+
   void clear();
 
   unsigned int size() { return allDetSummaries_.size(); }
 
-                void setTimeStamp(unsigned long long timeStamp) { timeStamp_ = timeStamp; }
+  void setTimeStamp(unsigned long long timeStamp) { timeStamp_ = timeStamp; }
   unsigned long long getTimeStamp() const { return timeStamp_; }
-  
-          void setRunNumber(unsigned int runNumber) { runNumber_ = runNumber; }
+
+  void setRunNumber(unsigned int runNumber) { runNumber_ = runNumber; }
   unsigned int getRunNumber() const { return runNumber_; }
-  
-          void setNumberOfEvents(unsigned int numberOfEvents) { numberOfEvents_ = numberOfEvents; }
+
+  void setNumberOfEvents(unsigned int numberOfEvents) { numberOfEvents_ = numberOfEvents; }
   unsigned int getNumberOfEvents() const { return numberOfEvents_; }
-  
-                void setLuminosityBlock(unsigned int lumBlock) { luminosityBlock_ = lumBlock; }
+
+  void setLuminosityBlock(unsigned int lumBlock) { luminosityBlock_ = lumBlock; }
   unsigned int getLuminosityBlock() const { return luminosityBlock_; };
-    
-  void print() const; 
-  void print(const uint32_t detId) const; 
-  void printAll() const;  
-  
+
+  void print() const;
+  void print(const uint32_t detId) const;
+  void printAll() const;
+
   std::vector<uint32_t> getAllDetIds() const;
   std::vector<DetSummary> getAllDetSummaries() const { return allDetSummaries_; }
   std::vector<float> getDetSummary(uint32_t detId) const;
 
-  // RawData 
+  // RawData
   bool setRawDataErrorType(uint32_t detId, int bin, float nErrors);
   // Digi
   bool setNumberOfDigis(uint32_t detId, float mean, float rms, float emPtn);
   bool setADC(uint32_t detId, float mean, float rms, float emPtn);
   // Cluster
   bool setNumberOfClusters(uint32_t detId, float mean, float rms, float emPtn);
-  bool setClusterCharge(uint32_t detId, float mean, float rms, float emPtn); 
+  bool setClusterCharge(uint32_t detId, float mean, float rms, float emPtn);
   bool setClusterSize(uint32_t detId, float mean, float rms, float emPtn);
   bool setClusterSizeX(uint32_t detId, float mean, float rms, float emPtn);
   bool setClusterSizeY(uint32_t detId, float mean, float rms, float emPtn);
@@ -74,37 +71,36 @@ public:
   bool setNumberOfRecHits(uint32_t detId, float mean, float rms, float emPtn);
   // TrackResidual
   bool setResidualX(uint32_t detId, float mean, float rms, float emPtn);
-  bool setResidualY(uint32_t detId, float mean, float rms, float emPtn);  
+  bool setResidualY(uint32_t detId, float mean, float rms, float emPtn);
   //
-  bool setNumberOfNoisCells(uint32_t detId, float nNpixCells); // N=4,1..
-  bool setNumberOfDeadCells(uint32_t detId, float nNpixCells); // N=4,1..
-  bool setNumberOfPixelHitsInTrackFit(uint32_t detId, float nPixelHits); 
+  bool setNumberOfNoisCells(uint32_t detId, float nNpixCells);  // N=4,1..
+  bool setNumberOfDeadCells(uint32_t detId, float nNpixCells);  // N=4,1..
+  bool setNumberOfPixelHitsInTrackFit(uint32_t detId, float nPixelHits);
   // Track
-  bool setFractionOfTracks(uint32_t detId, float mean, float rms); 
-  bool setNumberOfOnTrackClusters(uint32_t detId, float nClusters); 
-  bool setNumberOfOffTrackClusters(uint32_t detId, float nClusters); 
-  bool setClusterChargeOnTrack(uint32_t detId, float mean, float rms); 
-  bool setClusterChargeOffTrack(uint32_t detId, float mean, float rms);  
-  bool setClusterSizeOnTrack(uint32_t detId, float mean, float rms); 
-  bool setClusterSizeOffTrack(uint32_t detId, float mean, float rms);  
+  bool setFractionOfTracks(uint32_t detId, float mean, float rms);
+  bool setNumberOfOnTrackClusters(uint32_t detId, float nClusters);
+  bool setNumberOfOffTrackClusters(uint32_t detId, float nClusters);
+  bool setClusterChargeOnTrack(uint32_t detId, float mean, float rms);
+  bool setClusterChargeOffTrack(uint32_t detId, float mean, float rms);
+  bool setClusterSizeOnTrack(uint32_t detId, float mean, float rms);
+  bool setClusterSizeOffTrack(uint32_t detId, float mean, float rms);
 
 private:
-  std::pair<bool, std::vector<DetSummary>::iterator> initDet(const uint32_t detId); 
-  std::pair<bool, std::vector<DetSummary>::iterator>  setDet(const uint32_t detId, 
-                                                             const std::vector<float>& performanceValues); 
-   bool setValue(uint32_t detId, int index, float performanceValue);
+  std::pair<bool, std::vector<DetSummary>::iterator> initDet(const uint32_t detId);
+  std::pair<bool, std::vector<DetSummary>::iterator> setDet(const uint32_t detId,
+                                                            const std::vector<float>& performanceValues);
+  bool setValue(uint32_t detId, int index, float performanceValue);
   float getValue(uint32_t detId, int index);
 
-private: 
-  unsigned long long timeStamp_;  
+private:
+  unsigned long long timeStamp_;
   unsigned int runNumber_;
   unsigned int luminosityBlock_;
   unsigned int numberOfEvents_;
-  
+
   std::vector<DetSummary> allDetSummaries_;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelQuality.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelQuality.h
@@ -29,81 +29,74 @@ namespace edm {
 class TrackerGeometry;
 
 class SiPixelQuality {
-
- public:
-  struct disabledModuleType { 
-    uint32_t DetID;  
-    int      errorType;
+public:
+  struct disabledModuleType {
+    uint32_t DetID;
+    int errorType;
     unsigned short BadRocs;
-  
-  COND_SERIALIZABLE;
-};
 
-      //////////////////////////////////////
-      //  errortype "whole" = int 0 in DB //
-      //  errortype "tbmA" = int 1 in DB  //
-      //  errortype "tbmB" = int 2 in DB  //
-      //  errortype "none" = int 3 in DB  //
-      //////////////////////////////////////
-
-      /////////////////////////////////////////////////
-      //each bad roc correspond to a bit to 1: num=  //
-      // 0 <-> all good rocs                         //
-      // 1 <-> only roc 0 bad                        //
-      // 2<-> only roc 1 bad                         //
-      // 3<->  roc 0 and 1 bad                       //
-      // 4 <-> only roc 2 bad                        //
-      //  ...                                        //
-      /////////////////////////////////////////////////
-
-
-
-
-
-  class BadComponentStrictWeakOrdering{
-  public:
-    bool operator() (const disabledModuleType& p,const uint32_t i) const {return p.DetID < i;}
-    bool operator() (const disabledModuleType& p,const disabledModuleType& q) const {return p.DetID < q.DetID;}   
+    COND_SERIALIZABLE;
   };
 
+  //////////////////////////////////////
+  //  errortype "whole" = int 0 in DB //
+  //  errortype "tbmA" = int 1 in DB  //
+  //  errortype "tbmB" = int 2 in DB  //
+  //  errortype "none" = int 3 in DB  //
+  //////////////////////////////////////
 
+  /////////////////////////////////////////////////
+  //each bad roc correspond to a bit to 1: num=  //
+  // 0 <-> all good rocs                         //
+  // 1 <-> only roc 0 bad                        //
+  // 2<-> only roc 1 bad                         //
+  // 3<->  roc 0 and 1 bad                       //
+  // 4 <-> only roc 2 bad                        //
+  //  ...                                        //
+  /////////////////////////////////////////////////
 
-  SiPixelQuality() : theDisabledModules(0) {;}
+  class BadComponentStrictWeakOrdering {
+  public:
+    bool operator()(const disabledModuleType& p, const uint32_t i) const { return p.DetID < i; }
+    bool operator()(const disabledModuleType& p, const disabledModuleType& q) const { return p.DetID < q.DetID; }
+  };
+
+  SiPixelQuality() : theDisabledModules(0) { ; }
 
   // constructor from a list of disabled modules
-  SiPixelQuality(std::vector<disabledModuleType> & disabledModules) : theDisabledModules(disabledModules) {;}
+  SiPixelQuality(std::vector<disabledModuleType>& disabledModules) : theDisabledModules(disabledModules) { ; }
 
-  virtual ~SiPixelQuality() {;}
+  virtual ~SiPixelQuality() { ; }
 
   // set the list of disabled modules (current list is lost)
-  void setDisabledModuleList(std::vector<disabledModuleType> & disabledModules) 
-  { theDisabledModules = disabledModules; }
+  void setDisabledModuleList(std::vector<disabledModuleType>& disabledModules) { theDisabledModules = disabledModules; }
 
   // add a single module to the vector of disabled modules
-  void addDisabledModule(disabledModuleType module)
-  { theDisabledModules.push_back(module); }
+  void addDisabledModule(disabledModuleType module) { theDisabledModules.push_back(module); }
 
   // add a vector of modules to the vector of disabled modules
-  void addDisabledModule(std::vector<disabledModuleType> & idVector);
+  void addDisabledModule(std::vector<disabledModuleType>& idVector);
 
   // remove disabled module from the list
   // returns false if id not in disable list, true otherwise
   //  bool removeDisabledModule(const disabledModuleType & module);
-  //   bool removeDisabledModule(const uint32_t & detid); 
+  //   bool removeDisabledModule(const uint32_t & detid);
 
-
-//--------------- Interface for the user -----------------//
-//------- designed to match SiStripQuality methods ----------//
+  //--------------- Interface for the user -----------------//
+  //------- designed to match SiStripQuality methods ----------//
   //method copied from the SiStripQuality
   void add(const SiStripDetVOff*);
   //----------------------------------------
   //number of Bad modules
-  int BadModuleNumber();   
-  
-  bool IsModuleBad(const uint32_t & detid) const;  //returns True if module disabled
-  bool IsModuleUsable(const uint32_t& detid) const;  //returns True if module NOT disabled
+  int BadModuleNumber();
+
+  bool IsModuleBad(const uint32_t& detid) const;                   //returns True if module disabled
+  bool IsModuleUsable(const uint32_t& detid) const;                //returns True if module NOT disabled
   bool IsRocBad(const uint32_t& detid, const short& rocNb) const;  //returns True if ROC is disabled
-  bool IsAreaBad(uint32_t detid, sipixelobjects::GlobalPixel global,  const edm::EventSetup& es, const SiPixelFedCabling* map ) const;
+  bool IsAreaBad(uint32_t detid,
+                 sipixelobjects::GlobalPixel global,
+                 const edm::EventSetup& es,
+                 const SiPixelFedCabling* map) const;
   short getBadRocs(const uint32_t& detid) const;  //returns bad Rocs for given DetId
   //each bad roc correspond to a bit to 1: num=
   //0 <-> all good rocs
@@ -113,19 +106,19 @@ class SiPixelQuality {
   // 4 <-> only roc 2 bad
   //...
   const std::vector<disabledModuleType> getBadComponentList() const  //returns list of disabled modules/ROCs
-    { return theDisabledModules; }
-  const std::vector< LocalPoint > getBadRocPositions(const uint32_t & detid, const TrackerGeometry& theTracker, const SiPixelFedCabling* map ) const; 
-    //  const std::vector< std::pair <uint8_t, uint8_t> > getBadRocPositions(const uint32_t & detid,  const edm::EventSetup& es, const SiPixelFedCabling* map ) const; 
+  {
+    return theDisabledModules;
+  }
+  const std::vector<LocalPoint> getBadRocPositions(const uint32_t& detid,
+                                                   const TrackerGeometry& theTracker,
+                                                   const SiPixelFedCabling* map) const;
+  //  const std::vector< std::pair <uint8_t, uint8_t> > getBadRocPositions(const uint32_t & detid,  const edm::EventSetup& es, const SiPixelFedCabling* map ) const;
 
-
-
- private:
+private:
   std::vector<disabledModuleType> theDisabledModules;
-  bool IsFedBad(const uint32_t & detid) const; 
+  bool IsFedBad(const uint32_t& detid) const;
 
-
- COND_SERIALIZABLE;
-}; // class SiPixelQuality
-
+  COND_SERIALIZABLE;
+};  // class SiPixelQuality
 
 #endif

--- a/CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h
@@ -1,4 +1,4 @@
-#ifndef CondFormats_SiPixelObjects_SiPixelQualityProbabilities_h 
+#ifndef CondFormats_SiPixelObjects_SiPixelQualityProbabilities_h
 #define CondFormats_SiPixelObjects_SiPixelQualityProbabilities_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
@@ -7,39 +7,37 @@
 #include <string>
 #include <vector>
 
-class SiPixelQualityProbabilities{
+class SiPixelQualityProbabilities {
 public:
-  typedef std::vector<std::pair<std::string,float> > probabilityVec; 
-  typedef std::map<unsigned int,probabilityVec> probabilityMap; 
-  
-  SiPixelQualityProbabilities(){}
-  SiPixelQualityProbabilities( const SiPixelQualityProbabilities& rhs ){ m_probabilities = rhs.getProbability_Map(); };
-  virtual ~SiPixelQualityProbabilities(){}
+  typedef std::vector<std::pair<std::string, float> > probabilityVec;
+  typedef std::map<unsigned int, probabilityVec> probabilityMap;
 
-  void setProbabilities(const unsigned int puBin, const probabilityVec &theProbabilities);
-              
-  const probabilityMap& getProbability_Map () const  {return m_probabilities;}
-   
-  probabilityVec   getProbabilities(const unsigned int puBin) const;
-  const probabilityVec & getProbabilities(const unsigned int puBin);
-  
-  double size()const {return m_probabilities.size();}
-  double nelements(const int puBin)const {return m_probabilities.at(puBin).size();}
+  SiPixelQualityProbabilities() {}
+  SiPixelQualityProbabilities(const SiPixelQualityProbabilities& rhs) { m_probabilities = rhs.getProbability_Map(); };
+  virtual ~SiPixelQualityProbabilities() {}
+
+  void setProbabilities(const unsigned int puBin, const probabilityVec& theProbabilities);
+
+  const probabilityMap& getProbability_Map() const { return m_probabilities; }
+
+  probabilityVec getProbabilities(const unsigned int puBin) const;
+  const probabilityVec& getProbabilities(const unsigned int puBin);
+
+  double size() const { return m_probabilities.size(); }
+  double nelements(const int puBin) const { return m_probabilities.at(puBin).size(); }
   std::vector<unsigned int> getPileUpBins() const;
 
   void printAll() const;
 
   //dumping values on output stream
-  void print(std::ostream & os) const;
+  void print(std::ostream& os) const;
 
 private:
-
   probabilityMap m_probabilities;
 
   COND_SERIALIZABLE;
-
 };
 
-std::ostream & operator<<( std::ostream &, SiPixelQualityProbabilities theProbabilities);
+std::ostream& operator<<(std::ostream&, SiPixelQualityProbabilities theProbabilities);
 
-#endif //CondFormats_SiPixelObjects_SiPixelQualityProbabilities_h
+#endif  //CondFormats_SiPixelObjects_SiPixelQualityProbabilities_h

--- a/CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h
@@ -15,150 +15,137 @@
 
 class SiPixelTemplateDBObject {
 public:
-       struct Reader {
-           explicit Reader(SiPixelTemplateDBObject const & idb) : index_(0), isInvalid_(false), db(idb){}
+  struct Reader {
+    explicit Reader(SiPixelTemplateDBObject const& idb) : index_(0), isInvalid_(false), db(idb) {}
 
-        //- Fills integer from dbobject
-        Reader & operator>>( int& i)
-                {
-                        isInvalid_ = false;
-                        if(index_<=db.maxIndex()) {
-                                i = (int) db.sVector()[index_];
-                                index_++;
-                        }
-                        else
-                           setInvalid();
-                        return *this;
-                }
-        //- Fills float from dbobject
-        Reader & operator>>( float& f)
-                {
-                        isInvalid_ = false;
-                        if(index_<=db.maxIndex()) {
-                                f = db.sVector()[index_];
-                                index_++;
-                        }
-                        else
-                           setInvalid();
-                        return *this;
-                }
+    //- Fills integer from dbobject
+    Reader& operator>>(int& i) {
+      isInvalid_ = false;
+      if (index_ <= db.maxIndex()) {
+        i = (int)db.sVector()[index_];
+        index_++;
+      } else
+        setInvalid();
+      return *this;
+    }
+    //- Fills float from dbobject
+    Reader& operator>>(float& f) {
+      isInvalid_ = false;
+      if (index_ <= db.maxIndex()) {
+        f = db.sVector()[index_];
+        index_++;
+      } else
+        setInvalid();
+      return *this;
+    }
 
+    //- Functions to monitor integrity of dbobject
+    void setInvalid() { isInvalid_ = true; }
+    bool fail() { return isInvalid_; }
+    int index() const { return index_; }
+    int numOfTempl() const { return db.numOfTempl(); }
+    float version() const { return db.version(); }
+    std::vector<float> const& sVector() const { return db.sVector(); }
 
+    //- Able to set the index for template header
+    void incrementIndex(int i) { index_ += i; }
 
-        //- Functions to monitor integrity of dbobject
-        void setInvalid() {isInvalid_ = true;}
-        bool fail() {return isInvalid_;}
-        int index() const {return index_;}
-        int numOfTempl() const {return db.numOfTempl();}
-        float version() const {return db.version();}
-        std::vector<float> const & sVector() const {return db.sVector();}
+    int index_;
+    bool isInvalid_;
+    SiPixelTemplateDBObject const& db;
+  };
 
+  Reader reader() const { return Reader(*this); }
 
-        //- Able to set the index for template header
-        void incrementIndex(int i) {index_+=i;}
+  SiPixelTemplateDBObject() : index_(0), maxIndex_(0), numOfTempl_(1), version_(-99.9), isInvalid_(false), sVector_(0) {
+    sVector_.reserve(1000000);
+  }
+  virtual ~SiPixelTemplateDBObject() {}
 
-        int  index_;
-        bool isInvalid_;
-        SiPixelTemplateDBObject const & db;
-       };
+  //- Allows the dbobject to be read out like cout
+  friend std::ostream& operator<<(std::ostream& s, const SiPixelTemplateDBObject& dbobject);
 
-       Reader reader() const { return Reader(*this);}
+  //- Fills integer from dbobject
+  SiPixelTemplateDBObject& operator>>(int& i) {
+    isInvalid_ = false;
+    if (index_ <= maxIndex_) {
+      i = (int)(*this).sVector_[index_];
+      index_++;
+    } else
+      (*this).setInvalid();
+    return *this;
+  }
+  //- Fills float from dbobject
+  SiPixelTemplateDBObject& operator>>(float& f) {
+    isInvalid_ = false;
+    if (index_ <= maxIndex_) {
+      f = (*this).sVector_[index_];
+      index_++;
+    } else
+      (*this).setInvalid();
+    return *this;
+  }
 
-	SiPixelTemplateDBObject():index_(0),maxIndex_(0),numOfTempl_(1),version_(-99.9),isInvalid_(false),sVector_(0) {
-		sVector_.reserve(1000000);
-	}
-	virtual ~SiPixelTemplateDBObject(){}
-	
-	//- Allows the dbobject to be read out like cout
-	friend std::ostream& operator<<(std::ostream& s, const SiPixelTemplateDBObject& dbobject);
+  //- Functions to monitor integrity of dbobject
+  void setVersion(float version) { version_ = version; }
+  void setInvalid() { isInvalid_ = true; }
+  bool fail() { return isInvalid_; }
 
-	//- Fills integer from dbobject
-	SiPixelTemplateDBObject& operator>>( int& i)
-		{
-			isInvalid_ = false;
-			if(index_<=maxIndex_) {
-				i = (int) (*this).sVector_[index_];
-				index_++;
-			}
-			else
-				(*this).setInvalid();
-			return *this;
-		}
-	//- Fills float from dbobject
-	SiPixelTemplateDBObject& operator>>( float& f)
-		{
-			isInvalid_ = false;
-			if(index_<=maxIndex_) {
-				f = (*this).sVector_[index_];
-				index_++;
-			}
-			else
-				(*this).setInvalid();
-			return *this;
-		}
+  //- Setter functions
+  void push_back(float entry) { sVector_.push_back(entry); }
+  void setIndex(int index) { index_ = index; }
+  void setMaxIndex(int maxIndex) { maxIndex_ = maxIndex; }
+  void setNumOfTempl(int numOfTempl) { numOfTempl_ = numOfTempl; }
 
-	//- Functions to monitor integrity of dbobject
-	void setVersion(float version) {version_ = version;}
-	void setInvalid() {isInvalid_ = true;}
-	bool fail() {return isInvalid_;}
+  //- Accessor functions
+  int index() const { return index_; }
+  int maxIndex() const { return maxIndex_; }
+  int numOfTempl() const { return numOfTempl_; }
+  float version() const { return version_; }
+  std::vector<float> const& sVector() const { return sVector_; }
 
-	//- Setter functions
-	void push_back(float entry) {sVector_.push_back(entry);}
-	void setIndex(int index) {index_ = index;}
-	void setMaxIndex(int maxIndex) {maxIndex_ = maxIndex;}
-	void setNumOfTempl(int numOfTempl) {numOfTempl_ = numOfTempl;}
-	
-	//- Accessor functions
-	int index() const {return index_;}
-	int maxIndex() const {return maxIndex_;}
-	int numOfTempl() const {return numOfTempl_;}
-	float version() const {return version_;}
-	std::vector<float> const & sVector() const {return sVector_;}
+  //- Able to set the index for template header
+  void incrementIndex(int i) { index_ += i; }
 
-	//- Able to set the index for template header 
-	void incrementIndex(int i) {index_+=i;}
+  //- Allows storage of header (type = char[80]) in dbobject
+  union char2float {
+    char c[4];
+    float f;
+  };
 
-	//- Allows storage of header (type = char[80]) in dbobject
-	union char2float
-	{
-		char  c[4];
-		float f;
-	};
+  //- To be used to select template calibration based on detid
+  void putTemplateIDs(std::map<unsigned int, short>& t_ID) { templ_ID = t_ID; }
+  const std::map<unsigned int, short>& getTemplateIDs() const { return templ_ID; }
 
-	//- To be used to select template calibration based on detid
-	void putTemplateIDs(std::map<unsigned int,short>& t_ID) {templ_ID = t_ID;}
-	const std::map<unsigned int,short>& getTemplateIDs () const {return templ_ID;}
+  bool putTemplateID(const uint32_t& detid, short& value) {
+    std::map<unsigned int, short>::const_iterator id = templ_ID.find(detid);
+    if (id != templ_ID.end()) {
+      edm::LogError("SiPixelTemplateDBObject")
+          << "Template ID for DetID " << detid << " is already stored. Skipping this put" << std::endl;
+      return false;
+    } else
+      templ_ID[detid] = value;
+    return true;
+  }
 
-	bool putTemplateID(const uint32_t& detid, short& value)
-		{
-			std::map<unsigned int,short>::const_iterator id=templ_ID.find(detid);
-			if(id!=templ_ID.end()){
-				edm::LogError("SiPixelTemplateDBObject") << "Template ID for DetID " << detid
-																								 << " is already stored. Skipping this put" << std::endl;
-				return false;
-			}
-			else templ_ID[detid] = value;
-			return true;
-		}
+  short getTemplateID(const uint32_t& detid) const {
+    std::map<unsigned int, short>::const_iterator id = templ_ID.find(detid);
+    if (id != templ_ID.end())
+      return id->second;
+    else
+      edm::LogError("SiPixelTemplateDBObject") << "Template ID for DetID " << detid << " is not stored" << std::endl;
+    return 0;
+  }
 
-	short getTemplateID(const uint32_t& detid) const
-		{
-			std::map<unsigned int,short>::const_iterator id=templ_ID.find(detid);
-			if(id!=templ_ID.end()) return id->second;
-			else edm::LogError("SiPixelTemplateDBObject") << "Template ID for DetID " << detid
-																										<< " is not stored" << std::endl;
-			return 0;
-		}
-	
 private:
-	int index_;
-	int maxIndex_;
-	int numOfTempl_;
-	float version_;
-	bool isInvalid_;
-	std::vector<float> sVector_;
-	std::map<unsigned int,short> templ_ID;
+  int index_;
+  int maxIndex_;
+  int numOfTempl_;
+  float version_;
+  bool isInvalid_;
+  std::vector<float> sVector_;
+  std::map<unsigned int, short> templ_ID;
 
   COND_SERIALIZABLE;
-};//end SiPixelTemplateDBObject
+};  //end SiPixelTemplateDBObject
 #endif

--- a/CondFormats/SiPixelObjects/src/FrameConversion.cc
+++ b/CondFormats/SiPixelObjects/src/FrameConversion.cc
@@ -9,312 +9,298 @@ using namespace edm;
 using namespace sipixelobjects;
 
 FrameConversion::FrameConversion(bool bpix, int side, int layer, int rocIdInDetUnit) {
-  int slopeRow =0;
+  int slopeRow = 0;
   int slopeCol = 0;
-  int  rowOffset = 0;
-  int  colOffset = 0; 
- 
-  if (bpix ) { // bpix 
-    
-    if (side==-1 && layer!=1) {  // -Z side: 4 non-flipped modules oriented like 'dddd', except Layer 1
+  int rowOffset = 0;
+  int colOffset = 0;
 
-      if (rocIdInDetUnit <8) {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;	
+  if (bpix) {  // bpix
+
+    if (side == -1 && layer != 1) {  // -Z side: 4 non-flipped modules oriented like 'dddd', except Layer 1
+
+      if (rocIdInDetUnit < 8) {
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
-	slopeRow = -1;
-	slopeCol = 1;      
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
-      } // if roc
-      
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
+      }  // if roc
+
     } else {  // +Z side: 4 non-flipped modules oriented like 'pppp', but all 8 in Layer 1
-      
-      if (rocIdInDetUnit <8) {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc; 
+
+      if (rocIdInDetUnit < 8) {
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
       } else {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (16-rocIdInDetUnit)*LocalPixel::numColsInRoc-1; 
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (16 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       }
-      
-    } // end if +-Z
 
+    }  // end if +-Z
 
-
-  } else { // fpix 
+  } else {  // fpix
 
     // for fpix follow Urs's code for pilot blade
     // no difference between panels
-    if(side==-1) { // pannel 1
+    if (side == -1) {  // pannel 1
       if (rocIdInDetUnit < 8) {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
       }
-    } else { // pannel 2 
+    } else {  // pannel 2
       if (rocIdInDetUnit < 8) {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
       }
-      
-    } // side 
 
-  } // bpix/fpix
+    }  // side
 
-  theRowConversion      = LinearConversion(rowOffset,slopeRow);
-  theCollumnConversion =  LinearConversion(colOffset, slopeCol);
-  
+  }  // bpix/fpix
+
+  theRowConversion = LinearConversion(rowOffset, slopeRow);
+  theCollumnConversion = LinearConversion(colOffset, slopeCol);
 }
 
 FrameConversion::FrameConversion(bool bpix, int side, int rocIdInDetUnit) {
-  int slopeRow =0;
+  int slopeRow = 0;
   int slopeCol = 0;
-  int  rowOffset = 0;
-  int  colOffset = 0; 
- 
-  if (bpix ) { // bpix 
-    
-    if (side==-1) {  // -Z side
+  int rowOffset = 0;
+  int colOffset = 0;
 
-      if (rocIdInDetUnit <8) {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;	
+  if (bpix) {  // bpix
+
+    if (side == -1) {  // -Z side
+
+      if (rocIdInDetUnit < 8) {
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
-	slopeRow = -1;
-	slopeCol = 1;      
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
-      } // if roc
-      
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
+      }  // if roc
+
     } else {  // +Z side
-      
-      if (rocIdInDetUnit <8) {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc; 
+
+      if (rocIdInDetUnit < 8) {
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
       } else {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (16-rocIdInDetUnit)*LocalPixel::numColsInRoc-1; 
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (16 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       }
-      
-    } // end if +-Z
 
+    }  // end if +-Z
 
-
-  } else { // fpix 
+  } else {  // fpix
 
     // for fpix follow Urs's code for pilot blade
     // no difference between panels
-    if(side==-1) { // pannel 1
+    if (side == -1) {  // pannel 1
       if (rocIdInDetUnit < 8) {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
       }
-    } else { // pannel 2 
+    } else {  // pannel 2
       if (rocIdInDetUnit < 8) {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
       }
-      
-    } // side 
 
-  } // bpix/fpix
+    }  // side
 
-  theRowConversion      = LinearConversion(rowOffset,slopeRow);
-  theCollumnConversion =  LinearConversion(colOffset, slopeCol);
-  
+  }  // bpix/fpix
+
+  theRowConversion = LinearConversion(rowOffset, slopeRow);
+  theCollumnConversion = LinearConversion(colOffset, slopeCol);
 }
 
 // OLD method for phase0 bpix
-FrameConversion::FrameConversion( const PixelBarrelName & name, int rocIdInDetUnit)
-{
-  int slopeRow =0;
+FrameConversion::FrameConversion(const PixelBarrelName& name, int rocIdInDetUnit) {
+  int slopeRow = 0;
   int slopeCol = 0;
-  int  rowOffset = 0;
-  int  colOffset = 0; 
+  int rowOffset = 0;
+  int colOffset = 0;
 
   //
   PixelBarrelName::Shell shell = name.shell();
   if (shell == PixelBarrelName::mO || shell == PixelBarrelName::mI) {  // -Z side
 
-    if (name.isHalfModule() ) {
-
-      slopeRow = -1;  // d.k. 23/10/08 
+    if (name.isHalfModule()) {
+      slopeRow = -1;  // d.k. 23/10/08
       slopeCol = 1;   // d.k. 13/11/08
-      rowOffset = LocalPixel::numRowsInRoc-1;
+      rowOffset = LocalPixel::numRowsInRoc - 1;
       colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;  // d.k. 13/11/08
 
     } else {
+      if (rocIdInDetUnit < 8) {
+        slopeRow = 1;
+        slopeCol = -1;
 
-      if (rocIdInDetUnit <8) {
-	slopeRow = 1;
-	slopeCol = -1;
-
-	rowOffset = 0;
-	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        rowOffset = 0;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
 
       } else {
-	slopeRow = -1;
-	slopeCol = 1;
+        slopeRow = -1;
+        slopeCol = 1;
 
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
-
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = (rocIdInDetUnit - 8) * LocalPixel::numColsInRoc;
       }
-    } 
-    
+    }
 
   } else {  // +Z side
 
-    if (name.isHalfModule() ) {
-      slopeRow = -1; 
+    if (name.isHalfModule()) {
+      slopeRow = -1;
       slopeCol = 1;
-      rowOffset = LocalPixel::numRowsInRoc-1;
-      colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc; 
+      rowOffset = LocalPixel::numRowsInRoc - 1;
+      colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
     } else {  // Full modules
-      if (rocIdInDetUnit <8) {
-	slopeRow = -1;
-	slopeCol = 1;
-	rowOffset = 2*LocalPixel::numRowsInRoc-1;
-	colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc; 
+      if (rocIdInDetUnit < 8) {
+        slopeRow = -1;
+        slopeCol = 1;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
       } else {
-	slopeRow = 1;
-	slopeCol = -1;
-	rowOffset = 0;
-	colOffset = (16-rocIdInDetUnit)*LocalPixel::numColsInRoc-1; 
+        slopeRow = 1;
+        slopeCol = -1;
+        rowOffset = 0;
+        colOffset = (16 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       }
-    } // if modules 
-    
+    }  // if modules
 
-  } // end if +-Z
+  }  // end if +-Z
 
-  theRowConversion      = LinearConversion(rowOffset,slopeRow);
-  theCollumnConversion =  LinearConversion(colOffset, slopeCol);
-
+  theRowConversion = LinearConversion(rowOffset, slopeRow);
+  theCollumnConversion = LinearConversion(colOffset, slopeCol);
 }
 // OLD method for phase0 fpix
-FrameConversion::FrameConversion( const PixelEndcapName & name, int rocIdInDetUnit)
-{
-  int slopeRow =0;
+FrameConversion::FrameConversion(const PixelEndcapName& name, int rocIdInDetUnit) {
+  int slopeRow = 0;
   int slopeCol = 0;
-  int  rowOffset = 0;
-  int  colOffset = 0; 
+  int rowOffset = 0;
+  int colOffset = 0;
 
-  if (name.pannelName()==1) {
-    if (name.plaquetteName()==1) {
+  if (name.pannelName() == 1) {
+    if (name.plaquetteName() == 1) {
       slopeRow = 1;
       slopeCol = -1;
       rowOffset = 0;
-      colOffset = (1+rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
-    } else if (name.plaquetteName()==2) {
-      if (rocIdInDetUnit <3) {
+      colOffset = (1 + rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
+    } else if (name.plaquetteName() == 2) {
+      if (rocIdInDetUnit < 3) {
         slopeRow = -1;
         slopeCol = 1;
-        rowOffset = 2*LocalPixel::numRowsInRoc-1;
-        colOffset = rocIdInDetUnit*LocalPixel::numColsInRoc;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
       } else {
         slopeRow = 1;
         slopeCol = -1;
         rowOffset = 0;
-        colOffset = (6-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        colOffset = (6 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       }
-    } else if (name.plaquetteName()==3) {
-      if (rocIdInDetUnit <4) {
+    } else if (name.plaquetteName() == 3) {
+      if (rocIdInDetUnit < 4) {
         slopeRow = -1;
         slopeCol = 1;
-        rowOffset = 2*LocalPixel::numRowsInRoc-1;
-        colOffset = rocIdInDetUnit*LocalPixel::numColsInRoc;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+        colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
       } else {
         slopeRow = 1;
         slopeCol = -1;
         rowOffset = 0;
-        colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        colOffset = (8 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       }
-    } else if (name.plaquetteName()==4) {
+    } else if (name.plaquetteName() == 4) {
       slopeRow = -1;
       slopeCol = 1;
-      rowOffset = LocalPixel::numRowsInRoc-1;
-      colOffset = rocIdInDetUnit*LocalPixel::numColsInRoc;
+      rowOffset = LocalPixel::numRowsInRoc - 1;
+      colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc;
     }
   } else {
-    if (name.plaquetteName()==1) {
-      if (rocIdInDetUnit <3) {
+    if (name.plaquetteName() == 1) {
+      if (rocIdInDetUnit < 3) {
         slopeRow = 1;
         slopeCol = -1;
         rowOffset = 0;
-        colOffset = (3-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        colOffset = (3 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
         slopeRow = -1;
         slopeCol = 1;
-        colOffset = (rocIdInDetUnit-3)*LocalPixel::numColsInRoc;
-        rowOffset = 2*LocalPixel::numRowsInRoc-1;
-      } 
-    } else if (name.plaquetteName()==2) {
-      if (rocIdInDetUnit <4) {
+        colOffset = (rocIdInDetUnit - 3) * LocalPixel::numColsInRoc;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+      }
+    } else if (name.plaquetteName() == 2) {
+      if (rocIdInDetUnit < 4) {
         slopeRow = 1;
         slopeCol = -1;
         rowOffset = 0;
-        colOffset = (4-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        colOffset = (4 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
         slopeRow = -1;
         slopeCol = 1;
-        colOffset = (rocIdInDetUnit-4)*LocalPixel::numColsInRoc;
-        rowOffset = 2*LocalPixel::numRowsInRoc-1;
-      } 
-    } else if (name.plaquetteName()==3) {
-      if (rocIdInDetUnit <5) {
+        colOffset = (rocIdInDetUnit - 4) * LocalPixel::numColsInRoc;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+      }
+    } else if (name.plaquetteName() == 3) {
+      if (rocIdInDetUnit < 5) {
         slopeRow = 1;
         slopeCol = -1;
         rowOffset = 0;
-        colOffset = (5-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+        colOffset = (5 - rocIdInDetUnit) * LocalPixel::numColsInRoc - 1;
       } else {
         slopeRow = -1;
         slopeCol = 1;
-        colOffset = (rocIdInDetUnit-5)*LocalPixel::numColsInRoc;
-        rowOffset = 2*LocalPixel::numRowsInRoc-1;
-      } 
+        colOffset = (rocIdInDetUnit - 5) * LocalPixel::numColsInRoc;
+        rowOffset = 2 * LocalPixel::numRowsInRoc - 1;
+      }
     }
   }
 
-  theRowConversion =  LinearConversion(rowOffset,slopeRow);
-  theCollumnConversion =  LinearConversion(colOffset, slopeCol);
+  theRowConversion = LinearConversion(rowOffset, slopeRow);
+  theCollumnConversion = LinearConversion(colOffset, slopeCol);
 }

--- a/CondFormats/SiPixelObjects/src/PixelFEDCabling.cc
+++ b/CondFormats/SiPixelObjects/src/PixelFEDCabling.cc
@@ -6,58 +6,54 @@
 using namespace std;
 using namespace sipixelobjects;
 
-void PixelFEDCabling::setLinks(Links & links) 
-{
-  theLinks = links;
+void PixelFEDCabling::setLinks(Links& links) { theLinks = links; }
+
+void PixelFEDCabling::addLink(const PixelFEDLink& link) {
+  if (link.id() < 1)
+    return;
+  if (theLinks.size() < link.id())
+    theLinks.resize(link.id());
+  theLinks[link.id() - 1] = link;
 }
 
-void PixelFEDCabling::addLink(const PixelFEDLink & link)
-{
-  if ( link.id() < 1) return;
-  if ( theLinks.size() < link.id() ) theLinks.resize(link.id());
-  theLinks[link.id()-1] = link;
+void PixelFEDCabling::addItem(unsigned int linkId, const PixelROC& roc) {
+  if (linkId < 1)
+    return;
+  if (theLinks.size() < linkId)
+    theLinks.resize(linkId);
+  if (theLinks[linkId - 1].id() != linkId)
+    theLinks[linkId - 1] = PixelFEDLink(linkId);
+  theLinks[linkId - 1].addItem(roc);
 }
 
-void PixelFEDCabling::addItem(unsigned int linkId, const PixelROC & roc)
-{
-  if ( linkId < 1) return;
-  if ( theLinks.size() < linkId ) theLinks.resize(linkId);
-  if ( theLinks[linkId-1].id() != linkId)  theLinks[linkId-1] = PixelFEDLink(linkId);
-  theLinks[linkId-1].addItem(roc);
-}
-
-bool PixelFEDCabling::checkLinkNumbering() const
-{
+bool PixelFEDCabling::checkLinkNumbering() const {
   bool result = true;
   typedef Links::const_iterator IL;
   unsigned int idx_expected = 0;
   for (IL il = theLinks.begin(); il != theLinks.end(); il++) {
     idx_expected++;
-    if ((*il).id() != 0 && idx_expected != (*il).id() ) {
+    if ((*il).id() != 0 && idx_expected != (*il).id()) {
       result = false;
-      cout << " ** PixelFEDCabling ** link numbering inconsistency, expected id: "
-           << idx_expected <<" has: " << (*il).id() << endl;
-    } 
-    if (! (*il).checkRocNumbering() ) {
+      cout << " ** PixelFEDCabling ** link numbering inconsistency, expected id: " << idx_expected
+           << " has: " << (*il).id() << endl;
+    }
+    if (!(*il).checkRocNumbering()) {
       result = false;
-      cout << "** PixelFEDCabling ** inconsistent ROC numbering in link id: "
-           << (*il).id() << endl;
+      cout << "** PixelFEDCabling ** inconsistent ROC numbering in link id: " << (*il).id() << endl;
     }
   }
   return result;
 }
 
-string PixelFEDCabling::print(int depth) const
-{
+string PixelFEDCabling::print(int depth) const {
   ostringstream out;
-  typedef vector<PixelFEDLink>::const_iterator IT; 
-  if (depth-- >=0 ) {
-    out <<"FED: "<<id()<< endl;
-    for (IT it=theLinks.begin(); it != theLinks.end(); it++)
-         out << (*it).print(depth);
-    out <<"# total number of Links: "<< numberOfLinks() << endl;
+  typedef vector<PixelFEDLink>::const_iterator IT;
+  if (depth-- >= 0) {
+    out << "FED: " << id() << endl;
+    for (IT it = theLinks.begin(); it != theLinks.end(); it++)
+      out << (*it).print(depth);
+    out << "# total number of Links: " << numberOfLinks() << endl;
   }
   out << endl;
   return out.str();
 }
-

--- a/CondFormats/SiPixelObjects/src/PixelFEDLink.cc
+++ b/CondFormats/SiPixelObjects/src/PixelFEDLink.cc
@@ -3,110 +3,113 @@
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-
 #include <sstream>
 
 using namespace std;
 using namespace sipixelobjects;
 
-void PixelFEDLink::addItem(const PixelROC & roc)
-{
+void PixelFEDLink::addItem(const PixelROC& roc) {
   // INFO roc numbering vs vector has offset=1
-  if(roc.idInLink() > theROCs.size() ) theROCs.resize(roc.idInLink());
-  theROCs[roc.idInLink()-1] = roc;
+  if (roc.idInLink() > theROCs.size())
+    theROCs.resize(roc.idInLink());
+  theROCs[roc.idInLink() - 1] = roc;
 }
 
-bool PixelFEDLink::checkRocNumbering() const
-{
+bool PixelFEDLink::checkRocNumbering() const {
   bool result = true;
   unsigned int idx_expected = 0;
   typedef ROCs::const_iterator CIR;
   for (CIR it = theROCs.begin(); it != theROCs.end(); it++) {
     idx_expected++;
-    if (idx_expected != (*it).idInLink() ) {
+    if (idx_expected != (*it).idInLink()) {
       result = false;
-      cout << "** PixelFEDLink, idInLink in ROC, expected: "
-           << idx_expected <<" has: "<<(*it).idInLink() << endl;
+      cout << "** PixelFEDLink, idInLink in ROC, expected: " << idx_expected << " has: " << (*it).idInLink() << endl;
     }
   }
   return result;
 }
 
-void PixelFEDLink::add(const ROCs & rocs)
-{
-  theROCs.insert( theROCs.end(), rocs.begin(), rocs.end() );
-}
+void PixelFEDLink::add(const ROCs& rocs) { theROCs.insert(theROCs.end(), rocs.begin(), rocs.end()); }
 
-string PixelFEDLink::print(int depth) const
-{
+string PixelFEDLink::print(int depth) const {
   ostringstream out;
   // if (id() < 0) return  out.str(); // id() >= 0, since it returns an unsigned
 
-  if (depth-- >=0 ) {
-    if(id()<10) out <<"  LNK:  "<<id(); else  out <<"  LNK: "<<id();
-    if (depth==0) out << printForMap();
-    else { 
+  if (depth-- >= 0) {
+    if (id() < 10)
+      out << "  LNK:  " << id();
+    else
+      out << "  LNK: " << id();
+    if (depth == 0)
+      out << printForMap();
+    else {
       out << endl;
       typedef ROCs::const_iterator CIR;
-      for (CIR ir = theROCs.begin(); ir != theROCs.end(); ir++) out<< (ir)->print(depth); 
-      out <<"#  total number of ROCs: "<< numberOfROCs() << endl;
+      for (CIR ir = theROCs.begin(); ir != theROCs.end(); ir++)
+        out << (ir)->print(depth);
+      out << "#  total number of ROCs: " << numberOfROCs() << endl;
     }
   }
   return out.str();
-
 }
 
-string PixelFEDLink::printForMap() const 
-{
+string PixelFEDLink::printForMap() const {
   typedef ROCs::const_iterator CIR;
   ostringstream out;
 
-// barrel
-{
-  int minroc = 9999;
-  int maxroc = -1;
-  bool first = true;
-  PixelBarrelName prev;
-  for (CIR ir = theROCs.begin(); ir < theROCs.end(); ir++) {
-    DetId detid = DetId(ir->rawId());
-    bool barrel = PixelModuleName::isBarrel(detid.rawId()); if (!barrel) continue;
-    PixelBarrelName curr( detid);
-    if (first) prev = curr; 
+  // barrel
+  {
+    int minroc = 9999;
+    int maxroc = -1;
+    bool first = true;
+    PixelBarrelName prev;
+    for (CIR ir = theROCs.begin(); ir < theROCs.end(); ir++) {
+      DetId detid = DetId(ir->rawId());
+      bool barrel = PixelModuleName::isBarrel(detid.rawId());
+      if (!barrel)
+        continue;
+      PixelBarrelName curr(detid);
+      if (first)
+        prev = curr;
 
-    int idRoc = ir->idInDetUnit();
-    if (curr==prev) {
-      minroc = min(idRoc, minroc);
-      maxroc = max(idRoc, maxroc);
-    }
+      int idRoc = ir->idInDetUnit();
+      if (curr == prev) {
+        minroc = min(idRoc, minroc);
+        maxroc = max(idRoc, maxroc);
+      }
 
-    if ( !(curr==prev) ) {
-    out <<"    MOD: "<< prev.name() <<" ROC: "<< minroc<<", "<<maxroc<< std::endl;
-      prev = curr;
-      maxroc = minroc = idRoc;
- //     minroc = idRoc;
- //     maxroc = idRoc;
-    }
+      if (!(curr == prev)) {
+        out << "    MOD: " << prev.name() << " ROC: " << minroc << ", " << maxroc << std::endl;
+        prev = curr;
+        maxroc = minroc = idRoc;
+        //     minroc = idRoc;
+        //     maxroc = idRoc;
+      }
 
-    if ( ir==theROCs.end()-1) {
-    out <<"    MOD: "<< curr.name() <<" ROC: "<< minroc<<", "<<maxroc<< std::endl;
+      if (ir == theROCs.end() - 1) {
+        out << "    MOD: " << curr.name() << " ROC: " << minroc << ", " << maxroc << std::endl;
+      }
     }
   }
-}
 
-// same for endcpap
-{
-  bool first = true;
-  PixelEndcapName prev;
-  for (CIR ir = theROCs.begin(); ir < theROCs.end(); ir++) {
-    DetId detid = DetId(ir->rawId());
-    bool barrel = PixelModuleName::isBarrel(detid.rawId()); if (barrel) continue;
-    PixelEndcapName tmp( detid);
-    PixelEndcapName curr( tmp.halfCylinder(), tmp.diskName(), tmp.bladeName(), tmp.pannelName() );
-    if (first) prev = curr;
-    if ( !(curr==prev) ) out <<"    MOD: "<< prev.name() << std::endl;
-    if ( ir==theROCs.end()-1) out <<"    MOD: "<< curr.name() << std::endl;
+  // same for endcpap
+  {
+    bool first = true;
+    PixelEndcapName prev;
+    for (CIR ir = theROCs.begin(); ir < theROCs.end(); ir++) {
+      DetId detid = DetId(ir->rawId());
+      bool barrel = PixelModuleName::isBarrel(detid.rawId());
+      if (barrel)
+        continue;
+      PixelEndcapName tmp(detid);
+      PixelEndcapName curr(tmp.halfCylinder(), tmp.diskName(), tmp.bladeName(), tmp.pannelName());
+      if (first)
+        prev = curr;
+      if (!(curr == prev))
+        out << "    MOD: " << prev.name() << std::endl;
+      if (ir == theROCs.end() - 1)
+        out << "    MOD: " << curr.name() << std::endl;
+    }
   }
-}
   return out.str();
 }
-

--- a/CondFormats/SiPixelObjects/src/PixelROC.cc
+++ b/CondFormats/SiPixelObjects/src/PixelROC.cc
@@ -10,13 +10,12 @@ using namespace std;
 using namespace sipixelobjects;
 
 // Constructor with transformation frame initilization - NEVER CALLED
-PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
-  : theDetUnit(du), theIdDU(idDU), theIdLk(idLk) {
+PixelROC::PixelROC(uint32_t du, int idDU, int idLk) : theDetUnit(du), theIdDU(idDU), theIdLk(idLk) {
   initFrameConversion();
 }
 
 // // for testing, uses topology fot det id, it works but I cannot pass topology here
-// // not used  
+// // not used
 // void PixelROC::initFrameConversion(const TrackerTopology *tt, bool phase1) {
 //   const bool TEST = false;
 //   if(phase1) { // phase1
@@ -27,20 +26,20 @@ PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
 //       if((tt->pxbModule(theDetUnit))<5) side=-1;
 //       else side=1;
 //       if(TEST) {
-// 	// phase0 code 
+// 	// phase0 code
 // 	PXBDetId det(theDetUnit);
 // 	unsigned  int module = bpixSidePhase0(theDetUnit);
-// 	if(!phase1 && (tt->pxbModule(theDetUnit) != module) ) 
+// 	if(!phase1 && (tt->pxbModule(theDetUnit) != module) )
 // 	// phase1 code
 // 	unsigned  int module1 = bpixSidePhase1(theDetUnit);
 //       }
 //     } else {
-//       // Endcaps, use the panel to find the direction 
+//       // Endcaps, use the panel to find the direction
 //       if((tt->pxfPanel(theDetUnit))==1) side=-1; // panel 1
 //       else side =1; // panel 2
 //       if(TEST) {
 // 	// code -phase0
-// 	PXFDetId det(theDetUnit);      
+// 	PXFDetId det(theDetUnit);
 // 	unsigned int module = fpixSidePhase0(theDetUnit);
 // 	// phase1 code
 // 	unsigned int module1 = fpixSidePhase1(theDetUnit);
@@ -57,14 +56,13 @@ PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
 void PixelROC::initFrameConversionPhase1_CMSSW_9_0_X() {
   int side = 0;
   bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
-  if(isBarrel) {
-    side = bpixSidePhase1(theDetUnit); // find the side for phase1
+  if (isBarrel) {
+    side = bpixSidePhase1(theDetUnit);  // find the side for phase1
   } else {
     side = fpixSidePhase1(theDetUnit);
   }
 
-  theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
-
+  theFrameConverter = FrameConversion(isBarrel, side, theIdDU);
 }
 
 // works for phase 1, find det side from the local method
@@ -72,28 +70,25 @@ void PixelROC::initFrameConversionPhase1() {
   int side = 0;
   int layer = 0;
   bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
-  if(isBarrel) {
-    side = bpixSidePhase1(theDetUnit); // find the side for phase1
+  if (isBarrel) {
+    side = bpixSidePhase1(theDetUnit);  // find the side for phase1
     layer = bpixLayerPhase1(theDetUnit);
   } else {
     side = fpixSidePhase1(theDetUnit);
   }
 
   theFrameConverter = FrameConversion(isBarrel, side, layer, theIdDU);
-
 }
 
 // Works only for phase0, uses the fixed pixel id
 void PixelROC::initFrameConversion() {
-
-    if ( PixelModuleName::isBarrel(theDetUnit) ) {
-      PixelBarrelName barrelName(theDetUnit);
-      theFrameConverter = FrameConversion(barrelName, theIdDU);
-    } else {
-      PixelEndcapName endcapName(theDetUnit);
-      theFrameConverter =  FrameConversion(endcapName, theIdDU); 
-    }
-
+  if (PixelModuleName::isBarrel(theDetUnit)) {
+    PixelBarrelName barrelName(theDetUnit);
+    theFrameConverter = FrameConversion(barrelName, theIdDU);
+  } else {
+    PixelEndcapName endcapName(theDetUnit);
+    theFrameConverter = FrameConversion(endcapName, theIdDU);
+  }
 }
 
 // These are methods to find the module side.
@@ -104,20 +99,21 @@ int PixelROC::bpixSidePhase0(uint32_t rawId) const {
   /// two bits would be enough, but  we could use the number "0" as a wildcard
   //const unsigned int layerStartBit_=   16;
   //const unsigned int ladderStartBit_=   8;
-  const unsigned int moduleStartBit_=   2;
+  const unsigned int moduleStartBit_ = 2;
   /// two bits would be enough, but  we could use the number "0" as a wildcard
   //const unsigned int layerMask_=       0xF;
   //const unsigned int ladderMask_=      0xFF;
-  const unsigned int moduleMask_=      0x3F;
+  const unsigned int moduleMask_ = 0x3F;
 
   /// layer id
   //unsigned int layer = (rawId>>layerStartBit_) & layerMask_;
   /// ladder  id
   //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
   /// det id
-  unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
+  unsigned int module = (rawId >> moduleStartBit_) & moduleMask_;
 
-  if(module<5) side=-1; // modules 1-4 are on -z
+  if (module < 5)
+    side = -1;  // modules 1-4 are on -z
   return side;
 }
 int PixelROC::bpixSidePhase1(uint32_t rawId) const {
@@ -126,34 +122,35 @@ int PixelROC::bpixSidePhase1(uint32_t rawId) const {
   /// two bits would be enough, but  we could use the number "0" as a wildcard
   //const unsigned int layerStartBit_=   20;
   //const unsigned int ladderStartBit_=  12;
-  const unsigned int moduleStartBit_=   2;
+  const unsigned int moduleStartBit_ = 2;
   /// two bits would be enough, but  we could use the number "0" as a wildcard
   //const unsigned int layerMask_=       0xF;
   //const unsigned int ladderMask_=      0xFF;
-  const unsigned int moduleMask_=      0x3FF;
+  const unsigned int moduleMask_ = 0x3FF;
 
   /// layer id
   //unsigned int layer = (rawId>>layerStartBit_) & layerMask_;
   /// ladder  id
   //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
   /// det id
-  unsigned int module = (rawId>>moduleStartBit_)& moduleMask_;
+  unsigned int module = (rawId >> moduleStartBit_) & moduleMask_;
 
-  if(module<5) side=-1; // modules 1-4 are on -z
+  if (module < 5)
+    side = -1;  // modules 1-4 are on -z
   return side;
 }
 int PixelROC::bpixLayerPhase1(uint32_t rawId) {
   /// two bits would be enough, but  we could use the number "0" as a wildcard
-  const unsigned int layerStartBit_=   20;
+  const unsigned int layerStartBit_ = 20;
   //const unsigned int ladderStartBit_=  12;
   //const unsigned int moduleStartBit_=   2;
   /// two bits would be enough, but  we could use the number "0" as a wildcard
-  const unsigned int layerMask_=       0xF;
+  const unsigned int layerMask_ = 0xF;
   //const unsigned int ladderMask_=      0xFF;
   //const unsigned int moduleMask_=      0x3FF;
 
   /// layer id
-  unsigned int layer = (rawId>>layerStartBit_) & layerMask_;
+  unsigned int layer = (rawId >> layerStartBit_) & layerMask_;
   /// ladder  id
   //unsigned int ladder = (rawId>>ladderStartBit_) & ladderMask_;
   /// det id
@@ -170,14 +167,14 @@ int PixelROC::fpixSidePhase0(uint32_t rawId) const {
   //const unsigned int sideStartBit_=   23;
   //const unsigned int diskStartBit_=   16;
   //const unsigned int bladeStartBit_=  10;
-  const unsigned int panelStartBit_=  8;
+  const unsigned int panelStartBit_ = 8;
   //const unsigned int moduleStartBit_= 2;
   /// two bits would be enough, but  we could use the number "0" as a wildcard
-  
+
   //const unsigned int sideMask_=     0x3;
   //const unsigned int diskMask_=     0xF;
   //const unsigned int bladeMask_=    0x3F;
-  const unsigned int panelMask_=    0x3;
+  const unsigned int panelMask_ = 0x3;
   //const unsigned int moduleMask_=   0x3F;
 
   /// positive or negative id
@@ -187,11 +184,12 @@ int PixelROC::fpixSidePhase0(uint32_t rawId) const {
   /// blade id
   //unsigned int blade = ((rawId>>bladeStartBit_) & bladeMask_);
   /// panel id
-  unsigned int panel = ((rawId>>panelStartBit_) & panelMask_);
+  unsigned int panel = ((rawId >> panelStartBit_) & panelMask_);
   /// det id
   //unsigned int module = ((rawId>>moduleStartBit_) & moduleMask_);
 
-  if(panel==1) side=-1; // panel 1 faces -z (is this true for all disks?)
+  if (panel == 1)
+    side = -1;  // panel 1 faces -z (is this true for all disks?)
   return side;
 }
 int PixelROC::fpixSidePhase1(uint32_t rawId) const {
@@ -201,54 +199,54 @@ int PixelROC::fpixSidePhase1(uint32_t rawId) const {
   //const unsigned int sideStartBit_=   23;
   //const unsigned int diskStartBit_=   18;
   //const unsigned int bladeStartBit_=  12;
-  const unsigned int panelStartBit_=  10;
+  const unsigned int panelStartBit_ = 10;
   //const unsigned int moduleStartBit_= 2;
   /// two bits would be enough, but  we could use the number "0" as a wildcard
-  
+
   //const unsigned int sideMask_=     0x3;
   //const unsigned int diskMask_=     0xF;
   //const unsigned int bladeMask_=    0x3F;
-  const unsigned int panelMask_=    0x3;
+  const unsigned int panelMask_ = 0x3;
   //const unsigned int moduleMask_=   0xFF;
 
   /// positive or negative id
   //unsigned int sides = int((rawId>>sideStartBit_) & sideMask_);
   /// disk id
   //unsigned int disk = int((rawId>>diskStartBit_) & diskMask_);
-  
+
   /// blade id
   //unsigned int blade = ((rawId>>bladeStartBit_) & bladeMask_);
-  
- /// panel id 1 or 2
-  unsigned int panel = ((rawId>>panelStartBit_) & panelMask_);
+
+  /// panel id 1 or 2
+  unsigned int panel = ((rawId >> panelStartBit_) & panelMask_);
 
   /// det id
   //unsigned int module = ((rawId>>moduleStartBit_) & moduleMask_);
 
-  if(panel==1) side=-1; // panel 1 faces -z (is this true for all disks?)
+  if (panel == 1)
+    side = -1;  // panel 1 faces -z (is this true for all disks?)
   return side;
 }
 
-
 string PixelROC::print(int depth) const {
-
   ostringstream out;
   bool barrel = PixelModuleName::isBarrel(theDetUnit);
   DetId detId(theDetUnit);
-  if (depth-- >=0 ) {
-    out <<"======== PixelROC ";
+  if (depth-- >= 0) {
+    out << "======== PixelROC ";
     //out <<" unit: ";
     //if (barrel) out << PixelBarrelName(detId).name();
-    //else        out << PixelEndcapName(detId).name(); 
-    if (barrel) out << " barrel ";
-    else        out << " endcap "; 
-    out <<" ("<<theDetUnit<<")"
-        <<" idInDU: "<<theIdDU
-        <<" idInLk: "<<theIdLk
-//        <<" frame: "<<theRowOffset<<","<<theRowSlopeSign<<","<<theColOffset<<","<<theColSlopeSign
-//        <<" frame: "<<*theFrameConverter
-        <<endl;
+    //else        out << PixelEndcapName(detId).name();
+    if (barrel)
+      out << " barrel ";
+    else
+      out << " endcap ";
+    out << " (" << theDetUnit << ")"
+        << " idInDU: " << theIdDU << " idInLk: "
+        << theIdLk
+        //        <<" frame: "<<theRowOffset<<","<<theRowSlopeSign<<","<<theColOffset<<","<<theColSlopeSign
+        //        <<" frame: "<<*theFrameConverter
+        << endl;
   }
   return out.str();
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelCPEGenericErrorParm.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCPEGenericErrorParm.cc
@@ -2,65 +2,59 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <fstream>
 
-void SiPixelCPEGenericErrorParm::fillCPEGenericErrorParm(double version, std::string file)
-{
-	//--- Open the file
-	std::ifstream in(file.c_str(), std::ios::in);
+void SiPixelCPEGenericErrorParm::fillCPEGenericErrorParm(double version, std::string file) {
+  //--- Open the file
+  std::ifstream in(file.c_str(), std::ios::in);
 
-	//--- Currently do not need to store part of detector, but is in input file
-	int part;
-	set_version(version);
+  //--- Currently do not need to store part of detector, but is in input file
+  int part;
+  set_version(version);
 
   DbEntry Entry;
   in >> part >> Entry.bias >> Entry.pix_height >> Entry.ave_Qclus >> Entry.sigma >> Entry.rms;
 
-  while(!in.eof()) {
-    errors_.push_back( Entry );
-		
-    in >> part            >> Entry.bias  >> Entry.pix_height
-			 >> Entry.ave_Qclus >> Entry.sigma >> Entry.rms;
+  while (!in.eof()) {
+    errors_.push_back(Entry);
+
+    in >> part >> Entry.bias >> Entry.pix_height >> Entry.ave_Qclus >> Entry.sigma >> Entry.rms;
   }
   //--- Finished parsing the file, we're done.
   in.close();
 
-	//--- Specify the current binning sizes to use
-	DbEntryBinSize ErrorsBinSize;
-	//--- Part = 1 By
-	ErrorsBinSize.partBin_size  =   0;
-	ErrorsBinSize.sizeBin_size  =  40;
-	ErrorsBinSize.alphaBin_size =  10;
-	ErrorsBinSize.betaBin_size  =   1;
-	errorsBinSize_.push_back(ErrorsBinSize);
+  //--- Specify the current binning sizes to use
+  DbEntryBinSize ErrorsBinSize;
+  //--- Part = 1 By
+  ErrorsBinSize.partBin_size = 0;
+  ErrorsBinSize.sizeBin_size = 40;
+  ErrorsBinSize.alphaBin_size = 10;
+  ErrorsBinSize.betaBin_size = 1;
+  errorsBinSize_.push_back(ErrorsBinSize);
   //--- Part = 2 Bx
-	ErrorsBinSize.partBin_size  = 240;
-	ErrorsBinSize.alphaBin_size =   1;
-	ErrorsBinSize.betaBin_size  =  10;
-	errorsBinSize_.push_back(ErrorsBinSize);
-	//--- Part = 3 Fy
-	ErrorsBinSize.partBin_size  = 360;
-	ErrorsBinSize.alphaBin_size =  10;
-	ErrorsBinSize.betaBin_size  =   1;
-	errorsBinSize_.push_back(ErrorsBinSize);
-	//--- Part = 4 Fx
-	ErrorsBinSize.partBin_size  = 380;
-	ErrorsBinSize.alphaBin_size =   1;
-	ErrorsBinSize.betaBin_size  =  10;
-	errorsBinSize_.push_back(ErrorsBinSize);
+  ErrorsBinSize.partBin_size = 240;
+  ErrorsBinSize.alphaBin_size = 1;
+  ErrorsBinSize.betaBin_size = 10;
+  errorsBinSize_.push_back(ErrorsBinSize);
+  //--- Part = 3 Fy
+  ErrorsBinSize.partBin_size = 360;
+  ErrorsBinSize.alphaBin_size = 10;
+  ErrorsBinSize.betaBin_size = 1;
+  errorsBinSize_.push_back(ErrorsBinSize);
+  //--- Part = 4 Fx
+  ErrorsBinSize.partBin_size = 380;
+  ErrorsBinSize.alphaBin_size = 1;
+  ErrorsBinSize.betaBin_size = 10;
+  errorsBinSize_.push_back(ErrorsBinSize);
 }
 
-std::ostream& operator<<(std::ostream& s, const SiPixelCPEGenericErrorParm& genericErrors)
-{
-		for (unsigned int count=0; count < genericErrors.errors_.size(); ++count) {
+std::ostream& operator<<(std::ostream& s, const SiPixelCPEGenericErrorParm& genericErrors) {
+  for (unsigned int count = 0; count < genericErrors.errors_.size(); ++count) {
+    s.precision(6);
 
-			s.precision(6);
-			
-			s << genericErrors.errors_[count].bias << " "
-				<< genericErrors.errors_[count].pix_height << " "
-				<< genericErrors.errors_[count].ave_Qclus << " " << std::fixed
-				<< genericErrors.errors_[count].sigma << " "
-				<< genericErrors.errors_[count].rms << std::endl;
-	
-			s.unsetf ( std::ios_base::fixed );
-		}
-		return s;
+    s << genericErrors.errors_[count].bias << " " << genericErrors.errors_[count].pix_height << " "
+      << genericErrors.errors_[count].ave_Qclus << " " << std::fixed << genericErrors.errors_[count].sigma << " "
+      << genericErrors.errors_[count].rms << std::endl;
+
+    s.unsetf(std::ios_base::fixed);
+  }
+  return s;
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelCalibConfiguration.cc
@@ -2,27 +2,27 @@
 #include "CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h"
 #include <cstdlib>
 
-short SiPixelCalibConfiguration::vcalIndexForEvent(const uint32_t & eventnumber) const{
-  uint32_t relative_event = std::abs((int32_t)eventnumber-1)%patternSize();
-  short relative_pattern = relative_event/getNTriggers();
-  return relative_pattern; 
+short SiPixelCalibConfiguration::vcalIndexForEvent(const uint32_t &eventnumber) const {
+  uint32_t relative_event = std::abs((int32_t)eventnumber - 1) % patternSize();
+  short relative_pattern = relative_event / getNTriggers();
+  return relative_pattern;
 }
-short SiPixelCalibConfiguration::vcalForEvent(const uint32_t & eventnumber) const{
+short SiPixelCalibConfiguration::vcalForEvent(const uint32_t &eventnumber) const {
   short result = fVCalValues[vcalIndexForEvent(eventnumber)];
   return result;
 }
-std::vector<short> SiPixelCalibConfiguration::columnPatternForEvent(const uint32_t & eventnumber) const{
+std::vector<short> SiPixelCalibConfiguration::columnPatternForEvent(const uint32_t &eventnumber) const {
   std::vector<short> result;
-  uint32_t patternnumber = eventnumber/patternSize();
-  uint32_t colpatternnumber = patternnumber%nColumnPatterns();
+  uint32_t patternnumber = eventnumber / patternSize();
+  uint32_t colpatternnumber = patternnumber % nColumnPatterns();
 
-  uint32_t nminuscol=0;
-  for(size_t icol=0; icol<fColumnPattern.size(); icol++){
-    if(fColumnPattern[icol]==-1)
+  uint32_t nminuscol = 0;
+  for (size_t icol = 0; icol < fColumnPattern.size(); icol++) {
+    if (fColumnPattern[icol] == -1)
       nminuscol++;
-    else if(nminuscol>colpatternnumber)
+    else if (nminuscol > colpatternnumber)
       break;
-    else if(nminuscol==colpatternnumber){
+    else if (nminuscol == colpatternnumber) {
       short val = fColumnPattern[icol];
       result.push_back(val);
     }
@@ -30,64 +30,62 @@ std::vector<short> SiPixelCalibConfiguration::columnPatternForEvent(const uint32
   return result;
 }
 
-std::vector<short> SiPixelCalibConfiguration::rowPatternForEvent(const uint32_t & eventnumber) const {
+std::vector<short> SiPixelCalibConfiguration::rowPatternForEvent(const uint32_t &eventnumber) const {
   std::vector<short> result;
-  uint32_t patternnumber = eventnumber/patternSize();
-  uint32_t rowpatternnumber = patternnumber/nColumnPatterns();
+  uint32_t patternnumber = eventnumber / patternSize();
+  uint32_t rowpatternnumber = patternnumber / nColumnPatterns();
 
-  uint32_t nminusrow=0;
-  for(size_t irow=0; irow<fRowPattern.size(); irow++){
-    if(fRowPattern[irow]==-1)
+  uint32_t nminusrow = 0;
+  for (size_t irow = 0; irow < fRowPattern.size(); irow++) {
+    if (fRowPattern[irow] == -1)
       nminusrow++;
-    else if(nminusrow>rowpatternnumber)
+    else if (nminusrow > rowpatternnumber)
       break;
-    else if(nminusrow==rowpatternnumber){
+    else if (nminusrow == rowpatternnumber) {
       short val = fRowPattern[irow];
       result.push_back(val);
     }
   }
   return result;
 }
-uint32_t SiPixelCalibConfiguration::nextPatternChangeForEvent(const uint32_t & eventnumber) const {
-  uint32_t relative_event = eventnumber/patternSize();
-  relative_event+=1;
-  return relative_event*patternSize();
+uint32_t SiPixelCalibConfiguration::nextPatternChangeForEvent(const uint32_t &eventnumber) const {
+  uint32_t relative_event = eventnumber / patternSize();
+  relative_event += 1;
+  return relative_event * patternSize();
 }
-uint32_t SiPixelCalibConfiguration::expectedTotalEvents() const {
-  return patternSize()*nPatterns();
-}
+uint32_t SiPixelCalibConfiguration::expectedTotalEvents() const { return patternSize() * nPatterns(); }
 
-SiPixelCalibConfiguration::SiPixelCalibConfiguration(const pos::PixelCalibConfiguration &fancyConfig):
-  fNTriggers(0),
-  fRowPattern(std::vector<short>(0)),
-  fColumnPattern(std::vector<short>(0)),
-  fVCalValues(std::vector<short>(0)),
-  fMode("unknown")
+SiPixelCalibConfiguration::SiPixelCalibConfiguration(const pos::PixelCalibConfiguration &fancyConfig)
+    : fNTriggers(0),
+      fRowPattern(std::vector<short>(0)),
+      fColumnPattern(std::vector<short>(0)),
+      fVCalValues(std::vector<short>(0)),
+      fMode("unknown")
 
-{ // copy constructor that uses the complex object
+{  // copy constructor that uses the complex object
   fNTriggers = fancyConfig.nTriggersPerPattern();
   std::vector<int> vcalpoints(0);
   std::cout << "scan name = " << fancyConfig.scanName(0) << std::endl;
   std::vector<uint32_t> vcalpointsuint32 = fancyConfig.scanValues(fancyConfig.scanName(0));
-  for(size_t ical=0; ical<vcalpointsuint32.size(); ++ical){
+  for (size_t ical = 0; ical < vcalpointsuint32.size(); ++ical) {
     short vcalinput = vcalpointsuint32[ical];
-  
+
     std::cout << "Vcal value " << ical << " = " << vcalinput << std::endl;
     fVCalValues.push_back(vcalinput);
   }
   // copy row and column patterns
 
-  std::vector<std::vector<uint32_t> > cols=fancyConfig.columnList();
-  std::vector<std::vector<uint32_t> > rows= fancyConfig.rowList();
-  for(uint32_t i=0; i<cols.size(); ++i){
-    for(uint32_t j=0; j<cols[i].size(); ++j){
+  std::vector<std::vector<uint32_t> > cols = fancyConfig.columnList();
+  std::vector<std::vector<uint32_t> > rows = fancyConfig.rowList();
+  for (uint32_t i = 0; i < cols.size(); ++i) {
+    for (uint32_t j = 0; j < cols[i].size(); ++j) {
       short colval = cols[i][j];
       fColumnPattern.push_back(colval);
     }
     fColumnPattern.push_back(-1);
   }
-  for(uint32_t i=0; i<rows.size(); ++i){
-    for(uint32_t j=0; j<rows[i].size(); ++j){
+  for (uint32_t i = 0; i < rows.size(); ++i) {
+    for (uint32_t j = 0; j < rows[i].size(); ++j) {
       short rowval = rows[i][j];
       fRowPattern.push_back(rowval);
     }
@@ -96,21 +94,20 @@ SiPixelCalibConfiguration::SiPixelCalibConfiguration(const pos::PixelCalibConfig
   fMode = fancyConfig.mode();
 }
 
-uint32_t SiPixelCalibConfiguration::nRowPatterns() const{
- uint32_t nrows = 0;
- for(std::vector<short>::const_iterator i=fRowPattern.begin();i!=fRowPattern.end();++i){
-   if(*i == -1)
-    nrows++;
+uint32_t SiPixelCalibConfiguration::nRowPatterns() const {
+  uint32_t nrows = 0;
+  for (std::vector<short>::const_iterator i = fRowPattern.begin(); i != fRowPattern.end(); ++i) {
+    if (*i == -1)
+      nrows++;
   }
   return nrows;
 }
-uint32_t SiPixelCalibConfiguration::nColumnPatterns() const{
+uint32_t SiPixelCalibConfiguration::nColumnPatterns() const {
   uint32_t ncols = 0;
-  
-  for(std::vector<short>::const_iterator i=fColumnPattern.begin();i!=fColumnPattern.end();++i){
-    if(*i == -1)
-    ncols++;
+
+  for (std::vector<short>::const_iterator i = fColumnPattern.begin(); i != fColumnPattern.end(); ++i) {
+    if (*i == -1)
+      ncols++;
   }
   return ncols;
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelDbItem.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelDbItem.cc
@@ -3,15 +3,14 @@
 #include <iostream>
 #include <algorithm>
 
-
 //! The logic of individual setters:
 //! First, we put the new value into newXXX, which is a 32-bit word
-//! which has the new value at the bits where it should go, and 0's 
+//! which has the new value at the bits where it should go, and 0's
 //! everywhere else.  To make it, we:
 //! - assign the value
 //! - AND with a mask -- so all others are zeroes
 //! - shift up by noise_shift bits
-//! 
+//!
 //! Next, we prepare the oldValue with a whole where newXXX needs to go.
 //!  ~(mask << shift) has 1's everywhere except where the new value will go,
 //! so AND-ing packedVal_ with it creates a `whole' for the new value.
@@ -24,90 +23,73 @@
 //!   The new number is now positioned to be ff ff a2 ff, and then we AND these
 //!   two and get 00 03 a2 02.  We have replaced c3 with a2.
 
-
-void SiPixelDbItem::setNoise (short n)
-{
+void SiPixelDbItem::setNoise(short n) {
   PackedPixDbType newNoise = (n & packing_.noise_mask) << packing_.noise_shift;
-  PackedPixDbType oldValue = packedVal_ & ( ~(packing_.noise_mask << packing_.noise_shift) );
+  PackedPixDbType oldValue = packedVal_ & (~(packing_.noise_mask << packing_.noise_shift));
   packedVal_ = oldValue | newNoise;
 }
 
-void SiPixelDbItem::setPedestal (short p)
-{
+void SiPixelDbItem::setPedestal(short p) {
   PackedPixDbType newPedestal = (p & packing_.pedestal_mask) << packing_.pedestal_shift;
-  PackedPixDbType oldValue = packedVal_ & ( ~(packing_.pedestal_mask << packing_.pedestal_shift) );
+  PackedPixDbType oldValue = packedVal_ & (~(packing_.pedestal_mask << packing_.pedestal_shift));
   packedVal_ = oldValue | newPedestal;
 }
 
-void SiPixelDbItem::setGain (float g)
-{
+void SiPixelDbItem::setGain(float g) {
   // Convert gain into a shifted-integer
-  int mult_factor = 1 << packing_.gain_shift;   // TO DO: check
-  unsigned short gInIntRep = int( g * mult_factor );
+  int mult_factor = 1 << packing_.gain_shift;  // TO DO: check
+  unsigned short gInIntRep = int(g * mult_factor);
 
   PackedPixDbType newGain = (gInIntRep & packing_.gain_mask) << packing_.gain_shift;
-  PackedPixDbType oldValue = packedVal_ & ( ~(packing_.gain_mask << packing_.gain_shift) );
+  PackedPixDbType oldValue = packedVal_ & (~(packing_.gain_mask << packing_.gain_shift));
   packedVal_ = oldValue | newGain;
 }
 
-void SiPixelDbItem::setStatus (char s)
-{
+void SiPixelDbItem::setStatus(char s) {
   PackedPixDbType newStatus = (s & packing_.status_mask) << packing_.status_shift;
-  PackedPixDbType oldValue = packedVal_ & ( ~(packing_.status_mask << packing_.status_shift) );
+  PackedPixDbType oldValue = packedVal_ & (~(packing_.status_mask << packing_.status_shift));
   packedVal_ = oldValue | newStatus;
 }
 
-
-
 //! A fast version which sets all in one go.
-void SiPixelDbItem::set( short noise, short pedestal, float gain, char status) 
-{
+void SiPixelDbItem::set(short noise, short pedestal, float gain, char status) {
   // Convert gain into a shifted-integer
-  int mult_factor = 1 << packing_.gain_shift;   // TO DO: check usage here
-  unsigned short gInIntRep = int( gain * mult_factor );
+  int mult_factor = 1 << packing_.gain_shift;  // TO DO: check usage here
+  unsigned short gInIntRep = int(gain * mult_factor);
 
-  packedVal_ = 
-    (noise     << packing_.noise_shift)     | 
-    (pedestal  << packing_.pedestal_shift)  | 
-    (gInIntRep << packing_.gain_shift)      |
-    (status    << packing_.status_shift);
+  packedVal_ = (noise << packing_.noise_shift) | (pedestal << packing_.pedestal_shift) |
+               (gInIntRep << packing_.gain_shift) | (status << packing_.status_shift);
 }
 
-
-
-
-SiPixelDbItem::Packing::Packing(int noise_w, int pedestal_w, 
-				int gain_w, int status_w)
-  : noise_width(noise_w), pedestal_width(pedestal_w), status_width(status_w) 
-{
+SiPixelDbItem::Packing::Packing(int noise_w, int pedestal_w, int gain_w, int status_w)
+    : noise_width(noise_w), pedestal_width(pedestal_w), status_width(status_w) {
   // Constructor: pre-computes masks and shifts from field widths
   // Order of fields (from right to left) is
   // noise, pedestal, gain, status count.
-  
-  if ( noise_w+pedestal_w+gain_w+status_w != 32) {
-    std::cout << std::endl << "Error in SiPixelDbItem::Packing constructor:" 
-	      << "sum of field widths != 32" << std::endl;
+
+  if (noise_w + pedestal_w + gain_w + status_w != 32) {
+    std::cout << std::endl
+              << "Error in SiPixelDbItem::Packing constructor:"
+              << "sum of field widths != 32" << std::endl;
     // TO DO: throw an exception?
   }
 
   // Fields are counted from right to left!
-  
-  noise_shift     = 0;
-  pedestal_shift  = noise_shift + noise_w;
-  gain_shift    = pedestal_shift + pedestal_w;
-  status_shift     = gain_shift + gain_w;
 
-  // Ensure the complement of the correct 
+  noise_shift = 0;
+  pedestal_shift = noise_shift + noise_w;
+  gain_shift = pedestal_shift + pedestal_w;
+  status_shift = gain_shift + gain_w;
+
+  // Ensure the complement of the correct
   // number of bits:
   PackedPixDbType zero32 = 0;  // 32-bit wide
 
-  noise_mask     = ~(~zero32 << noise_w);
-  pedestal_mask  = ~(~zero32 << pedestal_w);
-  gain_mask    = ~(~zero32 << gain_w);
-  status_mask     = ~(~zero32 << status_w);
+  noise_mask = ~(~zero32 << noise_w);
+  pedestal_mask = ~(~zero32 << pedestal_w);
+  gain_mask = ~(~zero32 << gain_w);
+  status_mask = ~(~zero32 << status_w);
 }
 
 //  Initialize the packing (order is: noise, pedestal, gain, status)
-SiPixelDbItem::Packing SiPixelDbItem::packing_( 8, 8, 8, 8);  // TO DO: TBD
-
-
+SiPixelDbItem::Packing SiPixelDbItem::packing_(8, 8, 8, 8);  // TO DO: TBD

--- a/CondFormats/SiPixelObjects/src/SiPixelDetSummary.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelDetSummary.cc
@@ -6,115 +6,113 @@
 using namespace std;
 
 // ----------------------------------------------------------------------
-SiPixelDetSummary::SiPixelDetSummary(int verbose): fComputeMean(true), fVerbose(verbose) {
-
+SiPixelDetSummary::SiPixelDetSummary(int verbose) : fComputeMean(true), fVerbose(verbose) {
   unsigned int layers[] = {3, 4};
-  unsigned index = 0; 
+  unsigned index = 0;
 
   for (unsigned int idet = 0; idet < 2; ++idet) {
     for (unsigned int il = 0; il < layers[idet]; ++il) {
-      index = (idet+1)*10000 + (il+1)*1000; 
-      if (fVerbose) cout << "Adding index = " << index << endl;
-      fCountMap[index] = 0; 
+      index = (idet + 1) * 10000 + (il + 1) * 1000;
+      if (fVerbose)
+        cout << "Adding index = " << index << endl;
+      fCountMap[index] = 0;
     }
   }
 }
 
-
 // ----------------------------------------------------------------------
-void SiPixelDetSummary::add(const DetId & detid) {
-  fComputeMean= false; 
-  add(detid, 0.); 
+void SiPixelDetSummary::add(const DetId& detid) {
+  fComputeMean = false;
+  add(detid, 0.);
 }
 
-
 // ----------------------------------------------------------------------
-void SiPixelDetSummary::add(const DetId & detid, const float & value) {
-  
+void SiPixelDetSummary::add(const DetId& detid, const float& value) {
   int detNum = -1;
-  int idet(-1), il(-1); 
+  int idet(-1), il(-1);
   string name;
 
   switch (detid.subdetId()) {
-  case PixelSubdetector::PixelBarrel: {
-    idet = 1;
-    il   = PixelBarrelName(detid).layerName();
-    name = PixelBarrelName(detid).name();
-    break;
-  }
-  case PixelSubdetector::PixelEndcap: {
-    idet = 2;
-    PixelEndcapName::HalfCylinder hc = PixelEndcapName(detid).halfCylinder();
-    name = PixelEndcapName(detid).name();
-    if (hc == PixelEndcapName::pI || hc == PixelEndcapName::pO) {
-      il = 3 - PixelEndcapName(detid).diskName();
+    case PixelSubdetector::PixelBarrel: {
+      idet = 1;
+      il = PixelBarrelName(detid).layerName();
+      name = PixelBarrelName(detid).name();
+      break;
     }
-    if (hc == PixelEndcapName::mI || hc == PixelEndcapName::mO) {
-      il = 2 + PixelEndcapName(detid).diskName();
+    case PixelSubdetector::PixelEndcap: {
+      idet = 2;
+      PixelEndcapName::HalfCylinder hc = PixelEndcapName(detid).halfCylinder();
+      name = PixelEndcapName(detid).name();
+      if (hc == PixelEndcapName::pI || hc == PixelEndcapName::pO) {
+        il = 3 - PixelEndcapName(detid).diskName();
+      }
+      if (hc == PixelEndcapName::mI || hc == PixelEndcapName::mO) {
+        il = 2 + PixelEndcapName(detid).diskName();
+      }
+      break;
     }
-    break;
-  }
   }
 
-  detNum = idet*10000 + il*1000;
+  detNum = idet * 10000 + il * 1000;
 
   if (fVerbose > 0)
-    cout << "detNum: " << detNum 
-	 << " detID: " << static_cast<int>(detid) 
-	 << " " << name
-	 << endl;
+    cout << "detNum: " << detNum << " detID: " << static_cast<int>(detid) << " " << name << endl;
 
   fMeanMap[detNum] += value;
-  fRmsMap[detNum] += value*value;
+  fRmsMap[detNum] += value * value;
   fCountMap[detNum] += 1;
 }
 
 // ----------------------------------------------------------------------
-void SiPixelDetSummary::print(std::stringstream & ss, const bool mean) const {
-  std::map<int, int>::const_iterator countIt   = fCountMap.begin();
+void SiPixelDetSummary::print(std::stringstream& ss, const bool mean) const {
+  std::map<int, int>::const_iterator countIt = fCountMap.begin();
   std::map<int, double>::const_iterator meanIt = fMeanMap.begin();
-  std::map<int, double>::const_iterator rmsIt  = fRmsMap.begin();
-  
+  std::map<int, double>::const_iterator rmsIt = fRmsMap.begin();
+
   ss << "subDet" << setw(15) << "layer" << setw(16);
-  if (mean) ss << "mean +- rms" << endl;
-  else ss << "count" << endl;
+  if (mean)
+    ss << "mean +- rms" << endl;
+  else
+    ss << "count" << endl;
 
   std::string detector;
   std::string oldDetector;
 
-  for (; countIt != fCountMap.end(); ++countIt, ++meanIt, ++rmsIt ) {
+  for (; countIt != fCountMap.end(); ++countIt, ++meanIt, ++rmsIt) {
     int count = countIt->second;
     double mean = 0.;
     double rms = 0.;
     if (fComputeMean && count != 0) {
-      mean = (meanIt->second)/count;
-      rms = (rmsIt->second)/count - mean*mean;
+      mean = (meanIt->second) / count;
+      rms = (rmsIt->second) / count - mean * mean;
       if (rms <= 0)
-	rms = 0;
+        rms = 0;
       else
-	rms = sqrt(rms);
+        rms = sqrt(rms);
     }
 
     // -- Detector type
-    switch ((countIt->first)/10000) {
-    case 1:
-      detector = "BPIX";
-      break;
-    case 2:
-      detector = "FPIX";
-      break;
+    switch ((countIt->first) / 10000) {
+      case 1:
+        detector = "BPIX";
+        break;
+      case 2:
+        detector = "FPIX";
+        break;
     }
-    if( detector != oldDetector ) {
+    if (detector != oldDetector) {
       ss << std::endl << detector;
       oldDetector = detector;
-    }
-    else ss << "    ";
+    } else
+      ss << "    ";
 
     // -- Layer number
-    int layer = (countIt->first)/1000 - (countIt->first)/10000*10;
-    
-    ss << std::setw(15) << layer << std::setw(13) ;
-    if (fComputeMean) ss << mean << " +- " << rms << std::endl;
-    else ss << countIt->second << std::endl;
+    int layer = (countIt->first) / 1000 - (countIt->first) / 10000 * 10;
+
+    ss << std::setw(15) << layer << std::setw(13);
+    if (fComputeMean)
+      ss << mean << " +- " << rms << std::endl;
+    else
+      ss << countIt->second << std::endl;
   }
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelDisabledModules.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelDisabledModules.cc
@@ -11,36 +11,27 @@
 
 // add a list of modules to the vector of disabled modules
 void SiPixelDisabledModules::addDisabledModule(const disabledModuleListType& idVector) {
-  theDisabledModules.insert(theDisabledModules.end(),
-			    idVector.begin(),
-			    idVector.end());
+  theDisabledModules.insert(theDisabledModules.end(), idVector.begin(), idVector.end());
 
-} // void SiPixelDisabledModules::addDisabledModule(disabledModuleListType idVector)
-
+}  // void SiPixelDisabledModules::addDisabledModule(disabledModuleListType idVector)
 
 // remove disabled module from the list
 // returns false if id not in disable list, true otherwise
 bool SiPixelDisabledModules::removeDisabledModule(disabledModuleType module) {
-  disabledModuleListType::iterator iter = find(theDisabledModules.begin(),
-					      theDisabledModules.end(),
-					      module);
+  disabledModuleListType::iterator iter = find(theDisabledModules.begin(), theDisabledModules.end(), module);
   if (iter == theDisabledModules.end())
     return false;
-  
+
   theDisabledModules.erase(iter);
   return true;
 
-} // bool SiPixelDisabledModules::removeDisabledModule(disabledModuleType module)
-
+}  // bool SiPixelDisabledModules::removeDisabledModule(disabledModuleType module)
 
 // method to return true if the specified module is in the list
 // of disabled modules
 bool SiPixelDisabledModules::isModuleDisabled(disabledModuleType module) {
-  disabledModuleListType::const_iterator iter = find(theDisabledModules.begin(),
-						     theDisabledModules.end(),
-						     module);
+  disabledModuleListType::const_iterator iter = find(theDisabledModules.begin(), theDisabledModules.end(), module);
 
   return iter != theDisabledModules.end();
 
-} // bool SiPixelDisabledModules::isModuleDisabled(disabledModuleType module)
-
+}  // bool SiPixelDisabledModules::isModuleDisabled(disabledModuleType module)

--- a/CondFormats/SiPixelObjects/src/SiPixelDynamicInefficiency.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelDynamicInefficiency.cc
@@ -1,104 +1,119 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-SiPixelDynamicInefficiency::SiPixelDynamicInefficiency(){theInstLumiScaleFactor_=-9999;}
+SiPixelDynamicInefficiency::SiPixelDynamicInefficiency() { theInstLumiScaleFactor_ = -9999; }
 
-bool SiPixelDynamicInefficiency::putPixelGeomFactor (const uint32_t& detid, double& value){
-  std::map<unsigned int,double>::const_iterator id=m_PixelGeomFactors.find(detid);
-  if(id!=m_PixelGeomFactors.end()){
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency PixelGeomFactor for DetID " << detid << " is already stored. Skippig this put" << std::endl;
+bool SiPixelDynamicInefficiency::putPixelGeomFactor(const uint32_t& detid, double& value) {
+  std::map<unsigned int, double>::const_iterator id = m_PixelGeomFactors.find(detid);
+  if (id != m_PixelGeomFactors.end()) {
+    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency PixelGeomFactor for DetID " << detid
+                                                << " is already stored. Skippig this put" << std::endl;
     return false;
-  }
-  else m_PixelGeomFactors[detid]=value;
+  } else
+    m_PixelGeomFactors[detid] = value;
   return true;
 }
 
-double SiPixelDynamicInefficiency::getPixelGeomFactor (const uint32_t& detid) const  {
-  std::map<unsigned int,double>::const_iterator id=m_PixelGeomFactors.find(detid);
-  if(id!=m_PixelGeomFactors.end()) return id->second;
+double SiPixelDynamicInefficiency::getPixelGeomFactor(const uint32_t& detid) const {
+  std::map<unsigned int, double>::const_iterator id = m_PixelGeomFactors.find(detid);
+  if (id != m_PixelGeomFactors.end())
+    return id->second;
   else {
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency PixelGeomFactor for DetID " << detid << " is not stored" << std::endl; 
-  } 
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency PixelGeomFactor for DetID " << detid << " is not stored" << std::endl;
+  }
   return 0;
 }
 
-bool SiPixelDynamicInefficiency::putColGeomFactor (const uint32_t& detid, double& value){
-  std::map<unsigned int,double>::const_iterator id=m_ColGeomFactors.find(detid);
-  if(id!=m_ColGeomFactors.end()){
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency ColGeomFactor for DetID " << detid << " is already stored. Skippig this put" << std::endl;
+bool SiPixelDynamicInefficiency::putColGeomFactor(const uint32_t& detid, double& value) {
+  std::map<unsigned int, double>::const_iterator id = m_ColGeomFactors.find(detid);
+  if (id != m_ColGeomFactors.end()) {
+    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency ColGeomFactor for DetID " << detid
+                                                << " is already stored. Skippig this put" << std::endl;
     return false;
-  }
-  else m_ColGeomFactors[detid]=value;
+  } else
+    m_ColGeomFactors[detid] = value;
   return true;
 }
 
-double SiPixelDynamicInefficiency::getColGeomFactor (const uint32_t& detid) const  {
-  std::map<unsigned int,double>::const_iterator id=m_ColGeomFactors.find(detid);
-  if(id!=m_ColGeomFactors.end()) return id->second;
+double SiPixelDynamicInefficiency::getColGeomFactor(const uint32_t& detid) const {
+  std::map<unsigned int, double>::const_iterator id = m_ColGeomFactors.find(detid);
+  if (id != m_ColGeomFactors.end())
+    return id->second;
   else {
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency ColGeomFactor for DetID " << detid << " is not stored" << std::endl; 
-  } 
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency ColGeomFactor for DetID " << detid << " is not stored" << std::endl;
+  }
   return 0;
 }
 
-bool SiPixelDynamicInefficiency::putChipGeomFactor (const uint32_t& detid, double& value){
-  std::map<unsigned int,double>::const_iterator id=m_ChipGeomFactors.find(detid);
-  if(id!=m_ChipGeomFactors.end()){
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency ChipGeomFactor for DetID " << detid << " is already stored. Skippig this put" << std::endl;
+bool SiPixelDynamicInefficiency::putChipGeomFactor(const uint32_t& detid, double& value) {
+  std::map<unsigned int, double>::const_iterator id = m_ChipGeomFactors.find(detid);
+  if (id != m_ChipGeomFactors.end()) {
+    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency ChipGeomFactor for DetID " << detid
+                                                << " is already stored. Skippig this put" << std::endl;
     return false;
-  }
-  else m_ChipGeomFactors[detid]=value;
+  } else
+    m_ChipGeomFactors[detid] = value;
   return true;
 }
 
-double SiPixelDynamicInefficiency::getChipGeomFactor (const uint32_t& detid) const  {
-  std::map<unsigned int,double>::const_iterator id=m_ChipGeomFactors.find(detid);
-  if(id!=m_ChipGeomFactors.end()) return id->second;
+double SiPixelDynamicInefficiency::getChipGeomFactor(const uint32_t& detid) const {
+  std::map<unsigned int, double>::const_iterator id = m_ChipGeomFactors.find(detid);
+  if (id != m_ChipGeomFactors.end())
+    return id->second;
   else {
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency ChipGeomFactor for DetID " << detid << " is not stored" << std::endl; 
-  } 
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency ChipGeomFactor for DetID " << detid << " is not stored" << std::endl;
+  }
   return 0;
 }
 
-bool SiPixelDynamicInefficiency::putPUFactor (const uint32_t& detid, std::vector<double>& v_value){
-  std::map<unsigned int,std::vector<double> >::const_iterator id=m_PUFactors.find(detid);
-  if(id!=m_PUFactors.end()){
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency PUFactor for DetID " << detid << " is already stored. Skippig this put" << std::endl;
+bool SiPixelDynamicInefficiency::putPUFactor(const uint32_t& detid, std::vector<double>& v_value) {
+  std::map<unsigned int, std::vector<double> >::const_iterator id = m_PUFactors.find(detid);
+  if (id != m_PUFactors.end()) {
+    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency PUFactor for DetID " << detid
+                                                << " is already stored. Skippig this put" << std::endl;
     return false;
-  }
-  else m_PUFactors[detid]=v_value;
+  } else
+    m_PUFactors[detid] = v_value;
   return true;
 }
 
-std::vector<double> SiPixelDynamicInefficiency::getPUFactor (const uint32_t& detid) const {
-  std::map<unsigned int,std::vector<double> >::const_iterator id=m_PUFactors.find(detid);
-  if(id!=m_PUFactors.end()) return id->second;
+std::vector<double> SiPixelDynamicInefficiency::getPUFactor(const uint32_t& detid) const {
+  std::map<unsigned int, std::vector<double> >::const_iterator id = m_PUFactors.find(detid);
+  if (id != m_PUFactors.end())
+    return id->second;
   else {
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency PUFactor for DetID " << detid << " is not stored" << std::endl; 
-  } 
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency PUFactor for DetID " << detid << " is not stored" << std::endl;
+  }
   std::vector<double> empty;
   return empty;
 }
 
-bool SiPixelDynamicInefficiency::putDetIdmask(uint32_t& mask){
-  for (unsigned int i=0;i<v_DetIdmasks.size();i++) if (mask == v_DetIdmasks.at(i)) return false;
+bool SiPixelDynamicInefficiency::putDetIdmask(uint32_t& mask) {
+  for (unsigned int i = 0; i < v_DetIdmasks.size(); i++)
+    if (mask == v_DetIdmasks.at(i))
+      return false;
   v_DetIdmasks.push_back(mask);
   return true;
 }
-uint32_t SiPixelDynamicInefficiency::getDetIdmask(unsigned int& i) const{
+uint32_t SiPixelDynamicInefficiency::getDetIdmask(unsigned int& i) const {
   if (v_DetIdmasks.size() <= i) {
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency DetIdmask "<<i<<" is not stored!" << std::endl;
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency DetIdmask " << i << " is not stored!" << std::endl;
     return 0;
-  }
-  else return v_DetIdmasks.at(i);
+  } else
+    return v_DetIdmasks.at(i);
 }
 
-bool SiPixelDynamicInefficiency::puttheInstLumiScaleFactor(double& theInstLumiScaleFactor){
-  if (theInstLumiScaleFactor_ != -9999){
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency theInstLumiScaleFactor is already stored! Skippig this put!" << std::endl;
+bool SiPixelDynamicInefficiency::puttheInstLumiScaleFactor(double& theInstLumiScaleFactor) {
+  if (theInstLumiScaleFactor_ != -9999) {
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency theInstLumiScaleFactor is already stored! Skippig this put!" << std::endl;
     return false;
-  }
-  else {
+  } else {
     theInstLumiScaleFactor_ = theInstLumiScaleFactor;
     return true;
   }
@@ -106,8 +121,9 @@ bool SiPixelDynamicInefficiency::puttheInstLumiScaleFactor(double& theInstLumiSc
 
 double SiPixelDynamicInefficiency::gettheInstLumiScaleFactor() const {
   if (theInstLumiScaleFactor_ == -9999) {
-    edm::LogError("SiPixelDynamicInefficiency") << "SiPixelDynamicInefficiency theInstLumiScaleFactor is not stored!" << std::endl;
+    edm::LogError("SiPixelDynamicInefficiency")
+        << "SiPixelDynamicInefficiency theInstLumiScaleFactor is not stored!" << std::endl;
     return 0;
-  }
-  else return theInstLumiScaleFactor_;
+  } else
+    return theInstLumiScaleFactor_;
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelFEDChannelContainer.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFEDChannelContainer.cc
@@ -1,114 +1,117 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h"
-#include "FWCore/Utilities/interface/Exception.h" 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
-#include <iomanip>      // std::setw
+#include <iomanip>  // std::setw
 
 //****************************************************************************//
-void SiPixelFEDChannelContainer::setScenario(const std::string &theScenarioId, const SiPixelFEDChannelCollection &theBadFEDChannels) {
-  if( m_scenarioMap.find(theScenarioId) != m_scenarioMap.end()){
-    edm::LogWarning("SiPixelFEDChannelContainer") << "Scenario: " <<theScenarioId <<" is already in the map!"<<std::endl;
+void SiPixelFEDChannelContainer::setScenario(const std::string &theScenarioId,
+                                             const SiPixelFEDChannelCollection &theBadFEDChannels) {
+  if (m_scenarioMap.find(theScenarioId) != m_scenarioMap.end()) {
+    edm::LogWarning("SiPixelFEDChannelContainer")
+        << "Scenario: " << theScenarioId << " is already in the map!" << std::endl;
     return;
   } else {
-    m_scenarioMap.emplace(theScenarioId,theBadFEDChannels);
+    m_scenarioMap.emplace(theScenarioId, theBadFEDChannels);
   }
 }
 
 //****************************************************************************//
-SiPixelFEDChannelContainer::SiPixelFEDChannelCollection SiPixelFEDChannelContainer::getSiPixelBadFedChannels(const std::string &theScenarioId) const {
+SiPixelFEDChannelContainer::SiPixelFEDChannelCollection SiPixelFEDChannelContainer::getSiPixelBadFedChannels(
+    const std::string &theScenarioId) const {
   SiPixelBadFEDChannelsScenarioMap::const_iterator it = m_scenarioMap.find(theScenarioId);
 
-  if (it != m_scenarioMap.end()){
+  if (it != m_scenarioMap.end()) {
     return it->second;
   } else {
-    throw cms::Exception("SiPixelFEDChannelContainer")<< "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
+    throw cms::Exception("SiPixelFEDChannelContainer")
+        << "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
   }
 }
 
 //****************************************************************************//
-const SiPixelFEDChannelContainer::SiPixelFEDChannelCollection& SiPixelFEDChannelContainer::getSiPixelBadFedChannels(const std::string &theScenarioId) {
+const SiPixelFEDChannelContainer::SiPixelFEDChannelCollection &SiPixelFEDChannelContainer::getSiPixelBadFedChannels(
+    const std::string &theScenarioId) {
   SiPixelBadFEDChannelsScenarioMap::const_iterator it = m_scenarioMap.find(theScenarioId);
 
-  if (it != m_scenarioMap.end()){
+  if (it != m_scenarioMap.end()) {
     return it->second;
   } else {
-    throw cms::Exception("SiPixelFEDChannelContainer")<< "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
+    throw cms::Exception("SiPixelFEDChannelContainer")
+        << "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
   }
 }
 
 //****************************************************************************//
-const std::vector<PixelFEDChannel>& SiPixelFEDChannelContainer::getSiPixelBadFedChannelsInDetId(const std::string &theScenarioId,DetId theDetId) {
-
+const std::vector<PixelFEDChannel> &SiPixelFEDChannelContainer::getSiPixelBadFedChannelsInDetId(
+    const std::string &theScenarioId, DetId theDetId) {
   SiPixelBadFEDChannelsScenarioMap::const_iterator it = m_scenarioMap.find(theScenarioId);
 
-  if(it == m_scenarioMap.end()){
-    throw cms::Exception("SiPixelFEDChannelContainer")<< "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
+  if (it == m_scenarioMap.end()) {
+    throw cms::Exception("SiPixelFEDChannelContainer")
+        << "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
   } else {
-
     SiPixelFEDChannelCollection::const_iterator it2 = (it->second).find(theDetId);
 
-    if(it2 == (it->second).end()){
-      throw cms::Exception("SiPixelFEDChannelContainer")<< "No Bad Pixel FEDChannels defined for DetId:" <<theDetId <<" in Scenario id: " << theScenarioId << "\n";
+    if (it2 == (it->second).end()) {
+      throw cms::Exception("SiPixelFEDChannelContainer")
+          << "No Bad Pixel FEDChannels defined for DetId:" << theDetId << " in Scenario id: " << theScenarioId << "\n";
     }
     return it2->second;
   }
 }
 
 //****************************************************************************//
-std::unique_ptr<PixelFEDChannelCollection> SiPixelFEDChannelContainer::getDetSetBadPixelFedChannels(const std::string &theScenarioId) const {
-
+std::unique_ptr<PixelFEDChannelCollection> SiPixelFEDChannelContainer::getDetSetBadPixelFedChannels(
+    const std::string &theScenarioId) const {
   SiPixelBadFEDChannelsScenarioMap::const_iterator it = m_scenarioMap.find(theScenarioId);
 
-  if(it == m_scenarioMap.end()){
-    throw cms::Exception("SiPixelFEDChannelContainer")<< "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
+  if (it == m_scenarioMap.end()) {
+    throw cms::Exception("SiPixelFEDChannelContainer")
+        << "No Bad Pixel FEDChannels defined for Scenario id: " << theScenarioId << "\n";
   }
 
-  std::unique_ptr<PixelFEDChannelCollection> disabled_channelcollection = std::make_unique<edmNew::DetSetVector<PixelFEDChannel> >();
+  std::unique_ptr<PixelFEDChannelCollection> disabled_channelcollection =
+      std::make_unique<edmNew::DetSetVector<PixelFEDChannel> >();
   auto SiPixelBadFedChannels = it->second;
-  for(const auto &entry : SiPixelBadFedChannels){
+  for (const auto &entry : SiPixelBadFedChannels) {
     disabled_channelcollection->insert(entry.first, entry.second.data(), entry.second.size());
   }
   return disabled_channelcollection;
 }
 
-
 //****************************************************************************//
 void SiPixelFEDChannelContainer::printAll() const {
-  
-  edm::LogVerbatim("SiPixelFEDChannelContainer")<<"SiPixelFEDChannelContainer::printAll()";
-  edm::LogVerbatim("SiPixelFEDChannelContainer")<<" ===================================================================================================================";
-  for(auto it = m_scenarioMap.begin(); it != m_scenarioMap.end() ; ++it){
-    edm::LogVerbatim("SiPixelFEDChannelContainer")<< "run :"<< it->first << "  \n ";
-    for (const auto& thePixelFEDChannel : it->second){
-      
+  edm::LogVerbatim("SiPixelFEDChannelContainer") << "SiPixelFEDChannelContainer::printAll()";
+  edm::LogVerbatim("SiPixelFEDChannelContainer") << " ================================================================="
+                                                    "==================================================";
+  for (auto it = m_scenarioMap.begin(); it != m_scenarioMap.end(); ++it) {
+    edm::LogVerbatim("SiPixelFEDChannelContainer") << "run :" << it->first << "  \n ";
+    for (const auto &thePixelFEDChannel : it->second) {
       DetId detId = thePixelFEDChannel.first;
-	
-      edm::LogVerbatim("SiPixelFEDChannelContainer")<< "DetId :"<< detId << "  \n ";
 
-      for(const auto& entry: thePixelFEDChannel.second) {
-	//unsigned int fed, link, roc_first, roc_last;
-	edm::LogVerbatim("SiPixelFEDChannelContainer")<< " fed : "<< entry.fed 
-						      << " link : "<< entry.link
-						      << " roc_first : "<< entry.roc_first
-						      << " roc_last: : "<< entry.roc_last;       
+      edm::LogVerbatim("SiPixelFEDChannelContainer") << "DetId :" << detId << "  \n ";
+
+      for (const auto &entry : thePixelFEDChannel.second) {
+        //unsigned int fed, link, roc_first, roc_last;
+        edm::LogVerbatim("SiPixelFEDChannelContainer")
+            << " fed : " << entry.fed << " link : " << entry.link << " roc_first : " << entry.roc_first
+            << " roc_last: : " << entry.roc_last;
       }
     }
   }
 }
 
 //****************************************************************************//
-void SiPixelFEDChannelContainer::print(std::ostream & os) const {
-  for(auto it = m_scenarioMap.begin(); it != m_scenarioMap.end() ; ++it){
-    os<< "run :"<< it->first << "  \n ";
-    for (const auto& thePixelFEDChannel : it->second){
-      
-      DetId detId = thePixelFEDChannel.first;	
-      os<< "DetId :"<< detId << "  \n ";
-      for(const auto& entry: thePixelFEDChannel.second) {
-	os<< " fed : "<< entry.fed 
-	  << " link : "<< entry.link
-	  << " roc_first : "<< entry.roc_first
-	  << " roc_last: : "<< entry.roc_last;       
+void SiPixelFEDChannelContainer::print(std::ostream &os) const {
+  for (auto it = m_scenarioMap.begin(); it != m_scenarioMap.end(); ++it) {
+    os << "run :" << it->first << "  \n ";
+    for (const auto &thePixelFEDChannel : it->second) {
+      DetId detId = thePixelFEDChannel.first;
+      os << "DetId :" << detId << "  \n ";
+      for (const auto &entry : thePixelFEDChannel.second) {
+        os << " fed : " << entry.fed << " link : " << entry.link << " roc_first : " << entry.roc_first
+           << " roc_last: : " << entry.roc_last;
       }
     }
   }
@@ -119,16 +122,16 @@ std::vector<std::string> SiPixelFEDChannelContainer::getScenarioList() const {
   std::vector<std::string> scenarios;
   scenarios.reserve(m_scenarioMap.size());
 
-  for(auto it = m_scenarioMap.begin(); it != m_scenarioMap.end() ; ++it){
+  for (auto it = m_scenarioMap.begin(); it != m_scenarioMap.end(); ++it) {
     scenarios.push_back(it->first);
   }
   return scenarios;
 }
 
 //****************************************************************************//
-std::ostream & operator<<( std::ostream & os,  SiPixelFEDChannelContainer FEDChannels) {
+std::ostream &operator<<(std::ostream &os, SiPixelFEDChannelContainer FEDChannels) {
   std::stringstream ss;
-  FEDChannels.print( ss );
+  FEDChannels.print(ss);
   os << ss.str();
   return os;
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -10,29 +10,31 @@
 using namespace sipixelobjects;
 
 void SiPixelFedCablingMap::initializeRocs() {
-
-  // OLD Method 
-  //for (auto & v : theMap) v.second.initFrameConversion(); 
+  // OLD Method
+  //for (auto & v : theMap) v.second.initFrameConversion();
   // below is the new code, works for phase0 and phase1
 
   // Decide if it is phase0 or phase1 based on the first fed, 0-phase0, 1200-phase1
-  unsigned int fedId = (theMap.begin())->first.fed; // get the first fed
+  unsigned int fedId = (theMap.begin())->first.fed;  // get the first fed
 
-  // Specifically for CMSSW_9_0_X, we need to call a different version of the frame 
+  // Specifically for CMSSW_9_0_X, we need to call a different version of the frame
   // conversion steered by the version name in the cabling map
-  if (theVersion.find("CMSSW_9_0_X")!=std::string::npos) {
-    for (auto & v : theMap) v.second.initFrameConversionPhase1_CMSSW_9_0_X(); // works
-    std::cout<<"*** Found CMSSW_9_0_X specific cabling map\n";
+  if (theVersion.find("CMSSW_9_0_X") != std::string::npos) {
+    for (auto &v : theMap)
+      v.second.initFrameConversionPhase1_CMSSW_9_0_X();  // works
+    std::cout << "*** Found CMSSW_9_0_X specific cabling map\n";
     return;
   }
 
-  if(fedId>=FEDNumbering::MINSiPixeluTCAFEDID) { // phase1 >= 1200
-    for (auto & v : theMap) v.second.initFrameConversionPhase1(); // works
-  } else { // phase0
-    for (auto & v : theMap) v.second.initFrameConversion(); // works
+  if (fedId >= FEDNumbering::MINSiPixeluTCAFEDID) {  // phase1 >= 1200
+    for (auto &v : theMap)
+      v.second.initFrameConversionPhase1();  // works
+  } else {                                   // phase0
+    for (auto &v : theMap)
+      v.second.initFrameConversion();  // works
   }
-  
-  // if(0) {  // for testing 
+
+  // if(0) {  // for testing
   //   for (Map::iterator im = theMap.begin(); im != theMap.end(); im++) {
   //     unsigned int fedId = im->first.fed;
   //     unsigned int linkId = im->first.link;
@@ -42,70 +44,69 @@ void SiPixelFedCablingMap::initializeRocs() {
   //     auto idInLink = im->second.idInLink();
   //     //auto v = *im;
   //     if(fedId>=1200) {
-  // 	//v.second.initFrameConversionPhase1(); //  
-  // 	im->second.initFrameConversionPhase1(); // 
+  // 	//v.second.initFrameConversionPhase1(); //
+  // 	im->second.initFrameConversionPhase1(); //
   //     } else {
   // 	im->second.initFrameConversion();
   //     }
-  //   } //  
+  //   } //
   // } // end if(0)
-
 }
 
+bool SiPixelFedCablingMap::Key::operator<(const Key &other) const {
+  if (fed < other.fed)
+    return true;
+  if (fed > other.fed)
+    return false;
 
-bool SiPixelFedCablingMap::Key::operator < (const Key & other) const 
-{
-  if (fed < other.fed) return true;
-  if (fed > other.fed) return false;
+  if (link < other.link)
+    return true;
+  if (link > other.link)
+    return false;
 
-  if (link < other.link) return true;
-  if (link > other.link) return false;
-
-  if (roc < other.roc) return true;
-  if (roc > other.roc) return false;
+  if (roc < other.roc)
+    return true;
+  if (roc > other.roc)
+    return false;
 
   return false;
 }
 
-SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab) 
-  : theVersion(cab->version())
-{
-
-  // Never called  
+SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab) : theVersion(cab->version()) {
+  // Never called
   std::vector<const PixelFEDCabling *> fedList = cab->fedList();
-  for (std::vector<const PixelFEDCabling *>::const_iterator ifed=fedList.begin();
-   ifed != fedList.end(); ifed++) {
+  for (std::vector<const PixelFEDCabling *>::const_iterator ifed = fedList.begin(); ifed != fedList.end(); ifed++) {
     unsigned int fed = (**ifed).id();
     unsigned int numLink = (**ifed).numberOfLinks();
-    for (unsigned int link=1; link <= numLink; link++) {
-      const PixelFEDLink * pLink = (**ifed).link(link); 
-      if (pLink==nullptr) continue;
+    for (unsigned int link = 1; link <= numLink; link++) {
+      const PixelFEDLink *pLink = (**ifed).link(link);
+      if (pLink == nullptr)
+        continue;
       //unsigned int linkId = pLink->id();
-      //if (linkId != 0 && linkId!= link) 
+      //if (linkId != 0 && linkId!= link)
       //  std::cout << "PROBLEM WITH LINK NUMBER!!!!" << std::endl;
-      unsigned int numberROC = pLink->numberOfROCs(); 
+      unsigned int numberROC = pLink->numberOfROCs();
 
-      for (unsigned int roc=1; roc <= numberROC; roc++) {
-        const PixelROC * pROC = pLink->roc(roc);
-        if (pROC==nullptr) continue;
-        //if (pROC->idInLink() != roc) 
-	//  std::cout << "PROBLEM WITH ROC NUMBER!!!!" << std::endl;
-        Key key = {fed, link, roc}; 
+      for (unsigned int roc = 1; roc <= numberROC; roc++) {
+        const PixelROC *pROC = pLink->roc(roc);
+        if (pROC == nullptr)
+          continue;
+        //if (pROC->idInLink() != roc)
+        //  std::cout << "PROBLEM WITH ROC NUMBER!!!!" << std::endl;
+        Key key = {fed, link, roc};
         theMap[key] = (*pROC);
       }
-    } 
-  } // fed loop   
- 
+    }
+  }  // fed loop
 }
 
-std::unique_ptr<SiPixelFedCablingTree>  SiPixelFedCablingMap::cablingTree() const {
-
-  std::unique_ptr<SiPixelFedCablingTree>  tree(new SiPixelFedCablingTree(theVersion)); 
+std::unique_ptr<SiPixelFedCablingTree> SiPixelFedCablingMap::cablingTree() const {
+  std::unique_ptr<SiPixelFedCablingTree> tree(new SiPixelFedCablingTree(theVersion));
   for (Map::const_iterator im = theMap.begin(); im != theMap.end(); im++) {
-    const sipixelobjects::PixelROC & roc = im->second;
+    const sipixelobjects::PixelROC &roc = im->second;
     unsigned int fedId = im->first.fed;
     unsigned int linkId = im->first.link;
-    tree->addItem(fedId, linkId,  roc);
+    tree->addItem(fedId, linkId, roc);
   }
   return tree;
 }
@@ -114,22 +115,22 @@ std::vector<unsigned int> SiPixelFedCablingMap::fedIds() const {
   std::vector<unsigned int> result;
   for (Map::const_iterator im = theMap.begin(); im != theMap.end(); im++) {
     unsigned int fedId = im->first.fed;
-    if (find(result.begin(),result.end(),fedId) == result.end()) result.push_back(fedId);
+    if (find(result.begin(), result.end(), fedId) == result.end())
+      result.push_back(fedId);
   }
   return result;
 }
 
-const sipixelobjects::PixelROC* SiPixelFedCablingMap::findItem(
-    const sipixelobjects::CablingPathToDetUnit & path) const {
-  const PixelROC* roc = nullptr;
+const sipixelobjects::PixelROC *SiPixelFedCablingMap::findItem(const sipixelobjects::CablingPathToDetUnit &path) const {
+  const PixelROC *roc = nullptr;
   Key key = {path.fed, path.link, path.roc};
   Map::const_iterator inMap = theMap.find(key);
-  if (inMap!= theMap.end()) roc = &(inMap->second);
+  if (inMap != theMap.end())
+    roc = &(inMap->second);
   return roc;
 }
 
-
-std::unordered_map<uint32_t, unsigned int>  SiPixelFedCablingMap::det2fedMap() const {
+std::unordered_map<uint32_t, unsigned int> SiPixelFedCablingMap::det2fedMap() const {
   std::unordered_map<uint32_t, unsigned int> result;
   for (auto im = theMap.begin(); im != theMap.end(); ++im) {
     result[im->second.rawId()] = im->first.fed;  // we know: a det is in only one fed!
@@ -137,8 +138,8 @@ std::unordered_map<uint32_t, unsigned int>  SiPixelFedCablingMap::det2fedMap() c
   return result;
 }
 
-std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > SiPixelFedCablingMap::det2PathMap() const {
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > result;
+std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > SiPixelFedCablingMap::det2PathMap() const {
+  std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > result;
   for (auto im = theMap.begin(); im != theMap.end(); ++im) {
     CablingPathToDetUnit path = {im->first.fed, im->first.link, im->first.roc};
     result[im->second.rawId()].push_back(path);
@@ -146,13 +147,10 @@ std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > SiPixelFe
   return result;
 }
 
-
-std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingMap::pathToDetUnit(
-      uint32_t rawDetId) const {
-
+std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingMap::pathToDetUnit(uint32_t rawDetId) const {
   std::vector<sipixelobjects::CablingPathToDetUnit> result;
   for (auto im = theMap.begin(); im != theMap.end(); ++im) {
-    if(im->second.rawId()==rawDetId ) {
+    if (im->second.rawId() == rawDetId) {
       CablingPathToDetUnit path = {im->first.fed, im->first.link, im->first.roc};
       result.push_back(path);
     }
@@ -161,14 +159,11 @@ std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingMap::pathToDe
 }
 
 bool SiPixelFedCablingMap::pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const {
-
   auto end = theMap.end();
-  for (auto im = theMap.lower_bound( {fedId, 0, 0} ); 
-       im != end and im->first.fed == fedId; ++im) {
-    if(im->second.rawId()==rawDetId ) {
+  for (auto im = theMap.lower_bound({fedId, 0, 0}); im != end and im->first.fed == fedId; ++im) {
+    if (im->second.rawId() == rawDetId) {
       return true;
     }
   }
   return false;
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingTree.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingTree.cc
@@ -8,22 +8,21 @@ using namespace sipixelobjects;
 
 typedef std::unordered_map<int, SiPixelFedCablingTree::PixelFEDCabling>::const_iterator IMAP;
 
-std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingTree::pathToDetUnit(
-      uint32_t rawDetId) const
-{
+std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingTree::pathToDetUnit(uint32_t rawDetId) const {
   std::vector<sipixelobjects::CablingPathToDetUnit> result;
   for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {
-    const PixelFEDCabling & aFed = im->second;
+    const PixelFEDCabling& aFed = im->second;
     for (unsigned int idxLink = 1; idxLink <= aFed.numberOfLinks(); idxLink++) {
-      const PixelFEDLink * link = aFed.link(idxLink);
-      if (!link) continue;
+      const PixelFEDLink* link = aFed.link(idxLink);
+      if (!link)
+        continue;
       unsigned int numberOfRocs = link->numberOfROCs();
-      for(unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
-        const PixelROC * roc = link->roc(idxRoc);
-        if (rawDetId == roc->rawId() ) {
+      for (unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
+        const PixelROC* roc = link->roc(idxRoc);
+        if (rawDetId == roc->rawId()) {
           CablingPathToDetUnit path = {aFed.id(), link->id(), roc->idInLink()};
           result.push_back(path);
-        } 
+        }
       }
     }
   }
@@ -32,17 +31,18 @@ std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingTree::pathToD
 
 bool SiPixelFedCablingTree::pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const {
   for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {
-    const PixelFEDCabling & aFed = im->second;
-    if(aFed.id() == fedId) {
+    const PixelFEDCabling& aFed = im->second;
+    if (aFed.id() == fedId) {
       for (unsigned int idxLink = 1; idxLink <= aFed.numberOfLinks(); idxLink++) {
-        const PixelFEDLink * link = aFed.link(idxLink);
-        if (!link) continue;
+        const PixelFEDLink* link = aFed.link(idxLink);
+        if (!link)
+          continue;
         unsigned int numberOfRocs = link->numberOfROCs();
-        for(unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
-          const PixelROC * roc = link->roc(idxRoc);
-          if (rawDetId == roc->rawId() ) {
+        for (unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
+          const PixelROC* roc = link->roc(idxRoc);
+          if (rawDetId == roc->rawId()) {
             return true;
-          } 
+          }
         }
       }
     }
@@ -53,29 +53,31 @@ bool SiPixelFedCablingTree::pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned 
 std::unordered_map<uint32_t, unsigned int> SiPixelFedCablingTree::det2fedMap() const {
   std::unordered_map<uint32_t, unsigned int> result;
   for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {
-    auto const & aFed = im->second;
+    auto const& aFed = im->second;
     for (unsigned int idxLink = 1; idxLink <= aFed.numberOfLinks(); idxLink++) {
       auto link = aFed.link(idxLink);
-      if (!link) continue;
+      if (!link)
+        continue;
       unsigned int numberOfRocs = link->numberOfROCs();
-      for(unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
+      for (unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
         auto roc = link->roc(idxRoc);
-        result[roc->rawId()]=aFed.id();  // we know that a det is in one fed only...
+        result[roc->rawId()] = aFed.id();  // we know that a det is in one fed only...
       }
     }
   }
   return result;
 }
 
-std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > SiPixelFedCablingTree::det2PathMap() const {
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > result;
+std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > SiPixelFedCablingTree::det2PathMap() const {
+  std::map<uint32_t, std::vector<sipixelobjects::CablingPathToDetUnit> > result;
   for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {
-    auto const & aFed = im->second;
+    auto const& aFed = im->second;
     for (unsigned int idxLink = 1; idxLink <= aFed.numberOfLinks(); idxLink++) {
       auto link = aFed.link(idxLink);
-      if (!link) continue;
+      if (!link)
+        continue;
       unsigned int numberOfRocs = link->numberOfROCs();
-      for(unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
+      for (unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
         auto roc = link->roc(idxRoc);
         CablingPathToDetUnit path = {aFed.id(), link->id(), roc->idInLink()};
         result[roc->rawId()].push_back(path);
@@ -85,24 +87,21 @@ std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > SiPixelFe
   return result;
 }
 
-void SiPixelFedCablingTree::addFed(const PixelFEDCabling & f)
-{
+void SiPixelFedCablingTree::addFed(const PixelFEDCabling& f) {
   int id = f.id();
   theFedCablings[id] = f;
 }
 
-const PixelFEDCabling * SiPixelFedCablingTree::fed(unsigned int id) const
-{
-  auto  it = theFedCablings.find(id);
-  return ( it == theFedCablings.end() ) ? nullptr : & (*it).second;
+const PixelFEDCabling* SiPixelFedCablingTree::fed(unsigned int id) const {
+  auto it = theFedCablings.find(id);
+  return (it == theFedCablings.end()) ? nullptr : &(*it).second;
 }
 
-string SiPixelFedCablingTree::print(int depth) const
-{
+string SiPixelFedCablingTree::print(int depth) const {
   ostringstream out;
-  if ( depth-- >=0 ) {
+  if (depth-- >= 0) {
     out << theVersion << endl;
-    for(IMAP it=theFedCablings.begin(); it != theFedCablings.end(); it++) {
+    for (IMAP it = theFedCablings.begin(); it != theFedCablings.end(); it++) {
       out << (*it).second.print(depth);
     }
   }
@@ -110,55 +109,50 @@ string SiPixelFedCablingTree::print(int depth) const
   return out.str();
 }
 
-std::vector<const PixelFEDCabling *> SiPixelFedCablingTree::fedList() const
-{
-  std::vector<const PixelFEDCabling *> result;
+std::vector<const PixelFEDCabling*> SiPixelFedCablingTree::fedList() const {
+  std::vector<const PixelFEDCabling*> result;
   for (IMAP im = theFedCablings.begin(); im != theFedCablings.end(); im++) {
-    result.push_back( &(im->second) );
+    result.push_back(&(im->second));
   }
-  std::sort(result.begin(),result.end(),[](const PixelFEDCabling * a,const PixelFEDCabling * b){return a->id()<b->id();});
+  std::sort(result.begin(), result.end(), [](const PixelFEDCabling* a, const PixelFEDCabling* b) {
+    return a->id() < b->id();
+  });
   return result;
-
 }
 
-void SiPixelFedCablingTree::addItem(unsigned int fedId, unsigned int linkId, const PixelROC& roc)
-{
-  PixelFEDCabling & cabling = theFedCablings[fedId];
-  if (cabling.id() != fedId) cabling=PixelFEDCabling(fedId);
-  cabling.addItem(linkId,roc);
+void SiPixelFedCablingTree::addItem(unsigned int fedId, unsigned int linkId, const PixelROC& roc) {
+  PixelFEDCabling& cabling = theFedCablings[fedId];
+  if (cabling.id() != fedId)
+    cabling = PixelFEDCabling(fedId);
+  cabling.addItem(linkId, roc);
 }
 
-const sipixelobjects::PixelROC* SiPixelFedCablingTree::findItem(
-								const CablingPathToDetUnit & path) const
-{
+const sipixelobjects::PixelROC* SiPixelFedCablingTree::findItem(const CablingPathToDetUnit& path) const {
   const PixelROC* roc = nullptr;
-  const PixelFEDCabling * aFed = fed(path.fed);
+  const PixelFEDCabling* aFed = fed(path.fed);
   if (aFed) {
-    const  PixelFEDLink * aLink = aFed->link(path.link);
-    if (aLink) roc = aLink->roc(path.roc);
+    const PixelFEDLink* aLink = aFed->link(path.link);
+    if (aLink)
+      roc = aLink->roc(path.roc);
   }
   return roc;
 }
 
-
-const sipixelobjects::PixelROC* SiPixelFedCablingTree::findItemInFed(
-								const CablingPathToDetUnit & path, 
-								const PixelFEDCabling * aFed) const
-{
+const sipixelobjects::PixelROC* SiPixelFedCablingTree::findItemInFed(const CablingPathToDetUnit& path,
+                                                                     const PixelFEDCabling* aFed) const {
   const PixelROC* roc = nullptr;
-  const  PixelFEDLink * aLink = aFed->link(path.link);
-  if (aLink) roc = aLink->roc(path.roc);
+  const PixelFEDLink* aLink = aFed->link(path.link);
+  if (aLink)
+    roc = aLink->roc(path.roc);
   return roc;
 }
 
-
-int SiPixelFedCablingTree::checkNumbering() const
-{
+int SiPixelFedCablingTree::checkNumbering() const {
   int status = 0;
   for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {
-    if (im->first != static_cast<int>( im->second.id())) {
+    if (im->first != static_cast<int>(im->second.id())) {
       status = 1;
-      std::cout <<  "PROBLEM WITH FED ID!!" << im->first <<" vs: "<< im->second.id() << std::endl; 
+      std::cout << "PROBLEM WITH FED ID!!" << im->first << " vs: " << im->second.id() << std::endl;
     }
     im->second.checkLinkNumbering();
   }

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
@@ -12,57 +12,50 @@ using namespace std;
 using namespace sipixelobjects;
 
 SiPixelFrameConverter::SiPixelFrameConverter(const SiPixelFedCabling* map, int fedId)
-  : theFedId(fedId), theMap(map),
-    theTree(dynamic_cast<SiPixelFedCablingTree const *>(map)),
-    theFed(theTree ? theTree->fed(fedId) : nullptr)
-{}
+    : theFedId(fedId),
+      theMap(map),
+      theTree(dynamic_cast<SiPixelFedCablingTree const*>(map)),
+      theFed(theTree ? theTree->fed(fedId) : nullptr) {}
 
-bool SiPixelFrameConverter::hasDetUnit(uint32_t rawId) const
-{
+bool SiPixelFrameConverter::hasDetUnit(uint32_t rawId) const {
   return theMap->pathToDetUnitHasDetUnit(rawId, static_cast<unsigned int>(theFedId));
 }
 
-
-PixelROC const * SiPixelFrameConverter::toRoc(int link, int roc) const {
-  CablingPathToDetUnit path = {static_cast<unsigned int>(theFedId),
-                               static_cast<unsigned int>(link),
-                               static_cast<unsigned int>(roc)}; 
-  const PixelROC * rocp = (theFed) ? theTree->findItemInFed(path, theFed) : theMap->findItem(path);
-  if UNLIKELY(!rocp){
-    stringstream stm;
-    stm << "Map shows no fed="<<theFedId
-        <<", link="<< link
-        <<", roc="<< roc;
-    edm::LogWarning("SiPixelFrameConverter") << stm.str();
-  }
+PixelROC const* SiPixelFrameConverter::toRoc(int link, int roc) const {
+  CablingPathToDetUnit path = {
+      static_cast<unsigned int>(theFedId), static_cast<unsigned int>(link), static_cast<unsigned int>(roc)};
+  const PixelROC* rocp = (theFed) ? theTree->findItemInFed(path, theFed) : theMap->findItem(path);
+  if
+    UNLIKELY(!rocp) {
+      stringstream stm;
+      stm << "Map shows no fed=" << theFedId << ", link=" << link << ", roc=" << roc;
+      edm::LogWarning("SiPixelFrameConverter") << stm.str();
+    }
   return rocp;
 }
 
-
-
-int SiPixelFrameConverter::toCabling(
-    ElectronicIndex & cabling, const DetectorIndex & detector) const 
-{
+int SiPixelFrameConverter::toCabling(ElectronicIndex& cabling, const DetectorIndex& detector) const {
   std::vector<CablingPathToDetUnit> path = theMap->pathToDetUnit(detector.rawId);
-  typedef  std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for  (IT it = path.begin(); it != path.end(); ++it) {
-    const PixelROC * roc = theMap->findItem(*it); 
-    if (!roc) return 2;
-    if (roc->rawId() != detector.rawId) return 3;
+  typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
+  for (IT it = path.begin(); it != path.end(); ++it) {
+    const PixelROC* roc = theMap->findItem(*it);
+    if (!roc)
+      return 2;
+    if (roc->rawId() != detector.rawId)
+      return 3;
 
     GlobalPixel global = {detector.row, detector.col};
     //LogTrace("")<<"GLOBAL PIXEL: row=" << global.row <<" col="<< global.col;
 
     LocalPixel local = roc->toLocal(global);
-    // LogTrace("")<<"LOCAL PIXEL: dcol =" 
+    // LogTrace("")<<"LOCAL PIXEL: dcol ="
     //<<  local.dcol()<<" pxid="<<  local.pxid()<<" inside: " <<local.valid();
 
-    if(!local.valid()) continue;
-    ElectronicIndex cabIdx = {static_cast<int>(it->link), 
-                              static_cast<int>(it->roc), local.dcol(), local.pxid()}; 
+    if (!local.valid())
+      continue;
+    ElectronicIndex cabIdx = {static_cast<int>(it->link), static_cast<int>(it->roc), local.dcol(), local.pxid()};
     cabling = cabIdx;
     return 0;
-  }  
+  }
   return 1;
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
@@ -23,50 +23,45 @@
 using namespace std;
 using namespace sipixelobjects;
 
-SiPixelFrameReverter::SiPixelFrameReverter(const edm::EventSetup& iSetup, const SiPixelFedCabling* map) 
-  : map_(map), DetToFedMap(map->det2PathMap()) 
-{ 
+SiPixelFrameReverter::SiPixelFrameReverter(const edm::EventSetup& iSetup, const SiPixelFedCabling* map)
+    : map_(map), DetToFedMap(map->det2PathMap()) {
   // Build map
   // buildStructure(iSetup);
 }
 
-
-void SiPixelFrameReverter::buildStructure(const edm::EventSetup& iSetup) 
-{
-
+void SiPixelFrameReverter::buildStructure(const edm::EventSetup& iSetup) {
   // Create map connecting each detId to appropriate SiPixelFrameConverter
 
   edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
+  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
 
-  for(auto it = pDD->dets().begin(); it != pDD->dets().end(); it++){
-    
-    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=nullptr){
-
+  for (auto it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
+    if (dynamic_cast<PixelGeomDetUnit const*>((*it)) != nullptr) {
       DetId detId = (*it)->geographicalId();
       uint32_t id = detId();
       std::vector<CablingPathToDetUnit> paths = map_->pathToDetUnit(id);
-      DetToFedMap.insert(pair< uint32_t,std::vector<CablingPathToDetUnit> > (id,paths));
-
+      DetToFedMap.insert(pair<uint32_t, std::vector<CablingPathToDetUnit> >(id, paths));
     }
   }  // for(TrackerGeometry::DetContainer::const_iterator
 }  // end buildStructure
 
-
-int SiPixelFrameReverter::toCabling(
-    sipixelobjects::ElectronicIndex & cabling, const sipixelobjects::DetectorIndex & detector) const
-{
-  if(!hasDetUnit(detector.rawId)) return -1;
+int SiPixelFrameReverter::toCabling(sipixelobjects::ElectronicIndex& cabling,
+                                    const sipixelobjects::DetectorIndex& detector) const {
+  if (!hasDetUnit(detector.rawId))
+    return -1;
   std::vector<CablingPathToDetUnit> path = DetToFedMap.find(detector.rawId)->second;
   typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for  (IT it = path.begin(); it != path.end(); ++it) {
-    const PixelROC * roc = map_->findItem(*it);
-    if (!roc) return -3;
-    if (roc->rawId() != detector.rawId) return -4;
+  for (IT it = path.begin(); it != path.end(); ++it) {
+    const PixelROC* roc = map_->findItem(*it);
+    if (!roc)
+      return -3;
+    if (roc->rawId() != detector.rawId)
+      return -4;
 
     GlobalPixel global = {detector.row, detector.col};
     LocalPixel local = roc->toLocal(global);
-    if(!local.valid()) continue;
+    if (!local.valid())
+      continue;
     ElectronicIndex cabIdx = {static_cast<int>(it->link), static_cast<int>(it->roc), local.dcol(), local.pxid()};
     cabling = cabIdx;
 
@@ -75,92 +70,94 @@ int SiPixelFrameReverter::toCabling(
   return -2;
 }
 
-
-int SiPixelFrameReverter::findFedId(uint32_t detId)
-{
-  if(!hasDetUnit(detId)) return -1;
+int SiPixelFrameReverter::findFedId(uint32_t detId) {
+  if (!hasDetUnit(detId))
+    return -1;
   std::vector<CablingPathToDetUnit> path = DetToFedMap.find(detId)->second;
-  int fedId = (int) path[0].fed;
+  int fedId = (int)path[0].fed;
   return fedId;
 }
 
-
-short SiPixelFrameReverter::findLinkInFed(uint32_t detId, GlobalPixel global)
-{
-  if(!hasDetUnit(detId)) return -1;
+short SiPixelFrameReverter::findLinkInFed(uint32_t detId, GlobalPixel global) {
+  if (!hasDetUnit(detId))
+    return -1;
   std::vector<CablingPathToDetUnit> path = DetToFedMap.find(detId)->second;
-  typedef  std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for  (IT it = path.begin(); it != path.end(); ++it) {
-    const PixelROC * roc = map_->findItem(*it);
-    if (!roc) continue;
+  typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
+  for (IT it = path.begin(); it != path.end(); ++it) {
+    const PixelROC* roc = map_->findItem(*it);
+    if (!roc)
+      continue;
 
     LocalPixel local = roc->toLocal(global);
 
-    if(!local.valid()) continue;
-    short link = (short) it->link;
+    if (!local.valid())
+      continue;
+    short link = (short)it->link;
     return link;
   }
   return -1;
 }
 
-
-short SiPixelFrameReverter::findRocInLink(uint32_t detId, GlobalPixel global)
-{
-  if(!hasDetUnit(detId)) return -1;
+short SiPixelFrameReverter::findRocInLink(uint32_t detId, GlobalPixel global) {
+  if (!hasDetUnit(detId))
+    return -1;
   std::vector<CablingPathToDetUnit> path = DetToFedMap.find(detId)->second;
-  typedef  std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for  (IT it = path.begin(); it != path.end(); ++it) {
-    const PixelROC * roc = map_->findItem(*it);
-    if (!roc) continue;
+  typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
+  for (IT it = path.begin(); it != path.end(); ++it) {
+    const PixelROC* roc = map_->findItem(*it);
+    if (!roc)
+      continue;
 
     LocalPixel local = roc->toLocal(global);
 
-    if(!local.valid()) continue;
-    short rocInLink = (short) roc->idInLink();
+    if (!local.valid())
+      continue;
+    short rocInLink = (short)roc->idInLink();
     return rocInLink;
   }
   return -1;
 }
 
-
-short SiPixelFrameReverter::findRocInDet(uint32_t detId, GlobalPixel global)
-{
-  if(!hasDetUnit(detId)) return -1;
+short SiPixelFrameReverter::findRocInDet(uint32_t detId, GlobalPixel global) {
+  if (!hasDetUnit(detId))
+    return -1;
   std::vector<CablingPathToDetUnit> path = DetToFedMap.find(detId)->second;
-  typedef  std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for  (IT it = path.begin(); it != path.end(); ++it) {
-    const PixelROC * roc = map_->findItem(*it);
-    if (!roc) continue;
+  typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
+  for (IT it = path.begin(); it != path.end(); ++it) {
+    const PixelROC* roc = map_->findItem(*it);
+    if (!roc)
+      continue;
 
     LocalPixel local = roc->toLocal(global);
 
-    if(!local.valid()) continue;
-    short rocInDet = (short) roc->idInDetUnit();
+    if (!local.valid())
+      continue;
+    short rocInDet = (short)roc->idInDetUnit();
     return rocInDet;
   }
   return -1;
 }
 
-
-LocalPixel SiPixelFrameReverter::findPixelInRoc(uint32_t detId, GlobalPixel global)
-{
-  if(!hasDetUnit(detId)) {
-    LocalPixel::RocRowCol pixel = {-1,-1};
+LocalPixel SiPixelFrameReverter::findPixelInRoc(uint32_t detId, GlobalPixel global) {
+  if (!hasDetUnit(detId)) {
+    LocalPixel::RocRowCol pixel = {-1, -1};
     LocalPixel local(pixel);
     return local;
   }
   std::vector<CablingPathToDetUnit> path = DetToFedMap.find(detId)->second;
-  typedef  std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for  (IT it = path.begin(); it != path.end(); ++it) {
-    const PixelROC * roc = map_->findItem(*it);
-    if (!roc) continue;
+  typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
+  for (IT it = path.begin(); it != path.end(); ++it) {
+    const PixelROC* roc = map_->findItem(*it);
+    if (!roc)
+      continue;
 
     LocalPixel local = roc->toLocal(global);
 
-    if(!local.valid()) continue;
+    if (!local.valid())
+      continue;
     return local;
   }
-  LocalPixel::RocRowCol pixel = {-1,-1};
+  LocalPixel::RocRowCol pixel = {-1, -1};
   LocalPixel local(pixel);
   return local;
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelGainCalibration.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelGainCalibration.cc
@@ -6,190 +6,183 @@
 //
 // Constructors
 //
-SiPixelGainCalibration::SiPixelGainCalibration() :
-  minPed_(0.),
-  maxPed_(255.),
-  minGain_(0.),
-  maxGain_(255.),
-  numberOfRowsToAverageOver_(1),
-  nBinsToUseForEncoding_(253),
-  deadFlag_(255),
-  noisyFlag_(254)
-{
-   if (deadFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibration::SiPixelGainCalibration] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
+SiPixelGainCalibration::SiPixelGainCalibration()
+    : minPed_(0.),
+      maxPed_(255.),
+      minGain_(0.),
+      maxGain_(255.),
+      numberOfRowsToAverageOver_(1),
+      nBinsToUseForEncoding_(253),
+      deadFlag_(255),
+      noisyFlag_(254) {
+  if (deadFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibration::SiPixelGainCalibration] Dead flag was set to " << deadFlag_
+        << ", and it must be set less than or equal to 255";
 }
 //
-SiPixelGainCalibration::SiPixelGainCalibration(float minPed, float maxPed, float minGain, float maxGain) :
-  minPed_(minPed),
-  maxPed_(maxPed),
-  minGain_(minGain),
-  maxGain_(maxGain),
-  numberOfRowsToAverageOver_(1),
-  nBinsToUseForEncoding_(253),
-  deadFlag_(255),
-  noisyFlag_(254)
-{
-   if (deadFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibration::SiPixelGainCalibration] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
+SiPixelGainCalibration::SiPixelGainCalibration(float minPed, float maxPed, float minGain, float maxGain)
+    : minPed_(minPed),
+      maxPed_(maxPed),
+      minGain_(minGain),
+      maxGain_(maxGain),
+      numberOfRowsToAverageOver_(1),
+      nBinsToUseForEncoding_(253),
+      deadFlag_(255),
+      noisyFlag_(254) {
+  if (deadFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibration::SiPixelGainCalibration] Dead flag was set to " << deadFlag_
+        << ", and it must be set less than or equal to 255";
 }
 
 bool SiPixelGainCalibration::put(const uint32_t& DetId, Range input, const int& nCols) {
   // put in SiPixelGainCalibration of DetId
 
-  Registry::iterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibration::StrictWeakOrdering());
-  if (p!=indexes.end() && p->detid==DetId)
+  Registry::iterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibration::StrictWeakOrdering());
+  if (p != indexes.end() && p->detid == DetId)
     return false;
-  
-  size_t sd= input.second-input.first;
-  DetRegistry detregistry;
-  detregistry.detid=DetId;
-  detregistry.ncols=nCols;
-  detregistry.ibegin=v_pedestals.size();
-  detregistry.iend=v_pedestals.size()+sd;
-  indexes.insert(p,detregistry);
 
-  v_pedestals.insert(v_pedestals.end(),input.first,input.second);
+  size_t sd = input.second - input.first;
+  DetRegistry detregistry;
+  detregistry.detid = DetId;
+  detregistry.ncols = nCols;
+  detregistry.ibegin = v_pedestals.size();
+  detregistry.iend = v_pedestals.size() + sd;
+  indexes.insert(p, detregistry);
+
+  v_pedestals.insert(v_pedestals.end(), input.first, input.second);
   return true;
 }
 
 const int SiPixelGainCalibration::getNCols(const uint32_t& DetId) const {
   // get number of columns of DetId
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibration::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibration::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
     return 0;
   else
-    return p->ncols; 
+    return p->ncols;
 }
 
 const SiPixelGainCalibration::Range SiPixelGainCalibration::getRange(const uint32_t& DetId) const {
   // get SiPixelGainCalibration Range of DetId
-  
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibration::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
-    return SiPixelGainCalibration::Range(v_pedestals.end(),v_pedestals.end()); 
-  else 
-    return SiPixelGainCalibration::Range(v_pedestals.begin()+p->ibegin,v_pedestals.begin()+p->iend);
+
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibration::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
+    return SiPixelGainCalibration::Range(v_pedestals.end(), v_pedestals.end());
+  else
+    return SiPixelGainCalibration::Range(v_pedestals.begin() + p->ibegin, v_pedestals.begin() + p->iend);
 }
 
-const std::pair<const SiPixelGainCalibration::Range, const int>
-SiPixelGainCalibration::getRangeAndNCols(const uint32_t& DetId) const {
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibration::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
-    return std::make_pair(SiPixelGainCalibration::Range(v_pedestals.end(),v_pedestals.end()), 0); 
-  else 
-    return std::make_pair(SiPixelGainCalibration::Range(v_pedestals.begin()+p->ibegin,v_pedestals.begin()+p->iend), p->ncols);
+const std::pair<const SiPixelGainCalibration::Range, const int> SiPixelGainCalibration::getRangeAndNCols(
+    const uint32_t& DetId) const {
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibration::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
+    return std::make_pair(SiPixelGainCalibration::Range(v_pedestals.end(), v_pedestals.end()), 0);
+  else
+    return std::make_pair(SiPixelGainCalibration::Range(v_pedestals.begin() + p->ibegin, v_pedestals.begin() + p->iend),
+                          p->ncols);
 }
-  
 
 void SiPixelGainCalibration::getDetIds(std::vector<uint32_t>& DetIds_) const {
   // returns vector of DetIds in map
   SiPixelGainCalibration::RegistryIterator begin = indexes.begin();
-  SiPixelGainCalibration::RegistryIterator end   = indexes.end();
-  for (SiPixelGainCalibration::RegistryIterator p=begin; p != end; ++p) {
+  SiPixelGainCalibration::RegistryIterator end = indexes.end();
+  for (SiPixelGainCalibration::RegistryIterator p = begin; p != end; ++p) {
     DetIds_.push_back(p->detid);
   }
 }
 
-void SiPixelGainCalibration::setData(float ped, float gain, std::vector<char>& vped, bool isDeadPixel, bool isNoisyPixel){
-  
-  float theEncodedGain=0;
-  float theEncodedPed=0;
-  if(!isDeadPixel && !isNoisyPixel){
+void SiPixelGainCalibration::setData(
+    float ped, float gain, std::vector<char>& vped, bool isDeadPixel, bool isNoisyPixel) {
+  float theEncodedGain = 0;
+  float theEncodedPed = 0;
+  if (!isDeadPixel && !isNoisyPixel) {
     theEncodedGain = encodeGain(gain);
-    theEncodedPed  = encodePed (ped);
+    theEncodedPed = encodePed(ped);
   }
 
-  unsigned int ped_   = (static_cast<unsigned int>(theEncodedPed))  & 0xFF; 
-  unsigned int gain_  = (static_cast<unsigned int>(theEncodedGain)) & 0xFF;
+  unsigned int ped_ = (static_cast<unsigned int>(theEncodedPed)) & 0xFF;
+  unsigned int gain_ = (static_cast<unsigned int>(theEncodedGain)) & 0xFF;
 
-  if (isDeadPixel)
-  {
-     ped_  = deadFlag_ & 0xFF;
-     gain_ = deadFlag_ & 0xFF;
+  if (isDeadPixel) {
+    ped_ = deadFlag_ & 0xFF;
+    gain_ = deadFlag_ & 0xFF;
   }
-  if (isNoisyPixel)
-  {
-     ped_  = noisyFlag_ & 0xFF;
-     gain_ = noisyFlag_ & 0xFF;
+  if (isNoisyPixel) {
+    ped_ = noisyFlag_ & 0xFF;
+    gain_ = noisyFlag_ & 0xFF;
   }
-  unsigned int data = (ped_ << 8) | gain_ ;
-  vped.resize(vped.size()+2);
+  unsigned int data = (ped_ << 8) | gain_;
+  vped.resize(vped.size() + 2);
   // insert in vector of char
-  ::memcpy((void*)(&vped[vped.size()-2]),(void*)(&data),2);
+  ::memcpy((void*)(&vped[vped.size() - 2]), (void*)(&data), 2);
 }
 
-float SiPixelGainCalibration::getPed(const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const {
-
-  int nRows = (range.second-range.first)/2 / nCols;
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first+(col*nRows + row)*2);
-  if (col >= nCols || row >= nRows){
+float SiPixelGainCalibration::getPed(
+    const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const {
+  int nRows = (range.second - range.first) / 2 / nCols;
+  const DecodingStructure& s = (const DecodingStructure&)*(range.first + (col * nRows + row) * 2);
+  if (col >= nCols || row >= nRows) {
     throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibration::getPed] Pixel out of range: col " << col << " row " << row;
-  }  
+        << "[SiPixelGainCalibration::getPed] Pixel out of range: col " << col << " row " << row;
+  }
   if ((s.ped & 0xFF) == deadFlag_)
-     isDead = true;  
+    isDead = true;
   if ((s.ped & 0xFF) == noisyFlag_)
-     isNoisy = true;
-  return decodePed(s.ped & 0xFF);  
+    isNoisy = true;
+  return decodePed(s.ped & 0xFF);
 }
 
-float SiPixelGainCalibration::getGain(const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const {
-
-  int nRows = (range.second-range.first)/2 / nCols;
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first+(col*nRows + row)*2);
-  if (col >= nCols || row >= nRows){
+float SiPixelGainCalibration::getGain(
+    const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const {
+  int nRows = (range.second - range.first) / 2 / nCols;
+  const DecodingStructure& s = (const DecodingStructure&)*(range.first + (col * nRows + row) * 2);
+  if (col >= nCols || row >= nRows) {
     throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibration::getPed] Pixel out of range: col " << col << " row " << row;
-  }  
+        << "[SiPixelGainCalibration::getPed] Pixel out of range: col " << col << " row " << row;
+  }
   if ((s.gain & 0xFF) == deadFlag_)
-     isDead = true;  
+    isDead = true;
   if ((s.gain & 0xFF) == noisyFlag_)
-     isNoisy = true;
+    isNoisy = true;
   return decodeGain(s.gain & 0xFF);
 }
 
-float SiPixelGainCalibration::encodeGain( const float& gain ) {
-  
-  if(gain < minGain_ || gain > maxGain_ ) {
-    throw cms::Exception("InsertFailure")
-      << "[SiPixelGainCalibration::encodeGain] Trying to encode gain (" << gain << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
+float SiPixelGainCalibration::encodeGain(const float& gain) {
+  if (gain < minGain_ || gain > maxGain_) {
+    throw cms::Exception("InsertFailure") << "[SiPixelGainCalibration::encodeGain] Trying to encode gain (" << gain
+                                          << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
   } else {
-    double precision   = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-    float  encodedGain = (float)((gain-minGain_)/precision);
+    double precision = (maxGain_ - minGain_) / static_cast<float>(nBinsToUseForEncoding_);
+    float encodedGain = (float)((gain - minGain_) / precision);
     return encodedGain;
   }
-
 }
 
-float SiPixelGainCalibration::encodePed( const float& ped ) {
-
-  if(ped < minPed_ || ped > maxPed_ ) {
-    throw cms::Exception("InsertFailure")
-      << "[SiPixelGainCalibration::encodePed] Trying to encode pedestal (" << ped << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
+float SiPixelGainCalibration::encodePed(const float& ped) {
+  if (ped < minPed_ || ped > maxPed_) {
+    throw cms::Exception("InsertFailure") << "[SiPixelGainCalibration::encodePed] Trying to encode pedestal (" << ped
+                                          << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
   } else {
-    double precision   = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-    float  encodedPed = (float)((ped-minPed_)/precision);
+    double precision = (maxPed_ - minPed_) / static_cast<float>(nBinsToUseForEncoding_);
+    float encodedPed = (float)((ped - minPed_) / precision);
     return encodedPed;
   }
-
 }
 
-float SiPixelGainCalibration::decodePed( unsigned int ped ) const {
-
-  double precision = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-  float decodedPed = (float)(ped*precision + minPed_);
+float SiPixelGainCalibration::decodePed(unsigned int ped) const {
+  double precision = (maxPed_ - minPed_) / static_cast<float>(nBinsToUseForEncoding_);
+  float decodedPed = (float)(ped * precision + minPed_);
   return decodedPed;
-
 }
 
-float SiPixelGainCalibration::decodeGain( unsigned int gain ) const {
-
-  double precision = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-  float decodedGain = (float)(gain*precision + minGain_);
+float SiPixelGainCalibration::decodeGain(unsigned int gain) const {
+  double precision = (maxGain_ - minGain_) / static_cast<float>(nBinsToUseForEncoding_);
+  float decodedGain = (float)(gain * precision + minGain_);
   return decodedGain;
-
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationForHLT.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationForHLT.cc
@@ -6,140 +6,144 @@
 //
 // Constructors
 //
-SiPixelGainCalibrationForHLT::SiPixelGainCalibrationForHLT() :
-  minPed_(0.),
-  maxPed_(255.),
-  minGain_(0.),
-  maxGain_(255.),
-  numberOfRowsToAverageOver_(80),
-  nBinsToUseForEncoding_(253),
-  deadFlag_(255),
-  noisyFlag_(254)
-{
+SiPixelGainCalibrationForHLT::SiPixelGainCalibrationForHLT()
+    : minPed_(0.),
+      maxPed_(255.),
+      minGain_(0.),
+      maxGain_(255.),
+      numberOfRowsToAverageOver_(80),
+      nBinsToUseForEncoding_(253),
+      deadFlag_(255),
+      noisyFlag_(254) {
   initialize();
-   if (deadFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibrationHLT::SiPixelGainCalibrationHLT] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
+  if (deadFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibrationHLT::SiPixelGainCalibrationHLT] Dead flag was set to " << deadFlag_
+        << ", and it must be set less than or equal to 255";
 }
 //
-SiPixelGainCalibrationForHLT::SiPixelGainCalibrationForHLT(float minPed, float maxPed, float minGain, float maxGain) :
-  minPed_(minPed),
-  maxPed_(maxPed),
-  minGain_(minGain),
-  maxGain_(maxGain),
-  numberOfRowsToAverageOver_(80),
-  nBinsToUseForEncoding_(253),
-  deadFlag_(255),
-  noisyFlag_(254)
-{
+SiPixelGainCalibrationForHLT::SiPixelGainCalibrationForHLT(float minPed, float maxPed, float minGain, float maxGain)
+    : minPed_(minPed),
+      maxPed_(maxPed),
+      minGain_(minGain),
+      maxGain_(maxGain),
+      numberOfRowsToAverageOver_(80),
+      nBinsToUseForEncoding_(253),
+      deadFlag_(255),
+      noisyFlag_(254) {
   initialize();
-   if (deadFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibrationHLT::SiPixelGainCalibrationHLT] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
+  if (deadFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibrationHLT::SiPixelGainCalibrationHLT] Dead flag was set to " << deadFlag_
+        << ", and it must be set less than or equal to 255";
 }
 
-
 void SiPixelGainCalibrationForHLT::initialize() {
-  pedPrecision  = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-  gainPrecision = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-
+  pedPrecision = (maxPed_ - minPed_) / static_cast<float>(nBinsToUseForEncoding_);
+  gainPrecision = (maxGain_ - minGain_) / static_cast<float>(nBinsToUseForEncoding_);
 }
 
 bool SiPixelGainCalibrationForHLT::put(const uint32_t& DetId, Range input, const int& nCols) {
   // put in SiPixelGainCalibrationForHLT of DetId
 
-  Registry::iterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationForHLT::StrictWeakOrdering());
-  if (p!=indexes.end() && p->detid==DetId)
+  Registry::iterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationForHLT::StrictWeakOrdering());
+  if (p != indexes.end() && p->detid == DetId)
     return false;
-  
-  size_t sd= input.second-input.first;
-  DetRegistry detregistry;
-  detregistry.detid=DetId;
-  detregistry.ibegin=v_pedestals.size();
-  detregistry.iend=v_pedestals.size()+sd;
-  detregistry.ncols=nCols;
-  indexes.insert(p,detregistry);
 
-  v_pedestals.insert(v_pedestals.end(),input.first,input.second);
+  size_t sd = input.second - input.first;
+  DetRegistry detregistry;
+  detregistry.detid = DetId;
+  detregistry.ibegin = v_pedestals.size();
+  detregistry.iend = v_pedestals.size() + sd;
+  detregistry.ncols = nCols;
+  indexes.insert(p, detregistry);
+
+  v_pedestals.insert(v_pedestals.end(), input.first, input.second);
   return true;
 }
 
 const int SiPixelGainCalibrationForHLT::getNCols(const uint32_t& DetId) const {
   // get number of columns of DetId
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationForHLT::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationForHLT::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
     return 0;
-  else
-  {
+  else {
     return p->ncols;
   }
 }
 
 const SiPixelGainCalibrationForHLT::Range SiPixelGainCalibrationForHLT::getRange(const uint32_t& DetId) const {
   // get SiPixelGainCalibrationForHLT Range of DetId
-  
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationForHLT::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
-    return SiPixelGainCalibrationForHLT::Range(v_pedestals.end(),v_pedestals.end()); 
-  else 
-    return SiPixelGainCalibrationForHLT::Range(v_pedestals.begin()+p->ibegin,v_pedestals.begin()+p->iend);
+
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationForHLT::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
+    return SiPixelGainCalibrationForHLT::Range(v_pedestals.end(), v_pedestals.end());
+  else
+    return SiPixelGainCalibrationForHLT::Range(v_pedestals.begin() + p->ibegin, v_pedestals.begin() + p->iend);
 }
 
-const std::pair<const SiPixelGainCalibrationForHLT::Range, const int>
-SiPixelGainCalibrationForHLT::getRangeAndNCols(const uint32_t& DetId) const {
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationForHLT::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
-    return std::make_pair(SiPixelGainCalibrationForHLT::Range(v_pedestals.end(),v_pedestals.end()), 0); 
-  else 
-    return std::make_pair(SiPixelGainCalibrationForHLT::Range(v_pedestals.begin()+p->ibegin,v_pedestals.begin()+p->iend), p->ncols);
+const std::pair<const SiPixelGainCalibrationForHLT::Range, const int> SiPixelGainCalibrationForHLT::getRangeAndNCols(
+    const uint32_t& DetId) const {
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationForHLT::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
+    return std::make_pair(SiPixelGainCalibrationForHLT::Range(v_pedestals.end(), v_pedestals.end()), 0);
+  else
+    return std::make_pair(
+        SiPixelGainCalibrationForHLT::Range(v_pedestals.begin() + p->ibegin, v_pedestals.begin() + p->iend), p->ncols);
 }
 
 void SiPixelGainCalibrationForHLT::getDetIds(std::vector<uint32_t>& DetIds_) const {
   // returns vector of DetIds in map
   SiPixelGainCalibrationForHLT::RegistryIterator begin = indexes.begin();
-  SiPixelGainCalibrationForHLT::RegistryIterator end   = indexes.end();
-  for (SiPixelGainCalibrationForHLT::RegistryIterator p=begin; p != end; ++p) {
+  SiPixelGainCalibrationForHLT::RegistryIterator end = indexes.end();
+  for (SiPixelGainCalibrationForHLT::RegistryIterator p = begin; p != end; ++p) {
     DetIds_.push_back(p->detid);
   }
 }
 
-void SiPixelGainCalibrationForHLT::setData(float ped, float gain, std::vector<char>& vped, bool thisColumnIsDead, bool thisColumnIsNoisy){
-  
-  float theEncodedGain=0;
-  float theEncodedPed=0;
-  if(!thisColumnIsDead && !thisColumnIsNoisy){
+void SiPixelGainCalibrationForHLT::setData(
+    float ped, float gain, std::vector<char>& vped, bool thisColumnIsDead, bool thisColumnIsNoisy) {
+  float theEncodedGain = 0;
+  float theEncodedPed = 0;
+  if (!thisColumnIsDead && !thisColumnIsNoisy) {
     theEncodedGain = encodeGain(gain);
-    theEncodedPed = encodePed (ped);
+    theEncodedPed = encodePed(ped);
   }
 
-  unsigned int ped_   = (static_cast<unsigned int>(theEncodedPed))  & 0xFF; 
-  unsigned int gain_  = (static_cast<unsigned int>(theEncodedGain)) & 0xFF;
+  unsigned int ped_ = (static_cast<unsigned int>(theEncodedPed)) & 0xFF;
+  unsigned int gain_ = (static_cast<unsigned int>(theEncodedGain)) & 0xFF;
 
-  if (thisColumnIsDead)
-  {
-     ped_  = deadFlag_ & 0xFF;
-     gain_ = deadFlag_ & 0xFF;
-  }
-  else if (thisColumnIsNoisy)
-  {
-     ped_  = noisyFlag_ & 0xFF;
-     gain_ = noisyFlag_ & 0xFF;
+  if (thisColumnIsDead) {
+    ped_ = deadFlag_ & 0xFF;
+    gain_ = deadFlag_ & 0xFF;
+  } else if (thisColumnIsNoisy) {
+    ped_ = noisyFlag_ & 0xFF;
+    gain_ = noisyFlag_ & 0xFF;
   }
 
-  unsigned int data = (ped_ << 8) | gain_ ;
-  vped.resize(vped.size()+2);
+  unsigned int data = (ped_ << 8) | gain_;
+  vped.resize(vped.size() + 2);
   // insert in vector of char
-  ::memcpy((void*)(&vped[vped.size()-2]),(void*)(&data),2);
+  ::memcpy((void*)(&vped[vped.size() - 2]), (void*)(&data), 2);
 }
 
-
-std::pair<float,float> SiPixelGainCalibrationForHLT::getPedAndGain(const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn ) const {
+std::pair<float, float> SiPixelGainCalibrationForHLT::getPedAndGain(const int& col,
+                                                                    const int& row,
+                                                                    const Range& range,
+                                                                    const int& nCols,
+                                                                    bool& isDeadColumn,
+                                                                    bool& isNoisyColumn) const {
   // determine what averaged data block we are in (there should be 1 or 2 of these depending on if plaquette is 1 by X or 2 by X
-  unsigned int lengthOfColumnData  = (range.second-range.first)/nCols;
-  unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block 
+  unsigned int lengthOfColumnData = (range.second - range.first) / nCols;
+  unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block
   unsigned int numberOfDataBlocksToSkip = row / numberOfRowsToAverageOver_;
 
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first + col*lengthOfColumnData + lengthOfAveragedDataInEachColumn*numberOfDataBlocksToSkip);
+  const DecodingStructure& s = (const DecodingStructure&)*(range.first + col * lengthOfColumnData +
+                                                           lengthOfAveragedDataInEachColumn * numberOfDataBlocksToSkip);
 
   isDeadColumn = (s.ped & 0xFF) == deadFlag_;
   isNoisyColumn = (s.ped & 0xFF) == noisyFlag_;
@@ -152,81 +156,83 @@ std::pair<float,float> SiPixelGainCalibrationForHLT::getPedAndGain(const int& co
   }  
   */
 
-  return std::make_pair(decodePed(s.ped & 0xFF),decodeGain(s.gain & 0xFF));
-
-
+  return std::make_pair(decodePed(s.ped & 0xFF), decodeGain(s.gain & 0xFF));
 }
 
-
-float SiPixelGainCalibrationForHLT::getPed(const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn) const {
-   // TODO MERGE THIS FUNCTION WITH GET GAIN, then provide wrappers  ( VI done, see above)
+float SiPixelGainCalibrationForHLT::getPed(const int& col,
+                                           const int& row,
+                                           const Range& range,
+                                           const int& nCols,
+                                           bool& isDeadColumn,
+                                           bool& isNoisyColumn) const {
+  // TODO MERGE THIS FUNCTION WITH GET GAIN, then provide wrappers  ( VI done, see above)
 
   // determine what averaged data block we are in (there should be 1 or 2 of these depending on if plaquette is 1 by X or 2 by X
-  unsigned int lengthOfColumnData  = (range.second-range.first)/nCols;
-  unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block 
+  unsigned int lengthOfColumnData = (range.second - range.first) / nCols;
+  unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block
   unsigned int numberOfDataBlocksToSkip = row / numberOfRowsToAverageOver_;
 
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first+col*lengthOfColumnData + lengthOfAveragedDataInEachColumn*numberOfDataBlocksToSkip);
+  const DecodingStructure& s = (const DecodingStructure&)*(range.first + col * lengthOfColumnData +
+                                                           lengthOfAveragedDataInEachColumn * numberOfDataBlocksToSkip);
 
   if ((s.ped & 0xFF) == deadFlag_)
-     isDeadColumn = true;
+    isDeadColumn = true;
   else if ((s.ped & 0xFF) == noisyFlag_)
-     isNoisyColumn = true;
+    isNoisyColumn = true;
 
-  int maxRow = (lengthOfColumnData/lengthOfAveragedDataInEachColumn)*numberOfRowsToAverageOver_ - 1;
-  if (col >= nCols || row > maxRow){
+  int maxRow = (lengthOfColumnData / lengthOfAveragedDataInEachColumn) * numberOfRowsToAverageOver_ - 1;
+  if (col >= nCols || row > maxRow) {
     throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibrationForHLT::getPed] Pixel out of range: col " << col << " row: " << row;
-  }  
-  return decodePed(s.ped & 0xFF);  
+        << "[SiPixelGainCalibrationForHLT::getPed] Pixel out of range: col " << col << " row: " << row;
+  }
+  return decodePed(s.ped & 0xFF);
 }
 
-float SiPixelGainCalibrationForHLT::getGain(const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn) const {
-
+float SiPixelGainCalibrationForHLT::getGain(const int& col,
+                                            const int& row,
+                                            const Range& range,
+                                            const int& nCols,
+                                            bool& isDeadColumn,
+                                            bool& isNoisyColumn) const {
   // determine what averaged data block we are in (there should be 1 or 2 of these depending on if plaquette is 1 by X or 2 by X
-  unsigned int lengthOfColumnData  = (range.second-range.first)/nCols;
-  unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block 
+  unsigned int lengthOfColumnData = (range.second - range.first) / nCols;
+  unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block
   unsigned int numberOfDataBlocksToSkip = row / numberOfRowsToAverageOver_;
 
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first+col*lengthOfColumnData + lengthOfAveragedDataInEachColumn*numberOfDataBlocksToSkip);
+  const DecodingStructure& s = (const DecodingStructure&)*(range.first + col * lengthOfColumnData +
+                                                           lengthOfAveragedDataInEachColumn * numberOfDataBlocksToSkip);
 
   if ((s.gain & 0xFF) == deadFlag_)
-     isDeadColumn = true;
+    isDeadColumn = true;
   else if ((s.gain & 0xFF) == noisyFlag_)
-     isNoisyColumn = true;
-     
-  int maxRow = (lengthOfColumnData/lengthOfAveragedDataInEachColumn)*numberOfRowsToAverageOver_ - 1;
-  if (col >= nCols || row > maxRow){
-    throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibrationForHLT::getGain] Pixel out of range: col " << col << " row: " << row;
-  }  
-  return decodeGain(s.gain & 0xFF);  
+    isNoisyColumn = true;
 
+  int maxRow = (lengthOfColumnData / lengthOfAveragedDataInEachColumn) * numberOfRowsToAverageOver_ - 1;
+  if (col >= nCols || row > maxRow) {
+    throw cms::Exception("CorruptedData")
+        << "[SiPixelGainCalibrationForHLT::getGain] Pixel out of range: col " << col << " row: " << row;
+  }
+  return decodeGain(s.gain & 0xFF);
 }
 
-float SiPixelGainCalibrationForHLT::encodeGain( const float& gain ) {
-  
-  if(gain < minGain_ || gain > maxGain_ ) {
-    throw cms::Exception("InsertFailure")
-      << "[SiPixelGainCalibrationForHLT::encodeGain] Trying to encode gain (" << gain << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
+float SiPixelGainCalibrationForHLT::encodeGain(const float& gain) {
+  if (gain < minGain_ || gain > maxGain_) {
+    throw cms::Exception("InsertFailure") << "[SiPixelGainCalibrationForHLT::encodeGain] Trying to encode gain ("
+                                          << gain << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
   } else {
-    float precision   = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-    float  encodedGain = (float)((gain-minGain_)/precision);
+    float precision = (maxGain_ - minGain_) / static_cast<float>(nBinsToUseForEncoding_);
+    float encodedGain = (float)((gain - minGain_) / precision);
     return encodedGain;
   }
-
 }
 
-float SiPixelGainCalibrationForHLT::encodePed( const float& ped ) {
-
-  if(ped < minPed_ || ped > maxPed_ ) {
-    throw cms::Exception("InsertFailure")
-      << "[SiPixelGainCalibrationForHLT::encodePed] Trying to encode pedestal (" << ped << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
+float SiPixelGainCalibrationForHLT::encodePed(const float& ped) {
+  if (ped < minPed_ || ped > maxPed_) {
+    throw cms::Exception("InsertFailure") << "[SiPixelGainCalibrationForHLT::encodePed] Trying to encode pedestal ("
+                                          << ped << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
   } else {
-    float precision   = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-    float  encodedPed = (float)((ped-minPed_)/precision);
+    float precision = (maxPed_ - minPed_) / static_cast<float>(nBinsToUseForEncoding_);
+    float encodedPed = (float)((ped - minPed_) / precision);
     return encodedPed;
   }
-
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationOffline.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationOffline.cc
@@ -3,234 +3,243 @@
 #include <algorithm>
 #include <cstring>
 
-//	
+//
 // Constructors
 //
-SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline() :
-  minPed_(0.),
-  maxPed_(255.),
-  minGain_(0.),
-  maxGain_(255.),
-  numberOfRowsToAverageOver_(80),
-  nBinsToUseForEncoding_(253),
-  deadFlag_(255),
-  noisyFlag_(254)
-{
-   if (deadFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
-   if (noisyFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Noisy flag was set to " << noisyFlag_ << ", and it must be set less than or equal to 255";
+SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline()
+    : minPed_(0.),
+      maxPed_(255.),
+      minGain_(0.),
+      maxGain_(255.),
+      numberOfRowsToAverageOver_(80),
+      nBinsToUseForEncoding_(253),
+      deadFlag_(255),
+      noisyFlag_(254) {
+  if (deadFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Dead flag was set to " << deadFlag_
+        << ", and it must be set less than or equal to 255";
+  if (noisyFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Noisy flag was set to " << noisyFlag_
+        << ", and it must be set less than or equal to 255";
 }
 //
-SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline(float minPed, float maxPed, float minGain, float maxGain) :
-  minPed_(minPed),
-  maxPed_(maxPed),
-  minGain_(minGain),
-  maxGain_(maxGain),
-  numberOfRowsToAverageOver_(80),
-  nBinsToUseForEncoding_(253),
-  deadFlag_(255),
-  noisyFlag_(254)
-{
-   if (deadFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
-   if (noisyFlag_ > 0xFF)
-      throw cms::Exception("GainCalibration Payload configuration error")
-         << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Noisy flag was set to " << noisyFlag_ << ", and it must be set less than or equal to 255";
+SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline(float minPed, float maxPed, float minGain, float maxGain)
+    : minPed_(minPed),
+      maxPed_(maxPed),
+      minGain_(minGain),
+      maxGain_(maxGain),
+      numberOfRowsToAverageOver_(80),
+      nBinsToUseForEncoding_(253),
+      deadFlag_(255),
+      noisyFlag_(254) {
+  if (deadFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Dead flag was set to " << deadFlag_
+        << ", and it must be set less than or equal to 255";
+  if (noisyFlag_ > 0xFF)
+    throw cms::Exception("GainCalibration Payload configuration error")
+        << "[SiPixelGainCalibrationOffline::SiPixelGainCalibrationOffline] Noisy flag was set to " << noisyFlag_
+        << ", and it must be set less than or equal to 255";
 }
 
 bool SiPixelGainCalibrationOffline::put(const uint32_t& DetId, Range input, const int& nCols) {
   // put in SiPixelGainCalibrationOffline of DetId
 
-  Registry::iterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationOffline::StrictWeakOrdering());
-  if (p!=indexes.end() && p->detid==DetId)
+  Registry::iterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationOffline::StrictWeakOrdering());
+  if (p != indexes.end() && p->detid == DetId)
     return false;
-  
-  size_t sd= input.second-input.first;
-  DetRegistry detregistry;
-  detregistry.detid=DetId;
-  detregistry.ncols=nCols;
-  detregistry.ibegin=v_pedestals.size();
-  detregistry.iend=v_pedestals.size()+sd;
-  indexes.insert(p,detregistry);
 
-  v_pedestals.insert(v_pedestals.end(),input.first,input.second);
+  size_t sd = input.second - input.first;
+  DetRegistry detregistry;
+  detregistry.detid = DetId;
+  detregistry.ncols = nCols;
+  detregistry.ibegin = v_pedestals.size();
+  detregistry.iend = v_pedestals.size() + sd;
+  indexes.insert(p, detregistry);
+
+  v_pedestals.insert(v_pedestals.end(), input.first, input.second);
   return true;
 }
 
 const int SiPixelGainCalibrationOffline::getNCols(const uint32_t& DetId) const {
   // get number of columns of DetId
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationOffline::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationOffline::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
     return 0;
   else
-    return p->ncols; 
+    return p->ncols;
 }
 
 const SiPixelGainCalibrationOffline::Range SiPixelGainCalibrationOffline::getRange(const uint32_t& DetId) const {
   // get SiPixelGainCalibrationOffline Range of DetId
-  
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationOffline::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
-    return SiPixelGainCalibrationOffline::Range(v_pedestals.end(),v_pedestals.end()); 
-  else 
-    return SiPixelGainCalibrationOffline::Range(v_pedestals.begin()+p->ibegin,v_pedestals.begin()+p->iend);
+
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationOffline::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
+    return SiPixelGainCalibrationOffline::Range(v_pedestals.end(), v_pedestals.end());
+  else
+    return SiPixelGainCalibrationOffline::Range(v_pedestals.begin() + p->ibegin, v_pedestals.begin() + p->iend);
 }
 
-const std::pair<const SiPixelGainCalibrationOffline::Range, const int>
-SiPixelGainCalibrationOffline::getRangeAndNCols(const uint32_t& DetId) const {
-  RegistryIterator p = std::lower_bound(indexes.begin(),indexes.end(),DetId,SiPixelGainCalibrationOffline::StrictWeakOrdering());
-  if (p==indexes.end()|| p->detid!=DetId) 
-    return std::make_pair(SiPixelGainCalibrationOffline::Range(v_pedestals.end(),v_pedestals.end()), 0); 
-  else 
-    return std::make_pair(SiPixelGainCalibrationOffline::Range(v_pedestals.begin()+p->ibegin,v_pedestals.begin()+p->iend), p->ncols);
+const std::pair<const SiPixelGainCalibrationOffline::Range, const int> SiPixelGainCalibrationOffline::getRangeAndNCols(
+    const uint32_t& DetId) const {
+  RegistryIterator p =
+      std::lower_bound(indexes.begin(), indexes.end(), DetId, SiPixelGainCalibrationOffline::StrictWeakOrdering());
+  if (p == indexes.end() || p->detid != DetId)
+    return std::make_pair(SiPixelGainCalibrationOffline::Range(v_pedestals.end(), v_pedestals.end()), 0);
+  else
+    return std::make_pair(
+        SiPixelGainCalibrationOffline::Range(v_pedestals.begin() + p->ibegin, v_pedestals.begin() + p->iend), p->ncols);
 }
-  
 
 void SiPixelGainCalibrationOffline::getDetIds(std::vector<uint32_t>& DetIds_) const {
   // returns vector of DetIds in map
   SiPixelGainCalibrationOffline::RegistryIterator begin = indexes.begin();
-  SiPixelGainCalibrationOffline::RegistryIterator end   = indexes.end();
-  for (SiPixelGainCalibrationOffline::RegistryIterator p=begin; p != end; ++p) {
+  SiPixelGainCalibrationOffline::RegistryIterator end = indexes.end();
+  for (SiPixelGainCalibrationOffline::RegistryIterator p = begin; p != end; ++p) {
     DetIds_.push_back(p->detid);
   }
 }
 
-void SiPixelGainCalibrationOffline::setDataGain(float gain, const int& nRows, std::vector<char>& vped, bool thisColumnIsDead, bool thisColumnIsNoisy){
-  
-  float theEncodedGain=0;
-  if(!thisColumnIsDead && !thisColumnIsNoisy)
+void SiPixelGainCalibrationOffline::setDataGain(
+    float gain, const int& nRows, std::vector<char>& vped, bool thisColumnIsDead, bool thisColumnIsNoisy) {
+  float theEncodedGain = 0;
+  if (!thisColumnIsDead && !thisColumnIsNoisy)
     theEncodedGain = encodeGain(gain);
 
-  unsigned int gain_  = (static_cast<unsigned int>(theEncodedGain)) & 0xFF;
+  unsigned int gain_ = (static_cast<unsigned int>(theEncodedGain)) & 0xFF;
 
   // if this whole column is dead, set a char based dead flag in the blob.
   if (thisColumnIsDead)
-     gain_ = deadFlag_ & 0xFF;
+    gain_ = deadFlag_ & 0xFF;
   if (thisColumnIsNoisy)
-     gain_ = noisyFlag_ & 0xFF;
+    gain_ = noisyFlag_ & 0xFF;
 
-  vped.resize(vped.size()+1);
+  vped.resize(vped.size() + 1);
   //check to make sure the column is being placed in the right place in the blob
-  if (nRows != (int)numberOfRowsToAverageOver_)
-  {
+  if (nRows != (int)numberOfRowsToAverageOver_) {
     throw cms::Exception("GainCalibration Payload configuration error")
-      << "[SiPixelGainCalibrationOffline::setDataGain] You are setting a gain averaged over nRows = " << nRows << " where this payload is set ONLY to average over " << numberOfRowsToAverageOver_ << " nRows";
+        << "[SiPixelGainCalibrationOffline::setDataGain] You are setting a gain averaged over nRows = " << nRows
+        << " where this payload is set ONLY to average over " << numberOfRowsToAverageOver_ << " nRows";
   }
 
-  if (vped.size() % (nRows + 1) != 0) 
-  {
+  if (vped.size() % (nRows + 1) != 0) {
     throw cms::Exception("FillError")
-      << "[SiPixelGainCalibrationOffline::setDataGain] Column gain average (OR SETTING AN ENTIRE COLUMN DEAD/NOISY) must be filled after the pedestal for each row has been added. An additional source of this error would be setting a pixel dead/noisy AND setting its pedestal";
-  }  
+        << "[SiPixelGainCalibrationOffline::setDataGain] Column gain average (OR SETTING AN ENTIRE COLUMN DEAD/NOISY) "
+           "must be filled after the pedestal for each row has been added. An additional source of this error would be "
+           "setting a pixel dead/noisy AND setting its pedestal";
+  }
   // insert in vector of char
-  ::memcpy((void*)(&vped[vped.size()-1]),(void*)(&gain_),1);
+  ::memcpy((void*)(&vped[vped.size() - 1]), (void*)(&gain_), 1);
 }
 
-void SiPixelGainCalibrationOffline::setDataPedestal(float pedestal,  std::vector<char>& vped, bool thisPixelIsDead, bool thisPixelIsNoisy){
+void SiPixelGainCalibrationOffline::setDataPedestal(float pedestal,
+                                                    std::vector<char>& vped,
+                                                    bool thisPixelIsDead,
+                                                    bool thisPixelIsNoisy) {
+  float theEncodedPedestal = encodePed(pedestal);
 
-  float theEncodedPedestal  = encodePed(pedestal);
-
-  unsigned int ped_  = (static_cast<unsigned int>(theEncodedPedestal)) & 0xFF;
+  unsigned int ped_ = (static_cast<unsigned int>(theEncodedPedestal)) & 0xFF;
 
   if (thisPixelIsDead)
-     ped_ = deadFlag_ & 0xFF;
+    ped_ = deadFlag_ & 0xFF;
   if (thisPixelIsNoisy)
-     ped_ = noisyFlag_ & 0xFF;
+    ped_ = noisyFlag_ & 0xFF;
 
-  vped.resize(vped.size()+1);
+  vped.resize(vped.size() + 1);
   // insert in vector of char
-  ::memcpy((void*)(&vped[vped.size()-1]),(void*)(&ped_),1);
+  ::memcpy((void*)(&vped[vped.size() - 1]), (void*)(&ped_), 1);
 }
 
-float SiPixelGainCalibrationOffline::getPed(const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const {
-
-  unsigned int lengthOfColumnData = (range.second-range.first)/nCols;
+float SiPixelGainCalibrationOffline::getPed(
+    const int& col, const int& row, const Range& range, const int& nCols, bool& isDead, bool& isNoisy) const {
+  unsigned int lengthOfColumnData = (range.second - range.first) / nCols;
   //determine what row averaged range we are in (i.e. ROC 1 or ROC 2)
   unsigned int lengthOfAveragedDataInEachColumn = numberOfRowsToAverageOver_ + 1;
   unsigned int numberOfAveragedDataBlocksToSkip = row / numberOfRowsToAverageOver_;
-  unsigned int offSetInCorrectDataBlock         = row % numberOfRowsToAverageOver_;
+  unsigned int offSetInCorrectDataBlock = row % numberOfRowsToAverageOver_;
 
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first + col*(lengthOfColumnData) + (numberOfAveragedDataBlocksToSkip * lengthOfAveragedDataInEachColumn) + offSetInCorrectDataBlock);
+  const DecodingStructure& s = (const DecodingStructure&)*(
+      range.first + col * (lengthOfColumnData) + (numberOfAveragedDataBlocksToSkip * lengthOfAveragedDataInEachColumn) +
+      offSetInCorrectDataBlock);
 
   int maxRow = lengthOfColumnData - (lengthOfColumnData % numberOfRowsToAverageOver_) - 1;
-  if (col >= nCols || row > maxRow){
+  if (col >= nCols || row > maxRow) {
     throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibrationOffline::getPed] Pixel out of range: col " << col << " row " << row;
-  }  
+        << "[SiPixelGainCalibrationOffline::getPed] Pixel out of range: col " << col << " row " << row;
+  }
 
   if ((s.datum & 0xFF) == deadFlag_)
-     isDead = true;
+    isDead = true;
   if ((s.datum & 0xFF) == noisyFlag_)
-     isNoisy = true;
+    isNoisy = true;
 
-  return decodePed(s.datum & 0xFF);  
+  return decodePed(s.datum & 0xFF);
 }
 
-float SiPixelGainCalibrationOffline::getGain(const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn) const {
-
-  unsigned int lengthOfColumnData = (range.second-range.first)/nCols;
+float SiPixelGainCalibrationOffline::getGain(const int& col,
+                                             const int& row,
+                                             const Range& range,
+                                             const int& nCols,
+                                             bool& isDeadColumn,
+                                             bool& isNoisyColumn) const {
+  unsigned int lengthOfColumnData = (range.second - range.first) / nCols;
   //determine what row averaged range we are in (i.e. ROC 1 or ROC 2)
   unsigned int lengthOfAveragedDataInEachColumn = numberOfRowsToAverageOver_ + 1;
   unsigned int numberOfAveragedDataBlocksToSkip = row / numberOfRowsToAverageOver_;
 
   // gain average is stored in the last location of current row averaged column data block
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first+(col)*(lengthOfColumnData) + ( (numberOfAveragedDataBlocksToSkip+1) * lengthOfAveragedDataInEachColumn) - 1);
+  const DecodingStructure& s =
+      (const DecodingStructure&)*(range.first + (col) * (lengthOfColumnData) +
+                                  ((numberOfAveragedDataBlocksToSkip + 1) * lengthOfAveragedDataInEachColumn) - 1);
 
   if ((s.datum & 0xFF) == deadFlag_)
-     isDeadColumn = true;
+    isDeadColumn = true;
   if ((s.datum & 0xFF) == noisyFlag_)
-     isNoisyColumn = true;
+    isNoisyColumn = true;
 
   int maxRow = lengthOfColumnData - (lengthOfColumnData % numberOfRowsToAverageOver_) - 1;
-  if (col >= nCols || row > maxRow){
+  if (col >= nCols || row > maxRow) {
     throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibrationOffline::getPed] Pixel out of range: col " << col << " row " << row;
-  }  
+        << "[SiPixelGainCalibrationOffline::getPed] Pixel out of range: col " << col << " row " << row;
+  }
   return decodeGain(s.datum & 0xFF);
 }
 
-float SiPixelGainCalibrationOffline::encodeGain( const float& gain ) {
-  
-  if(gain < minGain_ || gain > maxGain_ ) {
-    throw cms::Exception("InsertFailure")
-      << "[SiPixelGainCalibrationOffline::encodeGain] Trying to encode gain (" << gain << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
+float SiPixelGainCalibrationOffline::encodeGain(const float& gain) {
+  if (gain < minGain_ || gain > maxGain_) {
+    throw cms::Exception("InsertFailure") << "[SiPixelGainCalibrationOffline::encodeGain] Trying to encode gain ("
+                                          << gain << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
   } else {
-    double precision   = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-    float  encodedGain = (float)((gain-minGain_)/precision);
+    double precision = (maxGain_ - minGain_) / static_cast<float>(nBinsToUseForEncoding_);
+    float encodedGain = (float)((gain - minGain_) / precision);
     return encodedGain;
   }
-
 }
 
-float SiPixelGainCalibrationOffline::encodePed( const float& ped ) {
-
-  if(ped < minPed_ || ped > maxPed_ ) {
-    throw cms::Exception("InsertFailure")
-      << "[SiPixelGainCalibrationOffline::encodePed] Trying to encode pedestal (" << ped << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
+float SiPixelGainCalibrationOffline::encodePed(const float& ped) {
+  if (ped < minPed_ || ped > maxPed_) {
+    throw cms::Exception("InsertFailure") << "[SiPixelGainCalibrationOffline::encodePed] Trying to encode pedestal ("
+                                          << ped << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
   } else {
-    double precision   = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-    float  encodedPed = (float)((ped-minPed_)/precision);
+    double precision = (maxPed_ - minPed_) / static_cast<float>(nBinsToUseForEncoding_);
+    float encodedPed = (float)((ped - minPed_) / precision);
     return encodedPed;
   }
-
 }
 
-float SiPixelGainCalibrationOffline::decodePed( unsigned int ped ) const {
-
-  double precision = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-  float decodedPed = (float)(ped*precision + minPed_);
+float SiPixelGainCalibrationOffline::decodePed(unsigned int ped) const {
+  double precision = (maxPed_ - minPed_) / static_cast<float>(nBinsToUseForEncoding_);
+  float decodedPed = (float)(ped * precision + minPed_);
   return decodedPed;
-
 }
 
-float SiPixelGainCalibrationOffline::decodeGain( unsigned int gain ) const {
-
-  double precision = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-  float decodedGain = (float)(gain*precision + minGain_);
+float SiPixelGainCalibrationOffline::decodeGain(unsigned int gain) const {
+  double precision = (maxGain_ - minGain_) / static_cast<float>(nBinsToUseForEncoding_);
+  float decodedGain = (float)(gain * precision + minGain_);
   return decodedGain;
 }
-

--- a/CondFormats/SiPixelObjects/src/SiPixelLorentzAngle.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelLorentzAngle.cc
@@ -1,20 +1,22 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-bool SiPixelLorentzAngle::putLorentzAngle(const uint32_t& detid, float& value){
-  std::map<unsigned int,float>::const_iterator id=m_LA.find(detid);
-  if(id!=m_LA.end()){
-    edm::LogError("SiPixelLorentzAngle") << "SiPixelLorentzAngle for DetID " << detid << " is already stored. Skippig this put" << std::endl;
+bool SiPixelLorentzAngle::putLorentzAngle(const uint32_t& detid, float& value) {
+  std::map<unsigned int, float>::const_iterator id = m_LA.find(detid);
+  if (id != m_LA.end()) {
+    edm::LogError("SiPixelLorentzAngle") << "SiPixelLorentzAngle for DetID " << detid
+                                         << " is already stored. Skippig this put" << std::endl;
     return false;
-  }
-  else m_LA[detid]=value;
+  } else
+    m_LA[detid] = value;
   return true;
 }
-float SiPixelLorentzAngle::getLorentzAngle(const uint32_t& detid) const  {
-  std::map<unsigned int,float>::const_iterator id=m_LA.find(detid);
-  if(id!=m_LA.end()) return id->second;
+float SiPixelLorentzAngle::getLorentzAngle(const uint32_t& detid) const {
+  std::map<unsigned int, float>::const_iterator id = m_LA.find(detid);
+  if (id != m_LA.end())
+    return id->second;
   else {
-    edm::LogError("SiPixelLorentzAngle") << "SiPixelLorentzAngle for DetID " << detid << " is not stored" << std::endl; 
+    edm::LogError("SiPixelLorentzAngle") << "SiPixelLorentzAngle for DetID " << detid << " is not stored" << std::endl;
   }
   return 0;
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelPedestals.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelPedestals.cc
@@ -1,4 +1,4 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelPedestals.h"
 
-SiPixelPedestals::SiPixelPedestals(){}
-SiPixelPedestals::~SiPixelPedestals(){}
+SiPixelPedestals::SiPixelPedestals() {}
+SiPixelPedestals::~SiPixelPedestals() {}

--- a/CondFormats/SiPixelObjects/src/SiPixelPerformanceSummary.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelPerformanceSummary.cc
@@ -4,222 +4,212 @@
 
 #include <algorithm>
 
-using namespace edm; 
-using namespace std; 
+using namespace edm;
+using namespace std;
 
-
-SiPixelPerformanceSummary::SiPixelPerformanceSummary() 
-                         : timeStamp_(0), runNumber_(0), luminosityBlock_(0), numberOfEvents_(0) {}
-
+SiPixelPerformanceSummary::SiPixelPerformanceSummary()
+    : timeStamp_(0), runNumber_(0), luminosityBlock_(0), numberOfEvents_(0) {}
 
 SiPixelPerformanceSummary::SiPixelPerformanceSummary(const SiPixelPerformanceSummary& performanceSummary) {
-        timeStamp_ = performanceSummary.getTimeStamp();
-        runNumber_ = performanceSummary.getRunNumber();
+  timeStamp_ = performanceSummary.getTimeStamp();
+  runNumber_ = performanceSummary.getRunNumber();
   luminosityBlock_ = performanceSummary.getLuminosityBlock();
-   numberOfEvents_ = performanceSummary.getNumberOfEvents(); 
+  numberOfEvents_ = performanceSummary.getNumberOfEvents();
   allDetSummaries_ = performanceSummary.getAllDetSummaries();
 }
 
-
 SiPixelPerformanceSummary::~SiPixelPerformanceSummary() {}
 
-
 void SiPixelPerformanceSummary::clear() {
-  timeStamp_=0; runNumber_=0; luminosityBlock_=0; numberOfEvents_=0; allDetSummaries_.clear(); 
+  timeStamp_ = 0;
+  runNumber_ = 0;
+  luminosityBlock_ = 0;
+  numberOfEvents_ = 0;
+  allDetSummaries_.clear();
 }
 
-
-pair<bool, vector<SiPixelPerformanceSummary::DetSummary>::iterator> 
-                  SiPixelPerformanceSummary::initDet(const uint32_t detId) { 
-  vector<float> performanceValues; 
-  for (int i=0; i<kDetSummarySize; ++i) performanceValues.push_back(kDefaultValue);
+pair<bool, vector<SiPixelPerformanceSummary::DetSummary>::iterator> SiPixelPerformanceSummary::initDet(
+    const uint32_t detId) {
+  vector<float> performanceValues;
+  for (int i = 0; i < kDetSummarySize; ++i)
+    performanceValues.push_back(kDefaultValue);
   return setDet(detId, performanceValues);
 }
 
-
-pair<bool, vector<SiPixelPerformanceSummary::DetSummary>::iterator> 
-                  SiPixelPerformanceSummary::setDet(const uint32_t detId, 
-		                                    const vector<float>& performanceValues) {
+pair<bool, vector<SiPixelPerformanceSummary::DetSummary>::iterator> SiPixelPerformanceSummary::setDet(
+    const uint32_t detId, const vector<float>& performanceValues) {
   vector<DetSummary>::iterator iDetSumm = allDetSummaries_.end();
-  
-  if (performanceValues.size()!=kDetSummarySize) { // for inappropriate input
-    cout << "not adding these "<< performanceValues.size() << " values; " 
-         << "SiPixelPerformanceSummary can only add "<< kDetSummarySize <<" values per DetSummary";
+
+  if (performanceValues.size() != kDetSummarySize) {  // for inappropriate input
+    cout << "not adding these " << performanceValues.size() << " values; "
+         << "SiPixelPerformanceSummary can only add " << kDetSummarySize << " values per DetSummary";
     return make_pair(false, iDetSumm);
   }
-  iDetSumm = lower_bound(allDetSummaries_.begin(), allDetSummaries_.end(), 
-                         detId, SiPixelPerformanceSummary::StrictWeakOrdering()); 
-  
-  if (iDetSumm!=allDetSummaries_.end() && // for an existong entry 
-      iDetSumm->detId_==detId) return make_pair(false, iDetSumm); 
-  
-  DetSummary newDetSumm; // for a new entry, put at (position-1) returned by StrictWeakOrdering
-  	     newDetSumm.detId_ = detId; 
-	     newDetSumm.performanceValues_ = performanceValues;
+  iDetSumm = lower_bound(
+      allDetSummaries_.begin(), allDetSummaries_.end(), detId, SiPixelPerformanceSummary::StrictWeakOrdering());
+
+  if (iDetSumm != allDetSummaries_.end() &&  // for an existong entry
+      iDetSumm->detId_ == detId)
+    return make_pair(false, iDetSumm);
+
+  DetSummary newDetSumm;  // for a new entry, put at (position-1) returned by StrictWeakOrdering
+  newDetSumm.detId_ = detId;
+  newDetSumm.performanceValues_ = performanceValues;
   return make_pair(true, allDetSummaries_.insert(iDetSumm, newDetSumm));
 }
 
-
 bool SiPixelPerformanceSummary::setValue(uint32_t detId, int index, float performanceValue) {
-  if (index>kDetSummarySize) {
-    cout << "cannot set the performance value for index = "<< index <<" > "<< kDetSummarySize;
+  if (index > kDetSummarySize) {
+    cout << "cannot set the performance value for index = " << index << " > " << kDetSummarySize;
     return false;
   }
   pair<bool, vector<DetSummary>::iterator> initResult = initDet(detId);
-  if (initResult.first || initResult.second!=allDetSummaries_.end()) { 
+  if (initResult.first || initResult.second != allDetSummaries_.end()) {
     initResult.second->performanceValues_[index] = performanceValue;
     return true;
-  }
-  else {
-    cout << "cannot set the performance value; cannot create new entry for detId = "<< detId;
-    return false; 
+  } else {
+    cout << "cannot set the performance value; cannot create new entry for detId = " << detId;
+    return false;
   }
   return true;
 }
 
-
 float SiPixelPerformanceSummary::getValue(uint32_t detId, int index) {
-  if (index>kDetSummarySize) {
-    cout << "cannot get value for detId = "<< detId <<" index = "<< index <<" > "<< kDetSummarySize; 
+  if (index > kDetSummarySize) {
+    cout << "cannot get value for detId = " << detId << " index = " << index << " > " << kDetSummarySize;
     return kDefaultValue;
   }
   vector<float> performanceValues = getDetSummary(detId);
-  if (performanceValues.size()==kDetSummarySize) return performanceValues[index]; 
-  else return kDefaultValue; 
+  if (performanceValues.size() == kDetSummarySize)
+    return performanceValues[index];
+  else
+    return kDefaultValue;
 }
-
 
 bool SiPixelPerformanceSummary::setRawDataErrorType(uint32_t detId, int bin, float nErrors) {
-  return  setValue(detId, bin, nErrors);
+  return setValue(detId, bin, nErrors);
 }
 
-
 bool SiPixelPerformanceSummary::setNumberOfDigis(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 15, mean) && setValue(detId, 16, rms) && setValue(detId, 17, emPtn)); 
+  return (setValue(detId, 15, mean) && setValue(detId, 16, rms) && setValue(detId, 17, emPtn));
 }
 
 bool SiPixelPerformanceSummary::setADC(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 18, mean) && setValue(detId, 19, rms) && setValue(detId, 20, emPtn)); 
+  return (setValue(detId, 18, mean) && setValue(detId, 19, rms) && setValue(detId, 20, emPtn));
 }
 
-
 bool SiPixelPerformanceSummary::setNumberOfClusters(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 21, mean) && setValue(detId, 22, rms) && setValue(detId, 23, emPtn)); 
+  return (setValue(detId, 21, mean) && setValue(detId, 22, rms) && setValue(detId, 23, emPtn));
 }
 
 bool SiPixelPerformanceSummary::setClusterCharge(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 24, mean) && setValue(detId, 25, rms) && setValue(detId, 26, emPtn)); 
+  return (setValue(detId, 24, mean) && setValue(detId, 25, rms) && setValue(detId, 26, emPtn));
 }
 
 bool SiPixelPerformanceSummary::setClusterSize(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 27, mean) && setValue(detId, 28, rms) && setValue(detId, 29, emPtn)); 
+  return (setValue(detId, 27, mean) && setValue(detId, 28, rms) && setValue(detId, 29, emPtn));
 }
 
 bool SiPixelPerformanceSummary::setClusterSizeX(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 30, mean) && setValue(detId, 31, rms) && setValue(detId, 32, emPtn)); 
+  return (setValue(detId, 30, mean) && setValue(detId, 31, rms) && setValue(detId, 32, emPtn));
 }
 
 bool SiPixelPerformanceSummary::setClusterSizeY(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 33, mean) && setValue(detId, 34, rms) && setValue(detId, 35, emPtn)); 
+  return (setValue(detId, 33, mean) && setValue(detId, 34, rms) && setValue(detId, 35, emPtn));
 }
-
 
 bool SiPixelPerformanceSummary::setNumberOfRecHits(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 36, mean) && setValue(detId, 37, rms) && setValue(detId, 38, emPtn)); 
+  return (setValue(detId, 36, mean) && setValue(detId, 37, rms) && setValue(detId, 38, emPtn));
 }
 
-
 bool SiPixelPerformanceSummary::setResidualX(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 39, mean) && setValue(detId, 40, rms) && setValue(detId, 41, emPtn)); 
+  return (setValue(detId, 39, mean) && setValue(detId, 40, rms) && setValue(detId, 41, emPtn));
 }
 
 bool SiPixelPerformanceSummary::setResidualY(uint32_t detId, float mean, float rms, float emPtn) {
-  return (setValue(detId, 42, mean) && setValue(detId, 43, rms) && setValue(detId, 44, emPtn)); 
+  return (setValue(detId, 42, mean) && setValue(detId, 43, rms) && setValue(detId, 44, emPtn));
 }
 
-
 bool SiPixelPerformanceSummary::setNumberOfNoisCells(uint32_t detId, float nNpixCells) {
-  return  setValue(detId, 45, nNpixCells); 
+  return setValue(detId, 45, nNpixCells);
 }
 
 bool SiPixelPerformanceSummary::setNumberOfDeadCells(uint32_t detId, float nNpixCells) {
-  return  setValue(detId, 46, nNpixCells); 
+  return setValue(detId, 46, nNpixCells);
 }
 
 bool SiPixelPerformanceSummary::setNumberOfPixelHitsInTrackFit(uint32_t detId, float nPixelHits) {
-  return  setValue(detId, 47, nPixelHits); 
+  return setValue(detId, 47, nPixelHits);
 }
 
 bool SiPixelPerformanceSummary::setFractionOfTracks(uint32_t detId, float mean, float rms) {
-  return (setValue(detId, 48, mean) && setValue(detId, 49, rms)); 
+  return (setValue(detId, 48, mean) && setValue(detId, 49, rms));
 }
 
 bool SiPixelPerformanceSummary::setNumberOfOnTrackClusters(uint32_t detId, float nClusters) {
-  return setValue(detId, 50, nClusters); 
+  return setValue(detId, 50, nClusters);
 }
 
 bool SiPixelPerformanceSummary::setNumberOfOffTrackClusters(uint32_t detId, float nClusters) {
-  return setValue(detId, 51, nClusters); 
+  return setValue(detId, 51, nClusters);
 }
 
 bool SiPixelPerformanceSummary::setClusterChargeOnTrack(uint32_t detId, float mean, float rms) {
-  return (setValue(detId, 52, mean) && setValue(detId, 53, rms)); 
+  return (setValue(detId, 52, mean) && setValue(detId, 53, rms));
 }
 
 bool SiPixelPerformanceSummary::setClusterChargeOffTrack(uint32_t detId, float mean, float rms) {
-  return (setValue(detId, 54, mean) && setValue(detId, 55, rms)); 
+  return (setValue(detId, 54, mean) && setValue(detId, 55, rms));
 }
 
 bool SiPixelPerformanceSummary::setClusterSizeOnTrack(uint32_t detId, float mean, float rms) {
-  return (setValue(detId, 56, mean) && setValue(detId, 57, rms)); 
+  return (setValue(detId, 56, mean) && setValue(detId, 57, rms));
 }
 
 bool SiPixelPerformanceSummary::setClusterSizeOffTrack(uint32_t detId, float mean, float rms) {
-  return (setValue(detId, 58, mean) && setValue(detId, 59, rms)); 
+  return (setValue(detId, 58, mean) && setValue(detId, 59, rms));
 }
 
 vector<uint32_t> SiPixelPerformanceSummary::getAllDetIds() const {
-  vector<uint32_t> allDetIds; 
-  for (vector<DetSummary>::const_iterator iDetSumm = allDetSummaries_.begin(); 
-       iDetSumm!=allDetSummaries_.end(); ++iDetSumm) allDetIds.push_back(iDetSumm->detId_); 
-  return allDetIds; 
+  vector<uint32_t> allDetIds;
+  for (vector<DetSummary>::const_iterator iDetSumm = allDetSummaries_.begin(); iDetSumm != allDetSummaries_.end();
+       ++iDetSumm)
+    allDetIds.push_back(iDetSumm->detId_);
+  return allDetIds;
 }
-
 
 vector<float> SiPixelPerformanceSummary::getDetSummary(const uint32_t detId) const {
-  vector<DetSummary>::const_iterator iDetSumm = find_if(allDetSummaries_.begin(), 
-                                                        allDetSummaries_.end(), 
-                                                        [&detId](const DetSummary& detSumm) -> bool
-                                                                {return detSumm.detId_ == detId;}
-                                                        );
-  if (iDetSumm==allDetSummaries_.end()) { 
-    vector<float> performanceValues; 
-    cout << "cannot get DetSummary for detId = "<< detId; 
-    return performanceValues; 
-  }
-  else return iDetSumm->performanceValues_; 
+  vector<DetSummary>::const_iterator iDetSumm =
+      find_if(allDetSummaries_.begin(), allDetSummaries_.end(), [&detId](const DetSummary& detSumm) -> bool {
+        return detSumm.detId_ == detId;
+      });
+  if (iDetSumm == allDetSummaries_.end()) {
+    vector<float> performanceValues;
+    cout << "cannot get DetSummary for detId = " << detId;
+    return performanceValues;
+  } else
+    return iDetSumm->performanceValues_;
 }
 
-
 void SiPixelPerformanceSummary::print(const uint32_t detId) const {
-  vector<float> performanceValues = getDetSummary(detId);   
-  cout << "DetSummary for detId "<< detId <<" : ";
-  for (vector<float>::const_iterator v = performanceValues.begin(); v!=performanceValues.end(); ++v) cout <<" "<< *v; 
+  vector<float> performanceValues = getDetSummary(detId);
+  cout << "DetSummary for detId " << detId << " : ";
+  for (vector<float>::const_iterator v = performanceValues.begin(); v != performanceValues.end(); ++v)
+    cout << " " << *v;
   cout << endl;
 }
 
-
 void SiPixelPerformanceSummary::print() const {
-  cout << "SiPixelPerformanceSummary size (allDets) = "<< allDetSummaries_.size() << ", "
-       << "time stamp = "<< timeStamp_ << ", "
-       << "run number = "<< runNumber_ << ", "
-       << "luminosity section = "<< luminosityBlock_ << ", "
-       << "number of events = "<< numberOfEvents_ << endl;
+  cout << "SiPixelPerformanceSummary size (allDets) = " << allDetSummaries_.size() << ", "
+       << "time stamp = " << timeStamp_ << ", "
+       << "run number = " << runNumber_ << ", "
+       << "luminosity section = " << luminosityBlock_ << ", "
+       << "number of events = " << numberOfEvents_ << endl;
 }
-
 
 void SiPixelPerformanceSummary::printAll() const {
   print();
-  for (vector<DetSummary>::const_iterator iDetSumm = allDetSummaries_.begin(); 
-       iDetSumm!=allDetSummaries_.end(); ++iDetSumm) print(iDetSumm->detId_); 
+  for (vector<DetSummary>::const_iterator iDetSumm = allDetSummaries_.begin(); iDetSumm != allDetSummaries_.end();
+       ++iDetSumm)
+    print(iDetSumm->detId_);
 }

--- a/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
@@ -20,57 +20,48 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-
 #include <algorithm>
 #include <iostream>
 
-
 using namespace sipixelobjects;
 
+//////////////////////////////////////
+//  errortype "whole" = int 0 in DB //
+//  errortype "tbmA" = int 1 in DB  //
+//  errortype "tbmB" = int 2 in DB  //
+//  errortype "none" = int 3 in DB  //
+//////////////////////////////////////
 
-      //////////////////////////////////////
-      //  errortype "whole" = int 0 in DB //
-      //  errortype "tbmA" = int 1 in DB  //
-      //  errortype "tbmB" = int 2 in DB  //
-      //  errortype "none" = int 3 in DB  //
-      //////////////////////////////////////
-    
-      /////////////////////////////////////////////////
-      //each bad roc correspond to a bit to 1: num=  //
-      // 0 <-> all good rocs                         //
-      // 1 <-> only roc 0 bad                        //
-      // 2<-> only roc 1 bad                         //
-      // 3<->  roc 0 and 1 bad                       //
-      // 4 <-> only roc 2 bad                        //
-      //  ...                                        //
-      /////////////////////////////////////////////////
-
+/////////////////////////////////////////////////
+//each bad roc correspond to a bit to 1: num=  //
+// 0 <-> all good rocs                         //
+// 1 <-> only roc 0 bad                        //
+// 2<-> only roc 1 bad                         //
+// 3<->  roc 0 and 1 bad                       //
+// 4 <-> only roc 2 bad                        //
+//  ...                                        //
+/////////////////////////////////////////////////
 
 // add a list of modules to the vector of disabled modules
-void SiPixelQuality::addDisabledModule(std::vector<SiPixelQuality::disabledModuleType> & idVector) {
-  theDisabledModules.insert(theDisabledModules.end(),
-			    idVector.begin(),
-			    idVector.end());
-
-} 
+void SiPixelQuality::addDisabledModule(std::vector<SiPixelQuality::disabledModuleType>& idVector) {
+  theDisabledModules.insert(theDisabledModules.end(), idVector.begin(), idVector.end());
+}
 
 void SiPixelQuality::add(const SiStripDetVOff* Voff) {
-  
   //Get vector of Voff dets
   std::vector<uint32_t> vdets;
   Voff->getDetIds(vdets);
 
-  std::vector<uint32_t>::const_iterator iter=vdets.begin();
-  std::vector<uint32_t>::const_iterator iterEnd=vdets.end();
+  std::vector<uint32_t>::const_iterator iter = vdets.begin();
+  std::vector<uint32_t>::const_iterator iterEnd = vdets.end();
 
-  for(;iter!=iterEnd;++iter){
-    SiPixelQuality::disabledModuleType BadModule;  
+  for (; iter != iterEnd; ++iter) {
+    SiPixelQuality::disabledModuleType BadModule;
     BadModule.DetID = *iter;
     BadModule.errorType = 0;
-    BadModule.BadRocs = 65535; //NOTE: here all module is bad - no difference for half modules
-    if(IsModuleUsable(BadModule.DetID))
+    BadModule.BadRocs = 65535;  //NOTE: here all module is bad - no difference for half modules
+    if (IsModuleUsable(BadModule.DetID))
       addDisabledModule(BadModule);
-    
   }
 }
 
@@ -85,50 +76,57 @@ void SiPixelQuality::add(const SiStripDetVOff* Voff) {
 
 // ask if module is OK
 bool SiPixelQuality::IsModuleUsable(const uint32_t& detid) const {
-   if(IsFedBad(detid))
-     return true;
-   std::vector<SiPixelQuality::disabledModuleType>disabledModules = theDisabledModules;
-   std::sort(disabledModules.begin(),disabledModules.end(),SiPixelQuality::BadComponentStrictWeakOrdering());
-   std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(disabledModules.begin(),disabledModules.end(),detid,SiPixelQuality::BadComponentStrictWeakOrdering());
-   if (iter != disabledModules.end() && iter->DetID==detid && iter->errorType ==0)
+  if (IsFedBad(detid))
+    return true;
+  std::vector<SiPixelQuality::disabledModuleType> disabledModules = theDisabledModules;
+  std::sort(disabledModules.begin(), disabledModules.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
+  std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(
+      disabledModules.begin(), disabledModules.end(), detid, SiPixelQuality::BadComponentStrictWeakOrdering());
+  if (iter != disabledModules.end() && iter->DetID == detid && iter->errorType == 0)
     return false;
   return true;
 }
 
 int SiPixelQuality::BadModuleNumber() {
-  std::vector<SiPixelQuality::disabledModuleType>disabledModules = theDisabledModules;
-  //does not distinguish between partially dead or not 
+  std::vector<SiPixelQuality::disabledModuleType> disabledModules = theDisabledModules;
+  //does not distinguish between partially dead or not
   return disabledModules.size();
 }
 
 //ask if module is bad
- bool SiPixelQuality::IsModuleBad(const uint32_t & detid) const {
-   if(IsFedBad(detid))
-     return true;
-   std::vector<SiPixelQuality::disabledModuleType>disabledModules = theDisabledModules;
-   std::sort(disabledModules.begin(),disabledModules.end(),SiPixelQuality::BadComponentStrictWeakOrdering());
-   std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(disabledModules.begin(),disabledModules.end(),detid,SiPixelQuality::BadComponentStrictWeakOrdering());
-   if (iter != disabledModules.end() && iter->DetID==detid && iter->errorType == 0) //errorType 0 corresponds to "whole" dead module
-      return true;
-   return false;
+bool SiPixelQuality::IsModuleBad(const uint32_t& detid) const {
+  if (IsFedBad(detid))
+    return true;
+  std::vector<SiPixelQuality::disabledModuleType> disabledModules = theDisabledModules;
+  std::sort(disabledModules.begin(), disabledModules.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
+  std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(
+      disabledModules.begin(), disabledModules.end(), detid, SiPixelQuality::BadComponentStrictWeakOrdering());
+  if (iter != disabledModules.end() && iter->DetID == detid &&
+      iter->errorType == 0)  //errorType 0 corresponds to "whole" dead module
+    return true;
+  return false;
 }
 
 //ask if roc is bad
 bool SiPixelQuality::IsRocBad(const uint32_t& detid, const short& rocNb) const {
-  if(IsModuleBad(detid))
+  if (IsModuleBad(detid))
     return true;
-   std::vector<SiPixelQuality::disabledModuleType>disabledModules = theDisabledModules;
-   std::sort(disabledModules.begin(),disabledModules.end(),SiPixelQuality::BadComponentStrictWeakOrdering());
-   std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(disabledModules.begin(),disabledModules.end(),detid,SiPixelQuality::BadComponentStrictWeakOrdering());
-   if (iter != disabledModules.end() && iter->DetID == detid){
-     return ((iter->BadRocs >> rocNb)&0x1);}
+  std::vector<SiPixelQuality::disabledModuleType> disabledModules = theDisabledModules;
+  std::sort(disabledModules.begin(), disabledModules.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
+  std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(
+      disabledModules.begin(), disabledModules.end(), detid, SiPixelQuality::BadComponentStrictWeakOrdering());
+  if (iter != disabledModules.end() && iter->DetID == detid) {
+    return ((iter->BadRocs >> rocNb) & 0x1);
+  }
   return false;
 }
 
-bool SiPixelQuality::IsAreaBad(uint32_t detid, sipixelobjects::GlobalPixel global, const edm::EventSetup& es, const SiPixelFedCabling* map ) const {
- 
-  SiPixelFrameReverter reverter(es,map);
-  int rocfromarea = -1;  
+bool SiPixelQuality::IsAreaBad(uint32_t detid,
+                               sipixelobjects::GlobalPixel global,
+                               const edm::EventSetup& es,
+                               const SiPixelFedCabling* map) const {
+  SiPixelFrameReverter reverter(es, map);
+  int rocfromarea = -1;
   rocfromarea = reverter.findRocInDet(detid, global);
 
   return SiPixelQuality::IsRocBad(detid, rocfromarea);
@@ -137,49 +135,45 @@ bool SiPixelQuality::IsAreaBad(uint32_t detid, sipixelobjects::GlobalPixel globa
 
 //ask for bad ROCS
 
-
-short SiPixelQuality::getBadRocs(const uint32_t& detid) const{
-  std::vector<SiPixelQuality::disabledModuleType>disabledModules = theDisabledModules;
-  std::sort(disabledModules.begin(),disabledModules.end(),SiPixelQuality::BadComponentStrictWeakOrdering());
-  std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(disabledModules.begin(),disabledModules.end(),detid,SiPixelQuality::BadComponentStrictWeakOrdering());
-  if (iter != disabledModules.end() && iter->DetID==detid)
+short SiPixelQuality::getBadRocs(const uint32_t& detid) const {
+  std::vector<SiPixelQuality::disabledModuleType> disabledModules = theDisabledModules;
+  std::sort(disabledModules.begin(), disabledModules.end(), SiPixelQuality::BadComponentStrictWeakOrdering());
+  std::vector<disabledModuleType>::const_iterator iter = std::lower_bound(
+      disabledModules.begin(), disabledModules.end(), detid, SiPixelQuality::BadComponentStrictWeakOrdering());
+  if (iter != disabledModules.end() && iter->DetID == detid)
     return iter->BadRocs;
   return 0;
 }
 
-const std::vector<LocalPoint> SiPixelQuality::getBadRocPositions(const uint32_t & detid, const TrackerGeometry& theTracker, const SiPixelFedCabling* map) const{
-  std::vector<LocalPoint> badrocpositions (0);
-   for(unsigned int i = 0; i < 16; i++){
-     if (IsRocBad(detid, i) == true){
-    std::vector<CablingPathToDetUnit> path = map->pathToDetUnit(detid);
-    typedef  std::vector<CablingPathToDetUnit>::const_iterator IT;
-       for  (IT it = path.begin(); it != path.end(); ++it) {
-          const PixelROC * myroc = map->findItem(*it);
-          if( myroc->idInDetUnit() == i) {
-              LocalPixel::RocRowCol  local = { 39, 25};   //corresponding to center of ROC row, col
-              GlobalPixel global = myroc->toGlobal( LocalPixel(local) );
-	      //       edm::ESHandle<TrackerGeometry> geom;
-	      //     es.get<TrackerDigiGeometryRecord>().get( geom );
-	      //    const TrackerGeometry& theTracker(*geom);
-              const PixelGeomDetUnit * theGeomDet = dynamic_cast<const PixelGeomDetUnit*> (theTracker.idToDet(detid) );
+const std::vector<LocalPoint> SiPixelQuality::getBadRocPositions(const uint32_t& detid,
+                                                                 const TrackerGeometry& theTracker,
+                                                                 const SiPixelFedCabling* map) const {
+  std::vector<LocalPoint> badrocpositions(0);
+  for (unsigned int i = 0; i < 16; i++) {
+    if (IsRocBad(detid, i) == true) {
+      std::vector<CablingPathToDetUnit> path = map->pathToDetUnit(detid);
+      typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
+      for (IT it = path.begin(); it != path.end(); ++it) {
+        const PixelROC* myroc = map->findItem(*it);
+        if (myroc->idInDetUnit() == i) {
+          LocalPixel::RocRowCol local = {39, 25};  //corresponding to center of ROC row, col
+          GlobalPixel global = myroc->toGlobal(LocalPixel(local));
+          //       edm::ESHandle<TrackerGeometry> geom;
+          //     es.get<TrackerDigiGeometryRecord>().get( geom );
+          //    const TrackerGeometry& theTracker(*geom);
+          const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*>(theTracker.idToDet(detid));
 
-	      PixelTopology const * topology = &(theGeomDet->specificTopology());
+          PixelTopology const* topology = &(theGeomDet->specificTopology());
 
-	      MeasurementPoint thepoint(global.row, global.col);
-              LocalPoint localpoint = topology->localPosition(thepoint);
-	      badrocpositions.push_back(localpoint);
-         break;
-	  }
-       }
-     }
-   }
+          MeasurementPoint thepoint(global.row, global.col);
+          LocalPoint localpoint = topology->localPosition(thepoint);
+          badrocpositions.push_back(localpoint);
+          break;
+        }
+      }
+    }
+  }
   return badrocpositions;
 }
 
-
-bool SiPixelQuality::IsFedBad(const uint32_t & detid) const{
-  return false;
-}
-
-
-
+bool SiPixelQuality::IsFedBad(const uint32_t& detid) const { return false; }

--- a/CondFormats/SiPixelObjects/src/SiPixelQualityProbabilities.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelQualityProbabilities.cc
@@ -1,86 +1,82 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h"
-#include "FWCore/Utilities/interface/Exception.h" 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
-#include <iomanip>      // std::setw
+#include <iomanip>  // std::setw
 
 //****************************************************************************//
 void SiPixelQualityProbabilities::setProbabilities(const unsigned int puBin, const probabilityVec &theProbabilities) {
-
-  if( m_probabilities.find(puBin) != m_probabilities.end()){
-    edm::LogWarning("SiPixelQualityProbabilities") << "PU bin: " << puBin <<" is already in the map!"<<std::endl;
+  if (m_probabilities.find(puBin) != m_probabilities.end()) {
+    edm::LogWarning("SiPixelQualityProbabilities") << "PU bin: " << puBin << " is already in the map!" << std::endl;
     return;
   } else {
-    m_probabilities.emplace(puBin,theProbabilities);
+    m_probabilities.emplace(puBin, theProbabilities);
   }
 }
 
 //****************************************************************************//
-SiPixelQualityProbabilities::probabilityVec SiPixelQualityProbabilities::getProbabilities(const unsigned int puBin) const {
+SiPixelQualityProbabilities::probabilityVec SiPixelQualityProbabilities::getProbabilities(
+    const unsigned int puBin) const {
   probabilityMap::const_iterator it = m_probabilities.find(puBin);
 
-  if (it != m_probabilities.end()){
+  if (it != m_probabilities.end()) {
     return it->second;
   } else {
-    throw cms::Exception("SiPixelQualityProbabilities")<< "No Probabilities are defined for PU bin " << puBin << "\n";
+    throw cms::Exception("SiPixelQualityProbabilities") << "No Probabilities are defined for PU bin " << puBin << "\n";
   }
 }
 
 //****************************************************************************//
-const SiPixelQualityProbabilities::probabilityVec& SiPixelQualityProbabilities::getProbabilities(const unsigned int puBin) {
+const SiPixelQualityProbabilities::probabilityVec &SiPixelQualityProbabilities::getProbabilities(
+    const unsigned int puBin) {
   probabilityMap::const_iterator it = m_probabilities.find(puBin);
 
-  if (it != m_probabilities.end()){
+  if (it != m_probabilities.end()) {
     return it->second;
   } else {
-    throw cms::Exception("SiPixelQualityProbabilities")<< "No Probabilities are defined for PU bin " << puBin << "\n";
+    throw cms::Exception("SiPixelQualityProbabilities") << "No Probabilities are defined for PU bin " << puBin << "\n";
   }
-
 }
-
 
 //****************************************************************************//
 void SiPixelQualityProbabilities::printAll() const {
-  
-  edm::LogVerbatim("SiPixelQualityProbabilities")<<"SiPixelQualityProbabilities::printAll()";
-  edm::LogVerbatim("SiPixelQualityProbabilities")<<" ===================================================================================================================";
-  for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
-    edm::LogVerbatim("SiPixelQualityProbabilities")<< "PU :"<< it->first << "  \n ";
-    for (const auto &entry : it->second){
-      edm::LogVerbatim("SiPixelQualityProbabilities")<<"SiPixelQuality snapshot: " <<  entry.first << " |probability: " << entry.second <<  std::endl;
+  edm::LogVerbatim("SiPixelQualityProbabilities") << "SiPixelQualityProbabilities::printAll()";
+  edm::LogVerbatim("SiPixelQualityProbabilities") << " ================================================================"
+                                                     "===================================================";
+  for (auto it = m_probabilities.begin(); it != m_probabilities.end(); ++it) {
+    edm::LogVerbatim("SiPixelQualityProbabilities") << "PU :" << it->first << "  \n ";
+    for (const auto &entry : it->second) {
+      edm::LogVerbatim("SiPixelQualityProbabilities")
+          << "SiPixelQuality snapshot: " << entry.first << " |probability: " << entry.second << std::endl;
     }
   }
-
 }
 
 //****************************************************************************//
-void SiPixelQualityProbabilities::print(std::ostream & os) const {
-
-  for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
-    os<< "PU :"<< it->first << "  \n ";
-    for (const auto &entry : it->second){
-      os<<"SiPixelQuality snapshot: " <<  entry.first << " |probability: " << entry.second <<  std::endl;
+void SiPixelQualityProbabilities::print(std::ostream &os) const {
+  for (auto it = m_probabilities.begin(); it != m_probabilities.end(); ++it) {
+    os << "PU :" << it->first << "  \n ";
+    for (const auto &entry : it->second) {
+      os << "SiPixelQuality snapshot: " << entry.first << " |probability: " << entry.second << std::endl;
     }
   }
-
 }
-
 
 //****************************************************************************//
 std::vector<unsigned int> SiPixelQualityProbabilities::getPileUpBins() const {
   std::vector<unsigned int> bins;
   bins.reserve(m_probabilities.size());
 
-  for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
+  for (auto it = m_probabilities.begin(); it != m_probabilities.end(); ++it) {
     bins.push_back(it->first);
   }
   return bins;
 }
 
 //****************************************************************************//
-std::ostream & operator<<( std::ostream & os, SiPixelQualityProbabilities theProbabilities) {
+std::ostream &operator<<(std::ostream &os, SiPixelQualityProbabilities theProbabilities) {
   std::stringstream ss;
-  theProbabilities.print( ss );
+  theProbabilities.print(ss);
   os << ss.str();
   return os;
 }

--- a/CondFormats/SiPixelObjects/src/T_EventSetup_SiPixelCPEGenericErrorParm.cc
+++ b/CondFormats/SiPixelObjects/src/T_EventSetup_SiPixelCPEGenericErrorParm.cc
@@ -1,4 +1,4 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
-TYPELOOKUP_DATA_REG(SiPixelCPEGenericErrorParm); 
+TYPELOOKUP_DATA_REG(SiPixelCPEGenericErrorParm);

--- a/CondFormats/SiPixelObjects/src/T_EventSetup_SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/T_EventSetup_SiPixelFedCablingMap.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(SiPixelFedCablingMap);
-

--- a/CondFormats/SiPixelObjects/src/T_EventSetup_SiPixelPerformanceSummary.cc
+++ b/CondFormats/SiPixelObjects/src/T_EventSetup_SiPixelPerformanceSummary.cc
@@ -2,5 +2,4 @@
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelPerformanceSummary.h"
 
-
 TYPELOOKUP_DATA_REG(SiPixelPerformanceSummary);

--- a/CondFormats/SiPixelObjects/src/classes.h
+++ b/CondFormats/SiPixelObjects/src/classes.h
@@ -25,32 +25,30 @@ template struct PixelDCSObject<CaenChannel>;
 
 namespace CondFormats_SiPixelObjects {
   struct dictionary {
-    std::map<SiPixelFedCablingMap::Key, sipixelobjects::PixelROC> theMap; 
-    std::pair<const SiPixelFedCablingMap::Key, sipixelobjects::PixelROC> theMapValueT; 
- 
-    std::map< unsigned int, SiPixelPedestals::SiPixelPedestalsVector> sipixped;
- 
+    std::map<SiPixelFedCablingMap::Key, sipixelobjects::PixelROC> theMap;
+    std::pair<const SiPixelFedCablingMap::Key, sipixelobjects::PixelROC> theMapValueT;
+
+    std::map<unsigned int, SiPixelPedestals::SiPixelPedestalsVector> sipixped;
+
     std::vector<char>::iterator p1;
     std::vector<char>::const_iterator p2;
-    std::vector< SiPixelGainCalibration::DetRegistry >::iterator p3;
-    std::vector< SiPixelGainCalibration::DetRegistry >::const_iterator p4;
- 
-    std::vector< SiPixelGainCalibrationForHLT::DetRegistry >::iterator p5;
-    std::vector< SiPixelGainCalibrationForHLT::DetRegistry >::const_iterator p6;
- 
-    std::vector< SiPixelGainCalibrationOffline::DetRegistry >::iterator p7;
-    std::vector< SiPixelGainCalibrationOffline::DetRegistry >::const_iterator p8;
- 
+    std::vector<SiPixelGainCalibration::DetRegistry>::iterator p3;
+    std::vector<SiPixelGainCalibration::DetRegistry>::const_iterator p4;
+
+    std::vector<SiPixelGainCalibrationForHLT::DetRegistry>::iterator p5;
+    std::vector<SiPixelGainCalibrationForHLT::DetRegistry>::const_iterator p6;
+
+    std::vector<SiPixelGainCalibrationOffline::DetRegistry>::iterator p7;
+    std::vector<SiPixelGainCalibrationOffline::DetRegistry>::const_iterator p8;
+
     std::vector<SiPixelPerformanceSummary::DetSummary>::iterator spps1;
     std::vector<SiPixelPerformanceSummary::DetSummary>::const_iterator spps2;
- 
+
     std::vector<SiPixelQuality::disabledModuleType>::iterator p9;
     std::vector<SiPixelQuality::disabledModuleType>::const_iterator p10;
     std::vector<SiPixelDbItem> p11;
 
-    std::map<unsigned int,SiPixelQualityProbabilities::probabilityVec> myProbabilityMap;
+    std::map<unsigned int, SiPixelQualityProbabilities::probabilityVec> myProbabilityMap;
     std::map<std::string, PixelFEDChannelCollection> myPixelFEDChannelCollection;
-
   };
-}
-
+}  // namespace CondFormats_SiPixelObjects

--- a/CondFormats/SiPixelObjects/src/headers.h
+++ b/CondFormats/SiPixelObjects/src/headers.h
@@ -22,4 +22,3 @@
 
 #include "CondFormats/External/interface/DetID.h"
 #include "CondFormats/External/interface/PixelFEDChannel.h"
-

--- a/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
+++ b/CondFormats/SiPixelObjects/test/FastSiPixelFEDChannelContainerFromQuality.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CondFormats/SiPixelObjects
 // Class:      FastSiPixelFEDChannelContainerFromQuality
-// 
+//
 /**\class FastSiPixelFEDChannelContainerFromQuality FastSiPixelFEDChannelContainerFromQuality.cc CondFormats/SiPixelObjects/plugins/FastSiPixelFEDChannelContainerFromQuality.cc
  Description: class to build the SiPixelFEDChannelContainer payloads
 */
@@ -34,7 +34,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include <iomanip>      // std::setw
+#include <iomanip>  // std::setw
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -48,31 +48,32 @@
 #include <TH1.h>
 
 namespace SiPixelFEDChannelUtils {
-  std::pair<unsigned int,unsigned int> unpack(cond::Time_t since){
+  std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {
     auto kLowMask = 0XFFFFFFFF;
-    auto run  = (since >> 32);
+    auto run = (since >> 32);
     auto lumi = (since & kLowMask);
-    return std::make_pair(run,lumi);
+    return std::make_pair(run, lumi);
   }
-}
+}  // namespace SiPixelFEDChannelUtils
 
 class FastSiPixelFEDChannelContainerFromQuality : public edm::one::EDAnalyzer<> {
 public:
-
-  explicit FastSiPixelFEDChannelContainerFromQuality(const edm::ParameterSet& iConfig );
+  explicit FastSiPixelFEDChannelContainerFromQuality(const edm::ParameterSet& iConfig);
   ~FastSiPixelFEDChannelContainerFromQuality() override;
-  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   void endJob() override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  SiPixelFEDChannelContainer::SiPixelFEDChannelCollection createFromSiPixelQuality(const SiPixelQuality & theQuality, const SiPixelFedCablingMap& theFedCabling,const SiPixelFedCablingTree& theCablingTree);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  SiPixelFEDChannelContainer::SiPixelFEDChannelCollection createFromSiPixelQuality(
+      const SiPixelQuality& theQuality,
+      const SiPixelFedCablingMap& theFedCabling,
+      const SiPixelFedCablingTree& theCablingTree);
 
 private:
-
   cond::persistency::ConnectionPool m_connectionPool;
   const std::string m_condDbQuality;
   const std::string m_condDbCabling;
   const std::string m_QualityTagName;
-  const std::string m_CablingTagName; 
+  const std::string m_CablingTagName;
   const std::string m_record;
 
   // Specify output text file name. Leave empty if do not want to dump in a file
@@ -80,7 +81,7 @@ private:
 
   // Manually specify the start/end time.
   unsigned long long m_startTime;
-  unsigned long long m_endTime;    
+  unsigned long long m_endTime;
 
   const bool printdebug_;
   const bool isMC_;
@@ -90,254 +91,284 @@ private:
 
   inline unsigned int closest_from_above(std::vector<unsigned int> const& vec, unsigned int value) {
     auto const it = std::lower_bound(vec.begin(), vec.end(), value);
-    return vec.at(it-vec.begin()-1);
+    return vec.at(it - vec.begin() - 1);
   }
 
   inline unsigned int closest_from_below(std::vector<unsigned int> const& vec, unsigned int value) {
     auto const it = std::upper_bound(vec.begin(), vec.end(), value);
-    return vec.at(it-vec.begin()-1);
+    return vec.at(it - vec.begin() - 1);
   }
-
-
 };
 
-FastSiPixelFEDChannelContainerFromQuality::FastSiPixelFEDChannelContainerFromQuality(const edm::ParameterSet& iConfig):
-  m_connectionPool(),
-  m_condDbQuality   ( iConfig.getParameter< std::string >("condDBQuality") ),
-  m_condDbCabling   ( iConfig.getParameter< std::string >("condDBCabling") ),
-  m_QualityTagName  ( iConfig.getParameter< std::string >("qualityTagName") ),
-  m_CablingTagName  ( iConfig.getParameter< std::string >("cablingMapTagName") ),
-  m_record   ( iConfig.getParameter<std::string>("record")),
-  m_output   ( iConfig.getParameter< std::string >("output") ),
-  m_startTime( iConfig.getParameter< unsigned long long >("startIOV") ),
-  m_endTime  ( iConfig.getParameter< unsigned long long >("endIOV") ),
-  printdebug_( iConfig.getUntrackedParameter<bool>("printDebug",false)),
-  isMC_      ( iConfig.getUntrackedParameter<bool>("isMC",true)),
-  removeEmptyPayloads_( iConfig.getUntrackedParameter<bool>("removeEmptyPayloads",false))
-{
-  m_connectionPool.setParameters( iConfig.getParameter<edm::ParameterSet>("DBParameters")  );
+FastSiPixelFEDChannelContainerFromQuality::FastSiPixelFEDChannelContainerFromQuality(const edm::ParameterSet& iConfig)
+    : m_connectionPool(),
+      m_condDbQuality(iConfig.getParameter<std::string>("condDBQuality")),
+      m_condDbCabling(iConfig.getParameter<std::string>("condDBCabling")),
+      m_QualityTagName(iConfig.getParameter<std::string>("qualityTagName")),
+      m_CablingTagName(iConfig.getParameter<std::string>("cablingMapTagName")),
+      m_record(iConfig.getParameter<std::string>("record")),
+      m_output(iConfig.getParameter<std::string>("output")),
+      m_startTime(iConfig.getParameter<unsigned long long>("startIOV")),
+      m_endTime(iConfig.getParameter<unsigned long long>("endIOV")),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
+      isMC_(iConfig.getUntrackedParameter<bool>("isMC", true)),
+      removeEmptyPayloads_(iConfig.getUntrackedParameter<bool>("removeEmptyPayloads", false)) {
+  m_connectionPool.setParameters(iConfig.getParameter<edm::ParameterSet>("DBParameters"));
   m_connectionPool.configure();
 
   //now do what ever initialization is needed
   myQualities = new SiPixelFEDChannelContainer();
-
 }
 
-FastSiPixelFEDChannelContainerFromQuality::~FastSiPixelFEDChannelContainerFromQuality() {
-  delete myQualities;
-}
+FastSiPixelFEDChannelContainerFromQuality::~FastSiPixelFEDChannelContainerFromQuality() { delete myQualities; }
 
 void FastSiPixelFEDChannelContainerFromQuality::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-
   std::stringstream ss;
-  
-  cond::Time_t startIov = m_startTime; 
-  cond::Time_t endIov   = m_endTime;   
+
+  cond::Time_t startIov = m_startTime;
+  cond::Time_t endIov = m_endTime;
   if (startIov > endIov)
     throw cms::Exception("endTime must be greater than startTime!");
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							    << "Set start time " << startIov 
-							    << "\n ... Set end time " << endIov;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
+      << "Set start time " << startIov << "\n ... Set end time " << endIov;
 
   // open db session for the quality
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							    << "Query the condition database " << m_condDbQuality;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
+      << "Query the condition database " << m_condDbQuality;
 
-  cond::persistency::Session condDbSession = m_connectionPool.createSession( m_condDbQuality );
-  condDbSession.transaction().start( true );
+  cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condDbQuality);
+  condDbSession.transaction().start(true);
 
   // query the database
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							    << "Reading IOVs from tag " << m_QualityTagName;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
+      << "Reading IOVs from tag " << m_QualityTagName;
 
   // open db session for the cabling map
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							    << "Query the condition database " << m_condDbCabling;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
+      << "Query the condition database " << m_condDbCabling;
 
-  cond::persistency::Session condDbSession2 = m_connectionPool.createSession( m_condDbCabling );
-  condDbSession2.transaction().start( true );
+  cond::persistency::Session condDbSession2 = m_connectionPool.createSession(m_condDbCabling);
+  condDbSession2.transaction().start(true);
 
   // query the database
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							    << "Reading IOVs from tag " << m_CablingTagName;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
+      << "Reading IOVs from tag " << m_CablingTagName;
 
   // get the list of payloads for the SiPixelQuality tag
-  std::vector<std::tuple<cond::Time_t,cond::Hash> > m_iovs;
-  condDbSession.getIovRange(m_QualityTagName,startIov,endIov, m_iovs);
-  
+  std::vector<std::tuple<cond::Time_t, cond::Hash> > m_iovs;
+  condDbSession.getIovRange(m_QualityTagName, startIov, endIov, m_iovs);
+
   const auto MIN_VAL = cond::timeTypeSpecs[cond::runnumber].beginValue;
   const auto MAX_VAL = cond::timeTypeSpecs[cond::runnumber].endValue;
 
-  // get the list of payloads for the Cabling Map 
-  std::vector<std::tuple<cond::Time_t,cond::Hash> > m_cabling_iovs;
-  condDbSession2.getIovRange(m_CablingTagName,MIN_VAL,MAX_VAL,m_cabling_iovs);
+  // get the list of payloads for the Cabling Map
+  std::vector<std::tuple<cond::Time_t, cond::Hash> > m_cabling_iovs;
+  condDbSession2.getIovRange(m_CablingTagName, MIN_VAL, MAX_VAL, m_cabling_iovs);
 
   // create here the unpacked list of IOVs (run numbers)
   std::vector<unsigned int> listOfIOVs;
-  std::transform(m_iovs.begin(), m_iovs.end(), std::back_inserter(listOfIOVs),
-		 [](std::tuple<cond::Time_t,cond::Hash> myIOV) -> unsigned int { return SiPixelFEDChannelUtils::unpack(std::get<0>(myIOV)).first; });
+  std::transform(m_iovs.begin(),
+                 m_iovs.end(),
+                 std::back_inserter(listOfIOVs),
+                 [](std::tuple<cond::Time_t, cond::Hash> myIOV) -> unsigned int {
+                   return SiPixelFEDChannelUtils::unpack(std::get<0>(myIOV)).first;
+                 });
 
   std::vector<unsigned int> listOfCablingIOVs;
-  std::transform(m_cabling_iovs.begin(), m_cabling_iovs.end(), std::back_inserter(listOfCablingIOVs),
-		 [](std::tuple<cond::Time_t,cond::Hash> myIOV2) -> unsigned int { return std::get<0>(myIOV2); });
+  std::transform(m_cabling_iovs.begin(),
+                 m_cabling_iovs.end(),
+                 std::back_inserter(listOfCablingIOVs),
+                 [](std::tuple<cond::Time_t, cond::Hash> myIOV2) -> unsigned int { return std::get<0>(myIOV2); });
 
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<<" Number of SiPixelQuality paloyads to analyze: " << listOfIOVs.size() << " Number of SiPixelFedCablngMap payloads: " << listOfCablingIOVs.size() << std::endl; 
-  
-  if(listOfCablingIOVs.size()>1){
-    if( closest_from_below(listOfCablingIOVs,listOfIOVs.front()) != closest_from_above(listOfCablingIOVs,listOfIOVs.back()) ){
-      throw cms::Exception("")<< " The Pixel FED Cabling map does not cover all the requested SiPixelQuality IOVs in the same interval of validity \n";
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << " Number of SiPixelQuality paloyads to analyze: " << listOfIOVs.size()
+      << " Number of SiPixelFedCablngMap payloads: " << listOfCablingIOVs.size() << std::endl;
+
+  if (listOfCablingIOVs.size() > 1) {
+    if (closest_from_below(listOfCablingIOVs, listOfIOVs.front()) !=
+        closest_from_above(listOfCablingIOVs, listOfIOVs.back())) {
+      throw cms::Exception("") << " The Pixel FED Cabling map does not cover all the requested SiPixelQuality IOVs in "
+                                  "the same interval of validity \n";
     }
   } else {
-    if(listOfIOVs.front() < listOfCablingIOVs.front() ){
-      throw cms::Exception("")<< " The Pixel FED Cabling map does not cover all the requested IOVs \n";
+    if (listOfIOVs.front() < listOfCablingIOVs.front()) {
+      throw cms::Exception("") << " The Pixel FED Cabling map does not cover all the requested IOVs \n";
     }
   }
 
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<< " First run covered by SiPixelQuality tag: " << listOfIOVs.front() << " / last run covered by SiPixelQuality tag: " << listOfIOVs.back() << std::endl;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << " First run covered by SiPixelQuality tag: " << listOfIOVs.front()
+      << " / last run covered by SiPixelQuality tag: " << listOfIOVs.back() << std::endl;
 
-  edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")<< " SiPixel Cabling Map IOVs in the interval: " ;
-  for(const auto& cb : m_cabling_iovs ){
-    edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")<< " " << std::setw(6) << std::get<0>(cb) << " : " << std::get<1>(cb);
+  edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << " SiPixel Cabling Map IOVs in the interval: ";
+  for (const auto& cb : m_cabling_iovs) {
+    edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")
+        << " " << std::setw(6) << std::get<0>(cb) << " : " << std::get<1>(cb);
   }
-  edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")<< std::endl;
+  edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << std::endl;
 
-  if(printdebug_){
-    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<< " closest_from_above(listOfCablingIOVs,listOfIOVs.back()): "  << closest_from_above(listOfCablingIOVs,listOfIOVs.back()) << std::endl;
-    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<< " closest_from_below(listOfCablingIOVs,listOfIOVs.front()): " << closest_from_below(listOfCablingIOVs,listOfIOVs.front()) << std::endl;
-  }  
+  if (printdebug_) {
+    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+        << " closest_from_above(listOfCablingIOVs,listOfIOVs.back()): "
+        << closest_from_above(listOfCablingIOVs, listOfIOVs.back()) << std::endl;
+    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+        << " closest_from_below(listOfCablingIOVs,listOfIOVs.front()): "
+        << closest_from_below(listOfCablingIOVs, listOfIOVs.front()) << std::endl;
+  }
 
-  auto it = std::find(listOfCablingIOVs.begin(),listOfCablingIOVs.end(),closest_from_below(listOfCablingIOVs,listOfIOVs.front()));
-  int index = std::distance(listOfCablingIOVs.begin(),it);  
+  auto it = std::find(
+      listOfCablingIOVs.begin(), listOfCablingIOVs.end(), closest_from_below(listOfCablingIOVs, listOfIOVs.front()));
+  int index = std::distance(listOfCablingIOVs.begin(), it);
 
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<< " using the SiPixelFedCablingMap with hash: " << std::get<1>(m_cabling_iovs.at(index)) << std::endl;
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << " using the SiPixelFedCablingMap with hash: " << std::get<1>(m_cabling_iovs.at(index)) << std::endl;
 
   auto theCablingMapPayload = condDbSession2.fetchPayload<SiPixelFedCablingMap>(std::get<1>(m_cabling_iovs.at(index)));
   auto theCablingTree = (*theCablingMapPayload).cablingTree();
 
-  printf("Progressing Bar                               :0%%       20%%       40%%       60%%       80%%       100%%\n");
+  printf(
+      "Progressing Bar                               :0%%       20%%       40%%       60%%       80%%       100%%\n");
   printf("Translating into SiPixelFEDChannelCollection  :");
-  int step = m_iovs.size()/50;
+  int step = m_iovs.size() / 50;
 
   int niov = 0;
-  for (const auto & myIOV : m_iovs){
-    
-    if(niov%step==0){printf(".");fflush(stdout);}
+  for (const auto& myIOV : m_iovs) {
+    if (niov % step == 0) {
+      printf(".");
+      fflush(stdout);
+    }
     auto payload = condDbSession.fetchPayload<SiPixelQuality>(std::get<1>(myIOV));
     auto runLS = SiPixelFEDChannelUtils::unpack(std::get<0>(myIOV));
-    
+
     // print IOVs summary
-    ss  << runLS.first << ","<< runLS.second << " ("<< std::get<0>(myIOV)  <<")" << " [hash: " << std::get<1>(myIOV)  << "] \n";
-    
-    std::string scenario = std::to_string(runLS.first)+"_"+std::to_string(runLS.second);
- 
-    if(printdebug_){
-      edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<<"Found IOV:" << runLS.first  <<"("<<  runLS.second <<")"<<std::endl;
-    }    
+    ss << runLS.first << "," << runLS.second << " (" << std::get<0>(myIOV) << ")"
+       << " [hash: " << std::get<1>(myIOV) << "] \n";
 
-    auto theSiPixelFEDChannelCollection = this->createFromSiPixelQuality(*payload,*theCablingMapPayload,*theCablingTree);
+    std::string scenario = std::to_string(runLS.first) + "_" + std::to_string(runLS.second);
 
-    if(removeEmptyPayloads_ && theSiPixelFEDChannelCollection.empty()) return;
+    if (printdebug_) {
+      edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+          << "Found IOV:" << runLS.first << "(" << runLS.second << ")" << std::endl;
+    }
 
-    myQualities->setScenario(scenario,theSiPixelFEDChannelCollection);
-    
+    auto theSiPixelFEDChannelCollection =
+        this->createFromSiPixelQuality(*payload, *theCablingMapPayload, *theCablingTree);
+
+    if (removeEmptyPayloads_ && theSiPixelFEDChannelCollection.empty())
+      return;
+
+    myQualities->setScenario(scenario, theSiPixelFEDChannelCollection);
+
     ++niov;
   }
 
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							    << "Read " << niov << " IOVs from tag " << m_QualityTagName << " corresponding to the specified time interval.\n\n" << ss.str();
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
+      << "Read " << niov << " IOVs from tag " << m_QualityTagName
+      << " corresponding to the specified time interval.\n\n"
+      << ss.str();
 
-  if(printdebug_){
-    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] "
-							      << ss.str();
+  if (printdebug_) {
+    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+        << "[FastSiPixelFEDChannelContainerFromQuality::" << __func__ << "] " << ss.str();
   }
 
   condDbSession.transaction().commit();
   condDbSession2.transaction().commit();
-  
+
   if (!m_output.empty()) {
     std::ofstream fout;
     fout.open(m_output);
     fout << ss.str();
     fout.close();
-  }  
+  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------
 SiPixelFEDChannelContainer::SiPixelFEDChannelCollection
-FastSiPixelFEDChannelContainerFromQuality::createFromSiPixelQuality(const SiPixelQuality & theQuality, const SiPixelFedCablingMap& theFedCabling,const SiPixelFedCablingTree& theCablingTree)
-{
+FastSiPixelFEDChannelContainerFromQuality::createFromSiPixelQuality(const SiPixelQuality& theQuality,
+                                                                    const SiPixelFedCablingMap& theFedCabling,
+                                                                    const SiPixelFedCablingTree& theCablingTree) {
   auto fedid_ = theFedCabling.det2fedMap();
 
   SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadChannelCollection;
 
   auto theDisabledModules = theQuality.getBadComponentList();
-  for (const auto &mod : theDisabledModules){
+  for (const auto& mod : theDisabledModules) {
     //mod.DetID, mod.errorType,mod.BadRocs
-    
+
     int coded_badRocs = mod.BadRocs;
     std::vector<PixelFEDChannel> disabledChannelsDetSet;
     std::vector<sipixelobjects::CablingPathToDetUnit> path = theFedCabling.pathToDetUnit(mod.DetID);
     unsigned int nrocs_inLink(0);
-    if (path.size() != 0){
-      const sipixelobjects::PixelFEDCabling * aFed = theCablingTree.fed(path.at(0).fed);
-      const sipixelobjects::PixelFEDLink    * link = aFed->link(path.at(0).link);
+    if (path.size() != 0) {
+      const sipixelobjects::PixelFEDCabling* aFed = theCablingTree.fed(path.at(0).fed);
+      const sipixelobjects::PixelFEDLink* link = aFed->link(path.at(0).link);
       nrocs_inLink = link->numberOfROCs();
-    }	
-    
-    std::bitset<16> bad_rocs(coded_badRocs);	  
-    unsigned int n_ch = bad_rocs.size()/nrocs_inLink;
-	  
-    for (unsigned int i_roc = 0; i_roc < n_ch; ++i_roc){
-      
-      unsigned int first_idx = nrocs_inLink*i_roc;
-      unsigned int sec_idx   = nrocs_inLink*(i_roc+1)-1;
-      unsigned int mask      = pow(2,nrocs_inLink)-1;
-      unsigned int n_setbits = (coded_badRocs >> (i_roc*nrocs_inLink)) & mask;
+    }
 
-      if (n_setbits==0){
-	continue;
+    std::bitset<16> bad_rocs(coded_badRocs);
+    unsigned int n_ch = bad_rocs.size() / nrocs_inLink;
+
+    for (unsigned int i_roc = 0; i_roc < n_ch; ++i_roc) {
+      unsigned int first_idx = nrocs_inLink * i_roc;
+      unsigned int sec_idx = nrocs_inLink * (i_roc + 1) - 1;
+      unsigned int mask = pow(2, nrocs_inLink) - 1;
+      unsigned int n_setbits = (coded_badRocs >> (i_roc * nrocs_inLink)) & mask;
+
+      if (n_setbits == 0) {
+        continue;
       }
 
-      if(n_setbits != mask){
-	if(printdebug_){      
-	  edm::LogWarning("FastSiPixelFEDChannelContainerFromQuality")  << "Mismatch! DetId: "<< mod.DetID << " " << n_setbits <<  " " <<  mask << std::endl;
-	}
-	continue;
+      if (n_setbits != mask) {
+        if (printdebug_) {
+          edm::LogWarning("FastSiPixelFEDChannelContainerFromQuality")
+              << "Mismatch! DetId: " << mod.DetID << " " << n_setbits << " " << mask << std::endl;
+        }
+        continue;
       }
-	    
-      if(printdebug_){      
-	edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << "passed" << std::endl;
+
+      if (printdebug_) {
+        edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << "passed" << std::endl;
       }
 
       unsigned int link_id = 99999;
       unsigned int fed_id = 99999;
-	    
-      for (auto const& p: path){
-	const sipixelobjects::PixelFEDCabling * aFed = theCablingTree.fed(p.fed);
-	const sipixelobjects::PixelFEDLink * link = aFed->link(p.link);
-	const sipixelobjects::PixelROC * roc = link->roc(p.roc);
-	unsigned int first_roc = roc->idInDetUnit();
-	
-	if (first_roc == first_idx){	
-	  link_id = p.link;
-	  fed_id = p.fed;
-	  break; 
-	}
+
+      for (auto const& p : path) {
+        const sipixelobjects::PixelFEDCabling* aFed = theCablingTree.fed(p.fed);
+        const sipixelobjects::PixelFEDLink* link = aFed->link(p.link);
+        const sipixelobjects::PixelROC* roc = link->roc(p.roc);
+        unsigned int first_roc = roc->idInDetUnit();
+
+        if (first_roc == first_idx) {
+          link_id = p.link;
+          fed_id = p.fed;
+          break;
+        }
       }
 
-      if(printdebug_){
-	edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << " " << fed_id << " " << link_id << " " << first_idx << "  " << sec_idx << std::endl;
-      }	 
+      if (printdebug_) {
+        edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")
+            << " " << fed_id << " " << link_id << " " << first_idx << "  " << sec_idx << std::endl;
+      }
 
       PixelFEDChannel ch = {fed_id, link_id, first_idx, sec_idx};
       disabledChannelsDetSet.push_back(ch);
-      
-      if(printdebug_){
-	edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << i_roc << " " << coded_badRocs <<  " " << first_idx << " " << sec_idx << std::endl;
-	edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality") << "=======================================" << std::endl;
+
+      if (printdebug_) {
+        edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")
+            << i_roc << " " << coded_badRocs << " " << first_idx << " " << sec_idx << std::endl;
+        edm::LogVerbatim("FastSiPixelFEDChannelContainerFromQuality")
+            << "=======================================" << std::endl;
       }
     }
-    
+
     if (!disabledChannelsDetSet.empty()) {
       theBadChannelCollection[mod.DetID] = disabledChannelsDetSet;
     }
@@ -345,60 +376,56 @@ FastSiPixelFEDChannelContainerFromQuality::createFromSiPixelQuality(const SiPixe
   return theBadChannelCollection;
 }
 
-
-void
-FastSiPixelFEDChannelContainerFromQuality::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-
+void FastSiPixelFEDChannelContainerFromQuality::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Writes payloads of type SiPixelFEDChannelContainer");
-  desc.addUntracked<bool>("printDebug",false);
-  desc.addUntracked<bool>("removeEmptyPayloads",false);
-  desc.add<std::string>("record","SiPixelStatusScenariosRcd");
-  desc.add<std::string>("condDBQuality","frontier://FrontierPrep/CMS_CONDITIONS");
-  desc.add<std::string>("qualityTagName","SiPixelQualityOffline_2017_threshold1percent_stuckTBM");
-  desc.add<std::string>("condDBCabling","frontier://FrontierProd/CMS_CONDITIONS");
-  desc.add<std::string>("cablingMapTagName","SiPixelFedCablingMap_v1");
-  desc.add<unsigned long long>("startIOV",1310841198608821);
-  desc.add<unsigned long long>("endIOV",1312696624480350);
-  desc.add<std::string>("output","summary.txt");
-  desc.add<std::string>("connect","");
+  desc.addUntracked<bool>("printDebug", false);
+  desc.addUntracked<bool>("removeEmptyPayloads", false);
+  desc.add<std::string>("record", "SiPixelStatusScenariosRcd");
+  desc.add<std::string>("condDBQuality", "frontier://FrontierPrep/CMS_CONDITIONS");
+  desc.add<std::string>("qualityTagName", "SiPixelQualityOffline_2017_threshold1percent_stuckTBM");
+  desc.add<std::string>("condDBCabling", "frontier://FrontierProd/CMS_CONDITIONS");
+  desc.add<std::string>("cablingMapTagName", "SiPixelFedCablingMap_v1");
+  desc.add<unsigned long long>("startIOV", 1310841198608821);
+  desc.add<unsigned long long>("endIOV", 1312696624480350);
+  desc.add<std::string>("output", "summary.txt");
+  desc.add<std::string>("connect", "");
 
   edm::ParameterSetDescription descDBParameters;
-  descDBParameters.addUntracked<std::string>("authenticationPath","");  
-  descDBParameters.addUntracked<int>("authenticationSystem",0);  
-  descDBParameters.addUntracked<std::string>("security","");  
-  descDBParameters.addUntracked<int>("messageLevel",0);  
+  descDBParameters.addUntracked<std::string>("authenticationPath", "");
+  descDBParameters.addUntracked<int>("authenticationSystem", 0);
+  descDBParameters.addUntracked<std::string>("security", "");
+  descDBParameters.addUntracked<int>("messageLevel", 0);
 
-  desc.add<edm::ParameterSetDescription>("DBParameters",descDBParameters);
+  desc.add<edm::ParameterSetDescription>("DBParameters", descDBParameters);
   descriptions.add("FastSiPixelFEDChannelContainerFromQuality", desc);
 }
 
-
-void 
-FastSiPixelFEDChannelContainerFromQuality::endJob() {
-
+void FastSiPixelFEDChannelContainerFromQuality::endJob() {
   //  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<<"Analyzed "<<IOVcount_<<" IOVs"<<std::endl;
-  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<<"Size of SiPixelFEDChannelContainer object "<< myQualities->size() <<std::endl<<std::endl;
-  
-  if(printdebug_){
-    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")<<"Content of SiPixelFEDChannelContainer "<<std::endl;
-    
+  edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality")
+      << "Size of SiPixelFEDChannelContainer object " << myQualities->size() << std::endl
+      << std::endl;
+
+  if (printdebug_) {
+    edm::LogInfo("FastSiPixelFEDChannelContainerFromQuality") << "Content of SiPixelFEDChannelContainer " << std::endl;
+
     // use built-in method in the CondFormat
-     myQualities->printAll();
+    myQualities->printAll();
   }
 
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    cond::Time_t valid_time = poolDbService->currentTime(); 
+  if (poolDbService.isAvailable()) {
+    cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    if(!isMC_){
-      poolDbService->writeOne(myQualities,valid_time, m_record);
+    if (!isMC_) {
+      poolDbService->writeOne(myQualities, valid_time, m_record);
     } else {
       // for MC IOV since=1
-      poolDbService->writeOne(myQualities,1, m_record);
+      poolDbService->writeOne(myQualities, 1, m_record);
     }
-  } 
+  }
 }
 
 DEFINE_FWK_MODULE(FastSiPixelFEDChannelContainerFromQuality);

--- a/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker.cc
@@ -17,126 +17,136 @@
 
 class SiPixelBadFEDChannelSimulationSanityChecker : public edm::one::EDAnalyzer<> {
 public:
-  explicit SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p); 
-  ~SiPixelBadFEDChannelSimulationSanityChecker(); 
+  explicit SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p);
+  ~SiPixelBadFEDChannelSimulationSanityChecker();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
-    
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
   const bool printdebug_;
-  
 };
-  
-SiPixelBadFEDChannelSimulationSanityChecker::SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p):
-  printdebug_(p.getUntrackedParameter<bool>("printDebug",true))
-{ 
-  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")<<"SiPixelBadFEDChannelSimulationSanityChecker"<<std::endl;
+
+SiPixelBadFEDChannelSimulationSanityChecker::SiPixelBadFEDChannelSimulationSanityChecker(edm::ParameterSet const& p)
+    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)) {
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")
+      << "SiPixelBadFEDChannelSimulationSanityChecker" << std::endl;
 }
 
-SiPixelBadFEDChannelSimulationSanityChecker::~SiPixelBadFEDChannelSimulationSanityChecker() {  
-  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")<<"~SiPixelBadFEDChannelSimulationSanityChecker "<<std::endl;
+SiPixelBadFEDChannelSimulationSanityChecker::~SiPixelBadFEDChannelSimulationSanityChecker() {
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")
+      << "~SiPixelBadFEDChannelSimulationSanityChecker " << std::endl;
 }
 
-void
-SiPixelBadFEDChannelSimulationSanityChecker::analyze(const edm::Event& e, const edm::EventSetup& context){
-  
-  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<"### SiPixelBadFEDChannelSimulationSanityChecker::analyze  ###"<<std::endl;
-  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-  
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenariosRcd")); 
-  if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+void SiPixelBadFEDChannelSimulationSanityChecker::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")
+      << "### SiPixelBadFEDChannelSimulationSanityChecker::analyze  ###" << std::endl;
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+  edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+  edm::eventsetup::EventSetupRecordKey recordKey(
+      edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenariosRcd"));
+  if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
     //record not found
-    edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") <<"Record \"SiPixelStatusScenariosRcd"<<"\" does not exist "<<std::endl;
+    edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") << "Record \"SiPixelStatusScenariosRcd"
+                                                                << "\" does not exist " << std::endl;
   }
-  
+
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle;  
+  edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle;
   context.get<SiPixelStatusScenariosRcd>().get(qualityCollectionHandle);
-  const SiPixelFEDChannelContainer* quality_map=qualityCollectionHandle.product();
+  const SiPixelFEDChannelContainer* quality_map = qualityCollectionHandle.product();
 
-  edm::eventsetup::EventSetupRecordKey recordKey2(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd>"));
-    
-  if( recordKey2.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+  edm::eventsetup::EventSetupRecordKey recordKey2(
+      edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd>"));
+
+  if (recordKey2.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
     //record not found
-    edm::LogWarning("SiPixelQualityProbabilitiesTestReader") <<"Record \"SiPixelStatusScenarioProbabilityRcd>"<<"\" does not exist "<<std::endl;
+    edm::LogWarning("SiPixelQualityProbabilitiesTestReader") << "Record \"SiPixelStatusScenarioProbabilityRcd>"
+                                                             << "\" does not exist " << std::endl;
   }
-  
+
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle;  
+  edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle;
   context.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
-  const SiPixelQualityProbabilities* myProbabilities=scenarioProbabilityHandle.product();
+  const SiPixelQualityProbabilities* myProbabilities = scenarioProbabilityHandle.product();
 
   SiPixelFEDChannelContainer::SiPixelBadFEDChannelsScenarioMap m_qualities = quality_map->getScenarioMap();
-  SiPixelQualityProbabilities:: probabilityMap m_probabilities = myProbabilities->getProbability_Map();    
+  SiPixelQualityProbabilities::probabilityMap m_probabilities = myProbabilities->getProbability_Map();
 
   std::vector<std::string> allScenarios = quality_map->getScenarioList();
   std::vector<std::string> allScenariosInProb;
 
-  for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
+  for (auto it = m_probabilities.begin(); it != m_probabilities.end(); ++it) {
     //int PUbin = it->first;
-    for (const auto &entry : it->second){
-      auto scenario    = entry.first;
+    for (const auto& entry : it->second) {
+      auto scenario = entry.first;
       auto probability = entry.second;
-      if(probability!=0){
-	if(std::find(allScenariosInProb.begin(), allScenariosInProb.end(), scenario) == allScenariosInProb.end()) {
-	  allScenariosInProb.push_back(scenario);
-	}
+      if (probability != 0) {
+        if (std::find(allScenariosInProb.begin(), allScenariosInProb.end(), scenario) == allScenariosInProb.end()) {
+          allScenariosInProb.push_back(scenario);
+        }
 
-	// if(m_qualities.find(scenario) == m_qualities.end()){
-	//   edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<"Pretty worrying! the scenario: " << scenario << " (prob:" << probability << ") is not found in the map!!"<<std::endl; 
-	// } else {
-	//   edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") << "scenario: "<< scenario << " is in the map! (all is good)"<< std::endl;  
-	// }
-	
-      } // if prob!=0
-    } // loop on the scenarios for that PU bin
-  } // loop on PU bins
-  
+        // if(m_qualities.find(scenario) == m_qualities.end()){
+        //   edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<"Pretty worrying! the scenario: " << scenario << " (prob:" << probability << ") is not found in the map!!"<<std::endl;
+        // } else {
+        //   edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker") << "scenario: "<< scenario << " is in the map! (all is good)"<< std::endl;
+        // }
+
+      }  // if prob!=0
+    }    // loop on the scenarios for that PU bin
+  }      // loop on PU bins
+
   std::vector<std::string> notFound;
-  std::copy_if(allScenariosInProb.begin(), allScenariosInProb.end(), std::back_inserter(notFound),
-	       [&allScenarios](const std::string& arg)
-	       { return (std::find(allScenarios.begin(),allScenarios.end(), arg) == allScenarios.end());});
-  
-  if(notFound.size()!=0){
-    for(const auto &entry : notFound){
-      edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<"Pretty worrying! the scenario: " << entry <<"  is not found in the map!!"<<std::endl; 
+  std::copy_if(allScenariosInProb.begin(),
+               allScenariosInProb.end(),
+               std::back_inserter(notFound),
+               [&allScenarios](const std::string& arg) {
+                 return (std::find(allScenarios.begin(), allScenarios.end(), arg) == allScenarios.end());
+               });
 
-      if(printdebug_){
-	edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<" This scenario is found in: "<< std::endl;
-	for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
-	  int PUbin = it->first;
+  if (notFound.size() != 0) {
+    for (const auto& entry : notFound) {
+      edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker")
+          << "Pretty worrying! the scenario: " << entry << "  is not found in the map!!" << std::endl;
 
-	  for (const auto &pair : it->second){
-	    if(pair.first == entry){
-	      edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker") <<" - PU bin "<< PUbin <<" with probability: "<< pair.second << std::endl;
-	    } // if the scenario matches
-	  } // loop on scenarios
-	} // loop on PU
-      } // if printdebug
-      edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<"=============================================="<<std::endl;
-    } // loop on scenarios not found
+      if (printdebug_) {
+        edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker") << " This scenario is found in: " << std::endl;
+        for (auto it = m_probabilities.begin(); it != m_probabilities.end(); ++it) {
+          int PUbin = it->first;
 
-    edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker") <<" ====> A total of "<< notFound.size() <<" scenarios are not found in the map!"<<std::endl;
+          for (const auto& pair : it->second) {
+            if (pair.first == entry) {
+              edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")
+                  << " - PU bin " << PUbin << " with probability: " << pair.second << std::endl;
+            }  // if the scenario matches
+          }    // loop on scenarios
+        }      // loop on PU
+      }        // if printdebug
+      edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")
+          << "==============================================" << std::endl;
+    }  // loop on scenarios not found
+
+    edm::LogWarning("SiPixelBadFEDChannelSimulationSanityChecker")
+        << " ====> A total of " << notFound.size() << " scenarios are not found in the map!" << std::endl;
 
   } else {
-    edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<"================================================================================="<<std::endl;
-    edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")    <<" All scenarios in probability record are found in the scenario map, (all is good)!"<< std::endl;
-    edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")<<"================================================================================="<<std::endl;
+    edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")
+        << "=================================================================================" << std::endl;
+    edm::LogInfo("SiPixelBadFEDChannelSimulationSanityChecker")
+        << " All scenarios in probability record are found in the scenario map, (all is good)!" << std::endl;
+    edm::LogVerbatim("SiPixelBadFEDChannelSimulationSanityChecker")
+        << "=================================================================================" << std::endl;
   }
-
 }
 
-void
-SiPixelBadFEDChannelSimulationSanityChecker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelBadFEDChannelSimulationSanityChecker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Tries sanity of Pixel Stuck TBM simulation");
-  desc.addUntracked<bool>("printDebug",true);
-  descriptions.add("SiPixelBadFEDChannelSimulationSanityChecker",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  descriptions.add("SiPixelBadFEDChannelSimulationSanityChecker", desc);
 }
 
 DEFINE_FWK_MODULE(SiPixelBadFEDChannelSimulationSanityChecker);

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerFromQualityConverter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CondFormats/SiPixelObjects
 // Class:      SiPixelFEDChannelContainerFromQualityConverter
-// 
+//
 /**\class SiPixelFEDChannelContainerFromQualityConverter SiPixelFEDChannelContainerFromQualityConverter.cc CondFormats/SiPixelObjects/plugins/SiPixelFEDChannelContainerFromQualityConverter.cc
  Description: class to build the SiPixelFEDChannelContainer payloads
 */
@@ -38,47 +38,45 @@
 // class declaration
 //
 
-class SiPixelFEDChannelContainerFromQualityConverter : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit SiPixelFEDChannelContainerFromQualityConverter(const edm::ParameterSet&);
-      ~SiPixelFEDChannelContainerFromQualityConverter();
+class SiPixelFEDChannelContainerFromQualityConverter : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiPixelFEDChannelContainerFromQualityConverter(const edm::ParameterSet&);
+  ~SiPixelFEDChannelContainerFromQualityConverter();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-      SiPixelFEDChannelContainer::SiPixelFEDChannelCollection createFromSiPixelQuality(const SiPixelQuality & theQuality, const SiPixelFedCablingMap& theFedCabling);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  SiPixelFEDChannelContainer::SiPixelFEDChannelCollection createFromSiPixelQuality(
+      const SiPixelQuality& theQuality, const SiPixelFedCablingMap& theFedCabling);
 
-   private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
-      // ----------member data ---------------------------
-      const std::string m_record;
-      const bool printdebug_;
-      const bool isMC_;
-      const bool removeEmptyPayloads_;
-      SiPixelFEDChannelContainer* myQualities;
+  // ----------member data ---------------------------
+  const std::string m_record;
+  const bool printdebug_;
+  const bool isMC_;
+  const bool removeEmptyPayloads_;
+  SiPixelFEDChannelContainer* myQualities;
 
-      int IOVcount_;
-      edm::ESWatcher<SiPixelQualityFromDbRcd> SiPixelQualityWatcher_;
-
+  int IOVcount_;
+  edm::ESWatcher<SiPixelQualityFromDbRcd> SiPixelQualityWatcher_;
 };
 
 //
 // constructors and destructor
 //
-SiPixelFEDChannelContainerFromQualityConverter::SiPixelFEDChannelContainerFromQualityConverter(const edm::ParameterSet& iConfig):
-  m_record(iConfig.getParameter<std::string>("record")),
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false)),
-  isMC_(iConfig.getUntrackedParameter<bool>("isMC",true)),
-  removeEmptyPayloads_(iConfig.getUntrackedParameter<bool>("removeEmptyPayloads",false))
-{
+SiPixelFEDChannelContainerFromQualityConverter::SiPixelFEDChannelContainerFromQualityConverter(
+    const edm::ParameterSet& iConfig)
+    : m_record(iConfig.getParameter<std::string>("record")),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
+      isMC_(iConfig.getUntrackedParameter<bool>("isMC", true)),
+      removeEmptyPayloads_(iConfig.getUntrackedParameter<bool>("removeEmptyPayloads", false)) {
   //now do what ever initialization is needed
   myQualities = new SiPixelFEDChannelContainer();
 }
 
-
-SiPixelFEDChannelContainerFromQualityConverter::~SiPixelFEDChannelContainerFromQualityConverter()
-{
+SiPixelFEDChannelContainerFromQualityConverter::~SiPixelFEDChannelContainerFromQualityConverter() {
   delete myQualities;
 }
 
@@ -87,115 +85,117 @@ SiPixelFEDChannelContainerFromQualityConverter::~SiPixelFEDChannelContainerFromQ
 //
 
 // ------------ method called for each event  ------------
-void
-SiPixelFEDChannelContainerFromQualityConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   
-   unsigned int RunNumber_= iEvent.eventAuxiliary().run();
-   unsigned int LuminosityBlockNumber_ = iEvent.eventAuxiliary().luminosityBlock();
-      
-   bool hasQualityIOV = SiPixelQualityWatcher_.check(iSetup);
-   
-   if(hasQualityIOV){
+void SiPixelFEDChannelContainerFromQualityConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-     //Retrieve the strip quality from conditions
-     edm::ESHandle<SiPixelQuality> siPixelQuality_;
-     iSetup.get<SiPixelQualityFromDbRcd>().get(siPixelQuality_);
+  unsigned int RunNumber_ = iEvent.eventAuxiliary().run();
+  unsigned int LuminosityBlockNumber_ = iEvent.eventAuxiliary().luminosityBlock();
 
-     edm::ESHandle<SiPixelFedCablingMap> cablingMapHandle;
-     iSetup.get<SiPixelFedCablingMapRcd>().get(cablingMapHandle);
+  bool hasQualityIOV = SiPixelQualityWatcher_.check(iSetup);
 
-     std::string scenario = std::to_string(RunNumber_)+"_"+std::to_string(LuminosityBlockNumber_);
+  if (hasQualityIOV) {
+    //Retrieve the strip quality from conditions
+    edm::ESHandle<SiPixelQuality> siPixelQuality_;
+    iSetup.get<SiPixelQualityFromDbRcd>().get(siPixelQuality_);
 
-     edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")<<"Found IOV:" << RunNumber_ <<"("<< LuminosityBlockNumber_ <<")"<<std::endl;
-     
-     auto theSiPixelFEDChannelCollection = this->createFromSiPixelQuality(*(siPixelQuality_.product()),*(cablingMapHandle.product()));
+    edm::ESHandle<SiPixelFedCablingMap> cablingMapHandle;
+    iSetup.get<SiPixelFedCablingMapRcd>().get(cablingMapHandle);
 
-     if(removeEmptyPayloads_ && theSiPixelFEDChannelCollection.empty()) return;
+    std::string scenario = std::to_string(RunNumber_) + "_" + std::to_string(LuminosityBlockNumber_);
 
-     myQualities->setScenario(scenario,theSiPixelFEDChannelCollection);
+    edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")
+        << "Found IOV:" << RunNumber_ << "(" << LuminosityBlockNumber_ << ")" << std::endl;
 
-     IOVcount_++;
+    auto theSiPixelFEDChannelCollection =
+        this->createFromSiPixelQuality(*(siPixelQuality_.product()), *(cablingMapHandle.product()));
 
-   }
+    if (removeEmptyPayloads_ && theSiPixelFEDChannelCollection.empty())
+      return;
+
+    myQualities->setScenario(scenario, theSiPixelFEDChannelCollection);
+
+    IOVcount_++;
+  }
 }
-   
+
 // ------------ method called once each job just before starting event loop  ------------
 SiPixelFEDChannelContainer::SiPixelFEDChannelCollection
-SiPixelFEDChannelContainerFromQualityConverter::createFromSiPixelQuality(const SiPixelQuality & theQuality, const SiPixelFedCablingMap& theFedCabling)
-{
+SiPixelFEDChannelContainerFromQualityConverter::createFromSiPixelQuality(const SiPixelQuality& theQuality,
+                                                                         const SiPixelFedCablingMap& theFedCabling) {
   auto fedid_ = theFedCabling.det2fedMap();
 
   SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadChannelCollection;
 
   auto theDisabledModules = theQuality.getBadComponentList();
-  for (const auto &mod : theDisabledModules){
+  for (const auto& mod : theDisabledModules) {
     //mod.DetID, mod.errorType,mod.BadRocs
-    
+
     int coded_badRocs = mod.BadRocs;
     std::vector<PixelFEDChannel> disabledChannelsDetSet;
     std::vector<sipixelobjects::CablingPathToDetUnit> path = theFedCabling.pathToDetUnit(mod.DetID);
     auto cabling_ = theFedCabling.cablingTree();
     unsigned int nrocs_inLink(0);
-    if (path.size() != 0){
-      const sipixelobjects::PixelFEDCabling * aFed = cabling_->fed(path.at(0).fed);
-      const sipixelobjects::PixelFEDLink    * link = aFed->link(path.at(0).link);
+    if (path.size() != 0) {
+      const sipixelobjects::PixelFEDCabling* aFed = cabling_->fed(path.at(0).fed);
+      const sipixelobjects::PixelFEDLink* link = aFed->link(path.at(0).link);
       nrocs_inLink = link->numberOfROCs();
-    }	
-    
-    std::bitset<16> bad_rocs(coded_badRocs);	  
-    unsigned int n_ch = bad_rocs.size()/nrocs_inLink;
-	  
-    for (unsigned int i_roc = 0; i_roc < n_ch; ++i_roc){
-      
-      unsigned int first_idx = nrocs_inLink*i_roc;
-      unsigned int sec_idx   = nrocs_inLink*(i_roc+1)-1;
-      unsigned int mask      = pow(2,nrocs_inLink)-1;
-      unsigned int n_setbits = (coded_badRocs >> (i_roc*nrocs_inLink)) & mask;
+    }
 
-      if (n_setbits==0){
-	continue;
+    std::bitset<16> bad_rocs(coded_badRocs);
+    unsigned int n_ch = bad_rocs.size() / nrocs_inLink;
+
+    for (unsigned int i_roc = 0; i_roc < n_ch; ++i_roc) {
+      unsigned int first_idx = nrocs_inLink * i_roc;
+      unsigned int sec_idx = nrocs_inLink * (i_roc + 1) - 1;
+      unsigned int mask = pow(2, nrocs_inLink) - 1;
+      unsigned int n_setbits = (coded_badRocs >> (i_roc * nrocs_inLink)) & mask;
+
+      if (n_setbits == 0) {
+        continue;
       }
 
-      if(n_setbits != mask){
-	edm::LogWarning("SiPixelFEDChannelContainerFromQualityConverter")  << "Mismatch! DetId: "<< mod.DetID << " " << n_setbits <<  " " <<  mask << std::endl;
-	continue;
+      if (n_setbits != mask) {
+        edm::LogWarning("SiPixelFEDChannelContainerFromQualityConverter")
+            << "Mismatch! DetId: " << mod.DetID << " " << n_setbits << " " << mask << std::endl;
+        continue;
       }
-	    
-      if(printdebug_){      
-	edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter") << "passed" << std::endl;
+
+      if (printdebug_) {
+        edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter") << "passed" << std::endl;
       }
 
       unsigned int link_id = 99999;
       unsigned int fed_id = 99999;
-	    
-      for (auto const& p: path){
-	const sipixelobjects::PixelFEDCabling * aFed = cabling_->fed(p.fed);
-	const sipixelobjects::PixelFEDLink * link = aFed->link(p.link);
-	const sipixelobjects::PixelROC * roc = link->roc(p.roc);
-	unsigned int first_roc = roc->idInDetUnit();
-	
-	if (first_roc == first_idx){	
-	  link_id = p.link;
-	  fed_id = p.fed;
-	  break; 
-	}
+
+      for (auto const& p : path) {
+        const sipixelobjects::PixelFEDCabling* aFed = cabling_->fed(p.fed);
+        const sipixelobjects::PixelFEDLink* link = aFed->link(p.link);
+        const sipixelobjects::PixelROC* roc = link->roc(p.roc);
+        unsigned int first_roc = roc->idInDetUnit();
+
+        if (first_roc == first_idx) {
+          link_id = p.link;
+          fed_id = p.fed;
+          break;
+        }
       }
 
-      if(printdebug_){
-	edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter") << " " << fed_id << " " << link_id << " " << first_idx << "  " << sec_idx << std::endl;
-      }	 
+      if (printdebug_) {
+        edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter")
+            << " " << fed_id << " " << link_id << " " << first_idx << "  " << sec_idx << std::endl;
+      }
 
       PixelFEDChannel ch = {fed_id, link_id, first_idx, sec_idx};
       disabledChannelsDetSet.push_back(ch);
-      
-      if(printdebug_){
-	edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter") << i_roc << " " << coded_badRocs <<  " " << first_idx << " " << sec_idx << std::endl;
-	edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter") << "=======================================" << std::endl;
+
+      if (printdebug_) {
+        edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter")
+            << i_roc << " " << coded_badRocs << " " << first_idx << " " << sec_idx << std::endl;
+        edm::LogVerbatim("SiPixelFEDChannelContainerFromQualityConverter")
+            << "=======================================" << std::endl;
       }
     }
-    
+
     if (!disabledChannelsDetSet.empty()) {
       theBadChannelCollection[mod.DetID] = disabledChannelsDetSet;
     }
@@ -203,50 +203,45 @@ SiPixelFEDChannelContainerFromQualityConverter::createFromSiPixelQuality(const S
   return theBadChannelCollection;
 }
 
-void 
-SiPixelFEDChannelContainerFromQualityConverter::beginJob()
-{
-  IOVcount_=0;
-}
+void SiPixelFEDChannelContainerFromQualityConverter::beginJob() { IOVcount_ = 0; }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelFEDChannelContainerFromQualityConverter::endJob() 
-{
+void SiPixelFEDChannelContainerFromQualityConverter::endJob() {
+  edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter") << "Analyzed " << IOVcount_ << " IOVs" << std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")
+      << "Size of SiPixelFEDChannelContainer object " << myQualities->size() << std::endl
+      << std::endl;
 
-  edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")<<"Analyzed "<<IOVcount_<<" IOVs"<<std::endl;
-  edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")<<"Size of SiPixelFEDChannelContainer object "<< myQualities->size() <<std::endl<<std::endl;
-
-  if(printdebug_){
-    edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")<<"Content of SiPixelFEDChannelContainer "<<std::endl;
+  if (printdebug_) {
+    edm::LogInfo("SiPixelFEDChannelContainerFromQualityConverter")
+        << "Content of SiPixelFEDChannelContainer " << std::endl;
 
     // use built-in method in the CondFormat
-     myQualities->printAll();
+    myQualities->printAll();
   }
 
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    cond::Time_t valid_time = poolDbService->currentTime(); 
+  if (poolDbService.isAvailable()) {
+    cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    if(!isMC_){
-      poolDbService->writeOne(myQualities,valid_time, m_record);
+    if (!isMC_) {
+      poolDbService->writeOne(myQualities, valid_time, m_record);
     } else {
       // for MC IOV since=1
-      poolDbService->writeOne(myQualities,1, m_record);
+      poolDbService->writeOne(myQualities, 1, m_record);
     }
-  } 
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-SiPixelFEDChannelContainerFromQualityConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelFEDChannelContainerFromQualityConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Writes payloads of type SiPixelFEDChannelContainer");
-  desc.addUntracked<bool>("printDebug",false);
-  desc.addUntracked<bool>("removeEmptyPayloads",false);
-  desc.add<std::string>("record","SiPixelStatusScenariosRcd");
-  descriptions.add("SiPixelFEDChannelContainerFromQualityConverter",desc);
+  desc.addUntracked<bool>("printDebug", false);
+  desc.addUntracked<bool>("removeEmptyPayloads", false);
+  desc.add<std::string>("record", "SiPixelStatusScenariosRcd");
+  descriptions.add("SiPixelFEDChannelContainerFromQualityConverter", desc);
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerTestReader.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerTestReader.cc
@@ -15,94 +15,100 @@
 
 class SiPixelFEDChannelContainerTestReader : public edm::one::EDAnalyzer<> {
 public:
-  explicit SiPixelFEDChannelContainerTestReader(edm::ParameterSet const& p); 
-  ~SiPixelFEDChannelContainerTestReader(); 
+  explicit SiPixelFEDChannelContainerTestReader(edm::ParameterSet const& p);
+  ~SiPixelFEDChannelContainerTestReader();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
-    
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
   const bool printdebug_;
   const std::string formatedOutput_;
-  
 };
-  
-SiPixelFEDChannelContainerTestReader::SiPixelFEDChannelContainerTestReader(edm::ParameterSet const& p):
-  printdebug_(p.getUntrackedParameter<bool>("printDebug",true)),
-  formatedOutput_(p.getUntrackedParameter<std::string>("outputFile",""))
-{ 
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader")<<"SiPixelFEDChannelContainerTestReader"<<std::endl;
+
+SiPixelFEDChannelContainerTestReader::SiPixelFEDChannelContainerTestReader(edm::ParameterSet const& p)
+    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
+      formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "SiPixelFEDChannelContainerTestReader" << std::endl;
 }
 
-SiPixelFEDChannelContainerTestReader::~SiPixelFEDChannelContainerTestReader() {  
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader")<<"~SiPixelFEDChannelContainerTestReader "<<std::endl;
+SiPixelFEDChannelContainerTestReader::~SiPixelFEDChannelContainerTestReader() {
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "~SiPixelFEDChannelContainerTestReader " << std::endl;
 }
 
-void
-SiPixelFEDChannelContainerTestReader::analyze(const edm::Event& e, const edm::EventSetup& context){
-  
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"### SiPixelFEDChannelContainerTestReader::analyze  ###"<<std::endl;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-  
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenariosRcd"));
-    
-  if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+void SiPixelFEDChannelContainerTestReader::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader")
+      << "### SiPixelFEDChannelContainerTestReader::analyze  ###" << std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+  edm::eventsetup::EventSetupRecordKey recordKey(
+      edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenariosRcd"));
+
+  if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
     //record not found
-    edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"Record \"SiPixelStatusScenariosRcd"<<"\" does not exist "<<std::endl;
+    edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "Record \"SiPixelStatusScenariosRcd"
+                                                         << "\" does not exist " << std::endl;
   }
-  
+
   //this part gets the handle of the event source and the record (i.e. the Database)
   edm::ESHandle<SiPixelFEDChannelContainer> qualityCollectionHandle;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"got eshandle"<<std::endl;
-  
-  context.get<SiPixelStatusScenariosRcd>().get(qualityCollectionHandle);
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"got context"<<std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got eshandle" << std::endl;
 
-  const SiPixelFEDChannelContainer* quality_map=qualityCollectionHandle.product();
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"got SiPixelFEDChannelContainer* "<< std::endl;
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "print  pointer address : " << quality_map << std::endl;  
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "Size "  <<  quality_map->size() << std::endl;     
-  edm::LogInfo("SiPixelFEDChannelContainerTestReader") <<"Content of myQuality_Map "<<std::endl;
+  context.get<SiPixelStatusScenariosRcd>().get(qualityCollectionHandle);
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got context" << std::endl;
+
+  const SiPixelFEDChannelContainer* quality_map = qualityCollectionHandle.product();
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "got SiPixelFEDChannelContainer* " << std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "print  pointer address : " << quality_map << std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "Size " << quality_map->size() << std::endl;
+  edm::LogInfo("SiPixelFEDChannelContainerTestReader") << "Content of myQuality_Map " << std::endl;
   // use built-in method in the CondFormat to print the content
-  if(printdebug_){
+  if (printdebug_) {
     quality_map->printAll();
   }
-  
-  FILE* pFile=NULL;
-  if(formatedOutput_!="")pFile=fopen(formatedOutput_.c_str(), "w");
-  if(pFile){
-    
-    fprintf(pFile,"SiPixelFEDChannelContainer::printAll() \n");
-    fprintf(pFile," =================================================================================================================== \n"); 
 
-    SiPixelFEDChannelContainer::SiPixelBadFEDChannelsScenarioMap m_qualities = quality_map-> getScenarioMap();
-      
-    for(auto it = m_qualities.begin(); it != m_qualities.end() ; ++it){
-      fprintf(pFile," =================================================================================================================== \n");
-      fprintf(pFile,"run : %s \n ",(it->first).c_str());
-      for (const auto& thePixelFEDChannel : it->second){
-	DetId detId = thePixelFEDChannel.first;
-	fprintf(pFile,"DetId : %i \n",detId.rawId());
-	for(const auto& entry: thePixelFEDChannel.second) {
-	  //unsigned int fed, link, roc_first, roc_last;
-	  fprintf(pFile,"fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",entry.fed, entry.link,  entry.roc_first, entry.roc_last);	  
-	}
+  FILE* pFile = NULL;
+  if (formatedOutput_ != "")
+    pFile = fopen(formatedOutput_.c_str(), "w");
+  if (pFile) {
+    fprintf(pFile, "SiPixelFEDChannelContainer::printAll() \n");
+    fprintf(pFile,
+            " ========================================================================================================="
+            "========== \n");
+
+    SiPixelFEDChannelContainer::SiPixelBadFEDChannelsScenarioMap m_qualities = quality_map->getScenarioMap();
+
+    for (auto it = m_qualities.begin(); it != m_qualities.end(); ++it) {
+      fprintf(pFile,
+              " ======================================================================================================="
+              "============ \n");
+      fprintf(pFile, "run : %s \n ", (it->first).c_str());
+      for (const auto& thePixelFEDChannel : it->second) {
+        DetId detId = thePixelFEDChannel.first;
+        fprintf(pFile, "DetId : %i \n", detId.rawId());
+        for (const auto& entry : thePixelFEDChannel.second) {
+          //unsigned int fed, link, roc_first, roc_last;
+          fprintf(pFile,
+                  "fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",
+                  entry.fed,
+                  entry.link,
+                  entry.roc_first,
+                  entry.roc_last);
+        }
       }
     }
   }
 }
 
-void
-SiPixelFEDChannelContainerTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelFEDChannelContainerTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Reads payloads of type SiPixelFEDChannelContainer");
-  desc.addUntracked<bool>("printDebug",true);
-  desc.addUntracked<std::string>("outputFile","");
-  descriptions.add("SiPixelFEDChannelContainerTestReader",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  desc.addUntracked<std::string>("outputFile", "");
+  descriptions.add("SiPixelFEDChannelContainerTestReader", desc);
 }
 
 DEFINE_FWK_MODULE(SiPixelFEDChannelContainerTestReader);

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CondFormats/SiPixelObjects
 // Class:      SiPixelFEDChannelContainerTestWriter
-// 
+//
 /**\class SiPixelFEDChannelContainerTestWriter SiPixelFEDChannelContainerTestWriter.cc CondFormats/SiPixelObjects/plugins/SiPixelFEDChannelContainerTestWriter.cc
  Description: class to build the SiPixelFEDChannelContainer payloads
 */
@@ -36,143 +36,133 @@
 // class declaration
 //
 
-class SiPixelFEDChannelContainerWriteFromASCII : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit SiPixelFEDChannelContainerWriteFromASCII(const edm::ParameterSet&);
-      ~SiPixelFEDChannelContainerWriteFromASCII();
+class SiPixelFEDChannelContainerWriteFromASCII : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiPixelFEDChannelContainerWriteFromASCII(const edm::ParameterSet&);
+  ~SiPixelFEDChannelContainerWriteFromASCII();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
-   private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
-
-      // ----------member data ---------------------------
-      const std::string m_record;
-      const std::string m_SnapshotInputs;
-      const bool printdebug_;
-      const bool addDefault_;
-      SiPixelFEDChannelContainer* myQualities;
-
+  // ----------member data ---------------------------
+  const std::string m_record;
+  const std::string m_SnapshotInputs;
+  const bool printdebug_;
+  const bool addDefault_;
+  SiPixelFEDChannelContainer* myQualities;
 };
 
 //
 // constructors and destructor
 //
-SiPixelFEDChannelContainerWriteFromASCII::SiPixelFEDChannelContainerWriteFromASCII(const edm::ParameterSet& iConfig):
-  m_record(iConfig.getParameter<std::string>("record")),
-  m_SnapshotInputs(iConfig.getParameter<std::string>("snapshots")),
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false)),
-  addDefault_(iConfig.getUntrackedParameter<bool>("addDefault",false))
-{
+SiPixelFEDChannelContainerWriteFromASCII::SiPixelFEDChannelContainerWriteFromASCII(const edm::ParameterSet& iConfig)
+    : m_record(iConfig.getParameter<std::string>("record")),
+      m_SnapshotInputs(iConfig.getParameter<std::string>("snapshots")),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
+      addDefault_(iConfig.getUntrackedParameter<bool>("addDefault", false)) {
   //now do what ever initialization is needed
   myQualities = new SiPixelFEDChannelContainer();
 }
 
-
-SiPixelFEDChannelContainerWriteFromASCII::~SiPixelFEDChannelContainerWriteFromASCII()
-{
-  delete myQualities;
-}
+SiPixelFEDChannelContainerWriteFromASCII::~SiPixelFEDChannelContainerWriteFromASCII() { delete myQualities; }
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-SiPixelFEDChannelContainerWriteFromASCII::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-      
-   std::ifstream mysnapshots(m_SnapshotInputs); 
-   std::string  line; 
+void SiPixelFEDChannelContainerWriteFromASCII::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   std::string scenario ="";
-   unsigned int thedetid(0);
-   
-   SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadFEDChannels;
+  std::ifstream mysnapshots(m_SnapshotInputs);
+  std::string line;
 
-   if(mysnapshots.is_open()){
-     while (getline (mysnapshots, line)) {
-       //edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << line << std::endl;
-       std::istringstream iss (line);            
-       unsigned int run, ls, detid, fed, link, roc_first, roc_last;
-       iss >> run >> ls >> detid >> fed >> link >> roc_first >> roc_last;
+  std::string scenario = "";
+  unsigned int thedetid(0);
 
-       PixelFEDChannel theBadChannel{fed,link,roc_first,roc_last};
-       
-       auto newscenario=std::to_string(run)+"_"+std::to_string(ls);
-       if(newscenario!=scenario){
-	 edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")<< "================================" << std::endl;
-	 edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")<< "found a new scenario: " << newscenario << std::endl;
-	 if(scenario!=""){
-	   edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")<< "size of the fed channel vector: " <<  theBadFEDChannels.size() << std::endl;
-	   edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")<< "================================" << std::endl;
-	   myQualities->setScenario(scenario,theBadFEDChannels);
-	   theBadFEDChannels.clear();
-	 }
-	 scenario=newscenario;
-       }
+  SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadFEDChannels;
 
-       if(detid!=thedetid){
-	 if(printdebug_) edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")<< "found a new detid!" << detid << std::endl;	 
-	 thedetid=detid;
-       } 
-       theBadFEDChannels[thedetid].push_back(theBadChannel);
-     }
-   }
-   
-   myQualities->setScenario(scenario,theBadFEDChannels);
+  if (mysnapshots.is_open()) {
+    while (getline(mysnapshots, line)) {
+      //edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << line << std::endl;
+      std::istringstream iss(line);
+      unsigned int run, ls, detid, fed, link, roc_first, roc_last;
+      iss >> run >> ls >> detid >> fed >> link >> roc_first >> roc_last;
 
-   if(printdebug_){
-     edm::LogInfo("SiPixelFEDChannelContainerWriteFromASCII")<<"Content of SiPixelFEDChannelContainer "<<std::endl;
+      PixelFEDChannel theBadChannel{fed, link, roc_first, roc_last};
 
-     // use buil-in method in the CondFormat
-     myQualities->printAll();
-   }
-}
-   
-// ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelFEDChannelContainerWriteFromASCII::beginJob()
-{
-}
+      auto newscenario = std::to_string(run) + "_" + std::to_string(ls);
+      if (newscenario != scenario) {
+        edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << "================================" << std::endl;
+        edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")
+            << "found a new scenario: " << newscenario << std::endl;
+        if (scenario != "") {
+          edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")
+              << "size of the fed channel vector: " << theBadFEDChannels.size() << std::endl;
+          edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII")
+              << "================================" << std::endl;
+          myQualities->setScenario(scenario, theBadFEDChannels);
+          theBadFEDChannels.clear();
+        }
+        scenario = newscenario;
+      }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelFEDChannelContainerWriteFromASCII::endJob() 
-{
-
-  // adds an empty payload with name "default" => no channels are masked
-  if(addDefault_){
-    SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadFEDChannels;
-    myQualities->setScenario("default",theBadFEDChannels);
+      if (detid != thedetid) {
+        if (printdebug_)
+          edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << "found a new detid!" << detid << std::endl;
+        thedetid = detid;
+      }
+      theBadFEDChannels[thedetid].push_back(theBadChannel);
+    }
   }
 
-  edm::LogInfo("SiPixelFEDChannelContainerWriteFromASCII")<<"Size of SiPixelFEDChannelContainer object "<< myQualities->size() <<std::endl<<std::endl;
+  myQualities->setScenario(scenario, theBadFEDChannels);
+
+  if (printdebug_) {
+    edm::LogInfo("SiPixelFEDChannelContainerWriteFromASCII") << "Content of SiPixelFEDChannelContainer " << std::endl;
+
+    // use buil-in method in the CondFormat
+    myQualities->printAll();
+  }
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void SiPixelFEDChannelContainerWriteFromASCII::beginJob() {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void SiPixelFEDChannelContainerWriteFromASCII::endJob() {
+  // adds an empty payload with name "default" => no channels are masked
+  if (addDefault_) {
+    SiPixelFEDChannelContainer::SiPixelFEDChannelCollection theBadFEDChannels;
+    myQualities->setScenario("default", theBadFEDChannels);
+  }
+
+  edm::LogInfo("SiPixelFEDChannelContainerWriteFromASCII")
+      << "Size of SiPixelFEDChannelContainer object " << myQualities->size() << std::endl
+      << std::endl;
 
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    cond::Time_t valid_time = poolDbService->currentTime(); 
+  if (poolDbService.isAvailable()) {
+    cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myQualities,valid_time, m_record);
-  } 
+    poolDbService->writeOne(myQualities, valid_time, m_record);
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-SiPixelFEDChannelContainerWriteFromASCII::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelFEDChannelContainerWriteFromASCII::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Writes payloads of type SiPixelFEDChannelContainer from input ASCII files");
-  desc.addUntracked<bool>("printDebug",true);
-  desc.addUntracked<bool>("addDefault",true);
-  desc.add<std::string>("snapshots","");
-  desc.add<std::string>("record","SiPixelStatusScenariosRcd");
-  descriptions.add("SiPixelFEDChannelContainerWriteFromASCII",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  desc.addUntracked<bool>("addDefault", true);
+  desc.add<std::string>("snapshots", "");
+  desc.add<std::string>("record", "SiPixelStatusScenariosRcd");
+  descriptions.add("SiPixelFEDChannelContainerWriteFromASCII", desc);
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapAnalyzer.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapAnalyzer.cc
@@ -12,35 +12,32 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
 // class declaration
 class SiPixelFedCablingMapAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit SiPixelFedCablingMapAnalyzer( const edm::ParameterSet& ) {}
-      ~SiPixelFedCablingMapAnalyzer();
-      virtual void analyze( const edm::Event&, const edm::EventSetup& );
-   private:
+public:
+  explicit SiPixelFedCablingMapAnalyzer(const edm::ParameterSet&) {}
+  ~SiPixelFedCablingMapAnalyzer();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
 };
 
+SiPixelFedCablingMapAnalyzer::~SiPixelFedCablingMapAnalyzer() {}
 
-SiPixelFedCablingMapAnalyzer::~SiPixelFedCablingMapAnalyzer(){}
+void SiPixelFedCablingMapAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::cout << "====== SiPixelFedCablingMapAnalyzer" << std::endl;
 
-void SiPixelFedCablingMapAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+  edm::ESHandle<SiPixelFedCablingMap> map;
+  iSetup.get<SiPixelFedCablingMapRcd>().get(map);
 
-   std::cout << "====== SiPixelFedCablingMapAnalyzer" << std::endl;
-
-   edm::ESHandle<SiPixelFedCablingMap> map;
-   iSetup.get<SiPixelFedCablingMapRcd>().get(map);
-
-   LogInfo(" got map, version: ") << map->version();
-   auto tree = map->cablingTree();
-   LogInfo("PRINT MAP:")<<tree->print(100);
-   LogInfo("PRINT MAP, end:");
-
+  LogInfo(" got map, version: ") << map->version();
+  auto tree = map->cablingTree();
+  LogInfo("PRINT MAP:") << tree->print(100);
+  LogInfo("PRINT MAP, end:");
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapTestWriter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFedCablingMapTestWriter.cc
@@ -23,83 +23,74 @@ using namespace edm;
 using namespace sipixelobjects;
 
 class SiPixelFedCablingMapTestWriter : public edm::EDAnalyzer {
- public:
-  explicit SiPixelFedCablingMapTestWriter( const edm::ParameterSet& );
+public:
+  explicit SiPixelFedCablingMapTestWriter(const edm::ParameterSet&);
   ~SiPixelFedCablingMapTestWriter();
   virtual void beginJob();
   virtual void endJob();
-  virtual void analyze(const edm::Event& , const edm::EventSetup& ){}
- private:
-  SiPixelFedCablingTree * cablingTree;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) {}
+
+private:
+  SiPixelFedCablingTree* cablingTree;
   string m_record;
 };
 
-
-SiPixelFedCablingMapTestWriter::SiPixelFedCablingMapTestWriter( const edm::ParameterSet& iConfig ) 
-  : cablingTree(0),
-    m_record(iConfig.getParameter<std::string>("record"))
-{
-  cout <<" HERE record: "<< m_record<<endl;
+SiPixelFedCablingMapTestWriter::SiPixelFedCablingMapTestWriter(const edm::ParameterSet& iConfig)
+    : cablingTree(0), m_record(iConfig.getParameter<std::string>("record")) {
+  cout << " HERE record: " << m_record << endl;
   ::putenv((char*)"CORAL_AUTH_USER=konec");
-  ::putenv((char*)"CORAL_AUTH_PASSWORD=test"); 
+  ::putenv((char*)"CORAL_AUTH_PASSWORD=test");
 }
 
-void  SiPixelFedCablingMapTestWriter::endJob()
-{
-  cout<<"Convert Tree to Map";
- 
-  SiPixelFedCablingMap * cablingMap = new SiPixelFedCablingMap(cablingTree);
-  cout<<"Now writing to DB"<<endl;
+void SiPixelFedCablingMapTestWriter::endJob() {
+  cout << "Convert Tree to Map";
+
+  SiPixelFedCablingMap* cablingMap = new SiPixelFedCablingMap(cablingTree);
+  cout << "Now writing to DB" << endl;
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
-  if( !mydbservice.isAvailable() ){
-    cout<<"db service unavailable"<<endl;
+  if (!mydbservice.isAvailable()) {
+    cout << "db service unavailable" << endl;
     return;
-  } else { cout<<"DB service OK"<<endl; }
+  } else {
+    cout << "DB service OK" << endl;
+  }
 
   try {
-    if( mydbservice->isNewTagRequest(m_record) ) {
-      mydbservice->createNewIOV<SiPixelFedCablingMap>( 
-          cablingMap,
-	  mydbservice->beginOfTime(),
-	  mydbservice->endOfTime(), 
-	  m_record);
+    if (mydbservice->isNewTagRequest(m_record)) {
+      mydbservice->createNewIOV<SiPixelFedCablingMap>(
+          cablingMap, mydbservice->beginOfTime(), mydbservice->endOfTime(), m_record);
     } else {
-      mydbservice->appendSinceTime<SiPixelFedCablingMap>(
-          cablingMap, 
-	  mydbservice->currentTime(), 
-	  m_record);
+      mydbservice->appendSinceTime<SiPixelFedCablingMap>(cablingMap, mydbservice->currentTime(), m_record);
     }
+  } catch (std::exception& e) {
+    cout << "std::exception:  " << e.what();
+  } catch (...) {
+    cout << "Unknown error caught " << endl;
   }
-  catch (std::exception &e) { cout <<"std::exception:  "<< e.what(); }
-  catch (...) { cout << "Unknown error caught "<<endl; }
-  cout<<"... all done, end"<<endl;
-
+  cout << "... all done, end" << endl;
 }
 
-SiPixelFedCablingMapTestWriter::~SiPixelFedCablingMapTestWriter()
-{
-  cout <<"DTOR !" << endl;
-}
+SiPixelFedCablingMapTestWriter::~SiPixelFedCablingMapTestWriter() { cout << "DTOR !" << endl; }
 
 // ------------ method called to produce the data  ------------
 void SiPixelFedCablingMapTestWriter::beginJob() {
-   cout << "BeginJob method " << endl;
-   cout<<"Building FED Cabling"<<endl;   
-   cablingTree =  new SiPixelFedCablingTree("My map V-TEST");
+  cout << "BeginJob method " << endl;
+  cout << "Building FED Cabling" << endl;
+  cablingTree = new SiPixelFedCablingTree("My map V-TEST");
 
-   PixelROC r1;
-   PixelROC r2;
+  PixelROC r1;
+  PixelROC r2;
 
-   PixelFEDLink link(2);
-   PixelFEDLink::ROCs rocs; rocs.push_back(r1); rocs.push_back(r2);
-   link.add(rocs);
+  PixelFEDLink link(2);
+  PixelFEDLink::ROCs rocs;
+  rocs.push_back(r1);
+  rocs.push_back(r2);
+  link.add(rocs);
 
-   PixelFEDCabling fed(0);
-   fed.addLink(link);
-   cablingTree->addFed(fed);
-   cout <<"PRINTING MAP:"<<endl<<cablingTree->print(3) << endl;
-
-   
+  PixelFEDCabling fed(0);
+  fed.addLink(link);
+  cablingTree->addFed(fed);
+  cout << "PRINTING MAP:" << endl << cablingTree->print(3) << endl;
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestReader.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestReader.cc
@@ -13,90 +13,91 @@
 
 class SiPixelQualityProbabilitiesTestReader : public edm::one::EDAnalyzer<> {
 public:
-  explicit SiPixelQualityProbabilitiesTestReader(edm::ParameterSet const& p); 
-  ~SiPixelQualityProbabilitiesTestReader(); 
+  explicit SiPixelQualityProbabilitiesTestReader(edm::ParameterSet const& p);
+  ~SiPixelQualityProbabilitiesTestReader();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
-    
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   // ----------member data ---------------------------
   const bool printdebug_;
   const std::string formatedOutput_;
-  
 };
-  
-SiPixelQualityProbabilitiesTestReader::SiPixelQualityProbabilitiesTestReader(edm::ParameterSet const& p):
-  printdebug_(p.getUntrackedParameter<bool>("printDebug",true)),
-  formatedOutput_(p.getUntrackedParameter<std::string>("outputFile",""))
-{ 
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader")<<"SiPixelQualityProbabilitiesTestReader"<<std::endl;
+
+SiPixelQualityProbabilitiesTestReader::SiPixelQualityProbabilitiesTestReader(edm::ParameterSet const& p)
+    : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
+      formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "SiPixelQualityProbabilitiesTestReader" << std::endl;
 }
 
-SiPixelQualityProbabilitiesTestReader::~SiPixelQualityProbabilitiesTestReader() {  
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader")<<"~SiPixelQualityProbabilitiesTestReader "<<std::endl;
+SiPixelQualityProbabilitiesTestReader::~SiPixelQualityProbabilitiesTestReader() {
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "~SiPixelQualityProbabilitiesTestReader " << std::endl;
 }
 
-void
-SiPixelQualityProbabilitiesTestReader::analyze(const edm::Event& e, const edm::EventSetup& context){
-  
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"### SiPixelQualityProbabilitiesTestReader::analyze  ###"<<std::endl;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-  
-  edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd"));
-    
-  if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+void SiPixelQualityProbabilitiesTestReader::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader")
+      << "### SiPixelQualityProbabilitiesTestReader::analyze  ###" << std::endl;
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << " ---EVENT NUMBER " << e.id().event() << std::endl;
+
+  edm::eventsetup::EventSetupRecordKey recordKey(
+      edm::eventsetup::EventSetupRecordKey::TypeTag::findType("SiPixelStatusScenarioProbabilityRcd"));
+
+  if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
     //record not found
-    edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"Record \"SiPixelStatusScenarioProbabilityRcd"<<"\" does not exist "<<std::endl;
+    edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "Record \"SiPixelStatusScenarioProbabilityRcd"
+                                                          << "\" does not exist " << std::endl;
   }
-  
+
   //this part gets the handle of the event source and the record (i.e. the Database)
   edm::ESHandle<SiPixelQualityProbabilities> scenarioProbabilityHandle;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"got eshandle"<<std::endl;
-  
-  context.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"got context"<<std::endl;
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got eshandle" << std::endl;
 
-  const SiPixelQualityProbabilities* myProbabilities=scenarioProbabilityHandle.product();
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"got SiPixelQualityProbabilities* "<< std::endl;
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "print  pointer address : " << myProbabilities << std::endl ;
-  
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "Size "  << myProbabilities->size() << std::endl;     
-  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") <<"Content of my Probabilities "<<std::endl;
+  context.get<SiPixelStatusScenarioProbabilityRcd>().get(scenarioProbabilityHandle);
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got context" << std::endl;
+
+  const SiPixelQualityProbabilities* myProbabilities = scenarioProbabilityHandle.product();
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "got SiPixelQualityProbabilities* " << std::endl;
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "print  pointer address : " << myProbabilities << std::endl;
+
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "Size " << myProbabilities->size() << std::endl;
+  edm::LogInfo("SiPixelQualityProbabilitiesTestReader") << "Content of my Probabilities " << std::endl;
   // use built-in method in the CondFormat to print the content
-  if(printdebug_){
+  if (printdebug_) {
     myProbabilities->printAll();
   }
-  
-  FILE* pFile=NULL;
-  if(formatedOutput_!="")pFile=fopen(formatedOutput_.c_str(), "w");
-  if(pFile){
-    
-    fprintf(pFile,"SiPixelQualityProbabilities::printAll() \n");
-    fprintf(pFile," =================================================================================================================== \n"); 
 
-    SiPixelQualityProbabilities:: probabilityMap m_probabilities = myProbabilities->getProbability_Map();
-      
-    for(auto it = m_probabilities.begin(); it != m_probabilities.end() ; ++it){
-      fprintf(pFile," =================================================================================================================== \n");
-      fprintf(pFile,"PU bin : %i \n ",(it->first));
-      for (const auto &entry : it->second){
-	fprintf(pFile,"Quality snapshot %s, probability %f \n",(entry.first).c_str(),entry.second);
+  FILE* pFile = NULL;
+  if (formatedOutput_ != "")
+    pFile = fopen(formatedOutput_.c_str(), "w");
+  if (pFile) {
+    fprintf(pFile, "SiPixelQualityProbabilities::printAll() \n");
+    fprintf(pFile,
+            " ========================================================================================================="
+            "========== \n");
+
+    SiPixelQualityProbabilities::probabilityMap m_probabilities = myProbabilities->getProbability_Map();
+
+    for (auto it = m_probabilities.begin(); it != m_probabilities.end(); ++it) {
+      fprintf(pFile,
+              " ======================================================================================================="
+              "============ \n");
+      fprintf(pFile, "PU bin : %i \n ", (it->first));
+      for (const auto& entry : it->second) {
+        fprintf(pFile, "Quality snapshot %s, probability %f \n", (entry.first).c_str(), entry.second);
       }
     }
   }
 }
 
-void
-SiPixelQualityProbabilitiesTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelQualityProbabilitiesTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Reads payloads of type SiPixelQualityProbabilities");
-  desc.addUntracked<bool>("printDebug",true);
-  desc.addUntracked<std::string>("outputFile","");
-  descriptions.add("SiPixelQualityProbabilitiesTestReader",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  desc.addUntracked<std::string>("outputFile", "");
+  descriptions.add("SiPixelQualityProbabilitiesTestReader", desc);
 }
 
 DEFINE_FWK_MODULE(SiPixelQualityProbabilitiesTestReader);

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestWriter.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesTestWriter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CondFormats/SiPixelObjects
 // Class:      SiPixelQualityProbabilitiesTestWriter
-// 
+//
 /**\class SiPixelQualityProbabilitiesTestWriter SiPixelQualityProbabilitiesTestWriter.cc CondFormats/SiPixelObjects/plugins/SiPixelQualityProbabilitiesTestWriter.cc
  Description: class to build the SiPixel Quality probabilities 
 */
@@ -34,133 +34,121 @@
 // class declaration
 //
 
-class SiPixelQualityProbabilitiesTestWriter : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit SiPixelQualityProbabilitiesTestWriter(const edm::ParameterSet&);
-      ~SiPixelQualityProbabilitiesTestWriter();
+class SiPixelQualityProbabilitiesTestWriter : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiPixelQualityProbabilitiesTestWriter(const edm::ParameterSet&);
+  ~SiPixelQualityProbabilitiesTestWriter();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
-   private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
-
-      // ----------member data ---------------------------
-      const std::string m_ProbInputs;
-      const std::string m_SnapshotInputs;
-      const std::string m_record;
-      const bool printdebug_;
-      SiPixelQualityProbabilities* myProbabilities;
-
+  // ----------member data ---------------------------
+  const std::string m_ProbInputs;
+  const std::string m_SnapshotInputs;
+  const std::string m_record;
+  const bool printdebug_;
+  SiPixelQualityProbabilities* myProbabilities;
 };
 
 //
 // constructors and destructor
 //
-SiPixelQualityProbabilitiesTestWriter::SiPixelQualityProbabilitiesTestWriter(const edm::ParameterSet& iConfig):
-  m_ProbInputs(iConfig.getParameter<std::string>("probabilities")),
-  m_SnapshotInputs(iConfig.getParameter<std::string>("snapshots")),
-  m_record(iConfig.getParameter<std::string>("record")),
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false))
-{
+SiPixelQualityProbabilitiesTestWriter::SiPixelQualityProbabilitiesTestWriter(const edm::ParameterSet& iConfig)
+    : m_ProbInputs(iConfig.getParameter<std::string>("probabilities")),
+      m_SnapshotInputs(iConfig.getParameter<std::string>("snapshots")),
+      m_record(iConfig.getParameter<std::string>("record")),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)) {
   //now do what ever initialization is needed
   myProbabilities = new SiPixelQualityProbabilities();
 }
 
-
-SiPixelQualityProbabilitiesTestWriter::~SiPixelQualityProbabilitiesTestWriter()
-{
-  delete myProbabilities;
-}
+SiPixelQualityProbabilitiesTestWriter::~SiPixelQualityProbabilitiesTestWriter() { delete myProbabilities; }
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-SiPixelQualityProbabilitiesTestWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   std::ifstream myfile(m_ProbInputs); 
-   std::ifstream mysnapshots(m_SnapshotInputs); 
-   std::string  line1,line2; 
-   std::map<int,std::string> snapshotIdToString;
+void SiPixelQualityProbabilitiesTestWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  std::ifstream myfile(m_ProbInputs);
+  std::ifstream mysnapshots(m_SnapshotInputs);
+  std::string line1, line2;
+  std::map<int, std::string> snapshotIdToString;
 
-   if(mysnapshots.is_open()){
-     while (getline (mysnapshots, line1)) {
-       //edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << line1 << std::endl;
-       std::istringstream iss (line1);            
-       int id, run, ls;
-       iss >> id >> run >> ls;
-       snapshotIdToString[id]=std::to_string(run)+"_"+std::to_string(ls);
-     }
-   }
+  if (mysnapshots.is_open()) {
+    while (getline(mysnapshots, line1)) {
+      //edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << line1 << std::endl;
+      std::istringstream iss(line1);
+      int id, run, ls;
+      iss >> id >> run >> ls;
+      snapshotIdToString[id] = std::to_string(run) + "_" + std::to_string(ls);
+    }
+  }
 
-   SiPixelQualityProbabilities::probabilityVec myProbVector;
+  SiPixelQualityProbabilities::probabilityVec myProbVector;
 
-   if (myfile.is_open()){
-     while (getline (myfile, line2)) {
-       edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << line2 << std::endl;
-       std::istringstream iss (line2);            
-       int pileupBinId, nEntries;
-       iss >>  pileupBinId >>  nEntries;
-       edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << "PILEUP BIN/ENTRIES:  " << pileupBinId << " " << nEntries <<  std::endl;
-       std::vector <int>     ids(nEntries, 0);
-       std::vector <float>   probs(nEntries, 0.0);
-       for (int i=0;i< nEntries; ++i){
-	 iss >> ids.at(i) >> probs.at(i);
-	 //edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << ids.at(i) << " " << probs.at(i)<< std::endl; 
-	 auto idAndProb = std::make_pair(snapshotIdToString.at(ids.at(i)),probs.at(i));
-	 myProbVector.push_back(idAndProb); 
-       }
-       if(nEntries>0) myProbabilities->setProbabilities(pileupBinId,myProbVector);
-       myProbVector.clear();
-     }    
-     myfile.close();
-   }
+  if (myfile.is_open()) {
+    while (getline(myfile, line2)) {
+      edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << line2 << std::endl;
+      std::istringstream iss(line2);
+      int pileupBinId, nEntries;
+      iss >> pileupBinId >> nEntries;
+      edm::LogInfo("SiPixelQualityProbabilitiesTestWriter")
+          << "PILEUP BIN/ENTRIES:  " << pileupBinId << " " << nEntries << std::endl;
+      std::vector<int> ids(nEntries, 0);
+      std::vector<float> probs(nEntries, 0.0);
+      for (int i = 0; i < nEntries; ++i) {
+        iss >> ids.at(i) >> probs.at(i);
+        //edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << ids.at(i) << " " << probs.at(i)<< std::endl;
+        auto idAndProb = std::make_pair(snapshotIdToString.at(ids.at(i)), probs.at(i));
+        myProbVector.push_back(idAndProb);
+      }
+      if (nEntries > 0)
+        myProbabilities->setProbabilities(pileupBinId, myProbVector);
+      myProbVector.clear();
+    }
+    myfile.close();
+  }
 
-   if(printdebug_){
-     edm::LogInfo("SiPixelQualityProbabilitiesTestWriter")<<"Content of SiPixelQualityProbabilities "<<std::endl;
-     // use buil-in method in the CondFormat
-     myProbabilities->printAll();
-   }
+  if (printdebug_) {
+    edm::LogInfo("SiPixelQualityProbabilitiesTestWriter") << "Content of SiPixelQualityProbabilities " << std::endl;
+    // use buil-in method in the CondFormat
+    myProbabilities->printAll();
+  }
 }
-   
+
 // ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelQualityProbabilitiesTestWriter::beginJob()
-{
-}
+void SiPixelQualityProbabilitiesTestWriter::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelQualityProbabilitiesTestWriter::endJob() 
-{
-
-  edm::LogInfo("SiPixelQualityProbabilitiesTestWriter")<<"Size of SiPixelQualityProbabilities object "<< myProbabilities->size() <<std::endl<<std::endl;
+void SiPixelQualityProbabilitiesTestWriter::endJob() {
+  edm::LogInfo("SiPixelQualityProbabilitiesTestWriter")
+      << "Size of SiPixelQualityProbabilities object " << myProbabilities->size() << std::endl
+      << std::endl;
 
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    cond::Time_t valid_time = poolDbService->currentTime(); 
+  if (poolDbService.isAvailable()) {
+    cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myProbabilities,valid_time, m_record);
-  } 
+    poolDbService->writeOne(myProbabilities, valid_time, m_record);
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-SiPixelQualityProbabilitiesTestWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelQualityProbabilitiesTestWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Writes payloads of type SiPixelQualityProbabilities");
-  desc.addUntracked<bool>("printDebug",true);
-  desc.add<std::string>("record","SiPixelStatusScenarioProbabilityRcd");
-  desc.add<std::string>("snapshots","");
-  desc.add<std::string>("probabilities","");
-  descriptions.add("SiPixelQualityProbabilitiesTestWriter",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  desc.add<std::string>("record", "SiPixelStatusScenarioProbabilityRcd");
+  desc.add<std::string>("snapshots", "");
+  desc.add<std::string>("probabilities", "");
+  descriptions.add("SiPixelQualityProbabilitiesTestWriter", desc);
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CondFormats/SiPixelObjects
 // Class:      SiPixelQualityProbabilitiesTestWriter
-// 
+//
 /**\class SiPixelQualityProbabilitiesTestWriter SiPixelQualityProbabilitiesTestWriter.cc CondFormats/SiPixelObjects/plugins/SiPixelQualityProbabilitiesTestWriter.cc
  Description: class to build the SiPixel Quality probabilities 
 */
@@ -34,111 +34,97 @@
 // class declaration
 //
 
-class SiPixelQualityProbabilitiesWriteFromASCII : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit SiPixelQualityProbabilitiesWriteFromASCII(const edm::ParameterSet&);
-      ~SiPixelQualityProbabilitiesWriteFromASCII();
+class SiPixelQualityProbabilitiesWriteFromASCII : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiPixelQualityProbabilitiesWriteFromASCII(const edm::ParameterSet&);
+  ~SiPixelQualityProbabilitiesWriteFromASCII();
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
 
-   private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
-
-      // ----------member data ---------------------------
-      const std::string m_ProbInputs;
-      const std::string m_record;
-      const bool printdebug_;
-      SiPixelQualityProbabilities* myProbabilities;
-
+  // ----------member data ---------------------------
+  const std::string m_ProbInputs;
+  const std::string m_record;
+  const bool printdebug_;
+  SiPixelQualityProbabilities* myProbabilities;
 };
 
 //
 // constructors and destructor
 //
-SiPixelQualityProbabilitiesWriteFromASCII::SiPixelQualityProbabilitiesWriteFromASCII(const edm::ParameterSet& iConfig):
-  m_ProbInputs(iConfig.getParameter<std::string>("probabilities")),
-  m_record(iConfig.getParameter<std::string>("record")),
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false))
-{
+SiPixelQualityProbabilitiesWriteFromASCII::SiPixelQualityProbabilitiesWriteFromASCII(const edm::ParameterSet& iConfig)
+    : m_ProbInputs(iConfig.getParameter<std::string>("probabilities")),
+      m_record(iConfig.getParameter<std::string>("record")),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)) {
   //now do what ever initialization is needed
   myProbabilities = new SiPixelQualityProbabilities();
 }
 
-
-SiPixelQualityProbabilitiesWriteFromASCII::~SiPixelQualityProbabilitiesWriteFromASCII()
-{
-  delete myProbabilities;
-}
+SiPixelQualityProbabilitiesWriteFromASCII::~SiPixelQualityProbabilitiesWriteFromASCII() { delete myProbabilities; }
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-SiPixelQualityProbabilitiesWriteFromASCII::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   std::ifstream myfile(m_ProbInputs); 
-   std::string line;
+void SiPixelQualityProbabilitiesWriteFromASCII::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  std::ifstream myfile(m_ProbInputs);
+  std::string line;
 
-   SiPixelQualityProbabilities::probabilityVec myProbVector;
+  SiPixelQualityProbabilities::probabilityVec myProbVector;
 
-   if (myfile.is_open()){
-     while (getline (myfile, line)) {
-       edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
-       std::istringstream iss (line);            
-       std::string scenario="";
-       float prob(0.);
-       iss >> scenario >> prob;
-       auto idAndProb = std::make_pair(scenario,prob);
-       myProbVector.push_back(idAndProb); 
-     }  
-     myProbabilities->setProbabilities(0,myProbVector);
-     myfile.close();
-   }
+  if (myfile.is_open()) {
+    while (getline(myfile, line)) {
+      edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
+      std::istringstream iss(line);
+      std::string scenario = "";
+      float prob(0.);
+      iss >> scenario >> prob;
+      auto idAndProb = std::make_pair(scenario, prob);
+      myProbVector.push_back(idAndProb);
+    }
+    myProbabilities->setProbabilities(0, myProbVector);
+    myfile.close();
+  }
 
-   if(printdebug_){
-     edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII")<<"Content of SiPixelQualityProbabilities "<<std::endl;
-     // use buil-in method in the CondFormat
-     myProbabilities->printAll();
-   }
+  if (printdebug_) {
+    edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << "Content of SiPixelQualityProbabilities " << std::endl;
+    // use buil-in method in the CondFormat
+    myProbabilities->printAll();
+  }
 }
-   
+
 // ------------ method called once each job just before starting event loop  ------------
-void 
-SiPixelQualityProbabilitiesWriteFromASCII::beginJob()
-{
-}
+void SiPixelQualityProbabilitiesWriteFromASCII::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-SiPixelQualityProbabilitiesWriteFromASCII::endJob() 
-{
-
-  edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII")<<"Size of SiPixelQualityProbabilities object "<< myProbabilities->size() <<std::endl<<std::endl;
+void SiPixelQualityProbabilitiesWriteFromASCII::endJob() {
+  edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII")
+      << "Size of SiPixelQualityProbabilities object " << myProbabilities->size() << std::endl
+      << std::endl;
 
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    cond::Time_t valid_time = poolDbService->currentTime(); 
+  if (poolDbService.isAvailable()) {
+    cond::Time_t valid_time = poolDbService->currentTime();
     // this writes the payload to begin in current run defined in cfg
-    poolDbService->writeOne(myProbabilities,valid_time, m_record);
-  } 
+    poolDbService->writeOne(myProbabilities, valid_time, m_record);
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-SiPixelQualityProbabilitiesWriteFromASCII::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void SiPixelQualityProbabilitiesWriteFromASCII::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Writes payloads of type SiPixelQualityProbabilities");
-  desc.addUntracked<bool>("printDebug",true);
-  desc.add<std::string>("record","SiPixelStatusScenarioProbabilityRcd");
-  desc.add<std::string>("probabilities","");
-  descriptions.add("SiPixelQualityProbabilitiesWriteFromASCII",desc);
+  desc.addUntracked<bool>("printDebug", true);
+  desc.add<std::string>("record", "SiPixelStatusScenarioProbabilityRcd");
+  desc.add<std::string>("probabilities", "");
+  descriptions.add("SiPixelQualityProbabilitiesWriteFromASCII", desc);
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/SiPixelTestSummary.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelTestSummary.cc
@@ -25,36 +25,35 @@ public:
   explicit SiPixelTestSummary(const edm::ParameterSet&) {}
   ~SiPixelTestSummary();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
 };
 
 // ----------------------------------------------------------------------
-SiPixelTestSummary::~SiPixelTestSummary(){}
+SiPixelTestSummary::~SiPixelTestSummary() {}
 
 // ----------------------------------------------------------------------
 void SiPixelTestSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   std::cout << "====== SiPixelTestSummary begin" << std::endl;
-  
-  SiPixelDetSummary a(1); 
 
+  SiPixelDetSummary a(1);
 
   edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
-  
+  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+
   cout << "**********************************************************************" << endl;
-  cout << " *** Geometry node for TrackerGeom is  "<<&(*pDD)<<std::endl;
-  cout << " *** I have " << pDD->dets().size() <<" detectors"<<std::endl;
-  cout << " *** I have " << pDD->detTypes().size() <<" types"<<std::endl;
-  
-  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++){
-    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+  cout << " *** Geometry node for TrackerGeom is  " << &(*pDD) << std::endl;
+  cout << " *** I have " << pDD->dets().size() << " detectors" << std::endl;
+  cout << " *** I have " << pDD->detTypes().size() << " types" << std::endl;
+
+  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
+    if (dynamic_cast<PixelGeomDetUnit const*>((*it)) != 0) {
       DetId detId = (*it)->geographicalId();
-      a.add(detId); 
+      a.add(detId);
     }
   }
 
-  bool toyExample(false); 
+  bool toyExample(false);
   if (toyExample) {
     a.add(302055684, 2.3);  // BPix_BmI_SEC4_LYR1_LDR5_MOD4  302055684
     a.add(302125072, 2.4);  // BPix_BmO_SEC4_LYR2_LDR8_MOD1  302125072
@@ -77,15 +76,12 @@ void SiPixelTestSummary::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   cout << endl;
   cout << "Testing map" << endl;
-  map<int, int> b = a.getCounts(); 
-  for (map<int,int>::const_iterator bIt = b.begin(); bIt != b.end(); ++bIt) {
+  map<int, int> b = a.getCounts();
+  for (map<int, int>::const_iterator bIt = b.begin(); bIt != b.end(); ++bIt) {
     cout << bIt->first << " -> " << bIt->second << endl;
   }
-  
 
   std::cout << "====== SiPixelTestSummary end" << std::endl;
-
-  
 }
 
 //define this as a plug-in

--- a/CondFormats/SiPixelObjects/test/testSerializationSiPixelObjects.cpp
+++ b/CondFormats/SiPixelObjects/test/testSerializationSiPixelObjects.cpp
@@ -2,50 +2,49 @@
 
 #include "CondFormats/SiPixelObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<PixelDCSObject<bool>>();
-    testSerialization<PixelDCSObject<float>>();
-    testSerialization<PixelDCSObject<CaenChannel>>();
-    testSerialization<SiPixelCPEGenericErrorParm>();
-    testSerialization<SiPixelCPEGenericErrorParm::DbEntry>();
-    testSerialization<SiPixelCPEGenericErrorParm::DbEntryBinSize>();
-    testSerialization<SiPixelCalibConfiguration>();
-    testSerialization<SiPixelDbItem>();
-    testSerialization<SiPixelDisabledModules>();
-    //testSerialization<SiPixelFedCabling>(); abstract
-    testSerialization<SiPixelFedCablingMap>();
-    testSerialization<SiPixelFedCablingMap::Key>();
-    testSerialization<SiPixelGainCalibration>();
-    testSerialization<SiPixelGainCalibration::DetRegistry>();
-    testSerialization<SiPixelGainCalibrationForHLT>();
-    testSerialization<SiPixelGainCalibrationForHLT::DetRegistry>();
-    testSerialization<SiPixelGainCalibrationOffline>();
-    testSerialization<SiPixelGainCalibrationOffline::DetRegistry>();
-    testSerialization<SiPixelGenErrorDBObject>();
-    testSerialization<SiPixelLorentzAngle>();
-    testSerialization<SiPixelPedestals>();
-    testSerialization<SiPixelPerformanceSummary>();
-    testSerialization<SiPixelPerformanceSummary::DetSummary>();
-    testSerialization<SiPixelQuality>();
-    testSerialization<SiPixelFEDChannelContainer>();
-    testSerialization<SiPixelFEDChannelContainer::SiPixelFEDChannelCollection>();
-    //testSerialization<std::unordered_map<std::string,SiPixelFEDChannelCollection>();
-    testSerialization<SiPixelQuality::disabledModuleType>();
-    testSerialization<SiPixelQualityProbabilities>();
-    testSerialization<SiPixelTemplateDBObject>();
-    testSerialization<sipixelobjects::PixelROC>();
-    testSerialization<std::map<SiPixelFedCablingMap::Key,sipixelobjects::PixelROC>>();
-    testSerialization<std::map<int,std::vector<SiPixelDbItem>>>();
-    testSerialization<std::pair<const SiPixelFedCablingMap::Key,sipixelobjects::PixelROC>>();
-    testSerialization<std::vector<SiPixelCPEGenericErrorParm::DbEntry>>();
-    testSerialization<std::vector<SiPixelCPEGenericErrorParm::DbEntryBinSize>>();
-    testSerialization<std::vector<SiPixelDbItem>>();
-    testSerialization<std::vector<SiPixelGainCalibration::DetRegistry>>();
-    testSerialization<std::vector<SiPixelGainCalibrationForHLT::DetRegistry>>();
-    testSerialization<std::vector<SiPixelGainCalibrationOffline::DetRegistry>>();
-    testSerialization<std::vector<SiPixelPerformanceSummary::DetSummary>>();
-    testSerialization<std::vector<SiPixelQuality::disabledModuleType>>();
+int main() {
+  testSerialization<PixelDCSObject<bool>>();
+  testSerialization<PixelDCSObject<float>>();
+  testSerialization<PixelDCSObject<CaenChannel>>();
+  testSerialization<SiPixelCPEGenericErrorParm>();
+  testSerialization<SiPixelCPEGenericErrorParm::DbEntry>();
+  testSerialization<SiPixelCPEGenericErrorParm::DbEntryBinSize>();
+  testSerialization<SiPixelCalibConfiguration>();
+  testSerialization<SiPixelDbItem>();
+  testSerialization<SiPixelDisabledModules>();
+  //testSerialization<SiPixelFedCabling>(); abstract
+  testSerialization<SiPixelFedCablingMap>();
+  testSerialization<SiPixelFedCablingMap::Key>();
+  testSerialization<SiPixelGainCalibration>();
+  testSerialization<SiPixelGainCalibration::DetRegistry>();
+  testSerialization<SiPixelGainCalibrationForHLT>();
+  testSerialization<SiPixelGainCalibrationForHLT::DetRegistry>();
+  testSerialization<SiPixelGainCalibrationOffline>();
+  testSerialization<SiPixelGainCalibrationOffline::DetRegistry>();
+  testSerialization<SiPixelGenErrorDBObject>();
+  testSerialization<SiPixelLorentzAngle>();
+  testSerialization<SiPixelPedestals>();
+  testSerialization<SiPixelPerformanceSummary>();
+  testSerialization<SiPixelPerformanceSummary::DetSummary>();
+  testSerialization<SiPixelQuality>();
+  testSerialization<SiPixelFEDChannelContainer>();
+  testSerialization<SiPixelFEDChannelContainer::SiPixelFEDChannelCollection>();
+  //testSerialization<std::unordered_map<std::string,SiPixelFEDChannelCollection>();
+  testSerialization<SiPixelQuality::disabledModuleType>();
+  testSerialization<SiPixelQualityProbabilities>();
+  testSerialization<SiPixelTemplateDBObject>();
+  testSerialization<sipixelobjects::PixelROC>();
+  testSerialization<std::map<SiPixelFedCablingMap::Key, sipixelobjects::PixelROC>>();
+  testSerialization<std::map<int, std::vector<SiPixelDbItem>>>();
+  testSerialization<std::pair<const SiPixelFedCablingMap::Key, sipixelobjects::PixelROC>>();
+  testSerialization<std::vector<SiPixelCPEGenericErrorParm::DbEntry>>();
+  testSerialization<std::vector<SiPixelCPEGenericErrorParm::DbEntryBinSize>>();
+  testSerialization<std::vector<SiPixelDbItem>>();
+  testSerialization<std::vector<SiPixelGainCalibration::DetRegistry>>();
+  testSerialization<std::vector<SiPixelGainCalibrationForHLT::DetRegistry>>();
+  testSerialization<std::vector<SiPixelGainCalibrationOffline::DetRegistry>>();
+  testSerialization<std::vector<SiPixelPerformanceSummary::DetSummary>>();
+  testSerialization<std::vector<SiPixelQuality::disabledModuleType>>();
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category alca,db.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/382//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


