### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/PhysicsTools/PatAlgos/interface/BaseIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/BaseIsolator.h
@@ -8,40 +8,47 @@
 
 #include <atomic>
 
-namespace pat { namespace helper {
-class BaseIsolator {
+namespace pat {
+  namespace helper {
+    class BaseIsolator {
     public:
-        typedef edm::ValueMap<float> Isolation;
-        BaseIsolator() {}
-        BaseIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
-        virtual ~BaseIsolator() {}
-        virtual void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) = 0;
-        virtual void endEvent() = 0;
+      typedef edm::ValueMap<float> Isolation;
+      BaseIsolator() {}
+      BaseIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut);
+      virtual ~BaseIsolator() {}
+      virtual void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) = 0;
+      virtual void endEvent() = 0;
 
-        /// Tests if the value associated to this item is strictly below the cut.
-        template<typename AnyRef> bool test(const AnyRef &ref) const {
-            bool ok = (getValue(ref.id(), ref.key()) < cut_);
-            try_++; if (!ok) fail_++;
-            return ok;
-        }
-        /// Returns the associated isolation value given any sort of ref
-        template<typename AnyRef> float getValue(const AnyRef &ref) const {
-            return getValue(ref.id(), ref.key());
-        }
+      /// Tests if the value associated to this item is strictly below the cut.
+      template <typename AnyRef>
+      bool test(const AnyRef &ref) const {
+        bool ok = (getValue(ref.id(), ref.key()) < cut_);
+        try_++;
+        if (!ok)
+          fail_++;
+        return ok;
+      }
+      /// Returns the associated isolation value given any sort of ref
+      template <typename AnyRef>
+      float getValue(const AnyRef &ref) const {
+        return getValue(ref.id(), ref.key());
+      }
 
-        virtual std::string description() const = 0;
-        void print(std::ostream &out) const ;
+      virtual std::string description() const = 0;
+      void print(std::ostream &out) const;
+
     protected:
-        virtual float getValue(const edm::ProductID &id, size_t index) const = 0;
-        edm::InputTag input_;
-        edm::EDGetTokenT<Isolation> inputToken_;
-        float cut_;
-        mutable std::atomic<uint64_t> try_, fail_;
-}; // class BaseIsolator
-} } // namespaces
+      virtual float getValue(const edm::ProductID &id, size_t index) const = 0;
+      edm::InputTag input_;
+      edm::EDGetTokenT<Isolation> inputToken_;
+      float cut_;
+      mutable std::atomic<uint64_t> try_, fail_;
+    };  // class BaseIsolator
+  }     // namespace helper
+}  // namespace pat
 
-inline std::ostream & operator<<(std::ostream &stream, const pat::helper::BaseIsolator &iso) {
-    iso.print(stream);
-    return stream;
+inline std::ostream &operator<<(std::ostream &stream, const pat::helper::BaseIsolator &iso) {
+  iso.print(stream);
+  return stream;
 }
 #endif

--- a/PhysicsTools/PatAlgos/interface/EfficiencyLoader.h
+++ b/PhysicsTools/PatAlgos/interface/EfficiencyLoader.h
@@ -11,41 +11,40 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
-namespace pat { namespace helper {
-class EfficiencyLoader {
+namespace pat {
+  namespace helper {
+    class EfficiencyLoader {
     public:
-        /// Empty constructor
-        EfficiencyLoader() {}
+      /// Empty constructor
+      EfficiencyLoader() {}
 
-        /// Constructor from a PSet
-        EfficiencyLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) ;
+      /// Constructor from a PSet
+      EfficiencyLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC);
 
-        /// 'true' if this there is at least one efficiency configured
-        bool enabled() const { return !names_.empty(); }
+      /// 'true' if this there is at least one efficiency configured
+      bool enabled() const { return !names_.empty(); }
 
-        /// To be called for each new event, reads in the ValueMaps for efficiencies
-        void newEvent(const edm::Event &event);
+      /// To be called for each new event, reads in the ValueMaps for efficiencies
+      void newEvent(const edm::Event &event);
 
-        /// Sets the efficiencies for this object, using the reference to the original objects
-        template<typename T, typename R>
-        void setEfficiencies( pat::PATObject<T> &obj,  const R & originalRef ) const ;
+      /// Sets the efficiencies for this object, using the reference to the original objects
+      template <typename T, typename R>
+      void setEfficiencies(pat::PATObject<T> &obj, const R &originalRef) const;
 
     private:
-        std::vector<std::string>   names_;
-        std::vector<edm::EDGetTokenT<edm::ValueMap<pat::LookupTableRecord> > > tokens_;
-        std::vector<edm::Handle< edm::ValueMap<pat::LookupTableRecord> > > handles_;
-}; // class
+      std::vector<std::string> names_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<pat::LookupTableRecord> > > tokens_;
+      std::vector<edm::Handle<edm::ValueMap<pat::LookupTableRecord> > > handles_;
+    };  // class
 
-template<typename T, typename R>
-void
-EfficiencyLoader::setEfficiencies( pat::PATObject<T> &obj,  const R & originalRef ) const
-{
-    for (size_t i = 0, n = names_.size(); i < n; ++i) {
-        obj.setEfficiency(names_[i], (* handles_[i])[originalRef] );
+    template <typename T, typename R>
+    void EfficiencyLoader::setEfficiencies(pat::PATObject<T> &obj, const R &originalRef) const {
+      for (size_t i = 0, n = names_.size(); i < n; ++i) {
+        obj.setEfficiency(names_[i], (*handles_[i])[originalRef]);
+      }
     }
-}
 
-} }
+  }  // namespace helper
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/HemisphereAlgo.h
+++ b/PhysicsTools/PatAlgos/interface/HemisphereAlgo.h
@@ -1,7 +1,6 @@
 #ifndef HemisphereAlgo_h
 #define HemisphereAlgo_h
 
-
 /*  \class HemisphereAlgo
 *
 *  Class that, given the 4-momenta of the objects in the event, 
@@ -22,80 +21,73 @@ Transported to PAT by Wolfgang Adam and Tanja Rommerskirchen
 #include <cmath>
 
 class HemisphereAlgo {
-
 public:
+  // There are 2 constructors:
+  // 1. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in
+  // the event that should be separated, the seeding method and the hemisphere
+  // association method,
+  // 2. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in
+  // the event that should be separated. The seeding method and the hemisphere
+  // association method should then be defined by SetMethod(seeding_method, association_method).
+  //
+  // Seeding method: choice of 2 inital axes
+  //   1: 1st: max P ; 2nd: max P * delta R wrt first one
+  //   2: 2 objects who give maximal invariant mass (recommended)
+  //
+  // HemisphereAlgo association method:
+  //   1: maximum pt longitudinal projected on the axes
+  //   2: minimal mass squared sum of the hemispheres
+  //   3: minimal Lund distance (recommended)
+  //
+  // Note that SetMethod also allows the seeding and/or association method to be
+  // redefined for an existing hemisphere object. The GetAxis or GetGrouping is
+  // then recomputed using the newly defined methods.
+  //
 
-// There are 2 constructors:
-// 1. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in
-// the event that should be separated, the seeding method and the hemisphere
-// association method,
-// 2. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in
-// the event that should be separated. The seeding method and the hemisphere
-// association method should then be defined by SetMethod(seeding_method, association_method).
-// 
-// Seeding method: choice of 2 inital axes
-//   1: 1st: max P ; 2nd: max P * delta R wrt first one 
-//   2: 2 objects who give maximal invariant mass (recommended)
-//
-// HemisphereAlgo association method:
-//   1: maximum pt longitudinal projected on the axes
-//   2: minimal mass squared sum of the hemispheres
-//   3: minimal Lund distance (recommended)
-//
-// Note that SetMethod also allows the seeding and/or association method to be
-// redefined for an existing hemisphere object. The GetAxis or GetGrouping is 
-// then recomputed using the newly defined methods.
-//
+  HemisphereAlgo(const std::vector<reco::CandidatePtr>& componentRefs_,
+                 const int seed_method = 0,
+                 const int hemisphere_association_method = 0);
 
-  HemisphereAlgo(const std::vector<reco::CandidatePtr>& componentRefs_, const int seed_method = 0, const int hemisphere_association_method = 0);
+  // Destructor
+  ~HemisphereAlgo(){};
 
-// Destructor
-~HemisphereAlgo(){};
+  std::vector<float> getAxis1();  // returns Nx, Ny, Nz, P, E of the axis of group 1
+  std::vector<float> getAxis2();  // returns Nx, Ny, Nz, P, E of the axis of group 2
 
+  // where Nx, Ny, Nz are the direction cosines e.g. Nx = Px/P,
+  // P is the momentum, E is the energy
 
-std::vector<float> getAxis1(); // returns Nx, Ny, Nz, P, E of the axis of group 1
-std::vector<float> getAxis2(); // returns Nx, Ny, Nz, P, E of the axis of group 2
+  std::vector<int> getGrouping();  // returns vector with "1" and "2"'s according to
+                                   // which group the object belongs
+                                   // (order of objects in vector is same as input)
 
-// where Nx, Ny, Nz are the direction cosines e.g. Nx = Px/P, 
-// P is the momentum, E is the energy
+  void SetMethod(int seed_method, int hemisphere_association_method) {
+    seed_meth = seed_method;
+    hemi_meth = hemisphere_association_method;
+    status = 0;
+  }  // sets or overwrites the seed and association methods
 
-std::vector<int> getGrouping(); // returns vector with "1" and "2"'s according to
-                           // which group the object belongs 
-			   // (order of objects in vector is same as input)
-
-void SetMethod(int seed_method, int hemisphere_association_method){
-  seed_meth = seed_method;
-  hemi_meth = hemisphere_association_method;
-  status = 0;
-}                    // sets or overwrites the seed and association methods
-
-void SetNoSeed(int object_number)  {
-  Object_Noseed[object_number] = 1; 
-  status = 0;
-} 
-                          // prevents an object from being used as a seed
-                          // (method introduced on 15/09/06)
+  void SetNoSeed(int object_number) {
+    Object_Noseed[object_number] = 1;
+    status = 0;
+  }
+  // prevents an object from being used as a seed
+  // (method introduced on 15/09/06)
 
 private:
+  int reconstruct();  // the hemisphere separation algorithm
+  std::vector<reco::CandidatePtr> Object;
 
+  std::vector<int> Object_Group;
+  std::vector<int> Object_Noseed;
 
-int reconstruct(); // the hemisphere separation algorithm
- std::vector<reco::CandidatePtr> Object;
+  std::vector<float> Axis1;
+  std::vector<float> Axis2;
 
-std::vector<int> Object_Group;
-std::vector<int> Object_Noseed;
-
-std::vector<float> Axis1;
-std::vector<float> Axis2;
-
-//static const float hemivsn = 1.01;
-int seed_meth;
-int hemi_meth;
-int status;
-
-
-
-
+  //static const float hemivsn = 1.01;
+  int seed_meth;
+  int hemi_meth;
+  int status;
 };
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/IsoDepositIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/IsoDepositIsolator.h
@@ -5,32 +5,34 @@
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "PhysicsTools/IsolationAlgos/interface/EventDependentAbsVeto.h"
 
-
-namespace pat { namespace helper {
-class IsoDepositIsolator : public BaseIsolator {
+namespace pat {
+  namespace helper {
+    class IsoDepositIsolator : public BaseIsolator {
     public:
-        typedef edm::ValueMap<reco::IsoDeposit> Isolation;
+      typedef edm::ValueMap<reco::IsoDeposit> Isolation;
 
-        IsoDepositIsolator() {}
-        IsoDepositIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
-        ~IsoDepositIsolator() override ;
-        void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) override ;
-        void endEvent() override ;
+      IsoDepositIsolator() {}
+      IsoDepositIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut);
+      ~IsoDepositIsolator() override;
+      void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) override;
+      void endEvent() override;
 
-        std::string description() const override ;
+      std::string description() const override;
+
     protected:
-        enum Mode { Sum, Sum2, SumRelative, Sum2Relative, Max, MaxRelative, Count };
-        edm::Handle<Isolation> handle_;
+      enum Mode { Sum, Sum2, SumRelative, Sum2Relative, Max, MaxRelative, Count };
+      edm::Handle<Isolation> handle_;
 
-        float deltaR_;
-        Mode  mode_;
-        reco::isodeposit::AbsVetos vetos_;
-        reco::isodeposit::EventDependentAbsVetos evdepVetos_; // subset of the above, don't delete twice
-        bool skipDefaultVeto_;
-        edm::EDGetTokenT<Isolation> inputIsoDepositToken_;
+      float deltaR_;
+      Mode mode_;
+      reco::isodeposit::AbsVetos vetos_;
+      reco::isodeposit::EventDependentAbsVetos evdepVetos_;  // subset of the above, don't delete twice
+      bool skipDefaultVeto_;
+      edm::EDGetTokenT<Isolation> inputIsoDepositToken_;
 
-        float getValue(const edm::ProductID &id, size_t index) const override ;
-}; // class IsoDepositIsolator
-} } // namespaces
+      float getValue(const edm::ProductID &id, size_t index) const override;
+    };  // class IsoDepositIsolator
+  }     // namespace helper
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h
+++ b/PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h
@@ -13,46 +13,46 @@
 
 #include "PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h"
 
-
-namespace pat { namespace helper {
-class KinResolutionsLoader {
+namespace pat {
+  namespace helper {
+    class KinResolutionsLoader {
     public:
-        /// Empty constructor
-        KinResolutionsLoader() {}
+      /// Empty constructor
+      KinResolutionsLoader() {}
 
-        /// Constructor from a PSet
-        KinResolutionsLoader(const edm::ParameterSet &iConfig) ;
+      /// Constructor from a PSet
+      KinResolutionsLoader(const edm::ParameterSet &iConfig);
 
-        /// 'true' if this there is at least one efficiency configured
-        bool enabled() const { return !patlabels_.empty(); }
-     
-        /// To be called for each new event, reads in the EventSetup object 
-        void newEvent(const edm::Event &event, const edm::EventSetup &setup);
+      /// 'true' if this there is at least one efficiency configured
+      bool enabled() const { return !patlabels_.empty(); }
 
-        /// Sets the efficiencies for this object, using the reference to the original objects
-        template<typename T>
-        void setResolutions( pat::PATObject<T> &obj ) const ;
+      /// To be called for each new event, reads in the EventSetup object
+      void newEvent(const edm::Event &event, const edm::EventSetup &setup);
 
-        /// Method for documentation and validation of PSet
-        static void fillDescription(edm::ParameterSetDescription & iDesc);
+      /// Sets the efficiencies for this object, using the reference to the original objects
+      template <typename T>
+      void setResolutions(pat::PATObject<T> &obj) const;
+
+      /// Method for documentation and validation of PSet
+      static void fillDescription(edm::ParameterSetDescription &iDesc);
+
     private:
-        /// Labels of the resolutions in PAT
-        std::vector<std::string>   patlabels_;
-        /// Labels of the KinematicResolutionProvider in the EventSetup
-        std::vector<std::string>   eslabels_;
-        /// Handles to the EventSetup
-        std::vector<edm::ESHandle<KinematicResolutionProvider> > handles_;
-}; // class
+      /// Labels of the resolutions in PAT
+      std::vector<std::string> patlabels_;
+      /// Labels of the KinematicResolutionProvider in the EventSetup
+      std::vector<std::string> eslabels_;
+      /// Handles to the EventSetup
+      std::vector<edm::ESHandle<KinematicResolutionProvider> > handles_;
+    };  // class
 
-template<typename T>
-void
-KinResolutionsLoader::setResolutions( pat::PATObject<T> &obj ) const
-{
-    for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
-        obj.setKinResolution( handles_[i]->getResolution(obj), patlabels_[i]);
+    template <typename T>
+    void KinResolutionsLoader::setResolutions(pat::PATObject<T> &obj) const {
+      for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
+        obj.setKinResolution(handles_[i]->getResolution(obj), patlabels_[i]);
+      }
     }
-}
 
-} }
+  }  // namespace helper
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h
+++ b/PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h
@@ -15,16 +15,22 @@
    a setup function is provided but might need to be re-implemented. 
 */
 
-namespace reco { class Candidate; }
-namespace pat  { class CandKinResolution; }
-namespace edm  { class ParameterSet; class EventSetup; }
+namespace reco {
+  class Candidate;
+}
+namespace pat {
+  class CandKinResolution;
+}
+namespace edm {
+  class ParameterSet;
+  class EventSetup;
+}  // namespace edm
 
 class KinematicResolutionProvider {
-
- public:
+public:
   virtual ~KinematicResolutionProvider() = default;
   /// everything that needs to be done before the event loop
-  virtual void setup(const edm::EventSetup &iSetup) const { }
+  virtual void setup(const edm::EventSetup &iSetup) const {}
   /// get a CandKinResolution object from the service; this
   /// function needs to be implemented by any derived class
   virtual pat::CandKinResolution getResolution(const reco::Candidate &c) const = 0;

--- a/PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h
+++ b/PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h
@@ -4,14 +4,14 @@
 //
 // Package:     PatAlgos
 // Class  :     KinematicResolutionRcd
-// 
+//
 /**\class KinematicResolutionRcd ParticleResolutionRcd.h PhysicsTools/PatAlgos/interface/ParticleResolutionRcd.h
 
  Description: Interface for getting Kinematic Resolutions through EventSetup
 
 */
 //
-// Author:      
+// Author:
 // Created:     Sun Jun 24 16:53:34 CEST 2007
 //
 
@@ -19,13 +19,9 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-
 #include "boost/mpl/vector.hpp"
 
-
-class KinematicResolutionRcd : 
-    public edm::eventsetup::DependentRecordImplementation<
-            KinematicResolutionRcd,
-            boost::mpl::vector<IdealMagneticFieldRecord>
-        > {};
+class KinematicResolutionRcd
+    : public edm::eventsetup::DependentRecordImplementation<KinematicResolutionRcd,
+                                                            boost::mpl::vector<IdealMagneticFieldRecord> > {};
 #endif

--- a/PhysicsTools/PatAlgos/interface/MultiIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/MultiIsolator.h
@@ -10,82 +10,83 @@
 
 #include "DataFormats/PatCandidates/interface/Isolation.h"
 
-namespace pat { namespace helper {
-class MultiIsolator {
+namespace pat {
+  namespace helper {
+    class MultiIsolator {
     public:
-        typedef std::vector<std::pair<pat::IsolationKeys,float> > IsolationValuePairs;
-        MultiIsolator() {}
-        MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector && iC, bool cuts=true) ;
-        ~MultiIsolator() {}
+      typedef std::vector<std::pair<pat::IsolationKeys, float> > IsolationValuePairs;
+      MultiIsolator() {}
+      MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC, bool cuts = true);
+      ~MultiIsolator() {}
 
-        // adds an isolator (and takes onwership of the pointer)
-        void addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key) ;
+      // adds an isolator (and takes onwership of the pointer)
+      void addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key);
 
-        // parses an isolator and adds it to the list
-        void addIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut, uint32_t mask, pat::IsolationKeys key) ;
+      // parses an isolator and adds it to the list
+      void addIsolator(const edm::ParameterSet &conf,
+                       edm::ConsumesCollector &iC,
+                       bool withCut,
+                       uint32_t mask,
+                       pat::IsolationKeys key);
 
-        // Parses out an isolator, and returns a pointer to it.
-        // For an empty PSet, it returns a null pointer.
-        // You own the returned pointer!
-        static BaseIsolator * make(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
+      // Parses out an isolator, and returns a pointer to it.
+      // For an empty PSet, it returns a null pointer.
+      // You own the returned pointer!
+      static BaseIsolator *make(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut);
 
-        void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup);
-        void endEvent() ;
+      void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup);
+      void endEvent();
 
-        template<typename T>
-        uint32_t test(const edm::View<T> &coll, int idx) const;
+      template <typename T>
+      uint32_t test(const edm::View<T> &coll, int idx) const;
 
-        template<typename T>
-        void fill(const edm::View<T> &coll, int idx, IsolationValuePairs& isolations) const ;
+      template <typename T>
+      void fill(const edm::View<T> &coll, int idx, IsolationValuePairs &isolations) const;
 
-        /// Fill Isolation from a Ref, Ptr or RefToBase to the object
-        template<typename RefType>
-        void fill(const RefType &ref, IsolationValuePairs& isolations) const ;
+      /// Fill Isolation from a Ref, Ptr or RefToBase to the object
+      template <typename RefType>
+      void fill(const RefType &ref, IsolationValuePairs &isolations) const;
 
-        void print(std::ostream &out) const ;
+      void print(std::ostream &out) const;
 
-        std::string printSummary() const ;
+      std::string printSummary() const;
 
-        /// True if it has a non null configuration
-        bool enabled() const  { return !isolators_.empty(); }
+      /// True if it has a non null configuration
+      bool enabled() const { return !isolators_.empty(); }
+
     private:
-        boost::ptr_vector<BaseIsolator> isolators_;
-        std::vector<uint32_t>           masks_;
-        std::vector<pat::IsolationKeys> keys_;
-};
+      boost::ptr_vector<BaseIsolator> isolators_;
+      std::vector<uint32_t> masks_;
+      std::vector<pat::IsolationKeys> keys_;
+    };
 
-    template<typename T>
-    uint32_t
-    MultiIsolator::test(const edm::View<T> &coll, int idx) const {
-        uint32_t retval = 0;
-        edm::RefToBase<T> rb = coll.refAt(idx); // edm::Ptr<T> in a shiny new future to come one remote day ;-)
-        for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
-            if (!isolators_[i].test(rb)) retval |= masks_[i];
-        }
-        return retval;
+    template <typename T>
+    uint32_t MultiIsolator::test(const edm::View<T> &coll, int idx) const {
+      uint32_t retval = 0;
+      edm::RefToBase<T> rb = coll.refAt(idx);  // edm::Ptr<T> in a shiny new future to come one remote day ;-)
+      for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
+        if (!isolators_[i].test(rb))
+          retval |= masks_[i];
+      }
+      return retval;
     }
 
-    template<typename RefType>
-    void
-    MultiIsolator::fill(const RefType &rb, IsolationValuePairs & isolations) const
-    {
-        isolations.resize(isolators_.size());
-        for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
-           isolations[i].first  = keys_[i];
-           isolations[i].second = isolators_[i].getValue(rb);
-        }
+    template <typename RefType>
+    void MultiIsolator::fill(const RefType &rb, IsolationValuePairs &isolations) const {
+      isolations.resize(isolators_.size());
+      for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
+        isolations[i].first = keys_[i];
+        isolations[i].second = isolators_[i].getValue(rb);
+      }
     }
 
-
-    template<typename T>
-    void
-    MultiIsolator::fill(const edm::View<T> &coll, int idx, IsolationValuePairs & isolations) const
-    {
-        edm::RefToBase<T> rb = coll.refAt(idx);
-        fill(rb, isolations);
+    template <typename T>
+    void MultiIsolator::fill(const edm::View<T> &coll, int idx, IsolationValuePairs &isolations) const {
+      edm::RefToBase<T> rb = coll.refAt(idx);
+      fill(rb, isolations);
     }
 
-}} // namespace
+  }  // namespace helper
+}  // namespace pat
 
 #endif
-

--- a/PhysicsTools/PatAlgos/interface/MuonMvaEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/MuonMvaEstimator.h
@@ -15,16 +15,15 @@ namespace pat {
 namespace reco {
   class JetCorrector;
   class Vertex;
-}
+}  // namespace reco
 
 namespace edm {
   class FileInPath;
 }
 
 namespace pat {
-  class MuonMvaEstimator{
+  class MuonMvaEstimator {
   public:
-
     MuonMvaEstimator(const edm::FileInPath& weightsfile, float dRmax);
 
     ~MuonMvaEstimator();
@@ -34,15 +33,13 @@ namespace pat {
                      const reco::JetTagCollection& bTags,
                      float& jetPtRatio,
                      float& jetPtRel,
-		     float& miniIsoValue,
-                     const reco::JetCorrector* correctorL1=nullptr,
-                     const reco::JetCorrector* correctorL1L2L3Res=nullptr) const;
+                     float& miniIsoValue,
+                     const reco::JetCorrector* correctorL1 = nullptr,
+                     const reco::JetCorrector* correctorL1L2L3Res = nullptr) const;
 
   private:
-
     std::unique_ptr<const GBRForest> gbrForest_;
     float dRmax_;
-
   };
-}
+}  // namespace pat
 #endif

--- a/PhysicsTools/PatAlgos/interface/ObjectModifier.h
+++ b/PhysicsTools/PatAlgos/interface/ObjectModifier.h
@@ -5,7 +5,7 @@
 #include <memory>
 
 namespace pat {
-  template<class T>
+  template <class T>
   class ObjectModifier {
   public:
     typedef std::unique_ptr<ModifyObjectValueBase> ModifierPointer;
@@ -14,17 +14,17 @@ namespace pat {
     ~ObjectModifier() {}
 
     void setEvent(const edm::Event& event) {
-      for( unsigned i = 0; i < modifiers_.size(); ++i )
+      for (unsigned i = 0; i < modifiers_.size(); ++i)
         modifiers_[i]->setEvent(event);
     }
 
     void setEventContent(const edm::EventSetup& setup) {
-      for( unsigned i = 0; i < modifiers_.size(); ++i )
+      for (unsigned i = 0; i < modifiers_.size(); ++i)
         modifiers_[i]->setEventContent(setup);
     }
 
     void modify(T& obj) const {
-      for( unsigned i = 0; i < modifiers_.size(); ++i )
+      for (unsigned i = 0; i < modifiers_.size(); ++i)
         modifiers_[i]->modifyObject(obj);
     }
 
@@ -32,16 +32,15 @@ namespace pat {
     std::vector<ModifierPointer> modifiers_;
   };
 
-  template<class T>
+  template <class T>
   ObjectModifier<T>::ObjectModifier(const edm::ParameterSet& conf, edm::ConsumesCollector&& cc) {
-    const std::vector<edm::ParameterSet>& mods = 
-      conf.getParameterSetVector("modifications");
-    for(unsigned i = 0; i < mods.size(); ++i ) {
+    const std::vector<edm::ParameterSet>& mods = conf.getParameterSetVector("modifications");
+    for (unsigned i = 0; i < mods.size(); ++i) {
       const edm::ParameterSet& iconf = mods[i];
       const std::string& mname = iconf.getParameter<std::string>("modifierName");
-      modifiers_.emplace_back(ModifyObjectValueFactory::get()->create(mname,iconf,cc));
+      modifiers_.emplace_back(ModifyObjectValueFactory::get()->create(mname, iconf, cc));
     }
   }
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/OverlapTest.h
+++ b/PhysicsTools/PatAlgos/interface/OverlapTest.h
@@ -12,82 +12,86 @@
 #include "PhysicsTools/PatUtils/interface/StringParserTools.h"
 #include "PhysicsTools/PatUtils/interface/PATDiObjectProxy.h"
 
-namespace pat { namespace helper {
+namespace pat {
+  namespace helper {
 
-// Base class for a test for overlaps
-class OverlapTest {
+    // Base class for a test for overlaps
+    class OverlapTest {
     public:
-        /// constructor: reads 'src' and 'requireNoOverlaps' parameters
-        OverlapTest(const std::string &name, const edm::ParameterSet &iConfig, edm::ConsumesCollector & iC) :
-            srcToken_(iC.consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("src"))),
+      /// constructor: reads 'src' and 'requireNoOverlaps' parameters
+      OverlapTest(const std::string &name, const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC)
+          : srcToken_(iC.consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("src"))),
             name_(name),
             requireNoOverlaps_(iConfig.getParameter<bool>("requireNoOverlaps")) {}
-        /// destructor, does nothing
-        virtual ~OverlapTest() {}
-        /// initializer for each event. to be implemented in child classes.
-        virtual void readInput(const edm::Event & iEvent, const edm::EventSetup &iSetup) = 0;
-        /// check for overlaps for a given item. to be implemented in child classes
-        /// return true if overlaps have been found, and fills the PtrVector
-        virtual bool fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const = 0;
-        /// end of event method. does nothing
-        virtual void done() {}
-        // -- basic getters ---
+      /// destructor, does nothing
+      virtual ~OverlapTest() {}
+      /// initializer for each event. to be implemented in child classes.
+      virtual void readInput(const edm::Event &iEvent, const edm::EventSetup &iSetup) = 0;
+      /// check for overlaps for a given item. to be implemented in child classes
+      /// return true if overlaps have been found, and fills the PtrVector
+      virtual bool fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const = 0;
+      /// end of event method. does nothing
+      virtual void done() {}
+      // -- basic getters ---
 
-        const std::string & name() const { return name_; }
-        bool requireNoOverlaps() const { return requireNoOverlaps_; }
+      const std::string &name() const { return name_; }
+      bool requireNoOverlaps() const { return requireNoOverlaps_; }
+
     protected:
-        edm::EDGetTokenT<reco::CandidateView> srcToken_;
-        std::string   name_;
-        bool          requireNoOverlaps_;
-};
+      edm::EDGetTokenT<reco::CandidateView> srcToken_;
+      std::string name_;
+      bool requireNoOverlaps_;
+    };
 
-class BasicOverlapTest : public OverlapTest {
+    class BasicOverlapTest : public OverlapTest {
     public:
-        BasicOverlapTest(const std::string &name, const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) :
-            OverlapTest(name, iConfig, iC),
+      BasicOverlapTest(const std::string &name, const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC)
+          : OverlapTest(name, iConfig, iC),
             presel_(iConfig.getParameter<std::string>("preselection")),
             deltaR_(iConfig.getParameter<double>("deltaR")),
             checkRecoComponents_(iConfig.getParameter<bool>("checkRecoComponents")),
             pairCut_(iConfig.getParameter<std::string>("pairCut")) {}
-        // implementation of mother methods
-        /// Read input, apply preselection cut
-        void readInput(const edm::Event & iEvent, const edm::EventSetup &iSetup) override ;
-        /// Check for overlaps
-        bool fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const override ;
-    protected:
-        // ---- configurables ----
-        /// A generic preselection cut that can work on any Candidate, but has access also to methods of PAT specific objects
-        PATStringCutObjectSelector presel_;
-        /// Delta R for the match
-        double deltaR_;
-        /// Check the overlapping by RECO components
-        bool checkRecoComponents_;
-        /// Cut on the pair of objects together
-        StringCutObjectSelector<pat::DiObjectProxy> pairCut_;
-        // ---- working variables ----
-        /// The collection to check overlaps against
-        edm::Handle<reco::CandidateView> candidates_;
-        /// Flag saying if each element has passed the preselection or not
-        std::vector<bool> isPreselected_;
-};
+      // implementation of mother methods
+      /// Read input, apply preselection cut
+      void readInput(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+      /// Check for overlaps
+      bool fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const override;
 
-class OverlapBySuperClusterSeed : public OverlapTest {
+    protected:
+      // ---- configurables ----
+      /// A generic preselection cut that can work on any Candidate, but has access also to methods of PAT specific objects
+      PATStringCutObjectSelector presel_;
+      /// Delta R for the match
+      double deltaR_;
+      /// Check the overlapping by RECO components
+      bool checkRecoComponents_;
+      /// Cut on the pair of objects together
+      StringCutObjectSelector<pat::DiObjectProxy> pairCut_;
+      // ---- working variables ----
+      /// The collection to check overlaps against
+      edm::Handle<reco::CandidateView> candidates_;
+      /// Flag saying if each element has passed the preselection or not
+      std::vector<bool> isPreselected_;
+    };
+
+    class OverlapBySuperClusterSeed : public OverlapTest {
     public:
-        // constructor: nothing except initialize the base class
-        OverlapBySuperClusterSeed(const std::string &name, const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) : OverlapTest(name, iConfig, iC) {}
-        // every event: nothing except read the input list
-        void readInput(const edm::Event & iEvent, const edm::EventSetup &iSetup) override {
-            iEvent.getByToken(srcToken_, others_);
-        }
-         /// Check for overlaps
-        bool fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const override ;
+      // constructor: nothing except initialize the base class
+      OverlapBySuperClusterSeed(const std::string &name, const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC)
+          : OverlapTest(name, iConfig, iC) {}
+      // every event: nothing except read the input list
+      void readInput(const edm::Event &iEvent, const edm::EventSetup &iSetup) override {
+        iEvent.getByToken(srcToken_, others_);
+      }
+      /// Check for overlaps
+      bool fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const override;
+
     protected:
-//         edm::Handle<edm::View<reco::RecoCandidate> > others_;
-        edm::Handle<reco::CandidateView> others_;
-};
+      //         edm::Handle<edm::View<reco::RecoCandidate> > others_;
+      edm::Handle<reco::CandidateView> others_;
+    };
 
-
-
-} } // namespaces
+  }  // namespace helper
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/PATPrimaryVertexSelector.h
+++ b/PhysicsTools/PatAlgos/interface/PATPrimaryVertexSelector.h
@@ -25,7 +25,7 @@ public:
   typedef reco::VertexCollection collection;
   typedef std::vector<const reco::Vertex*> container;
   typedef container::const_iterator const_iterator;
-  PATPrimaryVertexSelector (const edm::ParameterSet& cfg, edm::ConsumesCollector && iC);
+  PATPrimaryVertexSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC);
   /// needed for use with an ObjectSelector
   const_iterator begin() const { return selected_.begin(); }
   /// needed for use with an ObjectSelector
@@ -35,22 +35,22 @@ public:
   /// needed for use with an ObjectSelector
   size_t size() const { return selected_.size(); }
   /// operator used in sorting the selected vertices
-  bool operator() (const reco::Vertex*, const reco::Vertex*) const;
-private:
-  /// access to track-related vertex quantities (multiplicity and pt-sum)
-  void getVertexVariables (const reco::Vertex&, unsigned int&, double&) const;
-  /// track selection
-  bool acceptTrack (const reco::Track&) const;
+  bool operator()(const reco::Vertex*, const reco::Vertex*) const;
 
 private:
-  container selected_;               /// container of selected vertices
-  unsigned int multiplicityCut_;     /// minimum multiplicity of (selected) associated tracks
-  float ptSumCut_;                   /// minimum pt sum o (selected) associated tracks
-  float trackEtaCut_;                /// eta cut used for the track selection
-  float chi2Cut_;                    /// cut on the normalized chi2
-  float dr2Cut_;                     /// cut on the (squared) transverse position
-  float dzCut_;                      /// cut on the longitudinal position
+  /// access to track-related vertex quantities (multiplicity and pt-sum)
+  void getVertexVariables(const reco::Vertex&, unsigned int&, double&) const;
+  /// track selection
+  bool acceptTrack(const reco::Track&) const;
+
+private:
+  container selected_;            /// container of selected vertices
+  unsigned int multiplicityCut_;  /// minimum multiplicity of (selected) associated tracks
+  float ptSumCut_;                /// minimum pt sum o (selected) associated tracks
+  float trackEtaCut_;             /// eta cut used for the track selection
+  float chi2Cut_;                 /// cut on the normalized chi2
+  float dr2Cut_;                  /// cut on the (squared) transverse position
+  float dzCut_;                   /// cut on the longitudinal position
 };
 
 #endif
-

--- a/PhysicsTools/PatAlgos/interface/PATUserDataMerger.h
+++ b/PhysicsTools/PatAlgos/interface/PATUserDataMerger.h
@@ -38,85 +38,87 @@
 
 #include <iostream>
 
-
 namespace pat {
   namespace helper {
     struct AddUserInt {
-        typedef int                       value_type;
-        typedef edm::ValueMap<value_type> product_type;
-        template<typename ObjectType>
-        void addData(ObjectType &obj, const std::string & key, const value_type &val) { obj.addUserInt(key, val); }
+      typedef int value_type;
+      typedef edm::ValueMap<value_type> product_type;
+      template <typename ObjectType>
+      void addData(ObjectType &obj, const std::string &key, const value_type &val) {
+        obj.addUserInt(key, val);
+      }
     };
     struct AddUserFloat {
-        typedef float                     value_type;
-        typedef edm::ValueMap<value_type> product_type;
-        template<typename ObjectType>
-        void addData(ObjectType &obj, const std::string & key, const value_type &val) { obj.addUserFloat(key, val); }
+      typedef float value_type;
+      typedef edm::ValueMap<value_type> product_type;
+      template <typename ObjectType>
+      void addData(ObjectType &obj, const std::string &key, const value_type &val) {
+        obj.addUserFloat(key, val);
+      }
     };
     struct AddUserPtr {
-        typedef edm::Ptr<UserData>        value_type;
-        typedef edm::ValueMap<value_type> product_type;
-        template<typename ObjectType>
-        void addData(ObjectType &obj, const std::string & key, const value_type &val) {
-              obj.addUserDataFromPtr(key, val);
-        }
+      typedef edm::Ptr<UserData> value_type;
+      typedef edm::ValueMap<value_type> product_type;
+      template <typename ObjectType>
+      void addData(ObjectType &obj, const std::string &key, const value_type &val) {
+        obj.addUserDataFromPtr(key, val);
+      }
     };
     struct AddUserCand {
-        typedef reco::CandidatePtr        value_type;
-        typedef edm::ValueMap<value_type> product_type;
-        template<typename ObjectType>
-        void addData(ObjectType &obj, const std::string & key, const value_type &val) { obj.addUserCand(key, val); }
+      typedef reco::CandidatePtr value_type;
+      typedef edm::ValueMap<value_type> product_type;
+      template <typename ObjectType>
+      void addData(ObjectType &obj, const std::string &key, const value_type &val) {
+        obj.addUserCand(key, val);
+      }
     };
 
-  }
+  }  // namespace helper
 
-  template<typename ObjectType, typename Operation>
+  template <typename ObjectType, typename Operation>
   class PATUserDataMerger {
-
   public:
-
     PATUserDataMerger() {}
-    PATUserDataMerger(const edm::ParameterSet & iConfig, edm::ConsumesCollector & iC);
+    PATUserDataMerger(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC);
     ~PATUserDataMerger() {}
 
-    static void fillDescription(edm::ParameterSetDescription & iDesc);
+    static void fillDescription(edm::ParameterSetDescription &iDesc);
 
     // Method to call from PATUserDataHelper to add information to the PATObject in question.
-    void add(ObjectType & patObject,
-	     edm::Event const & iEvent, edm::EventSetup const & iSetup);
+    void add(ObjectType &patObject, edm::Event const &iEvent, edm::EventSetup const &iSetup);
 
   private:
-
     // configurables
     std::vector<edm::InputTag> userDataSrc_;
-    std::vector<edm::EDGetTokenT<typename Operation::product_type> > userDataSrcTokens_;
+    std::vector<edm::EDGetTokenT<typename Operation::product_type>> userDataSrcTokens_;
     std::vector<std::string> labelPostfixesToStrip_, labels_;
-    Operation                   loader_;
-
+    Operation loader_;
   };
 
-}
+}  // namespace pat
 
 // Constructor: Initilize user data src
-template<typename ObjectType, typename Operation>
-pat::PATUserDataMerger<ObjectType, Operation>::PATUserDataMerger(const edm::ParameterSet & iConfig, edm::ConsumesCollector & iC) :
-  userDataSrc_(iConfig.getParameter<std::vector<edm::InputTag> >("src")),
-  labelPostfixesToStrip_(iConfig.existsAs<std::vector<std::string>>("labelPostfixesToStrip") ? iConfig.getParameter<std::vector<std::string>>("labelPostfixesToStrip") : std::vector<std::string>())
-{
-  for ( std::vector<edm::InputTag>::const_iterator input_it = userDataSrc_.begin(); input_it !=  userDataSrc_.end(); ++input_it ) {
-    userDataSrcTokens_.push_back( iC.consumes< typename Operation::product_type >( *input_it ) );
+template <typename ObjectType, typename Operation>
+pat::PATUserDataMerger<ObjectType, Operation>::PATUserDataMerger(const edm::ParameterSet &iConfig,
+                                                                 edm::ConsumesCollector &iC)
+    : userDataSrc_(iConfig.getParameter<std::vector<edm::InputTag>>("src")),
+      labelPostfixesToStrip_(iConfig.existsAs<std::vector<std::string>>("labelPostfixesToStrip")
+                                 ? iConfig.getParameter<std::vector<std::string>>("labelPostfixesToStrip")
+                                 : std::vector<std::string>()) {
+  for (std::vector<edm::InputTag>::const_iterator input_it = userDataSrc_.begin(); input_it != userDataSrc_.end();
+       ++input_it) {
+    userDataSrcTokens_.push_back(iC.consumes<typename Operation::product_type>(*input_it));
   }
-  for (edm::InputTag tag : userDataSrc_) { // copy by value
-      for (const std::string & stripme : labelPostfixesToStrip_) {
-          auto match = tag.label().rfind(stripme);
-          if (match == (tag.label().length() - stripme.length())) {
-              tag = edm::InputTag(tag.label().substr(0, match), tag.instance(), tag.process());
-          } 
+  for (edm::InputTag tag : userDataSrc_) {  // copy by value
+    for (const std::string &stripme : labelPostfixesToStrip_) {
+      auto match = tag.label().rfind(stripme);
+      if (match == (tag.label().length() - stripme.length())) {
+        tag = edm::InputTag(tag.label().substr(0, match), tag.instance(), tag.process());
       }
-      labels_.push_back(tag.encode());
+    }
+    labels_.push_back(tag.encode());
   }
 }
-
 
 /* ==================================================================================
      PATUserDataMerger::add
@@ -134,17 +136,16 @@ pat::PATUserDataMerger<ObjectType, Operation>::PATUserDataMerger(const edm::Para
    ==================================================================================
 */
 
-template<class ObjectType, typename Operation>
-void
-pat::PATUserDataMerger<ObjectType, Operation>::add(ObjectType & patObject,
-						   edm::Event const & iEvent,
-						   const edm::EventSetup& iSetup)
-{
+template <class ObjectType, typename Operation>
+void pat::PATUserDataMerger<ObjectType, Operation>::add(ObjectType &patObject,
+                                                        edm::Event const &iEvent,
+                                                        const edm::EventSetup &iSetup) {
+  typename std::vector<edm::EDGetTokenT<typename Operation::product_type>>::const_iterator
+      token_begin = userDataSrcTokens_.begin(),
+      token_it = userDataSrcTokens_.begin(), token_end = userDataSrcTokens_.end();
 
-  typename std::vector<edm::EDGetTokenT<typename Operation::product_type> >::const_iterator token_begin = userDataSrcTokens_.begin(), token_it = userDataSrcTokens_.begin(), token_end = userDataSrcTokens_.end();
-
-  for ( ; token_it != token_end; ++token_it ) {
-    const std::string & encoded = (labels_.at(token_it - token_begin));
+  for (; token_it != token_end; ++token_it) {
+    const std::string &encoded = (labels_.at(token_it - token_begin));
 
     // Declare the object handles:
     // ValueMap containing the values, or edm::Ptr's to the UserData that
@@ -152,21 +153,18 @@ pat::PATUserDataMerger<ObjectType, Operation>::add(ObjectType & patObject,
     edm::Handle<typename Operation::product_type> userData;
 
     // Get the objects by label
-    if ( encoded.empty() ) continue;
-    iEvent.getByToken( *token_it, userData );
+    if (encoded.empty())
+      continue;
+    iEvent.getByToken(*token_it, userData);
 
     edm::Ptr<reco::Candidate> recoObject = patObject.originalObjectRef();
-    loader_.addData( patObject, encoded, (*userData)[recoObject]);
-
+    loader_.addData(patObject, encoded, (*userData)[recoObject]);
   }
-
 }
 
-template<class ObjectType, typename Operation>
-void
-pat::PATUserDataMerger<ObjectType, Operation>::fillDescription(edm::ParameterSetDescription & iDesc)
-{
-  iDesc.add<std::vector<edm::InputTag> >("src");
+template <class ObjectType, typename Operation>
+void pat::PATUserDataMerger<ObjectType, Operation>::fillDescription(edm::ParameterSetDescription &iDesc) {
+  iDesc.add<std::vector<edm::InputTag>>("src");
   iDesc.addOptional<std::vector<std::string>>("labelPostfixesToStrip", std::vector<std::string>());
 }
 

--- a/PhysicsTools/PatAlgos/interface/SimpleIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/SimpleIsolator.h
@@ -3,24 +3,25 @@
 
 #include "PhysicsTools/PatAlgos/interface/BaseIsolator.h"
 
-namespace pat { namespace helper {
-class SimpleIsolator : public BaseIsolator {
+namespace pat {
+  namespace helper {
+    class SimpleIsolator : public BaseIsolator {
     public:
-        typedef edm::ValueMap<double> IsoValueMap;
-        SimpleIsolator() {}
-        SimpleIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
-        ~SimpleIsolator() override {}
-        void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) override ;
-        void endEvent() override ;
+      typedef edm::ValueMap<double> IsoValueMap;
+      SimpleIsolator() {}
+      SimpleIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut);
+      ~SimpleIsolator() override {}
+      void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) override;
+      void endEvent() override;
 
-        std::string description() const override { return input_.encode(); }
+      std::string description() const override { return input_.encode(); }
+
     protected:
-        edm::Handle<IsoValueMap> handle_;
-        edm::EDGetTokenT<IsoValueMap> inputDoubleToken_;
-        float getValue(const edm::ProductID &id, size_t index) const override {
-            return handle_->get(id, index);
-        }
-}; // class SimpleIsolator
-} } // namespaces
+      edm::Handle<IsoValueMap> handle_;
+      edm::EDGetTokenT<IsoValueMap> inputDoubleToken_;
+      float getValue(const edm::ProductID &id, size_t index) const override { return handle_->get(id, index); }
+    };  // class SimpleIsolator
+  }     // namespace helper
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h
@@ -15,9 +15,8 @@ namespace edm {
 }
 
 namespace pat {
-  class SoftMuonMvaEstimator{
+  class SoftMuonMvaEstimator {
   public:
-
     SoftMuonMvaEstimator(const edm::FileInPath& weightsfile);
 
     ~SoftMuonMvaEstimator();
@@ -25,9 +24,7 @@ namespace pat {
     float computeMva(const pat::Muon& imuon) const;
 
   private:
-
     std::unique_ptr<const GBRForest> gbrForest_;
-
   };
-}
+}  // namespace pat
 #endif

--- a/PhysicsTools/PatAlgos/interface/StringResolutionProvider.h
+++ b/PhysicsTools/PatAlgos/interface/StringResolutionProvider.h
@@ -41,8 +41,7 @@
 */
 
 class StringResolutionProvider : public KinematicResolutionProvider {
-
- public:
+public:
   /// short cut within the common namespace
   typedef StringObjectFunction<reco::Candidate> Function;
 
@@ -50,11 +49,11 @@ class StringResolutionProvider : public KinematicResolutionProvider {
   StringResolutionProvider(const edm::ParameterSet& cfg);
   /// default destructor
   ~StringResolutionProvider() override;
-  /// get a CandKinResolution object from the service 
+  /// get a CandKinResolution object from the service
   pat::CandKinResolution getResolution(const reco::Candidate& cand) const override;
 
- private:
-  /// a vector of constrtaints for the CanKinResolution 
+private:
+  /// a vector of constrtaints for the CanKinResolution
   /// object
   std::vector<pat::CandKinResolution::Scalar> constraints_;
   /// a parametrization for the CanKinResolution object

--- a/PhysicsTools/PatAlgos/interface/VertexingHelper.h
+++ b/PhysicsTools/PatAlgos/interface/VertexingHelper.h
@@ -11,7 +11,6 @@
   \version  $Id: VertexingHelper.h,v 1.3 2008/06/06 14:13:40 gpetrucc Exp $
 */
 
-
 #include "DataFormats/PatCandidates/interface/Vertexing.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "PhysicsTools/PatUtils/interface/VertexAssociationSelector.h"
@@ -26,89 +25,89 @@
 
 #include "PhysicsTools/UtilAlgos/interface/ParameterAdapter.h"
 namespace reco {
-    namespace modules {
-        /// Helper struct to convert from ParameterSet to ElectronSelection
-        template<>
-        struct ParameterAdapter<pat::VertexAssociationSelector> {
-            static pat::VertexAssociationSelector make(const edm::ParameterSet & iConfig) {
-                pat::VertexAssociationSelector::Config assoconf;
-                if (iConfig.existsAs<double>("deltaZ"))  assoconf.dZ = iConfig.getParameter<double>("deltaZ");
-                if (iConfig.existsAs<double>("deltaR"))  assoconf.dR = iConfig.getParameter<double>("deltaR");
-                if (iConfig.existsAs<double>("sigmasZ")) assoconf.sigmasZ = iConfig.getParameter<double>("sigmasZ");
-                if (iConfig.existsAs<double>("sigmasR")) assoconf.sigmasR = iConfig.getParameter<double>("sigmasR");
-                return pat::VertexAssociationSelector(assoconf);
-            }
-        };
-    }
-}
+  namespace modules {
+    /// Helper struct to convert from ParameterSet to ElectronSelection
+    template <>
+    struct ParameterAdapter<pat::VertexAssociationSelector> {
+      static pat::VertexAssociationSelector make(const edm::ParameterSet &iConfig) {
+        pat::VertexAssociationSelector::Config assoconf;
+        if (iConfig.existsAs<double>("deltaZ"))
+          assoconf.dZ = iConfig.getParameter<double>("deltaZ");
+        if (iConfig.existsAs<double>("deltaR"))
+          assoconf.dR = iConfig.getParameter<double>("deltaR");
+        if (iConfig.existsAs<double>("sigmasZ"))
+          assoconf.sigmasZ = iConfig.getParameter<double>("sigmasZ");
+        if (iConfig.existsAs<double>("sigmasR"))
+          assoconf.sigmasR = iConfig.getParameter<double>("sigmasR");
+        return pat::VertexAssociationSelector(assoconf);
+      }
+    };
+  }  // namespace modules
+}  // namespace reco
 
-namespace pat { namespace helper {
+namespace pat {
+  namespace helper {
     class VertexingHelper {
-        public:
-            VertexingHelper() : enabled_(false) {}
-            VertexingHelper(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) ;
+    public:
+      VertexingHelper() : enabled_(false) {}
+      VertexingHelper(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC);
 
-            /// returns true if this was given a non dummy configuration
-            bool enabled() const {  return enabled_; }
+      /// returns true if this was given a non dummy configuration
+      bool enabled() const { return enabled_; }
 
-            /// To be called for each new event, reads in the vertex collection
-            void newEvent(const edm::Event &event) ;
+      /// To be called for each new event, reads in the vertex collection
+      void newEvent(const edm::Event &event);
 
-            /// To be called for each new event, reads in the vertex collection and the tracking info
-            /// You need this if 'useTrack' is true
-            void newEvent(const edm::Event &event, const edm::EventSetup & setup) ;
+      /// To be called for each new event, reads in the vertex collection and the tracking info
+      /// You need this if 'useTrack' is true
+      void newEvent(const edm::Event &event, const edm::EventSetup &setup);
 
-            /// Return true if this candidate is associated to a valid vertex
-            /// AnyCandRef should be a Ref<>, RefToBase<> or Ptr to a Candidate object
-            template<typename AnyCandRef>
-            pat::VertexAssociation  operator()(const AnyCandRef &) const ;
+      /// Return true if this candidate is associated to a valid vertex
+      /// AnyCandRef should be a Ref<>, RefToBase<> or Ptr to a Candidate object
+      template <typename AnyCandRef>
+      pat::VertexAssociation operator()(const AnyCandRef &) const;
 
-        private:
-            /// true if it has non null configuration
-            bool enabled_;
+    private:
+      /// true if it has non null configuration
+      bool enabled_;
 
-            /// true if it's just reading the associations from the event
-            bool playback_;
+      /// true if it's just reading the associations from the event
+      bool playback_;
 
-            /// selector of associations
-            pat::VertexAssociationSelector assoSelector_;
+      /// selector of associations
+      pat::VertexAssociationSelector assoSelector_;
 
-            //-------- Tools for production of vertex associations -------
-            edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
-            edm::Handle<reco::VertexCollection> vertexHandle_;
-            /// use tracks inside candidates
-            bool useTracks_;
-            edm::ESHandle<TransientTrackBuilder> ttBuilder_;
+      //-------- Tools for production of vertex associations -------
+      edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
+      edm::Handle<reco::VertexCollection> vertexHandle_;
+      /// use tracks inside candidates
+      bool useTracks_;
+      edm::ESHandle<TransientTrackBuilder> ttBuilder_;
 
-            //--------- Tools for reading vertex associations (playback mode) -----
-            edm::EDGetTokenT<edm::ValueMap<pat::VertexAssociation> > vertexAssociationsToken_;
-            edm::Handle<edm::ValueMap<pat::VertexAssociation> > vertexAssoMap_;
+      //--------- Tools for reading vertex associations (playback mode) -----
+      edm::EDGetTokenT<edm::ValueMap<pat::VertexAssociation> > vertexAssociationsToken_;
+      edm::Handle<edm::ValueMap<pat::VertexAssociation> > vertexAssoMap_;
 
-            /// Get out the track from the Candidate / RecoCandidate / PFCandidate
-            reco::TrackBaseRef  getTrack_(const reco::Candidate &c) const ;
+      /// Get out the track from the Candidate / RecoCandidate / PFCandidate
+      reco::TrackBaseRef getTrack_(const reco::Candidate &c) const;
 
-            /// Try to associated this candidate to a vertex.
-            /// If no association is found passing all cuts, return a null association
-            pat::VertexAssociation associate(const reco::Candidate &) const ;
+      /// Try to associated this candidate to a vertex.
+      /// If no association is found passing all cuts, return a null association
+      pat::VertexAssociation associate(const reco::Candidate &) const;
 
-    }; // class
+    };  // class
 
-    template<typename AnyCandRef>
-    pat::VertexAssociation
-    pat::helper::VertexingHelper::operator()(const AnyCandRef &cand) const
-    {
-        if (playback_) {
-            const pat::VertexAssociation &assoc = (*vertexAssoMap_)[cand];
-            return assoSelector_(assoc) ? assoc : pat::VertexAssociation();
-        } else {
-            return associate( *cand );
-        }
-
+    template <typename AnyCandRef>
+    pat::VertexAssociation pat::helper::VertexingHelper::operator()(const AnyCandRef &cand) const {
+      if (playback_) {
+        const pat::VertexAssociation &assoc = (*vertexAssoMap_)[cand];
+        return assoSelector_(assoc) ? assoc : pat::VertexAssociation();
+      } else {
+        return associate(*cand);
+      }
     }
 
-} }
-
-
-
+  }  // namespace helper
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/BaseMVAValueMapProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/BaseMVAValueMapProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PhysicsTools/PatAlgos
 // Class:      BaseMVAValueMapProducer
-// 
+//
 /**\class BaseMVAValueMapProducer BaseMVAValueMapProducer.cc PhysicsTools/PatAlgos/plugins/BaseMVAValueMapProducer.cc
 
  Description: [one line class summary]
@@ -26,4 +26,3 @@ typedef BaseMVAValueMapProducer<pat::Electron> EleBaseMVAValueMapProducer;
 DEFINE_FWK_MODULE(JetBaseMVAValueMapProducer);
 DEFINE_FWK_MODULE(MuonBaseMVAValueMapProducer);
 DEFINE_FWK_MODULE(EleBaseMVAValueMapProducer);
-

--- a/PhysicsTools/PatAlgos/plugins/BaseMVAValueMapProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/BaseMVAValueMapProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    PhysicsTools/PatAlgos
 // Class:      BaseMVAValueMapProducer
-// 
+//
 /**\class BaseMVAValueMapProducer BaseMVAValueMapProducer.cc PhysicsTools/PatAlgos/plugins/BaseMVAValueMapProducer.cc
 
  Description: [one line class summary]
@@ -19,7 +19,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -32,7 +31,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-
 
 #include "TMVA/Factory.h"
 #include "TMVA/Reader.h"
@@ -54,86 +52,88 @@
 // class declaration
 //
 
-
 template <typename T>
 class BaseMVAValueMapProducer : public edm::stream::EDProducer<> {
-  public:
-  explicit BaseMVAValueMapProducer(const edm::ParameterSet &iConfig):
-    src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src"))),
-    variablesOrder_(iConfig.getParameter<std::vector<std::string>>("variablesOrder")),
-    name_(iConfig.getParameter<std::string>("name")),
-    backend_(iConfig.getParameter<std::string>("backend")),
-    weightfilename_(iConfig.getParameter<edm::FileInPath>("weightFile").fullPath()),
-    isClassifier_(iConfig.getParameter<bool>("isClassifier")),
-    tmva_(backend_=="TMVA"),tf_(backend_=="TF")
-    {
-      if(tmva_) reader_=new TMVA::Reader();
-      edm::ParameterSet const & varsPSet = iConfig.getParameter<edm::ParameterSet>("variables");
-      for (const std::string & vname : varsPSet.getParameterNamesForType<std::string>()) {
-	  funcs_.emplace_back(std::pair<std::string,StringObjectFunction<T,true>>(vname,varsPSet.getParameter<std::string>(vname)));
-      }
-
-      values_.resize(variablesOrder_.size());
-      size_t i=0;
-      for(const auto & v : variablesOrder_){
-        positions_[v]=i;
-        if(tmva_) reader_->AddVariable(v,(&values_.front())+i);
-	    i++;
-      }
-//      reader_.BookMVA(name_,iConfig.getParameter<edm::FileInPath>("weightFile").fullPath() );
-    if(tmva_)
-    {
-        reco::details::loadTMVAWeights(reader_, name_, weightfilename_);
-    }else if(tf_)    {
-        tensorflow::setLogging("3");
-        graph_=tensorflow::loadGraphDef(weightfilename_);
-        inputTensorName_=iConfig.getParameter<std::string>("inputTensorName");
-        outputTensorName_=iConfig.getParameter<std::string>("outputTensorName");
-        output_names_=iConfig.getParameter<std::vector<std::string>>("outputNames");
-        for(const auto & s : iConfig.getParameter<std::vector<std::string>>("outputFormulas")) { output_formulas_.push_back(StringObjectFunction<std::vector<float>>(s));} 
-        size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
-        std::string singleThreadPool = iConfig.getParameter<std::string>("singleThreadPool");
-        tensorflow::SessionOptions sessionOptions;
-        tensorflow::setThreading(sessionOptions, nThreads, singleThreadPool);
-        session_ = tensorflow::createSession(graph_, sessionOptions);
-
-    } else  {
-          throw cms::Exception("ConfigError") << "Only 'TF' and 'TMVA' backends are supported\n";
+public:
+  explicit BaseMVAValueMapProducer(const edm::ParameterSet& iConfig)
+      : src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src"))),
+        variablesOrder_(iConfig.getParameter<std::vector<std::string>>("variablesOrder")),
+        name_(iConfig.getParameter<std::string>("name")),
+        backend_(iConfig.getParameter<std::string>("backend")),
+        weightfilename_(iConfig.getParameter<edm::FileInPath>("weightFile").fullPath()),
+        isClassifier_(iConfig.getParameter<bool>("isClassifier")),
+        tmva_(backend_ == "TMVA"),
+        tf_(backend_ == "TF") {
+    if (tmva_)
+      reader_ = new TMVA::Reader();
+    edm::ParameterSet const& varsPSet = iConfig.getParameter<edm::ParameterSet>("variables");
+    for (const std::string& vname : varsPSet.getParameterNamesForType<std::string>()) {
+      funcs_.emplace_back(
+          std::pair<std::string, StringObjectFunction<T, true>>(vname, varsPSet.getParameter<std::string>(vname)));
     }
-   if(tmva_) produces<edm::ValueMap<float>>();
-   else {
-        for(const auto & n : output_names_){
-            produces<edm::ValueMap<float>>(n);
-        }
-   }
 
+    values_.resize(variablesOrder_.size());
+    size_t i = 0;
+    for (const auto& v : variablesOrder_) {
+      positions_[v] = i;
+      if (tmva_)
+        reader_->AddVariable(v, (&values_.front()) + i);
+      i++;
+    }
+    //      reader_.BookMVA(name_,iConfig.getParameter<edm::FileInPath>("weightFile").fullPath() );
+    if (tmva_) {
+      reco::details::loadTMVAWeights(reader_, name_, weightfilename_);
+    } else if (tf_) {
+      tensorflow::setLogging("3");
+      graph_ = tensorflow::loadGraphDef(weightfilename_);
+      inputTensorName_ = iConfig.getParameter<std::string>("inputTensorName");
+      outputTensorName_ = iConfig.getParameter<std::string>("outputTensorName");
+      output_names_ = iConfig.getParameter<std::vector<std::string>>("outputNames");
+      for (const auto& s : iConfig.getParameter<std::vector<std::string>>("outputFormulas")) {
+        output_formulas_.push_back(StringObjectFunction<std::vector<float>>(s));
+      }
+      size_t nThreads = iConfig.getParameter<unsigned int>("nThreads");
+      std::string singleThreadPool = iConfig.getParameter<std::string>("singleThreadPool");
+      tensorflow::SessionOptions sessionOptions;
+      tensorflow::setThreading(sessionOptions, nThreads, singleThreadPool);
+      session_ = tensorflow::createSession(graph_, sessionOptions);
+
+    } else {
+      throw cms::Exception("ConfigError") << "Only 'TF' and 'TMVA' backends are supported\n";
+    }
+    if (tmva_)
+      produces<edm::ValueMap<float>>();
+    else {
+      for (const auto& n : output_names_) {
+        produces<edm::ValueMap<float>>(n);
+      }
+    }
   }
   ~BaseMVAValueMapProducer() override {}
 
-  void setValue(const std::string var,float val) {
-      if(positions_.find(var)!=positions_.end())
-          values_[positions_[var]]=val;
+  void setValue(const std::string var, float val) {
+    if (positions_.find(var) != positions_.end())
+      values_[positions_[var]] = val;
   }
-  
+
   static edm::ParameterSetDescription getDescription();
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-  void beginStream(edm::StreamID) override {};
+private:
+  void beginStream(edm::StreamID) override{};
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override {};
+  void endStream() override{};
 
   ///to be implemented in derived classes, filling values for additional variables
-  virtual void readAdditionalCollections(edm::Event&, const edm::EventSetup&)  {}
-  virtual void fillAdditionalVariables(const T&)  {}
-
+  virtual void readAdditionalCollections(edm::Event&, const edm::EventSetup&) {}
+  virtual void fillAdditionalVariables(const T&) {}
 
   edm::EDGetTokenT<edm::View<T>> src_;
-  std::map<std::string,size_t> positions_;
-  std::vector<std::pair<std::string,StringObjectFunction<T,true>>> funcs_;
+  std::map<std::string, size_t> positions_;
+  std::vector<std::pair<std::string, StringObjectFunction<T, true>>> funcs_;
   std::vector<std::string> variablesOrder_;
   std::vector<float> values_;
-  TMVA::Reader * reader_;
+  TMVA::Reader* reader_;
   tensorflow::GraphDef* graph_;
   tensorflow::Session* session_;
 
@@ -147,62 +147,59 @@ class BaseMVAValueMapProducer : public edm::stream::EDProducer<> {
   std::string outputTensorName_;
   std::vector<std::string> output_names_;
   std::vector<StringObjectFunction<std::vector<float>>> output_formulas_;
-  
 };
 
 template <typename T>
-void
-BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<edm::View<T>> src;
   iEvent.getByToken(src_, src);
-  readAdditionalCollections(iEvent,iSetup);
-  std::vector<std::vector<float>> mvaOut((tmva_)?1:output_names_.size());
-  for( auto & v : mvaOut) v.reserve(src->size());
+  readAdditionalCollections(iEvent, iSetup);
+  std::vector<std::vector<float>> mvaOut((tmva_) ? 1 : output_names_.size());
+  for (auto& v : mvaOut)
+    v.reserve(src->size());
 
-  for(auto const & o: *src) {
-	for(auto const & p : funcs_ ){
-        setValue(p.first,p.second(o));
-	}
-        fillAdditionalVariables(o);
-    if(tmva_){
-        mvaOut[0].push_back(isClassifier_ ? reader_->EvaluateMVA(name_) : reader_->EvaluateRegression(name_)[0]);
+  for (auto const& o : *src) {
+    for (auto const& p : funcs_) {
+      setValue(p.first, p.second(o));
     }
-    if(tf_){
-        //currently support only one input sensor to reuse the TMVA like config 
-        tensorflow::TensorShape input_size   {1,(long long int)positions_.size()} ;
-        tensorflow::NamedTensorList input_tensors;
-        input_tensors.resize(1); 
-        input_tensors[0] = tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
-        for(size_t j =0; j < values_.size();j++) {
-           input_tensors[0].second.matrix<float>()(0,j) = values_[j];
-        }
-       std::vector<tensorflow::Tensor> outputs;
-       std::vector<std::string> names; names.push_back(outputTensorName_);
-       tensorflow::run(session_, input_tensors, names, &outputs);
-       std::vector<float> tmpOut;
-       for(int k=0;k<outputs.at(0).matrix<float>().dimension(1);k++) tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
-       for(size_t k=0;k<output_names_.size();k++) mvaOut[k].push_back(output_formulas_[k](tmpOut));
-
+    fillAdditionalVariables(o);
+    if (tmva_) {
+      mvaOut[0].push_back(isClassifier_ ? reader_->EvaluateMVA(name_) : reader_->EvaluateRegression(name_)[0]);
     }
-    
-
+    if (tf_) {
+      //currently support only one input sensor to reuse the TMVA like config
+      tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
+      tensorflow::NamedTensorList input_tensors;
+      input_tensors.resize(1);
+      input_tensors[0] =
+          tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
+      for (size_t j = 0; j < values_.size(); j++) {
+        input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+      }
+      std::vector<tensorflow::Tensor> outputs;
+      std::vector<std::string> names;
+      names.push_back(outputTensorName_);
+      tensorflow::run(session_, input_tensors, names, &outputs);
+      std::vector<float> tmpOut;
+      for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
+        tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
+      for (size_t k = 0; k < output_names_.size(); k++)
+        mvaOut[k].push_back(output_formulas_[k](tmpOut));
+    }
   }
-  size_t k=0;
-  for( auto & m : mvaOut) { 
-      std::unique_ptr<edm::ValueMap<float>> mvaV(new edm::ValueMap<float>());
-      edm::ValueMap<float>::Filler filler(*mvaV);
-      filler.insert(src,m.begin(),m.end());
-      filler.fill();
-      iEvent.put(std::move(mvaV),(tmva_)?"":output_names_[k]);
-      k++;
+  size_t k = 0;
+  for (auto& m : mvaOut) {
+    std::unique_ptr<edm::ValueMap<float>> mvaV(new edm::ValueMap<float>());
+    edm::ValueMap<float>::Filler filler(*mvaV);
+    filler.insert(src, m.begin(), m.end());
+    filler.fill();
+    iEvent.put(std::move(mvaV), (tmva_) ? "" : output_names_[k]);
+    k++;
   }
-
 }
 
 template <typename T>
-edm::ParameterSetDescription
-BaseMVAValueMapProducer<T>::getDescription(){
+edm::ParameterSetDescription BaseMVAValueMapProducer<T>::getDescription() {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src")->setComment("input physics object collection");
   desc.add<std::vector<std::string>>("variablesOrder")->setComment("ordered list of MVA input variable names");
@@ -212,30 +209,31 @@ BaseMVAValueMapProducer<T>::getDescription(){
   variables.setAllowAnything();
   desc.add<edm::ParameterSetDescription>("variables", variables)->setComment("list of input variable definitions");
   desc.add<edm::FileInPath>("weightFile")->setComment("xml weight file");
-  desc.add<std::string>("backend","TMVA")->setComment("TMVA or TF");
-  desc.add<std::string>("inputTensorName","")->setComment("Name of tensorflow input tensor in the model");
-  desc.add<std::string>("outputTensorName","")->setComment("Name of tensorflow output tensor in the model");
-  desc.add<std::vector<std::string>>("outputNames",std::vector<std::string>())->setComment("Names of the output values to be used in the output valuemap");
-  desc.add<std::vector<std::string>>("outputFormulas",std::vector<std::string>())->setComment("Formulas to be used to post process the output");
-  desc.add<unsigned int>("nThreads",1)->setComment("number of threads");
+  desc.add<std::string>("backend", "TMVA")->setComment("TMVA or TF");
+  desc.add<std::string>("inputTensorName", "")->setComment("Name of tensorflow input tensor in the model");
+  desc.add<std::string>("outputTensorName", "")->setComment("Name of tensorflow output tensor in the model");
+  desc.add<std::vector<std::string>>("outputNames", std::vector<std::string>())
+      ->setComment("Names of the output values to be used in the output valuemap");
+  desc.add<std::vector<std::string>>("outputFormulas", std::vector<std::string>())
+      ->setComment("Formulas to be used to post process the output");
+  desc.add<unsigned int>("nThreads", 1)->setComment("number of threads");
   desc.add<std::string>("singleThreadPool", "no_threads");
-
 
   return desc;
 }
 
 template <typename T>
-void
-BaseMVAValueMapProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BaseMVAValueMapProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc = getDescription();
   std::string modname;
-  if (typeid(T) == typeid(pat::Jet)) modname+="Jet";
-  else if (typeid(T) == typeid(pat::Muon)) modname+="Muon";
-  else if (typeid(T) == typeid(pat::Electron)) modname+="Ele";
-  modname+="BaseMVAValueMapProducer";
-  descriptions.add(modname,desc);
+  if (typeid(T) == typeid(pat::Jet))
+    modname += "Jet";
+  else if (typeid(T) == typeid(pat::Muon))
+    modname += "Muon";
+  else if (typeid(T) == typeid(pat::Electron))
+    modname += "Ele";
+  modname += "BaseMVAValueMapProducer";
+  descriptions.add(modname, desc);
 }
-
-
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/CaloJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/CaloJetSlimmer.cc
@@ -13,50 +13,42 @@
 #include <vector>
 
 class CaloJetSlimmer : public edm::stream::EDProducer<> {
-
 public:
+  CaloJetSlimmer(edm::ParameterSet const& params)
+      : srcToken_(consumes<edm::View<reco::CaloJet> >(params.getParameter<edm::InputTag>("src"))),
+        cut_(params.getParameter<std::string>("cut")),
+        selector_(cut_) {
+    produces<reco::CaloJetCollection>();
+  }
 
-CaloJetSlimmer( edm::ParameterSet const & params ):
-    srcToken_(consumes<edm::View<reco::CaloJet> >( params.getParameter<edm::InputTag>("src") )),
-    cut_( params.getParameter<std::string>("cut") ),
-    selector_( cut_ )
-    {
-        produces< reco::CaloJetCollection> ();
+  ~CaloJetSlimmer() override {}
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    auto caloJets = std::make_unique<reco::CaloJetCollection>();
+
+    edm::Handle<edm::View<reco::CaloJet> > h_jets;
+    iEvent.getByToken(srcToken_, h_jets);
+
+    for (auto const& ijet : *h_jets) {
+      if (selector_(ijet)) {
+        reco::CaloJet::Specific tmp_specific;
+        const reco::Candidate::Point orivtx(0, 0, 0);
+        tmp_specific.mEnergyFractionEm = ijet.emEnergyFraction();
+        tmp_specific.mEnergyFractionHadronic = ijet.energyFractionHadronic();
+        reco::CaloJet newCaloJet(ijet.p4(), orivtx, tmp_specific);
+        float jetArea = ijet.jetArea();
+        newCaloJet.setJetArea(jetArea);
+        caloJets->push_back(newCaloJet);
+      }
     }
-   
-    ~CaloJetSlimmer() override {}
-   
-    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
-        
-        auto caloJets = std::make_unique<reco::CaloJetCollection>();
-        
-        edm::Handle< edm::View<reco::CaloJet> > h_jets;
-        iEvent.getByToken( srcToken_, h_jets);
-
-        for (auto const& ijet : *h_jets){
-           if( selector_(ijet) ){
-              reco::CaloJet::Specific tmp_specific;
-              const reco::Candidate::Point orivtx(0,0,0);
-              tmp_specific.mEnergyFractionEm = ijet.emEnergyFraction();
-              tmp_specific.mEnergyFractionHadronic = ijet.energyFractionHadronic();
-              reco::CaloJet newCaloJet(ijet.p4(), orivtx, tmp_specific);
-              float jetArea = ijet.jetArea();
-              newCaloJet.setJetArea(jetArea);          
-              caloJets->push_back(newCaloJet);
-           }
-         
-
-        } 
-        iEvent.put(std::move(caloJets), "");
-    }
-
+    iEvent.put(std::move(caloJets), "");
+  }
 
 protected:
-    const edm::EDGetTokenT<edm::View<reco::CaloJet> > srcToken_;
-    const std::string                                cut_;
-    const StringCutObjectSelector<reco::Jet>               selector_;
+  const edm::EDGetTokenT<edm::View<reco::CaloJet> > srcToken_;
+  const std::string cut_;
+  const StringCutObjectSelector<reco::Jet> selector_;
 };
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(CaloJetSlimmer);

--- a/PhysicsTools/PatAlgos/plugins/CandidateSummaryTable.cc
+++ b/PhysicsTools/PatAlgos/plugins/CandidateSummaryTable.cc
@@ -11,7 +11,6 @@
   \version  $Id: CandidateSummaryTable.cc,v 1.4 2010/02/20 21:00:15 wmtan Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -29,137 +28,140 @@ namespace pathelpers {
     const edm::InputTag src;
     mutable std::atomic<size_t> present, empty, min, max, total;
     Record(const edm::InputTag& tag) : src(tag), present(0), empty(0), min(0), max(0), total(0) {}
-    Record(const Record& other) : src(other.src), 
-                                  present(other.present.load()), 
-                                  empty(other.empty.load()), 
-                                  min(other.min.load()), 
-                                  max(other.max.load()), 
-                                  total(other.total.load()) {}
-    void update(const edm::View<reco::Candidate> &items) const {
+    Record(const Record& other)
+        : src(other.src),
+          present(other.present.load()),
+          empty(other.empty.load()),
+          min(other.min.load()),
+          max(other.max.load()),
+          total(other.total.load()) {}
+    void update(const edm::View<reco::Candidate>& items) const {
       present++;
       const size_t size = items.size();
       if (size == 0) {
         empty++;
-      } else  {
+      } else {
         auto previousMin = min.load();
-        while( previousMin > size and not min.compare_exchange_weak(previousMin, size) ) {}
+        while (previousMin > size and not min.compare_exchange_weak(previousMin, size)) {
+        }
         auto previousMax = max.load();
-        while( previousMax < size and not max.compare_exchange_weak(previousMax, size) ) {}        
+        while (previousMax < size and not max.compare_exchange_weak(previousMax, size)) {
+        }
       }
       total += size;
     }
   };
 
-  struct RecordCache { 
-    RecordCache(const edm::ParameterSet& iConfig) : 
-      perEvent_(iConfig.getUntrackedParameter<bool>("perEvent", false)),
-      perJob_(iConfig.getUntrackedParameter<bool>("perJob", true)),
-      self_(iConfig.getParameter<std::string>("@module_label")),
-      logName_(iConfig.getUntrackedParameter<std::string>("logName")),
-      dumpItems_(iConfig.getUntrackedParameter<bool>("dumpItems", false)),
-      totalEvents_(0) {
-      const std::vector<edm::InputTag>& tags  = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
-      for( const auto& tag : tags ) {
-        collections_.emplace_back( tag );
+  struct RecordCache {
+    RecordCache(const edm::ParameterSet& iConfig)
+        : perEvent_(iConfig.getUntrackedParameter<bool>("perEvent", false)),
+          perJob_(iConfig.getUntrackedParameter<bool>("perJob", true)),
+          self_(iConfig.getParameter<std::string>("@module_label")),
+          logName_(iConfig.getUntrackedParameter<std::string>("logName")),
+          dumpItems_(iConfig.getUntrackedParameter<bool>("dumpItems", false)),
+          totalEvents_(0) {
+      const std::vector<edm::InputTag>& tags = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
+      for (const auto& tag : tags) {
+        collections_.emplace_back(tag);
       }
     }
     const bool perEvent_, perJob_;
     const std::string self_, logName_;
     const bool dumpItems_;
     mutable std::atomic<size_t> totalEvents_;
-    std::vector<Record> collections_; // size of vector is never altered later! (atomics are in the class below)
-  };  
+    std::vector<Record> collections_;  // size of vector is never altered later! (atomics are in the class below)
+  };
 
-}
+}  // namespace pathelpers
 
 namespace pat {
   class CandidateSummaryTable : public edm::stream::EDAnalyzer<edm::GlobalCache<pathelpers::RecordCache> > {
   public:
-    explicit CandidateSummaryTable(const edm::ParameterSet & iConfig, const pathelpers::RecordCache*);
+    explicit CandidateSummaryTable(const edm::ParameterSet& iConfig, const pathelpers::RecordCache*);
     ~CandidateSummaryTable() override;
-    
+
     static std::unique_ptr<pathelpers::RecordCache> initializeGlobalCache(edm::ParameterSet const& conf) {
       return std::make_unique<pathelpers::RecordCache>(conf);
     }
 
-    void analyze(const edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
     static void globalEndJob(const pathelpers::RecordCache*);
-    
-  private:    
-    std::vector<std::pair<edm::InputTag,edm::EDGetTokenT<edm::View<reco::Candidate> > > > srcTokens;
+
+  private:
+    std::vector<std::pair<edm::InputTag, edm::EDGetTokenT<edm::View<reco::Candidate> > > > srcTokens;
   };
-} // namespace
+}  // namespace pat
 
-pat::CandidateSummaryTable::CandidateSummaryTable(const edm::ParameterSet & iConfig, const pathelpers::RecordCache*) {
-    const std::vector<edm::InputTag>& inputs = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
-    for (std::vector<edm::InputTag>::const_iterator it = inputs.begin(); it != inputs.end(); ++it) {      
-      srcTokens.emplace_back(*it, consumes<edm::View<reco::Candidate> >(*it));
-    }
+pat::CandidateSummaryTable::CandidateSummaryTable(const edm::ParameterSet& iConfig, const pathelpers::RecordCache*) {
+  const std::vector<edm::InputTag>& inputs = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
+  for (std::vector<edm::InputTag>::const_iterator it = inputs.begin(); it != inputs.end(); ++it) {
+    srcTokens.emplace_back(*it, consumes<edm::View<reco::Candidate> >(*it));
+  }
 }
 
-pat::CandidateSummaryTable::~CandidateSummaryTable() {
-}
+pat::CandidateSummaryTable::~CandidateSummaryTable() {}
 
-void
-pat::CandidateSummaryTable::analyze(const edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void pat::CandidateSummaryTable::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-  using std::setw; using std::left; using std::right; using std::setprecision;
+  using std::left;
+  using std::right;
+  using std::setprecision;
+  using std::setw;
 
   Handle<View<reco::Candidate> > candidates;
   if (globalCache()->perEvent_) {
-    LogInfo(globalCache()->logName_) << "Per Event Table " << globalCache()->logName_ 
-                                     << " (" << globalCache()->self_ << ", run:event " 
-                                     << iEvent.id().run() << ":" << iEvent.id().event() << ")";
+    LogInfo(globalCache()->logName_) << "Per Event Table " << globalCache()->logName_ << " (" << globalCache()->self_
+                                     << ", run:event " << iEvent.id().run() << ":" << iEvent.id().event() << ")";
   }
   ++(globalCache()->totalEvents_);
   auto& collections = globalCache()->collections_;
   auto tags = srcTokens.cbegin();
   for (auto it = collections.begin(), ed = collections.end(); it != ed; ++it, ++tags) {
     iEvent.getByToken(tags->second, candidates);
-    if (!candidates.failedToGet()) it->update(*candidates);
+    if (!candidates.failedToGet())
+      it->update(*candidates);
     if (globalCache()->perEvent_) {
-        LogVerbatim(globalCache()->logName_) << "    " << setw(30) << left  << it->src.encode() << right;
-        if (globalCache()->dumpItems_) {
-            size_t i = 0;
-            std::ostringstream oss;
-            for (View<reco::Candidate>::const_iterator cand = candidates->begin(), endc = candidates->end(); cand != endc; ++cand, ++i) {
-                oss << "      [" << setw(3) << i << "]" <<
-                        "  pt "  << setw(7) << setprecision(5) << cand->pt()  <<
-                        "  eta " << setw(7) << setprecision(5) << cand->eta() <<
-                        "  phi " << setw(7) << setprecision(5) << cand->phi() <<
-                        "  et "  << setw(7) << setprecision(5) << cand->et()  <<
-                        "  phi " << setw(7) << setprecision(5) << cand->phi() <<
-                        "  charge " << setw(2) << cand->charge() <<
-                        "  id "     << setw(7) << cand->pdgId() <<
-                        "  st "     << setw(7) << cand->status() << "\n";
-            }
-            LogVerbatim(globalCache()->logName_) << oss.str();
+      LogVerbatim(globalCache()->logName_) << "    " << setw(30) << left << it->src.encode() << right;
+      if (globalCache()->dumpItems_) {
+        size_t i = 0;
+        std::ostringstream oss;
+        for (View<reco::Candidate>::const_iterator cand = candidates->begin(), endc = candidates->end(); cand != endc;
+             ++cand, ++i) {
+          oss << "      [" << setw(3) << i << "]"
+              << "  pt " << setw(7) << setprecision(5) << cand->pt() << "  eta " << setw(7) << setprecision(5)
+              << cand->eta() << "  phi " << setw(7) << setprecision(5) << cand->phi() << "  et " << setw(7)
+              << setprecision(5) << cand->et() << "  phi " << setw(7) << setprecision(5) << cand->phi() << "  charge "
+              << setw(2) << cand->charge() << "  id " << setw(7) << cand->pdgId() << "  st " << setw(7)
+              << cand->status() << "\n";
         }
+        LogVerbatim(globalCache()->logName_) << oss.str();
+      }
     }
   }
-  if (globalCache()->perEvent_) LogInfo(globalCache()->logName_) << "" ;  // add an empty line
+  if (globalCache()->perEvent_)
+    LogInfo(globalCache()->logName_) << "";  // add an empty line
 }
 
-
-void
-pat::CandidateSummaryTable::globalEndJob(const pathelpers::RecordCache* rcd) {
-    using std::setw; using std::left; using std::right; using std::setprecision;
-    if (rcd->perJob_) {
-        std::ostringstream oss;
-        oss << "Summary Table " << rcd->logName_ << " (" << rcd->self_ << ", events total " << rcd->totalEvents_ << ")\n";
-        for (auto it = rcd->collections_.cbegin(), ed = rcd->collections_.cend(); it != ed; ++it) {
-            oss << "    " << setw(30) << left  << it->src.encode() << right <<
-                "  present " << setw(7) << it->present << " (" << setw(4) << setprecision(3) << (it->present*100.0/rcd->totalEvents_) << "%)" <<
-                "  empty "   << setw(7) << it->empty   << " (" << setw(4) << setprecision(3) << (it->empty*100.0/rcd->totalEvents_)   << "%)" <<
-                "  min "     << setw(7) << it->min     <<
-                "  max "     << setw(7) << it->max     <<
-                "  total "   << setw(7) << it->total   <<
-                "  avg "     << setw(5) << setprecision(3) << (it->total/double(rcd->totalEvents_)) << "\n";
-        }
-        oss << "\n";
-        edm::LogVerbatim(rcd->logName_) << oss.str();
+void pat::CandidateSummaryTable::globalEndJob(const pathelpers::RecordCache* rcd) {
+  using std::left;
+  using std::right;
+  using std::setprecision;
+  using std::setw;
+  if (rcd->perJob_) {
+    std::ostringstream oss;
+    oss << "Summary Table " << rcd->logName_ << " (" << rcd->self_ << ", events total " << rcd->totalEvents_ << ")\n";
+    for (auto it = rcd->collections_.cbegin(), ed = rcd->collections_.cend(); it != ed; ++it) {
+      oss << "    " << setw(30) << left << it->src.encode() << right << "  present " << setw(7) << it->present << " ("
+          << setw(4) << setprecision(3) << (it->present * 100.0 / rcd->totalEvents_) << "%)"
+          << "  empty " << setw(7) << it->empty << " (" << setw(4) << setprecision(3)
+          << (it->empty * 100.0 / rcd->totalEvents_) << "%)"
+          << "  min " << setw(7) << it->min << "  max " << setw(7) << it->max << "  total " << setw(7) << it->total
+          << "  avg " << setw(5) << setprecision(3) << (it->total / double(rcd->totalEvents_)) << "\n";
     }
+    oss << "\n";
+    edm::LogVerbatim(rcd->logName_) << oss.str();
+  }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
@@ -5,7 +5,6 @@
   \author   Andrej Saibel, andrej.saibel@cern.ch
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -21,67 +20,64 @@
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 
-
 namespace pat {
 
   class GenJetFlavourInfoPreserver : public edm::stream::EDProducer<> {
   public:
-    explicit GenJetFlavourInfoPreserver(const edm::ParameterSet & iConfig);
-    ~GenJetFlavourInfoPreserver() override { }
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-    
+    explicit GenJetFlavourInfoPreserver(const edm::ParameterSet& iConfig);
+    ~GenJetFlavourInfoPreserver() override {}
+
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
   private:
     const edm::EDGetTokenT<edm::View<reco::GenJet> > genJetsToken_;
     const edm::EDGetTokenT<edm::View<reco::Jet> > slimmedGenJetsToken_;
-    
+
     const edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> genJetFlavourInfosToken_;
     const edm::EDGetTokenT<edm::Association<std::vector<reco::GenJet> > > slimmedGenJetAssociationToken_;
   };
 
-} // namespace
+}  // namespace pat
 
-pat::GenJetFlavourInfoPreserver::GenJetFlavourInfoPreserver(const edm::ParameterSet & iConfig) :
-    genJetsToken_(consumes<edm::View<reco::GenJet> >(iConfig.getParameter<edm::InputTag>("genJets"))),
-    slimmedGenJetsToken_(consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("slimmedGenJets"))),
-    genJetFlavourInfosToken_(consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getParameter<edm::InputTag>("genJetFlavourInfos"))),
-    slimmedGenJetAssociationToken_(consumes<edm::Association<std::vector<reco::GenJet> > >(iConfig.getParameter<edm::InputTag>("slimmedGenJetAssociation")))
-{
-    produces<reco::JetFlavourInfoMatchingCollection>();
+pat::GenJetFlavourInfoPreserver::GenJetFlavourInfoPreserver(const edm::ParameterSet& iConfig)
+    : genJetsToken_(consumes<edm::View<reco::GenJet> >(iConfig.getParameter<edm::InputTag>("genJets"))),
+      slimmedGenJetsToken_(consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("slimmedGenJets"))),
+      genJetFlavourInfosToken_(
+          consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getParameter<edm::InputTag>("genJetFlavourInfos"))),
+      slimmedGenJetAssociationToken_(consumes<edm::Association<std::vector<reco::GenJet> > >(
+          iConfig.getParameter<edm::InputTag>("slimmedGenJetAssociation"))) {
+  produces<reco::JetFlavourInfoMatchingCollection>();
 }
 
-void 
-pat::GenJetFlavourInfoPreserver::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
+void pat::GenJetFlavourInfoPreserver::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    Handle<View<reco::GenJet> >      genJets;
-    iEvent.getByToken(genJetsToken_, genJets);
+  Handle<View<reco::GenJet> > genJets;
+  iEvent.getByToken(genJetsToken_, genJets);
 
-    Handle<View<reco::Jet> >      slimmedGenJets;
-    iEvent.getByToken(slimmedGenJetsToken_, slimmedGenJets);
+  Handle<View<reco::Jet> > slimmedGenJets;
+  iEvent.getByToken(slimmedGenJetsToken_, slimmedGenJets);
 
-    Handle<reco::JetFlavourInfoMatchingCollection> genJetFlavourInfos;
-    iEvent.getByToken(genJetFlavourInfosToken_, genJetFlavourInfos);
+  Handle<reco::JetFlavourInfoMatchingCollection> genJetFlavourInfos;
+  iEvent.getByToken(genJetFlavourInfosToken_, genJetFlavourInfos);
 
-    Handle<edm::Association<std::vector<reco::GenJet> > > slimmedGenJetAssociation;
-    iEvent.getByToken(slimmedGenJetAssociationToken_, slimmedGenJetAssociation);
+  Handle<edm::Association<std::vector<reco::GenJet> > > slimmedGenJetAssociation;
+  iEvent.getByToken(slimmedGenJetAssociationToken_, slimmedGenJetAssociation);
 
-    auto jetFlavourInfos = std::make_unique<reco::JetFlavourInfoMatchingCollection>(reco::JetRefBaseProd(slimmedGenJets));
-    assert(genJets->size() == genJetFlavourInfos->size());
+  auto jetFlavourInfos = std::make_unique<reco::JetFlavourInfoMatchingCollection>(reco::JetRefBaseProd(slimmedGenJets));
+  assert(genJets->size() == genJetFlavourInfos->size());
 
-    edm::Ref<std::vector<reco::GenJet> > slimmedGenJetRef;
+  edm::Ref<std::vector<reco::GenJet> > slimmedGenJetRef;
 
+  for (unsigned int i = 0; i < genJets->size(); ++i) {
+    slimmedGenJetRef = (*slimmedGenJetAssociation)[genJets->refAt(i)];
+    if (!slimmedGenJetRef)
+      continue;
+    (*jetFlavourInfos)[reco::JetBaseRef(slimmedGenJetRef)] = (*genJetFlavourInfos)[i].second;
+  }
 
-    for (unsigned int i=0; i<genJets->size();++i){
-
-        slimmedGenJetRef = (*slimmedGenJetAssociation)[genJets->refAt(i)]; 
-        if(!slimmedGenJetRef) continue;
-        (*jetFlavourInfos)[reco::JetBaseRef(slimmedGenJetRef)] = (*genJetFlavourInfos)[i].second;
-
-    }
-
-    iEvent.put(std::move(jetFlavourInfos));
+  iEvent.put(std::move(jetFlavourInfos));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/GenMETExtractor.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenMETExtractor.cc
@@ -7,8 +7,7 @@
 
 using namespace pat;
 
-GenMETExtractor::GenMETExtractor(const edm::ParameterSet& iConfig) {
-
+GenMETExtractor::GenMETExtractor(const edm::ParameterSet &iConfig) {
   edm::InputTag metIT = iConfig.getParameter<edm::InputTag>("metSource");
   metSrcToken_ = consumes<pat::METCollection>(metIT);
 
@@ -16,28 +15,22 @@ GenMETExtractor::GenMETExtractor(const edm::ParameterSet& iConfig) {
   produces<std::vector<reco::GenMET> >();
 }
 
+GenMETExtractor::~GenMETExtractor() {}
 
-GenMETExtractor::~GenMETExtractor() {
-
-}
-
-
-void GenMETExtractor::produce(edm::StreamID streamID, edm::Event & iEvent,
-			      const edm::EventSetup & iSetup) const {
-
-  edm::Handle<std::vector<pat::MET> >  src;
+void GenMETExtractor::produce(edm::StreamID streamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  edm::Handle<std::vector<pat::MET> > src;
   iEvent.getByToken(metSrcToken_, src);
-  if(src->empty()) edm::LogError("GenMETExtractor::produce") << "input genMET collection is empty" ;
+  if (src->empty())
+    edm::LogError("GenMETExtractor::produce") << "input genMET collection is empty";
 
-  const reco::GenMET *genMet =	src->front().genMET();
-  
+  const reco::GenMET *genMet = src->front().genMET();
+
   std::vector<reco::GenMET> *genMetCol = new std::vector<reco::GenMET>();
-  genMetCol->push_back( (*genMet) );
+  genMetCol->push_back((*genMet));
 
   std::unique_ptr<std::vector<reco::GenMET> > genMETs(genMetCol);
   iEvent.put(std::move(genMETs));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/PhysicsTools/PatAlgos/plugins/GenMETExtractor.h
+++ b/PhysicsTools/PatAlgos/plugins/GenMETExtractor.h
@@ -13,7 +13,6 @@
   \version  $Id: GenMETExtractor.h,v 1.0 2015/07/22 mmarionn Exp $
 */
 
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -26,21 +25,16 @@
 namespace pat {
 
   class GenMETExtractor : public edm::global::EDProducer<> {
-
-    public:
-
+  public:
     explicit GenMETExtractor(const edm::ParameterSet& iConfig);
     ~GenMETExtractor() override;
 
-    void produce(edm::StreamID streamID, edm::Event & iEvent,
-			 const edm::EventSetup & iSetup) const override;
+    void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   private:
-
     edm::EDGetTokenT<std::vector<pat::MET> > metSrcToken_;
-    
   };
 
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/IsolatedTrackCleaner.cc
+++ b/PhysicsTools/PatAlgos/plugins/IsolatedTrackCleaner.cc
@@ -9,59 +9,58 @@
 
 #include <vector>
 
-
 class IsolatedTrackCleaner : public edm::stream::EDProducer<> {
-    public:
-        IsolatedTrackCleaner( edm::ParameterSet const & params ) :
-            tracks_(consumes<std::vector<pat::IsolatedTrack>>(params.getParameter<edm::InputTag>("tracks"))),
-            cut_(params.getParameter<std::string>("cut"))
-        {
-            for (const edm::InputTag & tag : params.getParameter<std::vector<edm::InputTag>>("finalLeptons")) {
-                leptons_.push_back(consumes<reco::CandidateView>(tag));
-            }
-            produces<std::vector<pat::IsolatedTrack>>();
+public:
+  IsolatedTrackCleaner(edm::ParameterSet const& params)
+      : tracks_(consumes<std::vector<pat::IsolatedTrack>>(params.getParameter<edm::InputTag>("tracks"))),
+        cut_(params.getParameter<std::string>("cut")) {
+    for (const edm::InputTag& tag : params.getParameter<std::vector<edm::InputTag>>("finalLeptons")) {
+      leptons_.push_back(consumes<reco::CandidateView>(tag));
+    }
+    produces<std::vector<pat::IsolatedTrack>>();
+  }
+
+  ~IsolatedTrackCleaner() override {}
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    auto out = std::make_unique<std::vector<pat::IsolatedTrack>>();
+
+    std::vector<reco::CandidatePtr> leptonPfCands;
+    edm::Handle<reco::CandidateView> leptons;
+    for (const auto& token : leptons_) {
+      iEvent.getByToken(token, leptons);
+      for (const auto& lep : *leptons) {
+        for (unsigned int i = 0, n = lep.numberOfSourceCandidatePtrs(); i < n; ++i) {
+          auto ptr = lep.sourceCandidatePtr(i);
+          if (ptr.isNonnull())
+            leptonPfCands.push_back(ptr);
         }
+      }
+    }
+    std::sort(leptonPfCands.begin(), leptonPfCands.end());
 
-        ~IsolatedTrackCleaner() override {}
-
-        void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
-            auto out  = std::make_unique<std::vector<pat::IsolatedTrack>>();
-
-            std::vector<reco::CandidatePtr> leptonPfCands;
-            edm::Handle<reco::CandidateView> leptons;
-            for (const auto & token : leptons_) {
-                iEvent.getByToken(token, leptons);
-                for (const auto & lep : *leptons) {
-                    for (unsigned int i = 0, n = lep.numberOfSourceCandidatePtrs(); i < n; ++i) {
-                        auto ptr = lep.sourceCandidatePtr(i);
-                        if (ptr.isNonnull()) leptonPfCands.push_back(ptr);
-                    }
-                }
-            }
-            std::sort(leptonPfCands.begin(), leptonPfCands.end());
-
-            edm::Handle<std::vector<pat::IsolatedTrack>> tracks;
-            iEvent.getByToken(tracks_, tracks);
-            for (const auto & track : *tracks) {
-                if (!cut_(track)) continue; 
-                if (track.packedCandRef().isNonnull()) {
-                    reco::CandidatePtr pfCand(edm::refToPtr(track.packedCandRef()));
-                    if (std::binary_search(leptonPfCands.begin(), leptonPfCands.end(), pfCand)) {
-                        continue;
-                    }
-                }
-                out->push_back(track);
-            }
-
-            iEvent.put(std::move(out));
+    edm::Handle<std::vector<pat::IsolatedTrack>> tracks;
+    iEvent.getByToken(tracks_, tracks);
+    for (const auto& track : *tracks) {
+      if (!cut_(track))
+        continue;
+      if (track.packedCandRef().isNonnull()) {
+        reco::CandidatePtr pfCand(edm::refToPtr(track.packedCandRef()));
+        if (std::binary_search(leptonPfCands.begin(), leptonPfCands.end(), pfCand)) {
+          continue;
         }
+      }
+      out->push_back(track);
+    }
 
-    protected:
-        edm::EDGetTokenT<std::vector<pat::IsolatedTrack>> tracks_;
-        StringCutObjectSelector<pat::IsolatedTrack> cut_;
-        std::vector<edm::EDGetTokenT<reco::CandidateView>> leptons_;
+    iEvent.put(std::move(out));
+  }
+
+protected:
+  edm::EDGetTokenT<std::vector<pat::IsolatedTrack>> tracks_;
+  StringCutObjectSelector<pat::IsolatedTrack> cut_;
+  std::vector<edm::EDGetTokenT<reco::CandidateView>> leptons_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(IsolatedTrackCleaner);
-

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -16,19 +16,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-
 using namespace pat;
 
-JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
-  emf_(cfg.getParameter<bool>( "emf" )),
-  srcToken_(consumes<edm::View<reco::Jet> >(cfg.getParameter<edm::InputTag>( "src" ))),
-  type_ (cfg.getParameter<std::string>("flavorType")),
-  label_(cfg.getParameter<std::string>( "@module_label" )),
-  payload_( cfg.getParameter<std::string>("payload") ),
-  useNPV_(cfg.getParameter<bool>("useNPV")),
-  useRho_(cfg.getParameter<bool>("useRho")),
-  cacheId_(0)
-{
+JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg)
+    : emf_(cfg.getParameter<bool>("emf")),
+      srcToken_(consumes<edm::View<reco::Jet> >(cfg.getParameter<edm::InputTag>("src"))),
+      type_(cfg.getParameter<std::string>("flavorType")),
+      label_(cfg.getParameter<std::string>("@module_label")),
+      payload_(cfg.getParameter<std::string>("payload")),
+      useNPV_(cfg.getParameter<bool>("useNPV")),
+      useRho_(cfg.getParameter<bool>("useRho")),
+      cacheId_(0) {
   std::vector<std::string> levels = cfg.getParameter<std::vector<std::string> >("levels");
   // fill the std::map for levels_, which might be flavor dependent or not;
   // flavor dependency is determined from the fact whether the std::string
@@ -38,160 +36,161 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
   // and 'L7Parton' will be expanded accordingly; if not levels_ is filled
   // with only one vector of strings according to NONE. This vector will be
   // equivalent to the original vector of strings.
-  if(std::find(levels.begin(), levels.end(), "L5Flavor")!=levels.end() || std::find(levels.begin(), levels.end(), "L7Parton")!=levels.end()){
-    levels_[JetCorrFactors::GLUON ] = expand(levels, JetCorrFactors::GLUON );
-    levels_[JetCorrFactors::UDS   ] = expand(levels, JetCorrFactors::UDS   );
-    levels_[JetCorrFactors::CHARM ] = expand(levels, JetCorrFactors::CHARM );
+  if (std::find(levels.begin(), levels.end(), "L5Flavor") != levels.end() ||
+      std::find(levels.begin(), levels.end(), "L7Parton") != levels.end()) {
+    levels_[JetCorrFactors::GLUON] = expand(levels, JetCorrFactors::GLUON);
+    levels_[JetCorrFactors::UDS] = expand(levels, JetCorrFactors::UDS);
+    levels_[JetCorrFactors::CHARM] = expand(levels, JetCorrFactors::CHARM);
     levels_[JetCorrFactors::BOTTOM] = expand(levels, JetCorrFactors::BOTTOM);
-  }
-  else{
-    levels_[JetCorrFactors::NONE  ] = levels;
+  } else {
+    levels_[JetCorrFactors::NONE] = levels;
   }
   // if the std::string L1JPTOffset can be found in levels an additional
   // parameter extraJPTOffset is needed, which should pass on the the usual
   // L1Offset correction, which is an additional input to the L1JPTOffset
   // corrector
-  if(std::find(levels.begin(), levels.end(), "L1JPTOffset")!=levels.end()){
-    if(cfg.existsAs<std::string>("extraJPTOffset")){
+  if (std::find(levels.begin(), levels.end(), "L1JPTOffset") != levels.end()) {
+    if (cfg.existsAs<std::string>("extraJPTOffset")) {
       extraJPTOffset_.push_back(cfg.getParameter<std::string>("extraJPTOffset"));
-    }
-    else{
+    } else {
       throw cms::Exception("No parameter extraJPTOffset specified")
-	<< "The configured correction levels contain a L1JPTOffset correction, which re- \n"
-	<< "quires the additional parameter extraJPTOffset or type std::string. This     \n"
-	<< "string should correspond to the L1Offset corrections that should be applied  \n"
-	<< "together with the JPTL1Offset corrections. These corrections can be of type  \n"
-	<< "L1Offset or L1FastJet.                                                       \n";
+          << "The configured correction levels contain a L1JPTOffset correction, which re- \n"
+          << "quires the additional parameter extraJPTOffset or type std::string. This     \n"
+          << "string should correspond to the L1Offset corrections that should be applied  \n"
+          << "together with the JPTL1Offset corrections. These corrections can be of type  \n"
+          << "L1Offset or L1FastJet.                                                       \n";
     }
   }
   // if the std::string L1Offset can be found in levels an additional para-
   // meter primaryVertices is needed, which should pass on the offline pri-
   // mary vertex collection. The size of this collection is needed for the
   // L1Offset correction.
-  if(useNPV_){
-    if(cfg.existsAs<edm::InputTag>("primaryVertices")){
-      primaryVertices_=cfg.getParameter<edm::InputTag>("primaryVertices");
-      primaryVerticesToken_=mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
-    }
-    else{
+  if (useNPV_) {
+    if (cfg.existsAs<edm::InputTag>("primaryVertices")) {
+      primaryVertices_ = cfg.getParameter<edm::InputTag>("primaryVertices");
+      primaryVerticesToken_ = mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
+    } else {
       throw cms::Exception("No primaryVertices specified")
-	<< "The configured correction levels contain an L1Offset or L1FastJet correction, \n"
-	<< "which requires the number of offlinePrimaryVertices. Please specify this col- \n"
-	<< "lection as additional optional parameter primaryVertices of type edm::InputTag\n"
-	<< "in the jetCorrFactors module.                                                 \n";
+          << "The configured correction levels contain an L1Offset or L1FastJet correction, \n"
+          << "which requires the number of offlinePrimaryVertices. Please specify this col- \n"
+          << "lection as additional optional parameter primaryVertices of type edm::InputTag\n"
+          << "in the jetCorrFactors module.                                                 \n";
     }
   }
   // if the std::string L1FastJet can be found in levels an additional
   // parameter rho is needed, which should pass on the energy density
   // parameter for the corresponding jet collection.
-  if(useRho_){
-    if((!extraJPTOffset_.empty() && extraJPTOffset_.front()==std::string("L1FastJet")) || std::find(levels.begin(), levels.end(), "L1FastJet")!=levels.end()){
-      if(cfg.existsAs<edm::InputTag>("rho")){
-	rho_=cfg.getParameter<edm::InputTag>("rho");
-	rhoToken_=mayConsume<double>(rho_);
+  if (useRho_) {
+    if ((!extraJPTOffset_.empty() && extraJPTOffset_.front() == std::string("L1FastJet")) ||
+        std::find(levels.begin(), levels.end(), "L1FastJet") != levels.end()) {
+      if (cfg.existsAs<edm::InputTag>("rho")) {
+        rho_ = cfg.getParameter<edm::InputTag>("rho");
+        rhoToken_ = mayConsume<double>(rho_);
+      } else {
+        throw cms::Exception("No parameter rho specified")
+            << "The configured correction levels contain a L1FastJet correction, which re- \n"
+            << "quires the energy density parameter rho. Please specify this collection as \n"
+            << "additional optional parameter rho of type edm::InputTag in the jetCorrFac- \n"
+            << "tors module.                                                               \n";
       }
-      else{
-	throw cms::Exception("No parameter rho specified")
-	  << "The configured correction levels contain a L1FastJet correction, which re- \n"
-	  << "quires the energy density parameter rho. Please specify this collection as \n"
-	  << "additional optional parameter rho of type edm::InputTag in the jetCorrFac- \n"
-	  << "tors module.                                                               \n";
-      }
-    }
-    else{
-      edm::LogInfo message( "Parameter rho not used" );
+    } else {
+      edm::LogInfo message("Parameter rho not used");
       message << "Module is configured to use the parameter rho, but rho is only used     \n"
-	      << "for L1FastJet corrections. The configuration of levels does not contain \n"
-	      << "L1FastJet corrections though, so rho will not be used by this module.   \n";
+              << "for L1FastJet corrections. The configuration of levels does not contain \n"
+              << "L1FastJet corrections though, so rho will not be used by this module.   \n";
     }
   }
   produces<JetCorrFactorsMap>();
 }
 
-std::vector<std::string>
-JetCorrFactorsProducer::expand(const std::vector<std::string>& levels, const JetCorrFactors::Flavor& flavor)
-{
+std::vector<std::string> JetCorrFactorsProducer::expand(const std::vector<std::string>& levels,
+                                                        const JetCorrFactors::Flavor& flavor) {
   std::vector<std::string> expand;
-  for(std::vector<std::string>::const_iterator level=levels.begin(); level!=levels.end(); ++level){
-    if((*level)=="L5Flavor" || (*level)=="L7Parton"){
-      if(flavor==JetCorrFactors::GLUON ){
-	if(*level=="L7Parton" && type_=="T"){
-	  edm::LogWarning message( "L7Parton::GLUON not available" );
-	  message << "Jet energy corrections requested for level: L7Parton and type: 'T'. \n"
-		  << "For this combination there is no GLUON correction available. The    \n"
-		  << "correction for this flavor type will be taken from 'J'.";
-	}
-	expand.push_back(std::string(*level).append("_").append("g").append("J"));
+  for (std::vector<std::string>::const_iterator level = levels.begin(); level != levels.end(); ++level) {
+    if ((*level) == "L5Flavor" || (*level) == "L7Parton") {
+      if (flavor == JetCorrFactors::GLUON) {
+        if (*level == "L7Parton" && type_ == "T") {
+          edm::LogWarning message("L7Parton::GLUON not available");
+          message << "Jet energy corrections requested for level: L7Parton and type: 'T'. \n"
+                  << "For this combination there is no GLUON correction available. The    \n"
+                  << "correction for this flavor type will be taken from 'J'.";
+        }
+        expand.push_back(std::string(*level).append("_").append("g").append("J"));
       }
-      if(flavor==JetCorrFactors::UDS   ) expand.push_back(std::string(*level).append("_").append("q").append(type_));
-      if(flavor==JetCorrFactors::CHARM ) expand.push_back(std::string(*level).append("_").append("c").append(type_));
-      if(flavor==JetCorrFactors::BOTTOM) expand.push_back(std::string(*level).append("_").append("b").append(type_));
-    }
-    else{
+      if (flavor == JetCorrFactors::UDS)
+        expand.push_back(std::string(*level).append("_").append("q").append(type_));
+      if (flavor == JetCorrFactors::CHARM)
+        expand.push_back(std::string(*level).append("_").append("c").append(type_));
+      if (flavor == JetCorrFactors::BOTTOM)
+        expand.push_back(std::string(*level).append("_").append("b").append(type_));
+    } else {
       expand.push_back(*level);
     }
   }
   return expand;
 }
 
-std::vector<JetCorrectorParameters>
-JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameters, const std::vector<std::string>& levels) const
-{
+std::vector<JetCorrectorParameters> JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameters,
+                                                                   const std::vector<std::string>& levels) const {
   std::vector<JetCorrectorParameters> params;
-  for(std::vector<std::string>::const_iterator level=levels.begin(); level!=levels.end(); ++level){
-    const JetCorrectorParameters& ip = parameters[*level]; //ip.printScreen();
+  for (std::vector<std::string>::const_iterator level = levels.begin(); level != levels.end(); ++level) {
+    const JetCorrectorParameters& ip = parameters[*level];  //ip.printScreen();
     params.push_back(ip);
   }
   return params;
 }
 
-float
-JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet, const JetCorrFactors::Flavor& flavor, int level)
-{
+float JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet,
+                                       const JetCorrFactors::Flavor& flavor,
+                                       int level) {
   std::unique_ptr<FactorizedJetCorrector>& corrector = correctors_.find(flavor)->second;
   // add parameters for JPT corrections
-  const reco::JPTJet* jpt = dynamic_cast<reco::JPTJet const *>( &*jet );
-  if( jpt ){
-    TLorentzVector p4; p4.SetPtEtaPhiE(jpt->getCaloJetRef()->pt(), jpt->getCaloJetRef()->eta(), jpt->getCaloJetRef()->phi(), jpt->getCaloJetRef()->energy());
-    if( extraJPTOffsetCorrector_ ){
+  const reco::JPTJet* jpt = dynamic_cast<reco::JPTJet const*>(&*jet);
+  if (jpt) {
+    TLorentzVector p4;
+    p4.SetPtEtaPhiE(jpt->getCaloJetRef()->pt(),
+                    jpt->getCaloJetRef()->eta(),
+                    jpt->getCaloJetRef()->phi(),
+                    jpt->getCaloJetRef()->energy());
+    if (extraJPTOffsetCorrector_) {
       extraJPTOffsetCorrector_->setJPTrawP4(p4);
       corrector->setJPTrawOff(extraJPTOffsetCorrector_->getSubCorrections()[0]);
     }
     corrector->setJPTrawP4(p4);
   }
   //For PAT jets undo previous jet energy corrections
-  const Jet* patjet = dynamic_cast<Jet const *>( &*jet );
-  if( patjet ){
-    corrector->setJetEta(patjet->correctedP4(0).eta()); corrector->setJetPt(patjet->correctedP4(0).pt()); corrector->setJetE(patjet->correctedP4(0).energy());
+  const Jet* patjet = dynamic_cast<Jet const*>(&*jet);
+  if (patjet) {
+    corrector->setJetEta(patjet->correctedP4(0).eta());
+    corrector->setJetPt(patjet->correctedP4(0).pt());
+    corrector->setJetE(patjet->correctedP4(0).energy());
   } else {
-    corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy());
+    corrector->setJetEta(jet->eta());
+    corrector->setJetPt(jet->pt());
+    corrector->setJetE(jet->energy());
   }
-  if( emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)){
+  if (emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)) {
     corrector->setJetEMF(dynamic_cast<const reco::CaloJet*>(&*jet)->emEnergyFraction());
   }
   return corrector->getSubCorrections()[level];
 }
 
-std::string
-JetCorrFactorsProducer::payload()
-{
-  return payload_;
-}
+std::string JetCorrFactorsProducer::payload() { return payload_; }
 
-void
-JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-{
+void JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   // get jet collection from the event
   edm::Handle<edm::View<reco::Jet> > jets;
   event.getByToken(srcToken_, jets);
 
   // get primary vertices for L1Offset correction level if needed
   edm::Handle<std::vector<reco::Vertex> > primaryVertices;
-  if(!primaryVertices_.label().empty()) event.getByToken(primaryVerticesToken_, primaryVertices);
+  if (!primaryVertices_.label().empty())
+    event.getByToken(primaryVerticesToken_, primaryVertices);
 
   // get parameter rho for L1FastJet correction level if needed
   edm::Handle<double> rho;
-  if(!rho_.label().empty()) event.getByToken(rhoToken_, rho);
+  if (!rho_.label().empty())
+    event.getByToken(rhoToken_, rho);
 
   auto const& rec = setup.get<JetCorrectionsRecord>();
   if (cacheId_ != rec.cacheIdentifier()) {
@@ -199,19 +198,19 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     edm::ESHandle<JetCorrectorParametersCollection> parameters;
     setup.get<JetCorrectionsRecord>().get(payload(), parameters);
     // initialize jet correctors
-    for(FlavorCorrLevelMap::const_iterator flavor=levels_.begin(); flavor!=levels_.end(); ++flavor){
-      correctors_[flavor->first].reset( new FactorizedJetCorrector(params(*parameters, flavor->second)) );
+    for (FlavorCorrLevelMap::const_iterator flavor = levels_.begin(); flavor != levels_.end(); ++flavor) {
+      correctors_[flavor->first].reset(new FactorizedJetCorrector(params(*parameters, flavor->second)));
     }
     // initialize extra jet corrector for jpt if needed
-    if(!extraJPTOffset_.empty()){
-      extraJPTOffsetCorrector_.reset( new FactorizedJetCorrector(params(*parameters, extraJPTOffset_)) );
+    if (!extraJPTOffset_.empty()) {
+      extraJPTOffsetCorrector_.reset(new FactorizedJetCorrector(params(*parameters, extraJPTOffset_)));
     }
     cacheId_ = rec.cacheIdentifier();
   }
 
   // fill the jetCorrFactors
   std::vector<JetCorrFactors> jcfs;
-  for(edm::View<reco::Jet>::const_iterator jet = jets->begin(); jet!=jets->end(); ++jet){
+  for (edm::View<reco::Jet>::const_iterator jet = jets->begin(); jet != jets->end(); ++jet) {
     // the JetCorrFactors::CorrectionFactor is a std::pair<std::string, std::vector<float> >
     // the string corresponds to the label of the correction level, the vector contains four
     // floats if flavor dependent and one float else. Per construction jet energy corrections
@@ -219,50 +218,51 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     // pendent afterwards. The first correction level is predefined with label 'Uncorrected'.
     // Per definition it is flavor independent. The correction factor is 1.
     std::vector<JetCorrFactors::CorrectionFactor> jec;
-    jec.push_back(std::make_pair<std::string, std::vector<float> >(std::string("Uncorrected"), std::vector<float>(1, 1)));
+    jec.push_back(
+        std::make_pair<std::string, std::vector<float> >(std::string("Uncorrected"), std::vector<float>(1, 1)));
 
     // pick the first element in the map (which could be the only one) and loop all jec
     // levels listed for that element. If this is not the only element all jec levels, which
     // are flavor independent will give the same correction factors until the first flavor
     // dependent correction level is reached. So the first element is still a good choice.
-    FlavorCorrLevelMap::const_iterator corrLevel=levels_.begin();
-    if(corrLevel==levels_.end()){
-      throw cms::Exception("No JECFactors") << "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
-					    << "This makes no sense, either you should correct this or drop the module from \n"
-					    << "the sequence.";
+    FlavorCorrLevelMap::const_iterator corrLevel = levels_.begin();
+    if (corrLevel == levels_.end()) {
+      throw cms::Exception("No JECFactors")
+          << "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
+          << "This makes no sense, either you should correct this or drop the module from \n"
+          << "the sequence.";
     }
-    for(unsigned int idx=0; idx<corrLevel->second.size(); ++idx){
+    for (unsigned int idx = 0; idx < corrLevel->second.size(); ++idx) {
       std::vector<float> factors;
-      if(corrLevel->second[idx].find("L5Flavor")!=std::string::npos ||
-	 corrLevel->second[idx].find("L7Parton")!=std::string::npos){
-	for(FlavorCorrLevelMap::const_iterator flavor=corrLevel; flavor!=levels_.end(); ++flavor){
-	  if(!primaryVertices_.label().empty()){
-	    // if primaryVerticesToken_ has a value the number of primary vertices needs to be
-	    // specified
-	    correctors_.find(flavor->first)->second->setNPV(numberOf(primaryVertices));
-	  }
-	  if(!rho_.label().empty()){
-	    // if rhoToken_ has a value the energy density parameter rho and the jet area need
-	    //  to be specified
-	    correctors_.find(flavor->first)->second->setRho(*rho);
-	    correctors_.find(flavor->first)->second->setJetA(jet->jetArea());
-	  }
-	  factors.push_back(evaluate(jet, flavor->first, idx));
-	}
-      }
-      else{
-	if(!primaryVertices_.label().empty()){
-	  // if primaryVerticesToken_ has a value the number of primary vertices needs to be
-	  // specified
-	  correctors_.find(corrLevel->first)->second->setNPV(numberOf(primaryVertices));
-	}
-	if(!rho_.label().empty()){
-	  // if rhoToken_ has a value the energy density parameter rho and the jet area need
-	  // to be specified
-	  correctors_.find(corrLevel->first)->second->setRho(*rho);
-	  correctors_.find(corrLevel->first)->second->setJetA(jet->jetArea());
-	}
-	factors.push_back(evaluate(jet, corrLevel->first, idx));
+      if (corrLevel->second[idx].find("L5Flavor") != std::string::npos ||
+          corrLevel->second[idx].find("L7Parton") != std::string::npos) {
+        for (FlavorCorrLevelMap::const_iterator flavor = corrLevel; flavor != levels_.end(); ++flavor) {
+          if (!primaryVertices_.label().empty()) {
+            // if primaryVerticesToken_ has a value the number of primary vertices needs to be
+            // specified
+            correctors_.find(flavor->first)->second->setNPV(numberOf(primaryVertices));
+          }
+          if (!rho_.label().empty()) {
+            // if rhoToken_ has a value the energy density parameter rho and the jet area need
+            //  to be specified
+            correctors_.find(flavor->first)->second->setRho(*rho);
+            correctors_.find(flavor->first)->second->setJetA(jet->jetArea());
+          }
+          factors.push_back(evaluate(jet, flavor->first, idx));
+        }
+      } else {
+        if (!primaryVertices_.label().empty()) {
+          // if primaryVerticesToken_ has a value the number of primary vertices needs to be
+          // specified
+          correctors_.find(corrLevel->first)->second->setNPV(numberOf(primaryVertices));
+        }
+        if (!rho_.label().empty()) {
+          // if rhoToken_ has a value the energy density parameter rho and the jet area need
+          // to be specified
+          correctors_.find(corrLevel->first)->second->setRho(*rho);
+          correctors_.find(corrLevel->first)->second->setJetA(jet->jetArea());
+        }
+        factors.push_back(evaluate(jet, corrLevel->first, idx));
       }
       // push back the set of JetCorrFactors: the first entry corresponds to the label
       // of the correction level, which is taken from the first element in levels_. For
@@ -284,14 +284,12 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
   JetCorrFactorsMap::Filler filler(*jetCorrsMap);
   // jets and jetCorrs have their indices aligned by construction
   filler.insert(jets, jcfs.begin(), jcfs.end());
-  filler.fill(); // do the actual filling
+  filler.fill();  // do the actual filling
   // put our produced stuff in the event
   event.put(std::move(jetCorrsMap));
 }
 
-void
-JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.add<bool>("emf", false);
   iDesc.add<std::string>("flavorType", "J");
@@ -304,12 +302,12 @@ JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions & descri
   iDesc.add<std::string>("extraJPTOffset", "L1Offset");
 
   std::vector<std::string> levels;
-  levels.push_back(std::string("L1Offset"  ));
+  levels.push_back(std::string("L1Offset"));
   levels.push_back(std::string("L2Relative"));
   levels.push_back(std::string("L3Absolute"));
   levels.push_back(std::string("L2L3Residual"));
-  levels.push_back(std::string("L5Flavor"  ));
-  levels.push_back(std::string("L7Parton"  ));
+  levels.push_back(std::string("L5Flavor"));
+  levels.push_back(std::string("L7Parton"));
   iDesc.add<std::vector<std::string> >("levels", levels);
   descriptions.add("JetCorrFactorsProducer", iDesc);
 }

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
@@ -54,7 +54,6 @@
 #include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
-
 namespace pat {
 
   class JetCorrFactorsProducer : public edm::stream::EDProducer<> {
@@ -68,7 +67,7 @@ namespace pat {
     /// default constructor
     explicit JetCorrFactorsProducer(const edm::ParameterSet& cfg);
     /// default destructor
-    ~JetCorrFactorsProducer() override {};
+    ~JetCorrFactorsProducer() override{};
     /// everything that needs to be done per event
     void produce(edm::Event& event, const edm::EventSetup& setup) override;
     /// description of configuration file parameters
@@ -76,9 +75,10 @@ namespace pat {
 
   private:
     /// return true if the jec levels contain at least one flavor dependent correction level
-    bool flavorDependent() const { return (levels_.size()>1); };
+    bool flavorDependent() const { return (levels_.size() > 1); };
     /// return the jec parameters as input to the FactorizedJetCorrector for different flavors
-    std::vector<JetCorrectorParameters> params(const JetCorrectorParametersCollection& parameters, const std::vector<std::string>& levels) const;
+    std::vector<JetCorrectorParameters> params(const JetCorrectorParametersCollection& parameters,
+                                               const std::vector<std::string>& levels) const;
     /// return an expanded version of correction levels for different flavors; the result should
     /// be of type ['L2Relative', 'L3Absolute', 'L5FLavor_gJ', 'L7Parton_gJ']; L7Parton_gT will
     /// result in an empty string as this correction level is not available
@@ -132,15 +132,14 @@ namespace pat {
     std::unique_ptr<FactorizedJetCorrector> extraJPTOffsetCorrector_;
   };
 
-  inline int
-  JetCorrFactorsProducer::numberOf(const edm::Handle<std::vector<reco::Vertex> >& primaryVertices)
-  {
-    int npv=0;
-    for(std::vector<reco::Vertex>::const_iterator pv=primaryVertices->begin(); pv!=primaryVertices->end(); ++pv){
-      if(pv->ndof()>=4) ++npv;
+  inline int JetCorrFactorsProducer::numberOf(const edm::Handle<std::vector<reco::Vertex> >& primaryVertices) {
+    int npv = 0;
+    for (std::vector<reco::Vertex>::const_iterator pv = primaryVertices->begin(); pv != primaryVertices->end(); ++pv) {
+      if (pv->ndof() >= 4)
+        ++npv;
     }
     return npv;
   }
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
@@ -13,139 +13,156 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 namespace pat {
-  
 
-  template<typename T>
+  template <typename T>
   class LeptonUpdater : public edm::global::EDProducer<> {
-
-    public:
-
-      explicit LeptonUpdater(const edm::ParameterSet & iConfig) :
-            src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src"))),
-            vertices_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices"))),
-            computeMiniIso_(iConfig.getParameter<bool>("computeMiniIso"))
-        {
-            //for mini-isolation calculation
-            if (computeMiniIso_) {
-                readMiniIsoParams(iConfig);
-                pcToken_ = consumes<pat::PackedCandidateCollection >(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
-            }
-	    recomputeMuonBasicSelectors_ = false;
-            if (typeid(T) == typeid(pat::Muon)) recomputeMuonBasicSelectors_ = iConfig.getParameter<bool>("recomputeMuonBasicSelectors");
-            produces<std::vector<T>>();
-        }
-
-      ~LeptonUpdater() override {}
-
-      void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override ;
-
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-          edm::ParameterSetDescription desc;
-          desc.add<edm::InputTag>("src")->setComment("Lepton collection");
-          desc.add<edm::InputTag>("vertices")->setComment("Vertex collection");
-          desc.add<bool>("computeMiniIso", false)->setComment("Recompute miniIsolation");
-          desc.addOptional<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))->setComment("PackedCandidate collection used for miniIso");
-          if (typeid(T) == typeid(pat::Muon)) {
-            desc.add<bool>("recomputeMuonBasicSelectors",false)->setComment("Recompute basic cut-based muon selector flags");
-            desc.addOptional<std::vector<double>>("miniIsoParams")->setComment("Parameters used for miniIso (as in PATMuonProducer)");
-            descriptions.add("muonsUpdated", desc);
-          } else if (typeid(T) == typeid(pat::Electron)) {
-            desc.addOptional<std::vector<double>>("miniIsoParamsB")->setComment("Parameters used for miniIso in the barrel (as in PATElectronProducer)");
-            desc.addOptional<std::vector<double>>("miniIsoParamsE")->setComment("Parameters used for miniIso in the endcap (as in PATElectronProducer)");
-            descriptions.add("electronsUpdated", desc);
-          }
+  public:
+    explicit LeptonUpdater(const edm::ParameterSet &iConfig)
+        : src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src"))),
+          vertices_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices"))),
+          computeMiniIso_(iConfig.getParameter<bool>("computeMiniIso")) {
+      //for mini-isolation calculation
+      if (computeMiniIso_) {
+        readMiniIsoParams(iConfig);
+        pcToken_ = consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
       }
+      recomputeMuonBasicSelectors_ = false;
+      if (typeid(T) == typeid(pat::Muon))
+        recomputeMuonBasicSelectors_ = iConfig.getParameter<bool>("recomputeMuonBasicSelectors");
+      produces<std::vector<T>>();
+    }
 
-      void setDZ(T & lep, const reco::Vertex & pv) const {}
-        
-      void readMiniIsoParams(const edm::ParameterSet & iConfig) { 
-          miniIsoParams_[0] = iConfig.getParameter<std::vector<double> >("miniIsoParams");
-          if(miniIsoParams_[0].size() != 9) throw cms::Exception("ParameterError", "miniIsoParams must have exactly 9 elements.\n");
+    ~LeptonUpdater() override {}
+
+    void produce(edm::StreamID, edm::Event &, edm::EventSetup const &) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("src")->setComment("Lepton collection");
+      desc.add<edm::InputTag>("vertices")->setComment("Vertex collection");
+      desc.add<bool>("computeMiniIso", false)->setComment("Recompute miniIsolation");
+      desc.addOptional<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))
+          ->setComment("PackedCandidate collection used for miniIso");
+      if (typeid(T) == typeid(pat::Muon)) {
+        desc.add<bool>("recomputeMuonBasicSelectors", false)
+            ->setComment("Recompute basic cut-based muon selector flags");
+        desc.addOptional<std::vector<double>>("miniIsoParams")
+            ->setComment("Parameters used for miniIso (as in PATMuonProducer)");
+        descriptions.add("muonsUpdated", desc);
+      } else if (typeid(T) == typeid(pat::Electron)) {
+        desc.addOptional<std::vector<double>>("miniIsoParamsB")
+            ->setComment("Parameters used for miniIso in the barrel (as in PATElectronProducer)");
+        desc.addOptional<std::vector<double>>("miniIsoParamsE")
+            ->setComment("Parameters used for miniIso in the endcap (as in PATElectronProducer)");
+        descriptions.add("electronsUpdated", desc);
       }
-      const std::vector<double> & miniIsoParams(const T &lep) const { return miniIsoParams_[0]; }
+    }
 
-      void recomputeMuonBasicSelectors(T &, const reco::Vertex &, const bool) const;
+    void setDZ(T &lep, const reco::Vertex &pv) const {}
 
-    private:
-      // configurables
-      edm::EDGetTokenT<std::vector<T>> src_;
-      edm::EDGetTokenT<std::vector<reco::Vertex>> vertices_;
-      bool computeMiniIso_;
-      bool recomputeMuonBasicSelectors_;
-      std::vector<double> miniIsoParams_[2];
-      edm::EDGetTokenT<pat::PackedCandidateCollection> pcToken_;
+    void readMiniIsoParams(const edm::ParameterSet &iConfig) {
+      miniIsoParams_[0] = iConfig.getParameter<std::vector<double>>("miniIsoParams");
+      if (miniIsoParams_[0].size() != 9)
+        throw cms::Exception("ParameterError", "miniIsoParams must have exactly 9 elements.\n");
+    }
+    const std::vector<double> &miniIsoParams(const T &lep) const { return miniIsoParams_[0]; }
+
+    void recomputeMuonBasicSelectors(T &, const reco::Vertex &, const bool) const;
+
+  private:
+    // configurables
+    edm::EDGetTokenT<std::vector<T>> src_;
+    edm::EDGetTokenT<std::vector<reco::Vertex>> vertices_;
+    bool computeMiniIso_;
+    bool recomputeMuonBasicSelectors_;
+    std::vector<double> miniIsoParams_[2];
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcToken_;
   };
 
   // must do the specialization within the namespace otherwise gcc complains
   //
-  template<>
-  void LeptonUpdater<pat::Electron>::setDZ(pat::Electron & anElectron, const reco::Vertex & pv) const {
-      auto track = anElectron.gsfTrack();
-      anElectron.setDB( track->dz(pv.position()), std::hypot(track->dzError(), pv.zError()), pat::Electron::PVDZ );
-  }
-  
-  template<>
-  void LeptonUpdater<pat::Muon>::setDZ(pat::Muon & aMuon, const reco::Vertex & pv) const {
-      auto track = aMuon.muonBestTrack();
-      aMuon.setDB( track->dz(pv.position()), std::hypot(track->dzError(), pv.zError()), pat::Muon::PVDZ );
+  template <>
+  void LeptonUpdater<pat::Electron>::setDZ(pat::Electron &anElectron, const reco::Vertex &pv) const {
+    auto track = anElectron.gsfTrack();
+    anElectron.setDB(track->dz(pv.position()), std::hypot(track->dzError(), pv.zError()), pat::Electron::PVDZ);
   }
 
-  template<>
-  void LeptonUpdater<pat::Electron>::readMiniIsoParams(const edm::ParameterSet & iConfig) {
-      miniIsoParams_[0] = iConfig.getParameter<std::vector<double> >("miniIsoParamsB");
-      miniIsoParams_[1] = iConfig.getParameter<std::vector<double> >("miniIsoParamsE");
-      if(miniIsoParams_[0].size() != 9) throw cms::Exception("ParameterError", "miniIsoParamsB must have exactly 9 elements.\n");
-      if(miniIsoParams_[1].size() != 9) throw cms::Exception("ParameterError", "miniIsoParamsE must have exactly 9 elements.\n");
-  }
-  template<>
-  const std::vector<double> & LeptonUpdater<pat::Electron>::miniIsoParams(const pat::Electron &lep) const { 
-      return miniIsoParams_[lep.isEE()]; 
+  template <>
+  void LeptonUpdater<pat::Muon>::setDZ(pat::Muon &aMuon, const reco::Vertex &pv) const {
+    auto track = aMuon.muonBestTrack();
+    aMuon.setDB(track->dz(pv.position()), std::hypot(track->dzError(), pv.zError()), pat::Muon::PVDZ);
   }
 
-  template<typename T>
-  void LeptonUpdater<T>::recomputeMuonBasicSelectors(T & lep, const reco::Vertex & pv, const bool do_hip_mitigation_2016) const {}
+  template <>
+  void LeptonUpdater<pat::Electron>::readMiniIsoParams(const edm::ParameterSet &iConfig) {
+    miniIsoParams_[0] = iConfig.getParameter<std::vector<double>>("miniIsoParamsB");
+    miniIsoParams_[1] = iConfig.getParameter<std::vector<double>>("miniIsoParamsE");
+    if (miniIsoParams_[0].size() != 9)
+      throw cms::Exception("ParameterError", "miniIsoParamsB must have exactly 9 elements.\n");
+    if (miniIsoParams_[1].size() != 9)
+      throw cms::Exception("ParameterError", "miniIsoParamsE must have exactly 9 elements.\n");
+  }
+  template <>
+  const std::vector<double> &LeptonUpdater<pat::Electron>::miniIsoParams(const pat::Electron &lep) const {
+    return miniIsoParams_[lep.isEE()];
+  }
 
-  template<>
-  void LeptonUpdater<pat::Muon>::recomputeMuonBasicSelectors(pat::Muon & lep, const reco::Vertex & pv, const bool do_hip_mitigation_2016) const {
+  template <typename T>
+  void LeptonUpdater<T>::recomputeMuonBasicSelectors(T &lep,
+                                                     const reco::Vertex &pv,
+                                                     const bool do_hip_mitigation_2016) const {}
+
+  template <>
+  void LeptonUpdater<pat::Muon>::recomputeMuonBasicSelectors(pat::Muon &lep,
+                                                             const reco::Vertex &pv,
+                                                             const bool do_hip_mitigation_2016) const {
     lep.setSelectors(muon::makeSelectorBitset(lep, &pv, do_hip_mitigation_2016));
   }
 
-} // namespace
+}  // namespace pat
 
-template<typename T>
-void pat::LeptonUpdater<T>::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
-    edm::Handle<std::vector<T>> src;
-    iEvent.getByToken(src_, src);
+template <typename T>
+void pat::LeptonUpdater<T>::produce(edm::StreamID, edm::Event &iEvent, edm::EventSetup const &) const {
+  edm::Handle<std::vector<T>> src;
+  iEvent.getByToken(src_, src);
 
-    edm::Handle<std::vector<reco::Vertex>> vertices;
-    iEvent.getByToken(vertices_, vertices);
-    const reco::Vertex & pv = vertices->front();
+  edm::Handle<std::vector<reco::Vertex>> vertices;
+  iEvent.getByToken(vertices_, vertices);
+  const reco::Vertex &pv = vertices->front();
 
-    edm::Handle<pat::PackedCandidateCollection> pc;
-    if(computeMiniIso_) iEvent.getByToken(pcToken_, pc);
+  edm::Handle<pat::PackedCandidateCollection> pc;
+  if (computeMiniIso_)
+    iEvent.getByToken(pcToken_, pc);
 
-    std::unique_ptr<std::vector<T>> out(new std::vector<T>(*src));
+  std::unique_ptr<std::vector<T>> out(new std::vector<T>(*src));
 
-    const bool do_hip_mitigation_2016 = recomputeMuonBasicSelectors_ && (272728 <= iEvent.run() && iEvent.run() <= 278808);
+  const bool do_hip_mitigation_2016 =
+      recomputeMuonBasicSelectors_ && (272728 <= iEvent.run() && iEvent.run() <= 278808);
 
-    for (unsigned int i = 0, n = src->size(); i < n; ++i) {
-        T & lep = (*out)[i];
-        setDZ(lep, pv);
-        if (computeMiniIso_) {
-            const auto & params = miniIsoParams(lep);
-            pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc.product(), lep.p4(),
-                                                               params[0], params[1], params[2],
-                                                               params[3], params[4], params[5],
-                                                               params[6], params[7], params[8]);
-            lep.setMiniPFIsolation(miniiso);
-        }
-	if (recomputeMuonBasicSelectors_) recomputeMuonBasicSelectors(lep,pv,do_hip_mitigation_2016);
+  for (unsigned int i = 0, n = src->size(); i < n; ++i) {
+    T &lep = (*out)[i];
+    setDZ(lep, pv);
+    if (computeMiniIso_) {
+      const auto &params = miniIsoParams(lep);
+      pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc.product(),
+                                                         lep.p4(),
+                                                         params[0],
+                                                         params[1],
+                                                         params[2],
+                                                         params[3],
+                                                         params[4],
+                                                         params[5],
+                                                         params[6],
+                                                         params[7],
+                                                         params[8]);
+      lep.setMiniPFIsolation(miniiso);
     }
+    if (recomputeMuonBasicSelectors_)
+      recomputeMuonBasicSelectors(lep, pv, do_hip_mitigation_2016);
+  }
 
-    iEvent.put(std::move(out));
+  iEvent.put(std::move(out));
 }
-
-
 
 typedef pat::LeptonUpdater<pat::Electron> PATElectronUpdater;
 typedef pat::LeptonUpdater<pat::Muon> PATMuonUpdater;

--- a/PhysicsTools/PatAlgos/plugins/LowPtGSFToPackedCandidateLinker.cc
+++ b/PhysicsTools/PatAlgos/plugins/LowPtGSFToPackedCandidateLinker.cc
@@ -21,142 +21,145 @@
 
 class LowPtGSFToPackedCandidateLinker : public edm::global::EDProducer<> {
 public:
-	explicit LowPtGSFToPackedCandidateLinker(const edm::ParameterSet&);
-	~LowPtGSFToPackedCandidateLinker() override;
-    
-	void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-	static void fillDescriptions(edm::ConfigurationDescriptions&);
-   
+  explicit LowPtGSFToPackedCandidateLinker(const edm::ParameterSet&);
+  ~LowPtGSFToPackedCandidateLinker() override;
+
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
 private:
-	const edm::EDGetTokenT<reco::PFCandidateCollection> pfcands_;
-	const edm::EDGetTokenT<pat::PackedCandidateCollection> packed_;
-	const edm::EDGetTokenT<pat::PackedCandidateCollection> lost_tracks_;
-	const edm::EDGetTokenT<reco::TrackCollection>          tracks_;
-	const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2packed_;
-	const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > lost2trk_;
-	const edm::EDGetTokenT< edm::Association<reco::TrackCollection> > gsf2trk_;	
-	const edm::EDGetTokenT< std::vector<reco::GsfTrack> > gsftracks_;	
+  const edm::EDGetTokenT<reco::PFCandidateCollection> pfcands_;
+  const edm::EDGetTokenT<pat::PackedCandidateCollection> packed_;
+  const edm::EDGetTokenT<pat::PackedCandidateCollection> lost_tracks_;
+  const edm::EDGetTokenT<reco::TrackCollection> tracks_;
+  const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2packed_;
+  const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > lost2trk_;
+  const edm::EDGetTokenT<edm::Association<reco::TrackCollection> > gsf2trk_;
+  const edm::EDGetTokenT<std::vector<reco::GsfTrack> > gsftracks_;
 };
 
-LowPtGSFToPackedCandidateLinker::LowPtGSFToPackedCandidateLinker(const edm::ParameterSet& iConfig) :
-  pfcands_{consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("PFCandidates"))},
-  packed_{consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedCandidates"))},
-  lost_tracks_{consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostTracks"))},
-  tracks_{consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))},
-  pf2packed_{consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedCandidates"))},
-  lost2trk_{consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("lostTracks"))},
-  gsf2trk_{consumes<edm::Association<reco::TrackCollection> >(iConfig.getParameter<edm::InputTag>("gsfToTrack"))},
-  gsftracks_{consumes<std::vector<reco::GsfTrack> >(iConfig.getParameter<edm::InputTag>("gsfTracks"))} {     
-		produces< edm::Association<pat::PackedCandidateCollection> > ("packedCandidates");
-		produces< edm::Association<pat::PackedCandidateCollection> > ("lostTracks");
-	}
+LowPtGSFToPackedCandidateLinker::LowPtGSFToPackedCandidateLinker(const edm::ParameterSet& iConfig)
+    : pfcands_{consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("PFCandidates"))},
+      packed_{consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedCandidates"))},
+      lost_tracks_{consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostTracks"))},
+      tracks_{consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))},
+      pf2packed_{consumes<edm::Association<pat::PackedCandidateCollection> >(
+          iConfig.getParameter<edm::InputTag>("packedCandidates"))},
+      lost2trk_{consumes<edm::Association<pat::PackedCandidateCollection> >(
+          iConfig.getParameter<edm::InputTag>("lostTracks"))},
+      gsf2trk_{consumes<edm::Association<reco::TrackCollection> >(iConfig.getParameter<edm::InputTag>("gsfToTrack"))},
+      gsftracks_{consumes<std::vector<reco::GsfTrack> >(iConfig.getParameter<edm::InputTag>("gsfTracks"))} {
+  produces<edm::Association<pat::PackedCandidateCollection> >("packedCandidates");
+  produces<edm::Association<pat::PackedCandidateCollection> >("lostTracks");
+}
 
 LowPtGSFToPackedCandidateLinker::~LowPtGSFToPackedCandidateLinker() {}
 
 void LowPtGSFToPackedCandidateLinker::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-	edm::Handle<reco::PFCandidateCollection> pfcands;
-	iEvent.getByToken(pfcands_, pfcands);
+  edm::Handle<reco::PFCandidateCollection> pfcands;
+  iEvent.getByToken(pfcands_, pfcands);
 
-	edm::Handle<pat::PackedCandidateCollection> packed;
-	iEvent.getByToken(packed_, packed);
+  edm::Handle<pat::PackedCandidateCollection> packed;
+  iEvent.getByToken(packed_, packed);
 
-	edm::Handle<pat::PackedCandidateCollection> lost_tracks;
-	iEvent.getByToken(lost_tracks_, lost_tracks);
+  edm::Handle<pat::PackedCandidateCollection> lost_tracks;
+  iEvent.getByToken(lost_tracks_, lost_tracks);
 
-	edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2packed;
-	iEvent.getByToken(pf2packed_, pf2packed);
+  edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2packed;
+  iEvent.getByToken(pf2packed_, pf2packed);
 
-	edm::Handle<edm::Association<pat::PackedCandidateCollection> > lost2trk_assoc;
-	iEvent.getByToken(lost2trk_, lost2trk_assoc);
+  edm::Handle<edm::Association<pat::PackedCandidateCollection> > lost2trk_assoc;
+  iEvent.getByToken(lost2trk_, lost2trk_assoc);
 
-	edm::Handle<std::vector<reco::GsfTrack> > gsftracks;
-	iEvent.getByToken(gsftracks_, gsftracks);
+  edm::Handle<std::vector<reco::GsfTrack> > gsftracks;
+  iEvent.getByToken(gsftracks_, gsftracks);
 
-	edm::Handle<reco::TrackCollection> tracks;
-	iEvent.getByToken(tracks_, tracks);
+  edm::Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken(tracks_, tracks);
 
-	edm::Handle<edm::Association<reco::TrackCollection> > gsf2trk;
-	iEvent.getByToken(gsf2trk_, gsf2trk);
+  edm::Handle<edm::Association<reco::TrackCollection> > gsf2trk;
+  iEvent.getByToken(gsf2trk_, gsf2trk);
 
-	// collection sizes, for reference
-	const size_t npf = pfcands->size();
-	const size_t npacked = packed->size();
-	const size_t nlost = lost_tracks->size();
-	const size_t ntracks = tracks->size();
-	const size_t ngsf = gsftracks->size();
+  // collection sizes, for reference
+  const size_t npf = pfcands->size();
+  const size_t npacked = packed->size();
+  const size_t nlost = lost_tracks->size();
+  const size_t ntracks = tracks->size();
+  const size_t ngsf = gsftracks->size();
 
-	//store index mapping in vectors for easy and fast access
-	std::vector<size_t> trk2packed(ntracks, npacked);
-	std::vector<size_t> trk2lost(ntracks, nlost);
+  //store index mapping in vectors for easy and fast access
+  std::vector<size_t> trk2packed(ntracks, npacked);
+  std::vector<size_t> trk2lost(ntracks, nlost);
 
-	//store auxiliary mappings for association
-	std::vector<int> gsf2pack(ngsf, -1);
-	std::vector<int> gsf2lost(ngsf, -1);
+  //store auxiliary mappings for association
+  std::vector<int> gsf2pack(ngsf, -1);
+  std::vector<int> gsf2lost(ngsf, -1);
 
-	//electrons will never store their track (they store the Gsf track)
-	//map PackedPF <--> Track
-	for(unsigned int icand=0; icand < npf; ++icand) {
-		edm::Ref<reco::PFCandidateCollection> pf_ref(pfcands,icand);
-		const reco::PFCandidate &cand = pfcands->at(icand); 
-		auto packed_ref = (*pf2packed)[pf_ref];
-		if(cand.charge() && packed_ref.isNonnull() && cand.trackRef().isNonnull() 
-			 && cand.trackRef().id() == tracks.id() ) { 
-			size_t trkid = cand.trackRef().index();
-			size_t packid = packed_ref.index();
-			trk2packed[trkid] = packid;
-		}
-	}
+  //electrons will never store their track (they store the Gsf track)
+  //map PackedPF <--> Track
+  for (unsigned int icand = 0; icand < npf; ++icand) {
+    edm::Ref<reco::PFCandidateCollection> pf_ref(pfcands, icand);
+    const reco::PFCandidate& cand = pfcands->at(icand);
+    auto packed_ref = (*pf2packed)[pf_ref];
+    if (cand.charge() && packed_ref.isNonnull() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id()) {
+      size_t trkid = cand.trackRef().index();
+      size_t packid = packed_ref.index();
+      trk2packed[trkid] = packid;
+    }
+  }
 
-	//map LostTrack <--> Track
-	for(unsigned int itrk=0; itrk < ntracks; ++itrk) {
-		reco::TrackRef key(tracks, itrk);
-		pat::PackedCandidateRef lostTrack = (*lost2trk_assoc)[key];
-		if(lostTrack.isNonnull()) {
-			size_t ilost = lostTrack.index(); //assumes that LostTracks are all made from the same track collection
-			trk2lost[itrk] = ilost;
-		}
-	}	
+  //map LostTrack <--> Track
+  for (unsigned int itrk = 0; itrk < ntracks; ++itrk) {
+    reco::TrackRef key(tracks, itrk);
+    pat::PackedCandidateRef lostTrack = (*lost2trk_assoc)[key];
+    if (lostTrack.isNonnull()) {
+      size_t ilost = lostTrack.index();  //assumes that LostTracks are all made from the same track collection
+      trk2lost[itrk] = ilost;
+    }
+  }
 
-	//map Track --> GSF and fill GSF --> PackedCandidates and GSF --> Lost associations
-	for(unsigned int igsf=0; igsf < ngsf; ++igsf) {
-		reco::GsfTrackRef gref(gsftracks, igsf);
-		reco::TrackRef trk = (*gsf2trk)[gref];
-		if(trk.id() != tracks.id()) {
-			throw cms::Exception("WrongCollection", "The reco::Track collection used to match against the GSF Tracks was not used to produce such tracks");
-		}
-		size_t trkid = trk.index();
+  //map Track --> GSF and fill GSF --> PackedCandidates and GSF --> Lost associations
+  for (unsigned int igsf = 0; igsf < ngsf; ++igsf) {
+    reco::GsfTrackRef gref(gsftracks, igsf);
+    reco::TrackRef trk = (*gsf2trk)[gref];
+    if (trk.id() != tracks.id()) {
+      throw cms::Exception(
+          "WrongCollection",
+          "The reco::Track collection used to match against the GSF Tracks was not used to produce such tracks");
+    }
+    size_t trkid = trk.index();
 
-		if(trk2packed[trkid] != npacked) {
-			gsf2pack[igsf] = trk2packed[trkid];
-		} 
-		if(trk2lost[trkid] != nlost) {
-			gsf2lost[igsf] = trk2lost[trkid];
-		}
-	}
+    if (trk2packed[trkid] != npacked) {
+      gsf2pack[igsf] = trk2packed[trkid];
+    }
+    if (trk2lost[trkid] != nlost) {
+      gsf2lost[igsf] = trk2lost[trkid];
+    }
+  }
 
-	// create output collections from the mappings
-	auto assoc_gsf2pack = std::make_unique< edm::Association<pat::PackedCandidateCollection> >(packed);
-	edm::Association<pat::PackedCandidateCollection>::Filler gsf2pack_filler(*assoc_gsf2pack);
-	gsf2pack_filler.insert(gsftracks, gsf2pack.begin(), gsf2pack.end());
-	gsf2pack_filler.fill(); 
-	iEvent.put(std::move(assoc_gsf2pack), "packedCandidates");   
+  // create output collections from the mappings
+  auto assoc_gsf2pack = std::make_unique<edm::Association<pat::PackedCandidateCollection> >(packed);
+  edm::Association<pat::PackedCandidateCollection>::Filler gsf2pack_filler(*assoc_gsf2pack);
+  gsf2pack_filler.insert(gsftracks, gsf2pack.begin(), gsf2pack.end());
+  gsf2pack_filler.fill();
+  iEvent.put(std::move(assoc_gsf2pack), "packedCandidates");
 
-	auto assoc_gsf2lost = std::make_unique< edm::Association<pat::PackedCandidateCollection> >(lost_tracks);
-	edm::Association<pat::PackedCandidateCollection>::Filler gsf2lost_filler(*assoc_gsf2lost);
-	gsf2lost_filler.insert(gsftracks, gsf2lost.begin(), gsf2lost.end());
-	gsf2lost_filler.fill();
-	iEvent.put(std::move(assoc_gsf2lost), "lostTracks");
+  auto assoc_gsf2lost = std::make_unique<edm::Association<pat::PackedCandidateCollection> >(lost_tracks);
+  edm::Association<pat::PackedCandidateCollection>::Filler gsf2lost_filler(*assoc_gsf2lost);
+  gsf2lost_filler.insert(gsftracks, gsf2lost.begin(), gsf2lost.end());
+  gsf2lost_filler.fill();
+  iEvent.put(std::move(assoc_gsf2lost), "lostTracks");
 }
 
 void LowPtGSFToPackedCandidateLinker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-	edm::ParameterSetDescription desc;
-	desc.add<edm::InputTag>("PFCandidates", edm::InputTag("particleFlow"));
-	desc.add<edm::InputTag>("packedCandidates", edm::InputTag("packedPFCandidates"));
-	desc.add<edm::InputTag>("lostTracks", edm::InputTag("lostTracks"));
-	desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
-	desc.add<edm::InputTag>("gsfToTrack", edm::InputTag("lowPtGsfToTrackLinks"));
-	desc.add<edm::InputTag>("gsfTracks", edm::InputTag("lowPtGsfEleGsfTracks"));
-	descriptions.add("lowPtGsfLinksDefault", desc);
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("PFCandidates", edm::InputTag("particleFlow"));
+  desc.add<edm::InputTag>("packedCandidates", edm::InputTag("packedPFCandidates"));
+  desc.add<edm::InputTag>("lostTracks", edm::InputTag("lostTracks"));
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("gsfToTrack", edm::InputTag("lowPtGsfToTrackLinks"));
+  desc.add<edm::InputTag>("gsfTracks", edm::InputTag("lowPtGsfEleGsfTracks"));
+  descriptions.add("lowPtGsfLinksDefault", desc);
 }
 
 DEFINE_FWK_MODULE(LowPtGSFToPackedCandidateLinker);

--- a/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducer.h
@@ -12,39 +12,38 @@
 #include <memory>
 
 namespace pat {
-  
-  template<class T>
+
+  template <class T>
   class ModifiedObjectProducer : public edm::stream::EDProducer<> {
   public:
     typedef std::vector<T> Collection;
     typedef pat::ObjectModifier<T> Modifier;
 
-    ModifiedObjectProducer( const edm::ParameterSet& conf ) {
+    ModifiedObjectProducer(const edm::ParameterSet& conf) {
       //set our input source
       src_ = consumes<edm::View<T> >(conf.getParameter<edm::InputTag>("src"));
       //setup modifier
-      const edm::ParameterSet& mod_config = 
-        conf.getParameter<edm::ParameterSet>("modifierConfig");
+      const edm::ParameterSet& mod_config = conf.getParameter<edm::ParameterSet>("modifierConfig");
       modifier_ = std::make_unique<Modifier>(mod_config, consumesCollector());
       //declare products
       produces<Collection>();
     }
     ~ModifiedObjectProducer() override {}
 
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup& evs) final {
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& evs) final {
       modifier_->setEventContent(evs);
     }
-    
-    void produce(edm::Event& evt,const edm::EventSetup& evs) final {
+
+    void produce(edm::Event& evt, const edm::EventSetup& evs) final {
       edm::Handle<edm::View<T> > input;
       auto output = std::make_unique<Collection>();
 
-      evt.getByToken(src_,input);
+      evt.getByToken(src_, input);
       output->reserve(input->size());
 
       modifier_->setEvent(evt);
 
-      for( auto itr = input->begin(); itr != input->end(); ++itr ) {
+      for (auto itr = input->begin(); itr != input->end(); ++itr) {
         output->push_back(*itr);
         T& obj = output->back();
         modifier_->modify(obj);
@@ -57,6 +56,6 @@ namespace pat {
     edm::EDGetTokenT<edm::View<T> > src_;
     std::unique_ptr<Modifier> modifier_;
   };
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducers.cc
+++ b/PhysicsTools/PatAlgos/plugins/ModifiedObjectProducers.cc
@@ -7,10 +7,10 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 typedef pat::ModifiedObjectProducer<pat::Electron> ModifiedElectronProducer;
-typedef pat::ModifiedObjectProducer<pat::Photon>   ModifiedPhotonProducer;
-typedef pat::ModifiedObjectProducer<pat::Muon>     ModifiedMuonProducer;
-typedef pat::ModifiedObjectProducer<pat::Tau>      ModifiedTauProducer;
-typedef pat::ModifiedObjectProducer<pat::Jet>      ModifiedJetProducer;
+typedef pat::ModifiedObjectProducer<pat::Photon> ModifiedPhotonProducer;
+typedef pat::ModifiedObjectProducer<pat::Muon> ModifiedMuonProducer;
+typedef pat::ModifiedObjectProducer<pat::Tau> ModifiedTauProducer;
+typedef pat::ModifiedObjectProducer<pat::Jet> ModifiedJetProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(ModifiedElectronProducer);

--- a/PhysicsTools/PatAlgos/plugins/PATCleaner.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATCleaner.cc
@@ -2,15 +2,15 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 namespace pat {
-    typedef pat::PATCleaner<pat::Electron>   PATElectronCleaner;
-    typedef pat::PATCleaner<pat::Muon>       PATMuonCleaner;
-    typedef pat::PATCleaner<pat::Tau>        PATTauCleaner;
-    typedef pat::PATCleaner<pat::Photon>     PATPhotonCleaner;
-    typedef pat::PATCleaner<pat::Jet>        PATJetCleaner;
-    typedef pat::PATCleaner<pat::MET>        PATMETCleaner;
-    typedef pat::PATCleaner<pat::GenericParticle> PATGenericParticleCleaner;
-    typedef pat::PATCleaner<pat::PFParticle> PATPFParticleCleaner; 
-}
+  typedef pat::PATCleaner<pat::Electron> PATElectronCleaner;
+  typedef pat::PATCleaner<pat::Muon> PATMuonCleaner;
+  typedef pat::PATCleaner<pat::Tau> PATTauCleaner;
+  typedef pat::PATCleaner<pat::Photon> PATPhotonCleaner;
+  typedef pat::PATCleaner<pat::Jet> PATJetCleaner;
+  typedef pat::PATCleaner<pat::MET> PATMETCleaner;
+  typedef pat::PATCleaner<pat::GenericParticle> PATGenericParticleCleaner;
+  typedef pat::PATCleaner<pat::PFParticle> PATPFParticleCleaner;
+}  // namespace pat
 using namespace pat;
 DEFINE_FWK_MODULE(PATElectronCleaner);
 DEFINE_FWK_MODULE(PATMuonCleaner);

--- a/PhysicsTools/PatAlgos/plugins/PATCleaner.h
+++ b/PhysicsTools/PatAlgos/plugins/PATCleaner.h
@@ -13,7 +13,6 @@
   \version  $Id: PATCleaner.h,v 1.3 2010/10/20 23:08:30 wmtan Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -37,67 +36,65 @@
 
 namespace pat {
 
-  template<class PATObjType>
+  template <class PATObjType>
   class PATCleaner : public edm::stream::EDProducer<> {
-    public:
-      explicit PATCleaner(const edm::ParameterSet & iConfig);
-      ~PATCleaner() override {}
+  public:
+    explicit PATCleaner(const edm::ParameterSet& iConfig);
+    ~PATCleaner() override {}
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) final;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) final;
 
-    private:
-      typedef StringCutObjectSelector<PATObjType> Selector;
+  private:
+    typedef StringCutObjectSelector<PATObjType> Selector;
 
-      const edm::InputTag src_;
-      const edm::EDGetTokenT<edm::View<PATObjType> > srcToken_;
-      const Selector preselectionCut_;
-      const Selector finalCut_;
+    const edm::InputTag src_;
+    const edm::EDGetTokenT<edm::View<PATObjType>> srcToken_;
+    const Selector preselectionCut_;
+    const Selector finalCut_;
 
-      typedef pat::helper::OverlapTest OverlapTest;
-      std::vector<std::unique_ptr<OverlapTest> > overlapTests_;
+    typedef pat::helper::OverlapTest OverlapTest;
+    std::vector<std::unique_ptr<OverlapTest>> overlapTests_;
   };
 
-} // namespace
+}  // namespace pat
 
 template <class PATObjType>
-pat::PATCleaner<PATObjType>::PATCleaner(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")),
-    srcToken_(consumes<edm::View<PATObjType> >(src_)),
-    preselectionCut_(iConfig.getParameter<std::string>("preselection")),
-    finalCut_(iConfig.getParameter<std::string>("finalCut"))
-{
-    // pick parameter set for overlaps
-    edm::ParameterSet overlapPSet = iConfig.getParameter<edm::ParameterSet>("checkOverlaps");
-    // get all the names of the tests (all nested PSets in this PSet)
-    std::vector<std::string> overlapNames = overlapPSet.getParameterNamesForType<edm::ParameterSet>();
-    // loop on them
-    for (std::vector<std::string>::const_iterator itn = overlapNames.begin(); itn != overlapNames.end(); ++itn) {
-        // retrieve configuration
-        edm::ParameterSet cfg = overlapPSet.getParameter<edm::ParameterSet>(*itn);
-        // skip empty parameter sets
-        if (cfg.empty()) continue;
-        // get the name of the algorithm to use
-        std::string algorithm = cfg.getParameter<std::string>("algorithm");
-        // create the appropriate OverlapTest
-        if (algorithm == "byDeltaR") {
-            overlapTests_.emplace_back(new pat::helper::BasicOverlapTest(*itn, cfg, consumesCollector()));
-        } else if (algorithm == "bySuperClusterSeed") {
-            overlapTests_.emplace_back(new pat::helper::OverlapBySuperClusterSeed(*itn, cfg, consumesCollector()));
-        } else {
-            throw cms::Exception("Configuration") << "PATCleaner for " << src_ << ": unsupported algorithm '" << algorithm << "'\n";
-        }
+pat::PATCleaner<PATObjType>::PATCleaner(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      srcToken_(consumes<edm::View<PATObjType>>(src_)),
+      preselectionCut_(iConfig.getParameter<std::string>("preselection")),
+      finalCut_(iConfig.getParameter<std::string>("finalCut")) {
+  // pick parameter set for overlaps
+  edm::ParameterSet overlapPSet = iConfig.getParameter<edm::ParameterSet>("checkOverlaps");
+  // get all the names of the tests (all nested PSets in this PSet)
+  std::vector<std::string> overlapNames = overlapPSet.getParameterNamesForType<edm::ParameterSet>();
+  // loop on them
+  for (std::vector<std::string>::const_iterator itn = overlapNames.begin(); itn != overlapNames.end(); ++itn) {
+    // retrieve configuration
+    edm::ParameterSet cfg = overlapPSet.getParameter<edm::ParameterSet>(*itn);
+    // skip empty parameter sets
+    if (cfg.empty())
+      continue;
+    // get the name of the algorithm to use
+    std::string algorithm = cfg.getParameter<std::string>("algorithm");
+    // create the appropriate OverlapTest
+    if (algorithm == "byDeltaR") {
+      overlapTests_.emplace_back(new pat::helper::BasicOverlapTest(*itn, cfg, consumesCollector()));
+    } else if (algorithm == "bySuperClusterSeed") {
+      overlapTests_.emplace_back(new pat::helper::OverlapBySuperClusterSeed(*itn, cfg, consumesCollector()));
+    } else {
+      throw cms::Exception("Configuration")
+          << "PATCleaner for " << src_ << ": unsupported algorithm '" << algorithm << "'\n";
     }
+  }
 
-
-    produces<std::vector<PATObjType> >();
+  produces<std::vector<PATObjType>>();
 }
 
 template <class PATObjType>
-void
-pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-
+void pat::PATCleaner<PATObjType>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Read the input. We use edm::View<> in case the input happes to be something different than a std::vector<>
-  edm::Handle<edm::View<PATObjType> > candidates;
+  edm::Handle<edm::View<PATObjType>> candidates;
   iEvent.getByToken(srcToken_, candidates);
 
   // Prepare a collection for the output
@@ -105,37 +102,42 @@ pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup 
 
   // initialize the overlap tests
   for (auto& itov : overlapTests_) {
-    itov->readInput(iEvent,iSetup);
+    itov->readInput(iEvent, iSetup);
   }
 
-  for (typename edm::View<PATObjType>::const_iterator it = candidates->begin(), ed = candidates->end(); it != ed; ++it) {
-      // Apply a preselection to the inputs and copy them in the output
-      if (!preselectionCut_(*it)) continue;
+  for (typename edm::View<PATObjType>::const_iterator it = candidates->begin(), ed = candidates->end(); it != ed;
+       ++it) {
+    // Apply a preselection to the inputs and copy them in the output
+    if (!preselectionCut_(*it))
+      continue;
 
-      // Add it to the list and take a reference to it, so it can be modified (e.g. to set the overlaps)
-      // If at some point I'll decide to drop this item, I'll use pop_back to remove it
-      output->push_back(*it);
-      PATObjType &obj = output->back();
+    // Add it to the list and take a reference to it, so it can be modified (e.g. to set the overlaps)
+    // If at some point I'll decide to drop this item, I'll use pop_back to remove it
+    output->push_back(*it);
+    PATObjType& obj = output->back();
 
-      // Look for overlaps
-      bool badForOverlap = false;
-      for (auto& itov : overlapTests_) {
-        reco::CandidatePtrVector overlaps;
-        bool hasOverlap = itov->fillOverlapsForItem(obj, overlaps);
-        if (hasOverlap && itov->requireNoOverlaps()) {
-            badForOverlap = true; // mark for discarding
-            break; // no point in checking the others, as this item will be discarded
-        }
-        obj.setOverlaps(itov->name(), overlaps);
+    // Look for overlaps
+    bool badForOverlap = false;
+    for (auto& itov : overlapTests_) {
+      reco::CandidatePtrVector overlaps;
+      bool hasOverlap = itov->fillOverlapsForItem(obj, overlaps);
+      if (hasOverlap && itov->requireNoOverlaps()) {
+        badForOverlap = true;  // mark for discarding
+        break;                 // no point in checking the others, as this item will be discarded
       }
-      if (badForOverlap) { output->pop_back(); continue; }
+      obj.setOverlaps(itov->name(), overlaps);
+    }
+    if (badForOverlap) {
+      output->pop_back();
+      continue;
+    }
 
-      // Apply one final selection cut
-      if (!finalCut_(obj)) output->pop_back();
+    // Apply one final selection cut
+    if (!finalCut_(obj))
+      output->pop_back();
   }
 
   iEvent.put(std::move(output));
 }
-
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
@@ -10,71 +10,67 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <memory>
 
-
 #include <iostream>
 
 using namespace pat;
 using namespace std;
 using namespace edm;
 
-PATCompositeCandidateProducer::PATCompositeCandidateProducer(const ParameterSet & iConfig) :
-  srcToken_(consumes<edm::View<reco::CompositeCandidate> >(iConfig.getParameter<InputTag>( "src" ))),
-  useUserData_(iConfig.exists("userData")),
-  userDataHelper_( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() ),
-  addEfficiencies_(iConfig.getParameter<bool>("addEfficiencies")),  
-  addResolutions_(iConfig.getParameter<bool>("addResolutions"))
-{
- 
+PATCompositeCandidateProducer::PATCompositeCandidateProducer(const ParameterSet& iConfig)
+    : srcToken_(consumes<edm::View<reco::CompositeCandidate> >(iConfig.getParameter<InputTag>("src"))),
+      useUserData_(iConfig.exists("userData")),
+      userDataHelper_(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector()),
+      addEfficiencies_(iConfig.getParameter<bool>("addEfficiencies")),
+      addResolutions_(iConfig.getParameter<bool>("addResolutions")) {
   // Efficiency configurables
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
   if (addResolutions_) {
-     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
-  
+
   // produces vector of particles
   produces<vector<pat::CompositeCandidate> >();
-
 }
 
-PATCompositeCandidateProducer::~PATCompositeCandidateProducer() {
-}
+PATCompositeCandidateProducer::~PATCompositeCandidateProducer() {}
 
-void PATCompositeCandidateProducer::produce(Event & iEvent, const EventSetup & iSetup) {
+void PATCompositeCandidateProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   // Get the vector of CompositeCandidate's from the event
   Handle<View<reco::CompositeCandidate> > cands;
   iEvent.getByToken(srcToken_, cands);
 
-  if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
   auto myCompositeCandidates = std::make_unique<vector<pat::CompositeCandidate> >();
 
-  if ( cands.isValid() ) {
-
-    View<reco::CompositeCandidate>::const_iterator ibegin = cands->begin(),
-      iend = cands->end(), i = ibegin;
-    for ( ; i != iend; ++i ) {
-
+  if (cands.isValid()) {
+    View<reco::CompositeCandidate>::const_iterator ibegin = cands->begin(), iend = cands->end(), i = ibegin;
+    for (; i != iend; ++i) {
       pat::CompositeCandidate cand(*i);
 
-      if ( useUserData_ ) {
-	userDataHelper_.add( cand, iEvent, iSetup );
+      if (useUserData_) {
+        userDataHelper_.add(cand, iEvent, iSetup);
       }
 
-      if (efficiencyLoader_.enabled()) efficiencyLoader_.setEfficiencies( cand, cands->refAt(i - cands->begin()) );
-      if (resolutionLoader_.enabled()) resolutionLoader_.setResolutions(cand);
+      if (efficiencyLoader_.enabled())
+        efficiencyLoader_.setEfficiencies(cand, cands->refAt(i - cands->begin()));
+      if (resolutionLoader_.enabled())
+        resolutionLoader_.setResolutions(cand);
 
-      myCompositeCandidates->push_back( std::move(cand) );
+      myCompositeCandidates->push_back(std::move(cand));
     }
 
-  }// end if the two handles are valid
+  }  // end if the two handles are valid
 
   iEvent.put(std::move(myCompositeCandidates));
-
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.h
@@ -15,7 +15,6 @@
   \version  $Id: PATCompositeCandidateProducer.h,v 1.3 2009/06/25 23:49:35 gpetrucc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -38,30 +37,26 @@
 namespace pat {
 
   class PATCompositeCandidateProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATCompositeCandidateProducer(const edm::ParameterSet& iConfig);
+    ~PATCompositeCandidateProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATCompositeCandidateProducer(const edm::ParameterSet & iConfig);
-      ~PATCompositeCandidateProducer() override;
+  private:
+    // configurables
+    const edm::EDGetTokenT<edm::View<reco::CompositeCandidate> > srcToken_;  // list of reco::CompositeCandidates
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    const bool useUserData_;
+    pat::PATUserDataHelper<pat::CompositeCandidate> userDataHelper_;
 
-    private:
+    const bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      // configurables
-      const edm::EDGetTokenT<edm::View<reco::CompositeCandidate> > srcToken_;     // list of reco::CompositeCandidates
-
-      const bool useUserData_;
-      pat::PATUserDataHelper<pat::CompositeCandidate> userDataHelper_;
-
-      const bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
-
-      const bool addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
+    const bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATConversionProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATConversionProducer.h
@@ -30,29 +30,22 @@
 
 #include <string>
 
-
 namespace pat {
 
-
   class PATConversionProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PATConversionProducer(const edm::ParameterSet& iConfig);
+    ~PATConversionProducer() override;
 
-    public:
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
-      explicit PATConversionProducer(const edm::ParameterSet & iConfig);
-      ~PATConversionProducer() override;
-
-      void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
-
-    private:
-
-      // configurables
-      const edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
-      const edm::EDGetTokenT<reco::BeamSpot>                bsToken_;
-      const edm::EDGetTokenT<reco::ConversionCollection>    conversionsToken_;
-
+  private:
+    // configurables
+    const edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
+    const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+    const edm::EDGetTokenT<reco::ConversionCollection> conversionsToken_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -20,7 +20,6 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -47,81 +46,97 @@
 #include <vector>
 #include <memory>
 
-
 using namespace pat;
 using namespace std;
 
+PATElectronProducer::PATElectronProducer(const edm::ParameterSet& iConfig)
+    :  // general configurables
+      electronToken_(consumes<edm::View<reco::GsfElectron>>(iConfig.getParameter<edm::InputTag>("electronSource"))),
+      hConversionsToken_(consumes<reco::ConversionCollection>(edm::InputTag("allConversions"))),
+      embedGsfElectronCore_(iConfig.getParameter<bool>("embedGsfElectronCore")),
+      embedGsfTrack_(iConfig.getParameter<bool>("embedGsfTrack")),
+      embedSuperCluster_(iConfig.getParameter<bool>("embedSuperCluster")),
+      embedPflowSuperCluster_(iConfig.getParameter<bool>("embedPflowSuperCluster")),
+      embedSeedCluster_(iConfig.getParameter<bool>("embedSeedCluster")),
+      embedBasicClusters_(iConfig.getParameter<bool>("embedBasicClusters")),
+      embedPreshowerClusters_(iConfig.getParameter<bool>("embedPreshowerClusters")),
+      embedPflowBasicClusters_(iConfig.getParameter<bool>("embedPflowBasicClusters")),
+      embedPflowPreshowerClusters_(iConfig.getParameter<bool>("embedPflowPreshowerClusters")),
+      embedTrack_(iConfig.getParameter<bool>("embedTrack")),
+      addGenMatch_(iConfig.getParameter<bool>("addGenMatch")),
+      embedGenMatch_(addGenMatch_ ? iConfig.getParameter<bool>("embedGenMatch") : false),
+      embedRecHits_(iConfig.getParameter<bool>("embedRecHits")),
+      // pflow configurables
+      useParticleFlow_(iConfig.getParameter<bool>("useParticleFlow")),
+      usePfCandidateMultiMap_(iConfig.getParameter<bool>("usePfCandidateMultiMap")),
+      pfElecToken_(!usePfCandidateMultiMap_
+                       ? consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfElectronSource"))
+                       : edm::EDGetTokenT<reco::PFCandidateCollection>()),
+      pfCandidateMapToken_(!usePfCandidateMultiMap_ ? mayConsume<edm::ValueMap<reco::PFCandidatePtr>>(
+                                                          iConfig.getParameter<edm::InputTag>("pfCandidateMap"))
+                                                    : edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr>>()),
+      pfCandidateMultiMapToken_(usePfCandidateMultiMap_
+                                    ? consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+                                          iConfig.getParameter<edm::InputTag>("pfCandidateMultiMap"))
+                                    : edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>>()),
+      embedPFCandidate_(iConfig.getParameter<bool>("embedPFCandidate")),
+      // mva input variables
+      addMVAVariables_(iConfig.getParameter<bool>("addMVAVariables")),
+      reducedBarrelRecHitCollection_(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection")),
+      reducedBarrelRecHitCollectionToken_(mayConsume<EcalRecHitCollection>(reducedBarrelRecHitCollection_)),
+      reducedEndcapRecHitCollection_(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection")),
+      reducedEndcapRecHitCollectionToken_(mayConsume<EcalRecHitCollection>(reducedEndcapRecHitCollection_)),
+      // PFCluster Isolation maps
+      addPFClusterIso_(iConfig.getParameter<bool>("addPFClusterIso")),
+      addPuppiIsolation_(iConfig.getParameter<bool>("addPuppiIsolation")),
+      ecalPFClusterIsoT_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("ecalPFClusterIsoMap"))),
+      hcalPFClusterIsoT_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("hcalPFClusterIsoMap"))),
+      // embed high level selection variables?
+      embedHighLevelSelection_(iConfig.getParameter<bool>("embedHighLevelSelection")),
+      beamLineToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"))),
+      pvToken_(mayConsume<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("pvSrc"))),
+      addElecID_(iConfig.getParameter<bool>("addElectronID")),
+      pTComparator_(),
+      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
+                                                : edm::ParameterSet(),
+                consumesCollector(),
+                false),
+      addEfficiencies_(iConfig.getParameter<bool>("addEfficiencies")),
+      addResolutions_(iConfig.getParameter<bool>("addResolutions")),
+      useUserData_(iConfig.exists("userData"))
 
-PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
-  // general configurables
-  electronToken_(consumes<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ))),
-  hConversionsToken_(consumes<reco::ConversionCollection>(edm::InputTag("allConversions"))),
-  embedGsfElectronCore_(iConfig.getParameter<bool>( "embedGsfElectronCore" )),
-  embedGsfTrack_(iConfig.getParameter<bool>( "embedGsfTrack" )),
-  embedSuperCluster_(iConfig.getParameter<bool>         ( "embedSuperCluster"    )),
-  embedPflowSuperCluster_(iConfig.getParameter<bool>    ( "embedPflowSuperCluster"    )),
-  embedSeedCluster_(iConfig.getParameter<bool>( "embedSeedCluster" )),
-  embedBasicClusters_(iConfig.getParameter<bool>( "embedBasicClusters" )),
-  embedPreshowerClusters_(iConfig.getParameter<bool>( "embedPreshowerClusters" )),
-  embedPflowBasicClusters_(iConfig.getParameter<bool>( "embedPflowBasicClusters" )),
-  embedPflowPreshowerClusters_(iConfig.getParameter<bool>( "embedPflowPreshowerClusters" )),
-  embedTrack_(iConfig.getParameter<bool>( "embedTrack" )),  
-  addGenMatch_(iConfig.getParameter<bool>( "addGenMatch" )),
-  embedGenMatch_(addGenMatch_ ? iConfig.getParameter<bool>( "embedGenMatch" ) : false),
-  embedRecHits_(iConfig.getParameter<bool>( "embedRecHits" )),
-  // pflow configurables
-  useParticleFlow_(iConfig.getParameter<bool>( "useParticleFlow" )),
-  usePfCandidateMultiMap_(iConfig.getParameter<bool>( "usePfCandidateMultiMap" )),
-  pfElecToken_(!usePfCandidateMultiMap_ ? consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfElectronSource" )) : edm::EDGetTokenT<reco::PFCandidateCollection>()),
-  pfCandidateMapToken_(!usePfCandidateMultiMap_ ? mayConsume<edm::ValueMap<reco::PFCandidatePtr> >(iConfig.getParameter<edm::InputTag>( "pfCandidateMap" )) : edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr>>()),
-  pfCandidateMultiMapToken_(usePfCandidateMultiMap_ ? consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>( "pfCandidateMultiMap" )) : edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>>()),
-  embedPFCandidate_(iConfig.getParameter<bool>( "embedPFCandidate" )),
-  // mva input variables
-  addMVAVariables_(iConfig.getParameter<bool>("addMVAVariables")),
-  reducedBarrelRecHitCollection_(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection")),
-  reducedBarrelRecHitCollectionToken_(mayConsume<EcalRecHitCollection>(reducedBarrelRecHitCollection_)),
-  reducedEndcapRecHitCollection_(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection")),
-  reducedEndcapRecHitCollectionToken_(mayConsume<EcalRecHitCollection>(reducedEndcapRecHitCollection_)),
-  // PFCluster Isolation maps
-  addPFClusterIso_(iConfig.getParameter<bool>("addPFClusterIso")),
-  addPuppiIsolation_(iConfig.getParameter<bool>("addPuppiIsolation")),
-  ecalPFClusterIsoT_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("ecalPFClusterIsoMap"))),
-  hcalPFClusterIsoT_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("hcalPFClusterIsoMap"))),
-  // embed high level selection variables?
-  embedHighLevelSelection_(iConfig.getParameter<bool>("embedHighLevelSelection")),
-  beamLineToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"))),
-  pvToken_(mayConsume<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("pvSrc"))),  
-  addElecID_(iConfig.getParameter<bool>( "addElectronID" )),
-  pTComparator_(),
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false) ,
-  addEfficiencies_(iConfig.getParameter<bool>("addEfficiencies")),
-  addResolutions_(iConfig.getParameter<bool>( "addResolutions" )),
-  useUserData_(iConfig.exists("userData"))
-  
-{ 
+{
   // MC matching configurables (scheduled mode)
-  
+
   if (addGenMatch_) {
     if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
-    }
-    else {
-      genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    } else {
+      genMatchTokens_ = edm::vector_transform(
+          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
+          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
     }
   }
   // resolution configurables
   if (addResolutions_) {
     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
-  if(addPuppiIsolation_){
+  if (addPuppiIsolation_) {
     //puppi
-    PUPPIIsolation_charged_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
-    PUPPIIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
-    PUPPIIsolation_photons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
+    PUPPIIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
+    PUPPIIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
+    PUPPIIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
     //puppiNoLeptons
-    PUPPINoLeptonsIsolation_charged_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
-    PUPPINoLeptonsIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
-    PUPPINoLeptonsIsolation_photons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
+    PUPPINoLeptonsIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
+    PUPPINoLeptonsIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
+    PUPPINoLeptonsIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
   }
   // electron ID configurables
   if (addElecID_) {
@@ -132,27 +147,30 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
     // or there might be many of them
     if (iConfig.existsAs<edm::ParameterSet>("electronIDSources")) {
       // please don't configure me twice
-      if (!elecIDSrcs_.empty()){
-	throw cms::Exception("Configuration") << "PATElectronProducer: you can't specify both 'electronIDSource' and 'electronIDSources'\n";
+      if (!elecIDSrcs_.empty()) {
+        throw cms::Exception("Configuration")
+            << "PATElectronProducer: you can't specify both 'electronIDSource' and 'electronIDSources'\n";
       }
       // read the different electron ID names
       edm::ParameterSet idps = iConfig.getParameter<edm::ParameterSet>("electronIDSources");
       std::vector<std::string> names = idps.getParameterNamesForType<edm::InputTag>();
       for (std::vector<std::string>::const_iterator it = names.begin(), ed = names.end(); it != ed; ++it) {
-	elecIDSrcs_.push_back(NameTag(*it, idps.getParameter<edm::InputTag>(*it)));
+        elecIDSrcs_.push_back(NameTag(*it, idps.getParameter<edm::InputTag>(*it)));
       }
     }
     // but in any case at least once
-    if (elecIDSrcs_.empty()){
-      throw cms::Exception("Configuration") <<
-	"PATElectronProducer: id addElectronID is true, you must specify either:\n" <<
-	"\tInputTag electronIDSource = <someTag>\n" << "or\n" <<
-	"\tPSet electronIDSources = { \n" <<
-	"\t\tInputTag <someName> = <someTag>   // as many as you want \n " <<
-	"\t}\n";
+    if (elecIDSrcs_.empty()) {
+      throw cms::Exception("Configuration")
+          << "PATElectronProducer: id addElectronID is true, you must specify either:\n"
+          << "\tInputTag electronIDSource = <someTag>\n"
+          << "or\n"
+          << "\tPSet electronIDSources = { \n"
+          << "\t\tInputTag <someName> = <someTag>   // as many as you want \n "
+          << "\t}\n";
     }
   }
-  elecIDTokens_ = edm::vector_transform(elecIDSrcs_, [this](NameTag const & tag){return mayConsume<edm::ValueMap<float> >(tag.second);});
+  elecIDTokens_ = edm::vector_transform(
+      elecIDSrcs_, [this](NameTag const& tag) { return mayConsume<edm::ValueMap<float>>(tag.second); });
   // construct resolution calculator
 
   //   // IsoDeposit configurables
@@ -161,7 +179,6 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
   //      if (depconf.exists("tracker")) isoDepositLabels_.push_back(std::make_pair(TrackerIso, depconf.getParameter<edm::InputTag>("tracker")));
   //      if (depconf.exists("ecal"))    isoDepositLabels_.push_back(std::make_pair(ECalIso, depconf.getParameter<edm::InputTag>("ecal")));
   //      if (depconf.exists("hcal"))    isoDepositLabels_.push_back(std::make_pair(HCalIso, depconf.getParameter<edm::InputTag>("hcal")));
-
 
   //      if (depconf.exists("user")) {
   //         std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
@@ -176,13 +193,13 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
 
   // for mini-iso
   computeMiniIso_ = iConfig.getParameter<bool>("computeMiniIso");
-  miniIsoParamsE_ = iConfig.getParameter<std::vector<double> >("miniIsoParamsE");
-  miniIsoParamsB_ = iConfig.getParameter<std::vector<double> >("miniIsoParamsB");
-  if(computeMiniIso_ && (miniIsoParamsE_.size() != 9 || miniIsoParamsB_.size() != 9)){
-      throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
+  miniIsoParamsE_ = iConfig.getParameter<std::vector<double>>("miniIsoParamsE");
+  miniIsoParamsB_ = iConfig.getParameter<std::vector<double>>("miniIsoParamsB");
+  if (computeMiniIso_ && (miniIsoParamsE_.size() != 9 || miniIsoParamsB_.size() != 9)) {
+    throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
   }
-  if(computeMiniIso_)
-      pcToken_ = consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
+  if (computeMiniIso_)
+    pcToken_ = consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
 
   // read isoDeposit labels, for direct embedding
   readIsolationLabels(iConfig, "isoDeposits", isoDepositLabels_, isoDepositTokens_);
@@ -192,51 +209,50 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
   readIsolationLabels(iConfig, "isolationValuesNoPFId", isolationValueLabelsNoPFId_, isolationValueNoPFIdTokens_);
   // Efficiency configurables
   if (addEfficiencies_) {
-    efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
   // Check to see if the user wants to add user data
-  if ( useUserData_ ) {
-    userDataHelper_ = PATUserDataHelper<Electron>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
+  if (useUserData_) {
+    userDataHelper_ =
+        PATUserDataHelper<Electron>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
-  
+
   // consistency check
-  if (useParticleFlow_ && usePfCandidateMultiMap_) throw cms::Exception("Configuration", "usePfCandidateMultiMap not supported when useParticleFlow is set to true");
- 
+  if (useParticleFlow_ && usePfCandidateMultiMap_)
+    throw cms::Exception("Configuration", "usePfCandidateMultiMap not supported when useParticleFlow is set to true");
+
   // produces vector of muons
-  produces<std::vector<Electron> >();
-  }
-
-
-  PATElectronProducer::~PATElectronProducer()
-{
+  produces<std::vector<Electron>>();
 }
 
+PATElectronProducer::~PATElectronProducer() {}
 
-void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
+void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // switch off embedding (in unschedules mode)
-  if (iEvent.isRealData()){
+  if (iEvent.isRealData()) {
     addGenMatch_ = false;
     embedGenMatch_ = false;
   }
 
   edm::ESHandle<CaloTopology> theCaloTopology;
   iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
-  ecalTopology_ = & (*theCaloTopology);
+  ecalTopology_ = &(*theCaloTopology);
 
   // Get the collection of electrons from the event
-  edm::Handle<edm::View<reco::GsfElectron> > electrons;
+  edm::Handle<edm::View<reco::GsfElectron>> electrons;
   iEvent.getByToken(electronToken_, electrons);
 
-  edm::Handle<PackedCandidateCollection > pc;
-  if(computeMiniIso_)
-      iEvent.getByToken(pcToken_, pc);
+  edm::Handle<PackedCandidateCollection> pc;
+  if (computeMiniIso_)
+    iEvent.getByToken(pcToken_, pc);
 
   // for additional mva variables
-  edm::InputTag  reducedEBRecHitCollection(string("reducedEcalRecHitsEB"));
-  edm::InputTag  reducedEERecHitCollection(string("reducedEcalRecHitsEE"));
+  edm::InputTag reducedEBRecHitCollection(string("reducedEcalRecHitsEB"));
+  edm::InputTag reducedEERecHitCollection(string("reducedEcalRecHitsEE"));
   //EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollection, reducedEERecHitCollection);
-  EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+  EcalClusterLazyTools lazyTools(
+      iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
 
   // for conversion veto selection
   edm::Handle<reco::ConversionCollection> hConversions;
@@ -246,10 +262,13 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   // high level selection embedding
   edm::ESHandle<TransientTrackBuilder> trackBuilder;
 
-  if (isolator_.enabled()) isolator_.beginEvent(iEvent,iSetup);
+  if (isolator_.enabled())
+    isolator_.beginEvent(iEvent, iSetup);
 
-  if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
   IsoDepositMaps deposits(isoDepositTokens_.size());
   for (size_t j = 0, nd = isoDepositTokens_.size(); j < nd; ++j) {
@@ -257,12 +276,12 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   }
 
   IsolationValueMaps isolationValues(isolationValueTokens_.size());
-  for (size_t j = 0; j<isolationValueTokens_.size(); ++j) {
+  for (size_t j = 0; j < isolationValueTokens_.size(); ++j) {
     iEvent.getByToken(isolationValueTokens_[j], isolationValues[j]);
   }
 
   IsolationValueMaps isolationValuesNoPFId(isolationValueNoPFIdTokens_.size());
-  for (size_t j = 0; j<isolationValueNoPFIdTokens_.size(); ++j) {
+  for (size_t j = 0; j < isolationValueNoPFIdTokens_.size(); ++j) {
     iEvent.getByToken(isolationValueNoPFIdTokens_[j], isolationValuesNoPFId[j]);
   }
 
@@ -275,8 +294,8 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   }
 
   // prepare ID extraction
-  std::vector<edm::Handle<edm::ValueMap<float> > > idhandles;
-  std::vector<pat::Electron::IdPair>               ids;
+  std::vector<edm::Handle<edm::ValueMap<float>>> idhandles;
+  std::vector<pat::Electron::IdPair> ids;
   if (addElecID_) {
     idhandles.resize(elecIDSrcs_.size());
     ids.resize(elecIDSrcs_.size());
@@ -286,10 +305,9 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
     }
   }
 
-
   // prepare the high level selection:
   // needs beamline
-  reco::TrackBase::Point beamPoint(0,0,0);
+  reco::TrackBase::Point beamPoint(0, 0, 0);
   reco::Vertex primaryVertex;
   reco::BeamSpot beamSpot;
   bool beamSpotIsValid = false;
@@ -299,20 +317,20 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   edm::Handle<reco::BeamSpot> beamSpotHandle;
   iEvent.getByToken(beamLineToken_, beamSpotHandle);
 
-  if ( embedHighLevelSelection_ ) {
+  if (embedHighLevelSelection_) {
     // Get the primary vertex
-    edm::Handle< std::vector<reco::Vertex> > pvHandle;
-    iEvent.getByToken( pvToken_, pvHandle );
+    edm::Handle<std::vector<reco::Vertex>> pvHandle;
+    iEvent.getByToken(pvToken_, pvHandle);
 
     // This is needed by the IPTools methods from the tracking group
     iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
 
-    if ( pvHandle.isValid() && !pvHandle->empty() ) {
-        primaryVertex = pvHandle->at(0);
-        primaryVertexIsValid = true;
+    if (pvHandle.isValid() && !pvHandle->empty()) {
+      primaryVertex = pvHandle->at(0);
+      primaryVertexIsValid = true;
     } else {
-        edm::LogError("DataNotAvailable")
-            << "No primary vertex available from EventSetup, not adding high level selection \n";
+      edm::LogError("DataNotAvailable")
+          << "No primary vertex available from EventSetup, not adding high level selection \n";
     }
   }
   //value maps for puppi isolation
@@ -323,295 +341,294 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons;
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons;
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons;
-  if(addPuppiIsolation_){
+  if (addPuppiIsolation_) {
     //puppi
     iEvent.getByToken(PUPPIIsolation_charged_hadrons_, PUPPIIsolation_charged_hadrons);
     iEvent.getByToken(PUPPIIsolation_neutral_hadrons_, PUPPIIsolation_neutral_hadrons);
-    iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);  
+    iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);
     //puppiNoLeptons
     iEvent.getByToken(PUPPINoLeptonsIsolation_charged_hadrons_, PUPPINoLeptonsIsolation_charged_hadrons);
     iEvent.getByToken(PUPPINoLeptonsIsolation_neutral_hadrons_, PUPPINoLeptonsIsolation_neutral_hadrons);
-    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);  
+    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);
   }
-  
 
-  std::vector<Electron> * patElectrons = new std::vector<Electron>();
+  std::vector<Electron>* patElectrons = new std::vector<Electron>();
 
-  if( useParticleFlow_ ) {
-    edm::Handle< reco::PFCandidateCollection >  pfElectrons;
+  if (useParticleFlow_) {
+    edm::Handle<reco::PFCandidateCollection> pfElectrons;
     iEvent.getByToken(pfElecToken_, pfElectrons);
-    unsigned index=0;
+    unsigned index = 0;
 
-    for( reco::PFCandidateConstIterator i = pfElectrons->begin();
-	 i != pfElectrons->end(); ++i, ++index) {
-
+    for (reco::PFCandidateConstIterator i = pfElectrons->begin(); i != pfElectrons->end(); ++i, ++index) {
       reco::PFCandidateRef pfRef(pfElectrons, index);
-      reco::PFCandidatePtr ptrToPFElectron(pfElectrons,index);
-//       reco::CandidateBaseRef pfBaseRef( pfRef );
+      reco::PFCandidatePtr ptrToPFElectron(pfElectrons, index);
+      //       reco::CandidateBaseRef pfBaseRef( pfRef );
 
-      reco::GsfTrackRef PfTk= i->gsfTrackRef();
+      reco::GsfTrackRef PfTk = i->gsfTrackRef();
 
-      bool Matched=false;
-      bool MatchedToAmbiguousGsfTrack=false;
-      for (edm::View<reco::GsfElectron>::const_iterator itElectron = electrons->begin(); itElectron != electrons->end(); ++itElectron) {
-	unsigned int idx = itElectron - electrons->begin();
-  	auto elePtr = electrons -> ptrAt(idx);
-	if (Matched || MatchedToAmbiguousGsfTrack) continue;
+      bool Matched = false;
+      bool MatchedToAmbiguousGsfTrack = false;
+      for (edm::View<reco::GsfElectron>::const_iterator itElectron = electrons->begin(); itElectron != electrons->end();
+           ++itElectron) {
+        unsigned int idx = itElectron - electrons->begin();
+        auto elePtr = electrons->ptrAt(idx);
+        if (Matched || MatchedToAmbiguousGsfTrack)
+          continue;
 
-	reco::GsfTrackRef EgTk= itElectron->gsfTrack();
+        reco::GsfTrackRef EgTk = itElectron->gsfTrack();
 
-	if (itElectron->gsfTrack()==i->gsfTrackRef()){
-	  Matched=true;
-	}
-	else {
-	  for( reco::GsfTrackRefVector::const_iterator it = itElectron->ambiguousGsfTracksBegin() ;
-	       it!=itElectron->ambiguousGsfTracksEnd(); it++ ){
-	    MatchedToAmbiguousGsfTrack |= (bool)(i->gsfTrackRef()==(*it));
-	  }
-	}
+        if (itElectron->gsfTrack() == i->gsfTrackRef()) {
+          Matched = true;
+        } else {
+          for (reco::GsfTrackRefVector::const_iterator it = itElectron->ambiguousGsfTracksBegin();
+               it != itElectron->ambiguousGsfTracksEnd();
+               it++) {
+            MatchedToAmbiguousGsfTrack |= (bool)(i->gsfTrackRef() == (*it));
+          }
+        }
 
-	if (Matched || MatchedToAmbiguousGsfTrack){
+        if (Matched || MatchedToAmbiguousGsfTrack) {
+          // ptr needed for finding the matched gen particle
+          reco::CandidatePtr ptrToGsfElectron(electrons, idx);
 
-	  // ptr needed for finding the matched gen particle
-	  reco::CandidatePtr ptrToGsfElectron(electrons,idx);
-
-	  // ref to base needed for the construction of the pat object
-	  const edm::RefToBase<reco::GsfElectron>& elecsRef = electrons->refAt(idx);
-	  Electron anElectron(elecsRef);
-	  anElectron.setPFCandidateRef( pfRef  );
-    	  if (addPuppiIsolation_) {		 
-	    anElectron.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[elePtr], (*PUPPIIsolation_neutral_hadrons)[elePtr], (*PUPPIIsolation_photons)[elePtr]);
-      	    anElectron.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[elePtr], (*PUPPINoLeptonsIsolation_neutral_hadrons)[elePtr], (*PUPPINoLeptonsIsolation_photons)[elePtr]);
-    	  }
-	  else {
-      	    anElectron.setIsolationPUPPI(-999., -999.,-999.);
-	    anElectron.setIsolationPUPPINoLeptons(-999., -999.,-999.);
+          // ref to base needed for the construction of the pat object
+          const edm::RefToBase<reco::GsfElectron>& elecsRef = electrons->refAt(idx);
+          Electron anElectron(elecsRef);
+          anElectron.setPFCandidateRef(pfRef);
+          if (addPuppiIsolation_) {
+            anElectron.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[elePtr],
+                                         (*PUPPIIsolation_neutral_hadrons)[elePtr],
+                                         (*PUPPIIsolation_photons)[elePtr]);
+            anElectron.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[elePtr],
+                                                  (*PUPPINoLeptonsIsolation_neutral_hadrons)[elePtr],
+                                                  (*PUPPINoLeptonsIsolation_photons)[elePtr]);
+          } else {
+            anElectron.setIsolationPUPPI(-999., -999., -999.);
+            anElectron.setIsolationPUPPINoLeptons(-999., -999., -999.);
           }
 
           //it should be always true when particleFlow electrons are used.
-          anElectron.setIsPF( true );
+          anElectron.setIsPF(true);
 
-	  if( embedPFCandidate_ ) anElectron.embedPFCandidate();
+          if (embedPFCandidate_)
+            anElectron.embedPFCandidate();
 
-	  if ( useUserData_ ) {
-	    userDataHelper_.add( anElectron, iEvent, iSetup );
-	  }
+          if (useUserData_) {
+            userDataHelper_.add(anElectron, iEvent, iSetup);
+          }
 
-          double ip3d = -999; // for mva variable
+          double ip3d = -999;  // for mva variable
 
-	  // embed high level selection
-	  if ( embedHighLevelSelection_ ) {
-	    // get the global track
-	    const reco::GsfTrackRef& track = PfTk;
+          // embed high level selection
+          if (embedHighLevelSelection_) {
+            // get the global track
+            const reco::GsfTrackRef& track = PfTk;
 
-	    // Make sure the collection it points to is there
-	    if ( track.isNonnull() && track.isAvailable() ) {
+            // Make sure the collection it points to is there
+            if (track.isNonnull() && track.isAvailable()) {
+              reco::TransientTrack tt = trackBuilder->build(track);
+              embedHighLevel(anElectron, track, tt, primaryVertex, primaryVertexIsValid, beamSpot, beamSpotIsValid);
 
-	      reco::TransientTrack tt = trackBuilder->build(track);
-	      embedHighLevel( anElectron,
-			      track,
-			      tt,
-			      primaryVertex,
-			      primaryVertexIsValid,
-			      beamSpot,
-			      beamSpotIsValid );
+              std::pair<bool, Measurement1D> ip3dpv = IPTools::absoluteImpactParameter3D(tt, primaryVertex);
+              ip3d = ip3dpv.second.value();  // for mva variable
+            }
+          }
 
-              std::pair<bool,Measurement1D> ip3dpv = IPTools::absoluteImpactParameter3D(tt, primaryVertex);
-              ip3d = ip3dpv.second.value(); // for mva variable
-	    }
-	  }
+          //Electron Id
 
-	  //Electron Id
-
-	  if (addElecID_) {
-	    //STANDARD EL ID
-	    for (size_t i = 0; i < elecIDSrcs_.size(); ++i) {
-	      ids[i].second = (*idhandles[i])[elecsRef];
-	    }
-	    //SPECIFIC PF ID
-	    ids.push_back(std::make_pair("pf_evspi",pfRef->mva_e_pi()));
-	    ids.push_back(std::make_pair("pf_evsmu",pfRef->mva_e_mu()));
-	    anElectron.setElectronIDs(ids);
-	  }
+          if (addElecID_) {
+            //STANDARD EL ID
+            for (size_t i = 0; i < elecIDSrcs_.size(); ++i) {
+              ids[i].second = (*idhandles[i])[elecsRef];
+            }
+            //SPECIFIC PF ID
+            ids.push_back(std::make_pair("pf_evspi", pfRef->mva_e_pi()));
+            ids.push_back(std::make_pair("pf_evsmu", pfRef->mva_e_mu()));
+            anElectron.setElectronIDs(ids);
+          }
 
           if (addMVAVariables_) {
             // add missing mva variables
-            std::vector<float> vCov = lazyTools.localCovariances(*( itElectron->superCluster()->seed()));
+            std::vector<float> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
             anElectron.setMvaVariables(vCov[1], ip3d);
           }
-	  // PFClusterIso
-	  if (addPFClusterIso_) {
-	    // Get PFCluster Isolation
-	    edm::Handle<edm::ValueMap<float> > ecalPFClusterIsoMapH;
-	    iEvent.getByToken(ecalPFClusterIsoT_, ecalPFClusterIsoMapH);
-	    edm::Handle<edm::ValueMap<float> > hcalPFClusterIsoMapH;
-	    iEvent.getByToken(hcalPFClusterIsoT_, hcalPFClusterIsoMapH);
-	    reco::GsfElectron::PflowIsolationVariables newPFIsol = anElectron.pfIsolationVariables();
-	    newPFIsol.sumEcalClusterEt = (*ecalPFClusterIsoMapH)[elecsRef];
-	    newPFIsol.sumHcalClusterEt = (*hcalPFClusterIsoMapH)[elecsRef];
-	    anElectron.setPfIsolationVariables(newPFIsol);
-	  }
- 
-	  std::vector<DetId> selectedCells;
+          // PFClusterIso
+          if (addPFClusterIso_) {
+            // Get PFCluster Isolation
+            edm::Handle<edm::ValueMap<float>> ecalPFClusterIsoMapH;
+            iEvent.getByToken(ecalPFClusterIsoT_, ecalPFClusterIsoMapH);
+            edm::Handle<edm::ValueMap<float>> hcalPFClusterIsoMapH;
+            iEvent.getByToken(hcalPFClusterIsoT_, hcalPFClusterIsoMapH);
+            reco::GsfElectron::PflowIsolationVariables newPFIsol = anElectron.pfIsolationVariables();
+            newPFIsol.sumEcalClusterEt = (*ecalPFClusterIsoMapH)[elecsRef];
+            newPFIsol.sumHcalClusterEt = (*hcalPFClusterIsoMapH)[elecsRef];
+            anElectron.setPfIsolationVariables(newPFIsol);
+          }
+
+          std::vector<DetId> selectedCells;
           bool barrel = itElectron->isEB();
           //loop over sub clusters
           if (embedBasicClusters_) {
-            for (reco::CaloCluster_iterator clusIt = itElectron->superCluster()->clustersBegin(); clusIt!=itElectron->superCluster()->clustersEnd(); ++clusIt) {
+            for (reco::CaloCluster_iterator clusIt = itElectron->superCluster()->clustersBegin();
+                 clusIt != itElectron->superCluster()->clustersEnd();
+                 ++clusIt) {
               //get seed (max energy xtal)
               DetId seed = lazyTools.getMaximum(**clusIt).first;
               //get all xtals in 5x5 window around the seed
-              std::vector<DetId> dets5x5 = (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalBarrel)->getWindow(seed,5,5):
-            ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalEndcap)->getWindow(seed,5,5);
+              std::vector<DetId> dets5x5 =
+                  (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalBarrel)->getWindow(seed, 5, 5)
+                           : ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalEndcap)->getWindow(seed, 5, 5);
               selectedCells.insert(selectedCells.end(), dets5x5.begin(), dets5x5.end());
-              
+
               //get all xtals belonging to cluster
-              for (const std::pair<DetId, float> &hit : (*clusIt)->hitsAndFractions()) {
+              for (const std::pair<DetId, float>& hit : (*clusIt)->hitsAndFractions()) {
                 selectedCells.push_back(hit.first);
               }
             }
           }
-          
+
           if (embedPflowBasicClusters_ && itElectron->parentSuperCluster().isNonnull()) {
-            for (reco::CaloCluster_iterator clusIt = itElectron->parentSuperCluster()->clustersBegin(); clusIt!=itElectron->parentSuperCluster()->clustersEnd(); ++clusIt) {
+            for (reco::CaloCluster_iterator clusIt = itElectron->parentSuperCluster()->clustersBegin();
+                 clusIt != itElectron->parentSuperCluster()->clustersEnd();
+                 ++clusIt) {
               //get seed (max energy xtal)
               DetId seed = lazyTools.getMaximum(**clusIt).first;
               //get all xtals in 5x5 window around the seed
-              std::vector<DetId> dets5x5 = (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalBarrel)->getWindow(seed,5,5):
-            ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalEndcap)->getWindow(seed,5,5);
+              std::vector<DetId> dets5x5 =
+                  (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalBarrel)->getWindow(seed, 5, 5)
+                           : ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalEndcap)->getWindow(seed, 5, 5);
               selectedCells.insert(selectedCells.end(), dets5x5.begin(), dets5x5.end());
-              
+
               //get all xtals belonging to cluster
-              for (const std::pair<DetId, float> &hit : (*clusIt)->hitsAndFractions()) {
+              for (const std::pair<DetId, float>& hit : (*clusIt)->hitsAndFractions()) {
                 selectedCells.push_back(hit.first);
               }
             }
           }
-          
+
           //remove duplicates
-          std::sort(selectedCells.begin(),selectedCells.end());
-          std::unique(selectedCells.begin(),selectedCells.end());
-          
+          std::sort(selectedCells.begin(), selectedCells.end());
+          std::unique(selectedCells.begin(), selectedCells.end());
 
-	  // Retrieve the corresponding RecHits
+          // Retrieve the corresponding RecHits
 
-	  edm::Handle< EcalRecHitCollection > rechitsH ;
-	  if(barrel)
-	    iEvent.getByToken(reducedBarrelRecHitCollectionToken_,rechitsH);
-	  else
-	    iEvent.getByToken(reducedEndcapRecHitCollectionToken_,rechitsH);
+          edm::Handle<EcalRecHitCollection> rechitsH;
+          if (barrel)
+            iEvent.getByToken(reducedBarrelRecHitCollectionToken_, rechitsH);
+          else
+            iEvent.getByToken(reducedEndcapRecHitCollectionToken_, rechitsH);
 
-	  EcalRecHitCollection selectedRecHits;
-	  const EcalRecHitCollection *recHits = rechitsH.product();
+          EcalRecHitCollection selectedRecHits;
+          const EcalRecHitCollection* recHits = rechitsH.product();
 
-	  unsigned nSelectedCells = selectedCells.size();
-	  for (unsigned icell = 0 ; icell < nSelectedCells ; ++icell) {
-	   EcalRecHitCollection::const_iterator  it = recHits->find( selectedCells[icell] );
-	    if ( it != recHits->end() ) {
-	      selectedRecHits.push_back(*it);
-	    }
-	  }
-	  selectedRecHits.sort();
-	  if (embedRecHits_) anElectron.embedRecHits(& selectedRecHits);
+          unsigned nSelectedCells = selectedCells.size();
+          for (unsigned icell = 0; icell < nSelectedCells; ++icell) {
+            EcalRecHitCollection::const_iterator it = recHits->find(selectedCells[icell]);
+            if (it != recHits->end()) {
+              selectedRecHits.push_back(*it);
+            }
+          }
+          selectedRecHits.sort();
+          if (embedRecHits_)
+            anElectron.embedRecHits(&selectedRecHits);
 
-	    // set conversion veto selection
+          // set conversion veto selection
           bool passconversionveto = false;
-          if( hConversions.isValid()){
+          if (hConversions.isValid()) {
             // this is recommended method
-            passconversionveto = !ConversionTools::hasMatchedConversion( *itElectron, *hConversions, beamSpotHandle->position());
-          }else{
+            passconversionveto =
+                !ConversionTools::hasMatchedConversion(*itElectron, *hConversions, beamSpotHandle->position());
+          } else {
             // use missing hits without vertex fit method
-            passconversionveto = itElectron->gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) < 1;
+            passconversionveto =
+                itElectron->gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) < 1;
           }
 
-          anElectron.setPassConversionVeto( passconversionveto );
+          anElectron.setPassConversionVeto(passconversionveto);
 
+          // 	  fillElectron(anElectron,elecsRef,pfBaseRef,
+          // 		       genMatches, deposits, isolationValues);
 
-// 	  fillElectron(anElectron,elecsRef,pfBaseRef,
-// 		       genMatches, deposits, isolationValues);
+          //COLIN small warning !
+          // we are currently choosing to take the 4-momentum of the PFCandidate;
+          // the momentum of the GsfElectron is saved though
+          // we must therefore match the GsfElectron.
+          // because of this, we should not change the source of the electron matcher
+          // to the collection of PFElectrons in the python configuration
+          // I don't know what to do with the efficiencyLoader, since I don't know
+          // what this class is for.
+          fillElectron2(
+              anElectron, ptrToPFElectron, ptrToGsfElectron, ptrToGsfElectron, genMatches, deposits, isolationValues);
 
-	  //COLIN small warning !
-	  // we are currently choosing to take the 4-momentum of the PFCandidate;
-	  // the momentum of the GsfElectron is saved though
-	  // we must therefore match the GsfElectron.
-	  // because of this, we should not change the source of the electron matcher
-	  // to the collection of PFElectrons in the python configuration
-	  // I don't know what to do with the efficiencyLoader, since I don't know
-	  // what this class is for.
-	  fillElectron2( anElectron,
-			 ptrToPFElectron,
-			 ptrToGsfElectron,
-			 ptrToGsfElectron,
-			 genMatches, deposits, isolationValues );
+          //COLIN need to use fillElectron2 in the non-pflow case as well, and to test it.
 
-	  //COLIN need to use fillElectron2 in the non-pflow case as well, and to test it.
+          if (computeMiniIso_)
+            setElectronMiniIso(anElectron, pc.product());
 
-          if(computeMiniIso_)
-              setElectronMiniIso(anElectron, pc.product());
-
-	  patElectrons->push_back(anElectron);
-	}
+          patElectrons->push_back(anElectron);
+        }
       }
       //if( !Matched && !MatchedToAmbiguousGsfTrack) std::cout << "!!!!A pf electron could not be matched to a gsf!!!!"  << std::endl;
     }
   }
 
-  else{
-    edm::Handle<reco::PFCandidateCollection>  pfElectrons;
+  else {
+    edm::Handle<reco::PFCandidateCollection> pfElectrons;
     edm::Handle<edm::ValueMap<reco::PFCandidatePtr>> ValMapH;
     edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> ValMultiMapH;
     bool pfCandsPresent = false, valMapPresent = false;
     if (usePfCandidateMultiMap_) {
-        iEvent.getByToken(pfCandidateMultiMapToken_, ValMultiMapH);
+      iEvent.getByToken(pfCandidateMultiMapToken_, ValMultiMapH);
     } else {
-        pfCandsPresent = iEvent.getByToken(pfElecToken_, pfElectrons);
-        valMapPresent = iEvent.getByToken(pfCandidateMapToken_,ValMapH);
+      pfCandsPresent = iEvent.getByToken(pfElecToken_, pfElectrons);
+      valMapPresent = iEvent.getByToken(pfCandidateMapToken_, ValMapH);
     }
 
-    for (edm::View<reco::GsfElectron>::const_iterator itElectron = electrons->begin(); itElectron != electrons->end(); ++itElectron) {
+    for (edm::View<reco::GsfElectron>::const_iterator itElectron = electrons->begin(); itElectron != electrons->end();
+         ++itElectron) {
       // construct the Electron from the ref -> save ref to original object
       //FIXME: looks like a lot of instances could be turned into const refs
       unsigned int idx = itElectron - electrons->begin();
       edm::RefToBase<reco::GsfElectron> elecsRef = electrons->refAt(idx);
       reco::CandidateBaseRef elecBaseRef(elecsRef);
       Electron anElectron(elecsRef);
-      auto elePtr = electrons -> ptrAt(idx);
+      auto elePtr = electrons->ptrAt(idx);
 
       // Is this GsfElectron also identified as an e- in the particle flow?
       bool pfId = false;
 
       if (usePfCandidateMultiMap_) {
         for (const reco::PFCandidateRef& pf : (*ValMultiMapH)[elePtr]) {
-            if (pf->particleId() == reco::PFCandidate::e) {
-                pfId = true;
-                anElectron.setPFCandidateRef( pf );
-                break;
-            }
+          if (pf->particleId() == reco::PFCandidate::e) {
+            pfId = true;
+            anElectron.setPFCandidateRef(pf);
+            break;
+          }
         }
-      } else if ( pfCandsPresent ) {
-	// PF electron collection not available.
-	const reco::GsfTrackRef& trkRef = itElectron->gsfTrack();
-	int index = 0;
-	for( reco::PFCandidateConstIterator ie = pfElectrons->begin();
-	     ie != pfElectrons->end(); ++ie, ++index) {
-	  if(ie->particleId()!=reco::PFCandidate::e) continue;
-	  const reco::GsfTrackRef& pfTrkRef= ie->gsfTrackRef();
-	  if( trkRef == pfTrkRef ) {
-	    pfId = true;
-	    reco::PFCandidateRef pfRef(pfElectrons, index);
-	    anElectron.setPFCandidateRef( pfRef );
-	    break;
-	  }
-	}
-      }
-      else if( valMapPresent ) {
+      } else if (pfCandsPresent) {
+        // PF electron collection not available.
+        const reco::GsfTrackRef& trkRef = itElectron->gsfTrack();
+        int index = 0;
+        for (reco::PFCandidateConstIterator ie = pfElectrons->begin(); ie != pfElectrons->end(); ++ie, ++index) {
+          if (ie->particleId() != reco::PFCandidate::e)
+            continue;
+          const reco::GsfTrackRef& pfTrkRef = ie->gsfTrackRef();
+          if (trkRef == pfTrkRef) {
+            pfId = true;
+            reco::PFCandidateRef pfRef(pfElectrons, index);
+            anElectron.setPFCandidateRef(pfRef);
+            break;
+          }
+        }
+      } else if (valMapPresent) {
         // use value map if PF collection not available
-	const edm::ValueMap<reco::PFCandidatePtr> & myValMap(*ValMapH);
-	// Get the PFCandidate
-	const reco::PFCandidatePtr& pfElePtr(myValMap[elecsRef]);
-	pfId= pfElePtr.isNonnull();
+        const edm::ValueMap<reco::PFCandidatePtr>& myValMap(*ValMapH);
+        // Get the PFCandidate
+        const reco::PFCandidatePtr& pfElePtr(myValMap[elecsRef]);
+        pfId = pfElePtr.isNonnull();
       }
       // set PFId function
-      anElectron.setIsPF( pfId );
+      anElectron.setIsPF(pfId);
 
       // add resolution info
 
@@ -620,8 +637,11 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
         isolator_.fill(*electrons, idx, isolatorTmpStorage_);
         typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
         // better to loop backwards, so the vector is resized less times
-        for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(), ed = isolatorTmpStorage_.rend(); it != ed; ++it) {
-	  anElectron.setIsolation(it->first, it->second);
+        for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(),
+                                                         ed = isolatorTmpStorage_.rend();
+             it != ed;
+             ++it) {
+          anElectron.setIsolation(it->first, it->second);
         }
       }
 
@@ -632,147 +652,149 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
       // add electron ID info
       if (addElecID_) {
         for (size_t i = 0; i < elecIDSrcs_.size(); ++i) {
-	  ids[i].second = (*idhandles[i])[elecsRef];
+          ids[i].second = (*idhandles[i])[elecsRef];
         }
         anElectron.setElectronIDs(ids);
       }
 
-
-      if ( useUserData_ ) {
-	userDataHelper_.add( anElectron, iEvent, iSetup );
+      if (useUserData_) {
+        userDataHelper_.add(anElectron, iEvent, iSetup);
       }
 
-
-      double ip3d = -999; //for mva variable
+      double ip3d = -999;  //for mva variable
 
       // embed high level selection
-      if ( embedHighLevelSelection_ ) {
-	// get the global track
-	reco::GsfTrackRef track = itElectron->gsfTrack();
+      if (embedHighLevelSelection_) {
+        // get the global track
+        reco::GsfTrackRef track = itElectron->gsfTrack();
 
-	// Make sure the collection it points to is there
-	if ( track.isNonnull() && track.isAvailable() ) {
+        // Make sure the collection it points to is there
+        if (track.isNonnull() && track.isAvailable()) {
+          reco::TransientTrack tt = trackBuilder->build(track);
+          embedHighLevel(anElectron, track, tt, primaryVertex, primaryVertexIsValid, beamSpot, beamSpotIsValid);
 
-	  reco::TransientTrack tt = trackBuilder->build(track);
-	  embedHighLevel( anElectron,
-			  track,
-			  tt,
-			  primaryVertex,
-			  primaryVertexIsValid,
-			  beamSpot,
-			  beamSpotIsValid );
-
-          std::pair<bool,Measurement1D> ip3dpv = IPTools::absoluteImpactParameter3D(tt, primaryVertex);
-          ip3d = ip3dpv.second.value(); // for mva variable
-
-	}
+          std::pair<bool, Measurement1D> ip3dpv = IPTools::absoluteImpactParameter3D(tt, primaryVertex);
+          ip3d = ip3dpv.second.value();  // for mva variable
+        }
       }
 
       if (addMVAVariables_) {
         // add mva variables
-        std::vector<float> vCov = lazyTools.localCovariances(*( itElectron->superCluster()->seed()));
+        std::vector<float> vCov = lazyTools.localCovariances(*(itElectron->superCluster()->seed()));
         anElectron.setMvaVariables(vCov[1], ip3d);
       }
-      
+
       // PFCluster Isolation
       if (addPFClusterIso_) {
-	// Get PFCluster Isolation
-	edm::Handle<edm::ValueMap<float> > ecalPFClusterIsoMapH;
-	iEvent.getByToken(ecalPFClusterIsoT_, ecalPFClusterIsoMapH);
-	edm::Handle<edm::ValueMap<float> > hcalPFClusterIsoMapH;
-	iEvent.getByToken(hcalPFClusterIsoT_, hcalPFClusterIsoMapH);
-	reco::GsfElectron::PflowIsolationVariables newPFIsol = anElectron.pfIsolationVariables();
-	newPFIsol.sumEcalClusterEt = (*ecalPFClusterIsoMapH)[elecsRef];
-	newPFIsol.sumHcalClusterEt = (*hcalPFClusterIsoMapH)[elecsRef];
-	anElectron.setPfIsolationVariables(newPFIsol);
+        // Get PFCluster Isolation
+        edm::Handle<edm::ValueMap<float>> ecalPFClusterIsoMapH;
+        iEvent.getByToken(ecalPFClusterIsoT_, ecalPFClusterIsoMapH);
+        edm::Handle<edm::ValueMap<float>> hcalPFClusterIsoMapH;
+        iEvent.getByToken(hcalPFClusterIsoT_, hcalPFClusterIsoMapH);
+        reco::GsfElectron::PflowIsolationVariables newPFIsol = anElectron.pfIsolationVariables();
+        newPFIsol.sumEcalClusterEt = (*ecalPFClusterIsoMapH)[elecsRef];
+        newPFIsol.sumHcalClusterEt = (*hcalPFClusterIsoMapH)[elecsRef];
+        anElectron.setPfIsolationVariables(newPFIsol);
       }
-      
+
       if (addPuppiIsolation_) {
-        anElectron.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[elePtr], (*PUPPIIsolation_neutral_hadrons)[elePtr], (*PUPPIIsolation_photons)[elePtr]);
-        anElectron.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[elePtr], (*PUPPINoLeptonsIsolation_neutral_hadrons)[elePtr], (*PUPPINoLeptonsIsolation_photons)[elePtr]);
+        anElectron.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[elePtr],
+                                     (*PUPPIIsolation_neutral_hadrons)[elePtr],
+                                     (*PUPPIIsolation_photons)[elePtr]);
+        anElectron.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[elePtr],
+                                              (*PUPPINoLeptonsIsolation_neutral_hadrons)[elePtr],
+                                              (*PUPPINoLeptonsIsolation_photons)[elePtr]);
+      } else {
+        anElectron.setIsolationPUPPI(-999., -999., -999.);
+        anElectron.setIsolationPUPPINoLeptons(-999., -999., -999.);
       }
-      else {
-        anElectron.setIsolationPUPPI(-999., -999.,-999.);
-        anElectron.setIsolationPUPPINoLeptons(-999., -999.,-999.);
-      }
-        
+
       std::vector<DetId> selectedCells;
       bool barrel = itElectron->isEB();
       //loop over sub clusters
       if (embedBasicClusters_) {
-        for (reco::CaloCluster_iterator clusIt = itElectron->superCluster()->clustersBegin(); clusIt!=itElectron->superCluster()->clustersEnd(); ++clusIt) {
+        for (reco::CaloCluster_iterator clusIt = itElectron->superCluster()->clustersBegin();
+             clusIt != itElectron->superCluster()->clustersEnd();
+             ++clusIt) {
           //get seed (max energy xtal)
           DetId seed = lazyTools.getMaximum(**clusIt).first;
           //get all xtals in 5x5 window around the seed
-          std::vector<DetId> dets5x5 = (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalBarrel)->getWindow(seed,5,5):
-        ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalEndcap)->getWindow(seed,5,5);
+          std::vector<DetId> dets5x5 =
+              (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalBarrel)->getWindow(seed, 5, 5)
+                       : ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalEndcap)->getWindow(seed, 5, 5);
           selectedCells.insert(selectedCells.end(), dets5x5.begin(), dets5x5.end());
-          
+
           //get all xtals belonging to cluster
-          for (const std::pair<DetId, float> &hit : (*clusIt)->hitsAndFractions()) {
+          for (const std::pair<DetId, float>& hit : (*clusIt)->hitsAndFractions()) {
             selectedCells.push_back(hit.first);
           }
         }
       }
-      
+
       if (embedPflowBasicClusters_ && itElectron->parentSuperCluster().isNonnull()) {
-        for (reco::CaloCluster_iterator clusIt = itElectron->parentSuperCluster()->clustersBegin(); clusIt!=itElectron->parentSuperCluster()->clustersEnd(); ++clusIt) {
+        for (reco::CaloCluster_iterator clusIt = itElectron->parentSuperCluster()->clustersBegin();
+             clusIt != itElectron->parentSuperCluster()->clustersEnd();
+             ++clusIt) {
           //get seed (max energy xtal)
           DetId seed = lazyTools.getMaximum(**clusIt).first;
           //get all xtals in 5x5 window around the seed
-          std::vector<DetId> dets5x5 = (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalBarrel)->getWindow(seed,5,5):
-        ecalTopology_->getSubdetectorTopology(DetId::Ecal,EcalEndcap)->getWindow(seed,5,5);
+          std::vector<DetId> dets5x5 =
+              (barrel) ? ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalBarrel)->getWindow(seed, 5, 5)
+                       : ecalTopology_->getSubdetectorTopology(DetId::Ecal, EcalEndcap)->getWindow(seed, 5, 5);
           selectedCells.insert(selectedCells.end(), dets5x5.begin(), dets5x5.end());
-          
+
           //get all xtals belonging to cluster
-          for (const std::pair<DetId, float> &hit : (*clusIt)->hitsAndFractions()) {
+          for (const std::pair<DetId, float>& hit : (*clusIt)->hitsAndFractions()) {
             selectedCells.push_back(hit.first);
           }
         }
       }
-      
+
       //remove duplicates
-      std::sort(selectedCells.begin(),selectedCells.end());
-      std::unique(selectedCells.begin(),selectedCells.end());
-      
+      std::sort(selectedCells.begin(), selectedCells.end());
+      std::unique(selectedCells.begin(), selectedCells.end());
+
       // Retrieve the corresponding RecHits
 
-      edm::Handle< EcalRecHitCollection > rechitsH ;
-      if(barrel)
-	iEvent.getByToken(reducedBarrelRecHitCollectionToken_,rechitsH);
+      edm::Handle<EcalRecHitCollection> rechitsH;
+      if (barrel)
+        iEvent.getByToken(reducedBarrelRecHitCollectionToken_, rechitsH);
       else
-	iEvent.getByToken(reducedEndcapRecHitCollectionToken_,rechitsH);
+        iEvent.getByToken(reducedEndcapRecHitCollectionToken_, rechitsH);
 
       EcalRecHitCollection selectedRecHits;
-      const EcalRecHitCollection *recHits = rechitsH.product();
+      const EcalRecHitCollection* recHits = rechitsH.product();
 
       unsigned nSelectedCells = selectedCells.size();
-      for (unsigned icell = 0 ; icell < nSelectedCells ; ++icell) {
-        EcalRecHitCollection::const_iterator  it = recHits->find( selectedCells[icell] );
-	if ( it != recHits->end() ) {
-	  selectedRecHits.push_back(*it);
-	}
+      for (unsigned icell = 0; icell < nSelectedCells; ++icell) {
+        EcalRecHitCollection::const_iterator it = recHits->find(selectedCells[icell]);
+        if (it != recHits->end()) {
+          selectedRecHits.push_back(*it);
+        }
       }
       selectedRecHits.sort();
-      if (embedRecHits_) anElectron.embedRecHits(& selectedRecHits);
+      if (embedRecHits_)
+        anElectron.embedRecHits(&selectedRecHits);
 
       // set conversion veto selection
       bool passconversionveto = false;
-      if( hConversions.isValid()){
+      if (hConversions.isValid()) {
         // this is recommended method
-        passconversionveto = !ConversionTools::hasMatchedConversion( *itElectron, *hConversions, beamSpotHandle->position());
-      }else{
+        passconversionveto =
+            !ConversionTools::hasMatchedConversion(*itElectron, *hConversions, beamSpotHandle->position());
+      } else {
         // use missing hits without vertex fit method
-        passconversionveto = itElectron->gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) < 1;
+        passconversionveto =
+            itElectron->gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) < 1;
       }
-      anElectron.setPassConversionVeto( passconversionveto );
+      anElectron.setPassConversionVeto(passconversionveto);
 
       // add sel to selected
-      fillElectron( anElectron, elecsRef,elecBaseRef,
-		    genMatches, deposits, pfId, isolationValues, isolationValuesNoPFId);
+      fillElectron(
+          anElectron, elecsRef, elecBaseRef, genMatches, deposits, pfId, isolationValues, isolationValuesNoPFId);
 
-      if(computeMiniIso_)
-          setElectronMiniIso(anElectron, pc.product());
+      if (computeMiniIso_)
+        setElectronMiniIso(anElectron, pc.product());
 
       patElectrons->push_back(anElectron);
     }
@@ -782,24 +804,22 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   std::sort(patElectrons->begin(), patElectrons->end(), pTComparator_);
 
   // add the electrons to the event output
-  std::unique_ptr<std::vector<Electron> > ptr(patElectrons);
+  std::unique_ptr<std::vector<Electron>> ptr(patElectrons);
   iEvent.put(std::move(ptr));
 
   // clean up
-  if (isolator_.enabled()) isolator_.endEvent();
-
+  if (isolator_.enabled())
+    isolator_.endEvent();
 }
 
 void PATElectronProducer::fillElectron(Electron& anElectron,
-				       const edm::RefToBase<reco::GsfElectron>& elecRef,
-				       const reco::CandidateBaseRef& baseRef,
-				       const GenAssociations& genMatches,
-				       const IsoDepositMaps& deposits,
+                                       const edm::RefToBase<reco::GsfElectron>& elecRef,
+                                       const reco::CandidateBaseRef& baseRef,
+                                       const GenAssociations& genMatches,
+                                       const IsoDepositMaps& deposits,
                                        const bool pfId,
-				       const IsolationValueMaps& isolationValues,
-				       const IsolationValueMaps& isolationValuesNoPFId
-				       ) const {
-
+                                       const IsolationValueMaps& isolationValues,
+                                       const IsolationValueMaps& isolationValuesNoPFId) const {
   //COLIN: might want to use the PFCandidate 4-mom. Which one is in use now?
   //   if (useParticleFlow_)
   //     aMuon.setP4( aMuon.pfCandidateRef()->p4() );
@@ -817,34 +837,44 @@ void PATElectronProducer::fillElectron(Electron& anElectron,
   // is the concrete elecRef needed for the efficiency loader? what is this loader?
   // how can we make it compatible with the particle flow electrons?
 
-  if (embedGsfElectronCore_) anElectron.embedGsfElectronCore();
-  if (embedGsfTrack_) anElectron.embedGsfTrack();
-  if (embedSuperCluster_) anElectron.embedSuperCluster();
-  if (embedPflowSuperCluster_) anElectron.embedPflowSuperCluster();
-  if (embedSeedCluster_) anElectron.embedSeedCluster();
-  if (embedBasicClusters_) anElectron.embedBasicClusters();
-  if (embedPreshowerClusters_) anElectron.embedPreshowerClusters();
-  if (embedPflowBasicClusters_ ) anElectron.embedPflowBasicClusters();
-  if (embedPflowPreshowerClusters_ ) anElectron.embedPflowPreshowerClusters();
-  if (embedTrack_) anElectron.embedTrack();
+  if (embedGsfElectronCore_)
+    anElectron.embedGsfElectronCore();
+  if (embedGsfTrack_)
+    anElectron.embedGsfTrack();
+  if (embedSuperCluster_)
+    anElectron.embedSuperCluster();
+  if (embedPflowSuperCluster_)
+    anElectron.embedPflowSuperCluster();
+  if (embedSeedCluster_)
+    anElectron.embedSeedCluster();
+  if (embedBasicClusters_)
+    anElectron.embedBasicClusters();
+  if (embedPreshowerClusters_)
+    anElectron.embedPreshowerClusters();
+  if (embedPflowBasicClusters_)
+    anElectron.embedPflowBasicClusters();
+  if (embedPflowPreshowerClusters_)
+    anElectron.embedPflowPreshowerClusters();
+  if (embedTrack_)
+    anElectron.embedTrack();
 
   // store the match to the generated final state muons
   if (addGenMatch_) {
-    for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
-      if(useParticleFlow_) {
-	reco::GenParticleRef genElectron = (*genMatches[i])[anElectron.pfCandidateRef()];
-	anElectron.addGenParticleRef(genElectron);
-      }
-      else {
-	reco::GenParticleRef genElectron = (*genMatches[i])[elecRef];
-	anElectron.addGenParticleRef(genElectron);
+    for (size_t i = 0, n = genMatches.size(); i < n; ++i) {
+      if (useParticleFlow_) {
+        reco::GenParticleRef genElectron = (*genMatches[i])[anElectron.pfCandidateRef()];
+        anElectron.addGenParticleRef(genElectron);
+      } else {
+        reco::GenParticleRef genElectron = (*genMatches[i])[elecRef];
+        anElectron.addGenParticleRef(genElectron);
       }
     }
-    if (embedGenMatch_) anElectron.embedGenParticle();
+    if (embedGenMatch_)
+      anElectron.embedGenParticle();
   }
 
   if (efficiencyLoader_.enabled()) {
-    efficiencyLoader_.setEfficiencies( anElectron, elecRef );
+    efficiencyLoader_.setEfficiencies(anElectron, elecRef);
   }
 
   if (resolutionLoader_.enabled()) {
@@ -852,80 +882,81 @@ void PATElectronProducer::fillElectron(Electron& anElectron,
   }
 
   for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-    if(useParticleFlow_) {
-
-      reco::PFCandidateRef pfcandref =  anElectron.pfCandidateRef();
+    if (useParticleFlow_) {
+      reco::PFCandidateRef pfcandref = anElectron.pfCandidateRef();
       assert(!pfcandref.isNull());
       reco::CandidatePtr source = pfcandref->sourceCandidatePtr(0);
-      anElectron.setIsoDeposit(isoDepositLabels_[j].first,
-			  (*deposits[j])[source]);
-    }
-    else
-      anElectron.setIsoDeposit(isoDepositLabels_[j].first,
-                          (*deposits[j])[elecRef]);
+      anElectron.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[source]);
+    } else
+      anElectron.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[elecRef]);
   }
 
-  for (size_t j = 0; j<isolationValues.size(); ++j) {
-    if(useParticleFlow_) {
+  for (size_t j = 0; j < isolationValues.size(); ++j) {
+    if (useParticleFlow_) {
       reco::CandidatePtr source = anElectron.pfCandidateRef()->sourceCandidatePtr(0);
-      anElectron.setIsolation(isolationValueLabels_[j].first,
-			 (*isolationValues[j])[source]);
+      anElectron.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[source]);
+    } else if (pfId) {
+      anElectron.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[elecRef]);
     }
-    else
-      if(pfId){
-        anElectron.setIsolation(isolationValueLabels_[j].first,(*isolationValues[j])[elecRef]);
-      }
   }
 
   //for electrons not identified as PF electrons
-  for (size_t j = 0; j<isolationValuesNoPFId.size(); ++j) {
-    if( !pfId) {
-      anElectron.setIsolation(isolationValueLabelsNoPFId_[j].first,(*isolationValuesNoPFId[j])[elecRef]);
+  for (size_t j = 0; j < isolationValuesNoPFId.size(); ++j) {
+    if (!pfId) {
+      anElectron.setIsolation(isolationValueLabelsNoPFId_[j].first, (*isolationValuesNoPFId[j])[elecRef]);
     }
   }
-
 }
 
-void PATElectronProducer::fillElectron2( Electron& anElectron,
-					 const reco::CandidatePtr& candPtrForIsolation,
-					 const reco::CandidatePtr& candPtrForGenMatch,
-					 const reco::CandidatePtr& candPtrForLoader,
-					 const GenAssociations& genMatches,
-					 const IsoDepositMaps& deposits,
-					 const IsolationValueMaps& isolationValues) const {
-
+void PATElectronProducer::fillElectron2(Electron& anElectron,
+                                        const reco::CandidatePtr& candPtrForIsolation,
+                                        const reco::CandidatePtr& candPtrForGenMatch,
+                                        const reco::CandidatePtr& candPtrForLoader,
+                                        const GenAssociations& genMatches,
+                                        const IsoDepositMaps& deposits,
+                                        const IsolationValueMaps& isolationValues) const {
   //COLIN/Florian: use the PFCandidate 4-mom.
-  anElectron.setEcalDrivenMomentum(anElectron.p4()) ;
-  anElectron.setP4( anElectron.pfCandidateRef()->p4() );
-
+  anElectron.setEcalDrivenMomentum(anElectron.p4());
+  anElectron.setP4(anElectron.pfCandidateRef()->p4());
 
   // is the concrete elecRef needed for the efficiency loader? what is this loader?
   // how can we make it compatible with the particle flow electrons?
 
-  if (embedGsfElectronCore_) anElectron.embedGsfElectronCore();
-  if (embedGsfTrack_) anElectron.embedGsfTrack();
-  if (embedSuperCluster_) anElectron.embedSuperCluster();
-  if (embedPflowSuperCluster_ ) anElectron.embedPflowSuperCluster();
-  if (embedSeedCluster_) anElectron.embedSeedCluster();
-  if (embedBasicClusters_) anElectron.embedBasicClusters();
-  if (embedPreshowerClusters_) anElectron.embedPreshowerClusters();
-  if (embedPflowBasicClusters_ ) anElectron.embedPflowBasicClusters();
-  if (embedPflowPreshowerClusters_ ) anElectron.embedPflowPreshowerClusters();
-  if (embedTrack_) anElectron.embedTrack();
+  if (embedGsfElectronCore_)
+    anElectron.embedGsfElectronCore();
+  if (embedGsfTrack_)
+    anElectron.embedGsfTrack();
+  if (embedSuperCluster_)
+    anElectron.embedSuperCluster();
+  if (embedPflowSuperCluster_)
+    anElectron.embedPflowSuperCluster();
+  if (embedSeedCluster_)
+    anElectron.embedSeedCluster();
+  if (embedBasicClusters_)
+    anElectron.embedBasicClusters();
+  if (embedPreshowerClusters_)
+    anElectron.embedPreshowerClusters();
+  if (embedPflowBasicClusters_)
+    anElectron.embedPflowBasicClusters();
+  if (embedPflowPreshowerClusters_)
+    anElectron.embedPflowPreshowerClusters();
+  if (embedTrack_)
+    anElectron.embedTrack();
 
   // store the match to the generated final state muons
 
   if (addGenMatch_) {
-    for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
+    for (size_t i = 0, n = genMatches.size(); i < n; ++i) {
       reco::GenParticleRef genElectron = (*genMatches[i])[candPtrForGenMatch];
       anElectron.addGenParticleRef(genElectron);
     }
-    if (embedGenMatch_) anElectron.embedGenParticle();
+    if (embedGenMatch_)
+      anElectron.embedGenParticle();
   }
 
   //COLIN what's this? does it have to be GsfElectron specific?
   if (efficiencyLoader_.enabled()) {
-    efficiencyLoader_.setEfficiencies( anElectron, candPtrForLoader );
+    efficiencyLoader_.setEfficiencies(anElectron, candPtrForLoader);
   }
 
   if (resolutionLoader_.enabled()) {
@@ -933,62 +964,60 @@ void PATElectronProducer::fillElectron2( Electron& anElectron,
   }
 
   for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-    if( isoDepositLabels_[j].first==pat::TrackIso ||
-	isoDepositLabels_[j].first==pat::EcalIso ||
-	isoDepositLabels_[j].first==pat::HcalIso ||
-	deposits[j]->contains(candPtrForGenMatch.id())) {
-      anElectron.setIsoDeposit(isoDepositLabels_[j].first,
- 			       (*deposits[j])[candPtrForGenMatch]);
-    }
-    else if (deposits[j]->contains(candPtrForIsolation.id())) {
-      anElectron.setIsoDeposit(isoDepositLabels_[j].first,
- 			       (*deposits[j])[candPtrForIsolation]);
-    }
-    else {
-      anElectron.setIsoDeposit(isoDepositLabels_[j].first,
-			       (*deposits[j])[candPtrForIsolation->sourceCandidatePtr(0)]);
+    if (isoDepositLabels_[j].first == pat::TrackIso || isoDepositLabels_[j].first == pat::EcalIso ||
+        isoDepositLabels_[j].first == pat::HcalIso || deposits[j]->contains(candPtrForGenMatch.id())) {
+      anElectron.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[candPtrForGenMatch]);
+    } else if (deposits[j]->contains(candPtrForIsolation.id())) {
+      anElectron.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[candPtrForIsolation]);
+    } else {
+      anElectron.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[candPtrForIsolation->sourceCandidatePtr(0)]);
     }
   }
 
-  for (size_t j = 0; j<isolationValues.size(); ++j) {
-    if( isolationValueLabels_[j].first==pat::TrackIso ||
-	isolationValueLabels_[j].first==pat::EcalIso ||
-	isolationValueLabels_[j].first==pat::HcalIso ||
-	isolationValues[j]->contains(candPtrForGenMatch.id())) {
+  for (size_t j = 0; j < isolationValues.size(); ++j) {
+    if (isolationValueLabels_[j].first == pat::TrackIso || isolationValueLabels_[j].first == pat::EcalIso ||
+        isolationValueLabels_[j].first == pat::HcalIso || isolationValues[j]->contains(candPtrForGenMatch.id())) {
+      anElectron.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[candPtrForGenMatch]);
+    } else if (isolationValues[j]->contains(candPtrForIsolation.id())) {
+      anElectron.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[candPtrForIsolation]);
+    } else {
       anElectron.setIsolation(isolationValueLabels_[j].first,
- 			      (*isolationValues[j])[candPtrForGenMatch]);
-    }
-    else if (isolationValues[j]->contains(candPtrForIsolation.id())) {
-      anElectron.setIsolation(isolationValueLabels_[j].first,
- 			      (*isolationValues[j])[candPtrForIsolation]);
-    }
-    else {
-      anElectron.setIsolation(isolationValueLabels_[j].first,
-			      (*isolationValues[j])[candPtrForIsolation->sourceCandidatePtr(0)]);
+                              (*isolationValues[j])[candPtrForIsolation->sourceCandidatePtr(0)]);
     }
   }
 }
 
-void PATElectronProducer::setElectronMiniIso(Electron& anElectron, const PackedCandidateCollection *pc)
-{
+void PATElectronProducer::setElectronMiniIso(Electron& anElectron, const PackedCandidateCollection* pc) {
   pat::PFIsolation miniiso;
-  if(anElectron.isEE())
-      miniiso = pat::getMiniPFIsolation(pc, anElectron.p4(),
-                                        miniIsoParamsE_[0], miniIsoParamsE_[1], miniIsoParamsE_[2],
-                                        miniIsoParamsE_[3], miniIsoParamsE_[4], miniIsoParamsE_[5],
-                                        miniIsoParamsE_[6], miniIsoParamsE_[7], miniIsoParamsE_[8]);
+  if (anElectron.isEE())
+    miniiso = pat::getMiniPFIsolation(pc,
+                                      anElectron.p4(),
+                                      miniIsoParamsE_[0],
+                                      miniIsoParamsE_[1],
+                                      miniIsoParamsE_[2],
+                                      miniIsoParamsE_[3],
+                                      miniIsoParamsE_[4],
+                                      miniIsoParamsE_[5],
+                                      miniIsoParamsE_[6],
+                                      miniIsoParamsE_[7],
+                                      miniIsoParamsE_[8]);
   else
-      miniiso = pat::getMiniPFIsolation(pc, anElectron.p4(),
-                                        miniIsoParamsB_[0], miniIsoParamsB_[1], miniIsoParamsB_[2],
-                                        miniIsoParamsB_[3], miniIsoParamsB_[4], miniIsoParamsB_[5],
-                                        miniIsoParamsB_[6], miniIsoParamsB_[7], miniIsoParamsB_[8]);
+    miniiso = pat::getMiniPFIsolation(pc,
+                                      anElectron.p4(),
+                                      miniIsoParamsB_[0],
+                                      miniIsoParamsB_[1],
+                                      miniIsoParamsB_[2],
+                                      miniIsoParamsB_[3],
+                                      miniIsoParamsB_[4],
+                                      miniIsoParamsB_[5],
+                                      miniIsoParamsB_[6],
+                                      miniIsoParamsB_[7],
+                                      miniIsoParamsB_[8]);
   anElectron.setMiniPFIsolation(miniiso);
-
 }
 
 // ParameterSet description for module
-void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT electron producer module");
 
@@ -996,21 +1025,41 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   iDesc.add<edm::InputTag>("pfCandidateMap", edm::InputTag("no default"))->setComment("input collection");
   iDesc.add<edm::InputTag>("electronSource", edm::InputTag("no default"))->setComment("input collection");
 
-  iDesc.ifValue(edm::ParameterDescription<bool>("addPFClusterIso", false, true),
-		true >> (edm::ParameterDescription<edm::InputTag>("ecalPFClusterIsoMap", edm::InputTag("electronEcalPFClusterIsolationProducer"), true) and
-			 edm::ParameterDescription<edm::InputTag>("hcalPFClusterIsoMap", edm::InputTag("electronHcalPFClusterIsolationProducer"),true)) or
-		false >> (edm::ParameterDescription<edm::InputTag>("ecalPFClusterIsoMap", edm::InputTag(""), true) and
-			  edm::ParameterDescription<edm::InputTag>("hcalPFClusterIsoMap", edm::InputTag(""),true)));
+  iDesc.ifValue(
+      edm::ParameterDescription<bool>("addPFClusterIso", false, true),
+      true >> (edm::ParameterDescription<edm::InputTag>(
+                   "ecalPFClusterIsoMap", edm::InputTag("electronEcalPFClusterIsolationProducer"), true) and
+               edm::ParameterDescription<edm::InputTag>(
+                   "hcalPFClusterIsoMap", edm::InputTag("electronHcalPFClusterIsolationProducer"), true)) or
+          false >> (edm::ParameterDescription<edm::InputTag>("ecalPFClusterIsoMap", edm::InputTag(""), true) and
+                    edm::ParameterDescription<edm::InputTag>("hcalPFClusterIsoMap", edm::InputTag(""), true)));
 
   iDesc.ifValue(edm::ParameterDescription<bool>("addPuppiIsolation", false, true),
-    true >> (edm::ParameterDescription<edm::InputTag>("puppiIsolationChargedHadrons", edm::InputTag("egmElectronPUPPIIsolation","h+-DR030-BarVeto000-EndVeto001"), true) and
-       edm::ParameterDescription<edm::InputTag>("puppiIsolationNeutralHadrons", edm::InputTag("egmElectronPUPPIIsolation","h0-DR030-BarVeto000-EndVeto000"), true) and 
-       edm::ParameterDescription<edm::InputTag>("puppiIsolationPhotons", edm::InputTag("egmElectronPUPPIIsolation","gamma-DR030-BarVeto000-EndVeto008"), true) and
-       edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons", edm::InputTag("egmElectronPUPPINoLeptonsIsolation","gamma-DR030-BarVeto000-EndVeto008"), true) and 
-       edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons", edm::InputTag("egmElectronPUPPINoLeptonsIsolation","gamma-DR030-BarVeto000-EndVeto008"), true) and 
-       edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationPhotons", edm::InputTag("egmElectronPUPPINoLeptonsIsolation","gamma-DR030-BarVeto000-EndVeto008"), true))  or
-    false >> edm::EmptyGroupDescription());
-    
+                true >> (edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationChargedHadrons",
+                             edm::InputTag("egmElectronPUPPIIsolation", "h+-DR030-BarVeto000-EndVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationNeutralHadrons",
+                             edm::InputTag("egmElectronPUPPIIsolation", "h0-DR030-BarVeto000-EndVeto000"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationPhotons",
+                             edm::InputTag("egmElectronPUPPIIsolation", "gamma-DR030-BarVeto000-EndVeto008"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationChargedHadrons",
+                             edm::InputTag("egmElectronPUPPINoLeptonsIsolation", "gamma-DR030-BarVeto000-EndVeto008"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationNeutralHadrons",
+                             edm::InputTag("egmElectronPUPPINoLeptonsIsolation", "gamma-DR030-BarVeto000-EndVeto008"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationPhotons",
+                             edm::InputTag("egmElectronPUPPINoLeptonsIsolation", "gamma-DR030-BarVeto000-EndVeto008"),
+                             true)) or
+                    false >> edm::EmptyGroupDescription());
 
   // embedding
   iDesc.add<bool>("embedGsfElectronCore", true)->setComment("embed external gsf electron core");
@@ -1026,12 +1075,15 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   iDesc.add<bool>("embedRecHits", true)->setComment("embed external RecHits");
 
   // pf specific parameters
-  iDesc.add<edm::InputTag>("pfElectronSource", edm::InputTag("pfElectrons"))->setComment("particle flow input collection");
-  auto && usePfCandidateMultiMap = edm::ParameterDescription<bool>("usePfCandidateMultiMap", false, true);
-  usePfCandidateMultiMap.setComment("take ParticleFlow candidates from pfCandidateMultiMap instead of matching to pfElectrons by Gsf track reference");
+  iDesc.add<edm::InputTag>("pfElectronSource", edm::InputTag("pfElectrons"))
+      ->setComment("particle flow input collection");
+  auto&& usePfCandidateMultiMap = edm::ParameterDescription<bool>("usePfCandidateMultiMap", false, true);
+  usePfCandidateMultiMap.setComment(
+      "take ParticleFlow candidates from pfCandidateMultiMap instead of matching to pfElectrons by Gsf track "
+      "reference");
   iDesc.ifValue(usePfCandidateMultiMap,
-    true  >> edm::ParameterDescription<edm::InputTag>("pfCandidateMultiMap", true) or
-    false >> edm::EmptyGroupDescription());
+                true >> edm::ParameterDescription<edm::InputTag>("pfCandidateMultiMap", true) or
+                    false >> edm::EmptyGroupDescription());
   iDesc.add<bool>("useParticleFlow", false)->setComment("whether to use particle flow or not");
   iDesc.add<bool>("embedPFCandidate", false)->setComment("embed external particle flow object");
 
@@ -1039,24 +1091,29 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");
   iDesc.add<bool>("embedGenMatch", false)->setComment("embed MC matched MC information");
   std::vector<edm::InputTag> emptySourceVector;
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
-                 edm::ParameterDescription<std::vector<edm::InputTag> >("genParticleMatch", emptySourceVector, true)
-		 )->setComment("input with MC match information");
+  iDesc
+      .addNode(edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
+               edm::ParameterDescription<std::vector<edm::InputTag>>("genParticleMatch", emptySourceVector, true))
+      ->setComment("input with MC match information");
 
   // electron ID configurables
-  iDesc.add<bool>("addElectronID",true)->setComment("add electron ID variables");
+  iDesc.add<bool>("addElectronID", true)->setComment("add electron ID variables");
   edm::ParameterSetDescription electronIDSourcesPSet;
   electronIDSourcesPSet.setAllowAnything();
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("electronIDSource", edm::InputTag(), true) xor
-                 edm::ParameterDescription<edm::ParameterSetDescription>("electronIDSources", electronIDSourcesPSet, true)
-                 )->setComment("input with electron ID variables");
-
+  iDesc
+      .addNode(
+          edm::ParameterDescription<edm::InputTag>("electronIDSource", edm::InputTag(), true) xor
+          edm::ParameterDescription<edm::ParameterSetDescription>("electronIDSources", electronIDSourcesPSet, true))
+      ->setComment("input with electron ID variables");
 
   // mini-iso
   iDesc.add<bool>("computeMiniIso", false)->setComment("whether or not to compute and store electron mini-isolation");
-  iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))->setComment("collection to use to compute mini-iso");
-  iDesc.add<std::vector<double> >("miniIsoParamsE", std::vector<double>())->setComment("mini-iso parameters to use for endcap electrons");
-  iDesc.add<std::vector<double> >("miniIsoParamsB", std::vector<double>())->setComment("mini-iso parameters to use for barrel electrons");
+  iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))
+      ->setComment("collection to use to compute mini-iso");
+  iDesc.add<std::vector<double>>("miniIsoParamsE", std::vector<double>())
+      ->setComment("mini-iso parameters to use for endcap electrons");
+  iDesc.add<std::vector<double>>("miniIsoParamsB", std::vector<double>())
+      ->setComment("mini-iso parameters to use for barrel electrons");
 
   // IsoDeposit configurables
   edm::ParameterSetDescription isoDepositsPSet;
@@ -1069,7 +1126,7 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   isoDepositsPSet.addOptional<edm::InputTag>("pfPUChargedHadrons");
   isoDepositsPSet.addOptional<edm::InputTag>("pfNeutralHadrons");
   isoDepositsPSet.addOptional<edm::InputTag>("pfPhotons");
-  isoDepositsPSet.addOptional<std::vector<edm::InputTag> >("user");
+  isoDepositsPSet.addOptional<std::vector<edm::InputTag>>("user");
   iDesc.addOptional("isoDeposits", isoDepositsPSet);
 
   // isolation values configurables
@@ -1083,7 +1140,7 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   isolationValuesPSet.addOptional<edm::InputTag>("pfPUChargedHadrons");
   isolationValuesPSet.addOptional<edm::InputTag>("pfNeutralHadrons");
   isolationValuesPSet.addOptional<edm::InputTag>("pfPhotons");
-  isolationValuesPSet.addOptional<std::vector<edm::InputTag> >("user");
+  isolationValuesPSet.addOptional<std::vector<edm::InputTag>>("user");
   iDesc.addOptional("isolationValues", isolationValuesPSet);
 
   // isolation values configurables
@@ -1097,12 +1154,12 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   isolationValuesNoPFIdPSet.addOptional<edm::InputTag>("pfPUChargedHadrons");
   isolationValuesNoPFIdPSet.addOptional<edm::InputTag>("pfNeutralHadrons");
   isolationValuesNoPFIdPSet.addOptional<edm::InputTag>("pfPhotons");
-  isolationValuesNoPFIdPSet.addOptional<std::vector<edm::InputTag> >("user");
+  isolationValuesNoPFIdPSet.addOptional<std::vector<edm::InputTag>>("user");
   iDesc.addOptional("isolationValuesNoPFId", isolationValuesNoPFIdPSet);
 
   // Efficiency configurables
   edm::ParameterSetDescription efficienciesPSet;
-  efficienciesPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  efficienciesPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("efficiencies", efficienciesPSet);
   iDesc.add<bool>("addEfficiencies", false);
 
@@ -1111,14 +1168,13 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   PATUserDataHelper<Electron>::fillDescription(userDataPSet);
   iDesc.addOptional("userData", userDataPSet);
 
-
   // electron shapes
   iDesc.add<bool>("addMVAVariables", true)->setComment("embed extra variables in pat::Electron : sip3d, sigmaIEtaIPhi");
   iDesc.add<edm::InputTag>("reducedBarrelRecHitCollection", edm::InputTag("reducedEcalRecHitsEB"));
   iDesc.add<edm::InputTag>("reducedEndcapRecHitCollection", edm::InputTag("reducedEcalRecHitsEE"));
 
   edm::ParameterSetDescription isolationPSet;
-  isolationPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  isolationPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("userIsolation", isolationPSet);
 
   // Resolution configurables
@@ -1127,81 +1183,57 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
   iDesc.add<bool>("embedHighLevelSelection", true)->setComment("embed high level selection");
   edm::ParameterSetDescription highLevelPSet;
   highLevelPSet.setAllowAnything();
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true)
-                 )->setComment("input with high level selection");
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true)
-                 )->setComment("input with high level selection");
+  iDesc.addNode(edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true))
+      ->setComment("input with high level selection");
+  iDesc.addNode(edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true))
+      ->setComment("input with high level selection");
 
   descriptions.add("PATElectronProducer", iDesc);
-
 }
-
 
 // embed various impact parameters with errors
 // embed high level selection
-void PATElectronProducer::embedHighLevel( pat::Electron & anElectron,
-					  reco::GsfTrackRef track,
-					  reco::TransientTrack & tt,
-					  reco::Vertex & primaryVertex,
-					  bool primaryVertexIsValid,
-					  reco::BeamSpot & beamspot,
-					  bool beamspotIsValid
-					  )
-{
+void PATElectronProducer::embedHighLevel(pat::Electron& anElectron,
+                                         reco::GsfTrackRef track,
+                                         reco::TransientTrack& tt,
+                                         reco::Vertex& primaryVertex,
+                                         bool primaryVertexIsValid,
+                                         reco::BeamSpot& beamspot,
+                                         bool beamspotIsValid) {
   // Correct to PV
 
   // PV2D
-  std::pair<bool,Measurement1D> result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     primaryVertex);
+  std::pair<bool, Measurement1D> result =
+      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::PV2D);
-
+  anElectron.setDB(d0_corr, d0_err, pat::Electron::PV2D);
 
   // PV3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						  track->pz()),
-				     primaryVertex);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   d0_corr = result.second.value();
   d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::PV3D);
-
+  anElectron.setDB(d0_corr, d0_err, pat::Electron::PV3D);
 
   // Correct to beam spot
   // make a fake vertex out of beam spot
   reco::Vertex vBeamspot(beamspot.position(), beamspot.covariance3D());
 
   // BS2D
-  result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     vBeamspot);
+  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::BS2D);
+  anElectron.setDB(d0_corr, d0_err, pat::Electron::BS2D);
 
   // BS3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						  track->pz()),
-				     vBeamspot);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  anElectron.setDB( d0_corr, d0_err, pat::Electron::BS3D);
+  anElectron.setDB(d0_corr, d0_err, pat::Electron::BS3D);
 
-    // PVDZ
-  anElectron.setDB( track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ );
+  // PVDZ
+  anElectron.setDB(
+      track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
@@ -14,7 +14,6 @@
   \version  $Id: PATElectronProducer.h,v 1.31 2013/02/27 23:26:56 wmtan Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,207 +41,205 @@
 
 #include <string>
 
-
 namespace pat {
-
 
   class TrackerIsolationPt;
   class CaloIsolationEnergy;
   class LeptonLRCalc;
 
-
   class PATElectronProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATElectronProducer(const edm::ParameterSet& iConfig);
+    ~PATElectronProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATElectronProducer(const edm::ParameterSet & iConfig);
-      ~PATElectronProducer() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+  private:
+    // configurables
+    const edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
+    const edm::EDGetTokenT<reco::ConversionCollection> hConversionsToken_;
+    const bool embedGsfElectronCore_;
+    const bool embedGsfTrack_;
+    const bool embedSuperCluster_;
+    const bool embedPflowSuperCluster_;
+    const bool embedSeedCluster_;
+    const bool embedBasicClusters_;
+    const bool embedPreshowerClusters_;
+    const bool embedPflowBasicClusters_;
+    const bool embedPflowPreshowerClusters_;
+    const bool embedTrack_;
+    bool addGenMatch_;
+    bool embedGenMatch_;
+    const bool embedRecHits_;
+    // for mini-iso calculation
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcToken_;
+    bool computeMiniIso_;
+    std::vector<double> miniIsoParamsE_;
+    std::vector<double> miniIsoParamsB_;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > GenAssociations;
 
-    private:
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
-      // configurables
-      const edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
-      const edm::EDGetTokenT<reco::ConversionCollection> hConversionsToken_;
-      const bool          embedGsfElectronCore_;
-      const bool          embedGsfTrack_;
-      const bool          embedSuperCluster_;
-      const bool          embedPflowSuperCluster_;
-      const bool          embedSeedCluster_;
-      const bool          embedBasicClusters_;
-      const bool          embedPreshowerClusters_;
-      const bool          embedPflowBasicClusters_;
-      const bool          embedPflowPreshowerClusters_;
-      const bool          embedTrack_;
-      bool                addGenMatch_;
-      bool                embedGenMatch_;
-      const bool          embedRecHits_;
-      // for mini-iso calculation
-      edm::EDGetTokenT<pat::PackedCandidateCollection>  pcToken_;
-      bool computeMiniIso_;
-      std::vector<double> miniIsoParamsE_;
-      std::vector<double> miniIsoParamsB_;
+    /// pflow specific
+    const bool useParticleFlow_;
+    const bool usePfCandidateMultiMap_;
+    const edm::EDGetTokenT<reco::PFCandidateCollection> pfElecToken_;
+    const edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr> > pfCandidateMapToken_;
+    const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > pfCandidateMultiMapToken_;
+    const bool embedPFCandidate_;
 
-      typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > GenAssociations;
+    /// mva input variables
+    const bool addMVAVariables_;
+    const edm::InputTag reducedBarrelRecHitCollection_;
+    const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
+    const edm::InputTag reducedEndcapRecHitCollection_;
+    const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
 
-      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    const bool addPFClusterIso_;
+    const bool addPuppiIsolation_;
+    const edm::EDGetTokenT<edm::ValueMap<float> > ecalPFClusterIsoT_;
+    const edm::EDGetTokenT<edm::ValueMap<float> > hcalPFClusterIsoT_;
 
-      /// pflow specific
-      const bool          useParticleFlow_;
-      const bool          usePfCandidateMultiMap_;
-      const edm::EDGetTokenT<reco::PFCandidateCollection> pfElecToken_;
-      const edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr> > pfCandidateMapToken_;
-      const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > pfCandidateMultiMapToken_;
-      const bool          embedPFCandidate_;
+    /// embed high level selection variables?
+    const bool embedHighLevelSelection_;
+    const edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
+    const edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
 
-      /// mva input variables
-      const bool addMVAVariables_;
-      const edm::InputTag reducedBarrelRecHitCollection_;
-      const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
-      const edm::InputTag reducedEndcapRecHitCollection_;
-      const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
-      
-      const bool addPFClusterIso_;
-      const bool addPuppiIsolation_;
-      const edm::EDGetTokenT<edm::ValueMap<float> > ecalPFClusterIsoT_;
-      const edm::EDGetTokenT<edm::ValueMap<float> > hcalPFClusterIsoT_;
+    typedef edm::RefToBase<reco::GsfElectron> ElectronBaseRef;
+    typedef std::vector<edm::Handle<edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
+    typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsolationValueMaps;
 
-      /// embed high level selection variables?
-      const bool          embedHighLevelSelection_;
-      const edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
-      const edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
+    /// common electron filling, for both the standard and PF2PAT case
+    void fillElectron(Electron& aElectron,
+                      const ElectronBaseRef& electronRef,
+                      const reco::CandidateBaseRef& baseRef,
+                      const GenAssociations& genMatches,
+                      const IsoDepositMaps& deposits,
+                      const bool pfId,
+                      const IsolationValueMaps& isolationValues,
+                      const IsolationValueMaps& isolationValuesNoPFId) const;
 
-      typedef edm::RefToBase<reco::GsfElectron> ElectronBaseRef;
-      typedef std::vector< edm::Handle< edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
-      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
+    void fillElectron2(Electron& anElectron,
+                       const reco::CandidatePtr& candPtrForIsolation,
+                       const reco::CandidatePtr& candPtrForGenMatch,
+                       const reco::CandidatePtr& candPtrForLoader,
+                       const GenAssociations& genMatches,
+                       const IsoDepositMaps& deposits,
+                       const IsolationValueMaps& isolationValues) const;
 
-
-      /// common electron filling, for both the standard and PF2PAT case
-      void fillElectron( Electron& aElectron,
-			 const ElectronBaseRef& electronRef,
-			 const reco::CandidateBaseRef& baseRef,
-			 const GenAssociations& genMatches,
-			 const IsoDepositMaps& deposits,
-                         const bool pfId,
-			 const IsolationValueMaps& isolationValues,
-                         const IsolationValueMaps& isolationValuesNoPFId) const;
-
-      void fillElectron2( Electron& anElectron,
-			  const reco::CandidatePtr& candPtrForIsolation,
-			  const reco::CandidatePtr& candPtrForGenMatch,
-			  const reco::CandidatePtr& candPtrForLoader,
-			  const GenAssociations& genMatches,
-			  const IsoDepositMaps& deposits,
-			  const IsolationValueMaps& isolationValues ) const;
-
-      // set the mini-isolation variables
-      void setElectronMiniIso(pat::Electron& anElectron, const pat::PackedCandidateCollection *pc);
+    // set the mini-isolation variables
+    void setElectronMiniIso(pat::Electron& anElectron, const pat::PackedCandidateCollection* pc);
 
     // embed various impact parameters with errors
     // embed high level selection
-    void embedHighLevel( pat::Electron & anElectron,
-			 reco::GsfTrackRef track,
-			 reco::TransientTrack & tt,
-			 reco::Vertex & primaryVertex,
-			 bool primaryVertexIsValid,
-			 reco::BeamSpot & beamspot,
-			 bool beamspotIsValid );
+    void embedHighLevel(pat::Electron& anElectron,
+                        reco::GsfTrackRef track,
+                        reco::TransientTrack& tt,
+                        reco::Vertex& primaryVertex,
+                        bool primaryVertexIsValid,
+                        reco::BeamSpot& beamspot,
+                        bool beamspotIsValid);
 
-      typedef std::pair<pat::IsolationKeys,edm::InputTag> IsolationLabel;
-      typedef std::vector<IsolationLabel> IsolationLabels;
+    typedef std::pair<pat::IsolationKeys, edm::InputTag> IsolationLabel;
+    typedef std::vector<IsolationLabel> IsolationLabels;
 
-      /// fill the labels vector from the contents of the parameter set,
-      /// for the isodeposit or isolation values embedding
-      template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig,
-				                     const char* psetName,
-				                     IsolationLabels& labels,
-					             std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
+    /// fill the labels vector from the contents of the parameter set,
+    /// for the isodeposit or isolation values embedding
+    template <typename T>
+    void readIsolationLabels(const edm::ParameterSet& iConfig,
+                             const char* psetName,
+                             IsolationLabels& labels,
+                             std::vector<edm::EDGetTokenT<edm::ValueMap<T> > >& tokens);
 
-      const bool          addElecID_;
-      typedef std::pair<std::string, edm::InputTag> NameTag;
-      std::vector<NameTag> elecIDSrcs_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<float> > > elecIDTokens_;
+    const bool addElecID_;
+    typedef std::pair<std::string, edm::InputTag> NameTag;
+    std::vector<NameTag> elecIDSrcs_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<float> > > elecIDTokens_;
 
-      // tools
-      const GreaterByPt<Electron>       pTComparator_;
+    // tools
+    const GreaterByPt<Electron> pTComparator_;
 
-      pat::helper::MultiIsolator isolator_;
-      pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
-      IsolationLabels isoDepositLabels_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
-      IsolationLabels isolationValueLabels_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueTokens_;
-      IsolationLabels isolationValueLabelsNoPFId_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueNoPFIdTokens_;
+    pat::helper::MultiIsolator isolator_;
+    pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_;  // better here than recreate at each event
+    IsolationLabels isoDepositLabels_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
+    IsolationLabels isolationValueLabels_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueTokens_;
+    IsolationLabels isolationValueLabelsNoPFId_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueNoPFIdTokens_;
 
-      const bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
+    const bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      const bool addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
+    const bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      const bool useUserData_;
-      //PUPPI isolation tokens
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_charged_hadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_neutral_hadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_photons_;
-      //PUPPINoLeptons isolation tokens
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_charged_hadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_neutral_hadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_photons_;
-      pat::PATUserDataHelper<pat::Electron>      userDataHelper_;
+    const bool useUserData_;
+    //PUPPI isolation tokens
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_photons_;
+    //PUPPINoLeptons isolation tokens
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_photons_;
+    pat::PATUserDataHelper<pat::Electron> userDataHelper_;
 
-      const CaloTopology * ecalTopology_;
-
+    const CaloTopology* ecalTopology_;
   };
-}
-  
-template<typename T>
-void pat::PATElectronProducer::readIsolationLabels( const edm::ParameterSet & iConfig,
-						    const char* psetName,
-						    pat::PATElectronProducer::IsolationLabels& labels,
-						    std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens) {
-    
-    labels.clear();
-    
-    if (iConfig.exists( psetName )) {
-      edm::ParameterSet depconf
-        = iConfig.getParameter<edm::ParameterSet>(psetName);
-      
-      if (depconf.exists("tracker")) labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-      if (depconf.exists("ecal"))    labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-      if (depconf.exists("hcal"))    labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-      if (depconf.exists("pfAllParticles"))  {
-        labels.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
-      }
-      if (depconf.exists("pfChargedHadrons"))  {
-        labels.push_back(std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
-      }
-      if (depconf.exists("pfChargedAll"))  {
-        labels.push_back(std::make_pair(pat::PfChargedAllIso, depconf.getParameter<edm::InputTag>("pfChargedAll")));
-      }
-      if (depconf.exists("pfPUChargedHadrons"))  {
-        labels.push_back(std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
-      }
-      if (depconf.exists("pfNeutralHadrons"))  {
-        labels.push_back(std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
-      }
-      if (depconf.exists("pfPhotons")) {
-        labels.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfPhotons")));
-      }
-      if (depconf.exists("user")) {
-        std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
-        std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
-        int key = pat::IsolationKeys::UserBaseIso;
-        for ( ; it != ed; ++it, ++key) {
-          labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
-        }
+}  // namespace pat
+
+template <typename T>
+void pat::PATElectronProducer::readIsolationLabels(const edm::ParameterSet& iConfig,
+                                                   const char* psetName,
+                                                   pat::PATElectronProducer::IsolationLabels& labels,
+                                                   std::vector<edm::EDGetTokenT<edm::ValueMap<T> > >& tokens) {
+  labels.clear();
+
+  if (iConfig.exists(psetName)) {
+    edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>(psetName);
+
+    if (depconf.exists("tracker"))
+      labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
+    if (depconf.exists("ecal"))
+      labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
+    if (depconf.exists("hcal"))
+      labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
+    if (depconf.exists("pfAllParticles")) {
+      labels.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
+    }
+    if (depconf.exists("pfChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
+    }
+    if (depconf.exists("pfChargedAll")) {
+      labels.push_back(std::make_pair(pat::PfChargedAllIso, depconf.getParameter<edm::InputTag>("pfChargedAll")));
+    }
+    if (depconf.exists("pfPUChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
+    }
+    if (depconf.exists("pfNeutralHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
+    }
+    if (depconf.exists("pfPhotons")) {
+      labels.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfPhotons")));
+    }
+    if (depconf.exists("user")) {
+      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
+      std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
+      int key = pat::IsolationKeys::UserBaseIso;
+      for (; it != ed; ++it, ++key) {
+        labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
       }
     }
-    tokens = edm::vector_transform(labels, [this](IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
+  }
+  tokens = edm::vector_transform(
+      labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T> >(label.second); });
 }
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -25,138 +25,182 @@ namespace pat {
 
   class PATElectronSlimmer : public edm::stream::EDProducer<> {
   public:
-    explicit PATElectronSlimmer(const edm::ParameterSet & iConfig);
-    ~PATElectronSlimmer() override { }
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) final;
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) final;
-    
-    private:
-    const edm::EDGetTokenT<edm::View<pat::Electron> > src_;
-    
-    const StringCutObjectSelector<pat::Electron> dropSuperClusters_, dropBasicClusters_, dropPFlowClusters_, dropPreshowerClusters_, dropSeedCluster_, dropRecHits_;
-    const StringCutObjectSelector<pat::Electron> dropCorrections_,dropIsolations_,dropShapes_,dropSaturation_,dropExtrapolations_,dropClassifications_;
-    
-    const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > reco2pf_;
-    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2pc_;
-    const edm::EDGetTokenT<pat::PackedCandidateCollection>  pc_;
+    explicit PATElectronSlimmer(const edm::ParameterSet& iConfig);
+    ~PATElectronSlimmer() override {}
+
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) final;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
+
+  private:
+    const edm::EDGetTokenT<edm::View<pat::Electron>> src_;
+
+    const StringCutObjectSelector<pat::Electron> dropSuperClusters_, dropBasicClusters_, dropPFlowClusters_,
+        dropPreshowerClusters_, dropSeedCluster_, dropRecHits_;
+    const StringCutObjectSelector<pat::Electron> dropCorrections_, dropIsolations_, dropShapes_, dropSaturation_,
+        dropExtrapolations_, dropClassifications_;
+
+    const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
+    const edm::EDGetTokenT<pat::PackedCandidateCollection> pc_;
     const bool linkToPackedPF_;
     const StringCutObjectSelector<pat::Electron> saveNonZSClusterShapes_;
-    const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_;
+    const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_,
+        reducedEndcapRecHitCollectionToken_;
     const bool modifyElectron_;
-    std::unique_ptr<pat::ObjectModifier<pat::Electron> > electronModifier_;
+    std::unique_ptr<pat::ObjectModifier<pat::Electron>> electronModifier_;
   };
 
-} // namespace
+}  // namespace pat
 
-pat::PATElectronSlimmer::PATElectronSlimmer(const edm::ParameterSet & iConfig) :
-    src_(consumes<edm::View<pat::Electron> >(iConfig.getParameter<edm::InputTag>("src"))),
-    dropSuperClusters_(iConfig.getParameter<std::string>("dropSuperCluster")),
-    dropBasicClusters_(iConfig.getParameter<std::string>("dropBasicClusters")),
-    dropPFlowClusters_(iConfig.getParameter<std::string>("dropPFlowClusters")),
-    dropPreshowerClusters_(iConfig.getParameter<std::string>("dropPreshowerClusters")),
-    dropSeedCluster_(iConfig.getParameter<std::string>("dropSeedCluster")),
-    dropRecHits_(iConfig.getParameter<std::string>("dropRecHits")),
-    dropCorrections_(iConfig.getParameter<std::string>("dropCorrections")),
-    dropIsolations_(iConfig.getParameter<std::string>("dropIsolations")),
-    dropShapes_(iConfig.getParameter<std::string>("dropShapes")),
-    dropSaturation_(iConfig.getParameter<std::string>("dropSaturation")),
-    dropExtrapolations_(iConfig.getParameter<std::string>("dropExtrapolations")),
-    dropClassifications_(iConfig.getParameter<std::string>("dropClassifications")),
-    reco2pf_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("recoToPFMap"))),
-    pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-    pc_(mayConsume<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-    linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
-    saveNonZSClusterShapes_(iConfig.getParameter<std::string>("saveNonZSClusterShapes")),
-    reducedBarrelRecHitCollectionToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection"))),
-    reducedEndcapRecHitCollectionToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"))),
-    modifyElectron_(iConfig.getParameter<bool>("modifyElectrons"))
-{
-    if( modifyElectron_ ) {
-      const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      electronModifier_ = std::make_unique<pat::ObjectModifier<pat::Electron>>(mod_config, consumesCollector());
+pat::PATElectronSlimmer::PATElectronSlimmer(const edm::ParameterSet& iConfig)
+    : src_(consumes<edm::View<pat::Electron>>(iConfig.getParameter<edm::InputTag>("src"))),
+      dropSuperClusters_(iConfig.getParameter<std::string>("dropSuperCluster")),
+      dropBasicClusters_(iConfig.getParameter<std::string>("dropBasicClusters")),
+      dropPFlowClusters_(iConfig.getParameter<std::string>("dropPFlowClusters")),
+      dropPreshowerClusters_(iConfig.getParameter<std::string>("dropPreshowerClusters")),
+      dropSeedCluster_(iConfig.getParameter<std::string>("dropSeedCluster")),
+      dropRecHits_(iConfig.getParameter<std::string>("dropRecHits")),
+      dropCorrections_(iConfig.getParameter<std::string>("dropCorrections")),
+      dropIsolations_(iConfig.getParameter<std::string>("dropIsolations")),
+      dropShapes_(iConfig.getParameter<std::string>("dropShapes")),
+      dropSaturation_(iConfig.getParameter<std::string>("dropSaturation")),
+      dropExtrapolations_(iConfig.getParameter<std::string>("dropExtrapolations")),
+      dropClassifications_(iConfig.getParameter<std::string>("dropClassifications")),
+      reco2pf_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+          iConfig.getParameter<edm::InputTag>("recoToPFMap"))),
+      pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      pc_(mayConsume<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
+      saveNonZSClusterShapes_(iConfig.getParameter<std::string>("saveNonZSClusterShapes")),
+      reducedBarrelRecHitCollectionToken_(
+          consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection"))),
+      reducedEndcapRecHitCollectionToken_(
+          consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"))),
+      modifyElectron_(iConfig.getParameter<bool>("modifyElectrons")) {
+  if (modifyElectron_) {
+    const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
+    electronModifier_ = std::make_unique<pat::ObjectModifier<pat::Electron>>(mod_config, consumesCollector());
+  }
+
+  mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));
+  mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"));
+
+  produces<std::vector<pat::Electron>>();
+}
+
+void pat::PATElectronSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup) {}
+
+void pat::PATElectronSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+
+  Handle<View<pat::Electron>> src;
+  iEvent.getByToken(src_, src);
+
+  Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf;
+  Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  Handle<pat::PackedCandidateCollection> pc;
+  if (linkToPackedPF_) {
+    iEvent.getByToken(reco2pf_, reco2pf);
+    iEvent.getByToken(pf2pc_, pf2pc);
+    iEvent.getByToken(pc_, pc);
+  }
+  noZS::EcalClusterLazyTools lazyToolsNoZS(
+      iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+
+  auto out = std::make_unique<std::vector<pat::Electron>>();
+  out->reserve(src->size());
+
+  if (modifyElectron_) {
+    electronModifier_->setEvent(iEvent);
+  }
+  if (modifyElectron_)
+    electronModifier_->setEventContent(iSetup);
+
+  std::vector<unsigned int> keys;
+  for (View<pat::Electron>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    out->push_back(*it);
+    pat::Electron& electron = out->back();
+
+    if (modifyElectron_) {
+      electronModifier_->modify(electron);
     }
 
-    mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));
-    mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"));
-
-    produces<std::vector<pat::Electron> >();
-}
-
-void 
-pat::PATElectronSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup& iSetup) {
-}
-
-void 
-pat::PATElectronSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
-
-    Handle<View<pat::Electron> >      src;
-    iEvent.getByToken(src_, src);
-
-    Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf;
-    Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
-    Handle<pat::PackedCandidateCollection> pc;
+    if (dropSuperClusters_(electron)) {
+      electron.superCluster_.clear();
+      electron.embeddedSuperCluster_ = false;
+    }
+    if (dropBasicClusters_(electron)) {
+      electron.basicClusters_.clear();
+    }
+    if (dropSuperClusters_(electron) || dropPFlowClusters_(electron)) {
+      electron.pflowSuperCluster_.clear();
+      electron.embeddedPflowSuperCluster_ = false;
+    }
+    if (dropBasicClusters_(electron) || dropPFlowClusters_(electron)) {
+      electron.pflowBasicClusters_.clear();
+    }
+    if (dropPreshowerClusters_(electron)) {
+      electron.preshowerClusters_.clear();
+    }
+    if (dropPreshowerClusters_(electron) || dropPFlowClusters_(electron)) {
+      electron.pflowPreshowerClusters_.clear();
+    }
+    if (dropSeedCluster_(electron)) {
+      electron.seedCluster_.clear();
+      electron.embeddedSeedCluster_ = false;
+    }
+    if (dropRecHits_(electron)) {
+      electron.recHits_ = EcalRecHitCollection();
+      electron.embeddedRecHits_ = false;
+    }
+    if (dropCorrections_(electron)) {
+      electron.setCorrections(reco::GsfElectron::Corrections());
+    }
+    if (dropIsolations_(electron)) {
+      electron.setDr03Isolation(reco::GsfElectron::IsolationVariables());
+      electron.setDr04Isolation(reco::GsfElectron::IsolationVariables());
+      electron.setPfIsolationVariables(reco::GsfElectron::PflowIsolationVariables());
+    }
+    if (dropShapes_(electron)) {
+      electron.setShowerShape(reco::GsfElectron::ShowerShape());
+    }
+    if (dropSaturation_(electron)) {
+      electron.setSaturationInfo(reco::GsfElectron::SaturationInfo());
+    }
+    if (dropExtrapolations_(electron)) {
+      electron.setTrackExtrapolations(reco::GsfElectron::TrackExtrapolations());
+    }
+    if (dropClassifications_(electron)) {
+      electron.setClassificationVariables(reco::GsfElectron::ClassificationVariables());
+      electron.setClassification(reco::GsfElectron::Classification());
+    }
     if (linkToPackedPF_) {
-        iEvent.getByToken(reco2pf_, reco2pf);
-        iEvent.getByToken(pf2pc_, pf2pc);
-        iEvent.getByToken(pc_, pc);
-    }
-    noZS::EcalClusterLazyTools lazyToolsNoZS(iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
-
-    auto out = std::make_unique<std::vector<pat::Electron>>();
-    out->reserve(src->size());
-
-    if( modifyElectron_ ) { electronModifier_->setEvent(iEvent); }
-    if( modifyElectron_ ) electronModifier_->setEventContent(iSetup);
-
-    std::vector<unsigned int> keys;
-    for (View<pat::Electron>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        out->push_back(*it);
-        pat::Electron & electron = out->back();
-
-        if( modifyElectron_ ) { electronModifier_->modify(electron); }
-
-        if (dropSuperClusters_(electron)) { electron.superCluster_.clear(); electron.embeddedSuperCluster_ = false; }
-	if (dropBasicClusters_(electron)) { electron.basicClusters_.clear();  }
-	if (dropSuperClusters_(electron) || dropPFlowClusters_(electron)) { electron.pflowSuperCluster_.clear(); electron.embeddedPflowSuperCluster_ = false; }
-	if (dropBasicClusters_(electron) || dropPFlowClusters_(electron)) { electron.pflowBasicClusters_.clear(); }
-	if (dropPreshowerClusters_(electron)) { electron.preshowerClusters_.clear();  }
-	if (dropPreshowerClusters_(electron) || dropPFlowClusters_(electron)) { electron.pflowPreshowerClusters_.clear(); }
-	if (dropSeedCluster_(electron)) { electron.seedCluster_.clear(); electron.embeddedSeedCluster_ = false; }
-        if (dropRecHits_(electron)) { electron.recHits_ = EcalRecHitCollection(); electron.embeddedRecHits_ = false; }
-        if (dropCorrections_(electron)) { electron.setCorrections(reco::GsfElectron::Corrections()); }
-        if (dropIsolations_(electron)) { electron.setDr03Isolation(reco::GsfElectron::IsolationVariables()); electron.setDr04Isolation(reco::GsfElectron::IsolationVariables()); electron.setPfIsolationVariables(reco::GsfElectron::PflowIsolationVariables()); }
-        if (dropShapes_(electron)) { electron.setShowerShape(reco::GsfElectron::ShowerShape()); }
-        if (dropSaturation_(electron)) { electron.setSaturationInfo(reco::GsfElectron::SaturationInfo()); }
-        if (dropExtrapolations_(electron)) { electron.setTrackExtrapolations(reco::GsfElectron::TrackExtrapolations());  }
-        if (dropClassifications_(electron)) { electron.setClassificationVariables(reco::GsfElectron::ClassificationVariables()); electron.setClassification(reco::GsfElectron::Classification()); }
-        if (linkToPackedPF_) {
-            //std::cout << " PAT  electron in  " << src.id() << " comes from " << electron.refToOrig_.id() << ", " << electron.refToOrig_.key() << std::endl;
-            keys.clear();
-            for(auto const& pf: (*reco2pf)[electron.refToOrig_]) {
-              if( pf2pc->contains(pf.id()) ) {
-                keys.push_back( (*pf2pc)[pf].key());
-              }
-            }
-            electron.setAssociatedPackedPFCandidates(edm::RefProd<pat::PackedCandidateCollection>(pc),
-                                                     keys.begin(), keys.end());
-            //std::cout << "Electron with pt " << electron.pt() << " associated to " << electron.associatedPackedFCandidateIndices_.size() << " PF Candidates\n";
-            //if there's just one PF Cand then it's me, otherwise I have no univoque parent so my ref will be null 
-            if (keys.size() == 1) {
-                electron.refToOrig_ = electron.sourceCandidatePtr(0);
-            } else {
-                electron.refToOrig_ = reco::CandidatePtr(pc.id());
-            }
+      //std::cout << " PAT  electron in  " << src.id() << " comes from " << electron.refToOrig_.id() << ", " << electron.refToOrig_.key() << std::endl;
+      keys.clear();
+      for (auto const& pf : (*reco2pf)[electron.refToOrig_]) {
+        if (pf2pc->contains(pf.id())) {
+          keys.push_back((*pf2pc)[pf].key());
         }
-        if (saveNonZSClusterShapes_(electron)) {
-            std::vector<float> vCov = lazyToolsNoZS.localCovariances(*( electron.superCluster()->seed()));
-            electron.full5x5_setSigmaIetaIphi(vCov[1]);
-        }
+      }
+      electron.setAssociatedPackedPFCandidates(
+          edm::RefProd<pat::PackedCandidateCollection>(pc), keys.begin(), keys.end());
+      //std::cout << "Electron with pt " << electron.pt() << " associated to " << electron.associatedPackedFCandidateIndices_.size() << " PF Candidates\n";
+      //if there's just one PF Cand then it's me, otherwise I have no univoque parent so my ref will be null
+      if (keys.size() == 1) {
+        electron.refToOrig_ = electron.sourceCandidatePtr(0);
+      } else {
+        electron.refToOrig_ = reco::CandidatePtr(pc.id());
+      }
     }
+    if (saveNonZSClusterShapes_(electron)) {
+      std::vector<float> vCov = lazyToolsNoZS.localCovariances(*(electron.superCluster()->seed()));
+      electron.full5x5_setSigmaIetaIphi(vCov[1]);
+    }
+  }
 
-    iEvent.put(std::move(out));
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
@@ -28,213 +28,218 @@
 namespace pat {
   class PATGenCandsFromSimTracksProducer : public edm::stream::EDProducer<> {
   public:
-    explicit PATGenCandsFromSimTracksProducer(const edm::ParameterSet&);
+    explicit PATGenCandsFromSimTracksProducer(const edm::ParameterSet &);
     ~PATGenCandsFromSimTracksProducer() override {}
-    
+
   private:
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    
+    void produce(edm::Event &, const edm::EventSetup &) override;
+
     bool firstEvent_;
     edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
     edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken_;
     int setStatus_;
-    std::set<int>         pdgIds_; // these are the ones we really use
-    std::vector<PdtEntry> pdts_;   // these are needed before we get the EventSetup
-    std::set<int>         motherPdgIds_; // these are the ones we really use
-    std::vector<PdtEntry> motherPdts_;   // these are needed before we get the EventSetup
-    
+    std::set<int> pdgIds_;              // these are the ones we really use
+    std::vector<PdtEntry> pdts_;        // these are needed before we get the EventSetup
+    std::set<int> motherPdgIds_;        // these are the ones we really use
+    std::vector<PdtEntry> motherPdts_;  // these are needed before we get the EventSetup
+
     typedef StringCutObjectSelector<reco::GenParticle> StrFilter;
     const StrFilter filter_;
-    
+
     /// If true, I'll try to make a link from the GEANT particle to a GenParticle
     bool makeMotherLink_;
     /// If true, I'll save GenParticles corresponding to the ancestors of this GEANT particle. Common ancestors are only written once.
     bool writeAncestors_;
-    
+
     /// Collection of GenParticles I need to make refs to. It must also have its associated vector<int> of barcodes, aligned with them.
     edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
     edm::EDGetTokenT<std::vector<int> > genBarcodesToken_;
-    
-  /// Global context for all recursive methods
+
+    /// Global context for all recursive methods
     struct GlobalContext {
       GlobalContext(const edm::SimTrackContainer &simtks1,
                     const edm::SimVertexContainer &simvtxs1,
                     const edm::Handle<reco::GenParticleCollection> &gens1,
-                    const edm::Handle<std::vector<int> >           &genBarcodes1,
-                    bool                                            barcodesAreSorted1,
-                    reco::GenParticleCollection                     & output1,
-                    const edm::RefProd<reco::GenParticleCollection> & refprod1) :
-        simtks(simtks1), simvtxs(simvtxs1),
-        gens(gens1), genBarcodes(genBarcodes1), barcodesAreSorted(barcodesAreSorted1),
-        output(output1), refprod(refprod1), simTksProcessed() {}
+                    const edm::Handle<std::vector<int> > &genBarcodes1,
+                    bool barcodesAreSorted1,
+                    reco::GenParticleCollection &output1,
+                    const edm::RefProd<reco::GenParticleCollection> &refprod1)
+          : simtks(simtks1),
+            simvtxs(simvtxs1),
+            gens(gens1),
+            genBarcodes(genBarcodes1),
+            barcodesAreSorted(barcodesAreSorted1),
+            output(output1),
+            refprod(refprod1),
+            simTksProcessed() {}
       // GEANT info
       const edm::SimTrackContainer &simtks;
       const edm::SimVertexContainer &simvtxs;
       // PYTHIA info
       const edm::Handle<reco::GenParticleCollection> &gens;
-      const edm::Handle<std::vector<int> >           &genBarcodes;
-      bool                                            barcodesAreSorted;
+      const edm::Handle<std::vector<int> > &genBarcodes;
+      bool barcodesAreSorted;
       // MY OUTPUT info
-      reco::GenParticleCollection                     & output;
-      const edm::RefProd<reco::GenParticleCollection> & refprod;
+      reco::GenParticleCollection &output;
+      const edm::RefProd<reco::GenParticleCollection> &refprod;
       // BOOK-KEEPING
-      std::map<unsigned int,int> simTksProcessed; // key = sim track id;
+      std::map<unsigned int, int> simTksProcessed;  // key = sim track id;
       // val = 0: not processed;
       //       i>0:  (index+1) in my output
       //       i<0: -(index+1) in pythia [NOT USED]
     };
-    
+
     /// Find the mother of a given GEANT track (or NULL if it can't be found).
-    const SimTrack * findGeantMother(const SimTrack &tk, const GlobalContext &g) const ;
+    const SimTrack *findGeantMother(const SimTrack &tk, const GlobalContext &g) const;
     /// Find the GenParticle reference for a given GEANT or PYTHIA track.
     ///  - if the track corresponds to a PYTHIA particle, return a ref to that particle
     ///  - otherwise, if this simtrack has no mother simtrack, return a null ref
     ///  - otherwise, if writeAncestors is true,  make a GenParticle for it and return a ref to it
     ///  - otherwise, if writeAncestors is false, return the ref to the GEANT mother of this track
-    edm::Ref<reco::GenParticleCollection> findRef(const SimTrack &tk, GlobalContext &g) const ;
-    
+    edm::Ref<reco::GenParticleCollection> findRef(const SimTrack &tk, GlobalContext &g) const;
+
     /// Used by findRef if the track is a PYTHIA particle
-    edm::Ref<reco::GenParticleCollection> generatorRef_(const SimTrack &tk, const GlobalContext &g) const ;
+    edm::Ref<reco::GenParticleCollection> generatorRef_(const SimTrack &tk, const GlobalContext &g) const;
     /// Make a GenParticle for this SimTrack, with a given mother
-    reco::GenParticle makeGenParticle_(const SimTrack &tk, const edm::Ref<reco::GenParticleCollection> & mother, const GlobalContext &g) const ;
-    
-    
-    
+    reco::GenParticle makeGenParticle_(const SimTrack &tk,
+                                       const edm::Ref<reco::GenParticleCollection> &mother,
+                                       const GlobalContext &g) const;
+
     struct LessById {
       bool operator()(const SimTrack &tk1, const SimTrack &tk2) const { return tk1.trackId() < tk2.trackId(); }
-      bool operator()(const SimTrack &tk1, unsigned int    id ) const { return tk1.trackId() < id;            }
-      bool operator()(unsigned int     id, const SimTrack &tk2) const { return id            < tk2.trackId(); }
-    };    
+      bool operator()(const SimTrack &tk1, unsigned int id) const { return tk1.trackId() < id; }
+      bool operator()(unsigned int id, const SimTrack &tk2) const { return id < tk2.trackId(); }
+    };
   };
-}
+}  // namespace pat
 
 using namespace std;
 using namespace edm;
 using namespace reco;
 using pat::PATGenCandsFromSimTracksProducer;
 
-PATGenCandsFromSimTracksProducer::PATGenCandsFromSimTracksProducer(const ParameterSet& cfg) :
-  firstEvent_(true),
-  simTracksToken_(consumes<SimTrackContainer>(cfg.getParameter<InputTag>("src"))),            // source sim tracks
-  simVertexToken_(consumes<SimVertexContainer>(cfg.getParameter<InputTag>("src"))),            // source sim  vertices
-  setStatus_(cfg.getParameter<int32_t>("setStatus")), // set status of GenParticle to this code
-  filter_( cfg.existsAs<string>("filter") ? cfg.getParameter<string>("filter") : std::string("1 == 1") ),
-  makeMotherLink_(cfg.existsAs<bool>("makeMotherLink") ? cfg.getParameter<bool>("makeMotherLink") : false),
-  writeAncestors_(cfg.existsAs<bool>("writeAncestors") ? cfg.getParameter<bool>("writeAncestors") : false),
-  genParticlesToken_(mayConsume<GenParticleCollection>(cfg.getParameter<InputTag>("genParticles"))),
-  genBarcodesToken_(mayConsume<std::vector<int> >(cfg.getParameter<InputTag>("genParticles")))
-{
-    // Possibly allow a list of particle types
-    if (cfg.exists("particleTypes")) {
-        pdts_ = cfg.getParameter<vector<PdtEntry> >("particleTypes");
-    }
-    if (cfg.exists("motherTypes")) {
-        motherPdts_ = cfg.getParameter<vector<PdtEntry> >("motherTypes");
-    }
-    
-    if (writeAncestors_ && !makeMotherLink_) {
-        edm::LogWarning("Configuration") << "PATGenCandsFromSimTracksProducer: " <<
-            "you have set 'writeAncestors' to 'true' and 'makeMotherLink' to false;" <<
-            "GEANT particles with generator level (e.g.PYHIA) mothers won't have mother links.\n";
-    }
-    produces<GenParticleCollection>();
+PATGenCandsFromSimTracksProducer::PATGenCandsFromSimTracksProducer(const ParameterSet &cfg)
+    : firstEvent_(true),
+      simTracksToken_(consumes<SimTrackContainer>(cfg.getParameter<InputTag>("src"))),   // source sim tracks
+      simVertexToken_(consumes<SimVertexContainer>(cfg.getParameter<InputTag>("src"))),  // source sim  vertices
+      setStatus_(cfg.getParameter<int32_t>("setStatus")),  // set status of GenParticle to this code
+      filter_(cfg.existsAs<string>("filter") ? cfg.getParameter<string>("filter") : std::string("1 == 1")),
+      makeMotherLink_(cfg.existsAs<bool>("makeMotherLink") ? cfg.getParameter<bool>("makeMotherLink") : false),
+      writeAncestors_(cfg.existsAs<bool>("writeAncestors") ? cfg.getParameter<bool>("writeAncestors") : false),
+      genParticlesToken_(mayConsume<GenParticleCollection>(cfg.getParameter<InputTag>("genParticles"))),
+      genBarcodesToken_(mayConsume<std::vector<int> >(cfg.getParameter<InputTag>("genParticles"))) {
+  // Possibly allow a list of particle types
+  if (cfg.exists("particleTypes")) {
+    pdts_ = cfg.getParameter<vector<PdtEntry> >("particleTypes");
+  }
+  if (cfg.exists("motherTypes")) {
+    motherPdts_ = cfg.getParameter<vector<PdtEntry> >("motherTypes");
+  }
+
+  if (writeAncestors_ && !makeMotherLink_) {
+    edm::LogWarning("Configuration")
+        << "PATGenCandsFromSimTracksProducer: "
+        << "you have set 'writeAncestors' to 'true' and 'makeMotherLink' to false;"
+        << "GEANT particles with generator level (e.g.PYHIA) mothers won't have mother links.\n";
+  }
+  produces<GenParticleCollection>();
 }
 
-const SimTrack *
-PATGenCandsFromSimTracksProducer::findGeantMother(const SimTrack &tk, const GlobalContext &g) const {
-   assert(tk.genpartIndex() == -1); // MUST NOT be called with a PYTHIA track
-   if (!tk.noVertex()) {
-       const SimVertex &vtx = g.simvtxs[tk.vertIndex()];
-       if (!vtx.noParent()) {
-           unsigned int idx = vtx.parentIndex();
-           SimTrackContainer::const_iterator it = std::lower_bound(g.simtks.begin(), g.simtks.end(), idx, LessById());
-           if ((it != g.simtks.end()) && (it->trackId() == idx)) {
-                return &*it;
-           }
-       }
-   }
-   return nullptr;
+const SimTrack *PATGenCandsFromSimTracksProducer::findGeantMother(const SimTrack &tk, const GlobalContext &g) const {
+  assert(tk.genpartIndex() == -1);  // MUST NOT be called with a PYTHIA track
+  if (!tk.noVertex()) {
+    const SimVertex &vtx = g.simvtxs[tk.vertIndex()];
+    if (!vtx.noParent()) {
+      unsigned int idx = vtx.parentIndex();
+      SimTrackContainer::const_iterator it = std::lower_bound(g.simtks.begin(), g.simtks.end(), idx, LessById());
+      if ((it != g.simtks.end()) && (it->trackId() == idx)) {
+        return &*it;
+      }
+    }
+  }
+  return nullptr;
 }
 
-edm::Ref<reco::GenParticleCollection>
-PATGenCandsFromSimTracksProducer::findRef(const SimTrack &tk, GlobalContext &g) const {
-    if (tk.genpartIndex() != -1) return makeMotherLink_ ? generatorRef_(tk, g) : edm::Ref<reco::GenParticleCollection>();
-    const SimTrack * simMother = findGeantMother(tk, g);
+edm::Ref<reco::GenParticleCollection> PATGenCandsFromSimTracksProducer::findRef(const SimTrack &tk,
+                                                                                GlobalContext &g) const {
+  if (tk.genpartIndex() != -1)
+    return makeMotherLink_ ? generatorRef_(tk, g) : edm::Ref<reco::GenParticleCollection>();
+  const SimTrack *simMother = findGeantMother(tk, g);
 
-    edm::Ref<reco::GenParticleCollection> motherRef;
-    if (simMother != nullptr) motherRef = findRef(*simMother,g);
+  edm::Ref<reco::GenParticleCollection> motherRef;
+  if (simMother != nullptr)
+    motherRef = findRef(*simMother, g);
 
-    if (writeAncestors_) {
-        // If writing ancestors, I need to serialize myself, and then to return a ref to me
-        // But first check if I've already been serialized
-        std::map<unsigned int,int>::const_iterator it = g.simTksProcessed.find(tk.trackId());
-        if (it != g.simTksProcessed.end()) {
-            // just return a ref to it
-            assert(it->second > 0);
-            return edm::Ref<reco::GenParticleCollection>(g.refprod, (it->second) - 1);
-        } else {
-            // make genParticle, save, update the map, and return ref to myself
-            reco::GenParticle p = makeGenParticle_(tk, motherRef, g);
-            g.output.push_back(p);
-            g.simTksProcessed[tk.trackId()] = g.output.size();
-            return edm::Ref<reco::GenParticleCollection>(g.refprod, g.output.size()-1 );
-        }
+  if (writeAncestors_) {
+    // If writing ancestors, I need to serialize myself, and then to return a ref to me
+    // But first check if I've already been serialized
+    std::map<unsigned int, int>::const_iterator it = g.simTksProcessed.find(tk.trackId());
+    if (it != g.simTksProcessed.end()) {
+      // just return a ref to it
+      assert(it->second > 0);
+      return edm::Ref<reco::GenParticleCollection>(g.refprod, (it->second) - 1);
     } else {
-        // Otherwise, I just return a ref to my mum
-        return motherRef;
+      // make genParticle, save, update the map, and return ref to myself
+      reco::GenParticle p = makeGenParticle_(tk, motherRef, g);
+      g.output.push_back(p);
+      g.simTksProcessed[tk.trackId()] = g.output.size();
+      return edm::Ref<reco::GenParticleCollection>(g.refprod, g.output.size() - 1);
     }
+  } else {
+    // Otherwise, I just return a ref to my mum
+    return motherRef;
+  }
 }
 
-edm::Ref<reco::GenParticleCollection>
-PATGenCandsFromSimTracksProducer::generatorRef_(const SimTrack &st, const GlobalContext &g) const {
-    assert(st.genpartIndex() != -1);
-    // Note that st.genpartIndex() is the barcode, not the index within GenParticleCollection, so I have to search the particle
-    std::vector<int>::const_iterator it;
-    if (g.barcodesAreSorted) {
-        it = std::lower_bound(g.genBarcodes->begin(), g.genBarcodes->end(), st.genpartIndex());
-    } else {
-        it = std::find(       g.genBarcodes->begin(), g.genBarcodes->end(), st.genpartIndex());
-    }
+edm::Ref<reco::GenParticleCollection> PATGenCandsFromSimTracksProducer::generatorRef_(const SimTrack &st,
+                                                                                      const GlobalContext &g) const {
+  assert(st.genpartIndex() != -1);
+  // Note that st.genpartIndex() is the barcode, not the index within GenParticleCollection, so I have to search the particle
+  std::vector<int>::const_iterator it;
+  if (g.barcodesAreSorted) {
+    it = std::lower_bound(g.genBarcodes->begin(), g.genBarcodes->end(), st.genpartIndex());
+  } else {
+    it = std::find(g.genBarcodes->begin(), g.genBarcodes->end(), st.genpartIndex());
+  }
 
-    // Check that I found something
-    // I need to check '*it == st.genpartIndex()' because lower_bound just finds the right spot for an item in a sorted list, not the item
-    if ((it != g.genBarcodes->end()) && (*it == st.genpartIndex())) {
-        return reco::GenParticleRef(g.gens, it - g.genBarcodes->begin());
-    } else {
-        return reco::GenParticleRef();
-    }
+  // Check that I found something
+  // I need to check '*it == st.genpartIndex()' because lower_bound just finds the right spot for an item in a sorted list, not the item
+  if ((it != g.genBarcodes->end()) && (*it == st.genpartIndex())) {
+    return reco::GenParticleRef(g.gens, it - g.genBarcodes->begin());
+  } else {
+    return reco::GenParticleRef();
+  }
 }
 
-reco::GenParticle
-PATGenCandsFromSimTracksProducer::makeGenParticle_(const SimTrack &tk, const edm::Ref<reco::GenParticleCollection> & mother, const GlobalContext &g) const {
-    // Make up a GenParticleCandidate from the GEANT track info.
-    int charge = static_cast<int>(tk.charge());
-    const Particle::LorentzVector& p4 = tk.momentum();
-    Particle::Point vtx; // = (0,0,0) by default
-    if (!tk.noVertex()) vtx = g.simvtxs[tk.vertIndex()].position();
-    GenParticle gp(charge, p4, vtx, tk.type(), setStatus_, true);
-    if (mother.isNonnull()) gp.addMother(mother);
-    return gp;
+reco::GenParticle PATGenCandsFromSimTracksProducer::makeGenParticle_(
+    const SimTrack &tk, const edm::Ref<reco::GenParticleCollection> &mother, const GlobalContext &g) const {
+  // Make up a GenParticleCandidate from the GEANT track info.
+  int charge = static_cast<int>(tk.charge());
+  const Particle::LorentzVector &p4 = tk.momentum();
+  Particle::Point vtx;  // = (0,0,0) by default
+  if (!tk.noVertex())
+    vtx = g.simvtxs[tk.vertIndex()].position();
+  GenParticle gp(charge, p4, vtx, tk.type(), setStatus_, true);
+  if (mother.isNonnull())
+    gp.addMother(mother);
+  return gp;
 }
 
-
-void PATGenCandsFromSimTracksProducer::produce(Event& event,
-                                               const EventSetup& iSetup) {
-
-  if (firstEvent_){
+void PATGenCandsFromSimTracksProducer::produce(Event &event, const EventSetup &iSetup) {
+  if (firstEvent_) {
     if (!pdts_.empty()) {
       pdgIds_.clear();
       for (vector<PdtEntry>::iterator itp = pdts_.begin(), edp = pdts_.end(); itp != edp; ++itp) {
-	itp->setup(iSetup); // decode string->pdgId and vice-versa
-	pdgIds_.insert(std::abs(itp->pdgId()));
+        itp->setup(iSetup);  // decode string->pdgId and vice-versa
+        pdgIds_.insert(std::abs(itp->pdgId()));
       }
       pdts_.clear();
     }
     if (!motherPdts_.empty()) {
       motherPdgIds_.clear();
       for (vector<PdtEntry>::iterator itp = motherPdts_.begin(), edp = motherPdts_.end(); itp != edp; ++itp) {
-	itp->setup(iSetup); // decode string->pdgId and vice-versa
-	motherPdgIds_.insert(std::abs(itp->pdgId()));
+        itp->setup(iSetup);  // decode string->pdgId and vice-versa
+        motherPdgIds_.insert(std::abs(itp->pdgId()));
       }
       motherPdts_.clear();
     }
@@ -247,13 +252,13 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
 
   // Need to check that SimTrackContainer is sorted; otherwise, copy and sort :-(
   std::unique_ptr<SimTrackContainer> simtracksTmp;
-  const SimTrackContainer * simtracksSorted = &* simtracks;
+  const SimTrackContainer *simtracksSorted = &*simtracks;
   if (makeMotherLink_ || writeAncestors_) {
-      if (!__gnu_cxx::is_sorted(simtracks->begin(), simtracks->end(), LessById())) {
-          simtracksTmp.reset(new SimTrackContainer(*simtracks));
-          std::sort(simtracksTmp->begin(), simtracksTmp->end(), LessById());
-          simtracksSorted = &* simtracksTmp;
-      }
+    if (!__gnu_cxx::is_sorted(simtracks->begin(), simtracks->end(), LessById())) {
+      simtracksTmp.reset(new SimTrackContainer(*simtracks));
+      std::sort(simtracksTmp->begin(), simtracksTmp->end(), LessById());
+      simtracksSorted = &*simtracksTmp;
+    }
   }
 
   // Get the associated vertices
@@ -265,12 +270,12 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
   Handle<std::vector<int> > genBarcodes;
   bool barcodesAreSorted = true;
   if (makeMotherLink_) {
-      event.getByToken(genParticlesToken_, gens);
-      event.getByToken(genBarcodesToken_, genBarcodes);
-      if (gens->size() != genBarcodes->size()) throw cms::Exception("Corrupt data") << "Barcodes not of the same size as GenParticles!\n";
-      barcodesAreSorted = __gnu_cxx::is_sorted(genBarcodes->begin(), genBarcodes->end());
+    event.getByToken(genParticlesToken_, gens);
+    event.getByToken(genBarcodesToken_, genBarcodes);
+    if (gens->size() != genBarcodes->size())
+      throw cms::Exception("Corrupt data") << "Barcodes not of the same size as GenParticles!\n";
+    barcodesAreSorted = __gnu_cxx::is_sorted(genBarcodes->begin(), genBarcodes->end());
   }
-
 
   // make the output collection
   auto cands = std::make_unique<GenParticleCollection>();
@@ -278,37 +283,41 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
 
   GlobalContext globals(*simtracksSorted, *simvertices, gens, genBarcodes, barcodesAreSorted, *cands, refprod);
 
-  for (SimTrackContainer::const_iterator isimtrk = simtracks->begin();
-          isimtrk != simtracks->end(); ++isimtrk) {
+  for (SimTrackContainer::const_iterator isimtrk = simtracks->begin(); isimtrk != simtracks->end(); ++isimtrk) {
+    // Skip PYTHIA tracks.
+    if (isimtrk->genpartIndex() != -1)
+      continue;
 
-      // Skip PYTHIA tracks.
-      if (isimtrk->genpartIndex() != -1) continue;
+    // Maybe apply the PdgId filter
+    if (!pdgIds_.empty()) {  // if we have a filter on pdg ids
+      if (pdgIds_.find(std::abs(isimtrk->type())) == pdgIds_.end())
+        continue;
+    }
 
-      // Maybe apply the PdgId filter
-      if (!pdgIds_.empty()) { // if we have a filter on pdg ids
-           if (pdgIds_.find(std::abs(isimtrk->type())) == pdgIds_.end()) continue;
-      }
+    GenParticle genp = makeGenParticle_(*isimtrk, Ref<GenParticleCollection>(), globals);
 
-      GenParticle genp = makeGenParticle_(*isimtrk, Ref<GenParticleCollection>(), globals);
+    // Maybe apply filter on the particle
+    if (!(filter_(genp)))
+      continue;
 
-      // Maybe apply filter on the particle
-      if (!(filter_(genp))) continue;
+    if (!motherPdgIds_.empty()) {
+      const SimTrack *motherSimTk = findGeantMother(*isimtrk, globals);
+      if (motherSimTk == nullptr)
+        continue;
+      if (motherPdgIds_.find(std::abs(motherSimTk->type())) == motherPdgIds_.end())
+        continue;
+    }
 
+    if (makeMotherLink_ || writeAncestors_) {
+      Ref<GenParticleCollection> motherRef;
+      const SimTrack *mother = findGeantMother(*isimtrk, globals);
+      if (mother != nullptr)
+        motherRef = findRef(*mother, globals);
+      if (motherRef.isNonnull())
+        genp.addMother(motherRef);
+    }
 
-      if (!motherPdgIds_.empty()) {
-           const SimTrack *motherSimTk = findGeantMother(*isimtrk, globals);
-           if (motherSimTk == nullptr) continue;
-           if (motherPdgIds_.find(std::abs(motherSimTk->type())) == motherPdgIds_.end()) continue;
-      }
-
-      if (makeMotherLink_ || writeAncestors_) {
-          Ref<GenParticleCollection> motherRef;
-          const SimTrack * mother = findGeantMother(*isimtrk, globals);
-          if (mother != nullptr) motherRef = findRef(*mother, globals);
-          if (motherRef.isNonnull()) genp.addMother(motherRef);
-      }
-
-      cands->push_back(genp);
+    cands->push_back(genp);
   }
 
   // Write to the Event, and get back a handle (which can be useful for debugging)
@@ -317,32 +326,34 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
 #ifdef DEBUG_PATGenCandsFromSimTracksProducer
   std::cout << "Produced a list of " << orphans->size() << " genParticles." << std::endl;
   for (GenParticleCollection::const_iterator it = orphans->begin(), ed = orphans->end(); it != ed; ++it) {
-      std::cout << "    ";
-      std::cout << "GenParticle #" << (it - orphans->begin()) << ": pdgId " << it->pdgId()
-                << ", pt = " << it->pt() << ", eta = " << it->eta() << ", phi = " << it->phi()
-                << ", rho = " << it->vertex().Rho() << ", z = " << it->vertex().Z() << std::endl;
-      edm::Ref<GenParticleCollection> mom = it->motherRef();
-      size_t depth = 2;
-      while (mom.isNonnull()) {
-          if (mom.id() == orphans.id()) {
-              // I need to re-make the ref because they are not working until this module returns.
-              mom = edm::Ref<GenParticleCollection>(orphans, mom.key());
-          }
-          for (size_t i = 0; i < depth; ++i) std::cout << "    ";
-          std::cout << "GenParticleRef [" << mom.id() << "/" << mom.key() << "]: pdgId " << mom->pdgId() << ", status = " << mom->status()
-                    << ", pt = " << mom->pt() << ", eta = " << mom->eta() << ", phi = " << mom->phi()
-                    << ", rho = " << mom->vertex().Rho() << ", z = " << mom->vertex().Z() << std::endl;
-          if (mom.id() != orphans.id()) break;
-          if ((mom->motherRef().id() == mom.id()) && (mom->motherRef().key() == mom.key())) {
-              throw cms::Exception("Corrupt Data") << "A particle is it's own mother.\n";
-          }
-          mom = mom->motherRef();
-          depth++;
+    std::cout << "    ";
+    std::cout << "GenParticle #" << (it - orphans->begin()) << ": pdgId " << it->pdgId() << ", pt = " << it->pt()
+              << ", eta = " << it->eta() << ", phi = " << it->phi() << ", rho = " << it->vertex().Rho()
+              << ", z = " << it->vertex().Z() << std::endl;
+    edm::Ref<GenParticleCollection> mom = it->motherRef();
+    size_t depth = 2;
+    while (mom.isNonnull()) {
+      if (mom.id() == orphans.id()) {
+        // I need to re-make the ref because they are not working until this module returns.
+        mom = edm::Ref<GenParticleCollection>(orphans, mom.key());
       }
+      for (size_t i = 0; i < depth; ++i)
+        std::cout << "    ";
+      std::cout << "GenParticleRef [" << mom.id() << "/" << mom.key() << "]: pdgId " << mom->pdgId()
+                << ", status = " << mom->status() << ", pt = " << mom->pt() << ", eta = " << mom->eta()
+                << ", phi = " << mom->phi() << ", rho = " << mom->vertex().Rho() << ", z = " << mom->vertex().Z()
+                << std::endl;
+      if (mom.id() != orphans.id())
+        break;
+      if ((mom->motherRef().id() == mom.id()) && (mom->motherRef().key() == mom.key())) {
+        throw cms::Exception("Corrupt Data") << "A particle is it's own mother.\n";
+      }
+      mom = mom->motherRef();
+      depth++;
+    }
   }
   std::cout << std::endl;
 #endif
-
 }
 
 DEFINE_FWK_MODULE(PATGenCandsFromSimTracksProducer);

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -24,119 +24,110 @@ namespace pat {
 
   class PATGenJetSlimmer : public edm::stream::EDProducer<> {
   public:
-    explicit PATGenJetSlimmer(const edm::ParameterSet & iConfig);
-    ~PATGenJetSlimmer() override { }
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-    
+    explicit PATGenJetSlimmer(const edm::ParameterSet& iConfig);
+    ~PATGenJetSlimmer() override {}
+
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
   private:
     const edm::EDGetTokenT<edm::View<reco::GenJet> > src_;
     const edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp_;
-    
+
     const StringCutObjectSelector<reco::GenJet> cut_;
     const StringCutObjectSelector<reco::GenJet> cutLoose_;
     const unsigned nLoose_;
-    
+
     /// reset daughters to an empty vector
     const bool clearDaughters_;
     /// drop the specific
     const bool dropSpecific_;
   };
 
-} // namespace
+}  // namespace pat
 
-
-pat::PATGenJetSlimmer::PATGenJetSlimmer(const edm::ParameterSet & iConfig) :
-    src_(consumes<edm::View<reco::GenJet> >(iConfig.getParameter<edm::InputTag>("src"))),
-    gp2pgp_(consumes<edm::Association<std::vector<pat::PackedGenParticle> > >(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
-    cut_(iConfig.getParameter<std::string>("cut")),
-    cutLoose_(iConfig.getParameter<std::string>("cutLoose")),
-    nLoose_(iConfig.getParameter<unsigned>("nLoose")),
-    clearDaughters_(iConfig.getParameter<bool>("clearDaughters")),
-    dropSpecific_(iConfig.getParameter<bool>("dropSpecific"))
-{
-    produces<std::vector<reco::GenJet> >();
-    produces< edm::Association<std::vector<reco::GenJet> > >("slimmedGenJetAssociation");
+pat::PATGenJetSlimmer::PATGenJetSlimmer(const edm::ParameterSet& iConfig)
+    : src_(consumes<edm::View<reco::GenJet> >(iConfig.getParameter<edm::InputTag>("src"))),
+      gp2pgp_(consumes<edm::Association<std::vector<pat::PackedGenParticle> > >(
+          iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
+      cut_(iConfig.getParameter<std::string>("cut")),
+      cutLoose_(iConfig.getParameter<std::string>("cutLoose")),
+      nLoose_(iConfig.getParameter<unsigned>("nLoose")),
+      clearDaughters_(iConfig.getParameter<bool>("clearDaughters")),
+      dropSpecific_(iConfig.getParameter<bool>("dropSpecific")) {
+  produces<std::vector<reco::GenJet> >();
+  produces<edm::Association<std::vector<reco::GenJet> > >("slimmedGenJetAssociation");
 }
 
-void 
-pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
+void pat::PATGenJetSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    Handle<View<reco::GenJet> >      src;
-    iEvent.getByToken(src_, src);
+  Handle<View<reco::GenJet> > src;
+  iEvent.getByToken(src_, src);
 
-    auto out = std::make_unique<vector<reco::GenJet> >();
-    out->reserve(src->size());
+  auto out = std::make_unique<vector<reco::GenJet> >();
+  out->reserve(src->size());
 
-    Handle<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp;
-    iEvent.getByToken(gp2pgp_,gp2pgp);
+  Handle<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp;
+  iEvent.getByToken(gp2pgp_, gp2pgp);
 
-    auto genJetSlimmedGenJetAssociation = make_unique< edm::Association<std::vector<reco::GenJet> > > ();
+  auto genJetSlimmedGenJetAssociation = make_unique<edm::Association<std::vector<reco::GenJet> > >();
 
-    auto mapping = std::make_unique<std::vector<int> >();
-    mapping->reserve(src->size());
+  auto mapping = std::make_unique<std::vector<int> >();
+  mapping->reserve(src->size());
 
-    unsigned nl = 0; // number of loose jets
-    for (View<reco::GenJet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-
-	bool selectedLoose = false;
-	if ( nLoose_ > 0 && nl < nLoose_ && cutLoose_(*it) ) {
-	  selectedLoose = true;
-	  ++nl;
-	}
-
-	bool pass = cut_(*it) || selectedLoose;
-        if (!pass ) {
-            mapping->push_back(-1);
-            continue;
-        }
-
-        out->push_back(*it);
-        reco::GenJet & jet = out->back();
-
-        mapping->push_back(it-src->begin());
-
-
-        if (clearDaughters_) {
-            jet.clearDaughters();
-        }   
-	    else // rekey   
-	    {
-                //copy old 
-		reco::CompositePtrCandidate::daughters old = jet.daughterPtrVector();
-		jet.clearDaughters();
-		std::map<unsigned int,reco::CandidatePtr> ptrs;
-		for(unsigned int  i=0;i<old.size();i++)
-		{
-//	if(! ((*gp2pgp)[old[i]]).isNonnull())	{
-//		std::cout << "Missing ref for key"  <<  old[i].key() << " pdgid " << old[i]->pdgId() << " st "<<   old[i]->status() <<  " pt " << old[i]->pt() << " eta " << old[i]->eta() << std::endl;
-//	}
-			ptrs[((*gp2pgp)[old[i]]).key()]=refToPtr((*gp2pgp)[old[i]]);
-		}
-		for(std::map<unsigned int,reco::CandidatePtr>::iterator itp=ptrs.begin();itp!=ptrs.end();itp++) //iterate on sorted items
-		{
-			jet.addDaughter(itp->second);
-		}
-
-
-	}
-        if (dropSpecific_) {
-            jet.setSpecific( reco::GenJet::Specific() );
-        }
-        
+  unsigned nl = 0;  // number of loose jets
+  for (View<reco::GenJet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    bool selectedLoose = false;
+    if (nLoose_ > 0 && nl < nLoose_ && cutLoose_(*it)) {
+      selectedLoose = true;
+      ++nl;
     }
 
-    edm::OrphanHandle<std::vector<reco::GenJet> >  orphanHandle= iEvent.put(std::move(out));
+    bool pass = cut_(*it) || selectedLoose;
+    if (!pass) {
+      mapping->push_back(-1);
+      continue;
+    }
 
-    auto asso = std::make_unique<edm::Association<std::vector<reco::GenJet> > >(orphanHandle);
-    edm::Association< std::vector<reco::GenJet> >::Filler slimmedAssoFiller(*asso);
-    slimmedAssoFiller.insert(src, mapping->begin(), mapping->end());
-    slimmedAssoFiller.fill();
+    out->push_back(*it);
+    reco::GenJet& jet = out->back();
 
-    
-    iEvent.put(std::move(asso),"slimmedGenJetAssociation");
+    mapping->push_back(it - src->begin());
+
+    if (clearDaughters_) {
+      jet.clearDaughters();
+    } else  // rekey
+    {
+      //copy old
+      reco::CompositePtrCandidate::daughters old = jet.daughterPtrVector();
+      jet.clearDaughters();
+      std::map<unsigned int, reco::CandidatePtr> ptrs;
+      for (unsigned int i = 0; i < old.size(); i++) {
+        //	if(! ((*gp2pgp)[old[i]]).isNonnull())	{
+        //		std::cout << "Missing ref for key"  <<  old[i].key() << " pdgid " << old[i]->pdgId() << " st "<<   old[i]->status() <<  " pt " << old[i]->pt() << " eta " << old[i]->eta() << std::endl;
+        //	}
+        ptrs[((*gp2pgp)[old[i]]).key()] = refToPtr((*gp2pgp)[old[i]]);
+      }
+      for (std::map<unsigned int, reco::CandidatePtr>::iterator itp = ptrs.begin(); itp != ptrs.end();
+           itp++)  //iterate on sorted items
+      {
+        jet.addDaughter(itp->second);
+      }
+    }
+    if (dropSpecific_) {
+      jet.setSpecific(reco::GenJet::Specific());
+    }
+  }
+
+  edm::OrphanHandle<std::vector<reco::GenJet> > orphanHandle = iEvent.put(std::move(out));
+
+  auto asso = std::make_unique<edm::Association<std::vector<reco::GenJet> > >(orphanHandle);
+  edm::Association<std::vector<reco::GenJet> >::Filler slimmedAssoFiller(*asso);
+  slimmedAssoFiller.insert(src, mapping->begin(), mapping->end());
+  slimmedAssoFiller.fill();
+
+  iEvent.put(std::move(asso), "slimmedGenJetAssociation");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
@@ -9,31 +9,36 @@
 
 using namespace pat;
 
-PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet & iConfig) :
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false),
-  userDataHelper_ ( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() )
-{
+PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet& iConfig)
+    : isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
+                                                : edm::ParameterSet(),
+                consumesCollector(),
+                false),
+      userDataHelper_(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector()) {
   // initialize the configurables
-  srcToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>( "src" ));
+  srcToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"));
 
   // RECO embedding
-  embedTrack_        = iConfig.getParameter<bool>( "embedTrack" );
-  embedGsfTrack_     = iConfig.getParameter<bool>( "embedGsfTrack" );
-  embedStandalone_   = iConfig.getParameter<bool>( "embedStandAloneMuon" );
-  embedCombined_     = iConfig.getParameter<bool>( "embedCombinedMuon" );
-  embedSuperCluster_ = iConfig.getParameter<bool>( "embedSuperCluster" );
-  embedTracks_       = iConfig.getParameter<bool>( "embedMultipleTracks" );
-  embedCaloTower_    = iConfig.getParameter<bool>( "embedCaloTower" );
+  embedTrack_ = iConfig.getParameter<bool>("embedTrack");
+  embedGsfTrack_ = iConfig.getParameter<bool>("embedGsfTrack");
+  embedStandalone_ = iConfig.getParameter<bool>("embedStandAloneMuon");
+  embedCombined_ = iConfig.getParameter<bool>("embedCombinedMuon");
+  embedSuperCluster_ = iConfig.getParameter<bool>("embedSuperCluster");
+  embedTracks_ = iConfig.getParameter<bool>("embedMultipleTracks");
+  embedCaloTower_ = iConfig.getParameter<bool>("embedCaloTower");
 
   // MC matching configurables
-  addGenMatch_   = iConfig.getParameter<bool>( "addGenMatch" );
+  addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
-      embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
-      if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-        genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
-      } else {
-        genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
-      }
+    embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
+    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(
+          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    } else {
+      genMatchTokens_ = edm::vector_transform(
+          iConfig.getParameter<std::vector<edm::InputTag> >("genParticleMatch"),
+          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection> >(tag); });
+    }
   }
 
   // quality
@@ -44,58 +49,69 @@ PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet &
   produces<std::vector<GenericParticle> >();
 
   if (iConfig.exists("isoDeposits")) {
-     edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>("isoDeposits");
-     if (depconf.exists("tracker")) isoDepositLabels_.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-     if (depconf.exists("ecal"))    isoDepositLabels_.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-     if (depconf.exists("hcal"))    isoDepositLabels_.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-     if (depconf.exists("user")) {
-        std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
-        std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
-        int key = UserBaseIso;
-        for ( ; it != ed; ++it, ++key) {
-            isoDepositLabels_.push_back(std::make_pair(IsolationKeys(key), *it));
-        }
-     }
+    edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>("isoDeposits");
+    if (depconf.exists("tracker"))
+      isoDepositLabels_.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
+    if (depconf.exists("ecal"))
+      isoDepositLabels_.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
+    if (depconf.exists("hcal"))
+      isoDepositLabels_.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
+    if (depconf.exists("user")) {
+      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
+      std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
+      int key = UserBaseIso;
+      for (; it != ed; ++it, ++key) {
+        isoDepositLabels_.push_back(std::make_pair(IsolationKeys(key), *it));
+      }
+    }
   }
-  isoDepositTokens_ = edm::vector_transform(isoDepositLabels_, [this](std::pair<IsolationKeys,edm::InputTag> const & label){return consumes<edm::ValueMap<IsoDeposit> >(label.second);});
+  isoDepositTokens_ =
+      edm::vector_transform(isoDepositLabels_, [this](std::pair<IsolationKeys, edm::InputTag> const& label) {
+        return consumes<edm::ValueMap<IsoDeposit> >(label.second);
+      });
 
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
 
   if (iConfig.exists("vertexing")) {
-     vertexingHelper_ = pat::helper::VertexingHelper(iConfig.getParameter<edm::ParameterSet>("vertexing"), consumesCollector());
+    vertexingHelper_ =
+        pat::helper::VertexingHelper(iConfig.getParameter<edm::ParameterSet>("vertexing"), consumesCollector());
   }
 
   // Check to see if the user wants to add user data
   useUserData_ = false;
-  if ( iConfig.exists("userData") ) {
+  if (iConfig.exists("userData")) {
     useUserData_ = true;
   }
 }
 
-PATGenericParticleProducer::~PATGenericParticleProducer() {
-}
+PATGenericParticleProducer::~PATGenericParticleProducer() {}
 
-void PATGenericParticleProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void PATGenericParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Get the vector of GenericParticle's from the event
   edm::Handle<edm::View<reco::Candidate> > cands;
   iEvent.getByToken(srcToken_, cands);
 
   // prepare isolation
-  if (isolator_.enabled()) isolator_.beginEvent(iEvent,iSetup);
+  if (isolator_.enabled())
+    isolator_.beginEvent(iEvent, iSetup);
 
-  if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
-  if (vertexingHelper_.enabled())  vertexingHelper_.newEvent(iEvent,iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
+  if (vertexingHelper_.enabled())
+    vertexingHelper_.newEvent(iEvent, iSetup);
 
   // prepare IsoDeposits
   std::vector<edm::Handle<edm::ValueMap<IsoDeposit> > > deposits(isoDepositTokens_.size());
@@ -106,76 +122,89 @@ void PATGenericParticleProducer::produce(edm::Event & iEvent, const edm::EventSe
   // prepare the MC matching
   std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
-        for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
-            iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
-        }
+    for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
+      iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
+    }
   }
 
   // prepare the quality
   edm::Handle<edm::ValueMap<float> > qualities;
-  if (addQuality_) iEvent.getByToken(qualitySrcToken_, qualities);
+  if (addQuality_)
+    iEvent.getByToken(qualitySrcToken_, qualities);
 
   // loop over cands
-  std::vector<GenericParticle> * PATGenericParticles = new std::vector<GenericParticle>();
-  for (edm::View<reco::Candidate>::const_iterator itGenericParticle = cands->begin(); itGenericParticle != cands->end(); itGenericParticle++) {
+  std::vector<GenericParticle>* PATGenericParticles = new std::vector<GenericParticle>();
+  for (edm::View<reco::Candidate>::const_iterator itGenericParticle = cands->begin(); itGenericParticle != cands->end();
+       itGenericParticle++) {
     // construct the GenericParticle from the ref -> save ref to original object
     unsigned int idx = itGenericParticle - cands->begin();
     edm::RefToBase<reco::Candidate> candRef = cands->refAt(idx);
 
     PATGenericParticles->push_back(GenericParticle(candRef));
-    GenericParticle & aGenericParticle = PATGenericParticles->back();
+    GenericParticle& aGenericParticle = PATGenericParticles->back();
 
     // embed RECO
-    if (embedTrack_)        aGenericParticle.embedTrack();
-    if (embedGsfTrack_)     aGenericParticle.embedGsfTrack();
-    if (embedTracks_)       aGenericParticle.embedTracks();
-    if (embedStandalone_)   aGenericParticle.embedStandalone();
-    if (embedCombined_)     aGenericParticle.embedCombined();
-    if (embedSuperCluster_) aGenericParticle.embedSuperCluster();
-    if (embedCaloTower_)    aGenericParticle.embedCaloTower();
+    if (embedTrack_)
+      aGenericParticle.embedTrack();
+    if (embedGsfTrack_)
+      aGenericParticle.embedGsfTrack();
+    if (embedTracks_)
+      aGenericParticle.embedTracks();
+    if (embedStandalone_)
+      aGenericParticle.embedStandalone();
+    if (embedCombined_)
+      aGenericParticle.embedCombined();
+    if (embedSuperCluster_)
+      aGenericParticle.embedSuperCluster();
+    if (embedCaloTower_)
+      aGenericParticle.embedCaloTower();
 
     // isolation
     if (isolator_.enabled()) {
-        isolator_.fill(*cands, idx, isolatorTmpStorage_);
-        typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
-        // better to loop backwards, so the vector is resized less times
-        for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(), ed = isolatorTmpStorage_.rend(); it != ed; ++it) {
-            aGenericParticle.setIsolation(it->first, it->second);
-        }
+      isolator_.fill(*cands, idx, isolatorTmpStorage_);
+      typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
+      // better to loop backwards, so the vector is resized less times
+      for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(),
+                                                       ed = isolatorTmpStorage_.rend();
+           it != ed;
+           ++it) {
+        aGenericParticle.setIsolation(it->first, it->second);
+      }
     }
 
     // isodeposit
     for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-        aGenericParticle.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[candRef]);
+      aGenericParticle.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[candRef]);
     }
 
     // store the match to the generated final state muons
     if (addGenMatch_) {
-      for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
-          reco::GenParticleRef genGenericParticle = (*genMatches[i])[candRef];
-          aGenericParticle.addGenParticleRef(genGenericParticle);
+      for (size_t i = 0, n = genMatches.size(); i < n; ++i) {
+        reco::GenParticleRef genGenericParticle = (*genMatches[i])[candRef];
+        aGenericParticle.addGenParticleRef(genGenericParticle);
       }
-      if (embedGenMatch_) aGenericParticle.embedGenParticle();
+      if (embedGenMatch_)
+        aGenericParticle.embedGenParticle();
     }
 
     if (addQuality_) {
-      aGenericParticle.setQuality( (*qualities)[candRef] );
+      aGenericParticle.setQuality((*qualities)[candRef]);
     }
 
     if (efficiencyLoader_.enabled()) {
-        efficiencyLoader_.setEfficiencies( aGenericParticle, candRef );
+      efficiencyLoader_.setEfficiencies(aGenericParticle, candRef);
     }
 
     if (resolutionLoader_.enabled()) {
-        resolutionLoader_.setResolutions(aGenericParticle);
+      resolutionLoader_.setResolutions(aGenericParticle);
     }
 
     if (vertexingHelper_.enabled()) {
-        aGenericParticle.setVertexAssociation( vertexingHelper_(candRef) );
+      aGenericParticle.setVertexAssociation(vertexingHelper_(candRef));
     }
 
-    if ( useUserData_ ) {
-        userDataHelper_.add( aGenericParticle, iEvent, iSetup );
+    if (useUserData_) {
+      userDataHelper_.add(aGenericParticle, iEvent, iSetup);
     }
 
     // PATGenericParticles->push_back(aGenericParticle); // NOOOOO!!!!
@@ -189,8 +218,8 @@ void PATGenericParticleProducer::produce(edm::Event & iEvent, const edm::EventSe
   // put genEvt object in Event
   std::unique_ptr<std::vector<GenericParticle> > myGenericParticles(PATGenericParticles);
   iEvent.put(std::move(myGenericParticles));
-  if (isolator_.enabled()) isolator_.endEvent();
-
+  if (isolator_.enabled())
+    isolator_.endEvent();
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h
@@ -15,7 +15,6 @@
   \version  $Id: PATGenericParticleProducer.h,v 1.9 2009/06/25 23:49:35 gpetrucc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,51 +39,47 @@
 namespace pat {
 
   class PATGenericParticleProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATGenericParticleProducer(const edm::ParameterSet& iConfig);
+    ~PATGenericParticleProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATGenericParticleProducer(const edm::ParameterSet & iConfig);
-      ~PATGenericParticleProducer() override;
+  private:
+    // configurables
+    edm::EDGetTokenT<edm::View<reco::Candidate> > srcToken_;
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    // embed RECo objects
+    bool embedSuperCluster_, embedTrack_, embedTracks_, embedGsfTrack_, embedCaloTower_, embedStandalone_,
+        embedCombined_;
 
-    private:
+    bool addQuality_;
+    edm::EDGetTokenT<edm::ValueMap<float> > qualitySrcToken_;
 
-      // configurables
-      edm::EDGetTokenT<edm::View<reco::Candidate> > srcToken_;
+    bool addGenMatch_;
+    bool embedGenMatch_;
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
-      // embed RECo objects
-      bool embedSuperCluster_, embedTrack_, embedTracks_, embedGsfTrack_, embedCaloTower_, embedStandalone_, embedCombined_;
+    // tools
+    GreaterByEt<GenericParticle> eTComparator_;
 
-      bool addQuality_;
-      edm::EDGetTokenT<edm::ValueMap<float> > qualitySrcToken_;
+    pat::helper::MultiIsolator isolator_;
+    pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_;  // better here than recreate at each event
+    std::vector<std::pair<pat::IsolationKeys, edm::InputTag> > isoDepositLabels_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
 
-      bool addGenMatch_;
-      bool embedGenMatch_;
-      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      // tools
-      GreaterByEt<GenericParticle> eTComparator_;
+    bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      pat::helper::MultiIsolator isolator_;
-      pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
-      std::vector<std::pair<pat::IsolationKeys,edm::InputTag> > isoDepositLabels_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
+    pat::helper::VertexingHelper vertexingHelper_;
 
-      bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
-
-      bool addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
-
-      pat::helper::VertexingHelper vertexingHelper_;
-
-      bool useUserData_;
-      pat::PATUserDataHelper<pat::GenericParticle> userDataHelper_;
-
+    bool useUserData_;
+    pat::PATUserDataHelper<pat::GenericParticle> userDataHelper_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATHeavyIonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATHeavyIonProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PATHeavyIonProducer
 // Class:      PATHeavyIonProducer
-// 
+//
 /**\class PATHeavyIonProducer PATHeavyIonProducer.cc yetkin/PATHeavyIonProducer/src/PATHeavyIonProducer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Thu Aug 13 08:39:51 EDT 2009
 //
 //
-
 
 // system include files
 #include <memory>
@@ -47,23 +46,21 @@ class PATHeavyIonProducer : public edm::global::EDProducer<> {
 public:
   explicit PATHeavyIonProducer(const edm::ParameterSet&);
   ~PATHeavyIonProducer() override;
-  
+
 private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   // ----------member data ---------------------------
-  
+
   const bool doMC_;
   const bool doReco_;
   const std::vector<std::string> hepmcSrc_;
   const edm::InputTag centSrc_;
   const edm::InputTag evtPlaneSrc_;
-
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -72,36 +69,27 @@ private:
 //
 // constructors and destructor
 //
-PATHeavyIonProducer::PATHeavyIonProducer(const edm::ParameterSet& iConfig) :
-  doMC_(iConfig.getParameter<bool>("doMC")),
-  doReco_(iConfig.getParameter<bool>("doReco")),
-  hepmcSrc_( doMC_ ? iConfig.getParameter<std::vector<std::string> >("generators") : std::vector<std::string>() ),
-  centSrc_( doReco_ ? iConfig.getParameter<edm::InputTag>("centrality") : edm::InputTag() ),
-  evtPlaneSrc_(doReco_ ? iConfig.getParameter<edm::InputTag>("evtPlane") : edm::InputTag() )
-{
-   //register your products
-   produces<pat::HeavyIon>();   
+PATHeavyIonProducer::PATHeavyIonProducer(const edm::ParameterSet& iConfig)
+    : doMC_(iConfig.getParameter<bool>("doMC")),
+      doReco_(iConfig.getParameter<bool>("doReco")),
+      hepmcSrc_(doMC_ ? iConfig.getParameter<std::vector<std::string> >("generators") : std::vector<std::string>()),
+      centSrc_(doReco_ ? iConfig.getParameter<edm::InputTag>("centrality") : edm::InputTag()),
+      evtPlaneSrc_(doReco_ ? iConfig.getParameter<edm::InputTag>("evtPlane") : edm::InputTag()) {
+  //register your products
+  produces<pat::HeavyIon>();
 }
 
-
-PATHeavyIonProducer::~PATHeavyIonProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+PATHeavyIonProducer::~PATHeavyIonProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-PATHeavyIonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-
-}
+void PATHeavyIonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(PATHeavyIonProducer);

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
@@ -17,7 +17,6 @@
 //
 //
 
-
 //system
 #include <vector>
 #include <memory>
@@ -35,11 +34,9 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Candidate/interface/Particle.h"
 //User
-#include  "PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h"
-
+#include "PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h"
 
 using namespace pat;
-
 
 //
 // constants, enums and typedefs
@@ -52,54 +49,46 @@ using namespace pat;
 //
 // constructors and destructor
 //
-PATHemisphereProducer::PATHemisphereProducer(const edm::ParameterSet& iConfig) :
-  _patJetsToken       ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patJets" ) ) ),
-  _patMuonsToken      ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patMuons" ) ) ),
-  _patElectronsToken  ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patElectrons" ) ) ),
-  _patPhotonsToken    ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patPhotons" ) ) ),
-  _patTausToken       ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patTaus" ) ) ),
+PATHemisphereProducer::PATHemisphereProducer(const edm::ParameterSet& iConfig)
+    : _patJetsToken(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("patJets"))),
+      _patMuonsToken(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("patMuons"))),
+      _patElectronsToken(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("patElectrons"))),
+      _patPhotonsToken(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("patPhotons"))),
+      _patTausToken(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("patTaus"))),
 
-  _minJetEt       ( iConfig.getParameter<double>("minJetEt") ),
-  _minMuonEt       ( iConfig.getParameter<double>("minMuonEt") ),
-  _minElectronEt       ( iConfig.getParameter<double>("minElectronEt") ),
-  _minTauEt       ( iConfig.getParameter<double>("minTauEt") ),
-  _minPhotonEt       ( iConfig.getParameter<double>("minPhotonEt") ),
+      _minJetEt(iConfig.getParameter<double>("minJetEt")),
+      _minMuonEt(iConfig.getParameter<double>("minMuonEt")),
+      _minElectronEt(iConfig.getParameter<double>("minElectronEt")),
+      _minTauEt(iConfig.getParameter<double>("minTauEt")),
+      _minPhotonEt(iConfig.getParameter<double>("minPhotonEt")),
 
-  _maxJetEta       ( iConfig.getParameter<double>("maxJetEta") ),
-  _maxMuonEta       ( iConfig.getParameter<double>("maxMuonEta") ),
-  _maxElectronEta       ( iConfig.getParameter<double>("maxElectronEta") ),
-  _maxTauEta       ( iConfig.getParameter<double>("maxTauEta") ),
-  _maxPhotonEta       ( iConfig.getParameter<double>("maxPhotonEta") ),
+      _maxJetEta(iConfig.getParameter<double>("maxJetEta")),
+      _maxMuonEta(iConfig.getParameter<double>("maxMuonEta")),
+      _maxElectronEta(iConfig.getParameter<double>("maxElectronEta")),
+      _maxTauEta(iConfig.getParameter<double>("maxTauEta")),
+      _maxPhotonEta(iConfig.getParameter<double>("maxPhotonEta")),
 
-  _seedMethod    ( iConfig.getParameter<int>("seedMethod") ),
-  _combinationMethod ( iConfig.getParameter<int>("combinationMethod") )
+      _seedMethod(iConfig.getParameter<int>("seedMethod")),
+      _combinationMethod(iConfig.getParameter<int>("combinationMethod"))
 
 {
-
-
-  produces< std::vector<pat::Hemisphere> >();
+  produces<std::vector<pat::Hemisphere>>();
 }
 
-
-PATHemisphereProducer::~PATHemisphereProducer()
-{
-
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+PATHemisphereProducer::~PATHemisphereProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-PATHemisphereProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void PATHemisphereProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
   using namespace std;
-  
+
   std::vector<float> vPx, vPy, vPz, vE;
   std::vector<float> vA1, vA2;
   std::vector<int> vgroups;
@@ -107,88 +96,90 @@ PATHemisphereProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
 
   //Jets
   Handle<reco::CandidateView> pJets;
-  iEvent.getByToken(_patJetsToken,pJets);
+  iEvent.getByToken(_patJetsToken, pJets);
 
   //Muons
   Handle<reco::CandidateView> pMuons;
-  iEvent.getByToken(_patMuonsToken,pMuons);
-  
+  iEvent.getByToken(_patMuonsToken, pMuons);
+
   //Electrons
   Handle<reco::CandidateView> pElectrons;
-  iEvent.getByToken(_patElectronsToken,pElectrons);
-  
+  iEvent.getByToken(_patElectronsToken, pElectrons);
+
   //Photons
   Handle<reco::CandidateView> pPhotons;
-  iEvent.getByToken(_patPhotonsToken,pPhotons);
-  
+  iEvent.getByToken(_patPhotonsToken, pPhotons);
+
   //Taus
   Handle<reco::CandidateView> pTaus;
-  iEvent.getByToken(_patTausToken,pTaus);
-  
-  
+  iEvent.getByToken(_patTausToken, pTaus);
+
   //fill e,p vector with information from all objects (hopefully cleaned before)
-  for(int i = 0; i < (int) (*pJets).size() ; i++){
-    if((*pJets)[i].pt() <  _minJetEt || fabs((*pJets)[i].eta()) >  _maxJetEta) continue;
-    
+  for (int i = 0; i < (int)(*pJets).size(); i++) {
+    if ((*pJets)[i].pt() < _minJetEt || fabs((*pJets)[i].eta()) > _maxJetEta)
+      continue;
+
     componentPtrs.push_back(pJets->ptrAt(i));
   }
-  
-  for(int i = 0; i < (int) (*pMuons).size() ; i++){
-    if((*pMuons)[i].pt() <  _minMuonEt || fabs((*pMuons)[i].eta()) >  _maxMuonEta) continue;
-    
+
+  for (int i = 0; i < (int)(*pMuons).size(); i++) {
+    if ((*pMuons)[i].pt() < _minMuonEt || fabs((*pMuons)[i].eta()) > _maxMuonEta)
+      continue;
+
     componentPtrs.push_back(pMuons->ptrAt(i));
   }
-  
-  for(int i = 0; i < (int) (*pElectrons).size() ; i++){
-    if((*pElectrons)[i].pt() <  _minElectronEt || fabs((*pElectrons)[i].eta()) >  _maxElectronEta) continue;
-    
+
+  for (int i = 0; i < (int)(*pElectrons).size(); i++) {
+    if ((*pElectrons)[i].pt() < _minElectronEt || fabs((*pElectrons)[i].eta()) > _maxElectronEta)
+      continue;
+
     componentPtrs.push_back(pElectrons->ptrAt(i));
   }
-  
-  for(int i = 0; i < (int) (*pPhotons).size() ; i++){
-    if((*pPhotons)[i].pt() <  _minPhotonEt || fabs((*pPhotons)[i].eta()) >  _maxPhotonEta) continue;
-    
+
+  for (int i = 0; i < (int)(*pPhotons).size(); i++) {
+    if ((*pPhotons)[i].pt() < _minPhotonEt || fabs((*pPhotons)[i].eta()) > _maxPhotonEta)
+      continue;
+
     componentPtrs.push_back(pPhotons->ptrAt(i));
   }
-  
+
   //aren't taus included in jets?
-  for(int i = 0; i < (int) (*pTaus).size() ; i++){
-    if((*pTaus)[i].pt() <  _minTauEt || fabs((*pTaus)[i].eta()) >  _maxTauEta) continue;
-    
+  for (int i = 0; i < (int)(*pTaus).size(); i++) {
+    if ((*pTaus)[i].pt() < _minTauEt || fabs((*pTaus)[i].eta()) > _maxTauEta)
+      continue;
+
     componentPtrs.push_back(pTaus->ptrAt(i));
   }
-  
+
   // create product
   auto hemispheres = std::make_unique<std::vector<Hemisphere>>();
   hemispheres->reserve(2);
-  
+
   //calls HemiAlgorithm for seed method 3 (transv. inv. Mass) and association method 3 (Lund algo)
-  HemisphereAlgo myHemi(componentPtrs,_seedMethod,_combinationMethod);
-  
+  HemisphereAlgo myHemi(componentPtrs, _seedMethod, _combinationMethod);
+
   //get Hemisphere Axis
   vA1 = myHemi.getAxis1();
   vA2 = myHemi.getAxis2();
-  
-  reco::Particle::LorentzVector p1(vA1[0]*vA1[3],vA1[1]*vA1[3],vA1[2]*vA1[3],vA1[4]);
+
+  reco::Particle::LorentzVector p1(vA1[0] * vA1[3], vA1[1] * vA1[3], vA1[2] * vA1[3], vA1[4]);
   hemispheres->push_back(Hemisphere(p1));
 
-  reco::Particle::LorentzVector p2(vA2[0]*vA2[3],vA2[1]*vA2[3],vA2[2]*vA2[3],vA2[4]);
+  reco::Particle::LorentzVector p2(vA2[0] * vA2[3], vA2[1] * vA2[3], vA2[2] * vA2[3], vA2[4]);
   hemispheres->push_back(Hemisphere(p2));
 
   //get information to which Hemisphere each object belongs
   vgroups = myHemi.getGrouping();
 
-  for ( unsigned int i=0; i<vgroups.size(); ++i ) {
-    if ( vgroups[i]==1 ) {
+  for (unsigned int i = 0; i < vgroups.size(); ++i) {
+    if (vgroups[i] == 1) {
       (*hemispheres)[0].addDaughter(componentPtrs[i]);
-    }
-    else {
+    } else {
       (*hemispheres)[1].addDaughter(componentPtrs[i]);
     }
   }
-  
-  
-  iEvent.put(std::move(hemispheres));  
+
+  iEvent.put(std::move(hemispheres));
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
@@ -22,7 +22,7 @@
 // system include files
 #include <memory>
 #include <map>
-#include <utility>//pair
+#include <utility>  //pair
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -41,10 +41,10 @@ class PATHemisphereProducer : public edm::global::EDProducer<> {
 public:
   explicit PATHemisphereProducer(const edm::ParameterSet&);
   ~PATHemisphereProducer() override;
-  
+
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  
-private:  
+
+private:
   // ----------member data ---------------------------
   /// Input: All PAT objects that are to cross-clean  or needed for that
   const edm::EDGetTokenT<reco::CandidateView> _patJetsToken;
@@ -53,25 +53,23 @@ private:
   const edm::EDGetTokenT<reco::CandidateView> _patElectronsToken;
   const edm::EDGetTokenT<reco::CandidateView> _patPhotonsToken;
   const edm::EDGetTokenT<reco::CandidateView> _patTausToken;
-  
+
   const float _minJetEt;
   const float _minMuonEt;
   const float _minElectronEt;
   const float _minTauEt;
   const float _minPhotonEt;
-  
+
   const float _maxJetEta;
   const float _maxMuonEta;
   const float _maxElectronEta;
   const float _maxTauEta;
   const float _maxPhotonEta;
-  
+
   const int _seedMethod;
   const int _combinationMethod;
-  
+
   typedef std::vector<float> HemiAxis;
 };
 
 #endif
-
-

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -41,687 +41,735 @@
 
 namespace pat {
 
-    class PATIsolatedTrackProducer : public edm::stream::EDProducer<> {
-      public:
-          typedef pat::IsolatedTrack::LorentzVector LorentzVector;
+  class PATIsolatedTrackProducer : public edm::stream::EDProducer<> {
+  public:
+    typedef pat::IsolatedTrack::LorentzVector LorentzVector;
 
-          explicit PATIsolatedTrackProducer(const edm::ParameterSet&);
-          ~PATIsolatedTrackProducer() override;
+    explicit PATIsolatedTrackProducer(const edm::ParameterSet&);
+    ~PATIsolatedTrackProducer() override;
 
-          void produce(edm::Event&, const edm::EventSetup&) override;
-        
-          // compute iso/miniiso
-          void getIsolation(const LorentzVector& p4, const pat::PackedCandidateCollection* pc, int pc_idx,
-                            pat::PFIsolation &iso, pat::PFIsolation &miniiso) const;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
-          bool getPFLeptonOverlap(const LorentzVector& p4, const pat::PackedCandidateCollection* pc) const;
+    // compute iso/miniiso
+    void getIsolation(const LorentzVector& p4,
+                      const pat::PackedCandidateCollection* pc,
+                      int pc_idx,
+                      pat::PFIsolation& iso,
+                      pat::PFIsolation& miniiso) const;
 
-          float getPFNeutralSum(const LorentzVector& p4, const pat::PackedCandidateCollection* pc, int pc_idx) const;
+    bool getPFLeptonOverlap(const LorentzVector& p4, const pat::PackedCandidateCollection* pc) const;
 
-          void getNearestPCRef(const LorentzVector& p4, const pat::PackedCandidateCollection *pc, int pc_idx, int& pc_ref_idx) const;
-      
-          float getDeDx(const reco::DeDxHitInfo *hitInfo, bool doPixel, bool doStrip) const ;
+    float getPFNeutralSum(const LorentzVector& p4, const pat::PackedCandidateCollection* pc, int pc_idx) const;
 
-          TrackDetMatchInfo getTrackDetMatchInfo(const edm::Event&, const edm::EventSetup&, const reco::Track&);
+    void getNearestPCRef(const LorentzVector& p4,
+                         const pat::PackedCandidateCollection* pc,
+                         int pc_idx,
+                         int& pc_ref_idx) const;
 
-          void getCaloJetEnergy(const LorentzVector&, const reco::CaloJetCollection*, float&, float&) const;
+    float getDeDx(const reco::DeDxHitInfo* hitInfo, bool doPixel, bool doStrip) const;
 
-      private:             
-          const edm::EDGetTokenT<pat::PackedCandidateCollection>    pc_;
-          const edm::EDGetTokenT<pat::PackedCandidateCollection>    lt_;
-          const edm::EDGetTokenT<reco::TrackCollection>    gt_;
-          const edm::EDGetTokenT<reco::VertexCollection>    pv_;
-          const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > gt2pc_;
-          const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > gt2lt_;
-          const edm::EDGetTokenT<edm::Association<reco::PFCandidateCollection> > pc2pf_;
-          const edm::EDGetTokenT<reco::CaloJetCollection> caloJets_;
-          const edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > gt2dedxStrip_;
-          const edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > gt2dedxPixel_;
-          const edm::EDGetTokenT<reco::DeDxHitInfoAss> gt2dedxHitInfo_;
-          const bool addPrescaledDeDxTracks_;
-          const edm::EDGetTokenT<edm::ValueMap<int> >  gt2dedxHitInfoPrescale_;
-          const bool usePrecomputedDeDxStrip_;
-          const bool usePrecomputedDeDxPixel_;
-          const float pT_cut_;  // only save cands with pT>pT_cut_
-          const float pT_cut_noIso_;  // above this pT, don't apply any iso cut
-          const float pfIsolation_DR_;  // isolation radius
-          const float pfIsolation_DZ_;  // used in determining if pfcand is from PV or PU
-          const float absIso_cut_;  // save if ANY of absIso, relIso, or miniRelIso pass the cuts 
-          const float relIso_cut_;
-          const float miniRelIso_cut_;
-          const float caloJet_DR_;  // save energy of nearest calojet within caloJet_DR_
-          const float pflepoverlap_DR_;  // pf lepton overlap radius
-          const float pflepoverlap_pTmin_;  // pf lepton overlap min pT (only look at PF candidates with pT>pflepoverlap_pTmin_)
-          const float pcRefNearest_DR_;  // radius for nearest charged packed candidate
-          const float pcRefNearest_pTmin_;  // min pT for nearest charged packed candidate
-          const float pfneutralsum_DR_;  // pf lepton overlap radius
-          const bool saveDeDxHitInfo_;
-          StringCutObjectSelector<pat::IsolatedTrack> saveDeDxHitInfoCut_;
+    TrackDetMatchInfo getTrackDetMatchInfo(const edm::Event&, const edm::EventSetup&, const reco::Track&);
 
-          std::vector<double> miniIsoParams_;
+    void getCaloJetEnergy(const LorentzVector&, const reco::CaloJetCollection*, float&, float&) const;
 
-          TrackDetectorAssociator trackAssociator_;
-          TrackAssociatorParameters trackAssocParameters_;
-    };
-}
+  private:
+    const edm::EDGetTokenT<pat::PackedCandidateCollection> pc_;
+    const edm::EDGetTokenT<pat::PackedCandidateCollection> lt_;
+    const edm::EDGetTokenT<reco::TrackCollection> gt_;
+    const edm::EDGetTokenT<reco::VertexCollection> pv_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> gt2pc_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> gt2lt_;
+    const edm::EDGetTokenT<edm::Association<reco::PFCandidateCollection>> pc2pf_;
+    const edm::EDGetTokenT<reco::CaloJetCollection> caloJets_;
+    const edm::EDGetTokenT<edm::ValueMap<reco::DeDxData>> gt2dedxStrip_;
+    const edm::EDGetTokenT<edm::ValueMap<reco::DeDxData>> gt2dedxPixel_;
+    const edm::EDGetTokenT<reco::DeDxHitInfoAss> gt2dedxHitInfo_;
+    const bool addPrescaledDeDxTracks_;
+    const edm::EDGetTokenT<edm::ValueMap<int>> gt2dedxHitInfoPrescale_;
+    const bool usePrecomputedDeDxStrip_;
+    const bool usePrecomputedDeDxPixel_;
+    const float pT_cut_;          // only save cands with pT>pT_cut_
+    const float pT_cut_noIso_;    // above this pT, don't apply any iso cut
+    const float pfIsolation_DR_;  // isolation radius
+    const float pfIsolation_DZ_;  // used in determining if pfcand is from PV or PU
+    const float absIso_cut_;      // save if ANY of absIso, relIso, or miniRelIso pass the cuts
+    const float relIso_cut_;
+    const float miniRelIso_cut_;
+    const float caloJet_DR_;          // save energy of nearest calojet within caloJet_DR_
+    const float pflepoverlap_DR_;     // pf lepton overlap radius
+    const float pflepoverlap_pTmin_;  // pf lepton overlap min pT (only look at PF candidates with pT>pflepoverlap_pTmin_)
+    const float pcRefNearest_DR_;     // radius for nearest charged packed candidate
+    const float pcRefNearest_pTmin_;  // min pT for nearest charged packed candidate
+    const float pfneutralsum_DR_;     // pf lepton overlap radius
+    const bool saveDeDxHitInfo_;
+    StringCutObjectSelector<pat::IsolatedTrack> saveDeDxHitInfoCut_;
 
-pat::PATIsolatedTrackProducer::PATIsolatedTrackProducer(const edm::ParameterSet& iConfig) :
-  pc_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  lt_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostTracks"))),
-  gt_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("generalTracks"))),
-  pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
-  gt2pc_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  gt2lt_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("lostTracks"))),
-  pc2pf_(consumes<edm::Association<reco::PFCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  caloJets_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("caloJets"))),
-  gt2dedxStrip_(consumes<edm::ValueMap<reco::DeDxData> >(iConfig.getParameter<edm::InputTag>("dEdxDataStrip"))),
-  gt2dedxPixel_(consumes<edm::ValueMap<reco::DeDxData> >(iConfig.getParameter<edm::InputTag>("dEdxDataPixel"))),
-  gt2dedxHitInfo_(consumes<reco::DeDxHitInfoAss>(iConfig.getParameter<edm::InputTag>("dEdxHitInfo"))),
-  addPrescaledDeDxTracks_(iConfig.getParameter<bool>("addPrescaledDeDxTracks")),
-  gt2dedxHitInfoPrescale_(addPrescaledDeDxTracks_ ? consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("dEdxHitInfoPrescale")) : edm::EDGetTokenT<edm::ValueMap<int>>()),
-  usePrecomputedDeDxStrip_(iConfig.getParameter<bool>("usePrecomputedDeDxStrip")),
-  usePrecomputedDeDxPixel_(iConfig.getParameter<bool>("usePrecomputedDeDxPixel")),
-  pT_cut_         (iConfig.getParameter<double>("pT_cut")),
-  pT_cut_noIso_   (iConfig.getParameter<double>("pT_cut_noIso")),
-  pfIsolation_DR_ (iConfig.getParameter<double>("pfIsolation_DR")),
-  pfIsolation_DZ_ (iConfig.getParameter<double>("pfIsolation_DZ")),
-  absIso_cut_     (iConfig.getParameter<double>("absIso_cut")),
-  relIso_cut_     (iConfig.getParameter<double>("relIso_cut")),
-  miniRelIso_cut_ (iConfig.getParameter<double>("miniRelIso_cut")),
-  caloJet_DR_     (iConfig.getParameter<double>("caloJet_DR")),
-  pflepoverlap_DR_ (iConfig.getParameter<double>("pflepoverlap_DR")),
-  pflepoverlap_pTmin_ (iConfig.getParameter<double>("pflepoverlap_pTmin")),
-  pcRefNearest_DR_ (iConfig.getParameter<double>("pcRefNearest_DR")),
-  pcRefNearest_pTmin_ (iConfig.getParameter<double>("pcRefNearest_pTmin")),
-  pfneutralsum_DR_ (iConfig.getParameter<double>("pfneutralsum_DR")),
-  saveDeDxHitInfo_(iConfig.getParameter<bool>("saveDeDxHitInfo")),
-  saveDeDxHitInfoCut_(iConfig.getParameter<std::string>("saveDeDxHitInfoCut"))
-{
-    // TrackAssociator parameters
-    edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
-    edm::ConsumesCollector iC = consumesCollector();
-    trackAssocParameters_.loadParameters( parameters, iC );
+    std::vector<double> miniIsoParams_;
 
-    trackAssociator_.useDefaultPropagator();
+    TrackDetectorAssociator trackAssociator_;
+    TrackAssociatorParameters trackAssocParameters_;
+  };
+}  // namespace pat
 
-    miniIsoParams_ = iConfig.getParameter<std::vector<double> >("miniIsoParams");
-    if(miniIsoParams_.size() != 3)
-        throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 3 elements.\n";
+pat::PATIsolatedTrackProducer::PATIsolatedTrackProducer(const edm::ParameterSet& iConfig)
+    : pc_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      lt_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostTracks"))),
+      gt_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("generalTracks"))),
+      pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+      gt2pc_(consumes<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      gt2lt_(consumes<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("lostTracks"))),
+      pc2pf_(consumes<edm::Association<reco::PFCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      caloJets_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("caloJets"))),
+      gt2dedxStrip_(consumes<edm::ValueMap<reco::DeDxData>>(iConfig.getParameter<edm::InputTag>("dEdxDataStrip"))),
+      gt2dedxPixel_(consumes<edm::ValueMap<reco::DeDxData>>(iConfig.getParameter<edm::InputTag>("dEdxDataPixel"))),
+      gt2dedxHitInfo_(consumes<reco::DeDxHitInfoAss>(iConfig.getParameter<edm::InputTag>("dEdxHitInfo"))),
+      addPrescaledDeDxTracks_(iConfig.getParameter<bool>("addPrescaledDeDxTracks")),
+      gt2dedxHitInfoPrescale_(addPrescaledDeDxTracks_ ? consumes<edm::ValueMap<int>>(
+                                                            iConfig.getParameter<edm::InputTag>("dEdxHitInfoPrescale"))
+                                                      : edm::EDGetTokenT<edm::ValueMap<int>>()),
+      usePrecomputedDeDxStrip_(iConfig.getParameter<bool>("usePrecomputedDeDxStrip")),
+      usePrecomputedDeDxPixel_(iConfig.getParameter<bool>("usePrecomputedDeDxPixel")),
+      pT_cut_(iConfig.getParameter<double>("pT_cut")),
+      pT_cut_noIso_(iConfig.getParameter<double>("pT_cut_noIso")),
+      pfIsolation_DR_(iConfig.getParameter<double>("pfIsolation_DR")),
+      pfIsolation_DZ_(iConfig.getParameter<double>("pfIsolation_DZ")),
+      absIso_cut_(iConfig.getParameter<double>("absIso_cut")),
+      relIso_cut_(iConfig.getParameter<double>("relIso_cut")),
+      miniRelIso_cut_(iConfig.getParameter<double>("miniRelIso_cut")),
+      caloJet_DR_(iConfig.getParameter<double>("caloJet_DR")),
+      pflepoverlap_DR_(iConfig.getParameter<double>("pflepoverlap_DR")),
+      pflepoverlap_pTmin_(iConfig.getParameter<double>("pflepoverlap_pTmin")),
+      pcRefNearest_DR_(iConfig.getParameter<double>("pcRefNearest_DR")),
+      pcRefNearest_pTmin_(iConfig.getParameter<double>("pcRefNearest_pTmin")),
+      pfneutralsum_DR_(iConfig.getParameter<double>("pfneutralsum_DR")),
+      saveDeDxHitInfo_(iConfig.getParameter<bool>("saveDeDxHitInfo")),
+      saveDeDxHitInfoCut_(iConfig.getParameter<std::string>("saveDeDxHitInfoCut")) {
+  // TrackAssociator parameters
+  edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+  edm::ConsumesCollector iC = consumesCollector();
+  trackAssocParameters_.loadParameters(parameters, iC);
 
-    produces< pat::IsolatedTrackCollection > ();
+  trackAssociator_.useDefaultPropagator();
 
-    if (saveDeDxHitInfo_) {
-       produces<reco::DeDxHitInfoCollection>();
-       produces<reco::DeDxHitInfoAss>();
-    }
+  miniIsoParams_ = iConfig.getParameter<std::vector<double>>("miniIsoParams");
+  if (miniIsoParams_.size() != 3)
+    throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 3 elements.\n";
+
+  produces<pat::IsolatedTrackCollection>();
+
+  if (saveDeDxHitInfo_) {
+    produces<reco::DeDxHitInfoCollection>();
+    produces<reco::DeDxHitInfoAss>();
+  }
 }
 
 pat::PATIsolatedTrackProducer::~PATIsolatedTrackProducer() {}
 
 void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // packedPFCandidate collection
+  edm::Handle<pat::PackedCandidateCollection> pc_h;
+  iEvent.getByToken(pc_, pc_h);
+  const pat::PackedCandidateCollection* pc = pc_h.product();
 
-    // packedPFCandidate collection
-    edm::Handle<pat::PackedCandidateCollection> pc_h;
-    iEvent.getByToken( pc_, pc_h );
-    const pat::PackedCandidateCollection *pc = pc_h.product();
+  // lostTracks collection
+  edm::Handle<pat::PackedCandidateCollection> lt_h;
+  iEvent.getByToken(lt_, lt_h);
+  const pat::PackedCandidateCollection* lt = lt_h.product();
 
-    // lostTracks collection
-    edm::Handle<pat::PackedCandidateCollection> lt_h;
-    iEvent.getByToken( lt_, lt_h );
-    const pat::PackedCandidateCollection *lt = lt_h.product();
+  // generalTracks collection
+  edm::Handle<reco::TrackCollection> gt_h;
+  iEvent.getByToken(gt_, gt_h);
+  const reco::TrackCollection* generalTracks = gt_h.product();
 
-    // generalTracks collection
-    edm::Handle<reco::TrackCollection> gt_h;
-    iEvent.getByToken( gt_, gt_h );
-    const reco::TrackCollection *generalTracks = gt_h.product();
+  // get the primary vertex
+  edm::Handle<reco::VertexCollection> pvs;
+  iEvent.getByToken(pv_, pvs);
+  const reco::Vertex& pv = (*pvs)[0];
 
-    // get the primary vertex
-    edm::Handle<reco::VertexCollection> pvs;
-    iEvent.getByToken( pv_, pvs );
-    const reco::Vertex & pv = (*pvs)[0];
+  // generalTracks-->packedPFCandidate association
+  edm::Handle<edm::Association<pat::PackedCandidateCollection>> gt2pc;
+  iEvent.getByToken(gt2pc_, gt2pc);
 
-    // generalTracks-->packedPFCandidate association
-    edm::Handle<edm::Association<pat::PackedCandidateCollection> > gt2pc;
-    iEvent.getByToken(gt2pc_, gt2pc);
+  // generalTracks-->lostTracks association
+  edm::Handle<edm::Association<pat::PackedCandidateCollection>> gt2lt;
+  iEvent.getByToken(gt2lt_, gt2lt);
 
-    // generalTracks-->lostTracks association
-    edm::Handle<edm::Association<pat::PackedCandidateCollection> > gt2lt;
-    iEvent.getByToken(gt2lt_, gt2lt);
+  // packedPFCandidates-->particleFlow(reco::PFCandidate) association
+  edm::Handle<edm::Association<reco::PFCandidateCollection>> pc2pf;
+  iEvent.getByToken(pc2pf_, pc2pf);
 
-    // packedPFCandidates-->particleFlow(reco::PFCandidate) association
-    edm::Handle<edm::Association<reco::PFCandidateCollection> > pc2pf;
-    iEvent.getByToken(pc2pf_, pc2pf);
+  edm::Handle<reco::CaloJetCollection> caloJets;
+  iEvent.getByToken(caloJets_, caloJets);
 
-    edm::Handle<reco::CaloJetCollection> caloJets;
-    iEvent.getByToken(caloJets_, caloJets);
+  // associate generalTracks with their DeDx data (estimator for strip dE/dx)
+  edm::Handle<edm::ValueMap<reco::DeDxData>> gt2dedxStrip;
+  iEvent.getByToken(gt2dedxStrip_, gt2dedxStrip);
 
-    // associate generalTracks with their DeDx data (estimator for strip dE/dx)
-    edm::Handle<edm::ValueMap<reco::DeDxData> > gt2dedxStrip;
-    iEvent.getByToken(gt2dedxStrip_, gt2dedxStrip);
+  // associate generalTracks with their DeDx data (estimator for pixel dE/dx)
+  edm::Handle<edm::ValueMap<reco::DeDxData>> gt2dedxPixel;
+  iEvent.getByToken(gt2dedxPixel_, gt2dedxPixel);
 
-    // associate generalTracks with their DeDx data (estimator for pixel dE/dx)
-    edm::Handle<edm::ValueMap<reco::DeDxData> > gt2dedxPixel;
-    iEvent.getByToken(gt2dedxPixel_, gt2dedxPixel);
+  // associate generalTracks with their DeDx hit info (used to estimate pixel dE/dx)
+  edm::Handle<reco::DeDxHitInfoAss> gt2dedxHitInfo;
+  iEvent.getByToken(gt2dedxHitInfo_, gt2dedxHitInfo);
+  edm::Handle<edm::ValueMap<int>> gt2dedxHitInfoPrescale;
+  if (addPrescaledDeDxTracks_) {
+    iEvent.getByToken(gt2dedxHitInfoPrescale_, gt2dedxHitInfoPrescale);
+  }
 
-    // associate generalTracks with their DeDx hit info (used to estimate pixel dE/dx)
-    edm::Handle<reco::DeDxHitInfoAss> gt2dedxHitInfo;
-    iEvent.getByToken(gt2dedxHitInfo_, gt2dedxHitInfo);
-    edm::Handle<edm::ValueMap<int>> gt2dedxHitInfoPrescale;
+  edm::ESHandle<HcalChannelQuality> hcalQ_h;
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo", hcalQ_h);
+  const HcalChannelQuality* hcalQ = hcalQ_h.product();
+
+  edm::ESHandle<EcalChannelStatus> ecalS_h;
+  iSetup.get<EcalChannelStatusRcd>().get(ecalS_h);
+  const EcalChannelStatus* ecalS = ecalS_h.product();
+
+  auto outDeDxC = std::make_unique<reco::DeDxHitInfoCollection>();
+  std::vector<int> dEdXass;
+
+  auto outPtrP = std::make_unique<std::vector<pat::IsolatedTrack>>();
+
+  //add general tracks
+  for (unsigned int igt = 0; igt < generalTracks->size(); igt++) {
+    const reco::Track& gentk = (*gt_h)[igt];
+    reco::TrackRef tkref = reco::TrackRef(gt_h, igt);
+    pat::PackedCandidateRef pcref = (*gt2pc)[tkref];
+    pat::PackedCandidateRef ltref = (*gt2lt)[tkref];
+    const pat::PackedCandidate& pfCand = *(pcref.get());
+    const pat::PackedCandidate& lostTrack = *(ltref.get());
+
+    // Determine if this general track is associated with anything in packedPFCandidates or lostTracks
+    // Sometimes, a track gets associated w/ a neutral pfCand.
+    // In this case, ignore the pfCand and take from lostTracks
+    bool isInPackedCands = (pcref.isNonnull() && pcref.id() == pc_h.id() && pfCand.charge() != 0);
+    bool isInLostTracks = (ltref.isNonnull() && ltref.id() == lt_h.id());
+
+    LorentzVector p4;
+    pat::PackedCandidateRef refToCand;
+    int pdgId, charge, fromPV;
+    float dz, dxy, dzError, dxyError;
+    int pfCandInd;  //to avoid counting packedPFCands in their own isolation
+    int ltCandInd;  //to avoid pointing lost track to itself when looking for closest
+
+    // get the four-momentum and charge
+    if (isInPackedCands) {
+      p4 = pfCand.p4();
+      charge = pfCand.charge();
+      pfCandInd = pcref.key();
+      ltCandInd = -1;
+    } else if (isInLostTracks) {
+      p4 = lostTrack.p4();
+      charge = lostTrack.charge();
+      pfCandInd = -1;
+      ltCandInd = ltref.key();
+    } else {
+      double m = 0.13957018;  //assume pion mass
+      double E = sqrt(m * m + gentk.p() * gentk.p());
+      p4.SetPxPyPzE(gentk.px(), gentk.py(), gentk.pz(), E);
+      charge = gentk.charge();
+      pfCandInd = -1;
+      ltCandInd = -1;
+    }
+
+    int prescaled = 0;
     if (addPrescaledDeDxTracks_) {
-        iEvent.getByToken(gt2dedxHitInfoPrescale_, gt2dedxHitInfoPrescale);
+      const auto& dedxRef = (*gt2dedxHitInfo)[tkref];
+      if (dedxRef.isNonnull()) {
+        prescaled = (*gt2dedxHitInfoPrescale)[dedxRef];
+      }
     }
 
-    edm::ESHandle<HcalChannelQuality> hcalQ_h;
-    iSetup.get<HcalChannelQualityRcd>().get("withTopo", hcalQ_h);
-    const HcalChannelQuality *hcalQ = hcalQ_h.product();
-    
-    edm::ESHandle<EcalChannelStatus> ecalS_h;
-    iSetup.get<EcalChannelStatusRcd>().get(ecalS_h);
-    const EcalChannelStatus *ecalS = ecalS_h.product();
+    if (p4.pt() < pT_cut_ && prescaled <= 1)
+      continue;
+    if (charge == 0)
+      continue;
 
-    auto outDeDxC = std::make_unique<reco::DeDxHitInfoCollection>();
-    std::vector<int> dEdXass;
+    // get the isolation of the track
+    pat::PFIsolation isolationDR03;
+    pat::PFIsolation miniIso;
+    getIsolation(p4, pc, pfCandInd, isolationDR03, miniIso);
 
-    auto outPtrP = std::make_unique<std::vector<pat::IsolatedTrack>>();
+    // isolation cut
+    if (p4.pt() < pT_cut_noIso_ && prescaled <= 1 &&
+        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / p4.pt() < relIso_cut_ ||
+          miniIso.chargedHadronIso() / p4.pt() < miniRelIso_cut_))
+      continue;
 
-    //add general tracks
-    for(unsigned int igt=0; igt<generalTracks->size(); igt++){
-        const reco::Track &gentk = (*gt_h)[igt];
-        reco::TrackRef tkref = reco::TrackRef(gt_h, igt);
-        pat::PackedCandidateRef pcref = (*gt2pc)[tkref];
-        pat::PackedCandidateRef ltref = (*gt2lt)[tkref];
-        const pat::PackedCandidate & pfCand = *(pcref.get());
-        const pat::PackedCandidate & lostTrack = *(ltref.get());
-
-        // Determine if this general track is associated with anything in packedPFCandidates or lostTracks
-        // Sometimes, a track gets associated w/ a neutral pfCand.
-        // In this case, ignore the pfCand and take from lostTracks
-        bool isInPackedCands = (pcref.isNonnull() && pcref.id()==pc_h.id() && pfCand.charge()!=0);
-        bool isInLostTracks  = (ltref.isNonnull() && ltref.id()==lt_h.id());
-
-        LorentzVector p4;
-        pat::PackedCandidateRef refToCand;
-        int pdgId, charge, fromPV;
-        float dz, dxy, dzError, dxyError;
-        int pfCandInd; //to avoid counting packedPFCands in their own isolation
-	int ltCandInd; //to avoid pointing lost track to itself when looking for closest
-
-        // get the four-momentum and charge
-        if(isInPackedCands){
-            p4        = pfCand.p4();
-            charge    = pfCand.charge();
-            pfCandInd = pcref.key();
-	    ltCandInd = -1;
-        }else if(isInLostTracks){
-            p4        = lostTrack.p4();
-            charge    = lostTrack.charge();
-            pfCandInd = -1;
-	    ltCandInd = ltref.key();
-        }else{
-            double m = 0.13957018; //assume pion mass
-            double E = sqrt(m*m + gentk.p()*gentk.p());
-            p4.SetPxPyPzE(gentk.px(), gentk.py(), gentk.pz(), E);
-            charge = gentk.charge();
-            pfCandInd = -1;
-	    ltCandInd = -1;
-        }
-
-        int prescaled = 0;
-        if (addPrescaledDeDxTracks_) {
-            const auto &dedxRef = (*gt2dedxHitInfo)[tkref];
-            if (dedxRef.isNonnull()) {
-                prescaled = (*gt2dedxHitInfoPrescale)[dedxRef];
-            }
-        }
-
-        if(p4.pt() < pT_cut_ && prescaled <= 1) 
-            continue;
-        if(charge == 0)
-            continue;
-
-        // get the isolation of the track
-        pat::PFIsolation isolationDR03;
-        pat::PFIsolation miniIso;
-        getIsolation(p4, pc, pfCandInd, isolationDR03, miniIso);
-        
-        // isolation cut
-        if( p4.pt() < pT_cut_noIso_ && prescaled <= 1 && 
-            !(isolationDR03.chargedHadronIso() < absIso_cut_ ||
-              isolationDR03.chargedHadronIso()/p4.pt() < relIso_cut_ ||
-              miniIso.chargedHadronIso()/p4.pt() < miniRelIso_cut_))
-            continue;
-
-        // get the rest after the pt/iso cuts. Saves some runtime
-        if(isInPackedCands){
-            pdgId     = pfCand.pdgId();
-            dz        = pfCand.dz();
-            dxy       = pfCand.dxy();
-            dzError   = pfCand.hasTrackDetails() ? pfCand.dzError()  : gentk.dzError();
-            dxyError  = pfCand.hasTrackDetails() ? pfCand.dxyError() : gentk.dxyError();
-            fromPV    = pfCand.fromPV();
-            refToCand = pcref;
-        }else if(isInLostTracks){
-            pdgId     = lostTrack.pdgId();
-            dz        = lostTrack.dz();
-            dxy       = lostTrack.dxy();
-            dzError   = lostTrack.hasTrackDetails() ? lostTrack.dzError()  : gentk.dzError();
-            dxyError  = lostTrack.hasTrackDetails() ? lostTrack.dxyError() : gentk.dxyError();
-            fromPV    = lostTrack.fromPV();
-            refToCand = ltref;
-        }else{
-            pdgId     = 0;
-            dz        = gentk.dz(pv.position());
-            dxy       = gentk.dxy(pv.position());
-            dzError   = gentk.dzError();
-            dxyError  = gentk.dxyError();
-            fromPV    = -1;
-            refToCand = pat::PackedCandidateRef();  //NULL reference
-        }
-
-        float caloJetEm, caloJetHad;
-        getCaloJetEnergy(p4, caloJets.product(), caloJetEm, caloJetHad);
-
-	bool pfLepOverlap = getPFLeptonOverlap(p4, pc);
-	float pfNeutralSum = getPFNeutralSum(p4, pc, pfCandInd);
-	
-	pat::PackedCandidateRef refToNearestPF = pat::PackedCandidateRef();
-	int refToNearestPF_idx=-1;
-	getNearestPCRef(p4, pc, pfCandInd, refToNearestPF_idx);
-	if(refToNearestPF_idx!=-1)
-	  refToNearestPF = pat::PackedCandidateRef(pc_h, refToNearestPF_idx);
-	
-	pat::PackedCandidateRef refToNearestLostTrack = pat::PackedCandidateRef();
-	int refToNearestLostTrack_idx=-1;
-	getNearestPCRef(p4, lt, ltCandInd, refToNearestLostTrack_idx);
-	if(refToNearestLostTrack_idx!=-1)
-	  refToNearestLostTrack = pat::PackedCandidateRef(lt_h, refToNearestLostTrack_idx);
-	
-        // if no dEdx info exists, just store -1
-        float dEdxPixel=-1, dEdxStrip=-1;        
-        if(usePrecomputedDeDxStrip_ && gt2dedxStrip.isValid() && gt2dedxStrip->contains(tkref.id())){
-            dEdxStrip = (*gt2dedxStrip)[tkref].dEdx();
-        }else if(gt2dedxHitInfo.isValid() && gt2dedxHitInfo->contains(tkref.id())){
-            const reco::DeDxHitInfo* hitInfo = (*gt2dedxHitInfo)[tkref].get();
-            dEdxStrip = getDeDx(hitInfo, false, true);
-        }
-        if(usePrecomputedDeDxPixel_ && gt2dedxPixel.isValid() && gt2dedxPixel->contains(tkref.id())){
-            dEdxPixel = (*gt2dedxPixel)[tkref].dEdx();
-        }else if(gt2dedxHitInfo.isValid() && gt2dedxHitInfo->contains(tkref.id())){
-            const reco::DeDxHitInfo* hitInfo = (*gt2dedxHitInfo)[tkref].get();
-            dEdxPixel = getDeDx(hitInfo, true, false);
-        }
-
-        int trackQuality = gentk.qualityMask();
-
-        // get the associated ecal/hcal detectors
-        TrackDetMatchInfo trackDetInfo = getTrackDetMatchInfo(iEvent, iSetup, gentk);
-
-        // fill ecal/hcal status vectors
-        std::vector<uint32_t> crossedHcalStatus;
-        for(auto const & did : trackDetInfo.crossedHcalIds){
-            crossedHcalStatus.push_back(hcalQ->getValues(did.rawId())->getValue());
-        }
-        std::vector<uint16_t> crossedEcalStatus;
-        for(auto const & did : trackDetInfo.crossedEcalIds){
-            crossedEcalStatus.push_back(ecalS->find(did.rawId())->getStatusCode());
-        }
-
-        int deltaEta = int((trackDetInfo.trkGlobPosAtEcal.eta() - gentk.eta())/0.5 * 250);
-        int deltaPhi = int((trackDetInfo.trkGlobPosAtEcal.phi() - gentk.phi())/0.5 * 250);
-        if(deltaEta < -250) deltaEta = -250;
-        if(deltaEta > 250)  deltaEta = 250;
-        if(deltaPhi < -250) deltaPhi = -250;
-        if(deltaPhi > 250)  deltaPhi = 250;
-
-        outPtrP->push_back(pat::IsolatedTrack(isolationDR03, miniIso, caloJetEm, caloJetHad, pfLepOverlap, pfNeutralSum, p4,
-                                              charge, pdgId, dz, dxy, dzError, dxyError,
-                                              gentk.hitPattern(), dEdxStrip, dEdxPixel, fromPV, trackQuality,
-                                              crossedEcalStatus, crossedHcalStatus,
-                                              deltaEta, deltaPhi, refToCand,
-					      refToNearestPF, refToNearestLostTrack));
-        outPtrP->back().setStatus(prescaled);
-
-        if (saveDeDxHitInfo_) {
-            const auto &dedxRef = (*gt2dedxHitInfo)[tkref];
-            if (saveDeDxHitInfoCut_(outPtrP->back()) && dedxRef.isNonnull()) {
-                outDeDxC->push_back( *dedxRef );
-                dEdXass.push_back(outDeDxC->size()-1);
-            } else {
-                dEdXass.push_back(-1);
-            }
-        }
-
+    // get the rest after the pt/iso cuts. Saves some runtime
+    if (isInPackedCands) {
+      pdgId = pfCand.pdgId();
+      dz = pfCand.dz();
+      dxy = pfCand.dxy();
+      dzError = pfCand.hasTrackDetails() ? pfCand.dzError() : gentk.dzError();
+      dxyError = pfCand.hasTrackDetails() ? pfCand.dxyError() : gentk.dxyError();
+      fromPV = pfCand.fromPV();
+      refToCand = pcref;
+    } else if (isInLostTracks) {
+      pdgId = lostTrack.pdgId();
+      dz = lostTrack.dz();
+      dxy = lostTrack.dxy();
+      dzError = lostTrack.hasTrackDetails() ? lostTrack.dzError() : gentk.dzError();
+      dxyError = lostTrack.hasTrackDetails() ? lostTrack.dxyError() : gentk.dxyError();
+      fromPV = lostTrack.fromPV();
+      refToCand = ltref;
+    } else {
+      pdgId = 0;
+      dz = gentk.dz(pv.position());
+      dxy = gentk.dxy(pv.position());
+      dzError = gentk.dzError();
+      dxyError = gentk.dxyError();
+      fromPV = -1;
+      refToCand = pat::PackedCandidateRef();  //NULL reference
     }
 
-    // there are some number of pfcandidates with no associated track
-    // (mostly electrons, with a handful of muons)
-    // here we find these and store. Track-specific variables get some default values
-    for(unsigned int ipc=0; ipc<pc->size(); ipc++){
-        const pat::PackedCandidate& pfCand = pc->at(ipc);
-        pat::PackedCandidateRef pcref = pat::PackedCandidateRef(pc_h, ipc);
-        reco::PFCandidateRef pfref = (*pc2pf)[pcref];
+    float caloJetEm, caloJetHad;
+    getCaloJetEnergy(p4, caloJets.product(), caloJetEm, caloJetHad);
 
-        // already counted if it has a track reference in the generalTracks collection
-        if(pfref.get()->trackRef().isNonnull() && pfref.get()->trackRef().id() == gt_h.id())
-            continue;
+    bool pfLepOverlap = getPFLeptonOverlap(p4, pc);
+    float pfNeutralSum = getPFNeutralSum(p4, pc, pfCandInd);
 
-        LorentzVector p4;
-        pat::PackedCandidateRef refToCand;
-        int pdgId, charge, fromPV;
-        float dz, dxy, dzError, dxyError;
+    pat::PackedCandidateRef refToNearestPF = pat::PackedCandidateRef();
+    int refToNearestPF_idx = -1;
+    getNearestPCRef(p4, pc, pfCandInd, refToNearestPF_idx);
+    if (refToNearestPF_idx != -1)
+      refToNearestPF = pat::PackedCandidateRef(pc_h, refToNearestPF_idx);
 
-        p4 = pfCand.p4();
-        charge = pfCand.charge();
+    pat::PackedCandidateRef refToNearestLostTrack = pat::PackedCandidateRef();
+    int refToNearestLostTrack_idx = -1;
+    getNearestPCRef(p4, lt, ltCandInd, refToNearestLostTrack_idx);
+    if (refToNearestLostTrack_idx != -1)
+      refToNearestLostTrack = pat::PackedCandidateRef(lt_h, refToNearestLostTrack_idx);
 
-        if(p4.pt() < pT_cut_)
-            continue;
-        if(charge == 0)
-            continue;
-
-        // get the isolation of the track
-        pat::PFIsolation isolationDR03;
-        pat::PFIsolation miniIso;
-        getIsolation(p4, pc, ipc, isolationDR03, miniIso);
-        
-        // isolation cut
-        if( p4.pt() < pT_cut_noIso_ && 
-            !(isolationDR03.chargedHadronIso() < absIso_cut_ ||
-              isolationDR03.chargedHadronIso()/p4.pt() < relIso_cut_ ||
-              miniIso.chargedHadronIso()/p4.pt() < miniRelIso_cut_))
-            continue;
-
-        pdgId     = pfCand.pdgId();
-        dz        = pfCand.dz();
-        dxy       = pfCand.dxy();
-        if (pfCand.hasTrackDetails()){
-            dzError   = pfCand.dzError();
-            dxyError  = pfCand.dxyError();
-        } else {
-            dzError = 0;
-            dxyError = 0;
-        }
-        fromPV    = pfCand.fromPV();
-        refToCand = pcref;
-
-        float caloJetEm, caloJetHad;
-        getCaloJetEnergy(p4, caloJets.product(), caloJetEm, caloJetHad);
-
-	bool pfLepOverlap = getPFLeptonOverlap(p4, pc);
-	float pfNeutralSum = getPFNeutralSum(p4, pc, ipc);
-
-	pat::PackedCandidateRef refToNearestPF = pat::PackedCandidateRef();
-	int refToNearestPF_idx=-1;
-	getNearestPCRef(p4, pc, ipc, refToNearestPF_idx);
-	if(refToNearestPF_idx!=-1)
-	  refToNearestPF = pat::PackedCandidateRef(pc_h, refToNearestPF_idx);
-	
-	pat::PackedCandidateRef refToNearestLostTrack = pat::PackedCandidateRef();
-	int refToNearestLostTrack_idx=-1;
-	getNearestPCRef(p4, lt, -1, refToNearestLostTrack_idx);
-	if(refToNearestLostTrack_idx!=-1)
-	  refToNearestLostTrack = pat::PackedCandidateRef(lt_h, refToNearestLostTrack_idx);
-
-        // fill with default values
-        reco::HitPattern hp;
-        float dEdxPixel=-1, dEdxStrip=-1;
-        int trackQuality=0;
-        std::vector<uint16_t> ecalStatus;
-        std::vector<uint32_t> hcalStatus;
-        int deltaEta=0;
-        int deltaPhi=0;
-
-        outPtrP->push_back(pat::IsolatedTrack(isolationDR03, miniIso, caloJetEm, caloJetHad, pfLepOverlap, pfNeutralSum, p4,
-                                              charge, pdgId, dz, dxy, dzError, dxyError,
-                                              hp, dEdxStrip, dEdxPixel, fromPV, trackQuality,
-                                              ecalStatus, hcalStatus, deltaEta, deltaPhi, refToCand,
-					      refToNearestPF, refToNearestLostTrack));
-
-        dEdXass.push_back(-1); // these never have dE/dx hit info, as there's no track
+    // if no dEdx info exists, just store -1
+    float dEdxPixel = -1, dEdxStrip = -1;
+    if (usePrecomputedDeDxStrip_ && gt2dedxStrip.isValid() && gt2dedxStrip->contains(tkref.id())) {
+      dEdxStrip = (*gt2dedxStrip)[tkref].dEdx();
+    } else if (gt2dedxHitInfo.isValid() && gt2dedxHitInfo->contains(tkref.id())) {
+      const reco::DeDxHitInfo* hitInfo = (*gt2dedxHitInfo)[tkref].get();
+      dEdxStrip = getDeDx(hitInfo, false, true);
     }
-    
-    auto orphHandle = iEvent.put(std::move(outPtrP));
+    if (usePrecomputedDeDxPixel_ && gt2dedxPixel.isValid() && gt2dedxPixel->contains(tkref.id())) {
+      dEdxPixel = (*gt2dedxPixel)[tkref].dEdx();
+    } else if (gt2dedxHitInfo.isValid() && gt2dedxHitInfo->contains(tkref.id())) {
+      const reco::DeDxHitInfo* hitInfo = (*gt2dedxHitInfo)[tkref].get();
+      dEdxPixel = getDeDx(hitInfo, true, false);
+    }
+
+    int trackQuality = gentk.qualityMask();
+
+    // get the associated ecal/hcal detectors
+    TrackDetMatchInfo trackDetInfo = getTrackDetMatchInfo(iEvent, iSetup, gentk);
+
+    // fill ecal/hcal status vectors
+    std::vector<uint32_t> crossedHcalStatus;
+    for (auto const& did : trackDetInfo.crossedHcalIds) {
+      crossedHcalStatus.push_back(hcalQ->getValues(did.rawId())->getValue());
+    }
+    std::vector<uint16_t> crossedEcalStatus;
+    for (auto const& did : trackDetInfo.crossedEcalIds) {
+      crossedEcalStatus.push_back(ecalS->find(did.rawId())->getStatusCode());
+    }
+
+    int deltaEta = int((trackDetInfo.trkGlobPosAtEcal.eta() - gentk.eta()) / 0.5 * 250);
+    int deltaPhi = int((trackDetInfo.trkGlobPosAtEcal.phi() - gentk.phi()) / 0.5 * 250);
+    if (deltaEta < -250)
+      deltaEta = -250;
+    if (deltaEta > 250)
+      deltaEta = 250;
+    if (deltaPhi < -250)
+      deltaPhi = -250;
+    if (deltaPhi > 250)
+      deltaPhi = 250;
+
+    outPtrP->push_back(pat::IsolatedTrack(isolationDR03,
+                                          miniIso,
+                                          caloJetEm,
+                                          caloJetHad,
+                                          pfLepOverlap,
+                                          pfNeutralSum,
+                                          p4,
+                                          charge,
+                                          pdgId,
+                                          dz,
+                                          dxy,
+                                          dzError,
+                                          dxyError,
+                                          gentk.hitPattern(),
+                                          dEdxStrip,
+                                          dEdxPixel,
+                                          fromPV,
+                                          trackQuality,
+                                          crossedEcalStatus,
+                                          crossedHcalStatus,
+                                          deltaEta,
+                                          deltaPhi,
+                                          refToCand,
+                                          refToNearestPF,
+                                          refToNearestLostTrack));
+    outPtrP->back().setStatus(prescaled);
+
     if (saveDeDxHitInfo_) {
-        auto dedxOH = iEvent.put(std::move(outDeDxC));
-        auto dedxMatch = std::make_unique<reco::DeDxHitInfoAss>(dedxOH);
-        reco::DeDxHitInfoAss::Filler filler(*dedxMatch);  
-        filler.insert(orphHandle, dEdXass.begin(), dEdXass.end()); 
-        filler.fill();
-        iEvent.put(std::move(dedxMatch));
+      const auto& dedxRef = (*gt2dedxHitInfo)[tkref];
+      if (saveDeDxHitInfoCut_(outPtrP->back()) && dedxRef.isNonnull()) {
+        outDeDxC->push_back(*dedxRef);
+        dEdXass.push_back(outDeDxC->size() - 1);
+      } else {
+        dEdXass.push_back(-1);
+      }
     }
-    
+  }
+
+  // there are some number of pfcandidates with no associated track
+  // (mostly electrons, with a handful of muons)
+  // here we find these and store. Track-specific variables get some default values
+  for (unsigned int ipc = 0; ipc < pc->size(); ipc++) {
+    const pat::PackedCandidate& pfCand = pc->at(ipc);
+    pat::PackedCandidateRef pcref = pat::PackedCandidateRef(pc_h, ipc);
+    reco::PFCandidateRef pfref = (*pc2pf)[pcref];
+
+    // already counted if it has a track reference in the generalTracks collection
+    if (pfref.get()->trackRef().isNonnull() && pfref.get()->trackRef().id() == gt_h.id())
+      continue;
+
+    LorentzVector p4;
+    pat::PackedCandidateRef refToCand;
+    int pdgId, charge, fromPV;
+    float dz, dxy, dzError, dxyError;
+
+    p4 = pfCand.p4();
+    charge = pfCand.charge();
+
+    if (p4.pt() < pT_cut_)
+      continue;
+    if (charge == 0)
+      continue;
+
+    // get the isolation of the track
+    pat::PFIsolation isolationDR03;
+    pat::PFIsolation miniIso;
+    getIsolation(p4, pc, ipc, isolationDR03, miniIso);
+
+    // isolation cut
+    if (p4.pt() < pT_cut_noIso_ &&
+        !(isolationDR03.chargedHadronIso() < absIso_cut_ || isolationDR03.chargedHadronIso() / p4.pt() < relIso_cut_ ||
+          miniIso.chargedHadronIso() / p4.pt() < miniRelIso_cut_))
+      continue;
+
+    pdgId = pfCand.pdgId();
+    dz = pfCand.dz();
+    dxy = pfCand.dxy();
+    if (pfCand.hasTrackDetails()) {
+      dzError = pfCand.dzError();
+      dxyError = pfCand.dxyError();
+    } else {
+      dzError = 0;
+      dxyError = 0;
+    }
+    fromPV = pfCand.fromPV();
+    refToCand = pcref;
+
+    float caloJetEm, caloJetHad;
+    getCaloJetEnergy(p4, caloJets.product(), caloJetEm, caloJetHad);
+
+    bool pfLepOverlap = getPFLeptonOverlap(p4, pc);
+    float pfNeutralSum = getPFNeutralSum(p4, pc, ipc);
+
+    pat::PackedCandidateRef refToNearestPF = pat::PackedCandidateRef();
+    int refToNearestPF_idx = -1;
+    getNearestPCRef(p4, pc, ipc, refToNearestPF_idx);
+    if (refToNearestPF_idx != -1)
+      refToNearestPF = pat::PackedCandidateRef(pc_h, refToNearestPF_idx);
+
+    pat::PackedCandidateRef refToNearestLostTrack = pat::PackedCandidateRef();
+    int refToNearestLostTrack_idx = -1;
+    getNearestPCRef(p4, lt, -1, refToNearestLostTrack_idx);
+    if (refToNearestLostTrack_idx != -1)
+      refToNearestLostTrack = pat::PackedCandidateRef(lt_h, refToNearestLostTrack_idx);
+
+    // fill with default values
+    reco::HitPattern hp;
+    float dEdxPixel = -1, dEdxStrip = -1;
+    int trackQuality = 0;
+    std::vector<uint16_t> ecalStatus;
+    std::vector<uint32_t> hcalStatus;
+    int deltaEta = 0;
+    int deltaPhi = 0;
+
+    outPtrP->push_back(pat::IsolatedTrack(isolationDR03,
+                                          miniIso,
+                                          caloJetEm,
+                                          caloJetHad,
+                                          pfLepOverlap,
+                                          pfNeutralSum,
+                                          p4,
+                                          charge,
+                                          pdgId,
+                                          dz,
+                                          dxy,
+                                          dzError,
+                                          dxyError,
+                                          hp,
+                                          dEdxStrip,
+                                          dEdxPixel,
+                                          fromPV,
+                                          trackQuality,
+                                          ecalStatus,
+                                          hcalStatus,
+                                          deltaEta,
+                                          deltaPhi,
+                                          refToCand,
+                                          refToNearestPF,
+                                          refToNearestLostTrack));
+
+    dEdXass.push_back(-1);  // these never have dE/dx hit info, as there's no track
+  }
+
+  auto orphHandle = iEvent.put(std::move(outPtrP));
+  if (saveDeDxHitInfo_) {
+    auto dedxOH = iEvent.put(std::move(outDeDxC));
+    auto dedxMatch = std::make_unique<reco::DeDxHitInfoAss>(dedxOH);
+    reco::DeDxHitInfoAss::Filler filler(*dedxMatch);
+    filler.insert(orphHandle, dEdXass.begin(), dEdXass.end());
+    filler.fill();
+    iEvent.put(std::move(dedxMatch));
+  }
 }
 
+void pat::PATIsolatedTrackProducer::getIsolation(const LorentzVector& p4,
+                                                 const pat::PackedCandidateCollection* pc,
+                                                 int pc_idx,
+                                                 pat::PFIsolation& iso,
+                                                 pat::PFIsolation& miniiso) const {
+  float chiso = 0, nhiso = 0, phiso = 0, puiso = 0;      // standard isolation
+  float chmiso = 0, nhmiso = 0, phmiso = 0, pumiso = 0;  // mini isolation
+  float miniDR = std::max(miniIsoParams_[0], std::min(miniIsoParams_[1], miniIsoParams_[2] / p4.pt()));
+  for (pat::PackedCandidateCollection::const_iterator pf_it = pc->begin(); pf_it != pc->end(); pf_it++) {
+    if (int(pf_it - pc->begin()) == pc_idx)  //don't count itself
+      continue;
+    int id = std::abs(pf_it->pdgId());
+    bool fromPV = (pf_it->fromPV() > 1 || fabs(pf_it->dz()) < pfIsolation_DZ_);
+    float pt = pf_it->p4().pt();
+    float dr = deltaR(p4, pf_it->p4());
 
-void pat::PATIsolatedTrackProducer::getIsolation(const LorentzVector& p4, 
-                                                 const pat::PackedCandidateCollection *pc, int pc_idx,
-                                                 pat::PFIsolation &iso, pat::PFIsolation &miniiso) const
-{
-        float chiso=0, nhiso=0, phiso=0, puiso=0;   // standard isolation
-        float chmiso=0, nhmiso=0, phmiso=0, pumiso=0;  // mini isolation
-        float miniDR = std::max(miniIsoParams_[0], std::min(miniIsoParams_[1], miniIsoParams_[2]/p4.pt()));
-        for(pat::PackedCandidateCollection::const_iterator pf_it = pc->begin(); pf_it != pc->end(); pf_it++){
-            if(int(pf_it - pc->begin()) == pc_idx)  //don't count itself
-                continue;
-            int id = std::abs(pf_it->pdgId());
-            bool fromPV = (pf_it->fromPV()>1 || fabs(pf_it->dz()) < pfIsolation_DZ_);
-            float pt = pf_it->p4().pt();
-            float dr = deltaR(p4, pf_it->p4());
+    if (dr < pfIsolation_DR_) {
+      // charged cands from PV get added to trackIso
+      if (id == 211 && fromPV)
+        chiso += pt;
+      // charged cands not from PV get added to pileup iso
+      else if (id == 211)
+        puiso += pt;
+      // neutral hadron iso
+      if (id == 130)
+        nhiso += pt;
+      // photon iso
+      if (id == 22)
+        phiso += pt;
+    }
+    // same for mini isolation
+    if (dr < miniDR) {
+      if (id == 211 && fromPV)
+        chmiso += pt;
+      else if (id == 211)
+        pumiso += pt;
+      if (id == 130)
+        nhmiso += pt;
+      if (id == 22)
+        phmiso += pt;
+    }
+  }
 
-            if(dr < pfIsolation_DR_){
-                // charged cands from PV get added to trackIso
-                if(id==211 && fromPV)
-                    chiso += pt;
-                // charged cands not from PV get added to pileup iso
-                else if(id==211)
-                    puiso += pt;
-                // neutral hadron iso
-                if(id==130)
-                    nhiso += pt;
-                // photon iso
-                if(id==22)
-                    phiso += pt;
-            }
-            // same for mini isolation
-            if(dr < miniDR){
-                if(id == 211 && fromPV)
-                    chmiso += pt;
-                else if(id == 211)
-                    pumiso += pt;
-                if(id == 130)
-                    nhmiso += pt;
-                if(id == 22)
-                    phmiso += pt;
-            }
-        }
-
-        iso = pat::PFIsolation(chiso,nhiso,phiso,puiso);
-        miniiso = pat::PFIsolation(chmiso,nhmiso,phmiso,pumiso);
-
+  iso = pat::PFIsolation(chiso, nhiso, phiso, puiso);
+  miniiso = pat::PFIsolation(chmiso, nhmiso, phmiso, pumiso);
 }
 
 //get overlap of isolated track with a PF lepton
-bool pat::PATIsolatedTrackProducer::getPFLeptonOverlap(const LorentzVector& p4, const pat::PackedCandidateCollection *pc) const
-{
-        bool isOverlap = false;
-	float dr_min = pflepoverlap_DR_;
-	int id_drmin = 0;
-        for (const auto & pf : *pc) {
-            int id = std::abs(pf.pdgId());
-	    int charge = std::abs(pf.charge());
-            bool fromPV = (pf.fromPV()>1 || std::abs(pf.dz()) < pfIsolation_DZ_);
-            float pt = pf.pt();
-	    if(charge==0) // exclude neutral candidates
-	      continue;
-	    if(!(fromPV)) // exclude candidates not from PV
-	      continue;
-	    if(pt < pflepoverlap_pTmin_) // exclude pf candidates w/ pT below threshold
-	      continue;
+bool pat::PATIsolatedTrackProducer::getPFLeptonOverlap(const LorentzVector& p4,
+                                                       const pat::PackedCandidateCollection* pc) const {
+  bool isOverlap = false;
+  float dr_min = pflepoverlap_DR_;
+  int id_drmin = 0;
+  for (const auto& pf : *pc) {
+    int id = std::abs(pf.pdgId());
+    int charge = std::abs(pf.charge());
+    bool fromPV = (pf.fromPV() > 1 || std::abs(pf.dz()) < pfIsolation_DZ_);
+    float pt = pf.pt();
+    if (charge == 0)  // exclude neutral candidates
+      continue;
+    if (!(fromPV))  // exclude candidates not from PV
+      continue;
+    if (pt < pflepoverlap_pTmin_)  // exclude pf candidates w/ pT below threshold
+      continue;
 
-            float dr = deltaR(p4, pf.p4());
-            if(dr > pflepoverlap_DR_) // exclude pf candidates far from isolated track
-	      continue;
+    float dr = deltaR(p4, pf.p4());
+    if (dr > pflepoverlap_DR_)  // exclude pf candidates far from isolated track
+      continue;
 
-	    if(dr < dr_min){
-	      dr_min = dr;
-	      id_drmin = id;
-	    }
-	    
-        }
+    if (dr < dr_min) {
+      dr_min = dr;
+      id_drmin = id;
+    }
+  }
 
-	if(dr_min<pflepoverlap_DR_ && (id_drmin==11 || id_drmin==13))
-	  isOverlap = true;
-	
-	return isOverlap;
+  if (dr_min < pflepoverlap_DR_ && (id_drmin == 11 || id_drmin == 13))
+    isOverlap = true;
+
+  return isOverlap;
 }
 
 //get ref to nearest pf packed candidate
-void pat::PATIsolatedTrackProducer::getNearestPCRef(const LorentzVector& p4, const pat::PackedCandidateCollection *pc, int pc_idx, int& pc_ref_idx) const
-{
-	float dr_min = pcRefNearest_DR_;
-	float dr_min_pu = pcRefNearest_DR_;
-	int pc_ref_idx_pu=-1;
-        for(pat::PackedCandidateCollection::const_iterator pf_it = pc->begin(); pf_it != pc->end(); pf_it++){
-            if(int(pf_it - pc->begin()) == pc_idx)  //don't count itself
-                continue;
-	    int charge = std::abs(pf_it->charge());
-            bool fromPV = (pf_it->fromPV()>1 || fabs(pf_it->dz()) < pfIsolation_DZ_);
-            float pt = pf_it->p4().pt();
-            float dr = deltaR(p4, pf_it->p4());
-	    if(charge==0) // exclude neutral candidates
-	      continue;
-	    if(pt < pcRefNearest_pTmin_) // exclude candidates w/ pT below threshold
-	      continue;
-	    if(dr > dr_min && dr > dr_min_pu) // exclude too far candidates
-	      continue;
+void pat::PATIsolatedTrackProducer::getNearestPCRef(const LorentzVector& p4,
+                                                    const pat::PackedCandidateCollection* pc,
+                                                    int pc_idx,
+                                                    int& pc_ref_idx) const {
+  float dr_min = pcRefNearest_DR_;
+  float dr_min_pu = pcRefNearest_DR_;
+  int pc_ref_idx_pu = -1;
+  for (pat::PackedCandidateCollection::const_iterator pf_it = pc->begin(); pf_it != pc->end(); pf_it++) {
+    if (int(pf_it - pc->begin()) == pc_idx)  //don't count itself
+      continue;
+    int charge = std::abs(pf_it->charge());
+    bool fromPV = (pf_it->fromPV() > 1 || fabs(pf_it->dz()) < pfIsolation_DZ_);
+    float pt = pf_it->p4().pt();
+    float dr = deltaR(p4, pf_it->p4());
+    if (charge == 0)  // exclude neutral candidates
+      continue;
+    if (pt < pcRefNearest_pTmin_)  // exclude candidates w/ pT below threshold
+      continue;
+    if (dr > dr_min && dr > dr_min_pu)  // exclude too far candidates
+      continue;
 
-	    if(fromPV){ // Priority to candidates from PV
-	      if(dr < dr_min){
-		dr_min = dr;
-		pc_ref_idx = int(pf_it - pc->begin());
-	      }
-	    }
-	    else{ // Otherwise, store candidate from non-PV if no candidate from PV found
-	      if(dr < dr_min_pu){
-		dr_min_pu = dr;
-		pc_ref_idx_pu = int(pf_it - pc->begin());
-	      }
-	    }
-        }
+    if (fromPV) {  // Priority to candidates from PV
+      if (dr < dr_min) {
+        dr_min = dr;
+        pc_ref_idx = int(pf_it - pc->begin());
+      }
+    } else {  // Otherwise, store candidate from non-PV if no candidate from PV found
+      if (dr < dr_min_pu) {
+        dr_min_pu = dr;
+        pc_ref_idx_pu = int(pf_it - pc->begin());
+      }
+    }
+  }
 
-	if(pc_ref_idx == -1 && pc_ref_idx_pu != -1) // If no candidate from PV was found, store candidate from non-PV (if found)
-	  pc_ref_idx = pc_ref_idx_pu;
+  if (pc_ref_idx == -1 &&
+      pc_ref_idx_pu != -1)  // If no candidate from PV was found, store candidate from non-PV (if found)
+    pc_ref_idx = pc_ref_idx_pu;
 }
 
 // get PF neutral pT sum around isolated track
-float pat::PATIsolatedTrackProducer::getPFNeutralSum(const LorentzVector& p4, const pat::PackedCandidateCollection *pc, int pc_idx) const
-{
-        float nsum=0;
-        float nhsum=0, phsum=0;
-        for(pat::PackedCandidateCollection::const_iterator pf_it = pc->begin(); pf_it != pc->end(); pf_it++){
-            if(int(pf_it - pc->begin()) == pc_idx)  //don't count itself
-                continue;
-            int id = std::abs(pf_it->pdgId());
-            float pt = pf_it->p4().pt();
-            float dr = deltaR(p4, pf_it->p4());
+float pat::PATIsolatedTrackProducer::getPFNeutralSum(const LorentzVector& p4,
+                                                     const pat::PackedCandidateCollection* pc,
+                                                     int pc_idx) const {
+  float nsum = 0;
+  float nhsum = 0, phsum = 0;
+  for (pat::PackedCandidateCollection::const_iterator pf_it = pc->begin(); pf_it != pc->end(); pf_it++) {
+    if (int(pf_it - pc->begin()) == pc_idx)  //don't count itself
+      continue;
+    int id = std::abs(pf_it->pdgId());
+    float pt = pf_it->p4().pt();
+    float dr = deltaR(p4, pf_it->p4());
 
-            if(dr < pfneutralsum_DR_){
-	      // neutral hadron sum
-	      if(id==130)
-		nhsum += pt;
-	      // photon iso
-	      if(id==22)
-		phsum += pt;
-            }
-        }
+    if (dr < pfneutralsum_DR_) {
+      // neutral hadron sum
+      if (id == 130)
+        nhsum += pt;
+      // photon iso
+      if (id == 22)
+        phsum += pt;
+    }
+  }
 
-	nsum = nhsum + phsum;
-	
-	return nsum;
+  nsum = nhsum + phsum;
+
+  return nsum;
 }
 
 // get the estimated DeDx in either the pixels or strips (or both)
-float pat::PATIsolatedTrackProducer::getDeDx(const reco::DeDxHitInfo *hitInfo, bool doPixel, bool doStrip) const
-{
-    if(hitInfo == nullptr){
-        return -1;
-    }
+float pat::PATIsolatedTrackProducer::getDeDx(const reco::DeDxHitInfo* hitInfo, bool doPixel, bool doStrip) const {
+  if (hitInfo == nullptr) {
+    return -1;
+  }
 
-    std::vector<float> charge_vec;
-    for(unsigned int ih=0; ih<hitInfo->size(); ih++){
+  std::vector<float> charge_vec;
+  for (unsigned int ih = 0; ih < hitInfo->size(); ih++) {
+    bool isPixel = (hitInfo->pixelCluster(ih) != nullptr);
+    bool isStrip = (hitInfo->stripCluster(ih) != nullptr);
 
-        bool isPixel = (hitInfo->pixelCluster(ih) != nullptr);
-        bool isStrip = (hitInfo->stripCluster(ih) != nullptr);
+    if (isPixel && !doPixel)
+      continue;
+    if (isStrip && !doStrip)
+      continue;
 
-        if(isPixel && !doPixel) continue;
-        if(isStrip && !doStrip) continue;
+    // probably shouldn't happen
+    if (!isPixel && !isStrip)
+      continue;
 
-        // probably shouldn't happen
-        if(!isPixel && !isStrip) continue;
+    // shape selection for strips
+    if (isStrip && !DeDxTools::shapeSelection(*(hitInfo->stripCluster(ih))))
+      continue;
 
-        // shape selection for strips
-        if(isStrip && !DeDxTools::shapeSelection(*(hitInfo->stripCluster(ih))))
-            continue;
-        
-        float Norm=0;       
-        if(isPixel)
-            Norm = 3.61e-06; //compute the normalization factor to get the energy in MeV/mm
-        if(isStrip)
-            Norm = 3.61e-06 * 265;
-            
-        //save the dE/dx in MeV/mm to a vector.  
-        charge_vec.push_back(Norm*hitInfo->charge(ih)/hitInfo->pathlength(ih));           
-    }
+    float Norm = 0;
+    if (isPixel)
+      Norm = 3.61e-06;  //compute the normalization factor to get the energy in MeV/mm
+    if (isStrip)
+      Norm = 3.61e-06 * 265;
 
-    int size = charge_vec.size();
-    float result = 0.0;
+    //save the dE/dx in MeV/mm to a vector.
+    charge_vec.push_back(Norm * hitInfo->charge(ih) / hitInfo->pathlength(ih));
+  }
 
-    //build the harmonic 2 dE/dx estimator
-    float expo = -2;
-    for(int i=0; i<size; i++){
-        result += pow(charge_vec[i], expo);
-    }
-    result = (size>0) ? pow(result/size, 1./expo) : 0.0;
+  int size = charge_vec.size();
+  float result = 0.0;
 
-    return result;
+  //build the harmonic 2 dE/dx estimator
+  float expo = -2;
+  for (int i = 0; i < size; i++) {
+    result += pow(charge_vec[i], expo);
+  }
+  result = (size > 0) ? pow(result / size, 1. / expo) : 0.0;
+
+  return result;
 }
 
-TrackDetMatchInfo pat::PATIsolatedTrackProducer::getTrackDetMatchInfo(const edm::Event& iEvent, 
+TrackDetMatchInfo pat::PATIsolatedTrackProducer::getTrackDetMatchInfo(const edm::Event& iEvent,
                                                                       const edm::EventSetup& iSetup,
-                                                                      const reco::Track& track)
-{
-    edm::ESHandle<MagneticField> bField;
-    iSetup.get<IdealMagneticFieldRecord>().get(bField);
-    FreeTrajectoryState initialState = trajectoryStateTransform::initialFreeState(track,&*bField);
+                                                                      const reco::Track& track) {
+  edm::ESHandle<MagneticField> bField;
+  iSetup.get<IdealMagneticFieldRecord>().get(bField);
+  FreeTrajectoryState initialState = trajectoryStateTransform::initialFreeState(track, &*bField);
 
-    // can't use the associate() using reco::Track directly, since 
-    // track->extra() is non-null but segfaults when trying to use it
-    return trackAssociator_.associate(iEvent, iSetup, trackAssocParameters_, &initialState);
+  // can't use the associate() using reco::Track directly, since
+  // track->extra() is non-null but segfaults when trying to use it
+  return trackAssociator_.associate(iEvent, iSetup, trackAssocParameters_, &initialState);
 }
 
-void pat::PATIsolatedTrackProducer::getCaloJetEnergy(const LorentzVector& p4, const reco::CaloJetCollection* cJets,
-                                                     float &caloJetEm, float& caloJetHad) const
-{
-    float nearestDR = 999;
-    int ind = -1;
-    for(unsigned int i=0; i<cJets->size(); i++){
-        float dR = deltaR(cJets->at(i).p4(), p4);
-        if(dR < caloJet_DR_ && dR < nearestDR){
-            nearestDR = dR;
-            ind = i;
-        }
+void pat::PATIsolatedTrackProducer::getCaloJetEnergy(const LorentzVector& p4,
+                                                     const reco::CaloJetCollection* cJets,
+                                                     float& caloJetEm,
+                                                     float& caloJetHad) const {
+  float nearestDR = 999;
+  int ind = -1;
+  for (unsigned int i = 0; i < cJets->size(); i++) {
+    float dR = deltaR(cJets->at(i).p4(), p4);
+    if (dR < caloJet_DR_ && dR < nearestDR) {
+      nearestDR = dR;
+      ind = i;
     }
+  }
 
-    if(ind==-1){
-        caloJetEm = 0;
-        caloJetHad = 0;
-    }else{
-        const reco::CaloJet & cJet = cJets->at(ind);
-        caloJetEm = cJet.emEnergyInEB() + cJet.emEnergyInEE() + cJet.emEnergyInHF();
-        caloJetHad = cJet.hadEnergyInHB() + cJet.hadEnergyInHE() + cJet.hadEnergyInHF();
-    }
-
+  if (ind == -1) {
+    caloJetEm = 0;
+    caloJetHad = 0;
+  } else {
+    const reco::CaloJet& cJet = cJets->at(ind);
+    caloJetEm = cJet.emEnergyInEB() + cJet.emEnergyInEE() + cJet.emEnergyInHF();
+    caloJetHad = cJet.hadEnergyInHB() + cJet.hadEnergyInHE() + cJet.hadEnergyInHF();
+  }
 }
-
 
 using pat::PATIsolatedTrackProducer;
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -1,6 +1,5 @@
 //
 
-
 #include "PhysicsTools/PatAlgos/plugins/PATJetProducer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -38,167 +37,183 @@
 
 using namespace pat;
 
-
-PATJetProducer::PATJetProducer(const edm::ParameterSet& iConfig)  :
-  useUserData_(iConfig.exists("userData")),
-  printWarning_(true)
-{
+PATJetProducer::PATJetProducer(const edm::ParameterSet &iConfig)
+    : useUserData_(iConfig.exists("userData")), printWarning_(true) {
   // initialize configurables
-  jetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>( "jetSource" ));
-  embedCaloTowers_ = false; // parameter is optional
-  if ( iConfig.exists("embedCaloTowers") ) {
-    embedCaloTowers_ = iConfig.getParameter<bool>( "embedCaloTowers" );
+  jetsToken_ = consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jetSource"));
+  embedCaloTowers_ = false;  // parameter is optional
+  if (iConfig.exists("embedCaloTowers")) {
+    embedCaloTowers_ = iConfig.getParameter<bool>("embedCaloTowers");
   }
-  embedPFCandidates_ = iConfig.getParameter<bool>( "embedPFCandidates" );
-  getJetMCFlavour_ = iConfig.getParameter<bool>( "getJetMCFlavour" );
-  useLegacyJetMCFlavour_ = iConfig.getParameter<bool>( "useLegacyJetMCFlavour" );
-  addJetFlavourInfo_ = ( useLegacyJetMCFlavour_ ? false : iConfig.getParameter<bool>( "addJetFlavourInfo" ) );
+  embedPFCandidates_ = iConfig.getParameter<bool>("embedPFCandidates");
+  getJetMCFlavour_ = iConfig.getParameter<bool>("getJetMCFlavour");
+  useLegacyJetMCFlavour_ = iConfig.getParameter<bool>("useLegacyJetMCFlavour");
+  addJetFlavourInfo_ = (useLegacyJetMCFlavour_ ? false : iConfig.getParameter<bool>("addJetFlavourInfo"));
   if (getJetMCFlavour_ && useLegacyJetMCFlavour_)
-    jetPartonMapToken_ = consumes<reco::JetFlavourMatchingCollection>(iConfig.getParameter<edm::InputTag>( "JetPartonMapSource" ));
+    jetPartonMapToken_ =
+        consumes<reco::JetFlavourMatchingCollection>(iConfig.getParameter<edm::InputTag>("JetPartonMapSource"));
   else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_)
-    jetFlavourInfoToken_ = consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getParameter<edm::InputTag>( "JetFlavourInfoSource" ));
-  addGenPartonMatch_ = iConfig.getParameter<bool>( "addGenPartonMatch" );
-  embedGenPartonMatch_ = iConfig.getParameter<bool>( "embedGenPartonMatch" );
+    jetFlavourInfoToken_ =
+        consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getParameter<edm::InputTag>("JetFlavourInfoSource"));
+  addGenPartonMatch_ = iConfig.getParameter<bool>("addGenPartonMatch");
+  embedGenPartonMatch_ = iConfig.getParameter<bool>("embedGenPartonMatch");
   if (addGenPartonMatch_)
-    genPartonToken_ = consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genPartonMatch" ));
-  addGenJetMatch_ = iConfig.getParameter<bool>( "addGenJetMatch" );
-  embedGenJetMatch_ = iConfig.getParameter<bool>( "embedGenJetMatch" );
+    genPartonToken_ =
+        consumes<edm::Association<reco::GenParticleCollection>>(iConfig.getParameter<edm::InputTag>("genPartonMatch"));
+  addGenJetMatch_ = iConfig.getParameter<bool>("addGenJetMatch");
+  embedGenJetMatch_ = iConfig.getParameter<bool>("embedGenJetMatch");
   if (addGenJetMatch_)
-    genJetToken_ = consumes<edm::Association<reco::GenJetCollection> >(iConfig.getParameter<edm::InputTag>( "genJetMatch" ));
-  addPartonJetMatch_ = iConfig.getParameter<bool>( "addPartonJetMatch" );
-//   partonJetToken_ = mayConsume<reco::SomePartonJetType>(iConfig.getParameter<edm::InputTag>( "partonJetSource" ));
-  addJetCorrFactors_ = iConfig.getParameter<bool>( "addJetCorrFactors" );
-  if( addJetCorrFactors_ ) {
-    jetCorrFactorsTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "jetCorrFactorsSource" ), [this](edm::InputTag const & tag){return consumes<edm::ValueMap<JetCorrFactors> >(tag);});
+    genJetToken_ =
+        consumes<edm::Association<reco::GenJetCollection>>(iConfig.getParameter<edm::InputTag>("genJetMatch"));
+  addPartonJetMatch_ = iConfig.getParameter<bool>("addPartonJetMatch");
+  //   partonJetToken_ = mayConsume<reco::SomePartonJetType>(iConfig.getParameter<edm::InputTag>( "partonJetSource" ));
+  addJetCorrFactors_ = iConfig.getParameter<bool>("addJetCorrFactors");
+  if (addJetCorrFactors_) {
+    jetCorrFactorsTokens_ = edm::vector_transform(
+        iConfig.getParameter<std::vector<edm::InputTag>>("jetCorrFactorsSource"),
+        [this](edm::InputTag const &tag) { return consumes<edm::ValueMap<JetCorrFactors>>(tag); });
   }
-  addBTagInfo_ = iConfig.getParameter<bool>( "addBTagInfo" );
-  addDiscriminators_ = iConfig.getParameter<bool>( "addDiscriminators" );
-  discriminatorTags_ = iConfig.getParameter<std::vector<edm::InputTag> >( "discriminatorSources" );
-  discriminatorTokens_ = edm::vector_transform(discriminatorTags_, [this](edm::InputTag const & tag){return mayConsume<reco::JetFloatAssociation::Container>(tag);});
-  addTagInfos_ = iConfig.getParameter<bool>( "addTagInfos" );
-  tagInfoTags_ = iConfig.getParameter<std::vector<edm::InputTag> >( "tagInfoSources" );
-  tagInfoTokens_ =edm::vector_transform(tagInfoTags_, [this](edm::InputTag const & tag){return mayConsume<edm::View<reco::BaseTagInfo> >(tag);});
-  addAssociatedTracks_ = iConfig.getParameter<bool>( "addAssociatedTracks" );
+  addBTagInfo_ = iConfig.getParameter<bool>("addBTagInfo");
+  addDiscriminators_ = iConfig.getParameter<bool>("addDiscriminators");
+  discriminatorTags_ = iConfig.getParameter<std::vector<edm::InputTag>>("discriminatorSources");
+  discriminatorTokens_ = edm::vector_transform(discriminatorTags_, [this](edm::InputTag const &tag) {
+    return mayConsume<reco::JetFloatAssociation::Container>(tag);
+  });
+  addTagInfos_ = iConfig.getParameter<bool>("addTagInfos");
+  tagInfoTags_ = iConfig.getParameter<std::vector<edm::InputTag>>("tagInfoSources");
+  tagInfoTokens_ = edm::vector_transform(
+      tagInfoTags_, [this](edm::InputTag const &tag) { return mayConsume<edm::View<reco::BaseTagInfo>>(tag); });
+  addAssociatedTracks_ = iConfig.getParameter<bool>("addAssociatedTracks");
   if (addAssociatedTracks_)
-    trackAssociationToken_ = consumes<reco::JetTracksAssociation::Container>(iConfig.getParameter<edm::InputTag>( "trackAssociationSource" ));
-  addJetCharge_ = iConfig.getParameter<bool>( "addJetCharge" );
+    trackAssociationToken_ =
+        consumes<reco::JetTracksAssociation::Container>(iConfig.getParameter<edm::InputTag>("trackAssociationSource"));
+  addJetCharge_ = iConfig.getParameter<bool>("addJetCharge");
   if (addJetCharge_)
-    jetChargeToken_ = consumes<reco::JetFloatAssociation::Container>(iConfig.getParameter<edm::InputTag>( "jetChargeSource" ));
-  addJetID_ = iConfig.getParameter<bool>( "addJetID");
+    jetChargeToken_ =
+        consumes<reco::JetFloatAssociation::Container>(iConfig.getParameter<edm::InputTag>("jetChargeSource"));
+  addJetID_ = iConfig.getParameter<bool>("addJetID");
   if (addJetID_)
-    jetIDMapToken_ = consumes<reco::JetIDValueMap>(iConfig.getParameter<edm::InputTag>( "jetIDMap"));
+    jetIDMapToken_ = consumes<reco::JetIDValueMap>(iConfig.getParameter<edm::InputTag>("jetIDMap"));
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
   if (discriminatorTags_.empty()) {
     addDiscriminators_ = false;
   } else {
-    for (std::vector<edm::InputTag>::const_iterator it = discriminatorTags_.begin(), ed = discriminatorTags_.end(); it != ed; ++it) {
-        std::string label = it->label();
-        std::string::size_type pos = label.find("JetTags");
-        if ((pos !=  std::string::npos) && (pos != label.length() - 7)) {
-            label.erase(pos+7); // trim a tail after "JetTags"
-        }
-        if(!it->instance().empty()) {
-            label = (label+std::string(":")+it->instance()); 
-        }
-        discriminatorLabels_.push_back(label);
+    for (std::vector<edm::InputTag>::const_iterator it = discriminatorTags_.begin(), ed = discriminatorTags_.end();
+         it != ed;
+         ++it) {
+      std::string label = it->label();
+      std::string::size_type pos = label.find("JetTags");
+      if ((pos != std::string::npos) && (pos != label.length() - 7)) {
+        label.erase(pos + 7);  // trim a tail after "JetTags"
+      }
+      if (!it->instance().empty()) {
+        label = (label + std::string(":") + it->instance());
+      }
+      discriminatorLabels_.push_back(label);
     }
   }
   if (tagInfoTags_.empty()) {
     addTagInfos_ = false;
   } else {
-    for (std::vector<edm::InputTag>::const_iterator it = tagInfoTags_.begin(), ed = tagInfoTags_.end(); it != ed; ++it) {
-        std::string label = it->label();
-        std::string::size_type pos = label.find("TagInfos");
-        if ((pos !=  std::string::npos) && (pos != label.length() - 8)) {
-            label.erase(pos+8); // trim a tail after "TagInfos"
-        }
-        tagInfoLabels_.push_back(label);
+    for (std::vector<edm::InputTag>::const_iterator it = tagInfoTags_.begin(), ed = tagInfoTags_.end(); it != ed;
+         ++it) {
+      std::string label = it->label();
+      std::string::size_type pos = label.find("TagInfos");
+      if ((pos != std::string::npos) && (pos != label.length() - 8)) {
+        label.erase(pos + 8);  // trim a tail after "TagInfos"
+      }
+      tagInfoLabels_.push_back(label);
     }
   }
-  if (!addBTagInfo_) { addDiscriminators_ = false; addTagInfos_ = false; }
+  if (!addBTagInfo_) {
+    addDiscriminators_ = false;
+    addTagInfos_ = false;
+  }
   // Check to see if the user wants to add user data
-  if ( useUserData_ ) {
+  if (useUserData_) {
     userDataHelper_ = PATUserDataHelper<Jet>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   // produces vector of jets
-  produces<std::vector<Jet> >();
-  produces<reco::GenJetCollection> ("genJets");
-  produces<std::vector<CaloTower>  > ("caloTowers");
-  produces<reco::PFCandidateCollection > ("pfCandidates");
-  produces<edm::OwnVector<reco::BaseTagInfo> > ("tagInfos");
+  produces<std::vector<Jet>>();
+  produces<reco::GenJetCollection>("genJets");
+  produces<std::vector<CaloTower>>("caloTowers");
+  produces<reco::PFCandidateCollection>("pfCandidates");
+  produces<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
 }
 
+PATJetProducer::~PATJetProducer() {}
 
-PATJetProducer::~PATJetProducer() {
-
-}
-
-
-void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
+void PATJetProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // check whether dealing with MC or real data
-  if (iEvent.isRealData()){
-    getJetMCFlavour_   = false;
+  if (iEvent.isRealData()) {
+    getJetMCFlavour_ = false;
     useLegacyJetMCFlavour_ = false;
     addJetFlavourInfo_ = false;
     addGenPartonMatch_ = false;
-    addGenJetMatch_    = false;
+    addGenJetMatch_ = false;
     addPartonJetMatch_ = false;
   }
 
   // Get the vector of jets
-  edm::Handle<edm::View<reco::Jet> > jets;
+  edm::Handle<edm::View<reco::Jet>> jets;
   iEvent.getByToken(jetsToken_, jets);
 
-  if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
   // for jet flavour
   edm::Handle<reco::JetFlavourMatchingCollection> jetFlavMatch;
   edm::Handle<reco::JetFlavourInfoMatchingCollection> jetFlavInfoMatch;
-  if (getJetMCFlavour_ && useLegacyJetMCFlavour_) iEvent.getByToken (jetPartonMapToken_, jetFlavMatch);
-  else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_) iEvent.getByToken (jetFlavourInfoToken_, jetFlavInfoMatch);
+  if (getJetMCFlavour_ && useLegacyJetMCFlavour_)
+    iEvent.getByToken(jetPartonMapToken_, jetFlavMatch);
+  else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_)
+    iEvent.getByToken(jetFlavourInfoToken_, jetFlavInfoMatch);
 
   // Get the vector of generated particles from the event if needed
-  edm::Handle<edm::Association<reco::GenParticleCollection> > partonMatch;
-  if (addGenPartonMatch_) iEvent.getByToken(genPartonToken_,  partonMatch);
+  edm::Handle<edm::Association<reco::GenParticleCollection>> partonMatch;
+  if (addGenPartonMatch_)
+    iEvent.getByToken(genPartonToken_, partonMatch);
   // Get the vector of GenJets from the event if needed
-  edm::Handle<edm::Association<reco::GenJetCollection> > genJetMatch;
-  if (addGenJetMatch_) iEvent.getByToken(genJetToken_, genJetMatch);
-/* TO BE IMPLEMENTED FOR >= 1_5_X
+  edm::Handle<edm::Association<reco::GenJetCollection>> genJetMatch;
+  if (addGenJetMatch_)
+    iEvent.getByToken(genJetToken_, genJetMatch);
+  /* TO BE IMPLEMENTED FOR >= 1_5_X
   // Get the vector of PartonJets from the event if needed
   edm::Handle<edm::View<reco::SomePartonJetType> > partonJets;
   if (addPartonJetMatch_) iEvent.getByToken(partonJetToken_, partonJets);
 */
 
   // read in the jet correction factors ValueMap
-  std::vector<edm::ValueMap<JetCorrFactors> > jetCorrs;
+  std::vector<edm::ValueMap<JetCorrFactors>> jetCorrs;
   if (addJetCorrFactors_) {
-    for ( size_t i = 0; i < jetCorrFactorsTokens_.size(); ++i ) {
-      edm::Handle<edm::ValueMap<JetCorrFactors> > jetCorr;
+    for (size_t i = 0; i < jetCorrFactorsTokens_.size(); ++i) {
+      edm::Handle<edm::ValueMap<JetCorrFactors>> jetCorr;
       iEvent.getByToken(jetCorrFactorsTokens_[i], jetCorr);
-      jetCorrs.push_back( *jetCorr );
+      jetCorrs.push_back(*jetCorr);
     }
   }
 
   // Get the vector of jet tags with b-tagging info
-  std::vector<edm::Handle<reco::JetFloatAssociation::Container> > jetDiscriminators;
+  std::vector<edm::Handle<reco::JetFloatAssociation::Container>> jetDiscriminators;
   if (addBTagInfo_ && addDiscriminators_) {
     jetDiscriminators.resize(discriminatorTokens_.size());
     for (size_t i = 0; i < discriminatorTokens_.size(); ++i) {
-        iEvent.getByToken(discriminatorTokens_[i], jetDiscriminators[i]);
+      iEvent.getByToken(discriminatorTokens_[i], jetDiscriminators[i]);
     }
   }
-  std::vector<edm::Handle<edm::View<reco::BaseTagInfo> > > jetTagInfos;
+  std::vector<edm::Handle<edm::View<reco::BaseTagInfo>>> jetTagInfos;
   if (addBTagInfo_ && addTagInfos_) {
     jetTagInfos.resize(tagInfoTokens_.size());
     for (size_t i = 0; i < tagInfoTokens_.size(); ++i) {
@@ -207,14 +222,17 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   }
 
   // tracks Jet Track Association
-  edm::Handle<reco::JetTracksAssociation::Container > hTrackAss;
-  if (addAssociatedTracks_) iEvent.getByToken(trackAssociationToken_, hTrackAss);
-  edm::Handle<reco::JetFloatAssociation::Container > hJetChargeAss;
-  if (addJetCharge_) iEvent.getByToken(jetChargeToken_, hJetChargeAss);
+  edm::Handle<reco::JetTracksAssociation::Container> hTrackAss;
+  if (addAssociatedTracks_)
+    iEvent.getByToken(trackAssociationToken_, hTrackAss);
+  edm::Handle<reco::JetFloatAssociation::Container> hJetChargeAss;
+  if (addJetCharge_)
+    iEvent.getByToken(jetChargeToken_, hJetChargeAss);
 
   // jet ID handle
   edm::Handle<reco::JetIDValueMap> hJetIDMap;
-  if ( addJetID_ ) iEvent.getByToken( jetIDMapToken_, hJetIDMap );
+  if (addJetID_)
+    iEvent.getByToken(jetIDMapToken_, hJetIDMap);
 
   // loop over jets
   auto patJets = std::make_unique<std::vector<Jet>>();
@@ -224,14 +242,14 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   auto pfCandidatesOut = std::make_unique<reco::PFCandidateCollection>();
   auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
 
-
-  edm::RefProd<reco::GenJetCollection > h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection >( "genJets" );
-  edm::RefProd<std::vector<CaloTower>  >  h_caloTowersOut = iEvent.getRefBeforePut<std::vector<CaloTower>  > ( "caloTowers" );
-  edm::RefProd<reco::PFCandidateCollection > h_pfCandidatesOut = iEvent.getRefBeforePut<reco::PFCandidateCollection > ( "pfCandidates" );
-  edm::RefProd<edm::OwnVector<reco::BaseTagInfo> > h_tagInfosOut = iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo> > ( "tagInfos" );
+  edm::RefProd<reco::GenJetCollection> h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection>("genJets");
+  edm::RefProd<std::vector<CaloTower>> h_caloTowersOut = iEvent.getRefBeforePut<std::vector<CaloTower>>("caloTowers");
+  edm::RefProd<reco::PFCandidateCollection> h_pfCandidatesOut =
+      iEvent.getRefBeforePut<reco::PFCandidateCollection>("pfCandidates");
+  edm::RefProd<edm::OwnVector<reco::BaseTagInfo>> h_tagInfosOut =
+      iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
 
   for (edm::View<reco::Jet>::const_iterator itJet = jets->begin(); itJet != jets->end(); itJet++) {
-
     // construct the Jet from the ref -> save ref to original object
     unsigned int idx = itJet - jets->begin();
     edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
@@ -239,117 +257,124 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     Jet ajet(jetRef);
 
     // add the FwdPtrs to the CaloTowers
-    if ( (ajet.isCaloJet() || ajet.isJPTJet() ) && embedCaloTowers_) {
+    if ((ajet.isCaloJet() || ajet.isJPTJet()) && embedCaloTowers_) {
       const reco::CaloJet *cj = nullptr;
-      const reco::JPTJet * jptj = nullptr;
-      if ( ajet.isCaloJet()) cj = dynamic_cast<const reco::CaloJet *>(jetRef.get());
+      const reco::JPTJet *jptj = nullptr;
+      if (ajet.isCaloJet())
+        cj = dynamic_cast<const reco::CaloJet *>(jetRef.get());
       else {
-	jptj = dynamic_cast<const reco::JPTJet *>(jetRef.get() );
-	cj = dynamic_cast<const reco::CaloJet *>(jptj->getCaloJetRef().get() );
+        jptj = dynamic_cast<const reco::JPTJet *>(jetRef.get());
+        cj = dynamic_cast<const reco::CaloJet *>(jptj->getCaloJetRef().get());
       }
       pat::CaloTowerFwdPtrCollection itowersRef;
-      std::vector< CaloTowerPtr > itowers = cj->getCaloConstituents();
-      for ( std::vector<CaloTowerPtr>::const_iterator towBegin = itowers.begin(), towEnd = itowers.end(), itow = towBegin; itow != towEnd; ++itow ) {
-	if( itow->isAvailable() && itow->isNonnull() ){
-	  caloTowersOut->push_back( **itow );
-	  // set the "forward" ref to the thinned collection
-	  edm::Ref<std::vector<CaloTower> > caloTowerRef( h_caloTowersOut, caloTowersOut->size() - 1);
-	  edm::Ptr<CaloTower> caloForwardRef ( h_caloTowersOut.id(), caloTowerRef.key(), h_caloTowersOut.productGetter() );
-	  // set the "backward" ref to the original collection for association
-	  edm::Ptr<CaloTower> caloBackRef ( *itow );
-	  // add to the list of FwdPtr's
-	  itowersRef.push_back( pat::CaloTowerFwdPtrCollection::value_type ( caloForwardRef, caloBackRef ) );
-	}
+      std::vector<CaloTowerPtr> itowers = cj->getCaloConstituents();
+      for (std::vector<CaloTowerPtr>::const_iterator towBegin = itowers.begin(),
+                                                     towEnd = itowers.end(),
+                                                     itow = towBegin;
+           itow != towEnd;
+           ++itow) {
+        if (itow->isAvailable() && itow->isNonnull()) {
+          caloTowersOut->push_back(**itow);
+          // set the "forward" ref to the thinned collection
+          edm::Ref<std::vector<CaloTower>> caloTowerRef(h_caloTowersOut, caloTowersOut->size() - 1);
+          edm::Ptr<CaloTower> caloForwardRef(h_caloTowersOut.id(), caloTowerRef.key(), h_caloTowersOut.productGetter());
+          // set the "backward" ref to the original collection for association
+          edm::Ptr<CaloTower> caloBackRef(*itow);
+          // add to the list of FwdPtr's
+          itowersRef.push_back(pat::CaloTowerFwdPtrCollection::value_type(caloForwardRef, caloBackRef));
+        }
       }
-      ajet.setCaloTowers( itowersRef );
+      ajet.setCaloTowers(itowersRef);
     }
 
     // add the FwdPtrs to the PFCandidates
     if (ajet.isPFJet() && embedPFCandidates_) {
       const reco::PFJet *cj = dynamic_cast<const reco::PFJet *>(jetRef.get());
       pat::PFCandidateFwdPtrCollection iparticlesRef;
-      std::vector< reco::PFCandidatePtr > iparticles = cj->getPFConstituents();
-      for ( std::vector<reco::PFCandidatePtr>::const_iterator partBegin = iparticles.begin(),
-	      partEnd = iparticles.end(), ipart = partBegin;
-	    ipart != partEnd; ++ipart ) {
-	pfCandidatesOut->push_back( **ipart );
-	// set the "forward" ref to the thinned collection
-	edm::Ref<reco::PFCandidateCollection> pfCollectionRef( h_pfCandidatesOut, pfCandidatesOut->size() - 1);
-	edm::Ptr<reco::PFCandidate> pfForwardRef ( h_pfCandidatesOut.id(), pfCollectionRef.key(),  h_pfCandidatesOut.productGetter() );
-	// set the "backward" ref to the original collection for association
-	edm::Ptr<reco::PFCandidate> pfBackRef ( *ipart );
-	// add to the list of FwdPtr's
-	iparticlesRef.push_back( pat::PFCandidateFwdPtrCollection::value_type ( pfForwardRef, pfBackRef ) );
+      std::vector<reco::PFCandidatePtr> iparticles = cj->getPFConstituents();
+      for (std::vector<reco::PFCandidatePtr>::const_iterator partBegin = iparticles.begin(),
+                                                             partEnd = iparticles.end(),
+                                                             ipart = partBegin;
+           ipart != partEnd;
+           ++ipart) {
+        pfCandidatesOut->push_back(**ipart);
+        // set the "forward" ref to the thinned collection
+        edm::Ref<reco::PFCandidateCollection> pfCollectionRef(h_pfCandidatesOut, pfCandidatesOut->size() - 1);
+        edm::Ptr<reco::PFCandidate> pfForwardRef(
+            h_pfCandidatesOut.id(), pfCollectionRef.key(), h_pfCandidatesOut.productGetter());
+        // set the "backward" ref to the original collection for association
+        edm::Ptr<reco::PFCandidate> pfBackRef(*ipart);
+        // add to the list of FwdPtr's
+        iparticlesRef.push_back(pat::PFCandidateFwdPtrCollection::value_type(pfForwardRef, pfBackRef));
       }
-      ajet.setPFCandidates( iparticlesRef );
+      ajet.setPFCandidates(iparticlesRef);
     }
 
     if (addJetCorrFactors_) {
       // add additional JetCorrs to the jet
-      for ( unsigned int i=0; i<jetCorrFactorsTokens_.size(); ++i ) {
-	const JetCorrFactors& jcf = jetCorrs[i][jetRef];
-	// uncomment for debugging
-	// jcf.print();
-	ajet.addJECFactors(jcf);
+      for (unsigned int i = 0; i < jetCorrFactorsTokens_.size(); ++i) {
+        const JetCorrFactors &jcf = jetCorrs[i][jetRef];
+        // uncomment for debugging
+        // jcf.print();
+        ajet.addJECFactors(jcf);
       }
       std::vector<std::string> levels = jetCorrs[0][jetRef].correctionLabels();
-      if(std::find(levels.begin(), levels.end(), "L2L3Residual")!=levels.end()){
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2L3Residual"));
-      }
-      else if(std::find(levels.begin(), levels.end(), "L3Absolute")!=levels.end()){
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
-      }
-      else{
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
-	if(printWarning_){
-	  edm::LogWarning("L3Absolute not found") << "L2L3Residual and L3Absolute are not part of the jetCorrFactors\n"
-						  << "of module " <<  jetCorrs[0][jetRef].jecSet() << ". Jets will remain"
-						  << " uncorrected."; printWarning_=false;
-	}
+      if (std::find(levels.begin(), levels.end(), "L2L3Residual") != levels.end()) {
+        ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2L3Residual"));
+      } else if (std::find(levels.begin(), levels.end(), "L3Absolute") != levels.end()) {
+        ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
+      } else {
+        ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
+        if (printWarning_) {
+          edm::LogWarning("L3Absolute not found")
+              << "L2L3Residual and L3Absolute are not part of the jetCorrFactors\n"
+              << "of module " << jetCorrs[0][jetRef].jecSet() << ". Jets will remain"
+              << " uncorrected.";
+          printWarning_ = false;
+        }
       }
     }
 
     // get the MC flavour information for this jet
     if (getJetMCFlavour_ && useLegacyJetMCFlavour_) {
-        ajet.setPartonFlavour( (*jetFlavMatch)[edm::RefToBase<reco::Jet>(jetRef)].getFlavour() );
-    }
-    else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_) {
-        if ( addJetFlavourInfo_ ) ajet.setJetFlavourInfo( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)] );
-        else
-        {
-          ajet.setPartonFlavour( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getPartonFlavour() );
-          ajet.setHadronFlavour( (*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getHadronFlavour() );
-        }
+      ajet.setPartonFlavour((*jetFlavMatch)[edm::RefToBase<reco::Jet>(jetRef)].getFlavour());
+    } else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_) {
+      if (addJetFlavourInfo_)
+        ajet.setJetFlavourInfo((*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)]);
+      else {
+        ajet.setPartonFlavour((*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getPartonFlavour());
+        ajet.setHadronFlavour((*jetFlavInfoMatch)[edm::RefToBase<reco::Jet>(jetRef)].getHadronFlavour());
+      }
     }
     // store the match to the generated partons
     if (addGenPartonMatch_) {
       reco::GenParticleRef parton = (*partonMatch)[jetRef];
       if (parton.isNonnull() && parton.isAvailable()) {
-          ajet.setGenParton(parton, embedGenPartonMatch_);
-      } // leave empty if no match found
+        ajet.setGenParton(parton, embedGenPartonMatch_);
+      }  // leave empty if no match found
     }
     // store the match to the GenJets
     if (addGenJetMatch_) {
       reco::GenJetRef genjet = (*genJetMatch)[jetRef];
       if (genjet.isNonnull() && genjet.isAvailable()) {
-	genJetsOut->push_back( *genjet );
-	// set the "forward" ref to the thinned collection
-	edm::Ref<reco::GenJetCollection > genForwardRef ( h_genJetsOut, genJetsOut->size() - 1 );
-	// set the "backward" ref to the original collection
-	const edm::Ref<reco::GenJetCollection >& genBackRef ( genjet );
-	// make the FwdPtr
-	edm::FwdRef<reco::GenJetCollection > genjetFwdRef ( genForwardRef, genBackRef );
-	ajet.setGenJetRef(genjetFwdRef );
-      } // leave empty if no match found
+        genJetsOut->push_back(*genjet);
+        // set the "forward" ref to the thinned collection
+        edm::Ref<reco::GenJetCollection> genForwardRef(h_genJetsOut, genJetsOut->size() - 1);
+        // set the "backward" ref to the original collection
+        const edm::Ref<reco::GenJetCollection> &genBackRef(genjet);
+        // make the FwdPtr
+        edm::FwdRef<reco::GenJetCollection> genjetFwdRef(genForwardRef, genBackRef);
+        ajet.setGenJetRef(genjetFwdRef);
+      }  // leave empty if no match found
     }
 
     if (efficiencyLoader_.enabled()) {
-        efficiencyLoader_.setEfficiencies( ajet, jetRef );
+      efficiencyLoader_.setEfficiencies(ajet, jetRef);
     }
 
     // IMPORTANT: DO THIS AFTER JES CORRECTIONS
     if (resolutionLoader_.enabled()) {
-        resolutionLoader_.setResolutions(ajet);
+      resolutionLoader_.setResolutions(ajet);
     }
 
     // TO BE IMPLEMENTED FOR >=1_5_X: do the PartonJet matching
@@ -358,57 +383,65 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
     // add b-tag info if available & required
     if (addBTagInfo_) {
-        if (addDiscriminators_) {
-            for (size_t k=0; k<jetDiscriminators.size(); ++k) {
-                float value = (*jetDiscriminators[k])[jetRef];
-                ajet.addBDiscriminatorPair(std::make_pair(discriminatorLabels_[k], value));
+      if (addDiscriminators_) {
+        for (size_t k = 0; k < jetDiscriminators.size(); ++k) {
+          float value = (*jetDiscriminators[k])[jetRef];
+          ajet.addBDiscriminatorPair(std::make_pair(discriminatorLabels_[k], value));
+        }
+      }
+      if (addTagInfos_) {
+        for (size_t k = 0; k < jetTagInfos.size(); ++k) {
+          const edm::View<reco::BaseTagInfo> &taginfos = *jetTagInfos[k];
+          // This is not associative, so we have to search the jet
+          edm::Ptr<reco::BaseTagInfo> match;
+          // Try first by 'same index'
+          if ((idx < taginfos.size()) && (taginfos[idx].jet() == jetRef)) {
+            match = taginfos.ptrAt(idx);
+          } else {
+            // otherwise fail back to a simple search
+            for (edm::View<reco::BaseTagInfo>::const_iterator itTI = taginfos.begin(), edTI = taginfos.end();
+                 itTI != edTI;
+                 ++itTI) {
+              if (itTI->jet() == jetRef) {
+                match = taginfos.ptrAt(itTI - taginfos.begin());
+                break;
+              }
             }
+          }
+          if (match.isNonnull()) {
+            tagInfosOut->push_back(match->clone());
+            // set the "forward" ptr to the thinned collection
+            edm::Ptr<reco::BaseTagInfo> tagInfoForwardPtr(
+                h_tagInfosOut.id(), &tagInfosOut->back(), tagInfosOut->size() - 1);
+            // set the "backward" ptr to the original collection for association
+            const edm::Ptr<reco::BaseTagInfo> &tagInfoBackPtr(match);
+            // make FwdPtr
+            TagInfoFwdPtrCollection::value_type tagInfoFwdPtr(tagInfoForwardPtr, tagInfoBackPtr);
+            ajet.addTagInfo(tagInfoLabels_[k], tagInfoFwdPtr);
+          }
         }
-        if (addTagInfos_) {
-	  for (size_t k=0; k<jetTagInfos.size(); ++k) {
-	    const edm::View<reco::BaseTagInfo> & taginfos = *jetTagInfos[k];
-	    // This is not associative, so we have to search the jet
-	    edm::Ptr<reco::BaseTagInfo> match;
-	    // Try first by 'same index'
-	    if ((idx < taginfos.size()) && (taginfos[idx].jet() == jetRef)) {
-	      match = taginfos.ptrAt(idx);
-	    } else {
-	      // otherwise fail back to a simple search
-	      for (edm::View<reco::BaseTagInfo>::const_iterator itTI = taginfos.begin(), edTI = taginfos.end(); itTI != edTI; ++itTI) {
-		if (itTI->jet() == jetRef) { match = taginfos.ptrAt( itTI - taginfos.begin() ); break; }
-	      }
-	    }
-	    if (match.isNonnull()) {
-	      tagInfosOut->push_back( match->clone() );
-	      // set the "forward" ptr to the thinned collection
-	      edm::Ptr<reco::BaseTagInfo> tagInfoForwardPtr ( h_tagInfosOut.id(), &tagInfosOut->back(), tagInfosOut->size() - 1 );
-	      // set the "backward" ptr to the original collection for association
-	      const edm::Ptr<reco::BaseTagInfo>& tagInfoBackPtr ( match );
-	      // make FwdPtr
-	      TagInfoFwdPtrCollection::value_type tagInfoFwdPtr( tagInfoForwardPtr, tagInfoBackPtr ) ;
-	      ajet.addTagInfo(tagInfoLabels_[k], tagInfoFwdPtr );
-	    }
-	  }
-        }
+      }
     }
 
-    if (addAssociatedTracks_) ajet.setAssociatedTracks( (*hTrackAss)[jetRef] );
+    if (addAssociatedTracks_)
+      ajet.setAssociatedTracks((*hTrackAss)[jetRef]);
 
-    if (addJetCharge_) ajet.setJetCharge( (*hJetChargeAss)[jetRef] );
+    if (addJetCharge_)
+      ajet.setJetCharge((*hJetChargeAss)[jetRef]);
 
     // add jet ID for calo jets
-    if (addJetID_ && ajet.isCaloJet() ) {
-      reco::JetID jetId = (*hJetIDMap)[ jetRef ];
-      ajet.setJetID( jetId );
+    if (addJetID_ && ajet.isCaloJet()) {
+      reco::JetID jetId = (*hJetIDMap)[jetRef];
+      ajet.setJetID(jetId);
     }
     // add jet ID jpt jets
-    else if ( addJetID_ && ajet.isJPTJet() ){
+    else if (addJetID_ && ajet.isJPTJet()) {
       const reco::JPTJet *jptj = dynamic_cast<const reco::JPTJet *>(jetRef.get());
-      reco::JetID jetId = (*hJetIDMap)[ jptj->getCaloJetRef() ];
-      ajet.setJetID( jetId );
+      reco::JetID jetId = (*hJetIDMap)[jptj->getCaloJetRef()];
+      ajet.setJetID(jetId);
     }
-    if ( useUserData_ ) {
-      userDataHelper_.add( ajet, iEvent, iSetup );
+    if (useUserData_) {
+      userDataHelper_.add(ajet, iEvent, iSetup);
     }
     patJets->push_back(ajet);
   }
@@ -419,17 +452,14 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   // put genEvt  in Event
   iEvent.put(std::move(patJets));
 
-  iEvent.put(std::move(genJetsOut), "genJets" );
-  iEvent.put(std::move(caloTowersOut), "caloTowers" );
-  iEvent.put(std::move(pfCandidatesOut), "pfCandidates" );
-  iEvent.put(std::move(tagInfosOut), "tagInfos" );
-
-
+  iEvent.put(std::move(genJetsOut), "genJets");
+  iEvent.put(std::move(caloTowersOut), "caloTowers");
+  iEvent.put(std::move(pfCandidatesOut), "pfCandidates");
+  iEvent.put(std::move(tagInfosOut), "tagInfos");
 }
 
 // ParameterSet description for module
-void PATJetProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATJetProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT jet producer module");
 
@@ -437,7 +467,8 @@ void PATJetProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   iDesc.add<edm::InputTag>("jetSource", edm::InputTag("no default"))->setComment("input collection");
 
   // embedding
-  iDesc.addOptional<bool>("embedCaloTowers", false)->setComment("embed external CaloTowers (not to be used on AOD input)");
+  iDesc.addOptional<bool>("embedCaloTowers", false)
+      ->setComment("embed external CaloTowers (not to be used on AOD input)");
   iDesc.add<bool>("embedPFCandidates", true)->setComment("embed external PFCandidates");
 
   // MC matching configurables
@@ -466,16 +497,16 @@ void PATJetProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   // tag info
   iDesc.add<bool>("addTagInfos", true);
   std::vector<edm::InputTag> emptyVInputTags;
-  iDesc.add<std::vector<edm::InputTag> >("tagInfoSources", emptyVInputTags);
+  iDesc.add<std::vector<edm::InputTag>>("tagInfoSources", emptyVInputTags);
 
   // jet energy corrections
   iDesc.add<bool>("addJetCorrFactors", true);
-  iDesc.add<std::vector<edm::InputTag> >("jetCorrFactorsSource", emptyVInputTags);
+  iDesc.add<std::vector<edm::InputTag>>("jetCorrFactorsSource", emptyVInputTags);
 
   // btag discriminator tags
-  iDesc.add<bool>("addBTagInfo",true);
+  iDesc.add<bool>("addBTagInfo", true);
   iDesc.add<bool>("addDiscriminators", true);
-  iDesc.add<std::vector<edm::InputTag> >("discriminatorSources", emptyVInputTags);
+  iDesc.add<std::vector<edm::InputTag>>("discriminatorSources", emptyVInputTags);
 
   // jet flavour idetification configurables
   iDesc.add<bool>("getJetMCFlavour", true);
@@ -488,7 +519,7 @@ void PATJetProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
 
   // Efficiency configurables
   edm::ParameterSetDescription efficienciesPSet;
-  efficienciesPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  efficienciesPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("efficiencies", efficienciesPSet);
   iDesc.add<bool>("addEfficiencies", false);
 
@@ -503,4 +534,3 @@ void PATJetProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(PATJetProducer);
-

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.h
@@ -15,7 +15,6 @@
   \version  $Id: PATJetProducer.h,v 1.26 2010/08/09 18:13:54 srappocc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -41,77 +40,69 @@
 
 class JetFlavourIdentifier;
 
-
 namespace pat {
 
   class PATJetProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATJetProducer(const edm::ParameterSet& iConfig);
+    ~PATJetProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATJetProducer(const edm::ParameterSet & iConfig);
-      ~PATJetProducer() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+  private:
+    // configurables
+    edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken_;
+    bool embedCaloTowers_;
+    bool embedPFCandidates_;
+    bool getJetMCFlavour_;
+    bool useLegacyJetMCFlavour_;
+    bool addJetFlavourInfo_;
+    edm::EDGetTokenT<reco::JetFlavourMatchingCollection> jetPartonMapToken_;
+    edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> jetFlavourInfoToken_;
+    bool addGenPartonMatch_;
+    bool embedGenPartonMatch_;
+    edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > genPartonToken_;
+    bool addGenJetMatch_;
+    bool embedGenJetMatch_;
+    edm::EDGetTokenT<edm::Association<reco::GenJetCollection> > genJetToken_;
+    bool addPartonJetMatch_;
+    //       edm::EDGetTokenT<edm::View<reco::SomePartonJetType> > partonJetToken_;
+    bool addJetCorrFactors_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<JetCorrFactors> > > jetCorrFactorsTokens_;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    bool addBTagInfo_;
+    bool addDiscriminators_;
+    std::vector<edm::InputTag> discriminatorTags_;
+    std::vector<edm::EDGetTokenT<reco::JetFloatAssociation::Container> > discriminatorTokens_;
+    std::vector<std::string> discriminatorLabels_;
+    bool addTagInfos_;
+    std::vector<edm::InputTag> tagInfoTags_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > tagInfoTokens_;
+    std::vector<std::string> tagInfoLabels_;
+    bool addAssociatedTracks_;
+    edm::EDGetTokenT<reco::JetTracksAssociation::Container> trackAssociationToken_;
+    bool addJetCharge_;
+    edm::EDGetTokenT<reco::JetFloatAssociation::Container> jetChargeToken_;
+    bool addJetID_;
+    edm::EDGetTokenT<reco::JetIDValueMap> jetIDMapToken_;
+    // tools
+    GreaterByPt<Jet> pTComparator_;
+    GreaterByPt<CaloTower> caloPTComparator_;
 
-    private:
+    bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      // configurables
-      edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken_;
-      bool                     embedCaloTowers_;
-      bool                     embedPFCandidates_;
-      bool                     getJetMCFlavour_;
-      bool                     useLegacyJetMCFlavour_;
-      bool                     addJetFlavourInfo_;
-      edm::EDGetTokenT<reco::JetFlavourMatchingCollection> jetPartonMapToken_;
-      edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> jetFlavourInfoToken_;
-      bool                     addGenPartonMatch_;
-      bool                     embedGenPartonMatch_;
-      edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > genPartonToken_;
-      bool                     addGenJetMatch_;
-      bool                     embedGenJetMatch_;
-      edm::EDGetTokenT<edm::Association<reco::GenJetCollection> > genJetToken_;
-      bool                     addPartonJetMatch_;
-//       edm::EDGetTokenT<edm::View<reco::SomePartonJetType> > partonJetToken_;
-      bool                     addJetCorrFactors_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<JetCorrFactors> > > jetCorrFactorsTokens_;
+    bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      bool                       addBTagInfo_;
-      bool                       addDiscriminators_;
-      std::vector<edm::InputTag> discriminatorTags_;
-      std::vector<edm::EDGetTokenT<reco::JetFloatAssociation::Container> > discriminatorTokens_;
-      std::vector<std::string>   discriminatorLabels_;
-      bool                       addTagInfos_;
-      std::vector<edm::InputTag> tagInfoTags_;
-      std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > tagInfoTokens_;
-      std::vector<std::string>   tagInfoLabels_;
-      bool                       addAssociatedTracks_;
-      edm::EDGetTokenT<reco::JetTracksAssociation::Container> trackAssociationToken_;
-      bool                       addJetCharge_;
-      edm::EDGetTokenT<reco::JetFloatAssociation::Container> jetChargeToken_;
-      bool                       addJetID_;
-      edm::EDGetTokenT<reco::JetIDValueMap> jetIDMapToken_;
-      // tools
-      GreaterByPt<Jet>                   pTComparator_;
-      GreaterByPt<CaloTower>             caloPTComparator_;
-
-      bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
-
-      bool                     addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
-
-      bool useUserData_;
-      pat::PATUserDataHelper<pat::Jet>      userDataHelper_;
-      //
-      bool printWarning_; // this is introduced to issue warnings only once per job
-
-
-
+    bool useUserData_;
+    pat::PATUserDataHelper<pat::Jet> userDataHelper_;
+    //
+    bool printWarning_;  // this is introduced to issue warnings only once per job
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
@@ -16,31 +16,26 @@
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-
 #include <vector>
-
 
 namespace pat {
 
   class PATJetSelector : public edm::stream::EDFilter<> {
   public:
-
-
-  PATJetSelector( edm::ParameterSet const & params ) :
-      srcToken_(consumes<edm::View<pat::Jet> >( params.getParameter<edm::InputTag>("src") )),
-      cut_( params.getParameter<std::string>("cut") ),
-      cutLoose_( params.getParameter<std::string>("cutLoose") ),
-      filter_( params.exists("filter") ? params.getParameter<bool>("filter") : false ),
-      nLoose_( params.getParameter<unsigned>("nLoose") ),
-      selector_( cut_ ),
-      selectorLoose_( cutLoose_ )
-      {
-	produces< std::vector<pat::Jet> >();
-	produces<reco::GenJetCollection> ("genJets");
-	produces<std::vector<CaloTower>  > ("caloTowers");
-	produces<reco::PFCandidateCollection > ("pfCandidates");
-	produces<edm::OwnVector<reco::BaseTagInfo> > ("tagInfos");
-      }
+    PATJetSelector(edm::ParameterSet const& params)
+        : srcToken_(consumes<edm::View<pat::Jet>>(params.getParameter<edm::InputTag>("src"))),
+          cut_(params.getParameter<std::string>("cut")),
+          cutLoose_(params.getParameter<std::string>("cutLoose")),
+          filter_(params.exists("filter") ? params.getParameter<bool>("filter") : false),
+          nLoose_(params.getParameter<unsigned>("nLoose")),
+          selector_(cut_),
+          selectorLoose_(cutLoose_) {
+      produces<std::vector<pat::Jet>>();
+      produces<reco::GenJetCollection>("genJets");
+      produces<std::vector<CaloTower>>("caloTowers");
+      produces<reco::PFCandidateCollection>("pfCandidates");
+      produces<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
+    }
 
     ~PATJetSelector() override {}
 
@@ -48,188 +43,186 @@ namespace pat {
     virtual void endJob() {}
 
     bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
-
       auto patJets = std::make_unique<std::vector<Jet>>();
 
       auto genJetsOut = std::make_unique<reco::GenJetCollection>();
-      auto caloTowersOut = std::make_unique<std::vector<CaloTower> >();
+      auto caloTowersOut = std::make_unique<std::vector<CaloTower>>();
       auto pfCandidatesOut = std::make_unique<reco::PFCandidateCollection>();
       auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
 
+      edm::RefProd<reco::GenJetCollection> h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection>("genJets");
+      edm::RefProd<std::vector<CaloTower>> h_caloTowersOut =
+          iEvent.getRefBeforePut<std::vector<CaloTower>>("caloTowers");
+      edm::RefProd<reco::PFCandidateCollection> h_pfCandidatesOut =
+          iEvent.getRefBeforePut<reco::PFCandidateCollection>("pfCandidates");
+      edm::RefProd<edm::OwnVector<reco::BaseTagInfo>> h_tagInfosOut =
+          iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
 
-      edm::RefProd<reco::GenJetCollection > h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection >( "genJets" );
-      edm::RefProd<std::vector<CaloTower>  >  h_caloTowersOut = iEvent.getRefBeforePut<std::vector<CaloTower>  > ( "caloTowers" );
-      edm::RefProd<reco::PFCandidateCollection > h_pfCandidatesOut = iEvent.getRefBeforePut<reco::PFCandidateCollection > ( "pfCandidates" );
-      edm::RefProd<edm::OwnVector<reco::BaseTagInfo> > h_tagInfosOut = iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo> > ( "tagInfos" );
+      edm::Handle<edm::View<pat::Jet>> h_jets;
+      iEvent.getByToken(srcToken_, h_jets);
 
-      edm::Handle< edm::View<pat::Jet> > h_jets;
-      iEvent.getByToken( srcToken_, h_jets );
-
-      unsigned nl = 0; // number of loose jets
+      unsigned nl = 0;  // number of loose jets
       // First loop over the products and make the secondary output collections
-      for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
-	      iend = h_jets->end(), ijet = ibegin;
-	    ijet != iend; ++ijet ) {
-	
-	bool selectedLoose = false;
-	if ( nLoose_ > 0 && nl < nLoose_ && selectorLoose_(*ijet) ) {
-	  selectedLoose = true;
-	  ++nl;
-	}
+      for (edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(), iend = h_jets->end(), ijet = ibegin;
+           ijet != iend;
+           ++ijet) {
+        bool selectedLoose = false;
+        if (nLoose_ > 0 && nl < nLoose_ && selectorLoose_(*ijet)) {
+          selectedLoose = true;
+          ++nl;
+        }
 
+        if (selector_(*ijet) || selectedLoose) {
+          // Copy over the calo towers
+          for (CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
+                                                     itowerEnd = ijet->caloTowersFwdPtr().end(),
+                                                     itower = itowerBegin;
+               itower != itowerEnd;
+               ++itower) {
+            // Add to global calo tower list
+            caloTowersOut->push_back(**itower);
+          }
 
-	if ( selector_(*ijet) || selectedLoose ) {
-	  // Copy over the calo towers
-	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
-		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
-		itower != itowerEnd; ++itower ) {
-	    // Add to global calo tower list
-	    caloTowersOut->push_back( **itower );
-	  }
+          // Copy over the pf candidates
+          for (reco::PFCandidateFwdPtrVector::const_iterator icandBegin = ijet->pfCandidatesFwdPtr().begin(),
+                                                             icandEnd = ijet->pfCandidatesFwdPtr().end(),
+                                                             icand = icandBegin;
+               icand != icandEnd;
+               ++icand) {
+            // Add to global pf candidate list
+            pfCandidatesOut->push_back(**icand);
+          }
 
+          // Copy the tag infos
+          for (TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(),
+                                                       iinfoEnd = ijet->tagInfosFwdPtr().end(),
+                                                       iinfo = iinfoBegin;
+               iinfo != iinfoEnd;
+               ++iinfo) {
+            // Add to global calo tower list
+            tagInfosOut->push_back(**iinfo);
+          }
 
-	  // Copy over the pf candidates
-	  for ( reco::PFCandidateFwdPtrVector::const_iterator icandBegin = ijet->pfCandidatesFwdPtr().begin(),
-		  icandEnd = ijet->pfCandidatesFwdPtr().end(), icand = icandBegin;
-		icand != icandEnd; ++icand ) {
-	    // Add to global pf candidate list
-	    pfCandidatesOut->push_back( **icand );
-	  }
-
-	  // Copy the tag infos
-	  for ( TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(),
-		  iinfoEnd = ijet->tagInfosFwdPtr().end(), iinfo = iinfoBegin;
-		iinfo != iinfoEnd; ++iinfo ) {
-	    // Add to global calo tower list
-	    tagInfosOut->push_back( **iinfo );
-	  }
-
-	  // Copy the gen jet
-	  if ( ijet->genJet() != nullptr ) {
-	    genJetsOut->push_back( *(ijet->genJet()) );
-	  }
-
-	}
+          // Copy the gen jet
+          if (ijet->genJet() != nullptr) {
+            genJetsOut->push_back(*(ijet->genJet()));
+          }
+        }
       }
 
-
       // Output the secondary collections.
-      edm::OrphanHandle<reco::GenJetCollection>  oh_genJetsOut = iEvent.put(std::move(genJetsOut), "genJets" );
-      edm::OrphanHandle<std::vector<CaloTower> > oh_caloTowersOut = iEvent.put(std::move(caloTowersOut), "caloTowers" );
-      edm::OrphanHandle<reco::PFCandidateCollection> oh_pfCandidatesOut = iEvent.put(std::move(pfCandidatesOut), "pfCandidates" );
-      edm::OrphanHandle<edm::OwnVector<reco::BaseTagInfo> > oh_tagInfosOut = iEvent.put(std::move(tagInfosOut), "tagInfos" );
-
-
-
-
+      edm::OrphanHandle<reco::GenJetCollection> oh_genJetsOut = iEvent.put(std::move(genJetsOut), "genJets");
+      edm::OrphanHandle<std::vector<CaloTower>> oh_caloTowersOut = iEvent.put(std::move(caloTowersOut), "caloTowers");
+      edm::OrphanHandle<reco::PFCandidateCollection> oh_pfCandidatesOut =
+          iEvent.put(std::move(pfCandidatesOut), "pfCandidates");
+      edm::OrphanHandle<edm::OwnVector<reco::BaseTagInfo>> oh_tagInfosOut =
+          iEvent.put(std::move(tagInfosOut), "tagInfos");
 
       unsigned int caloTowerIndex = 0;
       unsigned int pfCandidateIndex = 0;
       unsigned int tagInfoIndex = 0;
       unsigned int genJetIndex = 0;
       // Now set the Ptrs with the orphan handles.
-      nl = 0; // Reset number of loose jets
-      for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
-	      iend = h_jets->end(), ijet = ibegin;
-	    ijet != iend; ++ijet ) {
+      nl = 0;  // Reset number of loose jets
+      for (edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(), iend = h_jets->end(), ijet = ibegin;
+           ijet != iend;
+           ++ijet) {
+        bool selectedLoose = false;
+        if (nLoose_ > 0 && nl < nLoose_ && selectorLoose_(*ijet)) {
+          selectedLoose = true;
+          ++nl;
+        }
 
-	bool selectedLoose = false;
-	if ( nLoose_ > 0 && nl < nLoose_ && selectorLoose_(*ijet) ) {
-	  selectedLoose = true;
-	  ++nl;
-	}
+        if (selector_(*ijet) || selectedLoose) {
+          // Add the jets that pass to the output collection
+          patJets->push_back(*ijet);
 
-	if ( selector_(*ijet) || selectedLoose ) {
-	  // Add the jets that pass to the output collection
-	  patJets->push_back( *ijet );
-	 
-	  // Copy over the calo towers
-	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
-		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
-		itower != itowerEnd; ++itower ) {
-	    // Update the "forward" bit of the FwdPtr to point at the new tower collection.
+          // Copy over the calo towers
+          for (CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
+                                                     itowerEnd = ijet->caloTowersFwdPtr().end(),
+                                                     itower = itowerBegin;
+               itower != itowerEnd;
+               ++itower) {
+            // Update the "forward" bit of the FwdPtr to point at the new tower collection.
 
-	    //  ptr to "this" tower in the global list
-	    edm::Ptr<CaloTower> outPtr( oh_caloTowersOut, caloTowerIndex);
-	    patJets->back().updateFwdCaloTowerFwdPtr( itower - itowerBegin,// index of "this" tower in the jet
-						      outPtr
-						      );
-	    ++caloTowerIndex;
-	  }
+            //  ptr to "this" tower in the global list
+            edm::Ptr<CaloTower> outPtr(oh_caloTowersOut, caloTowerIndex);
+            patJets->back().updateFwdCaloTowerFwdPtr(itower - itowerBegin,  // index of "this" tower in the jet
+                                                     outPtr);
+            ++caloTowerIndex;
+          }
 
+          // Copy over the pf candidates
+          for (reco::PFCandidateFwdPtrVector::const_iterator icandBegin = ijet->pfCandidatesFwdPtr().begin(),
+                                                             icandEnd = ijet->pfCandidatesFwdPtr().end(),
+                                                             icand = icandBegin;
+               icand != icandEnd;
+               ++icand) {
+            // Update the "forward" bit of the FwdPtr to point at the new tower collection.
 
-	  // Copy over the pf candidates
-	  for ( reco::PFCandidateFwdPtrVector::const_iterator icandBegin = ijet->pfCandidatesFwdPtr().begin(),
-		  icandEnd = ijet->pfCandidatesFwdPtr().end(), icand = icandBegin;
-		icand != icandEnd; ++icand ) {
-	    // Update the "forward" bit of the FwdPtr to point at the new tower collection.
+            // ptr to "this" cand in the global list
+            edm::Ptr<reco::PFCandidate> outPtr(oh_pfCandidatesOut, pfCandidateIndex);
+            patJets->back().updateFwdPFCandidateFwdPtr(icand - icandBegin,  // index of "this" tower in the jet
+                                                       outPtr);
+            ++pfCandidateIndex;
+          }
 
-	    // ptr to "this" cand in the global list
-	    edm::Ptr<reco::PFCandidate> outPtr( oh_pfCandidatesOut, pfCandidateIndex );
-	    patJets->back().updateFwdPFCandidateFwdPtr( icand - icandBegin,// index of "this" tower in the jet
-							outPtr
-							);
-	    ++pfCandidateIndex;
-	  }
+          // Copy the tag infos
+          for (TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(),
+                                                       iinfoEnd = ijet->tagInfosFwdPtr().end(),
+                                                       iinfo = iinfoBegin;
+               iinfo != iinfoEnd;
+               ++iinfo) {
+            // Update the "forward" bit of the FwdPtr to point at the new tower collection.
 
-	  // Copy the tag infos
-	  for ( TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(),
-		  iinfoEnd = ijet->tagInfosFwdPtr().end(), iinfo = iinfoBegin;
-		iinfo != iinfoEnd; ++iinfo ) {
-	    // Update the "forward" bit of the FwdPtr to point at the new tower collection.
+            // ptr to "this" info in the global list
+            edm::Ptr<reco::BaseTagInfo> outPtr(oh_tagInfosOut, tagInfoIndex);
+            patJets->back().updateFwdTagInfoFwdPtr(iinfo - iinfoBegin,  // index of "this" tower in the jet
+                                                   outPtr);
+            ++tagInfoIndex;
+          }
 
-	    // ptr to "this" info in the global list
-	    edm::Ptr<reco::BaseTagInfo > outPtr( oh_tagInfosOut, tagInfoIndex );
-	    patJets->back().updateFwdTagInfoFwdPtr( iinfo - iinfoBegin,// index of "this" tower in the jet
-						    outPtr
-						    );
-	    ++tagInfoIndex;
-	  }
-
-	  // Copy the gen jet
-	  if ( ijet->genJet() != nullptr ) {
-	    patJets->back().updateFwdGenJetFwdRef( edm::Ref<reco::GenJetCollection>( oh_genJetsOut, genJetIndex) // ref to "this" genjet in the global list
-						   );
-	    ++genJetIndex;
-	  }
-
-	}
+          // Copy the gen jet
+          if (ijet->genJet() != nullptr) {
+            patJets->back().updateFwdGenJetFwdRef(
+                edm::Ref<reco::GenJetCollection>(oh_genJetsOut, genJetIndex)  // ref to "this" genjet in the global list
+            );
+            ++genJetIndex;
+          }
+        }
       }
-
 
       // put genEvt  in Event
       bool pass = !patJets->empty();
       iEvent.put(std::move(patJets));
 
-      if ( filter_ )
-	return pass;
+      if (filter_)
+        return pass;
       else
-	return true;
+        return true;
     }
 
-
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription iDesc;
       iDesc.setComment("Energy Correlation Functions adder");
       iDesc.add<edm::InputTag>("src", edm::InputTag("no default"))->setComment("input collection");
-      iDesc.add<std::string> ("cut", "")->setComment("Jet selection.");
-      iDesc.add<std::string> ("cutLoose", "")->setComment("Loose jet selection. Will keep nLoose loose jets.");
-      iDesc.add<bool> ("filter", false)->setComment("Filter selection?");
+      iDesc.add<std::string>("cut", "")->setComment("Jet selection.");
+      iDesc.add<std::string>("cutLoose", "")->setComment("Loose jet selection. Will keep nLoose loose jets.");
+      iDesc.add<bool>("filter", false)->setComment("Filter selection?");
       iDesc.add<unsigned>("nLoose", 0)->setComment("Keep nLoose loose jets that satisfy cutLoose");
       descriptions.add("PATJetSelector", iDesc);
     }
-    
+
   protected:
-    const edm::EDGetTokenT<edm::View<pat::Jet> > srcToken_;
-    const std::string                    cut_;
-    const std::string                    cutLoose_;      // Cut to define loose jets.     
-    const bool                           filter_;    
-    const unsigned                       nLoose_;        // If desired, keep nLoose loose jets. 
-    const StringCutObjectSelector<Jet>   selector_;   
-    const StringCutObjectSelector<Jet>   selectorLoose_; // Selector for loose jets. 
+    const edm::EDGetTokenT<edm::View<pat::Jet>> srcToken_;
+    const std::string cut_;
+    const std::string cutLoose_;  // Cut to define loose jets.
+    const bool filter_;
+    const unsigned nLoose_;  // If desired, keep nLoose loose jets.
+    const StringCutObjectSelector<Jet> selector_;
+    const StringCutObjectSelector<Jet> selectorLoose_;  // Selector for loose jets.
   };
 
-}
-
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -24,140 +24,144 @@
 namespace pat {
 
   class PATJetSlimmer : public edm::stream::EDProducer<> {
-    public:
-      explicit PATJetSlimmer(const edm::ParameterSet & iConfig);
-      ~PATJetSlimmer() override { }
+  public:
+    explicit PATJetSlimmer(const edm::ParameterSet& iConfig);
+    ~PATJetSlimmer() override {}
 
-      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-      void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) final;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
-    private:
-      edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
-      edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> pf2pcAny_;
-      const edm::EDGetTokenT<edm::View<pat::Jet> >  jets_;
-      const StringCutObjectSelector<pat::Jet> dropJetVars_,dropDaughters_,rekeyDaughters_,dropTrackRefs_,dropSpecific_,dropTagInfos_;
-      const bool modifyJet_, mayNeedDaughterMap_, mixedDaughters_;
-      std::unique_ptr<pat::ObjectModifier<pat::Jet> > jetModifier_;
+  private:
+    edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
+    edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> pf2pcAny_;
+    const edm::EDGetTokenT<edm::View<pat::Jet>> jets_;
+    const StringCutObjectSelector<pat::Jet> dropJetVars_, dropDaughters_, rekeyDaughters_, dropTrackRefs_,
+        dropSpecific_, dropTagInfos_;
+    const bool modifyJet_, mayNeedDaughterMap_, mixedDaughters_;
+    std::unique_ptr<pat::ObjectModifier<pat::Jet>> jetModifier_;
   };
 
-} // namespace
+}  // namespace pat
 
-
-pat::PATJetSlimmer::PATJetSlimmer(const edm::ParameterSet & iConfig) :
-    jets_(consumes<edm::View<pat::Jet> >(iConfig.getParameter<edm::InputTag>("src"))),
-    dropJetVars_(iConfig.getParameter<std::string>("dropJetVars")),
-    dropDaughters_(iConfig.getParameter<std::string>("dropDaughters")),
-    rekeyDaughters_(iConfig.getParameter<std::string>("rekeyDaughters")),
-    dropTrackRefs_(iConfig.getParameter<std::string>("dropTrackRefs")),
-    dropSpecific_(iConfig.getParameter<std::string>("dropSpecific")),
-    dropTagInfos_(iConfig.getParameter<std::string>("dropTagInfos")),
-    modifyJet_(iConfig.getParameter<bool>("modifyJets")),
-    mayNeedDaughterMap_(iConfig.getParameter<std::string>("dropDaughters") != "1" && iConfig.getParameter<std::string>("rekeyDaughters") != "0"),
-    mixedDaughters_(iConfig.getParameter<bool>("mixedDaughters"))
-{
-    if (mayNeedDaughterMap_) {
-        if (mixedDaughters_) {
-            pf2pcAny_ = consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
-        } else {
-            pf2pc_ = consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
-        }
+pat::PATJetSlimmer::PATJetSlimmer(const edm::ParameterSet& iConfig)
+    : jets_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+      dropJetVars_(iConfig.getParameter<std::string>("dropJetVars")),
+      dropDaughters_(iConfig.getParameter<std::string>("dropDaughters")),
+      rekeyDaughters_(iConfig.getParameter<std::string>("rekeyDaughters")),
+      dropTrackRefs_(iConfig.getParameter<std::string>("dropTrackRefs")),
+      dropSpecific_(iConfig.getParameter<std::string>("dropSpecific")),
+      dropTagInfos_(iConfig.getParameter<std::string>("dropTagInfos")),
+      modifyJet_(iConfig.getParameter<bool>("modifyJets")),
+      mayNeedDaughterMap_(iConfig.getParameter<std::string>("dropDaughters") != "1" &&
+                          iConfig.getParameter<std::string>("rekeyDaughters") != "0"),
+      mixedDaughters_(iConfig.getParameter<bool>("mixedDaughters")) {
+  if (mayNeedDaughterMap_) {
+    if (mixedDaughters_) {
+      pf2pcAny_ =
+          consumes<edm::ValueMap<reco::CandidatePtr>>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
+    } else {
+      pf2pc_ = consumes<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
     }
-    if( modifyJet_ ) {
-      const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      jetModifier_ = std::make_unique<pat::ObjectModifier<pat::Jet>>(mod_config, consumesCollector());
-    }
-    produces<std::vector<pat::Jet> >();
+  }
+  if (modifyJet_) {
+    const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
+    jetModifier_ = std::make_unique<pat::ObjectModifier<pat::Jet>>(mod_config, consumesCollector());
+  }
+  produces<std::vector<pat::Jet>>();
 }
 
-void 
-pat::PATJetSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup& iSetup) {
-  if( modifyJet_ ) jetModifier_->setEventContent(iSetup);
+void pat::PATJetSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup) {
+  if (modifyJet_)
+    jetModifier_->setEventContent(iSetup);
 }
 
-void 
-pat::PATJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
+void pat::PATJetSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    Handle<View<pat::Jet> >      src;
-    iEvent.getByToken(jets_, src);
-    Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
-    Handle<edm::ValueMap<reco::CandidatePtr> > pf2pcAny;
-    if (mayNeedDaughterMap_) {
-        if (mixedDaughters_) {
-            iEvent.getByToken(pf2pcAny_,pf2pcAny);
-        } else {
-            iEvent.getByToken(pf2pc_,pf2pc);
+  Handle<View<pat::Jet>> src;
+  iEvent.getByToken(jets_, src);
+  Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  Handle<edm::ValueMap<reco::CandidatePtr>> pf2pcAny;
+  if (mayNeedDaughterMap_) {
+    if (mixedDaughters_) {
+      iEvent.getByToken(pf2pcAny_, pf2pcAny);
+    } else {
+      iEvent.getByToken(pf2pc_, pf2pc);
+    }
+  }
+
+  auto out = std::make_unique<std::vector<pat::Jet>>();
+  out->reserve(src->size());
+
+  if (modifyJet_) {
+    jetModifier_->setEvent(iEvent);
+  }
+
+  for (edm::View<pat::Jet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    out->push_back(*it);
+    pat::Jet& jet = out->back();
+
+    if (modifyJet_) {
+      jetModifier_->modify(jet);
+    }
+
+    if (dropTagInfos_(*it)) {
+      jet.tagInfoLabels_.clear();
+      jet.tagInfos_.clear();
+      jet.tagInfosFwdPtr_.clear();
+    }
+    if (dropJetVars_(*it)) {
+      //             jet.setJetArea(0);
+      jet.setNPasses(0);
+      //             jet.setPileup(0);
+    }
+    if (dropTrackRefs_(*it)) {
+      jet.setAssociatedTracks(reco::TrackRefVector());
+    }
+    if (dropDaughters_(*it)) {
+      jet.clearDaughters();
+      jet.pfCandidatesFwdPtr_.clear();
+      jet.caloTowersFwdPtr_.clear();
+    } else if (rekeyDaughters_(*it)) {  //rekey
+      //copy old
+      reco::CompositePtrCandidate::daughters old = jet.daughterPtrVector();
+      jet.clearDaughters();
+      if (mixedDaughters_) {
+        std::vector<reco::CandidatePtr> ptrs;
+        for (const reco::CandidatePtr& oldptr : old) {
+          ptrs.push_back((*pf2pcAny)[oldptr]);
         }
+        std::sort(ptrs.begin(), ptrs.end());
+        for (const reco::CandidatePtr& newptr : ptrs) {
+          jet.addDaughter(newptr);
+        }
+      } else {
+        std::map<unsigned int, reco::CandidatePtr> ptrs;
+        for (unsigned int i = 0; i < old.size(); i++) {
+          //	jet.addDaughter(refToPtr((*pf2pc)[old[i]]));
+          ptrs[((*pf2pc)[old[i]]).key()] = refToPtr((*pf2pc)[old[i]]);
+        }
+        for (std::map<unsigned int, reco::CandidatePtr>::iterator itp = ptrs.begin(); itp != ptrs.end();
+             itp++)  //iterate on sorted items
+        {
+          jet.addDaughter(itp->second);
+        }
+      }
     }
-	
-    auto out = std::make_unique<std::vector<pat::Jet>>();
-    out->reserve(src->size());
-
-    if( modifyJet_ ) { jetModifier_->setEvent(iEvent); }
-
-    for (edm::View<pat::Jet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-	    out->push_back(*it);
-	    pat::Jet & jet = out->back();
-
-            if( modifyJet_ ) { jetModifier_->modify(jet); }
-            
-	    if(dropTagInfos_(*it)){
-		    jet.tagInfoLabels_.clear();
-		    jet.tagInfos_.clear();
-		    jet.tagInfosFwdPtr_.clear(); 
-	    }
-	    if (dropJetVars_(*it)) {
-		    //             jet.setJetArea(0); 
-		    jet.setNPasses(0);
-		    //             jet.setPileup(0);
-	    }
-	    if(dropTrackRefs_(*it))
-	    {
-		    jet.setAssociatedTracks(reco::TrackRefVector());		
-	    }
-	    if (dropDaughters_(*it)) {
-		    jet.clearDaughters();
-		    jet.pfCandidatesFwdPtr_.clear();
-		    jet.caloTowersFwdPtr_.clear();
-	    } else if (rekeyDaughters_(*it)) {  //rekey
-		    //copy old 
-		    reco::CompositePtrCandidate::daughters old = jet.daughterPtrVector();
-		    jet.clearDaughters();
-                    if (mixedDaughters_) {
-                        std::vector<reco::CandidatePtr> ptrs;	    
-                        for(const reco::CandidatePtr &oldptr : old) {
-                            ptrs.push_back( (*pf2pcAny)[oldptr] );
-                        }
-                        std::sort(ptrs.begin(), ptrs.end());
-                        for(const reco::CandidatePtr &newptr : ptrs) {
-                            jet.addDaughter(newptr);
-                        }
-                    } else {
-                        std::map<unsigned int,reco::CandidatePtr> ptrs;	    
-                        for(unsigned int  i=0;i<old.size();i++)
-                        {
-                            //	jet.addDaughter(refToPtr((*pf2pc)[old[i]]));
-                            ptrs[((*pf2pc)[old[i]]).key()]=refToPtr((*pf2pc)[old[i]]);
-                        }
-                        for(std::map<unsigned int,reco::CandidatePtr>::iterator itp=ptrs.begin();itp!=ptrs.end();itp++) //iterate on sorted items
-                        {
-                            jet.addDaughter(itp->second);
-                        }
-                    }
-	    }	
-	    if (dropSpecific_(*it)) {
-		    // FIXME add method in pat::Jet
-		    jet.specificCalo_.clear();    
-		    jet.specificPF_.clear();    
-	    }
-	    //         if (dropJetCorrFactors_(*it)) {
-	    //             // FIXME add method in pat::Jet
-	    //             jet.jetEnergyCorrections_.clear();
-	    //         }
+    if (dropSpecific_(*it)) {
+      // FIXME add method in pat::Jet
+      jet.specificCalo_.clear();
+      jet.specificPF_.clear();
     }
+    //         if (dropJetCorrFactors_(*it)) {
+    //             // FIXME add method in pat::Jet
+    //             jet.jetEnergyCorrections_.clear();
+    //         }
+  }
 
-    iEvent.put(std::move(out));
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
@@ -1,6 +1,5 @@
 //
 
-
 #include "PhysicsTools/PatAlgos/plugins/PATJetUpdater.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -23,92 +22,95 @@
 
 using namespace pat;
 
-
-PATJetUpdater::PATJetUpdater(const edm::ParameterSet& iConfig) :
-  useUserData_(iConfig.exists("userData")),
-  printWarning_(iConfig.getParameter<bool>("printWarning"))
-{
+PATJetUpdater::PATJetUpdater(const edm::ParameterSet& iConfig)
+    : useUserData_(iConfig.exists("userData")), printWarning_(iConfig.getParameter<bool>("printWarning")) {
   // initialize configurables
-  jetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>( "jetSource" ));
-  addJetCorrFactors_ = iConfig.getParameter<bool>( "addJetCorrFactors" );
-  if( addJetCorrFactors_ ) {
-    jetCorrFactorsTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "jetCorrFactorsSource" ), [this](edm::InputTag const & tag){return mayConsume<edm::ValueMap<JetCorrFactors> >(tag);});
+  jetsToken_ = consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jetSource"));
+  addJetCorrFactors_ = iConfig.getParameter<bool>("addJetCorrFactors");
+  if (addJetCorrFactors_) {
+    jetCorrFactorsTokens_ = edm::vector_transform(
+        iConfig.getParameter<std::vector<edm::InputTag>>("jetCorrFactorsSource"),
+        [this](edm::InputTag const& tag) { return mayConsume<edm::ValueMap<JetCorrFactors>>(tag); });
   }
-  addBTagInfo_ = iConfig.getParameter<bool>( "addBTagInfo" );
-  addDiscriminators_ = iConfig.getParameter<bool>( "addDiscriminators" );
-  discriminatorTags_ = iConfig.getParameter<std::vector<edm::InputTag> >( "discriminatorSources" );
-  discriminatorTokens_ = edm::vector_transform(discriminatorTags_, [this](edm::InputTag const & tag){return mayConsume<reco::JetFloatAssociation::Container>(tag);});
-  addTagInfos_ = iConfig.getParameter<bool>( "addTagInfos" );
-  tagInfoTags_ = iConfig.getParameter<std::vector<edm::InputTag> >( "tagInfoSources" );
-  tagInfoTokens_ =edm::vector_transform(tagInfoTags_, [this](edm::InputTag const & tag){return mayConsume<edm::View<reco::BaseTagInfo> >(tag);});
+  addBTagInfo_ = iConfig.getParameter<bool>("addBTagInfo");
+  addDiscriminators_ = iConfig.getParameter<bool>("addDiscriminators");
+  discriminatorTags_ = iConfig.getParameter<std::vector<edm::InputTag>>("discriminatorSources");
+  discriminatorTokens_ = edm::vector_transform(discriminatorTags_, [this](edm::InputTag const& tag) {
+    return mayConsume<reco::JetFloatAssociation::Container>(tag);
+  });
+  addTagInfos_ = iConfig.getParameter<bool>("addTagInfos");
+  tagInfoTags_ = iConfig.getParameter<std::vector<edm::InputTag>>("tagInfoSources");
+  tagInfoTokens_ = edm::vector_transform(
+      tagInfoTags_, [this](edm::InputTag const& tag) { return mayConsume<edm::View<reco::BaseTagInfo>>(tag); });
   if (discriminatorTags_.empty()) {
     addDiscriminators_ = false;
   } else {
-    for (std::vector<edm::InputTag>::const_iterator it = discriminatorTags_.begin(), ed = discriminatorTags_.end(); it != ed; ++it) {
-        std::string label = it->label();
-        std::string::size_type pos = label.find("JetTags");
-        if ((pos !=  std::string::npos) && (pos != label.length() - 7)) {
-            label.erase(pos+7); // trim a tail after "JetTags"
-        }
-        if(!it->instance().empty()) {
-            label = (label+std::string(":")+it->instance());
-        }
-        discriminatorLabels_.push_back(label);
+    for (std::vector<edm::InputTag>::const_iterator it = discriminatorTags_.begin(), ed = discriminatorTags_.end();
+         it != ed;
+         ++it) {
+      std::string label = it->label();
+      std::string::size_type pos = label.find("JetTags");
+      if ((pos != std::string::npos) && (pos != label.length() - 7)) {
+        label.erase(pos + 7);  // trim a tail after "JetTags"
+      }
+      if (!it->instance().empty()) {
+        label = (label + std::string(":") + it->instance());
+      }
+      discriminatorLabels_.push_back(label);
     }
   }
   if (tagInfoTags_.empty()) {
     addTagInfos_ = false;
   } else {
-    for (std::vector<edm::InputTag>::const_iterator it = tagInfoTags_.begin(), ed = tagInfoTags_.end(); it != ed; ++it) {
-        std::string label = it->label();
-        std::string::size_type pos = label.find("TagInfos");
-        if ((pos !=  std::string::npos) && (pos != label.length() - 8)) {
-            label.erase(pos+8); // trim a tail after "TagInfos"
-        }
-        tagInfoLabels_.push_back(label);
+    for (std::vector<edm::InputTag>::const_iterator it = tagInfoTags_.begin(), ed = tagInfoTags_.end(); it != ed;
+         ++it) {
+      std::string label = it->label();
+      std::string::size_type pos = label.find("TagInfos");
+      if ((pos != std::string::npos) && (pos != label.length() - 8)) {
+        label.erase(pos + 8);  // trim a tail after "TagInfos"
+      }
+      tagInfoLabels_.push_back(label);
     }
   }
-  if (!addBTagInfo_) { addDiscriminators_ = false; addTagInfos_ = false; }
+  if (!addBTagInfo_) {
+    addDiscriminators_ = false;
+    addTagInfos_ = false;
+  }
   // Check to see if the user wants to add user data
-  if ( useUserData_ ) {
+  if (useUserData_) {
     userDataHelper_ = PATUserDataHelper<Jet>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   // produces vector of jets
-  produces<std::vector<Jet> >();
-  produces<edm::OwnVector<reco::BaseTagInfo> > ("tagInfos");
+  produces<std::vector<Jet>>();
+  produces<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
 }
 
+PATJetUpdater::~PATJetUpdater() {}
 
-PATJetUpdater::~PATJetUpdater() {
-
-}
-
-
-void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
+void PATJetUpdater::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Get the vector of jets
-  edm::Handle<edm::View<reco::Jet> > jets;
+  edm::Handle<edm::View<reco::Jet>> jets;
   iEvent.getByToken(jetsToken_, jets);
 
   // read in the jet correction factors ValueMap
-  std::vector<edm::ValueMap<JetCorrFactors> > jetCorrs;
+  std::vector<edm::ValueMap<JetCorrFactors>> jetCorrs;
   if (addJetCorrFactors_) {
-    for ( size_t i = 0; i < jetCorrFactorsTokens_.size(); ++i ) {
-      edm::Handle<edm::ValueMap<JetCorrFactors> > jetCorr;
+    for (size_t i = 0; i < jetCorrFactorsTokens_.size(); ++i) {
+      edm::Handle<edm::ValueMap<JetCorrFactors>> jetCorr;
       iEvent.getByToken(jetCorrFactorsTokens_[i], jetCorr);
-      jetCorrs.push_back( *jetCorr );
+      jetCorrs.push_back(*jetCorr);
     }
   }
 
   // Get the vector of jet tags with b-tagging info
-  std::vector<edm::Handle<reco::JetFloatAssociation::Container> > jetDiscriminators;
+  std::vector<edm::Handle<reco::JetFloatAssociation::Container>> jetDiscriminators;
   if (addBTagInfo_ && addDiscriminators_) {
     jetDiscriminators.resize(discriminatorTokens_.size());
     for (size_t i = 0; i < discriminatorTokens_.size(); ++i) {
-        iEvent.getByToken(discriminatorTokens_[i], jetDiscriminators[i]);
+      iEvent.getByToken(discriminatorTokens_[i], jetDiscriminators[i]);
     }
   }
-  std::vector<edm::Handle<edm::View<reco::BaseTagInfo> > > jetTagInfos;
+  std::vector<edm::Handle<edm::View<reco::BaseTagInfo>>> jetTagInfos;
   if (addBTagInfo_ && addTagInfos_) {
     jetTagInfos.resize(tagInfoTokens_.size());
     for (size_t i = 0; i < tagInfoTokens_.size(); ++i) {
@@ -121,15 +123,15 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 
   auto tagInfosOut = std::make_unique<edm::OwnVector<reco::BaseTagInfo>>();
 
-  edm::RefProd<edm::OwnVector<reco::BaseTagInfo> > h_tagInfosOut = iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo> > ( "tagInfos" );
+  edm::RefProd<edm::OwnVector<reco::BaseTagInfo>> h_tagInfosOut =
+      iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo>>("tagInfos");
 
   for (edm::View<reco::Jet>::const_iterator itJet = jets->begin(); itJet != jets->end(); itJet++) {
-
     // construct the Jet from the ref -> save ref to original object
     unsigned int idx = itJet - jets->begin();
     const edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
     const edm::RefToBase<Jet> patJetRef(jetRef.castTo<JetRef>());
-    Jet ajet( patJetRef );
+    Jet ajet(patJetRef);
 
     if (addJetCorrFactors_) {
       // undo previous jet energy corrections
@@ -137,67 +139,73 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
       // clear previous JetCorrFactors
       ajet.jec_.clear();
       // add additional JetCorrs to the jet
-      for ( unsigned int i=0; i<jetCorrFactorsTokens_.size(); ++i ) {
-	const JetCorrFactors& jcf = jetCorrs[i][jetRef];
-	// uncomment for debugging
-	// jcf.print();
-	ajet.addJECFactors(jcf);
+      for (unsigned int i = 0; i < jetCorrFactorsTokens_.size(); ++i) {
+        const JetCorrFactors& jcf = jetCorrs[i][jetRef];
+        // uncomment for debugging
+        // jcf.print();
+        ajet.addJECFactors(jcf);
       }
       std::vector<std::string> levels = jetCorrs[0][jetRef].correctionLabels();
-      if(std::find(levels.begin(), levels.end(), "L2L3Residual")!=levels.end()){
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2L3Residual"));
-      }
-      else if(std::find(levels.begin(), levels.end(), "L3Absolute")!=levels.end()){
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
-      }
-      else{
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
-	if(printWarning_){
-	  edm::LogWarning("L3Absolute not found") << "L2L3Residual and L3Absolute are not part of the jetCorrFactors\n"
-						  << "of module " <<  jetCorrs[0][jetRef].jecSet() << ". Jets will remain"
-						  << " uncorrected."; printWarning_=false;
-	}
+      if (std::find(levels.begin(), levels.end(), "L2L3Residual") != levels.end()) {
+        ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2L3Residual"));
+      } else if (std::find(levels.begin(), levels.end(), "L3Absolute") != levels.end()) {
+        ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
+      } else {
+        ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
+        if (printWarning_) {
+          edm::LogWarning("L3Absolute not found")
+              << "L2L3Residual and L3Absolute are not part of the jetCorrFactors\n"
+              << "of module " << jetCorrs[0][jetRef].jecSet() << ". Jets will remain"
+              << " uncorrected.";
+          printWarning_ = false;
+        }
       }
     }
 
     // add b-tag info if available & required
     if (addBTagInfo_) {
-        if (addDiscriminators_) {
-            for (size_t k=0; k<jetDiscriminators.size(); ++k) {
-                float value = (*jetDiscriminators[k])[jetRef];
-                ajet.addBDiscriminatorPair(std::make_pair(discriminatorLabels_[k], value));
+      if (addDiscriminators_) {
+        for (size_t k = 0; k < jetDiscriminators.size(); ++k) {
+          float value = (*jetDiscriminators[k])[jetRef];
+          ajet.addBDiscriminatorPair(std::make_pair(discriminatorLabels_[k], value));
+        }
+      }
+      if (addTagInfos_) {
+        for (size_t k = 0; k < jetTagInfos.size(); ++k) {
+          const edm::View<reco::BaseTagInfo>& taginfos = *jetTagInfos[k];
+          // This is not associative, so we have to search the jet
+          edm::Ptr<reco::BaseTagInfo> match;
+          // Try first by 'same index'
+          if ((idx < taginfos.size()) && (taginfos[idx].jet() == jetRef)) {
+            match = taginfos.ptrAt(idx);
+          } else {
+            // otherwise fail back to a simple search
+            for (edm::View<reco::BaseTagInfo>::const_iterator itTI = taginfos.begin(), edTI = taginfos.end();
+                 itTI != edTI;
+                 ++itTI) {
+              if (itTI->jet() == jetRef) {
+                match = taginfos.ptrAt(itTI - taginfos.begin());
+                break;
+              }
             }
+          }
+          if (match.isNonnull()) {
+            tagInfosOut->push_back(match->clone());
+            // set the "forward" ptr to the thinned collection
+            edm::Ptr<reco::BaseTagInfo> tagInfoForwardPtr(
+                h_tagInfosOut.id(), &tagInfosOut->back(), tagInfosOut->size() - 1);
+            // set the "backward" ptr to the original collection for association
+            const edm::Ptr<reco::BaseTagInfo>& tagInfoBackPtr(match);
+            // make FwdPtr
+            TagInfoFwdPtrCollection::value_type tagInfoFwdPtr(tagInfoForwardPtr, tagInfoBackPtr);
+            ajet.addTagInfo(tagInfoLabels_[k], tagInfoFwdPtr);
+          }
         }
-        if (addTagInfos_) {
-	  for (size_t k=0; k<jetTagInfos.size(); ++k) {
-	    const edm::View<reco::BaseTagInfo> & taginfos = *jetTagInfos[k];
-	    // This is not associative, so we have to search the jet
-	    edm::Ptr<reco::BaseTagInfo> match;
-	    // Try first by 'same index'
-	    if ((idx < taginfos.size()) && (taginfos[idx].jet() == jetRef)) {
-	      match = taginfos.ptrAt(idx);
-	    } else {
-	      // otherwise fail back to a simple search
-	      for (edm::View<reco::BaseTagInfo>::const_iterator itTI = taginfos.begin(), edTI = taginfos.end(); itTI != edTI; ++itTI) {
-		if (itTI->jet() == jetRef) { match = taginfos.ptrAt( itTI - taginfos.begin() ); break; }
-	      }
-	    }
-	    if (match.isNonnull()) {
-	      tagInfosOut->push_back( match->clone() );
-	      // set the "forward" ptr to the thinned collection
-	      edm::Ptr<reco::BaseTagInfo> tagInfoForwardPtr ( h_tagInfosOut.id(), &tagInfosOut->back(), tagInfosOut->size() - 1 );
-	      // set the "backward" ptr to the original collection for association
-	      const edm::Ptr<reco::BaseTagInfo>& tagInfoBackPtr ( match );
-	      // make FwdPtr
-	      TagInfoFwdPtrCollection::value_type tagInfoFwdPtr( tagInfoForwardPtr, tagInfoBackPtr ) ;
-	      ajet.addTagInfo(tagInfoLabels_[k], tagInfoFwdPtr );
-	    }
-	  }
-        }
+      }
     }
 
-    if ( useUserData_ ) {
-      userDataHelper_.add( ajet, iEvent, iSetup );
+    if (useUserData_) {
+      userDataHelper_.add(ajet, iEvent, iSetup);
     }
 
     // reassign the original object reference to preserve reference to the original jet the input PAT jet was derived from
@@ -213,13 +221,11 @@ void PATJetUpdater::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
   // put genEvt  in Event
   iEvent.put(std::move(patJets));
 
-  iEvent.put(std::move(tagInfosOut), "tagInfos" );
-
+  iEvent.put(std::move(tagInfosOut), "tagInfos");
 }
 
 // ParameterSet description for module
-void PATJetUpdater::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATJetUpdater::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT jet producer module");
 
@@ -229,19 +235,19 @@ void PATJetUpdater::fillDescriptions(edm::ConfigurationDescriptions & descriptio
   // tag info
   iDesc.add<bool>("addTagInfos", true);
   std::vector<edm::InputTag> emptyVInputTags;
-  iDesc.add<std::vector<edm::InputTag> >("tagInfoSources", emptyVInputTags);
+  iDesc.add<std::vector<edm::InputTag>>("tagInfoSources", emptyVInputTags);
 
   // jet energy corrections
   iDesc.add<bool>("addJetCorrFactors", true);
-  iDesc.add<std::vector<edm::InputTag> >("jetCorrFactorsSource", emptyVInputTags);
+  iDesc.add<std::vector<edm::InputTag>>("jetCorrFactorsSource", emptyVInputTags);
 
   // btag discriminator tags
-  iDesc.add<bool>("addBTagInfo",true);
+  iDesc.add<bool>("addBTagInfo", true);
   iDesc.add<bool>("addDiscriminators", true);
-  iDesc.add<std::vector<edm::InputTag> >("discriminatorSources", emptyVInputTags);
+  iDesc.add<std::vector<edm::InputTag>>("discriminatorSources", emptyVInputTags);
 
   // silent warning if false
-  iDesc.add<bool>("printWarning",true);
+  iDesc.add<bool>("printWarning", true);
 
   // Check to see if the user wants to add user data
   edm::ParameterSetDescription userDataPSet;

--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.h
@@ -15,7 +15,6 @@
   \version  $Id: PATJetUpdater.h,v 1.00 2014/03/11 18:13:54 srappocc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -32,43 +31,38 @@
 namespace pat {
 
   class PATJetUpdater : public edm::stream::EDProducer<> {
+  public:
+    explicit PATJetUpdater(const edm::ParameterSet& iConfig);
+    ~PATJetUpdater() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATJetUpdater(const edm::ParameterSet & iConfig);
-      ~PATJetUpdater() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+  private:
+    // configurables
+    edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken_;
+    bool addJetCorrFactors_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<JetCorrFactors> > > jetCorrFactorsTokens_;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    bool addBTagInfo_;
+    bool addDiscriminators_;
+    std::vector<edm::InputTag> discriminatorTags_;
+    std::vector<edm::EDGetTokenT<reco::JetFloatAssociation::Container> > discriminatorTokens_;
+    std::vector<std::string> discriminatorLabels_;
+    bool addTagInfos_;
+    std::vector<edm::InputTag> tagInfoTags_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > tagInfoTokens_;
+    std::vector<std::string> tagInfoLabels_;
 
-    private:
+    GreaterByPt<Jet> pTComparator_;
 
-      // configurables
-      edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken_;
-      bool                     addJetCorrFactors_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<JetCorrFactors> > > jetCorrFactorsTokens_;
-
-      bool                       addBTagInfo_;
-      bool                       addDiscriminators_;
-      std::vector<edm::InputTag> discriminatorTags_;
-      std::vector<edm::EDGetTokenT<reco::JetFloatAssociation::Container> > discriminatorTokens_;
-      std::vector<std::string>   discriminatorLabels_;
-      bool                       addTagInfos_;
-      std::vector<edm::InputTag> tagInfoTags_;
-      std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > tagInfoTokens_;
-      std::vector<std::string>   tagInfoLabels_;
-
-      GreaterByPt<Jet> pTComparator_;
-
-      bool useUserData_;
-      pat::PATUserDataHelper<pat::Jet>      userDataHelper_;
-      //
-      bool printWarning_; // this is introduced to issue warnings only once per job
-
+    bool useUserData_;
+    pat::PATUserDataHelper<pat::Jet> userDataHelper_;
+    //
+    bool printWarning_;  // this is introduced to issue warnings only once per job
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.cc
@@ -5,41 +5,36 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-
 using namespace pat;
 
+PATLeptonCountFilter::PATLeptonCountFilter(const edm::ParameterSet& iConfig)
+    : electronToken_(mayConsume<edm::View<Electron> >(iConfig.getParameter<edm::InputTag>("electronSource"))),
+      muonToken_(mayConsume<edm::View<Muon> >(iConfig.getParameter<edm::InputTag>("muonSource"))),
+      tauToken_(mayConsume<edm::View<Tau> >(iConfig.getParameter<edm::InputTag>("tauSource"))),
+      countElectrons_(iConfig.getParameter<bool>("countElectrons")),
+      countMuons_(iConfig.getParameter<bool>("countMuons")),
+      countTaus_(iConfig.getParameter<bool>("countTaus")),
+      minNumber_(iConfig.getParameter<unsigned int>("minNumber")),
+      maxNumber_(iConfig.getParameter<unsigned int>("maxNumber")) {}
 
-PATLeptonCountFilter::PATLeptonCountFilter(const edm::ParameterSet & iConfig) :
-  electronToken_(mayConsume<edm::View<Electron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ))),
-  muonToken_(mayConsume<edm::View<Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ))),
-  tauToken_(mayConsume<edm::View<Tau> >(iConfig.getParameter<edm::InputTag>( "tauSource" ))),
-  countElectrons_(iConfig.getParameter<bool>         ( "countElectrons" )),
-  countMuons_(iConfig.getParameter<bool>         ( "countMuons" )),
-  countTaus_(iConfig.getParameter<bool>         ( "countTaus" )),
-  minNumber_(iConfig.getParameter<unsigned int> ( "minNumber" )),
-  maxNumber_(iConfig.getParameter<unsigned int> ( "maxNumber" )) {
-  
-}
+PATLeptonCountFilter::~PATLeptonCountFilter() {}
 
-
-PATLeptonCountFilter::~PATLeptonCountFilter() {
-}
-
-
-bool PATLeptonCountFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
+bool PATLeptonCountFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<edm::View<Electron> > electrons;
-  if (countElectrons_) iEvent.getByToken(electronToken_, electrons);
+  if (countElectrons_)
+    iEvent.getByToken(electronToken_, electrons);
   edm::Handle<edm::View<Muon> > muons;
-  if (countMuons_) iEvent.getByToken(muonToken_, muons);
+  if (countMuons_)
+    iEvent.getByToken(muonToken_, muons);
   edm::Handle<edm::View<Tau> > taus;
-  if (countTaus_) iEvent.getByToken(tauToken_, taus);
+  if (countTaus_)
+    iEvent.getByToken(tauToken_, taus);
   unsigned int nrLeptons = 0;
   nrLeptons += (countElectrons_ ? electrons->size() : 0);
-  nrLeptons += (countMuons_     ? muons->size()     : 0);
-  nrLeptons += (countTaus_      ? taus->size()      : 0);
+  nrLeptons += (countMuons_ ? muons->size() : 0);
+  nrLeptons += (countTaus_ ? taus->size() : 0);
   return nrLeptons >= minNumber_ && nrLeptons <= maxNumber_;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(PATLeptonCountFilter);
-

--- a/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h
@@ -15,35 +15,27 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 
-
 namespace pat {
 
-
   class PATLeptonCountFilter : public edm::global::EDFilter<> {
+  public:
+    explicit PATLeptonCountFilter(const edm::ParameterSet& iConfig);
+    ~PATLeptonCountFilter() override;
 
-    public:
+  private:
+    bool filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
-      explicit PATLeptonCountFilter(const edm::ParameterSet & iConfig);
-      ~PATLeptonCountFilter() override;
-
-    private:
-
-      bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
-
-    private:
-
-      const edm::EDGetTokenT<edm::View<Electron> > electronToken_;
-      const edm::EDGetTokenT<edm::View<Muon> > muonToken_;
-      const edm::EDGetTokenT<edm::View<Tau> > tauToken_;
-      const bool          countElectrons_;
-      const bool          countMuons_;
-      const bool          countTaus_;
-      const unsigned int  minNumber_;
-      const unsigned int  maxNumber_;
-
+  private:
+    const edm::EDGetTokenT<edm::View<Electron> > electronToken_;
+    const edm::EDGetTokenT<edm::View<Muon> > muonToken_;
+    const edm::EDGetTokenT<edm::View<Tau> > tauToken_;
+    const bool countElectrons_;
+    const bool countMuons_;
+    const bool countTaus_;
+    const unsigned int minNumber_;
+    const unsigned int maxNumber_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -1,6 +1,5 @@
 #include <string>
 
-
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
@@ -26,48 +25,42 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 
 namespace {
-  bool passesQuality(const reco::Track& trk,const std::vector<reco::TrackBase::TrackQuality>& allowedQuals){
-    for(const auto& qual : allowedQuals){
-      if(trk.quality(qual)) return true;
+  bool passesQuality(const reco::Track& trk, const std::vector<reco::TrackBase::TrackQuality>& allowedQuals) {
+    for (const auto& qual : allowedQuals) {
+      if (trk.quality(qual))
+        return true;
     }
     return false;
   }
-}
+}  // namespace
 
 namespace pat {
   class PATLostTracks : public edm::global::EDProducer<> {
   public:
     explicit PATLostTracks(const edm::ParameterSet&);
     ~PATLostTracks() override;
-    
+
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-   
-  private:  
-    enum class TrkStatus {
-      NOTUSED=0,
-      PFCAND,
-      PFCANDNOTRKPROPS,
-      PFELECTRON,
-      PFPOSITRON,
-      VTX
-    };
-    bool passTrkCuts(const reco::Track& tr)const;
-    void addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
-			    const reco::TrackRef& trk,
-			    const reco::VertexRef& pvSlimmed,
-			    const reco::VertexRefProd& pvSlimmedColl,
-			    const reco::Vertex& pvOrig,
-			    const TrkStatus trkStatus)const;
-      
+
   private:
-    const edm::EDGetTokenT<reco::PFCandidateCollection>    cands_;
-    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
-    const edm::EDGetTokenT<reco::TrackCollection>          tracks_;
-    const edm::EDGetTokenT<reco::VertexCollection>         vertices_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         kshorts_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         lambdas_;
-    const edm::EDGetTokenT<reco::VertexCollection>         pv_;
-    const edm::EDGetTokenT<reco::VertexCollection>         pvOrigs_;
+    enum class TrkStatus { NOTUSED = 0, PFCAND, PFCANDNOTRKPROPS, PFELECTRON, PFPOSITRON, VTX };
+    bool passTrkCuts(const reco::Track& tr) const;
+    void addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
+                            const reco::TrackRef& trk,
+                            const reco::VertexRef& pvSlimmed,
+                            const reco::VertexRefProd& pvSlimmedColl,
+                            const reco::Vertex& pvOrig,
+                            const TrkStatus trkStatus) const;
+
+  private:
+    const edm::EDGetTokenT<reco::PFCandidateCollection> cands_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> map_;
+    const edm::EDGetTokenT<reco::TrackCollection> tracks_;
+    const edm::EDGetTokenT<reco::VertexCollection> vertices_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> kshorts_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> lambdas_;
+    const edm::EDGetTokenT<reco::VertexCollection> pv_;
+    const edm::EDGetTokenT<reco::VertexCollection> pvOrigs_;
     const double minPt_;
     const double minHits_;
     const double minPixelHits_;
@@ -76,183 +69,187 @@ namespace pat {
     const int covarianceSchema_;
     std::vector<reco::TrackBase::TrackQuality> qualsToAutoAccept_;
   };
-}
+}  // namespace pat
 
-pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
-  cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
-  map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
-  vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
-  kshorts_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("kshorts"))),
-  lambdas_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("lambdas"))),
-  pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
-  pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
-  minPt_(iConfig.getParameter<double>("minPt")),
-  minHits_(iConfig.getParameter<uint32_t>("minHits")),
-  minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")) ,
-  minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
-  covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
-  covarianceSchema_(iConfig.getParameter<int >("covarianceSchema"))
+pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig)
+    : cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
+      map_(consumes<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
+      vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
+      kshorts_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("kshorts"))),
+      lambdas_(consumes<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("lambdas"))),
+      pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+      pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
+      minPt_(iConfig.getParameter<double>("minPt")),
+      minHits_(iConfig.getParameter<uint32_t>("minHits")),
+      minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")),
+      minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps")),
+      covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
+      covarianceSchema_(iConfig.getParameter<int>("covarianceSchema"))
 
-{ 
-  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
-  std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
-  
-  if(std::find(qualsToAutoAccept_.begin(),qualsToAutoAccept_.end(),reco::TrackBase::undefQuality)!=qualsToAutoAccept_.end()){
+{
+  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string>>("qualsToAutoAccept"));
+  std::transform(
+      trkQuals.begin(), trkQuals.end(), std::back_inserter(qualsToAutoAccept_), reco::TrackBase::qualityByName);
+
+  if (std::find(qualsToAutoAccept_.begin(), qualsToAutoAccept_.end(), reco::TrackBase::undefQuality) !=
+      qualsToAutoAccept_.end()) {
     std::ostringstream msg;
-    msg<<" PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is therefore treated a config error\nquality requirements:\n   ";
-    for(const auto& trkQual : trkQuals) msg <<trkQual<<" ";
+    msg << " PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is "
+           "therefore treated a config error\nquality requirements:\n   ";
+    for (const auto& trkQual : trkQuals)
+      msg << trkQual << " ";
     throw cms::Exception("Configuration") << msg.str();
-  } 
-    
-  produces< std::vector<reco::Track> > ();
-  produces< std::vector<pat::PackedCandidate> > (); produces< std::vector<pat::PackedCandidate> > ("eleTracks");
-  produces< edm::Association<pat::PackedCandidateCollection> > ();
+  }
+
+  produces<std::vector<reco::Track>>();
+  produces<std::vector<pat::PackedCandidate>>();
+  produces<std::vector<pat::PackedCandidate>>("eleTracks");
+  produces<edm::Association<pat::PackedCandidateCollection>>();
 }
 
 pat::PATLostTracks::~PATLostTracks() {}
 
 void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<reco::PFCandidateCollection> cands;
+  iEvent.getByToken(cands_, cands);
 
-    edm::Handle<reco::PFCandidateCollection> cands;
-    iEvent.getByToken( cands_, cands );
+  edm::Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  iEvent.getByToken(map_, pf2pc);
 
-    edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
-    iEvent.getByToken(map_,pf2pc);
+  edm::Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken(tracks_, tracks);
 
-    edm::Handle<reco::TrackCollection> tracks;
-    iEvent.getByToken( tracks_, tracks );
-    
-    edm::Handle<reco::VertexCollection> vertices;
-    iEvent.getByToken( vertices_, vertices );
+  edm::Handle<reco::VertexCollection> vertices;
+  iEvent.getByToken(vertices_, vertices);
 
-    edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
-    iEvent.getByToken( kshorts_, kshorts );
-    edm::Handle<reco::VertexCompositeCandidateCollection> lambdas;
-    iEvent.getByToken( lambdas_, lambdas );
+  edm::Handle<reco::VertexCompositeCandidateCollection> kshorts;
+  iEvent.getByToken(kshorts_, kshorts);
+  edm::Handle<reco::VertexCompositeCandidateCollection> lambdas;
+  iEvent.getByToken(lambdas_, lambdas);
 
-    edm::Handle<reco::VertexCollection> pvs;
-    iEvent.getByToken( pv_, pvs );
-    reco::VertexRef pv(pvs.id());
-    reco::VertexRefProd pvRefProd(pvs);
-    if (!pvs->empty()) {
-        pv = reco::VertexRef(pvs, 0);
+  edm::Handle<reco::VertexCollection> pvs;
+  iEvent.getByToken(pv_, pvs);
+  reco::VertexRef pv(pvs.id());
+  reco::VertexRefProd pvRefProd(pvs);
+  if (!pvs->empty()) {
+    pv = reco::VertexRef(pvs, 0);
+  }
+  edm::Handle<reco::VertexCollection> pvOrigs;
+  iEvent.getByToken(pvOrigs_, pvOrigs);
+  const reco::Vertex& pvOrig = (*pvOrigs)[0];
+
+  auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
+  auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+  auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+
+  std::vector<TrkStatus> trkStatus(tracks->size(), TrkStatus::NOTUSED);
+  //Mark all tracks used in candidates
+  //check if packed candidates are storing the tracks by seeing if number of hits >0
+  //currently we dont use that information though
+  //electrons will never store their track (they store the GSF track)
+  for (unsigned int ic = 0, nc = cands->size(); ic < nc; ++ic) {
+    edm::Ref<reco::PFCandidateCollection> r(cands, ic);
+    const reco::PFCandidate& cand = (*cands)[ic];
+    if (cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id()) {
+      if (cand.pdgId() == 11)
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFELECTRON;
+      else if (cand.pdgId() == -11)
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFPOSITRON;
+      else if ((*pf2pc)[r]->numberOfHits() > 0)
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFCAND;
+      else
+        trkStatus[cand.trackRef().key()] = TrkStatus::PFCANDNOTRKPROPS;
     }
-    edm::Handle<reco::VertexCollection> pvOrigs;
-    iEvent.getByToken( pvOrigs_, pvOrigs );
-    const reco::Vertex & pvOrig = (*pvOrigs)[0];
+  }
 
-    auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
-    auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
-    auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
-  
-    std::vector<TrkStatus> trkStatus(tracks->size(),TrkStatus::NOTUSED);
-    //Mark all tracks used in candidates	
-    //check if packed candidates are storing the tracks by seeing if number of hits >0 	  
-    //currently we dont use that information though
-    //electrons will never store their track (they store the GSF track)
-    for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
-        edm::Ref<reco::PFCandidateCollection> r(cands,ic);
-        const reco::PFCandidate &cand=(*cands)[ic]; 
-	if(cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id() ) { 
-	  
-	  if(cand.pdgId()==11) trkStatus[cand.trackRef().key()]=TrkStatus::PFELECTRON;	  
-	  else if(cand.pdgId()==-11) trkStatus[cand.trackRef().key()]=TrkStatus::PFPOSITRON;
-	  else if((*pf2pc)[r]->numberOfHits() > 0) trkStatus[cand.trackRef().key()]=TrkStatus::PFCAND; 
-	  else trkStatus[cand.trackRef().key()]=TrkStatus::PFCANDNOTRKPROPS; 
-	}
+  //Mark all tracks used in secondary vertices
+  for (const auto& secVert : *vertices) {
+    for (auto trkIt = secVert.tracks_begin(); trkIt != secVert.tracks_end(); trkIt++) {
+      if (trkStatus[trkIt->key()] == TrkStatus::NOTUSED)
+        trkStatus[trkIt->key()] = TrkStatus::VTX;
     }
-        
-    //Mark all tracks used in secondary vertices
-    for(const auto& secVert : *vertices){
-        for(auto trkIt = secVert.tracks_begin();trkIt!=secVert.tracks_end();trkIt++){
-	    if(trkStatus[trkIt->key()]==TrkStatus::NOTUSED)  trkStatus[trkIt->key()]=TrkStatus::VTX;
-	}
+  }
+  for (const auto& v0 : *kshorts) {
+    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
+      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+      if (trkStatus[key] == TrkStatus::NOTUSED)
+        trkStatus[key] = TrkStatus::VTX;
     }
-    for(const auto& v0 : *kshorts){
-        for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
-	    size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-	    if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
-	}
+  }
+  for (const auto& v0 : *lambdas) {
+    for (size_t dIdx = 0; dIdx < v0.numberOfDaughters(); dIdx++) {
+      size_t key = (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
+      if (trkStatus[key] == TrkStatus::NOTUSED)
+        trkStatus[key] = TrkStatus::VTX;
     }
-    for(const auto& v0 : *lambdas){
-        for(size_t dIdx=0;dIdx<v0.numberOfDaughters(); dIdx++){
-	    size_t key= (dynamic_cast<const reco::RecoChargedCandidate*>(v0.daughter(dIdx)))->track().key();
-	    if(trkStatus[key]==TrkStatus::NOTUSED)  trkStatus[key]=TrkStatus::VTX;
-	}
-    }
-    std::vector<int> mapping(tracks->size(),-1);  
-    int lostTrkIndx=0;
-    for(unsigned int trkIndx=0; trkIndx < tracks->size(); trkIndx++){
-        reco::TrackRef trk(tracks,trkIndx);
-	if( trkStatus[trkIndx] == TrkStatus::VTX || 
-	   (trkStatus[trkIndx]==TrkStatus::NOTUSED && passTrkCuts(*trk)) ) { 
-	
-	    outPtrTrks->emplace_back(*trk);
-	    addPackedCandidate(*outPtrTrksAsCands,trk,pv,pvRefProd,pvOrig,trkStatus[trkIndx]);
-	
-	    //for creating the reco::Track -> pat::PackedCandidate map
-	    //not done for the lostTrack:eleTracks collection
-	    mapping[trkIndx]=lostTrkIndx;
-	    lostTrkIndx++;
-	}else if( (trkStatus[trkIndx]==TrkStatus::PFELECTRON || trkStatus[trkIndx]==TrkStatus::PFPOSITRON ) 
-		  && passTrkCuts(*trk) ) {
-   	    addPackedCandidate(*outPtrEleTrksAsCands,trk,pv,pvRefProd,pvOrig,trkStatus[trkIndx]);
+  }
+  std::vector<int> mapping(tracks->size(), -1);
+  int lostTrkIndx = 0;
+  for (unsigned int trkIndx = 0; trkIndx < tracks->size(); trkIndx++) {
+    reco::TrackRef trk(tracks, trkIndx);
+    if (trkStatus[trkIndx] == TrkStatus::VTX || (trkStatus[trkIndx] == TrkStatus::NOTUSED && passTrkCuts(*trk))) {
+      outPtrTrks->emplace_back(*trk);
+      addPackedCandidate(*outPtrTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx]);
 
-	
-      }	      
-    } 
-    
-    iEvent.put(std::move(outPtrTrks));
-    iEvent.put(std::move(outPtrEleTrksAsCands),"eleTracks");
-    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
-    auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
-    edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
-    tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
-    tk2pcFiller.fill() ; 
-    iEvent.put(std::move(tk2pc));   
+      //for creating the reco::Track -> pat::PackedCandidate map
+      //not done for the lostTrack:eleTracks collection
+      mapping[trkIndx] = lostTrkIndx;
+      lostTrkIndx++;
+    } else if ((trkStatus[trkIndx] == TrkStatus::PFELECTRON || trkStatus[trkIndx] == TrkStatus::PFPOSITRON) &&
+               passTrkCuts(*trk)) {
+      addPackedCandidate(*outPtrEleTrksAsCands, trk, pv, pvRefProd, pvOrig, trkStatus[trkIndx]);
+    }
+  }
+
+  iEvent.put(std::move(outPtrTrks));
+  iEvent.put(std::move(outPtrEleTrksAsCands), "eleTracks");
+  edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
+  auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
+  edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
+  tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
+  tk2pcFiller.fill();
+  iEvent.put(std::move(tk2pc));
 }
 
-bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr)const
-{
-    const bool passTrkHits = tr.pt() > minPt_ && 
-                             tr.numberOfValidHits() >= minHits_ && 
-                             tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
-    const bool passTrkQual = passesQuality(tr,qualsToAutoAccept_);
+bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr) const {
+  const bool passTrkHits = tr.pt() > minPt_ && tr.numberOfValidHits() >= minHits_ &&
+                           tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
+  const bool passTrkQual = passesQuality(tr, qualsToAutoAccept_);
 
-    return passTrkHits || passTrkQual;
+  return passTrkHits || passTrkQual;
 }
 
 void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
-					    const reco::TrackRef& trk,
-					    const reco::VertexRef& pvSlimmed,
-					    const reco::VertexRefProd& pvSlimmedColl,
-					    const reco::Vertex& pvOrig,
-					    const pat::PATLostTracks::TrkStatus trkStatus)const
-{
-    const float mass = 0.13957018;
-    
-    int id=211*trk->charge();
-    if(trkStatus==TrkStatus::PFELECTRON) id=11;
-    else if(trkStatus==TrkStatus::PFPOSITRON) id=-11; 
-    
-    reco::Candidate::PolarLorentzVector p4(trk->pt(),trk->eta(),trk->phi(),mass);
-    cands.emplace_back(pat::PackedCandidate(p4,trk->vertex(),
-					    trk->pt(),trk->eta(),trk->phi(),
-					    id,pvSlimmedColl,pvSlimmed.key()));
- 
-   if (trk->quality(reco::TrackBase::highPurity))
-       cands.back().setTrackHighPurity(true);
-    else
-       cands.back().setTrackHighPurity(false);
-              
-    if(trk->pt()>minPtToStoreProps_ || trkStatus==TrkStatus::VTX) cands.back().setTrackProperties(*trk,covarianceSchema_,covarianceVersion_);
-    if(pvOrig.trackWeight(trk) > 0.5) {
-         cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
-    }
+                                            const reco::TrackRef& trk,
+                                            const reco::VertexRef& pvSlimmed,
+                                            const reco::VertexRefProd& pvSlimmedColl,
+                                            const reco::Vertex& pvOrig,
+                                            const pat::PATLostTracks::TrkStatus trkStatus) const {
+  const float mass = 0.13957018;
+
+  int id = 211 * trk->charge();
+  if (trkStatus == TrkStatus::PFELECTRON)
+    id = 11;
+  else if (trkStatus == TrkStatus::PFPOSITRON)
+    id = -11;
+
+  reco::Candidate::PolarLorentzVector p4(trk->pt(), trk->eta(), trk->phi(), mass);
+  cands.emplace_back(
+      pat::PackedCandidate(p4, trk->vertex(), trk->pt(), trk->eta(), trk->phi(), id, pvSlimmedColl, pvSlimmed.key()));
+
+  if (trk->quality(reco::TrackBase::highPurity))
+    cands.back().setTrackHighPurity(true);
+  else
+    cands.back().setTrackHighPurity(false);
+
+  if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX)
+    cands.back().setTrackProperties(*trk, covarianceSchema_, covarianceVersion_);
+  if (pvOrig.trackWeight(trk) > 0.5) {
+    cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
+  }
 }
-
-
 
 using pat::PATLostTracks;
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -11,72 +11,68 @@
 
 #include <memory>
 
-
 using namespace pat;
 
-
-PATMETProducer::PATMETProducer(const edm::ParameterSet & iConfig):
-  useUserData_(iConfig.exists("userData"))
-{
+PATMETProducer::PATMETProducer(const edm::ParameterSet& iConfig) : useUserData_(iConfig.exists("userData")) {
   // initialize the configurables
-  metSrc_         = iConfig.getParameter<edm::InputTag>("metSource");
-  metToken_       = consumes<edm::View<reco::MET> >(metSrc_);
-  addGenMET_      = iConfig.getParameter<bool>         ("addGenMET");
-  genMETToken_    = mayConsume<edm::View<reco::GenMET> >(iConfig.getParameter<edm::InputTag>("genMETSource"));
-  addResolutions_ = iConfig.getParameter<bool>         ("addResolutions");
+  metSrc_ = iConfig.getParameter<edm::InputTag>("metSource");
+  metToken_ = consumes<edm::View<reco::MET> >(metSrc_);
+  addGenMET_ = iConfig.getParameter<bool>("addGenMET");
+  genMETToken_ = mayConsume<edm::View<reco::GenMET> >(iConfig.getParameter<edm::InputTag>("genMETSource"));
+  addResolutions_ = iConfig.getParameter<bool>("addResolutions");
 
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
 
   // Check to see if the user wants to add user data
-  if ( useUserData_ ) {
+  if (useUserData_) {
     userDataHelper_ = PATUserDataHelper<MET>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
 
   // MET Significance
   calculateMETSignificance_ = iConfig.getParameter<bool>("computeMETSignificance");
-  if(calculateMETSignificance_)
-    {
-      metSigAlgo_ = new metsig::METSignificance(iConfig);
-      rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
-      jetSFType_ = iConfig.getParameter<std::string>("srcJetSF");
-      jetResPtType_ = iConfig.getParameter<std::string>("srcJetResPt");
-      jetResPhiType_ = iConfig.getParameter<std::string>("srcJetResPhi");
-      jetToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcJets"));
-      pfCandToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("srcPFCands"));
-      std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter< std::vector<edm::InputTag> >("srcLeptons");
-      for(std::vector<edm::InputTag>::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
-	lepTokens_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
-      }
-    }  
+  if (calculateMETSignificance_) {
+    metSigAlgo_ = new metsig::METSignificance(iConfig);
+    rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
+    jetSFType_ = iConfig.getParameter<std::string>("srcJetSF");
+    jetResPtType_ = iConfig.getParameter<std::string>("srcJetResPt");
+    jetResPhiType_ = iConfig.getParameter<std::string>("srcJetResPhi");
+    jetToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcJets"));
+    pfCandToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("srcPFCands"));
+    std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter<std::vector<edm::InputTag> >("srcLeptons");
+    for (std::vector<edm::InputTag>::const_iterator it = srcLeptonsTags.begin(); it != srcLeptonsTags.end(); it++) {
+      lepTokens_.push_back(consumes<edm::View<reco::Candidate> >(*it));
+    }
+  }
 
   // produces vector of mets
   produces<std::vector<MET> >();
 }
 
+PATMETProducer::~PATMETProducer() {}
 
-PATMETProducer::~PATMETProducer() {
-}
-
-
-void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-
+void PATMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Get the vector of MET's from the event
   edm::Handle<edm::View<reco::MET> > mets;
   iEvent.getByToken(metToken_, mets);
 
-  if (mets->size() != 1) throw cms::Exception("Corrupt Data") << "The input MET collection " << metSrc_.encode() << " has size " << mets->size() << " instead of 1 as it should.\n";
-  if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (mets->size() != 1)
+    throw cms::Exception("Corrupt Data") << "The input MET collection " << metSrc_.encode() << " has size "
+                                         << mets->size() << " instead of 1 as it should.\n";
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
   // Get the vector of generated met from the event if needed
   edm::Handle<edm::View<reco::GenMET> > genMETs;
@@ -85,7 +81,7 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   }
 
   // loop over mets
-  std::vector<MET> * patMETs = new std::vector<MET>();
+  std::vector<MET>* patMETs = new std::vector<MET>();
   for (edm::View<reco::MET>::const_iterator itMET = mets->begin(); itMET != mets->end(); itMET++) {
     // construct the MET from the ref -> save ref to original object
     unsigned int idx = itMET - mets->begin();
@@ -93,28 +89,27 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     edm::Ptr<reco::MET> metsPtr = mets->ptrAt(idx);
     MET amet(metsRef);
     // add the generated MET
-    if (addGenMET_) amet.setGenMET((*genMETs)[idx]);
-
+    if (addGenMET_)
+      amet.setGenMET((*genMETs)[idx]);
 
     //add the MET significance
-    if(calculateMETSignificance_) {
+    if (calculateMETSignificance_) {
       const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup);
       amet.setSignificanceMatrix(sigcov);
-      double metSig=metSigAlgo_->getSignificance(sigcov, amet);
+      double metSig = metSigAlgo_->getSignificance(sigcov, amet);
       amet.setMETSignificance(metSig);
     }
 
     if (efficiencyLoader_.enabled()) {
-        efficiencyLoader_.setEfficiencies( amet, metsRef );
+      efficiencyLoader_.setEfficiencies(amet, metsRef);
     }
 
     if (resolutionLoader_.enabled()) {
-        resolutionLoader_.setResolutions(amet);
+      resolutionLoader_.setResolutions(amet);
     }
 
-
-    if ( useUserData_ ) {
-      userDataHelper_.add( amet, iEvent, iSetup );
+    if (useUserData_) {
+      userDataHelper_.add(amet, iEvent, iSetup);
     }
 
     // correct for muons if demanded... never more: it's now done by JetMETCorrections
@@ -128,12 +123,10 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   // put genEvt object in Event
   std::unique_ptr<std::vector<MET> > myMETs(patMETs);
   iEvent.put(std::move(myMETs));
-
 }
 
 // ParameterSet description for module
-void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT MET producer module");
 
@@ -148,7 +141,7 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
 
   // Efficiency configurables
   edm::ParameterSetDescription efficienciesPSet;
-  efficienciesPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  efficienciesPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("efficiencies", efficienciesPSet);
   iDesc.add<bool>("addEfficiencies", false);
 
@@ -160,25 +153,24 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   // muon correction
   iDesc.add<bool>("addMuonCorrections", false);
   iDesc.add<edm::InputTag>("muonSource", edm::InputTag("muons"));
-
 }
 
-const reco::METCovMatrix 
-PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
-  std::vector< edm::Handle<reco::CandidateView> > leptons;
-  for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
-	srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
+const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
+  std::vector<edm::Handle<reco::CandidateView> > leptons;
+  for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
+       srcLeptons_i != lepTokens_.end();
+       ++srcLeptons_i) {
     edm::Handle<reco::CandidateView> leptons_i;
     event.getByToken(*srcLeptons_i, leptons_i);
-    leptons.push_back( leptons_i );
+    leptons.push_back(leptons_i);
   }
   // jets
   edm::Handle<edm::View<reco::Jet> > inputJets;
-  event.getByToken( jetToken_, inputJets );
+  event.getByToken(jetToken_, inputJets);
 
   //candidates
   edm::Handle<edm::View<reco::Candidate> > inputCands;
-  event.getByToken( pfCandToken_, inputCands );
+  event.getByToken(pfCandToken_, inputCands);
 
   edm::Handle<double> rho;
   event.getByToken(rhoToken_, rho);
@@ -188,12 +180,11 @@ PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& 
   JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(iSetup, jetSFType_);
 
   //Compute the covariance matrix and fill it
-  reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, inputCands,
-						       *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
+  reco::METCovMatrix cov = metSigAlgo_->getCovariance(
+      *inputJets, leptons, inputCands, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
 
   return cov;
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -15,7 +15,6 @@
   \version  $Id: PATMETProducer.h,v 1.10 2009/06/25 23:49:35 gpetrucc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +25,6 @@
 #include "PhysicsTools/PatAlgos/interface/EfficiencyLoader.h"
 #include "PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h"
 
-
 #include "DataFormats/PatCandidates/interface/UserData.h"
 #include "PhysicsTools/PatAlgos/interface/PATUserDataHelper.h"
 
@@ -36,53 +34,47 @@
 namespace pat {
 
   class PATMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATMETProducer(const edm::ParameterSet& iConfig);
+    ~PATMETProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATMETProducer(const edm::ParameterSet & iConfig);
-      ~PATMETProducer() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+  private:
+    // configurables
+    edm::InputTag metSrc_;
+    edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
+    bool addGenMET_;
+    edm::EDGetTokenT<edm::View<reco::GenMET> > genMETToken_;
+    bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
+    bool addMuonCorr_;
+    edm::InputTag muonSrc_;
+    // tools
+    GreaterByEt<MET> eTComparator_;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-    private:
-
-      // configurables
-      edm::InputTag metSrc_;
-      edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
-      bool          addGenMET_;
-      edm::EDGetTokenT<edm::View<reco::GenMET> > genMETToken_;
-      bool          addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
-      bool          addMuonCorr_;
-      edm::InputTag muonSrc_;
-      // tools
-      GreaterByEt<MET> eTComparator_;
-
-      bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
-
-      bool useUserData_;
-      pat::PATUserDataHelper<pat::MET>      userDataHelper_;
+    bool useUserData_;
+    pat::PATUserDataHelper<pat::MET> userDataHelper_;
 
     //MET Significance
     bool calculateMETSignificance_;
     metsig::METSignificance* metSigAlgo_;
     edm::EDGetTokenT<edm::View<reco::Jet> > jetToken_;
     edm::EDGetTokenT<edm::View<reco::Candidate> > pfCandToken_;
-    std::vector< edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
     edm::EDGetTokenT<double> rhoToken_;
     std::string jetResPtType_;
     std::string jetResPhiType_;
     std::string jetSFType_;
 
-    const reco::METCovMatrix getMETCovMatrix(const edm::Event& event, 
-					     const edm::EventSetup& iSetup) const;
-
+    const reco::METCovMatrix getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -3,7 +3,6 @@
   \brief    Slimmer of PAT METs 
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -15,21 +14,34 @@
 #include "DataFormats/PatCandidates/interface/MET.h"
 
 namespace pat {
-  
+
   class PATMETSlimmer : public edm::global::EDProducer<> {
   public:
-    explicit PATMETSlimmer(const edm::ParameterSet & iConfig);
-    ~PATMETSlimmer() override { }
-    
-    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
-    
+    explicit PATMETSlimmer(const edm::ParameterSet &iConfig);
+    ~PATMETSlimmer() override {}
+
+    void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
+
   private:
     class OneMETShift {
     public:
-      OneMETShift() : shift(pat::MET::NoShift), level(pat::MET::None), t0FromMiniAOD(false), corShift(false), uncShift(false), isSmeared(false) {}
-      OneMETShift(pat::MET::METUncertainty shift_, pat::MET::METCorrectionType level_, const edm::InputTag & baseTag, edm::ConsumesCollector && cc,
-                  bool t0FromMiniAOD_, bool corShift_, bool uncShift_, bool isSmeared_=false) ;
+      OneMETShift()
+          : shift(pat::MET::NoShift),
+            level(pat::MET::None),
+            t0FromMiniAOD(false),
+            corShift(false),
+            uncShift(false),
+            isSmeared(false) {}
+      OneMETShift(pat::MET::METUncertainty shift_,
+                  pat::MET::METCorrectionType level_,
+                  const edm::InputTag &baseTag,
+                  edm::ConsumesCollector &&cc,
+                  bool t0FromMiniAOD_,
+                  bool corShift_,
+                  bool uncShift_,
+                  bool isSmeared_ = false);
       void readAndSet(const edm::Event &ev, pat::MET &met) const;
+
     private:
       const pat::MET::METUncertainty shift;
       const pat::MET::METCorrectionType level;
@@ -38,146 +50,209 @@ namespace pat {
       const bool corShift;
       const bool uncShift;
       const bool isSmeared;
-      
     };
-    void maybeReadShifts(const edm::ParameterSet &basePSet, const std::string &name, pat::MET::METCorrectionType level, bool readFromMiniAOD=false) ;
-    
+    void maybeReadShifts(const edm::ParameterSet &basePSet,
+                         const std::string &name,
+                         pat::MET::METCorrectionType level,
+                         bool readFromMiniAOD = false);
+
     const edm::EDGetTokenT<pat::METCollection> src_;
     std::vector<OneMETShift> shifts_;
-    
+
     const bool onMiniAOD_;
   };
-  
-} // namespace
 
-pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet & iConfig) :
-  src_(consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  onMiniAOD_(iConfig.existsAs<bool>("runningOnMiniAOD") ?  iConfig.getParameter<bool>("runningOnMiniAOD") : false)
-{
-  maybeReadShifts( iConfig, "rawVariation", pat::MET::None );
-  maybeReadShifts( iConfig, "t1Uncertainties", pat::MET::T1 );
-  maybeReadShifts( iConfig, "t01Variation", pat::MET::T0, onMiniAOD_ );
-  maybeReadShifts( iConfig, "t1SmearedVarsAndUncs", pat::MET::Smear );
-  
-  maybeReadShifts( iConfig, "tXYUncForRaw", pat::MET::TXYForRaw );
-  maybeReadShifts( iConfig, "tXYUncForT1", pat::MET::TXY );
-  maybeReadShifts( iConfig, "tXYUncForT01", pat::MET::TXYForT01 ); 
-  maybeReadShifts( iConfig, "tXYUncForT1Smear", pat::MET::TXYForT1Smear );
-  maybeReadShifts( iConfig, "tXYUncForT01Smear", pat::MET::TXYForT01Smear );
-  maybeReadShifts( iConfig, "caloMET", pat::MET::Calo );
-  maybeReadShifts( iConfig, "chsMET", pat::MET::Chs );
-  maybeReadShifts( iConfig, "trkMET", pat::MET::Trk );
+}  // namespace pat
 
-  produces<std::vector<pat::MET> >();
+pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet &iConfig)
+    : src_(consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      onMiniAOD_(iConfig.existsAs<bool>("runningOnMiniAOD") ? iConfig.getParameter<bool>("runningOnMiniAOD") : false) {
+  maybeReadShifts(iConfig, "rawVariation", pat::MET::None);
+  maybeReadShifts(iConfig, "t1Uncertainties", pat::MET::T1);
+  maybeReadShifts(iConfig, "t01Variation", pat::MET::T0, onMiniAOD_);
+  maybeReadShifts(iConfig, "t1SmearedVarsAndUncs", pat::MET::Smear);
+
+  maybeReadShifts(iConfig, "tXYUncForRaw", pat::MET::TXYForRaw);
+  maybeReadShifts(iConfig, "tXYUncForT1", pat::MET::TXY);
+  maybeReadShifts(iConfig, "tXYUncForT01", pat::MET::TXYForT01);
+  maybeReadShifts(iConfig, "tXYUncForT1Smear", pat::MET::TXYForT1Smear);
+  maybeReadShifts(iConfig, "tXYUncForT01Smear", pat::MET::TXYForT01Smear);
+  maybeReadShifts(iConfig, "caloMET", pat::MET::Calo);
+  maybeReadShifts(iConfig, "chsMET", pat::MET::Chs);
+  maybeReadShifts(iConfig, "trkMET", pat::MET::Trk);
+
+  produces<std::vector<pat::MET>>();
 }
 
-void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet, const std::string &name, pat::MET::METCorrectionType level, bool readFromMiniAOD) {
- 
-    if (basePSet.existsAs<edm::ParameterSet>(name)) {
-        throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
-    } else if (basePSet.existsAs<edm::InputTag>(name) ) {
-        const edm::InputTag & baseTag = basePSet.getParameter<edm::InputTag>(name);
+void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet,
+                                         const std::string &name,
+                                         pat::MET::METCorrectionType level,
+                                         bool readFromMiniAOD) {
+  if (basePSet.existsAs<edm::ParameterSet>(name)) {
+    throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
+  } else if (basePSet.existsAs<edm::InputTag>(name)) {
+    const edm::InputTag &baseTag = basePSet.getParameter<edm::InputTag>(name);
 
-	if(level==pat::MET::T1) {
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, false));
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::MuonEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::MuonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::ElectronEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::ElectronEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::PhotonEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::PhotonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::TauEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::TauEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
-	}
-	else if(level==pat::MET::Smear) {
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
-	  shifts_.push_back(OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
-	}
-	else {
-	  shifts_.push_back(OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false));
-	}
+    if (level == pat::MET::T1) {
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, false));
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::MuonEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::MuonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::ElectronEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::ElectronEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::PhotonEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::PhotonEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::TauEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::TauEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::UnclusteredEnUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::UnclusteredEnDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true));
+    } else if (level == pat::MET::Smear) {
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResUp, level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
+      shifts_.push_back(
+          OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector(), readFromMiniAOD, false, true, true));
+    } else {
+      shifts_.push_back(
+          OneMETShift(pat::MET::NoShift, level, baseTag, consumesCollector(), readFromMiniAOD, true, false));
     }
-
+  }
 }
 
-pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_, pat::MET::METCorrectionType level_, const edm::InputTag & baseTag,
-					     edm::ConsumesCollector && cc, bool t0FromMiniAOD_, bool corShift_, bool uncShift_, bool isSmeared) :
-  shift(shift_), level(level_), t0FromMiniAOD(t0FromMiniAOD_), corShift(corShift_), uncShift(uncShift_), isSmeared(isSmeared)
-{
-
-    std::string baseTagStr = baseTag.encode();
-    char buff[1024];
-    switch (shift) {
-        case pat::MET::NoShift  : snprintf(buff, 1023, baseTagStr.c_str(), "");   break;
-        case pat::MET::JetEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");   break;
-        case pat::MET::JetEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown"); break;
-        case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");   break;
-        case pat::MET::JetResDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetResDown"); break;
-        case pat::MET::MuonEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnUp");   break;
-        case pat::MET::MuonEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnDown"); break;
-        case pat::MET::ElectronEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnUp");   break;
-        case pat::MET::ElectronEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnDown"); break;
-        case pat::MET::PhotonEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnUp");   break;
-        case pat::MET::PhotonEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnDown"); break;
-        case pat::MET::TauEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "TauEnUp");   break;
-        case pat::MET::TauEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "TauEnDown"); break;
-        case pat::MET::UnclusteredEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnUp");   break;
-        case pat::MET::UnclusteredEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnDown"); break;
-        default: throw cms::Exception("LogicError", "OneMETShift constructor called with bogus shift");
-    }
-    token = cc.consumes<pat::METCollection>(edm::InputTag(buff));
-
+pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_,
+                                             pat::MET::METCorrectionType level_,
+                                             const edm::InputTag &baseTag,
+                                             edm::ConsumesCollector &&cc,
+                                             bool t0FromMiniAOD_,
+                                             bool corShift_,
+                                             bool uncShift_,
+                                             bool isSmeared)
+    : shift(shift_),
+      level(level_),
+      t0FromMiniAOD(t0FromMiniAOD_),
+      corShift(corShift_),
+      uncShift(uncShift_),
+      isSmeared(isSmeared) {
+  std::string baseTagStr = baseTag.encode();
+  char buff[1024];
+  switch (shift) {
+    case pat::MET::NoShift:
+      snprintf(buff, 1023, baseTagStr.c_str(), "");
+      break;
+    case pat::MET::JetEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");
+      break;
+    case pat::MET::JetEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown");
+      break;
+    case pat::MET::JetResUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");
+      break;
+    case pat::MET::JetResDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "JetResDown");
+      break;
+    case pat::MET::MuonEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnUp");
+      break;
+    case pat::MET::MuonEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnDown");
+      break;
+    case pat::MET::ElectronEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnUp");
+      break;
+    case pat::MET::ElectronEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnDown");
+      break;
+    case pat::MET::PhotonEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnUp");
+      break;
+    case pat::MET::PhotonEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "PhotonEnDown");
+      break;
+    case pat::MET::TauEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "TauEnUp");
+      break;
+    case pat::MET::TauEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "TauEnDown");
+      break;
+    case pat::MET::UnclusteredEnUp:
+      snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnUp");
+      break;
+    case pat::MET::UnclusteredEnDown:
+      snprintf(buff, 1023, baseTagStr.c_str(), "UnclusteredEnDown");
+      break;
+    default:
+      throw cms::Exception("LogicError", "OneMETShift constructor called with bogus shift");
+  }
+  token = cc.consumes<pat::METCollection>(edm::InputTag(buff));
 }
 
-void 
-pat::PATMETSlimmer::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
-    using namespace edm;
-    using namespace std;
+void pat::PATMETSlimmer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+  using namespace std;
 
-    Handle<pat::METCollection>  src;
-    iEvent.getByToken(src_, src);
-    if (src->size() != 1) throw cms::Exception("CorruptData", "More than one MET in the collection");
+  Handle<pat::METCollection> src;
+  iEvent.getByToken(src_, src);
+  if (src->size() != 1)
+    throw cms::Exception("CorruptData", "More than one MET in the collection");
 
-    auto out = std::make_unique<std::vector<pat::MET>>(1, src->front());
-    pat::MET & met = out->back();
+  auto out = std::make_unique<std::vector<pat::MET>>(1, src->front());
+  pat::MET &met = out->back();
 
-    for (const OneMETShift &shift : shifts_) {
-        shift.readAndSet(iEvent, met);
-    }
+  for (const OneMETShift &shift : shifts_) {
+    shift.readAndSet(iEvent, met);
+  }
 
-    iEvent.put(std::move(out));
-
+  iEvent.put(std::move(out));
 }
 
 void
 
 pat::PATMETSlimmer::OneMETShift::readAndSet(const edm::Event &ev, pat::MET &met) const {
-    edm::Handle<pat::METCollection>  src;
-    ev.getByToken(token, src);
+  edm::Handle<pat::METCollection> src;
+  ev.getByToken(token, src);
 
-    if (src->size() != 1) throw cms::Exception("CorruptData", "More than one MET in the shifted collection");
-    const pat::MET &met2 = src->front();
+  if (src->size() != 1)
+    throw cms::Exception("CorruptData", "More than one MET in the shifted collection");
+  const pat::MET &met2 = src->front();
 
-
-    if(t0FromMiniAOD) {
-      if(uncShift) met.setUncShift(met2.shiftedPx( shift, pat::MET::Type01), met2.shiftedPy(shift, pat::MET::Type01), 
-				   met2.shiftedSumEt(shift, pat::MET::Type01), shift, isSmeared);
-      if(corShift) met.setCorShift(met2.corPx(pat::MET::Type01), met2.corPy(pat::MET::Type01), 
-				   met2.corSumEt(pat::MET::Type01), level);
-    }
-    else {
-      if(uncShift) met.setUncShift(met2.px(), met2.py(), met2.sumEt(), shift, isSmeared);
-      if(corShift) met.setCorShift(met2.px(), met2.py(), met2.sumEt(), level);
-    }
-
+  if (t0FromMiniAOD) {
+    if (uncShift)
+      met.setUncShift(met2.shiftedPx(shift, pat::MET::Type01),
+                      met2.shiftedPy(shift, pat::MET::Type01),
+                      met2.shiftedSumEt(shift, pat::MET::Type01),
+                      shift,
+                      isSmeared);
+    if (corShift)
+      met.setCorShift(
+          met2.corPx(pat::MET::Type01), met2.corPy(pat::MET::Type01), met2.corSumEt(pat::MET::Type01), level);
+  } else {
+    if (uncShift)
+      met.setUncShift(met2.px(), met2.py(), met2.sumEt(), shift, isSmeared);
+    if (corShift)
+      met.setCorShift(met2.px(), met2.py(), met2.sumEt(), level);
+  }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
@@ -3,8 +3,7 @@
 
 #include "PhysicsTools/PatAlgos/plugins/PATMHTProducer.h"
 
-pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet & iConfig){
-
+pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet& iConfig) {
   // Initialize the configurables
   verbose_ = iConfig.getParameter<double>("verbose");
 
@@ -14,53 +13,48 @@ pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet & iConfig){
   tauToken_ = consumes<edm::View<pat::Tau> >(iConfig.getUntrackedParameter<edm::InputTag>("tauTag"));
   phoToken_ = consumes<edm::View<pat::Photon> >(iConfig.getUntrackedParameter<edm::InputTag>("photonTag"));
 
-  uncertaintyScaleFactor_ = iConfig.getParameter<double>( "uncertaintyScaleFactor") ;
-  controlledUncertainty_  = iConfig.getParameter<bool>( "controlledUncertainty") ;
+  uncertaintyScaleFactor_ = iConfig.getParameter<double>("uncertaintyScaleFactor");
+  controlledUncertainty_ = iConfig.getParameter<bool>("controlledUncertainty");
 
-  jetPtMin_     = iConfig.getParameter<double>("jetPtMin");
-  jetEtaMax_    = iConfig.getParameter<double>("jetEtaMax");
+  jetPtMin_ = iConfig.getParameter<double>("jetPtMin");
+  jetEtaMax_ = iConfig.getParameter<double>("jetEtaMax");
   jetEMfracMax_ = iConfig.getParameter<double>("jetEMfracMax");
-  elePtMin_     = iConfig.getParameter<double>("elePtMin");
-  eleEtaMax_    = iConfig.getParameter<double>("eleEtaMax");
-  muonPtMin_    = iConfig.getParameter<double>("muonPtMin");
-  muonEtaMax_   = iConfig.getParameter<double>("muonEtaMax");
+  elePtMin_ = iConfig.getParameter<double>("elePtMin");
+  eleEtaMax_ = iConfig.getParameter<double>("eleEtaMax");
+  muonPtMin_ = iConfig.getParameter<double>("muonPtMin");
+  muonEtaMax_ = iConfig.getParameter<double>("muonEtaMax");
 
-  jetEtUncertaintyParameter0_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter0") ;
-  jetEtUncertaintyParameter1_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter1") ;
-  jetEtUncertaintyParameter2_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter2") ;
-  jetPhiUncertaintyParameter0_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter0");
-  jetPhiUncertaintyParameter1_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter1");
-  jetPhiUncertaintyParameter2_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter2");
+  jetEtUncertaintyParameter0_ = iConfig.getParameter<double>("jetEtUncertaintyParameter0");
+  jetEtUncertaintyParameter1_ = iConfig.getParameter<double>("jetEtUncertaintyParameter1");
+  jetEtUncertaintyParameter2_ = iConfig.getParameter<double>("jetEtUncertaintyParameter2");
+  jetPhiUncertaintyParameter0_ = iConfig.getParameter<double>("jetPhiUncertaintyParameter0");
+  jetPhiUncertaintyParameter1_ = iConfig.getParameter<double>("jetPhiUncertaintyParameter1");
+  jetPhiUncertaintyParameter2_ = iConfig.getParameter<double>("jetPhiUncertaintyParameter2");
 
-  eleEtUncertaintyParameter0_  =  iConfig.getParameter<double>( "eleEtUncertaintyParameter0") ;
-  elePhiUncertaintyParameter0_ =  iConfig.getParameter<double>( "elePhiUncertaintyParameter0") ;
+  eleEtUncertaintyParameter0_ = iConfig.getParameter<double>("eleEtUncertaintyParameter0");
+  elePhiUncertaintyParameter0_ = iConfig.getParameter<double>("elePhiUncertaintyParameter0");
 
-  muonEtUncertaintyParameter0_  =  iConfig.getParameter<double>( "muonEtUncertaintyParameter0") ;
-  muonPhiUncertaintyParameter0_ =  iConfig.getParameter<double>( "muonPhiUncertaintyParameter0") ;
+  muonEtUncertaintyParameter0_ = iConfig.getParameter<double>("muonEtUncertaintyParameter0");
+  muonPhiUncertaintyParameter0_ = iConfig.getParameter<double>("muonPhiUncertaintyParameter0");
 
-  CaloTowerTag_  = iConfig.getParameter<edm::InputTag>("CaloTowerTag");
-  noHF_ = iConfig.getParameter<bool>( "noHF");
+  CaloTowerTag_ = iConfig.getParameter<edm::InputTag>("CaloTowerTag");
+  noHF_ = iConfig.getParameter<bool>("noHF");
 
   //  muonCalo_ = iConfig.getParameter<bool>("muonCalo");
-  towerEtThreshold_ = iConfig.getParameter<double>( "towerEtThreshold") ;
+  towerEtThreshold_ = iConfig.getParameter<double>("towerEtThreshold");
   useHO_ = iConfig.getParameter<bool>("useHO");
 
   setUncertaintyParameters();
-  
+
   produces<pat::MHTCollection>();
-
 }
 
+pat::PATMHTProducer::~PATMHTProducer() {}
 
-pat::PATMHTProducer::~PATMHTProducer() {
-}
-
-void
-pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
+void pat::PATMHTProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // make sure the SigInputObj container is empty
-  while(!physobjvector_.empty()){
-    physobjvector_.erase(physobjvector_.begin(),physobjvector_.end());
+  while (!physobjvector_.empty()) {
+    physobjvector_.erase(physobjvector_.begin(), physobjvector_.end());
   }
 
   // Clean the clustered towers
@@ -73,37 +67,35 @@ pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   double number_of_muons = getMuons(iEvent, iSetup);
 
   if (verbose_ == 1.) {
-    std::cout << ">>>---> Number of jets: "  <<  number_of_jets << std::endl;
-    std::cout << ">>>---> Number of electrons: "  <<  number_of_jets << std::endl;
-    std::cout << ">>>---> Number of muons: " <<  number_of_muons << std::endl;
+    std::cout << ">>>---> Number of jets: " << number_of_jets << std::endl;
+    std::cout << ">>>---> Number of electrons: " << number_of_jets << std::endl;
+    std::cout << ">>>---> Number of muons: " << number_of_muons << std::endl;
   }
 
-  double met_x=0;
-  double met_y=0;
-  double met_et=0;
-  double met_phi=0;
-  double met_set=0;
-
+  double met_x = 0;
+  double met_y = 0;
+  double met_et = 0;
+  double met_phi = 0;
+  double met_set = 0;
 
   auto themetsigcoll = std::make_unique<pat::MHTCollection>();
 
-  if(!physobjvector_.empty()) { // Only when the vector is not empty
+  if (!physobjvector_.empty()) {  // Only when the vector is not empty
 
     // calculate the MHT significance
 
     metsig::significanceAlgo signifAlgo;
     signifAlgo.addObjects(physobjvector_);
-    double significance = signifAlgo.significance(met_et,met_phi,met_set);
+    double significance = signifAlgo.significance(met_et, met_phi, met_set);
 
-    met_x=met_et*cos(met_phi);
-    met_y=met_et*sin(met_phi);
+    met_x = met_et * cos(met_phi);
+    met_y = met_et * sin(met_phi);
 
     if (verbose_ == 1.) {
       std::cout << ">>>----> MHT Sgificance = " << significance << std::endl;
     }
 
-    pat::MHT themetsigobj(reco::Particle::LorentzVector(met_x,met_y,0,met_et),met_set,significance);
-
+    pat::MHT themetsigobj(reco::Particle::LorentzVector(met_x, met_y, 0, met_et), met_set, significance);
 
     // Store the number of jets, electrons, muons
     themetsigobj.setNumberOfJets(number_of_jets);
@@ -112,34 +104,27 @@ pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
     themetsigcoll->push_back(themetsigobj);
 
-  } // If the vector is empty, just put empty product.
-
+  }  // If the vector is empty, just put empty product.
 
   iEvent.put(std::move(themetsigcoll));
-
-
 }
 
 // --------------------------------------------------
 //  Fill Input Vector with Jets
 // --------------------------------------------------
-double
-pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup & iSetup){
-
-  std::string objectname="jet";
+double pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::string objectname = "jet";
 
   double number_of_jets_ = 0.0;
 
   edm::Handle<edm::View<pat::Jet> > jetHandle;
-  iEvent.getByToken(jetToken_,jetHandle);
+  iEvent.getByToken(jetToken_, jetHandle);
   edm::View<pat::Jet> jets = *jetHandle;
 
   // Fill Input Vector with Jets
-  for(edm::View<pat::Jet>::const_iterator jet_iter = jets.begin(); jet_iter!=jets.end(); ++jet_iter){
-
-    if( (jet_iter->pt()  < jetPtMin_) ||
-	(TMath::Abs(jet_iter->eta()) > jetEtaMax_) ||
-        (jet_iter->emEnergyFraction() > jetEMfracMax_ ) )
+  for (edm::View<pat::Jet>::const_iterator jet_iter = jets.begin(); jet_iter != jets.end(); ++jet_iter) {
+    if ((jet_iter->pt() < jetPtMin_) || (TMath::Abs(jet_iter->eta()) > jetEtaMax_) ||
+        (jet_iter->emEnergyFraction() > jetEMfracMax_))
       continue;
 
     double jet_et = jet_iter->et();
@@ -147,78 +132,68 @@ pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup & iSetup)
 
     if (verbose_ == 3.) {
       std::cout << "jet pt : " << jet_iter->pt() << " eta : " << jet_iter->eta()
-		<< " EMF: "  << jet_iter->emEnergyFraction() <<  std::endl;
+                << " EMF: " << jet_iter->emEnergyFraction() << std::endl;
     }
 
-    double sigma_et, sigma_phi ;
+    double sigma_et, sigma_phi;
 
     if (controlledUncertainty_) {
-      sigma_et  = jetUncertainty.etUncertainty->Eval(jet_et);
+      sigma_et = jetUncertainty.etUncertainty->Eval(jet_et);
       sigma_phi = jetUncertainty.phiUncertainty->Eval(jet_et);
-    }
-    else {
-      sigma_et = 0.0 ; // jet_iter->resolutionEt();
-      sigma_phi =  0.0 ; //jet_iter->resolutionPhi();
+    } else {
+      sigma_et = 0.0;   // jet_iter->resolutionEt();
+      sigma_phi = 0.0;  //jet_iter->resolutionPhi();
     }
 
     if (verbose_ == 3.) {
-      std::cout << "jet sigma_et : " << sigma_et << ", jet sigma_phi : " << sigma_phi <<  std::endl;
+      std::cout << "jet sigma_et : " << sigma_et << ", jet sigma_phi : " << sigma_phi << std::endl;
     }
 
-    if(sigma_et<=0 || sigma_phi<=0)
-      edm::LogWarning("PATMHTProducer") <<
-	" uncertainties for "  << objectname <<
-	" are (et, phi): " << sigma_et << "," << sigma_phi << " (et,phi): " << jet_et << "," << jet_phi;
+    if (sigma_et <= 0 || sigma_phi <= 0)
+      edm::LogWarning("PATMHTProducer") << " uncertainties for " << objectname << " are (et, phi): " << sigma_et << ","
+                                        << sigma_phi << " (et,phi): " << jet_et << "," << jet_phi;
     // try to read out the jet resolution from the root file at PatUtils
     //-- Store jet for Significance Calculation --//
 
-    if (uncertaintyScaleFactor_ != 1.0){
-      sigma_et  = sigma_et  * uncertaintyScaleFactor_;
+    if (uncertaintyScaleFactor_ != 1.0) {
+      sigma_et = sigma_et * uncertaintyScaleFactor_;
       sigma_phi = sigma_phi * uncertaintyScaleFactor_;
       // edm::LogWarning("PATMHTProducer") << " using uncertainty scale factor: " << uncertaintyScaleFactor_ <<
       //" , uncertainties for " << objectname <<" changed to (et, phi): " << sigma_et << "," << sigma_phi;
     }
 
+    if (verbose_ == 101.) {  // Study the Jets behavior
 
-    if (verbose_ == 101.) { // Study the Jets behavior
-
-      std::cout << "v101> " <<  number_of_jets_ << "  "
-		<< jet_et   << "  "  <<  sigma_et << "  "
-		<< jet_phi  << "  "  <<  sigma_phi << std::endl;
+      std::cout << "v101> " << number_of_jets_ << "  " << jet_et << "  " << sigma_et << "  " << jet_phi << "  "
+                << sigma_phi << std::endl;
     }
 
-
-    metsig::SigInputObj tmp_jet(objectname,jet_et,jet_phi,sigma_et,sigma_phi);
+    metsig::SigInputObj tmp_jet(objectname, jet_et, jet_phi, sigma_et, sigma_phi);
     physobjvector_.push_back(tmp_jet);
-    number_of_jets_ ++;
+    number_of_jets_++;
 
     //-- Store tower DetId's to be removed from Calo Tower sum later --//
     std::vector<CaloTowerPtr> v_towers = jet_iter->getCaloConstituents();
     //std::cout << "tower size = " << v_towers.size() << std::endl;
 
-    for (unsigned int ii=0; ii < v_towers.size(); ii++) {
-      s_clusteredTowers.insert( (*v_towers.at(ii)).id() );
+    for (unsigned int ii = 0; ii < v_towers.size(); ii++) {
+      s_clusteredTowers.insert((*v_towers.at(ii)).id());
       //std::cout << "tower id = " << (*v_towers.at(ii)).id() << std::endl;
     }
-
   }
 
-  if (verbose_ == 101.) { // Study the Jets behavior - seperate events
+  if (verbose_ == 101.) {  // Study the Jets behavior - seperate events
     std::cout << "v101> --------------------------------------------" << std::endl;
   }
 
   return number_of_jets_;
-
 }
-
 
 // --------------------------------------------------
 //  Fill Input Vector with Electrons
 // --------------------------------------------------
-double
-pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iSetup){
-
-  std::string objectname="electron";
+double pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::string objectname = "electron";
 
   double number_of_electrons_ = 0.0;
 
@@ -227,53 +202,49 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
   // const CaloTowerConstituentsMap* caloTowerMap = cttopo.product();
 
   edm::Handle<edm::View<pat::Electron> > electronHandle;
-  iEvent.getByToken(eleToken_,electronHandle);
+  iEvent.getByToken(eleToken_, electronHandle);
   edm::View<pat::Electron> electrons = *electronHandle;
 
   // Fill Input Vector with Electrons
-  for(edm::View<pat::Electron>::const_iterator electron_iter = electrons.begin(); electron_iter!=electrons.end(); ++electron_iter){
-
+  for (edm::View<pat::Electron>::const_iterator electron_iter = electrons.begin(); electron_iter != electrons.end();
+       ++electron_iter) {
     // Select electrons
-    if (electron_iter->et() < elePtMin_ ||
-	TMath::Abs(electron_iter->eta()) > eleEtaMax_  ) continue;
+    if (electron_iter->et() < elePtMin_ || TMath::Abs(electron_iter->eta()) > eleEtaMax_)
+      continue;
 
     if (verbose_ == 3.) {
-      std::cout << "electron pt = " << electron_iter->pt()  << " eta : " << electron_iter->eta()
-		<<  std::endl;
+      std::cout << "electron pt = " << electron_iter->pt() << " eta : " << electron_iter->eta() << std::endl;
     }
 
-    double electron_et  = electron_iter->et();
+    double electron_et = electron_iter->et();
     double electron_phi = electron_iter->phi();
 
-    double sigma_et, sigma_phi ;
+    double sigma_et, sigma_phi;
 
     if (controlledUncertainty_) {
-      sigma_et  = eleUncertainty.etUncertainty->Eval(electron_et);
+      sigma_et = eleUncertainty.etUncertainty->Eval(electron_et);
       sigma_phi = eleUncertainty.phiUncertainty->Eval(electron_et);
-    }
-    else {
-      sigma_et = 0.0; //electron_iter->resolutionEt();
-      sigma_phi = 0.0; // electron_iter->resolutionPhi();
+    } else {
+      sigma_et = 0.0;   //electron_iter->resolutionEt();
+      sigma_phi = 0.0;  // electron_iter->resolutionPhi();
     }
 
     if (verbose_ == 3.) {
-      std::cout << "electron sigma_et : " << sigma_et << ", electron sigma_phi : " << sigma_phi
-		<<  std::endl;}
+      std::cout << "electron sigma_et : " << sigma_et << ", electron sigma_phi : " << sigma_phi << std::endl;
+    }
 
-    if(sigma_et< 0 || sigma_phi< 0)
-      edm::LogWarning("PATMHTProducer") << " uncertainties for "  << objectname
-					<<" are (et, phi): " << sigma_et
-					<< "," << sigma_phi <<  " (et,phi): "
-					<< electron_et << "," << electron_phi;
+    if (sigma_et < 0 || sigma_phi < 0)
+      edm::LogWarning("PATMHTProducer") << " uncertainties for " << objectname << " are (et, phi): " << sigma_et << ","
+                                        << sigma_phi << " (et,phi): " << electron_et << "," << electron_phi;
 
-    if (uncertaintyScaleFactor_ != 1.0){
-      sigma_et  = sigma_et  * uncertaintyScaleFactor_;
+    if (uncertaintyScaleFactor_ != 1.0) {
+      sigma_et = sigma_et * uncertaintyScaleFactor_;
       sigma_phi = sigma_phi * uncertaintyScaleFactor_;
     }
 
-    metsig::SigInputObj tmp_electron(objectname,electron_et,electron_phi,sigma_et,sigma_phi);
+    metsig::SigInputObj tmp_electron(objectname, electron_et, electron_phi, sigma_et, sigma_phi);
     physobjvector_.push_back(tmp_electron);
-    number_of_electrons_ ++;
+    number_of_electrons_++;
 
     //-- Store tower DetId's to be removed from Calo Tower sum later --//
     /*
@@ -296,151 +267,140 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
     }
 
     */
-
   }
 
   return number_of_electrons_;
 }
 
-
-
 // --------------------------------------------------
 //  Fill Input Vector with Muons
 // --------------------------------------------------
 
-double pat::PATMHTProducer::getMuons(edm::Event& iEvent, const edm::EventSetup & iSetup){
-
-  std::string objectname="muon";
+double pat::PATMHTProducer::getMuons(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::string objectname = "muon";
   edm::Handle<edm::View<pat::Muon> > muonHandle;
-  iEvent.getByToken(muoToken_,muonHandle);
+  iEvent.getByToken(muoToken_, muonHandle);
   edm::View<pat::Muon> muons = *muonHandle;
 
-  if ( !muonHandle.isValid() ) {
+  if (!muonHandle.isValid()) {
     std::cout << ">>> PATMHTSelector not valid muon Handle!" << std::endl;
     return 0.0;
   }
 
-
   double number_of_muons_ = 0.0;
 
-  for(edm::View<pat::Muon>::const_iterator muon_iter = muons.begin(); muon_iter!=muons.end(); ++muon_iter){
-
-    if (muon_iter->pt() < muonPtMin_ || TMath::Abs(muon_iter->eta()) > muonEtaMax_  ) continue;
+  for (edm::View<pat::Muon>::const_iterator muon_iter = muons.begin(); muon_iter != muons.end(); ++muon_iter) {
+    if (muon_iter->pt() < muonPtMin_ || TMath::Abs(muon_iter->eta()) > muonEtaMax_)
+      continue;
 
     if (verbose_ == 3.) {
-      std::cout << "muon pt = " << muon_iter->pt() << " eta : " << muon_iter->eta() <<  std::endl;
+      std::cout << "muon pt = " << muon_iter->pt() << " eta : " << muon_iter->eta() << std::endl;
     }
 
-    double muon_pt  = muon_iter->pt();
+    double muon_pt = muon_iter->pt();
     double muon_phi = muon_iter->phi();
 
-    double sigma_et, sigma_phi ;
+    double sigma_et, sigma_phi;
 
     if (controlledUncertainty_) {
-       sigma_et  = muonUncertainty.etUncertainty->Eval(muon_pt);
-       sigma_phi = muonUncertainty.phiUncertainty->Eval(muon_pt);
-    }
-    else {
-      sigma_et  = 0.0; //muon_iter->resolutionEt();
-      sigma_phi = 0.0; // muon_iter->resolutionPhi();
+      sigma_et = muonUncertainty.etUncertainty->Eval(muon_pt);
+      sigma_phi = muonUncertainty.phiUncertainty->Eval(muon_pt);
+    } else {
+      sigma_et = 0.0;   //muon_iter->resolutionEt();
+      sigma_phi = 0.0;  // muon_iter->resolutionPhi();
     }
 
     if (verbose_ == 3.) {
-      std::cout << "muon sigma_et : " << sigma_et
-		<< ", muon sigma_phi : " << sigma_phi
-		<<  std::endl;}
+      std::cout << "muon sigma_et : " << sigma_et << ", muon sigma_phi : " << sigma_phi << std::endl;
+    }
 
-   if(sigma_et< 0 || sigma_phi< 0)
-      edm::LogWarning("PATMHTProducer") <<
-	" uncertainties for "  << objectname << " are (et, phi): " << sigma_et << "," <<
-	sigma_phi << " (pt,phi): " << muon_pt << "," << muon_phi;
+    if (sigma_et < 0 || sigma_phi < 0)
+      edm::LogWarning("PATMHTProducer") << " uncertainties for " << objectname << " are (et, phi): " << sigma_et << ","
+                                        << sigma_phi << " (pt,phi): " << muon_pt << "," << muon_phi;
 
-    if (uncertaintyScaleFactor_ != 1.0){
-      sigma_et  = sigma_et  * uncertaintyScaleFactor_;
+    if (uncertaintyScaleFactor_ != 1.0) {
+      sigma_et = sigma_et * uncertaintyScaleFactor_;
       sigma_phi = sigma_phi * uncertaintyScaleFactor_;
     }
 
-    metsig::SigInputObj tmp_muon(objectname,muon_pt,muon_phi,sigma_et,sigma_phi);
+    metsig::SigInputObj tmp_muon(objectname, muon_pt, muon_phi, sigma_et, sigma_phi);
     physobjvector_.push_back(tmp_muon);
-    number_of_muons_ ++;
+    number_of_muons_++;
 
-  }// end Muon loop
+  }  // end Muon loop
 
   return number_of_muons_;
 }
 
-
 //=== Uncertainty Functions ===============================================
-void pat::PATMHTProducer::setUncertaintyParameters(){
-
+void pat::PATMHTProducer::setUncertaintyParameters() {
   // set the various functions here:
 
   //-- For Et functions, [0]= par_n, [1]=par_s, [2]= par_c ---//
   //-- Ecal Uncertainty Functions ------------------------------------//
   //-- From: FastSimulation/Calorimetry/data/HcalResponse.cfi --//
   //-- Ecal Barrel --//
-  ecalEBUncertainty.etUncertainty.reset( new TF1("ecalEBEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
-  ecalEBUncertainty.etUncertainty->SetParameter(0,0.2);
-  ecalEBUncertainty.etUncertainty->SetParameter(1,0.03);
-  ecalEBUncertainty.etUncertainty->SetParameter(2,0.005);
+  ecalEBUncertainty.etUncertainty.reset(new TF1("ecalEBEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
+  ecalEBUncertainty.etUncertainty->SetParameter(0, 0.2);
+  ecalEBUncertainty.etUncertainty->SetParameter(1, 0.03);
+  ecalEBUncertainty.etUncertainty->SetParameter(2, 0.005);
 
-  ecalEBUncertainty.phiUncertainty.reset( new TF1("ecalEBphiFunc","[0]*x",1) );
-  ecalEBUncertainty.phiUncertainty->SetParameter(0,0.0174);
+  ecalEBUncertainty.phiUncertainty.reset(new TF1("ecalEBphiFunc", "[0]*x", 1));
+  ecalEBUncertainty.phiUncertainty->SetParameter(0, 0.0174);
 
   //-- Ecal Endcap --//
-  ecalEEUncertainty.etUncertainty.reset( new TF1("ecalEEEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
-  ecalEEUncertainty.etUncertainty->SetParameter(0,0.2);
-  ecalEEUncertainty.etUncertainty->SetParameter(1,0.03);
-  ecalEEUncertainty.etUncertainty->SetParameter(2,0.005);
+  ecalEEUncertainty.etUncertainty.reset(new TF1("ecalEEEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
+  ecalEEUncertainty.etUncertainty->SetParameter(0, 0.2);
+  ecalEEUncertainty.etUncertainty->SetParameter(1, 0.03);
+  ecalEEUncertainty.etUncertainty->SetParameter(2, 0.005);
 
-  ecalEEUncertainty.phiUncertainty.reset( new TF1("ecalEEphiFunc","[0]*x",1) );
-  ecalEEUncertainty.phiUncertainty->SetParameter(0,0.087);
+  ecalEEUncertainty.phiUncertainty.reset(new TF1("ecalEEphiFunc", "[0]*x", 1));
+  ecalEEUncertainty.phiUncertainty->SetParameter(0, 0.087);
 
   //-- Hcal Uncertainty Functions --------------------------------------//
   //-- From: FastSimulation/Calorimetry/data/HcalResponse.cfi --//
   //-- Hcal Barrel --//
-  hcalHBUncertainty.etUncertainty.reset( new TF1("hcalHBEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
-  hcalHBUncertainty.etUncertainty->SetParameter(0,0.);
-  hcalHBUncertainty.etUncertainty->SetParameter(1,1.22);
-  hcalHBUncertainty.etUncertainty->SetParameter(2,0.05);
+  hcalHBUncertainty.etUncertainty.reset(new TF1("hcalHBEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
+  hcalHBUncertainty.etUncertainty->SetParameter(0, 0.);
+  hcalHBUncertainty.etUncertainty->SetParameter(1, 1.22);
+  hcalHBUncertainty.etUncertainty->SetParameter(2, 0.05);
 
-  hcalHBUncertainty.phiUncertainty.reset( new TF1("ecalHBphiFunc","[0]*x",1) );
-  hcalHBUncertainty.phiUncertainty->SetParameter(0,0.087);
+  hcalHBUncertainty.phiUncertainty.reset(new TF1("ecalHBphiFunc", "[0]*x", 1));
+  hcalHBUncertainty.phiUncertainty->SetParameter(0, 0.087);
 
   //-- Hcal Endcap --//
-  hcalHEUncertainty.etUncertainty.reset( new TF1("hcalHEEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
-  hcalHEUncertainty.etUncertainty->SetParameter(0,0.);
-  hcalHEUncertainty.etUncertainty->SetParameter(1,1.3);
-  hcalHEUncertainty.etUncertainty->SetParameter(2,0.05);
+  hcalHEUncertainty.etUncertainty.reset(new TF1("hcalHEEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
+  hcalHEUncertainty.etUncertainty->SetParameter(0, 0.);
+  hcalHEUncertainty.etUncertainty->SetParameter(1, 1.3);
+  hcalHEUncertainty.etUncertainty->SetParameter(2, 0.05);
 
-  hcalHEUncertainty.phiUncertainty.reset( new TF1("ecalHEphiFunc","[0]*x",1) );
-  hcalHEUncertainty.phiUncertainty->SetParameter(0,0.087);
+  hcalHEUncertainty.phiUncertainty.reset(new TF1("ecalHEphiFunc", "[0]*x", 1));
+  hcalHEUncertainty.phiUncertainty->SetParameter(0, 0.087);
 
   //-- Hcal Outer --//
-  hcalHOUncertainty.etUncertainty.reset( new TF1("hcalHOEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
-  hcalHOUncertainty.etUncertainty->SetParameter(0,0.);
-  hcalHOUncertainty.etUncertainty->SetParameter(1,1.82);
-  hcalHOUncertainty.etUncertainty->SetParameter(2,0.09);
+  hcalHOUncertainty.etUncertainty.reset(new TF1("hcalHOEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
+  hcalHOUncertainty.etUncertainty->SetParameter(0, 0.);
+  hcalHOUncertainty.etUncertainty->SetParameter(1, 1.82);
+  hcalHOUncertainty.etUncertainty->SetParameter(2, 0.09);
 
-  hcalHOUncertainty.phiUncertainty.reset( new TF1("ecalHOphiFunc","[0]*x",1) );
-  hcalHOUncertainty.phiUncertainty->SetParameter(0,0.087);
+  hcalHOUncertainty.phiUncertainty.reset(new TF1("ecalHOphiFunc", "[0]*x", 1));
+  hcalHOUncertainty.phiUncertainty->SetParameter(0, 0.087);
 
   //-- Hcal Forward --//
-  hcalHFUncertainty.etUncertainty.reset( new TF1("hcalHFEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
-  hcalHFUncertainty.etUncertainty->SetParameter(0,0.);
-  hcalHFUncertainty.etUncertainty->SetParameter(1,1.82);
-  hcalHFUncertainty.etUncertainty->SetParameter(2,0.09);
+  hcalHFUncertainty.etUncertainty.reset(new TF1("hcalHFEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
+  hcalHFUncertainty.etUncertainty->SetParameter(0, 0.);
+  hcalHFUncertainty.etUncertainty->SetParameter(1, 1.82);
+  hcalHFUncertainty.etUncertainty->SetParameter(2, 0.09);
 
-  hcalHFUncertainty.phiUncertainty.reset( new TF1("ecalHFphiFunc","[0]*x",1) );
-  hcalHFUncertainty.phiUncertainty->SetParameter(0,0.174);
+  hcalHFUncertainty.phiUncertainty.reset(new TF1("ecalHFphiFunc", "[0]*x", 1));
+  hcalHFUncertainty.phiUncertainty->SetParameter(0, 0.174);
 
   //--- Jet Uncertainty Functions --------------------------------------//
-  jetUncertainty.etUncertainty.reset( new TF1("jetEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
+  jetUncertainty.etUncertainty.reset(new TF1("jetEtFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
   //-- values from PTDR 1, ch 11.4 --//
   jetUncertainty.etUncertainty->SetParameter(0, jetEtUncertaintyParameter0_);
   jetUncertainty.etUncertainty->SetParameter(1, jetEtUncertaintyParameter1_);
   jetUncertainty.etUncertainty->SetParameter(2, jetEtUncertaintyParameter2_);
-
 
   //-- phi value from our own fits --//
   //jetUncertainty.phiUncertainty.reset( new TF1("jetPhiFunc","[0]*x",1) );
@@ -448,12 +408,10 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
 
   //-- phi Functions and values from
   // http://indico.cern.ch/getFile.py/access?contribId=9&sessionId=0&resId=0&materialId=slides&confId=46394
-  jetUncertainty.phiUncertainty.reset( new TF1("jetPhiFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
+  jetUncertainty.phiUncertainty.reset(new TF1("jetPhiFunc", "x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))", 3));
   jetUncertainty.phiUncertainty->SetParameter(0, jetPhiUncertaintyParameter0_);
   jetUncertainty.phiUncertainty->SetParameter(1, jetPhiUncertaintyParameter1_);
   jetUncertainty.phiUncertainty->SetParameter(2, jetPhiUncertaintyParameter2_);
-
-
 
   //-- Jet corrections are assumed not to have an error --//
   /*jetCorrUncertainty.etUncertainty.reset( new TF1("jetCorrEtFunc","[0]*x",1) );
@@ -461,29 +419,27 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   jetCorrUncertainty.phiUncertainty.reset( new TF1("jetCorrPhiFunc","[0]*x",1) );
   jetCorrUncertainty.phiUncertainty->SetParameter(0,0.0*(3.14159/180.));*/
 
-
   //--- Electron Uncertainty Functions ---------------------------------//
   // completely ambiguious values for electron-like jets...
   // the egamma group keeps track of these here:
   // https://twiki.cern.ch/twiki/bin/view/CMS/EgammaCMSSWVal
   // electron resolution in energy is around 3.4%, measured for 10 < pT < 50 at realistic events with pile-up.
 
-  eleUncertainty.etUncertainty.reset( new TF1("eleEtFunc","[0] * x",1) );
+  eleUncertainty.etUncertainty.reset(new TF1("eleEtFunc", "[0] * x", 1));
   //  eleUncertainty.etUncertainty->SetParameter(0,0.034);
   eleUncertainty.etUncertainty->SetParameter(0, eleEtUncertaintyParameter0_);
 
-
-  eleUncertainty.phiUncertainty.reset( new TF1("elePhiFunc","[0] * x",1) );
+  eleUncertainty.phiUncertainty.reset(new TF1("elePhiFunc", "[0] * x", 1));
   //  eleUncertainty.phiUncertainty->SetParameter(0,1*(3.14159/180.));
   eleUncertainty.phiUncertainty->SetParameter(0, elePhiUncertaintyParameter0_);
 
   //--- Muon Uncertainty Functions ------------------------------------//
   // and ambiguious values for the muons...
 
-  muonUncertainty.etUncertainty.reset( new TF1("muonEtFunc","[0] * x",1) );
+  muonUncertainty.etUncertainty.reset(new TF1("muonEtFunc", "[0] * x", 1));
   //  muonUncertainty.etUncertainty->SetParameter(0,0.01);
   muonUncertainty.etUncertainty->SetParameter(0, muonEtUncertaintyParameter0_);
-  muonUncertainty.phiUncertainty.reset( new TF1("muonPhiFunc","[0] * x",1) );
+  muonUncertainty.phiUncertainty.reset(new TF1("muonPhiFunc", "[0] * x", 1));
   //  muonUncertainty.phiUncertainty->SetParameter(0,1*(3.14159/180.));
   muonUncertainty.phiUncertainty->SetParameter(0, muonPhiUncertaintyParameter0_);
 
@@ -492,10 +448,7 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   muonCorrUncertainty.etUncertainty->SetParameter(0,0.0);
   muonCorrUncertainty.phiUncertainty.reset( new TF1("muonCorrPhiFunc","[0] * x",1) );
   muonCorrUncertainty.phiUncertainty->SetParameter(0,0.0*(3.14159/180.)); */
-
 }
-
 
 using namespace pat;
 DEFINE_FWK_MODULE(PATMHTProducer);
-

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.h
@@ -19,8 +19,6 @@
 #ifndef PhysicsTools_PatAlgos_PATMHTProducer_h
 #define PhysicsTools_PatAlgos_PATMHTProducer_h
 
-
-
 // system include files
 #include <memory>
 
@@ -37,7 +35,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
@@ -47,7 +44,6 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
-
 
 #include "RecoMET/METAlgorithms/interface/SignAlgoResolutions.h"
 #include "RecoMET/METAlgorithms/interface/significanceAlgo.h"
@@ -72,8 +68,7 @@ namespace pat {
     double getJets(edm::Event&, const edm::EventSetup&);
     double getElectrons(edm::Event&, const edm::EventSetup&);
     double getMuons(edm::Event&, const edm::EventSetup&);
-    void   getTowers(edm::Event&, const edm::EventSetup&);
-
+    void getTowers(edm::Event&, const edm::EventSetup&);
 
     // ----------member data ---------------------------
 
@@ -87,21 +82,20 @@ namespace pat {
     edm::EDGetTokenT<edm::View<pat::Tau> > tauToken_;
     edm::EDGetTokenT<edm::View<pat::Photon> > phoToken_;
 
-    std::vector<metsig::SigInputObj> physobjvector_ ;
+    std::vector<metsig::SigInputObj> physobjvector_;
 
-    double uncertaintyScaleFactor_; // scale factor for the uncertainty parameters.
-    bool    controlledUncertainty_; // use controlled uncertainty parameters.
-
+    double uncertaintyScaleFactor_;  // scale factor for the uncertainty parameters.
+    bool controlledUncertainty_;     // use controlled uncertainty parameters.
 
     //--- test the uncertainty parameters ---//
 
-    class uncertaintyFunctions{
+    class uncertaintyFunctions {
     public:
       std::unique_ptr<TF1> etUncertainty;
       std::unique_ptr<TF1> phiUncertainty;
     };
 
-    void setUncertaintyParameters();// fills the following uncertaintyFunctions objects:
+    void setUncertaintyParameters();  // fills the following uncertaintyFunctions objects:
     uncertaintyFunctions ecalEBUncertainty;
     uncertaintyFunctions ecalEEUncertainty;
     uncertaintyFunctions hcalHBUncertainty;
@@ -142,23 +136,23 @@ namespace pat {
 
     //  double uncertaintyScaleFactor_; // scale factor for the uncertainty parameters.
 
-    double jetEtUncertaintyParameter0_ ;
-    double jetEtUncertaintyParameter1_ ;
-    double jetEtUncertaintyParameter2_ ;
+    double jetEtUncertaintyParameter0_;
+    double jetEtUncertaintyParameter1_;
+    double jetEtUncertaintyParameter2_;
 
-    double jetPhiUncertaintyParameter0_ ;
-    double jetPhiUncertaintyParameter1_ ;
-    double jetPhiUncertaintyParameter2_ ;
+    double jetPhiUncertaintyParameter0_;
+    double jetPhiUncertaintyParameter1_;
+    double jetPhiUncertaintyParameter2_;
 
-    double eleEtUncertaintyParameter0_ ;
-    double elePhiUncertaintyParameter0_ ;
+    double eleEtUncertaintyParameter0_;
+    double elePhiUncertaintyParameter0_;
 
-    double muonEtUncertaintyParameter0_ ;
-    double muonPhiUncertaintyParameter0_ ;
+    double muonEtUncertaintyParameter0_;
+    double muonPhiUncertaintyParameter0_;
 
     edm::InputTag CaloJetAlgorithmTag_;
     edm::InputTag CorJetAlgorithmTag_;
-    std::string   JetCorrectionService_;
+    std::string JetCorrectionService_;
     edm::InputTag MuonTag_;
     edm::InputTag ElectronTag_;
     edm::InputTag CaloTowerTag_;
@@ -169,13 +163,11 @@ namespace pat {
     //TrackDetectorAssociator   trackAssociator_;
     //TrackAssociatorParameters trackAssociatorParameters_;
 
-    double towerEtThreshold_ ;
-    bool useHO_ ;
-
-
+    double towerEtThreshold_;
+    bool useHO_;
   };
   //define this as a plug-in
 
-} //end of namespace
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -54,12 +54,10 @@
 #include <vector>
 #include <memory>
 
-
 using namespace pat;
 using namespace std;
 
 PATMuonHeavyObjectCache::PATMuonHeavyObjectCache(const edm::ParameterSet& iConfig) {
-
   if (iConfig.getParameter<bool>("computeMuonMVA")) {
     edm::FileInPath mvaTrainingFile = iConfig.getParameter<edm::FileInPath>("mvaTrainingFile");
     edm::FileInPath mvaLowPtTrainingFile = iConfig.getParameter<edm::FileInPath>("lowPtmvaTrainingFile");
@@ -74,53 +72,60 @@ PATMuonHeavyObjectCache::PATMuonHeavyObjectCache(const edm::ParameterSet& iConfi
   }
 }
 
-PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavyObjectCache const*) :
-  relMiniIsoPUCorrected_(0),
-  useUserData_(iConfig.exists("userData")),
-  computeMuonMVA_(false),
-  computeSoftMuonMVA_(false),
-  recomputeBasicSelectors_(false),
-  mvaUseJec_(false),
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false)
-{
+PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyObjectCache const*)
+    : relMiniIsoPUCorrected_(0),
+      useUserData_(iConfig.exists("userData")),
+      computeMuonMVA_(false),
+      computeSoftMuonMVA_(false),
+      recomputeBasicSelectors_(false),
+      mvaUseJec_(false),
+      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
+                                                : edm::ParameterSet(),
+                consumesCollector(),
+                false) {
   // input source
-  muonToken_ = consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ));
+  muonToken_ = consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("muonSource"));
   // embedding of tracks
-  embedBestTrack_ = iConfig.getParameter<bool>( "embedMuonBestTrack" );
-  embedTunePBestTrack_ = iConfig.getParameter<bool>( "embedTunePMuonBestTrack" );
-  forceEmbedBestTrack_ = iConfig.getParameter<bool>( "forceBestTrackEmbedding" );
-  embedTrack_ = iConfig.getParameter<bool>( "embedTrack" );
-  embedCombinedMuon_ = iConfig.getParameter<bool>( "embedCombinedMuon"   );
-  embedStandAloneMuon_ = iConfig.getParameter<bool>( "embedStandAloneMuon" );
+  embedBestTrack_ = iConfig.getParameter<bool>("embedMuonBestTrack");
+  embedTunePBestTrack_ = iConfig.getParameter<bool>("embedTunePMuonBestTrack");
+  forceEmbedBestTrack_ = iConfig.getParameter<bool>("forceBestTrackEmbedding");
+  embedTrack_ = iConfig.getParameter<bool>("embedTrack");
+  embedCombinedMuon_ = iConfig.getParameter<bool>("embedCombinedMuon");
+  embedStandAloneMuon_ = iConfig.getParameter<bool>("embedStandAloneMuon");
   // embedding of muon MET correction information
-  embedCaloMETMuonCorrs_ = iConfig.getParameter<bool>("embedCaloMETMuonCorrs" );
-  embedTcMETMuonCorrs_ = iConfig.getParameter<bool>("embedTcMETMuonCorrs"   );
-  caloMETMuonCorrsToken_ = mayConsume<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("caloMETMuonCorrs" ));
-  tcMETMuonCorrsToken_ = mayConsume<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("tcMETMuonCorrs"   ));
+  embedCaloMETMuonCorrs_ = iConfig.getParameter<bool>("embedCaloMETMuonCorrs");
+  embedTcMETMuonCorrs_ = iConfig.getParameter<bool>("embedTcMETMuonCorrs");
+  caloMETMuonCorrsToken_ =
+      mayConsume<edm::ValueMap<reco::MuonMETCorrectionData>>(iConfig.getParameter<edm::InputTag>("caloMETMuonCorrs"));
+  tcMETMuonCorrsToken_ =
+      mayConsume<edm::ValueMap<reco::MuonMETCorrectionData>>(iConfig.getParameter<edm::InputTag>("tcMETMuonCorrs"));
   // pflow specific configurables
-  useParticleFlow_ = iConfig.getParameter<bool>( "useParticleFlow" );
-  embedPFCandidate_ = iConfig.getParameter<bool>( "embedPFCandidate" );
-  pfMuonToken_ = mayConsume<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfMuonSource" ));
-  embedPfEcalEnergy_ = iConfig.getParameter<bool>( "embedPfEcalEnergy" );
+  useParticleFlow_ = iConfig.getParameter<bool>("useParticleFlow");
+  embedPFCandidate_ = iConfig.getParameter<bool>("embedPFCandidate");
+  pfMuonToken_ = mayConsume<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfMuonSource"));
+  embedPfEcalEnergy_ = iConfig.getParameter<bool>("embedPfEcalEnergy");
   // embedding of tracks from TeV refit
-  embedPickyMuon_ = iConfig.getParameter<bool>( "embedPickyMuon" );
-  embedTpfmsMuon_ = iConfig.getParameter<bool>( "embedTpfmsMuon" );
-  embedDytMuon_ = iConfig.getParameter<bool>( "embedDytMuon" );
+  embedPickyMuon_ = iConfig.getParameter<bool>("embedPickyMuon");
+  embedTpfmsMuon_ = iConfig.getParameter<bool>("embedTpfmsMuon");
+  embedDytMuon_ = iConfig.getParameter<bool>("embedDytMuon");
   // Monte Carlo matching
-  addGenMatch_ = iConfig.getParameter<bool>( "addGenMatch" );
+  addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
-    embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
+    embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
     if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
-    }
-    else {
-      genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    } else {
+      genMatchTokens_ = edm::vector_transform(
+          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
+          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
     }
   }
   // efficiencies
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
-  if(addEfficiencies_){
-    efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+  if (addEfficiencies_) {
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
   // resolutions
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
@@ -129,28 +134,34 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
   }
   // puppi
   addPuppiIsolation_ = iConfig.getParameter<bool>("addPuppiIsolation");
-  if(addPuppiIsolation_){
-    PUPPIIsolation_charged_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
-    PUPPIIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
-    PUPPIIsolation_photons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
+  if (addPuppiIsolation_) {
+    PUPPIIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationChargedHadrons"));
+    PUPPIIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationNeutralHadrons"));
+    PUPPIIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiIsolationPhotons"));
     //puppiNoLeptons
-    PUPPINoLeptonsIsolation_charged_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
-    PUPPINoLeptonsIsolation_neutral_hadrons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
-    PUPPINoLeptonsIsolation_photons_ = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
+    PUPPINoLeptonsIsolation_charged_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons"));
+    PUPPINoLeptonsIsolation_neutral_hadrons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons"));
+    PUPPINoLeptonsIsolation_photons_ =
+        consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiNoLeptonsIsolationPhotons"));
   }
   // read isoDeposit labels, for direct embedding
   readIsolationLabels(iConfig, "isoDeposits", isoDepositLabels_, isoDepositTokens_);
   // read isolation value labels, for direct embedding
   readIsolationLabels(iConfig, "isolationValues", isolationValueLabels_, isolationValueTokens_);
   // check to see if the user wants to add user data
-  if( useUserData_ ){
+  if (useUserData_) {
     userDataHelper_ = PATUserDataHelper<Muon>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   // embed high level selection variables
   embedHighLevelSelection_ = iConfig.getParameter<bool>("embedHighLevelSelection");
-  if ( embedHighLevelSelection_ ) {
+  if (embedHighLevelSelection_) {
     beamLineToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"));
-    pvToken_ = consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("pvSrc"));
+    pvToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("pvSrc"));
   }
 
   //for mini-isolation calculation
@@ -158,70 +169,64 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
 
   computePuppiCombinedIso_ = iConfig.getParameter<bool>("computePuppiCombinedIso");
 
-  effectiveAreaVec_ = iConfig.getParameter<std::vector<double> >("effectiveAreaVec");
+  effectiveAreaVec_ = iConfig.getParameter<std::vector<double>>("effectiveAreaVec");
 
-  miniIsoParams_ = iConfig.getParameter<std::vector<double> >("miniIsoParams");
-  if(computeMiniIso_ && miniIsoParams_.size() != 9){
-      throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
+  miniIsoParams_ = iConfig.getParameter<std::vector<double>>("miniIsoParams");
+  if (computeMiniIso_ && miniIsoParams_.size() != 9) {
+    throw cms::Exception("ParameterError") << "miniIsoParams must have exactly 9 elements.\n";
   }
-  if(computeMiniIso_ || computePuppiCombinedIso_)
-      pcToken_ = consumes<pat::PackedCandidateCollection >(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
+  if (computeMiniIso_ || computePuppiCombinedIso_)
+    pcToken_ = consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandsForMiniIso"));
 
   // standard selectors
   recomputeBasicSelectors_ = iConfig.getParameter<bool>("recomputeBasicSelectors");
   computeMuonMVA_ = iConfig.getParameter<bool>("computeMuonMVA");
-  if (computeMuonMVA_ and not computeMiniIso_) 
+  if (computeMuonMVA_ and not computeMiniIso_)
     throw cms::Exception("ConfigurationError") << "MiniIso is needed for Muon MVA calculation.\n";
 
   if (computeMuonMVA_) {
     // pfCombinedInclusiveSecondaryVertexV2BJetTags
-    mvaBTagCollectionTag_  = consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("mvaJetTag"));
-    mvaL1Corrector_        = consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("mvaL1Corrector"));
+    mvaBTagCollectionTag_ = consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("mvaJetTag"));
+    mvaL1Corrector_ = consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("mvaL1Corrector"));
     mvaL1L2L3ResCorrector_ = consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("mvaL1L2L3ResCorrector"));
-    rho_                   = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+    rho_ = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
     mvaUseJec_ = iConfig.getParameter<bool>("mvaUseJec");
   }
 
   computeSoftMuonMVA_ = iConfig.getParameter<bool>("computeSoftMuonMVA");
 
   // MC info
-  simInfo_        = consumes<edm::ValueMap<reco::MuonSimInfo> >(iConfig.getParameter<edm::InputTag>("muonSimInfo"));
+  simInfo_ = consumes<edm::ValueMap<reco::MuonSimInfo>>(iConfig.getParameter<edm::InputTag>("muonSimInfo"));
 
   addTriggerMatching_ = iConfig.getParameter<bool>("addTriggerMatching");
-  if ( addTriggerMatching_ ){
-    triggerObjects_ = consumes<std::vector<pat::TriggerObjectStandAlone>>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
+  if (addTriggerMatching_) {
+    triggerObjects_ =
+        consumes<std::vector<pat::TriggerObjectStandAlone>>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
     triggerResults_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerResults"));
   }
   hltCollectionFilters_ = iConfig.getParameter<std::vector<std::string>>("hltCollectionFilters");
 
   // produces vector of muons
-  produces<std::vector<Muon> >();
+  produces<std::vector<Muon>>();
 }
 
-
-PATMuonProducer::~PATMuonProducer()
-{
-}
+PATMuonProducer::~PATMuonProducer() {}
 
 std::optional<GlobalPoint> PATMuonProducer::getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
                                                              const edm::ESHandle<GlobalTrackingGeometry>& geometry,
-                                                             const DetId& chamberId)
-{
-  const GeomDet* chamberGeometry = geometry->idToDet( chamberId );
-  if (chamberGeometry){
+                                                             const DetId& chamberId) {
+  const GeomDet* chamberGeometry = geometry->idToDet(chamberId);
+  if (chamberGeometry) {
     LocalPoint localPosition(chamberMatch.x, chamberMatch.y, 0);
     return std::optional<GlobalPoint>(std::in_place, chamberGeometry->toGlobal(localPosition));
   }
   return std::optional<GlobalPoint>();
-
 }
 
-
 void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
-					edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-					const edm::TriggerNames & names,
-					const edm::ESHandle<GlobalTrackingGeometry>& geometry)
-{
+                                        edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                                        const edm::TriggerNames& names,
+                                        const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
   // L1 trigger object parameters are defined at MB2/ME2. Use the muon
   // chamber matching information to get the local direction of the
   // muon trajectory and convert it to a global direction to match the
@@ -229,32 +234,39 @@ void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
 
   std::optional<GlobalPoint> muonPosition;
   // Loop over chambers
-  // initialize muonPosition with any available match, just in case 
-  // the second station is missing - it's better folling back to 
+  // initialize muonPosition with any available match, just in case
+  // the second station is missing - it's better folling back to
   // dR matching at IP
-  for ( const auto& chamberMatch: aMuon.matches() ) {
-    if ( chamberMatch.id.subdetId() == MuonSubdetId::DT) {
+  for (const auto& chamberMatch : aMuon.matches()) {
+    if (chamberMatch.id.subdetId() == MuonSubdetId::DT) {
       DTChamberId detId(chamberMatch.id.rawId());
-      if (abs(detId.station())>3) continue; 
+      if (abs(detId.station()) > 3)
+        continue;
       muonPosition = getMuonDirection(chamberMatch, geometry, detId);
-      if (abs(detId.station())==2) break;
+      if (abs(detId.station()) == 2)
+        break;
     }
-    if ( chamberMatch.id.subdetId() == MuonSubdetId::CSC) {
+    if (chamberMatch.id.subdetId() == MuonSubdetId::CSC) {
       CSCDetId detId(chamberMatch.id.rawId());
-      if (abs(detId.station())>3) continue;
+      if (abs(detId.station()) > 3)
+        continue;
       muonPosition = getMuonDirection(chamberMatch, geometry, detId);
-      if (abs(detId.station())==2) break;
+      if (abs(detId.station()) == 2)
+        break;
     }
   }
-  if (not muonPosition) return;
-  for (const auto& triggerObject: *triggerObjects){
-    if (triggerObject.hasTriggerObjectType(trigger::TriggerL1Mu)){
-      if (fabs(triggerObject.eta())<0.001){
-	// L1 is defined in X-Y plain
-	if (deltaPhi(triggerObject.phi(),muonPosition->phi())>0.1) continue;
+  if (not muonPosition)
+    return;
+  for (const auto& triggerObject : *triggerObjects) {
+    if (triggerObject.hasTriggerObjectType(trigger::TriggerL1Mu)) {
+      if (fabs(triggerObject.eta()) < 0.001) {
+        // L1 is defined in X-Y plain
+        if (deltaPhi(triggerObject.phi(), muonPosition->phi()) > 0.1)
+          continue;
       } else {
-	// 3D L1
-	if (deltaR(triggerObject.p4(),*muonPosition)>0.15) continue;
+        // 3D L1
+        if (deltaR(triggerObject.p4(), *muonPosition) > 0.15)
+          continue;
       }
       pat::TriggerObjectStandAlone obj(triggerObject);
       obj.unpackPathNames(names);
@@ -264,23 +276,24 @@ void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
 }
 
 void PATMuonProducer::fillHltTriggerInfo(pat::Muon& muon,
-					 edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-					 const edm::TriggerNames & names,
-					 const std::vector<std::string>& collection_filter_names)
-{
+                                         edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                                         const edm::TriggerNames& names,
+                                         const std::vector<std::string>& collection_filter_names) {
   // WARNING: in a case of close-by muons the dR matching may select both muons.
   // It's better to select the best match for a given collection.
-  for (const auto& triggerObject: *triggerObjects){
-    if (triggerObject.hasTriggerObjectType(trigger::TriggerMuon)){
+  for (const auto& triggerObject : *triggerObjects) {
+    if (triggerObject.hasTriggerObjectType(trigger::TriggerMuon)) {
       bool keepIt = false;
-      for (const auto& name: collection_filter_names){
-	if (triggerObject.hasCollection(name)){
-	  keepIt = true;
-	  break;
-	}
+      for (const auto& name : collection_filter_names) {
+        if (triggerObject.hasCollection(name)) {
+          keepIt = true;
+          break;
+        }
       }
-      if (not keepIt) continue;
-      if ( deltaR(triggerObject.p4(),muon)>0.1 ) continue;
+      if (not keepIt)
+        continue;
+      if (deltaR(triggerObject.p4(), muon) > 0.1)
+        continue;
       pat::TriggerObjectStandAlone obj(triggerObject);
       obj.unpackPathNames(names);
       muon.addTriggerObjectMatch(obj);
@@ -288,44 +301,44 @@ void PATMuonProducer::fillHltTriggerInfo(pat::Muon& muon,
   }
 }
 
-
-void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
-   // get the tracking Geometry
-   edm::ESHandle<GlobalTrackingGeometry> geometry;
-   iSetup.get<GlobalTrackingGeometryRecord>().get(geometry);
-   if ( ! geometry.isValid() )
-     throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
+void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // get the tracking Geometry
+  edm::ESHandle<GlobalTrackingGeometry> geometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry);
+  if (!geometry.isValid())
+    throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
 
   // switch off embedding (in unschedules mode)
-  if (iEvent.isRealData()){
-    addGenMatch_   = false;
+  if (iEvent.isRealData()) {
+    addGenMatch_ = false;
     embedGenMatch_ = false;
   }
 
-  edm::Handle<edm::View<reco::Muon> > muons;
+  edm::Handle<edm::View<reco::Muon>> muons;
   iEvent.getByToken(muonToken_, muons);
 
-  
   edm::Handle<pat::PackedCandidateCollection> pc;
-  if(computeMiniIso_ || computePuppiCombinedIso_)
-      iEvent.getByToken(pcToken_, pc);
+  if (computeMiniIso_ || computePuppiCombinedIso_)
+    iEvent.getByToken(pcToken_, pc);
 
   // get the ESHandle for the transient track builder,
   // if needed for high level selection embedding
   edm::ESHandle<TransientTrackBuilder> trackBuilder;
 
-  if(isolator_.enabled()) isolator_.beginEvent(iEvent,iSetup);
-  if(efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if(resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (isolator_.enabled())
+    isolator_.beginEvent(iEvent, iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
   IsoDepositMaps deposits(isoDepositTokens_.size());
-  for (size_t j = 0; j<isoDepositTokens_.size(); ++j) {
+  for (size_t j = 0; j < isoDepositTokens_.size(); ++j) {
     iEvent.getByToken(isoDepositTokens_[j], deposits[j]);
   }
 
   IsolationValueMaps isolationValues(isolationValueTokens_.size());
-  for (size_t j = 0; j<isolationValueTokens_.size(); ++j) {
+  for (size_t j = 0; j < isolationValueTokens_.size(); ++j) {
     iEvent.getByToken(isolationValueTokens_[j], isolationValues[j]);
   }
 
@@ -337,15 +350,15 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons;
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons;
   edm::Handle<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons;
-  if(addPuppiIsolation_){
+  if (addPuppiIsolation_) {
     //puppi
     iEvent.getByToken(PUPPIIsolation_charged_hadrons_, PUPPIIsolation_charged_hadrons);
     iEvent.getByToken(PUPPIIsolation_neutral_hadrons_, PUPPIIsolation_neutral_hadrons);
-    iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);  
+    iEvent.getByToken(PUPPIIsolation_photons_, PUPPIIsolation_photons);
     //puppiNoLeptons
     iEvent.getByToken(PUPPINoLeptonsIsolation_charged_hadrons_, PUPPINoLeptonsIsolation_charged_hadrons);
     iEvent.getByToken(PUPPINoLeptonsIsolation_neutral_hadrons_, PUPPINoLeptonsIsolation_neutral_hadrons);
-    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);  
+    iEvent.getByToken(PUPPINoLeptonsIsolation_photons_, PUPPINoLeptonsIsolation_photons);
   }
 
   // inputs for muon mva
@@ -353,13 +366,13 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   edm::Handle<reco::JetCorrector> mvaL1Corrector;
   edm::Handle<reco::JetCorrector> mvaL1L2L3ResCorrector;
   if (computeMuonMVA_) {
-    iEvent.getByToken(mvaBTagCollectionTag_,mvaBTagCollectionTag);
-    iEvent.getByToken(mvaL1Corrector_,mvaL1Corrector);
-    iEvent.getByToken(mvaL1L2L3ResCorrector_,mvaL1L2L3ResCorrector);
+    iEvent.getByToken(mvaBTagCollectionTag_, mvaBTagCollectionTag);
+    iEvent.getByToken(mvaL1Corrector_, mvaL1Corrector);
+    iEvent.getByToken(mvaL1L2L3ResCorrector_, mvaL1L2L3ResCorrector);
   }
-  
+
   // prepare the MC genMatchTokens_
-  GenAssociations  genMatches(genMatchTokens_.size());
+  GenAssociations genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
     for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
       iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
@@ -372,173 +385,170 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   reco::BeamSpot beamSpot;
   bool beamSpotIsValid = false;
   bool primaryVertexIsValid = false;
-  if ( embedHighLevelSelection_ ) {
+  if (embedHighLevelSelection_) {
     // get the beamspot
     edm::Handle<reco::BeamSpot> beamSpotHandle;
     iEvent.getByToken(beamLineToken_, beamSpotHandle);
 
     // get the primary vertex
-    edm::Handle< std::vector<reco::Vertex> > pvHandle;
-    iEvent.getByToken( pvToken_, pvHandle );
+    edm::Handle<std::vector<reco::Vertex>> pvHandle;
+    iEvent.getByToken(pvToken_, pvHandle);
 
-    if( beamSpotHandle.isValid() ){
+    if (beamSpotHandle.isValid()) {
       beamSpot = *beamSpotHandle;
       beamSpotIsValid = true;
-    } else{
-      edm::LogError("DataNotAvailable")
-	<< "No beam spot available from EventSetup, not adding high level selection \n";
+    } else {
+      edm::LogError("DataNotAvailable") << "No beam spot available from EventSetup, not adding high level selection \n";
     }
-    if( pvHandle.isValid() && !pvHandle->empty() ) {
+    if (pvHandle.isValid() && !pvHandle->empty()) {
       primaryVertex = pvHandle->at(0);
       primaryVertexIsValid = true;
     } else {
       edm::LogError("DataNotAvailable")
-	<< "No primary vertex available from EventSetup, not adding high level selection \n";
+          << "No primary vertex available from EventSetup, not adding high level selection \n";
     }
     // this is needed by the IPTools methods from the tracking group
     iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
   }
 
   // MC info
-  edm::Handle<edm::ValueMap<reco::MuonSimInfo> > simInfo;
-  bool simInfoIsAvailalbe = iEvent.getByToken(simInfo_,simInfo);
+  edm::Handle<edm::ValueMap<reco::MuonSimInfo>> simInfo;
+  bool simInfoIsAvailalbe = iEvent.getByToken(simInfo_, simInfo);
 
   // this will be the new object collection
-  std::vector<Muon> * patMuons = new std::vector<Muon>();
+  std::vector<Muon>* patMuons = new std::vector<Muon>();
 
-  edm::Handle< reco::PFCandidateCollection >  pfMuons;
-  if( useParticleFlow_ ){
+  edm::Handle<reco::PFCandidateCollection> pfMuons;
+  if (useParticleFlow_) {
     // get the PFCandidates of type muons
     iEvent.getByToken(pfMuonToken_, pfMuons);
 
-    unsigned index=0;
-    for( reco::PFCandidateConstIterator i = pfMuons->begin(); i != pfMuons->end(); ++i, ++index) {
+    unsigned index = 0;
+    for (reco::PFCandidateConstIterator i = pfMuons->begin(); i != pfMuons->end(); ++i, ++index) {
       const reco::PFCandidate& pfmu = *i;
       //const reco::IsolaPFCandidate& pfmu = *i;
       const reco::MuonRef& muonRef = pfmu.muonRef();
-      assert( muonRef.isNonnull() );
+      assert(muonRef.isNonnull());
 
       MuonBaseRef muonBaseRef(muonRef);
       Muon aMuon(muonBaseRef);
 
-      if ( useUserData_ ) {
-	userDataHelper_.add( aMuon, iEvent, iSetup );
+      if (useUserData_) {
+        userDataHelper_.add(aMuon, iEvent, iSetup);
       }
 
       // embed high level selection
-      if ( embedHighLevelSelection_ ) {
-	// get the tracks
-	reco::TrackRef innerTrack = muonBaseRef->innerTrack();
-	reco::TrackRef globalTrack= muonBaseRef->globalTrack();
-	reco::TrackRef bestTrack  = muonBaseRef->muonBestTrack();
-	reco::TrackRef chosenTrack = innerTrack;
-	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() )
-	  chosenTrack = bestTrack;
+      if (embedHighLevelSelection_) {
+        // get the tracks
+        reco::TrackRef innerTrack = muonBaseRef->innerTrack();
+        reco::TrackRef globalTrack = muonBaseRef->globalTrack();
+        reco::TrackRef bestTrack = muonBaseRef->muonBestTrack();
+        reco::TrackRef chosenTrack = innerTrack;
+        // Make sure the collection it points to is there
+        if (bestTrack.isNonnull() && bestTrack.isAvailable())
+          chosenTrack = bestTrack;
 
-	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
-	  unsigned int nhits = chosenTrack->numberOfValidHits(); // ????
-	  aMuon.setNumberOfValidHits( nhits );
+        if (chosenTrack.isNonnull() && chosenTrack.isAvailable()) {
+          unsigned int nhits = chosenTrack->numberOfValidHits();  // ????
+          aMuon.setNumberOfValidHits(nhits);
 
-	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
-	  embedHighLevel( aMuon,
-			  chosenTrack,
-			  tt,
-			  primaryVertex,
-			  primaryVertexIsValid,
-			  beamSpot,
-			  beamSpotIsValid );
+          reco::TransientTrack tt = trackBuilder->build(chosenTrack);
+          embedHighLevel(aMuon, chosenTrack, tt, primaryVertex, primaryVertexIsValid, beamSpot, beamSpotIsValid);
+        }
 
-	}
-
-	if ( globalTrack.isNonnull() && globalTrack.isAvailable() && !embedCombinedMuon_) {
-	  double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
-	  aMuon.setNormChi2( norm_chi2 );
-	}
+        if (globalTrack.isNonnull() && globalTrack.isAvailable() && !embedCombinedMuon_) {
+          double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
+          aMuon.setNormChi2(norm_chi2);
+        }
       }
-      reco::PFCandidateRef pfRef(pfMuons,index);
+      reco::PFCandidateRef pfRef(pfMuons, index);
       //reco::PFCandidatePtr ptrToMother(pfMuons,index);
-      reco::CandidateBaseRef pfBaseRef( pfRef );
+      reco::CandidateBaseRef pfBaseRef(pfRef);
 
-      aMuon.setPFCandidateRef( pfRef  );
-      if( embedPFCandidate_ ) aMuon.embedPFCandidate();
-      fillMuon( aMuon, muonBaseRef, pfBaseRef, genMatches, deposits, isolationValues );
+      aMuon.setPFCandidateRef(pfRef);
+      if (embedPFCandidate_)
+        aMuon.embedPFCandidate();
+      fillMuon(aMuon, muonBaseRef, pfBaseRef, genMatches, deposits, isolationValues);
 
-      if(computeMiniIso_) 
-          setMuonMiniIso(aMuon, pc.product());
+      if (computeMiniIso_)
+        setMuonMiniIso(aMuon, pc.product());
 
       if (addPuppiIsolation_) {
-	aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonBaseRef],
-				(*PUPPIIsolation_neutral_hadrons)[muonBaseRef],
-				(*PUPPIIsolation_photons)[muonBaseRef]);
-	
-	aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonBaseRef],
-					 (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonBaseRef],
-					 (*PUPPINoLeptonsIsolation_photons)[muonBaseRef]);
+        aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonBaseRef],
+                                (*PUPPIIsolation_neutral_hadrons)[muonBaseRef],
+                                (*PUPPIIsolation_photons)[muonBaseRef]);
+
+        aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonBaseRef],
+                                         (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonBaseRef],
+                                         (*PUPPINoLeptonsIsolation_photons)[muonBaseRef]);
+      } else {
+        aMuon.setIsolationPUPPI(-999., -999., -999.);
+        aMuon.setIsolationPUPPINoLeptons(-999., -999., -999.);
       }
-      else {
-	aMuon.setIsolationPUPPI(-999., -999.,-999.);
-	aMuon.setIsolationPUPPINoLeptons(-999., -999.,-999.);
-      }
-      
+
       if (embedPfEcalEnergy_) {
         aMuon.setPfEcalEnergy(pfmu.ecalEnergy());
       }
 
       patMuons->push_back(aMuon);
     }
-  }
-  else {
-    edm::Handle<edm::View<reco::Muon> > muons;
+  } else {
+    edm::Handle<edm::View<reco::Muon>> muons;
     iEvent.getByToken(muonToken_, muons);
 
     // embedding of muon MET corrections
-    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > caloMETMuonCorrs;
+    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData>> caloMETMuonCorrs;
     //edm::ValueMap<reco::MuonMETCorrectionData> caloMETmuCorValueMap;
-    if(embedCaloMETMuonCorrs_){
+    if (embedCaloMETMuonCorrs_) {
       iEvent.getByToken(caloMETMuonCorrsToken_, caloMETMuonCorrs);
       //caloMETmuCorValueMap  = *caloMETmuCorValueMap_h;
     }
-    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > tcMETMuonCorrs;
+    edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData>> tcMETMuonCorrs;
     //edm::ValueMap<reco::MuonMETCorrectionData> tcMETmuCorValueMap;
-    if(embedTcMETMuonCorrs_) {
+    if (embedTcMETMuonCorrs_) {
       iEvent.getByToken(tcMETMuonCorrsToken_, tcMETMuonCorrs);
       //tcMETmuCorValueMap  = *tcMETmuCorValueMap_h;
     }
 
     if (embedPfEcalEnergy_) {
-        // get the PFCandidates of type muons
-        iEvent.getByToken(pfMuonToken_, pfMuons);
+      // get the PFCandidates of type muons
+      iEvent.getByToken(pfMuonToken_, pfMuons);
     }
 
     for (edm::View<reco::Muon>::const_iterator itMuon = muons->begin(); itMuon != muons->end(); ++itMuon) {
       // construct the Muon from the ref -> save ref to original object
       unsigned int idx = itMuon - muons->begin();
       MuonBaseRef muonRef = muons->refAt(idx);
-      reco::CandidateBaseRef muonBaseRef( muonRef );
+      reco::CandidateBaseRef muonBaseRef(muonRef);
 
       Muon aMuon(muonRef);
-      fillMuon( aMuon, muonRef, muonBaseRef, genMatches, deposits, isolationValues);
-      if(computeMiniIso_)
-          setMuonMiniIso(aMuon, pc.product());
+      fillMuon(aMuon, muonRef, muonBaseRef, genMatches, deposits, isolationValues);
+      if (computeMiniIso_)
+        setMuonMiniIso(aMuon, pc.product());
       if (addPuppiIsolation_) {
-	aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonRef], (*PUPPIIsolation_neutral_hadrons)[muonRef], (*PUPPIIsolation_photons)[muonRef]);
-	aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonRef], (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonRef], (*PUPPINoLeptonsIsolation_photons)[muonRef]);
-      }
-      else {
-	aMuon.setIsolationPUPPI(-999., -999.,-999.);
-	aMuon.setIsolationPUPPINoLeptons(-999., -999.,-999.);
+        aMuon.setIsolationPUPPI((*PUPPIIsolation_charged_hadrons)[muonRef],
+                                (*PUPPIIsolation_neutral_hadrons)[muonRef],
+                                (*PUPPIIsolation_photons)[muonRef]);
+        aMuon.setIsolationPUPPINoLeptons((*PUPPINoLeptonsIsolation_charged_hadrons)[muonRef],
+                                         (*PUPPINoLeptonsIsolation_neutral_hadrons)[muonRef],
+                                         (*PUPPINoLeptonsIsolation_photons)[muonRef]);
+      } else {
+        aMuon.setIsolationPUPPI(-999., -999., -999.);
+        aMuon.setIsolationPUPPINoLeptons(-999., -999., -999.);
       }
 
       // Isolation
       if (isolator_.enabled()) {
-	//reco::CandidatePtr mother =  ptrToMother->sourceCandidatePtr(0);
-	isolator_.fill(*muons, idx, isolatorTmpStorage_);
-	typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
-	// better to loop backwards, so the vector is resized less times
-	for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(), ed = isolatorTmpStorage_.rend(); it != ed; ++it) {
-	  aMuon.setIsolation(it->first, it->second);
-	}
+        //reco::CandidatePtr mother =  ptrToMother->sourceCandidatePtr(0);
+        isolator_.fill(*muons, idx, isolatorTmpStorage_);
+        typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
+        // better to loop backwards, so the vector is resized less times
+        for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(),
+                                                         ed = isolatorTmpStorage_.rend();
+             it != ed;
+             ++it) {
+          aMuon.setIsolation(it->first, it->second);
+        }
       }
 
       //       for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
@@ -548,74 +558,71 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
       // add sel to selected
       edm::Ptr<reco::Muon> muonsPtr = muons->ptrAt(idx);
-      if ( useUserData_ ) {
-	userDataHelper_.add( aMuon, iEvent, iSetup );
+      if (useUserData_) {
+        userDataHelper_.add(aMuon, iEvent, iSetup);
       }
 
       // embed high level selection
-      if ( embedHighLevelSelection_ ) {
-	// get the tracks
-	reco::TrackRef innerTrack = itMuon->innerTrack();
-	reco::TrackRef globalTrack= itMuon->globalTrack();
-	reco::TrackRef bestTrack  = itMuon->muonBestTrack();
-	reco::TrackRef chosenTrack = innerTrack;
-	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() )
-	  chosenTrack = bestTrack;
-	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
-	  unsigned int nhits = chosenTrack->numberOfValidHits(); // ????
-	  aMuon.setNumberOfValidHits( nhits );
+      if (embedHighLevelSelection_) {
+        // get the tracks
+        reco::TrackRef innerTrack = itMuon->innerTrack();
+        reco::TrackRef globalTrack = itMuon->globalTrack();
+        reco::TrackRef bestTrack = itMuon->muonBestTrack();
+        reco::TrackRef chosenTrack = innerTrack;
+        // Make sure the collection it points to is there
+        if (bestTrack.isNonnull() && bestTrack.isAvailable())
+          chosenTrack = bestTrack;
+        if (chosenTrack.isNonnull() && chosenTrack.isAvailable()) {
+          unsigned int nhits = chosenTrack->numberOfValidHits();  // ????
+          aMuon.setNumberOfValidHits(nhits);
 
-	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
-	  embedHighLevel( aMuon,
-			  chosenTrack,
-			  tt,
-			  primaryVertex,
-			  primaryVertexIsValid,
-			  beamSpot,
-			  beamSpotIsValid );
+          reco::TransientTrack tt = trackBuilder->build(chosenTrack);
+          embedHighLevel(aMuon, chosenTrack, tt, primaryVertex, primaryVertexIsValid, beamSpot, beamSpotIsValid);
+        }
 
-	}
-
-	if ( globalTrack.isNonnull() && globalTrack.isAvailable() ) {
-	  double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
-	  aMuon.setNormChi2( norm_chi2 );
-	}
+        if (globalTrack.isNonnull() && globalTrack.isAvailable()) {
+          double norm_chi2 = globalTrack->chi2() / globalTrack->ndof();
+          aMuon.setNormChi2(norm_chi2);
+        }
       }
 
       // embed MET muon corrections
-      if( embedCaloMETMuonCorrs_ ) aMuon.embedCaloMETMuonCorrs((*caloMETMuonCorrs)[muonRef]);
-      if( embedTcMETMuonCorrs_ ) aMuon.embedTcMETMuonCorrs((*tcMETMuonCorrs  )[muonRef]);
+      if (embedCaloMETMuonCorrs_)
+        aMuon.embedCaloMETMuonCorrs((*caloMETMuonCorrs)[muonRef]);
+      if (embedTcMETMuonCorrs_)
+        aMuon.embedTcMETMuonCorrs((*tcMETMuonCorrs)[muonRef]);
 
       if (embedPfEcalEnergy_) {
-          aMuon.setPfEcalEnergy(-99.0);
-          for (const reco::PFCandidate &pfmu : *pfMuons) {
-              if (pfmu.muonRef().isNonnull()) {
-                  if (pfmu.muonRef().id() != muonRef.id()) throw cms::Exception("Configuration") << "Muon reference within PF candidates does not point to the muon collection." << std::endl;
-                  if (pfmu.muonRef().key() == muonRef.key()) {
-                      aMuon.setPfEcalEnergy(pfmu.ecalEnergy());
-                  }
-              } 
+        aMuon.setPfEcalEnergy(-99.0);
+        for (const reco::PFCandidate& pfmu : *pfMuons) {
+          if (pfmu.muonRef().isNonnull()) {
+            if (pfmu.muonRef().id() != muonRef.id())
+              throw cms::Exception("Configuration")
+                  << "Muon reference within PF candidates does not point to the muon collection." << std::endl;
+            if (pfmu.muonRef().key() == muonRef.key()) {
+              aMuon.setPfEcalEnergy(pfmu.ecalEnergy());
+            }
           }
+        }
       }
       // MC info
       aMuon.initSimInfo();
-      if (simInfoIsAvailalbe){
-	const auto& msi = (*simInfo)[muonBaseRef];
-	aMuon.setSimType(msi.primaryClass);
-	aMuon.setExtSimType(msi.extendedClass);
-	aMuon.setSimFlavour(msi.flavour);
-	aMuon.setSimHeaviestMotherFlavour(msi.heaviestMotherFlavour);
-	aMuon.setSimPdgId(msi.pdgId);
-	aMuon.setSimMotherPdgId(msi.motherPdgId);
-	aMuon.setSimBX(msi.tpBX);
-	aMuon.setSimTpEvent(msi.tpEvent);
-	aMuon.setSimProdRho(msi.vertex.Rho());
-	aMuon.setSimProdZ(msi.vertex.Z());
-	aMuon.setSimPt(msi.p4.pt());
-	aMuon.setSimEta(msi.p4.eta());
-	aMuon.setSimPhi(msi.p4.phi());
-	aMuon.setSimMatchQuality(msi.tpAssoQuality);
+      if (simInfoIsAvailalbe) {
+        const auto& msi = (*simInfo)[muonBaseRef];
+        aMuon.setSimType(msi.primaryClass);
+        aMuon.setExtSimType(msi.extendedClass);
+        aMuon.setSimFlavour(msi.flavour);
+        aMuon.setSimHeaviestMotherFlavour(msi.heaviestMotherFlavour);
+        aMuon.setSimPdgId(msi.pdgId);
+        aMuon.setSimMotherPdgId(msi.motherPdgId);
+        aMuon.setSimBX(msi.tpBX);
+        aMuon.setSimTpEvent(msi.tpEvent);
+        aMuon.setSimProdRho(msi.vertex.Rho());
+        aMuon.setSimProdZ(msi.vertex.Z());
+        aMuon.setSimPt(msi.p4.pt());
+        aMuon.setSimEta(msi.p4.eta());
+        aMuon.setSimPhi(msi.p4.phi());
+        aMuon.setSimMatchQuality(msi.tpAssoQuality);
       }
       patMuons->push_back(aMuon);
     }
@@ -624,97 +631,87 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   // sort muons in pt
   std::sort(patMuons->begin(), patMuons->end(), pTComparator_);
 
-  // Store standard muon selection decisions and jet related 
+  // Store standard muon selection decisions and jet related
   // quantaties.
   // Need a separate loop over muons to have all inputs properly
   // computed and stored in the object.
   edm::Handle<double> rho;
-  if (computeMuonMVA_) iEvent.getByToken(rho_,rho);
+  if (computeMuonMVA_)
+    iEvent.getByToken(rho_, rho);
   const reco::Vertex* pv(nullptr);
-  if (primaryVertexIsValid) pv = &primaryVertex;
+  if (primaryVertexIsValid)
+    pv = &primaryVertex;
 
-  edm::Handle<std::vector<pat::TriggerObjectStandAlone> > triggerObjects;
-  edm::Handle< edm::TriggerResults > triggerResults;
+  edm::Handle<std::vector<pat::TriggerObjectStandAlone>> triggerObjects;
+  edm::Handle<edm::TriggerResults> triggerResults;
   bool triggerObjectsAvailable = false;
   bool triggerResultsAvailable = false;
-  if (addTriggerMatching_){
+  if (addTriggerMatching_) {
     triggerObjectsAvailable = iEvent.getByToken(triggerObjects_, triggerObjects);
     triggerResultsAvailable = iEvent.getByToken(triggerResults_, triggerResults);
   }
 
-  for(auto& muon: *patMuons){
+  for (auto& muon : *patMuons) {
     // trigger info
-    if (addTriggerMatching_ and triggerObjectsAvailable and triggerResultsAvailable){
-      const edm::TriggerNames & triggerNames(iEvent.triggerNames( *triggerResults ));
-      fillL1TriggerInfo(muon,triggerObjects,triggerNames,geometry);
-      fillHltTriggerInfo(muon,triggerObjects,triggerNames,hltCollectionFilters_);
+    if (addTriggerMatching_ and triggerObjectsAvailable and triggerResultsAvailable) {
+      const edm::TriggerNames& triggerNames(iEvent.triggerNames(*triggerResults));
+      fillL1TriggerInfo(muon, triggerObjects, triggerNames, geometry);
+      fillHltTriggerInfo(muon, triggerObjects, triggerNames, hltCollectionFilters_);
     }
 
-    if (recomputeBasicSelectors_){
+    if (recomputeBasicSelectors_) {
       muon.setSelectors(0);
       bool isRun2016BCDEF = (272728 <= iEvent.run() && iEvent.run() <= 278808);
       muon.setSelectors(muon::makeSelectorBitset(muon, pv, isRun2016BCDEF));
     }
     float miniIsoValue = -1;
-    if (computeMiniIso_){
+    if (computeMiniIso_) {
       // MiniIsolation working points
 
-      miniIsoValue = getRelMiniIsoPUCorrected(muon,*rho, effectiveAreaVec_);
+      miniIsoValue = getRelMiniIsoPUCorrected(muon, *rho, effectiveAreaVec_);
 
-      muon.setSelector(reco::Muon::MiniIsoLoose,     miniIsoValue<0.40);
-      muon.setSelector(reco::Muon::MiniIsoMedium,    miniIsoValue<0.20);
-      muon.setSelector(reco::Muon::MiniIsoTight,     miniIsoValue<0.10);
-      muon.setSelector(reco::Muon::MiniIsoVeryTight, miniIsoValue<0.05);
+      muon.setSelector(reco::Muon::MiniIsoLoose, miniIsoValue < 0.40);
+      muon.setSelector(reco::Muon::MiniIsoMedium, miniIsoValue < 0.20);
+      muon.setSelector(reco::Muon::MiniIsoTight, miniIsoValue < 0.10);
+      muon.setSelector(reco::Muon::MiniIsoVeryTight, miniIsoValue < 0.05);
     }
 
     double puppiCombinedIsolationPAT = -1;
-    if(computePuppiCombinedIso_){
-
-      puppiCombinedIsolationPAT=puppiCombinedIsolation(muon, pc.product());
-      muon.setSelector(reco::Muon::PuppiIsoLoose, puppiCombinedIsolationPAT<0.27);
-      muon.setSelector(reco::Muon::PuppiIsoMedium, puppiCombinedIsolationPAT<0.22);
-      muon.setSelector(reco::Muon::PuppiIsoTight, puppiCombinedIsolationPAT<0.12);
+    if (computePuppiCombinedIso_) {
+      puppiCombinedIsolationPAT = puppiCombinedIsolation(muon, pc.product());
+      muon.setSelector(reco::Muon::PuppiIsoLoose, puppiCombinedIsolationPAT < 0.27);
+      muon.setSelector(reco::Muon::PuppiIsoMedium, puppiCombinedIsolationPAT < 0.22);
+      muon.setSelector(reco::Muon::PuppiIsoTight, puppiCombinedIsolationPAT < 0.12);
     }
 
     float jetPtRatio = 0.0;
     float jetPtRel = 0.0;
     float mva = 0.0;
     float mva_lowpt = 0.0;
-    if (computeMuonMVA_ && primaryVertexIsValid && computeMiniIso_){
-      if (mvaUseJec_){
+    if (computeMuonMVA_ && primaryVertexIsValid && computeMiniIso_) {
+      if (mvaUseJec_) {
         mva = globalCache()->muonMvaEstimator()->computeMva(muon,
                                                             primaryVertex,
                                                             *(mvaBTagCollectionTag.product()),
                                                             jetPtRatio,
                                                             jetPtRel,
-							    miniIsoValue,
+                                                            miniIsoValue,
                                                             &*mvaL1Corrector,
-                                                            &*mvaL1L2L3ResCorrector
-							    );
+                                                            &*mvaL1L2L3ResCorrector);
         mva_lowpt = globalCache()->muonLowPtMvaEstimator()->computeMva(muon,
-								       primaryVertex,
-								       *(mvaBTagCollectionTag.product()),
-								       jetPtRatio,
-								       jetPtRel,
-								       miniIsoValue,
-								       &*mvaL1Corrector,
-								       &*mvaL1L2L3ResCorrector
-								       );
-	
-      }
-      else{
-	mva = globalCache()->muonMvaEstimator()->computeMva(muon,
-                                                            primaryVertex,
-                                                            *(mvaBTagCollectionTag.product()),
-                                                            jetPtRatio,
-                                                            jetPtRel,
-							    miniIsoValue);
-	mva_lowpt = globalCache()->muonLowPtMvaEstimator()->computeMva(muon,
-								       primaryVertex,
-								       *(mvaBTagCollectionTag.product()),
-								       jetPtRatio,
-								       jetPtRel,
-								       miniIsoValue);
+                                                                       primaryVertex,
+                                                                       *(mvaBTagCollectionTag.product()),
+                                                                       jetPtRatio,
+                                                                       jetPtRel,
+                                                                       miniIsoValue,
+                                                                       &*mvaL1Corrector,
+                                                                       &*mvaL1L2L3ResCorrector);
+
+      } else {
+        mva = globalCache()->muonMvaEstimator()->computeMva(
+            muon, primaryVertex, *(mvaBTagCollectionTag.product()), jetPtRatio, jetPtRel, miniIsoValue);
+        mva_lowpt = globalCache()->muonLowPtMvaEstimator()->computeMva(
+            muon, primaryVertex, *(mvaBTagCollectionTag.product()), jetPtRatio, jetPtRel, miniIsoValue);
       }
 
       muon.setMvaValue(mva);
@@ -723,65 +720,70 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
       muon.setJetPtRel(jetPtRel);
 
       // multi-isolation
-      if (computeMiniIso_){
-	muon.setSelector(reco::Muon::MultiIsoMedium, miniIsoValue<0.11 && (muon.jetPtRatio() > 0.74 || muon.jetPtRel() > 6.8) );
+      if (computeMiniIso_) {
+        muon.setSelector(reco::Muon::MultiIsoMedium,
+                         miniIsoValue < 0.11 && (muon.jetPtRatio() > 0.74 || muon.jetPtRel() > 6.8));
       }
 
       // MVA working points
       // https://twiki.cern.ch/twiki/bin/viewauth/CMS/LeptonMVA
-      double dB2D  = fabs(muon.dB(pat::Muon::PV2D));
-      double dB3D  = fabs(muon.dB(pat::Muon::PV3D));
+      double dB2D = fabs(muon.dB(pat::Muon::PV2D));
+      double dB3D = fabs(muon.dB(pat::Muon::PV3D));
       double edB3D = fabs(muon.edB(pat::Muon::PV3D));
-      double sip3D = edB3D>0?dB3D/edB3D:0.0; 
+      double sip3D = edB3D > 0 ? dB3D / edB3D : 0.0;
       double dz = fabs(muon.muonBestTrack()->dz(primaryVertex.position()));
 
       // muon preselection
-      if (muon.pt()>5 and muon.isLooseMuon() and
-	  muon.passed(reco::Muon::MiniIsoLoose) and 
-	  sip3D<8.0 and dB2D<0.05 and dz<0.1){
-	muon.setSelector(reco::Muon::MvaLoose,  muon.mvaValue()>-0.60);
-	muon.setSelector(reco::Muon::MvaMedium, muon.mvaValue()>-0.20);
-	muon.setSelector(reco::Muon::MvaTight,  muon.mvaValue()> 0.15);
-	muon.setSelector(reco::Muon::MvaVTight,  muon.mvaValue()> 0.45);
-	muon.setSelector(reco::Muon::MvaVVTight,  muon.mvaValue()> 0.9);
+      if (muon.pt() > 5 and muon.isLooseMuon() and muon.passed(reco::Muon::MiniIsoLoose) and sip3D < 8.0 and
+          dB2D < 0.05 and dz < 0.1) {
+        muon.setSelector(reco::Muon::MvaLoose, muon.mvaValue() > -0.60);
+        muon.setSelector(reco::Muon::MvaMedium, muon.mvaValue() > -0.20);
+        muon.setSelector(reco::Muon::MvaTight, muon.mvaValue() > 0.15);
+        muon.setSelector(reco::Muon::MvaVTight, muon.mvaValue() > 0.45);
+        muon.setSelector(reco::Muon::MvaVVTight, muon.mvaValue() > 0.9);
       }
-      if (muon.pt()>5 and muon.isLooseMuon() and
-	  sip3D<4 and dB2D < 0.5 and dz < 1){
-	muon.setSelector(reco::Muon::LowPtMvaLoose,  muon.lowptMvaValue()>-0.60);
-	muon.setSelector(reco::Muon::LowPtMvaMedium, muon.lowptMvaValue()>-0.20);
+      if (muon.pt() > 5 and muon.isLooseMuon() and sip3D < 4 and dB2D < 0.5 and dz < 1) {
+        muon.setSelector(reco::Muon::LowPtMvaLoose, muon.lowptMvaValue() > -0.60);
+        muon.setSelector(reco::Muon::LowPtMvaMedium, muon.lowptMvaValue() > -0.20);
       }
     }
-    
+
     //SOFT MVA
-    if (computeSoftMuonMVA_){
+    if (computeSoftMuonMVA_) {
       float mva = globalCache()->softMuonMvaEstimator()->computeMva(muon);
       muon.setSoftMvaValue(mva);
       //preselection in SoftMuonMvaEstimator.cc
-      muon.setSelector(reco::Muon::SoftMvaId,  muon.softMvaValue() >   0.58  ); //WP choose for bmm4
-      
+      muon.setSelector(reco::Muon::SoftMvaId, muon.softMvaValue() > 0.58);  //WP choose for bmm4
     }
   }
 
   // put products in Event
-  std::unique_ptr<std::vector<Muon> > ptr(patMuons);
+  std::unique_ptr<std::vector<Muon>> ptr(patMuons);
   iEvent.put(std::move(ptr));
 
-  if (isolator_.enabled()) isolator_.endEvent();
+  if (isolator_.enabled())
+    isolator_.endEvent();
 }
 
-
-void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const reco::CandidateBaseRef& baseRef, const GenAssociations& genMatches, const IsoDepositMaps& deposits, const IsolationValueMaps& isolationValues ) const
-{
+void PATMuonProducer::fillMuon(Muon& aMuon,
+                               const MuonBaseRef& muonRef,
+                               const reco::CandidateBaseRef& baseRef,
+                               const GenAssociations& genMatches,
+                               const IsoDepositMaps& deposits,
+                               const IsolationValueMaps& isolationValues) const {
   // in the particle flow algorithm,
   // the muon momentum is recomputed.
   // the new value is stored as the momentum of the
   // resulting PFCandidate of type Muon, and choosen
   // as the pat::Muon momentum
   if (useParticleFlow_)
-    aMuon.setP4( aMuon.pfCandidateRef()->p4() );
-  if (embedTrack_)          aMuon.embedTrack();
-  if (embedStandAloneMuon_) aMuon.embedStandAloneMuon();
-  if (embedCombinedMuon_)   aMuon.embedCombinedMuon();
+    aMuon.setP4(aMuon.pfCandidateRef()->p4());
+  if (embedTrack_)
+    aMuon.embedTrack();
+  if (embedStandAloneMuon_)
+    aMuon.embedStandAloneMuon();
+  if (embedCombinedMuon_)
+    aMuon.embedCombinedMuon();
 
   // embed the TeV refit track refs (only available for globalMuons)
   if (aMuon.isGlobalMuon()) {
@@ -794,49 +796,50 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
   }
 
   // embed best tracks (at the end, so unless forceEmbedBestTrack_ is true we can save some space not embedding them twice)
-  if (embedBestTrack_)      aMuon.embedMuonBestTrack(forceEmbedBestTrack_);
-  if (embedTunePBestTrack_)      aMuon.embedTunePMuonBestTrack(forceEmbedBestTrack_);
+  if (embedBestTrack_)
+    aMuon.embedMuonBestTrack(forceEmbedBestTrack_);
+  if (embedTunePBestTrack_)
+    aMuon.embedTunePMuonBestTrack(forceEmbedBestTrack_);
 
   // store the match to the generated final state muons
   if (addGenMatch_) {
-    for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
+    for (size_t i = 0, n = genMatches.size(); i < n; ++i) {
       reco::GenParticleRef genMuon = (*genMatches[i])[baseRef];
       aMuon.addGenParticleRef(genMuon);
     }
-    if (embedGenMatch_) aMuon.embedGenParticle();
+    if (embedGenMatch_)
+      aMuon.embedGenParticle();
   }
   if (efficiencyLoader_.enabled()) {
-    efficiencyLoader_.setEfficiencies( aMuon, muonRef );
+    efficiencyLoader_.setEfficiencies(aMuon, muonRef);
   }
 
   for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-    if(useParticleFlow_) {
+    if (useParticleFlow_) {
       if (deposits[j]->contains(baseRef.id())) {
-	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[baseRef]);
-      } else if (deposits[j]->contains(muonRef.id())){
-	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
+        aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[baseRef]);
+      } else if (deposits[j]->contains(muonRef.id())) {
+        aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
       } else {
-	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
-	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[source]);
+        reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
+        aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[source]);
       }
-    }
-    else{
+    } else {
       aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
     }
   }
 
-  for (size_t j = 0; j<isolationValues.size(); ++j) {
-    if(useParticleFlow_) {
+  for (size_t j = 0; j < isolationValues.size(); ++j) {
+    if (useParticleFlow_) {
       if (isolationValues[j]->contains(baseRef.id())) {
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[baseRef]);
+        aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[baseRef]);
       } else if (isolationValues[j]->contains(muonRef.id())) {
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
+        aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
       } else {
-	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[source]);
+        reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
+        aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[source]);
       }
-    }
-    else{
+    } else {
       aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
     }
   }
@@ -846,90 +849,85 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
   }
 }
 
-void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollection *pc)
-{
-  pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc, aMuon.p4(),
-                                                     miniIsoParams_[0], miniIsoParams_[1], miniIsoParams_[2],
-                                                     miniIsoParams_[3], miniIsoParams_[4], miniIsoParams_[5],
-                                                     miniIsoParams_[6], miniIsoParams_[7], miniIsoParams_[8]);
+void PATMuonProducer::setMuonMiniIso(Muon& aMuon, const PackedCandidateCollection* pc) {
+  pat::PFIsolation miniiso = pat::getMiniPFIsolation(pc,
+                                                     aMuon.p4(),
+                                                     miniIsoParams_[0],
+                                                     miniIsoParams_[1],
+                                                     miniIsoParams_[2],
+                                                     miniIsoParams_[3],
+                                                     miniIsoParams_[4],
+                                                     miniIsoParams_[5],
+                                                     miniIsoParams_[6],
+                                                     miniIsoParams_[7],
+                                                     miniIsoParams_[8]);
   aMuon.setMiniPFIsolation(miniiso);
 }
 
-double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double> &area)
-{
+double PATMuonProducer::getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double>& area) {
   double mindr(miniIsoParams_[0]);
   double maxdr(miniIsoParams_[1]);
   double kt_scale(miniIsoParams_[2]);
-  double drcut = pat::miniIsoDr(muon.p4(),mindr,maxdr,kt_scale);
+  double drcut = pat::miniIsoDr(muon.p4(), mindr, maxdr, kt_scale);
   return pat::muonRelMiniIsoPUCorrected(muon.miniPFIsolation(), muon.p4(), drcut, rho, area);
 }
 
-
-double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc)
-{
+double PATMuonProducer::puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection* pc) {
   double dR_threshold = 0.4;
   double dR2_threshold = dR_threshold * dR_threshold;
   double mix_fraction = 0.5;
-  enum particleType{
-      CH = 0,
-      NH = 1,
-      PH = 2,
-      OTHER = 100000
-    };
+  enum particleType { CH = 0, NH = 1, PH = 2, OTHER = 100000 };
   double val_PuppiWithLep = 0.0;
-  double val_PuppiWithoutLep = 0.0;  
+  double val_PuppiWithoutLep = 0.0;
 
-  for(const auto & cand : *pc){//pat::pat::PackedCandidate loop start
+  for (const auto& cand : *pc) {  //pat::pat::PackedCandidate loop start
 
-     const particleType pType =
-        isChargedHadron( cand.pdgId() ) ? CH :
-        isNeutralHadron( cand.pdgId() ) ? NH :
-        isPhoton( cand.pdgId() ) ? PH : OTHER;
-     if( pType == OTHER ){
-        if( cand.pdgId() != 1 && cand.pdgId() != 2
-        && abs( cand.pdgId() ) != 11
-        && abs( cand.pdgId() ) != 13){
-        LogTrace("PATMuonProducer") <<"candidate with PDGID = " << cand.pdgId() << " is not CH/NH/PH/e/mu or 1/2 (and this is removed from isolation calculation)" << std::endl;
-       }
-       continue;
-     }
-     double d_eta = std::abs( cand.eta() - muon.eta() );
-     if( d_eta > dR_threshold ) continue;
+    const particleType pType =
+        isChargedHadron(cand.pdgId()) ? CH : isNeutralHadron(cand.pdgId()) ? NH : isPhoton(cand.pdgId()) ? PH : OTHER;
+    if (pType == OTHER) {
+      if (cand.pdgId() != 1 && cand.pdgId() != 2 && abs(cand.pdgId()) != 11 && abs(cand.pdgId()) != 13) {
+        LogTrace("PATMuonProducer") << "candidate with PDGID = " << cand.pdgId()
+                                    << " is not CH/NH/PH/e/mu or 1/2 (and this is removed from isolation calculation)"
+                                    << std::endl;
+      }
+      continue;
+    }
+    double d_eta = std::abs(cand.eta() - muon.eta());
+    if (d_eta > dR_threshold)
+      continue;
 
-     double d_phi = std::abs(reco::deltaPhi(cand.phi(),muon.phi()));
-     if( d_phi > dR_threshold ) continue ;
+    double d_phi = std::abs(reco::deltaPhi(cand.phi(), muon.phi()));
+    if (d_phi > dR_threshold)
+      continue;
 
-     double dR2=reco::deltaR2(cand, muon);
-     if( dR2  > dR2_threshold ) continue;
-     if( pType == CH && dR2 < 0.0001*0.0001 ) continue;
-     if( pType == NH && dR2 < 0.01  *0.01   ) continue;
-     if( pType == PH && dR2 < 0.01  *0.01   ) continue;
-     val_PuppiWithLep += cand.pt() * cand.puppiWeight();
-     val_PuppiWithoutLep += cand.pt() * cand.puppiWeightNoLep();
+    double dR2 = reco::deltaR2(cand, muon);
+    if (dR2 > dR2_threshold)
+      continue;
+    if (pType == CH && dR2 < 0.0001 * 0.0001)
+      continue;
+    if (pType == NH && dR2 < 0.01 * 0.01)
+      continue;
+    if (pType == PH && dR2 < 0.01 * 0.01)
+      continue;
+    val_PuppiWithLep += cand.pt() * cand.puppiWeight();
+    val_PuppiWithoutLep += cand.pt() * cand.puppiWeightNoLep();
 
-  }//pat::pat::PackedCandidate loop end
+  }  //pat::pat::PackedCandidate loop end
 
-  double reliso_Puppi_withLep    = val_PuppiWithLep/muon.pt();
-  double reliso_Puppi_withoutlep = val_PuppiWithoutLep/muon.pt();
-  double reliso_Puppi_combined = mix_fraction * reliso_Puppi_withLep + ( 1.0 - mix_fraction) * reliso_Puppi_withoutlep;
+  double reliso_Puppi_withLep = val_PuppiWithLep / muon.pt();
+  double reliso_Puppi_withoutlep = val_PuppiWithoutLep / muon.pt();
+  double reliso_Puppi_combined = mix_fraction * reliso_Puppi_withLep + (1.0 - mix_fraction) * reliso_Puppi_withoutlep;
   return reliso_Puppi_combined;
 }
 
-bool PATMuonProducer::isNeutralHadron( long pdgid ){
- return std::abs(pdgid) == 130;
-}
+bool PATMuonProducer::isNeutralHadron(long pdgid) { return std::abs(pdgid) == 130; }
 
-bool PATMuonProducer::isChargedHadron( long pdgid ){
- return std::abs(pdgid) == 211;
-}
+bool PATMuonProducer::isChargedHadron(long pdgid) { return std::abs(pdgid) == 211; }
 
-bool PATMuonProducer::isPhoton( long pdgid ){
- return pdgid==22;
-}
+bool PATMuonProducer::isPhoton(long pdgid) { return pdgid == 22; }
 
 // ParameterSet description for module
-void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT muon producer module");
 
@@ -937,9 +935,12 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.add<edm::InputTag>("muonSource", edm::InputTag("no default"))->setComment("input collection");
 
   // embedding
-  iDesc.add<bool>("embedMuonBestTrack",      true)->setComment("embed muon best track (global pflow)");
+  iDesc.add<bool>("embedMuonBestTrack", true)->setComment("embed muon best track (global pflow)");
   iDesc.add<bool>("embedTunePMuonBestTrack", true)->setComment("embed muon best track (muon only)");
-  iDesc.add<bool>("forceBestTrackEmbedding", true)->setComment("force embedding separately the best tracks even if they're already embedded e.g. as tracker or global tracks");
+  iDesc.add<bool>("forceBestTrackEmbedding", true)
+      ->setComment(
+          "force embedding separately the best tracks even if they're already embedded e.g. as tracker or global "
+          "tracks");
   iDesc.add<bool>("embedTrack", true)->setComment("embed external track");
   iDesc.add<bool>("embedStandAloneMuon", true)->setComment("embed external stand-alone muon");
   iDesc.add<bool>("embedCombinedMuon", false)->setComment("embed external combined muon");
@@ -949,9 +950,11 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
 
   // embedding of MET muon corrections
   iDesc.add<bool>("embedCaloMETMuonCorrs", true)->setComment("whether to add MET muon correction for caloMET or not");
-  iDesc.add<edm::InputTag>("caloMETMuonCorrs", edm::InputTag("muonMETValueMapProducer"  , "muCorrData"))->setComment("source of MET muon corrections for caloMET");
+  iDesc.add<edm::InputTag>("caloMETMuonCorrs", edm::InputTag("muonMETValueMapProducer", "muCorrData"))
+      ->setComment("source of MET muon corrections for caloMET");
   iDesc.add<bool>("embedTcMETMuonCorrs", true)->setComment("whether to add MET muon correction for tcMET or not");
-  iDesc.add<edm::InputTag>("tcMETMuonCorrs", edm::InputTag("muonTCMETValueMapProducer"  , "muCorrData"))->setComment("source of MET muon corrections for tcMET");
+  iDesc.add<edm::InputTag>("tcMETMuonCorrs", edm::InputTag("muonTCMETValueMapProducer", "muCorrData"))
+      ->setComment("source of MET muon corrections for tcMET");
 
   // pf specific parameters
   iDesc.add<edm::InputTag>("pfMuonSource", edm::InputTag("pfMuons"))->setComment("particle flow input collection");
@@ -963,16 +966,20 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");
   iDesc.add<bool>("embedGenMatch", false)->setComment("embed MC matched MC information");
   std::vector<edm::InputTag> emptySourceVector;
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
-                 edm::ParameterDescription<std::vector<edm::InputTag> >("genParticleMatch", emptySourceVector, true)
-		 )->setComment("input with MC match information");
+  iDesc
+      .addNode(edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
+               edm::ParameterDescription<std::vector<edm::InputTag>>("genParticleMatch", emptySourceVector, true))
+      ->setComment("input with MC match information");
 
   // mini-iso
   iDesc.add<bool>("computeMiniIso", false)->setComment("whether or not to compute and store electron mini-isolation");
-  iDesc.add<bool>("computePuppiCombinedIso",false)->setComment("whether or not to compute and store puppi combined isolation");
+  iDesc.add<bool>("computePuppiCombinedIso", false)
+      ->setComment("whether or not to compute and store puppi combined isolation");
 
-  iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))->setComment("collection to use to compute mini-iso");
-  iDesc.add<std::vector<double> >("miniIsoParams", std::vector<double>())->setComment("mini-iso parameters to use for muons");
+  iDesc.add<edm::InputTag>("pfCandsForMiniIso", edm::InputTag("packedPFCandidates"))
+      ->setComment("collection to use to compute mini-iso");
+  iDesc.add<std::vector<double>>("miniIsoParams", std::vector<double>())
+      ->setComment("mini-iso parameters to use for muons");
 
   iDesc.add<bool>("addTriggerMatching", false)->setComment("add L1 and HLT matching to offline muon");
 
@@ -989,7 +996,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   isoDepositsPSet.addOptional<edm::InputTag>("pfPUChargedHadrons");
   isoDepositsPSet.addOptional<edm::InputTag>("pfNeutralHadrons");
   isoDepositsPSet.addOptional<edm::InputTag>("pfPhotons");
-  isoDepositsPSet.addOptional<std::vector<edm::InputTag> >("user");
+  isoDepositsPSet.addOptional<std::vector<edm::InputTag>>("user");
   iDesc.addOptional("isoDeposits", isoDepositsPSet);
 
   // isolation values configurables
@@ -1006,17 +1013,35 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.addOptional("isolationValues", isolationValuesPSet);
 
   iDesc.ifValue(edm::ParameterDescription<bool>("addPuppiIsolation", false, true),
-		true >> (edm::ParameterDescription<edm::InputTag>("puppiIsolationChargedHadrons", edm::InputTag("muonPUPPIIsolation","h+-DR030-ThresholdVeto000-ConeVeto000"), true) and
-			 edm::ParameterDescription<edm::InputTag>("puppiIsolationNeutralHadrons", edm::InputTag("muonPUPPIIsolation","h0-DR030-ThresholdVeto000-ConeVeto001"), true) and 
-			 edm::ParameterDescription<edm::InputTag>("puppiIsolationPhotons", edm::InputTag("muonPUPPIIsolation","gamma-DR030-ThresholdVeto000-ConeVeto001"), true) and
-			 edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationChargedHadrons", edm::InputTag("muonPUPPINoLeptonsIsolation","h+-DR030-ThresholdVeto000-ConeVeto000"), true) and 
-			 edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationNeutralHadrons", edm::InputTag("muonPUPPINoLeptonsIsolation","h0-DR030-ThresholdVeto000-ConeVeto001"), true) and 
-			 edm::ParameterDescription<edm::InputTag>("puppiNoLeptonsIsolationPhotons", edm::InputTag("muonPUPPINoLeptonsIsolation","gamma-DR030-ThresholdVeto000-ConeVeto001"), true))  or
-		false >> edm::EmptyGroupDescription());
-  
+                true >> (edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationChargedHadrons",
+                             edm::InputTag("muonPUPPIIsolation", "h+-DR030-ThresholdVeto000-ConeVeto000"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationNeutralHadrons",
+                             edm::InputTag("muonPUPPIIsolation", "h0-DR030-ThresholdVeto000-ConeVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiIsolationPhotons",
+                             edm::InputTag("muonPUPPIIsolation", "gamma-DR030-ThresholdVeto000-ConeVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationChargedHadrons",
+                             edm::InputTag("muonPUPPINoLeptonsIsolation", "h+-DR030-ThresholdVeto000-ConeVeto000"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationNeutralHadrons",
+                             edm::InputTag("muonPUPPINoLeptonsIsolation", "h0-DR030-ThresholdVeto000-ConeVeto001"),
+                             true) and
+                         edm::ParameterDescription<edm::InputTag>(
+                             "puppiNoLeptonsIsolationPhotons",
+                             edm::InputTag("muonPUPPINoLeptonsIsolation", "gamma-DR030-ThresholdVeto000-ConeVeto001"),
+                             true)) or
+                    false >> edm::EmptyGroupDescription());
+
   // Efficiency configurables
   edm::ParameterSetDescription efficienciesPSet;
-  efficienciesPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  efficienciesPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("efficiencies", efficienciesPSet);
   iDesc.add<bool>("addEfficiencies", false);
 
@@ -1026,88 +1051,63 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.addOptional("userData", userDataPSet);
 
   edm::ParameterSetDescription isolationPSet;
-  isolationPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  isolationPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("userIsolation", isolationPSet);
 
   iDesc.add<bool>("embedHighLevelSelection", true)->setComment("embed high level selection");
   edm::ParameterSetDescription highLevelPSet;
   highLevelPSet.setAllowAnything();
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true)
-                 )->setComment("input with high level selection");
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true)
-                 )->setComment("input with high level selection");
+  iDesc.addNode(edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true))
+      ->setComment("input with high level selection");
+  iDesc.addNode(edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true))
+      ->setComment("input with high level selection");
 
   //descriptions.add("PATMuonProducer", iDesc);
 }
 
-
-
 // embed various impact parameters with errors
 // embed high level selection
-void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
-				      reco::TrackRef track,
-				      reco::TransientTrack & tt,
-				      reco::Vertex & primaryVertex,
-				      bool primaryVertexIsValid,
-				      reco::BeamSpot & beamspot,
-				      bool beamspotIsValid
-				      )
-{
+void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
+                                     reco::TrackRef track,
+                                     reco::TransientTrack& tt,
+                                     reco::Vertex& primaryVertex,
+                                     bool primaryVertexIsValid,
+                                     reco::BeamSpot& beamspot,
+                                     bool beamspotIsValid) {
   // Correct to PV
 
   // PV2D
-  std::pair<bool,Measurement1D> result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     primaryVertex);
+  std::pair<bool, Measurement1D> result =
+      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::PV2D);
-
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						  track->pz()),
-				     primaryVertex);
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   d0_corr = result.second.value();
   d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::PV3D);
-
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::PV3D);
 
   // Correct to beam spot
   // make a fake vertex out of beam spot
   reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
 
   // BS2D
-  result =
-    IPTools::signedTransverseImpactParameter(tt,
-					     GlobalVector(track->px(),
-							  track->py(),
-							  track->pz()),
-					     vBeamspot);
+  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::BS2D);
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
-    // BS3D
-  result =
-    IPTools::signedImpactParameter3D(tt,
-				     GlobalVector(track->px(),
-						  track->py(),
-						    track->pz()),
-				     vBeamspot);
+  // BS3D
+  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  aMuon.setDB( d0_corr, d0_err, pat::Muon::BS3D);
+  aMuon.setDB(d0_corr, d0_err, pat::Muon::BS3D);
 
-
-    // PVDZ
-  aMuon.setDB( track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ );
+  // PVDZ
+  aMuon.setDB(
+      track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -42,15 +42,10 @@ namespace pat {
 
   class PATMuonHeavyObjectCache {
   public:
-
     PATMuonHeavyObjectCache(const edm::ParameterSet&);
 
-    std::unique_ptr<const pat::MuonMvaEstimator> const& muonMvaEstimator() const {
-      return muonMvaEstimator_;
-    }
-    std::unique_ptr<const pat::MuonMvaEstimator> const& muonLowPtMvaEstimator() const {
-      return muonLowPtMvaEstimator_;
-    }
+    std::unique_ptr<const pat::MuonMvaEstimator> const& muonMvaEstimator() const { return muonMvaEstimator_; }
+    std::unique_ptr<const pat::MuonMvaEstimator> const& muonLowPtMvaEstimator() const { return muonLowPtMvaEstimator_; }
 
     std::unique_ptr<const pat::SoftMuonMvaEstimator> const& softMuonMvaEstimator() const {
       return softMuonMvaEstimator_;
@@ -68,10 +63,9 @@ namespace pat {
 
   /// class definition
   class PATMuonProducer : public edm::stream::EDProducer<edm::GlobalCache<PATMuonHeavyObjectCache>> {
-
   public:
     /// default constructir
-    explicit PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavyObjectCache const*);
+    explicit PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyObjectCache const*);
     /// default destructur
     ~PATMuonProducer() override;
 
@@ -79,68 +73,73 @@ namespace pat {
       return std::make_unique<PATMuonHeavyObjectCache>(iConfig);
     }
 
-    static void globalEndJob(PATMuonHeavyObjectCache*) { }
+    static void globalEndJob(PATMuonHeavyObjectCache*) {}
 
     /// everything that needs to be done during the event loop
-    void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
     /// description of config file parameters
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
     /// typedefs for convenience
     typedef edm::RefToBase<reco::Muon> MuonBaseRef;
-    typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > GenAssociations;
-    typedef std::vector< edm::Handle< edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
-    typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
-    typedef std::pair<pat::IsolationKeys,edm::InputTag> IsolationLabel;
+    typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection>>> GenAssociations;
+    typedef std::vector<edm::Handle<edm::ValueMap<IsoDeposit>>> IsoDepositMaps;
+    typedef std::vector<edm::Handle<edm::ValueMap<double>>> IsolationValueMaps;
+    typedef std::pair<pat::IsolationKeys, edm::InputTag> IsolationLabel;
     typedef std::vector<IsolationLabel> IsolationLabels;
 
-
     /// common muon filling, for both the standard and PF2PAT case
-      void fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const reco::CandidateBaseRef& baseRef, const GenAssociations& genMatches, const IsoDepositMaps& deposits, const IsolationValueMaps& isolationValues) const;
+    void fillMuon(Muon& aMuon,
+                  const MuonBaseRef& muonRef,
+                  const reco::CandidateBaseRef& baseRef,
+                  const GenAssociations& genMatches,
+                  const IsoDepositMaps& deposits,
+                  const IsolationValueMaps& isolationValues) const;
     /// fill label vector from the contents of the parameter set,
     /// for the embedding of isoDeposits or userIsolation values
-    template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
+    template <typename T>
+    void readIsolationLabels(const edm::ParameterSet& iConfig,
+                             const char* psetName,
+                             IsolationLabels& labels,
+                             std::vector<edm::EDGetTokenT<edm::ValueMap<T>>>& tokens);
 
-    void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection *pc);
-    double getRelMiniIsoPUCorrected(const pat::Muon& muon,  double rho, const std::vector<double> &area);
+    void setMuonMiniIso(pat::Muon& aMuon, const pat::PackedCandidateCollection* pc);
+    double getRelMiniIsoPUCorrected(const pat::Muon& muon, double rho, const std::vector<double>& area);
 
-    double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection *pc);
-    bool isNeutralHadron( long pdgid );
-    bool isChargedHadron( long pdgid );
-    bool isPhoton( long pdgid );
-
-
-
+    double puppiCombinedIsolation(const pat::Muon& muon, const pat::PackedCandidateCollection* pc);
+    bool isNeutralHadron(long pdgid);
+    bool isChargedHadron(long pdgid);
+    bool isPhoton(long pdgid);
 
     // embed various impact parameters with errors
     // embed high level selection
-    void embedHighLevel( pat::Muon & aMuon,
-			 reco::TrackRef track,
-			 reco::TransientTrack & tt,
-			 reco::Vertex & primaryVertex,
-			 bool primaryVertexIsValid,
-			 reco::BeamSpot & beamspot,
-			 bool beamspotIsValid );
-    double relMiniIsoPUCorrected( const pat::Muon& aMuon,
-				  double rho);
+    void embedHighLevel(pat::Muon& aMuon,
+                        reco::TrackRef track,
+                        reco::TransientTrack& tt,
+                        reco::Vertex& primaryVertex,
+                        bool primaryVertexIsValid,
+                        reco::BeamSpot& beamspot,
+                        bool beamspotIsValid);
+    double relMiniIsoPUCorrected(const pat::Muon& aMuon, double rho);
     std::optional<GlobalPoint> getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
                                                 const edm::ESHandle<GlobalTrackingGeometry>& geometry,
                                                 const DetId& chamberId);
     void fillL1TriggerInfo(pat::Muon& muon,
-			   edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-			   const edm::TriggerNames & names,
-			   const edm::ESHandle<GlobalTrackingGeometry>& geometry);
+                           edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                           const edm::TriggerNames& names,
+                           const edm::ESHandle<GlobalTrackingGeometry>& geometry);
     void fillHltTriggerInfo(pat::Muon& muon,
-			    edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
-			    const edm::TriggerNames & names,
-			    const std::vector<std::string>& collection_names);
+                            edm::Handle<std::vector<pat::TriggerObjectStandAlone>>& triggerObjects,
+                            const edm::TriggerNames& names,
+                            const std::vector<std::string>& collection_names);
+
   private:
     /// input source
-    edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
-    
+    edm::EDGetTokenT<edm::View<reco::Muon>> muonToken_;
+
     // for mini-iso calculation
-    edm::EDGetTokenT<pat::PackedCandidateCollection > pcToken_;
+    edm::EDGetTokenT<pat::PackedCandidateCollection> pcToken_;
     bool computeMiniIso_;
     bool computePuppiCombinedIso_;
     std::vector<double> effectiveAreaVec_;
@@ -151,7 +150,7 @@ namespace pat {
     bool embedBestTrack_;
     /// embed the track from best muon measurement (muon only)
     bool embedTunePBestTrack_;
-    /// force separate embed of the best track even if already embedded 
+    /// force separate embed of the best track even if already embedded
     bool forceEmbedBestTrack_;
     /// embed the track from inner tracker into the muon
     bool embedTrack_;
@@ -162,11 +161,11 @@ namespace pat {
     /// embed muon MET correction info for caloMET into the muon
     bool embedCaloMETMuonCorrs_;
     /// source of caloMET muon corrections
-    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > caloMETMuonCorrsToken_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData>> caloMETMuonCorrsToken_;
     /// embed muon MET correction info for tcMET into the muon
     bool embedTcMETMuonCorrs_;
     /// source of tcMET muon corrections
-    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > tcMETMuonCorrsToken_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData>> tcMETMuonCorrsToken_;
     /// embed track from picky muon fit into the muon
     bool embedPickyMuon_;
     /// embed track from tpfms muon fit into the muon
@@ -176,7 +175,7 @@ namespace pat {
     /// add generator match information
     bool addGenMatch_;
     /// input tags for generator match information
-    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>>> genMatchTokens_;
     /// embed the gen match information into the muon
     bool embedGenMatch_;
     /// add resolutions to the muon (this will be data members of th muon even w/o embedding)
@@ -194,13 +193,13 @@ namespace pat {
     /// input source of the primary vertex/beamspot
     edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
     /// input source of the primary vertex
-    edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
+    edm::EDGetTokenT<std::vector<reco::Vertex>> pvToken_;
     /// input source for isoDeposits
     IsolationLabels isoDepositLabels_;
-    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit>>> isoDepositTokens_;
     /// input source isolation value maps
     IsolationLabels isolationValueLabels_;
-    std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueTokens_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<double>>> isolationValueTokens_;
     /// add efficiencies to the muon (this will be data members of th muon even w/o embedding)
     bool addEfficiencies_;
     /// add user data to the muon (this will be data members of th muon even w/o embedding)
@@ -210,13 +209,13 @@ namespace pat {
     /// add puppi isolation
     bool addPuppiIsolation_;
     //PUPPI isolation tokens
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_charged_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_neutral_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_photons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPIIsolation_photons_;
     //PUPPINoLeptons isolation tokens
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_charged_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_neutral_hadrons_;
-    edm::EDGetTokenT<edm::ValueMap<float> > PUPPINoLeptonsIsolation_photons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float>> PUPPINoLeptonsIsolation_photons_;
     /// standard muon selectors
     bool computeMuonMVA_;
     bool computeSoftMuonMVA_;
@@ -226,7 +225,7 @@ namespace pat {
     edm::EDGetTokenT<reco::JetCorrector> mvaL1Corrector_;
     edm::EDGetTokenT<reco::JetCorrector> mvaL1L2L3ResCorrector_;
     edm::EDGetTokenT<double> rho_;
-    
+
     /// --- tools ---
     /// comparator for pt ordering
     GreaterByPt<Muon> pTComparator_;
@@ -240,7 +239,7 @@ namespace pat {
     pat::PATUserDataHelper<pat::Muon> userDataHelper_;
 
     /// MC info
-    edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo> > simInfo_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo>> simInfo_;
 
     /// Trigger
     bool addTriggerMatching_;
@@ -249,51 +248,59 @@ namespace pat {
     std::vector<std::string> hltCollectionFilters_;
   };
 
-}
+}  // namespace pat
 
-
-
-
-template<typename T>
-void pat::PATMuonProducer::readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, pat::PATMuonProducer::IsolationLabels& labels, std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens)
-{
+template <typename T>
+void pat::PATMuonProducer::readIsolationLabels(const edm::ParameterSet& iConfig,
+                                               const char* psetName,
+                                               pat::PATMuonProducer::IsolationLabels& labels,
+                                               std::vector<edm::EDGetTokenT<edm::ValueMap<T>>>& tokens) {
   labels.clear();
 
-  if (iConfig.exists( psetName )) {
+  if (iConfig.exists(psetName)) {
     edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>(psetName);
 
-    if (depconf.exists("tracker")) labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-    if (depconf.exists("ecal"))    labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-    if (depconf.exists("hcal"))    labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-    if (depconf.exists("pfAllParticles"))  {
+    if (depconf.exists("tracker"))
+      labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
+    if (depconf.exists("ecal"))
+      labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
+    if (depconf.exists("hcal"))
+      labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
+    if (depconf.exists("pfAllParticles")) {
       labels.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
     }
-    if (depconf.exists("pfChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
+    if (depconf.exists("pfChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
     }
-    if (depconf.exists("pfChargedAll"))  {
+    if (depconf.exists("pfChargedAll")) {
       labels.push_back(std::make_pair(pat::PfChargedAllIso, depconf.getParameter<edm::InputTag>("pfChargedAll")));
     }
-    if (depconf.exists("pfPUChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
+    if (depconf.exists("pfPUChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
     }
-    if (depconf.exists("pfNeutralHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
+    if (depconf.exists("pfNeutralHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
     }
     if (depconf.exists("pfPhotons")) {
       labels.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfPhotons")));
     }
     if (depconf.exists("user")) {
-      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
+      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag>>("user");
       std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
       int key = pat::IsolationKeys::UserBaseIso;
-      for ( ; it != ed; ++it, ++key) {
-       labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
+      for (; it != ed; ++it, ++key) {
+        labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
       }
-      tokens = edm::vector_transform(labels, [this](IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
+      tokens = edm::vector_transform(
+          labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T>>(label.second); });
     }
   }
-  tokens = edm::vector_transform(labels, [this](pat::PATMuonProducer::IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
+  tokens = edm::vector_transform(labels, [this](pat::PATMuonProducer::IsolationLabel const& label) {
+    return consumes<edm::ValueMap<T>>(label.second);
+  });
 }
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -3,7 +3,6 @@
   \brief    Slimmer of PAT Muons 
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -22,206 +21,233 @@
 #include "DataFormats/Math/interface/libminifloat.h"
 
 namespace pat {
-  
+
   class PATMuonSlimmer : public edm::stream::EDProducer<> {
   public:
-    explicit PATMuonSlimmer(const edm::ParameterSet & iConfig);
-    ~PATMuonSlimmer() override { }
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) final;
-    
+    explicit PATMuonSlimmer(const edm::ParameterSet &iConfig);
+    ~PATMuonSlimmer() override {}
+
+    void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) final;
+
   private:
     const edm::EDGetTokenT<pat::MuonCollection> src_;
     std::vector<edm::EDGetTokenT<reco::PFCandidateCollection>> pf_;
     std::vector<edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>>> pf2pc_;
     const bool linkToPackedPF_;
-    const StringCutObjectSelector<pat::Muon> saveTeVMuons_, dropDirectionalIso_, dropPfP4_, slimCaloVars_, 
-				             slimKinkVars_, slimCaloMETCorr_, slimMatches_,segmentsMuonSelection_;
-    const bool saveSegments_,modifyMuon_;
-    std::unique_ptr<pat::ObjectModifier<pat::Muon> > muonModifier_;
+    const StringCutObjectSelector<pat::Muon> saveTeVMuons_, dropDirectionalIso_, dropPfP4_, slimCaloVars_,
+        slimKinkVars_, slimCaloMETCorr_, slimMatches_, segmentsMuonSelection_;
+    const bool saveSegments_, modifyMuon_;
+    std::unique_ptr<pat::ObjectModifier<pat::Muon>> muonModifier_;
   };
 
-} // namespace
+}  // namespace pat
 
-pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet & iConfig) :
-    src_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-    linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
-    saveTeVMuons_(iConfig.getParameter<std::string>("saveTeVMuons")),
-    dropDirectionalIso_(iConfig.getParameter<std::string>("dropDirectionalIso")),
-    dropPfP4_(iConfig.getParameter<std::string>("dropPfP4")),
-    slimCaloVars_(iConfig.getParameter<std::string>("slimCaloVars")),
-    slimKinkVars_(iConfig.getParameter<std::string>("slimKinkVars")),
-    slimCaloMETCorr_(iConfig.getParameter<std::string>("slimCaloMETCorr")),
-    slimMatches_(iConfig.getParameter<std::string>("slimMatches")),
-    segmentsMuonSelection_(iConfig.getParameter<std::string>("segmentsMuonSelection")),
-    saveSegments_(iConfig.getParameter<bool>("saveSegments")),
-    modifyMuon_(iConfig.getParameter<bool>("modifyMuons"))
-{
-    if (linkToPackedPF_) {
-      const std::vector<edm::InputTag> & pf = iConfig.getParameter<std::vector<edm::InputTag>>("pfCandidates");
-      const std::vector<edm::InputTag> & pf2pc = iConfig.getParameter<std::vector<edm::InputTag>>("packedPFCandidates");
-        if (pf.size() != pf2pc.size()) throw cms::Exception("Configuration") << "Mismatching pfCandidates and packedPFCandidates\n";
-        for (const edm::InputTag &tag : pf) pf_.push_back(consumes<reco::PFCandidateCollection>(tag));
-        for (const edm::InputTag &tag : pf2pc) pf2pc_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
-    }
+pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet &iConfig)
+    : src_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
+      saveTeVMuons_(iConfig.getParameter<std::string>("saveTeVMuons")),
+      dropDirectionalIso_(iConfig.getParameter<std::string>("dropDirectionalIso")),
+      dropPfP4_(iConfig.getParameter<std::string>("dropPfP4")),
+      slimCaloVars_(iConfig.getParameter<std::string>("slimCaloVars")),
+      slimKinkVars_(iConfig.getParameter<std::string>("slimKinkVars")),
+      slimCaloMETCorr_(iConfig.getParameter<std::string>("slimCaloMETCorr")),
+      slimMatches_(iConfig.getParameter<std::string>("slimMatches")),
+      segmentsMuonSelection_(iConfig.getParameter<std::string>("segmentsMuonSelection")),
+      saveSegments_(iConfig.getParameter<bool>("saveSegments")),
+      modifyMuon_(iConfig.getParameter<bool>("modifyMuons")) {
+  if (linkToPackedPF_) {
+    const std::vector<edm::InputTag> &pf = iConfig.getParameter<std::vector<edm::InputTag>>("pfCandidates");
+    const std::vector<edm::InputTag> &pf2pc = iConfig.getParameter<std::vector<edm::InputTag>>("packedPFCandidates");
+    if (pf.size() != pf2pc.size())
+      throw cms::Exception("Configuration") << "Mismatching pfCandidates and packedPFCandidates\n";
+    for (const edm::InputTag &tag : pf)
+      pf_.push_back(consumes<reco::PFCandidateCollection>(tag));
+    for (const edm::InputTag &tag : pf2pc)
+      pf2pc_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
+  }
 
-    if( modifyMuon_ ) {
-      const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      muonModifier_ = std::make_unique<pat::ObjectModifier<pat::Muon>>(mod_config, consumesCollector());
-    }
-    produces<std::vector<pat::Muon> >();
-    if( saveSegments_ ) {
-      produces< DTRecSegment4DCollection >();
-      produces< CSCSegmentCollection >();
-    }
-
+  if (modifyMuon_) {
+    const edm::ParameterSet &mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
+    muonModifier_ = std::make_unique<pat::ObjectModifier<pat::Muon>>(mod_config, consumesCollector());
+  }
+  produces<std::vector<pat::Muon>>();
+  if (saveSegments_) {
+    produces<DTRecSegment4DCollection>();
+    produces<CSCSegmentCollection>();
+  }
 }
 
-void 
-pat::PATMuonSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup& iSetup) {
-  if( modifyMuon_ ) muonModifier_->setEventContent(iSetup);
+void pat::PATMuonSlimmer::beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &iSetup) {
+  if (modifyMuon_)
+    muonModifier_->setEventContent(iSetup);
 }
 
-void 
-pat::PATMuonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
+void pat::PATMuonSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    Handle<pat::MuonCollection>      src;
-    iEvent.getByToken(src_, src);
+  Handle<pat::MuonCollection> src;
+  iEvent.getByToken(src_, src);
 
-    auto out = std::make_unique<std::vector<pat::Muon>>();
-    out->reserve(src->size());
+  auto out = std::make_unique<std::vector<pat::Muon>>();
+  out->reserve(src->size());
 
-    auto outDTSegments = std::make_unique<DTRecSegment4DCollection>();
-    std::set<DTRecSegment4DRef> dtSegmentsRefs;
-    auto outCSCSegments = std::make_unique<CSCSegmentCollection>();
-    std::set<CSCSegmentRef> cscSegmentsRefs;
+  auto outDTSegments = std::make_unique<DTRecSegment4DCollection>();
+  std::set<DTRecSegment4DRef> dtSegmentsRefs;
+  auto outCSCSegments = std::make_unique<CSCSegmentCollection>();
+  std::set<CSCSegmentRef> cscSegmentsRefs;
 
-    if( modifyMuon_ ) { muonModifier_->setEvent(iEvent); }
+  if (modifyMuon_) {
+    muonModifier_->setEvent(iEvent);
+  }
 
-    std::map<reco::CandidatePtr,pat::PackedCandidateRef> mu2pc;
+  std::map<reco::CandidatePtr, pat::PackedCandidateRef> mu2pc;
+  if (linkToPackedPF_) {
+    Handle<reco::PFCandidateCollection> pf;
+    Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+    for (unsigned int ipfh = 0, npfh = pf_.size(); ipfh < npfh; ++ipfh) {
+      iEvent.getByToken(pf_[ipfh], pf);
+      iEvent.getByToken(pf2pc_[ipfh], pf2pc);
+      const auto &pfcoll = (*pf);
+      const auto &pfmap = (*pf2pc);
+      for (unsigned int i = 0, n = pf->size(); i < n; ++i) {
+        const reco::PFCandidate &p = pfcoll[i];
+        if (p.muonRef().isNonnull())
+          mu2pc[refToPtr(p.muonRef())] = pfmap[reco::PFCandidateRef(pf, i)];
+      }
+    }
+  }
+
+  for (vector<pat::Muon>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    out->push_back(*it);
+    pat::Muon &mu = out->back();
+
+    if (modifyMuon_) {
+      muonModifier_->modify(mu);
+    }
+
+    if (saveTeVMuons_(mu)) {
+      mu.embedPickyMuon();
+      mu.embedTpfmsMuon();
+      mu.embedDytMuon();
+    }
     if (linkToPackedPF_) {
-        Handle<reco::PFCandidateCollection> pf;
-        Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
-        for (unsigned int ipfh = 0, npfh = pf_.size(); ipfh < npfh; ++ipfh) {
-            iEvent.getByToken(pf_[ipfh], pf);
-            iEvent.getByToken(pf2pc_[ipfh], pf2pc);
-            const auto & pfcoll = (*pf);
-            const auto & pfmap  = (*pf2pc);
-            for (unsigned int i = 0, n = pf->size(); i < n; ++i) {
-                const reco::PFCandidate &p = pfcoll[i];
-                if (p.muonRef().isNonnull()) mu2pc[refToPtr(p.muonRef())] = pfmap[reco::PFCandidateRef(pf, i)];
-            }
-        }
+      mu.refToOrig_ = refToPtr(mu2pc[mu.refToOrig_]);
     }
-
-    for (vector<pat::Muon>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        out->push_back(*it);
-        pat::Muon & mu = out->back();
-        
-        if( modifyMuon_ ) { muonModifier_->modify(mu); }
-
-	if (saveTeVMuons_(mu)){mu.embedPickyMuon(); mu.embedTpfmsMuon(); mu.embedDytMuon();}
-	if (linkToPackedPF_) {
-            mu.refToOrig_ = refToPtr(mu2pc[mu.refToOrig_]);
-        }
-        if (dropDirectionalIso_(mu)) {
-            reco::MuonPFIsolation zero;
-            mu.setPFIsolation("pfIsoMeanDRProfileR03",zero);
-            mu.setPFIsolation("pfIsoSumDRProfileR03",zero);
-            mu.setPFIsolation("pfIsoMeanDRProfileR04",zero);
-            mu.setPFIsolation("pfIsoSumDRProfileR04",zero);
-        }
-        if (mu.isPFMuon() && dropPfP4_(mu)) mu.setPFP4(reco::Particle::LorentzVector());
-        if (slimCaloVars_(mu) && mu.isEnergyValid()) {
-            reco::MuonEnergy ene = mu.calEnergy();
-            if (ene.tower)   ene.tower = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.tower);
-            if (ene.towerS9) ene.towerS9 = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.towerS9);
-            if (ene.had)     ene.had = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.had);
-            if (ene.hadS9)  ene.hadS9 = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hadS9);
-            if (ene.hadMax) ene.hadMax = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hadMax);
-            if (ene.em)    ene.em = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.em);
-            if (ene.emS25) ene.emS25 = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.emS25);
-            if (ene.emMax) ene.emMax = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.emMax);
-            if (ene.hcal_time)   ene.hcal_time = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_time);
-            if (ene.hcal_timeError)   ene.hcal_timeError = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_timeError);
-            if (ene.ecal_time)   ene.ecal_time = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.ecal_time);
-            if (ene.ecal_timeError)   ene.ecal_timeError = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.ecal_timeError);
-            ene.ecal_position = math::XYZPointF(MiniFloatConverter::reduceMantissaToNbitsRounding<14>(ene.ecal_position.X()),
-						MiniFloatConverter::reduceMantissaToNbitsRounding<14>(ene.ecal_position.Y()),
-						MiniFloatConverter::reduceMantissaToNbitsRounding<14>(ene.ecal_position.Z()));
-            ene.hcal_position = math::XYZPointF(MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_position.X()),
-						MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_position.Y()), 
-						MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_position.Z()));
-            mu.setCalEnergy(ene);
-        }
-        if (slimKinkVars_(mu) && mu.isQualityValid()) {
-            reco::MuonQuality qual = mu.combinedQuality();
-            qual.tkKink_position = math::XYZPointF(MiniFloatConverter::reduceMantissaToNbitsRounding<12>(qual.tkKink_position.X()),
-						   MiniFloatConverter::reduceMantissaToNbitsRounding<12>(qual.tkKink_position.Y()),
-						   MiniFloatConverter::reduceMantissaToNbitsRounding<12>(qual.tkKink_position.Z()));
-            mu.setCombinedQuality(qual);
-        }
-        if (slimCaloMETCorr_(mu) && mu.caloMETMuonCorrs().type() != reco::MuonMETCorrectionData::NotUsed) {
-            reco::MuonMETCorrectionData corrs = mu.caloMETMuonCorrs();
-            corrs = reco::MuonMETCorrectionData(corrs.type(), MiniFloatConverter::reduceMantissaToNbitsRounding<10>(corrs.corrX()), MiniFloatConverter::reduceMantissaToNbitsRounding<10>(corrs.corrY()));
-            mu.embedCaloMETMuonCorrs(corrs);
-        }
-        if (slimMatches_(mu) && mu.isMatchesValid()) {
-            for (reco::MuonChamberMatch & cmatch : mu.matches()) {
-                cmatch.edgeX = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.edgeX);
-                cmatch.edgeY = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.edgeY);
-                cmatch.xErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.xErr);
-                cmatch.yErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.yErr);
-                cmatch.dXdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.dXdZErr);
-                cmatch.dYdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.dYdZErr);
-                for (reco::MuonSegmentMatch & smatch : cmatch.segmentMatches) {
-                    smatch.xErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.xErr);
-                    smatch.yErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.yErr);
-                    smatch.dXdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.dXdZErr);
-                    smatch.dYdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.dYdZErr);
-                    if( saveSegments_ &&  segmentsMuonSelection_(mu) ) {
-		      if(smatch.dtSegmentRef.isNonnull()) dtSegmentsRefs.insert(smatch.dtSegmentRef);
-		      if(smatch.cscSegmentRef.isNonnull()) cscSegmentsRefs.insert(smatch.cscSegmentRef);
-                    }
-                }
-            }
-        }
+    if (dropDirectionalIso_(mu)) {
+      reco::MuonPFIsolation zero;
+      mu.setPFIsolation("pfIsoMeanDRProfileR03", zero);
+      mu.setPFIsolation("pfIsoSumDRProfileR03", zero);
+      mu.setPFIsolation("pfIsoMeanDRProfileR04", zero);
+      mu.setPFIsolation("pfIsoSumDRProfileR04", zero);
     }
-
-    if( saveSegments_ ) {
-      std::map<DTRecSegment4DRef,size_t> dtMap;
-      std::vector<DTRecSegment4D> outDTSegmentsTmp; 
-      std::map<CSCSegmentRef,size_t> cscMap;
-      std::vector<CSCSegment> outCSCSegmentsTmp; 
-      for(auto & seg : dtSegmentsRefs) {
-         dtMap[seg]=outDTSegments->size();
-         outDTSegmentsTmp.push_back(*seg);
-      }
-      for(auto & seg : cscSegmentsRefs) {
-         cscMap[seg]=outCSCSegments->size();
-         outCSCSegmentsTmp.push_back(*seg);
-      }
-      outDTSegments->put(DTChamberId(),outDTSegmentsTmp.begin(),outDTSegmentsTmp.end());
-      outCSCSegments->put(CSCDetId(),outCSCSegmentsTmp.begin(),outCSCSegmentsTmp.end());
-      auto dtHandle = iEvent.put(std::move(outDTSegments));
-      auto cscHandle = iEvent.put(std::move(outCSCSegments));
-      for( auto & mu : *out) {
-        if(mu.isMatchesValid()) {
-          for (reco::MuonChamberMatch & cmatch : mu.matches()) {
-            for (reco::MuonSegmentMatch & smatch : cmatch.segmentMatches) {
-              if (dtMap.find(smatch.dtSegmentRef) != dtMap.end() )
-                smatch.dtSegmentRef=DTRecSegment4DRef(dtHandle,dtMap[smatch.dtSegmentRef]);
-              if (cscMap.find(smatch.cscSegmentRef) != cscMap.end() )
-                smatch.cscSegmentRef=CSCSegmentRef(cscHandle,cscMap[smatch.cscSegmentRef]);
-            }
+    if (mu.isPFMuon() && dropPfP4_(mu))
+      mu.setPFP4(reco::Particle::LorentzVector());
+    if (slimCaloVars_(mu) && mu.isEnergyValid()) {
+      reco::MuonEnergy ene = mu.calEnergy();
+      if (ene.tower)
+        ene.tower = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.tower);
+      if (ene.towerS9)
+        ene.towerS9 = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.towerS9);
+      if (ene.had)
+        ene.had = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.had);
+      if (ene.hadS9)
+        ene.hadS9 = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hadS9);
+      if (ene.hadMax)
+        ene.hadMax = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hadMax);
+      if (ene.em)
+        ene.em = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.em);
+      if (ene.emS25)
+        ene.emS25 = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.emS25);
+      if (ene.emMax)
+        ene.emMax = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.emMax);
+      if (ene.hcal_time)
+        ene.hcal_time = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_time);
+      if (ene.hcal_timeError)
+        ene.hcal_timeError = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_timeError);
+      if (ene.ecal_time)
+        ene.ecal_time = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.ecal_time);
+      if (ene.ecal_timeError)
+        ene.ecal_timeError = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.ecal_timeError);
+      ene.ecal_position = math::XYZPointF(MiniFloatConverter::reduceMantissaToNbitsRounding<14>(ene.ecal_position.X()),
+                                          MiniFloatConverter::reduceMantissaToNbitsRounding<14>(ene.ecal_position.Y()),
+                                          MiniFloatConverter::reduceMantissaToNbitsRounding<14>(ene.ecal_position.Z()));
+      ene.hcal_position = math::XYZPointF(MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_position.X()),
+                                          MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_position.Y()),
+                                          MiniFloatConverter::reduceMantissaToNbitsRounding<12>(ene.hcal_position.Z()));
+      mu.setCalEnergy(ene);
+    }
+    if (slimKinkVars_(mu) && mu.isQualityValid()) {
+      reco::MuonQuality qual = mu.combinedQuality();
+      qual.tkKink_position =
+          math::XYZPointF(MiniFloatConverter::reduceMantissaToNbitsRounding<12>(qual.tkKink_position.X()),
+                          MiniFloatConverter::reduceMantissaToNbitsRounding<12>(qual.tkKink_position.Y()),
+                          MiniFloatConverter::reduceMantissaToNbitsRounding<12>(qual.tkKink_position.Z()));
+      mu.setCombinedQuality(qual);
+    }
+    if (slimCaloMETCorr_(mu) && mu.caloMETMuonCorrs().type() != reco::MuonMETCorrectionData::NotUsed) {
+      reco::MuonMETCorrectionData corrs = mu.caloMETMuonCorrs();
+      corrs = reco::MuonMETCorrectionData(corrs.type(),
+                                          MiniFloatConverter::reduceMantissaToNbitsRounding<10>(corrs.corrX()),
+                                          MiniFloatConverter::reduceMantissaToNbitsRounding<10>(corrs.corrY()));
+      mu.embedCaloMETMuonCorrs(corrs);
+    }
+    if (slimMatches_(mu) && mu.isMatchesValid()) {
+      for (reco::MuonChamberMatch &cmatch : mu.matches()) {
+        cmatch.edgeX = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.edgeX);
+        cmatch.edgeY = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.edgeY);
+        cmatch.xErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.xErr);
+        cmatch.yErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.yErr);
+        cmatch.dXdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.dXdZErr);
+        cmatch.dYdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(cmatch.dYdZErr);
+        for (reco::MuonSegmentMatch &smatch : cmatch.segmentMatches) {
+          smatch.xErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.xErr);
+          smatch.yErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.yErr);
+          smatch.dXdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.dXdZErr);
+          smatch.dYdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.dYdZErr);
+          if (saveSegments_ && segmentsMuonSelection_(mu)) {
+            if (smatch.dtSegmentRef.isNonnull())
+              dtSegmentsRefs.insert(smatch.dtSegmentRef);
+            if (smatch.cscSegmentRef.isNonnull())
+              cscSegmentsRefs.insert(smatch.cscSegmentRef);
           }
-        } 
+        }
       }
     }
-    iEvent.put(std::move(out));
+  }
+
+  if (saveSegments_) {
+    std::map<DTRecSegment4DRef, size_t> dtMap;
+    std::vector<DTRecSegment4D> outDTSegmentsTmp;
+    std::map<CSCSegmentRef, size_t> cscMap;
+    std::vector<CSCSegment> outCSCSegmentsTmp;
+    for (auto &seg : dtSegmentsRefs) {
+      dtMap[seg] = outDTSegments->size();
+      outDTSegmentsTmp.push_back(*seg);
+    }
+    for (auto &seg : cscSegmentsRefs) {
+      cscMap[seg] = outCSCSegments->size();
+      outCSCSegmentsTmp.push_back(*seg);
+    }
+    outDTSegments->put(DTChamberId(), outDTSegmentsTmp.begin(), outDTSegmentsTmp.end());
+    outCSCSegments->put(CSCDetId(), outCSCSegmentsTmp.begin(), outCSCSegmentsTmp.end());
+    auto dtHandle = iEvent.put(std::move(outDTSegments));
+    auto cscHandle = iEvent.put(std::move(outCSCSegments));
+    for (auto &mu : *out) {
+      if (mu.isMatchesValid()) {
+        for (reco::MuonChamberMatch &cmatch : mu.matches()) {
+          for (reco::MuonSegmentMatch &smatch : cmatch.segmentMatches) {
+            if (dtMap.find(smatch.dtSegmentRef) != dtMap.end())
+              smatch.dtSegmentRef = DTRecSegment4DRef(dtHandle, dtMap[smatch.dtSegmentRef]);
+            if (cscMap.find(smatch.cscSegmentRef) != cscMap.end())
+              smatch.cscSegmentRef = CSCSegmentRef(cscHandle, cscMap[smatch.cscSegmentRef]);
+          }
+        }
+      }
+    }
+  }
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATObjectCrossLinker.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectCrossLinker.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PhysicsTools/NanoAOD
 // Class:      PATObjectCrossLinker
-// 
+//
 /**\class PATObjectCrossLinker PATObjectCrossLinker.cc PhysicsTools/PATObjectCrossLinker/plugins/PATObjectCrossLinker.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Mon, 28 Aug 2017 09:26:39 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -44,68 +43,68 @@
 //
 
 class PATObjectCrossLinker : public edm::stream::EDProducer<> {
-   public:
-      explicit PATObjectCrossLinker(const edm::ParameterSet&);
-      ~PATObjectCrossLinker() override;
+public:
+  explicit PATObjectCrossLinker(const edm::ParameterSet&);
+  ~PATObjectCrossLinker() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      template < class C1, class C2,class C3, class C4>
-      void matchOneToMany(const C1 & refProdOne,  C2 &  itemsOne, const std::string & nameOne,
-                    const C3 & refProdMany, C4& itemsMany, const std::string & nameMany);
+  template <class C1, class C2, class C3, class C4>
+  void matchOneToMany(const C1& refProdOne,
+                      C2& itemsOne,
+                      const std::string& nameOne,
+                      const C3& refProdMany,
+                      C4& itemsMany,
+                      const std::string& nameMany);
 
-      template < class C1, class C2,class C3,class C4>
-      void matchElectronToPhoton(const C1 & refProdOne, C2 & itemsOne, const std::string & nameOne,
-                    const C3 & refProdMany, C4& itemsMany, const std::string & nameMany);
+  template <class C1, class C2, class C3, class C4>
+  void matchElectronToPhoton(const C1& refProdOne,
+                             C2& itemsOne,
+                             const std::string& nameOne,
+                             const C3& refProdMany,
+                             C4& itemsMany,
+                             const std::string& nameMany);
 
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-      // ----------member data ---------------------------
-      const edm::EDGetTokenT<edm::View<pat::Jet>> jets_;
-      const edm::EDGetTokenT<edm::View<pat::Muon>> muons_;
-      const edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
-      const edm::EDGetTokenT<edm::View<pat::Tau>> taus_;
-      const edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
-
-
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<edm::View<pat::Jet>> jets_;
+  const edm::EDGetTokenT<edm::View<pat::Muon>> muons_;
+  const edm::EDGetTokenT<edm::View<pat::Electron>> electrons_;
+  const edm::EDGetTokenT<edm::View<pat::Tau>> taus_;
+  const edm::EDGetTokenT<edm::View<pat::Photon>> photons_;
 };
 
 //
 // constructors and destructor
 //
-PATObjectCrossLinker::PATObjectCrossLinker(const edm::ParameterSet& params):
-    jets_(consumes<edm::View<pat::Jet>>( params.getParameter<edm::InputTag>("jets") )),
-    muons_(consumes<edm::View<pat::Muon>>( params.getParameter<edm::InputTag>("muons") )),
-    electrons_(consumes<edm::View<pat::Electron>>( params.getParameter<edm::InputTag>("electrons") )),
-    taus_(consumes<edm::View<pat::Tau>>( params.getParameter<edm::InputTag>("taus") )),
-    photons_(consumes<edm::View<pat::Photon>>( params.getParameter<edm::InputTag>("photons") ))
+PATObjectCrossLinker::PATObjectCrossLinker(const edm::ParameterSet& params)
+    : jets_(consumes<edm::View<pat::Jet>>(params.getParameter<edm::InputTag>("jets"))),
+      muons_(consumes<edm::View<pat::Muon>>(params.getParameter<edm::InputTag>("muons"))),
+      electrons_(consumes<edm::View<pat::Electron>>(params.getParameter<edm::InputTag>("electrons"))),
+      taus_(consumes<edm::View<pat::Tau>>(params.getParameter<edm::InputTag>("taus"))),
+      photons_(consumes<edm::View<pat::Photon>>(params.getParameter<edm::InputTag>("photons")))
 
 {
-   produces<std::vector<pat::Jet>>("jets");
-   produces<std::vector<pat::Muon>>("muons");
-   produces<std::vector<pat::Electron>>("electrons");
-   produces<std::vector<pat::Tau>>("taus");
-   produces<std::vector<pat::Photon>>("photons");
-  
+  produces<std::vector<pat::Jet>>("jets");
+  produces<std::vector<pat::Muon>>("muons");
+  produces<std::vector<pat::Electron>>("electrons");
+  produces<std::vector<pat::Tau>>("taus");
+  produces<std::vector<pat::Photon>>("photons");
 }
 
-
-PATObjectCrossLinker::~PATObjectCrossLinker()
-{
- 
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-
+PATObjectCrossLinker::~PATObjectCrossLinker() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -114,110 +113,111 @@ PATObjectCrossLinker::~PATObjectCrossLinker()
 // ------------ method called to produce the data  ------------
 
 ///
-template < class C1, class C2,class C3,class C4>
-void PATObjectCrossLinker::matchOneToMany(const C1 & refProdOne, C2 & itemsOne, const std::string & nameOne,
-		    const C3 & refProdMany, C4& itemsMany, const std::string & nameMany)
-{
-    size_t ji=0;
-    for(auto & j: itemsOne) {
-        edm::PtrVector<reco::Candidate> overlaps(refProdMany.id());
-        size_t mi=0;
-        for(auto & m: itemsMany){
-	    if(matchByCommonSourceCandidatePtr(j,m) && (!m.hasUserCand(nameOne))){
-                m.addUserCand(nameOne,reco::CandidatePtr(refProdOne.id(), ji, refProdOne.productGetter()));
-                overlaps.push_back(reco::CandidatePtr(refProdMany.id(), mi, refProdMany.productGetter()));
-            }
-            mi++;
-        }
-    j.setOverlaps(nameMany,overlaps);
+template <class C1, class C2, class C3, class C4>
+void PATObjectCrossLinker::matchOneToMany(const C1& refProdOne,
+                                          C2& itemsOne,
+                                          const std::string& nameOne,
+                                          const C3& refProdMany,
+                                          C4& itemsMany,
+                                          const std::string& nameMany) {
+  size_t ji = 0;
+  for (auto& j : itemsOne) {
+    edm::PtrVector<reco::Candidate> overlaps(refProdMany.id());
+    size_t mi = 0;
+    for (auto& m : itemsMany) {
+      if (matchByCommonSourceCandidatePtr(j, m) && (!m.hasUserCand(nameOne))) {
+        m.addUserCand(nameOne, reco::CandidatePtr(refProdOne.id(), ji, refProdOne.productGetter()));
+        overlaps.push_back(reco::CandidatePtr(refProdMany.id(), mi, refProdMany.productGetter()));
+      }
+      mi++;
+    }
+    j.setOverlaps(nameMany, overlaps);
     ji++;
-   } 
+  }
 }
 
-template < class C1, class C2,class C3,class C4>
-void PATObjectCrossLinker::matchElectronToPhoton(const C1 & refProdOne, C2 & itemsOne, const std::string & nameOne,
-		    const C3 & refProdMany, C4& itemsMany, const std::string & nameMany)
-{
-    size_t ji=0;
-    for(auto & j: itemsOne) {
-        edm::PtrVector<reco::Candidate> overlaps(refProdMany.id());
-        size_t mi=0;
-        for(auto & m: itemsMany){
-	    if(matchByCommonParentSuperClusterRef(j,m) && (!m.hasUserCand(nameOne))){
-                m.addUserCand(nameOne,reco::CandidatePtr(refProdOne.id(), ji, refProdOne.productGetter()));
-                overlaps.push_back(reco::CandidatePtr(refProdMany.id(), mi, refProdMany.productGetter()));
-            }
-            mi++;
-        }
-    j.setOverlaps(nameMany,overlaps);
+template <class C1, class C2, class C3, class C4>
+void PATObjectCrossLinker::matchElectronToPhoton(const C1& refProdOne,
+                                                 C2& itemsOne,
+                                                 const std::string& nameOne,
+                                                 const C3& refProdMany,
+                                                 C4& itemsMany,
+                                                 const std::string& nameMany) {
+  size_t ji = 0;
+  for (auto& j : itemsOne) {
+    edm::PtrVector<reco::Candidate> overlaps(refProdMany.id());
+    size_t mi = 0;
+    for (auto& m : itemsMany) {
+      if (matchByCommonParentSuperClusterRef(j, m) && (!m.hasUserCand(nameOne))) {
+        m.addUserCand(nameOne, reco::CandidatePtr(refProdOne.id(), ji, refProdOne.productGetter()));
+        overlaps.push_back(reco::CandidatePtr(refProdMany.id(), mi, refProdMany.productGetter()));
+      }
+      mi++;
+    }
+    j.setOverlaps(nameMany, overlaps);
     ji++;
-   } 
+  }
 }
 
+void PATObjectCrossLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  edm::Handle<edm::View<pat::Jet>> jetsIn;
+  iEvent.getByToken(jets_, jetsIn);
+  auto jets = std::make_unique<std::vector<pat::Jet>>();
+  for (const auto& j : *jetsIn)
+    jets->push_back(j);
+  auto jetRefProd = iEvent.getRefBeforePut<std::vector<pat::Jet>>("jets");
 
-void
-PATObjectCrossLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    using namespace edm;
-    edm::Handle<edm::View<pat::Jet>> jetsIn;
-    iEvent.getByToken(jets_, jetsIn);
-    auto jets = std::make_unique<std::vector<pat::Jet>>();
-    for(const auto & j  : *jetsIn) jets->push_back(j);
-    auto jetRefProd =  iEvent.getRefBeforePut< std::vector<pat::Jet> >("jets");
+  edm::Handle<edm::View<pat::Muon>> muonsIn;
+  iEvent.getByToken(muons_, muonsIn);
+  auto muons = std::make_unique<std::vector<pat::Muon>>();
+  for (const auto& m : *muonsIn)
+    muons->push_back(m);
+  auto muRefProd = iEvent.getRefBeforePut<std::vector<pat::Muon>>("muons");
 
-    edm::Handle<edm::View<pat::Muon>> muonsIn;
-    iEvent.getByToken(muons_, muonsIn);
-    auto muons = std::make_unique<std::vector<pat::Muon>>();
-    for(const auto & m  : *muonsIn) muons->push_back(m);
-    auto muRefProd =  iEvent.getRefBeforePut< std::vector<pat::Muon> >("muons");
+  edm::Handle<edm::View<pat::Electron>> electronsIn;
+  iEvent.getByToken(electrons_, electronsIn);
+  auto electrons = std::make_unique<std::vector<pat::Electron>>();
+  for (const auto& e : *electronsIn)
+    electrons->push_back(e);
+  auto eleRefProd = iEvent.getRefBeforePut<std::vector<pat::Electron>>("electrons");
 
-    edm::Handle<edm::View<pat::Electron>> electronsIn;
-    iEvent.getByToken(electrons_, electronsIn);
-    auto electrons = std::make_unique<std::vector<pat::Electron>>();
-    for(const auto & e  : *electronsIn) electrons->push_back(e);
-    auto eleRefProd =  iEvent.getRefBeforePut< std::vector<pat::Electron> >("electrons");
+  edm::Handle<edm::View<pat::Tau>> tausIn;
+  iEvent.getByToken(taus_, tausIn);
+  auto taus = std::make_unique<std::vector<pat::Tau>>();
+  for (const auto& t : *tausIn)
+    taus->push_back(t);
+  auto tauRefProd = iEvent.getRefBeforePut<std::vector<pat::Tau>>("taus");
 
-    edm::Handle<edm::View<pat::Tau>> tausIn;
-    iEvent.getByToken(taus_, tausIn);
-    auto taus = std::make_unique<std::vector<pat::Tau>>();
-    for(const auto & t  : *tausIn) taus->push_back(t);
-    auto tauRefProd =  iEvent.getRefBeforePut< std::vector<pat::Tau> >("taus");
+  edm::Handle<edm::View<pat::Photon>> photonsIn;
+  iEvent.getByToken(photons_, photonsIn);
+  auto photons = std::make_unique<std::vector<pat::Photon>>();
+  for (const auto& p : *photonsIn)
+    photons->push_back(p);
+  auto phRefProd = iEvent.getRefBeforePut<std::vector<pat::Photon>>("photons");
 
-    edm::Handle<edm::View<pat::Photon>> photonsIn;
-    iEvent.getByToken(photons_, photonsIn);
-    auto photons = std::make_unique<std::vector<pat::Photon>>();
-    for(const auto & p  : *photonsIn) photons->push_back(p);
-    auto phRefProd =  iEvent.getRefBeforePut< std::vector<pat::Photon> >("photons");
+  matchOneToMany(jetRefProd, *jets, "jet", muRefProd, *muons, "muons");
+  matchOneToMany(jetRefProd, *jets, "jet", eleRefProd, *electrons, "electrons");
+  matchOneToMany(jetRefProd, *jets, "jet", tauRefProd, *taus, "taus");
+  matchOneToMany(jetRefProd, *jets, "jet", phRefProd, *photons, "photons");
 
-    matchOneToMany(jetRefProd,*jets,"jet",muRefProd,*muons,"muons");
-    matchOneToMany(jetRefProd,*jets,"jet",eleRefProd,*electrons,"electrons");
-    matchOneToMany(jetRefProd,*jets,"jet",tauRefProd,*taus,"taus");
-    matchOneToMany(jetRefProd,*jets,"jet",phRefProd,*photons,"photons");
+  matchElectronToPhoton(eleRefProd, *electrons, "electron", phRefProd, *photons, "photons");
 
-    matchElectronToPhoton(eleRefProd,*electrons,"electron",phRefProd,*photons,"photons");
-
-    iEvent.put(std::move(jets),"jets");
-    iEvent.put(std::move(muons),"muons");
-    iEvent.put(std::move(electrons),"electrons");
-    iEvent.put(std::move(taus),"taus");
-    iEvent.put(std::move(photons),"photons");
- 
+  iEvent.put(std::move(jets), "jets");
+  iEvent.put(std::move(muons), "muons");
+  iEvent.put(std::move(electrons), "electrons");
+  iEvent.put(std::move(taus), "taus");
+  iEvent.put(std::move(photons), "photons");
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-PATObjectCrossLinker::beginStream(edm::StreamID)
-{
-}
+void PATObjectCrossLinker::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-PATObjectCrossLinker::endStream() {
-}
+void PATObjectCrossLinker::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-PATObjectCrossLinker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PATObjectCrossLinker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/PhysicsTools/PatAlgos/plugins/PATObjectFilter.h
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectFilter.h
@@ -15,9 +15,10 @@
 
 namespace pat {
 
-  typedef ObjectCountFilter<edm::View<reco::Candidate>, AnySelector, AndSelector<MinNumberSelector, MaxNumberSelector> >::type PATCandViewCountFilter;
+  typedef ObjectCountFilter<edm::View<reco::Candidate>,
+                            AnySelector,
+                            AndSelector<MinNumberSelector, MaxNumberSelector> >::type PATCandViewCountFilter;
 
 }
-
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATObjectSelector.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectSelector.cc
@@ -14,7 +14,6 @@ DEFINE_FWK_MODULE(PATCompositeCandidateSelector);
 DEFINE_FWK_MODULE(PATTriggerObjectStandAloneSelector);
 DEFINE_FWK_MODULE(PATGenericParticleSelector);
 
-
 DEFINE_FWK_MODULE(PATElectronRefSelector);
 DEFINE_FWK_MODULE(PATMuonRefSelector);
 DEFINE_FWK_MODULE(PATTauRefSelector);
@@ -25,7 +24,5 @@ DEFINE_FWK_MODULE(PATPFParticleRefSelector);
 DEFINE_FWK_MODULE(PATGenericParticleRefSelector);
 DEFINE_FWK_MODULE(PATCompositeCandidateRefSelector);
 
-
 DEFINE_FWK_MODULE(IsoTrackSelector);
 DEFINE_FWK_MODULE(MuonRefPatCount);
-

--- a/PhysicsTools/PatAlgos/plugins/PATObjectSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectSelector.h
@@ -28,110 +28,61 @@
 
 #include <vector>
 
-
 namespace pat {
 
-
-  typedef SingleObjectSelector<
-              std::vector<Electron>,
-              StringCutObjectSelector<Electron>
-          > PATElectronSelector;
-  typedef SingleObjectSelector<
-              std::vector<Muon>,
-              StringCutObjectSelector<Muon>
-          > PATMuonSelector;
-  typedef SingleObjectSelector<
-              std::vector<Tau>,
-              StringCutObjectSelector<Tau>
-          > PATTauSelector;
-  typedef SingleObjectSelector<
-              std::vector<Photon>,
-              StringCutObjectSelector<Photon>
-          > PATPhotonSelector;
+  typedef SingleObjectSelector<std::vector<Electron>, StringCutObjectSelector<Electron> > PATElectronSelector;
+  typedef SingleObjectSelector<std::vector<Muon>, StringCutObjectSelector<Muon> > PATMuonSelector;
+  typedef SingleObjectSelector<std::vector<Tau>, StringCutObjectSelector<Tau> > PATTauSelector;
+  typedef SingleObjectSelector<std::vector<Photon>, StringCutObjectSelector<Photon> > PATPhotonSelector;
   /* typedef SingleObjectSelector< */
   /*             std::vector<Jet>, */
   /*             StringCutObjectSelector<Jet> */
   /*         > PATJetSelector; */
+  typedef SingleObjectSelector<std::vector<MET>, StringCutObjectSelector<MET> > PATMETSelector;
+  typedef SingleObjectSelector<std::vector<PFParticle>, StringCutObjectSelector<PFParticle> > PATPFParticleSelector;
   typedef SingleObjectSelector<
-              std::vector<MET>,
-              StringCutObjectSelector<MET>
-          > PATMETSelector;
-  typedef SingleObjectSelector<
-              std::vector<PFParticle>,
-              StringCutObjectSelector<PFParticle>
-          > PATPFParticleSelector;
-  typedef SingleObjectSelector<
-              std::vector<CompositeCandidate>,
-              StringCutObjectSelector<CompositeCandidate, true> // true => lazy parsing => get all methods of daughters
-          > PATCompositeCandidateSelector;
-  typedef SingleObjectSelector<
-              std::vector<TriggerObjectStandAlone>,
-              StringCutObjectSelector<TriggerObjectStandAlone>
-          > PATTriggerObjectStandAloneSelector;
-  typedef SingleObjectSelector<
-              std::vector<GenericParticle>,
-              StringCutObjectSelector<GenericParticle>
-          > PATGenericParticleSelector;
+      std::vector<CompositeCandidate>,
+      StringCutObjectSelector<CompositeCandidate, true>  // true => lazy parsing => get all methods of daughters
+      >
+      PATCompositeCandidateSelector;
+  typedef SingleObjectSelector<std::vector<TriggerObjectStandAlone>, StringCutObjectSelector<TriggerObjectStandAlone> >
+      PATTriggerObjectStandAloneSelector;
+  typedef SingleObjectSelector<std::vector<GenericParticle>, StringCutObjectSelector<GenericParticle> >
+      PATGenericParticleSelector;
 
+  typedef SingleObjectSelector<std::vector<Electron>,
+                               StringCutObjectSelector<Electron>,
+                               edm::RefVector<std::vector<Electron> > >
+      PATElectronRefSelector;
+  typedef SingleObjectSelector<std::vector<Muon>, StringCutObjectSelector<Muon>, edm::RefVector<std::vector<Muon> > >
+      PATMuonRefSelector;
+  typedef SingleObjectSelector<std::vector<Tau>, StringCutObjectSelector<Tau>, edm::RefVector<std::vector<Tau> > >
+      PATTauRefSelector;
+  typedef SingleObjectSelector<std::vector<Photon>, StringCutObjectSelector<Photon>, edm::RefVector<std::vector<Photon> > >
+      PATPhotonRefSelector;
+  typedef SingleObjectSelector<std::vector<Jet>, StringCutObjectSelector<Jet>, edm::RefVector<std::vector<Jet> > >
+      PATJetRefSelector;
+  typedef SingleObjectSelector<std::vector<MET>, StringCutObjectSelector<MET>, edm::RefVector<std::vector<MET> > >
+      PATMETRefSelector;
+  typedef SingleObjectSelector<std::vector<PFParticle>,
+                               StringCutObjectSelector<PFParticle>,
+                               edm::RefVector<std::vector<PFParticle> > >
+      PATPFParticleRefSelector;
+  typedef SingleObjectSelector<std::vector<GenericParticle>,
+                               StringCutObjectSelector<GenericParticle>,
+                               edm::RefVector<std::vector<GenericParticle> > >
+      PATGenericParticleRefSelector;
   typedef SingleObjectSelector<
-              std::vector<Electron>,
-              StringCutObjectSelector<Electron>,
-              edm::RefVector<std::vector<Electron> >
-          > PATElectronRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<Muon>,
-              StringCutObjectSelector<Muon>,
-              edm::RefVector<std::vector<Muon> >
-          > PATMuonRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<Tau>,
-              StringCutObjectSelector<Tau>,
-              edm::RefVector<std::vector<Tau> >
-          > PATTauRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<Photon>,
-              StringCutObjectSelector<Photon>,
-              edm::RefVector<std::vector<Photon> >
-          > PATPhotonRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<Jet>,
-              StringCutObjectSelector<Jet>,
-              edm::RefVector<std::vector<Jet> >
-          > PATJetRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<MET>,
-              StringCutObjectSelector<MET>,
-              edm::RefVector<std::vector<MET> >
-          > PATMETRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<PFParticle>,
-              StringCutObjectSelector<PFParticle>,
-              edm::RefVector<std::vector<PFParticle> >
-          > PATPFParticleRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<GenericParticle>,
-              StringCutObjectSelector<GenericParticle>,
-              edm::RefVector<std::vector<GenericParticle> >
-          > PATGenericParticleRefSelector;
-  typedef SingleObjectSelector<
-              std::vector<CompositeCandidate>,
-              StringCutObjectSelector<CompositeCandidate, true>, // true => lazy parsing => get all methods of daughters
-              edm::RefVector<std::vector<CompositeCandidate> >
-          > PATCompositeCandidateRefSelector;
+      std::vector<CompositeCandidate>,
+      StringCutObjectSelector<CompositeCandidate, true>,  // true => lazy parsing => get all methods of daughters
+      edm::RefVector<std::vector<CompositeCandidate> > >
+      PATCompositeCandidateRefSelector;
 
-  typedef SingleObjectSelector<
-              pat::IsolatedTrackCollection, 
-              StringCutObjectSelector<pat::IsolatedTrack> 
-          > IsoTrackSelector;
+  typedef SingleObjectSelector<pat::IsolatedTrackCollection, StringCutObjectSelector<pat::IsolatedTrack> >
+      IsoTrackSelector;
 
-  typedef ObjectCountFilter<
-              pat::MuonCollection, 
-              StringCutObjectSelector<pat::Muon>
-	  >::type MuonRefPatCount;
+  typedef ObjectCountFilter<pat::MuonCollection, StringCutObjectSelector<pat::Muon> >::type MuonRefPatCount;
 
-
-
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectUserDataEmbedder.cc
@@ -14,110 +14,116 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 namespace pat {
-  
+
   namespace helper {
 
     struct AddUserIntFromBool {
-      typedef bool                       value_type;
+      typedef bool value_type;
       typedef edm::ValueMap<value_type> product_type;
-      template<typename ObjectType>
-      void addData(ObjectType &obj, const std::string & key, const value_type &val) { obj.addUserInt(key, val); }
+      template <typename ObjectType>
+      void addData(ObjectType &obj, const std::string &key, const value_type &val) {
+        obj.addUserInt(key, val);
+      }
     };
 
-      template<typename A> 
-      class NamedUserDataLoader {
-        public:
-            NamedUserDataLoader(const edm::ParameterSet & iConfig, const std::string & main, edm::ConsumesCollector && cc) {
-                if (iConfig.existsAs<edm::ParameterSet>(main)) {
-                    edm::ParameterSet const & srcPSet = iConfig.getParameter<edm::ParameterSet>(main);
-                    for (const std::string & label : srcPSet.getParameterNamesForType<edm::InputTag>()) {
-                        labelsAndTokens_.emplace_back(label, cc.consumes<typename A::product_type>(srcPSet.getParameter<edm::InputTag>(label)));
-                    }
-                }
-            }
-            template<typename T> 
-            void addData(const edm::Event &iEvent, const std::vector<edm::Ptr<T>> & ptrs, std::vector<T> & out) const {
-                A adder;
-                unsigned int n = ptrs.size();
-                edm::Handle<typename A::product_type> handle;
-                for (const auto & pair : labelsAndTokens_) {
-                    iEvent.getByToken(pair.second, handle);
-                    for (unsigned int i = 0; i < n; ++i) {
-                        adder.addData(out[i], pair.first, (*handle)[ptrs[i]]);
-                    }
-                }
-            } 
-        private:
-            std::vector<std::pair<std::string,edm::EDGetTokenT<typename A::product_type>>> labelsAndTokens_;
-      }; // class NamedUserDataLoader
-  } // namespace helper
-
-  template<typename T>
-  class PATObjectUserDataEmbedder : public edm::stream::EDProducer<> {
-
+    template <typename A>
+    class NamedUserDataLoader {
     public:
-
-      explicit PATObjectUserDataEmbedder(const edm::ParameterSet & iConfig) :
-            src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src"))),
-            userFloats_(iConfig, "userFloats", consumesCollector()), 
-            userInts_(iConfig, "userInts", consumesCollector()), 
-            userIntFromBools_(iConfig, "userIntFromBools", consumesCollector()), 
-            userCands_(iConfig, "userCands", consumesCollector())
-        {
-            produces<std::vector<T>>();
-        }
-
-      ~PATObjectUserDataEmbedder() override {}
-
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-          edm::ParameterSetDescription desc;
-          desc.add<edm::InputTag>("src");
-          for (const std::string & what : { "userFloats", "userInts", "userIntFromBools", "userCands" }) {
-              edm::ParameterSetDescription descNested;
-              descNested.addWildcard<edm::InputTag>("*");
-              desc.add<edm::ParameterSetDescription>(what, descNested);
+      NamedUserDataLoader(const edm::ParameterSet &iConfig, const std::string &main, edm::ConsumesCollector &&cc) {
+        if (iConfig.existsAs<edm::ParameterSet>(main)) {
+          edm::ParameterSet const &srcPSet = iConfig.getParameter<edm::ParameterSet>(main);
+          for (const std::string &label : srcPSet.getParameterNamesForType<edm::InputTag>()) {
+            labelsAndTokens_.emplace_back(
+                label, cc.consumes<typename A::product_type>(srcPSet.getParameter<edm::InputTag>(label)));
           }
-          if (typeid(T) == typeid(pat::Muon)) descriptions.add("muonsWithUserData", desc);
-          else if (typeid(T) == typeid(pat::Electron)) descriptions.add("electronsWithUserData", desc);
-          else if (typeid(T) == typeid(pat::Photon)) descriptions.add("photonsWithUserData", desc);
-          else if (typeid(T) == typeid(pat::Tau)) descriptions.add("tausWithUserData", desc);
-          else if (typeid(T) == typeid(pat::Jet)) descriptions.add("jetsWithUserData", desc);
+        }
+      }
+      template <typename T>
+      void addData(const edm::Event &iEvent, const std::vector<edm::Ptr<T>> &ptrs, std::vector<T> &out) const {
+        A adder;
+        unsigned int n = ptrs.size();
+        edm::Handle<typename A::product_type> handle;
+        for (const auto &pair : labelsAndTokens_) {
+          iEvent.getByToken(pair.second, handle);
+          for (unsigned int i = 0; i < n; ++i) {
+            adder.addData(out[i], pair.first, (*handle)[ptrs[i]]);
+          }
+        }
       }
 
     private:
-      // configurables
-      edm::EDGetTokenT<edm::View<T>> src_;
-      helper::NamedUserDataLoader<pat::helper::AddUserFloat> userFloats_;
-      helper::NamedUserDataLoader<pat::helper::AddUserInt>   userInts_;
-      helper::NamedUserDataLoader<pat::helper::AddUserIntFromBool>   userIntFromBools_;
-      helper::NamedUserDataLoader<pat::helper::AddUserCand>  userCands_;
+      std::vector<std::pair<std::string, edm::EDGetTokenT<typename A::product_type>>> labelsAndTokens_;
+    };  // class NamedUserDataLoader
+  }     // namespace helper
+
+  template <typename T>
+  class PATObjectUserDataEmbedder : public edm::stream::EDProducer<> {
+  public:
+    explicit PATObjectUserDataEmbedder(const edm::ParameterSet &iConfig)
+        : src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src"))),
+          userFloats_(iConfig, "userFloats", consumesCollector()),
+          userInts_(iConfig, "userInts", consumesCollector()),
+          userIntFromBools_(iConfig, "userIntFromBools", consumesCollector()),
+          userCands_(iConfig, "userCands", consumesCollector()) {
+      produces<std::vector<T>>();
+    }
+
+    ~PATObjectUserDataEmbedder() override {}
+
+    void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("src");
+      for (const std::string &what : {"userFloats", "userInts", "userIntFromBools", "userCands"}) {
+        edm::ParameterSetDescription descNested;
+        descNested.addWildcard<edm::InputTag>("*");
+        desc.add<edm::ParameterSetDescription>(what, descNested);
+      }
+      if (typeid(T) == typeid(pat::Muon))
+        descriptions.add("muonsWithUserData", desc);
+      else if (typeid(T) == typeid(pat::Electron))
+        descriptions.add("electronsWithUserData", desc);
+      else if (typeid(T) == typeid(pat::Photon))
+        descriptions.add("photonsWithUserData", desc);
+      else if (typeid(T) == typeid(pat::Tau))
+        descriptions.add("tausWithUserData", desc);
+      else if (typeid(T) == typeid(pat::Jet))
+        descriptions.add("jetsWithUserData", desc);
+    }
+
+  private:
+    // configurables
+    edm::EDGetTokenT<edm::View<T>> src_;
+    helper::NamedUserDataLoader<pat::helper::AddUserFloat> userFloats_;
+    helper::NamedUserDataLoader<pat::helper::AddUserInt> userInts_;
+    helper::NamedUserDataLoader<pat::helper::AddUserIntFromBool> userIntFromBools_;
+    helper::NamedUserDataLoader<pat::helper::AddUserCand> userCands_;
   };
 
-}
+}  // namespace pat
 
-template<typename T>
-void pat::PATObjectUserDataEmbedder<T>::produce(edm::Event & iEvent, const edm::EventSetup& iSetup) {
-    edm::Handle<edm::View<T>> src;
-    iEvent.getByToken(src_, src);
+template <typename T>
+void pat::PATObjectUserDataEmbedder<T>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::Handle<edm::View<T>> src;
+  iEvent.getByToken(src_, src);
 
-    std::unique_ptr<std::vector<T>> out(new std::vector<T>());
-    out->reserve(src->size());
+  std::unique_ptr<std::vector<T>> out(new std::vector<T>());
+  out->reserve(src->size());
 
-    std::vector<edm::Ptr<T>> ptrs;
-    ptrs.reserve(src->size());
-    for (unsigned int i = 0, n = src->size(); i < n; ++i) {
-        // copy by value, save the ptr
-        out->push_back((*src)[i]);
-        ptrs.push_back(src->ptrAt(i));
-    }
-    userFloats_.addData(iEvent, ptrs, *out);
-    userInts_.addData(iEvent, ptrs, *out);
-    userIntFromBools_.addData(iEvent, ptrs, *out);
-    userCands_.addData(iEvent, ptrs, *out);
+  std::vector<edm::Ptr<T>> ptrs;
+  ptrs.reserve(src->size());
+  for (unsigned int i = 0, n = src->size(); i < n; ++i) {
+    // copy by value, save the ptr
+    out->push_back((*src)[i]);
+    ptrs.push_back(src->ptrAt(i));
+  }
+  userFloats_.addData(iEvent, ptrs, *out);
+  userInts_.addData(iEvent, ptrs, *out);
+  userIntFromBools_.addData(iEvent, ptrs, *out);
+  userCands_.addData(iEvent, ptrs, *out);
 
-    iEvent.put(std::move(out));
+  iEvent.put(std::move(out));
 }
 
 typedef pat::PATObjectUserDataEmbedder<pat::Electron> PATElectronUserDataEmbedder;

--- a/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.h
@@ -15,7 +15,6 @@
   \version  $Id: PATPFParticleProducer.h,v 1.8 2012/05/26 10:42:53 gpetrucc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -35,44 +34,37 @@
 
 #include <string>
 
-
 namespace pat {
 
   class LeptonLRCalc;
 
   class PATPFParticleProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATPFParticleProducer(const edm::ParameterSet& iConfig);
+    ~PATPFParticleProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATPFParticleProducer(const edm::ParameterSet & iConfig);
-      ~PATPFParticleProducer() override;
+  private:
+    // configurables
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > pfCandidateToken_;
+    bool embedPFCandidate_;
+    bool addGenMatch_;
+    bool embedGenMatch_;
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    // tools
+    GreaterByPt<PFParticle> pTComparator_;
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-    private:
+    bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      // configurables
-      edm::EDGetTokenT<edm::View<reco::PFCandidate> > pfCandidateToken_;
-      bool          embedPFCandidate_;
-      bool          addGenMatch_;
-      bool          embedGenMatch_;
-      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
-      // tools
-      GreaterByPt<PFParticle>      pTComparator_;
-
-      bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
-
-      bool addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
-
-      bool useUserData_;
-      pat::PATUserDataHelper<pat::PFParticle> userDataHelper_;
-
-
+    bool useUserData_;
+    pat::PATUserDataHelper<pat::PFParticle> userDataHelper_;
   };
 
-
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -33,154 +33,119 @@
 //#define CRAZYSORT
 
 namespace pat {
-/// conversion map from quality flags used in PV association and miniAOD one
-const static int qualityMap[8] = {1, 0, 1, 1, 4, 4, 5, 6};
+  /// conversion map from quality flags used in PV association and miniAOD one
+  const static int qualityMap[8] = {1, 0, 1, 1, 4, 4, 5, 6};
 
-class PATPackedCandidateProducer : public edm::global::EDProducer<> {
-public:
-  explicit PATPackedCandidateProducer(const edm::ParameterSet &);
-  ~PATPackedCandidateProducer() override;
+  class PATPackedCandidateProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PATPackedCandidateProducer(const edm::ParameterSet &);
+    ~PATPackedCandidateProducer() override;
 
-  void produce(edm::StreamID, edm::Event &,
-               const edm::EventSetup &) const override;
+    void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
-  // sorting of cands to maximize the zlib compression
-  static bool candsOrdering(pat::PackedCandidate const &i,
-                            pat::PackedCandidate const &j) {
-    if (std::abs(i.charge()) == std::abs(j.charge())) {
-      if (i.charge() != 0) {
-        if (i.hasTrackDetails() and !j.hasTrackDetails())
-          return true;
-        if (!i.hasTrackDetails() and j.hasTrackDetails())
-          return false;
-        if (i.covarianceSchema() > j.covarianceSchema())
-          return true;
-        if (i.covarianceSchema() < j.covarianceSchema())
-          return false;
+    // sorting of cands to maximize the zlib compression
+    static bool candsOrdering(pat::PackedCandidate const &i, pat::PackedCandidate const &j) {
+      if (std::abs(i.charge()) == std::abs(j.charge())) {
+        if (i.charge() != 0) {
+          if (i.hasTrackDetails() and !j.hasTrackDetails())
+            return true;
+          if (!i.hasTrackDetails() and j.hasTrackDetails())
+            return false;
+          if (i.covarianceSchema() > j.covarianceSchema())
+            return true;
+          if (i.covarianceSchema() < j.covarianceSchema())
+            return false;
+        }
+        if (i.vertexRef() == j.vertexRef())
+          return i.eta() > j.eta();
+        else
+          return i.vertexRef().key() < j.vertexRef().key();
       }
-      if (i.vertexRef() == j.vertexRef())
-        return i.eta() > j.eta();
-      else
-        return i.vertexRef().key() < j.vertexRef().key();
+      return std::abs(i.charge()) > std::abs(j.charge());
     }
-    return std::abs(i.charge()) > std::abs(j.charge());
-  }
 
-  template <typename T>
-  static std::vector<size_t> sort_indexes(const std::vector<T> &v) {
-    std::vector<size_t> idx(v.size());
-    for (size_t i = 0; i != idx.size(); ++i)
-      idx[i] = i;
-    std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) {
-      return candsOrdering(v[i1], v[i2]);
-    });
-    return idx;
-  }
+    template <typename T>
+    static std::vector<size_t> sort_indexes(const std::vector<T> &v) {
+      std::vector<size_t> idx(v.size());
+      for (size_t i = 0; i != idx.size(); ++i)
+        idx[i] = i;
+      std::sort(idx.begin(), idx.end(), [&v](size_t i1, size_t i2) { return candsOrdering(v[i1], v[i2]); });
+      return idx;
+    }
 
-private:
-  // if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
-  // otherwise assumes that if they are set, you wanted to use puppi and will
-  // throw an exception if the puppis are not found
-  const bool usePuppi_;
+  private:
+    // if PuppiSrc && PuppiNoLepSrc are empty, usePuppi is false
+    // otherwise assumes that if they are set, you wanted to use puppi and will
+    // throw an exception if the puppis are not found
+    const bool usePuppi_;
 
-  const edm::EDGetTokenT<reco::PFCandidateCollection> Cands_;
-  const edm::EDGetTokenT<reco::VertexCollection> PVs_;
-  const edm::EDGetTokenT<edm::Association<reco::VertexCollection>> PVAsso_;
-  const edm::EDGetTokenT<edm::ValueMap<int>> PVAssoQuality_;
-  const edm::EDGetTokenT<reco::VertexCollection> PVOrigs_;
-  const edm::EDGetTokenT<reco::TrackCollection> TKOrigs_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeight_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeightNoLep_;
-  const edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> PuppiCandsMap_;
-  const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCands_;
-  const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCandsNoLep_;
-  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> SVWhiteLists_;
-  const bool storeChargedHadronIsolation_;
-  const edm::EDGetTokenT<edm::ValueMap<bool>> ChargedHadronIsolation_;
+    const edm::EDGetTokenT<reco::PFCandidateCollection> Cands_;
+    const edm::EDGetTokenT<reco::VertexCollection> PVs_;
+    const edm::EDGetTokenT<edm::Association<reco::VertexCollection>> PVAsso_;
+    const edm::EDGetTokenT<edm::ValueMap<int>> PVAssoQuality_;
+    const edm::EDGetTokenT<reco::VertexCollection> PVOrigs_;
+    const edm::EDGetTokenT<reco::TrackCollection> TKOrigs_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeight_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> PuppiWeightNoLep_;
+    const edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> PuppiCandsMap_;
+    const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCands_;
+    const edm::EDGetTokenT<std::vector<reco::PFCandidate>> PuppiCandsNoLep_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> SVWhiteLists_;
+    const bool storeChargedHadronIsolation_;
+    const edm::EDGetTokenT<edm::ValueMap<bool>> ChargedHadronIsolation_;
 
-  const double minPtForChargedHadronProperties_;
-  const double minPtForTrackProperties_;
-  const int covarianceVersion_;
-  const std::vector<int> covariancePackingSchemas_;
+    const double minPtForChargedHadronProperties_;
+    const double minPtForTrackProperties_;
+    const int covarianceVersion_;
+    const std::vector<int> covariancePackingSchemas_;
 
-  const std::vector<int> pfCandidateTypesForHcalDepth_;
-  const bool storeHcalDepthEndcapOnly_;
+    const std::vector<int> pfCandidateTypesForHcalDepth_;
+    const bool storeHcalDepthEndcapOnly_;
 
-  const bool storeTiming_;
+    const bool storeTiming_;
 
-  // for debugging
-  float calcDxy(float dx, float dy, float phi) const {
-    return -dx * std::sin(phi) + dy * std::cos(phi);
-  }
-  float calcDz(reco::Candidate::Point p, reco::Candidate::Point v,
-               const reco::Candidate &c) const {
-    return p.Z() - v.Z() -
-           ((p.X() - v.X()) * c.px() + (p.Y() - v.Y()) * c.py()) * c.pz() /
-               (c.pt() * c.pt());
-  }
-};
-} // namespace pat
+    // for debugging
+    float calcDxy(float dx, float dy, float phi) const { return -dx * std::sin(phi) + dy * std::cos(phi); }
+    float calcDz(reco::Candidate::Point p, reco::Candidate::Point v, const reco::Candidate &c) const {
+      return p.Z() - v.Z() - ((p.X() - v.X()) * c.px() + (p.Y() - v.Y()) * c.py()) * c.pz() / (c.pt() * c.pt());
+    }
+  };
+}  // namespace pat
 
-pat::PATPackedCandidateProducer::PATPackedCandidateProducer(
-    const edm::ParameterSet &iConfig)
-    : usePuppi_(
-          !iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() ||
-          !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")
-               .encode()
-               .empty()),
-      Cands_(consumes<reco::PFCandidateCollection>(
-          iConfig.getParameter<edm::InputTag>("inputCollection"))),
-      PVs_(consumes<reco::VertexCollection>(
-          iConfig.getParameter<edm::InputTag>("inputVertices"))),
-      PVAsso_(consumes<edm::Association<reco::VertexCollection>>(
-          iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
-      PVAssoQuality_(consumes<edm::ValueMap<int>>(
-          iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
-      PVOrigs_(consumes<reco::VertexCollection>(
-          iConfig.getParameter<edm::InputTag>("originalVertices"))),
-      TKOrigs_(consumes<reco::TrackCollection>(
-          iConfig.getParameter<edm::InputTag>("originalTracks"))),
-      PuppiWeight_(usePuppi_
-                       ? consumes<edm::ValueMap<float>>(
-                             iConfig.getParameter<edm::InputTag>("PuppiSrc"))
-                       : edm::EDGetTokenT<edm::ValueMap<float>>()),
-      PuppiWeightNoLep_(
-          usePuppi_ ? consumes<edm::ValueMap<float>>(
-                          iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
-                    : edm::EDGetTokenT<edm::ValueMap<float>>()),
-      PuppiCandsMap_(
-          usePuppi_ ? consumes<edm::ValueMap<reco::CandidatePtr>>(
-                          iConfig.getParameter<edm::InputTag>("PuppiSrc"))
-                    : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>>()),
-      PuppiCands_(usePuppi_
-                      ? consumes<std::vector<reco::PFCandidate>>(
-                            iConfig.getParameter<edm::InputTag>("PuppiSrc"))
-                      : edm::EDGetTokenT<std::vector<reco::PFCandidate>>()),
+pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::ParameterSet &iConfig)
+    : usePuppi_(!iConfig.getParameter<edm::InputTag>("PuppiSrc").encode().empty() ||
+                !iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc").encode().empty()),
+      Cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCollection"))),
+      PVs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("inputVertices"))),
+      PVAsso_(
+          consumes<edm::Association<reco::VertexCollection>>(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
+      PVAssoQuality_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
+      PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
+      TKOrigs_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("originalTracks"))),
+      PuppiWeight_(usePuppi_ ? consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("PuppiSrc"))
+                             : edm::EDGetTokenT<edm::ValueMap<float>>()),
+      PuppiWeightNoLep_(usePuppi_ ? consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
+                                  : edm::EDGetTokenT<edm::ValueMap<float>>()),
+      PuppiCandsMap_(usePuppi_
+                         ? consumes<edm::ValueMap<reco::CandidatePtr>>(iConfig.getParameter<edm::InputTag>("PuppiSrc"))
+                         : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>>()),
+      PuppiCands_(usePuppi_ ? consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("PuppiSrc"))
+                            : edm::EDGetTokenT<std::vector<reco::PFCandidate>>()),
       PuppiCandsNoLep_(
-          usePuppi_ ? consumes<std::vector<reco::PFCandidate>>(
-                          iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
+          usePuppi_ ? consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc"))
                     : edm::EDGetTokenT<std::vector<reco::PFCandidate>>()),
-      storeChargedHadronIsolation_(
-          !iConfig.getParameter<edm::InputTag>("chargedHadronIsolation")
-               .encode()
-               .empty()),
-      ChargedHadronIsolation_(consumes<edm::ValueMap<bool>>(
-          iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
-      minPtForChargedHadronProperties_(
-          iConfig.getParameter<double>("minPtForChargedHadronProperties")),
-      minPtForTrackProperties_(
-          iConfig.getParameter<double>("minPtForTrackProperties")),
+      storeChargedHadronIsolation_(!iConfig.getParameter<edm::InputTag>("chargedHadronIsolation").encode().empty()),
+      ChargedHadronIsolation_(
+          consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
+      minPtForChargedHadronProperties_(iConfig.getParameter<double>("minPtForChargedHadronProperties")),
+      minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
-      covariancePackingSchemas_(
-          iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
-      pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int>>(
-          "pfCandidateTypesForHcalDepth")),
-      storeHcalDepthEndcapOnly_(
-          iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
+      covariancePackingSchemas_(iConfig.getParameter<std::vector<int>>("covariancePackingSchemas")),
+      pfCandidateTypesForHcalDepth_(iConfig.getParameter<std::vector<int>>("pfCandidateTypesForHcalDepth")),
+      storeHcalDepthEndcapOnly_(iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
       storeTiming_(iConfig.getParameter<bool>("storeTiming")) {
   std::vector<edm::InputTag> sv_tags =
-      iConfig.getParameter<std::vector<edm::InputTag>>(
-          "secondaryVerticesForWhiteList");
+      iConfig.getParameter<std::vector<edm::InputTag>>("secondaryVerticesForWhiteList");
   for (auto itag : sv_tags) {
     SVWhiteLists_.push_back(consumes<edm::View<reco::Candidate>>(itag));
   }
@@ -190,14 +155,12 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(
   produces<edm::Association<reco::PFCandidateCollection>>();
 
   if (not pfCandidateTypesForHcalDepth_.empty())
-    produces<edm::ValueMap<pat::HcalDepthEnergyFractions>>(
-        "hcalDepthEnergyFractions");
+    produces<edm::ValueMap<pat::HcalDepthEnergyFractions>>("hcalDepthEnergyFractions");
 }
 
 pat::PATPackedCandidateProducer::~PATPackedCandidateProducer() {}
 
-void pat::PATPackedCandidateProducer::produce(
-    edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   edm::Handle<reco::PFCandidateCollection> cands;
   iEvent.getByToken(Cands_, cands);
 
@@ -226,8 +189,7 @@ void pat::PATPackedCandidateProducer::produce(
   iEvent.getByToken(PVAsso_, assoHandle);
   edm::Handle<edm::ValueMap<int>> assoQualityHandle;
   iEvent.getByToken(PVAssoQuality_, assoQualityHandle);
-  const edm::Association<reco::VertexCollection> &associatedPV =
-      *(assoHandle.product());
+  const edm::Association<reco::VertexCollection> &associatedPV = *(assoHandle.product());
   const edm::ValueMap<int> &associationQuality = *(assoQualityHandle.product());
 
   edm::Handle<edm::ValueMap<bool>> chargedHadronIsolationHandle;
@@ -239,22 +201,17 @@ void pat::PATPackedCandidateProducer::produce(
   for (auto itoken : SVWhiteLists_) {
     edm::Handle<edm::View<reco::Candidate>> svWhiteListHandle;
     iEvent.getByToken(itoken, svWhiteListHandle);
-    const edm::View<reco::Candidate> &svWhiteList =
-        *(svWhiteListHandle.product());
+    const edm::View<reco::Candidate> &svWhiteList = *(svWhiteListHandle.product());
     for (unsigned int i = 0; i < svWhiteList.size(); i++) {
       // Whitelist via Ptrs
-      for (unsigned int j = 0; j < svWhiteList[i].numberOfSourceCandidatePtrs();
-           j++) {
-        const edm::Ptr<reco::Candidate> &c =
-            svWhiteList[i].sourceCandidatePtr(j);
+      for (unsigned int j = 0; j < svWhiteList[i].numberOfSourceCandidatePtrs(); j++) {
+        const edm::Ptr<reco::Candidate> &c = svWhiteList[i].sourceCandidatePtr(j);
         if (c.id() == cands.id())
           whiteList.insert(c.key());
       }
       // Whitelist via RecoCharged
-      for (auto dau = svWhiteList[i].begin(); dau != svWhiteList[i].end();
-           dau++) {
-        const reco::RecoChargedCandidate *chCand =
-            dynamic_cast<const reco::RecoChargedCandidate *>(&(*dau));
+      for (auto dau = svWhiteList[i].begin(); dau != svWhiteList[i].end(); dau++) {
+        const reco::RecoChargedCandidate *chCand = dynamic_cast<const reco::RecoChargedCandidate *>(&(*dau));
         if (chCand != nullptr) {
           whiteListTk.insert(chCand->track());
         }
@@ -283,8 +240,7 @@ void pat::PATPackedCandidateProducer::produce(
   for (unsigned int ic = 0, nc = cands->size(); ic < nc; ++ic) {
     const reco::PFCandidate &cand = (*cands)[ic];
     const reco::Track *ctrack = nullptr;
-    if ((abs(cand.pdgId()) == 11 || cand.pdgId() == 22) &&
-        cand.gsfTrackRef().isNonnull()) {
+    if ((abs(cand.pdgId()) == 11 || cand.pdgId() == 22) && cand.gsfTrackRef().isNonnull()) {
       ctrack = &*cand.gsfTrackRef();
     } else if (cand.trackRef().isNonnull()) {
       ctrack = &*cand.trackRef();
@@ -301,15 +257,11 @@ void pat::PATPackedCandidateProducer::produce(
       }
       PV = reco::VertexRef(PVs, pvi);
       math::XYZPoint vtx = cand.vertex();
-      pat::PackedCandidate::LostInnerHits lostHits =
-          pat::PackedCandidate::noLostInnerHits;
-      const reco::VertexRef &PVOrig =
-          associatedPV[reco::CandidatePtr(cands, ic)];
+      pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
+      const reco::VertexRef &PVOrig = associatedPV[reco::CandidatePtr(cands, ic)];
       if (PVOrig.isNonnull())
-        PV = reco::VertexRef(
-            PVs,
-            PVOrig
-                .key()); // WARNING: assume the PV slimmer is keeping same order
+        PV = reco::VertexRef(PVs,
+                             PVOrig.key());  // WARNING: assume the PV slimmer is keeping same order
       int quality = associationQuality[reco::CandidatePtr(cands, ic)];
       //          if ((size_t)pvi!=PVOrig.key()) std::cout << "not closest in Z"
       //          << pvi << " " << PVOrig.key() << " " << cand.pt() << " " <<
@@ -323,72 +275,59 @@ void pat::PATPackedCandidateProducer::produce(
       float etaAtVtx = ctrack->eta();
       float phiAtVtx = ctrack->phi();
 
-      int nlost = ctrack->hitPattern().numberOfLostHits(
-          reco::HitPattern::MISSING_INNER_HITS);
+      int nlost = ctrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
       if (nlost == 0) {
-        if (ctrack->hitPattern().hasValidHitInPixelLayer(
-                PixelSubdetector::SubDetector::PixelBarrel, 1)) {
+        if (ctrack->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
           lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
         }
       } else {
-        lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit
-                               : pat::PackedCandidate::moreLostInnerHits);
+        lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
       }
 
-      outPtrP->push_back(pat::PackedCandidate(cand.polarP4(), vtx, ptTrk,
-                                              etaAtVtx, phiAtVtx, cand.pdgId(),
-                                              PVRefProd, PV.key()));
-      outPtrP->back().setAssociationQuality(
-          pat::PackedCandidate::PVAssociationQuality(qualityMap[quality]));
+      outPtrP->push_back(
+          pat::PackedCandidate(cand.polarP4(), vtx, ptTrk, etaAtVtx, phiAtVtx, cand.pdgId(), PVRefProd, PV.key()));
+      outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(qualityMap[quality]));
       outPtrP->back().setCovarianceVersion(covarianceVersion_);
-      if (cand.trackRef().isNonnull() && PVOrig.isNonnull() &&
-          PVOrig->trackWeight(cand.trackRef()) > 0.5 && quality == 7) {
-        outPtrP->back().setAssociationQuality(
-            pat::PackedCandidate::UsedInFitTight);
+      if (cand.trackRef().isNonnull() && PVOrig.isNonnull() && PVOrig->trackWeight(cand.trackRef()) > 0.5 &&
+          quality == 7) {
+        outPtrP->back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
       }
       // properties of the best track
       outPtrP->back().setLostInnerHits(lostHits);
-      if (outPtrP->back().pt() > minPtForTrackProperties_ ||
-          outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
+      if (outPtrP->back().pt() > minPtForTrackProperties_ || outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
           whiteList.find(ic) != whiteList.end() ||
-          (cand.trackRef().isNonnull() &&
-           whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {
-        outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(
-            reco::HitPattern::TRACK_HITS, 0));
+          (cand.trackRef().isNonnull() && whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {
+        outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
         if (abs(outPtrP->back().pdgId()) == 22) {
-          outPtrP->back().setTrackProperties(
-              *ctrack, covariancePackingSchemas_[4], covarianceVersion_);
+          outPtrP->back().setTrackProperties(*ctrack, covariancePackingSchemas_[4], covarianceVersion_);
         } else {
           if (ctrack->hitPattern().numberOfValidPixelHits() > 0) {
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[0],
-                covarianceVersion_); // high quality
+            outPtrP->back().setTrackProperties(*ctrack,
+                                               covariancePackingSchemas_[0],
+                                               covarianceVersion_);  // high quality
           } else {
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[1], covarianceVersion_);
+            outPtrP->back().setTrackProperties(*ctrack, covariancePackingSchemas_[1], covarianceVersion_);
           }
         }
         // outPtrP->back().setTrackProperties(*ctrack,tsos.curvilinearError());
       } else {
         if (outPtrP->back().pt() > 0.5) {
           if (ctrack->hitPattern().numberOfValidPixelHits() > 0)
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[2],
-                covarianceVersion_); // low quality, with pixels
+            outPtrP->back().setTrackProperties(*ctrack,
+                                               covariancePackingSchemas_[2],
+                                               covarianceVersion_);  // low quality, with pixels
           else
-            outPtrP->back().setTrackProperties(
-                *ctrack, covariancePackingSchemas_[3],
-                covarianceVersion_); // low quality, without pixels
+            outPtrP->back().setTrackProperties(*ctrack,
+                                               covariancePackingSchemas_[3],
+                                               covarianceVersion_);  // low quality, without pixels
         }
       }
 
       // these things are always for the CKF track
-      outPtrP->back().setTrackHighPurity(
-          cand.trackRef().isNonnull() &&
-          cand.trackRef()->quality(reco::Track::highPurity));
+      outPtrP->back().setTrackHighPurity(cand.trackRef().isNonnull() &&
+                                         cand.trackRef()->quality(reco::Track::highPurity));
       if (cand.muonRef().isNonnull()) {
-        outPtrP->back().setMuonID(cand.muonRef()->isStandAloneMuon(),
-                                  cand.muonRef()->isGlobalMuon());
+        outPtrP->back().setMuonID(cand.muonRef()->isStandAloneMuon(), cand.muonRef()->isGlobalMuon());
       }
     } else {
       if (!PVs->empty()) {
@@ -396,44 +335,35 @@ void pat::PATPackedCandidateProducer::produce(
         PVpos = PV->position();
       }
 
-      outPtrP->push_back(
-          pat::PackedCandidate(cand.polarP4(), PVpos, cand.pt(), cand.eta(),
-                               cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
+      outPtrP->push_back(pat::PackedCandidate(
+          cand.polarP4(), PVpos, cand.pt(), cand.eta(), cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
       outPtrP->back().setAssociationQuality(
-          pat::PackedCandidate::PVAssociationQuality(
-              pat::PackedCandidate::UsedInFitTight));
+          pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
     }
 
     // neutrals and isolated charged hadrons
 
     bool isIsolatedChargedHadron = false;
     if (storeChargedHadronIsolation_) {
-      const edm::ValueMap<bool> &chargedHadronIsolation =
-          *(chargedHadronIsolationHandle.product());
+      const edm::ValueMap<bool> &chargedHadronIsolation = *(chargedHadronIsolationHandle.product());
       isIsolatedChargedHadron =
-          ((cand.pt() > minPtForChargedHadronProperties_) &&
-           (chargedHadronIsolation[reco::PFCandidateRef(cands, ic)]));
+          ((cand.pt() > minPtForChargedHadronProperties_) && (chargedHadronIsolation[reco::PFCandidateRef(cands, ic)]));
       outPtrP->back().setIsIsolatedChargedHadron(isIsolatedChargedHadron);
     }
 
     if (abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
-      outPtrP->back().setHcalFraction(cand.hcalEnergy() /
-                                      (cand.ecalEnergy() + cand.hcalEnergy()));
+      outPtrP->back().setHcalFraction(cand.hcalEnergy() / (cand.ecalEnergy() + cand.hcalEnergy()));
     } else if (cand.charge() && cand.pt() > 0.5) {
-      outPtrP->back().setHcalFraction(cand.hcalEnergy() /
-                                      (cand.ecalEnergy() + cand.hcalEnergy()));
-      outPtrP->back().setCaloFraction((cand.hcalEnergy() + cand.ecalEnergy()) /
-                                      cand.energy());
+      outPtrP->back().setHcalFraction(cand.hcalEnergy() / (cand.ecalEnergy() + cand.hcalEnergy()));
+      outPtrP->back().setCaloFraction((cand.hcalEnergy() + cand.ecalEnergy()) / cand.energy());
     } else {
       outPtrP->back().setHcalFraction(0);
       outPtrP->back().setCaloFraction(0);
     }
 
     if (isIsolatedChargedHadron) {
-      outPtrP->back().setRawCaloFraction(
-          (cand.rawEcalEnergy() + cand.rawHcalEnergy()) / cand.energy());
-      outPtrP->back().setRawHcalFraction(
-          cand.rawHcalEnergy() / (cand.rawEcalEnergy() + cand.rawHcalEnergy()));
+      outPtrP->back().setRawCaloFraction((cand.rawEcalEnergy() + cand.rawHcalEnergy()) / cand.energy());
+      outPtrP->back().setRawHcalFraction(cand.rawHcalEnergy() / (cand.rawEcalEnergy() + cand.rawHcalEnergy()));
     } else {
       outPtrP->back().setRawCaloFraction(0);
       outPtrP->back().setRawHcalFraction(0);
@@ -444,17 +374,14 @@ void pat::PATPackedCandidateProducer::produce(
     pat::HcalDepthEnergyFractions hcalDepthEFrac(dummyVector);
 
     // storing HcalDepthEnergyFraction information
-    if (std::find(pfCandidateTypesForHcalDepth_.begin(),
-                  pfCandidateTypesForHcalDepth_.end(),
-                  abs(cand.pdgId())) != pfCandidateTypesForHcalDepth_.end()) {
+    if (std::find(pfCandidateTypesForHcalDepth_.begin(), pfCandidateTypesForHcalDepth_.end(), abs(cand.pdgId())) !=
+        pfCandidateTypesForHcalDepth_.end()) {
       if (!storeHcalDepthEndcapOnly_ ||
-          fabs(outPtrP->back().eta()) >
-              1.3) { // storeHcalDepthEndcapOnly_==false -> store all eta of
-                     // selected PF types, if true, only |eta|>1.3 of selected
-                     // PF types will be stored
-        std::vector<float> hcalDepthEnergyFractionTmp(
-            cand.hcalDepthEnergyFractions().begin(),
-            cand.hcalDepthEnergyFractions().end());
+          fabs(outPtrP->back().eta()) > 1.3) {  // storeHcalDepthEndcapOnly_==false -> store all eta of
+                                                // selected PF types, if true, only |eta|>1.3 of selected
+                                                // PF types will be stored
+        std::vector<float> hcalDepthEnergyFractionTmp(cand.hcalDepthEnergyFractions().begin(),
+                                                      cand.hcalDepthEnergyFractions().end());
         hcalDepthEFrac.reset(hcalDepthEnergyFractionTmp);
       }
     }
@@ -463,8 +390,7 @@ void pat::PATPackedCandidateProducer::produce(
     // specifically this is the PFLinker requirements to apply the e/gamma
     // regression
     if (cand.particleId() == reco::PFCandidate::e ||
-        (cand.particleId() == reco::PFCandidate::gamma &&
-         cand.mva_nothing_gamma() > 0.)) {
+        (cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma() > 0.)) {
       outPtrP->back().setGoodEgamma();
     }
 
@@ -486,8 +412,7 @@ void pat::PATPackedCandidateProducer::produce(
           if (puppiCandsNoLepPtrs[ipcnl] == pkrefPtr) {
             foundNoLep = true;
             puppiWeightNoLepVal =
-                puppiCandsNoLep->at(ipcnl).pt() /
-                cand.pt(); // a hack for now, should use the value map
+                puppiCandsNoLep->at(ipcnl).pt() / cand.pt();  // a hack for now, should use the value map
             break;
           }
         }
@@ -504,7 +429,7 @@ void pat::PATPackedCandidateProducer::produce(
       outPtrP->back().setTime(cand.time(), cand.timeError());
     }
 
-    mapping[ic] = ic; // trivial at the moment!
+    mapping[ic] = ic;  // trivial at the moment!
     if (cand.trackRef().isNonnull() && cand.trackRef().id() == TKOrigs.id()) {
       mappingTk[cand.trackRef().key()] = ic;
     }
@@ -517,8 +442,7 @@ void pat::PATPackedCandidateProducer::produce(
     outPtrPSorted->push_back((*outPtrP)[order[i]]);
     reverseOrder[order[i]] = i;
     mappingReverse[order[i]] = i;
-    hcalDepthEnergyFractions_Ordered.push_back(
-        hcalDepthEnergyFractions[order[i]]);
+    hcalDepthEnergyFractions_Ordered.push_back(hcalDepthEnergyFractions[order[i]]);
   }
 
   // Fix track association for sorted candidates
@@ -531,14 +455,11 @@ void pat::PATPackedCandidateProducer::produce(
     mappingPuppi[i] = reverseOrder[mappingPuppi[i]];
   }
 
-  edm::OrphanHandle<pat::PackedCandidateCollection> oh =
-      iEvent.put(std::move(outPtrPSorted));
+  edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrPSorted));
 
   // now build the two maps
-  auto pf2pc =
-      std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
-  auto pc2pf =
-      std::make_unique<edm::Association<reco::PFCandidateCollection>>(cands);
+  auto pf2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
+  auto pc2pf = std::make_unique<edm::Association<reco::PFCandidateCollection>>(cands);
   edm::Association<pat::PackedCandidateCollection>::Filler pf2pcFiller(*pf2pc);
   edm::Association<reco::PFCandidateCollection>::Filler pc2pfFiller(*pc2pf);
   pf2pcFiller.insert(cands, mappingReverse.begin(), mappingReverse.end());
@@ -554,18 +475,14 @@ void pat::PATPackedCandidateProducer::produce(
   iEvent.put(std::move(pc2pf));
 
   // HCAL depth energy fraction additions using ValueMap
-  auto hcalDepthEnergyFractionsV =
-      std::make_unique<edm::ValueMap<HcalDepthEnergyFractions>>();
-  edm::ValueMap<HcalDepthEnergyFractions>::Filler
-      fillerHcalDepthEnergyFractions(*hcalDepthEnergyFractionsV);
+  auto hcalDepthEnergyFractionsV = std::make_unique<edm::ValueMap<HcalDepthEnergyFractions>>();
+  edm::ValueMap<HcalDepthEnergyFractions>::Filler fillerHcalDepthEnergyFractions(*hcalDepthEnergyFractionsV);
   fillerHcalDepthEnergyFractions.insert(
-      cands, hcalDepthEnergyFractions_Ordered.begin(),
-      hcalDepthEnergyFractions_Ordered.end());
+      cands, hcalDepthEnergyFractions_Ordered.begin(), hcalDepthEnergyFractions_Ordered.end());
   fillerHcalDepthEnergyFractions.fill();
 
   if (not pfCandidateTypesForHcalDepth_.empty())
-    iEvent.put(std::move(hcalDepthEnergyFractionsV),
-               "hcalDepthEnergyFractions");
+    iEvent.put(std::move(hcalDepthEnergyFractionsV), "hcalDepthEnergyFractions");
 }
 
 using pat::PATPackedCandidateProducer;

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
@@ -15,7 +15,6 @@
   \version  $Id: PATPhotonProducer.h,v 1.19 2009/06/25 23:49:35 gpetrucc Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -39,7 +38,6 @@
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 
-
 #include "DataFormats/PatCandidates/interface/UserData.h"
 #include "PhysicsTools/PatAlgos/interface/PATUserDataHelper.h"
 
@@ -50,125 +48,124 @@
 namespace pat {
 
   class PATPhotonProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATPhotonProducer(const edm::ParameterSet& iConfig);
+    ~PATPhotonProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATPhotonProducer(const edm::ParameterSet & iConfig);
-      ~PATPhotonProducer() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+  private:
+    // configurables
+    edm::EDGetTokenT<edm::View<reco::Photon> > photonToken_;
+    edm::EDGetTokenT<reco::GsfElectronCollection> electronToken_;
+    edm::EDGetTokenT<reco::ConversionCollection> hConversionsToken_;
+    edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    bool embedSuperCluster_;
+    bool embedSeedCluster_;
+    bool embedBasicClusters_;
+    bool embedPreshowerClusters_;
+    bool embedRecHits_;
 
-    private:
+    edm::InputTag reducedBarrelRecHitCollection_;
+    edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
+    edm::InputTag reducedEndcapRecHitCollection_;
+    edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
 
-      // configurables
-      edm::EDGetTokenT<edm::View<reco::Photon> > photonToken_;
-      edm::EDGetTokenT<reco::GsfElectronCollection> electronToken_;
-      edm::EDGetTokenT<reco::ConversionCollection> hConversionsToken_;
-      edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
+    bool addPFClusterIso_;
+    bool addPuppiIsolation_;
+    edm::EDGetTokenT<edm::ValueMap<float> > ecalPFClusterIsoT_;
+    edm::EDGetTokenT<edm::ValueMap<float> > hcalPFClusterIsoT_;
 
-      bool embedSuperCluster_;
-      bool          embedSeedCluster_;
-      bool          embedBasicClusters_;
-      bool          embedPreshowerClusters_;
-      bool          embedRecHits_;
+    bool addGenMatch_;
+    bool embedGenMatch_;
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
-      edm::InputTag reducedBarrelRecHitCollection_;
-      edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
-      edm::InputTag reducedEndcapRecHitCollection_;
-      edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;      
-      
-      bool addPFClusterIso_;
-      bool addPuppiIsolation_;
-      edm::EDGetTokenT<edm::ValueMap<float> > ecalPFClusterIsoT_;
-      edm::EDGetTokenT<edm::ValueMap<float> > hcalPFClusterIsoT_;
+    // tools
+    GreaterByEt<Photon> eTComparator_;
 
-      bool addGenMatch_;
-      bool embedGenMatch_;
-      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    typedef std::vector<edm::Handle<edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
+    typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsolationValueMaps;
+    typedef std::pair<pat::IsolationKeys, edm::InputTag> IsolationLabel;
+    typedef std::vector<IsolationLabel> IsolationLabels;
 
-      // tools
-      GreaterByEt<Photon> eTComparator_;
+    pat::helper::MultiIsolator isolator_;
+    pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_;  // better here than recreate at each event
+    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueTokens_;
 
-      typedef std::vector< edm::Handle< edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
-      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
-      typedef std::pair<pat::IsolationKeys,edm::InputTag> IsolationLabel;
-      typedef std::vector<IsolationLabel> IsolationLabels;
+    IsolationLabels isoDepositLabels_;
+    IsolationLabels isolationValueLabels_;
 
-      pat::helper::MultiIsolator isolator_;
-      pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
-      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueTokens_;
- 
-      IsolationLabels isoDepositLabels_;
-      IsolationLabels isolationValueLabels_;
+    /// fill the labels vector from the contents of the parameter set,
+    /// for the isodeposit or isolation values embedding
+    template <typename T>
+    void readIsolationLabels(const edm::ParameterSet& iConfig,
+                             const char* psetName,
+                             IsolationLabels& labels,
+                             std::vector<edm::EDGetTokenT<edm::ValueMap<T> > >& tokens);
 
-      /// fill the labels vector from the contents of the parameter set,
-      /// for the isodeposit or isolation values embedding
-      template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig,
-                                                     const char* psetName,
-                                                     IsolationLabels& labels,
-                                                     std::vector<edm::EDGetTokenT<edm::ValueMap<T> > >  & tokens);
+    bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
+    bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      bool addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
+    bool addPhotonID_;
+    typedef std::pair<std::string, edm::InputTag> NameTag;
+    std::vector<NameTag> photIDSrcs_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<Bool_t> > > photIDTokens_;
 
-      bool          addPhotonID_;
-      typedef std::pair<std::string, edm::InputTag> NameTag;
-      std::vector<NameTag> photIDSrcs_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<Bool_t> > > photIDTokens_;
+    bool useUserData_;
+    //PUPPI isolation tokens
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_charged_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_neutral_hadrons_;
+    edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_photons_;
+    pat::PATUserDataHelper<pat::Photon> userDataHelper_;
 
-      bool useUserData_;
-      //PUPPI isolation tokens
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_charged_hadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_neutral_hadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > PUPPIIsolation_photons_;
-      pat::PATUserDataHelper<pat::Photon>      userDataHelper_;
-      
-      const CaloTopology * ecalTopology_;
-      const CaloGeometry * ecalGeometry_;
+    const CaloTopology* ecalTopology_;
+    const CaloGeometry* ecalGeometry_;
 
-      bool saveRegressionData_;
-
+    bool saveRegressionData_;
   };
 
-}
+}  // namespace pat
 
-
-
-template<typename T>
-void pat::PATPhotonProducer::readIsolationLabels( const edm::ParameterSet & iConfig,
-                                               const char* psetName,
-                                               pat::PATPhotonProducer::IsolationLabels& labels,
-                                               std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens) {
-
+template <typename T>
+void pat::PATPhotonProducer::readIsolationLabels(const edm::ParameterSet& iConfig,
+                                                 const char* psetName,
+                                                 pat::PATPhotonProducer::IsolationLabels& labels,
+                                                 std::vector<edm::EDGetTokenT<edm::ValueMap<T> > >& tokens) {
   labels.clear();
 
-  if (iConfig.exists( psetName )) {
-    edm::ParameterSet depconf
-      = iConfig.getParameter<edm::ParameterSet>(psetName);
+  if (iConfig.exists(psetName)) {
+    edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>(psetName);
 
-    if (depconf.exists("tracker")) labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-    if (depconf.exists("ecal"))    labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-    if (depconf.exists("hcal"))    labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-    if (depconf.exists("pfAllParticles"))  {
+    if (depconf.exists("tracker"))
+      labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
+    if (depconf.exists("ecal"))
+      labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
+    if (depconf.exists("hcal"))
+      labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
+    if (depconf.exists("pfAllParticles")) {
       labels.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
     }
-    if (depconf.exists("pfChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
+    if (depconf.exists("pfChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
     }
-    if (depconf.exists("pfChargedAll"))  {
+    if (depconf.exists("pfChargedAll")) {
       labels.push_back(std::make_pair(pat::PfChargedAllIso, depconf.getParameter<edm::InputTag>("pfChargedAll")));
     }
-    if (depconf.exists("pfPUChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
+    if (depconf.exists("pfPUChargedHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
     }
-    if (depconf.exists("pfNeutralHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
+    if (depconf.exists("pfNeutralHadrons")) {
+      labels.push_back(
+          std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
     }
     if (depconf.exists("pfPhotons")) {
       labels.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfPhotons")));
@@ -177,16 +174,16 @@ void pat::PATPhotonProducer::readIsolationLabels( const edm::ParameterSet & iCon
       std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
       std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
       int key = pat::IsolationKeys::UserBaseIso;
-      for ( ; it != ed; ++it, ++key) {
-       labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
+      for (; it != ed; ++it, ++key) {
+        labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
       }
     }
-    
-    tokens = edm::vector_transform(labels, [this](IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
-    
-  }
-	tokens = edm::vector_transform(labels, [this](IsolationLabel const & label){return consumes<edm::ValueMap<T> >(label.second);});
-}
 
+    tokens = edm::vector_transform(
+        labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T> >(label.second); });
+  }
+  tokens = edm::vector_transform(
+      labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T> >(label.second); });
+}
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
@@ -54,9 +54,9 @@ namespace pat {
     public:
 
       explicit PATPhotonProducer(const edm::ParameterSet & iConfig);
-      ~PATPhotonProducer();
+      ~PATPhotonProducer() override;
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -26,147 +26,188 @@
 namespace pat {
 
   class PATPhotonSlimmer : public edm::stream::EDProducer<> {
-    public:
-      explicit PATPhotonSlimmer(const edm::ParameterSet & iConfig);
-      ~PATPhotonSlimmer() override { }
+  public:
+    explicit PATPhotonSlimmer(const edm::ParameterSet& iConfig);
+    ~PATPhotonSlimmer() override {}
 
-      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-      void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) final;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
-    private:
-      const edm::EDGetTokenT<edm::View<pat::Photon> > src_;
+  private:
+    const edm::EDGetTokenT<edm::View<pat::Photon>> src_;
 
-      const StringCutObjectSelector<pat::Photon> dropSuperClusters_, dropBasicClusters_, dropPreshowerClusters_, dropSeedCluster_, dropRecHits_, dropSaturation_, dropRegressionData_;
+    const StringCutObjectSelector<pat::Photon> dropSuperClusters_, dropBasicClusters_, dropPreshowerClusters_,
+        dropSeedCluster_, dropRecHits_, dropSaturation_, dropRegressionData_;
 
-      const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > reco2pf_;
-      const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2pc_;
-      const edm::EDGetTokenT<pat::PackedCandidateCollection>  pc_;
-      const bool linkToPackedPF_;
-      const StringCutObjectSelector<pat::Photon> saveNonZSClusterShapes_;
-      const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_;
-      const bool modifyPhoton_;
-      std::unique_ptr<pat::ObjectModifier<pat::Photon> > photonModifier_;
+    const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
+    const edm::EDGetTokenT<pat::PackedCandidateCollection> pc_;
+    const bool linkToPackedPF_;
+    const StringCutObjectSelector<pat::Photon> saveNonZSClusterShapes_;
+    const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_,
+        reducedEndcapRecHitCollectionToken_;
+    const bool modifyPhoton_;
+    std::unique_ptr<pat::ObjectModifier<pat::Photon>> photonModifier_;
   };
 
-} // namespace
+}  // namespace pat
 
-pat::PATPhotonSlimmer::PATPhotonSlimmer(const edm::ParameterSet & iConfig) :
-    src_(consumes<edm::View<pat::Photon> >(iConfig.getParameter<edm::InputTag>("src"))),
-    dropSuperClusters_(iConfig.getParameter<std::string>("dropSuperCluster")),
-    dropBasicClusters_(iConfig.getParameter<std::string>("dropBasicClusters")),
-    dropPreshowerClusters_(iConfig.getParameter<std::string>("dropPreshowerClusters")),
-    dropSeedCluster_(iConfig.getParameter<std::string>("dropSeedCluster")),
-    dropRecHits_(iConfig.getParameter<std::string>("dropRecHits")),
-    dropSaturation_(iConfig.getParameter<std::string>("dropSaturation")),
-    dropRegressionData_(iConfig.getParameter<std::string>("dropRegressionData")),
-    reco2pf_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(iConfig.getParameter<edm::InputTag>("recoToPFMap"))),
-    pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-    pc_(mayConsume<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-    linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
-    saveNonZSClusterShapes_(iConfig.getParameter<std::string>("saveNonZSClusterShapes")),
-    reducedBarrelRecHitCollectionToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection"))),
-    reducedEndcapRecHitCollectionToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"))),
-    modifyPhoton_(iConfig.getParameter<bool>("modifyPhotons"))
-{
-    if( modifyPhoton_ ) {
-      const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      photonModifier_ = std::make_unique<pat::ObjectModifier<pat::Photon>>(mod_config, consumesCollector());
+pat::PATPhotonSlimmer::PATPhotonSlimmer(const edm::ParameterSet& iConfig)
+    : src_(consumes<edm::View<pat::Photon>>(iConfig.getParameter<edm::InputTag>("src"))),
+      dropSuperClusters_(iConfig.getParameter<std::string>("dropSuperCluster")),
+      dropBasicClusters_(iConfig.getParameter<std::string>("dropBasicClusters")),
+      dropPreshowerClusters_(iConfig.getParameter<std::string>("dropPreshowerClusters")),
+      dropSeedCluster_(iConfig.getParameter<std::string>("dropSeedCluster")),
+      dropRecHits_(iConfig.getParameter<std::string>("dropRecHits")),
+      dropSaturation_(iConfig.getParameter<std::string>("dropSaturation")),
+      dropRegressionData_(iConfig.getParameter<std::string>("dropRegressionData")),
+      reco2pf_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
+          iConfig.getParameter<edm::InputTag>("recoToPFMap"))),
+      pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      pc_(mayConsume<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
+      saveNonZSClusterShapes_(iConfig.getParameter<std::string>("saveNonZSClusterShapes")),
+      reducedBarrelRecHitCollectionToken_(
+          consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection"))),
+      reducedEndcapRecHitCollectionToken_(
+          consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection"))),
+      modifyPhoton_(iConfig.getParameter<bool>("modifyPhotons")) {
+  if (modifyPhoton_) {
+    const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
+    photonModifier_ = std::make_unique<pat::ObjectModifier<pat::Photon>>(mod_config, consumesCollector());
+  }
+
+  mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));
+  mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"));
+
+  produces<std::vector<pat::Photon>>();
+}
+
+void pat::PATPhotonSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup) {}
+
+void pat::PATPhotonSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+
+  Handle<View<pat::Photon>> src;
+  iEvent.getByToken(src_, src);
+
+  Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf;
+  Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  Handle<pat::PackedCandidateCollection> pc;
+  if (linkToPackedPF_) {
+    iEvent.getByToken(reco2pf_, reco2pf);
+    iEvent.getByToken(pf2pc_, pf2pc);
+    iEvent.getByToken(pc_, pc);
+  }
+  noZS::EcalClusterLazyTools lazyToolsNoZS(
+      iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+
+  auto out = std::make_unique<std::vector<pat::Photon>>();
+  out->reserve(src->size());
+
+  if (modifyPhoton_) {
+    photonModifier_->setEvent(iEvent);
+  }
+  if (modifyPhoton_)
+    photonModifier_->setEventContent(iSetup);
+
+  std::vector<unsigned int> keys;
+  for (View<pat::Photon>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    out->push_back(*it);
+    pat::Photon& photon = out->back();
+
+    if (modifyPhoton_) {
+      photonModifier_->modify(photon);
     }
-    
-    mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));
-    mayConsume<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"));
 
-    produces<std::vector<pat::Photon> >();    
-}
+    if (dropSuperClusters_(photon)) {
+      photon.superCluster_.clear();
+      photon.embeddedSuperCluster_ = false;
+    }
+    if (dropBasicClusters_(photon)) {
+      photon.basicClusters_.clear();
+    }
+    if (dropPreshowerClusters_(photon)) {
+      photon.preshowerClusters_.clear();
+    }
+    if (dropSeedCluster_(photon)) {
+      photon.seedCluster_.clear();
+      photon.embeddedSeedCluster_ = false;
+    }
+    if (dropRecHits_(photon)) {
+      photon.recHits_ = EcalRecHitCollection();
+      photon.embeddedRecHits_ = false;
+    }
+    if (dropSaturation_(photon)) {
+      photon.setSaturationInfo(reco::Photon::SaturationInfo());
+    }
+    if (dropRegressionData_(photon)) {
+      photon.setEMax(0);
+      photon.setE2nd(0);
+      photon.setE3x3(0);
+      photon.setETop(0);
+      photon.setEBottom(0);
+      photon.setELeft(0);
+      photon.setERight(0);
+      photon.setSee(0);
+      photon.setSep(0);
+      photon.setSpp(0);
+      photon.setMaxDR(0);
+      photon.setMaxDRDPhi(0);
+      photon.setMaxDRDEta(0);
+      photon.setMaxDRRawEnergy(0);
+      photon.setSubClusRawE1(0);
+      photon.setSubClusRawE2(0);
+      photon.setSubClusRawE3(0);
+      photon.setSubClusDPhi1(0);
+      photon.setSubClusDPhi2(0);
+      photon.setSubClusDPhi3(0);
+      photon.setSubClusDEta1(0);
+      photon.setSubClusDEta2(0);
+      photon.setSubClusDEta3(0);
+      photon.setCryPhi(0);
+      photon.setCryEta(0);
+      photon.setIEta(0);
+      photon.setIPhi(0);
+    }
 
-void 
-pat::PATPhotonSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup& iSetup) {
-}
-
-void 
-pat::PATPhotonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
-
-    Handle<View<pat::Photon> >      src;
-    iEvent.getByToken(src_, src);
-
-    Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf;
-    Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
-    Handle<pat::PackedCandidateCollection> pc;
     if (linkToPackedPF_) {
-        iEvent.getByToken(reco2pf_, reco2pf);
-        iEvent.getByToken(pf2pc_, pf2pc);
-        iEvent.getByToken(pc_, pc);
+      //std::cout << " PAT  photon in  " << src.id() << " comes from " << photon.refToOrig_.id() << ", " << photon.refToOrig_.key() << std::endl;
+      keys.clear();
+      for (auto const& pf : (*reco2pf)[photon.refToOrig_]) {
+        if (pf2pc->contains(pf.id())) {
+          keys.push_back((*pf2pc)[pf].key());
+        }
+      }
+      photon.setAssociatedPackedPFCandidates(
+          edm::RefProd<pat::PackedCandidateCollection>(pc), keys.begin(), keys.end());
+      //std::cout << "Photon with pt " << photon.pt() << " associated to " << photon.associatedPackedFCandidateIndices_.size() << " PF Candidates\n";
+      //if there's just one PF Cand then it's me, otherwise I have no univoque parent so my ref will be null
+      if (keys.size() == 1) {
+        photon.refToOrig_ = photon.sourceCandidatePtr(0);
+      } else {
+        photon.refToOrig_ = reco::CandidatePtr(pc.id());
+      }
     }
-    noZS::EcalClusterLazyTools lazyToolsNoZS(iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+    if (saveNonZSClusterShapes_(photon)) {
+      std::vector<float> vCov = lazyToolsNoZS.localCovariances(*(photon.superCluster()->seed()));
+      float r9 = lazyToolsNoZS.e3x3(*(photon.superCluster()->seed())) / photon.superCluster()->rawEnergy();
+      float sigmaIetaIeta = (!edm::isNotFinite(vCov[0])) ? sqrt(vCov[0]) : 0;
+      float sigmaIetaIphi = vCov[1];
+      float sigmaIphiIphi = (!edm::isNotFinite(vCov[2])) ? sqrt(vCov[2]) : 0;
+      float e15o55 =
+          lazyToolsNoZS.e1x5(*(photon.superCluster()->seed())) / lazyToolsNoZS.e5x5(*(photon.superCluster()->seed()));
+      photon.addUserFloat("sigmaIetaIeta_NoZS", sigmaIetaIeta);
+      photon.addUserFloat("sigmaIetaIphi_NoZS", sigmaIetaIphi);
+      photon.addUserFloat("sigmaIphiIphi_NoZS", sigmaIphiIphi);
+      photon.addUserFloat("r9_NoZS", r9);
+      photon.addUserFloat("e1x5_over_e5x5_NoZS", e15o55);
+    }
+  }
 
-    auto out = std::make_unique<std::vector<pat::Photon>>();
-    out->reserve(src->size());
-
-    if( modifyPhoton_ ) { photonModifier_->setEvent(iEvent); }
-    if( modifyPhoton_ ) photonModifier_->setEventContent(iSetup);
-
-
-    std::vector<unsigned int> keys;
-    for (View<pat::Photon>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        out->push_back(*it);
-        pat::Photon & photon = out->back();
-
-        if( modifyPhoton_ ) { photonModifier_->modify(photon); }
-
-        if (dropSuperClusters_(photon)) { photon.superCluster_.clear(); photon.embeddedSuperCluster_ = false; }
-	if (dropBasicClusters_(photon)) { photon.basicClusters_.clear(); }
-	if (dropPreshowerClusters_(photon)) { photon.preshowerClusters_.clear(); }
-	if (dropSeedCluster_(photon)) { photon.seedCluster_.clear(); photon.embeddedSeedCluster_ = false; }
-        if (dropRecHits_(photon)) { photon.recHits_ = EcalRecHitCollection(); photon.embeddedRecHits_ = false; }
-        if (dropSaturation_(photon)) { photon.setSaturationInfo(reco::Photon::SaturationInfo()); }
-        if (dropRegressionData_(photon)) {
-            photon.setEMax(0); photon.setE2nd(0); photon.setE3x3(0);
-            photon.setETop(0); photon.setEBottom(0); photon.setELeft(0); photon.setERight(0);
-            photon.setSee(0); photon.setSep(0); photon.setSpp(0);
-            photon.setMaxDR(0); photon.setMaxDRDPhi(0); photon.setMaxDRDEta(0); photon.setMaxDRRawEnergy(0);
-            photon.setSubClusRawE1(0); photon.setSubClusRawE2(0); photon.setSubClusRawE3(0);
-            photon.setSubClusDPhi1(0); photon.setSubClusDPhi2(0); photon.setSubClusDPhi3(0);
-            photon.setSubClusDEta1(0); photon.setSubClusDEta2(0); photon.setSubClusDEta3(0);
-            photon.setCryPhi(0); photon.setCryEta(0); photon.setIEta(0); photon.setIPhi(0);
-        }
-
-        if (linkToPackedPF_) {
-            //std::cout << " PAT  photon in  " << src.id() << " comes from " << photon.refToOrig_.id() << ", " << photon.refToOrig_.key() << std::endl;
-            keys.clear();
-            for(auto const& pf: (*reco2pf)[photon.refToOrig_]) {
-              if( pf2pc->contains(pf.id()) ) {
-                keys.push_back( (*pf2pc)[pf].key());
-              }
-            }
-            photon.setAssociatedPackedPFCandidates(edm::RefProd<pat::PackedCandidateCollection>(pc),
-                                                   keys.begin(), keys.end());
-            //std::cout << "Photon with pt " << photon.pt() << " associated to " << photon.associatedPackedFCandidateIndices_.size() << " PF Candidates\n";
-            //if there's just one PF Cand then it's me, otherwise I have no univoque parent so my ref will be null 
-            if (keys.size() == 1) {
-                photon.refToOrig_ = photon.sourceCandidatePtr(0);
-            } else {
-                photon.refToOrig_ = reco::CandidatePtr(pc.id());
-            }
-        }
-        if (saveNonZSClusterShapes_(photon)) {
-            std::vector<float> vCov = lazyToolsNoZS.localCovariances(*( photon.superCluster()->seed()));
-            float r9 = lazyToolsNoZS.e3x3( *( photon.superCluster()->seed())) / photon.superCluster()->rawEnergy() ;
-            float sigmaIetaIeta = ( !edm::isNotFinite(vCov[0]) ) ? sqrt(vCov[0]) : 0;
-            float sigmaIetaIphi = vCov[1];
-            float sigmaIphiIphi = ( !edm::isNotFinite(vCov[2]) ) ? sqrt(vCov[2]) : 0;
-            float e15o55 = lazyToolsNoZS.e1x5( *( photon.superCluster()->seed()) ) / lazyToolsNoZS.e5x5( *( photon.superCluster()->seed()) );
-            photon.addUserFloat("sigmaIetaIeta_NoZS", sigmaIetaIeta);
-            photon.addUserFloat("sigmaIetaIphi_NoZS", sigmaIetaIphi);
-            photon.addUserFloat("sigmaIphiIphi_NoZS", sigmaIphiIphi);
-            photon.addUserFloat("r9_NoZS", r9);
-            photon.addUserFloat("e1x5_over_e5x5_NoZS", e15o55);
-        }
-
-     }
-
-    iEvent.put(std::move(out));
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATPuppiJetSpecificsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPuppiJetSpecificsProducer.cc
@@ -26,7 +26,7 @@ class PATPuppiJetSpecificProducer : public edm::global::EDProducer<>
 public:
 
   explicit PATPuppiJetSpecificProducer(const edm::ParameterSet& cfg);
-  ~PATPuppiJetSpecificProducer() {}
+  ~PATPuppiJetSpecificProducer() override {}
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/PhysicsTools/PatAlgos/plugins/PATPuppiJetSpecificsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPuppiJetSpecificsProducer.cc
@@ -21,27 +21,23 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-class PATPuppiJetSpecificProducer : public edm::global::EDProducer<> 
-{
+class PATPuppiJetSpecificProducer : public edm::global::EDProducer<> {
 public:
-
   explicit PATPuppiJetSpecificProducer(const edm::ParameterSet& cfg);
   ~PATPuppiJetSpecificProducer() override {}
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   // input collection
   edm::InputTag srcjets_;
   edm::EDGetTokenT<edm::View<pat::Jet> > jets_token;
-
 };
 
-PATPuppiJetSpecificProducer::PATPuppiJetSpecificProducer(const edm::ParameterSet& cfg)
-{
+PATPuppiJetSpecificProducer::PATPuppiJetSpecificProducer(const edm::ParameterSet& cfg) {
   srcjets_ = cfg.getParameter<edm::InputTag>("src");
   jets_token = consumes<edm::View<pat::Jet> >(srcjets_);
-  
+
   produces<edm::ValueMap<float> >("puppiMultiplicity");
   produces<edm::ValueMap<float> >("neutralPuppiMultiplicity");
   produces<edm::ValueMap<float> >("neutralHadronPuppiMultiplicity");
@@ -50,11 +46,10 @@ PATPuppiJetSpecificProducer::PATPuppiJetSpecificProducer(const edm::ParameterSet
   produces<edm::ValueMap<float> >("HFEMPuppiMultiplicity");
 }
 
-void PATPuppiJetSpecificProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
-{
+void PATPuppiJetSpecificProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {
   edm::Handle<edm::View<pat::Jet> > jets;
   evt.getByToken(jets_token, jets);
-  
+
   std::vector<float> puppiMultiplicities;
   std::vector<float> neutralPuppiMultiplicities;
   std::vector<float> neutralHadronPuppiMultiplicities;
@@ -62,7 +57,7 @@ void PATPuppiJetSpecificProducer::produce(edm::StreamID, edm::Event& evt, const 
   std::vector<float> HFHadronPuppiMultiplicities;
   std::vector<float> HFEMPuppiMultiplicities;
 
-  for( auto const& c : *jets ) {
+  for (auto const& c : *jets) {
     float puppiMultiplicity = 0;
     float neutralPuppiMultiplicity = 0;
     float neutralHadronPuppiMultiplicity = 0;
@@ -71,28 +66,28 @@ void PATPuppiJetSpecificProducer::produce(edm::StreamID, edm::Event& evt, const 
     float HFEMPuppiMultiplicity = 0;
 
     for (unsigned i = 0; i < c.numberOfDaughters(); i++) {
-        const pat::PackedCandidate &dau = static_cast<const pat::PackedCandidate &>(*c.daughter(i));
-        auto weight = dau.puppiWeight();
-        puppiMultiplicity += weight;
-        // This logic is taken from RecoJets/JetProducers/src/JetSpecific.cc
-        switch (std::abs(dau.pdgId())) {
-          case 130: //PFCandidate::h0 :    // neutral hadron
-            neutralHadronPuppiMultiplicity += weight;
-            neutralPuppiMultiplicity += weight;
-            break;
-          case 22: //PFCandidate::gamma:   // photon
-            photonPuppiMultiplicity += weight;
-            neutralPuppiMultiplicity += weight;
-            break;
-          case 1: // PFCandidate::h_HF :    // hadron in HF
-            HFHadronPuppiMultiplicity += weight;
-            neutralPuppiMultiplicity += weight;
-            break;
-          case 2: //PFCandidate::egamma_HF :    // electromagnetic in HF
-            HFEMPuppiMultiplicity += weight;
-            neutralPuppiMultiplicity += weight;
-            break;
-        }
+      const pat::PackedCandidate& dau = static_cast<const pat::PackedCandidate&>(*c.daughter(i));
+      auto weight = dau.puppiWeight();
+      puppiMultiplicity += weight;
+      // This logic is taken from RecoJets/JetProducers/src/JetSpecific.cc
+      switch (std::abs(dau.pdgId())) {
+        case 130:  //PFCandidate::h0 :    // neutral hadron
+          neutralHadronPuppiMultiplicity += weight;
+          neutralPuppiMultiplicity += weight;
+          break;
+        case 22:  //PFCandidate::gamma:   // photon
+          photonPuppiMultiplicity += weight;
+          neutralPuppiMultiplicity += weight;
+          break;
+        case 1:  // PFCandidate::h_HF :    // hadron in HF
+          HFHadronPuppiMultiplicity += weight;
+          neutralPuppiMultiplicity += weight;
+          break;
+        case 2:  //PFCandidate::egamma_HF :    // electromagnetic in HF
+          HFEMPuppiMultiplicity += weight;
+          neutralPuppiMultiplicity += weight;
+          break;
+      }
     }
 
     puppiMultiplicities.push_back(puppiMultiplicity);
@@ -105,45 +100,47 @@ void PATPuppiJetSpecificProducer::produce(edm::StreamID, edm::Event& evt, const 
 
   std::unique_ptr<edm::ValueMap<float> > puppiMultiplicities_out(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler puppiMultiplicities_filler(*puppiMultiplicities_out);
-  puppiMultiplicities_filler.insert(jets,puppiMultiplicities.begin(),puppiMultiplicities.end());
+  puppiMultiplicities_filler.insert(jets, puppiMultiplicities.begin(), puppiMultiplicities.end());
   puppiMultiplicities_filler.fill();
-  evt.put(std::move(puppiMultiplicities_out),"puppiMultiplicity");
+  evt.put(std::move(puppiMultiplicities_out), "puppiMultiplicity");
 
   std::unique_ptr<edm::ValueMap<float> > neutralPuppiMultiplicities_out(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler neutralPuppiMultiplicities_filler(*neutralPuppiMultiplicities_out);
-  neutralPuppiMultiplicities_filler.insert(jets,neutralPuppiMultiplicities.begin(),neutralPuppiMultiplicities.end());
+  neutralPuppiMultiplicities_filler.insert(jets, neutralPuppiMultiplicities.begin(), neutralPuppiMultiplicities.end());
   neutralPuppiMultiplicities_filler.fill();
-  evt.put(std::move(neutralPuppiMultiplicities_out),"neutralPuppiMultiplicity");
+  evt.put(std::move(neutralPuppiMultiplicities_out), "neutralPuppiMultiplicity");
 
   std::unique_ptr<edm::ValueMap<float> > neutralHadronPuppiMultiplicities_out(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler neutralHadronPuppiMultiplicities_filler(*neutralHadronPuppiMultiplicities_out);
-  neutralHadronPuppiMultiplicities_filler.insert(jets,neutralHadronPuppiMultiplicities.begin(),neutralHadronPuppiMultiplicities.end());
+  neutralHadronPuppiMultiplicities_filler.insert(
+      jets, neutralHadronPuppiMultiplicities.begin(), neutralHadronPuppiMultiplicities.end());
   neutralHadronPuppiMultiplicities_filler.fill();
-  evt.put(std::move(neutralHadronPuppiMultiplicities_out),"neutralHadronPuppiMultiplicity");
+  evt.put(std::move(neutralHadronPuppiMultiplicities_out), "neutralHadronPuppiMultiplicity");
 
   std::unique_ptr<edm::ValueMap<float> > photonPuppiMultiplicities_out(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler photonPuppiMultiplicities_filler(*photonPuppiMultiplicities_out);
-  photonPuppiMultiplicities_filler.insert(jets,photonPuppiMultiplicities.begin(),photonPuppiMultiplicities.end());
+  photonPuppiMultiplicities_filler.insert(jets, photonPuppiMultiplicities.begin(), photonPuppiMultiplicities.end());
   photonPuppiMultiplicities_filler.fill();
-  evt.put(std::move(photonPuppiMultiplicities_out),"photonPuppiMultiplicity");
+  evt.put(std::move(photonPuppiMultiplicities_out), "photonPuppiMultiplicity");
 
   std::unique_ptr<edm::ValueMap<float> > HFHadronPuppiMultiplicities_out(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler HFHadronPuppiMultiplicities_filler(*HFHadronPuppiMultiplicities_out);
-  HFHadronPuppiMultiplicities_filler.insert(jets,HFHadronPuppiMultiplicities.begin(),HFHadronPuppiMultiplicities.end());
+  HFHadronPuppiMultiplicities_filler.insert(
+      jets, HFHadronPuppiMultiplicities.begin(), HFHadronPuppiMultiplicities.end());
   HFHadronPuppiMultiplicities_filler.fill();
-  evt.put(std::move(HFHadronPuppiMultiplicities_out),"HFHadronPuppiMultiplicity");
+  evt.put(std::move(HFHadronPuppiMultiplicities_out), "HFHadronPuppiMultiplicity");
 
   std::unique_ptr<edm::ValueMap<float> > HFEMPuppiMultiplicities_out(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler HFEMPuppiMultiplicities_filler(*HFEMPuppiMultiplicities_out);
-  HFEMPuppiMultiplicities_filler.insert(jets,HFEMPuppiMultiplicities.begin(),HFEMPuppiMultiplicities.end());
+  HFEMPuppiMultiplicities_filler.insert(jets, HFEMPuppiMultiplicities.begin(), HFEMPuppiMultiplicities.end());
   HFEMPuppiMultiplicities_filler.fill();
-  evt.put(std::move(HFEMPuppiMultiplicities_out),"HFEMPuppiMultiplicity");
+  evt.put(std::move(HFEMPuppiMultiplicities_out), "HFEMPuppiMultiplicity");
 }
 
-void PATPuppiJetSpecificProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-   edm::ParameterSetDescription desc;
-   desc.add<edm::InputTag>("src", edm::InputTag("slimmedJets"));
-   descriptions.add("patPuppiJetSpecificProducer", desc);
+void PATPuppiJetSpecificProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedJets"));
+  descriptions.add("patPuppiJetSpecificProducer", desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATSecondaryVertexSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATSecondaryVertexSlimmer.cc
@@ -17,126 +17,124 @@
 #include "DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 
-
 namespace pat {
   class PATSecondaryVertexSlimmer : public edm::global::EDProducer<> {
   public:
     explicit PATSecondaryVertexSlimmer(const edm::ParameterSet&);
     ~PATSecondaryVertexSlimmer() override;
-    
+
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
   private:
     const edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection> src_;
     const edm::EDGetTokenT<std::vector<reco::Vertex> > srcLegacy_;
-    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>         srcV0s_;
+    const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> srcV0s_;
     const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
     const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map2_;
-    };
-}
+  };
+}  // namespace pat
 
-pat::PATSecondaryVertexSlimmer::PATSecondaryVertexSlimmer(const edm::ParameterSet& iConfig) :
-  src_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  srcLegacy_(mayConsume<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("src"))),
-  srcV0s_(mayConsume<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  map2_(mayConsume<edm::Association<pat::PackedCandidateCollection> >(iConfig.existsAs<edm::InputTag>("lostTracksCandidates") ? iConfig.getParameter<edm::InputTag>("lostTracksCandidates") : edm::InputTag("lostTracks") ))
-{
-  produces< reco::VertexCompositePtrCandidateCollection >();
+pat::PATSecondaryVertexSlimmer::PATSecondaryVertexSlimmer(const edm::ParameterSet& iConfig)
+    : src_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      srcLegacy_(mayConsume<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("src"))),
+      srcV0s_(mayConsume<reco::VertexCompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      map_(consumes<edm::Association<pat::PackedCandidateCollection> >(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      map2_(mayConsume<edm::Association<pat::PackedCandidateCollection> >(
+          iConfig.existsAs<edm::InputTag>("lostTracksCandidates")
+              ? iConfig.getParameter<edm::InputTag>("lostTracksCandidates")
+              : edm::InputTag("lostTracks"))) {
+  produces<reco::VertexCompositePtrCandidateCollection>();
 }
 
 pat::PATSecondaryVertexSlimmer::~PATSecondaryVertexSlimmer() {}
 
 void pat::PATSecondaryVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto outPtr = std::make_unique<reco::VertexCompositePtrCandidateCollection>();
 
-    auto outPtr = std::make_unique<reco::VertexCompositePtrCandidateCollection>();
- 
-    edm::Handle<reco::VertexCompositePtrCandidateCollection> candVertices;
-    iEvent.getByToken(src_, candVertices);
+  edm::Handle<reco::VertexCompositePtrCandidateCollection> candVertices;
+  iEvent.getByToken(src_, candVertices);
 
-    edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
-    iEvent.getByToken(map_,pf2pc);
+  edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
+  iEvent.getByToken(map_, pf2pc);
 
-    // if reco::VertexCompositePtrCandidate secondary vertices are present
-    if( candVertices.isValid() )
-    {
-        outPtr->reserve(candVertices->size());
-        for (unsigned int i = 0, n = candVertices->size(); i < n; ++i) {
+  // if reco::VertexCompositePtrCandidate secondary vertices are present
+  if (candVertices.isValid()) {
+    outPtr->reserve(candVertices->size());
+    for (unsigned int i = 0, n = candVertices->size(); i < n; ++i) {
+      reco::VertexCompositePtrCandidate v = (*candVertices)[i];
 
-                reco::VertexCompositePtrCandidate v = (*candVertices)[i];
+      std::vector<reco::CandidatePtr> daughters = v.daughterPtrVector();
+      v.clearDaughters();
 
-                std::vector<reco::CandidatePtr> daughters = v.daughterPtrVector();
-                v.clearDaughters();
+      for (std::vector<reco::CandidatePtr>::const_iterator it = daughters.begin(); it != daughters.end(); ++it) {
+        if ((*pf2pc)[*it].isNonnull() && (*pf2pc)[*it]->numberOfHits() > 0)
+          v.addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc)[*it])));
+      }
 
-                for(std::vector<reco::CandidatePtr>::const_iterator it = daughters.begin(); it != daughters.end(); ++it) {
-
-                    if((*pf2pc)[*it].isNonnull() && (*pf2pc)[*it]->numberOfHits() > 0)
-                        v.addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc)[*it]) ));
-                }
-
-                outPtr->push_back( v );
-        }
+      outPtr->push_back(v);
     }
-    // otherwise fallback to reco::Vertex secondary vertices
-    else
-    {
-      edm::Handle<std::vector<reco::Vertex> > vertices;
-      iEvent.getByToken(srcLegacy_, vertices);
+  }
+  // otherwise fallback to reco::Vertex secondary vertices
+  else {
+    edm::Handle<std::vector<reco::Vertex> > vertices;
+    iEvent.getByToken(srcLegacy_, vertices);
 
-      if( vertices.isValid() ){
+    if (vertices.isValid()) {
+      edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc2;
+      iEvent.getByToken(map2_, pf2pc2);
 
-        edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc2;
-        iEvent.getByToken(map2_,pf2pc2);
+      outPtr->reserve(vertices->size());
+      for (unsigned int i = 0, n = vertices->size(); i < n; ++i) {
+        const reco::Vertex& v = (*vertices)[i];
+        outPtr->push_back(reco::VertexCompositePtrCandidate(0, v.p4(), v.position(), v.error(), v.chi2(), v.ndof()));
 
-        outPtr->reserve(vertices->size());
-        for (unsigned int i = 0, n = vertices->size(); i < n; ++i) {
-                const reco::Vertex &v = (*vertices)[i];
-                outPtr->push_back(reco::VertexCompositePtrCandidate(0,v.p4(),v.position(), v.error(), v.chi2(), v.ndof()));
-
-                for(reco::Vertex::trackRef_iterator  it=v.tracks_begin(); it != v.tracks_end(); it++) {
-                        if(v.trackWeight(*it)>0.5) {
-                                if((*pf2pc)[*it].isNonnull() && (*pf2pc)[*it]->numberOfHits() > 0) {
-                                        outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc)[*it]) ));
-                                }
-                                else {
-                                        if((*pf2pc2)[*it].isNonnull()) {
-                                                outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc2)[*it]) ));
-                                        }	
-                                        else { edm::LogError("PATSecondaryVertexSlimmer") << "HELPME" << std::endl;}	
-                                }
-                        }
-                }
+        for (reco::Vertex::trackRef_iterator it = v.tracks_begin(); it != v.tracks_end(); it++) {
+          if (v.trackWeight(*it) > 0.5) {
+            if ((*pf2pc)[*it].isNonnull() && (*pf2pc)[*it]->numberOfHits() > 0) {
+              outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc)[*it])));
+            } else {
+              if ((*pf2pc2)[*it].isNonnull()) {
+                outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc2)[*it])));
+              } else {
+                edm::LogError("PATSecondaryVertexSlimmer") << "HELPME" << std::endl;
+              }
+            }
+          }
         }
-      }else {
-	///Must be V0s VertexCompositeCandidate format
-        edm::Handle<reco::VertexCompositeCandidateCollection> srcV0s;
-        iEvent.getByToken( srcV0s_, srcV0s );
+      }
+    } else {
+      ///Must be V0s VertexCompositeCandidate format
+      edm::Handle<reco::VertexCompositeCandidateCollection> srcV0s;
+      iEvent.getByToken(srcV0s_, srcV0s);
 
-        edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc2;
-        iEvent.getByToken(map2_,pf2pc2);
-		
-        outPtr->reserve(srcV0s->size());
-        for (unsigned int i = 0, n = srcV0s->size(); i < n; ++i) {
-                const reco::VertexCompositeCandidate &v = (*srcV0s)[i];
-                outPtr->push_back(reco::VertexCompositePtrCandidate(0,v.p4(),v.vertex(), v.vertexCovariance(), v.vertexChi2(), v.vertexNdof()));
+      edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc2;
+      iEvent.getByToken(map2_, pf2pc2);
 
-                for(size_t dIdx=0; dIdx< v.numberOfDaughters() ; dIdx++){
-			reco::TrackRef trackRef = (dynamic_cast<const reco::RecoChargedCandidate*>(v.daughter(dIdx)))->track();
-                         if((*pf2pc)[trackRef].isNonnull() && (*pf2pc)[trackRef]->numberOfHits() > 0) {
-                                        outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc)[trackRef]) ));
-                                }
-                                else {
-                                        if((*pf2pc2)[trackRef].isNonnull()) {
-                                                outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc2)[trackRef]) ));
-                                        }
-                                        else { edm::LogError("PATSecondaryVertexSlimmer") << "HELPME" << std::endl;}
-                                }
-                }
+      outPtr->reserve(srcV0s->size());
+      for (unsigned int i = 0, n = srcV0s->size(); i < n; ++i) {
+        const reco::VertexCompositeCandidate& v = (*srcV0s)[i];
+        outPtr->push_back(reco::VertexCompositePtrCandidate(
+            0, v.p4(), v.vertex(), v.vertexCovariance(), v.vertexChi2(), v.vertexNdof()));
+
+        for (size_t dIdx = 0; dIdx < v.numberOfDaughters(); dIdx++) {
+          reco::TrackRef trackRef = (dynamic_cast<const reco::RecoChargedCandidate*>(v.daughter(dIdx)))->track();
+          if ((*pf2pc)[trackRef].isNonnull() && (*pf2pc)[trackRef]->numberOfHits() > 0) {
+            outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc)[trackRef])));
+          } else {
+            if ((*pf2pc2)[trackRef].isNonnull()) {
+              outPtr->back().addDaughter(reco::CandidatePtr(edm::refToPtr((*pf2pc2)[trackRef])));
+            } else {
+              edm::LogError("PATSecondaryVertexSlimmer") << "HELPME" << std::endl;
+            }
+          }
         }
- 
-      } // if reco::Vertex 
-    } // if Candidate 
+      }
 
-    iEvent.put(std::move(outPtr));
+    }  // if reco::Vertex
+  }    // if Candidate
+
+  iEvent.put(std::move(outPtr));
 }
 
 using pat::PATSecondaryVertexSlimmer;

--- a/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.cc
@@ -9,95 +9,104 @@
 
 using pat::PATSingleVertexSelector;
 
+PATSingleVertexSelector::Mode PATSingleVertexSelector::parseMode(const std::string &mode) const {
+  if (mode == "firstVertex") {
+    return First;
+  } else if (mode == "nearestToCandidate") {
+    return NearestToCand;
+  } else if (mode == "fromCandidate") {
+    return FromCand;
+  } else if (mode == "beamSpot") {
+    return FromBeamSpot;
+  } else {
+    throw cms::Exception("Configuration")
+        << "PATSingleVertexSelector: Mode '" << mode << "' not recognized or not supported.\n";
+  }
+}
 
-PATSingleVertexSelector::Mode
-PATSingleVertexSelector::parseMode(const std::string &mode) const {
-    if (mode == "firstVertex") {
-        return First;
-    } else if (mode == "nearestToCandidate") {
-        return NearestToCand;
-    } else if (mode == "fromCandidate") {
-        return FromCand;
-    } else if (mode == "beamSpot") {
-        return FromBeamSpot;
-    } else {
-        throw cms::Exception("Configuration") << "PATSingleVertexSelector: Mode '" << mode << "' not recognized or not supported.\n";
+PATSingleVertexSelector::PATSingleVertexSelector(const edm::ParameterSet &iConfig)
+    : vtxPreselection_(iConfig.existsAs<std::string>("vertexPreselection")
+                           ? iConfig.getParameter<std::string>("vertexPreselection")
+                           : std::string(" 1 == 1 ")),
+      candPreselection_(iConfig.existsAs<std::string>("candidatePreselection")
+                            ? iConfig.getParameter<std::string>("candidatePreselection")
+                            : std::string(" 1 == 1 ")),
+      doFilterEvents_(false) {
+  using namespace std;
+
+  modes_.push_back(parseMode(iConfig.getParameter<std::string>("mode")));
+  if (iConfig.exists("fallbacks")) {
+    vector<string> modes = iConfig.getParameter<vector<string>>("fallbacks");
+    for (vector<string>::const_iterator it = modes.begin(), ed = modes.end(); it != ed; ++it) {
+      modes_.push_back(parseMode(*it));
     }
+  }
+  if (hasMode_(First) || hasMode_(NearestToCand)) {
+    verticesToken_ = consumes<vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("vertices"));
+  }
+  if (hasMode_(NearestToCand) || hasMode_(FromCand)) {
+    candidatesToken_ =
+        edm::vector_transform(iConfig.getParameter<vector<edm::InputTag>>("candidates"),
+                              [this](edm::InputTag const &tag) { return consumes<edm::View<reco::Candidate>>(tag); });
+  }
+  if (hasMode_(FromBeamSpot)) {
+    beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"));
+  }
+
+  if (iConfig.exists("filter"))
+    doFilterEvents_ = iConfig.getParameter<bool>("filter");
+
+  produces<vector<reco::Vertex>>();
 }
 
-
-PATSingleVertexSelector::PATSingleVertexSelector(const edm::ParameterSet & iConfig) : 
-  vtxPreselection_( iConfig.existsAs<std::string>("vertexPreselection") ? iConfig.getParameter<std::string>("vertexPreselection") : std::string(" 1 == 1 ") ), 
-  candPreselection_( iConfig.existsAs<std::string>("candidatePreselection") ? iConfig.getParameter<std::string>("candidatePreselection") : std::string(" 1 == 1 ") ),
-  doFilterEvents_(false)
-{
-   using namespace std;
-
-   modes_.push_back( parseMode(iConfig.getParameter<std::string>("mode")) );
-   if (iConfig.exists("fallbacks")) {
-      vector<string> modes = iConfig.getParameter<vector<string> >("fallbacks");
-      for (vector<string>::const_iterator it = modes.begin(), ed = modes.end(); it != ed; ++it) {
-        modes_.push_back( parseMode(*it) );
-      }
-   }
-   if (hasMode_(First) || hasMode_(NearestToCand)) {
-        verticesToken_ = consumes<vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("vertices"));        
-   }
-   if (hasMode_(NearestToCand) || hasMode_(FromCand)) {
-        candidatesToken_ = edm::vector_transform(iConfig.getParameter<vector<edm::InputTag> >("candidates"), [this](edm::InputTag const & tag){return consumes<edm::View<reco::Candidate> >(tag);});        
-   }
-   if (hasMode_(FromBeamSpot)) {
-        beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"));
-   }
-
-   if ( iConfig.exists("filter") ) doFilterEvents_ = iConfig.getParameter<bool>("filter");
-
-   produces<vector<reco::Vertex> >();
-}
-
-
-PATSingleVertexSelector::~PATSingleVertexSelector()
-{
-}
+PATSingleVertexSelector::~PATSingleVertexSelector() {}
 
 bool PATSingleVertexSelector::hasMode_(Mode mode) const {
-    return (std::find(modes_.begin(), modes_.end(), mode) != modes_.end());
+  return (std::find(modes_.begin(), modes_.end(), mode) != modes_.end());
 }
 
-bool
-PATSingleVertexSelector::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool PATSingleVertexSelector::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
 
   // Clear
-  selVtxs_.clear(); bestCand_ = reco::CandidatePtr();
-  
+  selVtxs_.clear();
+  bestCand_ = reco::CandidatePtr();
+
   // Gather data from the Event
   // -- vertex data --
   if (hasMode_(First) || hasMode_(NearestToCand)) {
-    Handle<vector<reco::Vertex> > vertices;
+    Handle<vector<reco::Vertex>> vertices;
     iEvent.getByToken(verticesToken_, vertices);
     for (vector<reco::Vertex>::const_iterator itv = vertices->begin(), edv = vertices->end(); itv != edv; ++itv) {
-      if ( !(vtxPreselection_(*itv)) ) continue;
-      selVtxs_.push_back( reco::VertexRef(vertices,std::distance(vertices->begin(),itv) ) );
+      if (!(vtxPreselection_(*itv)))
+        continue;
+      selVtxs_.push_back(reco::VertexRef(vertices, std::distance(vertices->begin(), itv)));
     }
   }
   // -- candidate data --
   if (hasMode_(NearestToCand) || hasMode_(FromCand)) {
-    vector<pair<double, reco::CandidatePtr> > cands;
-    for (vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator itt = candidatesToken_.begin(), edt = candidatesToken_.end(); itt != edt; ++itt) {
-      Handle<View<reco::Candidate> > theseCands;
+    vector<pair<double, reco::CandidatePtr>> cands;
+    for (vector<edm::EDGetTokenT<edm::View<reco::Candidate>>>::const_iterator itt = candidatesToken_.begin(),
+                                                                              edt = candidatesToken_.end();
+         itt != edt;
+         ++itt) {
+      Handle<View<reco::Candidate>> theseCands;
       iEvent.getByToken(*itt, theseCands);
-      for (View<reco::Candidate>::const_iterator itc = theseCands->begin(), edc = theseCands->end(); itc != edc; ++itc) {
-        if ( !(candPreselection_(*itc)) ) continue;
-        cands.push_back( pair<double, reco::CandidatePtr>(-itc->pt(), reco::CandidatePtr(theseCands,std::distance(theseCands->begin(),itc) ) ) );
+      for (View<reco::Candidate>::const_iterator itc = theseCands->begin(), edc = theseCands->end(); itc != edc;
+           ++itc) {
+        if (!(candPreselection_(*itc)))
+          continue;
+        cands.push_back(pair<double, reco::CandidatePtr>(
+            -itc->pt(), reco::CandidatePtr(theseCands, std::distance(theseCands->begin(), itc))));
       }
     }
-    if (!cands.empty()) bestCand_ = cands.front().second;
+    if (!cands.empty())
+      bestCand_ = cands.front().second;
   }
-  
+
   bool passes = false;
-  std::unique_ptr<vector<reco::Vertex> > result;
+  std::unique_ptr<vector<reco::Vertex>> result;
   // Run main mode + possible fallback modes
   for (std::vector<Mode>::const_iterator itm = modes_.begin(), endm = modes_.end(); itm != endm; ++itm) {
     result = filter_(*itm, iEvent, iSetup);
@@ -111,55 +120,66 @@ PATSingleVertexSelector::filter(edm::Event & iEvent, const edm::EventSetup & iSe
   // Check if we want to apply the EDFilter
   if (doFilterEvents_)
     return passes;
-  else return true;
+  else
+    return true;
 }
 
-std::unique_ptr<std::vector<reco::Vertex> >
-PATSingleVertexSelector::filter_(Mode mode, const edm::Event &iEvent, const edm::EventSetup & iSetup) {
+std::unique_ptr<std::vector<reco::Vertex>> PATSingleVertexSelector::filter_(Mode mode,
+                                                                            const edm::Event &iEvent,
+                                                                            const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
   auto result = std::make_unique<std::vector<reco::Vertex>>();
-  switch(mode) {
-  case First: {
-    if (selVtxs_.empty()) return result;
-    result->push_back(*selVtxs_.front());
-    return result;
-  }
-  case FromCand: {
-    if (bestCand_.isNull()) return result;
-    reco::Vertex vtx;
-    auto const& bestCandDeref = *bestCand_;
-    if (typeid(bestCandDeref) == typeid(reco::VertexCompositeCandidate)) {
-      vtx = reco::Vertex(bestCand_->vertex(), bestCand_->vertexCovariance(),
-                         bestCand_->vertexChi2(), bestCand_->vertexNdof(), bestCand_->numberOfDaughters() );
-    } else {
-      vtx = reco::Vertex(bestCand_->vertex(), reco::Vertex::Error(), 0, 0, 0);
+  switch (mode) {
+    case First: {
+      if (selVtxs_.empty())
+        return result;
+      result->push_back(*selVtxs_.front());
+      return result;
     }
-    result->push_back(vtx);
-    return result;
-  }
-  case NearestToCand: {
-    if (selVtxs_.empty() || (bestCand_.isNull())) return result;
-    reco::VertexRef which;
-    float dzmin = 9999.0;
-    for (auto itv = selVtxs_.begin(), edv = selVtxs_.end(); itv != edv; ++itv) {
-      float dz = std::abs((*itv)->z() - bestCand_->vz());
-      if (dz < dzmin) { dzmin = dz; which = *itv; }
+    case FromCand: {
+      if (bestCand_.isNull())
+        return result;
+      reco::Vertex vtx;
+      auto const &bestCandDeref = *bestCand_;
+      if (typeid(bestCandDeref) == typeid(reco::VertexCompositeCandidate)) {
+        vtx = reco::Vertex(bestCand_->vertex(),
+                           bestCand_->vertexCovariance(),
+                           bestCand_->vertexChi2(),
+                           bestCand_->vertexNdof(),
+                           bestCand_->numberOfDaughters());
+      } else {
+        vtx = reco::Vertex(bestCand_->vertex(), reco::Vertex::Error(), 0, 0, 0);
+      }
+      result->push_back(vtx);
+      return result;
     }
-    if (which.isNonnull()) // actually it should not happen, but better safe than sorry
-      result->push_back(*which);
-    return result;
-  }
-  case FromBeamSpot: {
-    Handle<reco::BeamSpot> beamSpot;
-    iEvent.getByToken(beamSpotToken_, beamSpot);
-    reco::Vertex bs(beamSpot->position(), beamSpot->covariance3D(), 0, 0, 0);
-    result->push_back(bs);
-    return result;
-  }
-  default:
-    // Return an empty vector signifying no vertices found.
-    return result;
+    case NearestToCand: {
+      if (selVtxs_.empty() || (bestCand_.isNull()))
+        return result;
+      reco::VertexRef which;
+      float dzmin = 9999.0;
+      for (auto itv = selVtxs_.begin(), edv = selVtxs_.end(); itv != edv; ++itv) {
+        float dz = std::abs((*itv)->z() - bestCand_->vz());
+        if (dz < dzmin) {
+          dzmin = dz;
+          which = *itv;
+        }
+      }
+      if (which.isNonnull())  // actually it should not happen, but better safe than sorry
+        result->push_back(*which);
+      return result;
+    }
+    case FromBeamSpot: {
+      Handle<reco::BeamSpot> beamSpot;
+      iEvent.getByToken(beamSpotToken_, beamSpot);
+      reco::Vertex bs(beamSpot->position(), beamSpot->covariance3D(), 0, 0, 0);
+      result->push_back(bs);
+      return result;
+    }
+    default:
+      // Return an empty vector signifying no vertices found.
+      return result;
   }
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
@@ -26,42 +26,40 @@
 namespace pat {
 
   class PATSingleVertexSelector : public edm::stream::EDFilter<> {
+  public:
+    explicit PATSingleVertexSelector(const edm::ParameterSet& iConfig);
+    ~PATSingleVertexSelector() override;
 
-    public:
+    bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATSingleVertexSelector(const edm::ParameterSet & iConfig);
-      ~PATSingleVertexSelector() override;
+  private:
+    enum Mode { First, NearestToCand, FromCand, FromBeamSpot };
+    typedef StringCutObjectSelector<reco::Vertex> VtxSel;
+    typedef StringCutObjectSelector<reco::Candidate> CandSel;
 
-      bool filter(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    Mode parseMode(const std::string& name) const;
 
-    private:
-      enum Mode { First, NearestToCand, FromCand, FromBeamSpot };
-      typedef StringCutObjectSelector<reco::Vertex>    VtxSel;
-      typedef StringCutObjectSelector<reco::Candidate> CandSel;
+    std::unique_ptr<std::vector<reco::Vertex> > filter_(Mode mode,
+                                                        const edm::Event& iEvent,
+                                                        const edm::EventSetup& iSetup);
+    bool hasMode_(Mode mode) const;
+    // configurables
+    std::vector<Mode> modes_;  // mode + optional fallbacks
+    edm::EDGetTokenT<std::vector<reco::Vertex> > verticesToken_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > candidatesToken_;
+    const VtxSel vtxPreselection_;
+    const CandSel candPreselection_;
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+    // transient data. meaningful while 'filter()' is on the stack
+    std::vector<reco::VertexRef> selVtxs_;
+    reco::CandidatePtr bestCand_;
 
-      Mode parseMode(const std::string &name) const;
-      
-      std::unique_ptr<std::vector<reco::Vertex> >
-        filter_(Mode mode, const edm::Event & iEvent, const edm::EventSetup & iSetup);
-      bool hasMode_(Mode mode) const ;
-      // configurables
-      std::vector<Mode> modes_; // mode + optional fallbacks
-      edm::EDGetTokenT<std::vector<reco::Vertex> > verticesToken_;
-      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > candidatesToken_;
-      const VtxSel vtxPreselection_;
-      const CandSel candPreselection_;
-      edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-      // transient data. meaningful while 'filter()' is on the stack
-      std::vector<reco::VertexRef> selVtxs_;
-      reco::CandidatePtr           bestCand_;
-
-      // flag to enable/disable EDFilter functionality:
-      // if set to false, PATSingleVertexSelector selects the "one" event vertex,
-      // but does not reject any events
-      bool doFilterEvents_;
+    // flag to enable/disable EDFilter functionality:
+    // if set to false, PATSingleVertexSelector selects the "one" event vertex,
+    // but does not reject any events
+    bool doFilterEvents_;
   };
 
-}
+}  // namespace pat
 
 #endif
-

--- a/PhysicsTools/PatAlgos/plugins/PATTauIDEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauIDEmbedder.cc
@@ -7,26 +7,22 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "FWCore/Utilities/interface/transform.h"
 
-class PATTauIDEmbedder : public edm::stream::EDProducer<>
-{
+class PATTauIDEmbedder : public edm::stream::EDProducer<> {
 public:
+  explicit PATTauIDEmbedder(const edm::ParameterSet&);
+  ~PATTauIDEmbedder() override{};
 
-	explicit PATTauIDEmbedder(const edm::ParameterSet&);
-	~PATTauIDEmbedder() override{};
-
-	void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-
-//--- configuration parameters
-	edm::EDGetTokenT<pat::TauCollection> src_;
-	typedef std::pair<std::string, edm::InputTag> NameTag;
-	std::vector<NameTag> tauIDSrcs_;
-	std::vector<edm::EDGetTokenT<pat::PATTauDiscriminator> > patTauIDTokens_;
+  //--- configuration parameters
+  edm::EDGetTokenT<pat::TauCollection> src_;
+  typedef std::pair<std::string, edm::InputTag> NameTag;
+  std::vector<NameTag> tauIDSrcs_;
+  std::vector<edm::EDGetTokenT<pat::PATTauDiscriminator> > patTauIDTokens_;
 };
 
-PATTauIDEmbedder::PATTauIDEmbedder(const edm::ParameterSet& cfg)
-{
+PATTauIDEmbedder::PATTauIDEmbedder(const edm::ParameterSet& cfg) {
   src_ = consumes<pat::TauCollection>(cfg.getParameter<edm::InputTag>("src"));
   // read the different tau ID names
   edm::ParameterSet idps = cfg.getParameter<edm::ParameterSet>("tauIDSources");
@@ -35,46 +31,47 @@ PATTauIDEmbedder::PATTauIDEmbedder(const edm::ParameterSet& cfg)
     tauIDSrcs_.push_back(NameTag(*it, idps.getParameter<edm::InputTag>(*it)));
   }
   // but in any case at least once
-  if (tauIDSrcs_.empty()) throw cms::Exception("Configuration") <<
-    "PATTauProducer: id addTauID is true, you must specify:\n" <<
-    "\tPSet tauIDSources = { \n" <<
-    "\t\tInputTag <someName> = <someTag>   // as many as you want \n " <<
-    "\t}\n";
-  patTauIDTokens_ = edm::vector_transform(tauIDSrcs_, [this](NameTag const & tag){return mayConsume<pat::PATTauDiscriminator>(tag.second);});
-  
+  if (tauIDSrcs_.empty())
+    throw cms::Exception("Configuration") << "PATTauProducer: id addTauID is true, you must specify:\n"
+                                          << "\tPSet tauIDSources = { \n"
+                                          << "\t\tInputTag <someName> = <someTag>   // as many as you want \n "
+                                          << "\t}\n";
+  patTauIDTokens_ = edm::vector_transform(
+      tauIDSrcs_, [this](NameTag const& tag) { return mayConsume<pat::PATTauDiscriminator>(tag.second); });
+
   produces<std::vector<pat::Tau> >();
 }
 
-void PATTauIDEmbedder::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void PATTauIDEmbedder::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<pat::TauCollection> inputTaus;
   evt.getByToken(src_, inputTaus);
-  
+
   auto outputTaus = std::make_unique<std::vector<pat::Tau> >();
   outputTaus->reserve(inputTaus->size());
-  
+
   int tau_idx = 0;
-  for(pat::TauCollection::const_iterator inputTau = inputTaus->begin(); inputTau != inputTaus->end(); ++inputTau, ++tau_idx){
+  for (pat::TauCollection::const_iterator inputTau = inputTaus->begin(); inputTau != inputTaus->end();
+       ++inputTau, ++tau_idx) {
     pat::Tau outputTau(*inputTau);
     pat::TauRef inputTauRef(inputTaus, tau_idx);
     size_t nTauIds = inputTau->tauIDs().size();
-    std::vector<pat::Tau::IdPair> tauIds(nTauIds+tauIDSrcs_.size());
-    
-    for(size_t i = 0; i < nTauIds; ++i){
+    std::vector<pat::Tau::IdPair> tauIds(nTauIds + tauIDSrcs_.size());
+
+    for (size_t i = 0; i < nTauIds; ++i) {
       tauIds[i] = inputTau->tauIDs().at(i);
     }
 
     edm::Handle<pat::PATTauDiscriminator> tauDiscr;
-    for(size_t i = 0; i < tauIDSrcs_.size(); ++i){
-      evt.getByToken(patTauIDTokens_[i], tauDiscr);      
-      tauIds[nTauIds+i].first = tauIDSrcs_[i].first;
-      tauIds[nTauIds+i].second = (*tauDiscr)[inputTauRef];
+    for (size_t i = 0; i < tauIDSrcs_.size(); ++i) {
+      evt.getByToken(patTauIDTokens_[i], tauDiscr);
+      tauIds[nTauIds + i].first = tauIDSrcs_[i].first;
+      tauIds[nTauIds + i].second = (*tauDiscr)[inputTauRef];
     }
-    
+
     outputTau.setTauIDs(tauIds);
     outputTaus->push_back(outputTau);
   }
-  
+
   evt.put(std::move(outputTaus));
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -20,7 +20,6 @@
 #include "DataFormats/PatCandidates/interface/TauPFSpecific.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
-
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -29,51 +28,58 @@
 
 using namespace pat;
 
-PATTauProducer::PATTauProducer(const edm::ParameterSet & iConfig):
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false) ,
-  useUserData_(iConfig.exists("userData"))
-{
-  firstOccurence_=true;
+PATTauProducer::PATTauProducer(const edm::ParameterSet& iConfig)
+    : isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
+                                                : edm::ParameterSet(),
+                consumesCollector(),
+                false),
+      useUserData_(iConfig.exists("userData")) {
+  firstOccurence_ = true;
   // initialize the configurables
-  baseTauToken_ = consumes<edm::View<reco::BaseTau> >(iConfig.getParameter<edm::InputTag>( "tauSource" ));
-  tauTransverseImpactParameterSrc_ = iConfig.getParameter<edm::InputTag>( "tauTransverseImpactParameterSource" );
-  tauTransverseImpactParameterToken_ = consumes<PFTauTIPAssociationByRef>( tauTransverseImpactParameterSrc_);
-  pfTauToken_ = consumes<reco::PFTauCollection>(iConfig.getParameter<edm::InputTag>( "tauSource" ));
-  caloTauToken_ = mayConsume<reco::CaloTauCollection>(iConfig.getParameter<edm::InputTag>( "tauSource" ));
-  embedIsolationTracks_ = iConfig.getParameter<bool>( "embedIsolationTracks" );
-  embedLeadTrack_ = iConfig.getParameter<bool>( "embedLeadTrack" );
-  embedSignalTracks_ = iConfig.getParameter<bool>( "embedSignalTracks" );
-  embedLeadPFCand_ = iConfig.getParameter<bool>( "embedLeadPFCand" );
-  embedLeadPFChargedHadrCand_ = iConfig.getParameter<bool>( "embedLeadPFChargedHadrCand" );
-  embedLeadPFNeutralCand_ = iConfig.getParameter<bool>( "embedLeadPFNeutralCand" );
-  embedSignalPFCands_ = iConfig.getParameter<bool>( "embedSignalPFCands" );
-  embedSignalPFChargedHadrCands_ = iConfig.getParameter<bool>( "embedSignalPFChargedHadrCands" );
-  embedSignalPFNeutralHadrCands_ = iConfig.getParameter<bool>( "embedSignalPFNeutralHadrCands" );
-  embedSignalPFGammaCands_ = iConfig.getParameter<bool>( "embedSignalPFGammaCands" );
-  embedIsolationPFCands_ = iConfig.getParameter<bool>( "embedIsolationPFCands" );
-  embedIsolationPFChargedHadrCands_ = iConfig.getParameter<bool>( "embedIsolationPFChargedHadrCands" );
-  embedIsolationPFNeutralHadrCands_ = iConfig.getParameter<bool>( "embedIsolationPFNeutralHadrCands" );
-  embedIsolationPFGammaCands_ = iConfig.getParameter<bool>( "embedIsolationPFGammaCands" );
-  addGenMatch_ = iConfig.getParameter<bool>( "addGenMatch" );
+  baseTauToken_ = consumes<edm::View<reco::BaseTau>>(iConfig.getParameter<edm::InputTag>("tauSource"));
+  tauTransverseImpactParameterSrc_ = iConfig.getParameter<edm::InputTag>("tauTransverseImpactParameterSource");
+  tauTransverseImpactParameterToken_ = consumes<PFTauTIPAssociationByRef>(tauTransverseImpactParameterSrc_);
+  pfTauToken_ = consumes<reco::PFTauCollection>(iConfig.getParameter<edm::InputTag>("tauSource"));
+  caloTauToken_ = mayConsume<reco::CaloTauCollection>(iConfig.getParameter<edm::InputTag>("tauSource"));
+  embedIsolationTracks_ = iConfig.getParameter<bool>("embedIsolationTracks");
+  embedLeadTrack_ = iConfig.getParameter<bool>("embedLeadTrack");
+  embedSignalTracks_ = iConfig.getParameter<bool>("embedSignalTracks");
+  embedLeadPFCand_ = iConfig.getParameter<bool>("embedLeadPFCand");
+  embedLeadPFChargedHadrCand_ = iConfig.getParameter<bool>("embedLeadPFChargedHadrCand");
+  embedLeadPFNeutralCand_ = iConfig.getParameter<bool>("embedLeadPFNeutralCand");
+  embedSignalPFCands_ = iConfig.getParameter<bool>("embedSignalPFCands");
+  embedSignalPFChargedHadrCands_ = iConfig.getParameter<bool>("embedSignalPFChargedHadrCands");
+  embedSignalPFNeutralHadrCands_ = iConfig.getParameter<bool>("embedSignalPFNeutralHadrCands");
+  embedSignalPFGammaCands_ = iConfig.getParameter<bool>("embedSignalPFGammaCands");
+  embedIsolationPFCands_ = iConfig.getParameter<bool>("embedIsolationPFCands");
+  embedIsolationPFChargedHadrCands_ = iConfig.getParameter<bool>("embedIsolationPFChargedHadrCands");
+  embedIsolationPFNeutralHadrCands_ = iConfig.getParameter<bool>("embedIsolationPFNeutralHadrCands");
+  embedIsolationPFGammaCands_ = iConfig.getParameter<bool>("embedIsolationPFGammaCands");
+  addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
-    embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
+    embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
     if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
-    }
-    else {
-      genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    } else {
+      genMatchTokens_ = edm::vector_transform(
+          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
+          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
     }
   }
-  addGenJetMatch_ = iConfig.getParameter<bool>( "addGenJetMatch" );
-  if(addGenJetMatch_) {
-    embedGenJetMatch_ = iConfig.getParameter<bool>( "embedGenJetMatch" );
-    genJetMatchToken_ = consumes<edm::Association<reco::GenJetCollection> >(iConfig.getParameter<edm::InputTag>( "genJetMatch" ));
+  addGenJetMatch_ = iConfig.getParameter<bool>("addGenJetMatch");
+  if (addGenJetMatch_) {
+    embedGenJetMatch_ = iConfig.getParameter<bool>("embedGenJetMatch");
+    genJetMatchToken_ =
+        consumes<edm::Association<reco::GenJetCollection>>(iConfig.getParameter<edm::InputTag>("genJetMatch"));
   }
-  addTauJetCorrFactors_ = iConfig.getParameter<bool>( "addTauJetCorrFactors" );
-  tauJetCorrFactorsTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "tauJetCorrFactorsSource" ), [this](edm::InputTag const & tag){return mayConsume<edm::ValueMap<TauJetCorrFactors> >(tag);});
+  addTauJetCorrFactors_ = iConfig.getParameter<bool>("addTauJetCorrFactors");
+  tauJetCorrFactorsTokens_ = edm::vector_transform(
+      iConfig.getParameter<std::vector<edm::InputTag>>("tauJetCorrFactorsSource"),
+      [this](edm::InputTag const& tag) { return mayConsume<edm::ValueMap<TauJetCorrFactors>>(tag); });
   // tau ID configurables
-  addTauID_ = iConfig.getParameter<bool>( "addTauID" );
-  if ( addTauID_ ) {
+  addTauID_ = iConfig.getParameter<bool>("addTauID");
+  if (addTauID_) {
     // read the different tau ID names
     edm::ParameterSet idps = iConfig.getParameter<edm::ParameterSet>("tauIDSources");
     std::vector<std::string> names = idps.getParameterNamesForType<edm::InputTag>();
@@ -81,289 +87,320 @@ PATTauProducer::PATTauProducer(const edm::ParameterSet & iConfig):
       tauIDSrcs_.push_back(NameTag(*it, idps.getParameter<edm::InputTag>(*it)));
     }
     // but in any case at least once
-    if (tauIDSrcs_.empty()) throw cms::Exception("Configuration") <<
-      "PATTauProducer: id addTauID is true, you must specify either:\n" <<
-      "\tPSet tauIDSources = { \n" <<
-      "\t\tInputTag <someName> = <someTag>   // as many as you want \n " <<
-      "\t}\n";
+    if (tauIDSrcs_.empty())
+      throw cms::Exception("Configuration") << "PATTauProducer: id addTauID is true, you must specify either:\n"
+                                            << "\tPSet tauIDSources = { \n"
+                                            << "\t\tInputTag <someName> = <someTag>   // as many as you want \n "
+                                            << "\t}\n";
   }
-  caloTauIDTokens_ = edm::vector_transform(tauIDSrcs_, [this](NameTag const & tag){return mayConsume<reco::CaloTauDiscriminator>(tag.second);});
-  pfTauIDTokens_   = edm::vector_transform(tauIDSrcs_, [this](NameTag const & tag){return mayConsume<reco::PFTauDiscriminator>(tag.second);});
-  skipMissingTauID_ = iConfig.getParameter<bool>( "skipMissingTauID" );
+  caloTauIDTokens_ = edm::vector_transform(
+      tauIDSrcs_, [this](NameTag const& tag) { return mayConsume<reco::CaloTauDiscriminator>(tag.second); });
+  pfTauIDTokens_ = edm::vector_transform(
+      tauIDSrcs_, [this](NameTag const& tag) { return mayConsume<reco::PFTauDiscriminator>(tag.second); });
+  skipMissingTauID_ = iConfig.getParameter<bool>("skipMissingTauID");
   // IsoDeposit configurables
   if (iConfig.exists("isoDeposits")) {
     edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>("isoDeposits");
-    if ( depconf.exists("tracker")         ) isoDepositLabels_.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-    if ( depconf.exists("ecal")            ) isoDepositLabels_.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-    if ( depconf.exists("hcal")            ) isoDepositLabels_.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-    if ( depconf.exists("pfAllParticles")  ) isoDepositLabels_.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
-    if ( depconf.exists("pfChargedHadron") ) isoDepositLabels_.push_back(std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadron")));
-    if ( depconf.exists("pfNeutralHadron") ) isoDepositLabels_.push_back(std::make_pair(pat::PfNeutralHadronIso,depconf.getParameter<edm::InputTag>("pfNeutralHadron")));
-    if ( depconf.exists("pfGamma")         ) isoDepositLabels_.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfGamma")));
+    if (depconf.exists("tracker"))
+      isoDepositLabels_.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
+    if (depconf.exists("ecal"))
+      isoDepositLabels_.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
+    if (depconf.exists("hcal"))
+      isoDepositLabels_.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
+    if (depconf.exists("pfAllParticles"))
+      isoDepositLabels_.push_back(
+          std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
+    if (depconf.exists("pfChargedHadron"))
+      isoDepositLabels_.push_back(
+          std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadron")));
+    if (depconf.exists("pfNeutralHadron"))
+      isoDepositLabels_.push_back(
+          std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadron")));
+    if (depconf.exists("pfGamma"))
+      isoDepositLabels_.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfGamma")));
 
-    if ( depconf.exists("user") ) {
-      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
+    if (depconf.exists("user")) {
+      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag>>("user");
       std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
       int key = UserBaseIso;
-      for ( ; it != ed; ++it, ++key) {
-       isoDepositLabels_.push_back(std::make_pair(IsolationKeys(key), *it));
+      for (; it != ed; ++it, ++key) {
+        isoDepositLabels_.push_back(std::make_pair(IsolationKeys(key), *it));
       }
     }
   }
-  isoDepositTokens_ = edm::vector_transform(isoDepositLabels_, [this](std::pair<IsolationKeys,edm::InputTag> const & label){return consumes<edm::ValueMap<IsoDeposit> >(label.second);});
+  isoDepositTokens_ =
+      edm::vector_transform(isoDepositLabels_, [this](std::pair<IsolationKeys, edm::InputTag> const& label) {
+        return consumes<edm::ValueMap<IsoDeposit>>(label.second);
+      });
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
+    efficiencyLoader_ =
+        pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
   // Resolution configurables
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
-     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
+    resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
   // Check to see if the user wants to add user data
-  if ( useUserData_ ) {
+  if (useUserData_) {
     userDataHelper_ = PATUserDataHelper<Tau>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   // produces vector of taus
-  produces<std::vector<Tau> >();
+  produces<std::vector<Tau>>();
 }
 
-PATTauProducer::~PATTauProducer()
-{
-}
+PATTauProducer::~PATTauProducer() {}
 
-void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
-{
+void PATTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // switch off embedding (in unschedules mode)
-  if (iEvent.isRealData()){
-    addGenMatch_    = false;
-    embedGenMatch_  = false;
+  if (iEvent.isRealData()) {
+    addGenMatch_ = false;
+    embedGenMatch_ = false;
     addGenJetMatch_ = false;
   }
 
   // Get the collection of taus from the event
-  edm::Handle<edm::View<reco::BaseTau> > anyTaus;
+  edm::Handle<edm::View<reco::BaseTau>> anyTaus;
   try {
     iEvent.getByToken(baseTauToken_, anyTaus);
-  } catch (const edm::Exception &e) {
-    edm::LogWarning("DataSource") << "WARNING! No Tau collection found. This missing input will not block the job. Instead, an empty tau collection is being be produced.";
+  } catch (const edm::Exception& e) {
+    edm::LogWarning("DataSource") << "WARNING! No Tau collection found. This missing input will not block the job. "
+                                     "Instead, an empty tau collection is being be produced.";
     auto patTaus = std::make_unique<std::vector<Tau>>();
     iEvent.put(std::move(patTaus));
     return;
   }
 
-  if (isolator_.enabled()) isolator_.beginEvent(iEvent,iSetup);
+  if (isolator_.enabled())
+    isolator_.beginEvent(iEvent, iSetup);
 
-  if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
-  if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
+  if (efficiencyLoader_.enabled())
+    efficiencyLoader_.newEvent(iEvent);
+  if (resolutionLoader_.enabled())
+    resolutionLoader_.newEvent(iEvent, iSetup);
 
-  std::vector<edm::Handle<edm::ValueMap<IsoDeposit> > > deposits(isoDepositTokens_.size());
+  std::vector<edm::Handle<edm::ValueMap<IsoDeposit>>> deposits(isoDepositTokens_.size());
   for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
     iEvent.getByToken(isoDepositTokens_[j], deposits[j]);
   }
 
   // prepare the MC matching
-  std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > >genMatches(genMatchTokens_.size());
+  std::vector<edm::Handle<edm::Association<reco::GenParticleCollection>>> genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
     for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
       iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
     }
   }
 
-  edm::Handle<edm::Association<reco::GenJetCollection> > genJetMatch;
-  if (addGenJetMatch_) iEvent.getByToken(genJetMatchToken_, genJetMatch);
+  edm::Handle<edm::Association<reco::GenJetCollection>> genJetMatch;
+  if (addGenJetMatch_)
+    iEvent.getByToken(genJetMatchToken_, genJetMatch);
 
   // read in the jet correction factors ValueMap
-  std::vector<edm::ValueMap<TauJetCorrFactors> > tauJetCorrs;
+  std::vector<edm::ValueMap<TauJetCorrFactors>> tauJetCorrs;
   if (addTauJetCorrFactors_) {
-    for ( size_t i = 0; i < tauJetCorrFactorsTokens_.size(); ++i ) {
-      edm::Handle<edm::ValueMap<TauJetCorrFactors> > tauJetCorr;
+    for (size_t i = 0; i < tauJetCorrFactorsTokens_.size(); ++i) {
+      edm::Handle<edm::ValueMap<TauJetCorrFactors>> tauJetCorr;
       iEvent.getByToken(tauJetCorrFactorsTokens_[i], tauJetCorr);
-      tauJetCorrs.push_back( *tauJetCorr );
+      tauJetCorrs.push_back(*tauJetCorr);
     }
   }
 
   auto patTaus = std::make_unique<std::vector<Tau>>();
 
-  bool first=true; // this is introduced to issue warnings only for the first tau-jet
+  bool first = true;  // this is introduced to issue warnings only for the first tau-jet
   for (size_t idx = 0, ntaus = anyTaus->size(); idx < ntaus; ++idx) {
     edm::RefToBase<reco::BaseTau> tausRef = anyTaus->refAt(idx);
     edm::Ptr<reco::BaseTau> tausPtr = anyTaus->ptrAt(idx);
 
     Tau aTau(tausRef);
-    if (embedLeadTrack_)       aTau.embedLeadTrack();
-    if (embedSignalTracks_)    aTau.embedSignalTracks();
-    if (embedIsolationTracks_) aTau.embedIsolationTracks();
+    if (embedLeadTrack_)
+      aTau.embedLeadTrack();
+    if (embedSignalTracks_)
+      aTau.embedSignalTracks();
+    if (embedIsolationTracks_)
+      aTau.embedIsolationTracks();
     if (embedLeadPFCand_) {
-      if (aTau.isPFTau() )
-	aTau.embedLeadPFCand();
+      if (aTau.isPFTau())
+        aTau.embedLeadPFCand();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedLeadPFChargedHadrCand_) {
-      if (aTau.isPFTau() )
-	aTau.embedLeadPFChargedHadrCand();
+      if (aTau.isPFTau())
+        aTau.embedLeadPFChargedHadrCand();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedLeadPFNeutralCand_) {
-      if (aTau.isPFTau() )
-	aTau.embedLeadPFNeutralCand();
+      if (aTau.isPFTau())
+        aTau.embedLeadPFNeutralCand();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedSignalPFCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedSignalPFCands();
+      if (aTau.isPFTau())
+        aTau.embedSignalPFCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedSignalPFChargedHadrCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedSignalPFChargedHadrCands();
+      if (aTau.isPFTau())
+        aTau.embedSignalPFChargedHadrCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedSignalPFNeutralHadrCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedSignalPFNeutralHadrCands();
+      if (aTau.isPFTau())
+        aTau.embedSignalPFNeutralHadrCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedSignalPFGammaCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedSignalPFGammaCands();
+      if (aTau.isPFTau())
+        aTau.embedSignalPFGammaCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedIsolationPFCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedIsolationPFCands();
+      if (aTau.isPFTau())
+        aTau.embedIsolationPFCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedIsolationPFChargedHadrCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedIsolationPFChargedHadrCands();
+      if (aTau.isPFTau())
+        aTau.embedIsolationPFChargedHadrCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedIsolationPFNeutralHadrCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedIsolationPFNeutralHadrCands();
+      if (aTau.isPFTau())
+        aTau.embedIsolationPFNeutralHadrCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
     if (embedIsolationPFGammaCands_) {
-      if (aTau.isPFTau() )
-	aTau.embedIsolationPFGammaCands();
+      if (aTau.isPFTau())
+        aTau.embedIsolationPFGammaCands();
       else
-	edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made from a reco::PFTau is impossible.\n";
+        edm::LogWarning("Type Error") << "Embedding a PFTau-specific information into a pat::Tau which wasn't made "
+                                         "from a reco::PFTau is impossible.\n";
     }
 
     if (addTauJetCorrFactors_) {
       // add additional JetCorrs to the jet
-      for ( unsigned int i=0; i<tauJetCorrs.size(); ++i ) {
-	const TauJetCorrFactors& tauJetCorr = tauJetCorrs[i][tausRef];
-	// uncomment for debugging
-	// tauJetCorr.print();
-	aTau.addJECFactors(tauJetCorr);
+      for (unsigned int i = 0; i < tauJetCorrs.size(); ++i) {
+        const TauJetCorrFactors& tauJetCorr = tauJetCorrs[i][tausRef];
+        // uncomment for debugging
+        // tauJetCorr.print();
+        aTau.addJECFactors(tauJetCorr);
       }
       std::vector<std::string> levels = tauJetCorrs[0][tausRef].correctionLabels();
-      if(std::find(levels.begin(), levels.end(), "L2L3Residual")!=levels.end()){
-	aTau.initializeJEC(tauJetCorrs[0][tausRef].jecLevel("L2L3Residual"));
-      }
-      else if(std::find(levels.begin(), levels.end(), "L3Absolute")!=levels.end()){
-	aTau.initializeJEC(tauJetCorrs[0][tausRef].jecLevel("L3Absolute"));
-      }
-      else{
-	aTau.initializeJEC(tauJetCorrs[0][tausRef].jecLevel("Uncorrected"));
-	if(first){
-	  edm::LogWarning("L3Absolute not found")
-	    << "L2L3Residual and L3Absolute are not part of the correction applied jetCorrFactors \n"
-	    << "of module " <<  tauJetCorrs[0][tausRef].jecSet() << " jets will remain"
-	    << " uncorrected.";
-	  first=false;
-	}
+      if (std::find(levels.begin(), levels.end(), "L2L3Residual") != levels.end()) {
+        aTau.initializeJEC(tauJetCorrs[0][tausRef].jecLevel("L2L3Residual"));
+      } else if (std::find(levels.begin(), levels.end(), "L3Absolute") != levels.end()) {
+        aTau.initializeJEC(tauJetCorrs[0][tausRef].jecLevel("L3Absolute"));
+      } else {
+        aTau.initializeJEC(tauJetCorrs[0][tausRef].jecLevel("Uncorrected"));
+        if (first) {
+          edm::LogWarning("L3Absolute not found")
+              << "L2L3Residual and L3Absolute are not part of the correction applied jetCorrFactors \n"
+              << "of module " << tauJetCorrs[0][tausRef].jecSet() << " jets will remain"
+              << " uncorrected.";
+          first = false;
+        }
       }
     }
 
     // store the match to the generated final state muons
     if (addGenMatch_) {
-      for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
-          reco::GenParticleRef genTau = (*genMatches[i])[tausRef];
-          aTau.addGenParticleRef(genTau);
+      for (size_t i = 0, n = genMatches.size(); i < n; ++i) {
+        reco::GenParticleRef genTau = (*genMatches[i])[tausRef];
+        aTau.addGenParticleRef(genTau);
       }
-      if (embedGenMatch_) aTau.embedGenParticle();
+      if (embedGenMatch_)
+        aTau.embedGenParticle();
     }
 
     // store the match to the visible part of the generated tau
     if (addGenJetMatch_) {
       reco::GenJetRef genJetTau = (*genJetMatch)[tausRef];
-      if (genJetTau.isNonnull() && genJetTau.isAvailable() ) {
-        aTau.setGenJet( genJetTau );
-      } // leave empty if no match found
+      if (genJetTau.isNonnull() && genJetTau.isAvailable()) {
+        aTau.setGenJet(genJetTau);
+      }  // leave empty if no match found
     }
 
     // prepare ID extraction
-    if ( addTauID_ ) {
+    if (addTauID_) {
       std::string missingDiscriminators;
       std::vector<pat::Tau::IdPair> ids(tauIDSrcs_.size());
       auto const& tausDeref = *tausRef;
-      for ( size_t i = 0; i < tauIDSrcs_.size(); ++i ) {
-	if ( typeid(tausDeref) == typeid(reco::PFTau) ) {
-	  //std::cout << "filling PFTauDiscriminator '" << tauIDSrcs_[i].first << "' into pat::Tau object..." << std::endl;
-	  edm::Handle<reco::PFTauCollection> pfTauCollection;
-	  iEvent.getByToken(pfTauToken_, pfTauCollection);
+      for (size_t i = 0; i < tauIDSrcs_.size(); ++i) {
+        if (typeid(tausDeref) == typeid(reco::PFTau)) {
+          //std::cout << "filling PFTauDiscriminator '" << tauIDSrcs_[i].first << "' into pat::Tau object..." << std::endl;
+          edm::Handle<reco::PFTauCollection> pfTauCollection;
+          iEvent.getByToken(pfTauToken_, pfTauCollection);
 
-	  edm::Handle<reco::PFTauDiscriminator> pfTauIdDiscr;
-	  iEvent.getByToken(pfTauIDTokens_[i], pfTauIdDiscr);
+          edm::Handle<reco::PFTauDiscriminator> pfTauIdDiscr;
+          iEvent.getByToken(pfTauIDTokens_[i], pfTauIdDiscr);
 
-	  if(skipMissingTauID_ && !pfTauIdDiscr.isValid()){
-	    if(!missingDiscriminators.empty()){
-	      missingDiscriminators+=", ";
-	    }
-	    missingDiscriminators+=tauIDSrcs_[i].first;
-	    continue;
-	  }
-	  ids[i].first = tauIDSrcs_[i].first;
-	  ids[i].second = getTauIdDiscriminator(pfTauCollection, idx, pfTauIdDiscr);
-	} else if ( typeid(tausDeref) == typeid(reco::CaloTau) ) {
-	  //std::cout << "filling CaloTauDiscriminator '" << tauIDSrcs_[i].first << "' into pat::Tau object..." << std::endl;
-	  edm::Handle<reco::CaloTauCollection> caloTauCollection;
-	  iEvent.getByToken(caloTauToken_, caloTauCollection);
+          if (skipMissingTauID_ && !pfTauIdDiscr.isValid()) {
+            if (!missingDiscriminators.empty()) {
+              missingDiscriminators += ", ";
+            }
+            missingDiscriminators += tauIDSrcs_[i].first;
+            continue;
+          }
+          ids[i].first = tauIDSrcs_[i].first;
+          ids[i].second = getTauIdDiscriminator(pfTauCollection, idx, pfTauIdDiscr);
+        } else if (typeid(tausDeref) == typeid(reco::CaloTau)) {
+          //std::cout << "filling CaloTauDiscriminator '" << tauIDSrcs_[i].first << "' into pat::Tau object..." << std::endl;
+          edm::Handle<reco::CaloTauCollection> caloTauCollection;
+          iEvent.getByToken(caloTauToken_, caloTauCollection);
 
-	  edm::Handle<reco::CaloTauDiscriminator> caloTauIdDiscr;
-	  iEvent.getByToken(caloTauIDTokens_[i], caloTauIdDiscr);
+          edm::Handle<reco::CaloTauDiscriminator> caloTauIdDiscr;
+          iEvent.getByToken(caloTauIDTokens_[i], caloTauIdDiscr);
 
-	  if(skipMissingTauID_ && !caloTauIdDiscr.isValid()){
-	    if(!missingDiscriminators.empty()){
-	      missingDiscriminators+=", ";
-	    }
-	    missingDiscriminators+=tauIDSrcs_[i].first;
-	    continue;
-	  }
-	  ids[i].first = tauIDSrcs_[i].first;
-	  ids[i].second = getTauIdDiscriminator(caloTauCollection, idx, caloTauIdDiscr);
-	} else {
-	  throw cms::Exception("Type Mismatch") <<
-	    "PATTauProducer: unsupported datatype '" << typeid(tausDeref).name() << "' for tauSource\n";
-	}
+          if (skipMissingTauID_ && !caloTauIdDiscr.isValid()) {
+            if (!missingDiscriminators.empty()) {
+              missingDiscriminators += ", ";
+            }
+            missingDiscriminators += tauIDSrcs_[i].first;
+            continue;
+          }
+          ids[i].first = tauIDSrcs_[i].first;
+          ids[i].second = getTauIdDiscriminator(caloTauCollection, idx, caloTauIdDiscr);
+        } else {
+          throw cms::Exception("Type Mismatch")
+              << "PATTauProducer: unsupported datatype '" << typeid(tausDeref).name() << "' for tauSource\n";
+        }
       }
-      if(!missingDiscriminators.empty() && firstOccurence_){
-	edm::LogWarning("DataSource") << "The following tau discriminators have not been found in the event:\n" 
-				      << missingDiscriminators <<"\n"
-				      << "They will not be embedded into the pat::Tau object.\n"
-				      << "Note: this message will be printed only at first occurence.";
-	firstOccurence_=false;
+      if (!missingDiscriminators.empty() && firstOccurence_) {
+        edm::LogWarning("DataSource") << "The following tau discriminators have not been found in the event:\n"
+                                      << missingDiscriminators << "\n"
+                                      << "They will not be embedded into the pat::Tau object.\n"
+                                      << "Note: this message will be printed only at first occurence.";
+        firstOccurence_ = false;
       }
       aTau.setTauIDs(ids);
     }
 
     // extraction of reconstructed tau decay mode
     // (only available for PFTaus)
-    if ( aTau.isPFTau() ) {
+    if (aTau.isPFTau()) {
       edm::Handle<reco::PFTauCollection> pfTaus;
       iEvent.getByToken(pfTauToken_, pfTaus);
       reco::PFTauRef pfTauRef(pfTaus, idx);
@@ -372,7 +409,7 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     }
 
     // extraction of variables needed to rerun MVA isolation and anti-electron discriminator on MiniAOD
-    if( !aTau.pfEssential_.empty() ) {
+    if (!aTau.pfEssential_.empty()) {
       edm::Handle<reco::PFTauCollection> pfTaus;
       iEvent.getByToken(pfTauToken_, pfTaus);
       reco::PFTauRef pfTauRef(pfTaus, idx);
@@ -383,100 +420,102 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       float sumEtaTimesEnergy = 0.;
       float sumEnergy = 0.;
       float leadChargedCandPt = -99;
-      float leadChargedCandEtaAtEcalEntrance = -99;	
+      float leadChargedCandEtaAtEcalEntrance = -99;
       const std::vector<reco::CandidatePtr>& signalCands = pfTauRef->signalCands();
-      for(const auto& it : signalCands) {
-	const reco::PFCandidate* icand = dynamic_cast<const reco::PFCandidate*>(it.get());
-	if (icand != nullptr) {
-	  ecalEnergy += icand->ecalEnergy();
-	  hcalEnergy += icand->hcalEnergy();
-	  sumPhiTimesEnergy += icand->positionAtECALEntrance().phi()*icand->energy();		
-	  sumEtaTimesEnergy += icand->positionAtECALEntrance().eta()*icand->energy();
-	  sumEnergy += icand->energy();	 
-	  const reco::Track* track = nullptr;
-	  if ( icand->trackRef().isNonnull() ) track = icand->trackRef().get();
-	  else if ( icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull()  ) track = icand->muonRef  ()->innerTrack().get();
-	  else if ( icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull() ) track = icand->muonRef  ()->globalTrack().get();
-	  else if ( icand->muonRef().isNonnull() && icand->muonRef()->outerTrack().isNonnull()  ) track = icand->muonRef  ()->outerTrack().get();
-	  else if ( icand->gsfTrackRef().isNonnull() ) track = icand->gsfTrackRef().get();
-	  if( track ) {
-	    if( track->pt() > leadChargedCandPt ) {
-	      leadChargedCandEtaAtEcalEntrance = icand->positionAtECALEntrance().eta();
-	      leadChargedCandPt = track->pt();
-	    }
-	  }
-	}
-	else {
-	  // TauReco@MiniAOD: individual ECAL and HCAL energies currently not available for PackedCandidates 
-	  // (see above implementation for PFCandidates).
-	  // Should be added if available, as well as on-the-fly computation of position at ECAL entrance
-	  sumEnergy += it->energy();
-	  const reco::Track* track = it->bestTrack();
-	  if( track != nullptr ) {
-	    if( track->pt() > leadChargedCandPt ) {
-	      leadChargedCandPt = track->pt();
-	    }
-	  }
-	}
+      for (const auto& it : signalCands) {
+        const reco::PFCandidate* icand = dynamic_cast<const reco::PFCandidate*>(it.get());
+        if (icand != nullptr) {
+          ecalEnergy += icand->ecalEnergy();
+          hcalEnergy += icand->hcalEnergy();
+          sumPhiTimesEnergy += icand->positionAtECALEntrance().phi() * icand->energy();
+          sumEtaTimesEnergy += icand->positionAtECALEntrance().eta() * icand->energy();
+          sumEnergy += icand->energy();
+          const reco::Track* track = nullptr;
+          if (icand->trackRef().isNonnull())
+            track = icand->trackRef().get();
+          else if (icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull())
+            track = icand->muonRef()->innerTrack().get();
+          else if (icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull())
+            track = icand->muonRef()->globalTrack().get();
+          else if (icand->muonRef().isNonnull() && icand->muonRef()->outerTrack().isNonnull())
+            track = icand->muonRef()->outerTrack().get();
+          else if (icand->gsfTrackRef().isNonnull())
+            track = icand->gsfTrackRef().get();
+          if (track) {
+            if (track->pt() > leadChargedCandPt) {
+              leadChargedCandEtaAtEcalEntrance = icand->positionAtECALEntrance().eta();
+              leadChargedCandPt = track->pt();
+            }
+          }
+        } else {
+          // TauReco@MiniAOD: individual ECAL and HCAL energies currently not available for PackedCandidates
+          // (see above implementation for PFCandidates).
+          // Should be added if available, as well as on-the-fly computation of position at ECAL entrance
+          sumEnergy += it->energy();
+          const reco::Track* track = it->bestTrack();
+          if (track != nullptr) {
+            if (track->pt() > leadChargedCandPt) {
+              leadChargedCandPt = track->pt();
+            }
+          }
+        }
       }
       aTauPFEssential.ecalEnergy_ = ecalEnergy;
       aTauPFEssential.hcalEnergy_ = hcalEnergy;
-      aTauPFEssential.ptLeadChargedCand_ = leadChargedCandPt;      
+      aTauPFEssential.ptLeadChargedCand_ = leadChargedCandPt;
       aTauPFEssential.etaAtEcalEntranceLeadChargedCand_ = leadChargedCandEtaAtEcalEntrance;
       if (sumEnergy != 0.) {
-        aTauPFEssential.phiAtEcalEntrance_ = sumPhiTimesEnergy/sumEnergy;
-        aTauPFEssential.etaAtEcalEntrance_ = sumEtaTimesEnergy/sumEnergy;
-      }
-      else {
+        aTauPFEssential.phiAtEcalEntrance_ = sumPhiTimesEnergy / sumEnergy;
+        aTauPFEssential.etaAtEcalEntrance_ = sumEtaTimesEnergy / sumEnergy;
+      } else {
         aTauPFEssential.phiAtEcalEntrance_ = -99.;
         aTauPFEssential.etaAtEcalEntrance_ = -99.;
-      }	
+      }
       float leadingTrackNormChi2 = 0;
       float ecalEnergyLeadChargedHadrCand = -99.;
       float hcalEnergyLeadChargedHadrCand = -99.;
       float emFraction = -1.;
       float myHCALenergy = 0.;
-      float myECALenergy = 0.;	
+      float myECALenergy = 0.;
       const reco::CandidatePtr& leadingPFCharged = pfTauRef->leadChargedHadrCand();
-      if(leadingPFCharged.isNonnull()) { 
-      	const reco::PFCandidate* pfCandPtr = dynamic_cast<const reco::PFCandidate*>(leadingPFCharged.get());
-	if(pfCandPtr != nullptr) { // PFTau made from PFCandidates
-	  ecalEnergyLeadChargedHadrCand = pfCandPtr->ecalEnergy();
-          hcalEnergyLeadChargedHadrCand = pfCandPtr->hcalEnergy(); 
+      if (leadingPFCharged.isNonnull()) {
+        const reco::PFCandidate* pfCandPtr = dynamic_cast<const reco::PFCandidate*>(leadingPFCharged.get());
+        if (pfCandPtr != nullptr) {  // PFTau made from PFCandidates
+          ecalEnergyLeadChargedHadrCand = pfCandPtr->ecalEnergy();
+          hcalEnergyLeadChargedHadrCand = pfCandPtr->hcalEnergy();
           reco::TrackRef trackRef = pfCandPtr->trackRef();
-          if( trackRef.isNonnull() ) {
-            leadingTrackNormChi2 = trackRef->normalizedChi2();			
-	    for(const auto& isoPFCand : pfTauRef->isolationPFCands()){
-	      myHCALenergy += isoPFCand->hcalEnergy();
-	      myECALenergy += isoPFCand->ecalEnergy();
-	    }
-	    for(const auto& signalPFCand : pfTauRef->signalPFCands()){
-	      myHCALenergy += signalPFCand->hcalEnergy();
-	      myECALenergy += signalPFCand->ecalEnergy();
-	    }	  
-	    if( myHCALenergy + myECALenergy != 0. ) {
-              emFraction = myECALenergy/( myHCALenergy + myECALenergy);    
-	    }
+          if (trackRef.isNonnull()) {
+            leadingTrackNormChi2 = trackRef->normalizedChi2();
+            for (const auto& isoPFCand : pfTauRef->isolationPFCands()) {
+              myHCALenergy += isoPFCand->hcalEnergy();
+              myECALenergy += isoPFCand->ecalEnergy();
+            }
+            for (const auto& signalPFCand : pfTauRef->signalPFCands()) {
+              myHCALenergy += signalPFCand->hcalEnergy();
+              myECALenergy += signalPFCand->ecalEnergy();
+            }
+            if (myHCALenergy + myECALenergy != 0.) {
+              emFraction = myECALenergy / (myHCALenergy + myECALenergy);
+            }
+          }
+        } else {
+          const pat::PackedCandidate* packedCandPtr = dynamic_cast<const pat::PackedCandidate*>(leadingPFCharged.get());
+          if (packedCandPtr != nullptr) {
+            // TauReco@MiniAOD: Update code below if ecal/hcal energies are available.
+            const reco::Track* track = packedCandPtr->hasTrackDetails() ? &packedCandPtr->pseudoTrack() : nullptr;
+            if (track != nullptr) {
+              leadingTrackNormChi2 = track->normalizedChi2();
+            }
           }
         }
-        else {
-	  const pat::PackedCandidate* packedCandPtr = dynamic_cast<const pat::PackedCandidate*>(leadingPFCharged.get());
-	  if (packedCandPtr != nullptr) {
-	    // TauReco@MiniAOD: Update code below if ecal/hcal energies are available.
-	    const reco::Track* track = packedCandPtr->hasTrackDetails() ? &packedCandPtr->pseudoTrack() : nullptr;
-	    if (track != nullptr) {
-	      leadingTrackNormChi2 = track->normalizedChi2();
-	    }
-	  }
-	}
       }
 
       aTauPFEssential.emFraction_ = emFraction;
       aTauPFEssential.leadingTrackNormChi2_ = leadingTrackNormChi2;
       aTauPFEssential.ecalEnergyLeadChargedHadrCand_ = ecalEnergyLeadChargedHadrCand;
-      aTauPFEssential.hcalEnergyLeadChargedHadrCand_ = hcalEnergyLeadChargedHadrCand; 	
+      aTauPFEssential.hcalEnergyLeadChargedHadrCand_ = hcalEnergyLeadChargedHadrCand;
       // extraction of tau lifetime information
-      if( !tauTransverseImpactParameterSrc_.label().empty() ) {
+      if (!tauTransverseImpactParameterSrc_.label().empty()) {
         edm::Handle<PFTauTIPAssociationByRef> tauLifetimeInfos;
         iEvent.getByToken(tauTransverseImpactParameterToken_, tauLifetimeInfos);
         const reco::PFTauTransverseImpactParameter& tauLifetimeInfo = *(*tauLifetimeInfos)[pfTauRef];
@@ -497,9 +536,11 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       isolator_.fill(*anyTaus, idx, isolatorTmpStorage_);
       typedef pat::helper::MultiIsolator::IsolationValuePairs IsolationValuePairs;
       // better to loop backwards, so the vector is resized less times
-      for ( IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(),
-	      ed = isolatorTmpStorage_.rend(); it != ed; ++it) {
-	aTau.setIsolation(it->first, it->second);
+      for (IsolationValuePairs::const_reverse_iterator it = isolatorTmpStorage_.rbegin(),
+                                                       ed = isolatorTmpStorage_.rend();
+           it != ed;
+           ++it) {
+        aTau.setIsolation(it->first, it->second);
       }
     }
 
@@ -508,15 +549,15 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     }
 
     if (efficiencyLoader_.enabled()) {
-      efficiencyLoader_.setEfficiencies( aTau, tausRef );
+      efficiencyLoader_.setEfficiencies(aTau, tausRef);
     }
 
     if (resolutionLoader_.enabled()) {
       resolutionLoader_.setResolutions(aTau);
     }
 
-    if ( useUserData_ ) {
-      userDataHelper_.add( aTau, iEvent, iSetup );
+    if (useUserData_) {
+      userDataHelper_.add(aTau, iEvent, iSetup);
     }
 
     patTaus->push_back(aTau);
@@ -529,19 +570,20 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   iEvent.put(std::move(patTaus));
 
   // clean up
-  if (isolator_.enabled()) isolator_.endEvent();
+  if (isolator_.enabled())
+    isolator_.endEvent();
 }
 
 template <typename TauCollectionType, typename TauDiscrType>
-float PATTauProducer::getTauIdDiscriminator(const edm::Handle<TauCollectionType>& tauCollection, size_t tauIdx, const edm::Handle<TauDiscrType>& tauIdDiscr)
-{
+float PATTauProducer::getTauIdDiscriminator(const edm::Handle<TauCollectionType>& tauCollection,
+                                            size_t tauIdx,
+                                            const edm::Handle<TauDiscrType>& tauIdDiscr) {
   edm::Ref<TauCollectionType> tauRef(tauCollection, tauIdx);
   return (*tauIdDiscr)[tauRef];
 }
 
 // ParameterSet description for module
-void PATTauProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void PATTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT tau producer module");
 
@@ -557,15 +599,15 @@ void PATTauProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");
   iDesc.add<bool>("embedGenMatch", false)->setComment("embed MC matched MC information");
   std::vector<edm::InputTag> emptySourceVector;
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
-                 edm::ParameterDescription<std::vector<edm::InputTag> >("genParticleMatch", emptySourceVector, true)
-		 )->setComment("input with MC match information");
+  iDesc
+      .addNode(edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
+               edm::ParameterDescription<std::vector<edm::InputTag>>("genParticleMatch", emptySourceVector, true))
+      ->setComment("input with MC match information");
 
   // MC jet matching variables
   iDesc.add<bool>("addGenJetMatch", true)->setComment("add MC jet matching");
   iDesc.add<bool>("embedGenJetMatch", false)->setComment("embed MC jet matched jet information");
   iDesc.add<edm::InputTag>("genJetMatch", edm::InputTag("tauGenJetMatch"));
-
 
   pat::helper::KinResolutionsLoader::fillDescription(iDesc);
 
@@ -573,11 +615,13 @@ void PATTauProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   iDesc.add<bool>("addTauID", true)->setComment("add tau ID variables");
   edm::ParameterSetDescription tauIDSourcesPSet;
   tauIDSourcesPSet.setAllowAnything();
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("tauIDSource", edm::InputTag(), true) xor
-                 edm::ParameterDescription<edm::ParameterSetDescription>("tauIDSources", tauIDSourcesPSet, true)
-               )->setComment("input with tau ID variables");
+  iDesc
+      .addNode(edm::ParameterDescription<edm::InputTag>("tauIDSource", edm::InputTag(), true) xor
+               edm::ParameterDescription<edm::ParameterSetDescription>("tauIDSources", tauIDSourcesPSet, true))
+      ->setComment("input with tau ID variables");
   // (Dis)allow to skip missing tauId sources
-  iDesc.add<bool>("skipMissingTauID", false)->setComment("allow to skip a tau ID variable when not present in the event");
+  iDesc.add<bool>("skipMissingTauID", false)
+      ->setComment("allow to skip a tau ID variable when not present in the event");
 
   // IsoDeposit configurables
   edm::ParameterSetDescription isoDepositsPSet;
@@ -588,12 +632,12 @@ void PATTauProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   isoDepositsPSet.addOptional<edm::InputTag>("pfChargedHadron");
   isoDepositsPSet.addOptional<edm::InputTag>("pfNeutralHadron");
   isoDepositsPSet.addOptional<edm::InputTag>("pfGamma");
-  isoDepositsPSet.addOptional<std::vector<edm::InputTag> >("user");
+  isoDepositsPSet.addOptional<std::vector<edm::InputTag>>("user");
   iDesc.addOptional("isoDeposits", isoDepositsPSet);
 
   // Efficiency configurables
   edm::ParameterSetDescription efficienciesPSet;
-  efficienciesPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  efficienciesPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("efficiencies", efficienciesPSet);
   iDesc.add<bool>("addEfficiencies", false);
 
@@ -603,13 +647,10 @@ void PATTauProducer::fillDescriptions(edm::ConfigurationDescriptions & descripti
   iDesc.addOptional("userData", userDataPSet);
 
   edm::ParameterSetDescription isolationPSet;
-  isolationPSet.setAllowAnything(); // TODO: the pat helper needs to implement a description.
+  isolationPSet.setAllowAnything();  // TODO: the pat helper needs to implement a description.
   iDesc.add("userIsolation", isolationPSet);
-
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(PATTauProducer);
-
-

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -14,7 +14,6 @@
   \author   Steven Lowette, Christophe Delaere
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,81 +39,81 @@
 
 #include <string>
 
-typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > PFTauTIPAssociationByRef;
+typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> >
+    PFTauTIPAssociationByRef;
 namespace pat {
 
   class PATTauProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATTauProducer(const edm::ParameterSet& iConfig);
+    ~PATTauProducer() override;
 
-    public:
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATTauProducer(const edm::ParameterSet & iConfig);
-      ~PATTauProducer() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+  private:
+    bool firstOccurence_;  // used to print LogWarnings only at first occurnece in the event loop
 
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+    // configurables
+    edm::EDGetTokenT<edm::View<reco::BaseTau> > baseTauToken_;
+    edm::EDGetTokenT<PFTauTIPAssociationByRef> tauTransverseImpactParameterToken_;
+    edm::EDGetTokenT<reco::PFTauCollection> pfTauToken_;
+    edm::EDGetTokenT<reco::CaloTauCollection> caloTauToken_;
+    edm::InputTag tauTransverseImpactParameterSrc_;
+    bool embedIsolationTracks_;
+    bool embedLeadTrack_;
+    bool embedSignalTracks_;
+    bool embedLeadPFCand_;
+    bool embedLeadPFChargedHadrCand_;
+    bool embedLeadPFNeutralCand_;
+    bool embedSignalPFCands_;
+    bool embedSignalPFChargedHadrCands_;
+    bool embedSignalPFNeutralHadrCands_;
+    bool embedSignalPFGammaCands_;
+    bool embedIsolationPFCands_;
+    bool embedIsolationPFChargedHadrCands_;
+    bool embedIsolationPFNeutralHadrCands_;
+    bool embedIsolationPFGammaCands_;
 
-    private:
-      bool firstOccurence_; // used to print LogWarnings only at first occurnece in the event loop
+    bool addGenMatch_;
+    bool embedGenMatch_;
+    std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
-      // configurables
-      edm::EDGetTokenT<edm::View<reco::BaseTau> > baseTauToken_;
-      edm::EDGetTokenT<PFTauTIPAssociationByRef> tauTransverseImpactParameterToken_;
-      edm::EDGetTokenT<reco::PFTauCollection> pfTauToken_;
-      edm::EDGetTokenT<reco::CaloTauCollection> caloTauToken_;
-      edm::InputTag tauTransverseImpactParameterSrc_;
-      bool embedIsolationTracks_;
-      bool embedLeadTrack_;
-      bool embedSignalTracks_;
-      bool embedLeadPFCand_;
-      bool embedLeadPFChargedHadrCand_;
-      bool embedLeadPFNeutralCand_;
-      bool embedSignalPFCands_;
-      bool embedSignalPFChargedHadrCands_;
-      bool embedSignalPFNeutralHadrCands_;
-      bool embedSignalPFGammaCands_;
-      bool embedIsolationPFCands_;
-      bool embedIsolationPFChargedHadrCands_;
-      bool embedIsolationPFNeutralHadrCands_;
-      bool embedIsolationPFGammaCands_;
+    bool addGenJetMatch_;
+    bool embedGenJetMatch_;
+    edm::EDGetTokenT<edm::Association<reco::GenJetCollection> > genJetMatchToken_;
 
-      bool          addGenMatch_;
-      bool          embedGenMatch_;
-      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
+    bool addTauJetCorrFactors_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<TauJetCorrFactors> > > tauJetCorrFactorsTokens_;
 
-      bool          addGenJetMatch_;
-      bool          embedGenJetMatch_;
-      edm::EDGetTokenT<edm::Association<reco::GenJetCollection> > genJetMatchToken_;
+    bool addTauID_;
+    typedef std::pair<std::string, edm::InputTag> NameTag;
+    std::vector<NameTag> tauIDSrcs_;
+    std::vector<edm::EDGetTokenT<reco::CaloTauDiscriminator> > caloTauIDTokens_;
+    std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > pfTauIDTokens_;
+    bool skipMissingTauID_;
+    // tools
+    GreaterByPt<Tau> pTTauComparator_;
 
-      bool          addTauJetCorrFactors_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<TauJetCorrFactors> > > tauJetCorrFactorsTokens_;
+    pat::helper::MultiIsolator isolator_;
+    pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_;  // better here than recreate at each event
+    std::vector<std::pair<pat::IsolationKeys, edm::InputTag> > isoDepositLabels_;
+    std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
 
-      bool          addTauID_;
-      typedef std::pair<std::string, edm::InputTag> NameTag;
-      std::vector<NameTag> tauIDSrcs_;
-      std::vector<edm::EDGetTokenT<reco::CaloTauDiscriminator> > caloTauIDTokens_;
-      std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > pfTauIDTokens_;
-      bool          skipMissingTauID_;
-      // tools
-      GreaterByPt<Tau>       pTTauComparator_;
+    bool addEfficiencies_;
+    pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      pat::helper::MultiIsolator isolator_;
-      pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
-      std::vector<std::pair<pat::IsolationKeys,edm::InputTag> > isoDepositLabels_;
-      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
+    bool addResolutions_;
+    pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      bool addEfficiencies_;
-      pat::helper::EfficiencyLoader efficiencyLoader_;
+    bool useUserData_;
+    pat::PATUserDataHelper<pat::Tau> userDataHelper_;
 
-      bool addResolutions_;
-      pat::helper::KinResolutionsLoader resolutionLoader_;
-
-      bool useUserData_;
-      pat::PATUserDataHelper<pat::Tau>      userDataHelper_;
-
-      template <typename TauCollectionType, typename TauDiscrType> float getTauIdDiscriminator(const edm::Handle<TauCollectionType>&, size_t, const edm::Handle<TauDiscrType>&);
+    template <typename TauCollectionType, typename TauDiscrType>
+    float getTauIdDiscriminator(const edm::Handle<TauCollectionType>&, size_t, const edm::Handle<TauDiscrType>&);
   };
 
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauSlimmer.cc
@@ -3,7 +3,6 @@
   \brief    Slimmer of PAT Taus 
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -16,123 +15,128 @@
 #include "PhysicsTools/PatAlgos/interface/ObjectModifier.h"
 
 namespace pat {
-  
+
   class PATTauSlimmer : public edm::stream::EDProducer<> {
   public:
-    explicit PATTauSlimmer(const edm::ParameterSet & iConfig);
-    ~PATTauSlimmer() override { }
-    
-    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) final;
-    
+    explicit PATTauSlimmer(const edm::ParameterSet &iConfig);
+    ~PATTauSlimmer() override {}
+
+    void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) final;
+
   private:
-    const edm::EDGetTokenT<edm::View<pat::Tau> > src_;
+    const edm::EDGetTokenT<edm::View<pat::Tau>> src_;
     const bool linkToPackedPF_;
-    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2pc_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
     const bool dropPiZeroRefs_;
     const bool dropTauChargedHadronRefs_;
     const bool dropPFSpecific_;
     const bool modifyTau_;
-    std::unique_ptr<pat::ObjectModifier<pat::Tau> > tauModifier_;    
+    std::unique_ptr<pat::ObjectModifier<pat::Tau>> tauModifier_;
   };
 
-} // namespace
+}  // namespace pat
 
-pat::PATTauSlimmer::PATTauSlimmer(const edm::ParameterSet & iConfig) :
-    src_(consumes<edm::View<pat::Tau> >(iConfig.getParameter<edm::InputTag>("src"))),
-    linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
-    pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-    dropPiZeroRefs_(iConfig.exists("dropPiZeroRefs") ? iConfig.getParameter<bool>("dropPiZeroRefs") : true ),
-    dropTauChargedHadronRefs_(iConfig.exists("dropTauChargedHadronRefs") ? iConfig.getParameter<bool>("dropTauChargedHadronRefs") : true),
-    dropPFSpecific_(iConfig.exists("dropPFSpecific") ? iConfig.getParameter<bool>("dropPFSpecific") : true),
-    modifyTau_(iConfig.getParameter<bool>("modifyTaus"))
-{
-    if( modifyTau_ ) {
-      const edm::ParameterSet& mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
-      tauModifier_ = std::make_unique<pat::ObjectModifier<pat::Tau>>(mod_config, consumesCollector());
-    }
-    produces<std::vector<pat::Tau> >();
+pat::PATTauSlimmer::PATTauSlimmer(const edm::ParameterSet &iConfig)
+    : src_(consumes<edm::View<pat::Tau>>(iConfig.getParameter<edm::InputTag>("src"))),
+      linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
+      pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(
+          iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+      dropPiZeroRefs_(iConfig.exists("dropPiZeroRefs") ? iConfig.getParameter<bool>("dropPiZeroRefs") : true),
+      dropTauChargedHadronRefs_(
+          iConfig.exists("dropTauChargedHadronRefs") ? iConfig.getParameter<bool>("dropTauChargedHadronRefs") : true),
+      dropPFSpecific_(iConfig.exists("dropPFSpecific") ? iConfig.getParameter<bool>("dropPFSpecific") : true),
+      modifyTau_(iConfig.getParameter<bool>("modifyTaus")) {
+  if (modifyTau_) {
+    const edm::ParameterSet &mod_config = iConfig.getParameter<edm::ParameterSet>("modifierConfig");
+    tauModifier_ = std::make_unique<pat::ObjectModifier<pat::Tau>>(mod_config, consumesCollector());
+  }
+  produces<std::vector<pat::Tau>>();
 }
 
-void 
-pat::PATTauSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup& iSetup) {
-  if( modifyTau_ ) tauModifier_->setEventContent(iSetup);
+void pat::PATTauSlimmer::beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &iSetup) {
+  if (modifyTau_)
+    tauModifier_->setEventContent(iSetup);
 }
 
-void 
-pat::PATTauSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    using namespace edm;
-    using namespace std;
+void pat::PATTauSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    Handle<View<pat::Tau> >      src;
-    iEvent.getByToken(src_, src);
+  Handle<View<pat::Tau>> src;
+  iEvent.getByToken(src_, src);
 
-    Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
-    if (linkToPackedPF_) iEvent.getByToken(pf2pc_, pf2pc);
+  Handle<edm::Association<pat::PackedCandidateCollection>> pf2pc;
+  if (linkToPackedPF_)
+    iEvent.getByToken(pf2pc_, pf2pc);
 
-    auto out = std::make_unique<std::vector<pat::Tau>>();
-    out->reserve(src->size());
+  auto out = std::make_unique<std::vector<pat::Tau>>();
+  out->reserve(src->size());
 
-    if( modifyTau_ ) { tauModifier_->setEvent(iEvent); }
+  if (modifyTau_) {
+    tauModifier_->setEvent(iEvent);
+  }
 
-    for (View<pat::Tau>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        out->push_back(*it);
-	pat::Tau & tau = out->back();
+  for (View<pat::Tau>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
+    out->push_back(*it);
+    pat::Tau &tau = out->back();
 
-        if( modifyTau_ ) { tauModifier_->modify(tau); }
-
-	// clearing the pat isolation which is not used by taus
-	tau.isolations_.clear();
-	tau.isoDeposits_.clear();
-	
-        if (linkToPackedPF_) {
-
-            reco::CandidatePtrVector signalChHPtrs, signalNHPtrs, signalGammaPtrs, isolationChHPtrs, isolationNHPtrs, isolationGammaPtrs;
-
-	    for (const reco::PFCandidatePtr &p : tau.signalPFChargedHadrCands()) {
-	      signalChHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
-            }
-            tau.setSignalChargedHadrCands(signalChHPtrs);
-
-	    for (const reco::PFCandidatePtr &p : tau.signalPFNeutrHadrCands()) {
-              signalNHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
-            }
-            tau.setSignalNeutralHadrCands(signalNHPtrs);
-
-	    for (const reco::PFCandidatePtr &p : tau.signalPFGammaCands()) {
-              signalGammaPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
-            }
-            tau.setSignalGammaCands(signalGammaPtrs);
-
-	    for (const reco::PFCandidatePtr &p : tau.isolationPFChargedHadrCands()) {
-              isolationChHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
-            }
-            tau.setIsolationChargedHadrCands(isolationChHPtrs);
-
-            for (const reco::PFCandidatePtr &p : tau.isolationPFNeutrHadrCands()) {
-              isolationNHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
-            }
-            tau.setIsolationNeutralHadrCands(isolationNHPtrs);
-
-            for (const reco::PFCandidatePtr &p : tau.isolationPFGammaCands()) {
-              isolationGammaPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
-            }
-            tau.setIsolationGammaCands(isolationGammaPtrs);
-
-        }
-     if(dropPiZeroRefs_){ 
-         tau.pfSpecific_[0].signalPiZeroCandidates_.clear();
-         tau.pfSpecific_[0].isolationPiZeroCandidates_.clear();
-       }
-     if(dropTauChargedHadronRefs_){ 
-          tau.pfSpecific_[0].signalTauChargedHadronCandidates_.clear();
-          tau.pfSpecific_[0].isolationTauChargedHadronCandidates_.clear();
-        }
-     if(dropPFSpecific_){ tau.pfSpecific_.clear();}
-
+    if (modifyTau_) {
+      tauModifier_->modify(tau);
     }
 
-    iEvent.put(std::move(out));
+    // clearing the pat isolation which is not used by taus
+    tau.isolations_.clear();
+    tau.isoDeposits_.clear();
+
+    if (linkToPackedPF_) {
+      reco::CandidatePtrVector signalChHPtrs, signalNHPtrs, signalGammaPtrs, isolationChHPtrs, isolationNHPtrs,
+          isolationGammaPtrs;
+
+      for (const reco::PFCandidatePtr &p : tau.signalPFChargedHadrCands()) {
+        signalChHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
+      }
+      tau.setSignalChargedHadrCands(signalChHPtrs);
+
+      for (const reco::PFCandidatePtr &p : tau.signalPFNeutrHadrCands()) {
+        signalNHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
+      }
+      tau.setSignalNeutralHadrCands(signalNHPtrs);
+
+      for (const reco::PFCandidatePtr &p : tau.signalPFGammaCands()) {
+        signalGammaPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
+      }
+      tau.setSignalGammaCands(signalGammaPtrs);
+
+      for (const reco::PFCandidatePtr &p : tau.isolationPFChargedHadrCands()) {
+        isolationChHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
+      }
+      tau.setIsolationChargedHadrCands(isolationChHPtrs);
+
+      for (const reco::PFCandidatePtr &p : tau.isolationPFNeutrHadrCands()) {
+        isolationNHPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
+      }
+      tau.setIsolationNeutralHadrCands(isolationNHPtrs);
+
+      for (const reco::PFCandidatePtr &p : tau.isolationPFGammaCands()) {
+        isolationGammaPtrs.push_back(edm::refToPtr((*pf2pc)[p]));
+      }
+      tau.setIsolationGammaCands(isolationGammaPtrs);
+    }
+    if (dropPiZeroRefs_) {
+      tau.pfSpecific_[0].signalPiZeroCandidates_.clear();
+      tau.pfSpecific_[0].isolationPiZeroCandidates_.clear();
+    }
+    if (dropTauChargedHadronRefs_) {
+      tau.pfSpecific_[0].signalTauChargedHadronCandidates_.clear();
+      tau.pfSpecific_[0].isolationTauChargedHadronCandidates_.clear();
+    }
+    if (dropPFSpecific_) {
+      tau.pfSpecific_.clear();
+    }
+  }
+
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -1,7 +1,6 @@
 //
 //
 
-
 #include "PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h"
 
 #include <cassert>
@@ -21,292 +20,311 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 using namespace pat;
 using namespace edm;
 
-
-PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig ) :
-  nameProcess_( iConfig.getParameter< std::string >( "processName" ) ),
-  autoProcessName_( nameProcess_ == "*" ),
-  tagTriggerProducer_( "patTrigger" ),
-  tagsTriggerMatcher_(),
-  // L1 configuration parameters
-  tagL1Gt_(),
-  // HLTConfigProvider
-  hltConfigInit_( false ),
-  // HLT configuration parameters
-  tagTriggerResults_( "TriggerResults" ),
-  tagTriggerEvent_( "hltTriggerSummaryAOD" ),
-  // Conditions configuration parameters
-  tagCondGt_(),
-  // Conditions
-  condRun_(),
-  condLumi_(),
-  gtCondRunInit_( false ),
-  gtCondLumiInit_( false )
-{
-
-  if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
-  triggerResultsGetter_ = GetterOfProducts< TriggerResults >( InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance(), autoProcessName_ ? std::string(""): nameProcess_ ) ), this);
-  if ( iConfig.exists( "triggerEvent" ) )       tagTriggerEvent_    = iConfig.getParameter< InputTag >( "triggerEvent" );
-  if ( iConfig.exists( "patTriggerProducer" ) ) tagTriggerProducer_ = iConfig.getParameter< InputTag >( "patTriggerProducer" );
-  triggerAlgorithmCollectionToken_ = mayConsume< TriggerAlgorithmCollection >( tagTriggerProducer_ );
-  triggerConditionCollectionToken_ = mayConsume< TriggerConditionCollection >( tagTriggerProducer_ );
-  triggerPathCollectionToken_      = mayConsume< TriggerPathCollection >( tagTriggerProducer_ );
-  triggerFilterCollectionToken_    = mayConsume< TriggerFilterCollection >( tagTriggerProducer_ );
-  triggerObjectCollectionToken_    = mayConsume< TriggerObjectCollection >( tagTriggerProducer_ );
-  if ( iConfig.exists( "condGtTag" ) ) {
-    tagCondGt_           = iConfig.getParameter< InputTag >( "condGtTag" );
-    tagCondGtRunToken_   = mayConsume< ConditionsInRunBlock, InRun >( tagCondGt_ );
-    tagCondGtLumiToken_  = mayConsume< ConditionsInLumiBlock, InLumi >( tagCondGt_ );
-    tagCondGtEventToken_ = mayConsume< ConditionsInEventBlock >( tagCondGt_ );
+PATTriggerEventProducer::PATTriggerEventProducer(const ParameterSet& iConfig)
+    : nameProcess_(iConfig.getParameter<std::string>("processName")),
+      autoProcessName_(nameProcess_ == "*"),
+      tagTriggerProducer_("patTrigger"),
+      tagsTriggerMatcher_(),
+      // L1 configuration parameters
+      tagL1Gt_(),
+      // HLTConfigProvider
+      hltConfigInit_(false),
+      // HLT configuration parameters
+      tagTriggerResults_("TriggerResults"),
+      tagTriggerEvent_("hltTriggerSummaryAOD"),
+      // Conditions configuration parameters
+      tagCondGt_(),
+      // Conditions
+      condRun_(),
+      condLumi_(),
+      gtCondRunInit_(false),
+      gtCondLumiInit_(false) {
+  if (iConfig.exists("triggerResults"))
+    tagTriggerResults_ = iConfig.getParameter<InputTag>("triggerResults");
+  triggerResultsGetter_ =
+      GetterOfProducts<TriggerResults>(InputTagMatch(InputTag(tagTriggerResults_.label(),
+                                                              tagTriggerResults_.instance(),
+                                                              autoProcessName_ ? std::string("") : nameProcess_)),
+                                       this);
+  if (iConfig.exists("triggerEvent"))
+    tagTriggerEvent_ = iConfig.getParameter<InputTag>("triggerEvent");
+  if (iConfig.exists("patTriggerProducer"))
+    tagTriggerProducer_ = iConfig.getParameter<InputTag>("patTriggerProducer");
+  triggerAlgorithmCollectionToken_ = mayConsume<TriggerAlgorithmCollection>(tagTriggerProducer_);
+  triggerConditionCollectionToken_ = mayConsume<TriggerConditionCollection>(tagTriggerProducer_);
+  triggerPathCollectionToken_ = mayConsume<TriggerPathCollection>(tagTriggerProducer_);
+  triggerFilterCollectionToken_ = mayConsume<TriggerFilterCollection>(tagTriggerProducer_);
+  triggerObjectCollectionToken_ = mayConsume<TriggerObjectCollection>(tagTriggerProducer_);
+  if (iConfig.exists("condGtTag")) {
+    tagCondGt_ = iConfig.getParameter<InputTag>("condGtTag");
+    tagCondGtRunToken_ = mayConsume<ConditionsInRunBlock, InRun>(tagCondGt_);
+    tagCondGtLumiToken_ = mayConsume<ConditionsInLumiBlock, InLumi>(tagCondGt_);
+    tagCondGtEventToken_ = mayConsume<ConditionsInEventBlock>(tagCondGt_);
   }
-  if ( iConfig.exists( "l1GtTag" ) ) tagL1Gt_ = iConfig.getParameter< InputTag >( "l1GtTag" );
-  l1GtToken_ = mayConsume< L1GlobalTriggerReadoutRecord >( tagL1Gt_ );
-  if ( iConfig.exists( "patTriggerMatches" ) ) tagsTriggerMatcher_ = iConfig.getParameter< std::vector< InputTag > >( "patTriggerMatches" );
-  triggerMatcherTokens_ = vector_transform( tagsTriggerMatcher_, [this](InputTag const & tag) { return mayConsume< TriggerObjectStandAloneMatch >( tag ); } );
+  if (iConfig.exists("l1GtTag"))
+    tagL1Gt_ = iConfig.getParameter<InputTag>("l1GtTag");
+  l1GtToken_ = mayConsume<L1GlobalTriggerReadoutRecord>(tagL1Gt_);
+  if (iConfig.exists("patTriggerMatches"))
+    tagsTriggerMatcher_ = iConfig.getParameter<std::vector<InputTag> >("patTriggerMatches");
+  triggerMatcherTokens_ = vector_transform(
+      tagsTriggerMatcher_, [this](InputTag const& tag) { return mayConsume<TriggerObjectStandAloneMatch>(tag); });
 
-  callWhenNewProductsRegistered( [ this ]( BranchDescription const& bd ) {
-    if(not ( this->autoProcessName_ and bd.processName()==this->moduleDescription().processName()) ) {
-      triggerResultsGetter_( bd );
+  callWhenNewProductsRegistered([this](BranchDescription const& bd) {
+    if (not(this->autoProcessName_ and bd.processName() == this->moduleDescription().processName())) {
+      triggerResultsGetter_(bd);
     }
-  } );
+  });
 
-  for ( size_t iMatch = 0; iMatch < tagsTriggerMatcher_.size(); ++iMatch ) {
-    produces< TriggerObjectMatch >( tagsTriggerMatcher_.at( iMatch ).label() );
+  for (size_t iMatch = 0; iMatch < tagsTriggerMatcher_.size(); ++iMatch) {
+    produces<TriggerObjectMatch>(tagsTriggerMatcher_.at(iMatch).label());
   }
-  produces< TriggerEvent >();
-
+  produces<TriggerEvent>();
 }
 
-
-void PATTriggerEventProducer::beginRun(const Run & iRun, const EventSetup & iSetup )
-{
-
+void PATTriggerEventProducer::beginRun(const Run& iRun, const EventSetup& iSetup) {
   // Initialize process name
-  if ( autoProcessName_ ) {
+  if (autoProcessName_) {
     // reset
     nameProcess_ = "*";
     // determine process name from last run TriggerSummaryProducerAOD module in process history of input
-    const ProcessHistory & processHistory( iRun.processHistory() );
+    const ProcessHistory& processHistory(iRun.processHistory());
     ProcessConfiguration processConfiguration;
     ParameterSet processPSet;
     // unbroken loop, which relies on time ordering (accepts the last found entry)
-    for ( ProcessHistory::const_iterator iHist = processHistory.begin(); iHist != processHistory.end(); ++iHist ) {
-      if ( processHistory.getConfigurationForProcess( iHist->processName(), processConfiguration )     &&
-           pset::Registry::instance()->getMapped( processConfiguration.parameterSetID(), processPSet ) &&
-           processPSet.exists( tagTriggerEvent_.label() )
-         ) {
+    for (ProcessHistory::const_iterator iHist = processHistory.begin(); iHist != processHistory.end(); ++iHist) {
+      if (processHistory.getConfigurationForProcess(iHist->processName(), processConfiguration) &&
+          pset::Registry::instance()->getMapped(processConfiguration.parameterSetID(), processPSet) &&
+          processPSet.exists(tagTriggerEvent_.label())) {
         nameProcess_ = iHist->processName();
-        LogDebug( "autoProcessName" ) << "HLT process name '" << nameProcess_ << "' discovered";
+        LogDebug("autoProcessName") << "HLT process name '" << nameProcess_ << "' discovered";
       }
     }
     // terminate, if nothing is found
-    if ( nameProcess_ == "*" ) {
-      LogError( "autoProcessName" ) << "trigger::TriggerEvent product with label '" << tagTriggerEvent_.label() << "' not produced according to process history of input data\n"
-                                    << "No trigger information produced.";
+    if (nameProcess_ == "*") {
+      LogError("autoProcessName") << "trigger::TriggerEvent product with label '" << tagTriggerEvent_.label()
+                                  << "' not produced according to process history of input data\n"
+                                  << "No trigger information produced.";
       return;
     }
-    LogInfo( "autoProcessName" ) << "HLT process name " << nameProcess_ << " used for PAT trigger information";
+    LogInfo("autoProcessName") << "HLT process name " << nameProcess_ << " used for PAT trigger information";
   }
   // adapt configuration of used input tags
-  if ( tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*" ) {
-    tagTriggerResults_ = InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_ );
-  } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
-    LogWarning( "triggerResultsTag" ) << "TriggerResults process name '" << tagTriggerResults_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
+  if (tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*") {
+    tagTriggerResults_ = InputTag(tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_);
+  } else if (tagTriggerEvent_.process() != nameProcess_) {
+    LogWarning("triggerResultsTag") << "TriggerResults process name '" << tagTriggerResults_.process()
+                                    << "' differs from HLT process name '" << nameProcess_ << "'";
   }
-  if ( tagTriggerEvent_.process().empty() || tagTriggerEvent_.process()   == "*" ) {
-    tagTriggerEvent_ = InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_ );
-  } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
-    LogWarning( "triggerEventTag" ) << "TriggerEvent process name '" << tagTriggerEvent_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
+  if (tagTriggerEvent_.process().empty() || tagTriggerEvent_.process() == "*") {
+    tagTriggerEvent_ = InputTag(tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_);
+  } else if (tagTriggerEvent_.process() != nameProcess_) {
+    LogWarning("triggerEventTag") << "TriggerEvent process name '" << tagTriggerEvent_.process()
+                                  << "' differs from HLT process name '" << nameProcess_ << "'";
   }
 
   gtCondRunInit_ = false;
-  if ( ! tagCondGt_.label().empty() ) {
-    Handle< ConditionsInRunBlock > condRunBlock;
-    iRun.getByToken( tagCondGtRunToken_, condRunBlock );
-    if ( condRunBlock.isValid() ) {
-      condRun_       = *condRunBlock;
+  if (!tagCondGt_.label().empty()) {
+    Handle<ConditionsInRunBlock> condRunBlock;
+    iRun.getByToken(tagCondGtRunToken_, condRunBlock);
+    if (condRunBlock.isValid()) {
+      condRun_ = *condRunBlock;
       gtCondRunInit_ = true;
     } else {
-      LogError( "conditionsInEdm" ) << "ConditionsInRunBlock product with InputTag '" << tagCondGt_.encode() << "' not in run";
+      LogError("conditionsInEdm") << "ConditionsInRunBlock product with InputTag '" << tagCondGt_.encode()
+                                  << "' not in run";
     }
   }
 
   // Initialize HLTConfigProvider
   hltConfigInit_ = false;
-  bool changed( true );
-  if ( ! hltConfig_.init( iRun, iSetup, nameProcess_, changed ) ) {
-    LogError( "hltConfigExtraction" ) << "HLT config extraction error with process name '" << nameProcess_ << "'";
-  } else if ( hltConfig_.size() <= 0 ) {
-    LogError( "hltConfigSize" ) << "HLT config size error";
-  } else hltConfigInit_ = true;
-
+  bool changed(true);
+  if (!hltConfig_.init(iRun, iSetup, nameProcess_, changed)) {
+    LogError("hltConfigExtraction") << "HLT config extraction error with process name '" << nameProcess_ << "'";
+  } else if (hltConfig_.size() <= 0) {
+    LogError("hltConfigSize") << "HLT config size error";
+  } else
+    hltConfigInit_ = true;
 }
 
-void PATTriggerEventProducer::beginLuminosityBlock(const LuminosityBlock & iLuminosityBlock, const EventSetup & iSetup )
-{
-
+void PATTriggerEventProducer::beginLuminosityBlock(const LuminosityBlock& iLuminosityBlock, const EventSetup& iSetup) {
   // Terminate, if auto process name determination failed
-  if ( nameProcess_ == "*" ) return;
+  if (nameProcess_ == "*")
+    return;
 
   gtCondLumiInit_ = false;
-  if ( ! tagCondGt_.label().empty() ) {
-    Handle< ConditionsInLumiBlock > condLumiBlock;
-    iLuminosityBlock.getByToken( tagCondGtLumiToken_, condLumiBlock );
-    if ( condLumiBlock.isValid() ) {
-      condLumi_       = *condLumiBlock;
+  if (!tagCondGt_.label().empty()) {
+    Handle<ConditionsInLumiBlock> condLumiBlock;
+    iLuminosityBlock.getByToken(tagCondGtLumiToken_, condLumiBlock);
+    if (condLumiBlock.isValid()) {
+      condLumi_ = *condLumiBlock;
       gtCondLumiInit_ = true;
     } else {
-      LogError( "conditionsInEdm" ) << "ConditionsInLumiBlock product with InputTag '" << tagCondGt_.encode() << "' not in lumi";
+      LogError("conditionsInEdm") << "ConditionsInLumiBlock product with InputTag '" << tagCondGt_.encode()
+                                  << "' not in lumi";
     }
   }
-
 }
 
-
-void PATTriggerEventProducer::produce( Event& iEvent, const EventSetup& iSetup )
-{
-
+void PATTriggerEventProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   // Terminate, if auto process name determination failed
-  if ( nameProcess_ == "*" ) return;
+  if (nameProcess_ == "*")
+    return;
 
-  if ( ! hltConfigInit_ ) return;
+  if (!hltConfigInit_)
+    return;
 
-  ESHandle< L1GtTriggerMenu > handleL1GtTriggerMenu;
-  iSetup.get< L1GtTriggerMenuRcd >().get( handleL1GtTriggerMenu );
-  Handle< TriggerResults > handleTriggerResults;
-  iEvent.getByLabel( tagTriggerResults_, handleTriggerResults );
-//   iEvent.getByToken( triggerResultsToken_, handleTriggerResults );
-  if ( ! handleTriggerResults.isValid() ) {
-    LogError( "triggerResultsValid" ) << "TriggerResults product with InputTag '" << tagTriggerResults_.encode() << "' not in event\n"
-                                      << "No trigger information produced";
+  ESHandle<L1GtTriggerMenu> handleL1GtTriggerMenu;
+  iSetup.get<L1GtTriggerMenuRcd>().get(handleL1GtTriggerMenu);
+  Handle<TriggerResults> handleTriggerResults;
+  iEvent.getByLabel(tagTriggerResults_, handleTriggerResults);
+  //   iEvent.getByToken( triggerResultsToken_, handleTriggerResults );
+  if (!handleTriggerResults.isValid()) {
+    LogError("triggerResultsValid") << "TriggerResults product with InputTag '" << tagTriggerResults_.encode()
+                                    << "' not in event\n"
+                                    << "No trigger information produced";
     return;
   }
-  Handle< TriggerAlgorithmCollection > handleTriggerAlgorithms;
-  iEvent.getByToken( triggerAlgorithmCollectionToken_, handleTriggerAlgorithms );
-  Handle< TriggerConditionCollection > handleTriggerConditions;
-  iEvent.getByToken( triggerConditionCollectionToken_, handleTriggerConditions );
-  Handle< TriggerPathCollection > handleTriggerPaths;
-  iEvent.getByToken( triggerPathCollectionToken_, handleTriggerPaths );
-  Handle< TriggerFilterCollection > handleTriggerFilters;
-  iEvent.getByToken( triggerFilterCollectionToken_, handleTriggerFilters );
-  Handle< TriggerObjectCollection > handleTriggerObjects;
-  iEvent.getByToken( triggerObjectCollectionToken_, handleTriggerObjects );
+  Handle<TriggerAlgorithmCollection> handleTriggerAlgorithms;
+  iEvent.getByToken(triggerAlgorithmCollectionToken_, handleTriggerAlgorithms);
+  Handle<TriggerConditionCollection> handleTriggerConditions;
+  iEvent.getByToken(triggerConditionCollectionToken_, handleTriggerConditions);
+  Handle<TriggerPathCollection> handleTriggerPaths;
+  iEvent.getByToken(triggerPathCollectionToken_, handleTriggerPaths);
+  Handle<TriggerFilterCollection> handleTriggerFilters;
+  iEvent.getByToken(triggerFilterCollectionToken_, handleTriggerFilters);
+  Handle<TriggerObjectCollection> handleTriggerObjects;
+  iEvent.getByToken(triggerObjectCollectionToken_, handleTriggerObjects);
 
-  bool physDecl( false );
-  if ( iEvent.isRealData() && ! tagL1Gt_.label().empty() ) {
-    Handle< L1GlobalTriggerReadoutRecord > handleL1GlobalTriggerReadoutRecord;
-    iEvent.getByToken( l1GtToken_, handleL1GlobalTriggerReadoutRecord );
-    if ( handleL1GlobalTriggerReadoutRecord.isValid() ) {
+  bool physDecl(false);
+  if (iEvent.isRealData() && !tagL1Gt_.label().empty()) {
+    Handle<L1GlobalTriggerReadoutRecord> handleL1GlobalTriggerReadoutRecord;
+    iEvent.getByToken(l1GtToken_, handleL1GlobalTriggerReadoutRecord);
+    if (handleL1GlobalTriggerReadoutRecord.isValid()) {
       L1GtFdlWord fdlWord = handleL1GlobalTriggerReadoutRecord->gtFdlWord();
-      if ( fdlWord.physicsDeclared() == 1 ) {
+      if (fdlWord.physicsDeclared() == 1) {
         physDecl = true;
       }
     } else {
-      LogError( "l1GlobalTriggerReadoutRecordValid" ) << "L1GlobalTriggerReadoutRecord product with InputTag '" << tagL1Gt_.encode() << "' not in event";
+      LogError("l1GlobalTriggerReadoutRecordValid")
+          << "L1GlobalTriggerReadoutRecord product with InputTag '" << tagL1Gt_.encode() << "' not in event";
     }
   } else {
     physDecl = true;
   }
 
-
   // produce trigger event
 
-  auto triggerEvent = std::make_unique<TriggerEvent>( handleL1GtTriggerMenu->gtTriggerMenuName(), std::string( hltConfig_.tableName() ), handleTriggerResults->wasrun(), handleTriggerResults->accept(), handleTriggerResults->error(), physDecl );
+  auto triggerEvent = std::make_unique<TriggerEvent>(handleL1GtTriggerMenu->gtTriggerMenuName(),
+                                                     std::string(hltConfig_.tableName()),
+                                                     handleTriggerResults->wasrun(),
+                                                     handleTriggerResults->accept(),
+                                                     handleTriggerResults->error(),
+                                                     physDecl);
   // set product references to trigger collections
-  if ( handleTriggerAlgorithms.isValid() ) {
-    triggerEvent->setAlgorithms( handleTriggerAlgorithms );
+  if (handleTriggerAlgorithms.isValid()) {
+    triggerEvent->setAlgorithms(handleTriggerAlgorithms);
   } else {
-    LogError( "triggerAlgorithmsValid" ) << "pat::TriggerAlgorithmCollection product with InputTag '" << tagTriggerProducer_.encode() << "' not in event";
+    LogError("triggerAlgorithmsValid") << "pat::TriggerAlgorithmCollection product with InputTag '"
+                                       << tagTriggerProducer_.encode() << "' not in event";
   }
-  if ( handleTriggerConditions.isValid() ) {
-    triggerEvent->setConditions( handleTriggerConditions );
+  if (handleTriggerConditions.isValid()) {
+    triggerEvent->setConditions(handleTriggerConditions);
   } else {
-    LogError( "triggerConditionsValid" ) << "pat::TriggerConditionCollection product with InputTag '" << tagTriggerProducer_.encode() << "' not in event";
+    LogError("triggerConditionsValid") << "pat::TriggerConditionCollection product with InputTag '"
+                                       << tagTriggerProducer_.encode() << "' not in event";
   }
-  if ( handleTriggerPaths.isValid() ) {
-    triggerEvent->setPaths( handleTriggerPaths );
+  if (handleTriggerPaths.isValid()) {
+    triggerEvent->setPaths(handleTriggerPaths);
   } else {
-    LogError( "triggerPathsValid" ) << "pat::TriggerPathCollection product with InputTag '" << tagTriggerProducer_.encode() << "' not in event";
+    LogError("triggerPathsValid") << "pat::TriggerPathCollection product with InputTag '"
+                                  << tagTriggerProducer_.encode() << "' not in event";
   }
-  if ( handleTriggerFilters.isValid() ) {
-    triggerEvent->setFilters( handleTriggerFilters );
+  if (handleTriggerFilters.isValid()) {
+    triggerEvent->setFilters(handleTriggerFilters);
   } else {
-    LogError( "triggerFiltersValid" ) << "pat::TriggerFilterCollection product with InputTag '" << tagTriggerProducer_.encode() << "' not in event";
+    LogError("triggerFiltersValid") << "pat::TriggerFilterCollection product with InputTag '"
+                                    << tagTriggerProducer_.encode() << "' not in event";
   }
-  if ( handleTriggerObjects.isValid() ) {
-    triggerEvent->setObjects( handleTriggerObjects );
+  if (handleTriggerObjects.isValid()) {
+    triggerEvent->setObjects(handleTriggerObjects);
   } else {
-    LogError( "triggerObjectsValid" ) << "pat::TriggerObjectCollection product with InputTag '" << tagTriggerProducer_.encode() << "' not in event";
+    LogError("triggerObjectsValid") << "pat::TriggerObjectCollection product with InputTag '"
+                                    << tagTriggerProducer_.encode() << "' not in event";
   }
-  if ( gtCondRunInit_ ) {
-    triggerEvent->setLhcFill( condRun_.lhcFillNumber );
-    triggerEvent->setBeamMode( condRun_.beamMode );
-    triggerEvent->setBeamMomentum( condRun_.beamMomentum );
-    triggerEvent->setBCurrentStart( condRun_.BStartCurrent );
-    triggerEvent->setBCurrentStop( condRun_.BStopCurrent );
-    triggerEvent->setBCurrentAvg( condRun_.BAvgCurrent );
+  if (gtCondRunInit_) {
+    triggerEvent->setLhcFill(condRun_.lhcFillNumber);
+    triggerEvent->setBeamMode(condRun_.beamMode);
+    triggerEvent->setBeamMomentum(condRun_.beamMomentum);
+    triggerEvent->setBCurrentStart(condRun_.BStartCurrent);
+    triggerEvent->setBCurrentStop(condRun_.BStopCurrent);
+    triggerEvent->setBCurrentAvg(condRun_.BAvgCurrent);
   }
-  if ( gtCondLumiInit_ ) {
-    triggerEvent->setIntensityBeam1( condLumi_.totalIntensityBeam1 );
-    triggerEvent->setIntensityBeam2( condLumi_.totalIntensityBeam2 );
+  if (gtCondLumiInit_) {
+    triggerEvent->setIntensityBeam1(condLumi_.totalIntensityBeam1);
+    triggerEvent->setIntensityBeam2(condLumi_.totalIntensityBeam2);
   }
-  if ( ! tagCondGt_.label().empty() ) {
-    Handle< ConditionsInEventBlock > condEventBlock;
-    iEvent.getByToken( tagCondGtEventToken_, condEventBlock );
-    if ( condEventBlock.isValid() ) {
-      triggerEvent->setBstMasterStatus( condEventBlock->bstMasterStatus );
-      triggerEvent->setTurnCount( condEventBlock->turnCountNumber );
+  if (!tagCondGt_.label().empty()) {
+    Handle<ConditionsInEventBlock> condEventBlock;
+    iEvent.getByToken(tagCondGtEventToken_, condEventBlock);
+    if (condEventBlock.isValid()) {
+      triggerEvent->setBstMasterStatus(condEventBlock->bstMasterStatus);
+      triggerEvent->setTurnCount(condEventBlock->turnCountNumber);
     } else {
-      LogError( "conditionsInEdm" ) << "ConditionsInEventBlock product with InputTag '" << tagCondGt_.encode() << "' not in event";
+      LogError("conditionsInEdm") << "ConditionsInEventBlock product with InputTag '" << tagCondGt_.encode()
+                                  << "' not in event";
     }
   }
 
   // produce trigger match association and set references
-  if ( handleTriggerObjects.isValid() ) {
-    for ( size_t iMatch = 0; iMatch < tagsTriggerMatcher_.size(); ++iMatch ) {
-      const std::string labelTriggerObjectMatcher( tagsTriggerMatcher_.at( iMatch ).label() );
+  if (handleTriggerObjects.isValid()) {
+    for (size_t iMatch = 0; iMatch < tagsTriggerMatcher_.size(); ++iMatch) {
+      const std::string labelTriggerObjectMatcher(tagsTriggerMatcher_.at(iMatch).label());
       // copy trigger match association using TriggerObjectStandAlone to those using TriggerObject
       // relying on the fact, that only one candidate collection is present in the association
-      Handle< TriggerObjectStandAloneMatch > handleTriggerObjectStandAloneMatch;
-      iEvent.getByToken( triggerMatcherTokens_.at( iMatch ), handleTriggerObjectStandAloneMatch );
-      if ( ! handleTriggerObjectStandAloneMatch.isValid() ) {
-        LogError( "triggerMatchValid" ) << "pat::TriggerObjectStandAloneMatch product with InputTag '" << labelTriggerObjectMatcher << "' not in event";
+      Handle<TriggerObjectStandAloneMatch> handleTriggerObjectStandAloneMatch;
+      iEvent.getByToken(triggerMatcherTokens_.at(iMatch), handleTriggerObjectStandAloneMatch);
+      if (!handleTriggerObjectStandAloneMatch.isValid()) {
+        LogError("triggerMatchValid") << "pat::TriggerObjectStandAloneMatch product with InputTag '"
+                                      << labelTriggerObjectMatcher << "' not in event";
         continue;
       }
-      auto it = makeAssociativeIterator< reco::CandidateBaseRef>( *handleTriggerObjectStandAloneMatch, iEvent );
-      auto itEnd =  it.end();
-      Handle< reco::CandidateView > handleCands;
-      if ( it != itEnd ) iEvent.get( it->first.id(), handleCands );
-      std::vector< int > indices;
-      while ( it != itEnd ) {
-        indices.push_back( it->second.key() );
+      auto it = makeAssociativeIterator<reco::CandidateBaseRef>(*handleTriggerObjectStandAloneMatch, iEvent);
+      auto itEnd = it.end();
+      Handle<reco::CandidateView> handleCands;
+      if (it != itEnd)
+        iEvent.get(it->first.id(), handleCands);
+      std::vector<int> indices;
+      while (it != itEnd) {
+        indices.push_back(it->second.key());
         ++it;
       }
       auto triggerObjectMatch = std::make_unique<TriggerObjectMatch>(handleTriggerObjects);
-      TriggerObjectMatch::Filler matchFiller( *triggerObjectMatch );
-      if ( handleCands.isValid() ) {
-        matchFiller.insert( handleCands, indices.begin(), indices.end() );
+      TriggerObjectMatch::Filler matchFiller(*triggerObjectMatch);
+      if (handleCands.isValid()) {
+        matchFiller.insert(handleCands, indices.begin(), indices.end());
       }
       matchFiller.fill();
-      OrphanHandle< TriggerObjectMatch > handleTriggerObjectMatch( iEvent.put(std::move(triggerObjectMatch), labelTriggerObjectMatcher ) );
+      OrphanHandle<TriggerObjectMatch> handleTriggerObjectMatch(
+          iEvent.put(std::move(triggerObjectMatch), labelTriggerObjectMatcher));
       // set product reference to trigger match association
-      if ( ! handleTriggerObjectMatch.isValid() ) {
-        LogError( "triggerMatchValid" ) << "pat::TriggerObjectMatch product with InputTag '" << labelTriggerObjectMatcher << "' not in event";
+      if (!handleTriggerObjectMatch.isValid()) {
+        LogError("triggerMatchValid") << "pat::TriggerObjectMatch product with InputTag '" << labelTriggerObjectMatcher
+                                      << "' not in event";
         continue;
       }
-      if ( ! ( triggerEvent->addObjectMatchResult( handleTriggerObjectMatch, labelTriggerObjectMatcher ) ) ) {
-        LogWarning( "triggerObjectMatchReplication" ) << "pat::TriggerEvent contains already a pat::TriggerObjectMatch from matcher module '" << labelTriggerObjectMatcher << "'";
+      if (!(triggerEvent->addObjectMatchResult(handleTriggerObjectMatch, labelTriggerObjectMatcher))) {
+        LogWarning("triggerObjectMatchReplication")
+            << "pat::TriggerEvent contains already a pat::TriggerObjectMatch from matcher module '"
+            << labelTriggerObjectMatcher << "'";
       }
     }
   }
 
-  iEvent.put(std::move(triggerEvent) );
-
+  iEvent.put(std::move(triggerEvent));
 }
 
-
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE( PATTriggerEventProducer );
+DEFINE_FWK_MODULE(PATTriggerEventProducer);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_PatAlgos_PATTriggerEventProducer_h
 #define PhysicsTools_PatAlgos_PATTriggerEventProducer_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatAlgos
@@ -27,7 +26,6 @@
   \version  $Id: PATTriggerEventProducer.h,v 1.11 2010/11/27 15:16:20 vadler Exp $
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/GetterOfProducts.h"
@@ -44,54 +42,48 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
-
 namespace pat {
 
   class PATTriggerEventProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATTriggerEventProducer(const edm::ParameterSet& iConfig);
+    ~PATTriggerEventProducer() override{};
 
-    public:
+  private:
+    void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      explicit PATTriggerEventProducer( const edm::ParameterSet & iConfig );
-      ~PATTriggerEventProducer() override {};
-
-    private:
-
-      void beginRun(const edm::Run & iRun, const edm::EventSetup& iSetup) override;
-      void beginLuminosityBlock(const edm::LuminosityBlock & iLumi, const edm::EventSetup& iSetup) override;
-      void produce( edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-
-      std::string                  nameProcess_;        // configuration
-      bool                         autoProcessName_;
-      edm::InputTag                tagTriggerProducer_; // configuration (optional with default)
-      edm::EDGetTokenT< TriggerAlgorithmCollection > triggerAlgorithmCollectionToken_;
-      edm::EDGetTokenT< TriggerConditionCollection > triggerConditionCollectionToken_;
-      edm::EDGetTokenT< TriggerPathCollection >      triggerPathCollectionToken_;
-      edm::EDGetTokenT< TriggerFilterCollection >    triggerFilterCollectionToken_;
-      edm::EDGetTokenT< TriggerObjectCollection >    triggerObjectCollectionToken_;
-      std::vector< edm::InputTag > tagsTriggerMatcher_; // configuration (optional)
-      std::vector< edm::EDGetTokenT< TriggerObjectStandAloneMatch > > triggerMatcherTokens_;
-      // L1
-      edm::InputTag                tagL1Gt_;            // configuration (optional with default)
-      edm::EDGetTokenT< L1GlobalTriggerReadoutRecord > l1GtToken_;
-      // HLT
-      HLTConfigProvider            hltConfig_;
-      bool                         hltConfigInit_;
-      edm::InputTag                tagTriggerResults_;  // configuration (optional with default)
-      edm::GetterOfProducts< edm::TriggerResults > triggerResultsGetter_;
-      edm::InputTag                tagTriggerEvent_;    // configuration (optional with default)
-      // Conditions
-      edm::InputTag                tagCondGt_;          // configuration (optional with default)
-      edm::EDGetTokenT< edm::ConditionsInRunBlock > tagCondGtRunToken_;
-      edm::EDGetTokenT< edm::ConditionsInLumiBlock > tagCondGtLumiToken_;
-      edm::EDGetTokenT< edm::ConditionsInEventBlock > tagCondGtEventToken_;
-      edm::ConditionsInRunBlock    condRun_;
-      edm::ConditionsInLumiBlock   condLumi_;
-      bool                         gtCondRunInit_;
-      bool                         gtCondLumiInit_;
-
+    std::string nameProcess_;  // configuration
+    bool autoProcessName_;
+    edm::InputTag tagTriggerProducer_;  // configuration (optional with default)
+    edm::EDGetTokenT<TriggerAlgorithmCollection> triggerAlgorithmCollectionToken_;
+    edm::EDGetTokenT<TriggerConditionCollection> triggerConditionCollectionToken_;
+    edm::EDGetTokenT<TriggerPathCollection> triggerPathCollectionToken_;
+    edm::EDGetTokenT<TriggerFilterCollection> triggerFilterCollectionToken_;
+    edm::EDGetTokenT<TriggerObjectCollection> triggerObjectCollectionToken_;
+    std::vector<edm::InputTag> tagsTriggerMatcher_;  // configuration (optional)
+    std::vector<edm::EDGetTokenT<TriggerObjectStandAloneMatch> > triggerMatcherTokens_;
+    // L1
+    edm::InputTag tagL1Gt_;  // configuration (optional with default)
+    edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> l1GtToken_;
+    // HLT
+    HLTConfigProvider hltConfig_;
+    bool hltConfigInit_;
+    edm::InputTag tagTriggerResults_;  // configuration (optional with default)
+    edm::GetterOfProducts<edm::TriggerResults> triggerResultsGetter_;
+    edm::InputTag tagTriggerEvent_;  // configuration (optional with default)
+    // Conditions
+    edm::InputTag tagCondGt_;  // configuration (optional with default)
+    edm::EDGetTokenT<edm::ConditionsInRunBlock> tagCondGtRunToken_;
+    edm::EDGetTokenT<edm::ConditionsInLumiBlock> tagCondGtLumiToken_;
+    edm::EDGetTokenT<edm::ConditionsInEventBlock> tagCondGtEventToken_;
+    edm::ConditionsInRunBlock condRun_;
+    edm::ConditionsInLumiBlock condLumi_;
+    bool gtCondRunInit_;
+    bool gtCondLumiInit_;
   };
 
-}
-
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerMatchEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerMatchEmbedder.cc
@@ -15,7 +15,6 @@
 //
 //
 
-
 #include <vector>
 
 #include "FWCore/Utilities/interface/transform.h"
@@ -35,93 +34,88 @@
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 
-
 namespace pat {
 
-  template< class PATObjectType >
+  template <class PATObjectType>
   class PATTriggerMatchEmbedder : public edm::global::EDProducer<> {
+    const edm::InputTag src_;
+    const edm::EDGetTokenT<edm::View<PATObjectType>> srcToken_;
+    const std::vector<edm::InputTag> matches_;
+    const std::vector<edm::EDGetTokenT<TriggerObjectStandAloneMatch>> matchesTokens_;
 
-      const edm::InputTag src_;
-      const edm::EDGetTokenT< edm::View< PATObjectType > > srcToken_;
-      const std::vector< edm::InputTag > matches_;
-      const std::vector< edm::EDGetTokenT< TriggerObjectStandAloneMatch > > matchesTokens_;
+  public:
+    explicit PATTriggerMatchEmbedder(const edm::ParameterSet& iConfig);
+    ~PATTriggerMatchEmbedder() override{};
 
-    public:
-
-      explicit PATTriggerMatchEmbedder( const edm::ParameterSet & iConfig );
-      ~PATTriggerMatchEmbedder() override {};
-
-    private:
-
-    void produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
-
+  private:
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
   };
 
-  typedef PATTriggerMatchEmbedder< Electron > PATTriggerMatchElectronEmbedder;
-  typedef PATTriggerMatchEmbedder< Jet >      PATTriggerMatchJetEmbedder;
-  typedef PATTriggerMatchEmbedder< MET >      PATTriggerMatchMETEmbedder;
-  typedef PATTriggerMatchEmbedder< Muon >     PATTriggerMatchMuonEmbedder;
-  typedef PATTriggerMatchEmbedder< Photon >   PATTriggerMatchPhotonEmbedder;
-  typedef PATTriggerMatchEmbedder< Tau >      PATTriggerMatchTauEmbedder;
+  typedef PATTriggerMatchEmbedder<Electron> PATTriggerMatchElectronEmbedder;
+  typedef PATTriggerMatchEmbedder<Jet> PATTriggerMatchJetEmbedder;
+  typedef PATTriggerMatchEmbedder<MET> PATTriggerMatchMETEmbedder;
+  typedef PATTriggerMatchEmbedder<Muon> PATTriggerMatchMuonEmbedder;
+  typedef PATTriggerMatchEmbedder<Photon> PATTriggerMatchPhotonEmbedder;
+  typedef PATTriggerMatchEmbedder<Tau> PATTriggerMatchTauEmbedder;
 
-}
-
+}  // namespace pat
 
 using namespace pat;
 
-
-template< class PATObjectType >
-PATTriggerMatchEmbedder< PATObjectType >::PATTriggerMatchEmbedder( const edm::ParameterSet & iConfig ) :
-  src_( iConfig.getParameter< edm::InputTag >( "src" ) ),
-  srcToken_( consumes< edm::View< PATObjectType > >( src_ ) ),
-  matches_( iConfig.getParameter< std::vector< edm::InputTag > >( "matches" ) ),
-  matchesTokens_( edm::vector_transform( matches_, [this](edm::InputTag const & tag) { return consumes< TriggerObjectStandAloneMatch >( tag ); } ) )
-{
-  produces< std::vector< PATObjectType > >();
+template <class PATObjectType>
+PATTriggerMatchEmbedder<PATObjectType>::PATTriggerMatchEmbedder(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      srcToken_(consumes<edm::View<PATObjectType>>(src_)),
+      matches_(iConfig.getParameter<std::vector<edm::InputTag>>("matches")),
+      matchesTokens_(edm::vector_transform(
+          matches_, [this](edm::InputTag const& tag) { return consumes<TriggerObjectStandAloneMatch>(tag); })) {
+  produces<std::vector<PATObjectType>>();
 }
 
-template< class PATObjectType >
-void PATTriggerMatchEmbedder< PATObjectType >::produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const
-{
+template <class PATObjectType>
+void PATTriggerMatchEmbedder<PATObjectType>::produce(edm::StreamID,
+                                                     edm::Event& iEvent,
+                                                     const edm::EventSetup& iSetup) const {
   auto output = std::make_unique<std::vector<PATObjectType>>();
 
-  edm::Handle< edm::View< PATObjectType > > candidates;
-  iEvent.getByToken( srcToken_, candidates );
-  if ( ! candidates.isValid() ) {
-    edm::LogError( "missingInputSource" ) << "Input source with InputTag " << src_.encode() << " not in event.";
+  edm::Handle<edm::View<PATObjectType>> candidates;
+  iEvent.getByToken(srcToken_, candidates);
+  if (!candidates.isValid()) {
+    edm::LogError("missingInputSource") << "Input source with InputTag " << src_.encode() << " not in event.";
     return;
   }
 
-  for ( typename edm::View< PATObjectType >::const_iterator iCand = candidates->begin(); iCand != candidates->end(); ++iCand ) {
-    const unsigned index( iCand - candidates->begin() );
-    PATObjectType cand( candidates->at( index ) );
-    std::set< TriggerObjectStandAloneRef > cachedRefs;
-    for ( size_t iMatch = 0; iMatch < matchesTokens_.size(); ++iMatch ) {
-      edm::Handle< TriggerObjectStandAloneMatch > match;
-      iEvent.getByToken( matchesTokens_.at( iMatch ), match );
-      if ( ! match.isValid() ) {
-        edm::LogError( "missingInputMatch" ) << "Input match with InputTag " << matches_.at( iMatch ).encode() << " not in event.";
+  for (typename edm::View<PATObjectType>::const_iterator iCand = candidates->begin(); iCand != candidates->end();
+       ++iCand) {
+    const unsigned index(iCand - candidates->begin());
+    PATObjectType cand(candidates->at(index));
+    std::set<TriggerObjectStandAloneRef> cachedRefs;
+    for (size_t iMatch = 0; iMatch < matchesTokens_.size(); ++iMatch) {
+      edm::Handle<TriggerObjectStandAloneMatch> match;
+      iEvent.getByToken(matchesTokens_.at(iMatch), match);
+      if (!match.isValid()) {
+        edm::LogError("missingInputMatch")
+            << "Input match with InputTag " << matches_.at(iMatch).encode() << " not in event.";
         continue;
       }
-      const TriggerObjectStandAloneRef trigRef( ( *match )[ candidates->refAt( index ) ] );
-      if ( trigRef.isNonnull() && trigRef.isAvailable() ) {
-        if ( cachedRefs.insert( trigRef ).second ) { // protection from multiple entries of the same trigger objects
-          cand.addTriggerObjectMatch( *trigRef );
+      const TriggerObjectStandAloneRef trigRef((*match)[candidates->refAt(index)]);
+      if (trigRef.isNonnull() && trigRef.isAvailable()) {
+        if (cachedRefs.insert(trigRef).second) {  // protection from multiple entries of the same trigger objects
+          cand.addTriggerObjectMatch(*trigRef);
         }
       }
     }
-    output->push_back( cand );
+    output->push_back(cand);
   }
 
-  iEvent.put(std::move(output) );
+  iEvent.put(std::move(output));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( PATTriggerMatchElectronEmbedder );
-DEFINE_FWK_MODULE( PATTriggerMatchJetEmbedder );
-DEFINE_FWK_MODULE( PATTriggerMatchMETEmbedder );
-DEFINE_FWK_MODULE( PATTriggerMatchMuonEmbedder );
-DEFINE_FWK_MODULE( PATTriggerMatchPhotonEmbedder );
-DEFINE_FWK_MODULE( PATTriggerMatchTauEmbedder );
+DEFINE_FWK_MODULE(PATTriggerMatchElectronEmbedder);
+DEFINE_FWK_MODULE(PATTriggerMatchJetEmbedder);
+DEFINE_FWK_MODULE(PATTriggerMatchMETEmbedder);
+DEFINE_FWK_MODULE(PATTriggerMatchMuonEmbedder);
+DEFINE_FWK_MODULE(PATTriggerMatchPhotonEmbedder);
+DEFINE_FWK_MODULE(PATTriggerMatchTauEmbedder);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerMatchSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerMatchSelector.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_PatAlgos_PATTriggerMatchSelector_h
 #define PhysicsTools_PatAlgos_PATTriggerMatchSelector_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatAlgos
@@ -19,7 +18,6 @@
 //
 //
 
-
 #include <string>
 #include <vector>
 #include <map>
@@ -28,25 +26,19 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 namespace pat {
 
-  template< typename T1, typename T2 >
-  class PATTriggerMatchSelector : public StringCutObjectSelector< T2 > {
+  template <typename T1, typename T2>
+  class PATTriggerMatchSelector : public StringCutObjectSelector<T2> {
+  public:
+    PATTriggerMatchSelector(const edm::ParameterSet& iConfig)
+        : StringCutObjectSelector<T2>(iConfig.getParameter<std::string>("matchedCuts")) {}
 
-    public:
-
-      PATTriggerMatchSelector( const edm::ParameterSet & iConfig ) :
-        StringCutObjectSelector< T2 >( iConfig.getParameter< std::string >( "matchedCuts" ) )
-      {}
-
-      bool operator()( const T1 & patObj, const T2 & trigObj ) const {
-        return StringCutObjectSelector< T2 >::operator()( trigObj );
-      }
-
+    bool operator()(const T1& patObj, const T2& trigObj) const {
+      return StringCutObjectSelector<T2>::operator()(trigObj);
+    }
   };
 
-}
-
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerMatcher.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerMatcher.cc
@@ -11,76 +11,60 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 
-
 /// Match by deltaR (default), ranking by deltaR (default)
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  pat::TriggerObjectStandAloneCollection,
-  pat::PATTriggerMatchSelector< reco::CandidateView::value_type,
-                                pat::TriggerObjectStandAloneCollection::value_type >
-> PATTriggerMatcherDRLessByR;
+    reco::CandidateView,
+    pat::TriggerObjectStandAloneCollection,
+    pat::PATTriggerMatchSelector<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type> >
+    PATTriggerMatcherDRLessByR;
 
 /// Match by deltaR and deltaPt, ranking by deltaR (default)
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  pat::TriggerObjectStandAloneCollection,
-  pat::PATTriggerMatchSelector< reco::CandidateView::value_type,
-                                pat::TriggerObjectStandAloneCollection::value_type>,
-  reco::MatchByDRDPt< reco::CandidateView::value_type,
-                      pat::TriggerObjectStandAloneCollection::value_type >
-> PATTriggerMatcherDRDPtLessByR;
+    reco::CandidateView,
+    pat::TriggerObjectStandAloneCollection,
+    pat::PATTriggerMatchSelector<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchByDRDPt<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type> >
+    PATTriggerMatcherDRDPtLessByR;
 
 /// Match by deltaR (default), ranking by deltaPt
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  pat::TriggerObjectStandAloneCollection,
-  pat::PATTriggerMatchSelector< reco::CandidateView::value_type,
-                                pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchByDR< reco::CandidateView::value_type,
-                   pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchLessByDPt< reco::CandidateView,
-                        pat::TriggerObjectStandAloneCollection >
-> PATTriggerMatcherDRLessByPt;
+    reco::CandidateView,
+    pat::TriggerObjectStandAloneCollection,
+    pat::PATTriggerMatchSelector<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchByDR<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchLessByDPt<reco::CandidateView, pat::TriggerObjectStandAloneCollection> >
+    PATTriggerMatcherDRLessByPt;
 
 /// Match by deltaR and deltaPt, ranking by deltaPt
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  pat::TriggerObjectStandAloneCollection,
-  pat::PATTriggerMatchSelector<reco::CandidateView::value_type,
-                               pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchByDRDPt< reco::CandidateView::value_type,
-                      pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchLessByDPt< reco::CandidateView,
-                        pat::TriggerObjectStandAloneCollection >
-> PATTriggerMatcherDRDPtLessByPt;
+    reco::CandidateView,
+    pat::TriggerObjectStandAloneCollection,
+    pat::PATTriggerMatchSelector<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchByDRDPt<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchLessByDPt<reco::CandidateView, pat::TriggerObjectStandAloneCollection> >
+    PATTriggerMatcherDRDPtLessByPt;
 
 /// Match by deltaEta, ranking by deltaR
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  pat::TriggerObjectStandAloneCollection,
-  pat::PATTriggerMatchSelector< reco::CandidateView::value_type,
-                                pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchByDEta< reco::CandidateView::value_type,
-                     pat::TriggerObjectStandAloneCollection::value_type >
-> PATTriggerMatcherDEtaLessByDR;
+    reco::CandidateView,
+    pat::TriggerObjectStandAloneCollection,
+    pat::PATTriggerMatchSelector<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchByDEta<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type> >
+    PATTriggerMatcherDEtaLessByDR;
 
 /// Match by deltaEta, ranking by deltaEta
 typedef reco::PhysObjectMatcher<
-  reco::CandidateView,
-  pat::TriggerObjectStandAloneCollection,
-  pat::PATTriggerMatchSelector< reco::CandidateView::value_type,
-                                pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchByDEta< reco::CandidateView::value_type,
-                     pat::TriggerObjectStandAloneCollection::value_type >,
-  reco::MatchLessByDEta< reco::CandidateView,
-                         pat::TriggerObjectStandAloneCollection >
-> PATTriggerMatcherDEtaLessByDEta;
-
+    reco::CandidateView,
+    pat::TriggerObjectStandAloneCollection,
+    pat::PATTriggerMatchSelector<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchByDEta<reco::CandidateView::value_type, pat::TriggerObjectStandAloneCollection::value_type>,
+    reco::MatchLessByDEta<reco::CandidateView, pat::TriggerObjectStandAloneCollection> >
+    PATTriggerMatcherDEtaLessByDEta;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE( PATTriggerMatcherDRLessByR );
-DEFINE_FWK_MODULE( PATTriggerMatcherDRDPtLessByR );
-DEFINE_FWK_MODULE( PATTriggerMatcherDRLessByPt );
-DEFINE_FWK_MODULE( PATTriggerMatcherDRDPtLessByPt );
-DEFINE_FWK_MODULE( PATTriggerMatcherDEtaLessByDR );
-DEFINE_FWK_MODULE( PATTriggerMatcherDEtaLessByDEta );
+DEFINE_FWK_MODULE(PATTriggerMatcherDRLessByR);
+DEFINE_FWK_MODULE(PATTriggerMatcherDRDPtLessByR);
+DEFINE_FWK_MODULE(PATTriggerMatcherDRLessByPt);
+DEFINE_FWK_MODULE(PATTriggerMatcherDRDPtLessByPt);
+DEFINE_FWK_MODULE(PATTriggerMatcherDEtaLessByDR);
+DEFINE_FWK_MODULE(PATTriggerMatcherDEtaLessByDEta);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneSlimmer.cc
@@ -11,7 +11,6 @@
   \author   Giovanni Petrucciani
 */
 
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -22,67 +21,59 @@
 #include <set>
 
 namespace pat {
-  
-  class PATTriggerObjectStandAloneSlimmer : public edm::global::EDProducer<> {
-    
-  public:
-    
-    explicit PATTriggerObjectStandAloneSlimmer( const edm::ParameterSet & iConfig );
-    ~PATTriggerObjectStandAloneSlimmer() override {};
-    
-  private:
-    
-    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
-    
-    const edm::EDGetTokenT<TriggerObjectStandAloneCollection> srcToken_;
-    const edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
- 
-    bool packFilterLabels_, packP4_;
- 
-  };
-  
-}
 
+  class PATTriggerObjectStandAloneSlimmer : public edm::global::EDProducer<> {
+  public:
+    explicit PATTriggerObjectStandAloneSlimmer(const edm::ParameterSet& iConfig);
+    ~PATTriggerObjectStandAloneSlimmer() override{};
+
+  private:
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+    const edm::EDGetTokenT<TriggerObjectStandAloneCollection> srcToken_;
+    const edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+
+    bool packFilterLabels_, packP4_;
+  };
+
+}  // namespace pat
 
 using namespace pat;
 
-
-PATTriggerObjectStandAloneSlimmer::PATTriggerObjectStandAloneSlimmer( const edm::ParameterSet & iConfig ) : 
-    srcToken_( consumes<TriggerObjectStandAloneCollection>( iConfig.getParameter<edm::InputTag>( "src" ) ) ),
-    triggerResultsToken_( consumes< edm::TriggerResults >( iConfig.getParameter< edm::InputTag >( "triggerResults" ) ) ),
-    packFilterLabels_( iConfig.getParameter<bool>("packFilterLabels") ),
-    packP4_( iConfig.getParameter<bool>("packP4") )
-{
-    produces<TriggerObjectStandAloneCollection>();
-    if (packFilterLabels_) {
-        produces<std::vector<std::string>>("filterLabels");
-    }
+PATTriggerObjectStandAloneSlimmer::PATTriggerObjectStandAloneSlimmer(const edm::ParameterSet& iConfig)
+    : srcToken_(consumes<TriggerObjectStandAloneCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      triggerResultsToken_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerResults"))),
+      packFilterLabels_(iConfig.getParameter<bool>("packFilterLabels")),
+      packP4_(iConfig.getParameter<bool>("packP4")) {
+  produces<TriggerObjectStandAloneCollection>();
+  if (packFilterLabels_) {
+    produces<std::vector<std::string>>("filterLabels");
+  }
 }
 
-void PATTriggerObjectStandAloneSlimmer::produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const
-{
-    edm::Handle<TriggerObjectStandAloneCollection> src;
-    iEvent.getByToken( srcToken_, src );
-    edm::Handle< edm::TriggerResults > triggerResults;
-    iEvent.getByToken( triggerResultsToken_, triggerResults );
+void PATTriggerObjectStandAloneSlimmer::produce(edm::StreamID,
+                                                edm::Event& iEvent,
+                                                const edm::EventSetup& iSetup) const {
+  edm::Handle<TriggerObjectStandAloneCollection> src;
+  iEvent.getByToken(srcToken_, src);
+  edm::Handle<edm::TriggerResults> triggerResults;
+  iEvent.getByToken(triggerResultsToken_, triggerResults);
 
-    auto slimmed = std::make_unique<TriggerObjectStandAloneCollection>(*src);
+  auto slimmed = std::make_unique<TriggerObjectStandAloneCollection>(*src);
 
-    if (packFilterLabels_) {
-        std::set<std::string> allLabels;
-        for (auto & obj : *slimmed) {
-	        obj.packFilterLabels(iEvent,*triggerResults);
-        }
-
+  if (packFilterLabels_) {
+    std::set<std::string> allLabels;
+    for (auto& obj : *slimmed) {
+      obj.packFilterLabels(iEvent, *triggerResults);
     }
-    if (packP4_) {
-        for (TriggerObjectStandAlone & obj : *slimmed) {
-            obj.packP4();
-        }
+  }
+  if (packP4_) {
+    for (TriggerObjectStandAlone& obj : *slimmed) {
+      obj.packP4();
     }
-    iEvent.put(std::move(slimmed) );
+  }
+  iEvent.put(std::move(slimmed));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE( PATTriggerObjectStandAloneSlimmer );
+DEFINE_FWK_MODULE(PATTriggerObjectStandAloneSlimmer);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneUnpacker.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneUnpacker.cc
@@ -13,7 +13,6 @@
   \author   Volker Adler
 */
 
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -24,59 +23,54 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 namespace pat {
-  
-  class PATTriggerObjectStandAloneUnpacker : public edm::global::EDProducer<> {
-    
-  public:
-    
-    explicit PATTriggerObjectStandAloneUnpacker( const edm::ParameterSet & iConfig );
-    ~PATTriggerObjectStandAloneUnpacker() override {};
-    
-  private:
-    
-    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
-    
-    const edm::EDGetTokenT< TriggerObjectStandAloneCollection > patTriggerObjectsStandAloneToken_;
-    const edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
-    bool unpackFilterLabels_;
-    const edm::EDGetTokenT< std::vector<std::string> > filterLabelsToken_;
-    
-  };
-  
-}
 
+  class PATTriggerObjectStandAloneUnpacker : public edm::global::EDProducer<> {
+  public:
+    explicit PATTriggerObjectStandAloneUnpacker(const edm::ParameterSet& iConfig);
+    ~PATTriggerObjectStandAloneUnpacker() override{};
+
+  private:
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+    const edm::EDGetTokenT<TriggerObjectStandAloneCollection> patTriggerObjectsStandAloneToken_;
+    const edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+    bool unpackFilterLabels_;
+    const edm::EDGetTokenT<std::vector<std::string> > filterLabelsToken_;
+  };
+
+}  // namespace pat
 
 using namespace pat;
 
-
-PATTriggerObjectStandAloneUnpacker::PATTriggerObjectStandAloneUnpacker( const edm::ParameterSet & iConfig )
-: patTriggerObjectsStandAloneToken_( consumes< TriggerObjectStandAloneCollection >( iConfig.getParameter< edm::InputTag >( "patTriggerObjectsStandAlone" ) ) )
-, triggerResultsToken_( consumes< edm::TriggerResults >( iConfig.getParameter< edm::InputTag >( "triggerResults" ) ) )
-, unpackFilterLabels_( iConfig.getParameter< bool >("unpackFilterLabels") )
-{
-  produces< TriggerObjectStandAloneCollection >();
+PATTriggerObjectStandAloneUnpacker::PATTriggerObjectStandAloneUnpacker(const edm::ParameterSet& iConfig)
+    : patTriggerObjectsStandAloneToken_(consumes<TriggerObjectStandAloneCollection>(
+          iConfig.getParameter<edm::InputTag>("patTriggerObjectsStandAlone"))),
+      triggerResultsToken_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerResults"))),
+      unpackFilterLabels_(iConfig.getParameter<bool>("unpackFilterLabels")) {
+  produces<TriggerObjectStandAloneCollection>();
 }
 
-void PATTriggerObjectStandAloneUnpacker::produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const
-{
-  edm::Handle< TriggerObjectStandAloneCollection > patTriggerObjectsStandAlone;
-  iEvent.getByToken( patTriggerObjectsStandAloneToken_, patTriggerObjectsStandAlone );
-  edm::Handle< edm::TriggerResults > triggerResults;
-  iEvent.getByToken( triggerResultsToken_, triggerResults );
+void PATTriggerObjectStandAloneUnpacker::produce(edm::StreamID,
+                                                 edm::Event& iEvent,
+                                                 const edm::EventSetup& iSetup) const {
+  edm::Handle<TriggerObjectStandAloneCollection> patTriggerObjectsStandAlone;
+  iEvent.getByToken(patTriggerObjectsStandAloneToken_, patTriggerObjectsStandAlone);
+  edm::Handle<edm::TriggerResults> triggerResults;
+  iEvent.getByToken(triggerResultsToken_, triggerResults);
 
   auto patTriggerObjectsStandAloneUnpacked = std::make_unique<TriggerObjectStandAloneCollection>();
 
-  for ( size_t iTrigObj = 0; iTrigObj < patTriggerObjectsStandAlone->size(); ++iTrigObj ) {
-    TriggerObjectStandAlone patTriggerObjectStandAloneUnpacked( patTriggerObjectsStandAlone->at( iTrigObj ) );
-    const edm::TriggerNames & names = iEvent.triggerNames( *triggerResults );
-    patTriggerObjectStandAloneUnpacked.unpackPathNames( names );
-    if (unpackFilterLabels_) patTriggerObjectStandAloneUnpacked.unpackFilterLabels(iEvent,*triggerResults );
-    patTriggerObjectsStandAloneUnpacked->push_back( patTriggerObjectStandAloneUnpacked );
+  for (size_t iTrigObj = 0; iTrigObj < patTriggerObjectsStandAlone->size(); ++iTrigObj) {
+    TriggerObjectStandAlone patTriggerObjectStandAloneUnpacked(patTriggerObjectsStandAlone->at(iTrigObj));
+    const edm::TriggerNames& names = iEvent.triggerNames(*triggerResults);
+    patTriggerObjectStandAloneUnpacked.unpackPathNames(names);
+    if (unpackFilterLabels_)
+      patTriggerObjectStandAloneUnpacked.unpackFilterLabels(iEvent, *triggerResults);
+    patTriggerObjectsStandAloneUnpacked->push_back(patTriggerObjectStandAloneUnpacked);
   }
 
-  iEvent.put(std::move(patTriggerObjectsStandAloneUnpacked) );
+  iEvent.put(std::move(patTriggerObjectsStandAloneUnpacked));
 }
 
-
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE( PATTriggerObjectStandAloneUnpacker );
+DEFINE_FWK_MODULE(PATTriggerObjectStandAloneUnpacker);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -1,7 +1,6 @@
 //
 //
 
-
 #include "PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h"
 
 #include <vector>
@@ -36,422 +35,489 @@
 using namespace pat;
 using namespace edm;
 
-
 // Constants' definitions
 const unsigned L1GlobalTriggerReadoutSetup::NumberPhysTriggers;
 const unsigned L1GlobalTriggerReadoutSetup::NumberPhysTriggersExtended;
 const unsigned L1GlobalTriggerReadoutSetup::NumberTechnicalTriggers;
 
-
-PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
-  nameProcess_( iConfig.getParameter< std::string >( "processName" ) ),
-  autoProcessName_( nameProcess_ == "*" ),
-  onlyStandAlone_( iConfig.getParameter< bool >( "onlyStandAlone" ) ),
-  firstInRun_( true ),
+PATTriggerProducer::PATTriggerProducer(const ParameterSet& iConfig)
+    : nameProcess_(iConfig.getParameter<std::string>("processName")),
+      autoProcessName_(nameProcess_ == "*"),
+      onlyStandAlone_(iConfig.getParameter<bool>("onlyStandAlone")),
+      firstInRun_(true),
+      // L1 configuration parameters
+      addL1Algos_(false),
+      tagL1GlobalTriggerObjectMaps_("l1L1GtObjectMap"),
+      tagL1ExtraMu_(),
+      tagL1ExtraNoIsoEG_(),
+      tagL1ExtraIsoEG_(),
+      tagL1ExtraCenJet_(),
+      tagL1ExtraForJet_(),
+      tagL1ExtraTauJet_(),
+      tagL1ExtraETM_(),
+      tagL1ExtraHTM_(),
+      autoProcessNameL1ExtraMu_(false),
+      autoProcessNameL1ExtraNoIsoEG_(false),
+      autoProcessNameL1ExtraIsoEG_(false),
+      autoProcessNameL1ExtraCenJet_(false),
+      autoProcessNameL1ExtraForJet_(false),
+      autoProcessNameL1ExtraTauJet_(false),
+      autoProcessNameL1ExtraETM_(false),
+      autoProcessNameL1ExtraHTM_(false),
+      mainBxOnly_(true),
+      saveL1Refs_(false),
+      hltPrescaleProvider_(iConfig, consumesCollector(), *this),
+      hltConfigInit_(false),
+      // HLT configuration parameters
+      tagTriggerResults_("TriggerResults"),
+      tagTriggerEvent_("hltTriggerSummaryAOD"),
+      hltPrescaleLabel_(),
+      labelHltPrescaleTable_(),
+      hltPrescaleTableRun_(),
+      hltPrescaleTableLumi_(),
+      addPathModuleLabels_(false),
+      packPathNames_(iConfig.existsAs<bool>("packTriggerPathNames") ? iConfig.getParameter<bool>("packTriggerPathNames")
+                                                                    : false),
+      packLabels_(iConfig.existsAs<bool>("packTriggerLabels") ? iConfig.getParameter<bool>("packTriggerLabels") : true),
+      packPrescales_(iConfig.existsAs<bool>("packTriggerPrescales") ? iConfig.getParameter<bool>("packTriggerPrescales")
+                                                                    : true) {
   // L1 configuration parameters
-  addL1Algos_( false ),
-  tagL1GlobalTriggerObjectMaps_( "l1L1GtObjectMap" ),
-  tagL1ExtraMu_(),
-  tagL1ExtraNoIsoEG_(),
-  tagL1ExtraIsoEG_(),
-  tagL1ExtraCenJet_(),
-  tagL1ExtraForJet_(),
-  tagL1ExtraTauJet_(),
-  tagL1ExtraETM_(),
-  tagL1ExtraHTM_(),
-  autoProcessNameL1ExtraMu_( false ),
-  autoProcessNameL1ExtraNoIsoEG_( false ),
-  autoProcessNameL1ExtraIsoEG_( false ),
-  autoProcessNameL1ExtraCenJet_( false ),
-  autoProcessNameL1ExtraForJet_( false ),
-  autoProcessNameL1ExtraTauJet_( false ),
-  autoProcessNameL1ExtraETM_( false ),
-  autoProcessNameL1ExtraHTM_( false ),
-  mainBxOnly_( true ),
-  saveL1Refs_( false ),
-  hltPrescaleProvider_(iConfig, consumesCollector(), *this),
-  hltConfigInit_( false ),
-  // HLT configuration parameters
-  tagTriggerResults_( "TriggerResults" ),
-  tagTriggerEvent_( "hltTriggerSummaryAOD" ),
-  hltPrescaleLabel_(),
-  labelHltPrescaleTable_(),
-  hltPrescaleTableRun_(),
-  hltPrescaleTableLumi_(),
-  addPathModuleLabels_( false ),
-  packPathNames_( iConfig.existsAs<bool>("packTriggerPathNames") ? iConfig.getParameter<bool>("packTriggerPathNames") : false ),
-  packLabels_( iConfig.existsAs<bool>("packTriggerLabels") ? iConfig.getParameter<bool>("packTriggerLabels") : true ),
-  packPrescales_( iConfig.existsAs<bool>("packTriggerPrescales") ? iConfig.getParameter<bool>("packTriggerPrescales") : true )
-{
-
-  // L1 configuration parameters
-  if ( iConfig.exists( "addL1Algos" ) ) addL1Algos_ = iConfig.getParameter< bool >( "addL1Algos" );
-  if ( iConfig.exists( "l1GlobalTriggerObjectMaps" ) ) tagL1GlobalTriggerObjectMaps_ = iConfig.getParameter< InputTag >( "l1GlobalTriggerObjectMaps" );
-  l1GlobalTriggerObjectMapsToken_ = mayConsume< L1GlobalTriggerObjectMaps >( tagL1GlobalTriggerObjectMaps_ );
-  if ( iConfig.exists( "l1ExtraMu" ) ) {
-    tagL1ExtraMu_ = iConfig.getParameter< InputTag >( "l1ExtraMu" );
-    if ( tagL1ExtraMu_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraMu_ = true;
-      else                    tagL1ExtraMu_ = InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance(), nameProcess_ );
+  if (iConfig.exists("addL1Algos"))
+    addL1Algos_ = iConfig.getParameter<bool>("addL1Algos");
+  if (iConfig.exists("l1GlobalTriggerObjectMaps"))
+    tagL1GlobalTriggerObjectMaps_ = iConfig.getParameter<InputTag>("l1GlobalTriggerObjectMaps");
+  l1GlobalTriggerObjectMapsToken_ = mayConsume<L1GlobalTriggerObjectMaps>(tagL1GlobalTriggerObjectMaps_);
+  if (iConfig.exists("l1ExtraMu")) {
+    tagL1ExtraMu_ = iConfig.getParameter<InputTag>("l1ExtraMu");
+    if (tagL1ExtraMu_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraMu_ = true;
+      else
+        tagL1ExtraMu_ = InputTag(tagL1ExtraMu_.label(), tagL1ExtraMu_.instance(), nameProcess_);
     }
-    l1ExtraMuGetter_ = GetterOfProducts< l1extra::L1MuonParticleCollection >( InputTagMatch( InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() ) ), this);
+    l1ExtraMuGetter_ = GetterOfProducts<l1extra::L1MuonParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraMu_.label(), tagL1ExtraMu_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) {
-    tagL1ExtraNoIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraNoIsoEG" );
-    if ( tagL1ExtraNoIsoEG_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraNoIsoEG_ = true;
-      else                    tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraNoIsoEG")) {
+    tagL1ExtraNoIsoEG_ = iConfig.getParameter<InputTag>("l1ExtraNoIsoEG");
+    if (tagL1ExtraNoIsoEG_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraNoIsoEG_ = true;
+      else
+        tagL1ExtraNoIsoEG_ = InputTag(tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_);
     }
-    l1ExtraNoIsoEGGetter_ = GetterOfProducts< l1extra::L1EmParticleCollection >( InputTagMatch( InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() ) ), this);
+    l1ExtraNoIsoEGGetter_ = GetterOfProducts<l1extra::L1EmParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraIsoEG" ) ) {
-    tagL1ExtraIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraIsoEG" );
-    if ( tagL1ExtraIsoEG_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraIsoEG_ = true;
-      else                    tagL1ExtraIsoEG_ = InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraIsoEG")) {
+    tagL1ExtraIsoEG_ = iConfig.getParameter<InputTag>("l1ExtraIsoEG");
+    if (tagL1ExtraIsoEG_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraIsoEG_ = true;
+      else
+        tagL1ExtraIsoEG_ = InputTag(tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance(), nameProcess_);
     }
-    l1ExtraIsoEGGetter_ = GetterOfProducts< l1extra::L1EmParticleCollection >( InputTagMatch( InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() ) ), this);
+    l1ExtraIsoEGGetter_ = GetterOfProducts<l1extra::L1EmParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraCenJet" ) ) {
-    tagL1ExtraCenJet_ = iConfig.getParameter< InputTag >( "l1ExtraCenJet" );
-    if ( tagL1ExtraCenJet_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraCenJet_ = true;
-      else                    tagL1ExtraCenJet_ = InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraCenJet")) {
+    tagL1ExtraCenJet_ = iConfig.getParameter<InputTag>("l1ExtraCenJet");
+    if (tagL1ExtraCenJet_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraCenJet_ = true;
+      else
+        tagL1ExtraCenJet_ = InputTag(tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance(), nameProcess_);
     }
-    l1ExtraCenJetGetter_ = GetterOfProducts< l1extra::L1JetParticleCollection >( InputTagMatch( InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() ) ), this);
+    l1ExtraCenJetGetter_ = GetterOfProducts<l1extra::L1JetParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraForJet" ) ) {
-    tagL1ExtraForJet_ = iConfig.getParameter< InputTag >( "l1ExtraForJet" );
-    if ( tagL1ExtraForJet_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraForJet_ = true;
-      else                    tagL1ExtraForJet_ = InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraForJet")) {
+    tagL1ExtraForJet_ = iConfig.getParameter<InputTag>("l1ExtraForJet");
+    if (tagL1ExtraForJet_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraForJet_ = true;
+      else
+        tagL1ExtraForJet_ = InputTag(tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance(), nameProcess_);
     }
-    l1ExtraForJetGetter_ = GetterOfProducts< l1extra::L1JetParticleCollection >( InputTagMatch( InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() ) ), this);
+    l1ExtraForJetGetter_ = GetterOfProducts<l1extra::L1JetParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraTauJet" ) ) {
-    tagL1ExtraTauJet_ = iConfig.getParameter< InputTag >( "l1ExtraTauJet" );
-    if ( tagL1ExtraTauJet_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraTauJet_ = true;
-      else                    tagL1ExtraTauJet_ = InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraTauJet")) {
+    tagL1ExtraTauJet_ = iConfig.getParameter<InputTag>("l1ExtraTauJet");
+    if (tagL1ExtraTauJet_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraTauJet_ = true;
+      else
+        tagL1ExtraTauJet_ = InputTag(tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance(), nameProcess_);
     }
-    l1ExtraTauJetGetter_ = GetterOfProducts< l1extra::L1JetParticleCollection >( InputTagMatch( InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() ) ), this);
+    l1ExtraTauJetGetter_ = GetterOfProducts<l1extra::L1JetParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraETM" ) ) {
-    tagL1ExtraETM_ = iConfig.getParameter< InputTag >( "l1ExtraETM" );
-    if ( tagL1ExtraETM_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraETM_ = true;
-      else                    tagL1ExtraETM_ = InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraETM")) {
+    tagL1ExtraETM_ = iConfig.getParameter<InputTag>("l1ExtraETM");
+    if (tagL1ExtraETM_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraETM_ = true;
+      else
+        tagL1ExtraETM_ = InputTag(tagL1ExtraETM_.label(), tagL1ExtraETM_.instance(), nameProcess_);
     }
-    l1ExtraETMGetter_ = GetterOfProducts< l1extra::L1EtMissParticleCollection >( InputTagMatch( InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() ) ), this);
+    l1ExtraETMGetter_ = GetterOfProducts<l1extra::L1EtMissParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraETM_.label(), tagL1ExtraETM_.instance())), this);
   }
-  if ( iConfig.exists( "l1ExtraHTM" ) ) {
-    tagL1ExtraHTM_ = iConfig.getParameter< InputTag >( "l1ExtraHTM" );
-    if ( tagL1ExtraHTM_.process() == "*" ) {
-      if ( autoProcessName_ ) autoProcessNameL1ExtraHTM_ = true;
-      else                    tagL1ExtraHTM_ = InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance(), nameProcess_ );
+  if (iConfig.exists("l1ExtraHTM")) {
+    tagL1ExtraHTM_ = iConfig.getParameter<InputTag>("l1ExtraHTM");
+    if (tagL1ExtraHTM_.process() == "*") {
+      if (autoProcessName_)
+        autoProcessNameL1ExtraHTM_ = true;
+      else
+        tagL1ExtraHTM_ = InputTag(tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance(), nameProcess_);
     }
-    l1ExtraHTMGetter_ = GetterOfProducts< l1extra::L1EtMissParticleCollection >( InputTagMatch( InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() ) ), this);
+    l1ExtraHTMGetter_ = GetterOfProducts<l1extra::L1EtMissParticleCollection>(
+        InputTagMatch(InputTag(tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance())), this);
   }
-  if ( iConfig.exists( "mainBxOnly" ) ) mainBxOnly_ = iConfig.getParameter< bool >( "mainBxOnly" );
-  if ( iConfig.exists( "saveL1Refs" ) ) saveL1Refs_ = iConfig.getParameter< bool >( "saveL1Refs" );
+  if (iConfig.exists("mainBxOnly"))
+    mainBxOnly_ = iConfig.getParameter<bool>("mainBxOnly");
+  if (iConfig.exists("saveL1Refs"))
+    saveL1Refs_ = iConfig.getParameter<bool>("saveL1Refs");
 
   // HLT configuration parameters
-  if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
-  triggerResultsGetter_ = GetterOfProducts< TriggerResults >( InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance(), autoProcessName_ ? std::string("") : nameProcess_  ) ), this);
-  if ( iConfig.exists( "triggerEvent" ) ) tagTriggerEvent_ = iConfig.getParameter< InputTag >( "triggerEvent" );
-  triggerEventGetter_ = GetterOfProducts< trigger::TriggerEvent >( InputTagMatch( InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance() ) ), this);
-  if ( iConfig.exists( "hltPrescaleLabel" ) )    hltPrescaleLabel_      = iConfig.getParameter< std::string >( "hltPrescaleLabel" );
-  if ( iConfig.exists( "hltPrescaleTable" ) ) {
-    labelHltPrescaleTable_ = iConfig.getParameter< std::string >( "hltPrescaleTable" );
-    hltPrescaleTableRunGetter_ = GetterOfProducts< trigger::HLTPrescaleTable >( InputTagMatch( InputTag( labelHltPrescaleTable_, "Run" ) ), this, InRun );
-    hltPrescaleTableLumiGetter_ = GetterOfProducts< trigger::HLTPrescaleTable >( InputTagMatch( InputTag( labelHltPrescaleTable_, "Lumi" ) ), this, InLumi );
-    hltPrescaleTableEventGetter_ = GetterOfProducts< trigger::HLTPrescaleTable >( InputTagMatch( InputTag( labelHltPrescaleTable_, "Event" ) ), this );
+  if (iConfig.exists("triggerResults"))
+    tagTriggerResults_ = iConfig.getParameter<InputTag>("triggerResults");
+  triggerResultsGetter_ =
+      GetterOfProducts<TriggerResults>(InputTagMatch(InputTag(tagTriggerResults_.label(),
+                                                              tagTriggerResults_.instance(),
+                                                              autoProcessName_ ? std::string("") : nameProcess_)),
+                                       this);
+  if (iConfig.exists("triggerEvent"))
+    tagTriggerEvent_ = iConfig.getParameter<InputTag>("triggerEvent");
+  triggerEventGetter_ = GetterOfProducts<trigger::TriggerEvent>(
+      InputTagMatch(InputTag(tagTriggerEvent_.label(), tagTriggerEvent_.instance())), this);
+  if (iConfig.exists("hltPrescaleLabel"))
+    hltPrescaleLabel_ = iConfig.getParameter<std::string>("hltPrescaleLabel");
+  if (iConfig.exists("hltPrescaleTable")) {
+    labelHltPrescaleTable_ = iConfig.getParameter<std::string>("hltPrescaleTable");
+    hltPrescaleTableRunGetter_ = GetterOfProducts<trigger::HLTPrescaleTable>(
+        InputTagMatch(InputTag(labelHltPrescaleTable_, "Run")), this, InRun);
+    hltPrescaleTableLumiGetter_ = GetterOfProducts<trigger::HLTPrescaleTable>(
+        InputTagMatch(InputTag(labelHltPrescaleTable_, "Lumi")), this, InLumi);
+    hltPrescaleTableEventGetter_ =
+        GetterOfProducts<trigger::HLTPrescaleTable>(InputTagMatch(InputTag(labelHltPrescaleTable_, "Event")), this);
   }
-  if ( iConfig.exists( "addPathModuleLabels" ) ) addPathModuleLabels_ = iConfig.getParameter< bool >( "addPathModuleLabels" );
+  if (iConfig.exists("addPathModuleLabels"))
+    addPathModuleLabels_ = iConfig.getParameter<bool>("addPathModuleLabels");
   exludeCollections_.clear();
-  if ( iConfig.exists( "exludeCollections" )  ) exludeCollections_ = iConfig.getParameter< std::vector< std::string > >( "exludeCollections" );
+  if (iConfig.exists("exludeCollections"))
+    exludeCollections_ = iConfig.getParameter<std::vector<std::string> >("exludeCollections");
 
-  callWhenNewProductsRegistered( [ this, &iConfig ]( BranchDescription const& bd ) {
-    if ( iConfig.exists( "l1ExtraMu" ) ) l1ExtraMuGetter_( bd );
-    if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) l1ExtraNoIsoEGGetter_( bd );
-    if ( iConfig.exists( "l1ExtraIsoEG" ) ) l1ExtraIsoEGGetter_( bd );
-    if ( iConfig.exists( "l1ExtraCenJet" ) ) l1ExtraCenJetGetter_( bd );
-    if ( iConfig.exists( "l1ExtraForJet" ) ) l1ExtraForJetGetter_( bd );
-    if ( iConfig.exists( "l1ExtraTauJet" ) ) l1ExtraTauJetGetter_( bd );
-    if ( iConfig.exists( "l1ExtraETM" ) ) l1ExtraETMGetter_( bd );
-    if ( iConfig.exists( "l1ExtraHTM" ) ) l1ExtraHTMGetter_( bd );
-    if(not ( this->autoProcessName_ and bd.processName()==this->moduleDescription().processName()) ) {
-      triggerResultsGetter_( bd );
+  callWhenNewProductsRegistered([this, &iConfig](BranchDescription const& bd) {
+    if (iConfig.exists("l1ExtraMu"))
+      l1ExtraMuGetter_(bd);
+    if (iConfig.exists("l1ExtraNoIsoEG"))
+      l1ExtraNoIsoEGGetter_(bd);
+    if (iConfig.exists("l1ExtraIsoEG"))
+      l1ExtraIsoEGGetter_(bd);
+    if (iConfig.exists("l1ExtraCenJet"))
+      l1ExtraCenJetGetter_(bd);
+    if (iConfig.exists("l1ExtraForJet"))
+      l1ExtraForJetGetter_(bd);
+    if (iConfig.exists("l1ExtraTauJet"))
+      l1ExtraTauJetGetter_(bd);
+    if (iConfig.exists("l1ExtraETM"))
+      l1ExtraETMGetter_(bd);
+    if (iConfig.exists("l1ExtraHTM"))
+      l1ExtraHTMGetter_(bd);
+    if (not(this->autoProcessName_ and bd.processName() == this->moduleDescription().processName())) {
+      triggerResultsGetter_(bd);
     }
-    triggerEventGetter_( bd );
-    if ( iConfig.exists( "hltPrescaleTable" ) ) {
-      hltPrescaleTableRunGetter_( bd );
-      hltPrescaleTableLumiGetter_( bd );
-      hltPrescaleTableEventGetter_( bd );
+    triggerEventGetter_(bd);
+    if (iConfig.exists("hltPrescaleTable")) {
+      hltPrescaleTableRunGetter_(bd);
+      hltPrescaleTableLumiGetter_(bd);
+      hltPrescaleTableEventGetter_(bd);
     }
-  } );
+  });
 
-  if ( ! onlyStandAlone_ ) {
-    produces< TriggerAlgorithmCollection >();
-    produces< TriggerConditionCollection >();
-    produces< TriggerPathCollection >();
-    produces< TriggerFilterCollection >();
-    produces< TriggerObjectCollection >();
+  if (!onlyStandAlone_) {
+    produces<TriggerAlgorithmCollection>();
+    produces<TriggerConditionCollection>();
+    produces<TriggerPathCollection>();
+    produces<TriggerFilterCollection>();
+    produces<TriggerObjectCollection>();
   }
   if (packPrescales_) {
-    produces< PackedTriggerPrescales >();
-    produces< PackedTriggerPrescales >("l1max");
-    produces< PackedTriggerPrescales >("l1min");
+    produces<PackedTriggerPrescales>();
+    produces<PackedTriggerPrescales>("l1max");
+    produces<PackedTriggerPrescales>("l1min");
   }
-  produces< TriggerObjectStandAloneCollection >();
-
+  produces<TriggerObjectStandAloneCollection>();
 }
 
-
-void PATTriggerProducer::beginRun(const Run & iRun, const EventSetup & iSetup )
-{
-
+void PATTriggerProducer::beginRun(const Run& iRun, const EventSetup& iSetup) {
   // Initialize
-  firstInRun_    = true;
-  l1PSet_        = nullptr;
+  firstInRun_ = true;
+  l1PSet_ = nullptr;
   hltConfigInit_ = false;
 
   // Initialize process name
-  if ( autoProcessName_ ) {
+  if (autoProcessName_) {
     // reset
     nameProcess_ = "*";
     // determine process name from last run TriggerSummaryProducerAOD module in process history of input
-    const ProcessHistory & processHistory( iRun.processHistory() );
+    const ProcessHistory& processHistory(iRun.processHistory());
     ProcessConfiguration processConfiguration;
     ParameterSet processPSet;
     // unbroken loop, which relies on time ordering (accepts the last found entry)
-    for ( ProcessHistory::const_iterator iHist = processHistory.begin(); iHist != processHistory.end(); ++iHist ) {
-      if ( processHistory.getConfigurationForProcess( iHist->processName(), processConfiguration )     &&
-           pset::Registry::instance()->getMapped( processConfiguration.parameterSetID(), processPSet ) &&
-           processPSet.exists( tagTriggerEvent_.label() )
-         ) {
+    for (ProcessHistory::const_iterator iHist = processHistory.begin(); iHist != processHistory.end(); ++iHist) {
+      if (processHistory.getConfigurationForProcess(iHist->processName(), processConfiguration) &&
+          pset::Registry::instance()->getMapped(processConfiguration.parameterSetID(), processPSet) &&
+          processPSet.exists(tagTriggerEvent_.label())) {
         nameProcess_ = iHist->processName();
-        LogDebug( "autoProcessName" ) << "HLT process name '" << nameProcess_ << "' discovered";
+        LogDebug("autoProcessName") << "HLT process name '" << nameProcess_ << "' discovered";
       }
     }
     // terminate, if nothing is found
-    if ( nameProcess_ == "*" ) {
-      LogError( "autoProcessName" ) << "trigger::TriggerEvent product with label '" << tagTriggerEvent_.label() << "' not produced according to process history of input data\n"
-                                    << "No trigger information produced";
+    if (nameProcess_ == "*") {
+      LogError("autoProcessName") << "trigger::TriggerEvent product with label '" << tagTriggerEvent_.label()
+                                  << "' not produced according to process history of input data\n"
+                                  << "No trigger information produced";
       return;
     }
-    LogInfo( "autoProcessName" ) << "HLT process name' " << nameProcess_ << "' used for PAT trigger information";
+    LogInfo("autoProcessName") << "HLT process name' " << nameProcess_ << "' used for PAT trigger information";
   }
   // adapt configuration of used input tags
-  if ( tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*" ) {
-    tagTriggerResults_ = InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_ );
-  } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
-    LogWarning( "inputTags" ) << "TriggerResults process name '" << tagTriggerResults_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
+  if (tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*") {
+    tagTriggerResults_ = InputTag(tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_);
+  } else if (tagTriggerEvent_.process() != nameProcess_) {
+    LogWarning("inputTags") << "TriggerResults process name '" << tagTriggerResults_.process()
+                            << "' differs from HLT process name '" << nameProcess_ << "'";
   }
-  if ( tagTriggerEvent_.process().empty() || tagTriggerEvent_.process()   == "*" ) {
-    tagTriggerEvent_ = InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_ );
-  } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
-    LogWarning( "inputTags" ) << "TriggerEvent process name '" << tagTriggerEvent_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
+  if (tagTriggerEvent_.process().empty() || tagTriggerEvent_.process() == "*") {
+    tagTriggerEvent_ = InputTag(tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_);
+  } else if (tagTriggerEvent_.process() != nameProcess_) {
+    LogWarning("inputTags") << "TriggerEvent process name '" << tagTriggerEvent_.process()
+                            << "' differs from HLT process name '" << nameProcess_ << "'";
   }
-  if ( autoProcessNameL1ExtraMu_ )      tagL1ExtraMu_      = InputTag( tagL1ExtraMu_.label()     , tagL1ExtraMu_.instance()     , nameProcess_ );
-  if ( autoProcessNameL1ExtraNoIsoEG_ ) tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
-  if ( autoProcessNameL1ExtraIsoEG_ )   tagL1ExtraIsoEG_   = InputTag( tagL1ExtraIsoEG_.label()  , tagL1ExtraIsoEG_.instance()  , nameProcess_ );
-  if ( autoProcessNameL1ExtraCenJet_ )  tagL1ExtraCenJet_  = InputTag( tagL1ExtraCenJet_.label() , tagL1ExtraCenJet_.instance() , nameProcess_ );
-  if ( autoProcessNameL1ExtraForJet_ )  tagL1ExtraForJet_  = InputTag( tagL1ExtraForJet_.label() , tagL1ExtraForJet_.instance() , nameProcess_ );
-  if ( autoProcessNameL1ExtraTauJet_ )  tagL1ExtraTauJet_  = InputTag( tagL1ExtraTauJet_.label() , tagL1ExtraTauJet_.instance() , nameProcess_ );
-  if ( autoProcessNameL1ExtraETM_ )     tagL1ExtraETM_     = InputTag( tagL1ExtraETM_.label()    , tagL1ExtraETM_.instance()    , nameProcess_ );
-  if ( autoProcessNameL1ExtraHTM_ )     tagL1ExtraHTM_     = InputTag( tagL1ExtraHTM_.label()    , tagL1ExtraHTM_.instance()    , nameProcess_ );
+  if (autoProcessNameL1ExtraMu_)
+    tagL1ExtraMu_ = InputTag(tagL1ExtraMu_.label(), tagL1ExtraMu_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraNoIsoEG_)
+    tagL1ExtraNoIsoEG_ = InputTag(tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraIsoEG_)
+    tagL1ExtraIsoEG_ = InputTag(tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraCenJet_)
+    tagL1ExtraCenJet_ = InputTag(tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraForJet_)
+    tagL1ExtraForJet_ = InputTag(tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraTauJet_)
+    tagL1ExtraTauJet_ = InputTag(tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraETM_)
+    tagL1ExtraETM_ = InputTag(tagL1ExtraETM_.label(), tagL1ExtraETM_.instance(), nameProcess_);
+  if (autoProcessNameL1ExtraHTM_)
+    tagL1ExtraHTM_ = InputTag(tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance(), nameProcess_);
 
   // Initialize HLTConfigProvider
-  HLTConfigProvider const&  hltConfig = hltPrescaleProvider_.hltConfigProvider();
-  bool changed( true );
-  if ( ! hltPrescaleProvider_.init( iRun, iSetup, nameProcess_, changed ) ) {
-    LogError( "hltConfig" ) << "HLT config extraction error with process name '" << nameProcess_ << "'";
-  } else if ( hltConfig.size() <= 0 ) {
-    LogError( "hltConfig" ) << "HLT config size error";
-  } else hltConfigInit_ = true;
+  HLTConfigProvider const& hltConfig = hltPrescaleProvider_.hltConfigProvider();
+  bool changed(true);
+  if (!hltPrescaleProvider_.init(iRun, iSetup, nameProcess_, changed)) {
+    LogError("hltConfig") << "HLT config extraction error with process name '" << nameProcess_ << "'";
+  } else if (hltConfig.size() <= 0) {
+    LogError("hltConfig") << "HLT config size error";
+  } else
+    hltConfigInit_ = true;
 
   // Update mapping from filter names to path names
-  if (hltConfigInit_ && changed) moduleLabelToPathAndFlags_.init( hltConfig );
+  if (hltConfigInit_ && changed)
+    moduleLabelToPathAndFlags_.init(hltConfig);
 
   // Extract pre-scales
-  if ( hltConfigInit_ ) {
+  if (hltConfigInit_) {
     // Start empty
     hltPrescaleTableRun_ = trigger::HLTPrescaleTable();
     // Try run product, if configured
-    if ( ! labelHltPrescaleTable_.empty() ) {
-      Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
-      iRun.getByLabel( InputTag( labelHltPrescaleTable_, "Run", nameProcess_ ), handleHltPrescaleTable );
-      if ( handleHltPrescaleTable.isValid() ) {
-        hltPrescaleTableRun_ = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
+    if (!labelHltPrescaleTable_.empty()) {
+      Handle<trigger::HLTPrescaleTable> handleHltPrescaleTable;
+      iRun.getByLabel(InputTag(labelHltPrescaleTable_, "Run", nameProcess_), handleHltPrescaleTable);
+      if (handleHltPrescaleTable.isValid()) {
+        hltPrescaleTableRun_ = trigger::HLTPrescaleTable(
+            handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table());
       }
     }
   }
-
 }
 
-
-void PATTriggerProducer::beginLuminosityBlock(const LuminosityBlock & iLuminosityBlock, const EventSetup & iSetup )
-{
-
+void PATTriggerProducer::beginLuminosityBlock(const LuminosityBlock& iLuminosityBlock, const EventSetup& iSetup) {
   // Terminate, if auto process name determination failed
-  if ( nameProcess_ == "*" ) return;
+  if (nameProcess_ == "*")
+    return;
 
   // Extract pre-scales
-  if ( hltConfigInit_ ) {
+  if (hltConfigInit_) {
     // Start from run
-    hltPrescaleTableLumi_ = trigger::HLTPrescaleTable( hltPrescaleTableRun_.set(), hltPrescaleTableRun_.labels(), hltPrescaleTableRun_.table() );
+    hltPrescaleTableLumi_ = trigger::HLTPrescaleTable(
+        hltPrescaleTableRun_.set(), hltPrescaleTableRun_.labels(), hltPrescaleTableRun_.table());
     // Try lumi product, if configured and available
-    if ( ! labelHltPrescaleTable_.empty() ) {
-      Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
-      iLuminosityBlock.getByLabel( InputTag( labelHltPrescaleTable_, "Lumi", nameProcess_ ), handleHltPrescaleTable );
-      if ( handleHltPrescaleTable.isValid() ) {
-        hltPrescaleTableLumi_ = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
+    if (!labelHltPrescaleTable_.empty()) {
+      Handle<trigger::HLTPrescaleTable> handleHltPrescaleTable;
+      iLuminosityBlock.getByLabel(InputTag(labelHltPrescaleTable_, "Lumi", nameProcess_), handleHltPrescaleTable);
+      if (handleHltPrescaleTable.isValid()) {
+        hltPrescaleTableLumi_ = trigger::HLTPrescaleTable(
+            handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table());
       }
     }
   }
-
 }
 
-
-void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
-{
-
+void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   // Terminate, if auto process name determination failed
-  if ( nameProcess_ == "*" ) return;
+  if (nameProcess_ == "*")
+    return;
 
   auto triggerObjects = std::make_unique<TriggerObjectCollection>();
   auto triggerObjectsStandAlone = std::make_unique<TriggerObjectStandAloneCollection>();
   std::unique_ptr<PackedTriggerPrescales> packedPrescales, packedPrescalesL1min, packedPrescalesL1max;
 
   // HLT
-  HLTConfigProvider const&  hltConfig = hltPrescaleProvider_.hltConfigProvider();
+  HLTConfigProvider const& hltConfig = hltPrescaleProvider_.hltConfigProvider();
 
   // Get and check HLT event data
-  Handle< trigger::TriggerEvent > handleTriggerEvent;
-  iEvent.getByLabel( tagTriggerEvent_, handleTriggerEvent );
-  Handle< TriggerResults > handleTriggerResults;
-  iEvent.getByLabel( tagTriggerResults_, handleTriggerResults );
-  bool goodHlt( hltConfigInit_ );
-  if ( goodHlt ) {
-    if( ! handleTriggerResults.isValid() ) {
-      LogError( "triggerResultsValid" ) << "TriggerResults product with InputTag '" << tagTriggerResults_.encode() << "' not in event\n"
-                                        << "No HLT information produced";
-      goodHlt = false;
-    } else if ( ! handleTriggerEvent.isValid() ) {
-      LogError( "triggerEventValid" ) << "trigger::TriggerEvent product with InputTag '" << tagTriggerEvent_.encode() << "' not in event\n"
+  Handle<trigger::TriggerEvent> handleTriggerEvent;
+  iEvent.getByLabel(tagTriggerEvent_, handleTriggerEvent);
+  Handle<TriggerResults> handleTriggerResults;
+  iEvent.getByLabel(tagTriggerResults_, handleTriggerResults);
+  bool goodHlt(hltConfigInit_);
+  if (goodHlt) {
+    if (!handleTriggerResults.isValid()) {
+      LogError("triggerResultsValid") << "TriggerResults product with InputTag '" << tagTriggerResults_.encode()
+                                      << "' not in event\n"
                                       << "No HLT information produced";
+      goodHlt = false;
+    } else if (!handleTriggerEvent.isValid()) {
+      LogError("triggerEventValid") << "trigger::TriggerEvent product with InputTag '" << tagTriggerEvent_.encode()
+                                    << "' not in event\n"
+                                    << "No HLT information produced";
       goodHlt = false;
     }
   }
 
   // Produce HLT paths and determine status of modules
 
-  if ( goodHlt ) {
-
+  if (goodHlt) {
     // Extract pre-scales
     // Start from lumi
-    trigger::HLTPrescaleTable hltPrescaleTable( hltPrescaleTableLumi_.set(), hltPrescaleTableLumi_.labels(), hltPrescaleTableLumi_.table() );
+    trigger::HLTPrescaleTable hltPrescaleTable(
+        hltPrescaleTableLumi_.set(), hltPrescaleTableLumi_.labels(), hltPrescaleTableLumi_.table());
     // Try event product, if configured and available
-    if ( ! labelHltPrescaleTable_.empty() ) {
-      Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
-      iEvent.getByLabel( InputTag( labelHltPrescaleTable_, "Event", nameProcess_ ), handleHltPrescaleTable );
-      if ( handleHltPrescaleTable.isValid() ) {
-        hltPrescaleTable = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
+    if (!labelHltPrescaleTable_.empty()) {
+      Handle<trigger::HLTPrescaleTable> handleHltPrescaleTable;
+      iEvent.getByLabel(InputTag(labelHltPrescaleTable_, "Event", nameProcess_), handleHltPrescaleTable);
+      if (handleHltPrescaleTable.isValid()) {
+        hltPrescaleTable = trigger::HLTPrescaleTable(
+            handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table());
       }
     }
     // Try event setup, if no product
-    if ( hltPrescaleTable.size() == 0 ) {
-      if ( ! labelHltPrescaleTable_.empty() ) {
-        LogWarning( "hltPrescaleInputTag" ) << "HLTPrescaleTable product with label '" << labelHltPrescaleTable_ << "' not found in process" << nameProcess_ << "\n"
-                                            << "Using default from event setup";
+    if (hltPrescaleTable.size() == 0) {
+      if (!labelHltPrescaleTable_.empty()) {
+        LogWarning("hltPrescaleInputTag") << "HLTPrescaleTable product with label '" << labelHltPrescaleTable_
+                                          << "' not found in process" << nameProcess_ << "\n"
+                                          << "Using default from event setup";
       }
-      if ( hltConfig.prescaleSize() > 0 ) {
-        if ( hltPrescaleProvider_.prescaleSet( iEvent, iSetup ) != -1 ) {
-          hltPrescaleTable = trigger::HLTPrescaleTable( hltPrescaleProvider_.prescaleSet( iEvent, iSetup ), hltConfig.prescaleLabels(), hltConfig.prescaleTable() );
-          LogDebug( "hltPrescaleTable" ) << "HLT prescale table found in event setup";
+      if (hltConfig.prescaleSize() > 0) {
+        if (hltPrescaleProvider_.prescaleSet(iEvent, iSetup) != -1) {
+          hltPrescaleTable = trigger::HLTPrescaleTable(
+              hltPrescaleProvider_.prescaleSet(iEvent, iSetup), hltConfig.prescaleLabels(), hltConfig.prescaleTable());
+          LogDebug("hltPrescaleTable") << "HLT prescale table found in event setup";
         } else {
-          LogWarning( "hltPrescaleSet" ) << "HLTPrescaleTable from event setup has error";
+          LogWarning("hltPrescaleSet") << "HLTPrescaleTable from event setup has error";
         }
       }
     }
-    unsigned set( hltPrescaleTable.set() );
-    if ( hltPrescaleTable.size() > 0 ) {
-      if ( !hltPrescaleLabel_.empty() ) {
-        bool foundPrescaleLabel( false );
-        for ( unsigned iLabel = 0; iLabel <  hltPrescaleTable.labels().size(); ++iLabel ) {
-          if ( hltPrescaleTable.labels().at( iLabel ) == hltPrescaleLabel_ ) {
-            set                = iLabel;
+    unsigned set(hltPrescaleTable.set());
+    if (hltPrescaleTable.size() > 0) {
+      if (!hltPrescaleLabel_.empty()) {
+        bool foundPrescaleLabel(false);
+        for (unsigned iLabel = 0; iLabel < hltPrescaleTable.labels().size(); ++iLabel) {
+          if (hltPrescaleTable.labels().at(iLabel) == hltPrescaleLabel_) {
+            set = iLabel;
             foundPrescaleLabel = true;
             break;
           }
         }
-        if ( ! foundPrescaleLabel ) {
-          LogWarning( "hltPrescaleLabel" ) << "HLT prescale label '" << hltPrescaleLabel_ << "' not in prescale table\n"
-                                           << "Using default";
+        if (!foundPrescaleLabel) {
+          LogWarning("hltPrescaleLabel") << "HLT prescale label '" << hltPrescaleLabel_ << "' not in prescale table\n"
+                                         << "Using default";
         }
       }
-    } else if ( iEvent.isRealData() ) {
-      if ( ( labelHltPrescaleTable_.empty() && firstInRun_ ) || ! labelHltPrescaleTable_.empty() ) {
-        LogError( "hltPrescaleTable" ) << "No HLT prescale table found\n"
-                                       << "Using default empty table with all prescales 1";
+    } else if (iEvent.isRealData()) {
+      if ((labelHltPrescaleTable_.empty() && firstInRun_) || !labelHltPrescaleTable_.empty()) {
+        LogError("hltPrescaleTable") << "No HLT prescale table found\n"
+                                     << "Using default empty table with all prescales 1";
       }
     }
 
-    const unsigned sizePaths( hltConfig.size() );
-    const unsigned sizeFilters( handleTriggerEvent->sizeFilters() );
-    const unsigned sizeObjects( handleTriggerEvent->sizeObjects() );
+    const unsigned sizePaths(hltConfig.size());
+    const unsigned sizeFilters(handleTriggerEvent->sizeFilters());
+    const unsigned sizeObjects(handleTriggerEvent->sizeObjects());
 
-    std::map< std::string, int > moduleStates;
+    std::map<std::string, int> moduleStates;
 
-    if ( ! onlyStandAlone_ ) {
+    if (!onlyStandAlone_) {
       auto triggerPaths = std::make_unique<TriggerPathCollection>();
-      triggerPaths->reserve( sizePaths );
-      const std::vector<std::string> & pathNames = hltConfig.triggerNames();
-      for ( size_t indexPath = 0; indexPath < sizePaths; ++indexPath ) {
-        const std::string & namePath = pathNames.at( indexPath );
-        unsigned indexLastFilterPathModules( handleTriggerResults->index( indexPath ) + 1 );
-        while ( indexLastFilterPathModules > 0 ) {
+      triggerPaths->reserve(sizePaths);
+      const std::vector<std::string>& pathNames = hltConfig.triggerNames();
+      for (size_t indexPath = 0; indexPath < sizePaths; ++indexPath) {
+        const std::string& namePath = pathNames.at(indexPath);
+        unsigned indexLastFilterPathModules(handleTriggerResults->index(indexPath) + 1);
+        while (indexLastFilterPathModules > 0) {
           --indexLastFilterPathModules;
-          const std::string & labelLastFilterPathModules( hltConfig.moduleLabel( indexPath, indexLastFilterPathModules ) );
-          unsigned indexLastFilterFilters = handleTriggerEvent->filterIndex( InputTag( labelLastFilterPathModules, "", nameProcess_ ) );
-          if ( indexLastFilterFilters < sizeFilters ) {
-            if ( hltConfig.moduleType( labelLastFilterPathModules ) == "HLTBool" ) continue;
+          const std::string& labelLastFilterPathModules(hltConfig.moduleLabel(indexPath, indexLastFilterPathModules));
+          unsigned indexLastFilterFilters =
+              handleTriggerEvent->filterIndex(InputTag(labelLastFilterPathModules, "", nameProcess_));
+          if (indexLastFilterFilters < sizeFilters) {
+            if (hltConfig.moduleType(labelLastFilterPathModules) == "HLTBool")
+              continue;
             break;
           }
         }
-        TriggerPath triggerPath( namePath, indexPath, hltConfig.prescaleValue( set, namePath ), handleTriggerResults->wasrun( indexPath ), handleTriggerResults->accept( indexPath ), handleTriggerResults->error( indexPath ), indexLastFilterPathModules, hltConfig.saveTagsModules( namePath ).size() );
+        TriggerPath triggerPath(namePath,
+                                indexPath,
+                                hltConfig.prescaleValue(set, namePath),
+                                handleTriggerResults->wasrun(indexPath),
+                                handleTriggerResults->accept(indexPath),
+                                handleTriggerResults->error(indexPath),
+                                indexLastFilterPathModules,
+                                hltConfig.saveTagsModules(namePath).size());
         // add module names to path and states' map
-        const unsigned sizeModulesPath( hltConfig.size( indexPath ) );
-        assert( indexLastFilterPathModules < sizeModulesPath );
-        std::map< unsigned, std::string > indicesModules;
-        for ( size_t iM = 0; iM < sizeModulesPath; ++iM ) {
-          const std::string& nameModule( hltConfig.moduleLabel( indexPath, iM ) );
-          if ( addPathModuleLabels_ ) {
-            triggerPath.addModule( nameModule );
+        const unsigned sizeModulesPath(hltConfig.size(indexPath));
+        assert(indexLastFilterPathModules < sizeModulesPath);
+        std::map<unsigned, std::string> indicesModules;
+        for (size_t iM = 0; iM < sizeModulesPath; ++iM) {
+          const std::string& nameModule(hltConfig.moduleLabel(indexPath, iM));
+          if (addPathModuleLabels_) {
+            triggerPath.addModule(nameModule);
           }
-          const unsigned indexFilter( handleTriggerEvent->filterIndex( InputTag( nameModule, "", nameProcess_ ) ) );
-          if ( indexFilter < sizeFilters ) {
-            triggerPath.addFilterIndex( indexFilter );
+          const unsigned indexFilter(handleTriggerEvent->filterIndex(InputTag(nameModule, "", nameProcess_)));
+          if (indexFilter < sizeFilters) {
+            triggerPath.addFilterIndex(indexFilter);
           }
-          const unsigned slotModule( hltConfig.moduleIndex( indexPath, nameModule ) );
-          indicesModules.insert( std::pair< unsigned, std::string >( slotModule, nameModule ) );
+          const unsigned slotModule(hltConfig.moduleIndex(indexPath, nameModule));
+          indicesModules.insert(std::pair<unsigned, std::string>(slotModule, nameModule));
         }
         // add L1 seeds
-        const L1SeedCollection& l1Seeds( hltConfig.hltL1GTSeeds( namePath ) );
-        for ( L1SeedCollection::const_iterator iSeed = l1Seeds.begin(); iSeed != l1Seeds.end(); ++iSeed ) {
-          triggerPath.addL1Seed( *iSeed );
+        const L1SeedCollection& l1Seeds(hltConfig.hltL1GTSeeds(namePath));
+        for (L1SeedCollection::const_iterator iSeed = l1Seeds.begin(); iSeed != l1Seeds.end(); ++iSeed) {
+          triggerPath.addL1Seed(*iSeed);
         }
         // store path
-        triggerPaths->push_back( triggerPath );
+        triggerPaths->push_back(triggerPath);
         // cache module states to be used for the filters
-        for ( std::map< unsigned, std::string >::const_iterator iM = indicesModules.begin(); iM != indicesModules.end(); ++iM ) {
-          if ( iM->first < indexLastFilterPathModules ) {
-            moduleStates[ iM->second ] = 1;
-          } else if ( iM->first == indexLastFilterPathModules ) {
-            moduleStates[ iM->second ] = handleTriggerResults->accept( indexPath );
-          } else if ( moduleStates.find( iM->second ) == moduleStates.end() ) {
-            moduleStates[ iM->second ] = -1;
+        for (std::map<unsigned, std::string>::const_iterator iM = indicesModules.begin(); iM != indicesModules.end();
+             ++iM) {
+          if (iM->first < indexLastFilterPathModules) {
+            moduleStates[iM->second] = 1;
+          } else if (iM->first == indexLastFilterPathModules) {
+            moduleStates[iM->second] = handleTriggerResults->accept(indexPath);
+          } else if (moduleStates.find(iM->second) == moduleStates.end()) {
+            moduleStates[iM->second] = -1;
           }
         }
       }
@@ -462,555 +528,640 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     // Store used trigger objects and their types for HLT filters
     // (only active filter(s) available from trigger::TriggerEvent)
 
-    std::multimap< trigger::size_type, int >         objectTypes;
-    std::multimap< trigger::size_type, std::string > filterLabels;
+    std::multimap<trigger::size_type, int> objectTypes;
+    std::multimap<trigger::size_type, std::string> filterLabels;
 
-    for ( size_t iF = 0; iF < sizeFilters; ++iF ) {
-      const std::string nameFilter( handleTriggerEvent->filterLabel( iF ) );
-      const trigger::Keys & keys  = handleTriggerEvent->filterKeys( iF );
-      const trigger::Vids & types = handleTriggerEvent->filterIds( iF );
-      assert( types.size() == keys.size() );
-      for ( size_t iK = 0; iK < keys.size(); ++iK ) {
-        filterLabels.insert( std::pair< trigger::size_type, std::string >( keys[ iK ], nameFilter ) );
-        objectTypes.insert( std::pair< trigger::size_type, int >( keys[ iK ], types[ iK ] ) );
+    for (size_t iF = 0; iF < sizeFilters; ++iF) {
+      const std::string nameFilter(handleTriggerEvent->filterLabel(iF));
+      const trigger::Keys& keys = handleTriggerEvent->filterKeys(iF);
+      const trigger::Vids& types = handleTriggerEvent->filterIds(iF);
+      assert(types.size() == keys.size());
+      for (size_t iK = 0; iK < keys.size(); ++iK) {
+        filterLabels.insert(std::pair<trigger::size_type, std::string>(keys[iK], nameFilter));
+        objectTypes.insert(std::pair<trigger::size_type, int>(keys[iK], types[iK]));
       }
     }
 
     // HLT objects
 
-    triggerObjects->reserve( onlyStandAlone_ ? 0 : sizeObjects );
-    triggerObjectsStandAlone->reserve( sizeObjects );
+    triggerObjects->reserve(onlyStandAlone_ ? 0 : sizeObjects);
+    triggerObjectsStandAlone->reserve(sizeObjects);
 
-    const trigger::Keys & collectionKeys( handleTriggerEvent->collectionKeys() );
-    std::map< trigger::size_type, trigger::size_type > newObjectKeys;
-    for ( size_t iO = 0, iC = 0, nC = handleTriggerEvent->sizeCollections(); iO < sizeObjects && iC < nC; ++iO ) {
-      const trigger::TriggerObject tobj = handleTriggerEvent->getObjects().at( iO );
-      TriggerObject triggerObject( reco::Particle::PolarLorentzVector(tobj.pt(), tobj.eta(), tobj.phi(), tobj.mass()), tobj.id()  );
+    const trigger::Keys& collectionKeys(handleTriggerEvent->collectionKeys());
+    std::map<trigger::size_type, trigger::size_type> newObjectKeys;
+    for (size_t iO = 0, iC = 0, nC = handleTriggerEvent->sizeCollections(); iO < sizeObjects && iC < nC; ++iO) {
+      const trigger::TriggerObject tobj = handleTriggerEvent->getObjects().at(iO);
+      TriggerObject triggerObject(reco::Particle::PolarLorentzVector(tobj.pt(), tobj.eta(), tobj.phi(), tobj.mass()),
+                                  tobj.id());
       // set collection
-      while ( iO >= collectionKeys[ iC ] ) ++iC; // relies on well ordering of trigger objects with respect to the collections
-      triggerObject.setCollection( handleTriggerEvent->collectionTagEncoded( iC ) );
+      while (iO >= collectionKeys[iC])
+        ++iC;  // relies on well ordering of trigger objects with respect to the collections
+      triggerObject.setCollection(handleTriggerEvent->collectionTagEncoded(iC));
       // set filter ID
-      typedef std::multimap< trigger::size_type, int >::const_iterator it_type;
-      for (std::pair<it_type,it_type> trange = objectTypes.equal_range(iO);
-          trange.first != trange.second; ++trange.first) {
-          triggerObject.addTriggerObjectType( trange.first->second );
+      typedef std::multimap<trigger::size_type, int>::const_iterator it_type;
+      for (std::pair<it_type, it_type> trange = objectTypes.equal_range(iO); trange.first != trange.second;
+           ++trange.first) {
+        triggerObject.addTriggerObjectType(trange.first->second);
       }
 
       // stand-alone trigger object
-      TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
+      TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
       // check for excluded collections
-      bool excluded( false );
-      for ( size_t iE = 0; iE < exludeCollections_.size(); ++iE ) {
-        if ( triggerObjectStandAlone.hasCollection( exludeCollections_.at( iE ) ) ) {
-          if ( ! onlyStandAlone_ ) newObjectKeys[ iO ] = trigger::size_type( sizeObjects );
+      bool excluded(false);
+      for (size_t iE = 0; iE < exludeCollections_.size(); ++iE) {
+        if (triggerObjectStandAlone.hasCollection(exludeCollections_.at(iE))) {
+          if (!onlyStandAlone_)
+            newObjectKeys[iO] = trigger::size_type(sizeObjects);
           excluded = true;
           break;
         }
       }
-      if ( excluded ) continue;
-      typedef std::multimap< trigger::size_type, std::string >::const_iterator it_fl;
-      for (std::pair<it_fl,it_fl> frange = filterLabels.equal_range(iO); frange.first != frange.second; ++frange.first) {
-          triggerObjectStandAlone.addFilterLabel( frange.first->second );
-          const std::vector<ModuleLabelToPathAndFlags::PathAndFlags> & paths = moduleLabelToPathAndFlags_[frange.first->second];
-          for (std::vector<ModuleLabelToPathAndFlags::PathAndFlags>::const_iterator iP = paths.begin(); iP != paths.end(); ++iP) {
-              bool pathFired = handleTriggerResults->wasrun( iP->pathIndex ) && handleTriggerResults->accept( iP->pathIndex );
-              triggerObjectStandAlone.addPathName( iP->pathName, pathFired && iP->lastFilter, pathFired && iP->l3Filter );
-          }
+      if (excluded)
+        continue;
+      typedef std::multimap<trigger::size_type, std::string>::const_iterator it_fl;
+      for (std::pair<it_fl, it_fl> frange = filterLabels.equal_range(iO); frange.first != frange.second;
+           ++frange.first) {
+        triggerObjectStandAlone.addFilterLabel(frange.first->second);
+        const std::vector<ModuleLabelToPathAndFlags::PathAndFlags>& paths =
+            moduleLabelToPathAndFlags_[frange.first->second];
+        for (std::vector<ModuleLabelToPathAndFlags::PathAndFlags>::const_iterator iP = paths.begin(); iP != paths.end();
+             ++iP) {
+          bool pathFired = handleTriggerResults->wasrun(iP->pathIndex) && handleTriggerResults->accept(iP->pathIndex);
+          triggerObjectStandAlone.addPathName(iP->pathName, pathFired && iP->lastFilter, pathFired && iP->l3Filter);
+        }
       }
 
-      triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-      if ( ! onlyStandAlone_ ) {
-        triggerObjects->push_back( triggerObject );
-        newObjectKeys[ iO ] = trigger::size_type( triggerObjects->size() - 1 );
+      triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+      if (!onlyStandAlone_) {
+        triggerObjects->push_back(triggerObject);
+        newObjectKeys[iO] = trigger::size_type(triggerObjects->size() - 1);
       }
     }
 
     // Re-iterate HLT filters and finally produce them in order to account for optionally skipped objects
-    if ( ! onlyStandAlone_ ) {
+    if (!onlyStandAlone_) {
       auto triggerFilters = std::make_unique<TriggerFilterCollection>();
-      triggerFilters->reserve( sizeFilters );
-      for ( size_t iF = 0; iF < sizeFilters; ++iF ) {
-        const std::string nameFilter( handleTriggerEvent->filterTag( iF ).label() );
-        const trigger::Keys & keys  = handleTriggerEvent->filterKeys( iF ); // not cached
-        const trigger::Vids & types = handleTriggerEvent->filterIds( iF );  // not cached
-        TriggerFilter triggerFilter( nameFilter );
+      triggerFilters->reserve(sizeFilters);
+      for (size_t iF = 0; iF < sizeFilters; ++iF) {
+        const std::string nameFilter(handleTriggerEvent->filterTag(iF).label());
+        const trigger::Keys& keys = handleTriggerEvent->filterKeys(iF);  // not cached
+        const trigger::Vids& types = handleTriggerEvent->filterIds(iF);  // not cached
+        TriggerFilter triggerFilter(nameFilter);
         // set filter type
-        const std::string typeFilter( hltConfig.moduleType( nameFilter ) );
-        triggerFilter.setType( typeFilter );
-        triggerFilter.setSaveTags( hltConfig.saveTags( nameFilter ) );
+        const std::string typeFilter(hltConfig.moduleType(nameFilter));
+        triggerFilter.setType(typeFilter);
+        triggerFilter.setSaveTags(hltConfig.saveTags(nameFilter));
         // set keys and trigger object types of used objects
-        for ( size_t iK = 0; iK < keys.size(); ++iK ) { // identical to types.size()
+        for (size_t iK = 0; iK < keys.size(); ++iK) {  // identical to types.size()
           // check, if current object is excluded
-          if ( newObjectKeys.find( keys.at( iK ) ) != newObjectKeys.end() ) {
-            if ( newObjectKeys[ keys.at( iK ) ] == sizeObjects ) continue;
-            triggerFilter.addObjectKey( newObjectKeys[ keys.at( iK ) ] );
-            triggerFilter.addTriggerObjectType( types.at( iK ) );
+          if (newObjectKeys.find(keys.at(iK)) != newObjectKeys.end()) {
+            if (newObjectKeys[keys.at(iK)] == sizeObjects)
+              continue;
+            triggerFilter.addObjectKey(newObjectKeys[keys.at(iK)]);
+            triggerFilter.addTriggerObjectType(types.at(iK));
           } else {
-            LogWarning( "triggerObjectKey" ) << "TriggerFilter '" << nameFilter << "' requests non-existing TriggerObject key " << keys.at( iK ) << "\n"
-                                             << "Skipping object assignment";
+            LogWarning("triggerObjectKey") << "TriggerFilter '" << nameFilter
+                                           << "' requests non-existing TriggerObject key " << keys.at(iK) << "\n"
+                                           << "Skipping object assignment";
           }
         }
         // set status from path info
-        std::map< std::string, int >::iterator iS( moduleStates.find( nameFilter ) );
-        if ( iS != moduleStates.end() ) {
-          if ( ! triggerFilter.setStatus( iS->second ) ) {
-            triggerFilter.setStatus( -1 ); // FIXME different code for "unvalid status determined" needed?
+        std::map<std::string, int>::iterator iS(moduleStates.find(nameFilter));
+        if (iS != moduleStates.end()) {
+          if (!triggerFilter.setStatus(iS->second)) {
+            triggerFilter.setStatus(-1);  // FIXME different code for "unvalid status determined" needed?
           }
         } else {
-          triggerFilter.setStatus( -1 ); // FIXME different code for "unknown" needed?
+          triggerFilter.setStatus(-1);  // FIXME different code for "unknown" needed?
         }
         // store filter
-        triggerFilters->push_back( triggerFilter );
+        triggerFilters->push_back(triggerFilter);
       }
       // put HLT filters to event
       iEvent.put(std::move(triggerFilters));
     }
 
     if (packPrescales_) {
-        packedPrescales.reset(new PackedTriggerPrescales(handleTriggerResults)); 
-        packedPrescalesL1min.reset(new PackedTriggerPrescales(handleTriggerResults)); 
-        packedPrescalesL1max.reset(new PackedTriggerPrescales(handleTriggerResults)); 
-        const edm::TriggerNames & names = iEvent.triggerNames(*handleTriggerResults);
-        //std::cout << "Run " << iEvent.id().run() << ", LS " << iEvent.id().luminosityBlock() << ": pset " << set << std::endl;
-        for (unsigned int i = 0, n = names.size(); i < n; ++i) {
-            auto pvdet = hltPrescaleProvider_.prescaleValuesInDetail( iEvent, iSetup, names.triggerName(i) );
-            //int hltprescale = hltConfig_.prescaleValue(set, names.triggerName(i));
-            if (pvdet.first.empty()) {
-                packedPrescalesL1max->addPrescaledTrigger(i, 1);
-                packedPrescalesL1min->addPrescaledTrigger(i, 1);
-            } else {
-                int pmin = -1, pmax = -1;
-                for (const auto & p : pvdet.first) {
-                    pmax = std::max(pmax, p.second);
-                    if (p.second > 0 && (pmin == -1 || pmin > p.second)) pmin = p.second;
-                }
-                packedPrescalesL1max->addPrescaledTrigger(i, pmax);
-                packedPrescalesL1min->addPrescaledTrigger(i, pmin);
-                //std::cout << "\tTrigger " << names.triggerName(i) << ", L1 ps " << pmin << "-" << pmax << ", HLT ps " << hltprescale << std::endl;
-            }
-            packedPrescales->addPrescaledTrigger(i, pvdet.second);
-            //assert( hltprescale == pvdet.second );
+      packedPrescales.reset(new PackedTriggerPrescales(handleTriggerResults));
+      packedPrescalesL1min.reset(new PackedTriggerPrescales(handleTriggerResults));
+      packedPrescalesL1max.reset(new PackedTriggerPrescales(handleTriggerResults));
+      const edm::TriggerNames& names = iEvent.triggerNames(*handleTriggerResults);
+      //std::cout << "Run " << iEvent.id().run() << ", LS " << iEvent.id().luminosityBlock() << ": pset " << set << std::endl;
+      for (unsigned int i = 0, n = names.size(); i < n; ++i) {
+        auto pvdet = hltPrescaleProvider_.prescaleValuesInDetail(iEvent, iSetup, names.triggerName(i));
+        //int hltprescale = hltConfig_.prescaleValue(set, names.triggerName(i));
+        if (pvdet.first.empty()) {
+          packedPrescalesL1max->addPrescaledTrigger(i, 1);
+          packedPrescalesL1min->addPrescaledTrigger(i, 1);
+        } else {
+          int pmin = -1, pmax = -1;
+          for (const auto& p : pvdet.first) {
+            pmax = std::max(pmax, p.second);
+            if (p.second > 0 && (pmin == -1 || pmin > p.second))
+              pmin = p.second;
+          }
+          packedPrescalesL1max->addPrescaledTrigger(i, pmax);
+          packedPrescalesL1min->addPrescaledTrigger(i, pmin);
+          //std::cout << "\tTrigger " << names.triggerName(i) << ", L1 ps " << pmin << "-" << pmax << ", HLT ps " << hltprescale << std::endl;
         }
-        iEvent.put(std::move(packedPrescales));
-        iEvent.put(std::move(packedPrescalesL1max), "l1max");
-        iEvent.put(std::move(packedPrescalesL1min), "l1min");
+        packedPrescales->addPrescaledTrigger(i, pvdet.second);
+        //assert( hltprescale == pvdet.second );
+      }
+      iEvent.put(std::move(packedPrescales));
+      iEvent.put(std::move(packedPrescalesL1max), "l1max");
+      iEvent.put(std::move(packedPrescalesL1min), "l1min");
     }
 
-  } // if ( goodHlt )
+  }  // if ( goodHlt )
 
   // L1 objects
   // (needs to be done after HLT objects, since their x-links with filters rely on their collection keys)
 
   // map for assignments of objects to conditions
-  std::map< L1GtObject, std::vector< unsigned > > l1ObjectTypeMap;
-  if ( ! tagL1ExtraMu_.label().empty() ) {
-    Handle< l1extra::L1MuonParticleCollection > handleL1ExtraMu;
-    iEvent.getByLabel( tagL1ExtraMu_, handleL1ExtraMu );
-    if ( handleL1ExtraMu.isValid() ) {
-      std::vector< unsigned > muKeys;
-      for ( size_t l1Mu = 0; l1Mu < handleL1ExtraMu->size(); ++l1Mu ) {
-        if ( mainBxOnly_ && handleL1ExtraMu->at( l1Mu ).bx() != 0 ) continue;
+  std::map<L1GtObject, std::vector<unsigned> > l1ObjectTypeMap;
+  if (!tagL1ExtraMu_.label().empty()) {
+    Handle<l1extra::L1MuonParticleCollection> handleL1ExtraMu;
+    iEvent.getByLabel(tagL1ExtraMu_, handleL1ExtraMu);
+    if (handleL1ExtraMu.isValid()) {
+      std::vector<unsigned> muKeys;
+      for (size_t l1Mu = 0; l1Mu < handleL1ExtraMu->size(); ++l1Mu) {
+        if (mainBxOnly_ && handleL1ExtraMu->at(l1Mu).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1MuonParticleRef( handleL1ExtraMu, l1Mu ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1MuonParticleRef(handleL1ExtraMu, l1Mu));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraMu->at( l1Mu ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraMu->at(l1Mu).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraMu_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1Mu );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraMu->at( l1Mu ).bx() == 0 ) muKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraMu_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1Mu);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraMu->at(l1Mu).bx() == 0)
+          muKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( Mu, muKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1MuonParticleCollection product with InputTag '" << tagL1ExtraMu_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(Mu, muKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1MuonParticleCollection product with InputTag '" << tagL1ExtraMu_.encode()
+                               << "' not in event";
   }
-  if ( ! tagL1ExtraNoIsoEG_.label().empty() ) {
-    Handle< l1extra::L1EmParticleCollection > handleL1ExtraNoIsoEG;
-    iEvent.getByLabel( tagL1ExtraNoIsoEG_, handleL1ExtraNoIsoEG );
-    if ( handleL1ExtraNoIsoEG.isValid() ) {
-      std::vector< unsigned > noIsoEGKeys;
-      for ( size_t l1NoIsoEG = 0; l1NoIsoEG < handleL1ExtraNoIsoEG->size(); ++l1NoIsoEG ) {
-        if ( mainBxOnly_ && handleL1ExtraNoIsoEG->at( l1NoIsoEG ).bx() != 0 ) continue;
+  if (!tagL1ExtraNoIsoEG_.label().empty()) {
+    Handle<l1extra::L1EmParticleCollection> handleL1ExtraNoIsoEG;
+    iEvent.getByLabel(tagL1ExtraNoIsoEG_, handleL1ExtraNoIsoEG);
+    if (handleL1ExtraNoIsoEG.isValid()) {
+      std::vector<unsigned> noIsoEGKeys;
+      for (size_t l1NoIsoEG = 0; l1NoIsoEG < handleL1ExtraNoIsoEG->size(); ++l1NoIsoEG) {
+        if (mainBxOnly_ && handleL1ExtraNoIsoEG->at(l1NoIsoEG).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1EmParticleRef( handleL1ExtraNoIsoEG, l1NoIsoEG ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1EmParticleRef(handleL1ExtraNoIsoEG, l1NoIsoEG));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraNoIsoEG->at( l1NoIsoEG ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraNoIsoEG->at(l1NoIsoEG).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraNoIsoEG_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1NoIsoEG );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraNoIsoEG->at( l1NoIsoEG ).bx() == 0 ) noIsoEGKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraNoIsoEG_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1NoIsoEG);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraNoIsoEG->at(l1NoIsoEG).bx() == 0)
+          noIsoEGKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( NoIsoEG, noIsoEGKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1EmParticleCollection product with InputTag '" << tagL1ExtraNoIsoEG_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(NoIsoEG, noIsoEGKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1EmParticleCollection product with InputTag '"
+                               << tagL1ExtraNoIsoEG_.encode() << "' not in event";
   }
-  if ( ! tagL1ExtraIsoEG_.label().empty() ) {
-    Handle< l1extra::L1EmParticleCollection > handleL1ExtraIsoEG;
-    iEvent.getByLabel( tagL1ExtraIsoEG_, handleL1ExtraIsoEG );
-    if ( handleL1ExtraIsoEG.isValid() ) {
-      std::vector< unsigned > isoEGKeys;
-      for ( size_t l1IsoEG = 0; l1IsoEG < handleL1ExtraIsoEG->size(); ++l1IsoEG ) {
-        if ( mainBxOnly_ && handleL1ExtraIsoEG->at( l1IsoEG ).bx() != 0 ) continue;
+  if (!tagL1ExtraIsoEG_.label().empty()) {
+    Handle<l1extra::L1EmParticleCollection> handleL1ExtraIsoEG;
+    iEvent.getByLabel(tagL1ExtraIsoEG_, handleL1ExtraIsoEG);
+    if (handleL1ExtraIsoEG.isValid()) {
+      std::vector<unsigned> isoEGKeys;
+      for (size_t l1IsoEG = 0; l1IsoEG < handleL1ExtraIsoEG->size(); ++l1IsoEG) {
+        if (mainBxOnly_ && handleL1ExtraIsoEG->at(l1IsoEG).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1EmParticleRef( handleL1ExtraIsoEG, l1IsoEG ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1EmParticleRef(handleL1ExtraIsoEG, l1IsoEG));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraIsoEG->at( l1IsoEG ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraIsoEG->at(l1IsoEG).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraIsoEG_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1IsoEG );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraIsoEG->at( l1IsoEG ).bx() == 0 ) isoEGKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraIsoEG_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1IsoEG);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraIsoEG->at(l1IsoEG).bx() == 0)
+          isoEGKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( IsoEG, isoEGKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1EmParticleCollection product with InputTag '" << tagL1ExtraIsoEG_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(IsoEG, isoEGKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1EmParticleCollection product with InputTag '" << tagL1ExtraIsoEG_.encode()
+                               << "' not in event";
   }
-  if ( ! tagL1ExtraCenJet_.label().empty() ) {
-    Handle< l1extra::L1JetParticleCollection > handleL1ExtraCenJet;
-    iEvent.getByLabel( tagL1ExtraCenJet_, handleL1ExtraCenJet );
-    if ( handleL1ExtraCenJet.isValid() ) {
-      std::vector< unsigned > cenJetKeys;
-      for ( size_t l1CenJet = 0; l1CenJet < handleL1ExtraCenJet->size(); ++l1CenJet ) {
-        if ( mainBxOnly_ && handleL1ExtraCenJet->at( l1CenJet ).bx() != 0 ) continue;
+  if (!tagL1ExtraCenJet_.label().empty()) {
+    Handle<l1extra::L1JetParticleCollection> handleL1ExtraCenJet;
+    iEvent.getByLabel(tagL1ExtraCenJet_, handleL1ExtraCenJet);
+    if (handleL1ExtraCenJet.isValid()) {
+      std::vector<unsigned> cenJetKeys;
+      for (size_t l1CenJet = 0; l1CenJet < handleL1ExtraCenJet->size(); ++l1CenJet) {
+        if (mainBxOnly_ && handleL1ExtraCenJet->at(l1CenJet).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1JetParticleRef( handleL1ExtraCenJet, l1CenJet ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1JetParticleRef(handleL1ExtraCenJet, l1CenJet));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraCenJet->at( l1CenJet ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraCenJet->at(l1CenJet).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraCenJet_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1CenJet );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraCenJet->at( l1CenJet ).bx() == 0 ) cenJetKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraCenJet_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1CenJet);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraCenJet->at(l1CenJet).bx() == 0)
+          cenJetKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( CenJet, cenJetKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1JetParticleCollection product with InputTag '" << tagL1ExtraCenJet_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(CenJet, cenJetKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1JetParticleCollection product with InputTag '"
+                               << tagL1ExtraCenJet_.encode() << "' not in event";
   }
-  if ( ! tagL1ExtraForJet_.label().empty() ) {
-    Handle< l1extra::L1JetParticleCollection > handleL1ExtraForJet;
-    iEvent.getByLabel( tagL1ExtraForJet_, handleL1ExtraForJet );
-    if ( handleL1ExtraForJet.isValid() ) {
-      std::vector< unsigned > forJetKeys;
-      for ( size_t l1ForJet = 0; l1ForJet < handleL1ExtraForJet->size(); ++l1ForJet ) {
-        if ( mainBxOnly_ && handleL1ExtraForJet->at( l1ForJet ).bx() != 0 ) continue;
+  if (!tagL1ExtraForJet_.label().empty()) {
+    Handle<l1extra::L1JetParticleCollection> handleL1ExtraForJet;
+    iEvent.getByLabel(tagL1ExtraForJet_, handleL1ExtraForJet);
+    if (handleL1ExtraForJet.isValid()) {
+      std::vector<unsigned> forJetKeys;
+      for (size_t l1ForJet = 0; l1ForJet < handleL1ExtraForJet->size(); ++l1ForJet) {
+        if (mainBxOnly_ && handleL1ExtraForJet->at(l1ForJet).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1JetParticleRef( handleL1ExtraForJet, l1ForJet ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1JetParticleRef(handleL1ExtraForJet, l1ForJet));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraForJet->at( l1ForJet ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraForJet->at(l1ForJet).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraForJet_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1ForJet );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraForJet->at( l1ForJet ).bx() == 0 ) forJetKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraForJet_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1ForJet);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraForJet->at(l1ForJet).bx() == 0)
+          forJetKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( ForJet, forJetKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1JetParticleCollection product with InputTag '" << tagL1ExtraForJet_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(ForJet, forJetKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1JetParticleCollection product with InputTag '"
+                               << tagL1ExtraForJet_.encode() << "' not in event";
   }
-  if ( ! tagL1ExtraTauJet_.label().empty() ) {
-    Handle< l1extra::L1JetParticleCollection > handleL1ExtraTauJet;
-    iEvent.getByLabel( tagL1ExtraTauJet_, handleL1ExtraTauJet );
-    if ( handleL1ExtraTauJet.isValid() ) {
-      std::vector< unsigned > tauJetKeys;
-      for ( size_t l1TauJet = 0; l1TauJet < handleL1ExtraTauJet->size(); ++l1TauJet ) {
-        if ( mainBxOnly_ && handleL1ExtraTauJet->at( l1TauJet ).bx() != 0 ) continue;
+  if (!tagL1ExtraTauJet_.label().empty()) {
+    Handle<l1extra::L1JetParticleCollection> handleL1ExtraTauJet;
+    iEvent.getByLabel(tagL1ExtraTauJet_, handleL1ExtraTauJet);
+    if (handleL1ExtraTauJet.isValid()) {
+      std::vector<unsigned> tauJetKeys;
+      for (size_t l1TauJet = 0; l1TauJet < handleL1ExtraTauJet->size(); ++l1TauJet) {
+        if (mainBxOnly_ && handleL1ExtraTauJet->at(l1TauJet).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1JetParticleRef( handleL1ExtraTauJet, l1TauJet ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1JetParticleRef(handleL1ExtraTauJet, l1TauJet));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraTauJet->at( l1TauJet ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraTauJet->at(l1TauJet).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraTauJet_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1TauJet );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraTauJet->at( l1TauJet ).bx() == 0 ) tauJetKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraTauJet_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1TauJet);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraTauJet->at(l1TauJet).bx() == 0)
+          tauJetKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( TauJet, tauJetKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1JetParticleCollection product with InputTag '" << tagL1ExtraTauJet_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(TauJet, tauJetKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1JetParticleCollection product with InputTag '"
+                               << tagL1ExtraTauJet_.encode() << "' not in event";
   }
-  if ( ! tagL1ExtraETM_ .label().empty()) {
-    Handle< l1extra::L1EtMissParticleCollection > handleL1ExtraETM;
-    iEvent.getByLabel( tagL1ExtraETM_, handleL1ExtraETM );
-    if ( handleL1ExtraETM.isValid() ) {
-      std::vector< unsigned > etmKeys;
-      for ( size_t l1ETM = 0; l1ETM < handleL1ExtraETM->size(); ++l1ETM ) {
-        if ( mainBxOnly_ && handleL1ExtraETM->at( l1ETM ).bx() != 0 ) continue;
+  if (!tagL1ExtraETM_.label().empty()) {
+    Handle<l1extra::L1EtMissParticleCollection> handleL1ExtraETM;
+    iEvent.getByLabel(tagL1ExtraETM_, handleL1ExtraETM);
+    if (handleL1ExtraETM.isValid()) {
+      std::vector<unsigned> etmKeys;
+      for (size_t l1ETM = 0; l1ETM < handleL1ExtraETM->size(); ++l1ETM) {
+        if (mainBxOnly_ && handleL1ExtraETM->at(l1ETM).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1EtMissParticleRef( handleL1ExtraETM, l1ETM ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1EtMissParticleRef(handleL1ExtraETM, l1ETM));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraETM->at( l1ETM ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraETM->at(l1ETM).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraETM_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1ETM );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraETM->at( l1ETM ).bx() == 0 ) etmKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraETM_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1ETM);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraETM->at(l1ETM).bx() == 0)
+          etmKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( ETM, etmKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1EtMissParticleCollection product with InputTag '" << tagL1ExtraETM_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(ETM, etmKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1EtMissParticleCollection product with InputTag '"
+                               << tagL1ExtraETM_.encode() << "' not in event";
   }
-  if ( ! tagL1ExtraHTM_.label().empty() ) {
-    Handle< l1extra::L1EtMissParticleCollection > handleL1ExtraHTM;
-    iEvent.getByLabel( tagL1ExtraHTM_, handleL1ExtraHTM );
-    if ( handleL1ExtraHTM.isValid() ) {
-      std::vector< unsigned > htmKeys;
-      for ( size_t l1HTM = 0; l1HTM < handleL1ExtraHTM->size(); ++l1HTM ) {
-        if ( mainBxOnly_ && handleL1ExtraHTM->at( l1HTM ).bx() != 0 ) continue;
+  if (!tagL1ExtraHTM_.label().empty()) {
+    Handle<l1extra::L1EtMissParticleCollection> handleL1ExtraHTM;
+    iEvent.getByLabel(tagL1ExtraHTM_, handleL1ExtraHTM);
+    if (handleL1ExtraHTM.isValid()) {
+      std::vector<unsigned> htmKeys;
+      for (size_t l1HTM = 0; l1HTM < handleL1ExtraHTM->size(); ++l1HTM) {
+        if (mainBxOnly_ && handleL1ExtraHTM->at(l1HTM).bx() != 0)
+          continue;
         TriggerObject triggerObject;
-        if ( saveL1Refs_ ) {
-          const reco::CandidateBaseRef leafCandRef( l1extra::L1EtMissParticleRef( handleL1ExtraHTM, l1HTM ) );
-          triggerObject = TriggerObject( leafCandRef );
+        if (saveL1Refs_) {
+          const reco::CandidateBaseRef leafCandRef(l1extra::L1EtMissParticleRef(handleL1ExtraHTM, l1HTM));
+          triggerObject = TriggerObject(leafCandRef);
         } else {
-          const reco::LeafCandidate leafCandidate( *( handleL1ExtraHTM->at( l1HTM ).reco::LeafCandidate::clone() ) );
-          triggerObject = TriggerObject( leafCandidate );
+          const reco::LeafCandidate leafCandidate(*(handleL1ExtraHTM->at(l1HTM).reco::LeafCandidate::clone()));
+          triggerObject = TriggerObject(leafCandidate);
         }
-        triggerObject.setCollection( tagL1ExtraHTM_ );
-        triggerObject.addTriggerObjectType( trigger::TriggerL1HTM );
-        if ( ! onlyStandAlone_ ) triggerObjects->push_back( triggerObject );
-        TriggerObjectStandAlone triggerObjectStandAlone( triggerObject );
-        triggerObjectsStandAlone->push_back( triggerObjectStandAlone );
-        if ( handleL1ExtraHTM->at( l1HTM ).bx() == 0 ) htmKeys.push_back( triggerObjectsStandAlone->size() - 1 );
+        triggerObject.setCollection(tagL1ExtraHTM_);
+        triggerObject.addTriggerObjectType(trigger::TriggerL1HTM);
+        if (!onlyStandAlone_)
+          triggerObjects->push_back(triggerObject);
+        TriggerObjectStandAlone triggerObjectStandAlone(triggerObject);
+        triggerObjectsStandAlone->push_back(triggerObjectStandAlone);
+        if (handleL1ExtraHTM->at(l1HTM).bx() == 0)
+          htmKeys.push_back(triggerObjectsStandAlone->size() - 1);
       }
-      l1ObjectTypeMap.insert( std::make_pair( HTM, htmKeys ) );
-    } else LogError( "l1ExtraValid" ) << "l1extra::L1EtMissParticleCollection product with InputTag '" << tagL1ExtraHTM_.encode() << "' not in event";
+      l1ObjectTypeMap.insert(std::make_pair(HTM, htmKeys));
+    } else
+      LogError("l1ExtraValid") << "l1extra::L1EtMissParticleCollection product with InputTag '"
+                               << tagL1ExtraHTM_.encode() << "' not in event";
   }
 
   // Put trigger objects to event
-  if ( ! onlyStandAlone_ ) iEvent.put(std::move(triggerObjects));
+  if (!onlyStandAlone_)
+    iEvent.put(std::move(triggerObjects));
 
   // L1 algorithms
-  if ( ! onlyStandAlone_ ) {
+  if (!onlyStandAlone_) {
     auto triggerAlgos = std::make_unique<TriggerAlgorithmCollection>();
     auto triggerConditions = std::make_unique<TriggerConditionCollection>();
-    if ( addL1Algos_ ) {
+    if (addL1Algos_) {
       // create trigger object types transalation map (yes, it's ugly!)
-      std::map< L1GtObject, trigger::TriggerObjectType > mapObjectTypes;
-      mapObjectTypes.insert( std::make_pair( Mu     , trigger::TriggerL1Mu ) );
-      mapObjectTypes.insert( std::make_pair( NoIsoEG, trigger::TriggerL1NoIsoEG ) );
-      mapObjectTypes.insert( std::make_pair( IsoEG  , trigger::TriggerL1IsoEG ) );
-      mapObjectTypes.insert( std::make_pair( CenJet , trigger::TriggerL1CenJet ) );
-      mapObjectTypes.insert( std::make_pair( ForJet , trigger::TriggerL1ForJet ) );
-      mapObjectTypes.insert( std::make_pair( TauJet , trigger::TriggerL1TauJet ) );
-      mapObjectTypes.insert( std::make_pair( ETM    , trigger::TriggerL1ETM ) );
-      mapObjectTypes.insert( std::make_pair( HTM    , trigger::TriggerL1HTM ) );
+      std::map<L1GtObject, trigger::TriggerObjectType> mapObjectTypes;
+      mapObjectTypes.insert(std::make_pair(Mu, trigger::TriggerL1Mu));
+      mapObjectTypes.insert(std::make_pair(NoIsoEG, trigger::TriggerL1NoIsoEG));
+      mapObjectTypes.insert(std::make_pair(IsoEG, trigger::TriggerL1IsoEG));
+      mapObjectTypes.insert(std::make_pair(CenJet, trigger::TriggerL1CenJet));
+      mapObjectTypes.insert(std::make_pair(ForJet, trigger::TriggerL1ForJet));
+      mapObjectTypes.insert(std::make_pair(TauJet, trigger::TriggerL1TauJet));
+      mapObjectTypes.insert(std::make_pair(ETM, trigger::TriggerL1ETM));
+      mapObjectTypes.insert(std::make_pair(HTM, trigger::TriggerL1HTM));
       // get and cache L1 menu
       L1GtUtils const& l1GtUtils = hltPrescaleProvider_.l1GtUtils();
-      ESHandle< L1GtTriggerMenu > handleL1GtTriggerMenu;
-      iSetup.get< L1GtTriggerMenuRcd >().get( handleL1GtTriggerMenu );
-      auto const & l1GtAlgorithms   = handleL1GtTriggerMenu->gtAlgorithmMap();
-      auto const & l1GtTechTriggers = handleL1GtTriggerMenu->gtTechnicalTriggerMap();
-      auto const & l1GtConditionsVector = handleL1GtTriggerMenu->gtConditionMap();
+      ESHandle<L1GtTriggerMenu> handleL1GtTriggerMenu;
+      iSetup.get<L1GtTriggerMenuRcd>().get(handleL1GtTriggerMenu);
+      auto const& l1GtAlgorithms = handleL1GtTriggerMenu->gtAlgorithmMap();
+      auto const& l1GtTechTriggers = handleL1GtTriggerMenu->gtTechnicalTriggerMap();
+      auto const& l1GtConditionsVector = handleL1GtTriggerMenu->gtConditionMap();
       // cache conditions in one single condition map
       ConditionMap l1GtConditions;
-      for ( size_t iCv = 0; iCv < l1GtConditionsVector.size(); ++iCv ) {
-        l1GtConditions.insert( l1GtConditionsVector.at( iCv ).begin(), l1GtConditionsVector.at( iCv ).end() );
+      for (size_t iCv = 0; iCv < l1GtConditionsVector.size(); ++iCv) {
+        l1GtConditions.insert(l1GtConditionsVector.at(iCv).begin(), l1GtConditionsVector.at(iCv).end());
       }
-      triggerAlgos->reserve( l1GtAlgorithms.size() + l1GtTechTriggers.size() );
-      Handle< L1GlobalTriggerObjectMaps > handleL1GlobalTriggerObjectMaps;
-      iEvent.getByToken( l1GlobalTriggerObjectMapsToken_, handleL1GlobalTriggerObjectMaps );
-      if( ! handleL1GlobalTriggerObjectMaps.isValid() ) {
-        LogError( "l1ObjectMap" ) << "L1GlobalTriggerObjectMaps product with InputTag '" << tagL1GlobalTriggerObjectMaps_.encode() << "' not in event\n"
-                                    << "No L1 objects and GTL results available for physics algorithms";
+      triggerAlgos->reserve(l1GtAlgorithms.size() + l1GtTechTriggers.size());
+      Handle<L1GlobalTriggerObjectMaps> handleL1GlobalTriggerObjectMaps;
+      iEvent.getByToken(l1GlobalTriggerObjectMapsToken_, handleL1GlobalTriggerObjectMaps);
+      if (!handleL1GlobalTriggerObjectMaps.isValid()) {
+        LogError("l1ObjectMap") << "L1GlobalTriggerObjectMaps product with InputTag '"
+                                << tagL1GlobalTriggerObjectMaps_.encode() << "' not in event\n"
+                                << "No L1 objects and GTL results available for physics algorithms";
       }
       handleL1GlobalTriggerObjectMaps->consistencyCheck();
-      if ( firstInRun_ ) {
-        l1PSet_ = ( ParameterSet* )( pset::Registry::instance()->getMapped(handleL1GlobalTriggerObjectMaps->namesParameterSetID()) );
+      if (firstInRun_) {
+        l1PSet_ = (ParameterSet*)(pset::Registry::instance()->getMapped(
+            handleL1GlobalTriggerObjectMaps->namesParameterSetID()));
         if (l1PSet_ == nullptr) {
-          LogError( "l1ObjectMap" ) << "ParameterSet registry not available\n"
-                                    << "Skipping conditions for all L1 physics algorithm names in this run";
+          LogError("l1ObjectMap") << "ParameterSet registry not available\n"
+                                  << "Skipping conditions for all L1 physics algorithm names in this run";
         }
       } else {
         if (l1PSet_ == nullptr) {
-          LogInfo( "l1ObjectMap" ) << "ParameterSet registry not available\n"
-                                   << "Skipping conditions for all L1 physics algorithm names in this event";
+          LogInfo("l1ObjectMap") << "ParameterSet registry not available\n"
+                                 << "Skipping conditions for all L1 physics algorithm names in this event";
         }
       }
       // physics algorithms
-      for ( CItAlgo iAlgo = l1GtAlgorithms.begin(); iAlgo != l1GtAlgorithms.end(); ++iAlgo ) {
-        const std::string & algoName( iAlgo->second.algoName() );
-        if ( ! ( iAlgo->second.algoBitNumber() < int( L1GlobalTriggerReadoutSetup::NumberPhysTriggers ) ) ) {
-          LogError( "l1Algo" ) << "L1 physics algorithm '" << algoName << "' has bit number " << iAlgo->second.algoBitNumber() << " >= " << L1GlobalTriggerReadoutSetup::NumberPhysTriggers << "\n"
-                               << "Skipping";
+      for (CItAlgo iAlgo = l1GtAlgorithms.begin(); iAlgo != l1GtAlgorithms.end(); ++iAlgo) {
+        const std::string& algoName(iAlgo->second.algoName());
+        if (!(iAlgo->second.algoBitNumber() < int(L1GlobalTriggerReadoutSetup::NumberPhysTriggers))) {
+          LogError("l1Algo") << "L1 physics algorithm '" << algoName << "' has bit number "
+                             << iAlgo->second.algoBitNumber()
+                             << " >= " << L1GlobalTriggerReadoutSetup::NumberPhysTriggers << "\n"
+                             << "Skipping";
           continue;
         }
         L1GtUtils::TriggerCategory category;
         int bit;
-        if ( ! l1GtUtils.l1AlgoTechTrigBitNumber( algoName, category, bit ) ) {
-          LogError( "l1Algo" ) << "L1 physics algorithm '" << algoName << "' not found in the L1 menu\n"
-                               << "Skipping";
+        if (!l1GtUtils.l1AlgoTechTrigBitNumber(algoName, category, bit)) {
+          LogError("l1Algo") << "L1 physics algorithm '" << algoName << "' not found in the L1 menu\n"
+                             << "Skipping";
           continue;
         }
-        if ( category != L1GtUtils::AlgorithmTrigger ) {
-          LogError( "l1Algo" ) << "L1 physics algorithm '" << algoName << "' does not have category 'AlgorithmTrigger' from 'L1GtUtils'\n"
-                               << "Skipping";
+        if (category != L1GtUtils::AlgorithmTrigger) {
+          LogError("l1Algo") << "L1 physics algorithm '" << algoName
+                             << "' does not have category 'AlgorithmTrigger' from 'L1GtUtils'\n"
+                             << "Skipping";
           continue;
         }
         bool decisionBeforeMask;
         bool decisionAfterMask;
-        int  prescale;
-        int  mask;
-        int  error( l1GtUtils.l1Results( iEvent, algoName, decisionBeforeMask, decisionAfterMask, prescale, mask ) );
-        if ( error ) {
-          LogError( "l1Algo" ) << "L1 physics algorithm '" << algoName << "' decision has error code " << error << " from 'L1GtUtils'\n"
-                               << "Skipping";
+        int prescale;
+        int mask;
+        int error(l1GtUtils.l1Results(iEvent, algoName, decisionBeforeMask, decisionAfterMask, prescale, mask));
+        if (error) {
+          LogError("l1Algo") << "L1 physics algorithm '" << algoName << "' decision has error code " << error
+                             << " from 'L1GtUtils'\n"
+                             << "Skipping";
           continue;
         }
-        TriggerAlgorithm triggerAlgo( algoName, iAlgo->second.algoAlias(), category == L1GtUtils::TechnicalTrigger, (unsigned)bit, (unsigned)prescale, (bool)mask, decisionBeforeMask, decisionAfterMask );
-        triggerAlgo.setLogicalExpression( iAlgo->second.algoLogicalExpression() );
+        TriggerAlgorithm triggerAlgo(algoName,
+                                     iAlgo->second.algoAlias(),
+                                     category == L1GtUtils::TechnicalTrigger,
+                                     (unsigned)bit,
+                                     (unsigned)prescale,
+                                     (bool)mask,
+                                     decisionBeforeMask,
+                                     decisionAfterMask);
+        triggerAlgo.setLogicalExpression(iAlgo->second.algoLogicalExpression());
         // GTL result and used conditions in physics algorithm
-        if( ! handleL1GlobalTriggerObjectMaps.isValid() ) {
-          triggerAlgos->push_back( triggerAlgo );
-          continue; // LogWarning already earlier (before loop)
+        if (!handleL1GlobalTriggerObjectMaps.isValid()) {
+          triggerAlgos->push_back(triggerAlgo);
+          continue;  // LogWarning already earlier (before loop)
         }
-        if ( ! handleL1GlobalTriggerObjectMaps->algorithmExists(bit)) {
-          LogError( "l1ObjectMap" ) << "L1 physics algorithm '" << algoName << "' is missing in L1GlobalTriggerObjectMaps\n"
-                                    << "Skipping conditions and GTL result";
-          triggerAlgos->push_back( triggerAlgo );
+        if (!handleL1GlobalTriggerObjectMaps->algorithmExists(bit)) {
+          LogError("l1ObjectMap") << "L1 physics algorithm '" << algoName
+                                  << "' is missing in L1GlobalTriggerObjectMaps\n"
+                                  << "Skipping conditions and GTL result";
+          triggerAlgos->push_back(triggerAlgo);
           continue;
         }
         bool algorithmResult = handleL1GlobalTriggerObjectMaps->algorithmResult(bit);
-//         if ( ( algorithmResult != decisionBeforeMask ) && ( decisionBeforeMask == true || prescale == 1 ) ) {
-        if ( ( algorithmResult != decisionBeforeMask ) && ( decisionBeforeMask == true ) ) { // FIXME: understand the difference for un-prescaled algos 118, 119, 123
-          LogInfo( "l1ObjectMap" ) << "L1 physics algorithm '" << algoName << "' with different decisions in\n"
-                                   << "L1GlobalTriggerObjectMaps (GTL result)        : " << algorithmResult << "\n"
-                                   << "L1GlobalTriggerReadoutRecord (decision before mask): " << decisionBeforeMask;
+        //         if ( ( algorithmResult != decisionBeforeMask ) && ( decisionBeforeMask == true || prescale == 1 ) ) {
+        if ((algorithmResult != decisionBeforeMask) &&
+            (decisionBeforeMask == true)) {  // FIXME: understand the difference for un-prescaled algos 118, 119, 123
+          LogInfo("l1ObjectMap") << "L1 physics algorithm '" << algoName << "' with different decisions in\n"
+                                 << "L1GlobalTriggerObjectMaps (GTL result)        : " << algorithmResult << "\n"
+                                 << "L1GlobalTriggerReadoutRecord (decision before mask): " << decisionBeforeMask;
         }
-        triggerAlgo.setGtlResult( algorithmResult );
+        triggerAlgo.setGtlResult(algorithmResult);
         // conditions in algorithm
-        L1GlobalTriggerObjectMaps::ConditionsInAlgorithm conditions = handleL1GlobalTriggerObjectMaps->getConditionsInAlgorithm(bit);
+        L1GlobalTriggerObjectMaps::ConditionsInAlgorithm conditions =
+            handleL1GlobalTriggerObjectMaps->getConditionsInAlgorithm(bit);
         if (l1PSet_ == nullptr) {
-          triggerAlgos->push_back( triggerAlgo );
+          triggerAlgos->push_back(triggerAlgo);
           continue;
         }
         if (!l1PSet_->exists(algoName)) {
-          if ( firstInRun_ ) {
-            LogError( "l1ObjectMap" ) << "L1 physics algorithm name '" << algoName << "' not available in ParameterSet registry\n"
-                                      << "Skipping conditions for this algorithm in this run";
+          if (firstInRun_) {
+            LogError("l1ObjectMap") << "L1 physics algorithm name '" << algoName
+                                    << "' not available in ParameterSet registry\n"
+                                    << "Skipping conditions for this algorithm in this run";
           } else {
-            LogInfo( "l1ObjectMap" ) << "L1 physics algorithm name '" << algoName << "' not available in ParameterSet registry\n"
-                                     << "Skipping conditions for this algorithm in this event";
+            LogInfo("l1ObjectMap") << "L1 physics algorithm name '" << algoName
+                                   << "' not available in ParameterSet registry\n"
+                                   << "Skipping conditions for this algorithm in this event";
           }
-          triggerAlgos->push_back( triggerAlgo );
+          triggerAlgos->push_back(triggerAlgo);
           continue;
         }
-        std::vector<std::string> conditionNames( l1PSet_->getParameter<std::vector<std::string> >(algoName) );
+        std::vector<std::string> conditionNames(l1PSet_->getParameter<std::vector<std::string> >(algoName));
 
-        for ( unsigned iT = 0; iT < conditionNames.size(); ++iT ) {
-          size_t key( triggerConditions->size() );
-          for ( size_t iC = 0; iC < triggerConditions->size(); ++iC ) {
-            if ( conditionNames.at(iT) == triggerConditions->at( iC ).name() ) {
+        for (unsigned iT = 0; iT < conditionNames.size(); ++iT) {
+          size_t key(triggerConditions->size());
+          for (size_t iC = 0; iC < triggerConditions->size(); ++iC) {
+            if (conditionNames.at(iT) == triggerConditions->at(iC).name()) {
               key = iC;
               break;
             }
           }
-          if ( key == triggerConditions->size() ) {
-            if ( iT >= conditions.nConditions() ) {
-              LogError( "l1CondMap" ) << "More condition names from ParameterSet registry than the " << conditions.nConditions() << " conditions in L1GlobalTriggerObjectMaps\n"
-                                      << "Skipping condition " << conditionNames.at(iT) << " in algorithm " << algoName;
+          if (key == triggerConditions->size()) {
+            if (iT >= conditions.nConditions()) {
+              LogError("l1CondMap") << "More condition names from ParameterSet registry than the "
+                                    << conditions.nConditions() << " conditions in L1GlobalTriggerObjectMaps\n"
+                                    << "Skipping condition " << conditionNames.at(iT) << " in algorithm " << algoName;
               break;
             }
-            TriggerCondition triggerCond( conditionNames[iT], conditions.getConditionResult(iT) );
-            if ( l1GtConditions.find( triggerCond.name() ) != l1GtConditions.end() ) {
-              triggerCond.setCategory( l1GtConditions[ triggerCond.name() ]->condCategory() );
-              triggerCond.setType( l1GtConditions[ triggerCond.name() ]->condType() );
-              const std::vector< L1GtObject > l1ObjectTypes( l1GtConditions[ triggerCond.name() ]->objectType() );
-              for ( size_t iType = 0 ; iType < l1ObjectTypes.size(); ++iType ) {
-                triggerCond.addTriggerObjectType( mapObjectTypes[ l1ObjectTypes.at( iType ) ] );
+            TriggerCondition triggerCond(conditionNames[iT], conditions.getConditionResult(iT));
+            if (l1GtConditions.find(triggerCond.name()) != l1GtConditions.end()) {
+              triggerCond.setCategory(l1GtConditions[triggerCond.name()]->condCategory());
+              triggerCond.setType(l1GtConditions[triggerCond.name()]->condType());
+              const std::vector<L1GtObject> l1ObjectTypes(l1GtConditions[triggerCond.name()]->objectType());
+              for (size_t iType = 0; iType < l1ObjectTypes.size(); ++iType) {
+                triggerCond.addTriggerObjectType(mapObjectTypes[l1ObjectTypes.at(iType)]);
               }
               // objects in condition
-              L1GlobalTriggerObjectMaps::CombinationsInCondition combinations = handleL1GlobalTriggerObjectMaps->getCombinationsInCondition(bit, iT);
-              for ( size_t iVV = 0; iVV < combinations.nCombinations(); ++iVV ) {
-                for ( size_t iV = 0; iV < combinations.nObjectsPerCombination(); ++iV ) {
-
+              L1GlobalTriggerObjectMaps::CombinationsInCondition combinations =
+                  handleL1GlobalTriggerObjectMaps->getCombinationsInCondition(bit, iT);
+              for (size_t iVV = 0; iVV < combinations.nCombinations(); ++iVV) {
+                for (size_t iV = 0; iV < combinations.nObjectsPerCombination(); ++iV) {
                   unsigned objectIndex = combinations.getObjectIndex(iVV, iV);
-                  if ( iV >= l1ObjectTypes.size() ) {
-                    LogError( "l1CondMap" ) << "Index " << iV << " in combinations vector overshoots size " << l1ObjectTypes.size() << " of types vector in conditions map\n"
-                                            << "Skipping object key in condition " << triggerCond.name();
-                  } else if ( l1ObjectTypeMap.find( l1ObjectTypes.at( iV ) ) != l1ObjectTypeMap.end() ) {
-                    if ( objectIndex >= l1ObjectTypeMap[ l1ObjectTypes.at( iV ) ].size() ) {
-                      LogError( "l1CondMap" ) << "Index " << objectIndex << " in combination overshoots number " << l1ObjectTypeMap[ l1ObjectTypes.at( iV ) ].size() << "of according trigger objects\n"
-                                              << "Skipping object key in condition " << triggerCond.name();
+                  if (iV >= l1ObjectTypes.size()) {
+                    LogError("l1CondMap") << "Index " << iV << " in combinations vector overshoots size "
+                                          << l1ObjectTypes.size() << " of types vector in conditions map\n"
+                                          << "Skipping object key in condition " << triggerCond.name();
+                  } else if (l1ObjectTypeMap.find(l1ObjectTypes.at(iV)) != l1ObjectTypeMap.end()) {
+                    if (objectIndex >= l1ObjectTypeMap[l1ObjectTypes.at(iV)].size()) {
+                      LogError("l1CondMap")
+                          << "Index " << objectIndex << " in combination overshoots number "
+                          << l1ObjectTypeMap[l1ObjectTypes.at(iV)].size() << "of according trigger objects\n"
+                          << "Skipping object key in condition " << triggerCond.name();
                     }
-                    const unsigned objectKey( l1ObjectTypeMap[ l1ObjectTypes.at( iV ) ].at( objectIndex ) );
-                    triggerCond.addObjectKey( objectKey );
+                    const unsigned objectKey(l1ObjectTypeMap[l1ObjectTypes.at(iV)].at(objectIndex));
+                    triggerCond.addObjectKey(objectKey);
                     // add current condition and algorithm also to the according stand-alone trigger object
-                    triggerObjectsStandAlone->at( objectKey ).addAlgorithmName( triggerAlgo.name(), ( triggerAlgo.decision() && triggerCond.wasAccept() ) );
-                    triggerObjectsStandAlone->at( objectKey ).addConditionName( triggerCond.name() );
+                    triggerObjectsStandAlone->at(objectKey).addAlgorithmName(
+                        triggerAlgo.name(), (triggerAlgo.decision() && triggerCond.wasAccept()));
+                    triggerObjectsStandAlone->at(objectKey).addConditionName(triggerCond.name());
                   }
                 }
               }
             } else {
-              LogWarning( "l1CondMap" ) << "L1 conditions '" << triggerCond.name() << "' not found in the L1 menu\n"
-                                        << "Remains incomplete";
+              LogWarning("l1CondMap") << "L1 conditions '" << triggerCond.name() << "' not found in the L1 menu\n"
+                                      << "Remains incomplete";
             }
-            triggerConditions->push_back( triggerCond );
+            triggerConditions->push_back(triggerCond);
           }
-          triggerAlgo.addConditionKey( key );
+          triggerAlgo.addConditionKey(key);
         }
-        triggerAlgos->push_back( triggerAlgo );
+        triggerAlgos->push_back(triggerAlgo);
       }
       // technical triggers
-      for ( CItAlgo iAlgo = l1GtTechTriggers.begin(); iAlgo != l1GtTechTriggers.end(); ++iAlgo ) {
-        const std::string & algoName( iAlgo->second.algoName() );
-        if ( ! ( iAlgo->second.algoBitNumber() < int( L1GlobalTriggerReadoutSetup::NumberTechnicalTriggers ) ) ) {
-          LogError( "l1Algo" ) << "L1 technical trigger '" << algoName << "' has bit number " << iAlgo->second.algoBitNumber() << " >= " << L1GlobalTriggerReadoutSetup::NumberTechnicalTriggers << "\n"
-                               << "Skipping";
+      for (CItAlgo iAlgo = l1GtTechTriggers.begin(); iAlgo != l1GtTechTriggers.end(); ++iAlgo) {
+        const std::string& algoName(iAlgo->second.algoName());
+        if (!(iAlgo->second.algoBitNumber() < int(L1GlobalTriggerReadoutSetup::NumberTechnicalTriggers))) {
+          LogError("l1Algo") << "L1 technical trigger '" << algoName << "' has bit number "
+                             << iAlgo->second.algoBitNumber()
+                             << " >= " << L1GlobalTriggerReadoutSetup::NumberTechnicalTriggers << "\n"
+                             << "Skipping";
           continue;
         }
         L1GtUtils::TriggerCategory category;
         int bit;
-        if ( ! l1GtUtils.l1AlgoTechTrigBitNumber( algoName, category, bit ) ) {
-          LogError( "l1Algo" ) << "L1 technical trigger '" << algoName << "' not found in the L1 menu\n"
-                               << "Skipping";
+        if (!l1GtUtils.l1AlgoTechTrigBitNumber(algoName, category, bit)) {
+          LogError("l1Algo") << "L1 technical trigger '" << algoName << "' not found in the L1 menu\n"
+                             << "Skipping";
           continue;
         }
-        if ( category != L1GtUtils::TechnicalTrigger ) {
-          LogError( "l1Algo" ) << "L1 technical trigger '" << algoName << "' does not have category 'TechnicalTrigger' from 'L1GtUtils'\n"
-                               << "Skipping";
+        if (category != L1GtUtils::TechnicalTrigger) {
+          LogError("l1Algo") << "L1 technical trigger '" << algoName
+                             << "' does not have category 'TechnicalTrigger' from 'L1GtUtils'\n"
+                             << "Skipping";
           continue;
         }
         bool decisionBeforeMask;
         bool decisionAfterMask;
-        int  prescale;
-        int  mask;
-        int  error( l1GtUtils.l1Results( iEvent, algoName, decisionBeforeMask, decisionAfterMask, prescale, mask ) );
-        if ( error ) {
-          LogError( "l1Algo" ) << "L1 technical trigger '" << algoName << "' decision has error code " << error << " from 'L1GtUtils'\n"
-                               << "Skipping";
+        int prescale;
+        int mask;
+        int error(l1GtUtils.l1Results(iEvent, algoName, decisionBeforeMask, decisionAfterMask, prescale, mask));
+        if (error) {
+          LogError("l1Algo") << "L1 technical trigger '" << algoName << "' decision has error code " << error
+                             << " from 'L1GtUtils'\n"
+                             << "Skipping";
           continue;
         }
-        TriggerAlgorithm triggerAlgo( algoName, iAlgo->second.algoAlias(), category == L1GtUtils::TechnicalTrigger, (unsigned)bit, (unsigned)prescale, (bool)mask, decisionBeforeMask, decisionAfterMask );
-        triggerAlgo.setLogicalExpression( iAlgo->second.algoLogicalExpression() );
-        triggerAlgos->push_back( triggerAlgo );
+        TriggerAlgorithm triggerAlgo(algoName,
+                                     iAlgo->second.algoAlias(),
+                                     category == L1GtUtils::TechnicalTrigger,
+                                     (unsigned)bit,
+                                     (unsigned)prescale,
+                                     (bool)mask,
+                                     decisionBeforeMask,
+                                     decisionAfterMask);
+        triggerAlgo.setLogicalExpression(iAlgo->second.algoLogicalExpression());
+        triggerAlgos->push_back(triggerAlgo);
       }
     }
 
@@ -1019,46 +1170,48 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     iEvent.put(std::move(triggerConditions));
   }
 
-
   edm::ProcessConfiguration config;
-  iEvent.processHistory().getConfigurationForProcess(nameProcess_,config);
+  iEvent.processHistory().getConfigurationForProcess(nameProcess_, config);
 
-
-  const edm::TriggerNames & names = iEvent.triggerNames(*handleTriggerResults);
-  for (pat::TriggerObjectStandAlone &obj : *triggerObjectsStandAlone) {
-        obj.setPSetID(config.parameterSetID());
-	if(packPathNames_)      obj.packPathNames(names);
-	if(packLabels_)      obj.packFilterLabels(iEvent,*handleTriggerResults);
+  const edm::TriggerNames& names = iEvent.triggerNames(*handleTriggerResults);
+  for (pat::TriggerObjectStandAlone& obj : *triggerObjectsStandAlone) {
+    obj.setPSetID(config.parameterSetID());
+    if (packPathNames_)
+      obj.packPathNames(names);
+    if (packLabels_)
+      obj.packFilterLabels(iEvent, *handleTriggerResults);
   }
-  
+
   // Put (finally) stand-alone trigger objects to event
   iEvent.put(std::move(triggerObjectsStandAlone));
 
   firstInRun_ = false;
-
 }
 
-void PATTriggerProducer::ModuleLabelToPathAndFlags::init(const HLTConfigProvider &hltConfig) {
-    clear();
-    const std::vector<std::string> & pathNames = hltConfig.triggerNames();
-    unsigned int sizePaths = pathNames.size();
-    for ( unsigned int indexPath = 0; indexPath < sizePaths; ++indexPath ) {
-        const std::string & namePath = pathNames[indexPath];
+void PATTriggerProducer::ModuleLabelToPathAndFlags::init(const HLTConfigProvider& hltConfig) {
+  clear();
+  const std::vector<std::string>& pathNames = hltConfig.triggerNames();
+  unsigned int sizePaths = pathNames.size();
+  for (unsigned int indexPath = 0; indexPath < sizePaths; ++indexPath) {
+    const std::string& namePath = pathNames[indexPath];
 
-        const std::vector<std::string> & nameModules = hltConfig.moduleLabels(indexPath);
-        unsigned int sizeModulesPath = nameModules.size();
-        bool lastFilter = true;
-        unsigned int iM = sizeModulesPath;
-        while (iM > 0) {
-            const std::string & nameFilter = nameModules[--iM];
-            if (hltConfig.moduleEDMType(nameFilter) != "EDFilter") continue;
-            if (hltConfig.moduleType(nameFilter)    == "HLTBool")  continue;
-            bool saveTags = hltConfig.saveTags(nameFilter);
-            insert( nameFilter, namePath, indexPath, lastFilter, saveTags );
-            if (saveTags) lastFilter = false; // FIXME: rather always?
-        }
+    const std::vector<std::string>& nameModules = hltConfig.moduleLabels(indexPath);
+    unsigned int sizeModulesPath = nameModules.size();
+    bool lastFilter = true;
+    unsigned int iM = sizeModulesPath;
+    while (iM > 0) {
+      const std::string& nameFilter = nameModules[--iM];
+      if (hltConfig.moduleEDMType(nameFilter) != "EDFilter")
+        continue;
+      if (hltConfig.moduleType(nameFilter) == "HLTBool")
+        continue;
+      bool saveTags = hltConfig.saveTags(nameFilter);
+      insert(nameFilter, namePath, indexPath, lastFilter, saveTags);
+      if (saveTags)
+        lastFilter = false;  // FIXME: rather always?
     }
+  }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE( PATTriggerProducer );
+DEFINE_FWK_MODULE(PATTriggerProducer);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_PatAlgos_PATTriggerProducer_h
 #define PhysicsTools_PatAlgos_PATTriggerProducer_h
 
-
 // -*- C++ -*-
 //
 // Package:    PatAlgos
@@ -35,7 +34,6 @@
   \version  $Id: PATTriggerProducer.h,v 1.20 2012/09/11 22:45:29 vadler Exp $
 */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/GetterOfProducts.h"
@@ -56,100 +54,98 @@
 namespace pat {
 
   class PATTriggerProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATTriggerProducer(const edm::ParameterSet& iConfig);
+    ~PATTriggerProducer() override{};
 
+  private:
+    void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock& iLuminosityBlock, const edm::EventSetup& iSetup) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+    std::string nameProcess_;  // configuration
+    bool autoProcessName_;
+    bool onlyStandAlone_;  // configuration
+    bool firstInRun_;
+    // L1
+    edm::ParameterSet* l1PSet_;
+    bool addL1Algos_;                             // configuration (optional with default)
+    edm::InputTag tagL1GlobalTriggerObjectMaps_;  // configuration (optional with default)
+    edm::EDGetTokenT<L1GlobalTriggerObjectMaps> l1GlobalTriggerObjectMapsToken_;
+    edm::InputTag tagL1ExtraMu_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1MuonParticleCollection> l1ExtraMuGetter_;
+    edm::InputTag tagL1ExtraNoIsoEG_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1EmParticleCollection> l1ExtraNoIsoEGGetter_;
+    edm::InputTag tagL1ExtraIsoEG_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1EmParticleCollection> l1ExtraIsoEGGetter_;
+    edm::InputTag tagL1ExtraCenJet_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1JetParticleCollection> l1ExtraCenJetGetter_;
+    edm::InputTag tagL1ExtraForJet_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1JetParticleCollection> l1ExtraForJetGetter_;
+    edm::InputTag tagL1ExtraTauJet_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1JetParticleCollection> l1ExtraTauJetGetter_;
+    edm::InputTag tagL1ExtraETM_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1EtMissParticleCollection> l1ExtraETMGetter_;
+    edm::InputTag tagL1ExtraHTM_;  // configuration (optional)
+    edm::GetterOfProducts<l1extra::L1EtMissParticleCollection> l1ExtraHTMGetter_;
+    bool autoProcessNameL1ExtraMu_;
+    bool autoProcessNameL1ExtraNoIsoEG_;
+    bool autoProcessNameL1ExtraIsoEG_;
+    bool autoProcessNameL1ExtraCenJet_;
+    bool autoProcessNameL1ExtraForJet_;
+    bool autoProcessNameL1ExtraTauJet_;
+    bool autoProcessNameL1ExtraETM_;
+    bool autoProcessNameL1ExtraHTM_;
+    bool mainBxOnly_;  // configuration (optional with default)
+    bool saveL1Refs_;  // configuration (optional with default)
+    // HLT
+    HLTPrescaleProvider hltPrescaleProvider_;
+    bool hltConfigInit_;
+    edm::InputTag tagTriggerResults_;  // configuration (optional with default)
+    edm::GetterOfProducts<edm::TriggerResults> triggerResultsGetter_;
+    edm::InputTag tagTriggerEvent_;  // configuration (optional with default)
+    edm::GetterOfProducts<trigger::TriggerEvent> triggerEventGetter_;
+    std::string hltPrescaleLabel_;       // configuration (optional)
+    std::string labelHltPrescaleTable_;  // configuration (optional)
+    edm::GetterOfProducts<trigger::HLTPrescaleTable> hltPrescaleTableRunGetter_;
+    edm::GetterOfProducts<trigger::HLTPrescaleTable> hltPrescaleTableLumiGetter_;
+    edm::GetterOfProducts<trigger::HLTPrescaleTable> hltPrescaleTableEventGetter_;
+    trigger::HLTPrescaleTable hltPrescaleTableRun_;
+    trigger::HLTPrescaleTable hltPrescaleTableLumi_;
+    bool addPathModuleLabels_;                    // configuration (optional with default)
+    std::vector<std::string> exludeCollections_;  // configuration (optional)
+    bool packPathNames_;                          // configuration (optional width default)
+    bool packLabels_;                             // configuration (optional width default)
+    bool packPrescales_;                          // configuration (optional width default)
+
+    class ModuleLabelToPathAndFlags {
     public:
-
-      explicit PATTriggerProducer( const edm::ParameterSet & iConfig );
-      ~PATTriggerProducer() override {};
+      struct PathAndFlags {
+        PathAndFlags(const std::string& name, unsigned int index, bool last, bool l3)
+            : pathName(name), pathIndex(index), lastFilter(last), l3Filter(l3) {}
+        PathAndFlags() {}
+        std::string pathName;
+        unsigned int pathIndex;
+        bool lastFilter;
+        bool l3Filter;
+      };
+      void init(const HLTConfigProvider&);
+      void clear() { map_.clear(); }
+      const std::vector<PathAndFlags>& operator[](const std::string& filter) const {
+        std::map<std::string, std::vector<PathAndFlags> >::const_iterator it = map_.find(filter);
+        return (it == map_.end() ? empty_ : it->second);
+      }
 
     private:
-
-      void beginRun(const edm::Run & iRun, const edm::EventSetup& iSetup) override;
-      void beginLuminosityBlock(const edm::LuminosityBlock & iLuminosityBlock, const edm::EventSetup& iSetup) override;
-      void produce( edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-
-      std::string nameProcess_;     // configuration
-      bool        autoProcessName_;
-      bool        onlyStandAlone_;  // configuration
-      bool        firstInRun_;
-      // L1
-      edm::ParameterSet * l1PSet_;
-      bool                addL1Algos_;                    // configuration (optional with default)
-      edm::InputTag       tagL1GlobalTriggerObjectMaps_;  // configuration (optional with default)
-      edm::EDGetTokenT< L1GlobalTriggerObjectMaps > l1GlobalTriggerObjectMapsToken_;
-      edm::InputTag       tagL1ExtraMu_;                  // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1MuonParticleCollection > l1ExtraMuGetter_;
-      edm::InputTag       tagL1ExtraNoIsoEG_;             // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1EmParticleCollection > l1ExtraNoIsoEGGetter_;
-      edm::InputTag       tagL1ExtraIsoEG_;               // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1EmParticleCollection > l1ExtraIsoEGGetter_;
-      edm::InputTag       tagL1ExtraCenJet_;              // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1JetParticleCollection > l1ExtraCenJetGetter_;
-      edm::InputTag       tagL1ExtraForJet_;              // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1JetParticleCollection > l1ExtraForJetGetter_;
-      edm::InputTag       tagL1ExtraTauJet_;              // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1JetParticleCollection > l1ExtraTauJetGetter_;
-      edm::InputTag       tagL1ExtraETM_;                 // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1EtMissParticleCollection > l1ExtraETMGetter_;
-      edm::InputTag       tagL1ExtraHTM_;                 // configuration (optional)
-      edm::GetterOfProducts< l1extra::L1EtMissParticleCollection > l1ExtraHTMGetter_;
-      bool                autoProcessNameL1ExtraMu_;
-      bool                autoProcessNameL1ExtraNoIsoEG_;
-      bool                autoProcessNameL1ExtraIsoEG_;
-      bool                autoProcessNameL1ExtraCenJet_;
-      bool                autoProcessNameL1ExtraForJet_;
-      bool                autoProcessNameL1ExtraTauJet_;
-      bool                autoProcessNameL1ExtraETM_;
-      bool                autoProcessNameL1ExtraHTM_;
-      bool                mainBxOnly_;                    // configuration (optional with default)
-      bool                saveL1Refs_;                    // configuration (optional with default)
-      // HLT
-      HLTPrescaleProvider hltPrescaleProvider_;
-      bool                      hltConfigInit_;
-      edm::InputTag             tagTriggerResults_;     // configuration (optional with default)
-      edm::GetterOfProducts< edm::TriggerResults > triggerResultsGetter_;
-      edm::InputTag             tagTriggerEvent_;       // configuration (optional with default)
-      edm::GetterOfProducts< trigger::TriggerEvent > triggerEventGetter_;
-      std::string               hltPrescaleLabel_;      // configuration (optional)
-      std::string               labelHltPrescaleTable_; // configuration (optional)
-      edm::GetterOfProducts< trigger::HLTPrescaleTable > hltPrescaleTableRunGetter_;
-      edm::GetterOfProducts< trigger::HLTPrescaleTable > hltPrescaleTableLumiGetter_;
-      edm::GetterOfProducts< trigger::HLTPrescaleTable > hltPrescaleTableEventGetter_;
-      trigger::HLTPrescaleTable hltPrescaleTableRun_;
-      trigger::HLTPrescaleTable hltPrescaleTableLumi_;
-      bool                       addPathModuleLabels_;  // configuration (optional with default)
-      std::vector< std::string > exludeCollections_;    // configuration (optional)
-      bool                      packPathNames_;         // configuration (optional width default)
-      bool                      packLabels_;         // configuration (optional width default)
-      bool                      packPrescales_;         // configuration (optional width default)
-
-      class ModuleLabelToPathAndFlags {
-          public:
-              struct PathAndFlags {
-                PathAndFlags(const std::string &name, unsigned int index, bool last, bool l3) : pathName(name), pathIndex(index), lastFilter(last), l3Filter(l3) {}
-                PathAndFlags() {}
-                std::string pathName;
-                unsigned int pathIndex;
-                bool lastFilter;
-                bool l3Filter;
-              };
-              void init(const HLTConfigProvider &) ;
-              void clear() { map_.clear(); }
-              const std::vector<PathAndFlags> & operator[](const std::string & filter) const {
-                  std::map<std::string,std::vector<PathAndFlags> >::const_iterator it = map_.find(filter);
-                  return (it == map_.end() ? empty_ : it->second);
-              }
-          private:
-              void insert(const std::string & filter, const std::string &path, unsigned int pathIndex, bool lastFilter, bool l3Filter) {
-                  map_[filter].push_back(PathAndFlags(path, pathIndex, lastFilter, l3Filter));
-              }
-              std::map<std::string,std::vector<PathAndFlags> > map_;
-              const std::vector<PathAndFlags> empty_;
-      };
-      ModuleLabelToPathAndFlags moduleLabelToPathAndFlags_;
-
+      void insert(
+          const std::string& filter, const std::string& path, unsigned int pathIndex, bool lastFilter, bool l3Filter) {
+        map_[filter].push_back(PathAndFlags(path, pathIndex, lastFilter, l3Filter));
+      }
+      std::map<std::string, std::vector<PathAndFlags> > map_;
+      const std::vector<PathAndFlags> empty_;
+    };
+    ModuleLabelToPathAndFlags moduleLabelToPathAndFlags_;
   };
-}
-
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATVertexSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATVertexSlimmer.cc
@@ -18,60 +18,63 @@ namespace pat {
   public:
     explicit PATVertexSlimmer(const edm::ParameterSet&);
     ~PATVertexSlimmer() override;
-    
+
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
   private:
-    const edm::EDGetTokenT<std::vector<reco::Vertex> > src_;
-    const edm::EDGetTokenT<edm::ValueMap<float> > score_;
+    const edm::EDGetTokenT<std::vector<reco::Vertex>> src_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> score_;
     const bool rekeyScores_;
   };
-}
+}  // namespace pat
 
-pat::PATVertexSlimmer::PATVertexSlimmer(const edm::ParameterSet& iConfig) :
-    src_(consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("src"))),
-    score_(mayConsume<edm::ValueMap<float>>(iConfig.existsAs<edm::InputTag>("score")?iConfig.getParameter<edm::InputTag>("score"):edm::InputTag())),
-    rekeyScores_(iConfig.existsAs<edm::InputTag>("score"))
-{
-  produces<std::vector<reco::Vertex> >();
-  if(rekeyScores_) produces<edm::ValueMap<float> >();
+pat::PATVertexSlimmer::PATVertexSlimmer(const edm::ParameterSet& iConfig)
+    : src_(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("src"))),
+      score_(mayConsume<edm::ValueMap<float>>(
+          iConfig.existsAs<edm::InputTag>("score") ? iConfig.getParameter<edm::InputTag>("score") : edm::InputTag())),
+      rekeyScores_(iConfig.existsAs<edm::InputTag>("score")) {
+  produces<std::vector<reco::Vertex>>();
+  if (rekeyScores_)
+    produces<edm::ValueMap<float>>();
 }
 
 pat::PATVertexSlimmer::~PATVertexSlimmer() {}
 
 void pat::PATVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-    edm::Handle<std::vector<reco::Vertex> > vertices;
-    iEvent.getByToken(src_, vertices);
-    auto outPtr = std::make_unique<std::vector<reco::Vertex>>();
+  edm::Handle<std::vector<reco::Vertex>> vertices;
+  iEvent.getByToken(src_, vertices);
+  auto outPtr = std::make_unique<std::vector<reco::Vertex>>();
 
-    outPtr->reserve(vertices->size());
-    for (unsigned int i = 0, n = vertices->size(); i < n; ++i) {
-        const reco::Vertex &v = (*vertices)[i];
-        auto co = v.covariance4D();
-        if(i>0) {
-          for(size_t j=0;j<4;j++){
-            for(size_t k=j;k<4;k++){
-              co(j,k) = MiniFloatConverter::reduceMantissaToNbits<10>( co(j,k) );
-            }
-          }
+  outPtr->reserve(vertices->size());
+  for (unsigned int i = 0, n = vertices->size(); i < n; ++i) {
+    const reco::Vertex& v = (*vertices)[i];
+    auto co = v.covariance4D();
+    if (i > 0) {
+      for (size_t j = 0; j < 4; j++) {
+        for (size_t k = j; k < 4; k++) {
+          co(j, k) = MiniFloatConverter::reduceMantissaToNbits<10>(co(j, k));
         }
-        outPtr->push_back(reco::Vertex(v.position(), co, v.t(), v.chi2(), v.ndof(), 0));
-    }
-
-    auto oh = iEvent.put(std::move(outPtr));
-    if(rekeyScores_) {
-      edm::Handle<edm::ValueMap<float> > scores;
-      iEvent.getByToken(score_, scores);
-      auto vertexScoreOutput = std::make_unique<edm::ValueMap<float>>();
-      edm::ValueMap<float>::const_iterator idIt=scores->begin();
-      for(;idIt!=scores->end();idIt++) {
-          if(idIt.id() ==  vertices.id()) break;
       }
-      // std::find_if(scores->begin(), scores->end(), [vertices] (const edm::ValueMap<float>::const_iterator& s) { return s.id() == vertices.id(); } );
-      edm::ValueMap<float>::Filler vertexScoreFiller(*vertexScoreOutput);
-      vertexScoreFiller.insert(oh,idIt.begin(),idIt.end());
-      vertexScoreFiller.fill();
-      iEvent.put(std::move(vertexScoreOutput));
     }
+    outPtr->push_back(reco::Vertex(v.position(), co, v.t(), v.chi2(), v.ndof(), 0));
+  }
+
+  auto oh = iEvent.put(std::move(outPtr));
+  if (rekeyScores_) {
+    edm::Handle<edm::ValueMap<float>> scores;
+    iEvent.getByToken(score_, scores);
+    auto vertexScoreOutput = std::make_unique<edm::ValueMap<float>>();
+    edm::ValueMap<float>::const_iterator idIt = scores->begin();
+    for (; idIt != scores->end(); idIt++) {
+      if (idIt.id() == vertices.id())
+        break;
+    }
+    // std::find_if(scores->begin(), scores->end(), [vertices] (const edm::ValueMap<float>::const_iterator& s) { return s.id() == vertices.id(); } );
+    edm::ValueMap<float>::Filler vertexScoreFiller(*vertexScoreOutput);
+    vertexScoreFiller.insert(oh, idIt.begin(), idIt.end());
+    vertexScoreFiller.fill();
+    iEvent.put(std::move(vertexScoreOutput));
+  }
 }
 
 using pat::PATVertexSlimmer;

--- a/PhysicsTools/PatAlgos/plugins/PackedPFCandidateRefMixer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedPFCandidateRefMixer.cc
@@ -20,71 +20,71 @@
 
 namespace pat {
   class PackedPFCandidateRefMixer : public edm::stream::EDProducer<> {
-    public:
-      explicit PackedPFCandidateRefMixer(const edm::ParameterSet & iConfig);
-      ~PackedPFCandidateRefMixer() override { }
+  public:
+    explicit PackedPFCandidateRefMixer(const edm::ParameterSet& iConfig);
+    ~PackedPFCandidateRefMixer() override {}
 
-      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    private:
-      edm::EDGetTokenT<std::vector<reco::PFCandidate>> pf_;
-      edm::EDGetTokenT<edm::ValueMap<reco::PFCandidateRef>> pf2pf_;
-      std::vector<edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>>> pf2pcs_;
+  private:
+    edm::EDGetTokenT<std::vector<reco::PFCandidate>> pf_;
+    edm::EDGetTokenT<edm::ValueMap<reco::PFCandidateRef>> pf2pf_;
+    std::vector<edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>>> pf2pcs_;
   };
 
-} // namespace
+}  // namespace pat
 
-
-pat::PackedPFCandidateRefMixer::PackedPFCandidateRefMixer(const edm::ParameterSet & iConfig) :
-    pf_(consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pf"))),
-    pf2pf_(consumes<edm::ValueMap<reco::PFCandidateRef>>(iConfig.getParameter<edm::InputTag>("pf2pf")))
-{
-    for (edm::InputTag const& tag : iConfig.getParameter<std::vector<edm::InputTag>>("pf2packed")) {
-        pf2pcs_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
-    }
-    produces<edm::ValueMap<reco::CandidatePtr>>();
+pat::PackedPFCandidateRefMixer::PackedPFCandidateRefMixer(const edm::ParameterSet& iConfig)
+    : pf_(consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pf"))),
+      pf2pf_(consumes<edm::ValueMap<reco::PFCandidateRef>>(iConfig.getParameter<edm::InputTag>("pf2pf"))) {
+  for (edm::InputTag const& tag : iConfig.getParameter<std::vector<edm::InputTag>>("pf2packed")) {
+    pf2pcs_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
+  }
+  produces<edm::ValueMap<reco::CandidatePtr>>();
 }
 
-
-void 
-pat::PackedPFCandidateRefMixer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    edm::Handle<std::vector<reco::PFCandidate>> pf;
-    edm::Handle<edm::ValueMap<reco::PFCandidateRef>> pf2pf;
-    std::vector<edm::Handle<edm::Association<pat::PackedCandidateCollection>>> pf2pcs(pf2pcs_.size());
-    iEvent.getByToken(pf_, pf);
-    iEvent.getByToken(pf2pf_, pf2pf);
-    for (unsigned int i = 0, n = pf2pcs.size(); i < n; ++i) {
-        iEvent.getByToken(pf2pcs_[i], pf2pcs[i]);
+void pat::PackedPFCandidateRefMixer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<reco::PFCandidate>> pf;
+  edm::Handle<edm::ValueMap<reco::PFCandidateRef>> pf2pf;
+  std::vector<edm::Handle<edm::Association<pat::PackedCandidateCollection>>> pf2pcs(pf2pcs_.size());
+  iEvent.getByToken(pf_, pf);
+  iEvent.getByToken(pf2pf_, pf2pf);
+  for (unsigned int i = 0, n = pf2pcs.size(); i < n; ++i) {
+    iEvent.getByToken(pf2pcs_[i], pf2pcs[i]);
+  }
+  std::vector<reco::CandidatePtr> outptrs;
+  outptrs.reserve(pf->size());
+  for (unsigned int i = 0, n = pf->size(); i < n; ++i) {
+    reco::PFCandidateRef oldpfRef(pf, i);
+    const auto& newpfRef = (*pf2pf)[oldpfRef];
+    bool found = false;
+    for (const auto& pf2pc : pf2pcs) {
+      if (pf2pc->contains(newpfRef.id())) {
+        outptrs.push_back(refToPtr((*pf2pc)[newpfRef]));
+        found = true;
+        break;
+      }
     }
-    std::vector<reco::CandidatePtr> outptrs;
-    outptrs.reserve(pf->size());
-    for (unsigned int i = 0, n = pf->size(); i < n; ++i) {
-        reco::PFCandidateRef oldpfRef(pf, i);
-        const auto & newpfRef = (*pf2pf)[oldpfRef];
-        bool found = false;
-        for (const auto & pf2pc : pf2pcs) {
-            if (pf2pc->contains(newpfRef.id())) {
-                outptrs.push_back(refToPtr((*pf2pc)[newpfRef]));
-                found = true;
-                break;
-            }
+    if (!found) {
+      edm::LogPrint("PackedPFCandidateRefMixer") << "oldpfRef: " << oldpfRef.id() << " / " << oldpfRef.key() << "\n";
+      edm::LogPrint("PackedPFCandidateRefMixer") << "newpfRef: " << newpfRef.id() << " / " << newpfRef.key() << "\n";
+      edm::LogPrint("PackedPFCandidateRefMixer") << "and I have " << pf2pcs.size() << " rekey maps."
+                                                 << "\n";
+      for (const auto& pf2pc : pf2pcs) {
+        edm::LogPrint("PackedPFCandidateRefMixer") << "this map has keys in: "
+                                                   << "\n";
+        for (const auto& pair : pf2pc->ids()) {
+          edm::LogPrint("PackedPFCandidateRefMixer") << "\t" << pair.first << "\n";
         }
-        if (!found) {
-            edm::LogPrint("PackedPFCandidateRefMixer") << "oldpfRef: " << oldpfRef.id() << " / " << oldpfRef.key() << "\n";
-            edm::LogPrint("PackedPFCandidateRefMixer") << "newpfRef: " << newpfRef.id() << " / " << newpfRef.key() << "\n";
-            edm::LogPrint("PackedPFCandidateRefMixer") << "and I have " << pf2pcs.size() << " rekey maps." << "\n";
-            for (const auto & pf2pc : pf2pcs) {
-                edm::LogPrint("PackedPFCandidateRefMixer") << "this map has keys in: " << "\n";
-                for (const auto & pair : pf2pc->ids()) { edm::LogPrint("PackedPFCandidateRefMixer") << "\t" << pair.first << "\n"; }
-            }
-            throw cms::Exception("LogicError") << "A packed candidate has refs that we don't understand\n";
-        }
+      }
+      throw cms::Exception("LogicError") << "A packed candidate has refs that we don't understand\n";
     }
-    std::unique_ptr<edm::ValueMap<reco::CandidatePtr>> out(new edm::ValueMap<reco::CandidatePtr>());
-    edm::ValueMap<reco::CandidatePtr>::Filler filler(*out);
-    filler.insert(pf, outptrs.begin(), outptrs.end());
-    filler.fill();
-    iEvent.put(std::move(out));
+  }
+  std::unique_ptr<edm::ValueMap<reco::CandidatePtr>> out(new edm::ValueMap<reco::CandidatePtr>());
+  edm::ValueMap<reco::CandidatePtr>::Filler filler(*out);
+  filler.insert(pf, outptrs.begin(), outptrs.end());
+  filler.fill();
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
@@ -9,33 +9,31 @@
 
 class PileupSummaryInfoSlimmer : public edm::global::EDProducer<> {
 public:
-  PileupSummaryInfoSlimmer(const edm::ParameterSet& conf) :
-    src_(consumes<std::vector<PileupSummaryInfo> >(conf.getParameter<edm::InputTag>("src"))),
-    keepDetailedInfoFor_(conf.getParameter<std::vector<int32_t> >("keepDetailedInfoFor")) {
-    produces<std::vector<PileupSummaryInfo> >();
+  PileupSummaryInfoSlimmer(const edm::ParameterSet& conf)
+      : src_(consumes<std::vector<PileupSummaryInfo>>(conf.getParameter<edm::InputTag>("src"))),
+        keepDetailedInfoFor_(conf.getParameter<std::vector<int32_t>>("keepDetailedInfoFor")) {
+    produces<std::vector<PileupSummaryInfo>>();
   }
 
-  void produce(edm::StreamID, edm::Event &, edm::EventSetup const &) const final;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
 
 private:
-  const edm::EDGetTokenT<std::vector<PileupSummaryInfo> > src_;
+  const edm::EDGetTokenT<std::vector<PileupSummaryInfo>> src_;
   const std::vector<int> keepDetailedInfoFor_;
 };
 
-void PileupSummaryInfoSlimmer::produce(edm::StreamID, 
-                                       edm::Event& evt,
-                                       const edm::EventSetup& es ) const {
-  edm::Handle<std::vector<PileupSummaryInfo> > input;
+void PileupSummaryInfoSlimmer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {
+  edm::Handle<std::vector<PileupSummaryInfo>> input;
   auto output = std::make_unique<std::vector<PileupSummaryInfo>>();
 
-  evt.getByToken(src_,input);
-  
-  for( const auto& psu : *input ) {
+  evt.getByToken(src_, input);
+
+  for (const auto& psu : *input) {
     const int bunchCrossing = psu.getBunchCrossing();
     const int bunchSpacing = psu.getBunchSpacing();
     const int num_PU_vertices = psu.getPU_NumInteractions();
     const float TrueNumInteractions = psu.getTrueNumInteractions();
-    
+
     std::vector<float> zpositions;
     std::vector<float> times;
     std::vector<float> sumpT_lowpT;
@@ -45,26 +43,27 @@ void PileupSummaryInfoSlimmer::produce(edm::StreamID,
     std::vector<edm::EventID> eventInfo;
     std::vector<float> pT_hats;
 
-    const bool keep_details = std::find(keepDetailedInfoFor_.begin(),
-                                        keepDetailedInfoFor_.end(),
-                                        bunchCrossing) != keepDetailedInfoFor_.end();
-    
-    if( keep_details ) {
-      zpositions   = psu.getPU_zpositions();
-      times        = psu.getPU_times();
-      sumpT_lowpT  = psu.getPU_sumpT_lowpT();
+    const bool keep_details = std::find(keepDetailedInfoFor_.begin(), keepDetailedInfoFor_.end(), bunchCrossing) !=
+                              keepDetailedInfoFor_.end();
+
+    if (keep_details) {
+      zpositions = psu.getPU_zpositions();
+      times = psu.getPU_times();
+      sumpT_lowpT = psu.getPU_sumpT_lowpT();
       sumpT_highpT = psu.getPU_sumpT_highpT();
-      ntrks_lowpT  = psu.getPU_ntrks_lowpT();
+      ntrks_lowpT = psu.getPU_ntrks_lowpT();
       ntrks_highpT = psu.getPU_ntrks_highpT();
-      eventInfo    = psu.getPU_EventID();
-      pT_hats      = psu.getPU_pT_hats();
+      eventInfo = psu.getPU_EventID();
+      pT_hats = psu.getPU_pT_hats();
     }
     // insert the slimmed vertex info
     output->emplace_back(num_PU_vertices,
                          zpositions,
                          times,
-                         sumpT_lowpT, sumpT_highpT,
-                         ntrks_lowpT, ntrks_highpT,
+                         sumpT_lowpT,
+                         sumpT_highpT,
+                         ntrks_lowpT,
+                         ntrks_highpT,
                          eventInfo,
                          pT_hats,
                          bunchCrossing,

--- a/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
+++ b/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.cc
@@ -8,56 +8,59 @@
 using namespace pat;
 
 RecoMETExtractor::RecoMETExtractor(const edm::ParameterSet& iConfig) {
-
   edm::InputTag metIT = iConfig.getParameter<edm::InputTag>("metSource");
   metSrcToken_ = consumes<pat::METCollection>(metIT);
-  
+
   std::string corLevel = iConfig.getParameter<std::string>("correctionLevel");
 
   //all possible met flavors
-  if(corLevel=="raw")           { corLevel_=pat::MET::Raw;}
-  else if(corLevel=="type1")         { corLevel_=pat::MET::Type1;}
-  else if(corLevel=="type01")        { corLevel_=pat::MET::Type01;}
-  else if(corLevel=="typeXY")        { corLevel_=pat::MET::TypeXY;}
-  else if(corLevel=="type1XY")       { corLevel_=pat::MET::Type1XY;}
-  else if(corLevel=="type01XY")      { corLevel_=pat::MET::Type01XY;}
-  else if(corLevel=="type1Smear")    { corLevel_=pat::MET::Type1Smear;}
-  else if(corLevel=="type01Smear")   { corLevel_=pat::MET::Type01Smear;}
-  else if(corLevel=="type1SmearXY")  { corLevel_=pat::MET::Type1SmearXY;}
-  else if(corLevel=="type01SmearXY") { corLevel_=pat::MET::Type01SmearXY;}
-  else if(corLevel=="rawCalo")       { corLevel_=pat::MET::RawCalo;}
-  else {
+  if (corLevel == "raw") {
+    corLevel_ = pat::MET::Raw;
+  } else if (corLevel == "type1") {
+    corLevel_ = pat::MET::Type1;
+  } else if (corLevel == "type01") {
+    corLevel_ = pat::MET::Type01;
+  } else if (corLevel == "typeXY") {
+    corLevel_ = pat::MET::TypeXY;
+  } else if (corLevel == "type1XY") {
+    corLevel_ = pat::MET::Type1XY;
+  } else if (corLevel == "type01XY") {
+    corLevel_ = pat::MET::Type01XY;
+  } else if (corLevel == "type1Smear") {
+    corLevel_ = pat::MET::Type1Smear;
+  } else if (corLevel == "type01Smear") {
+    corLevel_ = pat::MET::Type01Smear;
+  } else if (corLevel == "type1SmearXY") {
+    corLevel_ = pat::MET::Type1SmearXY;
+  } else if (corLevel == "type01SmearXY") {
+    corLevel_ = pat::MET::Type01SmearXY;
+  } else if (corLevel == "rawCalo") {
+    corLevel_ = pat::MET::RawCalo;
+  } else {
     //throw exception
-
   }
 
   // produces vector of recoMet
   produces<std::vector<reco::MET> >();
 }
 
+RecoMETExtractor::~RecoMETExtractor() {}
 
-RecoMETExtractor::~RecoMETExtractor() {
-
-}
-
-
-void RecoMETExtractor::produce(edm::StreamID streamID, edm::Event & iEvent,
-			       const edm::EventSetup & iSetup) const {
-
-  edm::Handle<std::vector<pat::MET> >  src;
+void RecoMETExtractor::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<std::vector<pat::MET> > src;
   iEvent.getByToken(metSrcToken_, src);
-  if(src->empty()) edm::LogError("RecoMETExtractor::produce") << "input reco MET collection is empty" ;
+  if (src->empty())
+    edm::LogError("RecoMETExtractor::produce") << "input reco MET collection is empty";
 
-  std::vector<reco::MET> *metCol = new std::vector<reco::MET>();
-  
-  reco::MET met(src->front().corSumEt(corLevel_), src->front().corP4(corLevel_), src->front().vertex() );
-  
-  metCol->push_back( met );
-  
+  std::vector<reco::MET>* metCol = new std::vector<reco::MET>();
+
+  reco::MET met(src->front().corSumEt(corLevel_), src->front().corP4(corLevel_), src->front().vertex());
+
+  metCol->push_back(met);
+
   std::unique_ptr<std::vector<reco::MET> > recoMETs(metCol);
   iEvent.put(std::move(recoMETs));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.h
+++ b/PhysicsTools/PatAlgos/plugins/RecoMETExtractor.h
@@ -12,7 +12,6 @@
   \version  $Id: RecoMETExtractor.h,v 1.0 2015/07/22 mmarionn Exp $
 */
 
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -25,23 +24,18 @@
 namespace pat {
 
   class RecoMETExtractor : public edm::global::EDProducer<> {
-
-    public:
-
+  public:
     explicit RecoMETExtractor(const edm::ParameterSet& iConfig);
     ~RecoMETExtractor() override;
 
-    void produce(edm::StreamID streamID, edm::Event & iEvent,
-			 const edm::EventSetup & iSetup) const override;
+    void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   private:
-
     edm::EDGetTokenT<std::vector<pat::MET> > metSrcToken_;
-    
-    pat::MET::METCorrectionLevel corLevel_;
 
+    pat::MET::METCorrectionLevel corLevel_;
   };
 
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/StringResolutionProviderESProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/StringResolutionProviderESProducer.cc
@@ -4,30 +4,29 @@
 #include "PhysicsTools/PatAlgos/interface/StringResolutionProvider.h"
 #include "PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h"
 
-class StringResolutionProviderESProducer : public edm::ESProducer 
-                                         {
-        public:
-                StringResolutionProviderESProducer() { }
-                StringResolutionProviderESProducer(const edm::ParameterSet &iConfig) ;
+class StringResolutionProviderESProducer : public edm::ESProducer {
+public:
+  StringResolutionProviderESProducer() {}
+  StringResolutionProviderESProducer(const edm::ParameterSet &iConfig);
 
-                std::unique_ptr<KinematicResolutionProvider>  produce(const KinematicResolutionRcd &rcd) ;
+  std::unique_ptr<KinematicResolutionProvider> produce(const KinematicResolutionRcd &rcd);
 
-        private:
-                edm::ParameterSet cfg_;
+private:
+  edm::ParameterSet cfg_;
 };
 
-StringResolutionProviderESProducer::StringResolutionProviderESProducer(const edm::ParameterSet &iConfig) :
-           cfg_(iConfig) {
-   std::string myName = iConfig.getParameter<std::string>("@module_label");
-   setWhatProduced(this,myName);
+StringResolutionProviderESProducer::StringResolutionProviderESProducer(const edm::ParameterSet &iConfig)
+    : cfg_(iConfig) {
+  std::string myName = iConfig.getParameter<std::string>("@module_label");
+  setWhatProduced(this, myName);
 }
 
-std::unique_ptr<KinematicResolutionProvider> 
-StringResolutionProviderESProducer::produce(const KinematicResolutionRcd &rcd) {
-        return std::make_unique<StringResolutionProvider>(cfg_);
+std::unique_ptr<KinematicResolutionProvider> StringResolutionProviderESProducer::produce(
+    const KinematicResolutionRcd &rcd) {
+  return std::make_unique<StringResolutionProvider>(cfg_);
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
-DEFINE_FWK_EVENTSETUP_MODULE( StringResolutionProviderESProducer );
+DEFINE_FWK_EVENTSETUP_MODULE(StringResolutionProviderESProducer);

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
@@ -13,59 +13,53 @@ typedef edm::ValueMap<pat::TauJetCorrFactors> TauJetCorrFactorsMap;
 using namespace pat;
 
 TauJetCorrFactorsProducer::TauJetCorrFactorsProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    srcToken_(consumes<edm::View<reco::BaseTau> >(cfg.getParameter<edm::InputTag>("src"))),
-    levels_(cfg.getParameter<std::vector<std::string> >("levels"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+      srcToken_(consumes<edm::View<reco::BaseTau> >(cfg.getParameter<edm::InputTag>("src"))),
+      levels_(cfg.getParameter<std::vector<std::string> >("levels")) {
   typedef std::vector<edm::ParameterSet> vParameterSet;
   vParameterSet parameters = cfg.getParameter<vParameterSet>("parameters");
-  for ( vParameterSet::const_iterator param = parameters.begin();
-	param != parameters.end(); ++param ) {
+  for (vParameterSet::const_iterator param = parameters.begin(); param != parameters.end(); ++param) {
     payloadMappingType payloadMapping;
 
     payloadMapping.payload_ = param->getParameter<std::string>("payload");
 
     vstring decayModes_string = param->getParameter<vstring>("decayModes");
-    for ( vstring::const_iterator decayMode = decayModes_string.begin();
-	  decayMode != decayModes_string.end(); ++decayMode ) {
-      if ( (*decayMode) == "*" ) {
-	defaultPayload_ = payloadMapping.payload_;
+    for (vstring::const_iterator decayMode = decayModes_string.begin(); decayMode != decayModes_string.end();
+         ++decayMode) {
+      if ((*decayMode) == "*") {
+        defaultPayload_ = payloadMapping.payload_;
       } else {
-	payloadMapping.decayModes_.push_back(atoi(decayMode->data()));
+        payloadMapping.decayModes_.push_back(atoi(decayMode->data()));
       }
     }
 
-    if ( !payloadMapping.decayModes_.empty() ) payloadMappings_.push_back(payloadMapping);
+    if (!payloadMapping.decayModes_.empty())
+      payloadMappings_.push_back(payloadMapping);
   }
 
   produces<TauJetCorrFactorsMap>();
 }
 
-std::vector<JetCorrectorParameters>
-TauJetCorrFactorsProducer::params(const JetCorrectorParametersCollection& jecParameters, const std::vector<std::string>& levels) const
-{
+std::vector<JetCorrectorParameters> TauJetCorrFactorsProducer::params(
+    const JetCorrectorParametersCollection& jecParameters, const std::vector<std::string>& levels) const {
   std::vector<JetCorrectorParameters> retVal;
-  for ( std::vector<std::string>::const_iterator corrLevel = levels.begin();
-	corrLevel != levels.end(); ++corrLevel ) {
+  for (std::vector<std::string>::const_iterator corrLevel = levels.begin(); corrLevel != levels.end(); ++corrLevel) {
     const JetCorrectorParameters& jecParameter_level = jecParameters[*corrLevel];
     retVal.push_back(jecParameter_level);
   }
   return retVal;
 }
 
-float
-TauJetCorrFactorsProducer::evaluate(edm::View<reco::BaseTau>::const_iterator& tauJet,
-				    boost::shared_ptr<FactorizedJetCorrector>& corrector, int corrLevel)
-{
+float TauJetCorrFactorsProducer::evaluate(edm::View<reco::BaseTau>::const_iterator& tauJet,
+                                          boost::shared_ptr<FactorizedJetCorrector>& corrector,
+                                          int corrLevel) {
   corrector->setJetEta(tauJet->eta());
   corrector->setJetPt(tauJet->pt());
   corrector->setJetE(tauJet->energy());
   return corrector->getSubCorrections()[corrLevel];
 }
 
-void
-TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // get tau-jet collection from the event
   edm::Handle<edm::View<reco::BaseTau> > tauJets;
   evt.getByToken(srcToken_, tauJets);
@@ -75,46 +69,48 @@ TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
   // fill the tauJetCorrFactors
   std::vector<TauJetCorrFactors> tauJetCorrections;
-  for ( edm::View<reco::BaseTau>::const_iterator tauJet = tauJets->begin();
-	tauJet != tauJets->end(); ++tauJet ) {
-
+  for (edm::View<reco::BaseTau>::const_iterator tauJet = tauJets->begin(); tauJet != tauJets->end(); ++tauJet) {
     // the TauJetCorrFactors::CorrectionFactor is a std::pair<std::string, float>
     // the string corresponds to the label of the correction level, the float to the tau-jet energy correction factor.
     // The first correction level is predefined with label 'Uncorrected'. The correction factor is 1.
     std::vector<TauJetCorrFactors::CorrectionFactor> jec;
     jec.push_back(std::make_pair(std::string("Uncorrected"), 1.0));
 
-    if ( levels_.empty() )
+    if (levels_.empty())
       throw cms::Exception("No JECFactors")
-	<< "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
-	<< "This makes no sense, either you should correct this or drop the module from \n"
-	<< "the sequence.";
+          << "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
+          << "This makes no sense, either you should correct this or drop the module from \n"
+          << "the sequence.";
 
     std::string payload = defaultPayload_;
-    if ( dynamic_cast<const reco::PFTau*>(&(*tauJet)) ) {
+    if (dynamic_cast<const reco::PFTau*>(&(*tauJet))) {
       const reco::PFTau* pfTauJet = dynamic_cast<const reco::PFTau*>(&(*tauJet));
-      for ( std::vector<payloadMappingType>::const_iterator payloadMapping = payloadMappings_.begin();
-	    payloadMapping != payloadMappings_.end(); ++payloadMapping ) {
-	for( vint::const_iterator decayMode = payloadMapping->decayModes_.begin();
-	     decayMode != payloadMapping->decayModes_.end(); ++decayMode ) {
-	  if ( pfTauJet->decayMode() == (*decayMode) ) payload = payloadMapping->payload_;
-	}
+      for (std::vector<payloadMappingType>::const_iterator payloadMapping = payloadMappings_.begin();
+           payloadMapping != payloadMappings_.end();
+           ++payloadMapping) {
+        for (vint::const_iterator decayMode = payloadMapping->decayModes_.begin();
+             decayMode != payloadMapping->decayModes_.end();
+             ++decayMode) {
+          if (pfTauJet->decayMode() == (*decayMode))
+            payload = payloadMapping->payload_;
+        }
       }
     }
 
     // retrieve JEC parameters from the DB and build a new corrector,
     // in case it does not exist already for current payload
-    if ( correctorMapping.find(payload) == correctorMapping.end() ) {
+    if (correctorMapping.find(payload) == correctorMapping.end()) {
       edm::ESHandle<JetCorrectorParametersCollection> jecParameters;
       es.get<JetCorrectionsRecord>().get(payload, jecParameters);
 
-      correctorMapping[payload] = FactorizedJetCorrectorPtr(new FactorizedJetCorrector(params(*jecParameters, levels_)));
+      correctorMapping[payload] =
+          FactorizedJetCorrectorPtr(new FactorizedJetCorrector(params(*jecParameters, levels_)));
     }
     FactorizedJetCorrectorPtr& corrector = correctorMapping[payload];
 
     // evaluate tau-jet energy corrections
     size_t numLevels = levels_.size();
-    for ( size_t idx = 0; idx < numLevels; ++idx ) {
+    for (size_t idx = 0; idx < numLevels; ++idx) {
       const std::string& corrLevel = levels_[idx];
 
       float jecFactor = evaluate(tauJet, corrector, idx);
@@ -139,7 +135,7 @@ TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   TauJetCorrFactorsMap::Filler filler(*jecMapping);
   // tauJets and tauJetCorrections vectors have their indices aligned by construction
   filler.insert(tauJets, tauJetCorrections.begin(), tauJetCorrections.end());
-  filler.fill(); // do the actual filling
+  filler.fill();  // do the actual filling
 
   // add valuemap to the event
   evt.put(std::move(jecMapping));

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
@@ -35,24 +35,24 @@
 
 namespace pat {
 
-  class TauJetCorrFactorsProducer : public edm::stream::EDProducer<>
-  {
-   public:
+  class TauJetCorrFactorsProducer : public edm::stream::EDProducer<> {
+  public:
     /// value map for JetCorrFactors (to be written into the event)
     typedef edm::ValueMap<pat::TauJetCorrFactors> JetCorrFactorsMap;
 
-   public:
+  public:
     /// default constructor
     explicit TauJetCorrFactorsProducer(const edm::ParameterSet&);
     /// default destructor
-    ~TauJetCorrFactorsProducer() override {};
+    ~TauJetCorrFactorsProducer() override{};
 
     /// everything that needs to be done per event
     void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
+  private:
     /// return the jec parameters as input to the FactorizedJetCorrector for different flavors
-    std::vector<JetCorrectorParameters> params(const JetCorrectorParametersCollection&, const std::vector<std::string>&) const;
+    std::vector<JetCorrectorParameters> params(const JetCorrectorParametersCollection&,
+                                               const std::vector<std::string>&) const;
 
     /// evaluate jet correction factor up to a given level
     float evaluate(edm::View<reco::BaseTau>::const_iterator&, boost::shared_ptr<FactorizedJetCorrector>&, int);
@@ -61,13 +61,12 @@ namespace pat {
     /// python label of this TauJetCorrFactorsProducer module
     std::string moduleLabel_;
 
-     /// input tau-jet collection
+    /// input tau-jet collection
     edm::EDGetTokenT<edm::View<reco::BaseTau> > srcToken_;
 
     /// mapping of reconstructed tau decay modes to payloads
     typedef std::vector<int> vint;
-    struct payloadMappingType
-    {
+    struct payloadMappingType {
       /// reconstructed tau decay modes associated to this payload,
       /// as defined in DataFormats/TauReco/interface/PFTau.h
       vint decayModes_;
@@ -88,6 +87,6 @@ namespace pat {
     typedef std::vector<std::string> vstring;
     vstring levels_;
   };
-}
+}  // namespace pat
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/TrackAndVertexUnpacker.cc
+++ b/PhysicsTools/PatAlgos/plugins/TrackAndVertexUnpacker.cc
@@ -5,7 +5,6 @@
   \version  $Id: TrackAndVertexUnpacker.cc,v 1.2 2010/02/20 21:00:29 wmtan Exp $
 */
 
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,128 +21,121 @@
 
 //#include "PhysicsTools/PatAlgos/interface/VertexingHelper.h"
 
-
 namespace pat {
-  
+
   class PATTrackAndVertexUnpacker : public edm::global::EDProducer<> {
-    
-    
   public:
-    
-    explicit PATTrackAndVertexUnpacker(const edm::ParameterSet & iConfig);
+    explicit PATTrackAndVertexUnpacker(const edm::ParameterSet& iConfig);
     ~PATTrackAndVertexUnpacker() override;
-    
-    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
-    
+
+    void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
   private:
     typedef std::vector<edm::InputTag> VInputTag;
     // configurables
-    const edm::EDGetTokenT<std::vector<pat::PackedCandidate> >    Cands_;
-    const edm::EDGetTokenT<reco::VertexCollection>         PVs_;
-    const edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection>         SVs_;
-    const edm::EDGetTokenT<std::vector<pat::PackedCandidate> >         AdditionalTracks_;
+    const edm::EDGetTokenT<std::vector<pat::PackedCandidate>> Cands_;
+    const edm::EDGetTokenT<reco::VertexCollection> PVs_;
+    const edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection> SVs_;
+    const edm::EDGetTokenT<std::vector<pat::PackedCandidate>> AdditionalTracks_;
     //////    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > particlesTokens_;
-    
   };
 
-}
+}  // namespace pat
 
 using pat::PATTrackAndVertexUnpacker;
 
-PATTrackAndVertexUnpacker::PATTrackAndVertexUnpacker(const edm::ParameterSet& iConfig) :
-  Cands_(consumes< std::vector<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("packedCandidates"))),
-  PVs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("slimmedVertices"))),
-  SVs_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("slimmedSecondaryVertices"))),
-  AdditionalTracks_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("additionalTracks")))
-{
-    produces<reco::TrackCollection>();
-    produces<reco::VertexCollection>();
-    produces<reco::VertexCollection>("secondary");
+PATTrackAndVertexUnpacker::PATTrackAndVertexUnpacker(const edm::ParameterSet& iConfig)
+    : Cands_(consumes<std::vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("packedCandidates"))),
+      PVs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("slimmedVertices"))),
+      SVs_(consumes<reco::VertexCompositePtrCandidateCollection>(
+          iConfig.getParameter<edm::InputTag>("slimmedSecondaryVertices"))),
+      AdditionalTracks_(
+          consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("additionalTracks"))) {
+  produces<reco::TrackCollection>();
+  produces<reco::VertexCollection>();
+  produces<reco::VertexCollection>("secondary");
 }
 
+PATTrackAndVertexUnpacker::~PATTrackAndVertexUnpacker() {}
 
-PATTrackAndVertexUnpacker::~PATTrackAndVertexUnpacker() {
+void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
+  using namespace std;
+  using namespace reco;
+  Handle<std::vector<pat::PackedCandidate>> cands;
+  iEvent.getByToken(Cands_, cands);
+  Handle<VertexCollection> pvs;
+  iEvent.getByToken(PVs_, pvs);
+  Handle<VertexCompositePtrCandidateCollection> svs;
+  iEvent.getByToken(SVs_, svs);
+  Handle<std::vector<pat::PackedCandidate>> addTracks;
+  iEvent.getByToken(AdditionalTracks_, addTracks);
+
+  auto outTks = std::make_unique<std::vector<reco::Track>>();
+  std::map<unsigned int, std::vector<unsigned int>> asso;
+  std::map<unsigned int, unsigned int> trackKeys;
+  unsigned int j = 0;
+  for (unsigned int i = 0; i < cands->size(); i++) {
+    const pat::PackedCandidate& c = (*cands)[i];
+    if (c.hasTrackDetails() && c.charge() != 0 && c.numberOfHits() > 0) {
+      outTks->push_back(c.pseudoTrack());
+      for (size_t ipv = 0; ipv < pvs->size(); ++ipv) {
+        if (c.fromPV(ipv) == pat::PackedCandidate::PVUsedInFit)
+          asso[ipv].push_back(j);
+      }
+      trackKeys[i] = j;
+      j++;
+    }
+  }
+
+  int offsetAdd = j;
+  for (unsigned int i = 0; i < addTracks->size(); i++) {
+    if ((*addTracks)[i].hasTrackDetails()) {
+      outTks->push_back((*addTracks)[i].pseudoTrack());
+      for (size_t ipv = 0; ipv < pvs->size(); ++ipv) {
+        if ((*addTracks)[i].fromPV(ipv) == pat::PackedCandidate::PVUsedInFit)
+          asso[ipv].push_back(j);
+      }
+      j++;
+    }
+  }
+
+  edm::OrphanHandle<std::vector<reco::Track>> oh = iEvent.put(std::move(outTks));
+
+  auto outPv = std::make_unique<std::vector<reco::Vertex>>();
+
+  for (size_t ipv = 0; ipv < pvs->size(); ++ipv) {
+    reco::Vertex pv = (*pvs)[ipv];
+    for (unsigned int i = 0; i < asso[ipv].size(); i++) {
+      TrackRef r(oh, asso[ipv][i]);
+      TrackBaseRef rr(r);
+      pv.add(rr);
+    }
+    outPv->push_back(pv);
+  }
+  iEvent.put(std::move(outPv));
+
+  auto outSv = std::make_unique<std::vector<reco::Vertex>>();
+  for (size_t i = 0; i < svs->size(); i++) {
+    const reco::VertexCompositePtrCandidate& sv = (*svs)[i];
+    outSv->push_back(reco::Vertex(sv.vertex(), sv.vertexCovariance(), sv.vertexChi2(), sv.vertexNdof(), 0));
+    for (size_t j = 0; j < sv.numberOfDaughters(); j++) {
+      TrackRef r;
+      if (sv.daughterPtr(j).id() == cands.id()) {
+        r = TrackRef(oh,
+                     trackKeys[sv.daughterPtr(j).key()]);  // use trackKeys because cand->track has gaps from neutral
+      } else {
+        //				std::cout << "vertex " << i << " using lost Track " << sv.daughterPtr(j).key()  << "  " << offsetAdd+sv.daughterPtr(j).key() << std::endl;
+        r = TrackRef(oh,
+                     offsetAdd + sv.daughterPtr(j).key());  // use directly the key because addTracks is only charged
+      }
+      TrackBaseRef rr(r);
+      outSv->back().add(rr);
+    }
+  }
+
+  iEvent.put(std::move(outSv), "secondary");
 }
-
-
-void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
-	using namespace edm; using namespace std; using namespace reco;
-	Handle<std::vector<pat::PackedCandidate> > cands;
-	iEvent.getByToken(Cands_, cands);
-	Handle<VertexCollection> pvs;
-	iEvent.getByToken(PVs_, pvs);
-	Handle<VertexCompositePtrCandidateCollection> svs;
-	iEvent.getByToken(SVs_, svs);
-	Handle<std::vector<pat::PackedCandidate> > addTracks;
-	iEvent.getByToken(AdditionalTracks_, addTracks);
-
-	auto outTks = std::make_unique<std::vector<reco::Track>>();
-	std::map<unsigned int, std::vector<unsigned int> > asso;
-	std::map<unsigned int, unsigned int> trackKeys;
-	unsigned int j=0;
-	for(unsigned int i=0;i<cands->size();i++)	{
-		const pat::PackedCandidate & c = (*cands)[i];
-		if(c.hasTrackDetails() && c.charge() != 0 && c.numberOfHits()> 0){
-			outTks->push_back(c.pseudoTrack());
-			for(size_t ipv=0;ipv< pvs->size(); ++ipv) {
-				if(c.fromPV(ipv)==pat::PackedCandidate::PVUsedInFit)
-					asso[ipv].push_back(j);
-			}
-			trackKeys[i]=j;
-			j++;
-		}	
-	}
-
-	int offsetAdd=j;
-	for(unsigned int i = 0; i < addTracks->size(); i++) {
-		if( (*addTracks)[i].hasTrackDetails() ){
-			outTks->push_back((*addTracks)[i].pseudoTrack());
-		        for(size_t ipv=0;ipv< pvs->size(); ++ipv) {
-				if((*addTracks)[i].fromPV(ipv)==pat::PackedCandidate::PVUsedInFit)
-					asso[ipv].push_back(j);
-			}
-			j++;
-		}
-	}
-	
-	edm::OrphanHandle< std::vector<reco::Track>  > oh = iEvent.put(std::move(outTks));
-	
-	auto outPv = std::make_unique<std::vector<reco::Vertex>>();
-	
-	for(size_t ipv=0;ipv< pvs->size(); ++ipv) {
-		reco::Vertex  pv = (*pvs)[ipv];
-		for(unsigned int i=0;i<asso[ipv].size();i++)
-		{
-			TrackRef r(oh,asso[ipv][i]);
-			TrackBaseRef rr(r);
-			pv.add(rr);
-		}
-		outPv->push_back(pv);
-	}
-	iEvent.put(std::move(outPv));
-
-        auto outSv = std::make_unique<std::vector<reco::Vertex>>();
-	for(size_t i=0;i< svs->size(); i++) {
-		const reco::VertexCompositePtrCandidate &sv = (*svs)[i];	
-		outSv->push_back(reco::Vertex(sv.vertex(),sv.vertexCovariance(),sv.vertexChi2(),sv.vertexNdof(),0));
-		for(size_t j=0;j<sv.numberOfDaughters();j++){
-	                TrackRef r;
-			if(sv.daughterPtr(j).id() == cands.id()) {
-	                	 r= TrackRef(oh,trackKeys[sv.daughterPtr(j).key()]); // use trackKeys because cand->track has gaps from neutral
-			} else {
-//				std::cout << "vertex " << i << " using lost Track " << sv.daughterPtr(j).key()  << "  " << offsetAdd+sv.daughterPtr(j).key() << std::endl;  
-                                r=TrackRef(oh,offsetAdd+sv.daughterPtr(j).key());  // use directly the key because addTracks is only charged
-			}
-        	        TrackBaseRef rr(r);
-			outSv->back().add(rr);
-
-		}	
-	}   
-
-       iEvent.put(std::move(outSv),"secondary");
-
-}
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
@@ -12,7 +12,6 @@
   \version  $Id: VertexAssociationProducer.cc,v 1.2 2010/02/20 21:00:29 wmtan Exp $
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,52 +22,46 @@
 #include "DataFormats/PatCandidates/interface/Vertexing.h"
 #include "PhysicsTools/PatAlgos/interface/VertexingHelper.h"
 
-
 namespace pat {
 
   class PATVertexAssociationProducer : public edm::stream::EDProducer<> {
-
     typedef edm::ValueMap<pat::VertexAssociation> VertexAssociationMap;
 
-    public:
+  public:
+    explicit PATVertexAssociationProducer(const edm::ParameterSet& iConfig);
+    ~PATVertexAssociationProducer() override;
 
-      explicit PATVertexAssociationProducer(const edm::ParameterSet & iConfig);
-      ~PATVertexAssociationProducer() override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-
-    private:
-      typedef std::vector<edm::InputTag> VInputTag;
-      // configurables
-      std::vector<edm::InputTag>   particles_;
-      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > particlesTokens_;
-      pat::helper::VertexingHelper vertexing_;
-
+  private:
+    typedef std::vector<edm::InputTag> VInputTag;
+    // configurables
+    std::vector<edm::InputTag> particles_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > particlesTokens_;
+    pat::helper::VertexingHelper vertexing_;
   };
 
-}
+}  // namespace pat
 
 using pat::PATVertexAssociationProducer;
 
-PATVertexAssociationProducer::PATVertexAssociationProducer(const edm::ParameterSet& iConfig) :
-  particles_( iConfig.existsAs<VInputTag>("candidates") ?       // if it's a VInputTag
-                iConfig.getParameter<VInputTag>("candidates") :
-                VInputTag(1, iConfig.getParameter<edm::InputTag>("candidates")) ),
-  vertexing_(iConfig, consumesCollector())
-{
+PATVertexAssociationProducer::PATVertexAssociationProducer(const edm::ParameterSet& iConfig)
+    : particles_(iConfig.existsAs<VInputTag>("candidates")
+                     ?  // if it's a VInputTag
+                     iConfig.getParameter<VInputTag>("candidates")
+                     : VInputTag(1, iConfig.getParameter<edm::InputTag>("candidates"))),
+      vertexing_(iConfig, consumesCollector()) {
   for (VInputTag::const_iterator it = particles_.begin(), end = particles_.end(); it != end; ++it) {
-    particlesTokens_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
+    particlesTokens_.push_back(consumes<edm::View<reco::Candidate> >(*it));
   }
-    produces<VertexAssociationMap>();
+  produces<VertexAssociationMap>();
 }
 
+PATVertexAssociationProducer::~PATVertexAssociationProducer() {}
 
-PATVertexAssociationProducer::~PATVertexAssociationProducer() {
-}
-
-
-void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-  using namespace edm; using namespace std;
+void PATVertexAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
   // read in vertices and EventSetup
   vertexing_.newEvent(iEvent, iSetup);
 
@@ -78,17 +71,21 @@ void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::Event
   vector<pat::VertexAssociation> assos;
 
   // loop on input tags
-  for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator it = particlesTokens_.begin(), end = particlesTokens_.end(); it != end; ++it) {
-      // read candidates
-      Handle<View<reco::Candidate> > cands;
-      iEvent.getByToken(*it, cands);
-      assos.clear(); assos.reserve(cands->size());
-      // loop on candidates
-      for (size_t i = 0, n = cands->size(); i < n; ++i) {
-        assos.push_back( vertexing_(cands->refAt(i)) );
-      }
-      // insert into ValueMap
-      filler.insert(cands, assos.begin(), assos.end());
+  for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator it = particlesTokens_.begin(),
+                                                                                   end = particlesTokens_.end();
+       it != end;
+       ++it) {
+    // read candidates
+    Handle<View<reco::Candidate> > cands;
+    iEvent.getByToken(*it, cands);
+    assos.clear();
+    assos.reserve(cands->size());
+    // loop on candidates
+    for (size_t i = 0, n = cands->size(); i < n; ++i) {
+      assos.push_back(vertexing_(cands->refAt(i)));
+    }
+    // insert into ValueMap
+    filler.insert(cands, assos.begin(), assos.end());
   }
 
   // do the real filling
@@ -97,7 +94,6 @@ void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::Event
   // put our produced stuff in the event
   iEvent.put(std::move(result));
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/PhysicsTools/PatAlgos/src/BaseIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/BaseIsolator.cc
@@ -4,17 +4,14 @@
 
 using pat::helper::BaseIsolator;
 
-BaseIsolator::BaseIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) :
-    input_(conf.getParameter<edm::InputTag>("src")),
-    inputToken_(iC.consumes<Isolation>(input_)),
-    cut_(withCut ? conf.getParameter<double>("cut") : -2.0),
-    try_(0), fail_(0)
-{
-}
+BaseIsolator::BaseIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut)
+    : input_(conf.getParameter<edm::InputTag>("src")),
+      inputToken_(iC.consumes<Isolation>(input_)),
+      cut_(withCut ? conf.getParameter<double>("cut") : -2.0),
+      try_(0),
+      fail_(0) {}
 
-void
-BaseIsolator::print(std::ostream &out) const {
-    using namespace std;
-    out << description() << " < " << cut_ << ": try " << try_ << ", fail " << fail_;
+void BaseIsolator::print(std::ostream &out) const {
+  using namespace std;
+  out << description() << " < " << cut_ << ": try " << try_ << ", fail " << fail_;
 }
-

--- a/PhysicsTools/PatAlgos/src/EfficiencyLoader.cc
+++ b/PhysicsTools/PatAlgos/src/EfficiencyLoader.cc
@@ -4,24 +4,22 @@
 
 using pat::helper::EfficiencyLoader;
 
-EfficiencyLoader::EfficiencyLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC)
-{
-    // Get the names (sorted)
-    names_ = iConfig.getParameterNamesForType<edm::InputTag>();
-    std::sort(names_.begin(), names_.end());
+EfficiencyLoader::EfficiencyLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC) {
+  // Get the names (sorted)
+  names_ = iConfig.getParameterNamesForType<edm::InputTag>();
+  std::sort(names_.begin(), names_.end());
 
-    // get the InputTags
-    for (std::vector<std::string>::const_iterator it = names_.begin(), ed = names_.end(); it != ed; ++it) {
-        tokens_.push_back( iC.consumes<edm::ValueMap<pat::LookupTableRecord> >(iConfig.getParameter<edm::InputTag>(*it) ));
-    }
+  // get the InputTags
+  for (std::vector<std::string>::const_iterator it = names_.begin(), ed = names_.end(); it != ed; ++it) {
+    tokens_.push_back(iC.consumes<edm::ValueMap<pat::LookupTableRecord> >(iConfig.getParameter<edm::InputTag>(*it)));
+  }
 
-    // prepare the Handles
-    handles_.resize(names_.size());
+  // prepare the Handles
+  handles_.resize(names_.size());
 }
 
-void
-EfficiencyLoader::newEvent(const edm::Event &iEvent) {
-    for (size_t i = 0, n = names_.size(); i < n; ++i) {
-        iEvent.getByToken(tokens_[i], handles_[i]);
-    }
+void EfficiencyLoader::newEvent(const edm::Event &iEvent) {
+  for (size_t i = 0, n = names_.size(); i < n; ++i) {
+    iEvent.getByToken(tokens_[i], handles_[i]);
+  }
 }

--- a/PhysicsTools/PatAlgos/src/HemisphereAlgo.cc
+++ b/PhysicsTools/PatAlgos/src/HemisphereAlgo.cc
@@ -8,309 +8,296 @@
 using namespace std;
 using std::vector;
 
-HemisphereAlgo::HemisphereAlgo(const std::vector<reco::CandidatePtr>& componentPtr_,const int seed_method, const int hemisphere_association_method )
-  : Object(componentPtr_), Object_Group() , Axis1(), Axis2(), seed_meth(seed_method), hemi_meth(hemisphere_association_method), status(0) {
-
-  for(int i = 0; i < (int) Object.size(); i++){
+HemisphereAlgo::HemisphereAlgo(const std::vector<reco::CandidatePtr>& componentPtr_,
+                               const int seed_method,
+                               const int hemisphere_association_method)
+    : Object(componentPtr_),
+      Object_Group(),
+      Axis1(),
+      Axis2(),
+      seed_meth(seed_method),
+      hemi_meth(hemisphere_association_method),
+      status(0) {
+  for (int i = 0; i < (int)Object.size(); i++) {
     Object_Noseed.push_back(0);
   }
+}
 
-}   
-
-
-   
-vector<float> HemisphereAlgo::getAxis1(){
-  if (status != 1){this->reconstruct();}   
+vector<float> HemisphereAlgo::getAxis1() {
+  if (status != 1) {
+    this->reconstruct();
+  }
   return Axis1;
-}   
-vector<float> HemisphereAlgo::getAxis2(){
-  if (status != 1){this->reconstruct();}  
+}
+vector<float> HemisphereAlgo::getAxis2() {
+  if (status != 1) {
+    this->reconstruct();
+  }
   return Axis2;
 }
 
-vector<int> HemisphereAlgo::getGrouping(){
-  if (status != 1){this->reconstruct();}  
+vector<int> HemisphereAlgo::getGrouping() {
+  if (status != 1) {
+    this->reconstruct();
+  }
   return Object_Group;
 }
 
-int HemisphereAlgo::reconstruct(){
-
-     int vsize = (int) Object.size();
+int HemisphereAlgo::reconstruct() {
+  int vsize = (int)Object.size();
 
   LogDebug("HemisphereAlgo") << " HemisphereAlgo method ";
-  
+
   Object_Group.clear();
   Axis1.clear();
   Axis2.clear();
 
-  for(int j = 0; j < vsize; j++){
+  for (int j = 0; j < vsize; j++) {
     Object_Group.push_back(0);
   }
 
-  for(int j = 0; j < 5; j++){
+  for (int j = 0; j < 5; j++) {
     Axis1.push_back(0);
     Axis2.push_back(0);
   }
-  
- 
-  for (int i = 0; i <vsize; i++){
-   
-    if ( (*(Object)[i]).p() > (*Object[i]).energy() + 0.001) { 
- 
-      edm::LogWarning("HemisphereAlgo") << "Object " << i << " has E = " << (*Object[i]).energy()
-                                        << " less than P = " << (*Object[i]).p() ;
-    
-    } 
-  } 
 
-   
-   
+  for (int i = 0; i < vsize; i++) {
+    if ((*(Object)[i]).p() > (*Object[i]).energy() + 0.001) {
+      edm::LogWarning("HemisphereAlgo") << "Object " << i << " has E = " << (*Object[i]).energy()
+                                        << " less than P = " << (*Object[i]).p();
+    }
+  }
+
   LogDebug("HemisphereAlgo") << " Seeding method = " << seed_meth;
   int I_Max = -1;
   int J_Max = -1;
-   
+
   if (seed_meth == 1) {
-    
     float P_Max = 0.;
     float DeltaRP_Max = 0.;
-       
-    // take highest momentum object as first axis   
-    for (int i=0;i<vsize;i++){    
+
+    // take highest momentum object as first axis
+    for (int i = 0; i < vsize; i++) {
       Object_Group[i] = 0;
-      if (Object_Noseed[i] == 0 && P_Max < (*Object[i]).p()){
+      if (Object_Noseed[i] == 0 && P_Max < (*Object[i]).p()) {
         P_Max = (*Object[i]).p();
-        I_Max = i; 
-      }           
+        I_Max = i;
+      }
     }
-    
-    Axis1[0] = (*Object[I_Max]).px() /  (*Object[I_Max]).p();
-    Axis1[1] = (*Object[I_Max]).py() /  (*Object[I_Max]).p();
-    Axis1[2] = (*Object[I_Max]).pz() /  (*Object[I_Max]).p();
+
+    Axis1[0] = (*Object[I_Max]).px() / (*Object[I_Max]).p();
+    Axis1[1] = (*Object[I_Max]).py() / (*Object[I_Max]).p();
+    Axis1[2] = (*Object[I_Max]).pz() / (*Object[I_Max]).p();
     Axis1[3] = (*Object[I_Max]).p();
     Axis1[4] = (*Object[I_Max]).energy();
-    
+
     // take as second axis
-    for (int i=0;i<vsize;i++){     
-      
-      float DeltaR = deltaR((*Object[i]).eta(),(*Object[i]).phi(),(*Object[I_Max]).eta(),(*Object[I_Max]).phi()) ;   
-      
-      if (Object_Noseed[i] == 0 && DeltaR > 0.5) { 
-    
-        float DeltaRP = DeltaR * (*Object[i]).p();       
-        if (DeltaRP > DeltaRP_Max){
+    for (int i = 0; i < vsize; i++) {
+      float DeltaR = deltaR((*Object[i]).eta(), (*Object[i]).phi(), (*Object[I_Max]).eta(), (*Object[I_Max]).phi());
+
+      if (Object_Noseed[i] == 0 && DeltaR > 0.5) {
+        float DeltaRP = DeltaR * (*Object[i]).p();
+        if (DeltaRP > DeltaRP_Max) {
           DeltaRP_Max = DeltaRP;
           J_Max = i;
-	}	
-      }
-    } 
-    
-    if (J_Max >=0){
-      Axis2[0] = (*Object[J_Max]).px() /  (*Object[J_Max]).p();
-      Axis2[1] =(*Object[J_Max]).py() /  (*Object[J_Max]).p();
-      Axis2[2] = (*Object[J_Max]).pz() /  (*Object[J_Max]).p();
-      Axis2[3] = (*Object[J_Max]).p();
-      Axis2[4] = (*Object[J_Max]).energy();
-     
-    } else {   
-      return 0;
-    }
-    LogDebug("HemisphereAlgo") << " Axis 1 is Object = " << I_Max;
-    LogDebug("HemisphereAlgo") << " Axis 2 is Object = " << J_Max;
-
-   
-  } else if ( (seed_meth == 2) | (seed_meth == 3)  ) {
-
-    float Mass_Max = 0.;
-    float InvariantMass = 0.;
-    
-    // maximize the invariant mass of two objects
-    for (int i=0;i<vsize;i++){    
-      Object_Group[i] = 0;
-      if (Object_Noseed[i] == 0){ 
-        for (int j=i+1;j<vsize;j++){  
-          if (Object_Noseed[j] == 0){ 
-
-            // either the invariant mass
-            if (seed_meth == 2){
-              InvariantMass =  ((*Object[i]).energy() +  (*Object[j]).energy())* ((*Object[i]).energy() + (*Object[j]).energy())
-                - ((*Object[i]).px() + (*Object[j]).px())* ((*Object[i]).px() + (*Object[j]).px()) 
-                - ((*Object[i]).py() + (*Object[j]).py())* ((*Object[i]).py() + (*Object[j]).py())
-                - ((*Object[i]).pz() + (*Object[j]).pz())* ((*Object[i]).pz() + (*Object[j]).pz()) ;  
-            } 
-            // or the transverse mass
-            else if (seed_meth == 3){
-              float pti = sqrt((*Object[i]).px()*(*Object[i]).px() + (*Object[i]).py()*(*Object[i]).py());
-              float ptj = sqrt((*Object[j]).px()*(*Object[j]).px() + (*Object[j]).py()*(*Object[j]).py());
-              InvariantMass =  2. * (pti*ptj - (*Object[i]).px()*(*Object[j]).px()
-                                     - (*Object[i]).py()*(*Object[j]).py() );
-            }
-            if ( Mass_Max < InvariantMass){
-              Mass_Max = InvariantMass;
-              I_Max = i;
-              J_Max = j;
-            }
-          }               
         }
       }
     }
-    
-    if (J_Max>0) {
 
-      Axis1[0] = (*Object[I_Max]).px() /  (*Object[I_Max]).p();
-      Axis1[1] = (*Object[I_Max]).py() /  (*Object[I_Max]).p();
-      Axis1[2] = (*Object[I_Max]).pz() /  (*Object[I_Max]).p();
-    
-      Axis1[3] = (*Object[I_Max]).p();
-      Axis1[4] = (*Object[I_Max]).energy(); 
-  
-      Axis2[0] = (*Object[J_Max]).px() /  (*Object[J_Max]).p();
-      Axis2[1] =(*Object[J_Max]).py() /  (*Object[J_Max]).p();
-      Axis2[2] = (*Object[J_Max]).pz() /  (*Object[J_Max]).p();
-    
+    if (J_Max >= 0) {
+      Axis2[0] = (*Object[J_Max]).px() / (*Object[J_Max]).p();
+      Axis2[1] = (*Object[J_Max]).py() / (*Object[J_Max]).p();
+      Axis2[2] = (*Object[J_Max]).pz() / (*Object[J_Max]).p();
       Axis2[3] = (*Object[J_Max]).p();
-      Axis2[4] = (*Object[J_Max]).energy(); 
+      Axis2[4] = (*Object[J_Max]).energy();
 
     } else {
       return 0;
     }
     LogDebug("HemisphereAlgo") << " Axis 1 is Object = " << I_Max;
     LogDebug("HemisphereAlgo") << " Axis 2 is Object = " << J_Max;
-    
-    
+
+  } else if ((seed_meth == 2) | (seed_meth == 3)) {
+    float Mass_Max = 0.;
+    float InvariantMass = 0.;
+
+    // maximize the invariant mass of two objects
+    for (int i = 0; i < vsize; i++) {
+      Object_Group[i] = 0;
+      if (Object_Noseed[i] == 0) {
+        for (int j = i + 1; j < vsize; j++) {
+          if (Object_Noseed[j] == 0) {
+            // either the invariant mass
+            if (seed_meth == 2) {
+              InvariantMass =
+                  ((*Object[i]).energy() + (*Object[j]).energy()) * ((*Object[i]).energy() + (*Object[j]).energy()) -
+                  ((*Object[i]).px() + (*Object[j]).px()) * ((*Object[i]).px() + (*Object[j]).px()) -
+                  ((*Object[i]).py() + (*Object[j]).py()) * ((*Object[i]).py() + (*Object[j]).py()) -
+                  ((*Object[i]).pz() + (*Object[j]).pz()) * ((*Object[i]).pz() + (*Object[j]).pz());
+            }
+            // or the transverse mass
+            else if (seed_meth == 3) {
+              float pti = sqrt((*Object[i]).px() * (*Object[i]).px() + (*Object[i]).py() * (*Object[i]).py());
+              float ptj = sqrt((*Object[j]).px() * (*Object[j]).px() + (*Object[j]).py() * (*Object[j]).py());
+              InvariantMass =
+                  2. * (pti * ptj - (*Object[i]).px() * (*Object[j]).px() - (*Object[i]).py() * (*Object[j]).py());
+            }
+            if (Mass_Max < InvariantMass) {
+              Mass_Max = InvariantMass;
+              I_Max = i;
+              J_Max = j;
+            }
+          }
+        }
+      }
+    }
+
+    if (J_Max > 0) {
+      Axis1[0] = (*Object[I_Max]).px() / (*Object[I_Max]).p();
+      Axis1[1] = (*Object[I_Max]).py() / (*Object[I_Max]).p();
+      Axis1[2] = (*Object[I_Max]).pz() / (*Object[I_Max]).p();
+
+      Axis1[3] = (*Object[I_Max]).p();
+      Axis1[4] = (*Object[I_Max]).energy();
+
+      Axis2[0] = (*Object[J_Max]).px() / (*Object[J_Max]).p();
+      Axis2[1] = (*Object[J_Max]).py() / (*Object[J_Max]).p();
+      Axis2[2] = (*Object[J_Max]).pz() / (*Object[J_Max]).p();
+
+      Axis2[3] = (*Object[J_Max]).p();
+      Axis2[4] = (*Object[J_Max]).energy();
+
+    } else {
+      return 0;
+    }
+    LogDebug("HemisphereAlgo") << " Axis 1 is Object = " << I_Max;
+    LogDebug("HemisphereAlgo") << " Axis 2 is Object = " << J_Max;
+
   } else {
     throw cms::Exception("Configuration") << "Please give a valid seeding method!";
   }
-   
-  // seeding done 
+
+  // seeding done
   // now do the hemisphere association
-   
+
   LogDebug("HemisphereAlgo") << " Association method = " << hemi_meth;
 
   int numLoop = 0;
   bool I_Move = true;
 
-
-  while (I_Move && (numLoop < 100)){
-
+  while (I_Move && (numLoop < 100)) {
     I_Move = false;
     numLoop++;
-    LogDebug("HemisphereAlgo")  << " Iteration = " << numLoop;
-   
+    LogDebug("HemisphereAlgo") << " Iteration = " << numLoop;
+
     float Sum1_Px = 0.;
     float Sum1_Py = 0.;
     float Sum1_Pz = 0.;
     float Sum1_P = 0.;
-    float Sum1_E = 0.; 
+    float Sum1_E = 0.;
     float Sum2_Px = 0.;
     float Sum2_Py = 0.;
     float Sum2_Pz = 0.;
     float Sum2_P = 0.;
-    float Sum2_E = 0.; 
-   
-    
+    float Sum2_E = 0.;
+
     if (hemi_meth == 1) {
-       
-      for (int i=0;i<vsize;i++){  
-        float  P_Long1 = (*Object[i]).px()*Axis1[0] + (*Object[i]).py()*Axis1[1] + (*Object[i]).pz()*Axis1[2];
-        float  P_Long2 = (*Object[i]).px()*Axis2[0]+ (*Object[i]).py()*Axis2[1] + (*Object[i]).pz()*Axis2[2];
-        if (P_Long1 >= P_Long2){
-          if (Object_Group[i] != 1){ 
-	    I_Move = true;
-	  }      
+      for (int i = 0; i < vsize; i++) {
+        float P_Long1 = (*Object[i]).px() * Axis1[0] + (*Object[i]).py() * Axis1[1] + (*Object[i]).pz() * Axis1[2];
+        float P_Long2 = (*Object[i]).px() * Axis2[0] + (*Object[i]).py() * Axis2[1] + (*Object[i]).pz() * Axis2[2];
+        if (P_Long1 >= P_Long2) {
+          if (Object_Group[i] != 1) {
+            I_Move = true;
+          }
           Object_Group[i] = 1;
-	  Sum1_Px += (*Object[i]).px();
-	  Sum1_Py += (*Object[i]).py();
-	  Sum1_Pz += (*Object[i]).pz();
-	  Sum1_P += (*Object[i]).p();
-	  Sum1_E += (*Object[i]).energy(); 
+          Sum1_Px += (*Object[i]).px();
+          Sum1_Py += (*Object[i]).py();
+          Sum1_Pz += (*Object[i]).pz();
+          Sum1_P += (*Object[i]).p();
+          Sum1_E += (*Object[i]).energy();
         } else {
-          if (Object_Group[i] != 2){ 
-	    I_Move = true;
-	  }
+          if (Object_Group[i] != 2) {
+            I_Move = true;
+          }
           Object_Group[i] = 2;
-	  Sum2_Px += (*Object[i]).px();
-	  Sum2_Py += (*Object[i]).py();
-	  Sum2_Pz += (*Object[i]).pz();
-	  Sum2_P += (*Object[i]).p();
-	  Sum2_E += (*Object[i]).energy(); 
+          Sum2_Px += (*Object[i]).px();
+          Sum2_Py += (*Object[i]).py();
+          Sum2_Pz += (*Object[i]).pz();
+          Sum2_P += (*Object[i]).p();
+          Sum2_E += (*Object[i]).energy();
         }
       }
-    
-    } else if (hemi_meth == 2 || hemi_meth == 3){
-    
-      for (int i=0;i<vsize;i++){  
+
+    } else if (hemi_meth == 2 || hemi_meth == 3) {
+      for (int i = 0; i < vsize; i++) {
         if (i == I_Max) {
-	  Object_Group[i] = 1;
-	  Sum1_Px += (*Object[i]).px();
-	  Sum1_Py += (*Object[i]).py();
-	  Sum1_Pz += (*Object[i]).pz();
-	  Sum1_P += (*Object[i]).p();
-	  Sum1_E += (*Object[i]).energy(); 
-	} else if (i == J_Max) {
-	  Object_Group[i] = 2;
-	  Sum2_Px += (*Object[i]).px();
-	  Sum2_Py += (*Object[i]).py();
-	  Sum2_Pz += (*Object[i]).pz();
-	  Sum2_P += (*Object[i]).p();
-	  Sum2_E += (*Object[i]).energy(); 
+          Object_Group[i] = 1;
+          Sum1_Px += (*Object[i]).px();
+          Sum1_Py += (*Object[i]).py();
+          Sum1_Pz += (*Object[i]).pz();
+          Sum1_P += (*Object[i]).p();
+          Sum1_E += (*Object[i]).energy();
+        } else if (i == J_Max) {
+          Object_Group[i] = 2;
+          Sum2_Px += (*Object[i]).px();
+          Sum2_Py += (*Object[i]).py();
+          Sum2_Pz += (*Object[i]).pz();
+          Sum2_P += (*Object[i]).p();
+          Sum2_E += (*Object[i]).energy();
         } else {
-	
-	
-          if(!I_Move){ 
-	  
+          if (!I_Move) {
             float NewAxis1_Px = Axis1[0] * Axis1[3];
             float NewAxis1_Py = Axis1[1] * Axis1[3];
             float NewAxis1_Pz = Axis1[2] * Axis1[3];
             float NewAxis1_E = Axis1[4];
-	 
+
             float NewAxis2_Px = Axis2[0] * Axis2[3];
             float NewAxis2_Py = Axis2[1] * Axis2[3];
             float NewAxis2_Pz = Axis2[2] * Axis2[3];
             float NewAxis2_E = Axis2[4];
-       
-            if (Object_Group[i] == 1){
-	  
+
+            if (Object_Group[i] == 1) {
               NewAxis1_Px = NewAxis1_Px - (*Object[i]).px();
               NewAxis1_Py = NewAxis1_Py - (*Object[i]).py();
               NewAxis1_Pz = NewAxis1_Pz - (*Object[i]).pz();
-              NewAxis1_E = NewAxis1_E - (*Object[i]).energy(); 
-	 
+              NewAxis1_E = NewAxis1_E - (*Object[i]).energy();
+
             } else if (Object_Group[i] == 2) {
-	 
               NewAxis2_Px = NewAxis2_Px - (*Object[i]).px();
               NewAxis2_Py = NewAxis2_Py - (*Object[i]).py();
               NewAxis2_Pz = NewAxis2_Pz - (*Object[i]).pz();
               NewAxis2_E = NewAxis2_E - (*Object[i]).energy();
             }
-               
-	  
-            float mass1 =  NewAxis1_E - (((*Object[i]).px()*NewAxis1_Px + (*Object[i]).py()*NewAxis1_Py +
-                                          (*Object[i]).pz()*NewAxis1_Pz)/(*Object[i]).p());
-	 
-            float mass2 =  NewAxis2_E - (((*Object[i]).px()*NewAxis2_Px + (*Object[i]).py()*NewAxis2_Py +
-                                          (*Object[i]).pz()*NewAxis2_Pz)/(*Object[i]).p());
-	 
+
+            float mass1 =
+                NewAxis1_E -
+                (((*Object[i]).px() * NewAxis1_Px + (*Object[i]).py() * NewAxis1_Py + (*Object[i]).pz() * NewAxis1_Pz) /
+                 (*Object[i]).p());
+
+            float mass2 =
+                NewAxis2_E -
+                (((*Object[i]).px() * NewAxis2_Px + (*Object[i]).py() * NewAxis2_Py + (*Object[i]).pz() * NewAxis2_Pz) /
+                 (*Object[i]).p());
+
             if (hemi_meth == 3) {
-	 
-              mass1 *= NewAxis1_E/((NewAxis1_E+(*Object[i]).energy())*(NewAxis1_E+(*Object[i]).energy()));
-	 
-              mass2 *= NewAxis2_E/((NewAxis2_E+(*Object[i]).energy())*(NewAxis2_E+(*Object[i]).energy()));
-	
+              mass1 *= NewAxis1_E / ((NewAxis1_E + (*Object[i]).energy()) * (NewAxis1_E + (*Object[i]).energy()));
+
+              mass2 *= NewAxis2_E / ((NewAxis2_E + (*Object[i]).energy()) * (NewAxis2_E + (*Object[i]).energy()));
             }
-	 
-            if(mass1 < mass2) {
-              if (Object_Group[i] != 1){ 
+
+            if (mass1 < mass2) {
+              if (Object_Group[i] != 1) {
                 I_Move = true;
               }
               Object_Group[i] = 1;
-       
+
               Sum1_Px += (*Object[i]).px();
               Sum1_Py += (*Object[i]).py();
               Sum1_Pz += (*Object[i]).pz();
               Sum1_P += (*Object[i]).p();
-              Sum1_E += (*Object[i]).energy(); 
+              Sum1_E += (*Object[i]).energy();
             } else {
-              if (Object_Group[i] != 2){ 
+              if (Object_Group[i] != 2) {
                 I_Move = true;
               }
               Object_Group[i] = 2;
@@ -318,76 +305,60 @@ int HemisphereAlgo::reconstruct(){
               Sum2_Py += (*Object[i]).py();
               Sum2_Pz += (*Object[i]).pz();
               Sum2_P += (*Object[i]).p();
-              Sum2_E += (*Object[i]).energy(); 
-	 
+              Sum2_E += (*Object[i]).energy();
             }
-      
-      
+
           } else {
-	
-            if (Object_Group[i] == 1){
+            if (Object_Group[i] == 1) {
               Sum1_Px += (*Object[i]).px();
               Sum1_Py += (*Object[i]).py();
               Sum1_Pz += (*Object[i]).pz();
               Sum1_P += (*Object[i]).p();
-              Sum1_E += (*Object[i]).energy(); 
+              Sum1_E += (*Object[i]).energy();
             }
-            if (Object_Group[i] == 2){
+            if (Object_Group[i] == 2) {
               Sum2_Px += (*Object[i]).px();
               Sum2_Py += (*Object[i]).py();
               Sum2_Pz += (*Object[i]).pz();
               Sum2_P += (*Object[i]).p();
-              Sum2_E += (*Object[i]).energy(); 
+              Sum2_E += (*Object[i]).energy();
             }
-         
-	
-	
           }
-	
-	
         }
       }
     } else {
-      throw cms::Exception("Configuration") 
-        << "Please give a valid hemisphere association method!";
+      throw cms::Exception("Configuration") << "Please give a valid hemisphere association method!";
     }
-    
-    // recomputing the axes     
 
-    Axis1[3] = sqrt(Sum1_Px*Sum1_Px + Sum1_Py*Sum1_Py + Sum1_Pz*Sum1_Pz);
-    if (Axis1[3]<0.0001) {
-      edm::LogWarning("HemisphereAlgo") << "ZERO objects in group 1! "; 
-    } else {    
-      Axis1[0] = Sum1_Px / Axis1[3];   
+    // recomputing the axes
+
+    Axis1[3] = sqrt(Sum1_Px * Sum1_Px + Sum1_Py * Sum1_Py + Sum1_Pz * Sum1_Pz);
+    if (Axis1[3] < 0.0001) {
+      edm::LogWarning("HemisphereAlgo") << "ZERO objects in group 1! ";
+    } else {
+      Axis1[0] = Sum1_Px / Axis1[3];
       Axis1[1] = Sum1_Py / Axis1[3];
       Axis1[2] = Sum1_Pz / Axis1[3];
-      Axis1[4] = Sum1_E; 
+      Axis1[4] = Sum1_E;
     }
-    
-   
-    
-    Axis2[3] = sqrt(Sum2_Px*Sum2_Px + Sum2_Py*Sum2_Py + Sum2_Pz*Sum2_Pz);
-    if (Axis2[3]<0.0001) {
+
+    Axis2[3] = sqrt(Sum2_Px * Sum2_Px + Sum2_Py * Sum2_Py + Sum2_Pz * Sum2_Pz);
+    if (Axis2[3] < 0.0001) {
       edm::LogWarning("HemisphereAlgo") << "ZERO objects in group 2!";
-    } else {  
-      Axis2[0] = Sum2_Px / Axis2[3];   
+    } else {
+      Axis2[0] = Sum2_Px / Axis2[3];
       Axis2[1] = Sum2_Py / Axis2[3];
       Axis2[2] = Sum2_Pz / Axis2[3];
-      Axis2[4] = Sum2_E; 
+      Axis2[4] = Sum2_E;
     }
 
     LogDebug("HemisphereAlgo") << " Grouping = ";
-    for (int i=0;i<vsize;i++){  
+    for (int i = 0; i < vsize; i++) {
       LogTrace("HemisphereAlgo") << "  " << Object_Group[i];
     }
     LogTrace("HemisphereAlgo") << std::endl;
-    
   }
-  
-        
+
   status = 1;
   return 1;
 }
-
-
- 

--- a/PhysicsTools/PatAlgos/src/IsoDepositIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/IsoDepositIsolator.cc
@@ -4,100 +4,114 @@
 #include "DataFormats/RecoCandidate/interface/IsoDepositVetos.h"
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositVetoFactory.h"
 
-using pat::helper::IsoDepositIsolator;
 using pat::helper::BaseIsolator;
+using pat::helper::IsoDepositIsolator;
 using namespace reco::isodeposit;
 
-IsoDepositIsolator::IsoDepositIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) :
-    BaseIsolator(conf,iC,withCut), deltaR_(conf.getParameter<double>("deltaR")),
-    mode_(Sum), skipDefaultVeto_(false),
-    inputIsoDepositToken_(iC.consumes<Isolation>(input_))
-{
-    if (conf.exists("mode")) {
-        std::string mode = conf.getParameter<std::string>("mode");
-        if (mode == "sum") mode_ = Sum;
-        else if (mode == "sumRelative") mode_ = SumRelative;
-        else if (mode == "max") mode_ = Max;
-        else if (mode == "maxRelative") mode_ = MaxRelative;
-        else if (mode == "sum2") mode_ = Sum2;
-        else if (mode == "sum2Relative") mode_ = Sum2Relative;
-        else if (mode == "count") mode_ = Count;
-        else throw cms::Exception("Not Implemented") << "Mode '" << mode << "' not implemented. " <<
-                "Supported modes are 'sum', 'sumRelative', 'max', 'maxRelative', 'sum2', 'sum2Relative', 'count'." <<
-                "New methods can be easily implemented if requested.";
-    }
+IsoDepositIsolator::IsoDepositIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut)
+    : BaseIsolator(conf, iC, withCut),
+      deltaR_(conf.getParameter<double>("deltaR")),
+      mode_(Sum),
+      skipDefaultVeto_(false),
+      inputIsoDepositToken_(iC.consumes<Isolation>(input_)) {
+  if (conf.exists("mode")) {
+    std::string mode = conf.getParameter<std::string>("mode");
+    if (mode == "sum")
+      mode_ = Sum;
+    else if (mode == "sumRelative")
+      mode_ = SumRelative;
+    else if (mode == "max")
+      mode_ = Max;
+    else if (mode == "maxRelative")
+      mode_ = MaxRelative;
+    else if (mode == "sum2")
+      mode_ = Sum2;
+    else if (mode == "sum2Relative")
+      mode_ = Sum2Relative;
+    else if (mode == "count")
+      mode_ = Count;
+    else
+      throw cms::Exception("Not Implemented")
+          << "Mode '" << mode << "' not implemented. "
+          << "Supported modes are 'sum', 'sumRelative', 'max', 'maxRelative', 'sum2', 'sum2Relative', 'count'."
+          << "New methods can be easily implemented if requested.";
+  }
 
-    if (conf.exists("veto")) {
-        vetos_.push_back(new ConeVeto(Direction(), conf.getParameter<double>("veto")));
-    }
-    if (conf.exists("threshold")) {
-        vetos_.push_back(new ThresholdVeto(conf.getParameter<double>("threshold")));
-    }
-    if (conf.exists("skipDefaultVeto")) {
-        skipDefaultVeto_ = conf.getParameter<bool>("skipDefaultVeto");
-    }
+  if (conf.exists("veto")) {
+    vetos_.push_back(new ConeVeto(Direction(), conf.getParameter<double>("veto")));
+  }
+  if (conf.exists("threshold")) {
+    vetos_.push_back(new ThresholdVeto(conf.getParameter<double>("threshold")));
+  }
+  if (conf.exists("skipDefaultVeto")) {
+    skipDefaultVeto_ = conf.getParameter<bool>("skipDefaultVeto");
+  }
 
-    if (conf.exists("vetos")) { // expert configuration
-        if (!vetos_.empty())
-            throw cms::Exception("Configuration") << "You can't both configure this module with 'veto'/'threshold' AND with 'vetos'!";
-        if (!conf.exists("skipDefaultVeto"))
-            throw cms::Exception("Configuration") << "When using the expert configuration variable 'vetos' you must specify the value for 'skipDefaultVeto' too.";
+  if (conf.exists("vetos")) {  // expert configuration
+    if (!vetos_.empty())
+      throw cms::Exception("Configuration")
+          << "You can't both configure this module with 'veto'/'threshold' AND with 'vetos'!";
+    if (!conf.exists("skipDefaultVeto"))
+      throw cms::Exception("Configuration") << "When using the expert configuration variable 'vetos' you must specify "
+                                               "the value for 'skipDefaultVeto' too.";
 
-        typedef std::vector<std::string> vstring;
-        vstring vetos = conf.getParameter< vstring >("vetos");
-        reco::isodeposit::EventDependentAbsVeto *evdep = nullptr;
-        for (vstring::const_iterator it = vetos.begin(), ed = vetos.end(); it != ed; ++it) {
-              vetos_.push_back( IsoDepositVetoFactory::make( it->c_str(), evdep, iC ) );
-              if (evdep != nullptr) evdepVetos_.push_back(evdep);
-        }
+    typedef std::vector<std::string> vstring;
+    vstring vetos = conf.getParameter<vstring>("vetos");
+    reco::isodeposit::EventDependentAbsVeto *evdep = nullptr;
+    for (vstring::const_iterator it = vetos.begin(), ed = vetos.end(); it != ed; ++it) {
+      vetos_.push_back(IsoDepositVetoFactory::make(it->c_str(), evdep, iC));
+      if (evdep != nullptr)
+        evdepVetos_.push_back(evdep);
     }
-
+  }
 }
 
 IsoDepositIsolator::~IsoDepositIsolator() {
-    for (auto veto : vetos_){
-        delete veto;
-    }
+  for (auto veto : vetos_) {
+    delete veto;
+  }
 }
 
-void
-IsoDepositIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
-    event.getByToken(inputIsoDepositToken_, handle_);
-    for (auto veto :  evdepVetos_) {
-        veto->setEvent(event,eventSetup);
-    }
+void IsoDepositIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
+  event.getByToken(inputIsoDepositToken_, handle_);
+  for (auto veto : evdepVetos_) {
+    veto->setEvent(event, eventSetup);
+  }
 }
 
-void
-IsoDepositIsolator::endEvent() {
-    handle_.clear();
+void IsoDepositIsolator::endEvent() { handle_.clear(); }
+
+std::string IsoDepositIsolator::description() const {
+  using namespace std;
+  ostringstream oss;
+  oss << input_.encode() << "(dR=" << deltaR_ << ")";
+  return oss.str();
 }
 
-std::string
-IsoDepositIsolator::description() const {
-    using namespace std;
-    ostringstream oss;
-    oss << input_.encode() << "(dR=" << deltaR_ <<")";
-    return oss.str();
+float IsoDepositIsolator::getValue(const edm::ProductID &id, size_t index) const {
+  const reco::IsoDeposit &dep = handle_->get(id, index);
+
+  double eta = dep.eta(),
+         phi = dep.phi();  // better to center on the deposit direction that could be, e.g., the impact point at calo
+  for (auto veto : vetos_) {
+    veto->centerOn(eta, phi);
+  }
+  switch (mode_) {
+    case Count:
+      return dep.countWithin(deltaR_, vetos_, skipDefaultVeto_);
+    case Sum:
+      return dep.sumWithin(deltaR_, vetos_, skipDefaultVeto_);
+    case SumRelative:
+      return dep.sumWithin(deltaR_, vetos_, skipDefaultVeto_) / dep.candEnergy();
+    case Sum2:
+      return dep.sum2Within(deltaR_, vetos_, skipDefaultVeto_);
+    case Sum2Relative:
+      return dep.sum2Within(deltaR_, vetos_, skipDefaultVeto_) / (dep.candEnergy() * dep.candEnergy());
+    case Max:
+      return dep.maxWithin(deltaR_, vetos_, skipDefaultVeto_);
+    case MaxRelative:
+      return dep.maxWithin(deltaR_, vetos_, skipDefaultVeto_) / dep.candEnergy();
+  }
+  throw cms::Exception("Logic error") << "Should not happen at " << __FILE__ << ", line "
+                                      << __LINE__;  // avoid gcc warning
 }
-
-float
-IsoDepositIsolator::getValue(const edm::ProductID &id, size_t index) const {
-    const reco::IsoDeposit &dep = handle_->get(id, index);
-
-    double eta = dep.eta(), phi = dep.phi(); // better to center on the deposit direction that could be, e.g., the impact point at calo
-    for (auto veto : vetos_) {
-        veto->centerOn(eta, phi);
-    }
-    switch (mode_) {
-        case Count:        return dep.countWithin(deltaR_, vetos_, skipDefaultVeto_);
-        case Sum:          return dep.sumWithin(deltaR_, vetos_, skipDefaultVeto_);
-        case SumRelative:  return dep.sumWithin(deltaR_, vetos_, skipDefaultVeto_) / dep.candEnergy() ;
-        case Sum2:         return dep.sum2Within(deltaR_, vetos_, skipDefaultVeto_);
-        case Sum2Relative: return dep.sum2Within(deltaR_, vetos_, skipDefaultVeto_) / (dep.candEnergy() * dep.candEnergy()) ;
-        case Max:          return dep.maxWithin(deltaR_, vetos_, skipDefaultVeto_);
-        case MaxRelative:  return dep.maxWithin(deltaR_, vetos_, skipDefaultVeto_) / dep.candEnergy() ;
-    }
-    throw cms::Exception("Logic error") << "Should not happen at " << __FILE__ << ", line " << __LINE__; // avoid gcc warning
-}
-

--- a/PhysicsTools/PatAlgos/src/KinResolutionsLoader.cc
+++ b/PhysicsTools/PatAlgos/src/KinResolutionsLoader.cc
@@ -5,37 +5,35 @@
 
 using pat::helper::KinResolutionsLoader;
 
-KinResolutionsLoader::KinResolutionsLoader(const edm::ParameterSet &iConfig) 
-{
-    // Get the names (sorted)
-    patlabels_ = iConfig.getParameterNamesForType<std::string>();
-    
-    // get the InputTags
-    for (std::vector<std::string>::const_iterator it = patlabels_.begin(), ed = patlabels_.end(); it != ed; ++it) {
-        eslabels_.push_back( iConfig.getParameter<std::string>(*it) );
-    }
+KinResolutionsLoader::KinResolutionsLoader(const edm::ParameterSet &iConfig) {
+  // Get the names (sorted)
+  patlabels_ = iConfig.getParameterNamesForType<std::string>();
 
-    // prepare the Handles
-    handles_.resize(patlabels_.size());
+  // get the InputTags
+  for (std::vector<std::string>::const_iterator it = patlabels_.begin(), ed = patlabels_.end(); it != ed; ++it) {
+    eslabels_.push_back(iConfig.getParameter<std::string>(*it));
+  }
 
-    // 'default' maps to empty string
-    for (std::vector<std::string>::iterator it = patlabels_.begin(), ed = patlabels_.end(); it != ed; ++it) {
-        if (*it == "default") *it = "";
-    }
+  // prepare the Handles
+  handles_.resize(patlabels_.size());
+
+  // 'default' maps to empty string
+  for (std::vector<std::string>::iterator it = patlabels_.begin(), ed = patlabels_.end(); it != ed; ++it) {
+    if (*it == "default")
+      *it = "";
+  }
 }
 
-void
-KinResolutionsLoader::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-    for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
-        iSetup.get<KinematicResolutionRcd>().get(eslabels_[i], handles_[i]);
-        handles_[i]->setup(iSetup);
-    }    
+void KinResolutionsLoader::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
+    iSetup.get<KinematicResolutionRcd>().get(eslabels_[i], handles_[i]);
+    handles_[i]->setup(iSetup);
+  }
 }
 
-void 
-KinResolutionsLoader::fillDescription(edm::ParameterSetDescription & iDesc) {
-    iDesc.add<bool>("addResolutions",false)->setComment("Add resolutions into this PAT Object");
-    edm::ParameterSetDescription resolutionPSet;
-    resolutionPSet.setAllowAnything();
-    iDesc.addOptional("resolutions", resolutionPSet)->setComment("Resolution values to get from EventSetup");
+void KinResolutionsLoader::fillDescription(edm::ParameterSetDescription &iDesc) {
+  iDesc.add<bool>("addResolutions", false)->setComment("Add resolutions into this PAT Object");
+  edm::ParameterSetDescription resolutionPSet;
+  resolutionPSet.setAllowAnything();
+  iDesc.addOptional("resolutions", resolutionPSet)->setComment("Resolution values to get from EventSetup");
 }

--- a/PhysicsTools/PatAlgos/src/KinematicResolutionRcd.cc
+++ b/PhysicsTools/PatAlgos/src/KinematicResolutionRcd.cc
@@ -2,11 +2,11 @@
 //
 // Package:     PatAlgos
 // Class  :     KinematicResolutionRcd
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Sun Jun 24 16:53:34 CEST 2007
 
 #include "PhysicsTools/PatAlgos/interface/KinematicResolutionRcd.h"

--- a/PhysicsTools/PatAlgos/src/MultiIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/MultiIsolator.cc
@@ -6,90 +6,99 @@
 
 using namespace pat::helper;
 
-MultiIsolator::MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector && iC, bool cuts) {
-    using pat::Flags;
-    if (conf.exists("tracker")) addIsolator(conf.getParameter<edm::ParameterSet>("tracker"), iC, cuts, Flags::Isolation::Tracker, pat::TrackIso);
-    if (conf.exists("ecal"))    addIsolator(conf.getParameter<edm::ParameterSet>("ecal"),    iC, cuts, Flags::Isolation::ECal, pat::EcalIso);
-    if (conf.exists("hcal"))    addIsolator(conf.getParameter<edm::ParameterSet>("hcal"),    iC, cuts, Flags::Isolation::HCal, pat::HcalIso);
-    if (conf.exists("calo"))    addIsolator(conf.getParameter<edm::ParameterSet>("calo"),    iC, cuts, Flags::Isolation::Calo, pat::CaloIso);
-    if (conf.exists("calo") && (conf.exists("ecal") || conf.exists("hcal"))) {
-        throw cms::Exception("Configuration") <<
-            "MultiIsolator: you can't specify both 'calo' isolation and 'ecal'/'hcal', " <<
-            "as the 'calo' isolation flag is just the logical OR of 'ecal' and 'hcal'.\n";
+MultiIsolator::MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC, bool cuts) {
+  using pat::Flags;
+  if (conf.exists("tracker"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("tracker"), iC, cuts, Flags::Isolation::Tracker, pat::TrackIso);
+  if (conf.exists("ecal"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("ecal"), iC, cuts, Flags::Isolation::ECal, pat::EcalIso);
+  if (conf.exists("hcal"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("hcal"), iC, cuts, Flags::Isolation::HCal, pat::HcalIso);
+  if (conf.exists("calo"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("calo"), iC, cuts, Flags::Isolation::Calo, pat::CaloIso);
+  if (conf.exists("calo") && (conf.exists("ecal") || conf.exists("hcal"))) {
+    throw cms::Exception("Configuration")
+        << "MultiIsolator: you can't specify both 'calo' isolation and 'ecal'/'hcal', "
+        << "as the 'calo' isolation flag is just the logical OR of 'ecal' and 'hcal'.\n";
+  }
+  if (conf.exists("pfAllParticles"))
+    addIsolator(
+        conf.getParameter<edm::ParameterSet>("pfAllParticles"), iC, cuts, Flags::Isolation::Calo, pat::PfAllParticleIso);
+  if (conf.exists("pfChargedHadron"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("pfChargedHadron"),
+                iC,
+                cuts,
+                Flags::Isolation::Calo,
+                pat::PfChargedHadronIso);
+  if (conf.exists("pfNeutralHadron"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("pfNeutralHadron"),
+                iC,
+                cuts,
+                Flags::Isolation::Calo,
+                pat::PfNeutralHadronIso);
+  if (conf.exists("pfGamma"))
+    addIsolator(conf.getParameter<edm::ParameterSet>("pfGamma"), iC, cuts, Flags::Isolation::Calo, pat::PfGammaIso);
+  if (conf.exists("user")) {
+    std::vector<edm::ParameterSet> psets = conf.getParameter<std::vector<edm::ParameterSet> >("user");
+    if (psets.size() > 5) {
+      throw cms::Exception("Configuration") << "MultiIsolator: you can specify at most 5 user isolation collections.\n";
     }
-    if (conf.exists("pfAllParticles"))  addIsolator(conf.getParameter<edm::ParameterSet>("pfAllParticles"), iC, cuts,Flags::Isolation::Calo, pat::PfAllParticleIso);
-    if (conf.exists("pfChargedHadron")) addIsolator(conf.getParameter<edm::ParameterSet>("pfChargedHadron"), iC, cuts,Flags::Isolation::Calo, pat::PfChargedHadronIso);
-    if (conf.exists("pfNeutralHadron")) addIsolator(conf.getParameter<edm::ParameterSet>("pfNeutralHadron"), iC, cuts,Flags::Isolation::Calo, pat::PfNeutralHadronIso);
-    if (conf.exists("pfGamma"))         addIsolator(conf.getParameter<edm::ParameterSet>("pfGamma"), iC, cuts,Flags::Isolation::Calo, pat::PfGammaIso);
-    if (conf.exists("user")) {
-
-        std::vector<edm::ParameterSet> psets = conf.getParameter<std::vector<edm::ParameterSet> >("user");
-        if (psets.size() > 5) {
-            throw cms::Exception("Configuration") <<
-                "MultiIsolator: you can specify at most 5 user isolation collections.\n";
-        }
-        uint32_t bit = Flags::Isolation::User1;
-        for (std::vector<edm::ParameterSet>::const_iterator it = psets.begin(), ed = psets.end(); it != ed; ++it, bit <<= 1) {
-            addIsolator(*it, iC, cuts, bit, pat::IsolationKeys(pat::UserBaseIso + (it - psets.begin())));
-        }
+    uint32_t bit = Flags::Isolation::User1;
+    for (std::vector<edm::ParameterSet>::const_iterator it = psets.begin(), ed = psets.end(); it != ed;
+         ++it, bit <<= 1) {
+      addIsolator(*it, iC, cuts, bit, pat::IsolationKeys(pat::UserBaseIso + (it - psets.begin())));
     }
+  }
 }
 
-
-void
-MultiIsolator::addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key) {
-    isolators_.push_back(iso);
-    masks_.push_back(mask);
-    keys_.push_back(key);
+void MultiIsolator::addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key) {
+  isolators_.push_back(iso);
+  masks_.push_back(mask);
+  keys_.push_back(key);
 }
 
-BaseIsolator *
-MultiIsolator::make(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) {
-    if (conf.empty()) return nullptr;
-    if (conf.exists("placeholder") && conf.getParameter<bool>("placeholder")) return nullptr;
-    if (conf.exists("deltaR")) {
-        return new IsoDepositIsolator(conf, iC, withCut);
-    } else {
-        return new SimpleIsolator(conf, iC, withCut);
-    }
+BaseIsolator *MultiIsolator::make(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut) {
+  if (conf.empty())
+    return nullptr;
+  if (conf.exists("placeholder") && conf.getParameter<bool>("placeholder"))
+    return nullptr;
+  if (conf.exists("deltaR")) {
+    return new IsoDepositIsolator(conf, iC, withCut);
+  } else {
+    return new SimpleIsolator(conf, iC, withCut);
+  }
 }
 
-
-void
-MultiIsolator::addIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut, uint32_t mask, pat::IsolationKeys key) {
-   BaseIsolator * iso = make(conf, iC, withCut);
-    if (iso) addIsolator(iso, mask, key);
+void MultiIsolator::addIsolator(
+    const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut, uint32_t mask, pat::IsolationKeys key) {
+  BaseIsolator *iso = make(conf, iC, withCut);
+  if (iso)
+    addIsolator(iso, mask, key);
 }
 
-
-void
-MultiIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
-    for (boost::ptr_vector<BaseIsolator>::iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
-        it->beginEvent(event, eventSetup);
-    }
+void MultiIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
+  for (boost::ptr_vector<BaseIsolator>::iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
+    it->beginEvent(event, eventSetup);
+  }
 }
 
-void
-MultiIsolator::endEvent() {
-    for (boost::ptr_vector<BaseIsolator>::iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
-        it->endEvent();
-    }
+void MultiIsolator::endEvent() {
+  for (boost::ptr_vector<BaseIsolator>::iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
+    it->endEvent();
+  }
 }
 
-void
-MultiIsolator::print(std::ostream &out) const {
-    for (boost::ptr_vector<BaseIsolator>::const_iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
-        out << " * ";
-        it->print(out);
-        out << ": Flag " << pat::Flags::bitToString( masks_[it - isolators_.begin()] ) << "\n";
-    }
-    out << "\n";
+void MultiIsolator::print(std::ostream &out) const {
+  for (boost::ptr_vector<BaseIsolator>::const_iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
+    out << " * ";
+    it->print(out);
+    out << ": Flag " << pat::Flags::bitToString(masks_[it - isolators_.begin()]) << "\n";
+  }
+  out << "\n";
 }
 
-std::string
-MultiIsolator::printSummary() const {
-    std::ostringstream isoSumm;
-    print(isoSumm);
-    return isoSumm.str();
+std::string MultiIsolator::printSummary() const {
+  std::ostringstream isoSumm;
+  print(isoSumm);
+  return isoSumm.str();
 }
-

--- a/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
@@ -13,54 +13,51 @@
 
 using namespace pat;
 
-MuonMvaEstimator::MuonMvaEstimator(const edm::FileInPath& weightsfile, float dRmax):
-  dRmax_(dRmax)
-{
-  gbrForest_ = createGBRForest( weightsfile );
+MuonMvaEstimator::MuonMvaEstimator(const edm::FileInPath& weightsfile, float dRmax) : dRmax_(dRmax) {
+  gbrForest_ = createGBRForest(weightsfile);
 }
 
-MuonMvaEstimator::~MuonMvaEstimator() { }
+MuonMvaEstimator::~MuonMvaEstimator() {}
 
 namespace {
 
   enum inputIndexes {
-      kPt,
-      kEta,
-      kJetNDauCharged,
-      kMiniRelIsoCharged,
-      kMiniRelIsoNeutral,
-      kJetPtRel,
-      kJetBTagCSV,
-      kJetPtRatio,
-      kLog_abs_dxyBS,
-      kSip,
-      kLog_abs_dzPV,
-      kSegmentCompatibility,
-      kLast
+    kPt,
+    kEta,
+    kJetNDauCharged,
+    kMiniRelIsoCharged,
+    kMiniRelIsoNeutral,
+    kJetPtRel,
+    kJetBTagCSV,
+    kJetPtRatio,
+    kLog_abs_dxyBS,
+    kSip,
+    kLog_abs_dzPV,
+    kSegmentCompatibility,
+    kLast
   };
 
-  float ptRel(const reco::Candidate::LorentzVector& muP4, const reco::Candidate::LorentzVector& jetP4,
-              bool subtractMuon=true)
-  {
+  float ptRel(const reco::Candidate::LorentzVector& muP4,
+              const reco::Candidate::LorentzVector& jetP4,
+              bool subtractMuon = true) {
     reco::Candidate::LorentzVector jp4 = jetP4;
-    if (subtractMuon) jp4-=muP4;
-    float dot = muP4.Vect().Dot( jp4.Vect() );
-    float ptrel = muP4.P2() - dot*dot/jp4.P2();
-    ptrel = ptrel>0 ? sqrt(ptrel) : 0.0;
+    if (subtractMuon)
+      jp4 -= muP4;
+    float dot = muP4.Vect().Dot(jp4.Vect());
+    float ptrel = muP4.P2() - dot * dot / jp4.P2();
+    ptrel = ptrel > 0 ? sqrt(ptrel) : 0.0;
     return ptrel;
   }
-}
+}  // namespace
 
 float MuonMvaEstimator::computeMva(const pat::Muon& muon,
-				  const reco::Vertex& vertex,
-				  const reco::JetTagCollection& bTags,
-                                  float& jetPtRatio,
-                                  float& jetPtRel,
-				  float& miniIsoValue, 
-				  const reco::JetCorrector* correctorL1,
-				  const reco::JetCorrector* correctorL1L2L3Res
-				   ) const
-{
+                                   const reco::Vertex& vertex,
+                                   const reco::JetTagCollection& bTags,
+                                   float& jetPtRatio,
+                                   float& jetPtRel,
+                                   float& miniIsoValue,
+                                   const reco::JetCorrector* correctorL1,
+                                   const reco::JetCorrector* correctorL1L2L3Res) const {
   float var[kLast]{};
 
   var[kPt] = muon.pt();
@@ -69,13 +66,13 @@ float MuonMvaEstimator::computeMva(const pat::Muon& muon,
   var[kMiniRelIsoCharged] = muon.miniPFIsolation().chargedHadronIso() / muon.pt();
   var[kMiniRelIsoNeutral] = miniIsoValue - var[kMiniRelIsoCharged];
 
-  double dB2D  = fabs(muon.dB(pat::Muon::PV2D));
-  double dB3D  = muon.dB(pat::Muon::PV3D);
+  double dB2D = fabs(muon.dB(pat::Muon::PV2D));
+  double dB3D = muon.dB(pat::Muon::PV3D);
   double edB3D = muon.edB(pat::Muon::PV3D);
-  double dz    = fabs(muon.muonBestTrack()->dz(vertex.position()));
-  var[kSip]  = edB3D>0?fabs(dB3D/edB3D):0.0;
-  var[kLog_abs_dxyBS]     = dB2D>0?log(dB2D):0;
-  var[kLog_abs_dzPV]      = dz>0?log(dz):0;
+  double dz = fabs(muon.muonBestTrack()->dz(vertex.position()));
+  var[kSip] = edB3D > 0 ? fabs(dB3D / edB3D) : 0.0;
+  var[kLog_abs_dxyBS] = dB2D > 0 ? log(dB2D) : 0;
+  var[kLog_abs_dzPV] = dz > 0 ? log(dz) : 0;
 
   //Initialise loop variables
   double minDr = 9999;
@@ -83,29 +80,29 @@ float MuonMvaEstimator::computeMva(const pat::Muon& muon,
   double jecL1 = 1.;
 
   // Compute corrected isolation variables
-  double chIso  = muon.pfIsolationR04().sumChargedHadronPt;
-  double nIso   = muon.pfIsolationR04().sumNeutralHadronEt;
+  double chIso = muon.pfIsolationR04().sumChargedHadronPt;
+  double nIso = muon.pfIsolationR04().sumNeutralHadronEt;
   double phoIso = muon.pfIsolationR04().sumPhotonEt;
-  double puIso  = muon.pfIsolationR04().sumPUPt;
-  double dbCorrectedIsolation = chIso + std::max( nIso + phoIso - .5*puIso, 0. ) ;
-  double dbCorrectedRelIso = dbCorrectedIsolation/muon.pt();
+  double puIso = muon.pfIsolationR04().sumPUPt;
+  double dbCorrectedIsolation = chIso + std::max(nIso + phoIso - .5 * puIso, 0.);
+  double dbCorrectedRelIso = dbCorrectedIsolation / muon.pt();
 
-  var[kJetPtRatio] = 1./(1+dbCorrectedRelIso);
-  var[kJetPtRel]   = 0;
+  var[kJetPtRatio] = 1. / (1 + dbCorrectedRelIso);
+  var[kJetPtRel] = 0;
   var[kJetBTagCSV] = -999;
   var[kJetNDauCharged] = -1;
 
-
-  for (const auto& tagI: bTags){
-    // for each muon with the lepton 
+  for (const auto& tagI : bTags) {
+    // for each muon with the lepton
     double dr = deltaR(*(tagI.first), muon);
-    if(dr > minDr) continue;  
+    if (dr > minDr)
+      continue;
     minDr = dr;
-      
-    const reco::Candidate::LorentzVector& muP4(muon.p4()); 
+
+    const reco::Candidate::LorentzVector& muP4(muon.p4());
     reco::Candidate::LorentzVector jetP4(tagI.first->p4());
 
-    if (correctorL1 && correctorL1L2L3Res){
+    if (correctorL1 && correctorL1L2L3Res) {
       jecL1L2L3Res = correctorL1L2L3Res->correction(*(tagI.first));
       jecL1 = correctorL1->correction(*(tagI.first));
     }
@@ -113,40 +110,52 @@ float MuonMvaEstimator::computeMva(const pat::Muon& muon,
     // Get b-jet info
     var[kJetBTagCSV] = tagI.second;
     var[kJetNDauCharged] = 0;
-    for (auto jet: tagI.first->getJetConstituentsQuick()){
-      const reco::PFCandidate *pfcand = dynamic_cast<const reco::PFCandidate*>(jet);
-      if (pfcand==nullptr) throw cms::Exception("ConfigurationError") << "Cannot get jet constituents";
-      if (pfcand->charge()==0) continue;
+    for (auto jet : tagI.first->getJetConstituentsQuick()) {
+      const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(jet);
+      if (pfcand == nullptr)
+        throw cms::Exception("ConfigurationError") << "Cannot get jet constituents";
+      if (pfcand->charge() == 0)
+        continue;
       auto bestTrackPtr = pfcand->bestTrack();
-      if (!bestTrackPtr) continue;
-      if (!bestTrackPtr->quality(reco::Track::highPurity)) continue;
-      if (bestTrackPtr->pt()<1.) continue;
-      if (bestTrackPtr->hitPattern().numberOfValidHits()<8) continue;
-      if (bestTrackPtr->hitPattern().numberOfValidPixelHits()<2) continue;
-      if (bestTrackPtr->normalizedChi2()>=5) continue;
+      if (!bestTrackPtr)
+        continue;
+      if (!bestTrackPtr->quality(reco::Track::highPurity))
+        continue;
+      if (bestTrackPtr->pt() < 1.)
+        continue;
+      if (bestTrackPtr->hitPattern().numberOfValidHits() < 8)
+        continue;
+      if (bestTrackPtr->hitPattern().numberOfValidPixelHits() < 2)
+        continue;
+      if (bestTrackPtr->normalizedChi2() >= 5)
+        continue;
 
-      if (std::fabs(bestTrackPtr->dxy(vertex.position())) > 0.2) continue;
-      if (std::fabs(bestTrackPtr->dz(vertex.position())) > 17) continue;
+      if (std::fabs(bestTrackPtr->dxy(vertex.position())) > 0.2)
+        continue;
+      if (std::fabs(bestTrackPtr->dz(vertex.position())) > 17)
+        continue;
       var[kJetNDauCharged]++;
     }
 
-    if(minDr < dRmax_){
-      if ((jetP4-muP4).Rho()<0.0001){ 
-	var[kJetPtRel] = 0;
-	var[kJetPtRatio] = 1;
+    if (minDr < dRmax_) {
+      if ((jetP4 - muP4).Rho() < 0.0001) {
+        var[kJetPtRel] = 0;
+        var[kJetPtRatio] = 1;
       } else {
-	jetP4 -= muP4/jecL1;
-	jetP4 *= jecL1L2L3Res;
-	jetP4 += muP4;
-      
-	var[kJetPtRatio] = muP4.pt()/jetP4.pt();
-	var[kJetPtRel] = ptRel(muP4,jetP4);
+        jetP4 -= muP4 / jecL1;
+        jetP4 *= jecL1L2L3Res;
+        jetP4 += muP4;
+
+        var[kJetPtRatio] = muP4.pt() / jetP4.pt();
+        var[kJetPtRel] = ptRel(muP4, jetP4);
       }
     }
   }
 
-  if (var[kJetPtRatio] > 1.5) var[kJetPtRatio] = 1.5;
-  if (var[kJetBTagCSV] < 0) var[kJetBTagCSV] = 0;
+  if (var[kJetPtRatio] > 1.5)
+    var[kJetPtRatio] = 1.5;
+  if (var[kJetBTagCSV] < 0)
+    var[kJetBTagCSV] = 0;
   jetPtRatio = var[kJetPtRatio];
   jetPtRel = var[kJetPtRel];
   return gbrForest_->GetClassifier(var);

--- a/PhysicsTools/PatAlgos/src/OverlapTest.cc
+++ b/PhysicsTools/PatAlgos/src/OverlapTest.cc
@@ -6,75 +6,79 @@
 
 using namespace pat::helper;
 
-void
-BasicOverlapTest::readInput(const edm::Event & iEvent, const edm::EventSetup &iSetup)
-{
-    iEvent.getByToken(srcToken_, candidates_);
-    isPreselected_.resize(candidates_->size());
-    size_t idx = 0;
-    for (reco::CandidateView::const_iterator it = candidates_->begin(); it != candidates_->end(); ++it, ++idx) {
-        isPreselected_[idx] = presel_(*it);
-    }
-    // Yes, I could use std::transform. But would people like it?
-    // http://www.sgi.com/tech/stl/transform.html
+void BasicOverlapTest::readInput(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  iEvent.getByToken(srcToken_, candidates_);
+  isPreselected_.resize(candidates_->size());
+  size_t idx = 0;
+  for (reco::CandidateView::const_iterator it = candidates_->begin(); it != candidates_->end(); ++it, ++idx) {
+    isPreselected_[idx] = presel_(*it);
+  }
+  // Yes, I could use std::transform. But would people like it?
+  // http://www.sgi.com/tech/stl/transform.html
 }
 
-bool
-BasicOverlapTest::fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const
-{
-    size_t idx = 0;
-    std::vector<std::pair<float,size_t> > matches;
-    for (reco::CandidateView::const_iterator it = candidates_->begin(); it != candidates_->end(); ++it, ++idx) {
-        if (!isPreselected_[idx]) continue;
-        double dr = reco::deltaR(item, *it);
-        if (dr < deltaR_) {
-            if (checkRecoComponents_) {
-                OverlapChecker overlaps;
-                if (!overlaps(item, *it)) continue;
-            }
-            if (!pairCut_(pat::DiObjectProxy(item,*it))) continue;
-            matches.push_back(std::make_pair(dr, idx));
-        }
+bool BasicOverlapTest::fillOverlapsForItem(const reco::Candidate &item,
+                                           reco::CandidatePtrVector &overlapsToFill) const {
+  size_t idx = 0;
+  std::vector<std::pair<float, size_t> > matches;
+  for (reco::CandidateView::const_iterator it = candidates_->begin(); it != candidates_->end(); ++it, ++idx) {
+    if (!isPreselected_[idx])
+      continue;
+    double dr = reco::deltaR(item, *it);
+    if (dr < deltaR_) {
+      if (checkRecoComponents_) {
+        OverlapChecker overlaps;
+        if (!overlaps(item, *it))
+          continue;
+      }
+      if (!pairCut_(pat::DiObjectProxy(item, *it)))
+        continue;
+      matches.push_back(std::make_pair(dr, idx));
     }
-    // see if we matched anything
-    if (matches.empty()) return false;
+  }
+  // see if we matched anything
+  if (matches.empty())
+    return false;
 
-    // sort matches
-    std::sort(matches.begin(), matches.end());
-    // fill ptr vector
-    for (std::vector<std::pair<float,size_t> >::const_iterator it = matches.begin(); it != matches.end(); ++it) {
-        overlapsToFill.push_back(candidates_->ptrAt(it->second));
-    }
-    return true;
+  // sort matches
+  std::sort(matches.begin(), matches.end());
+  // fill ptr vector
+  for (std::vector<std::pair<float, size_t> >::const_iterator it = matches.begin(); it != matches.end(); ++it) {
+    overlapsToFill.push_back(candidates_->ptrAt(it->second));
+  }
+  return true;
 }
 
-bool
-OverlapBySuperClusterSeed::fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const
-{
-    const reco::RecoCandidate * input = dynamic_cast<const reco::RecoCandidate *>(&item);
-    if (input == nullptr) throw cms::Exception("Type Error") << "Input to OverlapBySuperClusterSeed is not a RecoCandidate. "
-                                                       << "It's a " << typeid(item).name() << "\n";
-    reco::SuperClusterRef mySC = input->superCluster();
-    if (mySC.isNull() || !mySC.isAvailable()) {
-        throw cms::Exception("Bad Reference") << "Input to OverlapBySuperClusterSeed has a null or dangling superCluster reference\n";
+bool OverlapBySuperClusterSeed::fillOverlapsForItem(const reco::Candidate &item,
+                                                    reco::CandidatePtrVector &overlapsToFill) const {
+  const reco::RecoCandidate *input = dynamic_cast<const reco::RecoCandidate *>(&item);
+  if (input == nullptr)
+    throw cms::Exception("Type Error") << "Input to OverlapBySuperClusterSeed is not a RecoCandidate. "
+                                       << "It's a " << typeid(item).name() << "\n";
+  reco::SuperClusterRef mySC = input->superCluster();
+  if (mySC.isNull() || !mySC.isAvailable()) {
+    throw cms::Exception("Bad Reference")
+        << "Input to OverlapBySuperClusterSeed has a null or dangling superCluster reference\n";
+  }
+  const reco::CaloClusterPtr &mySeed = mySC->seed();
+  if (mySeed.isNull()) {
+    throw cms::Exception("Bad Reference")
+        << "Input to OverlapBySuperClusterSeed has a null superCluster seed reference\n";
+  }
+  bool hasOverlaps = false;
+  size_t idx = 0;
+  //     for (edm::View<reco::RecoCandidate>::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
+  for (reco::CandidateView::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
+    const reco::RecoCandidate *other = dynamic_cast<const reco::RecoCandidate *>(&*it);
+    reco::SuperClusterRef otherSc = other->superCluster();
+    if (otherSc.isNull() || !otherSc.isAvailable()) {
+      throw cms::Exception("Bad Reference")
+          << "One item in the OverlapBySuperClusterSeed input list has a null or dangling superCluster reference\n";
     }
-    const reco::CaloClusterPtr & mySeed = mySC->seed();
-    if (mySeed.isNull()) {
-        throw cms::Exception("Bad Reference") << "Input to OverlapBySuperClusterSeed has a null superCluster seed reference\n";
+    if (mySeed == otherSc->seed()) {
+      overlapsToFill.push_back(others_->ptrAt(idx));
+      hasOverlaps = true;
     }
-    bool hasOverlaps = false;
-    size_t idx = 0;
-//     for (edm::View<reco::RecoCandidate>::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
-    for (reco::CandidateView::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
-        const reco::RecoCandidate * other = dynamic_cast<const reco::RecoCandidate *>(&*it);
-        reco::SuperClusterRef otherSc = other->superCluster();
-        if (otherSc.isNull() || !otherSc.isAvailable()) {
-            throw cms::Exception("Bad Reference") << "One item in the OverlapBySuperClusterSeed input list has a null or dangling superCluster reference\n";
-        }
-        if (mySeed == otherSc->seed()) {
-            overlapsToFill.push_back(others_->ptrAt(idx));
-            hasOverlaps = true;
-        }
-    }
-    return hasOverlaps;
+  }
+  return hasOverlaps;
 }

--- a/PhysicsTools/PatAlgos/src/PATPrimaryVertexSelector.cc
+++ b/PhysicsTools/PatAlgos/src/PATPrimaryVertexSelector.cc
@@ -3,56 +3,53 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-PATPrimaryVertexSelector::PATPrimaryVertexSelector (const edm::ParameterSet& cfg, edm::ConsumesCollector && iC) :
-  multiplicityCut_(cfg.getParameter<unsigned int>("minMultiplicity")),
-  ptSumCut_(cfg.getParameter<double>("minPtSum")),
-  trackEtaCut_(cfg.getParameter<double>("maxTrackEta")),
-  chi2Cut_(cfg.getParameter<double>("maxNormChi2")),
-  dr2Cut_(cfg.getParameter<double>("maxDeltaR")),
-  dzCut_(cfg.getParameter<double>("maxDeltaZ")) {
+PATPrimaryVertexSelector::PATPrimaryVertexSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+    : multiplicityCut_(cfg.getParameter<unsigned int>("minMultiplicity")),
+      ptSumCut_(cfg.getParameter<double>("minPtSum")),
+      trackEtaCut_(cfg.getParameter<double>("maxTrackEta")),
+      chi2Cut_(cfg.getParameter<double>("maxNormChi2")),
+      dr2Cut_(cfg.getParameter<double>("maxDeltaR")),
+      dzCut_(cfg.getParameter<double>("maxDeltaZ")) {
   // store squared cut (avoid using sqrt() for each vertex)
   dr2Cut_ *= dr2Cut_;
 }
 
-void
-PATPrimaryVertexSelector::select (const edm::Handle<collection>& handle,
-				  const edm::Event& event,
-				  const edm::EventSetup& setup) {
+void PATPrimaryVertexSelector::select(const edm::Handle<collection>& handle,
+                                      const edm::Event& event,
+                                      const edm::EventSetup& setup) {
   selected_.clear();
   // FIXME: the fixed reference point should be replaced with the measured beamspot
-  const math::XYZPoint beamSpot(0.,0.,0.);
+  const math::XYZPoint beamSpot(0., 0., 0.);
   unsigned int multiplicity;
   double ptSum;
-  for ( collection::const_iterator iv=handle->begin(); iv!=handle->end(); ++iv ) {
-    math::XYZVector displacement(iv->position()-beamSpot);
-    if ( iv->normalizedChi2()<chi2Cut_ &&
-	 fabs(displacement.z())<dzCut_ && displacement.perp2()<dr2Cut_ ) {
-      getVertexVariables(*iv,multiplicity,ptSum);
-      if ( multiplicity>=multiplicityCut_ && ptSum>ptSumCut_ ) selected_.push_back(&*iv);
+  for (collection::const_iterator iv = handle->begin(); iv != handle->end(); ++iv) {
+    math::XYZVector displacement(iv->position() - beamSpot);
+    if (iv->normalizedChi2() < chi2Cut_ && fabs(displacement.z()) < dzCut_ && displacement.perp2() < dr2Cut_) {
+      getVertexVariables(*iv, multiplicity, ptSum);
+      if (multiplicity >= multiplicityCut_ && ptSum > ptSumCut_)
+        selected_.push_back(&*iv);
     }
   }
-  sort(selected_.begin(),selected_.end(),*this);
+  sort(selected_.begin(), selected_.end(), *this);
 }
 
-bool
-PATPrimaryVertexSelector::operator() (const reco::Vertex* v1, const reco::Vertex* v2) const {
+bool PATPrimaryVertexSelector::operator()(const reco::Vertex* v1, const reco::Vertex* v2) const {
   unsigned int mult1;
   double ptSum1;
-  getVertexVariables(*v1,mult1,ptSum1);
+  getVertexVariables(*v1, mult1, ptSum1);
   unsigned int mult2;
   double ptSum2;
-  getVertexVariables(*v2,mult2,ptSum2);
-  return ptSum1>ptSum2;
+  getVertexVariables(*v2, mult2, ptSum2);
+  return ptSum1 > ptSum2;
 }
 
-void
-PATPrimaryVertexSelector::getVertexVariables (const reco::Vertex& vertex,
-					      unsigned int& multiplicity, double& ptSum) const {
+void PATPrimaryVertexSelector::getVertexVariables(const reco::Vertex& vertex,
+                                                  unsigned int& multiplicity,
+                                                  double& ptSum) const {
   multiplicity = 0;
   ptSum = 0.;
-  for(reco::Vertex::trackRef_iterator it=vertex.tracks_begin();
-      it!=vertex.tracks_end(); ++it) {
-    if(fabs((**it).eta())<trackEtaCut_) {
+  for (reco::Vertex::trackRef_iterator it = vertex.tracks_begin(); it != vertex.tracks_end(); ++it) {
+    if (fabs((**it).eta()) < trackEtaCut_) {
       ++multiplicity;
       ptSum += (**it).pt();
     }

--- a/PhysicsTools/PatAlgos/src/PATUserDataMerger.cc
+++ b/PhysicsTools/PatAlgos/src/PATUserDataMerger.cc
@@ -1,2 +1,1 @@
 #include "PhysicsTools/PatAlgos/interface/PATUserDataMerger.h"
-

--- a/PhysicsTools/PatAlgos/src/SimpleIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/SimpleIsolator.cc
@@ -1,22 +1,14 @@
 #include "PhysicsTools/PatAlgos/interface/SimpleIsolator.h"
 #include <sstream>
 
-using pat::helper::SimpleIsolator;
 using pat::helper::BaseIsolator;
+using pat::helper::SimpleIsolator;
 
+SimpleIsolator::SimpleIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector &iC, bool withCut)
+    : BaseIsolator(conf, iC, withCut) {}
 
-SimpleIsolator::SimpleIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) :
-    BaseIsolator(conf, iC, withCut)
-{
+void SimpleIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
+  event.getByToken(inputDoubleToken_, handle_);
 }
 
-void
-SimpleIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
-    event.getByToken(inputDoubleToken_, handle_);
-}
-
-void
-SimpleIsolator::endEvent() {
-    handle_.clear();
-}
-
+void SimpleIsolator::endEvent() { handle_.clear(); }

--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaEstimator.cc
@@ -9,12 +9,11 @@
 
 using namespace pat;
 
-SoftMuonMvaEstimator::SoftMuonMvaEstimator(const edm::FileInPath& weightsfile)
-{
-  gbrForest_ = createGBRForest( weightsfile );
+SoftMuonMvaEstimator::SoftMuonMvaEstimator(const edm::FileInPath& weightsfile) {
+  gbrForest_ = createGBRForest(weightsfile);
 }
 
-SoftMuonMvaEstimator::~SoftMuonMvaEstimator() { }
+SoftMuonMvaEstimator::~SoftMuonMvaEstimator() {}
 
 namespace {
   enum inputIndexes {
@@ -40,93 +39,86 @@ namespace {
   };
 }
 
-float SoftMuonMvaEstimator::computeMva(const pat::Muon& muon) const
-{
-	float var[kLast]{};
+float SoftMuonMvaEstimator::computeMva(const pat::Muon& muon) const {
+  float var[kLast]{};
 
-	reco::TrackRef gTrack = muon.globalTrack();
-	reco::TrackRef iTrack = muon.innerTrack();
-	reco::TrackRef oTrack = muon.outerTrack();
+  reco::TrackRef gTrack = muon.globalTrack();
+  reco::TrackRef iTrack = muon.innerTrack();
+  reco::TrackRef oTrack = muon.outerTrack();
 
-	if(!(muon.innerTrack().isNonnull() and
-	     muon.outerTrack().isNonnull() and
-	     muon.globalTrack().isNonnull()))
-	{
-	  return -1;
-	}
+  if (!(muon.innerTrack().isNonnull() and muon.outerTrack().isNonnull() and muon.globalTrack().isNonnull())) {
+    return -1;
+  }
 
-	//VARIABLE EXTRACTION
-	var[kPt] = muon.pt();
-	var[kEta] = muon.eta();
-	var[kMomID] = -1;
-	var[kPID] = -1;
+  //VARIABLE EXTRACTION
+  var[kPt] = muon.pt();
+  var[kEta] = muon.eta();
+  var[kMomID] = -1;
+  var[kPID] = -1;
 
-	var[kChi2LocalMomentum] = muon.combinedQuality().chi2LocalMomentum;
-	var[kChi2LocalPosition] = muon.combinedQuality().chi2LocalPosition;
-	var[kGlbTrackProbability] =  muon.combinedQuality().glbTrackProbability;
-	var[kTrkRelChi2] =  muon.combinedQuality().trkRelChi2;
+  var[kChi2LocalMomentum] = muon.combinedQuality().chi2LocalMomentum;
+  var[kChi2LocalPosition] = muon.combinedQuality().chi2LocalPosition;
+  var[kGlbTrackProbability] = muon.combinedQuality().glbTrackProbability;
+  var[kTrkRelChi2] = muon.combinedQuality().trkRelChi2;
 
-	var[kTrkKink] = muon.combinedQuality().trkKink;
-	var[kLog2PlusGlbKink] =  TMath::Log(2+muon.combinedQuality().glbKink);
-	var[kSegmentCompatibility] = muon.segmentCompatibility();
+  var[kTrkKink] = muon.combinedQuality().trkKink;
+  var[kLog2PlusGlbKink] = TMath::Log(2 + muon.combinedQuality().glbKink);
+  var[kSegmentCompatibility] = muon.segmentCompatibility();
 
-	var[kTimeAtIpInOutErr] = muon.time().timeAtIpInOutErr;
+  var[kTimeAtIpInOutErr] = muon.time().timeAtIpInOutErr;
 
-	//TRACK RELATED VARIABLES
-	
-	var[kIValidFraction] =  iTrack->validFraction();
-	var[kInnerChi2] =  iTrack->normalizedChi2();
-	var[kLayersWithMeasurement] = iTrack->hitPattern().trackerLayersWithMeasurement();
+  //TRACK RELATED VARIABLES
 
-	var[kOuterChi2] = oTrack->normalizedChi2();
+  var[kIValidFraction] = iTrack->validFraction();
+  var[kInnerChi2] = iTrack->normalizedChi2();
+  var[kLayersWithMeasurement] = iTrack->hitPattern().trackerLayersWithMeasurement();
 
-	var[kQProd] =  iTrack->charge()*oTrack->charge();
+  var[kOuterChi2] = oTrack->normalizedChi2();
 
-	//vComb Calculation
+  var[kQProd] = iTrack->charge() * oTrack->charge();
 
-	const reco::HitPattern &gMpattern = gTrack->hitPattern();
+  //vComb Calculation
 
-	std::vector<int> fvDThits {0,0,0,0};
-	std::vector<int> fvRPChits {0,0,0,0};
-	std::vector<int> fvCSChits {0,0,0,0};
+  const reco::HitPattern& gMpattern = gTrack->hitPattern();
 
-	var[kVMuonHitComb] = 0;
+  std::vector<int> fvDThits{0, 0, 0, 0};
+  std::vector<int> fvRPChits{0, 0, 0, 0};
+  std::vector<int> fvCSChits{0, 0, 0, 0};
 
-	for (int i=0;i<gMpattern.numberOfAllHits(reco::HitPattern::TRACK_HITS);i++){
+  var[kVMuonHitComb] = 0;
 
-	  uint32_t hit = gMpattern.getHitPattern(reco::HitPattern::TRACK_HITS, i);
-	  if ( !gMpattern.validHitFilter(hit) ) continue;
+  for (int i = 0; i < gMpattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); i++) {
+    uint32_t hit = gMpattern.getHitPattern(reco::HitPattern::TRACK_HITS, i);
+    if (!gMpattern.validHitFilter(hit))
+      continue;
 
-	  int muStation0 = gMpattern.getMuonStation(hit) - 1;
-	  if (muStation0 >=0 && muStation0 < 4){
-	    if (gMpattern.muonDTHitFilter(hit)) fvDThits[muStation0]++;
-	    if (gMpattern.muonRPCHitFilter(hit)) fvRPChits[muStation0]++;
-	    if (gMpattern.muonCSCHitFilter(hit)) fvCSChits[muStation0]++;
-	  }
+    int muStation0 = gMpattern.getMuonStation(hit) - 1;
+    if (muStation0 >= 0 && muStation0 < 4) {
+      if (gMpattern.muonDTHitFilter(hit))
+        fvDThits[muStation0]++;
+      if (gMpattern.muonRPCHitFilter(hit))
+        fvRPChits[muStation0]++;
+      if (gMpattern.muonCSCHitFilter(hit))
+        fvCSChits[muStation0]++;
+    }
+  }
 
-	}
-  
+  for (unsigned int station = 0; station < 4; ++station) {
+    var[kVMuonHitComb] += (fvDThits[station]) / 2.;
+    var[kVMuonHitComb] += fvRPChits[station];
 
-	for (unsigned int station = 0; station < 4; ++station) {
+    if (fvCSChits[station] > 6) {
+      var[kVMuonHitComb] += 6;
+    } else {
+      var[kVMuonHitComb] += fvCSChits[station];
+    }
+  }
 
-	  var[kVMuonHitComb] += (fvDThits[station])/2.;
-	  var[kVMuonHitComb] += fvRPChits[station];
-
-	  if (fvCSChits[station] > 6){
-	    var[kVMuonHitComb] += 6;
-	  }else{
-	    var[kVMuonHitComb] += fvCSChits[station];
-	  }
-
-	}
-
-	if(var[kChi2LocalMomentum] < 5000 and var[kChi2LocalPosition] < 2000 and
-	   var[kGlbTrackProbability] < 5000 and var[kTrkKink] < 900 and
-	   var[kLog2PlusGlbKink] < 50 and var[kTimeAtIpInOutErr] < 4 and
-	   var[kOuterChi2] < 1000 and var[kInnerChi2] < 10 and var[kTrkRelChi2] < 3)
-	{
-	  return gbrForest_->GetAdaBoostClassifier(var);
-	} else {
-	  return -1;
-        }
+  if (var[kChi2LocalMomentum] < 5000 and var[kChi2LocalPosition] < 2000 and var[kGlbTrackProbability] < 5000 and
+      var[kTrkKink] < 900 and var[kLog2PlusGlbKink] < 50 and var[kTimeAtIpInOutErr] < 4 and var[kOuterChi2] < 1000 and
+      var[kInnerChi2] < 10 and var[kTrkRelChi2] < 3) {
+    return gbrForest_->GetAdaBoostClassifier(var);
+  } else {
+    return -1;
+  }
 }

--- a/PhysicsTools/PatAlgos/src/StringResolutionProvider.cc
+++ b/PhysicsTools/PatAlgos/src/StringResolutionProvider.cc
@@ -5,22 +5,25 @@
 #include "PhysicsTools/PatAlgos/interface/StringResolutionProvider.h"
 #include "DataFormats/PatCandidates/interface/ParametrizationHelper.h"
 
-StringResolutionProvider::StringResolutionProvider(const edm::ParameterSet& cfg): constraints_() 
-{ 
+StringResolutionProvider::StringResolutionProvider(const edm::ParameterSet& cfg) : constraints_() {
   typedef pat::CandKinResolution::Parametrization Parametrization;
-  
-  // 
-  std::vector<double> constr = cfg.getParameter<std::vector<double> > ("constraints");
+
+  //
+  std::vector<double> constr = cfg.getParameter<std::vector<double> >("constraints");
   constraints_.insert(constraints_.end(), constr.begin(), constr.end());
-  
-  std::string parametrization(cfg.getParameter<std::string> ("parametrization") );
+
+  std::string parametrization(cfg.getParameter<std::string>("parametrization"));
   parametrization_ = pat::helper::ParametrizationHelper::fromString(parametrization);
-  
-  std::vector<edm::ParameterSet> functionSets_ = cfg.getParameter <std::vector<edm::ParameterSet> >("functions");
-  for(std::vector<edm::ParameterSet>::const_iterator iSet = functionSets_.begin(); iSet != functionSets_.end(); ++iSet){
-    if(iSet->exists("bin"))bins_.push_back(iSet->getParameter<std::string>("bin"));
-    else if(functionSets_.size()==1)bins_.push_back("");
-    else throw cms::Exception("WrongConfig") << "Parameter 'bin' is needed if more than one PSet is specified\n";
+
+  std::vector<edm::ParameterSet> functionSets_ = cfg.getParameter<std::vector<edm::ParameterSet> >("functions");
+  for (std::vector<edm::ParameterSet>::const_iterator iSet = functionSets_.begin(); iSet != functionSets_.end();
+       ++iSet) {
+    if (iSet->exists("bin"))
+      bins_.push_back(iSet->getParameter<std::string>("bin"));
+    else if (functionSets_.size() == 1)
+      bins_.push_back("");
+    else
+      throw cms::Exception("WrongConfig") << "Parameter 'bin' is needed if more than one PSet is specified\n";
 
     funcEt_.push_back(iSet->getParameter<std::string>("et"));
     funcEta_.push_back(iSet->getParameter<std::string>("eta"));
@@ -28,29 +31,28 @@ StringResolutionProvider::StringResolutionProvider(const edm::ParameterSet& cfg)
   }
 }
 
-StringResolutionProvider::~StringResolutionProvider()
-{
-}
- 
-pat::CandKinResolution
-StringResolutionProvider::getResolution(const reco::Candidate& cand) const 
-{ 
-  int selectedBin=-1;
-  for(unsigned int i=0; i<bins_.size(); ++i){
+StringResolutionProvider::~StringResolutionProvider() {}
+
+pat::CandKinResolution StringResolutionProvider::getResolution(const reco::Candidate& cand) const {
+  int selectedBin = -1;
+  for (unsigned int i = 0; i < bins_.size(); ++i) {
     StringCutObjectSelector<reco::Candidate> select_(bins_[i]);
-    if(select_(cand)){
+    if (select_(cand)) {
       selectedBin = i;
       break;
     }
   }
   std::vector<pat::CandKinResolution::Scalar> covariances(3);
-  if(selectedBin>=0){
-    covariances[0] = ROOT::Math::Square(Function(funcEt_ [selectedBin]).operator()(cand));
+  if (selectedBin >= 0) {
+    covariances[0] = ROOT::Math::Square(Function(funcEt_[selectedBin]).operator()(cand));
     covariances[1] = ROOT::Math::Square(Function(funcEta_[selectedBin]).operator()(cand));
     covariances[2] = ROOT::Math::Square(Function(funcPhi_[selectedBin]).operator()(cand));
   }
   // fill 0. for not selected candidates
-  else for(int i=0; i<3; ++i){covariances[i] = 0.;}
-  
+  else
+    for (int i = 0; i < 3; ++i) {
+      covariances[i] = 0.;
+    }
+
   return pat::CandKinResolution(parametrization_, covariances, constraints_);
 }

--- a/PhysicsTools/PatAlgos/src/VertexingHelper.cc
+++ b/PhysicsTools/PatAlgos/src/VertexingHelper.cc
@@ -8,85 +8,92 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
-pat::helper::VertexingHelper::VertexingHelper(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC)
-{
-    if (!iConfig.empty()) {
-        enabled_ = true;
-        if ( iConfig.existsAs<edm::InputTag>("vertexAssociations") == iConfig.existsAs<edm::InputTag>("vertices")) {
-            throw cms::Exception("Configuration") <<
-                "VertexingHelper: you must configure either 'vertices' (to produce associations) or 'vertexAssociations' (to read them from disk), " <<
-                "you can't specify both, nor you can specify none!\n";
-        }
+pat::helper::VertexingHelper::VertexingHelper(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC) {
+  if (!iConfig.empty()) {
+    enabled_ = true;
+    if (iConfig.existsAs<edm::InputTag>("vertexAssociations") == iConfig.existsAs<edm::InputTag>("vertices")) {
+      throw cms::Exception("Configuration") << "VertexingHelper: you must configure either 'vertices' (to produce "
+                                               "associations) or 'vertexAssociations' (to read them from disk), "
+                                            << "you can't specify both, nor you can specify none!\n";
+    }
 
-        if (iConfig.existsAs<edm::InputTag>("vertexAssociations")) {
-            playback_ = true;
-            vertexAssociationsToken_ = iC.consumes<edm::ValueMap<pat::VertexAssociation> >(iConfig.getParameter<edm::InputTag>("vertexAssociations"));
-        }
-        if (iConfig.existsAs<edm::InputTag>("vertices")) { // vertex have been specified, so run on the fly
-            playback_ = false;
-            verticesToken_ =  iC.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
-            // ------ MODE ------------------
-            useTracks_ = iConfig.getParameter<bool>("useTracks");
-            // ------ CUTS (fully optional) ------------------
-        }
-        assoSelector_ = reco::modules::make<pat::VertexAssociationSelector>(iConfig);
+    if (iConfig.existsAs<edm::InputTag>("vertexAssociations")) {
+      playback_ = true;
+      vertexAssociationsToken_ = iC.consumes<edm::ValueMap<pat::VertexAssociation> >(
+          iConfig.getParameter<edm::InputTag>("vertexAssociations"));
+    }
+    if (iConfig.existsAs<edm::InputTag>("vertices")) {  // vertex have been specified, so run on the fly
+      playback_ = false;
+      verticesToken_ = iC.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
+      // ------ MODE ------------------
+      useTracks_ = iConfig.getParameter<bool>("useTracks");
+      // ------ CUTS (fully optional) ------------------
+    }
+    assoSelector_ = reco::modules::make<pat::VertexAssociationSelector>(iConfig);
+  } else {
+    enabled_ = false;
+  }
+}
+
+void pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent) {
+  if (playback_) {
+    iEvent.getByToken(vertexAssociationsToken_, vertexAssoMap_);
+  } else {
+    iEvent.getByToken(verticesToken_, vertexHandle_);
+  }
+}
+
+void pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  newEvent(iEvent);
+  if (!playback_)
+    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", ttBuilder_);
+}
+
+pat::VertexAssociation pat::helper::VertexingHelper::associate(const reco::Candidate &c) const {
+  if (playback_)
+    throw cms::Exception("Configuration")
+        << "VertexingHelper: if this module was configured to read associations from the event,"
+        << " you must use 'operator()' passing a candidate ref, and not 'associate()' directly!\n";
+
+  reco::VertexCollection::const_iterator vtx, end;
+  size_t ivtx;
+  reco::TrackBaseRef tk;
+  reco::TransientTrack tt;
+  if (useTracks_) {
+    if (!ttBuilder_.isValid())
+      throw cms::Exception("Configuration")
+          << "VertexingHelper: If you use 'useTracks', you must call newEvent(iEvent,iSetup)!\n";
+    tk = getTrack_(c);
+    if (tk.isNull())
+      return pat::VertexAssociation();
+    tt = ttBuilder_->build(*tk);
+  }
+  for (vtx = vertexHandle_->begin(), end = vertexHandle_->end(), ivtx = 0; vtx != end; ++vtx, ++ivtx) {
+    pat::VertexAssociation association(reco::VertexRef(vertexHandle_, ivtx), tk);
+    if (useTracks_ == false) {
+      association.setDistances(c.vertex(), vtx->position(), vtx->error());
     } else {
-        enabled_ = false;
+      GlobalPoint vtxGP(vtx->x(), vtx->y(), vtx->z());  // need to convert XYZPoint to GlobalPoint
+      TrajectoryStateClosestToPoint tscp = tt.trajectoryStateClosestToPoint(vtxGP);
+      GlobalPoint trackPos = tscp.theState().position();
+      AlgebraicSymMatrix33 trackErr = tscp.theState().cartesianError().matrix().Sub<AlgebraicSymMatrix33>(0, 0);
+      association.setDistances(trackPos, vtx->position(), trackErr + vtx->error());
     }
+    if (assoSelector_(association))
+      return association;
+  }
+  return pat::VertexAssociation();
 }
 
-void
-pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent) {
-    if (playback_) {
-        iEvent.getByToken(vertexAssociationsToken_, vertexAssoMap_);
-    } else {
-        iEvent.getByToken(verticesToken_, vertexHandle_);
-    }
-}
+reco::TrackBaseRef pat::helper::VertexingHelper::getTrack_(const reco::Candidate &c) const {
+  const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&c);
+  if (rc != nullptr) {
+    return rc->bestTrackRef();
+  }
+  const reco::PFCandidate *pfc = dynamic_cast<const reco::PFCandidate *>(&c);
+  if (pfc != nullptr) {
+    return reco::TrackBaseRef(pfc->trackRef());
+  }
 
-void
-pat::helper::VertexingHelper::newEvent(const edm::Event &iEvent, const edm::EventSetup & iSetup) {
-    newEvent(iEvent);
-    if (!playback_) iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", ttBuilder_);
-}
-
-
-pat::VertexAssociation
-pat::helper::VertexingHelper::associate(const reco::Candidate &c) const {
-    if (playback_) throw cms::Exception("Configuration") << "VertexingHelper: if this module was configured to read associations from the event," <<
-                                                            " you must use 'operator()' passing a candidate ref, and not 'associate()' directly!\n";
-
-    reco::VertexCollection::const_iterator vtx, end;
-    size_t ivtx;
-    reco::TrackBaseRef tk;
-    reco::TransientTrack tt;
-    if (useTracks_) {
-        if (!ttBuilder_.isValid()) throw cms::Exception("Configuration") << "VertexingHelper: If you use 'useTracks', you must call newEvent(iEvent,iSetup)!\n";
-        tk = getTrack_(c);
-        if (tk.isNull()) return pat::VertexAssociation();
-        tt = ttBuilder_->build(*tk);
-    }
-    for (vtx = vertexHandle_->begin(), end = vertexHandle_->end(), ivtx = 0; vtx != end; ++vtx, ++ivtx) {
-        pat::VertexAssociation association(reco::VertexRef(vertexHandle_, ivtx), tk);
-        if (useTracks_ == false) {
-            association.setDistances(c.vertex(), vtx->position(), vtx->error());
-        } else {
-            GlobalPoint vtxGP(vtx->x(), vtx->y(), vtx->z()); // need to convert XYZPoint to GlobalPoint
-            TrajectoryStateClosestToPoint tscp = tt.trajectoryStateClosestToPoint(vtxGP);
-            GlobalPoint          trackPos = tscp.theState().position();
-            AlgebraicSymMatrix33 trackErr = tscp.theState().cartesianError().matrix().Sub<AlgebraicSymMatrix33>(0,0);
-            association.setDistances(trackPos, vtx->position(), trackErr + vtx->error());
-        }
-        if (assoSelector_(association)) return association;
-    }
-    return pat::VertexAssociation();
-}
-
-reco::TrackBaseRef pat::helper::VertexingHelper::getTrack_(const reco::Candidate &c) const  {
-    const reco::RecoCandidate   *rc  = dynamic_cast<const reco::RecoCandidate *>(&c);
-    if (rc  != nullptr)  { return rc->bestTrackRef(); }
-    const reco::PFCandidate *pfc = dynamic_cast<const reco::PFCandidate *>(&c);
-    if (pfc != nullptr) { return reco::TrackBaseRef(pfc->trackRef()); }
-
-    return reco::TrackBaseRef();
+  return reco::TrackBaseRef();
 }

--- a/PhysicsTools/PatAlgos/test/private/PATUserDataTestModule.cc
+++ b/PhysicsTools/PatAlgos/test/private/PATUserDataTestModule.cc
@@ -17,7 +17,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -31,7 +30,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
 #include "DataFormats/Common/interface/View.h"
@@ -41,7 +39,9 @@
 #include <string>
 
 // BEGIN CRAZY WORKAROUND
-namespace edm { using ::std::advance; }
+namespace edm {
+  using ::std::advance;
+}
 // END CRAZY WORKAROUND
 /*  Exmplanation of  the above crazy workaround:
     1) edm::Ptr uses 'advance' free function to locate a given item within a collection
@@ -64,151 +64,147 @@ namespace edm { using ::std::advance; }
 //
 
 class PATUserDataTestModule : public edm::EDProducer {
-   public:
-      explicit PATUserDataTestModule(const edm::ParameterSet&);
-      ~PATUserDataTestModule();
+public:
+  explicit PATUserDataTestModule(const edm::ParameterSet&);
+  ~PATUserDataTestModule();
 
+private:
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<edm::View<pat::Muon> > muonsToken_;
-      std::string   label_;
-      enum TestMode { TestRead, TestWrite, TestExternal };
-      TestMode mode_;
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<edm::View<pat::Muon>> muonsToken_;
+  std::string label_;
+  enum TestMode { TestRead, TestWrite, TestExternal };
+  TestMode mode_;
 };
 
 //
 // constructors and destructor
 //
-PATUserDataTestModule::PATUserDataTestModule(const edm::ParameterSet& iConfig):
-  muonsToken_(consumes<edm::View<pat::Muon> >(iConfig.getParameter<edm::InputTag>("muons"))),
-  label_(iConfig.existsAs<std::string>("label") ? iConfig.getParameter<std::string>("label") : ""),
-  mode_( iConfig.getParameter<std::string>("mode") == "write" ? TestWrite :
-        (iConfig.getParameter<std::string>("mode") == "read"  ? TestRead  :
-         TestExternal
-        ))
+PATUserDataTestModule::PATUserDataTestModule(const edm::ParameterSet& iConfig)
+    : muonsToken_(consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("muons"))),
+      label_(iConfig.existsAs<std::string>("label") ? iConfig.getParameter<std::string>("label") : ""),
+      mode_(iConfig.getParameter<std::string>("mode") == "write"
+                ? TestWrite
+                : (iConfig.getParameter<std::string>("mode") == "read" ? TestRead : TestExternal))
 
 {
   if (mode_ != TestExternal) {
-      produces<std::vector<pat::Muon> >();
+    produces<std::vector<pat::Muon>>();
   } else {
-      produces<edm::ValueMap<int> >(label_);
-      produces<edm::ValueMap<float> >();
-      produces<edm::OwnVector<pat::UserData> >();
-      produces<edm::ValueMap<edm::Ptr<pat::UserData> > >();
+    produces<edm::ValueMap<int>>(label_);
+    produces<edm::ValueMap<float>>();
+    produces<edm::OwnVector<pat::UserData>>();
+    produces<edm::ValueMap<edm::Ptr<pat::UserData>>>();
   }
 }
 
-
-PATUserDataTestModule::~PATUserDataTestModule()
-{
-}
+PATUserDataTestModule::~PATUserDataTestModule() {}
 
 // ------------ method called to for each event  ------------
-void
-PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void PATUserDataTestModule::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   // I need to define a type for which we don't have a dictionary in CMSSW. I hope this is crazy enough.
-   typedef std::pair<std::map<std::string,pat::Muon>, std::vector<math::XYZVector> > CrazyDataType;
+  // I need to define a type for which we don't have a dictionary in CMSSW. I hope this is crazy enough.
+  typedef std::pair<std::map<std::string, pat::Muon>, std::vector<math::XYZVector>> CrazyDataType;
 
-   if (mode_ != TestExternal) {
-       edm::Handle<View<pat::Muon> > muons;
-       iEvent.getByToken(muonsToken_,muons);
+  if (mode_ != TestExternal) {
+    edm::Handle<View<pat::Muon>> muons;
+    iEvent.getByToken(muonsToken_, muons);
 
-       auto output = std::make_unique<std::vector<pat::Muon> >();
+    auto output = std::make_unique<std::vector<pat::Muon>>();
 
-       for (View<pat::Muon>::const_iterator muon = muons->begin(), end = muons->end(); muon != end; ++muon) {
-           if (mode_ == TestWrite) {
-               pat::Muon myMuon = *muon; // copy
-               myMuon.addUserInt("answer", 42);
-               myMuon.addUserFloat("pi", 3.14);
-               myMuon.addUserData("half p4", 0.5*muon->p4());
+    for (View<pat::Muon>::const_iterator muon = muons->begin(), end = muons->end(); muon != end; ++muon) {
+      if (mode_ == TestWrite) {
+        pat::Muon myMuon = *muon;  // copy
+        myMuon.addUserInt("answer", 42);
+        myMuon.addUserFloat("pi", 3.14);
+        myMuon.addUserData("half p4", 0.5 * muon->p4());
 
-               //// This shoud throw an exception because we don't have the wrapper type
-               //myMuon.addUserData("self", *muon);
-               //// This should throw an exception because we don't have the dictionary (I hope)
-               // myMuon.addUserData("crazy", CrazyDataType());
-               //// These instead should not throw an exception as long as they don't get saved on disk
-               // myMuon.addUserData("tmp self", *muon, true);
-               // myMuon.addUserData("tmp crazy", CrazyDataType(), true);
+        //// This shoud throw an exception because we don't have the wrapper type
+        //myMuon.addUserData("self", *muon);
+        //// This should throw an exception because we don't have the dictionary (I hope)
+        // myMuon.addUserData("crazy", CrazyDataType());
+        //// These instead should not throw an exception as long as they don't get saved on disk
+        // myMuon.addUserData("tmp self", *muon, true);
+        // myMuon.addUserData("tmp crazy", CrazyDataType(), true);
 
-               output->push_back(std::move(myMuon));
-           } else {
-               std::cout << "Muon #" << (muon - muons->begin()) << ":" << std::endl;
-               std::cout << "\tanswer   = " << muon->userInt("answer") << std::endl;
-               std::cout << "\tanswer:il= " << muon->userInt("answer:il") << std::endl;
-               std::cout << "\tpi       = " << muon->userFloat("pi") << std::endl;
-               std::cout << "\tmiss int = " << muon->userInt("missing int") << std::endl;
-               std::cout << "\tmiss flt = " << muon->userFloat("missing flt") << std::endl;
-               std::cout << "\t# u d    = " << muon->userDataNames().size() << std::endl;
-               std::cout << "\tud nam[0]= " << muon->userDataNames()[0] << std::endl;
-               std::cout << "\thas p4/2 = " << muon->hasUserData("half p4") << std::endl;
-               if (muon->hasUserData("half p4")) {
-                   std::cout << "\ttyp p4/2 = " << muon->userDataObjectType("half p4") << std::endl;
-                   std::cout << "\tval p4/2 = " << (*muon->userData<reco::Particle::LorentzVector>("half p4")) << "  == " << (0.5*muon->p4()) << std::endl;
-               }
-               if (muon->hasUserData("tmp self")) {
-                   std::cout << "\tself.pt  = " << muon->userData<pat::Muon>("tmp self")->pt() << "  == " << muon->pt() << std::endl;
-               }
-               if (muon->hasUserData("tmp crazy")) {
-                   std::cout << "\tcrazy.siz= " << muon->userData<CrazyDataType>("tmp crazy")->second.size() << "  == 0 " << std::endl;
-               }
-               if (muon->hasUserData("halfP4")) {
-                   std::cout << "\ttyp P4/2 = " << muon->userDataObjectType("halfP4") << std::endl;
-                   std::cout << "\tval P4/2 = " << (*muon->userData<reco::Particle::LorentzVector>("halfP4")) << "  == " << (0.5*muon->p4()) << std::endl;
-               }
-           }
-       }
-       iEvent.put(std::move(output));
-   } else {
-       using namespace std;
-       Handle<View<reco::Muon> > recoMuons;
-       iEvent.getByToken(muonsToken_, recoMuons);
-       std::cout << "Got " << recoMuons->size() << " muons" << std::endl;
+        output->push_back(std::move(myMuon));
+      } else {
+        std::cout << "Muon #" << (muon - muons->begin()) << ":" << std::endl;
+        std::cout << "\tanswer   = " << muon->userInt("answer") << std::endl;
+        std::cout << "\tanswer:il= " << muon->userInt("answer:il") << std::endl;
+        std::cout << "\tpi       = " << muon->userFloat("pi") << std::endl;
+        std::cout << "\tmiss int = " << muon->userInt("missing int") << std::endl;
+        std::cout << "\tmiss flt = " << muon->userFloat("missing flt") << std::endl;
+        std::cout << "\t# u d    = " << muon->userDataNames().size() << std::endl;
+        std::cout << "\tud nam[0]= " << muon->userDataNames()[0] << std::endl;
+        std::cout << "\thas p4/2 = " << muon->hasUserData("half p4") << std::endl;
+        if (muon->hasUserData("half p4")) {
+          std::cout << "\ttyp p4/2 = " << muon->userDataObjectType("half p4") << std::endl;
+          std::cout << "\tval p4/2 = " << (*muon->userData<reco::Particle::LorentzVector>("half p4"))
+                    << "  == " << (0.5 * muon->p4()) << std::endl;
+        }
+        if (muon->hasUserData("tmp self")) {
+          std::cout << "\tself.pt  = " << muon->userData<pat::Muon>("tmp self")->pt() << "  == " << muon->pt()
+                    << std::endl;
+        }
+        if (muon->hasUserData("tmp crazy")) {
+          std::cout << "\tcrazy.siz= " << muon->userData<CrazyDataType>("tmp crazy")->second.size() << "  == 0 "
+                    << std::endl;
+        }
+        if (muon->hasUserData("halfP4")) {
+          std::cout << "\ttyp P4/2 = " << muon->userDataObjectType("halfP4") << std::endl;
+          std::cout << "\tval P4/2 = " << (*muon->userData<reco::Particle::LorentzVector>("halfP4"))
+                    << "  == " << (0.5 * muon->p4()) << std::endl;
+        }
+      }
+    }
+    iEvent.put(std::move(output));
+  } else {
+    using namespace std;
+    Handle<View<reco::Muon>> recoMuons;
+    iEvent.getByToken(muonsToken_, recoMuons);
+    std::cout << "Got " << recoMuons->size() << " muons" << std::endl;
 
-       vector<int> ints(recoMuons->size(), 42);
-       auto answers = std::make_unique<ValueMap<int>>();
-       ValueMap<int>::Filler intfiller(*answers);
-       intfiller.insert(recoMuons, ints.begin(), ints.end());
-       intfiller.fill();
-       iEvent.put(std::move(answers), label_);
-       std::cout << "Filled in the answer" << std::endl;
+    vector<int> ints(recoMuons->size(), 42);
+    auto answers = std::make_unique<ValueMap<int>>();
+    ValueMap<int>::Filler intfiller(*answers);
+    intfiller.insert(recoMuons, ints.begin(), ints.end());
+    intfiller.fill();
+    iEvent.put(std::move(answers), label_);
+    std::cout << "Filled in the answer" << std::endl;
 
-       vector<float> floats(recoMuons->size(), 3.14);
-       auto pis = std::make_unique<ValueMap<float>>();
-       ValueMap<float>::Filler floatfiller(*pis);
-       floatfiller.insert(recoMuons, floats.begin(), floats.end());
-       floatfiller.fill();
-       iEvent.put(std::move(pis));
-       std::cout << "Wrote useless floats into the event" << std::endl;
+    vector<float> floats(recoMuons->size(), 3.14);
+    auto pis = std::make_unique<ValueMap<float>>();
+    ValueMap<float>::Filler floatfiller(*pis);
+    floatfiller.insert(recoMuons, floats.begin(), floats.end());
+    floatfiller.fill();
+    iEvent.put(std::move(pis));
+    std::cout << "Wrote useless floats into the event" << std::endl;
 
-       auto halfp4s = std::make_unique<OwnVector<pat::UserData>>();
-       for (size_t i = 0; i < recoMuons->size(); ++i) {
-            halfp4s->push_back( pat::UserData::make( 0.5 * (*recoMuons)[i].p4() ) );
-       }
-       OrphanHandle<OwnVector<pat::UserData> > handle = iEvent.put(std::move(halfp4s));
-       std::cout << "Wrote OwnVector of useless objects into the event" << std::endl;
-       vector<Ptr<pat::UserData> > halfp4sPtr;
-       for (size_t i = 0; i < recoMuons->size(); ++i) {
-            // It is crucial to use the OrphanHandle here and not a RefProd from GetRefBeforePut
-            halfp4sPtr.push_back(Ptr<pat::UserData>(handle, i));
-       }
-       std::cout << "   Made edm::Ptr<> to those useless objects" << std::endl;
-       auto vmhalfp4s = std::make_unique<ValueMap<Ptr<pat::UserData>>>();
-       ValueMap<Ptr<pat::UserData> >::Filler filler(*vmhalfp4s);
-       filler.insert(recoMuons, halfp4sPtr.begin(), halfp4sPtr.end());
-       filler.fill();
-       std::cout << "   Filled the ValueMap of edm::Ptr<> to those useless objects" << std::endl;
-       iEvent.put(std::move(vmhalfp4s));
-       std::cout << "   Wrote the ValueMap of edm::Ptr<> to those useless objects" << std::endl;
+    auto halfp4s = std::make_unique<OwnVector<pat::UserData>>();
+    for (size_t i = 0; i < recoMuons->size(); ++i) {
+      halfp4s->push_back(pat::UserData::make(0.5 * (*recoMuons)[i].p4()));
+    }
+    OrphanHandle<OwnVector<pat::UserData>> handle = iEvent.put(std::move(halfp4s));
+    std::cout << "Wrote OwnVector of useless objects into the event" << std::endl;
+    vector<Ptr<pat::UserData>> halfp4sPtr;
+    for (size_t i = 0; i < recoMuons->size(); ++i) {
+      // It is crucial to use the OrphanHandle here and not a RefProd from GetRefBeforePut
+      halfp4sPtr.push_back(Ptr<pat::UserData>(handle, i));
+    }
+    std::cout << "   Made edm::Ptr<> to those useless objects" << std::endl;
+    auto vmhalfp4s = std::make_unique<ValueMap<Ptr<pat::UserData>>>();
+    ValueMap<Ptr<pat::UserData>>::Filler filler(*vmhalfp4s);
+    filler.insert(recoMuons, halfp4sPtr.begin(), halfp4sPtr.end());
+    filler.fill();
+    std::cout << "   Filled the ValueMap of edm::Ptr<> to those useless objects" << std::endl;
+    iEvent.put(std::move(vmhalfp4s));
+    std::cout << "   Wrote the ValueMap of edm::Ptr<> to those useless objects" << std::endl;
 
-       std::cout << "So long, and thanks for all the muons.\n" << std::endl;
-   }
-
+    std::cout << "So long, and thanks for all the muons.\n" << std::endl;
+  }
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatAlgos/test/private/TestEventHypothesisReader.cc
+++ b/PhysicsTools/PatAlgos/test/private/TestEventHypothesisReader.cc
@@ -14,98 +14,91 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 
 class TestEventHypothesisReader : public edm::EDAnalyzer {
-    public:
-        TestEventHypothesisReader(const edm::ParameterSet &iConfig) ;
-        virtual void analyze( const edm::Event &iEvent, const edm::EventSetup &iSetup) ;
-        void runTests( const pat::EventHypothesis &h) ;
-    private:
-        edm::EDGetTokenT<std::vector<pat::EventHypothesis> > hypsToken_;
-        edm::EDGetTokenT<edm::ValueMap<double> >  deltaRsHToken_;
+public:
+  TestEventHypothesisReader(const edm::ParameterSet &iConfig);
+  virtual void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup);
+  void runTests(const pat::EventHypothesis &h);
+
+private:
+  edm::EDGetTokenT<std::vector<pat::EventHypothesis> > hypsToken_;
+  edm::EDGetTokenT<edm::ValueMap<double> > deltaRsHToken_;
 };
 
+TestEventHypothesisReader::TestEventHypothesisReader(const edm::ParameterSet &iConfig)
+    : hypsToken_(consumes<std::vector<pat::EventHypothesis> >(iConfig.getParameter<edm::InputTag>("events"))),
+      deltaRsHToken_(consumes<edm::ValueMap<double> >(
+          edm::InputTag((iConfig.getParameter<edm::InputTag>("events")).label(), "deltaR"))) {}
 
+void TestEventHypothesisReader::runTests(const pat::EventHypothesis &h) {
+  using namespace std;
+  using namespace pat::eventhypothesis;
+  cout << "Test 1: Print the muon " << h["mu"]->pt() << endl;
 
-TestEventHypothesisReader::TestEventHypothesisReader(const edm::ParameterSet &iConfig) :
-    hypsToken_(consumes<std::vector<pat::EventHypothesis> >(iConfig.getParameter<edm::InputTag>("events"))),
-    deltaRsHToken_(consumes<edm::ValueMap<double> >(edm::InputTag((iConfig.getParameter<edm::InputTag>("events")).label(), "deltaR")))
-{
+  for (size_t i = 0; i < h.count() - 2; ++i) {
+    cout << "Test 2." << (i + 1) << ": Getting of the other jets: " << h.get("other jet", i)->et() << endl;
+  }
+
+  cout << "Test 3: count: " << (h.count() - 2) << " vs " << h.count("other jet") << endl;
+
+  cout << "Test 4: regexp count: " << (h.count() - 1) << " vs " << h.count(".*jet") << endl;
+
+  cout << "Test 5.0: all with muon: " << h.all("mu").size() << endl;
+  cout << "Test 5.1: all with muon: " << h.all("mu").front()->pt() << endl;
+  cout << "Test 5.2: all with other jets: " << h.all("other jet").size() << endl;
+  cout << "Test 5.3: all with regex: " << h.all(".*jet").size() << endl;
+
+  cout << "Test 6.0: get as : " << h.getAs<reco::CaloJet>("nearest jet")->maxEInHadTowers() << endl;
+
+  cout << "Loopers" << endl;
+  cout << "Test 7.0: simple looper on all" << endl;
+  for (CandLooper jet = h.loop(); jet; ++jet) {
+    cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
+  }
+  cout << "Test 7.1: simple looper on jets" << endl;
+  for (CandLooper jet = h.loop(".*jet"); jet; ++jet) {
+    cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
+  }
+  cout << "Test 7.2: loopAs on jets" << endl;
+  for (Looper<reco::CaloJet> jet = h.loopAs<reco::CaloJet>(".*jet"); jet; ++jet) {
+    cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->maxEInHadTowers() << endl;
+  }
 }
 
-void
-TestEventHypothesisReader::runTests( const pat::EventHypothesis &h) {
-    using namespace std;
-    using namespace pat::eventhypothesis;
-    cout << "Test 1: Print the muon " << h["mu"]->pt() << endl;
+void TestEventHypothesisReader::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
+  using reco::Candidate;
+  using reco::CandidatePtr;
 
-    for (size_t i = 0; i < h.count() - 2; ++i) {
-        cout << "Test 2." << (i+1) << ": Getting of the other jets: " << h.get("other jet",i)->et() << endl;
+  Handle<vector<pat::EventHypothesis> > hyps;
+  iEvent.getByToken(hypsToken_, hyps);
+
+  Handle<ValueMap<double> > deltaRsH;
+  iEvent.getByToken(deltaRsHToken_, deltaRsH);
+  const ValueMap<double> &deltaRs = *deltaRsH;
+
+  for (size_t i = 0, n = hyps->size(); i < n; ++i) {
+    const pat::EventHypothesis &h = (*hyps)[i];
+
+    std::cout << "Hypothesis " << (i + 1) << ": " << std::endl;
+    CandidatePtr mu = h["mu"];
+    std::cout << "   muon : pt = " << mu->pt() << ", eta = " << mu->eta() << ", phi = " << mu->phi() << std::endl;
+    CandidatePtr jet = h["nearest jet"];
+    std::cout << "   n jet: pt = " << jet->pt() << ", eta = " << jet->eta() << ", phi = " << jet->phi() << std::endl;
+
+    for (pat::EventHypothesis::CandLooper j2 = h.loop("other jet"); j2; ++j2) {
+      std::cout << "   0 jet: pt = " << j2->pt() << ", eta = " << j2->eta() << ", phi = " << j2->phi() << std::endl;
     }
 
-    cout << "Test 3: count: " << (h.count() - 2) << " vs " << h.count("other jet") << endl;
+    Ref<vector<pat::EventHypothesis> > key(hyps, i);
+    std::cout << "   deltaR: " << deltaRs[key] << "\n" << std::endl;
 
-    cout << "Test 4: regexp count: " << (h.count() - 1) << " vs " << h.count(".*jet") << endl;
+    runTests(h);
+  }
 
-    cout << "Test 5.0: all with muon: " << h.all("mu").size() << endl;
-    cout << "Test 5.1: all with muon: " << h.all("mu").front()->pt() << endl;
-    cout << "Test 5.2: all with other jets: " << h.all("other jet").size() << endl;
-    cout << "Test 5.3: all with regex: " << h.all(".*jet").size() << endl;
-
-    cout << "Test 6.0: get as : " << h.getAs<reco::CaloJet>("nearest jet")->maxEInHadTowers() << endl;
-
-    cout << "Loopers" << endl;
-    cout << "Test 7.0: simple looper on all" << endl;
-    for (CandLooper jet = h.loop(); jet; ++jet) {
-        cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
-    }
-    cout << "Test 7.1: simple looper on jets" << endl;
-    for (CandLooper jet = h.loop(".*jet"); jet; ++jet) {
-        cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
-    }
-    cout << "Test 7.2: loopAs on jets" << endl;
-    for (Looper<reco::CaloJet> jet = h.loopAs<reco::CaloJet>(".*jet"); jet; ++jet) {
-        cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->maxEInHadTowers() << endl;
-    }
-
-
-}
-
-
-
-void
-TestEventHypothesisReader::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-    using namespace edm; using namespace std;
-    using reco::Candidate;
-    using reco::CandidatePtr;
-
-    Handle<vector<pat::EventHypothesis> > hyps;
-    iEvent.getByToken(hypsToken_, hyps);
-
-    Handle<ValueMap<double> >  deltaRsH;
-    iEvent.getByToken(deltaRsHToken_, deltaRsH);
-    const ValueMap<double> & deltaRs = *deltaRsH;
-
-    for (size_t i = 0, n = hyps->size(); i < n; ++i) {
-        const pat::EventHypothesis &h = (*hyps)[i];
-
-        std::cout << "Hypothesis " << (i+1) << ": " << std::endl;
-        CandidatePtr  mu = h["mu"];
-        std::cout << "   muon : pt = " << mu->pt() << ", eta = " << mu->eta() << ", phi = " << mu->phi() << std::endl;
-        CandidatePtr jet = h["nearest jet"];
-        std::cout << "   n jet: pt = " << jet->pt() << ", eta = " << jet->eta() << ", phi = " << jet->phi() << std::endl;
-
-        for (pat::EventHypothesis::CandLooper j2 = h.loop("other jet"); j2; ++j2) {
-            std::cout << "   0 jet: pt = " << j2->pt() << ", eta = " << j2->eta() << ", phi = " << j2->phi() << std::endl;
-        }
-
-        Ref< vector<pat::EventHypothesis> > key(hyps,i);
-        std::cout << "   deltaR: " << deltaRs[key] << "\n" << std::endl;
-
-        runTests( h );
-
-    }
-
-    std::cout << "Found " << hyps->size() << " possible options" << "\n\n" << std::endl;
-
+  std::cout << "Found " << hyps->size() << " possible options"
+            << "\n\n"
+            << std::endl;
 }
 
 DEFINE_FWK_MODULE(TestEventHypothesisReader);

--- a/PhysicsTools/PatAlgos/test/private/TestEventHypothesisWriter.cc
+++ b/PhysicsTools/PatAlgos/test/private/TestEventHypothesisWriter.cc
@@ -14,124 +14,125 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 
 class TestEventHypothesisWriter : public edm::EDProducer {
-    public:
-        TestEventHypothesisWriter(const edm::ParameterSet &iConfig) ;
-        virtual void produce( edm::Event &iEvent, const edm::EventSetup &iSetup) ;
-        void runTests( const pat::EventHypothesis &h) ;
-    private:
-        edm::EDGetTokenT<edm::View<reco::Candidate> > jetsToken_;
-        edm::EDGetTokenT<edm::View<reco::Candidate> > muonsToken_;
+public:
+  TestEventHypothesisWriter(const edm::ParameterSet &iConfig);
+  virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup);
+  void runTests(const pat::EventHypothesis &h);
+
+private:
+  edm::EDGetTokenT<edm::View<reco::Candidate>> jetsToken_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> muonsToken_;
 };
 
-
-
-TestEventHypothesisWriter::TestEventHypothesisWriter(const edm::ParameterSet &iConfig) :
-    jetsToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("jets"))),
-    muonsToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("muons")))
-{
-    produces<std::vector<pat::EventHypothesis> >();
-    produces<edm::ValueMap<double> >("deltaR");
+TestEventHypothesisWriter::TestEventHypothesisWriter(const edm::ParameterSet &iConfig)
+    : jetsToken_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      muonsToken_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("muons"))) {
+  produces<std::vector<pat::EventHypothesis>>();
+  produces<edm::ValueMap<double>>("deltaR");
 }
 
-void
-TestEventHypothesisWriter::runTests( const pat::EventHypothesis &h) {
-    using namespace std;
-    using namespace pat::eventhypothesis;
-    cout << "Test 1: Print the muon " << h["mu"]->pt() << endl;
+void TestEventHypothesisWriter::runTests(const pat::EventHypothesis &h) {
+  using namespace std;
+  using namespace pat::eventhypothesis;
+  cout << "Test 1: Print the muon " << h["mu"]->pt() << endl;
 
-    for (size_t i = 0; i < h.count() - 2; ++i) {
-        cout << "Test 2." << (i+1) << ": Getting of the other jets: " << h.get("other jet",i)->et() << endl;
-    }
+  for (size_t i = 0; i < h.count() - 2; ++i) {
+    cout << "Test 2." << (i + 1) << ": Getting of the other jets: " << h.get("other jet", i)->et() << endl;
+  }
 
-    cout << "Test 3: count: " << (h.count() - 2) << " vs " << h.count("other jet") << endl;
+  cout << "Test 3: count: " << (h.count() - 2) << " vs " << h.count("other jet") << endl;
 
-    cout << "Test 4: regexp count: " << (h.count() - 1) << " vs " << h.count(".*jet") << endl;
+  cout << "Test 4: regexp count: " << (h.count() - 1) << " vs " << h.count(".*jet") << endl;
 
-    cout << "Test 5.0: all with muon: " << h.all("mu").size() << endl;
-    cout << "Test 5.1: all with muon: " << h.all("mu").front()->pt() << endl;
-    cout << "Test 5.2: all with other jets: " << h.all("other jet").size() << endl;
-    cout << "Test 5.3: all with regex: " << h.all(".*jet").size() << endl;
+  cout << "Test 5.0: all with muon: " << h.all("mu").size() << endl;
+  cout << "Test 5.1: all with muon: " << h.all("mu").front()->pt() << endl;
+  cout << "Test 5.2: all with other jets: " << h.all("other jet").size() << endl;
+  cout << "Test 5.3: all with regex: " << h.all(".*jet").size() << endl;
 
-    cout << "Test 6.0: get as : " << h.getAs<reco::CaloJet>("nearest jet")->maxEInHadTowers() << endl;
+  cout << "Test 6.0: get as : " << h.getAs<reco::CaloJet>("nearest jet")->maxEInHadTowers() << endl;
 
-    cout << "Loopers" << endl;
-    cout << "Test 7.0: simple looper on all" << endl;
-    for (CandLooper jet = h.loop(); jet; ++jet) {
-        cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
-    }
-    cout << "Test 7.1: simple looper on jets" << endl;
-    for (CandLooper jet = h.loop(".*jet"); jet; ++jet) {
-        cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
-    }
-    cout << "Test 7.2: loopAs on jets" << endl;
-    for (Looper<reco::CaloJet> jet = h.loopAs<reco::CaloJet>(".*jet"); jet; ++jet) {
-        cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->maxEInHadTowers() << endl;
-    }
-
-
+  cout << "Loopers" << endl;
+  cout << "Test 7.0: simple looper on all" << endl;
+  for (CandLooper jet = h.loop(); jet; ++jet) {
+    cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
+  }
+  cout << "Test 7.1: simple looper on jets" << endl;
+  for (CandLooper jet = h.loop(".*jet"); jet; ++jet) {
+    cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->et() << endl;
+  }
+  cout << "Test 7.2: loopAs on jets" << endl;
+  for (Looper<reco::CaloJet> jet = h.loopAs<reco::CaloJet>(".*jet"); jet; ++jet) {
+    cout << "\titem " << jet.index() << ", role " << jet.role() << ": " << jet->maxEInHadTowers() << endl;
+  }
 }
 
-void
-TestEventHypothesisWriter::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
-    using namespace edm;
-    using namespace std;
-    using reco::Candidate;
-    using reco::CandidatePtr;
+void TestEventHypothesisWriter::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+  using namespace std;
+  using reco::Candidate;
+  using reco::CandidatePtr;
 
-    auto hyps = std::make_unique<std::vector<pat::EventHypothesis>>();;
-    vector<double>  deltaRs;
+  auto hyps = std::make_unique<std::vector<pat::EventHypothesis>>();
+  ;
+  vector<double> deltaRs;
 
-    Handle<View<Candidate> > hMu;
-    iEvent.getByToken(muonsToken_, hMu);
+  Handle<View<Candidate>> hMu;
+  iEvent.getByToken(muonsToken_, hMu);
 
-    Handle<View<Candidate> > hJet;
-    iEvent.getByToken(jetsToken_, hJet);
+  Handle<View<Candidate>> hJet;
+  iEvent.getByToken(jetsToken_, hJet);
 
-    // fake analysis
-    for (size_t imu = 0, nmu = hMu->size(); imu < nmu; ++imu) {
-        pat::EventHypothesis h;
-        CandidatePtr mu = hMu->ptrAt(imu);
-        h.add(mu, "mu");
+  // fake analysis
+  for (size_t imu = 0, nmu = hMu->size(); imu < nmu; ++imu) {
+    pat::EventHypothesis h;
+    CandidatePtr mu = hMu->ptrAt(imu);
+    h.add(mu, "mu");
 
-        int bestj = -1; double drmin = 99.0;
-        for (size_t ij = 0, nj = hJet->size(); ij < nj; ++ij) {
-            CandidatePtr jet = hJet->ptrAt(ij);
-            if (jet->et() < 10) break;
-            double dr = deltaR(*jet, *mu);
-            if (dr < drmin) {
-                bestj = ij; drmin = dr;
-            }
-        }
-        if (bestj == -1) continue;
+    int bestj = -1;
+    double drmin = 99.0;
+    for (size_t ij = 0, nj = hJet->size(); ij < nj; ++ij) {
+      CandidatePtr jet = hJet->ptrAt(ij);
+      if (jet->et() < 10)
+        break;
+      double dr = deltaR(*jet, *mu);
+      if (dr < drmin) {
+        bestj = ij;
+        drmin = dr;
+      }
+    }
+    if (bestj == -1)
+      continue;
 
-        h.add(hJet->ptrAt(bestj), "nearest jet");
+    h.add(hJet->ptrAt(bestj), "nearest jet");
 
-        for (size_t ij = 0, nj = hJet->size(); ij < nj; ++ij) {
-            if (ij == size_t(bestj)) continue;
-            CandidatePtr jet = hJet->ptrAt(ij);
-            if (jet->et() < 10) break;
-            h.add(jet, "other jet");
-        }
-
-        // save hypothesis
-        deltaRs.push_back(drmin);
-
-        runTests(h);
-
-        hyps->push_back(h);
+    for (size_t ij = 0, nj = hJet->size(); ij < nj; ++ij) {
+      if (ij == size_t(bestj))
+        continue;
+      CandidatePtr jet = hJet->ptrAt(ij);
+      if (jet->et() < 10)
+        break;
+      h.add(jet, "other jet");
     }
 
-    std::cout << "Found " << deltaRs.size() << " possible options" << std::endl;
+    // save hypothesis
+    deltaRs.push_back(drmin);
 
-    // work done, save results
-    OrphanHandle<vector<pat::EventHypothesis> > handle = iEvent.put(std::move(hyps));
-    auto deltaRMap = std::make_unique<ValueMap<double>>();
-    //if (deltaRs.size() > 0) {
-        ValueMap<double>::Filler filler(*deltaRMap);
-        filler.insert(handle, deltaRs.begin(), deltaRs.end());
-        filler.fill();
-    //}
-    iEvent.put(std::move(deltaRMap), "deltaR");
+    runTests(h);
+
+    hyps->push_back(h);
+  }
+
+  std::cout << "Found " << deltaRs.size() << " possible options" << std::endl;
+
+  // work done, save results
+  OrphanHandle<vector<pat::EventHypothesis>> handle = iEvent.put(std::move(hyps));
+  auto deltaRMap = std::make_unique<ValueMap<double>>();
+  //if (deltaRs.size() > 0) {
+  ValueMap<double>::Filler filler(*deltaRMap);
+  filler.insert(handle, deltaRs.begin(), deltaRs.end());
+  filler.fill();
+  //}
+  iEvent.put(std::move(deltaRMap), "deltaR");
 }
 
 DEFINE_FWK_MODULE(TestEventHypothesisWriter);


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/384//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


